### PR TITLE
docs(notebook): clarify two accuracy columns in Sudoku-16 evaluation

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -1482,6 +1482,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "eval-ambiguity-note",
+   "metadata": {},
+   "source": [
+    "> **A lire avant d'executer la cellule suivante** : la sortie contient DEUX mesures distinctes :\n",
+    ">\n",
+    "> - **Precision/case** (`cell_acc`) — pourcentage de cases (1 a 81) correctement predites. **C'est la mesure utile** : comptez ~30% pour le MLP, ~50-55% pour le CNN.\n",
+    "> - **Precision/grille** (`grid_acc`) — pourcentage de puzzles dont les 81 cases sont SIMULTANEMENT correctes. **Elle sera a 0% (0/200)**. C'est le comportement attendu avec seulement 1000 puzzles d'entrainement et des reseaux purs sans contrainte Sudoku.\n",
+    ">\n",
+    "> Ne vous inquietez pas si la colonne `Precision/grille` affiche `0.0%` : cela fait partie de la lecon pedagogique (cf. interpretation ci-dessous). Si en revanche `Precision/case` est tres basse (< 20%), verifiez que les cellules d'entrainement (sections 3 et 4) ont bien ete executees avant."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "full-eval",


### PR DESCRIPTION
## Contexte

Un etudiant a rapporte "accuracy zero" sur le notebook Sudoku-16-NeuralNetwork-Python alors que la sortie prevue indique ~30% (MLP) ou ~50% (CNN).

## Diagnostic

Le notebook expose DEUX mesures dans la cellule d'evaluation :
- `Precision/case` (cell_acc) : 30-55% — la mesure utile
- `Precision/grille` (grid_acc) : **0/200 = 0%** — normal avec 1000 puzzles + reseaux purs sans contrainte Sudoku

L'interpretation markdown qui suit la cellule explique bien que la precision grille a 0% est attendue, mais plusieurs etudiants lisent la sortie avant l'interpretation et concluent "j'ai zero".

## Reproduction

J'ai re-execute le CNN localement (torch 2.10 CPU, 5 epochs, 400 train / 100 test) → `cell_acc = 0.519`. Le code fonctionne comme attendu. Ce n'est pas un bug code, c'est une ambiguite pedagogique.

## Changement

Ajout d'une cellule markdown de type "callout" juste APRES le titre `## 6. Evaluation comparative et analyse` et AVANT la cellule d'evaluation, qui :
- Clarifie que `Precision/grille = 0.0%` est ATTENDU (comportement normal, pas un bug)
- Indique les valeurs de `Precision/case` a attendre (~30% MLP, ~50-55% CNN)
- Oriente le diagnostic si `cell_acc < 20%` : verifier que les sections 3 et 4 ont ete executees

## Test plan

- [x] `nbformat.validate` passe
- [x] Reproduction CNN cell_acc = 0.519 confirmee sur CPU
- [x] Aucune modification de code, juste une cellule markdown ajoutee

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>