### PR TITLE
fix(csp): align notebook titles with filenames (refs #383)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Search-6-CSP-Fundamentals\n",
+    "# CSP-1 : Fondamentaux des CSP\n",
     "\n",
     "**Navigation** : [<< Search-5 GeneticAlgorithms](Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [Search-7 CSP-Consistency >>](Search-7-CSP-Consistency.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Search-7-CSP-Consistency\n",
+    "# CSP-2 : Propagation de Contraintes et Consistance\n",
     "\n",
     "**Navigation** : [<< Search-6 CSP-Fundamentals](Search-6-CSP-Fundamentals.ipynb) | [Index](../README.md) | [Search-8 CSP-Advanced >>](Search-8-CSP-Advanced.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Search-8 : CSP Avance - Contraintes globales, OR-Tools et LNS\n",
+    "# CSP-3 : CSP Avance - Contraintes globales, OR-Tools et LNS\n",
     "\n",
     "**Navigation** : [<< Search-7 CSP-Consistency](Search-7-CSP-Consistency.ipynb) | [Index](../README.md) | [Applications >>](../Applications/README.md)\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# Search-17 : CSP Temporels - Raisonnement sur le Temps\n",
+    "# CSP-8 : CSP Temporels - Raisonnement sur le Temps\n",
     "\n",
     "**Navigation** : [<< Search-16 CSP-Soft](Search-16-CSP-Soft.ipynb) | [Index](../README.md) | [Search-18 CSP-Distributed >>](Search-18-CSP-Distributed.ipynb)\n",
     "\n",


### PR DESCRIPTION
## Summary
4 Part2-CSP notebooks had H1 titles using legacy \`Search-N\` numbering while their filenames use the newer \`CSP-N\` convention. Flagged in issue #383 (po-2023 audit) for CSP-8 specifically.

## Renames (H1 only)
| File | Old title | New title |
|------|-----------|-----------|
| CSP-1-Fundamentals | \`Search-6-CSP-Fundamentals\` | \`CSP-1 : Fondamentaux des CSP\` |
| CSP-2-Consistency | \`Search-7-CSP-Consistency\` | \`CSP-2 : Propagation de Contraintes et Consistance\` |
| CSP-3-Advanced | \`Search-8 : CSP Avance...\` | \`CSP-3 : CSP Avance...\` |
| CSP-8-Temporal | \`Search-17 : CSP Temporels...\` | \`CSP-8 : CSP Temporels...\` |

## Scope
- **Title only** (H1 first line of cell 0)
- Navigation links and cross-references inside the notebooks still use old \`Search-N\` names. Those are left for a separate pass — they point to neighbor notebooks (\`Search-6-CSP-Fundamentals.ipynb\` etc.) that would themselves need renaming.

## Test plan
- [x] Minimal diff (4 files, 4+/4-): byte-level string replacement preserves all JSON structure (outputs, metadata, execution_count intact)
- [x] All 4 notebooks verified: JSON parses, new titles visible, no cell data lost
- [x] 5 other CSP notebooks already used correct naming (CSP-4/5/6/7/9) — no change needed

Refs #383