### PR TITLE
feat(ML): Ajout exercices bonus notebooks ML.NET pour ECE TP #49

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -921,6 +921,20 @@
     "\n",
     "**Navigation** : [Index](README.md) | [Suivant >> ML-2 Data & Features](ML-2-Data%26Features.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dhhim59y2jj",
+   "source": "---\n\n## Exercice : Prédiction du prix d'une voiture d'occasion\n\n### Objectif\nCréez un modèle de régression pour prédire le prix d'une voiture d'occasion en fonction de son kilométrage et de son année de fabrication.\n\n### Contexte\nUn concessionnaire automobile souhaite estimer automatiquement le prix de reprise des véhicules. Vous disposez d'un jeu de données avec les informations suivantes :\n- `Kilometrage` : nombre de kilomètres parcourus\n- `Annee` : année de fabrication\n- `Prix` : prix de vente (en milliers d'euros)\n\n### Instructions\n\n1. **Définir les classes de données** : Créez une classe `VoitureData` avec les propriétés Kilometrage, Annee et Prix\n2. **Créer les données d'entraînement** : Utilisez au moins 8 exemples de voitures\n3. **Construire le pipeline** : Concaténez les features et utilisez SDCA comme trainer de régression\n4. **Entraîner le modèle** : Appelez la méthode Fit sur vos données\n5. **Faire une prédiction** : Prédisez le prix d'une voiture de 2019 avec 45000 km\n\n### Données suggérées\n\n| Kilométrage | Année | Prix (k€) |\n|-------------|-------|-----------|\n| 120000 | 2015 | 8.5 |\n| 45000 | 2019 | 15.2 |\n| 89000 | 2017 | 11.8 |\n| 150000 | 2014 | 6.9 |\n| 25000 | 2021 | 19.5 |\n| 67000 | 2018 | 13.4 |\n| 95000 | 2016 | 10.2 |\n| 30000 | 2020 | 17.8 |\n\n### Code de démarrage\n\n```csharp\n// Étape 1 : Définir la classe VoitureData\n// À compléter...\n\n// Étape 2 : Créer les données d'entraînement\n// À compléter...\n\n// Étape 3-5 : Pipeline, entraînement et prédiction\n// À compléter...\n```\n\n### Critères de réussite\n- Le modèle prédit un prix cohérent pour la voiture test (entre 12k€ et 18k€ attendu)\n- Le code compile sans erreur\n- Les étapes du pipeline ML.NET sont correctement enchaînées",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6hdfxqo3cj9",
+   "source": "// Exercice : Prédiction du prix d'une voiture d'occasion\n// Complétez le code ci-dessous pour créer votre modèle\n\n// Étape 1 : Définir la classe VoitureData (propriétés : Kilometrage, Annee, Prix)\n\n\n// Étape 2 : Créer les données d'entraînement avec les données du tableau\n\n\n// Étape 3 : Construire le pipeline ML.NET\n\n\n// Étape 4 : Entraîner le modèle\n\n\n// Étape 5 : Prédire le prix d'une voiture de 2019 avec 45000 km\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
@@ -974,6 +974,20 @@
    "source": [
     "Nous avons maintenant un IDataView chargé et un pipeline prêt pour l'entraînement."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "nd5tlidfhnn",
+   "source": "---\n\n## Exercice : Pipeline de préparation pour un dataset de employés\n\n### Objectif\nConstruisez un pipeline complet de préparation des données pour prédire le salaire d'un employé en fonction de ses caractéristiques.\n\n### Contexte\nLe service RH dispose de données sur les employés avec des variables catégorielles (département, niveau d'études) et numériques (années d'expérience, âge). Vous devez préparer ces données pour un modèle de régression.\n\n### Instructions\n\n1. **Définir la classe `EmployeData`** avec les propriétés :\n   - `Departement` (string) : \"IT\", \"Marketing\", \"Finance\", \"RH\"\n   - `NiveauEtudes` (string) : \"Bac\", \"Licence\", \"Master\", \"Doctorat\"\n   - `AnneesExperience` (float)\n   - `Age` (float)\n   - `Salaire` (float) - colonne label à prédire\n\n2. **Créer un IDataView** avec au moins 6 exemples d'employés\n\n3. **Construire le pipeline de transformations** :\n   - Appliquer `OneHotEncoding` sur `Departement` et `NiveauEtudes`\n   - Remplacer les valeurs manquantes sur `AnneesExperience` et `Age`\n   - Concaténer toutes les features en une colonne \"Features\"\n\n4. **Exécuter le pipeline** avec `Fit` et `Transform`\n\n5. **Vérifier le résultat** en affichant les données transformées\n\n### Données suggérées\n\n| Département | Niveau | Expérience | Âge | Salaire (k€) |\n|-------------|--------|------------|-----|--------------|\n| IT | Master | 5 | 28 | 45 |\n| Marketing | Licence | 3 | 25 | 35 |\n| Finance | Master | 8 | 32 | 55 |\n| RH | Licence | 2 | 24 | 32 |\n| IT | Doctorat | 10 | 35 | 70 |\n| Marketing | Master | 6 | 30 | 42 |\n\n### Code de démarrage\n\n```csharp\n// Étape 1 : Classe EmployeData\n// À compléter...\n\n// Étape 2 : Créer l'IDataView\n// À compléter...\n\n// Étape 3 : Pipeline avec OneHotEncoding, ReplaceMissingValues, Concatenate\n// À compléter...\n\n// Étape 4-5 : Exécuter et vérifier\n// À compléter...\n```\n\n### Critères de réussite\n- Les colonnes catégorielles sont encodées en one-hot (vecteurs numériques)\n- La colonne \"Features\" contient toutes les caractéristiques concaténées\n- Le pipeline s'exécute sans erreur",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ikdnmm6i8il",
+   "source": "// Exercice : Pipeline de préparation pour un dataset de employés\n// Complétez le code ci-dessous\n\n// Étape 1 : Définir la classe EmployeData\n\n\n// Étape 2 : Créer l'IDataView avec les 6 exemples\n\n\n// Étape 3 : Construire le pipeline de transformations\n\n\n// Étape 4 : Exécuter le pipeline (Fit + Transform)\n\n\n// Étape 5 : Afficher un aperçu des données transformées\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -1034,6 +1034,18 @@
     "> [⏩ Module suivant - Évaluation du modèle](./04-Model%20Evaluation.ipynb)  \n",
     "> [⏪ Module précédent - Préparation des données et ingénierie des fonctionnalités](./02-Data%20Preparation%20and%20Feature%20Engineering.ipynb)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "---\n\n## Exercice : Comparaison de trainers avec AutoML\n\n### Objectif\nUtilisez AutoML pour comparer plusieurs algorithmes de régression et identifier le meilleur modèle pour prédire une relation non-linéaire.\n\n### Contexte\nVous devez modéliser la relation entre l'investissement publicitaire et le chiffre d'affaires d'une entreprise. Cette relation n'est pas linéaire - les rendements diminuent à mesure que l'investissement augmente.\n\n### Instructions\n\n1. **Créer les données** : Générez un dataset avec la relation `CA = 50 * sqrt(Investissement) + bruit`\n2. **Configurer AutoML** : Utilisez `AutoMLExperiment` avec un budget de 30 secondes\n3. **Comparer les résultats** : Identifiez quel trainer a donné le meilleur RMSE\n4. **Analyser** : Pourquoi un trainer non-linéaire (comme LightGBM) est-il meilleur que SDCA ?\n\n### Code de démarrage\n\n```csharp\n// Génération des données\nvar rand = new Random(42);\nvar investissements = Enumerable.Range(1, 200).Select(x => (float)x * 0.5f).ToArray();\nvar ca = investissements.Select(inv => 50 * Math.Sqrt(inv) + (rand.NextDouble() - 0.5) * 5).ToArray();\n\n// Créer le DataFrame\nvar df = new DataFrame();\ndf[\"Investissement\"] = DataFrameColumn.Create(\"Investissement\", investissements);\ndf[\"CA\"] = DataFrameColumn.Create(\"CA\", ca.Select(v => (float)v).ToArray());\n\n// Diviser en train/test\n// À compléter...\n\n// Configurer AutoML\n// À compléter...\n\n// Analyser les résultats\n// À compléter...\n```\n\n### Questions à répondre\n1. Quel est le RMSE du meilleur modèle ?\n2. Quel type d'algorithme (linéaire ou non-linéaire) performe le mieux ? Pourquoi ?\n3. Que se passe-t-il si vous augmentez le bruit dans les données ?\n\n### Critères de réussite\n- L'expérience AutoML s'exécute sans erreur\n- Au moins 5 trainers différents sont testés\n- Le RMSE est inférieur à 10 sur le jeu de test",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice : Comparaison de trainers avec AutoML\n// Complétez le code ci-dessous\n\n// Génération des données\nvar rand = new Random(42);\nvar investissements = Enumerable.Range(1, 200).Select(x => (float)x * 0.5f).ToArray();\nvar ca = investissements.Select(inv => 50 * Math.Sqrt(inv) + (rand.NextDouble() - 0.5) * 5).ToArray();\n\n// Créer le DataFrame\nvar df = new DataFrame();\ndf[\"Investissement\"] = DataFrameColumn.Create(\"Investissement\", investissements);\ndf[\"CA\"] = DataFrameColumn.Create(\"CA\", ca.Select(v => (float)v).ToArray());\n\n// Étape 1 : Diviser en train/test (80% / 20%)\n\n\n// Étape 2 : Configurer le pipeline AutoML avec Regression\n\n\n// Étape 3 : Créer et exécuter l'expérience (30 secondes)\n\n\n// Étape 4 : Afficher le meilleur modèle et son RMSE\n\n\n// Questions à répondre :\n// 1. Quel est le RMSE du meilleur modèle ?\n// 2. Quel type d'algorithme performe le mieux ?\n// 3. Que se passe-t-il avec plus de bruit ?\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -2537,6 +2537,20 @@
     "- [Classification binaire avec le jeu de données Titanic](./REF-Kaggle%20with%20Titanic%20Dataset.ipynb)  \n",
     "- [Prédiction de valeurs/Régression avec le jeu de données Taxi](./E2E-Regression%20with%20Taxi%20Dataset.ipynb)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adri0nhcw4",
+   "source": "---\n\n## Exercice : Validation croisée et Interprétation PFI\n\n### Objectif\nAppliquez la validation croisée K-Fold et analysez l'importance des features avec PFI sur un modèle de prédiction des tarifs de taxi.\n\n### Contexte\nVous avez entraîné un modèle pour prédire les tarifs de taxi. Maintenant, vous devez :\n1. Évaluer sa robustesse avec une validation croisée 5-Fold\n2. Identifier quelles features contribuent le plus aux prédictions\n\n### Instructions\n\n1. **Préparer le pipeline** : Utilisez les mêmes transformations que le notebook (OneHotEncoding, ReplaceMissingValues, Concatenate)\n2. **Appliquer CrossValidate** : Utilisez `mlContext.Regression.CrossValidate` avec 5 folds\n3. **Analyser les métriques** : Calculez la moyenne et l'écart-type du R² sur les 5 folds\n4. **Calculer PFI** : Utilisez `PermutationFeatureImportance` sur le meilleur modèle\n5. **Interpréter** : Identifiez les 3 features les plus importantes\n\n### Code de démarrage\n\n```csharp\n// Pipeline de préparation (déjà défini dans le notebook)\nvar evalPipeline = \n    mlContext.Transforms.Categorical.OneHotEncoding(...)\n    .Append(mlContext.Transforms.ReplaceMissingValues(...))\n    .Append(mlContext.Transforms.Concatenate(\"Features\", ...))\n    .Append(mlContext.Regression.Trainers.FastForest(labelColumnName: \"fare_amount\"));\n\n// Étape 1 : Validation croisée 5-Fold\nvar cvResults = mlContext.Regression.CrossValidate(trainSet, evalPipeline, numberOfFolds: 5, labelColumnName: \"fare_amount\");\n\n// Étape 2 : Calculer les statistiques (moyenne R², écart-type)\n// À compléter...\n\n// Étape 3 : Entraîner un modèle final sur toutes les données\n// À compléter...\n\n// Étape 4 : Calculer PFI\n// À compléter...\n\n// Étape 5 : Afficher les features triées par importance\n// À compléter...\n```\n\n### Questions à répondre\n1. Quel est le R² moyen sur les 5 folds ? Et l'écart-type ?\n2. Quelles sont les 3 features les plus importantes selon PFI ?\n3. Pourquoi `trip_distance` est-elle probablement la feature la plus importante ?\n\n### Critères de réussite\n- La validation croisée s'exécute sans erreur\n- Le R² moyen est cohérent avec les résultats du notebook (entre 0.8 et 0.9)\n- Les features sont correctement triées par importance",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "4ho4s9zpk0b",
+   "source": "// Exercice : Validation croisée et Interprétation PFI\n// Complétez le code ci-dessous\n\n// Étape 1 : Préparer le pipeline (reprendre les transformations du notebook)\n\n\n// Étape 2 : Validation croisée 5-Fold\n\n\n// Étape 3 : Calculer les statistiques (moyenne R², écart-type)\n\n\n// Étape 4 : Entraîner le meilleur modèle sur toutes les données\n\n\n// Étape 5 : Calculer et afficher PFI\n\n\n// Questions :\n// 1. R² moyen = ?\n// 2. Top 3 features = ?\n// 3. Pourquoi trip_distance ?\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -647,6 +647,18 @@
     "\n",
     "**Navigation** : [<< ML-4-Evaluation](ML-4-Evaluation.ipynb) | [ML-6-ONNX](ML-6-ONNX.ipynb) | [Index](README.md)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "---\n\n## Exercice : Forecasting des ventes mensuelles\n\n### Objectif\nUtilisez ForecastBySsa pour prédire les ventes des 3 prochains mois à partir de données historiques.\n\n### Contexte\nUn magasin a enregistré ses ventes mensuelles sur 2 ans (24 mois). Vous devez prédire les ventes du trimestre suivant.\n\n### Instructions\n\n1. **Créer les données** : Générez 24 points de données avec une tendance et une saisonnalité\n2. **Configurer ForecastBySsa** : windowSize=12 (saisonnalité annuelle), horizon=3\n3. **Afficher les prévisions** : Montrez les 3 mois prédits avec intervalles de confiance\n4. **Calculer l'erreur** : Comparez avec les 3 valeurs réelles suivantes\n\n### Code de démarrage\n\n```csharp\n// Données de ventes mensuelles (24 mois)\nvar ventes = new float[] { \n    100, 120, 150, 180, 200, 220, 250, 230, 190, 160, 130, 110,  // Année 1\n    115, 135, 170, 200, 225, 250, 280, 260, 210, 175, 145, 125   // Année 2\n};\n\n// Étape 1 : Créer le DataFrame avec les données\n// À compléter...\n\n// Étape 2 : Configurer le pipeline ForecastBySsa\n// À compléter...\n\n// Étape 3 : Entraîner et prédire\n// À compléter...\n```\n\n### Critères de réussite\n- Les 3 prévisions sont cohérentes avec la tendance\n- L'intervalle de confiance est affiché\n- Le code s'exécute sans erreur",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice : Forecasting des ventes mensuelles\n// Complétez le code ci-dessous\n\n// Données de ventes mensuelles (24 mois)\nvar ventes = new float[] { \n    100, 120, 150, 180, 200, 220, 250, 230, 190, 160, 130, 110,  // Année 1\n    115, 135, 170, 200, 225, 250, 280, 260, 210, 175, 145, 125   // Année 2\n};\n\n// Étape 1 : Créer le DataFrame avec les données\n\n\n// Étape 2 : Configurer le pipeline ForecastBySsa (windowSize=12, horizon=3)\n\n\n// Étape 3 : Entraîner et prédire\n\n\n// Étape 4 : Afficher les prévisions avec intervalles de confiance\n\n\n// Valeurs réelles pour comparaison : 140, 165, 195\n// Calculez le MAE\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
@@ -859,6 +859,20 @@
     "\n",
     "**Navigation** : [<< ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | [Suivant >> ML-7-Recommendation](ML-7-Recommendation.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "xk7snh0er5",
+   "source": "---\n\n## Exercice : Workflow Python vers ML.NET via ONNX\n\n### Objectif\nSimulez un workflow complet d'export ONNX depuis Python et d'import dans ML.NET.\n\n### Scénario\nVous avez entraîné un modèle de classification en Python avec scikit-learn. Vous devez maintenant l'utiliser dans une application .NET.\n\n### Instructions\n\n1. **Créer un modèle simple** : Entraînez un SdcaLogisticRegression sur des données synthétiques\n2. **Simuler l'export ONNX** : Décrivez les étapes Python équivalentes\n3. **Tester l'inférence** : Faites des prédictions avec le modèle entraîné\n4. **Comparer les performances** : Mesurez le temps de prédiction pour 1000 samples\n\n### Questions\n1. Quels frameworks Python peuvent exporter vers ONNX ?\n2. Quels sont les avantages de ONNX Runtime vs Python natif ?\n3. Quelles sont les limitations de l'export ONNX depuis ML.NET ?\n\n### Critères de réussite\n- Le modèle s'entraîne sans erreur\n- Les prédictions sont cohérentes\n- Le temps de prédiction est mesuré",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "sogvu7rica",
+   "source": "// Exercice : Workflow Python vers ML.NET via ONNX\n// TODO: Créez un modèle de classification binaire avec ML.NET\n\nvar mlContextEx = new MLContext(seed: 42);\n\n// 1. Définir la classe de données d'entraînement\n// TODO: Complétez la classe DonneesEntrainement avec:\n// - Feature1 (float)\n// - Feature2 (float)  \n// - Feature3 (float)\n// - Label (bool)\n\npublic class DonneesEntrainement\n{\n    // TODO: Ajoutez les propriétés\n}\n\n// 2. Générer des données synthétiques (100 exemples)\n// TODO: Créez une liste de 100 DonneesEntrainement avec des valeurs aléatoires\n// Utilisez new Random(42) pour la reproductibilité\n\nvar donneesEntrainement = new List<DonneesEntrainement>();\n// TODO: Ajoutez votre code ici\n\n// 3. Charger les données dans ML.NET\nvar donneesView = mlContextEx.Data.LoadFromEnumerable(donneesEntrainement);\n\n// 4. Créer le pipeline avec OneHotEncoding si nécessaire\n// TODO: Construisez un pipeline qui:\n// - Concatène les features\n// - Utilise SdcaLogisticRegression pour la classification\n\nvar pipelineEx = // TODO: Complétez le pipeline\n\n// 5. Entraîner le modèle\nvar modeleEx = pipelineEx.Fit(donneesView);\n\nConsole.WriteLine(\"Modèle entraîné avec succès !\");\n\n// 6. Tester une prédiction\nvar exempleTest = new DonneesEntrainement \n{ \n    // TODO: Définissez des valeurs de test\n};\n\n// TODO: Créez un moteur de prédiction et affichez le résultat\n\n// 7. Mesurer le temps de prédiction pour 1000 samples\nvar stopwatch = System.Diagnostics.Stopwatch.StartNew();\n\n// TODO: Faites 1000 prédictions et mesurez le temps\n\nstopwatch.Stop();\nConsole.WriteLine($\"Temps pour 1000 prédictions: {stopwatch.ElapsedMilliseconds} ms\");\n\n// 8. Simuler l'export ONNX (description)\n// TODO: Décrivez en commentaire les étapes Python équivalentes:\n// - Quelle bibliothèque Python utiliseriez-vous ?\n// - Quelle fonction d'export ?\n// - Comment chargeriez-vous dans ML.NET ?",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -1010,6 +1010,18 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "source": "---\n\n## Exercice : Système de recommandation de restaurants\n\n### Objectif\nConstruisez un système de recommandation pour une application de livraison de repas.\n\n### Contexte\nVous avez des données sur les notes des clients pour différents restaurants. Vous devez recommander des restaurants à un utilisateur.\n\n### Instructions\n\n1. **Définir les classes** : RestaurantRating (UserId, RestaurantId, Rating)\n2. **Créer les données** : Au moins 20 notes de 5 utilisateurs sur 6 restaurants\n3. **Entraîner le modèle** : Utilisez SDCA pour prédire les notes\n4. **Générer des recommandations** : Pour chaque utilisateur, montrez les 3 meilleurs restaurants non notés\n5. **Gérer le cold start** : Proposez une recommandation pour un nouvel utilisateur\n\n### Code de démarrage\n\n```csharp\n// Données de notes de restaurants\nvar restaurantData = new List<RestaurantRating>\n{\n    // Utilisateur 1 : aime Cuisine française\n    new RestaurantRating { UserId = 1, RestaurantId = 1, Rating = 5 },  // Le Petit Bistrot\n    new RestaurantRating { UserId = 1, RestaurantId = 2, Rating = 4 },  // Chez Marie\n    // ... ajoutez plus de données\n};\n\n// Étape 1 : Créer le modèle\n// Étape 2 : Entraîner\n// Étape 3 : Recommander\n```\n\n### Critères de réussite\n- Au moins 3 utilisateurs ont des recommandations personnalisées\n- Le cold start est géré (nouvel utilisateur)\n- Les recommandations sont cohérentes avec les préférences",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice : Système de recommandation de restaurants\n// Complétez le code ci-dessous\n\n// Étape 1 : Définir la classe RestaurantRating\n\n\n// Étape 2 : Créer les données (20+ notes)\n\n\n// Étape 3 : Entraîner le modèle de recommandation\n\n\n// Étape 4 : Générer les recommandations Top-3 pour chaque utilisateur\n\n\n// Étape 5 : Gérer le cold start (nouvel utilisateur)\n// Proposer les restaurants les plus populaires\n\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Ajout d'exercices bonus dans les 7 notebooks ML.NET pour l'examen ECE TP (17-18 mars 2026).

**Issue**: #49 (ECE TP Audit)

## Exercices ajoutés

| Notebook | Thème | Exercice | Durée |
|----------|-------|----------|-------|
| ML-1 | Introduction | Prédiction prix voiture (régression SDCA) | 10-15 min |
| ML-2 | Data & Features | Pipeline employés avec OneHotEncoding | 10-15 min |
| ML-3 | Entraînement & AutoML | Comparaison trainers avec AutoML (sqrt) | 10-15 min |
| ML-4 | Évaluation | K-Fold cross-validation + PFI | 10-15 min |
| ML-5 | Time Series | Prévision ventes mensuelles (ForecastBySsa) | 10-15 min |
| ML-6 | ONNX | Workflow Python → ML.NET via ONNX | 10-15 min |
| ML-7 | Recommendation | Système recommandation restaurants | 10-15 min |

## Format des exercices

Chaque exercice comprend :
- **Instructions** en français avec objectifs clairs
- **Code skeleton** avec marqueurs TODO
- **Questions de réflexion** pour approfondissement
- **Critères de réussite** mesurables

## Test plan

- [x] Tous les notebooks ont été modifiés avec succès
- [x] Les cellules markdown et code sont correctement insérées
- [x] Le format suit les conventions pédagogiques du projet
- [ ] Exécution à valider par l'équipe pédagogique

🤖 Generated with [Claude Code](https://claude.com/claude-code)