### PR TITLE
feat(QC): Add Framework Composite EMA-Cross + TrendStocks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/alpha_models.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/alpha_models.py
@@ -1,0 +1,139 @@
+# region imports
+from AlgorithmImports import *
+# endregion
+
+
+class EMACrossAlpha(AlphaModel):
+    """EMA Crossover Alpha Model.
+
+    Generates UP insights when EMA fast > EMA slow, FLAT otherwise.
+    Uses explicit ticker filtering (no algorithm.securities iteration).
+
+    Parameters:
+    - tickers: List of tickers to trade
+    - fast_period: Fast EMA period (default 20)
+    - slow_period: Slow EMA period (default 50)
+    """
+
+    def __init__(self, tickers, fast_period=20, slow_period=50):
+        super().__init__()
+        self.name = "EMACross"
+        self.tickers = tickers
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+        self._ema_fast = {}
+        self._ema_slow = {}
+        self.symbols = {}
+
+    def update(self, algorithm, data):
+        if algorithm.is_warming_up:
+            return []
+
+        insights = []
+        period = timedelta(days=1)
+
+        for ticker in self.tickers:
+            symbol = self.symbols.get(ticker)
+            if symbol is None:
+                continue
+
+            fast = self._ema_fast.get(ticker)
+            slow = self._ema_slow.get(ticker)
+            if not fast or not slow or not fast.is_ready or not slow.is_ready:
+                continue
+
+            if fast.current.value > slow.current.value:
+                insights.append(Insight.price(
+                    symbol, period, InsightDirection.UP,
+                    source_model=self.name
+                ))
+            else:
+                insights.append(Insight.price(
+                    symbol, period, InsightDirection.FLAT,
+                    source_model=self.name
+                ))
+
+        return insights
+
+    def on_securities_changed(self, algorithm, changes):
+        for security in changes.added_securities:
+            ticker = security.symbol.value
+            if ticker in self.tickers:
+                self.symbols[ticker] = security.symbol
+                self._ema_fast[ticker] = algorithm.ema(security.symbol, self.fast_period, Resolution.DAILY)
+                self._ema_slow[ticker] = algorithm.ema(security.symbol, self.slow_period, Resolution.DAILY)
+
+
+class TrendStocksAlpha(AlphaModel):
+    """Trend Stocks Alpha Model - Double confirmation trend following.
+
+    Generates UP insights when Price > SMA200 AND EMA20 > EMA50.
+    Uses explicit ticker filtering and weekly emission guard.
+    """
+
+    def __init__(self, tickers, ema_fast=20, ema_slow=50, sma_trend=200):
+        super().__init__()
+        self.name = "TrendStocks"
+        self.tickers = tickers
+        self.ema_fast_period = ema_fast
+        self.ema_slow_period = ema_slow
+        self.sma_trend_period = sma_trend
+        self._ema_fast = {}
+        self._ema_slow = {}
+        self._sma_trend = {}
+        self.symbols = {}
+        self._last_week = -1
+
+    def update(self, algorithm, data):
+        if algorithm.is_warming_up:
+            return []
+
+        week = algorithm.time.isocalendar()[1]
+        if week == self._last_week:
+            return []
+        self._last_week = week
+
+        insights = []
+        period = timedelta(days=7)
+
+        for ticker in self.tickers:
+            symbol = self.symbols.get(ticker)
+            if symbol is None:
+                continue
+
+            fast = self._ema_fast.get(ticker)
+            slow = self._ema_slow.get(ticker)
+            sma = self._sma_trend.get(ticker)
+            if not fast or not slow or not sma:
+                continue
+            if not fast.is_ready or not slow.is_ready or not sma.is_ready:
+                continue
+
+            price = algorithm.securities[symbol].price
+            if price <= 0:
+                continue
+
+            price_above_sma = price > sma.current.value
+            ema_bullish = fast.current.value > slow.current.value
+
+            if price_above_sma and ema_bullish:
+                insights.append(Insight.price(
+                    symbol, period, InsightDirection.UP,
+                    source_model=self.name
+                ))
+            else:
+                insights.append(Insight.price(
+                    symbol, period, InsightDirection.FLAT,
+                    source_model=self.name
+                ))
+
+        return insights
+
+    def on_securities_changed(self, algorithm, changes):
+        for security in changes.added_securities:
+            ticker = security.symbol.value
+            if ticker in self.tickers:
+                self.symbols[ticker] = security.symbol
+                self._ema_fast[ticker] = algorithm.ema(security.symbol, self.ema_fast_period, Resolution.DAILY)
+                self._ema_slow[ticker] = algorithm.ema(security.symbol, self.ema_slow_period, Resolution.DAILY)
+                self._sma_trend[ticker] = algorithm.sma(security.symbol, self.sma_trend_period, Resolution.DAILY)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/main.py
@@ -1,0 +1,78 @@
+# region imports
+from AlgorithmImports import *
+from alpha_models import EMACrossAlpha, TrendStocksAlpha
+from portfolio_construction import MultiStrategyPCM
+# endregion
+
+
+class FrameworkCompositeEMATrend(QCAlgorithm):
+    """
+    Framework Composite - EMA-Cross + TrendStocks
+
+    Combines EMA-Cross (5 tech stocks, daily rebalance) with TrendStocks
+    (15 diversified stocks, weekly rebalance) via QC Algorithm Framework.
+
+    Universe overlap: The 5 tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA)
+    are included in both strategies. This is intentional - the MultiStrategyPCM
+    will additively combine weights, giving tech stocks higher allocation
+    when both strategies agree on the direction.
+
+    Target allocation (starting point): EMA40/Trend60
+    Sweep range: EMA30/Trend70 to EMA70/Trend30
+
+    Reference strategies:
+    - EMA-Cross-Alpha: Sharpe 0.980, daily emission
+    - TrendStocks-Alpha: Sharpe 0.718, weekly emission
+
+    Design principles:
+    - EMA-Cross: Fast mean-reversion on tech stocks (20/50 EMA)
+    - TrendStocks: Double-confirmation trend following (Price>SMA200 + EMA20>EMA50)
+    - Complementarity: Different timeframes and confirmation logic
+    """
+
+    def initialize(self):
+        self.set_start_date(2015, 1, 1)
+        self.set_cash(100000)
+        self.set_brokerage_model(BrokerageName.INTERACTIVE_BROKERS_BROKERAGE, AccountType.MARGIN)
+
+        # EMA-Cross universe: 5 tech stocks
+        ema_tickers = ["AAPL", "MSFT", "GOOGL", "AMZN", "NVDA"]
+
+        # TrendStocks universe: 15 stocks (includes the 5 tech)
+        trend_tickers = [
+            "AAPL", "MSFT", "GOOGL", "AMZN", "NVDA",  # Tech (overlap)
+            "JPM", "V", "MA",                            # Financials
+            "UNH", "JNJ",                                 # Healthcare
+            "XOM", "CVX",                                 # Energy
+            "HD", "PG", "KO"                             # Consumer staples
+        ]
+
+        # Add all equities
+        all_tickers = list(set(ema_tickers + trend_tickers))
+        for ticker in all_tickers:
+            self.add_equity(ticker, Resolution.DAILY)
+
+        # Create Alpha models
+        self.set_alpha(CompositeAlphaModel(
+            EMACrossAlpha(ema_tickers, fast_period=20, slow_period=50),
+            TrendStocksAlpha(trend_tickers, ema_fast=20, ema_slow=50, sma_trend=200)
+        ))
+
+        # Target allocation: EMA40/Trend60 (starting point for sweep)
+        self.set_portfolio_construction(MultiStrategyPCM(
+            alpha_allocations={
+                "EMACross": 0.40,
+                "TrendStocks": 0.60,
+            },
+            rebalance=timedelta(days=7)  # Weekly rebalance to align with TrendStocks
+        ))
+
+        self.set_risk_management(NullRiskManagementModel())
+        self.set_execution(ImmediateExecutionModel())
+        self.set_benchmark("SPY")
+        self.set_warm_up(210, Resolution.DAILY)  # Max(SMA200, EMA50)
+
+    def on_end_of_algorithm(self):
+        final = self.portfolio.total_portfolio_value
+        self.log(f"FRAMEWORK COMPOSITE (EMA40/Trend60): Final=${final:,.2f}, "
+                 f"Return={(final - 100000) / 100000:.2%}")

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/portfolio_construction.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/portfolio_construction.py
@@ -1,0 +1,58 @@
+from AlgorithmImports import *
+
+
+class MultiStrategyPCM(PortfolioConstructionModel):
+    """
+    Custom Portfolio Construction Model for multi-strategy framework.
+
+    Groups insights by source_model (alpha name), allocates a capital slice
+    per strategy, then aggregates overlapping tickers additively.
+    """
+
+    def __init__(self, alpha_allocations, rebalance=timedelta(days=31)):
+        super().__init__()
+        self.alpha_allocations = alpha_allocations
+        self.set_rebalancing_func(lambda dt: dt + rebalance)
+
+    def determine_target_percent(self, active_insights):
+        result = {}
+
+        if not active_insights:
+            return result
+
+        by_alpha = {}
+        for insight in active_insights:
+            source = insight.source_model or "Unknown"
+            if source not in by_alpha:
+                by_alpha[source] = []
+            by_alpha[source].append(insight)
+
+        for alpha_name, insights in by_alpha.items():
+            capital_slice = self.alpha_allocations.get(alpha_name, 0)
+            if capital_slice <= 0:
+                for insight in insights:
+                    result[insight] = 0
+                continue
+
+            active = [i for i in insights if i.direction != InsightDirection.FLAT]
+            flat = [i for i in insights if i.direction == InsightDirection.FLAT]
+
+            for insight in flat:
+                result[insight] = 0
+
+            if not active:
+                continue
+
+            has_weights = all(
+                i.weight is not None and i.weight > 0 for i in active
+            )
+
+            if has_weights:
+                for insight in active:
+                    result[insight] = insight.direction * insight.weight * capital_slice
+            else:
+                per_symbol = capital_slice / len(active)
+                for insight in active:
+                    result[insight] = insight.direction * per_symbol
+
+        return result

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QuantBook Research: Composite EMA-Cross + TrendStocks\n",
+    "\n",
+    "## Objectif\n",
+    "\n",
+    "Analyser la complémentarité entre les deux AlphaModels avant de créer le composite:\n",
+    "\n",
+    "1. **Corrélation des signaux** : Pourcentage de positions UP chaque semaine\n",
+    "2. **Complémentarité temporelle** : Performance pendant les drawdowns\n",
+    "3. **Overlap des signaux** : Les 5 tech stocks sont communs aux deux univers\n",
+    "4. **Proposition d'allocation** : Ratio optimal entre les deux stratégies\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# region imports\n",
+    "from AlgorithmImports import *\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from scipy import stats\n",
+    "# endregion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Définition des univers\n",
+    "\n",
+    "- **EMA-Cross** : 5 tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA)\n",
+    "- **TrendStocks** : 15 stocks diversifiés incluant les 5 tech stocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Univers EMA-Cross\n",
+    "ema_tickers = [\"AAPL\", \"MSFT\", \"GOOGL\", \"AMZN\", \"NVDA\"]\n",
+    "\n",
+    "# Univers TrendStocks (inclut les 5 tech)\n",
+    "trend_tickers = [\n",
+    "    \"AAPL\", \"MSFT\", \"GOOGL\", \"AMZN\", \"NVDA\",  # Tech (communs)\n",
+    "    \"JPM\", \"V\", \"MA\",                            # Financials\n",
+    "    \"UNH\", \"JNJ\",                                 # Healthcare\n",
+    "    \"XOM\", \"CVX\",                                 # Energy\n",
+    "    \"HD\", \"PG\", \"KO\"                             # Consumer staples\n",
+    "]\n",
+    "\n",
+    "print(f\"EMA-Cross: {len(ema_tickers)} stocks\")\n",
+    "print(f\"TrendStocks: {len(trend_tickers)} stocks\")\n",
+    "print(f\"Overlap: {set(ema_tickers) & set(trend_tickers)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Initialisation du QuantBook et récupération des données (2015-2025)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qb = QuantBook()\n",
+    "start_date = datetime(2015, 1, 1)\n",
+    "end_date = datetime(2025, 1, 1)\n",
+    "\n",
+    "# Ajouter tous les tickers\n",
+    "for ticker in trend_tickers:\n",
+    "    qb.add_equity(ticker, Resolution.DAILY)\n",
+    "\n",
+    "print(f\"QuantBook initialisé avec {len(qb.securities)} securities\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Calcul des indicateurs EMA-Cross"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Paramètres EMA-Cross\n",
+    "ema_fast = 20\n",
+    "ema_slow = 50\n",
+    "\n",
+    "# Récupérer l'historique\n",
+    "history = qb.history(qb.securities.keys(), start_date, end_date, Resolution.DAILY)\n",
+    "\n",
+    "# Calculer les signaux EMA-Cross pour les 5 tech stocks\n",
+    "ema_signals = pd.DataFrame(index=history.index.get_level_values(0).unique())\n",
+    "\n",
+    "for ticker in ema_tickers:\n",
+    "    symbol = qb.symbol(ticker)\n",
+    "    df_ticker = history.loc[symbol]['close']\n",
+    "    \n",
+    "    # Calculer EMAs\n",
+    "    ema_f = df_ticker.ewm(span=ema_fast, adjust=False).mean()\n",
+    "    ema_s = df_ticker.ewm(span=ema_slow, adjust=False).mean()\n",
+    "    \n",
+    "    # Signal: UP si fast > slow\n",
+    "    ema_signals[ticker] = (ema_f > ema_s).astype(int)\n",
+    "\n",
+    "# Pourcentage de stocks UP par semaine\n",
+    "ema_signals_weekly = ema_signals.resample('W').mean()\n",
+    "ema_up_pct = ema_signals_weekly.mean(axis=1) * 100\n",
+    "\n",
+    "print(f\"Signal EMA-Cross - Moyenne hebdomadaire: {ema_up_pct.mean():.1f}% des stocks UP\")\n",
+    "print(f\"Ecart-type: {ema_up_pct.std():.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Calcul des indicateurs TrendStocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Paramètres TrendStocks\n",
+    "trend_ema_fast = 20\n",
+    "trend_ema_slow = 50\n",
+    "trend_sma_trend = 200\n",
+    "\n",
+    "# Calculer les signaux TrendStocks pour les 15 stocks\n",
+    "trend_signals = pd.DataFrame(index=history.index.get_level_values(0).unique())\n",
+    "\n",
+    "for ticker in trend_tickers:\n",
+    "    symbol = qb.symbol(ticker)\n",
+    "    df_ticker = history.loc[symbol]['close']\n",
+    "    \n",
+    "    # Calculer indicateurs\n",
+    "    ema_f = df_ticker.ewm(span=trend_ema_fast, adjust=False).mean()\n",
+    "    ema_s = df_ticker.ewm(span=trend_ema_slow, adjust=False).mean()\n",
+    "    sma_t = df_ticker.rolling(window=trend_sma_trend).mean()\n",
+    "    \n",
+    "    # Signal: UP si Price > SMA200 ET EMA20 > EMA50\n",
+    "    price_above_sma = df_ticker > sma_t\n",
+    "    ema_bullish = ema_f > ema_s\n",
+    "    \n",
+    "    trend_signals[ticker] = (price_above_sma & ema_bullish).astype(int)\n",
+    "\n",
+    "# Pourcentage de stocks UP par semaine\n",
+    "trend_signals_weekly = trend_signals.resample('W').mean()\n",
+    "trend_up_pct = trend_signals_weekly.mean(axis=1) * 100\n",
+    "\n",
+    "print(f\"Signal TrendStocks - Moyenne hebdomadaire: {trend_up_pct.mean():.1f}% des stocks UP\")\n",
+    "print(f\"Ecart-type: {trend_up_pct.std():.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Analyse 1: Corrélation des signaux (Pearson)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Aligner les dates\n",
+    "common_dates = ema_up_pct.index.intersection(trend_up_pct.index)\n",
+    "ema_aligned = ema_up_pct.loc[common_dates]\n",
+    "trend_aligned = trend_up_pct.loc[common_dates]\n",
+    "\n",
+    "# Corrélation de Pearson\n",
+    "correlation, p_value = stats.pearsonr(ema_aligned, trend_aligned)\n",
+    "\n",
+    "print(f\"=== CORRÉLATION DES SIGNAUX (2015-2025) ===\")\n",
+    "print(f\"Corrélation de Pearson: {correlation:.3f}\")\n",
+    "print(f\"P-value: {p_value:.2e}\")\n",
+    "print(f\"\")\n",
+    "print(f\"Interprétation:\")\n",
+    "if correlation > 0.7:\n",
+    "    print(f\"  - Forte corrélation positive: les stratégies réagissent souvent de manière similaire\")\n",
+    "elif correlation > 0.3:\n",
+    "    print(f\"  - Corrélation modérée: certaine complémentarité possible\")\n",
+    "elif correlation > 0:\n",
+    "    print(f\"  - Faible corrélation: bonne diversification\")\n",
+    "else:\n",
+    "    print(f\"  - Corrélation négative ou nulle: excellente diversification\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Analyse 2: Complémentarité temporelle (Drawdowns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Périodes de drawdown majeures du marché (SPY)\n",
+    "drawdown_periods = [\n",
+    "    (\"2018 Q4\", datetime(2018, 10, 1), datetime(2019, 1, 1)),\n",
+    "    (\"2020 Mars\", datetime(2020, 2, 20), datetime(2020, 4, 1)),\n",
+    "    (\"2022 Bear\", datetime(2022, 1, 1), datetime(2022, 12, 31)),\n",
+    "]\n",
+    "\n",
+    "print(f\"=== PERFORMANCE PENDANT LES DRAWDOWS ===\")\n",
+    "print(f\"\")\n",
+    "\n",
+    "for name, start, end in drawdown_periods:\n",
+    "    # Filtrer les données de la période\n",
+    "    mask = (ema_aligned.index >= start) & (ema_aligned.index <= end)\n",
+    "    \n",
+    "    if mask.sum() > 0:\n",
+    "        ema_dd = ema_aligned[mask].mean()\n",
+    "        trend_dd = trend_aligned[mask].mean()\n",
+    "        \n",
+    "        print(f\"{name}:\")\n",
+    "        print(f\"  - EMA-Cross: {ema_dd:.1f}% des stocks UP\")\n",
+    "        print(f\"  - TrendStocks: {trend_dd:.1f}% des stocks UP\")\n",
+    "        print(f\"  - Différence: {abs(ema_dd - trend_dd):.1f} points de pourcentage\")\n",
+    "        print(f\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Analyse 3: Overlap des signaux (5 tech stocks communs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Comparer les signaux pour les 5 tech stocks communs\n",
+    "common_tickers = set(ema_tickers) & set(trend_tickers)\n",
+    "\n",
+    "overlap_results = {}\n",
+    "\n",
+    "for ticker in common_tickers:\n",
+    "    # Signaux EMA-Cross pour ce ticker\n",
+    "    ema_sig = ema_signals[ticker].resample('W').last()\n",
+    "    \n",
+    "    # Signaux TrendStocks pour ce ticker\n",
+    "    trend_sig = trend_signals[ticker].resample('W').last()\n",
+    "    \n",
+    "    # Aligner\n",
+    "    common = ema_sig.index.intersection(trend_sig.index)\n",
+    "    ema_common = ema_sig.loc[common]\n",
+    "    trend_common = trend_sig.loc[common]\n",
+    "    \n",
+    "    # Scénarios:\n",
+    "    # - UP/UP: Les deux sont haussiers\n",
+    "    # - UP/FLAT ou FLAT/UP: Divergence\n",
+    "    # - FLAT/FLAT: Les deux sont neutres\n",
+    "    \n",
+    "    up_up = ((ema_common == 1) & (trend_common == 1)).sum()\n",
+    "    up_flat = ((ema_common == 1) & (trend_common == 0)).sum()\n",
+    "    flat_up = ((ema_common == 0) & (trend_common == 1)).sum()\n",
+    "    flat_flat = ((ema_common == 0) & (trend_common == 0)).sum()\n",
+    "    total = len(common)\n",
+    "    \n",
+    "    overlap_results[ticker] = {\n",
+    "        'up_up_pct': up_up / total * 100,\n",
+    "        'divergence_pct': (up_flat + flat_up) / total * 100,\n",
+    "        'flat_flat_pct': flat_flat / total * 100,\n",
+    "    }\n",
+    "\n",
+    "print(f\"=== OVERLAP DES SIGNAUX (5 TECH STOCKS) ===\")\n",
+    "print(f\"\")\n",
+    "print(f\"{'Ticker':<8} {'UP/UP':>10} {'Divergence':>12} {'FLAT/FLAT':>12}\")\n",
+    "print(f\"-\" * 46)\n",
+    "\n",
+    "for ticker, stats in overlap_results.items():\n",
+    "    print(f\"{ticker:<8} {stats['up_up_pct']:>9.1f}% {stats['divergence_pct']:>11.1f}% {stats['flat_flat_pct']:>11.1f}%\")\n",
+    "\n",
+    "# Moyennes\n",
+    "avg_up_up = np.mean([s['up_up_pct'] for s in overlap_results.values()])\n",
+    "avg_div = np.mean([s['divergence_pct'] for s in overlap_results.values()])\n",
+    "avg_flat = np.mean([s['flat_flat_pct'] for s in overlap_results.values()])\n",
+    "print(f\"-\" * 46)\n",
+    "print(f\"{'MOYENNE':<8} {avg_up_up:>9.1f}% {avg_div:>11.1f}% {avg_flat:>11.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Analyse 4: Proposition d'allocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"=== PROPOSITION D'ALLOCATION ===\")\n",
+    "print(f\"\")\n",
+    "print(f\"Synthèse des analyses:\")\n",
+    "print(f\"1. Corrélation: {correlation:.3f}\")\n",
+    "print(f\"2. Volatilité EMA-Cross: {ema_up_pct.std():.1f}%\")\n",
+    "print(f\"3. Volatilité TrendStocks: {trend_up_pct.std():.1f}%\")\n",
+    "print(f\"4. Divergence moyenne sur tech stocks: {avg_div:.1f}%\")\n",
+    "print(f\"\")\n",
+    "print(f\"Recommandation:\")\n",
+    "\n",
+    "# Décision basée sur la corrélation\n",
+    "if correlation > 0.5:\n",
+    "    # Forte corrélation: favoriser la plus robuste (TrendStocks avec confirmation double)\n",
+    "    print(f\"  - EMA30/Trend70: Corrélation élevée, TrendStocks plus robuste\")\n",
+    "    recommended = \"EMA30/Trend70\"\n",
+    "elif correlation > 0.2:\n",
+    "    # Corrélation modérée: équilibrer\n",
+    "    print(f\"  - EMA40/Trend60: Corrélation modérée, bon équilibre\")\n",
+    "    recommended = \"EMA40/Trend60\"\n",
+    "else:\n",
+    "    # Faible corrélation: diversifier équitablement\n",
+    "    print(f\"  - EMA50/Trend50: Faible corrélation, diversification optimale\")\n",
+    "    recommended = \"EMA50/Trend50\"\n",
+    "\n",
+    "print(f\"\")\n",
+    "print(f\"Allocation de départ recommandée: {recommended}\")\n",
+    "print(f\"\")\n",
+    "print(f\"Plan de sweep (à exécuter après backtest initial):\")\n",
+    "print(f\"  - EMA30/Trend70\")\n",
+    "print(f\"  - EMA40/Trend60\")\n",
+    "print(f\"  - EMA50/Trend50\")\n",
+    "print(f\"  - EMA60/Trend40\")\n",
+    "print(f\"  - EMA70/Trend30\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Conclusion\n",
+    "\n",
+    "Ce QuantBook a permis d'analyser la complémentarité entre EMA-Cross et TrendStocks.\n",
+    "Les résultats guideront l'allocation initiale du composite ainsi que les sweeps à effectuer."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary

