### PR TITLE
fix(sudoku-12): add missing section 3 header

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -187,6 +187,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 3. Solveurs Z3 : Int et BitVector\n",
+    "\n",
+    "Nous presentons deux approches pour encoder le Sudoku avec Z3 :\n",
+    "\n",
+    "- **Z3 Int** : variables entieres symboliques (Int), encodage classique.\n",
+    "- **Z3 BitVector** : variables BitVec 4 bits, optimisation pour plages bornees.\n",
+    "\n",
+    "Nous definissons d'abord une representation de la grille, puis comparons les deux encodages sur les memes puzzles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Representation de la grille Sudoku avec fonctions de chargement."
    ],
    "id": "c0d8af3c2d9b36c"


### PR DESCRIPTION
## Summary
- Sudoku-12-Z3-Python had a numbering gap (sections 1, 2, 4, 5 — no ## 3.)
- Section 3 content (SudokuGrid, Z3Solver, Z3BitVectorSolver, interpretations) was present without a top-level markdown header
- This PR adds a `## 3. Solveurs Z3 : Int et BitVector` markdown cell between config code and SudokuGrid class to restore structural continuity
- Pre-existing bug not caught during PR #382 structural fixes

## Test plan
- [x] Structural diff verified: sections now numbered 1, 2, 3, 4, 5 consecutively
- [x] No code cell modified, only markdown header added
- [ ] Papermill re-execution not required (no logic change)

Part of review rigor work (see CLAUDE.md review-rigor rules 2026-04-20).