### PR TITLE
feat(tweety): add exercises to Tweety-2,3,4,7a,7b for EPITA

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
@@ -2333,6 +2333,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "21ejyu27m0t",
+   "source": "## Exercice : Modelisation d'un probleme de planification en logique propositionnelle\n\n### Contexte\n\nUn enseignant doit planifier 3 cours (Maths, Info, Physique) sur 2 creneaux (Matin, Apres-midi).\nLes contraintes sont :\n1. Chaque cours doit etre assigne a exactement un creneau\n2. Maths et Physique ne peuvent pas etre au meme creneau (conflit de salle)\n3. Info doit etre le matin\n\n### Objectifs\n\n1. Modeliser ce probleme avec des propositions Tweety (`Proposition`, `Negation`, `Conjunction`, `Disjunction`)\n2. Construire la base de croyances (`PlBeliefSet`) contenant toutes les contraintes\n3. Utiliser le raisonneur SAT (`Sat4jSolver` ou pySAT) pour trouver une solution\n4. Verifier si la contrainte supplementaire \"Physique le matin\" est satisfiable avec les autres\n\n### Indices\n\n- Utilisez 6 propositions : `maths_am`, `maths_pm`, `info_am`, `info_pm`, `phys_am`, `phys_pm`\n- \"Exactement un creneau\" = `(x_am || x_pm) && !(x_am && x_pm)`\n- \"Pas au meme creneau\" = `!(maths_am && phys_am) && !(maths_pm && phys_pm)`\n- Reutilisez le pattern de parsing du notebook : `parser_pl.parseFormula(\"...\")`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "l8jm9v7af8",
+   "source": "# --- Exercice : Planification en Logique Propositionnelle ---\n# Modelisez le probleme de planification decrit ci-dessus.\n\nif jvm_ready:\n    from org.tweetyproject.logics.pl.syntax import Proposition, PlBeliefSet, Negation, Conjunction, Disjunction\n    from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n    from org.tweetyproject.logics.pl.reasoner import SatReasoner\n\n    # 1. Definir les 6 propositions\n    # maths_am = Proposition(\"maths_am\")\n    # ...\n    raise NotImplementedError(\"A vous de jouer !\")\n\n    # 2. Construire les contraintes\n    # Contrainte: chaque cours a exactement un creneau\n    # Contrainte: Maths et Physique pas au meme creneau\n    # Contrainte: Info le matin\n\n    # 3. Creer la KB et ajouter les contraintes\n    # kb = PlBeliefSet()\n    # kb.add(...)\n\n    # 4. Resoudre avec SAT\n    # SatSolver.setDefaultSolver(Sat4jSolver())\n    # reasoner = SatReasoner()\n    # print(\"KB consistante ?\", reasoner.isConsistent(kb))\n\n    # 5. (Bonus) Ajouter \"Physique le matin\" et re-tester\nelse:\n    print(\"JVM non demarree - exercice non disponible.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "8511a380",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -1166,6 +1166,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gukci1vj9ze",
+   "source": "## Exercice : Construction d'une ontologie universitaire en Description Logic\n\n### Contexte\n\nVous devez modeliser une ontologie simple pour une universite avec les concepts suivants :\n- **Personne**, **Etudiant**, **Enseignant** (concepts atomiques)\n- **Cours** (concept atomique, disjoint de Personne)\n- **enseigne** (role entre Enseignant et Cours)\n- **inscritA** (role entre Etudiant et Cours)\n\n### Objectifs\n\n1. Definir les concepts atomiques et roles avec `AtomicConcept` et `AtomicRole`\n2. Creer les axiomes TBox :\n   - `Etudiant` est equivalent a `Personne` (subsomption)\n   - `Enseignant` est equivalent a `Personne`\n   - `Cours` est equivalent a `NOT Personne` (disjonction)\n3. Creer les assertions ABox pour au moins 2 etudiants, 1 enseignant et 2 cours\n4. Utiliser `NaiveDlReasoner` pour verifier :\n   - Un etudiant est-il une Personne ?\n   - Un cours est-il une Personne ?\n   - Un enseignant est-il un Etudiant ?\n\n### Indices\n\n- Reutilisez le pattern du notebook : `AtomicConcept(\"Etudiant\")`, `EquivalenceAxiom(...)`, `ConceptAssertion(...)`\n- La disjonction se fait avec `Complement` : `EquivalenceAxiom(cours, Complement(personne))`\n- Le raisonneur : `NaiveDlReasoner().query(kb, assertion)`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "w4l5v5ty69",
+   "source": "# --- Exercice : Ontologie Universitaire en Description Logic ---\n# Construisez l'ontologie decrite ci-dessus.\n\nif jvm_ready and dl_imports_ok:\n    from org.tweetyproject.logics.dl.syntax import (\n        AtomicConcept, AtomicRole, Individual,\n        EquivalenceAxiom, ConceptAssertion, RoleAssertion,\n        DlBeliefSet, Complement\n    )\n    from org.tweetyproject.logics.dl.reasoner import NaiveDlReasoner\n\n    # 1. Definir les concepts atomiques\n    # personne = AtomicConcept(\"Personne\")\n    # etudiant = AtomicConcept(\"Etudiant\")\n    # ...\n    raise NotImplementedError(\"A vous de jouer !\")\n\n    # 2. Definir les roles\n    # enseigne = AtomicRole(\"enseigne\")\n    # ...\n\n    # 3. Creer les axiomes TBox\n    # etudiant_personne = EquivalenceAxiom(etudiant, personne)\n    # ...\n\n    # 4. Creer les individus et assertions ABox\n    # alice = Individual(\"Alice\")\n    # alice_etudiant = ConceptAssertion(alice, etudiant)\n    # ...\n\n    # 5. Construire la KB\n    # kb = DlBeliefSet()\n    # kb.add(...)  # TBox + ABox\n\n    # 6. Raisonner\n    # reasoner = NaiveDlReasoner()\n    # print(\"Etudiant est Personne ?\", reasoner.query(kb, ...))\n    # print(\"Cours est Personne ?\", reasoner.query(kb, ...))\nelse:\n    print(\"JVM ou imports DL non disponibles.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "4a2b4ad3",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -1581,6 +1581,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "to82h53o9o",
+   "source": "## Exercice : Diagnostic d'incoherence dans une base de regles meteo\n\n### Contexte\n\nUne station meteo automatisee produit les regles suivantes (certaines contradictoires) :\n1. `soleil => sec` (s'il fait soleil, il fait sec)\n2. `pluie => !sec` (s'il pleut, il ne fait pas sec)\n3. `soleil` (il fait soleil)\n4. `pluie` (il pleut)\n5. `vent => froid` (s'il y a du vent, il fait froid)\n6. `soleil => !froid` (s'il fait soleil, il ne fait pas froid)\n7. `vent` (il y a du vent)\n\n### Objectifs\n\n1. Construire la KB avec les 7 formules en logique propositionnelle\n2. Verifier que la KB est **inconsistante**\n3. Calculer une mesure d'incoherence (par exemple, le nombre de MUS)\n4. Identifier les sous-ensembles minimaux inconsistants (MUS)\n5. Proposer la reparation minimale (quelles formules retirer pour restaurer la coherence ?)\n\n### Indices\n\n- Utilisez `PlParser` pour parser les formules et `PlBeliefSet` pour la KB\n- `SatReasoner().isConsistent(kb)` pour verifier la consistance\n- Pour les MUS, utilisez `PlMusEnumerator` ou une approche manuelle (retirer une formule a la fois)\n- La KB contient 2 conflits independants : {1,2,3,4} et {1,5,6,3,7} - trouvez les MUS exacts",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "n7jccc36dd",
+   "source": "# --- Exercice : Diagnostic d'incoherence meteo ---\n# Construisez la KB contradictoire et identifiez les MUS.\n\nif jvm_ready:\n    from org.tweetyproject.logics.pl.syntax import PlBeliefSet\n    from org.tweetyproject.logics.pl.parser import PlParser\n    from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n    from org.tweetyproject.logics.pl.reasoner import SatReasoner\n\n    SatSolver.setDefaultSolver(Sat4jSolver())\n    parser = PlParser()\n\n    # 1. Definir les 7 formules\n    formulas_str = [\n        \"soleil => sec\",\n        \"pluie => !sec\",\n        \"soleil\",\n        \"pluie\",\n        \"vent => froid\",\n        \"soleil => !froid\",\n        \"vent\",\n    ]\n\n    # 2. Construire la KB\n    # kb = PlBeliefSet()\n    # for f_str in formulas_str:\n    #     kb.add(parser.parseFormula(f_str))\n    raise NotImplementedError(\"A vous de jouer !\")\n\n    # 3. Verifier l'inconsistance\n    # reasoner = SatReasoner()\n    # print(\"KB consistante ?\", reasoner.isConsistent(kb))\n\n    # 4. Trouver les MUS (approche manuelle)\n    # Pour chaque sous-ensemble de formules, verifier s'il est inconsistant\n    # et s'il est minimal (retirer une formule le rend consistant)\n    # Indice: utilisez itertools.combinations\n\n    # 5. Proposer la reparation minimale\n    # Quelles formules retirer pour restaurer la coherence ?\n    # (Chercher un \"hitting set\" minimal des MUS)\nelse:\n    print(\"JVM non demarree - exercice non disponible.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "67c15393",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
@@ -1396,6 +1396,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bw8w4lkmya6",
+   "source": "## Exercice : Modelisation d'un debat avec un framework bipolaire\n\n### Contexte\n\nModelisez un debat sur le choix d'un langage de programmation pour un projet :\n\n**Arguments :**\n- `a` : \"Python est facile a apprendre\"\n- `b` : \"Python est lent pour le calcul intensif\"\n- `c` : \"NumPy compense la lenteur de Python\" (support de `a`, attaque `b`)\n- `d` : \"Java a un typage statique plus sur\"\n- `e` : \"Le typage statique ralentit le developpement\" (attaque `d`)\n- `f` : \"Les IDE modernes compensent le typage\" (support de `d`, attaque `e`)\n\n**Relations :**\n- Attaques : `b` attaque `a`, `c` attaque `b`, `e` attaque `d`, `f` attaque `e`\n- Supports : `c` supporte `a`, `f` supporte `d`\n\n### Objectifs\n\n1. Construire un `DungTheory` avec les 6 arguments et les attaques\n2. Calculer les extensions grounded et preferred\n3. (Bonus) Si les imports bipolaires fonctionnent, construire un `NecessityArgumentationFramework` ou `EvidentialArgumentationFramework` avec les relations de support\n4. Interpreter les resultats : quel langage \"gagne\" le debat ?\n\n### Indices\n\n- `DungTheory`, `Argument`, `Attack` pour le framework de base\n- `SimpleGroundedReasoner().getModel(theory)` pour l'extension grounded\n- `SimplePreferredReasoner().getModels(theory)` pour les extensions preferred\n- Les supports bipolaires utilisent `Support(source, target)` et `NecessityArgumentationFramework`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "jwmc8oi45a",
+   "source": "# --- Exercice : Debat langage de programmation (Framework bipolaire) ---\n\nif jvm_ready:\n    from org.tweetyproject.arg.dung.syntax import DungTheory, Argument, Attack\n    from org.tweetyproject.arg.dung.reasoner import SimpleGroundedReasoner, SimplePreferredReasoner\n\n    # 1. Creer les arguments\n    # a = Argument(\"a\")  # Python facile\n    # b = Argument(\"b\")  # Python lent\n    # c = Argument(\"c\")  # NumPy compense\n    # d = Argument(\"d\")  # Java typage sur\n    # e = Argument(\"e\")  # Typage ralentit\n    # f = Argument(\"f\")  # IDE compense\n    raise NotImplementedError(\"A vous de jouer !\")\n\n    # 2. Construire le framework\n    # theory = DungTheory()\n    # for arg in [a, b, c, d, e, f]: theory.add(arg)\n    # theory.add(Attack(b, a))  # b attaque a\n    # ...\n\n    # 3. Calculer les extensions\n    # grounded = SimpleGroundedReasoner().getModel(theory)\n    # print(\"Extension grounded:\", grounded)\n    # preferred = SimplePreferredReasoner().getModels(theory)\n    # print(\"Extensions preferred:\", preferred)\n\n    # 4. Interpreter : quels arguments sont acceptes ?\n    # Quel langage \"gagne\" le debat selon chaque semantique ?\n\n    # 5. (Bonus) Ajouter les relations de support avec un framework bipolaire\n    # from org.tweetyproject.arg.bipolar.syntax import ...\nelse:\n    print(\"JVM non demarree - exercice non disponible.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "7f9856bd",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -641,6 +641,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dvkdvqdcyq",
+   "source": "## Exercice : Comparaison de semantiques de classement sur un debat medical\n\n### Contexte\n\nModelisez un debat medical simplifie sur le choix d'un traitement :\n\n**Arguments :**\n- `t1` : \"Le traitement A est efficace\" (non attaque)\n- `t2` : \"Le traitement B est moins cher\"\n- `e1` : \"Des effets secondaires graves sont associes a A\" (attaque `t1`)\n- `e2` : \"Une etude recente contredit les effets secondaires\" (attaque `e1`)\n- `c1` : \"Le cout de B est sous-estime\" (attaque `t2`)\n\n### Objectifs\n\n1. Construire le `DungTheory` avec les 5 arguments et attaques\n2. Appliquer au moins 3 semantiques de classement (Categorizer, Burden-Based, Discussion-Based)\n3. Comparer les classements obtenus : convergent-ils ?\n4. Repondre : quel traitement est le mieux supporte selon chaque semantique ?\n5. (Bonus) Modifier la structure (ajouter un argument `e3` qui attaque `e2`) et observer l'impact sur les classements\n\n### Indices\n\n- Reutilisez le pattern : `CategorizerRankingReasoner().getModel(theory)`\n- `RankingTools.roundRanking(ranking, 3)` pour arrondir les scores\n- Un argument non attaque a un score de 1.0 (Categorizer)\n- Comparez les rangs relatifs, pas les valeurs absolues",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ihnq7d0yl8",
+   "source": "# --- Exercice : Classement d'un debat medical ---\n\nif jvm_ready:\n    from org.tweetyproject.arg.dung.syntax import DungTheory, Argument, Attack\n    from org.tweetyproject.arg.rankings.reasoner import (\n        CategorizerRankingReasoner, BurdenBasedRankingReasoner,\n        DiscussionBasedRankingReasoner\n    )\n    from org.tweetyproject.arg.rankings.util import RankingTools\n\n    # 1. Creer les arguments\n    # t1 = Argument(\"t1\")  # Traitement A efficace\n    # t2 = Argument(\"t2\")  # Traitement B moins cher\n    # e1 = Argument(\"e1\")  # Effets secondaires de A\n    # e2 = Argument(\"e2\")  # Etude contredit e1\n    # c1 = Argument(\"c1\")  # Cout de B sous-estime\n    raise NotImplementedError(\"A vous de jouer !\")\n\n    # 2. Construire le framework\n    # theory = DungTheory()\n    # for arg in [t1, t2, e1, e2, c1]: theory.add(arg)\n    # theory.add(Attack(e1, t1))  # e1 attaque t1\n    # theory.add(Attack(e2, e1))  # e2 attaque e1 (reinstatement)\n    # theory.add(Attack(c1, t2))  # c1 attaque t2\n\n    # 3. Appliquer les semantiques de classement\n    # cat = CategorizerRankingReasoner().getModel(theory)\n    # print(\"Categorizer:\", RankingTools.roundRanking(cat, 3))\n    #\n    # bb = BurdenBasedRankingReasoner().getModel(theory)\n    # print(\"Burden-Based:\", bb)\n    #\n    # db = DiscussionBasedRankingReasoner().getModel(theory)\n    # print(\"Discussion-Based:\", db)\n\n    # 4. Analyser : quel traitement gagne ?\n    # - Si t1 > t2 : traitement A prefere\n    # - Si t2 > t1 : traitement B prefere\n\n    # 5. (Bonus) Ajouter e3 qui attaque e2 et re-calculer\n    # e3 = Argument(\"e3\")  # Nouvelle etude confirme les effets secondaires\n    # theory.add(e3)\n    # theory.add(Attack(e3, e2))\n    # Recalculer et comparer\nelse:\n    print(\"JVM non demarree - exercice non disponible.\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "cef18cf7",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- Add open exercises to 5 Tweety notebooks (Priority 1 from coordinator directive)
- Each exercise includes: context, objectives, skeleton code with `raise NotImplementedError`, hints
- No solution code included - exercises are designed for student self-completion

## Notebooks modified
| Notebook | Exercise Topic |
|----------|---------------|
| Tweety-2-Basic-Logics | Scheduling problem with propositional logic + SAT |
| Tweety-3-Advanced-Logics | University ontology in Description Logic |
| Tweety-4-Belief-Revision | Inconsistency diagnosis with MUS identification |
| Tweety-7a-Extended-Frameworks | Programming debate with bipolar framework |
| Tweety-7b-Ranking-Probabilistic | Medical debate with ranking semantics comparison |

## Context
- EPITA IA Symbolique preparation (issue #55, deadline May 20)
- Coordinator directive: msg-20260316T215933-u4frfm (Priority 1)

## Test plan
- [ ] Verify each notebook opens correctly in Jupyter
- [ ] Verify exercise cells have proper `raise NotImplementedError`
- [ ] Verify hints reference patterns that exist in the notebook
- [ ] Verify no solution code is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)