### PR TITLE
fix(csp): reorder misplaced sections in CSP-2, CSP-5, CSP-9

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -1194,47 +1194,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-25",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008876,
-     "end_time": "2026-02-26T06:45:36.006124",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:35.997248",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 4. Forward Checking (~8 min)\n",
-    "\n",
-    "Le **Forward Checking** (FC) est une technique qui integre la propagation de contraintes directement dans le backtracking. L'idee est simple :\n",
-    "\n",
-    "> Quand on assigne $X_i = v$, on retire immediatement les valeurs incompatibles des domaines des **voisins non assignes** de $X_i$.\n",
-    "\n",
-    "### Difference avec le backtracking simple\n",
-    "\n",
-    "| Backtracking pur | Forward Checking |\n",
-    "|-------------------|------------------|\n",
-    "| Verifie la consistance seulement avec les variables **deja assignees** | En plus, propage vers les variables **non assignees** |\n",
-    "| Detecte les echecs au moment de l'assignation | Detecte les echecs plus tot (domaine vide) |\n",
-    "| Ne modifie pas les domaines | Reduit les domaines dynamiquement |\n",
-    "\n",
-    "### Principe\n",
-    "\n",
-    "1. Choisir une variable $X_i$ (avec MRV par exemple)\n",
-    "2. Pour chaque valeur $v \\in D_i$ :\n",
-    "   a. Assigner $X_i = v$\n",
-    "   b. Pour chaque voisin non assigne $X_j$, retirer de $D_j$ les valeurs incompatibles avec $v$\n",
-    "   c. Si un domaine devient vide, **backtrack immediatement** (pas besoin d'essayer plus loin)\n",
-    "   d. Sinon, recurser sur les variables restantes\n",
-    "   e. Restaurer les domaines si echec (backtrack)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "46v1yvn2tk6",
    "metadata": {},
    "source": [
@@ -1678,6 +1637,47 @@
     "### 3.5 AC-3 vs AC-4 : Comparaison des algorithmes de consistance d'arc\n",
     "\n",
     "AC-3 n'est pas le seul algorithme pour etablir la consistance d'arc. Voici une comparaison avec **AC-4**, une alternative optimisee pour certains cas.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-25",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008876,
+     "end_time": "2026-02-26T06:45:36.006124",
+     "exception": false,
+     "start_time": "2026-02-26T06:45:35.997248",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Forward Checking (~8 min)\n",
+    "\n",
+    "Le **Forward Checking** (FC) est une technique qui integre la propagation de contraintes directement dans le backtracking. L'idee est simple :\n",
+    "\n",
+    "> Quand on assigne $X_i = v$, on retire immediatement les valeurs incompatibles des domaines des **voisins non assignes** de $X_i$.\n",
+    "\n",
+    "### Difference avec le backtracking simple\n",
+    "\n",
+    "| Backtracking pur | Forward Checking |\n",
+    "|-------------------|------------------|\n",
+    "| Verifie la consistance seulement avec les variables **deja assignees** | En plus, propage vers les variables **non assignees** |\n",
+    "| Detecte les echecs au moment de l'assignation | Detecte les echecs plus tot (domaine vide) |\n",
+    "| Ne modifie pas les domaines | Reduit les domaines dynamiquement |\n",
+    "\n",
+    "### Principe\n",
+    "\n",
+    "1. Choisir une variable $X_i$ (avec MRV par exemple)\n",
+    "2. Pour chaque valeur $v \\in D_i$ :\n",
+    "   a. Assigner $X_i = v$\n",
+    "   b. Pour chaque voisin non assigne $X_j$, retirer de $D_j$ les valeurs incompatibles avec $v$\n",
+    "   c. Si un domaine devient vide, **backtrack immediatement** (pas besoin d'essayer plus loin)\n",
+    "   d. Sinon, recurser sur les variables restantes\n",
+    "   e. Restaurer les domaines si echec (backtrack)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -909,6 +909,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "394e95e4",
+   "metadata": {},
+   "source": [
+    "## 4. Optimisation de Portefeuille\n\n",
+    "L'optimisation de portefeuille avec contraintes de cardinalite\n",
+    "est un probleme classique qui combine selection d'actifs et contraintes budgetaires.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5012b0fc",
    "metadata": {
     "papermill": {
@@ -1307,35 +1317,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f60f676f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004481,
-     "end_time": "2026-03-04T16:41:05.813195",
-     "exception": false,
-     "start_time": "2026-03-04T16:41:05.808714",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 6. Exercices\n",
-    "\n",
-    "### Exercice 1: Multi-Knapsack\n",
-    "Généralisez le Knapsack à plusieurs sacs avec capacités différentes.\n",
-    "\n",
-    "### Exercice 2: Bin Packing avec contraintes de conflit\n",
-    "Certains objets ne peuvent pas être dans le même bin. Ajoutez cette contrainte.\n",
-    "\n",
-    "### Exercice 3: Portfolio avec contraintes de risque\n",
-    "Ajoutez une contrainte de variance maximale du portefeuille.\n",
-    "\n",
-    "### Exercice 4: Cutting Stock avec chutes réutilisables\n",
-    "Les chutes de longueur > seuil peuvent être réutilisées comme nouvelles barres."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "h2ha8li6gbe",
    "metadata": {},
    "source": [
@@ -1503,6 +1484,35 @@
     "2. $s_1$ est strictement meilleure sur au moins un critere\n",
     "\n",
     "En eliminant les solutions dominees, on reduit l'espace de recherche sans perdre la solution optimale.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f60f676f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004481,
+     "end_time": "2026-03-04T16:41:05.813195",
+     "exception": false,
+     "start_time": "2026-03-04T16:41:05.808714",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercices\n",
+    "\n",
+    "### Exercice 1: Multi-Knapsack\n",
+    "Généralisez le Knapsack à plusieurs sacs avec capacités différentes.\n",
+    "\n",
+    "### Exercice 2: Bin Packing avec contraintes de conflit\n",
+    "Certains objets ne peuvent pas être dans le même bin. Ajoutez cette contrainte.\n",
+    "\n",
+    "### Exercice 3: Portfolio avec contraintes de risque\n",
+    "Ajoutez une contrainte de variance maximale du portefeuille.\n",
+    "\n",
+    "### Exercice 4: Cutting Stock avec chutes réutilisables\n",
+    "Les chutes de longueur > seuil peuvent être réutilisées comme nouvelles barres."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -1575,21 +1575,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exercices\n",
-    "\n",
-    "### Exercice 1 : N-Queens distribue\n",
-    "Implementez une resolution distribuee du probleme des N-reines ou chaque agent controle une colonne.\n",
-    "\n",
-    "### Exercice 2 : Comparaison ABT vs AWC\n",
-    "Comparez les performances d'ABT et AWC sur des graphes de coloration de densite variable.\n",
-    "\n",
-    "### Exercice 3 : Negociation multi-agent\n",
-    "Simulez une negociation entre 4 agents pour l'allocation de ressources avec preferences secretes.\n",
-    "\n",
-    "### Exercice 4 : Analyse de confidentialite\n",
-    "Quantifiez la quantite d'information revelee dans ABT standard vs privacy-preserving."
-   ]
+   "source": "## Exercices\n\n### Exercice 1 : N-Queens distribue\nImplementez une resolution distribuee du probleme des N-reines ou chaque agent controle une colonne."
   },
   {
    "cell_type": "code",
@@ -1819,6 +1805,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "013260c1",
+   "source": "## 7. Synthese et bonnes pratiques\n\n### Quand utiliser DisCSP ?\n\n| Scenario | DisCSP approprie ? | Algorithme recommande |\n|----------|-------------------|----------------------|\n| Agents independants avec confidentialite | Oui | ABT + Privacy-preserving |\n| Problemes tres difficiles | Oui | AWC (reordonnancement) |\n| Passage a l'echelle massif | Oui | Distributed Breakout |\n| Coordination simple, confiance totale | Non | Centralise (plus simple) |\n| Real-time strict | Non | Latence communication trop elevee |\n\n### Points cles a retenir\n\n1. **ABT** est l'algorithme de base, simple et correct\n2. **AWC** ameliore les performances sur les instances difficiles\n3. **Privacy-preserving** est crucial pour les applications reelles\n4. **Communication asynchrone** = robustesse mais complexite accrue\n5. **Nogoods** = apprentissage distribue, mais attention a l'explosion",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "bd81bd52",
+   "source": "# Cellule finale - Resume du notebook\nprint(\"=== Resume CSP-9: CSP Distribues ===\")\nprint(\"\")\nprint(\"Concepts couverts:\")\nprint(\"1. Formalisation DisCSP (agents, contraintes inter-agent)\")\nprint(\"2. Asynchronous Backtracking (ABT) - algorithme de base\")\nprint(\"3. Messages ok?, nogood, addlink, stop\")\nprint(\"4. Apprentissage par nogoods\")\nprint(\"5. Asynchronous Weak-Commitment (AWC) - reordonnancement dynamique\")\nprint(\"6. Privacy-preserving CSP - protection des contraintes privees\")\nprint(\"7. Application: Ordonnancement multi-hopital\")\nprint(\"\")\nprint(\"Prochaines etapes:\")\nprint(\"- Explorer Distributed Breakout pour l'optimisation\")\nprint(\"- Combiner avec des techniques de ML pour l'apprentissage de contraintes\")\nprint(\"- Appliquer aux smart grids et reseaux peer-to-peer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "ed14da1e",
    "metadata": {
     "papermill": {
@@ -1848,103 +1848,6 @@
     "- Private DisCSP (Silaghi et al., 2007)\n",
     "- Distributed Breakout Algorithm (Yokoo & Hirayama, 1996)\n",
     "- DisCSP avec incertitude (besoins de probabilites)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "29ee3cf6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-21T02:18:10.978783Z",
-     "iopub.status.busy": "2026-04-21T02:18:10.978321Z",
-     "iopub.status.idle": "2026-04-21T02:18:10.985811Z",
-     "shell.execute_reply": "2026-04-21T02:18:10.984486Z"
-    },
-    "papermill": {
-     "duration": 0.016413,
-     "end_time": "2026-03-05T12:19:19.089488",
-     "exception": false,
-     "start_time": "2026-03-05T12:19:19.073075",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Resume Search-18: CSP Distribues ===\n",
-      "\n",
-      "Concepts couverts:\n",
-      "1. Formalisation DisCSP (agents, contraintes inter-agent)\n",
-      "2. Asynchronous Backtracking (ABT) - algorithme de base\n",
-      "3. Messages ok?, nogood, addlink, stop\n",
-      "4. Apprentissage par nogoods\n",
-      "5. Asynchronous Weak-Commitment (AWC) - reordonnancement dynamique\n",
-      "6. Privacy-preserving CSP - protection des contraintes privees\n",
-      "7. Application: Ordonnancement multi-hopital\n",
-      "\n",
-      "Prochaines etapes:\n",
-      "- Explorer Distributed Breakout pour l'optimisation\n",
-      "- Combiner avec des techniques de ML pour l'apprentissage de contraintes\n",
-      "- Appliquer aux smart grids et reseaux peer-to-peer\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Cellule finale - Resume du notebook\n",
-    "print(\"=== Resume Search-18: CSP Distribues ===\")\n",
-    "print(\"\")\n",
-    "print(\"Concepts couverts:\")\n",
-    "print(\"1. Formalisation DisCSP (agents, contraintes inter-agent)\")\n",
-    "print(\"2. Asynchronous Backtracking (ABT) - algorithme de base\")\n",
-    "print(\"3. Messages ok?, nogood, addlink, stop\")\n",
-    "print(\"4. Apprentissage par nogoods\")\n",
-    "print(\"5. Asynchronous Weak-Commitment (AWC) - reordonnancement dynamique\")\n",
-    "print(\"6. Privacy-preserving CSP - protection des contraintes privees\")\n",
-    "print(\"7. Application: Ordonnancement multi-hopital\")\n",
-    "print(\"\")\n",
-    "print(\"Prochaines etapes:\")\n",
-    "print(\"- Explorer Distributed Breakout pour l'optimisation\")\n",
-    "print(\"- Combiner avec des techniques de ML pour l'apprentissage de contraintes\")\n",
-    "print(\"- Appliquer aux smart grids et reseaux peer-to-peer\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dd2989fc",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005558,
-     "end_time": "2026-03-05T12:19:19.045311",
-     "exception": false,
-     "start_time": "2026-03-05T12:19:19.039753",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 7. Synthese et bonnes pratiques\n",
-    "\n",
-    "### Quand utiliser DisCSP ?\n",
-    "\n",
-    "| Scenario | DisCSP approprie ? | Algorithme recommande |\n",
-    "|----------|-------------------|----------------------|\n",
-    "| Agents independants avec confidentialite | Oui | ABT + Privacy-preserving |\n",
-    "| Problemes tres difficiles | Oui | AWC (reordonnancement) |\n",
-    "| Passage a l'echelle massif | Oui | Distributed Breakout |\n",
-    "| Coordination simple, confiance totale | Non | Centralise (plus simple) |\n",
-    "| Real-time strict | Non | Latence communication trop elevee |\n",
-    "\n",
-    "### Points cles a retenir\n",
-    "\n",
-    "1. **ABT** est l'algorithme de base, simple et correct\n",
-    "2. **AWC** ameliore les performances sur les instances difficiles\n",
-    "3. **Privacy-preserving** est crucial pour les applications reelles\n",
-    "4. **Communication asynchrone** = robustesse mais complexite accrue\n",
-    "5. **Nogoods** = apprentissage distribue, mais attention a l'explosion"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- **CSP-2**: Move subsections 3.4/3.5 back inside section 3 (were after section 4 header)
- **CSP-5**: Add missing section 4 header for Portfolio content; move subsections 5.1/5.3 before Exercices
- **CSP-9**: Remove duplicate exercise descriptions from summary cell; move section 7 Synthese before References

These are mechanical structural fixes identified in the Issue #383 audit. CSP-8 was checked and found already correct (title was already `CSP-8 : CSP Temporels`, not `Search-17`).

## Test plan
- [x] Verified section header order in all 3 notebooks via Python JSON parsing
- [x] CSP-2: `##1, ##2, ##3, ##4, ##5, ##6, ##7, ##8` (correct ascending order)
- [x] CSP-5: `##1, ##2, ##3, ##4(new), ##5, ##6, ##References, ##Conclusion` (correct)
- [x] CSP-9: `##Exercices(Ex1 only), ###Ex2, ###Ex3, ###Ex4, ##7 Synthese, ##References` (correct)

Refs #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)