### PR TITLE
docs: update README notebook counts to match current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Les notebooks sont disponibles en **Python**, **C# (.NET Interactive)** et **Lea
 
 ```
 CoursIA/
-├── MyIA.AI.Notebooks/           # 460+ notebooks interactifs
+├── MyIA.AI.Notebooks/           # 500+ notebooks interactifs
 │   ├── Search/                  # Recherche et optimisation (31 notebooks)
 │   │   ├── Foundations/         # Theorie progressive
 │   │   └── Applications/        # Problemes appliques (projets etudiants)
@@ -37,8 +37,8 @@ CoursIA/
 │   │   ├── Tweety/              # Logiques formelles, argumentation (10)
 │   │   ├── SemanticWeb/         # RDF, OWL, SPARQL, GraphRAG (18)
 │   │   ├── Lean/                # Verification formelle Lean 4 (13)
-│   │   ├── Planners/            # Planification PDDL, Fast-Downward (15)
-│   │   ├── SmartContracts/      # Solidity, Move, Anchor (17)
+│   │   ├── Planners/            # Planification PDDL, Fast-Downward (14)
+│   │   ├── SmartContracts/      # Solidity, Move, Anchor (27)
 │   │   └── Argument_Analysis/   # Analyse argumentative LLM (6)
 │   ├── GameTheory/              # Theorie des jeux (26 notebooks)
 │   │   ├── GameTheory-1 to 17   # Notebooks principaux (Python)
@@ -54,7 +54,7 @@ CoursIA/
 │   ├── GenAI/                   # IA Generative (97 notebooks)
 │   │   ├── 00-GenAI-Environment/# Setup et configuration (6)
 │   │   ├── Image/               # Generation d'images (19)
-│   │   ├── Audio/               # Speech, TTS, musique (16)
+│   │   ├── Audio/               # Speech, TTS, musique (17)
 │   │   ├── Video/               # Generation et comprehension (16)
 │   │   ├── Texte/               # LLMs, RAG, prompt engineering (11)
 │   │   ├── SemanticKernel/      # Microsoft Semantic Kernel (20)
@@ -123,9 +123,9 @@ L'IA symbolique regroupe les systemes de raisonnement automatique. Cette serie c
 
 **Lean** (13 notebooks) -- Verification formelle avec Lean 4. Types dependants, isomorphisme de Curry-Howard, tactiques Mathlib, assistance par LLMs (LeanCopilot, AlphaProof), TorchLean (reseaux de neurones formellement verifies). Necessite WSL sous Windows.
 
-**Planners** (15 notebooks) -- Planification automatique, organisee en 4 niveaux : fondations PDDL, planification classique (Fast-Downward, heuristiques), avancee (OR-Tools scheduling, planification temporelle, HTN), et neurosymbolique (LLM-planning, Unified Planning, LOOP).
+**Planners** (14 notebooks) -- Planification automatique, organisee en 4 niveaux : fondations PDDL, planification classique (Fast-Downward, heuristiques), avancee (OR-Tools scheduling, planification temporelle, HTN), et neurosymbolique (LLM-planning, Unified Planning, LOOP).
 
-**Smart Contracts** (17 notebooks) -- De Solidity aux blockchains multi-chain (Move/Sui, Solana/Anchor). Tests avec Foundry, fuzz testing, verification formelle de smart contracts, DAO governance, account abstraction.
+**Smart Contracts** (27 notebooks) -- Des origines cypherpunk a Solidity avancee et aux blockchains multi-chain (Vyper, Move/Sui, Solana/Anchor, Ripple, Bitcoin). Tests avec Foundry, fuzz testing, verification formelle, zero-knowledge proofs, chiffrement homomorphe, DAO governance, account abstraction. Tous les notebooks SC-3 a SC-7 utilisent `compile_and_deploy()` pour executer du code Solidity reel.
 
 **Argument Analysis** (6 notebooks) -- Analyse argumentative multi-agents avec Semantic Kernel et LLMs.
 
@@ -134,11 +134,11 @@ L'IA symbolique regroupe les systemes de raisonnement automatique. Cette serie c
 | Tweety | 10 | JDK 17+ (auto-telecharge) | [README](MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md) |
 | SemanticWeb | 18 | Python (rdflib) | [README](MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md) |
 | Lean | 13 | WSL, elan | [README](MyIA.AI.Notebooks/SymbolicAI/Lean/README.md) |
-| Planners | 15 | Python | [README](MyIA.AI.Notebooks/SymbolicAI/Planners/README.md) |
-| SmartContracts | 17 | Node.js, Foundry | [README](MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md) |
+| Planners | 14 | Python | [README](MyIA.AI.Notebooks/SymbolicAI/Planners/README.md) |
+| SmartContracts | 27 | Node.js, Foundry | [README](MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md) |
 | Argument_Analysis | 6 | OpenAI API | [README](MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md) |
 
-82 notebooks -- Python, Lean 4, C# -- [README detaille](MyIA.AI.Notebooks/SymbolicAI/README.md)
+89 notebooks -- Python, Lean 4, C# -- [README detaille](MyIA.AI.Notebooks/SymbolicAI/README.md)
 
 ### GameTheory - Theorie des Jeux
 
@@ -202,7 +202,7 @@ La serie la plus etendue du depot, organisee par modalite. Les domaines Image, A
 | 03-Orchestration | Comparaison multi-modeles, workflows, optimisation |
 | 04-Applications | Contenu educatif, workflows creatifs, production |
 
-**Audio** (16 notebooks) -- Synthese vocale (OpenAI TTS, Kokoro, XTTS), transcription (Whisper), generation musicale (MusicGen), separation de sources (Demucs).
+**Audio** (17 notebooks) -- Synthese vocale (OpenAI TTS, Kokoro, Chatterbox, XTTS), transcription (Whisper), generation musicale (MusicGen), separation de sources (Demucs), gateway multi-modeles TTS.
 
 | Niveau | Contenu |
 |--------|---------|
@@ -230,14 +230,14 @@ La serie la plus etendue du depot, organisee par modalite. Les domaines Image, A
 |--------------|-----------|-----------------|
 | 00-Environment | 6 | - |
 | Image/ | 19 | OpenAI / Docker GPU |
-| Audio/ | 16 | OpenAI / GPU local |
+| Audio/ | 17 | OpenAI / GPU local |
 | Video/ | 16 | OpenAI / GPU local |
 | Texte/ | 11 | OpenAI API |
 | SemanticKernel/ | 20 | OpenAI API |
 | Vibe-Coding/ | 5 | Claude/Roo |
 | EPF/ | 4 | Variable |
 
-97 notebooks -- Python -- [README detaille](MyIA.AI.Notebooks/GenAI/README.md)
+98 notebooks -- Python -- [README detaille](MyIA.AI.Notebooks/GenAI/README.md)
 
 ### QuantConnect - Trading Algorithmique
 


### PR DESCRIPTION
## Summary
- SmartContracts: 17 → 27 (SC-0 to SC-26 with compile_and_deploy)
- Planners: 15 → 14 (actual count after audit)
- Audio: 16 → 17 (Kokoro TTS gateway added in PR #177)
- SymbolicAI total: 82 → 89 (after additions, excluding _output and archive)
- GenAI total: 97 → 98
- Total notebooks: 460+ → 500+
- Updated SmartContracts description to reflect blockchain coverage

## Context
Post-audit EPITA corrections. All counts verified with `find` on active notebooks.

## Test plan
- [x] All counts verified against filesystem
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)