### PR TITLE
docs(slides): migrate README from Marp to Slidev

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -1,129 +1,143 @@
 # Slides du cours Intelligence Artificielle
 
-Presentations du cours IA 101 / CS 405, converties au format **Marp** (Markdown) pour edition et maintenance facilitees.
+Presentations du cours IA 101 / CS 405 au format **Slidev** (Markdown + Vue), editables en texte pur et versionnees dans git.
 
 ## Format et outils
 
-Les slides sont au format [Marp](https://marp.app/) : du Markdown pur avec des directives de presentation. Cela permet a Claude (et a tout editeur) de lire et modifier le contenu et le layout directement en texte, sans passer par PowerPoint.
+Les slides sont ecrits en Slidev ([slidev.antfu.me](https://sli.dev/)) : du Markdown avec directives de layout, composants Vue optionnels, et hot-reload via `@slidev/cli`. Chaque deck est un fichier `slides.md` isole dans son dossier, avec son propre `package.json` au niveau racine `slides/` qui installe l'environnement commun.
 
-### Commandes Marp CLI
+### Installation une fois
 
 ```bash
-# Preview live dans le navigateur (hot-reload)
-npx @marp-team/marp-cli --preview slides/08-ia-generative/slides.md
+cd slides
+npm install
+```
 
-# Export HTML (un fichier par deck)
-npx @marp-team/marp-cli slides/08-ia-generative/slides.md --html --allow-local-files -o slides/08-ia-generative/output/index.html
+### Commandes Slidev
+
+```bash
+# Preview live dans le navigateur (hot-reload), depuis le dossier du deck
+cd slides/01-introduction && npx slidev slides.md
+
+# Port personnalise pour servir plusieurs decks en parallele
+cd slides/02-resolution-problemes && npx slidev slides.md --port 3032
+cd slides/03-logique && npx slidev slides.md --port 3030
+
+# Export HTML statique (SPA)
+cd slides/08-ia-generative && npx slidev build
 
 # Export PDF
-npx @marp-team/marp-cli slides/08-ia-generative/slides.md --pdf --allow-local-files -o slides/08-ia-generative/output/slides.pdf
-
-# Export PPTX (si besoin de revenir en PowerPoint)
-npx @marp-team/marp-cli slides/08-ia-generative/slides.md --pptx --allow-local-files -o slides/08-ia-generative/output/slides.pptx
-
-# Render tous les decks en HTML
-for d in slides/*/slides.md; do
-  out="$(dirname "$d")/output/index.html"
-  mkdir -p "$(dirname "$out")"
-  npx @marp-team/marp-cli "$d" --html --allow-local-files -o "$out"
-done
+cd slides/08-ia-generative && npx slidev export --output slides.pdf
 ```
+
+Scripts raccourcis (`slides/package.json`) : `npm run dev`, `npm run build`, `npm run export`.
 
 ### Theme personnalise
 
-Le fichier `themes/ia101.css` definit le style visuel partage :
-- Accent rouge-brique (#8B1A1A) sur fond gris clair (#F5F5F5)
-- Classes : `title` (slide de titre), `section` (sommaire), `questions` (respiration), `crossref` (liens notebooks)
-- Configuration Marp dans `.marprc.yml` (theme, HTML, fichiers locaux)
+Le dossier `theme-ia101/` contient le theme Slidev partage par tous les decks :
+- Accent rouge-brique (`#8B1A1A`) sur fond gris clair (`#F5F5F5`)
+- Layouts custom (`cover`, `section`, `questions`, `image-overlay`, `dense`, `two-cols`)
+- Reference dans le frontmatter : `theme: ../theme-ia101`
+
+Les images pleine-largeur utilisent le layout **`image-overlay`** (fond d'image + texte par-dessus), jamais en colonne droite — convention validee pour la coherence visuelle.
 
 ## Inventaire des decks
 
-| # | Deck | Slides | Images | Lignes .md | Statut |
-|---|------|--------|--------|------------|--------|
-| 01 | Introduction | 46 | 40 | 706 | Corrige |
-| 02 | Resolution de problemes | 100 | 56 | 1552 | Corrige |
-| 03 | Logique | 100 | 45 | 1399 | Corrige |
-| 04 | Probabilites | 118 | 110 | 1763 | Corrige |
-| 05 | Theorie des jeux | 43 | 54 | 782 | Corrige |
-| 06 | Apprentissage | 127 | 140 | 2206 | Corrige |
-| 07 | Elargissements | 42 | 9 | 683 | Enrichi |
-| 08 | IA Generative | 28 | 36 | 432 | Corrige |
-| S1 | Argumentation | 51 | 20 | 693 | Enrichi |
-| S2 | IA exploratoire/symbolique | 58 | 54 | 1025 | Corrige |
-| S3 | Acculturation | 72 | 133 | 2037 | Corrige |
-| S4 | Trading algorithmique | 128 | 14 | 1873 | Enrichi |
-| | **Total** | **913** | **711** | **15 151** | **12/12** |
+| # | Deck | Dossier | Ligne `slides.md` | Images | Sessions |
+|---|------|---------|-------------------|--------|----------|
+| 01 | Introduction a l'IA | `01-introduction/` | ~772 | 40 | EPITA, ECE |
+| 02 | Resolution de problemes | `02-resolution-problemes/` | ~1551 | 56 | EPITA |
+| 03 | Logique | `03-logique/` | ~1969 | 45 | EPITA |
+| 04 | Probabilites | `04-probabilites/` | ~1945 | 110 | EPITA, ECE |
+| 05 | Theorie des jeux | `05-theorie-des-jeux/` | ~705 | 54 | EPITA |
+| 06 | Apprentissage | `06-apprentissage/` | ~2394 | 140 | EPITA, ECE |
+| 07 | Elargissements | `07-elargissements/` | ~642 | 9 | EPITA |
+| 08 | IA Generative | `08-ia-generative/` | ~464 | 36 | EPITA, ECE |
+| S1 | Argumentation | `S1-argumentation/` | ~791 | 20 | Sessions avancees |
+| S2 | IA exploratoire/symbolique | `S2-ia-exploratoire-symbolique/` | ~1112 | 54 | Sessions avancees |
+| S3 | Acculturation IA | `S3-acculturation/` | ~2039 | 133 | Sessions avancees |
+| S4 | Trading algorithmique | `S4-trading-algorithmique/` | ~2761 | 15 | ESGF |
+| S4 | Trading exercices | `S4-trading-exercices/` | ~871 | 0 | ESGF |
 
-Les decks marques "Enrichi" ont recu des images libres de droits (Wikimedia Commons, CC BY-SA / CC0) en plus des corrections de contenu.
+Le decompte exact de slides se fait au runtime Slidev (les separateurs `---` incluent aussi les frontmatter locaux des layouts custom). Lancer le serveur pour voir le compteur pagine.
 
-## Ameliorations appliquees
+## Cross-references slides <-> notebooks
 
-Chaque deck a beneficie d'une relecture qualitative (guidee par les `analysis/improvement_plan.md`) :
+Chaque deck pointe vers les notebooks Jupyter pertinents dans `MyIA.AI.Notebooks/` :
 
-- **Hierarchie des puces** : sous-items indentes correctement (2 espaces)
-- **Eclatement des slides denses** : les slides surchargees ont ete scindees en 2-3 slides
-- **Cross-references notebooks** : liens vers les notebooks Jupyter pertinents en fin de section
-- **Enrichissement textuel** : reformulation des fragments telegraphiques, ajout d'exemples et de contexte
-- **Slides "Questions?"** : conservees comme pauses respiratoires entre sections
-- **Images libres de droits** : ajout d'illustrations Wikimedia Commons (CC BY-SA, CC0) pour les decks pauvres en visuels
+| Deck | Notebooks references | Type |
+|------|----------------------|------|
+| 01 Introduction | (transversal) | Vue d'ensemble |
+| 02 Resolution | `Search/`, `Sudoku/` | Demo directe |
+| 03 Logique | `SymbolicAI/`, `Lean/` | Demo directe |
+| 04 Probabilites | `Probas/`, `Infer/` | Demo directe |
+| 05 Theorie des jeux | `GameTheory/` | Demo directe |
+| 06 Apprentissage | `ML/`, `RL/` | Demo partielle |
+| 07 Elargissements | (transversal) | References |
+| 08 IA Generative | `GenAI/` | Demo riche |
+| S1 Argumentation | `SymbolicAI/Argument_Analysis/` | Demo directe |
+| S2 IA exploratoire | `Search/`, `Sudoku/`, `SymbolicAI/` | TP pratique |
+| S3 Acculturation | (transversal) | Vulgarisation |
+| S4 Trading algo | `QuantConnect/` | Demo directe (27 notebooks + 89 strategies) |
 
 ## Structure par deck
 
 ```
 slides/
-  themes/
-    ia101.css                # Theme Marp partage
-  .marprc.yml                # Configuration Marp (theme, HTML, local files)
-  .markdownlint.json         # Regles markdownlint adaptees a Marp
-  _tools/
-    pptx_to_marp.py          # Script de conversion PPTX -> Marp
+  package.json               # Slidev CLI + theme-default + playwright-chromium
+  theme-ia101/               # Theme Slidev partage (layouts, styles, composants Vue)
+    index.ts
+    layouts/                 # cover, section, questions, image-overlay, dense, two-cols
+    styles/
+    package.json
+  _tools/                    # Scripts conversion PPTX (historique)
+    pptx_to_marp.py          # Etape 1 : PPTX -> Markdown brut
+    marp_to_slidev.py        # Etape 2 : normalisation Slidev + layouts
     slide_tools.py           # Extraction PPTX (texte, images, inventaire)
     batch_extract_all.py     # Extraction batch des 12 decks
-    slide_inventory.py       # Inventaire presentations etudiantes
+    compare_marp_pptx.py     # Diff visuel PPTX <-> rendu Slidev
+  analysis/                  # Rapports audits visuels cross-deck
   XX-nom-du-deck/
-    slides.md                # Source Marp (livrable principal, commite)
+    slides.md                # Source Slidev (livrable principal, commite)
     images/                  # Images referencees par slides.md (commite)
-    output/                  # HTML/PDF generes par Marp CLI [.gitignore]
-    original/                # PPTX de reference [.gitignore]
-    extracted/
-      content.md             # Texte markdown extrait du PPTX
-      inventory.json         # Metadonnees (layout, mots, images par slide)
-      renders/               # PNG de chaque slide PPTX [.gitignore]
-      images/                # Images extraites du PPTX [.gitignore]
-    analysis/
-      improvement_plan.md    # Diagnostic qualitatif + plan d'amelioration
+    pptx-reference/          # Renders PNG du PPTX d'origine pour audit visuel (commite)
+    analysis/                # Audits PPTX<->Slidev, mapping, vision compare
+      mapping-YYYYMMDD.md
+      visual-audit-deckNN.md
+    public/                  # Assets statiques Slidev (optionnel)
 ```
 
-## Cross-references slides <-> notebooks
+## Pipeline de conversion (historique)
 
-| Deck | Repertoire notebooks | Nb notebooks | Type |
-|------|---------------------|--------------|------|
-| 01 Introduction | (transversal) | - | Vue d'ensemble |
-| 02 Resolution | `Search/`, `Sudoku/` | ~15 | Demo directe |
-| 03 Logique | `SymbolicAI/`, `Lean/` | ~35 | Demo directe |
-| 04 Probabilites | `Probas/`, `Infer/` | ~22 | Demo directe |
-| 05 Theorie des jeux | `GameTheory/` | ~26 | Demo directe |
-| 06 Apprentissage | `ML/`, `RL/` | ~8 | Demo partielle |
-| 07 Elargissements | (transversal) | - | References |
-| 08 IA Generative | `GenAI/` | ~58 | Demo riche |
-| S1 Argumentation | `SymbolicAI/Argument_Analysis/` | 5 | Demo directe |
-| S2 IA exploratoire | `Search/`, `Sudoku/`, `SymbolicAI/` | ~35 | TP pratique |
-| S3 Acculturation | (transversal) | - | Vulgarisation |
-| S4 Trading algo | `QuantConnect/` | ~27 | Demo directe |
+Les decks 01-08 et S1-S4 ont ete convertis depuis des PPTX originaux en deux temps :
 
-## Pipeline de conversion
+1. **PPTX -> Marp** via `_tools/pptx_to_marp.py` (extraction texte + images + inventaire)
+2. **Marp -> Slidev** via `_tools/marp_to_slidev.py` (normalisation frontmatter, conversion layouts, migration theme `ia101.css` vers `theme-ia101/`)
+3. **Relecture qualitative** : hierarchie des puces, eclatement des slides denses, cross-references notebooks, enrichissement textuel
+4. **Audits visuels PPTX <-> Slidev** : mapping manuel + verification sk-agent glm-4.6v + screenshots Playwright par slide
 
-La conversion depuis les PPTX originaux s'est faite en plusieurs etapes :
+Le format Marp n'est plus utilise pour editer les slides — les scripts de conversion restent disponibles pour d'eventuels nouveaux decks PPTX a importer.
 
-1. **Extraction** : `slide_tools.py full-extract` -> `content.md`, `inventory.json`, images
-2. **Conversion** : `pptx_to_marp.py` -> `slides.md` brut avec images migrees
-3. **Relecture qualitative** : amelioration manuelle (hierarchie, splits, cross-refs, TODOs)
-4. **Verification** : rendu Marp CLI sans erreur pour les 12 decks
+## Audits visuels
+
+Chaque deck critique (cours imminent) fait l'objet d'un audit visuel strict :
+- **Mapping PPTX <-> Slidev** : paires de titres, SPLIT/MERGE/MISSING/EXTRA
+- **Vision compare** : `mcp__sk-agent__call_agent` (model `glm-4.6v`) avec screenshots cote-a-cote
+- **Screenshots Playwright** : `?clicks=99` pour capturer le contenu complet apres toutes les animations
+- **Rapport** : `<deck>/analysis/visual-audit-deck<NN>.md` avec verdict par slide (MATCH / PARTIAL / DIFFERENT)
+
+Regles de base pour les images et le layout :
+- Zero image mal taillee (ratio respecte, pas d'ecrasement ni d'etirement)
+- Zero superposition texte/image
+- Zero overflow (contenu coupe en bas = rejet)
+- Positionnement explicite (top/right/width documentes, jamais par defaut)
+- Coherence visuelle inter-slides
 
 ## Decisions de conception
 
-- **Format Marp** (Markdown) : lisible et editable en texte pur, versionnable dans git
+- **Slidev** (Markdown + Vue) : hot-reload, layouts custom, composants Vue pour interactivite, export HTML/PDF
+- **Theme-ia101 partage** : coherence visuelle entre tous les decks (13 au total)
+- **Images en overlay** : layout `image-overlay` pour les slides image-dominantes, jamais en colonne droite (convention issue #221, confirmee 5+ fois)
 - **Slides "Questions?"** conservees comme pauses respiratoires entre sections
-- **Theme partage** (`ia101.css`) : coherence visuelle entre tous les decks
-- **Images migrees depuis PPTX** : conservees dans `images/` par deck
-- **PPTX originaux en .gitignore** : servent de reference mais ne sont pas edites
+- **PPTX-reference en `.gitignore` ou committe** selon le deck : les renders PNG servent a l'audit visuel
+- **Cross-references notebooks** : chaque deck termine ses sections par un lien vers le notebook Jupyter correspondant


### PR DESCRIPTION
## Summary

The `slides/README.md` was still describing the Marp workflow despite all 13 decks having migrated to Slidev weeks ago.

### Changes
- **Commands** : `marp-cli` → `slidev` CLI (dev / build / export)
- **Theme** : `themes/ia101.css` (deleted) → `theme-ia101/` directory with custom Slidev layouts
- **Installation** : added `cd slides && npm install` step
- **Inventory table** : updated structure to reflect current decks (S4-trading-exercices added, removed the misleading "Total" row with outdated counts)
- **Visual audit section** : new section documenting sk-agent vision + Playwright protocol and base rules for images
- **Pipeline** : kept as historical reference (pptx → marp → slidev)
- **Cross-refs** : updated QC notebook counts (27 notebooks + 89 strategies)

### Test plan
- [x] README renders correctly in GitHub preview
- [x] Commands match actual `slides/package.json` scripts
- [x] No remaining references to `marp-cli` in the active workflow
- [x] Theme path `theme-ia101/` exists and matches frontmatter