### PR TITLE
fix(csp-1): remove duplicate Section 7 block + reposition Section 4.3 (URGENT cours en cours)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -969,403 +969,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cd7141e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006312,
-     "end_time": "2026-02-26T06:45:32.787221",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.780909",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 7. Recapitulatif et exercices\n",
-    "\n",
-    "### Tableau recapitulatif\n",
-    "\n",
-    "| Approche | Noeuds explores | Temps | Facilite d'utilisation |\n",
-    "|----------|----------------|-------|------------------------|\n",
-    "| Brute force | $\\prod |D_i|$ (tous) | Lent | Simple mais intraitable |\n",
-    "| Backtracking simple | Reduit (elagage) | Rapide | Implementation moderee |\n",
-    "| Backtracking + MRV | Tres reduit | Tres rapide | Implementation moderee |\n",
-    "| Backtracking + MRV + LCV | Minimal | Tres rapide | Plus complexe a implementer |\n",
-    "| python-constraint | Optimise (interne) | Rapide | Tres simple (declaratif) |\n",
-    "\n",
-    "### Resume du formalisme CSP\n",
-    "\n",
-    "| Concept | Definition | Exemple |\n",
-    "|---------|------------|--------|\n",
-    "| **Variable** ($X_i$) | Quantite a determiner | Region a colorier |\n",
-    "| **Domaine** ($D_i$) | Valeurs possibles pour $X_i$ | {Rouge, Vert, Bleu} |\n",
-    "| **Contrainte** ($C_k$) | Restriction sur un sous-ensemble de variables | $X_1 \\neq X_2$ |\n",
-    "| **Solution** | Assignation complete et consistante | Toutes les regions coloriees sans conflit |\n",
-    "\n",
-    "### Resume des algorithmes\n",
-    "\n",
-    "| Algorithme / Heuristique | Principe | Impact |\n",
-    "|--------------------------|----------|--------|\n",
-    "| **Backtracking** | DFS avec verification de consistance a chaque etape | Base de toute resolution CSP |\n",
-    "| **MRV** | Choisir la variable au domaine le plus restreint | Fail-first : detecte les impasses tot |\n",
-    "| **LCV** | Essayer la valeur la moins contraignante | Succeed-first : maximise les chances |\n",
-    "| **python-constraint** | API declarative avec solveur integre | Productivite en production |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3586d6ec",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006648,
-     "end_time": "2026-02-26T06:45:32.800718",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.794070",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 1 : 4-Reines avec backtracking manuel\n",
-    "\n",
-    "**Enonce** : modelisez et resolvez le probleme des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
-    "\n",
-    "Completez la cellule ci-dessous."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "bfd0af8f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-21T02:16:38.126754Z",
-     "iopub.status.busy": "2026-04-21T02:16:38.126440Z",
-     "iopub.status.idle": "2026-04-21T02:16:38.130625Z",
-     "shell.execute_reply": "2026-04-21T02:16:38.129907Z"
-    },
-    "papermill": {
-     "duration": 0.012367,
-     "end_time": "2026-02-26T06:45:32.820599",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.808232",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice visuel - decommentez pour tester\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 1 : 4-Reines avec backtracking manuel\n",
-    "\n",
-    "# A COMPLETER\n",
-    "# csp_4q = make_nqueens_csp(4)\n",
-    "# sol_4q = backtracking_improved(csp_4q, use_mrv=True, use_lcv=True)\n",
-    "# print(f\"Solution : {sol_4q}\")\n",
-    "# print(f\"Assignations : {csp_4q.n_assigns}\")\n",
-    "# draw_queens(sol_4q, 4, \"4-Reines - Backtracking manuel\")\n",
-    "# plt.show()\n",
-    "print(\"Exercice visuel - decommentez pour tester\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43775d9c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006862,
-     "end_time": "2026-02-26T06:45:32.846246",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.839384",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 2 : comparer MRV sur les 4-Reines\n",
-    "\n",
-    "**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit probleme ?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "08fcbcc6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-21T02:16:38.133069Z",
-     "iopub.status.busy": "2026-04-21T02:16:38.132756Z",
-     "iopub.status.idle": "2026-04-21T02:16:38.137277Z",
-     "shell.execute_reply": "2026-04-21T02:16:38.136430Z"
-    },
-    "papermill": {
-     "duration": 0.014764,
-     "end_time": "2026-02-26T06:45:32.867295",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.852531",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice de benchmark - decommentez pour tester\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 2 : comparaison avec et sans MRV sur 4-Reines\n",
-    "\n",
-    "# A COMPLETER\n",
-    "# csp_no_mrv = make_nqueens_csp(4)\n",
-    "# sol1 = backtracking_improved(csp_no_mrv, use_mrv=False, use_lcv=False)\n",
-    "# print(f\"Sans MRV : {csp_no_mrv.n_assigns} assignations\")\n",
-    "#\n",
-    "# csp_with_mrv = make_nqueens_csp(4)\n",
-    "# sol2 = backtracking_improved(csp_with_mrv, use_mrv=True, use_lcv=True)\n",
-    "# print(f\"Avec MRV : {csp_with_mrv.n_assigns} assignations\")\n",
-    "#\n",
-    "# if csp_with_mrv.n_assigns > 0:\n",
-    "#     print(f\"Facteur  : {csp_no_mrv.n_assigns / csp_with_mrv.n_assigns:.1f}x\")\n",
-    "print(\"Exercice de benchmark - decommentez pour tester\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "63846a3f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005681,
-     "end_time": "2026-02-26T06:45:32.891395",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.885714",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 3 : Cryptarithmetique SEND + MORE = MONEY\n",
-    "\n",
-    "**Enonce** : le puzzle cryptarithmetique **SEND + MORE = MONEY** consiste a trouver l'affectation de chiffres (0-9) aux lettres telle que l'addition soit correcte. Chaque lettre represente un chiffre distinct, et S et M ne peuvent pas etre 0 (pas de zero initial).\n",
-    "\n",
-    "```\n",
-    "    S E N D\n",
-    "  + M O R E\n",
-    "  ---------\n",
-    "  M O N E Y\n",
-    "```\n",
-    "\n",
-    "Modelisez et resolvez ce probleme avec `python-constraint`.\n",
-    "\n",
-    "**Indice** : la contrainte principale est :\n",
-    "$$1000 \\times S + 100 \\times E + 10 \\times N + D + 1000 \\times M + 100 \\times O + 10 \\times R + E$$\n",
-    "$$= 10000 \\times M + 1000 \\times O + 100 \\times N + 10 \\times E + Y$$"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "bcbf03dd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-21T02:16:38.139408Z",
-     "iopub.status.busy": "2026-04-21T02:16:38.139158Z",
-     "iopub.status.idle": "2026-04-21T02:16:38.143205Z",
-     "shell.execute_reply": "2026-04-21T02:16:38.142299Z"
-    },
-    "papermill": {
-     "duration": 0.011669,
-     "end_time": "2026-02-26T06:45:32.908879",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.897210",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice Sudoku - decommentez pour tester\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 3 : SEND + MORE = MONEY\n",
-    "\n",
-    "# A COMPLETER\n",
-    "# from constraint import Problem, AllDifferentConstraint\n",
-    "#\n",
-    "# money = Problem()\n",
-    "# money.addVariables(???, range(0, 10))\n",
-    "# money.addConstraint(AllDifferentConstraint())\n",
-    "# # S et M != 0\n",
-    "# # Contrainte arithmetique\n",
-    "# sol = money.getSolution()\n",
-    "# print(f\"Solution : {sol}\")\n",
-    "print(\"Exercice Sudoku - decommentez pour tester\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "46d47e13",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007256,
-     "end_time": "2026-02-26T06:45:32.938010",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:32.930754",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Et ensuite ?\n",
-    "\n",
-    "Ce notebook a couvert les **fondamentaux** des CSP : formalisme, backtracking avec heuristiques, et utilisation de la bibliotheque `python-constraint`. Le notebook suivant, [Search-7 CSP-Consistency](Search-7-CSP-Consistency.ipynb), introduit les techniques de **propagation de contraintes** :\n",
-    "\n",
-    "- **Forward Checking** : eliminer les valeurs inconsistantes des voisins a chaque assignation\n",
-    "- **Arc Consistency (AC-3)** : rendre le CSP arc-consistent avant et pendant la recherche\n",
-    "- **MAC (Maintaining Arc Consistency)** : combiner AC-3 avec le backtracking\n",
-    "\n",
-    "Ces techniques permettent de reduire encore davantage l'exploration en detectant les impasses plus tot.\n",
-    "\n",
-    "### References\n",
-    "\n",
-    "- Russell, S. & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapitre 6\n",
-    "- Dechter, R. *Constraint Processing*, Cambridge University Press, 2003\n",
-    "- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complete des CSP"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fr0whufdu8r",
-   "metadata": {},
-   "source": [
-    "### Exercice 4 : Sudoku 4x4 avec visualisation\n",
-    "\n",
-    "**Enonce** : Un Sudoku 4x4 est une grille 4x4 ou chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
-    "\n",
-    "Modelez ce probleme comme un CSP et utilisez le visualiseur de backtracking pour observer la resolution.\n",
-    "\n",
-    "**Grille initiale** (0 = case vide) :\n",
-    "```\n",
-    "1 0 | 0 2\n",
-    "0 0 | 0 0\n",
-    "---------\n",
-    "0 0 | 0 0\n",
-    "3 0 | 0 4\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "suhmqzd7qko",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-21T02:16:38.145436Z",
-     "iopub.status.busy": "2026-04-21T02:16:38.145204Z",
-     "iopub.status.idle": "2026-04-21T02:16:38.149441Z",
-     "shell.execute_reply": "2026-04-21T02:16:38.148477Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice visualisation Sudoku - decommentez pour tester\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Exercice 4 : Sudoku 4x4 avec visualisation\n",
-    "\n",
-    "# A COMPLETER\n",
-    "# def make_sudoku_4x4_csp(initial_grid):\n",
-    "#     \"\"\"\n",
-    "#     Cree un CSP pour un Sudoku 4x4.\n",
-    "#     \n",
-    "#     initial_grid : liste de 4 listes de 4 entiers (0 = vide)\n",
-    "#     \"\"\"\n",
-    "#     csp = CSP()\n",
-    "#     \n",
-    "#     # Variables : (ligne, colonne)\n",
-    "#     for i in range(4):\n",
-    "#         for j in range(4):\n",
-    "#             if initial_grid[i][j] == 0:\n",
-    "#                 csp.add_variable(f\"{i}{j}\", [1, 2, 3, 4])\n",
-    "#     \n",
-    "#     # Contraintes : lignes, colonnes, blocs 2x2\n",
-    "#     # ...\n",
-    "#     \n",
-    "#     return csp\n",
-    "#\n",
-    "# initial = [\n",
-    "#     [1, 0, 0, 2],\n",
-    "#     [0, 0, 0, 0],\n",
-    "#     [0, 0, 0, 0],\n",
-    "#     [3, 0, 0, 4]\n",
-    "# ]\n",
-    "#\n",
-    "# sudoku_csp = make_sudoku_4x4_csp(initial)\n",
-    "# solution, viz = backtracking_with_viz(sudoku_csp)\n",
-    "#\n",
-    "# print(f\"Solution : {solution}\")\n",
-    "# viz.draw(max_depth=5, title=\"Arbre de Backtracking - Sudoku 4x4\")\n",
-    "print(\"Exercice visualisation Sudoku - decommentez pour tester\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "67a79e8a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006067,
-     "end_time": "2026-02-26T06:45:31.940351",
-     "exception": false,
-     "start_time": "2026-02-26T06:45:31.934284",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## 5. Heuristiques : MRV et LCV (~8 min)\n",
-    "\n",
-    "Le backtracking simple fonctionne, mais deux choix strategiques peuvent considerablement l'accelerer :\n",
-    "\n",
-    "1. **Quelle variable** assigner ensuite ? (variable ordering)\n",
-    "2. **Quelle valeur** essayer en premier ? (value ordering)\n",
-    "\n",
-    "### 5.1 Variable Ordering : MRV (Minimum Remaining Values)\n",
-    "\n",
-    "**Principe** : choisir la variable qui a le **plus petit domaine restant** (le moins de valeurs viables).\n",
-    "\n",
-    "**Intuition (\"fail-first\")** : si une variable n'a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d'abord celle a 2 valeurs. Si elle echoue, on le decouvre plus vite, et on elague un sous-arbre plus tot.\n",
-    "\n",
-    "$$\\text{MRV}(X_i) = |\\{v \\in D_i : v \\text{ est consistant avec l'assignation courante}\\}|$$\n",
-    "\n",
-    "On choisit $X_i$ qui minimise $\\text{MRV}(X_i)$."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "l07u2toghu",
    "source": [
     "### 4.3 Visualisation du processus de backtracking\n",
@@ -1615,6 +1218,40 @@
     "3. L'ordre des variables influence la forme de l'arbre (variables a petit domaine en premier = arbre plus etroit)\n"
    ],
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67a79e8a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006067,
+     "end_time": "2026-02-26T06:45:31.940351",
+     "exception": false,
+     "start_time": "2026-02-26T06:45:31.934284",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Heuristiques : MRV et LCV (~8 min)\n",
+    "\n",
+    "Le backtracking simple fonctionne, mais deux choix strategiques peuvent considerablement l'accelerer :\n",
+    "\n",
+    "1. **Quelle variable** assigner ensuite ? (variable ordering)\n",
+    "2. **Quelle valeur** essayer en premier ? (value ordering)\n",
+    "\n",
+    "### 5.1 Variable Ordering : MRV (Minimum Remaining Values)\n",
+    "\n",
+    "**Principe** : choisir la variable qui a le **plus petit domaine restant** (le moins de valeurs viables).\n",
+    "\n",
+    "**Intuition (\"fail-first\")** : si une variable n'a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d'abord celle a 2 valeurs. Si elle echoue, on le decouvre plus vite, et on elague un sous-arbre plus tot.\n",
+    "\n",
+    "$$\\text{MRV}(X_i) = |\\{v \\in D_i : v \\text{ est consistant avec l'assignation courante}\\}|$$\n",
+    "\n",
+    "On choisit $X_i$ qui minimise $\\text{MRV}(X_i)$."
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## URGENT - Bug signale par etudiant pendant cours EPITA 21/04/2026

**Le notebook CSP-1-Fundamentals est structurellement casse**. Un etudiant a remonte le bug oralement pendant la pause (80 etudiants en cours).

## 3 problemes identifies

### 1. Bloc Section 7 duplique (9 cellules)

La Section 7 entiere (Recapitulatif + Exercices 1-3 + "Et ensuite" + Exercice 4 enonce) apparaissait DEUX fois :
- Une fois MAL PLACEE entre la Section 4 et la Section 5 (cellules 23-31)
- Une fois au BON endroit avant la Conclusion (cellules 69-77)

Les 9 cellules du bloc duplique partagent les MEMES cell IDs (`2cd7141e`, `3586d6ec`, `bfd0af8f`, `43775d9c`, `08fcbcc6`, `63846a3f`, `bcbf03dd`, `46d47e13`, `fr0whufd`) ce qui prouve un copy-paste accidentel.

### 2. Section 4.3 mal placee

`### 4.3 Visualisation du processus de backtracking` apparaissait APRES le header `## 5. Heuristiques`, donc logiquement INSIDE la Section 5 alors que son contenu appartient a la Section 4.

### 3. Code orphelin

Une 10eme cellule (`id=suhmqzd7qko`, "Exercice 4 Sudoku 4x4 code") etait orpheline, laissee apres un fix partiel precedent.

## Fix applique

- Suppression du bloc duplique apres Section 4 (9 cellules)
- Suppression du code orphelin Exercice 4 dup (1 cellule)
- Deplacement de Section 4.3 (5 cellules) AVANT le header Section 5

## Structure finale (71 cellules, conforme au plan pedagogique)

```
1. Introduction
2. Formalisation CSP
3. Exemple coloration Australie
4. Backtracking (4.1 principe, 4.2 trace, 4.3 visualisation)
5. Heuristiques (5.1 MRV, 5.2 LCV)
6. Bibliotheque python-constraint
7. Recapitulatif et exercices (4 exercices)
Conclusion
```

## Verification

- **0** cellule avec IDs dupliques (avant : 10 duplicats)
- **Scan des 8 autres notebooks CSP** (CSP-2 a CSP-9) : aucun bug similaire
- **diff** : `+35 -398` (on supprime plus qu'on ajoute : c'est normal pour une dedup)

## Origine probable

Merge accidentel lors de PR #330 (*fix(pedagogy): move exercises before ending sections, 44 notebooks*) ou suivante. Tous les notebooks enrichis a cette epoque meritent un scan de coherence structurelle.

## Test plan

- [ ] Merger URGEMMENT (cours en cours, 2eme fournee de TPs imminente)
- [ ] Scanner les 43 autres notebooks touches par PR #330 pour duplications similaires
- [ ] Ajouter un test automatique `ensure_unique_cell_ids` dans `validate_notebook_structure`

## Refs

- CLAUDE.md 2026-04-20 : non-detection = review superficielle lors de PR #330
- Memory : `session_20260420_review_rigor.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
