### PR TITLE
feat(sudoku-9): Antoine Gaillard Welsh-Powell exercise (supersedes #418)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "403f4734",
    "metadata": {
     "papermill": {
-     "duration": 0.002552,
-     "end_time": "2026-02-25T17:11:17.707031",
+     "duration": 0.002,
+     "end_time": "2026-04-22T09:04:52.364880",
      "exception": false,
-     "start_time": "2026-02-25T17:11:17.704479",
+     "start_time": "2026-04-22T09:04:52.362880",
      "status": "completed"
     },
     "tags": []
@@ -36,27 +36,38 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "34a69449",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:17.713116Z",
-     "iopub.status.busy": "2026-02-25T17:11:17.712740Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.164299Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.162998Z"
-    },
-    "papermill": {
-     "duration": 0.456609,
-     "end_time": "2026-02-25T17:11:18.166094",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:17.709485",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:09:58.419713Z",
      "start_time": "2026-04-20T08:09:57.302191300Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.368881Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.368881Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.487641Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.487641Z"
+    },
+    "papermill": {
+     "duration": 0.121753,
+     "end_time": "2026-04-22T09:04:52.488634",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.366881",
+     "status": "completed"
+    },
+    "tags": []
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NetworkX version: 3.4.2\n",
+      "Graphes Sudoku disponibles: True\n"
+     ]
+    }
+   ],
    "source": [
     "# Imports\n",
     "import time\n",
@@ -65,28 +76,17 @@
     "\n",
     "print(f\"NetworkX version: {nx.__version__}\")\n",
     "print(f\"Graphes Sudoku disponibles: {hasattr(nx, 'sudoku_graph')}\")\n"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NetworkX version: 3.5\n",
-      "Graphes Sudoku disponibles: True\n"
-     ]
-    }
-   ],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e3b99014",
    "metadata": {
     "papermill": {
-     "duration": 0.002479,
-     "end_time": "2026-02-25T17:11:18.171649",
+     "duration": 0.001001,
+     "end_time": "2026-04-22T09:04:52.491635",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.169170",
+     "start_time": "2026-04-22T09:04:52.490634",
      "status": "completed"
     },
     "tags": []
@@ -112,28 +112,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "a896d02a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:18.178757Z",
-     "iopub.status.busy": "2026-02-25T17:11:18.178030Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.187307Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.186095Z"
-    },
-    "papermill": {
-     "duration": 0.014767,
-     "end_time": "2026-02-25T17:11:18.189140",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:18.174373",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:11:59.270566100Z",
      "start_time": "2026-04-20T08:11:59.150112600Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.495634Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.495634Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.503860Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.502859Z"
+    },
+    "papermill": {
+     "duration": 0.010225,
+     "end_time": "2026-04-22T09:04:52.503860",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.493635",
+     "status": "completed"
+    },
+    "tags": []
    },
-   "source": "# Configuration du chemin vers les puzzles\nfrom pathlib import Path\n\nNOTEBOOK_DIR = Path.cwd()\nPUZZLES_DIR = NOTEBOOK_DIR / \"Puzzles\"\n\ndef load_puzzles(filepath: str, max_puzzles: int = None) -> List[str]:\n    puzzles = []\n    with open(filepath, \"r\") as f:\n        for line in f:\n            line = line.strip()\n            if len(line) >= 81:\n                puzzles.append(line[:81])\n                if max_puzzles and len(puzzles) >= max_puzzles:\n                    break\n    return puzzles\n\neasy_puzzles = load_puzzles(str(PUZZLES_DIR / \"Sudoku_Easy51.txt\"), max_puzzles=10)\nprint(f\"Puzzles charges: {len(easy_puzzles)} faciles\")",
    "outputs": [
     {
      "name": "stdout",
@@ -143,17 +143,37 @@
      ]
     }
    ],
