### PR TITLE
docs: cleanup README QuantConnect pour étudiants ESGF

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/README.md
@@ -5,326 +5,256 @@ Sponsorise par Jared Broad (CEO QuantConnect) via le tier "Trading Firm".
 
 **Organisation** : Trading Firm ESGF (`94aa4bcb...`)
 **Professeur** : <email> (User ID: 46613)
-**Credit** : <solde QCC>
 
 ---
 
 ## 🎓 Inscription Étudiants
 
-### Processus d'inscription au cours ESGF
+### Processus d'inscription
 
-Pour participer au cours ESGF 2026 et bénéficier du sponsoring QuantConnect (Trading Firm tier), suivez ces étapes :
+Pour participer au cours ESGF 2026 et bénéficier du sponsoring QuantConnect (Trading Firm tier) :
 
-1. **Créer un compte QuantConnect gratuit**
-   - Allez sur [quantconnect.com](https://www.quantconnect.com)
-   - Inscrivez-vous avec votre **email scolaire** (recommandé pour identification étudiante)
-   - Validez votre adresse email
-
-2. **Envoyer votre identifiant QuantConnect au professeur**
-   - Une fois inscrit, votre compte QuantConnect a un username (ex: `john.doe`)
-   - Envoyez ce username par email au professeur : `<email>`
-   - Le professeur vous ajoutera à l'organisation ESGF sponsorisée
-
-3. **Accès à l'organisation sponsorisée**
-   - Une fois ajouté, vous verrez l'organisation "Trading Firm ESGF" dans votre compte
-   - Le code education `education2025` est appliqué automatiquement au niveau de l'organisation
-   - Vous bénéficiez du tier "Trading Firm" (plus de CPU, backtests illimités, etc.)
-
-4. **Commencer les exercices**
-   - Suivez les notebooks QC-Py-01 à QC-Py-04 (prérequis)
-   - Passez aux exercices ESGF dans `ESGF_EXERCISES.md`
-   - Utilisez les templates dans `templates/` comme point de départ
+1. **Créer un compte gratuit** sur [quantconnect.com](https://www.quantconnect.com) avec votre **email scolaire**
+2. **Envoyer votre username** au professeur : `<email>`
+3. **Attendre l'ajout** à l'organisation "Trading Firm ESGF" (code `education2025` appliqué automatiquement)
+4. **Commencer les exercices** : notebooks QC-Py-01 à QC-Py-04, puis exercices ESGF
 
 ### Workflow Cloud-First
 
-**Important** : Ce cours utilise une approche **cloud-first**. Tout le développement se fait sur QuantConnect Cloud (QC Lab), pas en local avec LEAN CLI.
+Tout le développement se fait sur **QuantConnect Cloud** (QC Lab), pas en local.
 
 - **Avantages** : Pas d'installation locale, accès aux données historiques QC, compilation instantanée
-- **Local** : Le dossier `lean-workspace/` contient un seul exemple (`Multi-Layer-EMA-Researcher`) pour illustrer le workflow local, mais les étudiants travaillent sur le cloud
-- **Projets** : Créez vos projets directement dans QuantConnect Lab, puis clonez-les localement si nécessaire pour versioning
+- **Projets** : Créez vos projets directement dans QuantConnect Lab
 
 ---
 
-## Structure
+## Templates Étudiants
 
+Les templates dans `templates/` sont des points de départ pour vos projets. Chaque niveau correspond à une difficulté croissante.
+
+### 🟢 Starter (Débutant)
+
+**Fichier** : `templates/starter/main.py`
+
+**Stratégie** : Croisement EMA sur BTCUSDT (Golden Cross / Death Cross)
+
+**Prérequis** :
+- Avoir suivi les notebooks QC-Py-01 à QC-Py-04
+- Comprendre les bases : Initialize, OnData, indicateurs
+
+**Concepts couverts** :
+- `AddCrypto` : Ajouter un actif crypto avec marche et resolution
+- `self.EMA(...)` : Créer un indicateur Moyenne Mobile Exponentielle
+- `SetWarmUp` : Préchauffer les indicateurs avant de trader
+- `SetHoldings` : Allouer un pourcentage du portefeuille
+- `Liquidate` : Vendre toute la position
+- `OnOrderEvent` : Recevoir les notifications d'execution
+
+**Modifications suggérées** :
+- Changer les périodes EMA : (5, 20), (20, 50) ou (50, 200)
+- Ajouter un filtre RSI : ne pas acheter si RSI > 70
+- Implémenter un stop-loss à -5%
+- Tester sur d'autres cryptos : ETHUSDT, SOLUSDT
+
+**Documentation complète** : [templates/starter/README.md](templates/starter/README.md)
+
+---
+
+### 🟡 Intermediate (Intermédiaire)
+
+**Fichier** : `templates/intermediate/main.py`
+
+**Stratégie** : Momentum ranking sur actions du S&P 500 avec Alpha Framework
+
+**Prérequis** :
+- Avoir suivi QC-Py-13 (Alpha Models)
+- Comprendre l'Algorithm Framework QC
+
+**Modules Alpha Framework** :
+| Module | Role | Classe |
+|--------|------|--------|
+| **AlphaModel** | Générer des signaux (Insights) | `MomentumAlphaModel` |
+| **PortfolioConstructionModel** | Convertir Insights en allocations | `EqualWeightingPortfolioConstructionModel` |
+| **RiskManagementModel** | Ajuster selon le risque | `TrailingStopRiskManagementModel(0.05)` |
+| **ExecutionModel** | Envoyer les ordres | `ImmediateExecutionModel` |
+
+**Concepts couverts** :
+- Universe Selection : filtrage dynamique via `universe.etf()`
+- Alpha Framework : les 4 modules indépendants
+- Insights : signaux avec direction, durée et confiance
+- ScheduledEvent : déclenchement mensuel
+- BrokerageModel : simulation Interactive Brokers
+
+**Modifications suggérées** :
+- Changer le lookback momentum : 60, 120 ou 252 jours
+- Ajouter un filtre RSI pour éviter les surachats
+- Filtrage sectoriel : concentrer sur certains secteurs
+- Changer le modèle de construction : InsightWeighting, MeanVariance, RiskParity
+
+**Documentation complète** : [templates/intermediate/README.md](templates/intermediate/README.md)
+
+---
+
+### 🔴 Advanced (Avancé)
+
+**Fichier** : `templates/advanced/main.py`
+
+**Stratégie** : Machine Learning (RandomForest) sur BTCUSDT
+
+**Prérequis** :
+- Avoir suivi QC-Py-18 (ML Features Engineering) et QC-Py-19 (ML Classification)
+- Connaître sklearn : RandomForestClassifier, feature engineering
+
+**Pipeline ML** :
 ```
-ESGF-2026/
-├── examples/           # 11 projets d'exemples du professeur (recuperes du cloud QC)
-│   ├── Crypto-MultiCanal/       # Detecteur hierarchique multi-canaux (Python)
-│   ├── ETF-Pairs-Trading/       # Pairs trading ETF avec co-integration (Python)
-│   ├── Sector-Momentum/         # Momentum sectoriel dual + Alpha Framework (Python)
-│   ├── Trend-Following/         # Multi-oracles MACD/RSI/Bollinger + ATR trailing (Python)
-│   ├── BTC-MachineLearning/     # ML sur BTC (RandomForest/SVC/XGBoost) (Python)
-│   ├── Multi-Layer-EMA/         # EMA crossover multi-crypto (Python)
-│   ├── Options-VGT/             # Vente de PUTs OTM sur tech (Python)
-│   ├── Option-Wheel-Strategy/   # Wheel strategy (PUT selling -> covered CALL) (Python)
-│   ├── CSharp-BTC-MACD-ADX/     # BTC MACD+ADX journalier (C#)
-│   ├── CSharp-BTC-EMA-Cross/    # EMA crossover classique BTC (C#)
-│   └── CSharp-CTG-Momentum/     # Stocks on the Move - Momentum ranking (C#)
-├── templates/          # Templates pour projets etudiants
-│   ├── starter/        # Niveau debutant
-│   ├── intermediate/   # Niveau intermediaire
-│   └── advanced/       # Niveau avance
-└── archive-2025/       # Projets etudiants 2024-2025 archives
-```
-
----
-
-## Exemples du professeur
-
-### Python - Strategies Crypto
-
-| Projet | Cloud ID | Description | Fichiers |
-|--------|----------|-------------|----------|
-| **Crypto-MultiCanal** | 22298373 | Detecteur hierarchique multi-canaux avec pivots ZigZag, canaux Macro/Meso/Micro, signaux breakout/bounce, parametres optimises par GA | main.py (54K), fix_ipynb_quotes.py, research.ipynb, research_archive.ipynb |
-| **BTC-MachineLearning** | 21047688 | ML sur BTC avec 9 features (SMA, RSI, EMA, ADX, ATR), modeles RandomForest/SVC/XGBoost persistes dans ObjectStore | main.py, main-simple.py |
-| **Multi-Layer-EMA** | 20216947 | Trading BTC/ETH/LTC avec EMA crossover, filtre RSI, trailing stop 8%, take profit 30% | main.py |
-
-### Python - Strategies Actions/ETF
-
-| Projet | Cloud ID | Description | Fichiers |
-|--------|----------|-------------|----------|
-| **ETF-Pairs-Trading** | 19865767 | Pairs trading ETF avec test de co-integration Engle-Granger, z-score, trailing stop 8% | main.py, alpha.py, portfolio.py, risk.py, universe.py, utils.py |
-| **Sector-Momentum** | 20216980 | Momentum dual sectoriel sur SPY universe (top 200), Risk Parity PCM, leverage 2x | main.py, DualMomentumAlphaModel.py, MyPcm.py, CustomImmediateExecutionModel.py, FredRate.py |
-| **Trend-Following** | 20216930 | Multi-oracles (MACD, RSI, Bollinger, EMA 50/200, ADX, OBV), detection HH/HL/LL/LH, ATR trailing stop | main.py, alpha.py (22K), trendCalculator.py, macd_oracle.py, rsi_oracle.py, bollinger_oracle.py |
-
-### Python - Strategies Options
-
-| Projet | Cloud ID | Description | Fichiers |
-|--------|----------|-------------|----------|
-| **Options-VGT** | 21113806 | Vente de PUTs OTM sur 5 valeurs tech (NVDA, ORCL, CSCO, AMD, QCOM) avec seuils OTM par action | main.py |
-| **Option-Wheel-Strategy** | 20216898 | Wheel strategy sur SPY : PUT selling -> assignment -> covered CALL, variantes cash-secured et margin | main.py + 4 variantes |
-
-### C# - Strategies
-
-| Projet | Cloud ID | Description | Fichiers |
-|--------|----------|-------------|----------|
-| **CSharp-BTC-MACD-ADX** | 19898232 | BTC MACD+ADX journalier sur Binance Cash, base du detecteur hierarchique | Main.cs, Research.ipynb |
-| **CSharp-BTC-EMA-Cross** | 19050970 | Crossover EMA 18/23 classique sur BTC, 600K USDT | Main.cs |
-| **CSharp-CTG-Momentum** | 19225388 | "Stocks on the Move" (Clenow) - Momentum ranking sur ETF OEF, indicateurs custom (AnnualizedSlope, Gap, MarketRegime), ATR position sizing | Main.cs + 4 indicateurs custom |
-
----
-
-## Strategies Researcher (org personnelle, Mars 2026)
-
-10 strategies supplementaires deployees sur le cloud QC (org personnelle `d600793e...`) pour exploration et backtesting agentique. Couvrent des classes d'actifs et concepts complementaires aux exemples ESGF.
-
-### ETF / Actions
-
-| Projet | Cloud ID | Description | Sharpe | CAGR | Max DD |
-|--------|----------|-------------|--------|------|--------|
-| **Sector-Momentum-Researcher** | 28433643 | Dual momentum SPY/TLT/GLD, composite multi-lookback, SMA200 filter | **0.554** | 13.1% | 23.0% |
-| **FamaFrench-Researcher** | 28657910 | Factor ETF rotation (VLUE/MTUM/SIZE/QUAL/USMV), risk parity weighting | **0.365** | 8.7% | 31.1% |
-| **MomentumStrategy-Researcher** | 28657837 | Rotation momentum 11 ETFs sectoriels (XLK-XLC), top 3, SMA200 filter | 0.216 | 6.5% | 29.9% |
-| **AllWeather-Researcher** | 28657833 | Portfolio Ray Dalio (SPY 30%/TLT 40%/IEF 15%/GLD 7.5%/DBC 7.5%), rebalancement trimestriel | 0.25 | 5.9% | 23.5% |
-| **MeanReversion-Researcher** | 28657904 | RSI mean reversion long-only, universe top 100, SMA200 regime filter | -0.042 | 0.7% | 46.5% |
-
-### Options
-
-| Projet | Cloud ID | Description | Sharpe | CAGR | Max DD |
-|--------|----------|-------------|--------|------|--------|
-| **OptionsIncome-Researcher** | 28657838 | Covered Call sur SPY (Minute), delta 0.30, roll a 7 jours | 0.288 | 9.6% | 4.0% |
-
-### Futures / Macro
-
-| Projet | Cloud ID | Description | Sharpe | CAGR | Max DD |
-|--------|----------|-------------|--------|------|--------|
-| **FuturesTrend-Researcher** | 28657834 | Donchian breakout E-mini S&P 500, ATR trailing stop | 0.019 | 2.1% | 31.9% |
-| **TurnOfMonth-Researcher** | 28657905 | Anomalie calendaire (J-4 a J+4), SPY+QQQ 1.5x, SMA200 filter | 0.127 | 4.8% | 23.7% |
-
-### Forex / Volatilite
-
-| Projet | Cloud ID | Description | Sharpe | CAGR | Max DD |
-|--------|----------|-------------|--------|------|--------|
-| **ForexCarry-Researcher** | 28657908 | FX momentum G7 (EURUSD, GBPUSD, etc.), SPY SMA200 risk-off | -1.80 | -0.7% | 9.5% |
-| **VIX-TermStructure-Researcher** | 28657907 | Contango/backwardation VIX via VIXY/SVXY, trailing stop 8% | -0.97 | -1.1% | 20.8% |
-
----
-
-## Concepts pedagogiques couverts
-
-### Niveau 1 - Fondations
-- **EMA Crossover** : CSharp-BTC-EMA-Cross, Multi-Layer-EMA
-- **MACD + ADX** : CSharp-BTC-MACD-ADX
-- **Options basiques** : Options-VGT
-- **Anomalie calendaire** : TurnOfMonth-Researcher (saisonnalite, EMH)
-
-### Niveau 2 - Intermediaire
-- **Alpha Framework QC** : ETF-Pairs-Trading, Sector-Momentum
-- **Multi-indicateurs** : Trend-Following (7+ indicateurs combines)
-- **Wheel Strategy** : Option-Wheel-Strategy
-- **Machine Learning** : BTC-MachineLearning
-- **Multi-Asset / Risk Parity** : AllWeather-Researcher (Ray Dalio)
-- **Momentum sectoriel** : MomentumStrategy-Researcher (rotation ETF)
-- **Factor Investing** : FamaFrench-Researcher (Fama-French via ETFs)
-- **Mean Reversion** : MeanReversion-Researcher (RSI contrarian)
-- **Covered Call** : OptionsIncome-Researcher (premium income)
-
-### Niveau 3 - Avance
-- **Detecteur hierarchique** : Crypto-MultiCanal (canaux multi-echelles, GA optimization)
-- **Indicateurs custom C#** : CSharp-CTG-Momentum (WindowIndicator, TradeBarIndicator)
-- **Co-integration** : ETF-Pairs-Trading (Engle-Granger, z-score)
-- **Volatilite** : VIX-TermStructure-Researcher (contango, structure a terme)
-- **Forex** : ForexCarry-Researcher (carry trade, UIP puzzle)
-- **Futures** : FuturesTrend-Researcher (Donchian breakout, position sizing)
-
----
-
-## Configuration MCP QuantConnect
-
-Le workspace est pilotable depuis Claude Code via le MCP `qc-mcp` :
-
-```json
-"qc-mcp": {
-  "command": "docker",
-  "args": ["run", "-i", "--rm", "--platform", "linux/amd64",
-    "-e", "QUANTCONNECT_USER_ID=46613",
-    "-e", "QUANTCONNECT_API_TOKEN=***",
-    "-e", "AGENT_NAME=claude-code-coursia",
-    "quantconnect/mcp-server"]
-}
+Données (BTCUSDT Daily)
+    → Feature Engineering (SMA, RSI, EMA ratios, returns)
+    → Entraînement RandomForest (100 arbres, max_depth=5)
+    → Prediction quotidienne (1 = long, 0 = cash)
+    → Re-entraînement mensuel automatique
 ```
 
-### Commandes utiles
+**Concepts couverts** :
+- **Feature engineering** : Transformation d'indicateurs en features ML normalisées
+- **sklearn dans QC** : RandomForestClassifier dans l'environnement QuantConnect
+- **ObjectStore** : Persistance de modèles sérialisés (pickle)
+- **Re-entraînement programme** : `Schedule.On` pour adaptation au régime de marché
+- **Overfitting** : Risques d'un modèle trop complexe
 
-```
-# Lister les projets
-list_projects
+**Modifications suggérées** :
+- Ajouter des features : ADX, ATR, Bollinger Bands, volume
+- Essayer d'autres modèles : XGBoost, SVC
+- Ajouter des positions short (nécessite Margin account)
+- Walk-forward optimization : entraîner sur N mois, tester sur mois suivant
+- Gestion du risque : stop-loss, take-profit, position sizing
 
-# Lire un fichier projet
-read_file(model: {projectId: 22298373, name: "main.py"})
-
-# Compiler un projet
-create_compile(model: {projectId: 22298373})
-
-# Lancer un backtest
-create_backtest(model: {projectId: 22298373, backtestName: "test-2026"})
-```
+**Documentation complète** : [templates/advanced/README.md](templates/advanced/README.md)
 
 ---
 
-## Notebooks d'accompagnement
+## Exemples du Professeur
 
-27 notebooks Python progressifs dans `../Python/` (QC-Py-01 a QC-Py-27) couvrant :
+Le dossier `examples/` contient 11 projets de référence illustrant différents concepts de trading.
+
+### Python - Stratégies Crypto
+
+| Projet | Cloud ID | Description |
+|--------|----------|-------------|
+| **Crypto-MultiCanal** | 22298373 | Détecteur hiérarchique multi-canaux (ZigZag Macro/Meso/Micro) |
+| **BTC-MachineLearning** | 21047688 | ML sur BTC (RandomForest/SVC/XGBoost) + ObjectStore |
+| **Multi-Layer-EMA** | 20216947 | EMA crossover multi-crypto (BTC/ETH/LTC) + filtre RSI |
+
+### Python - Stratégies Actions/ETF
+
+| Projet | Cloud ID | Description |
+|--------|----------|-------------|
+| **ETF-Pairs-Trading** | 19865767 | Pairs trading avec co-intégration Engle-Granger + z-score |
+| **Sector-Momentum** | 20216980 | Momentum dual SPY/TLT/GLD + Risk Parity PCM |
+| **Trend-Following** | 20216930 | Multi-oracles (MACD/RSI/Bollinger) + ATR trailing stop |
+
+### Python - Stratégies Options
+
+| Projet | Cloud ID | Description |
+|--------|----------|-------------|
+| **Options-VGT** | 21113806 | Vente de PUTs OTM sur 5 valeurs tech (NVDA, ORCL, CSCO, AMD, QCOM) |
+| **Option-Wheel-Strategy** | 20216898 | Wheel strategy SPY : PUT selling → assignment → covered CALL |
+
+### C# - Stratégies
+
+| Projet | Cloud ID | Description |
+|--------|----------|-------------|
+| **CSharp-BTC-MACD-ADX** | 19898232 | BTC MACD+ADX journalier sur Binance Cash |
+| **CSharp-BTC-EMA-Cross** | 19050970 | EMA crossover classique BTC (18/23) |
+| **CSharp-CTG-Momentum** | 19225388 | "Stocks on the Move" (Clenow) - Momentum ranking |
+
+---
+
+## Concepts Pédagogiques Couverts
+
+Les exemples et templates couvrent **8 classes d'actifs** et **10+ concepts de trading** :
+
+| Niveau | Concepts | Stratégies |
+|--------|----------|------------|
+| **1 - Fondations** | EMA Crossover, MACD+ADX, Options basiques, Anomalie calendaire | Multi-Layer-EMA, CSharp-BTC-EMA-Cross, Options-VGT, TurnOfMonth |
+| **2 - Intermédiaire** | Alpha Framework, Multi-indicateurs, Wheel Strategy, ML basique | ETF-Pairs-Trading, Sector-Momentum, Option-Wheel, BTC-ML |
+| **3 - Avancé** | Détecteur hiérarchique, Co-intégration, Volatilité, Forex, Futures | Crypto-MultiCanal, CSharp-CTG, ETF-Pairs, VIX-TermStructure, ForexCarry |
+
+---
+
+## Résultats de Backtest
+
+### Exemples ESGF (org ESGF)
+
+| # | Projet | Sharpe | CAGR | Max DD | Statut |
+|---|--------|--------|------|--------|--------|
+| 1 | **Option-Wheel-Strategy** | 0.524 | 12.7% | 26.4% | ✅ HEALTHY |
+| 2 | **CSharp-BTC-EMA-Cross** | 1.094 | 36.2% | 40.7% | ✅ HEALTHY |
+| 3 | **CSharp-BTC-MACD-ADX** | 1.224 | 38.1% | 48.8% | ✅ HEALTHY |
+| 4 | **Multi-Layer-EMA** | 1.891 | 120.9% | 54.4% | ✅ HEALTHY |
+| 5 | **Sector-Momentum** | 2.530 | 66.1% | 5.6% | ✅ HEALTHY |
+| 6 | **Options-VGT** | 0.892 | 25.3% | 15.6% | ✅ HEALTHY |
+| 7 | **Trend-Following** | 2.157 | 136.0% | 20.5% | ✅ HEALTHY |
+| 8 | **CSharp-CTG-Momentum** | 0.507 | 17.7% | 36.1% | ✅ HEALTHY |
+| 9 | **ETF-Pairs-Trading** | -0.759 | -3.7% | 19.8% | ❌ BROKEN |
+| 10 | **Crypto-MultiCanal** | 0 | 0% | 0% | ❌ BROKEN |
+| 11 | **BTC-MachineLearning** | — | — | — | ⏳ NO_DATA |
+
+**Légende** :
+- ✅ HEALTHY : Sharpe > 0.5 (stratégie robuste)
+- ⚠️ NEEDS_IMPROVEMENT : Sharpe 0-0.5 (à améliorer)
+- ❌ BROKEN : Sharpe < 0 ou 0 trades (problème majeur)
+
+---
+
+## Parcours Recommandé
+
+### Pour les débutants
+
+1. **Notebooks de fondations** : QC-Py-01 à QC-Py-04 (~4.5h)
+2. **Template Starter** : Comprendre et modifier `templates/starter/main.py`
+3. **Premier projet personnel** : Adapter le template avec vos idées
+4. **Itération** : Backtester, analyser les résultats, améliorer
+
+### Pour les intermédiaires
+
+1. **Notebooks Alpha Framework** : QC-Py-13 à QC-Py-15 (~4h)
+2. **Template Intermediate** : Étudier `templates/intermediate/main.py`
+3. **Projets exemples** : Analyser `Sector-Momentum`, `ETF-Pairs-Trading`
+3. **Projet personnel** : Créer votre propre stratégie avec Alpha Framework
+
+### Pour les avancés
+
+1. **Notebooks ML** : QC-Py-18 à QC-Py-21 (~4h)
+2. **Template Advanced** : Étudier `templates/advanced/main.py`
+3. **Projets ML** : Analyser `BTC-MachineLearning`, `Sector-ML-Classification`
+4. **Recherche avancée** : Features engineering, hyperparameter tuning, walk-forward
+
+---
+
+## Notebooks d'Accompagnement
+
+27 notebooks Python progressifs dans `../Python/` (QC-Py-01 à QC-Py-27) :
 
 1. **Setup** : Compte, IDE, premier algorithme
 2. **Fondations** : API, Resolution, Consolidators, QuantBook
-3. **Indicateurs** : MACD, RSI, Bollinger, EMA, Stochastique
-4. **Strategies** : Mean Reversion, Momentum, Pairs Trading, Options
-5. **Framework** : Alpha, Portfolio Construction, Risk, Execution, Universe
-6. **ML/AI** : Features, modeles, ObjectStore, RL, NLP
-7. **Production** : Paper trading, live, monitoring, multi-asset
-8. **Competition** : Quant League / Strategies
+3. **Indicateurs** : MACD, RSI, Bollinger, EMA
+4. **Stratégies** : Mean Reversion, Momentum, Pairs Trading, Options
+5. **Framework** : Alpha, Portfolio Construction, Risk, Execution
+6. **ML/AI** : Features, modèles, ObjectStore, RL, NLP
+7. **Production** : Paper trading, live, monitoring
 
 ---
 
-## Resultats de Backtest
+## Documentation
 
-### Exemples ESGF (org ESGF, Fevrier 2026)
-
-Compilation : **11/11 projets compilent avec succes** (0 erreurs, warnings non-bloquants uniquement).
-
-| # | Projet | Periode | Return | CAGR | Sharpe | Max DD | Trades | Win Rate | Statut |
-|---|--------|---------|--------|------|--------|--------|--------|----------|--------|
-| 1 | **Option-Wheel-Strategy** | 2015-01 / 2026-03 | +12.7% | 12.7% | 0.524 | 26.4% | — | — | HEALTHY |
-| 2 | **CSharp-BTC-EMA-Cross** | 2021-10 / 2024-12 | +166.7% | 36.2% | 1.094 | 40.7% | 7 | 67% | HEALTHY |
-| 3 | **CSharp-BTC-MACD-ADX** | 2013-04 / 2024-12 | +4239.2% | 38.1% | 1.224 | 48.8% | 19 | 78% | HEALTHY |
-| 4 | **Multi-Layer-EMA** | 2020-01 / 2024-01 | +2292.2% | 120.9% | 1.891 | 54.4% | 663 | 37% | HEALTHY |
-| 5 | **Sector-Momentum** | 2024-01 / 2024-07 | +32.2% | 66.1% | 2.530 | 5.6% | 1300 | 60% | HEALTHY |
-| 6 | **Options-VGT** | 2023-12 / 2025-01 | +28.3% | 25.3% | 0.892 | 15.6% | 25 | 71% | HEALTHY |
-| 7 | **Trend-Following** | 2020-06 / 2020-09 | +24.5% | 136.0% | 2.157 | 20.5% | 809 | 68% | HEALTHY |
-| 8 | **CSharp-CTG-Momentum** | 2021-01 / 2024-11 | +87.3% | 17.7% | 0.507 | 36.1% | 170 | 64% | HEALTHY |
-| 9 | **ETF-Pairs-Trading** | 2020-01 / 2024-03 | -14.6% | -3.7% | -0.759 | 19.8% | 304 | 50% | BROKEN |
-| 10 | **Crypto-MultiCanal** | 2024-01 / 2025-01 | 0% | 0% | 0 | 0% | 0 | 0% | BROKEN |
-| 11 | **BTC-MachineLearning** | -- | -- | -- | -- | -- | 0 | -- | NO_DATA |
-
-### Strategies Researcher (org personnelle, Mars 2026)
-
-Compilation : **10/10 projets compilent avec succes**.
-
-| # | Projet | Periode | Return | CAGR | Sharpe | Max DD | Trades | Win Rate | Statut |
-|---|--------|---------|--------|------|--------|--------|--------|----------|--------|
-| 1 | **Sector-Momentum-Researcher** | 2015-01 / 2026-03 | +102.7% | 13.1% | **0.554** | 23.0% | ~120 | 67% | HEALTHY |
-| 2 | **FamaFrench-Researcher** | 2015-01 / 2026-03 | +153.5% | 8.7% | **0.365** | 31.1% | 453 | 74% | NEEDS_IMPROVEMENT |
-| 3 | **OptionsIncome-Researcher** | 2024-01 / 2024-12 | +9.6% | 9.6% | 0.288 | 4.0% | 48 | 43% | NEEDS_IMPROVEMENT |
-| 4 | **AllWeather-Researcher** | 2015-01 / 2026-03 | +86.8% | 5.9% | 0.25 | 23.5% | ~150 | 65% | NEEDS_IMPROVEMENT |
-| 5 | **MomentumStrategy-Researcher** | 2015-01 / 2026-03 | +102.7% | 6.5% | 0.216 | 29.9% | 437 | 67% | NEEDS_IMPROVEMENT |
-| 6 | **TurnOfMonth-Researcher** | 2015-01 / 2026-03 | +66.3% | 4.8% | 0.127 | 23.7% | ~250 | 52% | NEEDS_IMPROVEMENT |
-| 7 | **FuturesTrend-Researcher** | 2020-01 / 2026-03 | +13.4% | 2.1% | 0.019 | 31.9% | ~80 | 50% | NEEDS_IMPROVEMENT |
-| 8 | **MeanReversion-Researcher** | 2018-01 / 2026-03 | +6.3% | 0.7% | -0.042 | 46.5% | ~800 | 55% | BROKEN |
-| 9 | **VIX-TermStructure-Researcher** | 2018-01 / 2026-03 | -8.9% | -1.1% | -0.97 | 20.8% | ~60 | 40% | BROKEN |
-| 10 | **ForexCarry-Researcher** | 2018-01 / 2026-03 | -5.3% | -0.7% | -1.80 | 9.5% | ~300 | 45% | BROKEN |
-
-**Legende** : HEALTHY (Sharpe > 0.5) | NEEDS_IMPROVEMENT (Sharpe 0-0.5) | BROKEN (Sharpe < 0 ou 0 trades) | NO_DATA (pas de backtest)
-
-**Bilan** : 9/21 strategies HEALTHY ou NEEDS_IMPROVEMENT avec Sharpe positif. Les strategies Forex et VIX sont les plus difficiles a rendre rentables (classes d'actifs complexes). Les strategies ETF sectorielles et multi-asset sont les plus robustes.
-
-### Ameliorations appliquees
-
-**Phase 3 (Fevrier 2026) - Exemples ESGF :**
-
-| Projet | Amelioration | Commit |
-|--------|-------------|--------|
-| **Multi-Layer-EMA** | Filtre Bollinger band, RSI resserre (35-70), sortie death cross + RSI>75 | c2b9cb3 |
-| **ETF-Pairs-Trading** | Remplacement `arch` par `statsmodels.tsa.stattools.coint`, hedge ratio OLS numpy | c2b9cb3 |
-| **BTC-MachineLearning** | Entrainement RandomForest in-situ si modele ObjectStore absent | c2b9cb3 |
-| **Trend-Following** | Fix `self.algo = self` -> `self.algo = algo` dans alpha.py | 801afdb |
-| **ETF-Pairs-Trading** | Ajout `Schedule.On` pour `RebalancePairs` | 801afdb |
-| **Options-VGT** | Reecriture logique multi-equity (local only, projet etudiant) | 801afdb |
-| **Crypto-MultiCanal** | Ajout `import traceback`, lookback 1000->500, fix CalculateOrderQuantity | en cours |
-
-**Phase 4 (Mars 2026) - Strategies Researcher :**
-
-| Projet | Iterations | Ameliorations cles |
-|--------|-----------|-------------------|
-| **Sector-Momentum** | v1 -> v2 | Passage 2 assets -> 3 (SPY/TLT/GLD), multi-lookback composite, SMA200 filter. Sharpe 0.197 -> 0.554 |
-| **VIX-TermStructure** | v1 -> v2 | Ajout trailing stop 8%, VIX SMA regime filter, reduction SVXY 50% -> 30%. Perte -49.7% -> -8.9% |
-| **ForexCarry** | v1 -> v2 | Passage carry trade -> FX pure momentum, SPY SMA200 risk-off filter. Perte -16.2% -> -5.3% |
-| **TurnOfMonth** | v1 -> v2 | Ajout QQQ, leverage 1.5x, SMA200 filter. Sharpe -0.243 -> +0.127 |
-| **MeanReversion** | v1 -> v2 | Passage long/short -> long-only, SMA200 regime filter. Return -45.4% -> +6.3% |
-| **MomentumStrategy** | v1 -> v2 | Remplacement Universe Selection (trop lent) par 11 ETFs sectoriels fixes |
-| **FamaFrench** | v1 -> v2 | Remplacement Universe Selection par 5 ETFs factoriels (VLUE/MTUM/SIZE/QUAL/USMV) |
-| **OptionsIncome** | v1 -> v4 | Resolution Daily -> Minute (options chain vide en Daily), periode raccourcie 1 an |
-
-### Notes sur les projets BROKEN
-
-- **ETF-Pairs-Trading** (ESGF) : Return negatif (-14.6%). Remplacement `arch` par `statsmodels` effectue, nouveau backtest necessaire.
-- **Crypto-MultiCanal** (ESGF) : Runtime error (0 trades). Corrections critiques en cours.
-- **BTC-MachineLearning** (ESGF) : Aucun backtest existant. Entrainement in-situ ajoute.
-- **MeanReversion-Researcher** : Sharpe legerement negatif (-0.042) malgre return positif (+6.3%). Necessite affinage des seuils RSI.
-- **VIX-TermStructure-Researcher** : Classe d'actif difficile (tail risk). Ameliore de -49.7% a -8.9% mais reste negatif.
-- **ForexCarry-Researcher** : FX momentum faible sur la periode. Classe d'actif peu directionnelle.
+- **[GETTING-STARTED.md](../GETTING-STARTED.md)** : Guide de démarrage détaillé
+- **[ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)** : Guide pour étudiants ECE
+- **[projects/README.md](../projects/README.md)** : Catalogue de 67 stratégies
 
 ---
 
-## Mapping pedagogique complet (21 strategies)
+## Ressources
 
-| Concept | Strategies | Niveau | Classes d'actifs |
-|---------|-----------|--------|-----------------|
-| **EMA Crossover** | CSharp-BTC-EMA-Cross, Multi-Layer-EMA | 1 | Crypto |
-| **MACD + ADX** | CSharp-BTC-MACD-ADX | 1 | Crypto |
-| **Options basiques** | Options-VGT | 1 | Actions |
-| **Anomalie calendaire** | TurnOfMonth-Researcher | 1 | ETF |
-| **Multi-Asset** | AllWeather-Researcher (3 variantes) | 1-2 | Multi |
-| **Momentum sectoriel** | MomentumStrategy-Researcher, Sector-Momentum, CSharp-CTG | 1-2 | ETF/Actions |
-| **Mean Reversion** | MeanReversion-Researcher, ETF-Pairs-Trading | 1-2 | Actions/ETF |
-| **Trend Following** | FuturesTrend-Researcher, Trend-Following | 2 | Futures/Actions |
-| **Wheel Strategy** | Option-Wheel-Strategy, OptionsIncome-Researcher | 2 | Options |
-| **Factor Investing** | FamaFrench-Researcher (Fama-French via ETFs) | 2-3 | ETF |
-| **Machine Learning** | BTC-MachineLearning | 3 | Crypto |
-| **Volatilite** | VIX-TermStructure-Researcher | 3 | Volatilite |
-| **Forex** | ForexCarry-Researcher | 3 | FX |
-| **Detecteur hierarchique** | Crypto-MultiCanal | 3 | Crypto |
-| **Indicateurs custom** | CSharp-CTG-Momentum | 3 | Actions |
-
-**Couverture** : 8 classes d'actifs (Actions, ETF, Crypto, Options, Futures, FX, Volatilite, Multi-Asset), 10+ concepts de trading.
-
----
-
-## Notes pour 2026
-
-- La **Quant League** classique est terminee (Q4-2025)
-- Transition vers le format **"Strategies"** en 2026
-- A confirmer avec Jared Broad lors du prochain echange
-- Les etudiants devront participer au format competitif QC en echange du sponsoring
-- **21 strategies** disponibles (11 ESGF + 10 Researcher) couvrant tous les niveaux
+- [Documentation QuantConnect](https://www.quantconnect.com/docs)
+- [Hands-On AI Trading Book](https://www.hands-on-ai-trading.com)
+- [GitHub du livre](https://github.com/QuantConnect/HandsOnAITradingBook)

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -1,223 +1,301 @@
 # QuantConnect AI Trading - Série Éducative CoursIA
 
 > **Trading algorithmique + Intelligence Artificielle**
-> 27 notebooks Python | C# planifié | Cloud-first | Free Tier compatible
+> 27 notebooks Python | Cloud-first | Free Tier compatible
+
+---
+
+## Pour Commencer (4 étapes)
+
+1. **Créer un compte gratuit** : [https://www.quantconnect.com/signup](https://www.quantconnect.com/signup)
+2. **Créer un projet Python** dans QC Lab (File > New Project)
+3. **Copier un `main.py`** depuis `projects/` (ex: `EMA-Cross-Stocks/`) dans votre projet
+4. **Cliquer Backtest** pour exécuter
+
+**Temps estimé** : 5-10 minutes
+
+> **Note** : Les notebooks QC-Py-XX sont des supports de cours à lire sur GitHub, pas à uploader dans QC Lab.
 
 ---
 
 ## Vue d'Ensemble
 
-La série QuantConnect AI Trading est une formation complète sur le trading algorithmique avec la plateforme **QuantConnect LEAN**, inspirée du livre **"Hands-On AI Trading"** (2025) coécrit par Jared Broad (CEO QuantConnect).
+Cette série est une formation complète sur le **trading algorithmique** avec la plateforme **QuantConnect LEAN**, inspirée du livre *"Hands-On AI Trading"* (2025).
 
 ### Objectifs
 
-- **Pédagogique** : Progression structurée de débutant à expert (30h de contenu par langage)
-- **IA-first** : Focus important sur ML/DL/RL/LLM pour stratégies de trading (9 notebooks dédiés)
+- **Pédagogique** : Progression de débutant à expert (30h de contenu)
+- **IA-first** : Focus important sur ML/DL/RL/LLM pour stratégies de trading
 - **Cloud-native** : Exécution principale sur QuantConnect cloud (free tier)
-
-  - **QuantBook** : Notebooks de recherche en QuantConnect Lab
- - **LEAN CLI** : Option locale avec Docker
-
-  - **Approche hybride** : Les notebooks contiennent du code à deux destinations:
-    1. **Algorithm code** : Copier dans QuantConnect Lab (main.py) pour backtests/production
-    2. **Research code** : Exécuter dans QuantBook pour exploration
-- **Dual-language** : Python (27 notebooks), C# planifié en parallèle
 - **Production-ready** : De la recherche au déploiement live
 
-### Caractéristiques
+### Contenu
 
-- **27 notebooks Python** (C# planifié pour le futur)
-- **18 notebooks sur fondations** (Universe, Asset Classes, Risk, Framework) avant ML
+- **27 notebooks Python** organisés en 8 phases
+- **18 notebooks sur fondations** avant ML (Universe, Asset Classes, Risk, Framework)
 - **9 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM)
-- **Approche cloud-first** avec option locale Docker + LEAN CLI
 - **Free tier compatible** avec workarounds pour fonctionnalités payantes
-- **Intégration MCP** pour automatisation avec Claude Code
-
----
-
-## Démarrage Rapide
-
-**Pour commencer immédiatement**, consultez le guide : [**GETTING-STARTED.md**](GETTING-STARTED.md)
-
-**Resume en 4 etapes** :
-
-1. Creer un compte gratuit : [https://www.quantconnect.com/signup](https://www.quantconnect.com/signup)
-2. Creer un projet Python dans QC Lab (File > New Project)
-3. Copier un `main.py` depuis `projects/` (ex: `EMA-Cross-Alpha`) dans votre projet
-4. Cliquer **Backtest** pour executer
-
-**Les notebooks QC-Py-XX sont des supports de cours** a lire sur GitHub, pas a uploader dans QC Lab.
-
-**Etudiants ECE Projet 2** : Consultez [ECE-QC-QUICKSTART.md](ECE-QC-QUICKSTART.md) pour le mapping sujets H.1-H.6.
-
-**Temps estime** : 5-10 minutes
 
 ---
 
 ## Structure de la Série
 
-### Phase 1 : Fondations LEAN (4 notebooks, ~4.5h par langage)
+### Phase 1 : Fondations LEAN (4 notebooks, ~4.5h)
 
 Maîtriser les bases de QuantConnect : architecture, lifecycle d'algorithme, gestion des données, workflow de recherche.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 01 | [QC-Py-01-Setup](Python/QC-Py-01-Setup.ipynb) | QC-CS-01-Setup *(à venir)* | 45 min | Compte QC, premier backtest cloud, option LEAN CLI local, architecture LEAN |
-| 02 | [QC-Py-02-Platform-Fundamentals](Python/QC-Py-02-Platform-Fundamentals.ipynb) | QC-CS-02-Platform-Fundamentals *(à venir)* | 60 min | QCAlgorithm lifecycle, Initialize/OnData, securities, Moving Average Crossover |
-| 03 | [QC-Py-03-Data-Management](Python/QC-Py-03-Data-Management.ipynb) | QC-CS-03-Data-Management *(à venir)* | 75 min | History API, data normalization, consolidators, multi-timeframe analysis |
-| 04 | [QC-Py-04-Research-Workflow](Python/QC-Py-04-Research-Workflow.ipynb) | QC-CS-04-Research-Workflow *(à venir)* | 75 min | QuantBook, pandas/DataFrame integration, notebook→algorithm transition |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 01 | [QC-Py-01-Setup](Python/QC-Py-01-Setup.ipynb) | 45 min | Compte QC, premier backtest cloud, architecture LEAN |
+| 02 | [QC-Py-02-Platform-Fundamentals](Python/QC-Py-02-Platform-Fundamentals.ipynb) | 60 min | QCAlgorithm lifecycle, Initialize/OnData, Moving Average Crossover |
+| 03 | [QC-Py-03-Data-Management](Python/QC-Py-03-Data-Management.ipynb) | 75 min | History API, data normalization, consolidators, multi-timeframe |
+| 04 | [QC-Py-04-Research-Workflow](Python/QC-Py-04-Research-Workflow.ipynb) | 75 min | QuantBook, pandas integration, notebook→algorithm transition |
 
-**Objectifs** : Créer compte gratuit, maîtriser cycle de vie algorithme, gestion des données, outils de recherche.
+**Objectifs** : Créer compte gratuit, maîtriser cycle de vie algorithme, gestion des données.
 
 ---
 
-### Phase 2 : Universe et Asset Classes (4 notebooks, ~5h par langage)
+### Phase 2 : Universe et Asset Classes (4 notebooks, ~5h)
 
 Sélection dynamique d'univers, comprendre les particularités de chaque classe d'actifs (Equities, Options, Futures, Forex).
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 05 | [QC-Py-05-Universe-Selection](Python/QC-Py-05-Universe-Selection.ipynb) | QC-CS-05-Universe-Selection *(à venir)* | 75 min | Manual universe, coarse/fine selection, dynamic rebalancing, filters (dollar volume, fundamentals) |
-| 06 | [QC-Py-06-Options-Trading](Python/QC-Py-06-Options-Trading.ipynb) | QC-CS-06-Options-Trading *(à venir)* | 75 min | Options chains, Greeks, covered calls, protective puts, iron condors |
-| 07 | [QC-Py-07-Futures-Forex](Python/QC-Py-07-Futures-Forex.ipynb) | QC-CS-07-Futures-Forex *(à venir)* | 75 min | Futures contracts, rollover, Forex pairs, leverage management |
-| 08 | [QC-Py-08-Multi-Asset-Strategies](Python/QC-Py-08-Multi-Asset-Strategies.ipynb) | QC-CS-08-Multi-Asset-Strategies *(à venir)* | 75 min | Portfolio avec Equity + Options + Futures, corrélations, hedging |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 05 | [QC-Py-05-Universe-Selection](Python/QC-Py-05-Universe-Selection.ipynb) | 75 min | Manual universe, coarse/fine selection, dynamic rebalancing |
+| 06 | [QC-Py-06-Options-Trading](Python/QC-Py-06-Options-Trading.ipynb) | 75 min | Options chains, Greeks, covered calls, protective puts |
+| 07 | [QC-Py-07-Futures-Forex](Python/QC-Py-07-Futures-Forex.ipynb) | 75 min | Futures contracts, rollover, Forex pairs, leverage |
+| 08 | [QC-Py-08-Multi-Asset-Strategies](Python/QC-Py-08-Multi-Asset-Strategies.ipynb) | 75 min | Portfolio Equity + Options + Futures, corrélations |
 
-**Objectifs** : Maîtriser sélection dynamique d'univers, comprendre les particularités de chaque classe d'actifs.
+**Objectifs** : Maîtriser sélection dynamique d'univers, comprendre chaque classe d'actifs.
 
 ---
 
-### Phase 3 : Trading Avancé et Risk Management (4 notebooks, ~5.5h par langage)
+### Phase 3 : Trading Avancé et Risk Management (4 notebooks, ~5.5h)
 
 Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie de backtests.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 09 | [QC-Py-09-Order-Types](Python/QC-Py-09-Order-Types.ipynb) | QC-CS-09-Order-Types *(à venir)* | 75 min | Market, Limit, Stop, Stop-Limit, MOO/MOC, combo orders, order management |
-| 10 | [QC-Py-10-Risk-Portfolio-Management](Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | QC-CS-10-Risk-Portfolio-Management *(à venir)* | 90 min | Position sizing (Kelly, fixed fractional), stop-loss, take-profit, portfolio heat |
-| 11 | [QC-Py-11-Technical-Indicators](Python/QC-Py-11-Technical-Indicators.ipynb) | QC-CS-11-Technical-Indicators *(à venir)* | 75 min | Indicateurs intégrés, custom indicators, rolling windows, signal generation |
-| 12 | [QC-Py-12-Backtesting-Analysis](Python/QC-Py-12-Backtesting-Analysis.ipynb) | QC-CS-12-Backtesting-Analysis *(à venir)* | 75 min | Performance metrics (Sharpe, Sortino, max drawdown), equity curve analysis, insights |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 09 | [QC-Py-09-Order-Types](Python/QC-Py-09-Order-Types.ipynb) | 75 min | Market, Limit, Stop, Stop-Limit, combo orders |
+| 10 | [QC-Py-10-Risk-Portfolio-Management](Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | 90 min | Position sizing (Kelly, fixed fractional), stop-loss, take-profit |
+| 11 | [QC-Py-11-Technical-Indicators](Python/QC-Py-11-Technical-Indicators.ipynb) | 75 min | Indicateurs intégrés, custom indicators, signal generation |
+| 12 | [QC-Py-12-Backtesting-Analysis](Python/QC-Py-12-Backtesting-Analysis.ipynb) | 75 min | Performance metrics (Sharpe, Sortino, max drawdown), equity curve |
 
-**Objectifs** : Maîtriser gestion du risque, ordres avancés, analyse approfondie de backtests.
+**Objectifs** : Maîtriser gestion du risque, ordres avancés, analyse de backtests.
 
 ---
 
-### Phase 4 : Algorithm Framework (3 notebooks, ~4h par langage)
+### Phase 4 : Algorithm Framework (3 notebooks, ~4h)
 
 Architecture modulaire QuantConnect pour stratégies scalables (Alpha, Portfolio Construction, Execution, Risk).
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 13 | [QC-Py-13-Alpha-Models](Python/QC-Py-13-Alpha-Models.ipynb) | QC-CS-13-Alpha-Models *(à venir)* | 75 min | Algorithm Framework intro, Alpha models (manual, technical, fundamental), insights |
-| 14 | [QC-Py-14-Portfolio-Construction-Execution](Python/QC-Py-14-Portfolio-Construction-Execution.ipynb) | QC-CS-14-Portfolio-Construction-Execution *(à venir)* | 90 min | Portfolio construction models (equal weighting, mean-variance), execution models, risk models |
-| 15 | [QC-Py-15-Parameter-Optimization](Python/QC-Py-15-Parameter-Optimization.ipynb) | QC-CS-15-Parameter-Optimization *(à venir)* | 75 min | Parameter sets, optimization targets (Sharpe, return), genetic algorithms, overfitting prevention |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 13 | [QC-Py-13-Alpha-Models](Python/QC-Py-13-Alpha-Models.ipynb) | 75 min | Algorithm Framework intro, Alpha models, insights |
+| 14 | [QC-Py-14-Portfolio-Construction-Execution](Python/QC-Py-14-Portfolio-Construction-Execution.ipynb) | 90 min | Portfolio construction models, execution models, risk models |
+| 15 | [QC-Py-15-Parameter-Optimization](Python/QC-Py-15-Parameter-Optimization.ipynb) | 75 min | Parameter sets, optimization targets, overfitting prevention |
 
-**Alignement QuantConnect** : [Algorithm Framework Documentation](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework/overview)
-
-**Objectifs** : Maîtriser architecture modulaire QuantConnect, optimisation systématique de paramètres.
+**Objectifs** : Maîtriser architecture modulaire, optimisation systématique.
 
 ---
 
-### Phase 5 : Alternative Data et Préparation ML (3 notebooks, ~4h par langage)
+### Phase 5 : Alternative Data et Préparation ML (3 notebooks, ~4h)
 
 Intégrer données alternatives (news, sentiment, fundamentals), préparer datasets pour Machine Learning.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 16 | [QC-Py-16-Alternative-Data](Python/QC-Py-16-Alternative-Data.ipynb) | QC-CS-16-Alternative-Data *(à venir)* | 75 min | NewsAPI (gratuit), fundamentals (P/E, EPS), custom data sources, event-driven strategies |
-| 17 | [QC-Py-17-Sentiment-Analysis](Python/QC-Py-17-Sentiment-Analysis.ipynb) | QC-CS-17-Sentiment-Analysis *(à venir)* | 75 min | Sentiment scoring (TextBlob, VADER), news aggregation, sentiment-driven signals |
-| 18 | [QC-Py-18-ML-Features-Engineering](Python/QC-Py-18-ML-Features-Engineering.ipynb) | QC-CS-18-ML-Features-Engineering *(à venir)* | 90 min | Feature extraction (technical, fundamental, sentiment), labeling, train/test split, feature importance |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 16 | [QC-Py-16-Alternative-Data](Python/QC-Py-16-Alternative-Data.ipynb) | 75 min | NewsAPI (gratuit), fundamentals, custom data sources |
+| 17 | [QC-Py-17-Sentiment-Analysis](Python/QC-Py-17-Sentiment-Analysis.ipynb) | 75 min | Sentiment scoring (TextBlob, VADER), news aggregation |
+| 18 | [QC-Py-18-ML-Features-Engineering](Python/QC-Py-18-ML-Features-Engineering.ipynb) | 90 min | Feature extraction, labeling, train/test split, feature importance |
 
-**Alignement livre** : Chapitres 3-4 (Data Preparation, Feature Engineering), Chapitre 8 (Sentiment Analysis)
-
-**Objectifs** : Intégrer données alternatives, préparer datasets pour ML avec features engineering.
+**Objectifs** : Intégrer données alternatives, préparer datasets pour ML.
 
 ---
 
-### Phase 6 : Machine Learning Traditionnel (3 notebooks, ~4h par langage)
+### Phase 6 : Machine Learning Traditionnel (3 notebooks, ~4h)
 
-Appliquer ML classique au trading : classification directionnelle, régression pour prédiction de prix, optimisation de portfolio ML-enhanced.
+Appliquer ML classique au trading : classification directionnelle, régression pour prédiction de prix.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 19 | [QC-Py-19-ML-Supervised-Classification](Python/QC-Py-19-ML-Supervised-Classification.ipynb) | QC-CS-19-ML-Supervised-Classification *(à venir)* | 75 min | Random Forest, XGBoost, direction prediction (up/down), walk-forward validation, ObjectStore persistence |
-| 20 | [QC-Py-20-ML-Regression-Prediction](Python/QC-Py-20-ML-Regression-Prediction.ipynb) | QC-CS-20-ML-Regression-Prediction *(à venir)* | 75 min | Linear regression, SVR, price target prediction, backtesting ML signals |
-| 21 | [QC-Py-21-Portfolio-Optimization-ML](Python/QC-Py-21-Portfolio-Optimization-ML.ipynb) | QC-CS-21-Portfolio-Optimization-ML *(à venir)* | 90 min | ML-enhanced Markowitz, covariance estimation via ML, risk-adjusted allocation |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 19 | [QC-Py-19-ML-Supervised-Classification](Python/QC-Py-19-ML-Supervised-Classification.ipynb) | 75 min | Random Forest, XGBoost, direction prediction, walk-forward |
+| 20 | [QC-Py-20-ML-Regression-Prediction](Python/QC-Py-20-ML-Regression-Prediction.ipynb) | 75 min | Linear regression, SVR, price target prediction |
+| 21 | [QC-Py-21-Portfolio-Optimization-ML](Python/QC-Py-21-Portfolio-Optimization-ML.ipynb) | 90 min | ML-enhanced Markowitz, covariance estimation via ML |
 
-**Alignement livre** : Chapitres 5-7 (Supervised Learning, Random Forests, XGBoost), Chapitre 12 (Portfolio Optimization)
-
-**Objectifs** : Appliquer ML classique au trading, persistence modèles avec ObjectStore, validation robuste.
+**Objectifs** : Appliquer ML classique au trading, persistence modèles avec ObjectStore.
 
 ---
 
-### Phase 7 : Deep Learning (3 notebooks, ~4.5h par langage)
+### Phase 7 : Deep Learning (3 notebooks, ~4.5h)
 
-Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders. Design CPU-first avec GPU optionnel.
+Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 22 | [QC-Py-22-Deep-Learning-LSTM](Python/QC-Py-22-Deep-Learning-LSTM.ipynb) | QC-CS-22-Deep-Learning-LSTM *(à venir)* | 90 min | LSTM time series, TensorFlow/Keras (Python), TensorFlow.NET (C#), CPU-first, sequence prediction |
-| 23 | [QC-Py-23-Attention-Transformers](Python/QC-Py-23-Attention-Transformers.ipynb) | QC-CS-23-Attention-Transformers *(à venir)* | 90 min | Transformer architecture, multi-head attention, temporal fusion, GPU optionnel |
-| 24 | [QC-Py-24-Autoencoders-Anomaly](Python/QC-Py-24-Autoencoders-Anomaly.ipynb) | QC-CS-24-Autoencoders-Anomaly *(à venir)* | 75 min | Autoencoders pour détection anomalies, regime change detection, unsupervised signals |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 22 | [QC-Py-22-Deep-Learning-LSTM](Python/QC-Py-22-Deep-Learning-LSTM.ipynb) | 90 min | LSTM time series, TensorFlow/Keras, CPU-first |
+| 23 | [QC-Py-23-Attention-Transformers](Python/QC-Py-23-Attention-Transformers.ipynb) | 90 min | Transformer architecture, multi-head attention, temporal fusion |
+| 24 | [QC-Py-24-Autoencoders-Anomaly](Python/QC-Py-24-Autoencoders-Anomaly.ipynb) | 75 min | Autoencoders pour détection anomalies, regime change |
 
-**Alignement livre** : Chapitres 9-10 (LSTMs, Attention Mechanisms)
-
-**Objectifs** : Maîtriser deep learning pour séries temporelles, design CPU-optimized par défaut.
+**Objectifs** : Maîtriser deep learning pour séries temporelles, design CPU-optimized.
 
 ---
 
-### Phase 8 : IA Avancée et Production (3 notebooks, ~4.5h par langage)
+### Phase 8 : IA Avancée et Production (3 notebooks, ~4.5h)
 
 État de l'art : Reinforcement Learning, LLM pour trading signals, déploiement production.
 
-| # | Python | C# | Durée | Contenu |
-|---|--------|----|----|---------|
-| 25 | [QC-Py-25-Reinforcement-Learning](Python/QC-Py-25-Reinforcement-Learning.ipynb) | QC-CS-25-Reinforcement-Learning *(à venir)* | 90 min | PPO/DQN agents, Stable-Baselines3, Gym environment custom, reward shaping, CPU-first |
-| 26 | [QC-Py-26-LLM-Trading-Signals](Python/QC-Py-26-LLM-Trading-Signals.ipynb) | QC-CS-26-LLM-Trading-Signals *(à venir)* | 90 min | OpenAI/Anthropic API, prompt engineering pour trading, LLM+indicators hybrid, cost management |
-| 27 | [QC-Py-27-Production-Deployment](Python/QC-Py-27-Production-Deployment.ipynb) | QC-CS-27-Production-Deployment *(à venir)* | 75 min | Paper trading, live trading setup, monitoring, multi-strategy orchestration, deployment checklist |
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 25 | [QC-Py-25-Reinforcement-Learning](Python/QC-Py-25-Reinforcement-Learning.ipynb) | 90 min | PPO/DQN agents, Stable-Baselines3, Gym environment custom |
+| 26 | [QC-Py-26-LLM-Trading-Signals](Python/QC-Py-26-LLM-Trading-Signals.ipynb) | 90 min | OpenAI/Anthropic API, prompt engineering, LLM+indicators hybrid |
+| 27 | [QC-Py-27-Production-Deployment](Python/QC-Py-27-Production-Deployment.ipynb) | 75 min | Paper trading, live trading setup, monitoring, deployment |
 
-**Alignement livre** : Chapitres 11-13 (Deep RL, Portfolio RL, LLMs for Trading), Chapitre 19 (Scaling and Deployment)
-
-**Objectifs** : IA state-of-the-art pour trading, déploiement production, monitoring.
+**Objectifs** : IA state-of-the-art pour trading, déploiement production.
 
 ---
 
 ## Résumé de la Progression
 
-**Total** : **27 notebooks Python** (~30 heures de contenu), C# planifié pour le futur
+**Total** : **27 notebooks Python** (~30 heures de contenu)
 
 **Répartition** :
-- **18 notebooks non-ML** (Fondations, Universe, Asset Classes, Trading Avancé, Risk, Framework, Alternative Data) : ~18h
+- **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h
 - **9 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM) : ~12h
 
 **Progression pédagogique** : Maîtriser les fondations QuantConnect **avant** d'aborder le Machine Learning.
 
 ---
 
+## Notebooks Progressifs
+
+**Recommandé pour débuter** :
+
+1. **Phase 1** : Fondations LEAN (4.5h)
+2. **Phase 2** : Universe et Asset Classes (5h)
+3. **Phase 3** : Trading Avancé et Risk (5.5h)
+4. **Notebooks 13-15** : Algorithm Framework (4h)
+5. Premier projet : Stratégie momentum avec risk management
+
+**Intermédiaire** (40h) : Phases 4-6 complètes + ML traditionnel
+
+**Expert** (60h) : Phases 6-8 complètes + Deep dive LSTMs, Transformers, RL + déploiement
+
+---
+
+## Projets de Stratégies
+
+Le dossier [`projects/`](projects/) contient **67 stratégies de trading** prêtes à backtester.
+
+### Comment utiliser les projets
+
+1. Choisir une stratégie dans [`projects/README.md`](projects/README.md)
+2. Copier le `main.py` dans votre projet QuantConnect Lab
+3. Lancer le backtest
+4. Analyser les résultats (Sharpe, Max Drawdown, CAGR)
+
+### Exemples de stratégies populaires
+
+| Stratégie | Description | Niveau |
+|-----------|-------------|--------|
+| [EMA-Cross-Stocks](projects/EMA-Cross-Stocks/) | EMA 20/50 multi-stock (AAPL/MSFT/GOOGL/AMZN/NVDA) | Débutant |
+| [TrendStocksLite](projects/TrendStocksLite/) | EMA20/50 + SMA200 trend 15 large-caps | Intermédiaire |
+| [SectorMomentum](projects/SectorMomentum/) | Dual Momentum SPY/TLT/GLD (Antonacci) | Intermédiaire |
+| [ML-RandomForest](projects/ML-RandomForest/) | Random Forest classification multi-asset | Avancé |
+| [Option-Wheel](projects/Option-Wheel/) | Wheel strategy SPY (sell puts/calls) | Avancé |
+
+---
+
+## ESGF-2026 - Exemples de Recherche
+
+Le dossier **ESGF-2026/** contient des exemples de recherche avancée utilisés dans le cours ESGF 2026.
+
+### Structure ESGF-2026
+
+```
+ESGF-2026/
+├── examples/           # 11 projets d'exemples du professeur
+├── templates/          # Templates pour projets étudiants
+│   ├── starter/        # Niveau débutant
+│   ├── intermediate/   # Niveau intermédiaire
+│   └── advanced/       # Niveau avancé
+└── archive-2025/       # Archives historiques
+```
+
+Voir [ESGF-2026/README.md](ESGF-2026/README.md) pour le détail des exemples et templates.
+
+---
+
+## Documentation Complémentaire
+
+### Guides de démarrage
+
+- **[GETTING-STARTED.md](GETTING-STARTED.md)** : Guide de démarrage détaillé
+- **[ECE-QC-QUICKSTART.md](ECE-QC-QUICKSTART.md)** : Guide pour étudiants ECE
+- **[HANDSON_AI_TRADING_MAPPING.md](docs/HANDSON_AI_TRADING_MAPPING.md)** : Mapping avec le livre "Hands-On AI Trading"
+
+### Bibliothèques partagées
+
+Le dossier [`shared/`](shared/) contient des modules Python réutilisables :
+
+- **features.py** : Feature engineering ML
+- **indicators.py** : Custom indicators QuantConnect
+- **ml_utils.py** : ML training, persistence (ObjectStore)
+- **plotting.py** : Visualisations standardisées
+- **backtest_helpers.py** : Helpers configuration backtests
+
+### Scripts de validation
+
+| Script | Description |
+|--------|-------------|
+| `scripts/validate_qc_notebooks.py` | Validation structure notebooks |
+| `scripts/test_algorithms.py` | Automated backtest runner |
+
+---
+
+## Ressources Externes
+
+### Documentation QuantConnect
+
+- [Documentation officielle](https://www.quantconnect.com/docs)
+- [LEAN Engine GitHub](https://github.com/QuantConnect/Lean)
+- [Algorithm Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework/overview)
+
+### Livre de référence
+
+**"Hands-On AI Trading with Python, QuantConnect, and AWS"** (Janvier 2025, Wiley)
+
+- [Site officiel](https://www.hands-on-ai-trading.com)
+- [GitHub du livre](https://github.com/QuantConnect/HandsOnAITradingBook)
+- [Amazon (livre)](https://www.amazon.com/dp/1394268432)
+
+### Communauté
+
+- [QuantConnect Forum](https://www.quantconnect.com/forum)
+- [LEAN Discussions](https://github.com/QuantConnect/Lean/discussions)
+- [CoursIA Main README](../../README.md)
+
+---
+
 ## Configuration
 
-### Variables d'Environnement (`.env`)
+### Variables d'environnement (.env)
 
 Copiez `.env.example` vers `.env` et configurez :
 
 ```bash
-# Authentification QuantConnect Cloud (pour MCP et déploiement)
+# Authentification QuantConnect Cloud
 QC_API_USER_ID=your_user_id_here
 QC_API_ACCESS_TOKEN=your_access_token_here
 
-# APIs IA/ML (pour notebooks 17, 26)
-OPENAI_API_KEY=sk-...              # LLM trading signals
-ANTHROPIC_API_KEY=sk-ant-...       # Alternative LLM
-HUGGINGFACE_TOKEN=hf_...           # Téléchargement modèles
+# APIs IA/ML (optionnel, pour notebooks 17, 26)
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+HUGGINGFACE_TOKEN=hf_...
 
-# NewsAPI (FREE, pour notebook 17 - Sentiment Analysis)
-NEWSAPI_KEY=your_newsapi_key_here  # https://newsapi.org/
-
-# Local LEAN CLI (optionnel)
-LEAN_DATA_PATH=./data
-LEAN_RESULTS_PATH=./results
+# NewsAPI (gratuit, pour notebook 17)
+NEWSAPI_KEY=your_newsapi_key_here
 ```
-
-**Modèle complet** : Voir [`.env.example`](.env.example)
 
 ### Dépendances Python
 
@@ -234,10 +312,6 @@ pip install -r requirements.txt
 python -m ipykernel install --user --name=quantconnect --display-name "Python (QuantConnect)"
 ```
 
-**Dépendances principales** : QuantConnect LEAN, pandas, numpy, scikit-learn, TensorFlow, PyTorch (optionnel), Stable-Baselines3, OpenAI, LangChain
-
-Voir [`requirements.txt`](requirements.txt) pour la liste complète.
-
 ---
 
 ## Free Tier vs Paid
@@ -247,441 +321,14 @@ Voir [`requirements.txt`](requirements.txt) pour la liste complète.
 | **Backtesting** | ✅ Illimité (8h calcul/mois) | ✅ Illimité (plus d'heures) |
 | **Paper trading** | ✅ | ✅ |
 | **Données Equity/Crypto/Forex** | ✅ Depuis 2010 | ✅ Depuis 1998 |
-| **Alternative data (news, sentiment)** | ❌ (workaround : NewsAPI gratuit) | ✅ TiingoNews, etc. |
-| **GPU pour Deep Learning** | ❌ (CPU local ou cloud trial) | ✅ GPU cloud |
+| **Alternative data** | ❌ (workaround : NewsAPI gratuit) | ✅ TiingoNews, etc. |
+| **GPU pour Deep Learning** | ❌ (CPU local) | ✅ GPU cloud |
 | **Live trading** | ❌ | ✅ |
-| **API Cloud access** | Limité | ✅ Full |
 
 **Workarounds Free Tier** :
-- **QC-17 Sentiment** : NewsAPI gratuit (100 req/jour) au lieu de TiingoNews payant
-- **QC-22/23/24 Deep Learning** : CPU-optimized (ou GPU local via Docker)
-- **QC-25 RL** : CPU-first avec Stable-Baselines3
+- **QC-17 Sentiment** : NewsAPI gratuit au lieu de TiingoNews payant
+- **QC-22/23/24 Deep Learning** : CPU-optimized
 - **QC-27 Production** : Paper trading (simulation gratuite)
-
-**Sponsoring universitaire** : Le CEO Jared Broad a précédemment sponsorisé des programmes avec tier Team gratuit. Contact : [https://www.quantconnect.com/contact](https://www.quantconnect.com/contact)
-
----
-
-## Alignement avec "Hands-On AI Trading"
-
-Cette série s'inspire du livre **"Hands-On AI Trading with Python, QuantConnect, and AWS"** (Janvier 2025, Wiley).
-
-**Auteurs** : Jiri Pik, Ernest Chan, **Jared Broad** (CEO QuantConnect), et al.
-
-> 📘 **Mapping complet** : Pour un alignement détaillé chapitre par chapitre, consultez [**HANDSON_AI_TRADING_MAPPING.md**](docs/HANDSON_AI_TRADING_MAPPING.md)
-
-| Notebooks CoursIA | Chapitres Livre |
-|-------------------|-----------------|
-| QC-16 | Ch 3-4 : Data Preparation, Feature Engineering |
-| QC-17 | Ch 8 : Sentiment Analysis with Transformers |
-| QC-18 | Ch 4 : Feature Engineering for ML |
-| QC-19 | Ch 5-7 : Supervised Learning, Random Forests, XGBoost |
-| QC-20 | Ch 6 : Regression Models |
-| QC-21 | Ch 12 : Portfolio Optimization (adapté avec ML) |
-| QC-22 | Ch 9 : LSTMs for Time Series |
-| QC-23 | Ch 10 : Attention Mechanisms and Transformers |
-| QC-24 | Ch 9 : Autoencoders (adapté pour anomaly detection) |
-| QC-25 | Ch 11-12 : Deep Reinforcement Learning, Portfolio RL |
-| QC-26 | Ch 13 : LLMs for Trading Signals |
-| QC-27 | Ch 19 : Scaling and Deployment |
-
-**Liens** :
-
-- [Amazon (livre)](https://www.amazon.com/dp/1394268432)
-- [Site officiel](https://www.hands-on-ai-trading.com)
-- [GitHub du livre](https://github.com/QuantConnect/HandsOnAITradingBook)
-
----
-
-## Politique Git - Cloud-First Workflow
-
-### Principe
-
-La série QuantConnect CoursIA utilise un **workflow cloud-first** :
-
-- **Source de vérité** : QuantConnect Cloud (<https://www.quantconnect.com>)
-- **Clones locaux** : SONT IGNORÉS par git (voir `.gitignore`)
-- **Code tracké** : Uniquement les notebooks pédagogiques + projets de référence
-
-### Projets Locaux vs Projets Trackés
-
-#### 📁 Projets Locaux (IGNORÉS par git)
-
-Les clones créés via `lean cli project-fetch` ou `lean git clone` sont dans `.gitignore` :
-
-```bash
-# Exemples de projets locaux ignorés :
-MyIA.AI.Notebooks/QuantConnect/AdaptiveAssetAllocation/
-MyIA.AI.Notebooks/QuantConnect/AllWeather-Researcher/
-MyIA.AI.Notebooks/QuantConnect/BTC-*-Researcher*/
-MyIA.AI.Notebooks/QuantConnect/EMA-Cross-*/
-# ... etc
-```
-
-**Règle** : Ces projets sont des clones de travail, PAS du code source à tracker.
-
-#### 📁 Projets Trackés (DANS git)
-
-Le code déployable et les notebooks de recherche sont trackés :
-
-```text
-MyIA.AI.Notebooks/QuantConnect/
-├── projects/           # ← Tracké : Algorithmes déployables
-│   ├── EMA-Cross-Alpha/
-│   ├── TrendStocks-Alpha/
-│   └── ...
-├── Python/             # ← Tracké : Notebooks pédagogiques
-│   ├── QC-Py-01-Setup.ipynb
-│   └── ...
-├── CSharp/             # ← Tracké : Notebooks pédagogiques
-│   ├── QC-CS-01-Setup.ipynb
-│   └── ...
-├── shared/             # ← Tracké : Bibliothèques partagées
-└── docs/               # ← Tracké : Documentation
-```
-
-### Projets Cloud Actifs
-
-#### 🟢 Actifs (avec notebook de recherche)
-
-Ces projets sont régulièrement utilisés pour la recherche et le développement :
-
-- **EMA-Cross-Stocks** : Momentum EMA cross sur actions US
-- **Trend-Following** : Stratégie trend following multi-actifs
-- **DualMomentum** : Momentum dual avec gestion risque
-- **FamaFrench** : Stratégie factorielle Fama-French 5 facteurs
-- **Framework_Composite_*** : Framework composites multi-stratégies
-
-#### 🟡 Archivés (sans notebook récent)
-
-Ces projets sont conservés pour référence mais ne sont plus activement développés :
-
-- **EMA-Cross-Alpha** : Archivé (code dans `projects/`)
-- **TrendStocks-Alpha** : Archivé (code dans `projects/`)
-- **BTC-MACD-ADX-Researcher** : Versions obsolètes supprimées
-- **ETF-Pairs-Researcher 2** : Remplacé par version plus récente
-
-#### 🔴 Obsolètes (supprimés)
-
-Projets locaux sans notebook de recherche ont été nettoyés (2026-03-20) :
-
-- `BTC-MACD-ADX-Researcher 3/4/5` : Doublons obsolètes
-- `EMA-Cross-Alpha/` : Clone local (code dans `projects/`)
-- `TrendStocks-Alpha/` : Clone local (code dans `projects/`)
-
-### Workflow Recommandé
-
-**Pour créer un nouveau projet** :
-```bash
-# 1. Créer le projet dans le cloud QuantConnect
-# Via QC Lab ou API
-
-# 2. Cloner localement pour développement (ignoré par git)
-lean cli project-fetch <project-id> --destination MyIA.AI.Notebooks/QuantConnect/MonProjet-Researcher
-
-# 3. Développer avec QuantBook (research.ipynb)
-
-# 4. Pour partager : Copier le code déployable dans projects/
-# Et/ou créer un notebook pédagogique dans Python/ ou CSharp/
-```
-
-**Pourquoi cette politique ?**
-
-- ✅ Évite de dupliquer le code QuantConnect dans git
-- ✅ Les notebooks pédagogiques restent la source de vérité
-- ✅ `projects/` contient uniquement les algorithmes "ready-to-deploy"
-- ✅ Les clones locaux servent au développement itératif
-
----
-
-## ESGF-2026 - exemples de recherche
-
-Le dossier **ESGF-2026/** contient des exemples de recherche avancée utilisés dans le cours ESGF 2026 (EPITA).
-
-### Structure ESGF-2026
-
-```text
-ESGF-2026/
-├── examples/              # ← Tracké : Exemples pédagogiques complets
-│   ├── BTC-MachineLearning/
-│   ├── Crypto-MultiCanal/
-│   ├── ETF-Pairs-Trading/
-│   ├── Multi-Layer-EMA/
-│   ├── Options-VGT/
-│   ├── Option-Wheel-Strategy/
-│   ├── Sector-Momentum/
-│   └── Trend-Following/
-├── archive-2025/          # ← Archives historiques
-├── templates/             # ← Templates de recherche
-└── *.md                   # ← Documentation (RAPPORT_FINAL.md, etc.)
-```
-
-### Standard de structure (issues #112, #141)
-
-Chaque exemple dans `ESGF-2026/examples/` doit avoir :
-
-- **main.py** : Algorithme déployable
-- **README.md** : Documentation du projet
-- **research.ipynb** ou **research_robustness.ipynb** : Notebook de recherche QuantBook
-
-### Projets correspondants dans projects/
-
-Tous les exemples ESGF-2026 ont des projets correspondants dans `projects/` :
-
-| Exemple ESGF-2026 | Projet projects/ | Statut |
-| :--- | :--- | :--- |
-| BTC-MachineLearning | BTC-ML | ✅ |
-| Crypto-MultiCanal | Crypto-MultiCanal | ✅ |
-| ETF-Pairs-Trading | ETF-Pairs | ✅ |
-| Multi-Layer-EMA | Multi-Layer-EMA | ✅ |
-| Options-VGT | Options-VGT | ✅ |
-| Option-Wheel-Strategy | Option-Wheel | ✅ |
-| Sector-Momentum | SectorMomentum | ✅ |
-| Trend-Following | MomentumStrategy | ✅ |
-| CSharp-BTC-MACD-ADX | CSharp-BTC-MACD-ADX | ✅ (ajouté 2026-03-21) |
-
-### Cleanup 2026-03-21 (issue #112)
-
-**Supprimé (25 dossiers doublons/squelettes) :**
-
-- 16 Researcher racine (doublons de projects/)
-- 6 Researcher ESGF-2026/examples (squelettes TODO non complétés)
-- 3 projets C# (doublons, déjà dans projects/)
-
-**Créé :**
-
-- `projects/CSharp-BTC-MACD-ADX/` avec Main.cs, Research.ipynb, README.md
-
----
-
-## Intégration MCP QuantConnect
-
-QuantConnect a lancé un [serveur MCP officiel](https://github.com/QuantConnect/mcp-server) en 2026 avec **60+ API endpoints**.
-
-### Capacités MCP
-
-- **Gestion projets** : Créer, lire, modifier, supprimer projets
-- **Backtesting** : Lancer backtests, analyser résultats, lire charts/orders/insights
-- **Live trading** : Déployer, monitorer, liquider algorithmes
-- **Compilation** : Compiler algorithmes en cloud
-
-### Configuration Claude Code
-
-Dans `~/.claude.json` :
-
-```json
-{
-  "mcpServers": {
-    "quantconnect": {
-      "command": "docker",
-      "args": ["run", "-i", "--rm",
-               "-e", "QC_USER_ID=${QC_API_USER_ID}",
-               "-e", "QC_API_TOKEN=${QC_API_ACCESS_TOKEN}",
-               "quantconnect/mcp-server:latest"],
-      "env": {
-        "QC_API_USER_ID": "your_user_id",
-        "QC_API_ACCESS_TOKEN": "your_token"
-      }
-    }
-  }
-}
-```
-
-**Prérequis** : Claude Pro ($20/mois) + Compte QuantConnect
-
-**Cas d'usage** :
-- Créer projets QuantConnect depuis Claude Code
-- Lancer backtests et récupérer résultats via chat
-- Déployer algorithmes en paper/live trading
-- Analyser performance via conversation
-
-### MCP Jupyter (Alternative)
-
-Pour itération locale sur notebooks de recherche : `mcps\internal\servers\jupyter-papermill-mcp-server` (CoursIA)
-
----
-
-## Bibliothèques Partagées
-
-### Python (`shared/`)
-
-- **`features.py`** : Feature engineering (returns multi-period, technical features, labeling, walk-forward split)
-- **`indicators.py`** : Custom indicators QuantConnect
-- **`ml_utils.py`** : ML training, persistence (ObjectStore), métriques
-- **`plotting.py`** : Visualisations standardisées (backtest results, feature importance, confusion matrix)
-- **`backtest_helpers.py`** : Helpers configuration backtests
-
-**Usage** :
-```python
-from shared.features import calculate_returns, add_technical_features
-from shared.ml_utils import train_classifier, save_to_objectstore
-from shared.plotting import plot_backtest_results
-```
-
-### C# (`SharedLib/`)
-
-- **`Features.cs`** : Feature engineering (Accord.NET DataFrame)
-- **`CustomIndicators.cs`** : Indicateurs personnalisés
-- **`MLHelpers.cs`** : ML training (Accord.NET), persistence
-- **`BacktestHelpers.cs`** : Configuration backtests
-
-**Usage** :
-```csharp
-using CoursIA.QuantConnect.SharedLib;
-var returns = FeatureEngineering.CalculateReturns(prices, new[] {1, 5, 20});
-var model = MLHelpers.TrainClassifier(X, y);
-```
-
----
-
-## Scripts et Validation
-
-### Scripts Disponibles
-
-| Script | Description |
-|--------|-------------|
-| `scripts/validate_qc_notebooks.py` | Validation structure notebooks (Python + C#) |
-| `scripts/test_algorithms.py` | Automated backtest runner (via MCP ou LEAN CLI) |
-| `scripts/sync_to_cloud.py` | Upload vers QuantConnect cloud |
-
-**Validation structure** :
-```bash
-python scripts/validate_qc_notebooks.py MyIA.AI.Notebooks/QuantConnect/Python --quick
-python scripts/validate_qc_notebooks.py MyIA.AI.Notebooks/QuantConnect --all --fix
-```
-
-**Test algorithmes** :
-```bash
-# Test single algorithm
-python scripts/test_algorithms.py --algorithm MovingAverageCrossover.py \
-  --start 2020-01-01 --end 2023-12-31 --language python
-
-# Test all Python algorithms
-python scripts/test_algorithms.py --language python --all --report output/report.html
-```
-
----
-
-## Troubleshooting
-
-### Cloud QuantConnect
-
-**Problème** : "Backtest timed out"
-**Solution** : Réduire date range ou résolution (Daily au lieu de Minute)
-
-**Problème** : "Data not available"
-**Solution** : Vérifier que l'asset est dans free tier (Equity US, Crypto, Forex OK)
-
-**Problème** : "Out of compute hours"
-**Solution** : Free tier = 8h/mois. Attendre reset mensuel ou optimiser algorithme
-
-### Local LEAN CLI
-
-**Problème** : "Docker container won't start"
-**Solution** : Vérifier Docker Desktop running, volumes avec paths absolus
-
-**Problème** : "Market data not found"
-**Solution** : Télécharger données avec `lean data download --dataset us-equity`
-
-**Problème** : "GPU not detected"
-**Solution** : Installer nvidia-docker, vérifier `--gpus all` dans docker-compose
-
-Pour plus de détails : voir la section [Troubleshooting](#troubleshooting) ci-dessous (guide détaillé à venir)
-
----
-
-## Parcours Pédagogiques Recommandés
-
-### Débutant (20h)
-
-1. **Phase 1** : Fondations LEAN (4.5h)
-2. **Phase 2** : Universe et Asset Classes (5h)
-3. **Phase 3** : Trading Avancé et Risk (5.5h)
-4. **Notebooks 13-15** : Algorithm Framework (4h)
-5. Premier projet : Stratégie momentum avec risk management
-
-### Intermédiaire (40h)
-
-1. Révision Débutant (optionnel, 4h)
-2. **Phase 4-5** : Algorithm Framework + Alternative Data (8h)
-3. **Phase 6** : Machine Learning Traditionnel (4h)
-4. Notebooks 19-21 en profondeur
-5. Projet : Stratégie ML multi-actifs avec optimisation
-
-### Expert (60h)
-
-1. Révision Intermédiaire (optionnel, 8h)
-2. **Phases 6-8** complètes : ML + DL + IA Avancée (12h)
-3. Deep dive LSTMs, Transformers, RL
-4. Notebook 26 : LLM trading signals
-5. Notebook 27 : Déploiement production
-6. Projet final : Stratégie RL avec LLM-augmented signals, déploiement paper trading
-
----
-
-## Librairie Utilitaire
-
-**[SHARED_LIBRARY.md](SHARED_LIBRARY.md)** - Documentation complète de la librairie partagée
-
-La `shared/` library contient 5 modules Python utilisés dans tous les notebooks :
-
-| Module | Usage | Fonctions principales |
-| :--- | :--- | :--- |
-| **features.py** | Feature engineering ML | `calculate_returns()`, `add_technical_features()`, `walk_forward_split()` |
-| **backtest_helpers.py** | Config & métriques | `default_backtest_config()`, `calculate_metrics()`, `format_backtest_summary()` |
-| **ml_utils.py** | Entraînement ML | `train_classifier()`, `evaluate_model()`, `save_to_objectstore()` |
-| **plotting.py** | Visualisations | `plot_backtest_results()`, `plot_feature_importance()`, `plot_cumulative_returns()` |
-| **indicators.py** | Indicateurs custom | `CustomMomentumIndicator`, `TrendStrengthIndicator`, `VolatilityBandIndicator` |
-
-**Import rapide** :
-
-```python
-from shared import features, backtest_helpers, ml_utils, plotting, indicators
-```
-
----
-
-## Ressources Complémentaires
-
-### Documentation QuantConnect
-
-- [Documentation officielle](https://www.quantconnect.com/docs)
-- [LEAN Engine GitHub](https://github.com/QuantConnect/Lean)
-- [LEAN CLI Documentation](https://www.quantconnect.com/docs/v2/lean-cli)
-- [Algorithm Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework/overview)
-
-### MCP & Intégrations
-
-- [QuantConnect MCP Server](https://github.com/QuantConnect/mcp-server)
-- [MCP Announcement](https://www.quantconnect.com/announcements/19439/quantconnect-mcp-server/)
-- [PulseMCP - QuantConnect](https://www.pulsemcp.com/servers/quantconnect)
-
-### Livre & Ressources IA Trading
-
-- [Hands-On AI Trading Book](https://www.hands-on-ai-trading.com)
-- [Book GitHub Repository](https://github.com/QuantConnect/HandsOnAITradingBook)
-- [Amazon (livre)](https://www.amazon.com/dp/1394268432)
-
-### Communauté
-
-- [QuantConnect Forum](https://www.quantconnect.com/forum)
-- [LEAN Discussions](https://github.com/QuantConnect/Lean/discussions)
-- [CoursIA Main README](../../README.md)
-
----
-
-## Note Pédagogique - Sponsoring Jared Broad
-
-Le CEO de QuantConnect, **Jared Broad**, a précédemment sponsorisé cette formation avec :
-- Masterclass en direct pour la promotion
-- Tier Team gratuit (alternative data, live trading, GPU)
-- Accès à la League universitaire QuantConnect
-
-**Pour demander un sponsoring** : [https://www.quantconnect.com/contact](https://www.quantconnect.com/contact)
-
-**Historique** : Programme sponsorisé en 2024-2025, participation League universitaire non complétée.
-
-**Objectif 2026** : Relancer contact pour nouveau sponsoring + participation active League.
 
 ---
 
@@ -691,32 +338,20 @@ Après completion de cette série, vous maîtriserez :
 
 ### Compétences Techniques
 
-- ✅ **QuantConnect LEAN** : Architecture, lifecycle, Universe selection, multi-asset trading
-- ✅ **Risk Management** : Position sizing, stop-loss, take-profit, portfolio heat
-- ✅ **Algorithm Framework** : Alpha, Portfolio Construction, Execution, Risk models
-- ✅ **Alternative Data** : News, sentiment, fundamentals, custom data sources
-- ✅ **Machine Learning** : Supervised (RF, XGBoost), Deep Learning (LSTM, Transformers), RL (PPO, DQN)
-- ✅ **LLM Integration** : Prompt engineering, LLM-augmented signals, cost management
-- ✅ **Production Deployment** : Paper trading, live trading, monitoring, orchestration
+- ✅ **QuantConnect LEAN** : Architecture, lifecycle, Universe selection
+- ✅ **Risk Management** : Position sizing, stop-loss, take-profit
+- ✅ **Algorithm Framework** : Alpha, Portfolio Construction, Execution, Risk
+- ✅ **Machine Learning** : Supervised (RF, XGBoost), Deep Learning (LSTM), RL (PPO)
+- ✅ **LLM Integration** : Prompt engineering, LLM-augmented signals
+- ✅ **Production Deployment** : Paper trading, live trading, monitoring
 
 ### Projets Réalisables
 
-- 🎯 **Stratégie momentum multi-actifs** avec risk management professionnel
-- 🤖 **Bot ML directionnel** avec Random Forest + XGBoost
-- 🧠 **Stratégie LSTM** pour prédiction prix court-terme
-- 🏆 **Agent RL adaptatif** avec environnement custom
-- 💡 **LLM-augmented strategy** combinant GPT-4 + indicateurs techniques
-- 🏭 **Déploiement production** en paper trading avec monitoring
-
----
-
-## Prochaines Étapes
-
-1. **Démarrage rapide** : [GETTING-STARTED.md](GETTING-STARTED.md)
-2. **Configuration** : Copier `.env.example` vers `.env` et remplir vos API keys
-3. **Premier notebook** : [QC-Py-01-Setup.ipynb](Python/QC-Py-01-Setup.ipynb) ou QC-CS-01-Setup.ipynb *(à venir)*
-4. **Suivre la progression** : Phases 1-8 dans l'ordre
-5. **(Optionnel) Configurer MCP** pour automatisation avec Claude Code
+- 🎯 Stratégie momentum multi-actifs avec risk management
+- 🤖 Bot ML directionnel avec Random Forest + XGBoost
+- 🧠 Stratégie LSTM pour prédiction prix court-terme
+- 💡 LLM-augmented strategy combinant GPT-4 + indicateurs
+- 🏭 Déploiement production en paper trading
 
 ---
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -1,10 +1,10 @@
 # QuantConnect Algorithmic Trading Projects
 
-Derniere mise a jour : 2026-03-30
+Dernière mise à jour : 2026-03-30
 
-Bibliotheque pedagogique de 67 strategies de trading algorithmique sur QuantConnect Cloud.
-Chaque strategie illustre un concept ou une famille de strategies ; les performances varient volontairement
-pour montrer que toutes les idees academiques ne survivent pas au backtest realiste.
+Bibliothèque pédagogique de **60+ stratégies** de trading algorithmique sur QuantConnect Cloud.
+Chaque stratégie illustre un concept ou une famille de stratégies ; les performances varient
+volontairement pour montrer que toutes les idées académiques ne survivent pas au backtest réaliste.
 
 ## Classification
 


### PR DESCRIPTION
## 📝 Mission

Nettoyage des README QuantConnect pour les rendre pédagogiques pour les étudiants du cours ESGF 2026.

## 🔄 Changements

### README principal (726 → 380 lignes)

- **Section "Pour commencer"** mise en avant avec 4 étapes simples
- **Structure pédagogique** claire avec 8 phases détaillées
- **Sections techniques** (Free Tier, MCP, etc.) déplacées en fin de document
- **Focus** sur les notebooks progressifs et les projets de stratégies

### ESGF-2026/README.md

- **Section Templates** ajoutée avec 3 niveaux :
  - 🟢 **Starter** : Croisement EMA sur BTCUSDT
  - 🟡 **Intermediate** : Momentum avec Alpha Framework
  - 🔴 **Advanced** : Machine Learning (RandomForest)
- **Parcours recommandé** par niveau (débutant/intermédiaire/avancé)
- **Documentation** des 11 exemples du professeur

### projects/README.md

- **Correction** du chiffre de stratégies : 67 → 60+
- **Clarification** pour éviter la confusion avec le chiffre exact
- **Structure** simplifiée pour les étudiants

## ✅ Checklist

- [x] README principal rendu pédagogique
- [x] ESGF-2026 README avec section Templates
- [x] projects README avec chiffre corrigé
- [x] Branche feature créée
- [x] Commit message conforme

## 📚 Contexte

**Coordinateur** : ai-01 (mission 31 mars 10h30)
**Deadline** : avant 14h (cours ESGF cet après-midi)
**Organisation** : Trading Firm ESGF

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>