### PR TITLE
docs(qc): add README.md batch 2 (62 projects) [READY-TO-MERGE]

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Adaptive-Conformal-Risk/README.md
@@ -1,0 +1,30 @@
+# Adaptive-Conformal-Risk
+
+**Asset class:** US Equities/ETF (multi-factor)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Adaptive Conformal Inference (ACI) risk overlay on multi-factor momentum. Uses conformal prediction intervals to dynamically size positions based on prediction uncertainty.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | ACI risk overlay + multi-factor |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, conformal risk sizing)
+
+## References
+
+- Romano et al. (2020), Conformalized Quantile Regression

--- a/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AdaptiveAssetAllocation/README.md
@@ -1,0 +1,31 @@
+# AdaptiveAssetAllocation
+
+**Asset class:** US Equities/ETF (diversified)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Top-4 ETFs by 6-month momentum with minimum-variance portfolio optimization. Selects from SPY, QQQ, TLT, GLD, EFA, IWM.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | 6M momentum + min-variance |
+| Universe | 6 ETFs (top 4) |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (iter2c, adaptive allocation)
+
+## References
+
+- Faber (2007), A Quantitative Approach to Tactical Asset Allocation

--- a/MyIA.AI.Notebooks/QuantConnect/projects/AssetClassMomentum-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/AssetClassMomentum-QC/README.md
@@ -1,0 +1,29 @@
+# AssetClassMomentum-QC
+
+**Asset class:** Multi-Asset (ETF universe)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Cross-asset momentum rotation across equities, bonds, commodities, and real estate ETFs.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Source | QC Strategy Library |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-MACD-ADX/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-MACD-ADX/README.md
@@ -1,0 +1,27 @@
+# BTC-MACD-ADX
+
+**Asset class:** Crypto (BTC)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Bitcoin MACD + ADX trend-following strategy. Enters when MACD crosses above signal AND ADX > 25 (strong trend).
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | MACD + ADX trend filter |
+| Universe | BTCUSD |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BTC-ML/README.md
@@ -1,0 +1,27 @@
+# BTC-ML
+
+**Asset class:** Crypto (BTC)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Machine learning strategy on Bitcoin using lagged returns, volatility, and volume features with sklearn classifiers.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | ML classifier |
+| Universe | BTCUSD |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/BlackLitterman-Momentum/README.md
@@ -1,0 +1,31 @@
+# BlackLitterman-Momentum
+
+**Asset class:** US Equities/ETF (multi-asset)
+**Cloud project ID:** 29816300
+
+## Description
+
+Black-Litterman portfolio with multi-window momentum views (1M, 3M, 6M, 12M). BL optimization produces final weights.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Deployed as project 29816300.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Black-Litterman + momentum views |
+| Lookbacks | 1M, 3M, 6M, 12M |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, BL momentum)
+
+## References
+
+- Black & Litterman (1992), Global Portfolio Optimization

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CausalEventAlpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CausalEventAlpha/README.md
@@ -1,0 +1,26 @@
+# CausalEventAlpha
+
+**Asset class:** US Equities (event-driven)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Causal inference framework for event-driven alpha. Uses DoWhy/causal methods to identify genuine causal effects from corporate events.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Causal inference (DoWhy) |
+| Focus | Event study methodology |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Chronos-Foundation-Forecasting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Chronos-Foundation-Forecasting/README.md
@@ -1,0 +1,31 @@
+# Chronos-Foundation-Forecasting
+
+**Asset class:** US Equities/ETF (8 ETFs)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Ensemble GradientBoosting + Ridge using Chronos foundation model embeddings. Predicts returns on 8-ETF universe.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | Ensemble GB + Ridge |
+| Universe | 8 ETFs |
+| Rebalance | Biweekly |
+
+## Files
+
+- main.py - Strategy (v2, ensemble with Chronos features)
+
+## References
+
+- Amazon Chronos: Learning the Language of Time Series

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Clustering-Fundamentals-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Clustering-Fundamentals-ML/README.md
@@ -1,0 +1,32 @@
+# Clustering-Fundamentals-ML (HandsOn Ex10)
+
+**Asset class:** US Equities (top 50)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Fundamental factor clustering using Z-score composite ranking (P/E, ROE, debt ratio, earnings growth) to select top stocks.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.244 |
+| CAGR | 7.68% |
+| Max Drawdown | 44.8% |
+| Model | Z-score composite rank + KMeans |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v4, fundamental clustering)
+- research.ipynb - Factor analysis and cluster evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 10

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Crypto-MultiCanal/README.md
@@ -1,0 +1,27 @@
+# Crypto-MultiCanal
+
+**Asset class:** Crypto (BTC)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Multi-channel ZigZag strategy on Bitcoin. Uses 3 nested ZigZag channels (short/medium/long) to identify trend structure at multiple scales.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Multi-channel ZigZag |
+| Universe | BTCUSD |
+| Channels | 3 (nested) |
+
+## Files
+
+- main.py - Strategy (v17, multi-channel ZigZag)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DL-LSTM/README.md
@@ -1,0 +1,26 @@
+# DL-LSTM
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Deep learning LSTM strategy using Keras. Predicts next-day returns from sequence of past returns and technical features.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | LSTM (Keras) |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Dividend-Harvesting-ML/README.md
@@ -1,0 +1,32 @@
+# Dividend-Harvesting-ML (HandsOn Ex06)
+
+**Asset class:** US Equities (QQQ 100)
+**Cloud project ID:** None (local only)
+
+## Description
+
+DecisionTreeRegressor dividend prediction. Predicts dividend yield using fundamental ratios. Buys top-10 predicted high-dividend stocks quarterly.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.468 |
+| CAGR | 12.66% |
+| Max Drawdown | 30.6% |
+| Model | DecisionTreeRegressor |
+| Rebalance | Quarterly |
+
+## Files
+
+- main.py - Strategy (v1.0, dividend yield prediction)
+- research.ipynb - Dividend feature analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentumNoTLT/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentumNoTLT/README.md
@@ -1,0 +1,31 @@
+# DualMomentumNoTLT
+
+**Asset class:** US Equities + Gold (SPY, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Dual momentum variant excluding TLT. Absolute + relative momentum on SPY vs GLD only.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Dual momentum (SPY vs GLD) |
+| Universe | SPY, GLD |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy
+
+## References
+
+- Antonacci (2014), Dual Momentum Investing

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Dynamic-Options-Wheel/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Dynamic-Options-Wheel/README.md
@@ -1,0 +1,27 @@
+# Dynamic-Options-Wheel
+
+**Asset class:** US Equities (SPY Options)
+**Cloud project ID:** None (local only)
+
+## Description
+
+IV percentile-based dynamic options wheel on SPY. Adjusts put strike delta and call skew based on implied volatility rank.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | IV-adaptive options wheel |
+| Underlying | SPY |
+| DTE | ~21 days |
+
+## Files
+
+- main.py - Strategy (v1.0, dynamic IV wheel)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DynamicVIXSpyRegime-QC/README.md
@@ -1,0 +1,32 @@
+# DynamicVIXSpyRegime-QC
+
+**Asset class:** US Equities (SPY)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. VIX-based regime detection on SPY switching between aggressive and defensive positioning.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.72 |
+| CAGR | 29.76% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Alpha/README.md
@@ -1,0 +1,41 @@
+# EMA-Cross-Alpha
+
+**Asset class:** US Equities (Large-cap tech)
+**Cloud project ID:** 28885488
+
+## Description
+
+Framework-based EMA crossover alpha strategy on 5 major tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA).
+Uses the QuantConnect Alpha Model framework with `EMACrossAlpha` (fast=20, slow=50) and daily portfolio rebalance via `MultiStrategyPCM`.
+
+The alpha model generates insights when the fast EMA crosses the slow EMA for each stock, and the portfolio construction module allocates capital accordingly.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 28885488 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | ~1.00 |
+| Benchmark | SPY |
+| Rebalance | Daily |
+| Universe | 5 tech stocks |
+
+## Files
+
+- `main.py` - Strategy entry point (framework alpha model)
+- `alpha_models.py` - EMACrossAlpha implementation
+- `portfolio_construction.py` - MultiStrategyPCM module
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- QC Framework: Alpha Model + Portfolio Construction pattern
+- Ref: Brock et al. (1992), moving average trading rules

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/README.md
@@ -1,0 +1,27 @@
+# EMA-Cross-Crypto
+
+**Asset class:** Crypto (BTC, ETH)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Dual EMA crossover on cryptocurrency. Goes long when EMA(20) > EMA(60) on BTC/ETH.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | EMA 20/60 crossover |
+| Universe | BTC, ETH |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Index/README.md
@@ -1,0 +1,40 @@
+# EMA-Cross-Index
+
+**Asset class:** US Equities (S&P 500 ETF)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Dual EMA crossover on SPY (S&P 500 index ETF). Long when EMA(20) > EMA(60), flat otherwise.
+Includes a 3-day cooldown after exit to prevent immediate re-entry on false signals.
+
+EMA 20/60 selected over 20/50 based on robustness testing (IS/OOS ratio = 1.55).
+Slow=60 captures quarterly trends and reduces whipsaws compared to the standard 50-period.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| OOS Sharpe (2010-2015) | 1.325 |
+| IS/OOS Robustness | 1.55 |
+| Beta | ~0.42 |
+| Cooldown | 3 days post-exit |
+
+## Files
+
+- `main.py` - Strategy (v2.0, EMA 20/60 with cooldown)
+- `research.ipynb` - EMA period grid search and robustness validation
+
+## References
+
+- Brock et al. (1992), "Simple Technical Trading Rules and the Stochastic Properties of Stock Returns"
+- research.ipynb: H1-H5 hypothesis testing on EMA parameters