-   "execution_count": 2
+   "source": [
+    "# Configuration du chemin vers les puzzles\n",
+    "from pathlib import Path\n",
+    "\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
+    "PUZZLES_DIR = NOTEBOOK_DIR / \"Puzzles\"\n",
+    "\n",
+    "def load_puzzles(filepath: str, max_puzzles: int = None) -> List[str]:\n",
+    "    puzzles = []\n",
+    "    with open(filepath, \"r\") as f:\n",
+    "        for line in f:\n",
+    "            line = line.strip()\n",
+    "            if len(line) >= 81:\n",
+    "                puzzles.append(line[:81])\n",
+    "                if max_puzzles and len(puzzles) >= max_puzzles:\n",
+    "                    break\n",
+    "    return puzzles\n",
+    "\n",
+    "easy_puzzles = load_puzzles(str(PUZZLES_DIR / \"Sudoku_Easy51.txt\"), max_puzzles=10)\n",
+    "print(f\"Puzzles charges: {len(easy_puzzles)} faciles\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b6bb9148",
    "metadata": {
     "papermill": {
-     "duration": 0.00235,
-     "end_time": "2026-02-25T17:11:18.194529",
+     "duration": 0.000999,
+     "end_time": "2026-04-22T09:04:52.506860",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.192179",
+     "start_time": "2026-04-22T09:04:52.505861",
      "status": "completed"
     },
     "tags": []
@@ -166,40 +186,28 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "a8c8438a",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:18.203749Z",
-     "iopub.status.busy": "2026-02-25T17:11:18.203003Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.211469Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.210511Z"
-    },
-    "papermill": {
-     "duration": 0.015556,
-     "end_time": "2026-02-25T17:11:18.213027",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:18.197471",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:12:07.781825Z",
      "start_time": "2026-04-20T08:12:07.647028300Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.510862Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.509859Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.518365Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.518365Z"
+    },
+    "papermill": {
+     "duration": 0.010506,
+     "end_time": "2026-04-22T09:04:52.519365",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.508859",
+     "status": "completed"
+    },
+    "tags": []
    },
-   "source": [
-    "# Creer le graphe Sudoku avec NetworkX\n",
-    "G = nx.sudoku_graph()\n",
-    "\n",
-    "print(\"=== Statistiques du Graphe Sudoku ===\")\n",
-    "print(f\"Sommets: {G.number_of_nodes()}\")\n",
-    "print(f\"Aretes: {G.number_of_edges()}\")\n",
-    "\n",
-    "# Verifier que c'est un graphe regulier\n",
-    "degrees = [d for n, d in G.degree()]\n",
-    "print(f\"Degre min: {min(degrees)}, max: {max(degrees)}\")\n",
-    "print(f\"Graphe regulier: {len(set(degrees)) == 1}\")\n"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -213,17 +221,29 @@
      ]
     }
    ],
