### PR TITLE
docs(qc): add README.md for 12 priority projects [READY-TO-MERGE]

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
@@ -1,0 +1,41 @@
+# EMA-Cross-Alpha
+
+**Asset class:** US Equities (Large-cap tech)
+**Cloud project ID:** 28885488
+
+## Description
+
+Framework-based EMA crossover alpha strategy on 5 major tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA).
+Uses the QuantConnect Alpha Model framework with `EMACrossAlpha` (fast=20, slow=50) and daily portfolio rebalance via `MultiStrategyPCM`.
+
+The alpha model generates insights when the fast EMA crosses the slow EMA for each stock, and the portfolio construction module allocates capital accordingly.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 28885488 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | ~1.00 |
+| Benchmark | SPY |
+| Rebalance | Daily |
+| Universe | 5 tech stocks |
+
+## Files
+
+- `main.py` - Strategy entry point (framework alpha model)
+- `alpha_models.py` - EMACrossAlpha implementation
+- `portfolio_construction.py` - MultiStrategyPCM module
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- QC Framework: Alpha Model + Portfolio Construction pattern
+- Ref: Brock et al. (1992), moving average trading rules

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/README.md
@@ -1,0 +1,40 @@
+# EMA-Cross-Index
+
+**Asset class:** US Equities (S&P 500 ETF)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Dual EMA crossover on SPY (S&P 500 index ETF). Long when EMA(20) > EMA(60), flat otherwise.
+Includes a 3-day cooldown after exit to prevent immediate re-entry on false signals.
+
+EMA 20/60 selected over 20/50 based on robustness testing (IS/OOS ratio = 1.55).
+Slow=60 captures quarterly trends and reduces whipsaws compared to the standard 50-period.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| OOS Sharpe (2010-2015) | 1.325 |
+| IS/OOS Robustness | 1.55 |
+| Beta | ~0.42 |
+| Cooldown | 3 days post-exit |
+
+## Files
+
+- `main.py` - Strategy (v2.0, EMA 20/60 with cooldown)
+- `research.ipynb` - EMA period grid search and robustness validation
+
+## References
+
+- Brock et al. (1992), "Simple Technical Trading Rules and the Stochastic Properties of Stock Returns"
+- research.ipynb: H1-H5 hypothesis testing on EMA parameters

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/README.md
@@ -1,0 +1,41 @@
+# FamaFrench
+
+**Asset class:** US Factor ETFs
+**Cloud project ID:** None (local only)
+
+## Description
+
+Factor ETF rotation strategy using risk-adjusted momentum (12m-1m return / 63d realized volatility) with skip-month.
+Universe of 5 Fama-French factor ETFs: VLUE (value), MTUM (momentum), SIZE (size), QUAL (quality), USMV (low-vol).
+
+SMA200 regime filter on SPY: in bear markets, rotates to USMV as risk-off asset.
+Dynamic top_n selection (all factors with positive score). Per-position stop-loss at -12%.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.540 |
+| CAGR | 12.1% |
+| Max Drawdown | 24.2% |
+| Net Return | +258% |
+| Rebalance | Monthly |
+
+## Files
+
+- `main.py` - Strategy (v3, risk-adjusted momentum with skip-month)
+- `research.ipynb` - Factor analysis and signal robustness tests
+
+## References
+
+- Fama & French (1993), "Common risk factors in the returns on stocks and bonds"
+- Barroso & Santa-Clara (2015), "Momentum has its moments"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/README.md
@@ -1,0 +1,42 @@
+# ForexCarry
+
+**Asset class:** G10 Currencies (FX)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Cross-sectional G10 currency momentum strategy on 4 FX pairs (EURUSD, AUDUSD, USDJPY, USDCAD).
+Uses risk-adjusted momentum (information ratio = 6m return / 21d realized vol) with skip-month (excludes last 21 days of mean-reversion noise).
+
+Long-only top-2 momentum currencies vs USD, monthly rebalance. Signal is inverted for USD/XXX pairs (USDJPY, USDCAD).
+
+**Structural limitation:** G10 FX momentum earns ~1-2% CAGR vs T-bill ~2.5% average in 2018-2026. Extended start to 2013 for better regime coverage.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2013-2026)
+
+| Metric | Value |
+|--------|-------|
+| Target Sharpe | -0.3 to -0.5 |
+| Rebalance | Monthly |
+| Universe | 4 G10 FX pairs |
+| Leverage | Standard (100% allocated) |
+
+## Files
+
+- `main.py` - Strategy (v4.0, risk-adjusted momentum with skip-month)
+- `research.ipynb` - FX momentum signal analysis (H1-H4)
+
+## References
+
+- Menkhoff et al. (2012), "Currency momentum strategies"
+- Barroso & Santa-Clara (2015), risk-adjusted momentum
+- Okunev & White (2003), skip-month momentum

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
@@ -1,0 +1,39 @@
+# ML-RandomForest
+
+**Asset class:** US Equities (Large-cap)
+**Cloud project ID:** 29434751
+
+## Description
+
+Random Forest (sklearn `RandomForestClassifier`) strategy on 10 large-cap US stocks.
+Uses 12 technical features (RSI, Bollinger Bands, MACD, momentum, volatility, volume, price ratios) to predict 10-day forward returns.
+
+Monthly model training with biweekly rebalance (every other Monday). Prediction threshold of 0.54 with max 5 concurrent positions at 18% weight each.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434751 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.68 |
+| CAGR | 20.1% |
+| Max Drawdown | 36.4% |
+| Rebalance | Biweekly |
+
+## Files
+
+- `main.py` - Strategy (v3, RandomForestClassifier)
+- `research.ipynb` - Feature engineering and hyperparameter research
+
+## References
+
+- Breiman (2001), "Random Forests"
+- Hands-On AI Trading, Section 06 Example

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/README.md
@@ -1,0 +1,41 @@
+# ML-SVM
+
+**Asset class:** US Equities (Equity ETFs)
+**Cloud project ID:** 29434752
+
+## Description
+
+SVM Classification (sklearn `SVC`, linear kernel, C=0.5) strategy on 8 equity ETFs (SPY, QQQ, IWM, DIA, XLK, XLF, XLV, XLY).
+Uses 8 features (RSI, BB position, MACD histogram, momentum, volatility, price/SMAs) to classify positive 10-day forward returns.
+
+Monthly training, biweekly rebalance. Threshold 0.55 with max 4 positions.
+
+**Structural ceiling:** SVM for ETF direction prediction has limited signal-to-noise ratio. Sharpe 0.147 reflects this ceiling, not a code issue.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434752 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.147 |
+| Rebalance | Biweekly |
+| Kernel | Linear |
+| Universe | 8 equity ETFs |
+
+## Files
+
+- `main.py` - Strategy (v3, SVC linear)
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- Vapnik (1995), Support-Vector Networks
+- Hands-On AI Trading, Section 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/README.md
@@ -1,0 +1,40 @@
+# ML-XGBoost
+
+**Asset class:** US Equities (Large-cap liquid)
+**Cloud project ID:** 29434753
+
+## Description
+
+Gradient Boosting (sklearn `GradientBoostingRegressor`) strategy on 15 liquid US stocks.
+Uses 22 comprehensive features including RSI, Bollinger Bands, MACD, Stochastic oscillator, ATR, momentum, volatility, volume ratios, and price/SMAs.
+
+Alternating Monday pattern: odd Mondays for training, even Mondays for rebalance. 90% allocation across up to 9 positions with prediction threshold 0.001.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434753 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.566 |
+| CAGR | 14.8% |
+| Max Drawdown | 38.6% |
+| Rebalance | Biweekly |
+| Max Positions | 9 |
+
+## Files
+
+- `main.py` - Strategy (v2, GradientBoostingRegressor)
+- `research.ipynb` - Feature importance and hyperparameter tuning
+
+## References
+
+- Friedman (2001), "Greedy Function Approximation: A Gradient Boosting Machine"
+- Hands-On AI Trading, Section 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
@@ -1,0 +1,41 @@
+# MeanReversion
+
+**Asset class:** US Sector ETFs
+**Cloud project ID:** None (local only)
+
+## Description
+
+Short-term mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC).
+Buys the most oversold ETFs (RSI(14) < 40) and holds for 15 days or until RSI > 60.
+
+SMA200 regime filter on SPY: exits all positions in bear markets.
+Stop-loss at -8% to cut real breakdowns. Max 4 concurrent positions at 25% each.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.294 |
+| CAGR | 7.53% |
+| Max Drawdown | 16.5% |
+| Net Return | +80.9% |
+| Rebalance | Daily scan |
+
+## Files
+
+- `main.py` - Strategy (v4.0, sector ETF mean reversion)
+- `research.ipynb` - RSI optimization, stop-loss, and holding period tests
+
+## References
+
+- Jegadeesh (1990), "Evidence of Predictable Behavior of Security Returns"
+- De Bondt & Thaler (1985), "Does the Stock Market Overreact?"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
@@ -1,0 +1,41 @@
+# Option-Wheel
+
+**Asset class:** US Equities (SPY Options)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Options wheel strategy on SPY: sells OTM put options (5% OTM, ~21 DTE) to collect premium.
+If assigned, sells OTM covered calls on the resulting SPY position. Full wheel cycle.
+
+VIX regime filter: skips put selling when VIX > 20 (high volatility). Aggressive selling when VIX < 15.
+Cash-secured puts with 80% max exposure and margin disabled for safety. Minute-resolution backtest.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Starting Capital | $1,000,000 |
+| Resolution | Minute |
+| Put OTM | 5% |
+| DTE | 21 days |
+| VIX Filter | Skip selling if VIX > 20 |
+
+## Files
+
+- `main.py` - Strategy (wheel: short put -> covered call)
+- `research.ipynb` - Options premium analysis and DTE/OTM optimization
+
+## References
+
+- Options wheel strategy: systematic premium collection via put/call selling
+- Interactive Brokers brokerage model (cash account)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/README.md
@@ -1,0 +1,44 @@
+# SectorMomentum
+
+**Asset class:** US Equities + Bonds + Gold (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling ~0.56)
+
+## Description
+
+Dual momentum strategy with composite multi-lookback (1, 3, 6, 12 month, weights 0.4/0.2/0.2/0.2) on 3 assets: SPY (risk-on), TLT (bonds), GLD (gold).
+
+When SPY has positive absolute momentum AND is above SMA200 AND outperforms TLT/GLD: go 100% SPY.
+Otherwise: rotate to the better-performing defensive asset (TLT or GLD).
+Daily SMA200 exit protection (intra-month stops if SPY breaks below SMA200).
+
+**Archived because:** Sharpe ceiling ~0.56 for dual momentum on 3-5 assets. Target of 0.8 requires a fundamentally different approach. See ARCHIVE.md for full details.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.555 |
+| CAGR | 13.0% |
+| Max Drawdown | 22.8% |
+| Rebalance | Monthly (entries), Daily (SMA200 exit) |
+
+## Files
+
+- `main.py` - Strategy (v3.2, confirmed best)
+- `research.ipynb` - Multi-lookback optimization and expanded universe tests
+
+## References
+
+- Antonacci (2014), "Dual Momentum Investing"
+- Faber (2007), "A Quantitative Approach to Tactical Asset Allocation"
+- ARCHIVE.md - Full iteration history and ceiling analysis

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/README.md
@@ -1,0 +1,42 @@
+# TrendStocks-Alpha
+
+**Asset class:** US Equities (Large-cap diversified)
+**Cloud project ID:** 28885507
+
+## Description
+
+Framework-based trend-following alpha strategy on 15 large-cap stocks across sectors.
+Uses `TrendStocksAlpha` with EMA(20/50) for signal and SMA(200) as trend confirmation.
+Weekly rebalance via `MultiStrategyPCM`.
+
+The strategy enters long positions when short-term EMA is above long-term EMA AND the price is above the 200-day SMA, confirming the secular uptrend.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 28885507 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | ~0.61 |
+| Benchmark | SPY |
+| Rebalance | Weekly |
+| Universe | 15 large-cap stocks |
+
+## Files
+
+- `main.py` - Strategy entry point (framework alpha model)
+- `alpha_models.py` - TrendStocksAlpha implementation
+- `portfolio_construction.py` - MultiStrategyPCM module
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- QC Framework: Alpha Model + Portfolio Construction pattern
+- Ref: Faber (2007), "A Quantitative Approach to Tactical Asset Allocation"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/README.md
@@ -1,0 +1,43 @@
+# TurnOfMonth
+
+**Asset class:** US Equities (SPY + QQQ)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling ~0.13)
+
+## Description
+
+Turn-of-the-month calendar anomaly strategy: buys SPY+QQQ around month boundaries.
+Window: last 4 + first 4 trading days of each month. 1.5x leverage (75% SPY, 75% QQQ).
+SMA200 regime filter: stays flat in bear markets.
+
+**Why the ceiling is structural:** The ToM effect has Sharpe ~0.36 on 2000-2025 because it outperforms in bear markets (forced institutional rebalancing). In 2015-2026 (~90% bull market), every day has similar returns, so the ToM premium is diluted. The strategy correctly demonstrates the anomaly but is period-constrained.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.128 |
+| CAGR | 4.8% |
+| Max Drawdown | 23.7% |
+| Academic Sharpe (2000-2025) | ~0.36 |
+| Leverage | 1.5x |
+
+## Files
+
+- `main.py` - Strategy (v2.1, confirmed best after 5 iterations)
+- `research.ipynb` - Calendar anomaly analysis and 9 hypothesis tests (H1-H9)
+
+## References
+
+- Ariel (1987), "A Monthly Effect in Stock Returns"
+- Lakonishok & Smidt (1988), "Are Seasonal Anomalies Real?"
+- ARCHIVE.md - Full iteration history and structural ceiling analysis


### PR DESCRIPTION
## Summary

- Add structured README.md (~30 lines each) for 12 QuantConnect projects that had main.py + research but no documentation
- Each README contains: title, asset class, cloud project ID (if any), description, how to run, backtest metrics, file inventory, and academic references

## Projects covered (12)

**Cloud-linked (5):** EMA-Cross-Alpha (28885488), TrendStocks-Alpha (28885507), ML-RandomForest (29434751), ML-SVM (29434752), ML-XGBoost (29434753)

**Established (5):** FamaFrench, MeanReversion, EMA-Cross-Index, ForexCarry, Option-Wheel

**Archived (2):** SectorMomentum, TurnOfMonth (with Sharpe ceiling documentation)

## Context

From audit (PR #416): 83/95 projects missing README.md. This is batch 1 covering the 12 highest-priority projects.

## Test plan

- [x] Each README verified against actual main.py content (read all 12 source files)
- [x] Backtest metrics match docstrings in main.py
- [x] Cloud project IDs verified against config.json where available
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)