### PR TITLE
fix(pedagogy): remove solution leaks from 4 EPITA notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
@@ -1698,11 +1698,8 @@
     },
     "tags": []
    },
-   "source": [
-    "#### Solution de l'exercice 1\n",
-    "\n",
-    "Utilisons une recherche en largeur (BFS) simple pour trouver la solution."
-   ]
+   "source": "#### Indices pour l'exercice 1\n\n**Rappels** :\n- Utilisez une recherche en largeur (BFS) pour explorer l'espace d'etats\n- La file (deque) contient des paires `(etat, liste_actions)`\n- Pensez a marquer les etats visites pour eviter les boucles\n- La condition d'arret est `problem.is_goal(state)`\n\n```python\nfrom collections import deque\n\ndef bfs_solve(problem: SearchProblem):\n    # TODO: Implementez la recherche en largeur\n    pass  # A completer\n```",
+   "outputs": []
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -2000,7 +2000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "exercise-3",
    "metadata": {
     "execution": {
@@ -2018,117 +2018,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Approche hybride CNN + Backtracking ===\n",
-      "\n",
-      "Puzzle 1 :\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  NN a rempli 41 cases (seuil=0.9), backtracking pour les 14 restantes\n",
-      "  Resultat : 30/81 cases correctes\n",
-      "\n",
-      "Puzzle 2 :\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  NN a rempli 37 cases (seuil=0.9), backtracking pour les 13 restantes\n",
-      "  Resultat : 42/81 cases correctes\n",
-      "\n",
-      "Puzzle 3 :\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  NN a rempli 36 cases (seuil=0.9), backtracking pour les 11 restantes\n",
-      "  Resultat : 44/81 cases correctes\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 3 : Approche hybride\n",
-    "# Indice : le NN reduit le nombre de cases a explorer par backtracking\n",
-    "\n",
-    "def hybrid_solve(model, puzzle: np.ndarray, confidence_threshold: float = 0.95) -> np.ndarray:\n",
-    "    \"\"\"Resout un Sudoku par approche hybride NN + backtracking.\"\"\"\n",
-    "    current = puzzle.copy()\n",
-    "    \n",
-    "    # Phase 1 : remplir les cases avec haute confiance\n",
-    "    model.eval()\n",
-    "    nn_filled = 0\n",
-    "    \n",
-    "    while True:\n",
-    "        encoded = encode_puzzle(current)\n",
-    "        x = torch.FloatTensor(encoded).permute(2, 0, 1).unsqueeze(0).to(device)\n",
-    "        with torch.no_grad():\n",
-    "            output = model(x)\n",
-    "            probs = torch.softmax(output[0], dim=-1).cpu().numpy()\n",
-    "        \n",
-    "        # Trouver la case vide la plus confiante\n",
-    "        best_conf = -1\n",
-    "        best_pos = None\n",
-    "        best_digit = None\n",
-    "        \n",
-    "        for r in range(9):\n",
-    "            for c in range(9):\n",
-    "                if current[r, c] == 0:\n",
-    "                    max_prob = probs[r, c].max()\n",
-    "                    if max_prob > best_conf:\n",
-    "                        best_conf = max_prob\n",
-    "                        best_pos = (r, c)\n",
-    "                        best_digit = probs[r, c].argmax() + 1\n",
-    "        \n",
-    "        if best_pos is None or best_conf < confidence_threshold:\n",
-    "            break\n",
-    "        \n",
-    "        current[best_pos[0], best_pos[1]] = best_digit\n",
-    "        nn_filled += 1\n",
-    "    \n",
-    "    # Phase 2 : backtracking pour les cases restantes\n",
-    "    remaining = np.sum(current == 0)\n",
-    "    \n",
-    "    def backtrack(grid):\n",
-    "        for r in range(9):\n",
-    "            for c in range(9):\n",
-    "                if grid[r, c] == 0:\n",
-    "                    for num in range(1, 10):\n",
-    "                        if is_valid(grid, r, c, num):\n",
-    "                            grid[r, c] = num\n",
-    "                            if backtrack(grid):\n",
-    "                                return True\n",
-    "                            grid[r, c] = 0\n",
-    "                    return False\n",
-    "        return True\n",
-    "    \n",
-    "    backtrack(current)\n",
-    "    print(f\"  NN a rempli {nn_filled} cases (seuil={confidence_threshold}), \"\n",
-    "          f\"backtracking pour les {remaining} restantes\")\n",
-    "    \n",
-    "    return current\n",
-    "\n",
-    "\n",
-    "# Test\n",
-    "print(\"=== Approche hybride CNN + Backtracking ===\")\n",
-    "for i in range(3):\n",
-    "    puzzle = puzzles_test[i]\n",
-    "    solution = solutions_test[i]\n",
-    "    print(f\"\\nPuzzle {i+1} :\")\n",
-    "    result = hybrid_solve(cnn_model, puzzle, confidence_threshold=0.90)\n",
-    "    n_correct = np.sum(result == solution)\n",
-    "    print(f\"  Resultat : {n_correct}/81 cases correctes\")"
-   ]
+   "outputs": [],
+   "source": "# Exercice 3 : Approche hybride\n# Indice : le NN reduit le nombre de cases a explorer par backtracking\n\ndef hybrid_solve(model, puzzle: np.ndarray, confidence_threshold: float = 0.95) -> np.ndarray:\n    \"\"\"Resout un Sudoku par approche hybride NN + backtracking.\"\"\"\n    # TODO: Implementez l'approche hybride\n    # 1. Utilisez le modele pour pre-remplir les cases confiantes (probabilite > threshold)\n    # 2. Appliquez un backtracking sur les cases restantes\n    current = puzzle.copy()\n    \n    # A completer...\n    print(\"Exercice a completer - hybrid_solve\")\n    return current"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1575,43 +1575,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "Alpha      Succes     Temps moy. (ms)   "
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "----------------------------------------"
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "0,99       10/10      2                 "
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "0,999      10/10      4                 "
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "0,9999     10/10      3                 "
-     },
-     "metadata": {}
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Exercice 1 : Comparaison des programmes de refroidissement\n",
     "// Completez le code ci-dessous pour tester differentes valeurs de Alpha\n",
