### PR TITLE
fix(slides): fix 7 overflow slides + true image overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,27 @@ Les agents Roo sur les machines po-2023, po-2024, po-2025, po-2026 travaillent s
 - Ne pas creer de fichiers de planification (EXTEND_*.md, PROCEDURE_*.md) dans le repo — utiliser RooSync
 - Les rapports d'audit, inventaires, et status vont sur le **dashboard RooSync**, pas dans le repo
 
+### Review PR : validation explicite des objectifs
+
+Toute PR doit faire l'objet d'une **review complete** avant merge :
+
+1. **Relire l'issue ou le contexte d'origine** : identifier les objectifs precis (layout, positionnement, contenu, format)
+2. **Valider chaque objectif explicitement** : verifier dans le code ET visuellement que chaque exigence est satisfaite
+3. **Verification visuelle obligatoire pour les slides** :
+   - Lancer le serveur Slidev et verifier CHAQUE slide modifie (pas un echantillon)
+   - Verifier avec `?clicks=99` pour voir le contenu complet revele
+   - Verifier l'absence d'overflow (contenu coupe en bas)
+   - Verifier les layouts d'images (overlay uniquement, jamais colonne droite)
+4. **Verification visuelle obligatoire pour les notebooks** : executer ou au moins valider la structure
+5. **Ne jamais merger une PR sur la seule base du CI green** : CI valide la syntaxe, pas le rendu visuel ni la conformite aux specifications
+
+**Slides : images en overlay uniquement**
+- Les images de fond doivent utiliser `layout: image-overlay` avec le texte par-dessus, jamais en colonne droite
+- Cette regle a ete specifiee dans l'issue #221 et confirmee 5+ fois dans les discussions
+- Verifier que chaque image est bien positionnee sur le bon slide
+
+**VIOLATION = PR a rejeter, meme si le code compile**
+
 ### Pas de duplication
 
 - Avant de creer un fichier (README, docs, shared library), verifier qu'il n'existe pas deja

--- a/slides/S4-trading-algorithmique/slides.md
+++ b/slides/S4-trading-algorithmique/slides.md
@@ -222,12 +222,6 @@ Intelligence Artificielle -- S4
 
 </div>
 
-<div v-click="1">
-
-- **Conseil pour debuter** : Commencer par le LFT, migrer vers le MFT avec l'experience
-- La plupart des strategies dans ce cours sont MFT ou LFT
-
-</div>
 ---
 layout: section
 ---
@@ -782,7 +776,6 @@ layout: section
 
 - **Avancees recentes (2023-2026)**
   - LLMs pour l'analyse de sentiment et la generation de signaux
-  - Theorie des jeux : modeliser le marche comme un jeu adversarial
   - Foundation models pre-entraines sur les series temporelles financieres
 
 </div>
@@ -995,17 +988,11 @@ imageClass: mid-right
 | AllWeather | Allocation | 0.67 | Faible drawdown |
 | SectorMomentum | Rotation | 0.62 | Dual momentum + bonds |
 | RegimeSwitching | Adaptatif | 0.55 | Adapte l'allocation au regime |
-| PairsTrading | Stat-arb | -0.36 | Echec : co-integration instable |
-| ForexCarry | FX carry | -0.32 | Echec : prime epuisee |
 
 </div>
 
-<div v-click="1">
+Echecs pedagogiques : PairsTrading (-0.36), ForexCarry (-0.32) -- aussi dans le depot
 
-- Les strategies simples (EMA, momentum) fonctionnent souvent mieux que les complexes
-- Les echecs sont aussi pedagogiques que les succes
-
-</div>
 ---
 layout: section
 ---
@@ -1234,11 +1221,7 @@ imageClass: mid-right
 </div>
 <div v-click="3">
 
-- **Projets du depot** (resultats backtestes)
-  - `MomentumStrategy` (Sharpe 0.57) -- Rotation sur 11 ETFs
-  - `DualMomentum` (Sharpe 0.35) -- Antonacci dual momentum
-  - `SectorMomentum` (Sharpe 0.62) -- Rotation sectorielle + bonds
-  - `TrendStocks-Alpha` -- Alpha model base sur le trend
+- **Projets du depot** : `SectorMomentum` (Sharpe 0.62), `MomentumStrategy` (0.57), `DualMomentum` (0.35)
 
 </div>
 ---
@@ -1351,14 +1334,7 @@ imageClass: mid-right
 
 - **Utilisation Pratique**
   - Les hedge funds et les traders algorithmiques utilisent l'analyse du sentiment
-  - Pour ameliorer leurs strategies
-</div>
-<div v-click="4">
-
-- **Pratique dans le depot**
-  - Notebook : `QC-Py-17-Sentiment-Analysis.ipynb`
-  - Projet : `projects/ML-TextClassification`
-  - Pipeline complet : `QC-Py-18-ML-Features-Engineering.ipynb`
+  - Notebooks : `QC-Py-17-Sentiment-Analysis.ipynb`, `QC-Py-18-ML-Features-Engineering.ipynb`
 
 </div>
 ---
@@ -2736,17 +2712,9 @@ layout: section
 | **Deep Learning** | QC-Py-22 a 25 | LSTM, Transformers, Autoencoders, RL |
 | **Avance** | QC-Py-26 a 28 | LLM Trading, Production, Regime Detection |
 
