### PR TITLE
fix(slides-03): restore I-VII chapter list on Plan du cours slide

### DIFF
--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -22,10 +22,24 @@ INTELLIGENCE ARTIFICIELLE -- III
 - Representation des connaissances
 
 ---
-layout: section
+layout: default
 ---
 
 # Plan du cours
+
+I. Introduction
+
+II. Resolution de problemes
+
+III. **Bases de connaissances et logique**
+
+IV. Raisonnement probabiliste
+
+V. Apprentissage
+
+VI. Traitement du langage naturel
+
+VII. TP final projets trimestriels
 
 ---
 layout: default


### PR DESCRIPTION
## Summary
- Deck 03 EPITA (Bases de connaissances et Logique) slide 2 "Plan du cours" was rendering with an empty content area
- The PPTX reference lists the 7 chapters with chapter III "Bases de connaissances et logique" highlighted
- Slidev layout was incorrectly set to \`section\` (dark full-screen divider)

## Fix
- Change layout from \`section\` to \`default\`
- Add the 7-chapter list (I. Introduction through VII. TP final projets trimestriels)
- Highlight chapter III in bold

## Visual verification
- Re-exported deck 03 via \`npx slidev export --format png\`
- Confirmed slide 2 now matches PPTX reference structure
- No regression on surrounding slides

## Test plan
- [x] Source edit: \`slides/03-logique/slides.md\` L25-L46
- [x] Re-export to PNG
- [x] Visual comparison with \`slides/03-logique/pptx-reference/slide-02.png\`
- [ ] Merge after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)