### PR TITLE
chore(vibe-coding): switch opus mapping to Qwen 3.6 Plus

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
@@ -61,7 +61,7 @@ C'est l'etape la plus importante. Vous devez definir **3 variables obligatoires*
 | `ANTHROPIC_BASE_URL` | `https://openrouter.ai/api` | Dit a Claude Code d'utiliser OpenRouter au lieu d'Anthropic |
 | `ANTHROPIC_AUTH_TOKEN` | `sk-or-v1-VOTRE_CLE` | Votre cle d'authentification OpenRouter |
 | `ANTHROPIC_API_KEY` | *(vide)* | Doit etre vide pour ne pas conflit avec OpenRouter |
-| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `moonshotai/kimi-k2.5` | Modele "opus" = Kimi K2.5 (raisonnement complexe) |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `qwen/qwen3.6-plus` | Modele "opus" = Qwen 3.6 Plus (raisonnement complexe) |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | `minimax/minimax-m2.7` | Modele "sonnet" = MiniMax M2.7 (usage quotidien) |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `qwen/qwen3.5-27b` | Modele "haiku" = Qwen 3.5 27B (taches rapides) |
 
@@ -87,7 +87,7 @@ Contenu (remplacez `sk-or-v1-VOTRE_CLE` par votre vraie cle) :
     "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
     "ANTHROPIC_AUTH_TOKEN": "sk-or-v1-VOTRE_CLE",
     "ANTHROPIC_API_KEY": "",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "moonshotai/kimi-k2.5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen/qwen3.6-plus",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax/minimax-m2.7",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.5-27b"
   }
@@ -109,7 +109,7 @@ Ajoutez a la fin :
 $env:ANTHROPIC_BASE_URL = "https://openrouter.ai/api"
 $env:ANTHROPIC_AUTH_TOKEN = "sk-or-v1-VOTRE_CLE"
 $env:ANTHROPIC_API_KEY = ""
-$env:ANTHROPIC_DEFAULT_OPUS_MODEL = "moonshotai/kimi-k2.5"
+$env:ANTHROPIC_DEFAULT_OPUS_MODEL = "qwen/qwen3.6-plus"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = "minimax/minimax-m2.7"
 $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.5-27b"
 ```
@@ -135,7 +135,7 @@ Ajoutez a la fin :
 export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
 export ANTHROPIC_AUTH_TOKEN="sk-or-v1-VOTRE_CLE"
 export ANTHROPIC_API_KEY=""
-export ANTHROPIC_DEFAULT_OPUS_MODEL="moonshotai/kimi-k2.5"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
 ```
@@ -197,7 +197,7 @@ Vous devez recevoir une reponse du modele (MiniMax M2.7 par defaut).
 # Modele par defaut (sonnet = MiniMax M2.7)
 claude -p "Reponds 'Sonnet OK'"
 
-# Modele opus (Kimi K2.5)
+# Modele opus (Qwen 3.6 Plus)
 claude --model opus -p "Reponds 'Opus OK'"
 
 # Modele haiku (Qwen 3.5 27B)
@@ -238,13 +238,13 @@ Claude Code va analyser votre projet et creer un fichier `CLAUDE.md` avec le con
 | Alias | Modele | Quand l'utiliser |
 |-------|--------|-----------------|
 | **sonnet** (defaut) | MiniMax M2.7 | Developpement quotidien, debug, questions |
-| **opus** | Kimi K2.5 | Refactoring complexe, architecture, documentation |
+| **opus** | Qwen 3.6 Plus | Refactoring complexe, architecture, documentation |
 | **haiku** | Qwen 3.5 27B | Questions rapides, exploration, prototypage |
 
 Pour changer de modele dans une session :
 
 ```bash
-claude --model opus    # utilise Kimi K2.5
+claude --model opus    # utilise Qwen 3.6 Plus
 claude --model sonnet  # utilise MiniMax M2.7 (defaut)
 claude --model haiku   # utilise Qwen 3.5 27B
 ```

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/CHEAT-SHEET.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/CHEAT-SHEET.md
@@ -462,7 +462,7 @@ export ANTHROPIC_API_KEY=""
 export ANTHROPIC_MODEL="claude-sonnet-4-5-20250929"
 
 # Aliases de modeles OpenRouter