--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Stocks/README.md
@@ -1,0 +1,26 @@
+# EMA-Cross-Stocks
+
+**Asset class:** US Equities (multi-stock)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Dual EMA crossover applied to individual stocks with equal-weight allocation across trending stocks.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | EMA 20/60 crossover |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/FamaFrench/README.md
@@ -1,0 +1,41 @@
+# FamaFrench
+
+**Asset class:** US Factor ETFs
+**Cloud project ID:** None (local only)
+
+## Description
+
+Factor ETF rotation strategy using risk-adjusted momentum (12m-1m return / 63d realized volatility) with skip-month.
+Universe of 5 Fama-French factor ETFs: VLUE (value), MTUM (momentum), SIZE (size), QUAL (quality), USMV (low-vol).
+
+SMA200 regime filter on SPY: in bear markets, rotates to USMV as risk-off asset.
+Dynamic top_n selection (all factors with positive score). Per-position stop-loss at -12%.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.540 |
+| CAGR | 12.1% |
+| Max Drawdown | 24.2% |
+| Net Return | +258% |
+| Rebalance | Monthly |
+
+## Files
+
+- `main.py` - Strategy (v3, risk-adjusted momentum with skip-month)
+- `research.ipynb` - Factor analysis and signal robustness tests
+
+## References
+
+- Fama & French (1993), "Common risk factors in the returns on stocks and bonds"
+- Barroso & Santa-Clara (2015), "Momentum has its moments"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/README.md
@@ -1,0 +1,42 @@
+# ForexCarry
+
+**Asset class:** G10 Currencies (FX)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Cross-sectional G10 currency momentum strategy on 4 FX pairs (EURUSD, AUDUSD, USDJPY, USDCAD).
+Uses risk-adjusted momentum (information ratio = 6m return / 21d realized vol) with skip-month (excludes last 21 days of mean-reversion noise).
+
+Long-only top-2 momentum currencies vs USD, monthly rebalance. Signal is inverted for USD/XXX pairs (USDJPY, USDCAD).
+
+**Structural limitation:** G10 FX momentum earns ~1-2% CAGR vs T-bill ~2.5% average in 2018-2026. Extended start to 2013 for better regime coverage.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2013-2026)
+
+| Metric | Value |
+|--------|-------|
+| Target Sharpe | -0.3 to -0.5 |
+| Rebalance | Monthly |
+| Universe | 4 G10 FX pairs |
+| Leverage | Standard (100% allocated) |
+
+## Files
+
+- `main.py` - Strategy (v4.0, risk-adjusted momentum with skip-month)
+- `research.ipynb` - FX momentum signal analysis (H1-H4)
+
+## References
+
+- Menkhoff et al. (2012), "Currency momentum strategies"
+- Barroso & Santa-Clara (2015), risk-adjusted momentum
+- Okunev & White (2003), skip-month momentum

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_EMATrend/README.md
@@ -1,0 +1,26 @@
+# Framework_Composite_EMATrend
+
+**Asset class:** US Equities (ETF + stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Framework composite combining EMA-Cross-Alpha with TrendStocks-Alpha. Blends EMA crossover signals with trend-following stock selection.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Composite EMA + Trend |
+| Components | EMA-Cross-Alpha + TrendStocks-Alpha |
+
+## Files
+
+- main.py - Strategy (v1.0, EMA+Trend composite)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Framework_Composite_TrendWeather/README.md
@@ -1,0 +1,28 @@
+# Framework_Composite_TrendWeather
+
+**Asset class:** US Equities (ETF + stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Framework composite combining TrendStocks (75%) with AllWeather (25%). Trend uses SMA200+EMA, AllWeather provides diversification.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.155 |
+| CAGR | 27.4% |
+| Max Drawdown | 27.7% |
+| Allocation | 75% Trend / 25% AllWeather |
+
+## Files
+
+- main.py - Strategy (v1.5, T75/AW25 composite)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Gaussian-Direction-Classifier/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Gaussian-Direction-Classifier/README.md
@@ -1,0 +1,29 @@
+# Gaussian-Direction-Classifier
+
+**Asset class:** US Equities (8 tech stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+GaussianNB direction classifier on 8 tech stocks. Uses lagged returns, RSI, volume, and volatility features to predict next-day direction.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.761 |
+| CAGR | 23.1% |
+| Max Drawdown | 25.6% |
+| Model | GaussianNB |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v2.0, Gaussian direction)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HMM-KMeans-Voting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HMM-KMeans-Voting/README.md
@@ -1,0 +1,26 @@
+# HMM-KMeans-Voting
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Ensemble regime detection combining Hidden Markov Models with KMeans clustering. Voting mechanism merges regime labels.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | HMM + KMeans voting |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HighBookToMarketFScore-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HighBookToMarketFScore-QC/README.md
@@ -1,0 +1,34 @@
+# HighBookToMarketFScore-QC
+
+**Asset class:** US Equities (value stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Value investing selecting high book-to-market stocks with strong Piotroski F-Scores.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 2.09 |
+| CAGR | 18.44% |
+| Max Drawdown | 24.20% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library
+- Piotroski (2000), Value Investing

--- a/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/InverseVolatility-Rank/README.md
@@ -1,0 +1,32 @@
+# InverseVolatility-Rank (HandsOn Ex11)
+
+**Asset class:** Futures (12 contracts)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Ridge regression inverse volatility ranking on 12 futures contracts. Predicts next-month volatility and allocates inversely.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.124 |
+| CAGR | 4.13% |
+| Model | Ridge |
+| Universe | 12 futures contracts |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, inverse vol futures)
+- research.ipynb - Volatility prediction features
+## References
+
+- Hands-On AI Trading, Section 06, Example 11

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LSTM-Forecasting/README.md
@@ -1,0 +1,29 @@
+# LSTM-Forecasting
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+MLPClassifier (not actual LSTM) return prediction. Uses sklearn MLPClassifier with lagged return features. Despite the name, no LSTM is used.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.525 |
+| CAGR | 11.3% |
+| Max Drawdown | 32.5% |
+| Model | MLPClassifier (sklearn) |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v2.1, MLP forecasting)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LeveragedETFMomentum-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LeveragedETFMomentum-QC/README.md
@@ -1,0 +1,33 @@
+# LeveragedETFMomentum-QC
+
+**Asset class:** US Equities (Leveraged ETFs)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Momentum strategy on leveraged ETFs with aggressive momentum rotation.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.80 |
+| CAGR | 101.03% |
+| Max Drawdown | 47.50% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/LongShortHarvest-QC/README.md
@@ -1,0 +1,33 @@
+# LongShortHarvest-QC
+
+**Asset class:** US Equities (long/short)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Long/short equity strategy harvesting alpha from both directions via pairs-style mean reversion.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 3.39 |
+| CAGR | 57.94% |
+| Max Drawdown | 15.20% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Chronos-Foundation/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Chronos-Foundation/README.md
@@ -1,0 +1,32 @@
+# ML-Chronos-Foundation (HandsOn Ex18)
+
+**Asset class:** US Equities (top 10)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Amazon Chronos T5 foundation model for time series forecasting. Biweekly rebalance based on forecast direction.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.277 |
+| CAGR | 7.23% |
+| Max Drawdown | 13.5% |
+| Model | Chronos T5 (Amazon) |
+| Rebalance | Biweekly |
+
+## Files
+
+- main.py - Strategy (v1.0, Chronos forecasting)
+- research.ipynb - Foundation model evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 18

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-DeepLearning/README.md
@@ -1,0 +1,25 @@
+# ML-DeepLearning
+
+**Asset class:** Template (no active strategy)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for deep learning strategies. Contains basic framework structure but no implemented trading logic.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-EnhancedPairs/README.md
@@ -1,0 +1,26 @@
+# ML-EnhancedPairs
+
+**Asset class:** US Equities (pairs)
+**Cloud project ID:** None (local only)
+
+## Description
+
+ML-enhanced pairs trading. Uses ML to improve pair selection and signal generation beyond traditional cointegration tests.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | ML-enhanced pairs trading |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Ensemble/README.md
@@ -1,0 +1,25 @@
+# ML-Ensemble
+
+**Asset class:** Template (no active strategy)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for ensemble ML strategies. Contains basic framework for combining multiple ML models.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FX-SVM-Wavelet/README.md
@@ -1,0 +1,30 @@
+# ML-FX-SVM-Wavelet (HandsOn Ex05)
+
+**Asset class:** Forex (4 pairs: EURUSD, AUDUSD, USDJPY, USDCAD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+SVR + Wavelet decomposition on G10 FX pairs. Uses pywt wavelet denoising on price series, then SVR to predict returns.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | SVR + Wavelet (pywt) |
+| Universe | 4 G10 FX pairs |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, SVR + wavelet)
+- research.ipynb - Wavelet decomposition analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 05

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FeatureEngineering/README.md
@@ -1,0 +1,26 @@
+# ML-FeatureEngineering
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Feature engineering experiments for ML trading strategies. Tests various feature sets and their impact on prediction accuracy.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Feature engineering experiments |
+| Focus | Feature selection and evaluation |
+
+## Files
+
+- main.py - Feature engineering framework

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-FinBERT-Sentiment/README.md
@@ -1,0 +1,29 @@
+# ML-FinBERT-Sentiment (HandsOn Ex19)
+
+**Asset class:** US Equities (top 10 tech)
+**Cloud project ID:** None (local only)
+
+## Description
+
+FinBERT sentiment analysis on financial text. Requires TensorFlow and model weights unavailable in QC Cloud.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | FinBERT (HuggingFace) |
+| Note | Requires local Lean execution with TF |
+
+## Files
+
+- main.py - Strategy (v1.0, FinBERT sentiment)
+- research.ipynb - Sentiment model evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 19

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Gaussian-Classifier/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Gaussian-Classifier/README.md
@@ -1,0 +1,32 @@
+# ML-Gaussian-Classifier (HandsOn Ex15)
+
+**Asset class:** US Equities (top 10 tech)
+**Cloud project ID:** None (local only)
+
+## Description
+
+GaussianNB direction classifier on top-10 tech stocks. Uses lagged returns, RSI, and MACD features.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.361 |
+| CAGR | 12.49% |
+| Max Drawdown | 47.4% |
+| Model | GaussianNB |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v1.0, Gaussian NB classifier)
+- research.ipynb - Feature selection and NB evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 15

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-HMM-Regime/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-HMM-Regime/README.md
@@ -1,0 +1,31 @@
+# ML-HMM-Regime (HandsOn Ex04)
+
+**Asset class:** US Equities/ETF (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Hidden Markov Model regime detection using statsmodels MarkovRegression. Identifies bull/bear/sideways regimes on SPY returns.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.571 |
+| Model | MarkovRegression (statsmodels) |
+| Universe | SPY, TLT, GLD |
+| Regimes | 3 (bull/bear/sideways) |
+
+## Files
+
+- main.py - Strategy (v1.0, HMM regime switching)
+- research.ipynb - Regime persistence analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 04

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-HeadShoulders-CNN/README.md
@@ -1,0 +1,30 @@
+# ML-HeadShoulders-CNN (HandsOn Ex17)
+
+**Asset class:** Forex (USDCAD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Keras CNN for head-and-shoulders pattern detection on USDCAD. Requires pre-trained model from research.ipynb.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | Keras CNN (pattern detection) |
+| Universe | USDCAD |
+| Rebalance | Event-driven (pattern) |
+
+## Files
+
+- main.py - Strategy (v1.0, pattern CNN)
+- research.ipynb - Pattern labeling and CNN training
+## References
+
+- Hands-On AI Trading, Section 06, Example 17

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-LLM-Summarization/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-LLM-Summarization/README.md
@@ -1,0 +1,32 @@
+# ML-LLM-Summarization (HandsOn Ex16)
+
+**Asset class:** US Equities (SPY)
+**Cloud project ID:** None (local only)
+
+## Description
+
+LLM-based news summarization for sentiment signals. Uses OpenAI API or keyword extraction to score financial news sentiment.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.686 |
+| CAGR | 15.45% |
+| Max Drawdown | 22.7% |
+| Model | OpenAI API / Keywords |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, LLM sentiment)
+- research.ipynb - Sentiment signal evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 16

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-PCA-StatArb/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-PCA-StatArb/README.md
@@ -1,0 +1,32 @@
+# ML-PCA-StatArb (HandsOn Ex13)
+
+**Asset class:** US Equities (top 100)
+**Cloud project ID:** None (local only)
+
+## Description
+
+PCA statistical arbitrage. Extracts principal components from top-100 stock returns, uses LinearRegression on residual mean-reversion signals.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.399 |
+| CAGR | 12.65% |
+| Max Drawdown | 31.8% |
+| Model | PCA + LinearRegression |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v1.0, PCA stat arb)
+- research.ipynb - Component analysis and signal evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 13

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Pairs-PCA-Selection/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Pairs-PCA-Selection/README.md
@@ -1,0 +1,28 @@
+# ML-Pairs-PCA-Selection (HandsOn Ex09)
+
+**Asset class:** N/A (Research only)
+**Cloud project ID:** None (local only)
+**Status:** Research phase
+
+## Description
+
+PCA-based pair selection framework. Identifies cointegrated pairs using PCA residuals. No executable main.py - research-only notebook.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | PCA + cointegration tests |
+
+## Files
+
+- research.ipynb - PCA pair selection methodology
+## References
+
+- Hands-On AI Trading, Section 06, Example 09

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-RandomForest/README.md
@@ -1,0 +1,39 @@
+# ML-RandomForest
+
+**Asset class:** US Equities (Large-cap)
+**Cloud project ID:** 29434751
+
+## Description
+
+Random Forest (sklearn `RandomForestClassifier`) strategy on 10 large-cap US stocks.
+Uses 12 technical features (RSI, Bollinger Bands, MACD, momentum, volatility, volume, price ratios) to predict 10-day forward returns.
+
+Monthly model training with biweekly rebalance (every other Monday). Prediction threshold of 0.54 with max 5 concurrent positions at 18% weight each.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434751 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.68 |
+| CAGR | 20.1% |
+| Max Drawdown | 36.4% |
+| Rebalance | Biweekly |
+
+## Files
+
+- `main.py` - Strategy (v3, RandomForestClassifier)
+- `research.ipynb` - Feature engineering and hyperparameter research
+
+## References
+
+- Breiman (2001), "Random Forests"
+- Hands-On AI Trading, Section 06 Example

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Regression/README.md
@@ -1,0 +1,25 @@
+# ML-Regression
+
+**Asset class:** Template (no active strategy)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for regression-based ML strategies.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Reversion-Trending/README.md
@@ -1,0 +1,32 @@
+# ML-Reversion-Trending (HandsOn Ex03)
+
+**Asset class:** US Equities/ETF (5 assets)
+**Cloud project ID:** None (local only)
+
+## Description
+
+GradientBoostingClassifier mean-reversion-in-trending. Uses Bollinger Band width, RSI, and return lags to predict next-day direction.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.375 |
+| CAGR | 8.44% |
+| Max Drawdown | 24.4% |
+| Model | GradientBoostingClassifier |
+| Rebalance | Weekly |
+
+## Files
+
+- main.py - Strategy (v1.0, GBM reversion/trending)
+- research.ipynb - Regime detection and model comparison
+## References
+
+- Hands-On AI Trading, Section 06, Example 03

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-SVM/README.md
@@ -1,0 +1,41 @@
+# ML-SVM
+
+**Asset class:** US Equities (Equity ETFs)
+**Cloud project ID:** 29434752
+
+## Description
+
+SVM Classification (sklearn `SVC`, linear kernel, C=0.5) strategy on 8 equity ETFs (SPY, QQQ, IWM, DIA, XLK, XLF, XLV, XLY).
+Uses 8 features (RSI, BB position, MACD histogram, momentum, volatility, price/SMAs) to classify positive 10-day forward returns.
+
+Monthly training, biweekly rebalance. Threshold 0.55 with max 4 positions.
+
+**Structural ceiling:** SVM for ETF direction prediction has limited signal-to-noise ratio. Sharpe 0.147 reflects this ceiling, not a code issue.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434752 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.147 |
+| Rebalance | Biweekly |
+| Kernel | Linear |
+| Universe | 8 equity ETFs |
+
+## Files
+
+- `main.py` - Strategy (v3, SVC linear)
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- Vapnik (1995), Support-Vector Networks
+- Hands-On AI Trading, Section 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Temporal-CNN/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Temporal-CNN/README.md
@@ -1,0 +1,30 @@
+# ML-Temporal-CNN (HandsOn Ex14)
+
+**Asset class:** US Equities (QQQ top-3)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Temporal Conv1D CNN for return prediction. Uses sliding window of past 20 days returns as input to a 1D convolutional network.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | Conv1D CNN (Keras) |
+| Universe | QQQ top-3 |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v1.0, temporal CNN)
+- research.ipynb - CNN architecture and training
+## References
+
+- Hands-On AI Trading, Section 06, Example 14

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-TextClassification/README.md
@@ -1,0 +1,25 @@
+# ML-TextClassification
+
+**Asset class:** Template (no active strategy)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for text classification strategies. Contains basic NLP framework.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Trend-Scanning/README.md
@@ -1,0 +1,31 @@
+# ML-Trend-Scanning (HandsOn Ex01)
+
+**Asset class:** US Equities/ETF (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+RandomForestClassifier trend-scanning. Predicts next-day direction using lagged returns, volatility, and volume features on a 3-asset universe. Monthly rebalance.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.292 |
+| Model | RandomForestClassifier |
+| Universe | SPY, TLT, GLD |
+| Rebalance | Monthly |
+
+## Files
+
+- main.py - Strategy (v1.0, RandomForest trend scanning)
+- research.ipynb - Feature engineering and model evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 01

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-XGBoost/README.md
@@ -1,0 +1,40 @@
+# ML-XGBoost
+
+**Asset class:** US Equities (Large-cap liquid)
+**Cloud project ID:** 29434753
+
+## Description
+
+Gradient Boosting (sklearn `GradientBoostingRegressor`) strategy on 15 liquid US stocks.
+Uses 22 comprehensive features including RSI, Bollinger Bands, MACD, Stochastic oscillator, ATR, momentum, volatility, volume ratios, and price/SMAs.
+
+Alternating Monday pattern: odd Mondays for training, even Mondays for rebalance. 90% allocation across up to 9 positions with prediction threshold 0.001.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 29434753 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.566 |
+| CAGR | 14.8% |
+| Max Drawdown | 38.6% |
+| Rebalance | Biweekly |
+| Max Positions | 9 |
+
+## Files
+
+- `main.py` - Strategy (v2, GradientBoostingRegressor)
+- `research.ipynb` - Feature importance and hyperparameter tuning
+
+## References
+
+- Friedman (2001), "Greedy Function Approximation: A Gradient Boosting Machine"
+- Hands-On AI Trading, Section 06

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MacroFactorRotation-QC/README.md
@@ -1,0 +1,33 @@
+# MacroFactorRotation-QC
+
+**Asset class:** Multi-Asset (factor rotation)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Macro factor rotation rotating between asset classes based on macroeconomic indicators.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.23 |
+| CAGR | 33.45% |
+| Max Drawdown | 27.60% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Markov-Regime-Detection/README.md
@@ -1,0 +1,27 @@
+# Markov-Regime-Detection
+
+**Asset class:** US Equities/ETF (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Markov regime detection using statsmodels MarkovRegression. Identifies 2-regime (bull/bear) states on SPY returns.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.408 |
+| Model | MarkovRegression |
+| Regimes | 2 (bull/bear) |
+
+## Files
+
+- main.py - Strategy (v1.1, Markov regime)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/MeanReversion/README.md
@@ -1,0 +1,41 @@
+# MeanReversion
+
+**Asset class:** US Sector ETFs
+**Cloud project ID:** None (local only)
+
+## Description
+
+Short-term mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC).
+Buys the most oversold ETFs (RSI(14) < 40) and holds for 15 days or until RSI > 60.
+
+SMA200 regime filter on SPY: exits all positions in bear markets.
+Stop-loss at -8% to cut real breakdowns. Max 4 concurrent positions at 25% each.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.294 |
+| CAGR | 7.53% |
+| Max Drawdown | 16.5% |
+| Net Return | +80.9% |
+| Rebalance | Daily scan |
+
+## Files
+
+- `main.py` - Strategy (v4.0, sector ETF mean reversion)
+- `research.ipynb` - RSI optimization, stop-loss, and holding period tests
+
+## References
+
+- Jegadeesh (1990), "Evidence of Predictable Behavior of Security Returns"
+- De Bondt & Thaler (1985), "Does the Stock Market Overreact?"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Multi-Layer-EMA/README.md
@@ -1,0 +1,26 @@
+# Multi-Layer-EMA
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Multi-layer EMA strategy with stacked lookbacks. EMA(10), EMA(20), EMA(50) alignment as entry signal.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | Multi-layer EMA alignment |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Option-Wheel/README.md
@@ -1,0 +1,41 @@
+# Option-Wheel
+
+**Asset class:** US Equities (SPY Options)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Options wheel strategy on SPY: sells OTM put options (5% OTM, ~21 DTE) to collect premium.
+If assigned, sells OTM covered calls on the resulting SPY position. Full wheel cycle.
+
+VIX regime filter: skips put selling when VIX > 20 (high volatility). Aggressive selling when VIX < 15.
+Cash-secured puts with 80% max exposure and margin disabled for safety. Minute-resolution backtest.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Starting Capital | $1,000,000 |
+| Resolution | Minute |
+| Put OTM | 5% |
+| DTE | 21 days |
+| VIX Filter | Skip selling if VIX > 20 |
+
+## Files
+
+- `main.py` - Strategy (wheel: short put -> covered call)
+- `research.ipynb` - Options premium analysis and DTE/OTM optimization
+
+## References
+
+- Options wheel strategy: systematic premium collection via put/call selling
+- Interactive Brokers brokerage model (cash account)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArb/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArb/README.md
@@ -1,0 +1,30 @@
+# PCA-StatArb
+
+**Asset class:** US Equities (top 100)
+**Cloud project ID:** None (local only)
+
+## Description
+
+PCA statistical arbitrage using numpy/scipy PCA (non-QC Cloud compatible, see PCA-StatArbitrage for sklearn version).
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | PCA + residual mean-reversion |
+| Universe | Top 100 US equities |
+
+## Files
+
+- main.py - Strategy (numpy PCA version)
+
+## References
+
+- Avellaneda & Lee (2010), Statistical Arbitrage

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PCA-StatArbitrage/README.md
@@ -1,0 +1,30 @@
+# PCA-StatArbitrage
+
+**Asset class:** US Equities (top 100)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Cloud-compatible PCA statistical arbitrage using sklearn PCA instead of numpy/scipy.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | sklearn PCA + mean-reversion |
+| Universe | Top 100 US equities |
+
+## Files
+
+- main.py - Strategy (v1.0, sklearn PCA version)
+
+## References
+
+- Avellaneda & Lee (2010), Statistical Arbitrage

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Positive-Negative-Splits-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Positive-Negative-Splits-ML/README.md
@@ -1,0 +1,32 @@
+# Positive-Negative-Splits-ML (HandsOn Ex07)
+
+**Asset class:** US Equities (Tech sector)
+**Cloud project ID:** None (local only)
+
+## Description
+
+LinearRegression positive/negative split prediction. Uses earnings surprise magnitude and historical split ratios to predict post-earnings drift.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.736 |
+| CAGR | 90.83% |
+| Max Drawdown | 42.4% |
+| Model | LinearRegression |
+| Rebalance | Event-driven (earnings) |
+
+## Files
+
+- main.py - Strategy (v1.0, split prediction)
+- research.ipynb - Earnings split analysis
+## References
+
+- Hands-On AI Trading, Section 06, Example 07

--- a/MyIA.AI.Notebooks/QuantConnect/projects/PuppiesOfTheDow-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/PuppiesOfTheDow-QC/README.md
@@ -1,0 +1,34 @@
+# PuppiesOfTheDow-QC
+
+**Asset class:** US Equities (Dow Jones)
+**Cloud project ID:** None (local only)
+
+## Description
+
+QC Strategy Library clone. Dogs of the Dow variant selecting lowest-priced stocks among highest-yielding Dow components.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 1.99 |
+| CAGR | 10.16% |
+| Max Drawdown | 22.90% |
+| Source | QC Strategy Library clone |
+| Note | Metrics from original library, not locally reproduced |
+
+## Files
+
+- main.py - Strategy (QC Library clone)
+
+## References
+
+- QuantConnect Strategy Library
+- O Higgins (1991), Beating the Dow

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-DQN-Trading/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-DQN-Trading/README.md
@@ -1,0 +1,31 @@
+# RL-DQN-Trading
+
+**Asset class:** US Equities/ETF (5 ETFs)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Deep Q-Network RL agent using MLPRegressor as Q-function approximator on 5 ETFs with risk-adjusted reward function.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | DQN with MLPRegressor |
+| Universe | 5 ETFs |
+| Reward | Risk-adjusted (drawdown penalty) |
+
+## Files
+
+- main.py - Strategy (v2.0.1, DQN agent)
+
+## References
+
+- Mnih et al. (2015), Human-level control through deep RL

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RL-Portfolio/README.md
@@ -1,0 +1,25 @@
+# RL-Portfolio
+
+**Asset class:** Template (RL portfolio)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for RL portfolio optimization.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RegimeSwitching/README.md
@@ -1,0 +1,26 @@
+# RegimeSwitching
+
+**Asset class:** US Equities/ETF
+**Cloud project ID:** None (local only)
+
+## Description
+
+Momentum/mean-reversion regime switching using SMA50/SMA200 crossover. Applies momentum in trending, mean-reversion in sideways.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Method | SMA50/200 regime switch |
+| Strategies | Momentum + Mean-reversion |
+
+## Files
+
+- main.py - Strategy (iter3, regime switching)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Reinforcement-Learning-Trading/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Reinforcement-Learning-Trading/README.md
@@ -1,0 +1,25 @@
+# Reinforcement-Learning-Trading
+
+**Asset class:** Template (RL trading)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Template/skeleton project for reinforcement learning trading.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Status | Template/skeleton (no active strategy) |
+
+## Files
+
+- main.py - Template structure

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SVM-Wavelet-Forecasting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SVM-Wavelet-Forecasting/README.md
@@ -1,0 +1,26 @@
+# SVM-Wavelet-Forecasting
+
+**Asset class:** Forex
+**Cloud project ID:** None (local only)
+
+## Description
+
+SVM regression with wavelet-decomposed features for FX forecasting. Decomposes price series then applies SVR on denoised features.
+
+## How to Run
+
+**Lean CLI:**
+
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | SVR + wavelet decomposition |
+| Asset | Forex pairs |
+
+## Files
+
+- main.py - Strategy

--- a/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/SectorMomentum/README.md
@@ -1,0 +1,44 @@
+# SectorMomentum
+
+**Asset class:** US Equities + Bonds + Gold (SPY, TLT, GLD)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling ~0.56)
+
+## Description
+
+Dual momentum strategy with composite multi-lookback (1, 3, 6, 12 month, weights 0.4/0.2/0.2/0.2) on 3 assets: SPY (risk-on), TLT (bonds), GLD (gold).
+
+When SPY has positive absolute momentum AND is above SMA200 AND outperforms TLT/GLD: go 100% SPY.
+Otherwise: rotate to the better-performing defensive asset (TLT or GLD).
+Daily SMA200 exit protection (intra-month stops if SPY breaks below SMA200).
+
+**Archived because:** Sharpe ceiling ~0.56 for dual momentum on 3-5 assets. Target of 0.8 requires a fundamentally different approach. See ARCHIVE.md for full details.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.555 |
+| CAGR | 13.0% |
+| Max Drawdown | 22.8% |
+| Rebalance | Monthly (entries), Daily (SMA200 exit) |
+
+## Files
+
+- `main.py` - Strategy (v3.2, confirmed best)
+- `research.ipynb` - Multi-lookback optimization and expanded universe tests
+
+## References
+
+- Antonacci (2014), "Dual Momentum Investing"
+- Faber (2007), "A Quantitative Approach to Tactical Asset Allocation"
+- ARCHIVE.md - Full iteration history and ceiling analysis

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Stoploss-Volatility-ML/README.md
@@ -1,0 +1,33 @@
+# Stoploss-Volatility-ML (HandsOn Ex08)
+
+**Asset class:** US Equities (KO)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Lasso regression stop-loss volatility prediction. Predicts next-day realized volatility. Adjusts stop-loss dynamically based on predicted vol.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.291 |
+| CAGR | 7.83% |
+| Max Drawdown | 20.0% |
+| Model | Lasso |
+| Universe | KO (Coca-Cola) |
+| Rebalance | Daily |
+
+## Files
+
+- main.py - Strategy (v1.0, ML vol-adjusted stops)
+- research.ipynb - Volatility feature engineering
+## References
+
+- Hands-On AI Trading, Section 06, Example 08

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Temporal-CNN-Prediction/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Temporal-CNN-Prediction/README.md
@@ -1,0 +1,32 @@
+# Temporal-CNN-Prediction
+
+**Asset class:** US Equities (S&P 500)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Temporal CNN forecasting using Conv1D networks on S&P 500 price data.
+Separate implementation from HandsOn Ex14 (ML-Temporal-CNN), focused on multi-layer convolutional
+architectures for time-series prediction.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Resolution | Daily |
+| Model | Conv1D temporal network |
+| Universe | S&P 500 |
+
+## Files
+
+- `main.py` - Strategy (temporal CNN prediction pipeline)
+- `research.ipynb` - CNN architecture experiments and feature engineering

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TermStructureCommodities-QC/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TermStructureCommodities-QC/README.md
@@ -1,0 +1,38 @@
+# TermStructureCommodities-QC
+
+**Asset class:** Commodities (Futures)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Commodity futures term structure strategy from the QuantConnect Strategy Library.
+Exploits contango/backwardation in commodity futures curves by rolling between
+near and far contracts based on the shape of the term structure.
+
+**Note:** Metrics from original QC Library, not locally reproduced.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (Original Library)
+
+| Metric | Value |
+|--------|-------|
+| 5Y CAGR | -15.71% |
+| 5Y Drawdown | 80.80% |
+| Asset Class | Commodities Futures |
+
+## Files
+
+- `main.py` - Strategy (cloned from QC Strategy Library)
+
+## References
+
+- QuantConnect Strategy Library
+- Gorton & Rouwenhorst (2006), "Facts and Fantasies about Commodity Futures"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TradingCosts-Optimization/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TradingCosts-Optimization/README.md
@@ -1,0 +1,30 @@
+# TradingCosts-Optimization (HandsOn Ex12)
+
+**Asset class:** Crypto (BTC)
+**Cloud project ID:** None (local only)
+**Status:** Educational demo
+
+## Description
+
+Educational demo of ML-based trading cost prediction. DecisionTreeRegressor predicts execution costs from order features.
+
+## How to Run
+
+**Lean CLI:**
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Model | DecisionTreeRegressor |
+| Focus | Execution cost prediction |
+
+## Files
+
+- main.py - Strategy (v1.0, cost prediction demo)
+- research.ipynb - Cost analysis and ML evaluation
+## References
+
+- Hands-On AI Trading, Section 06, Example 12

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocks-Alpha/README.md
@@ -1,0 +1,42 @@
+# TrendStocks-Alpha
+
+**Asset class:** US Equities (Large-cap diversified)
+**Cloud project ID:** 28885507
+
+## Description
+
+Framework-based trend-following alpha strategy on 15 large-cap stocks across sectors.
+Uses `TrendStocksAlpha` with EMA(20/50) for signal and SMA(200) as trend confirmation.
+Weekly rebalance via `MultiStrategyPCM`.
+
+The strategy enters long positions when short-term EMA is above long-term EMA AND the price is above the 200-day SMA, confirming the secular uptrend.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Open project 28885507 in the QuantConnect IDE and click "Backtest".
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | ~0.61 |
+| Benchmark | SPY |
+| Rebalance | Weekly |
+| Universe | 15 large-cap stocks |
+
+## Files
+
+- `main.py` - Strategy entry point (framework alpha model)
+- `alpha_models.py` - TrendStocksAlpha implementation
+- `portfolio_construction.py` - MultiStrategyPCM module
+- `quantbook.ipynb` - Research notebook
+
+## References
+
+- QC Framework: Alpha Model + Portfolio Construction pattern
+- Ref: Faber (2007), "A Quantitative Approach to Tactical Asset Allocation"

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocksLite/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocksLite/README.md
@@ -1,0 +1,33 @@
+# TrendStocksLite
+
+**Asset class:** US Equities (15 stocks)
+**Cloud project ID:** None (local only)
+
+## Description
+
+Simplified trend-following strategy on a 15-stock universe using SMA200 + EMA filter.
+Weekly rebalance: goes long stocks above SMA200 with positive EMA slope, flat otherwise.
+Lighter version of TrendStocks-Alpha (which uses 50 stocks + monthly rebalance).
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics
+
+| Metric | Value |
+|--------|-------|
+| Universe | 15 US stocks |
+| Rebalance | Weekly |
+| Indicators | SMA200 + EMA slope |
+| Leverage | Standard (equal weight) |
+
+## Files
+
+- `main.py` - Strategy (SMA200 trend + EMA filter, 15 stocks)
+- `research.ipynb` - Universe selection and rebalance frequency analysis

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/README.md
@@ -1,0 +1,43 @@
+# TurnOfMonth
+
+**Asset class:** US Equities (SPY + QQQ)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling ~0.13)
+
+## Description
+
+Turn-of-the-month calendar anomaly strategy: buys SPY+QQQ around month boundaries.
+Window: last 4 + first 4 trading days of each month. 1.5x leverage (75% SPY, 75% QQQ).
+SMA200 regime filter: stays flat in bear markets.
+
+**Why the ceiling is structural:** The ToM effect has Sharpe ~0.36 on 2000-2025 because it outperforms in bear markets (forced institutional rebalancing). In 2015-2026 (~90% bull market), every day has similar returns, so the ToM premium is diluted. The strategy correctly demonstrates the anomaly but is period-constrained.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | 0.128 |
+| CAGR | 4.8% |
+| Max Drawdown | 23.7% |
+| Academic Sharpe (2000-2025) | ~0.36 |
+| Leverage | 1.5x |
+
+## Files
+
+- `main.py` - Strategy (v2.1, confirmed best after 5 iterations)
+- `research.ipynb` - Calendar anomaly analysis and 9 hypothesis tests (H1-H9)
+
+## References
+
+- Ariel (1987), "A Monthly Effect in Stock Returns"
+- Lakonishok & Smidt (1988), "Are Seasonal Anomalies Real?"
+- ARCHIVE.md - Full iteration history and structural ceiling analysis

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VIX-TermStructure/README.md
@@ -1,0 +1,43 @@
+# VIX-TermStructure
+
+**Asset class:** Volatility (SVXY)
+**Cloud project ID:** None (local only)
+**Status:** ARCHIVED (Sharpe ceiling +0.05)
+
+## Description
+
+VIX term structure strategy using SVXY (short-volatility ETF).
+Signals based on the spread between VIX spot and VIX3M (3-month VIX futures).
+Goes long SVXY when term structure is in contango (VIX < VIX3M), flat in backwardation.
+
+**Archived because:** Structural ceiling at Sharpe +0.05. Short-vol strategies suffer from
+asymmetric payoffs (small gains, rare catastrophic losses). The 2018 Volmageddon event
+demonstrates the structural risk. See ARCHIVE.md for full ceiling analysis.
+
+## How to Run
+
+**Lean CLI:**
+```bash
+lean backtest --project .
+```
+
+**QC Cloud:** Not yet deployed. Copy files to a new QC Cloud project to run.
+
+## Backtest Metrics (2015-2026)
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | +0.05 |
+| Strategy | Long SVXY in contango |
+| Signal | VIX vs VIX3M spread |
+| Risk | Volmageddon tail risk |
+
+## Files
+
+- `main.py` - Strategy (v4.1, VIX term structure contango signal)
+- `research.ipynb` - VIX spread analysis and regime testing
+
+## References
+
+- Simon & Campasano (2014), "The VIX Fix"
+- ARCHIVE.md - Full iteration history and structural ceiling analysis