-   "execution_count": 3
+   "source": [
+    "# Creer le graphe Sudoku avec NetworkX\n",
+    "G = nx.sudoku_graph()\n",
+    "\n",
+    "print(\"=== Statistiques du Graphe Sudoku ===\")\n",
+    "print(f\"Sommets: {G.number_of_nodes()}\")\n",
+    "print(f\"Aretes: {G.number_of_edges()}\")\n",
+    "\n",
+    "# Verifier que c'est un graphe regulier\n",
+    "degrees = [d for n, d in G.degree()]\n",
+    "print(f\"Degre min: {min(degrees)}, max: {max(degrees)}\")\n",
+    "print(f\"Graphe regulier: {len(set(degrees)) == 1}\")\n"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "50545bc9",
    "metadata": {
     "papermill": {
-     "duration": 0.002269,
-     "end_time": "2026-02-25T17:11:18.218014",
+     "duration": 0.002003,
+     "end_time": "2026-04-22T09:04:52.522368",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.215745",
+     "start_time": "2026-04-22T09:04:52.520365",
      "status": "completed"
     },
     "tags": []
@@ -245,10 +265,10 @@
    "id": "b9920bf3",
    "metadata": {
     "papermill": {
-     "duration": 0.002476,
-     "end_time": "2026-02-25T17:11:18.222810",
+     "duration": 0.002,
+     "end_time": "2026-04-22T09:04:52.525368",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.220334",
+     "start_time": "2026-04-22T09:04:52.523368",
      "status": "completed"
     },
     "tags": []
@@ -259,27 +279,48 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "ee1b47b6",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:18.230083Z",
-     "iopub.status.busy": "2026-02-25T17:11:18.229575Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.239473Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.238214Z"
-    },
-    "papermill": {
-     "duration": 0.015529,
-     "end_time": "2026-02-25T17:11:18.241394",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:18.225865",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:14:06.338802100Z",
      "start_time": "2026-04-20T08:14:06.261561900Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.528370Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.528370Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.534371Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.534371Z"
+    },
+    "papermill": {
+     "duration": 0.008003,
+     "end_time": "2026-04-22T09:04:52.534371",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.526368",
+     "status": "completed"
+    },
+    "tags": []
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle facile:\n",
+      "9 . 2 | . . 5 | 4 . 3 \n",
+      "1 . . | . 6 3 | . 2 5 \n",
+      "5 . 8 | 4 . 7 | . 6 . \n",
+      "---------------------\n",
+      ". 2 6 | 3 . 9 | . . 1 \n",
+      ". 5 7 | . 1 . | 2 9 . \n",
+      ". 9 . | 6 7 . | 5 3 . \n",
+      "---------------------\n",
+      "2 4 . | 5 3 . | 6 . . \n",
+      "7 . 5 | 2 . . | 3 . 4 \n",
+      ". 8 . | . 4 1 | 9 5 . \n"
+     ]
+    }
+   ],
    "source": [
     "class SudokuGrid:\n",
     "    \"\"\"Representation d'une grille de Sudoku 9x9.\"\"\"\n",
@@ -333,38 +374,17 @@
     "test_grid = SudokuGrid.from_string(easy_puzzles[0])\n",
     "print(\"Puzzle facile:\")\n",
     "print(test_grid)\n"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Puzzle facile:\n",
-      "9 . 2 | . . 5 | 4 . 3 \n",
-      "1 . . | . 6 3 | . 2 5 \n",
-      "5 . 8 | 4 . 7 | . 6 . \n",
-      "---------------------\n",
-      ". 2 6 | 3 . 9 | . . 1 \n",
-      ". 5 7 | . 1 . | 2 9 . \n",
-      ". 9 . | 6 7 . | 5 3 . \n",
-      "---------------------\n",
-      "2 4 . | 5 3 . | 6 . . \n",
-      "7 . 5 | 2 . . | 3 . 4 \n",
-      ". 8 . | . 4 1 | 9 5 . \n"
-     ]
-    }
-   ],
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "69b3809b",
    "metadata": {
     "papermill": {
-     "duration": 0.002285,
-     "end_time": "2026-02-25T17:11:18.246449",
+     "duration": 0.000999,
+     "end_time": "2026-04-22T09:04:52.537879",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.244164",
+     "start_time": "2026-04-22T09:04:52.536880",
      "status": "completed"
     },
     "tags": []
@@ -377,27 +397,65 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "e52a9d76",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:18.256012Z",
-     "iopub.status.busy": "2026-02-25T17:11:18.255536Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.268108Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.266849Z"
-    },
-    "papermill": {
-     "duration": 0.019123,
-     "end_time": "2026-02-25T17:11:18.270031",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:18.250908",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:15:12.717278800Z",
      "start_time": "2026-04-20T08:15:12.638358300Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.541880Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.541880Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.549879Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.549879Z"
+    },
+    "papermill": {
+     "duration": 0.010646,
+     "end_time": "2026-04-22T09:04:52.550527",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.539881",
+     "status": "completed"
+    },
+    "tags": []
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle a resoudre:\n",
+      "9 . 2 | . . 5 | 4 . 3 \n",
+      "1 . . | . 6 3 | . 2 5 \n",
+      "5 . 8 | 4 . 7 | . 6 . \n",
+      "---------------------\n",
+      ". 2 6 | 3 . 9 | . . 1 \n",
+      ". 5 7 | . 1 . | 2 9 . \n",
+      ". 9 . | 6 7 . | 5 3 . \n",
+      "---------------------\n",
+      "2 4 . | 5 3 . | 6 . . \n",
+      "7 . 5 | 2 . . | 3 . 4 \n",
+      ". 8 . | . 4 1 | 9 5 . \n",
+      "\n",
+      "Resolu: True en 1.00 ms\n",
+      "Noeuds explores: 37\n",
+      "Backtracks: 0\n",
+      "\n",
+      "Solution:\n",
+      "9 6 2 | 1 8 5 | 4 7 3 \n",
+      "1 7 4 | 9 6 3 | 8 2 5 \n",
+      "5 3 8 | 4 2 7 | 1 6 9 \n",
+      "---------------------\n",
+      "8 2 6 | 3 5 9 | 7 4 1 \n",
+      "3 5 7 | 8 1 4 | 2 9 6 \n",
+      "4 9 1 | 6 7 2 | 5 3 8 \n",
+      "---------------------\n",
+      "2 4 9 | 5 3 8 | 6 1 7 \n",
+      "7 1 5 | 2 9 6 | 3 8 4 \n",
+      "6 8 3 | 7 4 1 | 9 5 2 \n"
+     ]
+    }
+   ],
    "source": [
     "def solve_with_mrv_backtracking(grid: SudokuGrid) -> Tuple[bool, int, int]:\n",
     "    \"\"\"\n",
@@ -462,49 +520,21 @@
     "print(f\"Backtracks: {bts}\")\n",
     "print(\"\\nSolution:\")\n",
     "print(test_grid)\n"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Puzzle a resoudre:\n",
-      "9 . 2 | . . 5 | 4 . 3 \n",
-      "1 . . | . 6 3 | . 2 5 \n",
-      "5 . 8 | 4 . 7 | . 6 . \n",
-      "---------------------\n",
-      ". 2 6 | 3 . 9 | . . 1 \n",
-      ". 5 7 | . 1 . | 2 9 . \n",
-      ". 9 . | 6 7 . | 5 3 . \n",
-      "---------------------\n",
-      "2 4 . | 5 3 . | 6 . . \n",
-      "7 . 5 | 2 . . | 3 . 4 \n",
-      ". 8 . | . 4 1 | 9 5 . \n",
-      "\n",
-      "Resolu: True en 3.17 ms\n",
-      "Noeuds explores: 37\n",
-      "Backtracks: 0\n",
-      "\n",
-      "Solution:\n",
-      "9 6 2 | 1 8 5 | 4 7 3 \n",
-      "1 7 4 | 9 6 3 | 8 2 5 \n",
-      "5 3 8 | 4 2 7 | 1 6 9 \n",
-      "---------------------\n",
-      "8 2 6 | 3 5 9 | 7 4 1 \n",
-      "3 5 7 | 8 1 4 | 2 9 6 \n",
-      "4 9 1 | 6 7 2 | 5 3 8 \n",
-      "---------------------\n",
-      "2 4 9 | 5 3 8 | 6 1 7 \n",
-      "7 1 5 | 2 9 6 | 3 8 4 \n",
-      "6 8 3 | 7 4 1 | 9 5 2 \n"
-     ]
-    }
-   ],
-   "execution_count": 5
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "4taoqji9bpb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001998,
+     "end_time": "2026-04-22T09:04:52.553530",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.551532",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Backtracking avec MRV sur Graphe\n",
     "\n",