-export ANTHROPIC_DEFAULT_OPUS_MODEL="moonshotai/kimi-k2.5"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/INSTALLATION-CLAUDE-CODE.md
@@ -141,7 +141,7 @@ $env:ANTHROPIC_AUTH_TOKEN = "sk-or-v1-VOTRE_CLE_OPENROUTER"
 $env:ANTHROPIC_API_KEY = ""
 
 # Mapping des aliases de modeles (optionnel - voir section Modeles Alternatifs)
-$env:ANTHROPIC_DEFAULT_OPUS_MODEL = "moonshotai/kimi-k2.5"
+$env:ANTHROPIC_DEFAULT_OPUS_MODEL = "qwen/qwen3.6-plus"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = "minimax/minimax-m2.7"
 $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.5-27b"
 ```
@@ -194,7 +194,7 @@ export ANTHROPIC_AUTH_TOKEN="sk-or-v1-VOTRE_CLE_OPENROUTER"
 export ANTHROPIC_API_KEY=""
 
 # Mapping des aliases de modeles (optionnel - voir section Modeles Alternatifs)
-export ANTHROPIC_DEFAULT_OPUS_MODEL="moonshotai/kimi-k2.5"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
 ```
@@ -228,7 +228,7 @@ Contenu :
     "ANTHROPIC_BASE_URL": "https://openrouter.ai/api",
     "ANTHROPIC_AUTH_TOKEN": "sk-or-v1-VOTRE_CLE_OPENROUTER",
     "ANTHROPIC_API_KEY": "",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "moonshotai/kimi-k2.5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen/qwen3.6-plus",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax/minimax-m2.7",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.5-27b"
   }
@@ -320,7 +320,7 @@ OpenRouter permet d'utiliser des modeles alternatifs a Claude, souvent moins che
 
 | Alias Claude | Modele Alternatif | Identifiant OpenRouter | Context | Prix (Input/Output per M) |
 | ------------ | ----------------- | ---------------------- | ------- | ------------------------- |
-| `opus` | Kimi K2.5 | `moonshotai/kimi-k2.5` | 262K | $0.42 / $2.20 |
+| `opus` | Qwen 3.6 Plus | `qwen/qwen3.6-plus` | 262K | voir OpenRouter |
 | `sonnet` | MiniMax M2.7 | `minimax/minimax-m2.7` | 205K | $0.30 / $1.20 |
 | `haiku` | Qwen 3.5 27B | `qwen/qwen3.5-27b` | 262K | $0.20 / $1.56 |
 
@@ -331,26 +331,26 @@ OpenRouter permet d'utiliser des modeles alternatifs a Claude, souvent moins che
 claude -p "Explique ce code"
 
 # Utiliser explicitement un modele
-claude --model opus -p "Refactore ce projet"    # Kimi K2.5
+claude --model opus -p "Refactore ce projet"    # Qwen 3.6 Plus
 claude --model sonnet -p "Corrige ce bug"       # MiniMax M2.7
 claude --model haiku -p "Liste les fichiers"    # Qwen 3.5 27B
 
 # Forcer un modele specifique (bypass alias)