### PR DESCRIPTION
## Summary

- Add standardized README.md files for 62 QC projects that had no documentation
- Covers HandsOn Section 06 examples (Ex01-Ex19), archived strategies, template/skeleton projects, QC Library clones, and active research projects
- Same methodology as Batch 1 (PR #419): title, asset class, cloud project ID, description, how to run, backtest metrics, files inventory, references

## Categories

| Category | Count | Examples |
|----------|-------|---------|
| HandsOn Section 06 (Ex01-Ex19) | 18 | ML-Trend-Scanning, Dividend-Harvesting-ML, ML-Chronos-Foundation |
| Archived strategies | 6 | SectorMomentum, TurnOfMonth, VIX-TermStructure |
| Active strategies | 16 | EMA-Cross-Stocks, BlackLitterman-Momentum, CausalEventAlpha |
| QC Library clones | 7 | DynamicVIXSpyRegime-QC, LeveragedETFMomentum-QC |
| Template/skeleton | 6 | ML-DeepLearning, RL-Portfolio, ML-Ensemble |
| Other research | 9 | BTC-MACD-ADX, HMM-KMeans-Voting, Markov-Regime-Detection |

## Test plan

- [x] All 62 README.md files created with consistent template
- [x] Cloud project IDs verified against config.json files (7 of 89 have cloud-ids)
- [x] QC Library clones annotated with "Metrics from original library, not locally reproduced"
- [x] Template/skeleton projects marked as "no active strategy"
- [x] Archived strategies include Status and ceiling explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>