### PR TITLE
fix(qc): ESGF advanced template - crypto AfterMarketOpen Runtime Error

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/templates/advanced/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/templates/advanced/main.py
@@ -52,9 +52,11 @@ class AdvancedMLAlgorithm(QCAlgorithm):
             self.Debug("Modele ML charge depuis l'ObjectStore")
 
         # --- Re-entrainement programme le 1er de chaque mois ---
+        # Note: Crypto trade 24/7, AfterMarketOpen n'existe pas.
+        # On utilise Noon comme substitut.
         self.Schedule.On(
             self.DateRules.MonthStart(self.symbol),
-            self.TimeRules.AfterMarketOpen(self.symbol, 1),
+            self.TimeRules.Noon,
             self.RetrainModel
         )
 


### PR DESCRIPTION
## Summary
- Fix Runtime Error in ESGF advanced template: `TimeRules.AfterMarketOpen` doesn't work for crypto (24/7 market)
- Replaced with `TimeRules.Noon` for monthly ML retraining schedule
- All 3 ESGF templates validated on QC Cloud (org ESGF):

| Template | Compile | Backtest | Notes |
|----------|---------|----------|-------|
| Starter (EMA BTC) | OK | OK | EMA cross sur BTCUSDT, horaire |
| Intermediate (Momentum SPY) | OK | Sharpe 0.192, CAGR 6.8% | Alpha Framework, 21k orders |
| Advanced (ML BTC) | OK | Sharpe 0.154, CAGR 2.3% | Fix AfterMarketOpen -> Noon |

## Test plan
- [x] Starter compiles and backtests on QC Cloud (org ESGF, project 29540889)
- [x] Intermediate compiles and backtests on QC Cloud (org ESGF, project 29540896)
- [x] Advanced compiles and backtests on QC Cloud (org ESGF, project 29540897)
- [x] README files reviewed - all 3 are clear and pedagogical

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>