### PR TITLE
fix(GenAI): tiktoken fallback for unknown models (#155)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -412,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "8c2dd909",
    "metadata": {
     "dotnet_interactive": {
@@ -436,88 +436,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Liste des tokens pour text-davinci-003 (indexes) :\n",
-      " [5812, 910, 460, 345, 766]\n",
-      "\n",
-      "Décodage token par token (text-davinci-003) :\n",
-      "Token 0: 'Oh'\n",
-      "Token 1: ' say'\n",
-      "Token 2: ' can'\n",
-      "Token 3: ' you'\n",
-      "Token 4: ' see'\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Liste des tokens pour gpt-5-mini (indexes) :\n",
-      " [18009, 2891, 665, 481, 1921]\n",
-      "\n",
-      "Décodage token par token (gpt-5-mini) :\n",
-      "Token 0: 'Oh'\n",
-      "Token 1: ' say'\n",
-      "Token 2: ' can'\n",
-      "Token 3: ' you'\n",
-      "Token 4: ' see'\n",
-      "\n",
-      "Liste des tokens pour gpt-5 (indexes) :\n",
-      " [18009, 2891, 665, 481, 1921]\n",
-      "\n",
-      "Décodage token par token (gpt-5) :\n",
-      "Token 0: 'Oh'\n",
-      "Token 1: ' say'\n",
-      "Token 2: ' can'\n",
-      "Token 3: ' you'\n",
-      "Token 4: ' see'\n"
-     ]
-    }
-   ],
-   "source": [
-    "# ============================\n",
-    "# Cellule 5 : Analyse de la Tokenisation\n",
-    "# ============================\n",
-    "\n",
-    "import tiktoken\n",
-    "\n",
-    "# --- Partie 1 : Utilisation de l'encodeur pour \"text-davinci-003\" ---\n",
-    "encoder_td = tiktoken.encoding_for_model(\"text-davinci-003\")\n",
-    "texte = \"Oh say can you see\"\n",
-    "tokens_td = encoder_td.encode(texte)\n",
-    "print(\"Liste des tokens pour text-davinci-003 (indexes) :\\n\", tokens_td)\n",
-    "\n",
-    "# Décodage token par token\n",
-    "decoded_td = [encoder_td.decode([t]) for t in tokens_td]\n",
-    "print(\"\\nDécodage token par token (text-davinci-003) :\")\n",
-    "for i, token in enumerate(decoded_td):\n",
-    "    print(f\"Token {i}: '{token}'\")\n",
-    "\n",
-    "# --- Partie 2 : Utilisation de l'encodeur pour \"gpt-5-mini\" (ou gpt-5-mini) ---\n",
-    "encoder_gpt4 = tiktoken.encoding_for_model(\"gpt-5-mini\")\n",
-    "tokens_gpt4 = encoder_gpt4.encode(texte)\n",
-    "print(\"\\nListe des tokens pour gpt-5-mini (indexes) :\\n\", tokens_gpt4)\n",
-    "\n",
-    "decoded_gpt4 = [encoder_gpt4.decode([t]) for t in tokens_gpt4]\n",
-    "print(\"\\nDécodage token par token (gpt-5-mini) :\")\n",
-    "for i, token in enumerate(decoded_gpt4):\n",
-    "    print(f\"Token {i}: '{token}'\")\n",
-    "    \n",
-    "# --- Partie 3 : Utilisation de l'encodeur pour \"gpt-5\" (ou gpt-5-mini) ---\n",
-    "encoder_gpt5 = tiktoken.encoding_for_model(\"gpt-5-mini\")\n",
-    "tokens_gpt5 = encoder_gpt5.encode(texte)\n",
-    "print(\"\\nListe des tokens pour gpt-5 (indexes) :\\n\", tokens_gpt5)\n",
-    "\n",
-    "decoded_gpt5 = [encoder_gpt5.decode([t]) for t in tokens_gpt5]\n",
-    "print(\"\\nDécodage token par token (gpt-5) :\")\n",
-    "for i, token in enumerate(decoded_gpt5):\n",
-    "    print(f\"Token {i}: '{token}'\")\n"
-   ]
+   "outputs": [],
+   "source": "# ============================\n# Cellule 5 : Analyse de la Tokenisation\n# ============================\n\nimport tiktoken\n\ndef get_encoder(model_name):\n    \"\"\"Obtenir l'encodeur tiktoken pour un modele, avec fallback.\"\"\"\n    try:\n        return tiktoken.encoding_for_model(model_name)\n    except KeyError:\n        # Fallback pour les modeles recents non encore dans tiktoken\n        print(f\"Note: tiktoken ne connait pas '{model_name}', utilisation de o200k_base\")\n        return tiktoken.get_encoding(\"o200k_base\")\n\ntexte = \"Oh say can you see\"\n\n# --- Partie 1 : Utilisation de l'encodeur pour \"text-davinci-003\" ---\nencoder_td = get_encoder(\"text-davinci-003\")\ntokens_td = encoder_td.encode(texte)\nprint(\"Liste des tokens pour text-davinci-003 (indexes) :\\n\", tokens_td)\n\ndecoded_td = [encoder_td.decode([t]) for t in tokens_td]\nprint(\"\\nDecodage token par token (text-davinci-003) :\")\nfor i, token in enumerate(decoded_td):\n    print(f\"Token {i}: '{token}'\")\n\n# --- Partie 2 : Utilisation de l'encodeur pour le modele par defaut ---\nencoder_default = get_encoder(DEFAULT_MODEL)\ntokens_default = encoder_default.encode(texte)\nprint(f\"\\nListe des tokens pour {DEFAULT_MODEL} (indexes) :\\n\", tokens_default)\n\ndecoded_default = [encoder_default.decode([t]) for t in tokens_default]\nprint(f\"\\nDecodage token par token ({DEFAULT_MODEL}) :\")\nfor i, token in enumerate(decoded_default):\n    print(f\"Token {i}: '{token}'\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

`tiktoken.encoding_for_model("gpt-5-mini")` crash sur tiktoken 0.9.0. Ajout d'un helper `get_encoder()` avec fallback sur `o200k_base`.

Simplifie aussi la cellule tokenisation (2 sections au lieu de 3).

## Verification

Notebook 1 execute 26/26 cellules via Papermill avec gpt-4.1-mini + cle OpenAI directe.

Generated with [Claude Code](https://claude.com/claude-code)