@@ -522,18 +552,17 @@
     "3. **Graphe regulier** : Tous les sommets ont degre 20, donc MRV se base sur les domaines\n",
     "\n",
     "> **Note technique** : L'heuristique MRV (Minimum Remaining Values) est particulierement efficace sur Sudoku car les contraintes locales (ligne, colonne, bloc) reduisent rapidement les domaines des cases voisines.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6f0fd4c0",
    "metadata": {
     "papermill": {
-     "duration": 0.002834,
-     "end_time": "2026-02-25T17:11:18.276629",
+     "duration": 0.001508,
+     "end_time": "2026-04-22T09:04:52.557039",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.273795",
+     "start_time": "2026-04-22T09:04:52.555531",
      "status": "completed"
     },
     "tags": []
@@ -544,27 +573,61 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "11e2b2f2",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-25T17:11:18.283564Z",
-     "iopub.status.busy": "2026-02-25T17:11:18.283051Z",
-     "iopub.status.idle": "2026-02-25T17:11:18.448493Z",
-     "shell.execute_reply": "2026-02-25T17:11:18.447336Z"
-    },
-    "papermill": {
-     "duration": 0.170609,
-     "end_time": "2026-02-25T17:11:18.450082",
-     "exception": false,
-     "start_time": "2026-02-25T17:11:18.279473",
-     "status": "completed"
-    },
-    "tags": [],
     "ExecuteTime": {
      "end_time": "2026-04-20T08:16:20.273985100Z",
      "start_time": "2026-04-20T08:16:19.956182900Z"
-    }
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.560039Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.560039Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.643714Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.643714Z"
+    },
+    "papermill": {
+     "duration": 0.086675,
+     "end_time": "2026-04-22T09:04:52.644714",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.558039",
+     "status": "completed"
+    },
+    "tags": []
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Benchmark: Puzzles Faciles (3 puzzles)\n",
+      "Succes: 3/3\n",
+      "Temps moyen: 5.16 ms\n",
+      "\n",
+      "Benchmark: Puzzles Difficiles (2 puzzles)\n",
+      "Succes: 2/2\n",
+      "Temps moyen: 30.30 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'success': True,\n",
+       "  'time_ms': 6.000041961669922,\n",
+       "  'nodes': 164,\n",
+       "  'backtracks': 104},\n",
+       " {'success': True,\n",
+       "  'time_ms': 54.59761619567871,\n",
+       "  'nodes': 1496,\n",
+       "  'backtracks': 1437}]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def benchmark(puzzles: List[str], name: str, limit: int = 5):\n",
     "    \"\"\"Benchmark de solveur MRV.\"\"\"\n",
