### PR TITLE
chore: add ESGF-Workspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -610,6 +610,7 @@ MyIA.AI.Notebooks/QuantConnect/TrendStocks*/
 MyIA.AI.Notebooks/QuantConnect/TurnOfMonth-Researcher/
 MyIA.AI.Notebooks/QuantConnect/VIX-TermStructure-Researcher/
 MyIA.AI.Notebooks/QuantConnect/lean.json
+MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/
 
 # Temporary screenshots (slide reviews, debug)
 /*.png


### PR DESCRIPTION
## Summary
- Add `MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/` to `.gitignore`
- Fixes 234 untracked files causing VS Code git notifications noise
- ESGF-Workspace contains 42 student/template projects from ESGF course (local artefact, not for repo)

## Test plan
- [x] `git status --short` no longer shows ESGF-Workspace files

🤖 Generated with [Claude Code](https://claude.com/claude-code)