### PR TITLE
fix(readme): correct obsolete path and remove broken links

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -262,10 +262,7 @@ jupyter lab
 2. **Configuration** : Créez un fichier `.env` dans `MyIA.AI.Notebooks/GenAI/`
 3. **Utilisation** : Les notebooks chargent automatiquement les credentials
 
-📖 **Documentation complète** :
-- **Guide Étudiants** : [`README-ETUDIANTS-AUTH.md`](README-ETUDIANTS-AUTH.md) - Configuration pas-à-pas
-- **Documentation Technique** : [`README-AUTH.md`](README-AUTH.md) - Architecture d'authentification
-- **Scripts Admin** : [`scripts/genai-auth/`](../../scripts/genai-auth/) - Gestion des tokens
+📖 **Documentation complète** : voir `00-GenAI-Environment/` pour la configuration pas-à-pas.
 
 ### ⚠️ **Important**
 - ✅ Tous les notebooks supportent l'authentification (graceful degradation si désactivée)
@@ -450,10 +447,7 @@ print(result.stdout.split('\n')[0])  # Affiche la version
 - `shared/` - Utilitaires Python partagés
 
 ### 📖 **Documentation**
-- [Architecture Complète](../../docs/genai-image-architecture.md)
-- [Templates Phase 2](../../docs/genai-phase2-templates.md)  
-- [Standards Développement](../../docs/genai-images-development-standards.md)
-- [Guide Déploiement](../../docs/genai-deployment-production-ready.md)
+- [Mission Images GenAI](../../docs/genai-images-mission-complete.md)
 
 ### 🔗 **Intégrations**
 - **MCP Jupyter** : Exécution notebooks automatisée

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ CoursIA/
 ├── scripts/                     # Scripts utilitaires
 │   ├── notebook_tools.py        # CLI : validate, skeleton, analyze, check-env
 │   ├── notebook_helpers.py      # Helpers pour manipulation notebooks
-│   ├── extract_notebook_skeleton.py  # Extraction structure pour README
+│   ├── notebook_tools/          # Notebook tools subdirectory
+│   │   └── extract_notebook_skeleton.py  # Extraction structure pour README
 │   └── genai-stack/             # Validation GenAI (Docker, Papermill)
 │
 ├── docker-configurations/       # Infrastructure Docker GPU
@@ -572,7 +573,7 @@ docker-configurations/
 |--------|--------|-------|
 | `notebook_tools.py` | `scripts/` | CLI consolide : skeleton, validate, analyze, check-env |
 | `notebook_helpers.py` | `scripts/` | Helpers pour manipulation notebooks et iteration cellules |
-| `extract_notebook_skeleton.py` | `scripts/` | Extraction structure pour generation README |
+| `extract_notebook_skeleton.py` | `scripts/notebook_tools/` | Extraction structure pour generation README |
 | `validate_notebooks.py` | `scripts/genai-stack/` | Validation GenAI via Papermill |
 | `validate_stack.py` | `scripts/genai-stack/` | Validation ecosysteme GenAI complet |
 | `check_vram.py` | `scripts/genai-stack/` | Verification VRAM disponible |


### PR DESCRIPTION
## Summary
- Fix obsolete path for `extract_notebook_skeleton.py` in main README (tree + table): `scripts/` → `scripts/notebook_tools/`
- Remove 3 broken auth doc links from GenAI/README.md (README-ETUDIANTS-AUTH.md, README-AUTH.md, scripts/genai-auth/ — files don't exist)
- Replace 4 broken doc links in GenAI/README.md with the only existing one (`genai-images-mission-complete.md`)

## Scope
8 errors from README audit. 18 warnings intentionally excluded (separate PR later).

## Validation
- `extract_notebook_skeleton.py` confirmed at `scripts/notebook_tools/` via Glob
- All 7 removed links verified non-existent via Glob/Grep
- Only surviving doc: `docs/genai-images-mission-complete.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>