-claude --model moonshotai/kimi-k2.5 -p "Question complexe"
+claude --model qwen/qwen3.6-plus -p "Question complexe"
 ```
 
 ### Presentation des Modeles
 
-#### Kimi K2.5 (Alias Opus)
+#### Qwen 3.6 Plus (Alias Opus)
 
-**Identifiant :** `moonshotai/kimi-k2.5`
+**Identifiant :** `qwen/qwen3.6-plus`
 
-Kimi K2.5 est le modele flagship de Moonshot AI :
+Qwen 3.6 Plus est le modele flagship de la famille Qwen 3.6 (Alibaba, avril 2026), plus recent et plus performant que Kimi K2.5 sur les taches de raisonnement et de coding agentique :
 
 - **Context window** : 262K tokens
 - **Forces** : Raisonnement avance, programmation complexe, taches agentiques multi-etapes
 - **Cas d'usage ideaux** : Refactoring complexe, architecture de projets, documentation technique
-- **Prix** : $0.42 / $2.20 per million tokens (input/output)
+- **Prix** : voir [openrouter.ai/qwen/qwen3.6-plus](https://openrouter.ai/qwen/qwen3.6-plus)
 
 #### MiniMax M2.7 (Alias Sonnet)
 
@@ -377,11 +377,11 @@ Modele dense compact et rapide :
 
 ### Comparaison avec les Modeles Claude Natifs
 
-| Aspect | Claude Opus | Kimi K2.5 | Claude Sonnet | MiniMax M2.7 | Claude Haiku | Qwen 3.5 27B |
-| ---------------- | ----------- | --------- | ------------- | ------------ | ------------ | ------------ |
+| Aspect | Claude Opus | Qwen 3.6 Plus | Claude Sonnet | MiniMax M2.7 | Claude Haiku | Qwen 3.5 27B |
+| ---------------- | ----------- | ------------- | ------------- | ------------ | ------------ | ------------ |
 | **Context** | 200K | 262K | 200K | 205K | 200K | 262K |
-| **Prix Input** | $15.00 | $0.42 | $3.00 | $0.30 | $0.25 | $0.20 |
-| **Prix Output** | $75.00 | $2.20 | $15.00 | $1.20 | $1.25 | $1.56 |
+| **Prix Input** | $15.00 | voir OR | $3.00 | $0.30 | $0.25 | $0.20 |
+| **Prix Output** | $75.00 | voir OR | $15.00 | $1.20 | $1.25 | $1.56 |
 | **Coding** | Excellent | Excellent | Tres bon | Excellent | Bon | Tres bon |
 | **Raisonnement** | Excellent | Excellent | Tres bon | Tres bon | Bon | Bon |
 
@@ -759,8 +759,8 @@ Editez `.claude/settings.json` :
 - [Documentation OpenRouter](https://openrouter.ai/docs)
 - [Guide d'integration Claude Code](https://openrouter.ai/docs/guides/claude-code-integration)
 - [Tarifs et modeles](https://openrouter.ai/models)
-- [Kimi K2.5 sur OpenRouter](https://openrouter.ai/moonshotai/kimi-k2.5)
-- [Qwen 3.5 397B sur OpenRouter](https://openrouter.ai/minimax/minimax-m2.7)
+- [Qwen 3.6 Plus sur OpenRouter](https://openrouter.ai/qwen/qwen3.6-plus)
+- [MiniMax M2.7 sur OpenRouter](https://openrouter.ai/minimax/minimax-m2.7)
 - [Qwen 3.5 27B sur OpenRouter](https://openrouter.ai/qwen/qwen3.5-27b)
 
 ### Communaute

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/roo-code/INSTALLATION-ROO.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/roo-code/INSTALLATION-ROO.md
@@ -74,7 +74,7 @@ Les profils vous permettent de basculer rapidement entre différents modèles d'
 | `Deepseek-Deepseek-r1`       | `deepseek/deepseek-r1`                 |
 | `MiniMax-M2.7`               | `minimax/minimax-m2.7`                 |
 | `Qwen-3.5-27B`               | `qwen/qwen3.5-27b`                    |
-| `Kimi-K2.5`                  | `moonshotai/kimi-k2.5`                |
+| `Qwen-3.6-Plus`              | `qwen/qwen3.6-plus`                   |
 | `Mistral-Mistral-Small`    | `mistralai/mistral-small`         |
 
 *Note : Certains noms de modèles demandés ont été adaptés aux identifiants disponibles sur OpenRouter.*


### PR DESCRIPTION
## Summary

- Update OpenRouter model mapping for the `opus` alias from `moonshotai/kimi-k2.5` to `qwen/qwen3.6-plus`
- More recent Qwen family model (April 2026), better performance on reasoning and agentic coding tasks
- Sonnet (`minimax/minimax-m2.7`) and Haiku (`qwen/qwen3.5-27b`) mappings unchanged

## Scope

4 files updated (docs only, no code):
- `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md` (quickstart guide)
- `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/INSTALLATION-CLAUDE-CODE.md` (complete guide)
- `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/claude-code/CHEAT-SHEET.md`
- `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/roo-code/INSTALLATION-ROO.md`

## Follow-up

A separate issue will be created to track the Haiku mapping update to `qwen/qwen3.6-35b-a3b` once it lands on OpenRouter (a few days). This is the model currently served locally via vLLM on ai-01 with better perf than the current `qwen3.5-27b`.

## Test plan

- [ ] Visual check: no remaining `moonshotai/kimi-k2.5` references in Vibe-Coding docs
- [ ] Manual test: `claude --model opus -p "OK"` returns a response from Qwen 3.6 Plus (requires OpenRouter credit)
- [ ] ESGF lundi 20/04 aprem : valider avec les etudiants que le setup fonctionne

Ref issue follow-up : #TBD (Haiku update)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>