-**57 projets de strategies** dans `QuantConnect/projects/`
-- Strategies classiques : EMA-Cross, MeanReversion, DualMomentum, PairsTrading
-- ML : ML-RandomForest, ML-SVM, ML-XGBoost, ML-Ensemble, DL-LSTM
-- Framework composites : 4 strategies combinees (Trend, FamaFrench, Momentum, Weather)
-- Crypto : BTC-MACD-ADX, EMA-Cross-Crypto, Crypto-LSTM-Prediction
+**57 projets de strategies** dans `QuantConnect/projects/` : classiques (EMA, MeanReversion), ML (RandomForest, XGBoost, LSTM), Framework composites, Crypto (BTC-MACD-ADX)
 
-**Autres notebooks pertinents**
-- Optimisation de portefeuille : `Search/Portfolio_Optimization_GeneticSharp.ipynb`
-- Algorithmes genetiques : `Search/Search-5-GeneticAlgorithms.ipynb`
-- Metaheuristiques : `Search/Search-11-Metaheuristics.ipynb`
-- Theorie de la decision : `Probas/Infer-14` a `Infer-20` (utilite, risque, decisions sequentielles)
+**Voir aussi** : `Search/` (optimisation, genetiques), `Probas/Infer-14` a `Infer-20` (decision sous incertitude)
 
 ---
 
@@ -2765,17 +2733,15 @@ layout: section
 <div v-click="2">
 
 - **La pratique avec Lean/QuantConnect**
-  - 28 notebooks progressifs (`QC-Py-01` a `QC-Py-28`)
-  - 57 projets de strategies prets a backtester
-  - 4 strategies composites Framework pour apprendre l'architecture
+  - 28 notebooks progressifs, 57 projets prets a backtester
+  - Commencez par `QC-Py-01-Setup.ipynb` puis explorez `projects/EMA-Cross-Stocks`
 </div>
 <div v-click="3">
 
 - **Conseil final**
   - Commencez simple, mesurez, iterez
-  - La gestion du risque est plus importante que la generation de signaux
-  - "Il vaut mieux un Sharpe de 1.5 stable qu'un Sharpe de 3 qui explose tous les 2 ans"
-  - Commencez par `QC-Py-01-Setup.ipynb` puis explorez `projects/EMA-Cross-Stocks`
+  - La gestion du risque > la generation de signaux
+  - "Mieux vaut un Sharpe de 1.5 stable qu'un Sharpe de 3 qui explose tous les 2 ans"
 
 </div>
 ---

--- a/slides/theme-ia101/layouts/image-overlay.vue
+++ b/slides/theme-ia101/layouts/image-overlay.vue
@@ -26,47 +26,53 @@ const props = defineProps<{
 
 .overlay-content {
   width: 100%;
-}
-
-.overlay-content.has-image {
-  max-width: 65%;
+  position: relative;
+  z-index: 2;
 }
 
 .overlay-img {
   position: absolute;
-  top: 40px;
-  right: 40px;
-  max-width: 30%;
-  max-height: 45%;
+  top: 50%;
+  right: 30px;
+  transform: translateY(-50%);
+  max-width: 35%;
+  max-height: 70%;
   object-fit: contain;
   z-index: 1;
+  opacity: 0.15;
 }
 
 /* Utility classes for positioning */
 .overlay-img.top-right {
   top: 40px;
-  right: 60px;
+  transform: none;
 }
 
 .overlay-img.mid-right {
   top: 50%;
-  right: 60px;
+  right: 30px;
   transform: translateY(-50%);
 }
 
 .overlay-img.bottom-right {
-  bottom: 60px;
+  bottom: 40px;
   top: auto;
-  right: 60px;
+  right: 30px;
+  transform: none;
 }
 
 .overlay-img.small {
-  max-width: 20%;
-  max-height: 30%;
+  max-width: 25%;
+  max-height: 50%;
 }
 
 .overlay-img.large {
-  max-width: 40%;
-  max-height: 50%;
+  max-width: 45%;
+  max-height: 80%;
+}
+
+/* Higher opacity variant for images that need more visibility */
+.overlay-img.visible {
+  opacity: 0.3;
 }
 </style>


### PR DESCRIPTION
## Summary

- Fix 7 slides with content overflow (verified programmatically on all 136 slides)
- Convert image-overlay layout from right-column to true background overlay
- Add CLAUDE.md rule: mandatory visual review before merge

## Overflow Fixes

| Slide | Before | After | Fix |
|-------|--------|-------|-----|
| 11 | +49px | 0 | Remove blockquote under HFT/MFT/LFT table |
| 36 | +10px | 0 | Trim AI selection content |
| 48 | +130px | 0 | Reduce panorama to 6 rows |
| 59 | +4px | 0 | Condense momentum list |
| 64 | +17px | 0 | Merge last 2 v-clicks |
| 134 | +27px | 0 | Condense project lists |
| 135 | +48px | 0 | Condense synthese |

## Image Overlay Fix

`image-overlay.vue`: images now render as true background (opacity 0.15, z-index 1 behind text z-index 2), not right-column layout.

## Verification

- All 136 slides checked via Playwright `scrollHeight > clientHeight`
- All 14 image-overlay slides verified: opacity 0.15, imgBehindContent: true

## Test plan

- [x] All 136 slides: 0 overflow
- [x] 14 image slides: true overlay (not column)
- [x] CLAUDE.md updated with review rule

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>