### PR TITLE
docs(qc): DATA-ONLY markers for 7 viz-only notebooks + VIX metrics summary

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Chronos-Foundation-Forecasting/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Chronos-Foundation-Forecasting/research.ipynb
@@ -35,6 +35,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. L'implementation de la strategie contient des erreurs d'execution (erreurs de forme dans les donnees, cascades de variables non definies) qui empechent le calcul fiable de metriques de backtest (Sharpe, CAGR, MaxDD). Il presente des concepts et visualisations pedagogiques (quantification de series temporelles, attention mechanism) mais ne constitue pas une strategie validable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Setup et Donnees"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/research.ipynb
@@ -39,6 +39,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. Le moteur de backtest EMA-Cross-Crypto presente des erreurs d'acces aux donnees (KeyError close) sur les regimes de marche, empechant le calcul fiable des metriques de performance. Les tableaux de resultats par regime sont vides. Le notebook presente le cadre conceptuel (backtest EMA cross, analyse par regime) mais les resultats numeriques ne sont pas exploitables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Setup et Données"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/research.ipynb
@@ -34,6 +34,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. L'implementation LSTM (cellule from scratch + backtest) produit une erreur ValueError sur l'evaluation de Series booleennes, bloquant la generation de signaux et le calcul de metriques. Le notebook presente l'architecture LSTM, les mecanismes de portes et la visualisation des filtres mais ne produit pas de backtest fonctionnel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Setup et Donnees"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/research.ipynb
@@ -20,6 +20,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. La recherche multi-hypotheses (H1-H6) echoue en cascade : l'echec du chargement de donnees (ValueError) provoque des NameError successives sur spy_p, h1_df, h2_df, h3_df, base_ret. Les 13/17 cellules sont en erreur. Le notebook presente le cadre de recherche (Hurst exponent, ML overlay, regime detection) mais aucun resultat exploitable."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "f3792812",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/research.ipynb
@@ -39,6 +39,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. L'analyse du covered call (Black-Scholes theta decay, VIX filtering) presente des erreurs de calcul sur 3/4 cellules de code. Les metriques de reference (Sharpe 0.288, CAGR 9.6%) mentionnees en en-tete proviennent du cloud QC et non d'une execution locale reussie. Le contenu pedagogique (mecanique des options, analyse VIX) reste pertinent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section_mechanics",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Reinforcement-Learning-Trading/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Reinforcement-Learning-Trading/research.ipynb
@@ -34,6 +34,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. L'implementation DQN (Deep Q-Network) pour le trading presente des erreurs d'execution sur la moitie des cellules (environnement, agent, training loop). L'agent ne parvient pas a generer de signaux utilisables. Le notebook presente les concepts du RL applique au trading (environnement, recompenses, exploration vs exploitation) mais ne produit pas de backtest fonctionnel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Setup et Donnees"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Temporal-CNN-Prediction/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Temporal-CNN-Prediction/research.ipynb
@@ -32,6 +32,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **[DATA-ONLY]** Ce notebook est a visee exploratoire. L'implementation CNN 1D (filtres de momentum/reversal) produit des erreurs sur la generation de signaux et le backtest. Le notebook presente la theorie des convolutions 1D appliquees aux series temporelles et la visualisation des filtres mais ne produit pas de metriques de backtest fiables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Setup et Donnees"
    ]
   },

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/research.ipynb
@@ -984,6 +984,13 @@
     "\n",
     "Test: Comparer cash vs SPY parking pour les periodes hors SVXY."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Synthese des metriques de backtest\n\nLe notebook VIX-TermStructure produit des metriques exploitables par regime de volatilite :\n\n| Regime | Sharpe Ratio |\n|--------|-------------|\n| VIX < 13 | 7.34 |\n| 13 <= VIX < 16 | 3.67 |\n| VIX >= 16 | 2.82 |\n\nLes meilleures configurations de parametres testees presentent des Sharpe negatifs (de -0.358 a -0.910), ce qui indique que la strategie telle qu'implementee n'est pas profitable sur la periode de test. L'interet pedagogique reside dans l'analyse par regime de volatilite VIX et l'optimisation des parametres de term structure."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Add `[DATA-ONLY]` blockquote headers to 7 QC research notebooks with broken execution (Chronos, EMA-Crypto, LSTM, LongShort, OptionsIncome, RL-Trading, Temporal-CNN)
- Each marker explains specifically why backtest metrics are unavailable for that notebook
- Add metrics summary cell to VIX-TermStructure (has real Sharpe/CAGR data by VIX regime)

## Mission C4 completion
Transforms 8 "visualization-only" projects per coordinator dispatch. 7 cannot produce reliable metrics locally and get [DATA-ONLY] markers. 1 (VIX-TermStructure) already has metrics and gets a summary cell.

## Files changed (8 notebooks, +64 lines)
| Project | Action |
|---------|--------|
| Chronos-Foundation-Forecasting | [DATA-ONLY] marker |
| EMA-Cross-Crypto | [DATA-ONLY] marker |
| LSTM-Forecasting | [DATA-ONLY] marker |
| LongShortHarvest-QC | [DATA-ONLY] marker |
| OptionsIncome | [DATA-ONLY] marker |
| Reinforcement-Learning-Trading | [DATA-ONLY] marker |
| Temporal-CNN-Prediction | [DATA-ONLY] marker |
| VIX-TermStructure | Metrics summary cell |

🤖 Generated with [Claude Code](https://claude.com/claude-code)