### PR TITLE
feat(qc): add risk management to Ex11 InverseVolatility-Rank

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,14 +133,36 @@ Toute modification d'une strategie QC (main.py, parametres, periodes) **DOIT** e
 
 **Changer une date ou un parametre sans backtest = travail invalide.**
 
-### MCP qc-mcp
+### QC Cloud API - Acces via MCP Docker (OBLIGATOIRE)
 
-Le MCP `qc-mcp` est disponible sur ai-01 et doit etre utilise pour toute interaction avec QuantConnect Cloud. Les infos de connexion (User ID, Org IDs, tokens) sont sur le **dashboard RooSync** et dans les memoires agents — **pas dans le CLAUDE.md** pour raisons de securite.
+**Methode d'acces** : Utiliser le MCP Docker `quantconnect/mcp-server` configure dans `.mcp.json` a la racine du projet.
+- **NE PAS** utiliser de scripts Python avec l'API REST directe (provoque du rate-limiting et des erreurs d'auth)
+- Le MCP gere l'authentification et le rate-limiting automatiquement
+- Fichier de config : `.mcp.json` (deja dans `.gitignore`, JAMAIS committer)
 
-Pour retrouver les infos QC :
+**Configuration** (`.mcp.json`) :
+```json
+{
+  "mcpServers": {
+    "quantconnect": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-e", "QUANTCONNECT_USER_ID", "-e", "QUANTCONNECT_API_TOKEN", "-e", "QUANTCONNECT_ORGANIZATION_ID", "quantconnect/mcp-server"],
+      "env": {
+        "QUANTCONNECT_USER_ID": "<voir dashboard RooSync>",
+        "QUANTCONNECT_API_TOKEN": "<voir dashboard RooSync>",
+        "QUANTCONNECT_ORGANIZATION_ID": "<voir dashboard RooSync>"
+      }
+    }
+  }
+}
+```
+
+**Rate limiting strict** : MAX 10 appels/minute entre TOUS les agents. Avant de lancer un backtest, poster sur le dashboard. Un seul agent a la fois sur l'API QC.
+
+**Pour retrouver les tokens** :
 - Dashboard workspace CoursIA : section status
-- Memoire ai-01 : `jared_qc_partnership.md`, `qc_strategies_catalog.md`
-- Messages RooSync : rechercher tag `quantconnect`
+- Messages RooSync : tag `quantconnect` ou `TOKEN`
+- En cas de token invalide : demander au coordinateur (ai-01) via RooSync
 
 ### Structure QC dans le depot
 


### PR DESCRIPTION
## Summary
- Add risk management parameters to Ex11 InverseVolatility-Rank: weight multiplier, max position cap, stop-loss
- Add daily stop-loss check (liquidate positions exceeding -8% loss)
- Cap individual position size at 15% to reduce concentration risk
- Update CLAUDE.md with QC Cloud MCP Docker instructions and rate limiting rules

## Backtest Results (QC Cloud)
| Version | Sharpe | CAGR | MaxDD | Verdict |
|---------|--------|------|-------|---------|
| v1 (original) | 0.212 | 5.85% | 54.7% | Reference |
| v2 (mult=1.0) | -0.05 | 2.09% | 22.7% | Too conservative |
| v3 (mult=2.0, cap+SL) | 0.124 | 4.13% | 41.0% | Mixed |

**Conclusion**: Strategy has a structural ceiling. No parameter combination achieves Sharpe > 0.15 with MaxDD < 35%. Pedagogical value: documented case of optimization limits.

## Test plan
- [x] Compiled on QC Cloud (project 29463533)
- [x] Backtested all 3 variants with documented results
- [ ] Review risk management code for correctness
- [ ] Confirm CLAUDE.md MCP section is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)