@@ -589,45 +652,21 @@
     "\n",
     "hard_puzzles = load_puzzles(str(PUZZLES_DIR / \"Sudoku_hardest.txt\"))\n",
     "benchmark(hard_puzzles, \"Puzzles Difficiles\", limit=2)\n"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Benchmark: Puzzles Faciles (3 puzzles)\n",
-      "Succes: 3/3\n",
-      "Temps moyen: 4.44 ms\n",
-      "\n",
-      "Benchmark: Puzzles Difficiles (2 puzzles)\n",
-      "Succes: 2/2\n",
-      "Temps moyen: 43.82 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[{'success': True,\n",
-       "  'time_ms': 7.6007843017578125,\n",
-       "  'nodes': 164,\n",
-       "  'backtracks': 104},\n",
-       " {'success': True,\n",
-       "  'time_ms': 80.04879951477051,\n",
-       "  'nodes': 1496,\n",
-       "  'backtracks': 1437}]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "9mkm25kzhhd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001763,
+     "end_time": "2026-04-22T09:04:52.648476",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.646713",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Benchmark Graph Coloring\n",
     "\n",
@@ -649,12 +688,21 @@
     "3. **Graphe regulier** : Le degre constant (20) aide a comprendre la structure\n",
     "\n",
     "> **Note technique** : La coloration de graphe est un probleme NP-complet. Le Sudoku est un cas particulier avec une structure tres reguliere, ce qui permet des optimisations specifiques que NetworkX n'exploite pas.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ytp2bllgm1n",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-04-22T09:04:52.652476",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.650476",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple : Coloration avec l'Heuristique LCV\n",
     "\n",
@@ -676,12 +724,42 @@
     "### Avantage attendu\n",
     "\n",
     "LCV peut ralentir la recherche (calcul couteux) mais reduit les backtracks sur les puzzles difficiles en maintenant les domaines des voisins plus ouverts.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "dlfjm9oprek",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-20T08:45:27.227701600Z",
+     "start_time": "2026-04-20T08:45:26.966039400Z"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.656767Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.656767Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.689647Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.689647Z"
+    },
+    "papermill": {
+     "duration": 0.036449,
+     "end_time": "2026-04-22T09:04:52.690645",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.654196",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LCV - Noeuds: 182, Backtracks: 122\n",
+      "MRV pur - Noeuds: 164, Backtracks: 104\n"
+     ]
+    }
+   ],
    "source": [
     "def get_available_colors(vertex: int, coloring: List[int]) -> set:\n",
     "    used = set()\n",
@@ -782,28 +860,21 @@
     "success2, nodes2, bts2 = solve_with_mrv_backtracking(grid_test2)\n",
     "print(f\"MRV pur - Noeuds: {nodes2}, Backtracks: {bts2}\")\n",
     "#print(\"Exercice LCV a implementer !\")"
-   ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2026-04-20T08:45:27.227701600Z",
-     "start_time": "2026-04-20T08:45:26.966039400Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LCV - Noeuds: 182, Backtracks: 122\n",
-      "MRV pur - Noeuds: 164, Backtracks: 104\n"
-     ]
-    }
-   ],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e33c5566",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001504,
+     "end_time": "2026-04-22T09:04:52.694151",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.692647",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : LCV vs MRV pur\n",
     "\n",
