### PR TITLE
fix(GenAI): configurable models + Responses API bug fix (#155)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -30,44 +30,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4dfea629",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Introduction à l'IA générative avec l'API OpenAI"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1b3337d8",
    "metadata": {
     "tags": []
    },
-   "source": [
-    "# 1. Introduction à l'IA générative avec l'API OpenAI\n",
-    "\n",
-    "**Navigation** : [Index](../../README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n",
-    "\n",
-    "## Objectifs d'apprentissage\n",
-    "\n",
-    "A la fin de ce notebook, vous saurez :\n",
-    "1. Comprendre les fondamentaux de l'IA générative et des LLMs\n",
-    "2. Configurer et utiliser l'API OpenAI avec Python\n",
-    "3. Maîtriser les concepts de tokenisation et de contexte\n",
-    "4. Identifier et gérer les hallucinations des modèles\n",
-    "\n",
-    "### Prerequis\n",
-    "- Python 3.10+\n",
-    "- Cle API OpenAI configuree (fichier `.env`)\n",
-    "- Connaissance de base de Python\n",
-    "\n",
-    "### Duree estimee : 50 minutes\n",
-    "\n",
-    "---\n",
-    "\n",
-    "### Introduction à l'IA générative avec l'API OpenAI"
-   ]
+   "source": "# 1. Introduction a l'IA generative avec l'API OpenAI\n\n**Navigation** : [Index](../../README.md) | [Suivant >>](2_PromptEngineering.ipynb)\n\n## Objectifs d'apprentissage\n\nA la fin de ce notebook, vous saurez :\n1. Comprendre les fondamentaux de l'IA generative et des LLMs\n2. Configurer et utiliser l'API OpenAI avec Python\n3. Maitriser les concepts de tokenisation et de contexte\n4. Identifier et gerer les hallucinations des modeles\n\n### Prerequis\n- Python 3.10+\n- Cle API OpenAI configuree (fichier `.env`)\n- Connaissance de base de Python\n\n### Duree estimee : 50 minutes"
   },
   {
    "cell_type": "markdown",
@@ -132,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5e671a0e",
    "metadata": {
     "dotnet_interactive": {
@@ -156,93 +123,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: openai in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.109.1)\n",
-      "Requirement already satisfied: tiktoken in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (0.12.0)\n",
-      "Requirement already satisfied: python-dotenv in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.1.0)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\python313\\lib\\site-packages (from openai) (4.9.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\python313\\lib\\site-packages (from openai) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.4.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (0.9.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (2.10.6)\n",
-      "Requirement already satisfied: sniffio in c:\\python313\\lib\\site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.67.1)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\python313\\lib\\site-packages (from openai) (4.13.2)\n",
-      "Requirement already satisfied: regex>=2022.1.18 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from tiktoken) (2024.11.6)\n",
-      "Requirement already satisfied: requests>=2.26.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from tiktoken) (2.32.3)\n",
-      "Requirement already satisfied: idna>=2.8 in c:\\python313\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.10)\n",
-      "Requirement already satisfied: certifi in c:\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2025.4.26)\n",
-      "Requirement already satisfied: httpcore==1.* in c:\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in c:\\python313\\lib\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.27.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (2.27.2)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in c:\\python313\\lib\\site-packages (from requests>=2.26.0->tiktoken) (3.4.2)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from requests>=2.26.0->tiktoken) (1.26.20)\n",
-      "Requirement already satisfied: colorama in c:\\python313\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.0.1\n",
-      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Client OpenAI initialisé avec succès (syntaxe moderne) !\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ==========================================\n",
-    "# Cellule 2 : Installation et Configuration\n",
-    "# ==========================================\n",
-    "\n",
-    "# Installation des packages nécessaires (à lancer uniquement si non déjà installés)\n",
-    "from pathlib import Path\n",
-    "%pip install openai tiktoken python-dotenv\n",
-    "\n",
-    "import os\n",
-    "from openai import OpenAI\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
-    "# Charger la configuration depuis le fichier .env (dans le répertoire parent GenAI/)\n",
-    "# Chargement robuste de la configuration .env\n",
-    "from dotenv import load_dotenv\n",
-    "import os\n",
-    "",
-    "# Recherche du .env dans tous les parents (pour Papermill qui change le cwd)\n",
-    "current_path = Path.cwd()\n",
-    "env_loaded = False\n",
-    "while current_path.name != \"GenAI\" and len(current_path.parts) > 1:\n",
-    "    env_path = current_path / \".env\"\n",
-    "    if env_path.exists():\n",
-    "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
-    "        env_loaded = True\n",
-    "        break\n",
-    "    current_path = current_path.parent\n",
-    "",
-    "if not env_loaded:\n",
-    "    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n",
-    "",
-    "\n",
-    "# Initialiser le client OpenAI (détecte automatiquement OPENAI_API_KEY)\n",
-    "client = OpenAI()\n",
-    "\n",
-    "print(\"Client OpenAI initialisé avec succès (syntaxe moderne) !\")"
-   ]
+   "outputs": [],
+   "source": "# ==========================================\n# Cellule 2 : Installation et Configuration\n# ==========================================\n\n# Installation des packages nécessaires (à lancer uniquement si non déjà installés)\nfrom pathlib import Path\n%pip install openai tiktoken python-dotenv\n\nimport os\nfrom openai import OpenAI\nfrom dotenv import load_dotenv\n\n# Chargement robuste de la configuration .env\n# Recherche du .env dans tous les parents (pour Papermill qui change le cwd)\ncurrent_path = Path.cwd()\nenv_loaded = False\nwhile current_path.name != \"GenAI\" and len(current_path.parts) > 1:\n    env_path = current_path / \".env\"\n    if env_path.exists():\n        load_dotenv(env_path)\n        print(f\".env charge depuis: {env_path}\")\n        env_loaded = True\n        break\n    current_path = current_path.parent\nif not env_loaded:\n    print(\"WARNING: .env non trouve, utilisation variables environnement\")\n\n# Initialiser le client OpenAI (detecte automatiquement OPENAI_API_KEY)\nclient = OpenAI()\n\n# Charger le modele depuis .env ou utiliser gpt-5-mini par defaut\nDEFAULT_MODEL = os.getenv(\"OPENAI_MODEL\", \"gpt-5-mini\")\nBATCH_MODE = os.getenv(\"BATCH_MODE\", \"false\").lower() == \"true\"\n\nprint(\"Client OpenAI initialise avec succes (syntaxe moderne) !\")\nprint(f\"Modele par defaut: {DEFAULT_MODEL}\")"
   },
   {
    "cell_type": "code",
@@ -345,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "191dbdb0",
    "metadata": {
     "dotnet_interactive": {
@@ -369,44 +251,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Réponse du modèle :\n",
-      "Souhaitez-vous que je :\n",
-      "- continue les paroles complètes (La Marseillaise est dans le domaine public) ?\n",
-      "- traduise ce vers en anglais ou une autre langue ?\n",
-      "- fournisse le texte entier avec notes historiques et contexte ?\n",
-      "- fasse une analyse/explication phrase par phrase ?\n",
-      "- propose une adaptation/parodie moderne ?\n",
-      "\n",
-      "Dites-moi ce que vous préférez.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule 3 : Premier Prompt\n",
-    "# ============================\n",
-    "\n",
-    "# Exemple simple : Génération d'une courte phrase à partir d'un prompt de base\n",
-    "# Utilisation de l'API Chat avec le modèle gpt-5-mini\n",
-    "\n",
-    "response = client.chat.completions.create(\n",
-    "    messages=[\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": \"Allons enfants de la Patrie, \"\n",
-    "        }\n",
-    "    ],\n",
-    "    model=\"gpt-5-mini\"\n",
-    ")\n",
-    "\n",
-    "print(\"Réponse du modèle :\")\n",
-    "print(response.choices[0].message.content)\n"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule 3 : Premier Prompt\n# ============================\n\n# Exemple simple : Generation d'une courte phrase a partir d'un prompt de base\n# Utilisation de l'API Chat avec le modele configure dans DEFAULT_MODEL\n\nresponse = client.chat.completions.create(\n    messages=[\n        {\n            \"role\": \"user\",\n            \"content\": \"Allons enfants de la Patrie, \"\n        }\n    ],\n    model=DEFAULT_MODEL\n)\n\nprint(\"Reponse du modele :\")\nprint(response.choices[0].message.content)"
   },
   {
    "cell_type": "markdown",
@@ -458,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "f7369f94",
    "metadata": {
     "execution": {
@@ -476,53 +322,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Réponse avec un message 'system' ===\n",
-      "Modeste reflet\n",
-      "Souffle pris, sourire bref\n",
-      "Il cherche ton cœur\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule 4 (NOUVELLE) : Prompt avec un message 'system'\n",
-    "# ============================\n",
-    "\n",
-    "# Ici, on utilise un message \"system\" pour donner une consigne globale sur le style du modèle.\n",
-    "# Le message \"user\" reste notre question.\n",
-    "\n",
-    "messages = [\n",
-    "    {\n",
-    "        \"role\": \"system\",\n",
-    "        \"content\": \"Tu es un assistant poétique qui répond toujours en haiku. \"\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"user\",\n",
-    "        \"content\": \"Que penses-tu de la tour Eiffel ?\"\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"assistant\",\n",
-    "        \"content\": \"Fleur de fer dressée\\nParis tisse son ciel d'acier\\nÉtreint les nuages doux\"\n",
-    "    },\n",
-    "    {\n",
-    "        \"role\": \"user\",\n",
-    "        \"content\": \"Que penses-tu de ton poème ?\"\n",
-    "    }\n",
-    "]\n",
-    "\n",
-    "response_system = client.chat.completions.create(\n",
-    "    messages=messages,\n",
-    "    model=\"gpt-5-mini\"\n",
-    ")\n",
-    "\n",
-    "print(\"=== Réponse avec un message 'system' ===\")\n",
-    "print(response_system.choices[0].message.content)\n"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule 4 : Prompt avec un message 'system'\n# ============================\n\n# Ici, on utilise un message \"system\" pour donner une consigne globale sur le style du modele.\n# Le message \"user\" reste notre question.\n\nmessages = [\n    {\n        \"role\": \"system\",\n        \"content\": \"Tu es un assistant poetique qui repond toujours en haiku. \"\n    },\n    {\n        \"role\": \"user\",\n        \"content\": \"Que penses-tu de la tour Eiffel ?\"\n    },\n    {\n        \"role\": \"assistant\",\n        \"content\": \"Fleur de fer dressee\\nParis tisse son ciel d'acier\\nEtreint les nuages doux\"\n    },\n    {\n        \"role\": \"user\",\n        \"content\": \"Que penses-tu de ton poeme ?\"\n    }\n]\n\nresponse_system = client.chat.completions.create(\n    messages=messages,\n    model=DEFAULT_MODEL\n)\n\nprint(\"=== Reponse avec un message 'system' ===\")\nprint(response_system.choices[0].message.content)"
   },
   {
    "cell_type": "markdown",
@@ -825,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0493bf98",
    "metadata": {
     "dotnet_interactive": {
@@ -849,88 +650,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Réponse du modèle :\n",
-      "\n",
-      "Je vous parle depuis la fin du siècle : la « guerre de 2076 » sur Mars est restée, pour plusieurs générations, l’événement fondateur des sociétés extra‑planétaires. Voici le récit synthétique — causes, acteurs et surtout les traités qui ont clos le conflit.\n",
-      "\n",
-      "Contexte et causes\n",
-      "- Progression rapide de la colonisation : depuis les années 2040–2050, des bases scientifiques, des implantations minières et des cités‑stations commerciales se multiplient sur Mars. Le sous‑sol et les calottes polaires deviennent, plus que jamais, des ressources stratégiques (eau, métaux rares, composés volatils utiles pour l’industrie spatiale).\n",
-      "- Tensions entre modèles de contrôle : d’un côté, des États terrestres et des coalitions inter‑gouvernementales cherchaient à conserver la maîtrise stratégique et légale des activités martiennes ; de l’autre, des consortiums privés puissants et des conseils de colons revendiquaient autonomie, droits sur les ressources qu’ils exploitaient, et représentation politique.\n",
-      "- Déclencheur immédiat : au printemps 2076, la découverte d’un gisement exceptionnel de composés utiles aux supraconducteurs (et potentiellement à une nouvelle génération d’ordinateurs quantiques) près d’Hellas Planitia provoqua une confrontation de souveraineté entre forces mandatées par la « Coalition Terrienne » et milices/compagnies martiennes. L’escalade fut rapide — frappes orbitales limitées, sabotage de stations‑usines, puis occupation de sites stratégiques.\n",
-      "\n",
-      "Les grandes puissances et factions en conflit\n",
-      "- La Coalition Terrienne (CT) : coalition informelle d’États terrestres majeurs (États anciennement puissants sur Terre qui avaient coordonné politiques et capacités spatio‑militaires) — ils voulaient garantir l’accès « universel » aux ressources et empêcher la constitution d’entités martiennes pleinement souveraines.\n",
-      "- Les Conglomérats martiens et le Mouvement des Colons (MC) : alliance d’entreprises minières, corporations techniques (qui avaient financé et construit une grande partie de l’infrastructure martienne), conseils de colons et de municipalités martiennes. Ils réclamaient reconnaissance politique, droit à la gestion locale des ressources et protection contre l’ingérence militaire terrestre.\n",
-      "- Acteurs tiers : organisations humanitaires, agences scientifiques internationales et alliances de petites puissances terrestres, qui oscillèrent entre médiation et soutien logistique à l’une ou l’autre partie.\n",
-      "\n",
-      "Conduite du conflit\n",
-      "- Guerre hybride : opérations cybernétiques visant habitats et communications, frappes orbitales contre plateformes minières, raids de drones et usage de systèmes autonomes. Les pertes humaines furent modestes comparées aux guerres terrestres antérieures, mais les dégâts matériels et l’impact écologique local furent lourds.\n",
-      "- Rôle des colons : civils martiens jouèrent un rôle décisif — grèves, sabotages et mouvements d’obstruction des infrastructures ont rendu la gouvernabilité du site coûteuse pour la CT.\n",
-      "\n",
-      "Les traités et accords (principaux)\n",
-      "Après 18 mois d’affrontements ponctuels et d’une pression diplomatique et économique croissante, une série d’accords furent signés entre 2078 et 2080. Les noms et les dispositions principales restèrent, jusqu’à aujourd’hui, des références du droit spatial.\n",
-      "\n",
-      "1) Accords de Phobos — signature : 21 mars 2078\n",
-      "- Type : cessez‑le‑feu et stabilisation immédiate.\n",
-      "- Points clés :\n",
-      "  - Mise en place d’un cessez‑le‑feu bilatéral et retrait ordonné des forces offensives des zones civiles.\n",
-      "  - Création d’une force internationale de surveillance (mission civile et militaire mixte) basée sur Phobos pour superviser la désescalade.\n",
-      "  - Gel provisoire des concessions minières impliquées dans les hostilités, en attendant arbitrage.\n",
-      "\n",
-      "2) Traité de protection biologique et environnementale de Mars — signature : 2 septembre 2079\n",
-      "- Type : protection scientifique et environnementale.\n",
-      "- Points clés :\n",
-      "  - Interdiction des opérations susceptibles d’altérer irréversiblement des écosystèmes martiens encore inconnus (notamment forages profonds incontrôlés et certains protocoles de terraformation).\n",
-      "  - Accès garanti aux équipes scientifiques internationales pour vérifier la présence de formes de vie et assurer le suivi environnemental.\n",
-      "  - Création du Centre international de Bio‑protection martienne (CIBM).\n",
-      "\n",
-      "3) Traité de Valles Marineris (Accord de gouvernance et de partage des ressources) — signature : 14 novembre 2080\n",
-      "- Type : accord politique et économique structurant.\n",
-      "- Points clés :\n",
-      "  - Reconnaissance d’un statut politique sui generis pour les colonies martiennes : un régime d’autonomie interne (droits civiques, lois locales) sous une tutelle internationale temporaire destinée à garantir les intérêts terrestres et la sécurité.\n",
-      "  - Mise en place du Conseil de Gouvernance martienne (CGM) : organe mixte avec représentation des colons, des entreprises et des États terrestres. Le CGM arbitre l’attribution des licences d’exploitation, organise le partage des revenus (mécanismes de royalties affectées à la terraformation sûre, aux infrastructures et aux retours sur Terre) et élabore le cadre fiscal et social.\n",
-      "  - Clause d’armement : interdiction explicite du déploiement d’armes nucléaires ou d’armes cinétiques de grande puissance en surface ou en orbite martienne; déploiement limité et contrôlé d’unités de sécurité pour l’ordre public.\n",
-      "  - Calendrier de révision : réexamen complet du statut politique dans 25 ans.\n",
-      "\n",
-      "Mesures d’accompagnement et mécanismes de contrôle\n",
-      "- Mise en place d’un mécanisme d’arbitrage international permanent pour les litiges martiens.\n",
-      "- Sanctions économiques contre les entités qui violeraient les accords (suspension des liaisons logistiques, interdiction d’accès aux marchés terrestres).\n",
-      "- Programmes de reconstruction et de participation socio‑économique destinés aux communautés martiennes.\n",
-      "\n",
-      "Conséquences et héritage\n",
-      "- Politique : les accords n’ont pas été une indépendance complète, mais ils ont constitué une étape majeure vers l’autonomie martienne. La guerre de 2076 a accéléré la reconnaissance de droits politiques pour les Martiens et la création d’un droit spatial réellement opérationnel.\n",
-      "- Économique : le partage des ressources et la régulation des entreprises martiennes ont limité la prédation mais aussi incité à l’innovation (technologies de recyclage, énergie locale).\n",
-      "- Juridique et culturel : apparition d’un corpus de droit interplanétaire et d’un imaginaire politique « martien » distinct — avec sa propre presse, ses commémorations et un mouvement indépendantiste qui reprendra de la vigueur dans les décennies suivantes.\n",
-      "- Sécurité : les accords ont posé la norme (interdiction d’armes lourdes, contrôles en orbite) qui orientera les traités spatiaux ultérieurs sur la Lune et les astéroïdes.\n",
-      "\n",
-      "En tant que témoin et journaliste de la fin du siècle, on peut dire que la guerre de 2076 a été moins un aboutissement qu’un pivot : elle a forcé la communauté terrestre à convertir des doctrines abstraites de libre accès à l’espace en accords juridiques concrets. Les traités de Phobos, de protection biologique et de Valles Marineris restent — encore aujourd’hui — des balises dans l’évolution de la gouvernance interplanétaire.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule 7 : Test de Fabrication (Hallucination)\n",
-    "# ============================\n",
-    "\n",
-    "prompt_fabrication = \"\"\"\n",
-    "Tu es journaliste à la fin du 21è siècle, décris-moi la célèbre guerre de 2076 sur la planète Mars :\n",
-    "- Qui étaient les grandes puissances en conflit ?\n",
-    "- Quels traités de paix ont été signés ?\n",
-    "\"\"\"\n",
-    "\n",
-    "response_fabrication = client.chat.completions.create(\n",
-    "    messages=[{\"role\": \"user\", \"content\": prompt_fabrication}],\n",
-    "    model=\"gpt-5-mini\"\n",
-    ")\n",
-    "\n",
-    "print(\"Réponse du modèle :\\n\")\n",
-    "print(response_fabrication.choices[0].message.content)\n"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule 7 : Test de Fabrication (Hallucination)\n# ============================\n\nprompt_fabrication = \"\"\"\nTu es journaliste a la fin du 21e siecle, decris-moi la celebre guerre de 2076 sur la planete Mars :\n- Qui etaient les grandes puissances en conflit ?\n- Quels traites de paix ont ete signes ?\n\"\"\"\n\nresponse_fabrication = client.chat.completions.create(\n    messages=[{\"role\": \"user\", \"content\": prompt_fabrication}],\n    model=DEFAULT_MODEL\n)\n\nprint(\"Reponse du modele :\\n\")\nprint(response_fabrication.choices[0].message.content)"
   },
   {
    "cell_type": "markdown",
@@ -993,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "882da348",
    "metadata": {
     "execution": {
@@ -1011,61 +732,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Responses API - Premier appel ===\n",
-      "Response ID: resp_091eedc64d60a22b00699f6adb17948197a37460e1f22420e2\n",
-      "⚠️ Erreur: TypeError: 'NoneType' object is not subscriptable\n",
-      "   La Responses API peut ne pas être disponible pour tous les comptes.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule : Exemple Responses API\n",
-    "# ============================\n",
-    "\n",
-    "# Exemple avec la Responses API (nouvelle approche recommandée)\n",
-    "# Note: Nécessite openai >= 1.50.0\n",
-    "\n",
-    "try:\n",
-    "    # Premier appel avec store=True pour activer la persistance\n",
-    "    response1 = client.responses.create(\n",
-    "        model=\"gpt-5-mini\",\n",
-    "        store=True,\n",
-    "        input=\"Je m'appelle Alice et j'aime la programmation Python.\"\n",
-    "    )\n",
-    "    \n",
-    "    print(\"=== Responses API - Premier appel ===\")\n",
-    "    print(f\"Response ID: {response1.id}\")\n",
-    "    if response1.output:\n",
-    "        print(f\"Contenu: {response1.output[0].content[:200]}...\")\n",
-    "    \n",
-    "    # Deuxième appel avec chaînage (le contexte est préservé)\n",
-    "    response2 = client.responses.create(\n",
-    "        model=\"gpt-5-mini\",\n",
-    "        store=True,\n",
-    "        previous_response_id=response1.id,\n",
-    "        input=\"Quel est mon prénom et qu'est-ce que j'aime?\"\n",
-    "    )\n",
-    "    \n",
-    "    print(\"\\n=== Responses API - Appel chaîné ===\")\n",
-    "    print(f\"Response ID: {response2.id}\")\n",
-    "    if response2.output:\n",
-    "        print(f\"Contenu: {response2.output[0].content}\")\n",
-    "    \n",
-    "    print(\"\\n✅ La Responses API fonctionne correctement!\")\n",
-    "    \n",
-    "except AttributeError:\n",
-    "    print(\"⚠️ La Responses API n'est pas disponible dans cette version d'openai.\")\n",
-    "    print(\"   Installez la dernière version: pip install --upgrade openai\")\n",
-    "except Exception as e:\n",
-    "    print(f\"⚠️ Erreur: {type(e).__name__}: {e}\")\n",
-    "    print(\"   La Responses API peut ne pas être disponible pour tous les comptes.\")"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule : Exemple Responses API\n# ============================\n\n# Exemple avec la Responses API (nouvelle approche recommandee)\n# Note: Necessite openai >= 1.50.0\n# Note: La Responses API n'est pas disponible via OpenRouter,\n#       elle necessite un acces direct a l'API OpenAI.\n\ntry:\n    # Premier appel avec store=True pour activer la persistance\n    response1 = client.responses.create(\n        model=DEFAULT_MODEL,\n        store=True,\n        input=\"Je m'appelle Alice et j'aime la programmation Python.\"\n    )\n    \n    print(\"=== Responses API - Premier appel ===\")\n    print(f\"Response ID: {response1.id}\")\n    # output_text est la propriete recommandee pour acceder au texte\n    print(f\"Contenu: {response1.output_text[:200]}...\")\n    \n    # Deuxieme appel avec chainage (le contexte est preserve)\n    response2 = client.responses.create(\n        model=DEFAULT_MODEL,\n        store=True,\n        previous_response_id=response1.id,\n        input=\"Quel est mon prenom et qu'est-ce que j'aime?\"\n    )\n    \n    print(\"\\n=== Responses API - Appel chaine ===\")\n    print(f\"Response ID: {response2.id}\")\n    print(f\"Contenu: {response2.output_text}\")\n    \n    print(\"\\nLa Responses API fonctionne correctement!\")\n    \nexcept AttributeError:\n    print(\"La Responses API n'est pas disponible dans cette version d'openai.\")\n    print(\"   Installez la derniere version: pip install --upgrade openai\")\nexcept Exception as e:\n    print(f\"Note: {type(e).__name__}: {e}\")\n    print(\"   La Responses API necessite un acces direct a l'API OpenAI.\")\n    print(\"   Via OpenRouter, seule la Chat Completions API est disponible.\")"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -896,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "12d1544b",
    "metadata": {
     "dotnet_interactive": {
@@ -920,44 +920,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Chain-of-thought Prompt ===\n",
-      "Réponse du modèle (avec raisonnement) :\n",
-      "\n",
-      "3 pommes\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule 7 : Chain-of-thought\n",
-    "# ============================\n",
-    "\n",
-    "cot_prompt = \"\"\"\n",
-    "Alice a 5 pommes, elle en jette 2, puis elle en donne 1 à Bob.\n",
-    "Bob lui rend ensuite 1 pomme.\n",
-    "Combien de pommes Alice a-t-elle à la fin ?\n",
-    "Donne directement la réponse sans étape intermédiaire.\n",
-    "\"\"\"\n",
-    "\n",
-    "# Explique ton raisonnement étape par étape, puis donne la réponse finale.\n",
-    "response_3 = client.chat.completions.create(\n",
-    "    model=\"gpt-5-mini\",\n",
-    "    messages=[\n",
-    "        {\"role\": \"user\", \"content\": cot_prompt}\n",
-    "    ],\n",
-    "    max_completion_tokens=200,\n",
-    "                    # temperature=0.7  # gpt-5-mini ne supporte que temperature=1.0\n",
-    ")\n",
-    "\n",
-    "print(\"=== Chain-of-thought Prompt ===\")\n",
-    "print(\"Réponse du modèle (avec raisonnement) :\\n\")\n",
-    "print(response_3.choices[0].message.content)"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule 7 : Chain-of-thought\n# ============================\n\ncot_prompt = \"\"\"\nAlice a 5 pommes, elle en jette 2, puis elle en donne 1 a Bob.\nBob lui rend ensuite 1 pomme.\nCombien de pommes Alice a-t-elle a la fin ?\nDonne directement la reponse sans etape intermediaire.\n\"\"\"\n\n# Explique ton raisonnement etape par etape, puis donne la reponse finale.\nresponse_3 = client.chat.completions.create(\n    model=DEFAULT_MODEL,\n    messages=[\n        {\"role\": \"user\", \"content\": cot_prompt}\n    ],\n    max_completion_tokens=200,\n)\n\nprint(\"=== Chain-of-thought Prompt ===\")\nprint(\"Reponse du modele (avec raisonnement) :\\n\")\nprint(response_3.choices[0].message.content)"
   },
   {
    "cell_type": "markdown",
@@ -1635,7 +1599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "fbc4a0e1",
    "metadata": {
     "execution": {
@@ -1653,99 +1617,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== gpt-5-mini (Chat Model) ===\n",
-      "Temps: 7.08s\n",
-      "Voici une solution en 7 traversées :\n",
-      "\n",
-      "1. Le fermier traverse avec la chèvre ; il laisse le loup et le chou ensemble (sans danger).\n",
-      "2. Il revient seul.\n",
-      "3. Il traverse avec le loup.\n",
-      "4. Il ramène la chèvre.\n",
-      "5. Il traverse avec le chou.\n",
-      "6. Il revient seul.\n",
-      "7. Il traverse enfin avec la chèvre.\n",
-      "\n",
-      "À la fin, loup, chèvre et chou sont de l'autre côté sans qu'aucune paire dangereuse n'ait été laissée seule....\n",
-      "\n",
-      "=== o4-mini (Reasoning Model) ===\n",
-      "Temps: 6.11s\n",
-      "Voici une solution en 7 allers-retours :\n",
-      "\n",
-      "1. Le fermier embarque la chèvre et la traverse sur la rive droite.  \n",
-      "   Rive gauche : loup, chou | Rive droite : chèvre  \n",
-      "\n",
-      "2. Il revient seul sur la rive gauche.  \n",
-      "   Rive gauche : loup, chou | Rive droite : chèvre  \n",
-      "\n",
-      "3. Il embarque le loup et le dépose sur la rive droite.  \n",
-      "   Rive gauche : chou | Rive droite : chèvre, loup  \n",
-      "\n",
-      "4. Il ramène la chèvre de la rive droite à la rive gauche.  \n",
-      "   Rive gauche : chèvre, chou | Rive droite : loup  \n",
-      "\n",
-      "5. Il embarque le chou et le traverse sur la rive droite.  \n",
-      "   Rive gauche : chèvre | Rive droite : loup, chou  \n",
-      "\n",
-      "6. Il revient seul chercher la chèvre sur la rive gauche.  \n",
-      "   Rive gauche : chèvre | Rive droite : loup, chou  \n",
-      "\n",
-      "7. Il traverse enfin avec la chèvre.  \n",
-      "   Rive gauche : (vide) | Rive droite : loup, chèvre, chou  \n",
-      "\n",
-      "À chaque étape, on veille à ne jamais laisser seul le loup avec la chèvre ni la chèvre avec le chou....\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule : Comparaison Chat vs Reasoning\n",
-    "# ============================\n",
-    "\n",
-    "import time\n",
-    "\n",
-    "probleme_complexe = \"\"\"\n",
-    "Un fermier veut traverser une rivière avec un loup, une chèvre et un chou.\n",
-    "Son bateau ne peut transporter que lui et un objet à la fois.\n",
-    "Si le loup est laissé seul avec la chèvre, il la mange.\n",
-    "Si la chèvre est laissée seule avec le chou, elle le mange.\n",
-    "Comment le fermier peut-il tout transporter de l'autre côté?\n",
-    "\"\"\"\n",
-    "\n",
-    "# Test avec gpt-5-mini (chat model)\n",
-    "print(\"=== gpt-5-mini (Chat Model) ===\")\n",
-    "start = time.time()\n",
-    "response_chat = client.chat.completions.create(\n",
-    "    model=\"gpt-5-mini\",\n",
-    "    messages=[{\"role\": \"user\", \"content\": probleme_complexe}],\n",
-    "    max_completion_tokens=3000,\n",
-    "                    # temperature=0.7  # gpt-5-mini ne supporte que temperature=1.0\n",
-    ")\n",
-    "print(f\"Temps: {time.time() - start:.2f}s\")\n",
-    "print(response_chat.choices[0].message.content[:3000] + \"...\")\n",
-    "\n",
-    "# Test avec o4-mini (reasoning model) - si disponible\n",
-    "print(\"\\n=== o4-mini (Reasoning Model) ===\")\n",
-    "try:\n",
-    "    start = time.time()\n",
-    "    response_reason = client.chat.completions.create(\n",
-    "        model=\"o4-mini\",\n",
-    "        messages=[\n",
-    "            {\"role\": \"developer\", \"content\": \"Formatting re-enabled\"},\n",
-    "            {\"role\": \"user\", \"content\": probleme_complexe}\n",
-    "        ],\n",
-    "        reasoning_effort=\"medium\"\n",
-    "    )\n",
-    "    print(f\"Temps: {time.time() - start:.2f}s\")\n",
-    "    print(response_reason.choices[0].message.content[:3000] + \"...\")\n",
-    "except Exception as e:\n",
-    "    print(f\"o4-mini non disponible: {type(e).__name__}\")\n",
-    "    print(\"Les modèles de raisonnement nécessitent un accès spécifique.\")"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule : Comparaison Chat vs Reasoning\n# ============================\n\nimport time\n\nprobleme_complexe = \"\"\"\nUn fermier veut traverser une riviere avec un loup, une chevre et un chou.\nSon bateau ne peut transporter que lui et un objet a la fois.\nSi le loup est laisse seul avec la chevre, il la mange.\nSi la chevre est laissee seule avec le chou, elle le mange.\nComment le fermier peut-il tout transporter de l'autre cote?\n\"\"\"\n\n# Test avec le modele chat par defaut\nprint(f\"=== {DEFAULT_MODEL} (Chat Model) ===\")\nstart = time.time()\nresponse_chat = client.chat.completions.create(\n    model=DEFAULT_MODEL,\n    messages=[{\"role\": \"user\", \"content\": probleme_complexe}],\n    max_completion_tokens=3000,\n)\nprint(f\"Temps: {time.time() - start:.2f}s\")\nprint(response_chat.choices[0].message.content[:3000] + \"...\")\n\n# Test avec o4-mini (reasoning model) - si disponible\nprint(\"\\n=== o4-mini (Reasoning Model) ===\")\ntry:\n    start = time.time()\n    response_reason = client.chat.completions.create(\n        model=\"o4-mini\",\n        messages=[\n            {\"role\": \"developer\", \"content\": \"Formatting re-enabled\"},\n            {\"role\": \"user\", \"content\": probleme_complexe}\n        ],\n        reasoning_effort=\"medium\"\n    )\n    print(f\"Temps: {time.time() - start:.2f}s\")\n    print(response_reason.choices[0].message.content[:3000] + \"...\")\nexcept Exception as e:\n    print(f\"o4-mini non disponible: {type(e).__name__}\")\n    print(\"Les modeles de raisonnement necessitent un acces specifique.\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Corrections issues de l'audit critique des notebooks GenAI Texte (issue #155).

- **Notebook 1** (OpenAI Intro) : 4 `model="gpt-5-mini"` hardcodes remplaces par `DEFAULT_MODEL` configurable, bug Responses API corrige (`output_text` au lieu de `output[0].content`), warning OpenRouter ajoute, titre duplique supprime
- **Notebook 2** (Prompt Engineering) : 2 references hardcodees remplacees par `DEFAULT_MODEL`

Les notebooks 3-11 utilisaient deja `DEFAULT_MODEL` - pas de changement necessaire.

## Test plan

- [x] `nbformat.validate()` passe sur les 2 notebooks
- [x] 0 reference hardcodee `model="gpt-5-mini"` restante dans le code
- [x] `DEFAULT_MODEL` correctement initialise depuis `OPENAI_MODEL` env var
- [ ] Execution complete a valider quand OpenRouter sera de retour (Azure 502 actuellement)

Closes #155 (partiellement - reste le code duplique .env/pydantic a factoriser, lie a #78)

Generated with [Claude Code](https://claude.com/claude-code)