### PR TITLE
fix(SymbolicAI): eliminate all consecutive code cells (35 notebooks, 123 cells)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
@@ -3126,6 +3126,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "source": "Demonstration complete du systeme multi-agents avec orchestration des differents roles et execution de bout en bout.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -356,6 +356,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2n35tcj4m9u",
+   "source": "### 4.2 Implementation avec unified-planning\n\nModelisation du probleme de l'interrupteur en utilisant l'API unified-planning avec un environnement explicite et des parametres d'action typés.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-9",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -1407,6 +1407,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "opks33hg4ue",
+   "source": "Definition du probleme PDDL correspondant au domaine Gripper, instanciant les objets concrets, l'etat initial et le but a atteindre.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "2873108b",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-3-State-Space.ipynb
@@ -340,6 +340,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "n2lxn6uxvq",
+   "source": "Visualisation du graphe d'etats construit pour la grille de navigation, representant chaque etat accessible comme un noeud et chaque action possible comme une arete.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "cell-8",
@@ -1454,6 +1460,12 @@
     "print(goal_puzzle)\n",
     "print(f\"\\nHeuristique h(initial) = {puzzle.manhattan_heuristic(initial_puzzle)}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "l95assxmqa",
+   "source": "Resolution du 8-puzzle avec l'algorithme A* en utilisant la distance de Manhattan comme heuristique admissible, puis affichage de la sequence de mouvements trouvee.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-4-Fast-Downward.ipynb
@@ -278,6 +278,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "jm98kmfbnoj",
+   "source": "Verification de la disponibilite de l'image Docker Fast Downward et tentative de telechargement depuis le registre public si elle n'est pas presente localement.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "cell-8",
@@ -700,6 +706,12 @@
     "print(f\"Domaine: blocks\")\n",
     "print(f\"Probleme: empiler A sur B\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fnprzo9k9es",
+   "source": "Execution de Fast Downward via Docker sur le probleme Blocks World avec l'algorithme A* et l'heuristique LM-cut, puis affichage du plan et des statistiques de recherche.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1341,6 +1353,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sns40d8qf4o",
+   "source": "Lancement de Fast Downward sur le domaine Logistics et affichage du plan optimal trouve, incluant les actions de chargement, transport et dechargement des colis.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "cell-30",
@@ -1551,6 +1569,12 @@
     "else:\n",
     "    print(\"unified-planning non disponible\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feg1j8jjl79",
+   "source": "Resolution du meme probleme via l'interface unified-planning en testant les planificateurs disponibles et en comparant leurs resultats avec l'appel Docker direct.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -323,6 +323,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c8g5aurjvpg",
+   "source": "Application de l'heuristique h^max au probleme de l'interrupteur pour illustrer le calcul concret de la valeur heuristique sur un exemple minimal.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "hmax-example",
@@ -880,6 +886,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "uqfx20us1zf",
+   "source": "Implementation de l'heuristique landmark-counting qui compte le nombre de landmarks non encore atteints pour estimer le cout restant jusqu'au but.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "landmark-heuristic",
@@ -1054,6 +1066,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "spewdp9x519",
+   "source": "Calcul et comparaison des valeurs de toutes les heuristiques implementees sur l'etat initial du probleme Blocks World : h^max, h^add, h^FF et h^landmark.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "benchmark-comparison",
@@ -1122,6 +1140,12 @@
     "print(\"-\" * 50)\n",
     "print(f\"h* (optimal)    {h_optimal}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46l97hxzgl7",
+   "source": "Visualisation sous forme de graphique en barres des valeurs heuristiques calculees pour chaque methode, facilitant la comparaison visuelle de leur informativite respective.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1301,6 +1325,12 @@
     "        print(f\"Erreur: {e}\")\n",
     "        print(\"C est normal si aucun planificateur externe n est installe.\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ta62b3jhoqr",
+   "source": "Resolution du meme probleme avec un second planificateur pour comparer les resultats obtenus selon les differentes configurations d'heuristiques disponibles.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains.ipynb
@@ -399,6 +399,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "tg0vrx46nzg",
+   "source": "Definition d'un probleme Block World plus complexe impliquant l'inversion de deux tours, ce qui necessite de defaire une configuration existante avant de reconstruire.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "cell-11",
@@ -611,6 +617,12 @@
     "    print(f\"Objets: {[o.name for o in blocks_problem.all_objects]}\")\n",
     "    print(f\"Actions: {[a.name for a in blocks_problem.actions]}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "y3zv46k5ejh",