Phase 3 of AlphaModel migration - Composite strategy combining EMA-Cross and TrendStocks via QC Algorithm Framework.

**Files added:**
- `quantbook_composite_research.ipynb`: Correlation analysis between the two strategies
- `alpha_models.py`: EMACrossAlpha + TrendStocksAlpha with `source_model` tags
- `portfolio_construction.py`: MultiStrategyPCM with `determine_target_percent`
- `main.py`: Composite with EMA40/Trend60 allocation

**Design:**
- EMA-Cross: 5 tech stocks, daily rebalance (20/50 EMA crossover)
- TrendStocks: 15 stocks, weekly rebalance (Price>SMA200 + EMA20>EMA50)
- Overlap: 5 tech stocks are in both universes (intentional - weights add up)

## Test plan

- [x] Code structure follows Framework_Composite_FamaFrenchAllWeather pattern
- [x] AlphaModels copied from corrected git HEAD (commit f7ca216)
- [x] MultiStrategyPCM uses `determine_target_percent` (not `create_targets`)
- [x] Each AlphaModel has `self.name` and `source_model=self.name`
- [ ] Compile on QC cloud (pending review)
- [ ] QuantBook correlation analysis (pending execution)
- [ ] Backtest with EMA40/Trend60 (pending review)
- [ ] Sweep EMA30/Trend70 to EMA70/Trend30 (pending after initial backtest)

## Next steps

1. Review code structure and AlphaModel implementations
2. Execute QuantBook to determine optimal allocation
3. Deploy to QC cloud and run initial backtest
4. Run parameter sweep on allocation ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)