@@ -1676,15 +1640,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "Exercice 2 : implementez le rechauffement adaptatif ci-dessus."
-     },
-     "metadata": {}
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Exercice 2 : Rechauffement adaptatif\n",
     "// A completer : modifier SimulatedAnnealingWithReheatSolver\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -721,29 +721,7 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "Easy : 0/51 resolus par propagation seule"
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "Medium : 0/11 resolus par propagation seule"
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": "Hard : 0/95 resolus par propagation seule"
-     },
-     "metadata": {}
-    }
-   ]
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- **Search-1-StateSpace**: Replaced "Solution de l'exercice 1" markdown cell with pedagogical hints (was giving away the full BFS approach to Missionaries & Cannibales exercise)
- **Sudoku-16-NeuralNetwork-Python**: Replaced full solution code in Exercice 3 (hybrid_solve) with a stub + TODO marker, cleared outputs
- **Sudoku-4-SimulatedAnnealing-Csharp**: Cleared outputs from exercise cells 34 and 36 (results table was revealing expected backtest performance)
- **Sudoku-7-Norvig-Csharp**: Cleared outputs from exercise cell 28 (showed propagation-only solve counts)

## Verification

Post-fix scan confirms 0 solution leaks across all EPITA notebooks:
- Search Part1-Foundations: 7/7 notebooks
- Search Part2-CSP: 9/9 notebooks
- Sudoku Python: 17/17 notebooks
- Sudoku C#: 15/15 notebooks

All exercise cells have proper stubs (TODO, COMPLETER, NotImplementedError/Exception).

## Known remaining (non-blocking)

- 30 notebooks have structural corruption (exercises placed after "Et ensuite?" section) — tracked for follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)