### PR TITLE
fix(csp-8): recycle solutions into Exemples resolus + new exercise stubs

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.004572,
-     "end_time": "2026-04-22T15:45:43.489285",
+     "duration": 0.004968,
+     "end_time": "2026-04-22T17:48:34.672339",
      "exception": false,
-     "start_time": "2026-04-22T15:45:43.484713",
+     "start_time": "2026-04-22T17:48:34.667371",
      "status": "completed"
     },
     "tags": []
@@ -45,16 +45,16 @@
    "id": "setup-temporal",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:43.498083Z",
-     "iopub.status.busy": "2026-04-22T15:45:43.497769Z",
-     "iopub.status.idle": "2026-04-22T15:45:44.275985Z",
-     "shell.execute_reply": "2026-04-22T15:45:44.275294Z"
+     "iopub.execute_input": "2026-04-22T17:48:34.681907Z",
+     "iopub.status.busy": "2026-04-22T17:48:34.681528Z",
+     "iopub.status.idle": "2026-04-22T17:48:35.448010Z",
+     "shell.execute_reply": "2026-04-22T17:48:35.447019Z"
     },
     "papermill": {
-     "duration": 0.783884,
-     "end_time": "2026-04-22T15:45:44.277304",
+     "duration": 0.772724,
+     "end_time": "2026-04-22T17:48:35.449347",
      "exception": false,
-     "start_time": "2026-04-22T15:45:43.493420",
+     "start_time": "2026-04-22T17:48:34.676623",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "section-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004284,
-     "end_time": "2026-04-22T15:45:44.286138",
+     "duration": 0.005428,
+     "end_time": "2026-04-22T17:48:35.459460",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.281854",
+     "start_time": "2026-04-22T17:48:35.454032",
      "status": "completed"
     },
     "tags": []
@@ -135,10 +135,10 @@
    "id": "section-2-allen",
    "metadata": {
     "papermill": {
-     "duration": 0.003736,
-     "end_time": "2026-04-22T15:45:44.293746",
+     "duration": 0.004905,
+     "end_time": "2026-04-22T17:48:35.469515",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.290010",
+     "start_time": "2026-04-22T17:48:35.464610",
      "status": "completed"
     },
     "tags": []
@@ -180,16 +180,16 @@
    "id": "allen-relations",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:44.304838Z",
-     "iopub.status.busy": "2026-04-22T15:45:44.304240Z",
-     "iopub.status.idle": "2026-04-22T15:45:44.312913Z",
-     "shell.execute_reply": "2026-04-22T15:45:44.312254Z"
+     "iopub.execute_input": "2026-04-22T17:48:35.479920Z",
+     "iopub.status.busy": "2026-04-22T17:48:35.479487Z",
+     "iopub.status.idle": "2026-04-22T17:48:35.486201Z",
+     "shell.execute_reply": "2026-04-22T17:48:35.485608Z"
     },
     "papermill": {
-     "duration": 0.016679,
-     "end_time": "2026-04-22T15:45:44.314421",
+     "duration": 0.013146,
+     "end_time": "2026-04-22T17:48:35.487317",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.297742",
+     "start_time": "2026-04-22T17:48:35.474171",
      "status": "completed"
     },
     "tags": []
