### PR TITLE
fix(validator): reduce LaTeX false positives

### DIFF
--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -720,6 +720,8 @@ class NotebookValidator:
 
         # Remove various non-LaTeX $ patterns before checking
         source_for_latex = source
+        # Remove fenced code blocks (```...```) which may contain $ in shell/env vars
+        source_for_latex = re.sub(r'```.*?```', '', source_for_latex, flags=re.DOTALL)
         # Remove markdown table rows
         source_for_latex = re.sub(r'^\|.*?\|$', '', source_for_latex, flags=re.MULTILINE)
         # Remove inline code with $ (like `$defs`, `$id`, `$schema`)
@@ -743,19 +745,19 @@ class NotebookValidator:
         single_dollars = len(re.findall(r'(?<!\$)\$(?!\$)', source_for_latex))
         if single_dollars % 2 != 0:
             issues.append(ValidationIssue(
-                issue_type='error',
+                issue_type='warning',
                 category='latex',
                 cell_index=index,
-                message='Unbalanced $ signs in LaTeX'
+                message='Possibly unbalanced $ signs in LaTeX (may be false positive)'
             ))
 
         double_dollars = len(re.findall(r'\$\$', source_for_latex))
         if double_dollars % 2 != 0:
             issues.append(ValidationIssue(
-                issue_type='error',
+                issue_type='warning',
                 category='latex',
                 cell_index=index,
-                message='Unbalanced $$ signs in LaTeX'
+                message='Possibly unbalanced $$ signs in LaTeX (may be false positive)'
             ))
 
         # Check links


### PR DESCRIPTION
## Summary

- Strip fenced code blocks before counting $ signs in LaTeX validation
- Downgrade LaTeX balance checks from error to warning (high false positive rate)

Before: Search Part1 = 9 errors, CSP Part2 = 7 errors (all false positives)
After: 0 errors, 16 warnings

## Test plan

- [ ] notebook_tools.py validate runs without false errors
- [ ] Real LaTeX issues still show as warnings

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>