### PR TITLE
feat(sc3): convert print-only type cells to executable Solidity (#119)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "470cc7c2",
    "metadata": {
     "execution": {
@@ -243,57 +243,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Operateurs booleens: && (and), || (or), ! (not)\n",
-      "\n",
-      "contract BoolExample {\n",
-      "    bool public isActive = true;\n",
-      "    bool public isPaused = false;\n",
-      "\n",
-      "    function toggle() public {\n",
-      "        isActive = !isActive;\n",
-      "    }\n",
-      "\n",
-      "    function and(bool a, bool b) public pure returns (bool) {\n",
-      "        return a && b;\n",
-      "    }\n",
-      "\n",
-      "    function or(bool a, bool b) public pure returns (bool) {\n",
-      "        return a || b;\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Types booleens\n",
-    "BOOL_EXAMPLE = '''\n",
-    "contract BoolExample {\n",
-    "    bool public isActive = true;\n",
-    "    bool public isPaused = false;\n",
-    "\n",
-    "    function toggle() public {\n",
-    "        isActive = !isActive;\n",
-    "    }\n",
-    "\n",
-    "    function and(bool a, bool b) public pure returns (bool) {\n",
-    "        return a && b;\n",
-    "    }\n",
-    "\n",
-    "    function or(bool a, bool b) public pure returns (bool) {\n",
-    "        return a || b;\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Operateurs booleens: && (and), || (or), ! (not)\")\n",
-    "print(BOOL_EXAMPLE)"
-   ]
+   "outputs": [],
+   "source": "# Types booleens - compilation et deploiement reel\nBOOL_EXAMPLE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract BoolExample {\n    bool public isActive = true;\n    bool public isPaused = false;\n\n    function toggle() public {\n        isActive = !isActive;\n    }\n\n    function logicalAnd(bool a, bool b) public pure returns (bool) {\n        return a && b;\n    }\n\n    function logicalOr(bool a, bool b) public pure returns (bool) {\n        return a || b;\n    }\n\n    function logicalNot(bool a) public pure returns (bool) {\n        return !a;\n    }\n}\n'''\n\nprint(\"--- Booleens: bool (true/false), && (and), || (or), ! (not) ---\")\nbool_contract, receipt = compile_and_deploy(w3, BOOL_EXAMPLE, deployer)\nprint(f\"  Deploye : {bool_contract.address}\")\nprint(f\"  isActive = {bool_contract.functions.isActive().call()}\")\nbool_contract.functions.toggle().transact({'from': deployer})\nprint(f\"  Apres toggle() : {bool_contract.functions.isActive().call()}\")\nprint(f\"  True && False = {bool_contract.functions.logicalAnd(True, False).call()}\")\nprint(f\"  True || False = {bool_contract.functions.logicalOr(True, False).call()}\")"
   },
   {
    "cell_type": "markdown",
@@ -314,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c45e972c",
    "metadata": {
     "execution": {
@@ -332,61 +283,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Types entiers: uint8, uint256, int8, int256\n",
-      "\n",
-      "contract IntExample {\n",
-      "    // Entiers non signes (positifs)\n",
-      "    uint8 public smallNumber;      // 0 a 255\n",
-      "    uint256 public bigNumber;      // 0 a 2^256-1\n",
-      "    uint public defaultUint;       // uint256 par defaut\n",
-      "\n",
-      "    // Entiers signes (positifs et negatifs)\n",
-      "    int8 public signedSmall;       // -128 a 127\n",
-      "    int256 public signedBig;       // -2^255 a 2^255-1\n",
-      "\n",
-      "    function add(uint a, uint b) public pure returns (uint) {\n",
-      "        return a + b;\n",
-      "    }\n",
-      "\n",
-      "    function subtract(int a, int b) public pure returns (int) {\n",
-      "        return a - b;\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Types entiers\n",
-    "INT_EXAMPLE = '''\n",
-    "contract IntExample {\n",
-    "    // Entiers non signes (positifs)\n",
-    "    uint8 public smallNumber;      // 0 a 255\n",
-    "    uint256 public bigNumber;      // 0 a 2^256-1\n",
-    "    uint public defaultUint;       // uint256 par defaut\n",
-    "\n",
-    "    // Entiers signes (positifs et negatifs)\n",
-    "    int8 public signedSmall;       // -128 a 127\n",
-    "    int256 public signedBig;       // -2^255 a 2^255-1\n",
-    "\n",
-    "    function add(uint a, uint b) public pure returns (uint) {\n",
-    "        return a + b;\n",
-    "    }\n",
-    "\n",
-    "    function subtract(int a, int b) public pure returns (int) {\n",
-    "        return a - b;\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Types entiers: uint8, uint256, int8, int256\")\n",
-    "print(INT_EXAMPLE)"
-   ]
+   "outputs": [],
+   "source": "# Types entiers - compilation et deploiement reel\nINT_EXAMPLE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract IntExample {\n    // Entiers non signes (positifs)\n    uint8 public smallNumber;      // 0 a 255\n    uint256 public bigNumber;      // 0 a 2^256-1\n    uint public defaultUint;       // uint256 par defaut\n\n    // Entiers signes (positifs et negatifs)\n    int8 public signedSmall;       // -128 a 127\n    int256 public signedBig;       // -2^255 a 2^255-1\n\n    function add(uint a, uint b) public pure returns (uint) {\n        return a + b;\n    }\n\n    function subtract(int a, int b) public pure returns (int) {\n        return a - b;\n    }\n\n    function multiply(uint a, uint b) public pure returns (uint) {\n        return a * b;\n    }\n\n    function modulo(uint a, uint b) public pure returns (uint) {\n        return a % b;\n    }\n}\n'''\n\nprint(\"--- Entiers: uint8, uint256, int8, int256 (signes/non signes) ---\")\nint_contract, receipt = compile_and_deploy(w3, INT_EXAMPLE, deployer)\nprint(f\"  Deploye : {int_contract.address}\")\nprint(f\"  add(100, 200) = {int_contract.functions.add(100, 200).call()}\")\nprint(f\"  subtract(10, 3) = {int_contract.functions.subtract(10, 3).call()}\")\nprint(f\"  multiply(7, 6) = {int_contract.functions.multiply(7, 6).call()}\")\nprint(f\"  modulo(17, 5) = {int_contract.functions.modulo(17, 5).call()}\")"
   },
   {
    "cell_type": "markdown",
@@ -407,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "d833b35a",
    "metadata": {
     "execution": {
@@ -425,59 +323,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Types adresse: address, address payable\n",
-      "Proprietes: .balance, .code\n",
-      "\n",
-      "contract AddressExample {\n",
-      "    address public owner;\n",
-      "    address payable public treasury;\n",
-      "\n",
-      "    constructor() {\n",
-      "        owner = msg.sender;\n",
-      "    }\n",
-      "\n",
-      "    function getBalance(address addr) public view returns (uint256) {\n",
-      "        return addr.balance;\n",
-      "    }\n",
-      "\n",
-      "    function sendEther(address payable to) public payable {\n",
-      "        to.transfer(msg.value);\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Types adresse\n",
-    "ADDRESS_EXAMPLE = '''\n",
-    "contract AddressExample {\n",
-    "    address public owner;\n",
-    "    address payable public treasury;\n",
-    "\n",
-    "    constructor() {\n",
-    "        owner = msg.sender;\n",
-    "    }\n",
-    "\n",
-    "    function getBalance(address addr) public view returns (uint256) {\n",
-    "        return addr.balance;\n",
-    "    }\n",
-    "\n",
-    "    function sendEther(address payable to) public payable {\n",
-    "        to.transfer(msg.value);\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Types adresse: address, address payable\")\n",
-    "print(\"Proprietes: .balance, .code\")\n",
-    "print(ADDRESS_EXAMPLE)"
-   ]
+   "outputs": [],
+   "source": "# Types adresse - compilation et deploiement reel\nADDRESS_EXAMPLE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract AddressExample {\n    address public owner;\n    address payable public treasury;\n\n    constructor() {\n        owner = msg.sender;\n    }\n\n    function getBalance(address addr) public view returns (uint256) {\n        return addr.balance;\n    }\n\n    function isContract(address addr) public view returns (bool) {\n        uint256 size;\n        assembly { size := extcodesize(addr) }\n        return size > 0;\n    }\n}\n'''\n\nprint(\"--- Adresses: address (20 octets), address payable (transfert ETH) ---\")\naddr_contract, receipt = compile_and_deploy(w3, ADDRESS_EXAMPLE, deployer)\nprint(f\"  Deploye : {addr_contract.address}\")\nprint(f\"  owner = {addr_contract.functions.owner().call()}\")\nprint(f\"  deployer = {deployer}\")\nprint(f\"  owner == deployer : {addr_contract.functions.owner().call().lower() == deployer.lower()}\")\nbalance = addr_contract.functions.getBalance(deployer).call()\nprint(f\"  balance(deployer) = {w3.from_wei(balance, 'ether'):.2f} ETH\")"
   },
   {
    "cell_type": "markdown",
@@ -498,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4a799a26",
    "metadata": {
     "execution": {
@@ -516,61 +363,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Types bytes: bytes1 a bytes32 (fixes), bytes (dynamique)\n",
-      "Type string: UTF-8, dynamique\n",
-      "\n",
-      "contract BytesExample {\n",
-      "    bytes32 public fixedData = \"hello\";\n",
-      "    bytes public dynamicData = \"world\";\n",
-      "    string public message = \"Hello Solidity\";\n",
-      "\n",
-      "    function setFixed(bytes32 _data) public {\n",
-      "        fixedData = _data;\n",
-      "    }\n",
-      "\n",
-      "    function setMessage(string memory _msg) public {\n",
-      "        message = _msg;\n",
-      "    }\n",
-      "\n",
-      "    function getLength() public view returns (uint) {\n",
-      "        return bytes(message).length;\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Types bytes et string\n",
-    "BYTES_EXAMPLE = '''\n",
-    "contract BytesExample {\n",
-    "    bytes32 public fixedData = \"hello\";\n",
-    "    bytes public dynamicData = \"world\";\n",
-    "    string public message = \"Hello Solidity\";\n",
-    "\n",
-    "    function setFixed(bytes32 _data) public {\n",
-    "        fixedData = _data;\n",
-    "    }\n",
-    "\n",
-    "    function setMessage(string memory _msg) public {\n",
-    "        message = _msg;\n",
-    "    }\n",
-    "\n",
-    "    function getLength() public view returns (uint) {\n",
-    "        return bytes(message).length;\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Types bytes: bytes1 a bytes32 (fixes), bytes (dynamique)\")\n",
-    "print(\"Type string: UTF-8, dynamique\")\n",
-    "print(BYTES_EXAMPLE)"
-   ]
+   "outputs": [],
+   "source": "# Types bytes et string - compilation et deploiement reel\nBYTES_EXAMPLE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract BytesExample {\n    bytes32 public fixedData = \"hello\";\n    bytes public dynamicData = \"world\";\n    string public message = \"Hello Solidity\";\n\n    function setFixed(bytes32 _data) public {\n        fixedData = _data;\n    }\n\n    function setMessage(string memory _msg) public {\n        message = _msg;\n    }\n\n    function getLength() public view returns (uint) {\n        return bytes(message).length;\n    }\n\n    function concatenate(string memory a, string memory b) public pure returns (string memory) {\n        return string(abi.encodePacked(a, b));\n    }\n}\n'''\n\nprint(\"--- Bytes/String: bytes32 (fixe), bytes (dynamique), string (UTF-8) ---\")\nbytes_contract, receipt = compile_and_deploy(w3, BYTES_EXAMPLE, deployer)\nprint(f\"  Deploye : {bytes_contract.address}\")\nprint(f\"  message = '{bytes_contract.functions.message().call()}'\")\nprint(f\"  getLength() = {bytes_contract.functions.getLength().call()}\")\nbytes_contract.functions.setMessage(\"Solidity rocks!\").transact({'from': deployer})\nprint(f\"  Apres setMessage : '{bytes_contract.functions.message().call()}'\")\nresult = bytes_contract.functions.concatenate(\"Hello\", \" World\").call()\nprint(f\"  concatenate('Hello', ' World') = '{result}'\")"
   },
   {
    "cell_type": "markdown",
@@ -595,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "e1dec068",
    "metadata": {
     "execution": {
@@ -613,49 +407,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Variables d'etat = stockees sur la blockchain\n",
-      "\n",
-      "contract StateVariables {\n",
-      "    // Stockees en permanence sur la blockchain\n",
-      "    uint256 public storedData = 42;\n",
-      "    address public owner;\n",
-      "    bool private initialized = false;\n",
-      "\n",
-      "    // Visibilite:\n",
-      "    // public - accessible depuis l'exterieur\n",
-      "    // private - accessible uniquement dans ce contrat\n",
-      "    // internal - accessible dans ce contrat et les contrats enfants\n",
-      "    // external - accessible uniquement depuis l'exterieur\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Variables d'etat\n",
-    "STATE_VARS = '''\n",
-    "contract StateVariables {\n",
-    "    // Stockees en permanence sur la blockchain\n",
-    "    uint256 public storedData = 42;\n",
-    "    address public owner;\n",
-    "    bool private initialized = false;\n",
-    "\n",
-    "    // Visibilite:\n",
-    "    // public - accessible depuis l'exterieur\n",
-    "    // private - accessible uniquement dans ce contrat\n",
-    "    // internal - accessible dans ce contrat et les contrats enfants\n",
-    "    // external - accessible uniquement depuis l'exterieur\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Variables d'etat = stockees sur la blockchain\")\n",
-    "print(STATE_VARS)"
-   ]
+   "outputs": [],
+   "source": "# Variables d'etat - compilation et deploiement reel\nSTATE_VARS = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract StateVariables {\n    // Stockees en permanence sur la blockchain\n    uint256 public storedData = 42;\n    address public owner;\n    bool private initialized = false;\n\n    // Visibilite:\n    // public   - getter auto-genere, visible de partout\n    // private  - uniquement ce contrat\n    // internal - ce contrat + contrats enfants\n    // external - uniquement depuis l'exterieur (fonctions seulement)\n\n    constructor() {\n        owner = msg.sender;\n        initialized = true;\n    }\n\n    function setData(uint256 _data) public {\n        storedData = _data;\n    }\n\n    function isInitialized() public view returns (bool) {\n        return initialized;\n    }\n}\n'''\n\nprint(\"--- Variables d'etat : persistees sur la blockchain entre les appels ---\")\nstate_contract, receipt = compile_and_deploy(w3, STATE_VARS, deployer)\nprint(f\"  Deploye : {state_contract.address}\")\nprint(f\"  storedData = {state_contract.functions.storedData().call()}\")\nprint(f\"  owner = {state_contract.functions.owner().call()}\")\nprint(f\"  isInitialized() = {state_contract.functions.isInitialized().call()}\")\nstate_contract.functions.setData(100).transact({'from': deployer})\nprint(f\"  Apres setData(100) : storedData = {state_contract.functions.storedData().call()}\")"
   },
   {
    "cell_type": "markdown",
@@ -676,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8052eb2c",
    "metadata": {
     "execution": {
@@ -694,51 +447,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Variables locales = temporaires, non stockees\n",
-      "\n",
-      "contract LocalVariables {\n",
-      "    uint256 public result;\n",
-      "\n",
-      "    function calculate(uint a, uint b) public returns (uint256) {\n",
-      "        // Variables locales (non stockees)\n",
-      "        uint256 sum = a + b;\n",
-      "        uint256 product = a * b;\n",
-      "\n",
-      "        // Stockage du resultat\n",
-      "        result = sum + product;\n",
-      "        return result;\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Variables locales\n",
-    "LOCAL_VARS = '''\n",
-    "contract LocalVariables {\n",
-    "    uint256 public result;\n",
-    "\n",
-    "    function calculate(uint a, uint b) public returns (uint256) {\n",
-    "        // Variables locales (non stockees)\n",
-    "        uint256 sum = a + b;\n",
-    "        uint256 product = a * b;\n",
-    "\n",
-    "        // Stockage du resultat\n",
-    "        result = sum + product;\n",
-    "        return result;\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Variables locales = temporaires, non stockees\")\n",
-    "print(LOCAL_VARS)"
-   ]
+   "outputs": [],
+   "source": "# Variables locales - compilation et deploiement reel\nLOCAL_VARS = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract LocalVariables {\n    uint256 public result;\n\n    function calculate(uint a, uint b) public returns (uint256) {\n        // Variables locales (en memoire, non stockees sur la blockchain)\n        uint256 sum = a + b;\n        uint256 product = a * b;\n\n        // Seul le resultat final est stocke\n        result = sum + product;\n        return result;\n    }\n\n    function computeOnly(uint a, uint b) public pure returns (uint256 sum, uint256 product) {\n        // pure : ni lecture ni ecriture sur la blockchain\n        sum = a + b;\n        product = a * b;\n    }\n}\n'''\n\nprint(\"--- Variables locales : temporaires, en memoire (non stockees) ---\")\nlocal_contract, receipt = compile_and_deploy(w3, LOCAL_VARS, deployer)\nprint(f\"  Deploye : {local_contract.address}\")\nprint(f\"  calculate(3, 4) = {local_contract.functions.calculate(3, 4).call()}\")\nlocal_contract.functions.calculate(3, 4).transact({'from': deployer})\nprint(f\"  result sur la blockchain = {local_contract.functions.result().call()}\")\ns, p = local_contract.functions.computeOnly(5, 6).call()\nprint(f\"  computeOnly(5, 6) : sum={s}, product={p} (pas stocke)\")"
   },
   {
    "cell_type": "markdown",
@@ -759,7 +469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "f5180f71",
    "metadata": {
     "execution": {
@@ -777,71 +487,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Variables globales Solidity:\n",
-      "  msg.sender - Adresse de l'appelant\n",
-      "  msg.value - ETH envoye\n",
-      "  msg.data - Donnees de l'appel\n",
-      "  block.timestamp - Horodatage\n",
-      "  block.number - Numero du bloc\n",
-      "  tx.origin - Createur de la transaction\n",
-      "\n",
-      "contract GlobalVariables {\n",
-      "    function getGlobals() public view returns (\n",
-      "        address sender,\n",
-      "        uint256 value,\n",
-      "        uint256 timestamp,\n",
-      "        uint256 blockNumber,\n",
-      "        uint256 gasLimit\n",
-      "    ) {\n",
-      "        return (\n",
-      "            msg.sender,     // Adresse de l'appelant\n",
-      "            msg.value,      // ETH envoye (en wei)\n",
-      "            block.timestamp,// Horodatage du bloc\n",
-      "            block.number,   // Numero du bloc\n",
-      "            block.gaslimit  // Limite de gaz du bloc\n",
-      "        );\n",
-      "    }\n",
-      "}\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Variables globales\n",
-    "GLOBAL_VARS = '''\n",
-    "contract GlobalVariables {\n",
-    "    function getGlobals() public view returns (\n",
-    "        address sender,\n",
-    "        uint256 value,\n",
-    "        uint256 timestamp,\n",
-    "        uint256 blockNumber,\n",
-    "        uint256 gasLimit\n",
-    "    ) {\n",
-    "        return (\n",
-    "            msg.sender,     // Adresse de l'appelant\n",
-    "            msg.value,      // ETH envoye (en wei)\n",
-    "            block.timestamp,// Horodatage du bloc\n",
-    "            block.number,   // Numero du bloc\n",
-    "            block.gaslimit  // Limite de gaz du bloc\n",
-    "        );\n",
-    "    }\n",
-    "}\n",
-    "'''\n",
-    "\n",
-    "print(\"Variables globales Solidity:\")\n",
-    "print(\"  msg.sender - Adresse de l'appelant\")\n",
-    "print(\"  msg.value - ETH envoye\")\n",
-    "print(\"  msg.data - Donnees de l'appel\")\n",
-    "print(\"  block.timestamp - Horodatage\")\n",
-    "print(\"  block.number - Numero du bloc\")\n",
-    "print(\"  tx.origin - Createur de la transaction\")\n",
-    "print(GLOBAL_VARS)"
-   ]
+   "outputs": [],
+   "source": "# Variables globales - compilation et deploiement reel\nGLOBAL_VARS = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract GlobalVariables {\n    event GlobalsRead(\n        address sender,\n        uint256 timestamp,\n        uint256 blockNumber,\n        uint256 gasLimit\n    );\n\n    function getGlobals() public returns (\n        address sender,\n        uint256 timestamp,\n        uint256 blockNumber,\n        uint256 gasLimit\n    ) {\n        sender = msg.sender;\n        timestamp = block.timestamp;\n        blockNumber = block.number;\n        gasLimit = block.gaslimit;\n        emit GlobalsRead(sender, timestamp, blockNumber, gasLimit);\n    }\n\n    function getMsgValue() public payable returns (uint256) {\n        return msg.value;\n    }\n}\n'''\n\nprint(\"--- Variables globales : msg.sender, block.timestamp, block.number ---\")\nglobals_contract, receipt = compile_and_deploy(w3, GLOBAL_VARS, deployer)\nprint(f\"  Deploye : {globals_contract.address}\")\nsender, ts, block_n, gas_lim = globals_contract.functions.getGlobals().call({'from': deployer})\nprint(f\"  msg.sender   = {sender}\")\nprint(f\"  block.timestamp = {ts}\")\nprint(f\"  block.number = {block_n}\")\nprint(f\"  block.gaslimit = {gas_lim:,}\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Phase 3 de l'issue #119 — SC-3 Solidity Basics : conversion des 7 cellules print-only en code réellement exécutable via `compile_and_deploy()`.

## Pattern appliqué

**Avant** (print-only) :
```python
BOOL_EXAMPLE = '''contract BoolExample { ... }'''
print("Operateurs booleens...")
print(BOOL_EXAMPLE)
```

**Après** (executable) :
```python
BOOL_EXAMPLE = '''
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.28;
contract BoolExample { ... }
'''
print("--- Booleens: bool, &&, ||, ! ---")
bool_contract, receipt = compile_and_deploy(w3, BOOL_EXAMPLE, deployer)
print(f"  isActive = {bool_contract.functions.isActive().call()}")
bool_contract.functions.toggle().transact({'from': deployer})
```

## Cellules converties (7/7)

| Cellule | Contrat | Démonstration |
|---------|---------|---------------|
| `470cc7c2` | `BoolExample` | toggle(), logicalAnd(), logicalOr() |
| `c45e972c` | `IntExample` | add(), subtract(), multiply(), modulo() |
| `d833b35a` | `AddressExample` | owner, balance(deployer) |
| `4a799a26` | `BytesExample` | message, setMessage(), concatenate() |
| `e1dec068` | `StateVariables` | storedData, setData(), isInitialized() |
| `8052eb2c` | `LocalVariables` | calculate() vs computeOnly() (persistent vs éphémère) |
| `f5180f71` | `GlobalVariables` | msg.sender, block.timestamp, block.number live |

## Prérequis

- Anvil doit être lancé localement (déjà requis par le notebook depuis cell-2)
- `compile_and_deploy()` est définie dans cell `web3-setup`

## Test plan

- [ ] Lancer `anvil` dans un terminal
- [ ] Exécuter le notebook cell-by-cell via MCP Jupyter avec kernel `smartcontracts`
- [ ] Vérifier que chaque contrat se déploie et que les appels de fonctions retournent les valeurs attendues
- [ ] `notebook_tools.py validate` : 1 OK, 0 erreurs ✅

Closes partiellement #119 (SC-3 done, SC-4 à SC-14 restants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)