### PR TITLE
feat(slides-06): Replace copyright SVM + add 5 RLHF slides

### DIFF
--- a/slides/06-apprentissage/slides.marp.md
+++ b/slides/06-apprentissage/slides.marp.md
@@ -1977,6 +1977,89 @@ Le calcul dans l'espace projeté se fait **sans projeter explicitement** (astuce
 
 ---
 
+# RLHF : Aligner les LLMs avec les Préférences Humaines
+
+- **Problème** : les LLMs entraînés sur du texte brut ne suivent pas forcément les instructions ni les valeurs humaines
+- **Comportements problématiques observés** :
+  - Réponses toxiques, biaisées ou dangereuses
+  - Hallucinations présentées avec confiance
+  - Réponses verbeuses mais peu utiles
+- **Solution** : Reinforcement Learning from Human Feedback (RLHF)
+  - Apprendre un **modèle de récompense** à partir des préférences humaines
+  - Optimiser le LLM via RL pour maximiser cette récompense
+
+<!-- RLHF : connexion directe entre RL classique (reward) et alignement des LLMs -->
+
+---
+
+# Pipeline RLHF : 3 Étapes
+
+**Étape 1 — Supervised Fine-Tuning (SFT)**
+- Fine-tuner le LLM pré-entraîné sur des démonstrations d'experts (~10k–100k exemples annotés)
+
+**Étape 2 — Reward Model (RM)**
+- Collecter des comparaisons : pour un prompt, A est préféré à B
+- Entraîner un modèle de récompense : RM(prompt, réponse) → score de qualité
+
+**Étape 3 — PPO Fine-tuning**
+- Optimiser le LLM via PPO pour maximiser RM(prompt, réponse)
+- Contrainte KL pour ne pas trop s'éloigner du modèle SFT
+
+<!-- Pipeline SFT → RM → PPO : fondement d'InstructGPT (2022), ChatGPT, Claude 1 -->
+
+---
+
+# Reward Modeling : Apprendre les Préférences Humaines
+
+**Modèle Bradley-Terry** : P(A ≻ B) = σ(r(A) − r(B))
+
+- Entraîner le RM à prédire quelle réponse les humains préfèrent
+- Données : paires (réponse_A, réponse_B, préférence) pour chaque prompt
+- Architecture : LLM backbone + tête de régression scalaire
+
+| Aspect | Valeur typique |
+|--------|----------------|
+| Données de comparaison | 30k–500k paires |
+| Accord inter-annotateurs | 60–75% |
+| Corrélation RM ↔ humains | ~0.75–0.85 |
+
+<!-- Bradley-Terry : modèle probabiliste de préférence, base de l'InstructGPT reward model -->
+
+---
+
+# PPO et InstructGPT / ChatGPT
+
+**Proximal Policy Optimization (PPO)** pour fine-tuner le LLM :
+
+- **Récompense combinée** : r(x,y) = RM(x,y) − β · KL(π_RL ‖ π_SFT)
+  - RM(x,y) : score du reward model (préférence humaine)
+  - β · KL : pénalité pour rester proche du modèle SFT (β ≈ 0.02–0.5)
+- **InstructGPT** (Ouyang et al., 2022) : première démonstration à grande échelle
+  - GPT-3 fine-tuné par RLHF → suivi d'instructions radicalement amélioré
+  - Base de ChatGPT (déployé Nov. 2022) puis GPT-4
+
+<!-- PPO + KL penalty : équilibre entre optimisation des préférences et préservation des capacités du LLM -->
+
+---
+
+# Constitutional AI : RLAIF sans Labels Humains
+
+**Anthropic Claude** — Constitution de principes plutôt qu'annotateurs massifs :
+
+1. **SFT initial** : fine-tuning sur des réponses bénignes
+2. **AI Feedback (RLAIF)** : un LLM critique génère ses propres préférences selon une **constitution** (principes : utile, inoffensif, honnête)
+3. **RM entraîné sur RLAIF** : scalabilité sans annotateurs humains
+4. **PPO** sur ce reward model constitutionnel
+
+| Méthode | Labels humains | Scalabilité |
+|---------|----------------|-------------|
+| RLHF classique | Requis (coûteux) | Limitée |
+| Constitutional AI (RLAIF) | Minimaux | Haute |
+
+<!-- Constitutional AI (Bai et al., 2022) : alignement scalable, base de Claude 1 et Claude 2 -->
+
+---
+
 <!-- _class: questions -->
 
 # Questions?


### PR DESCRIPTION
## Résumé

Améliorations P1 + P2 du deck `slides/06-apprentissage` pour le CM ECE du 24 mars.

### P1 — Corrections urgentes ✅

**Images/slides copyright SVM remplacées**
- 19 slides `Copyright © 2001, 2003, Andrew W. Moore` → 8 slides originales en français
- Contenu : classificateurs linéaires, marge, marge maximale, vecteurs de support, calcul M=2/‖w‖, optimisation QP, kernel trick, performance empirique

**Titre** : déjà "Intelligence Artificielle -- VI" dans le Marp

**Questions?** : 7 slides vérifiés, présents à la fin de chaque section majeure

### P2 — Expansion RLHF ✅

5 nouveaux slides ajoutés entre "Résumé RL" et "Questions?" :

| Slide | Titre |
|-------|-------|
| 112 | RLHF : Aligner les LLMs avec les Préférences Humaines |
| 113 | Pipeline RLHF : 3 Étapes (SFT → Reward Model → PPO) |
| 114 | Reward Modeling : Bradley-Terry, comparaisons humaines |
| 115 | PPO et InstructGPT / ChatGPT (formule KL penalty) |
| 116 | Constitutional AI : RLAIF sans labels humains (Claude) |

### Statistiques finales
- Avant : 127 slides PPTX (dont 19 copyright), Marp 115 slides
- Après : **120 slides** (copyright supprimés + 5 RLHF ajoutés)

## Test

```bash
npx @marp-team/marp-cli --preview slides/06-apprentissage/slides.marp.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)