@@ -821,12 +892,21 @@
     "3. **Graphe regulier** : Tous les sommets ayant le meme degre, l'avantage de LCV est moins marque que sur des graphes heterogenes\n",
     "\n",
     "> **Note technique** : LCV est plus utile sur des graphes avec des degres heterogenes (certains sommets beaucoup plus contraints que d'autres). Sur le graphe Sudoku regulier (deg. 20 partout), le gain est limite par le cout de calcul.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "5b18e409",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001,
+     "end_time": "2026-04-22T09:04:52.697155",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.696155",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Heuristique Welsh-Powell\n",
     "\n",
@@ -858,19 +938,48 @@
     "Le degre actuel d'un sommet non colorie est le nombre de ses voisins qui sont egalement non colories. Plus ce degre est eleve, plus le sommet est contraint et doit etre colorie prioritairement.\n",
     "\n",
     "Welsh-Powell est une heuristique gloutonne classique qui performe bien sur les graphes de coloration generaux, mais peut etre moins efficace que MRV sur Sudoku ou la structure est tres reguliere.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "39831a5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T09:04:52.702350Z",
+     "iopub.status.busy": "2026-04-22T09:04:52.702350Z",
+     "iopub.status.idle": "2026-04-22T09:04:52.737955Z",
+     "shell.execute_reply": "2026-04-22T09:04:52.737377Z"
+    },
+    "papermill": {
+     "duration": 0.039608,
+     "end_time": "2026-04-22T09:04:52.738958",
+     "exception": false,
+     "start_time": "2026-04-22T09:04:52.699350",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welsh-Powell (easy[0]) - Succes: True, Noeuds: 992, Backtracks: 955\n",
+      "MRV (easy[0]) - Succes: True, Noeuds: 37, Backtracks: 0\n"
+     ]
+    }
+   ],
    "source": [
     "def sort_vertices_by_degree(coloring: List[int], G) -> List[int]:\n",
     "    \"\"\"\n",
     "    Retourne la liste des sommets non colories tries par degre decroissant.\n",
     "    Le degre compte les voisins non colories seulement.\n",
     "    \"\"\"\n",
-    "    raise NotImplementedError(\"TODO: Implementer le tri par degre decroissant\")\n",
+    "    uncolored = [v for v in range(81) if coloring[v] == 0]\n",
+    "    def get_degree(v):\n",
+    "        return sum(1 for neighbor in G.neighbors(v) if coloring[neighbor] == 0)\n",
+    "    return sorted(uncolored, key=get_degree, reverse=True)\n",
     "\n",
     "def solve_with_welsh_powell(grid: SudokuGrid) -> tuple:\n",
     "    \"\"\"\n",
@@ -878,30 +987,70 @@
     "    Welsh-Powell: choisir le sommet non colorie avec le plus grand degre actuel.\n",
     "    Retourne (success, nodes_explored, backtracks).\n",
     "    \"\"\"\n",
-    "    raise NotImplementedError(\"TODO: Implementer le solveur Welsh-Powell\")\n",
+    "    G = nx.sudoku_graph()\n",
+    "    coloring = grid.to_coloring()\n",
+    "    nodes_explored = 0\n",
+    "    backtracks = 0\n",
+    "    \n",
+    "    def get_available_colors(vertex: int, coloring: List[int]) -> set:\n",
+    "        used = set()\n",
+    "        for neighbor in G.neighbors(vertex):\n",
+    "            if coloring[neighbor] != 0:\n",
+    "                used.add(coloring[neighbor])\n",
+    "        return set(range(1, 10)) - used\n",
+    "    \n",
+    "    def backtrack(coloring: List[int]) -> bool:\n",
+    "        nonlocal nodes_explored, backtracks\n",
+    "        nodes_explored += 1\n",
+    "        \n",
+    "        sorted_vertices = sort_vertices_by_degree(coloring, G)\n",
+    "        if not sorted_vertices:\n",
+    "            return True\n",
+    "            \n",
+    "        vertex = sorted_vertices[0]\n",
+    "        \n",
+    "        for color in sorted(list(get_available_colors(vertex, coloring))):\n",
+    "            coloring[vertex] = color\n",
+    "            if backtrack(coloring):\n",
+    "                return True\n",
+    "            coloring[vertex] = 0\n",
+    "            backtracks += 1\n",
+    "        return False\n",
+    "        \n",
+    "    success = backtrack(coloring)\n",
+    "    grid.from_coloring(coloring)\n",
+    "    return success, nodes_explored, backtracks\n",
     "\n",
-    "# Test comparatif Welsh-Powell vs MRV\n",
-    "# grid_test = SudokuGrid.from_string(hard_puzzles[0])\n",
-    "# success, nodes, bts = solve_with_welsh_powell(grid_test)\n",
-    "# print(f\"Welsh-Powell - Noeuds: {nodes}, Backtracks: {bts}\")\n",
-    "#\n",
-    "# grid_test2 = SudokuGrid.from_string(hard_puzzles[0])\n",
-    "# success2, nodes2, bts2 = solve_with_mrv_backtracking(grid_test2)\n",
-    "# print(f\"MRV - Noeuds: {nodes2}, Backtracks: {bts2}\")\n"
-   ],
-   "metadata": {},
-   "execution_count": 8,
-   "outputs": []
+    "# Test comparatif Welsh-Powell vs MRV sur un puzzle facile.\n",
+    "# Note: Welsh-Powell selectionne le sommet de plus haut degre non colorie. Sur un graphe\n",
+    "# Sudoku regulier (tous degre 20), cette heuristique n'apporte pas de guide efficace\n",
+    "# et tombe vite dans de longues branches de backtracking sur les puzzles difficiles.\n",
+    "# Les puzzles difficiles peuvent necessiter sys.setrecursionlimit() eleve et un stack Python\n",
+    "# agrandi pour terminer ; on utilise ici un puzzle easy pour un benchmark reproductible.\n",
+    "grid_test = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "success, nodes, bts = solve_with_welsh_powell(grid_test)\n",
+    "print(f\"Welsh-Powell (easy[0]) - Succes: {success}, Noeuds: {nodes}, Backtracks: {bts}\")\n",
+    "\n",
+    "grid_test2 = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "success2, nodes2, bts2 = solve_with_mrv_backtracking(grid_test2)\n",
+    "print(f\"MRV (easy[0]) - Succes: {success2}, Noeuds: {nodes2}, Backtracks: {bts2}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10f7be5f",
+   "source": "### Interpretation : Welsh-Powell vs MRV sur Sudoku\n\nLes resultats sur le meme puzzle `easy_puzzles[0]` illustrent clairement les limites de Welsh-Powell dans ce contexte.\n\n| Methode | Noeuds explores | Backtracks | Analyse |\n|---------|-----------------|------------|---------|\n| **Welsh-Powell** | 992 | 955 | Beaucoup de retours en arriere |\n| **MRV pur** | 37 | 0 | Resolution sans erreur |\n\n**Points cles** :\n\n1. **Welsh-Powell est correct mais sous-optimal** : L'algorithme produit une coloration valide (solution Sudoku complete), mais au prix d'un nombre de backtracks tres eleve.\n2. **Graphe regulier = heuristique inoperante** : Sur le graphe Sudoku, tous les sommets non colories ont un degre similaire (proche de 20). Le tri par degre decroissant n'apporte donc pas de guide discriminant, et le choix du premier sommet devient quasi-arbitraire.\n3. **MRV exploite la propagation des contraintes** : Choisir le sommet avec le **moins** de couleurs disponibles contraint mecaniquement la recherche : les sommets \"faciles\" sont resolus tot, les difficiles apparaissent quand le contexte est deja mieux contraint.\n4. **Generalisation** : Welsh-Powell reste pertinent sur des graphes a degres heterogenes (graphes de registres pour l'allocation, graphes sociaux, etc.). Pour le Sudoku et les problemes reguliers fortement contraints, MRV et ses variantes (MRV + LCV, dom/deg) sont plus adaptees.\n\n> **Note technique** : Sur les puzzles plus difficiles (`Sudoku_hardest.txt`, `Sudoku_top95.txt`), Welsh-Powell peut partir en branches de recherche tres profondes. Un `sys.setrecursionlimit(50000)` est alors necessaire pour eviter un `RecursionError`, et sur Windows la taille de stack Python par defaut (1 MB) peut encore limiter ; les benchmarks sur puzzles difficiles sont donc laisses de cote dans ce notebook pour rester reproductible.\n",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
    "id": "022b15c7",
    "metadata": {
     "papermill": {
-     "duration": 0.003942,
-     "end_time": "2026-02-25T17:11:18.458201",
+     "duration": 0.001001,
+     "end_time": "2026-04-22T09:04:52.741958",
      "exception": false,
-     "start_time": "2026-02-25T17:11:18.454259",
+     "start_time": "2026-04-22T09:04:52.740957",
      "status": "completed"
     },
     "tags": []
@@ -947,18 +1096,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.849021,
-   "end_time": "2026-02-25T17:11:18.799455",
+   "duration": 4.332196,
+   "end_time": "2026-04-22T09:04:55.697075",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb",
    "parameters": {},
-   "start_time": "2026-02-25T17:11:14.950434",
+   "start_time": "2026-04-22T09:04:51.364879",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Supersedes PR #418

Travail etudiant de @AntoineGailrd sur l'exercice Welsh-Powell de Sudoku-9-GraphColoring-Python.

### Pourquoi une supersede

La PR #418 de l'etudiant est basee sur un main obsolete (anterieur a #416, #419, #421, #430, #412). Merger telle quelle reverterait :
- 12 README QC (projets EMA-Cross-Alpha, ForexCarry, SectorMomentum, etc.)
- `QUANTCONNECT_PROJECTS_AUDIT.md` (217 lignes)
- `CSP-4-Scheduling.ipynb` travail de Jules Lange merge via #430

Cette PR extrait uniquement le travail legitime de l'etudiant sur Sudoku-9 + ajoute des corrections coordinateur minimales.

### Travail etudiant conserve

- `sort_vertices_by_degree(coloring, G)` : tri des sommets non colories par degre decroissant
- `solve_with_welsh_powell(grid)` : backtracking + heuristique Welsh-Powell
- Code structurellement correct (verifie : produit solutions Sudoku valides sur easy puzzles)

### Modifications coordinateur

- **Test final cellule 19** bascule de `hard_puzzles[0]` -> `easy_puzzles[0]` pour benchmark reproductible
  - `hard_puzzles` est defini en cell 13 (benchmark) mais Welsh-Powell sur graphe Sudoku regulier explose en recursion (Sudoku_hardest[0] segfault meme avec sys.setrecursionlimit + stack 64MB)
  - `easy_puzzles[0]` execute en 0.01s et illustre clairement le point pedagogique
- **Nouvelle cellule markdown** d'interpretation (Welsh-Powell 992 noeuds / 955 backtracks vs MRV 37 noeuds / 0 backtracks sur le meme puzzle) explicitant pourquoi Welsh-Powell est sous-optimal sur un graphe regulier
- **Execution Papermill** effectuee, cell 19 a bien son output

### Verdict pedagogique

- Algo Welsh-Powell **correct** (pas "fails" comme indique par erreur dans une review precedente)
- Sous-optimal sur Sudoku (graphe regulier degre 20) -> bonne matiere pedagogique pour montrer les limites des heuristiques gloutonnes
- Comparaison Welsh-Powell vs MRV illustre la difference entre heuristique de choix de sommet (degre) vs exploitation de la propagation de contraintes (domaine)

### Verification anti-regression

- Diff limite a 1 fichier : `MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb`
- Aucun revert des merges recents
- `git diff main --stat` : 1 file, 412 insertions, 263 deletions (enrichissement pedagogique conforme)

Closes #418

Co-Authored-By: AntoineGailrd <antoine.gaillard@epita.fr>