+   "source": "Resolution du probleme Block World avec pyperplan et affichage du plan trouve, en verifiant que le planificateur produce une solution valide pour les deux instances.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1115,6 +1127,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "kjoe8igka0h",
+   "source": "Creation du probleme Logistics concret avec les objets (colis, vehicules, locations), l'etat initial et le but, en utilisant l'API unified-planning.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "cell-24",
@@ -1176,6 +1194,12 @@
     "    \n",
     "    print(\"Probleme Logistics simplifie cree\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "egq7ok0ens5",
+   "source": "Lancement du planificateur sur le probleme Logistics et affichage du plan genere avec les actions de chargement, deplacement et dechargement des colis.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
@@ -485,6 +485,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "w67msk42e7",
+   "source": "Importation de la bibliotheque unified-planning et verification de la disponibilite de l'extension de planification temporelle.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "cell-12",
@@ -525,6 +531,12 @@
     "    print(\"Solution: pip install unified-planning\")\n",
     "    UP_OK = False"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fuzx19yryn6",
+   "source": "Verification des planificateurs temporels disponibles dans l'installation unified-planning et affichage de leurs capacites respectives.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -714,6 +726,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "jpzos8tyi5i",
+   "source": "Definition d'une action durative de deplacement avec ses conditions temporelles (at start, over all, at end) et ses effets en debut et fin d'execution.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "cell-16",
@@ -897,6 +915,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "sw2zz50iea",
+   "source": "Definition des actions duratives pour chaque tache de l'usine avec leurs durees, machines associees et contraintes de precedence entre operations.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "cell-19",
@@ -1057,6 +1081,12 @@
     "    print(\"Ressources: 1 tache a la fois par machine\")\n",
     "    print(\"Objectif: minimiser makespan\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ss2fbfor6yq",
+   "source": "Lancement du solveur CP-SAT et affichage de l'ordonnancement optimal obtenu avec les dates de debut et de fin de chaque tache sur chaque machine.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -1000,6 +1000,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "hyut0gmgq6",
+   "source": "Definition du probleme logistique concret : etat initial avec les positions des colis et vehicules, but a atteindre, puis resolution par decomposition HTN.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "cell-19",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -148,6 +148,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "qwhoava1aus",
+   "source": "Configuration des clients API OpenAI et Anthropic avec les parametres par defaut (modele, temperature, tokens), en lisant les cles depuis les variables d'environnement.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "35bf6b1c",
@@ -344,6 +350,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "erhfybdkgim",
+   "source": "Demonstration de la planification directe par LLM sur un exemple de voyage Paris-Tokyo en definissant l'etat initial, le but et les actions disponibles.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "0dd0d8b0",
@@ -523,6 +535,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "akalpwcqg8i",
+   "source": "Implementation de la variante Tree-of-Thought qui explore plusieurs branches de raisonnement en parallele avant de selectionner le meilleur plan candidat.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "1fc7c73f",
@@ -677,6 +695,12 @@
     "    \n",
     "    return \";; API non configuree\""
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2tbqoup6bpy",
+   "source": "Application de la fonction de traduction au domaine logistique : generation d'un domaine PDDL complet a partir d'une description en langage naturel via le LLM.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1012,6 +1036,12 @@
     "\n",
     "print(\"Fonction heuristique LLM definie\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57m8ot06t6t",
+   "source": "Demonstration de l'heuristique LLM sur un etat concret de navigation, en interrogeant le modele de langage pour estimer le nombre d'etapes restantes jusqu'au but.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -184,6 +184,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "k2tskaw3di8",
+   "source": "Verification des moteurs de planification disponibles sur le systeme et affichage de leurs capacites (planification classique, temporelle, numerique, etc.).",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-check-engines",
@@ -783,6 +789,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a40w8be6wev",
+   "source": "Affichage formate sous forme de tableau des resultats de la comparaison entre solveurs, incluant le statut, le temps de resolution et la longueur du plan produit.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "cell-display-comparison",
@@ -1082,6 +1094,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "vu0h3sb3j7p",
+   "source": "Creation du probleme numerique avec le robot et sa batterie : initialisation des fluents, definition de l'etat initial et specification du but a atteindre.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "cell-numeric-problem",
@@ -1277,6 +1295,12 @@
     "domain_pddl = writer.get_domain()\n",
     "print(domain_pddl)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5i8xn0m3cpp",
