### PR TITLE
fix(search-7): align Nim docs to NORMAL variant (refs #383)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.003204,
-     "end_time": "2026-03-07T18:24:30.794225",
+     "duration": 0.020707,
+     "end_time": "2026-04-21T10:02:25.595246",
      "exception": false,
-     "start_time": "2026-03-07T18:24:30.791021",
+     "start_time": "2026-04-21T10:02:25.574539",
      "status": "completed"
     },
     "tags": []
@@ -41,16 +41,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:30.800958Z",
-     "iopub.status.busy": "2026-03-07T18:24:30.800650Z",
-     "iopub.status.idle": "2026-03-07T18:24:31.628649Z",
-     "shell.execute_reply": "2026-03-07T18:24:31.627831Z"
+     "iopub.execute_input": "2026-04-21T10:02:25.673077Z",
+     "iopub.status.busy": "2026-04-21T10:02:25.671525Z",
+     "iopub.status.idle": "2026-04-21T10:02:26.394677Z",
+     "shell.execute_reply": "2026-04-21T10:02:26.394279Z"
     },
     "papermill": {
-     "duration": 0.833373,
-     "end_time": "2026-03-07T18:24:31.630497",
+     "duration": 0.757124,
+     "end_time": "2026-04-21T10:02:26.403029",
      "exception": false,
-     "start_time": "2026-03-07T18:24:30.797124",
+     "start_time": "2026-04-21T10:02:25.645905",
      "status": "completed"
     },
     "tags": []
@@ -88,10 +88,10 @@
    "id": "intro-section",
    "metadata": {
     "papermill": {
-     "duration": 0.004838,
-     "end_time": "2026-03-07T18:24:31.639352",
+     "duration": 0.050399,
+     "end_time": "2026-04-21T10:02:26.513749",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.634514",
+     "start_time": "2026-04-21T10:02:26.463350",
      "status": "completed"
     },
     "tags": []
@@ -121,10 +121,10 @@
    "id": "mcts-intro-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002277,
-     "end_time": "2026-03-07T18:24:31.646367",
+     "duration": 0.035316,
+     "end_time": "2026-04-21T10:02:26.604913",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.644090",
+     "start_time": "2026-04-21T10:02:26.569597",
      "status": "completed"
     },
     "tags": []
@@ -160,16 +160,16 @@
    "id": "mcts-node-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:31.655351Z",
-     "iopub.status.busy": "2026-03-07T18:24:31.654822Z",
-     "iopub.status.idle": "2026-03-07T18:24:31.662599Z",
-     "shell.execute_reply": "2026-03-07T18:24:31.661604Z"
+     "iopub.execute_input": "2026-04-21T10:02:26.669241Z",
+     "iopub.status.busy": "2026-04-21T10:02:26.667053Z",
+     "iopub.status.idle": "2026-04-21T10:02:26.708707Z",
+     "shell.execute_reply": "2026-04-21T10:02:26.702722Z"
     },
     "papermill": {
-     "duration": 0.015293,
-     "end_time": "2026-03-07T18:24:31.664606",
+     "duration": 0.079308,
+     "end_time": "2026-04-21T10:02:26.715582",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.649313",
+     "start_time": "2026-04-21T10:02:26.636274",
      "status": "completed"
     },
     "tags": []
@@ -218,7 +218,16 @@
   {
    "cell_type": "markdown",
    "id": "79692fea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008188,
+     "end_time": "2026-04-21T10:02:26.742867",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:26.734679",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Implementation de la classe MCTS avec selection UCB1, expansion, simulation et retropropagation."
    ]
@@ -229,16 +238,16 @@
    "id": "mcts-algorithm",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:31.673313Z",
-     "iopub.status.busy": "2026-03-07T18:24:31.672982Z",
-     "iopub.status.idle": "2026-03-07T18:24:31.682018Z",
-     "shell.execute_reply": "2026-03-07T18:24:31.681340Z"
+     "iopub.execute_input": "2026-04-21T10:02:26.828223Z",
+     "iopub.status.busy": "2026-04-21T10:02:26.826251Z",
+     "iopub.status.idle": "2026-04-21T10:02:26.873254Z",
+     "shell.execute_reply": "2026-04-21T10:02:26.871495Z"
     },
     "papermill": {
-     "duration": 0.015001,
-     "end_time": "2026-03-07T18:24:31.683374",
+     "duration": 0.098213,
+     "end_time": "2026-04-21T10:02:26.875625",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.668373",
+     "start_time": "2026-04-21T10:02:26.777412",
      "status": "completed"
     },
     "tags": []
@@ -330,7 +339,16 @@
   {
    "cell_type": "markdown",
    "id": "ng2kq8fnyml",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.043754,
+     "end_time": "2026-04-21T10:02:26.943163",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:26.899409",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Maintenant que nous avons la structure de nœud, nous pouvons implémenter l'algorithme **MCTS complet** qui utilise ces nœuds pour construire l'arbre de recherche.\n"
    ]
@@ -340,10 +358,10 @@
    "id": "test-mcts-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002383,
-     "end_time": "2026-03-07T18:24:31.688388",
+     "duration": 0.022659,
+     "end_time": "2026-04-21T10:02:27.000637",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.686005",
+     "start_time": "2026-04-21T10:02:26.977978",
      "status": "completed"
     },
     "tags": []
@@ -360,16 +378,16 @@
    "id": "tictactoe-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:31.696825Z",
-     "iopub.status.busy": "2026-03-07T18:24:31.696433Z",
-     "iopub.status.idle": "2026-03-07T18:24:31.728625Z",
-     "shell.execute_reply": "2026-03-07T18:24:31.727867Z"
+     "iopub.execute_input": "2026-04-21T10:02:27.040109Z",
+     "iopub.status.busy": "2026-04-21T10:02:27.038121Z",
+     "iopub.status.idle": "2026-04-21T10:02:27.128506Z",
+     "shell.execute_reply": "2026-04-21T10:02:27.127631Z"
     },
     "papermill": {
-     "duration": 0.03694,
-     "end_time": "2026-03-07T18:24:31.730029",
+     "duration": 0.11057,
+     "end_time": "2026-04-21T10:02:27.130206",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.693089",
+     "start_time": "2026-04-21T10:02:27.019636",
      "status": "completed"
     },
     "tags": []
@@ -379,7 +397,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MCTS (1000 iterations): action=6, valeur=0.104, temps=0.027s\n",
+      "MCTS (1000 iterations): action=6, valeur=0.064, temps=0.038s\n",
       "Stats: {'selections': 1000, 'expansions': 1000, 'simulations': 1000, 'backprops': 1000}\n"
      ]
     }
@@ -454,7 +472,16 @@
   {
    "cell_type": "markdown",
    "id": "e103e3fc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.037178,
+     "end_time": "2026-04-21T10:02:27.193525",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:27.156347",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Premiers resultats MCTS\n",
     "\n",
@@ -482,10 +509,10 @@
    "id": "comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002069,
-     "end_time": "2026-03-07T18:24:31.735859",
+     "duration": 0.05743,
+     "end_time": "2026-04-21T10:02:27.311719",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.733790",
+     "start_time": "2026-04-21T10:02:27.254289",
      "status": "completed"
     },
     "tags": []
@@ -502,16 +529,16 @@
    "id": "comparison-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:31.743279Z",
-     "iopub.status.busy": "2026-03-07T18:24:31.743039Z",
-     "iopub.status.idle": "2026-03-07T18:24:33.146119Z",
-     "shell.execute_reply": "2026-03-07T18:24:33.144750Z"
+     "iopub.execute_input": "2026-04-21T10:02:27.438512Z",
+     "iopub.status.busy": "2026-04-21T10:02:27.436894Z",
+     "iopub.status.idle": "2026-04-21T10:02:30.110087Z",
+     "shell.execute_reply": "2026-04-21T10:02:30.109187Z"
     },
     "papermill": {
-     "duration": 1.40884,
-     "end_time": "2026-03-07T18:24:33.147426",
+     "duration": 2.740034,
+     "end_time": "2026-04-21T10:02:30.111308",
      "exception": false,
-     "start_time": "2026-03-07T18:24:31.738586",
+     "start_time": "2026-04-21T10:02:27.371274",
      "status": "completed"
     },
     "tags": []
@@ -548,37 +575,37 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Minimax</td>\n",
-       "      <td>1.204123</td>\n",
+       "      <td>2.320090</td>\n",
        "      <td>0</td>\n",
        "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>MCTS (100)</td>\n",
-       "      <td>0.002991</td>\n",
-       "      <td>7</td>\n",
-       "      <td>0.294118</td>\n",
+       "      <td>0.010409</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.315789</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>MCTS (500)</td>\n",
-       "      <td>0.014981</td>\n",
-       "      <td>5</td>\n",
-       "      <td>0.000000</td>\n",
+       "      <td>0.027859</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.050633</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>MCTS (1000)</td>\n",
-       "      <td>0.029255</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0.119289</td>\n",
+       "      <td>0.069664</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.138211</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>MCTS (5000)</td>\n",
-       "      <td>0.154470</td>\n",
-       "      <td>6</td>\n",
-       "      <td>0.058057</td>\n",
+       "      <td>0.189939</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.015404</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -586,11 +613,11 @@
       ],
       "text/plain": [
        "    Algorithme  Temps (s)  Valeur    Action\n",
-       "0      Minimax   1.204123       0  0.000000\n",
-       "1   MCTS (100)   0.002991       7  0.294118\n",
-       "2   MCTS (500)   0.014981       5  0.000000\n",
-       "3  MCTS (1000)   0.029255       3  0.119289\n",
-       "4  MCTS (5000)   0.154470       6  0.058057"
+       "0      Minimax   2.320090       0  0.000000\n",
+       "1   MCTS (100)   0.010409       3  0.315789\n",
+       "2   MCTS (500)   0.027859       3  0.050633\n",
+       "3  MCTS (1000)   0.069664       1  0.138211\n",
+       "4  MCTS (5000)   0.189939       2  0.015404"
       ]
      },
      "metadata": {},
@@ -644,7 +671,16 @@
   {
    "cell_type": "markdown",
    "id": "28365b23",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005968,
+     "end_time": "2026-04-21T10:02:30.123224",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:30.117256",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Comparaison MCTS vs Minimax\n",
     "\n",
@@ -671,10 +707,10 @@
    "id": "mcts-analysis-section",
    "metadata": {
     "papermill": {
-     "duration": 0.00264,
-     "end_time": "2026-03-07T18:24:33.152955",
+     "duration": 0.014117,
+     "end_time": "2026-04-21T10:02:30.146007",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.150315",
+     "start_time": "2026-04-21T10:02:30.131890",
      "status": "completed"
     },
     "tags": []
@@ -703,10 +739,10 @@
    "id": "openspiel-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002506,
-     "end_time": "2026-03-07T18:24:33.158362",
+     "duration": 0.010852,
+     "end_time": "2026-04-21T10:02:30.168914",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.155856",
+     "start_time": "2026-04-21T10:02:30.158062",
      "status": "completed"
     },
     "tags": []
@@ -739,16 +775,16 @@
    "id": "openspiel-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:33.164685Z",
-     "iopub.status.busy": "2026-03-07T18:24:33.164356Z",
-     "iopub.status.idle": "2026-03-07T18:24:33.170434Z",
-     "shell.execute_reply": "2026-03-07T18:24:33.169674Z"
+     "iopub.execute_input": "2026-04-21T10:02:30.185967Z",
+     "iopub.status.busy": "2026-04-21T10:02:30.185548Z",
+     "iopub.status.idle": "2026-04-21T10:02:30.192285Z",
+     "shell.execute_reply": "2026-04-21T10:02:30.191687Z"
     },
     "papermill": {
-     "duration": 0.010519,
-     "end_time": "2026-03-07T18:24:33.171531",
+     "duration": 0.015305,
+     "end_time": "2026-04-21T10:02:30.193374",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.161012",
+     "start_time": "2026-04-21T10:02:30.178069",
      "status": "completed"
     },
     "tags": []
