### PR TITLE
fix(vibe-coding): correct import path in notebook 01 cell 14

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/01-Claude-CLI-Bases.ipynb
@@ -227,18 +227,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Format JSON\n",
-    "from helpers.claude_cli import run_claude_json\n",
-    "\n",
-    "result = run_claude_json(\n",
-    "    \"Donne-moi une liste de 3 frameworks web en JSON avec nom et langage\"\n",
-    ")\n",
-    "\n",
-    "print(\"=== Format JSON ===\")\n",
-    "import json\n",
-    "print(json.dumps(result, indent=2, ensure_ascii=False))"
-   ]
+   "source": "# Format JSON\nfrom claude_cli import run_claude_json\n\nresult = run_claude_json(\n    \"Donne-moi une liste de 3 frameworks web en JSON avec nom et langage\"\n)\n\nprint(\"=== Format JSON ===\")\nimport json\nprint(json.dumps(result, indent=2, ensure_ascii=False))"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Fix broken import `from helpers.claude_cli import run_claude_json` in notebook 01 cell 14
- The correct import is `from claude_cli import run_claude_json` (consistent with cell 2 and all other notebooks)
- Without this fix, cell 14 raises `ImportError` at runtime

## Context
Validated all 5 Claude-Code ESGF notebooks for Monday 20/04 session (Tour 9 mission). This was the only bug found. All notebooks execute without Python errors.

## Test plan
- [x] Notebook 01 executes via Papermill: 28/28 cells pass
- [x] Grep confirms no other instances of `from helpers.claude_cli` in notebooks
- [ ] Visual confirmation cell 14 output after fix with Claude CLI in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)