### PR TITLE
fix(Sudoku): resolve CS0104 Task ambiguity (#157)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -135,29 +135,10 @@
   },
   {
    "cell_type": "code",
-   "source": [
-    "// Imports Choco via IKVM (espaces de noms Java mappés vers .NET)\n",
-    "// NOTE: Ce code ne s'exécutera pas car le JAR ne peut pas être chargé\n",
-    "using org.chocosolver.solver;\n",
-    "using org.chocosolver.solver.variables;\n",
-    "using org.chocosolver.solver.constraints;\n",
-    "using org.chocosolver.solver.search.strategy.selectors.variables;\n",
-    "using org.chocosolver.solver.search.strategy.selectors.values;\n",
-    "using System;\n",
-    "using System.Linq;\n",
-    "using System.Collections.Generic;\n",
-    "\n",
-    "Console.WriteLine(\"Choco-solver via IKVM 7.2.4630.5 - Pret pour resolution Sudoku\");\n"
-   ],
+   "source": "// Imports Choco via IKVM (espaces de noms Java mappes vers .NET)\n// NOTE: Ce code ne s'executera pas car le JAR ne peut pas etre charge\nusing org.chocosolver.solver;\nusing org.chocosolver.solver.variables;\nusing org.chocosolver.solver.constraints;\nusing org.chocosolver.solver.search.strategy.selectors.variables;\nusing org.chocosolver.solver.search.strategy.selectors.values;\nusing System;\nusing System.Linq;\nusing System.Collections.Generic;\n\n// Desambiguation : org.chocosolver.solver.variables.Task vs System.Threading.Tasks.Task\nusing Task = System.Threading.Tasks.Task;\n\nConsole.WriteLine(\"Choco-solver via IKVM 7.2.4630.5 - Pret pour resolution Sudoku\");",
    "metadata": {},
    "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Packages IKVM et Choco-solver charges.\r\n"
-    }
-   ]
+   "outputs": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Sudoku-11-Choco-Csharp echouait avec CS0104 : 'Task' ambigu entre `org.chocosolver.solver.variables.Task` et `System.Threading.Tasks.Task`.

Fix : ajout `using Task = System.Threading.Tasks.Task;` dans la cellule d'imports.

Generated with [Claude Code](https://claude.com/claude-code)