@@ -262,10 +262,10 @@
    "id": "009fdad6",
    "metadata": {
     "papermill": {
-     "duration": 0.004296,
-     "end_time": "2026-04-22T15:45:44.324436",
+     "duration": 0.004054,
+     "end_time": "2026-04-22T17:48:35.495681",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.320140",
+     "start_time": "2026-04-22T17:48:35.491627",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +282,16 @@
    "id": "allen-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:44.332732Z",
-     "iopub.status.busy": "2026-04-22T15:45:44.332449Z",
-     "iopub.status.idle": "2026-04-22T15:45:44.793618Z",
-     "shell.execute_reply": "2026-04-22T15:45:44.792932Z"
+     "iopub.execute_input": "2026-04-22T17:48:35.506813Z",
+     "iopub.status.busy": "2026-04-22T17:48:35.506454Z",
+     "iopub.status.idle": "2026-04-22T17:48:35.941063Z",
+     "shell.execute_reply": "2026-04-22T17:48:35.940281Z"
     },
     "papermill": {
-     "duration": 0.466709,
-     "end_time": "2026-04-22T15:45:44.794708",
+     "duration": 0.441727,
+     "end_time": "2026-04-22T17:48:35.942113",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.327999",
+     "start_time": "2026-04-22T17:48:35.500386",
      "status": "completed"
     },
     "tags": []
@@ -371,10 +371,10 @@
    "id": "djqnxo5337",
    "metadata": {
     "papermill": {
-     "duration": 0.003786,
-     "end_time": "2026-04-22T15:45:44.802886",
+     "duration": 0.00477,
+     "end_time": "2026-04-22T17:48:35.952288",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.799100",
+     "start_time": "2026-04-22T17:48:35.947518",
      "status": "completed"
     },
     "tags": []
@@ -403,10 +403,10 @@
    "id": "section-3-stp",
    "metadata": {
     "papermill": {
-     "duration": 0.004466,
-     "end_time": "2026-04-22T15:45:44.811153",
+     "duration": 0.004293,
+     "end_time": "2026-04-22T17:48:35.961104",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.806687",
+     "start_time": "2026-04-22T17:48:35.956811",
      "status": "completed"
     },
     "tags": []
@@ -440,16 +440,16 @@
    "id": "stp-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:44.821196Z",
-     "iopub.status.busy": "2026-04-22T15:45:44.820749Z",
-     "iopub.status.idle": "2026-04-22T15:45:44.828625Z",
-     "shell.execute_reply": "2026-04-22T15:45:44.828015Z"
+     "iopub.execute_input": "2026-04-22T17:48:35.971496Z",
+     "iopub.status.busy": "2026-04-22T17:48:35.970937Z",
+     "iopub.status.idle": "2026-04-22T17:48:35.979846Z",
+     "shell.execute_reply": "2026-04-22T17:48:35.979218Z"
     },
     "papermill": {
-     "duration": 0.014655,
-     "end_time": "2026-04-22T15:45:44.829475",
+     "duration": 0.015519,
+     "end_time": "2026-04-22T17:48:35.980945",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.814820",
+     "start_time": "2026-04-22T17:48:35.965426",
      "status": "completed"
     },
     "tags": []
@@ -542,10 +542,10 @@
    "id": "ff62427b",
    "metadata": {
     "papermill": {
-     "duration": 0.003993,
-     "end_time": "2026-04-22T15:45:44.837612",
+     "duration": 0.004401,
+     "end_time": "2026-04-22T17:48:35.989873",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.833619",
+     "start_time": "2026-04-22T17:48:35.985472",
      "status": "completed"
     },
     "tags": []
@@ -562,16 +562,16 @@
    "id": "stp-example",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:44.846955Z",
-     "iopub.status.busy": "2026-04-22T15:45:44.846228Z",
-     "iopub.status.idle": "2026-04-22T15:45:44.853369Z",
-     "shell.execute_reply": "2026-04-22T15:45:44.852534Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.000257Z",
+     "iopub.status.busy": "2026-04-22T17:48:35.999760Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.005649Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.004996Z"
     },
     "papermill": {
-     "duration": 0.012975,
-     "end_time": "2026-04-22T15:45:44.854505",
+     "duration": 0.012263,
+     "end_time": "2026-04-22T17:48:36.006653",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.841530",
+     "start_time": "2026-04-22T17:48:35.994390",
      "status": "completed"
     },
     "tags": []
@@ -629,10 +629,10 @@
    "id": "769amh53sz3",
    "metadata": {
     "papermill": {
-     "duration": 0.004118,
-     "end_time": "2026-04-22T15:45:44.865519",
+     "duration": 0.004316,
+     "end_time": "2026-04-22T17:48:36.015472",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.861401",
+     "start_time": "2026-04-22T17:48:36.011156",
      "status": "completed"
     },
     "tags": []
@@ -663,16 +663,16 @@
    "id": "stp-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:44.874843Z",
-     "iopub.status.busy": "2026-04-22T15:45:44.874534Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.009399Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.008290Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.025182Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.024705Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.140498Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.139315Z"
     },
     "papermill": {
-     "duration": 0.14114,
-     "end_time": "2026-04-22T15:45:45.010748",
+     "duration": 0.122079,
+     "end_time": "2026-04-22T17:48:36.141692",
      "exception": false,
-     "start_time": "2026-04-22T15:45:44.869608",
+     "start_time": "2026-04-22T17:48:36.019613",
      "status": "completed"
     },
     "tags": []
@@ -727,10 +727,10 @@
    "id": "eia6je5saga",
    "metadata": {
     "papermill": {
-     "duration": 0.004412,
-     "end_time": "2026-04-22T15:45:45.021407",
+     "duration": 0.005356,
+     "end_time": "2026-04-22T17:48:36.152426",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.016995",
+     "start_time": "2026-04-22T17:48:36.147070",
      "status": "completed"
     },
     "tags": []
@@ -760,10 +760,10 @@
    "id": "section-4-tcsp",
    "metadata": {
     "papermill": {
-     "duration": 0.00466,
-     "end_time": "2026-04-22T15:45:45.030743",
+     "duration": 0.007879,
+     "end_time": "2026-04-22T17:48:36.167537",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.026083",
+     "start_time": "2026-04-22T17:48:36.159658",
      "status": "completed"
     },
     "tags": []
@@ -797,16 +797,16 @@
    "id": "tcsp-example",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.043522Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.043071Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.051486Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.050693Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.183047Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.182435Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.190748Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.190030Z"
     },
     "papermill": {
-     "duration": 0.017625,
-     "end_time": "2026-04-22T15:45:45.053180",
+     "duration": 0.01727,
+     "end_time": "2026-04-22T17:48:36.192545",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.035555",
+     "start_time": "2026-04-22T17:48:36.175275",
      "status": "completed"
     },
     "tags": []
@@ -889,10 +889,10 @@
    "id": "section-5-application",
    "metadata": {
     "papermill": {
-     "duration": 0.008367,
-     "end_time": "2026-04-22T15:45:45.070052",
+     "duration": 0.007377,
+     "end_time": "2026-04-22T17:48:36.207935",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.061685",
+     "start_time": "2026-04-22T17:48:36.200558",
      "status": "completed"
     },
     "tags": []
@@ -917,16 +917,16 @@
    "id": "meeting-planner",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.088360Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.087963Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.094841Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.094196Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.224539Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.224113Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.231373Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.230594Z"
     },
     "papermill": {
-     "duration": 0.017978,
-     "end_time": "2026-04-22T15:45:45.096467",
+     "duration": 0.018165,
+     "end_time": "2026-04-22T17:48:36.232393",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.078489",
+     "start_time": "2026-04-22T17:48:36.214228",
      "status": "completed"
     },
     "tags": []
@@ -1014,10 +1014,10 @@
    "id": "0432912b",
    "metadata": {
     "papermill": {
-     "duration": 0.007663,
-     "end_time": "2026-04-22T15:45:45.112756",
+     "duration": 0.005806,
+     "end_time": "2026-04-22T17:48:36.243325",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.105093",
+     "start_time": "2026-04-22T17:48:36.237519",
      "status": "completed"
     },
     "tags": []
@@ -1042,16 +1042,16 @@
    "id": "meeting-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.129749Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.129274Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.256645Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.255568Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.255453Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.255095Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.350208Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.349366Z"
     },
     "papermill": {
-     "duration": 0.137199,
-     "end_time": "2026-04-22T15:45:45.257884",
+     "duration": 0.103266,
+     "end_time": "2026-04-22T17:48:36.351498",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.120685",
+     "start_time": "2026-04-22T17:48:36.248232",
      "status": "completed"
     },
     "tags": []
@@ -1103,10 +1103,10 @@
    "id": "4okf88refvs",
    "metadata": {
     "papermill": {
-     "duration": 0.004595,
-     "end_time": "2026-04-22T15:45:45.267236",
+     "duration": 0.005027,
+     "end_time": "2026-04-22T17:48:36.361972",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.262641",
+     "start_time": "2026-04-22T17:48:36.356945",
      "status": "completed"
     },
     "tags": []
@@ -1135,10 +1135,10 @@
    "id": "section-6-summary",
    "metadata": {
     "papermill": {
-     "duration": 0.004388,
-     "end_time": "2026-04-22T15:45:45.276068",
+     "duration": 0.005091,
+     "end_time": "2026-04-22T17:48:36.372902",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.271680",
+     "start_time": "2026-04-22T17:48:36.367811",
      "status": "completed"
     },
     "tags": []
@@ -1168,10 +1168,10 @@
    "id": "exercises",
    "metadata": {
     "papermill": {
-     "duration": 0.00444,
-     "end_time": "2026-04-22T15:45:45.285682",
+     "duration": 0.006381,
+     "end_time": "2026-04-22T17:48:36.384396",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.281242",
+     "start_time": "2026-04-22T17:48:36.378015",
      "status": "completed"
     },
     "tags": []
@@ -1195,10 +1195,10 @@
      "shell.execute_reply": "2026-03-05T12:19:05.129183Z"
     },
     "papermill": {
-     "duration": 0.004589,
-     "end_time": "2026-04-22T15:45:45.294821",
+     "duration": 0.004801,
+     "end_time": "2026-04-22T17:48:36.394581",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.290232",
+     "start_time": "2026-04-22T17:48:36.389780",
      "status": "completed"
     },
     "tags": []
@@ -1217,16 +1217,16 @@
    "id": "d8536881",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.314376Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.313946Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.350196Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.349170Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.405886Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.405626Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.431859Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.431124Z"
     },
     "papermill": {
-     "duration": 0.046777,
-     "end_time": "2026-04-22T15:45:45.351469",
+     "duration": 0.033148,
+     "end_time": "2026-04-22T17:48:36.432849",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.304692",
+     "start_time": "2026-04-22T17:48:36.399701",
      "status": "completed"
     },
     "tags": []
@@ -1249,7 +1249,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : table de composition complete par enumeration\n",
+    "# Exemple resolu : Table de composition d'Allen par enumeration\n",
     "\n",
     "\n",
     "def endpoints_to_allen(s1, e1, s2, e2):\n",
@@ -1310,13 +1310,75 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2bb9a999",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005148,
+     "end_time": "2026-04-22T17:48:36.443433",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:36.438285",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1b : Inverse et composition partielle d'Allen\n",
+    "\n",
+    "**Enonce** : Implementez deux fonctions sur les relations d'Allen :\n",
+    "\n",
+    "1. `inverse_relation(r: AllenRelation) -> AllenRelation` : retourne la relation inverse\n",
+    "   (ex : BEFORE <-> AFTER, MEETS <-> MET_BY)\n",
+    "2. `compose_pair(r1: AllenRelation, r2: AllenRelation) -> Set[AllenRelation]` : retourne\n",
+    "   la composition de deux relations (sans enumeration exhaustive, utilisez les proprietes)\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Inspirez-vous de la table de composition de l'exemple ci-dessus\n",
+    "2. Utilisez les symetries (ex : inverse de BEFORE = AFTER)\n",
+    "3. Verifiez : `compose(BEFORE, OVERLAPS) == {BEFORE, OVERLAPS, MEETS, FINISHED_BY}`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "dc44ae76",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T17:48:36.455073Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.454736Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.458262Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.457650Z"
+    },
+    "papermill": {
+     "duration": 0.010417,
+     "end_time": "2026-04-22T17:48:36.459206",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:36.448789",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1b : Inverse et composition partielle d'Allen\n",
+    "\n",
+    "# TODO: implementez inverse_relation(r)\n",
+    "# Indice : 6 paires de relations inverses (BEFORE/AFTER, MEETS/MET_BY, etc.)\n",
+    "\n",
+    "# TODO: implementez compose_pair(r1, r2)\n",
+    "# Indice : decomposez en cas selon les proprietes des intervalles\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "df41fdf2",
    "metadata": {
     "papermill": {
-     "duration": 0.004607,
-     "end_time": "2026-04-22T15:45:45.361129",
+     "duration": 0.004791,
+     "end_time": "2026-04-22T17:48:36.469050",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.356522",
+     "start_time": "2026-04-22T17:48:36.464259",
      "status": "completed"
     },
     "tags": []
@@ -1331,20 +1393,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "b5d783f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.372473Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.371855Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.379711Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.379124Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.482210Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.481759Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.488824Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.488263Z"
     },
     "papermill": {
-     "duration": 0.015229,
-     "end_time": "2026-04-22T15:45:45.380953",
+     "duration": 0.01609,
+     "end_time": "2026-04-22T17:48:36.490042",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.365724",
+     "start_time": "2026-04-22T17:48:36.473952",
      "status": "completed"
     },
     "tags": []
@@ -1365,7 +1427,7 @@
     }
    ],
    "source": [
-    "# Exercice 2 : STP avec deadlines\n",
+    "# Exemple resolu : STP avec deadlines\n",
     "\n",
     "class STPWithDeadlines(SimpleTemporalProblem):\n",
     "    \"\"\"STP enrichi avec des contraintes de deadline et de release time.\"\"\"\n",
@@ -1413,13 +1475,78 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bfac4336",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005157,
+     "end_time": "2026-04-22T17:48:36.500539",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:36.495382",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2b : STP pour planification de projet avec contraintes\n",
+    "\n",
+    "**Enonce** : Utilisez `SimpleTemporalProblem` (ou `STPWithDeadlines`) pour\n",
+    "modeliser un **projet de construction** avec des contraintes temporelles.\n",
+    "\n",
+    "Taches et durees :\n",
+    "- Fondations : 3 jours (demarre au jour 0)\n",
+    "- Structure : 5 jours (apres fondations)\n",
+    "- Toiture : 2 jours (apres structure)\n",
+    "- Electricite : 2 jours (apres structure, avant finition)\n",
+    "- Plomberie : 3 jours (apres structure, avant finition)\n",
+    "- Finition : 4 jours (apres toiture, electricite et plomberie)\n",
+    "- Deadline : tout doit etre termine avant le jour 25\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Modelisez les contraintes de precedence et les durees dans un STP\n",
+    "2. Ajoutez la deadline comme contrainte sur le dernier evenement\n",
+    "3. Trouvez l'horaire optimal et affichez-le sous forme de diagramme de Gantt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2c09ae09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T17:48:36.515164Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.514260Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.519294Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.518280Z"
+    },
+    "papermill": {
+     "duration": 0.014304,
+     "end_time": "2026-04-22T17:48:36.520438",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:36.506134",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2b : STP pour planification de projet\n",
+    "\n",
+    "# TODO: definissez les evenements (debut + fin de chaque tache)\n",
+    "# TODO: ajoutez les contraintes de precedence et de duree\n",
+    "# Indice : pour \"Structure prend 5 jours\", contrainte : fin_struct - debut_struct in [5, 5]\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "70eeb3d6",
    "metadata": {
     "papermill": {
-     "duration": 0.004633,
-     "end_time": "2026-04-22T15:45:45.392103",
+     "duration": 0.007574,
+     "end_time": "2026-04-22T17:48:36.535055",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.387470",
+     "start_time": "2026-04-22T17:48:36.527481",
      "status": "completed"
     },
     "tags": []
@@ -1437,20 +1564,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "6befa3b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:45.403982Z",
-     "iopub.status.busy": "2026-04-22T15:45:45.403118Z",
-     "iopub.status.idle": "2026-04-22T15:45:45.999207Z",
-     "shell.execute_reply": "2026-04-22T15:45:45.998463Z"
+     "iopub.execute_input": "2026-04-22T17:48:36.550897Z",
+     "iopub.status.busy": "2026-04-22T17:48:36.550090Z",
+     "iopub.status.idle": "2026-04-22T17:48:36.987519Z",
+     "shell.execute_reply": "2026-04-22T17:48:36.986674Z"
     },
     "papermill": {
-     "duration": 0.603271,
-     "end_time": "2026-04-22T15:45:46.000284",
+     "duration": 0.446322,
+     "end_time": "2026-04-22T17:48:36.988671",
      "exception": false,
-     "start_time": "2026-04-22T15:45:45.397013",
+     "start_time": "2026-04-22T17:48:36.542349",
      "status": "completed"
     },
     "tags": []
@@ -1468,7 +1595,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Planification multi-reunions avec precedences (OR-Tools CP-SAT)\n",
+    "# Exemple resolu : Planification multi-reunions avec precedences\n",
     "\n",
     "install_if_missing('ortools')\n",
     "from ortools.sat.python import cp_model\n",
@@ -1576,13 +1703,77 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8c8d9ba8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00584,
+     "end_time": "2026-04-22T17:48:37.001201",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:36.995361",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3b : Planification de cours avec contraintes de salle\n",
+    "\n",
+    "**Enonce** : Planifiez **6 cours** dans une journee (8h-18h) avec :\n",
+    "\n",
+    "- Des contraintes de **precedence** (certains cours doivent etre avant d'autres)\n",
+    "- Des contraintes de **salle** (2 salles disponibles, un seul cours par salle par creneau)\n",
+    "- Des contraintes de **duree** (chaque cours dure 1h ou 2h)\n",
+    "\n",
+    "Precedences : CoursA avant CoursC, CoursB avant CoursD, CoursC avant CoursE\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Inspirez-vous du modele CP-SAT de l'exemple multi-reunions\n",
+    "2. Ajoutez des variables pour le choix de salle\n",
+    "3. Affichez l'emploi du temps optimal\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "7c199733",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T17:48:37.016319Z",
+     "iopub.status.busy": "2026-04-22T17:48:37.015822Z",
+     "iopub.status.idle": "2026-04-22T17:48:37.021170Z",
+     "shell.execute_reply": "2026-04-22T17:48:37.020145Z"
+    },
+    "papermill": {
+     "duration": 0.015129,
+     "end_time": "2026-04-22T17:48:37.022796",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:37.007667",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3b : Planification de cours avec contraintes de salle\n",
+    "\n",
+    "# TODO: definissez les cours, durees et precedences\n",
+    "# COURSES = {'A': 1, 'B': 2, 'C': 1, 'D': 1, 'E': 2, 'F': 1}  # durees en heures\n",
+    "# PRECEDENCES = [('A', 'C'), ('B', 'D'), ('C', 'E')]\n",
+    "\n",
+    "# TODO: creez le modele CP-SAT avec variables start[i], duration[i], room[i]\n",
+    "# Indice : noOverlap pour chaque salle + precedence pour les contraintes d'ordre\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1de2a8a2",
    "metadata": {
     "papermill": {
-     "duration": 0.006112,
-     "end_time": "2026-04-22T15:45:46.012125",
+     "duration": 0.008839,
+     "end_time": "2026-04-22T17:48:37.040400",
      "exception": false,
-     "start_time": "2026-04-22T15:45:46.006013",
+     "start_time": "2026-04-22T17:48:37.031561",
      "status": "completed"
     },
     "tags": []
@@ -1597,20 +1788,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "7e66ca5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:45:46.030964Z",
-     "iopub.status.busy": "2026-04-22T15:45:46.030358Z",
-     "iopub.status.idle": "2026-04-22T15:45:46.061709Z",
-     "shell.execute_reply": "2026-04-22T15:45:46.060668Z"
+     "iopub.execute_input": "2026-04-22T17:48:37.054713Z",
+     "iopub.status.busy": "2026-04-22T17:48:37.054254Z",
+     "iopub.status.idle": "2026-04-22T17:48:37.069585Z",
+     "shell.execute_reply": "2026-04-22T17:48:37.068465Z"
     },
     "papermill": {
-     "duration": 0.042902,
-     "end_time": "2026-04-22T15:45:46.063358",
+     "duration": 0.024055,
+     "end_time": "2026-04-22T17:48:37.071254",
      "exception": false,
-     "start_time": "2026-04-22T15:45:46.020456",
+     "start_time": "2026-04-22T17:48:37.047199",
      "status": "completed"
     },
     "tags": []
@@ -1639,7 +1830,7 @@
     }
    ],
    "source": [
-    "# Exercice 4 : STP resolu avec OR-Tools CP-SAT\n",
+    "# Exemple resolu : STP resolu avec OR-Tools CP-SAT\n",
     "\n",
     "\n",
     "def solve_stp_cp_sat(\n",
@@ -1722,13 +1913,79 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ffb34f74",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005262,
+     "end_time": "2026-04-22T17:48:37.085805",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:37.080543",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4b : STP disjonctif avec intervals d'Allen\n",
+    "\n",
+    "**Enonce** : Combinez le STP avec les **relations d'Allen** pour modeliser\n",
+    "un probleme ou certaines taches doivent etre dans une relation specifique.\n",
+    "\n",
+    "Scenario : Planification d'une conference avec 4 presentations :\n",
+    "- Keynote doit OVERLAP avec au moins une autre presentation\n",
+    "- Talk1 et Talk2 doivent se MEET (fin de l'un = debut de l'autre)\n",
+    "- Workshop doit etre AFTER Talk2\n",
+    "- Chaque presentation dure entre 30 min et 2h\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Utilisez CP-SAT avec des variables de debut et fin pour chaque presentation\n",
+    "2. Modelisez les relations d'Allen comme des contraintes lineaires\n",
+    "   (ex : MEET(A, B) = fin_A == debut_B)\n",
+    "3. Trouvez un horaire valide\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a3df3a84",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T17:48:37.098650Z",
+     "iopub.status.busy": "2026-04-22T17:48:37.098174Z",
+     "iopub.status.idle": "2026-04-22T17:48:37.102987Z",
+     "shell.execute_reply": "2026-04-22T17:48:37.101997Z"
+    },
+    "papermill": {
+     "duration": 0.013628,
+     "end_time": "2026-04-22T17:48:37.104692",
+     "exception": false,
+     "start_time": "2026-04-22T17:48:37.091064",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 4b : STP disjonctif avec relations d'Allen\n",
+    "\n",
+    "# TODO: definissez les 4 presentations et leurs contraintes\n",
+    "# presentations = ['Keynote', 'Talk1', 'Talk2', 'Workshop']\n",
+    "\n",
+    "# TODO: modelisez les relations d'Allen comme contraintes CP-SAT\n",
+    "# Indice : OVERLAP = debut_A < fin_B ET debut_B < fin_A\n",
+    "#          MEET(A, B) = fin_A == debut_B\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "references",
    "metadata": {
     "papermill": {
-     "duration": 0.004853,
-     "end_time": "2026-04-22T15:45:46.074572",
+     "duration": 0.008776,
+     "end_time": "2026-04-22T17:48:37.121978",
      "exception": false,
-     "start_time": "2026-04-22T15:45:46.069719",
+     "start_time": "2026-04-22T17:48:37.113202",
      "status": "completed"
     },
     "tags": []
@@ -1771,14 +2028,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.895869,
-   "end_time": "2026-04-22T15:45:46.542744",
+   "duration": 4.631612,
+   "end_time": "2026-04-22T17:48:37.475775",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-8-Temporal.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-8-Temporal_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-22T15:45:41.646875",
+   "start_time": "2026-04-22T17:48:32.844163",
    "version": "2.6.0"
   }
  },

--- a/scripts/recycle_csp8.py
+++ b/scripts/recycle_csp8.py
@@ -1,0 +1,238 @@
+"""
+Recycle CSP-8-Temporal exercises (Issue #463).
+
+Converts 4 student solutions into labeled "Exemple resolu" cells
+and creates new exercise stubs with variant data.
+"""
+
+import json
+
+
+def main():
+    path = "MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb"
+    with open(path, encoding="utf-8") as f:
+        nb = json.load(f)
+
+    # --- Exercise layout (33 cells) ---
+    # [24] md  : Ex1 Allen composition table
+    # [25] code: Ex1 table de composition (58L)
+    # [26] md  : Ex2 STP avec deadlines
+    # [27] code: Ex2 STPWithDeadlines (45L)
+    # [28] md  : Ex3 Planning multi-reunions
+    # [29] code: Ex3 Multi-reunions CP-SAT (105L)
+    # [30] md  : Ex4 STP avec OR-Tools CP-SAT
+    # [31] code: Ex4 solve_stp_cp_sat (80L)
+    # [32] md  : References
+
+    # ================================================================
+    # Ex1: Allen composition table → Exemple resolu (cell 25)
+    # ================================================================
+    nb["cells"][25]["source"][0] = "# Exemple resolu : Table de composition d'Allen par enumeration\n"
+    nb["cells"][25]["outputs"] = []
+    nb["cells"][25]["execution_count"] = None
+
+    ex1b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 1b : Inverse et composition partielle d'Allen\n",
+            "\n",
+            "**Enonce** : Implementez deux fonctions sur les relations d'Allen :\n",
+            "\n",
+            "1. `inverse_relation(r: AllenRelation) -> AllenRelation` : retourne la relation inverse\n",
+            "   (ex : BEFORE <-> AFTER, MEETS <-> MET_BY)\n",
+            "2. `compose_pair(r1: AllenRelation, r2: AllenRelation) -> Set[AllenRelation]` : retourne\n",
+            "   la composition de deux relations (sans enumeration exhaustive, utilisez les proprietes)\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Inspirez-vous de la table de composition de l'exemple ci-dessus\n",
+            "2. Utilisez les symetries (ex : inverse de BEFORE = AFTER)\n",
+            "3. Verifiez : `compose(BEFORE, OVERLAPS) == {BEFORE, OVERLAPS, MEETS, FINISHED_BY}`\n",
+        ],
+    }
+
+    ex1b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 1b : Inverse et composition partielle d'Allen\n",
+            "\n",
+            "# TODO: implementez inverse_relation(r)\n",
+            "# Indice : 6 paires de relations inverses (BEFORE/AFTER, MEETS/MET_BY, etc.)\n",
+            "\n",
+            "# TODO: implementez compose_pair(r1, r2)\n",
+            "# Indice : decomposez en cas selon les proprietes des intervalles\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(26, ex1b_md)
+    nb["cells"].insert(27, ex1b_code)
+
+    # ================================================================
+    # Ex2: STP avec deadlines → Exemple resolu (now cell 29)
+    # ================================================================
+    nb["cells"][29]["source"][0] = "# Exemple resolu : STP avec deadlines\n"
+    nb["cells"][29]["outputs"] = []
+    nb["cells"][29]["execution_count"] = None
+
+    ex2b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 2b : STP pour planification de projet avec contraintes\n",
+            "\n",
+            "**Enonce** : Utilisez `SimpleTemporalProblem` (ou `STPWithDeadlines`) pour\n",
+            "modeliser un **projet de construction** avec des contraintes temporelles.\n",
+            "\n",
+            "Taches et durees :\n",
+            "- Fondations : 3 jours (demarre au jour 0)\n",
+            "- Structure : 5 jours (apres fondations)\n",
+            "- Toiture : 2 jours (apres structure)\n",
+            "- Electricite : 2 jours (apres structure, avant finition)\n",
+            "- Plomberie : 3 jours (apres structure, avant finition)\n",
+            "- Finition : 4 jours (apres toiture, electricite et plomberie)\n",
+            "- Deadline : tout doit etre termine avant le jour 25\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Modelisez les contraintes de precedence et les durees dans un STP\n",
+            "2. Ajoutez la deadline comme contrainte sur le dernier evenement\n",
+            "3. Trouvez l'horaire optimal et affichez-le sous forme de diagramme de Gantt\n",
+        ],
+    }
+
+    ex2b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 2b : STP pour planification de projet\n",
+            "\n",
+            "# TODO: definissez les evenements (debut + fin de chaque tache)\n",
+            "# TODO: ajoutez les contraintes de precedence et de duree\n",
+            "# Indice : pour \"Structure prend 5 jours\", contrainte : fin_struct - debut_struct in [5, 5]\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(30, ex2b_md)
+    nb["cells"].insert(31, ex2b_code)
+
+    # ================================================================
+    # Ex3: Planning multi-reunions → Exemple resolu (now cell 33)
+    # ================================================================
+    nb["cells"][33]["source"][0] = "# Exemple resolu : Planification multi-reunions avec precedences\n"
+    nb["cells"][33]["outputs"] = []
+    nb["cells"][33]["execution_count"] = None
+
+    ex3b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 3b : Planification de cours avec contraintes de salle\n",
+            "\n",
+            "**Enonce** : Planifiez **6 cours** dans une journee (8h-18h) avec :\n",
+            "\n",
+            "- Des contraintes de **precedence** (certains cours doivent etre avant d'autres)\n",
+            "- Des contraintes de **salle** (2 salles disponibles, un seul cours par salle par creneau)\n",
+            "- Des contraintes de **duree** (chaque cours dure 1h ou 2h)\n",
+            "\n",
+            "Precedences : CoursA avant CoursC, CoursB avant CoursD, CoursC avant CoursE\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Inspirez-vous du modele CP-SAT de l'exemple multi-reunions\n",
+            "2. Ajoutez des variables pour le choix de salle\n",
+            "3. Affichez l'emploi du temps optimal\n",
+        ],
+    }
+
+    ex3b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 3b : Planification de cours avec contraintes de salle\n",
+            "\n",
+            "# TODO: definissez les cours, durees et precedences\n",
+            "# COURSES = {'A': 1, 'B': 2, 'C': 1, 'D': 1, 'E': 2, 'F': 1}  # durees en heures\n",
+            "# PRECEDENCES = [('A', 'C'), ('B', 'D'), ('C', 'E')]\n",
+            "\n",
+            "# TODO: creez le modele CP-SAT avec variables start[i], duration[i], room[i]\n",
+            "# Indice : noOverlap pour chaque salle + precedence pour les contraintes d'ordre\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(34, ex3b_md)
+    nb["cells"].insert(35, ex3b_code)
+
+    # ================================================================
+    # Ex4: STP avec OR-Tools → Exemple resolu (now cell 37)
+    # ================================================================
+    nb["cells"][37]["source"][0] = "# Exemple resolu : STP resolu avec OR-Tools CP-SAT\n"
+    nb["cells"][37]["outputs"] = []
+    nb["cells"][37]["execution_count"] = None
+
+    ex4b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 4b : STP disjonctif avec intervals d'Allen\n",
+            "\n",
+            "**Enonce** : Combinez le STP avec les **relations d'Allen** pour modeliser\n",
+            "un probleme ou certaines taches doivent etre dans une relation specifique.\n",
+            "\n",
+            "Scenario : Planification d'une conference avec 4 presentations :\n",
+            "- Keynote doit OVERLAP avec au moins une autre presentation\n",
+            "- Talk1 et Talk2 doivent se MEET (fin de l'un = debut de l'autre)\n",
+            "- Workshop doit etre AFTER Talk2\n",
+            "- Chaque presentation dure entre 30 min et 2h\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Utilisez CP-SAT avec des variables de debut et fin pour chaque presentation\n",
+            "2. Modelisez les relations d'Allen comme des contraintes lineaires\n",
+            "   (ex : MEET(A, B) = fin_A == debut_B)\n",
+            "3. Trouvez un horaire valide\n",
+        ],
+    }
+
+    ex4b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 4b : STP disjonctif avec relations d'Allen\n",
+            "\n",
+            "# TODO: definissez les 4 presentations et leurs contraintes\n",
+            "# presentations = ['Keynote', 'Talk1', 'Talk2', 'Workshop']\n",
+            "\n",
+            "# TODO: modelisez les relations d'Allen comme contraintes CP-SAT\n",
+            "# Indice : OVERLAP = debut_A < fin_B ET debut_B < fin_A\n",
+            "#          MEET(A, B) = fin_A == debut_B\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(38, ex4b_md)
+    nb["cells"].insert(39, ex4b_code)
+
+    # ================================================================
+    # Write back
+    # ================================================================
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(nb, f, ensure_ascii=False, indent=1)
+
+    print(f"CSP-8 updated: {len(nb['cells'])} cells (was 33, +8 new cells)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Convert 4 student solutions in CSP-8-Temporal to labeled "Exemple resolu" cells
- Create 4 new exercise stubs with variant data
- All notebooks pass Papermill validation before and after changes

## Changes
| Exercise | Exemple resolu | New variant |
|----------|---------------|-------------|
| Ex1: Allen composition table | Allen composition table | Inverse and partial composition variant |
| Ex2: STP with deadlines | STP with deadlines | Construction project planning variant |
| Ex3: Multi-meeting planning CP-SAT | Multi-meeting planning | Course scheduling with rooms variant |
| Ex4: STP with OR-Tools CP-SAT | STP CP-SAT | Disjunctive STP with Allen relations variant |

Refs #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)