+   "source": "Generation et affichage du fichier PDDL du probleme (problem.pddl) exporté, contenant les objets, l'etat initial et le but sous forme textuelle standardisee.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-12-LOOP.ipynb
@@ -1156,6 +1156,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "55ujn6jty4e",
+   "source": "Simulation d'une boucle d'entrainement complete avec des donnees synthetiques, en suivant la convergence de la perte de politique et de valeur sur plusieurs epochs.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "cell-training-loop",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -137,6 +137,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-002",
+   "metadata": {},
+   "source": [
+    "Importation des bibliotheques principales : rdflib, owlrl, OWLReady2 et reasonable."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "8ce4bd97",
@@ -272,6 +280,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-005",
+   "metadata": {},
+   "source": [
+    "Definition de la hierarchie de classes OWL pour l'ontologie de test (Pizza Ontology simplifiee)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "d54d3c88",
@@ -330,6 +346,14 @@
     "g.add((EX.VegetarianRestriction, OWL.allValuesFrom, EX.VegetarianTopping))\n",
     "\n",
     "print(\"✓ Hiérarchie de classes définie\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-006",
+   "metadata": {},
+   "source": [
+    "Ajout des individus (instances de classes) pour alimenter le raisonnement."
    ]
   },
   {
@@ -395,6 +419,14 @@
     "\n",
     "print(f\"✓ {len(individuals)} instances créées\")\n",
     "print(f\"✓ Total triples dans l'ontologie: {len(g)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-007",
+   "metadata": {},
+   "source": [
+    "Serialisation du graphe initial en Turtle comme reference avant l'application du raisonnement."
    ]
   },
   {
@@ -553,6 +585,14 @@
     "print(f\"✓ Triples avant raisonnement: {len(g)}\")\n",
     "print(f\"✓ Triples après raisonnement: {triples_owlrl}\")\n",
     "print(f\"✓ Triples inférés: {inferred_owlrl}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-011",
+   "metadata": {},
+   "source": [
+    "Affichage d'exemples de triplets inferences par owlrl pour illustrer les resultats du raisonnement OWL 2 RL."
    ]
   },
   {
@@ -718,6 +758,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-016",
+   "metadata": {},
+   "source": [
+    "Creation des classes et proprietes OWLReady2 pour reproduire l'ontologie avec le raisonneur HermiT."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "2bcbb98f",
@@ -793,6 +841,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-017",
+   "metadata": {},
+   "source": [
+    "Ajout des instances dans l'ontologie OWLReady2 et preparation du raisonnement HermiT."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "c50ac732",
@@ -839,6 +895,14 @@
     "    print(f\"✓ Instances créées\")\n",
     "    print(f\"  - Margherita a {len(margherita.has_topping)} toppings\")\n",
     "    print(f\"  - Pepperoni a {len(pepperoni.has_topping)} toppings\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-018",
+   "metadata": {},
+   "source": [
+    "Execution du raisonnement HermiT sur l'ontologie et collecte des resultats inferences."
    ]
   },
   {
@@ -1024,6 +1088,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-023",
+   "metadata": {},
+   "source": [
+    "Execution du raisonnement avec la bibliotheque reasonable et collecte des resultats."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "id": "a3234357",
@@ -1199,6 +1271,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-028",
+   "metadata": {},
+   "source": [
+    "Verification de la disponibilite de Growl et execution du raisonnement si disponible."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "id": "68c97c3d",
@@ -1365,6 +1445,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-031",
+   "metadata": {},
+   "source": [
+    "Visualisation des temps d'execution de chaque raisonneur sous forme de graphique."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "cd7352e6",
@@ -1421,6 +1509,14 @@
     "    plt.show()\n",
     "else:\n",
     "    print(\"Pas assez de données pour le graphique\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-032",
+   "metadata": {},
+   "source": [
+    "Comparaison du nombre de triplets inferences par les raisonneurs compatibles OWL 2 RL."
    ]
   },
   {
@@ -1596,6 +1692,14 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "trans-036",
+   "metadata": {},
+   "source": [
+    "Exercice 2 : verification de l'equivalence entre les triplets inferences par owlrl et reasonable."
+   ]
+  },
+  {
    "cell_type": "code",
    "id": "ex-sw13-2",
    "source": [
@@ -1628,6 +1732,14 @@
    "metadata": {},
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "trans-037",
+   "metadata": {},
+   "source": [
+    "Exercice 3 : profilage avance avec cProfile pour identifier les fonctions les plus couteuses."
+   ]
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
@@ -49,6 +49,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Importation des espaces de noms dotNetRDF et configuration de l'environnement de travail."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -133,6 +140,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Utilisation de StringParser pour la detection automatique de format et de NTriplesParser pour un parsing explicite."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -164,6 +178,13 @@
     "Graph g2 = new Graph();\n",
     "new NTriplesParser().Load(g2, new StringReader(\"<http://example.org/a> <http://example.org/b> <http://example.org/c>.\"));\n",
     "Console.WriteLine($\"NTriplesParser       : {g2.Triples.Count} triplet\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comptage des triplets avec CountHandler sans charger le graphe en memoire."
    ]
   },
   {
@@ -255,6 +276,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Serialisation du graphe en RDF/XML via deux methodes equivalentes : helper statique et StringWriter explicite."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -303,6 +331,13 @@
     "Console.WriteLine($\"StringWriter: {data2.Length} car.\");\n",
     "Console.WriteLine($\"Identiques  : {data1 == data2}\");\n",
     "Console.WriteLine($\"\\n=== RDF/XML (extrait) ===\\n{data1.Substring(0, Math.Min(data1.Length, 400))}...\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configuration avancee des writers (compression, pretty-print) pour optimiser la sortie Turtle."
    ]
   },
   {
@@ -562,6 +597,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combinaison de selections par predicat et par objet avec des expressions LINQ pour filtrer les animaux."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -738,6 +780,13 @@
     "int avant = g.Triples.Count;\n",
     "g.RetractList(newRoot);\n",
     "Console.WriteLine($\"RetractList   : {avant} -> {g.Triples.Count} triplets\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ajout et suppression d'elements dans une liste RDF existante avec AddToList et RemoveFromList."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
@@ -50,6 +50,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Importation des espaces de noms dotNetRDF pour SPARQL, QueryBuilder et la gestion des parsers."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -268,6 +275,13 @@
     "\n",
     "Console.WriteLine(\"=== FILTER numerique ===\");\n",
     "Console.WriteLine(qb.BuildQuery().ToString());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Construction d'une requete FILTER avec expression reguliere pour filtrer les resultats par pattern textuel."
    ]
   },
   {
@@ -506,6 +520,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Utilisation d'une chaine SPARQL brute avec SparqlQueryParser pour construire une requete avec LIMIT et OFFSET."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -642,6 +663,13 @@
     "\n",
     "Console.WriteLine(\"=== Requete complexe ===\");\n",
     "Console.WriteLine(qb.BuildQuery().ToString());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Chargement d'un graphe de test en memoire et execution d'une requete SELECT avec FILTER sur ce graphe."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
@@ -103,6 +103,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "v2fyj3kyd1h",
+   "source": "Importation de rdflib et chargement du graphe d'animaux depuis le fichier Turtle.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "imports-and-load",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
@@ -61,6 +61,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Importation des espaces de noms dotNetRDF et definition des fonctions utilitaires pour les requetes SPARQL distantes."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -468,6 +475,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete pour lister les films dans lesquels Brad Pitt apparait en tant qu'acteur."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -618,6 +632,13 @@
     "Console.WriteLine(\"=== Livres de J.K. Rowling ===\");\n",
     "string q3 = \"SELECT ?book WHERE { ?book dbo:author <http://dbpedia.org/resource/J._K._Rowling> . }\";\n",
     "ExecuteAndDisplaySparqlQuery(endpoint, q3);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete pour recuperer les villes de France depuis DBpedia."
    ]
   },
   {
@@ -911,6 +932,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete pour obtenir les films d'aventure avec leurs metadonnees enrichies."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -948,6 +976,13 @@
     "\n",
     "Console.WriteLine(\"=== Films d'aventure enrichis ===\");\n",
     "ExecuteAndDisplaySparqlQuery(endpoint, q7, 5);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete avancee avec GROUP_CONCAT et OPTIONAL pour lister les comedies romantiques avec leurs acteurs."
    ]
   },
   {
@@ -1086,6 +1121,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete Wikidata pour lister les films avec Brad Pitt via son identifiant Q35332."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1129,6 +1171,13 @@
     "{\n",
     "    Console.WriteLine($\"Erreur Wikidata : {ex.Message}\");\n",
     "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execution d'une requete Wikidata pour obtenir les grandes villes de France avec leur population."
    ]
   },
   {
@@ -1313,6 +1362,13 @@
     "{\n",
     "    Console.WriteLine($\"Erreur : {ex.Message}\");\n",
     "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Approche en deux etapes pour relier les entites DBpedia et Wikidata via le predicat owl:sameAs."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
@@ -104,6 +104,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "qsddfrks7mi",
+   "source": "Importation de SPARQLWrapper et des constantes de format de retour pour les requetes SPARQL distantes.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "sparqlwrapper-imports",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -104,6 +104,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "zyf8e47gkb",
+   "source": "Importation de la bibliotheque OWLReady2 pour la manipulation d'ontologies OWL.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "imports-owlready2",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -224,6 +224,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "ycu6xb9a2k",
+   "source": "Détection de falsification dans la chaîne de blocs en vérifiant l'intégrité des hash successifs.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "tamper-detection",
    "metadata": {},
@@ -382,6 +388,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ksp2wjxkt8",
+   "source": "Génération d'une preuve Merkle permettant de vérifier qu'une transaction appartient à un bloc sans télécharger toute la blockchain.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -693,6 +705,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tfj33xjo5me",
+   "source": "Implémentation du format Bencode utilisé par BitTorrent pour sérialiser les métadonnées de torrents.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -63,6 +63,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "hbguetgo0we",
+   "source": "Installation du compilateur Solidity via py-solc-x pour permettre la compilation de contrats directement depuis Python.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "install-solc",
    "metadata": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -234,6 +234,12 @@
    "source": "# Visibilite des fonctions - demonstration\nVISIBILITY_EXAMPLE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract VisibilityExample {\n    uint256 private privateVar = 1;\n    uint256 internal internalVar = 2;\n    uint256 public publicVar = 3;\n\n    function publicFunction() public pure returns (string memory) {\n        return \"Je suis publique!\";\n    }\n\n    function externalFunction() external pure returns (string memory) {\n        return \"Je suis externe!\";\n    }\n\n    function internalFunction() internal pure returns (string memory) {\n        return \"Je suis interne!\";\n    }\n\n    function privateFunction() private pure returns (string memory) {\n        return \"Je suis prive!\";\n    }\n\n    function callInternal() public pure returns (string memory) {\n        return internalFunction();\n    }\n\n    function getPrivateVar() public view returns (uint256) {\n        return privateVar;\n    }\n\n    function getAllVars() public view returns (uint256, uint256, uint256) {\n        return (privateVar, internalVar, publicVar);\n    }\n}\n'''\n\nprint(\"--- Visibilite : public / external / internal / private ---\")\nvis_contract, receipt = compile_and_deploy(w3, VISIBILITY_EXAMPLE, deployer)\nprint(f\"  Deploye : {vis_contract.address}\")\nprint(f\"  publicFunction() = '{vis_contract.functions.publicFunction().call()}'\")\nprint(f\"  callInternal() = '{vis_contract.functions.callInternal().call()}'\")\nprint(f\"  publicVar = {vis_contract.functions.publicVar().call()}\")\npriv, intern, pub = vis_contract.functions.getAllVars().call()\nprint(f\"  getAllVars() : private={priv}, internal={intern}, public={pub}\")"
   },
   {
+   "cell_type": "markdown",
+   "id": "866fhiq3cqo",
+   "source": "Comparaison entre les modificateurs `external` et `public` pour illustrer l'impact sur la consommation de gas.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cell-7",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -165,6 +165,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "yg3w7iow4e",
+   "source": "Configuration des clients API Anthropic et OpenAI avec gestion des clés d'authentification.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "60d4ec03",
@@ -543,6 +549,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "1kc5a7nzpil",
+   "source": "Génération d'un contrat Solidity simple à partir d'une description en langage naturel via l'API LLM.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "195057f0",
@@ -754,6 +766,12 @@
     "\n",
     "print(\"Fonction audit_contract definie\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mkag5p3bllk",
+   "source": "Exemple de génération NatSpec : ajout automatique de documentation à un contrat sans commentaires.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -993,6 +1011,12 @@
     "\n",
     "print(\"Fonction generate_natspec definie\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bpgc36ig574",
+   "source": "Exemple d'audit automatique d'un contrat volontairement vulnérable pour identifier les failles de sécurité.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1263,6 +1287,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5r44axt1imq",
+   "source": "Démonstration du workflow complet : génération, audit et documentation d'un contrat Solidity via l'assistant LLM.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "3bf3c533",
@@ -1478,6 +1508,12 @@
     "print(f\"Endpoint: {local_assistant.endpoint}\")\n",
     "print(f\"Modele: {local_assistant.model}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3rjfq8lwstk",
+   "source": "Démonstration de l'assistant LLM local avec un modèle hébergé en local (si disponible) pour la génération de contrats.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -108,6 +108,12 @@
    "source": "# Interface ERC-20 complete\nERC20_INTERFACE = '''\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\n/// @title ERC-20 Token Standard\ninterface IERC20 {\n    event Transfer(address indexed from, address indexed to, uint256 value);\n    event Approval(address indexed owner, address indexed spender, uint256 value);\n\n    function totalSupply() external view returns (uint256);\n    function balanceOf(address account) external view returns (uint256);\n    function allowance(address owner, address spender) external view returns (uint256);\n    function transfer(address to, uint256 amount) external returns (bool);\n    function transferFrom(address from, address to, uint256 amount) external returns (bool);\n    function approve(address spender, uint256 amount) external returns (bool);\n}\n'''\n\n# Les interfaces ne peuvent pas etre deployees (pas de bytecode)\n# Elles definissent uniquement les signatures de fonctions\nprint(\"Interface ERC-20 (reference - ne se deploie pas) :\")\nprint(\"  - totalSupply(), balanceOf(), allowance()\")\nprint(\"  - transfer(), transferFrom(), approve()\")\nprint(\"  - events: Transfer, Approval\")\nprint(\"\\nL implementation est dans la cellule suivante.\")"
   },
   {
+   "cell_type": "markdown",
+   "id": "8m52cghcys3",
+   "source": "Implémentation complète du standard ERC-20 avec toutes les fonctions requises par l'interface.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "cell-3",
@@ -203,6 +209,12 @@
     "print(\"Interface ERC-721:\")\n",
     "print(ERC721_INTERFACE)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dpvnh17qrem",
+   "source": "Implémentation simplifiée d'un token ERC-721 (NFT) avec gestion de la propriété et des approbations.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -187,6 +187,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "lhfs9v9mglt",
+   "source": "Implémentation Solidity d'un AMM basé sur la formule de produit constant, correspondant à la simulation Python précédente.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-3",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -105,6 +105,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6piuuv7vvay",
+   "source": "Vérification de l'installation de Foundry en testant la disponibilité des outils `forge`, `cast` et `anvil`.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-3",
@@ -210,6 +216,12 @@
     "print(\"Creation d'un projet Foundry:\")\n",
     "print(project_setup)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "l1h032jcvqs",
+   "source": "Configuration du fichier `foundry.toml` définissant les paramètres du projet Foundry (répertoires, compilateur, profils).",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -362,6 +374,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2ff2wu7ar3s",
+   "source": "Test basique utilisant le pattern DSTest pour valider le comportement du contrat Counter déployé.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "cell-10",
@@ -455,6 +473,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3849567sxvs",
+   "source": "Commandes Foundry pour compiler le projet et exécuter les tests avec différents niveaux de verbosité.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "cell-11",
@@ -512,6 +536,12 @@
     "print(\"Commandes forge test:\")\n",
     "print(test_commands)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "oyl7uq8ix1g",
+   "source": "Sortie attendue de la commande `forge test` illustrant le résultat d'une exécution réussie des tests unitaires.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -630,6 +660,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ah98su2s3c",
+   "source": "Exemple d'utilisation de `vm.prank` et `vm.deal` pour simuler des appels depuis une adresse spécifique avec un solde défini.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "cell-16",
@@ -727,6 +763,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "y6g7hj9zhz",
+   "source": "Manipulation du temps de la blockchain avec `vm.warp` et `vm.roll` pour tester des fonctions dépendantes du temps.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "cell-17",
@@ -800,6 +842,12 @@
     "print(\"Test avec vm.warp et vm.roll:\")\n",
     "print(time_test)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ggxzslodku5",
+   "source": "Utilisation de `vm.expectRevert` pour vérifier qu'une transaction échoue avec le bon message d'erreur.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -965,6 +1013,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "g43j440z6b",
+   "source": "Exemple complet d'un contrat de test utilisant les assertions Foundry pour valider le comportement du Counter.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "id": "cell-22",
@@ -1048,6 +1102,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "pdpjpq1gvh",
+   "source": "Fonctions de logging disponibles dans Foundry pour afficher des valeurs pendant l'exécution des tests avec verbosité.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "cell-23",
@@ -1105,6 +1165,12 @@
     "print(\"Fonctions de logging Foundry:\")\n",
     "print(logging_funcs)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11ryohyjdvd",
+   "source": "Exemple complet intégrant les fonctions de logging pour afficher des informations de débogage pendant les tests.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -1300,6 +1366,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "i0b08d5d8k",
+   "source": "Exercice : écriture des tests pour le contrat SimpleVault en utilisant les cheatcodes Foundry étudiés précédemment.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "cell-29",
@@ -1447,6 +1519,12 @@
     "print(\"Contrat Timelock.sol:\")\n",
     "print(timelock_contract)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mm4vfpmukp",
+   "source": "Exercice : écriture des tests pour le contrat Timelock en utilisant notamment `vm.warp()` pour simuler l'écoulement du temps.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -231,6 +231,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "zggas8edupp",
+   "source": "Spécification formelle CVL (Certora Verification Language) définissant les propriétés à vérifier sur le contrat Vault.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "cell-5",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -194,6 +194,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "iuw9y1r5rdd",
+   "source": "Chiffrement et déchiffrement d'un nombre entier avec le schéma de Paillier pour valider la configuration des clés.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "paillier-encrypt",
    "metadata": {},
@@ -221,6 +227,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4abv9a25ki",
+   "source": "Démonstration de la propriété homomorphique additive : addition de valeurs chiffrées sans déchiffrement intermédiaire.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -398,6 +410,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t721zr9tflq",
+   "source": "Mesure des performances et de la profondeur multiplicative disponible avec le schéma CKKS sur des données réelles.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -732,6 +750,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dgqc83t9dbh",
+   "source": "Reconstruction du secret à partir de différents sous-ensembles de parts pour vérifier la propriété de seuil du schéma de Shamir.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
@@ -107,6 +107,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "komr5i55k4",
+   "source": "Simulation du processus de vote pour 7 électeurs avec chiffrement homomorphique de chaque bulletin.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "encrypt-ballots",
    "metadata": {},
@@ -381,6 +387,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "n1mjog4u0g",
+   "source": "Vérification individuelle permettant à chaque électeur de confirmer que son bulletin est bien enregistré sur le tableau d'affichage public.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "verify-individual",
    "metadata": {},
@@ -498,6 +510,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0td529f57lf",
+   "source": "Démonstration illustrative du SDK ElectionGuard pour le vote vérifié de bout en bout.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -207,6 +207,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "9183uady7tj",
+   "source": "Implémentation d'un token ERC-20 simplifié en Vyper pour illustrer la gestion des balances et des transferts.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "token-contract",
    "metadata": {},
@@ -411,6 +417,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "z4tzjljere",
+   "source": "Déploiement du contrat de stockage Vyper sur une blockchain locale (Anvil) et interaction avec ses fonctions.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "deploy-code",
    "metadata": {},
@@ -589,6 +601,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "j57gq57p65l",
+   "source": "Deuxième comparaison illustrant la gestion du contrôle d'accès (Ownable) en Solidity et Vyper.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "comparison-ownable",
    "metadata": {},
@@ -661,6 +679,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ntwd27av9mo",
+   "source": "Troisième comparaison portant sur la gestion des boucles, un point de divergence important entre Solidity et Vyper.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -161,6 +161,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "kiyi7nubjkg",
+   "source": "Connexion au testnet XRP Ledger via un client JSON-RPC pour interagir avec le réseau de test.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "setup-connect",
    "metadata": {},
@@ -189,6 +195,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kq1o265ipl",
+   "source": "Création d'un wallet de test via le faucet du testnet XRP pour obtenir des fonds de développement.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -343,6 +355,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "brjfwi7k7f4",
+   "source": "Création d'une Trust Line pour accepter un IOU (dette émise) d'un autre compte sur le XRP Ledger.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "tx-trustline-code",
    "metadata": {},
@@ -393,6 +411,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdsg6uhk6w",
+   "source": "Création d'un Offer sur le DEX intégré du XRP Ledger pour échanger des devises de manière décentralisée.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -567,6 +591,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4j194fc48ue",
+   "source": "Ouverture réelle d'un Payment Channel sur le testnet XRP via la transaction PaymentChannelCreate.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -176,6 +176,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "3t3h3yuwh0u",
+   "source": "Simulation d'une transaction UTXO d'Alice vers Bob pour illustrer le mécanisme de dépense des sorties non dépensées.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "utxo-transactions",
    "metadata": {},
@@ -425,6 +431,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "qxzuzbabf2",
+   "source": "Implémentation du script P2PKH (Pay-to-Public-Key-Hash), le type de script de verrouillage le plus courant dans Bitcoin.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "p2pkh-code",
    "metadata": {},
@@ -616,6 +628,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "fh92oeykv6h",
+   "source": "Utilisation de la bibliothèque python-bitcoinlib pour la construction et la manipulation de transactions Bitcoin.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "bitcoinlib-code",
    "metadata": {},
@@ -776,6 +794,12 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "id": "19rt8g6ajvd",
+   "source": "Présentation des scripts TIMELOCK (CLTV et CSV) pour verrouiller des fonds jusqu'à une date ou un nombre de blocs défini.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "id": "timelock-code",
    "metadata": {},
@@ -835,6 +859,12 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "oohk8p3ahs",
+   "source": "Illustration du format P2SH (Pay-to-Script-Hash) permettant d'encapsuler des scripts complexes dans une adresse standard.",
+   "metadata": {}
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -232,6 +232,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "tzzbrohpgh",
+   "source": "Contrat expéditeur CCIP permettant d'envoyer des messages et des tokens vers d'autres blockchains via le protocole Chainlink.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "cell-5",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
@@ -212,6 +212,13 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Déploiement du contrat SimpleStorage sur Sepolia, nécessitant un compte approvisionné en ETH de test."
+   ]
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "source": [
@@ -341,6 +348,13 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Envoi d'un paiement XRP sur le testnet après ouverture du canal de paiement."
+   ]
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
@@ -203,6 +203,13 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Déploiement du contrat sur le réseau Base mainnet après vérification du solde et de la connexion."
+   ]
+  },
+  {
    "cell_type": "code",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

- Add **123 transition markdown cells** across 35 SymbolicAI notebooks to eliminate all consecutive code cell pairs
- SmartContracts: 16 notebooks, 53 transition cells
- SemanticWeb: 7 notebooks, 36 transition cells
- Planners: 11 notebooks, 33 transition cells
- Lean: 1 notebook, 1 transition cell
- Result: **0 consecutive code cell pairs** remaining across 89 SymbolicAI notebooks (was 126)

## Test plan

- [x] Verified 0 remaining consecutive code pairs via automated audit script
- [ ] Spot-check transition cell content quality in a few notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)