@@ -800,7 +836,16 @@
   {
    "cell_type": "markdown",
    "id": "3930bc69",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006329,
+     "end_time": "2026-04-21T10:02:30.205753",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:30.199424",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : OpenSpiel et la normalisation des jeux\n",
     "\n",
@@ -826,10 +871,10 @@
    "id": "alphago-section",
    "metadata": {
     "papermill": {
-     "duration": 0.00221,
-     "end_time": "2026-03-07T18:24:33.176314",
+     "duration": 0.006956,
+     "end_time": "2026-04-21T10:02:30.218827",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.174104",
+     "start_time": "2026-04-21T10:02:30.211871",
      "status": "completed"
     },
     "tags": []
@@ -869,16 +914,16 @@
    "id": "alphazero-sketch",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:33.184072Z",
-     "iopub.status.busy": "2026-03-07T18:24:33.183839Z",
-     "iopub.status.idle": "2026-03-07T18:24:33.190247Z",
-     "shell.execute_reply": "2026-03-07T18:24:33.189336Z"
+     "iopub.execute_input": "2026-04-21T10:02:30.232502Z",
+     "iopub.status.busy": "2026-04-21T10:02:30.232158Z",
+     "iopub.status.idle": "2026-04-21T10:02:30.243557Z",
+     "shell.execute_reply": "2026-04-21T10:02:30.242602Z"
     },
     "papermill": {
-     "duration": 0.012645,
-     "end_time": "2026-03-07T18:24:33.191181",
+     "duration": 0.019959,
+     "end_time": "2026-04-21T10:02:30.245208",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.178536",
+     "start_time": "2026-04-21T10:02:30.225249",
      "status": "completed"
     },
     "tags": []
@@ -958,7 +1003,16 @@
   {
    "cell_type": "markdown",
    "id": "68274e65",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007074,
+     "end_time": "2026-04-21T10:02:30.260275",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:30.253201",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Concept AlphaZero et integration reseau/MCTS\n",
     "\n",
@@ -985,10 +1039,10 @@
    "id": "advanced-section",
    "metadata": {
     "papermill": {
-     "duration": 0.00236,
-     "end_time": "2026-03-07T18:24:33.196202",
+     "duration": 0.006262,
+     "end_time": "2026-04-21T10:02:30.272815",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.193842",
+     "start_time": "2026-04-21T10:02:30.266553",
      "status": "completed"
     },
     "tags": []
@@ -1022,16 +1076,16 @@
    "id": "parallel-mcts",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-03-07T18:24:33.202266Z",
-     "iopub.status.busy": "2026-03-07T18:24:33.201889Z",
-     "iopub.status.idle": "2026-03-07T18:24:33.210869Z",
-     "shell.execute_reply": "2026-03-07T18:24:33.210078Z"
+     "iopub.execute_input": "2026-04-21T10:02:30.286952Z",
+     "iopub.status.busy": "2026-04-21T10:02:30.286669Z",
+     "iopub.status.idle": "2026-04-21T10:02:30.296250Z",
+     "shell.execute_reply": "2026-04-21T10:02:30.295584Z"
     },
     "papermill": {
-     "duration": 0.013409,
-     "end_time": "2026-03-07T18:24:33.212010",
+     "duration": 0.018129,
+     "end_time": "2026-04-21T10:02:30.297300",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.198601",
+     "start_time": "2026-04-21T10:02:30.279171",
      "status": "completed"
     },
     "tags": []
@@ -1077,7 +1131,16 @@
   {
    "cell_type": "markdown",
    "id": "b55cd8eb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010463,
+     "end_time": "2026-04-21T10:02:30.312486",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:30.302023",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Parallelisation de MCTS\n",
     "\n",
@@ -1104,10 +1167,10 @@
    "id": "exercices-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002818,
-     "end_time": "2026-03-07T18:24:33.223221",
+     "duration": 0.009245,
+     "end_time": "2026-04-21T10:02:30.338787",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.220403",
+     "start_time": "2026-04-21T10:02:30.329542",
      "status": "completed"
     },
     "tags": []
@@ -1121,7 +1184,7 @@
     "Mesurez comment la qualite des decisions MCTS evolue avec le nombre d'iterations et tracez les courbes de convergence.\n",
     "\n",
     "### Exemple resolu 2 : MCTS sur le jeu de Nim\n",
-    "Implementez le jeu de Nim (prendre 1 a 3 allumettes, le dernier perd) et verifiez que MCTS decouvre la strategie optimale connue (laisser un multiple de 4).\n",
+    "Implementez le jeu de Nim (prendre 1 a 3 allumettes, le dernier a jouer gagne) et verifiez que MCTS decouvre la strategie optimale connue (laisser un multiple de 4).\n",
     "\n",
     "### Exercice 2 : Rollout intelligent\n",
     "Implementez un rollout guide par heuristiques au lieu d'un choix purement aleatoire.\n",
@@ -1138,10 +1201,123 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "rhge3yrtj9e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:30.363580Z",
+     "iopub.status.busy": "2026-04-21T10:02:30.363159Z",
+     "iopub.status.idle": "2026-04-21T10:02:56.200752Z",
+     "shell.execute_reply": "2026-04-21T10:02:56.195657Z"
+    },
+    "papermill": {
+     "duration": 25.857745,
+     "end_time": "2026-04-21T10:02:56.207979",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:30.350234",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>iterations</th>\n",
+       "      <th>taux_optimal</th>\n",
+       "      <th>valeur_moyenne</th>\n",
+       "      <th>temps_moyen</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10</td>\n",
+       "      <td>3.333333</td>\n",
+       "      <td>0.616667</td>\n",
+       "      <td>0.000321</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>50</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.453272</td>\n",
+       "      <td>0.003003</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>100</td>\n",
+       "      <td>6.666667</td>\n",
+       "      <td>0.262385</td>\n",
+       "      <td>0.013375</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>500</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.099325</td>\n",
+       "      <td>0.058108</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1000</td>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>0.125467</td>\n",
+       "      <td>0.075405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5000</td>\n",
+       "      <td>10.000000</td>\n",
+       "      <td>0.021222</td>\n",
+       "      <td>0.455247</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   iterations  taux_optimal  valeur_moyenne  temps_moyen\n",
+       "0          10      3.333333        0.616667     0.000321\n",
+       "1          50      0.000000        0.453272     0.003003\n",
+       "2         100      6.666667        0.262385     0.013375\n",
+       "3         500      0.000000        0.099325     0.058108\n",
+       "4        1000     10.000000        0.125467     0.075405\n",
+       "5        5000     10.000000        0.021222     0.455247"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABdIAAAGGCAYAAAB/pnNVAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxBJJREFUeJzs3QV4FNfXBvA3BiG4EwharMHdneLuUlxKkeLuGtzdpaW4t3iR4E5xK+7uCSHZ7zl3v81/Y5BNNpmV99dnmp3Z2dm7u8PcmTP3nuug0+l0ICIiIiIiIiIiIiKiUDmGvpiIiIiIiIiIiIiIiAQD6URERERERERERERE38BAOhERERERERERERHRNzCQTkRERERERERERET0DQykExERERERERERERF9AwPpRERERERERERERETfwEA6EREREREREREREdE3MJBORERERERERERERPQNDKQTEREREREREREREX0DA+lERNFs2LBhcHBwsLv3JiKKrDt37qhj2NKlS2Fv7PmzWxLW4UREtk2Os3K8jSo8lmsvtN8gXbp0aNmypWZlIuvBQDpZvFu3buGXX35BhgwZ4Orqinjx4qFYsWKYNm0aPn/+rHXxiEL16dMnVUHv379f66IQEWmiRo0acHNzw/v378Ncp2nTpogRIwZevnwZrWWzZCtXrsTUqVO1LoZdYx1ORBQ5vIY3zZgxY7Bp0yar2S6RPWMgnSzaX3/9hRw5cmDNmjWoXr06ZsyYAS8vL6RJkwa9e/dG165dtS4iUZgX4cOHDw/1InzQoEE8gSQimydBcjnWbdy4Mczj5ObNm1GpUiUkTpw42stnbYH0tGnTqu+zWbNmmpTLnrAOJyKKOF7Df1to9QgD6UTWw1nrAhCF5fbt22jUqJG6cPznn3/g7u4e+FynTp1w8+ZNVUlbMx8fH9USz9GR97Qi6+PHj4gdOzasgbOzs5qIiGy9RXrcuHFVYLh58+Yhnpcguhy7JeBu6XQ6naqzY8WKpVkZpAuytOojbbEOJyKy72v4yGI9Yt+xALJ+jN6RxRo/fjw+fPiARYsWBamADTJmzBjkbvbXr18xcuRI/PDDD4gZM6bKcTVgwAD4+voGeZ0sr1atGg4dOoSCBQuqi1LpcrZ8+fLAdU6dOqUuWJctWxbifXfu3Kme27ZtW+Cyhw8fonXr1kiePLl672zZsmHx4sVBXietmuR1q1atUnehU6VKpbq8v3v3Tj2/du1aeHp6qvJkz55dteCTHF1SXmMBAQGqpZq8h6wr7ynd5l6/fm3y5zR48+YNunfvrl4j5ffw8FBBjxcvXgSuI9/j0KFD1fcu66ROnRp9+vQJ8f0G17lzZ8SJE0e17gqucePGSJEiBfz9/QOXbd++HSVKlFAVoQRgqlatikuXLgV5nXwvsk3pMlilShW1niEQc+PGDdStW1dtVz6zfBY5mXv79u03y2n4DfLly6cCJUmSJMHPP/+sftvQ3vu///5DxYoVVTlTpkyJESNGqECLIY9t0qRJ1WNp0Sa/u3GuvdByssm8fFeG/UDKUKRIEVy4cEE9P2/ePPXdy2cqXbq0eg9j3t7eqF+/vmrpYfh95Ddlqzki0oocx+rUqYO9e/fi2bNnIZ6XALscvyXg/urVK/Tq1Uu1YJNjrHQBr1y5Ms6fPx+u97p69Srq1auHRIkSqeNk/vz5sWXLlnDlJJWc47Lc+LhqqEOlzpdtyWeR4/C3HD9+XLWujx8/vqrfS5UqhcOHDwdZR9LcdOvWLbC+TZYsGX766SecOXNGPS/Hdwkw3L17N7DuMJwHhJYj3VAn3bt3T5VXHsv5xaxZs9TzUoeULVtW1VUS1JDvPLRzACmT1BtSJqlrxo0bp843InL+EdzEiRNVueUzBde/f3/VoMCwDdbhrMOJyLpF9TW8XFMb6mU5ZzD0HNqwYYOal+Os1AVnz541+fj/Ld+73pfjddasWdVkfOyW8xv5HooWLRp4zRu8HpHHEgiW2IOhzjHO1R2eWENozLFdQwxDehdInSjnGHLuJudcUjfL7yTnEHI+I99vq1atQvx2hjryjz/+QJYsWQJ/o4MHD4Yos/xucv4n54GyvXLlyuHYsWOhnrcdOHAAHTt2VO8t5wumxBPCK7znSGRndEQWKlWqVLoMGTKEe/0WLVpIDairV6+ebtasWbrmzZur+Vq1agVZL23atLosWbLokidPrhswYIBu5syZurx58+ocHBx0Fy9eDFxP3rtKlSoh3qdVq1a6hAkT6r58+aLmnzx5ovPw8NClTp1aN2LECN2cOXN0NWrUUO89ZcqUwNft27dPLfP09NTlzp1bN3nyZJ2Xl5fu48ePum3btqn3z5kzp1o+ePBg9R7Zs2dX5TXWtm1bnbOzs65du3a6uXPn6vr27auLHTu2rkCBAoFlMuVzvn//Xr2Pk5OT2qaUf+TIkWp7Z8+eVev4+/vrKlSooHNzc9N169ZNN2/ePF3nzp1VOWrWrPnN3+XgwYPqc69ZsybIcvncUu5OnToFLlu+fLkqX6VKlXQzZszQjRs3TpcuXTpdggQJdLdv3w7yW8eMGVP3ww8/qMfyPchrfX19denTp9elTJlSN2rUKN3ChQt1w4cPV5/lzp073yznkiVLVDllXfnd+vXrp4sVK5Z6/9evXwd5b1dXV12mTJl0zZo1U99rtWrV1GvldxMfPnxQ36Msq127tm7FihVqOn/+vHp+6NCh6jljMi+/v+xHY8eOVVP8+PF1adKkUe8h+82kSZN0gwYN0sWIEUNXpkyZIK/v0qWL2l/HjBmjfp82bdqo31T+PRgL7b2JiKLKrl271DFHjunGXr58qXNxcVF1tTh58qQ6psuxV45hUp/KeYAcBx8+fBj4OqkLZHtyzDaQOk3Wk+Ok1BtyzCxZsqSqTzZs2PDd45/h+G9cz0gdmjFjRlUXS5mknpF6PCx79+5Vx+YiRYqoY7XUI3JMl2XHjx8PXK9JkyZqWY8ePVQdJeWtXr267vfffw/8vuQcIUmSJIF1x8aNG8P87IY6ST57hw4d1PlP0aJFA9eT+rB3797q+8+WLZuqF/77778gdbGUM3HixOpcQT6n/Cby3XXt2jVC5x/B3b17V21v/PjxIZ6Tc62qVauqx6zDWYcTkfWL6mt4d3d33bBhw9SxXt4rTpw4qg6V463x8VfqcLmGNeX4byDL5HhrEN7r/WPHjqljd/fu3QOXNWrUSNVH165dC/NYLnWMXNuWKFEisM45cuSISe8dGnNs1xDDkHMTOceZPn267rffflP1unw2Oa+pXLmy+u3ke5V1pe4O/n1KvEHObeS95NxHfk/5Xi5cuBDkfE7OK+Q3lniE/JZyXiCfQb7b4HW+1K2lSpVS5ziyrinxhNDqUymT7CcROUci+8IzMbJIb9++VQe27wVpDc6dO6fWl4s8Y7169VLL//nnnyAHSFkmAV6DZ8+eqQN0z549A5f1799fXeS/evUqcJlc5MlBuHXr1oHL5GJHDvYvXrwI8t5SsUgl/unTpyCVkJxYGJYZ5MiRQ1VkEtQ22L9/v1rfOJDu7e2tlv3xxx9BXr9jx44Qy8P7OYcMGaLWMw42GAQEBKi/Uuk6Ojqq9zcmlYm89vDhwyFea7wNOcmpW7dukOUSWDcun3x2+W7lAt2YVPLyPRovN5xwyYWyMQn8y/K1a9fqTCEBgGTJkqkK/vPnz4HL5QaHbE++o+DvLRe9xp9RAgFycfz8+XO1TP4GPwkzCOsiXH4b4wpeLqZleYoUKXTv3r0Lsm8GD/oE36eE3KiRil6CGN96byKiqPL161dVR8rFV2j1x86dO9W8j49PkAteIcc4OS7KRZfxsuDB5HLlyql6VLZhfFyWgLJcMEc0kC7LpH79HnkveZ+KFSsG1puG47JcAP7000+By6Q+M76BHBqpT4LfRA/rsxvqJAnAGkjgWC5O5fi/atWqwOVXr14NUS/JhapctF6/fj3Ie0n9KsGAe/fumXz+ERr5/fPlyxdk2YkTJ9Rr5aJXsA4PinU4EVmb6LiGNwSChZxDyDKp84yPlYbjr/EN8PAe/0Xw4394r/cNx3i5bpZrXKnPZFtTp04N8rrQjuVSFxsHcSPy3qGJ7HYNMQypY41vmjdu3FjVURJED17fBz+HkdfLdOrUqcBl8nvJjQ25YW0gN0/kt7h161bgskePHunixo2rGkgEP28rXry4Os80MCWeEJ5AenjPkcj+MLULWSRDuhPpihMef//9t/rbo0ePIMt79uyp/gbPwybdbqW7j4F04ZVuRtLVy6Bhw4bw8/NT3cQMdu3apbr3yHNC6oX169erQVTksaRCMUzSZUy6Oxm6axu0aNEiSI7VR48eqa6/kkpFui8ZSJdw6Z5mTLoMS5dx6QZu/F7SNUpeu2/fPpM/p5Q/V65cqF27dojv1dDlTN73xx9/VF3VjN9XuouL4O8bfBvSXVl+I+nmZ7B69WrVNax48eJqfvfu3eq7lXQvxu/h5OSEQoUKhfoev/76a5B5+W6EdMUPLZVMWCSVj6QdkK5hxvlnpRuYfObQ8vhJ9zTjzyjzX758wZ49exBR0nXNOJWPfG4h3dyN/y0Ylhv/jsb7lHThk+9OuhDKfhm8ayMRUXSRY7ik5jh69GiQdBaSYkS6EstxT0h3WcN4IdL1+eXLl6pekzoreD1qTLpMSw7WBg0aqLQphrpDXi/1sKQKCZ7eI7zSp0+vtvE9586dU+/TpEkT9b6GMsixWD6fdF02dAFOkCCBSgEjdb85tW3bNvCxvId8b9KlWb4XA1kmzxnXHVK/y3lCwoQJg9S95cuXV7+Dodu1qecfwcl50+nTp1VKNuPzAPnda9asqeZZh+uxDiciaxUd1/CSNiv48VSuSSU11reOsxE9/pt6vS9pWyRFilzzS70k1/S//fZbuL6PyL53VG5XYhUuLi5BvmN5raSGMSbL79+/r1L2GJPfTc4ZDOT3kvpf6nw535BJYi21atVS6WgNJC2OnF9JulrD/mXQrl07dZ5pEJF4wreE9xyJ7A9HOCCLJDmxhFwUh4fk3ZQLcMlZZUxybMpFY/C8nMYVrYEcII3zfEpwWS7A5EKvTZs2apk8lrybhgDy8+fP1cF6/vz5agpN8LywcmEevOwieNkNy4wrMblQl4pN8oCF573C8znlolYu8r5F3vfKlSuBOUO/976hXUBLXlXJVysVoQTU5cRJcqsagvXyHsLw3Ya1TxjIAC3GudAM362ciE2ePFnlYJOKT3LvSp5UwwV6aAy/gQQZgpN9QCpuY7KvGVfwInPmzOpv8Lynpgj+exnKLDnZQltu/DtKftwhQ4ao7zh4vtrw5JYlIooqMobFlClTVPBc8p4+ePBA5YSWC0vDBZAEmqdNm4bZs2ergcqMx85InDhxmNuWQcvkQm7w4MFqCquOkhu3pgpeX4fFUH/JRXNY5Dgs9a/kjpX15LguF5QyzodcnAavU0whwePg9bPUE1JHBs/lLcuN6wgp+7///vvd+t3U84/g5Ia61M9yHiX7gPxmcoFqyIMqWIezDici6xbd1/CmHGcjevw39Xpfxv2QPOMFChRQ9fOSJUtCHZ8lPCISa4iq7Zry3cs5ndRdxudvmTJlCvEe8t3LjXMpj5DHodXl0qBPtikBerlJEdZ5mqnxhO8J7zkS2R8G0skiyUFOBv+4ePGiSa8LbyVlfOfSWPCBRiQAPHr0aHXnUe6sywWO3OE0jLJtaGEmF3lhXUDnzJkzyLxxqyNTyfvJRaxcYIYm+EE+vJ8zPO8rrePl4jY0wSvQ4AoXLqxaackgJRJI37p1qxqExdCy3/AeYsWKFerkKbjgI5sbt140NmnSJDWIyubNm9VdbQnUeHl5qUFKggfeLU1Yv9f3fkcJOEkrQWmZ2bdvXxU4kJaI0gpTvgsOhkJEWpKAsRyX/vzzTxVElb9y/DIMEi3GjBmjAuHSskkGHZNBQ+UYLwM8fesYZnhOBioNq/W44QI9rHME46B9ROprQxkmTJiA3Llzh7qOoceZtBCXALEMKC51lLxGBq2S3m8SVI7OusNQdqk/ZPDw0BgCDKaefwQn53TyueU8QPYBqZMleCyf3RjrcNbhRGS9tLqGN9c1b2gicr0vrayFj4+PCsaG98a8Od47qrarxXf/PcHP00yNJ3xPeM+RyP4wkE4WS0blljuk0h3cuAtXaNKmTasOdFJRyR1Lg6dPn6q7rfJ8REigV0anlq5P0gVduhNJF3XjC0cJsMtFkHTxiQhD2aRVXXDBl8lo5tLtrFixYpEKyAff5vdOdmSd8+fPq27LEb2jLsEDaW0o36G0SJPAugTYjd9DyIV6RL9LAwn6yzRo0CAcOXJEfV9z587FqFGjvvkbXLt2LcQdbFkWfP+RfU26ChpXntevX1d/Dd26I/o9RYSkBpL3lxHZpWWjcfc2IiJLIEFzCZRLyx5pmS4tk6S1lsG6detQpkwZLFq0KMjrpA6XnmBhMbQsk+7G36s7pEW4YZvS0s0geIs3UxnqLwkghKf+km7K0t1bJmnNlDdvXnXT3hBIj876Q8ouvcS+V25znH/IOZV8ZqlX5TzAzc1NdSsPjnW4HutwIrJGlnANH5bwHP+DM/V6X85zRowYgVatWqnUb5J6TY7z3+pZFVa9Y45YQ1Rt11SG1uLG5LuXcwHDzXh5LPV2cFevXlWNK77XeM+c8QRTzpHI/jBHOlksufMnLXKk8pHKNDhJSSKBWSFdo4WkDzFmaEEteTIjQip0uZiTCz6Z5OK3ZMmSQe7ASloUCbSHFow2dFP6Frlrnz17dixfvjxIDvEDBw6oSjd4MFoqPGmtF5zkIZMTDlNJ+SVILq3jwrqTLO8rLaMWLFgQYh1pWS75PMNzAe3r66suFHfs2BEkb6uQloQShJBWiZKbPiLfpQTpg+djk99PKl5577Dkz59fVbhyoW683vbt21VKm9D2n5kzZwb5nmReAjmGfL9yIiAi8puYytASwPjOvzw2/PsgItKaofW5pK+QC0vj1uiG41jw1kuS+uN7+c3l2F26dGnMmzcPjx8//mbdYbjAMs5pKfWX1EuRbXEv2544cWKQejx4GaT+Dp6mQ8ov5wHGdY+c+0RXOg+piyXYYWg9Z0zqL0Odao7zDznfkN9ZeiTIbyvBFvmsBqzDWYcTkfWzhGv4b/ne8T84U6735RpWehJJvS6fcenSpeo76N69+3fLJd9Z8DrHHLGGqNquqeRcwzhlraRpkd5nFSpUUOWRSR7LMuM0O/L9SQMMGVfte6lZzBFPiMg5EtkftkgniyUXpXLQlACsBLSllY4EnGUwEGmhJBdhUlEZ8plLtyS5+y0HNRnU48SJE+riWAaskFZuESXvLxf+kuNMcqUHTycyduxYNXCFDGAhA17IICjSPVcqCmm9JY+/Rw72MtiGtLqSu9eSz00qdfm8xhfl8rkkr7h0c5ZAhFQ2UvHLHV75PqTCrlevnkmfr3fv3qoloOQvlS71EhCQMksaG7kole+2WbNmqjt2hw4d1GeVcsoFtdwdluVSuciF7LdIizvpXj9w4EB1oWuc1kVIpTdnzhz1XrKutPyXu9PS9VsGmpH3ND7xCY0MOCcDxshnkZYGUrlJ1y7DyUJY5DuU7uXy3ct3LOl7pNKW71NaJwQ/+ZF9QW4GyD4nv7tcrEsZpbu64Y66tNiTfUFuwEhZJE2B/J4ymZt0A5d/L5LaQIJO8l3KiVHwvIBERFqRbs0yeKJcIInggXQJqhpacMl6ciNZ0oiEJ3f4rFmz1AWWBF2lHpbXyDFcLn4kH7vcLBZSZ0qOT6nLpe6TukHymBrqmoiS84KFCxeqFuWSu1M+g+Rkl+Ox1JlyTJaUZpIzVtKTSD0tdauke5HzhJMnT6qUJgZSD0vdIfnCpdW+rBday21zkO9B6nv5/uWcSt5bbi7I9y/nBnIxKz0CzHH+IcFuOR+TAIl8F8HPA1iHsw4nIutnKdfwoQnP8T804b3el55TUkfu3btXtfiW9CgSR5AeVlJHGm4chEbqX9mW1JESiJfzJnm/yMYaomq7ppJ9QALdkrJNUrTKmDhCev8byPcnvbHknE56sEkqFmkoIbEDGWPme8wRT4jIORLZIR2Rhbt+/bquXbt2unTp0ulixIihixs3rq5YsWK6GTNm6Hx8fALX8/Pz0w0fPlyXPn16nYuLiy516tS6/v37B1lHpE2bVle1atUQ71OqVCk1BXfjxg1pIqSmQ4cOhVrGp0+f6jp16qTeU947RYoUunLlyunmz58fuM6+ffvUNtauXRvqNlatWqXLmjWrLmbMmLrs2bPrtmzZoqtbt65aFpxsN1++fLpYsWKp7yNHjhy6Pn366B49ehShz/ny5Utd586ddalSpVLfsYeHh65Fixa6Fy9eBK7z5csX3bhx43TZsmVTZUyYMKEqg3znb9++1YXHwIED1XeQMWPGMNeR76lixYq6+PHj61xdXXU//PCDrmXLlrpTp04FriNlix07dojX/vfff7rWrVur18hrEyVKpCtTpoxuz5494Srf6tWrdXny5FGfT17btGlT3YMHD4KsY3jvW7du6SpUqKBzc3PTJU+eXDd06FCdv79/kHWPHDmiviP5TuVzyzpC/gY//Mq87EPGbt++rZZPmDAhxHcUfF+6fPmyrnz58ro4ceLokiRJov7NnD9/Xq23ZMmSwPVCe28iougwa9YsdfwpWLBgiOekru7Zs6fO3d1d1W1Szx89ejREnWU4Lhof14Qck5s3b67qX6mHpT6rVq2abt26dUHWO336tK5QoULquJwmTRrd5MmT1bZkm7Lt79Wh33L27FldnTp1dIkTJ1b1iGyjQYMGur1796rnfX19db1799blypVL1d1Sl8jj2bNnB9nOhw8fdE2aNNElSJBAlUu2E9ZnD6s+lO9M6uvgQvtc79+/V+dLUjfL9yJ1SNGiRXUTJ05Udb+p5x/fsmDBAvUZ5LWfP38O8hzrcNbhRGQ7ousaPrzHX1OO/8bH/PBe78v5hbOzs65Lly5BXvf161ddgQIFdClTptS9fv06zGP51atXdSVLllT1qzwn5Q3ve39LZLcbVgzDcO508uTJIMsNn+358+dBvk95n99//12XKVMmVU9LfS3bDu7MmTMqFiD1ofxGch4g9XF43tuUeEJov4HsY8bfj6nnSGQ/HOR/WgfziSh0MmiZ3EVlnkzLIXej5Q50aN33iYiIyHKxDicisk88/mtH8rR36tTJpNbgRJaMOdKJLIDk8AqeY2v//v2qO7rkfiUiIiIiIiIiIiLtMEc6kQWQnJgyGvTPP/+scpdJ7nHJT54iRQqVl5yIiIiIiIiIiIi0w0A6kQVImDChGrxCBiuT0aRldG0ZpVwGAUmcOLHWxSMiIiIiIiIiIrJrzJFORERERERERERERPQNzJFORERERERERERERPQNDKQTEREREREREREREX0Dc6QDCAgIwKNHjxA3blw4ODhoXRwiIrJDkmnt/fv3asBhR0fe5w4v1uFERGQJWI+bjnU4ERFZWx3OQDqgKu/UqVNrXQwiIiLcv38fHh4eWhfDarAOJyIiS8J6PPxYhxMRkbXV4QykA+oOuOELixcvXqTvqj9//hxJkyZlSwQKF+4zZCruM7bp3bt36mLSUCdR+LAOJy1xn6GI4H5jm1iPm451OGmN+w2ZivuMbTKlDmcgHQjsRiaVtzkqcB8fH7Ud/qOi8OA+Q6biPmPb2LXZNKzDSUvcZygiuN/YNtbj4cc6nLTG/YZMxX3GtoWnDuevTkRERERERERERET0DQykExEREREREVG0mDVrFjw9PVGgQAGti0JERGQSBtKJiIiIiIiIKFp06tQJly9fxsmTJ7UuChERkUmYI52IiIiIiMiE/KhfvnyJ1Ov9/PxUjlXmV7UeLi4ucHJy0roYREREpCEG0omIiIiIiMJBAui3b99WwfCI0ul06vXv37/nwJRWJkGCBEiRIgV/NyIiIjvFQDoREREREVE4AuCPHz9WrZJTp04d4dbksp2vX7/C2dmZAVkrIb/Zp0+f8OzZMzXv7u6udZGIiIjI3gLpBw8exIQJE3D69Gl1Urpx40bUqlUryAnL0KFDsWDBArx58wbFihXDnDlzkClTpsB1Xr16hS5dumDr1q3qZLZu3bqYNm0a4sSJo9GnIiIiIqvj7w8cOADXa9eALFmAUqUAduEnIiMS/JZgasqUKeHm5hbh7TCQbp1ixYql/kowPVmyZEzzQkREpBH/AH943/PG4/eP4R7XHSXSlICTY/TUy5om5fv48SNy5cqlRu0Ozfjx4zF9+nTMnTsXx48fR+zYsVGxYkWVT9CgadOmuHTpEnbv3o1t27ap4Hz79u2j8VMQERGRVduwAUiXDo7lyiFBx47qr8yr5URE/89fbrgBiBEjhtZFIY0YbqBIjnuKOLn+9/T0RIECBbQuChERWZkNVzYg3bR0KLOsDJpsaKL+yrwst/lAeuXKlTFq1CjUrl071JYaU6dOxaBBg1CzZk3kzJkTy5cvx6NHj7Bp0ya1zpUrV7Bjxw4sXLgQhQoVQvHixTFjxgysWrVKrUdERET0TRIsr1cPePAg6PKHD/XLGUwnomDYitx+8bc3j06dOuHy5cs4efKk1kUhIiIrsuHKBtRbUw8P3gW9dnv47qFaHh3BdIsdJl4G8Xny5AnKly8fuCx+/PgqYH706FE1L39lwJf8+fMHriPrS4oXacFOREREFCZpXdq1q9y9D/mcYVm3bvr1iIiIiIiISLN0Ll13dIUOIa/dDMu67eim1rPLwUYliC6SJ08eZLnMG56Tv5KfzpjkGkyUKFHgOqHx9fVVk8G7d+/U34CAADVFhrxeWtNHdjtkP7jPkKm4z9gm/p4a8PYO2RI9eDD9/n39eqVLR2fJiIisyrBhw1Sv4XPnzlnE+wwePBhPnz7F/Pnzw7XdL1++IHPmzFi3bl2QRlpERERkGbzveYdoiR48mH7/3X21Xul0pe0vkB6VvLy8MHz48BDLnz9/HiT/ekQDIW/fvlVBLmkZT/Q93GfIVNxnbNP79++1LoL9efzYvOsREVmo+/fvY+jQoSot5osXL+Du7o5atWphyJAhSJw4scnpTTZu3Kheb9CrVy906dIFlkAaVE2bNg0XLlwIkZd7woQJ6nkZp0tSghYsWDAw7718hr59+2Lv3r0alZyIiIjCIgOLmnM9mwukp0iRQv2VlgRyomcg87lz5w5cR0ZNN/b161e8evUq8PWh6d+/P3r06BGkRXrq1KmRNGlSxIsXL9IBLjm5lG0xwEXhwX2GTMV9xja5urpqXQT7Y3R+YZb1iIgs0H///YciRYqoFtd//vkn0qdPj0uXLqF3797Yvn07jh07pnr0RkacOHHUZAlk/KyiRYsibdq0gctWr16trv/mzp2rUoXKWFwVK1bEtWvXAns4N23aFD179lTfTbZs2TT8BERERBTc3bd3ER7ucaP22s1iIzBygifBcOMWARLwltznciIo5O+bN29w+vTpwHX++ecfFWSSE6SwxIwZUwXMjSchASlzTBLgMte2ONnHxH2Gk6kT9xnbnCialSgBeHhI88qw13Fy+vbzRERWMLCjtLjetWsXSpUqhTRp0qBy5crYs2cPHj58iIEDBwaumy5dOowcORKNGzdG7NixkSpVKtWS2/h5Ubt2bXUuYpiXlCuGxk6iZcuWqsX6mDFjVGpOGddqxIgRqtGTBPAlcO/h4YElS5YEKau0CJeAv5ubGzJkyKBStPj5+Zn0eVetWoXq1asHWTZ58mS0a9cOrVq1gqenpwqoy3ssXrw4cJ2ECROiWLFi6vVERERkGd77vkf7re3Rf2//b67nAAekjpcaJdKUiNLyaHrV/uHDB5XfzpDjTgYYlcf37t1TJ2bdunXDqFGjsGXLFtU1r3nz5kiZMmVgN8Iff/wRlSpVUidFJ06cwOHDh9G5c2c0atRIrUdERETRSwIuEliRFvZyU1vq52+RG+IS5JHeZ3KjWwIof//9d/QUVoLk06bpHwcPlhvmZaDRcuWA8eOlO0j0lIuIrMrHLx/DnHy++oR73c9+n8O1rimkp+7OnTvRsWNHxIoVK8hz0mhJWmFLa21JF2cg6U8k9cnZs2fRr18/dO3aFbt371bPnTx5Uv2VAPjjx48D50MjDZwePXqEgwcPqkC2pJapVq2aClhL46gOHTrgl19+wQOjsSrixo2LpUuX4vLlyyo9y4IFCzBlyhSTPq+81jjPueQ/l4ZX5cuXD1wmN69l/ujRo0FeL6levGVcDCIiItLcwbsHkWtuLiw4s0DNV8tUTQXM5T9jhvmplabCydHJdlO7nDp1CmXKlAmcN6RbadGihTqB6tOnDz5+/Ij27durC+3ixYurvH7G3d//+OMPFTwvV66cOiGqW7cupk+frsnnISIismfh6TpvTIIbP/30k3pOBniTlo93795VLRejTZ06wLp1QNeuQQcelZbqXl7A9u1ysiHNJPWDji5bBkQyBQIR2ZY4XmGnNKmSqQr+avJX4Hyyicnwye9TqOuWSlsK+1vuD5xPNy0dXnx6EWI93dD/Bb2/58aNGypILg2QQiPLX79+rcaKMhynpVW2BNCF3NyUxkoSzJbjtaSVE3Kc/lYqTSGtzuW6TK7RsmTJgvHjx+PTp08YMGBAYLrNsWPH4tChQ6ohlBg0aND/Pn+6dCpvubQQl+vC8JAGWfJ5jRtVSU54f39/1TLemMxfvXo1yDJ5ndRDREREpJ3Pfp8x8J+BmHpsqhpENG38tFhaa6kaRHTDlQ3ouqNrkIFHPeJ5qCB6nR/rRHnZNA2kly5dOkjrh+CkVbp0AZTpWydoK1eujKISEhERUXgZd50XElD/66+/VNd5Q1DGmCyX1oNHjhyBi4uLWmZIExCtJJhesyYCDhzAu2vXEC9LFjiWKqVvsd6kCSCPZRC9bduAPHmANWuAb6SQIyKyNN+65grOkEbTeF5ujJpK8owbpy2TwHX27NkD552cnNRAp8ZjXskNWQm+37p1S/VellQwpoxh9fnz50iNOyKt9iXYT1Hfe00mucFBRERk7NSjU2i+sTmuvLii5tvkaYPJFScjXkz9+YAEy2tmqQnve95qYFHJiS7pXKK6JbrFDzZKRERE1sPQdV5aGH6v67yBpG6TAI2kdtm8ebNq6dikSROVI1cCLNFK3q90afh4eiKetMo0BH8kxUu7dkCBAkD9+sDNm/rc6hMmAL/9xvzpRIQP/T+E+Vzwi7pnvZ6poLYEiJ2dnVXDIQNHh6BZN+90vRPpsmXMmFG9x5UrV1Re8+BkuaRaMbQ0NyfDDVIDKUdoy2R8KyF1haSaGT58uOrNFD9+fNUafdKkSeF+zyRJkqi/0sre8JlkmdQpT58+DbKuzAdvVS83d6Piu6CgpN6XScZAk9+ZiIjIz98Pow6Owmjv0fDX+SNFnBRYUH0BqmWuFur5lbRO1wID6URERBRppnSdN/jvv/9UDl0JnEhe9Js3b6o8vjKwnOTSDY2vr6+aDOQiXEggxhCMiSh5vQS4Qt1OzpzAiRNwaNcODuvXA926QXfgAHSLFgEMAtitb+4zZLO/t2EycHNx++brQlvXz8EvRFA5rHW/tc73SO9dSckye/ZsNf6UcZ70J0+eqDSZzZo1C7LdY8eOBXkPmZcUMIZlUm65EWC8juFx8LKFNh/WMkkhkzZt2sDUL+LOnTuhbj+s70AGKJUW7JcuXUKmTJkCy5svXz41uGrNmjUDf8u9e/eqYK7xti5evIg8efKEuX1DWUOrc3gcICIiiphLzy6h+abmOPP4jJpvkK0BZleZjcRuiWFpGEgnIiIiTUjQQXLyzp8/X7UWlEDHw4cP1UB3YQXSvby8VGvF4CS/r4+PT6TL8/btWxUkMU5HEMSMGXDLkwdxhw+Hw8aN8D9zBm/mz8dXCbST3QnXPkM2Q27yyW8uQWSZIkr2F0NKC+MW6VFF8puXKlVKtfKW46ek0JIBOSXlluQEl2XGn0cC2pK7vEaNGirYvHbtWtVryLCOBLslKC1jYcgg0dKi3XCTwbCOIdBsvF1DEDr4d2dYT4LgkuNcgvsyWOj27duxadMmtY7xdkPbhrGyZcuqAUNlYFOD3377DW3atFFB8gIFCmDGjBlqLC65iWC8LXmd1D9hbV+WSxlevnwZ4kbI+/fvw/mLEBERkfAP8MeUY1Mw6J9B8PX3RULXhJhddTYaZdePnWKJGEgnIiKiSDOl67yBu7u7CkQYp3GRVo/SSlJSxcSIESPEayR1jGFwckOL9NSpU6uu+Kbk0Q2NBEckqCXb+mZQtH9/6MqXBxo2hPPdu0hcvTp0U6YAv/zCVC92Jtz7DNkEuVknwVJJySJTZIXWIj0qyHH15MmTGDZsmEqfJelL5LgsrbMlaCx5yo3JMfbs2bMYNWqUOq5KapUqVaoEPi/zPXv2xKJFi9Qg0bdv31b7v/xbMHwvMi+T8fckzxuvY2BYT1LPSKt5maTnUdWqVdXgoxLoN95uaNswJmN1tG/fXt2UNfy7NHxuGXtL6pjcuXOrQL2U30BSy8iNsYZybA9j+7JctinfWfA87BHNy05ERGSP/nv9H1psaoFD9w6p+coZK2NhjYVIGfd/A4ZbIgedKX0DbZQhN5ucOJnjIlwGzJEWdrygovDgPkOm4j5jm8xZF2lFWicWLFhQtfQz7Ktp0qRB586dQx1sVLrvy4DhkuLFsC9PmzYN48aNw6NHjyy/Dn/9GmjRAti6VT/fuDEwbx4QN26kykHWg8dj+wukS9A4ffr0kQqahpUj3RJIa3VDMNtayfcr9VH37t3RWI7L4SQB9Fy5cgVJLWPKPmAL9Xh043U4aY37DZmK+4x56un5p+ej566e+Oj3EXFixMGUilPUoKJanReZUh/xVyciIiKzkFaMCxYswLJly9QAdr/++qvqOt+qVSv1fPPmzYMMRirPSwvBrl274vr16/jrr78wZswYlbPWKiRMCGzeDEycqB+s9M8/gfz5gQsXtC4ZEZHdkotwSRlmSvod6QWVI0cOFXwnIiKiqPHw3UNU/qMyOvzVQQXRS6UthX87/Iu2edtaXOOCsDC1CxEREZmFtOaTXOVDhgwJ7Dq/Y8eOwAFIJfetccsNScmyc+dOFbjImTOn6mIvQfW+ffvCasgJX8+eQOHCKtULrl+XpvnArFnA/99AICKi6CX1j0zhJanEJI0MERERRU0r9JUXVqLz9s544/MGMZ1iwqucF7oW7gpHB+tq481AOhEREZmNpHGRKTT79+8PsaxIkSI4duwYrF6xYsC5c0CzZsCOHUDr1sDBg/qAupub1qUjIgqXO3fuaF0EIiIisiHPPz7Hr3/9ivVX1qv5/CnzY3mt5fgx6Y+wRtYV9iciIiKyVEmSAH/9BYweLSPiAUuXAgULAleuaF0yIiIiIiKiaLXl2hZkn5NdBdGdHZ0xovQIHGl9xGqD6IKBdCIiIiJzkQC6DFS3dy+QIgVw6RJQoACwcqXWJSMiIiIiIopyb33eotXmVqi5qiaefXyGbEmz4Xjb4xhcajBcnFxgzRhIJyIiIjK30qWBs2eBMmWAjx+Bpk2BDh0AHx+tS0ZEZsjzSfYpICBA6yLYhFmzZsHT0xMF5EYzERHZlH9u/4Mcc3Jg6bmlcIADehftjVPtTyGve17YAuZIJyIiIooK0iJ9925gxAhg5Ehg3jzg+HFg7VogY0atS0dEJnJxcYGDg4MaVDlp0qTqcUQD8V+/foWzs3OEt0HRS36zL1++qN9eBs2WwUkp4jp16qSmd+/eIX78+FoXh4iIzOCT3yf029MPM07MUPMZEmbAslrLUDxNcdgSBtKJiIiIooqTEzB8uH4wUmmVLgOS5s0LLF4M1KundemIyAROTk7w8PDAgwcPIjUopwRlpWWzBGQZSLcubm5uSJMmjfrtiIiISO/Yg2NovrE5bry6oeY75OuACRUmIE6MOLA1DKQTERERRbUKFfRB9EaNgEOHgPr1gd9+AyZMANiykchqxIkTB5kyZYKfn1+EtyFB9JcvXyJx4sQMyFrZjRT2IiAiIvqfL/5fMGz/MIw7PA4BugCkipsKi2osQsWMFWGrGEgnIiIiig6pUgH//AMMGgSMHw9Mnw4cOwasXg2kS6d16YjIhICqTJEJpEuaGFdXVwbSiYiIyCr9+/RfNNvYTP0VP+f8GdMrTUfCWAlhy3jmRkRERBRdXFyAceOArVuBhAmBEyeAPHmALVu0LhkREREREdE3fQ34Ci9vL+Sfn18F0ZO4JcG6+uuwovYKmw+iCwbSiYiIiKJbtWrA2bNAwYLAmzdAzZpAnz5AJNJFEBERERERRZXrL6+jxJISGPDPAPgF+KFmlpq4+OtF1PWsC3vBQDoRERGRFtKmBby9gW7d9POSL710aeDBA61LRkREREREpEj+85knZiL33NxqYNF4MeNhac2l2NhwI5LHSQ57wkA6ERERkVZkoNEpU4B164B48YAjR/SpXnbs0LpkRERERERk5+69vYcKKyqgy/Yu+Pz1M8qlL4cLv15Ai9wt7HIAbgbSiYiIiLRWty5w5ow+iP7iBVClin5Q0q9ftS4ZERERERHZGZ1Oh6XnliLHnBzYe3svYjnHwozKM7Cr2S6kiZ8G9oqBdCIiIiJL8MMP+hbpv/4qZ67A6NHATz8Bjx9rXTIiIiIiIrITTz88Ra3VtdBqcyu8832Hwh6Fca7DOXQu2BmODvYdSrbvT09ERERkSVxdgdmzgZUrgdixgf379a3U9+3TumRERERERGTj1l9ej+xzsmPLtS1wcXSBVzkvHGp1CJkTZ9a6aBaBgXQiIiIiS9O4MXDqFJA9O/D0KVC+PDByJBAQoHXJiIiIiIjIxrz+/Bo/b/gZ9dbWw4tPL5AzeU6can8K/Yr3g5Ojk9bFsxgMpBMRERFZoqxZgePHgdat9QH0IUOAypWB58+1LhkREREREdmInTd3qlbof1z4Q6VuGVB8AE62O6mC6RQUA+lERERElsrNDVi0CFiyBIgVC9i1S5/q5dAhrUtGRERERERW7MOXD/h126+o9EclPHr/SKVvOdz6MEaXG40YTjG0Lp5FYiCdiIiIyNK1bAmcOAFkyQI8fAiULg1MmMBUL0REZHVmzZoFT09PFChQQOuiEBHZrUP3DiHX3FyYe3qumv+t4G84+8tZNbAohY2BdCIiIiJrIPnSJW96kyaAvz/Qpw9Qsybw6pXWJSMiIgq3Tp064fLlyzh58qTWRSEisjs+X33Qe1dvlFxSEv+9/g9p4qfB3uZ7Ma3yNLi5uGldPIvHQDoRERGRtYgTB/j9d2DePCBmTGDbNn2qF8mlTkREREREFIYzj88g//z8mHh0InTQoVXuVvi3w78om76s1kWzGgykExEREVkTBwegfXvg6FHghx+Ae/eAEiWA6dMBnU7r0hERERERkQXx8/fDiAMjUGhhIVx6fgnJYyfH5kabsbjmYsR3ja918awKA+lERERE1khaop8+DdSrB/j5AV27AvXrA2/fal0yIiIiIiKyAFeeX0HRxUUxdP9QfA34inqe9XCx40XUyFJD66JZJQbSiYiIiKxV/PjAmjX61uguLsD69UC+fMCZM1qXjIiIiIiINBKgC8Dko5ORZ14enHp0CglcE+CPOn9gTb01SOKWROviWS0G0omIiIisPdVLly7AoUNA2rTArVtA0aLA3LlM9UJEREREZGduv76NMsvKoOeunvD190WljJVw8deLaJKjCRzk2oEijIF0IiIiIltQsKC+JXr16oCvL/Drr0DTpsD791qXjIiIiIiIophOp8OC0wuQc25OHLx7ELFdYmNetXn4u8nfSBUvldbFswkMpBMRERHZikSJgM2bgQkTACcn4M8/gQIFgAsXtC4ZERERERFFkUfvH6Han9XQflt7fPjyASXSlMC/v/6L9vnasxW6GTGQTkRERGRL5ES5Vy/gwAEgVSrg2jWgUCFgyRKtS0ZERERERGa26uIqZJ+dHX/f+BsxnWJi4k8Tsa/FPmRImEHrotkcBtKJiIiIbFGxYsDZs0DFisDnz0Dr1kCrVsCnT1qXjIiIiIiIIunlp5douK4hGq9vjNc+r5HXPS9Otz+NnkV7wsnRSevi2SQG0omIiIhsVdKkwN9/A6NGAY6OwNKl+tbpV69qXTIiIiIiIoqgv67/hexzsmPNpTVwcnDC0FJDcazNMWRLlk3rotk0BtKJiIiIbJkE0AcOBPbsAVKkAC5eBPLnB1au1LpkRERERERkgne+79B2S1uVD/3JhyfwTOqJ422PY1jpYXBxctG6eDaPgXQiIiIie1CmjD7Vi/z9+BFo2hTo0AHw8dG6ZERERERE9B377+xHzjk5sejsIjjAAT2L9FSpXPKlzKd10ewGA+lERERE9kJapO/eDQwerB+UdN48oEgR4OZNrUtGRERERESh+Oz3Gd12dEOZZWVw9+1dpE+QHvtb7sfEChPh6uyqdfHsCgPpRERERPbEyQkYMQLYvh1IkgQ4dw7Ilw9Yv17rkhERERERkZETD08gz7w8mHZ8mppvn7c9znc4j5JpS2pdNLvEQDoRERGRPapYUZ/qpXhx4N07oF49oGtX4MsXrUtGRERERGTXvvh/weB/BqPooqK49vIa3OO44+8mf2Ne9XmIGzOu1sWzWwykExEREdkrDw/gn3+APn3089OnAyVKAHfuaF0yIiIiIiK7dPHZRRReWBijvEfBX+ePxtkb42LHi6icqbLWRbN7DKQTERGR2cyaNQvp0qWDq6srChUqhBMnToS57tKlS+Hg4BBkktdRNHNxAcaNA7ZuBRImBOQ3y5tXP09ERERERNHCP8Af4w+PR775+XD2yVkkjpUYa+qtwcq6K5EoViKti0eWHkj39/fH4MGDkT59esSKFQs//PADRo4cCZ1OF7iOPB4yZAjc3d3VOuXLl8eNGzc0LTcREZE9Wr16NXr06IGhQ4fizJkzyJUrFypWrIhnz56F+Zp48eLh8ePHgdPdu3ejtcxkpFo1faqXggWB16+BGjX0LdX9/LQuGRERERGRTbv56iZKLS2Fvnv6qrQu1TNXV63Q62err3XRyFoC6ePGjcOcOXMwc+ZMXLlyRc2PHz8eM2bMCFxH5qdPn465c+fi+PHjiB07trpo9/Hx0bTsRERE9mby5Mlo164dWrVqBU9PT1U3u7m5YfHixWG+Rlqhp0iRInBKnjx5tJaZgkmbFvD21udKFxMmAGXKAA8eaF0yIiKyQLVr10bChAlRT8bZICIik0kD4Tkn5yDX3Fw4fP8w4saIi8U1FmNzo81IESeF1sWjYJxhAglmr1q1Ct7e3qrF2KdPn5A0aVLkyZNHBa/r1q2LmDFjwlyOHDmCmjVromrVqmpeuor/+eefgd3EZWebOnUqBg0apNYTy5cvVxfhmzZtQqNGjcxWFiIiIgrbly9fcPr0afTv3z9wmaOjo+opdvTo0TBf9+HDB6RNmxYBAQHImzcvxowZg2zZsoW5vq+vr5oM3skgmYB6vUyRIa+Xc4vIbsfqOTvLXRGgWDE4tG0Lh8OHocuTB7rly/UDlFIg7jMUEdxvbJO9/p5du3ZF69atsWzZMq2LQkRkdR68e4DWm1tj93+71XyZdGWwpOYSpE2QVuuiUWQC6dI9u0+fPjh06BCKFSumcp7KnWdJpfLq1StcvHgRAwcORJcuXdR63bp1M0tAvWjRopg/fz6uX7+OzJkz4/z586oM0uJN3L59G0+ePFEX6Qbx48dX5ZOL9rAC6bwIJ0vCfYZMxX3GNln77/nixQuVki14i3KZv3r1aqivyZIli2qtnjNnTrx9+xYTJ05Udf+lS5fgIYNghsLLywvDhw8Psfz58+eR7o0mv4GUQ/59yU0Au1eiBJx27kSCdu3gcvEiULUqPnbtig+9egFOTlqXziJwn6GI4H5jm96/fw97VLp0aezfv1/rYhARWRU5B/j939/RZXsXvPV9C1dnV4wrPw6dC3aGowPPDaw+kC4tzXv37o1169YhQYIEYa4nwetp06Zh0qRJGDBgQKQL169fPxXkzpo1K5ycnNQF+ujRo9G0aVP1vATRRWgX7YbnQsOLcLIk3GfIVNxnbJM9XoAXKVJETQYSRP/xxx8xb948NSZKaKTFu+RhN5DzhNSpU6secpJvPbL/tiTVjGyL/7b+X7JkwPHj0PXoAYd58xBn6lTEPn8eut9/B1Kwqyn3GYoI7je2yRIHyz548CAmTJigeozJOCQbN25ErVq1QgwSLuvI9bOMbSJpVAvKWBlERBQlnn98jl+2/YKNVzeq+UKpCmFZrWXIkiSL1kUjcwXSpUW4i4tLuC+I/cw0KNWaNWvwxx9/YOXKlaqb97lz51Rr95QpU6JFixYR3i4vwsmScJ8hU3GfsU2WeAFuiiRJkqib3k+fPg2yXOYl93l4yLmGpIu7efNmmOtIj7fQer3JvwVz/HuQf1vm2pbNcHMD5s4FSpUC2rWDw759cMibF/jzT33+dDvHfYYigvuN7bHE3/Ljx48qOC6pV+rUqRPmIOEypon06pa0qZKy9dq1a0gmN1IB5M6dG1+/fg3x2l27dqnrciIiCr9NVzeh/db2eP7pOVwcXTCs9DD0KdYHzo4mZd4mDYXrlwpPED0y64dFWsFLq3RDipYcOXKo3OzSolwC6YYLc7lId3d3D3ydzEuFHxZehJOl4T5DpuI+Y3us/beMESMG8uXLh7179wa2dpObPjLfuXPncG1Dep5duHABVapUieLSUoQ0bgzkyQPUrw9IqhdJrSc9/KQXopXvv0REtqhy5cpqCs8g4UIC6n/99ZdKuybX4UIas5kLU6ySpeF+Q9G1z7zxeYNuO7thxb8r1HyOZDmwrOYy5EqRK3C7pB1Tvv8I3/KQrmGSE/3AgQPqwldyp0talwwZMsBcZDDT4IEFae1m+IDp06dXwXS5SDcEzqUyPn78OH799VezlYOIiIi+T1q1yY3u/Pnzq27h0rJNWsMZLtCbN2+OVKlSqRviYsSIEShcuDAyZsyIN2/eqK7lcsO8bdu2Gn8SClPWrCrVC+TmyJIlwODBwKFDwIoVQNKkWpeOiIiieJDwyGCKVbI03G8oOvaZAw8OoMf+Hnj08ZHKf94xV0f0yt8LMR1j4tmzZ1FeZjJvmtUIB9Kle5h0/5KLYKmEZ86ciSZNmuDYsWMwl+rVq6uc6GnSpFGpXc6ePavumst7G1pkSqqXUaNGIVOmTCqwPnjwYNXFLHjuNyIiIopaDRs2VBfDQ4YMUblW5Sb3jh07AscyuXfvXpATztevX6uWcLJuwoQJVYv2I0eOwNPTU8NPQeFK9bJ4sRqMFJ06ATt36luqr1oFFC+udemIiCiKBgkPjQTez58/r26cy0Dha9euDTL+iTGmWCVLw/2GonKf+fjlI/rt7YfZp2ar+YyJMmJJjSUomrpoNJWWoiLNargD6V27dsWYMWMQO3ZsNS/5Szds2IBYsWIFPl+yZEmYkwx0IoHxjh07qrs0EiD/5Zdf1AW6QZ8+fVSl3b59e9WarXjx4uqi3dpzzRIREVkjSeMSViqX/fv3B5mfMmWKmshKSU+DAgWAevWAa9eA0qWluSHQsydTvRAR2Yk9e/aEe12mWCVLxP2GomKfOXL/CFpsaoGbr/RjP3Uu0Bljy49F7Bj6mCpZFlP+/Yc7kC53l6Wl2Pjx41GjRg3V6kxapEseUxlcVILqTZs2hTnFjRtXdQuX6Vs7sLSKl4mIiIiIolH27MCpU8AvvwArV0oLB8DbG1i6FEiUSOvSERFRFA4STkREQfl+9cXQ/UMx4cgEBOgC4BHPA0tqLkH5DOW1LhqZiaMpA39u374dc+bMUSN+Sw5ySbsiQXTpEiYBdmlBTkRERER2JE4c4PffZZQ6aW4IbN0K5M0LnDihdcmIiCgcg4QbGAYJDys1i7nMmjVLpXErIL2aiIhsxLkn51BgQQGMOzxOBdFb5GqBC79eYBDdxpiUI11ykEsw/Y8//kCpUqVUOpeJEyeqVuFEREREZKfkXFBapRcsCNSvD9y6pc+XPnEi0KWL/nkiIopWHz58UClZDW7fvo1z584hUaJEahyy7w0SHlU6deqkJsmRHj9+/Ch9LyIic/EP8MeBOwdw7dE1ZPmUBaXSlYKToxO+BnzFuEPjMPzAcPgF+CFZ7GSYV20eamXl2I22yOTBRl++fKlSuEhKl549e6q71fPnz0fOnDmjpoREREREZB1k0NHTp4E2bYD162UQHeDgQWDRIoDBEiKiaHXq1CmUKVMmcN4w0KcEz5cuXfrdQcKJiEhvw5UN6LqjKx68exC4TNK29CnaB79f+B0nHup7Ytb5sQ7mVp2LpLGTalhasojULtLFSypUGZlW8qXLSN6LFy+Gl5cXGjdurAb9/Pz5c5QWloiIiIgsnATM164Fpk8HXFz0AfV8+YCzZ7UuGRGRXSldujR0Ol2ISYLoBjJA+N27d+Hr64vjx4+rcdCIiChoEL3emnpBguhC5n/b8ZsKosePGR8raq/AuvrrGES3ceEOpEvXKwmWf/r0CTNnzkS3bt3UcrnDfebMGbi4uKg72ERERERk5ySVi6R0OXQISJtWn+pFcu7OmwfodFqXjoiINMQc6URkTelcpCW6DmGfv8Z0ionzHc7j55w/M/W1HQh3IP3x48eoWrUqXF1dUalSJdUFzCBmzJhq4NENGzZEVTmJiIiIyNpIzvQzZ4Bq1QBfX6BDB+DnnyVxr9YlIyIijUgjvcuXL+PkyZNaF4WI6Ju873mHaIkenK+/L26/uR1tZSIrCaTXqFED9erVw4ABA1ChQgWVIz24bNmymbt8RERERGTNEiUCNm8Gxo8HnJyAlSuB/PmBCxe0LhkRERERUQjPPj7DpqubMPHIxHCt//j94ygvE1nZYKOLFi3CvHnzVG70n3/+Ga1bt47akhERERGRbXB0BHr3BooWBRo2BK5dAyQP7+zZQMuWWpeOiIiIiOxUgC4AV19cxeF7h3H4vn66+eqmSdtwj+seZeUjKw2kx4gRA10k1yURERERUUQUK6YfdFTSu+zaBbRqBRw4IAlzATc3rUtHRERERDbuk98nnHx4UgXMj9w/oqbXPq+DrOMAB2RLlg1FPIpg3eV1eOPzJtQ86bKeRzwPlEhTIho/AVl8IP3YsWMoXLhwuDYog5Hevn2baV6IiIiIKKSkSYHt24ExY4ChQ4GlS4FTp4C1a4GsWQF/f8DbWwboAdzdgRIl9ClhiIjIZgYblclfjvdERFHsyYcnQVqbn3l8Bl8DvgZZJ5ZzLBTyKIRiqYupqUjqIkjgmkA9VyljJdRbU08FzY2D6TIvplaaCidHnqvai3AF0ps1a4YMGTKgbdu2Kjd67NixQ6wjg4X8/vvvWLJkCcaNG8dAOhERERGFnepl0CB9C/XGjYGLF/V509u1A9atAx4YDerk4QFMmwbUqaNliYmIyIyDjcr07t07xI8fX+viEJGNpWm59OxSYNBcAuihDQSaMm7KwKB5sTTFkCt5Lrg4uYS6zTo/1sG6BuvQdUfXIAOPSkt0CaLL82Q/whVIlyD5nDlzMGjQIDRp0gSZM2dGypQp4erqitevX6u86R8+fEDt2rWxa9cu5MiRI+pLTkRERETWrUwZ4Nw5fTB9/35g6tSQ6zx8CNSrpw+wM5hOREREZFP8A/zhfc9bDdgpucYlTUp4W3h//PIRxx8eVwHzIw+O4Oj9o3jr+zbIOtJyPGfynCiaumhg4Dxt/LRwcNC3KA8PCZbXzFITB+4cwLVH15AlZRaUSleKLdHtULgC6S4uLvjtt9/UdOrUKRw6dAh3797F58+fkStXLnTv3h1lypRBokSJor7ERERERGQ7UqQAdu4EkiQB3r8P+bxOB8iFTrduQM2aTPNCREREZCM2XNkQakvvaZWmhdrSW9aTnOaGVC3nnpyDvy5omqjYLrFR2KNwYNBcHseLGS/SZZWgeel0peHp5olkyZLBUXpYkt0J92CjBvnz51cTEREREZFZHDkSehDdOJh+/74+d3rp0tFZMiIiIiKKoiC65B4PPojnw3cP1fI19dYgY+KMQfKb33t7L8R2UsdLrQLmEjiXVufS+tzZ0eRwJ1G4cM8iIiIiIm3JwKLmXI+IiIiILDqdi7REDx5EF4ZlDdY1CPG8o4OjymduaG0uf1PHTx1t5SZiIJ2IiIiItOXubt71iIjIYs2aNUtN/v5B0zEQkf2QnOjG6VxCI0H0WM6xUCJticCBQQt5FEKcGHGirZxEwTGQTkRERETaKlEC8PDQDywqaVyCkxzp8rysR0REVq1Tp05qevfuHeLHj691cYhIAzKwaHgsqL4ATXM2jfLyEIUXM+MTERERkbZkANFp0/4XNA/N1KkcaJSIiIjIyl1/eR2zTs4K17qp4qWK8vIQRVsg3cfHJzIvJyIiIiLSq1MHWLcOSBXKBVP37vrniYiIiMgqvfz0Er9t/w3ZZmdTA4d+iwMc1CCiJdKwNyJZeSA9ICAAI0eORKpUqRAnThz8999/avngwYOxaNGiqCgjEREREdkDCZbfuQPs2wesXAm0aKFfvnu3nIRqXToiIiIiMpHvV19MPDIRP0z/ATNOzMDXgK+omqkqplacqgLm8p8xw/zUSlPh5MjeiGTlgfRRo0Zh6dKlGD9+PGLEiBG4PHv27Fi4cKG5y0dERERE9kTSt5QuDTRuDEyeDMSNC1y4AGzdqnXJiIiIiCicdDod1lxagx9n/Yjeu3vjre9b5EqeC3ua7cG2JtvQtXBXrGuwLkT6Fo94Hmp5nR/ZG5FsYLDR5cuXY/78+ShXrhw6dOgQuDxXrly4evWquctHRERERPYqUSIZlQ4YOxYYORKoUSPsHOpEREREZBGO3j+Knrt64uiDo2rePY47Rpcdjea5mgdpZS7B8ppZasL7nrcagNQ9rrtK58KW6GQzgfSHDx8iY8aMoaZ88fPzM1e5iIiIiIiAHj2A6dOB06eBnTuBSpW0LhEREUXCrFmz1OTv7691UYjIzP57/R/67+2vWqILNxc39C3WFz2L9ETsGLFDfY0EzUunKx3NJSWKptQunp6e8Pb2DrF83bp1yJMnTwSLQUREREQUiqRJAUMvSGmVrtNpXSIiIoqETp064fLlyzh58qTWRSEiM3n9+TV67eql0rhIEF3ynLfJ0wY3u9zEkFJDwgyiE9l8i/QhQ4agRYsWqmW6tELfsGEDrl27plK+bNu2LWpKSURERFHOx8cHrq6uWheDKKRevaQJI3DkiH4g0rJltS4RERERkd3z8/fDnFNzMPzAcLz6/Eot+ynDT5hYYSJyJs+pdfGItG+RXrNmTWzduhV79uxB7NixVWD9ypUratlPP/1k/hISERFRlJGb4iNHjkSqVKkQJ04c/Pfff2r54MGDsWjRIq2LR6Tn7g60bfu/VulEREREpOlAopuubkK22dnQdUdXFUT3TOqJv5v8jZ0/72QQnWyWyYF0UaJECezevRvPnj3Dp0+fcOjQIVSoUMH8pSMiIqIoNWrUKCxduhTjx49HjBgxApdnz54dCxcu1LRsREH07Qu4uAD79wOHDmldGiIiIiK7dOrRKZReVhq1V9fGjVc3kCx2MsytOhfnO5xH5UyV4cCB4cmGRSiQTkRERLZBUrPNnz8fTZs2hZOTU+DyXLly4erVq5qWjSiI1KmBli31j0eN0ro0RERERHbl3tt7+HnDzyiwoAAO3j0IV2dXDCg+ADe63MAv+X+Bs6PJ2aOJrE649vKECROG+47Sq1f6nEhERERk+WTMk4wZM4aa8sXPz0+TMhGFqV8/YPFiYOdO4MQJoGBBrUtEREREZNPe+b7D2ENjMeXYFPh89VHLmuVshtFlRyN1/NRaF4/I8gLpU6dOjfqSEBERUbTz9PSEt7c30qZNG2T5unXrkCdPHs3KRRSqDBmApk2lKwUwejSwebPWJSIiIiKySV8DvmLhmYUYun8onn18ppaVSlsKkypMQr6U+bQuHpHlBtJbtGgR9SUhIiKiaCeDhks9Ly3TpRX6hg0bcO3aNZXyZdu2bVoXjyikAQOAFSuALVuA8+clD5HWJSIiIhPMmjVLTf7+/loXhYjCGEh0+83t6L27Ny4/v6yWZU6cGePLj0eNLDWYA53sWqRypPv4+ODdu3dBJiIiIrIeNWvWxNatW7Fnzx7Ejh1bBdavXLmilv30009aF48opCxZgAYN9I+ZK52IyOp06tQJly9fxsmTJ7UuChEFc/7JeVT4vQKqrqyqguiJYyXG9ErTcfHXi6iZtSaD6GT3TB4J4OPHj+jbty/WrFmDly9fhnied5WJiIisS4kSJbB7926ti0EUfgMHAqtXA+vXA5cvS44irUtEREREZLUevX+Ewf8MxpJzS6CDDjGcYuC3gr9hYMmBSOCaQOviEVlvi/Q+ffrgn3/+wZw5cxAzZkwsXLgQw4cPR8qUKVU3cCIiIrIub968UfX5gAEDAgcNP3PmjEr3QmSRcuQAateWvsfAmDFal4aIiIjIKn388hHD9w9HphmZsPjcYhVEb5itIa52uooJFSYwiE4U2UC6dPWePXs26tatC2dnZ9WKbdCgQRgzZgz++OMPUzdHREREGvr333+ROXNmjBs3DhMmTFBBdSG50vv372/y9iTnabp06eDq6opChQrhxIkT4XrdqlWrVFfRWrVqmfyeZMet0sWffwI3bmhdGiIiIiKr4R/gj8VnF6sA+rADw/DJ7xOKeBTB0TZHsareKqRPmF7rIhLZRiBdWqplyJBBPY4XL15gy7XixYvj4MGD5i8hERERRZkePXqgZcuWuHHjhgp+G1SpUsXken316tVqe0OHDlUt2nPlyoWKFSvi2bNn33zdnTt30KtXL3Vznijc8uWTHRUICAC8vLQuDREREZFV2PPfHuSdnxdttrTB4w+PkT5BeqyptwaHWx9GYY/CWhePyLYC6RJEv337tnqcNWtWlSvd0FI9QQJ2+SAiIrImMtDXL7/8EmJ5qlSp8OTJE5O2NXnyZLRr1w6tWrWCp6cn5s6dCzc3NyxevDjM18jYKk2bNlVp4gw36onCbfBg/d8VK+SOjNalISIiIrJYMnioDCL604qf8O/Tf1Xalok/TcSVTldQP1t9DiRKFBWDjcrF8fnz51GqVCn069cP1atXx8yZM+Hn56cuoImIiMh6yHgn7969C7H8+vXrSJo0abi38+XLF5w+fTpIOhhHR0eUL18eR48eDfN1I0aMQLJkydCmTRt4e3t/9318fX3VZGAoe0BAgJoiQ16v0+kivR2KRgULwqFcOTjs3Qvd2LHQzZ4drW/PfYYigvuNbeLvSUSW6umHpxi2fxgWnFkAf50/nB2d0TF/RwwpNQSJ3RJrXTwi2w6kd+/ePfCxXBxfvXpVXThnzJgROXPmNHf5iIiIKArVqFFDBbMNPcykJcq9e/fQt29fNR5KeL148UK1Lk+ePHmQ5TIv5wqhOXToEBYtWoRz586F+328vLxU6/Xgnj9/Dh8fH0Q2CPL27VsV4JKbAGQdXDp2ROK9e4ElS/Dil18Q4O4ebe/NfYYigvuNbXr//r3WRSAiCuKz32dMOTYFYw+Nxfsv+mNU7ay1Mbb8WGROnFnr4hHZRyA9uLRp06qJiIiIrM+kSZNQr1491Sr88+fPqseZpHQpUqQIRo8eHaUBh2bNmmHBggVIkiRJuF8nLd4lD7txi/TUqVOr1vMydktkg1tyI0G2xeCWFalVC7oSJeDg7Y2kS5dCN2VKtL019xmKCO43tsl4nBEiIi0F6AKw8sJKDNg7APff3VfL8qfMj0kVJqFk2pJaF4/I/gLpkk913759avCw4F3YmN6FiIjIesSPHx+7d+9WrcP//fdffPjwAXnz5lW9zkwhwXAnJyc8ffo0yHKZT5EiRYj1b926pQYZlRRxBoZzCmdnZ1y7dg0//PBDqKloZApOglHmCEhJcMtc26JozpVeoQIc5s+Hw4AB0hUi2t6a+wxFBPcb28PfkogswcG7B9FzV0+cenRKzaeOlxpe5bzQOEdjODrwOEUU7YH0MWPGYNCgQciSJYvqrm08GAEHJiAiIrJOxYsXV1NExYgRA/ny5cPevXtRq1atwMC4zHfu3DnE+jJg+YULF4Isk/MLaak+bdo01cqcKNzkxk/BgsCJE9LNAhg/XusSERFRGGbNmqUmSQlHROZx/eV19N3TF5uublLzcWPERf/i/dGtcDfEcomldfGI7DeQLhe3ixcvRsuWLaOmRERERBStzNXTTFKutGjRAvnz50fBggUxdepUfPz4UQ1ULpo3b45UqVKpPOfSBT579uxBXp8gQQL1N/hyou+SxhzSKl16OMiAo337Aok5eBYRkSXq1KmTmiQ9m/SMI6KIe/npJUYcGIHZp2bja8BXODk4oX2+9hhWehiSxU6mdfGIbI5zRLqsFStWDNHl4cOHasCz7du349OnT2pQ0yVLlqiLdCGD9AwdOlTlWH3z5o0q25w5c5ApU6ZoKyMREZG1MmdPs4YNG6pBP4cMGaLyrOfOnRs7duwIHIBUBjFl13eKMlWrArlzAzJ47dSpwMiRWpeIiChCpL68e/euuv6VXPrZsmULNa0ZEdkv36++mHFiBkYdHIW3vm/VsqqZqmL8T+PhmdRT6+IR2SyTA+ndu3dX3bCklVlUe/36tQqMlylTRgXS5STixo0bSJgwYeA648ePx/Tp07Fs2TKkT58egwcPRsWKFXH58mUO+EJERBTNPc0kjUtoqVzE/v37v/napUuXmqUMZKfkxs+gQUC9esD06UDPntLNQetSERGFi4wbIg3CVq1ahQcPHqgGY8bp00qUKIH27dujbt26vClNZMfk2LD28lr029MPt9/cVstyJc+FiRUmonwG08Y4IqJoCKT36tULVatWVQOAeXp6wsXFJcjzGzZsgLmMGzdO5UiVFugGEiw3PoBIQF9a0tWsWVMtW758uWr5tmnTJjRq1MhsZSEiIrJF0d3TjChK1a4NZMsGXLoEzJihT/dCRGThfvvtN9UwTBqEjRo1SqVHS5kyJWLFioVXr17h4sWL8Pb2Vj2+hg8frq6PCxQooHWxiSiaHb1/VA0kevTBUTXvHscdo8uORvNczeHk6KR18YjsgmNEKnnJo5o5c2YkTpxY5TQznsxpy5YtKoVL/fr1kSxZMuTJk0elcDG4ffu26jpeXgaY+n9ShkKFCuHoUf2BhYiIiL7f04zIJkgrzYED9Y+l9+T791qXiIjou2LHjo3//vsPa9asQbNmzVS6tbhx48LZ2VldB5ctW1alM71y5QomTpyI+/fva11kIopGt1/fRsN1DVF0cVEVRHdzccOwUsNwo8sNtMrTikF0IktukS53ytevX69apUc1OZmQ7m0yeNmAAQPUYGgSyJeubTKYmQTRhSH3qoHMG54Lja+vr5oMZJATIQOsBR9kzVTyemkpH9ntkP3gPkOm4j5jm7T6PaOzpxlRtGjQABg6FLhxA5gzB+jTR+sSERF9kwzCHV6VKlWK0rIQkeV44/MGow+OxvQT0/HF/wsc4IBWuVthZNmRSBk3pdbFI7JLJgfSEyVKpC62oyuoIC3SZSA0IS3SpVvb3LlzVSA9Micq0iUuOBkgzcfHJ9Jlfvv2rQpyMXcdhQf3GTIV9xnb9F6jlrOGnmYyHon0NDN1gFEii+PkBAwYALRqBUyaJIn7ATc3rUtFRBQunz9/Vud4bv9/3JJBRzdu3Igff/xRpX4hItvn5++HOafmYPiB4Xj1+ZVaJvnPJ/40EblS5NK6eER2zeRA+rBhw1S3MsnLZqjco4q7u7tqHWdMTiCkRbxIkSKF+vv06VO1roHM586dO8zt9u/fX7VyN26RLrnYZTDTePHiRTrAJUEI2RYDXBQe3GfIVNxnbJNWA2RHZ08zomjTtCkgjSbu3AEkLWDXrlqXiIgoXGTsrzp16qBDhw548+aNSlsqvcVevHiByZMn49dff9W6iEQUReQm2uZrm9Fndx/ceHVDLfNM6okJP01A5YyV2eCFyBoD6dOnT8etW7dU+pR06dKF6AJ+5swZsxVOBj+7du1akGXXr19H2rRpAwcelWD63r17AwPnEhQ/fvz4N08wYsaMqabgJCBljqCUHNzMtS2yD9xnyFTcZ2yPVr9ldPY0I4o2cn7avz/wyy/A+PH6vxrdrCIiMoVcT0+ZMkU9XrdunbruPnv2rLrpLYONMpBOZJtOPTqFXrt64cDdA2o+WexkGFF6BNrkbQNnR5NDd0QURUz+11irVi1E5wBoRYsWValdGjRogBMnTmD+/PlqMgSSunXrpkY2z5QpkwqsDx48WI1wHp3lJCIislbR2dOMKFpJGsCRI4EHD4AlSwAGn4jICnz69EkNNCp27dqlWqfLzfbChQurNC9EZFvuv72PAf8MwO///q7mXZ1d0aNwD/Qt3hfxYkYuYwIRWUAgXS62o0uBAgVUPjhJxTJixAgVKJ86dSqaSnfd/9enTx98/PgR7du3V13fihcvjh07dmjWRZ6IiMiaRGdPM6JoJb0PZaDR334Dxo4F2rbVt1QnIrJgGTNmxKZNm1C7dm3s3LlTNS4Tz549i3QaUiKyHO9932PsobGYfGwyfL7qx+r7OefPGF12NNLET6N18YgoDBbfP6RatWpqCou0Spcgu0xERERkGvbgIpsmwfPRo4F794AVK4DWrbUuERHRN0n6liZNmqgAerly5VCkSJHA1ul58uTRunhEFElfA75i4ZmFGLp/KJ59fKaWlUxbEpMqTEL+lPm1Lh4RmSOQLvlTJTd5kiRJkDBhwm8OcPDqlX5EYSIiIrJ80dnTjCjaxYoF9OoF9O4NjBkDNG8OOFt8OxIismP16tVTvawfP36MXLlyBS6XoLq0Uici6x1IdPvN7ei9uzcuP7+slmVKlEkNJFojSw0OJEpkJcJ1JSGDnRjytMlj/gMnIiIiIqvQoYM+tcutW8CqVcDPP2tdIiKib0qRIoWajBUsWFCz8hBR5Jx/ch69dvfCnv/2qPnEsRJjaKmh6JC/A1ycmHaOyOYC6S1ksKb/17Jly6gsDxEREUUx9jQjuxInDtCjBzBwoD7NS5MmgKOj1qUiIgrUoUMHDBo0CB4eHt9dd/Xq1fj69WuQccOszaxZs9Tk7++vdVGIotSj948w+J/BWHJuCXTQIYZTDPxW8DcMLDkQCVwTaF08IooAk/u2Ojk5qW5myZIlC7L85cuXahkrQyIiIsvGnmZkdzp3BiZMAK5eBdavB+rX17pERESBkiZNimzZsqFYsWKoXr068ufPj5QpU8LV1RWvX7/G5cuXcejQIaxatUotnz9/PqxZp06d1PTu3TvEjx9f6+IQmd3HLx8x8chEjD8yHp/8PqllDbI1gFc5L2RImEHr4hFRdAbSJa9TaHx9fREjRozIlIWIiIiiAXuakd2JFw/47TdABqcfNQqoW5et0onIYowcORKdO3fGwoULMXv2bBU4NyY3v8uXL68C6JUqVdKsnET0bf4B/lh+fjkG7RukWqOLIh5F1ECiRVLrBw4mIjsJpE+fPl39lVZrUsHHkW6y/09aoR88eBBZs2aNmlISERFRlGBPM7IbXbsCkycD//4LbNsG1KihdYmIiAIlT54cAwcOVJO0Qr937x4+f/6s0rD98MMP7D1GZOEk/3mvXb1w/ul5NZ8+QXqMKz8O9Tzr8d8vkT0G0qXrt6FF+ty5c9WFt4G0RE+XLp1aTkRERNaDPc3IbiRKpE/xIgOPjhwJVK8uLUS0LhURUQgyfolMRGT5Lj+/jN67e+PvG3+r+fgx42NwycHoXLAzYjrH1Lp4RKRVIP327dvqb5kyZbBhwwZW7ERERFaMPc3ILnXvDkybBpw6BezcCTBFAhEREUXAs4/PMHTfUCw4swD+On84OzqjY/6OGFJqCBK7Jda6eERkKTnS9+3bF6IVG7upEBERWRf2NCO7JCmMOnSQfwD6VukVK7JVOhEREYXbZ7/PmHpsKrwOeeH9l/dqWa2stVQal8yJM2tdPCKytEC6WLRokboAv3HjhprPlCkTunXrhrZt25q7fERERBQF2NOM7FavXsDs2cCRI8D+/fKPQOsSERERkYUL0AVg5YWVGLB3AO6/u6+W5XPPpwYSLZWulNbFIyJLDaQPGTIEkydPRpcuXVCkiH7U4aNHj6J79+5qQJQRI0ZERTmJiIgoChj3NDOkdblw4QLSpk3L4DrZppQpgTZt9MF0aZXOQDoRERF9w8G7B9FzV0+cenRKzaeOlxpe5bzQOEdjODo4al08IrLkQPqcOXOwYMECNG7cOHBZjRo1kDNnThVcZyCdiIjIekiPshw5cqBNmzYqiF6yZEl1g9zNzQ3btm1D6dKltS4ikfn17QssWCB3koDDh4FixbQuERGR8vnzZ5V2TephcffuXWzcuBGenp6oUKGC1sUjsivXX15H3z19senqJjUfN0Zc9C/eH90Kd0Msl1haF4+INGDyrTM/Pz/kz58/xPJ8+fLh69ev5ioXERERRYO1a9ciV65c6vHWrVtx584dXL16VfU0GzhwoNbFI4oaadIALVroH48apXVpiIgC1axZE8uXL1eP37x5g0KFCmHSpElquTRqIyLz8A/wx/47+7Hx5kb1V+YNXn56ia7buyLb7GwqiC6tzjvk64AbXW6gf4n+DKIT2TGTA+nNmjULtQKfP38+mjZtaq5yERERUTR4+fIlUqRIoR7//fffqF+/PjJnzozWrVurFC9ENqt/f0AG2d2xAzh5UuvSEBEpZ86cQYkSJdTjdevWIXny5KpVugTXp0+frnXxiGzChisbkG5aOpRbUQ4d93ZUf2V+9cXVmHRkEjLOyIjpJ6bja8BXVMlUBRd+vYA51eYgeZzkWhediKx1sNFdu3ahcOHCav748eMqP3rz5s3Ro0ePwPUklzoRERFZLrlAv3z5Mtzd3bFjx47Am+WfPn2CkwQZiWxVhgxAkybAihX6VumbN2tdIiIiVf/GjRtXPZZr7jp16sDR0VFde0tAnYgiH0Svt6YedNAFWf7g3QM0Wt8ocD5n8pxqINHyGcprUEoisplA+sWLF5E3b171+NatW+pvkiRJ1CTPGTg4OJiznERERBQFWrVqhQYNGqhAutTd5cuXD7xJnjVrVq2LRxS1BgwAfv8d2LIFOH8e+P80R0REWsmYMSM2bdqE2rVrY+fOnSrVmnj27BnixYundfGIrJqkb+m6o2uIILoxSeMyv9p8tMzdEk6ObFRCRJEMpO+TQZmIiIjIJgwbNgzZs2fH/fv3VVqXmDFjquXSGr1fv35aF48oasnNogYNgNWrgdGjgTVrtC4REdm5IUOGoEmTJiqAXrZsWRQpUiSwdXqePHm0Lh6RVfO+561ann9LgC4APyT6gUF0IjJfaheDBw/0ByAPD4/IbIaIiIg0VK9ePfXXx8cncFkLw0CMRLZOBtWVQPq6dcCVK8CPP2pdIiKy8zq5ePHiePz4ceBg4KJcuXKqlToRRdzj94/Nuh4R2R+TBxsNCAjAiBEjED9+fKRNm1ZNCRIkwMiRI9VzREREZD38/f1VHZ4qVSrEiRMH//33n1o+ePBgNSYKkc3LkQOoVQvQ6fSt0omINCaDgEvr84cPH6oeY6JgwYJMuUYUSe5x3c26HhHZH5MD6QMHDsTMmTMxduxYnD17Vk1jxozBjBkz1EU3ERERWY/Ro0dj6dKlGD9+PGLEiBG4XNK9LFy4UNOyEUWbQYP0f//8E7h5U+vSEJEd+/r1q7quloZr6dKlU5M8HjRoEPz8/LQuHpFVK5GmBJLFThbm8w5wQOp4qdV6RERmSe2ybNkydWFdo0aNwGU5c+ZULdk6duyoLsiJiIjIOixfvhzz589XXcY7dOgQuFy6k1+9elXTshFFm3z5gMqVge3bAS8vgL0xiEgjXbp0wYYNG9QNbkN+9KNHj6oxTV6+fIk5c+ZoXUQiq/X+y3uENc6oBNHF1EpTmR+diMwXSH/16lWoXcpkmTxHRERE1kO6jWfMmDHEcknXxpZvZFekZ6UE0pcv1z9Ol07rEhGRHVq5ciVWrVqFynJzz6jhWurUqdG4cWMG0okiSKfTodXmVnj26RmSuSWDs5MzHr1/FPi8RzwPFUSv82MdTctJRDaW2kVaqElql+BkmfFgKERERGT5PD094e3tHWL5unXrVH5WIrshLT/LlZO8CsD48VqXhojsVMyYMVU6l+DSp08fJAWbJZD87aVLl1bnEhLsX7t2rdZFIgrTlGNTsOnqJsRwioG/mv6Fe93uYW+zvZhdbrb6e7vrbQbRicj8LdKli1nVqlWxZ8+eIF3NpBL9+++/Td0cERERaWjIkCFo0aKFapkurdClO/m1a9dUypdt27ZpXTyi6CUt0ffu1ad2GTgQSJVK6xIRkZ3p3LmzGgR8yZIlKqgufH19VQpVec6SODs7Y+rUqcidOzeePHmCfPnyoUqVKogdO7bWRSMK4sj9I+i7p696PKXiFORPmV89Lp2uNDzdPJEsWTI4OprczpSI7JDJR4pSpUrh+vXrqF27Nt68eaOmOnXqqIvuEiU4IAMREZE1qVmzJrZu3apukMuFrwTWr1y5opb99NNPWhePKHqVLAkULw58+QJMmKB1aYjIDp09e1bdyPbw8ED58uXVJI+lXj5//ry69jZMWnN3d1dBdJEiRQokSZKE6V7J4rz49AIN1zXE14CvaJS9EX7N/6vWRSIiKxahW24pU6ZUd8TXr1+vplGjRqllREREZH3kRvju3bvx7NkzfPr0CYcOHUKFChUitK1Zs2apLumurq4oVKgQTpw4Eea60vo9f/78SJAggQriy8X4ihUrIvFJiCLJwUHfKl3Mnw88fap1iYjIzkidWLduXVSrVk3lRZdJHkvgPH78+EGm7zl48CCqV6+urtUdHBywadOmSNXb33L69Gn4+/ur8hJZigBdAJptbIYH7x4gc+LMmF9tvvq3QEQUbaldiIiIiEKzevVq9OjRA3PnzlUX49Ldu2LFiqrXmnSZDS5RokQYOHCgGrBc8r5KC7xWrVqpdeV1RJqQnhgFCwISTJo8GRg3TusSEZEdkZQu5vLx40c1jlnr1q1DbcEennpbbnJ/lbEjgtm1a1dgYzpphd68eXMsWLDAbGUnMgcvby/suLkDrs6uWFd/HeLGjKt1kYjIyjnoZOhiO/fu3Tt1R//t27eIFy9epLYl+WWlRR9zbFF4cZ8hU3GfsU3mrIu0IhfhBQoUCByUXPZVaZnWpUsX9OvXL1zbyJs3rxqLRfLDhgfrcIoSW7cCNWoAkuf37l0gceJQV+M+QxHB/cY2WXo9Lq1wN27ciFq1apm13pb87ZIKrl27dmjWrNl315XJ+DuT93v9+rVZ6vDnz58jadKk/HdFyr47+1Dh9wqqVfrC6gvRKnerEOtwvyFTcZ+xTVIfJUyYMFx1OFukExERUaR9+fJFdevu379/4DI5uZTcrjIo+ffIff1//vlHtYIbxxbApLVq1aQZJnDuHDB1KhDOGztERJH18uVLNV7Jvn371A0XCdoYM1cO8sjW24a6u2XLlihbtux3g+jCy8sLw4cPD7FcglI+Pj6IDPmeJAAiZWJwi559eobG6xqrIHrDzA1RNWVV9e8pOO43ZCruM7bp/fv34V6XgXQiIiKKtBcvXqjcqMmTJw+yXOavXr0a5uvkRDRVqlSqhZqTkxNmz579zUFOQ2vNZjipDR5sMJW8Xk6KI7sdshEDBsCxQQPopk+Hrnt3SVwcYhXuMxQR3G9sk7l+TwlI37x5E23atFF1aFTlc45ovW3s8OHDKj1Mzpw5A/Ovy1gnOXLkCHV9CdpLKpngLdKlZac5WqTLd8VWoiSDijb+vTGef36O7EmzY2GdhXBzcQt1Xe43ZCruM7ZJxgkJLwbSiYiI7JSfn5/KTy65yX/88UdNyhA3blycO3cOHz58wN69e9UFdoYMGVC6dOlQ12drNoo2xYohcebMcLl+HR/GjcNHCaYHw32GIoL7jW0ypTXbt3h7e6tBvyW3uaUrXry4STcQYsaMqabg5N+BOf4tSHDLXNsi6zVi/wjsv7sfcWLEwboG6xAnZpxvrs/9hkzFfcb2mPJbmhxIf/r0KXr16qUudqVrTPAU63JXm4iIiCyfi4tLpIPPBkmSJFEtyuU8wZjMp0iR4psnLRkzZgwc0OzKlSsqWB5WIJ2t2ShaDR4szUMRZ+FCxB4wQO78BHma+wxFBPcb22RKa7ZvkRvcnz9/RlSLaL1NZMm239iO0d6j1eMF1RcgS5IsWheJiGyMyYF0yYF27949DB48GO7u7lHW1YyIiIiiXqdOnVRO8oULF8LZOeId1WLEiIF8+fKpG+2GgcwkWCTznTt3Dvd25DXGqVuCY2s2ilaNGwMjRsDhxg04zJ8P9O4dYhXuMxQR3G9sj7l+S0lxJgN9Sp707Nmzq5vexsw1kKm56u2ImDVrlprYCI/M6f7b+2i2UZ+rv2P+jmiUvZHWRSIiG2TyFbN0M5PuZtJqjIiIiKzbyZMn1UXzrl27VE7T2LFjB3l+w4YN4d6WtBRv0aIF8ufPj4IFC2Lq1Kn4+PEjWrVqpZ5v3ry5yocuLc6F/JV1f/jhBxU8//vvv1Vu1Tlz5pj5UxJFkJOTypUO2YcnTpQ7T4Bb6HlWiYjMIUGCBKq3lQzgaUx6gssNGFOCz5I2TfKtG9y+fVulU0uUKBHSpEnz3Xo7Km/iyySfM378+FH6XmQf/Pz90HBdQ7z8/BL53PNhcsXJWheJiGyUyYF06T4dPJ0LERERWe8Fe926dc2yrYYNG6pc5dKK7smTJ+qm+44dOwIHMpMebcYt9uRivWPHjnjw4AFixYqlurP//vvvajtEFqNpU0Dy8t+5AyxYAHTtqnWJiMiGNW3aVLVCX7lyZaQHGz116hTKlCkTOG9IjSbB86VLl3633iayFv329MPRB0cRP2Z8rKm/BjGdQ/ZeJCIyBwediVFxabE2adIkzJs3D+nSpYMtMNwJl0F/zJFfVXLHJ0uWjF01KVy4z5CpuM/YJnPWRfaEdThFi3nzgA4dgJQpgf/+kxxDajH3GYoI7je2yVz1kZubG86ePYssWWw/tzPrcDKHjVc2os6aOvrHDTeiVlZ9qqLw4H5DpuI+Y5tMqY9M/tXlrvX+/ftVN+y4ceOqbmHGExERERGRTWnZEkiVCnj0CFiyROvSEJENkzQr9+/f17oYRFbhv9f/odVmfSqinkV6mhREJyKKltQukjeNiIiIbEP69Om/2W38P2l9S2TvpAV6nz76tC5jxwJt2gDBBgAkIjKHLl26oGvXrujdu7cauyT4YKM5c+aEteNgo2QOPl99UH9tfbz1fYsiHkXgVU4/Bg8RkUUF0iWfGhEREdmGbt26BZn38/NTXcolR6pcxBPR/2vXDhgzBrh7F1ixAmjdWusSEZENMowT0troGCM3vCMy2Kil4mCjZA49dvbAmcdnkDhWYqyutxouTrzBTUQWGEgXUnlv2rQJV65cUfPZsmVDjRo14OTkZO7yERERURSSVm+hkZZiMkgZEf2/WLGAXr0AucHk5QU0bw4wNyYRmdnt27e1LgKRxfvzwp+Yc2oOHOCA3+v8jtTxU2tdJCKyEyYH0m/evIkqVarg4cOHgQOgeHl5IXXq1Pjrr79U7nQiIiKybpUrV0b//v2xhPmgif5HBhyV1C43bwKrVwONG2tdIiKyMWnTptW6CEQW7eqLq2i3tZ16PLDEQFTKWEnrIhGRHTG5Gc1vv/2mguUyAMqZM2fUdO/ePZVjVZ4jIiIi67du3ToOIk4UXJw4QPfu+sejRwMBAVqXiIhs0IoVK1CsWDGkTJkSdyWd1P+PVbZ582ati0akqU9+n1BvTT189PuIMunKYFjpYVoXiYjsjMkt0g8cOIBjx44FubhOnDgxxo4dqyp7IiIish558uQJMtio5GB98uQJnj9/jtmzZ2taNiKL1LkzMHEiICkOR46Ea4oUgPTSLFUKYJpDIoqkOXPmYMiQIWoMk9GjRwfmRE+QIIEKptesWRPWjoONUkR1+rsTLj2/hBRxUmBl3ZVwcmS9S0QWHkiPGTMm3r9/H2L5hw8fECNGDHOVi4iIiKJBrVq1gsw7OjoiadKkKF26NLJmzapZuYgslgyM99NPwNq1cBwxAgkMyz08gGnTgDp1tC0fEVm1GTNmYMGCBap+lsZqBvnz50cvGafBBnCwUYqIJWeXYOm5pXB0cMSfdf9UwXQiIosPpFerVg3t27fHokWLULBgQbXs+PHj6NChgxpwNCrJiYTka5WB0eRuvPDx8UHPnj2xatUq+Pr6omLFiqoFXfLkyaO0LERERLZg6NChWheByLps2CC5j0Iuf/gQqFdP/xyD6UQUicFGpbdYaA3aPn78qEmZiLT279N/0fHvjurxyDIjUTpdaa2LRER2yuQc6dOnT1c50osUKQJXV1c1SUqXjBkzYpq0wokiJ0+exLx585AzZ84gy7t3746tW7di7dq1Ku3Mo0ePUIcXL0REROF269YtDBo0CI0bN8azZ8/Usu3bt+PSpUtaF43Iskgagq5dJQdSyOcMy7p1069HRBQBMvbYuXPnQizfsWMHfvzxR03KRKSld77vVF50n68+amDRfsX7aV0kIrJjJgfSJTebDHJy7do1NRCZTPJ448aNUdYtS9LGNG3aVHVxS5gwYeDyt2/fqpbxkydPRtmyZZEvXz4sWbIER44cUXnciYiI6NvkJnSOHDlU77INGzaoOlecP3+erdWJgvP2Bh48CPt5Cabfv69fj4jIBCNGjMCnT5/Qo0cPlfZk9erVatySEydOqFzp0jO7T58+WheTKFrJv4H2W9vjxqsb8IjngRW1V6jULkREVpPaxSBTpkxqig5yIlG1alWUL18eo0aNClx++vRp+Pn5qeUGks81TZo0OHr0KAoXLhzq9iQFjEwGkptNBAQEqCky5PVysI/sdsh+cJ8hU3GfsU1a/Z79+vVTdatcuMeNGzdwudygnjlzpiZlIrJYjx+bdz0iov83fPhwlS61bdu2iBUrluopJoH1Jk2aIGXKlKr3d6NGjbQuJlG0mnNqDlZfWg1nR2esqbcGSdySaF0kIrJz4Qqky8X1yJEjETt2bPX4W6R1uDlJ7vMzZ86o1C7BPXnyRA1wKq3kjUl+dHkuLF5eXupEJbjnz5+rnOuRDYRIS3kJcsmAbUTfw32GTMV9xjaFNpB3dLhw4QJWrlwZYnmyZMnw4sULTcpEZLHc3c27HhHR/5PzOgPpjS2TBNKlp5jUybZk1qxZavJnGiz6hlOPTqH7zu7q8fjy41EkdRGti0REFL5A+tmzZ1XLb8Pj6HL//n01sOju3btVLnZzkW5xxjcEpEV66tSpkTRpUsSLFy/SAS4HBwe1LQa4KDy4z5CpuM/YJnPWc6aQm9GPHz9WOVmNSX2fKlUqTcpEZLFKlAA8PPQDi4aWJ104OOjTuxARmUjO74y5ubmpydZIj3OZ5Do8qtLDknV7/fk16q+tjy/+X1Aray10K9xN6yIREYU/kL5v375QH0c1Sd0ig57lzZs3cJnctT548KDqbr5z5058+fIFb968CdIq/enTp0iRIkWY25URz2UKTgJS5ghKyQmQubZF9oH7DJmK+4zt0eq3lG7iffv2VYN2y34lN2oOHz6MXr16oXnz5pqUichiOTkB06YB9erpA+bGwXTDvEzyb+fQIWDqVCBWLC1LTERWJHPmzCGC6cG9evUq2spDpFXvjJabW+LOmzvIkDADltRc8t1/F0REFpsjvXXr1io/m3EeVfHx40d06dIFixcvNlvhypUrp7qcG2vVqpXKgy4X/dKK3MXFBXv37kXdunXV8zLw6b1791CkCLv9EBERfc+YMWNUqzCpU+Vmtaenp/orOVklPysRBVOnDrBuHdC1a9CBR6WluqQ4lHPXkSOB+fOB48eBtWtlcCEtS0xEVkLSj7KFNtm7SUcnYcu1LYjhFANr669FAtegqXyJiKwqkL5s2TKMHTs2RCD98+fPWL58uVkD6fIe2bNnD7JM8rQnTpw4cHmbNm1UmpZEiRKptCwSzJcgelgDjRIREdH/yFgjCxYswODBg3Hx4kWVizVPnjzRNqA4kdUG02vWRMCBA3h37RriZckCx1Kl9C3WpbV68eKS5Bg4fx7Ilw9YuBBo0EDrUhORhZNeYraWD53IFIfvHUa/Pf3U42mVpiGv+/+yExARWVUgXfKXSRcbmWRANONcrtJy7e+//9ak0p8yZYrqDi8t0n19fVGxYkXMnj072stBRERkzdKkSaMmIgonCZqXLg0fT0/Ek3Ng4/RMP/0EnDsnUTHA2xto2BA4eBCYNElyDGpZaiKyUExdQfbu+cfnaLiuIfx1/micvTF+yfeL1kUiIop4IF1ykEvlLpPkbgtOlktXtKi2f//+IPMS0DeM+k1ERETfZzzg9vdMllQVRGS6lCmBf/4BhgwBvLwAOVc9dgxYswbIkEHr0hGRhZEGa/bCcP0uDfKIRIAuAD9v/BkP3z9E1iRZMb/6fN5cIiLrDqTLIKNSuZctWxbr169XqVSMu4WnTZsWKeWCgYiIiCza2bNnw7UeL2CIIsnZWQYi0Kd6adYMOH0ayJsXWLIEqF1b69IRkQWRwb7thYzNIpP0emdOeBKjD47Grlu7EMs5lsqLHidGHK2LREQUuUB6Kcn7COD27duq6zcvromIiKyT3BwnomhUpYo+1YukeDl6VJ9jvVs3YNw4aZGidemIiIg0s/e/vRi6f6h6PKfqHGRPFnScPCIiS2KUzDF8/vnnH6xbty7E8rVr16qBSImIiIiIKJjUqYEDB4CePfXzU6cCJUsCd+9qXTIiIiJNPH7/GE02NIEOOrTO3RotcrfQukhEROZpkW7g5eWFefPmhVguA422b98eLVrwwEdERGRNTp06hTVr1uDevXv48uVLkOc2bNigWbmIbI6LCzBxoj6ALufMx48DefIAy5cD1appXToiIqJo8zXgKxqvb4xnH58hZ/KcmFllptZFIiIyf4t0uchOnz59iOWSI12eIyIiIuuxatUqFC1aFFeuXMHGjRvh5+eHS5cuqR5ozFtKFEVq1JDBCoACBYDXr4Hq1YE+fQA/P61LRkREFC2G7BuCA3cPqHzokhc9lkssrYtERGT+QLq0PP/3339DLD9//jwSJ05s6uaIiIhIQ2PGjMGUKVOwdetWNXj4tGnTcPXqVTRo0ECNiUJEUSRdOsDbG+jSRT8/YQJQpgzw4IHWJSMiIopSf9/4G16HvNTjhdUXInPizFoXiYgoagLpjRs3xm+//aYGKvP391eTtFrr2rUrGjVqZOrmiIiISEO3bt1C1apV1WMJpH/8+FENKN69e3fMnz9f6+IR2baYMYHp02WwISBePODwYX2qlx07tC4ZERFRlLj39h6abWymHncq0AkNszfUukhERFEXSB85ciQKFSqEcuXKIVasWGqqUKECypYtq1q1ERERkfVImDAh3r9/rx6nSpUKFy9eVI/fvHmDT58+aVw6IjtRrx5w+jSQOzfw4gVQuTIwaBDw9avWJSMiIjKbL/5f0GBtA7z6/Ar5U+bHpAqTtC4SEVHUBtKltdrq1atVt+8//vhDDUImrdkWL16sniMiIiLrUbJkSezevVs9rl+/vuph1q5dO9UDTW6aE1E0yZgROHoU6NBBPz96NFC+PPD4sdYlIyIyq1mzZsHT0xMFZJwIsit9d/fF8YfHkcA1AdbUW4OYzjG1LhIRkUmcEUGZM2dWExEREVkfaXmePXt2zJw5Ez4+PmrZwIED4eLigiNHjqBu3boYJC1iiSj6uLoCc+bIHS6gfXvgwAF9K/U//wTKltW6dEREZtGpUyc1vXv3jgOb25ENVzZg6vGp6vGyWsuQPmF6rYtERBQ9gfQHDx5gy5YtuHfvHr58+RLkucmTJ0dkk0RERBSNcubMqVqCtW3bNnCME0dHR/Tr10/rohFR48ZA3rzSTQS4cEHfMn3YMLnbBTg5aV06IiIik9x6dQutNrdSj3sX7Y0aWWpoXSQiouhJ7bJ3715kyZIFc+bMwaRJk9Sgo0uWLFGpXc6dOxexUhAREVG0OnDgALJly4aePXvC3d0dLVq0gLe3t9bFIiKDLFmAY8eANm0AnQ4YOhSoVAl49kzrkhEREYWbz1cf1F9bH+9836FY6mIYXXa01kUiIoq+QHr//v3Rq1cvXLhwAa6urli/fj3u37+PUqVKqdyqREREZPlKlCihboI/fvwYM2bMwJ07d1RdLmnbxo0bhydPnmhdRCJycwMWLgSWLdM/3rNHn+rl4EGtS0ZERBQu3XZ0w9knZ5HELQlW1VsFFycXrYtERBR9gfQrV66gefPm6rGzszM+f/6MOHHiYMSIEerCm4iIiKxH7Nix0apVK9VC/fr16+qmuAwCliZNGtSowW63RBZBzr1PngR+/FE/+GiZMoCXFxAQoHXJiIiIAvkH+GP/nf3488Kf6u+K8ysw7/Q8OMABf9T5Ax7xPLQuIhFR9OZIlwtuQ1506Qp+69Yt1TVcvHjxInKlISIiIs1kzJgRAwYMQNq0aVUPtL/++kvrIhGRgaenPpj+66/AihXAgAGApGNavhxIkkTr0hERkZ2TwUS77uiKB+8eBC6TALoYXHIwKvxQQcPSERFp1CK9cOHCOHTokHpcpUoVlVt19OjRaN26tXqOiIiIrM/BgwfRsmVLpEiRAr1790adOnVw+PBhrYtFRMZix9aneZF0L66uwPbtQJ48wJEjWpeMiIjsPIheb029IEF0oYNO/c2RLIdGJSMi0jiQPnnyZBQqVEg9Hj58OMqVK4fVq1cjXbp0WLRokZmLR0RERFHl0aNHGDNmjMqLXrp0ady8eRPTp09XyxcsWBChG+SSFkbOCWQcFTlfOHHiRJjryntIrvaECROqqXz58t9cn4ikeZ+DfgDS48eBzJmBBw+AUqWAiRP1g5ISERFFczoXaYluCJoHJ63Se+zqodYjIrK7QHqGDBmQM2fOwDQvc+fOxb///qsGHZWu4ERERGT5KleurOptGWi0du3aagwU6XEm+dKlfo8IubHeo0cPDB06FGfOnEGuXLlQsWJFPHv2LNT19+/fj8aNG2Pfvn04evQoUqdOjQoVKuDhw4eR/HREdkDOx0+dAho1Ar5+BXr3BmrVAl6/1rpkRERkR7zveYdoiW5MAuz3391X6xER2V0gnYiIiKyfi4sL1q1bhwcPHqjBwrNkyRLpbUqvtXbt2qlgvKenp7rZ7ubmhsWLF4e6/h9//IGOHTsid+7cyJo1KxYuXIiAgADs3bs30mUhsgtx4wIrVwJz5gAxYgBbtuhTvbBnBxERRZPH7x+bdT0iIkvGQDoREZEd2rJlC2rWrAknJyezbE8GIj99+rRKz2Lg6Oio5qW1eXh8+vQJfn5+SJQokVnKRGQ3qV46dADk31mGDMDdu0Dx4sD06Uz1QkQWSdLAyQ33AgUKaF0UMgP3uO5mXY+IyJI5a10AIiIisn4vXryAv78/kidPHmS5zF+9ejVc2+jbty9SpkwZJBgfnK+vr5oM3r17p/5KS3aZIkNer9PpIr0dsh8Wtc/kzq1SvTi0bQuHDRuArl2hO3AAOhmYNH58rUtHlrrfkNnw9wy/Tp06qUnq8Pg8Plm97EmzI6ZTTPj6/+/8LHiOdI94HiiRpkS0l42IyNwYSCciIiLNjR07FqtWrVJ502Wg0rB4eXmpwc6De/78OXx8fCIdBHn79q0KcElreiKr3GdmzoRb3ryIO3y4Cqj7nz6NN/Pn4+v/j3FE2rPI/YYi7f3791oXgSja3Xx1E9VWVvtmEF1MrTQVTo7m6QVJRGRVgXS5SA3rAvfx48dwd2d3HSIiInuTJEkSlSbm6dOnQZbLfIoUKb752okTJ6pA+p49ewIHNA9L//791YCmBtKaTQYpTZo0KeLFixfp4JaDg4PaFoNbZNX7TP/+0JUrpwYidb57F4mrV4du8mR9ChhJBUOastj9hiLlWzeBiWyR911v1F5dGy8/v0TqeKnRrXA3TDk2JcjAo9ISXYLodX6so2lZiYg0C6TnzZsXK1euVAODGVu/fj06dOigWoQRERGRfYkRIwby5cunBgqtVauWWmYYOLRz585hvm78+PEYPXo0du7cifz583/3fWLGjKmm4CQYZY6AlAS3zLUtsg8Wu88ULgycPQu0bAmHLVvgIP8Ovb2BBQv0g5SSpix2v6EI429J9mTF+RVos6UN/AL8UCBlAWxutFnlQO9aqCu873mrgUVlXtK5sCU6EdkSk2v70qVLo3Dhwhg3bpya//jxI1q2bIlmzZphwIABUVFGIiIisgLSUnzBggVYtmwZrly5gl9//VWdJ7Rq1Uo937x5c9Wi3EDOJQYPHozFixcjXbp0ePLkiZo+fPig4acgsiEJEwKbNkm3D8DZGVi9GpAbVv/+q3XJiIjICgXoAjD4n8Fovqm5CqLX/bEu9rfcHziQqATNS6crjcY5Gqu/DKITEey9Rfrs2bNRtWpVtG3bFtu2bVPpXOLEiYMTJ04ge/bsUVNKIiIisngNGzZUPdOGDBmiAuLSe23Hjh2BA5Deu3cvSIu9OXPm4MuXL6hXr16Q7QwdOhTDhg2L9vIT2SRJ5dKzJ1CkiPwjBa5fBwoVAmbMANq0YaoXIiIKl89+n9FqcyusvrRazfcr1g+jy42GowN7YxCR/YjQYKOVK1dGnTp11AWws7Mztm7dyiA6ERERqTQuYaVykYFEjd25cyeaSkVEKFpUn+qleXNg+3agXTvg4EG5owXEjq116YiIyII9/fAUtVbXwrEHx+Di6IJ51eahVR59j0MiInti8q3DW7duoUiRIqo1uuQz7dOnD2rUqKH++vn5RU0piYiIiIgocpIkAbZtA8aMkYTOwIoVQMGCwOXLWpeMiIgs1KVnl1BoYSEVRE/omhC7mu1iEJ2I7JbJgXTppp0+fXqcP38eP/30E0aNGoV9+/Zhw4YNKCgn4kREREREZJkkgC5jFezbB7i764PoBQoAy5drXTIiIrIwO2/uRNHFRXH37V1kTJQRx9oeU7nPiYjslWNEcqSvWrUKCRIkCFxWtGhRnD17Fnnz5jV3+YiIiIiIyNxKlgTOnQPKlwc+fQJatADatgU+f9a6ZEREZAHmnJyDqiur4p3vO5RMWxLH2hxD5sSZtS4WEZF1BdKbNWsW6vK4ceNi0aJF5igTERERERFFtWTJgB07gOHD9YOOyrm8DER67ZrWJSMiIo34B/ij245u6Ph3R/jr/NEiVwvs+nkXErsl1rpoRETWN9jo8m90+3RwcAgz0E5ERERERBbGyQkYMgQoVgxo0gS4cAHInx+YPx9o3Fjr0hERUTR67/seTTY0wbbr29T86LKj0b94fxXrISKiCATSu3btGmReBhj99OkTYsSIATc3NwbSiYiIiIisTbly+lQvEkzfv1//9+BBYMoUwNVV69IREVEUu//2Pqr/WR3nn56Hq7MrltVahgbZGmhdLCIi607t8vr16yDThw8fcO3aNRQvXhx//vln1JSSiIiIiIiilgw+uns3MGiQPtXL3LkyGBJw86bWJSMioih0+tFpFFpYSAXRk8dOjv0t9jOITkRkjkB6aDJlyoSxY8eGaK1ORERERERWxNkZGDkS2L4dSJIEOHsWyJcPWL9e65IRkY2YNWsWPD09UaBAAa2LQgA2XtmIEktK4PGHx8ieLDuOtz2OQh6FtC4WEZHtBtKFs7MzHj16ZK7NERERERGRVipW1AfRixcH3r0D6tUDfvsN8PXVumREZOU6deqEy5cv4+TJk1oXxa7pdDpMODwBddfUxeevn1EpYyUcbn0YaROk1bpoRES2kyN9y5YtIQ6+jx8/xsyZM1FMBikiIiIiIiLr5+EB/POPPtXL+PHAjBnAsWPA6tVA+vRal46IiCLoi/8XdPyrIxadXaTmOxXohKmVpsLZ0eQQERGRXTH5KFmrVq0g8zJ6c9KkSVG2bFlMmjTJnGUjIiIiIiItubgA48YBJUoAzZsD0oI0b15g6VKgZk2tS0dERCZ6/fm1aoW+784+ODo4YmrFqehSqIvWxSIiss1AekBAQNSUhIiIiIiILFO1asC5c0DDhvpW6dK4pkcPYOxYfbCdiIgs3s1XN1FtZTVce3kNcWLEwaq6q1A1c1Wti0VEZH850omIiIiIyIalSQMcOAB0766fnzwZKFUKuH9f65IREdF3eN/1RuGFhVUQ3SOeBw61OsQgOhGRiSKUAOvBgwcqV/q9e/fw5cuXIM9NlhNqIiIiIiKyPTFi6APoJUsCLVsCR48CuXMDK1YAVapoXToiIgrF7//+jjZb2qjc6PlT5seWRlvgHtdd62IREdl+IH3v3r2oUaMGMmTIgKtXryJ79uy4c+eOGnQ0r+RLJCIiIiIi2yapXc6cARo0AE6fBqpWBfr1A0aOBJw5WB0RkSWQOM3Q/UMx8uBINV/3x7pYXns53FzctC4aEZF9pHbp378/evXqhQsXLsDV1RXr16/H/fv3UapUKdSvXz9qSklERERERJYlQwbg8GGgc2f9vORLL1sWePhQ65IREdk9n68+aLKhSWAQvV+xflhTfw2D6ERE0RlIv3LlCpo3b64eOzs74/Pnz4gTJw5GjBiBcePGwZy8vLxQoEABxI0bF8mSJUOtWrVw7dq1IOv4+PigU6dOSJw4sSpH3bp18fTpU7OWg4iIiIiIQhEzJjBjBrBmDRA3LuDtDeTJA+zerXXJiIjs1tMPT1FmWRmsurgKzo7OWFxjMbzKe8HRgcPkERFFhslH0dixYwfmRXd3d8etW7cCn3vx4gXM6cCBAypIfuzYMezevRt+fn6oUKECPn78GLhO9+7dsXXrVqxdu1at/+jRI9SpU8es5SAiIiIiom+QnqmS4kXypT9/DlSsCAwdCvj7a10yIiK7cunZJRRaWAjHHhxDQteE2PXzLrTK00rrYhER2YRwJzCUFuc9e/ZE4cKFcejQIfz444+oUqWKWiZpXjZs2KCeM6cdO3YEmV+6dKlqmX769GmULFkSb9++xaJFi7By5UqUlW6kAJYsWaLKJsF3c5eHiIiIiIjCkCmTfvDRbt2AefPkAgI4dAj44w8gRQqtS0dEZPN23tyJBusa4J3vO/yQ8Af81eQvZEmSRetiERHZX4v04cOHq5bgkydPRqFChQKXlStXDqtXr0a6dOlUUDsqSeBcJEqUSP2VgLq0Ui9fvnzgOlmzZkWaNGlwVE7iiYiIiIgo+ri6AnPnAr//Ll1ZgX/+0ad62bdP65IREdm0OSfnoOrKqiqIXiJNCRxre4xBdCIirVqky2jPIoMMKmSU5mWunChHg4CAAHTr1g3FihVD9uzZ1bInT54gRowYSJAgQZB1kydPrp4Li6+vr5oM3r17F/geMkW2nPJdRXY7ZD+4z5CpuM/YJv6eRGRTmjYF8uUD6tUDLl0CpOHL8OHAgAGAI3P0EhGZi3+AP3rt6oWpx6eq+ea5mmN+tfmI6RxT66IREdlvIF04ODhAK5Ir/eLFiyqtjDkGMZXW9ME9f/5cDV4a2UCItJyXIJcjLxIoHLjPkKm4z9im9+/fa10EIiLzypoVOHEC6NxZ8i8CgwfrByOV1upJk2pdOiIiq/fhywc0Xt8Y265vU/Ojy45G/+L9NY3dEBHZMpMC6ZkzZ/7uAfnVq1cwt86dO2Pbtm04ePAgPDw8ApenSJFCDXz65s2bIK3Snz59qp4LS//+/dGjR48gLdJTp06NpEmTIl68eJEOcMl3JNtigIvCg/sMmYr7jG1ylXQIRES2xs0NWLwYKFkS6NgR2LVLn+pl1SqgeHGtS0dEZLUevHuA6n9Wx7kn5+Dq7IpltZahQbYGWheLiMimmRRIl1bc8ePHR3SR1pZdunTBxo0bsX//fqRPnz7I8/ny5YOLiwv27t2LunXrqmXXrl3DvXv3UKRIkTC3GzNmTDUFJwEpcwSlJMBlrm2RfeA+Q6biPmN7+FsSkU1r2RLInx+oXx+4ehUoXRoYPRro3du+Ur34+wMHDsD12jUgSxagVCnAyUnrUhGRlTn96LQKoj/+8BjJYifDlkZbUMhDP5YdERFZSCC9UaNGSJYsGaIzncvKlSuxefNmxI0bNzDvuQTzY8WKpf62adNGtS6XAUilNbkE3iWIXrhw4WgrJxERERERfYeMc3TyJNChA/DHH0C/fvpUL8uWAYkTw+Zt2AB07QrHBw8Q2JdWettOmwbUqaNt2YjIamy8shE/b/wZn/w+IVvSbNjWZBvSJUindbGIiOxCuJt/aJFja86cOSoPcOnSpeHu7h44rV69OnCdKVOmoFq1aqpFesmSJVVKlw1ykkpERERERJYlThxgxQpg/nzpJgr89Zc+1cuxY7Bpcn0iA68+eBB0+cOH+uW8fiGicPTYn3B4AuquqauC6BV/qIjDrQ8ziE5EZImBdDloRzd5z9CmltI11Cin7KxZs1Ru9o8fP6og+rfyoxMRERERkYakgU67dvrgecaMwP37QIkS0kJGLgBgk+lcunYN/bMZlnXrpl+PiCgUfv5+aL+1Pfrs6QMddOiYv6NqiR7fNfpS7xIRkQmBdBncLjrTuhARERERkQ3LnRs4fRpo0AD4+hXo0UOf4uT1a9iUTZtCtkQPHkyXmwmS5obIirx58wb58+dH7ty5kT17dixYsEDrItmk159fo9IflbDw7EI4OjhiWqVpmFllJpwdTcrUS0REZsAjLxERERERaSNePGDVKv2gm92764PO584Ba9fqBye1Rl++AEeOADt26Kfz58P3usePo7pkRGYl45gdPHgQbm5uqne4BNPr1KmDxPYw5kE0ufXqFqqurIprL68hTow4WFV3Fapmrqp1sYiI7BYD6UREREREpG2ql44dgUKFgPr1gdu3gWLFgEmTgE6d9M9bOinzzp36wPnevcCHD6ZvQwZdzZcPyJw5KkpIZHZOTk4qiC58fX0DU7GSeRy6dwi1VtXCy88v4RHPA9sab0OuFLm0LhYRkV0Ld2oXIiIiIiKiKCNB5DNngNq19a26u3QBGjYE3r6Fxfn8WR80l9zmWbMCGTIAv/4KbN6sD6JLSszmzYGVK4EnTwAPj+/fEJBAvGyrUSPg33+j65OQDZPW4tWrV0fKlCnh4OCATdLjIxgZbyxdunRq7LFChQrhxIkTJqd3yZUrFzw8PNC7d28kSZLEjJ/Afv3+7+8ot7ycCqLnT5kfJ9qeYBCdiMgCMJBORERERESWIUECYP16/cCjzs7/S/Ei6V60JK1sr14Fpk4FKlUCEiUCKlcGpk0Drl2TprlAyZLAmDH6mwGSpkVamDduDCRPrl9PBA+my7xMY8cCNWro32f1aiBXLqBWLeDkSU0+LtkGSbciQW4Jlodm9erV6NGjB4YOHYozZ86odStWrIhnz54FrmPIfx58evTokXo+QYIEOH/+PG7fvo2VK1fi6dOn0fb5bJG06B+ybwiabWyGL/5fUOfHOjjQ8gDc47prXTQiImJqFyIiIiIisigSWJaW3kWK6AcivXkTKFxYH4xu3z76Ur28e6dP0yItz6W1+N27QZ9PnVofTJfAetmyQPz4YW9LBlFdtw7o2jXowKPSUl2C8/K8kHzqEoyXGwjSul2mChWAgQP1gXoiE1SuXFlNYZk8eTLatWuHVq1aqfm5c+fir7/+wuLFi9GvXz+17Fw4b2IlT55cBeK9vb1Rr169UNeR9C8yGbyTf2MAAgIC1BQZ8noJQkd2O1ry+eqD1ltaY/Wl1Wq+T9E+GF12tBpg1Jo/lyWzhf2Gohf3Gdtkyu/JQDoREREREVkeyZl+9izQogWwbRvQoYPkqgDmzQPixDH/+8lFlASyDYOEyoChX7/+7/mYMfWDokrgXCZJw2JKUF+C5TVrIuDAAby7dg3xsmSBo2xPWrMbSEt0aZE+fLi+lfrvvwO7dumnEiWAQYOAn36yjrzxZNG+fPmC06dPo3///oHLHB0dUb58eRw9ejRc25DW55IjXQYdffv2rUol86ukOAqDl5cXhsu+Hczz58/h4+ODyAZBpAwS4JLPYW1efH6BVjtb4dTTU3B2dMb4EuPROGtjvHj+Quui2TRr328o+nGfsU3v378P97oMpBMRERERkWWSFCrSKlsGHpWAn+QcP31a32I7R47Ib//FC2D37v+1Og+elkIG/jQEziXo/f8DK0aYBM1Ll4aPpyfiSR71sC7CJUi/dCkwdCgwfjyweDHg7Q1UrKhPdSMB9erVw3490Xe8ePEC/v7+qiW5MZm/KmmMwuHu3bto37594CCjXbp0QY5v/LuUoL2kkjFukZ46dWokTZoU8eLFi3RwS/LAy7asLbh16dkl1NhSA3fe3EEC1wRYV38dyqQro3Wx7II17zekDe4ztknGCQkvBtKJiIjIbCQP64QJE/DkyRPVxXvGjBkoWLBgqOteunQJQ4YMUS3i5GJ8ypQp6CbpHIiIjMmFau/eQNGi+sFHJSe5tFaXvM+SksLfXx9klrzk7u76ltvGrbyNyboymKKh1bnkIJe85AaxYwPlyukD5xK0lkFEtZQ+PTBnjj5wLjcT5s4FTp3S50/Pnl2f8qV+/bA/L1EUkvo9vKlfRMyYMdUUnASjzBGQkuCWubYVXXbd2oX6a+vjne87/JDwB/zV5C9kSZJF62LZFWvcb0hb3Gdsjym/JX91IiIiMovwDFpm7NOnT8iQIQPGjh2LFClSRHt5icjKFCumT/UiAe7Pn4HWrfW5ydOmBcqUAZo00f9Nlw7YsOF/r5NBEZcs0QfhkybVB+RHjNAH1CWInjMn0KcP8M8/wKtX+hbwkp5C6yC6sVSpJKG1Pk/7gAFA3LjAxYv6wUx//FH/+fz8tC4lWZEkSZLAyckpxOCgMs86OXrMPTUXVf6oooLoJdKUwLG2xxhEJyKycAykExERkVkYD1rm6empBi2T3KkyaFloChQooFqvN2rUKNQWakREIUgg/O+/gdGj9XnC9+0DHj4Muo7M160L1K6tzzkuQWgJuq9ZA7x+DSRMqB/EVI5Nsq7kRR83Th+EjxEDFv/55bNLQF1uBkjqmxs39J8vUyZ96/VI5pom+xAjRgzky5cPe2VAXaOUBTJfRAb6jeLea3KeIOcB9sg/wB89dvbAr3/9Cn+dP5rnao7dzXYjiVsSrYtGRETfwdQuREREZBGDloWHr6+vmozzqxou/k0ZbT008nrJ8RrZ7ZD94D6jod694TB1qoxSiBDDbhpStWzapJ+VgLsE7CpWhE5as8tjZ6PLoGj+/cyy38SPr0/r0rWrGnzVYdIkOEhwvWNH6EaOhK5nT6B9e32qGooWlngc+PDhA27evBk4f/v2bZWKJVGiREiTJo3qRdaiRQvkz59fpWmZOnUqPn78qG6IR6VOnTqpSerw+LIv25EPXz6gyfom2Hp9q5ofVWYUBpQYoFJFEBGR5WMgnYiIiCxi0LLw8PLywvDhw0Msf/78OXwi2QpTgiBv375VAS7mPKTw4D6jnRhHjiDR8+ffXe9Dt2742LYtdIkT/2+hpG+xpf2mWTOgXj24rVqF2DNnwunRIzj06oWA0aPxsX17fGrdGrpIDuRI3/f+/XtYmlOnTqGM9LT4f4aBPiV4vnTpUjRs2FDVnzJeiYxtkjt3buzYsSNEXU7m8eDdA1T/szrOPTmHmE4xsbz2cjTI1kDrYhERkQkYSCciIiKrIS3eDYEAIa3ZUqdOjaRJkyJeJANFEtySFmGyLQZFKTy4z2hIcqSHg1v+/HCTHOL2sN/07Qt0746AFSvgMH48HG/eRNxx4xBHBijt1Ak6ab2ehKkjooqrqyssTenSpdUNm2/p3LmzmihqnX50WgXRH394jGSxk2Fzo80o7FFY62IREZGJGEgnIiIiqxm0THKph5ZPXYJR5ghISXDLXNsi+8B9RiOS9zwcHGU9C/xtomy/kWBuu3aApOaQnPBjxsDh0iX9X0mF06ED0KsX4O5u3vclHgNMzJEuk/Rkswebrm5C0w1N8cnvE7IlzYZtTbYhXYJ0WheLiIgigLU9ERERWfWgZURkh0qUADw89AOOhkaWp06tX88eSQ74Jk2Af/8FNmwA8uUDPn2SUaGB9OlVC3U1YCmRBiQ/+uXLl3Hy5EnYMukNMPHIRNRZXUcF0Sv+UBGHWx9mEJ2IyIoxkE5EZEWk4c7+/cDGja7qr5005LHo3+LPP/V/+Vvoc68uWLAAy5Ytw5UrV/Drr78GGbSsefPmQQYjlQFKZdAzmeTxw4cP1WPjgdGIiELl5ARMm6Z/HDyYbpiXFtiynj2TVtK1awMSsNy+HShWTEZtBmbPBjJmBFq3Bq5f17qURDbHz98P7be2R+/dvaGDDh3zd1Qt0eO72tfgqkREtoaBdCIiKyENytKlA8qVc0THjgnUX5mX5aTNbyHjd0mDP/nL3wJq0LKJEyeqQctkwDIJihsPWnbv3j08fvw4cP1Hjx4hT548apLl8lp53LZtWw0/BRFZjTp1gHXrQqZ5kZbqslyep//dXKhUCfD21t/9LV8e+PoVWLIEkBzyjRsDFy5oXUoim/D682tU/qMyFp5dCEcHR0yrNA0zq8yEsyMz6xIRWTsH3fdGH7EDMlBZ/Pjx8fbtW7MMVPbs2TMkS5aMefIoXLjPUHhIgLZePekiGnqjO8YLrP+3MGddZE9Yh5OWuM9YCOkSJAFiuVEnub8lnYsFt0S3mP3m+HFg9Ghg69b/LatZExg4EChQQLtyWSnW46azxTr81qtbqPZnNVx9cRWxXWJjVb1VqJa5mmblIevYb8h6cJ+xTabUR/zViYisID7QtWvIwK0wLOvWjalFogN/CyIiCyRB89Kl9a2q5a8FB9EtSqFCwJYtwLlzQIMG+jvCmzcDBQv+r/U6URSQgUY9PT1RwMZu2By6dwiFFhZSQXSPeB4qHzqD6EREtoV9i4iILJxcxz54EPbzEsC9f1/fMztu3Ogsmf15/z58v4X8ZhLLISIisni5cgGrVwPDhwNeXsAffwA7d+qnkiX1LdR/+insgV2JIjDYqEyGFoC24Pd/f0ebLW3wxf8L8rnnw9bGW+Ee113rYhERkZkxkE5EZOGMUkp/040bUV0SMvdvRkREZDGyZgWWLQOGDQPGjdPnTz94UD9Jy+FBg4Bq1fQDmBKRIplyh+0fhhEHR6j52llrY0XtFYgdI7bWRSMioijAQDoRkYVLlix8640dC+TMGdWlsW///gv06/f99SRFLxERkVVKnx6YOxcYPBiYOBGYNw84eVKfPz1HDn0LdRkshCl0yM75fPVB682t8efFP9V8n6J94FXeSw0wSkREtomBdCIiCyZpS/v0+fY60tPawwPo1YvXtFGtQgVg5kzg4cPQ86T/X3t3At5Ulfdx/NcWWgTZlF3QuoKVTdnEEWGEV2XcAEFEBxRRR6yOjrs+vDKujDogCCiKy6CvCrIqqDiIgD4OqIALioAiKIpQylYoQqH0ff73Ttp0SZq0SbN9P89zm9ybk+Q0Ocm5+d9z/8fzXtg8dwAAxLRjjpGeekq67z5p7Fi3A1y1SrriCumUU9ztV10lVa8e6ZoCVS4rN0t9pvbR0l+WqlpyNU26cJKGnTEs0tUCAIQZh0oBIAr9/rv7+7RjR2nlSqlmTXd7yfSknnX7fUsQPfzsNR43zr3OewEASJhT4x57TPrpJzeP+lFHSevWSUOHSiefLD37rLR/f6RrCVSZ1dtWO5OKWhC9Xo16+vef/00QHQASBIF0IILy86XFi6XZs2s4l7YOLFrkpmixVC3WJgYMkNavl2bOdAeHebPRzzNmSP36Raq2icdea3vNeS8AAAmlfn3pgQekjRulJ56QGjd2g+s33SSdcII0ZoyUmxvpWiIGTJw4URkZGepkufdjzIL1C9T1xa7auGujTqx/opYNW6Y/Hv/HSFcLAFBFCKQDETJrlpSeLvXsmaybbqrnXNq6bUdi2rlTuv566dxzpR9+kJo1k+bMkd58U2rSxA3Q2m/XhQsP65lndjmXGzYQuI0Ez3thBz1ef9295L0AACSE2rWlu+5yO77x490jyTbL9h13uDu3Nnp99+5I1xJRLDMzU6tXr9bnlns/hkxaPkm9X+utnAM56nZsNy27bplaNmgZ6WoBAKoQgXQgAixYbnM0/fJL8e2Wd9m2E0xPLJZr20abZ2RIL7zgbhs+XFq92p3Xy5ulDOnRQ+rbd79zSQqRyPG8F4MGuZe8FwCAhHLEEdLNN7unzdkOzIknStnZ7mSkxx3nTlZq60CMyz+cr9vfv13D3xmu/IJ8DW47WAsGL1CDmg0iXTUAQBUjkA5UMUvVceutZU9U6Nl2222keUkUdvDERjHbAZQtW6SWLaWPPpKeeUaqWzfStQMAAChHaqo0bJi0Zo302mvuyAAbkf7II+4IdZsN3UasAzFob95e9Z3WV08te8pZf/iPD2tKnylKq5YW6aoBACKAQDpQxT7+uPRI9JLB9E2b3HKIX4cPS5Mmub81LX1LtWruwK0vv5S6dYt07QAAAIJkOzNXXimtWuWeanfGGW7O9NGjpeOPd0ev//xzpGsJBOyXnF/U7eVumrturtJS0jT1sqkacc4IJZWccR4AkDAIpANVbPPmwMrZvE02Mv3ll6WVK6UDB8JdM1SVtWvdVCCWviUnR+rSxX2PH3pIqlEj0rUDAACohORk93S75culd9+VzjrL3ZGdONFN/2Kj17//PtK1BPxasXmFurzQRV9u+VKNajXS4msWa2DrgZGuFgAgwqpFugJAotizR3rlFenxxwMr/9137uJh+ZdbtZLat5fatStaGjcOW5URYnl50pNPugFzu16rljsfV2Ym+bUBAECcsVG7vXtLF1wgLVnipnpZuFB66SXpX/+SBg6U7r9fat060jUFipmzZo6umnWV9h3cp9ManqZ5V85Ter30SFcLABAFCKQDYWYDbmwAjo0st9HHnt8VZeVI99zWqJEbYLUzY7/6yk33sXOn9O237mLpJz0skO4dWLfF8mxXr141/x8C8+mn0nXXSd98467b78pnn3Xn4gIAAIhbtnNrp+LZsmyZ9Oij0rx50htvuEufPu4EpR07RrqmqCITJ050lvwomxSqoKBAY5aO0V0L7lKBCnTeiefpzf5vqm4NJi4CALgIpANhyn/9739LTz8tvfde0XYLcFt6yHr1pCFD3G3eAXVPuj2baNLOiPWwMpZX3YLq3osF6bdudZ/LFu85n047zQ2qe49gr18/7P86Sti7Vxoxwm0L9j42aCCNGycNGlT0fgMAACSEM8+U5s51R4nYqJEZM9zJYmw5/3x3p+nssyNdS4RZZmams+Tk5Khu3egIUh/MP6jMdzM1eeVkZ314x+F6uvfTqpZMyAQAUIReIYTsgLqdtbh2bQ0nYNq9O+kaEo2NOLczVSdMKEr9aMHSP/1JuuUW6X/+x00baWrWlG69tfjEo82bS2PHFg+iex6jRQt3ueiiou02f5ONcPYOrn/9tZtG5osv3MWb3b/k6PWTTiqqE0Jr/nzpL38pmldr8GBpzBg3mA4AAJCwbKTHm2+6eQz/8Q/3dMv333cX+xFlI9R79WLUAarEzt93asD0AVq4YaGSlKSnzn9Kf+3yVyYVBQCUQiA9RGbN8gRFLSJZrzAoaiNPSwZFEZ+TR1rw3ILoNgLZ1KkjXXutm//agtUlWbu49FI7+HJYa9fmqGXLOurePTmogy+WY9smqrTFezT8xo1FKWE8AXbbtmmTu9jZtB4W0G/TpnhwvW1bqXbtyrwiiW3bNulvfytKwZOeLj33nHTeeZGuGQAAQBQ59VRpyhRp5Eh3IiHLhWgjk2zp3NkdoW6jSAhoIkzW71ivi964SGuy16hW9Vp647I3dHHLiyNdLQBAlCKQHqIgev/+pXNe//qru93OWCSYHn8sYG1pWyxlh3daFfs9YKPPbfTxkUf6fwwLmlu6yIyM/WrUqE5IRobbY5xwgrv07Vu0ffdud7S69+h1y8G+b5+bv9sWbyeeWHr0uuXz5neMb/YdYMHz226Ttm933wu7bpOL2kEPAAAAlMF2XG3Uwf/+r/TPf0rPPy999pl0ySXuCA8boX7ZZZzui5D65OdP1GdaH2Xvy1bzOs01d9BctW/SPtLVAgBEMQLpIUjnYiPRy5o40rZZ0NECaTbymP2++LBrlztYxiYQXb/e3Wbv88UXuwH0nj2jM9hs6Qe7dXMX7/ZrKWhK5l63g0D2v9liB4q8H8N+y3gH11u3lo44IiL/UlSxEf833uiekWzsdXrhBalTp0jXDAAAIEZ48hzef7/01FPuDreNBBk40J1s6L77pCuvlKpXj3RNEeNe+/o1Xfv2tcrLz1OHph309qC31ax2s0hXCwAQ5QikV9LHHxfPcV1WMN1SaVgw0oLpNgkkYtPq1W76lldecXOTG5s0dNgw6aab3IE0scYO7rRq5S72+8QjO7t0cN3+fxvVbm3eFg8bdW2/a0qOXm/aNDoPKISaHYwYP94dKGWj+9PS3LOT77yT33gAAAAV0qiRNGqUdPfd7o6WBdctl+I110h//7t0zz3u9Ro1Il1TxJiCggI9uORBZzF9W/XVq31fVa1UTh8FAJSPQHol/fZbYOUuv9y9POooqUkTqXHj4pcltzVsKFXj3YmKIOk777jpWxYuLNp+2mnSX/8qXXVVfKbssMkwbWS9LR55edKaNaUD7JYP3OaJsmXq1OKPUTK4bmlv4ulgkg2Quu466fPP3XWbG8vORD7llEjXDAAAIA7Ury898IA7+cyzz0qjR7unAQ4fLj38sDty4YYb4nOHHCG3/9B+XfvWtXrjmzec9bvPulujeo1SclII8msCABICodpKslG3gbBRu5ZTe8cOd7HRvf7YSF4LRJYVdC8ZfD/6aNLGhNrOndKLL0rPPCNt2FD0HtpZBZa+xfKaJ8Joa28WALd0JbZY/nfPGRdbtpSe2NQGDNmodjv44H0AwkZoWzDdgurt2xcF2K2tx5L9+6VHHnHnxDp0yE158+ST7tkJochzDwAAAC+1a7uj021H3HLnPfGEe1rw7bdLjz3mXtoporZThqg3ceJEZ8m3UUtVJCs3S32n9dV/Nv1H1ZKradKFkzTsjGFV9vwAgPiQVGDnNiW4nJwc1a1bV7t371adOnWCuq/1/enpbk7psl5JC7Zaqj/LNW1pMbZudQOPvi5tsRG+FnQPlAXRbQS7v6C759JGxCdaADgY33zjnj36f//npukw9prZqGPbN7fJNkPt8OHDysrKUqNGjZQcJ1HY33+Xvv229Oh1+wyUpVmz0qPXbVR3NB4gWrLEHfi0bp27bvNeWZsJ9KBaKMRjm0Hl+qJEFsrXjc8WgkWbQUXQbkLATpW0fIuW/uXHH91tFkS3U0ZtAisbaVTF6Mejtw9fvW21Lnz9Qm3ctVH1atTTzMtn6tzjz61k7REP+D5GsGgz8SmY/ogR6ZVkgb5x46T+/d0AtXcw3ROwtpR+NhLXRt3aYmlBygvO22je8oLudmnlrLwnCF8eq4elHAwk6G77ookQdLcRxXPnusHQRYuKttvIa9sXHzRIqlkzkjWMPTb5aMeO7uJhn42ffy4dXP/hB2nzZnd5772i8pby0iYyLRlgj9RAIzsIYAOhLHWLscC5zX/Vt29k6gMAAJCw7FRJG+liedKnTZMefdTNM2jpXsaMcVO/3HGH+6MGCW3B+gXqP72/cg7k6MT6J2relfPUqkGrSFcLABCjCKSHQL9+0owZ7uAH74lHPZPO2+3BBuctmG2LBXPLCwLbCHZPIN1f0N1Syhw86I6et6U8Nmmipx7+8rnb5ZFHRlfQ3Q4u2ISYlsPeAp7dupUe3bx9u3tmqKVvsQCvsTIWGLWzRu0+0fQ/xTp7LW1Evy2XXFK0fc8eadWq4sF1W7cJXZcvdxdvdgZIyeD68cdXPqWKvzYze7aUmVk0J4KNSLe0LjbZLAAAACLEJpWySYts5IvtsFlA/YsvpH/+0x0lY8F2Gwlx7LEV+8GAmJB/OF9LNi7R2s1r1XJfS3VP766U5BQ9t/w5Zb6bqfyCfJ197NmaPXC2GtSMsZySAICoEjeBdMux9uSTT2rLli1q166dxo8fr86dO1fZ81uw3PJnL1lyWGvX5qhlyzrq3j057Ptitu9o+32BpJWwMyCzskqnkikr6G6jbw8ccAPMniBzeSOQA8nnbku45wKaNavsgxp25oC9Txaotf3q115zc10bO/vTgqM2eKVFi/DWD6VTXp51lrt4WGojS4dUcvS6tUWbX8qWt94qKm8Hcuygk3dwvU2bwNuarzYzcqQ7St5uN5ZuZvJk6ZxzQvXfAwAAoNJsRIXl27Odfdt5s8lsli51Tx987jlpyBDp3nulk08O7AcDYsas72bp1vm36pecoveyee3mOr3p6Zq7bq6z/ue2f9YLF7+gtGppEawpACAexEWO9GnTpmnIkCGaNGmSunTporFjx2r69Olau3atk7eoPORXLc0CzIHkc7fre/cG99gW9AwktYxdWnqPYNg+saXZKdmqPWl3MjKKT/R6+unu6PMrrnAPBkRCvLSZqpoE9uuvi09uarnY7aBPSfaen3RS6YlN7TeS95kGvtpMyQNW99wjjRgRfJsMB9pMfCK3asXQhyOSaDOoCNpNFbAdu8WL3YD6hx+62+y1tp3+Tp3cyUnL+sFg7FTjCgTT6cdV5a+ZBdH7v9lfBfK9I/9Qj4c04pwRSuJUY5SB72MEizYTn4Lpj+IikG7B806dOmnChAmFDbtFixa65ZZbdK+NPCgHP8Irx1JwBJLP3S5tEspgWD7sQILudrzERv9b2g/vgSVlsbdlwAA3gG6joCO9T5WIbSaULL3R2rWlR6/7mjOgfv3io9bvv989U8NfCs5ly9yDLtGCNhOf+AFeMfThiCTaDCqCdlPFbGS6pXx5553yy9oPAxt1sWFD0Gle6MeDV5nXzNK5pI9LLzYSvaSjjzhaW+/c6qR5AcrC9zGCRZuJTwk12WheXp5WrFih++67r3CbNeZevXppqe00leHAgQPO4v2CeT4QtlSG3d+OTVT2cWKJjeS2ALYt/tghGxu97j2a3V2SSqy7t+flJTkpZmyxQGl5atcu0J495UfF33jjsDMC2VOnSB9KSsQ2E0rWd516qrvYICMPC45bQN0dwZ7kXNocVDt3JjkDlGwJhKVE2rnTvhsUNWgz8Yn3EwCAMOjaVZo3z82dfttt0kcf+S5rPww2bXJzp/foUZW1RJA+/vljv0F0s/337U65Hum8lwCA0Ij5QHp2drby8/PV2IYme7H1NWvWlHmfUaNG6cEHHyy1fdu2bdrvSZpdiUCIHcGwIBdHp3yPMrelZUv/+7A5OUnKykrWtm22pDiXRet2PUXZ2e71Q4eSAgqim+3bc5SVVbn3OZRoM+HjGXk+eLC7bsfP1q2rptWrq+vbb6tpyZJUrVtXvdzHsXkPMjJoMwivPTbzLgAACA87vfDGG/0H0j08M8wjav2257eQlgMAICEC6RVho9dvt7x4XiPSLRVMw4YNQ3JauOVfs8ciwFU5dmzEMx+QP4cPF2jnzgLNnSsNG1b+a24TwTZqFD2nW9JmqpZNJtuzp3vdRqV7rvtDm0FVqBENCfgBAIhnTZuGthwipmntpiEtBwBAQgTSGzRooJSUFG21fCBebL2JJc8uQ1pamrOUZAGpUASlLMAVqsdC+exlbthQuvpqaeRI6ddfy07X4kl52L27vTeKKrSZyOje3W0TtBlEA95LAADCrFu3wHb+rByiWrdju6l5neb6NefXMicbTVKSc7uVAwAgVGL+V3tqaqo6dOighQsXFhutaetdLR8eEobNBzRunHu95ASinvWxY4OeNwhxjDYDAACQQNj5iwoTJ05URkaGOnXqVOHHsAlEx10wrjBo7s2zPvaCsUw0CgAIqZgPpBtL0zJ58mRNmTJF3333nYYPH67c3FwNHTo00lVDFevXT5oxQzrmmOLbbWCJbbfbAW+0GQAAgATCzl/EZWZmavXq1fr8888r9Tj9Tu2nGZfP0DF1ir+XNhLdttvtAACEUsyndjEDBw50Jgp94IEHtGXLFrVv317z588vNQEpEoPt+156qfTxx+48QZbi0M7OZGAJfKHNAAAAJBB2/uKGBcsvbXmplmxcorWb16pls5bqnt6dkegAgLCIixHp5uabb9ZPP/2kAwcO6NNPP1WXLl0iXSVEkO0D9+ghDRrkXrJPjPLQZoDQna6dnp7uTJ5qffFnn33mt/z06dPVqlUrp3ybNm307rvvVlldAQAJjJ2/uGFB8x7pPdT3pL7OJUF0AEC4xE0gHQAARNa0adOcdGsjR47UypUr1a5dO51//vnKysoqs/x//vMfDRo0SMOGDdMXX3yhPn36OMs333xT5XUHAAAAACDuU7sAAIDIGzNmjK6//vrCOUomTZqkd955Ry+99JLuvffeUuXHjRunCy64QHfddZez/vDDD2vBggWaMGGCc99g5OblKiWv9Ag0G5VWo1qNYuV8Kij9mL4kJyXriOpHFK7vO7hPBQUlHuC/kpKSVLN6zQqV/f3g7zpccNhnPWql1qpQ2f2H9iv/cH5Iylp9rd7mwKEDOnT4UEjK2utrr7PJy8/TwfyDISlr7cEzWjGYslbOynuzCe7t/bS2ckTqEaqWXM1nWW9p1dIKy9prYK+FL6kpqaqeUj3osvae2Xvni5Wz8sGWtTZmbS0UZe01sNfC2GfCXstQlA3mcx9M2ZKf+4p+R3i3m+TkZL4j4ug7AgAAxDcC6QAAoNLy8vK0YsUK3XfffYXbLEDUq1cvLV26tMz72HYbwe7NRrDPmTPH5/NYCjdbPHJycpzLZqObSUWxsEK9T+qteYPmFa43+mcjnwG4c449R1MvmOoEuUz6uHRl78sus2zHph316XWfFq5nTMzQT7t/KrNsRoMMrRq+qnC90/OdtDp7dZllj6t7nH78649FdXr5HC3/bXmZZRvUbKCtd2wt+l9f660lPy3xGZzac++ewvV+0/rpvR/eky/5/1sUFPvzrD9r5nczfZbNuSenMKh2w9wb9MrXr/gsu+X2LWpYq6Fz/W/v/03PLn/WZ9n1t6xXer105/r9C+/X6KWjfZb9+i9f67RGpznXH/3oUT300UM+yy4btkydmnVyro9dOlb3LLzHZ9mFgxc6aQLMc8uf0y3zb/FZ9u0r3taFJ1/oXH/161c17O1hPstOvWyqBmQMcK7PXD1TV8y8wmfZFy95Ude0u8a5/t737+mSqZf4LDv+gvG6qdNNznXLF9zz1Z4+yz7e83HdedadzvXlm5frzBfP9Fn2gXMe0MjuI53r32Z9q7bPtfVZ9o6ud+iJXk841zfu2qgTx5/os+zwjsM1ofcE5/q23G1qMqaJz7JD2g7Ry5e+7Fy3AHSdx+v4LHvZqZfpzf5vFq4fOepIn2WD+Y7oflx3fTjkw8J1viNcfEe43xEvffGSz3IAACA+EEgHAACVlp2drfz8/FITfdv6mjVryryPTRBeVnnb7suoUaP04IMPBhXg904t42uUpzl48KB27drllLGDAJ6AepllDx0s9rj2v/tyKP9QsbK27os9jndZex5frH7eZe1/9cX+p0DLGu+y3gcuymITvudWd0fm7t+/33/Z7G0qyHXfg9/3+R6pbLZv366aee7I2325vkcfmx07dihLbp1zc/2cdSBp546dyqrmlt27d6/fstYePK/Fnj1FQcay7N61u6hsjv+yObtzCsvadX/ssTxl7Tn8lt1TVNbq7o/9756y9pr4Y6+pp6y91v7Ye+Upu33Pdr9lrQ14ymb/XnZA2sPalqesv9HonjbrK6VUZb4jSpblO8LFd8R/y+7xXxYAAMS+pAJ/e4sJwkaz1a1bV7t371adOr5HtwTCs8PaqFEj50c4UB7aDIJFm4lPoeyLImHz5s065phjnLznXbt2Ldx+9913a8mSJc5E4CWlpqZqypQpTp50j2eeecYJlG/dWjSKsrwR6S1atNAvW38p83ULNrXL3l171bBhQ+ezRWqXwMomemoXO4jUoEEDUrtUoGwip3bxtBtSu8TPd8T2ndvVqEGjmO3HI4Hf4Yg02g2CRZuJT8H0R4xIBwAAlWYBoZSUlFIBcFtv0qTsdA22PZjyJi0tzVlKql2jtrOUx18Z2zHOTXJzFtsSyON5HJl2ZFjK1kqrFZayNVNrhqWsBZPDUbZGcg3VqF4jomXTktOUVj2tVJv5PfV3p614/5gqq6wvqcmpSq2WGvKyVp/q1aqHvqySVTuldsjLmrCVrRH5st6fe1/tpqyy5eE7Ioq+IwL8zAMAgNhFIN3rFE5PntXKsB1jO622Ro0aHJ1CQGgzCBZtJj55+qBYPVHMRpd36NBBCxcuVJ8+fQrbqq3ffPPNZd7HRq7b7bfddlvhNpts1HtEe3nowxFJtBlUBO0mPsV6Px4J9OGINNoNgkWbiU/B9OEE0r1yXtqp4QAARLpPstPKYpFNHHr11VerY8eO6ty5s8aOHevkoh06dKhz+5AhQ5z0L5bn3Nx6663q3r27Ro8erQsvvFBTp07V8uXL9fzzzwf8nPThAIBoEsv9eFWjDwcAxFofTiBdUrNmzbRp0ybVrl27MCef6dSpkz7//PMy7+PrNk+uVnu8aM+N5+//i7bnqOjjBHO/QMqWV6Yit8dSm4mldhMtbSaQcsF+19BmwvccFXmcULUZO/ptHbf1SbFq4MCBzqRyDzzwgDNhaPv27TV//vzCCUV//vnnYiM3zjrrLL3++usaMWKE7r//fp188smaM2eOWrduHdY+3NftfLbC8/h8H0cPvo8j32Zird3Ee5sJ9n7x3o9XNV99uOH7ODqeI9Kfq2DK8X0cPc8RLe2G+E3stJtOMdSHE0j/b17I5s2bl9puuV59fTD83Wbstmj/UJX3P0TTc1T0cYK5XyBlyytTmdtjoc3EUruJljYTSLmKftfQZkL/HBV5nFC2mXgYwWZpXHylclm8eHGpbQMGDHCWquzDy7udz1ZoH5/v4+jB93H0tJlYaTfx3maCvV8i9ONVyVcfbvg+jo7niIbPVaDl+D6OnueIlnZD/CZ22k1KDPXhJPTxIzMzs0K3xYqq+B9C9RwVfZxg7hdI2fLKVPb2WBAr7SZa2kwg5fiuiZ7nqMjjhKPNoPL4Po6ex+f7OHrwfRx8WdpMfLeZYO8XD+9prOCzFR3PEU2fK76PY6PNVOZxiN8kbrvJjJI2E4ikAmZDCSk7zcOOYuzevTsmjk4h8mgzCBZtBggPPlsIFm0GFUG7AUKPzxUqgnaDYNFmwIj0EEtLS9PIkSOdSyAQtBkEizYDhAefLQSLNoOKoN0AocfnChVBu0GwaDNgRDoAAAAAAAAAAH4wIh0AAAAAAAAAAD8IpAMAAAAAAAAA4AeBdAAAAAAAAAAA/CCQDgAAAAAAAACAHwTSq1Dfvn1Vv3599e/fP9JVQYzYtGmTevTooYyMDLVt21bTp0+PdJUQ5Xbt2qWOHTuqffv2at26tSZPnhzpKgFxg34cwaAPR7Dow4HwoQ9HMOjDURH044khqaCgoCDSlUgUixcv1p49ezRlyhTNmDEj0tVBDPjtt9+0detW54t4y5Yt6tChg9atW6datWpFumqIUvn5+Tpw4IBq1qyp3NxcpwNfvny5jj766EhXDYh59OMIBn04gkUfDoQPfTiCQR+OiqAfTwyMSK9CdkSzdu3aka4GYkjTpk2dzts0adJEDRo00I4dOyJdLUSxlJQUp+M21onbsVKOlwKhQT+OYNCHI1j04UD40IcjGPThqAj68cRAID1AH330kS6++GI1a9ZMSUlJmjNnTqkyEydOVHp6umrUqKEuXbros88+i0hdEZ/tZsWKFc4RzhYtWlRBzRHLbcZOKWvXrp2aN2+uu+66y9nxAxId/TiCRR+OYNGHA+FBH45g0YejIujHEQgC6QGy0zLsw2AfmrJMmzZNt99+u0aOHKmVK1c6Zc8//3xlZWVVeV0Rf+3Gjn4PGTJEzz//fBXVHLHcZurVq6evvvpKGzZs0Ouvv+6clggkOvpxBIs+HMGiDwfCgz4cwaIPR0XQjyMgliMdwbGXbfbs2cW2de7cuSAzM7NwPT8/v6BZs2YFo0aNKlZu0aJFBZdddlmV1RWx3272799f0K1bt4JXXnmlSuuL2P6u8Rg+fHjB9OnTw15XIJbQjyNY9OEIFn04EB704QgWfTgqgn4cvjAiPQTy8vKc03169epVuC05OdlZX7p0aUTrhthuN/b9fc011+jcc8/V4MGDI1hbxEqbsSPeNpGS2b17t3N6WsuWLSNWZyAW0I8jWPThCBZ9OBAe9OEIFn04KoJ+HB4E0kMgOzvbyZnVuHHjYttt3WZ49rAP2IABA/Tuu+86+ZLo2BNbIO3mk08+cU4fstxcNtmJLatWrYpQjRELbeann35St27dnNPM7PKWW25RmzZtIlRjIDbQjyNY9OEIFn04EB704QgWfTgqgn4cHtUKryHsPvjgg0hXATHm7LPP1uHDhyNdDcSQzp0768svv4x0NYC4RD+OYNCHI1j04UD40IcjGPThqAj68cTAiPQQsFl4U1JSSk0iYOtNmjSJWL0Q3Wg3CBZtBggPPlsIFm0GwaLNAOHBZwvBos2gImg38CCQHgKpqanq0KGDFi5cWLjNjl7aeteuXSNaN0Qv2g2CRZsBwoPPFoJFm0GwaDNAePDZQrBoM6gI2g08SO0SoL179+qHH34oXN+wYYNzysZRRx2lY489VrfffruuvvpqdezY0TmdY+zYscrNzdXQoUMjWm9EFu0GwaLNAOHBZwvBos0gWLQZIDz4bCFYtBlUBO0GASlAQBYtWlRgL1fJ5eqrry4sM378+IJjjz22IDU1taBz584Fy5Yti2idEXm0GwSLNgOEB58tBIs2g2DRZoDw4LOFYNFmUBG0GwQiyf4EFnIHAAAAAAAAACDxkCMdAAAAAAAAAAA/CKQDAAAAAAAAAOAHgXQAAAAAAAAAAPwgkA4AAAAAAAAAgB8E0gEAAAAAAAAA8INAOgAAAAAAAAAAfhBIBwAAAAAAAADADwLpAAAAAAAAAAD4QSAdAAAAAAAAAAA/CKQDCKv09HSNHTs20tUAAABBog8HACA20YcD4UEgHYgj11xzjfr06eNc79Gjh2677bYqe+5//etfqlevXqntn3/+uW644YYqqwcAALGIPhwAgNhEHw4kjmqRrgCA6JaXl6fU1NQK379hw4YhrQ8AAAgMfTgAALGJPhyIToxIB+L0iPiSJUs0btw4JSUlOcvGjRud27755hv17t1bRx55pBo3bqzBgwcrOzu78L52BP3mm292jqI3aNBA559/vrN9zJgxatOmjWrVqqUWLVropptu0t69e53bFi9erKFDh2r37t2Fz/f3v/+9zFPKfv75Z1166aXO89epU0eXX365tm7dWni73a99+/Z69dVXnfvWrVtXV1xxhfbs2VNYZsaMGU5djjjiCB199NHq1auXcnNzq+CVBQAgvOjDAQCITfThQPwjkA7EIeu4u3btquuvv16//fabs1inu2vXLp177rk6/fTTtXz5cs2fP9/pPK0T9TZlyhTn6Pcnn3yiSZMmOduSk5P19NNP69tvv3Vu//DDD3X33Xc7t5111llOJ20dsuf57rzzzlL1Onz4sNN579ixw9nBWLBggX788UcNHDiwWLn169drzpw5mjdvnrNY2X/84x/ObfbYgwYN0rXXXqvvvvvO2Xno16+fCgoKwviKAgBQNejDAQCITfThQPwjtQsQh+zosXXANWvWVJMmTQq3T5gwwem8H3vsscJtL730ktO5r1u3Tqeccoqz7eSTT9YTTzxR7DG987zZEepHHnlEN954o5555hnnuew57Qi49/OVtHDhQq1atUobNmxwntO88sorOu2005wcbp06dSrs6C3XW+3atZ11O1pv93300UedDvzQoUNOp33cccc5t9tRcQAA4gF9OAAAsYk+HIh/jEgHEshXX32lRYsWOadzeZZWrVoVHn326NChQ6n7fvDBB+rZs6eOOeYYp2O1TnX79u3at29fwM9vR66t4/Z03iYjI8OZHMVu895B8HTepmnTpsrKynKut2vXzqmHddoDBgzQ5MmTtXPnzgq8GgAAxA76cAAAYhN9OBA/CKQDCcRyqV188cX68ssviy3ff/+9zjnnnMJyln/Nm+V1u+iii9S2bVvNnDlTK1as0MSJEwsnQQm16tWrF1u3I+x2dNykpKQ4p6K99957Tuc/fvx4tWzZ0jm6DgBAvKIPBwAgNtGHA/GDQDoQp+w0r/z8/GLbzjjjDCe3mh1pPumkk4otJTttb9ZhWwc6evRonXnmmc6pZ5s3by73+Uo69dRTtWnTJmfxWL16tZMzzjrjQFmH/oc//EEPPvigvvjiC+e5Z8+eHfD9AQCIZvThAADEJvpwIL4RSAfilHXSn376qXMU22YDtw44MzPTmWDEJgmxXGh2Gtn777/vzPTtr/O1Dv7gwYPOUWeblMRm8vZMfuL9fHak3XKo2fOVdaqZzeptp4JdddVVWrlypT777DMNGTJE3bt3V8eOHQP6v+x/stxyNkmLzTw+a9Ysbdu2zdk5AAAgHtCHAwAQm+jDgfhGIB2IUzZbt51+ZUeYGzZs6HR2zZo1c2YAt876vPPOczpTm7zEcqPZbOC+WD60MWPG6PHHH1fr1q312muvadSoUcXK2IzhNumJzfxtz1dykhTPEey33npL9evXd05hsw79hBNO0LRp0wL+v2xG8o8++kh/+tOfnCPyI0aMcI7Q9+7dO8hXCACA6EQfDgBAbKIPB+JbUkFBQUGkKwEAAAAAAAAAQLRiRDoAAAAAAAAAAH4QSAcAAAAAAAAAwA8C6QAAAAAAAAAA+EEgHQAAAAAAAAAAPwikAwAAAAAAAADgB4F0AAAAAAAAAAD8IJAOAAAAAAAAAIAfBNIBAAAAAAAAAPCDQDoAAAAAAAAAAH4QSAcAAAAAAAAAwA8C6QAAAAAAAAAA+EEgHQAAAAAAAAAA+fb/c/1JayyX9dkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1500x400 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Exemple resolu : Analyse de convergence MCTS\n",
     "# Comment la qualite des decisions MCTS evolue-t-elle avec le nombre d'iterations ?\n",
@@ -1230,7 +1406,16 @@
   {
    "cell_type": "markdown",
    "id": "cdfd37bf",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008085,
+     "end_time": "2026-04-21T10:02:56.243224",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:56.235139",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exemple resolu : Analyse de convergence MCTS\n",
     "\n",
@@ -1239,19 +1424,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "883gmdiqt1x",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:56.262086Z",
+     "iopub.status.busy": "2026-04-21T10:02:56.261669Z",
+     "iopub.status.idle": "2026-04-21T10:02:58.823686Z",
+     "shell.execute_reply": "2026-04-21T10:02:58.818903Z"
+    },
+    "papermill": {
+     "duration": 2.580514,
+     "end_time": "2026-04-21T10:02:58.831767",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:56.251253",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nim(15) - MCTS(2000 iter): prendre 1, valeur=-0.527\n",
+      "Nim(15) - Strategie optimale: prendre 3\n",
+      "Optimal atteint: False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Tournoi MCTS(500 iter) vs Strategie optimale (50 parties):\n",
+      "  Victoires MCTS: 0/50\n",
+      "  Nulles: 0/50\n",
+      "  Victoires strategie optimale: 50/50\n"
+     ]
+    }
+   ],
    "source": [
     "# Exemple resolu : MCTS sur le jeu de Nim\n",
     "# Le jeu de Nim est un cas ideal pour MCTS : espace petit, strategie optimale connue.\n",
     "# Regles: N allumettes au depart, chaque joueur prend 1, 2 ou 3 allumettes.\n",
-    "# Le joueur qui prend la derniere allumette PERD (variante \"misere\").\n",
+    "# Le joueur qui prend la derniere allumette GAGNE (variante normale).\n",
     "# Strategie optimale: laisser un multiple de 4 a l'adversaire.\n",
     "\n",
     "class NimGame(JeuSommeNulle):\n",
-    "    \"\"\"Jeu de Nim : N allumettes, prendre 1-3, le dernier a jouer perd.\"\"\"\n",
+    "    \"\"\"Jeu de Nim : N allumettes, prendre 1-3, le dernier a jouer gagne.\"\"\"\n",
     "\n",
     "    def __init__(self, n_allumettes=15):\n",
     "        self.n_initial = n_allumettes\n",
@@ -1275,15 +1496,15 @@
     "        return etat[0] == 0\n",
     "\n",
     "    def utilite(self, etat, joueur):\n",
-    "        # etat = (0, joueur_qui_doit_jouer) -> il ne peut pas jouer -> l'autre a pris la derniere -> l'autre perd\n",
-    "        # Le joueur qui vient de jouer (pas celui dont c'est le tour) a pris la derniere allumette -> il perd\n",
+    "        # etat = (0, joueur_qui_doit_jouer) -> il ne peut pas jouer -> l'autre a pris la derniere -> l'autre GAGNE\n",
+    "        # Le joueur qui vient de jouer (pas celui dont c'est le tour) a pris la derniere allumette -> il GAGNE\n",
     "        gagnant = 'MAX' if etat[1] == 'O' else 'MIN'\n",
     "        return 1 if gagnant == joueur else -1\n",
     "\n",
     "def strategie_optimale_nim(etat):\n",
     "    \"\"\"\n",
     "    Strategie optimale : laisser un multiple de 4 a l'adversaire.\n",
-    "    Si n % 4 == 0, on est en position perdante (prendre 1 par defaut).\n",
+    "    Si n % 4 == 0, on est en position desavantageuse (prendre 1 par defaut).\n",
     "    Sinon, prendre le reste pour laisser un multiple de 4.\n",
     "    \"\"\"\n",
     "    n = etat[0]\n",
@@ -1333,7 +1554,16 @@
   {
    "cell_type": "markdown",
    "id": "f14e3762",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.069276,
+     "end_time": "2026-04-21T10:02:58.961353",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:58.892077",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exemple resolu : MCTS sur le jeu de Nim\n",
     "\n",
@@ -1346,7 +1576,22 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "lgdo4zcr7yb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:59.127447Z",
+     "iopub.status.busy": "2026-04-21T10:02:59.123002Z",
+     "iopub.status.idle": "2026-04-21T10:02:59.180888Z",
+     "shell.execute_reply": "2026-04-21T10:02:59.174432Z"
+    },
+    "papermill": {
+     "duration": 0.162513,
+     "end_time": "2026-04-21T10:02:59.192531",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.030018",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1393,7 +1638,16 @@
   {
    "cell_type": "markdown",
    "id": "1a18c0e5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010733,
+     "end_time": "2026-04-21T10:02:59.287428",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.276695",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---"
    ]
@@ -1402,13 +1656,35 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "h1i12z2bmuq",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:59.350690Z",
+     "iopub.status.busy": "2026-04-21T10:02:59.349407Z",
+     "iopub.status.idle": "2026-04-21T10:02:59.372004Z",
+     "shell.execute_reply": "2026-04-21T10:02:59.370255Z"
+    },
+    "papermill": {
+     "duration": 0.058874,
+     "end_time": "2026-04-21T10:02:59.374863",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.315989",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice charge - completez le code puis decommentez les tests.\n"
+      "Exercice charge - completez le code puis decommentez les tests."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -1452,7 +1728,16 @@
   {
    "cell_type": "markdown",
    "id": "58192bea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007199,
+     "end_time": "2026-04-21T10:02:59.395415",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.388216",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---"
    ]
@@ -1461,7 +1746,22 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "nei8ynhul4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:59.410790Z",
+     "iopub.status.busy": "2026-04-21T10:02:59.410505Z",
+     "iopub.status.idle": "2026-04-21T10:02:59.420977Z",
+     "shell.execute_reply": "2026-04-21T10:02:59.415311Z"
+    },
+    "papermill": {
+     "duration": 0.020422,
+     "end_time": "2026-04-21T10:02:59.422812",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.402390",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1498,7 +1798,16 @@
   {
    "cell_type": "markdown",
    "id": "0f84dd86",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.018614,
+     "end_time": "2026-04-21T10:02:59.450784",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.432170",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---"
    ]
@@ -1507,7 +1816,22 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "suyzx6a7qh",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:59.560631Z",
+     "iopub.status.busy": "2026-04-21T10:02:59.558894Z",
+     "iopub.status.idle": "2026-04-21T10:02:59.580960Z",
+     "shell.execute_reply": "2026-04-21T10:02:59.578558Z"
+    },
+    "papermill": {
+     "duration": 0.081658,
+     "end_time": "2026-04-21T10:02:59.584339",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.502681",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1549,7 +1873,16 @@
   {
    "cell_type": "markdown",
    "id": "5db5e6a2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012362,
+     "end_time": "2026-04-21T10:02:59.626614",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.614252",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exemple : Parametre d'exploration c\n",
     "\n",
@@ -1562,7 +1895,22 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "41im4gza0gh",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:02:59.718643Z",
+     "iopub.status.busy": "2026-04-21T10:02:59.718065Z",
+     "iopub.status.idle": "2026-04-21T10:03:11.684107Z",
+     "shell.execute_reply": "2026-04-21T10:03:11.680172Z"
+    },
+    "papermill": {
+     "duration": 12.014999,
+     "end_time": "2026-04-21T10:03:11.690410",
+     "exception": false,
+     "start_time": "2026-04-21T10:02:59.675411",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1599,27 +1947,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0.50</th>\n",
-       "      <td>0.70</td>\n",
-       "      <td>0.085052</td>\n",
-       "      <td>567.470</td>\n",
+       "      <td>0.65</td>\n",
+       "      <td>0.299557</td>\n",
+       "      <td>564.300</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1.00</th>\n",
-       "      <td>0.70</td>\n",
-       "      <td>0.083108</td>\n",
-       "      <td>458.875</td>\n",
+       "      <td>0.80</td>\n",
+       "      <td>0.350432</td>\n",
+       "      <td>462.075</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1.41</th>\n",
-       "      <td>0.75</td>\n",
-       "      <td>0.079064</td>\n",
-       "      <td>451.260</td>\n",
+       "      <td>0.55</td>\n",
+       "      <td>0.298621</td>\n",
+       "      <td>427.950</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2.00</th>\n",
-       "      <td>0.65</td>\n",
-       "      <td>0.084627</td>\n",
-       "      <td>412.280</td>\n",
+       "      <td>0.55</td>\n",
+       "      <td>0.241968</td>\n",
+       "      <td>431.070</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1628,10 +1976,10 @@
       "text/plain": [
        "      taux_victoire  temps_moyen  visites_moyennes\n",
        "c                                                 \n",
-       "0.50           0.70     0.085052           567.470\n",
-       "1.00           0.70     0.083108           458.875\n",
-       "1.41           0.75     0.079064           451.260\n",
-       "2.00           0.65     0.084627           412.280"
+       "0.50           0.65     0.299557           564.300\n",
+       "1.00           0.80     0.350432           462.075\n",
+       "1.41           0.55     0.298621           427.950\n",
+       "2.00           0.55     0.241968           431.070"
       ]
      },
      "metadata": {},
@@ -1724,6 +2072,16 @@
   {
    "cell_type": "markdown",
    "id": "d4785a8a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.039405,
+     "end_time": "2026-04-21T10:03:11.779151",
+     "exception": false,
+     "start_time": "2026-04-21T10:03:11.739746",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1752,12 +2110,37 @@
     "- Pour la methode `resultat`, les jetons tombent : trouver la premiere case vide dans la colonne en partant du bas\n",
     "- Pour `est_terminal`, verifiez les 4 directions : horizontal, vertical, et les deux diagonales\n",
     "- Le nombre de positions au Connect-4 est d'environ 4.5 trillions, MCTS est donc particulierement pertinent"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
    "id": "d66a3ffa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-21T10:03:11.924448Z",
+     "iopub.status.busy": "2026-04-21T10:03:11.923310Z",
+     "iopub.status.idle": "2026-04-21T10:03:11.936330Z",
+     "shell.execute_reply": "2026-04-21T10:03:11.935350Z"
+    },
+    "papermill": {
+     "duration": 0.088267,
+     "end_time": "2026-04-21T10:03:11.938184",
+     "exception": false,
+     "start_time": "2026-04-21T10:03:11.849917",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice charge - completez la classe ConnectFour puis decommentez les tests.\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice : MCTS sur le jeu de Connect-4\n",
     "# TODO: Implementez la classe ConnectFour et testez MCTS dessus\n",
@@ -1811,17 +2194,6 @@
     "#     print(f\"  {n_iter:5d} iter -> colonne={a}, valeur={v:.3f}, temps={t:.3f}s\")\n",
     "\n",
     "print(\"Exercice charge - completez la classe ConnectFour puis decommentez les tests.\")"
-   ],
-   "metadata": {},
-   "execution_count": 16,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exercice charge - completez la classe ConnectFour puis decommentez les tests.\n"
-     ]
-    }
    ]
   },
   {
@@ -1829,10 +2201,10 @@
    "id": "conclusion-section",
    "metadata": {
     "papermill": {
-     "duration": 0.002514,
-     "end_time": "2026-03-07T18:24:33.217714",
+     "duration": 0.013593,
+     "end_time": "2026-04-21T10:03:11.964161",
      "exception": false,
-     "start_time": "2026-03-07T18:24:33.215200",
+     "start_time": "2026-04-21T10:03:11.950568",
      "status": "completed"
     },
     "tags": []
@@ -1884,18 +2256,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.5"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.711153,
-   "end_time": "2026-03-07T18:24:33.671873",
+   "duration": 51.5343,
+   "end_time": "2026-04-21T10:03:13.074662",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb",
+   "input_path": "Search-7-MCTS-And-Beyond.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/search7-output.ipynb",
    "parameters": {},
-   "start_time": "2026-03-07T18:24:28.960720",
+   "start_time": "2026-04-21T10:02:21.540362",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

- Fix documentation mismatch in Search-7 MCTS notebook: code implements Nim NORMAL (last to play wins) but docs said MISERE (last to play loses)
- Aligned comments and docstrings in cell 27 to match the actual `utilite()` game logic
- Executed notebook to populate outputs

## Changes

Cell 27 (NimGame class):
- `PERD (variante "misere")` → `GAGNE (variante normale)` (line 3)
- `le dernier a jouer perd` → `le dernier a jouer gagne` (line 7)
- `position perdante` → `position desavantageuse` (line 39)

## MCTS Bug Confirmation

Execution confirms the MCTS backpropagation bug flagged by ai-01:
- Convergence: non-monotone, 3-10% optimal rate even at 5000 iterations
- Nim tournament: MCTS wins 0/50 games vs optimal strategy
- Root cause suspected: value accumulation in child perspective instead of parent (Kocsis-Szepesvari convention)

This backpropagation bug is a **separate issue** — ai-01 plans a follow-up PR.

## Test plan

- [x] Notebook executes fully (papermill, 41/41 cells)
- [x] All cells in LIST source format
- [x] No remaining MISERE/PERD references in non-exercise cells
- [x] Output reflects the documented NORMAL variant correctly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>