### PR TITLE
fix(app-6): recyclage solutions etudiants + stubs TODO (#463)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
@@ -1,2892 +1,3122 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "cell-00",
-      "metadata": {
-        "papermill": {
-          "duration": 0.037913,
-          "end_time": "2026-02-26T07:01:08.977145",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:08.939232",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-00"
-      },
-      "source": [
-        "# App-6 - Demineur : CSP, Probabilites et NP-completude\n",
-        "\n",
-        "**Navigation** : [<< App-5 Timetabling](App-5-Timetabling.ipynb) | [Index](../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)\n",
-        "\n",
-        "## Objectifs d'apprentissage\n",
-        "\n",
-        "A la fin de ce notebook, vous saurez :\n",
-        "1. **Modeliser** le Demineur comme un probleme de satisfaction de contraintes (CSP)\n",
-        "2. **Implementer** un solveur par regles simples pour les cas non ambigus\n",
-        "3. **Construire** un solveur CSP qui enumere les solutions et deduit les cellules sures/minees\n",
-        "4. **Etendre** le solveur avec un raisonnement probabiliste pour les cas ambigus\n",
-        "5. **Comparer** les trois approches en termes de taux de victoire et de performance\n",
-        "\n",
-        "### Prerequis\n",
-        "- Python 3.10+, numpy, matplotlib\n",
-        "- `python-constraint` (CSP)\n",
-        "- Notions de CSP (Search-6 et Search-7)\n",
-        "\n",
-        "### Duree estimee : 50 minutes\n",
-        "\n",
-        "### Source\n",
-        "\n",
-        "Adapte du projet etudiant EPITA PPC 2025 : [jsboigeEpita/2025-PPC RDER-minesweeper](https://github.com/jsboigeEpita/2025-PPC) (CSP + probabilites, preuve NP-completude)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-01",
-      "metadata": {
-        "papermill": {
-          "duration": 0.014699,
-          "end_time": "2026-02-26T07:01:09.002372",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:08.987673",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-01"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 1. Introduction : le Demineur comme probleme de contraintes (~5 min)\n",
-        "\n",
-        "Le **Demineur** (Minesweeper) est un jeu classique ou le joueur doit reveler toutes les cellules sures d'une grille sans cliquer sur une mine. Chaque cellule revelee affiche un nombre indiquant combien de ses 8 voisines contiennent une mine.\n",
-        "\n",
-        "### Pourquoi le Demineur interesse-t-il l'IA ?\n",
-        "\n",
-        "Le Demineur est bien plus qu'un jeu : c'est un **probleme NP-complet**. Richard Kaye a demontre en 2000 que determiner si une configuration de Demineur est consistante (c'est-a-dire s'il existe un placement de mines compatible avec les indices visibles) est **NP-complet**.\n",
-        "\n",
-        "| Propriete | Valeur |\n",
-        "|-----------|--------|\n",
-        "| Complexite | NP-complet (Kaye, 2000) |\n",
-        "| Type de probleme | Satisfaction de contraintes |\n",
-        "| Variables | Cellules inconnues (mine ou sure) |\n",
-        "| Contraintes | Indices numeriques des cellules revelees |\n",
-        "| Reduction | Reduction depuis SAT / Circuit-SAT |\n",
-        "\n",
-        "### Modelisation CSP\n",
-        "\n",
-        "Le Demineur se modelise naturellement comme un CSP :\n",
-        "\n",
-        "- **Variables** : chaque cellule non revelee $C_{i,j}$ est une variable binaire\n",
-        "- **Domaines** : $D_{i,j} = \\{0, 1\\}$ ou $0$ = sure, $1$ = mine\n",
-        "- **Contraintes** : pour chaque cellule revelee affichant la valeur $n$, la somme des variables voisines doit valoir exactement $n$ :\n",
-        "\n",
-        "$$\\sum_{(r,c) \\in \\text{voisins}(i,j)} C_{r,c} = n_{i,j}$$\n",
-        "\n",
-        "- **Contrainte globale** : le nombre total de mines est connu\n",
-        "\n",
-        "### Plan du notebook\n",
-        "\n",
-        "Nous allons construire trois solveurs de complexite croissante :\n",
-        "\n",
-        "| Approche | Principe | Quand l'utiliser |\n",
-        "|----------|----------|------------------|\n",
-        "| Regles simples | Deductions deterministes locales | Cas triviaux |\n",
-        "| CSP complet | Enumeration des solutions, cellules forcees | Cas ambigus localement |\n",
-        "| CSP + Probabilites | Comptage de solutions, choix optimal | Quand aucune cellule n'est forcee |"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-02",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:01.481513Z",
-          "iopub.status.busy": "2026-04-21T00:32:01.481017Z",
-          "iopub.status.idle": "2026-04-21T00:32:02.650975Z",
-          "shell.execute_reply": "2026-04-21T00:32:02.648853Z"
-        },
-        "papermill": {
-          "duration": 0.386712,
-          "end_time": "2026-02-26T07:01:09.402160",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.015448",
-          "status": "completed"
-        },
-        "tags": [],
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "cell-02",
-        "outputId": "f45aa90e-3e39-43cb-d04b-37bf7e59172d"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting python-constraint\n",
-            "  Downloading python-constraint-1.4.0.tar.bz2 (18 kB)\n",
-            "  Preparing metadata (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "Building wheels for collected packages: python-constraint\n",
-            "  Building wheel for python-constraint (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for python-constraint: filename=python_constraint-1.4.0-py2.py3-none-any.whl size=24061 sha256=8e0a0dda8e6e2121970ab37cf9273f100e8420b850e440801bdcede52f0ddcdb\n",
-            "  Stored in directory: /root/.cache/pip/wheels/c1/d2/3d/082849b61a9c6de02d4a7c8a402c224640f08d8a971307b92b\n",
-            "Successfully built python-constraint\n",
-            "Installing collected packages: python-constraint\n",
-            "Successfully installed python-constraint-1.4.0\n",
-            "Imports OK\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Imports pour tout le notebook\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import matplotlib.patches as mpatches\n",
-        "import matplotlib.colors as mcolors\n",
-        "from collections import defaultdict\n",
-        "from itertools import product\n",
-        "import random\n",
-        "import time\n",
-        "import sys\n",
-        "import copy\n",
-        "\n",
-        "# Install CSP solver library if not already installed\n",
-        "!pip install python-constraint\n",
-        "\n",
-        "# CSP solver\n",
-        "from constraint import Problem, ExactSumConstraint\n",
-        "\n",
-        "# Helpers partages de la serie Search\n",
-        "sys.path.insert(0, '..')\n",
-        "from search_helpers import benchmark_table\n",
-        "\n",
-        "# Reproductibilite\n",
-        "random.seed(42)\n",
-        "np.random.seed(42)\n",
-        "\n",
-        "print(\"Imports OK\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-03",
-      "metadata": {
-        "papermill": {
-          "duration": 0.003232,
-          "end_time": "2026-02-26T07:01:09.410905",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.407673",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-03"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 2. Representation du plateau (~5 min)\n",
-        "\n",
-        "Avant de resoudre le Demineur, nous devons le representer. Le plateau est une grille 2D ou chaque cellule est dans l'un des etats suivants :\n",
-        "\n",
-        "| Etat interne | Etat visible par le joueur | Description |\n",
-        "|--------------|----------------------------|-------------|\n",
-        "| Mine | Cache / Drapeau | Cellule contenant une mine |\n",
-        "| Sure (indice 0-8) | Cache / Revelee | Cellule sure avec nombre de mines voisines |\n",
-        "\n",
-        "Nous implementons une classe `MinesweeperBoard` qui gere la generation du plateau et la revelation des cellules."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-04",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:02.654215Z",
-          "iopub.status.busy": "2026-04-21T00:32:02.653914Z",
-          "iopub.status.idle": "2026-04-21T00:32:02.668550Z",
-          "shell.execute_reply": "2026-04-21T00:32:02.667355Z"
-        },
-        "papermill": {
-          "duration": 0.013559,
-          "end_time": "2026-02-26T07:01:09.430099",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.416540",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-04",
-        "outputId": "80deca68-de22-466b-a6df-2503f57b5bb1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Classe MinesweeperBoard definie.\n"
-          ]
-        }
-      ],
-      "source": [
-        "class MinesweeperBoard:\n",
-        "    \"\"\"Plateau de Demineur avec generation, revelation et visualisation.\n",
-        "\n",
-        "    Attributs:\n",
-        "        rows, cols: dimensions de la grille\n",
-        "        n_mines: nombre total de mines\n",
-        "        mines: ensemble de positions (r, c) contenant une mine\n",
-        "        numbers: grille des indices (nombre de mines voisines)\n",
-        "        revealed: ensemble de cellules revelees\n",
-        "        flagged: ensemble de cellules marquees comme mines\n",
-        "        game_over: True si une mine a ete revelee\n",
-        "        won: True si toutes les cellules sures sont revelees\n",
-        "    \"\"\"\n",
-        "\n",
-        "    NEIGHBORS_OFFSETS = [(-1, -1), (-1, 0), (-1, 1),\n",
-        "                         (0, -1),           (0, 1),\n",
-        "                         (1, -1),  (1, 0),  (1, 1)]\n",
-        "\n",
-        "    def __init__(self, rows=8, cols=8, n_mines=10, safe_cell=None):\n",
-        "        \"\"\"Genere un plateau aleatoire.\n",
-        "\n",
-        "        Args:\n",
-        "            rows, cols: dimensions\n",
-        "            n_mines: nombre de mines\n",
-        "            safe_cell: position (r, c) garantie sans mine (premier clic)\n",
-        "        \"\"\"\n",
-        "        self.rows = rows\n",
-        "        self.cols = cols\n",
-        "        self.n_mines = n_mines\n",
-        "        self.revealed = set()\n",
-        "        self.flagged = set()\n",
-        "        self.game_over = False\n",
-        "        self.won = False\n",
-        "\n",
-        "        # Generer les mines en evitant safe_cell et ses voisins\n",
-        "        all_cells = [(r, c) for r in range(rows) for c in range(cols)]\n",
-        "        excluded = set()\n",
-        "        if safe_cell is not None:\n",
-        "            excluded.add(safe_cell)\n",
-        "            excluded.update(self.get_neighbors(*safe_cell))\n",
-        "\n",
-        "        candidates = [cell for cell in all_cells if cell not in excluded]\n",
-        "        self.mines = set(random.sample(candidates, min(n_mines, len(candidates))))\n",
-        "\n",
-        "        # Calculer les indices (nombre de mines voisines pour chaque cellule)\n",
-        "        self.numbers = np.zeros((rows, cols), dtype=int)\n",
-        "        for r in range(rows):\n",
-        "            for c in range(cols):\n",
-        "                if (r, c) not in self.mines:\n",
-        "                    self.numbers[r, c] = sum(\n",
-        "                        1 for nr, nc in self.get_neighbors(r, c)\n",
-        "                        if (nr, nc) in self.mines\n",
-        "                    )\n",
-        "\n",
-        "    def get_neighbors(self, r, c):\n",
-        "        \"\"\"Retourne les positions voisines valides de (r, c).\"\"\"\n",
-        "        neighbors = []\n",
-        "        for dr, dc in self.NEIGHBORS_OFFSETS:\n",
-        "            nr, nc = r + dr, c + dc\n",
-        "            if 0 <= nr < self.rows and 0 <= nc < self.cols:\n",
-        "                neighbors.append((nr, nc))\n",
-        "        return neighbors\n",
-        "\n",
-        "    def reveal(self, r, c):\n",
-        "        \"\"\"Revele la cellule (r, c). Retourne True si sure, False si mine.\"\"\"\n",
-        "        if (r, c) in self.revealed or (r, c) in self.flagged:\n",
-        "            return True\n",
-        "\n",
-        "        if (r, c) in self.mines:\n",
-        "            self.game_over = True\n",
-        "            return False\n",
-        "\n",
-        "        self.revealed.add((r, c))\n",
-        "\n",
-        "        # Si la cellule est un 0, reveler en cascade les voisins\n",
-        "        if self.numbers[r, c] == 0:\n",
-        "            for nr, nc in self.get_neighbors(r, c):\n",
-        "                if (nr, nc) not in self.revealed:\n",
-        "                    self.reveal(nr, nc)\n",
-        "\n",
-        "        # Verifier la victoire\n",
-        "        safe_cells = self.rows * self.cols - len(self.mines)\n",
-        "        if len(self.revealed) == safe_cells:\n",
-        "            self.won = True\n",
-        "\n",
-        "        return True\n",
-        "\n",
-        "    def flag(self, r, c):\n",
-        "        \"\"\"Marque/demarque une cellule comme mine.\"\"\"\n",
-        "        if (r, c) not in self.revealed:\n",
-        "            if (r, c) in self.flagged:\n",
-        "                self.flagged.discard((r, c))\n",
-        "            else:\n",
-        "                self.flagged.add((r, c))\n",
-        "\n",
-        "    def get_unknown_neighbors(self, r, c):\n",
-        "        \"\"\"Retourne les voisins ni reveles ni marques.\"\"\"\n",
-        "        return [\n",
-        "            (nr, nc) for nr, nc in self.get_neighbors(r, c)\n",
-        "            if (nr, nc) not in self.revealed and (nr, nc) not in self.flagged\n",
-        "        ]\n",
-        "\n",
-        "    def get_flagged_neighbors(self, r, c):\n",
-        "        \"\"\"Retourne les voisins marques comme mines.\"\"\"\n",
-        "        return [\n",
-        "            (nr, nc) for nr, nc in self.get_neighbors(r, c)\n",
-        "            if (nr, nc) in self.flagged\n",
-        "        ]\n",
-        "\n",
-        "    def remaining_mines(self):\n",
-        "        \"\"\"Nombre de mines non encore marquees.\"\"\"\n",
-        "        return self.n_mines - len(self.flagged)\n",
-        "\n",
-        "    def copy(self):\n",
-        "        \"\"\"Retourne une copie profonde du plateau.\"\"\"\n",
-        "        board = MinesweeperBoard.__new__(MinesweeperBoard)\n",
-        "        board.rows = self.rows\n",
-        "        board.cols = self.cols\n",
-        "        board.n_mines = self.n_mines\n",
-        "        board.mines = set(self.mines)\n",
-        "        board.numbers = self.numbers.copy()\n",
-        "        board.revealed = set(self.revealed)\n",
-        "        board.flagged = set(self.flagged)\n",
-        "        board.game_over = self.game_over\n",
-        "        board.won = self.won\n",
-        "        return board\n",
-        "\n",
-        "print(\"Classe MinesweeperBoard definie.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-05",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004337,
-          "end_time": "2026-02-26T07:01:09.438133",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.433796",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-05"
-      },
-      "source": [
-        "### Visualisation du plateau\n",
-        "\n",
-        "La fonction suivante dessine le plateau avec un code couleur clair :\n",
-        "- Gris : cellule cachee\n",
-        "- Blanc avec chiffre : cellule revelee\n",
-        "- Rouge avec drapeau : cellule marquee comme mine\n",
-        "- Noir (game over) : mine revelee"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-06",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:02.671233Z",
-          "iopub.status.busy": "2026-04-21T00:32:02.670852Z",
-          "iopub.status.idle": "2026-04-21T00:32:02.682956Z",
-          "shell.execute_reply": "2026-04-21T00:32:02.681861Z"
-        },
-        "papermill": {
-          "duration": 0.016173,
-          "end_time": "2026-02-26T07:01:09.458475",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.442302",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-06",
-        "outputId": "e1dd82a9-26b1-4c3d-acc6-a371e3f07e3a",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Fonction draw_board definie.\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Couleurs pour les chiffres du demineur (convention classique)\n",
-        "NUMBER_COLORS = {\n",
-        "    0: '#CCCCCC', 1: '#0000FF', 2: '#008000', 3: '#FF0000',\n",
-        "    4: '#000080', 5: '#800000', 6: '#008080', 7: '#000000', 8: '#808080'\n",
-        "}\n",
-        "\n",
-        "\n",
-        "def draw_board(board, title=\"Demineur\", show_mines=False,\n",
-        "               highlight_safe=None, highlight_mines=None,\n",
-        "               probabilities=None, figsize=None):\n",
-        "    \"\"\"Visualise le plateau de Demineur.\n",
-        "\n",
-        "    Args:\n",
-        "        board: MinesweeperBoard\n",
-        "        title: titre du graphique\n",
-        "        show_mines: reveler toutes les mines (fin de partie)\n",
-        "        highlight_safe: ensemble de cellules a surligner en vert (deduites sures)\n",
-        "        highlight_mines: ensemble de cellules a surligner en rouge (deduites mines)\n",
-        "        probabilities: dict (r,c) -> probabilite de mine (pour affichage)\n",
-        "    \"\"\"\n",
-        "    if figsize is None:\n",
-        "        figsize = (max(6, board.cols * 0.7), max(6, board.rows * 0.7))\n",
-        "\n",
-        "    fig, ax = plt.subplots(figsize=figsize)\n",
-        "\n",
-        "    for r in range(board.rows):\n",
-        "        for c in range(board.cols):\n",
-        "            # Determiner la couleur de fond\n",
-        "            if (r, c) in board.revealed:\n",
-        "                bg_color = '#E8E8E8'  # Gris clair pour revelee\n",
-        "            elif (r, c) in board.flagged:\n",
-        "                bg_color = '#FFB3B3'  # Rouge clair pour drapeau\n",
-        "            elif highlight_safe and (r, c) in highlight_safe:\n",
-        "                bg_color = '#B3FFB3'  # Vert clair pour sure deduites\n",
-        "            elif highlight_mines and (r, c) in highlight_mines:\n",
-        "                bg_color = '#FF6666'  # Rouge pour mine deduite\n",
-        "            else:\n",
-        "                bg_color = '#C0C0C0'  # Gris pour cachee\n",
-        "\n",
-        "            rect = plt.Rectangle((c, board.rows - 1 - r), 1, 1,\n",
-        "                                 facecolor=bg_color, edgecolor='#666666',\n",
-        "                                 linewidth=1)\n",
-        "            ax.add_patch(rect)\n",
-        "\n",
-        "            # Contenu de la cellule\n",
-        "            cx, cy = c + 0.5, board.rows - 1 - r + 0.5\n",
-        "\n",
-        "            if (r, c) in board.revealed:\n",
-        "                num = board.numbers[r, c]\n",
-        "                if num > 0:\n",
-        "                    ax.text(cx, cy, str(num), ha='center', va='center',\n",
-        "                            fontsize=14, fontweight='bold',\n",
-        "                            color=NUMBER_COLORS.get(num, 'black'))\n",
-        "            elif (r, c) in board.flagged:\n",
-        "                ax.text(cx, cy, 'F', ha='center', va='center',\n",
-        "                        fontsize=12, fontweight='bold', color='darkred')\n",
-        "            elif show_mines and (r, c) in board.mines:\n",
-        "                ax.text(cx, cy, 'X', ha='center', va='center',\n",
-        "                        fontsize=14, fontweight='bold', color='black')\n",
-        "            elif probabilities and (r, c) in probabilities:\n",
-        "                prob = probabilities[(r, c)]\n",
-        "                ax.text(cx, cy, f'{prob:.0%}', ha='center', va='center',\n",
-        "                        fontsize=8, color='#444444')\n",
-        "\n",
-        "    ax.set_xlim(0, board.cols)\n",
-        "    ax.set_ylim(0, board.rows)\n",
-        "    ax.set_aspect('equal')\n",
-        "    ax.set_xticks(range(board.cols))\n",
-        "    ax.set_yticks(range(board.rows))\n",
-        "    ax.set_xticklabels(range(board.cols))\n",
-        "    ax.set_yticklabels(range(board.rows - 1, -1, -1))\n",
-        "    ax.set_xlabel('Colonne')\n",
-        "    ax.set_ylabel('Ligne')\n",
-        "    ax.set_title(title, fontsize=13, fontweight='bold')\n",
-        "    plt.tight_layout()\n",
-        "    return fig\n",
-        "\n",
-        "\n",
-        "print(\"Fonction draw_board definie.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-07",
-      "metadata": {
-        "papermill": {
-          "duration": 0.003666,
-          "end_time": "2026-02-26T07:01:09.466058",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.462392",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-07"
-      },
-      "source": [
-        "Creons un plateau 8x8 avec 10 mines et simulons un premier clic pour reveler quelques cellules."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-08",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:02.685499Z",
-          "iopub.status.busy": "2026-04-21T00:32:02.685138Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.280381Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.278814Z"
-        },
-        "papermill": {
-          "duration": 0.223476,
-          "end_time": "2026-02-26T07:01:09.693428",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.469952",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-08",
-        "outputId": "889070e9-3d7d-40f1-b5d8-d843550fc1da",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Plateau : 8x8, 10 mines\n",
-            "Cellules revelees apres le premier clic : 44\n",
-            "Cellules restantes (inconnues)           : 20\n",
-            "Mines a trouver                          : 10\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQadJREFUeJzt3Xl0VPX9//HXkDCTkJCwJUAkJKxlX8omooIi4s5W9CACcatoLFqU9kurElSUfmktqMiiNsEKxX6RQKDKJotQQUGbH5sQthgallADCQFMILm/PziZZkhCFpK5+TDPxzk5Z+bOnTvv953JzCuf+5kbh2VZlgAAAAxUy+4CAAAAKosgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADnzRgwAA5HA45HA4lJCRc07aio6Pd29q4cWO575eamuq+n8PhuKYaim4nNTX1mrZ1vavK595XJCQkuPfZgAED7C6nTBs3bnTXGx0d7V5elb9zqDn87S4AZkpISNCjjz561XX69+/v8cE+c+ZMnTlzRpIUExPj8QZTGampqe4Ponr16un555+/pu1VteTkZC1btkzS5bATExNjaz0AcD0iyMBrZs6cqR9++EHS5b+KqyLITJ06VZIUFRVVoSDzzjvvKCsrS5LUtm3ba6pjyZIl+umnnyRJnTt3di9PTk5219e/f/9iQaZp06bavHnzNT024A333HOP+7UaGhpqczWVx+/c9YkggypR0ptDTX7DKxo4rlXPnj0rdT+Xy6Wbb765yuowSU5OjoKDg+0uwwgXLlyQy+VSrVr2zQQIDw9XeHh4tT5GQUGBcnNzFRgYWG2P4cu/c9cz5sigStx8883FfgrDQlxcnBwOh3s0RpJuu+0293HquLg4SdKaNWv04IMPql27dmrYsKFq166t0NBQ9enTR2+99ZYuXrzovn90dLRuu+029/UffvihQvNESpsnERMT41FXUlKSbrzxRgUGBiosLExPPfWUzp0757GtkubIOBwOj0NvmzZtKnZs/mrH6+Pi4jRw4EA1b95cwcHBcjqdioiI0LBhwyo0D6c0FdnXJe2XZcuWqXfv3goMDFR4eLieeuopnT592uM+RfdxfHy8Zs6cqfbt28vpdOqll15yr/f999/riSeeUMuWLRUQEKCQkBD169dPCQkJsizLY5vp6el66qmn1LJlS7lcLgUGBioyMlKDBg3SlClTrnm/ZGZm6uWXX1bXrl0VHByswMBAdezYUXFxccrJySnXNq58XjMzM/X000+rSZMmCggIUM+ePZWUlORxnyvndKSkpGj48OGqX7++6tSpo+zsbElSfn6+5s2bp1tuuUX169eX0+lUVFSUnnzySR05cuSqdRw/flyjRo1SaGio6tevr0ceeUQ//vij8vLy9MorrygyMlIBAQHq0aOH1qxZ47GtsubIfPLJJ7rzzjvVqFEjOZ1ONW3aVKNGjdLOnTuLrVu0pp07d+q5557TDTfcoNq1a2v16tVl7t9Dhw4pNjZW7dq1U506dRQUFKR27drpl7/8pXJzcyv03FwpOTlZMTExHq/Fzp07a9KkSWXWBRtZQCXEx8dbktw/VzNlyhSPda/8mTJlimVZlvXb3/72qusNGTLEvc2oqKirrnvkyJGr1tS/f3/3uvHx8e7l48aNcy9v3bp1idt+6qmnPLZVtJYNGzZYlmVdtbbC/XXkyJFS92Hjxo1Lva/D4bA+/fRTj/Ur0ntF9/WV+6V9+/Yl3qdr167W+fPnS9zHbdq08Vj3ueeesyzLshITE62AgIBS6xg9erRVUFBgWZZl5eXlWa1atSp1XZfLVWbfV9ZV9Lk/cOCA1axZs1K336lTJ+vHH38sc/tXPq8dOnQo8TlcuHCh+z4bNmxw3xYaGmqFhYV5rH/69Gnr/Pnz1m233VZqffXq1bO+/vrrUuto27Ztsfv07dvXGjZsWLHlTqfTSk1NdW+r6O97//793cvz8/Othx9++KrPSVJSksf+KXr7la+LxMTEq+7blStXWnXq1Cn18U6fPl1sf0ZFRZW6T4qaP3++5e/vX+J2Q0NDy3zeYR9GZFAliv6VU/gzc+ZMSdJjjz2mzZs3q0mTJu713377bW3evFmbN2/WY489Jkm69dZb9fbbb2vZsmX64osvtH79ei1cuFCtW7eWJC1fvlzbt2+XdHleyttvv+3eXpMmTdzb27x5s5o2bXrNPR08eFCjRo3SypUr9fTTT7uXf/jhh2X+db5582b97ne/c1/v1q2bR31lef7557VgwQL94x//0MaNG7V69Wq98cYbkiTLsvTyyy9XsqvLKrKvr/T999/r8ccf12effabXX39dtWvXliT9v//3//TWW2+VeJ8DBw7ogQceUGJiopYtW6ZBgwbp1KlTGjNmjHt+0fjx47Vq1Sr99a9/VVRUlCRp4cKFio+Pd2//0KFDkqQuXbooMTFRa9eu1YIFC/Tcc8+5a6+sRx55RP/+978lXR4xTExM1IoVK9S/f39J0u7duys1ofzMmTNKSEhQYmKi+vTpI+nycxgbG1tsdE+SsrKydPHiRc2cOVNr1qzRrFmz5HK5FBcXpw0bNkiSWrRoofj4eK1Zs0bjx493P86oUaN06dKlEuvIzc3V4sWL9d5777lHI7Zu3arly5crLi5OK1eudM8Xy8vL09y5c8vsbd68eVq0aJEkqVGjRpo9e7bWrl2rl156SQ6HQ7m5uRozZkyx0bpChw4d0gsvvKDPP/9cf/3rX9WqVatSH+vUqVN6+OGHdf78eUlSy5YtNW/ePK1evVpz5sxx79vK2Lt3r55++mn3vuvWrZsWLFigVatWaebMmerQoUOltw0vsDtJwUxXjsiU9PPnP//Z4z4ljVwUde7cOev111+3evToYYWEhFgOh6PYNt9++233+qX91VUe5RmR6dixo3s0ID8/3+MvwZ07d5bZV2l/xRa62l+He/bsscaOHWu1aNHCcrlcJe7f7Oxs9/pFl5dnRKai+7rofunVq5fHtp599ln3bV26dClxH/fo0aNYDe+8847HaMfmzZvdP7///e/dt914442WZVlWSkqKe9nAgQOtPXv2WHl5eWX2eqWSnvtdu3a5l9WuXdtavXq1u5YlS5Z43Hb27Nmrbv/K5/Uf//iH+7Zjx45ZTqfTfdvSpUsty/J8LUsqNopRUFDgMUrz1ltveeyvpk2bum9btWpViXV89tln7u0VHSV68MEH3ctnzJjhXj58+HD38tJeyz169HAvnzRpkkdN3bt3d982d+5c932K1jRx4sRyPmuW9e6777rvFxwcbP373/8udd2Kjsi8+OKL7mXNmjWzcnJyyl0X7MdkX1SJkkYZWrZsWe77W5ale+65R5s2bbrqeqX9ZVcdbr/9dvdfrrVq1VL9+vXdfw1mZmZW2+Pu2rVLffv2LfGv9aJOnz6tunXrVnj717qvr5wsefPNN+vdd9+VdHnkpSTDhw8vtmzv3r3uy7t379Ytt9xS4n13794tSWrdurXuuOMOrVu3Tl988YU6duwoPz8/tWrVSn379tX48eN14403XrWn0hSt5eLFixo8eHCJ6128eFH79+9Xjx49yr3tovuradOmatmypfbt2yep5P3lcrl03333eSw7deqUTp065b4+ceLEUh9v9+7dJdZ/0003uS83bNjQfblv377uy40aNXJfLs9rvOh+mzFjhmbMmFFqTSUZMWJEmY9R0mP16dNHN9xwQ7nvW5FtDx48WEFBQVW2bVQ/ggyqxLV+E2Dr1q3uD1Y/Pz/FxcXppptuktPp1Kuvvqq1a9dKuvzNBm9p0KCBx3V////+ulhXTEKtSu+88447xLRp00ZxcXGKjIxUQUGBx0TLyu4LO/b1tRzqKzyM53A4tGLFCi1YsECrV6/W3r17dfjwYaWkpCglJUWLFi3SV199VelvkVW0nurSuHHjazpZW2n1Ff0WYdFvQNWrV6/E9avyNV5aTVVxCBhgjgy8puib55Ufkmlpae7L3bp100svvaTbb79dN954o8dt5d1eTVDZ+or2O2HCBD388MO65ZZb5OfnVyV1VWZfF/XPf/6z1OulzVMp6YO5ffv27ss33XSTLMsq8afwQ9CyLAUEBOipp57S0qVLtW/fPp07d04TJkyQdHm0ZMmSJWXWX5KitQQGBurMmTOl1lI4Z6a8iu6fEydO6PDhw+7rJe2vkvZVWFiYx2jJ6tWrS62vKr69VV5F99u8efNKrCk3N1fz588v8f4VCWxF56l8/fXXOnbsWOULv8q216xZU2w0tDr/cMG1Y0QGVWLLli3Flvn7+3sM9Tds2ND9FdEFCxaoVq1a8vf3V5cuXTwOQ+3cuVPvvfeeWrRoofnz52v//v0lPmbR4fFjx47po48+UsuWLRUYGFihof/qUrS+nTt3aunSpQoPD1e9evXUqVOnUu9XdF988MEHio6OVmZmpsdXlq9FZfZ1Ud98841++ctfavjw4frXv/6lefPmuW978MEHy13HQw89pN/97nfKycnRV199pV/84hd6+OGHFRoaqvT0dO3fv1+fffaZhg4dqilTpujkyZPq16+fRowYoc6dO6tp06Y6f/68duzY4d5m4cThiurcubN69eql7du368KFC7r99ts1YcIERUZG6tSpUzpy5IjWr1+vgoICrVu3rkLb/uUvf6lp06YpNDRUf/jDH5SXlyfp8kjInXfeWa5tFH6dv/DQzdixY/U///M/6tSpk3JycpSWlqZt27Zp5cqV7q9qe8Pjjz+u7777TpL0wgsv6NSpU+rVq5fy8vJ09OhR7dixQ0lJSdq+ffs1nwDzwQcf1OTJk3X27Fl3oPzNb36j6OhopaamKj4+Xp999lmpI0xXExMToz//+c/Kz8/X0aNH1b9/fz333HNq3LixUlJStHjx4hLf41BDeGkuDq4z5Znse+VXFidPnlzieps3b7by8/Otm266qdhtQUFBVq9evdzXC7+qbVmWdenSpRK/LtuqVasy6y/PZN+ij2VZpU/qLW15ZmZmiV8VHThwoGVZpU883Llzp1W7du1i9xswYECpk3pLW16SyuzrovulW7duJU4O7ty5s3Xu3Lky93FRS5cuverXr4vWcfz48auu5+/v7/H149KUVldKSspVv34tlTxp+0pXPq9FJ70W/jgcDuujjz5y36c8E9fPnz9f7DVQ0k9pdZRnH5Q2qfdqX78eNWpUmTVV9rV6peXLl1uBgYGlPs61fP16zpw5lp+fX4nb5evXNRuHluA1L730kp566imFh4cXG1KuVauWli9frpiYGDVu3FhBQUG67bbbtHHjxlK/+ujn56fExETdeuutqlOnjjdaqJD69etr6dKl6tmzp1wuV7nv17lzZ61du1Z9+/ZVUFCQmjRpomeffVYrVqyokroqs6+LGjJkiP7xj3+oT58+CggIUKNGjfTkk09qw4YNFX4ehg0bpn/961/65S9/qdatWysgIEBBQUFq3bq17rvvPs2dO1fPPPOMpMsjGK+99pruvPNONW/eXIGBgfL391dERISGDx+uzZs3q3fv3pXaJ9Ll+Ug7d+7UK6+8ou7duys4OFgul0vNmzfXrbfeqmnTppXrK8lX2rBhg2JjY9WkSRO5XC79/Oc/16effqoxY8ZUaDuBgYFat26d5s+frwEDBqhBgwby9/dX48aN1aNHD/3617+ukpMlVkStWrW0aNEi/f3vf9ddd92lsLAw+fv7q1GjRurSpYvGjx+vzz77TJGRkVXyeA888ICSk5M1fvx4tWnTRgEBAapTp47atm2rJ5544prOCjx+/Hh9/fXXGjNmjKKjo+V0OhUcHKxOnTrpySefrJL6UT0clsXBPwBXFxMTowULFkiSpkyZ4j4bM4pLTU1VixYt3Nd5iwWqFyMyAADAWAQZAABgLIIMAAAwFnNkAACAsRiRAQAAxiLIAAAAYxl9Zt+CggIdO3ZMdevWvab/TQIAAGoWy7J09uxZRUREePzLlysZHWSOHTtWZSdaAgAANc/Ro0fVrFmzUm83OsjUrVtXkvSnP/1JjRs3trka7zp27Jj27t2r3r17KyQkxO5yvKqw9wceeMDjH+n5goMHD+rLL7+kd3r3GYW9+/J7nS/2LkknT57UCy+84P6sL43RQabwcFLjxo2vmtauRxcvXpTT6VSTJk3UoEEDu8vxqsLeo6OjFRERYXc5XnXhwgV6p3e7y/Gqwt59+b3OF3svqqypI0z2BQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFj+dhcA1HRJSS5t2eJUcnJt7dvnr7w8h/u2EydO2lgZUD2O5xzX6h9Wa+uxrdp/er8yzmcoOy9bIc4QdWzYUSPbjtTItiPlcDjK3hhQzQgyQBlmzQrSnj217S4D8JolB5Zo2tfTii3P/ClTm9M3a3P6Zq08vFLxg+PlV8vPhgqB/yLIAGVwOKTo6Evq2vWSMjJqaetWp90lAV4RXidcA5sPVFTdKB09e1SfHvhUP+X/JEla88MaLd6/WKPbj7a5Svg6ggxQhhUrMhUYePnyjBlBBBlc924IvkHv3v6uhrYeKv9a//2YGNZmmH6x4hfu6+vT1hNkYDuCDFCGwhAD+IrhbYaXuPzmG25Wg4AGyvwpU5KUV5DnzbKAEvGtJQBAuRRO+i3UPby7jdUAlxFkAABlulRwSS9uelGXCi5JkhoFNtLYDmNtrgogyAAAypCTl6Oxn4/Vmh/WSJKCawfro7s+UqPARjZXBjBHBgBwFek56Rrz+Rjt/XGvJKlhQEN9fM/HHFZCjUGQAQCUKDkjWeNWjdPJ85dP/NgqtJUW3rNQ0aHR9hYGFMGhJQBAMZ8d+UzDkoa5Q8yNTW/UymErCTGocRiRAcqQkBCo1NTLZy/dscPzDL9xccHuyzExFxQdne/V2oDqkHQoSePXjVeBVSBJCnGGaECzAfrbvr95rBfiDNEjHR6xo0TAjSADlGH58oBST4I3d26Q+/KgQbkEGVwX9mfud4cYScrOy9b07dOLrdcsuBlBBrbj0BIAADAWIzJAGRITT9tdAuBVk3pN0qRek+wuAygXRmQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYq0YEmdmzZys6OloBAQHq06ePvvnmG7tLAgAABrA9yHzyySeaOHGipkyZou+++05du3bV4MGDlZGRYXdpAACghrM9yLz11lt68skn9eijj6pDhw6aO3eu6tSpo7/85S92lwYAAGo4fzsfPC8vT99++60mT57sXlarVi3dcccd2rp1a7H1c3NzlZub676enZ0tSTp27JguXrxY/QXXIKdOnZIkpaenKysry+ZqvKuw95SUFPdlX5GWliaJ3unddxT27svvdb7Yu6Ryv9ZtDTL/+c9/lJ+fr8aNG3ssb9y4sfbt21ds/TfffFNTp04ttnzv3r1yOp3VVmdNtmvXLrtLsIXD4dD69evtLsMW9E7vvshX3+sk3+09Ly+vXOvZGmQqavLkyZo4caL7enZ2tiIjI9W7d281adLExsq8Lz09Xbt27VLfvn0VGhpqdzleVdj7iBEjFBYWZnc5XpWSkqL169fTO737jMLeffm9zhd7l6QTJ04oISGhzPVsDTKNGjWSn5+fTp486bH85MmTJQYTl8sll8tVbHlISIgaNGhQbXXWRIXDjKGhoT7be1hYmCIiImyuxrsKh1rpnd59RWHvvvxe54u9S9L58+fLtZ6tk32dTqd69OihL774wr2soKBAX3zxhfr27WtjZQAAwAS2H1qaOHGixo0bp549e6p3796aOXOmzp07p0cffdTu0gAAQA1ne5B56KGHdOrUKb3yyis6ceKEunXrplWrVhWbAAwAAHAl24OMJD377LN69tln7S4DAAAYxvYT4gEAAFQWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLH+7CwBqsuM5x7X6h9Xaemyr9p/er4zzGcrOy1aIM0QdG3bUyLYjNbLtSDkcDrtLBaoMr3uYhCADXMWSA0s07etpxZZn/pSpzembtTl9s1YeXqn4wfHyq+VnQ4VA1eN1D5NwaAkoh/A64RrVbpT+p9f/aHS70QrwC3DftuaHNVq8f7GN1QHVg9c9TMCIDHAVNwTfoHdvf1dDWw+Vf63//roMazNMv1jxC/f19WnrNbr9aDtKBKocr3uYhCADXMXwNsNLXH7zDTerQUADZf6UKUnKK8jzZllAteJ1D5NwaAmohMLJj4W6h3e3sRrAO3jdoyYiyAAVdKngkl7c9KIuFVySJDUKbKSxHcbaXBVQvXjdo6YiyAAVkJOXo7Gfj9WaH9ZIkoJrB+ujuz5So8BGNlcGVB9e96jJmCMDlFN6TrrGfD5Ge3/cK0lqGNBQH9/zMcPruK7xukdNR5AByiE5I1njVo3TyfMnJUmtQltp4T0LFR0abW9hQDXidQ8TcGgJKMNnRz7TsKRh7jfzG5veqJXDVvJmjusar3uYghEZ4CqSDiVp/LrxKrAKJEkhzhANaDZAf9v3N4/1QpwheqTDI3aUCFQ5XvcwCUEGuIr9mfvdb+aSlJ2Xrenbpxdbr1lwM97Qcd3gdQ+TcGgJAAAYixEZ4Com9ZqkSb0m2V0G4FW87mESRmQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYy9Yg8+WXX+r+++9XRESEHA6Hli1bZmc5AADAMLYGmXPnzqlr166aPXu2nWUAAABD+dv54HfffbfuvvtuO0sAAAAGszXIVFRubq5yc3Pd17OzsyVJx44d08WLF+0qyxanTp2SJKWnpysrK8vmaryrsPeUlBT3ZV+RlpYmid7p3XcU9u7L73W+2Lukcr/WHZZlWdVcS7k4HA4lJiZq6NChpa4TFxenqVOnFlseExMjp9NZjdWhpnE4HKohL12vo3d69zX07pu95+XlKSEhQVlZWQoJCSl1PaNGZCZPnqyJEye6r2dnZysyMlK9e/dWkyZNbKzM+9LT07Vr1y717dtXoaGhdpfjVYW9jxgxQmFhYXaX41UpKSlav349vdO7z6B33+xdklJTU5WQkFDmekYFGZfLJZfLVWx5SEiIGjRoYENF9ikcZgwNDfXZ3sPCwhQREWFzNd5VONRK7/TuK+jdN3uXpJycnHKtx3lkAACAsWwdkcnJydHBgwfd148cOaLk5GQ1aNBAzZs3t7EyAABgAluDzI4dO3Tbbbe5rxfOfxk3bly5josBAADfZmuQGTBggM/OxgYAANeOOTIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsfztLgCo6ZKSXNqyxank5Nrat89feXkO920nTpy0sTKgevjya/54znGt/mG1th7bqv2n9yvjfIay87IV4gxRx4YdNbLtSI1sO1IOh6PsjRnG1N4JMkAZZs0K0p49te0uA/AaX37NLzmwRNO+nlZseeZPmdqcvlmb0zdr5eGVih8cL79afjZUWH1M7Z0gA5TB4ZCioy+pa9dLysiopa1bnXaXBFQrXvNSeJ1wDWw+UFF1o3T07FF9euBT/ZT/kyRpzQ9rtHj/Yo1uP9rmKquHab0TZIAyrFiRqcDAy5dnzAjyyTd1+BZffs3fEHyD3r39XQ1tPVT+tf77ETmszTD9YsUv3NfXp62vUR/mVcHU3gkyQBkK39ABX+HLr/nhbYaXuPzmG25Wg4AGyvwpU5KUV5DnzbK8wtTe+dYSAABlKJz4Wqh7eHcbq/Gumt47QQYAgKu4VHBJL256UZcKLkmSGgU20tgOY22uyjtM6J0gAwBAKXLycjT287Fa88MaSVJw7WB9dNdHahTYyObKqp8pvTNHBgCAEqTnpGvM52O098e9kqSGAQ318T0f17hDK9XBpN4JMgAAXCE5I1njVo3TyfOXTwDYKrSVFt6zUNGh0fYW5gWm9c6hJQAAivjsyGcaljTM/UF+Y9MbtXLYyhr7QV6VTOydERmgDAkJgUpNvXwWyx07PM92GhcX7L4cE3NB0dH5Xq0NqA6+/JpPOpSk8evGq8AqkCSFOEM0oNkA/W3f3zzWC3GG6JEOj9hRYrUxtXeCDFCG5csDSj0h2Ny5Qe7LgwblXndv6vBNvvya35+53/1BLknZedmavn16sfWaBTerUR/mVcHU3jm0BAAAjMWIDFCGxMTTdpcAeJUvv+Yn9ZqkSb0m2V2GLUztnREZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxrI1yLz55pvq1auX6tatq/DwcA0dOlT79++3syQAAGAQW4PMpk2bFBsbq23btmnt2rW6ePGi7rzzTp07d87OsgAAgCH87XzwVatWeVxPSEhQeHi4vv32W9166602VQUAAExha5C5UlZWliSpQYMGJd6em5ur3Nxc9/Xs7GxJ0rFjx3Tx4sXqL7AGOXXqlCQpPT3dvd98RWHvKSkp7su+Ii0tTRK907vvoHff7F26/PlWHg7LsqxqrqVcCgoK9MADD+jMmTPasmVLievExcVp6tSpxZbHxMTI6XRWd4k1jsPhUA15+ryO3und19A7vfuavLw8JSQkKCsrSyEhIaWuV2OCzNNPP63PP/9cW7ZsUbNmzUpcp6QRmcjISC1dulTR0dFeqrRmSElJ0fr16zVixAiFhYXZXY5X0Tu907vvoHff7F2SUlNTNXz48DKDTI04tPTss89q5cqV+vLLL0sNMZLkcrnkcrmKLW/UqJEiIiKqs8Qap3CYMSwsjN59CL3TO737Dl/uXZJycnLKtZ6tQcayLP3qV79SYmKiNm7cqBYtWthZDgAAMIytQSY2NlaLFi3S8uXLVbduXZ04cUKSFBoaqsDAQDtLAwAABrD1PDJz5sxRVlaWBgwYoKZNm7p/PvnkEzvLAgAAhrD90BIAAEBl8b+WAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLH87S7AJElJLm3Z4lRycm3t2+evvDyH+7YTJ07aWFn1o3ff7B0AajqCTAXMmhWkPXtq212GLejdN3sHgJqOIFMBDocUHX1JXbteUkZGLW3d6rS7JK+hd9/sHQBqOoJMBaxYkanAwMuXZ8wI8qkPNHq/fNnXegeAmo7JvhVQ+GHmi+gdAFATEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIzFeWQqICEhUKmpfpKkHTs8z/QaFxfsvhwTc0HR0flera260btv9g4ANR1BpgKWLw8o9WRoc+cGuS8PGpR73X2g0btv9g4ANR2HlgAAgLEYkamAxMTTdpdgG3oHANREjMgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMa65iDz008/VUUdAAAAFVapIFNQUKDXXntNN9xwg4KDg3X48GFJ0ssvv6wPP/ywSgsEAAAoTaWCzOuvv66EhAT97//+r5zO//4zvU6dOumDDz6osuIAAACuplJB5qOPPtL8+fM1evRo+fn5uZd37dpV+/btq7LiAAAArqZSQSY9PV2tW7cutrygoEAXL1685qIAAADKo1JBpkOHDtq8eXOx5UuWLFH37t2vuSgAAIDy8K/MnV555RWNGzdO6enpKigo0NKlS7V//3599NFHWrlyZVXXCAAAUKJKjcgMGTJEK1as0Lp16xQUFKRXXnlF33//vVasWKFBgwZVdY0AAAAlqtSIjCTdcsstWrt2bVXWAgAAUCGVDjKSlJeXp4yMDBUUFHgsb968+TUVBQAAUB6VCjIHDhzQY489pq+++spjuWVZcjgcys/Pr5LiAAAArqZSQSYmJkb+/v5auXKlmjZtKofDUdV1AQAAlKlSQSY5OVnffvut2rVrd00PPmfOHM2ZM0epqamSpI4dO+qVV17R3XfffU3bBQAAvqHS55H5z3/+c80P3qxZM02fPl3ffvutduzYodtvv11DhgzRnj17rnnbAADg+lepIPOHP/xBv/nNb7Rx40b9+OOPys7O9vgpr/vvv1/33HOP2rRpo7Zt22ratGkKDg7Wtm3bKlMWAADwMZU6tHTHHXdIkgYOHOix/Fom++bn5+v//u//dO7cOfXt27cyZQEAAB9TqSCzYcOGKitg165d6tu3r3766ScFBwcrMTFRHTp0KHHd3Nxc5ebmuq8Xjv4cPHhQFy5cqLKaTJCWliZJSklJ0alTp2yuxrvond7p3XfQu2/2Ll3+v47l4bAsy6rmWq4qLy9PaWlpysrK0pIlS/TBBx9o06ZNJYaZuLg4TZ06tdjymJgYOZ1Ob5RbozgcDtn89NmG3und19A7vfuavLw8JSQkKCsrSyEhIaWuV6kgs3PnzpI35nAoICBAzZs3l8vlquhmJV0+bNWqVSvNmzev2G0ljchERkZq6dKlio6OrtTjmSolJUXr16/XiBEjFBYWZnc5XkXv9E7vvoPefbN3SUpNTdXw4cPLDDKVOrTUrVu3q547pnbt2nrooYc0b948BQQEVGjbBQUFHmGlKJfLVWJAatSokSIiIir0OKYrHGYMCwujdx9C7/RO777Dl3uXpJycnHKtV6lvLSUmJqpNmzaaP3++kpOTlZycrPnz5+tnP/uZFi1apA8//FDr16/XSy+9dNXtTJ48WV9++aVSU1O1a9cuTZ48WRs3btTo0aMrUxYAAPAxlRqRmTZtmmbNmqXBgwe7l3Xu3FnNmjXTyy+/rG+++UZBQUF64YUX9Mc//rHU7WRkZGjs2LE6fvy4QkND1aVLF61evZr/oA0AAMqlUkFm165dioqKKrY8KipKu3btknT58NPx48evup0PP/ywMg8PAAAgqZKHltq1a6fp06crLy/PvezixYuaPn26+98WpKenq3HjxlVTJQAAQAkqNSIze/ZsPfDAA2rWrJm6dOki6fIoTX5+vlauXClJOnz4sJ555pmqqxQAAOAKlQoyN910k44cOaKFCxcqJSVFkjRy5Eg9/PDDqlu3riRpzJgxVVclAABACSoVZCSpbt26Gj9+fFXWAgAAUCHlDjJJSUm6++67Vbt2bSUlJV113QceeOCaCwMAAChLuYPM0KFDdeLECYWHh2vo0KGlrlfZfxoJAABQUeUOMgUFBSVeLuro0aN69dVXr70qAACAcqjU169Lk5mZqb/85S9VuUkAAIBSVWmQAQAA8CaCDAAAMBZBBgAAGKtC55EZPnz4VW8/c+bMtdQCAABQIRUKMqGhoWXePnbs2GsqCAAAoLwqFGTi4+Orqw4AAIAKY44MAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLFqTJCZPn26HA6Hnn/+ebtLAQAAhqgRQWb79u2aN2+eunTpYncpAADAILYHmZycHI0ePVrvv/++6tevb3c5AADAILYHmdjYWN17772644477C4FAAAYxt/OB1+8eLG+++47bd++vVzr5+bmKjc31309OztbknTw4EFduHChWmqsqdLS0iRJKSkpOnXqlM3VeBe90zu9+w56983eJSk9Pb1c6zksy7KquZYSHT16VD179tTatWvdc2MGDBigbt26aebMmSXeJy4uTlOnTi22PCYmRk6nszrLrZEcDodsevpsR+/07mvond59TV5enhISEpSVlaWQkJBS17MtyCxbtkzDhg2Tn5+fe1l+fr4cDodq1aql3Nxcj9ukkkdkIiMjtXTpUkVHR3ur9BohJSVF69ev14gRIxQWFmZ3OV5F7/RO776D3n2zd0lKTU3V8OHDywwyth1aGjhwoHbt2uWx7NFHH1W7du3029/+tliIkSSXyyWXy1VseaNGjRQREVFttdZEhcOMYWFh9O5D6J3e6d13+HLv0uUvA5WHbUGmbt266tSpk8eyoKAgNWzYsNhyAACAktj+rSUAAIDKsvVbS1fauHGj3SUAAACDMCIDAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjOVvdwEmSUpyacsWp5KTa2vfPn/l5Tnct504cdLGyqofvdM7vdO7dP33DvMQZCpg1qwg7dlT2+4ybEHv9O5r6N03e4d5CDIV4HBI0dGX1LXrJWVk1NLWrU67S/Iaeqd3eqd3oCYiyFTAihWZCgy8fHnGjCCf+uWm98uX6Z3efYEv9w7zMNm3Agp/sX0RvfsmevdNvtw7zEOQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFueRqYCEhEClpvpJknbs8DzrZVxcsPtyTMwFRUfne7W26kbv9E7v/0Xvl12PvcM8BJkKWL48oNQTQ82dG+S+PGhQ7nX3y03v9H4ler+M3q+v3mEeDi0BAABjMSJTAYmJp+0uwTb07pvo3Tf5cu8wDyMyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGMvWIBMXFyeHw+Hx065dOztLAgAABvG3u4COHTtq3bp17uv+/raXBAAADGF7avD391eTJk3sLgMAABjI9jkyBw4cUEREhFq2bKnRo0crLS3N7pIAAIAhbB2R6dOnjxISEvSzn/1Mx48f19SpU3XLLbdo9+7dqlu3brH1c3NzlZub676enZ0tSTp48KAuXLjgtbprgsLAl5KSolOnTtlcjXfRO73Tu++gd9/sXZLS09PLtZ7DsiyrmmsptzNnzigqKkpvvfWWHn/88WK3x8XFaerUqcWWx8TEyOl0eqNEALCFw+FQDXq79ip6983e8/LylJCQoKysLIWEhJS6Xo0KMpLUq1cv3XHHHXrzzTeL3VbSiExkZKTee+89n5tnk56erl27dqlv374KDQ21uxyvond699XeR4wYobCwMLvL8aqUlBStX7+e3n2sd0lKTU3V8OHDywwytk/2LSonJ0eHDh3SmDFjSrzd5XLJ5XIVWx4SEqIGDRpUd3k1SlZWliQpNDSU3n0Ivft272FhYYqIiLC5Gu8qPKRC777Vu3Q5E5SHrZN9X3zxRW3atEmpqan66quvNGzYMPn5+WnUqFF2lgUAAAxh64jMv//9b40aNUo//vijwsLCdPPNN2vbtm0+OYQGAAAqztYgs3jxYjsfHgAAGM7288gAAABUFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMJa/3QUAAGqWpCSXtmxxKjm5tvbt81densN924kTJ22sDCiOIAMA8DBrVpD27KltdxlAuRBkAAAeHA4pOvqSuna9pIyMWtq61Wl3SUCpCDIAAA8rVmQqMPDy5RkzgggyqNGY7AsA8FAYYgATEGQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIzFeWQAAB4SEgKVmuonSdqxw/MMv3Fxwe7LMTEXFB2d79XagCsRZAAAHpYvDyj1JHhz5wa5Lw8alEuQge04tAQAAIzFiAwAwENi4mm7SwDKjREZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjGV7kElPT9cjjzyihg0bKjAwUJ07d9aOHTvsLgsAABjA384HP336tPr166fbbrtNn3/+ucLCwnTgwAHVr1/fzrIAAIAhbA0yf/jDHxQZGan4+Hj3shYtWthYEQAAMImth5aSkpLUs2dPjRw5UuHh4erevbvef/99O0sCAAAGsXVE5vDhw5ozZ44mTpyo3/3ud9q+fbsmTJggp9OpcePGFVs/NzdXubm57uvZ2dmSpGPHjunixYteq7smOHXqlKTLc4yysrJsrsa76J3efbX3lJQU92VfkZaWJonefa136fLvenk4LMuyqrmWUjmdTvXs2VNfffWVe9mECRO0fft2bd26tdj6cXFxmjp1arHlMTExcjqd1VorANjJ4XDIxrdrW9G7b/ael5enhIQEZWVlKSQkpNT1bB2Radq0qTp06OCxrH379vr0009LXH/y5MmaOHGi+3p2drYiIyPVu3dvNWnSpFprrWnS09O1a9cu9e3bV6GhoXaX41X0Tu++2vuIESMUFhZmdzlelZKSovXr19O7j/UuSampqUpISChzPVuDTL9+/bR//36PZSkpKYqKiipxfZfLJZfLVWx5SEiIGjRoUC011lSFQ+uhoaH07kPo3bd7DwsLU0REhM3VeFfhIRV6963eJSknJ6dc69k62ffXv/61tm3bpjfeeEMHDx7UokWLNH/+fMXGxtpZFgAAMIStQaZXr15KTEzU3/72N3Xq1EmvvfaaZs6cqdGjR9tZFgAAMISth5Yk6b777tN9991ndxkAAMBAtv+LAgAAgMoiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADG8re7AABAzZKU5NKWLU4lJ9fWvn3+ystzuG87ceKkjZUBxRFkAAAeZs0K0p49te0uAygXggwAwIPDIUVHX1LXrpeUkVFLW7c67S4JKBVBBgDgYcWKTAUGXr48Y0YQQQY1GpN9AQAeCkMMYAKCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsTiPDADAQ0JCoFJT/SRJO3Z4nuE3Li7YfTkm5oKio/O9WhtwJYIMAMDD8uUBpZ4Eb+7cIPflQYNyCTKwHYeWAACAsRiRAQB4SEw8bXcJQLkxIgMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxbA0y0dHRcjgcxX5iY2PtLAsAABjC384H3759u/Lz893Xd+/erUGDBmnkyJE2VgUAAExha5AJCwvzuD59+nS1atVK/fv3t6kiAABgkhozRyYvL08ff/yxHnvsMTkcDrvLAQAABrB1RKaoZcuW6cyZM4qJiSl1ndzcXOXm5rqvZ2VlSZJOnjxZ3eXVOKdOnVJeXp5OnDih8+fP212OV9E7vftq76mpqcrJybG7HK9KT0+ndx/sXZLS0tIkSZZlXXU9h1XWGl4yePBgOZ1OrVixotR14uLiNHXqVC9WBQAA7HT06FE1a9as1NtrRJD54Ycf1LJlSy1dulRDhgwpdb0rR2TOnDmjqKgopaWlKTQ01Bul1hjZ2dmKjIzU0aNHFRISYnc5XkXv9E7vvoPefbN36fJIzNmzZxUREaFatUqfCVMjDi3Fx8crPDxc995771XXc7lccrlcxZaHhob65JMsSSEhIfTug+id3n0Nvftm7+UZpLB9sm9BQYHi4+M1btw4+fvXiFwFAAAMYXuQWbdundLS0vTYY4/ZXQoAADCM7UMgd955Z5kzkkvjcrk0ZcqUEg83Xe/ond59Db3Tu6/x5d4rokZM9gUAAKgM2w8tAQAAVBZBBgAAGIsgAwAAjGV0kJk9e7aio6MVEBCgPn366JtvvrG7pGr35Zdf6v7771dERIQcDoeWLVtmd0le8+abb6pXr16qW7euwsPDNXToUO3fv9/usrxizpw56tKli/t8En379tXnn39ud1m2mD59uhwOh55//nm7S6l2cXFxcjgcHj/t2rWzuyyvSU9P1yOPPKKGDRsqMDBQnTt31o4dO+wuq9pFR0cXe94dDodiY2PtLq1GMjbIfPLJJ5o4caKmTJmi7777Tl27dtXgwYOVkZFhd2nV6ty5c+ratatmz55tdylet2nTJsXGxmrbtm1au3atLl68qDvvvFPnzp2zu7Rq16xZM02fPl3ffvutduzYodtvv11DhgzRnj177C7Nq7Zv36558+apS5cudpfiNR07dtTx48fdP1u2bLG7JK84ffq0+vXrp9q1a+vzzz/X3r179ac//Un169e3u7Rqt337do/nfO3atZKkkSNH2lxZDWUZqnfv3lZsbKz7en5+vhUREWG9+eabNlblXZKsxMREu8uwTUZGhiXJ2rRpk92l2KJ+/frWBx98YHcZXnP27FmrTZs21tq1a63+/ftbzz33nN0lVbspU6ZYXbt2tbsMW/z2t7+1br75ZrvLqBGee+45q1WrVlZBQYHdpdRIRo7I5OXl6dtvv9Udd9zhXlarVi3dcccd2rp1q42VwZsK//t5gwYNbK7Eu/Lz87V48WKdO3dOffv2tbscr4mNjdW9997r8XvvCw4cOKCIiAi1bNlSo0ePdv9H4OtdUlKSevbsqZEjRyo8PFzdu3fX+++/b3dZXpeXl6ePP/5Yjz32mBwOh93l1EhGBpn//Oc/ys/PV+PGjT2WN27cWCdOnLCpKnhTQUGBnn/+efXr10+dOnWyuxyv2LVrl4KDg+VyuTR+/HglJiaqQ4cOdpflFYsXL9Z3332nN9980+5SvKpPnz5KSEjQqlWrNGfOHB05ckS33HKLzp49a3dp1e7w4cOaM2eO2rRpo9WrV+vpp5/WhAkTtGDBArtL86ply5bpzJkziomJsbuUGsv2M/sClREbG6vdu3f7zHwBSfrZz36m5ORkZWVlacmSJRo3bpw2bdp03YeZo0eP6rnnntPatWsVEBBgdzledffdd7svd+nSRX369FFUVJT+/ve/6/HHH7exsupXUFCgnj176o033pAkde/eXbt379bcuXM1btw4m6vzng8//FB33323IiIi7C6lxjJyRKZRo0by8/PTyZMnPZafPHlSTZo0sakqeMuzzz6rlStXasOGDWrWrJnd5XiN0+lU69at1aNHD7355pvq2rWrZs2aZXdZ1e7bb79VRkaGfv7zn8vf31/+/v7atGmT3n77bfn7+ys/P9/uEr2mXr16atu2rQ4ePGh3KdWuadOmxUJ6+/btfebQmiT98MMPWrdunZ544gm7S6nRjAwyTqdTPXr00BdffOFeVlBQoC+++MKn5gz4Gsuy9OyzzyoxMVHr169XixYt7C7JVgUFBcrNzbW7jGo3cOBA7dq1S8nJye6fnj17avTo0UpOTpafn5/dJXpNTk6ODh06pKZNm9pdSrXr169fsdMrpKSkKCoqyqaKvC8+Pl7h4eG699577S6lRjP20NLEiRM1btw49ezZU71799bMmTN17tw5Pfroo3aXVq1ycnI8/ho7cuSIkpOT1aBBAzVv3tzGyqpfbGysFi1apOXLl6tu3bru+VChoaEKDAy0ubrqNXnyZN19991q3ry5zp49q0WLFmnjxo1avXq13aVVu7p16xabBxUUFKSGDRte9/OjXnzxRd1///2KiorSsWPHNGXKFPn5+WnUqFF2l1btfv3rX+umm27SG2+8oQcffFDffPON5s+fr/nz59tdmlcUFBQoPj5e48aNk7+/sR/V3mH316auxTvvvGM1b97ccjqdVu/eva1t27bZXVK127BhgyWp2M+4cePsLq3aldS3JCs+Pt7u0qrdY489ZkVFRVlOp9MKCwuzBg4caK1Zs8busmzjK1+/fuihh6ymTZtaTqfTuuGGG6yHHnrIOnjwoN1lec2KFSusTp06WS6Xy2rXrp01f/58u0vymtWrV1uSrP3799tdSo3Hf78GAADGMnKODAAAgESQAQAABiPIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADoEaIi4tTt27d7C4DgGEIMgCqxIkTJ/SrX/1KLVu2lMvlUmRkpO6//36Pf+4KAFWN/0QF4JqlpqaqX79+qlevnmbMmKHOnTvr4sWLWr16tWJjY7Vv3z67SwRwnWJEBsA1e+aZZ+RwOPTNN99oxIgRatu2rTp27KiJEydq27ZtkqS0tDQNGTJEwcHBCgkJ0YMPPqiTJ0+Wus2CggK9+uqratasmVwul7p166ZVq1a5b09NTZXD4dDSpUt12223qU6dOuratau2bt3qXichIUH16tXT6tWr1b59ewUHB+uuu+7S8ePHPR7rgw8+UPv27RUQEKB27drpvffeq+I9BKC6EGQAXJPMzEytWrVKsbGxCgoKKnZ7vXr1VFBQoCFDhigzM1ObNm3S2rVrdfjwYT300EOlbnfWrFn605/+pD/+8Y/auXOnBg8erAceeEAHDhzwWO/3v/+9XnzxRSUnJ6tt27YaNWqULl265L79/Pnz+uMf/6i//vWv+vLLL5WWlqYXX3zRffvChQv1yiuvaNq0afr+++/1xhtv6OWXX9aCBQuqYO8AqHZ2//ttAGb7+uuvLUnW0qVLS11nzZo1lp+fn5WWluZetmfPHkuS9c0331iWZVlTpkyxunbt6r49IiLCmjZtmsd2evXqZT3zzDOWZVnWkSNHLEnWBx98UGyb33//vWVZlhUfH29Jsg4ePOheZ/bs2Vbjxo3d11u1amUtWrTI43Fee+01q2/fvuXdBQBsxIgMgGtiWVaZ63z//feKjIxUZGSke1mHDh1Ur149ff/998XWz87O1rFjx9SvXz+P5f369Su2fpcuXdyXmzZtKknKyMhwL6tTp45atWrlsU7h7efOndOhQ4f0+OOPKzg42P3z+uuv69ChQ2X2BcB+TPYFcE3atGkjh8Nh24Te2rVruy87HA5Jl+fXlHR74TqF4SsnJ0eS9P7776tPnz4e6/n5+VVLvQCqFiMyAK5JgwYNNHjwYM2ePVvnzp0rdvuZM2fUvn17HT16VEePHnUv37t3r86cOaMOHToUu09ISIgiIiL0z3/+02P5P//5zxLXr6zGjRsrIiJChw8fVuvWrT1+WrRoUWWPA6D6MCID4JrNnj1b/fr1U+/evfXqq6+qS5cuunTpktauXas5c+Zo79696ty5s0aPHq2ZM2fq0qVLeuaZZ9S/f3/17NmzxG1OmjRJU6ZMUatWrdStWzfFx8crOTlZCxcurNLap06dqgkTJig0NFR33XWXcnNztWPHDp0+fVoTJ06s0scCUPUIMgCuWcuWLfXdd99p2rRpeuGFF3T8+HGFhYWpR48emjNnjhwOh5YvX65f/epXuvXWW1WrVi3dddddeuedd0rd5oQJE5SVlaUXXnhBGRkZ6tChg5KSktSmTZsqrf2JJ55QnTp1NGPGDE2aNElBQUHq3Lmznn/++Sp9HADVw2GVZ6YeAABADcQcGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACM9f8Bq4DZtDSjhqwAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATylJREFUeJzt/Xl4FGXe/n+fHSAbIQFCWEKAyOIgsoggyKACGgVhJAgyjqKCwtzKoiwCmrlHCDoCDuM+yCKYuKJfGCKbCiiCqKCAv9yAsgskhlURQoBsdD1/8KSGJgkkId2Vi36/jiPH0XXV1d2fT3elcqa6uttlWZYlAAAAAwU4XQAAAEBZEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZHBZkpOT5XK55HK51LVrV6fLgQ/Exsbaz/nq1asdreWLL76wa3nrrbe8ch+DBg2y7yMxMdEr9wFPiYmJ9mM+aNAgp8sp0vHjxxUeHi6Xy6UHH3zQ6XL8GkEGtvNDyfk/gYGBql+/vvr27evVP1yvvPKKEhMTlZiYqH379nntflAxHD9+3H6+yxIQ3G63nnzySUlSgwYN+GMCn6pevbqGDRsmSXr//fe1adMmhyvyX5WdLgAVX15eng4cOKCUlBSlpKTotdde0+OPP17u9/PKK69o//79kqSuXbsqNja23O8DFcfx48c1adIke7m0Yebjjz/W//3f/0mSHn30UVWpUqU8y7P97//+r4YMGSJJatiwoVfuA2YaPny4/vnPf8qyLD333HP6+OOPnS7JL3FEBsVau3at1q5dqw8++EBXX321PT5u3DgdOXLEwcoA6Y033rAv33fffV67n2bNmummm27STTfddMUFmaysLKdLMFqDBg3UuXNnSdLSpUuVkZHhcEX+iSCDYhXsvO+77z7NnDnTHs/JydG333570ev+9ttveuyxx9SxY0fVq1dPwcHBCgkJUdOmTfXXv/5VP//8sz234PXwgqMxktStW7ciz0s4duyYnnnmGbVp00ZhYWEKCQnRtddeq8TExEI75T179uiRRx7R9ddfrzp16igwMFBVq1ZVixYtNHr06EJh7GKvy3ft2tVel5ycXKLHz+126+2331ZcXJxq1aqlwMBA1alTR7fddpuWLl3qMffnn3/W0KFD1bRpUwUHByssLExt2rTRhAkTdPz48YvW+cknn6hdu3YKDg5WkyZN9O9//1uStGvXLvXu3Vvh4eGqXr26/vKXv+jo0aMX7WvOnDlq3bq1goODFRMTo6eeekrZ2dkl6leSfvnlF40aNUrNmzdXSEiIwsLC1K5dO7388svKy8vzuN+rrrrK47rnv5x5qZcwjx49qlWrVkmSmjdvrsaNG3usv/Dcre+++0633HKLQkNDFRMTo8TERJ09e1aHDh3Sgw8+qJo1ayosLEy9evXSnj17PG6ruHNkLnwevvnmG916662qWrWqIiIidO+99xYZ+Ev6GEnnjlqNHTvWnhsUFKTo6Gh16dJF48aN0+nTpy/6OBVV/3vvvae2bdsqODhYDzzwQKnrSkhIsG/v0UcfLXR/TZs2tdevWLGiTH1fzNmzZzVr1izdfPPNqlGjhgIDA9WoUSP99a9/1d69e4u8zooVKxQfH6+6desqMDBQUVFR6t27t9auXVto7vr16xUfH6969eqpSpUqCg8PV9OmTdWvXz+9//77heb36tXLrmv+/Pkl7gPlyAL+/5KSkixJ9s/5fvjhB491H330UaHrdOnSxZ6/bds2j/kX/tSoUcPas2ePZVmWNXHixIvOnThxomVZlrVr1y4rJiam2HktW7a0fvvtN7uGTz/99KK3Gxsba/3+++/2/PPrGDhwoEf/Xbp0sdclJSVd8rHMzs627rjjjmLve+TIkfbc1atXW2FhYcXOveqqq6xffvmlyDqbNGliBQQEFLrOU089ZdWsWbPQePfu3Yvtq0WLFkXef48ePSy3221fp1GjRva6L7/80h5ft26dVb169WL76Natm5WdnV3ofov6Of92i7JgwYJinyvL8twuY2JirNDQ0EL38eijj1qNGzcuNN6iRQvr7Nmz9m0NHDiw0LZ44fNw1VVXWZUrV77k412ax8iyLOuWW2656ON08ODBiz5OF9bfrFkzj+vHx8eXuq6dO3fa4zVr1rRyc3M9+itY16hRI/txLG3fxf0unj592urWrVuxt1O9enXru+++8+j/qaeeKnZ+QECANWPGDHvutm3brKCgoGLnX/h8WpZlrVq1yl7fu3fvSz4fKH8ckcEl/fLLL5owYYLH2HXXXXfR69SoUUPPPvusPvroI3322WdavXq1lixZYv8H+Pvvv+vFF1+UJD3yyCNau3at6tata1//tddes1/aeuSRRyRJDzzwgH755RdJ547YpKSkaMmSJerSpYskaevWrRo1apR9G40aNdLUqVO1YMECrVixQqtXr1ZKSop69OghSdq3b5/efPPNsj8wFzFp0iT7v1GXy6X/+Z//0eLFi/Wf//xHo0aNUrVq1SRJ2dnZuv/+++2jSR06dNDChQv1zjvvqH79+pKkvXv36n/+53+KvJ89e/aof//+WrZsmfr162ePv/DCC6pWrZo++ugjvf766/b48uXLtWPHjiJva9u2bRo/frw++eQTjRkzxh7/7LPP9MEHH1y035ycHN1777320aN+/fpp2bJlWrBggVq3bi1J+vLLL/X8889Lkl5//fVC/70WPN9r165V27ZtL3p/W7ZssS83a9bsonN/+eUXderUSUuWLNHQoUPt8VmzZun48eN666239O677yokJESS9NNPP2nlypUXvc0L7d27V926ddPixYs1ceJEe/z8x7u0j9Gvv/6qr776StK5lzA+/PBDffHFF3rvvff01FNPqWXLlnK5XKWqc9euXercubM++ugjLVu2TH/5y19KXVezZs10yy23SDp3hPTTTz+1b//87eThhx9WQEBAqW//YhITE/Xll19Kkq666iolJSVpxYoVeuyxxySdO4J13333KT8/X5L06aef6oUXXpAkhYSE6J///KdWrlypF198UUFBQXK73Xr88ce1c+dOSedeHsrJyZEk9e/fX5999pk++eQTzZo1SwMGDFCtWrUK1XT+y+6bN2++ZA/wAqeTFCqOC4/IFPdz/n9IxR2RsSzLWrp0qdWrVy+rbt26Rf63ev3113vML+4/fcuyrC1bttjrqlSpYi1fvtxau3attXbtWo//zqtUqWKdPHnSvt4777xj3XrrrVatWrWsSpUqFaqhb9++9tzyOiLjdrutqKgoe/7o0aOLnbto0SJ7XmBgoHXgwAGPx69gncvlsg4fPlyozujoaCsvL8+yLMv6/vvvPXr75JNP7Nu69tpr7fHFixcX2Vf//v09avvTn/5U5H+aRT1PS5YssceioqKsr776yn5+Xn/9dXtdvXr17NvZu3evR72lMWzYMPt65/9HXeD87TI4ONg+UnfkyBGP+3zjjTfs6/Tq1csef+211+zxkhyRqVWrlnX69Gl7XfPmzQs93qV9jM6cOWNvs61atbI2bdpknTlzplSP04X1169fv9BtlOW5e/vtt+3xP//5z5ZlWVZ+fr5Vu3Zt+0jH/v37y3z7Rf0uXvh79dJLL9m3s3btWqtevXr2us8++8yyLMvq16+fPfbggw96zO/Zs6e97umnn7Ysy7Jmz55tjz355JPW/v37PY5GFuX06dP2dUJDQ0v9/ODy8a4llFhUVJSGDx+uv/3tb5ec+9Zbb2nw4MEXnfP777+X+L5/+ukn+3JeXp66d+9e5Ly8vDzt2LFD7dq104QJE/Tcc8+VWw0l9euvv3qci9K3b99i527fvt2+3KRJE9WrV89evummm+zLlmVpx44dql27tsf1O3TooMqVz/0aR0ZGeqzr1KmTffn8/ySPHTtWZC3n31/BcsG5PLt27Sq2B8nz+Tl69Kj9H/uFDh48qN9++61QrZfDsqyLrm/evLlq1qwp6fIfo+J06tTJPqJz4f0U3FZZHqOBAwfqrbfe0pYtW9SuXTsFBASoYcOG6tixox5++OFifw+K07NnTwUHB3uMlaWue+65R48//rgyMzO1ZMkSnTx5Ut9++619TlBcXJx9YnR5bRtHjx71+L06/6jhhbZu3aru3bt73Pe7776rd999t9j5khQfH68JEybo0KFDevHFF/Xiiy8qJCREzZs316233qqRI0eqQYMGHte91PYH7+OlJRSr4DD/+vXrtWfPHh0+fFgTJ04s0dtcp06dal/u0aOHFi9erLVr1+rll1+2x91ut1fqzsrKUl5enl566SV7bMCAAfr000+1du1ajR8/vsgazj9MX3BousCFJ8lWFBEREfblgADPX+fq1asXeR2nd7zl8U6ZqKgo+/KlQocvHqOCoFSgIFyW5bak/z5Gs2fP1nvvvae//OUvatmypQIDA7Vv3z599NFH6tGjhxYtWlSq2z0/KJdFQV2hoaH6y1/+Ikk6c+aMFi5c6PGy0qX+ibnU7V+u0t5OwfzatWvrhx9+0LPPPqvbb79dDRs2VHZ2tv6//+//04svvqibb75ZmZmZHtc9f/u78B8N+AZBBsUqeNdSx44d1bhx41K9Hp+WlmZfnjZtmu666y7ddNNNF93BnP9H5sKQc80119iXQ0JCdPz4cVmWVegnKytLXbp00W+//aZTp07Z15k5c6Z69Oihm266Sb/99luR91+jRg37csG5ONK5oxHFnVdSlFq1ann8oU1JSSk0p+CPW/Pmze2xPXv26NChQ/byN998Y192uVz6wx/+UOIayuL8+7twuWnTphe97vnPT8OGDZWXl1fs89OoUSNJhUNFaYJtq1at7MuleW6cVNbHaMCAAZo3b562bNmiU6dOadq0afbtzJs3r1Q1FPU7XJa6JM+wMmfOHHs7j4yMVJ8+fS779i8UFRXlcdRs+fLlxd5OwXlK5993QkJCkfPPnj1rn+djWZbq1aunZ555RitWrND+/ft17Ngx+8jd/v37C71j8/zt7/ztEr7DS0vwisaNG2vbtm2SpH/84x8aPHiwNm3adNET+iIjI+23T7799tsKCAhQ5cqV1bp1a7Vq1Uo33HCDNmzYoDNnzujWW2/VE088oQYNGujo0aPau3evVq1aJbfbrc8//1x16tRR1apV7TDzt7/9TXfddZdWrVqlpKSkIu///JP2vvrqK40ZM0YNGzbUa6+9prNnz5a4d5fLpcGDB9tHpV555RWdPn1avXr1Un5+vr755hsFBwfrueee0x133KHo6GgdOHBAubm5uvvuu/XUU08pKytLCQkJ9m3eeeedXv9vb8GCBUpISFCXLl20atUqj7eI//nPf77odW+//XY1aNBA6enpSktLU/fu3fXXv/5VtWvX1sGDB7Vnzx6tWLFCzZo1sx//mjVryuVy2aHu5ZdfVocOHRQQEGB/NkdxbrnlFvu633///WV27htleYyaNm2qnj17ql27doqOjtbZs2ftE4Alleqt8eVZl3TuZc2WLVtq69at+vrrr+3xBx98UIGBgZd9+xdyuVx6+OGH7SD30EMP6emnn1bLli2VlZWltLQ0rV+/XkuXLrWPmgwePFgLFy6UdO4fKrfbrVtuuUUBAQFKS0vT5s2btWjRIr377rvq2rWr5s+fr5deeknx8fFq3LixateurQMHDni8rfvCx/z87a/gjQfwMa+ceQMjXezt1yW5zvkn+86cObPQibWSrK5du9qXGzVq5HFbCQkJRV5n7dq1lmWde9vnxd5+fWENTz/99CVrOH9+fn6+x0maBT8RERFWgwYN7OWSvP36zJkz1m233VZsnaV9+3V6ero9v7iTki928mxxJyufP962bdsi7//222/3eDtycSdlf/vttxd9i+2F9VqWZXXq1KnQnEqVKl3y8bUsy4qLi7Ovs3v3bo91FzsJ/fz72rt3rz1e3Em9JTnZt6Qnh5f2MbrYW4ElWf/5z38u+TgVV//5yvLcWZZlvfzyy4Xmbdmy5bJv/2Jvvz7/97e4n/ONHz/+kvMLtuN58+ZddF5MTIyVmZnpcfudO3e2t9u0tLRLPh8of7y0BK949NFHNWPGDDVv3lzBwcFq1qyZXnnllUJv4z7f3//+dz366KOqXbt2kYfAmzVrps2bN2vChAlq27atwsLCFBQUpIYNG+qWW27R888/7/HBfc8995yee+45NW7cWMHBwWrdurXef/99DRw4sMj7r1SpkhYtWqQePXooNDRU1apVU3x8vNavX1/oA9cuJTg4WCtWrNDcuXPVrVs31axZU5UrV1ZUVJRuvfVWxcXF2XO7dOmi1NRUPfroo2rcuLECAwMVEhKiVq1a6e9//7t++OEHxcTElOr+y+KJJ57Q22+/rdatW9sfvDZ27FgtWrSo0MtARenUqZO2bNmiMWPG6Nprr1VoaKhCQkJ01VVX6fbbb9fLL7+sZ5991uM67777rnr27Gm/Hb00zn8r9aXeHl5RlPYxmjJlinr37q3Y2FiFhYWpUqVKioqKUo8ePfTJJ59c9ERyb9ZV4IEHHvA4+lJwlKa8bv9CISEh+vzzzzV79mx17drV/r2qU6eO2rVrp9GjRxf6MMUXXnhBK1as0N13321/yF2NGjXUokULPfTQQ1qwYIFuvPFGSVLHjh01duxYderUyf7wvKCgIDVt2lSPPfaY1q1b57GtpqWl2S819erVq9CJwPANl2VxyjXgr7p27ao1a9ZIkpKSkirsNw0Xxe126/rrr9f//d//qUGDBtqzZ4/Xvm8JKMr48eM1bdo0uVwubdiwQe3atXO6JL/EERkARgoICLA/VDE9PV3vvPOOwxXBnxw/ftw+AjxgwABCjIM42ReAsW677TbH304O/1S9evVCb8WGMzgiAwAAjMU5MgAAwFgckQEAAMYiyAAAAGMZfbKv2+3WgQMHVK1atVJ/nT0AAKi4LMvSyZMnFR0dfdHPsjI6yBw4cIAPIAIA4AqWnp5+0Q8FNTrIFHzC4osvvqg6deo4XI1vHThwQD/99JM6dOig8PBwp8vxqYLee/fu7fElcv5g9+7d+uqrr+id3v1GQe/+vK/zx94l6fDhw3ryyScv+cnfRgeZgpeT6tSp45OPcK9I8vLyFBgYqLp166pmzZpOl+NTBb3HxsYqOjra6XJ86syZM/RO706X41MFvfvzvs4fez/fpU4d4WRfAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjFXZ6QJQsWVkZGjw4MHKzs6WJLVv317Tpk2Ty+Wy51iWpbFjx2rTpk2SpODgYM2ZM0cxMTGO1FzeFi8O0tdfByo1tYq2b6+s3Nz/9n7o0GEHKwO842DWQS3fv1zrDqzTjt936MjpI8rMzVR4YLiujbxW/a/ur/5X9/fYD5jOn/d1pvfOERlcVP369TVs2DB7eePGjUpJSfGYk5KSYm/ckjR06NAKsXGXl1dfrap33gnV5s1VPEIMcKVasGuBnl77tBbtWaTtx7brWPYx5bvzdSz7mNZmrNUTXz6hgZ8N1Fn3WadLLTf+vK8zvXeCDC6pd+/euvHGG+3l2bNnKz09XZKUnp6uWbNm2es6dOig+Ph4n9foTS6XFBubr/j4bHXqlOt0OYDP1A6trfua36enb3haA5oPUHClYHvdiv0r9OGODx2srvz5877O5N4JMiiRcePGKTw8XJKUnZ2tyZMnKzc3V5MnT1ZOTo4kKTw8XOPHj3eyTK9YsuSY1q//TbNmndAf/0iQwZWvflh9/fvWf+uHB37Qy11f1qh2o/Ri1xf1Xs/3POatSlvlUIXe48/7OlN7J8igRCIjIzVmzBh7edu2bRo6dKi2bdtmj40ePVq1atVyojyvCglxugLAt/o266t7rr5HlQM8T6O8qf5Nqhlc017OdV95wd6f93Wm9k6QQYl17dpVcXFx9vKePXvsy3FxcerWrZsTZQHwkYKTfgu0rd3WwWq8x5/3dSb2TpBBqYwcOVKRkZEeYzVq1NDIkSMdqgiAL+S78zV2zVjlu/MlSbVCaumhFg85XJX3+PO+zrTeCTIolaNHjyozM9Nj7OTJkzp06JBDFQHwtqzcLD306UNasX+FJCmsSpje6fGOaoVUrJcYypM/7+tM650ggxLLz8/X5MmTlZeXV+R4bu6V93o54O8ysjLUe1FvrUo/d2JvZHCk5t81X9fXud7hyrzHn/d1JvZOkEGJJSUlaffu3fZynz597Mt79+7V3LlzHagKgLekHklVz4U99dNvP0mSmkQ00bK7l12x58YU8Od9nYm9E2RQIlu3btW8efPs5Z49e2rUqFHq2bOnPTZ//nxt3rzZifIAlLNP9n6iuxffrcOnz3169Y31btTSu5cqNiLW2cK8zJ/3dab2zlcU4JLOnDmjKVOmyO12S5Lq1q2rESNGSJJGjBih1NRUHThwQG63W1OmTNHcuXMVGhrqZMnlKjk5RPv2VZIkbdxYxWNdYmKYfXnQoDOKjb1yPukU/mvxnsV67PPH5LbO/c6HB4ara0xXzds+z2NeeGC4HmjxgBMleoU/7+tM7p0jMrikN954QxkZGZKkgIAAJSQk2BtwaGioEhISFBBwblM6ePCgpk+f7lit3rBoUbBmzqyqmTOrauPGQI91BeMzZ1ZVRga/Trgy7Di2ww4xkpSZm6mpG6bq2fXPevy88sMrzhXpBf68rzO5d/a8uKjvvvtOS5YssZfvuecetWnTxmNOq1atdP/999vLy5Yt07p163xWIwBcLn/e15neOy8t4aI6duyo1atXX3LekCFDNGTIEO8X5ICUlN+dLgHwqXE3jNO4G8Y5XYZP+fO+zvTeOSIDAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWBUiyEyfPl2xsbEKDg5Wx44d9f333ztdEgAAMIDjQeajjz7SmDFjNHHiRP3www9q06aNunfvriNHjjhdGgAAqOAcDzIvvfSS/vrXv+rhhx9WixYtNHPmTIWGhuqtt95yujQAAFDBVXbyznNzc7Vp0yYlJCTYYwEBAYqLi9O6desKzc/JyVFOTo69nJmZKUk6cOCA8vLyvF9wBXL06FFJUkZGhk6cOOFwNb5V0PvOnTvty/4iLS1NEr3Tu/8o6N2f93X+2LukEm/rjgaZX3/9VWfPnlWdOnU8xuvUqaPt27cXmj9lyhRNmjSp0PhPP/2kwMBAr9VZkW3ZssXpEhzhcrm0atUqp8twBL3Tuz/y132d5L+95+bmlmieo0GmtBISEjRmzBh7OTMzUw0aNFCHDh1Ut25dByvzvYyMDG3ZskWdOnVSRESE0+X4VEHv/fr1U1RUlNPl+NTOnTu1atUqeqd3v1HQuz/v6/yxd0k6dOiQkpOTLznP0SBTq1YtVapUSYcPH/YYP3z4cJHBJCgoSEFBQYXGw8PDVbNmTa/VWREVHGaMiIjw296joqIUHR3tcDW+VXCold7p3V8U9O7P+zp/7F2STp8+XaJ5jp7sGxgYqHbt2umLL76wx9xut7744gt16tTJwcoAAIAJHH9pacyYMRo4cKDat2+vDh066JVXXtGpU6f08MMPO10aAACo4BwPMvfee6+OHj2qCRMm6NChQ7ruuuv02WefFToBGAAA4EKOBxlJGjFihEaMGOF0GQAAwDCOfyAeAABAWRFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMaq7HQBJsjIyNDgwYOVnZ0tSWrfvr2mTZsml8tlz7EsS2PHjtWmTZskScHBwZozZ45iYmIcqRnl42DWQS3fv1zrDqzTjt936MjpI8rMzVR4YLiujbxW/a/ur/5X9/fYFgDT+eN278/7edN754hMCdSvX1/Dhg2zlzdu3KiUlBSPOSkpKfYTLElDhw6tEE8wLs+CXQv09NqntWjPIm0/tl3Hso8p352vY9nHtDZjrZ748gkN/GygzrrPOl0qUG78cbv35/286b0TZEqod+/euvHGG+3l2bNnKz09XZKUnp6uWbNm2es6dOig+Ph4n9cI76kdWlv3Nb9PT9/wtAY0H6DgSsH2uhX7V+jDHR86WB3gHf623fvzft7k3gkypTBu3DiFh4dLkrKzszV58mTl5uZq8uTJysnJkSSFh4dr/PjxTpaJclQ/rL7+feu/9cMDP+jlri9rVLtRerHri3qv53se81alrXKoQqD8+fN278/7eVN7J8iUQmRkpMaMGWMvb9u2TUOHDtW2bdvssdGjR6tWrVpOlAcv6Nusr+65+h5VDvA8neym+jepZnBNeznXnevr0gCv8eft3p/386b2TpAppa5duyouLs5e3rNnj305Li5O3bp1c6Is+FjByY8F2tZu62A1gG/4y3bvz/t5E3snyJTByJEjFRkZ6TFWo0YNjRw50qGK4Ev57nyNXTNW+e58SVKtkFp6qMVDDlcFeJe/bff+vJ83rXeCTBkcPXpUmZmZHmMnT57UoUOHHKoIvpKVm6WHPn1IK/avkCSFVQnTOz3eUa2QinWoFShP/rjd+/N+3rTeCTKllJ+fr8mTJysvL6/I8dzcK+81Y5yTkZWh3ot6a1X6uRMcI4MjNf+u+bq+zvUOVwZ4jz9u9/68nzexd4JMKSUlJWn37t32cp8+fezLe/fu1dy5cx2oCt6WeiRVPRf21E+//SRJahLRRMvuXnbFniMASP673fvzft7E3gkypbB161bNmzfPXu7Zs6dGjRqlnj172mPz58/X5s2bnSgPXvLJ3k909+K7dfj0YUnSjfVu1NK7lyo2ItbZwgAv8tft3p/386b2zlcUlNCZM2c0ZcoUud1uSVLdunU1YsQISdKIESOUmpqqAwcOyO12a8qUKZo7d65CQ0OdLBnlYPGexXrs88fkts497+GB4eoa01Xzts/zmBceGK4HWjzgRIlAufPX7d6f9/Mm906QKaE33nhDGRkZkqSAgAAlJCTYT2JoaKgSEhI0cuRIud1uHTx4UNOnT9e4ceOcLBnlYMexHfbOXJIyczM1dcPUQvNiwmKuqB06/Ju/bvf+vJ83uXdeWiqB7777TkuWLLGX77nnHrVp08ZjTqtWrXT//ffby8uWLdO6det8ViMAoOz8eT9veu8ckSmBjh07avXq1ZecN2TIEA0ZMsT7BcFnxt0wTuNuqBj/dQC+4o/bvT/v503vnSMyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjOVokPnqq6901113KTo6Wi6XSx9//LGT5QAAAMM4GmROnTqlNm3aaPr06U6WAQAADFXZyTu/8847deeddzpZAgAAMJijQaa0cnJylJOTYy9nZmZKkg4cOKC8vDynynLE0aNHJUkZGRk6ceKEw9X4VkHvO3futC/7i7S0NEn0Tu/+o6B3f97X+WPvkkq8rbssy7K8XEuJuFwupaSkqE+fPsXOSUxM1KRJkwqNDxo0SIGBgV6sDhWNy+VSBdl0fY7e6d3f0Lt/9p6bm6vk5GSdOHFC4eHhxc4z6ohMQkKCxowZYy9nZmaqQYMG6tChg+rWretgZb6XkZGhLVu2qFOnToqIiHC6HJ8q6L1fv36Kiopyuhyf2rlzp1atWkXv9O436N0/e5ekffv2KTk5+ZLzjAoyQUFBCgoKKjQeHh6umjVrOlCRcwoOM0ZERPht71FRUYqOjna4Gt8qONRK7/TuL+jdP3uXpKysrBLN43NkAACAsRw9IpOVlaXdu3fby3v37lVqaqpq1qyphg0bOlgZAAAwgaNBZuPGjerWrZu9XHD+y8CBA0v0uhgAAPBvjgaZrl27+u3Z2AAA4PJxjgwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgrMpOF4CKLSMjQ4MHD1Z2drYkqX379po2bZpcLpc9x7IsjR07Vps2bZIkBQcHa86cOYqJiXGk5vK2eHGQvv46UKmpVbR9e2Xl5v6390OHDjtYGeAd/rzNH8w6qOX7l2vdgXXa8fsOHTl9RJm5mQoPDNe1kdeq/9X91f/q/h77wCuFqb0TZHBR9evX17Bhw/TSSy9JkjZu3KiUlBT17dvXnpOSkmKHGEkaOnToFRNiJOnVV6vqxx+rOF0G4DP+vM0v2LVAz3/3fKHxY9nHtDZjrdZmrNXSn5cqqXuSKgVUcqBC7zG1d15awiX17t1bN954o708e/ZspaenS5LS09M1a9Yse12HDh0UHx/v8xq9yeWSYmPzFR+frU6dcp0uB/A6tnmpdmht3df8Pj19w9Ma0HyAgisF2+tW7F+hD3d86GB13mVa7xyRQYmMGzdODz/8sDIzM5Wdna3Jkyfr1Vdf1eTJk5WTkyNJCg8P1/jx4x2utPwtWXJMISHnLk+bVlXr1gU6WxDgZf68zdcPq69/3/pv9WnaR5UD/vsn8u5md+ueJffYy6vSVmnANQOcKNFrTO2dIzIokcjISI0ZM8Ze3rZtm4YOHapt27bZY6NHj1atWrWcKM+rCnbogL/w522+b7O+uufqezz+kEvSTfVvUs3gmvZyrvvKO1Jlau8EGZRY165dFRcXZy/v2bPHvhwXF6du3bo5URYAeF3Bia8F2tZu62A1vlXReyfIoFRGjhypyMhIj7EaNWpo5MiRDlUEAN6V787X2DVjle/OlyTVCqmlh1o85HBVvmFC7wQZlMrRo0eVmZnpMXby5EkdOnTIoYoAwHuycrP00KcPacX+FZKksCpheqfHO6oVcuW9jH4hU3onyKDE8vPzNXnyZOXl5RU5nptbsV43BYDLkZGVod6LemtV+ipJUmRwpObfNV/X17ne4cq8z6TeCTIosaSkJO3evdte7tOnj3157969mjt3rgNVAUD5Sz2Sqp4Le+qn336SJDWJaKJldy+rcOeHeINpvRNkUCJbt27VvHnz7OWePXtq1KhR6tmzpz02f/58bd682YnyAKDcfLL3E929+G4dPn3uU4xvrHejlt69VLERsc4W5gMm9s7nyOCSzpw5oylTpsjtdkuS6tatqxEjRkiSRowYodTUVB04cEBut1tTpkzR3LlzFRoa6mTJ5So5OUT79p37FMuNGz0/7TQxMcy+PGjQGcXGnvVpbYA3+PM2v3jPYj32+WNyW+f2d+GB4eoa01Xzts/zmBceGK4HWjzgRIleY2rvBBlc0htvvKGMjAxJUkBAgBISEuygEhoaqoSEBI0cOVJut1sHDx7U9OnTNW7cOCdLLleLFgUX+4FgM2dWtS/ffnvOFbdTh3/y521+x7Ed9h9yScrMzdTUDVMLzYsJi6lQf8zLg6m989ISLuq7777TkiVL7OV77rlHbdq08ZjTqlUr3X///fbysmXLtG7dOp/VCADwXxyRwUV17NhRq1evvuS8IUOGaMiQId4vyAEpKb87XQLgU/68zY+7YZzG3XDlHFEuDVN754gMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYzkaZKZMmaIbbrhB1apVU+3atdWnTx/t2LHDyZIAAIBBHA0ya9as0fDhw7V+/XqtXLlSeXl5uuOOO3Tq1CknywIAAIao7OSdf/bZZx7LycnJql27tjZt2qRbbrnFoaoAAIApHA0yFzpx4oQkqWbNmkWuz8nJUU5Ojr2cmZkpSTpw4IDy8vK8X2AFcvToUUlSRkaG/bj5i4Led+7caV/2F2lpaZLond79B737Z+/Sub9vJeGyLMvyci0l4na71bt3bx0/flxff/11kXMSExM1adKkQuODBg1SYGCgt0uscFwulyrI0+dz9E7v/obe6d3f5ObmKjk5WSdOnFB4eHix8ypMkBk6dKg+/fRTff3114qJiSlyTlFHZBo0aKCFCxcqNjbWR5VWDDt37tSqVavUr18/RUVFOV2OT9E7vdO7/6B3/+xdkvbt26e+ffteMshUiJeWRowYoaVLl+qrr74qNsRIUlBQkIKCggqN16pVS9HR0d4sscIpOMwYFRVF736E3umd3v2HP/cuSVlZWSWa52iQsSxLjz/+uFJSUrR69WpdddVVTpYDAAAM42iQGT58uD744AMtWrRI1apV06FDhyRJERERCgkJcbI0AABgAEc/R2bGjBk6ceKEunbtqnr16tk/H330kZNlAQAAQzj+0hIAAEBZ8V1LAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFiVnS7AJIsXB+nrrwOVmlpF27dXVm6uy1536NBhByvzPnr3z94BoKIjyJTCq69W1Y8/VnG6DEfQu3/2DgAVHUGmFFwuKTY2X23a5OvIkQCtWxfodEk+Q+/+2TsAVHQEmVJYsuSYQkLOXZ42rapf/UGj93OX/a13AKjoONm3FAr+mPkjegcAVEQEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAY/E5MqWQnByiffsqSZI2bvT8pNfExDD78qBBZxQbe9antXkbvftn7wBQ0RFkSmHRouBiPwxt5syq9uXbb8+54v6g0bt/9g4AFR0vLQEAAGNxRKYUUlJ+d7oEx9A7AKAi4ogMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGCsyw4y2dnZ5VEHAABAqZUpyLjdbj333HOqX7++wsLC9PPPP0uSnnnmGc2dO7dcCwQAAChOmYLMP/7xDyUnJ+uf//ynAgP/+2V6LVu21Jw5c8qtOAAAgIspU5B55513NHv2bA0YMECVKlWyx9u0aaPt27eXW3EAAAAXU6Ygk5GRoaZNmxYad7vdysvLu+yiAAAASqJMQaZFixZau3ZtofEFCxaobdu2l10UAABASVQuy5UmTJiggQMHKiMjQ263WwsXLtSOHTv0zjvvaOnSpeVdIwAAQJHKdEQmPj5eS5Ys0eeff66qVatqwoQJ2rZtm5YsWaLbb7+9vGsEAAAoUpmOyEjSzTffrJUrV5ZnLQAAAKVS5iAjSbm5uTpy5IjcbrfHeMOGDS+rKAAAgJIoU5DZtWuXHnnkEX377bce45ZlyeVy6ezZs+VSHAAAwMWUKcgMGjRIlStX1tKlS1WvXj25XK7yrgsAAOCSyhRkUlNTtWnTJjVv3vyy7nzGjBmaMWOG9u3bJ0m69tprNWHCBN15552XdbsAAMA/lPlzZH799dfLvvOYmBhNnTpVmzZt0saNG3XrrbcqPj5eP/7442XfNgAAuPKVKci88MILGj9+vFavXq3ffvtNmZmZHj8lddddd6lnz55q1qyZrr76aj3//PMKCwvT+vXry1IWAADwM2V6aSkuLk6SdNttt3mMX87JvmfPntX8+fN16tQpderUqSxlAQAAP1OmIPPll1+WWwFbtmxRp06dlJ2drbCwMKWkpKhFixZFzs3JyVFOTo69XHD0Z/fu3Tpz5ky51WSCtLQ0SdLOnTt19OhRh6vxLXqnd3r3H/Tun71L577XsSRclmVZXq7lonJzc5WWlqYTJ05owYIFmjNnjtasWVNkmElMTNSkSZMKjQ8aNEiBgYG+KLdCcblccvjpcwy907u/oXd69ze5ublKTk7WiRMnFB4eXuy8MgWZzZs3F31jLpeCg4PVsGFDBQUFlfZmJZ172apJkyaaNWtWoXVFHZFp0KCBFi5cqNjY2DLdn6l27typVatWqV+/foqKinK6HJ+id3qnd/9B7/7ZuyTt27dPffv2vWSQKdNLS9ddd91FPzumSpUquvfeezVr1iwFBweX6rbdbrdHWDlfUFBQkQGpVq1aio6OLtX9mK7gMGNUVBS9+xF6p3d69x/+3LskZWVllWhemd61lJKSombNmmn27NlKTU1VamqqZs+erT/84Q/64IMPNHfuXK1atUp///vfL3o7CQkJ+uqrr7Rv3z5t2bJFCQkJWr16tQYMGFCWsgAAgJ8p0xGZ559/Xq+++qq6d+9uj7Vq1UoxMTF65pln9P3336tq1ap68skn9a9//avY2zly5IgeeughHTx4UBEREWrdurWWL1/ON2gDAIASKVOQ2bJlixo1alRovFGjRtqyZYukcy8/HTx48KK3M3fu3LLcPQAAgKQyvrTUvHlzTZ06Vbm5ufZYXl6epk6dan9tQUZGhurUqVM+VQIAABShTEdkpk+frt69eysmJkatW7eWdO4ozdmzZ7V06VJJ0s8//6xhw4aVX6UAAAAXKFOQ+eMf/6i9e/fq/fff186dOyVJ/fv31/33369q1apJkh588MHyqxIAAKAIZQoyklStWjU99thj5VkLAABAqZQ4yCxevFh33nmnqlSposWLF190bu/evS+7MAAAgEspcZDp06ePDh06pNq1a6tPnz7Fzivrl0YCAACUVomDjNvtLvLy+dLT0/Xss89eflUAAAAlUKa3Xxfn2LFjeuutt8rzJgEAAIpVrkEGAADAlwgyAADAWAQZAABgrFJ9jkzfvn0vuv748eOXUwsAAECplCrIREREXHL9Qw89dFkFAQAAlFSpgkxSUpK36gAAACg1zpEBAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMFaFCTJTp06Vy+XSqFGjnC4FAAAYokIEmQ0bNmjWrFlq3bq106UAAACDOB5ksrKyNGDAAL355puqUaOG0+UAAACDOB5khg8frl69eikuLs7pUgAAgGEqO3nnH374oX744Qdt2LChRPNzcnKUk5NjL2dmZkqSdu/erTNnznilxooqLS1NkrRz504dPXrU4Wp8i97pnd79B737Z++SlJGRUaJ5LsuyLC/XUqT09HS1b99eK1eutM+N6dq1q6677jq98sorRV4nMTFRkyZNKjQ+aNAgBQYGerPcCsnlcsmhp89x9E7v/obe6d3f5ObmKjk5WSdOnFB4eHix8xwLMh9//LHuvvtuVapUyR47e/asXC6XAgIClJOT47FOKvqITIMGDbRw4ULFxsb6qvQKYefOnVq1apX69eunqKgop8vxKXqnd3r3H/Tun71L0r59+9S3b99LBhnHXlq67bbbtGXLFo+xhx9+WM2bN9dTTz1VKMRIUlBQkIKCggqN16pVS9HR0V6rtSIqOMwYFRVF736E3umd3v2HP/cunXszUEk4FmSqVaumli1beoxVrVpVkZGRhcYBAACK4vi7lgAAAMrK0XctXWj16tVOlwAAAAzCERkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgrMpOF2CSxYuD9PXXgUpNraLt2ysrN9dlrzt06LCDlXkfvdM7vdO7dOX3DvMQZErh1Ver6scfqzhdhiPond79Db37Z+8wD0GmFFwuKTY2X23a5OvIkQCtWxfodEk+Q+/0Tu/0DlREBJlSWLLkmEJCzl2eNq2qX/1y0/u5y/RO7/7An3uHeTjZtxQKfrH9Eb37J3r3T/7cO8xDkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBafI1MKyckh2revkiRp40bPT71MTAyzLw8adEaxsWd9Wpu30Tu90/t/0fs5V2LvMA9BphQWLQou9oOhZs6sal++/facK+6Xm97p/UL0fg69X1m9wzy8tAQAAIzFEZlSSEn53ekSHEPv/one/ZM/9w7zcEQGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYzkaZBITE+VyuTx+mjdv7mRJAADAIJWdLuDaa6/V559/bi9Xrux4SQAAwBCOp4bKlSurbt26TpcBAAAM5Pg5Mrt27VJ0dLQaN26sAQMGKC0tzemSAACAIRw9ItOxY0clJyfrD3/4gw4ePKhJkybp5ptv1tatW1WtWrVC83NycpSTk2MvZ2ZmSpJ2796tM2fO+KzuiqAg8O3cuVNHjx51uBrfond6p3f/Qe/+2bskZWRklGiey7Isy8u1lNjx48fVqFEjvfTSSxo8eHCh9YmJiZo0aVKh8UGDBikwMNAXJQKAI1wulyrQ7tqn6N0/e8/NzVVycrJOnDih8PDwYudVqCAjSTfccIPi4uI0ZcqUQuuKOiLToEEDvfHGG353nk1GRoa2bNmiTp06KSIiwulyfIre6d1fe+/Xr5+ioqKcLsendu7cqVWrVtG7n/UuSfv27VPfvn0vGWQcP9n3fFlZWdqzZ48efPDBItcHBQUpKCio0Hh4eLhq1qzp7fIqlBMnTkiSIiIi6N2P0Lt/9x4VFaXo6GiHq/GtgpdU6N2/epfOZYKScPRk37Fjx2rNmjXat2+fvv32W919992qVKmS7rvvPifLAgAAhnD0iMwvv/yi++67T7/99puioqJ00003af369X55CA0AAJSeo0Hmww8/dPLuAQCA4Rz/HBkAAICyIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxqrsdAGo2DIyMjR48GBlZ2dLktq3b69p06bJ5XLZcyzL0tixY7Vp0yZJUnBwsObMmaOYmBhHagYuB9u8tHhxkL7+OlCpqVW0fXtl5eb+t/dDhw47WBlQGEdkcFH169fXsGHD7OWNGzcqJSXFY05KSoq9Q5ekoUOHXjE7dPgftnnp1Ver6p13QrV5cxWPEANURAQZXFLv3r1144032suzZ89Wenq6JCk9PV2zZs2y13Xo0EHx8fE+rxEoT/6+zbtcUmxsvuLjs9WpU67T5QAXRZBBiYwbN07h4eGSpOzsbE2ePFm5ubmaPHmycnJyJEnh4eEaP368k2UC5caft/klS45p/frfNGvWCf3xjwQZVGwEGZRIZGSkxowZYy9v27ZNQ4cO1bZt2+yx0aNHq1atWk6UB5Q7f97mQ0KcrgAoOYIMSqxr166Ki4uzl/fs2WNfjouLU7du3ZwoC/Aatnmg4iPIoFRGjhypyMhIj7EaNWpo5MiRDlUEeBfbPFCxEWRQKkePHlVmZqbH2MmTJ3Xo0CGHKgK8i20eqNgIMiix/Px8TZ48WXl5eUWO5+ZyUiCuLGzzQMVHkEGJJSUlaffu3fZynz597Mt79+7V3LlzHagK8B62eaDiI8igRLZu3ap58+bZyz179tSoUaPUs2dPe2z+/PnavHmzE+UB5Y5tHjADQQaXdObMGU2ZMkVut1uSVLduXY0YMUKSNGLECEVHR0uS3G63pkyZotOnTztWK1Ae/H2bT04OUWJimBITw7RmTaDHuoLxxMQw7dtXyaEKgf8iyOCS3njjDWVkZEiSAgIClJCQoNDQUElSaGioEhISFBBwblM6ePCgpk+f7litQHnw921+0aJgzZxZVTNnVtXGjZ5BpmB85syqysjgTwicx1aIi/ruu++0ZMkSe/mee+5RmzZtPOa0atVK999/v728bNkyrVu3zmc1AuWJbR4wC99+jYvq2LGjVq9efcl5Q4YM0ZAhQ7xfEOBlbPNSSsrvTpcAlBhHZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADCW40EmIyNDDzzwgCIjIxUSEqJWrVpp48aNTpcFAAAMUNnJO//999/VuXNndevWTZ9++qmioqK0a9cu1ahRw8myAACAIRwNMi+88IIaNGigpKQke+yqq65ysCIAAGASR19aWrx4sdq3b6/+/furdu3aatu2rd58800nSwIAAAZx9IjMzz//rBkzZmjMmDH629/+pg0bNuiJJ55QYGCgBg4cWGh+Tk6OcnJy7OXMzExJ0oEDB5SXl+ezuiuCo0ePSjp3jtGJEyccrsa36J3e/bX3nTt32pf9RVpamiR697fepXO/6yXhsizL8nItxQoMDFT79u317bff2mNPPPGENmzYoHXr1hWan5iYqEmTJhUaHzRokAIDA71aKwA4yeVyycHdtaPo3T97z83NVXJysk6cOKHw8PBi5zl6RKZevXpq0aKFx9g111yj//znP0XOT0hI0JgxY+zlzMxMNWjQQB06dFDdunW9WmtFk5GRoS1btqhTp06KiIhwuhyfond699fe+/Xrp6ioKKfL8amdO3dq1apV9O5nvUvSvn37lJycfMl5jgaZzp07a8eOHR5jO3fuVKNGjYqcHxQUpKCgoELj4eHhqlmzpldqrKgKDq1HRETQux+hd//uPSoqStHR0Q5X41sFL6nQu3/1LklZWVklmufoyb6jR4/W+vXrNXnyZO3evVsffPCBZs+ereHDhztZFgAAMISjQeaGG25QSkqK5s2bp5YtW+q5557TK6+8ogEDBjhZFgAAMISjLy1J0p/+9Cf96U9/croMAABgIMe/ogAAAKCsCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsSo7XYAJMjIyNHjwYGVnZ0uS2rdvr2nTpsnlctlzLMvS2LFjtWnTJklScHCw5syZo5iYGEdqBoCyWrw4SF9/HajU1Cravr2ycnP/u687dOiwg5UBhXFEpgTq16+vYcOG2csbN25USkqKx5yUlBQ7xEjS0KFDCTEAjPTqq1X1zjuh2ry5ikeIASoigkwJ9e7dWzfeeKO9PHv2bKWnp0uS0tPTNWvWLHtdhw4dFB8f7/MaAaA8uFxSbGy+4uOz1alTrtPlABdFkCmFcePGKTw8XJKUnZ2tyZMnKzc3V5MnT1ZOTo4kKTw8XOPHj3eyTAC4LEuWHNP69b9p1qwT+uMfCTKo2AgypRAZGakxY8bYy9u2bdPQoUO1bds2e2z06NGqVauWE+UBQLkICXG6AqDkCDKl1LVrV8XFxdnLe/bssS/HxcWpW7duTpQFAIBfIsiUwciRIxUZGekxVqNGDY0cOdKhigAA8E8EmTI4evSoMjMzPcZOnjypQ4cOOVQRAAD+iSBTSvn5+Zo8ebLy8vKKHM/N5cQ4AAB8hSBTSklJSdq9e7e93KdPH/vy3r17NXfuXAeqAgDAPxFkSmHr1q2aN2+evdyzZ0+NGjVKPXv2tMfmz5+vzZs3O1EeAAB+h68oKKEzZ85oypQpcrvdkqS6detqxIgRkqQRI0YoNTVVBw4ckNvt1pQpUzR37lyFhoY6WTIAlElycoj27askSdq4sYrHusTEMPvyoEFnFBt71qe1ARciyJTQG2+8oYyMDElSQECAEhIS7KASGhqqhIQEjRw5Um63WwcPHtT06dM1btw4J0sGgDJZtChY69YFFrlu5syq9uXbb88hyMBxvLRUAt99952WLFliL99zzz1q06aNx5xWrVrp/vvvt5eXLVumdevW+axGAAD8EUdkSqBjx45avXr1JecNGTJEQ4YM8X5BAOBFKSm/O10CUGIckQEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYjgaZ2NhYuVyuQj/Dhw93siwAAGCIyk7e+YYNG3T27Fl7eevWrbr99tvVv39/B6sCAACmcDTIREVFeSxPnTpVTZo0UZcuXRyqCAAAmKTCnCOTm5ur9957T4888ohcLpfT5QAAAAM4ekTmfB9//LGOHz+uQYMGFTsnJydHOTk59vKJEyckSYcPH/Z2eRXO0aNHlZubq0OHDun06dNOl+NT9E7v/tr7vn37lJWV5XQ5PpWRkUHvfti7JKWlpUmSLMu66DyXdakZPtK9e3cFBgZqyZIlxc5JTEzUpEmTfFgVAABwUnp6umJiYopdXyGCzP79+9W4cWMtXLhQ8fHxxc678IjM8ePH1ahRI6WlpSkiIsIXpVYYmZmZatCggdLT0xUeHu50OT5F7/RO7/6D3v2zd+nckZiTJ08qOjpaAQHFnwlTIV5aSkpKUu3atdWrV6+LzgsKClJQUFCh8YiICL98kiUpPDyc3v0QvdO7v6F3/+y9JAcpHD/Z1+12KykpSQMHDlTlyhUiVwEAAEM4HmQ+//xzpaWl6ZFHHnG6FAAAYBjHD4HccccdlzwjuThBQUGaOHFikS83Xenond79Db3Tu7/x595Lo0Kc7AsAAFAWjr+0BAAAUFYEGQAAYCyCDAAAMJbRQWb69OmKjY1VcHCwOnbsqO+//97pkrzuq6++0l133aXo6Gi5XC59/PHHTpfkM1OmTNENN9ygatWqqXbt2urTp4927NjhdFk+MWPGDLVu3dr+PIlOnTrp008/dbosR0ydOlUul0ujRo1yuhSvS0xMlMvl8vhp3ry502X5TEZGhh544AFFRkYqJCRErVq10saNG50uy+tiY2MLPe8ul0vDhw93urQKydgg89FHH2nMmDGaOHGifvjhB7Vp00bdu3fXkSNHnC7Nq06dOqU2bdpo+vTpTpfic2vWrNHw4cO1fv16rVy5Unl5ebrjjjt06tQpp0vzupiYGE2dOlWbNm3Sxo0bdeuttyo+Pl4//vij06X51IYNGzRr1iy1bt3a6VJ85tprr9XBgwftn6+//trpknzi999/V+fOnVWlShV9+umn+umnn/Tiiy+qRo0aTpfmdRs2bPB4zleuXClJ6t+/v8OVVVCWoTp06GANHz7cXj579qwVHR1tTZkyxcGqfEuSlZKS4nQZjjly5IglyVqzZo3TpTiiRo0a1pw5c5wuw2dOnjxpNWvWzFq5cqXVpUsXa+TIkU6X5HUTJ0602rRp43QZjnjqqaesm266yekyKoSRI0daTZo0sdxut9OlVEhGHpHJzc3Vpk2bFBcXZ48FBAQoLi5O69atc7Ay+FLBt5/XrFnT4Up86+zZs/rwww916tQpderUyelyfGb48OHq1auXx++9P9i1a5eio6PVuHFjDRgwwP5G4Cvd4sWL1b59e/Xv31+1a9dW27Zt9eabbzpdls/l5ubqvffe0yOPPCKXy+V0ORWSkUHm119/1dmzZ1WnTh2P8Tp16ujQoUMOVQVfcrvdGjVqlDp37qyWLVs6XY5PbNmyRWFhYQoKCtJjjz2mlJQUtWjRwumyfOLDDz/UDz/8oClTpjhdik917NhRycnJ+uyzzzRjxgzt3btXN998s06ePOl0aV73888/a8aMGWrWrJmWL1+uoUOH6oknntDbb7/tdGk+9fHHH+v48eMaNGiQ06VUWI5/si9QFsOHD9fWrVv95nwBSfrDH/6g1NRUnThxQgsWLNDAgQO1Zs2aKz7MpKena+TIkVq5cqWCg4OdLsen7rzzTvty69at1bFjRzVq1Ej/7//9Pw0ePNjByrzP7Xarffv2mjx5siSpbdu22rp1q2bOnKmBAwc6XJ3vzJ07V3feeaeio6OdLqXCMvKITK1atVSpUiUdPnzYY/zw4cOqW7euQ1XBV0aMGKGlS5fqyy+/VExMjNPl+ExgYKCaNm2qdu3aacqUKWrTpo1effVVp8vyuk2bNunIkSO6/vrrVblyZVWuXFlr1qzRa6+9psqVK+vs2bNOl+gz1atX19VXX63du3c7XYrX1atXr1BIv+aaa/zmpTVJ2r9/vz7//HMNGTLE6VIqNCODTGBgoNq1a6cvvvjCHnO73friiy/86pwBf2NZlkaMGKGUlBStWrVKV111ldMlOcrtdisnJ8fpMrzutttu05YtW5Sammr/tG/fXgMGDFBqaqoqVarkdIk+k5WVpT179qhevXpOl+J1nTt3LvTxCjt37lSjRo0cqsj3kpKSVLt2bfXq1cvpUio0Y19aGjNmjAYOHKj27durQ4cOeuWVV3Tq1Ck9/PDDTpfmVVlZWR7/je3du1epqamqWbOmGjZs6GBl3jd8+HB98MEHWrRokapVq2afDxUREaGQkBCHq/OuhIQE3XnnnWrYsKFOnjypDz74QKtXr9by5cudLs3rqlWrVug8qKpVqyoyMvKKPz9q7Nixuuuuu9SoUSMdOHBAEydOVKVKlXTfffc5XZrXjR49Wn/84x81efJk/fnPf9b333+v2bNna/bs2U6X5hNut1tJSUkaOHCgKlc29k+1bzj9tqnL8frrr1sNGza0AgMDrQ4dOljr1693uiSv+/LLLy1JhX4GDhzodGleV1TfkqykpCSnS/O6Rx55xGrUqJEVGBhoRUVFWbfddpu1YsUKp8tyjL+8/free++16tWrZwUGBlr169e37r33Xmv37t1Ol+UzS5YssVq2bGkFBQVZzZs3t2bPnu10ST6zfPlyS5K1Y8cOp0up8Pj2awAAYCwjz5EBAACQCDIAAMBgBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZABUCImJibruuuucLgOAYQgyAMrFoUOH9Pjjj6tx48YKCgpSgwYNdNddd3l8uSsAlDe+iQrAZdu3b586d+6s6tWra9q0aWrVqpXy8vK0fPlyDR8+XNu3b3e6RABXKI7IALhsw4YNk8vl0vfff69+/frp6quv1rXXXqsxY8Zo/fr1kqS0tDTFx8crLCxM4eHh+vOf/6zDhw8Xe5tut1vPPvusYmJiFBQUpOuuu06fffaZvX7fvn1yuVxauHChunXrptDQULVp00br1q2z5yQnJ6t69epavny5rrnmGoWFhalHjx46ePCgx33NmTNH11xzjYKDg9W8eXO98cYb5fwIAfAWggyAy3Ls2DF99tlnGj58uKpWrVpoffXq1eV2uxUfH69jx45pzZo1WrlypX7++Wfde++9xd7uq6++qhdffFH/+te/tHnzZnXv3l29e/fWrl27POb97//+r8aOHavU1FRdffXVuu+++5Sfn2+vP336tP71r3/p3Xff1VdffaW0tDSNHTvWXv/+++9rwoQJev7557Vt2zZNnjxZzzzzjN5+++1yeHQAeJ3TX78NwGzfffedJclauHBhsXNWrFhhVapUyUpLS7PHfvzxR0uS9f3331uWZVkTJ0602rRpY6+Pjo62nn/+eY/bueGGG6xhw4ZZlmVZe/futSRZc+bMKXSb27ZtsyzLspKSkixJ1u7du+0506dPt+rUqWMvN2nSxPrggw887ue5556zOnXqVNKHAICDOCID4LJYlnXJOdu2bVODBg3UoEEDe6xFixaqXr26tm3bVmh+ZmamDhw4oM6dO3uMd+7cudD81q1b25fr1asnSTpy5Ig9FhoaqiZNmnjMKVh/6tQp7dmzR4MHD1ZYWJj9849//EN79uy5ZF8AnMfJvgAuS7NmzeRyuRw7obdKlSr2ZZfLJenc+TVFrS+YUxC+srKyJElvvvmmOnbs6DGvUqVKXqkXQPniiAyAy1KzZk11795d06dP16lTpwqtP378uK655hqlp6crPT3dHv/pp590/PhxtWjRotB1wsPDFR0drW+++cZj/JtvvilyflnVqVNH0dHR+vnnn9W0aVOPn6uuuqrc7geA93BEBsBlmz59ujp37qwOHTro2WefVevWrZWfn6+VK1dqxowZ+umnn9SqVSsNGDBAr7zyivLz8zVs2DB16dJF7du3L/I2x40bp4kTJ6pJkya67rrrlJSUpNTUVL3//vvlWvukSZP0xBNPKCIiQj169FBOTo42btyo33//XWPGjCnX+wJQ/ggyAC5b48aN9cMPP+j555/Xk08+qYMHDyoqKkrt2rXTjBkz5HK5tGjRIj3++OO65ZZbFBAQoB49euj1118v9jafeOIJnThxQk8++aSOHDmiFi1aaPHixWrWrFm51j5kyBCFhoZq2rRpGjdunKpWrapWrVpp1KhR5Xo/ALzDZZXkTD0AAIAKiHNkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADDW/w/Jt9y5MFoLbAAAAABJRU5ErkJggg==\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Creer un plateau avec premier clic garanti sur\n",
-        "board = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(4, 4))\n",
-        "board.reveal(4, 4)  # Premier clic\n",
-        "\n",
-        "print(f\"Plateau : {board.rows}x{board.cols}, {board.n_mines} mines\")\n",
-        "print(f\"Cellules revelees apres le premier clic : {len(board.revealed)}\")\n",
-        "print(f\"Cellules restantes (inconnues)           : {board.rows * board.cols - len(board.revealed)}\")\n",
-        "print(f\"Mines a trouver                          : {board.remaining_mines()}\")\n",
-        "\n",
-        "# Visualiser l'etat initial\n",
-        "fig = draw_board(board, title=\"Etat initial apres le premier clic\")\n",
-        "plt.show()\n",
-        "\n",
-        "# Visualiser avec les mines (pour reference)\n",
-        "fig = draw_board(board, title=\"Plateau complet (mines revelees)\", show_mines=True)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-09",
-      "metadata": {
-        "papermill": {
-          "duration": 0.006927,
-          "end_time": "2026-02-26T07:01:09.707778",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.700851",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-09"
-      },
-      "source": [
-        "### Interpretation : representation du plateau\n",
-        "\n",
-        "**Sortie obtenue** : deux vues du meme plateau -- la vue du joueur (cellules cachees en gris) et la vue complete avec les mines.\n",
-        "\n",
-        "| Element | Signification |\n",
-        "|---------|---------------|\n",
-        "| Chiffre colore | Nombre de mines dans les 8 voisines |\n",
-        "| Gris uni | Cellule non revelee (inconnue) |\n",
-        "| X (vue complete) | Position d'une mine |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Le premier clic avec `safe_cell` garantit que ni la cellule cliquee ni ses voisines ne contiennent de mine -- c'est le comportement standard du jeu\n",
-        "2. Les cellules affichant 0 declenchent une revelation en cascade de leurs voisines\n",
-        "3. La frontiere entre cellules revelees et cachees constitue notre zone de travail pour le solveur"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-10",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004061,
-          "end_time": "2026-02-26T07:01:09.715782",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.711721",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-10"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 3. Approche 1 : solveur par regles simples (~8 min)\n",
-        "\n",
-        "Le solveur le plus basique applique deux regles deterministes en boucle :\n",
-        "\n",
-        "### Regle 1 -- Toutes les voisines sont des mines\n",
-        "\n",
-        "Si une cellule revelee affiche $n$ et a exactement $n$ voisines inconnues (ni revelees ni marquees), alors **toutes** ces voisines sont des mines.\n",
-        "\n",
-        "$$\\text{unknown\\_count}(i,j) = n_{i,j} - \\text{flagged\\_count}(i,j) \\implies \\text{marquer toutes les inconnues}$$\n",
-        "\n",
-        "### Regle 2 -- Toutes les voisines sont sures\n",
-        "\n",
-        "Si une cellule revelee affiche $n$ et a deja $n$ voisines marquees, alors toutes les voisines inconnues restantes sont **sures**.\n",
-        "\n",
-        "$$\\text{flagged\\_count}(i,j) = n_{i,j} \\implies \\text{reveler toutes les inconnues}$$\n",
-        "\n",
-        "Ces deux regles suffisent pour les configurations simples, mais echouent sur les cas ambigus."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-11",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.284165Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.283617Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.296341Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.294839Z"
-        },
-        "papermill": {
-          "duration": 0.013537,
-          "end_time": "2026-02-26T07:01:09.733613",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.720076",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-11",
-        "outputId": "128ae2a5-60f7-49f1-c37e-e0530bbb106f",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Classe RuleBasedSolver definie.\n"
-          ]
-        }
-      ],
-      "source": [
-        "class RuleBasedSolver:\n",
-        "    \"\"\"Solveur par regles simples (deductions locales).\n",
-        "\n",
-        "    Applique iterativement les regles 1 et 2 jusqu'a\n",
-        "    ce qu'aucune nouvelle deduction ne soit possible.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    def __init__(self, board):\n",
-        "        self.board = board\n",
-        "        self.moves_log = []  # historique des coups\n",
-        "\n",
-        "    def solve_step(self):\n",
-        "        \"\"\"Applique un tour de regles. Retourne True si des progres ont ete faits.\"\"\"\n",
-        "        progress = False\n",
-        "\n",
-        "        for r in range(self.board.rows):\n",
-        "            for c in range(self.board.cols):\n",
-        "                if (r, c) not in self.board.revealed:\n",
-        "                    continue\n",
-        "\n",
-        "                num = self.board.numbers[r, c]\n",
-        "                if num == 0:\n",
-        "                    continue\n",
-        "\n",
-        "                unknown = self.board.get_unknown_neighbors(r, c)\n",
-        "                flagged = self.board.get_flagged_neighbors(r, c)\n",
-        "                remaining_mines = num - len(flagged)\n",
-        "\n",
-        "                # Regle 1 : toutes les inconnues sont des mines\n",
-        "                if remaining_mines == len(unknown) and len(unknown) > 0:\n",
-        "                    for ur, uc in unknown:\n",
-        "                        self.board.flag(ur, uc)\n",
-        "                        self.moves_log.append(('flag', (ur, uc), (r, c)))\n",
-        "                        progress = True\n",
-        "\n",
-        "                # Regle 2 : toutes les inconnues sont sures\n",
-        "                elif remaining_mines == 0 and len(unknown) > 0:\n",
-        "                    for ur, uc in unknown:\n",
-        "                        safe = self.board.reveal(ur, uc)\n",
-        "                        self.moves_log.append(('reveal', (ur, uc), (r, c)))\n",
-        "                        if not safe:\n",
-        "                            return False  # Mine touchee (ne devrait pas arriver)\n",
-        "                        progress = True\n",
-        "\n",
-        "        return progress\n",
-        "\n",
-        "    def solve(self, max_iterations=100):\n",
-        "        \"\"\"Applique les regles jusqu'a convergence.\n",
-        "\n",
-        "        Retourne le nombre d'iterations effectuees.\n",
-        "        \"\"\"\n",
-        "        for i in range(max_iterations):\n",
-        "            if self.board.game_over or self.board.won:\n",
-        "                break\n",
-        "            if not self.solve_step():\n",
-        "                break\n",
-        "        return i + 1\n",
-        "\n",
-        "\n",
-        "print(\"Classe RuleBasedSolver definie.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-12",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004258,
-          "end_time": "2026-02-26T07:01:09.742253",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.737995",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-12"
-      },
-      "source": [
-        "Testons le solveur par regles sur notre plateau d'exemple."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-13",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.299853Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.299277Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.618748Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.617192Z"
-        },
-        "papermill": {
-          "duration": 0.127743,
-          "end_time": "2026-02-26T07:01:09.874958",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.747215",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-13",
-        "outputId": "428b031b-33a3-4e5a-f2dd-83aa488a7dd3",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 746
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Solveur par regles simples\n",
-            "=============================================\n",
-            "Iterations         : 5\n",
-            "Cellules revelees  : 44 -> 54 (+10)\n",
-            "Drapeaux poses     : 0 -> 9 (+9)\n",
-            "Cellules inconnues : 1\n",
-            "Partie gagnee      : True\n",
-            "Coups effectues    : 19\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATglJREFUeJzt3Xl4VOXd//HPZJkkJIQtAYkskU12pICouAKK4MImtYIIorUqKIrQPtQqoZbFR+ujrYhriYqAFYkEigKasinKYlOQJQEkBiMQNEAIS0KS8/uDX44Zk0ASkjm5Oe/XdeVy5j53Zr7fmTO3H86cmXgsy7IEAABgoACnCwAAAKgsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDHCeYmNj5fF45PF4tGrVKqfLgcOK9gWPx6O0tDSny5Ekvfnmm3ZNSUlJTpfjOvn5+WrRooU8Ho+uvfZap8u54BBkXGbdunU+C63H49G2bducLgtANcnJydFTTz0lSbriiivUu3dvn+0vvviihg0bpksuucRnXYiPjy/zNpcuXar+/fsrKipKXq9XMTExGj58uL755pvqbMVYQUFB+v3vfy9JWrt2rRISEhyu6MJCkHGZ0hansy1YAMz2+uuv68CBA5KkcePGldgeFxenhQsXlvvo0eTJk3Xbbbfpk08+0U8//aTTp09r//79mj9/vrp3765ly5ZVZfkXjFGjRikiIkKSNHXqVIerubAQZFzkxIkT+uCDD0qMz507VwUFBdV+/zk5OdV+H6icwsJCnTx50ukyynS+9R0/frwKqzGHZVmaPXu2JKlWrVoaOHBgiTmdOnXSmDFj9Morr6hhw4Znvb3169dr5syZ9vU///nPWrFihSZMmCBJys3N1ciRI5WVlVWFXVwYwsLCNGjQIEnSf//7X3355ZfOFnQBIci4SEJCgrKzsyWdOcTctm1bSdKBAwe0fPnyEvNHjx5tH2aOi4vTRx99pMsvv1xhYWFq2LChfve73+nw4cM+v3P99dfbvzNnzhy9+OKLateunbxer/70pz/Z83bs2KH7779fLVq0UGhoqCIjI9WrVy/Fx8frl3+QPSMjQ7/73e/UokULhYSEKCwsTE2bNtWNN96oKVOmlKv3nTt3asSIEWratKm8Xq/Cw8MVGxurW2+9VX/7299KzE9MTNSAAQPUsGFDBQcHKyoqSjfddJMWLlxYrvu78sor7cdh/vz5PtvS09MVEBAgj8ejWrVq6ejRo/a2DRs26K677rLrrFevnvr27avExMQS91HWuTlpaWk+bxEUV3x8y5YtGj9+vC6++GIFBweXug+UdX+fffaZ/vd//1etW7dWSEiIWrZsqWeffVaFhYU+vxMXF6c+ffqoWbNmioiIsN+GGDx4cKnnE1VVfStWrNCUKVPUokULBQUF6Y033qjUYyxJixYtUteuXRUaGqqmTZtq8uTJ2rlzZ5mP8dn4e7/fvHmzdu/eLUm69tpr7SMCxa1du1ZvvfWWHnroIYWFhZ319hYvXmxfvvbaa/XUU0/pxhtv1F//+le1bt1akpSVlaW33367XPUV3eatt96qiy66SF6vV1FRUerVq1eJ2zh48KAmTZqk9u3bq1atWgoLC1Pbtm31+OOP64cffvCZGxcXZz83o0eP9tlWfI0qfjS6MutdRdeVW265xb68YMGCcj9GOAcLrtG3b19LkiXJevnll61nnnnGvj5s2LAS80eNGmVvb9eunX25+E+XLl2sEydO2L9z3XXX2dtat27tM3f8+PGWZVlWQkKCFRoaWurtSbJGjBhhFRYWWpZlWXl5eVbLli3LnBsSEnLOvn/88Uerfv36Zd7GpZde6jP/kUceKXOuJOuBBx7wmd+8eXN727///W/LsizrjTfesMduvfVWn/kzZsywt40cOdIenzVrlhUQEFDm/U6ePPmc92tZlrV3716f3yuu+Pgvn5+EhISzPo7F7699+/blemwaNWpUZj8ej8f68MMPq6W+X/7u//3f/1XqMX777bdLnferX/2qXI/x3r177XF/7/eWZVnPP/+8/TtTpkw55/zij+GcOXNKbH/ggQfs7f379/fZ1rVrV3vbbbfdds77KiwstEaPHl1mjwMHDrTnbt++3WrYsGGZc6Oioqz//ve/9vwpU6bY20aNGuVzv8XXqOI9VnS9q+i6YlmW9e2339rbO3fufM7HCOVDkHGJ9PR0ewEPCgqyDh065POiCgkJsbKysnx+p/gLW5J13333WcuWLbP+8pe/WMHBwfb4X/7yF/t3ii8Skqzbb7/dSkhIsD766CNr6dKlVmZmphUREWFvf/DBB61PPvnEevfdd30W0bfeesuyLMvauHGjzws/ISHBWrlypfX2229b48ePtzp06HDO3j/44AP7Nm644QZr6dKl1vLly61//OMf1v3332/17t3bnrt48WKf+h9//HFr2bJl1h/+8AfL4/HY4//85z/t3yktUGRnZ1vh4eGWJCs4ONj68ccf7fmdOnWy569atcqyLMv65ptv7OcnICDAevLJJ60VK1ZYr732mlWvXj17/meffXbW+7Ws8geZgIAA64knnrA+/vhj691337W2bNly1sex+P15vV5r+vTp1rJly0rsJ+vWrbN/Z8aMGdbbb79t/etf/7JWrVplLV++3Jo+fbo9t3379tVSnyTr3nvvtZYuXWr985//tNasWVPhx/jYsWNWnTp17PGrrrrK+uijj6zZs2f7jJcnyDix31uW72t47ty555x/riDzf//3f/b20NBQKykpyTpx4oS1aNEin4DYqVOnc97Xa6+95vNY3XHHHdbChQutxMRE609/+pN1//3323OLB8fWrVtb8+fPtz744AOfQN2xY0eroKDAsqzzDzLlWe8qsq4UFxQUZEmyAgMD7XpxfggyLjFt2jT7RXfLLbfY41dddZU9/sorr/j8TvEXdo8ePXy2jRs3rtR/WRRfJLp161aijr///e8+C8/atWvtnyeffNLedsUVV1iWZVmpqan2WJ8+faxt27ZZeXl5Fep9xYoV9m0MHz7c2rVrl5Wfn1/q3MGDB9tzf/mvyjvuuMPeNmDAAHu8rEBx7733lnhst2zZYo+1atXK/hf4E088YY/37dvX53EZM2aMve03v/nNOe+3vEFmwoQJFXoci9/fpEmTfLYVD2ePPvqoPb5t2zbrnnvusS655BIrJCTE5/6LfrKzs6u8viFDhpTYXtHHeOHChT7B7cCBA/ZtvfzyyxUKMk7s95ZlWQMGDLBv5+OPP67QY1hakDly5IjVtGnTUp/H4j+tW7c+5311797dnj948OAy5/33v//1ue3Nmzfb27755hufbRs2bLAs6/yDTHnWu4qsK8UVP7KUmZl5zvk4N4KMS7Rp08Z+8cybN88enzVrlj1++eWX+/xO8Rf2448/7rNtwYIF9rawsDB7vPgiMW3atBJ1PPTQQ+dcBCVZERERlmWdOfxc/C2xon/JtGnTxho1apS1fv36c/Z+8uRJq0OHDj634fV6rQ4dOlgPPfSQtW3bNntu8UPKzz77rM/tvPjii/a2Fi1a2ONlBYp169bZ47169bIsy7L+53/+xx6bPn26Pbd///7lelw6dux4zvstb5D5/PPPz/nYFVf8/hYvXuyz7cEHH7S3Fb3lsGXLFvuo1Nl+vvvuuyqv77333iuxvaKPcfG3ANu1a+dzW8nJyRUKMk7s95blG2SWLVtWocewtCBjWWf2r/79+/scoWzcuLHVp0+fMteS0tSqVcue/+6775Y57/333y91rSlSt25de/s777xjWdb5B5nyrHcVWVeKi46OJshUMU72dYEvvvhCqamp9vXhw4fbJ7WNHTvWHt+wYYN27NhRZffbuHHjSv9u0SecPB6PlixZoldffVWDBw/WpZdeqoCAAKWmpurtt9/Wtddeq02bNp31tkJDQ/X555/r+eef1y233KKWLVuqoKBA27Zt0+zZs3XVVVcpPT290rWWpVevXrr00kslnXkO9u7da5/4GxgYqFGjRlX4Not/8qv4Sab5+fn25UOHDpXrts7n+SmPv//97/anhVq3bq333ntPa9asKXGS7y9PEK6K+qpq3ytSkRN6z0dV7veSFB0dbV+uqk8SxcbGatmyZfrxxx+1YcMGpaamKj09Xc2bN7fndOnSpUruq7LKem1I5X99nEtl15WiE4YDAgLUoEGDKqnF7QgyLlCRTxCUNffzzz8v83qrVq1K/Z3SFv927drZl6+66ipZZ44KlvgpWtAty1JoaKh+97vfadGiRdq5c6eOHz+uRx99VJJ0+vTpc36SyLIs1alTR0888YSWLl2q3bt3Kzs7W0OHDpUkHT161P7ui6JPcp2r5+LzzmbMmDF2DePGjdN3330nSRowYIBiYmJKfVzuuuuuMh+X4l84Vq9ePfvy999/b19esmRJuWo7n/85//Kx+eKLL+zLRftD8UX80Ucf1fDhw3XNNdcoMDCw2us7175Xnse46FM4krRnzx79+OOP9vW1a9dWqB4n9nvpzEeri6SkpFSo5nOpX7++evToodatWystLc3n03lFr62zad++vX25tC+Is/7/p7iKv9ZOnjyp//znP/b17du368iRI/b1orllvTZ27dpVrsehPOtdRdaVInv27LGDVYcOHRQQwP+Cq0KQ0wWgep06dUrvv/++fX3ixIlq2bKlz5ytW7fqlVdekSS9++67mjZtWon/2WzYsEEPPPCAhgwZov/85z967bXX7G2//vWvy13PnXfeqT/+8Y/KycnRF198oTvuuEPDhw9XnTp1lJGRoZSUFC1btkyDBg3SlClTdPDgQfXq1UtDhw5Vp06d1LhxY504ccLnX6OnTp06631u2LBBv/3tb+1/2V500UXKysry+UbjotsYPXq0vaguWbJEEydOVN++fbVmzRp9+OGH9vxffqSzLPfcc4+efPJJ5efn+yxq9913n8+80aNH68UXX1RhYaHmz5+v2rVr69Zbb1VISIi+//57bd++XYmJifrjH/9o33ebNm3sRf1Pf/qTjh07pr1795b6sc+q9tJLL6l+/frq3LmzPvjgA23ZssXeVrQ/tGjRwh578803FRsbq6ysLJ+P4ftTRR/jm266SXXq1NHRo0eVm5uroUOH6oknntD+/fsr3IMT+7105qPGRTZs2FDqnBUrVujEiROSZP9Xkr7++mvVrVtXknT11VcrKipKkuyPrvfo0UORkZHasmWLnn32Wft7fnr37q1+/fqds7b777/f7mfRokX6zW9+ozvvvFPBwcHavHmzvv/+e73xxhvq3LmzfvWrX+nrr7+273/q1KkKDAz0+WK5jh07qlu3bpLOvDaKrFmzRhMmTFCzZs30t7/9rVzfmVWe9a4i60rx2y1y3XXXnbMOlJM/3r+Cc+bNm2e/HxsZGWnl5uaWmHP48GGfs/KLTgos/p7xZZdd5vOeeNFPp06drOPHj9u3Vdb7z8UtWrTorB9DlX7+qOj+/fvPOi8oKMj66quvzvoYrF+//qy3Ubt2bSstLc2eX/zEvtJ+fvvb3/rcflnnqhQZOHCgz+83atTIOn36dIl5L7/88lk/GvzLx7T4OTjFfzp27Fih8zfKq3ifxT9qW/znvvvus+dv2bLFZ78q+rn++uvLrKOq6ivtebCsij/GZX38+rLLLqvwY+zv/d6yzpxrU3R+XFhYmHXs2LGzPm5l/RR/PH/5ycTiP926dbMOHjx4zrosy7IKCgqskSNHlnlbxT9+vW3btrN+/LpBgwY+H7/Oz8+32rZtW2JenTp1fE5WLuscmfKsdxVdVyzLskaMGGFvr+g5YCgbQeYC169fP/uFM3z48DLn3XTTTfa8O++807Is3xf2lClTrGXLllk9e/a0QkNDraioKOu3v/2tz8eKLat8QcayLGvHjh3WAw88YLVq1coKDQ21wsPDrVatWlm33nqr9eqrr9qL4cmTJ61nnnnGuummm6xmzZpZYWFhVlBQkBUTE2MNGTKkXCc9Hjp0yHryySet6667zoqJibFCQkKs4OBgq1mzZtbdd99tbd++vcTvJCQkWDfffLMVFRVlBQUFWfXr17f69u3r87HrIuf6H2hiYqLPAvf73/++zFo3bNhgjRgxwmrWrJnl9XqtyMhI69JLL7WGDRtmvfPOO9bRo0d95r/99tvWpZdeavfz1FNPWTt27Kj2IPPZZ59ZL7zwgtW6dWvL6/Val1xyiTV9+vQSn9pYtWqVdeWVV1rh4eHWRRddZI0bN846duyYY0HGsir+GC9cuNDq0qWL5fV6rZiYGGvixInWF198Yd9XrVq1fOafrQd/7vdF/vrXv9r1FJ0MW9bjVp4g88orr1jXXHON1ahRIys4ONiqW7eu1atXL+vll18u9R9K57Jw4UJrwIABVsOGDe3X2lVXXVVi/Thw4ID1xBNPWG3btrVCQ0Ot0NBQq02bNtb48eOtjIyMErebkpJi3XzzzVatWrWs2rVrWwMHDrR27NhRrpN9y7PeVXRdOXHihP0RfL5DpmoRZFCmX76w4W7lDQoXkqKPx//S3/72N59/vddkOTk5VuPGjS1JVs+ePZ0up8aq7vWu+CdEFy1aVOW372acaQQAZVi5cqV+85vfaOnSpdqzZ49SUlL06quv2n9NWjpzHlRNFh4ermeeeUaS9NVXX+mzzz5zuCL3yc/P13PPPSdJuuaaazR48GCHK7qwcLIvAJShsLBQ77//vs8J88UNHDhQjzzyiJ+rqrj77ruvxAnm8J+goCDt3bvX6TIuWByRAYAytGnTRiNHjlSbNm1Uu3ZtBQcHq1GjRrr55ps1b948JSQkKCiIfw8CTvJY1i/+5CoAAIAhOCIDAACMRZABAADGMvrN3cLCQv3www+qXbu23/4WCgAAqH6WZenYsWOKiYk5659zMDrI/PDDD2ratKnTZQAAgGqyb98+NWnSpMztRgeZ2rVrS5Lmzp2rZs2aOVyNf+3evVtr1qzRyM6d1Sgiwuly/Gr7oUNatmuXbr/9dvvvv7hF0fNO7/TuFqx1u3T55ZcrMjLS6XL87uDBg3riiSfs/9eXxeggU/R2UrNmzXz+SJgbnDx5Ul6vV62io9Xs//9hN7fIKSiQ1+tVbGysz1+QdoOi553e6d0tWOu8uuiii1S/fn2ny3HMuU4d4WRfAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjBXkdAGm2J+zX8u/W671P6xXyuEUZZ7IVHZetiK9kerQoIOGtRmmYW2GyePxOF0qqlhiYojWrfMqOTlYO3cGKS/v5+f4wIGDDlYGVA/WO3fJyMjQfffdp1OnTkmSunfvrueee87n+bUsSxMnTtTmzZslSaGhoXrzzTfVpEkTR2oujiBTTgt3LdS0r6aVGM86laW1GWu1NmOtln67VHP6zVFgQKADFVa/z+fN0/r588vcHhIerkcWLPBjRf7x0kvh2rYt2OkyAL9x+3rntrXu4osv1sMPP6wXXnhBkrRp0yYlJCRoyJAh9pyEhAQ7xEjSQw89VCNCjMRbSxXWsFZD3dX2Lv1Pj//RiLYjFBoYam9b8d0KLUi5cHZunOHxSLGx+Ro48JSuvDLP6XIAv2G9c4/bb79dV1xxhX399ddf1759+yRJ+/bt02uvvWZvu/zyyzVw4EC/11gWjsiU08URF+vl3i9rUKtBCgr4+WEb3Hqw7lhyh309KT1JI9qNcKJEv7qkWzf1HDbMZywg8ML7l5kkLVmSpbCwM5efey5c69d7nS0IqGasdz9z01o3adIk3XvvvcrOztapU6c0ffp0vfTSS5o+fbpyc3MlSZGRkfr973/vcKW+CDLlNKT1kFLHr774atUPra+sU1mSpLxCd/yLvVadOmrSoYPTZfhFUYgB3IL17mduWusaNGigCRMmKC4uTpK0Y8cOPfTQQ9qzZ4895/HHH1dUVJRDFZaOt5bOU9FJcEW6NuzqYDUAUH1Y7y58119/vfr27WtfLx5i+vbtqxtuuMGJss6KIzLnIb8wXxNXT1R+Yb4kKSosSve0v8fhqvxjW1KStiUl+Yx16N1b/R9/3KGKAFQnt653blzrxo8fr//85z/66aef7LF69epp/PjxDlZVNo7IVFJOXo7u+fgerfhuhSQpIjhC79z8jqLCatYhNwA4X6x37nLo0CFlZ2f7jB07dkwHDhxwqKKz44hMJWTkZGjkxyO1/aftkqQGoQ00d8BcVx1mLe0EuPB69RyqBkB1cft657a1Lj8/X9OnT9fp06dLHX/ttdfk9dasDzwQZCooOTNZoz4ZpYMnznwRWss6LfXegPcUWyfW2cL8zE0nwAFuxXrnvrVuzpw52r17t3190KBB+uijjyRJe/fu1VtvvaWHHnrIoepKx1tLFbBs7zINThxsv6ivaHyFlg5e6qoXNQB3YL1zn2+++Ubzi30R4IABA/TYY49pwIAB9tgHH3ygLVu2OFFemTgiU06JexL14KcPqtAqlCRFeiN1fZPrNX+n77c/RnojdXf7u50oEdUkPj5MaWlnvjdi0ybfb/iNi4uwL48efVKxsQV+rQ2oDqx37nPy5EnNmDFDhYVnnvOLLrpI48aNkySNGzdOycnJ+uGHH1RYWKgZM2borbfeUq1atZws2UaQKaeUrBT7RS1J2XnZmrlxZol5TSKa8MK+wCxeHFrml+C9+mq4ffnGG3MJMrggsN65zyuvvKKMjAxJUkBAgCZPnmwHlVq1amny5MkaP368CgsLtX//fs2aNUuTJk1ysmQbby0BAOBiX331lZYsWWJfv+OOO9SlSxefOZ06ddLw4cPt6//617+0fv16v9V4NhyRKadJPSZpUo+akT6d0mv4cPUqtiO7RULCYadLAPzK7eud29a6nj17atWqVeecd//99+v++++v/oIqiCMyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjFUjgsysWbMUGxur0NBQ9ezZUxs2bHC6JAAAYADHg8z777+vCRMmaMqUKfr666/VpUsX9evXT5mZmU6XBgAAajjHg8wLL7yg3/72t7r33nvVvn17vfrqq6pVq5b+8Y9/OF0aAACo4YKcvPO8vDxt3rxZkydPtscCAgLUt29frV+/vsT83Nxc5ebm2tezs7MlSbt379bJkyerv+AaJD09XZK0NTNT+3NyHK7Gv3ZnZUmSUlNTdejQIYer8a+i553e6d0tWOukjIwMHT161OFq/K+8+7qjQebHH39UQUGBGjVq5DPeqFEj7dy5s8T8GTNmaOrUqSXG16xZI6/XW2111lQej0eJKSlOl+EIj8ejpKQkp8twBL3Tu9t4JPeudZK2bt3qdBmOyMvLK9c8R4NMRU2ePFkTJkywr2dnZ6tp06Ya2bmzWkVHO1iZ/23NzFRiSoqGDh2qaJf1npqaqqSkJHqnd9eg9ySN6dpVjSMinC7Hr4rWeTf2Lkm7Dx1SfDnmORpkoqKiFBgYqIMHD/qMHzx4UBdddFGJ+SEhIQoJCSkx3igiQs3q1q2uMmukokOs0dHRiomJcbga/yo63Ejv9O4W9C41dvE678beJelYOU8ZcfRkX6/Xq27duumzzz6zxwoLC/XZZ5/pyiuvdLAyAABgAsffWpowYYJGjRql7t276/LLL9eLL76o48eP695773W6NAAAUMM5HmTuvPNOHTp0SE8//bQOHDigyy67TJ988kmJE4ABAAB+yfEgI0njxo3TuHHjnC4DAAAYxvEvxAMAAKgsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWEFOFwADnDqliBdeUNB//6ugPXvkOXxYntxcWZGRym/RQnl9++rEmDGyIiOdrrTK7c/Zr+XfLdf6H9Yr5XCKMk9kKjsvW5HeSHVo0EHD2gzTsDbD5PF4nC4VqDLs9zAJQaYCPp83T+vnzy9ze0h4uB5ZsMCPFfmH5/hxhf/tbyXHs7LkzcqSd9MmhS5YoKyPP5ZVr54DFVafhbsWatpX00qMZ53K0tqMtVqbsVZLv12qOf3mKDAg0IEKgarn9v3erWu9ZGbvBBmUS0HjxjrdvbsKmjRRYb16CvjpJ4X+618K/P57SVJQWprC5s7ViUcecbjS6tGwVkP1adZHzWs3175j+/Thrg91quCUJGnFdyu0IGWBRrQb4XCVQNViv4cJCDKVdEm3buo5bJjPWEDghfcvE0myGjTQj//5T4nxEw8+qOiuXe3rgfv2+bMsv7g44mK93PtlDWo1SEEBP79cBrcerDuW3GFfT0pPYkHHBYP9/mduWut/yZTeCTKVVKtOHTXp0MHpMpxRUKCAzEyFzZ3rM5x/6aUOFVR9hrQeUur41Rdfrfqh9ZV1KkuSlFeY58+ygGrFfv8zN6/1pvROkEG5edesUb1f/7rUbXlXXKGTIy7sf5kVV3TyY5GuDbueZTZwYWC/R01EkKmkbUlJ2paU5DPWoXdv9X/8cYcqcs7JIUN07LnnpNBQp0vxi/zCfE1cPVH5hfmSpKiwKN3T/h6HqwKql1v3ezev9ab0TpBBueW3aKFjTz8tT16eAr7/XqHLlikgK0thixYpeOtWHZ43T4VNmzpdZrXKycvRAysfUNK+My/uiOAIvXPzO4oKi3K4MqD6sN+jJiPIVFJpJ0GFX2AfPf6lwiZNdOLhh+3rOX/4gxr07avAgwcVtGuXaj/9tI7OmeNghdUrIydDIz8eqe0/bZckNQhtoLkD5nJ4HRc0t+/3blzri5jSO0Gmkkw5Cao6WdHROt2tmwKXLZMkeb/4wuGKqk9yZrJGfTJKB08clCS1rNNS7w14T7F1Yp0tDKhG7PfuXutN6Z0/UYBzCl63Tp6cnBLjnp9+UvDXXxcbuDC/5XPZ3mUanDjYXsyvaHyFlg5e6qrFHO7Dfg9TcEQG51TrzTcVsnq18q65Rqfbt5cVFqbA/fsV8q9/KfDQIXtebt++DlZZPRL3JOrBTx9UoVUoSYr0Rur6Jtdr/k7fb76M9Ebq7vZ3O1EiUOXY72ESggzKxXPypEJWrFDIihWlbj/dsaOOxcX5tyg/SMlKsRdzScrOy9bMjTNLzGsS0YQFHRcM9nuYhCCDczp5770qbNhQwV9/rYADBxRw5IgUFKTCqCjlt2+vU/3769Qdd0jBwU6XCgBwGYJMBfQaPly9hg93ugy/y7vuOuVdd53TZThiUo9JmtRjktNlAH7l9v3erWu9ZGbvnOwLAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWI4GmTVr1ui2225TTEyMPB6PPvroIyfLAQAAhnE0yBw/flxdunTRrFmznCwDAAAYKsjJO+/fv7/69+/vZAkAAMBgjgaZisrNzVVubq59PTs7W5K0/dAh5RQUOFWWI3ZnZUmSUlNTdejQIYer8a/09HRJ9E7v7kHv0tbMTO3PyXG4Gv8qWufd2Lskpf///s/FY1mWVc21lIvH41FCQoIGDRpU5py4uDhNnTq1xPjo0aPl9XqrsbqaySOpRjx5DvB4PKohu67f0Tu9uw29u7P3vLw8xcfH6+jRo4qMjCxznlFBprQjMk2bNtWiRYsUGxtb/UXWIKmpqUpKStKYrl3VOCLC6XL8amtmphJTUjR06FBFR0c7XY5fFT3v9E7vbkHv7uxdktLS0jRkyJBzBhmj3loKCQlRSEhIifGoqCjFxMQ4UJFzig4vN46IULO6dZ0txs+KDrFGR0e79nmnd3p3C3p3Z++SlFPOt9P4HhkAAGAsR4/I5OTkaPfu3fb1vXv3Kjk5WfXr11ezZs0crAwAAJjA0SCzadMm3XDDDfb1CRMmSJJGjRql+Ph4h6oCAACmcDTIXH/99a49GxsAAJw/zpEBAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjBXkdAGm2J+zX8u/W671P6xXyuEUZZ7IVHZetiK9kerQoIOGtRmmYW2GyePxOF0qqlhiYojWrfMqOTlYO3cGKS/v5+f4wIGDDlYGVA837/NuXutN7Z0gU04Ldy3UtK+mlRjPOpWltRlrtTZjrZZ+u1Rz+s1RYECgAxVWv8/nzdP6+fPL3B4SHq5HFizwY0X+8dJL4dq2LdjpMgC/cfM+7+a13tTeCTIV1LBWQ/Vp1kfNazfXvmP79OGuD3Wq4JQkacV3K7QgZYFGtBvhcJWoSh6PFBubry5d8pWZGaD1671OlwRUK/Z5d6/1pvVOkCmniyMu1su9X9agVoMUFPDzwza49WDdseQO+3pSelKNeoKryyXduqnnsGE+YwGBNSehV6UlS7IUFnbm8nPPhbtyUYe7uHmfd/Nab2rvBJlyGtJ6SKnjV198teqH1lfWqSxJUl5hnj/LckytOnXUpEMHp8vwi6IFHXALN+/zbl7rTe2dTy2dp6KToYp0bdjVwWoAANXBzWt9Te+dIzLnIb8wXxNXT1R+Yb4kKSosSve0v8fhqvxjW1KStiUl+Yx16N1b/R9/3KGKAKB6uHmtN6F3jshUUk5eju75+B6t+G6FJCkiOELv3PyOosKiHK4MAFBV3LzWm9I7R2QqISMnQyM/HqntP22XJDUIbaC5A+bWuMNt1am0k33D69VzqBoAqHpuXutN6p0gU0HJmcka9ckoHTxx5kuhWtZpqfcGvKfYOrHOFuZnbjrZF4D7uHmtN6133lqqgGV7l2lw4mD7yb2i8RVaOnhpjX1yAQAV5+a13sTeOSJTTol7EvXgpw+q0CqUJEV6I3V9k+s1f6fvN91GeiN1d/u7nSgR1SQ+PkxpaWe+I2fTJt9vO42Li7Avjx59UrGxBX6tDagObt7n3bzWm9o7QaacUrJS7CdXkrLzsjVz48wS85pENKlRTzDO3+LFoWV+Idirr4bbl2+8MfeCW9ThTm7e59281pvaO28tAQAAY3FEppwm9ZikST0mOV2Go3oNH65ew4c7XYbfJSQcdroEwK/cvM+7ea03tXeOyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADCWo0FmxowZ6tGjh2rXrq2GDRtq0KBBSklJcbIkAABgEEeDzOrVqzV27Fh9+eWXWrlypU6fPq2bbrpJx48fd7IsAABgiCAn7/yTTz7xuR4fH6+GDRtq8+bNuvbaax2qCgAAmMLRIPNLR48elSTVr1+/1O25ubnKzc21r2dnZ0uSdu/erZMnT1Z/gTVIenq6JGlrZqb25+Q4XI1/7c7KkiSlpqbq0KFDDlfjX0XPO73Tu1vQuzt7l6SMjIxyzfNYlmVVcy3lUlhYqNtvv11HjhzRunXrSp0TFxenqVOnlhgfPXq0vF5vdZdY43g8HtWQp8/v6J3e3Ybe6d1t8vLyFB8fr6NHjyoyMrLMeTUmyDz00EP6+OOPtW7dOjVp0qTUOaUdkWnatKkWLVqk2NhYP1VaM6SmpiopKUlDhw5VdHS00+X4Fb3TO727B727s3dJSktL05AhQ84ZZGrEW0vjxo3T0qVLtWbNmjJDjCSFhIQoJCSkxHhUVJRiYmKqs8Qap+gwY3R0NL27CL3TO727h5t7l6Sccp424WiQsSxLjzzyiBISErRq1SpdcsklTpYDAAAM42iQGTt2rObNm6fFixerdu3aOnDggCSpTp06CgsLc7I0AABgAEe/R2b27Nk6evSorr/+ejVu3Nj+ef/9950sCwAAGMLxt5YAAAAqi7+1BAAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIwV5HQBJklMDNG6dV4lJwdr584g5eV57G0HDhx0sLLqR+/u7B0AajqCTAW89FK4tm0LdroMR9C7O3sHgJqOIFMBHo8UG5uvLl3ylZkZoPXrvU6X5Df07s7eAaCmI8hUwJIlWQoLO3P5uefCXfU/NHo/c9ltvQNATcfJvhVQ9D8zN6J3AEBNRJABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAW3yNTAfHxYUpLC5Qkbdrk+02vcXER9uXRo08qNrbAr7VVN3p3Z+8AUNMRZCpg8eLQMr8M7dVXw+3LN96Ye8H9D43e3dk7ANR0vLUEAACMxRGZCkhIOOx0CY6hdwBATcQRGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWOcdZE6dOlUVdQAAAFRYpYJMYWGhnnnmGV188cWKiIjQt99+K0l66qmn9NZbb1VpgQAAAGWpVJD5y1/+ovj4eP3v//6vvN6f/5hex44d9eabb1ZZcQAAAGdTqSDzzjvv6PXXX9eIESMUGBhoj3fp0kU7d+6ssuIAAADOplJBJiMjQ61atSoxXlhYqNOnT593UQAAAOVRqSDTvn17rV27tsT4woUL1bVr1/MuCgAAoDyCKvNLTz/9tEaNGqWMjAwVFhZq0aJFSklJ0TvvvKOlS5dWdY0AAAClqtQRmYEDB2rJkiX69NNPFR4erqefflo7duzQkiVLdOONN1Z1jQAAAKWq1BEZSbrmmmu0cuXKqqwFAACgQiodZCQpLy9PmZmZKiws9Blv1qzZeRUFAABQHpUKMrt27dKYMWP0xRdf+IxbliWPx6OCgoIqKQ4AAOBsKhVkRo8eraCgIC1dulSNGzeWx+Op6roAAADOqVJBJjk5WZs3b1bbtm3P685nz56t2bNnKy0tTZLUoUMHPf300+rfv/953S4AAHCHSn+PzI8//njed96kSRPNnDlTmzdv1qZNm9S7d28NHDhQ27ZtO+/bBgAAF75KBZlnn31Wv//977Vq1Sr99NNPys7O9vkpr9tuu00DBgxQ69at1aZNG02bNk0RERH68ssvK1MWAABwmUq9tdS3b19JUp8+fXzGz+dk34KCAn3wwQc6fvy4rrzyysqUBQAAXKZSQebf//53lRWwdetWXXnllTp16pQiIiKUkJCg9u3blzo3NzdXubm59vWioz+7d+/WyZMnq6wmE6Snp0uSUlNTdejQIYer8S96p3d6dw96d2fv0pm/61geHsuyrGqu5azy8vKUnp6uo0ePauHChXrzzTe1evXqUsNMXFycpk6dWmJ89OjR8nq9/ii3RvF4PHL46XMMvdO729A7vbtNXl6e4uPjdfToUUVGRpY5r1JBZsuWLaXfmMej0NBQNWvWTCEhIRW9WUln3rZq2bKlXnvttRLbSjsi07RpUy1atEixsbGVuj9TpaamKikpSUOHDlV0dLTT5fgVvdM7vbsHvbuzd0lKS0vTkCFDzhlkKvXW0mWXXXbW744JDg7WnXfeqddee02hoaEVuu3CwkKfsFJcSEhIqQEpKipKMTExFbof0xUdZoyOjqZ3F6F3eqd393Bz75KUk5NTrnmV+tRSQkKCWrdurddff13JyclKTk7W66+/rksvvVTz5s3TW2+9paSkJP3pT3866+1MnjxZa9asUVpamrZu3arJkydr1apVGjFiRGXKAgAALlOpIzLTpk3TSy+9pH79+tljnTp1UpMmTfTUU09pw4YNCg8P1xNPPKHnn3++zNvJzMzUPffco/3796tOnTrq3Lmzli9fzl/QBgAA5VKpILN161Y1b968xHjz5s21detWSWfeftq/f/9Zb+ett96qzN0DAABIquRbS23bttXMmTOVl5dnj50+fVozZ860/2xBRkaGGjVqVDVVAgAAlKJSR2RmzZql22+/XU2aNFHnzp0lnTlKU1BQoKVLl0qSvv32Wz388MNVVykAAMAvVCrIXHXVVdq7d6/ee+89paamSpKGDRum4cOHq3bt2pKkkSNHVl2VAAAApahUkJGk2rVr68EHH6zKWgAAACqk3EEmMTFR/fv3V3BwsBITE8869/bbbz/vwgAAAM6l3EFm0KBBOnDggBo2bKhBgwaVOa+yfzQSAACgosodZAoLC0u9XNy+ffv05z//+fyrAgAAKIdKffy6LFlZWfrHP/5RlTcJAABQpioNMgAAAP5EkAEAAMYiyAAAAGNV6HtkhgwZctbtR44cOZ9aAAAAKqRCQaZOnTrn3H7PPfecV0EAAADlVaEgM2fOnOqqAwAAoMI4RwYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWDUmyMycOVMej0ePPfaY06UAAABD1Iggs3HjRr322mvq3Lmz06UAAACDOB5kcnJyNGLECL3xxhuqV6+e0+UAAACDOB5kxo4dq1tuuUV9+/Z1uhQAAGCYICfvfMGCBfr666+1cePGcs3Pzc1Vbm6ufT07O1uStHv3bp08ebJaaqyp0tPTJUmpqak6dOiQw9X4F73TO727B727s3dJysjIKNc8j2VZVjXXUqp9+/ape/fuWrlypX1uzPXXX6/LLrtML774Yqm/ExcXp6lTp5YYHz16tLxeb3WWWyN5PB459PQ5jt7p3W3ond7dJi8vT/Hx8Tp69KgiIyPLnOdYkPnoo480ePBgBQYG2mMFBQXyeDwKCAhQbm6uzzap9CMyTZs21aJFixQbG+uv0muE1NRUJSUlaejQoYqOjna6HL+id3qnd/egd3f2LklpaWkaMmTIOYOMY28t9enTR1u3bvUZu/fee9W2bVv94Q9/KBFiJCkkJEQhISElxqOiohQTE1NttdZERYcZo6Oj6d1F6J3e6d093Ny7dObDQOXhWJCpXbu2Onbs6DMWHh6uBg0alBgHAAAojeOfWgIAAKgsRz+19EurVq1yugQAAGAQjsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYwU5XYBJEhNDtG6dV8nJwdq5M0h5eR5724EDBx2srPrRO73TO71LF37vMA9BpgJeeilc27YFO12GI+id3t2G3t3ZO8xDkKkAj0eKjc1Xly75yswM0Pr1XqdL8ht6p3d6p3egJiLIVMCSJVkKCztz+bnnwl314qb3M5fpnd7dwM29wzyc7FsBRS9sN6J3d6J3d3Jz7zAPQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFh8j0wFxMeHKS0tUJK0aZPvt17GxUXYl0ePPqnY2AK/1lbd6J3e6f1n9H7Ghdg7zEOQqYDFi0PL/GKoV18Nty/feGPuBffipnd6/yV6P4PeL6zeYR7eWgIAAMbiiEwFJCQcdroEx9C7O9G7O7m5d5iHIzIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYy9EgExcXJ4/H4/PTtm1bJ0sCAAAGCXK6gA4dOujTTz+1rwcFOV4SAAAwhOOpISgoSBdddJHTZQAAAAM5fo7Mrl27FBMToxYtWmjEiBFKT093uiQAAGAIR4/I9OzZU/Hx8br00ku1f/9+TZ06Vddcc42++eYb1a5du8T83Nxc5ebm2tezs7MlSbt379bJkyf9VndNUBT4UlNTdejQIYer8S96p3d6dw96d2fvkpSRkVGueR7LsqxqrqXcjhw5oubNm+uFF17QfffdV2J7XFycpk6dWmJ89OjR8nq9/iixRvFIqjFPnp95PB7VoF3Xr1zdu9jn3Yje3dl7Xl6e4uPjdfToUUVGRpY5r0YFGUnq0aOH+vbtqxkzZpTYVtoRmaZNm2rRokWKjY31Y5XOS01NVVJSksZ07arGERFOl+NXWzMzlZiSoqFDhyo6Otrpcvyq6Hl3c+/s8+583undXb1LUlpamoYMGXLOIOP4yb7F5eTkaM+ePRo5cmSp20NCQhQSElJiPCoqSjExMdVdXo1SdJixcUSEmtWt62wxfrY/J0eSFB0d7drn3c29s8+783mnd3f1Lp3JBOXh6Mm+EydO1OrVq5WWlqYvvvhCgwcPVmBgoO666y4nywIAAIZw9IjM999/r7vuuks//fSToqOjdfXVV+vLL7905SE0AABQcY4GmQULFjh59wAAwHCOf48MAABAZRFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMFOV2AKfbn7Nfy75Zr/Q/rlXI4RZknMpWdl61Ib6Q6NOigYW2GaVibYfJ4PE6XWm0+nzdP6+fPL3N7SHi4HlmwwI8V+UdiYojWrfMqOTlYO3cGKS/v5+f4wIGDDlZW/dzcu8Q+79bnHWYhyJTTwl0LNe2raSXGs05laW3GWq3NWKul3y7VnH5zFBgQ6ECFqC4vvRSubduCnS7DEW7u3c143mESgkwFNazVUH2a9VHz2s2179g+fbjrQ50qOCVJWvHdCi1IWaAR7UY4XGX1u6RbN/UcNsxnLCDwwgxwHo8UG5uvLl3ylZkZoPXrvU6X5Ddu7v2X2OeBmokgU04XR1ysl3u/rEGtBiko4OeHbXDrwbpjyR329aT0JFcEmVp16qhJhw5Ol+EXS5ZkKSzszOXnngt31aLu5t5/iX0eqJkIMuU0pPWQUsevvvhq1Q+tr6xTWZKkvMI8f5YFPyha0N3Izb27Gc87TEKQOU9FJ/0W6dqwq4PV+M+2pCRtS0ryGevQu7f6P/64QxUB1Yt9HqiZ+Pj1ecgvzNfE1ROVX5gvSYoKi9I97e9xuCoAANyDIzKVlJOXowdWPqCkfWf+hRYRHKF3bn5HUWFRDlfmH6Wd+Bher55D1QDVj30eqJkIMpWQkZOhkR+P1PaftkuSGoQ20NwBc13ztpLkrhMfAYl9HqipCDIVlJyZrFGfjNLBE2e+FKplnZZ6b8B7iq0T62xhAAC4EOfIVMCyvcs0OHGwHWKuaHyFlg5eSogBAMAhHJEpp8Q9iXrw0wdVaBVKkiK9kbq+yfWav9P368sjvZG6u/3dTpSIahIfH6a0tDNffLZpk++3ncbFRdiXR48+qdjYAr/WVt3c3Lub8bzDJASZckrJSrFDjCRl52Vr5saZJeY1iWhCkLnALF4cWuYXgr36arh9+cYbcy+4Rd3NvbsZzztMQpBBufUaPly9hg93ugzAb9jngZqPIFNOk3pM0qQek5wuAw5ISDjsdAmOcXPvbsbzDpNwsi8AADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGcjzIZGRk6O6771aDBg0UFhamTp06adOmTU6XBQAADBDk5J0fPnxYvXr10g033KCPP/5Y0dHR2rVrl+rVq+dkWQAAwBCOBplnn31WTZs21Zw5c+yxSy65xMGKAACASRx9aykxMVHdu3fXsGHD1LBhQ3Xt2lVvvPGGkyUBAACDOHpE5ttvv9Xs2bM1YcIE/fGPf9TGjRv16KOPyuv1atSoUSXm5+bmKjc3176enZ0tSdq9e7dOnjzpt7prgvT0dEnS1sxM7c/Jcbga/9qdlSVJSk1N1aFDhxyuxr+Knnc3984+787nnd7d1bt05hza8vBYlmVVcy1l8nq96t69u7744gt77NFHH9XGjRu1fv36EvPj4uI0derUEuOjR4+W1+ut1lprIo/HIwefPkfRO727Db3Tu9vk5eUpPj5eR48eVWRkZJnzHD0i07hxY7Vv395nrF27dvrwww9LnT958mRNmDDBvp6dna2mTZtqZOfOahUdXa211jRbMzOVmJKioUOHKtplvaempiopKYne6d016J3e3da7JKWlpSk+Pv6c8xwNMr169VJKSorPWGpqqpo3b17q/JCQEIWEhJQYbxQRoWZ161ZHiTVW0aH16OhoxcTEOFyNfxUdYqV3encLeqd3t/UuSTnlfAvZ0ZN9H3/8cX355ZeaPn26du/erXnz5un111/X2LFjnSwLAAAYwtEg06NHDyUkJGj+/Pnq2LGjnnnmGb344osaMWKEk2UBAABDOPrWkiTdeuutuvXWW50uAwAAGMjxP1EAAABQWQQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFhBThdgks/nzdP6+fPL3B4SHq5HFizwY0X+sT9nv5Z/t1zrf1ivlMMpyjyRqey8bEV6I9WhQQcNazNMw9oMk8fjcbrUapGYGKJ167xKTg7Wzp1Bysv7uc8DBw46WFn1o3d6d1vvMA9BBue0cNdCTftqWonxrFNZWpuxVmsz1mrpt0s1p98cBQYEOlBh9XrppXBt2xbsdBmOoHd6B2o6gkwlXdKtm3oOG+YzFhB44f1PvLiGtRqqT7M+al67ufYd26cPd32oUwWnJEkrvluhBSkLNKLdCIerrHoejxQbm68uXfKVmRmg9eu9TpfkN/RO727rHeYhyFRSrTp11KRDB6fL8IuLIy7Wy71f1qBWgxQU8PMuM7j1YN2x5A77elJ60gUZZJYsyVJY2JnLzz0X7qpFnd7PXKZ39/QO8xBkcE5DWg8pdfzqi69W/dD6yjqVJUnKK8zzZ1l+U7SguxG9u5Obe4d5CDKVtC0pSduSknzGOvTurf6PP+5QRf5XdNJvka4NuzpYDQDAjfj4NSolvzBfE1dPVH5hviQpKixK97S/x+GqAABuwxGZSirtZN/wevUcqsa/cvJy9MDKB5S078wRqYjgCL1z8zuKCotyuDIAgNsQZCrJTSf7FpeRk6GRH4/U9p+2S5IahDbQ3AFzeVsJAOAIggzKLTkzWaM+GaWDJ858IVbLOi313oD3FFsn1tnCAACuxTkyKJdle5dpcOJgO8Rc0fgKLR28lBADAHAUR2RwTol7EvXgpw+q0CqUJEV6I3V9k+s1f6fvn2uI9Ebq7vZ3O1FitYqPD1Na2pkvO9y0yffbTuPiIuzLo0efVGxsgV9rq270Tu9u6x3mIcjgnFKyUuwQI0nZedmauXFmiXlNIppckEFm8eLQMr8Q7NVXw+3LN96Ye8Et6vRO7790ofcO8xBkKqDX8OHqNXy402UAAID/jyCDc5rUY5Im9ZjkdBmOSUg47HQJjqF3d3Jz7zAPJ/sCAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLEeDTGxsrDweT4mfsWPHOlkWAAAwRJCTd75x40YVFBTY17/55hvdeOONGjZsmINVAQAAUzgaZKKjo32uz5w5Uy1bttR1113nUEUAAMAkNeYcmby8PM2dO1djxoyRx+NxuhwAAGAAR4/IFPfRRx/pyJEjGj16dJlzcnNzlZuba18/evSoJOnbH3+s7vJqnPSsLOXl5SktLU05OTlOl+NXGRkZ9E7vTpfjV/RO727rXZLS09MlSZZlnXWexzrXDD/p16+fvF6vlixZUuacuLg4TZ061Y9VAQAAJ+3bt09NmjQpc3uNCDLfffedWrRooUWLFmngwIFlzvvlEZkjR46oefPmSk9PV506dfxRao2RnZ2tpk2bat++fYqMjHS6HL+id3qnd/egd3f2Lp05EnPs2DHFxMQoIKDsM2FqxFtLc+bMUcOGDXXLLbecdV5ISIhCQkJKjNepU8eVT7IkRUZG0rsL0Tu9uw29u7P38hykcPxk38LCQs2ZM0ejRo1SUFCNyFUAAMAQjgeZTz/9VOnp6RozZozTpQAAAMM4fgjkpptuOucZyWUJCQnRlClTSn276UJH7/TuNvRO727j5t4rokac7AsAAFAZjr+1BAAAUFkEGQAAYCyCDAAAMJbRQWbWrFmKjY1VaGioevbsqQ0bNjhdUrVbs2aNbrvtNsXExMjj8eijjz5yuiS/mTFjhnr06KHatWurYcOGGjRokFJSUpwuyy9mz56tzp07298nceWVV+rjjz92uixHzJw5Ux6PR4899pjTpVS7uLg4eTwen5+2bds6XZbfZGRk6O6771aDBg0UFhamTp06adOmTU6XVe1iY2NLPO8ej0djx451urQaydgg8/7772vChAmaMmWKvv76a3Xp0kX9+vVTZmam06VVq+PHj6tLly6aNWuW06X43erVqzV27Fh9+eWXWrlypU6fPq2bbrpJx48fd7q0atekSRPNnDlTmzdv1qZNm9S7d28NHDhQ27Ztc7o0v9q4caNee+01de7c2elS/KZDhw7av3+//bNu3TqnS/KLw4cPq1evXgoODtbHH3+s7du3669//avq1avndGnVbuPGjT7P+cqVKyVJw4YNc7iyGsoy1OWXX26NHTvWvl5QUGDFxMRYM2bMcLAq/5JkJSQkOF2GYzIzMy1J1urVq50uxRH16tWz3nzzTafL8Jtjx45ZrVu3tlauXGldd9111vjx450uqdpNmTLF6tKli9NlOOIPf/iDdfXVVztdRo0wfvx4q2XLllZhYaHTpdRIRh6RycvL0+bNm9W3b197LCAgQH379tX69esdrAz+VPTXz+vXr+9wJf5VUFCgBQsW6Pjx47ryyiudLsdvxo4dq1tuucXnde8Gu3btUkxMjFq0aKERI0bYfxH4QpeYmKju3btr2LBhatiwobp27ao33njD6bL8Li8vT3PnztWYMWPk8XicLqdGMjLI/PjjjyooKFCjRo18xhs1aqQDBw44VBX8qbCwUI899ph69eqljh07Ol2OX2zdulUREREKCQnRgw8+qISEBLVv397psvxiwYIF+vrrrzVjxgynS/Grnj17Kj4+Xp988olmz56tvXv36pprrtGxY8ecLq3affvtt5o9e7Zat26t5cuX66GHHtKjjz6qt99+2+nS/Oqjjz7SkSNHNHr0aKdLqbEc/2ZfoDLGjh2rb775xjXnC0jSpZdequTkZB09elQLFy7UqFGjtHr16gs+zOzbt0/jx4/XypUrFRoa6nQ5ftW/f3/7cufOndWzZ081b95c//znP3Xfffc5WFn1KywsVPfu3TV9+nRJUteuXfXNN9/o1Vdf1ahRoxyuzn/eeust9e/fXzExMU6XUmMZeUQmKipKgYGBOnjwoM/4wYMHddFFFzlUFfxl3LhxWrp0qf7973+rSZMmTpfjN16vV61atVK3bt00Y8YMdenSRS+99JLTZVW7zZs3KzMzU7/61a8UFBSkoKAgrV69Wn/7298UFBSkgoICp0v0m7p166pNmzbavXu306VUu8aNG5cI6e3atXPNW2uS9N133+nTTz/V/fff73QpNZqRQcbr9apbt2767LPP7LHCwkJ99tlnrjpnwG0sy9K4ceOUkJCgpKQkXXLJJU6X5KjCwkLl5uY6XUa169Onj7Zu3ark5GT7p3v37hoxYoSSk5MVGBjodIl+k5OToz179qhx48ZOl1LtevXqVeLrFVJTU9W8eXOHKvK/OXPmqGHDhrrlllucLqVGM/atpQkTJmjUqFHq3r27Lr/8cr344os6fvy47r33XqdLq1Y5OTk+/xrbu3evkpOTVb9+fTVr1szByqrf2LFjNW/ePC1evFi1a9e2z4eqU6eOwsLCHK6uek2ePFn9+/dXs2bNdOzYMc2bN0+rVq3S8uXLnS6t2tWuXbvEeVDh4eFq0KDBBX9+1MSJE3XbbbepefPm+uGHHzRlyhQFBgbqrrvucrq0avf444/rqquu0vTp0/XrX/9aGzZs0Ouvv67XX3/d6dL8orCwUHPmzNGoUaMUFGTs/6r9w+mPTZ2Pv//971azZs0sr9drXX755daXX37pdEnV7t///rclqcTPqFGjnC6t2pXWtyRrzpw5TpdW7caMGWM1b97c8nq9VnR0tNWnTx9rxYoVTpflGLd8/PrOO++0GjdubHm9Xuviiy+27rzzTmv37t1Ol+U3S5YssTp27GiFhIRYbdu2tV5//XWnS/Kb5cuXW5KslJQUp0up8fjr1wAAwFhGniMDAAAgEWQAAIDBCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyACoEeLi4nTZZZc5XQYAwxBkAFSJAwcO6JFHHlGLFi0UEhKipk2b6rbbbvP5464AUNX4S1QAzltaWpp69eqlunXr6rnnnlOnTp10+vRpLV++XGPHjtXOnTudLhHABYojMgDO28MPPyyPx6MNGzZo6NChatOmjTp06KAJEyboyy+/lCSlp6dr4MCBioiIUGRkpH7961/r4MGDZd5mYWGh/vznP6tJkyYKCQnRZZddpk8++cTenpaWJo/Ho0WLFumGG25QrVq11KVLF61fv96eEx8fr7p162r58uVq166dIiIidPPNN2v//v0+9/Xmm2+qXbt2Cg0NVdu2bfXKK69U8SMEoLoQZACcl6ysLH3yyScaO3aswsPDS2yvW7euCgsLNXDgQGVlZWn16tVauXKlvv32W915551l3u5LL72kv/71r3r++ee1ZcsW9evXT7fffrt27drlM+/JJ5/UxIkTlZycrDZt2uiuu+5Sfn6+vf3EiRN6/vnn9e6772rNmjVKT0/XxIkT7e3vvfeenn76aU2bNk07duzQ9OnT9dRTT+ntt9+ugkcHQLVz+s9vAzDbV199ZUmyFi1aVOacFStWWIGBgVZ6ero9tm3bNkuStWHDBsuyLGvKlClWly5d7O0xMTHWtGnTfG6nR48e1sMPP2xZlmXt3bvXkmS9+eabJW5zx44dlmVZ1pw5cyxJ1u7du+05s2bNsho1amRfb9mypTVv3jyf+3nmmWesK6+8srwPAQAHcUQGwHmxLOucc3bs2KGmTZuqadOm9lj79u1Vt25d7dixo8T87Oxs/fDDD+rVq5fPeK9evUrM79y5s325cePGkqTMzEx7rFatWmrZsqXPnKLtx48f1549e3TfffcpIiLC/vnLX/6iPXv2nLMvAM7jZF8A56V169byeDyOndAbHBxsX/Z4PJLOnF9T2vaiOUXhKycnR5L0xhtvqGfPnj7zAgMDq6VeAFWLIzIAzkv9+vXVr18/zZo1S8ePHy+x/ciRI2rXrp327dunffv22ePbt2/XkSNH1L59+xK/ExkZqZiYGH3++ec+459//nmp8yurUaNGiomJ0bfffqtWrVr5/FxyySVVdj8Aqg9HZACct1mzZqlXr166/PLL9ec//1mdO3dWfn6+Vq5cqdmzZ2v79u3q1KmTRowYoRdffFH5+fl6+OGHdd1116l79+6l3uakSZM0ZcoUtWzZUpdddpnmzJmj5ORkvffee1Va+9SpU/Xoo4+qTp06uvnmm5Wbm6tNmzbp8OHDmjBhQpXeF4CqR5ABcN5atGihr7/+WtOmTdMTTzyh/fv3Kzo6Wt26ddPs2bPl8Xi0ePFiPfLII7r22msVEBCgm2++WX//+9/LvM1HH31UR48e1RNPPKHMzEy1b99eiYmJat26dZXWfv/996tWrVp67rnnNGnSJIWHh6tTp0567LHHqvR+AFQPj1WeM/UAAABqIM6RAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBY/w+ddGtiKeo4IAAAAABJRU5ErkJggg==\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Copier le plateau pour tester le solveur par regles\n",
-        "board_rules = board.copy()\n",
-        "solver_rules = RuleBasedSolver(board_rules)\n",
-        "\n",
-        "# Etat avant\n",
-        "revealed_before = len(board_rules.revealed)\n",
-        "flagged_before = len(board_rules.flagged)\n",
-        "\n",
-        "# Resoudre\n",
-        "iterations = solver_rules.solve()\n",
-        "\n",
-        "# Resultats\n",
-        "revealed_after = len(board_rules.revealed)\n",
-        "flagged_after = len(board_rules.flagged)\n",
-        "total_cells = board_rules.rows * board_rules.cols\n",
-        "unknown_remaining = total_cells - revealed_after - flagged_after\n",
-        "\n",
-        "print(\"Solveur par regles simples\")\n",
-        "print(\"=\" * 45)\n",
-        "print(f\"Iterations         : {iterations}\")\n",
-        "print(f\"Cellules revelees  : {revealed_before} -> {revealed_after} (+{revealed_after - revealed_before})\")\n",
-        "print(f\"Drapeaux poses     : {flagged_before} -> {flagged_after} (+{flagged_after - flagged_before})\")\n",
-        "print(f\"Cellules inconnues : {unknown_remaining}\")\n",
-        "print(f\"Partie gagnee      : {board_rules.won}\")\n",
-        "print(f\"Coups effectues    : {len(solver_rules.moves_log)}\")\n",
-        "\n",
-        "# Visualiser le resultat\n",
-        "fig = draw_board(board_rules,\n",
-        "                 title=f\"Apres solveur par regles ({len(solver_rules.moves_log)} coups)\",\n",
-        "                 show_mines=True)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-14",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004905,
-          "end_time": "2026-02-26T07:01:09.884988",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.880083",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-14"
-      },
-      "source": [
-        "### Interpretation : solveur par regles\n",
-        "\n",
-        "**Sortie obtenue** : le solveur par regles a effectue des deductions locales en quelques iterations.\n",
-        "\n",
-        "| Mesure | Valeur | Commentaire |\n",
-        "|--------|--------|-------------|\n",
-        "| Iterations | Typiquement 3-8 | Convergence rapide |\n",
-        "| Cellules resolues | Variable | Depend de la configuration |\n",
-        "| Cellules restantes | >0 en general | Les cas ambigus ne sont pas resolus |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Les regles simples sont **rapides** (temps constant par cellule par iteration) et **sures** (pas de risque d'erreur)\n",
-        "2. Elles se bloquent quand aucune cellule n'est localement determinee -- c'est la **frontiere du raisonnement local**\n",
-        "3. En pratique, elles resolvent environ 30 a 50% des decisions sur un plateau 8x8 typique\n",
-        "\n",
-        "> **Limite fondamentale** : les regles ne combinent pas les contraintes de plusieurs cellules revelees. Le CSP va combler cette lacune."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-15",
-      "metadata": {
-        "papermill": {
-          "duration": 0.0051,
-          "end_time": "2026-02-26T07:01:09.894907",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.889807",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-15"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 4. Approche 2 : solveur CSP (~12 min)\n",
-        "\n",
-        "Le solveur CSP va plus loin que les regles simples en considerant **simultanement** toutes les contraintes. L'idee est :\n",
-        "\n",
-        "1. **Modeliser** les cellules inconnues proches de la frontiere comme des variables binaires\n",
-        "2. **Poser les contraintes** : chaque cellule revelee impose une somme sur ses voisines inconnues\n",
-        "3. **Enumerer les solutions** du CSP\n",
-        "4. **Deduire** : si une variable vaut la meme chose (0 ou 1) dans **toutes** les solutions, elle est determinee\n",
-        "\n",
-        "### Pourquoi est-ce plus puissant ?\n",
-        "\n",
-        "Considerons cette configuration :\n",
-        "\n",
-        "```\n",
-        "1  ?  ?\n",
-        "1  ?  ?\n",
-        "1  ?  ?\n",
-        "```\n",
-        "\n",
-        "Les regles simples ne deduisent rien (chaque `1` a 2 ou 3 voisines inconnues). Mais en combinant les trois contraintes, le CSP peut determiner que certaines cellules sont necessairement sures ou minees.\n",
-        "\n",
-        "### Optimisation : travailler sur la frontiere\n",
-        "\n",
-        "Pour eviter d'enumerer les solutions sur toute la grille, nous ne considerons que les cellules inconnues **adjacentes a au moins une cellule revelee**. Les cellules completement isolees ne sont pas contraintes localement."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-16",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.622708Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.622135Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.640840Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.639202Z"
-        },
-        "papermill": {
-          "duration": 0.016013,
-          "end_time": "2026-02-26T07:01:09.915708",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.899695",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-16",
-        "outputId": "297571a0-4afa-404d-c3f7-a53159a75ab8",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Classe CSPSolver definie.\n"
-          ]
-        }
-      ],
-      "source": [
-        "class CSPSolver:\n",
-        "    \"\"\"Solveur CSP pour le Demineur.\n",
-        "\n",
-        "    Utilise python-constraint pour enumerer les solutions\n",
-        "    et deduire les cellules determinee.\n",
-        "    \"\"\"\n",
-        "\n",
-        "    def __init__(self, board):\n",
-        "        self.board = board\n",
-        "\n",
-        "    def get_frontier_cells(self):\n",
-        "        \"\"\"Retourne les cellules inconnues adjacentes a une cellule revelee.\"\"\"\n",
-        "        frontier = set()\n",
-        "        for r in range(self.board.rows):\n",
-        "            for c in range(self.board.cols):\n",
-        "                if (r, c) in self.board.revealed:\n",
-        "                    for nr, nc in self.board.get_neighbors(r, c):\n",
-        "                        if ((nr, nc) not in self.board.revealed and\n",
-        "                            (nr, nc) not in self.board.flagged):\n",
-        "                            frontier.add((nr, nc))\n",
-        "        return frontier\n",
-        "\n",
-        "    def get_constraint_cells(self):\n",
-        "        \"\"\"Retourne les cellules revelees qui contraignent des cellules inconnues.\"\"\"\n",
-        "        constraint_cells = []\n",
-        "        for r in range(self.board.rows):\n",
-        "            for c in range(self.board.cols):\n",
-        "                if (r, c) not in self.board.revealed:\n",
-        "                    continue\n",
-        "                if self.board.numbers[r, c] == 0:\n",
-        "                    continue\n",
-        "                unknown = self.board.get_unknown_neighbors(r, c)\n",
-        "                if len(unknown) > 0:\n",
-        "                    flagged_count = len(self.board.get_flagged_neighbors(r, c))\n",
-        "                    remaining = self.board.numbers[r, c] - flagged_count\n",
-        "                    constraint_cells.append(((r, c), unknown, remaining))\n",
-        "        return constraint_cells\n",
-        "\n",
-        "    def build_csp(self):\n",
-        "        \"\"\"Construit le probleme CSP avec python-constraint.\"\"\"\n",
-        "        frontier = self.get_frontier_cells()\n",
-        "        constraints = self.get_constraint_cells()\n",
-        "\n",
-        "        if not frontier:\n",
-        "            return None, frontier\n",
-        "\n",
-        "        problem = Problem()\n",
-        "\n",
-        "        # Variables : chaque cellule frontiere est binaire (0=sure, 1=mine)\n",
-        "        for cell in frontier:\n",
-        "            problem.addVariable(cell, [0, 1])\n",
-        "\n",
-        "        # Contraintes : pour chaque cellule revelee, la somme de ses\n",
-        "        # voisines inconnues dans la frontiere = mines restantes\n",
-        "        for (r, c), unknown, remaining in constraints:\n",
-        "            # Filtrer les inconnues qui sont dans la frontiere\n",
-        "            vars_in_frontier = [u for u in unknown if u in frontier]\n",
-        "            if vars_in_frontier:\n",
-        "                problem.addConstraint(\n",
-        "                    ExactSumConstraint(remaining),\n",
-        "                    vars_in_frontier\n",
-        "                )\n",
-        "\n",
-        "        return problem, frontier\n",
-        "\n",
-        "    def solve(self):\n",
-        "        \"\"\"Resout le CSP et retourne les cellules deduites.\n",
-        "\n",
-        "        Retourne:\n",
-        "            safe_cells: ensemble de cellules determinees sures\n",
-        "            mine_cells: ensemble de cellules determinees mines\n",
-        "            solutions: liste de toutes les solutions\n",
-        "        \"\"\"\n",
-        "        problem, frontier = self.build_csp()\n",
-        "\n",
-        "        if problem is None:\n",
-        "            return set(), set(), []\n",
-        "\n",
-        "        solutions = problem.getSolutions()\n",
-        "\n",
-        "        if not solutions:\n",
-        "            return set(), set(), []\n",
-        "\n",
-        "        # Determiner les cellules forcees\n",
-        "        safe_cells = set()\n",
-        "        mine_cells = set()\n",
-        "\n",
-        "        for cell in frontier:\n",
-        "            values = [sol[cell] for sol in solutions]\n",
-        "            if all(v == 0 for v in values):\n",
-        "                safe_cells.add(cell)\n",
-        "            elif all(v == 1 for v in values):\n",
-        "                mine_cells.add(cell)\n",
-        "\n",
-        "        return safe_cells, mine_cells, solutions\n",
-        "\n",
-        "    def get_probabilities(self, solutions):\n",
-        "        \"\"\"Calcule la probabilite de mine pour chaque cellule frontiere.\n",
-        "\n",
-        "        Retourne un dict (r,c) -> probabilite.\n",
-        "        \"\"\"\n",
-        "        if not solutions:\n",
-        "            return {}\n",
-        "\n",
-        "        probabilities = {}\n",
-        "        n_solutions = len(solutions)\n",
-        "\n",
-        "        # Collecter toutes les variables presentes dans les solutions\n",
-        "        all_vars = set()\n",
-        "        for sol in solutions:\n",
-        "            all_vars.update(sol.keys())\n",
-        "\n",
-        "        for cell in all_vars:\n",
-        "            mine_count = sum(1 for sol in solutions if sol.get(cell, 0) == 1)\n",
-        "            probabilities[cell] = mine_count / n_solutions\n",
-        "\n",
-        "        return probabilities\n",
-        "\n",
-        "\n",
-        "print(\"Classe CSPSolver definie.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-17",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004705,
-          "end_time": "2026-02-26T07:01:09.925456",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.920751",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-17"
-      },
-      "source": [
-        "Testons le solveur CSP sur le plateau apres que le solveur par regles s'est bloque."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-18",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.644411Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.643742Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.807648Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.806153Z"
-        },
-        "papermill": {
-          "duration": 0.147515,
-          "end_time": "2026-02-26T07:01:10.077873",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:09.930358",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-18",
-        "outputId": "ce8c3fa6-4351-44aa-d40b-a18aebf6c613",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 763
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Solveur CSP\n",
-            "==================================================\n",
-            "Variables (frontiere)      : 0\n",
-            "Contraintes                : 0\n",
-            "Solutions trouvees         : 0\n",
-            "Cellules deduites sures    : 0\n",
-            "Cellules deduites mines    : 0\n",
-            "Cellules non determinees   : 0\n",
-            "Temps                      : 0.6 ms\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUetJREFUeJzt3Xl0VPX9//HXZJkkZGNJAoRAgqyyU1YLboCyuLGIyo5LLRU3FNpiv0qoVahYK1UqopaoCLEqSEBk0SiComymIkoCshqWoAFCEBKS3N8f/DJmSEIWkrn5MM/HOTln5t47M+/33Jub13zunRuHZVmWAAAADORjdwEAAACVRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkKlBxo8fL4fDIYfDofj4eLvLcYmPj3fVNX78eLvL8To7duyQv7+/HA6HnnjiCbvLqTBPbtd79+51vZbD4ajW1wKq2zXXXOPalhMSEuwup1RXXnmlHA6HmjdvrtzcXI+/PkFGUkJCgtvOz8fHR4GBgapfv766dOmi3//+99qwYYPdZVabhIQExcfHKz4+XikpKXaXU20KCgq0dOlS3XbbbYqLi1NQUJDCwsJ0+eWXa/To0Vq2bJnO/48dX331lW677TbFxMTI6XQqNDRUsbGxuuaaa/TQQw/p22+/dVu+6I6n6E9wcLDatm2rRx99VBkZGRWqe8qUKcrLy1NwcLAeeuihYvO//fZbjRw5UtHR0XI6nYqOjtbIkSO1ffv2ir9JNVxKSoprW63JO/bq5E3r29N4byvnL3/5iyTphx9+0Jw5czxfgAVr/vz5lqQyf0aOHGllZ2dXWx3jxo1zvda0adOq7XXOd/XVV7ted/78+cXm79u3z1q3bp21bt06Ky0tzWN1VaXDhw9bV111VZnr+NixY67HLFmyxPL19b3g8q+88orb6xR9L0v7qV+/vrVz585y1b1lyxbX4+65555i81esWGEFBASU+DqBgYHW6tWrL+p9qwpVuV0X/V29+uqri80/c+aMa1tdt27dRb1WTWTC+jZVTXxvv/nmG9e2fOTIEY+/fkU0a9bMkmRFRUVZOTk5Hn1tRmRKsG7dOiUnJ+s///mP+vfv75q+cOFC3XbbbcU+tV/qmjRpot69e6t3795q0aKF3eVU2C+//KL+/fvrs88+kyT5+Pjorrvu0uLFi/Xxxx8rISFBt99+u/z9/d0eN2nSJOXn50uSBg8erCVLluiTTz5RYmKiHnroIcXExFzwdQcOHOjalv72t7/J19dXknTkyBFNmTKlXLX/+9//dt0eMWKE27xjx45p7NixysnJkSSNHTtWy5Yt09ixYyVJZ86c0ejRo3XixIlyvdalICAgwLWt9u7d2+5yqtSlsL7Pnj1ry6GHstTU97Z9+/aubTkqKsqjr11RhfunjIwMLV682LMv7tHYVEOdPyJzvieffNJtfmJiotv8U6dOWX//+9+tbt26WaGhoZbT6bSaN29uTZo0ycrIyCj2fBkZGdZdd91l1atXz6pVq5Z19dVXW1988UWpn1wv9Ik2NjbWNe+TTz5xm3fo0CHrj3/8o9W+fXsrODjYCgwMtJo2bWqNHj3aOnLkSJkjUePGjbMsy7KmTZtWbFqhnJwc6/nnn7d69uxphYWFWf7+/lZMTIw1YsQIa/PmzW7L7tmzx+35f/75Z+u+++6zGjRoYDmdTqtz587WypUr3R5z5swZa/r06VaHDh2sWrVqWf7+/lb9+vWtnj17Wg888IB16NChEtaou6efftrtdRctWlTicqmpqa5PEkeOHHF7zIkTJ4otX1BQYJ08edJtWtERmfPfq7Fjx7rmhYeHl1l3Xl6eFRYWZkmygoODrby8PLf5//rXv1zP17JlS6ugoMCyLMvKz8+3WrRo4Zr34osvlvlax44dsx599FGrVatWVmBgoOV0Oq2GDRtaV111lTV58mTr1KlTbsunpKRYY8aMsZo0aWI5nU4rNDTU6tatmzVr1izrzJkzbstW1XZ9oW218Pf2/G3sfGvXrrWGDh1qNWzY0PL397dq165t9e7d23rllVes/Px8t2XPH6l87bXXrA4dOlgBAQFWw4YNrT//+c/F1smKFSus6667zoqIiLD8/Pys8PBwq1WrVtaIESOsFStWlLkeLsSu9V30/dyzZ49r+ieffOKaHhsb65p+/jo4ePCgNW7cOCsyMtJyOBzW119/7Vo2MTHRuu6666x69epZ/v7+VoMGDaw77rjD+t///lesZlPe2/P3lx988IH1m9/8xgoICLAuu+wy64UXXrAsy7LS0tKsm266yQoNDbXCw8Ot22+/vdjfi9JGy8//3Vm6dKnVo0cPKzAw0IqIiLDuvffeEo8efPfdd9bdd99tNW3a1AoICLBCQ0Ot3/72t9b8+fNdPRf68ccfrXvvvddq2rSp5XQ6rcDAQCsmJsbq16+f9cQTTxR77g0bNrhquuWWW8p8n6oSQcYqO8icvzEPHDjQNe/o0aNWu3btSt25NmrUyNq9e7dr+ezsbKtNmzbFlgsICHCbfrFBZtOmTVa9evVKrevrr7++6CCTnZ1t9ezZs9TH+/n5Wa+//rpr+fN3cEXf08Ifp9Np7d271/WYon/8S/rZsGFDmeu3VatWruX79OlT5vKWZVm//PKL5ePj43rc6NGjrfXr11unT5++4OMuFGQefPBB17ygoKAya9i8ebNr+ZIOowwePNg1f/z48W7zim4zQ4cOLfO1yjrsVjQwLlq0yPL39y912S5dulhZWVkl1mJnkJk1a5blcDhKffygQYOss2fPupYvui5L2lYlWTNmzHAt//HHH1/w+X//+9+XuR4uxK71XXR6ZYLM+e/d119/beXn51sjR44s9fUDAgKspKQk13Oa9N4W3V82a9bMbT9S+POnP/3Jqlu3brHp/fv3d3uu8gSZ5s2bl+s9WbJkiRUYGFjqezhq1ChXmMnNzXUdKipt/ZzvzJkzltPptCRZderUKfbBoDpxaKkcfHx81LdvX9f9zZs3u25PnDjRdcJnp06dtGjRIn344YcaNmyYJCk9PV3jxo1zLf/ss8/qu+++kyQ5nU7NnDlTy5cv14033uiafrFycnI0fPhw/fzzz5KkqKgo/fOf/9SqVav0n//8R9ddd50cDocGDRqkdevWqVOnTq7HPvbYY1q3bp3WrVvnOoGrNI8//ri+/PJLSVJISIhmz56t5cuXa/DgwZKkvLw83XvvvTpw4ECJjz927JheeeUVvfPOO2rUqJEkKTc3V3PnznUt895770mSwsPDNX/+fCUnJysxMVHx8fHq1q2bfHwuvAmfOnVKqamprvvXX3/9BZcvFBQUpGuvvdZ1f8GCBerdu7dCQ0PVuXNn/fGPf9TOnTvL9Vxnz57VunXrtGDBAte0zp07l/m4bdu2uW6XdEhv9+7drtsNGjRwm1f0/g8//HDB1/npp59ch90aN26sxMREffzxx1qwYIH+9Kc/qV27dq5vAB0+fFh33323zp49K+nc4bNly5bp3//+t8LDwyVJW7Zs0Z///Ocy+6uodevW6bHHHnPd79Spk2tbXbdu3QUf+7///U9//OMfXYeFx4wZow8++EAzZ86U0+mUJK1YsUL//Oc/S3z8zp079cADD+iDDz7Qrbfe6po+e/Zs1+3Fixe7nv++++7TRx99pKSkJL344osaMmSIwsLCKtf4/2fH+q4K+/fv11//+letWrVK8+bNU0REhF5++WUtXLhQkhQREaE5c+ZozZo1+r//+z85HA7l5ORozJgxOnbsmCRz3tvz/fDDDxo+fLg++OAD198ESfr73/+u0NBQvf3223rhhRdc01etWuW2vyqPXbt2acSIEVq+fLn+8Ic/uKa/9tprys7OliQdPXpUY8aM0ZkzZyRJEyZM0MqVK/Xmm28qNjZWkvTWW29p/vz5ks79vhT22qFDBy1ZskRr1qzR66+/roceekjNmzcvVkdAQICaNGki6dy+vbT9frXwWGSqwcoakbEsy/rLX/7imu/v729Z1rnh2aIngy5cuNB1YtYnn3zi9ql1x44dlmVZbqM3kyZNcj1/bm6u1ahRoyr55Lp8+XLXNB8fH2vr1q0X7L+sk31LGpEpKChwG/H5xz/+4Vo+JyfHio6Ods175plnLMsq/kntv//9r+sxM2fOLPFTT+HzREdHW59//nmFT7b+8ccf3V7z/JNzL2TPnj0XHG3z9/cvdpixPCf7+vr6WmvWrCnz9Z955hm3T3DnK/qJ6fyh3scff9ztU+GFnD592rUdt2/f3tqyZUupI0+zZ892PW9kZKTbci+++KJrXlhYmOuwS1UeMi3rZN/SRmQmTZrkmta+fXu3x0yePNk1r02bNq7pRdfloEGDXNMPHz7s9hqFo0+PPfaY2+/DwYMHS37DK8mO9W1ZFz8i869//avYc3bp0sU1f8qUKW4naHfu3Nk1b+7cuZZlmfPeWpb7/jI6Oto1yrdx40a396Xo4bC2bdu6phcdiSrPiEzbtm3dDoXVqlXLNe+bb76xLMuyXnjhBde0du3aub3fRf+29ezZ07Ksc4e9Cqf17dvX2r59u5Wbm1tm7927d3c9buPGjWUuX1UYkSmno0ePum7Xrl1bkpSWluY6GVSSRo4cqSuvvFJXXnmlrr32WtenVkmuUZtdu3a5pl1xxRWu2/7+/urevXuV1Fp0ZKdp06bl+vRfUUePHnWN+EhyO7HS6XS69bJjx44Sn6PoKFe9evVctzMzM123J0yYIEk6ePCgevXqpZCQEMXExOiWW27R22+/XWadheuqUNGayxIXF6eUlBQtW7ZMEydOVOfOnV0n7ErnRlomTJjg+pRTHl27dtWqVavUr1+/cj9GUoknmAcHB7tuF56kWNL9kJCQCz53YGCga9Rw27Zt6tKli4KDg9W0aVPdcccdWrVqlWvZouuya9euCgwMdN0vug1kZWXp4MGDZbXlMUXrPv8k4KL309LSSnyvS9tWpV+31zFjxrjWyaOPPqro6GiFhobqiiuuUHx8vNt2XRl2rO+qUHQkolDRfdSsWbNc+80rr7xSX3/9tWte4X7TlPf2fN27d5efn5+k4ttN0f1/RESE63ZFe+nTp49rBM3Hx0d16tQp9lxF3+9vv/3W7f1+6qmn3OZJUvPmzV37qI8//lht27ZVUFCQWrVqpfHjx7tG4s9X0u+OJxBkyqGgoEAfffSR637Xrl0r/ByFQ3yVUXSYNy8vz23eTz/9VOnntVvdunVdtwt/2SX3X4bHH39cSUlJGjdunDp37qyQkBClp6crKSlJd9xxh9vQfkmCg4PVqlUr1/2i67E8fH19deONN+rFF1/U1q1bdfToUbfDJsePHy91KLjwW0vr16/X5s2b9dNPP2nTpk1ufxQvJDIy0nW7pJ3bZZdd5rp9+PBht3mHDh1y3W7WrFmZrzVv3jwtWLBAd9xxh9q1ayen06m9e/fq7bff1oABA7R06dJy1VwRJm3XpW2r0q/ba+vWrZWSkqKpU6fq6quvVsOGDZWdna0vv/xS06dPV//+/d0++FRUTVjfRddT0Q93F9KwYcNyLVeSwv2mSe9tUYWHWyUVOwx+/oesQhUNA0W3Tan0fWl5FL7fDodDy5Yt09y5czVkyBC1atVKPj4+SktL0+uvv66rrrrK7RSLQkX3U578lhVBphyefPJJt2OohZ9mWrZs6fYJPTU1Vda5E6jdfrKzs12PKfqLUDTV5uXladOmTSW+ftGE/eOPP7puJycn69SpU8WWb9Omjev2nj179L///a/YMkU38KK/YAUFBSXWcL7IyEi3Txiff/656/bZs2fdemndunW5nrMklmXppptuUkJCgrZu3aqsrCz997//dc1ftGhRmc9R9GrEH330kd55550Sl9u5c6frq6EFBQVKSkoqtiOoU6eOHn74Ybdppb1nUVFR6t27t3r16qUuXboU+0RWlvbt27tulxSW+vTp47r9xRdfuOooKChwWx9FlyuNj4+PRo0apUWLFmnbtm06deqUZs2a5Zpf+D4XXZdbtmxxG40q+pphYWFl/gGr6HZdWGeh8m6r59ddtM7z77ds2bLS54dYlqXmzZvr6aef1qeffqqDBw/q0KFDiouLk3Tu3LrynldVEjvWt1T6elq2bFm56i7p/bz88stdt19++eUS95s5OTmaN2+eJLPe25qo6Pv929/+tsT3u/BvlXTu/Q4MDNTvf/97LV68WDt27NCpU6f04IMPSjq3j3/33XfdXuPMmTPav3+/pHMBrnHjxh7qTvIrexHvs379ep09e1b79u3TokWLtHr1ate8QYMG6bbbbpN0LlEPHTrU9Ydx0KBBmjJlipo3b67jx49r3759+uyzz7Rjxw7X0Patt97qukrknDlz1KBBA7Vt21YJCQluO4miWrZs6bq9aNEiNW3aVIGBgW47nqL69eun2NhY7du3TwUFBRowYICmTp2qyy+/XIcOHVJiYqJmzJihjh07SnIf8nznnXcUFxcnp9OpVq1auY0KFOVwODR27FjXyZHTpk2Tv7+/LrvsMr322mtKT0+XdO4EsDvuuKOMd7x0vXv3VuvWrXXFFVcoOjpa/v7+WrlypWt+eQ7rPPTQQ0pMTHQFuhEjRmj16tW68cYbFRYWpvT0dK1cuVLvvPOOjhw5IqfTqYKCAt1yyy2KjY3V0KFD1aNHD0VFRenYsWN6+eWXXc8dFhbmFhyrUqdOnRQeHq4TJ05o69atys/PdwvOo0eP1vTp0/Xzzz9r586dGj9+vG677TYlJia6gndERIRGjRpV5ms1b95cgwYNUpcuXRQdHa38/HzXCaHSr+/zbbfdpqlTp+qXX35RRkaGbr31Vk2YMEE//vij28nho0ePLjZycb6KbteS+7b6zTffaPHixYqKilLt2rXVrl27Uh83duxYPf/887IsS998843uvPNO3Xbbbfr222/1r3/9y7XcxfwLjn/84x/68MMPdcMNNyg2NlZ169bVzp073UYuim6vRf/A79mzx/VHuTR2rG/p3Hr66quvJJ37csPEiRO1ZcsWvfnmm2W+Tmnuvvtubd26VdK5Q0VHjx5Vt27dlJubqwMHDmjz5s1KSkrSpk2bFBcXZ9R7WxPdfvvteuyxx5Sdna0vvvhCt956q0aOHKnw8HClp6crNTVVK1as0ODBgzVt2jQdOXJEvXr10rBhw9S+fXs1bNhQv/zyi9sozPn73q+//tp1OsWVV15Z5hcxqpQnTsSp6cp7Zd9Ro0YVO9k0IyPjgieE6rwT4U6ePGm1bt26xBNAi55wVvTkxxMnTpT4VeqYmBirdu3aJZ4U+dVXX1l16tQptaai13J4+eWXS1zmzTfftCyr+r5+Xdo6KHoSZ9GvTpf089xzz5VrHR86dKhCV/Y9e/ZsubaJefPmub3Ohb5+XRn33HOP6/k++uijYvOXL1/u+srj+T8BAQHWhx9+WK7XKe2KpoU/7733nmvZ8nz9uuh1d0o7qbcy23VmZqbbyYyFP3379rUs6+K/fl30hMYLnQRf9HGFJ8DOmDHjgu9h586d3b6SWtJzlMWO9f3WW2+VuEzR/d6FTvYtSX5+vjVixIgyf79MfG9L219e6H0pbVsr73VkiirtRPnFixdf8OvXRZ/r0KFDF1zOz8/P+uqrr9xet+hJw2+99Va53quqwqGlEjgcDjmdTkVFRek3v/mN7r33Xn3xxRdasGCB20lh0rlDLBs3btSzzz6rnj17Kjw8XP7+/oqOjlbPnj31l7/8xfUVYuncyWJr167V+PHjVbduXQUFBemKK67QypUrS70SaVhYmFasWKHevXsrICBAdevW1ZgxY/TVV1+5HYMtqnv37vr22281efJktWvXTrVq1VJgYKCaNm2qUaNGKTo62rXs3XffralTpyomJqZCKTo4OFhr167VP//5T/Xo0UOhoaHy8/NTdHS07rjjDm3YsMF1ZczK+vOf/6zhw4erefPmCgsLk6+vr+rWratrrrlGb775piZNmlSu52nQoIE++eQTLVmyRLfeequaNGmiwMBAhYSEqFWrVho5cqSWLl3qej/9/Py0atUq/fnPf1bv3r0VFxenWrVqyd/fX40aNdLQoUOVnJys3/3udxfVX1mKfp2y8OuqRd1www3atGmTbr/9djVo0ED+/v5q0KCB7rjjDm3atEkDBgwo1+vMmDFDN998s+Li4hQSEiJfX19FRkZqwIABWrFihYYOHepa9o477tDGjRs1evRoNW7cWP7+/goJCVGXLl30zDPPaP369eX6Omxltus6depo8eLF6tq1qwICAsrVW6HJkyfrk08+0dChQ9WgQQP5+fkpPDxcvXr10ssvv6xly5YVu7pzRQwYMED333+/fvOb3ygqKkp+fn4KCgpSmzZtNGXKFH388ceu36/zz+coby92rO+RI0dq1qxZio2Nlb+/v1q0aKHnnnuuzPPTLsTHx0cLFy7Uf//7Xw0YMECRkZHy8/NTRESEOnTooAkTJmjFihWuwxMmvbc11ZAhQ/T111/r3nvvVfPmzRUYGKjg4GA1b95cN954o+bOnav77rtP0rmjDU8++aSuv/56NWnSREFBQa59+9ChQ7Vu3bpiX05JTEyUdO5vYtFLFHiCw7K87Hr7gGFuvvlmLVu2TMHBwdq3b1+Fz7VBzfPVV1+pZ8+ekqR77rlHr7zyis0VXTp4bz1vxYoVuuGGGyRJzz33XLk/YFYVRmSAGu6ZZ56Rn5+fTp06peeff97uclAFCr89Fx0drWeffdbmai4tvLeeN2PGDEnnvswyceJEj78+J/sCNVzr1q3drkkE83388ceS5HZFZFQN3lvPK+vK2tWNQ0sAAMBYHFoCAADGIsgAAABjEWQAAICxjD7Zt6CgQAcPHlRoaGiV/tt5AABgL8uydPLkSUVHR1/wGmdGB5mDBw969P85AAAAzzpw4IBiYmJKnW90kAkNDZUkLViwQE2aNLG5Gs/atWuXPvvsM43p0EH1K/iv5U333dGjWrFzp26++WZFRETYXY5HFa53eqd3b8G+bqe6d+9erqtlX2qOHDmiRx991PW3vjRGB5nCw0lNmjRx+wd03uD06dNyOp1qHhmpJqX8O/hLVXZ+vpxOp+Li4tz+1YI3KFzv9E7v3oJ9nVMNGjRQ3bp17S7HNmWdOsLJvgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABjLz+4CTHEo+5BW7VulDQc3KPVYqjJ+yVBWbpbCnGFqW6+thrccruEth8vhcNhdKqpYUlKA1q93KiXFXzt2+Ck399d1fPjwERsrA6oH+zuYhCBTTu/ufFdPffVUsemZZzK1Ln2d1qWv0/LdyzW//3z5+vjaUGH1+3zhQm1YtKjU+QHBwXogMdGDFXnG7NnB2r7d3+4yAI/x9v2dt+7rTEWQqaCoWlHq26SvYkNjdeDkAb238z2dyT8jSVq9b7USUxM16vJRNleJquRwSHFxeerYMU8ZGT7asMFpd0mAR7C/gwkIMuXUKKSRXuzzogY3Hyw/n1/ftiEthujWZbe67ifvT/aKX+ymXbqox/DhbtN8fC+9T2aStGxZpoKCzt2eNSuYIINLHvu7X3nTvs5UBJlyGtpiaInTezfqrbqBdZV5JlOSlFuQ68mybFMrPFwxbdvaXYZHFIYYwFuwv/uVN+3rTMW3li5S4UlwhTpHdbaxGgCoPuzvUBMxInMR8gryNHntZOUV5EmSIoIiNLbNWJur8oztycnanpzsNq1tnz4aOGmSTRUBqE7eur9jX1fzMSJTSdm52Rr74Vit3rdakhTiH6I3BryhiKAImysDgKrF/g41GSMylZCena4xH47Rdz9/J0mqF1hPCwYt8Kph1pJOgAuuU8emagBUF2/f37Gvq/kIMhWUkpGicSvH6cgv5y6E1iy8md4a9JbiwuPsLczDOAEOuPSxv2NfZwIOLVXAij0rNCRpiOuXumfDnlo+ZLlX/VID8A7s72AKRmTKKemHJE34aIIKrAJJUpgzTNfEXKNFO9yv/hjmDNPoNqPtKBHVJCEhSHv3nrtuxObN7lf4jY8Pcd0eP/604uLyPVobUB3Y38EkBJlySs1Mdf1SS1JWbpZmbppZbLmYkBh+sS8xS5cGlnoRvLlzg123r7suhyCDSwL7O5iEQ0sAAMBYjMiU05RuUzSl2xS7y7BVr5Ej1WvkSLvL8LglS47ZXQLgUd6+v/PWfZ2pGJEBAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgrBoRZObMmaO4uDgFBgaqR48e2rhxo90lAQAAA9geZN5++2098sgjmjZtmrZu3aqOHTuqf//+ysjIsLs0AABQw9keZJ577jn97ne/05133qk2bdpo7ty5qlWrlv7zn//YXRoAAKjh/Ox88dzcXG3ZskVTp051TfPx8VG/fv20YcOGYsvn5OQoJyfHdT8rK0uStGvXLp0+fbr6C65B9u/fL0nalpGhQ9nZNlfjWbsyMyVJaWlpOnr0qM3VeFbheqd3evcW7Ouk9PR0nThxwuZqPK+827qtQeann35Sfn6+6tev7za9fv362rFjR7HlZ8yYoenTpxeb/tlnn8npdFZbnTWVw+FQUmqq3WXYwuFwKDk52e4ybEHv9O5tHJL37uskbdu2ze4ybJGbm1uu5WwNMhU1depUPfLII677WVlZaty4scZ06KDmkZE2VuZ52zIylJSaqmHDhinSy3pPS0tTcnIyvdO716D3ZN3VubMahoTYXY5HFe7nvbF3Sdp19KgSyrGcrUEmIiJCvr6+OnLkiNv0I0eOqEGDBsWWDwgIUEBAQLHp9UNC1KR27eoqs0YqHGKNjIxUdHS0zdV4VuFwI73Tu7egd6mhF+/nvbF3STpZzlNGbD3Z1+l0qkuXLvr4449d0woKCvTxxx/riiuusLEyAABgAtsPLT3yyCMaN26cunbtqu7du+v555/XqVOndOedd9pdGgAAqOFsDzK33367jh49qieeeEKHDx9Wp06dtHLlymInAAMAAJzP9iAjSffff7/uv/9+u8sAAACGsf2CeAAAAJVFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYy8/uAmCAM2cU8txz8vvf/+T3ww9yHDsmR06OrLAw5V12mXL79dMvd90lKyzM7kqr3KHsQ1q1b5U2HNyg1GOpyvglQ1m5WQpzhqltvbYa3nK4hrccLofDYXepQJVhu4dJCDIV8PnChdqwaFGp8wOCg/VAYqIHK/IMx6lTCv7Xv4pPz8yUMzNTzs2bFZiYqMwPP5RVp44NFVafd3e+q6e+eqrY9MwzmVqXvk7r0tdp+e7lmt9/vnx9fG2oEKh63r7de+u+XjKzd4IMyiW/YUOd7dpV+TExKqhTRz4//6zADz6Q748/SpL89u5V0IIF+uWBB2yutHpE1YpS3yZ9FRsaqwMnD+i9ne/pTP4ZSdLqfauVmJqoUZePsrlKoGqx3cMEBJlKatqli3oMH+42zcf30vtkIklWvXr66euvi03/ZcIERXbu7Lrve+CAJ8vyiEYhjfRinxc1uPlg+fn8+usypMUQ3brsVtf95P3J7NBxyWC7/5U37evPZ0rvBJlKqhUerpi2be0uwx75+fLJyFDQggVuk/NatbKpoOoztMXQEqf3btRbdQPrKvNMpiQptyDXk2UB1Yrt/lfevK83pXeCDMrN+dlnqnPbbSXOy+3ZU6dHXdqfzIoqPPmxUOeozhdYGrg0sN2jJiLIVNL25GRtT052m9a2Tx8NnDTJporsc3roUJ2cNUsKDLS7FI/IK8jT5LWTlVeQJ0mKCIrQ2DZjba4KqF7eut17877elN4JMii3vMsu08knnpAjN1c+P/6owBUr5JOZqaDFi+W/bZuOLVyogsaN7S6zWmXnZuveNfcq+cC5X+4Q/xC9MeANRQRF2FwZUH3Y7lGTEWQqqaSToIIvsa8en68gJka/3Hef6372n/6kev36yffIEfnt3KnQJ57QifnzbayweqVnp2vMh2P03c/fSZLqBdbTgkELGF7HJc3bt3tv3NcXMqV3gkwlmXISVHWyIiN1tksX+a5YIUlyfvGFzRVVn5SMFI1bOU5HfjkiSWoW3kxvDXpLceFx9hYGVCO2e+/e15vSO/+iAGXyX79ejuzsYtMdP/8s/61bi0y4NK/yuWLPCg1JGuLamfds2FPLhyz3qp05vA/bPUzBiAzKVOvVVxWwdq1yr7xSZ9u0kRUUJN9DhxTwwQfyPXrUtVxOv342Vlk9kn5I0oSPJqjAKpAkhTnDdE3MNVq0w/3Kl2HOMI1uM9qOEoEqx3YPkxBkUC6O06cVsHq1AlavLnH+2XbtdDI+3rNFeUBqZqprZy5JWblZmrlpZrHlYkJi2KHjksF2D5MQZFCm03feqYKoKPlv3Sqfw4flc/y45OengogI5bVpozMDB+rMrbdK/v52lwoA8DIEmQroNXKkeo0caXcZHpd79dXKvfpqu8uwxZRuUzSl2xS7ywA8ytu3e2/d10tm9s7JvgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxla5D57LPPdNNNNyk6OloOh0Pvv/++neUAAADD2BpkTp06pY4dO2rOnDl2lgEAAAzlZ+eLDxw4UAMHDrSzBAAAYDBbg0xF5eTkKCcnx3U/KytLkvTd0aPKzs+3qyxb7MrMlCSlpaXp6NGjNlfjWfv375dE7/TuPehd2paRoUPZ2TZX41mF+3lv7F2S9v///svisCzLquZaysXhcGjJkiUaPHhwqcvEx8dr+vTpxaaPHz9eTqezGqurmRySasTKs4HD4VAN2XQ9jt7p3dvQu3f2npubq4SEBJ04cUJhYWGlLmdUkClpRKZx48ZavHix4uLiqr/IGiQtLU3Jycm6q3NnNQwJsbscj9qWkaGk1FQNGzZMkZGRdpfjUYXrnd7p3VvQu3f2Lkl79+7V0KFDywwyRh1aCggIUEBAQLHpERERio6OtqEi+xQOLzcMCVGT2rXtLcbDCodYIyMjvXa90zu9ewt6987eJSm7nIfTuI4MAAAwlq0jMtnZ2dq1a5fr/p49e5SSkqK6deuqSZMmNlYGAABMYGuQ2bx5s6699lrX/UceeUSSNG7cOCUkJNhUFQAAMIWtQeaaa67x2rOxAQDAxeMcGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYfnYXYIpD2Ye0at8qbTi4QanHUpXxS4aycrMU5gxT23ptNbzlcA1vOVwOh8PuUlHFkpICtH69Uykp/tqxw0+5ub+u48OHj9hYGVA9vHmb9+Z9vam9E2TK6d2d7+qpr54qNj3zTKbWpa/TuvR1Wr57ueb3ny9fH18bKqx+ny9cqA2LFpU6PyA4WA8kJnqwIs+YPTtY27f7210G4DHevM17877e1N4JMhUUVStKfZv0VWxorA6cPKD3dr6nM/lnJEmr961WYmqiRl0+yuYqUZUcDikuLk8dO+YpI8NHGzY47S4JqFZs8969rzetd4JMOTUKaaQX+7yowc0Hy8/n17dtSIshunXZra77yfuTa9QKri5Nu3RRj+HD3ab5+NachF6Vli3LVFDQuduzZgV75U4d3sWbt3lv3teb2jtBppyGthha4vTejXqrbmBdZZ7JlCTlFuR6sizb1AoPV0zbtnaX4RGFO3TAW3jzNu/N+3pTe+dbSxep8GSoQp2jOttYDQCgOnjzvr6m986IzEXIK8jT5LWTlVeQJ0mKCIrQ2DZjba7KM7YnJ2t7crLbtLZ9+mjgpEk2VQQA1cOb9/Um9M6ITCVl52Zr7IdjtXrfaklSiH+I3hjwhiKCImyuDABQVbx5X29K74zIVEJ6drrGfDhG3/38nSSpXmA9LRi0oMYNt1Wnkk72Da5Tx6ZqAKDqefO+3qTeCTIVlJKRonErx+nIL+cuCtUsvJneGvSW4sLj7C3Mw7zpZF8A3seb9/Wm9c6hpQpYsWeFhiQNca3cng17avmQ5TV25QIAKs6b9/Um9s6ITDkl/ZCkCR9NUIFVIEkKc4bpmphrtGiH+5Vuw5xhGt1mtB0lopokJARp795z18jZvNn9aqfx8SGu2+PHn1ZcXL5HawOqgzdv8968rze1d4JMOaVmprpWriRl5WZp5qaZxZaLCYmpUSsYF2/p0sBSLwg2d26w6/Z11+Vccjt1eCdv3ua9eV9vau8cWgIAAMZiRKacpnSboindpthdhq16jRypXiNH2l2Gxy1ZcszuEgCP8uZt3pv39ab2zogMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAY9kaZGbMmKFu3bopNDRUUVFRGjx4sFJTU+0sCQAAGMTWILN27VpNnDhRX375pdasWaOzZ8/q+uuv16lTp+wsCwAAGMLPzhdfuXKl2/2EhARFRUVpy5Ytuuqqq2yqCgAAmMLWIHO+EydOSJLq1q1b4vycnBzl5OS47mdlZUmSdu3apdOnT1d/gTXI/v37JUnbMjJ0KDvb5mo8a1dmpiQpLS1NR48etbkazypc7/RO796C3r2zd0lKT08v13IOy7Ksaq6lXAoKCnTzzTfr+PHjWr9+fYnLxMfHa/r06cWmjx8/Xk6ns7pLrHEcDodqyOrzOHqnd29D7/TubXJzc5WQkKATJ04oLCys1OVqTJD5wx/+oA8//FDr169XTExMicuUNCLTuHFjLV68WHFxcR6qtGZIS0tTcnKyhg0bpsjISLvL8Sh6p3d69x707p29S9LevXs1dOjQMoNMjTi0dP/992v58uX67LPPSg0xkhQQEKCAgIBi0yMiIhQdHV2dJdY4hcOMkZGR9O5F6J3e6d17eHPvkpRdztMmbA0ylmXpgQce0JIlS/Tpp5+qadOmdpYDAAAMY2uQmThxohYuXKilS5cqNDRUhw8fliSFh4crKCjIztIAAIABbL2OzEsvvaQTJ07ommuuUcOGDV0/b7/9tp1lAQAAQ9h+aAkAAKCy+F9LAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFh+dhdgkqSkAK1f71RKir927PBTbq7DNe/w4SM2Vlb96N07eweAmo4gUwGzZwdr+3Z/u8uwBb17Z+8AUNMRZCrA4ZDi4vLUsWOeMjJ8tGGD0+6SPIbevbN3AKjpCDIVsGxZpoKCzt2eNSvYq/6g0fu5297WOwDUdJzsWwGFf8y8Eb0DAGoiggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLG4jkwFJCQEae9eX0nS5s3uV3qNjw9x3R4//rTi4vI9Wlt1o3fv7B0AajqCTAUsXRpY6sXQ5s4Ndt2+7rqcS+4PGr17Z+8AUNNxaAkAABiLEZkKWLLkmN0l2IbeAQA1ESMyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxLjrInDlzpirqAAAAqLBKBZmCggI9+eSTatSokUJCQrR7925J0uOPP67XXnutSgsEAAAoTaWCzN/+9jclJCTomWeekdP56z/Ta9eunV599dUqKw4AAOBCKhVk3njjDc2bN0+jRo2Sr6+va3rHjh21Y8eOKisOAADgQioVZNLT09W8efNi0wsKCnT27NmLLgoAAKA8KhVk2rRpo3Xr1hWb/u6776pz584XXRQAAEB5+FXmQU888YTGjRun9PR0FRQUaPHixUpNTdUbb7yh5cuXV3WNAAAAJarUiMwtt9yiZcuW6aOPPlJwcLCeeOIJff/991q2bJmuu+66qq4RAACgRJUakZGkK6+8UmvWrKnKWgAAACqk0kFGknJzc5WRkaGCggK36U2aNLmoogAAAMqjUkFm586duuuuu/TFF1+4TbcsSw6HQ/n5+VVSHAAAwIVUKsiMHz9efn5+Wr58uRo2bCiHw1HVdQEAAJSpUkEmJSVFW7ZsUevWrS/qxV966SW99NJL2rt3rySpbdu2euKJJzRw4MCLel4AAOAdKn0dmZ9++umiXzwmJkYzZ87Uli1btHnzZvXp00e33HKLtm/fftHPDQAALn2VCjJ///vf9cc//lGffvqpfv75Z2VlZbn9lNdNN92kQYMGqUWLFmrZsqWeeuophYSE6Msvv6xMWQAAwMtU6tBSv379JEl9+/Z1m34xJ/vm5+frnXfe0alTp3TFFVdUpiwAAOBlKhVkPvnkkyorYNu2bbriiit05swZhYSEaMmSJWrTpk2Jy+bk5CgnJ8d1v3D0Z9euXTp9+nSV1WSC/fv3S5LS0tJ09OhRm6vxLHqnd3r3HvTunb1L5/6vY3k4LMuyqrmWC8rNzdX+/ft14sQJvfvuu3r11Ve1du3aEsNMfHy8pk+fXmz6+PHj5XQ6PVFujeJwOGTz6rMNvdO7t6F3evc2ubm5SkhI0IkTJxQWFlbqcpUKMt98803JT+ZwKDAwUE2aNFFAQEBFn1bSucNWzZo108svv1xsXkkjMo0bN9bixYsVFxdXqdczVVpampKTkzVs2DBFRkbaXY5H0Tu907v3oHfv7F2S9u7dq6FDh5YZZCp1aKlTp04XvHaMv7+/br/9dr388ssKDAys0HMXFBS4hZWiAgICSgxIERERio6OrtDrmK5wmDEyMpLevQi90zu9ew9v7l2SsrOzy7Vcpb61tGTJErVo0ULz5s1TSkqKUlJSNG/ePLVq1UoLFy7Ua6+9puTkZP3f//3fBZ9n6tSp+uyzz7R3715t27ZNU6dO1aeffqpRo0ZVpiwAAOBlKjUi89RTT2n27Nnq37+/a1r79u0VExOjxx9/XBs3blRwcLAeffRRPfvss6U+T0ZGhsaOHatDhw4pPDxcHTp00KpVq/gP2gAAoFwqFWS2bdum2NjYYtNjY2O1bds2SecOPx06dOiCz/Paa69V5uUBAAAkVfLQUuvWrTVz5kzl5ua6pp09e1YzZ850/duC9PR01a9fv2qqBAAAKEGlRmTmzJmjm2++WTExMerQoYOkc6M0+fn5Wr58uSRp9+7duu+++6quUgAAgPNUKsj89re/1Z49e/TWW28pLS1NkjR8+HCNHDlSoaGhkqQxY8ZUXZUAAAAlqFSQkaTQ0FBNmDChKmsBAACokHIHmaSkJA0cOFD+/v5KSkq64LI333zzRRcGAABQlnIHmcGDB+vw4cOKiorS4MGDS12usv80EgAAoKLKHWQKCgpKvF3UgQMH9Ne//vXiqwIAACiHSn39ujSZmZn6z3/+U5VPCQAAUKoqDTIAAACeRJABAADGIsgAAABjVeg6MkOHDr3g/OPHj19MLQAAABVSoSATHh5e5vyxY8deVEEAAADlVaEgM3/+/OqqAwAAoMI4RwYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWDUmyMycOVMOh0MPP/yw3aUAAABD1Iggs2nTJr388svq0KGD3aUAAACD2B5ksrOzNWrUKL3yyiuqU6eO3eUAAACD2B5kJk6cqBtuuEH9+vWzuxQAAGAYPztfPDExUVu3btWmTZvKtXxOTo5ycnJc97OysiRJu3bt0unTp6ulxppq//79kqS0tDQdPXrU5mo8i97pnd69B717Z++SlJ6eXq7lHJZlWdVcS4kOHDigrl27as2aNa5zY6655hp16tRJzz//fImPiY+P1/Tp04tNHz9+vJxOZ3WWWyM5HA7ZtPpsR+/07m3ond69TW5urhISEnTixAmFhYWVupxtQeb999/XkCFD5Ovr65qWn58vh8MhHx8f5eTkuM2TSh6Rady4sRYvXqy4uDhPlV4jpKWlKTk5WcOGDVNkZKTd5XgUvdM7vXsPevfO3iVp7969Gjp0aJlBxrZDS3379tW2bdvcpt15551q3bq1/vSnPxULMZIUEBCggICAYtMjIiIUHR1dbbXWRIXDjJGRkfTuReid3unde3hz79K5LwOVh21BJjQ0VO3atXObFhwcrHr16hWbDgAAUBLbv7UEAABQWbZ+a+l8n376qd0lAAAAgzAiAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIzlZ3cBJklKCtD69U6lpPhrxw4/5eY6XPMOHz5iY2XVj97pnd7pXbr0e4d5CDIVMHt2sLZv97e7DFvQO717G3r3zt5hHoJMBTgcUlxcnjp2zFNGho82bHDaXZLH0Du90zu9AzURQaYCli3LVFDQuduzZgV71S83vZ+7Te/07g28uXeYh5N9K6DwF9sb0bt3onfv5M29wzwEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAY3EdmQpISAjS3r2+kqTNm92vehkfH+K6PX78acXF5Xu0tupG7/RO77+i93Muxd5hHoJMBSxdGljqhaHmzg123b7uupxL7peb3un9fPR+Dr1fWr3DPBxaAgAAxmJEpgKWLDlmdwm2oXfvRO/eyZt7h3kYkQEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYtgaZ+Ph4ORwOt5/WrVvbWRIAADCIn90FtG3bVh999JHrvp+f7SUBAABD2J4a/Pz81KBBA7vLAAAABrL9HJmdO3cqOjpal112mUaNGqX9+/fbXRIAADCErSMyPXr0UEJCglq1aqVDhw5p+vTpuvLKK/Xtt98qNDS02PI5OTnKyclx3c/KypIk7dq1S6dPn/ZY3TVBYeBLS0vT0aNHba7Gs+id3unde9C7d/YuSenp6eVazmFZllXNtZTb8ePHFRsbq+eee0533313sfnx8fGaPn16senjx4+X0+n0RIk1ikNSjVl5HuZwOFSDNl2P8urexTbvjejdO3vPzc1VQkKCTpw4obCwsFKXq1FBRpK6deumfv36acaMGcXmlTQi07hxYy1evFhxcXEerNJ+aWlpSk5O1l2dO6thSIjd5XjUtowMJaWmatiwYYqMjLS7HI8qXO/e3DvbvHeud3r3rt4lae/evRo6dGiZQcb2k32Lys7O1g8//KAxY8aUOD8gIEABAQHFpkdERCg6Orq6y6tRCocZG4aEqEnt2vYW42GHsrMlSZGRkV673r25d7Z571zv9O5dvUvnMkF52Hqy7+TJk7V27Vrt3btXX3zxhYYMGSJfX1+NGDHCzrIAAIAhbB2R+fHHHzVixAj9/PPPioyMVO/evfXll1965RAaAACoOFuDTGJiop0vDwAADGf7dWQAAAAqiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGMvP7gJMcSj7kFbtW6UNBzco9ViqMn7JUFZulsKcYWpbr62Gtxyu4S2Hy+Fw2F1qtfl84UJtWLSo1PkBwcF6IDHRgxV5RlJSgNavdyolxV87dvgpN/fXdXz48BEbK6t+3ty7xDbvresdZiHIlNO7O9/VU189VWx65plMrUtfp3Xp67R893LN7z9fvj6+NlSI6jJ7drC2b/e3uwxbeHPv3oz1DpMQZCooqlaU+jbpq9jQWB04eUDv7XxPZ/LPSJJW71utxNREjbp8lM1VVr+mXbqox/DhbtN8fC/NAOdwSHFxeerYMU8ZGT7asMFpd0ke4829n49tHqiZCDLl1CikkV7s86IGNx8sP59f37YhLYbo1mW3uu4n70/2iiBTKzxcMW3b2l2GRyxblqmgoHO3Z80K9qqdujf3fj62eaBmIsiU09AWQ0uc3rtRb9UNrKvMM5mSpNyCXE+WBQ8o3KF7I2/u3Zux3mESgsxFKjzpt1DnqM42VuM525OTtT052W1a2z59NHDSJJsqAqoX2zxQM/H164uQV5CnyWsnK68gT5IUERShsW3G2lwVAADegxGZSsrOzda9a+5V8oFzn9BC/EP0xoA3FBEUYXNlnlHSiY/BderYVA1Q/djmgZqJIFMJ6dnpGvPhGH3383eSpHqB9bRg0AKvOawkedeJj4DENg/UVASZCkrJSNG4leN05JdzF4VqFt5Mbw16S3HhcfYWBgCAF+IcmQpYsWeFhiQNcYWYng17avmQ5YQYAABswohMOSX9kKQJH01QgVUgSQpzhumamGu0aIf75cvDnGEa3Wa0HSWimiQkBGnv3nMXPtu82f1qp/HxIa7b48efVlxcvkdrq27e3Ls3Y73DJASZckrNTHWFGEnKys3SzE0ziy0XExJDkLnELF0aWOoFwebODXbdvu66nEtup+7NvXsz1jtMQpBBufUaOVK9Ro60uwzAY9jmgZqPIFNOU7pN0ZRuU+wuAzZYsuSY3SXYxpt792asd5iEk30BAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwlu1BJj09XaNHj1a9evUUFBSk9u3ba/PmzXaXBQAADOBn54sfO3ZMvXr10rXXXqsPP/xQkZGR2rlzp+rUqWNnWQAAwBC2Bpm///3vaty4sebPn++a1rRpUxsrAgAAJrH10FJSUpK6du2q4cOHKyoqSp07d9Yrr7xiZ0kAAMAgto7I7N69Wy+99JIeeeQRPfbYY9q0aZMefPBBOZ1OjRs3rtjyOTk5ysnJcd3PysqSJO3atUunT5/2WN01wf79+yVJ2zIydCg72+ZqPGtXZqYkKS0tTUePHrW5Gs8qXO/e3DvbvHeud3r3rt6lc+fQlofDsiyrmmspldPpVNeuXfXFF1+4pj344IPatGmTNmzYUGz5+Ph4TZ8+vdj08ePHy+l0VmutNZHD4ZCNq89W9E7v3obe6d3b5ObmKiEhQSdOnFBYWFipy9k6ItOwYUO1adPGbdrll1+u9957r8Tlp06dqkceecR1PysrS40bN9aYDh3UPDKyWmutabZlZCgpNVXDhg1TpJf1npaWpuTkZHqnd69B7/Tubb1L0t69e5WQkFDmcrYGmV69eik1NdVtWlpammJjY0tcPiAgQAEBAcWm1w8JUZPataujxBqrcGg9MjJS0dHRNlfjWYVDrPRO796C3und23qXpOxyHkK29WTfSZMm6csvv9TTTz+tXbt2aeHChZo3b54mTpxoZ1kAAMAQtgaZbt26acmSJVq0aJHatWunJ598Us8//7xGjRplZ1kAAMAQth5akqQbb7xRN954o91lAAAAA9n+LwoAAAAqiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGMvP7gJM8vnChdqwaFGp8wOCg/VAYqIHK/KMQ9mHtGrfKm04uEGpx1KV8UuGsnKzFOYMU9t6bTW85XANbzlcDofD7lKrRVJSgNavdyolxV87dvgpN/fXPg8fPmJjZdWP3und23qHeQgyKNO7O9/VU189VWx65plMrUtfp3Xp67R893LN7z9fvj6+NlRYvWbPDtb27f52l2ELeqd3oKYjyFRS0y5d1GP4cLdpPr6X3h/xoqJqRalvk76KDY3VgZMH9N7O93Qm/4wkafW+1UpMTdSoy0fZXGXVczikuLg8deyYp4wMH23Y4LS7JI+hd3r3tt5hHoJMJdUKD1dM27Z2l+ERjUIa6cU+L2pw88Hy8/l1kxnSYohuXXar637y/uRLMsgsW5apoKBzt2fNCvaqnTq9n7tN797TO8xDkEGZhrYYWuL03o16q25gXWWeyZQk5RbkerIsjyncoXsjevdO3tw7zEOQqaTtycnanpzsNq1tnz4aOGmSTRV5XuFJv4U6R3W2sRoAgDfi69eolLyCPE1eO1l5BXmSpIigCI1tM9bmqgAA3oYRmUoq6WTf4Dp1bKrGs7Jzs3XvmnuVfODciFSIf4jeGPCGIoIibK4MAOBtCDKV5E0n+xaVnp2uMR+O0Xc/fydJqhdYTwsGLeCwEgDAFgQZlFtKRorGrRynI7+cuyBWs/BmemvQW4oLj7O3MACA1+IcGZTLij0rNCRpiCvE9GzYU8uHLCfEAABsxYgMypT0Q5ImfDRBBVaBJCnMGaZrYq7Roh3u/64hzBmm0W1G21FitUpICNLevecudrh5s/vVTuPjQ1y3x48/rbi4fI/WVt3ond69rXeYhyCDMqVmprpCjCRl5WZp5qaZxZaLCYm5JIPM0qWBpV4QbO7cYNft667LueR26vRO7+e71HuHeQgyFdBr5Ej1GjnS7jIAAMD/R5BBmaZ0m6Ip3abYXYZtliw5ZncJtqF37+TNvcM8nOwLAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsWwNMnFxcXI4HMV+Jk6caGdZAADAEH52vvimTZuUn5/vuv/tt9/quuuu0/Dhw22sCgAAmMLWIBMZGel2f+bMmWrWrJmuvvpqmyoCAAAmqTHnyOTm5mrBggW666675HA47C4HAAAYwNYRmaLef/99HT9+XOPHjy91mZycHOXk5LjunzhxQpK0+6efqru8Gmd/ZqZyc3O1d+9eZWdn212OR6Wnp9M7vdtdjkfRO717W++StH//fkmSZVkXXM5hlbWEh/Tv319Op1PLli0rdZn4+HhNnz7dg1UBAAA7HThwQDExMaXOrxFBZt++fbrsssu0ePFi3XLLLaUud/6IzPHjxxUbG6v9+/crPDzcE6XWGFlZWWrcuLEOHDigsLAwu8vxKHqnd3r3HvTunb1L50ZiTp48qejoaPn4lH4mTI04tDR//nxFRUXphhtuuOByAQEBCggIKDY9PDzcK1eyJIWFhdG7F6J3evc29O6dvZdnkML2k30LCgo0f/58jRs3Tn5+NSJXAQAAQ9geZD766CPt379fd911l92lAAAAw9g+BHL99deXeUZyaQICAjRt2rQSDzdd6uid3r0NvdO7t/Hm3iuiRpzsCwAAUBm2H1oCAACoLIIMAAAwFkEGAAAYy+ggM2fOHMXFxSkwMFA9evTQxo0b7S6p2n322We66aabFB0dLYfDoffff9/ukjxmxowZ6tatm0JDQxUVFaXBgwcrNTXV7rI84qWXXlKHDh1c15O44oor9OGHH9pdli1mzpwph8Ohhx9+2O5Sql18fLwcDofbT+vWre0uy2PS09M1evRo1atXT0FBQWrfvr02b95sd1nVLi4urth6dzgcmjhxot2l1UjGBpm3335bjzzyiKZNm6atW7eqY8eO6t+/vzIyMuwurVqdOnVKHTt21Jw5c+wuxePWrl2riRMn6ssvv9SaNWt09uxZXX/99Tp16pTdpVW7mJgYzZw5U1u2bNHmzZvVp08f3XLLLdq+fbvdpXnUpk2b9PLLL6tDhw52l+Ixbdu21aFDh1w/69evt7skjzh27Jh69eolf39/ffjhh/ruu+/0j3/8Q3Xq1LG7tGq3adMmt3W+Zs0aSdLw4cNtrqyGsgzVvXt3a+LEia77+fn5VnR0tDVjxgwbq/IsSdaSJUvsLsM2GRkZliRr7dq1dpdiizp16livvvqq3WV4zMmTJ60WLVpYa9assa6++mrroYcesrukajdt2jSrY8eOdpdhiz/96U9W79697S6jRnjooYesZs2aWQUFBXaXUiMZOSKTm5urLVu2qF+/fq5pPj4+6tevnzZs2GBjZfCkwv9+XrduXZsr8az8/HwlJibq1KlTuuKKK+wux2MmTpyoG264we333hvs3LlT0dHRuuyyyzRq1CjXfwS+1CUlJalr164aPny4oqKi1LlzZ73yyit2l+Vxubm5WrBgge666y45HA67y6mRjAwyP/30k/Lz81W/fn236fXr19fhw4dtqgqeVFBQoIcffli9evVSu3bt7C7HI7Zt26aQkBAFBARowoQJWrJkidq0aWN3WR6RmJiorVu3asaMGXaX4lE9evRQQkKCVq5cqZdeekl79uzRlVdeqZMnT9pdWrXbvXu3XnrpJbVo0UKrVq3SH/7wBz344IN6/fXX7S7No95//30dP35c48ePt7uUGsv2K/sClTFx4kR9++23XnO+gCS1atVKKSkpOnHihN59912NGzdOa9euveTDzIEDB/TQQw9pzZo1CgwMtLscjxo4cKDrdocOHdSjRw/Fxsbqv//9r+6++24bK6t+BQUF6tq1q55++mlJUufOnfXtt99q7ty5GjdunM3Vec5rr72mgQMHKjo62u5SaiwjR2QiIiLk6+urI0eOuE0/cuSIGjRoYFNV8JT7779fy5cv1yeffKKYmBi7y/EYp9Op5s2bq0uXLpoxY4Y6duyo2bNn211WtduyZYsyMjL0m9/8Rn5+fvLz89PatWv1r3/9S35+fsrPz7e7RI+pXbu2WrZsqV27dtldSrVr2LBhsZB++eWXe82hNUnat2+fPvroI91zzz12l1KjGRlknE6nunTpoo8//tg1raCgQB9//LFXnTPgbSzL0v33368lS5YoOTlZTZs2tbskWxUUFCgnJ8fuMqpd3759tW3bNqWkpLh+unbtqlGjRiklJUW+vr52l+gx2dnZ+uGHH9SwYUO7S6l2vXr1KnZ5hbS0NMXGxtpUkefNnz9fUVFRuuGGG+wupUYz9tDSI488onHjxqlr167q3r27nn/+eZ06dUp33nmn3aVVq+zsbLdPY3v27FFKSorq1q2rJk2a2FhZ9Zs4caIWLlyopUuXKjQ01HU+VHh4uIKCgmyurnpNnTpVAwcOVJMmTXTy5EktXLhQn376qVatWmV3adUuNDS02HlQwcHBqlev3iV/ftTkyZN10003KTY2VgcPHtS0adPk6+urESNG2F1atZs0aZJ++9vf6umnn9Ztt92mjRs3at68eZo3b57dpXlEQUGB5s+fr3HjxsnPz9g/1Z5h99emLsYLL7xgNWnSxHI6nVb37t2tL7/80u6Sqt0nn3xiSSr2M27cOLtLq3Yl9S3Jmj9/vt2lVbu77rrLio2NtZxOpxUZGWn17dvXWr16td1l2cZbvn59++23Ww0bNrScTqfVqFEj6/bbb7d27dpld1kes2zZMqtdu3ZWQECA1bp1a2vevHl2l+Qxq1atsiRZqampdpdS4/HfrwEAgLGMPEcGAABAIsgAAACDEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAFQI8THx6tTp052lwHAMAQZAFXi8OHDeuCBB3TZZZcpICBAjRs31k033eT2z10BoKrxn6gAXLS9e/eqV69eql27tmbNmqX27dvr7NmzWrVqlSZOnKgdO3bYXSKASxQjMgAu2n333SeHw6GNGzdq2LBhatmypdq2batHHnlEX375pSRp//79uuWWWxQSEqKwsDDddtttOnLkSKnPWVBQoL/+9a+KiYlRQECAOnXqpJUrV7rm7927Vw6HQ4sXL9a1116rWrVqqWPHjtqwYYNrmYSEBNWuXVurVq3S5ZdfrpCQEA0YMECHDh1ye61XX31Vl19+uQIDA9W6dWv9+9//ruJ3CEB1IcgAuCiZmZlauXKlJk6cqODg4GLza9eurYKCAt1yyy3KzMzU2rVrtWbNGu3evVu33357qc87e/Zs/eMf/9Czzz6rb775Rv3799fNN9+snTt3ui33l7/8RZMnT1ZKSopatmypESNGKC8vzzX/l19+0bPPPqs333xTn332mfbv36/Jkye75r/11lt64okn9NRTT+n777/X008/rccff1yvv/56Fbw7AKqd3f9+G4DZvvrqK0uStXjx4lKXWb16teXr62vt37/fNW379u2WJGvjxo2WZVnWtGnTrI4dO7rmR0dHW0899ZTb83Tr1s267777LMuyrD179liSrFdffbXYc37//feWZVnW/PnzLUnWrl27XMvMmTPHql+/vut+s2bNrIULF7q9zpNPPmldccUV5X0LANiIERkAF8WyrDKX+f7779W4cWM1btzYNa1NmzaqXbu2vv/++2LLZ2Vl6eDBg+rVq5fb9F69ehVbvkOHDq7bDRs2lCRlZGS4ptWqVUvNmjVzW6Zw/qlTp/TDDz/o7rvvVkhIiOvnb3/7m3744Ycy+wJgP072BXBRWrRoIYfDYdsJvf7+/q7bDodD0rnza0qaX7hMYfjKzs6WJL3yyivq0aOH23K+vr7VUi+AqsWIDICLUrduXfXv319z5szRqVOnis0/fvy4Lr/8ch04cEAHDhxwTf/uu+90/PhxtWnTpthjwsLCFB0drc8//9xt+ueff17i8pVVv359RUdHa/fu3WrevLnbT9OmTavsdQBUH0ZkAFy0OXPmqFevXurevbv++te/qkOHDsrLy9OaNWv00ksv6bvvvlP79u01atQoPf/888rLy9N9992nq6++Wl27di3xOadMmaJp06apWbNm6tSpk+bPn6+UlBS99dZbVVr79OnT9eCDDyo8PFwDBgxQTk6ONm/erGPHjumRRx6p0tcCUPUIMgAu2mWXXaatW7fqqaee0qOPPqpDhw4pMjJSXbp00UsvvSSHw6GlS5fqgQce0FVXXSUfHx8NGDBAL7zwQqnP+eCDD+rEiRN69NFHlZGRoTZt2igpKUktWrSo0trvuece1apVS7NmzdKUKVMUHBys9u3b6+GHH67S1wFQPRxWec7UAwAAqIE4RwYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAY/0/05h98SSHL7sAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Partir du plateau deja partiellement resolu par les regles\n",
-        "board_csp = board_rules.copy()\n",
-        "csp_solver = CSPSolver(board_csp)\n",
-        "\n",
-        "# Construire et resoudre le CSP\n",
-        "start = time.time()\n",
-        "safe_cells, mine_cells, solutions = csp_solver.solve()\n",
-        "elapsed = (time.time() - start) * 1000\n",
-        "\n",
-        "frontier = csp_solver.get_frontier_cells()\n",
-        "constraints = csp_solver.get_constraint_cells()\n",
-        "\n",
-        "print(\"Solveur CSP\")\n",
-        "print(\"=\" * 50)\n",
-        "print(f\"Variables (frontiere)      : {len(frontier)}\")\n",
-        "print(f\"Contraintes                : {len(constraints)}\")\n",
-        "print(f\"Solutions trouvees         : {len(solutions)}\")\n",
-        "print(f\"Cellules deduites sures    : {len(safe_cells)}\")\n",
-        "print(f\"Cellules deduites mines    : {len(mine_cells)}\")\n",
-        "print(f\"Cellules non determinees   : {len(frontier) - len(safe_cells) - len(mine_cells)}\")\n",
-        "print(f\"Temps                      : {elapsed:.1f} ms\")\n",
-        "\n",
-        "if safe_cells:\n",
-        "    print(f\"\\nCellules sures : {sorted(safe_cells)}\")\n",
-        "if mine_cells:\n",
-        "    print(f\"Cellules mines : {sorted(mine_cells)}\")\n",
-        "\n",
-        "# Visualiser avec les deductions surlignees\n",
-        "fig = draw_board(board_csp,\n",
-        "                 title=f\"Deductions CSP ({len(solutions)} solutions, \"\n",
-        "                       f\"{len(safe_cells)} sures, {len(mine_cells)} mines)\",\n",
-        "                 highlight_safe=safe_cells,\n",
-        "                 highlight_mines=mine_cells)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-19",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004574,
-          "end_time": "2026-02-26T07:01:10.087106",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.082532",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-19"
-      },
-      "source": [
-        "### Interpretation : deductions CSP\n",
-        "\n",
-        "**Sortie obtenue** : le CSP a enumere toutes les solutions compatibles avec les contraintes visibles et a identifie les cellules determinees.\n",
-        "\n",
-        "| Mesure | Valeur | Signification |\n",
-        "|--------|--------|---------------|\n",
-        "| Variables | Cellules de la frontiere | Seules les cellules adjacentes aux revelees |\n",
-        "| Solutions | Variable | Nombre de placements de mines compatibles |\n",
-        "| Cellules deduites | Forcees dans toutes les solutions | Certitude absolue |\n",
-        "| Non determinees | Valeur differente selon les solutions | Necessite un choix |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Le CSP combine les contraintes de **plusieurs** cellules revelees, ce qui lui permet de deduire des cellules que les regles simples ne voient pas\n",
-        "2. L'enumeration des solutions est **exacte** : si une cellule est dite sure, elle l'est avec certitude\n",
-        "3. Le cout est l'enumeration exhaustive, qui peut etre exponentielle dans le pire cas\n",
-        "\n",
-        "> **NP-completude en action** : le nombre de solutions peut exploser exponentiellement avec la taille de la frontiere. Sur un plateau 16x16, la frontiere peut contenir 30+ cellules, rendant l'enumeration couteuse."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-20",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005087,
-          "end_time": "2026-02-26T07:01:10.096665",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.091578",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-20"
-      },
-      "source": [
-        "### Application des deductions CSP\n",
-        "\n",
-        "Appliquons les deductions du CSP au plateau, puis relançons les regles simples pour propager les consequences."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-21",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.810621Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.810209Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.847337Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.845690Z"
-        },
-        "papermill": {
-          "duration": 0.120532,
-          "end_time": "2026-02-26T07:01:10.221892",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.101360",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-21",
-        "outputId": "73658d99-a12a-4667-a894-64526a02223d",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 711
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Apres application des deductions CSP + regles\n",
-            "==================================================\n",
-            "Cellules revelees  : 54\n",
-            "Drapeaux           : 9\n",
-            "Inconnues restantes: 1\n",
-            "Partie gagnee      : True\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUuVJREFUeJzt3Xl4FHW69vG7s4dsLEmQECCyiewICAgjKCCCC2vGVxBBcWFTBOHMMM5A0EGYwY2jKDJioiLgEYksymqURUAWzZE1AQGDEUggQAhLQpJ6/+CkTZMEkkB3pejv57r6urqrqrufp6u6cvevqys2wzAMAQAAWJCH2QUAAACUF0EGAABYFkEGAABYFkEGAABYFkEGAABYFkEGAABYFkEGAABYFkEGAABYFkEGAABYFkEGuAkNHTpUNptNNptNMTExZpcjSTpx4oSqVKkim82mxx9/3CnPERcXZ++7S5cuTnkO4GYzd+5c+/smISHB7HLKjCBzA23cuNG+MRRcdu/ebXZZLnPu3DnNmjVLPXr00C233CJfX1+FhYWpZcuWGjt2rHbs2FHkPgsXLlTXrl0VGhoqb29vVa1aVQ0aNNCDDz6ol156SWfOnHFY/srX12azycPDQ5UrV1b79u311ltvKScnx1UtowymTJmi06dPy2azaeLEiQ7z1q9frxEjRqhNmzby9fUljMBlTp8+rZiYGPvFLHFxcfYaEhMTXfrcjz/+uGrVqiVJevHFF5Wfn+/S579uBm6YYcOGGZIcLuPHjze7LJfYsmWLUbt27SL9F760aNHC4T7jxo276vKSjP379zvc51rLSzLuuusu4+LFiy7svuIZMmSI/fWYPHmy2eUYR48eNby9vQ1JRrdu3YrMHzNmTLHrsnPnzmV6nuPHjxsbNmwwNmzYYPz88883qHrczA4dOuSwzZmlc+fO9hpiY2Nd/vyvvPKK/fnj4+Nd/vzXgxGZG+T8+fP6/PPPi0yfN2+e8vLynP78WVlZTn+Okuzdu1c9evRQSkqKJCkkJER///vftWLFCq1evVpvv/227r77btlsNvt9Dh48qDfffFPS5VGWCRMmaMWKFVq7dq3mzp2rQYMGKTg4+KrP+7e//U0bNmzQypUrNXjwYPv0TZs2afbs2eXqpUuXLrLZbIqLiyvX/a/GzHVktg8++ECXLl2SJD366KNF5oeHh+vhhx/Wyy+/rOjo6HI/T3h4uDp16qROnTqpWbNm5X4cVAwXLlyw3uiARRV+X5Z3/2kas5PUzWLevHn2NNu+fXujUaNG9ttfffVVkeWv/MQcHx9vtG3b1vDz8zPCwsKMZ555xsjIyHC4T+HE/uGHHxpvvvmm0ahRI8Pb29sYM2aMfbk9e/YYw4YNM2699VbD19fXCAoKMu666y4jNjbWyM/Pd3jM3377zXjmmWeMW2+91fDx8TH8/PyMyMhIo1u3bsakSZNK1ft9991nryskJMTYu3dvscsV/oT82Wef2e/TqlWrYpe/ePGikZOT4zBNhT45Ff7UkpeXZ0RFRdnn9e7du1S1X6ngNS7vJ6LJkyfbaxgyZIixcuVKo0OHDkalSpUcRqROnjxp/P3vfzeaN29uBAQEGH5+fkbjxo2NyZMnG2fPni3yuIcPHzYGDBhgBAcHG0FBQcYDDzxg7N69u8RPcVcbkTl37pzxr3/9y2jbtq0RFBRk+Pj4GPXr1zfGjh1rpKWlOSybl5dnzJw5076sl5eXERoaatxxxx3GM888U+K6vlKTJk3s9Rw7dqzUr2FZR2RiY2OLve+3335rn16nTh3j119/NR577DGjatWqhp+fn9GpUydj27ZtRR7v4sWLxsyZM42OHTsalStXNry9vY0aNWoYDzzwgLFp0yaHZRMTE43BgwcbtWvXNnx8fIygoCCjbdu2xowZM4qMEF65fpYsWWK0a9fO8PPzM0JDQ41nnnnGyMrKcrhPnTp17PdZu3atMWPGDKNBgwaGj4+PERUVZbz++usOy1/Zc0mv8ZAhQxzm5ebmGrNnzzY6depk77l27drGU089ZRw8eLDIa/TJJ5/Yl/X09DSqVq1qNG3a1BgyZIixefPmklZViXUmJSUZffv2NSpXrmxIMk6dOuW0ugq/f4q7fPvtt4ZhGMbbb79t3H///UZUVJT9fRAWFmbcd999xuLFi4s8d1nWVeFttrhL4fXj7PfubbfdZkgyPDw8jJMnT15z3VUUBJkbpFu3bvYN75133nEYpouOji6yfOEd2e23317iVzHnz5+336fwm65BgwYOyxYEmfj4eMPPz6/EN8WgQYPsYSYnJ8eoV69eicv6+vpes+/ff//dsNls9vu8/PLLpXq9Vq5cab+Pl5eX8corrxg7d+408vLyrnq/koKMYRhG8+bN7fN69uxZqjqudCODTN26dQ0PDw+H9WkYhrF//34jMjKyxNe9adOmDjuRo0ePGhEREUWWq1KlinHrrbeWKcikp6cbTZs2LfG5a9as6fBHYdKkSVfdyS5YsOCar0l6erp9G7nyD+q1XkNnBJng4GAjPDy8SC+hoaFGZmam/T4nT540WrVqVWLvb775pn3ZBQsW2L86K+7SunVrh8cuvH7q169f7H2effZZh94K/3G88v1f3PooT5A5f/68cc8995TYR+XKlY0ffvjBvvyHH3541e1j2rRp11xnhesMCQkxwsLCHB7j1KlTTqurtEGmXbt2V12u8LZQ1nVV2iDjivfu448/bp9fXECrqPhq6QY4cuSI/UhvLy8vPfLIIxo0aJB9/tKlS3Xq1KkS7793714NGzZMX3/9tf75z3/K29tbkvS///u/euONN4q9z/79+/Xwww8rPj5eX375pbp376709HQNHjxYFy9elCQNHz5cK1eu1CeffKI6depIkj799FPFxsbaH/+XX36RJDVv3lzx8fFas2aNPvroI40ZM0b169e/Zu8//vijDMOw377vvvuueR9JateunapVqyZJys3N1T/+8Q81a9ZMQUFB6tKli2bMmHHV16yw8+fPa86cOfr555/t01q1alWq+zrTwYMH1ahRI33yySdatWqVnnvuOUnSY489pt9++02SdM899yg+Pl7Lli1T586dJUm7du3SCy+8YH+cl156Sb///rskKTg4WLNmzdKSJUvUtGlTHTp0qEw1jRo1Srt27ZIktWzZUgsWLNCKFSvUv39/SVJqaqqGDBliX/6LL76QdHm7fvvtt5WQkKDPP/9c06ZNU+fOne3b6tXs2rXLvo00aNCgTPU6Q2ZmpgICAjR//nzFxsYqJCRE0uVfVc2fP9++3OjRo/XTTz9Jknx8fDRhwgR99dVXWrhwoYYNGyZfX19J0rFjxzRs2DD7V2c9e/bUsmXL9O6779ofe8eOHfrrX/9abD0HDhzQo48+quXLl2vEiBH26XPnzi3x68iDBw9q8uTJWr58uX27kaSZM2eW92WRJMXExOjbb7+VJN16662KjY3V6tWrNXz4cEmXD4x99NFHlZubK+mP7aPgvt98843i4+P1xhtv6P7775e/v3+Znv/MmTO6dOmS3nrrLa1evVozZ86Ur6+v0+p6++23ixwSsGHDBvulYD8yZMgQzZ07V8uXL9d3332nNWvW6J133rFvAzExMfbnvtK11lWvXr20YcMGtWzZ0j6v4GvzDRs26KWXXpLkmvduw4YN7dcL708rPLOT1M1g6tSp9hT7wAMP2Kffdddd9unvvvuuw30KfyJr27atw7zRo0fb5zVv3tw+vfCnh9atWxep4+2337bPb9q0qf2gxw0bNhgvvfSSfV779u0NwzCM5ORk+7SuXbsau3fvLvJVzrUU/kpNKnpw7tWsWrXKqFatWomfGMLDw4sMf5a0bOFL9erVjaNHj17z+a/1SajwpTQjCYbh+Em3UqVKRb5G2blzp32+t7e3sWrVKvs6WrRokcO8s2fPGnl5eUZwcLB9+htvvGF/rPT0dIfRt2uNyJw6dcrw9PS0T58/f779ub/99luHEYV9+/YZhvHHNuzv72+sWrXKOH36dKleh8L+53/+x/64jzzySJleQ2eMyEgytm7dap83fPhw+/Rx48YZhmEYp0+fNry8vOzTZ86cWeJzzpw5075cWFiYceHCBfu8d955xz4vODjYyM3NNQzDcf00adLEPkqal5dnVKpUyT6v8NexhT/ljxw50j59y5Yt9ulVq1YttufSjMjk5+c7jIa88cYbDvuQGjVq2OetXLnSMAzDGDhwoMMn/PT09NKsJgdXrpulS5c6zHd2XaU52DclJcUYOXKkcdtttxn+/v7F7iOuZ10ZxtUP9nXVe/fdd98ttu6Kzku4bh999JH9euGRmEGDBmnTpk2SLv+0rvCnrcI6depU5PY777wj6fLIS3H69etXZNqePXvs13ft2qU//elPxd63INXXr19f3bp109q1a/XNN9+oSZMm8vT0VL169dShQwcNHz5c7du3L/YxClSuXNnh9smTJ0s1kiNdHr05dOiQFi1apISEBG3evNk+QiRJaWlpeuGFF7Ry5cpSPZ6Xl5cefPBBvf7667rllltKdR9n6tixo6pXr+4wrfA6unTpknr06FHsfS9duqSkpCTVrFlTmZmZDo9ZIDQ0VI0aNSr1TzWTk5MdDjwfOHBgicvu2rVLt912m4YPH65NmzbpwoUL9lrDw8PVsmVL9e/fX08++aS8vEq/GzEKjd6ZJSgoSG3btrXfLhgZlKSMjAxJl1+rwp+wi3u/Fdi3b5/9eps2beTn52e/Xfi9nZmZqd9//93+M9cC9957r/1AeA8PD1WpUkXnz593qOdKXbt2vWr95ZGenq709HT77XHjxpW47K5du9SjRw89/fTT+uyzz5SXl2c/WLRKlSpq3ry5HnzwQY0cOVKVKlUqdQ2+vr568MEHK1Rdx44dU5s2bZSWlnbV5UoaQb4R68pV792K8P4sD4LMddq0aZOSk5PttwcOHFjsRrZ161bt3btXt99++w153ho1apT7vgXD1TabTcuWLdNHH32kVatWac+ePTp48KCSk5OVnJys+fPna9OmTWrTpk2Jj3XHHXfIZrPZ3wBr165Vu3btSl1LUFCQnnjiCT3xxBOSLg/Djh49WitWrJAk/fDDDyXe929/+5t69uwpDw8PBQYGqn79+mXaaRYM6Rb23HPPKTEx0f7YBQr/cSqt61lH0uX1VPiXXpKK3HaWgm1k8ODBqlOnjubPn6+ffvpJycnJSktL0+rVq7V69Wrt3bvX/uuzkoSFhdmvX88f2hulatWqDrcL78zN2JGXp57C9ykpSBbeVq782qNwMCiPgu2jS5cu2r59u+Li4rR9+3YlJSXpxIkTWrdundatW6fvv/9e8fHxpX7c6tWrX9c27oy6PvzwQ3uIqV69ul599VXVr19fHh4e6tu3r06cOCFJJf66qjTr6ka6nvdu4fdneHi402u9UThG5joVHo0p77Lff/99ibdLGt0o7s1eOCTdddddMi4fzF3kUrChG4YhPz8/Pfvss1q8eLH27dunc+fO6fnnn5d0eVRg0aJFV+2pRo0aDsfFvP766yWOIhWMBEnS4cOH7ccfFFa3bl2H73mv9tPLBg0aqFOnTrrrrrvUvHnzMoUYyfGnugWXgmMaCh674HK1MFeSa60jf39/nT59usR11LlzZ4WFhdlrkqQtW7bYr584ccJhNOBaGjZsKE9PT/vtpKSkEp+7YB0YhqG7775bs2fP1g8//KBTp045hMsFCxZc83mbNm1qfy2SkpJKXa+ZrnytivujVxAyGjVqZJ+2Y8cO+zFqkuN7OTg4+LrDbVlUqVLFfv3EiRPKzs6WdDnUFDfKGRYWptDQUPvtVatWlbh9TJ48WdLl16Bly5Z66623tHHjRqWnp+vAgQMKDAyUJC1ZssQ+ulQaxb1nnF2Xh4fjn8Er9zkFp5WQLh/f9uSTT+ruu+9W7dq1dfLkyVL3di2F67iyBle9dwu/P610+gJGZK7DxYsX9dlnn9lvjx8/XvXq1XNYZufOnXr33XclSZ988ommTp3qsEFKl0drnnnmGfXr108//fST3n//ffu8P//5z6Wu55FHHtHf/vY3ZWVladOmTRowYIAGDhyokJAQpaamKikpSV9//bX69OmjyZMn6/jx4+rYsaP69++vZs2aqUaNGjp//ry2b9/u0OO1vPnmm+rQoYPOnDmjU6dOqV27dnruued01113ydPTU8nJyfriiy+UkZFhDy8HDhxQ9+7d1bZtWz344INq0aKFgoODlZKSoqlTp9ofu0OHDqXu3wqaNWumtm3batu2bbpw4YLuvfdePf/886pVq5bS09N16NAhJSQkKD8/X2vXrpWHh4cGDBiguXPnSpImTZokHx8fRUREaMaMGaVaPwUqV66sfv362Q9u7NWrlyZMmKD69evr9OnT+vXXX7V+/Xrt27fPHpCio6Pl5eWlLl26qGbNmgoICNDq1avtj1ma5w8NDVWTJk20a9cuHTlyRMeOHSvy1V/h5ywczk6cOKEvv/xSklS7dm3dcccdpe73eoSEhCg6OloLFy6UJE2YMEGpqanq3LmzsrKy9M0336hFixYaMWKE/vznP2vixIk6f/680tLSNGDAAA0fPly//fab/UBN6fIfQVd8Ii9Qt25deXl5KTc3V9nZ2YqOjtb999+vzz//XAcPHiyyvM1m0xNPPKEZM2ZIuny217/+9a9q2rSpsrKylJKSoi1btmj58uX2rzvHjh2rX375Rffdd59q1aqlkJAQ/fjjj/aQYBiGsrOzy/whw5V1Va1a1WFU+c0339Sdd94pDw8PdezYUXXr1rXXsmjRInXo0EH5+fmaMmXKDR3BK/y10+eff66oqCj5+PjotttuU1hYmEveu1u3brW/5nffffcN683pnHHgjbuYP3++w4F82dnZRZY5deqUw4FYK1asMAzD8WC/li1bOvyEueDSrFkz49y5c/bHKs2ZHxcvXnzVn1+r0MGfR48evepyXl5eDj9pvJqyntl3zZo1V11WkhEYGGjs2LHD4XkKz3fG2S9v9HlkipOcnHzVn1/rigNVS/r5dUhIiMO5c0rz8+u0tLSr/oRTVxwY2qNHj6su+/zzz5fqdfnnP/9pv88HH3xw1detpEtJr2dhpT2PTEnPXfg5Tpw44fCT/isvZf359ZkzZ+zLX+08P4UPFC34+e/Vpl/tYNWnn366SC02m83hvD5X/vy6S5cu11wXBZ599tmrLvfwww9fc51dbd24qq4OHToUWcbT09MwjMvvvypVqhSZ37hxY4ef8V/vunr//feLrfWTTz4xDMP57939+/fb53Xv3v2a660i4aul61D4q6IHH3xQPj4+RZapXLmy7rnnHvvt4s4Y27t3b3311Vdq166d/Pz8FBoaqqefflrffvttmT/J9O3bVz/99JOeeeYZ1a9fX35+fgoICFD9+vX14IMPavbs2Ro5cqS9tldeeUX33XefateuLX9/f3l5eSkiIkL9+vXThg0bdOedd5bqedu1a6c9e/bonXfeUffu3RUeHi5vb29Vq1ZNzZs315gxY/TBBx/Yl+/QoYM+++wzDR8+XK1bt1bNmjXl4+MjPz8/NWzYUM8++6x++uknl30Cd6UGDRro559/1qRJk9SqVSsFBgbK19dXtWvX1t13362pU6c6nFnzlltu0ffff6/+/fsrKChIgYGB6tGjhzZu3OhwsHVAQMA1nzssLExbt27Va6+9pvbt2yskJETe3t6KiIhQ+/bt9dJLLzn8dHXEiBEaPHiwGjVqpCpVqsjT01MhISFq3769Zs6cec3jYwo89dRT9p97Fv6Jc0VWrVo1/fDDD3rjjTfUoUMH+2tVo0YN9erVy+FYsP/3//6ftm7dqscee0y1atWSt7e3AgMD1bp1a/373//Wxo0br3mmamd444039PTTT6tatWry8/NT+/bt9dVXX2nAgAHFLu/v76+1a9dqzpw56tKli6pWrSovLy9Vr15drVu31tixY/Xdd9/Zl3/00Uf11FNPqVmzZqpWrZo8PT0VEBCgVq1a6eWXX3YYsb4ezq7rk08+Ua9evRQUFFTkuW+55RZ999136tatm4KDg1WtWjU99thj+vbbb8v88/KrGTZsmCZOnKjIyMgiX3dJzn/vFv6qqaQfplRUNsOw6GHKFjd06FB7EJo8eXKF+Q/FqJgMwyhy/EBaWpqioqJ04cIFSVJiYqJatGhhRnml8vzzz+vtt9+WzWbTrl271LhxY7NLAiApJydH9erV02+//aaWLVtqx44dxYapiso6lQJurGvXrpozZ45++uknHTlyRGvXrlXv3r3tIaZFixZq3ry5yVVe3eTJk1W5cmUZhqFp06aZXQ6A//PJJ5/YT9L52muvWSrESBzsC1jCnj179OyzzxY7Lzw8XPPmzXPZT7PLq1q1aqU+WzMA1xk2bJiGDRtmdhnlZq3YBbipESNGqF27dgoNDZWXl5eCgoJ0xx136O9//7t2796tpk2bml0iAJiCY2QAAIBlMSIDAAAsiyADAAAsy9IH++bn5+v3339XUFBQhT/QEQAAlJ5hGDp79qwiIiKu+ksqSweZ4v6TLAAAuHkcOXJEkZGRJc63dJApOAvjvHnzVLt2bZOrca0DBw5o/fr1Gty8uar/3z9Ccxd70tP19f79evjhhx3+mZw7KFjv9E7v7oJ93X7deeedppwZ2mzHjx/Xiy++WOwZlwuzdJAp+Dqpdu3aatiwocnVuNaFCxfk4+Oj+mFhql3oNPXuICsvTz4+PoqKilJERITZ5bhUwXqnd3p3F+zrfHTLLbeoatWqZpdjmmsdOsLBvgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLK8zC7AKo5mHdWqX1dp8++blXQqSWnn05SZk6lgn2A1qdZE0Q2jFd0wWjabzexScYMtXeqrjRt9lJjorX37vJST88c6PnbsuImVAc7B/s69pKamatiwYbp48aIkqU2bNpoxY4bD+jUMQ+PHj9eOHTskSX5+fvrggw8UGRlpSs2FEWRKadH+RZr6w9Qi0zMuZmhD6gZtSN2g5QeXK7ZHrDw9PE2o0Pm+nz9fmxcsKHG+b0CAnlu40IUVucbMmQHavdvb7DIAl3H3/Z277etq1qypkSNH6o033pAkbd++XfHx8erXr599mfj4eHuIkaQRI0ZUiBAj8dVSmYVXCtejjR7VX9v+VYMaDZKfp5993upfV2th0s2zceMym02KispV794X1aFDjtnlAC7D/s59PPzww2rfvr399pw5c3TkyBFJ0pEjR/T+++/b5915553q3bu3y2ssCSMypVQzsKbeufcd9anfR14ef7xsfRv01YBlA+y3E1ISNOj2QWaU6FK3tm6tdtHRDtM8PG++T2aStGxZhvz9L1+fMSNAmzf7mFsQ4GTs7/7gTvu6CRMm6IknnlBmZqYuXryoV199VTNnztSrr76q7OxsSVJwcLD+67/+y+RKHRFkSqlfg37FTu9Us5Oq+lVVxsUMSVJOvnt8Yq8UEqLIJk3MLsMlCkIM4C7Y3/3BnfZ11apV07hx4xQTEyNJ2rt3r0aMGKFffvnFvszYsWMVGhpqUoXF46ul61RwEFyBVuGtTKwGAJyH/d3Nr0uXLurWrZv9duEQ061bN91zzz1mlHVVjMhch9z8XI1fN165+bmSpFD/UD3e+HGTq3KN3QkJ2p2Q4DCtyb33qufYsSZVBMCZ3HV/5477ujFjxuinn37SyZMn7dOqVKmiMWPGmFhVyRiRKaesnCw9vuJxrf51tSQp0DtQH9//sUL9K9aQGwBcL/Z37iU9PV2ZmZkO086ePatjx46ZVNHVMSJTDqlZqRq8YrD2nNwjSarmV03zes1zq2HW4g6AC6hSxaRqADiLu+/v3G1fl5ubq1dffVWXLl0qdvr7778vH5+K9YMHgkwZJaYlasjKITp+/vKJ0OqF1NOnvT5VVEiUuYW5mDsdAAe4K/Z37revi42N1YEDB+y3+/Tpoy+//FKSdOjQIc2dO1cjRowwqbri8dVSGXx96Gv1XdrX/qZuX6O9lvdd7lZvagDugf2d+9m1a5cWFDoRYK9evfTCCy+oV69e9mmff/65fv75ZzPKKxEjMqW09JelGr52uPKNfElSsE+wukR20YJ9jmd/DPYJ1mONHzOjRDhJXJy/Dh++fN6I7dsdz/AbExNovz506AVFReW5tDbAGdjfuZ8LFy5o2rRpys+/vM5vueUWjR49WpI0evRoJSYm6vfff1d+fr6mTZumuXPnqlKlSmaWbEeQKaWkjCT7m1qSMnMyNX3b9CLLRQZG8sa+ySxZ4lfiSfBmzw6wX+/ePZsgg5sC+zv38+677yo1NVWS5OHhoYkTJ9qDSqVKlTRx4kSNGTNG+fn5Onr0qGbNmqUJEyaYWbIdXy0BAODGfvjhBy1btsx+e8CAAWrRooXDMs2aNdPAgQPtt7/66itt3rzZZTVeDSMypTSh7QRNaFsx0qdZOg4cqI6FNmR3ER9/yuwSAJdy9/2du+3r2rVrp+++++6ayz311FN66qmnnF9QGTEiAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALKtCBJlZs2YpKipKfn5+ateunbZu3Wp2SQAAwAJMDzKfffaZxo0bp8mTJ+vHH39UixYt1KNHD6WlpZldGgAAqOBMDzJvvPGGnn76aT3xxBNq3LixZs+erUqVKunDDz80uzQAAFDBeZn55Dk5OdqxY4cmTpxon+bh4aFu3bpp8+bNRZbPzs5Wdna2/XZmZqYk6cCBA7pw4YLzC65AUlJSJEk709J0NCvL5Gpc60BGhiQpOTlZ6enpJlfjWgXrnd7p3V2wr5NSU1N15swZk6txvdJu66YGmRMnTigvL0/Vq1d3mF69enXt27evyPLTpk3TlClTikxfv369fHx8nFZnRWWz2bQ0KcnsMkxhs9mUkJBgdhmmoHd6dzc2yX33dZJ27txpdhmmyMnJKdVypgaZspo4caLGjRtnv52ZmalatWppcPPmqh8WZmJlrrczLU1Lk5LUv39/hblZ78nJyUpISKB3encb9J6gJ1u1Uo3AQLPLcamC/bw79i5JB9LTFVeK5UwNMqGhofL09NTx48cdph8/fly33HJLkeV9fX3l6+tbZHr1wEDVrlzZWWVWSAVDrGFhYYqIiDC5GtcqGG6kd3p3F/Qu1XDj/bw79i5JZ0t5yIipB/v6+PiodevW+uabb+zT8vPz9c0336hDhw4mVgYAAKzA9K+Wxo0bpyFDhqhNmza688479dZbb+ncuXN64oknzC4NAABUcKYHmUceeUTp6emaNGmSjh07ppYtW2rlypVFDgAGAAC4kulBRpJGjx6t0aNHm10GAACwGNNPiAcAAFBeBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZXmYXAAu4eFGBb7whr//9X3n98otsp07Jlp0tIzhYuXXrKqdbN51/8kkZwcFmV3rDHc06qlW/rtLm3zcr6VSS0s6nKTMnU8E+wWpSrYmiG0YrumG0bDab2aUCNwzbPayEIFMG38+fr80LFpQ43zcgQM8tXOjCilzDdu6cAv77v4tOz8iQT0aGfLZvl9/ChcpYsUJGlSomVOg8i/Yv0tQfphaZnnExQxtSN2hD6gYtP7hcsT1i5enhaUKFwI3n7tu9u+7rJWv2TpBBqeTVqKFLbdooLzJS+VWqyOPkSfl99ZU8f/tNkuR1+LD8583T+eeeM7lS5wivFK6utbuqTlAdHTl7RF/s/0IX8y5Kklb/uloLkxZq0O2DTK4SuLHY7mEFBJlyurV1a7WLjnaY5uF5830ykSSjWjWd+OmnItPPDx+usFat7Lc9jxxxZVkuUTOwpt659x31qd9HXh5/vF36NuirAcsG2G8npCSwQ8dNg+3+D+60r7+SVXonyJRTpZAQRTZpYnYZ5sjLk0damvznzXOYnHvbbSYV5Dz9GvQrdnqnmp1U1a+qMi5mSJJy8nNcWRbgVGz3f3Dnfb1VeifIoNR81q9XlT//udh5Oe3b68Kgm/uTWWEFBz8WaBXe6ipLAzcHtntURASZctqdkKDdCQkO05rce696jh1rUkXmudCvn87OmCH5+Zldikvk5udq/Lrxys3PlSSF+ofq8caPm1wV4Fzuut27877eKr0TZFBquXXr6uykSbLl5Mjjt9/k9/XX8sjIkP/ixfLeuVOn5s9Xfq1aZpfpVFk5WXpmzTNKOHL5zR3oHaiP7/9Yof6hJlcGOA/bPSoygkw5FXcQVMBN9tPjK+VHRur8yJH221l/+Yuqdesmz+PH5bV/v4ImTdKZ2FgTK3Su1KxUDV4xWHtO7pEkVfOrpnm95jG8jpuau2/37rivL2CV3gky5WSVg6CcyQgL06XWreX59deSJJ9Nm0yuyHkS0xI1ZOUQHT9/XJJUL6SePu31qaJCoswtDHAitnv33tdbpXf+RQGuyXvjRtmysopMt508Ke8ffyw04eY8y+fXh75W36V97Tvz9jXaa3nf5W61M4f7YbuHVTAig2uq9MEH8l23Tjl/+pMuNW4sw99fnkePyverr+SZnm5fLrtbNxOrdI6lvyzV8LXDlW/kS5KCfYLVJbKLFuxzPPNlsE+wHmv8mBklAjcc2z2shCCDUrFduCDf1avlu3p1sfMvNW2qszExri3KBZIykuw7c0nKzMnU9G3TiywXGRjJDh03DbZ7WAlBBtd04YknlB8eLu8ff5THsWPyOH1a8vJSfmiochs31sWePXVxwADJ29vsUgEAboYgUwYdBw5Ux4EDzS7D5XI6d1ZO585ml2GKCW0naELbCWaXAbiUu2/37rqvl6zZOwf7AgAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyzI1yKxfv14PPfSQIiIiZLPZ9OWXX5pZDgAAsBhTg8y5c+fUokULzZo1y8wyAACARXmZ+eQ9e/ZUz549zSwBAABYmKlBpqyys7OVnZ1tv52ZmSlJ2pOerqy8PLPKMsWBjAxJUnJystLT002uxrVSUlIk0Tu9uw96l3ampeloVpbJ1bhWwX7eHXuXpJT/6/9abIZhGE6upVRsNpvi4+PVp0+fEpeJiYnRlClTikwfOnSofHx8nFhdxWSTVCFWnglsNpsqyKbrcvRO7+6G3t2z95ycHMXFxenMmTMKDg4ucTlLBZniRmRq1aqlxYsXKyoqyvlFViDJyclKSEjQk61aqUZgoNnluNTOtDQtTUpS//79FRYWZnY5LlWw3umd3t0Fvbtn75J0+PBh9evX75pBxlJfLfn6+srX17fI9NDQUEVERJhQkXkKhpdrBAaqduXK5hbjYgVDrGFhYW673umd3t0Fvbtn75KUVcqv0ziPDAAAsCxTR2SysrJ04MAB++1Dhw4pMTFRVatWVe3atU2sDAAAWIGpQWb79u2655577LfHjRsnSRoyZIji4uJMqgoAAFiFqUGmS5cubns0NgAAuH4cIwMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACzLy+wCrOJo1lGt+nWVNv++WUmnkpR2Pk2ZOZkK9glWk2pNFN0wWtENo2Wz2cwuFTfY0qW+2rjRR4mJ3tq3z0s5OX+s42PHjptYGeAc7rzNu/O+3qq9E2RKadH+RZr6w9Qi0zMuZmhD6gZtSN2g5QeXK7ZHrDw9PE2o0Pm+nz9fmxcsKHG+b0CAnlu40IUVucbMmQHavdvb7DIAl3Hnbd6d9/VW7Z0gU0bhlcLVtXZX1QmqoyNnj+iL/V/oYt5FSdLqX1drYdJCDbp9kMlV4kay2aSoqFy1aJGrtDQPbd7sY3ZJgFOxzbv3vt5qvRNkSqlmYE29c+876lO/j7w8/njZ+jboqwHLBthvJ6QkVKgV7Cy3tm6tdtHRDtM8PCtOQr+Rli3LkL//5eszZgS45U4d7sWdt3l33tdbtXeCTCn1a9Cv2OmdanZSVb+qyriYIUnKyc9xZVmmqRQSosgmTcwuwyUKduiAu3Dnbd6d9/VW7Z1fLV2ngoOhCrQKb2ViNQAAZ3DnfX1F750RmeuQm5+r8evGKzc/V5IU6h+qxxs/bnJVrrE7IUG7ExIcpjW59171HDvWpIoAwDnceV9vhd4ZkSmnrJwsPb7ica3+dbUkKdA7UB/f/7FC/UNNrgwAcKO4877eKr0zIlMOqVmpGrxisPac3CNJquZXTfN6zatww23OVNzBvgFVqphUDQDceO68r7dS7wSZMkpMS9SQlUN0/Pzlk0LVC6mnT3t9qqiQKHMLczF3OtgXgPtx53291Xrnq6Uy+PrQ1+q7tK995bav0V7L+y6vsCsXAFB27ryvt2LvjMiU0tJflmr42uHKN/IlScE+weoS2UUL9jme6TbYJ1iPNX7MjBLhJHFx/jp8+PI5crZvdzzbaUxMoP360KEXFBWV59LaAGdw523enff1Vu2dIFNKSRlJ9pUrSZk5mZq+bXqR5SIDIyvUCsb1W7LEr8QTgs2eHWC/3r179k23U4d7cudt3p339Vbtna+WAACAZTEiU0oT2k7QhLYTzC7DVB0HDlTHgQPNLsPl4uNPmV0C4FLuvM27877eqr0zIgMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACyLIAMAACzL1CAzbdo0tW3bVkFBQQoPD1efPn2UlJRkZkkAAMBCTA0y69at06hRo7RlyxatWbNGly5d0n333adz586ZWRYAALAILzOffOXKlQ634+LiFB4erh07dujuu+82qSoAAGAVpgaZK505c0aSVLVq1WLnZ2dnKzs72347MzNTknTgwAFduHDB+QVWICkpKZKknWlpOpqVZXI1rnUgI0OSlJycrPT0dJOrca2C9U7v9O4u6N09e5ek1NTUUi1nMwzDcHItpZKfn6+HH35Yp0+f1saNG4tdJiYmRlOmTCkyfejQofLx8XF2iRWOzWZTBVl9Lkfv9O5u6J3e3U1OTo7i4uJ05swZBQcHl7hchQkyI0aM0IoVK7Rx40ZFRkYWu0xxIzK1atXS4sWLFRUV5aJKK4bk5GQlJCSof//+CgsLM7scl6J3eqd390Hv7tm7JB0+fFj9+vW7ZpCpEF8tjR49WsuXL9f69etLDDGS5OvrK19f3yLTQ0NDFRER4cwSK5yCYcawsDB6dyP0Tu/07j7cuXdJyirlYROmBhnDMPTcc88pPj5e3333nW699VYzywEAABZjapAZNWqU5s+fryVLligoKEjHjh2TJIWEhMjf39/M0gAAgAWYeh6Z9957T2fOnFGXLl1Uo0YN++Wzzz4zsywAAGARpn+1BAAAUF78ryUAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZXmYXYCVLl/pq40YfJSZ6a98+L+Xk2Ozzjh07bmJlzkfv7tk7AFR0BJkymDkzQLt3e5tdhino3T17B4CKjiBTBjabFBWVqxYtcpWW5qHNm33MLsll6N09eweAio4gUwbLlmXI3//y9RkzAtzqDxq9X77ubr0DQEXHwb5lUPDHzB3ROwCgIiLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAy+I8MmUQF+evw4c9JUnbtzue6TUmJtB+fejQC4qKynNpbc5G7+7ZOwBUdASZMliyxK/Ek6HNnh1gv969e/ZN9weN3t2zdwCo6PhqCQAAWBYjMmUQH3/K7BJMQ+8AgIqIERkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZBBkAAGBZ1x1kLl68eCPqAAAAKLNyBZn8/Hy98sorqlmzpgIDA3Xw4EFJ0j/+8Q/NnTv3hhYIAABQknIFmX/+85+Ki4vTv//9b/n4/PHP9Jo2baoPPvjghhUHAABwNeUKMh9//LHmzJmjQYMGydPT0z69RYsW2rdv3w0rDgAA4GrKFWRSU1NVv379ItPz8/N16dKl6y4KAACgNMoVZBo3bqwNGzYUmb5o0SK1atXquosCAAAoDa/y3GnSpEkaMmSIUlNTlZ+fr8WLFyspKUkff/yxli9ffqNrBAAAKFa5RmR69+6tZcuWae3atQoICNCkSZO0d+9eLVu2TN27d7/RNQIAABSrXCMykvSnP/1Ja9asuZG1AAAAlEm5g4wk5eTkKC0tTfn5+Q7Ta9eufV1FAQAAlEa5gsz+/fv15JNPatOmTQ7TDcOQzWZTXl7eDSkOAADgasoVZIYOHSovLy8tX75cNWrUkM1mu9F1AQAAXFO5gkxiYqJ27NihRo0aXdeTv/fee3rvvfd0+PBhSVKTJk00adIk9ezZ87oeFwAAuIdyn0fmxIkT1/3kkZGRmj59unbs2KHt27fr3nvvVe/evbV79+7rfmwAAHDzK1eQ+de//qX/+q//0nfffaeTJ08qMzPT4VJaDz30kHr16qUGDRqoYcOGmjp1qgIDA7Vly5bylAUAANxMub5a6tatmySpa9euDtOv52DfvLw8ff755zp37pw6dOhQnrIAAICbKVeQ+fbbb29YATt37lSHDh108eJFBQYGKj4+Xo0bNy522ezsbGVnZ9tvF4z+HDhwQBcuXLhhNVlBSkqKJCk5OVnp6ekmV+Na9E7v9O4+6N09e5cu/1/H0rAZhmE4uZarysnJUUpKis6cOaNFixbpgw8+0Lp164oNMzExMZoyZUqR6UOHDpWPj48ryq1QbDabTF59pqF3enc39E7v7iYnJ0dxcXE6c+aMgoODS1yuXEHm559/Lv7BbDb5+fmpdu3a8vX1LevDSrr8tVW9evX0/vvvF5lX3IhMrVq1tHjxYkVFRZXr+awqOTlZCQkJ6t+/v8LCwswux6Xond7p3X3Qu3v2LkmHDx9Wv379rhlkyvXVUsuWLa967hhvb2898sgjev/99+Xn51emx87Pz3cIK4X5+voWG5BCQ0MVERFRpuexuoJhxrCwMHp3I/RO7/TuPty5d0nKysoq1XLl+tVSfHy8GjRooDlz5igxMVGJiYmaM2eObrvtNs2fP19z585VQkKC/v73v1/1cSZOnKj169fr8OHD2rlzpyZOnKjvvvtOgwYNKk9ZAADAzZRrRGbq1KmaOXOmevToYZ/WrFkzRUZG6h//+Ie2bt2qgIAAvfjii3rttddKfJy0tDQ9/vjjOnr0qEJCQtS8eXOtWrWK/6ANAABKpVxBZufOnapTp06R6XXq1NHOnTslXf766ejRo1d9nLlz55bn6QEAACSV86ulRo0aafr06crJybFPu3TpkqZPn27/twWpqamqXr36jakSAACgGOUakZk1a5YefvhhRUZGqnnz5pIuj9Lk5eVp+fLlkqSDBw9q5MiRN65SAACAK5QryNx11106dOiQPv30UyUnJ0uSoqOjNXDgQAUFBUmSBg8efOOqBAAAKEa5gowkBQUFafjw4TeyFgAAgDIpdZBZunSpevbsKW9vby1duvSqyz788MPXXRgAAMC1lDrI9OnTR8eOHVN4eLj69OlT4nLl/aeRAAAAZVXqIJOfn1/s9cKOHDmil19++fqrAgAAKIVy/fy6JBkZGfrwww9v5EMCAACU6IYGGQAAAFciyAAAAMsiyAAAAMsq03lk+vXrd9X5p0+fvp5aAAAAyqRMQSYkJOSa8x9//PHrKggAAKC0yhRkYmNjnVUHAABAmXGMDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsKwKE2SmT58um82mF154wexSAACARVSIILNt2za9//77at68udmlAAAACzE9yGRlZWnQoEH6z3/+oypVqphdDgAAsBDTg8yoUaP0wAMPqFu3bmaXAgAALMbLzCdfuHChfvzxR23btq1Uy2dnZys7O9t+OzMzU5J04MABXbhwwSk1VlQpKSmSpOTkZKWnp5tcjWvRO73Tu/ugd/fsXZJSU1NLtZzNMAzDybUU68iRI2rTpo3WrFljPzamS5cuatmypd56661i7xMTE6MpU6YUmT506FD5+Pg4s9wKyWazyaTVZzp6p3d3Q+/07m5ycnIUFxenM2fOKDg4uMTlTAsyX375pfr27StPT0/7tLy8PNlsNnl4eCg7O9thnlT8iEytWrW0ePFiRUVFuar0CiE5OVkJCQnq37+/wsLCzC7Hpeid3undfdC7e/YuSYcPH1a/fv2uGWRM+2qpa9eu2rlzp8O0J554Qo0aNdJf/vKXIiFGknx9feXr61tkemhoqCIiIpxWa0VUMMwYFhZG726E3umd3t2HO/cuXf4xUGmYFmSCgoLUtGlTh2kBAQGqVq1akekAAADFMf1XSwAAAOVl6q+WrvTdd9+ZXQIAALAQRmQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBlEWQAAIBleZldgJUsXeqrjRt9lJjorX37vJSTY7PPO3bsuImVOR+90zu907t08/cO6yHIlMHMmQHavdvb7DJMQe/07m7o3T17h/UQZMrAZpOionLVokWu0tI8tHmzj9kluQy90zu90ztQERFkymDZsgz5+1++PmNGgFu9uen98nV6p3d34M69w3o42LcMCt7Y7oje3RO9uyd37h3WQ5ABAACWRZABAACWRZABAACWRZABAACWRZABAACWRZABAACWxXlkyiAuzl+HD3tKkrZvdzzrZUxMoP360KEXFBWV59LanI3e6Z3e/0Dvl92MvcN6CDJlsGSJX4knhpo9O8B+vXv37JvuzU3v9H4ler+M3m+u3mE9fLUEAAAsixGZMoiPP2V2Caahd/dE7+7JnXuH9TAiAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALIsgAwAALMvUIBMTEyObzeZwadSokZklAQAAC/Eyu4AmTZpo7dq19tteXqaXBAAALML01ODl5aVbbrnF7DIAAIAFmX6MzP79+xUREaG6detq0KBBSklJMbskAABgEaaOyLRr105xcXG67bbbdPToUU2ZMkV/+tOftGvXLgUFBRVZPjs7W9nZ2fbbmZmZkqQDBw7owoULLqu7IigIfMnJyUpPTze5Gteid3qnd/dB7+7ZuySlpqaWajmbYRiGk2sptdOnT6tOnTp64403NGzYsCLzY2JiNGXKlCLThw4dKh8fH1eUWKHYJFWYlediNptNFWjTdSm37l1s8+6I3t2z95ycHMXFxenMmTMKDg4ucbkKFWQkqW3bturWrZumTZtWZF5xIzK1atXS4sWLFRUV5cIqzZecnKyEhAQ92aqVagQGml2OS+1MS9PSpCT1799fYWFhZpfjUgXr3Z17Z5t3z/VO7+7VuyQdPnxY/fr1u2aQMf1g38KysrL0yy+/aPDgwcXO9/X1la+vb5HpoaGhioiIcHZ5FUrBMGONwEDVrlzZ3GJc7GhWliQpLCzMbde7O/fONu+e653e3at36XImKA1TD/YdP3681q1bp8OHD2vTpk3q27evPD099eijj5pZFgAAsAhTR2R+++03Pfroozp58qTCwsLUqVMnbdmyxS2H0AAAQNmZGmQWLlxo5tMDAACLM/08MgAAAOVFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJZFkAEAAJblZXYBVnE066hW/bpKm3/frKRTSUo7n6bMnEwF+wSrSbUmim4YreiG0bLZbGaX6jTfz5+vzQsWlDjfNyBAzy1c6MKKXGPpUl9t3OijxERv7dvnpZycP9bxsWPHTazM+dy5d4lt3l3XO6yFIFNKi/Yv0tQfphaZnnExQxtSN2hD6gYtP7hcsT1i5enhaUKFcJaZMwO0e7e32WWYwp17d2esd1gJQaaMwiuFq2vtrqoTVEdHzh7RF/u/0MW8i5Kk1b+u1sKkhRp0+yCTq3S+W1u3VrvoaIdpHp43Z4Cz2aSoqFy1aJGrtDQPbd7sY3ZJLuPOvV+JbR6omAgypVQzsKbeufcd9anfR14ef7xsfRv01YBlA+y3E1IS3CLIVAoJUWSTJmaX4RLLlmXI3//y9RkzAtxqp+7OvV+JbR6omAgypdSvQb9ip3eq2UlV/aoq42KGJCknP8eVZcEFCnbo7side3dnrHdYCUHmOhUc9FugVXgrE6txnd0JCdqdkOAwrcm996rn2LEmVQQ4F9s8UDHx8+vrkJufq/Hrxis3P1eSFOofqscbP25yVQAAuA9GZMopKydLz6x5RglHLn9CC/QO1Mf3f6xQ/1CTK3ON4g58DKhSxaRqAOdjmwcqJoJMOaRmpWrwisHac3KPJKmaXzXN6zXPbb5WktzrwEdAYpsHKiqCTBklpiVqyMohOn7+8kmh6oXU06e9PlVUSJS5hQEA4IY4RqYMvj70tfou7WsPMe1rtNfyvssJMQAAmIQRmVJa+stSDV87XPlGviQp2CdYXSK7aME+x9OXB/sE67HGj5lRIpwkLs5fhw9fPvHZ9u2OZzuNiQm0Xx869IKiovJcWpuzuXPv7oz1DishyJRSUkaSPcRIUmZOpqZvm15kucjASILMTWbJEr8STwg2e3aA/Xr37tk33U7dnXt3Z6x3WAlBBqXWceBAdRw40OwyAJdhmwcqPoJMKU1oO0ET2k4wuwyYID7+lNklmMade3dnrHdYCQf7AgAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyyLIAAAAyzI9yKSmpuqxxx5TtWrV5O/vr2bNmmn79u1mlwUAACzAy8wnP3XqlDp27Kh77rlHK1asUFhYmPbv368qVaqYWRYAALAIU4PMv/71L9WqVUuxsbH2abfeequJFQEAACsx9aulpUuXqk2bNoqOjlZ4eLhatWql//znP2aWBAAALMTUEZmDBw/qvffe07hx4/S3v/1N27Zt0/PPPy8fHx8NGTKkyPLZ2dnKzs62387MzJQkHThwQBcuXHBZ3RVBSkqKJGlnWpqOZmWZXI1rHcjIkCQlJycrPT3d5Gpcq2C9u3PvbPPuud7p3b16ly4fQ1saNsMwDCfXUiIfHx+1adNGmzZtsk97/vnntW3bNm3evLnI8jExMZoyZUqR6UOHDpWPj49Ta62IbDabTFx9pqJ3enc39E7v7iYnJ0dxcXE6c+aMgoODS1zO1BGZGjVqqHHjxg7Tbr/9dn3xxRfFLj9x4kSNGzfOfjszM1O1atXS4ObNVT8szKm1VjQ709K0NClJ/fv3V5ib9Z6cnKyEhAR6p3e3Qe/07m69S9Lhw4cVFxd3zeVMDTIdO3ZUUlKSw7Tk5GTVqVOn2OV9fX3l6+tbZHr1wEDVrlzZGSVWWAVD62FhYYqIiDC5GtcqGGKld3p3F/RO7+7WuyRllfIrZFMP9h07dqy2bNmiV199VQcOHND8+fM1Z84cjRo1ysyyAACARZgaZNq2bav4+HgtWLBATZs21SuvvKK33npLgwYNMrMsAABgEaZ+tSRJDz74oB588EGzywAAABZk+r8oAAAAKC+CDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCyCDAAAsCwvswuwku/nz9fmBQtKnO8bEKDnFi50YUWucTTrqFb9ukqbf9+spFNJSjufpsycTAX7BKtJtSaKbhit6IbRstlsZpfqFEuX+mrjRh8lJnpr3z4v5eT80eexY8dNrMz56J3e3a13WA9BBte0aP8iTf1hapHpGRcztCF1gzakbtDyg8sV2yNWnh6eJlToXDNnBmj3bm+zyzAFvdM7UNERZMrp1tat1S462mGah+fN90e8sPBK4epau6vqBNXRkbNH9MX+L3Qx76IkafWvq7UwaaEG3T7I5CpvPJtNiorKVYsWuUpL89DmzT5ml+Qy9E7v7tY7rIcgU06VQkIU2aSJ2WW4RM3Amnrn3nfUp34feXn8scn0bdBXA5YNsN9OSEm4KYPMsmUZ8ve/fH3GjAC32qnT++Xr9O4+vcN6CDK4pn4N+hU7vVPNTqrqV1UZFzMkSTn5Oa4sy2UKdujuiN7dkzv3DushyJTT7oQE7U5IcJjW5N571XPsWJMqcr2Cg34LtApvZWI1AAB3xM+vUS65+bkav268cvNzJUmh/qF6vPHjJlcFAHA3jMiUU3EH+wZUqWJSNa6VlZOlZ9Y8o4Qjl0ekAr0D9fH9HyvUP9TkygAA7oYgU07udLBvYalZqRq8YrD2nNwjSarmV03zes3jayUAgCkIMii1xLREDVk5RMfPXz4hVr2Qevq016eKCokytzAAgNviGBmUyteHvlbfpX3tIaZ9jfZa3nc5IQYAYCpGZHBNS39ZquFrhyvfyJckBfsEq0tkFy3Y5/jvGoJ9gvVY48fMKNGp4uL8dfjw5ZMdbt/ueLbTmJhA+/WhQy8oKirPpbU5G73Tu7v1DushyOCakjKS7CFGkjJzMjV92/Qiy0UGRt6UQWbJEr8STwg2e3aA/Xr37tk33U6d3un9Sjd777AegkwZdBw4UB0HDjS7DAAA8H8IMrimCW0naELbCWaXYZr4+FNml2AaendP7tw7rIeDfQEAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGURZAAAgGWZGmSioqJks9mKXEaNGmVmWQAAwCK8zHzybdu2KS8vz357165d6t69u6Kjo02sCgAAWIWpQSYsLMzh9vTp01WvXj117tzZpIoAAICVVJhjZHJycjRv3jw9+eSTstlsZpcDAAAswNQRmcK+/PJLnT59WkOHDi1xmezsbGVnZ9tvnzlzRpJ08MQJZ5dX4aRkZCgnJ0eHDx9WVlaW2eW4VGpqKr3Tu9nluBS907u79S5JKSkpkiTDMK66nM241hIu0qNHD/n4+GjZsmUlLhMTE6MpU6a4sCoAAGCmI0eOKDIyssT5FSLI/Prrr6pbt64WL16s3r17l7jclSMyp0+fVp06dZSSkqKQkBBXlFphZGZmqlatWjpy5IiCg4PNLsel6J3e6d190Lt79i5dHok5e/asIiIi5OFR8pEwFeKrpdjYWIWHh+uBBx646nK+vr7y9fUtMj0kJMQtV7IkBQcH07sbond6dzf07p69l2aQwvSDffPz8xUbG6shQ4bIy6tC5CoAAGARpgeZtWvXKiUlRU8++aTZpQAAAIsxfQjkvvvuu+YRySXx9fXV5MmTi/266WZH7/Tubuid3t2NO/deFhXiYF8AAIDyMP2rJQAAgPIiyAAAAMsiyAAAAMuydJCZNWuWoqKi5Ofnp3bt2mnr1q1ml+R069ev10MPPaSIiAjZbDZ9+eWXZpfkMtOmTVPbtm0VFBSk8PBw9enTR0lJSWaX5RLvvfeemjdvbj+fRIcOHbRixQqzyzLF9OnTZbPZ9MILL5hditPFxMTIZrM5XBo1amR2WS6Tmpqqxx57TNWqVZO/v7+aNWum7du3m12W00VFRRVZ7zabTaNGjTK7tArJskHms88+07hx4zR58mT9+OOPatGihXr06KG0tDSzS3Oqc+fOqUWLFpo1a5bZpbjcunXrNGrUKG3ZskVr1qzRpUuXdN999+ncuXNml+Z0kZGRmj59unbs2KHt27fr3nvvVe/evbV7926zS3Opbdu26f3331fz5s3NLsVlmjRpoqNHj9ovGzduNLsklzh16pQ6duwob29vrVixQnv27NHrr7+uKlWqmF2a023bts1hna9Zs0aSFB0dbXJlFZRhUXfeeacxatQo++28vDwjIiLCmDZtmolVuZYkIz4+3uwyTJOWlmZIMtatW2d2KaaoUqWK8cEHH5hdhsucPXvWaNCggbFmzRqjc+fOxpgxY8wuyekmT55stGjRwuwyTPGXv/zF6NSpk9llVAhjxowx6tWrZ+Tn55tdSoVkyRGZnJwc7dixQ926dbNP8/DwULdu3bR582YTK4MrFfz386pVq5pciWvl5eVp4cKFOnfunDp06GB2OS4zatQoPfDAAw7ve3ewf/9+RUREqG7duho0aJD9PwLf7JYuXao2bdooOjpa4eHhatWqlf7zn/+YXZbL5eTkaN68eXryySdls9nMLqdCsmSQOXHihPLy8lS9enWH6dWrV9exY8dMqgqulJ+frxdeeEEdO3ZU06ZNzS7HJXbu3KnAwED5+vpq+PDhio+PV+PGjc0uyyUWLlyoH3/8UdOmTTO7FJdq166d4uLitHLlSr333ns6dOiQ/vSnP+ns2bNml+Z0Bw8e1HvvvacGDRpo1apVGjFihJ5//nl99NFHZpfmUl9++aVOnz6toUOHml1KhWX6mX2B8hg1apR27drlNscLSNJtt92mxMREnTlzRosWLdKQIUO0bt26mz7MHDlyRGPGjNGaNWvk5+dndjku1bNnT/v15s2bq127dqpTp47+53/+R8OGDTOxMufLz89XmzZt9Oqrr0qSWrVqpV27dmn27NkaMmSIydW5zty5c9WzZ09FRESYXUqFZckRmdDQUHl6eur48eMO048fP65bbrnFpKrgKqNHj9by5cv17bffKjIy0uxyXMbHx0f169dX69atNW3aNLVo0UIzZ840uyyn27Fjh9LS0nTHHXfIy8tLXl5eWrdunf77v/9bXl5eysvLM7tEl6lcubIaNmyoAwcOmF2K09WoUaNISL/99tvd5qs1Sfr111+1du1aPfXUU2aXUqFZMsj4+PiodevW+uabb+zT8vPz9c0337jVMQPuxjAMjR49WvHx8UpISNCtt95qdkmmys/PV3Z2ttllOF3Xrl21c+dOJSYm2i9t2rTRoEGDlJiYKE9PT7NLdJmsrCz98ssvqlGjhtmlOF3Hjh2LnF4hOTlZderUMaki14uNjVV4eLgeeOABs0up0Cz71dK4ceM0ZMgQtWnTRnfeeafeeustnTt3Tk888YTZpTlVVlaWw6exQ4cOKTExUVWrVlXt2rVNrMz5Ro0apfnz52vJkiUKCgqyHw8VEhIif39/k6tzrokTJ6pnz56qXbu2zp49q/nz5+u7777TqlWrzC7N6YKCgoocBxUQEKBq1ard9MdHjR8/Xg899JDq1Kmj33//XZMnT5anp6ceffRRs0tzurFjx+quu+7Sq6++qj//+c/aunWr5syZozlz5phdmkvk5+crNjZWQ4YMkZeXZf9Uu4bZP5u6Hm+//bZRu3Ztw8fHx7jzzjuNLVu2mF2S03377beGpCKXIUOGmF2a0xXXtyQjNjbW7NKc7sknnzTq1Klj+Pj4GGFhYUbXrl2N1atXm12Wadzl59ePPPKIUaNGDcPHx8eoWbOm8cgjjxgHDhwwuyyXWbZsmdG0aVPD19fXaNSokTFnzhyzS3KZVatWGZKMpKQks0up8Pjv1wAAwLIseYwMAACARJABAAAWRpABAACWRZABAACWRZABAACWRZABAACWRZABAACWRZABAACWRZABUCHExMSoZcuWZpcBwGIIMgBuiGPHjum5555T3bp15evrq1q1aumhhx5y+OeuAHCj8Z+oAFy3w4cPq2PHjqpcubJmzJihZs2a6dKlS1q1apVGjRqlffv2mV0igJsUIzIArtvIkSNls9m0detW9e/fXw0bNlSTJk00btw4bdmyRZKUkpKi3r17KzAwUMHBwfrzn/+s48ePl/iY+fn5evnllxUZGSlfX1+1bNlSK1eutM8/fPiwbDabFi9erHvuuUeVKlVSixYttHnzZvsycXFxqly5slatWqXbb79dgYGBuv/++3X06FGH5/rggw90++23y8/PT40aNdK77757g18hAM5CkAFwXTIyMrRy5UqNGjVKAQEBReZXrlxZ+fn56t27tzIyMrRu3TqtWbNGBw8e1COPPFLi486cOVOvv/66XnvtNf3888/q0aOHHn74Ye3fv99huZdeeknjx49XYmKiGjZsqEcffVS5ubn2+efPn9drr72mTz75ROvXr1dKSorGjx9vn//pp59q0qRJmjp1qvbu3atXX31V//jHP/TRRx/dgFcHgNOZ/e+3AVjbDz/8YEgyFi9eXOIyq1evNjw9PY2UlBT7tN27dxuSjK1btxqGYRiTJ082WrRoYZ8fERFhTJ061eFx2rZta4wcOdIwDMM4dOiQIcn44IMPijzm3r17DcMwjNjYWEOSceDAAfsys2bNMqpXr26/Xa9ePWP+/PkOz/PKK68YHTp0KO1LAMBEjMgAuC6GYVxzmb1796pWrVqqVauWfVrjxo1VuXJl7d27t8jymZmZ+v3339WxY0eH6R07diyyfPPmze3Xa9SoIUlKS0uzT6tUqZLq1avnsEzB/HPnzumXX37RsGHDFBgYaL/885//1C+//HLNvgCYj4N9AVyXBg0ayGazmXZAr7e3t/26zWaTdPn4muLmFyxTEL6ysrIkSf/5z3/Url07h+U8PT2dUi+AG4sRGQDXpWrVqurRo4dmzZqlc+fOFZl/+vRp3X777Tpy5IiOHDlin75nzx6dPn1ajRs3LnKf4OBgRURE6Pvvv3eY/v333xe7fHlVr15dEREROnjwoOrXr+9wufXWW2/Y8wBwHkZkAFy3WbNmqWPHjrrzzjv18ssvq3nz5srNzdWaNWv03nvvac+ePWrWrJkGDRqkt956S7m5uRo5cqQ6d+6sNm3aFPuYEyZM0OTJk1WvXj21bNlSsbGxSkxM1KeffnpDa58yZYqef/55hYSE6P7771d2dra2b9+uU6dOady4cTf0uQDceAQZANetbt26+vHHHzV16lS9+OKLOnr0qMLCwtS6dWu99957stlsWrJkiZ577jndfffd8vDw0P3336+33367xMd8/vnndebMGb344otKS0tT48aNtXTpUjVo0OCG1v7UU0+pUqVKmjFjhiZMmKCAgAA1a9ZML7zwwg19HgDOYTNKc6QeAABABcQxMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLIIMgAAwLL+P5Bm3zLi0dn8AAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Appliquer les deductions CSP\n",
-        "for cell in mine_cells:\n",
-        "    board_csp.flag(*cell)\n",
-        "for cell in safe_cells:\n",
-        "    board_csp.reveal(*cell)\n",
-        "\n",
-        "# Relancer les regles simples pour propager\n",
-        "solver_rules_2 = RuleBasedSolver(board_csp)\n",
-        "iterations_2 = solver_rules_2.solve()\n",
-        "\n",
-        "total_cells = board_csp.rows * board_csp.cols\n",
-        "unknown = total_cells - len(board_csp.revealed) - len(board_csp.flagged)\n",
-        "\n",
-        "print(\"Apres application des deductions CSP + regles\")\n",
-        "print(\"=\" * 50)\n",
-        "print(f\"Cellules revelees  : {len(board_csp.revealed)}\")\n",
-        "print(f\"Drapeaux           : {len(board_csp.flagged)}\")\n",
-        "print(f\"Inconnues restantes: {unknown}\")\n",
-        "print(f\"Partie gagnee      : {board_csp.won}\")\n",
-        "\n",
-        "fig = draw_board(board_csp,\n",
-        "                 title=f\"Apres CSP + regles ({unknown} inconnues restantes)\",\n",
-        "                 show_mines=True)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-22",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004674,
-          "end_time": "2026-02-26T07:01:10.231047",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.226373",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-22"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 5. Approche 3 : extension probabiliste (~10 min)\n",
-        "\n",
-        "Quand le CSP ne determine pas toutes les cellules, il faut **choisir** une cellule a reveler. Ce choix est risque : nous pourrions toucher une mine.\n",
-        "\n",
-        "### Strategie probabiliste\n",
-        "\n",
-        "L'idee est de **compter les solutions** pour chaque cellule inconnue :\n",
-        "\n",
-        "$$P(\\text{mine}_{i,j}) = \\frac{\\text{nombre de solutions ou } C_{i,j} = 1}{\\text{nombre total de solutions}}$$\n",
-        "\n",
-        "On choisit alors la cellule avec la **plus faible probabilite de mine** pour la reveler.\n",
-        "\n",
-        "### Traitement des cellules hors frontiere\n",
-        "\n",
-        "Les cellules completement isolees (non adjacentes a une cellule revelee) ne sont pas dans le CSP. Pour elles, la probabilite est calculee a partir du nombre de mines restantes et du nombre de cellules hors frontiere :\n",
-        "\n",
-        "$$P(\\text{mine}_{\\text{isolee}}) = \\frac{\\text{mines non attribuees}}{\\text{cellules hors frontiere}}$$"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-23",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.850340Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.849943Z",
-          "iopub.status.idle": "2026-04-21T00:32:03.865401Z",
-          "shell.execute_reply": "2026-04-21T00:32:03.864178Z"
-        },
-        "papermill": {
-          "duration": 0.014599,
-          "end_time": "2026-02-26T07:01:10.250785",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.236186",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-23",
-        "outputId": "ef0aa460-f79a-45ab-d5a2-31fdb129282a",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Classe ProbabilisticSolver definie.\n"
-          ]
-        }
-      ],
-      "source": [
-        "class ProbabilisticSolver:\n",
-        "    \"\"\"Solveur combinant regles, CSP et probabilites.\n",
-        "\n",
-        "    Strategie :\n",
-        "    1. Appliquer les regles simples (gratuit et sur)\n",
-        "    2. Si bloque, resoudre le CSP pour deduire les cellules forcees\n",
-        "    3. Si toujours bloque, choisir la cellule avec la plus faible P(mine)\n",
-        "    \"\"\"\n",
-        "\n",
-        "    def __init__(self, board):\n",
-        "        self.board = board\n",
-        "        self.decisions = {'rules': 0, 'csp': 0, 'guess': 0}\n",
-        "        self.guesses_log = []  # historique des devinettes avec probabilites\n",
-        "\n",
-        "    def play_game(self, verbose=False):\n",
-        "        \"\"\"Joue une partie complete. Retourne True si gagnee.\"\"\"\n",
-        "        while not self.board.game_over and not self.board.won:\n",
-        "            # Etape 1 : regles simples\n",
-        "            rule_solver = RuleBasedSolver(self.board)\n",
-        "            rule_solver.solve()\n",
-        "            if rule_solver.moves_log:\n",
-        "                self.decisions['rules'] += len(rule_solver.moves_log)\n",
-        "                continue  # Recommencer le cycle\n",
-        "\n",
-        "            if self.board.game_over or self.board.won:\n",
-        "                break\n",
-        "\n",
-        "            # Etape 2 : CSP\n",
-        "            csp_solver = CSPSolver(self.board)\n",
-        "            safe_cells, mine_cells, solutions = csp_solver.solve()\n",
-        "\n",
-        "            if safe_cells or mine_cells:\n",
-        "                for cell in mine_cells:\n",
-        "                    self.board.flag(*cell)\n",
-        "                for cell in safe_cells:\n",
-        "                    self.board.reveal(*cell)\n",
-        "                self.decisions['csp'] += len(safe_cells) + len(mine_cells)\n",
-        "                continue  # Recommencer le cycle\n",
-        "\n",
-        "            if self.board.game_over or self.board.won:\n",
-        "                break\n",
-        "\n",
-        "            # Etape 3 : choix probabiliste\n",
-        "            best_cell, best_prob = self._choose_best_cell(csp_solver, solutions)\n",
-        "\n",
-        "            if best_cell is None:\n",
-        "                break  # Plus rien a faire\n",
-        "\n",
-        "            if verbose:\n",
-        "                print(f\"  Devinette : {best_cell} (P(mine) = {best_prob:.1%})\")\n",
-        "\n",
-        "            self.guesses_log.append((best_cell, best_prob))\n",
-        "            self.decisions['guess'] += 1\n",
-        "            self.board.reveal(*best_cell)\n",
-        "\n",
-        "        return self.board.won\n",
-        "\n",
-        "    def _choose_best_cell(self, csp_solver, solutions):\n",
-        "        \"\"\"Choisit la cellule avec la plus faible probabilite de mine.\"\"\"\n",
-        "        frontier = csp_solver.get_frontier_cells()\n",
-        "\n",
-        "        # Probabilites des cellules frontiere (via CSP)\n",
-        "        if solutions:\n",
-        "            probs = csp_solver.get_probabilities(solutions)\n",
-        "        else:\n",
-        "            probs = {}\n",
-        "\n",
-        "        # Probabilite des cellules hors frontiere\n",
-        "        all_unknown = set()\n",
-        "        for r in range(self.board.rows):\n",
-        "            for c in range(self.board.cols):\n",
-        "                if ((r, c) not in self.board.revealed and\n",
-        "                    (r, c) not in self.board.flagged):\n",
-        "                    all_unknown.add((r, c))\n",
-        "\n",
-        "        non_frontier = all_unknown - frontier\n",
-        "        if non_frontier:\n",
-        "            # Mines restantes non attribuees a la frontiere\n",
-        "            mines_in_frontier = sum(\n",
-        "                probs.get(cell, 0.5) for cell in frontier\n",
-        "            )\n",
-        "            remaining_mines = max(0, self.board.remaining_mines() - mines_in_frontier)\n",
-        "            if len(non_frontier) > 0:\n",
-        "                non_frontier_prob = remaining_mines / len(non_frontier)\n",
-        "            else:\n",
-        "                non_frontier_prob = 0\n",
-        "\n",
-        "            for cell in non_frontier:\n",
-        "                probs[cell] = non_frontier_prob\n",
-        "\n",
-        "        if not probs:\n",
-        "            return None, 1.0\n",
-        "\n",
-        "        # Choisir la cellule avec la plus faible probabilite de mine\n",
-        "        best_cell = min(probs, key=probs.get)\n",
-        "        best_prob = probs[best_cell]\n",
-        "\n",
-        "        return best_cell, best_prob\n",
-        "\n",
-        "\n",
-        "print(\"Classe ProbabilisticSolver definie.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-24",
-      "metadata": {
-        "papermill": {
-          "duration": 0.00534,
-          "end_time": "2026-02-26T07:01:10.261393",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.256053",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-24"
-      },
-      "source": [
-        "### Simulation d'une partie complete\n",
-        "\n",
-        "Jouons une partie complete avec le solveur probabiliste et observons les decisions prises."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-25",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:03.868582Z",
-          "iopub.status.busy": "2026-04-21T00:32:03.868008Z",
-          "iopub.status.idle": "2026-04-21T00:32:04.003704Z",
-          "shell.execute_reply": "2026-04-21T00:32:04.002375Z"
-        },
-        "papermill": {
-          "duration": 0.130759,
-          "end_time": "2026-02-26T07:01:10.396981",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.266222",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-25",
-        "outputId": "26b6434d-f273-414e-89d3-f8a842bbec7f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 902
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "  Devinette : (1, 0) (P(mine) = 0.0%)\n",
-            "\n",
-            "Resultat de la partie\n",
-            "==================================================\n",
-            "Issue               : VICTOIRE\n",
-            "Temps total         : 31.4 ms\n",
-            "Decisions par regles: 13\n",
-            "Decisions par CSP   : 11\n",
-            "Devinettes (guess)  : 1\n",
-            "\n",
-            "Repartition :\n",
-            "  rules   :  13 (52%)\n",
-            "  csp     :  11 (44%)\n",
-            "  guess   :   1 (4%)\n",
-            "\n",
-            "Devinettes effectuees :\n",
-            "  (1, 0) -> P(mine)=0.0% -> sure\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAR5BJREFUeJzt3Xt8VPW97vFncpkk5MItCRIChKsQFKSA6AYLKghoVS5St4IGaPfeVNRWKttjdwtBi7IPrZUqB6XapB5E6lGQgCCgkZti5WJaBElAiYkxECSQEAgZklnnD3amxCSQBGZWfqzP+/Xi5cyalZnnyy8hj2tWVlyWZVkCAAAwUJDdAQAAAJqKIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiA6DB0tPT5XK55HK5NHz4cLvjAABFBmgOzi8I5/9xu93q0KGDxo8fr02bNvk9xzvvvKPU1FSlpqYG5PUu5MyZM0pLS9Ndd92ljh07KiIiQlFRUeratauGDRum3/72t/r888/r/fif/vSnNf4uBw0adNHXLCoq0jPPPKPhw4crPj5ebrdbbdq0Ua9evXTnnXdq8eLFKiwsrPEx579GWFiYcnNzazyemprqe/yGG26o92Pr+3P+8w0fPvyi+6enp190TuCKYgGwXVpamiXpon/++Mc/+jVHSkqK77XmzJlT6/EjR45YW7dutbZu3Wr94x//8FuOXbt2Wd27d7/o38fgwYPr/PhTp05ZMTExtfb//PPP633NpUuXWtHR0Rd9zSeeeKLGx33/8ZSUlBqPz5kzp968DVnzQ4cO+fYfNmzYRfdPS0tr1N81YLqQy1mKAFweW7dulSTl5+crNTVVOTk5kqRZs2bp3nvvVXx8/GV9vVOnTikyMvKi+8XHx1/21/6+7OxsjRgxQsePH5cktWjRQj/96U918803q1WrVvruu++0a9curVixot7nWLFihUpLS2ttT09P14IFC2pt/+tf/6oHHnhA1v/8Dt0OHTroZz/7mQYMGKDQ0FAVFBToo48+uuBrVlu6dKn+1//6X+rVq1dDR5Yk/epXv9KYMWNqbW/fvn2d+48ZM0a/+tWvam3v2bNno14XMJ7dTQpA7SMy58vMzKzx2MqVKy3LsqwXXnjBGj16tJWUlGRFR0dbISEhVlxcnHXbbbdZK1asqPUanTt39j3H+vXrrdmzZ1tdunSxgoODrT/84Q8X/L/8YcOG1cpZve18y5cvt0aOHGm1bdvWCg0Nta666irrX//1X62///3vDf67GD16tO81oqOjrc8++6zO/bxer7Vr1646HxsxYoTvOaZMmeK73b59e6uysrLGvidPnrTi4uJ8+/Tt29cqLi6u83nLy8utvXv31thW19/XPffc43u8oUdkGnIk5fwjMt8/8gM4FefIAM1cq1atatz3eDySzv2f/3vvvafc3FydPHlSlZWVOnr0qDZs2KDx48fr+eefr/c5H374YT311FM6dOiQqqqqLjmj1+vVpEmT9K//+q/auHGjjh07prNnz+rw4cNavny5rr/+eq1evfqiz3P48GGtX7/ed3/mzJm67rrr6tzX5XLpBz/4Qa3t+fn5yszMlCS53W79/ve/V7du3SRJhYWFNZ5fkt59910dPXrUd3/hwoVq3bp1na8ZHh6u5OTkevNXnwPz9ttva/fu3fXuB+DyocgAzdg333yj2bNn19hW/Y09JSVFr776qtasWaNNmzZp48aNevHFFxUWFibp3EmmlZWVdT7vgQMHNHXqVK1Zs0Zvvvmm+vfvr61bt9Z4a2Pq1KnaunWrtm7dqhdeeOGCOV9++WUtW7ZMkhQbG6tFixZp48aN+vWvfy2Xy6WKigo98MADvreL6rN7927f2zuSNHr0aN/tyspKbdu2rdafEydO1HiO1157TV6vV9K5t1/atGmjSZMm+R7//smwu3bt8t1u0aKFfvjDH/ruHzt2rM7XPD/j+R577DG1bdtWlmXp17/+9QVn/b6pU6fWOnG3vhInSX/5y1/qPNn3+38fwJWOc2SAZsjlctW5PSUlxXcOxI9+9CPNnz9fH3zwgfLy8lReXl5j35KSEn3xxRe69tpraz3P+PHj9ec//7nW9vPPf+nUqZOGDh3aoLyvvvqq7/bUqVPVt29fSdKoUaP07rvv6rPPPlNJSYnefPNN/cd//Ee9z/P9ohMbG+u7feLECd100021PmbdunU1Cs9rr73muz158mTff5966ilJUkZGho4fP+476nL+a7Zu3VpBQf/8/7sPP/xQEydOrPWa5eXlCg8Pr7U9JiZGTzzxhP7zP/9T69at07Zt2+qdFcDlQZEBDBAXF6cZM2b4Tu48fPiwBg4cqKKiogt+XH1HQCZMmHBZ8+3bt893e8GCBXWeUCvpgj8uLdV+G+3YsWPq3r17g3N8/PHHvhOjY2Ji9KMf/UiS1KNHDw0aNEg7duxQRUWFli9frp/97Ge1XvP48ePyer01ykxjPfzww/rDH/6gwsJC/dd//ZduvvnmBn1cXSf7RkVF1bt/fSf7RkdHNy4wYDiKDNAMVf/UUmhoqOLi4tSlS5caR2n+/Oc/+0pMu3bt9Mwzz6h79+4KCgrSuHHj9N1330mS7y2W76vvJ2H8rays7IKP/+AHP5DL5fK9dbNx40YNHjxY0rmjM9Xb6ztidf7bRqWlpYqIiKh3v+oiM2DAAN/206dP6+OPP/YdibrnnntkWZY2bdrU4EISERGhX//615oxY4a2bNmis2fPNujjevTo0eAjYNK5o2eN2R+4UnGODNAMDR06VEOHDtXgwYPVtWvXWt+48/LyfLcnT56sadOm6Yc//KE6deqkY8eOXfT56ysC5x+JqK8E1aV3796+2y+//LIsy6r1p6KiQkuWLLng87Rv31633Xab7/7vf/977d+/v0EZzpw5ozfffLNB+3766ae+573jjjtqvIX12GOPXbRwXcy//du/qUuXLpKk7du3X9JzAbgwjsgABuratavv9ltvvaUbb7xRXq9Xc+fOrfdE1IZo27at7/batWs1dOhQtWjRQp07d1bHjh3r/bif/OQnvp/S+eUvf6mjR49q0KBB8ng8ys/P186dO5WRkaEdO3YoKSnpghn+8Ic/6MYbb1RJSYlOnDihwYMH66GHHtJNN92kiIgIff3113V+3MqVK1VSUiLp3Ftx1efEnG/JkiX67LPPJJ07KjN//nxFR0fr+eef951Ps3PnTl133XWaMWOG7/yitWvXXjDz94WGhio1NVUpKSkN/pgDBw7UeU5NcnKy2rRpU2t7UVFRnft36NDBV6IAR7Dnp74BnO9C15GpS2FhodW6deta1y9JTk624uPjffc//PBD38ecfx2Z87efb/369XVeF+Xpp5+ulfP868hUVVVZ9913X6OuUnshn3zyidWpU6cGXfn2gw8+sCzLsm677Tbftv/4j/+o83lffPFF3z4JCQk1rinz6quvWi1atLjo64WEhFhnzpzxfdz5j61bt67G30nv3r1rPN6UK/tWXzfIshp2Zd+f//znDfo7Bq4UvLUEGOiqq67Spk2bNGLECMXExKht27aaPHmyPvzww3rPC2mI2267Tc8995y6deum4ODgBn9cUFCQli1bpjfffFOjR49WXFycQkJCFBsbq759+2r69Olau3btBY/qnG/w4MH64osvtGjRIt1222266qqrFBoaqvDwcCUmJmrEiBGaO3euPv/8c91yyy0qKCjQ+++/7/v4+k5mHjdunO9ttW+//VYbN270PTZt2jQdOHBAv/nNb3TDDTeodevWCg4OVmRkpHr06KFx48bphRde0DfffOP7EfeL/Z08/fTTDZoXQNO5LOsSjkMDAADYiCMyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGMvrKvl6vV99++62io6PrveQ6AAAwj2VZOnnypBISEi74i1yNLjLffvttgy+wBQAAzJOfn6/ExMR6Hze6yFT/uvqlS5eqU6dONqcJrIMHD2rLli266667avzCOyeonv2Bvn3VLirK7jgBte/oUa09cMDRs/M578x1d/LsTvycl879ctzJkyf7vtfXx+giU/12UqdOndSzZ0+b0wRWeXm53G63kpKSlJCQYHecgKqevXtcnDq1amV3nIAqq6py/Ox8zreyO05A8TnvzM/5813s1BFO9gUAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYIXYHgBkyMsK0bZtbWVmh2r8/RB6Py/fY4cNHbEwG+EdhWaHWf71e27/druzj2So6XaRST6li3DHq07aPJvacqIk9J8rlcl38yQADmPrvPEUGDbJwYaT27g21O4ZtPlq2TNvfeKPex8MiI/XI8uUBTBQ4Tp39rQNvad7f5tXaXnymWFsLtmprwVat+WqN0kalKTgo2IaE/uXUdZecO7up/85TZNAgLpeUlFSpfv0qVVQUpO3b3XZHAgIivkW8bu10qzpHd1b+yXy9feBtnak6I0na8PUGLc9erkm9J9mcErh0pv47T5FBg6xeXayIiHO3FyyINOYT3B+6DBigwRMn1tgWFHzl/R95XZw0e4eoDnrxlhc1tvtYhQT985/KcT3G6Z7V9/juZ+ZlXvFFxknr/n1Omt3Uf+cpMmiQ6k9uSC1atlRinz52x7CFk2Yf32N8nduHdhiqNuFtVHymWJLk8XoCGcsWTlr373PS7Kb+O89PLQFAI1Sf9Futf3x/G9MA4IgM0Eh7MzO1NzOzxrY+t9yiMY89ZlOiwHHy7JJU6a3U45sfV6W3UpIUGxGrB5MftDmV/zl53Z08uyk4IgMADVDmKdOD6x7Uhq83SJKiQqP02ujXFBsRa3MywNk4IgM0Ul0n/0W2bm1TmsBy6uwFZQV6YN0D2ndsnySpbXhbLb19qWPeVnLqukvOnt0UFBmgkZx08t/3OXH2rKIspbyXoiOnz10QrFvLbnr99teV1DLJ3mAB5MR1r+bk2U3BW0sAUI+1h9ZqXMY4X4m5of0NWjNujaNKDNDccUQGDZKeHqHc3HPXTti5s+aVH1NTo3y3p0wpV1JSVUCzAf6Q8WWGpr8/XV7LK0mKccdoeOJwvbG/5hVfY9wxmpw82Y6IwGVl6r/zFBk0yKpV4fVeHOmllyJ9t0eOrGhWn+BAU2UXZ/tKjCSVeko1f8f8WvslRiVSZHBFMPXfed5aAgAAxuKIDBpk5crjdkew1ZD779eQ+++3O4YtnDr7rEGzNGvQLLtj2Map6y45d3ZT/53niAwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjNYsis2jRIiUlJSk8PFyDBw/Wp59+anckAABgANuLzF//+lfNnDlTc+bM0e7du9WvXz+NGjVKRUVFdkcDAADNnO1F5rnnntO//du/aerUqUpOTtZLL72kFi1a6M9//rPd0QAAQDMXYueLezwe7dq1S08++aRvW1BQkEaMGKHt27fX2r+iokIVFRW++6WlpZKkgwcPqry83P+Bm5G8vDxJUk5Ojo4ePWpzmsCqnn1PUZEKy8psThNYB4uLJTl7dj7nnbnuTp7diZ/zklRQUNCg/WwtMt99952qqqrUrl27GtvbtWun/fv319r/2Wef1dy5c2tt37Jli9xut99yNlcul0uZmZl2x7CFy+VSRna23TFs4fTZ+Zx3HqfP7tTPeY/H06D9bC0yjfXkk09q5syZvvulpaXq2LGj7rrrLiUlJdkXzAY5OTnKzMzUhAkTFBcXZ3ecgGJ2Zmd252B2Z84uSbm5uUpPT7/ofrYWmdjYWAUHB+vIkSM1th85ckRXXXVVrf3DwsIUFhZW5/MkJCT4LWdzVH2YMS4ujtkdhNmZndmdw8mzS1JZA99KtPVkX7fbrQEDBuiDDz7wbfN6vfrggw9044032pgMAACYwPa3lmbOnKmUlBQNHDhQ119/vZ5//nmdOnVKU6dOtTsaAABo5mwvMvfee6+OHj2q2bNn6/Dhw7ruuuv03nvv1ToBGAAA4PtsLzKS9PDDD+vhhx+2OwYAADCM7RfEAwAAaCqKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYIXYHMElGRpi2bXMrKytU+/eHyONx+R47fPiIjcn8q7CsUOu/Xq/t325X9vFsFZ0uUqmnVDHuGPVp20cTe07UxJ4T5XK5Lv5kpjlzRlHPPaeQv/9dIV9+Kdfx43JVVMiKiVFl167yjBih09OmyYqJsTupXzh57Zmd2Z02u6nf4ygyjbBwYaT27g21O0bAvXXgLc3727xa24vPFGtrwVZtLdiqNV+tUdqoNAUHBduQ0H9cp04p8o9/rL29uFju4mK5d+5U+PLlKl63Tlbr1jYk9C8nrz2zM/v5nDC7qd/jKDKN4HJJSUmV6tevUkVFQdq+3W13pICKbxGvWzvdqs7RnZV/Ml9vH3hbZ6rOSJI2fL1By7OXa1LvSTanvPyq2rfX2YEDVZWYKG/r1go6dkzh776r4G++kSSF5OYqYulSnX7kEZuT+o9T115idmZ3zuymfo+jyDTC6tXFiog4d3vBgkhjFvlSdYjqoBdveVFju49VSNA/P2XG9Rine1bf47ufmZd5xX1hW23b6rvPPqu1/fT06Yrr3993Pzg/P5CxAsbJa8/szO602U39HkeRaYTqBXaa8T3G17l9aIehahPeRsVniiVJHq8nkLHsUVWloKIiRSxdWmNz5dVX2xTIv5y89sxeG7Nf2bOb+j2OIoMmqz4Jrlr/+P4X2Nts7i1b1PrHP67zMc8NN6h80pX1f2YX46S1/z5mZ3bJWbM3d/z4NZqk0lupxzc/rkpvpSQpNiJWDyY/aHOqwCsfP14nXn9dCg+3O0rAOHntmZ3ZJWfNbgKOyKDRyjxl+veN/67M/ExJUlRolF4b/ZpiI2JtTuY/lV276uTs2XJ5PAr65huFr12roOJiRaxYodA9e3R82TJ5O3a0O6bfOXHtqzE7s0vOmt0UFBk0SkFZgR5Y94D2HdsnSWob3lZLb196xR9m9SYm6vRDD/nulz3xhNqOGKHgI0cUcuCAomfPVklamo0J/c+pay8xO7M7b3aTUGTQYFlFWUp5L0VHTp+7MFK3lt30+u2vK6llkr3BbGDFxensgAEKXrtWkuT++GObE/mXk9ee2ZldctbspuEcGTTI2kNrNS5jnO+L+ob2N2jNuDVX/Bd16LZtcpWV1druOnZMobt3n7fhyrvKZzWnrr3E7MzuvNlNxBGZRkhPj1Bu7rkrOe7cWfPqh6mpUb7bU6aUKympKqDZ/CnjywxNf3+6vJZXkhTjjtHwxOF6Y/8bNfaLccdocvJkOyL6TYtXXlHY5s3y3HSTziYny4qIUHBhocLefVfBR4/69qsYMcLGlP7j5LVndmaXnDW7qd/jKDKNsGpVeL0XCHrppUjf7ZEjK5rVIl+q7OJs3xe1JJV6SjV/x/xa+yVGJV5xX9iS5CovV9iGDQrbsKHOx89ec41OpqYGNlSAOHntmZ3ZJWfNbur3OIoMcAHlU6fKGx+v0N27FXT4sIJOnJBCQuSNjVVlcrLOjBmjM/fcI4Wa9/tJAOBKQJFphJUrj9sdwRazBs3SrEGz7I5hC8+wYfIMG2Z3DNs4ee2ZndmdxtTvcZzsCwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFi2FpktW7bozjvvVEJCglwul9555x074wAAAMPYWmROnTqlfv36adGiRXbGAAAAhgqx88XHjBmjMWPG2BkBAAAYzNYi01gVFRWqqKjw3S8tLZUkHTx4UOXl5XbFskVeXp4kKScnR0ePHrU5TWAxO7Mzu3MwuzNnl6SCgoIG7eeyLMvyc5YGcblcWrlypcaOHVvvPqmpqZo7d26t7VOmTJHb7fZjuubJJalZLJ4NXC6XmsmnbsAxO7M7DbM7c3aPx6P09HSVlJQoJiam3v2MKjJ1HZHp2LGjVqxYoaSkJP+HbEZycnKUmZmpaf37q31UlN1xAmpPUZEysrM1YcIExcXF2R0noKrXndmZ3SmY3ZmzS1Jubq7Gjx9/0SJj1FtLYWFhCgsLq7U9NjZWCQkJNiSyT/VhxvZRUerUqpW9YQKssKxMkhQXF+fYdWd2ZncKZnfm7JJU9j//1l8M15EBAADGsvWITFlZmQ4ePOi7f+jQIWVlZalNmzbq1KmTjckAAIAJbC0yO3fu1M033+y7P3PmTElSSkqK0tPTbUoFAABMYWuRGT58uGPPxgYAAJeOc2QAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY4XYHcAUhWWFWv/1em3/druyj2er6HSRSj2linHHqE/bPprYc6Im9pwol8tld1RcRk5f94yMMG3b5lZWVqj27w+Rx/PPOQ8fPmJjMgA4hyLTQG8deEvz/jav1vbiM8XaWrBVWwu2as1Xa5Q2Kk3BQcE2JPS/j5Yt0/Y33qj38bDISD2yfHkAE/mf09d94cJI7d0bancMAKgXRaaR4lvE69ZOt6pzdGfln8zX2wfe1pmqM5KkDV9v0PLs5ZrUe5LNKXG5OXXdXS4pKalS/fpVqqgoSNu3u+2OBAA1UGQaqENUB714y4sa232sQoL++dc2rsc43bP6Ht/9zLzMK/Ib2vd1GTBAgydOrLEtKPjKOyLh9HVfvbpYERHnbi9YEEmRAdDsUGQaaHyP8XVuH9phqNqEt1HxmWJJksfrCWQs27Ro2VKJffrYHcPvnL7u1SUGAJorfmrpElWf/Fmtf3x/G9MgUFh3AGgeOCJzCSq9lXp88+Oq9FZKkmIjYvVg8oM2pwqMvZmZ2puZWWNbn1tu0ZjHHrMpUeA4ed0BoLnhiEwTlXnK9OC6B7Xh6w2SpKjQKL02+jXFRsTanAz+xLoDQPPCEZkmKCgr0APrHtC+Y/skSW3D22rp7Usd9fZCXSf7RrZubVOawGDdAaD5ocg0UlZRllLeS9GR0+cuBtatZTe9fvvrSmqZZG+wAHPKyb7VWHcAaJ54a6kR1h5aq3EZ43zfzG5of4PWjFvDN7MrHOsOAM0XR2QaKOPLDE1/f7q8lleSFOOO0fDE4Xpjf80r3ca4YzQ5ebIdEeEHTl/39PQI5eaeuz7Qzp01r/Cbmhrluz1lSrmSkqoCmg0AJIpMg2UXZ/u+mUlSqadU83fMr7VfYlTiFfkNzamcvu6rVoXXexG8l16K9N0eObKCIgPAFry1BAAAjMURmQaaNWiWZg2aZXcMWw25/34Nuf9+u2MElNPXfeXK43ZHAIAL4ogMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY9laZJ599lkNGjRI0dHRio+P19ixY5WdnW1nJAAAYBBbi8zmzZs1Y8YMffLJJ9q4caPOnj2r2267TadOnbIzFgAAMESInS/+3nvv1bifnp6u+Ph47dq1Sz/84Q9tSgUAAExha5H5vpKSEklSmzZt6ny8oqJCFRUVvvulpaWSpIMHD6q8vNz/AZuRvLw8SdKeoiIVlpXZnCawDhYXS5JycnJ09OhRm9MEVvW6MzuzOwWzO3N2SSooKGjQfi7Lsiw/Z2kQr9eru+66SydOnNC2bdvq3Cc1NVVz586ttX3KlClyu93+jtjsuFwuNZPlCziXJGdO7vB1Z3a7Y9iC2Z05u8fjUXp6ukpKShQTE1Pvfs2myPzsZz/TunXrtG3bNiUmJta5T11HZDp27KgPnntO3ePiAhW1WdhTVKSM7GxNmDBBcQ6bPScnR5mZmZrWv7/aR0XZHSegWPdMZmd2x3Dy7JKUm5ur8ePHX7TINIu3lh5++GGtWbNGW7ZsqbfESFJYWJjCwsJqbW8XFaVOrVr5MWHzU/12UlxcnBISEmxOE1jVh1jbs+42pwms6nVndmZ3CifPLkllDTxtwtYiY1mWHnnkEa1cuVKbNm1Sly5d7IwDAAAMY2uRmTFjhpYtW6ZVq1YpOjpahw8fliS1bNlSERERdkYDAAAGsPU6MosXL1ZJSYmGDx+u9u3b+/789a9/tTMWAAAwhO1vLQEAADQVv2sJAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGCvE7gAm+WjZMm1/4416Hw+LjNQjy5cHMFGAnDmjqOeeU8jf/66QL7+U6/hxuSoqZMXEqLJrV3lGjNDpadNkxcTYndRvnLr2GRlh2rbNraysUO3fHyKPx+V77PDhIzYmA4BzKDK4KNepU4r84x9rby8ulru4WO6dOxW+fLmK162T1bq1DQnhLwsXRmrv3lC7YwBAvSgyTdRlwAANnjixxrag4GCb0vhfVfv2OjtwoKoSE+Vt3VpBx44p/N13FfzNN5KkkNxcRSxdqtOPPGJzUv9z0tq7XFJSUqX69atUUVGQtm932x0JAGqgyDRRi5Ytldinj90xAsJq21bfffZZre2np09XXP/+vvvB+fmBjGUbJ6396tXFiog4d3vBgkiKDIBmhyKDxquqUlBRkSKWLq2xufLqq20KBH+pLjEA0FxRZJpob2am9mZm1tjW55ZbNOaxx2xK5H/uLVvU+sc/rvMxzw03qHzSpAAnsocT1x4Amit+/BqXrHz8eJ14/XUpPNzuKAAAh+GITBPVdcJn5BX+EzuVXbvq5OzZcnk8CvrmG4WvXaug4mJFrFih0D17dHzZMnk7drQ7pt85ce0BoLmiyDSRk074rOZNTNTphx7y3S974gm1HTFCwUeOKOTAAUXPnq2StDQbEwaGE9ceAJor3lpCk1lxcTo7YIDvvvvjj21MAwBwIooMLip02za5yspqbXcdO6bQ3bvP2+CqtQ8AAP7EW0u4qBavvKKwzZvluekmnU1OlhURoeDCQoW9+66Cjx717VcxYoSNKeEP6ekRys09d7G/nTtrXuE3NTXKd3vKlHIlJVUFNBsASBQZNJCrvFxhGzYobMOGOh8/e801OpmaGthQ8LtVq8LrvQjeSy9F+m6PHFlBkQFgC4pMIwy5/34Nuf9+u2MEXPnUqfLGxyt0924FHT6soBMnpJAQeWNjVZmcrDNjxujMPfdIoVfu7+Rx6toDQHNHkcFFeYYNk2fYMLtjwAYrVx63OwIAXBAn+wIAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxrrkInPmzJnLkQMAAKDRmlRkvF6vnn76aXXo0EFRUVH66quvJEm/+c1v9Oqrr17WgAAAAPVpUpH57W9/q/T0dP3v//2/5Xb/8xfKXXPNNXrllVcuWzgAAIALaVKRee2117RkyRJNmjRJwcHBvu39+vXT/v37L1s4AACAC2lSkSkoKFD37t1rbfd6vTp79uwlhwIAAGiIJhWZ5ORkbd26tdb2t956S/3797/kUAAAAA0R0pQPmj17tlJSUlRQUCCv16sVK1YoOztbr732mtasWXO5MwIAANSpSUdk7r77bq1evVrvv/++IiMjNXv2bH3xxRdavXq1Ro4cebkzAgAA1KlJR2Qk6aabbtLGjRsvZxYAAIBGaXKRkSSPx6OioiJ5vd4a2zt16nRJoQAAABqiSUXmwIEDmjZtmj7++OMa2y3LksvlUlVV1WUJBwAAcCFNKjJTpkxRSEiI1qxZo/bt28vlcl3uXAAAABfVpCKTlZWlXbt2qVevXpf04osXL9bixYuVm5srSerTp49mz56tMWPGXNLzAgAAZ2jydWS+++67S37xxMREzZ8/X7t27dLOnTt1yy236O6779bevXsv+bkBAMCVr0lF5r//+7/1n//5n9q0aZOOHTum0tLSGn8a6s4779Ttt9+uHj16qGfPnpo3b56ioqL0ySefNCUWAABwmCa9tTRixAhJ0q233lpj+6Wc7FtVVaX/9//+n06dOqUbb7yxKbEAAIDDNKnIfPjhh5ctwJ49e3TjjTfqzJkzioqK0sqVK5WcnFznvhUVFaqoqPDdrz76s+/oUZU57CelDhYXS5JycnJ09OhRm9MEVl5eniRpT1GRCsvKbE4TWKw7szO7czh5dunc73VsCJdlWZafs1yQx+NRXl6eSkpK9NZbb+mVV17R5s2b6ywzqampmjt3bq3tU6ZMkdvtDkTcZsXlcsnm5bMNszO70zA7szuNx+NRenq6SkpKFBMTU+9+TSoy//jHP+p+MpdL4eHh6tSpk8LCwhr7tJLOvW3VrVs3vfzyy7Ueq+uITMeOHbVixQolJSU16fVMlZOTo8zMTE2YMEFxcXF2xwkoZmd2ZncOZnfm7JKUm5ur8ePHX7TINOmtpeuuu+6C144JDQ3Vvffeq5dfflnh4eGNem6v11ujrJwvLCyszoIUGxurhISERr2O6aoPM8bFxTG7gzA7szO7czh5dkkqa+CpA036qaWVK1eqR48eWrJkibKyspSVlaUlS5bo6quv1rJly/Tqq68qMzNTv/71ry/4PE8++aS2bNmi3Nxc7dmzR08++aQ2bdqkSZMmNSUWAABwmCYdkZk3b54WLlyoUaNG+bZde+21SkxM1G9+8xt9+umnioyM1C9/+Uv97ne/q/d5ioqK9OCDD6qwsFAtW7ZU3759tX79en6DNgAAaJAmFZk9e/aoc+fOtbZ37txZe/bskXTu7afCwsILPs+rr77alJcHAACQ1MS3lnr16qX58+fL4/H4tp09e1bz58/3/dqCgoICtWvX7vKkBAAAqEOTjsgsWrRId911lxITE9W3b19J547SVFVVac2aNZKkr776Sg899NDlSwoAAPA9TSoy//Iv/6JDhw7p9ddfV05OjiRp4sSJuv/++xUdHS1JeuCBBy5fSgAAgDo0qchIUnR0tKZPn345swAAADRKg4tMRkaGxowZo9DQUGVkZFxw37vuuuuSgwEAAFxMg4vM2LFjdfjwYcXHx2vs2LH17tfUXxoJAADQWA0uMl6vt87b58vPz9dTTz116akAAAAaoEk/fl2f4uJi/fnPf76cTwkAAFCvy1pkAAAAAokiAwAAjEWRAQAAxmrUdWTGjx9/wcdPnDhxKVkAAAAapVFFpmXLlhd9/MEHH7ykQAAAAA3VqCKTlpbmrxwAAACNxjkyAADAWBQZAABgLIoMAAAwVpN/+7XTFJYVav3X67X92+3KPp6totNFKvWUKsYdoz5t+2hiz4ma2HOiXC6X3VEvvzNnFPXccwr5+98V8uWXch0/LldFhayYGFV27SrPiBE6PW2arJgYu5P6RUZGmLZtcysrK1T794fI4/nnGh8+fMTGZP7n5NkBmIEi00BvHXhL8/42r9b24jPF2lqwVVsLtmrNV2uUNipNwUHBNiT0H9epU4r84x9rby8ulru4WO6dOxW+fLmK162T1bq1DQn9a+HCSO3dG2p3DFs4eXYAZqDINFJ8i3jd2ulWdY7urPyT+Xr7wNs6U3VGkrTh6w1anr1ck3pPsjnl5VfVvr3ODhyoqsREeVu3VtCxYwp/910Ff/ONJCkkN1cRS5fq9COP2Jz08nO5pKSkSvXrV6mioiBt3+62O1LAOHl2AGagyDRQh6gOevGWFzW2+1iFBP3zr21cj3G6Z/U9vvuZeZlXXJGx2rbVd599Vmv76enTFde/v+9+cH5+IGMFzOrVxYqIOHd7wYJIR30zd/LsAMxAkWmg8T3qvqrx0A5D1Sa8jYrPFEuSPF5PIGPZo6pKQUVFili6tMbmyquvtimQf1V/I3ciJ88OwAwUmUtUfdJvtf7x/S+wt9ncW7ao9Y9/XOdjnhtuUPmkK+tIFACg+ePHry9BpbdSj29+XJXeSklSbESsHkx23q9oKB8/Xidef10KD7c7CgDAYTgi00RlnjL9+8Z/V2Z+piQpKjRKr41+TbERsTYn85/Krl11cvZsuTweBX3zjcLXrlVQcbEiVqxQ6J49Or5smbwdO9odEwDgIBSZJigoK9AD6x7QvmP7JEltw9tq6e1Lr+i3lSTJm5io0w895Ltf9sQTajtihIKPHFHIgQOKnj1bJfw+LgBAAPHWUiNlFWXp9hW3+0pMt5bd9O64d6/4ElMXKy5OZwcM8N13f/yxjWkAAE5EkWmEtYfWalzGOB05fe6Kpje0v0Frxq1RUsske4P5Wei2bXKVldXa7jp2TKG7d5+34Qq8qjEAoFnjraUGyvgyQ9Pfny6v5ZUkxbhjNDxxuN7Y/0aN/WLcMZqcPNmOiH7T4pVXFLZ5szw33aSzycmyIiIUXFiosHffVfDRo779KkaMsDGl/6SnRyg399zVmnfurHmV29TUKN/tKVPKlZRUFdBs/ubk2QGYgSLTQNnF2b4SI0mlnlLN3zG/1n6JUYlXXJGRJFd5ucI2bFDYhg11Pn72mmt0MjU1sKECZNWq8HovBPfSS5G+2yNHVlxx38ydPDsAM1BkcFHlU6fKGx+v0N27FXT4sIJOnJBCQuSNjVVlcrLOjBmjM/fcI4XyO3kAAIFFkWmgWYNmadagWXbHsIVn2DB5hg2zO4ZtVq48bncE2zh5dgBm4GRfAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjNVsisz8+fPlcrn0i1/8wu4oAADAEM2iyOzYsUMvv/yy+vbta3cUAABgENuLTFlZmSZNmqQ//elPat26td1xAACAQWwvMjNmzNAdd9yhESNG2B0FAAAYJsTOF1++fLl2796tHTt2NGj/iooKVVRU+O6XlpZKkg4ePKjy8nK/ZGyu8vLyJEk5OTk6evSozWkCi9mZndmdg9mdObskFRQUNGg/l2VZlp+z1Ck/P18DBw7Uxo0bfefGDB8+XNddd52ef/75Oj8mNTVVc+fOrbV9ypQpcrvd/ozbLLlcLtm0fLZjdmZ3GmZndqfxeDxKT09XSUmJYmJi6t3PtiLzzjvvaNy4cQoODvZtq6qqksvlUlBQkCoqKmo8JtV9RKZjx4764Lnn1D0uLmDZm4M9RUXKyM7WhAkTFOew2XNycpSZmcnszO4YzM7sTptdknJzczV+/PiLFhnb3lq69dZbtWfPnhrbpk6dql69eumJJ56oVWIkKSwsTGFhYbW2t4uKUqdWrfwVtVkqLCuTJMXFxSkhIcHmNIFVfYiV2ZndKZid2Z02u3Tuh4EawrYiEx0drWuuuabGtsjISLVt27bWdgAAgLrY/lNLAAAATWXrTy1936ZNm+yOAAAADMIRGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGCsELsDmOSjZcu0/Y036n08LDJSjyxfHsBEgZOREaZt29zKygrV/v0h8nhcvscOHz5iYzIAgJNRZNAgCxdGau/eULtjAABQA0WmiboMGKDBEyfW2BYUHGxTGv9zuaSkpEr161epoqIgbd/utjsSAAAUmaZq0bKlEvv0sTtGwKxeXayIiHO3FyyIpMgAAJoFTvZFg1SXGAAAmhOOyDTR3sxM7c3MrLGtzy23aMxjj9mUCAAA5+GIDAAAMBZHZJqorpN9I1u3tikNAADORJFpIqed7AsAQHPEW0sAAMBYFBkAAGAs3lpCg6SnRyg399wF/3burHmF39TUKN/tKVPKlZRUFdBsAADnosigQVatCq/3IngvvRTpuz1yZAVFBgAQMBSZRhhy//0acv/9dscAAAD/gyKDBlm58rjdEQAAqIWTfQEAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADCWrUUmNTVVLperxp9evXrZGQkAABgkxO4Affr00fvvv++7HxJieyQAAGAI21tDSEiIrrrqKrtjAAAAA9l+jsyBAweUkJCgrl27atKkScrLy7M7EgAAMIStR2QGDx6s9PR0XX311SosLNTcuXN100036fPPP1d0dHSt/SsqKlRRUeG7X1paKknad/SoyqqqApa7OThYXCxJysnJ0dGjR21OE1jVZZfZmd0pmJ3ZnTa7JBUUFDRoP5dlWZafszTYiRMn1LlzZz333HP6yU9+Uuvx1NRUzZ07t9b2KVOmyO12ByJis+JyudSMli+gmJ3ZnYbZmd1pPB6P0tPTVVJSopiYmHr3a1ZFRpIGDRqkESNG6Nlnn631WF1HZDp27KgVK1YoKSkpgCntl5OTo8zMTE2YMEFxcXF2xwkoZmd2ZncOZnfm7JKUm5ur8ePHX7TI2H6y7/nKysr05Zdf6oEHHqjz8bCwMIWFhdXaHhsbq4SEBH/Ha1aqDzPGxcUxu4MwO7Mzu3M4eXbpXCdoCFtP9n388ce1efNm5ebm6uOPP9a4ceMUHBys++67z85YAADAELYekfnmm29033336dixY4qLi9PQoUP1ySefOPIQGgAAaDxbi8zy5cvtfHkAAGA4268jAwAA0FQUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYIXYHMElGRpi2bXMrKytU+/eHyONx+R47fPiIjcn8q7CsUOu/Xq/t325X9vFsFZ0uUqmnVDHuGPVp20cTe07UxJ4T5XK5Lv5kBnLqukvOnt3JnLzuzG7e7BSZRli4MFJ794baHSPg3jrwlub9bV6t7cVnirW1YKu2FmzVmq/WKG1UmoKDgm1I6F9OXXfJ2bM7mZPXndnNm50i0wgul5SUVKl+/SpVVBSk7dvddkcKqPgW8bq1063qHN1Z+Sfz9faBt3Wm6owkacPXG7Q8e7km9Z5kc8rLz8nr7uTZnczJ687s5s1OkWmE1auLFRFx7vaCBZHGLPKl6hDVQS/e8qLGdh+rkKB/fsqM6zFO96y+x3c/My/ziiwyTl13ydmzO5mT153Zz902aXaKTCNUL7DTjO8xvs7tQzsMVZvwNio+UyxJ8ng9gYwVME5dd8nZszuZk9ed2c3DTy2hyapP+q3WP76/jWkAAE5EkUGTVHor9fjmx1XprZQkxUbE6sHkB21OBQBwGooMGq3MU6YH1z2oDV9vkCRFhUbptdGvKTYi1uZkAACn4RwZNEpBWYEeWPeA9h3bJ0lqG95WS29fyttKAABbUGTQYFlFWUp5L0VHTp+7MFK3lt30+u2vK6llkr3BAACOxVtLaJC1h9ZqXMY4X4m5of0NWjNuDSUGAGArjsg0Qnp6hHJzz125dufOmlc/TE2N8t2eMqVcSUlVAc3mTxlfZmj6+9PltbySpBh3jIYnDtcb+9+osV+MO0aTkyfbEdGvnLrukrNndzInrzuzmzc7RaYRVq0Kr/cCQS+9FOm7PXJkRbNa5EuVXZztKzGSVOop1fwd82vtlxiVeEUWGaeuu+Ts2Z3MyevO7ObNzltLAADAWByRaYSVK4/bHcEWswbN0qxBs+yOYRunrrvk7NmdzMnrzuzm4YgMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxrK9yBQUFGjy5Mlq27atIiIidO2112rnzp12xwIAAAYIsfPFjx8/riFDhujmm2/WunXrFBcXpwMHDqh169Z2xgIAAIawtcj893//tzp27Ki0tDTfti5dutiYCAAAmMTWt5YyMjI0cOBATZw4UfHx8erfv7/+9Kc/2RkJAAAYxNYjMl999ZUWL16smTNn6le/+pV27NihRx99VG63WykpKbX2r6ioUEVFhe9+aWmpJOngwYMqLy8PWO7mIC8vT5KUk5Ojo0eP2pwmsJid2ZndOZjdmbNL586hbQiXZVmWn7PUy+12a+DAgfr444992x599FHt2LFD27dvr7V/amqq5s6dW2v7lClT5Ha7/Zq1OXK5XLJx+WzlkuTMyR2+7sxudwxb8PXuzOk9Ho/S09NVUlKimJiYevez9YhM+/btlZycXGNb79699fbbb9e5/5NPPqmZM2f67peWlqpjx4666667lJSU5M+ozU5OTo4yMzM1YcIExcXF2R0noKpnn9a/v9pHRdkdJ6D2FBUpIzvb0evO7M6cna93Z627JOXm5io9Pf2i+9laZIYMGaLs7Owa23JyctS5c+c69w8LC1NYWFit7bGxsUpISPBLxuaq+jBjXFycY2dvHxWlTq1a2RsmwArLyiQ5e92Z3Zmz8/XurHWXpLL/mf9ibD3Z97HHHtMnn3yiZ555RgcPHtSyZcu0ZMkSzZgxw85YAADAELYWmUGDBmnlypV64403dM011+jpp5/W888/r0mTJtkZCwAAGMLWt5Yk6Uc/+pF+9KMf2R0DAAAYyPZfUQAAANBUFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWCF2B4AZMjLCtG2bW1lZodq/P0Qej8v32OHDR2xMFhgfLVum7W+8Ue/jYZGRemT58gAmCgynr7tTOX3d+Xo3a90pMmiQhQsjtXdvqN0xEGCsuzOx7s5k6rpTZNAgLpeUlFSpfv0qVVQUpO3b3XZHsk2XAQM0eOLEGtuCgoNtSuNfrLszse7/xNd780eRQYOsXl2siIhztxcsiDTmE9wfWrRsqcQ+feyOERCsuzOx7v/E13vzx8m+aJDqT244C+vuTKy7M5m67hyRARppb2am9mZm1tjW55ZbNOaxx2xKBMBf+Hpv/jgiAwAAjMURGaCR6jr5L7J1a5vSAPAnvt6bP4oM0EhOOvkPcDq+3ps/3loCAADGosgAAABj8dYSGiQ9PUK5uecuArVzZ80rP6amRvluT5lSrqSkqoBmg/+w7s7EujuTqetOkUGDrFoVXu/FkV56KdJ3e+TIimb1CY5Lw7o7E+vuTKauO0UGaIAh99+vIfffb3cMAAHA17tZKDJokJUrj9sdATZg3Z2JdXcmU9edk30BAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwlq1FJikpSS6Xq9afGTNm2BkLAAAYIsTOF9+xY4eqqqp89z///HONHDlSEydOtDEVAAAwha1FJi4ursb9+fPnq1u3bho2bJhNiQAAgEmazTkyHo9HS5cu1bRp0+RyueyOAwAADGDrEZnzvfPOOzpx4oSmTJlS7z4VFRWqqKjw3S8pKZEk5eXl+Ttes1NQUCCPx6Pc3FyVlZXZHSegqmc/ePSoTpaX2x0noPKKix2/7szuzNn5enfWukv//N5uWdYF93NZF9sjQEaNGiW3263Vq1fXu09qaqrmzp0bwFQAAMBO+fn5SkxMrPfxZlFkvv76a3Xt2lUrVqzQ3XffXe9+3z8ic+LECXXu3Fl5eXlq2bJlIKI2G6WlperYsaPy8/MVExNjd5yAYnZmZ3bnYHZnzi6dOxJz8uRJJSQkKCio/jNhmsVbS2lpaYqPj9cdd9xxwf3CwsIUFhZWa3vLli0duciSFBMTw+wOxOzM7jTM7szZG3KQwvaTfb1er9LS0pSSkqKQkGbRqwAAgCFsLzLvv/++8vLyNG3aNLujAAAAw9h+COS222676BnJ9QkLC9OcOXPqfLvpSsfszO40zM7sTuPk2RujWZzsCwAA0BS2v7UEAADQVBQZAABgLIoMAAAwltFFZtGiRUpKSlJ4eLgGDx6sTz/91O5IfrdlyxbdeeedSkhIkMvl0jvvvGN3pIB59tlnNWjQIEVHRys+Pl5jx45Vdna23bECYvHixerbt6/vehI33nij1q1bZ3csW8yfP18ul0u/+MUv7I7id6mpqXK5XDX+9OrVy+5YAVNQUKDJkyerbdu2ioiI0LXXXqudO3faHcvvkpKSaq27y+XSjBkz7I7WLBlbZP76179q5syZmjNnjnbv3q1+/fpp1KhRKioqsjuaX506dUr9+vXTokWL7I4ScJs3b9aMGTP0ySefaOPGjTp79qxuu+02nTp1yu5ofpeYmKj58+dr165d2rlzp2655Rbdfffd2rt3r93RAmrHjh16+eWX1bdvX7ujBEyfPn1UWFjo+7Nt2za7IwXE8ePHNWTIEIWGhmrdunXat2+ffv/736t169Z2R/O7HTt21FjzjRs3SpImTpxoc7JmyjLU9ddfb82YMcN3v6qqykpISLCeffZZG1MFliRr5cqVdsewTVFRkSXJ2rx5s91RbNG6dWvrlVdesTtGwJw8edLq0aOHtXHjRmvYsGHWz3/+c7sj+d2cOXOsfv362R3DFk888YQ1dOhQu2M0Cz//+c+tbt26WV6v1+4ozZKRR2Q8Ho927dqlESNG+LYFBQVpxIgR2r59u43JEEjVv/28TZs2NicJrKqqKi1fvlynTp3SjTfeaHecgJkxY4buuOOOGl/3TnDgwAElJCSoa9eumjRpku83Al/pMjIyNHDgQE2cOFHx8fHq37+//vSnP9kdK+A8Ho+WLl2qadOmyeVy2R2nWTKyyHz33XeqqqpSu3btamxv166dDh8+bFMqBJLX69UvfvELDRkyRNdcc43dcQJiz549ioqKUlhYmKZPn66VK1cqOTnZ7lgBsXz5cu3evVvPPvus3VECavDgwUpPT9d7772nxYsX69ChQ7rpppt08uRJu6P53VdffaXFixerR48eWr9+vX72s5/p0Ucf1V/+8he7owXUO++8oxMnTmjKlCl2R2m2bL+yL9AUM2bM0Oeff+6Y8wUk6eqrr1ZWVpZKSkr01ltvKSUlRZs3b77iy0x+fr5+/vOfa+PGjQoPD7c7TkCNGTPGd7tv374aPHiwOnfurDfffFM/+clPbEzmf16vVwMHDtQzzzwjSerfv78+//xzvfTSS0pJSbE5XeC8+uqrGjNmjBISEuyO0mwZeUQmNjZWwcHBOnLkSI3tR44c0VVXXWVTKgTKww8/rDVr1ujDDz9UYmKi3XECxu12q3v37howYICeffZZ9evXTwsXLrQ7lt/t2rVLRUVF+sEPfqCQkBCFhIRo8+bN+uMf/6iQkBBVVVXZHTFgWrVqpZ49e+rgwYN2R/G79u3b1yrpvXv3dsxba5L09ddf6/3339dPf/pTu6M0a0YWGbfbrQEDBuiDDz7wbfN6vfrggw8cdc6A01iWpYcfflgrV65UZmamunTpYnckW3m9XlVUVNgdw+9uvfVW7dmzR1lZWb4/AwcO1KRJk5SVlaXg4GC7IwZMWVmZvvzyS7Vv397uKH43ZMiQWpdXyMnJUefOnW1KFHhpaWmKj4/XHXfcYXeUZs3Yt5ZmzpyplJQUDRw4UNdff72ef/55nTp1SlOnTrU7ml+VlZXV+L+xQ4cOKSsrS23atFGnTp1sTOZ/M2bM0LJly7Rq1SpFR0f7zodq2bKlIiIibE7nX08++aTGjBmjTp066eTJk1q2bJk2bdqk9evX2x3N76Kjo2udBxUZGam2bdte8edHPf7447rzzjvVuXNnffvtt5ozZ46Cg4N133332R3N7x577DH9y7/8i5555hn9+Mc/1qeffqolS5ZoyZIldkcLCK/Xq7S0NKWkpCgkxNhv1YFh949NXYoXXnjB6tSpk+V2u63rr7/e+uSTT+yO5HcffvihJanWn5SUFLuj+V1dc0uy0tLS7I7md9OmTbM6d+5sud1uKy4uzrr11lutDRs22B3LNk758et7773Xat++veV2u60OHTpY9957r3Xw4EG7YwXM6tWrrWuuucYKCwuzevXqZS1ZssTuSAGzfv16S5KVnZ1td5Rmj99+DQAAjGXkOTIAAAASRQYAABiMIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDIBmITU1Vdddd53dMQAYhiID4LI4fPiwHnnkEXXt2lVhYWHq2LGj7rzzzhq/3BUALjd+ExWAS5abm6shQ4aoVatWWrBgga699lqdPXtW69ev14wZM7R//367IwK4QnFEBsAle+ihh+RyufTpp59qwoQJ6tmzp/r06aOZM2fqk08+kSTl5eXp7rvvVlRUlGJiYvTjH/9YR44cqfc5vV6vnnrqKSUmJiosLEzXXXed3nvvPd/jubm5crlcWrFihW6++Wa1aNFC/fr10/bt2337pKenq1WrVlq/fr169+6tqKgojR49WoWFhTVe65VXXlHv3r0VHh6uXr166f/8n/9zmf+GAPgLRQbAJSkuLtZ7772nGTNmKDIystbjrVq1ktfr1d13363i4mJt3rxZGzdu1FdffaV777233udduHChfv/73+t3v/ud/vGPf2jUqFG66667dODAgRr7/dd//Zcef/xxZWVlqWfPnrrvvvtUWVnpe/z06dP63e9+p//7f/+vtmzZory8PD3++OO+x19//XXNnj1b8+bN0xdffKFnnnlGv/nNb/SXv/zlMvztAPA7u3/9NgCz/e1vf7MkWStWrKh3nw0bNljBwcFWXl6eb9vevXstSdann35qWZZlzZkzx+rXr5/v8YSEBGvevHk1nmfQoEHWQw89ZFmWZR06dMiSZL3yyiu1nvOLL76wLMuy0tLSLEnWwYMHffssWrTIateune9+t27drGXLltV4naefftq68cYbG/pXAMBGHJEBcEksy7roPl988YU6duyojh07+rYlJyerVatW+uKLL2rtX1paqm+//VZDhgypsX3IkCG19u/bt6/vdvv27SVJRUVFvm0tWrRQt27dauxT/fipU6f05Zdf6ic/+YmioqJ8f37729/qyy+/vOhcAOzHyb4ALkmPHj3kcrlsO6E3NDTUd9vlckk6d35NXY9X71NdvsrKyiRJf/rTnzR48OAa+wUHB/slL4DLiyMyAC5JmzZtNGrUKC1atEinTp2q9fiJEyfUu3dv5efnKz8/37d93759OnHihJKTk2t9TExMjBISEvTRRx/V2P7RRx/VuX9TtWvXTgkJCfrqq6/UvXv3Gn+6dOly2V4HgP9wRAbAJVu0aJGGDBmi66+/Xk899ZT69u2ryspKbdy4UYsXL9a+fft07bXXatKkSXr++edVWVmphx56SMOGDdPAgQPrfM5Zs2Zpzpw56tatm6677jqlpaUpKytLr7/++mXNPnfuXD366KNq2bKlRo8erYqKCu3cuVPHjx/XzJkzL+trAbj8KDIALlnXrl21e/duzZs3T7/85S9VWFiouLg4DRgwQIsXL5bL5dKqVav0yCOP6Ic//KGCgoI0evRovfDCC/U+56OPPqqSkhL98pe/VFFRkZKTk5WRkaEePXpc1uw//elP1aJFCy1YsECzZs1SZGSkrr32Wv3iF7+4rK8DwD9cVkPO1AMAAGiGOEcGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGP9f4vBk7VfqfS8AAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Nouvelle partie pour le solveur probabiliste\n",
-        "random.seed(123)\n",
-        "np.random.seed(123)\n",
-        "board_prob = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(4, 4))\n",
-        "board_prob.reveal(4, 4)\n",
-        "\n",
-        "solver_prob = ProbabilisticSolver(board_prob)\n",
-        "\n",
-        "start = time.time()\n",
-        "won = solver_prob.play_game(verbose=True)\n",
-        "elapsed = (time.time() - start) * 1000\n",
-        "\n",
-        "print(\"\\nResultat de la partie\")\n",
-        "print(\"=\" * 50)\n",
-        "print(f\"Issue               : {'VICTOIRE' if won else 'DEFAITE'}\")\n",
-        "print(f\"Temps total         : {elapsed:.1f} ms\")\n",
-        "print(f\"Decisions par regles: {solver_prob.decisions['rules']}\")\n",
-        "print(f\"Decisions par CSP   : {solver_prob.decisions['csp']}\")\n",
-        "print(f\"Devinettes (guess)  : {solver_prob.decisions['guess']}\")\n",
-        "total_decisions = sum(solver_prob.decisions.values())\n",
-        "if total_decisions > 0:\n",
-        "    print(f\"\\nRepartition :\")\n",
-        "    for method, count in solver_prob.decisions.items():\n",
-        "        pct = count / total_decisions * 100\n",
-        "        print(f\"  {method:<8}: {count:>3} ({pct:.0f}%)\")\n",
-        "\n",
-        "if solver_prob.guesses_log:\n",
-        "    print(f\"\\nDevinettes effectuees :\")\n",
-        "    for cell, prob in solver_prob.guesses_log:\n",
-        "        result = \"mine !\" if cell in board_prob.mines else \"sure\"\n",
-        "        print(f\"  {cell} -> P(mine)={prob:.1%} -> {result}\")\n",
-        "\n",
-        "fig = draw_board(board_prob,\n",
-        "                 title=f\"Partie {'GAGNEE' if won else 'PERDUE'}\",\n",
-        "                 show_mines=True)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-26",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004375,
-          "end_time": "2026-02-26T07:01:10.406185",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.401810",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-26"
-      },
-      "source": [
-        "### Interpretation : partie complete avec solveur probabiliste\n",
-        "\n",
-        "**Sortie obtenue** : le solveur a joue une partie complete en combinant les trois niveaux de raisonnement.\n",
-        "\n",
-        "| Methode | Decisions | Role |\n",
-        "|---------|-----------|------|\n",
-        "| Regles simples | Majorite des decisions | Deductions locales gratuites |\n",
-        "| CSP | Complement significatif | Deductions globales exactes |\n",
-        "| Devinettes | Quelques-unes | Choix sous incertitude |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. La grande majorite des decisions sont prises par les **regles simples**, qui sont instantanees\n",
-        "2. Le **CSP** intervient quand les regles se bloquent et resout les cas ambigus localement mais determines globalement\n",
-        "3. Les **devinettes** sont rares mais inevitables (le Demineur est NP-complet, certaines configurations sont intrinsequement ambigues)\n",
-        "4. Chaque devinette est faite de maniere **optimale** : on choisit la cellule la moins risquee"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-27",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004629,
-          "end_time": "2026-02-26T07:01:10.415247",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.410618",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-27"
-      },
-      "source": [
-        "### Visualisation des probabilites\n",
-        "\n",
-        "Repartons d'un plateau neuf et visualisons les probabilites calculees par le CSP a un instant ou le solveur doit deviner."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-28",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:04.007718Z",
-          "iopub.status.busy": "2026-04-21T00:32:04.007173Z",
-          "iopub.status.idle": "2026-04-21T00:32:04.242487Z",
-          "shell.execute_reply": "2026-04-21T00:32:04.241551Z"
-        },
-        "papermill": {
-          "duration": 0.127444,
-          "end_time": "2026-02-26T07:01:10.547467",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.420023",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-28",
-        "outputId": "adb67688-90e5-4b87-8ef3-1f270a97e92f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 624
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Toutes les cellules ont ete determinees par le CSP.\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUQpJREFUeJzt3Xl8VPW9//H3ZA8JSQhJgJBAWGVfyiZFBRFksYqAyBUQEL23VFypXGtbIahUWqwXXApFLdEiYKsgi7JplEWjLP5SWSQBJAQRCBIghCUhyfn9QTNlSAIJJHPy5byej0cej5lzzsz5fObM8p5zvnPisizLEgAAgIF87C4AAADgahFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWSuc0lJSXK5XHK5XOrVq5fd5eASvXr1cm+fpKQku8uBIcaOHet+3iQmJtpdji0SExPdj8HYsWPtLgc28rO7AJRfUlKSHnjggRLT/f39FR0drW7duumxxx6rssAyc+ZMnThxQtKFN9KEhIQqWc/15OIPmSeeeEIRERG21XK9O3HihGbOnOm+7tQPeFS+7OxszZ07VytXrtTOnTt18uRJRUZGKj4+Xv369dP999+vG264wb18YWGh3njjDf3973/Xjh07dPr0aYWHhysqKkotW7ZUhw4dNHnyZLlcLklSRkaGGjVqVGK9Pj4+ioiIULt27TR69Gh3gMUlLBhj3rx5lqQr/r3yyiul3qZnz57XtP6GDRu67+uzzz67tmYc4uLtsm/fvhLzv/32W2vDhg3Whg0brCNHjni/wOvIvn37PB7v69mYMWPcfU6ZMsXucmwxZcoU92MwZsyYKlvPihUrrMjIyMu+5w4aNMjjNkOHDr3i+/T58+fdy1/63C3rb+jQoVXWp8nYI2OwDRs2SJIOHDigxMREpaenS5ImTZqk4cOHKyYmxs7yUA5t27at8nXk5uYqNDS0ytdzveLxs0d1eNw///xzDR48WOfPn5ck1atXT48//rg6deqkgoICbdu2TQsWLChxmw8++ECSFBgYqClTpqhz586SpL1792r16tVatWrVZdf7yiuvqGPHjjp58qRee+019/IffPCBli5dqkGDBlV2q2azO0mh/C7dI3Ox5ORkj3lLliwpcZuL98j89NNP1i9/+Uura9euVt26da3AwEArKCjIatKkifXQQw9Ze/fudS978Tef0v4u/kZ47Ngx6/e//73Vrl07KyQkxAoKCrJatWplTZkyxTp16pRHzXv27LEeeOABq2PHjlZMTIzl7+9v1ahRw2rZsqX1xBNPlNhDcblvYD179nTPmzdvXrkez4KCAmvOnDnWTTfdZEVERFj+/v5WgwYNrIceesj6/vvvPZa99BvTsWPHrIcfftiqW7euFRAQYHXs2NFatWqVe/mLvzGX9ldc4+Xqrshjeel23rRpk9WnTx+rZs2aVkREhHu506dPW3/84x+tLl26WDVr1rQCAgKspk2bWk8++aSVlZXlcZ+fffaZ+z4bNmxo7dq1yxo4cKAVEhJiRUdHW4888oh15swZKycnx3rkkUesmJgYKygoyLr55putzZs3l3i8r2Xd+/fvt0aNGmVFRkZaQUFB1k033eSxjosfx9L+rrQH8dI9HH//+9+tDh06WIGBgR7ftg8cOGA9/vjj1g033GAFBQVZISEh1s9+9jPr5ZdftvLz8z3u8/jx49avf/1r97IBAQFWvXr1rFtuucV66qmnrNOnT3ssn5qaat1///1WgwYNrICAAKtmzZpWly5drBkzZljnzp27bL1Xmm5ZFd+jeunrbcOGDVbPnj2tkJAQKyIiwho+fLiVmZnpcZvVq1dbw4YNs2644QYrMjLS8vPzs8LCwqyuXbtaf/7zn0s8RuV93MtT38Uq8touS2FhodWiRQuP5+Hhw4dLXXbbtm3uy3/84x/dtxk8eHCpy1/6+r30/eXi7XPmzBkrKCjIPe/xxx8vV/1OQpAxyOWCzDfffOMx77333itxm4uDzHfffXfZN/5atWq5w0x5g8zu3butuLi4Mpdr06aNdezYMXcNK1euvOz9JiQkWMePH3cvX5lB5syZM9att95a5rojIiKsr7/+2r38pW80zZo1K3GbgIAAKyMjw7Ksaw8yFX0sL97O9evXt4KDg93Xw8PDLcuyrKNHj1pt2rQp8z7r16/v8SZ/cZiIiIiwYmJiStxmyJAhVrdu3UpMj4qKsnJyctz3dS3rDgsLK3XdF6+jMoPMpdu2+AM1JSXFioiIKHMdt956q0fguOWWWy5b06FDh9zLLly40PL39y9z2U6dOnk8nt4OMs2aNSu1vri4OI8vHE8//fRle740nJTncS9PfRe/H1T0tV2WlJQUj9u98847V7yNZVnWnDlz3LcJDQ21XnnlFSs9Pd0qKioq8zaXCzKWZVnh4eHueb/61a/KVYeT8Kul68APP/ygyZMne0zr0KHDZW9Tq1YtPffcc3rvvfe0atUqff7551q+fLlGjRolSTp+/Lj+/Oc/S5LGjRunDRs2qG7duu7bv/LKK9qwYYM2bNigcePGSZJGjRqlH374QZJ06623asmSJVq+fLl69uwpSdq+fbueeOIJ9300bNhQ06dP1/vvv681a9bo888/15IlS9S/f39JFwbAvfHGG1f/wFxGYmKiPvvsM0lSo0aNNG/ePK1Zs0bjx4+XdGHg6H333aeCgoJSb3/8+HG98cYb+uc//6n69etLkvLz8zVnzhxJ0u9+9zv3ob9i//znP92P2cCBAy9bX0Ufy4sdPHhQkZGReuONN7RmzRo999xzkqQJEyZo+/btki48PxYuXKiVK1dq6NCh7tuNGTOm1Ps8ceKEYmNjtWTJEo9BtIsXL9a//vUvzZw5Ux988IH7cOZPP/3kscv9Wtadk5OjkJAQLViwQPPmzVN4eHiJdbz66qv65z//6XG74sd6w4YN6tixY6n3XZrdu3erR48eeu+99/TRRx/pv/7rv5SXl6fhw4e7B7sPHTpUH330kd5//321a9dOkvTZZ59p2rRp7trWr18vSYqPj9eiRYv06aefav78+Xr66afVpk0b96DNw4cP68EHH3QfvhgwYICWL1+uv/zlL+5et27dqt/85jfl7qGy7d69WwMGDNCKFSv06quvug/5/PDDD/rd737nXu6WW27RK6+8og8//FCffvqpkpOT9e6776pp06aSpKVLl2rz5s1lruPSx/1qXOtru9jWrVs9rt9+++3lWn+fPn0UGBgo6cLhsccee0zNmzdXrVq11L9/f82ZM0dnz54t133l5ORoypQpOnnypHtaRZ7LjmF3kkL5lXew78XfTi432HfFihXWHXfcYdWtW9fy8/MrcT8/+9nPPJa/3De6bdu2uef5+/tbq1evdg9iff/99z3mXbxb9Z133rF69+5tRUVFWb6+vqV+4y9WWXtkioqKrOjoaPfyL7/8srvWDRs2WPXq1XPPKz5cdOk3pn/84x/u+5s+fXqp9VrWlQf7llb31TyWF29nl8tl/etf//JYz/Hjxz0e3wULFrjv87PPPvP4tr1r1y7Lsjz3ikiydu7c6X78QkJC3NP/93//172eCRMmuKdPnDix0ta9adMm9zrGjx9fYh2lbaOKuHjPQP369a2zZ896zF++fLl7fnR0tLV+/Xp3D6+++qp7Xr169SzLsqyzZ8+6e27btq21devWEvdZbNasWR73ffFyr732mnteWFiYVVBQUKJeb+yRiY2NtfLy8tzzXnrpJY89HIWFhZZlXTh8+MILL1idOnWywsLCLJfLVeI1ffGPEa70uJe3vuL3g6t5bZflhRde8Kj74sG5V/L22297vEYu/WvSpInH4dTyDvZt0aKFdebMmXLX4RQM9r2OREdHa8KECfrtb397xWX/9re/6cEHH7zsMsePHy/3unfu3Om+fP78efXr16/U5c6fP6+0tDR16tRJkydP1vPPP19pNZTX0aNHdfToUff1iRMnlrns9u3bS+3ltttuc1+uXbu2+3J2dvY113c1j+XFmjZt6t5LUCw9PV2FhYXu6yNGjChz/du3b/f4KakkRUREqGXLlpIkl8ulyMhInT59WpLUvXt393JRUVHuy8WPxbWuu2bNmurSpYv7emU/3pcaOHCggoKCPKZdvE2OHj2qW265pdTbHjp0SMeOHVPt2rU1ZswY/e1vf9O2bdvUqVMn+fj4qEGDBurWrZseeOAB93bdtWuX+/adO3f2WPdNN93kvpyTk6Mff/xR8fHxldJnRXTr1k0BAQGl1nXixAn99NNPio6O1sCBA7Vu3brL3ldZr+nSHveKqozXdrFLT5Vw7Ngx1alTp1x1jB49WgMHDtQ//vEPffbZZ0pJSdHBgwfd8/fu3atnn33WvQf3SoKCgjR8+HD96U9/UnBwcLlu4yQEGYMVH7ooPo9Mo0aNyn2OgenTp7sv9+/fXw8//LBq1aqlLVu26Mknn5QkFRUVVX7RurC79fz583r55Zfd00aOHKlRo0YpNDRUy5cv15/+9KcSNVzc26W7hS9+86rsWksTGRnpvuzn95+XkWVZVVJHWUqrr169epV+n8WHOIr5+PznqHRZ58a5mseitHVf/FhLVf94V8bjV7t2bc2dO1e9e/fWihUrtH37du3Zs0cZGRnKyMjQe++9pw8//LDSf31yudfITz/9VKnrulRKSoo7xPj6+ioxMVE///nPFRAQoOeee05r166VVPb7yrU+7hVV1mu72KVfED755BONHDmy3PcfFRWlhx9+WA8//LAkadu2bRo3bpy2bNkiSfr666/LvG3xr5aKzyPTtGlTjyAJTwQZg138raiiMjMz3ZdnzJihNm3aSLrw08GyXPzhdembUfG3dUkKDg7WoUOHSnz4SdLp06cVEhKiw4cPu7/RS9KcOXPcx93LOsNtrVq13JeLx49IF46tp6WllVn3paKjoxUVFeV+Y1+9enWpx7+La70WLpfL/WFb3mBY0ceytHVeqnnz5vL19XXvGUlLS1Pz5s3LfZ/Xwlvrvvj5KV14vC+dVh6lPX4Xb5MGDRpo7969HoGq2MU9+Pj4aOTIke4Pv6KiIr388suaNGmSJGnhwoUaNGiQWrRo4b791q1bde7cOfeeiS+++MI9Lyws7Iof9mW9RpKTkz1ebxW1adMmnT9/Xv7+/iXqKj7RW3Jysntahw4d9Pvf/17ShUB18ftNWSrjRG+V+dru2rWrWrZsqe+++06S9Oyzz6pv376lntZix44dat26taQLgSU4ONg9LqhY27Ztdc8997iDzOXeD9q2bXtN7+9OQ5BxqMaNG7tfoC+88IIefPBBbd261T1YsTS1a9fWvn37JElvv/22fHx85Ofnp3bt2qlt27bq0qWLNm/erLNnz6p379567LHHFB8fr6NHj2rfvn1KTk5WUVGRPvnkE9WpU0chISHuN9ff/va3uvPOO5WcnKx58+aVuv6LP/zWr1+viRMnqkGDBnrllVc8Dl1cicvl0gMPPKAZM2ZIurAb+De/+Y3atGmj3NxcZWZm6quvvtKKFSuUk5NT7vstTe3atd1vqnPmzNEvfvEL+fj4qGvXrmV+w6roY1keERERGjJkiHtA7MCBAzVp0iQ1bdpUJ06c0P79+7V+/Xrt2rXL41BHZfDWuiMjIz2C4//93/+pa9eu8vHxUY8ePa6ph759+yo+Pl4HDhxQZmam+vXrp//+7/9WTEyMDh06pL1792rNmjVq1qyZ+/nbtGlTDRw4UJ06dVJsbKwKCwvdA4Al6dy5c5Kke++9V88884zOnDmjrKws3XPPPRo/fnyJgbSjRo0qNTxd7OLXyMKFC9WoUSMFBQW5n+tX6+DBg7r33nv10EMPKSMjQ1OnTnXPu+eee+Tj46PGjRu7p3377bf6y1/+okaNGmnu3LkV+qJxLSrzte3j46O//OUvuv3223X+/Hnt27dPHTt21BNPPKGOHTuqqKhIO3bs0Lvvvqu4uDh9+OGHki7safnlL3+pW265RQMGDFDr1q1Vo0YNpaWleeyFvviQLK6RrSN0UCGX+/l1eW5z8WDfi38iePFfr1693JcbNmzocV/PPPNMqbfZsGGDZVmWlZ6eftmfDF9aw29+85sr1nDx8gUFBR7ndSj+Cw8Pt+Lj493Xy/vz64vXU9ZfscsNJL3cgOr77ruv1Ps9cOCAZVllD1Ku6GNZnjM4Z2VlXfYn0Jdu80vP5XKxsgaOljUguzLXfblB3927dy9xv76+vqU+Hhcrz5lyv/zyy8v+/PrSegIDAy+77AcffOBetjw/vz558uQV6z158qRVu3btErePi4vzqL2ig31btWpVaj/169d3n1ulsLDQ+vnPf15imZCQEKtLly6l1nstZyi+3M+vK/LavpKKntn3jTfeuOK669ata+3fv999myv9/BqXx8+vHeqXv/ylZs+erRYtWigoKEjNmjXTzJkzS/yM+2K///3v9ctf/lIxMTGl7gZu1qyZvv32W02ePFkdO3ZUaGioAgMD1aBBA91yyy2aNm2ax+C2559/Xs8//7waN26soKAgtWvXTu+++26ZP8P19fXV0qVL1b9/f9WoUUM1a9bUoEGD9NVXX3l8GyyP4OBgffLJJ5o7d6569eqlyMhI+fn5qU6dOurUqZOefPLJyx5mK69Zs2Zp+PDh7r0F5VXRx7I8oqOjtWnTJr300ku68cYbFR4eLn9/f8XGxurGG2/U7373O/cZSSubt9b997//XQMHDlTNmjUroWpP3bt317Zt2zRx4kT3t+zg4GA1atRIffv21f/93/+5f+ouSS+++KLuuusuJSQkKDQ0VL6+voqOjlb//v318ccfa8iQIe5l/+u//kubNm3SqFGjFB8fL39/f4WGhqpTp07605/+pI0bNyosLOyKNYaFhenjjz/WTTfdpMDAQEVGRur+++/X119/XerhyfLq0qWL1q1bp969eyskJETh4eG699579cUXX7gHwPr4+Gjp0qUaO3ase4/rrbfeqs8//1ytWrW66nVXVGW/tu+44w7t3r1bL774om6++WZFRUXJ399fMTEx6tSpk3772996jDkcPHiw3n77bY0dO1bt27dX3bp15e/vrxo1aqhNmzaaOHGiUlNT1aBBgyro3plcluXl0YkAgGovMTHRfQhpzJgx/Hd2VFvskQEAAMYiyAAAAGMRZAAAgLEYIwMAAIzFHhkAAGAsggwAADCW0Wf2LSoq0o8//qiaNWtWyumtAQBA9WBZlk6dOqXY2NjL/rsRo4OMXf8JFgAAeMeBAwcUFxdX5nyjg0zx2Tvnz5/vuLMk7tmzR+vXr9ddd92lqKgou8vxKnqnd3p3Dnpfr/vbtVOdf/9TXSf5/qefdNdvf3vFM3UbHWSKDyc1aNCg1P+mez07e/asAgIClJCQoNjYWLvL8Sp6p3d6dw56D1DT6Gg1iIiwuxzbXGnoCIN9AQCAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMJaf3QUAqL6WLQvUxo0BSk31165dfsrPd7nnHT58xMbKqh69O7P3Q7mHtHr/aqX8mKK042nKOpOlnPwchQWEqXXt1hrWfJiGNR8ml8t15TuDVxBkAJRp1qwQ7djhb3cZtqB3Z/b+/u73Ne3raSWmZ5/L1oaDG7Th4Aat+H6F5vWbJ18fXxsqrFpfLFiglIULy5wfGBKiRxct8mJFV0aQAVAml0tKSChQ+/YFysryUUpKgN0leQ29O7P3YjE1YnRbg9vUsGZDHTh1QB/s/kDnCs9JktbsX6NFaYs0suVIm6uERJABcBnLl2crOPjC5RkzQhz1gUbvFy47rff6ofX1Wu/XdHfTu+Xn85+PyMHNBuue5fe4rydnJl/3QaZRp07qNmyYxzQf3+q3F4ogA6BMxR9mTkTvzjSk2ZBSp99U/yZFBkUq+1y2JCm/KN+bZdmiRni44lq3truMK+JXSwAAXEHxoN9iHWM62lgNLsYeGQAALqOgqEBPrXtKBUUFkqSo4CiNbjXa5qqq3o7kZO1ITvaY1rp3bw148kmbKiode2QAAChDbn6uRq8crTX710iSQv1D9U7/dxQVHGVzZSjGHhkAAEpxMPeg7l95v3Ye2ylJqh1UW/MHznfMYaXSBvuG1KplUzVlI8gAAHCJ1KxUjVk1RkfOXDgBYJPwJnp34LtKCE+wtzAvYrAvAAAG+njfxxq8bLA7xNxY70atGLzCUSHGJOyRAVCmpKRgZWRcOG/Eli2eZ3pNTAx1Xx479qwSEgq9WltVo3dn9r5s7zKN/2S8iqwiSVJYQJh6xfXSwl2eZ7sNCwjTqFaj7CgRlyDIACjT0qVBZZ4Mbc6cEPflvn3zrrsPNHp3Zu9p2WnuECNJOfk5mr55eonl4kLjCDLVBIeWAACAsdgjA6BMS5Yct7sE29C7M03qMkmTukyyuwzb9BgxQj1GjLC7jAphjwwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjVYsg8/rrryshIUFBQUHq1q2bNm3aZHdJAADAALYHmffee08TJ07UlClT9M0336h9+/bq16+fsrKy7C4NAABUc7YHmZdffln//d//rQceeECtWrXSnDlzVKNGDf3tb3+zuzQAAFDN+dm58vz8fG3dulXPPPOMe5qPj4/69OmjlJSUEsvn5eUpLy/PfT0nJ0eStGfPHp09e7bqC65GMjMzJUnp6ek6evSozdV4F73TO707B71L27KydCg31+ZqvC8zO7tcy9kaZH766ScVFhaqTp06HtPr1KmjXbt2lVj+xRdf1NSpU0tMX79+vQICAqqszurK5XIpOTnZ7jJsQe8O7V1ybu9O3u5O7l3SsrQ0u8uwRX5+frmWszXIVNQzzzyjiRMnuq/n5OQoPj5ed911lxISEuwrzAbp6elKTk7W0KFDFR0dbXc5XkXvzu59XMeOqhcaanc5XrUtK0vL0tIcvd2d3LsTn/OStOfoUSWVYzlbg0xUVJR8fX115MgRj+lHjhxR3bp1SywfGBiowMDAUu8nNja2yuqsjop3sUZHR9O7g9C7VC80VA0iIuwtxsuKDys4ebs7uXcnPucl6VQ5h4zYOtg3ICBAnTp10qeffuqeVlRUpE8//VTdu3e3sTIAAGAC2w8tTZw4UWPGjFHnzp3VtWtXzZw5U6dPn9YDDzxgd2kAAKCasz3IDB8+XEePHtXkyZN1+PBhdejQQatWrSoxABgAAOBStgcZSXrkkUf0yCOP2F0GAAAwjO0nxAMAALhaBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsfzsLsAky5YFauPGAKWm+mvXLj/l57vc8w4fPmJjZVXPyb07GdvdmQ7lHtLq/auV8mOK0o6nKetMlnLycxQWEKbWtVtrWPNhGtZ8mFwu15Xv7DowZswqrV6d4b7evXs9LVkyyL6C4IEgUwGzZoVoxw5/u8uwhZN7dzKnb/cvFixQysKFZc4PDAnRo4sWebEi73h/9/ua9vW0EtOzz2Vrw8EN2nBwg1Z8v0Lz+s2Tr4+vDRV6zz//me4RYq53Jj7nCTIV4HJJCQkFat++QFlZPkpJCbC7JK9xcu9OxnZ3tpgaMbqtwW1qWLOhDpw6oA92f6BzheckSWv2r9GitEUa2XKkzVVWncOHT+vZZ7+wuwxcAUGmApYvz1Zw8IXLM2aEOOpN3cm9Oxnb/T8adeqkbsOGeUzz8b0+90bUD62v13q/prub3i0/n/98TAxuNlj3LL/HfT05M/m6DjKTJq3XiRN5ql8/VJGRQdq27Se7S/IqU57zBJkKKH5DdyIn9+5kbPf/qBEerrjWre0uwyuGNBtS6vSb6t+kyKBIZZ/LliTlF+V7syyvWrRol9au3S+XS5o5s5defnmr3SV5nSnPeX61BAAol+JBv8U6xnS0sZqqc+hQrqZM+VKSNHp0K918c5zNFeFy2CMDAOWwIzlZO5KTPaa17t1bA5580qaKvKugqEBPrXtKBUUFkqSo4CiNbjXa5qqqxq9/vU4nT+arQYOamjy5u93l2MaU5zx7ZAAAl5Wbn6vRK0drzf41kqRQ/1C90/8dRQVH2VxZ5VuwYJeSkw/8+5DSrQoJce6v9kzBHhkAKIfSBj6G1KplUzXeczD3oO5feb92HtspSaodVFvzB86/Lg8rnTtXoMTEC4eUxo1ro5//PNbmiuxlynOeIAMA5WDKwMfKlJqVqjGrxujImQsnP2wS3kTvDnxXCeEJ9hZWRfLyCpWTc2EA81tvbddbb20vdbmUlEOqW3fOdX9iPFOe8xxaAgCU8PG+jzV42WB3iLmx3o1aMXjFdRtiYC72yFRAUlKwMjIu/IZ+yxbP46aJiaHuy2PHnlVCQqFXa6tqTu7dydjuzrRs7zKN/2S8iqwiSVJYQJh6xfXSwl2eZ3wNCwjTqFaj7CixSvj7++iOOxqXOi8l5UdlZ184GWBkZJC6d4/VDTdUv8MsTkSQqYClS4PKPCHYnDkh7st9++Zdd2/qTu7dydjuzpSWneYOMZKUk5+j6Zunl1guLjTuugoyNWr46623bi913uDBS5WSckiSdMMNtcpcDt7HoSUAAGAs9shUwJIlx+0uwTZO7t3JnL7de4wYoR4jRthdhtdN6jJJk7pMsruMauV6HtR7MROf8+yRAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCxbg8z69et15513KjY2Vi6XSx9++KGd5QAAAMPYGmROnz6t9u3b6/XXX7ezDAAAYCg/O1c+YMAADRgwwM4SAACAwWwNMhWVl5envLw89/WcnBxJ0p49e3T27Fm7yrJFZmamJCk9PV1Hjx61uRrvondn974tK0uHcnNtrsa79mRnS3L2dndy7058zktS5r+f91fisizLquJaysXlcmnJkiW6++67y1wmMTFRU6dOLTF97NixCggIqMLqqieXy6Vqsvm8jt7p3WlckpzZOdvdmZ1L+fn5SkpK0smTJxUWFlbmckbtkXnmmWc0ceJE9/WcnBzFx8fr/nbt1DQ62sbKvG9bVpaWpaVp6NChinZY7+np6UpOTqZ3eneM4t7HdeyoeqGhdpfjVbzXOXO7S9Keo0eVVI7ljAoygYGBCgwMLDG9TmioGkREeL8gGxXvZoyOjlZsbKzN1XhX8e5leqd3pyjuvR7vdTZX411O3u6SdKqcQ0Y4jwwAADCWrXtkcnNztWfPHvf1ffv2KTU1VZGRkWrQoIGNlQEAABPYGmS2bNmiW2+91X29ePzLmDFjlJSUZFNVAADAFLYGmV69ejl2JDoAALh2jJEBAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjOVndwEww7Jlgdq4MUCpqf7atctP+fku97zDh4/YWBmqkpO3+6HcQ1q9f7VSfkxR2vE0ZZ3JUk5+jsICwtS6dmsNaz5Mw5oPk8vluvKdwRznzin05Zfl969/yW/vXrmOH5crL09WWJgKGjdWfp8+OjNunKywMLsrxb8RZCrgiwULlLJwYZnzA0NC9OiiRV6syHtmzQrRjh3+dpcBL3Pydn9/9/ua9vW0EtOzz2Vrw8EN2nBwg1Z8v0Lz+s2Tr4+vDRVWLae+37lOn1bIK6+UnJ6drYDsbAVs2aKgRYuUvXKlrFq1bKiwapm43QkyKBeXS0pIKFD79gXKyvJRSkqA3SXBC9juUkyNGN3W4DY1rNlQB04d0Ae7P9C5wnOSpDX712hR2iKNbDnS5ipRmQrr1dP5zp1VGBenolq15HPsmII++ki+P/wgSfLLyFDw/Pk68+ijNlcKiSBz1Rp16qRuw4Z5TPPxvf6+lRVbvjxbwcEXLs+YEeLIDzQncvJ2rx9aX6/1fk13N71bfj7/easc3Gyw7ll+j/t6cmbydR9knPR+Z9WurZ/+3/8rMf3M+PGK7tjRfd33wAFvlmULU7Y7QeYq1QgPV1zr1naX4TXFH2ZwFidv9yHNhpQ6/ab6NykyKFLZ57IlSflF+d4syxZOe7/zUFgon6wsBc+f7zG54IYbbCrIe0zZ7gQZAKiA4kG/xTrGdLzM0jBVwPr1qnXvvaXOy7/xRp0deX3vhTMJQeYq7UhO1o7kZI9prXv31oAnn7SpIgBVraCoQE+te0oFRQWSpKjgKI1uNdrmqqoe73f/cXbIEJ2aMUMKCrK7lCpnynYnyABAOeTm5+p/1v6Pkg9ceGMP9Q/VO/3fUVRwlM2VoSoUNG6sU5Mny5WfL58fflDQxx/LJztbwYsXy3/bNh1fsEBF8fF2lwkRZK5aaYOgQq7Dn+IBkA7mHtT9K+/XzmM7JUm1g2pr/sD5jjms5MT3u6K4OJ15+GH39dynn1btPn3ke+SI/HbvVs3Jk3Vy3jwbK6x6pmx3gsxVMmUQFIBrk5qVqjGrxujImQsnAGwS3kTvDnxXCeEJ9hbmRbzfSVZ0tM536iTfjz+WJAV8+aXNFVU9U7Y7/6IAAMrw8b6PNXjZYHeIubHejVoxeIWjQozT+G/cKFdubonprmPH5P/NNxdN4IzO1QV7ZFAuSUnBysi4cP6ALVs8z/SamBjqvjx27FklJBR6tTZUHSdv92V7l2n8J+NVZBVJksICwtQrrpcW7vI862lYQJhGtRplR4moAjXefFOB69Yp/+abdb5VK1nBwfI9dEiBH30k36NH3cvl9eljY5W4GEEG5bJ0aVCZJ0ObMyfEfblv37zr7gPNyZy83dOy09whRpJy8nM0ffP0EsvFhcYRZK4zrrNnFbhmjQLXrCl1/vk2bXQqMdG7RaFMBBkAAP7t7AMPqCgmRv7ffCOfw4flc+KE5OenoqgoFbRqpXMDBujcPfdI/s78H2TVEUGmAnqMGKEeI0bYXYYtliw5bncJsIGTt/ukLpM0qcsku8uwjVPf7/J79lR+z552l2EbE7c7g30BAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYy9Yg8+KLL6pLly6qWbOmYmJidPfddystLc3OkgAAgEFsDTLr1q3ThAkT9NVXX2nt2rU6f/68br/9dp0+fdrOsgAAgCH87Fz5qlWrPK4nJSUpJiZGW7du1S233GJTVQAAwBS2BplLnTx5UpIUGRlZ6vy8vDzl5eW5r+fk5EiSdh49qtzCwqovsBrZk50tSUpPT9fRo0dtrsa7MjMzJdE7vTtHce/bsrJ0KDfX5mq8i/c6Z253Scr897a/EpdlWVYV11IuRUVFuuuuu3TixAlt3Lix1GUSExM1derUEtPHjh2rgICAqi6x2nG5XKomm8/r6J3enYbe6d1p8vPzlZSUpJMnTyosLKzM5apNkPnVr36llStXauPGjYqLiyt1mdL2yMTHx2vx4sVKSEjwUqXVQ3p6upKTkzV06FBFR0fbXY5X0Tu907tz0Lsze5ekjIwMDRky5IpBplocWnrkkUe0YsUKrV+/vswQI0mBgYEKDAwsMT0qKkqxsbFVWWK1U7yLNTo6mt4dhN7pnd6dw8m9S1JuOQ+n2RpkLMvSo48+qiVLlujzzz9Xo0aN7CwHAAAYxtYgM2HCBC1YsEBLly5VzZo1dfjwYUlSeHi4goOD7SwNAAAYwNbzyMyePVsnT55Ur169VK9ePfffe++9Z2dZAADAELYfWgIAALha/K8lAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCw/uwswybJlgdq4MUCpqf7atctP+fku97zDh4/YWFnVc3LvcCYnP+ed3LvOnVPoyy/L71//kt/evXIdPy5XXp6ssDAVNG6s/D59dGbcOFlhYXZXWukO5R7S6v2rlfJjitKOpynrTJZy8nMUFhCm1rVba1jzYRrWfJhcLteV78yLCDIVMGtWiHbs8Le7DFs4uXc4k5Of807u3XX6tEJeeaXk9OxsBWRnK2DLFgUtWqTslStl1aplQ4VV5/3d72va19NKTM8+l60NBzdow8ENWvH9Cs3rN0++Pr42VFg6gkwFuFxSQkKB2rcvUFaWj1JSAuwuyWuc3DucycnPeSf3LkmF9erpfOfOKoyLU1GtWvI5dkxBH30k3x9+kCT5ZWQoeP58nXn0UZsrrRoxNWJ0W4Pb1LBmQx04dUAf7P5A5wrPSZLW7F+jRWmLNLLlSJur/A+CTAUsX56t4OALl2fMCHHUi9vJvcOZnPycd3LvVu3a+un//b8S08+MH6/ojh3d130PHPBmWV5RP7S+Xuv9mu5uerf8fP4TDwY3G6x7lt/jvp6cmUyQMVXxC9uJnNw7nMnJz3kn915CYaF8srIUPH++x+SCG26wqaCqM6TZkFKn31T/JkUGRSr7XLYkKb8o35tlXRFBBgCASwSsX69a995b6rz8G2/U2ZHVZ49EVSse9FusY0zHyyztffz8GgCAcjo7ZIhOvPuuFBRkdyleUVBUoKfWPaWCogJJUlRwlEa3Gm1zVZ7YIwMAwCUKGjfWqcmT5crPl88PPyjo44/lk52t4MWL5b9tm44vWKCi+Hi7y6xSufm5+p+1/6PkA8mSpFD/UL3T/x1FBUfZXJknggwAAJcoiovTmYcfdl/Pffpp1e7TR75Hjshv927VnDxZJ+fNs7HCqnUw96DuX3m/dh7bKUmqHVRb8wfOr3aHlSQOLQEAcEVWdLTOd+rkvh7w5Zc2VlO1UrNSNXDxQHeIaRLeRB8N/qhahhiJIAMAgJv/xo1y5eaWmO46dkz+33xz0YTqdXbbyvLxvo81eNlgHTlz4QzON9a7USsGr1BCeIK9hV0Gh5YqICkpWBkZF85muGWL51kvExND3ZfHjj2rhIRCr9ZW1ZzcO5zJyc95J/de4803FbhunfJvvlnnW7WSFRws30OHFPjRR/I9etS9XF6fPjZWWTWW7V2m8Z+MV5FVJEkKCwhTr7heWrhrocdyYQFhGtVqlB0lloogUwFLlwaVeWKoOXNC3Jf79s277l7cTu4dzuTk57yTe5ck19mzClyzRoFr1pQ6/3ybNjqVmOjdorwgLTvNHWIkKSc/R9M3Ty+xXFxoHEEGAIDq6OwDD6goJkb+33wjn8OH5XPihOTnp6KoKBW0aqVzAwbo3D33SP7O/F9U1RFBpgKWLDludwm2cXLvcCYnP+ed3Ht+z57K79nT7jJsManLJE3qMsnuMiqMwb4AAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLGuOcicO3euMuoAAACosKsKMkVFRXr++edVv359hYaG6vvvv5ckPfvss3rrrbcqtUAAAICyXFWQeeGFF5SUlKQ//elPCgj4zz8Wa9Omjd58881KKw4AAOByrirIvPPOO5o7d65GjhwpX19f9/T27dtr165dlVYcAADA5VxVkDl48KCaNm1aYnpRUZHOnz9/zUUBAACUx1UFmVatWmnDhg0lpr///vvq2LHjNRcFAABQHn5Xc6PJkydrzJgxOnjwoIqKirR48WKlpaXpnXfe0YoVKyq7RgAAgFJd1R6ZQYMGafny5frkk08UEhKiyZMn67vvvtPy5cvVt2/fyq4RAACgVFe1R0aSbr75Zq1du7YyawEAAKiQqw4ykpSfn6+srCwVFRV5TG/QoME1FQUAAFAeVxVkdu/erXHjxunLL7/0mG5ZllwulwoLCyulOAAAgMu5qiAzduxY+fn5acWKFapXr55cLldl1wUAAHBFVxVkUlNTtXXrVrVo0eKaVj579mzNnj1bGRkZkqTWrVtr8uTJGjBgwDXdLwAAcIarPo/MTz/9dM0rj4uL0/Tp07V161Zt2bJFvXv31qBBg7Rjx45rvm8AAHD9u6og88c//lH/+7//q88//1zHjh1TTk6Ox1953XnnnRo4cKCaNWum5s2ba9q0aQoNDdVXX311NWUBAACHuapDS3369JEk3XbbbR7Tr2Wwb2Fhof75z3/q9OnT6t69+9WUBQAAHOaqgsxnn31WaQVs27ZN3bt317lz5xQaGqolS5aoVatWpS6bl5envLw89/XivT979uzR2bNnK60mE2RmZkqS0tPTdfToUZur8S56p3d6dw56d2bv0oX/61geLsuyrCqu5bLy8/OVmZmpkydP6v3339ebb76pdevWlRpmEhMTNXXq1BLTx44dq4CAAG+UW624XC7ZvPlsQ+/07jT07tDeJTmz8wv5ICkpSSdPnlRYWFiZy11VkPn2229LvzOXS0FBQWrQoIECAwMrereSLhy2atKkif7617+WmFfaHpn4+HgtXrxYCQkJV7U+U6Wnpys5OVlDhw5VdHS03eV4Fb3TO707B70na1zHjqoXGmp3OV635+hR3TZx4hWDzFUdWurQocNlzx3j7++v4cOH669//auCgoIqdN9FRUUeYeVigYGBpQakqKgoxcbGVmg9pivezRgdHU3vDkLv9E7vzlHce73QUDWIiLC3GBucKueQkav61dKSJUvUrFkzzZ07V6mpqUpNTdXcuXN1ww03aMGCBXrrrbeUnJys3//+95e9n2eeeUbr169XRkaGtm3bpmeeeUaff/65Ro4ceTVlAQAAh7mqPTLTpk3TrFmz1K9fP/e0tm3bKi4uTs8++6w2bdqkkJAQ/frXv9ZLL71U5v1kZWVp9OjROnTokMLDw9WuXTutXr2a/6ANAADK5aqCzLZt29SwYcMS0xs2bKht27ZJunD46dChQ5e9n7feeutqVg8AACDpKg8ttWjRQtOnT1d+fr572vnz5zV9+nT3vy04ePCg6tSpUzlVAgAAlOKq9si8/vrruuuuuxQXF6d27dpJurCXprCwUCtWrJAkff/993r44Ycrr1IAAIBLXFWQ+fnPf659+/bp3XffVXp6uiRp2LBhGjFihGrWrClJuv/++yuvSgAAgFJcVZCRpJo1a2r8+PGVWQsAAECFlDvILFu2TAMGDJC/v7+WLVt22WXvuuuuay4MAADgSsodZO6++24dPnxYMTExuvvuu8tc7mr/aSQAAEBFlTvIFBUVlXr5YgcOHNBzzz137VUBAACUw1X9/Los2dnZ+tvf/laZdwkAAFCmSg0yAAAA3kSQAQAAxiLIAAAAY1XoPDJDhgy57PwTJ05cSy0AAAAVUqEgEx4efsX5o0ePvqaCAAAAyqtCQWbevHlVVQcAAECFMUYGAAAYiyADAACMRZABAADGuur/fg3g+rdsWaA2bgxQaqq/du3yU36+yz3v8OEjNlZW9eid3p3WuyR9sWCBUhYuLHN+YEiIHl20yIsVXRlBBkCZZs0K0Y4d/naXYQt6p3eYgSADoEwul5SQUKD27QuUleWjlJQAu0vyGnqnd6f1fqlGnTqp27BhHtN8fH1tqqZsBBkAZVq+PFvBwRcuz5gR4qg3dXq/cJnendP7pWqEhyuudWu7y7giBvsCKFPxG7oT0bszObl3U7FHBgAAlLAjOVk7kpM9prXu3VsDnnzSpopKxx4ZAABgLPbIAACAEkob7BtSq5ZN1ZSNIAMAAEpgsC8AAEAVI8gAAABjcWgJQJmSkoKVkXHhBFhbtnie7TQxMdR9eezYs0pIKPRqbVWN3undab2biiADoExLlwaVeUKwOXNC3Jf79s277t7U6Z3eL3W9924qggwAAJAk9RgxQj1GjLC7jAohyAAo05Ilx+0uwTb07kxO7t1UDPYFAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWNUmyEyfPl0ul0tPPPGE3aUAAABDVIsgs3nzZv31r39Vu3bt7C4FAAAYxPYgk5ubq5EjR+qNN95QrVq17C4HAAAYxPYgM2HCBN1xxx3q06eP3aUAAADD+Nm58kWLFumbb77R5s2by7V8Xl6e8vLy3NdzcnIkSXv27NHZs2erpMbqKjMzU5KUnp6uo0eP2lyNd9E7vdO7c9C7tC0rS4dyc22uxvsys7PLtZzLsiyrimsp1YEDB9S5c2etXbvWPTamV69e6tChg2bOnFnqbRITEzV16tQS08eOHauAgICqLLdacrlcsmnz2Y7eHdq7JGd27vDtTu92l2GL/Px8JSUl6eTJkwoLCytzOduCzIcffqjBgwfL19fXPa2wsFAul0s+Pj7Ky8vzmCeVvkcmPj5eixcvVkJCgrdKrxbS09OVnJysoUOHKjo62u5yvIrend37uI4dVS801O5yvGpbVpaWpaU5ervTu7N6l6SMjAwNGTLkikHGtkNLt912m7Zt2+Yx7YEHHlCLFi309NNPlwgxkhQYGKjAwMAS06OiohQbG1tltVZHxbtYo6Oj6d1B6F2qFxqqBhER9hbjZcWHFZy83endWb1LF34MVB62BZmaNWuqTZs2HtNCQkJUu3btEtMBAABKY/uvlgAAAK6Wrb9autTnn39udwkAAMAg7JEBAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxvKzuwAA1deyZYHauDFAqan+2rXLT/n5Lve8w4eP2FiZd3yxYIFSFi4sc35gSIgeXbTIixV5h5O3O72b1ztBBkCZZs0K0Y4d/naXAS9z8nand/N6J8gAKJPLJSUkFKh9+wJlZfkoJSXA7pJs06hTJ3UbNsxjmo+vr03VVC0nb3d6N693ggyAMi1fnq3g4AuXZ8wIMeaNrSrUCA9XXOvWdpfhFU7e7vR+4bJJvTPYF0CZit/U4CxO3u70bh72yABAOexITtaO5GSPaa1799aAJ5+0qSIAEntkAACAwdgjAwDlUNpg35BatWyqBkAxggwAlIOTBvsCJuHQEgAAMBZBBgAAGItDSwDKlJQUrIyMCyd927LF84yfiYmh7stjx55VQkKhV2tD1XHydqd383onyAAo09KlQWWeFGvOnBD35b5986rVGxuujZO3O72b1ztBBgDK0GPECPUYMcLuMgBcBkEGQJmWLDludwmwgZO3O72bh8G+AADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGMvWIJOYmCiXy+Xx16JFCztLAgAABvGzu4DWrVvrk08+cV/387O9JAAAYAjbU4Ofn5/q1q1rdxkAAMBAto+R2b17t2JjY9W4cWONHDlSmZmZdpcEAAAMYesemW7duikpKUk33HCDDh06pKlTp+rmm2/W9u3bVbNmzRLL5+XlKS8vz309JydHkrRnzx6dPXvWa3VXB8WBLz09XUePHrW5Gu+id2f3vi0rS4dyc22uxrv2ZGdLcvZ2p3dn9S5JBw8eLNdyLsuyrCqupdxOnDihhg0b6uWXX9aDDz5YYn5iYqKmTp1aYvrYsWMVEBDgjRKrFZfLpWq0+byK3undaeid3p0mPz9fSUlJOnnypMLCwspcrloFGUnq0qWL+vTpoxdffLHEvNL2yMTHx2vx4sVKSEjwYpX2S09PV3JysoYOHaro6Gi7y/Eqeqd3encOendm75KUkZGhIUOGXDHI2D7Y92K5ubnau3ev7r///lLnBwYGKjAwsMT0qKgoxcbGVnV51Urxbsbo6Gh6dxB6p3d6dw4n9y5dyATlYetg36eeekrr1q1TRkaGvvzySw0ePFi+vr6677777CwLAAAYwtY9Mj/88IPuu+8+HTt2TNHR0brpppv01VdfOXIXGgAAqDhbg8yiRYvsXD0AADCc7eeRAQAAuFoEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYfnYXAKD6OpR7SKv3r1bKjylKO56mrDNZysnPUVhAmFrXbq1hzYdpWPNhcrlcdpda6ejdmb0vWxaojRsDlJrqr127/JSf/58eDx8+YmNlVc/U3gkyAMr0/u73Ne3raSWmZ5/L1oaDG7Th4Aat+H6F5vWbJ18fXxsqrDr07szeZ80K0Y4d/naXYQtTeyfIALiimBoxuq3BbWpYs6EOnDqgD3Z/oHOF5yRJa/av0aK0RRrZcqTNVVYNendW7y6XlJBQoPbtC5SV5aOUlAC7S/IaU3snyAAoU/3Q+nqt92u6u+nd8vP5z9vF4GaDdc/ye9zXkzOTr7sPNHp3Zu/Ll2crOPjC5RkzQoz5MK8MpvZOkAFQpiHNhpQ6/ab6NykyKFLZ57IlSflF+d4syyvovSQn9F78Qe5EpvbOr5YAVFjx4M9iHWM62liNd9G7M3tH9UWQAVAhBUUFemrdUyooKpAkRQVHaXSr0TZX5R307szeUb0RZACUW25+rkavHK01+9dIkkL9Q/VO/3cUFRxlc2VVj96d2TuqP8bIACiXg7kHdf/K+7Xz2E5JUu2g2po/cL4jDi/QuzN7hxkIMgCuKDUrVWNWjdGRMxdOitUkvIneHfiuEsIT7C3MC+jdmb3DHBxaAnBZH+/7WIOXDXZ/mN1Y70atGLzCER9m9O7M3mEW9sgAKNOyvcs0/pPxKrKKJElhAWHqFddLC3ct9FguLCBMo1qNsqPEKkPvzuw9KSlYGRkXzla8ZYvnWW4TE0Pdl8eOPauEhEKv1lbVTO2dIAOgTGnZae4PM0nKyc/R9M3TSywXFxp33X2g0bsze1+6NKjME8HNmRPivty3b161+jCvDKb2zqElAABgLPbIACjTpC6TNKnLJLvLsAW9O7P3JUuO212CbUztnT0yAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGMv2IHPw4EGNGjVKtWvXVnBwsNq2bastW7bYXRYAADCAn50rP378uHr06KFbb71VK1euVHR0tHbv3q1atWrZWRYAADCErUHmj3/8o+Lj4zVv3jz3tEaNGtlYEQAAMImth5aWLVumzp07a9iwYYqJiVHHjh31xhtv2FkSAAAwiK17ZL7//nvNnj1bEydO1G9/+1tt3rxZjz32mAICAjRmzJgSy+fl5SkvL899PScnR5K0Z88enT171mt1VweZmZmSpPT0dB09etTmaryL3umd3p2D3p3Zu3RhDG15uCzLsqq4ljIFBASoc+fO+vLLL93THnvsMW3evFkpKSkllk9MTNTUqVNLTB87dqwCAgKqtNbqyOVyycbNZyt6d2jvkpzZucO3u5N7l3Of8/n5+UpKStLJkycVFhZW5nK27pGpV6+eWrVq5TGtZcuW+uCDD0pd/plnntHEiRPd13NychQfH6+77rpLCQkJVVlqtZOenq7k5GQNHTpU0dHRdpfjVfTu7N7HdeyoeqGhdpfjVduysrQsLc3R293JvTvxOS9Je44eVVI5lrM1yPTo0UNpaWke09LT09WwYcNSlw8MDFRgYGCJ6VFRUYqNja2SGqur4t2M0dHR9O4g9C7VCw1Vg4gIe4vxskO5uZKcvd2d3LsTn/OSdKqcQ0ZsHez75JNP6quvvtIf/vAH7dmzRwsWLNDcuXM1YcIEO8sCAACGsDXIdOnSRUuWLNHChQvVpk0bPf/885o5c6ZGjhxpZ1kAAMAQth5akqRf/OIX+sUvfmF3GQAAwEC2/4sCAACAq0WQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIzlZ3cBAKqvZcsCtXFjgFJT/bVrl5/y813ueYcPH7GxMu/4YsECpSxcWOb8wJAQPbpokRcr8g4nb3cn9y6Z+ZwnyAAo06xZIdqxw9/uMuBlTt7uTu7dVAQZAGVyuaSEhAK1b1+grCwfpaQE2F2SbRp16qRuw4Z5TPPx9bWpmqrl5O3u5N4vZcpzniADoEzLl2crOPjC5RkzQhz9pl4jPFxxrVvbXYZXOHm7O7n3S5nynGewL4AyFb+hw1mcvN2d3Lup2CMDAOWwIzlZO5KTPaa17t1bA5580qaKgKplynOePTIAAMBY7JEBgHIobeBjSK1aNlUDVD1TnvMEGQAoB1MGPgKVxZTnPIeWAACAsQgyAADAWBxaAlCmpKRgZWRcOAHWli2eZztNTAx1Xx479qwSEgq9WhuqjpO3u5N7NxVBBkCZli4NKvOEYHPmhLgv9+2bx5v6dcTJ293JvZuKIAMAZegxYoR6jBhhdxmA15j4nCfIACjTkiXH7S4BNnDydndy76ZisC8AADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGsjXIJCQkyOVylfibMGGCnWUBAABD+Nm58s2bN6uwsNB9ffv27erbt6+GDRtmY1UAAMAUtgaZ6Ohoj+vTp09XkyZN1LNnT5sqAgAAJqk2Y2Ty8/M1f/58jRs3Ti6Xy+5yAACAAWzdI3OxDz/8UCdOnNDYsWPLXCYvL095eXnu6ydPnpQkZWZmVnV51c7BgweVn5+vjIwM5ebm2l2OV9G7s3vfc/SoTp09a3c5XpWZne347e7k3p34nJek73/6SZJkWdZll3NZV1rCS/r166eAgAAtX768zGUSExM1depUL1YFAADsdODAAcXFxZU5v1oEmf3796tx48ZavHixBg0aVOZyl+6ROXHihBo2bKjMzEyFh4d7o9RqIycnR/Hx8Tpw4IDCwsLsLser6J3e6d056N2ZvUsX9sScOnVKsbGx8vEpeyRMtTi0NG/ePMXExOiOO+647HKBgYEKDAwsMT08PNyRG1mSwsLC6N2B6J3enYbendl7eXZS2D7Yt6ioSPPmzdOYMWPk51ctchUAADCE7UHmk08+UWZmpsaNG2d3KQAAwDC27wK5/fbbrzgiuSyBgYGaMmVKqYebrnf0Tu9OQ+/07jRO7r0iqsVgXwAAgKth+6ElAACAq0WQAQAAxiLIAAAAYxkdZF5//XUlJCQoKChI3bp106ZNm+wuqcqtX79ed955p2JjY+VyufThhx/aXZLXvPjii+rSpYtq1qypmJgY3X333UpLS7O7LK+YPXu22rVr5z6fRPfu3bVy5Uq7y7LF9OnT5XK59MQTT9hdSpVLTEyUy+Xy+GvRooXdZXnNwYMHNWrUKNWuXVvBwcFq27attmzZYndZVS4hIaHEdne5XJowYYLdpVVLxgaZ9957TxMnTtSUKVP0zTffqH379urXr5+ysrLsLq1KnT59Wu3bt9frr79udylet27dOk2YMEFfffWV1q5dq/Pnz+v222/X6dOn7S6tysXFxWn69OnaunWrtmzZot69e2vQoEHasWOH3aV51ebNm/XXv/5V7dq1s7sUr2ndurUOHTrk/tu4caPdJXnF8ePH1aNHD/n7+2vlypXauXOn/vznP6tWrVp2l1blNm/e7LHN165dK0kaNmyYzZVVU5ahunbtak2YMMF9vbCw0IqNjbVefPFFG6vyLknWkiVL7C7DNllZWZYka926dXaXYotatWpZb775pt1leM2pU6esZs2aWWvXrrV69uxpPf7443aXVOWmTJlitW/f3u4ybPH0009bN910k91lVAuPP/641aRJE6uoqMjuUqolI/fI5Ofna+vWrerTp497mo+Pj/r06aOUlBQbK4M3Ff/388jISJsr8a7CwkItWrRIp0+fVvfu3e0ux2smTJigO+64w+N17wS7d+9WbGysGjdurJEjRyozM9Pukrxi2bJl6ty5s4YNG6aYmBh17NhRb7zxht1leV1+fr7mz5+vcePGyeVy2V1OtWRkkPnpp59UWFioOnXqeEyvU6eODh8+bFNV8KaioiI98cQT6tGjh9q0aWN3OV6xbds2hYaGKjAwUOPHj9eSJUvUqlUru8vyikWLFumbb77Riy++aHcpXtWtWzclJSVp1apVmj17tvbt26ebb75Zp06dsru0Kvf9999r9uzZatasmVavXq1f/epXeuyxx/T222/bXZpXffjhhzpx4oTGjh1rdynVlu1n9gWuxoQJE7R9+3bHjBeQpBtuuEGpqak6efKk3n//fY0ZM0br1q277sPMgQMH9Pjjj2vt2rUKCgqyuxyvGjBggPtyu3bt1K1bNzVs2FD/+Mc/9OCDD9pYWdUrKipS586d9Yc//EGS1LFjR23fvl1z5szRmDFjbK7Oe9566y0NGDBAsbGxdpdSbRm5RyYqKkq+vr46cuSIx/QjR46obt26NlUFb3nkkUe0YsUKffbZZ4qLi7O7HK8JCAhQ06ZN1alTJ7344otq3769Zs2aZXdZVW7r1q3KysrSz372M/n5+cnPz0/r1q3TK6+8Ij8/PxUWFtpdotdERESoefPm2rNnj92lVLl69eqVCOktW7Z0zKE1Sdq/f78++eQTPfTQQ3aXUq0ZGWQCAgLUqVMnffrpp+5pRUVF+vTTTx01ZsBpLMvSI488oiVLlig5OVmNGjWyuyRbFRUVKS8vz+4yqtxtt92mbdu2KTU11f3XuXNnjRw5UqmpqfL19bW7RK/Jzc3V3r17Va9ePbtLqXI9evQocXqF9PR0NWzY0KaKvG/evHmKiYnRHXfcYXcp1Zqxh5YmTpyoMWPGqHPnzuratatmzpyp06dP64EHHrC7tCqVm5vr8W1s3759Sk1NVWRkpBo0aGBjZVVvwoQJWrBggZYuXaqaNWu6x0OFh4crODjY5uqq1jPPPKMBAwaoQYMGOnXqlBYsWKDPP/9cq1evtru0KlezZs0S46BCQkJUu3bt63581FNPPaU777xTDRs21I8//qgpU6bI19dX9913n92lVbknn3xSP//5z/WHP/xB9957rzZt2qS5c+dq7ty5dpfmFUVFRZo3b57GjBkjPz9jP6q9w+6fTV2LV1991WrQoIEVEBBgde3a1frqq6/sLqnKffbZZ5akEn9jxoyxu7QqV1rfkqx58+bZXVqVGzdunNWwYUMrICDAio6Otm677TZrzZo1dpdlG6f8/Hr48OFWvXr1rICAAKt+/frW8OHDrT179thdltcsX77catOmjRUYGGi1aNHCmjt3rt0lec3q1astSVZaWprdpVR7/PdrAABgLCPHyAAAAEgEGQAAYDCCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAKqFxMREdejQwe4yABiGIAOgUhw+fFiPPvqoGjdurMDAQMXHx+vOO+/0+OeuAFDZ+E9UAK5ZRkaGevTooYiICM2YMUNt27bV+fPntXr1ak2YMEG7du2yu0QA1yn2yAC4Zg8//LBcLpc2bdqkoUOHqnnz5mrdurUmTpyor776SpKUmZmpQYMGKTQ0VGFhYbr33nt15MiRMu+zqKhIzz33nOLi4hQYGKgOHTpo1apV7vkZGRlyuVxavHixbr31VtWoUUPt27dXSkqKe5mkpCRFRERo9erVatmypUJDQ9W/f38dOnTIY11vvvmmWrZsqaCgILVo0UJ/+ctfKvkRAlBVCDIArkl2drZWrVqlCRMmKCQkpMT8iIgIFRUVadCgQcrOzta6deu0du1aff/99xo+fHiZ9ztr1iz9+c9/1ksvvaRvv/1W/fr101133aXdu3d7LPe73/1OTz31lFJTU9W8eXPdd999KigocM8/c+aMXnrpJf3973/X+vXrlZmZqaeeeso9/91339XkyZM1bdo0fffdd/rDH/6gZ599Vm+//XYlPDoAqpzd/34bgNm+/vprS5K1ePHiMpdZs2aN5evra2VmZrqn7dixw5Jkbdq0ybIsy5oyZYrVvn179/zY2Fhr2rRpHvfTpUsX6+GHH7Ysy7L27dtnSbLefPPNEvf53XffWZZlWfPmzbMkWXv27HEv8/rrr1t16tRxX2/SpIm1YMECj/U8//zzVvfu3cv7EACwEXtkAFwTy7KuuMx3332n+Ph4xcfHu6e1atVKERER+u6770osn5OTox9//FE9evTwmN6jR48Sy7dr1859uV69epKkrKws97QaNWqoSZMmHssUzz99+rT27t2rBx98UKGhoe6/F154QXv37r1iXwDsx2BfANekWbNmcrlctg3o9ff3d192uVySLoyvKW1+8TLF4Ss3N1eS9MYbb6hbt24ey/n6+lZJvQAqF3tkAFyTyMhI9evXT6+//rpOnz5dYv6JEyfUsmVLHThwQAcOHHBP37lzp06cOKFWrVqVuE1YWJhiY2P1xRdfeEz/4osvSl3+atWpU0exsbH6/vvv1bRpU4+/Ro0aVdp6AFQd9sgAuGavv/66evTooa5du+q5555Tu3btVFBQoLVr12r27NnauXOn2rZtq5EjR2rmzJkqKCjQww8/rJ49e6pz586l3uekSZM0ZcoUNWnSRB06dNC8efOUmpqqd999t1Jrnzp1qh577DGFh4erf//+ysvL05YtW3T8+HFNnDixUtcFoPIRZABcs8aNG+ubb77RtGnT9Otf/1qHDh1SdHS0OnXqpNmzZ8vlcmnp0qV69NFHdcstt8jHx0f9+/fXq6++WuZ9PvbYYzp58qR+/etfKysrS61atdKyZcvUrFmzSq39oYceUo0aNTRjxgxNmjRJISEhatu2rZ544olKXQ+AquGyyjNSDwAAoBpijAwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxvr/SMzPClaPbP4AAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Creer un plateau et avancer jusqu'au premier blocage\n",
-        "random.seed(77)\n",
-        "np.random.seed(77)\n",
-        "board_viz = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(3, 3))\n",
-        "board_viz.reveal(3, 3)\n",
-        "\n",
-        "# Appliquer les regles simples\n",
-        "rule_solver_viz = RuleBasedSolver(board_viz)\n",
-        "rule_solver_viz.solve()\n",
-        "\n",
-        "# Calculer le CSP et les probabilites\n",
-        "csp_solver_viz = CSPSolver(board_viz)\n",
-        "safe, mines, solutions_viz = csp_solver_viz.solve()\n",
-        "\n",
-        "# Appliquer les deductions sures\n",
-        "for cell in mines:\n",
-        "    board_viz.flag(*cell)\n",
-        "for cell in safe:\n",
-        "    board_viz.reveal(*cell)\n",
-        "\n",
-        "# Relancer regles + CSP jusqu'au blocage complet\n",
-        "for _ in range(5):\n",
-        "    rs = RuleBasedSolver(board_viz)\n",
-        "    rs.solve()\n",
-        "    cs = CSPSolver(board_viz)\n",
-        "    s, m, sols = cs.solve()\n",
-        "    if not s and not m:\n",
-        "        break\n",
-        "    for cell in m:\n",
-        "        board_viz.flag(*cell)\n",
-        "    for cell in s:\n",
-        "        board_viz.reveal(*cell)\n",
-        "\n",
-        "# Calculer les probabilites finales\n",
-        "csp_final = CSPSolver(board_viz)\n",
-        "_, _, solutions_final = csp_final.solve()\n",
-        "probs = csp_final.get_probabilities(solutions_final)\n",
-        "\n",
-        "if probs:\n",
-        "    print(\"Probabilites de mine pour les cellules non determinees :\")\n",
-        "    print(\"=\" * 50)\n",
-        "    for cell in sorted(probs.keys()):\n",
-        "        p = probs[cell]\n",
-        "        if 0 < p < 1:  # Seulement les cellules non determinees\n",
-        "            print(f\"  {cell} : P(mine) = {p:.1%}\")\n",
-        "\n",
-        "    fig = draw_board(board_viz,\n",
-        "                     title=\"Probabilites de mine (cellules non determinees)\",\n",
-        "                     probabilities=probs)\n",
-        "    plt.show()\n",
-        "else:\n",
-        "    print(\"Toutes les cellules ont ete determinees par le CSP.\")\n",
-        "    fig = draw_board(board_viz, title=\"Plateau entierement resolu par le CSP\")\n",
-        "    plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-29",
-      "metadata": {
-        "papermill": {
-          "duration": 0.004961,
-          "end_time": "2026-02-26T07:01:10.557485",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.552524",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-29"
-      },
-      "source": [
-        "### Interpretation : carte de probabilites\n",
-        "\n",
-        "**Sortie obtenue** : les pourcentages sur les cellules non determinees representent la probabilite qu'elles contiennent une mine.\n",
-        "\n",
-        "| P(mine) | Interpretation | Action |\n",
-        "|---------|---------------|--------|\n",
-        "| 0% | Sure dans toutes les solutions | Reveler sans risque |\n",
-        "| 100% | Mine dans toutes les solutions | Poser un drapeau |\n",
-        "| 10-30% | Faible risque | Bon candidat pour une devinette |\n",
-        "| 40-60% | Incertitude forte | Eviter si possible |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Les probabilites sont **exactes** (calculees par enumeration complete)\n",
-        "2. Le solveur choisit toujours la cellule a **0%** si elle existe, puis la plus faible probabilite sinon\n",
-        "3. Les probabilites dependent des solutions **globales** du CSP, pas seulement des voisins locaux"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-30",
-      "metadata": {
-        "papermill": {
-          "duration": 0.007185,
-          "end_time": "2026-02-26T07:01:10.570820",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.563635",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-30"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 6. Analyse des performances (~7 min)\n",
-        "\n",
-        "Comparons les trois approches sur un grand nombre de parties pour mesurer leur taux de victoire et leur temps d'execution.\n",
-        "\n",
-        "### Protocole experimental\n",
-        "\n",
-        "- 100 parties par approche\n",
-        "- Plateau 8x8 avec 10 mines (difficulte standard \"debutant\")\n",
-        "- Premier clic garanti sur (4, 4)\n",
-        "- Meme sequence aleatoire pour toutes les approches"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-31",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:04.244946Z",
-          "iopub.status.busy": "2026-04-21T00:32:04.244524Z",
-          "iopub.status.idle": "2026-04-21T00:32:04.255205Z",
-          "shell.execute_reply": "2026-04-21T00:32:04.254108Z"
-        },
-        "papermill": {
-          "duration": 0.016946,
-          "end_time": "2026-02-26T07:01:10.594801",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.577855",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-31",
-        "outputId": "ecbb40a3-0a60-47bb-f716-62ab4c9028ac",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Fonctions de simulation definies.\n"
-          ]
-        }
-      ],
-      "source": [
-        "def play_rule_only(board):\n",
-        "    \"\"\"Joue une partie avec les regles simples uniquement.\n",
-        "\n",
-        "    Quand les regles se bloquent, choisit une cellule aleatoire.\n",
-        "    \"\"\"\n",
-        "    decisions = {'rules': 0, 'random': 0}\n",
-        "    while not board.game_over and not board.won:\n",
-        "        solver = RuleBasedSolver(board)\n",
-        "        solver.solve()\n",
-        "        if solver.moves_log:\n",
-        "            decisions['rules'] += len(solver.moves_log)\n",
-        "            continue\n",
-        "\n",
-        "        if board.game_over or board.won:\n",
-        "            break\n",
-        "\n",
-        "        # Choisir aleatoirement parmi les inconnues\n",
-        "        unknown = [\n",
-        "            (r, c) for r in range(board.rows) for c in range(board.cols)\n",
-        "            if (r, c) not in board.revealed and (r, c) not in board.flagged\n",
-        "        ]\n",
-        "        if not unknown:\n",
-        "            break\n",
-        "        cell = random.choice(unknown)\n",
-        "        board.reveal(*cell)\n",
-        "        decisions['random'] += 1\n",
-        "\n",
-        "    return board.won, decisions\n",
-        "\n",
-        "\n",
-        "def play_csp_only(board):\n",
-        "    \"\"\"Joue une partie avec regles + CSP.\n",
-        "\n",
-        "    Quand le CSP se bloque, choisit une cellule aleatoire.\n",
-        "    \"\"\"\n",
-        "    decisions = {'rules': 0, 'csp': 0, 'random': 0}\n",
-        "    while not board.game_over and not board.won:\n",
-        "        # Regles simples\n",
-        "        solver = RuleBasedSolver(board)\n",
-        "        solver.solve()\n",
-        "        if solver.moves_log:\n",
-        "            decisions['rules'] += len(solver.moves_log)\n",
-        "            continue\n",
-        "\n",
-        "        if board.game_over or board.won:\n",
-        "            break\n",
-        "\n",
-        "        # CSP\n",
-        "        csp_solver = CSPSolver(board)\n",
-        "        safe, mines, _ = csp_solver.solve()\n",
-        "        if safe or mines:\n",
-        "            for cell in mines:\n",
-        "                board.flag(*cell)\n",
-        "            for cell in safe:\n",
-        "                board.reveal(*cell)\n",
-        "            decisions['csp'] += len(safe) + len(mines)\n",
-        "            continue\n",
-        "\n",
-        "        if board.game_over or board.won:\n",
-        "            break\n",
-        "\n",
-        "        # Aleatoire\n",
-        "        unknown = [\n",
-        "            (r, c) for r in range(board.rows) for c in range(board.cols)\n",
-        "            if (r, c) not in board.revealed and (r, c) not in board.flagged\n",
-        "        ]\n",
-        "        if not unknown:\n",
-        "            break\n",
-        "        cell = random.choice(unknown)\n",
-        "        board.reveal(*cell)\n",
-        "        decisions['random'] += 1\n",
-        "\n",
-        "    return board.won, decisions\n",
-        "\n",
-        "\n",
-        "def play_probabilistic(board):\n",
-        "    \"\"\"Joue une partie avec le solveur probabiliste complet.\"\"\"\n",
-        "    solver = ProbabilisticSolver(board)\n",
-        "    won = solver.play_game()\n",
-        "    return won, solver.decisions\n",
-        "\n",
-        "\n",
-        "print(\"Fonctions de simulation definies.\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f9cg0uqgn9b",
-      "metadata": {
-        "papermill": {
-          "duration": 0.006512,
-          "end_time": "2026-02-26T07:01:10.607628",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.601116",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "f9cg0uqgn9b"
-      },
-      "source": [
-        "Lançons le benchmark sur 100 parties pour chaque approche. L'execution peut prendre quelques secondes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-32",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:04.257590Z",
-          "iopub.status.busy": "2026-04-21T00:32:04.257255Z",
-          "iopub.status.idle": "2026-04-21T00:32:04.534191Z",
-          "shell.execute_reply": "2026-04-21T00:32:04.532917Z"
-        },
-        "papermill": {
-          "duration": 0.993538,
-          "end_time": "2026-02-26T07:01:11.607695",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:10.614157",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-32",
-        "outputId": "78b9fba7-dd46-428a-ba55-a5d78e50f1ca",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Regles + aleatoire\n",
-            "  Victoires : 75/100 (75%)\n",
-            "  Temps moyen : 2.7 ms\n",
-            "  Decisions : {'rules': 2309, 'random': 131}\n",
-            "\n",
-            "Regles + CSP + aleatoire\n",
-            "  Victoires : 89/100 (89%)\n",
-            "  Temps moyen : 28.5 ms\n",
-            "  Decisions : {'rules': 2316, 'csp': 378, 'random': 46}\n",
-            "\n",
-            "Regles + CSP + probabilites\n",
-            "  Victoires : 87/100 (87%)\n",
-            "  Temps moyen : 15.2 ms\n",
-            "  Decisions : {'rules': 2365, 'csp': 395, 'guess': 59}\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Benchmark sur 100 parties\n",
-        "N_GAMES = 100\n",
-        "ROWS, COLS, MINES = 8, 8, 10\n",
-        "\n",
-        "approaches = [\n",
-        "    (\"Regles + aleatoire\", play_rule_only),\n",
-        "    (\"Regles + CSP + aleatoire\", play_csp_only),\n",
-        "    (\"Regles + CSP + probabilites\", play_probabilistic),\n",
-        "]\n",
-        "\n",
-        "results = []\n",
-        "\n",
-        "for name, play_func in approaches:\n",
-        "    wins = 0\n",
-        "    total_time = 0\n",
-        "    total_decisions = defaultdict(int)\n",
-        "\n",
-        "    for game_id in range(N_GAMES):\n",
-        "        # Meme graine pour chaque approche\n",
-        "        random.seed(1000 + game_id)\n",
-        "        np.random.seed(1000 + game_id)\n",
-        "\n",
-        "        board_bench = MinesweeperBoard(ROWS, COLS, MINES, safe_cell=(4, 4))\n",
-        "        board_bench.reveal(4, 4)\n",
-        "\n",
-        "        # Remettre le generateur aleatoire pour le solveur\n",
-        "        random.seed(2000 + game_id)\n",
-        "\n",
-        "        start = time.time()\n",
-        "        won, decisions = play_func(board_bench)\n",
-        "        total_time += time.time() - start\n",
-        "\n",
-        "        if won:\n",
-        "            wins += 1\n",
-        "        for k, v in decisions.items():\n",
-        "            total_decisions[k] += v\n",
-        "\n",
-        "    win_rate = wins / N_GAMES * 100\n",
-        "    avg_time = total_time / N_GAMES * 1000\n",
-        "    results.append({\n",
-        "        'name': name,\n",
-        "        'wins': wins,\n",
-        "        'win_rate': win_rate,\n",
-        "        'avg_time_ms': avg_time,\n",
-        "        'decisions': dict(total_decisions)\n",
-        "    })\n",
-        "\n",
-        "    print(f\"{name}\")\n",
-        "    print(f\"  Victoires : {wins}/{N_GAMES} ({win_rate:.0f}%)\")\n",
-        "    print(f\"  Temps moyen : {avg_time:.1f} ms\")\n",
-        "    print(f\"  Decisions : {dict(total_decisions)}\")\n",
-        "    print()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-33",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005886,
-          "end_time": "2026-02-26T07:01:11.619808",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.613922",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-33"
-      },
-      "source": [
-        "### Tableau comparatif et visualisation"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-34",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:04.537875Z",
-          "iopub.status.busy": "2026-04-21T00:32:04.537314Z",
-          "iopub.status.idle": "2026-04-21T00:32:04.733490Z",
-          "shell.execute_reply": "2026-04-21T00:32:04.731905Z"
-        },
-        "papermill": {
-          "duration": 0.130504,
-          "end_time": "2026-02-26T07:01:11.756196",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.625692",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-34",
-        "outputId": "11157cf1-7ebc-4f51-ab64-f1b6139f8e47",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 448
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Comparaison des approches - Demineur 8x8, 10 mines\n",
-            "=================================================================\n",
-            "Approche                        Victoires     Taux   Temps (ms)\n",
-            "-----------------------------------------------------------------\n",
-            "Regles + aleatoire                 75/100     75%         2.7\n",
-            "Regles + CSP + aleatoire           89/100     89%        28.5\n",
-            "Regles + CSP + probabilites        87/100     87%        15.2\n",
-            "=================================================================\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 1400x500 with 2 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAABW8AAAHvCAYAAAArVS1OAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAApzxJREFUeJzs3Xd8Tvf///Fn9hYrRFRssWPFCjVrB61NS2pX1KhVVcSqGkWN4tMitEZRm5q1laKqtJpqrA5q1KgZkvP7wy/ne13ZsXLRx/12u27Jdc77vM/7jOs67+t13uf9tjMMwxAAAAAAAAAAwKbYp3cBAAAAAAAAAAAJEbwFAAAAAAAAABtE8BYAAAAAAAAAbBDBWwAAAAAAAACwQQRvAQAAAAAAAMAGEbwFAAAAAAAAABtE8BYAAAAAAAAAbBDBWwAAAAAAAACwQQRvAQAAAAAAAMAGEbwFADxxO3bskJ2dnezs7JQnT570Ls4TkSdPHnObduzY8VTWEZe/nZ2dzpw581TWYQuexb58UYSGhpr7Kjw8PL2LY1P+K58XS6+//rrs7Ozk7e2ta9eupXdxkITq1aub52ZERER6FwfPgfQ4Z4YOHSo7Ozs5OTkpMjLymawTAPBoCN4CgI2JiIiwCkrEvdzd3ZUvXz61bt1ae/fuTe9iAnhBWAbT437IZ8iQQfnz51f9+vU1depUXb9+Pb2L+Z936NAhLVq0SJLUo0cPZcyY0Wr+3r171aJFC/n7+8vFxUXOzs566aWX9Nprr2nnzp2Pvf6zZ8+qZ8+eKly4sDw8POTo6CgfHx/VqFFDc+fOlWEYj72Of/75R0OHDlW9evWUNWvWVAfojx8/rrZt28rPz0/Ozs7y8/NT27Zt9dNPPz12mWDtzJkzGjhwoGrWrClvb2+rY5ScvXv3qkmTJvLx8ZGLi4ty586trl276ty5c4mmv3XrlkaMGKHixYvL3d1d3t7eqlKlihYsWPBEzrVnLTw83HzZyo2XPn36yMPDQw8ePNDAgQPTuzgAgOQYAACbMm/ePENSsi8HBwdj7dq16V3UJG3fvt0sa+7cudO7OE9E7ty5zW3avn37U1mH5TE+ffr0U1mHLXgW+/JF0aFDB3NfDR8+/Kmsw/J4JPXy8fExNm/e/FTW/6h2795tvu7evZvexXnqQkJCDEmGnZ2dce7cOat5K1euNOzt7ZM8fnZ2dsaSJUseed1nzpwxMmfOnOw58tZbbz3uJhpHjhxJMv+kvhM3bNhguLi4JLqMq6trupy3P/74o3lu/v333898/U/TypUrkzxGSfnss88MOzu7RJfJnDmz8cMPP1il/+eff4zAwMAk19OxY8envZlPXErncnqdM506dTLLdeTIkWe2XgBA2tDyFgBs3O7du7V7924tXLhQ2bNnlyTFxMRo0qRJ6Vyy/4abN2+mdxFgg2JjY3Xnzp30LsYT9+abb2r37t1au3athgwZoqxZs0qSLl26pEaNGmn37t3pXML/U6VKFfPl4uKS3sV5ZPfv31d0dHSyac6ePav169dLerjduXLlspo/ceJExcbGSpKKFy+uVatWaeXKlSpcuLAkyTCMx7pmfPrpp/rnn38kSRkyZNDcuXO1adMmhYSEmGn+97//Pfb3pbOzs4KDg9W7d29NnDgxxfRXr15V+/btde/ePUlS+/bttXbtWrVv316SdPfuXb3++uvPvOV4iRIlzHMzW7Zsz3TdT5u7u7tq1KihAQMG6L333ksx/W+//aawsDCztWy/fv20Zs0aNWzYUNLD1tZt2rRRTEyMucyAAQN09OhRSVKhQoW0dOlSffLJJ3Jzc5MkzZ07V4sXL37Sm/bE3blzx/xcpiS9zpk2bdqY/8+aNeuZrRcAkEbpHT0GAFiL3/LWUr9+/czpAQEBCZb9+eefjU6dOhl58+Y1XFxcDC8vL6Ny5crGvHnzjNjYWKu08Vv0rV692qhQoYLh6upqZM2a1ejatatx8+bNBOv47bffjB49ehgBAQGGm5ub4e7ubgQEBBhdunQxW7/Fb3n7119/GaGhoUaWLFkMV1dXo0qVKsbBgwet8h0+fLi5TIcOHYz169cbZcqUMVxcXIx8+fIZ06ZNMwzDMH799VcjJCTE8PLyMry9vY1WrVoZFy9etMpr0aJFRuPGjY38+fMb3t7ehqOjo5E5c2bj5ZdfNubMmZNgX1SrVs1c99y5c43JkycbhQsXNpycnIzevXsbhpF4a9HY2FirVit58uQxoqKiUjjChvHNN98YlSpVMlxdXY1s2bIZb731lnH16tVkW+ak5dj+8ccfRteuXY28efMazs7Ohqurq/HSSy8ZtWvXNoYNG5Zi+QzDME6cOGG0bdvWeOmllwwnJyfD3d3dyJ07t9GwYUPj448/TpB+9erVRv369Q0fHx/D0dHRyJIli/HKK68Yy5YtS5A2sX1ZsWJFc9qiRYus0p89e9ZsteXm5mZcu3bNnHfgwAGjdevWZjkzZsxo1KpVy1i9enWq1msYhnH69OkkP3OW048ePWr06tXL8PPzM+zt7Y2VK1cahmEYn3/+uVGlShUjY8aMhoODg5E5c2ajePHiRocOHYxvv/02Vfv74sWLRseOHY0sWbIY7u7uRrVq1Yx9+/Yl2/L21q1bxrhx44ygoCDDy8vLcHZ2NgoUKGD07ds3wWciOZb7Jf46/vjjD8Pf39+cX6xYMSMmJsYqTVqOQfzP2sSJE428efMarq6uRlBQkLF161bDMAzj66+/NsqXL2+4uroafn5+xuDBg40HDx5Y5ZXU58Vye7Zu3WpMmDDBKFiwoOHs7GzkyZPH+OijjxLdD5s2bTIaN25sZM+e3XBycjKyZs1qhISEGLt27UqQNql1J/XUQfxz7K+//jI6dOhg+Pj4GHZ2dim2eJswYYK57IcffphgfrFixcz5cd+V8ZcrVaqUYRiGER0dbZQvX96cPmLECDP98ePHzVaszs7Oxvfff28YhmGEhYWZ6Zs1a2amP3jwoNV2WX42H1f8fZZYa8WpU6ea8wsVKmR+F8bExBgFCxY0502fPj3F9T3Ja5DleT5v3jxz+qNed5/1939qWZ7vSf2sfOedd8z5tWvXNqffvn3b8PLyMuetW7fOMAzDuHz5suHs7GxO37Nnj7nM6NGjzenlypVLsXzxz6ErV64Y3bt3N7Jnz264uLgYZcuWTfA9dfnyZaNbt25G+fLlDV9fX8PFxcVwdXU18ufPb3Tu3DnBNT7+Zz4yMtJ49dVXjYwZMxqSjCZNmiTZgtjy/EjqnDEMw7hy5Yrx/vvvGyVLljQ8PDwMV1dXo2jRosbw4cONf//91yrt3bt3jREjRhglS5Y03N3dDScnJyN79uxGxYoVjbfffts4f/68VfoHDx4YHh4ehiQjU6ZMCb7fAQC2geAtANiYpIK3v//+u1GmTBlzesuWLa2WW7lypeHq6prkD4R27dpZ/ciz/BFZoECBRJfp1q2b1TrWrVtnuLu7J7mOq1evGoZh/WMmY8aMxksvvZQgbdasWY0bN26YeVv+cM6fP3+ijwAPGjQo0Ud369ata1XOVq1aJftjKS4gG8fyR5PlD37LtPEDf7GxsUaXLl3MaQEBAcbvv/+e4vHdtGmT4ejomKBMpUuXTjJQkZZjGx0dbeTPnz/JtC4uLimW8fLly8k+Ih3/xsHbb7+d7P7u2rWrVfrEgqiffvqpOa1Ro0ZW6ceOHWvOe+ONN8zpM2bMSPZR8cGDB6e4XsNIffA2/rmxcuVKY+7cuclu+9ixY1Pc3zdv3jSKFi2a6LGynG4ZWL106ZJRvHjxJNebM2dO49SpUymuO/5+Saxrhs8//9wq7wMHDjzyMbD8rBUqVChBeicnJ2PUqFGJPmIdf18m9Xmx3J74xyzutXjxYqu8Bg0alOQ22NvbGzNnzkzVulMbvI1frpSCt40aNUr03I3Tt29fc37x4sWNVatWGStXrjQKFy5sTrcMWkdFRZmBMycnJ+P77783oqOjra4xU6ZMMdOvXr3anJ4hQwZj7ty5xubNm82uHCQZISEhyW5DWqUmeNu0aVNzfmhoqNU8y2vca6+9luL6nuQ1KDXB29Red5/1939apCZ4W6pUKXN+eHh4kvvpnXfeMQzDMFatWmVOc3R0NO7fv5/o+uzs7Izr168nW77451Bi37N2dnbGwoULzWVOnDiR5P6THgY4LQO4lmXy9vY2fHx8rNI/bvD25MmTidahLD/vV65cMdO3b98+2fUldkPx5ZdfNufH3bABANgWgrcAYGNS0+dt8eLFjTNnzpjLXLx40fD09DTnd+/e3di4caPx+eefWwUy5syZYy5j+SNSktGmTRtj3bp1xltvvWX1wymuVcfFixeNDBkymPPy5ctnzJ4929i0aZMxc+ZMo0KFCokGbyUZefPmNRYtWmTMmzfP8Pb2NqfPmjXLLI/lD2dJRqtWrYz169cbzZo1s5qeO3du48svvzSmTZtmNf2XX34x81q4cKExa9YsY82aNcb27duNbdu2GXPmzDGyZs1qSA/7DLZsfWL5o0mS0bhxY2PlypXGqlWrzNZAlvvxm2++Mbp3726+L1GihHHhwoUUj21MTIzVD+uiRYsay5YtM7744gsjV65cVmWIC1Sk9dhatoQrWbKksXLlSmPLli3G/Pnzjd69exvFihVLsZzLli0z86hRo4axbt06Y9OmTcbcuXONzp07GzVr1jTTWgZ1JBl9+/Y1NmzYYAwaNMgqALd06VJzmcSCqDdu3DBb/zg5ORmXL18205coUcJMv2PHDsMwHrYQjAuu2NvbG0OGDDE2b95szJ4928iUKZOZftu2bcmu1zBSH7y1t7c3+vXrZ3z99dfG559/bvz4449Gw4YNrQIT27ZtM1auXGlMmjTJqFevnlUALCnh4eFmHs7OzsaHH35orFu3LsG5bxlYbdmypTm9VKlSxuLFi42vv/7aapmqVaumuO74+yWx4O2FCxesyjFjxoxHPgaWnzV7e3tj+PDhxvr1640iRYpYraNWrVrG2rVrrW6Q+Pr6JnlskgreOjg4GMOHDzfWrVtnte6KFSua6Tds2GBOd3NzM8aPH29s2bLF+Oijj8xWqI6OjkZkZGSK605t8NbFxcUYOXKksWnTJuN///tfijd+LLfpjz/+SDD/9u3bRpcuXaxaLMa9cuTIYcydOzfBMl988YXVNWXgwIHm+/g3UAzDMCZPnpxo4NLZ2dl47733jNu3bye7DWmVmuBtyZIlzfnvvvuu1TzLgHxgYGCK63uS16DUBG+l1F13n/X3f1qkJnhrWW+wvOYbhvWN1iZNmhiGYRiTJk1K8jMfP7Ca0k2P+OeQn5+fERERYaxcudKoUKGCOT1jxoxmi+cLFy4YI0eONL788ktj48aNxo4dO4y1a9car7/+upm+R48eSe6DjBkzGlOmTDE2b95sfPzxx2ZftpZpli1blqB/26TOGcty1qhRw1i5cqWxdu1aq/SWNzXjrqPe3t7GvHnzjG+++cZYsmSJER4ebgQFBVndfIvTuXNnM6+IiIhk9ykAIH0QvAUAG5Oa4G2FChWMY8eOmctY/ogsXry41UA+Q4YMSTRgYfkjslixYlaPm1q2rv3xxx8NwzCM6dOnm9M8PT0TDSDEif9j5rvvvjPnWQY941raGIb1D2c/Pz+ztc13331nldeGDRvMZSwfFV6zZo05/fLly8agQYOMEiVKGB4eHom24rNMb/kjqGzZsoluk+UPZctH/IOCgqxavSTn0KFDVmU4evSoOc8ygGQZqEjrsf3111/NabVq1TJ++uknIzo6OlXli7N582Yzj7Zt2xonT55M8Mh6nFdffdVMG7/lXfPmzc15DRo0MKcnFUR98803zemffPKJYRgPB3GJm1agQAHzPLXsQqR27dpW+6Vjx47mvNatW6e43tQGby3P1zht27Y15y9evNi4dOlS6nayBcsWtH379jWnR0dHGzlz5jTnxQVWr169ajg4OJjTFy1aZG779u3bDScnJ3OeZUApKSkFb+/fv2+1H8aMGWMYxqMdA8vPmuXTA+PHjzenu7q6mp+pS5cuWa3bsrV+Yp+X+NtjGWTZv3+/OT1z5szmdMvg3BtvvGG1HQ0aNDDnWQYHk1p3aoO3U6dOTfG4WLL8Tr5z506C+Q8ePDDGjBljZM+ePdFrRs2aNRP9zo4fTIz7/k3sPF62bJnVjRTLV4ECBRLtXuJxpCZ4a3kzLH6XAEOHDjXn5c+fP8X1PclrUGqCt6m57qbH939apCZ4a/ldFf8mwhtvvGFVXsMwjFGjRpnT/P39rdJHRUVZrW/37t3Jli/+ObR+/Xpz3l9//WV1s2PFihXmvHXr1hkNGzY0fH19E31SpkyZMknuA8vzwFJK53Ji58yxY8fMaU5OTsamTZvM4798+XKreXEBfz8/P/Mc3rt3b6LdcMRneeNm/PjxKaYHADx7jgIA2LS4AYKuXr2qyZMna/v27Tpw4IDq1aunqKgoubi46OeffzbTHz9+XFWrVk00r+PHjyc6vWbNmrKzs5Mk2dvbK1OmTLp9+7YkmYPUWK6jQoUKypkzZ6rK7+XlpaCgIPN9lixZzP/j8o6vfPnycnR0TJBekipVqmT+HzeYkmVed+7cUXBwsCIjI5Mt19WrVxOd/tprryW7nCTt37/fXP+WLVvk7e2d4jLSw4Fb4ri7u6tkyZLm++Dg4ESXSeuxLVCggGrXrq2tW7dq27ZtKlasmBwcHJQ/f35VqlRJ3bt3V8WKFZMtZ9WqVVWsWDH99NNPWrRokRYtWiRnZ2cVLFhQL7/8snr27KmiRYtKkn755RdzuSpVqljlU6VKFS1fvjxBuqR06tRJ8+bNkyQtXLhQb731lhYtWmTO79ixo3meWu6XrVu3auvWrcnulyehWbNmCaZ16dJFX375pWJiYsyBXzJlyqSSJUuqUaNG6tGjh9zd3ZPN1/K8sDy/nZycVL58ea1cudIq/a+//mo1uE/btm2TzPv48eMKCAhIfsNScOnSJav3GTNmlPT4x6By5crm/5af84CAAGXOnFmS9Wdcevg59/LySnXZa9Wqleg6LL97LLfj888/1+eff55oXk/7XEot4/8P/GSpR48e+t///idJatKkiT755BO5u7tryJAh+uSTT/TNN98oJCREhw4dkr39/41XPH36dO3Zs0dRUVHmtM8//zzBfl+8eLF5nhUsWFDLly9XgQIFtHz5coWGhuq3335T/fr1FRkZmeprw5Pg4eFh/h83aFli7z09PdOU7+Ncg1IrrdfdZ/X9/6R5eHjoxo0bklJ3jFJ7TC2XSS3La1SOHDmUL18+89p08uRJSQ8HQ+vUqVOy+SRVf3BxcVGjRo3SVKbkWB7/+/fvq27duommu3//viIjI1W2bFl1795dw4YN019//WXWK3LmzKmyZcuqbdu2atWqVYLlE/tOAQDYFvuUkwAA0lPc6MMhISFWgaw///xTO3fuTFNeSY0EHhcoiRP3o1V6/Er9o+RtGQy1DDRI/xc4ii8ur5UrV5qBWw8PD02dOlXbt2/X7t27VaJECTN9UiNA58iRI4kt+T8ODg6SpMuXL6dqtO1nIe7Y2tnZae3atZo1a5ZeffVVBQQEyN7eXr/++qvmz5+vl19+WYcOHUo2L1dXV+3du1cTJ05Uw4YNlT9/fsXExOinn37SzJkzVblyZZ07d+6Jb0NwcLAZaNy3b59Onz5tjiju4OCgDh06pDlPy3M+LlAiSQ8ePDD/jx+cTEpi50b16tV16NAh9e7dW8HBwcqaNauuXr2qnTt3asCAAWrXrl2ay/wkJfWZT4vNmzdbvS9XrtwTKUNSn/OkPuNS2r+PLL9/LL97HkVS2/GkzqXk+Pj4mP/HDxLeu3dPc+bMMd+Hh4fLz89PGTNm1AcffGBOP3LkiBmginPx4sUEZT5y5EiC9X/yySfm/z169FDJkiXl7u6u9u3bKzAwUJJ069YtrVu3Lk3b9bjy5ctn/n/hwgWreefPnzf/z58/f5ryfZxrUGo9yevuk/z+f9LSeows01+5csXq82WZ3s7Ozirtk/Lhhx+a/9erV09r1qzR7t27NXnyZHN6UvWH7NmzW11nnqW4c2Do0KFas2aNOnTooNKlS8vT01N//vmn1qxZo9atW+vjjz9OsKzld0q2bNmeWZkBAKlH8BYAniPxf9DFVbiLFCliTqtcubKMh93iJHg9TiAnrqWlJB04cEB//fXXI+f1NFkGFevVq6e3335b1atXV8mSJfXHH3+kuHxqfnhNnDhRGTJkkPQwqDFgwIBUlc0ygHD79m0dO3bMfL9v375El0nrsTUMQ66ururWrZtWrFihX375Rbdu3VKvXr0kPWyhE9caNimGYcjb21v9+vXTunXr9Ntvv+nGjRtma8Hr169rw4YNkqTChQuby+3du9cqH8v3lumS07FjR7MMPXv21NmzZyVJDRo0kJ+fX6L7pU2bNknuF8vWkpkyZTL/tzwX1q5dm6qyJXZuGIahUqVKacqUKdqzZ48uXbqk3377zWwRtnr1arM1XVIsz4u4Vt3Sw6DgwYMHE6QvVKiQeQNBkiIjI5M8Jx4l4G3pjz/+0Pvvv2++L1q0qBm8fZRjYIsst2Pw4MGJbkNMTIy+/vprM93TOJeSY3njKf5TBVevXrVqiR3XylF6+Fm1ZPn+wYMHatu2rZk+Lnj43nvv6fvvv7dazjLAa5m/YRjJru9pq1mzpvn/vn37zKBabGys1fePZbrnSXp8/z9plvs+7kki6WGw0fI8i0tXpUoVOTk5SXp4jn777bdmml27dpn/ly1b1rwOp5blOXHhwgWdOnXKfF+gQAFJ1nWICRMmKCQkRFWqVElV/Sm5z7XlvKSCv/FZHn83Nzddu3YtyeNfrVo1SQ/PgZCQEEVEROj777/XjRs3tHTpUjOfuBuiliy/Uyy/awAAtoNuEwDAxu3Zs0fS/3WbYCkuoNqqVSu99957unnzpvbt26fmzZurbdu28vb21p9//qnIyEht2LBBTZs21fDhwx+pHC1bttTgwYP177//mj8UBg4cqDx58ujMmTOaN2+eNmzYkGyruWfBsiXOtm3b9Pnnn8vb21sTJ05M8lHHtCpVqpTWrl2runXr6u7du5o4caLc3d01YsSIZJcrU6aM8uXLZ/5gbNu2rcLDw3Xv3r0kW/Cm9dj+/fffCg4OVrNmzVSiRAnlyJFDt2/ftmptdffu3WTL+d1336lLly5myy1fX1/9888/+umnnxLkERoaaj7Wv3btWvXv31+1a9fWrl279NVXX5npQ0NDk11nnPbt22vIkCF68OCBGSCWlOAx1tDQUE2ZMkWxsbFavHixvLy81KhRI7m4uOiPP/7Qzz//rDVr1ui9994z112oUCGzVeH777+vf//9V6dPn9bUqVNTVbbE9O3bV1FRUapTp45y5colb29vff/992bA1jAM3bt3L9muE5o3b27u2xkzZsjX11fFihVTREREojccMmbMqNdee03Lli2T9DCwPWDAABUoUEDXrl3T2bNntWvXLv3yyy+p6q7C0rlz57Rnzx5dv35d3377rWbNmqUrV65IkpydnTVr1iyzJeKjHANb1KlTJ61YsULSw2BNbGysXn75Zdnb2+vcuXP68ccftXr1an3++eeqXr26pIfn0oEDByRJYWFhCgsL0+HDh5PscuFxVa9e3WzV+t1331kFxLJlyyZfX1+zVWNYWJiGDx8uV1dXjR8/3kzn7u6uYsWKme/ff/99cxvq16+v1q1bq0OHDoqOjlbr1q31/fffmzchAgMDzQDP5MmTlS1bNuXLl09fffWVVQDMsouc8PBw8zuxQ4cOioiISHE7b9++bbb0vnjxotW8zZs3m60CmzZtKkl6/fXXNWLECF25ckUnT55UaGioWrZsqSVLlpjlypo1a7q3gH9UT/v7PzQ0VPPnz5ckDR8+XOHh4SmW6fLly2a9JP6NmVWrVkl6eK7VqVNHktS9e3dNnz5d0dHR+uabb9SvXz9Vr15dn3zyiW7duiXp4c29evXqSXrYTcXrr79udqHTqVMnjRkzRpcuXdK4cePMdfXp0ycNe/Khrl27asyYMfL29ta4ceMUHR0t6eF3alx58+XLpxMnTkiSRo8erU6dOunw4cMaM2ZMmtdnKUuWLLp8+bIkadasWWrUqJHs7e1Vvnx5OTs7J7pMiRIlFBQUpIMHD+rOnTuqWbOmevXqpVy5cunSpUs6ffq0vvnmG8XGxprd1lSpUkWFCxdWpUqV5OfnJycnJ23cuNHMM/71PyYmxgyie3t7q1SpUo+1nQCAp+RJdJwLAHhyUjNgmSSjXbt2VsutWLHCcHV1TXYZy8GILAdOiT9IUVIDO61evdpwc3NLMv+rV68ahpH0oD2GYT0oTIcOHVKcntxgUokN8HHr1i0jX758Ccrm6+trFC5cONFBZJIaXCalfbJ69WqrwUzGjRuX6LKWvv7660QHQAkICEhyQJO0HNvz588nm87R0THR0aYtffvtt8nm4eXlZZw5c8ZM37Nnz2TTd+nSJcV9aalJkyZWy2fPnt0cPMjS9OnTDXt7+2TXbXk89+zZk2gaywHD4p9jSR2TON26dUt2/Y0bN052XxuGYfz7779W52bcy8HBwWpAJsvP6cWLFxOUO/4r/mcvKZbHI6mXj4+PsXnz5sc+Bkl91iy/96pVq2a1jqSOQVLTH2VgOssBe5J6Wea1cOHCFM+l5AYsS6uzZ8+a+7lKlSoJ5i9cuDDF42A5SNrWrVvN9FmyZDHOnz9vGIZhtGjRwkzfvn17M/3PP/9sZMqUKdn8mzVrZlWmpL7TkxN/PyX1srRu3TqrgacsXy4uLsbXX3+dqnU/qWtQctMf5br7NL//kytPUuIP0JWa757Zs2cnOnCoJCNTpkzG4cOHrdJfuXIlycHxHud8Kl26dIK87OzsjAULFpjLzJo1K9F1Vq9ePdHtS66+Y6lNmzaJ5vv7778bhpH0OfPrr78aL730UrL72/I7M35dIv5r0qRJVuXasmWLOS/+tRoAYDvoNgEAnhMODg7KkiWLqlevrv/9739ma5k4r776qo4cOaKuXbuqQIECcnV1lYeHhwoUKKBGjRpp1qxZ6tGjx2OVoXHjxvrhhx/UvXt3FSxYUK6urnJ3d1ehQoXUuXNnubm5PVb+T4K7u7u++eYbvfrqq8qcObO8vb3VuHFj7dmzR9mzZ3+i62rcuLE+++wz83HIQYMGadq0ackuU69ePW3cuFEVK1aUi4uLsmTJotDQUKvHQeNLy7HNmDGjRo0apTp16sjf319ubm5ydHSUn5+fXnvtNe3evVvly5dPtowFChTQkCFDVK1aNfn5+cnFxUVOTk7y9/fX66+/rgMHDih37txm+mnTpmnlypWqV6+esmbNKkdHR2XOnFm1a9fW0qVLzYGUUit+K9sOHTok2l9pWFiY9u/fr3bt2snf31/Ozs7KkCGDAgIC1KJFCy1YsMBqALrg4GDNnz9fAQEB5vYMHTrUbMH6KNq0aaPOnTurRIkSypIlixwcHOTh4aHSpUtr5MiR+vLLL1PMw9PTUzt37lRoaKgyZ84sNzc3VapUSRs3bkwwCFwcHx8ffffdd5o4caIqVqwob29vOTk5yc/PTxUrVtSQIUOsWj6nhb29vTw9PZUvXz7Vq1dPU6dO1cmTJ/XKK68kSJvWY2Crxo0bp82bN+vVV19Vjhw55OTkpEyZMqlo0aJq3769li9fbjXQU9u2bTVhwgTlzp1bTk5OKliwoCZNmpRof5JPgr+/vxo2bCjp4aPf8fucbtu2rfbs2aPWrVubxyHufGjatKk2b96st99+W9LDlpNvvPGG+ej2rFmz5OvrK0maPXu2OeDYggULzH7WixQpoh9++EFvv/22ihYtKnd3dzk4OChz5syqVq2aZs+eneBct+zKwdXV9SnslYcaNmyogwcPqlWrVvL19ZWTk5N8fX3VunVrHTx40GzR+bx6mt//z+oYde3aVTt27FCjRo2UJUsWOTk5KVeuXOrcubO+//57lSlTxip95syZtW/fPg0bNkxFihSRq6urvLy8VLlyZc2bN89slZtW27dvV1hYmHx9feXi4qIyZcroq6++0htvvGGm6datm2bOnKnChQvL1dVVBQsW1JQpUzRs2LDH2gcff/yxWrVqpcyZM6ep25SCBQvqxx9/1LBhw8w+bF1cXOTv76+XX35ZY8aM0axZs8z07777rlq0aKECBQooQ4YM5ue0evXq+vzzz9W3b1+r/C27UXjrrbceaxsBAE+PnWEwvCQAAABgyw4dOqTy5cvLMAwNHDjQ6hFyW1S/fn1t3LhRbm5u+vHHH80+RWE7ihQpol9++UXZs2fXzz//nGAQtefdmTNnlDdvXvM9P3utXb58Wblz59bt27fVuHFjrV69Or2LBABIAi1vAQAAABtXrlw5s+/WmTNn6tq1a+lboGRER0ebg1ONGDGCwK0N+vPPP80+sadNm/bCBW6Rso8//li3b9+Wo6OjVf/YAADbQ8tbAAAAAE/Mrl27VK1aNZUrV0779++Xg4NDehcJ8SxYsEAdOnRQ06ZNzUEnXzS0vAUAvCgI3gIAAAAAXigEbwEALwqCtwAAAAAAAABgg+jzFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAWAdFK9enXZ2dnJzs5OZ86cSZcynDlzxixD9erV06UMtlgWPN/izqM8efKkd1EAAABsUkREhFlnCg8PT+/i2Kzw8HBzP0VERKR3cfAfRfAWgM3KkyePeaFM6bVjx470Lu5/0pkzZxQeHq7w8HCtWrUqvYvzwoiOjlZ4eLjq1Kkjb2/vVAW1f/vtN7Vr107Zs2eXi4uL8ufPr0GDBunGjRsJ0sbGxmrmzJkqXbq03N3d5e3trdq1a2vbtm1PcauenFWrVpnnXXrd+AAAwJZQb8aTEhes/K8EKq9du2bWK/8r24znj2N6FwAAkH5y5Mih3bt3S5K8vb3TvPyZM2c0YsQISVKHDh3UtGnTdCvLi+T27dvmfk2No0ePqlq1arp+/bo57dSpUxo/frw2b96sXbt2ycvLy5zXsWNHzZ8/33x/584dbdu2Td98840iIiLUvn37J7MhT8mqVavM8levXj1BC9u488jV1fVZFw0AAADPkWvXrpn17mrVqik0NNRqfseOHVW7dm1JUqFChZ518QBJBG8B2LDly5fr7t275vsWLVrowoULkqSpU6eqdOnS5rwSJUo88/K9CFxcXFSlSpX0LoaktJclNjZW0dHRz2WALqWy29vbq0KFCqpcubIcHR01YcKEZPN78803zcBt165d1bBhQ3300UfatWuXfvjhB40cOdLMY82aNWbg08/PT5MmTdL58+c1YMAAPXjwQGFhYapbt66yZ8/+BLf4ybh165Y8PDxSTGcr5zQAAM8K9Wbg6fD395e/v396FwP/cXSbAMBmlStXTlWqVDFfLi4u5rwSJUqY0/Pmzau+ffsqMDBQWbNmlZOTkzJnzqyaNWsmeJQ/qb6dEutvNTIyUm5ubmbfmbdu3ZIkXb9+XX5+frKzs5OHh4d+++23ZLcjJiZG4eHhypkzp9zd3VWjRg0dPXo02WVWr16t2rVrK1OmTHJxcVFAQIBGjBihO3fuJLvc/fv3lTVrVtnZ2SlLlix68OCB1fyAgADZ2dnJ1dVVV69eTbaf2Tt37uiDDz5QmTJl5OnpKQ8PDxUrVkzDhg2T9LDFY40aNcz08+fPN/OyvGN94cIF9erVS/nz55eLi4syZsyo6tWra9myZVbrS6oslv1MzZ07V6NHj1bu3Lnl5OSk/fv3S5IMw9C8efMUHBysDBkyyM3NTYGBgfr4448VGxub7D6L89VXX6lKlSry9vaWs7OzfH19VaVKFQ0aNEiGYUhK2/mT2rInJkOGDNq/f78mTZqkmjVrJlvu7777TkeOHJEkFSlSRLNmzVLjxo21ZMkS2dnZSZLmzJmj+/fvS5JmzZplLvvRRx+pVatW6tOnjzp16iRJunnzpr744otk17ljxw6rY71p0yaVK1dOrq6uyps3r6ZMmWKV/s8//1THjh1T9RmNn/eKFStUqlQpubi4KCwsTHZ2dlathmvUqJHgMdCk+ry9f/++Jk2apLJly8rDw0MeHh6qUKFCotu7Y8cO1a5dW5kzZ5aTk5N8fHxUvnx59e7d26qFMwAAtiC19eYqVarIwcFB4eHhKl68uNzc3JQhQwZVr15dX3/9tVWe8es327dvV9myZeXm5qYyZcqY192ZM2cqX758cnV1VXBwcIJ6ruU4D8eOHVNYWJh8fHzk4eGhRo0aKSoqyir90aNH1aRJE2XLlk1OTk7KkiWLSpUqpe7du+vcuXPJ7of49Yhly5apSJEicnd3V9WqVXXs2DHFxsZq5MiRZt28fv36Onv2bIK8vv/+e7Vo0UK+vr5m3bB58+Y6fPiwmWbOnDnm+oYPH261/OrVq815b7/9tjn95s2bj7T/Dx48qBo1asjd3V2+vr56//33U13P/eabbxQUFCRXV1flz59fM2bMSNVyli5duqR33nlHBQsWlIuLizJlyqSGDRta1Wnv3bunokWLys7OTk5OTlbnQsOGDc3tWbx4cZr3R5yNGzeqQYMG8vHxkbOzs3LmzKnmzZubxzAt9fXQ0FDlzZvXTLNz584EaZLr8zY150hiZfriiy9UvHhxubi4qFChQlq6dGmqjwP+owwAeE7kzp3bkGRIMrZv325O//bbb83pib3mz59vpp03b545ffjw4eb006dPm9OrVatmTp84caI5vV+/foZhGEbXrl3NadOmTUux3GFhYQnKlCFDBiNPnjzm+9OnT5vphw4dmuS2VK1a1bh3716y6+vevbuZfvPmzeb0o0ePmtNfffXVZLf7+vXrRqlSpRItQ+7cuQ3DMIxq1aolWc4OHToYhmEYp06dMnx9fZNMN2jQoBSPwfDhw83p+fLls1o+7jxo3759kuto1apVisdox44dhr29fZJ53L9/3zCMtJ8/qSl7Sr7++utE847z0UcfmfPffPNNq3l58+Y15x05csSIjY01MmTIYE47e/asmXb+/Pnm9CZNmiRbpu3bt5tp8+fPbzg4OCTYZ2PHjjXTp+Uzapl33rx5DTs7O6vzKrl84vZp/HPVMAwjOjraqFWrVpLLDhw40Ez7yy+/GG5ubkmmPXnyZCqOHAAA6SepevO1a9eMEiVKJHmNmzFjhpnWsn6TM2dOw9XV1Sqtm5ub0b9//wR55MmTx6w7GYZ1nTEgICBB+pw5cxqXL182DMMwLl++bPj4+CRZvi1btiS73cnVIyQZvr6+RpcuXRLkGxwcbJXP6tWrDScnp0TL4OTkZKxevdowDMP4999/DU9PT0OSUaBAAas8OnbsaC6zb9++x9r/OXLkSLRu8umnn6Z4Luzdu9dwdnZOsGzJkiUTrdfG1V/nzZtnTjt79qzx0ksvpbg/DMMw9u/fb9YNy5cvb8TExBiLFi0y0zdr1sxMm5b9YRiGMWLEiBTrgWmprydXt4xLY1mft9wnqT1H4pcp/m8CSYa9vb3xyy+/pHgs8d9Fy1sAzz1fX199+OGH+uqrr7R161Zt375d8+fPl4+PjyRp9OjRj5x33759VblyZUnSxx9/rGnTpunTTz+V9LDFX1hYWLLL//LLL/rkk08kPXwUPjw8XOvWrVOlSpUSHWjp4MGDGjVqlKSHfcDOmTNHGzduVMOGDSU97Mtz8uTJya7z9ddfN/9fvnx5ov9bpknMkCFD9MMPP0iSMmfOrMmTJ2vjxo2aNm2aChcuLEmaNm2apk6dai5Tv3597d69W7t379aQIUMkST169DAf2atevbrWrFmjSZMmmd0FjBs3TgcOHEi2LJZOnTqldu3aaf369VqwYIFy5syp5cuXa8GCBZIetixevHix1q5dq4oVK0qSvvzyS3355ZfJ5rt27Vqz5cIHH3ygbdu2acmSJXr//ffN1gOPK7GyPwmW51H8rg6yZctm/n/69GldvXrVagAzy/Tx06ZWVFSUWrVqpfXr16tv377m9PDwcF2+fFnSo39GT58+rXLlymnZsmVatWqV2rRpo927d6t+/fpmmqlTp5rnneUjofF9/PHH5oBsFStW1MqVK7V8+XIFBARIksaPH2+ei1u2bDFbuffu3Vvbtm3T8uXLNXr0aJUrV+6JnA8AAKSHIUOG6NixY5KkBg0amPUSX19fSQ/rvr///nuC5f7880/Vrl1b69evN58KunPnjiZOnKjOnTtr3bp1Zh3xzJkz2rRpU6Lrv3LliubNm6dly5YpX758Zt4ffPCBJOnbb7/VpUuXJElt2rTRli1btGrVKk2cOFHVqlWTg4NDqrf19OnTCg0N1fr1682uIi5cuKBPP/1UgwcP1sqVK8260N69e/XTTz9JethNU6dOncynlt566y1t2LBBPXr0kPTwSZ5OnTrp1q1b8vT0VMuWLSU9HDw2ri4RGxur9evXS3o4mFylSpUea/+fP39eZcqU0erVq9WrVy9z+uzZs1PcD/369VN0dLQkqXbt2lq7dq1GjRplbm984eHhMgzD6km6Hj166I8//pAktW/fXhs3btTMmTPl6emp+/fvq2PHjuZTihUqVFD//v0lPXxCbPTo0erTp48kycfHRzNnzjTzTcv+OHTokFXr5k6dOmnt2rVavHixWrRoIXv7tIe3hgwZYvU0YKlSpcx65bRp05JcLi3nSHynTp1Sp06dtG7dOtWqVUvSw/Pls88+S3P58R+S3tFjAEitpFoQGIZhREREGFWrVjUyZsyY4A67JOP69euGYaS95aRhGEZkZGSCO91eXl7GmTNnUizzuHHjzGVatGhhTr927Zrh7u5uzotredu7d29z2nvvvWfs3r3b2L17t7F27VpzevHixZNdZ2xsrNniMlu2bMaDBw8MwzCMIkWKGJKMjBkzGnfv3k1yu2NiYozMmTOb0zdt2pTkuixbN8S1to1z5coV81i4uLiYLSoMwzD69etnLte7d+8ky2IY1ne747eKMAzDaNKkiTl/6tSp5j779NNPzemNGjVKdp+9++67Ztply5ZZldXS47S8TazsqZFSy1vLVh3Dhg2zmle1alVz3ueff26cO3fO6jyOjY01027bts2cnj9//mTLZHnc/f39zXPMMAwjODjYnLdgwQJzemo/o5Z5e3p6GleuXEmwfstWEom1YI6bZ9nyNjAw0Jy+dOlS8zwZOXKkOb1nz56GYRjGrFmzzGlTpkwxzp8/n+z+AADA1iRWb46JiTEyZcpkSDKcnZ2NrVu3mtfDHj16mOknTpxoGIZ1/cbNzc28Vi9btsyqHhBXn5gwYYLV9TOOZctby5aiW7ZssWqNaBiGsXHjRnPawIEDjXPnzlnVV1JiWY/IlSuXERMTk6BsVatWNdNbPiG3atUqwzAMY8WKFea0smXLWuVftmxZc97KlSsNw3jYsjVu2ttvv20YhvVTR+++++5j739nZ2fjwoULZj5xvyMyZsyY7P74+++/zTxcXFys6lXt2rVLtF4bn2Wd3tfX1yzz7t27jVdffdXMY/ny5eYyd+/eNYoWLZqgvvfVV1+ZadK6Pyx/J7Vp0ybJ8qa1vp7c70DDSLzlbVrPEcsyBQYGmmn3799vTm/atGmS2wQwYBmA597kyZP1zjvvJJvm2rVrypAhwyPlX6hQIY0aNcq8gyw9bDGaO3fuFJc9deqU+X9QUJD5v7e3twICAsy+SuP8+uuv5v8ffPCB2QrB0i+//JLsOu3s7NS2bVuNGTNGFy9e1K5du5Q9e3adOHFCktS8eXOrftDiu3z5sv755x9JDwcRixtdNa1Onjxp9hWbP39+ZcmSxZxXvnx583/LbU5Jo0aNEkyzXN6yJYKluG1PSrt27TR58mTdu3dPLVq0kPSwJWpwcLB69OjxyPvAUmJlfxIsB/C6d++e1by4VhZx6eIP9nXv3j2zFXT8tKlVrlw5q1Yw5cuX1969eyX93/n/qJ/R4OBgZc6cOdVlSY7leRLXQia+uPOkSZMmGjJkiK5cuaI+ffqoT58+ypQpkypUqKCOHTua5wgAAM+Ty5cv6+rVq5IeXveTqt8kVm8KCAgwr9OW1+ayZcuaT6RkzZrVnH7t2rVE865QoYL5v2V98MyZMzIMQ1WrVlXBggV18uRJjR8/XuPHj5eXl5fKlCmjdu3aqVOnTqluYVm2bFkzrWWZy5UrZ/6fWJkt6wyW5Y0rc1x/pnHpKleurMKFC+uXX37Rl19+qcmTJ2vNmjXmMm3atJH0ePu/cOHCZithe3t7ZcqUSbdv305yP8ex/C2SP39+q/1Qvnx5LVy4MNnlpYctiuPq9BcuXFDVqlVTLLeLi4siIiJUoUIFc9mWLVvqtddeM9OkdX9YHpenVa9OrbSeI5aqVatm/m/5+yilY4n/NrpNAPDcs3ykZeDAgdq2bZt2795tNZJu3CPxlo87x8TEmP/HPd6dlPiVqOPHjz9WmeOXJS0ePHiQIEgXX/yuEyy7TGjXrl2q1xXXsf6T9qh5xu8WILUSe2TJUvHixXX48GH16tVLFSpUkLe3ty5evKiVK1eqbt262rdvn6RHP38ep+wpsRyU6++//7aaF9dlhSTlzZtXmTJlsgqQWqaPn/ZRJXZs0/IZtfS09llS4s4TX19fHT58WIMGDVKVKlWUJUsWXb16VRs3blTLli21ZMmSZ1ouAACepcTqTd7e3ub/lsHTpBpHxAXskpNYncHd3V179+7VyJEjVbNmTfn6+urff//Vzp071bVrV40fPz41m/BMyyzJHPj14sWL2rx5sxm8LVasmEqWLJnqMkuJ7/9MmTJZvXd0fPx2eE+6jh+/3JGRkVb7NDIy0uxm4HHyTcnj1NefhJT2q+WxtDyOqTn/8N9F8BbAc+/PP/+U9PDO5bhx41SzZk2VLl3anG7JshJnGazauHFjkvlv3LhRc+bMkSSzheHMmTO1ffv2FMsW15eX9LCfpjjXr19XZGRkgvSFChUy/583b54Mw0jwunXrVrItZ6WHd+fLlCkjSVqxYoXZl1OuXLms7vYmJmvWrGal4u7du9q6dWuSaS0rwvGDbwUKFDArL1FRUbpy5Yo5z7KfW8ttTklilSHL5bdv357oPos/inF8hmGoWLFi+vjjj7V//35du3bNDHjHxsZq1apVkh7t/Emu7E9ClSpVzP+//fZbs+L3559/miMyZ8qUScWKFZOdnZ2Cg4PN9HFB6bhl4yTVoiIxhw8ftjr2lsfWsi87KXWfUUtJ7bPkzrukWJ4np06dSvQ8iesT1zAM5c6dWx9++KF2796ty5cv6+DBg+byK1asSNU6AQCwJZZ1PE9PT/37778JroUxMTGaN2/eUyvDd999Z/5vWWfIkyeP7OzsZBiGfHx8NHToUG3btk3nz5/XqVOn5OnpKenZXIMt6wyW5Y3/3jJd+/bt5eTkJEkaM2aM2Z9sXKtbKX32v+UN+VOnTpktXSWletwJyzp9/vz59eDBgwTljo6O1siRI81lzp8/bz4RF/f76ejRoxozZoyZJq37w3J/x/UnnJi01tcft16Z2nMEeBx0mwDguZc7d26dPHlSV65c0YcffqiSJUvq448/Nh/9t1SgQAHz/y+++EL58+fXzZs3k7yLf/36dXXp0kXSw7v0q1evVoMGDXTnzh117NhRx44dMyuTiQkJCdGgQYMkSV999ZVGjRqlsmXLavr06YneRW7btq0+/vhjSQ876P/nn39UsmRJXbt2TVFRUdq8ebNy586tuXPnprhfXn/9dX3//fe6cOGCWXFp27ZtikFEe3t7tW3bVjNmzDCXGTp0qAoXLqxTp05pzZo12rBhgyTrO8d79uzR119/LS8vLxUqVEjZsmVT3bp1tXHjRt27d08tW7ZU3759FRUVZQ7iJllXah9Fu3bttHr1aknSG2+8oSFDhqhgwYK6dOmSTp48qfXr16t+/fpWAxzEN378eO3YsUMNGzaUv7+/PDw8rAbaiGvpnNbz53HEBY/jBo6TpEuXLpnTixYtqqJFi6p8+fIqXbq0jhw5osjISHXr1k2NGjXSRx99ZAZyO3XqZP6g6N69u77++mtJDwewsLOz04ULF8wbFJ6enikOaGfp7Nmz6tChg9q2batt27aZXSa4uLioXr16ktL2GU0Ny/Puiy++kIODgxwcHKwC2fG1a9dOR48elfTwUbuBAwfqpZde0vnz5/XLL79o9erV6tevn0JDQ7V48WLNmjVLTZs2Vd68eeXt7a1vvvnGzCullu8AANgie3t7tWnTRp988olu3rypOnXqqFevXsqaNav++OMPHT9+XCtWrNDcuXNVvXr1p1KGwYMHy9HRUR4eHho8eLA5vUmTJpIe3lju1auXmjVrpoIFCypr1qz68ccfdfv2bUnP5hpcp04dZcmSRVeuXNGhQ4fUs2dPNWzYUBs2bDAbY2TNmlWvvPKKuUy2bNnUqFEjrVy50qwLSVLr1q3N/9Nj/2fPnl0VKlTQgQMHdPfuXbVu3Vq9evXS0aNHU/0kUebMmVW/fn1t2LBBUVFRaty4sTp16iQvLy+dPXtWR44c0YoVK/Ttt9+aT4R169bNDBQvXbpUQ4cO1c8//6wPPvhATZs2ValSpdK8P9q1a2f+Tlq0aJE8PDzUpEkT3bp1S6tXr1a3bt308ssvp7m+blmvPHbsmFatWqWsWbPK399f/v7+iS7zKOcI8FieTle6APDkJTVgmeUABHGvrFmzGgEBAeb7uAHBDMMwKlWqlCB93GBeitdRfWhoqDl95syZhmFYD0L21ltvpVju7t27J1ifm5ubkTNnzkTLN3To0ATpLV/xBwZLyl9//WU4ODhYLfvjjz9apUmqg/5r164ZJUuWTHT9loNA3b9/3/D19U2QJq4z/6ioqETnx70GDRqUYlkSGyQgvvbt2ye7z5IbhMEwDGPUqFFJLmtvb2/s2bPHTJuW8yc1ZU9KctsTf5uOHDlieHt7J5quVKlSxo0bN6zythzwy/JlZ2dnzJ8/P8WyWQ4GUqRIEcPJySlBXqNHjzbTp+UzmtwgeHEsB/CzfMXfd5bn6r1794xatWolu0/jjtHnn3+ebLrFixenuI8AAEhPSdWbr169apQoUSLZ61xc+qTqZkldq5MaKMpywLLE6pc5cuQwLl68aBiGYezevTvZso0dOzbZ7U5r2ZKqq61atSrR+o0kw8nJyVi9enWCda9bt84qXfny5ROkeRL73zCsj29Kdu3alei2FCxYMNV15bNnzxovvfRSsuWOq8tFRESY01q1amUYxsMB3Ozt7Q3p4YBd0dHRad4fhmEYw4YNS1W6tNTXDcN6kLH4++RJnCOPMmg2YIluEwA89/r27avRo0crd+7ccnd3V/Xq1fXNN9/I19c30fQLFy5U3bp15erqKh8fH/Xu3dvsVsDShg0bFBERIenhwEndunWT9LC1YtxAB7NmzTIftU7KtGnTNHToUOXIkUOurq4KDg7Wtm3brO4KWxo5cqTWrVunevXqKUuWLHJyclLOnDlVpUoVffjhhxoxYkSq9kuOHDlUs2ZN833JkiWt+hhNjre3t7799luNGjVKgYGBcnNzk7u7u4oUKaL27dub6RwdHbVmzRpVqVJFXl5eCfLJly+fvv/+e/Xs2VN58+aVk5OTMmTIoJdffllffvmlPvzww1SVJyXz58/XggULVK1aNXl7e8vZ2Vn+/v6qVauWpk6dqh49eiS7fIMGDdStWzcVL15cmTJlkoODgzJnzqw6depo06ZNVl0NpPb8eZZKlSqlgwcPqm3btsqWLZucnZ2VN29eDRw4UDt37kxwbObOnasZM2aoVKlScnV1VYYMGVSrVi1t2bLF6vimRvny5bVx40YFBQXJxcVFuXPn1kcffaQhQ4aYadL6GU1Jo0aNNHHiROXPnz/Vfb45Oztr48aNmjp1qsqXLy8vLy+5uroqb968atiwoebMmaNXX31VklSpUiX17t1bZcqUUdasWeXg4CBvb29VrVpVX375pVUrGgAAnicZM2ZMtI5XsGBBNW/eXIsXL1bFihWf2voXL16sXr16ycfHR25ubqpfv7527dolHx8fSQ8fMx80aJAqVqyo7Nmzy9HRUZ6engoKCtKMGTPMJ9qetiZNmujbb79V8+bNlS1bNjk6OsrHx0evvfaa9u3bp8aNGydYpl69evLz8zPfJ/Z0WXrs/6pVq2rDhg0qU6aMnJ2dlTt3bo0bN86q5XNK/P39deTIEQ0YMECFCxeWq6urvLy8VLhwYbVv315r1qxRrly59Ndff6lPnz6SHrZojWspW7FiRbMbhaNHj2rUqFGPtD9GjBih9evXW/1O8vPz02uvvWbVRURa6+uLFy9WvXr1EvQtnJxHOUeAR2VnGPSKDAAAUm/Hjh2qUaOGJKlDhw7mTQ4AAID4qlevrp07d0qSTp8+bTXY6oumY8eOmjdvnuzt7fXHH38oR44c6V0kAC8A+rwFAAAAAAB4BMb/H1A4KirKHEjrlVdeIXAL4IkheAsAAAAAAPAIzp49a/XIvp2dnd5///10LBGAFw193gIAAAAAADwGBwcHBQQEaNGiRapSpUp6FwfAC4Q+bwEAAAAAAADABtHyFgAAAAAAAABsEMFbAAAAAAAAALBBDFgGPAWxsbH666+/5OXlJTs7u/QuDgAANsUwDP3777/y8/OTvT1tCQBbRH0WAIDEPeu6LMFb4Cn466+/lCtXrvQuBgAANu3333/XSy+9lN7FAJAI6rMAACTvWdVlCd4CT4GXl5ekhx/kDBkypHNpAACwLTdu3FCuXLnM6yUA20N9FgCAxD3ruizBW+ApiHu0LEOGDFR2AQBIAo9iA7aL+iwAAMl7VnVZOhkDAAAAAAAAABtE8BYAAAAAAAAAbBDBWwAAAAAAAACwQQRvAQAAAAAAAMAGEbwFAAAAAAAAABtE8BYAAAAAAAAAbBDBWwAAAAAAAACwQQRvAQAAAAAAAMAGEbwFAAAAAAAAABtE8BYAAAAAAAAAbBDBWwAAAAAAAACwQQRvAQAAAAAAAMAGEbwFAAAAAAAAABtE8BYAAAAAAAAAbJBjehcAeKHN9Zbc0rsQAIDnRjcjvUsAANaozwK2i3oD8J9Ay1sAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAGxYTEyMhg4dqrx588rNzU358+fXqFGjZBiGmcbOzi7R14QJEyRJ9+7d0xtvvKEMGTKoUKFC2rp1q9U6JkyYoLfffvuZbhcAAHj6du3apZCQEPn5+cnOzk6rVq2ymh8aGpqg/lCvXr1k8xw7dqyCgoLk5eWlbNmyqWnTpoqMjHyKWwH8t9lk8DYiIkIZM2ZM72IgjZ7UccuTJ4+mTJmSbBrLi86ZM2dkZ2enH374QZK0Y8cO2dnZ6dq1a49dFgAA0tu4ceM0c+ZMTZ8+XSdOnNC4ceM0fvx4TZs2zUxz/vx5q9fcuXNlZ2enZs2aSZL+97//6fDhw/r222/VtWtXtW3b1gz+nj59Wp9++qnGjBmTLtv3IqIu+3yiLgvgRXTr1i0FBgZqxowZSaapV6+eVT1i8eLFyea5c+dOhYWFaf/+/dqyZYvu37+vOnXq6NatW0+6+ACUxuCt5R0ZJycn5c2bVwMHDtTdu3efVvlsVnR0tMaPH6/AwEC5u7sra9asCg4O1rx583T//n1J0qVLl/TWW2/J399fLi4u8vX1Vd26dbV3714znzx58pj71MPDQ2XKlNGyZcvSa7OeG+fPn1f9+vUTnVe5cmWdP39e3t7ekvgBBQB4vu3bt09NmjRRw4YNlSdPHjVv3lx16tTRd999Z6bx9fW1eq1evVo1atRQvnz5JEknTpxQ48aNVaxYMYWFhenSpUu6fPmyJOmtt97SuHHjlCFDhnTZvmeJuuz/oS6bvqjLAnhW6tevr9GjR+vVV19NMk3cd3zcK1OmTMnmuXHjRoWGhqpYsWIKDAxURESEzp07p8OHDz/p4gPQI7S8jbsjc+rUKU2ePFmzZ8/W8OHDn0bZnpnw8HCFhoamOn10dLTq1q2rDz/8UF27dtW+ffv03XffKSwsTNOmTdNPP/0kSWrWrJmOHDmi+fPn69dff9WaNWtUvXp1XblyxSq/kSNH6vz58zpy5IiCgoLUqlUr7du3L1Vl2bFjh/LkyZPqsj+KmJgYxcbGPtV1pJWvr69cXFwSnefs7CxfX1/Z2dk941IBAPDkVa5cWdu2bdOvv/4qSTp69Kj27NmTZODn77//1vr169WpUydzWmBgoPbs2aM7d+5o06ZNypEjh7JmzaqFCxfK1dU12R90LxrqstRlbQF1WQC2ZMeOHcqWLZsCAgL01ltvJfieT8n169clSZkzZ34axQP+89IcvI27I5MrVy41bdpUtWvX1pYtW8z5sbGxGjt2rNkvW2BgoJYvX26Vx5o1a1SwYEG5urqqRo0amj9/foqPBq1evVplypSRq6ur8uXLpxEjRujBgweSJMMwFB4ebrYK8PPzU69evdK6aak2ZcoU7dq1S9u2bVNYWJhKlSqlfPnyqW3btjpw4IAKFiyoa9euaffu3Ro3bpxq1Kih3Llzq3z58ho8eLAaN25slZ+Xl5d8fX1VqFAhzZgxQ25ublq7du1TKXvcY1jr169XyZIl5erqqooVK+r48eNmmri7+2vWrFHRokXl4uKic+fO6erVq2rfvr0yZcokd3d31a9fXydPnkywjlWrVpnHt27duvr999/NeVFRUWrSpImyZ88uT09PBQUFJeh3T5L+/fdftWnTRh4eHsqZM2eCRzwS66sn/jZeu3ZNO3bs0Jtvvqnr16+brULCw8MlPez/r3///sqZM6c8PDxUoUIF7dixw8zn7NmzCgkJUaZMmeTh4aFixYppw4YNadjbAAA8vnfffVetW7dW4cKF5eTkpNKlS6tPnz5q165dounnz58vLy8vvfbaa+a0jh07KjAwUEWLFtWYMWO0dOlSXb16VcOGDdO0adP0/vvvq0CBAqpbt67+/PPPZ7Vp6YK6LHVZ6rIA8H/q1aunBQsWaNu2bRo3bpx27typ+vXrKyYmJlXLx8bGqk+fPgoODlbx4sWfcmmB/6bH6vP2+PHj2rdvn5ydnc1pY8eO1YIFCzRr1iz99NNP6tu3r15//XXt3LlT0sN+1Zo3b66mTZvq6NGj6tatm4YMGZLsenbv3q327durd+/e+vnnnzV79mxFRESYfbN99dVXZsuJkydPatWqVSpRosTjbFqyFi5cqNq1a6t06dIJ5jk5OcnDw0Oenp7y9PTUqlWrdO/evVTn7ejoKCcnJ0VHRz/JIicwYMAAffTRRzp48KB8fHwUEhJiPiInSbdv39a4ceP02Wef6aefflK2bNkUGhqqQ4cOac2aNfr2229lGIYaNGiQYLkxY8ZowYIF2rt3r65du6bWrVub82/evKkGDRpo27ZtOnLkiOrVq6eQkBCdO3fOqnwTJkxQYGCgjhw5onfffVe9e/e2+mGVWpUrV9aUKVOUIUMGs/+e/v37S5J69uypb7/9VkuWLNGPP/6oFi1aqF69emYlPiwsTPfu3dOuXbt07NgxjRs3Tp6enomu5969e7px44bVCwCAJ2Hp0qVauHChFi1apO+//17z58/XxIkTNX/+/ETTz507V+3atZOrq6s5zcnJSTNmzNDp06d18OBBValSRf369VOvXr105MgRrVq1SkePHlXFihWfatDQ1lCXpS5LXfb/UJ8F/ptat26txo0bq0SJEmratKnWrVungwcPWt0MSk5YWJiOHz+uJUuWPN2CAv9hjmldYN26dfL09NSDBw9079492dvba/r06ZIeXvA/+OADbd26VZUqVZIk5cuXT3v27NHs2bNVrVo1zZ49WwEBAeboxwEBATp+/Hiyg2SMGDFC7777rjp06GDmOWrUKA0cOFDDhw/XuXPn5Ovrq9q1a8vJyUn+/v4qX758mndGap08eVLVq1dPNo2jo6MiIiLUpUsXzZo1S2XKlFG1atXUunVrlSxZMtFloqOj9dFHH+n69euqWbPmUyj5/xk+fLheeeUVSQ9b6Lz00ktauXKlWrZsKUm6f/++PvnkEwUGBkp6uM1r1qzR3r17VblyZUkPK/65cuXSqlWr1KJFC3O56dOnq0KFCmbeRYoU0Xfffafy5csrMDDQzFOSRo0apZUrV2rNmjXq2bOnOT04OFjvvvuuJKlQoULau3evJk+ebJY5tZydneXt7S07Ozv5+vqa08+dO6d58+bp3Llz8vPzkyT1799fGzdu1Lx58/TBBx/o3LlzatasmfnjKa7fwMSMHTtWI0aMSFPZAABIjQEDBpitbyWpRIkSOnv2rMaOHWvWjeLs3r1bkZGR+vLLL5PNc/v27frpp5/02WefacCAAWrQoIE8PDzUsmVLs173oqIuS12WumziqM8CkB5+V2TNmlW//fabatWqlWzanj17at26ddq1a5deeumlZ1RC4L8nzS1va9SooR9++EEHDhxQhw4d9Oabb5ojGf/222+6ffu2XnnlFfNuvaenpxYsWKCoqChJUmRkpIKCgqzyTKlyevToUY0cOdIqzy5duuj8+fO6ffu2WrRooTt37ihfvnzq0qWLVq5caT6Glpjdu3db5fXBBx9o4cKFVtMWLlyY5PJxozOnpFmzZvrrr7+0Zs0a1atXTzt27FCZMmUUERFhlW7QoEHy9PSUu7u7xo0bpw8//FANGzZMMl/LctavX1/nzp2zmta9e/cUyxb3g0R62C9NQECATpw4YU5zdna2qpifOHFCjo6OZkVWkrJkyZJgOUdHR6vjW7hwYWXMmNFMc/PmTfXv319FihRRxowZ5enpqRMnTiRorWBZvrj3lut5XMeOHVNMTIwKFSpkte927txpnqu9evXS6NGjFRwcrOHDh+vHH39MMr/Bgwfr+vXr5svy8ToAAB7H7du3ZW9vXWVzcHBItA/POXPmqGzZslbBpfju3r2rsLAwzZ49Ww4ODoqJiTFbHt6/fz/Vj0k+r6jLUpeNQ13WGvVZAJL0xx9/6MqVK8qRI0eSaQzDUM+ePbVy5Up98803yps37zMsIfDfk+aWtx4eHipQoICkh4/lBQYGas6cOerUqZNu3rwpSVq/fr1y5sxptVxSHfKnxs2bNzVixAirvtviuLq6KleuXIqMjNTWrVu1ZcsW9ejRQxMmTNDOnTvl5OSUYJly5crphx9+MN9PnTpVf/75p8aNG2dOy549e5LlKVSokH755ZdUld3V1VWvvPKKXnnlFQ0dOlSdO3fW8OHDrQaVGDBggEJDQ+Xp6ans2bOnODiBZdkPHDigQYMGWT3S8CRGi3Zzc3sqgyT0799fW7Zs0cSJE1WgQAG5ubmpefPmT/3Ruvhu3rwpBwcHHT58WA4ODlbz4h4n69y5s+rWrav169dr8+bNGjt2rD766CO9/fbbCfJzcXF5rHMcAICkhISEaMyYMfL391exYsV05MgRTZo0SR07drRKd+PGDS1btkwfffRRsvmNGjVKDRo0MB+ZDw4O1oABA/Tmm29q+vTpCg4OfmrbYguoy1KXfRwval1Woj4LvKhu3ryp3377zXx/+vRp/fDDD8qcObMyZ86sESNGqFmzZvL19VVUVJQGDhxo9oMfp1atWnr11VfNJwzCwsK0aNEirV69Wl5eXrpw4YIkydvbW25ubs92A4H/gDQHby3Z29vrvffe0zvvvKO2bdtaDQhQrVq1RJcJCAhI0FH+wYMHk11PmTJlFBkZaVa0E+Pm5qaQkBCFhIQoLCxMhQsX1rFjx1SmTJlE01rmlTlzZt24cSPZ/C21bdtW7733no4cOZKgr7D79+8rOjpaHh4eiS5btGjRBIMTZM2aNdXrlmSV9o8//pCjo2Oalpek/fv3y9/fX5J09epV/frrrypSpEiS6YsUKaIHDx7owIED5qNmV65cUWRkpIoWLWqme/DggQ4dOmS2QImMjNS1a9fMvPfu3avQ0FBzVOubN2/qzJkziZYv/vvkypccZ2fnBK2ISpcurZiYGF28eFFVq1ZNctlcuXKpe/fu6t69uwYPHqxPP/00yQovAABPw7Rp0zR06FD16NFDFy9elJ+fn7p166Zhw4ZZpVuyZIkMw1CbNm2SzOv48eNaunSpVfCsefPm2rFjh6pWraqAgAAtWrToaW2KzaEuS12WuiyAF92hQ4dUo0YN8/0777wjSerQoYNmzpypH3/8UfPnz9e1a9fk5+enOnXqaNSoUVY3c6KionT58mXz/cyZMyUpQRc88+bNs7q5B+DJeKzgrSS1aNFCAwYM0IwZM9S/f3/1799fffv2VWxsrKpUqaLr169r7969ypAhgzp06KBu3bpp0qRJGjRokDp16qQffvjBfPQqqbvjw4YNU6NGjeTv76/mzZvL3t5eR48e1fHjxzV69GhFREQoJiZGFSpUkLu7u7744gu5ubkpd+7cj7t5ierTp4/Wr1+vWrVqadSoUapSpYq8vLx06NAhjRs3TnPmzFGuXLnUokULdezYUSVLljTnjx8/Xk2aNHkq5UqLkSNHKkuWLMqePbuGDBmirFmzqmnTpkmmL1iwoJo0aaIuXbpo9uzZ8vLy0rvvvqucOXNabY+Tk5PefvttTZ06VY6OjurZs6cqVqxoVoALFiyoFStWKCQkRHZ2dho6dGiij33u3btX48ePV9OmTbVlyxYtW7ZM69evf6RtzZMnj27evKlt27YpMDBQ7u7uKlSokNq1a6f27dvro48+UunSpXXp0iVt27ZNJUuWVMOGDdWnTx/Vr19fhQoV0tWrV7V9+/ZHrnQDAPCovLy8NGXKFE2ZMiXZdF27dlXXrl2TTVO8eHFzMKM49vb2+uSTT/TJJ588blGfS9RlqctSlwXwIqtevXqy3eVs2rQpxTzi36RKbfc7AJ6MNPd5G19cpWb8+PG6deuWRo0apaFDh2rs2LEqUqSI6tWrp/Xr15t9oOTNm1fLly/XihUrVLJkSc2cOdMcoTepx3Tq1q2rdevWafPmzQoKClLFihU1efJks0KbMWNGffrppwoODlbJkiW1detWrV27VlmyZHnczUuUi4uLtmzZooEDB2r27NmqWLGigoKCNHXqVPXq1UvFixeXp6enKlSooMmTJ+vll19W8eLFNXToUHXp0sUmBgL58MMP1bt3b5UtW1YXLlzQ2rVrrUZaTsy8efNUtmxZNWrUSJUqVZJhGNqwYYPV43zu7u4aNGiQ2rZtq+DgYHl6eloNmjJp0iRlypRJlStXVkhIiOrWrZtoi5J+/frp0KFDKl26tEaPHq1JkyZZPbaRFpUrV1b37t3VqlUr+fj4aPz48eb2tG/fXv369VNAQICaNm2qgwcPmq04YmJiFBYWZp7HhQoV+s/+sAUA4EVFXZa6LHVZAABgy+wMG7hlMmbMGM2aNYtO8Z+BHTt2qEaNGrp69aoyZsyY3sV5Yd24cUPe3t66PlnKQJc/AIDU6pbu1bJnwrxOXr/+RPo3TW/UZZ8d6rLPDvVZ4DnwH6k3ALbmWddlH7vbhEfxySefKCgoSFmyZNHevXs1YcIEs+NrAAAAwJZRlwUAAMCzki7B25MnT2r06NH6559/5O/vr379+mnw4MHpURQAAAAgTajLAgAA4FmxiW4TgBcNj5kBAB7Jf+Txxxet2wTgRUR9FngO/EfqDYCtedZ12ccesAwAAAAAAAAA8OQRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABskGN6FwB4oXW8LmXIkN6lAAAAAB4N9VkAANIVLW8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABskGN6FwB4kbVc11ZO7k7pXQwAwAtkbdOV6V0EAP8h1GcBAM+7573+TMtbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAAAAAAAAwAYRvAUAAAAAAAAAG0TwFgAAAAAAAABsEMFbAAAAAAAAALBBBG8BAACeczExMRo6dKjy5s0rNzc35c+fX6NGjZJhGGaav//+W6GhofLz85O7u7vq1aunkydPWuXzzjvvKHPmzMqVK5cWLlxoNW/ZsmUKCQl5JtsDAAAAPCtjx45VUFCQvLy8lC1bNjVt2lSRkZFWaS5cuKA33nhDvr6+ypEjhyRp9erVyeYbHh4uOzs7q1fhwoXTXL7/RPA2IiJCGTNmTO9i/GeFhoaqadOm6V0MSbZVFgAAnpRx48Zp5syZmj59uk6cOKFx48Zp/PjxmjZtmiTJMAw1bdpUp06d0urVq3XkyBHlzp1btWvX1q1btyRJa9eu1aJFi7R582aNHz9enTt31uXLlyVJ169f15AhQzRjxox028b/Ouqz6cuW6pC2VBYAAF4EO3fuVFhYmPbv368tW7bo/v37qlOnjllPlqT27dsrMjJSa9as0b59+yQ9vCYfOXIk2byLFSum8+fPm689e/akuXzpGrwNDQ01I89OTk7KmzevBg4cqLt376ZnsdJFdHS0xo8fr8DAQLm7uytr1qwKDg7WvHnzdP/+fUnSpUuX9NZbb8nf318uLi7y9fVV3bp1tXfvXjOfPHnymPvUw8NDZcqU0bJly9Jrs56aR620fvzxx4qIiHji5QEAID3t27dPTZo0UcOGDZUnTx41b95cderU0XfffSdJOnnypPbv36+ZM2cqKChIAQEBmjlzpu7cuaPFixdLkk6cOKHq1aurXLlyatOmjTJkyKDTp09LkgYOHGjWQWCN+uz/oT6bNtRnAQCwDRs3blRoaKiKFSumwMBARURE6Ny5czp8+LCZZt++fXr77bdVvnx55c2bV5Lk7e1tlSYxjo6O8vX1NV9Zs2ZNc/nSveVtvXr1dP78eZ06dUqTJ0/W7NmzNXz48PQu1mMJDw9XaGhoqtNHR0erbt26+vDDD9W1a1ft27dP3333ncLCwjRt2jT99NNPkqRmzZrpyJEjmj9/vn799VetWbNG1atX15UrV6zyGzlypM6fP68jR44oKChIrVq1Mu8KpGTHjh3KkydPqsv+vPH29k621Up0dPSzKwwAAE9I5cqVtW3bNv3666+SpKNHj2rPnj2qX7++JOnevXuSJFdXV3MZe3t7ubi4mHf/AwMDdejQIV29elWHDx/WnTt3VKBAAe3Zs0fff/+9evXq9Yy36vlBfZb67LNEfRYAgKfr+vXrkqTMmTOb0ypXrqwvv/xS//zzj2JjYyU9rGNXr1492bxOnjwpPz8/5cuXT+3atdO5c+fSXJ50D97G3XHPlSuXmjZtqtq1a2vLli3m/NjYWI0dO9bswy0wMFDLly+3ymPNmjUqWLCgXF1dVaNGDc2fP192dna6du1akutdvXq1ypQpI1dXV+XLl08jRozQgwcPJD18tDA8PNxsEeDn5/dUf7BMmTJFu3bt0rZt2xQWFqZSpUopX758atu2rQ4cOKCCBQvq2rVr2r17t8aNG6caNWood+7cKl++vAYPHqzGjRtb5efl5SVfX18VKlRIM2bMkJubm9auXftUyh4TE6NOnTqZxycgIEAff/xxssukdExTyjM8PFzz58/X6tWrzVYZO3bskCQdO3ZMNWvWlJubm7JkyaKuXbvq5s2b5rLxWzhUr15dPXv2VJ8+fZQ1a1bVrVtXknT8+HHVr19fnp6eyp49u9544w3z0VEAAGzNu+++q9atW6tw4cJycnJS6dKl1adPH7Vr106SVLhwYfn7+2vw4MG6evWqoqOjNW7cOP3xxx86f/68JKlu3bp6/fXXFRQUpNDQUM2fP18eHh566623NGvWLM2cOVMBAQEKDg42A3F4iPos9VnqswAAvBhiY2PVp08fBQcHq3jx4ub0pUuX6v79+8qSJYt8fHwkSV988YUKFCiQZF4VKlRQRESENm7cqJkzZ+r06dOqWrWq/v333zSVyfHRNuXpOH78uPbt26fcuXOb08aOHasvvvhCs2bNUsGCBbVr1y69/vrr8vHxUbVq1XT69Gk1b95cvXv3VufOnXXkyBH1798/2fXs3r1b7du319SpU1W1alVFRUWpa9eukqThw4frq6++0uTJk7VkyRIVK1ZMFy5c0NGjR5/adi9cuFC1a9dW6dKlE8xzcnKSk5OTHjx4IE9PT61atUoVK1aUi4tLqvJ2dHSUk5PTU7sDHxsbq5deeknLli1TlixZtG/fPnXt2lU5cuRQy5YtE10mpWOaUp79+/fXiRMndOPGDc2bN0/Sw7sht27dUt26dVWpUiUdPHhQFy9eVOfOndWzZ89kHy2bP3++3nrrLfNxvWvXrqlmzZrq3LmzJk+erDt37mjQoEFq2bKlvvnmm0TzuHfvntmqSZJu3LjxiHsUAIC0W7p0qRYuXKhFixapWLFi+uGHH9SnTx/5+fmpQ4cOcnJy0ooVK9SpUydlzpxZDg4Oql27turXr281qFl4eLjCw8PN9yNGjFDt2rXl5OSk0aNH69ixY1q3bp3at2+f4iNi/1XUZ6nPUp8FAOD5FRYWpuPHjyfom3bo0KG6du2atm7dKldXV1WpUkVvvvmmChQooBIlSiSaV9xTcJJUsmRJVahQQblz59bSpUvVqVOnVJcp3YO369atk6enpx48eKB79+7J3t5e06dPl/SwAvHBBx9o69atqlSpkiQpX7582rNnj2bPnq1q1app9uzZCggI0IQJEyRJAQEBOn78uMaMGZPkOkeMGKF3331XHTp0MPMcNWqUBg4cqOHDh+vcuXPy9fU1f6z4+/urfPnyT20fnDx5MsVm1o6OjoqIiFCXLl00a9YslSlTRtWqVVPr1q1VsmTJRJeJjo7WRx99pOvXr6tmzZpPoeQPK+MjRoww3+fNm1fffvutli5dmmhlNzXHNKU8PT095ebmpnv37snX19dMN3/+fN29e1cLFiyQh4eHJGn69OkKCQnRuHHjlD179kS3oWDBgho/frz5fvTo0SpdurQ++OADc9rcuXOVK1cu/frrrypUqFCCPMaOHWtVZgAAnqUBAwaYrW8lqUSJEjp79qzGjh1r1nfKli2rH374QdevX1d0dLR8fHxUoUIFlStXLtE8f/nlF33xxRc6cuSI5s6dq5dfflk+Pj5q2bKlOnbsqH///VdeXl7PbBttGfVZ6rPUZwEAeP717NlT69at065du/TSSy+Z06OiojR9+nQdP35cxYoVM29wlipVSjNmzNCsWbNSlX/GjBlVqFAh/fbbb2kqV7oHb2vUqKGZM2fq1q1bmjx5shwdHdWsWTNJ0m+//abbt2/rlVdesVomOjravKsfGRmpoKAgq/kpVUyPHj2qvXv3WlWIY2JidPfuXd2+fVstWrTQlClTlC9fPtWrV08NGjRQSEiIHB0T3127d++2iqZHR0fLMAyrR6dmz55tProYn2WLl+Q0a9ZMDRs21O7du7V//359/fXXGj9+vD777DOrPskGDRqk999/X3fv3pWnp6c+/PBDNWzYMMl8PT09rfbDvXv3rKa9/vrryZ6IM2bM0Ny5c3Xu3DnduXNH0dHRKlWqVKJpU3NM05pnnBMnTigwMNCs6EpScHCwYmNjFRkZmWRlt2zZslbvjx49qu3bt1vtgzhRUVGJVnYHDx6sd955x3x/48YN5cqVK9nyAgDwpNy+fVv29ta9YTk4OJj9cVny9vaW9DDYdujQIY0aNSpBGsMw1K1bN02aNEmenp6KiYkxB5yK+xsTE/OkN+O5RX2W+qxEfRYAgOeVYRh6++23tXLlSu3YscMckCzO7du3JSnV9e2k3Lx5U1FRUXrjjTfSVL50D956eHiY/UPMnTtXgYGBmjNnjjp16mT27bR+/XrlzJnTarnUPmaVmJs3b2rEiBF67bXXEsxzdXVVrly5FBkZqa1bt2rLli3q0aOHJkyYoJ07d8rJySnBMuXKldMPP/xgvp86dar+/PNPjRs3zpyWVEVLkgoVKqRffvklVWV3dXXVK6+8oldeeUVDhw5V586dNXz4cKvK7oABAxQaGmr2b2VnZ5dsnpZlP3DggAYNGmT2uSVJGTJkSHLZJUuWqH///vroo49UqVIleXl5acKECTpw4ECi6VNzTNOa5+OyrBzHlTGudUN8OXLkSDQPFxeXxzonAQB4HCEhIRozZoz8/f1VrFgxHTlyRJMmTVLHjh3NNMuWLZOPj4/8/f117Ngx9e7dW02bNlWdOnUS5PfZZ5/Jx8dHISEhkh4Gj8LDw81gW9GiRZMdMOm/hvos9dk41GcBAHj+hIWFadGiRVq9erW8vLx04cIFSQ8bPbi5ualw4cIqUKCAunXrpokTJ8rZ2VmStH37dvXr18/Mp1atWnr11VfVs2dPSVL//v0VEhKi3Llz66+//tLw4cPl4OCgNm3apKl86R68tWRvb6/33ntP77zzjtq2bauiRYvKxcVF586dU7Vq1RJdJiAgQBs2bLCadvDgwWTXU6ZMGUVGRibbqbCbm5tCQkIUEhKisLAwFS5cWMeOHVOZMmUSTWuZV+bMmXXjxo1k87fUtm1bvffeezpy5EiCfsLu37+v6OjoBBWyOEWLFtWqVauspmXNmjXV65ZklfaPP/6Qo6Njqpffu3evKleurB49epjToqKikkyfmmOamjydnZ0TtPgpUqSIIiIidOvWLXN/7d27V/b29goICEjV9kgPz4+vvvpKefLkSbJ1CgAAtmTatGkaOnSoevTooYsXL8rPz0/dunXTsGHDzDTnz5/XO++8o7///ls5cuRQ+/btNXTo0AR5/f333xozZoz27dtnTitfvrz69eunhg0bKlu2bJo/f/4z2a7nEfVZ6rOpzZP6LAAAtmHmzJmSlKALqHnz5ik0NFROTk7asGGD3n33XYWEhJg3cmfNmqUGDRqY6aOioqwGB/3jjz/Upk0bXblyRT4+PqpSpYr2799vDniWWvYpJ3m2WrRoIQcHB82YMUNeXl7q37+/+vbtq/nz5ysqKkrff/+9pk2bZv5o6Natm3755RcNGjRIv/76q5YuXWp25p/UHfphw4ZpwYIFGjFihH766SedOHFCS5Ys0fvvvy9JioiI0Jw5c3T8+HGdOnVKX3zxhdzc3KwGnniS4kaxq1WrlmbMmKGjR4/q1KlTWrp0qSpWrKiTJ0/qypUrqlmzpr744gv9+OOPOn36tJYtW6bx48erSZMmT6VcqVGwYEEdOnRImzZt0q+//qqhQ4cm+2MjNcc0NXnmyZNHP/74oyIjI3X58mXdv39f7dq1k6urqzp06KDjx49r+/btevvtt/XGG28k21IkvrCwMP3zzz9q06aNDh48qKioKG3atElvvvkmj4gCAGySl5eXpkyZorNnz+rOnTuKiorS6NGjzVYBktSrVy/9/vvvio6O1tmzZzVq1Cir+XGyZ8+uM2fOyM/Pz2r6sGHDdOXKFZ04ceKp9p36IqA+S32W+iwAAM8PwzASfVk+FVSwYEF99dVX+vvvv3X+/HlJMsebiHPmzBmrwX+XLFmiv/76S/fu3dMff/yhJUuWKH/+/Gkun80Fbx0dHdWzZ0+NHz9et27d0qhRozR06FCNHTtWRYoUUb169bR+/Xqz/4m8efNq+fLlWrFihUqWLKmZM2dqyJAhkpJ+FK1u3bpat26dNm/erKCgIFWsWFGTJ082K7MZM2bUp59+quDgYJUsWVJbt27V2rVrlSVLlqeyzS4uLtqyZYsGDhyo2bNnq2LFigoKCtLUqVPVq1cvFS9eXJ6enqpQoYImT56sl19+WcWLF9fQoUPVpUsXc0CM9NCtWze99tpratWqlSpUqKArV65YtTBITErHNDV5dunSRQEBASpXrpx8fHy0d+9eubu7a9OmTfrnn38UFBSk5s2bq1atWmneP35+ftq7d69iYmJUp04dlShRQn369FHGjBkT9G8CAAAQH/VZ6rPUZwEAwJNiZ6R2dIHnyJgxYzRr1iz9/vvv6V0U/EfduHFD3t7eqruwoZzcE/YrBwDAo1rbdGV6F+GxxV0nr1+/nmxfpP9l1GeR3qjPAgBeFE+6/vys67IvRAdIn3zyiYKCgpQlSxbt3btXEyZMMDsHBgAAAGwd9VkAAAAk5oUI3p48eVKjR4/WP//8I39/f/Xr10+DBw9O72IBAAAAqUJ9FgAAAIl5IYK3kydP1uTJk9O7GAAAAMAjoT4LAACAxNBbPQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDCN4CAAAAAAAAgA0ieAsAAAAAAAAANojgLQAAAAAAAADYIIK3AAAAAAAAAGCDHNO7AMCLbGmjRcqQIUN6FwMAAAB4JNRnAQBIX7S8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEEEbwEAAAAAAADABhG8BQAAAAAAAAAbRPAWAAAAAAAAAGwQwVsAAAAAAAAAsEGO6V0A4EVW8rObsnfjHgkAPEmn3vJM7yIAwH/G81Cf5boAAHiR2fZVGAAAAAAAAAD+owjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANIngLAAAAAAAAADaI4C0AAAAAAAAA2CCCtwAAAAAAAABggwjeAgAAAAAAAIANInj7HIiIiFDGjBnTuxiPJU+ePJoyZUp6F0OSbZUFAPBk5MmTR3Z2dgleYWFhkqTq1asnmNe9e3dz+X/++UchISHy9PRU6dKldeTIEav8w8LC9NFHHz3TbQJeFNRlnyxbKsvzYuzYsQoKCpKXl5eyZcumpk2bKjIyMtllErtu2NnZqWHDhs+o1AAAPETw9jGEhoaaF3EnJyflzZtXAwcO1N27d9O7aP8Jj1pxPXjwoLp27frkCwQASDcHDx7U+fPnzdeWLVskSS1atDDTdOnSxSrN+PHjzXljxozRv//+q++//17Vq1dXly5dzHn79+/XgQMH1KdPn2e2PcCzQF02fVGXfXZ27typsLAw7d+/X1u2bNH9+/dVp04d3bp1K8llVqxYYXXNOH78uBwcHKyuKwAAPAuO6V2A5129evU0b9483b9/X4cPH1aHDh1kZ2encePGpXfRHll4eLjOnDmjiIiI9C7KU+Hj45Ps/Pv378vJyekZlQYA8CTE/27/8MMPlT9/flWrVs2c5u7uLl9f30SXP3HihFq3bq1ChQqpa9eu+t///ifp4TWhe/fu+uyzz+Tg4PD0NgBIJ9Rlnz/UZdNu48aNVu8jIiKULVs2HT58WC+//HKiy2TOnNnq/ZIlS+Tu7k7wFgDwzNHy9jG5uLjI19dXuXLlUtOmTVW7dm2ztY8kxcbGauzYscqbN6/c3NwUGBio5cuXW+WxZs0aFSxYUK6urqpRo4bmz58vOzs7Xbt2Lcn1rl69WmXKlJGrq6vy5cunESNG6MGDB5IkwzAUHh4uf39/ubi4yM/PT7169Xoq2y9JUVFRatKkibJnzy5PT08FBQVp69atyS5z7do1de7cWT4+PsqQIYNq1qypo0ePpjrP6tWr6+zZs+rbt6/ZYiTOV199pWLFisnFxUV58uRJ8Jhr/FYOdnZ2mjlzpho3biwPDw+NGTNGUvL7GABgu6Kjo/XFF1+oY8eOVteHhQsXKmvWrCpevLgGDx6s27dvm/MCAwP1zTff6MGDB9q0aZNKliwpSRo/fryqV6+ucuXKPfPtAJ4F6rLUZf+Lrl+/LilhgDY5c+bMUevWreXh4fG0igUAQKII3j5Bx48f1759++Ts7GxOGzt2rBYsWKBZs2bpp59+Ut++ffX6669r586dkqTTp0+refPmatq0qY4ePapu3bppyJAhya5n9+7dat++vXr37q2ff/5Zs2fPVkREhFlR++qrrzR58mTNnj1bJ0+e1KpVq1SiRImntt03b95UgwYNtG3bNh05ckT16tVTSEiIzp07l+QyLVq00MWLF/X111/r8OHDKlOmjGrVqqV//vknVXmuWLFCL730kkaOHGk+yiRJhw8fVsuWLdW6dWsdO3ZM4eHhGjp0aIotL8LDw/Xqq6/q2LFj6tixY4r7GABgu1atWqVr164pNDTUnNa2bVt98cUX2r59uwYPHqzPP/9cr7/+ujn/3XfflaOjo/Lnz6+VK1dqzpw5OnnypObPn6+hQ4eqe/fuypcvn1q2bGn+6AdeNNRlqcv+F8TGxqpPnz4KDg5W8eLFU7XMd999p+PHj6tz585PuXQAACREtwmPad26dfL09NSDBw9079492dvba/r06ZKke/fu6YMPPtDWrVtVqVIlSVK+fPm0Z88ezZ49W9WqVdPs2bMVEBCgCRMmSJICAgJ0/PjxZCtWI0aM0LvvvqsOHTqYeY4aNUoDBw7U8OHDde7cOfn6+qp27dpycnKSv7+/ypcv/9T2QWBgoAIDA833o0aN0sqVK7VmzRr17NkzQfo9e/bou+++08WLF+Xi4iJJmjhxolatWqXly5era9euKeaZOXNmOTg4yMvLy+oR2EmTJqlWrVoaOnSoJKlQoUL6+eefNWHCBKsf8fG1bdtWb775pvm+Y8eOye7j+O7du6d79+6Z72/cuJHSbgMAPCVz5sxR/fr15efnZ06z7B+yRIkSypEjh2rVqqWoqCjlz59f3t7eWrRokVU+NWvW1IQJE7Rw4UKdOnVKkZGR6tKli0aOHMngZXhhUJelLhvnv1KfDQsL0/Hjx7Vnz55ULzNnzhyVKFHiqZ6HAAAkheDtY6pRo4ZmzpypW7duafLkyXJ0dFSzZs0kSb/99ptu376tV155xWqZ6OholS5dWpIUGRmpoKAgq/kpVQqOHj2qvXv3WlWKY2JidPfuXd2+fVstWrTQlClTlC9fPtWrV08NGjRQSEiIHB0TP9y7d+9W/fr1rcpnGIbVI3GzZ89Wu3btEl3+5s2bCg8P1/r163X+/Hk9ePBAd+7cSbK1wtGjR3Xz5k1lyZLFavqdO3cUFRX1SHnGOXHihJo0aWI1LTg4WFOmTFFMTEyS/RXGfxw2pX3s7u5ulX7s2LEaMWJEsmUDADx9Z8+e1datW7VixYpk01WoUEHSw2t1/vz5E8yfN2+eMmbMqCZNmui1115T06ZN5eTkpBYtWmjYsGFPpexAeqAuS102zn+hPtuzZ0+tW7dOu3bt0ksvvZSqZW7duqUlS5Zo5MiRT7l0AAAkjuDtY/Lw8FCBAgUkSXPnzlVgYKDmzJmjTp066ebNm5Kk9evXK2fOnFbLxd2lfxQ3b97UiBEj9NprryWY5+rqqly5cikyMlJbt27Vli1b1KNHD02YMEE7d+5MdPCCcuXK6YcffjDfT506VX/++afVQBXZs2dPsjz9+/fXli1bNHHiRBUoUEBubm5q3ry5oqOjkyx/jhw5tGPHjgTzMmbM+Eh5Pq74fVeltI/jGzx4sN555x3z/Y0bN5QrV64nX1AAQLLmzZunbNmyqWHDhsmmi7vu5ciRI8G8S5cuaeTIkWarrJiYGN2/f1/Sw4GAYmJinmyhgXREXZa6bJwXuT5rGIbefvttrVy5Ujt27FDevHlTveyyZct07949q652AAB4lgjePkH29vZ677339M4776ht27YqWrSoXFxcdO7cOavRri0FBARow4YNVtMOHjyY7HrKlCmjyMhIs6KdGDc3N4WEhCgkJERhYWEqXLiwjh07pjJlyiSa1jKvzJkz68aNG8nmb2nv3r0KDQ3Vq6++KulhZfHMmTPJlv/ChQtydHRUnjx5HjlPZ2fnBD+gixQpor179ybIq1ChQmkaJTw1+9iSi4vLY/2IAQA8vtjYWM2bN08dOnSwaqEXFRWlRYsWqUGDBsqSJYt+/PFH9e3bVy+//LI5MJmlPn36qF+/fmawKjg4WJ9//rnq1Kmj//3vfwoODn5m2wQ8S9Rl/7t1WenFrs+GhYVp0aJFWr16tby8vHThwgVJkre3t9zc3CRJ7du3V86cOTV27FirZefMmaOmTZsmaGkNAMCzQvD2CWvRooUGDBigGTNmqH///urfv7/69u2r2NhYValSRdevX9fevXuVIUMGdejQQd26ddOkSZM0aNAgderUST/88IM5IIHlqLOWhg0bpkaNGsnf31/NmzeXvb29jh49quPHj2v06NGKiIhQTEyMKlSoIHd3d33xxRdyc3NT7ty5n8o2FyxYUCtWrFBISIjs7Ow0dOhQxcbGJpm+du3aqlSpkpo2barx48erUKFC+uuvv7R+/Xq9+uqrKleuXKryzJMnj3bt2qXWrVvLxcVFWbNmVb9+/RQUFKRRo0apVatW+vbbbzV9+nR98sknadqmlPYxAMD2bN26VefOnVPHjh2tpjs7O2vr1q2aMmWKbt26pVy5cqlZs2Z6//33E+SxadMm/fbbb/r888/NaT179tShQ4dUoUIFlS9fPsn+IoEXAXVZ6rIvopkzZ0qSqlevbjV93rx5Zl/C586dk7299XjekZGR2rNnjzZv3vwsigkAQKLsU06CtHB0dFTPnj01fvx43bp1S6NGjdLQoUM1duxYFSlSRPXq1dP69evNR3Xy5s2r5cuXa8WKFSpZsqRmzpxpjtCb1J3vunXrat26ddq8ebOCgoJUsWJFTZ482azQZsyYUZ9++qmCg4NVsmRJbd26VWvXrn1qd4snTZqkTJkyqXLlyvp/7d15dE33+sfxT2QmE4IkvcQUw0WNQaihjZ9w+/OjuVcNuRqkeqmxZnXNY5VWq0VbbbQa1L1FS2kvWkMNMWtVGvNQjRpDYirJ9/dHl30dCZJIcg7er7XOWs53f8/ez35y5Dz7yT57t2rVShEREZmeFXGLk5OTVqxYocaNG6tLly6qUKGC2rdvr2PHjllfacvKOseOHaujR4+qXLlyKlasmKQ/zjJYtGiRFi5cqKpVq2rkyJEaO3bsPW/wkJn75RgA4HiaN28uY4wqVKhgM16yZEmtW7dO586d07Vr13TgwAFNmTJFPj4+GdYRERGh+Ph4mwP4ggULatGiRbp06ZJWr16t4sWL5/m+APZCLUst+ygyxmT6uD2va9eutf7wcEvFihVljMlw3WcAAPKTkzHG2DsI2JowYYJmz56tEydO2DsU5NClS5fk6+ur4GknVcAzY3MAAJBzh3t42TsEPKBbn5MXL17MtImOhxu17KPhYapn+VwAAOSn/K5luWyCA5g5c6ZCQ0NVtGhRbdy4Ua+//rp69epl77AAAACA+6KWBQAAyDs0bx3AgQMHNH78eJ0/f16lSpXSgAEDNGzYMHuHBQAAANwXtSwAAEDe4bIJQB54mL5mBgAPG74e+/DjsgmA43uY6lk+FwAA+Sm/a1luWAYAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAXOwdAPAo++FFL/n4eNk7DAAAACBHqGcBALAvzrwFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQDRvAQAAAAAAAMAB0bwFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQDRvAQAAAAAAAMAB0bwFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQDRvAQAAAAAAAMAB0bwFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQC72DgB4FBljJEmXLl2ycyQAADieW5+Ptz4vATge6lkAADKX37UszVsgD5w7d06SVLJkSTtHAgCA4zp37px8fX3tHQaATFDPAgBwbykpKflSy9K8BfJAkSJFJEnHjx/noDQfXLp0SSVLltSJEyfk4+Nj73AeaeQ6f5Hv/EW+88/FixdVqlQp6/MSgOOhns0ePkOyj5xlD/nKPnKWfeQsa4wxSklJUVBQUL5sj+YtkAcKFPjjctK+vr78wstHPj4+5DufkOv8Rb7zF/nOP7c+LwE4HurZnOEzJPvIWfaQr+wjZ9lHzu4vP/+wScUMAAAAAAAAAA6I5i0AAAAAAAAAOCCat0AecHd316hRo+Tu7m7vUB4L5Dv/kOv8Rb7zF/nOP+QacHz8P80e8pV95Cx7yFf2kbPsI2eOyckYY+wdBAAAAAAAAADAFmfeAgAAAAAAAIADonkLAAAAAAAAAA6I5i0AAAAAAAAAOCCat0AeePfdd1W6dGl5eHioXr162rp1q71DeuhNmjRJoaGh8vb2VvHixdWmTRslJibazLl27Zp69uypokWLysvLS3/961/122+/2SniR8fkyZPl5OSkfv36WWPkOnedPHlSf//731W0aFF5enqqWrVq2r59u7XcGKORI0cqMDBQnp6eatasmQ4cOGDHiB9eaWlpGjFihMqUKSNPT0+VK1dO48aN0+23ACDfObd+/Xq1atVKQUFBcnJy0tKlS22WZyW358+fV1RUlHx8fOTn56eYmBilpqbm414AoJbNutGjR8vJycnmUalSJXuH5TBy43PhcXO/nHXu3DnDe65Fixb2CdYBcJyYfVnJWdOmTTO8z7p3726niEHzFshln332mfr3769Ro0Zp586dql69uiIiInT69Gl7h/ZQW7dunXr27KktW7Zo1apVunHjhpo3b67Lly9bc1555RUtW7ZM//rXv7Ru3Tr9+uuvioyMtGPUD79t27bpvffe05NPPmkzTq5zz4ULF9SwYUO5urpq5cqV2rdvn6ZNm6bChQtbc6ZMmaK3335bs2fPVnx8vAoVKqSIiAhdu3bNjpE/nF577TXNmjVL77zzjhISEvTaa69pypQpmjFjhjWHfOfc5cuXVb16db377ruZLs9KbqOiovTTTz9p1apVWr58udavX6+XXnopv3YBeOxRy2ZflSpVlJSUZD2+//57e4fkMHLjc+Fxc7+cSVKLFi1s3nMLFizIxwgdC8eJ2ZeVnElSt27dbN5nU6ZMsVPEkAGQq+rWrWt69uxpPU9LSzNBQUFm0qRJdozq0XP69Gkjyaxbt84YY0xycrJxdXU1//rXv6w5CQkJRpLZvHmzvcJ8qKWkpJiQkBCzatUq06RJE9O3b19jDLnObUOGDDFPPfXUXZenp6ebgIAA8/rrr1tjycnJxt3d3SxYsCA/QnykPPvss6Zr1642Y5GRkSYqKsoYQ75zkySzZMkS63lWcrtv3z4jyWzbts2as3LlSuPk5GROnjyZb7EDjzNq2ewZNWqUqV69ur3DeCjk5HPhcXdnzowxJjo62rRu3dou8TwMOE7MvjtzZoyxOf6D/XHmLZCLfv/9d+3YsUPNmjWzxgoUKKBmzZpp8+bNdozs0XPx4kVJUpEiRSRJO3bs0I0bN2xyX6lSJZUqVYrc51DPnj317LPP2uRUIte57csvv1SdOnXUtm1bFS9eXDVr1tQHH3xgLT9y5IhOnTplk29fX1/Vq1ePfOdAgwYNtGbNGu3fv1+StGfPHn3//fdq2bKlJPKdl7KS282bN8vPz0916tSx5jRr1kwFChRQfHx8vscMPG6oZXPmwIEDCgoKUtmyZRUVFaXjx4/bO6SHAp+5Obd27VoVL15cFStWVI8ePXTu3Dl7h+QwOE7MvjtzdktcXJz8/f1VtWpVDRs2TFeuXLFHeJDkYu8AgEfJ2bNnlZaWphIlStiMlyhRQj///LOdonr0pKenq1+/fmrYsKGqVq0qSTp16pTc3Nzk5+dnM7dEiRI6deqUHaJ8uC1cuFA7d+7Utm3bMiwj17nr8OHDmjVrlvr3769XX31V27ZtU58+feTm5qbo6Ggrp5n9XiHf2Td06FBdunRJlSpVkrOzs9LS0jRhwgRFRUVJEvnOQ1nJ7alTp1S8eHGb5S4uLipSpAj5B/IBtWz21atXT3PnzlXFihWVlJSkMWPGqFGjRtq7d6+8vb3tHZ5D4zM3Z1q0aKHIyEiVKVNGhw4d0quvvqqWLVtq8+bNcnZ2tnd4dsVxYvZlljNJ6tixo4KDgxUUFKQffvhBQ4YMUWJiohYvXmzHaB9fNG8BPHR69uypvXv3cj2xPHLixAn17dtXq1atkoeHh73DeeSlp6erTp06mjhxoiSpZs2a2rt3r2bPnq3o6Gg7R/foWbRokeLi4jR//nxVqVJFu3fvVr9+/RQUFES+AQDZduubG5L05JNPql69egoODtaiRYsUExNjx8jwqGrfvr3172rVqunJJ59UuXLltHbtWoWHh9sxMvvjODH77paz2+83UK1aNQUGBio8PFyHDh1SuXLl8jvMxx6XTQBykb+/v5ydnTPcufK3335TQECAnaJ6tPTq1UvLly/Xd999pz/96U/WeEBAgH7//XclJyfbzCf32bdjxw6dPn1atWrVkouLi1xcXLRu3Tq9/fbbcnFxUYkSJch1LgoMDNSf//xnm7HKlStbX7m8lVN+r+SOQYMGaejQoWrfvr2qVaumTp066ZVXXtGkSZMkke+8lJXcBgQEZLgp0s2bN3X+/HnyD+QDatkH5+fnpwoVKujgwYP2DsXh8ZmbO8qWLSt/f//H/j3HcWL23S1nmalXr54kPfbvM3uheQvkIjc3N9WuXVtr1qyxxtLT07VmzRqFhYXZMbKHnzFGvXr10pIlS/Ttt9+qTJkyNstr164tV1dXm9wnJibq+PHj5D6bwsPD9eOPP2r37t3Wo06dOoqKirL+Ta5zT8OGDZWYmGgztn//fgUHB0uSypQpo4CAAJt8X7p0SfHx8eQ7B65cuaICBWzLH2dnZ6Wnp0si33kpK7kNCwtTcnKyduzYYc359ttvlZ6ebh00AMg71LIPLjU1VYcOHVJgYKC9Q3F4fObmjl9++UXnzp17bN9zHCdm3/1ylpndu3dL0mP7PrM7O98wDXjkLFy40Li7u5u5c+eaffv2mZdeesn4+fmZU6dO2Tu0h1qPHj2Mr6+vWbt2rUlKSrIeV65cseZ0797dlCpVynz77bdm+/btJiwszISFhdkx6kfHnXcbJde5Z+vWrcbFxcVMmDDBHDhwwMTFxZmCBQuaTz/91JozefJk4+fnZ7744gvzww8/mNatW5syZcqYq1ev2jHyh1N0dLR54oknzPLly82RI0fM4sWLjb+/vxk8eLA1h3znXEpKitm1a5fZtWuXkWTeeOMNs2vXLnPs2DFjTNZy26JFC1OzZk0THx9vvv/+exMSEmI6dOhgr10CHjvUstkzYMAAs3btWnPkyBGzceNG06xZM+Pv729Onz5t79AcQm58Ljxu7pWzlJQUM3DgQLN582Zz5MgRs3r1alOrVi0TEhJirl27Zu/Q7YLjxOy7X84OHjxoxo4da7Zv326OHDlivvjiC1O2bFnTuHFjO0f++KJ5C+SBGTNmmFKlShk3NzdTt25ds2XLFnuH9NCTlOkjNjbWmnP16lXz8ssvm8KFC5uCBQua5557ziQlJdkv6EfInc1bcp27li1bZqpWrWrc3d1NpUqVzPvvv2+zPD093YwYMcKUKFHCuLu7m/DwcJOYmGinaB9uly5dMn379jWlSpUyHh4epmzZsmb48OHm+vXr1hzynXPfffddpr+ro6OjjTFZy+25c+dMhw4djJeXl/Hx8TFdunQxKSkpdtgb4PFFLZt17dq1M4GBgcbNzc088cQTpl27dubgwYP2Dsth5MbnwuPmXjm7cuWKad68uSlWrJhxdXU1wcHBplu3bo/1H1c4Tsy+++Xs+PHjpnHjxqZIkSLG3d3dlC9f3gwaNMhcvHjRvoE/xpyMMSZvz+0FAAAAAAAAAGQX17wFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQDRvAQAAAAAAAMAB0bwFAAAAAAAAAAdE8xYAAAAAAAAAHBDNWwAAAAAAAABwQDRvAQAAAAAAAMAB0bwFAAAAAACA3Tg5OWnp0qUPvJ4RI0bopZdeevCA7uLs2bMqXry4fvnllzzbBnAnmrcAALsZPXq0atSo8dBvQ8q9gjMz586dU/HixXX06NEcr4NCEwAAZIWTk9M9H6NHj7Z3iHiI3a02T0pKUsuWLR9o3adOndJbb72l4cOHP9B67sXf318vvPCCRo0alWfbAO5E8xYAHkEU3f81cOBArVmzJsvzc9qEzY2C824mTJig1q1bq3Tp0pKk8+fPq1WrVvLy8lLNmjW1a9cum/k9e/bUtGnTbMYoNAEAQFYkJSVZj+nTp8vHx8dmbODAgfYOEbnk999/z7dtGWN08+bNuy4PCAiQu7v7A21jzpw5atCggYKDgx9oPffTpUsXxcXF6fz583m6HeAWmrcA8Aii6P4vLy8vFS1aNM+3c7+C88aNGzla75UrV/Thhx8qJibGGpswYYJSUlK0c+dONW3aVN26dbOWbdmyRfHx8erXr1+GdVFoAgCA+wkICLAevr6+cnJyshlbuHChKleuLA8PD1WqVEkzZ860Xnv06FE5OTlp0aJFatSokTw9PRUaGqr9+/dr27ZtqlOnjry8vNSyZUudOXPGel3nzp3Vpk0bjRkzRsWKFZOPj4+6d+9u01z897//rWrVqsnT01NFixZVs2bNdPny5Uz3Ye3atXJyctI333yjmjVrytPTU88884xOnz6tlStXqnLlyvLx8VHHjh115coV63XXr19Xnz59VLx4cXl4eOipp57Stm3bJP3RfCxfvrymTp1qs63du3fLyclJBw8elCQlJyfrxRdftPbjmWee0Z49e6z5t848nTdvnkqXLi1fX1+1b99eKSkpd/2ZzJ07V35+flq6dKlCQkLk4eGhiIgInThxwppz6NAhtW7dWiVKlJCXl5dCQ0O1evVqm/WULl1a48aN0wsvvCAfH5+7Xl6gadOm6tWrl3r16iVfX1/5+/trxIgRMsZYc+bNm6c6derI29tbAQEB6tixo06fPp3hZ7By5UrVrl1b7u7u+vTTTzVmzBjt2bPHOqlk7ty5kjKeQHHixAk9//zz8vPzU5EiRdS6dev7fgtt4cKFatWqVYZ96d27t/r166fChQurRIkS+uCDD3T58mV16dJF3t7eKl++vFauXGm95sKFC4qKilKxYsXk6empkJAQxcbGWsurVKmioKAgLVmy5J7xALmF5i0APILuVXRfvnxZUVFR9yzsMjv71M/PzyquPvnkE3l5eenAgQPW8pdfflmVKlWyKYDvNHnyZJUoUULe3t6KiYnRtWvXMsyZM2fOXQ8I7vT+++8rKChI6enpNuOtW7dW165dJWX+1ayPPvpIVapUkbu7uwIDA9WrVy9Jss5sfe655+Tk5GQ9l6RZs2apXLlycnNzU8WKFTVv3jybdd6es1sHLp999pmaNGkiDw8PxcXFZXv/JGnFihVyd3dX/fr1rbGEhAS1b99eFSpU0EsvvaSEhARJfzSIu3fvrtmzZ8vZ2TnDuig0AQDAg4iLi9PIkSM1YcIEJSQkaOLEiRoxYoQ+/vhjm3mjRo3SP//5T+3cuVMuLi7q2LGjBg8erLfeeksbNmzQwYMHNXLkSJvXrFmzRgkJCVq7dq0WLFigxYsXa8yYMZL+ODGhQ4cO6tq1qzUnMjLSppmYmdGjR+udd97Rpk2brGbg9OnTNX/+fH311Vf6z3/+oxkzZljzBw8erM8//1wff/yxdu7cqfLlyysiIkLnz5+Xk5OTunbtatPEk6TY2Fg1btxY5cuXlyS1bdvWahLv2LFDtWrVUnh4uM0fzw8dOqSlS5dq+fLlWr58udatW6fJkyffc1+uXLmiCRMm6JNPPtHGjRuVnJys9u3bW8tTU1P1l7/8RWvWrNGuXbvUokULtWrVSsePH7dZz9SpU1W9enXt2rVLI0aMuOv2Pv74Y7m4uGjr1q1666239MYbb2jOnDnW8hs3bmjcuHHas2ePli5dqqNHj6pz584Z1jN06FBNnjxZCQkJ+p//+R8NGDBAVapUsU4qadeuXYbX3LhxQxEREfL29taGDRu0ceNGeXl5qUWLFnc9W/j8+fPat2+f6tSpk+m++Pv7a+vWrerdu7d69Oihtm3bqkGDBtq5c6eaN2+uTp06WccxI0aM0L59+7Ry5UolJCRo1qxZ8vf3t1ln3bp1tWHDhrvmD8hVBgDwSIuNjTW+vr7W8927d5vZs2ebH3/80ezfv9/885//NB4eHubYsWPWHElmyZIlNuvx9fU1sbGx1vO2bdua0NBQc+PGDbN8+XLj6upqtm/fftc4PvvsM+Pu7m7mzJljfv75ZzN8+HDj7e1tqlevbs359NNPTWBgoPn888/N4cOHzeeff26KFCli5s6dm+k6z58/b9zc3Mzq1autsXPnztmMjRo1ymYbM2fONB4eHmb69OkmMTHRbN261bz55pvGGGNOnz5tJJnY2FiTlJRkTp8+bYwxZvHixcbV1dW8++67JjEx0UybNs04Ozubb7/9NtOcHTlyxEgypUuXtvbl119/zfb+GWNMnz59TIsWLWzGhg4datq2bWtu3Lhh3nzzTVO/fn1jjDHjx483ffv2veu6jDGmXbt2Jjo6+p5zAAAAjMlYR5YrV87Mnz/fZs64ceNMWFiYMea/NdCcOXOs5QsWLDCSzJo1a6yxSZMmmYoVK1rPo6OjTZEiRczly5etsVmzZhkvLy+TlpZmduzYYSSZo0ePZinu7777zkiyqREnTZpkJJlDhw5ZY//4xz9MRESEMcaY1NRU4+rqauLi4qzlv//+uwkKCjJTpkwxxhhz8uRJ4+zsbOLj463l/v7+Vi23YcMG4+PjY65du2YTT7ly5cx7771njPmjNi1YsKC5dOmStXzQoEGmXr16d92f2NhYI8ls2bLFGktISDCSrFgyU6VKFTNjxgzreXBwsGnTps1d59/SpEkTU7lyZZOenm6NDRkyxFSuXPmur9m2bZuRZFJSUowx//0ZLF261GbenbX5LbfX0vPmzTMVK1a02f7169eNp6en+eabbzLd/q5du4wkc/z48Qz78tRTT1nPb968aQoVKmQ6depkjSUlJRlJZvPmzcYYY1q1amW6dOly1301xphXXnnFNG3a9J5zgNzCmbcA8JipXr26/vGPf6hq1aoKCQnRuHHjVK5cOX355ZfZWs97772npKQk9enTRzExMRo9erRq16591/nTp09XTEyMYmJiVLFiRY0fP15//vOfbeaMGjVK06ZNU2RkpMqUKaPIyEi98soreu+99zJdZ+HChdWyZUvNnz/fGvv3v/8tf39/Pf3005m+Zvz48RowYID69u2rChUqKDQ01LrEQLFixST9cZZxQECA9Xzq1Knq3LmzXn75ZVWoUEH9+/dXZGRkhq/N3alfv37WvgQGBmZ7/yTp2LFjCgoKshkbOnSoXFxcVK5cOS1ZskQffvihDhw4oI8//lgjRoxQ9+7dVbZsWT3//PO6ePGizWuDgoJ07Nixe8YNAABwp8uXL+vQoUOKiYmRl5eX9Rg/frwOHTpkM/fJJ5+0/l2iRAlJUrVq1WzGbv+KvfRHjVqwYEHreVhYmFJTU3XixAlVr15d4eHhqlatmtq2basPPvhAFy5cuG/Md8ZRsGBBlS1bNtM4Dh06pBs3bqhhw4bWcldXV9WtW9f6llNQUJCeffZZffTRR5KkZcuW6fr162rbtq0kac+ePUpNTVXRokVtcnTkyBGbHJUuXVre3t7W88DAwAz5uJOLi4tCQ0Ot55UqVZKfn58VW2pqqgYOHKjKlSvLz89PXl5eSkhIyHDmbWZnpmamfv36cnJysp6HhYXpwIEDSktLkyTt2LFDrVq1UqlSpeTt7a0mTZpIUo63d7s9e/bo4MGD8vb2tnJYpEgRXbt2LcN77ZarV69Kkjw8PDIsu/194OzsrKJFi2Z4P0qyfgY9evTQwoULVaNGDQ0ePFibNm3KsE5PT897fuMQyE0u9g4AAJC/UlNTNXr0aH311VdKSkrSzZs3dfXq1QyF1v0ULlxYH374oSIiItSgQQMNHTr0nvMTEhLUvXt3m7GwsDB99913kmwPCG6/huvNmzfl6+t71/VGRUWpW7dumjlzptzd3RUXF6f27durQIGMf588ffq0fv31V4WHh2dnV5WQkJDhmmANGzbUW2+9dc/X3V6s5nT/rl69mqEI9fX1tWlYS9Izzzyj119/XXFxcTp8+LASExPVrVs3jR071ubmZRSaAAAgJ1JTUyVJH3zwgerVq2ez7M7LNbm6ulr/vtUAvHPszste3Yuzs7NWrVqlTZs2WZc6GD58uOLj41WmTJm7vu7Obd7+PCdxSNKLL76oTp066c0331RsbKzatWtnNZ1TU1MVGBiotWvXZnidn59fpnHlNI47DRw4UKtWrdLUqVNVvnx5eXp66m9/+1uGywwUKlTogbYj/VHXRkREKCIiQnFxcSpWrJiOHz+uiIiIXNleamqqateubV127Ha3Tq64063LGly4cCHDnMzyndl79NbPoGXLljp27JhWrFihVatWKTw8XD179rQ5ceP8+fN3jQXIbTRvAeAxk5XCzsnJKcM1xDK74db69evl7OyspKQkXb582eYMguzKzgHB7Vq1aiVjjL766iuFhoZqw4YNevPNNzOd6+npmeP4cuL2YjWn++fv73/fM0tiY2Pl5+en1q1bKzIyUm3atJGrq6vatm2b4XpyFJoAACAnSpQooaCgIB0+fFhRUVG5vv49e/bo6tWrVr22ZcsWeXl5qWTJkpL+qE8bNmyohg0bauTIkQoODtaSJUvUv3//XNn+rXsbbNy4UcHBwZL+qH+3bdtmcyPYv/zlLypUqJBmzZqlr7/+WuvXr7eW1apVS6dOnZKLi4vNvRNyw82bN7V9+3bVrVtXkpSYmKjk5GRVrlxZkrRx40Z17txZzz33nKQ/as/73eDrXuLj422eb9myRSEhIXJ2dtbPP/+sc+fOafLkydbPZ/v27Vlar5ubm3X27t3UqlVLn332mYoXLy4fH58srbdcuXLy8fHRvn37VKFChSy95l6KFSum6OhoRUdHq1GjRho0aJBN83bv3r1q2rTpA28HyAoumwAAj5nbC7tq1aopICAgQ2FXrFgxJSUlWc8PHDiQ4WzNTZs26bXXXtOyZcvk5eVl3fTrbipXrpxpEXjL7QcE5cuXt3nc64wKDw8PRUZGKi4uTgsWLFDFihVVq1atTOd6e3urdOnSWrNmzV3X5+rqmqGgrFy5sjZu3GgztnHjxgyXfbiXnO5fzZo1tW/fvrsuP3PmjMaOHWvdbCMtLc1qtN+4cSPDvuzdu1c1a9bMctwAAAC3jBkzRpMmTdLbb7+t/fv368cff1RsbKzeeOONB17377//rpiYGO3bt08rVqzQqFGj1KtXLxUoUEDx8fGaOHGitm/fruPHj2vx4sU6c+aM1bjMDYUKFVKPHj00aNAgff3119q3b5+6deumK1euKCYmxprn7Oyszp07a9iwYQoJCVFYWJi1rFmzZgoLC1ObNm30n//8R0ePHtWmTZs0fPjwLDc378bV1VW9e/dWfHy8duzYoc6dO6t+/fpWMzckJESLFy/W7t27tWfPHnXs2PGBzuY9fvy4+vfvr8TERC1YsEAzZsxQ3759JUmlSpWSm5ubZsyYocOHD+vLL7/UuHHjsrTe0qVL68iRI9q9e7fOnj2r69evZ5gTFRUlf39/tW7dWhs2bNCRI0e0du1a9enTR7/88kum6y1QoICaNWum77//Psf7fMvIkSP1xRdf6ODBg/rpp5+0fPlym/falStXtGPHDjVv3vyBtwVkBWfeAsBj5lZh16pVKzk5OWnEiBEZCrtnnnlG77zzjsLCwpSWlqYhQ4bYfLUoJSVFnTp1Up8+fdSyZUv96U9/UmhoqFq1aqW//e1vmW63b9++6ty5s+rUqaOGDRsqLi5OP/30k811x8aMGaM+ffrI19dXLVq00PXr17V9+3ZduHDhnmdVREVF6X//93/1008/6e9///s993/06NHq3r27ihcvrpYtWyolJUUbN25U7969Jclq7jZs2FDu7u4qXLiwBg0apOeff141a9ZUs2bNtGzZMi1evFirV6++b75vl5P9i4iI0LBhw3ThwgUVLlw4w/J+/fppwIABeuKJJyT9cTmHefPmqXnz5nr//fdtrtt2q9CcOHFituIGAACQ/rhkQMGCBfX6669r0KBBKlSokKpVq2ZzZmpOhYeHKyQkRI0bN9b169fVoUMHjR49WpLk4+Oj9evXa/r06bp06ZKCg4M1bdo0tWzZ8oG3e7vJkycrPT1dnTp1UkpKiurUqaNvvvkmQw0WExOjiRMnqkuXLjbjTk5OWrFihYYPH64uXbrozJkzCggIUOPGja3rquZUwYIFNWTIEHXs2FEnT55Uo0aN9OGHH1rL33jjDXXt2lUNGjSQv7+/hgwZokuXLuV4ey+88IKuXr2qunXrytnZWX379rUuI1asWDHNnTtXr776qt5++23VqlVLU6dO1f/93//dd71//etftXjxYj399NNKTk5WbGysOnfunGFf169fryFDhigyMlIpKSl64oknFB4efs8zcV988UV169ZNU6ZMyfQSalnl5uamYcOG6ejRo/L09FSjRo20cOFCa/kXX3yhUqVKqVGjRjneBpAt9r5jGgAgb915l+AjR46Yp59+2nh6epqSJUuad955xzRp0sT07dvXmnPy5EnTvHlzU6hQIRMSEmJWrFhhfH19TWxsrDHGmC5duphq1arZ3El32rRppkiRIuaXX365aywTJkww/v7+xsvLy0RHR5vBgwdnuNtsXFycqVGjhnFzczOFCxc2jRs3NosXL77nPqalpZnAwMAMdxA2JvM72s6ePdtUrFjRuLq6msDAQNO7d29r2ZdffmnKly9vXFxcTHBwsDU+c+ZMU7ZsWePq6moqVKhgPvnkE5t16rY75N660/KuXbsyxJqT/atbt66ZPXt2hvGvv/7a1K1b16SlpVljly9fNm3btjXe3t4mPDzc/Pbbb9ay+fPn29zZGQAAwBFER0eb1q1b2zuMLFu/fr1xdXU1p06dypft3VnP57U7jw0eFunp6SY0NNTMnz8/T7dTr149ExcXl6fbAG7nZMwdFzUEAAAO5auvvtKgQYO0d+/eBzqLoH79+urTp486duyYi9EBAAA8mM6dOys5OVlLly61dyj3dP36dZ05c0bR0dEKCAjI9IZaeWHu3Lnq16+fkpOT82V7TZs2VY0aNTR9+vR82V5u2r17t3788Ud16tQpT9Z/9uxZffTRRxo0aJB1ozMgr3HZBAAAHNyzzz6rAwcO6OTJk9ZNIbLr7NmzioyMVIcOHXI5OgAAgMfDggULFBMToxo1auiTTz6xdzjIRI0aNVSjRo08W7+/v78GDx6cZ+sHMsOZtwAAAAAAAADggHL+3UsAAAAAAAAAQJ6heQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAOieQsAAAAAAAAADojmLQAAAAAAAAA4IJq3AAAAAAAAAOCAaN4CAAAAAAAAgAP6fzxUr+ik5t3hAAAAAElFTkSuQmCC\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "# Tableau comparatif\n",
-        "print(\"Comparaison des approches - Demineur 8x8, 10 mines\")\n",
-        "print(\"=\" * 65)\n",
-        "print(f\"{'Approche':<30} {'Victoires':>10} {'Taux':>8} {'Temps (ms)':>12}\")\n",
-        "print(\"-\" * 65)\n",
-        "for r in results:\n",
-        "    print(f\"{r['name']:<30} {r['wins']:>6}/{N_GAMES}  {r['win_rate']:>5.0f}%  {r['avg_time_ms']:>10.1f}\")\n",
-        "print(\"=\" * 65)\n",
-        "\n",
-        "# Visualisation\n",
-        "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
-        "\n",
-        "names = [r['name'] for r in results]\n",
-        "win_rates = [r['win_rate'] for r in results]\n",
-        "avg_times = [r['avg_time_ms'] for r in results]\n",
-        "\n",
-        "# Taux de victoire\n",
-        "colors = ['#2196F3', '#4CAF50', '#FF9800']\n",
-        "bars1 = axes[0].barh(names, win_rates, color=colors)\n",
-        "axes[0].set_xlabel('Taux de victoire (%)')\n",
-        "axes[0].set_title('Taux de victoire sur 100 parties', fontweight='bold')\n",
-        "axes[0].set_xlim(0, 100)\n",
-        "for bar, val in zip(bars1, win_rates):\n",
-        "    axes[0].text(val + 1, bar.get_y() + bar.get_height()/2,\n",
-        "                 f'{val:.0f}%', va='center', fontsize=10)\n",
-        "\n",
-        "# Temps moyen\n",
-        "bars2 = axes[1].barh(names, avg_times, color=colors)\n",
-        "axes[1].set_xlabel('Temps moyen par partie (ms)')\n",
-        "axes[1].set_title('Temps moyen d\\'execution', fontweight='bold')\n",
-        "for bar, val in zip(bars2, avg_times):\n",
-        "    axes[1].text(val + 0.5, bar.get_y() + bar.get_height()/2,\n",
-        "                 f'{val:.1f}', va='center', fontsize=10)\n",
-        "\n",
-        "plt.suptitle(f'Benchmark des solveurs de Demineur ({ROWS}x{COLS}, {MINES} mines, {N_GAMES} parties)',\n",
-        "             fontsize=13, fontweight='bold')\n",
-        "plt.tight_layout()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-35",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005757,
-          "end_time": "2026-02-26T07:01:11.768723",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.762966",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-35"
-      },
-      "source": [
-        "### Interpretation : comparaison des approches\n",
-        "\n",
-        "**Sortie obtenue** : le tableau et les graphiques montrent les performances des trois approches.\n",
-        "\n",
-        "| Approche | Taux de victoire | Temps moyen | Compromis |\n",
-        "|----------|-----------------|-------------|----------|\n",
-        "| Regles + aleatoire | ~30-45% | Tres rapide | Simplement des deductions locales |\n",
-        "| Regles + CSP + aleatoire | ~50-65% | Modere | Deductions globales mais choix aleatoire |\n",
-        "| Regles + CSP + probabilites | ~60-80% | Plus lent | Choix optimal sous incertitude |\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Le **CSP** apporte un gain significatif par rapport aux regles seules, en deduisant des cellules que le raisonnement local ne voit pas\n",
-        "2. Les **probabilites** ameliorent encore le taux de victoire en remplacant le choix aleatoire par un choix optimal\n",
-        "3. Le **cout** du CSP (enumeration des solutions) est visible dans le temps moyen, mais reste acceptable sur 8x8\n",
-        "4. Meme le meilleur solveur ne gagne pas 100% du temps : certaines configurations du Demineur sont **fondamentalement ambigues** (consequence de la NP-completude)\n",
-        "\n",
-        "> **A retenir** : le triplet regles/CSP/probabilites illustre une strategie generale en IA -- commencer par les methodes les moins couteuses, puis monter en puissance si necessaire."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-36",
-      "metadata": {
-        "papermill": {
-          "duration": 0.006103,
-          "end_time": "2026-02-26T07:01:11.780309",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.774206",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-36"
-      },
-      "source": [
-        "### Replay d'une partie (etape par etape)\n",
-        "\n",
-        "Visualisons les etapes cles d'une partie pour mieux comprendre le comportement du solveur."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-37",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:04.737863Z",
-          "iopub.status.busy": "2026-04-21T00:32:04.737239Z",
-          "iopub.status.idle": "2026-04-21T00:32:05.020932Z",
-          "shell.execute_reply": "2026-04-21T00:32:05.019529Z"
-        },
-        "papermill": {
-          "duration": 0.162193,
-          "end_time": "2026-02-26T07:01:11.947832",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.785639",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-37",
-        "outputId": "11bbf96d-2a2a-4e58-c85d-1df2fa239732",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 499
-        }
-      },
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 1000x500 with 2 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7MAAAHvCAYAAACGzYjKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATJNJREFUeJzt3Xl0VPX9//FXAkkmCUkgECQIhFWWAoIghq1spSAWWUSNJCwWF8CqlC+KwvcrqG0VCiKiQnGBgnXDDdkKlQYIiFWqspRFRMLmEgyQhSQsyf39wW9uM5ANSHLzuXk+zsk5kztz577fM3c+d15z79zxsyzLEgAAAAAABvF3ugAAAAAAAC4XYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgDKwejRo+Xn5yc/Pz9Nnz7d6XIKtXjxYrvOnj17Ol1OpbVhwwb7eWjYsGG5L9+7bD8/PyUnJ5f78isqXh8AULEQZgG4Rv43mvn/goOD1bRpU40ePVr/+c9/nC7TWISb0rNhwwZNnz5d06dP10cffeR0OeUuf1j38/OTv7+/goKCVKtWLbVt21YjR47UunXrZFmW06UCACqwqk4XAABlLScnRwcOHNCBAwf03nvv6dNPP1Xbtm2dLguV2IYNG/Tkk09KkkaNGqXBgwf7XN++fXslJSVJkjweT3mXV+4sy9LZs2eVmpqq1NRU7dy5U0uXLlXfvn31t7/9TVFRUU6XKEkaMGCA/bxEREQ4XA0AgDALwLWSkpJ07tw5bdu2TY8//rhyc3N1+vRpvfjii1q4cKHT5aESyszMVLVq1Yq9XUREhLp161YOFVUMy5YtU1RUlI4dO6aPP/5Y7777rizL0j/+8Q/1799fmzdvVnBwsNNlqnbt2qpdu7bTZZSKkq6LAFCRcZgxANfq1q2bevXqpUceeUT9+/e3px8+fPiS2x49elQTJkxQixYtFBwcrGrVqqlDhw6aM2eOzp0753Pb6dOn24dHjh49Wps3b1bPnj1VrVo11ahRQ3FxcTpy5EiJaty2bZsSEhLUpk0bRUVFKSAgQGFhYWrXrp2mTZumzMxMSdLBgwdVpUoV+fn5qVq1avZ0r5kzZ9o13X777cUu9/z583r66afVsGFDeTwetWnTRosXLy5Rzfn17NnTXu7F8xf2vcuGDRva09evX69Zs2bpuuuuU1BQkBo1aqTnnnuuwGWtW7dOgwYNUp06dRQYGKioqCjdeuut9p6ykrj4u8sfffSROnXqpODgYNWuXVv333+/Tp486TPPW2+9pUGDBqlp06aqXr26AgICVLNmTfXo0UOvv/76JYfC5n9MFi1apOeff14tW7ZUYGCgEhIS5OfnZ++VlaS//vWvl3w/trjvzJbGYyFJiYmJ6tKli4KDg3XNNddo/PjxOnXqVJHz7NmzR/fcc48aN24sj8ej8PBwde3aVYsXL77iw4I7duyoHj16aPjw4Xr77be1ZMkS+7ovv/xSL7zwgs/tc3Nz9Ze//EXdu3dXjRo1FBgYqJiYGN177706ePCgz22Tk5N91sUffvhBd911lyIiIlSjRg0lJCQoNTVVZ8+e1RNPPKH69evL4/GoQ4cOWrdunc99Ffad2Yufr8OHD2vEiBGqWbOmgoOD1b17d23btu2SvrOysjRz5kx16tRJ4eHhCgoKUrNmzTRx4kQdP368RMuWCv9O/sVj1dq1a9WlSxeFhoZWqg9LALiYBQAusWjRIkuS/ZffLbfcYk8fM2aMz3Vbt261qlev7jNv/r9evXpZOTk59u2nTZtmX9esWTMrICDgknnq1atn/fTTT/Y8o0aNsq+bNm2aPX3+/PmFLleS1aFDB+vcuXOX9PDqq6/69NCxY0f7ulWrVhX7WI0cObLA5bVv396+3KNHD595vNMPHjxoT+vRo4c9fdGiRQXe/uJ5YmJifB6/gup46623fO5r8uTJhT5G/v7+1vz584vt2bJ8n4eWLVsWeH/XX3+9lZWVZc9z5513FvkcPfzwwz7LyP+YXNzfoEGDiryvmJgYy7IsKzEx8ZJppf1YrF271qpatWqR68DFz92HH35oeTyeQpcfHx9v5eXlFbvs/P1dvAyvPn36+DxXXllZWVavXr0KraF69erWv/71L/v2Bw8e9Ln+uuuuu2Sezp07W0OGDLlkemBgoJWcnGzfV/4xJv/rI38/4eHhVu3atS+5r1q1alnp6en2PMePH7dat25daB/XXnut9d133xW7bMsqfHzJP1Y1btzY8vf391nPAcB07JkF4FqbN2/Whg0bNHv2bK1du1aSFBgYqHHjxtm3OXPmjO688057b9Rtt92mVatW6b333rO/V5uYmKg//vGPBS5j//79uvnmm7Vy5UrNmzfPPmzv6NGjmjp1arE1tm3bVrNnz9aHH36oTz75RImJiVq2bJluvPFGSdK///1vffjhh5KkBx54wJ7vtddesy8fOnTI3usTHR2tfv36FbnMjRs3+uz5uueee7R69WpNnTpV27dvL3Q+y7JkWVapnl33u+++07Rp07Ry5Ur16NHDnj537lz78po1azRjxgxJUnBwsGbOnKl//OMfmj17toKCgpSXl6cHH3xQ33zzzWUte8+ePRozZoxWr16tP/zhDwoICJAkbd++3Wfv8K233qoFCxbo448/VmJiotavX6/XXntNtWrVkiS9+OKL+vHHHwtcxv79+3Xrrbfqww8/1EcffaS7775bSUlJuvvuu+3b3HzzzUpKSlJSUpLee++9ImsurcciLy9P48eP1/nz5yVJrVq10rJly/TGG2/o559/LnCe48ePa8SIEcrJyZEkjR07Vn//+9+1dOlSxcTESJL+9re/adGiRUUuu6T69u1rX96zZ4+ysrIkXdjbmJiYKElq1KiRFi1apHXr1mns2LGSpFOnTumuu+6ye7vYmTNn9Pbbb+vll1+Wn5+fJGnr1q1avny5pk+frpUrV+q6666TJJ09e1YLFiy4rLrT09MVGhqqN998U4sWLbK/W/vzzz/rzTfftG/3wAMPaNeuXZKkdu3a6a233tKaNWt02223SZKOHTumUaNGXdayi/Ldd9+pRYsWWrp0qdauXasHH3yw1O4bABzjdJoGgNJy8Z7Zi/86duxoJSUl+cyzYsUK+/qoqChr06ZNVlJSkpWUlGTNmzfPvi46OtqeJ//ejrp161pnzpyxr5s1a5bPHqLc3FzLsgrfc3Lu3Dlr3rx5VteuXa0aNWr47Dnx/k2cONGyLMvKy8uzmjRpYk/fvXv3Jct89NFHi32cfve73/nshcvvjjvuKHTvT0Guds/s+PHj7emfffaZPT0yMtKeftttt9nTR4wYYT8/SUlJ1oABA+zrHnvssWLrzf883HjjjYU+Lm3btrWn//zzz9bkyZOtNm3aWKGhoZafn98lz9HHH39c4GPSoUOHAuvIvw6NGjXqkusL2zNbWo/Ftm3bfOrfvn27fd3q1asLfO7yvx5at27ts+ypU6fa18XGxha57Iv7u3j98HrllVd8bnPs2DErLy/PioqKsqc999xzPnVER0fb1/3973+3LOvSPbOrV6+2l9GqVSt7+h133GFP//Of/2xPHzp0qD29JHtmJVmff/65fd3YsWMveS2fPHnSqlKlij39zTfftHtITEz0Odpj7969RS7bskq2ZzYkJMT68ccfi31uAMAknAAKQKWxe/duHT169JJpXsePH9cvf/nLAuf94YcflJqaqpo1a/pMv+mmmxQYGGj/n/97aKdOndLPP/9c5Aljfvvb32rp0qVF1u39Dqefn5/GjRunSZMmSbqwd3bWrFk+e/NGjx5d5H1J0rfffmtf7ty5s891Xbt21bvvvlvsfZSWPn362JfzP7YnTpywL+d/jpYuXVro4+Xdy1VSF39nsFu3bnrxxRclXdijKknZ2dnq2rWr9u3bV+R9Xfw9W6+hQ4deVk3FKa3HIv86EBIS4nN2765duxa77F27dql79+5XtOySuvg7o9WrV9fx48d9pk+cOLHQ+Xft2lXgUQpdunSxL+df5/K/Frx73SXfdbEkwsLC7CMrLl6G976++eYb5ebm2tOHDx9e6P3t2rVLzZs3v6waCtK1a1ddc801V30/AFCRcJgxANeyLEspKSkaOXKkpAsnWxk1apTPm/LLcfFJl67WsWPHfMLIhAkTtG7dOiUlJdk1SxcOCfW6++677bO6Ll26VAcPHtS//vUvSReCdcuWLUu1xuJ4D9OU5HNY58VBpDCRkZH25apVr+7z1dJ+fiTpww8/tINsaGioXnjhBSUmJiopKUlt2rSxb5f/OcovOjq61GsqibJ4LMp72flPvtSyZUuFhISUSh35f1LH3/+/b4OqV69e4O2tyzypVf51WvJdry/3vqT/9lHYa00q2evNqXURAMoSYRaAq0VFRWnhwoVq1KiRpAvfgXvsscfs6/OHvwYNGujcuXP2d0Pz/2VmZtrfC8zv888/9znb8ZYtW+zLERERPnt4Lpb/jMc1a9bUnDlz1LdvX3Xr1k3Hjh0rcJ7IyEjdddddkqSUlBSNGTPGfoNckr2yktSkSRP78meffeZz3aefflqi+/CqUaOGfTn/Xu8VK1Zc1v0UJf9z9Pjjjxf4/OTm5mrNmjWXdb/5n6uL/2/atKkk3zNf9+/fXw8++KB69uyptm3bXrKXvyD5A0h++UNUYUG4IKX1WORfB7KysrRz5077/8LWgfzL7tKlS4HL9r5WrtbixYu1YcMG+3/vd0ejoqJ8XlNr164ttIZp06ZddR1l5brrrlOVKlXs//ft21doH97e87/W8o8Pp06d0ubNm4tdZmHrIgCYjMOMAbheUFCQpk6dqnvuuUfShaD11VdfqX379urbt6/q16+vI0eO6PDhw+rXr5/uvfde1a5dWz/88IMOHDigdevWqVmzZgWe2ObYsWO64447dM899yg5OdnnJ1eGDRvmE1ou1rhxY/tyamqq/vjHP6pjx4567733tH79+kLne+CBB/T6669Lkn0iHI/Ho7i4uBI9HsOGDdNLL70k6cLPntx///0aMmSIPv30Uy1btqxE9+HlPVGOJM2ZM0dhYWFKT0/XrFmzLut+ijJmzBh98MEHkqQ///nPysvL0y9/+Uv5+/vr8OHD2rFjh5YvX66lS5de8pMlRfn888913333aejQofrqq6/0l7/8xb7ujjvukOT7HK1fv15Lly5VRESEZs2aVeihxSWR/9DTpKQkrVq1ShEREapTp44dpAtSWo/FDTfcoMaNG+u7776TdOEw1+nTp+vMmTOaMmVKgfPceeedmjJlijIzM/Xpp59q2LBhGj58uCIiInTs2DHt27dPq1ev1uDBgy87SG7btk2HDh3SsWPHtHz5cp9D3W+44QY99NBDki4Esrvvvlt//vOfJUkjR47UY489ptatWyszM1OHDx/WZ599ppUrVyo9Pf2yaihP1atX19ChQ+3X24ABA/TII4+oadOmOnXqlA4dOqRNmzZp79692rt3ryTf11pycrJGjx6tjh076rXXXqvQvQJAmSrj7+QCQLkp6qd5zp49azVo0MC+bvDgwfZ1n376aZE/zaOLTtKT/6QqrVq1soKCgi65/bXXXutzspXCTtASFxd3ybxVqlSxunfvXuQJgmJjY33miYuLu6zHKj4+vsA+mzdvflkngPruu++swMDAS+7n4p8cKewEUImJifb0i0/Uk9+jjz5a5PNz8X0VJv/z0K5duwJP5tSmTRvr9OnTlmVZ1unTp63GjRtfcps6depYLVq0sP/Pf/Krok6K5bV79+4CT/bl/dmoon6ap7QeizVr1hT40zz514GLn7sPPvigyJ/muXj9LszFJ0wq7K9v375WSkqKz7xZWVlWz549i53Xq6j1qrDnqrCTLZXkBFAXP1+FnewrJSWlyJ/mKei++vbte8ltAgMDfX5uqLATQBU0jgCA6TjMGEClEBAQoMmTJ9v/L1++XDt27JB04cQvO3fu1MSJE/WLX/xCISEhCg4OVqNGjdS3b1/NmTNHTz31VIH3e+ONN2rjxo3q3bu3QkNDFRERoTvuuENbtmwp0clWXn31VU2YMEH16tVTcHCwbrrpJq1evVq9e/cucr78P9MjyeenXkpi8eLFmj59uho0aKDAwEA1b95c8+bN8zkEuyQaNWqkjz76SO3atVNgYKDq1Kmj3/3ud0pKSrqs+ynOjBkztG7dOg0ZMkTR0dEKCAhQjRo11KpVK40cOVLvvfeeYmNjL+s+Bw0apFWrVummm26Sx+NRrVq1dO+99yoxMdH+fmZISIj++c9/asiQIYqMjFRERIRuvfVWbd68+apOptOyZUstWbJEv/jFL+yfBCqp0nos+vfvr7///e+KjY1VUFCQatasqdGjR2vTpk2FzjNkyBB99dVXuu+++9S0aVN5PB6FhoaqadOm+s1vfqMFCxZo/Pjxl9WPV0BAgGrWrKk2bdpoxIgRWrt2rdauXauoqCif2wUHB+uTTz7RwoUL1bNnT0VGRqpq1aq65ppr1KFDB/3+97/3OUS5ooqKitLnn3+uWbNmKTY2VhEREQoICFDdunUVGxurqVOn6v333/eZZ8mSJbrjjjsUHh6ukJAQ9enTR5s2bbrkRG4AUFn4WdYVnI0AACqx6dOn24cTjxo1SosXLy73GjIzMxUeHi7LslSvXj0dOnSoyEOaccHo0aP117/+VZI0bdo0TZ8+3dmCAADAFeM7swBgkOzsbGVlZWnu3Ln2iZ/uuecegiwAAKh0CLMAYJCbb75ZGzdutP+Pjo7Www8/7GBFAAAAzuCjfAAwUHh4uPr3769//OMfhf4+JgAAgJvxnVkAAAAAgHHYMwsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFmUiw0bNsjPz08NGzYs1+VOnjxZfn5++uCDD8p1uW6VnJwsPz8/+fn5lfuyR48eLT8/P/t3QadPny4/Pz+NHj26RPPfeuutqlq1qv7zn/+UXZEAAFdavHix/Pz81LNnzzJdzpo1a+Tn56eHHnqoTJdjgu+//14ej0edO3d2uhRUYIRZFKlhw4Z2eAkKClJ0dLT69++vjz76yJF6LicUHzlyRHPnzlXTpk01ZMiQsi+uEggPD9fDDz9cIX4KJjY2Vg8//LB+/etfl+j2jzzyiHJzczV58uQyrgwAyk/+7XT+v+eff16Scx8mF+W3v/2tGjdubNe6ePFip0uqECzL0qRJk+Tv769JkybZ0+fOnavrr79eVatWLfRD3LfeeksdOnRQtWrVFBUVpfvuu0/p6enlWH3pq1u3ruLj4/XZZ5/pvffec7ocVFD8zixKpHfv3mrSpIm+/vprrV27VmvXrtWjjz6qGTNmOF1aoebPn68zZ84oPj6+zPcknj9/XlWqVHFkj2VBzp07p4CAgFK/38jISPsN0tU4e/asAgMDr+o++vfvr/79+5f49t26dVNMTIxWr16tb7/9Vk2bNr2q5QNARdK7d2+1adPG/r99+/YOVlO0LVu2qFWrVvrxxx+VnZ1dZsuxLEu5ubmqWtWMt7v/+Mc/tHv3bvXo0UMNGjSwp2/btk3Vq1dXgwYNdPDgwUvm++CDDzR8+HB5PB7FxcVp9+7deuWVV/TTTz9p+fLl5dlCqUtISNDrr7+uF154QcOGDXO6HFRA7JlFidx+++1auHChPv/8c82ePVuSNHPmTP373/+WJOXk5Ojpp59Wy5YtFRoaqubNm+tPf/qTzp07d8l9zZ07V3Xr1lXNmjV133332Rsy7yE8+T89zn9o6eLFi9WrVy9J0qFDh+xPdJOTkwus+cMPP5Qk9enTx562Z88ede3aVbVq1VJAQIAiIyM1cOBAHThwwL6N91Pu2bNnq2PHjgoJCVHnzp21fft2+zbeZb/00ktq3ry5goKClJaWprS0NE2cOFFNmzZVaGioWrdurYULF8r7C1hHjx7Vrbfeqpo1ayooKEgxMTG69dZbC33cvf0/8MADGjJkiEJCQnTdddfp7bfftm/Ts2dP+fn5acqUKfrlL3+pwMBArVq1Srm5uXr55ZfVtm1bhYaGqnHjxpo0aZIyMzMl+R4y/NJLL6lRo0YKCwvTpEmT9N1336lHjx4KDQ1Vz549deTIkUvm8frhhx/029/+VjExMapWrZo6duzoc1i393Dg22+/XSNGjFC1atX06KOPFtjvjz/+qLFjx6pJkybyeDxq0KCBXn311QJvW9BhxomJierdu7eioqIUEhKiG264QYcOHbKfs969e8uyLOM37gBwsdtvv13PP/+8/dejR48it5vvvvuu2rZtq4iICFWtWlV169bVuHHjlJWVJcl3vF+6dKkaNmyoiIgI3X777UpNTbWXu23bNvXv31+1a9dWZGSk+vfv77O9LMi+ffu0cuVKhYeHl7g/77Z5wYIFxd5mxowZat++vQICArRr164SvUdZunSpmjRporCwMN1777266667iv0qS3G9v//++7r++usVGhqq8PBwtW3bVvPnzy/0/gp63+KtbePGjerUqVOB83nfE4waNUqLFi3S2rVrJUkff/yxvv7660KXV9Q289ixYxo1apQaNGigsLAw3XDDDXrjjTfseb3b4PyHXXvfj3j3tJfkPUxxj1HXrl0VFBSkzZs36+effy60F1RehFlctt///ve65pprJMk+3DghIUFPPPGELMvS8OHD5e/vr6lTp2rKlCk+8x45ckTz58/XzTffrNzcXL3yyis+h9IUpVWrVrrtttskSWFhYfbhrgVtDLOzs7V37157Pq/U1FTl5eVp4MCBuu+++9SgQQOtXLlScXFxl9zH//3f/6l169Zq0aKFPvvsM/Xr188Ogl7/8z//o44dO+r222+Xn5+ffv3rX2vOnDmKiIhQfHy80tPTdf/99+vll1+WJE2ZMkUrVqxQixYtNGbMGLVt21ZJSUnF9j5//nzl5uaqd+/e2r9/v4YPH67PP//c5zbPPvusPB6PRo4cqZo1a2ry5Ml64IEHdOrUKd15552qVauWZs+erd/+9reX3P8f//hHde/eXVlZWXaIr1OnjmrVqqWNGzfqf//3fwus6/Tp0+rcubMWLVqkmJgY3XXXXTp48KBuu+02rVq1yue277//vrZv366EhAQ1b9680Pv6y1/+opycHCUkJKh169b281iclStXqk+fPkpMTFSLFi0UHx+vs2fP6uTJk/ZtfvGLX0iSvvjiixLdJwCYYtmyZZowYYL99+233xa53Tx06JDq1q2ruLg4O7AtWLBA06ZNu+S+p06dql/96leqVq2a3nvvPY0cOVKS9OWXX6pr165KTExU165d1b9/f33yySfq2bOnjh07Vm69X2zKlClq1KiR4uPjFRISUux7lK1bt2rkyJH67rvv1LNnTx04cEDvvvtukcsorvecnBwNHz5cu3fv1m233aZhw4YpNDTU3glQ2H1Kvu9bSsLj8Ui68IF9enq6z/uDr776qsB5itpmZmdnq0+fPlqyZIlq1aql2267Tbt379aIESO0aNGiy6pNKvw9TEkeo8DAQDVr1kyWZWnbtm2XvWy4nxnHXaBC8fPzU0xMjH766Sf99NNPOnLkiN5//31JFw7lDA0N1fXXX6+9e/fq5Zdf9jkU2d/fX5s2bVLt2rX1q1/9SsOHD9frr7+uF198sdjldurUSb/73e/0/vvvF3u4a/4AExERYV/u1q2b5s6dqw0bNuj48eNq27attm/frm3btunkyZOqUaOGfds//vGP+v3vf6/s7GzVrVtXP/300yXBd+7cubr//vslSUlJSfr8889VtWpVde3aVf7+/mrdurWOHDmiF198UQ888IDOnDkjSerSpYuGDRtmf0pcnIEDB9p7E/v166d169bp9ddf9/mU9s4779Rbb70l6cJhvP369ZN04bul4eHhateunb744gstW7ZMP/30k8/9z58/X4MGDdKOHTu0fft2denSRe+8847mzZunhx56qNCN7wcffKBDhw4pIiJCN9xwgySpZcuW2rJli1588UXdcsst9m0bNGigbdu2FXp48QcffKDk5GSFhITo3//+t+rUqSNJBe7dL8icOXNkWZaGDh1qr4/ShUPAvbwffJw4caJE9wkApvjnP/+pf/7zn/b/gwcPVs+ePQvdbv7+979XixYttH37dp04cUItWrTQDz/8oHXr1unPf/6zz30vX75c7du319atW9WlSxetXr1aP/zwg1566SWdPXtWv/jFLxQTEyNJqlevng4dOqQ33nijVM9RsH79ep07d87eNhTl0Ucf1TPPPCNJJXqP4g1offv21YoVKyRJ119/vXbs2FHoMorr/YEHHtD58+dVrVo1DRo0SK1atdJ1111XZN3e9y7537eUxMSJE/Xhhx9q06ZNl8z7448/FjhPUdvMjz76SPv27VP16tW1ZcsWBQcHq3nz5poyZYpmz56tu++++7LqK+w9zKxZs0r0GLHtRlEIs7hslmXZh6Fcc801Onz4sH3da6+95nPbrKwsff/99/b/tWrVUu3atSX995PHnJwcHT9+vMBl5Q8il6N69er25fT0dEVGRkqSZs+eXeie4JSUFJ8w660vODhYDRs21Ndff+3TqySfw2u8150/f17z5s3zud3+/fslSU899ZR+/PFHPf/885o1a5b8/f3Vr18/vffeewoJCSm0n/yf0rZq1Urr1q0rspbjx4/bh28vW7bskvvbv3+/6tWrZ//v3WPpfdxatmwp6cIn+ZIu2SN9cc9paWmaO3dugT17de7cucjvyXrvq0mTJj5vVkr63V/v/F27dvWZnv+7Ut6TYeR/ngHADebPn6+xY8eW+PZDhgzRypUrL5mekpJyyTTvNij/tujIkSP2uPuf//znkjPFX7wNuFpNmjQp8W0L2jZLhb9HOXr0qCSpdevW9nWtWrUqMswW13u1atW0cOFCPfXUU/Z3PcPDw/X0008XeqZi7zb4ck/c1K5dO33zzTd65513lJKSoo4dO2rKlCnat2+f/Z6rsPoL2mZ6v5fbsGFDBQcHS/rvc1/Qd3a9CnvPVth7mJI+Rmy7URQOM8Zle+655+w9e4MGDfIJRbt375ZlWfbfgQMHfK7/+eef7eC6e/duSRcOj6lVq5aqVasmSTp16pR9+127dvksu0qVKpKkvLy8ImsMCQmxD2X1LkeS/X2PBx98UGfOnNHWrVvt67zfa83fi3ThkGXv93Lr16/vc5ugoCD7srfP4OBgpaam2o9Bbm6uvv32W0kXNgwbN25URkaGtm/frg4dOmjNmjU+n4oWJH8P3stF1VKrVi37sKPVq1f7PCfffvutunXr5jPvxSfH8D7OxfH2XL9+feXk5NjLOHv2rBITEwutryDek1189913PnuOS/qBhnf+Tz/91Gd6/vm9j513LzIAuF1B281Tp07ZQfadd95Rbm6uvSfz4m2h9N+xM/+2qH79+vY24I477vDZzpw4ceKSvbtX68CBA9q7d6/Pe4TCFLRtlgp/j+Ldnub/Wkv+XgtSkt4TEhJ06NAhHT9+XB9//LHS09P1yCOPFLpd826bilv2xc6fP69rrrlGEyZM0J/+9CdFRkZq37598vf3V+/evQucp6htZqNGjSRd+N6094PxPXv2SJJ9nfc9m3dv8tmzZ/XNN98UuKyi3sMU9xidO3fOfg9VkU9qBuewZxYlsmzZMn355Zf6+uuv7e8bPvroo+rYsaOkC4eQrFixQr169dJvfvMbZWdna9u2bYqOjtaGDRvs+8nLy1P37t3VtWtXO8Ddfffd8vf3V/v27eXv76+0tDQlJCTo9OnTl5xEwjv4Hj16VGPGjFHt2rXtDfDFBg8erBkzZmj9+vV2ePPu8fv444+VlZWl9evXF9rz//3f/2n79u3asWOHTp06pdq1a+s3v/lNobfv1q2b2rVrp6+//lodO3ZU3759dfLkSX322Wfq3bu3Fi9erHHjxmn37t1q2bKlAgIC7E+ui/u0ceXKlRo0aJDy8vK0bt06SSrwu69eQUFBuvfeezVv3jzFxcVp8ODBkmT3UtQnq5dj6NChmjp1qo4cOaIbb7xRXbp0UUpKijZv3qzx48fbvwlbEkOGDFHDhg2VnJysDh066Oabb9bx48d13XXXaebMmcXOP2HCBCUmJur9999Xjx491Lx5c23btk2vv/662rVrJ0n2IXiDBg26knYBoMJatmyZTxjr1KmThg8fXuB286mnnlJYWJgyMjI0e/ZsrVq1qsif3Bs8eLD69u2rNWvWSJJuvvlmRUdHa9y4cXrjjTf07rvv6uTJk2rcuLGSk5O1ceNGrVmzptDfZJ00aZJ+/vlnpaWlSZJeffVVbdiwQYMHD7a3Vxfr06ePDh06dNl7oGNiYop9j3L33Xdr4cKFWrNmjYYMGaKMjIxLPky/WEl6j4qKUo8ePVSvXj37O8Th4eGFfmA8ePBg/eUvf9H69et9zlXx6quvavPmzfrXv/4lSdq8ebNGjx6tFi1a6LHHHlNycrL69u2rnj17Kjs7234uJ0yYYIfPixW1zbzlllvUrFkz7d+/X926dVObNm30zjvvSLpweLokdejQQZK0c+dOjR8/Xnv27Cn0KLui3sMU9xh9+umnysnJUWxsbIkOMUclZAFFiImJsSRZkqyAgACrTp06Vr9+/azly5f73O706dPW9OnTrRYtWlgej8eqVauW1bNnT+uNN96wLMuyEhMTLUlWTEyMNXfuXCs6OtqqUaOGNWbMGCszM9O+nxdeeMGqU6eOVatWLWvEiBHW4MGDLUnWtGnT7Ns8/vjjVmRkpCXJioiIKLT25ORkKzAw0GrWrJmVl5dnWZZl7d271+rSpYvl8Xisli1bWkuWLLH727Nnj0/Pc+fOtTp16mR5PB6rU6dO1r///W/7vr3zHDx40GeZqamp1sMPP2w1adLECgoKsurUqWPdfPPN1urVqy3LsqxXX33Vat++vRUeHm4FBgZajRs3tp588slCexg1apQlyXrooYesYcOGWcHBwVbTpk3tx9WyLKtHjx6WJGvRokU+8547d86aO3eu1aZNGys0NNSqUaOGFRsbaz3//POWZVnWwYMHL+nDe1+TJ0+2LMuyFi1aZD9vF8/jdfjwYWv06NFWTEyMFRQUZNWrV88aOnSotXXrVsuyLGvatGmWJGvUqFGF9un1ww8/WPfdd5/VqFEjKzAw0KpXr571yiuv+DwW3nWhoPtdv3691atXL6tmzZpWcHCw1b59eys5OdmyLMtKSkqyJFn9+vUrtg4AMEX+7XT+v/xjY0HbzRUrVlhNmza1goKCrD59+lh/+MMfLEnWNddcY1mW73j/zjvvWI0aNbLCwsKsoUOHWikpKfZ9b9261erXr59Vu3Ztext13333Wd9///1l15x/W1/YPPPnzy/2NomJiT7Ti3uPYlmWtWTJEqtRo0ZWaGioNWbMGGvIkCGWJGvMmDGWZf13e9ijR48S93777bfb28awsDCrS5cu1oYNGwqtPy8vz2rRooXl7+9vHTp0yJ7u3f5d/Oet5aeffrJiY2OtsLAwKzAw0GrVqpX1wgsv2O99ClPUNvPw4cNWQkKCde2111qhoaFWu3btrMWLF/vMP3nyZKtmzZpWdHS09dBDD1mxsbE+70dK8h6muMdozJgxliTrrbfeKrIXVF6EWbjaI488Ykmy3n///RLPU9jG0AkXBzhcuYEDB1pVqlSxduzY4XQpAFDhFfThpZudPHnSvpybm2s1b97ckmT94Q9/KNc6Vq1aZUmyHnzwwXJdblm42vcw33//vRUUFGTddNNNxQZzVF4cZgxXmzlzZokOUYX7ffzxx06XAACooG688Ub17NlT9evX1z//+U/t27dPNWrUKPJ3ZsvCgAEDCvzecmUUHR2tnJwcp8tABUeYBQAAQKXWqVMnLV++XGlpaYqOjlZ8fLyefPJJXXvttU6XBqAIfhYf/wAAAAAADMNP8wAAAAAAjEOYBQAAAAAYhzALAAAAADBOiU4AlZeXp++//15hYWHy8/Mr65oAACh1lmUpIyNDdevWlb+/Oz/LZXsNAHCDkm6zSxRmv//+e9WvX7/UigMAwClHjhxRvXr1nC6jTLC9BgC4SXHb7BKF2bCwMEnSsmXLFBISUjqVVRDr169Xnz59nC6jTCQlJWnMmDFOl1HqXnvtNVf2Jbm3N7f2tWDBAvXu3dvpMsqEG8fGrKws3X777fY2zY28vX355Zeu7HPxSy/p0c6dnS6j1D3z5Zcac889TpdRJtw6/tOXedw6fjz12Wfq/atfOV1GqSvpNrtEYdZ7qFJISIhCQ0OvvroKJCgoyHU9eQUFBbnyzYzH43FlX5J7e3NrX24fP9zam5sPv/X2FhYW5srXnCcoSOEu+1BdutCXG58vyb3jP32Zx63jh5u311Lx22x3fmkIAAAAAOBqhFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxqjpdAMy1dWuA5s0L1ddfB+jEiQufi8yYka5Ro7IdrgyVyfzt87UueZ0OpB3QqZxTigqJUpe6XTSp4yTFhMc4XR7gOm5+zb39+OM6umtXgdcNmjJFzTp3LueKSgfba1QUbh0/3Dp2mIAwiyu2c2eANm0KVExMrr1xBMrbaztf07HMY2pavak8VTw6nHFYy75Zpo1HN2pL3BaFBYY5XSLgKpXhNVelalXVbtLEZ5onzNy+2F6jonD7+OG2scMEhFlcsWHDsjViRJaOH/dXp05RTpeDSiqhZYKGXTdM9cLqSZKe2PKEFu5cqJSsFCUdS9KARgMcrhBwl8rwmguNjFT8rFlOl1Fq2F6jonD7+OG2scMEfDyHKxYZaSk42OkqUNlN6DDB3ihK0k3RN9mXA/0DnSgJcDVec+Zhe42KgvEDpY09swBcIzcvV2/seUOSFBMeo+71ujtcEeBubn3NpaekaNbAgT7TJq1Y4VA1gDu5cfxg7Ch/hFkArnD63GmN+2ScEo8kqnZIbS3pv0RBVYKcLgtwLTe/5gr63huA0uPW8YOxo/wRZgEYLyUrRQlrErTj+A41iWiiN2950+izIgIVndtfc3zvDSg7bh4/GDvKH2EWgNH2ntirhNUJOpp5VLHRsVrUb5FqeGo4XRbgWrzmAFwpxg+UNsIsrtiqVUF6+ulqOn/ez542c2Y1zZ8fohtuOKeXX053sDpUFmPWjtHRzKOSpMyzmYpfHW9fF98yXvEt4wubFcAV4DVnHrbXqCgYP1DaCLO4YhkZfkpO9l2FUlP9lZrqr+joPIeqQmVzJveMfXlXqu8Plveq36u8ywFcj9ecedheo6Jg/EBpI8ziisXF5SguLsfpMlDJbUvY5nQJQKXi5tdc3DPPOF1CmWB7jYrCreOHW8cOE/A7swAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHD/LsqzibpSenq6IiAhNnDhRQUFB5VFXucnJyZHH43G6jDJx/vx5hYaGOl1GqcvKylJISIjTZZQJt/bm1r7S09NdNyZ6uXFsPHPmjJ577jmlpaUpPDzc6XLKhHd7PXXCBHlcuG5m5uYq2IVjSVZOjivHSMm94z99mScnLU3VAgKcLqPUZZ49qxAXjvc5Z87oT88/X+w2u+rl3GmfPn1cF47Wrl2rfv36OV1GmUhMTNTYsWOdLqPULViwwJV9Se7tza19vfDCC/r1r3/tdBllwo1j4+nTp/Xcc885XUa5eLRzZ4W78A3pk198obHjxztdRqlz6xgpubc3+jLPK3PmaGq3bk6XUer+mJTkyr7Ss7L0p+efL/Z2HGYMAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcao6XQDMNH/7fK1LXqcDaQd0KueUokKi1KVuF03qOEkx4TFOl4dKhHURKF9vP/64ju7aVeB1g6ZMUbPOncu5otITsnChPG+/rSpHj8ovJ0d5NWvqXIcOOj1xos63auV0eVeMcRIVhVvXRTePixW9N8IsrshrO1/Tscxjalq9qTxVPDqccVjLvlmmjUc3akvcFoUFhjldIioJ1kXAGVWqVlXtJk18pnnCzH69BWzdKv/UVOXGxMgvJ0dVDhyQZ+VKBW7ZouPbtkmhoU6XeEUYJ1FRuH1ddOO46FVReyPM4ooktEzQsOuGqV5YPUnSE1ue0MKdC5WSlaKkY0ka0GiAwxWismBdBJwRGhmp+FmznC6jVKXNny95PPb/oTNmqNqcOfI/eVJVv/1W56+/3sHqrhzjJCoKt6+LbhwXvSpqb3xnFldkQocJ9kAkSTdF32RfDvQPdKIkVFKsiwBKjcejoNWrVWPAANXs3l2hc+dKkvJq1lTuRXskTMI4iYqCdRGljT2zuGq5ebl6Y88bkqSY8Bh1r9fd4YpQWbEuAuUnPSVFswYO9Jk2acUKh6opPf7Hjyvwyy/t/883aKBTS5bIqlbNwapKD+MkKgo3rotuHRelitsbYRZX5fS50xr3yTglHklU7ZDaWtJ/iYKqBDldFioh1kWgfBX0/Sk3yB41StkjR8r/2DGFPf20PMuXq/r99+vEqlXGB1rGSVQUbl0X3TouShW3N8IsrlhKVooS1iRox/EdahLRRG/e8qbRZ6KDuVgXgfJXUb8/VSr8/JRXr55OP/ywPMuXq+q+ffJ8+KGyR4xwurIrxjiJisLN66Kbx8WK2hvfmcUV2XtirwZ8MEA7ju9QbHSsVg5Z6ZqBCGZhXQRQGvxOnJBn2TLp7Fl7WuD69f+9PivLibJKBeMkKgrWRZQ29sziioxZO0ZHM49KkjLPZip+dbx9XXzLeMW3jC9sVqBUsS4CKA1+mZmKePBBhT/6qM7HxMg/I0NVjh2TJOVVq6acAeaeZZVxEhUF6yJKG2EWV+RM7hn78q5U3x9S7lW/V3mXg0qMdRFAabAiIpQzeLCqfvWVqh46JJ07p9xrr9XZzp11+qGHlFe/vtMlXjHGSVQUrIsobYRZXJFtCducLgGQxLoIlLe4Z55xuoQyYUVEKG3BAqfLKBOMk6go3LouunVclCp+b3xnFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACM42dZllXcjdLT0xUREaGJEycqKCioPOoqNzk5OfJ4PE6XUSbOnz+v0NBQp8sodVlZWQoJCXG6jDLh1t7c3FdwcLDTZZSJ7Oxs1/V25swZPfvss0pLS1N4eLjT5ZQJ7/b6scmT5XHZ9lqScjIyFBoY6HQZpS4zL0/BLtxeS+4e/+nLLFlZWQpx4Xv+rOxshbhsey1JOWfO6NkZM4rdZl9WmF21apXrwtHatWvVr18/p8soE4mJiRo3bpzTZZS6BQsWaOzYsU6XUSbc2ht9mceNvWVkZKhZs2aVIszu379fYWFhTpdT6l6ZM0f/262b02WUuie/+EJjx493uowy4caxRKIvE7m1N7f2VdJtNocZAwAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADBOVacLgLm2bg3QvHmh+vrrAJ04ceFzkRkz0jVqVLbDlaGyceu6OH/7fK1LXqcDaQd0KueUokKi1KVuF03qOEkx4TFOl3fF3NpXZeHm5+/txx/X0V27Crxu0JQpata5czlXVDrcOkbCPG5dF908Llb03tgziyu2c2eANm0KVI0aeU6XgkrOreviaztf02c/fKaIwAjVCa2jY5nHtOybZRr40UBlnM1wurwr5ta+KovK8PxVqVpV0c2b+/x5wsKcLuuKuXWMhHncui66eVys6L0RZnHFhg3L1v79KXrrrZNOl4JKzq3rYkLLBH0R/4WS4pL0efznuq/NfZKklKwUJR1Lcri6K+fWviqLyvD8hUZGKn7WLJ+/+q1bO13WFXPrGAnzuHVddPO4WNF7I8ziikVGWgoOdroKwL3r4oQOE1QvrJ79/03RN9mXA/0DnSipVLi1r8qC5888bh0jYR63rotuHhcrem98ZxYADJCbl6s39rwhSYoJj1H3et0drqh0uLWvysKtz196SopmDRzoM23SihUOVQPAJG4dF6WK2RthFgAquNPnTmvcJ+OUeCRRtUNqa0n/JQqqEuR0WVfNrX1VFm5+/qpUraraTZo4XQYAw7h5XKyovRFmAaACS8lKUcKaBO04vkNNIprozVverBBnD7xabu2rsnD78+f9ziwAlJSbx8WK3BthFgAqqL0n9iphdYKOZh5VbHSsFvVbpBqeGk6XddXc2ldlwfMHAL7cPC5W9N4Is7hiq1YF6emnq+n8eT972syZ1TR/fohuuOGcXn453cHqUJm4dV0cs3aMjmYelSRlns1U/Op4+7r4lvGKbxlf2KwVmlv7qix4/szj1jES5nHruujmcbGi90aYxRXLyPBTcrLvKpSa6q/UVH9FR7vr98NQsbl1XTyTe8a+vCt1l891ver3Ku9ySo1b+6oseP7M49YxEuZx67ro5nGxovdGmMUVi4vLUVxcjtNlAK5dF7clbHO6hDLh1r4qCzc/f3HPPON0CWXCrWMkzOPWddHN42JF743fmQUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4/hZlmUVd6P09HRFREToscceU1BQUHnUVW6ys7MVHBzsdBllIjs7WyEhIU6XUeqysrJc2Zfk3t7oyzxu7C0nJ0fPPvus0tLSFB4e7nQ5ZSL/9trj8ThdTqnLyspSiBv7yslx3evNy41jiURfJnJrb27tq6Tb7MsKs/v371dYWFipFuq0BQsWaOzYsU6XUSbc2ptb+5Lc2xt9mceNvWVkZKhZs2aVIsy6cXstuXO9lNzbl+Te3ujLPG7tza19lXSbzWHGAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxTYcLs1q0BGj68ulq1ilKdOteoTp1r9Ne/Bjtd1lVza1+Su3sDABTMzWO/W3tza18AUGHC7M6dAdq0KVA1auQ5XUqpcmtfkrt7AwAUzM1jv1t7c2tfAFBhwuywYdnavz9Fb7110ulSSpVb+5Lc3RsAoGBuHvvd2ptb+wKAqk4X4BUZaTldQplwa1+Su3sDABTMzWO/W3tza18AUGH2zAIAAAAAUFKEWQAAAACAcQizAAAAAADjEGYBAAAAAMapMGF21aogxcbW1NChkfa0mTOrKTa2psaPD3ewsqvj1r4kd/cGACiYm8d+t/bm1r4AoMKczTgjw0/Jyb7lpKb6KzXVX9HR5v4umlv7ktzdGwCgYG4e+93am1v7AoAKE2bj4nIUF5fjdBmlzq19Se7uDQBQMDeP/W7tza19AUCFOcwYAAAAAICSIswCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4fpZlWcXdKD09XREREXrsscfk8XjKo65yk5WVpZCQEKfLKBNu7c2tfUnu7Y2+zOPG3nJycvTss88qLS1N4eHhTpdTJty8vZbcuV5K7u1Lcm9v9GUet/bm1r5Kus2+rDC7f/9+hYWFlWqhTluwYIHGjh3rdBllwq29ubUvyb290Zd53NhbRkaGmjVrVinCrBu315I710vJvX1J7u2Nvszj1t7c2ldJt9kcZgwAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4/hZlmUVd6P09HRFRETosccek8fjKY+6yk1WVpZCQkKcLqNMuLU3t/Ylubc3+jKPG3vLycnRs88+q7S0NIWHhztdTplw8/Zacud6Kbm3L8m9vdGXedzam1v7Kuk2+7LC7P79+xUWFlaqhTptwYIFGjt2rNNllAm39ubWviT39kZf5nFjbxkZGWrWrFmlCLNu3F5L7lwvJff2Jbm3N/oyj1t7c2tfJd1mc5gxAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAONUmDC7dWuAhg+vrlatolSnzjWqU+ca/fWvwU6XddXc2pfk3t7oyzxu7g2oaNz8enNrb27tS3Jvb/QFlEyFCbM7dwZo06ZA1aiR53QppcqtfUnu7Y2+zOPm3oCKxs2vN7f25ta+JPf2Rl9AyVSYMDtsWLb270/RW2+ddLqUUuXWviT39kZf5nFzb0BF4+bXm1t7c2tfknt7oy+gZKo6XYBXZKTldAllwq19Se7tjb7M4+begIrGza83t/bm1r4k9/ZGX0DJVJg9swAAAAAAlBRhFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEqTJhdtSpIsbE1NXRopD1t5sxqio2tqfHjwx2s7Oq4tS/Jvb3Rl3nc3BtQ0bj59ebW3tzal+Te3ugLKJkKczbjjAw/JSf7lpOa6q/UVH9FR5v7W1Ru7Utyb2/0ZR439wZUNG5+vbm1N7f2Jbm3N/oCSqbChNm4uBzFxeU4XUapc2tfknt7oy/zuLk3oKJx8+vNrb25tS/Jvb3RF1AyFeYwYwAAAAAASoowCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4/hZlmUVd6P09HRFRETof/7nfxQUFFQedZWb7OxsBQcHO11GmXBrb27tS3Jvb+fOnVNoaKjTZZS6rKwshYSEOF1GmXBjbzk5OXr22WeVlpam8PBwp8spE97t9WOPPSaPx+N0OaUuJy1NoYGBTpdR6jLz8hTswjFScudYIrEumsit66Jb+yrpNvuywuyqVatc94Z07dq16tevn9NllAm39ubWviT39paYmKhx48Y5XUapW7BggcaOHet0GWXCjb1lZGSoWbNmlSLM7t+/X2FhYU6XU+pemTNH/9utm9NllLonv/hCY8ePd7qMMuHGsURiXTSRW9dFt/ZV0m02hxkDAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAME5VpwsAgKu1dWuA5s0L1ddfB+jEiQuf0c2Yka5Ro7Idrgxwn/nb52td8jodSDugUzmnFBUSpS51u2hSx0mKCY9xuryr8vbjj+vorl0FXjdoyhQ169y5nCsqHW4eI93aG+siUDKEWQDG27kzQJs2BSomJtfeOAIoG6/tfE3HMo+pafWm8lTx6HDGYS37Zpk2Ht2oLXFbFBYY5nSJV61K1aqq3aSJzzRPmLl9uXmMdHNvEusiUBzCLADjDRuWrREjsnT8uL86dYpyuhzA1RJaJmjYdcNUL6yeJOmJLU9o4c6FSslKUdKxJA1oNMDhCq9eaGSk4mfNcrqMUuPmMdLNvUmsi0Bx+EgEgPEiIy0FBztdBVA5TOgwwQ6yknRT9E325UD/QCdKQjHcPEa6uTc34vlCaWPPLAAAuCK5ebl6Y88bkqSY8Bh1r9fd4YpKR3pKimYNHOgzbdKKFQ5Vg8qMdREoGmEWAABcttPnTmvcJ+OUeCRRtUNqa0n/JQqqEuR0WaWioO8pAk5gXQSKRpgFAACXJSUrRQlrErTj+A41iWiiN2950/gzGefntu8pwlysi0DRCLMAAKDE9p7Yq4TVCTqaeVSx0bFa1G+RanhqOF0WAKAS4gRQAIy3alWQYmNraujQSHvazJnVFBtbU+PHhztYGeA+Y9aO0dHMo5KkzLOZil8drwEfDNCADwbob3v+5nB1KIibx0g39+ZGPF8obeyZBWC8jAw/JSf7Dmepqf5KTfVXdHSeQ1UB7nQm94x9eVfqLp/retXvVd7loATcPEa6uTc34vlCaSPMAjBeXFyO4uJynC4DqBS2JWxzuoQyE/fMM06XUCbcPEa6tTfWRaBkOMwYAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjEOYBQAAAAAYhzALAAAAADAOYRYAAAAAYBzCLAAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGMfPsiyruBulp6crIiJCEydOVFBQUHnUVW5ycnLk8XicLqNMuLU3t/Ylube38+fPKzQ01OkySl1WVpZCQkKcLqNMuLG3nJwcPfvss0pLS1N4eLjT5ZQJ7/Z66oQJ8rhsey1Jmbm5CnbZeilJWTk5rnu9eblxLJH+f18u3F6zLprHrX2VdJt9WWF21apVrntDunbtWvXr18/pMsqEW3tza1+Se3tLTEzUuHHjnC6j1C1YsEBjx451uowy4cbeMjIy1KxZs0oRZtPeeUfhLnxz8+QXX2js+PFOl1Hq3Ph683Jrb/RlHrf25ta+SrrN5jBjAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMap6nQBAHC1tm4N0Lx5ofr66wCdOHHhM7oZM9I1alS2w5UB7vP244/r6K5dBV43aMoUNevcuZwrKh3zt8/XuuR1OpB2QKdyTikqJEpd6nbRpI6TFBMe43R5V8XNY6Rbe6MvoGTYMwvAeDt3BmjTpkDVqJHndClApVGlalVFN2/u8+cJC3O6rCv22s7X9NkPnykiMEJ1QuvoWOYxLftmmQZ+NFAZZzOcLu+quHmMdGtv9AWUDHtmARhv2LBsjRiRpePH/dWpU5TT5QCVQmhkpOJnzXK6jFKT0DJBw64bpnph9SRJT2x5Qgt3LlRKVoqSjiVpQKMBDld45dw8Rrq1N/oCSoY9swCMFxlpKTjY6SoAmGxChwl2kJWkm6Jvsi8H+gc6UVKpcfMY6dbe6AsoGfbMAgCAy5aekqJZAwf6TJu0YoVD1ZSu3LxcvbHnDUlSTHiMutfr7nBFAICCEGYBAMBlq1K1qmo3aeJ0GaXu9LnTGvfJOCUeSVTtkNpa0n+JgqoEOV0WAKAAhFkAAHDZ3PadWUlKyUpRwpoE7Ti+Q00imujNW940/kzGAOBmhFkAAFDp7T2xVwmrE3Q086hio2O1qN8i1fDUcLosAEAROAEUAOOtWhWk2NiaGjo00p42c2Y1xcbW1Pjx4Q5WBsAUY9aO0dHMo5KkzLOZil8drwEfDNCADwbob3v+5nB1V8fNY6Rbe6MvoGTYMwvAeBkZfkpO9h3OUlP9lZrqr+hofssOQPHO5J6xL+9K3eVzXa/6vcq7nFLl5jHSrb3RF1AyhFkAxouLy1FcXI7TZQCVQtwzzzhdQpnYlrDN6RLKjJvHSLf2Rl9AyXCYMQAAAADAOIRZAAAAAIBxCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgHMIsAAAAAMA4hFkAAAAAgHEIswAAAAAA4xBmAQAAAADGIcwCAAAAAIxDmAUAAAAAGIcwCwAAAAAwDmEWAAAAAGAcwiwAAAAAwDiEWQAAAACAcQizAAAAAADjEGYBAAAAAMYhzAIAAAAAjFO1JDeyLEuSlJWVVabFOOHMmTM6ffq002WUCbf25ta+JPf2dubMGWVkZDhdRqnLyclxZV+SO3vz9uPdprmRt7d0F26vJSmHscQ4bu2Nvszj1t7c2ldJt9l+Vgm26kePHlX9+vVLpzIAABx05MgR1atXz+kyygTbawCAmxS3zS5RmM3Ly9P333+vsLAw+fn5lWqBAACUB8uylJGRobp168rf353fsmF7DQBwg5Jus0sUZgEAAAAAqEjc+dE0AAAAAMDVCLMAAAAAAOMQZgEAAAAAxiHMAgAAAACMQ5gFAAAAABiHMAsAAAAAMA5hFgAAAABgnP8HVeesQAA6frEAAAAASUVORK5CYII=\n"
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "Issue : VICTOIRE\n",
-            "Etapes totales : 2\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Replay d'une partie avec snapshots\n",
-        "random.seed(42)\n",
-        "np.random.seed(42)\n",
-        "board_replay = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
-        "board_replay.reveal(4, 4)\n",
-        "\n",
-        "snapshots = []\n",
-        "snapshots.append((board_replay.copy(), \"Debut (apres premier clic)\"))\n",
-        "\n",
-        "step = 0\n",
-        "while not board_replay.game_over and not board_replay.won and step < 20:\n",
-        "    # Regles\n",
-        "    rs = RuleBasedSolver(board_replay)\n",
-        "    rs.solve()\n",
-        "    if rs.moves_log:\n",
-        "        snapshots.append((board_replay.copy(),\n",
-        "                          f\"Etape {step+1} : regles ({len(rs.moves_log)} coups)\"))\n",
-        "        step += 1\n",
-        "        continue\n",
-        "\n",
-        "    if board_replay.game_over or board_replay.won:\n",
-        "        break\n",
-        "\n",
-        "    # CSP\n",
-        "    cs = CSPSolver(board_replay)\n",
-        "    safe, mines, sols = cs.solve()\n",
-        "    if safe or mines:\n",
-        "        for cell in mines:\n",
-        "            board_replay.flag(*cell)\n",
-        "        for cell in safe:\n",
-        "            board_replay.reveal(*cell)\n",
-        "        snapshots.append((board_replay.copy(),\n",
-        "                          f\"Etape {step+1} : CSP ({len(safe)} sures, {len(mines)} mines)\"))\n",
-        "        step += 1\n",
-        "        continue\n",
-        "\n",
-        "    if board_replay.game_over or board_replay.won:\n",
-        "        break\n",
-        "\n",
-        "    # Probabilites\n",
-        "    probs_replay = cs.get_probabilities(sols)\n",
-        "    if probs_replay:\n",
-        "        best = min(probs_replay, key=probs_replay.get)\n",
-        "        p = probs_replay[best]\n",
-        "        board_replay.reveal(*best)\n",
-        "        snapshots.append((board_replay.copy(),\n",
-        "                          f\"Etape {step+1} : devinette {best} (P={p:.0%})\"))\n",
-        "    else:\n",
-        "        # Choix aleatoire\n",
-        "        unknown = [(r, c) for r in range(8) for c in range(8)\n",
-        "                   if (r, c) not in board_replay.revealed\n",
-        "                   and (r, c) not in board_replay.flagged]\n",
-        "        if unknown:\n",
-        "            cell = random.choice(unknown)\n",
-        "            board_replay.reveal(*cell)\n",
-        "            snapshots.append((board_replay.copy(),\n",
-        "                              f\"Etape {step+1} : aleatoire {cell}\"))\n",
-        "        else:\n",
-        "            break\n",
-        "    step += 1\n",
-        "\n",
-        "# Afficher les snapshots cles (max 6)\n",
-        "display_snapshots = snapshots[:6] if len(snapshots) > 6 else snapshots\n",
-        "n_snap = len(display_snapshots)\n",
-        "cols_per_row = min(3, n_snap)\n",
-        "rows_needed = (n_snap + cols_per_row - 1) // cols_per_row\n",
-        "\n",
-        "fig, axes = plt.subplots(rows_needed, cols_per_row,\n",
-        "                         figsize=(5 * cols_per_row, 5 * rows_needed))\n",
-        "if rows_needed == 1 and cols_per_row == 1:\n",
-        "    axes = np.array([axes])\n",
-        "axes = np.atleast_2d(axes)\n",
-        "\n",
-        "for idx, (snap_board, snap_title) in enumerate(display_snapshots):\n",
-        "    row_idx = idx // cols_per_row\n",
-        "    col_idx = idx % cols_per_row\n",
-        "    ax = axes[row_idx, col_idx]\n",
-        "\n",
-        "    for r in range(snap_board.rows):\n",
-        "        for c in range(snap_board.cols):\n",
-        "            if (r, c) in snap_board.revealed:\n",
-        "                bg = '#E8E8E8'\n",
-        "            elif (r, c) in snap_board.flagged:\n",
-        "                bg = '#FFB3B3'\n",
-        "            else:\n",
-        "                bg = '#C0C0C0'\n",
-        "            rect = plt.Rectangle((c, snap_board.rows - 1 - r), 1, 1,\n",
-        "                                 facecolor=bg, edgecolor='#666', linewidth=0.5)\n",
-        "            ax.add_patch(rect)\n",
-        "            cx, cy = c + 0.5, snap_board.rows - 1 - r + 0.5\n",
-        "            if (r, c) in snap_board.revealed:\n",
-        "                num = snap_board.numbers[r, c]\n",
-        "                if num > 0:\n",
-        "                    ax.text(cx, cy, str(num), ha='center', va='center',\n",
-        "                            fontsize=10, fontweight='bold',\n",
-        "                            color=NUMBER_COLORS.get(num, 'black'))\n",
-        "            elif (r, c) in snap_board.flagged:\n",
-        "                ax.text(cx, cy, 'F', ha='center', va='center',\n",
-        "                        fontsize=10, fontweight='bold', color='darkred')\n",
-        "\n",
-        "    ax.set_xlim(0, snap_board.cols)\n",
-        "    ax.set_ylim(0, snap_board.rows)\n",
-        "    ax.set_aspect('equal')\n",
-        "    ax.set_title(snap_title, fontsize=9, fontweight='bold')\n",
-        "    ax.set_xticks([])\n",
-        "    ax.set_yticks([])\n",
-        "\n",
-        "# Masquer les axes vides\n",
-        "for idx in range(n_snap, rows_needed * cols_per_row):\n",
-        "    row_idx = idx // cols_per_row\n",
-        "    col_idx = idx % cols_per_row\n",
-        "    axes[row_idx, col_idx].set_visible(False)\n",
-        "\n",
-        "plt.suptitle('Replay d\\'une partie de Demineur', fontsize=13, fontweight='bold')\n",
-        "plt.tight_layout()\n",
-        "plt.show()\n",
-        "\n",
-        "print(f\"\\nIssue : {'VICTOIRE' if board_replay.won else 'DEFAITE'}\")\n",
-        "print(f\"Etapes totales : {len(snapshots)}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-38",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005664,
-          "end_time": "2026-02-26T07:01:11.959575",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.953911",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-38"
-      },
-      "source": [
-        "### Interpretation : replay de partie\n",
-        "\n",
-        "**Sortie obtenue** : la sequence d'etapes montre la progression du solveur.\n",
-        "\n",
-        "**Points cles** :\n",
-        "1. Le premier clic ouvre une zone (propagation des zeros)\n",
-        "2. Les regles simples font des progres rapides dans les premieres etapes\n",
-        "3. Le CSP intervient quand les regles se bloquent, souvent pres des bords de la zone revelee\n",
-        "4. Les devinettes sont rares mais chaque erreur est fatale\n",
-        "\n",
-        "> **Lien avec la NP-completude** : meme avec un solveur parfait, certaines configurations exigent une devinette. La probabilite de succes depend de la densite de mines et de la taille du plateau."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-39",
-      "metadata": {
-        "papermill": {
-          "duration": 0.006241,
-          "end_time": "2026-02-26T07:01:11.971826",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.965585",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-39"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 7. Exercices\n",
-        "\n",
-        "### Exercice 1 : contraintes couplees\n",
-        "\n",
-        "**Enonce** : dans le solveur CSP, les contraintes sont posees independamment pour chaque cellule revelee. Cependant, on peut renforcer le modele en ajoutant une **contrainte globale** : le nombre total de mines dans la grille est connu.\n",
-        "\n",
-        "Implementez cette contrainte globale dans `CSPSolver.build_csp()` et mesurez l'impact sur le nombre de solutions et le taux de victoire."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-40",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:05.023664Z",
-          "iopub.status.busy": "2026-04-21T00:32:05.023274Z",
-          "iopub.status.idle": "2026-04-21T00:32:05.028118Z",
-          "shell.execute_reply": "2026-04-21T00:32:05.026742Z"
-        },
-        "papermill": {
-          "duration": 0.011922,
-          "end_time": "2026-02-26T07:01:11.990035",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:11.978113",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-40",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c3386823-5fba-45a5-a850-b26bd84d1ad9"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Lancement du benchmark sur 50 parties...\n",
-            "\n",
-            "Resultats Exercice 1 :\n",
-            "Taux de victoire (Standard) : 86.0%\n",
-            "Taux de victoire (Enhanced) : 88.0%\n"
-          ]
-        }
-      ],
-      "source": [
-        "class EnhancedCSPSolver(CSPSolver):\n",
-        "    def build_csp(self):\n",
-        "        problem, frontier = super().build_csp()\n",
-        "        if problem is None:\n",
-        "            return None, frontier\n",
-        "\n",
-        "        # Contrainte globale : si toutes les cases inconnues sont dans la frontiere,\n",
-        "        # on peut imposer la somme exacte des mines restantes.\n",
-        "        all_unknown = [(r, c) for r in range(self.board.rows) for c in range(self.board.cols)\n",
-        "                       if (r, c) not in self.board.revealed and (r, c) not in self.board.flagged]\n",
-        "\n",
-        "        if len(all_unknown) == len(frontier) and len(frontier) > 0:\n",
-        "            problem.addConstraint(ExactSumConstraint(self.board.remaining_mines()), list(frontier))\n",
-        "\n",
-        "        return problem, frontier\n",
-        "\n",
-        "# Benchmark pour comparer\n",
-        "N_GAMES_EX1 = 50\n",
-        "wins_std = 0\n",
-        "wins_enhanced = 0\n",
-        "\n",
-        "print(f\"Lancement du benchmark sur {N_GAMES_EX1} parties...\")\n",
-        "\n",
-        "for i in range(N_GAMES_EX1):\n",
-        "    seed = 4000 + i\n",
-        "\n",
-        "    # Test Standard\n",
-        "    random.seed(seed)\n",
-        "    np.random.seed(seed)\n",
-        "    b1 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
-        "    b1.reveal(4, 4)\n",
-        "    s1 = ProbabilisticSolver(b1)\n",
-        "    if s1.play_game(): wins_std += 1\n",
-        "\n",
-        "    # Test Enhanced (on echange le solveur CSP dans le ProbabilisticSolver)\n",
-        "    random.seed(seed)\n",
-        "    np.random.seed(seed)\n",
-        "    b2 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
-        "    b2.reveal(4, 4)\n",
-        "\n",
-        "    # On monkey-patch temporairement le solver pour l'exercice\n",
-        "    original_csp = CSPSolver\n",
-        "    import __main__\n",
-        "    __main__.CSPSolver = EnhancedCSPSolver\n",
-        "    s2 = ProbabilisticSolver(b2)\n",
-        "    if s2.play_game(): wins_enhanced += 1\n",
-        "    __main__.CSPSolver = original_csp\n",
-        "\n",
-        "print(\"\\nResultats Exercice 1 :\")\n",
-        "print(f\"Taux de victoire (Standard) : {wins_std/N_GAMES_EX1:.1%}\")\n",
-        "print(f\"Taux de victoire (Enhanced) : {wins_enhanced/N_GAMES_EX1:.1%}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-42",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005833,
-          "end_time": "2026-02-26T07:01:12.013863",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:12.008030",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-42"
-      },
-      "source": [
-        "### Exercice 2 : garantie du premier clic\n",
-        "\n",
-        "**Enonce** : dans notre implementation, `safe_cell` empeche de placer des mines sur la cellule cliquee et ses voisines. Mais certains jeux ne generent les mines qu'**apres** le premier clic.\n",
-        "\n",
-        "Modifiez `MinesweeperBoard` pour supporter une generation differee : le plateau est cree vide, et les mines ne sont placees qu'au premier appel a `reveal()`, en excluant la cellule cliquee et ses voisines."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-43",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:05.030789Z",
-          "iopub.status.busy": "2026-04-21T00:32:05.030307Z",
-          "iopub.status.idle": "2026-04-21T00:32:05.035574Z",
-          "shell.execute_reply": "2026-04-21T00:32:05.034270Z"
-        },
-        "papermill": {
-          "duration": 0.010441,
-          "end_time": "2026-02-26T07:01:12.030274",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:12.019833",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-43",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 642
-        },
-        "outputId": "4c315d12-8ab4-4726-99ed-f75c751ea19b"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Avant reveal : 0 mines\n",
-            "Apres reveal : 10 mines\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<Figure size 600x600 with 1 Axes>"
-            ],
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARd5JREFUeJzt3Xl4VOXB/vF7yL5DSIKEhARZZF+UxRSsKCDigiCi1Sih2PblBVcEW9oq0Bahr61ClYJbk+ICbREkUFkNq4KAmBpEErYQDIQgS2JYEiDn9we/TDMkISGQOXmc7+e6cl0z5zxz5n5mQnJzzpkTh2VZlgAAAAzUwO4AAAAAtUWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEB3Cw+Pl4Oh0MOh0Nr1661O061qsrbt29f5/KUlBSXx3z33XcaPXq04uPj5e3tLYfDofj4eOf67OxsPfLII4qJiZGXl5ccDof69u3rlvnY5dFHH5XD4VBYWJhOnjx5xY/Pzs52vt4Oh8NlXfnl2dnZ1yYw9Nhjj8nhcKhRo0Y6duyY3XFQBYoMamXlypUaMWKE2rRpo5CQEPn7+ys2NlY9evTQs88+q08++cTuiLY4efKkJk+e7PzyVKNGjdIbb7yhAwcO6MKFCy7rSktLNXToUM2bN0+5ubkqLS21KaX7bNu2TR988IEkacyYMWrYsKG9gQxy7tw5zZgxQzfddJOCg4MVHBys7t27a+bMmTp37twVb+/TTz/Vfffdp8jISPn5+SkuLk6/+MUvlJOTU2HsxIkT5XA4dPLkSf3ud7+7FtNBHXDwt5ZwJY4ePapHH31UK1eurHbsmTNn5O/v74ZU9Ud2drZatGjhvF/ZP69t27bp7NmzkqROnTopLCzMbflqIz4+XgcOHJAkrVmzxrnnJCMjQwUFBZKkNm3aKCoqSpJUUlKiwMBAZ4F57bXX1LVrV/n7+6t79+7au3evWrVqJUny9vbWu+++q5iYGIWFhalTp05unp17DB48WEuWLJHD4dCBAwcUGxt7xdu43PfWxo0bnbd79OghPz+/qwtcT5SUlOjuu+/W6tWrK10/cOBALVmyRD4+PjXa3jvvvKOf//znlf67DA8PV1pamrp06eKyvH///vrkk0/k6+urgwcPOr/PUY9YQA2dOXPGuummmyxJzq8HHnjAev/99620tDRryZIl1vTp060+ffpYkqwzZ87YHbnWvv/++1o9bv/+/S6vzw9BXFyccz5r1qypdvyBAwdcXoPS0lKX9evWrXOua968eR2lvqi27+O1lJ2dbTVo0MCSZN1yyy213s4P8XurOr///e+d842MjLTmzp1rzZ0714qKinIuf+mll2q0rd27d1t+fn7Oxz333HNWamqqdffddzuXtWvXzjp//rzL495++23n+mnTptXFNHGVPONfA66J6dOnu/wgffvtt6sc++WXX1b4gXDs2DHrt7/9rdW5c2crKCjI8vf3t9q3b29NmjSpwi+c5ORk5/Pceuut1o4dO6zBgwdboaGhVmBgoDVo0CBr9+7dFZ73ap5jy5YtVv/+/a2QkBCrYcOGlmVZ1tatW63ExESrY8eOVkREhOXt7W0FBwdbXbp0sV588UWXbd56660ur8+lX2Ul4HLFYO/evdbo0aOtli1bWn5+flZQUJDVuXNn64UXXrBOnDjhMnbSpEnO7SQlJVkbN260brvtNiswMNAKDQ21HnzwQevIkSNVvkeXSk9PtwYMGGAFBgZajRo1sh555BHr22+/rTJv+fkmJydX+xokJSW5bOvSr0mTJjm3vXPnTuvxxx+3WrRoYfn5+VkhISHWj370Iys5OblCMUpKSnLZxrvvvmt17drV8vPzs+677z7nuIMHD1pPP/20dcMNN1j+/v5WUFCQdeONN1qvvPKKVVJSUuH1OHXqlPXHP/7R6tGjhxUSEmL5+vparVq1sp599lkrPz+/xq/ryy+/7Mw3ffr0SsccPnzYev75561OnTo5v29btGhhPfroo8738HJFpvzy/fv3u6zbs2ePNWbMGOuGG26wAgICrMDAQOuGG26wfv7zn1tnz56t0Rw+//xz6yc/+YkVExNj+fj4WA0bNrT69etnLV68uMLYS78v3nnnHatz586Wn5+f1bRpU+tXv/pVhZ8NlTl//rxLYXnvvfec69577z3n8uuuu65G2xs3bpzzMf3793cuP336tBUSEuJct3TpUpfHHT582LmuS5cu1T4P3I8igxpr27atyy/+K7F7924rJiamyl9iHTt2tI4dO+YcX75kNG3a1AoKCqrwmPbt21sXLly4Js/RrFkzKyAgwHk/LCzMsizLmj179mXLyU033WSdO3fOsqyrLzJr1661goODq3x8ixYtrG+//dY5vnyRadGiheXt7V3hMQMHDqzR+/Of//yn0ueOi4uzwsPD3VpkFi1aZPn7+1c5LjEx0aXMlC8yrVu3dhlbVmQ2bdpkNWzYsMpt3nbbbS6/1I8ePWp17NixyvHNmjWz9u3bV6PX9p577qn09SuzdetWq3HjxlU+15dffmlZVu2KzNKlS63AwMAqt31pOa7MrFmznHuUKvuaOHGiy/jy3wOXvh9lXzXZs5Genu7ymOzsbOe6S1+Lr776qtrtde3a1Tl+8uTJVWYeN25chcc2b97ckmQ5HA6XnyGoHygyqJFTp05d9gfR9u3brQ0bNrh8lf/B06tXL5dfGosWLbKWLFni8gPksccec44vXzIkWTfeeKP14YcfWjNmzLB8fHycy5cvX37NnqNZs2bWW2+9Za1cudKaOXOmZVmW9emnn1p//vOfrUWLFlmrV6+21qxZY/3rX/+yevTo4XzcP//5T8uyLOurr76y/vWvf7lss/zrcfLkScuyKi8yZ86csaKjo53Le/bsaS1cuNCaO3eu1axZM+fyu+66y5m/fJGRZA0YMMBKTU2tsHzXrl3Vvr99+/Z1eR3mzp1rffjhh1anTp1ctlVdkbnca5CVlWVt3brV+stf/uJcd9111znXHzhwwMrPz3cpVKNHj7aWL19uvfvuuy6v2zvvvOPMUb7ISLJ69+5t/eMf/7D+/e9/W/PmzbPOnj3r/EUkyRo2bJj173//21qwYIHVuXNn5/IXXnjBuc0HH3zQubxr167WvHnzrGXLllnDhg1zLq/pYaLyucsXUcuyrLNnz1rx8fHO9VFRUdarr75qrVixwvrb3/5mDRgwwEpPT7cs68qLTH5+vhUaGupcfv3111tvvPGGtWLFCmv27NlWr169qi0yO3bscJaYBg0aWL/5zW+slStXWm+88YbVqFEj57Y/+eSTSr8vJFlPPvmk9e9//9t64IEHXN736ixcuNBlO+WL5pkzZ1zWLVq0qNrtlX8t5syZ47LuoYcecq4rvxevTP/+/Z3r165dW+1zwb0oMqiRb7/91uUHx1tvveWyvkOHDhX+1/XLX/7SsizLysjIcC7z8fGxVqxY4fzltWDBApd1ZYdqypcMHx8fl18Ad955p3PdX/7yl2vyHA6Hw/rPf/5TYd7nzp2zXnvtNat3795Wo0aNKv2fafn/wdXkPIbKiszixYudy3x9fa1Dhw45xy9dutQlZ9mhhvKFJSIiwjp9+rTzMeX3nqWmpl72vT169KhL5vKHC3bu3HlFRaYmr8GaNWuc6+Li4lzWvfbaa851HTt2dCmCv/nNb5zrbr75ZudjyheZZs2aVTg3a8mSJc71kZGR1vr1653bLP98TZs2tSzLsk6cOGF5eXk5l3/wwQfO8WvWrHEp0jUpieX3iFyarfx726BBA2v79u1VbudKi8zrr7/uXBYcHFyhRNXEc88959xG//79Xd6PUaNGOdf95Cc/cT6m/PdF+eKdl5fnkrOwsPCyz/3uu++6jC+/F+7ChQsu6959991q51L+Pf3b3/7msu6xxx5zruvXr1+Fx5YvtmX/cUH94S2gBi79uOiVXFNh586dztvnzp3TwIEDKx137tw5ZWZm6qabbnJZ3rZtWzVr1sx5v3Hjxs7bx48fvybP0apVK3Xu3LnC+FGjRundd9+tamqSpBMnTlx2fU3s2rXLebtly5Zq2rSp836fPn2cty3LUmZmZoVPTiQkJCggIMB5v7LXqCp79+6tsK0y7dq1U6NGja7JHGui/Pu4Y8cO3XLLLZWO27FjR6XL77rrrgqflCu/zaNHj+rHP/5xpY89fPiwjh07pr1797p8ZPyRRx6pMu+OHTt0ww03VLn+UtYln5Ypn61Fixbq1q1bjbdVnfLb7tWrl8u/odpsY/Xq1VV+eqiq96Nfv37O2+W/J6WL35chISFVPndQUJDL/eLiYud7W1xc7LIuODi4yu2U315hYWGljy9/v7JtXfq+oX7hOjKokaCgIJcf2KtWrXJZv2PHDlmWpVtvvfWqnqeoqKjCsvDwcJf73t7/7d+1+QFT2XOULw5lcnNzXUrMM888o5UrV2rDhg0aMWKEc3l9uA7KtX6N6rvK3kOp8vfxWmz3asZHRkY6b1dXKk1V1etQ/vuy/PekVP335fXXX+9yPy8vz3n78OHDLutatmxZbcby2yu/rUu3V9m2yr9vfPy6/qHIoMZGjhzpvP3JJ59o/vz5NXpcu3btnLcDAgJ08uRJWRcPa7p8FRUV1boIXe1zXHqlVEk6ePCg83bjxo316quvasCAAerTp49yc3MrzdGgges/qZqWnLZt2zpv79271+UH7aeffuqS80r2ANTEpT+4N2/e7Ly9a9cut+2NkVzfxx/96EeVvodl72NlKnsfy2+zefPmOnfuXJXbjIuLU5s2beTl5eV8TGZmZpXjk5KSqp1T+WvjZGZmuqxr37698/b+/fv1n//8p8Lja1tEy2/7888/16FDh654G+Vfu4cffrjK96OqPTJXo2PHji6lYcOGDc7b69evd95u0qSJy1yrcvvtt1e6raKiIm3fvr3ScWXK3jeHw6GOHTvWcAZwFw4tocaefvppzZ8/3/nDNjExUcuWLdO9996riIgIfffdd5VeHbNTp07q0aOHtm7dqjNnzuj222/XU089pdjYWB09elT79+9XWlqaSktLq9x1XZ26eI7y/4M7duyYpk6dqu7du2vBggVVXrk4PDxcDofD+cvn1VdfVc+ePdWgQQP17t27yue64447FB0drUOHDqmkpERDhw7VL3/5SxUVFWnixInOcYMGDbrm/yOMiIjQrbfeqnXr1kmSxo4dq4KCAgUGBrr9aqYPPfSQfv3rX6uoqEifffaZHnjgAT3yyCMKCwtTbm6uMjMz9fHHH2vIkCGaNGlSjbY5YMAAxcbG6uDBg8rJydHAgQP185//XFFRUTp8+LD27t2rlStXqnXr1kpOTlbDhg11//3361//+peki4erJkyYoFatWunkyZM6cOCA1q9fr127drkcEqxK3759tXTpUknSli1bXH5R9u/fX3FxcTpw4IBKS0t15513auLEiWrXrp0OHz6s+fPna9q0aRUu0lYTDz74oCZOnKjvv//eWeCff/55xcfHKzs7W8nJyfr4448ve5XhkSNHasaMGSotLdW8efMUEhKie+65R35+fvr222+1c+dOpaam6te//rXLf3SuBS8vL40dO9b5Po8bN87572r8+PHOcU8++aRL8azqAo6jR4/W66+/rpKSEqWlpem5555T37599de//lWnTp2SdPE/FHfeeadLjsOHD+vbb7+VJHXo0KHCITLUA3V18g1+mPLy8qr9mHHZV/lPgWRlZV32o9GS60e6L73GS3mXXjekLp6jzE9+8pMK2/Dy8rJuueUW5/2kpCSXxyQkJFT6mDJX8/HrgwcPOsdfeh2Z8qo6EbcqX375ZaUfcY+KirLCwsIqzVsXJ/ta1sVPq1zu49eXvu9VfT+U99lnn13249eXvob5+fmX/fh1Vdkrc+DAAedJ4n369Kmw/vPPP3f5BNClX1fz8evFixe7XFbg0q+afPz69ddfv+zHry99/y/3vVdVzqoUFxdbt99+e5XP279//wrXALrcdZreeOMNy+FwVLqtRo0aWV988UWFDG+99ZZzzNSpU6vNDPfj0BKuSJMmTbRmzRotXrxYDz74oOLj4+Xv7y8fHx9FRkYqISFBzzzzjFavXq0pU6Y4H9e6dWt99dVXevHFF9WtWzcFBwfLz89PzZs3149//GNNnTpVc+bMuapsdfEcb7/9tp555hnFxMQoICBAvXr10scff1zp7ucy7777ru66667LnshYmVtvvVXp6en6n//5H11//fXy9fVVQECAOnXqpN/+9rfavn27YmJirmibNdW1a1dt2LBB/fv3V2BgoMLCwnT//ffrs88+c/vfBRo6dKi+/PJL/eIXv1CrVq3k7++voKAgtWrVSvfcc4/mzJmjMWPGXNE2ExISlJGRoXHjxqlDhw4KDAxUQECAWrRooQEDBujVV1912fsUGRmpLVu26E9/+pNuvvlmhYWFycfHR9HR0br55pv1m9/8Rh9++GGNnrt58+a6++67JV08THjpXsuePXtqx44dGj9+vDp27KjAwED5+/urRYsWSkxMVHR09BXNtbzBgwcrPT1do0ePVuvWreXv76/AwEC1adNGP/vZz1xOEK/K2LFjtXnzZiUmJqp58+by9fVVaGiobrjhBg0fPlxz587V/fffX+uMl+Pr66tly5bplVdeUbdu3RQYGKjAwEB169ZNr7zyij7++OMKf56g/Inal574/Ytf/EJr167VPffco8aNG8vHx0exsbH62c9+pu3bt+vGG2+skGHevHmSJB8fHz3++ON1MEtcLf7WEgDUsW3btqlnz56yLEvPP/+8/vjHP9od6QfpyJEjuu666yRdPKRYk78Jdzlff/21OnXqJMuy9NRTT2nmzJnXIiauMfbIAEAd6969uxITEyVJs2fP1smTJ+0N9ANVdv5bUFCQ3nzzzave3vTp02VZlho2bKgXX3zxqreHusEeGQDAD8KoUaOUnJysGTNm6Omnn7Y7DtyEIgMAAIzFoSUAAGAsigwAADAWRQYAABjL6Cv7lpaW6tChQwoJCan00uQAAMBMlmXp+++/V3R0dIU//1Ke0UXm0KFDio2NtTsGAACoIwcPHrzsxUCNLjJlV05977331Lx5c5vTuNeePXu0fv16DR48WBEREXbHcauyuffs2VOhoaF2x3GrQ4cOaefOncyduXsM5u6Zc5cuXuDwueeeq/Yq6UYXmbLDSc2bN1ebNm1sTuNeZ86cka+vr+Lj46/qEuYmKpv7ddddp/DwcLvjuNW5c+eYO3O3O45bMXfPnHt51Z06wsm+AADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGMvb7gAwQ2qqnzZu9FV6uo927fJWSYnDuS4v74iNyQAAnowigxqZOTNIX3/tY3cMAABcUGRQIw6HFB9/Xl26nFd+fgNt2uRrdyQAACgyqJklS44rIODi7ZdfDqLIAADqBU72RY2UlRgAAOoTigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLG4jgxqJCUlQNnZXpKkbdtcr/A7eXKw8/bIkWcUH3/BrdkAAJ6LIoMaWbzYv8qL4M2ZE+S8PWBAMUUGAOA2HFoCAADGYo8MamTRohN2RwAAoAL2yAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADBWvSgys2bNUnx8vPz9/dWrVy9t2bLF7kgAAMAAtheZf/zjHxo3bpwmTZqk7du3q0uXLho4cKDy8/PtjgYAAOo524vMK6+8op///Of66U9/qvbt22vOnDkKDAzU3/72N7ujAQCAes7bzicvKSnRF198oYkTJzqXNWjQQP3799emTZsqjC8uLlZxcbHzfmFhoSRpz549OnPmTN0HrkdycnIkSVlZWTp69KjNadyrbO65ubkqKCiwOY17lb3XzJ25ewrm7plzl1Tj3222FpnvvvtOFy5cUJMmTVyWN2nSRLt27aowftq0aZoyZUqF5evXr5evr2+d5ayvHA6H0tLS7I5hm4yMDLsj2Ia5eybm7pk8de4lJSU1GmdrkblSEydO1Lhx45z3CwsLFRsbq8GDBys+Pt6+YDbIyspSWlqahg0bpsjISLvjuFXZ3BMSEhQWFmZ3HLfKzc1VRkYGc2fuHoO5e+bcJSkvL08pKSnVjrO1yERERMjLy0tHjhxxWX7kyBFdd911Fcb7+fnJz8+v0u1ER0fXWc76qGyXW2RkpMfOPSwsTOHh4Tanca+y3cvMnbl7CubumXOXpNOnT9donK0n+/r6+uqmm27SJ5984lxWWlqqTz75RAkJCTYmAwAAJrD90NK4ceOUlJSk7t27q2fPnpoxY4ZOnTqln/70p3ZHAwAA9ZztReahhx7S0aNH9eKLLyovL09du3bV8uXLK5wADAAAcCnbi4wkPfHEE3riiSfsjgEAAAxj+wXxAAAAaosiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADCWt90BUP8dLjqsFQdWaNOhTco8kan80/kqLClUqG+oOjTuoOFthmt4m+FyOBx2RwUAeBiKDKq1YPcCTf18aoXlx88e14bcDdqQu0FL9y1V8sBkeTXwsiEhAMBTcWgJNRYVGKWH2z6sX/X4lRLbJsrfy9+5buWBlZqfOd/GdAAAT8QeGVSrWXAzvX776xrSaoi8G/z3W2Zo66F6YMkDzvtpOWlKbJdoR0QAgIeiyKBa97e+v9LlfZr1Ubh/uI6fPS5JKiktcWcsAAA4tITaKzvpt0y3qG42pgEAeCKKDGrlfOl5jV83XudLz0uSIgIiNKL9CJtTAQA8DUUGV6yopEgjlo3QygMrJUnBPsGae+dcRQRE2JwMAOBpOEcGVyS3KFePLXtMO4/tlCQ19m+s9+56j8NKAABbUGRQY+n56UpanqQjp49IklqGtdT7d72v+LB4e4MBADwWh5ZQIx/v/1hDU4c6S8zNTW/W0qFLKTEAAFuxRwbVSt2bqtGrR6vUKpUkhfqGqm9MX83bNc9lXKhvqB5t/6gdEQEAHooig2plHs90lhhJKiwp1PSt0yuMiwmOocgAANyKQ0sAAMBY7JFBtSb0mKAJPSbYHQMAgArYIwMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYthaZ9evX695771V0dLQcDoc++ugjO+MAAADD2FpkTp06pS5dumjWrFl2xgAAAIbytvPJBw0apEGDBtkZAQAAGMzWInOliouLVVxc7LxfWFgoSdqzZ4/OnDljVyxb5OTkSJKysrJ09OhRm9O4V9ncc3NzVVBQYHMa9yp7r5k7c/cUzN0z5y6pxr/bHJZlWXWcpUYcDocWLVqkIUOGVDlm8uTJmjJlSoXlI0eOlK+vbx2mq58cDofqydsHAMA1VVJSopSUFBUUFCg0NLTKcUYVmcr2yMTGxmrhwoWKj4+v+5D1SFZWltLS0jRs2DBFRkbaHcetyuaekJCgsLAwu+O4VW5urjIyMpg7c/cYzN0z5y5JeXl5GjNmTLVFxqhDS35+fvLz86uwPCIiQtHR0TYksk/ZLrfIyEiPnXtYWJjCw8NtTuNeZbuXmTtz9xTM3TPnLkmnT5+u0TiuIwMAAIxl6x6ZoqIi7dmzx3l///79Sk9PV3h4uJo3b25jMgAAYAJbi8y2bdt02223Oe+PGzdOkpSUlKSUlBSbUgEAAFPYWmT69u3Lp24AAECtcY4MAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCxvuwOg/jtcdFgrDqzQpkOblHkiU/mn81VYUqhQ31B1aNxBw9sM1/A2w+VwOOyOCgDwMBQZVGvB7gWa+vnUCsuPnz2uDbkbtCF3g5buW6rkgcnyauBlQ0IAgKfi0BJqLCowSg+3fVi/6vErJbZNlL+Xv3PdygMrNT9zvo3pAACeiD0yqFaz4GZ6/fbXNaTVEHk3+O+3zNDWQ/XAkgec99Ny0pTYLtGOiAAAD0WRQbXub31/pcv7NOujcP9wHT97XJJUUlrizlgAAHBoCbVXdtJvmW5R3WxMAwDwRBQZ1Mr50vMav268zpeelyRFBERoRPsRNqcCAHgaigyuWFFJkUYsG6GVB1ZKkoJ9gjX3zrmKCIiwORkAwNNwjgyuSG5Rrh5b9ph2HtspSWrs31jv3fUeh5UAALagyKDG0vPTlbQ8SUdOH5EktQxrqffvel/xYfH2BgMAeCwOLaFGPt7/sYamDnWWmJub3qylQ5dSYgAAtmKPDKqVujdVo1ePVqlVKkkK9Q1V35i+mrdrnsu4UN9QPdr+UTsiAgA8FEUG1co8nuksMZJUWFKo6VunVxgXExxDkQEAuBWHlgAAgLHYI4NqTegxQRN6TLA7BgAAFbBHBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLFsLTLTpk1Tjx49FBISoqioKA0ZMkSZmZl2RgIAAAaxtcisW7dOY8eO1ebNm7Vq1SqdO3dOd9xxh06dOmVnLAAAYAhvO598+fLlLvdTUlIUFRWlL774Qj/+8Y9tSgUAAExha5G5VEFBgSQpPDy80vXFxcUqLi523i8sLJQk7dmzR2fOnKn7gPVITk6OJCkrK0tHjx61OY17lc09NzfX+T3jKcrea+bO3D0Fc/fMuUuq8e82h2VZVh1nqZHS0lINHjxYJ0+e1MaNGysdM3nyZE2ZMqXC8pEjR8rX17euI9Y7DodD9eTtczvm7plzB+A5SkpKlJKSooKCAoWGhlY5rt4Umf/93//VsmXLtHHjRsXExFQ6prI9MrGxsVq4cKHi4+PdlLR+yMrKUlpamoYNG6bIyEi747gVc/fsuSckJCgsLMzuOG6Vm5urjIwM5s7cPUpeXp7GjBlTbZGpF4eWnnjiCS1dulTr16+vssRIkp+fn/z8/Cosj4iIUHR0dF1GrHfKdrlFRkYydw/C3KWwsLAqDz//UJUdVmDuzN2TnD59ukbjbC0ylmXpySef1KJFi7R27Vq1aNHCzjgAAMAwthaZsWPH6oMPPtDixYsVEhKivLw8SRfbZ0BAgJ3RAACAAWy9jszs2bNVUFCgvn37qmnTps6vf/zjH3bGAgAAhrD90BIAAEBt8beWAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLG87Q4AM6Sm+mnjRl+lp/to1y5vlZQ4nOvy8o7YmKxuHS46rBUHVmjToU3KPJGp/NP5KiwpVKhvqDo07qDhbYZreJvhcjgc1W/MQJ4+fwD1H0UGNTJzZpC+/trH7hhut2D3Ak39fGqF5cfPHteG3A3akLtBS/ctVfLAZHk18LIhYd3y9PkDqP8oMqgRh0OKjz+vLl3OKz+/gTZt8rU7kltFBUapX/N+iguJ08HvD+rD3R/q7IWzkqSVB1ZqfuZ8JbZLtDll3fH0+QOovygyqJElS44rIODi7ZdfDvKYItMsuJlev/11DWk1RN4N/vvPZWjroXpgyQPO+2k5aT/IX+SePn8A9R9FBjVSVmI8zf2t7690eZ9mfRTuH67jZ49LkkpKS9wZy208ff4A6j8+tQTUQtlJr2W6RXWzMY37efr8AdQfFBngCp0vPa/x68brfOl5SVJEQIRGtB9hcyr38fT5A6hfKDLAFSgqKdKIZSO08sBKSVKwT7Dm3jlXEQERNidzD0+fP4D6h3NkgBrKLcrVY8se085jOyVJjf0b67273vOYwyqePn8A9RNFBqiB9Px0JS1P0pHTFy/+1zKspd6/633Fh8XbG8xNPH3+AOovDi0B1fh4/8camjrU+Uv85qY3a+nQpR7zS9zT5w+gfmOPDGokJSVA2dkXr9y6bZvrFX4nTw523h458ozi4y+4NVtdSt2bqtGrR6vUKpUkhfqGqm9MX83bNc9lXKhvqB5t/6gdEeuUp88fQP1HkUGNLF7sX+VF8ObMCXLeHjCg+AdVZDKPZzp/iUtSYUmhpm+dXmFcTHDMD/IXuafPH0D9x6ElAABgLPbIoEYWLTphdwRbTOgxQRN6TLA7hm08ff4A6j/2yAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxrrqInP27NlrkQMAAOCK1arIlJaW6ve//72aNWum4OBg7du3T5L0wgsv6J133rmmAQEAAKpSqyLzhz/8QSkpKfq///s/+fr+9w8JduzYUW+//fY1CwcAAHA5tSoyc+fO1ZtvvqnExER5eXk5l3fp0kW7du26ZuEAAAAup1ZFJjc3V61ataqwvLS0VOfOnbvqUAAAADVRqyLTvn17bdiwocLyBQsWqFu3blcdCgAAoCa8a/OgF198UUlJScrNzVVpaakWLlyozMxMzZ07V0uXLr3WGQEAACpVqz0y9913n5YsWaLVq1crKChIL774or755hstWbJEAwYMuNYZAQAAKlWrPTKSdMstt2jVqlXXMgsAAMAVqXWRkaSSkhLl5+ertLTUZXnz5s2vKhQAAEBN1KrI7N69W6NGjdJnn33mstyyLDkcDl24cOGahAMAALicWhWZkSNHytvbW0uXLlXTpk3lcDiudS4AAIBq1arIpKen64svvlDbtm2v6slnz56t2bNnKzs7W5LUoUMHvfjiixo0aNBVbRcAAHiGWl9H5rvvvrvqJ4+JidH06dP1xRdfaNu2bbr99tt133336euvv77qbQMAgB++WhWZP/7xj3r++ee1du1aHTt2TIWFhS5fNXXvvffqrrvuUuvWrdWmTRtNnTpVwcHB2rx5c21iAQAAD1OrQ0v9+/eXJPXr189l+dWc7HvhwgX961//0qlTp5SQkFCbWAAAwMPUqsisWbPmmgXIyMhQQkKCzp49q+DgYC1atEjt27evdGxxcbGKi4ud98v2/uzZs0dnzpy5ZplMkJOTI0nKysrS0aNHbU7jXszds+eem5urgoICm9O4V9l7zdyZuyep6c84h2VZVh1nuaySkhLl5OSooKBACxYs0Ntvv61169ZVWmYmT56sKVOmVFg+cuRI+fr6uiNuveJwOGTz22cb5u6ZcwfgOUpKSpSSkqKCggKFhoZWOa5WRearr76qfGMOh/z9/dW8eXP5+fld6WYlXTxs1bJlS73xxhsV1lW2RyY2NlYLFy5UfHx8rZ7PVFlZWUpLS9OwYcMUGRlpdxy3Yu6ePfeEhASFhYXZHcetcnNznXuvmbvn8OS5S1JeXp7GjBlTbZGp1aGlrl27XvbaMT4+PnrooYf0xhtvyN/f/4q2XVpa6lJWyvPz86u0IEVERCg6OvqKnsd0ZbvcIiMjmbsHYe5SWFiYwsPDbU7jXmWHFZg7c/ckp0+frtG4Wn1qadGiRWrdurXefPNNpaenKz09XW+++aZuuOEGffDBB3rnnXeUlpam3/72t5fdzsSJE7V+/XplZ2crIyNDEydO1Nq1a5WYmFibWAAAwMPUao/M1KlTNXPmTA0cONC5rFOnToqJidELL7ygLVu2KCgoSM8995z+9Kc/Vbmd/Px8jRgxQocPH1ZYWJg6d+6sFStW8Be0AQBAjdSqyGRkZCguLq7C8ri4OGVkZEi6ePjp8OHDl93OO++8U5unBwAAkFTLQ0tt27bV9OnTVVJS4lx27tw5TZ8+3flnC3Jzc9WkSZNrkxIAAKAStdojM2vWLA0ePFgxMTHq3LmzpIt7aS5cuKClS5dKkvbt26cxY8Zcu6QAAACXqFWR+dGPfqT9+/fr/fffV1ZWliRp+PDheuSRRxQSEiJJeuyxx65dSgAAgErUqshIUkhIiEaPHn0tswAAAFyRGheZ1NRUDRo0SD4+PkpNTb3s2MGDB191MAAAgOrUuMgMGTJEeXl5ioqK0pAhQ6ocV9s/GgkAAHClalxkSktLK71d3sGDB/W73/3u6lMBAADUQK0+fl2V48eP629/+9u13CQAAECVrmmRAQAAcCeKDAAAMBZFBgAAGOuKriNz//33X3b9yZMnryYLAADAFbmiIhMWFlbt+hEjRlxVIAAAgJq6oiKTnJxcVzkAAACuGOfIAAAAY1FkAACAsSgyAADAWLX+69cAfvhSU/20caOv0tN9tGuXt0pKHM51eXlHbEwGABdRZABUaebMIH39tY/dMQCgShQZAFVyOKT4+PPq0uW88vMbaNMmX7sjAYALigyAKi1ZclwBARdvv/xyEEUGQL3Dyb4AqlRWYgCgvqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYi+vIAKhSSkqAsrO9JEnbtrle4Xfy5GDn7ZEjzyg+/oJbswGARJEBcBmLF/tXeRG8OXOCnLcHDCimyACwBYeWAACAsdgjA6BKixadsDsCAFwWe2QAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwVr0pMtOnT5fD4dAzzzxjdxQAAGCIelFktm7dqjfeeEOdO3e2OwoAADCI7UWmqKhIiYmJeuutt9SoUSO74wAAAIPYXmTGjh2ru+++W/3797c7CgAAMIy3nU8+f/58bd++XVu3bq3R+OLiYhUXFzvvFxYWSpL27NmjM2fO1EnG+ionJ0eSlJWVpaNHj9qcxr2Yu2fPPTc3VwUFBTanca+y95q5M3dPUtOfcQ7Lsqw6zlKpgwcPqnv37lq1apXz3Ji+ffuqa9eumjFjRqWPmTx5sqZMmVJh+ciRI+Xr61uXceslh8Mhm94+2zF3z5w7AM9RUlKilJQUFRQUKDQ0tMpxthWZjz76SEOHDpWXl5dz2YULF+RwONSgQQMVFxe7rJMq3yMTGxurhQsXKj4+3l3R64WsrCylpaVp2LBhioyMtDuOWzF3z557QkKCwsLC7I7jVrm5ucrIyGDuzN2j5OXlacyYMdUWGdsOLfXr108ZGRkuy37605+qbdu2+uUvf1mhxEiSn5+f/Pz8KiyPiIhQdHR0nWWtj8p2uUVGRjJ3D8LcpbCwMIWHh9ucxr3KDiswd+buSU6fPl2jcbYVmZCQEHXs2NFlWVBQkBo3blxhOQAAQGVs/9QSAABAbdn6qaVLrV271u4IAADAIOyRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMbytjsAUN+lpvpp40Zfpaf7aNcub5WUOJzr8vKO2Jis7h0uOqwVB1Zo06FNyjyRqfzT+SosKVSob6g6NO6g4W2Ga3ib4XI4HNVvDADqAEUGqMbMmUH6+msfu2PYYsHuBZr6+dQKy4+fPa4NuRu0IXeDlu5bquSByfJq4GVDQgCejiIDVMPhkOLjz6tLl/PKz2+gTZt87Y7kdlGBUerXvJ/iQuJ08PuD+nD3hzp74awkaeWBlZqfOV+J7RJtTgnAE1FkgGosWXJcAQEXb7/8cpBHFZlmwc30+u2va0irIfJu8N8fF0NbD9UDSx5w3k/LSaPIALAFRQaoRlmJ8UT3t76/0uV9mvVRuH+4jp89LkkqKS1xZywAcOJTSwCuWNlJv2W6RXWzMQ0AT0aRAXBFzpee1/h143W+9LwkKSIgQiPaj7A5FQBPRZEBUGNFJUUasWyEVh5YKUkK9gnW3DvnKiIgwuZkADwV58gAqJHcolw9tuwx7Ty2U5LU2L+x3rvrPQ4rAbAVRQZAtdLz05W0PElHTl+8AGDLsJZ6/673FR8Wb28wAB6PQ0sALuvj/R9raOpQZ4m5uenNWjp0KSUGQL3AHhmgGikpAcrOvnjV2m3bXK/wO3lysPP2yJFnFB9/wa3Z6lrq3lSNXj1apVapJCnUN1R9Y/pq3q55LuNCfUP1aPtH7YgIwMNRZIBqLF7sX+VF8ObMCXLeHjCg+AdXZDKPZzpLjCQVlhRq+tbpFcbFBMdQZADYgkNLAADAWOyRAaqxaNEJuyPYZkKPCZrQY4LdMQCgSuyRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFi2FpnJkyfL4XC4fLVt29bOSAAAwCDedgfo0KGDVq9e7bzv7W17JAAAYAjbW4O3t7euu+46u2MAAAAD2X6OzO7duxUdHa3rr79eiYmJysnJsTsSAAAwhK17ZHr16qWUlBTdcMMNOnz4sKZMmaJbbrlFO3bsUEhISIXxxcXFKi4udt4vLCyUJO3Zs0dnzpxxW+76oKzwZWVl6ejRozancS/m7tlzz83NVUFBgc1p3KvsvWbuzN2T1PRnnMOyLKuOs9TYyZMnFRcXp1deeUWPP/54hfWTJ0/WlClTKiwfOXKkfH193RGxXnE4HKpHb59befLcAcATlJSUKCUlRQUFBQoNDa1yXL0qMpLUo0cP9e/fX9OmTauwrrI9MrGxsVq4cKHi4+PdmNJ+WVlZSktL07BhwxQZGWl3HLdi7mlKSEhQWFiY3XHcKjc3VxkZGcyduXsMT567JOXl5WnMmDHVFhnbT/Ytr6ioSHv37tVjjz1W6Xo/Pz/5+flVWB4REaHo6Oi6jlevlO1yi4yMZO4epGzuYWFhCg8PtzmNe5XtWmfuzN1TePLcJen06dM1Gmfryb7jx4/XunXrlJ2drc8++0xDhw6Vl5eXHn74YTtjAQAAQ9i6R+bbb7/Vww8/rGPHjikyMlJ9+vTR5s2bPe5wAQAAqB1bi8z8+fPtfHoAAGA4268jAwAAUFsUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBY3nYHAOq71FQ/bdzoq/R0H+3a5a2SEodzXV7eERuTAQAoMkA1Zs4M0tdf+9gdAwBQCYoMUA2HQ4qPP68uXc4rP7+BNm3ytTsSAOD/o8gA1Viy5LgCAi7efvnlIIoMANQjnOwLVKOsxAAA6h+KDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsbiODFCNlJQAZWd7SZK2bXO9wu/kycHO2yNHnlF8/AW3ZgMAT0eRAaqxeLF/lRfBmzMnyHl7wIBiigwAuBmHlgAAgLHYIwNUY9GiE3ZHAABUgT0yAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGMv2IpObm6tHH31UjRs3VkBAgDp16qRt27bZHQsAABjA284nP3HihHr37q3bbrtNy5YtU2RkpHbv3q1GjRrZGQsAABjC1iLzxz/+UbGxsUpOTnYua9GihY2JAACASWw9tJSamqru3btr+PDhioqKUrdu3fTWW2/ZGQkAABjE1j0y+/bt0+zZszVu3Dj9+te/1tatW/XUU0/J19dXSUlJFcYXFxeruLjYeb+wsFCStGfPHp05c8ZtueuDnJwcSVJWVpaOHj1qcxr3Yu4Xzy0rKCiwOY17lb3XzJ25ewpPnrukGv98d1iWZdVxlir5+vqqe/fu+uyzz5zLnnrqKW3dulWbNm2qMH7y5MmaMmVKheUjR46Ur69vnWatjxwOh2x8+2zlyXMHAE9QUlKilJQUFRQUKDQ0tMpxtu6Radq0qdq3b++yrF27dvrwww8rHT9x4kSNGzfOeb+wsFCxsbEaPHiw4uPj6zJqvZOVlaW0tDQNGzZMkZGRdsdxK+aepoSEBIWFhdkdx61yc3OVkZHB3Jm7x/DkuUtSXl6eUlJSqh1na5Hp3bu3MjMzXZZlZWUpLi6u0vF+fn7y8/OrsDwiIkLR0dF1krG+KtvlFhkZydw9SNncw8LCFB4ebnMa9yrbtc7cmbun8OS5S9Lp06drNM7Wk32fffZZbd68WS+99JL27NmjDz74QG+++abGjh1rZywAAGAIW4tMjx49tGjRIs2bN08dO3bU73//e82YMUOJiYl2xgIAAIaw9dCSJN1zzz2655577I4BAAAMZPufKAAAAKgtigwAADAWRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFgUGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLG+7AwD1XWqqnzZu9FV6uo927fJWSYnDuS4v74iNyQAAFBmgGjNnBunrr33sjgEAqARFBqiGwyHFx59Xly7nlZ/fQJs2+dodCQDw/1FkgGosWXJcAQEXb7/8chBFBgDqEU72BapRVmIAAPUPRQYAABiLIgMAAIxFkQEAAMaiyAAAAGNRZAAAgLEoMgAAwFhcRwaoRkpKgLKzvSRJ27a5XuF38uRg5+2RI88oPv6CW7MBgKejyADVWLzYv8qL4M2ZE+S8PWBAMUUGANyMQ0sAAMBY7JEBqrFo0Qm7IwAAqsAeGQAAYCyKDAAAMBZFBgAAGIsiAwAAjEWRAQAAxqLIAAAAY1FkAACAsSgyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgMAAIxla5GJj4+Xw+Go8DV27Fg7YwEAAEN42/nkW7du1YULF5z3d+zYoQEDBmj48OE2pgIAAKawtchERka63J8+fbpatmypW2+91aZEAADAJPXmHJmSkhK99957GjVqlBwOh91xAACAAWzdI1PeRx99pJMnT2rkyJFVjikuLlZxcbHzfkFBgSQpJyenruPVO7m5uSopKVF2draKiorsjuNWzL1EeXl5On36tN1x3Oro0aPMnbnbHcetPHnuknTkyBFJkmVZlx3nsKob4SYDBw6Ur6+vlixZUuWYyZMna8qUKW5MBQAA7HTw4EHFxMRUub5eFJkDBw7o+uuv18KFC3XfffdVOe7SPTInT55UXFyccnJyFBYW5o6o9UZhYaFiY2N18OBBhYaG2h3HrZg7c2funoO5e+bcpYt7Yr7//ntFR0erQYOqz4SpF4eWkpOTFRUVpbvvvvuy4/z8/OTn51dheVhYmEe+yZIUGhrK3D0Qc2funoa5e+bca7KTwvaTfUtLS5WcnKykpCR5e9eLXgUAAAxhe5FZvXq1cnJyNGrUKLujAAAAw9i+C+SOO+6o9ozkqvj5+WnSpEmVHm76oWPuzN3TMHfm7mk8ee5Xol6c7AsAAFAbth9aAgAAqC2KDAAAMBZFBgAAGMvoIjNr1izFx8fL399fvXr10pYtW+yOVOfWr1+ve++9V9HR0XI4HProo4/sjuQ206ZNU48ePRQSEqKoqCgNGTJEmZmZdsdyi9mzZ6tz587O60kkJCRo2bJldseyxfTp0+VwOPTMM8/YHaXOTZ48WQ6Hw+Wrbdu2dsdym9zcXD366KNq3LixAgIC1KlTJ23bts3uWHUuPj6+wvvucDg0duxYu6PVS8YWmX/84x8aN26cJk2apO3bt6tLly4aOHCg8vPz7Y5Wp06dOqUuXbpo1qxZdkdxu3Xr1mns2LHavHmzVq1apXPnzumOO+7QqVOn7I5W52JiYjR9+nR98cUX2rZtm26//Xbdd999+vrrr+2O5lZbt27VG2+8oc6dO9sdxW06dOigw4cPO782btxodyS3OHHihHr37i0fHx8tW7ZMO3fu1J///Gc1atTI7mh1buvWrS7v+apVqyRJw4cPtzlZPWUZqmfPntbYsWOd9y9cuGBFR0db06ZNszGVe0myFi1aZHcM2+Tn51uSrHXr1tkdxRaNGjWy3n77bbtjuM33339vtW7d2lq1apV16623Wk8//bTdkercpEmTrC5dutgdwxa//OUvrT59+tgdo154+umnrZYtW1qlpaV2R6mXjNwjU1JSoi+++EL9+/d3LmvQoIH69++vTZs22ZgM7lT218/Dw8NtTuJeFy5c0Pz583Xq1CklJCTYHcdtxo4dq7vvvtvl370n2L17t6Kjo3X99dcrMTFROTk5dkdyi9TUVHXv3l3Dhw9XVFSUunXrprfeesvuWG5XUlKi9957T6NGjZLD4bA7Tr1kZJH57rvvdOHCBTVp0sRleZMmTZSXl2dTKrhTaWmpnnnmGfXu3VsdO3a0O45bZGRkKDg4WH5+fho9erQWLVqk9u3b2x3LLebPn6/t27dr2rRpdkdxq169eiklJUXLly/X7NmztX//ft1yyy36/vvv7Y5W5/bt26fZs2erdevWWrFihf73f/9XTz31lP7+97/bHc2tPvroI508eVIjR460O0q9ZfuVfYHaGDt2rHbs2OEx5wtI0g033KD09HQVFBRowYIFSkpK0rp1637wZebgwYN6+umntWrVKvn7+9sdx60GDRrkvN25c2f16tVLcXFx+uc//6nHH3/cxmR1r7S0VN27d9dLL70kSerWrZt27NihOXPmKCkpyeZ07vPOO+9o0KBBio6OtjtKvWXkHpmIiAh5eXnpyJEjLsuPHDmi6667zqZUcJcnnnhCS5cu1Zo1axQTE2N3HLfx9fVVq1atdNNNN2natGnq0qWLZs6caXesOvfFF18oPz9fN954o7y9veXt7a1169bpL3/5i7y9vXXhwgW7I7pNw4YN1aZNG+3Zs8fuKHWuadOmFUp6u3btPObQmiQdOHBAq1ev1s9+9jO7o9RrRhYZX19f3XTTTfrkk0+cy0pLS/XJJ5941DkDnsayLD3xxBNatGiR0tLS1KJFC7sj2aq0tFTFxcV2x6hz/fr1U0ZGhtLT051f3bt3V2JiotLT0+Xl5WV3RLcpKirS3r171bRpU7uj1LnevXtXuLxCVlaW4uLibErkfsnJyYqKitLdd99td5R6zdhDS+PGjVNSUpK6d++unj17asaMGTp16pR++tOf2h2tThUVFbn8b2z//v1KT09XeHi4mjdvbmOyujd27Fh98MEHWrx4sUJCQpznQ4WFhSkgIMDmdHVr4sSJGjRokJo3b67vv/9eH3zwgdauXasVK1bYHa3OhYSEVDgPKigoSI0bN/7Bnx81fvx43XvvvYqLi9OhQ4c0adIkeXl56eGHH7Y7Wp179tln9aMf/UgvvfSSHnzwQW3ZskVvvvmm3nzzTbujuUVpaamSk5OVlJQkb29jf1W7h90fm7oar732mtW8eXPL19fX6tmzp7V582a7I9W5NWvWWJIqfCUlJdkdrc5VNm9JVnJyst3R6tyoUaOsuLg4y9fX14qMjLT69etnrVy50u5YtvGUj18/9NBDVtOmTS1fX1+rWbNm1kMPPWTt2bPH7lhus2TJEqtjx46Wn5+f1bZtW+vNN9+0O5LbrFixwpJkZWZm2h2l3uOvXwMAAGMZeY4MAACARJEBAAAGo8gAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABiLIgOgXpg8ebK6du1qdwwAhqHIALgm8vLy9OSTT+r666+Xn5+fYmNjde+997r8cVcAuNb4S1QArlp2drZ69+6thg0b6uWXX1anTp107tw5rVixQmPHjtWuXbvsjgjgB4o9MgCu2pgxY+RwOLRlyxYNGzZMbdq0UYcOHTRu3Dht3rxZkpSTk6P77rtPwcHBCg0N1YMPPqgjR45Uuc3S0lL97ne/U0xMjPz8/NS1a1ctX77cuT47O1sOh0MLFy7UbbfdpsDAQHXp0kWbNm1yjklJSVHDhg21YsUKtWvXTsHBwbrzzjt1+PBhl+d6++231a5dO/n7+6tt27b661//eo1fIQB1hSID4KocP35cy5cv19ixYxUUFFRhfcOGDVVaWqr77rtPx48f17p167Rq1Srt27dPDz30UJXbnTlzpv785z/rT3/6k7766isNHDhQgwcP1u7du13G/eY3v9H48eOVnp6uNm3a6OGHH9b58+ed60+fPq0//elPevfdd7V+/Xrl5ORo/PjxzvXvv/++XnzxRU2dOlXffPONXnrpJb3wwgv6+9//fg1eHQB1zu4/vw3AbJ9//rklyVq4cGGVY1auXGl5eXlZOTk5zmVff/21JcnasmWLZVmWNWnSJKtLly7O9dHR0dbUqVNdttOjRw9rzJgxlmVZ1v79+y1J1ttvv11hm998841lWZaVnJxsSbL27NnjHDNr1iyrSZMmzvstW7a0PvjgA5fn+f3vf28lJCTU9CUAYCP2yAC4KpZlVTvmm2++UWxsrGJjY53L2rdvr4YNG+qbb76pML6wsFCHDh1S7969XZb37t27wvjOnTs7bzdt2lSSlJ+f71wWGBioli1buowpW3/q1Cnt3btXjz/+uIKDg51ff/jDH7R3795q5wXAfpzsC+CqtG7dWg6Hw7YTen18fJy3HQ6HpIvn11S2vmxMWfkqKiqSJL311lvq1auXyzgvL686yQvg2mKPDICrEh4eroEDB2rWrFk6depUhfUnT55Uu3btdPDgQR08eNC5fOfOnTp58qTat29f4TGhoaGKjo7Wp59+6rL8008/rXR8bTVp0kTR0dHat2+fWrVq5fLVokWLa/Y8AOoOe2QAXLVZs2apd+/e6tmzp373u9+pc+fOOn/+vFatWqXZs2dr586d6tSpkxITEzVjxgydP39eY8aM0a233qru3btXus0JEyZo0qRJatmypbp27ark5GSlp6fr/fffv6bZp0yZoqeeekphYWG68847VVxcrG3btunEiRMaN27cNX0uANceRQbAVbv++uu1fft2TZ06Vc8995wOHz6syMhI3XTTTZo9e7YcDocWL16sJ598Uj/+8Y/VoEED3XnnnXrttdeq3OZTTz2lgoICPffcc8rPz1f79u2Vmpqq1q1bX9PsP/vZzxQYGKiXX35ZEyZMUFBQkDp16qRnnnnmmj4PgLrhsGpyph4AAEA9xDkyAADAWBQZAABgLIoMAAAwFkUGAAAYiyIDAACMRZEBAADGosgAAABjUWQAAICxKDIAAMBYFBkAAGAsigwAADAWRQYAABjr/wHQrND6s99L3wAAAABJRU5ErkJggg==\n"
-          },
-          "metadata": {}
-        }
-      ],
-      "source": [
-        "class LazyMinesweeperBoard(MinesweeperBoard):\n",
-        "    def __init__(self, rows=8, cols=8, n_mines=10):\n",
-        "        self.rows = rows\n",
-        "        self.cols = cols\n",
-        "        self.n_mines = n_mines\n",
-        "        self.revealed = set()\n",
-        "        self.flagged = set()\n",
-        "        self.game_over = False\n",
-        "        self.won = False\n",
-        "        self.mines_placed = False\n",
-        "        self.mines = set()\n",
-        "        self.numbers = np.zeros((rows, cols), dtype=int)\n",
-        "\n",
-        "    def _place_mines(self, safe_cell):\n",
-        "        all_cells = [(r, c) for r in range(self.rows) for c in range(self.cols)]\n",
-        "        excluded = {safe_cell}\n",
-        "        excluded.update(self.get_neighbors(*safe_cell))\n",
-        "\n",
-        "        candidates = [cell for cell in all_cells if cell not in excluded]\n",
-        "        self.mines = set(random.sample(candidates, min(self.n_mines, len(candidates))))\n",
-        "\n",
-        "        self.numbers = np.zeros((self.rows, self.cols), dtype=int)\n",
-        "        for r in range(self.rows):\n",
-        "            for c in range(self.cols):\n",
-        "                if (r, c) not in self.mines:\n",
-        "                    self.numbers[r, c] = sum(\n",
-        "                        1 for nr, nc in self.get_neighbors(r, c)\n",
-        "                        if (nr, nc) in self.mines\n",
-        "                    )\n",
-        "        self.mines_placed = True\n",
-        "\n",
-        "    def reveal(self, r, c):\n",
-        "        if not self.mines_placed:\n",
-        "            self._place_mines((r, c))\n",
-        "        return super().reveal(r, c)\n",
-        "\n",
-        "# Test de la generation differee\n",
-        "random.seed(42)\n",
-        "board_lazy = LazyMinesweeperBoard(8, 8, 10)\n",
-        "print(\"Avant reveal :\", len(board_lazy.mines), \"mines\")\n",
-        "board_lazy.reveal(0, 0)\n",
-        "print(\"Apres reveal :\", len(board_lazy.mines), \"mines\")\n",
-        "draw_board(board_lazy, title=\"Generation differee (clic en 0,0)\")\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-45",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005914,
-          "end_time": "2026-02-26T07:01:12.052992",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:12.047078",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-45"
-      },
-      "source": [
-        "### Exercice 3 : scalabilite sur 16x16\n",
-        "\n",
-        "**Enonce** : testez le solveur probabiliste sur un plateau 16x16 avec 40 mines (difficulte \"intermediaire\" standard). Mesurez :\n",
-        "- Le taux de victoire sur 30 parties\n",
-        "- Le temps moyen par partie\n",
-        "- Le nombre moyen de devinettes\n",
-        "\n",
-        "Comparez avec les resultats 8x8 et commentez la scalabilite."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-46",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2026-04-21T00:32:05.038928Z",
-          "iopub.status.busy": "2026-04-21T00:32:05.038398Z",
-          "iopub.status.idle": "2026-04-21T00:32:05.043936Z",
-          "shell.execute_reply": "2026-04-21T00:32:05.042514Z"
-        },
-        "papermill": {
-          "duration": 0.01171,
-          "end_time": "2026-02-26T07:01:12.071688",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:12.059978",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-46",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "9116ffa3-d56b-4792-ca43-1747a4b74aad"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "16x16 (40 mines) :\n",
-            "  Victoires : 25/30\n",
-            "  Temps moyen : 198 ms\n",
-            "  Devinettes moyennes : 0.8\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Exercice 3 : test sur 16x16\n",
-        "\n",
-        "N_GAMES_16 = 30\n",
-        "wins_16 = 0\n",
-        "total_time_16 = 0\n",
-        "total_guesses_16 = 0\n",
-        "\n",
-        "for game_id in range(N_GAMES_16):\n",
-        "    random.seed(3000 + game_id)\n",
-        "    np.random.seed(3000 + game_id)\n",
-        "    board_16 = MinesweeperBoard(16, 16, 40, safe_cell=(8, 8))\n",
-        "    board_16.reveal(8, 8)\n",
-        "    solver_16 = ProbabilisticSolver(board_16)\n",
-        "    start = time.time()\n",
-        "    won = solver_16.play_game()\n",
-        "    total_time_16 += time.time() - start\n",
-        "    if won:\n",
-        "        wins_16 += 1\n",
-        "    total_guesses_16 += solver_16.decisions['guess']\n",
-        "\n",
-        "print(f\"16x16 (40 mines) :\")\n",
-        "print(f\"  Victoires : {wins_16}/{N_GAMES_16}\")\n",
-        "print(f\"  Temps moyen : {total_time_16/N_GAMES_16*1000:.0f} ms\")\n",
-        "print(f\"  Devinettes moyennes : {total_guesses_16/N_GAMES_16:.1f}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Analyse de la scalabilit&eacute; : 8x8 vs 16x16\n",
-        "\n",
-        "En comparant les r&eacute;sultats obtenus pr&eacute;c&eacute;demment, nous pouvons observer l'impact de l'augmentation de la taille du plateau :\n",
-        "\n",
-        "| Param&egrave;tre | D&eacute;butant (8x8, 10 mines) | Interm&eacute;diaire (16x16, 40 mines) | Facteur d'augmentation |\n",
-        "| :--- | :--- | :--- | :--- |\n",
-        "| **Nombre de cases** | 64 | 256 | x4 |\n",
-        "| **Nombre de mines** | 10 | 40 | x4 |\n",
-        "| **Temps moyen** | ~15 ms | ~136 ms | **~x9** |\n",
-        "| **Taux de victoire** | ~87% | ~83% | L&eacute;g&egrave;re baisse |\n",
-        "| **Devinettes moy.** | ~0.6 | ~0.8 | Augmentation mod&eacute;r&eacute;e |\n",
-        "\n",
-        "#### Commentaires sur la scalabilit&eacute;\n",
-        "\n",
-        "1.  **Complexit&eacute; du CSP** : Le temps d'ex&eacute;cution augmente beaucoup plus vite que le nombre de cases. C'est une cons&eacute;quence directe de la **NP-compl&eacute;tude** : sur un plateau plus grand, la \"fronti&egrave;re\" des cellules inconnues est plus longue, ce qui augmente de mani&egrave;re exponentielle le nombre de combinaisons possibles que le solveur CSP doit &eacute;num&eacute;rer.\n",
-        "2.  **D&eacute;terminisme vs Chance** : Le taux de victoire reste &eacute;lev&eacute; car le solveur utilise toujours les probabilit&eacute;s optimales. Cependant, la probabilit&eacute; de rencontrer une configuration n&eacute;cessitant une devinette (comme un \"50/50\") augmente avec la taille du plateau, ce qui explique la l&eacute;g&egrave;re baisse du taux de victoire.\n",
-        "3.  **Limites** : Sur un plateau \"Expert\" (16x30, 99 mines), l'&eacute;num&eacute;ration compl&egrave;te des solutions CSP pourrait devenir trop lente, n&eacute;cessitant des techniques plus avanc&eacute;es comme le d&eacute;coupage de la fronti&egrave;re en sous-probl&egrave;mes ind&eacute;pendants."
-      ],
-      "metadata": {
-        "id": "1UwVQOn1ah1L"
-      },
-      "id": "1UwVQOn1ah1L"
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-48",
-      "metadata": {
-        "papermill": {
-          "duration": 0.005907,
-          "end_time": "2026-02-26T07:01:12.095266",
-          "exception": false,
-          "start_time": "2026-02-26T07:01:12.089359",
-          "status": "completed"
-        },
-        "tags": [],
-        "id": "cell-48"
-      },
-      "source": [
-        "---\n",
-        "\n",
-        "## 8. Recapitulatif\n",
-        "\n",
-        "### Resume des approches\n",
-        "\n",
-        "| Approche | Principe | Avantage | Limitation |\n",
-        "|----------|----------|----------|------------|\n",
-        "| **Regles simples** | Deductions locales (1 cellule a la fois) | Rapide, sans erreur | Se bloque sur les cas ambigus |\n",
-        "| **CSP** | Enumeration des solutions globales | Deduit des cellules invisibles aux regles | Cout exponentiel (NP-complet) |\n",
-        "| **CSP + probabilites** | Choix optimal sous incertitude | Maximise les chances de victoire | Ne garantit pas la victoire |\n",
-        "\n",
-        "### Concepts cles\n",
-        "\n",
-        "| Concept | Definition | Application au Demineur |\n",
-        "|---------|------------|------------------------|\n",
-        "| **NP-completude** | Pas d'algorithme polynomial connu | Le Demineur n'est pas resolvable en temps polynomial (Kaye, 2000) |\n",
-        "| **CSP** | Variables + domaines + contraintes | Cellules binaires + sommes = indices |\n",
-        "| **Cellule forcee** | Meme valeur dans toutes les solutions | Certitude absolue sans deviner |\n",
-        "| **Raisonnement probabiliste** | Compter les solutions favorables | Choisir le coup le moins risque |\n",
-        "| **Frontiere** | Zone entre le connu et l'inconnu | Seules les cellules adjacentes aux revelees sont pertinentes |\n",
-        "\n",
-        "### Et ensuite ?\n",
-        "\n",
-        "Ce notebook a presente le Demineur comme un CSP avec extension probabiliste. Voici des pistes pour aller plus loin :\n",
-        "\n",
-        "- **Approches SAT** : encoder le probleme comme une formule booleenne et utiliser un solveur SAT\n",
-        "- **Apprentissage profond** : entrainer un reseau convolutionnel pour predire les mines\n",
-        "- **Hybride LLM + CSP** : utiliser un LLM pour guider l'exploration dans les cas ambigus (voir le projet etudiant original)\n",
-        "- **Plateau hexagonal** : generaliser a d'autres topologies de grille\n",
-        "\n",
-        "### References\n",
-        "\n",
-        "- Kaye, R. (2000). *Minesweeper is NP-complete*. Mathematical Intelligencer, 22(2), 9-15\n",
-        "- Becerra, D. J. (2015). *Algorithmic Approaches to Playing Minesweeper*. Harvard University\n",
-        "- Projet etudiant EPITA 2025 : jsboigeEpita/2025-PPC RDER-minesweeper"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.13.7"
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "deb2baa1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:08.243292Z",
+     "iopub.status.busy": "2026-04-22T18:08:08.242547Z",
+     "iopub.status.idle": "2026-04-22T18:08:08.250672Z",
+     "shell.execute_reply": "2026-04-22T18:08:08.249061Z"
     },
     "papermill": {
-      "default_parameters": {},
-      "duration": 4.753923,
-      "end_time": "2026-02-26T07:01:12.356575",
-      "environment_variables": {},
-      "exception": null,
-      "input_path": "Applications/App-6-Minesweeper.ipynb",
-      "output_path": "Applications/App-6-Minesweeper.ipynb",
-      "parameters": {},
-      "start_time": "2026-02-26T07:01:07.602652",
-      "version": "2.6.0"
+     "duration": 0.027093,
+     "end_time": "2026-04-22T18:08:08.253229",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:08.226136",
+     "status": "completed"
     },
-    "colab": {
-      "provenance": []
-    }
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {
+    "id": "cell-00",
+    "papermill": {
+     "duration": 0.012585,
+     "end_time": "2026-04-22T18:08:08.281028",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:08.268443",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# App-6 - Demineur : CSP, Probabilites et NP-completude\n",
+    "\n",
+    "**Navigation** : [<< App-5 Timetabling](App-5-Timetabling.ipynb) | [Index](../README.md) | [App-7 Wordle >>](App-7-Wordle.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. **Modeliser** le Demineur comme un probleme de satisfaction de contraintes (CSP)\n",
+    "2. **Implementer** un solveur par regles simples pour les cas non ambigus\n",
+    "3. **Construire** un solveur CSP qui enumere les solutions et deduit les cellules sures/minees\n",
+    "4. **Etendre** le solveur avec un raisonnement probabiliste pour les cas ambigus\n",
+    "5. **Comparer** les trois approches en termes de taux de victoire et de performance\n",
+    "\n",
+    "### Prerequis\n",
+    "- Python 3.10+, numpy, matplotlib\n",
+    "- `python-constraint` (CSP)\n",
+    "- Notions de CSP (Search-6 et Search-7)\n",
+    "\n",
+    "### Duree estimee : 50 minutes\n",
+    "\n",
+    "### Source\n",
+    "\n",
+    "Adapte du projet etudiant EPITA PPC 2025 : [jsboigeEpita/2025-PPC RDER-minesweeper](https://github.com/jsboigeEpita/2025-PPC) (CSP + probabilites, preuve NP-completude)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-01",
+   "metadata": {
+    "id": "cell-01",
+    "papermill": {
+     "duration": 0.004718,
+     "end_time": "2026-04-22T18:08:08.291350",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:08.286632",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 1. Introduction : le Demineur comme probleme de contraintes (~5 min)\n",
+    "\n",
+    "Le **Demineur** (Minesweeper) est un jeu classique ou le joueur doit reveler toutes les cellules sures d'une grille sans cliquer sur une mine. Chaque cellule revelee affiche un nombre indiquant combien de ses 8 voisines contiennent une mine.\n",
+    "\n",
+    "### Pourquoi le Demineur interesse-t-il l'IA ?\n",
+    "\n",
+    "Le Demineur est bien plus qu'un jeu : c'est un **probleme NP-complet**. Richard Kaye a demontre en 2000 que determiner si une configuration de Demineur est consistante (c'est-a-dire s'il existe un placement de mines compatible avec les indices visibles) est **NP-complet**.\n",
+    "\n",
+    "| Propriete | Valeur |\n",
+    "|-----------|--------|\n",
+    "| Complexite | NP-complet (Kaye, 2000) |\n",
+    "| Type de probleme | Satisfaction de contraintes |\n",
+    "| Variables | Cellules inconnues (mine ou sure) |\n",
+    "| Contraintes | Indices numeriques des cellules revelees |\n",
+    "| Reduction | Reduction depuis SAT / Circuit-SAT |\n",
+    "\n",
+    "### Modelisation CSP\n",
+    "\n",
+    "Le Demineur se modelise naturellement comme un CSP :\n",
+    "\n",
+    "- **Variables** : chaque cellule non revelee $C_{i,j}$ est une variable binaire\n",
+    "- **Domaines** : $D_{i,j} = \\{0, 1\\}$ ou $0$ = sure, $1$ = mine\n",
+    "- **Contraintes** : pour chaque cellule revelee affichant la valeur $n$, la somme des variables voisines doit valoir exactement $n$ :\n",
+    "\n",
+    "$$\\sum_{(r,c) \\in \\text{voisins}(i,j)} C_{r,c} = n_{i,j}$$\n",
+    "\n",
+    "- **Contrainte globale** : le nombre total de mines est connu\n",
+    "\n",
+    "### Plan du notebook\n",
+    "\n",
+    "Nous allons construire trois solveurs de complexite croissante :\n",
+    "\n",
+    "| Approche | Principe | Quand l'utiliser |\n",
+    "|----------|----------|------------------|\n",
+    "| Regles simples | Deductions deterministes locales | Cas triviaux |\n",
+    "| CSP complet | Enumeration des solutions, cellules forcees | Cas ambigus localement |\n",
+    "| CSP + Probabilites | Comptage de solutions, choix optimal | Quand aucune cellule n'est forcee |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-02",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:08.301373Z",
+     "iopub.status.busy": "2026-04-22T18:08:08.301160Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.007493Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.006697Z"
+    },
+    "id": "cell-02",
+    "outputId": "f45aa90e-3e39-43cb-d04b-37bf7e59172d",
+    "papermill": {
+     "duration": 1.712679,
+     "end_time": "2026-04-22T18:08:10.008264",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:08.295585",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Requirement already satisfied: python-constraint in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (1.4.0)\n",
+      "Imports OK\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Imports pour tout le notebook\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.patches as mpatches\n",
+    "import matplotlib.colors as mcolors\n",
+    "from collections import defaultdict\n",
+    "from itertools import product\n",
+    "import random\n",
+    "import time\n",
+    "import sys\n",
+    "import copy\n",
+    "\n",
+    "# Install CSP solver library if not already installed\n",
+    "!pip install python-constraint\n",
+    "\n",
+    "# CSP solver\n",
+    "from constraint import Problem, ExactSumConstraint\n",
+    "\n",
+    "# Helpers partages de la serie Search\n",
+    "sys.path.insert(0, '..')\n",
+    "from search_helpers import benchmark_table\n",
+    "\n",
+    "# Reproductibilite\n",
+    "random.seed(42)\n",
+    "np.random.seed(42)\n",
+    "\n",
+    "print(\"Imports OK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {
+    "id": "cell-03",
+    "papermill": {
+     "duration": 0.004724,
+     "end_time": "2026-04-22T18:08:10.018041",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.013317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 2. Representation du plateau (~5 min)\n",
+    "\n",
+    "Avant de resoudre le Demineur, nous devons le representer. Le plateau est une grille 2D ou chaque cellule est dans l'un des etats suivants :\n",
+    "\n",
+    "| Etat interne | Etat visible par le joueur | Description |\n",
+    "|--------------|----------------------------|-------------|\n",
+    "| Mine | Cache / Drapeau | Cellule contenant une mine |\n",
+    "| Sure (indice 0-8) | Cache / Revelee | Cellule sure avec nombre de mines voisines |\n",
+    "\n",
+    "Nous implementons une classe `MinesweeperBoard` qui gere la generation du plateau et la revelation des cellules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-04",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.028164Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.027859Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.036818Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.036007Z"
+    },
+    "id": "cell-04",
+    "outputId": "80deca68-de22-466b-a6df-2503f57b5bb1",
+    "papermill": {
+     "duration": 0.014895,
+     "end_time": "2026-04-22T18:08:10.037454",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.022559",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe MinesweeperBoard definie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class MinesweeperBoard:\n",
+    "    \"\"\"Plateau de Demineur avec generation, revelation et visualisation.\n",
+    "\n",
+    "    Attributs:\n",
+    "        rows, cols: dimensions de la grille\n",
+    "        n_mines: nombre total de mines\n",
+    "        mines: ensemble de positions (r, c) contenant une mine\n",
+    "        numbers: grille des indices (nombre de mines voisines)\n",
+    "        revealed: ensemble de cellules revelees\n",
+    "        flagged: ensemble de cellules marquees comme mines\n",
+    "        game_over: True si une mine a ete revelee\n",
+    "        won: True si toutes les cellules sures sont revelees\n",
+    "    \"\"\"\n",
+    "\n",
+    "    NEIGHBORS_OFFSETS = [(-1, -1), (-1, 0), (-1, 1),\n",
+    "                         (0, -1),           (0, 1),\n",
+    "                         (1, -1),  (1, 0),  (1, 1)]\n",
+    "\n",
+    "    def __init__(self, rows=8, cols=8, n_mines=10, safe_cell=None):\n",
+    "        \"\"\"Genere un plateau aleatoire.\n",
+    "\n",
+    "        Args:\n",
+    "            rows, cols: dimensions\n",
+    "            n_mines: nombre de mines\n",
+    "            safe_cell: position (r, c) garantie sans mine (premier clic)\n",
+    "        \"\"\"\n",
+    "        self.rows = rows\n",
+    "        self.cols = cols\n",
+    "        self.n_mines = n_mines\n",
+    "        self.revealed = set()\n",
+    "        self.flagged = set()\n",
+    "        self.game_over = False\n",
+    "        self.won = False\n",
+    "\n",
+    "        # Generer les mines en evitant safe_cell et ses voisins\n",
+    "        all_cells = [(r, c) for r in range(rows) for c in range(cols)]\n",
+    "        excluded = set()\n",
+    "        if safe_cell is not None:\n",
+    "            excluded.add(safe_cell)\n",
+    "            excluded.update(self.get_neighbors(*safe_cell))\n",
+    "\n",
+    "        candidates = [cell for cell in all_cells if cell not in excluded]\n",
+    "        self.mines = set(random.sample(candidates, min(n_mines, len(candidates))))\n",
+    "\n",
+    "        # Calculer les indices (nombre de mines voisines pour chaque cellule)\n",
+    "        self.numbers = np.zeros((rows, cols), dtype=int)\n",
+    "        for r in range(rows):\n",
+    "            for c in range(cols):\n",
+    "                if (r, c) not in self.mines:\n",
+    "                    self.numbers[r, c] = sum(\n",
+    "                        1 for nr, nc in self.get_neighbors(r, c)\n",
+    "                        if (nr, nc) in self.mines\n",
+    "                    )\n",
+    "\n",
+    "    def get_neighbors(self, r, c):\n",
+    "        \"\"\"Retourne les positions voisines valides de (r, c).\"\"\"\n",
+    "        neighbors = []\n",
+    "        for dr, dc in self.NEIGHBORS_OFFSETS:\n",
+    "            nr, nc = r + dr, c + dc\n",
+    "            if 0 <= nr < self.rows and 0 <= nc < self.cols:\n",
+    "                neighbors.append((nr, nc))\n",
+    "        return neighbors\n",
+    "\n",
+    "    def reveal(self, r, c):\n",
+    "        \"\"\"Revele la cellule (r, c). Retourne True si sure, False si mine.\"\"\"\n",
+    "        if (r, c) in self.revealed or (r, c) in self.flagged:\n",
+    "            return True\n",
+    "\n",
+    "        if (r, c) in self.mines:\n",
+    "            self.game_over = True\n",
+    "            return False\n",
+    "\n",
+    "        self.revealed.add((r, c))\n",
+    "\n",
+    "        # Si la cellule est un 0, reveler en cascade les voisins\n",
+    "        if self.numbers[r, c] == 0:\n",
+    "            for nr, nc in self.get_neighbors(r, c):\n",
+    "                if (nr, nc) not in self.revealed:\n",
+    "                    self.reveal(nr, nc)\n",
+    "\n",
+    "        # Verifier la victoire\n",
+    "        safe_cells = self.rows * self.cols - len(self.mines)\n",
+    "        if len(self.revealed) == safe_cells:\n",
+    "            self.won = True\n",
+    "\n",
+    "        return True\n",
+    "\n",
+    "    def flag(self, r, c):\n",
+    "        \"\"\"Marque/demarque une cellule comme mine.\"\"\"\n",
+    "        if (r, c) not in self.revealed:\n",
+    "            if (r, c) in self.flagged:\n",
+    "                self.flagged.discard((r, c))\n",
+    "            else:\n",
+    "                self.flagged.add((r, c))\n",
+    "\n",
+    "    def get_unknown_neighbors(self, r, c):\n",
+    "        \"\"\"Retourne les voisins ni reveles ni marques.\"\"\"\n",
+    "        return [\n",
+    "            (nr, nc) for nr, nc in self.get_neighbors(r, c)\n",
+    "            if (nr, nc) not in self.revealed and (nr, nc) not in self.flagged\n",
+    "        ]\n",
+    "\n",
+    "    def get_flagged_neighbors(self, r, c):\n",
+    "        \"\"\"Retourne les voisins marques comme mines.\"\"\"\n",
+    "        return [\n",
+    "            (nr, nc) for nr, nc in self.get_neighbors(r, c)\n",
+    "            if (nr, nc) in self.flagged\n",
+    "        ]\n",
+    "\n",
+    "    def remaining_mines(self):\n",
+    "        \"\"\"Nombre de mines non encore marquees.\"\"\"\n",
+    "        return self.n_mines - len(self.flagged)\n",
+    "\n",
+    "    def copy(self):\n",
+    "        \"\"\"Retourne une copie profonde du plateau.\"\"\"\n",
+    "        board = MinesweeperBoard.__new__(MinesweeperBoard)\n",
+    "        board.rows = self.rows\n",
+    "        board.cols = self.cols\n",
+    "        board.n_mines = self.n_mines\n",
+    "        board.mines = set(self.mines)\n",
+    "        board.numbers = self.numbers.copy()\n",
+    "        board.revealed = set(self.revealed)\n",
+    "        board.flagged = set(self.flagged)\n",
+    "        board.game_over = self.game_over\n",
+    "        board.won = self.won\n",
+    "        return board\n",
+    "\n",
+    "print(\"Classe MinesweeperBoard definie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {
+    "id": "cell-05",
+    "papermill": {
+     "duration": 0.004746,
+     "end_time": "2026-04-22T18:08:10.047042",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.042296",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Visualisation du plateau\n",
+    "\n",
+    "La fonction suivante dessine le plateau avec un code couleur clair :\n",
+    "- Gris : cellule cachee\n",
+    "- Blanc avec chiffre : cellule revelee\n",
+    "- Rouge avec drapeau : cellule marquee comme mine\n",
+    "- Noir (game over) : mine revelee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-06",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.056934Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.056678Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.063897Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.063023Z"
+    },
+    "id": "cell-06",
+    "outputId": "e1dd82a9-26b1-4c3d-acc6-a371e3f07e3a",
+    "papermill": {
+     "duration": 0.012968,
+     "end_time": "2026-04-22T18:08:10.064474",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.051506",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonction draw_board definie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Couleurs pour les chiffres du demineur (convention classique)\n",
+    "NUMBER_COLORS = {\n",
+    "    0: '#CCCCCC', 1: '#0000FF', 2: '#008000', 3: '#FF0000',\n",
+    "    4: '#000080', 5: '#800000', 6: '#008080', 7: '#000000', 8: '#808080'\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def draw_board(board, title=\"Demineur\", show_mines=False,\n",
+    "               highlight_safe=None, highlight_mines=None,\n",
+    "               probabilities=None, figsize=None):\n",
+    "    \"\"\"Visualise le plateau de Demineur.\n",
+    "\n",
+    "    Args:\n",
+    "        board: MinesweeperBoard\n",
+    "        title: titre du graphique\n",
+    "        show_mines: reveler toutes les mines (fin de partie)\n",
+    "        highlight_safe: ensemble de cellules a surligner en vert (deduites sures)\n",
+    "        highlight_mines: ensemble de cellules a surligner en rouge (deduites mines)\n",
+    "        probabilities: dict (r,c) -> probabilite de mine (pour affichage)\n",
+    "    \"\"\"\n",
+    "    if figsize is None:\n",
+    "        figsize = (max(6, board.cols * 0.7), max(6, board.rows * 0.7))\n",
+    "\n",
+    "    fig, ax = plt.subplots(figsize=figsize)\n",
+    "\n",
+    "    for r in range(board.rows):\n",
+    "        for c in range(board.cols):\n",
+    "            # Determiner la couleur de fond\n",
+    "            if (r, c) in board.revealed:\n",
+    "                bg_color = '#E8E8E8'  # Gris clair pour revelee\n",
+    "            elif (r, c) in board.flagged:\n",
+    "                bg_color = '#FFB3B3'  # Rouge clair pour drapeau\n",
+    "            elif highlight_safe and (r, c) in highlight_safe:\n",
+    "                bg_color = '#B3FFB3'  # Vert clair pour sure deduites\n",
+    "            elif highlight_mines and (r, c) in highlight_mines:\n",
+    "                bg_color = '#FF6666'  # Rouge pour mine deduite\n",
+    "            else:\n",
+    "                bg_color = '#C0C0C0'  # Gris pour cachee\n",
+    "\n",
+    "            rect = plt.Rectangle((c, board.rows - 1 - r), 1, 1,\n",
+    "                                 facecolor=bg_color, edgecolor='#666666',\n",
+    "                                 linewidth=1)\n",
+    "            ax.add_patch(rect)\n",
+    "\n",
+    "            # Contenu de la cellule\n",
+    "            cx, cy = c + 0.5, board.rows - 1 - r + 0.5\n",
+    "\n",
+    "            if (r, c) in board.revealed:\n",
+    "                num = board.numbers[r, c]\n",
+    "                if num > 0:\n",
+    "                    ax.text(cx, cy, str(num), ha='center', va='center',\n",
+    "                            fontsize=14, fontweight='bold',\n",
+    "                            color=NUMBER_COLORS.get(num, 'black'))\n",
+    "            elif (r, c) in board.flagged:\n",
+    "                ax.text(cx, cy, 'F', ha='center', va='center',\n",
+    "                        fontsize=12, fontweight='bold', color='darkred')\n",
+    "            elif show_mines and (r, c) in board.mines:\n",
+    "                ax.text(cx, cy, 'X', ha='center', va='center',\n",
+    "                        fontsize=14, fontweight='bold', color='black')\n",
+    "            elif probabilities and (r, c) in probabilities:\n",
+    "                prob = probabilities[(r, c)]\n",
+    "                ax.text(cx, cy, f'{prob:.0%}', ha='center', va='center',\n",
+    "                        fontsize=8, color='#444444')\n",
+    "\n",
+    "    ax.set_xlim(0, board.cols)\n",
+    "    ax.set_ylim(0, board.rows)\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.set_xticks(range(board.cols))\n",
+    "    ax.set_yticks(range(board.rows))\n",
+    "    ax.set_xticklabels(range(board.cols))\n",
+    "    ax.set_yticklabels(range(board.rows - 1, -1, -1))\n",
+    "    ax.set_xlabel('Colonne')\n",
+    "    ax.set_ylabel('Ligne')\n",
+    "    ax.set_title(title, fontsize=13, fontweight='bold')\n",
+    "    plt.tight_layout()\n",
+    "    return fig\n",
+    "\n",
+    "\n",
+    "print(\"Fonction draw_board definie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {
+    "id": "cell-07",
+    "papermill": {
+     "duration": 0.004761,
+     "end_time": "2026-04-22T18:08:10.074064",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.069303",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Creons un plateau 8x8 avec 10 mines et simulons un premier clic pour reveler quelques cellules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-08",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.084962Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.084672Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.369819Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.369018Z"
+    },
+    "id": "cell-08",
+    "outputId": "889070e9-3d7d-40f1-b5d8-d843550fc1da",
+    "papermill": {
+     "duration": 0.291818,
+     "end_time": "2026-04-22T18:08:10.370534",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.078716",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plateau : 8x8, 10 mines\n",
+      "Cellules revelees apres le premier clic : 44\n",
+      "Cellules restantes (inconnues)           : 20\n",
+      "Mines a trouver                          : 10\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOxlJREFUeJzt3Ql0FFW+x/F/k5AQExIFwhK2IIvsgRFQXFFA1BmVRfQgCnGZNyqOC8I4zIwSVFweowMqgoiT6AjiPCQSGAHRKMgYFPTliSCbEINhCcoSA5gA6Xf+19M92Veg+nZ9P+fUSS+V6lu3bnf/+tatKo/X6/UKAACAheo5XQAAAIDaIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyMCVBgwYIB6Px0wpKSl1WlZ8fLx/WR9//HG1/y8rK8v/fzrVRfHl6HJxZra9W2g9+epM6y/Q6fvQV159f56O9xwCR6jTBYC9H2y33357pfNcfvnlJb7Yp0+fLocOHTK3ExMTS3zA1IZ+KPm+iM4++2x58MEHJZBkZmbKu+++a27ruuo6AwBOLYIMzhgNMt999525rb/qTkWQmTJlirndtm3bGgWZF198UQ4fPmxud+rUqU7lWLhwofz888/mdo8ePUoEGV/5NNSVDjItWrSQTz75pE6vDZwJ1157rb+txsTEWFvpvOeCE0EGp0R5X8iB/IFXPHDUVZ8+fWr1f+Hh4XLJJZeIG+Xn50tUVJTTxbDCsWPHTFupV8+5kQBNmzY10+lUVFQkBQUFEhERcdpew83vuWDGGBmcEvrhUHryhYWkpCSzP9rXG6OuuOIK/35qfV69//77ctNNN0nnzp2lcePGUr9+fROGLrjgAnn++efl+PHj/v/X3hxdho8uuybjRCoaJ6G9JsXLlZaWJhdeeKH5cI2NjZXf/e53cuTIkSrHyOjt4rveVq1aVWbffGX76/W1Bw4cKG3atDFf+GFhYRIXFyfDhg2r0TicitSkrsurF91l1q9fP1Mv+gWn9XLw4MEK6zg5Odn0yHXp0sWsy1/+8hf/fN98843cddddcu6550qDBg0kOjpaLr74YrNdvF5viWXm5OSY19J59UtJX79169YyePBgmTx5cp3r5cCBA/Loo49KQkKCqXddfrdu3cw6a/iqjtLbVZd5zz33SPPmzc36afDVdlXZmI6tW7fK8OHD5ZxzzpGzzjpL8vLyzHwnT56UV155RS699FLznNal9kb+9re/lZ07d1Zajj179sioUaPMdtb/vfXWW+XHH3+UwsJCeeyxx0w9avnOP/980z5qMkbm7bfflquuukqaNGliyqQ9H/paX331VZl5i5dJn3/ggQekZcuWpg2uWLGiyvr99ttvZdy4cabtat1ERkaa2//1X/9lglBNtk1p2ouqbb14W9TPsYkTJ1ZZLjjIC9RCcnKyfsP4p8pMnjy5xLylJ31ePfLII5XOd8MNN/iX2bZt20rn3blzZ6Vluvzyy/3z6rr4jB071v94hw4dyl327373uxLLKl6Wjz76yDxWWdl89aVlrKgOmzVrVuH/ejwe7zvvvFNi/pqse03runS9dOnSpdz/SUhI8B49erTcOu7YsWOJeR944AEzT2pqqrdBgwYVlmP06NHeoqIiM29hYaG3ffv2Fc4bHh5e5XpXtu23bdvmbdWqVYXL7969u/fHH3+scvmlt2vXrl3L3Ybz5s3z/4+2G99zMTEx3tjY2BLzHzx40NTtFVdcUWH5zj77bO9nn31WYTk6depU5n/69+/vHTZsWJnHw8LCvFlZWeW+37X+fE6ePOm95ZZbKt0maWlpJeqn+POl24W2h8osXbrUe9ZZZ1X4elpPpetT358V1Ulxc+bM8YaGhpa7XN0mCFz0yOCUKP4rxzfpL3B1xx13mF1P+ovU54UXXjCP6aTPq8suu8w8rr/2P/zwQ0lPT5d58+ZJhw4dzPOLFy+WdevW+cel6Lw+umzf8nTSX4R1tX37dvOrcunSpeYXtc9rr71W5a9zLcOf/vQn//1evXqVKF9VdLzP66+/Lv/617/Mr3X9pfrUU0+Z5/S7QHsN6qImdV2a9qDceeed8t5778mTTz5pfkmr//u//zO9OeXZtm2bXH/99ZKammpeU3tQ9u/fL7fddpt/fNHdd98ty5cvl3/84x+ml0FpmbQ3x7d8/TWuevbsaZa1cuVKU0/6q95X9trSHorvv//e3NbePl3+kiVLzPgm9fXXX9dqQLkOcNceDV2e9nj5tqH2KpTu3VM6dkt7xPT9oz0jM2bMML1P2iv00UcfmXnatWtn6kWf13rzvY621xMnTpRbDu2tWLBggbz88sv+3oiMjAyzrXXZ2s5948W0l2b27NlVrpv2Ds2fP9/c1t6YmTNnmm2iPW76Gvqauo1L99b56PZ8+OGHZdmyZWa7t2/fvsLX0vZyyy23yNGjR8197TXR19f3xqxZs/x1WxubNm0y73Ff3en7VduVtkfdDl27dq31snEGOJ2kEBw9MuVNf/vb36rsuSjuyJEj3ieffNJ7/vnne6Ojo82v1tLLfOGFF/zzV/Srqzqq0yPTrVs3f2+A/vIs/kvwq6++qnK9KvoVW51fhxs3bvSOGTPG265dO/Ortrz6zcvL889f0x6ZmtZ18Xrp27dviWXdd999/ud69uxZbh3r65T24osvlujt+OSTT/zTn//8Z/9zF154oZl/69at/scGDhxo6kh7aWqqvG2/YcMG/2P169f3rlixwl+WhQsXlnjup59+qnT5pbfrv/71L/9zu3fvNr0dvucWLVpUpi3rVLoXQ9th8V6a559/vkR9tWjRwv/c8uXLyy3He++9519e8V6im266yf/4tGnT/I8PHz68yras29X3+MSJE0uUqXfv3v7nZs+e7f+f4mUaP358tbfbSy+95P+/qKgo7/fff1/hvDXtkZkwYYL/Me2Vy8/Pr3a54DwG++KUKK+XQX8x1SBQmyMjdCxJZSr6ZXc6XHnllf5frjrQUscV+H4N6riH02XDhg3Sv3//cn+tl66Lhg0b1nj5da3r0oMl9f5LL73k73kpj473KO9XsI/2dui4j/Loc0p7XAYNGiQffPCB6UXSsSshISHmV7zWl/ZM6Him2iheFu0NGTJkSLnz6XNbtmwx40iqq3h9aU+hvi82b95cYX1p78tvfvObMr0ROvmMHz++wtfT+iqv/BdddJH/to6L8tG689FeFZ/qtPHi9TZt2jQzVVSm8owYMaLK1yjvtbT3RcfVnCrFl611p+NuYA+CDE6Juh4JoF3cvi9W/XLSrm794NWBg48//rjprvYd2XCmNGrUqMT90ND/vF1KD0I9lfTQcF+I6dixo6kLHYip6158oGVt68KJuq7Lrj7fbjwNlbqrR7v8dXeCfvns2LHDDIzVSXdxfPrpp7U+iqym5TldmjVrVqeTtVVUvuJHERY/AkrPwVSeU9nGKyrTqdgFDDBGBmdM8Q/P0l+S2dnZ/tu6f1r3sWuPiP7CLv5cdZcXCGpbvuLre//995txAdpboaHjVKhNXRf373//u8L7FY1TKe+LWY9g8tEgpV+c5U2+L0G9rUeS6FFLixYtMr0aGvi0jny9JTp2qjaKl0WPVNLxJhWVxTdmprqK18/evXtN+KqsvsqrKz1irnhviQa5isp3Ko7eqk296XiV8sqk42TmzJlT7v/XJLAVH6fy2Wefye7du+tY+vKXreOOSveGns4fLqg7emRwSqxZs6Zs4woNLdHVr93ZvkNE9Ve1ftHrPDpws/huKD0kUwck6oBG/QDUrvzyFO8e1w+1N954wyxHv4hq0vV/uhQvn66Tfvnqocr6C7h79+4V/l/xupg7d645HFe7+YsfslwXtanr4j7//HNzqKvuLvrf//1f8wXmo4d0V9fNN99sBkTrl6/2pNx4440mtGnPgR5mrWXRAcVDhw41X8779u0zh2Xr7gg9JFZ/zeuuvvXr1/uX6Rs4XFO6vL59+5oBznreFg12GpC0J0x36Wi71QHRGkh111ZNaF1NnTrVrNezzz5rBtIqbQd6yHJ1+A7n9+26GTNmjPzxj3807UjrTwPo2rVrzYBd36HaZ4IO+v7yyy/NbR20q3Wl9ajruGvXLrNt9FBzrde6ngBT29akSZPkp59+8gfKP/zhD2a5eli1Dn7W9lJRD1Nl9JDrv/3tb+bwdi23LlsHkGvvmPb26SDp8j7jECCcHqSD4B3sW/qQxUmTJpU7nw4M1MG0F110UZnnIiMjzeDS0odqqxMnTpR7uKweonsqBvsWf63KBvVW9PiBAwfKPVRUB6pWNvBQBxLroNLS/zdgwIAKB/XWZLBvbeq6eL306tWr3MHBPXr0MIOIq6rj4nSwa2WHXxcvx549eyqdTw+dLX74cUUqKpcOJq7s8OvSA10rUnq7Fh/06pu0/t54440aDVzXw69Lt4HyporKUZ06qGhQb2WHX48aNarKMtW2rZa2ePFib0RExGk5/HrWrFnekJCQcpfL4deBjV1LOGO0R0F3C2ivROkuZe2d0cNA9ZeR/grSwXZ6CKweelzRoY+6q0UPadVDifXEWIFGBwdrL4yO2dABnDXpHdBxKjoIU+tBDy2/7777zPiQU6E2dV3cDTfcYA4L1wGXuqtHd3noCdn00OCabgc9wZ/26mivhe5m0eVpefS2DnjVQ4DvvfdeM6/+0n7iiSdML4aeKFB73rRHT08UqL1DOuBcT9JXWzoeSXuo9ORwvXv3NifE0+2mr6VtTHtVqnNIcmlaL3qotW5HXd6vfvUreeedd8xhyTWh66u9QdpzpmOldAyXrr9uQ+2BfOihh07JyRJr2pZ0bNI///lPufrqq80uMC2TtgntadUB2NpLoj1bp4Iewq8nrdPl6vbS9qJtTg8b15Mq1uWswLpM3WWl20V7eXTMmLYB7fXS9o3A5dE043QhAAQ2DT26O1Dpbh7f2ZhRlu7m0F11PnzEAqcXPTIAAMBaBBkAAGAtggwAALAWY2QAAIC16JEBAADWIsgAAABrWX1mXz3Lpp7RVS+cV5drkwAAgMCipy7QMznruaKKX/IlqIKMhphTdaIlAAAQePSyEa1atQrOIKM9Meq5554zZ7d0Ew1xevVfPZNpdHS0uHHd9SyfxS+k5wbbt2+X1atXs+5sd9e1eTd/1rlx3ZVeX02v4eX7rg/KIOPbnaQhprK0Foz0Sr96Cm097bmeqtyN666nEdcuRzfRCxqy7mx3N7Z5N3/WuXHdi6tq6AiDfQEAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALBWqNMFAAJdWlq4rFkTJpmZ9WXz5lApLPT4n9u7d5+jZQNOhz35e2TFdyskY3eGbDm4RXKP5kpeYZ5Eh0VLt8bdZGSnkWbyeP7zXgCcQpABqjBjRqRs3FifeoJrLNy2UKZ+NrXM4wd+PiCf5HxipqU7lkrykGQJqRfiSBkBH4IMUAX90Rkff0ISEk5Ibm49ycgIo87gCk3PaioD2wyUtg3byq6fdsk7296Rn0/+bJ57/7v3ZcGWBTK6y2iniwmXI8gAVViy5IBERPxye9q0SIIMgl7LqJby0pUvydAOQyW03n++JoZ1HCY3LrnRfz89O50gA8cRZIAq+EIM4BbDOw4v9/FLWl4ijRo0MruYVGFR4RkuGVAWRy0BAKrFN+jXp3fT3tQcHEeQAQBU6UTRCZmwaoL5q5pENJExXcdQc3AcQQYAUKn8wnwZs2yMGeCroupHyRtXv2HCDOA0xsgAACqUk58jty27TTb9uMncb9ygsbx57ZvsVkLAIMgAAMqVmZspY5ePlX1HfznxY/uY9jLv2nkSHxNPjSFgsGsJAFDGezvfk2Fpw/wh5sIWF8rSYUsJMQg49MgAVUhJiZCsrF/OXrp+fckz/CYlRflvJyYek/j4k9QnrJf2bZrc/cHdUuQtMvf10gQDWg2Qtza/VWI+ffzWrrc6VErgFwQZoAqLFzeo8CR4s2dH+m8PHlxAkEFQ2HJgiz/EKD3k+pl1z5SZr1VUK4IMHMeuJQAAYC16ZIAqpKYepI7gKhP7TjQTYAN6ZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFgrIILMzJkzJT4+Xho0aCAXXHCBfP75504XCQAAWMDxIPP222/L+PHjZfLkyfLll19KQkKCDBkyRHJzc50uGgAACHCOB5nnn39efvvb38rtt98uXbt2ldmzZ8tZZ50lf//7350uGgAACHChTr54YWGhfPHFFzJp0iT/Y/Xq1ZNBgwZJRkZGmfkLCgrM5JOXl2f+7t69W44fPy5usn//fvM3JydHDh8+LG5c961bt/pvu0V2drb5y7qz3d3W5t38WefGdVfV/Xx3NMj88MMPcvLkSWnWrFmJx/X+5s2by8z/9NNPy5QpU8o8vmnTJgkLCxM32rBhg7iRx+OR9PR0cSPWne3uRm79rHPzuhcWFgZ+kKkp7bnR8TTFe2Rat24t/fr1k+bNm4ubaELXxt2/f3+JiYkRN677iBEjJDY2VtxEe2I0wLHubHe3tXk3f9a5cd3V3r17JSUlRQI6yDRp0kRCQkJk3759JR7X++UFk/DwcDOVFh0dLY0aNRI38XUzauN267priImLixM3drWy7mx3t7V5N3/WuXHd1dGjRyXgB/vq7qDzzz9fPvzwQ/9jRUVF5r4mUAAAgIDetaS7isaOHSt9+vQxu4imT58uR44cMUcxAQAABHSQufnmm03X4WOPPWb2h/Xq1UuWL19eZgAwAABAwAUZdd9995kJAADAqhPiAQAA1BZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGCtUKcLAASyPfl7ZMV3KyRjd4ZsObhFco/mSl5hnkSHRUu3xt1kZKeRZvJ4PE4XFThlaPewCUEGqMTCbQtl6mdTyzx+4OcD8knOJ2ZaumOpJA9JlpB6IdQlggLtHjZh1xJQDU3PaiqjOo+SP/b9o4zuPFoahDTwP/f+d+/Lgi0LqEcEHdo9bECPDFCJllEt5aUrX5KhHYZKaL3/vF2GdRwmNy650X8/PTtdRncZTV0iKNDuYROCDFCJ4R2Hl/v4JS0vkUYNGpldTKqwqJB6RNCg3cMm7FoCasE36Nend9Pe1COCHu0egYggA9TQiaITMmHVBPNXNYloImO6jqEeEdRo9whUBBmgBvIL82XMsjFmgK+Kqh8lb1z9hgkzQLCi3SOQMUYGqKac/By5bdltsunHTeZ+4waN5c1r32S3EoIa7R6BjiADVENmbqaMXT5W9h3dZ+63j2kv866dJ/Ex8dQfghbtHjZg1xJQhfd2vifD0ob5Q8yFLS6UpcOWEmIQ1Gj3sAU9MkAl0r5Nk7s/uFuKvEXmvl6aYECrAfLW5rdKzKeP39r1VuoSQYF2D5sQZIBKbDmwxR9ilB5y/cy6Z8rM1yqqFUEGQYN2D5uwawkAAFiLHhmgEhP7TjQT4Ca0e9iEHhkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWcjTIrF69Wq677jqJi4sTj8cj7777rpPFAQAAlnE0yBw5ckQSEhJk5syZThYDAABYKtTJF7/mmmvMBAAAYF2QqamCggIz+eTl5Zm/u3fvluPHj4ub7N+/3/zNycmRw4cPixvXfevWrf7bbpGdnW3+su5sd7e1eTd/1rlx3VV1P989Xq/XKwFAx8ikpqbK0KFDK5wnKSlJpkyZUubxxMRECQsLO80lRCDR9hIgTfeMY93Z7m5Dm3dnmy8sLJSUlBQT4qKjo4OjR2bSpEkyfvz4Ej0yrVu3ln79+knz5s3FTTShb9iwQfr37y8xMTHixnUfMWKExMbGiptoT0x6ejrrznZ3Ddq8O9/vKisrywSZqlgVZMLDw81Umia1Ro0aiZv4uhk1xLh13fWNrUe8ubGrlXVnu7sFbd6d73eVn58v1cF5ZAAAgLVCnU5b27dv99/fuXOnZGZmmh6GNm3aOFk0AABgAUeDzPr16+WKK67w3/eNfxk7dmy19osBAAB3czTIDBgwwLVHngAAgLpjjAwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgrVCnCwAEurS0cFmzJkwyM+vL5s2hUljo8T+3d+8+R8sGnA5ubvN78vfIiu9WSMbuDNlycIvkHs2VvMI8iQ6Llm6Nu8nITiPN5PH8p06CxR5L150gA1RhxoxI2bixPvUE13Bzm1+4baFM/WxqmccP/HxAPsn5xExLdyyV5CHJElIvRILJQkvXnSADVEF/fMTHn5CEhBOSm1tPMjLCqDMENdq8SNOzmsrANgOlbcO2suunXfLOtnfk55M/m/p5/7v3ZcGWBTK6y2gJRk0tW3eCDFCFJUsOSETEL7enTYskyCDoubnNt4xqKS9d+ZIM7TBUQuv95ytyWMdhcuOSG/3307PTA+rL3M3rTpABquD7QAfcws1tfnjH4eU+fknLS6RRg0ZmN4sqLCqUYDPc0nXnqCUAAKrgG/jq07tpb9fUWW6ArztBBgCASpwoOiETVk0wf1WTiCYypusYV9TZCQvWnSADAEAF8gvzZcyyMWaQq4qqHyVvXP2G+UIPdvmWrDtjZAAAKEdOfo7ctuw22fTjJnO/cYPG8ua1bwbcrhW3rztBBgCAUjJzM2Xs8rGy7+gvJwBsH9Ne5l07T+Jj4oO+rjItW3d2LQEAUMx7O9+TYWnD/F/kF7a4UJYOWxqwX+RuX3d6ZIAqpKRESFbWL2exXL++5NlOk5Ki/LcTE49JfPxJ6hPWc3ObT/s2Te7+4G4p8haZ+3p6/gGtBshbm98qMZ8+fmvXWyWYpFm67gQZoAqLFzeo8IRgs2dH+m8PHlwQdB/qcCc3t/ktB7b4v8iVHnb8zLpnyszXKqpVQH2Zu3nd2bUEAACsRY8MUIXU1IPUEVzFzW1+Yt+JZnKjiZauOz0yAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArOVokHn66aelb9++0rBhQ2natKkMHTpUtmzZ4mSRAACARRwNMqtWrZJx48bJ2rVrZeXKlXL8+HG56qqr5MiRI04WCwAAWCLUyRdfvnx5ifspKSmmZ+aLL76Qyy67zLFyAQAAOzgaZEo7fPiw+duoUaNyny8oKDCTT15envm7e/du05vjJvv37zd/c3Jy/PXmtnXfunWr/7ZbZGdnm7+sO9vdLWjz7ny/+77fqsPj9Xq9EgCKiork+uuvl0OHDsmaNWvKnScpKUmmTJlS5vHExEQJCwsTt/F4PBIgm++MY93Z7m5Dm6fNu01hYaHZU6M/1qOjowM/yNxzzz2ybNkyE2JatWpV7R6Z1q1by6JFiyQ+Pl7cRBN6enq6jBgxQmJjY8VNWHe2O23ePXi/u/P9rrKysmT48OFVBpmA2LV03333ydKlS2X16tUVhhgVHh5uptKaNGkicXFx4ia+bkZt3Ky7e7DdafO8393Dze93lZ+fL9XhaJDRzqDf//73kpqaKh9//LG0a9fOyeIAAADLOBpk9NDr+fPny+LFi825ZPbu3Wsej4mJkYiICCeLBgAALODoeWRmzZpl9n0NGDBAWrRo4Z/efvttJ4sFAAAs4fiuJQAAgNriWksAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWqFOF8AmaWnhsmZNmGRm1pfNm0OlsNDjf27v3n0SzFh3d253AAh0BJkamDEjUjZurC9uxLq7c7sDQKAjyNSAxyMSH39CEhJOSG5uPcnICBO3YN3dud0BINARZGpgyZIDEhHxy+1p0yJd9YXGurtzuwNAoGOwbw34Qowbse4AgEBEkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBbnkamBlJQIycoKMbfXry95ptekpCj/7cTEYxIff1KCCevuzu0OAIGOIFMDixc3qPBkaLNnR/pvDx5cEHRfaKy7O7c7AAQ6di0BAABr0SNTA6mpB8WtWHcAQCCiRwYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAcG+Q+fnnn09NSQAAAM5EkCkqKpInnnhCWrZsKVFRUbJjxw7z+KOPPiqvvfZabRYJAABwZoLMk08+KSkpKfLf//3fEhb2n4vpde/eXebOnVubRQIAAJyZIPPGG2/InDlzZPTo0RISEuJ/PCEhQTZv3lybRQIAAJyZIJOTkyMdOnQod5fT8ePHa7NIAACAMxNkunbtKp988kmZxxcuXCi9e/euzSIBAABqLLTm/yLy2GOPydixY03PjPbCLFq0SLZs2WJ2OS1durQ2iwQAADgzPTI33HCDLFmyRD744AOJjIw0weabb74xjw0ePLg2iwQAADgzPTLq0ksvlZUrV9b23wEAAJwLMqqwsFByc3PN7qXi2rRpU9dyAQAAnJ4gs23bNrnjjjvk008/LfG41+sVj8cjJ0+erM1iAQAATn+QSUxMlNDQUDOwt0WLFia8AAAAWBFkMjMz5YsvvpDOnTvX6cVnzZplpqysLHO/W7duZuDwNddcU6flAgAAd6j1eWR++OGHOr94q1at5JlnnjGhaP369XLllVeaI6I2btxY52UDAIDgV6sg8+yzz8of/vAH+fjjj+XHH3+UvLy8ElN1XXfddXLttddKx44dpVOnTjJ16lRzEcq1a9fWplgAAMBlarVradCgQebvwIEDT9lgX/2f//mf/5EjR45I//79a1MsAADgMrUKMh999NEpK8CGDRtMcPn5559Nb0xqaqrZdVWegoICM/n4en+2b98ux44dEzfJzs42f7du3Sr79+8XN2Hd2e60effg/e7O97vSqwdUh8er3SgO0nPRaEM9fPiwuVbT3LlzZdWqVeWGmaSkJJkyZUq5R1GFhYWJ22jvl8ObzzGsO9vdbWjztHm3KSwslJSUFJMPoqOjT22Q+eqrr8pfmMcjDRo0MCfECw8Pl9rutmrfvr288sor1eqRad26tbnWU3x8vLiJJvT09HQZMWKExMbGipuw7mx32rx78H535/td6RHNw4cPrzLI1GrXUq9evSo9d0z9+vXl5ptvNmFEg01N6FmCi4eV4jQclReQmjRpInFxceImvm5Gbdysu3uw3WnzvN/dw83vd5Wfny+n7aglHceiRxrNmTPHnFNGJ7193nnnyfz58+W1114zvQV/+ctfKl3OpEmTZPXq1SZ16VgZva9HQo0ePbo2xQIAAC5Tqx4ZPUx6xowZMmTIEP9jPXr0MOeFefTRR+Xzzz83V8V++OGH5a9//WuFy9HrNI0ZM0b27NkjMTEx0rNnT1mxYgVX0AYAAKcvyGjvSdu2bcs8ro/pc77dTxpQKqM9NwAAALVVq11LemkCPSOvjij2OX78uHnMd9kCPWyqWbNmtS4YAADAaemRmTlzplx//fVmV5LuDlLaE6MntdMLSaodO3bIvffeW5vFAwAAnL4gc9FFF8nOnTtl3rx55tA4NXLkSLnlllukYcOG5v5tt91Wm0UDAACc3iCjNLDcfffdtf13AACAMxdk0tLS5JprrjHniNHbldHdTgAAAAETZIYOHSp79+6Vpk2bmtsVqe1FIwEAAE5bkNEz7pZ3u7hdu3bJ448/XuNCAAAAnLHDryty4MAB+fvf/34qFwkAAHBmggwAAMCZRJABAADWIsgAAAB3nEdm+PDhlT5/6NChupYHAADg9AQZvUJ1Vc/r1awBAAACLsgkJyefvpIAAADUEGNkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKwVMEHmmWeeEY/HIw8++KDTRQEAAJYIiCCzbt06eeWVV6Rnz55OFwUAAFjE8SCTn58vo0ePlldffVXOOeccp4sDAAAs4niQGTdunPz617+WQYMGOV0UAABgmVAnX3zBggXy5Zdfml1L1VFQUGAmn7y8PPN3+/btcuzYMXGT7Oxs83fr1q2yf/9+cRPWne1Om3cP3u/ufL+rnJwcqQ6P1+v1igN27dolffr0kZUrV/rHxgwYMEB69eol06dPL/d/kpKSZMqUKWUeT0xMlLCwMHEbHRzt0OZzHOvOdncb2jxt3m0KCwslJSVFDh8+LNHR0YEXZN59910ZNmyYhISE+B87efKkebPWq1fP9LwUf66iHpnWrVvLokWLJD4+XtxEE3p6erqMGDFCYmNjxU1Yd7Y7bd49eL+78/2usrKyZPjw4VUGGcd2LQ0cOFA2bNhQ4rHbb79dOnfuLI888kiZEKPCw8PNVFqTJk0kLi5O3MTXzaiNm3V3D7Y7bZ73u3u4+f3uOxioOhwLMg0bNpTu3buXeCwyMlIaN25c5nEAAICAPGoJAADAyqOWSvv444+dLgIAALAIPTIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWqFOF8AmaWnhsmZNmGRm1pfNm0OlsNDjf27v3n0SzFh3tjttnve7Gz7rYB+CTA3MmBEpGzfWFzdi3dnubkObd2ebh30IMjXg8YjEx5+QhIQTkptbTzIywsQtWHe2O22e9zsQiAgyNbBkyQGJiPjl9rRpka4KMqz7L/XAdqfNu4Gb3++wD4N9a8D3xnYj1t2d2O7u5ObtDvsQZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArMV5ZGogJSVCsrJCzO3160ue9TIpKcp/OzHxmMTHn5Rgwrqz3Wnz/8H7PXg/62AfgkwNLF7coMITQ82eHem/PXhwQdC9uVl3tntptPlf8H4Prs862IddSwAAwFr0yNRAaupBcSvW3Z3Y7u7k5u0O+9AjAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUcDTJJSUni8XhKTJ07d3aySAAAwCKhThegW7du8sEHH/jvh4Y6XiQAAGAJx1ODBpfmzZs7XQwAAGAhx8fIbNu2TeLi4uTcc8+V0aNHS3Z2ttNFAgAAlnC0R+aCCy6QlJQUOe+882TPnj0yZcoUufTSS+Xrr7+Whg0blpm/oKDATD55eXnm7/bt2+XYsWPiJr7At3XrVtm/f7+4CevOdqfNuwfvd3e+31VOTo5Uh8fr9XolQBw6dEjatm0rzz//vNx5553lDg7WsFNaYmKihIWFnaFSAsCZpwdDBNDH9RnFurtzuxcWFprOjsOHD0t0dLQdQUb17dtXBg0aJE8//XS1emRat24tL7/8suvG2WhS3bBhg/Tv319iYmLETVh3trtb2/yIESMkNjZW3ER7I9LT01l3l213lZWVJcOHD68yyDg+2Le4/Px8+fbbb+W2224r9/nw8HAzlaYr2KhRI3ET3bBKP9BZd/dgu7u7zeuXmY4pdBPfLhXW3V3b3ZcJAn6w74QJE2TVqlUmdX366acybNgwCQkJkVGjRjlZLAAAYAlHe2S+//57E1p+/PFHk7YvueQSWbt2reu6TgEAgIVBZsGCBU6+PAAAsJzj55EBAACoLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK1QpwsAAAgsaWnhsmZNmGRm1pfNm0OlsNDjf27v3n2Olg0ojSADAChhxoxI2bixPrUCKxBkAAAleDwi8fEnJCHhhOTm1pOMjDBqCAGLIAMAKGHJkgMSEfHL7WnTIgkyCGgM9gUAlOALMYANCDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANbiPDIAgBJSUiIkKyvE3F6/vuQZfpOSovy3ExOPSXz8SWoPjiLIAABKWLy4QYUnwZs9O9J/e/DgAoIMHMeuJQAAYC16ZAAAJaSmHqRGYA16ZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALCW40EmJydHbr31VmncuLFERERIjx49ZP369U4XCwAAWCDUyRc/ePCgXHzxxXLFFVfIsmXLJDY2VrZt2ybnnHOOk8UCAACWcDTIPPvss9K6dWtJTk72P9auXTsniwQAACzi6K6ltLQ06dOnj4wcOVKaNm0qvXv3lldffdXJIgEAAIs42iOzY8cOmTVrlowfP17+9Kc/ybp16+T++++XsLAwGTt2bJn5CwoKzOSTl5dn/u7evVuOHz8ubrJ//37/GKPDhw+Lm7DubHe3tvmtW7f6b7tFdna2+cu6u2u7+77fqsPj9Xq94hANLNoj8+mnn/of0yCjgSYjI6PM/ElJSTJlypQyjycmJpplAUCw8ng84uDHtaNYd3du98LCQklJSTE/XKKjowOzR6ZFixbStWvXEo916dJF3nnnnXLnnzRpkum9Kd4jo2Ns+vXrJ82bNxe3JdUNGzZI//79JSYmRtyEdWe7u7XNjxgxwhwU4SbaE5Oens66u2y7q6ysLBNkquJokNEjlrZs2VKm0bZt27bc+cPDw81Umia1Ro0aiZv4utb1A511dw+2u7vbvH6ZxcXFiZv4dqWx7u7a7io/P18CfrDvQw89JGvXrpWnnnpKtm/fLvPnz5c5c+bIuHHjnCwWAACwhKNBpm/fvpKamipvvfWWdO/eXZ544gmZPn26jB492sliAQAASzi6a0n95je/MRMAAIB1lygAAACoLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK1QpwsAAAgsaWnhsmZNmGRm1pfNm0OlsNDjf27v3n2Olg0ojSADAChhxoxI2bixPrUCKxBkAAAleDwi8fEnJCHhhOTm1pOMjDBqCAGLIAMAKGHJkgMSEfHL7WnTIgkyCGgM9gUAlOALMYANCDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANbiPDIAgBJSUiIkKyvE3F6/vuQZfpOSovy3ExOPSXz8SWoPjiLIAABKWLy4QYUnwZs9O9J/e/DgAoIMHMeuJQAAYC16ZAAAJaSmHqRGYA16ZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALCWo0EmPj5ePB5PmWncuHFOFgsAAFgi1MkXX7dunZw8edJ//+uvv5bBgwfLyJEjnSwWAACwhKNBJjY2tsT9Z555Rtq3by+XX365Y2UCAAD2CJgxMoWFhfLmm2/KHXfcYXYvAQAABHSPTHHvvvuuHDp0SBITEyucp6CgwEw+hw8fNn/37dsnbrN//34T/vbu3StHjx4VN2Hd2e5ubfNZWVmSn58vbpKTk8O6u3C7q+zsbPPX6/VKZTzequY4Q4YMGSJhYWGyZMmSCudJSkqSKVOmnNFyAQAA5+zatUtatWoV2EHmu+++k3PPPVcWLVokN9xwQ7V7ZLQHp23btia1xcTEiJvk5eVJ69atzQaOjo4WN2Hd2e60effg/e7O97vSePLTTz9JXFyc1KtXL7B3LSUnJ0vTpk3l17/+daXzhYeHm6k0DTFu3MhK15t1dx+2O+93t6HNu7PNx1Sjk8Lxwb5FRUUmyIwdO1ZCQwMiVwEAAEs4HmQ++OADs2tIj1YCAACoCce7QK666qoqRyRXRHczTZ48udzdTcGOdWe7uw1tnjbvNm5u8zUREIN9AQAArNy1BAAAUFsEGQAAYC2CDAAAsJbVQWbmzJkSHx8vDRo0kAsuuEA+//xzCXarV6+W6667zpwgSK9JpZd2cIunn35a+vbtKw0bNjTnHRo6dKhs2bJF3GDWrFnSs2dP/7k0+vfvL8uWLRM30ovLatt/8MEHJdjp2cx1XYtPnTt3FjddnuDWW2+Vxo0bS0REhPTo0UPWr18vwU6/10pvd53GjRvndNECkrVB5u2335bx48ebEd1ffvmlJCQkmMsc5ObmSjA7cuSIWVcNcW6zatUq80Zeu3atrFy5Uo4fP26OetM6CXZ6em79Av/iiy/MB/mVV15pzoK9ceNGcZN169bJK6+8YkKdW3Tr1k327Nnjn9asWSNucPDgQbn44oulfv36JrRv2rRJnnvuOTnnnHPEDe28+DbXzzs1cuRIp4sWmLyW6tevn3fcuHH++ydPnvTGxcV5n376aa9b6OZLTU31ulVubq6pg1WrVnnd6JxzzvHOnTvX6xY//fSTt2PHjt6VK1d6L7/8cu8DDzzgDXaTJ0/2JiQkeN3okUce8V5yySVOFyMgaFtv3769t6ioyOmiBCQre2T0KrD6y3TQoEH+x/Q6DHo/IyPD0bLhzPFd/bxRo0auqvaTJ0/KggULTE+U7mJyC+2N08uYFH/fu8G2bdvMrmS9Ht3o0aP9VwQOdmlpadKnTx/TC6G7knv37i2vvvqquI1+37355pvmpLG6ewllWRlkfvjhB/Nh3qxZsxKP6/29e/c6Vi6c2Utb6BgJ7Xru3r27K6p+w4YNEhUVZU6Odffdd0tqaqp07dpV3ECDm+5C1nFSbqJj/1JSUmT58uVmnNTOnTvl0ksvNRfSC3Y7duww69yxY0dZsWKF3HPPPXL//ffL66+/Lm6i4yD1AsmJiYlOFyVgOX5mX6C2v86//vpr14wXUOedd55kZmaanqiFCxea65PpuKFgDzN65d8HHnjAjBPQgf1ucs011/hv67ggDTZt27aVf/7zn3LnnXdKsP9Y0R6Zp556ytzXHhl9z8+ePdu0fbd47bXXTDvQXjkEUY9MkyZNJCQkRPbt21ficb3fvHlzx8qFM+O+++6TpUuXykcffWQGwbpFWFiYdOjQQc4//3zTM6GDvmfMmCHBTncj6yD+X/3qV+bCsjppgHvhhRfMbe2ddYuzzz5bOnXqJNu3b5dg16JFizIhvUuXLq7Ztaa+++47cz3Cu+66y+miBLR6tn6g64f5hx9+WCK96303jRlwGx3frCFGd6mkp6dLu3btxM20zRcUFEiwGzhwoNmtpr1Rvkl/qet4Eb2tP2rcIj8/X7799lvzJR/sdLdx6dMrbN261fRIuUVycrIZH6RjwxCEu5b00GvtXtQPtH79+sn06dPN4Mfbb79dgv2DrPivMd1nrh/mOuC1TZs2Euy7k+bPny+LFy8255LxjYeKiYkx55gIZpMmTTLdy7qNdXyE1sPHH39sxg4EO93WpcdBRUZGmnOLBPv4qAkTJpjzRumX9+7du83pJjS4jRo1SoLdQw89JBdddJHZtXTTTTeZ84TNmTPHTG75oaJBRr/ntOcRlfBa7MUXX/S2adPGGxYWZg7HXrt2rTfYffTRR+aQ49LT2LFjvcGuvPXWKTk52Rvs7rjjDm/btm1NW4+NjfUOHDjQ+/7773vdyi2HX998883eFi1amO3esmVLc3/79u1et1iyZIm3e/fu3vDwcG/nzp29c+bM8brFihUrzOfbli1bnC5KwOPq1wAAwFpWjpEBAABQBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgACQlJSkvTq1cvpYgCwDEEGwCmh1776/e9/L+eee66Eh4dL69atzXWCil/cFQBONa5EBaDOsrKyzNWKzz77bJk2bZr06NFDjh8/bi5qqRf73Lx5M7UM4LSgRwZAnd17773i8XjMFYpHjBghnTp1km7dupmr1K9du9bMk52dLTfccINERUVJdHS0uaLxvn37Kr367+OPPy6tWrUyPTy622n58uUlwpO+5qJFi+SKK66Qs846SxISEiQjI8M/T0pKiglXGqi6dOliXvvqq6+WPXv2lHituXPnmucbNGggnTt3lpdffplWAViCIAOgTg4cOGAChva8REZGlnleg4SGEg0xOu+qVatk5cqVsmPHDrn55psrXO6MGTPkueeek7/+9a/y1VdfyZAhQ+T666+Xbdu2lZjvz3/+s0yYMEEyMzNNgBo1apScOHHC//zRo0fNMv7xj3/I6tWrTaDS+X3mzZsnjz32mEydOlW++eYbeeqpp+TRRx+V119/nZYB2MDpy28DsNtnn33m1Y+SRYsWVTjP+++/7w0JCfFmZ2f7H9u4caP5v88//9zcnzx5sjchIcH/fFxcnHfq1KklltO3b1/vvffea27v3LnT/P/cuXPLLPObb74x95OTk8397du3++eZOXOmt1mzZv777du3986fP7/E6zzxxBPe/v3716o+AJxZ9MgAqOuPoSrn0Z4OHfyrk0/Xrl1Nb40+V1peXp7s3r3bjLspTu+Xnr9nz57+2y1atDB/c3Nz/Y/pLqf27duXmMf3/JEjR+Tbb7+VO++80+x28k1PPvmkeRxA4GOwL4A66dixoxmr4tSA3vr16/tvazmU7soq73nfPL7wlZ+fb/6++uqrcsEFF5SYLyQk5LSWG8CpQY8MgDpp1KiRGb8yc+ZM08NR2qFDh8xA2l27dpnJZ9OmTeY57ZkpTQcDx8XFyb///e8Sj+v98uavrWbNmpnX0fE6HTp0KDG1a9fulL0OgNOHHhkAdaYhRnf79OvXzxxppLt7dMCtDuqdNWuWCS16SPbo0aNl+vTp5jk90unyyy+XPn36lLvMiRMnyuTJk81uIT1iKTk52Qzo1cG5p9KUKVPk/vvvl5iYGHNEU0FBgaxfv14OHjxojroCENgIMgDqTE+C9+WXX5ojfx5++GFzeHNsbKycf/75Jsjo7pzFixebE+ZddtllUq9ePRMaXnzxxQqXqeHi8OHDZnk6pkV7YtLS0syurFPprrvuMuNo9Pw3Gp70yCsNXQ8++OApfR0Ap4dHR/yepmUDAACcVoyRAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAEBs9f+rgNm04Jni9wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARyNJREFUeJzt3Ql4FFW6//E3LElYDAJhCyBRRJHFiLK6BsUNR3bGK6igMHdkGVkElJlRQEdwhnFhHFZhEhlH9OIQIaAiDgIyBjRwcwFlC4IwgUAUJIQlC+n/8x7/XSYhOyTdp+v7eZ56uqu60l2n6nTlV6dOVQd5PB6PAAAAWKiKrxcAAACgvAgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDK4KLGxsRIUFGSG6Oho1qYLREZGOtt83bp1Pl2Wf/3rX86y/O1vf6uQzxg6dKjzGVOnTq2Qz0B+up6961zXvz/68ccfJSwszCzjo48+6uvFcTWCDAoNJXmH4OBgadq0qfTr169C/3G9/vrrZgemw4EDB9gyAU7/EXi3d3kCQm5urjz99NPmefPmzflngkp1+eWXy8iRI83zf/zjH7Jlyxa2gI9U89UHwx7Z2dly+PBhiYuLM8Nf/vIX+c1vflMhQea7774zz7V1R4/8EdhBZtq0ac54WcPMBx98IP/3f/9nnv/617+W6tWrS0X43e9+J8OHDzfPr7jiigr5DNhp1KhR8qc//Un0JwtffPFFUydR+WiRQZE+//xzM7zzzjtyzTXXONMnTpwox44dY83Bp+bMmeM8f/jhhyvsc1q1aiW33nqrGQItyGRkZPh6EaymLYG33HKLeb5y5UpJSUnx9SK5EkEGRfLuvPWfxLx585zpmZmZ8sUXXxS75n744Qd58sknpUuXLtKkSRMJDQ2VGjVqyNVXXy2/+tWv5Ntvv73gfLi3NUZ179690H4Jx48fl+eee06ioqKkdu3a5j3btm1r5im4U963b5888cQTcuONN0qjRo3MKbJatWpJmzZtZNy4cReEseLOy2sLkfc1PQVX2lMfb731lvTo0UPCw8PN5+ty3HXXXWanl5eujxEjRpj1o+tKy6ZlfP75503LRXHL+eGHH8pNN91k/q5ly5by17/+1cy3d+9e6dWrlzmPr83g//Vf/yVpaWnFlmvhwoVy/fXXm/dq1qyZPPPMM3Lu3Dkprf/85z8yduxYad26tdk2Wg5dttdee8207OX93CuvvDLf3+Y9nVnSKUwtx9q1a81z/ayrrrqq2L5bmzdvlttvv11q1qxpyqXr8Pz585KammpOSdWrV88s6wMPPGDqTWn6yBTcDv/+97/lzjvvNHWsTp068tBDDxUa+Eu7jpRu+wkTJjjzhoSESEREhNxxxx3mgOLMmTMlbpOCy//2229Lhw4dzDZ+5JFHyrxckydPdt5PW8IK0jrsff2TTz4pV7mLo9tt/vz5ctttt0ndunXN96pFixZmv7J///5C/0aXo3fv3tK4cWMzf4MGDcx3Qw/UCtq0aZOZV/db2sqn3x8tU//+/c0ppIK0zniXa+nSpaUuBy4hD/D/xcTEeLRKeIe8tm7dmu+1995774K/ueOOO5z5d+7cmW/+gkPdunU9+/btM/NOmTKl2Hn1dbV3715Ps2bNipyvXbt2nh9++MFZho8++qjY942MjPScOHHCmT/vcgwZMiRf+bVs3te0zCU5d+6c55577inys8eMGePMu27dOk/t2rWLnPfKK6/0/Oc//yl0OVu2bOmpUqXKBX/zzDPPeOrVq3fB9HvvvbfIcrVp06bQz7/vvvs8ubm5zt+0aNHCee2zzz5zpickJHguv/zyIsvRvXt3s14Kfm5hQ973Lcz7779f5LYqWC+1ztSsWfOCz/j1r3/tueqqqy6Yruvh/Pnzznvp+xesiwW3g26jatWqlbi+y7KO1O23317sejpy5Eix66ng8rdq1Srf3/fu3bvMy7Vnzx5nutaxrKysfOXzvqb1xLsey1ruor6LZ86cMfMW9T76GZs3b85Xfv0uFDW/fnfmzp2bb78VEhJS5PwFt6dau3at83qvXr1K3B649GiRQYn0SEpbBvK64YYbiv0bPVJ64YUX5L333pOPP/7YHGHHx8c7R4AnTpyQV155xTzXVhM9MtKjJS/th+M9taWvK/1bXRZvi43219H31KNTtWPHDnPE56VHaS+//LK8//775ohMl0H/5r777jOva4fiN998s0JqgPb98B6N6pHpf//3f8uKFSvkn//8p1nGyy67zLymrR2DBg1yWpM6d+4sy5Ytk8WLF5sO1kqPMvXvC6OtBwMHDpRVq1aZI0avP/7xj+YzdP2/8cYbzvTVq1fL7t27C32vnTt3yqRJk0wLz/jx453puv309GJxtJVOWyC8rUe6LLpMuu61hUd99tln8tJLL5nnukwFj16921sHbTEozvbt2/Od+imO1plu3bqZuqKtXl56VK/Lq1c7/f3vfzetBOqbb76RNWvWSFnoNtI6qdt4ypQpha7vsq6j77//XjZs2OCcwnj33XfNVVraoqItZe3atTN1qyy0lU5PhWi90M/WVrqyLpeub23d8raQfvTRR877560njz/+uFSpUqXM718cbVHSeZW26MXExJjvmbb+Kv0MbUHOyckx47ps+l1Qun21P4tuW933aOuWtppqf789e/aYebSlVJdX6fdK675+H7SuDB482LSsFpT3tPu2bdvKtD1wiVRAOEKAtMgUNeQ9QiqqRUatXLnS88ADD3gaN25c6NHqjTfemG/+oo701fbt253Xqlev7lm9erXn888/N0Peo3N97dSpU87fLV682HPnnXd6wsPDPVWrVr1gGfr163fJW2S09aJBgwbO/OPGjSty3uXLlzvzBQcHew4fPpxv/XlfCwoK8hw9evSC5YyIiPBkZ2eb6V9++WW+sn344YfOe7Vt29aZvmLFikLLNXDgwHzL9otf/KLQI83CtlN8fLwzTcu+YcMGZ/u88cYbzmtNmjRx3mf//v35lrcsRo4c6fxd3iPqwuplaGio01J37NixfJ85Z84c52+0rnqn/+UvfylTi4zWL20t8GrduvUF67us6+js2bNOnW3fvr1ny5YtZlpZ5V3+pk2bXvAe5dl2b731ljP9l7/8pZmWk5PjadiwodPS8d1335X7/Qv7Lhb8Xr366qvO++igf+997eOPPzZ/079/f2fao48+mm/+nj17Oq89++yzZv4FCxY4055++mlThrytkYXR7e79G235Q+XjqiWUmp5X1l76v/3tb0ucV49yhw0bVuw82ipTWnqU7KXn0++9995C59PX9AhYz71rK5JeSXCplqG09Eg6b18UvWy9KLt27XKea/8WPS/vpf2TvPSqCC1Xw4YN8/29tuBUq/bT17h+/fr5XtNWCK+8R5J6FF2YvJ/nHff25dEj+dJuHy2794i9oCNHjpj+UwWX9WLouimO9snQPjCXYh0VRd/H26JT8HO871WedTRkyBDzXdIWKK3T2sKhHY6175m2eBT1PShKz549Td+YvMqzXAMGDDAtGenp6aal69SpU6bfnLdPkPYL83aMvlR1Q/827/cqb6thQdo6q+sm72drq5sORc2vtG+M7je075S22uig21XrkPZ/GjNmjGkdK0v9Q8Xj1BKK5G3m185vegrj6NGjptm8NJe56ikdLz2Vo03u+l7asc9Lm3Urgp6m0UDz6quvOtO0WVibmXUZ9PRJYcuQt5ne2zTtVbCTrL/QTqVe+k8uL+3gWxhf73gvxZUyGqpLGzoqYx15g5KXN1yW573yrqMFCxaYU0l6CkhPJWlHVT0lqqeG9Hu1fPnyMr1v3qBcHt7l0k7Tukzq7Nmz5nRo3tNKJR3ElPT+F6us7+OdXw8Utm7dak6L33333SaM6enf//3f/zWhRjsYa3jLK2/9K3iggcpBkEGJVy3p0Z9eFVKW8/EHDx50ns+cOVMefPBB817F7WDy/pMpGHKuu+4657keIem5cP0HUXDQ99c+M3pkd/r0aedv9Kor3fHrMuhrRfXr8fL2xfG2RhTVr6QwemSf9x+t9sspyPvPTY/0vDQs6pGgl14F46Xr/tprr5WKlPfzCo7rVRvFybt9dOevQbKo7aN9lwoLFWUJtu3bt3eel2Xb+FJ515GG8CVLlphWGa3T+n3y0ullUdh3uDzLVTCs6NVu3nquLSp9+vS56PcvSL9TeVvNtP9RUe/j7aeU97P1aqvC5terjbz9fHRcw55eGal9b/RKSg0q3pY7HS94xWbe+pe3XqLycGoJFUKDj3YeVX/4wx/MTk/vfFlchz7dAXovn9TLlnUnrke22iFQdxCdOnWSr776yhwBajPvU089ZZp5tbVE/04vx9V/hp9++qm5zFkvg/WGGT0dpmFK59EOgoXJ22lPO1lq07XueLXjse7syvLPQsvrbZXSG/3pZbJ6maa29GhA0OZ9Pe11zz33mMtp9YaDWVlZ0rdvX9ORU3fGuuP1uv/++yv8aE87X+pnahDU9ZT3EvFf/vKXxf6tHr3qtjh06JAJsdqsr5fD6jLrKQMNafqPQTuKete/tmLouvKGOm2t01Nlut299+Yoip6e8P7tl19+KTYozzrSAKmng/S0ktYTrYfeDsCqLJfGX8rlUrqttJVIT8ts3LjRma6Xs2vL0cW+f0G6vfV0mjfIPfbYY/Lss8+aZdDvi763th5rvfW2muj3UFuLlP6d7h+07mgd0/m1c662aukpJ71MXzuga0uunmLSfZguo343817WXXCd561/3gsPUMl80C8HFl5+XZq/ydvZd968eYV2FI6Ojnaea6fRvCZPnlzo32jHPO9ln8Vdfl1wGbQDX0nLkHd+7ayYt5Omd6hTp46nefPmpe7sq7RD5V133XXJLr8+dOhQiZ2Si+s8W1Rn5bzTO3ToUOjn33333fkuRy6qU/YXX3xR7CW2BZdXdevW7YJ5tINrafTo0cP5m+Tk5HyvFdcJPe9n6TorqVNvaTr7lrZzeFnXUXGXAuvwz3/+s8T1VNTy51Webadee+21C+bTjvkX+/7FXX6d9/tb1JDXpEmTSpzfW4+XLFlS7Hy6/0lPT8/3/rfccotTbw8ePFji9sClx6klVAi9UdbcuXPNqRNtfdCjLW2ZKHgZd16///3vzd/pUVBhTeD6HnoEpe+hl+fqDbX0EkptNdGjLG3tyXvjPm3x0EGPrHQZtGVHb2ilHSgLU7VqVXN0pqegtA+AXr6sR2Z6lFfwhmsl0c/To8xFixaZy3K19UFbl7R5XFuTtDNk3qO4pKQkU3b9HD2a1dNn2gql60TP2etN3CqatnBpS5iuJ++N1/RmbLpOCp4GKow2v+vpD23J0psU6jrUcuhlsnpUri0u2vcgLz0S1hYH7+XoZZH3UuqSLg/3F2VdRzNmzDA3btOf69D6rnVU65DWUb0suLiO5BW5XF56S4S8rS/eVppL9f4F6d9oi6v2HdIWFO/3SltgtdVKb3RZ8GaKevm1fhe1tdN7kzs9jaw3xtRWHW2J7Nq1q5lXT6Nrndfl9d48T78L2jKml3gnJCTkq6vaquM91aQtrgU7AqNyBGmaqaTPAuBn9J/B+vXrzXNt1vfXXxoujJ4m0Ls26+8t6T8QPUVRUb+3BBRGLxzQU1Z64KWnvTVMofLRIgPAStpK5L2pova/0JsIApVFLzjwtgBrh2xCjO/Q2ReAtfR3q2hUhi/opfsFL8WGb9AiAwAArEUfGQAAYC1aZAAAgLUIMgAAwFpWd/bVyy/1rot6XX9Zf84eAAD4L+3Irz9Iqve0Ku5eVlYHGQ0x3IAIAIDApbdXKO6moFYHGe8dFvVeEnpnRzfREKc/Ua930gwLCxM3ll3veJr3R+TcIDk52fzWDmVnu7utzrt5X+fGsqujR4/K008/XeKdv60OMt7TSRpiKuMW7v5Ef0FWb5+tt9HW23S7sex623ZtcnQT/cFMys52d2Odd/O+zo1lz6ukriN09gUAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBa1Xy9APBvKSkpMmzYMDl37pwZ79ixo8ycOVOCgoKceTwej0yYMEG2bNlixkNDQ2XhwoXSrFkzCQQrVoTIxo3BkpRUXXbtqiZZWT+XPTX1qE+XDagIRzKOyOrvVkvC4QTZfWK3HDtzTNKz0iUsOEza1m8rA68ZaIa8+wHbuXlfl2J52WmRQbGaNm0qI0eOdMYTExMlLi4u3zw67q3casSIEX5RuS+VWbNqyeLFNWXbtur5QgwQqN7f+748+/mzsnzfctl1fJccP3dccnJzzOPnKZ/LU589JUM+HiLnc89LoHDzvq6p5WUnyKBEvXr1kq5duzrjCxYskEOHDpnn+jh//nzntc6dO0vv3r0Daq3qQUlkZI707n1OunXL8vXiAJWmYc2G8nDrh+XZTs/K4NaDJbRqqPPaJ999Iu/ufjegtoab93W9LC47QQalMnHiRAkLCzPPtflx+vTpkpWVZR4zMzPNdH190qRJAbdG4+OPy6ZNP8j8+Sfl5psJMgh8TWs3lb/e+VfZ+shWeS36NRl701h5JfoVebvn2/nmW3twrQQaN+/rJlpadoIMSqV+/foyfvx4Z3znzp2maVEfvcaNGyfh4eEBt0Zr1PD1EgCVq1+rfjLgmgFSrUr+bpS3Nr1V6oXWc8azcgMv2Lt5X1ff0rITZFBq0dHR0qNHD2d83759znOd3r17d9YmEMC8nX69OjTsIIHIzfu6aAvLTpBBmYwZM8ak9rzq1q1rpgMIXNrZd8L6CeZRhdcIl8faPCaBys37ujGWlZ0ggzJJS0uT9PSfj8jUqVOnJDU1lTUJBKiMrAx57KPHTAdfVbt6bVl832ITZgKVm/d1aZaVnSCDUsvJyTGdvrKzswudrp3CAASWlIwU6bW8l6w99FPH3vqh9WXpg0vlxkY3SqBy874ux8KyE2RQajExMZKcnOyM9+nTx3m+f/9+WbRoEWsTCCBJx5Kk57Ke8s0P35jxlnVayqq+qwK2b4yXm/d1MRaWnSCDUtmxY4csWbLEGe/Zs6eMHTvWPHotXbpUtm3bxhoFAsCH+z+Uviv6ytEzP929umuTrrKy70qJrBMpgczN+7odlpadnyhAic6ePSszZsyQ3NxcM964cWMZPXq0ea6PSUlJcvjwYfO6zqeJvWbNmgGzZmNja8iBA1XN88TE6vlemzq1tvN86NCzEhkZOHc6hXut2LdCnvz0Scn1/PSd158miG4WLUt2/fxPzjv9kTaPSKBw877urMVlp0UGJZozZ475LQ5TYapUkcmTJzsVWB91XKerI0eOyOzZswNqrS5fHirz5tUyQ2JicL7XvNN1SEnh64TAsPv4bifEKL3k+uWvXpYXNr2Qb3h96+sSSNy8r5tjcdnZ86JYmzdvlvj4eGd8wIABEhUVlW+e9u3by6BBg5zxVatWSUJCAmsWgDXcvK/bbHnZObWEYnXp0kXWrVtX4loaPny4GQJRXNwJXy8CUKkmdppoBjdx876ui+Vlp0UGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtfwiyMyePVsiIyMlNDRUunTpIl9++aWvFwkAAFjA50Hmvffek/Hjx8uUKVNk69atEhUVJffee68cO3bM14sGAAD8nM+DzKuvviq/+tWv5PHHH5c2bdrIvHnzpGbNmvK3v/3N14sGAAD8XDVffnhWVpZs2bJFJk+e7EyrUqWK9OjRQxISEi6YPzMz0wxe6enp5vHw4cOSnZ0tbpKWlmYeU1JS5OTJk+LGsu/Zs8d57hYHDx40j5Sd7e62Ou/mfZ0by65Ku3/3aZD5/vvv5fz589KoUaN803V8165dF8w/Y8YMmTZt2gXTv/nmGwkODhY32r59u7hRUFCQrF27VtyIsrPd3cit+zo3lz0rK8v/g0xZacuN9qfJ2yLTvHlz6dy5szRu3FjcRBO6Vu5u3bpJnTp1xI1l79+/vzRo0EDcRFtiNMBRdra72+q8m/d1biy7Sk1NldjYWPHrIBMeHi5Vq1aVo0eP5puu44UFk5CQEDMUFBYWJvXq1RM38TYzauV2a9k1xERERIgbm1opO9vdbXXezfs6N5ZdnTlzRvy+s6+eDrrpppvkX//6lzMtNzfXjGsCBQAA8OtTS3qqaMiQIdKxY0dziuj111+X06dPm6uYAAAA/DrIPPTQQ6bp8Pnnnzfnw2644Qb5+OOPL+gADAAA4HdBRo0ePdoMAAAAVt0QDwAAoLwIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrVfP1AtggJSVFhg0bJufOnTPjHTt2lJkzZ0pQUJAzj8fjkQkTJsiWLVvMeGhoqCxcuFCaNWvms+XGxTuScURWf7daEg4nyO4Tu+XYmWOSnpUuYcFh0rZ+Wxl4zUAz5K0LgO3cWO/dvJ9PsbzstMiUQtOmTWXkyJHOeGJiosTFxeWbR8e9G1iNGDHCLzYwLs77e9+XZz9/VpbvWy67ju+S4+eOS05ujnn8POVzeeqzp2TIx0PkfO55VjUChhvrvZv3800tLztBppR69eolXbt2dcYXLFgghw4dMs/1cf78+c5rnTt3lt69e1/qbQUfalizoTzc+mF5ttOzMrj1YAmtGuq89sl3n8i7u99l+yDguK3eu3k/38vishNkymDixIkSFhZmnmsT3PTp0yUrK8s8ZmZmmun6+qRJkypma6HSNa3dVP56519l6yNb5bXo12TsTWPllehX5O2eb+ebb+3BtWwdBAw313s37+cnWlp2gkwZ1K9fX8aPH++M79y50zSv6aPXuHHjJDw8/NJuJfhMv1b9ZMA1A6RalfzdyW5teqvUC63njGflZvlg6YCK4eZ67+b9fH1Ly06QKaPo6Gjp0aOHM75v3z7nuU7v3r37pds68Fvezo9eHRp28OnyAJXBLfXezfv5aAvLTpAphzFjxpjkmlfdunXNdAQ+7fQ4Yf0E86jCa4TLY20e8/ViARXKbfXezfv5MZaVnSBTDmlpaZKe/vNRiTp16pSkpqZequ0CP5WRlSGPffSY6eioalevLYvvW2x26kCgcmO9d/N+Ps2yshNkyignJ8d0fMrOzi50unaMQmBKyUiRXst7ydpDP3VwrB9aX5Y+uFRubHSjrxcNqDBurPdu3s/nWFh2gkwZxcTESHJysjPep08f5/n+/ftl0aJFl27rwG8kHUuSnst6yjc/fGPGW9ZpKav6rgrYPgKAm+u9m/fzMRaWnSBTBjt27JAlS5Y44z179pSxY8eaR6+lS5fKtm3bLu1Wgk99uP9D6buirxw9c9SMd23SVVb2XSmRdSLZMghYbq33bt7P77C07PxEQSmdPXtWZsyYIbm5uWa8cePGMnr0aPNcH5OSkuTw4cPmdZ1PU2vNmjUrbsuhUqzYt0Ke/PRJyfX8tN31Fu3RzaJlya6fv+ze6Y+0eYStgoDg1nrv5v38WYvLTpAppTlz5pjfo1BVqlSRyZMnOxtRH3Vce3TrRj5y5IjMnj3b3FwIdtt9fLezM1d66enLX718wXzNajcLqB063M2t9d7N+/k5FpedU0ulsHnzZomPj3fGBwwYIFFRUfnmad++vQwaNMgZX7VqlSQkJFzKbQUAqCBu3s9vtrzstMiUQpcuXWTdunUlzjd8+HAzIHBM7DTRDICbuLHeu3k/38XystMiAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFo+DTIbNmyQBx98UCIiIiQoKEg++OADXy4OAACwjE+DzOnTpyUqKkpmz57ty8UAAACWqubLD7///vvNAAAAYF2QKavMzEwzeKWnp5vHw4cPS3Z2trhJWlqaeUxJSZGTJ0+KG8u+Z88e57lbHDx40DxSdra72+q8m/d1biy7Ku3+Pcjj8XjED2gfmbi4OOnTp0+R80ydOlWmTZt2wfShQ4dKcHBwBS8h/InWFz+pupWOsrPd3YY67846n5WVJbGxsSbEhYWFBUaLzOTJk2X8+PH5WmSaN28unTt3lsaNG4ubaELfvn27dOvWTerUqSNuLHv//v2lQYMG4ibaErN27VrKznZ3Deq8O7/v6sCBAybIlMSqIBMSEmKGgjSp1atXT9zE28yoIcatZdcvtl7x5samVsrOdncL6rw7v+8qIyNDSoP7yAAAAGtV83XaSk5Odsb3798vSUlJpoXhiiuu8OWiAQAAC/g0yCQmJkr37t2dcW//lyFDhpTqvBgAAHA3nwaZ6Oho1155AgAALh59ZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrVfP1AsC/paSkyLBhw+TcuXNmvGPHjjJz5kwJCgpy5vF4PDJhwgTZsmWLGQ8NDZWFCxdKs2bNJBCsWBEiGzcGS1JSddm1q5pkZf1c9tTUoz5dNqAiuLnOH8k4Iqu/Wy0JhxNk94ndcuzMMUnPSpew4DBpW7+tDLxmoBny7gMDxRFLy06QQbGaNm0qI0eOlFdffdWMJyYmSlxcnPTr18+ZR8e9IUaNGDEiYEKMmjWrlnz9dXVfLwZQadxc59/f+768tPmlC6YfP3dcPk/53Awrv10pMffGSNUqVSWQvG9p2Tm1hBL16tVLunbt6owvWLBADh06ZJ7r4/z5853XOnfuLL179w6otaoHH5GROdK79znp1i3L14sDVDjqvEjDmg3l4dYPy7OdnpXBrQdLaNVQZ/188t0n8u7udwO2Jja0rOy0yKBUJk6cKI8//rikp6eb00zTp0+XWbNmmcfMzEwzT1hYmEyaNCng1mh8/HGpUeOn5zNn1pKEhGBfLxJQodxc55vWbip/vfOv0ufqPlKtys//Ivu26isD4gc442sPrpXB1w2WQNLU0rLTIoNSqV+/vowfP94Z37lzpzmFpI9e48aNk/Dw8IBbo94dOuAWbq7z/Vr1kwHXDMj3j1zd2vRWqRdazxnPyg281tl+lpadIINSi46Olh49ejjj+/btc57r9O7du7M2AQQkb8dXrw4NO4hbHPPzshNkUCZjxowxrTN51a1b10wHgECUk5sjE9ZPMI8qvEa4PNbmMXGDHAvKTpBBmaSlpZl+MnmdOnVKUlNTWZMAAk5GVoY89tFjppOrql29tiy+b7H5hx7oMiwpO0EGpZaTk2M692ZnZxc6PSvLv86bAsDFSMlIkV7Le8naQ2vNeP3Q+rL0waVyY6MbA37FplhUdoIMSi0mJkaSk5Od8T59+jjP9+/fL4sWLWJtAggISceSpOeynvLND9+Y8ZZ1Wsqqvqv8rn9IRbCt7AQZlMqOHTtkyZIlznjPnj1l7Nix5tFr6dKlsm3bNtYoAKt9uP9D6buirxw989NdjLs26Sor+66UyDqREug+tLDs3EcGJTp79qzMmDFDcnNzzXjjxo1l9OjR5rk+JiUlyeHDh83rOp+2zNSsWTNg1mxsbA05cOCnu1gmJua/2+nUqbWd50OHnpXIyPOVvnzApebmOr9i3wp58tMnJdfz0/5Ob88f3Sxaluz6+UDOO/2RNo9IIFlhadkJMijRnDlzzG8uqSpVqsjkyZOdoKKPOq5XLWmQOXLkiMyePdvcQC9QLF8eWuQNwebNq+U8v/vuzIDbqcOd3Fzndx/f7fwjV3rZ8ctfvXzBfM1qN/Orf+ZuLjunllCszZs3S3x8vDM+YMAAiYqKyjdP+/btZdCgQc74qlWrJCEhgTULAKhwtMigWF26dJF169aVuJaGDx9uhkAUF3fC14sAVCo31/mJnSaawY0mWlp2WmQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYy6dBZsaMGdKpUye57LLLpGHDhtKnTx/ZvXu3LxcJAABYxKdBZv369TJq1CjZtGmTrFmzRrKzs+Wee+6R06dP+3KxAACAJar58sM//vjjfOOxsbGmZWbLli1y++23+2y5AACAHXwaZAo6efKkeaxXr16hr2dmZprBKz093TwePnzYtOa4SVpamnlMSUlx1pvbyr5nzx7nuVscPHjQPFJ2trtbUOfd+X33/n8rjSCPx+MRP5Cbmyu9evWSH3/8UTZu3FjoPFOnTpVp06ZdMH3o0KESHBwsbhMUFCR+svkqHWVnu7sNdZ467zZZWVnmTI0erIeFhfl/kBkxYoR89NFHJsQ0a9as1C0yzZs3l2XLlklkZKS4iSb0tWvXSv/+/aVBgwbiJpSd7U6ddw++7+78vqsDBw5Iv379SgwyfnFqafTo0bJy5UrZsGFDkSFGhYSEmKGg8PBwiYiIEDfxNjNq5abs7sF2p87zfXcPN3/fVUZGhpSGT4OMNgb95je/kbi4OFm3bp1ceeWVvlwcAABgGZ8GGb30+p133pHly5ebe8mkpqaa6XXq1JEaNWr4ctEAAIAFfHofmblz55pzX9HR0dKkSRNneO+993y5WAAAwBI+P7UEAABQXvzWEgAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALBWNV8vgE1WrAiRjRuDJSmpuuzaVU2ysoKc11JTj0ogo+zu3O4A4O8IMmUwa1Yt+frr6uJGlN2d2x0A/B1BpgyCgkQiI3MkKipHjh2rIgkJweIWlN2d2x0A/B1Bpgzi449LjRo/PZ85s5ar/qFRdndudwDwd3T2LQNviHEjyg4A8EcEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAa3EfmTKIja0hBw5UNc8TE/Pf6XXq1NrO86FDz0pk5HkJJJTdndsdAPwdQaYMli8PLfJmaPPm1XKe3313ZsD9Q6Ps7tzuAODvOLUEAACsRYtMGcTFnRC3ouwAAH9EiwwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAA4N4gc+7cuUuzJAAAAJURZHJzc+XFF1+Upk2bSu3ateXbb78105977jlZtGhRed4SAACgcoLMH/7wB4mNjZU//elPEhz884/ptWvXThYuXFietwQAAKicILN48WJZsGCBDB48WKpWrepMj4qKkl27dpXnLQEAAConyKSkpMjVV19d6Cmn7Ozs8rwlAABA5QSZNm3ayOeff37B9Pfff186dOhQnrcEAAAos2pl/xOR559/XoYMGWJaZrQVZtmyZbJ7925zymnlypXleUsAAIDKaZHp3bu3xMfHy6effiq1atUywWbnzp1m2t13312etwQAAKicFhl12223yZo1a8r75wAAAL4LMiorK0uOHTtmTi/ldcUVV1zscgEAAFRMkNm7d6888cQT8sUXX+Sb7vF4JCgoSM6fP1+etwUAAKj4IDN06FCpVq2a6djbpEkTE14AAACsCDJJSUmyZcsWad269UV9+Ny5c81w4MABM962bVvTcfj++++/qPcFAADuUO77yHz//fcX/eHNmjWTl19+2YSixMREufPOO80VUV9//fVFvzcAAAh85Qoyf/zjH2XSpEmybt06+eGHHyQ9PT3fUFoPPvig9OzZU1q1aiXXXHONvPTSS+ZHKDdt2lSexQIAAC5TrlNLPXr0MI933XXXJevsq3+zdOlSOX36tHTr1q08iwUAAFymXEHms88+u2QLsH37dhNczp07Z1pj4uLizKmrwmRmZprBy9v6k5ycLGfPnhU3OXjwoHncs2ePpKWliZtQdrY7dd49+L678/uu9NcDSiPIo80oPqT3otGKevLkSfNbTQsXLpT169cXGmamTp0q06ZNK/QqquDgYHEbbf3y8ebzGcrOdncb6jx13m2ysrIkNjbW5IOwsLBLG2S2bdtW+JsFBUloaKi5IV5ISIiU97RVy5YtZf78+aVqkWnevLn5rafIyEhxE03oa9eulf79+0uDBg3ETSg725067x583935fVd6RXO/fv1KDDLlOrV0ww03FHvvmOrVq8tDDz1kwogGm7LQuwTnDSt5aTgqLCCFh4dLRESEuIm3mVErN2V3D7Y7dZ7vu3u4+fuuMjIypMKuWtJ+LHql0YIFC8w9ZXTQ59dee6288847smjRItNa8Pvf/77Y95k8ebJs2LDBpC7tK6PjeiXU4MGDy7NYAADAZcrVIqOXSc+aNUvuvfdeZ1r79u3NfWGee+45+fLLL82vYj/99NPy5z//ucj30d9peuyxx+TIkSNSp04duf7662X16tX8gjYAAKi4IKOtJy1atLhguk7T17ynnzSgFEdbbgAAAMqrXKeW9KcJ9I682qPYKzs720zz/myBXjbVqFGjci8YAABAhbTIzJ49W3r16mVOJenpIKUtMXpTO/0hSfXtt9/KyJEjy/P2AAAAFRdkbr75Ztm/f7/84x//MJfGqYEDB8qgQYPksssuM+OPPvpoed4aAACgYoOM0sDy5JNPlvfPAQAAKi/IrFixQu6//35zjxh9Xhw97QQAAOA3QaZPnz6SmpoqDRs2NM+LUt4fjQQAAKiwIKN33C3seV6HDh2SF154ocwLAQAAUGmXXxfl+PHj8re//e1SviUAAEDlBBkAAIDKRJABAADWIsgAAAB33EemX79+xb7+448/XuzyAAAAVEyQ0V+oLul1/TVrAAAAvwsyMTExFbckAAAAZUQfGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABr+U2QefnllyUoKEjGjh3r60UBAACW8Isg89VXX8n8+fPl+uuv9/WiAAAAi/g8yGRkZMjgwYPlzTfflLp16/p6cQAAgEV8HmRGjRolDzzwgPTo0cPXiwIAACxTzZcf/u6778rWrVvNqaXSyMzMNINXenq6eUxOTpazZ8+Kmxw8eNA87tmzR9LS0sRNKDvbnTrvHnzf3fl9VykpKVIaQR6PxyM+cOjQIenYsaOsWbPG6RsTHR0tN9xwg7z++uuF/s3UqVNl2rRpF0wfOnSoBAcHi9to52gfbT6fo+xsd7ehzlPn3SYrK0tiY2Pl5MmTEhYW5n9B5oMPPpC+fftK1apVnWnnz583X9YqVaqYlpe8rxXVItO8eXNZtmyZREZGiptoQl+7dq30799fGjRoIG5C2dnu1Hn34Pvuzu+7OnDggPTr16/EIOOzU0t33XWXbN++Pd+0xx9/XFq3bi3PPPPMBSFGhYSEmKGg8PBwiYiIEDfxNjNq5abs7sF2p87zfXcPN3/fvRcDlYbPgsxll10m7dq1yzetVq1aUr9+/QumAwAA+OVVSwAAAFZetVTQunXrfL0IAADAIrTIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGtV8/UC2GTFihDZuDFYkpKqy65d1SQrK8h5LTX1qAQyys52p87zfXfDvg72IciUwaxZteTrr6uLG1F2trvbUOfdWedhH4JMGQQFiURG5khUVI4cO1ZFEhKCxS0oO9udOs/3HfBHBJkyiI8/LjVq/PR85sxargoylP2n9cB2p867gZu/77APnX3LwPvFdiPK7k5sd3dy83aHfQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADW4j4yZRAbW0MOHKhqnicm5r/r5dSptZ3nQ4eelcjI8xJIKDvbnTr/M77vgbuvg30IMmWwfHlokTeGmjevlvP87rszA+7LTdnZ7gVR53/C9z2w9nWwD6eWAACAtWiRKYO4uBPiVpTdndju7uTm7Q770CIDAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtXwaZKZOnSpBQUH5htatW/tykQAAgEWq+XoB2rZtK59++qkzXq2azxcJAABYwuepQYNL48aNfb0YAADAQj7vI7N3716JiIiQq666SgYPHiwHDx709SIBAABL+LRFpkuXLhIbGyvXXnutHDlyRKZNmya33Xab7NixQy677LIL5s/MzDSDV3p6unlMTk6Ws2fPipt4A9+ePXskLS1N3ISys92p8+7B992d33eVkpIipRHk8Xg84id+/PFHadGihbz66qsybNiwQjsHa9gpaOjQoRIcHFxJSwkAlU8vhvCj3XWlouzu3O5ZWVmmsePkyZMSFhZmR5BRnTp1kh49esiMGTNK1SLTvHlzmTNnjuv62WhS3b59u3Tr1k3q1KkjbkLZ2e5urfP9+/eXBg0aiJtoa8TatWspu8u2uzpw4ID069evxCDj886+eWVkZMi+ffvk0UcfLfT1kJAQMxSkBaxXr564iW5YpTt0yu4ebHd313n9Z6Z9Ct3Ee0qFsrtru3szgd939p0wYYKsX7/epK4vvvhC+vbtK1WrVpWHH37Yl4sFAAAs4dMWmf/85z8mtPzwww8mbd96662yadMm1zWdAgAAC4PMu+++68uPBwAAlvP5fWQAAADKiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWKuarxcA/i0lJUWGDRsm586dM+MdO3aUmTNnSlBQkDOPx+ORCRMmyJYtW8x4aGioLFy4UJo1a+az5QbKizovsmJFiGzcGCxJSdVl165qkpX18/c9NfUolQt+hRYZFKtp06YycuRIZzwxMVHi4uLyzaPj3hCjRowYQYiBtajzIrNm1ZLFi2vKtm3V84UYwB8RZFCiXr16SdeuXZ3xBQsWyKFDh8xzfZw/f77zWufOnaV3796sVVjN7XVeG1wjI3Okd+9z0q1blq8XBygWQQalMnHiRAkLCzPP9TTT9OnTJSsryzxmZmaa6fr6pEmTWKMICG6u8/Hxx2XTph9k/vyTcvPNBBn4N4IMSqV+/foyfvx4Z3znzp3mFJI+eo0bN07Cw8NZowgIbq7zNWr4egmA0iPIoNSio6OlR48ezvi+ffuc5zq9e/furE0EFOo84P8IMiiTMWPGmCPVvOrWrWumA4GIOg/4N4IMyiQtLU3S09PzTTt16pSkpqayJhGQqPOAfyPIoNRycnJMR8fs7OxCp2tHSCCQUOcB/0eQQanFxMRIcnKyM96nTx/n+f79+2XRokWsTQQU6jzg/wgyKJUdO3bIkiVLnPGePXvK2LFjzaPX0qVLZdu2baxRBATqPGAHggxKdPbsWZkxY4bk5uaa8caNG8vo0aPNc32MiIgwz/V1ne/MmTOsVVjN7XU+NraGTJ1a2wzr1wfne807XYcDB6r6bBkBL4IMSjRnzhzz+zOmwlSpIpMnT5aaNWuacX3UcZ2ujhw5IrNnz2atwmpur/PLl4fKvHm1zJCYmD/IeKfrkJLCvxD4HrUQxdq8ebPEx8c74wMGDJCoqKh887Rv314GDRrkjK9atUoSEhJYs7ASdR6wC79+jWJ16dJF1q1bV+JaGj58uBkA21Hn9YdgT/h6MwClRosMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1vJ5kElJSZFHHnlE6tevLzVq1JD27dtLYmKirxcLAABYoJovP/zEiRNyyy23SPfu3eWjjz6SBg0ayN69e6Vu3bq+XCwAAGAJnwaZP/7xj9K8eXOJiYlxpl155ZW+XCQAAGARn55aWrFihXTs2FEGDhwoDRs2lA4dOsibb77py0UCAAAW8WmLzLfffitz586V8ePHy29/+1v56quv5KmnnpLg4GAZMmTIBfNnZmaawSs9Pd08Hj58WLKzs8VN0tLSnD5GJ0+eFDeh7Gx3t9b5PXv2OM/d4uDBg+aRsrtru3v/v5VGkMfj8YiPaGDRFpkvvvjCmaZBRgNNQkLCBfNPnTpVpk2bdsH0oUOHmvcCgEAVFBQkPtxd+xRld+d2z8rKktjYWHPgEhYW5p8tMk2aNJE2bdrkm3bdddfJP//5z0Lnnzx5smm9ydsio31sOnfuLI0bNxa3JdXt27dLt27dpE6dOuImlJ3t7tY6379/f3NRhJtoS8zatWspu8u2uzpw4IAJMiXxaZDRK5Z27959QaVt0aJFofOHhISYoSBNavXq1RM38Tat6w6dsrsH293ddV7/mUVERIibeE+lUXZ3bXeVkZEhft/Zd9y4cbJp0yaZPn26JCcnyzvvvCMLFiyQUaNG+XKxAACAJXwaZDp16iRxcXGyZMkSadeunbz44ovy+uuvy+DBg325WAAAwBI+PbWkfvGLX5gBAADAup8oAAAAKC+CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGCtar5eABukpKTIsGHD5Ny5c2a8Y8eOMnPmTAkKCnLm8Xg8MmHCBNmyZYsZDw0NlYULF0qzZs18ttwAUB4rVoTIxo3BkpRUXXbtqiZZWT/v61JTj7JS4VdokSmFpk2bysiRI53xxMREiYuLyzePjntDjBoxYgQhBoCVZs2qJYsX15Rt26rnCzGAPyLIlFKvXr2ka9euzviCBQvk0KFD5rk+zp8/33mtc+fO0rt370u9rQCgUmhjc2RkjvTufU66dctircOvEWTKYOLEiRIWFmae62mm6dOnS1ZWlnnMzMw00/X1SZMmVczWAoBKEB9/XDZt+kHmzz8pN99MkIF/I8iUQf369WX8+PHO+M6dO80pJH30GjdunISHh1/arQQAlahGDVY37EGQKaPo6Gjp0aOHM75v3z7nuU7v3r37pds6AACgWASZchgzZoxpncmrbt26ZjoAAKg8BJlySEtLk/T09HzTTp06JampqZdquwAAgFIgyJRRTk6O6dybnZ1d6HTt/AsAACoHQaaMYmJiJDk52Rnv06eP83z//v2yaNGiS7d1AABAsQgyZbBjxw5ZsmSJM96zZ08ZO3asefRaunSpbNu2rSxvCwAAyomfKCils2fPyowZMyQ3N9eMN27cWEaPHm2e62NSUpIcPnzYvK7zactMzZo1y7tdAMBnYmNryIEDVc3zxMTq+V6bOrW283zo0LMSGXm+0pcPyIsgU0pz5swxv7mkqlSpIpMnT3aCij7quF61pEHmyJEjMnv2bHMDPQCwzfLloZKQEFzoa/Pm1XKe3313JkEGPseppVLYvHmzxMfHO+MDBgyQqKiofPO0b99eBg0a5IyvWrVKEhISLuW2AgAABdAiUwpdunSRdevWlTjf8OHDzQAANouLO+HrRQBKjRYZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArOXTIBMZGSlBQUEXDKNGjfLlYgEAAEtU8+WHf/XVV3L+/HlnfMeOHXL33XfLwIEDfblYAADAEj4NMg0aNMg3/vLLL0vLli3ljjvu8NkyAQAAe/hNH5msrCx5++235YknnjCnlwAAAPy6RSavDz74QH788UcZOnRokfNkZmaawevkyZPm8ejRo+I2aWlpJvylpqbKmTNnxE0oO9vdrXX+wIEDkpGRIW6SkpJC2V243dXBgwfNo8fjkeIEeUqao5Lce++9EhwcLPHx8UXOM3XqVJk2bVqlLhcAAPCdQ4cOSbNmzfw7yHz33Xdy1VVXybJly6R3796lbpHRFpwWLVqY1FanTh1xk/T0dGnevLnZwGFhYeImlJ3tTp13D77v7vy+K40np06dkoiICKlSpYp/n1qKiYmRhg0bygMPPFDsfCEhIWYoSEOMGzey0nJTdvdhu/N9dxvqvDvrfJ1SNFL4vLNvbm6uCTJDhgyRatX8IlcBAABL+DzIfPrpp+bUkF6tBAAAUBY+bwK55557SuyRXBQ9zTRlypRCTzcFOsrOdncb6jx13m3cXOfLwi86+wIAAFh5agkAAKC8CDIAAMBaBBkAAGAtq4PM7NmzJTIyUkJDQ6VLly7y5ZdfSqDbsGGDPPjgg+YGQfqbVPrTDm4xY8YM6dSpk1x22WXmvkN9+vSR3bt3ixvMnTtXrr/+eudeGt26dZOPPvpI3Eh/XFbr/tixYyXQ6d3Mtax5h9atW4ubfp7gkUcekfr160uNGjWkffv2kpiYKIFO/68V3O46jBo1yteL5pesDTLvvfeejB8/3vTo3rp1q0RFRZmfOTh27JgEstOnT5uyaohzm/Xr15sv8qZNm2TNmjWSnZ1trnrTdRLo9Pbc+g98y5YtZkd+5513mrtgf/311+ImX331lcyfP9+EOrdo27atHDlyxBk2btwobnDixAm55ZZbpHr16ia0f/PNN/LKK69I3bp1xQ31PO821/2dGjhwoK8XzT95LNW5c2fPqFGjnPHz5897IiIiPDNmzPC4hW6+uLg4j1sdO3bMrIP169d73Khu3bqehQsXetzi1KlTnlatWnnWrFnjueOOOzxjxozxBLopU6Z4oqKiPG70zDPPeG699VZfL4Zf0LresmVLT25urq8XxS9Z2SKjvwKrR6Y9evRwpunvMOh4QkKCT5cNlcf76+f16tVz1Wo/f/68vPvuu6YlSk8xuYW2xunPmOT93rvB3r17zalk/T26wYMHO78IHOhWrFghHTt2NK0Qeiq5Q4cO8uabb4rb6P+7t99+29w0Vk8v4UJWBpnvv//e7MwbNWqUb7qOp6am+my5ULk/baF9JLTpuV27dq5Y9du3b5fatWubm2M9+eSTEhcXJ23atBE30OCmp5C1n5SbaN+/2NhY+fjjj00/qf3798ttt91mfkgv0H377bemzK1atZLVq1fLiBEj5KmnnpK33npL3ET7QeoPJA8dOtTXi+K3fH5nX6C8R+c7duxwTX8Bde2110pSUpJpiXr//ffN75Npv6FADzP6y79jxowx/QS0Y7+b3H///c5z7RekwaZFixbyP//zPzJs2DAJ9IMVbZGZPn26GdcWGf3Oz5s3z9R9t1i0aJGpB9oqhwBqkQkPD5eqVavK0aNH803X8caNG/tsuVA5Ro8eLStXrpTPPvvMdIJ1i+DgYLn66qvlpptuMi0T2ul71qxZEuj0NLJ24r/xxhvND8vqoAHuL3/5i3murbNucfnll8s111wjycnJEuiaNGlyQUi/7rrrXHNqTX333Xfm9wiHDx/u60Xxa1Vs3aHrzvxf//pXvvSu427qM+A22r9ZQ4yeUlm7dq1ceeWV4mZa5zMzMyXQ3XXXXea0mrZGeQc9Utf+IvpcD2rcIiMjQ/bt22f+yQc6PW1c8PYKe/bsMS1SbhETE2P6B2nfMATgqSW99FqbF3WH1rlzZ3n99ddN58fHH39cAn1HlvdoTM+Z685cO7xeccUVEuink9555x1Zvny5uZeMtz9UnTp1zD0mAtnkyZNN87JuY+0foeth3bp1pu9AoNNtXbAfVK1atcy9RQK9f9SECRPMfaP0n/fhw4fN7SY0uD388MMS6MaNGyc333yzObX0y1/+0twnbMGCBWZwy4GKBhn9P6ctjyiGx2JvvPGG54orrvAEBweby7E3bdrkCXSfffaZueS44DBkyBBPoCus3DrExMR4At0TTzzhadGihanrDRo08Nx1112eTz75xONWbrn8+qGHHvI0adLEbPemTZua8eTkZI9bxMfHe9q1a+cJCQnxtG7d2rNgwQKPW6xevdrs33bv3u3rRfF7/Po1AACwlpV9ZAAAABRBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAL8wdepUueGGG3y9GAAsQ5ABcEnob1/95je/kauuukpCQkKkefPm5neC8v64KwBcavwSFYCLduDAAfNrxZdffrnMnDlT2rdvL9nZ2eZHLfXHPnft2sVaBlAhaJEBcNFGjhwpQUFB5heK+/fvL9dcc420bdvW/Er9pk2bzDwHDx6U3r17S+3atSUsLMz8ovHRo0eL/fXfF154QZo1a2ZaePS008cff5wvPOlnLlu2TLp37y41a9aUqKgoSUhIcOaJjY014UoD1XXXXWc++7777pMjR47k+6yFCxea10NDQ6V169YyZ84cagVgCYIMgIty/PhxEzC05aVWrVoXvK5BQkOJhhidd/369bJmzRr59ttv5aGHHiryfWfNmiWvvPKK/PnPf5Zt27bJvffeK7169ZK9e/fmm+93v/udTJgwQZKSkkyAevjhhyUnJ8d5/cyZM+Y9/v73v8uGDRtMoNL5vf7xj3/I888/Ly+99JLs3LlTpk+fLs8995y89dZb1AzABr7++W0Adtu8ebNHdyXLli0rcp5PPvnEU7VqVc/BgwedaV9//bX5uy+//NKMT5kyxRMVFeW8HhER4XnppZfyvU+nTp08I0eONM/3799v/n7hwoUXvOfOnTvNeExMjBlPTk525pk9e7anUaNGznjLli0977zzTr7PefHFFz3dunUr1/oAULlokQFwsQdDJc6jLR3a+VcHrzZt2pjWGn2toPT0dDl8+LDpd5OXjhec//rrr3eeN2nSxDweO3bMmaannFq2bJlvHu/rp0+fln379smwYcPMaSfv8Ic//MFMB+D/6OwL4KK0atXK9FXxVYfe6tWrO891OZSeyirsde883vCVkZFhHt98803p0qVLvvmqVq1aocsN4NKgRQbARalXr57pvzJ79mzTwlHQjz/+aDrSHjp0yAxe33zzjXlNW2YK0s7AERER8u9//zvfdB0vbP7yatSokfkc7a9z9dVX5xuuvPLKS/Y5ACoOLTIALpqGGD3t07lzZ3OlkZ7u0Q632ql37ty5JrToJdmDBw+W119/3bymVzrdcccd0rFjx0Lfc+LEiTJlyhRzWkivWIqJiTEderVz7qU0bdo0eeqpp6ROnTrmiqbMzExJTEyUEydOmKuuAPg3ggyAi6Y3wdu6dau58ufpp582lzc3aNBAbrrpJhNk9HTO8uXLzQ3zbr/9dqlSpYoJDW+88UaR76nh4uTJk+b9tE+LtsSsWLHCnMq6lIYPH2760ej9bzQ86ZVXGrrGjh17ST8HQMUI0h6/FfTeAAAAFYo+MgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAACIrf4fybfcuY7cZxgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Creer un plateau avec premier clic garanti sur\n",
+    "board = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(4, 4))\n",
+    "board.reveal(4, 4)  # Premier clic\n",
+    "\n",
+    "print(f\"Plateau : {board.rows}x{board.cols}, {board.n_mines} mines\")\n",
+    "print(f\"Cellules revelees apres le premier clic : {len(board.revealed)}\")\n",
+    "print(f\"Cellules restantes (inconnues)           : {board.rows * board.cols - len(board.revealed)}\")\n",
+    "print(f\"Mines a trouver                          : {board.remaining_mines()}\")\n",
+    "\n",
+    "# Visualiser l'etat initial\n",
+    "fig = draw_board(board, title=\"Etat initial apres le premier clic\")\n",
+    "plt.show()\n",
+    "\n",
+    "# Visualiser avec les mines (pour reference)\n",
+    "fig = draw_board(board, title=\"Plateau complet (mines revelees)\", show_mines=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {
+    "id": "cell-09",
+    "papermill": {
+     "duration": 0.006189,
+     "end_time": "2026-04-22T18:08:10.381898",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.375709",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : representation du plateau\n",
+    "\n",
+    "**Sortie obtenue** : deux vues du meme plateau -- la vue du joueur (cellules cachees en gris) et la vue complete avec les mines.\n",
+    "\n",
+    "| Element | Signification |\n",
+    "|---------|---------------|\n",
+    "| Chiffre colore | Nombre de mines dans les 8 voisines |\n",
+    "| Gris uni | Cellule non revelee (inconnue) |\n",
+    "| X (vue complete) | Position d'une mine |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le premier clic avec `safe_cell` garantit que ni la cellule cliquee ni ses voisines ne contiennent de mine -- c'est le comportement standard du jeu\n",
+    "2. Les cellules affichant 0 declenchent une revelation en cascade de leurs voisines\n",
+    "3. La frontiere entre cellules revelees et cachees constitue notre zone de travail pour le solveur"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {
+    "id": "cell-10",
+    "papermill": {
+     "duration": 0.004825,
+     "end_time": "2026-04-22T18:08:10.391637",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.386812",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 3. Approche 1 : solveur par regles simples (~8 min)\n",
+    "\n",
+    "Le solveur le plus basique applique deux regles deterministes en boucle :\n",
+    "\n",
+    "### Regle 1 -- Toutes les voisines sont des mines\n",
+    "\n",
+    "Si une cellule revelee affiche $n$ et a exactement $n$ voisines inconnues (ni revelees ni marquees), alors **toutes** ces voisines sont des mines.\n",
+    "\n",
+    "$$\\text{unknown\\_count}(i,j) = n_{i,j} - \\text{flagged\\_count}(i,j) \\implies \\text{marquer toutes les inconnues}$$\n",
+    "\n",
+    "### Regle 2 -- Toutes les voisines sont sures\n",
+    "\n",
+    "Si une cellule revelee affiche $n$ et a deja $n$ voisines marquees, alors toutes les voisines inconnues restantes sont **sures**.\n",
+    "\n",
+    "$$\\text{flagged\\_count}(i,j) = n_{i,j} \\implies \\text{reveler toutes les inconnues}$$\n",
+    "\n",
+    "Ces deux regles suffisent pour les configurations simples, mais echouent sur les cas ambigus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-11",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.402334Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.402044Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.407826Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.406991Z"
+    },
+    "id": "cell-11",
+    "outputId": "128ae2a5-60f7-49f1-c37e-e0530bbb106f",
+    "papermill": {
+     "duration": 0.012069,
+     "end_time": "2026-04-22T18:08:10.408349",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.396280",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe RuleBasedSolver definie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class RuleBasedSolver:\n",
+    "    \"\"\"Solveur par regles simples (deductions locales).\n",
+    "\n",
+    "    Applique iterativement les regles 1 et 2 jusqu'a\n",
+    "    ce qu'aucune nouvelle deduction ne soit possible.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, board):\n",
+    "        self.board = board\n",
+    "        self.moves_log = []  # historique des coups\n",
+    "\n",
+    "    def solve_step(self):\n",
+    "        \"\"\"Applique un tour de regles. Retourne True si des progres ont ete faits.\"\"\"\n",
+    "        progress = False\n",
+    "\n",
+    "        for r in range(self.board.rows):\n",
+    "            for c in range(self.board.cols):\n",
+    "                if (r, c) not in self.board.revealed:\n",
+    "                    continue\n",
+    "\n",
+    "                num = self.board.numbers[r, c]\n",
+    "                if num == 0:\n",
+    "                    continue\n",
+    "\n",
+    "                unknown = self.board.get_unknown_neighbors(r, c)\n",
+    "                flagged = self.board.get_flagged_neighbors(r, c)\n",
+    "                remaining_mines = num - len(flagged)\n",
+    "\n",
+    "                # Regle 1 : toutes les inconnues sont des mines\n",
+    "                if remaining_mines == len(unknown) and len(unknown) > 0:\n",
+    "                    for ur, uc in unknown:\n",
+    "                        self.board.flag(ur, uc)\n",
+    "                        self.moves_log.append(('flag', (ur, uc), (r, c)))\n",
+    "                        progress = True\n",
+    "\n",
+    "                # Regle 2 : toutes les inconnues sont sures\n",
+    "                elif remaining_mines == 0 and len(unknown) > 0:\n",
+    "                    for ur, uc in unknown:\n",
+    "                        safe = self.board.reveal(ur, uc)\n",
+    "                        self.moves_log.append(('reveal', (ur, uc), (r, c)))\n",
+    "                        if not safe:\n",
+    "                            return False  # Mine touchee (ne devrait pas arriver)\n",
+    "                        progress = True\n",
+    "\n",
+    "        return progress\n",
+    "\n",
+    "    def solve(self, max_iterations=100):\n",
+    "        \"\"\"Applique les regles jusqu'a convergence.\n",
+    "\n",
+    "        Retourne le nombre d'iterations effectuees.\n",
+    "        \"\"\"\n",
+    "        for i in range(max_iterations):\n",
+    "            if self.board.game_over or self.board.won:\n",
+    "                break\n",
+    "            if not self.solve_step():\n",
+    "                break\n",
+    "        return i + 1\n",
+    "\n",
+    "\n",
+    "print(\"Classe RuleBasedSolver definie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {
+    "id": "cell-12",
+    "papermill": {
+     "duration": 0.00484,
+     "end_time": "2026-04-22T18:08:10.418423",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.413583",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Testons le solveur par regles sur notre plateau d'exemple."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-13",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 746
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.430041Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.429764Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.542936Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.542152Z"
+    },
+    "id": "cell-13",
+    "outputId": "428b031b-33a3-4e5a-f2dd-83aa488a7dd3",
+    "papermill": {
+     "duration": 0.120168,
+     "end_time": "2026-04-22T18:08:10.543538",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.423370",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solveur par regles simples\n",
+      "=============================================\n",
+      "Iterations         : 5\n",
+      "Cellules revelees  : 44 -> 54 (+10)\n",
+      "Drapeaux poses     : 0 -> 9 (+9)\n",
+      "Cellules inconnues : 1\n",
+      "Partie gagnee      : True\n",
+      "Coups effectues    : 19\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAARpZJREFUeJzt3Ql4VNX9//FvFpJAQiJLQCBAEFAkLFJWt4osIliVtVYQiEv9o7iBoD/aKqEWwaL+QEUQsYmWzYoggbJqBESDCpaKIGENwQgECRDCkkAy/+ccfjNONrIQmDlz3q/nuc/M3LmZ3PXMZ849514/h8PhEAAAAAP5e3oGAAAAKoogAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADXKLo6Gjx8/PTw9q1a1mflnPuC2pITU0VbzB79mzXPCUlJXl6dqxz/vx5ueaaa/T6/+1vf+vp2fE5BBnLbNiwoUBBq4Zt27Z5erYAXCbZ2dnywgsv6OddunSRbt26FXh/6tSpMmjQIGnSpEmBciEhIaHEz1y2bJn07t1bateuLUFBQVK/fn0ZPHiw/PDDD2zHYgQGBspzzz2nn3/xxReyePFi1lMlIshYprjC6WIFFgCzzZo1Sw4dOqSfP/HEE0Xej4uLk4ULF5a59mjcuHFy9913y8qVK+Xo0aNy7tw5OXjwoMyfP186dOggy5cvr/Rl8AXDhw+XsLAw/XzChAmenh2fQpCxyOnTp+Wjjz4qMn7OnDmSl5d3RX4Zwjvl5+fLmTNnxFfn79SpU2IjdU/gGTNm6OfVqlWTe++9t8g0rVu3loceekjefvttqVOnzkU/Lzk5WSZPnux6/de//lVWr14to0eP1q9zcnJk6NChkpmZWenLYrqqVatK37599fP//ve/snHjRk/Pks8gyFhEVWdmZWW5qphbtGihn6tfa6tWrSoyfWxsrKuaWf1q++STT6RTp076gFQF3v/7f/9Pjh07VuBvunbt6vqb+Ph4XW19/fXX6+rnv/zlL67pfvzxR3nkkUf0eeOQkBAJDw+Xm2++WdcOFb4he3p6uv5fatrg4GD9/xs2bCg9e/aU8ePHl2nZd+zYIUOGDNF/p+YlNDRUt2353e9+J2+88UaR6RMTE6VPnz56OatUqaKr0O+44w79y7UsbrzxRtd6UL9U3aWlpYm/v79+T325nDhxwvXeN998I/fff79rPmvUqCE9evTQ81PWtjnql7X7KQJ37uO///57efrpp6VBgwZ6GYvbB0r6f5999pn8/e9/l+bNm+tt0rRpU3nllVd04HCn9pvu3btLo0aN9K9R52mIfv36FdueqLLmT325qn1D7TOqWv/dd9+t0DpWFi1aJO3atdP7qfobVSOh9qeS1vHFXOn9fvPmzbJ79279XLXNcNYIuFOnOt577z157LHH9P+4mCVLlrieq89Tp6zU/Lz22mt6X1BUiHn//ffLNH/Oz1TH4dVXX623hzrW1Dop/BmHDx+WsWPHSsuWLfVxo+ZVlWGjRo2Sn3/+uch+59w2qhwrqYxyr42uSHlX3nLlrrvucj1fsGBBmdcRSuGANXr06KFKSj289dZbjpdeesn1etCgQUWmHz58uOv966+/3vXcfWjbtq3j9OnTrr+57bbbXO81b968wLRPP/20nmbx4sWOkJCQYj9PDUOGDHHk5+fraXNzcx1NmzYtcdrg4OBSl/uXX35x1KxZs8TPuO666wpM/+STT5Y4rRoeffTRAtM3btzY9d7nn3+ux7377ruucb/73e8KTD9p0iTXe0OHDnWNnz59usPf37/E/ztu3LhS/6+yb9++An/nzn184e2jtsvFuP+/li1blmnd1K1bt8Tl8fPzc3z88ceXZf4K/+3//u//Vmgdv//++8VO95vf/KZM61htC6crvd8rr776qutvxo8fX+r07uswPj6+yPtq+zrf7927d4H32rVr53rv7rvvLvV/qWWNjY0tcRnvvfde17Tbt2931KlTp8Rpa9eu7fjvf//rml4tq/M9VY65cy+j3JexvOVdecsVZe/eva7327RpU+o6QtkQZCyRlpbmKsADAwMdR44cKXBQqYIxMzOzwN+4H9hqePjhhx3Lly93/O1vf3NUqVLFNV69Lq6QUMM999yjC/BPPvnEsWzZMkdGRoYjLCzM9f6IESMcK1eudPzzn/8sUIi+9957+vO+/fbbAge++qw1a9boLxgVjGJiYkpd9o8++sj1Gbfffruej1WrVjn+8Y9/OB555BFHt27dXNMuWbKkwPyPGjVKL/Pzzz+vv3id4//1r39dNFBkZWU5QkND9Ti1rlSh59S6dWvX9GvXrtXjfvjhB9f2UY9//vOfHatXr3a88847jho1arim/+yzzy76f8sTZNT/efbZZx0rVqzQ6//777+/6Hp0/39BQUGOl19+Wa+bwvvJhg0bCoQ2ta3+/e9/62VV6139nXsguhzzp4YHH3xQb2u1rdavX1/udXzy5ElHRESEa/xNN92k9+MZM2YUGF+WIOOJ/V5x3zZz5sy55CCjAqHzfRXKkpKS9Bf7okWLCgREtY+XRq1393U1cOBAx8KFCx2JiYmOv/zlL/rYdHIPjiqkzp8/Xx/X7oG6VatWjry8vEoJMmUp78pTrrhT5a/6m4CAANf84tIQZCwxceJE10F31113ucarwtk5/u233y7wN+4HdseOHQu898QTTxT7y8K9kGjfvn2R+XjzzTcLFDxffPGFa1BfLM73unTpoqffuXOna1z37t0d27Zt079Wy0N9WTk/Y/DgwY5du3Y5zp8/X+y0/fr1K/FXpSpone/16dOn1EChvkgLr1v1Zewc16xZM9cvcPWF7Ryvas7c18tDDz3keu8Pf/hDpQWZ0aNHl2s9uv+/sWPHFnjPPZw99dRTrvFqew0bNszRpEkTHZbd/79zUKGvsuevf//+Rd4v7zpWX6ruwe3QoUOuz1I1muUJMp7Y7xW1nzo/RwXCSw0yx48fdzRs2LDY7eg+qLBRmg4dOrimV8ddSVRNi/tnb9682fWeCqfu733zzTeVEmTKUt6Vp1xx516zpAIuLh1BxhLXXnut6+CZN2+ea7yqaneO79SpU4G/cT+wVc2EuwULFrjeq1q1arGFhApPhT322GOlFoJqUL9eFfVF735KzPlLRi2Pmr/k5ORSl/3MmTP6F6z7Z6gvJjVOzY/6knByr1J+5ZVXCnzO1KlTXe9dc801pQYKVTPhHH/zzTfrcf/zP//jGqdqJpxUNX1Z1ov6EqysIPPll186ysP9/6maK3eqhqHwKQcV2py1Uhcb9u/fX+nzN3fu3CLvl3cdu58CVPuFuy1btpQryHhivy8cZFTtwqUGGUUtk1qX7jWU9erV04GrpLKkONWqVXNNr2qmSvLhhx8WW9Y4XXXVVa73P/jgg0oJMmUp78pTrriLjIwkyFQyGvta4KuvvpKdO3e6XqvrPTgbtY0cObJAI0jVGLGy1KtX75J7OKl5XLp0qcycOVM3EL3uuut0Q1m1PKoxoGpwuGnTpot+lmpU+eWXX8qrr76qG9uphqmql5a6fo7q0XHTTTfpBriVTTVYVPPr3Ab79u1zNfwNCAjQ3TEvpeeXeyNTdcEtpyNHjlz27VMWb775pqu3kGoIOnfuXFm/fn2RRr6FGwhXxvxV1r7nVJ4GvZeiMvd7JTIy0vW8snoSqcasqov1L7/8ossMNU/q+GncuLFrmrZt24onlXRslOf4KE1FyxVng2G1PWvVqlUp82I7gowFytODoKRp1QFb0utmzZoV+zfFFf6qB5OTOtD/r1awyOAs0NVzVWCoHgOq94jqJaC+HJ966in9vrqGRWk9idRnREREyLPPPqsv5KV6cajeWwMGDNDvq15DzmtfOHtylbbM7tNdjOrW6pwHdQ2P/fv369eqR5TqvVPcelE9akpaL+4XHFO9bZx++ukn13P1BVgWl/LlXHjdqKBWeH9wL8TV9lIB+tZbb9Uh7nLPX2n7XlnWsbMXjrJnzx79xe3e06c8PLHfO7tWO6WkpEhlqlmzpnTs2FGvJ9VTzr13nvPYuhjV+8ipuAvEOXtxuR9rqgv+f/7zH9fr7du3y/Hjx12vndOWdGzs2rWrTOuhLOVdecoV9/3IGaxiYmJ0mMGlC6yEz4AXO3v2rHz44Yeu12PGjNG/HNxt3bpVX0NC+ec//ykTJ04s8mWjfnk9+uij0r9/f12QvPPOO673fv/735d5fu677z7505/+pAts9eU3cOBA/QWnCgTV3VQVMurgV9dbUF1MVZdLVbOhCgdVKKtf2up6OO6/RtUyXoya9z/+8Y+uX7aqm6f6dep+RWPnZ6gumM5CVQUCtb5U11xVk/Dxxx+7pi/cpbMkw4YNkz//+c+68HIv1B5++OEC06nPU13VVe2E+kKoXr267sKput2qglgV2Kp7sFp3zv997bXXugp11bX95MmTutanuG6flW3atGn6i6xNmzb62kSqq3Th/UF1G3a/RL76Ja/Wu3s3/CupvOtYdbdX+6X6QlLXR1H7oPrSUhd/K+8yeGK/d3Y1dj8OiqO6qqvPVpyPynfffSdXXXWVfn7LLbfobtGKs+u6CjGq+7ja9qrrvfM6P+rKwb169Sp13lQ3dOfyqLD2hz/8Qa8n1dVedRtX20R1m1f72G9+8xs9P87/ry4op8oo9wvLtWrVStq3b+86NpzUsauuc6MuAaCOjbJcM6ss5V15yhX3z3W67bbbSp0PlFFln6uCd1HtYZznb8PDwx05OTlFpjl27FiBVvnORoHu54xvuOGGAufEnYNq5Hnq1KlSzz+7Uz0cLtYN1b2r6MGDBy86neoB8PXXX190Haj2BBf7jOrVqztSU1OLbdhX3PDHP/6xwOeX1FbFSXUjdf971SX53LlzRaZTDUgv1jW48Dp1b4NTuI1HedpvlJX7crp3tS3c08NJtZFx36+cQ9euXUucj8qav+K2Q0XWcUndr9XxUN51fKX3e2dbG2f7ONW2Q/XEuth6K2lwX5+Feya6D6qB/+HDh8u0vVSPHXX5gbJ0v1btTS7W/bpWrVoFul+rRrctWrQoMp3qbebeWLmkNjJlKe/KW64oqot9RduAoWQEGR/Xq1evAi3rS3LHHXe4prvvvvuKHNiqgFWNBTt37qwLY3XdBvWF7t6tuKxBRvnxxx/1NSlUzx31eapRqHqurrkyc+ZMV2GoGtSp692o+WvUqJEujFUhXr9+fd0zpSyNHlVXc9UzRM2b+jvVe0Z9warPe+CBB/Q1KgpT3V3vvPNOvZzq/6nrRajGl+7drsv6Baq6k7oXcM8991yJ86p6XajCTs2bajiowqe6HoW6zo9qyHjixIkC06svWvW+c3leeOEFvW4vd5BRXZRff/113TtFzafqlaQaLxfutaG6XN944416+1599dU6JKovU08FmYqsY9V7SV0/RE2r9p8xY8Y4vvrqK9f/Uo1W3V1sGa7kfu/02muvFWkMeylBRvXAu/XWW3UgV/udamyrGrOrkFjcD6XSqPWrGiWroOI81lRvysLlh+o1pnqeqYCi1p0aVEhT3dHT09OLfG5KSoo+htX2UaFCBSO1/svS2Lcs5V15yxXVTd3ZBZ9ryFQuggxKVPjAht3KGhR8ibN7fGFvvPFGgV/v3iw7O1v3KlLzqr6Y4Znyzr2HqKqdQ+WhpREAlGDNmjW67YZqzKkaaqq2LKonkfNu0s52UN5MXTb/pZde0s+//vprfXsJXFmqjdyUKVP0c9XgXbWrQeWhsS8AlEA1DFaN5d0bzLtTN2F88sknvX79qcblhRuY48pR9/tSDfFxeVAjAwAlUL1f1N2c1aPq5aR61NStW1fuvPNOmTdvnu7hpr6kAHiOnzq/5MH/DwAAUGHUyAAAAGMRZAAAgLECTW+I9/PPP+tz11fqXigAAODyUy1f1BXL1e1cLnY7B6ODjAox6lLZAADANx04cECioqJ8M8iomhhlzpw5+j4aNlE3KFP3EBnapo3UDQsTm2w/ckSW79ol99xzj+v+L7Ztd5ad7W4Lyrpd0qlTJ31fK9scPnxY39/M+V3vk0HGeTpJhRj3m4TZQN2gLSgoSJpFRkqj/7uxmy2y8/L0squbELrfQdqm7c6ys91tQVkXpG9IqW7Saiu/UpqO0NgXAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYwV6egZMcTD7oKzav0qSf06WlGMpknE6Q7JysyQ8KFxiasXIoGsH6cHPz8/Ts4pKlpgYLBs2BMmWLVVkx45Ayc39dRsfOnSY9Q2fQ3lnl/T0dHn44Yfl7Nmz+nWHDh1kypQpBb7PHA6HjBkzRjZv3qxfh4SEyOzZsyUqKko8jSBTRgt3LZSJX08sMj7zbKZ8kf6FHpbtXSbxveIlwD9AfNGX8+ZJ8vz5Jb4fHBoqTy5YIL5m2rRQ2batiqdnA7hibC/vbCvrGjRoII8//ri8/vrr+vWmTZtk8eLF0r9/f9c06rUzxCiPPfaYV4QYhVNL5VSnWh25v8X98j8d/0eGtBgiIQEhrvdW718tC1J8Z+fGBepHSXT0ebn33rNy4425rBZYg/LOHvfcc4906dLF9XrWrFly4MAB/Vw9vvPOO673OnXqJPfee694C2pkyqhBWAN5q9tb0rdZXwn0/3W19WveTwYuHeh6nZSWJEOuH1L5W8rLNGnfXjoPGlRgnH+A7/0yU5YuzZSqVS88nzIlVJKTgzw9S8BlRXlnZ1k3duxYefDBByUrK0ufZnr55Zdl2rRp+jEnJ0dPEx4eLs8995x4E4JMGfVv/msVm7tbGtwiNUNq6ipXJTffjl/s1SIiJComRmzgDDGALSjv7CzratWqJaNHj5a4uDj9+scff9SnkPbs2eOaZtSoUVK7dm3xJpxaukTORr9O7eq0u9SPBACvRHnn+7p27So9evRwvXYPMWr87bffLt6GGplLcD7/vIxZN0Y/KrWr1pZhLYeJDbYlJenBXUy3btJ71CiPzROAy8fW8s7Gsu7pp5+W//znP3L06FHXuBo1aujx3ogamQrKzs2WYSuG6Qa+SliVMPngzg/0wQ0AvoTyzi5HjhzR7WTcnTx5Ug4dOiTeiBqZCkjPTpehK4bK9qPb9etaIbVkTp85Vp1WKq4BXGiNGh6bHwCXh+3lnW1l3fnz53Xj3nPnzhU7XvVeCgryrg4PBJly2pKxRYavHC6HT1+4EFrTiKYyt89ciY6IFpvY1AAOsBXlnX1lXXx8vOzevdv1um/fvvLJJ5/o5/v27ZP33ntPNwD2JpxaKofl+5ZLv8R+rhDTpV4XWdZvmXUhBoDvo7yzzw8//CDz3S4E2KdPH3nmmWf0o9NHH30k33//vXgTamTKKHFPooz4dITkO/L1a3Vrgq5RXWX+joJXf1TjH2j5QOVvKXhMQkJVSU29cN2ITZsKXuE3Li7M9Tw29oxER+dd8fkDKhvlnX3OnDkjkyZNkvz8C99xV199tTzxxBP6uXrcsmWL/Pzzz/p9NZ2qmalWrZp4A4JMGaVkprhCjKK6XE/+dnKR6aLCoggyPmbJkpASL4I3c2ao63nPnjkEGfgEyjv7vP322/qeS4q/v7+MGzfOFVTUo3qtei2pIHPw4EGZPn26voCeN+DUEgAAFvv6669l6dKlrtcDBw6Utm3bFpimdevWMnjwYNfrf//735KcnCzegBqZMhrbcawebHbz4MF6sM3ixcc8PQvAFWV7eWdbWde5c2dZu3ZtqdM98sgjevA21MgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwllcEmenTp0t0dLSEhIRI586d5ZtvvvH0LAEAAAN4PMh8+OGHMnr0aBk/frx899130rZtW+nVq5dkZGR4etYAAICX83iQef311+WPf/yjPPjgg9KyZUuZOXOmVKtWTf7xj394etYAAICXC/TkP8/NzZXNmzfLuHHjXOP8/f2lR48ekpycXGT6nJwcPThlZWXpx927d8uZM2fEJmlpafpxa0aGHMzOFpvszszUjzt37pQjR46IjdudZWe724KyTiQ9PV1OnDghtjlSxuPco0Hml19+kby8PKlbt26B8er1jh07ikw/adIkmTBhQpHx69evl6CgILGNn5+fJKakiI3UsiclJYmNWHa2u238ROwt69QP1q1bxUa5ubneH2TKS9XcqPY07jUyDRs2lKFt2kizyEixiaqJUQf2gAEDJNKyZVe1ESrEsOxsd1uwzyfJQ+3aSb2wMLGxnLdx2ZXdR45Ignh5kKldu7YEBATI4cOHC4xXr6+++uoi0wcHB+uhsLphYdLoqqvEJs7TSSrE1K9fX2ysbmTZ2e62YJ8X/UVuazlv47IrJ8vYZMSjjX3V6aD27dvLZ5995hqXn5+vX994442enDUAAGAAj59aUqeKhg8fLh06dJBOnTrJ1KlT5dSpU7oXEwAAgFcHmfvuu09Xm7744oty6NAhueGGG2TlypVFGgADAAB4XZBRnnjiCT0AAAAYdUE8AACAiiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIwV6OkZgAHOnpWw11+XwP/+VwL37BG/Y8fELydHHOHhcv6aayS3Rw85/dBD+rWvOZh9UFbtXyXJPydLyrEUyTidIVm5WRIeFC4xtWJk0LWD9ODn5+fpWQUqDfs9TEKQKYcv582T5PnzS3w/ODRUnlywQHyN36lTEvrGG0XHZ2ZKkBo2bZKQBQskc8UKcdSoIb5k4a6FMvHriUXGZ57NlC/Sv9DDsr3LJL5XvAT4B3hkHoHKZvt+b2tZb+qyE2RQJnn16sm5Dh0kLypK8mvUEP+jRyXk3/+WgJ9+urAjpaZK1Tlz5PSTT/rkGq1TrY50b9RdGldvLAdOHpCPd30sZ/PO6vdW718tC1IWyJDrh3h6NoFKxX4PExBkKqhJ+/bSedCgAuP8A3zvl4niqFVLfvnPf4qMPz1ihES2a+d6HXDggPiaBmEN5K1ub0nfZn0l0P/Xw6Vf834ycOlA1+uktCSCDHwG+72dZb2py06QqaBqERESFRMjVsrLE/+MDF0D4+78ddeJr+nfvH+x429pcIvUDKmpq9qV3PzcKzxnwOXDfv8rm8v6aoYsO0EGZRa0fr3U+P3vi30vt0sXOTPEnlMrzka/Tu3q/FozBfgq9nt4I4JMBW1LStKDu5hu3aT3qFFimzP9+8vJKVNEQkLEBufzz8uYdWP0o1K7am0Z1nKYp2cLuKxs3e9tLuu3GbLsBBmUmepqffLFF8UvN1f8f/pJQpYvF//MTKm6aJFU2bpVjs2bJ/kNG/r0Gs3OzZZH1zwqSQcuHNxhVcLkgzs/0IU64KvY7+HNCDKV2Agq1Me6HheWHxUlpx9/3PU6+/nnpVaPHhJw+LAE7tol1V98UU7Ex4uvSs9Ol6Erhsr2o9v161ohtWROnzmcVoJPs32/t7GsN23ZCTI+3gjqcnJERsq59u0lYPly/Troq6/EV23J2CLDVw6Xw6cP69dNI5rK3D5zJToi2tOzBlw27Pd2l/XVDFl2blGAUlXZsEH8srOLjPc7elSqfPed2wjfvLrt8n3LpV9iP1eI6VKviyzrt4wQA5/Gfg9TUCODUlWbPVuC162T3FtvlXMtW4qjalUJOHhQgtUF8Y4ccU2X06OHz63NxD2JMuLTEZLvyNev1a0JukZ1lfk7Cl75Uo1/oOUDHppLoHKx38MkBBmUid+ZMxK8erUeinOuVSs5GRfnc2szJTPFFWIU1eV68reTi0wXFRZFkIHPYL+HSQgyKNWZBx+U/Dp19Gkk/0OHxP/4cZHAQMmvXVvOt2wpZ3v3lrMDB4pUqcLaBABcUQSZcrh58GA92Cb3ttv0YKOxHcfqAbCJ7fu9rWW9qctOY18AAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADG8miQWb9+vdx9991Sv3598fPzk08++cSTswMAAAzj0SBz6tQpadu2rUyfPt2TswEAAAwV6Ml/3rt3bz0AAAAYF2TKKycnRw9OWVlZ+nH7kSOSnZcnNtmdmakfd+7cKUeOHBGbpKWl6UeWne1uC/Z5ka0ZGXIwO1tsLOdtXHYl7f+WvzR+DofDIV5AtZFZvHix9O3bt8Rp4uLiZMKECUXGx8bGSlBQkNjGT0S8YuN5aH/xkl33imPZ2e62YZ+3c5/Pzc2VhIQEOXHihISHh/tGkCmuRqZhw4ayaNEiiY6OFpuo2oikpCR5qF07qRcWJjZRv04SU1JkwIABEhkZKTZud5ad7W4L9nk7j3clNTVV+vfvX2qQMerUUnBwsB4Kq127tu75ZBPn6SQVYhpddZXYxFnFqg5sW7c7y852twX7vJ3Hu5JdxtNpXEcGAAAYK9DTaWv37t2u1/v27ZMtW7ZIzZo1pVGjRp6cNQAAYACPBplNmzbJ7bff7no9evRo/Th8+HDdwAcAAMBrg0zXrl2t7XkCAAAuHW1kAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMFenoGTHEw+6Cs2r9Kkn9OlpRjKZJxOkOycrMkPChcYmrFyKBrB+nBz8/P07OKSpaYGCwbNgTJli1VZMeOQMnN/XUbHzp0mPUNn2PzPm9zWX/Q0GUnyJTRwl0LZeLXE4uMzzybKV+kf6GHZXuXSXyveAnwDxBf9OW8eZI8f36J7weHhsqTCxaIr5k2LVS2bavi6dkArhib93mby/qFhi47Qaac6lSrI90bdZfG1RvLgZMH5ONdH8vZvLP6vdX7V8uClAUy5Pohl2NbwUPUj4/o6PPStu15ycjwl+TkILYFfBr7vN1lfR3Dlp0gU0YNwhrIW93ekr7N+kqg/6+rrV/zfjJw6UDX66S0JK/awJdLk/btpfOgQQXG+Qd4T0KvTEuXZkrVqheeT5kSSpCBz7N5n7e5rG9g6LITZMqof/P+xY6/pcEtUjOkpq56U3Lzc8UG1SIiJComRmzgLNABW9i8z9tc1vc3dNnptXSJnI2hnNrVaXepHwkA8DI2l/UZXr7s1MhcgvP552XMujH6UaldtbYMazlMbLAtKUkP7mK6dZPeo0Z5bJ4A4HKwuaw/b8CyUyNTQdm52TJsxTDd8EkJqxImH9z5gd7IAADfYHNZn23IslMjUwHp2ekydMVQ2X50u35dK6SWzOkzx+uq2650Y9/QGjU8Nj8AUNlsLuvTDVp2gkw5bcnYIsNXDpfDpy9cFKppRFOZ22euREdEi01sauwLwD42l/VbDFt2Ti2Vw/J9y6VfYj/Xxu1Sr4ss67fMazcuAKD8bC7rlxu47NTIlFHinkQZ8ekIyXfk69fqks1do7rK/B0Fr3Srxj/Q8oHK31LwmISEqpKaeuEaOZs2FbzaaVxcmOt5bOwZiY7Ou+LzB1Q2m/d5m8v6REOXnSBTRimZKa6Nq6iuaJO/nVxkuqiwKK/awLh0S5aElHhBsJkzQ13Pe/bM8blCHXayeZ+3uaxPMXTZObUEAACMRY1MGY3tOFYPNrt58GA92Gbx4mOengXgirJ5n7e5rB9r6LJTIwMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYHg0ykyZNko4dO0r16tWlTp060rdvX0lJSfHkLAEAAIN4NMisW7dORo4cKRs3bpQ1a9bIuXPn5I477pBTp055crYAAIAhAj35z1euXFngdUJCgq6Z2bx5s/z2t7/12HwBAAAzeDTIFHbixAn9WLNmzWLfz8nJ0YNTVlaWfty9e7ecOXNGbJKWlqYft2ZkyMHsbLHJ7sxM/bhz5045cuSI2LjdWXa2uy3Y5+083pX09HQpCz+Hw+EQL5Cfny/33HOPHD9+XDZs2FDsNHFxcTJhwoQi42NjYyUoKEhs4+fnJ16y+a44lp3tbhv2efZ52+Tm5uozNaqSIzw83PuDzGOPPSYrVqzQISYqKqrMNTINGzaURYsWSXR0tNhEJfSkpCQZMGCAREZGik1YdrY7+7w9ON7tPN6V1NRU6d+/f6lBxitOLT3xxBOybNkyWb9+fYkhRgkODtZDYbVr15b69euLTZzVjGrnZtntwXZnn+d4t4fNx7uSXcZmEx4NMqoy6Mknn5TFixfL2rVrpUmTJp6cHQAAYBiPBhnV9XrevHmyZMkSfS2ZQ4cO6fERERFStWpVT84aAAAwgEevIzNjxgx97qtr165Sr1491/Dhhx96crYAAIAhPH5qCQAAoKK41xIAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwVqCnZ8AkiYnBsmFDkGzZUkV27AiU3Fw/13uHDh0WX8ay27ndAcDbEWTKYdq0UNm2rYrYiGW3c7sDgLcjyJSDn59IdPR5adv2vGRk+EtycpDYgmW3c7sDgLcjyJTD0qWZUrXqhedTpoRa9YXGstu53QHA29HYtxycIcZGLDsAwBsRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjMV1ZMohIaGqpKYG6OebNhW80mtcXJjreWzsGYmOzhNfwrLbud0BwNsRZMphyZKQEi+GNnNmqOt5z545PveFxrLbud0BwNtxagkAABiLGplyWLz4mNiKZQcAeCNqZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAe4PM2bNnK2dOAAAArkSQyc/Pl5deekkaNGggYWFhsnfvXj3+hRdekPfee68iHwkAAHBlgszf/vY3SUhIkL///e8SFPTrzfRatWols2fPrshHAgAAXJkg88EHH8isWbNkyJAhEhAQ4Brftm1b2bFjR0U+EgAA4MoEmfT0dGnWrFmxp5zOnTtXkY8EAAC4MkGmZcuW8sUXXxQZv3DhQmnXrl1FPhIAAKDcAsv/JyIvvviiDB8+XNfMqFqYRYsWSUpKij7ltGzZsop8JAAAwJWpkbn33ntl6dKl8umnn0poaKgONj/++KMe17Nnz4p8JAAAwJWpkVFuvfVWWbNmTUX/HAAAwHNBRsnNzZWMjAx9esldo0aNLnW+AAAALk+Q2bVrlzz00EPy1VdfFRjvcDjEz89P8vLyKvKxAAAAlz/IxMbGSmBgoG7YW69ePR1eAAAAjAgyW7Zskc2bN0uLFi0u6Z/PmDFDD6mpqfp1TEyMbjjcu3fvS/pcAABghwpfR+aXX3655H8eFRUlkydP1qFo06ZN0q1bN90jatu2bZf82QAAwPdVKMi88sor8txzz8natWvl6NGjkpWVVWAoq7vvvlv69OkjzZs3l2uvvVYmTpyob0K5cePGiswWAACwTIVOLfXo0UM/du/evdIa+6q/+eijj+TUqVNy4403VmS2AACAZSoUZD7//PNKm4GtW7fq4HL27FldG7N48WJ96qo4OTk5enBy1v7s3r1bzpw5IzZJS0vTjzt37pQjR46ITVh2tjv7vD043u083hV194Cy8HOoahQPUteiUTvqiRMn9L2aZs+eLevWrSs2zMTFxcmECROK7UUVFBQktlG1Xx7efB7DsrPdbcM+zz5vm9zcXElISND5IDw8vHKDzPfff1/8h/n5SUhIiL4gXnBwsFT0tFXTpk3lnXfeKVONTMOGDfW9nqKjo8UmKqEnJSXJgAEDJDIyUmzCsrPd2eftwfFu5/GuqB7N/fv3LzXIVOjU0g033HDRa8dUqVJF7rvvPh1GVLApD3WVYPew4k6Fo+ICUu3ataV+/fpiE2c1o9q5WXZ7sN3Z5zne7WHz8a5kZ2fLZeu1pNqxqJ5Gs2bN0teUUYN6ft1118m8efPkvffe07UFf/nLXy76OePGjZP169fr1KXayqjXqifUkCFDKjJbAADAMhWqkVHdpKdNmya9evVyjWvdurW+LswLL7wg33zzjb4r9rPPPiuvvvpqiZ+j7tM0bNgwOXjwoEREREibNm1k1apV3EEbAABcviCjak8aN25cZLwap95znn5SAeViVM0NAABARVXo1JK6NYG6Iq9qUex07tw5Pc552wLVbapu3boVnjEAAIDLUiMzffp0ueeee/SpJHU6SFE1MeqidupGksrevXvl8ccfr8jHAwAAXL4gc9NNN8m+fftk7ty5umucMmjQIBk8eLBUr15dvx46dGhFPhoAAODyBhlFBZYRI0ZU9M8BAACuXJBJTEyU3r1762vEqOcXo047AQAAeE2Q6du3rxw6dEjq1Kmjn5ekojeNBAAAuGxBRl1xt7jn7g4cOCB//etfyz0TAAAAV6z7dUkyMzPlH//4R2V+JAAAwJUJMgAAAFcSQQYAABiLIAMAAOy4jkz//v0v+v7x48cvdX4AAAAuT5BRd6gu7X11N2sAAACvCzLx8fGXb04AAADKiTYyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMbymiAzefJk8fPzk2eeecbTswIAAAzhFUHm22+/lXfeeUfatGnj6VkBAAAG8XiQyc7OliFDhsi7774rNWrU8PTsAAAAg3g8yIwcOVLuuusu6dGjh6dnBQAAGCbQk/98wYIF8t133+lTS2WRk5OjB6esrCz9uHv3bjlz5ozYJC0tTT/u3LlTjhw5IjZh2dnu7PP24Hi383hX0tPTpSz8HA6HQzzgwIED0qFDB1mzZo2rbUzXrl3lhhtukKlTpxb7N3FxcTJhwoQi42NjYyUoKEhsoxpHe2jzeRzLzna3Dfs8+7xtcnNzJSEhQU6cOCHh4eHeF2Q++eQT6devnwQEBLjG5eXl6YPV399f17y4v1dSjUzDhg1l0aJFEh0dLTZRCT0pKUkGDBggkZGRYhOWne3OPm8Pjnc7j3clNTVV+vfvX2qQ8dippe7du8vWrVsLjHvwwQelRYsW8vzzzxcJMUpwcLAeCqtdu7bUr19fbOKsZlQ7N8tuD7Y7+zzHuz1sPt6dnYHKwmNBpnr16tKqVasC40JDQ6VWrVpFxgMAAHhlryUAAAAjey0VtnbtWk/PAgAAMAg1MgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYgZ6eAZMkJgbLhg1BsmVLFdmxI1Byc/1c7x06dFh8GcvOdmef53i3oayDeQgy5TBtWqhs21ZFbMSys91twz5v5z4P8xBkysHPTyQ6+ry0bXteMjL8JTk5SGzBsrPd2ec53gFvRJAph6VLM6Vq1QvPp0wJtSrIsOwX1gPbnX3eBjYf7zAPjX3LwXlg24hltxPb3U42b3eYhyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsriNTDgkJVSU1NUA/37Sp4FUv4+LCXM9jY89IdHSe+BKWne3OPv8rjnffLetgHoJMOSxZElLihaFmzgx1Pe/ZM8fnDm6Wne1eGPv8BRzvvlXWwTycWgIAAMaiRqYcFi8+JrZi2e3EdreTzdsd5qFGBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGN5NMjExcWJn59fgaFFixaenCUAAGCQQE/PQExMjHz66aeu14GBHp8lAABgCI+nBhVcrr76ak/PBgAAMJDH28js2rVL6tevL9dcc40MGTJE0tLSPD1LAADAEB6tkencubMkJCTIddddJwcPHpQJEybIrbfeKj/88INUr169yPQ5OTl6cMrKytKPu3fvljNnzohNnIFv586dcuTIEbEJy852Z5+3B8e7nce7kp6eLmXh53A4HOIljh8/Lo0bN5bXX39dHn744WIbB6uwU1hsbKwEBQWJbfxExGs23hWmGoZ70a57RVm97OzzYiOr93mLlz03N1dXdpw4cULCw8PNCDJKx44dpUePHjJp0qQy1cg0bNhQFi1aJNHR0WITldCTkpLkoXbtpF5YmNhka0aGJKakyIABAyQyMlJs3O42Lzv7vJ3b3eZ93sZlV1JTU6V///6lBhmPN/Z1l52dLXv27JGhQ4cW+35wcLAeCqtdu7ZuZ2MTZzWjCjGNrrpKbHIwO1s/qgPb1u1u87Kzz9u53W3e521cdmcm8PrGvmPGjJF169bp1PXVV19Jv379JCAgQO6//35PzhYAADCER2tkfvrpJx1ajh49qhPnLbfcIhs3brSyCg0AABgWZBYsWODJfw8AAAzn8evIAAAAVBRBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADBWoKdnwBQHsw/Kqv2rJPnnZEk5liIZpzMkKzdLwoPCJaZWjAy6dpAe/Pz8xFd9OW+eJM+fX+L7waGh8uSCBeJrEhODZcOGINmypYrs2BEoubm/buNDhw6LL7N52RX2eTu3O8xCkCmjhbsWysSvJxYZn3k2U75I/0IPy/Yuk/he8RLgH1DZ2wkeNG1aqGzbVsXKbWDzstuM7Q6TEGTKqU61OtK9UXdpXL2xHDh5QD7e9bGczTur31u9f7UsSFkgQ64fIr6uSfv20nnQoALj/AN8M8CpSrbo6PPStu15ycjwl+TkILGFzcteGPs84J0IMmXUIKyBvNXtLenbrK8E+v+62vo17ycDlw50vU5KS7IiyFSLiJComBixwdKlmVK16oXnU6aEWvVlbvOyF8Y+D3gngkwZ9W/ev9jxtzS4RWqG1NSnmJTc/NzK2zrwCs4vchvZvOw2Y7vDJASZS+Rs9OvUrk47scG2pCQ9uIvp1k16jxrlsXkCLif2ecA70f36EpzPPy9j1o3Rj0rtqrVlWMthlbVtAABAKaiRqaDs3Gx5dM2jknTgQq1EWJUw+eDOD3SYsbXhY2iNGh6bH+ByY58HvBNBpgLSs9Nl6Iqhsv3odv26VkgtmdNnjjWnlWxr+Ago7POAdyLIlNOWjC0yfOVwOXz6wkWhmkY0lbl95kp0RPTl2D4AAOAiaCNTDsv3LZd+if1cIaZLvS6yrN8yQgwAAB5CjUwZJe5JlBGfjpB8R75+rW5N0DWqq8zfUfCS/Wr8Ay0fqPwtBY9JSKgqqakXLva3aVPBq9zGxYW5nsfGnpHo6DzxJTYvu83Y7jAJQaaMUjJTXCFGUV2uJ387uch0UWFRBBkfs2RJSIkXgps5M9T1vGfPHJ/7Mrd52W3GdodJCDIos5sHD9YDYAv2ecD7EWTKaGzHsXqAfRYvPia2snnZbcZ2h0lo7AsAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxPB5k0tPT5YEHHpBatWpJ1apVpXXr1rJp0yZPzxYAADBAoCf/+bFjx+Tmm2+W22+/XVasWCGRkZGya9cuqVGjhidnCwAAGMKjQeaVV16Rhg0bSnx8vGtckyZNPDlLAADAIB49tZSYmCgdOnSQQYMGSZ06daRdu3by7rvvenKWAACAQTxaI7N3716ZMWOGjB49Wv70pz/Jt99+K0899ZQEBQXJ8OHDi0yfk5OjB6esrCz9uHv3bjlz5ozYJC0tTT9uzciQg9nZYpPdmZn6cefOnXLkyBGxcbvbvOzs83Zud5v3eRuX3dmGtiz8HA6HQzxEBRZVI/PVV1+5xqkgowJNcnJykenj4uJkwoQJRcbHxsbqz7KNn5+feHDzeRTLzna3Dfs8+7xtcnNzJSEhQU6cOCHh4eHeWSNTr149admyZYFx119/vXz88cfFTj9u3Dhde+NeI6Pa2Axt00aaRUaKTdSv0sSUFBkwYIBuJG0T9eskKSmJZWe7W4N9nuPdtuNdSU1N1UGmNB4NMqrHUkpKSpEDtnHjxsVOHxwcrIfC6oaFSaOrrhKbOE8nqZ27fv36YhNnFSvLzna3Bfs8x7tt5bySXcZmEx5t7Dtq1CjZuHGjvPzyy7qdy7x582TWrFkycuRIT84WAAAwhEeDTMeOHWXx4sUyf/58adWqlbz00ksydepUGTJkiCdnCwAAGMKjp5aU3/3ud3oAAAAw7hYFAAAAFUWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIwV6OkZMMmX8+ZJ8vz5Jb4fHBoqTy5YIL7mYPZBWbV/lST/nCwpx1Ik43SGZOVmSXhQuMTUipFB1w7Sg5+fn/iixMRg2bAhSLZsqSI7dgRKbu6vy3no0GHxZSw72922fR7mIcigVAt3LZSJX08sMj7zbKZ8kf6FHpbtXSbxveIlwD/A59botGmhsm1bFbERy852B7wdQaaCmrRvL50HDSowzj/A977E3dWpVke6N+oujas3lgMnD8jHuz6Ws3ln9Xur96+WBSkLZMj1Q8TXqIqm6Ojz0rbtecnI8Jfk5CCxBcvOdrdtn4d5CDIVVC0iQqJiYsQGDcIayFvd3pK+zfpKoP+vu0y/5v1k4NKBrtdJaUk+GWSWLs2UqlUvPJ8yJdSqQp1lv7Ae2O727PMwD0EGperfvH+x429pcIvUDKmpTzEpufm5Prk2nSHGRiy7nWze7jAPQaaCtiUl6cFdTLdu0nvUKLGFs9GvU7s67Tw6PwAA+9D9GhVyPv+8jFk3Rj8qtavWlmEth7E2AQBXFDUyldjYN7RGDbFBdm62PLrmUUk6cKFGKqxKmHxw5wc6zAAAcCURZCrIpsa+7tKz02XoiqGy/eh2/bpWSC2Z02cOp5UAAB5BkEGZbcnYIsNXDpfDpy9cEKtpRFOZ22euREdEsxYBAB5BGxmUyfJ9y6VfYj9XiOlSr4ss67eMEAMA8ChqZFCqxD2JMuLTEZLvyNev1a0JukZ1lfk7Ct6uQY1/oOUDPrdGExKqSmrqhYsdbtpU8EqvcXFhruexsWckOjpPfAnLzna3bZ+HeQgyKFVKZoorxCiqy/XkbycXmS4qLMong8ySJSElXgRv5sxQ1/OePXN8rlBn2dnutu3zMA9BphxuHjxYDwAAwDsQZFCqsR3H6sFWixcfE1ux7HayebvDPDT2BQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgeDTLR0dHi5+dXZBg5cqQnZwsAABgi0JP//Ntvv5W8vDzX6x9++EF69uwpgwYN8uRsAQAAQ3g0yERGRhZ4PXnyZGnatKncdtttHpsnAABgDq9pI5Obmytz5syRhx56SJ9eAgAA8OoaGXeffPKJHD9+XGJjY0ucJicnRw9OJ06c0I97f/lFbJOWmanDX2pqqmRnZ4tN0tPTWXa2u9iEfZ6yzrZyXklLS9OPDodDLsbPUdoUV0ivXr0kKChIli5dWuI0cXFxMmHChCs6XwAAwHMOHDggUVFR3h1k9u/fL9dcc40sWrRI7r333jLXyKganMaNG+vUFhERITbJysqShg0b6g0cHh4uNmHZ2e7s8/bgeLfzeFdUPDl58qTUr19f/P39vfvUUnx8vNSpU0fuuuuui04XHBysh8JUiLFxIytquVl2+7DdOd5twz5v5z4fUYZKCo839s3Pz9dBZvjw4RIY6BW5CgAAGMLjQebTTz/Vp4ZUbyUAAIDy8HgVyB133FFqi+SSqNNM48ePL/Z0k69j2dnutmGfZ5+3jc37fHl4RWNfAAAAI08tAQAAVBRBBgAAGIsgAwAAjGV0kJk+fbpER0dLSEiIdO7cWb755hvxdevXr5e7775bXyBI3ZNK3drBFpMmTZKOHTtK9erV9XWH+vbtKykpKWKDGTNmSJs2bVzX0rjxxhtlxYoVYiN1c1m17z/zzDPi69TVzNWyug8tWrQQm27N8MADD0itWrWkatWq0rp1a9m0aZP4OvW9Vni7q2HkyJGenjWvZGyQ+fDDD2X06NG6Rfd3330nbdu21bc5yMjIEF926tQpvawqxNlm3bp1+kDeuHGjrFmzRs6dO6d7val14uvU5bnVF/jmzZt1Qd6tWzd9Fext27aJTb799lt55513dKizRUxMjBw8eNA1bNiwQWxw7Ngxufnmm6VKlSo6tG/fvl1ee+01qVGjhtiwn7tvc1XeKYMGDfL0rHknh6E6derkGDlypOt1Xl6eo379+o5JkyY5bKE23+LFix22ysjI0Otg3bp1DhvVqFHDMXv2bIctTp486WjevLljzZo1jttuu83x9NNPO3zd+PHjHW3btnXY6Pnnn3fccsstnp4Nr6D29aZNmzry8/M9PSteycgaGXXXZ/XLtEePHq5x6j4M6nVycrJH5w1XjvPu5zVr1rRqtefl5cmCBQt0TZQ6xWQLVRunbmPiftzbYNeuXfpUsrof3ZAhQ1x3BPZ1iYmJ0qFDB10LoU4lt2vXTt59912xjfq+mzNnjr5orDq9hKKMDDK//PKLLszr1q1bYLx6fejQIY/NF67srS1UGwlV9dyqVSsrVv3WrVslLCxMXxxrxIgRsnjxYmnZsqXYQAU3dQpZtZOyiWr7l5CQICtXrtTtpPbt2ye33nqrvpGer9u7d69e5ubNm8uqVavksccek6eeekref/99sYlqB6lukBwbG+vpWfFaHr+yL1DRX+c//PCDNe0FlOuuu062bNmia6IWLlyo70+m2g35ephRd/59+umndTsB1bDfJr1793Y9V+2CVLBp3Lix/Otf/5KHH35YfP3HiqqRefnll/VrVSOjjvmZM2fqfd8W7733nt4PVK0cfKhGpnbt2hIQECCHDx8uMF69vvrqqz02X7gynnjiCVm2bJl8/vnnuhGsLYKCgqRZs2bSvn17XTOhGn1PmzZNfJ06jawa8f/mN7/RN5ZVgwpwb7zxhn6uamdtcdVVV8m1114ru3fvFl9Xr169IiH9+uuvt+bUmrJ//359P8JHHnnE07Pi1fxNLdBVYf7ZZ58VSO/qtU1tBmyj2jerEKNOqSQlJUmTJk3EZmqfz8nJEV/XvXt3fVpN1UY5B/VLXbUXUc/VjxpbZGdny549e/SXvK9Tp40LX15h586dukbKFvHx8bp9kGobBh88taS6XqvqRVWgderUSaZOnaobPz744IPi6wWZ+68xdc5cFeaqwWujRo3E108nzZs3T5YsWaKvJeNsDxUREaGvMeHLxo0bp6uX1TZW7SPUeli7dq1uO+Dr1LYu3A4qNDRUX1vE19tHjRkzRl83Sn15//zzz/pyEyq43X///eLrRo0aJTfddJM+tfT73/9eXyds1qxZerDlh4oKMup7TtU84iIcBnvzzTcdjRo1cgQFBenu2Bs3bnT4us8//1x3OS48DB8+3OHriltuNcTHxzt83UMPPeRo3Lix3tcjIyMd3bt3d6xevdphK1u6X993332OevXq6e3eoEED/Xr37t0OWyxdutTRqlUrR3BwsKNFixaOWbNmOWyxatUqXb6lpKR4ela8Hne/BgAAxjKyjQwAAIBCkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgA8ArxMXFyQ033ODp2QBgGIIMgEqh7n315JNPyjXXXCPBwcHSsGFDfZ8g95u7AkBl405UAC5ZamqqvlvxVVddJVOmTJHWrVvLuXPn9E0t1c0+d+zYwVoGcFlQIwPgkj3++OPi5+en71A8YMAAufbaayUmJkbfpX7jxo16mrS0NLn33nslLCxMwsPD9R2NDx8+fNG7//71r3+VqKgoXcOjTjutXLmyQHhS/3PRokVy++23S7Vq1aRt27aSnJzsmiYhIUGHKxWorr/+ev2/77zzTjl48GCB/zV79mz9fkhIiLRo0ULefvtt9grAEAQZAJckMzNTBwxV8xIaGlrkfRUkVChRIUZNu27dOlmzZo3s3btX7rvvvhI/d9q0afLaa6/Jq6++Kt9//7306tVL7rnnHtm1a1eB6f785z/LmDFjZMuWLTpA3X///XL+/HnX+6dPn9af8c9//lPWr1+vA5Wa3mnu3Lny4osvysSJE+XHH3+Ul19+WV544QV5//332TMAE3j69tsAzPb11187VFGyaNGiEqdZvXq1IyAgwJGWluYat23bNv1333zzjX49fvx4R9u2bV3v169f3zFx4sQCn9OxY0fH448/rp/v27dP//3s2bOLfOaPP/6oX8fHx+vXu3fvdk0zffp0R926dV2vmzZt6pg3b16B//PSSy85brzxxgqtDwBXFjUyAC71x1Cp06iaDtX4Vw1OLVu21LU16r3CsrKy5Oeff9btbtyp14Wnb9Omjet5vXr19GNGRoZrnDrl1LRp0wLTON8/deqU7NmzRx5++GF92sk5/O1vf9PjAXg/GvsCuCTNmzfXbVU81aC3SpUqrudqPhR1Kqu4953TOMNXdna2fnz33Xelc+fOBaYLCAi4rPMNoHJQIwPgktSsWVO3X5k+fbqu4Sjs+PHjuiHtgQMH9OC0fft2/Z6qmSlMNQauX7++fPnllwXGq9fFTV9RdevW1f9Htddp1qxZgaFJkyaV9n8AXD7UyAC4ZCrEqNM+nTp10j2N1Oke1eBWNeqdMWOGDi2qS/aQIUNk6tSp+j3V0+m2226TDh06FPuZY8eOlfHjx+vTQqrHUnx8vG7QqxrnVqYJEybIU089JREREbpHU05OjmzatEmOHTume10B8G4EGQCXTF0E77vvvtM9f5599lndvTkyMlLat2+vg4w6nbNkyRJ9wbzf/va34u/vr0PDm2++WeJnqnBx4sQJ/XmqTYuqiUlMTNSnsirTI488otvRqOvfqPCkel6p0PXMM89U6v8BcHn4qRa/l+mzAQAALivayAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAAAgpvr/nXRrYuOt/tQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Copier le plateau pour tester le solveur par regles\n",
+    "board_rules = board.copy()\n",
+    "solver_rules = RuleBasedSolver(board_rules)\n",
+    "\n",
+    "# Etat avant\n",
+    "revealed_before = len(board_rules.revealed)\n",
+    "flagged_before = len(board_rules.flagged)\n",
+    "\n",
+    "# Resoudre\n",
+    "iterations = solver_rules.solve()\n",
+    "\n",
+    "# Resultats\n",
+    "revealed_after = len(board_rules.revealed)\n",
+    "flagged_after = len(board_rules.flagged)\n",
+    "total_cells = board_rules.rows * board_rules.cols\n",
+    "unknown_remaining = total_cells - revealed_after - flagged_after\n",
+    "\n",
+    "print(\"Solveur par regles simples\")\n",
+    "print(\"=\" * 45)\n",
+    "print(f\"Iterations         : {iterations}\")\n",
+    "print(f\"Cellules revelees  : {revealed_before} -> {revealed_after} (+{revealed_after - revealed_before})\")\n",
+    "print(f\"Drapeaux poses     : {flagged_before} -> {flagged_after} (+{flagged_after - flagged_before})\")\n",
+    "print(f\"Cellules inconnues : {unknown_remaining}\")\n",
+    "print(f\"Partie gagnee      : {board_rules.won}\")\n",
+    "print(f\"Coups effectues    : {len(solver_rules.moves_log)}\")\n",
+    "\n",
+    "# Visualiser le resultat\n",
+    "fig = draw_board(board_rules,\n",
+    "                 title=f\"Apres solveur par regles ({len(solver_rules.moves_log)} coups)\",\n",
+    "                 show_mines=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {
+    "id": "cell-14",
+    "papermill": {
+     "duration": 0.00511,
+     "end_time": "2026-04-22T18:08:10.554015",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.548905",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : solveur par regles\n",
+    "\n",
+    "**Sortie obtenue** : le solveur par regles a effectue des deductions locales en quelques iterations.\n",
+    "\n",
+    "| Mesure | Valeur | Commentaire |\n",
+    "|--------|--------|-------------|\n",
+    "| Iterations | Typiquement 3-8 | Convergence rapide |\n",
+    "| Cellules resolues | Variable | Depend de la configuration |\n",
+    "| Cellules restantes | >0 en general | Les cas ambigus ne sont pas resolus |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Les regles simples sont **rapides** (temps constant par cellule par iteration) et **sures** (pas de risque d'erreur)\n",
+    "2. Elles se bloquent quand aucune cellule n'est localement determinee -- c'est la **frontiere du raisonnement local**\n",
+    "3. En pratique, elles resolvent environ 30 a 50% des decisions sur un plateau 8x8 typique\n",
+    "\n",
+    "> **Limite fondamentale** : les regles ne combinent pas les contraintes de plusieurs cellules revelees. Le CSP va combler cette lacune."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {
+    "id": "cell-15",
+    "papermill": {
+     "duration": 0.00486,
+     "end_time": "2026-04-22T18:08:10.563953",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.559093",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 4. Approche 2 : solveur CSP (~12 min)\n",
+    "\n",
+    "Le solveur CSP va plus loin que les regles simples en considerant **simultanement** toutes les contraintes. L'idee est :\n",
+    "\n",
+    "1. **Modeliser** les cellules inconnues proches de la frontiere comme des variables binaires\n",
+    "2. **Poser les contraintes** : chaque cellule revelee impose une somme sur ses voisines inconnues\n",
+    "3. **Enumerer les solutions** du CSP\n",
+    "4. **Deduire** : si une variable vaut la meme chose (0 ou 1) dans **toutes** les solutions, elle est determinee\n",
+    "\n",
+    "### Pourquoi est-ce plus puissant ?\n",
+    "\n",
+    "Considerons cette configuration :\n",
+    "\n",
+    "```\n",
+    "1  ?  ?\n",
+    "1  ?  ?\n",
+    "1  ?  ?\n",
+    "```\n",
+    "\n",
+    "Les regles simples ne deduisent rien (chaque `1` a 2 ou 3 voisines inconnues). Mais en combinant les trois contraintes, le CSP peut determiner que certaines cellules sont necessairement sures ou minees.\n",
+    "\n",
+    "### Optimisation : travailler sur la frontiere\n",
+    "\n",
+    "Pour eviter d'enumerer les solutions sur toute la grille, nous ne considerons que les cellules inconnues **adjacentes a au moins une cellule revelee**. Les cellules completement isolees ne sont pas contraintes localement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-16",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.579209Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.578895Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.587359Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.586572Z"
+    },
+    "id": "cell-16",
+    "outputId": "297571a0-4afa-404d-c3f7-a53159a75ab8",
+    "papermill": {
+     "duration": 0.015713,
+     "end_time": "2026-04-22T18:08:10.588082",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.572369",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe CSPSolver definie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class CSPSolver:\n",
+    "    \"\"\"Solveur CSP pour le Demineur.\n",
+    "\n",
+    "    Utilise python-constraint pour enumerer les solutions\n",
+    "    et deduire les cellules determinee.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, board):\n",
+    "        self.board = board\n",
+    "\n",
+    "    def get_frontier_cells(self):\n",
+    "        \"\"\"Retourne les cellules inconnues adjacentes a une cellule revelee.\"\"\"\n",
+    "        frontier = set()\n",
+    "        for r in range(self.board.rows):\n",
+    "            for c in range(self.board.cols):\n",
+    "                if (r, c) in self.board.revealed:\n",
+    "                    for nr, nc in self.board.get_neighbors(r, c):\n",
+    "                        if ((nr, nc) not in self.board.revealed and\n",
+    "                            (nr, nc) not in self.board.flagged):\n",
+    "                            frontier.add((nr, nc))\n",
+    "        return frontier\n",
+    "\n",
+    "    def get_constraint_cells(self):\n",
+    "        \"\"\"Retourne les cellules revelees qui contraignent des cellules inconnues.\"\"\"\n",
+    "        constraint_cells = []\n",
+    "        for r in range(self.board.rows):\n",
+    "            for c in range(self.board.cols):\n",
+    "                if (r, c) not in self.board.revealed:\n",
+    "                    continue\n",
+    "                if self.board.numbers[r, c] == 0:\n",
+    "                    continue\n",
+    "                unknown = self.board.get_unknown_neighbors(r, c)\n",
+    "                if len(unknown) > 0:\n",
+    "                    flagged_count = len(self.board.get_flagged_neighbors(r, c))\n",
+    "                    remaining = self.board.numbers[r, c] - flagged_count\n",
+    "                    constraint_cells.append(((r, c), unknown, remaining))\n",
+    "        return constraint_cells\n",
+    "\n",
+    "    def build_csp(self):\n",
+    "        \"\"\"Construit le probleme CSP avec python-constraint.\"\"\"\n",
+    "        frontier = self.get_frontier_cells()\n",
+    "        constraints = self.get_constraint_cells()\n",
+    "\n",
+    "        if not frontier:\n",
+    "            return None, frontier\n",
+    "\n",
+    "        problem = Problem()\n",
+    "\n",
+    "        # Variables : chaque cellule frontiere est binaire (0=sure, 1=mine)\n",
+    "        for cell in frontier:\n",
+    "            problem.addVariable(cell, [0, 1])\n",
+    "\n",
+    "        # Contraintes : pour chaque cellule revelee, la somme de ses\n",
+    "        # voisines inconnues dans la frontiere = mines restantes\n",
+    "        for (r, c), unknown, remaining in constraints:\n",
+    "            # Filtrer les inconnues qui sont dans la frontiere\n",
+    "            vars_in_frontier = [u for u in unknown if u in frontier]\n",
+    "            if vars_in_frontier:\n",
+    "                problem.addConstraint(\n",
+    "                    ExactSumConstraint(remaining),\n",
+    "                    vars_in_frontier\n",
+    "                )\n",
+    "\n",
+    "        return problem, frontier\n",
+    "\n",
+    "    def solve(self):\n",
+    "        \"\"\"Resout le CSP et retourne les cellules deduites.\n",
+    "\n",
+    "        Retourne:\n",
+    "            safe_cells: ensemble de cellules determinees sures\n",
+    "            mine_cells: ensemble de cellules determinees mines\n",
+    "            solutions: liste de toutes les solutions\n",
+    "        \"\"\"\n",
+    "        problem, frontier = self.build_csp()\n",
+    "\n",
+    "        if problem is None:\n",
+    "            return set(), set(), []\n",
+    "\n",
+    "        solutions = problem.getSolutions()\n",
+    "\n",
+    "        if not solutions:\n",
+    "            return set(), set(), []\n",
+    "\n",
+    "        # Determiner les cellules forcees\n",
+    "        safe_cells = set()\n",
+    "        mine_cells = set()\n",
+    "\n",
+    "        for cell in frontier:\n",
+    "            values = [sol[cell] for sol in solutions]\n",
+    "            if all(v == 0 for v in values):\n",
+    "                safe_cells.add(cell)\n",
+    "            elif all(v == 1 for v in values):\n",
+    "                mine_cells.add(cell)\n",
+    "\n",
+    "        return safe_cells, mine_cells, solutions\n",
+    "\n",
+    "    def get_probabilities(self, solutions):\n",
+    "        \"\"\"Calcule la probabilite de mine pour chaque cellule frontiere.\n",
+    "\n",
+    "        Retourne un dict (r,c) -> probabilite.\n",
+    "        \"\"\"\n",
+    "        if not solutions:\n",
+    "            return {}\n",
+    "\n",
+    "        probabilities = {}\n",
+    "        n_solutions = len(solutions)\n",
+    "\n",
+    "        # Collecter toutes les variables presentes dans les solutions\n",
+    "        all_vars = set()\n",
+    "        for sol in solutions:\n",
+    "            all_vars.update(sol.keys())\n",
+    "\n",
+    "        for cell in all_vars:\n",
+    "            mine_count = sum(1 for sol in solutions if sol.get(cell, 0) == 1)\n",
+    "            probabilities[cell] = mine_count / n_solutions\n",
+    "\n",
+    "        return probabilities\n",
+    "\n",
+    "\n",
+    "print(\"Classe CSPSolver definie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {
+    "id": "cell-17",
+    "papermill": {
+     "duration": 0.005087,
+     "end_time": "2026-04-22T18:08:10.598533",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.593446",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Testons le solveur CSP sur le plateau apres que le solveur par regles s'est bloque."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-18",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 763
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.611419Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.611135Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.731903Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.731006Z"
+    },
+    "id": "cell-18",
+    "outputId": "ce8c3fa6-4351-44aa-d40b-a18aebf6c613",
+    "papermill": {
+     "duration": 0.128067,
+     "end_time": "2026-04-22T18:08:10.732773",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.604706",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solveur CSP\n",
+      "==================================================\n",
+      "Variables (frontiere)      : 0\n",
+      "Contraintes                : 0\n",
+      "Solutions trouvees         : 0\n",
+      "Cellules deduites sures    : 0\n",
+      "Cellules deduites mines    : 0\n",
+      "Cellules non determinees   : 0\n",
+      "Temps                      : 0.2 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASKRJREFUeJzt3Ql4VNX9//FvFhIggcgSkD0IKBIEKSIuqMhSxFZlkVJldamlolYUa22rQC2CpfoHlYqoJVo2W4USKKtGQTQoaKkIJYAQQASCBIlhSSCZ//M9/GacbGQhZObMeb+e5z6ZLTP33nPumc8999w7YR6PxyMAAAAWCg/0DAAAAFQUQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBJoiMHDlSwsLCzDR+/HgJFjov3vnSeUTV2rp1q1SrVs2s/6eeesq61V+V9To9Pd33WToBNuvevbuvLiclJUmwuu6668w8tm7dWnJzc6v88wkyIqaC+Dd+4eHhUr16dWnYsKF07txZfvnLX0pqaqqE8vLrF4xOGzdulFCVn58vixYtkp/97GeSkJAgNWrUkNq1a8ull14qQ4cOlcWLF0vhX+z45JNPzOubNm0qUVFRUqtWLWnRooVpYH7961/Ll19+WWLD4z/FxMRIYmKiPProo5KRkVGu+X7sscfk9OnT5j30MwvTebjzzjulcePGZh71r97fvHmzhBqtn966GswN+/nkUnlXNdZtxfz+9783f7/66iuZPn26VDn9rSXXzZo1S7+9Sp3uvPNOT3Z29nmbjxEjRvg+a9y4cZ6qcsMNN/g+V9dFYbt37/Z8+OGHZtq2bZvHRgcOHPBcf/31pZbxkSNHfP+zcOFCT0RExFlf/+qrr5a4LkuaGjZs6Nm+fXuZ5vuzzz7z/d+9995b5PmlS5d6oqOji/2c6tWre1auXOkJtMqs1/7bqq7rwk6ePOmrqzqFGhvK21bBuG6/+OILX10+ePCgJ5i1atXKrKsGDRp4cnJyqvSz6ZEpxocffigpKSnyt7/9Tfr06eN7fO7cuWbv3LXf2WzevLl069bNTG3atBHbHD9+3JTjmjVrzH3tcbv77rtlwYIF8t5775k9+8GDB5vDN/7GjBkjeXl55na/fv1k4cKF8v7778v8+fNNz4j20pxN3759fXXpT3/6k0RERJjHDx48aHpZyuKvf/2r7/Ydd9xR4LkjR47I8OHDJScnx9zX29qrpH/VyZMnTU/T0aNHxRXR0dG+uqpTKAmF8j516lRADj3Yum4vu+wyX11u0KCBBLM7/q990h5nbVurVJXGJkt6ZAp7+umnCzw/f/78As8fO3bM8+yzz3q6dOniqVWrlicqKsrTunVrz5gxYzwZGRlF3k8fu/vuuz316tXz1KxZ0+xZfvzxxyXuuZ5tj7ZFixa+595///0Cz+3fv9/zm9/8xnPZZZd5YmJizF5Fy5YtPUOHDjXpvrSeKP1cpZ9Z+DEvTd5Tp071XHXVVZ7atWt7qlWr5mnatKnnjjvu8GzYsKHAa3ft2lXg/Q8fPuy5//77PRdeeKFZZ506dfIsX768yB72hAkTPB06dDDrSt9fezT08x588EGzjKV55plnCnzuvHnzin1dWlqab09C14///xw9erTI6/Pz8z3ff/99iT0yhdfV8OHDfc/FxcWVOt+nT58261Rfr+Wn9/298MILvve7+OKLzfyovLw8T5s2bXzPvfTSS6V+lvZEPfroo55LLrnE1BMtj0aNGplerLFjx5o67m/jxo2eYcOGeZo3b25eq/Ve6/+UKVNMmfmrrHpdWk9XcXWssNWrV3sGDBhglk3r0gUXXODp1q2b6VnT9Xa2nsrXX3/d1EPda9f//+1vf1ukTHSvvnfv3p769et7IiMjTTnrOtXtQZ87F4Eqb//1qevXS8vF+7iWl1fhMvjmm29MWcfHx3vCwsI8//nPf3yv1bZU15e2hVoe2hb8/Oc/9/z3v/8tMs+2rNvC7eW///1vz49+9CNTby666CLPiy++aF6nvdu33HKL2XZ0WQYPHlzk+6Kk3vLC286iRYs8Xbt2NWWp6+e+++4r9ujBli1bPPfcc4/5HtD50c++5pprzHt7l9nr66+/Nu+jr9X6oe+tbXuvXr08Tz31VJH3Tk1N9c3Tbbfd5qlKBJkyBJnClblv376+5w4dOuRp3759iY1rkyZNPDt37vS9XitXu3btirxOK5X/4+caZNavX28ah5LmSxuTcw0yuiwaKEr6f21s3njjjRIbOP916p10g0lPTy/2y7+4STee0mhj5319jx49PGVx/PhxT3h4uO//NPytXbvWc+LEibP+39mCzEMPPeR7rkaNGqXOgwbBsx1G6devn+/5kSNHFnjOv87oF3dpSjvs5h8YNQjql05Jr+3cubMnKysr6IKMhiz9Ii3p/2+++WbPqVOnii3L4uqqTpMmTfK9/r333jvr+//yl7/0nItAlfe5BpnC607bHm1T9VB9SZ+v7WFycrKV69a/vdTDLf7tiHd6/PHHPXXr1i3yeJ8+fcodZFq3bl2mdaKHyjWMlLQOhwwZ4gszubm5vkNFJZVPYboDo+23Pl+nTp0iOwbnE4eWykAPRfTs2dN3f8OGDb7bo0eP9g34vPzyy2XevHmybNkyGThwoHls3759MmLECN/r//KXv8iWLVvMbR2oN3nyZFmyZIn89Kc/9T1+rrR7dNCgQXL48GFzX7sk/9//+3+yYsUKc7isd+/eZgDqzTffbA596Hx7/e53vzOP6eQdwFWSJ598UtatW2dux8bGyrRp08yy6GEYpQNU77vvPtm7d2+J3bmvvvqq/POf/5QmTZqYx7TbecaMGb7XvPPOO+ZvXFyczJo1yxym0UM7OtizS5cupmzO5tixY5KWlua7/+Mf/1jKQgcC33jjjb77s2fPNt27Oti3U6dO8pvf/Ea2b99e5u50XZ/6Hl76HqXZtGmT73Zxh/R27tzpu33hhRcWeM7/vg7AO5tvv/3Wd9itWbNmZv3qITed38cff1zat2/vOwPowIEDcs8995hl8h4+0y54PQSmZaQ+++wz+e1vfyuVTdeh1k8vrbfeuqrT2fz3v/81ZeY9LDxs2DD597//bbY/3Q7V0qVLzXZSHC3rBx980PzP7bff7ntc67yXdqd73//++++Xd999V5KTk+Wll16S/v37m4Hl5yIQ5V0Z9uzZI3/84x9N+zNz5kypX7++vPLKK+ZQvdL7OkB01apV8oc//MF8trZhWkbaRti0bgvT12tbrPXG+52gnn32WdOWvPXWW/Liiy/6Htd15N9elcWOHTvMYR1te3/1q1/5Hn/99dclOzvb3D506JBZn3qITI0aNUqWL18uf//7383JC2rOnDmmjfVuL95l7dChgzmsruXzxhtvmMPqenZScYd1dRiC0nIrqd0/L6osMlncI6N+//vf+57XvVFv96z/YNC5c+f6Bmbp3or/XuvWrVvN//j33uihJy9NwNp7Uxl7rkuWLPE9pnsDn3/++TkN9i2uR0aTu3+Pz3PPPed7vR6eady4se+5P//5z8Xuqf3jH//w/c/kyZOL3evxvo/+/eijj8o92Fq7R882OPdsdH7P1tum5Vv4MGNZBvtqnVm1alWpn6/rzX8PrjD/PabCXb1PPvlkgb3Cs9FeJm891sOQOsC4pJ6nadOm+d5XDxX4v0673b3P6SEx72GXyjxkWtpg35J6ZHRb8z6my+hPD6V4n9Ne0eLKUntr/AeO+3+Gt/fpd7/7XYHtQQ+pVKZAlLc61x4ZPWxTmPbaeZ9/7LHHCgzQ1kPM3udmzJhh1bot3F5qu+Xt5fv0008LrBf/w2GJiYm+x/17osrSI5OYmFjgUJgegvc+p4OFlR7O8j6mbZr/+vb/btMedu9hL+9jPXv29GzevNl8R5Xmyiuv9P2fLm9VoUemjDTRel1wwQXm77Zt23yDQZWeAqnn0+uke/PevVbl7bXR9Ox19dVX+27rQNMrr7xSKoN/z07Lli3LtPdfkfXh7fFR/gMrdQ/Xf1n0OijF8e/lqlevnu92Zmam77buOahvvvlGrr32WtPzo4Nsb7vtNrM3UxpvWXn5z3Np9BRtPd1Xexy0503Xo3fArtLy1fnz7uWUxRVXXGH2unr16iXlUdwAcz0d28s7SLG4+7rOzkYvNeDtNdReIL3kgL631p2f//znZn6LK0tdFv3f4upAVlaWKbNg4T/fhQcB+9/Xbbq4dV1SXfWvr7rH6y0TPc1eT4vWvW7dzrUH0b9eV0Qgyrsy+PdEFNdGTZkyxddu6vSf//ynSLtpy7otTNvByMjIYuuNf/uvvVJe5V2WHj16+HrQtIe6Tp06Rd7Lf33rOvVf3xMnTizwnNIeF28bpb11eukI7aW+5JJLzHWhvD3xhQXqRBiCTBmvP6Jdmf4NeHl5u/gqwr+bVw/XFO4mtlXdunV9t70be+GNQQ9faReyNrwaJLQh0cN1+pg2uv5d+yU1ULrxefmXY1locNHDftqF/fnnn5sA53/Y5LvvviuxK9h71tLatWvN4Ugtq/Xr1xf4Ujyb+Pj4szZuF110ke+2HvLxt3//ft/tVq1alfpZ2uWvhxZ0neqhBQ2jenE5DYs33XSTuf5OZbOpXpdUV/3ra9u2bU3wfeKJJ+SGG26QRo0ame1eG/0JEyaYM+f8d3zKKxjK27+c/HfuzkbXQ0V5202b1q0/7+FWVfgweOGdrIqGgbp+dfNsbWl51rdum7oDp4f59dCdtqE6/xr09fDS9ddfX2CIRXHtVFWeZUWQKYOnn366wDFU797MxRdfXGAPXb/Q/m8AdYFJK4f3f/w3BP9Uqw2EfskVxz9hf/31177bOl5Ex4AU1q5dO9/tXbt2meOdhflXcP8NTENbWb9k/fcwPvroowI9Ff7Loo1QRel83nLLLeYUaQ0Suqf/j3/8w/e8jkkqjf/ViDXI6JicksZBeE8N1fWgYalwQ6Bl8fDDDxd4rKR1phuy7u1rT5Lu9RbeIyvLqZdexYUl3RPz+vjjj33zoX/9y8P/dSXROjBkyBCzPnUvXeuV7ikXXs/+ZaljYfx7o/w/U8cslPYFVt567Z3P8tbVwvPtP5+F7+s2XdHxIVpXdE/2mWeekQ8++MD0SOmXoPbsKW34yzquqjiBKO+zlZN+0ZVFcetTL0LppeNlims3tSdEA5dt6zYYXeq3vq+55ppi17f3u0rpbe2504vB6vgk7dHUOvLQQw/52vi33367wGdoW6DjobwBTsdfVZWCuxYwdA9aC2r37t1mg165cqVvzegAWb2WjDdRDxgwwPfFqM/p9UF0g9M9df1/HVSnlcDbta0DBb1X4NQBbjqQTLvt9Ivav5Hwp42rl86PdgFrJfNvePxpl6AO4NLP1w1R97B0T0Yrs278Orhv0qRJ0rFjR/N6/y9YXRZtHHQPTVO4f69A4cZJr7HgHRw5btw4c3hM92x0kJn2mngHgOleX0VpENAvIe2G1e5k/QwdpOZVlsM6OjhNl9kb6HRgnJap9rToF67Oq76nLrte40WXXdebHr7S9ahl3LVrVxNMdBCbNrxe+v/+wbEy6WBWbRD02hUa4nSP0z8463UtdG9UD5dpI66BTeumLqs3eGuXtX5hlUbrrNZfDVy6nvWzvANC/dezvr/WJb02j14vQuuzHl7Tuus/OFznrXDPxbnW68J19YsvvjCNrJaLbovas1ASratTp041DbT+31133WWWRbvSX3jhBd/rzuUnOJ577jkz0P8nP/mJqTe6p6zl4t9z4V9f/b/gdYfD+6VckkCUt7ec9ArXSg+x6qQhVgeKVpQOGNc67T1UpOtIB+/rjoQOEtVgojsSukOk68WmdRuMBg8ebAbKa1DRoKbbrQ6F0PZF2z/dUdLB7nqihrbl2g7qDpgeFtQdKt0p0W3evxemcNurhwS9wyn0kFVpJ2JUqiobjRMCV/bV09MKDzbV8/7PNiC08EA4ve5I27Ztix0A6j/gzH/wo17DpLhTqfWcfr0ORnGDIj/55BNzClxJ8+R/LYdXXnml2Nf8/e9/P6+nX5dUBv6DOP1PnS5uev7558tUxno6aXmu7KsD9MpSJ2bOnFnm068rQq/m632/d999t8jzOrDbe8pjcadILlu2rEyfU9IVTb3TO++8U67Tr/2vu1PSoN6K1OvMzMwCgxn9ByRWxunX/gMazzYIvrgBsHoq9tnWoQ5i9T8ltbj3KE0gynvOnDnFvsa/3TvbYN/i6HrQ67+Utn3ZuG5Lai/Ptl5KqmtlvY5MWQbKL1iw4KynX/u/l7aXZ3udtu36HePPf9Cw1pmqxKGlYmia171y3dP70Y9+ZE4h1hSrx5T9B4Up7bH49NNPzWnVV111lUm42mugezl6X/dSvacQKx3jsXr1apP4da9CB1Bpb4P2CJR0JVLd69e0rM9rD4f+nw5+070k/2OwhQeZ6d7m2LFjzZ5qzZo1zd6u7vXqXoXOn//eke5l6yDa8qRoXRe6LNoroz0WOvhO98L1vbUXRn+fyntlzIrS8Sh6+qLuQep60B4JXX79TSPdI9Sr75aF9nzpVXn1NELdG9HTBHV9aHloz5Punei4AO/61OXQQY/6+bredY9O16GWrZ4qrr00egjkF7/4hZxP/qdTek9X9ad7qLrXqntcuow6f/pX178+rr1xZaE9dLfeeqtZTl0nup61buv/a93T5fXS99Y6r3ux2n2sn6n/o3v3f/7zn02PZllOh61IvdbDHNoLo+PU9H/KQ7cFrQO6LLqOtIz1c3TPU3vZ9FBJ4as7l4euqwceeMC0Gdp26Pvr9q09dtpTq4MmvdtX4fEcZV2WQJS3bhvaS6Y9Ifp5eimA559/vtTxaWej60Hrsx4m1s/Uz9b1pb0eerqv9vLpfHgPT9i0boNV//79Ta+Jfp9pe6rtn7bhelt7p3U8jJ7arrSHU4dU6OUqtK3Ude1t27Vu6Ni/wienaO+V0rL0v0RBVQjTNFOlnwigXPQLR79ktdHRw4XlHWuD4KNhTXd01L333muupwTWra2WLl1qgqDSkFvWHczKQo8MEOS0l0P3hnSwnY7zgP28Z8/pHq725oJ1a7NJkyb5TmbRMVRVjcG+QJDTwc7+1ySC/fRQiPK/IjJYt7b6sJQra59vHFoCAADW4tASAACwFkEGAABYiyADAACsZfVgX736ql6qWq9fUpk/Ow8AAAJLrw7z/fffm7P7znaNM6uDjIaYqvw9BwAAULX0Zyv0gq0hGWS0J0bpFXf16oMu2bFjh/ltlGEdOkjDcv60vO22HDokS7dvNxeK0yuBuljuLDvl7grauu3mKrpluVp2qNHffNLf4vJ+14dkkPEeTtIQ4/8DdC44ceKE+RmF1vHx0ryEn4MPVdl5eWbZ9fLq/j+14FK5s+yUuyto66LMTyXoT3i4KqyUoSMM9gUAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBakYGeAVvsz94vK3avkNRvUiXtSJpkHM+QrNwsqR1VWxLrJcqgiweZKSwsLNCzikqWnBwta9dGycaN1WTr1kjJzf2hjA8cOMj6RsihvYNNCDJl9Pb2t2XiJxOLPJ55MlM+3PehmZbsXCKz+sySiPAICUUfzZ0rqfPmlfh8dEyMPDh/voSaadNiZPPmaoGeDaDKuN7eudrW2YogU04NajaQns17SotaLWTv93vlne3vyMm8k+a5lbtXyvy0+TLk0iHno6wQINrJlpBwWjp2PC0ZGeGSmhpFWcAJtHewAUGmjJrENpGXerwk/Vr3k8jwH1Zb/zb95fbFt/vup+xJcSLItOzcWboOGlTgsfCI0NszU4sXZ0qNGmduT5kSQ5BByKO9c7OtsxVBpowGtBlQ7OPdmnSTutXrmi5XlZufKy6oGRcnTRMTxQXeEAO4gvbOzbbOVpy1dI68g369OjXodK5vCQBBifYOwYgemXNwOv+0jF091vxV9WvUl+HthosLNqekmMlfYo8e0nfMmIDNE4Dzx9X2jrYu+NEjU0HZudkyfNlwM8BXxVaLlTdvetNs3AAQSmjvEMzokamAfdn7ZNiyYbLl8BZzv171ejL75tlOHVYqbgBcTJ06AZsfAOeH6+0dbV3wI8iU08aMjTJi+Qg5ePzMhdBaxbWSOTfPkYS4BHEJA+CA0Ed7R1tnAw4tlcPSXUulf3J/X4i5qtFVsqT/EudCDIDQR3sHW9AjU0bJXyXLqHdHSb4n39zXnybo3rS7zNta8OqP+vjQdkMrv6QQMElJNSQ9/cx1IzZsKHiF3/HjY323R448IQkJeVU+f0Blo72DTQgyZZSWmeYLMUpPuZ68fnKR1zWNbUqQCTGLFlUv8SJ4M2bE+G737p1DkEFIoL2DTTi0BAAArEWPTBk91uUxM7ns2jvvNJNrFi48EuhZAKqU6+2dq22dreiRAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK2gCDLTp0+XhIQEqV69unTt2lU+/fTTQM8SAACwQMCDzFtvvSWPPPKIjBs3Tj7//HPp2LGj9OnTRzIyMgI9awAAIMgFPMg8//zz8otf/ELuuusuadeuncyYMUNq1qwpf/vb3wI9awAAIMhFBvLDc3Nz5bPPPpMnnnjC91h4eLj06tVLUlNTi7w+JyfHTF5ZWVnm744dO+TEiRPikj179pi/mzIyZH92trhkR2am+btt2zY5dOiQuFjuLDvl7graOpF9+/bJ0aNHxTWHyridBzTIfPvtt5KXlycNGzYs8Lje37p1a5HXT5o0SSZMmFDk8TVr1khUVJS4JiwsTJLT0sRFuuwpKSniIpadcndNmIi7bZ3usG7aJC7Kzc0N/iBTXtpzo+Np/HtkmjVrJsM6dJDW8fHiEu2J0Q174MCBEu/YsmtvhIYYlp1ydwV1PkXu7tRJGsXGiovtvIvLrnYcOiRJEuRBpn79+hIRESEHDx4s8Ljev/DCC4u8Pjo62kyFNYyNleYXXCAu8R5O0hDTuHFjcbG7kWWn3F1BnRfzRe5qO+/isqvvyzhkJKCDffVwUOfOneW9997zPZafn2/uX3311YGcNQAAYIGAH1rSQ0UjRoyQK664Qq688kqZOnWqHDt2zJzFBAAAENRBZvDgwabb9KmnnpIDBw7I5ZdfLsuXLy8yABgAACDogox64IEHzAQAAGDVBfEAAAAqiiADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZkoGcAFjh5UmKff14i//tfifzqKwk7ckTCcnLEU7u2nL7oIsnt1UuO3323uR9q9mfvlxW7V0jqN6mSdiRNMo5nSFZultSOqi2J9RJl0MWDzBQWFhboWQUqDfUeNiHIlMNHc+dK6rx5JT4fHRMjD86fL6Em7NgxiXnhhaKPZ2ZKlE4bNkj1+fMlc9ky8dSpI6Hk7e1vy8RPJhZ5PPNkpny470MzLdm5RGb1mSUR4REBmUegsrle711t621ddoIMyiSvUSM5dcUVkte0qeTXqSPhhw9L9X//WyK+/vpMRUpPlxqzZ8vxBx8MyTXaoGYD6dm8p7So1UL2fr9X3tn+jpzMO2meW7l7pcxPmy9DLh0S6NkEKhX1HjYgyFRQy86dpeugQQUeC48IvT0T5alXT779z3+KPH581CiJ79TJdz9i714JNU1im8hLPV6Sfq37SWT4D5tL/zb95fbFt/vup+xJIcggZFDv3WzrbV12gkwF1YyLk6aJieKkvDwJz8gwPTD+Tl9yiYSaAW0GFPt4tybdpG71uqarXeXm51bxnAHnD/X+By639TUtWXaCDMosas0aqfOznxX7XO5VV8mJIe4cWvEO+vXq1OCHnikgVFHvEYwIMhW0OSXFTP4Se/SQvmPGiGtODBgg30+ZIlK9urjgdP5pGbt6rPmr6teoL8PbDQ/0bAHnlav13uW2frMly06QQZnpqdbfP/WUhOXmSvjXX0v1pUslPDNTaixYINU2bZIjc+dKfrNmIb1Gs3Oz5b5V90nK3jMbd2y1WHnzpjdNow6EKuo9ghlBphIHQcWE2KnHheU3bSrH77/fdz/78celXq9eEnHwoERu3y61nnpKjs6aJaFqX/Y+GbZsmGw5vMXcr1e9nsy+eTaHlRDSXK/3Lrb1ti07QSbEB0GdT574eDnVubNELF1q7kd9/LGEqo0ZG2XE8hFy8PhBc79VXCuZc/McSYhLCPSsAecN9d7ttr6mJcvOTxSgVNXWrpWw7Owij4cdPizVPv/c74HQvLrt0l1LpX9yf1+IuarRVbKk/xJCDEIa9R62oEcGpar52msSvXq15F53nZxq1048NWpIxP79Eq0XxDt0yPe6nF69Qm5tJn+VLKPeHSX5nnxzX3+aoHvT7jJva8ErX+rjQ9sNDdBcApWLeg+bEGRQJmEnTkj0ypVmKs6p9u3l+/HjQ25tpmWm+UKM0lOuJ6+fXOR1TWObEmQQMqj3sAlBBqU6cdddkt+ggTmMFH7ggIR/951IZKTk168vp9u1k5N9+8rJ228XqVaNtQkAqFIEmXK49s47zeSa3BtuMJOLHuvymJkAl7he711t621ddgb7AgAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZAg8yaNWvklltukcaNG0tYWJj861//CuTsAAAAywQ0yBw7dkw6duwo06dPD+RsAAAAS0UG8sP79u1rJgAAAOuCTHnl5OSYySsrK8v83XLokGTn5YlLdmRmmr/btm2TQ4cOiUv27Nlj/rLslLsrqPMimzIyZH92trjYzru47GrP/y1/acI8Ho9HgoCOkVm4cKH069evxNeMHz9eJkyYUOTxkSNHSlRUlLgmTESCovACVF+CpOpWOZadcncNdd7NOp+bmytJSUly9OhRqV27dmgEmeJ6ZJo1ayYLFiyQhIQEcYn2RqSkpMjdnTpJo9hYcYnunSSnpcnAgQMlPj5eXCx3lp1ydwV13s3tXaWnp8uAAQNKDTJWHVqKjo42U2H169c3Zz65xHs4SUNM8wsuEJd4u1h1w3a13Fl2yt0V1Hk3t3eVXcbDaVxHBgAAWCsy0Glrx44dvvu7du2SjRs3St26daV58+aBnDUAAGCBgAaZDRs2yI033ui7/8gjj5i/I0aMMAN8AAAAgjbIdO/e3dkzTwAAwLljjAwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgrchAz4At9mfvlxW7V0jqN6mSdiRNMo5nSFZultSOqi2J9RJl0MWDzBQWFhboWUUlS06OlrVro2TjxmqydWuk5Ob+UMYHDhxkfSPkuFznXW7r91u67ASZMnp7+9sy8ZOJRR7PPJkpH+770ExLdi6RWX1mSUR4hISij+bOldR580p8PjomRh6cP19CzbRpMbJ5c7VAzwZQZVyu8y639W9buuwEmXJqULOB9GzeU1rUaiF7v98r72x/R07mnTTPrdy9UuanzZchlw45H2WFANGdj4SE09Kx42nJyAiX1NQoygIhjTrvdlvfwLJlJ8iUUZPYJvJSj5ekX+t+Ehn+w2rr36a/3L74dt/9lD0pQVXA50vLzp2l66BBBR4LjwiehF6ZFi/OlBo1ztyeMiWGIIOQ53Kdd7mtb2LpshNkymhAmwHFPt6tSTepW72u6XpTufm54oKacXHSNDFRXOBt0AFXuFznXW7rB1i67Jy1dI68g6G8OjXodK5vCQAIMi639RlBvuz0yJyD0/mnZezqseavql+jvgxvN1xcsDklxUz+Env0kL5jxgRsngDgfHC5rT9twbLTI1NB2bnZMnzZcDPwScVWi5U3b3rTFDIAIDS43NZnW7Ls9MhUwL7sfTJs2TDZcniLuV+vej2ZffPsoOtuq+rBvjF16gRsfgCgsrnc1u+zaNkJMuW0MWOjjFg+Qg4eP3NRqFZxrWTOzXMkIS5BXOLSYF8A7nG5rd9o2bJzaKkclu5aKv2T+/sK96pGV8mS/kuCtnABAOXnclu/1MJlp0emjJK/SpZR746SfE++ua+XbO7etLvM21rwSrf6+NB2Qyu/pBAwSUk1JD39zDVyNmwoeLXT8eNjfbdHjjwhCQl5VT5/QGVzuc673NYnW7rsBJkySstM8xWu0lPRJq+fXOR1TWObBlUB49wtWlS9xAuCzZgR47vdu3dOyDXqcJPLdd7ltj7N0mXn0BIAALAWPTJl9FiXx8zksmvvvNNMrlm48EigZwGoUi7XeZfb+scsXXZ6ZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFgroEFm0qRJ0qVLF6lVq5Y0aNBA+vXrJ2lpaYGcJQAAYJGABpnVq1fL6NGjZd26dbJq1So5deqU/PjHP5Zjx44FcrYAAIAlIgP54cuXLy9wPykpyfTMfPbZZ3L99dcHbL4AAIAdAhpkCjt69Kj5W7du3WKfz8nJMZNXVlaW+btjxw45ceKEuGTPnj3m76aMDNmfnS0u2ZGZaf5u27ZNDh06JC6WO8tOubuCOu/m9q727dsnZRHm8Xg8EgTy8/Pl1ltvle+++07Wrl1b7GvGjx8vEyZMKPL4yJEjJSoqSlwTFhYmQVJ8VY5lp9xdQ52nzrsmNzfXHKnRTo7atWsHf5D51a9+JcuWLTMhpmnTpmXukWnWrJksWLBAEhISxCWa0FNSUmTgwIESHx8vLmHZKXfqvDvY3t3c3lV6eroMGDCg1CATFIeWHnjgAVmyZImsWbOmxBCjoqOjzVRY/fr1pXHjxuISbzejVm6W3R2UO3We7d0dLm/vKruMwyYCGmS0M+jBBx+UhQsXygcffCAtW7YM5OwAAADLBDTI6KnXc+fOlUWLFplryRw4cMA8HhcXJzVq1AjkrAEAAAsE9DoyL7/8sjn21b17d2nUqJFveuuttwI5WwAAwBIBP7QEAABQUfzWEgAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALBWZKBnwCbJydGydm2UbNxYTbZujZTc3DDfcwcOHJRQxrK7We4AEOwIMuUwbVqMbN5cTVzEsrtZ7gAQ7Agy5RAWJpKQcFo6djwtGRnhkpoaJa5g2d0sdwAIdgSZcli8OFNq1Dhze8qUGKe+0Fh2N8sdAIIdg33LwRtiXMSyAwCCEUEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaXEemHJKSakh6eoS5vWFDwSu9jh8f67s9cuQJSUjIk1DCsrtZ7gAQ7Agy5bBoUfUSL4Y2Y0aM73bv3jkh94XGsrtZ7gAQ7Di0BAAArEWPTDksXHhEXMWyAwCCET0yAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC7QebkyZOVMycAAABVEWTy8/Pl6aefliZNmkhsbKzs3LnTPP7kk0/K66+/XpG3BAAAqJog86c//UmSkpLkz3/+s0RF/fBjeu3bt5fXXnutIm8JAABQNUHmzTfflJkzZ8qQIUMkIiLC93jHjh1l69atFXlLAACAqgky+/btk9atWxd7yOnUqVMVeUsAAICqCTLt2rWTDz/8sMjjb7/9tnTq1KkibwkAAFBukeX/F5GnnnpKRowYYXpmtBdmwYIFkpaWZg45LVmypCJvCQAAUDU9MrfddpssXrxY3n33XYmJiTHB5n//+595rHfv3hV5SwAAgKrpkVHXXXedrFq1qqL/DgAAELggo3JzcyUjI8McXvLXvHnzc50vAACA8xNktm/fLnfffbd8/PHHBR73eDwSFhYmeXl5FXlbAACA8x9kRo4cKZGRkWZgb6NGjUx4AQAAsCLIbNy4UT777DNp27btOX34yy+/bKb09HRzPzEx0Qwc7tu37zm9LwAAcEOFryPz7bffnvOHN23aVCZPnmxC0YYNG6RHjx7mjKjNmzef83sDAIDQV6Eg8+yzz8pvfvMb+eCDD+Tw4cOSlZVVYCqrW265RW6++WZp06aNXHzxxTJx4kTzI5Tr1q2ryGwBAADHVOjQUq9evczfnj17VtpgX/2ff/7zn3Ls2DG5+uqrKzJbAADAMRUKMu+//36lzcCmTZtMcDl58qTpjVm4cKE5dFWcnJwcM3l5e3927NghJ06cEJfs2bPH/N22bZscOnRIXMKyU+7UeXewvbu5vSv99YCyCPNoN0oA6bVotKIePXrU/FbTa6+9JqtXry42zIwfP14mTJhQ7FlUUVFR4hrt/Qpw8QUMy065u4Y6T513TW5uriQlJZl8ULt27coNMl988UXxbxYWJtWrVzcXxIuOjpaKHrZq1aqVvPLKK2XqkWnWrJn5raeEhARxiSb0lJQUGThwoMTHx4tLWHbKnTrvDrZ3N7d3pWc0DxgwoNQgU6FDS5dffvlZrx1TrVo1GTx4sAkjGmzKQ68S7B9W/Gk4Ki4g1a9fXxo3biwu8XYzauVm2d1BuVPn2d7d4fL2rrKzs+W8nbWk41j0TKOZM2eaa8ropLcvueQSmTt3rrz++uumt+APf/jDWd/niSeekDVr1pjUpWNl9L6eCTVkyJCKzBYAAHBMhXpk9DTpadOmSZ8+fXyPXXbZZea6ME8++aR8+umn5lexH330UfnLX/5S4vvo7zQNHz5c9u/fL3FxcdKhQwdZsWIFv6ANAADOX5DR3pMWLVoUeVwf0+e8h580oJyN9twAAABUVIUOLelPE+gVeXVEsdepU6fMY96fLdDTpho2bFjhGQMAADgvPTLTp0+XW2+91RxK0sNBSnti9KJ2+kOSaufOnXL//fdX5O0BAADOX5C55pprZNeuXTJnzhxzapwaNGiQ3HnnnVKrVi1zf9iwYRV5awAAgPMbZJQGllGjRlX03wEAAKouyCQnJ0vfvn3NNWL09tnoYScAAICgCTL9+vWTAwcOSIMGDcztklT0RyMBAADOW5DRK+4Wd9vf3r175Y9//GO5ZwIAAKDKTr8uSWZmpvztb3+rzLcEAAComiADAABQlQgyAADAWgQZAADgxnVkBgwYcNbnv/vuu3OdHwAAgPMTZPQXqkt7Xn/NGgAAIOiCzKxZs87fnAAAAJQTY2QAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArBU0QWby5MkSFhYmDz/8cKBnBQAAWCIogsz69evllVdekQ4dOgR6VgAAgEUCHmSys7NlyJAh8uqrr0qdOnUCPTsAAMAiAQ8yo0ePlp/85CfSq1evQM8KAACwTGQgP3z+/Pny+eefm0NLZZGTk2Mmr6ysLPN3x44dcuLECXHJnj17zN9t27bJoUOHxCUsO+VOnXcH27ub27vat2+flEWYx+PxSADs3btXrrjiClm1apVvbEz37t3l8ssvl6lTpxb7P+PHj5cJEyYUeXzkyJESFRUlrtHB0QEqvoBj2Sl311DnqfOuyc3NlaSkJDl69KjUrl07+ILMv/71L+nfv79ERET4HsvLyzMba3h4uOl58X+upB6ZZs2ayYIFCyQhIUFcogk9JSVFBg4cKPHx8eISlp1yp867g+3dze1dpaeny4ABA0oNMgE7tNSzZ0/ZtGlTgcfuuusuadu2rTz++ONFQoyKjo42U2H169eXxo0bi0u83YxauVl2d1Du1Hm2d3e4vL17TwYqi4AFmVq1akn79u0LPBYTEyP16tUr8jgAAEBQnrUEAABg5VlLhX3wwQeBngUAAGARemQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtSIDPQM2SU6OlrVro2TjxmqydWuk5OaG+Z47cOCghDKWnXKnzrO9u9DWwT4EmXKYNi1GNm+uJi5i2Sl311Dn3azzsA9BphzCwkQSEk5Lx46nJSMjXFJTo8QVLDvlTp1neweCEUGmHBYvzpQaNc7cnjIlxqkgw7KfWQ+UO3XeBS5v77APg33Lwbthu4hldxPl7iaXyx32IcgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiL68iUQ1JSDUlPjzC3N2woeNXL8eNjfbdHjjwhCQl5EkpYdsqdOv8DtvfQbetgH4JMOSxaVL3EC0PNmBHju927d07IbdwsO+VeGHX+DLb30GrrYB8OLQEAAGvRI1MOCxceEVex7G6i3N3kcrnDPvTIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK2ABpnx48dLWFhYgalt27aBnCUAAGCRyEDPQGJiorz77ru++5GRAZ8lAABgiYCnBg0uF154YaBnAwAAWCjgY2S2b98ujRs3losuukiGDBkie/bsCfQsAQAASwS0R6Zr166SlJQkl1xyiezfv18mTJgg1113nXz55ZdSq1atIq/Pyckxk1dWVpb5u2PHDjlx4oS4xBv4tm3bJocOHRKXsOyUO3XeHWzvbm7vat++fVIWYR6PxyNB4rvvvpMWLVrI888/L/fcc0+xg4M17BQ2cuRIiYqKEteEiUjQFF4V04HhQVR1q5TTy06dFxc5XecdXvbc3FzT2XH06FGpXbu2HUFGdenSRXr16iWTJk0qU49Ms2bNZMGCBZKQkCAu0YSekpIid3fqJI1iY8UlmzIyJDktTQYOHCjx8fHiYrm7vOzUeTfL3eU67+Kyq/T0dBkwYECpQSbgg339ZWdny1dffSXDhg0r9vno6GgzFVa/fn0zzsYl3m5GDTHNL7hAXLI/O9v81Q3b1XJ3edmp826Wu8t13sVl92aCoB/sO3bsWFm9erVJXR9//LH0799fIiIi5I477gjkbAEAAEsEtEfm66+/NqHl8OHDJnF269ZN1q1b52QXGgAAsCzIzJ8/P5AfDwAALBfw68gAAABUFEEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZkoGfAFvuz98uK3Ssk9ZtUSTuSJhnHMyQrN0tqR9WWxHqJMujiQWYKCwuTUPXR3LmSOm9eic9Hx8TIg/PnS6hJTo6WtWujZOPGarJ1a6Tk5v5QxgcOHJRQ5vKyK+q8m+UOuxBkyujt7W/LxE8mFnk882SmfLjvQzMt2blEZvWZJRHhEZVdTgigadNiZPPmak6WgcvL7jLKHTYhyJRTg5oNpGfzntKiVgvZ+/1eeWf7O3Iy76R5buXulTI/bb4MuXSIhLqWnTtL10GDCjwWHhGaAU472RISTkvHjqclIyNcUlOjxBUuL3th1HkgOBFkyqhJbBN5qcdL0q91P4kM/2G19W/TX25ffLvvfsqeFCeCTM24OGmamCguWLw4U2rUOHN7ypQYp77MXV72wqjzQHAiyJTRgDYDin28W5NuUrd6XXOISeXm51Ze6SAoeL/IXeTysruMcodNCDLnyDvo16tTg07igs0pKWbyl9ijh/QdMyZg8wScT9R5IDhx+vU5OJ1/WsauHmv+qvo16svwdsMrq2wAAEAp6JGpoOzcbLlv1X2SsvdMr0RstVh586Y3TZhxdeBjTJ06AZsf4HyjzgPBiSBTAfuy98mwZcNky+Et5n696vVk9s2znTms5NrAR0BR54HgRJApp40ZG2XE8hFy8PiZi0K1imslc26eIwlxCeejfAAAwFkwRqYclu5aKv2T+/tCzFWNrpIl/ZcQYgAACBB6ZMoo+atkGfXuKMn35Jv7+tME3Zt2l3lbC16yXx8f2m5o5ZcUAiYpqYakp5+52N+GDQWvcjt+fKzv9siRJyQhIU9CicvL7jLKHTYhyJRRWmaaL8QoPeV68vrJRV7XNLYpQSbELFpUvcQLwc2YEeO73bt3Tsh9mbu87C6j3GETggzK7No77zQT4ArqPBD8CDJl9FiXx8wE9yxceERc5fKyu4xyh00Y7AsAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1Ah5k9u3bJ0OHDpV69epJjRo15LLLLpMNGzYEerYAAIAFIgP54UeOHJFrr71WbrzxRlm2bJnEx8fL9u3bpU6dOoGcLQAAYImABplnn31WmjVrJrNmzfI91rJly0DOEgAAsEhADy0lJyfLFVdcIYMGDZIGDRpIp06d5NVXXw3kLAEAAIsEtEdm586d8vLLL8sjjzwiv/vd72T9+vXy0EMPSVRUlIwYMaLI63NycszklZWVZf7u2LFDTpw4IS7Zs2eP+bspI0P2Z2eLS3ZkZpq/27Ztk0OHDomL5e7yslPn3Sx3l+u8i8vuHUNbFmEej8cjAaKBRXtkPv74Y99jGmQ00KSmphZ5/fjx42XChAlFHh85cqR5L9eEhYVJAIsvoFh2yt011HnqvGtyc3MlKSlJjh49KrVr1w7OHplGjRpJu3btCjx26aWXyjvvvFPs65944gnTe+PfI6NjbIZ16CCt4+PFJbpXmpyWJgMHDjSDpF2ieycpKSksO+XuDOo827tr27tKT083QaY0AQ0yesZSWlpakQ22RYsWxb4+OjraTIU1jI2V5hdcIC7xHk7Syt24cWNxibeLlWWn3F1BnWd7d62dV9llHDYR0MG+Y8aMkXXr1skzzzxjxrnMnTtXZs6cKaNHjw7kbAEAAEsENMh06dJFFi5cKPPmzZP27dvL008/LVOnTpUhQ4YEcrYAAIAlAnpoSf30pz81EwAAgHU/UQAAAFBRBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWpGBngGbfDR3rqTOm1fi89ExMfLg/PkSavZn75cVu1dI6jepknYkTTKOZ0hWbpbUjqotifUSZdDFg8wUFhYmoSg5OVrWro2SjRurydatkZKb+8NyHjhwUEIZy065u1bnYR+CDEr19va3ZeInE4s8nnkyUz7c96GZluxcIrP6zJKI8IiQW6PTpsXI5s3VxEUsO+UOBDuCTAW17NxZug4aVOCx8IjQ+xL316BmA+nZvKe0qNVC9n6/V97Z/o6czDtpnlu5e6XMT5svQy4dIqFGO5oSEk5Lx46nJSMjXFJTo8QVLDvl7lqdh30IMhVUMy5OmiYmiguaxDaRl3q8JP1a95PI8B+qTP82/eX2xbf77qfsSQnJILN4cabUqHHm9pQpMU416iz7mfVAubtT52EfggxKNaDNgGIf79akm9StXtccYlK5+bkhuTa9IcZFLLubXC532IcgU0GbU1LM5C+xRw/pO2aMuMI76NerU4NOAZ0fAIB7OP0aFXI6/7SMXT3W/FX1a9SX4e2GszYBAFWKHplKHOwbU6eOuCA7N1vuW3WfpOw90yMVWy1W3rzpTRNmAACoSgSZCnJpsK+/fdn7ZNiyYbLl8BZzv171ejL75tkcVgIABARBBmW2MWOjjFg+Qg4eP3NBrFZxrWTOzXMkIS6BtQgACAjGyKBMlu5aKv2T+/tCzFWNrpIl/ZcQYgAAAUWPDEqV/FWyjHp3lOR78s19/WmC7k27y7ytBX+uQR8f2m5oyK3RpKQakp5+5mKHGzYUvNLr+PGxvtsjR56QhIQ8CSUsO+XuWp2HfQgyKFVaZpovxCg95Xry+slFXtc0tmlIBplFi6qXeBG8GTNifLd7984JuUadZafcXavzsA9BphyuvfNOMwEAgOBAkEGpHuvymJlctXDhEXEVy+4ml8sd9mGwLwAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYKaJBJSEiQsLCwItPo0aMDOVsAAMASkYH88PXr10teXp7v/pdffim9e/eWQYMGBXK2AACAJQIaZOLj4wvcnzx5srRq1UpuuOGGgM0TAACwR9CMkcnNzZXZs2fL3XffbQ4vAQAABHWPjL9//etf8t1338nIkSNLfE1OTo6ZvI4ePWr+7vz2W3HNnsxME/7S09MlOztbXLJv3z6WnXIXl1Dnaetca+fVnj17zF+PxyNnE+Yp7RVVpE+fPhIVFSWLFy8u8TXjx4+XCRMmVOl8AQCAwNm7d680bdo0uIPM7t275aKLLpIFCxbIbbfdVuYeGe3BadGihUltcXFx4pKsrCxp1qyZKeDatWuLS1h2yp067w62dze3d6Xx5Pvvv5fGjRtLeHh4cB9amjVrljRo0EB+8pOfnPV10dHRZipMQ4yLhax0uVl291DubO+uoc67WefjytBJEfDBvvn5+SbIjBgxQiIjgyJXAQAASwQ8yLz77rvm0JCerQQAAFAeAe8C+fGPf1zqiOSS6GGmcePGFXu4KdSx7JS7a6jz1HnXuFznyyMoBvsCAABYeWgJAACgoggyAADAWgQZAABgLauDzPTp0yUhIUGqV68uXbt2lU8//VRC3Zo1a+SWW24xFwjS36TSn3ZwxaRJk6RLly5Sq1Ytc92hfv36SVpamrjg5Zdflg4dOviupXH11VfLsmXLxEX647Ja9x9++GEJdXo1c11W/6lt27bi0k8zDB06VOrVqyc1atSQyy67TDZs2CChTr/XCpe7TqNHjw70rAUla4PMW2+9JY888ogZ0f35559Lx44dzc8cZGRkSCg7duyYWVYNca5ZvXq12ZDXrVsnq1atklOnTpmz3nSdhDq9PLd+gX/22WemIe/Ro4e5CvbmzZvFJevXr5dXXnnFhDpXJCYmyv79+33T2rVrxQVHjhyRa6+9VqpVq2ZC+5YtW+S5556TOnXqiAv13L/Mtb1TgwYNCvSsBSePpa688krP6NGjfffz8vI8jRs39kyaNMnjCi2+hQsXelyVkZFh1sHq1as9LqpTp47ntdde87ji+++/97Rp08azatUqzw033OD59a9/7Ql148aN83Ts2NHjoscff9zTrVu3QM9GUNC63qpVK09+fn6gZyUoWdkjo7/6rHumvXr18j2mv8Og91NTUwM6b6g63l8/r1u3rlOrPS8vT+bPn296ovQQkyu0N05/xsR/u3fB9u3bzaFk/T26IUOG+H4RONQlJyfLFVdcYXoh9FByp06d5NVXXxXX6Pfd7NmzzUVj9fASirIyyHz77bemMW/YsGGBx/X+gQMHAjZfqNqfttAxEtr13L59eydW/aZNmyQ2NtZcHGvUqFGycOFCadeunbhAg5seQtZxUi7RsX9JSUmyfPlyM05q165dct1115kf0gt1O3fuNMvcpk0bWbFihfzqV7+Shx56SN544w1xiY6D1B9IHjlyZKBnJWgF/Mq+QEX3zr/88ktnxguoSy65RDZu3Gh6ot5++23z+2Q6bijUw4z+8u+vf/1rM05AB/a7pG/fvr7bOi5Ig02LFi3kH//4h9xzzz0S6jsr2iPzzDPPmPvaI6Pb/IwZM0zdd8Xrr79u6oH2yiGEemTq168vERERcvDgwQKP6/0LL7wwYPOFqvHAAw/IkiVL5P333zeDYF0RFRUlrVu3ls6dO5ueCR30PW3aNAl1ehhZB/H/6Ec/Mj8sq5MGuBdeeMHc1t5ZV1xwwQVy8cUXy44dOyTUNWrUqEhIv/TSS505tKZ2795tfo/w3nvvDfSsBLVwWxt0bczfe++9Auld77s0ZsA1Or5ZQ4weUklJSZGWLVuKy7TO5+TkSKjr2bOnOaymvVHeSffUdbyI3tadGldkZ2fLV199Zb7kQ50eNi58eYVt27aZHilXzJo1y4wP0rFhCMFDS3rqtXYvaoN25ZVXytSpU83gx7vuuktCvSHz3xvTY+bamOuA1+bNm0uoH06aO3euLFq0yFxLxjseKi4uzlxjIpQ98cQTpntZy1jHR+h6+OCDD8zYgVCnZV14HFRMTIy5tkioj48aO3asuW6Ufnl/88035nITGtzuuOMOCXVjxoyRa665xhxa+tnPfmauEzZz5kwzubKjokFGv+e05xFn4bHYiy++6GnevLknKirKnI69bt06T6h7//33zSnHhacRI0Z4Ql1xy63TrFmzPKHu7rvv9rRo0cLU9fj4eE/Pnj09K1eu9LjKldOvBw8e7GnUqJEp9yZNmpj7O3bs8Lhi8eLFnvbt23uio6M9bdu29cycOdPjihUrVpj2LS0tLdCzEvT49WsAAGAtK8fIAAAAKIIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAQWH8+PFy+eWXB3o2AFiGIAOgUuhvXz344INy0UUXSXR0tDRr1sz8TpD/j7sCQGXjl6gAnLP09HTza8UXXHCBTJkyRS677DI5deqU+VFL/bHPrVu3spYBnBf0yAA4Z/fff7+EhYWZXygeOHCgXHzxxZKYmGh+pX7dunXmNXv27JHbbrtNYmNjpXbt2uYXjQ8ePHjWX//94x//KE2bNjU9PHrYafny5QXCk37mggUL5MYbb5SaNWtKx44dJTU11feapKQkE640UF166aXms2+66SbZv39/gc967bXXzPPVq1eXtm3byl//+ldqBWAJggyAc5KZmWkChva8xMTEFHleg4SGEg0x+trVq1fLqlWrZOfOnTJ48OAS33fatGny3HPPyV/+8hf54osvpE+fPnLrrbfK9u3bC7zu97//vYwdO1Y2btxoAtQdd9whp0+f9j1//Phx8x5///vfZc2aNSZQ6eu95syZI0899ZRMnDhR/ve//8kzzzwjTz75pLzxxhvUDMAGgf75bQB2++STTzzalCxYsKDE16xcudITERHh2bNnj++xzZs3m//79NNPzf1x48Z5Onbs6Hu+cePGnokTJxZ4ny5dunjuv/9+c3vXrl3m/1977bUi7/m///3P3J81a5a5v2PHDt9rpk+f7mnYsKHvfqtWrTxz584t8DlPP/205+qrr67Q+gBQteiRAXCuO0OlvkZ7OnTwr05e7dq1M701+lxhWVlZ8s0335hxN/70fuHXd+jQwXe7UaNG5m9GRobvMT3k1KpVqwKv8T5/7Ngx+eqrr+See+4xh52805/+9CfzOIDgx2BfAOekTZs2ZqxKoAb0VqtWzXdb50Ppoazinve+xhu+srOzzd9XX31VunbtWuB1ERER53W+AVQOemQAnJO6deua8SvTp083PRyFfffdd2Yg7d69e83ktWXLFvOc9swUpoOBGzduLB999FGBx/V+ca+vqIYNG5rP0fE6rVu3LjC1bNmy0j4HwPlDjwyAc6YhRg/7XHnlleZMIz3cowNudVDvyy+/bEKLnpI9ZMgQmTp1qnlOz3S64YYb5Iorrij2PR977DEZN26cOSykZyzNmjXLDOjVwbmVacKECfLQQw9JXFycOaMpJydHNmzYIEeOHDFnXQEIbgQZAOdML4L3+eefmzN/Hn30UXN6c3x8vHTu3NkEGT2cs2jRInPBvOuvv17Cw8NNaHjxxRdLfE8NF0ePHjXvp2NatCcmOTnZHMqqTPfee68ZR6PXv9HwpGdeaeh6+OGHK/VzAJwfYTri9zy9NwAAwHnFGBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAAxFb/H9OYffFX08A7AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Partir du plateau deja partiellement resolu par les regles\n",
+    "board_csp = board_rules.copy()\n",
+    "csp_solver = CSPSolver(board_csp)\n",
+    "\n",
+    "# Construire et resoudre le CSP\n",
+    "start = time.time()\n",
+    "safe_cells, mine_cells, solutions = csp_solver.solve()\n",
+    "elapsed = (time.time() - start) * 1000\n",
+    "\n",
+    "frontier = csp_solver.get_frontier_cells()\n",
+    "constraints = csp_solver.get_constraint_cells()\n",
+    "\n",
+    "print(\"Solveur CSP\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"Variables (frontiere)      : {len(frontier)}\")\n",
+    "print(f\"Contraintes                : {len(constraints)}\")\n",
+    "print(f\"Solutions trouvees         : {len(solutions)}\")\n",
+    "print(f\"Cellules deduites sures    : {len(safe_cells)}\")\n",
+    "print(f\"Cellules deduites mines    : {len(mine_cells)}\")\n",
+    "print(f\"Cellules non determinees   : {len(frontier) - len(safe_cells) - len(mine_cells)}\")\n",
+    "print(f\"Temps                      : {elapsed:.1f} ms\")\n",
+    "\n",
+    "if safe_cells:\n",
+    "    print(f\"\\nCellules sures : {sorted(safe_cells)}\")\n",
+    "if mine_cells:\n",
+    "    print(f\"Cellules mines : {sorted(mine_cells)}\")\n",
+    "\n",
+    "# Visualiser avec les deductions surlignees\n",
+    "fig = draw_board(board_csp,\n",
+    "                 title=f\"Deductions CSP ({len(solutions)} solutions, \"\n",
+    "                       f\"{len(safe_cells)} sures, {len(mine_cells)} mines)\",\n",
+    "                 highlight_safe=safe_cells,\n",
+    "                 highlight_mines=mine_cells)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {
+    "id": "cell-19",
+    "papermill": {
+     "duration": 0.00702,
+     "end_time": "2026-04-22T18:08:10.746742",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.739722",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : deductions CSP\n",
+    "\n",
+    "**Sortie obtenue** : le CSP a enumere toutes les solutions compatibles avec les contraintes visibles et a identifie les cellules determinees.\n",
+    "\n",
+    "| Mesure | Valeur | Signification |\n",
+    "|--------|--------|---------------|\n",
+    "| Variables | Cellules de la frontiere | Seules les cellules adjacentes aux revelees |\n",
+    "| Solutions | Variable | Nombre de placements de mines compatibles |\n",
+    "| Cellules deduites | Forcees dans toutes les solutions | Certitude absolue |\n",
+    "| Non determinees | Valeur differente selon les solutions | Necessite un choix |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le CSP combine les contraintes de **plusieurs** cellules revelees, ce qui lui permet de deduire des cellules que les regles simples ne voient pas\n",
+    "2. L'enumeration des solutions est **exacte** : si une cellule est dite sure, elle l'est avec certitude\n",
+    "3. Le cout est l'enumeration exhaustive, qui peut etre exponentielle dans le pire cas\n",
+    "\n",
+    "> **NP-completude en action** : le nombre de solutions peut exploser exponentiellement avec la taille de la frontiere. Sur un plateau 16x16, la frontiere peut contenir 30+ cellules, rendant l'enumeration couteuse."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-20",
+   "metadata": {
+    "id": "cell-20",
+    "papermill": {
+     "duration": 0.076955,
+     "end_time": "2026-04-22T18:08:10.831110",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.754155",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Application des deductions CSP\n",
+    "\n",
+    "Appliquons les deductions du CSP au plateau, puis relançons les regles simples pour propager les consequences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-21",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 711
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:10.843161Z",
+     "iopub.status.busy": "2026-04-22T18:08:10.842941Z",
+     "iopub.status.idle": "2026-04-22T18:08:10.990787Z",
+     "shell.execute_reply": "2026-04-22T18:08:10.989986Z"
+    },
+    "id": "cell-21",
+    "outputId": "73658d99-a12a-4667-a894-64526a02223d",
+    "papermill": {
+     "duration": 0.154991,
+     "end_time": "2026-04-22T18:08:10.991565",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.836574",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres application des deductions CSP + regles\n",
+      "==================================================\n",
+      "Cellules revelees  : 54\n",
+      "Drapeaux           : 9\n",
+      "Inconnues restantes: 1\n",
+      "Partie gagnee      : True\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASdJJREFUeJzt3Ql4VNX9//FvFpJAQpBdIEAQUAQEKSAuWJFFxLbKIvUnu0st7qLY1rZqUBFbqpUqiopCFQFbBAkoIDYKokFBm4ogYQ0gAkEChLAkQOb/fA//GScbWQiZOXPer+e5T2buTGbunXPunc8959w7YR6PxyMAAAAWCg/0AgAAAFQUQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBghBo0aNkrCwMDMlJSVJMPjxxx+ldu3aZplGjBhxVt5j+vTpvvXu0aPHWXkPINS8/vrrvu0mJSVFbEOQqUQrVqzwVQbvtHbtWnHF4cOHZfLkydK3b18599xzJTo6WurXry8XX3yxjBkzRr766qsi/zN79mzp1auX1KtXT6pVqyZ16tSR1q1byy9/+Uv505/+JAcPHizw/MKfr07h4eFyzjnnyKWXXirPP/+85OXlVeFao6zGjRsnBw4cMGX2yCOPFHhs+fLlcuedd0qXLl1MvSGMoKpondSw750CRUO4dxnS0tKq9L1HjBghTZs2Nbcfeughyc/PF6voby2hctx22236u1UFprFjxzrx8a5cudLTrFmzIuvvP3Xs2LHA/zz44IOnfb5OGzduLPA/pT1fp8svv9xz7Ngxj8tGjhzp+zwef/zxQC+OZ9euXZ5q1aqZ5endu3eRx++///5iy/Kqq64q1/vs2bPH8+mnn5rpm2++qcQ1QKjaunVrgToXKFrXvcswbdq0Kn//J5980vf+8+bN89iEFplKcuTIEfn3v/9dZP6MGTPk5MmTcrbl5ORIoHz33XemFWb79u3mfq1ateTPf/6zLFq0SD788EN54YUX5Oc//7k5yvbasmWL/P3vfze3df7DDz9snv/RRx+ZZs6hQ4dKfHz8ad/3j3/8o3z66aeyePFiGT58uG/+559/LlOmTKnQumh3hC6PHh2FUhkF2tSpU+X48ePm9s0331zk8QYNGsj1118vTzzxhAwePLjC76Ov0717dzNddNFFZ7TMCLyjR4/a1zpgqZv9tsuK7j8DJtBJKlTMmDHDl2YvvfRST5s2bXz333///VKPmDUBd+3a1RMTE+OpX7++54477vBkZWWVmNjfeOMNz9///nfzPnqkq0e0XuvWrTOtQy1atPBER0d7atasaVopNOXn5+cXeM3vv//evJc+Nyoqyrx/QkKCOWp+7LHHyrTu11xzjW+5atWq5fnuu++KfZ7/EfI777zj+59OnToV+3xtVcnLyyswz//Iyf+o5eTJk57ExETfYzfccIOnIryfcUWPiLQsvcugZbx48WLPZZdd5qlRo0aBFql9+/Z5/vznP3s6dOjgiY2NNZ9727Ztzf8fOnSoyOtmZGR4brzxRk98fLwpz1/84heetWvXlngUd7oWmcOHD3v+8pe/mPqmr6Xl3qpVK8+YMWM8mZmZBZ6rn+ukSZN8z42MjPTUq1fP87Of/czUm5LKurB27dr5lmf37t1l/gzL2yKjn0Fx//vxxx/75jdv3tyzbds2z7Bhwzx16tQxn3337t09q1atKrYO6vpfccUVnnPOOcdsa40aNTKf/+eff17guWlpaZ7hw4eblkn9TPXz0s9t4sSJRVoIC5fP/PnzPd26dTPLop+vfrY5OTkF/keX2/s/H330kXnd1q1bm/fSuv/ss88WeH7hdS7pM9Zl8XfixAnPlClTzGfiXWddp9tvv92zZcuWIp/RW2+95XtuRESE+Uzbt29vXjc1NbXUMiu8nOnp6Z4BAwaY19N5+/fvP2vL5b/9FDfpsqkXXnjBc+2115rP2bsd6H5a931z584t8t7lKSv/Olvc5F8+Z3vbveCCC8x7hoeHm32ULQgylUS/+L0V78UXXyzQTDd48OAiz/ffkV144YUldsUcOXLE9z/+G51uFP7P9QYZDUS6Myxpoxg6dKgvzGhIaNmyZYnP1RBUmh9++METFhbm+58nnniiTJ+XfsF7/0c3MP281qxZYza+0ykpyCgNBd7H+vXr5wl0kDnvvPPMDsG/PJV2l2lYLOlz152t/05Eu2UaN25c5Hm1a9c2AbQ8QWbv3r3m9Ut67yZNmhT4UtAwe7qd7KxZs0r9TPQ9vXWk8BdqIIKMhsEGDRoUWRfdyWdnZ/v+R8tAQ3ZJ664HEl76OXi7zoqbOnfuXOC1/ctHv4iK+5/f/va3JX45Ft7+iyuPigQZ3d9cffXVJa6HhoIvvvjC93w9oDpd/ZgwYUKpZea/nHogpAHB/zU0yJyt5SprkNGQebrn+deF8pZVWYNMVWy7I0aM8D1eXEALVnQtVYIdO3b4RnpHRkbKTTfdZLpGvJKTk2X//v2n7Zq57bbb5IMPPpCnnnrKDHpV//vf/+S5554r9n82btxomuLnzZsn7733nvTp00f27t1ruliOHTtmnjN69GjT7fLWW29J8+bNzby3335bpk2b5nv9zZs3m9sdOnQwr7V06VL55z//Kffff7+0atWq1HX/+uuvNQz77l9zzTVl+sy6desmdevWNbdPnDghjz76qOkKqFmzpunemThx4mk/s8Ldeq+++qp88803vnmdOnWSQNPuszZt2pjPf8mSJXLvvfea+cOGDZPvv//e3L766qvN575gwQK56qqrzLxvv/1WHnjgAd/r6KDnH374wdzW7jYdUD1//nxp3769bN26tVzLdPfdd5vXVzoIe9asWaZLb9CgQWbezp07ZeTIkb7nv/vuu756rV2EWs+1C3XChAlmeb119XT0/bx1RAdyB1p2drbExsbKzJkzzbagXaHes6p0ntc999wj//3vf83tqKgo0/35/vvvmwHqur3qoGS1e/duc9/bddavXz9Tni+99JLvtXWg+x/+8Idil2fTpk2mWX/hwoVmwLOXdrGW1B2pdevxxx83/+OtN2rSpEln9NnoQNOPP/7Y3G7RooX5fLR7WPcl3oGxuqy6zfrXD+///uc//zH1Wfdb1157rVSvXr1c76+D+/Vz1EH7+r66Pvo5n63l0jpdeEiAdld7J+9+RLcJLQ/9vD/55BOzn3zxxRd9dUDfw/ve5S2r6667zryXbo+Fu8110u2/qrbd888/33fbf38a9AKdpELB+PHjfSlWm5y9tDvHO/+ll14q8D/+R2Ta9Ofvnnvu8T2mrQxe/kcPeoRXmDZ/eh/X5O4d9KjTn/70pwJdX2rDhg2+eb169TJdFYW7csrTpVbc4NzTWbJkiadu3bolHjHoUXPh5s/THWF4p4YNG5pWjNKUdiTkP5WlJaHwka52JxXuRtFWJ+/jegSvn4G3jObMmVPgMe1i0hYqbUHwzn/uued8r6VHaP6tb6W1yOiRrTaxe+fPnDnT99565OnforB+/foCdbh69epmWQ8cOOApr3/961++173pppsC3iKj05dfful7bPTo0b75OgBd6XpqS6F3vjbRl0Qf8z5PWxOOHj3qe0xbZ72PaTlq90jh8tFuN28rqZa31hvvY/7dsf5H+XfddVeBgfbe+dp9UtEWGV0G/9YQrWv++xDtUvM+pi2qasiQIQWO8LVOllfhsklOTi7w+NlerrIM9t2+fbv5zLXrRbeF4vYRZ1JWpQ32rapt96WXXip2uYNdZKCDVCjQFgwv/5YYva0DT5UOHvU/2vKnAxML39e07215Kc7AgQOLzFu3bp3vtib3K6+8stj/9aZ6bXHp3bu3GWCrRyzt2rWTiIgIadmypVx22WXmaEdPaT4dPe3Z3759+8rUkuNtvdEWhTlz5pijhdTUVF8LkcrMzDQtE9qqVBZ65KGnbT/77LPm9O9Au+KKK6Rhw4YllpEeeeog6eLoY+np6dKkSRPTguD/ml56yrq2+JT1VM0NGzYUGHg+ZMiQEp+rdeSCCy4wdUDrsA669C6rDqjVI0I9Erz11lvN515W/q13gaKtfl27dvXd97YMqqysLN9n5X+EXdz25rV+/XrfbT19PCYmpthtW8tRW9a8p7l69ezZ0zcQXi8loNfa0VZG/+UpTC9ZcLrlrwht0dXJ68EHHzxt/dD68Jvf/EbeeecdU6+8g0V1+bWFV7fFu+66S2rUqFHmZdAWDv2/YFoubXHTctX90emU1IJcGWVVVduuJwi2z4ogyJwhrShayfwrWHGV7MsvvzRdSBdeeKFUhkaNGlX4f73N1brz1CZwDWLa9aFfstoMquujkzaz6/rpRlySn/3sZ+Z1vBuAhiLtNirPl8ott9xiJqXvr0362mSqvvjiixL/V5tftRlfd/5xcXEmQJVnp+lt0vWn3T8aDLyv7eX/5VQVZeQtJ/8zvVTh+2eLt45oV6V2S2pd0G4WrRe6Q9dmfZ20TnvPPiuJXkuoMr5oK4teq8if/848EDvyiiyP//+UFCT960rhbg//YHAm9UO7gVevXm0O1PSvhm/tolu2bJmZPvvsM9OlU1Ya/M+kjp+N5XrjjTd8IUaX7+mnnzb7Gt3vDBgwwLyuKunsqrKUVbBsu1l+26eGHlswRqYSW2Mq+lzdqEq6X1LrRnEbu39Iuvzyy81OsLjJW9H1tn5B//a3v5W5c+eaI0u9qN19993naxXQ1pLSvqz9x8Voa0hJrUjeliCVkZHhG3/g77zzzivQz3u6Uy91vIUe8eq66pFWeUJM4VN1vZN3TIP3tb3T6cJcSUorI+2n1779kspI+7E1BHiXSa1cudJ3W3eg/q0BpdH+b21x89Kde0nv7S0Dva+nzuvpmBoq9ajTP1xqP31pdCyP97PQ97RB4c+quC89b8jQVjEvHQvjHaNWeFvW8U1nGm7LQ1sg/OtKbm6uL9QU18qpdU1b+bz04Kak+qFjPpTe1yN8HdOiFwTVgKRjfvTAQulYLm/rUkW3mbO9XBpI/BXe53gvK+Ed36YtGbpNNGvWzLRAVxb/5Si8DFW17ab7bZ82Xb6AFpkzoDssbb70Gjt2rOmW8bdmzRoz6E/poM/x48cXqJDe1po77rjDNF/rl/srr7zie+zXv/51mZdHBxlrS4JWZm1JufHGG03rkH4R6kAwraQ6oLh///5mg9+zZ4/pqtBmRq20upPVjVuPYPzXsTSa6rUrSgfq6caiLTLasqEBQ9dVjwR04JmmfW940Z2KDlDWJn5t6u3YsaPZ0etOQz8jL33dUKKfs67zqlWrTJOvditocNTuBt3ZalebdrPpjkxbt3TnpuWoAw3VY489ZgaeNm7c2AyILkv5+HcDah3zDm7UFikdwKphWQPVtm3bzBV2NRx5A5Je00WPIvUIV7u5dJCsHs15leX99UtIuy01yOrAeG2qL9z15/+e/uFMv4B1MLvSLw5tAawKus3ouuvAXqWfk25DGi51+9KuWK2z2l2s26heqVi3HT3i1fLSZn0d0O0dqOn9EqyKI3L/gwJ9Pw0uGmJ0fXSgq5a/tnwWFyK0ZVTrlfdqrzpAWYOorrNumxqkddCqt7tTr9it3cF6MKN1WD83PQHAGxL0y1Tfu7wHGVW5XNpi4t+qrPuzSy65xGx7un/Uz9FLD+x0n6Tbp16pujJb8Py7nbSMEhMTzbau3UQa5qpi2/3yyy99n7mGIGsEepCOzXTAlf9Avtzc3CLP0UFa/gOxFi1aVGSw38UXX1zgFGbvdNFFF5nrBpTnyo96ytzpTr/2H/ypA2JP9zwd7Oh/SmNlXtl36dKlp32uTnFxcZ6vvvqqwPv4P342rn5Z2deRKY4Osj7d6deFB6qWdPq1nqrqf+2cspx+rdeaON0pnIUHhvbt2/e0z73vvvvK9Lk89dRTvv+ZOnXqaT+3kqaSPs+KXEempPf2f48ff/yxwCn9Z3r69cGDB0stn8IDRb2n/55u/ukGq/7mN78psiy6r/G/rk/h06979OhRall46Snip3ve9ddfX2qZna5sqmq59FpPhZ+jg2u9259e6qDw43rdJ//T+M+0rF555ZVil1Wvh1MV2+7GjRt9j/Xp08djE7qWzoB/V5G2Kmh6Lu4oWE+x9SruirE33HCDOa1TWzK0q0ePYHWwmp5uWN4jGe2z1VYPbeHRtK6vp0lcb+syajOjDnTzLtuTTz5pjlr0aFe7OjTB69G+pn8dP6JHJmWhy65jbHSQsra0aLeNnt6nRxna7aOnc+vVXb30qEZbs/TItXPnzuaIQT8/XV5tRtXuLl2PqjoCr0rabaWnNmrrip7eqc3dOshRy0CPgrRFyv/Kmtp6oV0U2nKmY4r0+Tp4T5vM/QdbazmXRo/s9Kjrb3/7mxnIrUeqWk5a5npfWxD8T13VFgfta9fuE+2q0BY2/R99rp4+Wtr4GK/bb7/dd7qn/ynOwUzrrjbF6ym7Wl+9n5W2XOoRsf9YsP/7v/8zn6u2umgLgD5Py0nr9l//+ldTVqVdqfps0GXXfYmui25bWm66r9FWo+LoPkBbAvVyBnokr60Vuk/QsSG6LtrSoacfe+lAWi1bbWnU99D6ofVQ67Vepdm/xfpMnO3l0tZyLVPdvgrT7U9fW0+M0DLU19Ny1v1zeU8vPx09hV9b9hISEop0d1XFtjvLr6uppBNTglWYpplAL4Srv07sDULazRMsv1CM4KSbaeHxA9qNoc3P2kWldJCydncEK+1C0+tZ6HpoN1Pbtm0DvUgARMwP7eqwCO0O1bFFOtaruDAVrOxZUsBhegqnHo1qK5WOM9GjU23J84YYDTDa8hXMNLBrC5KGMr0oF4Dg8NZbb/ku0qktPjaFGMVgX8AC2m2n3W3F0W48/XHSqjo1u6K0Sb6sV2sGUHVuu+02M9nKrtgFOEr7rHVMho6f0rEB2pev44f0V8bXrl1rzuAAABcxRgYAAFiLFhkAAGAtggwAALCW1YN99eqK+iNsOl4g2Ac6AgCAstMzHA8dOmSulXO6M6msDjLF/ZIsAAAIHXrJCb1QYEgGGe9VGPXUU70qqkv0t4r0tzWGd+ggDf//D6G5Yt3evfLBxo1y/fXXF/gxOZfKnXWn3F3Bvm6jucJ6IK4MHWj6e4APPfRQsVdcDpkg4+1O0hCjl7V3iV4ITS/p36p+fWnmd5l6F+ScPGnWXa9qq02OLpY76065u4J9XZT5mQT9WQZXhZUydITBvgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFgrMtALYItdObtkybYlkvpDqqTvT5fMI5mSnZct8VHx0q5uOxl8/mAzhYWFBXpRUcmSk6NlxYooSUurJuvXR0pe3k9lvHv3Hj5vhBz2d27ZuXOn3HbbbXLs2DFzv0uXLjJx4sQC32cej0fGjh0rX331lbkfExMjU6dOlYSEBAk0gkwZzdk4R8Z/Mb7I/KxjWfLpzk/NtHDLQpnWd5pEhEdIKPps5kxJnTWrxMejY2Pl3tmzJdRMmhQra9dWC/RiAFXG9f2da/u6Jk2ayF133SXPPfecub969WqZN2+eDBw40Pccve8NMerOO+8MihCj6FoqpwY1GsjNbW6WP3T9gwxtM1RiImJ8j3247UOZnR46lRun6EFJYuIJueGGY3LZZXl8LHAG+zt3XH/99XLppZf67r/66quyY8cOc1v/vvLKK77HLrnkErnhhhskWNAiU0ZN4prIiz1flP6t+ktk+E8f24DWA+TGBTf67qdsT5GhFw6t/JIKMi06d5ZugwcXmBceEXpHZmrBgiypXv3U7YkTYyU1NSrQiwScVezv3NzXPfzww3LLLbdIdna26WZ6+umnZdKkSeZvbm6ueU58fLz87ne/k2BCkCmjga1/amLz171Jd6kTU8c0uaq8fDeO2GvUqiUJ7dqJC7whBnAF+zs393V169aVBx98UJKSksz97777znQhbd682fecMWPGSL169SSY0LV0hryDfr06Neh0pi8JAEGJ/V3o69Gjh/Tu3dt33z/E6Pyrr75agg0tMmfgRP4JGbtsrPmr6lWvJyPajhAXrE1JMZO/dj17Sr8xYwK2TADOHlf3dy7u6+6//37573//K/v27fPNq127tpkfjGiRqaCcvBwZsWiEGeCr4qrFyZvXvmk2bgAIJezv3LJ3714zTsbfoUOHZPfu3RKMaJGpgJ05O2X4ouGybt86c79uTF2Zcd0Mp7qVihsAF1u7dsCWB8DZ4fr+zrV93YkTJ8zg3uPHjxc7X89eiooKrhMeCDLllJaZJiMXj5Q9R05dCK1lrZby9nVvS2KtRHGJSwPgAFexv3NvXzdt2jTZtGmT737//v3lvffeM7e3bt0qr7/+uhkAHEzoWiqHD7Z+IAOSB/hCzKWNLpWFAxY6F2IAhD72d+759ttvZZbfhQCvu+46eeCBB8xfr3//+9/yzTffSDChRaaMkjcny+iPRku+J9/c158m6JHQQ2atL3j1R50/rO2wyi8pBMz06dUlI+PUdSNWry54hd+kpDjf7VGjjkpi4skqXz6gsrG/c8/Ro0dlwoQJkp9/6jvu3HPPlXvuucfc1r9paWnyww8/mMf1edoyU6NGDQkGBJkySs9K94UYpadcP7PqmSLPS4hLIMiEmPnzY0q8CN6UKbG+23365BJkEBLY37nnpZdeMr+5pMLDw+WRRx7xBRX9q/f1rCUNMrt27ZLJkyebC+gFA7qWAABw2BdffCELFizw3b/xxhulY8eOBZ5z0UUXyZAhQ3z333//fUlNTZVgQItMGT3c9WEzueyKIUPM5Jp58/YHehGAKuX6/s61fV23bt3kk08+KfV5t99+u5mCDS0yAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArBUUQWby5MmSmJgoMTEx0q1bN/nyyy8DvUgAAMACAQ8y77zzjjz44IPy+OOPy9dffy0dO3aUvn37SmZmZqAXDQAABLmAB5nnnntOfvOb38gtt9wibdu2lSlTpkiNGjXkjTfeCPSiAQCAIBcZyDfPy8uTr776Sh555BHfvPDwcOndu7ekpqYWeX5ubq6ZvLKzs83fTZs2ydGjR8Ul27dvN3/XZGbKrpwcccmmrCzzd8OGDbJ3715xsdxZd8rdFezrRHbu3CkHDx4U1+wt43Ye0CDz448/ysmTJ6Vhw4YF5uv99evXF3n+hAkTZNy4cUXmL1++XKKiosQ1YWFhkpyeLi7SdU9JSREXse6Uu2vCRNzd1+kB65o14qK8vLzgDzLlpS03Op7Gv0WmadOmMrxDB2lVv764RFtidMMeNGiQ1Hds3bU1QkMM6065u4I6nyK3duokjeLixMX9vIvrrjbt3SvTJciDTL169SQiIkL27NlTYL7eP/fcc4s8Pzo62kyFNYyLk2bnnCMu8XYnaYhp3LixuNjcyLpT7q6gzov5Ind1P+/iuqtDZRwyEtDBvtod1LlzZ/nPf/7jm5efn2/uX3bZZYFcNAAAYIGAdy1pV9HIkSOlS5cucskll8jzzz8vhw8fNmcxAQAABHWQuemmm0yz6WOPPSa7d++Wiy++WBYvXlxkADAAAEDQBRl1zz33mAkAAMCqC+IBAABUFEEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK3IQC8ALHDsmMQ995xE/u9/Erl5s4Tt3y9hubniiY+XE+edJ3m9e8uRW28190PNrpxdsmTbEkn9IVXS96dL5pFMyc7LlvioeGlXt50MPn+wmcLCwgK9qEClod7DJgSZcvhs5kxJnTWrxMejY2Pl3tmzJdSEHT4ssf/4R9H5WVkSpdPq1RIze7ZkLVokntq1JZTM2ThHxn8xvsj8rGNZ8unOT820cMtCmdZ3mkSERwRkGYHK5nq9d3Vfb+u6E2RQJicbNZLjXbrIyYQEya9dW8L37ZOY99+XiO+/P1WRMjKk+owZcuTee0PyE21Qo4H0atZLmtdsLjsO7ZB3N74rx04eM499uO1DmZ0+W4ZeODTQiwlUKuo9bECQqaAWnTtLt8GDC8wLjwi9IxPlqVtXfvzvf4vMPzJ6tNTv1Ml3P2LHDgk1TeKayIs9X5T+rfpLZPhPm8uA1gPkxgU3+u6nbE8hyCBkUO/d3Nfbuu4EmQqqUauWJLRrJ046eVLCMzNNC4y/ExdcIKFmYOuBxc7v3qS71ImpY5raVV5+XhUvGXD2UO9/4vK+voYl606QQZlFLV8utX/962Ify7v0Ujk61J2uFe+gX69ODX5qmQJCFfUewYggU0FrU1LM5K9dz57Sb8wYcc3RgQPl0MSJIjEx4oIT+Sdk7LKx5q+qV72ejGg7ItCLBZxVrtZ7l/f1ay1Zd4IMykxPtT702GMSlpcn4d9/LzEffCDhWVlSfe5cqbZmjeyfOVPymzYN6U80Jy9H7lh6h6TsOLVxx1WLkzevfdPs1IFQRb1HMCPIVOIgqNgQO/W4sPyEBDly112++zm//73U7d1bIvbskciNG6XmY4/JwWnTJFTtzNkpwxcNl3X71pn7dWPqyozrZtCthJDmer13cV9v27oTZEJ8ENTZ5KlfX4537iwRH3xg7kd9/rmEqrTMNBm5eKTsObLH3G9Zq6W8fd3bklgrMdCLBpw11Hu39/U1LFl3fqIApaq2YoWE5eQUmR+2b59U+/prvxmheXXbD7Z+IAOSB/hCzKWNLpWFAxYSYhDSqPewBS0yKFWNqVMletkyybvySjnetq14qleXiF27JFoviLd3r+95ub17h9ynmbw5WUZ/NFryPfnmvv40QY+EHjJrfcErX+r8YW2HBWgpgcpFvYdNCDIok7CjRyX6ww/NVJzj7dvLoaSkkPs007PSfSFG6SnXz6x6psjzEuISCDIIGdR72IQgg1IdveUWyW/QwHQjhe/eLeEHDohERkp+vXpyom1bOdavnxy78UaRatX4NAEAVYogUw5XDBliJtfkXXWVmVz0cNeHzQS4xPV67+q+3tZ1Z7AvAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAawU0yCxfvlx+9atfSePGjSUsLEzee++9QC4OAACwTECDzOHDh6Vjx44yefLkQC4GAACwVGQg37xfv35mAgAAsC7IlFdubq6ZvLKzs83fdXv3Ss7Jk+KSTVlZ5u+GDRtk79694pLt27ebv6w75e4K6rzImsxM2ZWTIy7u511cd7X9/69/acI8Ho9HgoCOkZk3b57079+/xOckJSXJuHHjiswfNWqUREVFiWvCRCQoCi9A9SVIqm6VY90pd9dQ592s83l5eTJ9+nQ5ePCgxMfHh0aQKa5FpmnTpjJ37lxJTEwUl2hrREpKitzaqZM0iosTl+jRSXJ6ugwaNEjq168vLpY76065u4I67+b2rjIyMmTgwIGlBhmrupaio6PNVFi9evXMmU8u8XYnaYhpds454hJvE6tu2K6WO+tOubuCOu/m9q5yytidxnVkAACAtSIDnbY2bdrku79161ZJS0uTOnXqSLNmzQK5aAAAwAIBDTKrV6+Wq6++2nf/wQcfNH9HjhxpBvgAAAAEbZDp0aOHs2eeAACAM8cYGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBakYFeAFvsytklS7YtkdQfUiV9f7pkHsmU7LxsiY+Kl3Z128ng8webKSwsLNCLikqWnBwtK1ZESVpaNVm/PlLy8n4q49279/B5I+S4XOdd3tfvsnTdCTJlNGfjHBn/xfgi87OOZcmnOz8108ItC2Va32kSER4hoeizmTMlddasEh+Pjo2Ve2fPllAzaVKsrF1bLdCLAVQZl+u8y/v6OZauO0GmnBrUaCC9mvWS5jWby45DO+Tdje/KsZPHzGMfbvtQZqfPlqEXDj0bZYUA0YOPxMQT0rHjCcnMDJfU1CjKAiGNOu/2vr6BZetOkCmjJnFN5MWeL0r/Vv0lMvynj21A6wFy44IbffdTtqcEVQGfLS06d5ZugwcXmBceETwJvTItWJAl1aufuj1xYixBBiHP5Trv8r6+iaXrTpApo4GtBxY7v3uT7lInpo5pelN5+Xnighq1aklCu3biAu8OHXCFy3Xe5X39QEvXnbOWzpB3MJRXpwadzvQlAQBBxuV9fWaQrzstMmfgRP4JGbtsrPmr6lWvJyPajhAXrE1JMZO/dj17Sr8xYwK2TABwNri8rz9hwbrTIlNBOXk5MmLRCDPwScVVi5M3r33TFDIAIDS4vK/PsWTdaZGpgJ05O2X4ouGybt86c79uTF2Zcd2MoGtuq+rBvrG1awdseQCgsrm8r99p0boTZMopLTNNRi4eKXuOnLooVMtaLeXt696WxFqJ4hKXBvsCcI/L+/o0y9adrqVy+GDrBzIgeYCvcC9tdKksHLAwaAsXAFB+Lu/rP7Bw3WmRKaPkzcky+qPRku/JN/f1ks09EnrIrPUFr3Sr84e1HVb5JYWAmT69umRknLpGzurVBa92mpQU57s9atRRSUw8WeXLB1Q2l+u8y/v6ZEvXnSBTRulZ6b7CVXoq2jOrninyvIS4hKAqYJy5+fNjSrwg2JQpsb7bffrkhtxOHW5yuc67vK9Pt3Td6VoCAADWokWmjB7u+rCZXHbFkCFmcs28efsDvQhAlXK5zru8r3/Y0nWnRQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1AhpkJkyYIF27dpWaNWtKgwYNpH///pKenh7IRQIAABYJaJBZtmyZ3H333bJy5UpZunSpHD9+XK655ho5fPhwIBcLAABYIjKQb7548eIC96dPn25aZr766iv5+c9/HrDlAgAAdghokCns4MGD5m+dOnWKfTw3N9dMXtnZ2ebvpk2b5OjRo+KS7du3m79rMjNlV06OuGRTVpb5u2HDBtm7d6+4WO6sO+XuCuq8m9u72rlzp5RFmMfj8UgQyM/Pl+uvv14OHDggK1asKPY5SUlJMm7cuCLzR40aJVFRUeKasLAwCZLiq3KsO+XuGuo8dd41eXl5pqdGGzni4+ODP8jceeedsmjRIhNiEhISytwi07RpU5k7d64kJiaKSzShp6SkyKBBg6R+/friEtadcqfOu4Pt3c3tXWVkZMjAgQNLDTJB0bV0zz33yMKFC2X58uUlhhgVHR1tpsLq1asnjRs3Fpd4mxm1crPu7qDcqfNs7+5weXtXOWUcNhHQIKONQffee6/MmzdPPvnkE2nRokUgFwcAAFgmoEFGT72eOXOmzJ8/31xLZvfu3WZ+rVq1pHr16oFcNAAAYIGAXkfm5ZdfNn1fPXr0kEaNGvmmd955J5CLBQAALBHwriUAAICK4reWAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUiA70ANklOjpYVK6IkLa2arF8fKXl5Yb7Hdu/eI6GMdXez3AEg2BFkymHSpFhZu7aauIh1d7PcASDYEWTKISxMJDHxhHTseEIyM8MlNTVKXMG6u1nuABDsCDLlsGBBllSvfur2xImxTn2hse5uljsABDsG+5aDN8S4iHUHAAQjggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLW4jkw5TJ9eXTIyIszt1asLXuk1KSnOd3vUqKOSmHhSQgnr7ma5A0CwI8iUw/z5MSVeDG3KlFjf7T59ckPuC411d7PcASDY0bUEAACsRYtMOcybt19cxboDAIIRLTIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLtB5tixY5WzJAAAAFURZPLz8+XJJ5+UJk2aSFxcnGzZssXMf/TRR+X111+vyEsCAABUTZB56qmnZPr06fLXv/5VoqJ++jG99u3by9SpUyvykgAAAFUTZN5880159dVXZejQoRIREeGb37FjR1m/fn1FXhIAAKBqgszOnTulVatWxXY5HT9+vCIvCQAAUDVBpm3btvLpp58WmT9nzhzp1KlTRV4SAACg3CLL/y8ijz32mIwcOdK0zGgrzNy5cyU9Pd10OS1cuLAiLwkAAFA1LTI33HCDLFiwQD766COJjY01wea7774z8/r06VORlwQAAKiaFhl15ZVXytKlSyv67wAAAIELMiovL08yMzNN95K/Zs2anelyAQAAnJ0gs3HjRrn11lvl888/LzDf4/FIWFiYnDx5siIvCwAAcPaDzKhRoyQyMtIM7G3UqJEJLwAAAFYEmbS0NPnqq6+kTZs2Z/TmL7/8spkyMjLM/Xbt2pmBw/369Tuj1wUAAG6o8HVkfvzxxzN+84SEBHnmmWdMKFq9erX07NnTnBG1du3aM35tAAAQ+ioUZP7yl7/I7373O/nkk09k3759kp2dXWAqq1/96ldy3XXXSevWreX888+X8ePHmx+hXLlyZUUWCwAAOKZCXUu9e/c2f3v16lVpg331f/7973/L4cOH5bLLLqvIYgEAAMdUKMh8/PHHlbYAa9asMcHl2LFjpjVm3rx5puuqOLm5uWby8rb+bNq0SY4ePSou2b59u/m7YcMG2bt3r7iEdafcqfPuYHt3c3tX+usBZRHm0WaUANJr0WhFPXjwoPmtpqlTp8qyZcuKDTNJSUkybty4Ys+iioqKEtdo61eAiy9gWHfK3TXUeeq8a/Ly8mT69OkmH8THx1dukPnmm2+Kf7GwMImJiTEXxIuOjpaKdlu1bNlSXnnllTK1yDRt2tT81lNiYqK4RBN6SkqKDBo0SOrXry8uYd0pd+q8O9je3dzelZ7RPHDgwFKDTIW6li6++OLTXjumWrVqctNNN5kwosGmPPQqwf5hxZ+Go+ICUr169aRx48biEm8zo1Zu1t0dlDt1nu3dHS5v7yonJ0fO2llLOo5FzzR69dVXzTVldNLbF1xwgcycOVNef/1101rw5z//+bSv88gjj8jy5ctN6tKxMnpfz4QaOnRoRRYLAAA4pkItMnqa9KRJk6Rv376+eRdddJG5Lsyjjz4qX375pflV7Iceekj+9re/lfg6+jtNI0aMkF27dkmtWrWkQ4cOsmTJEn5BGwAAnL0go60nzZs3LzJf5+lj3u4nDSinoy03AAAAFVWhriX9aQK9Iq+OKPY6fvy4mef92QI9baphw4YVXjAAAICz0iIzefJkuf76601XknYHKW2J0Yva6Q9Jqi1btshdd91VkZcHAAA4e0Hm8ssvl61bt8rbb79tTo1TgwcPliFDhkjNmjXN/eHDh1fkpQEAAM5ukFEaWEaPHl3RfwcAAKi6IJOcnCz9+vUz14jR26ej3U4AAABBE2T69+8vu3fvlgYNGpjbJanoj0YCAACctSCjV9wt7ra/HTt2yBNPPFHuhQAAAKiy069LkpWVJW+88UZlviQAAEDVBBkAAICqRJABAADWIsgAAAA3riMzcODA0z5+4MCBM10eAACAsxNk9BeqS3tcf80aAAAg6ILMtGnTzt6SAAAAlBNjZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsFTRB5plnnpGwsDB54IEHAr0oAADAEkERZFatWiWvvPKKdOjQIdCLAgAALBLwIJOTkyNDhw6V1157TWrXrh3oxQEAABYJeJC5++675Re/+IX07t070IsCAAAsExnIN589e7Z8/fXXpmupLHJzc83klZ2dbf5u2rRJjh49Ki7Zvn27+bthwwbZu3evuIR1p9yp8+5ge3dze1c7d+6UsgjzeDweCYAdO3ZIly5dZOnSpb6xMT169JCLL75Ynn/++WL/JykpScaNG1dk/qhRoyQqKkpco4OjA1R8Ace6U+6uoc5T512Tl5cn06dPl4MHD0p8fHzwBZn33ntPBgwYIBEREb55J0+eNBtreHi4aXnxf6ykFpmmTZvK3LlzJTExUVyiCT0lJUUGDRok9evXF5ew7pQ7dd4dbO9ubu8qIyNDBg4cWGqQCVjXUq9evWTNmjUF5t1yyy3Spk0b+f3vf18kxKjo6GgzFVavXj1p3LixuMTbzKiVm3V3B+VOnWd7d4fL27v3ZKCyCFiQqVmzprRv377AvNjYWKlbt26R+QAAAEF51hIAAICVZy0V9sknnwR6EQAAgEVokQEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWigz0AtgkOTlaVqyIkrS0arJ+faTk5YX5Htu9e4+EMtadcqfOs727sK+DfQgy5TBpUqysXVtNXMS6U+6uoc67WedhH4JMOYSFiSQmnpCOHU9IZma4pKZGiStYd8qdOs/2DgQjgkw5LFiQJdWrn7o9cWKsU0GGdT/1OVDu1HkXuLy9wz4M9i0H74btItbdTZS7m1wud9iHIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2uI1MO06dXl4yMCHN79eqCV71MSorz3R416qgkJp6UUMK6U+7U+Z+wvYfuvg72IciUw/z5MSVeGGrKlFjf7T59ckNu42bdKffCqPOnsL2H1r4O9qFrCQAAWIsWmXKYN2+/uIp1dxPl7iaXyx32oUUGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAawU0yCQlJUlYWFiBqU2bNoFcJAAAYJHIQC9Au3bt5KOPPvLdj4wM+CIBAABLBDw1aHA599xzA70YAADAQgEfI7Nx40Zp3LixnHfeeTJ06FDZvn17oBcJAABYIqAtMt26dZPp06fLBRdcILt27ZJx48bJlVdeKd9++63UrFmzyPNzc3PN5JWdnW3+btq0SY4ePSou8Qa+DRs2yN69e8UlrDvlTp13B9u7m9u72rlzp5RFmMfj8UiQOHDggDRv3lyee+45ue2224odHKxhp7BRo0ZJVFSUuCZMRIKm8KqYDgwPoqpbpZxed+q8uMjpOu/wuufl5ZnGjoMHD0p8fLwdQUZ17dpVevfuLRMmTChTi0zTpk1l7ty5kpiYKC7RhJ6SkiK3duokjeLixCVrMjMlOT1dBg0aJPXr1xcXy93ldafOu1nuLtd5F9ddZWRkyMCBA0sNMgEf7OsvJydHNm/eLMOHDy/28ejoaDMVVq9ePTPOxiXeZkYNMc3OOUdcsisnx/zVDdvVcnd53anzbpa7y3XexXX3ZoKgH+w7duxYWbZsmUldn3/+uQwYMEAiIiLk5ptvDuRiAQAASwS0Reb77783oWXfvn0mcXbv3l1WrlzpZBMaAACwLMjMnj07kG8PAAAsF/DryAAAAFQUQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwVmSgF8AWu3J2yZJtSyT1h1RJ358umUcyJTsvW+Kj4qVd3XYy+PzBZgoLC5NQ9dnMmZI6a1aJj0fHxsq9s2dLqElOjpYVK6IkLa2arF8fKXl5P5Xx7t17JJS5vO6KOu9mucMuBJkymrNxjoz/YnyR+VnHsuTTnZ+aaeGWhTKt7zSJCI+o7HJCAE2aFCtr11ZzsgxcXneXUe6wCUGmnBrUaCC9mvWS5jWby45DO+Tdje/KsZPHzGMfbvtQZqfPlqEXDpVQ16JzZ+k2eHCBeeERoRngtJEtMfGEdOx4QjIzwyU1NUpc4fK6F0adB4ITQaaMmsQ1kRd7vij9W/WXyPCfPrYBrQfIjQtu9N1P2Z7iRJCpUauWJLRrJy5YsCBLqlc/dXvixFinvsxdXvfCqPNAcCLIlNHA1gOLnd+9SXepE1PHdDGpvPy8yisdBAXvF7mLXF53l1HusAlB5gx5B/16dWrQSVywNiXFTP7a9ewp/caMCdgyAWcTdR4ITpx+fQZO5J+QscvGmr+qXvV6MqLtiMoqGwAAUApaZCooJy9H7lh6h6TsONUqEVctTt689k0TZlwd+Bhbu3bAlgc426jzQHAiyFTAzpydMnzRcFm3b525Xzemrsy4boYz3UquDXwEFHUeCE4EmXJKy0yTkYtHyp4jpy4K1bJWS3n7urclsVbi2SgfAABwGoyRKYcPtn4gA5IH+ELMpY0ulYUDFhJiAAAIEFpkyih5c7KM/mi05HvyzX39aYIeCT1k1vqCl+zX+cPaDqv8kkLATJ9eXTIyTl3sb/Xqgle5TUqK890eNeqoJCaelFDi8rq7jHKHTQgyZZSele4LMUpPuX5m1TNFnpcQl0CQCTHz58eUeCG4KVNifbf79MkNuS9zl9fdZZQ7bEKQQZldMWSImQBXUOeB4EeQKaOHuz5sJrhn3rz94iqX191llDtswmBfAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArBXwILNz504ZNmyY1K1bV6pXry4XXXSRrF69OtCLBQAALBAZyDffv3+/XHHFFXL11VfLokWLpH79+rJx40apXbt2IBcLAABYIqBB5i9/+Ys0bdpUpk2b5pvXokWLQC4SAACwSEC7lpKTk6VLly4yePBgadCggXTq1Elee+21QC4SAACwSEBbZLZs2SIvv/yyPPjgg/LHP/5RVq1aJffdd59ERUXJyJEjizw/NzfXTF7Z2dnm76ZNm+To0aPiku3bt5u/azIzZVdOjrhkU1aW+bthwwbZu3evuFjuLq87dd7Ncne5zru47t4xtGUR5vF4PBIgGli0Rebzzz/3zdMgo4EmNTW1yPOTkpJk3LhxReaPGjXKvJZrwsLCJIDFF1CsO+XuGuo8dd41eXl5Mn36dDl48KDEx8cHZ4tMo0aNpG3btgXmXXjhhfLuu+8W+/xHHnnEtN74t8joGJvhHTpIq/r1xSV6VJqcni6DBg0yg6RdokcnKSkprDvl7gzqPNu7a9u7ysjIMEGmNAENMnrGUnp6epENtnnz5sU+Pzo62kyFNYyLk2bnnCMu8XYnaeVu3LixuMTbxMq6U+6uoM6zvbu2n1c5ZRw2EdDBvmPGjJGVK1fK008/bca5zJw5U1599VW5++67A7lYAADAEgENMl27dpV58+bJrFmzpH379vLkk0/K888/L0OHDg3kYgEAAEsEtGtJ/fKXvzQTAACAdT9RAAAAUFEEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBakYFeAJt8NnOmpM6aVeLj0bGxcu/s2RJqduXskiXblkjqD6mSvj9dMo9kSnZetsRHxUu7uu1k8PmDzRQWFiahKDk5WlasiJK0tGqyfn2k5OX9tJ67d++RUMa6U+6u1XnYhyCDUs3ZOEfGfzG+yPysY1ny6c5PzbRwy0KZ1neaRIRHhNwnOmlSrKxdW01cxLpT7kCwI8hUUIvOnaXb4MEF5oVHhN6XuL8GNRpIr2a9pHnN5rLj0A55d+O7cuzkMfPYh9s+lNnps2XohUMl1GhDU2LiCenY8YRkZoZLamqUuIJ1p9xdq/OwD0GmgmrUqiUJ7dqJC5rENZEXe74o/Vv1l8jwn6rMgNYD5MYFN/rup2xPCckgs2BBllSvfur2xImxTu3UWfdTnwPl7k6dh30IMijVwNYDi53fvUl3qRNTx3Qxqbz8vJD8NL0hxkWsu5tcLnfYhyBTQWtTUszkr13PntJvzBhxhXfQr1enBp0CujwAAPdw+jUq5ET+CRm7bKz5q+pVrycj2o7g0wQAVClaZCpxsG9s7drigpy8HLlj6R2SsuNUi1RctTh589o3TZgBAKAqEWQqyKXBvv525uyU4YuGy7p968z9ujF1ZcZ1M+hWAgAEBEEGZZaWmSYjF4+UPUdOXRCrZa2W8vZ1b0tirUQ+RQBAQDBGBmXywdYPZEDyAF+IubTRpbJwwEJCDAAgoGiRQamSNyfL6I9GS74n39zXnybokdBDZq0v+HMNOn9Y22Eh94lOn15dMjJOXexw9eqCV3pNSorz3R416qgkJp6UUMK6U+6u1XnYhyCDUqVnpftCjNJTrp9Z9UyR5yXEJYRkkJk/P6bEi+BNmRLru92nT27I7dRZd8rdtToP+xBkyuGKIUPMBAAAggNBBqV6uOvDZnLVvHn7xVWsu5tcLnfYh8G+AADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWCugQSYxMVHCwsKKTHfffXcgFwsAAFgiMpBvvmrVKjl58qTv/rfffit9+vSRwYMHB3KxAACAJQIaZOrXr1/g/jPPPCMtW7aUq666KmDLBAAA7BE0Y2Ty8vJkxowZcuutt5ruJQAAgKBukfH33nvvyYEDB2TUqFElPic3N9dMXgcPHjR/t/z4o7hme1aWCX8ZGRmSk5MjLtm5cyfrTrmLS6jz7Otc28+r7du3m78ej0dOJ8xT2jOqSN++fSUqKkoWLFhQ4nOSkpJk3LhxVbpcAAAgcHbs2CEJCQnBHWS2bdsm5513nsydO1duuOGGMrfIaAtO8+bNTWqrVauWuCQ7O1uaNm1qCjg+Pl5cwrpT7tR5d7C9u7m9K40nhw4dksaNG0t4eHhwdy1NmzZNGjRoIL/4xS9O+7zo6GgzFaYhxsVCVrrerLt7KHe2d9dQ592s87XK0EgR8MG++fn5JsiMHDlSIiODIlcBAABLBDzIfPTRR6ZrSM9WAgAAKI+AN4Fcc801pY5ILol2Mz3++OPFdjeFOtadcncNdZ467xqX63x5BMVgXwAAACu7lgAAACqKIAMAAKxFkAEAANayOshMnjxZEhMTJSYmRrp16yZffvmlhLrly5fLr371K3OBIP1NKv1pB1dMmDBBunbtKjVr1jTXHerfv7+kp6eLC15++WXp0KGD71oal112mSxatEhcpD8uq3X/gQcekFCnVzPXdfWf2rRpIy79NMOwYcOkbt26Ur16dbnoootk9erVEur0e61wuet09913B3rRgpK1Qeadd96RBx980Izo/vrrr6Vjx47mZw4yMzMllB0+fNisq4Y41yxbtsxsyCtXrpSlS5fK8ePHzVlv+pmEOr08t36Bf/XVV2ZH3rNnT3MV7LVr14pLVq1aJa+88ooJda5o166d7Nq1yzetWLFCXLB//3654oorpFq1aia0r1u3Tp599lmpXbu2uFDP/ctc93dq8ODBgV604OSx1CWXXOK5++67ffdPnjzpady4sWfChAkeV2jxzZs3z+OqzMxM8xksW7bM46LatWt7pk6d6nHFoUOHPK1bt/YsXbrUc9VVV3nuv/9+T6h7/PHHPR07dvS46Pe//72ne/fugV6MoKB1vWXLlp78/PxAL0pQsrJFRn/1WY9Me/fu7Zunv8Og91NTUwO6bKg63l8/r1OnjlMf+8mTJ2X27NmmJUq7mFyhrXH6Myb+270LNm7caLqS9ffohg4d6vtF4FCXnJwsXbp0Ma0Q2pXcqVMnee2118Q1+n03Y8YMc9FY7V5CUVYGmR9//NHszBs2bFhgvt7fvXt3wJYLVfvTFjpGQpue27dv78RHv2bNGomLizMXxxo9erTMmzdP2rZtKy7Q4KZdyDpOyiU69m/69OmyePFiM05q69atcuWVV5of0gt1W7ZsMevcunVrWbJkidx5551y3333yT//+U9xiY6D1B9IHjVqVKAXJWgF/Mq+QEWPzr/99ltnxguoCy64QNLS0kxL1Jw5c8zvk+m4oVAPM/rLv/fff78ZJ6AD+13Sr18/320dF6TBpnnz5vKvf/1LbrvtNgn1gxVtkXn66afNfW2R0W1+ypQppu674vXXXzf1QFvlEEItMvXq1ZOIiAjZs2dPgfl6/9xzzw3YcqFq3HPPPbJw4UL5+OOPzSBYV0RFRUmrVq2kc+fOpmVCB31PmjRJQp12I+sg/p/97Gfmh2V10gD3j3/8w9zW1llXnHPOOXL++efLpk2bJNQ1atSoSEi/8MILnelaU9u2bTO/R3j77bcHelGCWritO3Tdmf/nP/8pkN71vktjBlyj45s1xGiXSkpKirRo0UJcpnU+NzdXQl2vXr1Mt5q2RnknPVLX8SJ6Ww9qXJGTkyObN282X/KhTruNC19eYcOGDaZFyhXTpk0z44N0bBhCsGtJT73W5kXdoV1yySXy/PPPm8GPt9xyi4T6jsz/aEz7zHVnrgNemzVrJqHenTRz5kyZP3++uZaMdzxUrVq1zDUmQtkjjzximpe1jHV8hH4On3zyiRk7EOq0rAuPg4qNjTXXFgn18VFjx441143SL+8ffvjBXG5Cg9vNN98soW7MmDFy+eWXm66lX//61+Y6Ya+++qqZXDlQ0SCj33Pa8ojT8FjshRde8DRr1swTFRVlTsdeuXKlJ9R9/PHH5pTjwtPIkSM9oa649dZp2rRpnlB36623epo3b27qev369T29evXyfPjhhx5XuXL69U033eRp1KiRKfcmTZqY+5s2bfK4YsGCBZ727dt7oqOjPW3atPG8+uqrHlcsWbLE7N/S09MDvShBj1+/BgAA1rJyjAwAAIAiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQARAUkpKS5OKLLw70YgCwDEEGQKXQ376699575bzzzpPo6Ghp2rSp+Z0g/x93BYDKxi9RAThjGRkZ5teKzznnHJk4caJcdNFFcvz4cfOjlvpjn+vXr+dTBnBW0CID4IzdddddEhYWZn6heNCgQXL++edLu3btzK/Ur1y50jxn+/btcsMNN0hcXJzEx8ebXzTes2fPaX/994knnpCEhATTwqPdTosXLy4QnvQ9586dK1dffbXUqFFDOnbsKKmpqb7nTJ8+3YQrDVQXXnihee9rr71Wdu3aVeC9pk6dah6PiYmRNm3ayEsvvUStACxBkAFwRrKyskzA0JaX2NjYIo9rkNBQoiFGn7ts2TJZunSpbNmyRW666aYSX3fSpEny7LPPyt/+9jf55ptvpG/fvnL99dfLxo0bCzzvT3/6k4wdO1bS0tJMgLr55pvlxIkTvsePHDliXuOtt96S5cuXm0Clz/d6++235bHHHpPx48fLd999J08//bQ8+uij8s9//pOaAdgg0D+/DcBuX3zxhUd3JXPnzi3xOR9++KEnIiLCs337dt+8tWvXmv/78ssvzf3HH3/c07FjR9/jjRs39owfP77A63Tt2tVz1113mdtbt241/z916tQir/ndd9+Z+9OmTTP3N23a5HvO5MmTPQ0bNvTdb9mypWfmzJkF3ufJJ5/0XHbZZRX6PABULVpkAJzpwVCpz9GWDh38q5NX27ZtTWuNPlZYdna2/PDDD2bcjT+9X/j5HTp08N1u1KiR+ZuZmembp11OLVu2LPAc7+OHDx+WzZs3y2233Wa6nbzTU089ZeYDCH4M9gVwRlq3bm3GqgRqQG+1atV8t3U5lHZlFfe49zne8JWTk2P+vvbaa9KtW7cCz4uIiDiryw2gctAiA+CM1KlTx4xfmTx5smnhKOzAgQNmIO2OHTvM5LVu3TrzmLbMFKaDgRs3biyfffZZgfl6v7jnV1TDhg3N++h4nVatWhWYWrRoUWnvA+DsoUUGwBnTEKPdPpdccok500i7e3TArQ7qffnll01o0VOyhw4dKs8//7x5TM90uuqqq6RLly7FvubDDz8sjz/+uOkW0jOWpk2bZgb06uDcyjRu3Di57777pFatWuaMptzcXFm9erXs37/fnHUFILgRZACcMb0I3tdff23O/HnooYfM6c3169eXzp07myCj3Tnz5883F8z7+c9/LuHh4SY0vPDCCyW+poaLgwcPmtfTMS3aEpOcnGy6sirT7bffbsbR6PVvNDzpmVcauh544IFKfR8AZ0eYjvg9S68NAABwVjFGBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAACx1f8DkGbfMvZxpPwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Appliquer les deductions CSP\n",
+    "for cell in mine_cells:\n",
+    "    board_csp.flag(*cell)\n",
+    "for cell in safe_cells:\n",
+    "    board_csp.reveal(*cell)\n",
+    "\n",
+    "# Relancer les regles simples pour propager\n",
+    "solver_rules_2 = RuleBasedSolver(board_csp)\n",
+    "iterations_2 = solver_rules_2.solve()\n",
+    "\n",
+    "total_cells = board_csp.rows * board_csp.cols\n",
+    "unknown = total_cells - len(board_csp.revealed) - len(board_csp.flagged)\n",
+    "\n",
+    "print(\"Apres application des deductions CSP + regles\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"Cellules revelees  : {len(board_csp.revealed)}\")\n",
+    "print(f\"Drapeaux           : {len(board_csp.flagged)}\")\n",
+    "print(f\"Inconnues restantes: {unknown}\")\n",
+    "print(f\"Partie gagnee      : {board_csp.won}\")\n",
+    "\n",
+    "fig = draw_board(board_csp,\n",
+    "                 title=f\"Apres CSP + regles ({unknown} inconnues restantes)\",\n",
+    "                 show_mines=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-22",
+   "metadata": {
+    "id": "cell-22",
+    "papermill": {
+     "duration": 0.005453,
+     "end_time": "2026-04-22T18:08:11.002801",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:10.997348",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 5. Approche 3 : extension probabiliste (~10 min)\n",
+    "\n",
+    "Quand le CSP ne determine pas toutes les cellules, il faut **choisir** une cellule a reveler. Ce choix est risque : nous pourrions toucher une mine.\n",
+    "\n",
+    "### Strategie probabiliste\n",
+    "\n",
+    "L'idee est de **compter les solutions** pour chaque cellule inconnue :\n",
+    "\n",
+    "$$P(\\text{mine}_{i,j}) = \\frac{\\text{nombre de solutions ou } C_{i,j} = 1}{\\text{nombre total de solutions}}$$\n",
+    "\n",
+    "On choisit alors la cellule avec la **plus faible probabilite de mine** pour la reveler.\n",
+    "\n",
+    "### Traitement des cellules hors frontiere\n",
+    "\n",
+    "Les cellules completement isolees (non adjacentes a une cellule revelee) ne sont pas dans le CSP. Pour elles, la probabilite est calculee a partir du nombre de mines restantes et du nombre de cellules hors frontiere :\n",
+    "\n",
+    "$$P(\\text{mine}_{\\text{isolee}}) = \\frac{\\text{mines non attribuees}}{\\text{cellules hors frontiere}}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-23",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:11.015211Z",
+     "iopub.status.busy": "2026-04-22T18:08:11.014937Z",
+     "iopub.status.idle": "2026-04-22T18:08:11.023167Z",
+     "shell.execute_reply": "2026-04-22T18:08:11.022144Z"
+    },
+    "id": "cell-23",
+    "outputId": "ef0aa460-f79a-45ab-d5a2-31fdb129282a",
+    "papermill": {
+     "duration": 0.015465,
+     "end_time": "2026-04-22T18:08:11.023956",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.008491",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe ProbabilisticSolver definie.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class ProbabilisticSolver:\n",
+    "    \"\"\"Solveur combinant regles, CSP et probabilites.\n",
+    "\n",
+    "    Strategie :\n",
+    "    1. Appliquer les regles simples (gratuit et sur)\n",
+    "    2. Si bloque, resoudre le CSP pour deduire les cellules forcees\n",
+    "    3. Si toujours bloque, choisir la cellule avec la plus faible P(mine)\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, board):\n",
+    "        self.board = board\n",
+    "        self.decisions = {'rules': 0, 'csp': 0, 'guess': 0}\n",
+    "        self.guesses_log = []  # historique des devinettes avec probabilites\n",
+    "\n",
+    "    def play_game(self, verbose=False):\n",
+    "        \"\"\"Joue une partie complete. Retourne True si gagnee.\"\"\"\n",
+    "        while not self.board.game_over and not self.board.won:\n",
+    "            # Etape 1 : regles simples\n",
+    "            rule_solver = RuleBasedSolver(self.board)\n",
+    "            rule_solver.solve()\n",
+    "            if rule_solver.moves_log:\n",
+    "                self.decisions['rules'] += len(rule_solver.moves_log)\n",
+    "                continue  # Recommencer le cycle\n",
+    "\n",
+    "            if self.board.game_over or self.board.won:\n",
+    "                break\n",
+    "\n",
+    "            # Etape 2 : CSP\n",
+    "            csp_solver = CSPSolver(self.board)\n",
+    "            safe_cells, mine_cells, solutions = csp_solver.solve()\n",
+    "\n",
+    "            if safe_cells or mine_cells:\n",
+    "                for cell in mine_cells:\n",
+    "                    self.board.flag(*cell)\n",
+    "                for cell in safe_cells:\n",
+    "                    self.board.reveal(*cell)\n",
+    "                self.decisions['csp'] += len(safe_cells) + len(mine_cells)\n",
+    "                continue  # Recommencer le cycle\n",
+    "\n",
+    "            if self.board.game_over or self.board.won:\n",
+    "                break\n",
+    "\n",
+    "            # Etape 3 : choix probabiliste\n",
+    "            best_cell, best_prob = self._choose_best_cell(csp_solver, solutions)\n",
+    "\n",
+    "            if best_cell is None:\n",
+    "                break  # Plus rien a faire\n",
+    "\n",
+    "            if verbose:\n",
+    "                print(f\"  Devinette : {best_cell} (P(mine) = {best_prob:.1%})\")\n",
+    "\n",
+    "            self.guesses_log.append((best_cell, best_prob))\n",
+    "            self.decisions['guess'] += 1\n",
+    "            self.board.reveal(*best_cell)\n",
+    "\n",
+    "        return self.board.won\n",
+    "\n",
+    "    def _choose_best_cell(self, csp_solver, solutions):\n",
+    "        \"\"\"Choisit la cellule avec la plus faible probabilite de mine.\"\"\"\n",
+    "        frontier = csp_solver.get_frontier_cells()\n",
+    "\n",
+    "        # Probabilites des cellules frontiere (via CSP)\n",
+    "        if solutions:\n",
+    "            probs = csp_solver.get_probabilities(solutions)\n",
+    "        else:\n",
+    "            probs = {}\n",
+    "\n",
+    "        # Probabilite des cellules hors frontiere\n",
+    "        all_unknown = set()\n",
+    "        for r in range(self.board.rows):\n",
+    "            for c in range(self.board.cols):\n",
+    "                if ((r, c) not in self.board.revealed and\n",
+    "                    (r, c) not in self.board.flagged):\n",
+    "                    all_unknown.add((r, c))\n",
+    "\n",
+    "        non_frontier = all_unknown - frontier\n",
+    "        if non_frontier:\n",
+    "            # Mines restantes non attribuees a la frontiere\n",
+    "            mines_in_frontier = sum(\n",
+    "                probs.get(cell, 0.5) for cell in frontier\n",
+    "            )\n",
+    "            remaining_mines = max(0, self.board.remaining_mines() - mines_in_frontier)\n",
+    "            if len(non_frontier) > 0:\n",
+    "                non_frontier_prob = remaining_mines / len(non_frontier)\n",
+    "            else:\n",
+    "                non_frontier_prob = 0\n",
+    "\n",
+    "            for cell in non_frontier:\n",
+    "                probs[cell] = non_frontier_prob\n",
+    "\n",
+    "        if not probs:\n",
+    "            return None, 1.0\n",
+    "\n",
+    "        # Choisir la cellule avec la plus faible probabilite de mine\n",
+    "        best_cell = min(probs, key=probs.get)\n",
+    "        best_prob = probs[best_cell]\n",
+    "\n",
+    "        return best_cell, best_prob\n",
+    "\n",
+    "\n",
+    "print(\"Classe ProbabilisticSolver definie.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-24",
+   "metadata": {
+    "id": "cell-24",
+    "papermill": {
+     "duration": 0.005374,
+     "end_time": "2026-04-22T18:08:11.034787",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.029413",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Simulation d'une partie complete\n",
+    "\n",
+    "Jouons une partie complete avec le solveur probabiliste et observons les decisions prises."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-25",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 902
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:11.046539Z",
+     "iopub.status.busy": "2026-04-22T18:08:11.046292Z",
+     "iopub.status.idle": "2026-04-22T18:08:11.170184Z",
+     "shell.execute_reply": "2026-04-22T18:08:11.169324Z"
+    },
+    "id": "cell-25",
+    "outputId": "26b6434d-f273-414e-89d3-f8a842bbec7f",
+    "papermill": {
+     "duration": 0.130949,
+     "end_time": "2026-04-22T18:08:11.170919",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.039970",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Devinette : (1, 0) (P(mine) = 0.0%)\n",
+      "\n",
+      "Resultat de la partie\n",
+      "==================================================\n",
+      "Issue               : VICTOIRE\n",
+      "Temps total         : 2.4 ms\n",
+      "Decisions par regles: 13\n",
+      "Decisions par CSP   : 11\n",
+      "Devinettes (guess)  : 1\n",
+      "\n",
+      "Repartition :\n",
+      "  rules   :  13 (52%)\n",
+      "  csp     :  11 (44%)\n",
+      "  guess   :   1 (4%)\n",
+      "\n",
+      "Devinettes effectuees :\n",
+      "  (1, 0) -> P(mine)=0.0% -> sure\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQZ5JREFUeJzt3Qt4VNW99/H/5B4SgiEkSAgQ5CIEBCkgWrUgBBFbKddaRSRiL1S0rVbrsa0YalF6aK2oHFGxST1cYo8SCQgCGgXRUIlIiyDhGoMxECRACIQMSeZ91uKdMSEJJOEys2Z9P8+zn5m9ZzKz1157Zn5Za+29HS6XyyUAAAAGCvD2CgAAADQXQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBkCjpaeni8Ph0NOQIUPYcgC8jiAD+FhAqDmFhIRI+/btZezYsfLBBx9c9PV46623JDU1VU+X4v3O5uTJk5KWliajRo2SDh06SHh4uERGRsoVV1whgwcPlj/96U/y+eefN/j3P/nJT2pty4EDB57zPYuLi+Wpp57SIS0uLk5v/9atW0uPHj3ktttukxdffFGKiopq/U3N9wgNDZX8/Pxaj6tt6X782muvbfBvG5pqvp5ar3M9X+1LgFXUtZYAeFdaWpq65tk5p+eee+6irsfkyZM97/XEE0/UefzAgQOuDz/8UE//+c9/Ltp6fPrpp66uXbuec3sMGjSo3r8/fvy4Kyoqqs7zP//88wbfc8GCBa6WLVue8z0fffTRWn935uNqG9aktmND69uYOt+7d6/n+YMHDz7n89W+BNgkyNtBCkBdH374ob7dt2+f/o9+x44dev6RRx6R22+/XbcWXEjHjx+XiIiIcz5Pve+Ffu8z5eXlSXJyshw+fFjPt2jRQreu3HTTTXLZZZfJN998I59++qksWbKkwddQj5WWltZZrlorZs+eXWf566+/LpMmTVL/2Ol51Qr2i1/8Qvr37y/BwcFSWFgoH3300Vnf023BggXyX//1X7oVpyl+97vfyciRI+ssb9euXb3PV89Vf3Om7t27N+l9AeN5O0kBqNsiU1N2dnatxzIzM/Xy559/3nXLLbe4EhMTdUtCUFCQKzY21nXzzTe7lixZUmezdurUyfMaq1atck2fPt3VuXNnV2BgoOtvf/vbWf/LVy0BZ66ne1lNGRkZruHDh7tiYmJcwcHBrssvv9z14x//2PXvf/+70dWsyuR+D1Wuzz77rN7nVVdX65ab+iQnJ3teIyUlxXO/Xbt2rsrKylrPPXbsmN5u7uf06dPHVVJSUu/rlpeXu7Zu3VprWX3ba/z48U1ukWlMS0rNFpkzW34AWzFGBvBxqhWiJqfT6fnP/5133tFjKI4dOyaVlZVy8OBBWb16tR5T8+yzzzb4mvfff7/88Y9/lL1790pVVdV5r2N1dbVMnDhRfvzjH8uaNWvk0KFDcurUKdm/f79kZGTINddcI8uWLTvn66jnr1q1yjP/0EMPydVXX13vc9V4kO985zt1lqtWrOzsbH1fjXH561//Kl26dNHzanxLzddX3n77bb3d3ObMmSPR0dH1vmdYWJgkJSU1uP7uMTBvvvmmbNq06RylBXAhEGQAH/bVV1/J9OnTay1z/7BPnjxZXn31VVm+fLkemKsCxAsvvKAHnCqqS0qFm/rs3LlT7rnnHv23//znP6Vfv366O6tm14Z6XC1T0/PPP3/W9XzppZdk0aJF+n6bNm1k7ty5en3+8Ic/6MBRUVGhu27c3UUNUT/+7u4d5ZZbbvHcV2VZv359nenIkSO1XuO1117TwUpR5VGDdVXIcjtzMKzqpnJT3Vjf+973PPMqkNX3njXXsaYHH3xQYmJi9OOq7E2htveZA3cbCnHKP/7xj3oH+565PQB/xxgZwAepH6T6qPDiHgPxgx/8QGbNmiXvvfeeFBQUSHl5ea3nHj16VL744gu56qqr6ryOarH5+9//Xmd5zfEvHTt2lBtuuKFR66sCVc0f5D59+uj7I0aM0C0en332mV4fFZp+/vOfN/g6ZwYdFYrc1A/0jTfeWOdvVq5cWSvwqCDjdtddd3luVQuUkpWVpd/H3epS8z3VsoCAb/+/e//992XChAl13lNta9U6c6aoqCh59NFH5be//a1eLxV6AFxcBBnAALGxsTJt2jTP4E7VBTNgwAB9uPDZNNQCMm7cuAu6ftu2bfPcV4Np6xtQq5ztcOn6utFUi0jXrl0bvR4ff/yxZ2C0ChUq7CndunXTh19v3LhRtw6p7i41mPfM91TbS7Xm1AwzTaW67f72t7/pbqzf//73epBycwf7qsPNG9LQYN+WLVs2Y60BcxFkAB8+akkdMaNCTOfOnWu10qjWFHeIadu2rT73ifrBVz/AY8aM0Uf2KO4ulsYeCXOxlZWVnfVxNeZFldPddaO6pwYNGuRpnXEvb6jFqma3kTpqSZ17pqHnuYOMOjLJ7cSJEzoMuVuixo8fr99Tdd01NpCo91TdSip4rlu3To8VagwVthrbAuZuPWvK8wF/xRgZwAepHyg1qR9xdQK4M3+4VVeSm+o2mTJlih7bobqDVCvGuTQUBGq2RDQUgurTs2fPWuNl1I//mZNqCXn55ZfP+joqYN18882eeTVQd/v27Y0+gZ7qumqMTz75xPO63//+92t1YalxLucKXOfy05/+VIdPJScn57xeC8DZ0SIDGEiFG7c33nhDrrvuOh08ZsyY0eBA1MZQA1XdVqxYocOUGgDbqVMnfXbdhtx7772eo3R+85vf6KOAVFeOOsJKHUWUm5urx6aorp3ExMSzroPqllHlUWNq1LgYFebuu+8+PT5GtXZ8+eWX9f5dZmam/htFtWK5x8TUpIKUGq/jbpVRY4xUV4w6wss9nkatqxpkq1pU3OOL1LZoCtWSpgZbqzFNjaUGYNc3pkYdJaUGLJ9JtcjV93x1Dhx3iAKs4O3jvwGc/Twy9SkqKnJFR0fXOX9JUlKSKy4uzjP//vvv13semZrLa1Lnl6nvvChPPvnkWc8jU1VV5brjjjuadJbas9mwYYOrY8eOjTrz7Xvvvaf/Rp0/x73s5z//eb2v+8ILL3ieEx8fX+ucMq+++qqrRYsW53w/db6ekydPev6u5mMrV66stU169uxZ6/HmnNnXfd6gxp7Z91e/+lWjtjHgL+haAgx0+eWX63Eb6gy4alCraklRLQrqKJuGxoU0hurWeeaZZ/R5VwIDAxv9d6pLSh1+rbp21BFEqkUkKChId9moI5imTp2qWzXO1qpTk2qFUUdcqcO41Tqp8qpWDnWkUEJCgi63an1Sg4eHDh2qz7z77rvvnnMwsxo/5O5W+/rrr/UYHDfVPadaRR5//HF9Phh1BJPaBuqMx2r8ivpbdRi6OiTefYj7ubbJk08+2ajyAmg+h0oz5/H3AAAAXkOLDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsYw+s686k6k6F4Q6M2dDp1wHAADmUWeHOXbsmMTHx5/1Qq5GBxkVYhp7gi0AAGAedZkTdSJMvwwy7svVL1iwQF8szya7du3SV9YdNWpUrQve2VT2SX36SNvISLHJtoMHZcXOnVaXnX3eznpnn7fre959cVx1xnL3b71fBhl3d5IKMd27dxeblJeXS0hIiL4An2p2s7HsXWNjpeNll4lNyqqqrC87+zz7vG2fdxv3+ZrONXSEwb4AAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYK8jbKwAzZGWFyvr1IbJ5c7Bs3x4kTqfD89j+/Qe8um7AxVBUViSrvlwlOV/nSN7hPCk+USylzlKJComSXjG9ZEL3CXpyOL79LAAmyzL0e54gg0aZMydCtm4NtnZrfbRokeQsXtzg46EREfJARob4I1vL/sbON2Tmv2bWWV5yskQ+LPxQT8v3LJe0EWkSGBAo/sbWere57HMM/Z4nyKBR1D+diYmV0rdvpRQXB0hOTghbDlaIaxEnwzoOk04tO8m+Y/vkzZ1vysmqk/qx1V+uloy8DJnYc6K3VxOw9nueIINGWbasRMLDT9+fPTvCmB38Yujcv78MmjCh1rKAQP/7j9z2srePbC8vDH1BRncdLUEB335Vjuk2RsYvG++Zzy7I9vsgY1O921z2ZYZ+zxNk0CjunRsiLVq1koRevazcFDaVfWy3sfUuv6H9DdI6rLXuYlKc1U7xdzbVu81lDzf0e56jlgCgCdyDft36xfVj+wFeRIsM0ERbs7P1VFOvoUNl5IMP+v22tLnsSmV1pTy89mF9q7QJbyN3J90t/s7mere57KagRQYAGqHMWSZ3r7xbD/BVIoMj5bVbXtNhBoD30CIDXIDBfxHR0VZsR1vLXlhWKJNWTpJth7bp+ZiwGFlw6wJrupVsrXfby24KggzQRDYN/juTjWXfXLxZJr8zWQ6cOH1CsC6tusjCWxdKYqtEsYWN9e5mc9lNQdcSADRgxd4VMiZrjCfEXNvuWlk+ZrlVIQbwdbTIoFHS08MlP//0uRNyc2uf+TE1NdJzPyWlXBITq9iqMF7W7iyZ+u5UqXZV63l1aYIhCUNk8fbaZ3xVy+9KustLawlcOKZ+zxNk0ChLl4Y1eHKkefMiPPeHD6/wqR0caK68kjxPiFHUIdezNs6q87yEyASCDPzCUkO/5+laAgAAxqJFBo2SmXnY6i11/Z136slGtpb9kYGP6MlWtta7zWXPNPR7nhYZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxvKJIDN37lxJTEyUsLAwGTRokHzyySfeXiUAAGAArweZ119/XR566CF54oknZNOmTdK3b18ZMWKEFBcXe3vVAACAj/N6kHnmmWfkpz/9qdxzzz2SlJQk8+bNkxYtWsjf//53b68aAADwcUHefHOn0ymffvqpPPbYY55lAQEBkpycLDk5OXWeX1FRoSe30tJSfbtr1y4pLy8XmxQUFOjbHTt2yMGDB8XGsm8pLpaisjKxya6SErG97OzzdtY7+7xd3/NKYWGh+HyQ+eabb6Sqqkratm1ba7ma3759e53nP/300zJjxow6y9etWychISFiG4fDIdnZ2WIjVfasvDyxke1lZ5+3D/u8nd/zTqfT94NMU6mWGzWepmaLTIcOHWTUqFF6sLBN1H+l6gt93LhxEhsbKzah7NQ7+7w9+Lzb+XlX8vPzJT09XXw6yLRp00YCAwPlwIEDtZar+csvv7zO80NDQ/VU3+vEx8eLTdzdSWrnpuz2oN7Z5/m828Pmz7tS1shuVK8O9lXdQf3795f33nvPs6y6ulrPX3fddd5cNQAAYACvdy2prqLJkyfLgAED5JprrpFnn31Wjh8/ro9iAgAA8Okgc/vtt+vms+nTp8v+/fvl6quvlnfeeafOAGAAAACfCzLK/fffrycAAACjTogHAADQXAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLGCvL0CJsnKCpX160Nk8+Zg2b49SJxOh+ex/fsPiL8qKiuSVV+ukpyvcyTvcJ4UnyiWUmepRIVESa+YXjKh+wQ9ORzfbg+/cfKkRD7zjAT9+98StHu3OA4fFkdFhbiioqTyiivEmZwsJ6ZM0fP+yOa6p+zUu237fJahv3EEmSaYMydCtm4NFtu8sfMNmfmvmXWWl5wskQ8LP9TT8j3LJW1EmgQGBIo/cRw/LhHPPVd3eUmJhKgpN1fCMjKkZOVKcUVHi7+xue4pO/Vu2z4/x9DfOIJME6gAnphYKX37VkpxcYDk5ISITeJaxMmwjsOkU8tOsu/YPnlz55tysuqkfmz1l6slIy9DJvacKP6mql07OTVggFQlJEh1dLQEHDokYW+/LYFffaUfD8rPl/AFC+TEAw+Iv7K17hXKTr3bss87DP2NI8g0wbJlJRIefvr+7NkRxlTy+Wof2V5eGPqCjO46WoICvt1lxnQbI+OXjffMZxdk+90H2xUTI9989lmd5SemTpXYfv0884H79ok/srnuKTv1bts+v8zQ3ziCTBO4K9g2Y7uNrXf5De1vkNZhrXWTq+Ksdorfq6qSgOJi3QJTU+WVV4o/srnuKXtd1Lt/7/Phhv7GEWTQbO5BcG794r5tofA3IevWSfSPflTvY85rr5Xyif71n9m52FT3Z6Ls1Ltt+7yv4/BrNEtldaU8vPZhfau0CW8jdyfdbd3WLB87Vo4sXCgSFia2sLnuKTv1bts+bwJaZNBkZc4y+dman0n2vmw9HxkcKa/d8pr+cPsrdaj1senTxeF0SsBXX0nYihUSUFIi4UuWSPCWLXJ40SKp7tBB/J2Nde9G2al32/Z5UxBk0CSFZYUyaeUk2XZom56PCYuRBbcu8Ptm1uqEBDlx332e+bJHH5WY5GQJPHBAgnbulJbTp8vRtDTxZ7bWvULZqXfb9nmTEGTQaJuLN8vkdybLgROnT4zUpVUXWXjrQklslWjdVnTFxsqp/v0lcMUKPR/y8cfiz2yue8pOvdu2z5uGMTJolBV7V8iYrDGeH7Jr210ry8cs9/sPdfD69eIoK6uz3HHokARv2lRjgf+d5dP2ulcoO/Vu2z5vIlpkmiA9PVzy80+fyTE3t/bZD1NTIz33U1LKJTGxSvxF1u4smfruVKl2Vet5daruIQlDZPH2xbWep5bflXSX+JMW8+dL6Nq14rzxRjmVlCSu8HAJLCqSUHVCvIMHPc+rSE4Wf2Rz3VN26t22fT7d0N84gkwTLF0a1uAJgubNi/DcHz68wqcq+XzlleR5fsgUddjtrI2z6jwvITLB7z7YiqO8XEJXr9ZTfU717i3HUlPFH9lc95Sderdtn19q6G8cQQY4i/J77pHquDjdjRSwf78EHDkiEhQk1W3aSGVSkpwcOVJOjh8vEmze9UkAwB8QZJogM/Ow2OiRgY/oyUbOwYP1ZCub656yU++2yTT0N47BvgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIzl1SCzbt06ue222yQ+Pl4cDoe89dZb3lwdAABgGK8GmePHj0vfvn1l7ty53lwNAABgqCBvvvnIkSP1BAAAYFyQaaqKigo9uZWWlurbXbt2SXl5udikoKBA3+7YsUMOHjwoNqHs1Dv7vD34vNv5eVcKCwulMRwul8slPkCNkcnMzJTRo0c3+JzU1FSZMWNGneUpKSkSEhIitnGIiE9Unpf2Fx/ZdS85yk6924Z93s593ul0Snp6uhw9elSioqL8I8jU1yLToUMHWbJkiSQmJopNVELPzs6WKf36SbvISLHJluJiycrLk3HjxklsbKzYWO+UnXq3Bfu8nZ93JT8/X8aOHXvOIGNU11JoaKieztSmTRt95JNN3M2MKsR0vOwysUlRWZm+VR9sW+udslPvtmCft/PzrpT9/+/6c+E8MgAAwFhB3k5baqCu2969e2Xz5s3SunVr6dixozdXDQAAGMCrQSY3N1duuukmz/xDDz2kbydPnqwH+AAAAPhskBkyZIi1R54AAIDzxxgZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFhB3l4BUxSVFcmqL1dJztc5knc4T4pPFEups1SiQqKkV0wvmdB9gp4cDoe3VxUXkO31npUVKuvXh8jmzcGyfXuQOJ3flnP//gNeXTcAUAgyjfTGzjdk5r9m1llecrJEPiz8UE/L9yyXtBFpEhgQ6Jd710eLFknO4sUNPh4aESEPZGSIP7G93ufMiZCtW4O9vRoA0CCCTBPFtYiTYR2HSaeWnWTfsX3y5s435WTVSf3Y6i9XS0ZehkzsObGpLwsfZ2u9q4amxMRK6du3UoqLAyQnJ8TbqwQAtRBkGql9ZHt5YegLMrrraAkK+Hazjek2RsYvG++Zzy7I9ssftDN17t9fBk2YUGtZQKD/tUjYXu/LlpVIePjp+7NnRxBkAPgcgkwjje02tt7lN7S/QVqHtdZdDYqz2ik2aNGqlST06iX+zvZ6d4cYAPBVHLV0ntyDP936xfU735eEAah3APANtMich8rqSnl47cP6VmkT3kbuTrpbbLA1O1tPNfUaOlRGPvig+Dub6x0AfA0tMs1U5iyTu1ferQd6KpHBkfLaLa/pHzX4L+odAHwLLTLNUFhWKJNWTpJth7bp+ZiwGFlw6wKrupXqG+wbER3ttfW5FKh3APA9BJkm2ly8WSa/M1kOnDh9MrAurbrIwlsXSmKrRLGJLYN93ah3APBNdC01wYq9K2RM1hhPiLm23bWyfMxy60KMbah3APBdtMg0UtbuLJn67lSpdlXreXWK+iEJQ2Tx9tpnulXL70q668LXFLzC9npPTw+X/PzT5wfKza19ht/U1EjP/ZSUcklMrLrk6wcABJlGyivJ8/yYKeqQ61kbZ9V5XkJkgl/+oNnK9npfujSswZPgzZsX4bk/fHgFQQaAV9C1BAAAjEWLTCM9MvARPdns+jvv1JNNbK/3zMzD3l4FADgrWmQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYy6tB5umnn5aBAwdKy5YtJS4uTkaPHi15eXneXCUAAGAQrwaZtWvXyrRp02TDhg2yZs0aOXXqlNx8881y/Phxb64WAAAwRJA33/ydd96pNZ+enq5bZj799FP53ve+57X1AgAAZvBqkDnT0aNH9W3r1q3rfbyiokJPbqWlpfp2165dUl5eLjYpKCjQt1uKi6WorExssqukRN/u2LFDDh48KDbWO2Wn3m3BPm/n510pLCyUxnC4XC6X+IDq6moZNWqUHDlyRNavX1/vc1JTU2XGjBl1lqekpEhISIjYxuFwiI9U3yXnEBE7S255vVN2sRH1bme9O51O3VOjGjmioqJ8P8j84he/kJUrV+oQk5CQ0OgWmQ4dOsh7zzwjXWNjxSaqJSYrL0/GjRsnsZaVXf13kp2dLVP69ZN2kZFiE+o92+p9nrJT7zbJz8+XsWPHnjPI+ETX0v333y/Lly+XdevWNRhilNDQUD2dqW1kpHS87DKxibs7SX2hx8fHi03cTawqxFDv9tW7zfs8ZafebVLWyGETXg0yqjHogQcekMzMTPnggw+kc+fO3lwdAABgGK8GGXXo9aJFi2Tp0qX6XDL79+/Xy1u1aiXh4eHeXDUAAGAAr55H5sUXX9R9X0OGDJF27dp5ptdff92bqwUAAAzh9a4lAACA5uJaSwAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYQd5eAZN8tGiR5Cxe3ODjoRER8kBGhvidkycl8plnJOjf/5ag3bvFcfiwOCoqxBUVJZVXXCHO5GQ5MWWKnvdXttZ9VlaorF8fIps3B8v27UHidDo8j+3ff8Cr6wYACkEG5+Q4flwinnuu7vKSEglRU26uhGVkSMnKleKKjmaL+pE5cyJk69Zgb68GADSIINNMnfv3l0ETJtRaFhAYKP6qql07OTVggFQlJEh1dLQEHDokYW+/LYFffaUfD8rPl/AFC+TEAw+Iv7Op7h0OkcTESunbt1KKiwMkJyfE26sEALUQZJqpRatWktCrl9jAFRMj33z2WZ3lJ6ZOldh+/Tzzgfv2iQ1sqvtly0okPPz0/dmzIwgyAHwOQQZNV1UlAcXFugWmpsorr2Rr+hl3iAEAX0WQaaat2dl6qqnX0KEy8sEHxV+FrFsn0T/6Ub2POa+9VsonThQb2Fj3AOCrOPwa56187Fg5snChSFgYWxMAcEnRInMBB3xG+PkRO+pQ62PTp4vD6ZSAr76SsBUrJKCkRMKXLJHgLVvk8KJFUt2hg/g7G+seAHwVQaaZbBrw6VadkCAn7rvPM1/26KMSk5wsgQcOSNDOndJy+nQ5mpYm/s7GugcAX0XXEprNFRsrp/r398yHfPwxWxMAcEkRZHBOwevXi6OsrM5yx6FDErxpU40F3571FQCAS4GuJZxTi/nzJXTtWnHeeKOcSkoSV3i4BBYVSag6Id7Bg57nVSQnszX9THp6uOTnnz7ZX25u7TP8pqZGeu6npJRLYmLVJV8/ACDIoFEc5eUSunq1nupzqndvOZaaytb0M0uXhjV4Erx58yI894cPryDIAPAKgkwTXH/nnXqyTfk990h1XJzuRgrYv18CjhwRCQqS6jZtpDIpSU6OHCknx48XCfbfa/LYWvcA4OsIMjgn5+DBeoJ9MjMPe3sVAOCsGOwLAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAANgbZE6ePHlh1gQAAOBSBJnq6mp58sknpX379hIZGSl79uzRyx9//HF59dVXm/OSAAAAlybI/OlPf5L09HT57//+bwkJ+faCcr1795b58+c35yUBAAAuTZB57bXX5OWXX5aJEydKYGCgZ3nfvn1l+/btzXlJAACASxNkCgsLpWvXrvV2OZ06dao5LwkAAHBpgkxSUpJ8+OGHdZa/8cYb0q9fv+a8JAAAQJMFNf1PRKZPny6TJ0/WLTOqFWbJkiWSl5enu5yWL1/enJcEAAC4NC0yP/zhD2XZsmXy7rvvSkREhA42X3zxhV42fPjw5rwkAADApWmRUW688UZZs2ZNc/8cAADAe0FGcTqdUlxcrLuXaurYseP5rhcAAMDFCTI7d+6UKVOmyMcff1xrucvlEofDIVVVVc15WQAAgIsfZFJSUiQoKEgP7G3Xrp0OLwAAAEYEmc2bN8unn34qPXr0OK83f/HFF/WUn5+v53v16qUHDo8cOfK8XhcAANih2eeR+eabb877zRMSEmTWrFk6FOXm5srQoUP1EVFbt24979cGAAD+r1lB5s9//rP89re/lQ8++EAOHTokpaWltabGuu222+TWW2+Vbt26Sffu3WXmzJn6IpQbNmxozmoBAADLNKtrKTk5Wd8OGzbsgg32VX/zf//3f3L8+HG57rrrmrNaAADAMs0KMu+///4FW4EtW7bo4HLy5EndGpOZmam7rupTUVGhJzd368+2gwelzLIjpXaVlOjbHTt2yMGDB8UmBQUF+nZLcbEUlZWJTah3u/d5yk6926SwsLBRz3O4VDOKF6lz0agP6dGjR/W1mubPny9r166tN8ykpqbKjBkz6j2KKiQkRGyjWr+8XH1eQ9mpd9uwz7PP28bpdEp6errOB1FRURc2yPznP/+p/8UcDgkLC9MnxAsNDZXmdlt16dJFXnrppUa1yHTo0EFf6ykxMVFsov4zy87OlnHjxklsbKzYhLJT7+zz9uDzbufnXVFHNI8dO/acQaZZXUtXX331Wc8dExwcLLfffrsOIyrYNIU6S3DNsFKTCkf1BaQ2bdpIfHy82MTdtK52bspuD+qdfZ7Puz1s/rwrZY0cOtCso5bUOBZ1pNHLL7+szymjJnX/yiuvlEWLFsmrr76qWwv+8Ic/nPV1HnvsMVm3bp1OXWqsjJpXR0JNnDixOasFAAAs06wWGXWY9Jw5c2TEiBGeZVdddZU+L8zjjz8un3zyib4q9m9+8xv5y1/+0uDrqOs03X333VJUVCStWrWSPn36yKpVq7iCNgAAuHhBRrWedOrUqc5ytUw95u5+UgHlbFTLDQAAQHM1q2tJXZpAnZFXjSh2O3XqlF7mvmyBOmyqbdu2zV4xAACAi9IiM3fuXBk1apTuSlLdQYpqiVEntVMXklT27Nkj9913X3NeHgAA4OIFme9+97uyd+9eWbhwoT40TpkwYYLceeed0rJlSz0/adKk5rw0AADAxQ0yigosU6dObe6fAwAAXLogk5WVJSNHjtTniFH3z0Z1OwEAAPhMkBk9erTs379f4uLi9P2GNPeikQAAABctyKgz7tZ3v6Z9+/bJH//4xyavBAAAwCU7/LohJSUl8ve///1CviQAAMClCTIAAACXEkEGAAAYiyADAADsOI/M2LFjz/r4kSNHznd9AAAALk6QUVeoPtfj6mrWAAAAPhdk0tLSLt6aAAAANBFjZAAAgLEIMgAAwFgEGQAAYN/Vr21TVFYkq75cJTlf50je4TwpPlEspc5SiQqJkl4xvWRC9wl6Utea8jsnT0rkM89I0L//LUG7d4vj8GFxVFSIKypKKq+4QpzJyXJiyhQ974+yskJl/foQ2bw5WLZvDxKn89s63r//gPgzm8sOwAwEmUZ6Y+cbMvNfM+ssLzlZIh8Wfqin5XuWS9qINAkMCBR/4jh+XCKee67u8pISCVFTbq6EZWRIycqV4oqOFn8zZ06EbN0aLDayuewAzECQaaK4FnEyrOMw6dSyk+w7tk/e3PmmnKw6qR9b/eVqycjLkIk9J4q/qWrXTk4NGCBVCQlSHR0tAYcOSdjbb0vgV1/px4Py8yV8wQI58cAD4m9UI1tiYqX07VspxcUBkpMTIrawuewAzECQaaT2ke3lhaEvyOiuoyUo4NvNNqbbGBm/bLxnPrsg2++CjCsmRr757LM6y09MnSqx/fp55gP37RN/tGxZiYSHn74/e3aEVT/mNpcdgBkIMo00tlv9ZzW+of0N0jqste5iUpzVTvF7VVUSUFysW2BqqrzySvFH7h9yG9lcdgBmIMicJ/egX7d+cd+2UPibkHXrJPpHP6r3Mee110r5RP9qiQIA+D4Ovz4PldWV8vDah/Wt0ia8jdydZN8lGsrHjpUjCxeKhIV5e1UAAJahRaaZypxl8rM1P5Psfdl6PjI4Ul675TUdZvyVOtT62PTp4nA6JeCrryRsxQoJKCmR8CVLJHjLFjm8aJFUd+jg7dUEAFiEINMMhWWFMmnlJNl2aJuejwmLkQW3LvDrbiWlOiFBTtx3n2e+7NFHJSY5WQIPHJCgnTul5fTpcpTrcQEALiG6lppoc/FmuXXJrZ4Q06VVF3l7zNt+H2Lq44qNlVP9+3vmQz7+2KvrAwCwD0GmCVbsXSFjssbIgROnz2h6bbtrZfmY5ZLYKlH8WfD69eIoK6uz3HHokARv2lRjgR+e1RgA4NPoWmqkrN1ZMvXdqVLtqtbz6tIEQxKGyOLti2s9Ty2/K+ku8Sct5s+X0LVrxXnjjXIqKUlc4eESWFQkoeqEeAcPep5XkZws/ig9PVzy80+frTk3t/ZZblNTIz33U1LKJTGxSvyJzWUHYAaCTCPlleR5QoyiDrmetXFWneclRCb4XZBRHOXlErp6tZ7qc6p3bzmWmir+aOnSsAZPBDdvXoTn/vDhFX73Y25z2QGYgSCDcyq/5x6pjovT3UgB+/dLwJEjIkFBUt2mjVQmJcnJkSPl5PjxIsFckwcAcGkRZBrpkYGP6MlGzsGD9WSrzMzDYiubyw7ADAz2BQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFg+E2RmzZolDodDfv3rX3t7VQAAgCF8Ishs3LhRXnrpJenTp4+3VwUAABjE60GmrKxMJk6cKK+88opER0d7e3UAAIBBvB5kpk2bJt///vclOTnZ26sCAAAME+TNN8/IyJBNmzbprqXGqKio0JNbaWmpvt21a5eUl5eLTQoKCvTtjh075ODBg2ITyk69s8/bg8+7nZ93pbCwUBrD4XK5XOIF+/btkwEDBsiaNWs8Y2OGDBkiV199tTz77LP1/k1qaqrMmDGjzvKUlBQJCQkR26jB0V6qPq+j7NS7bdjn2edt43Q6JT09XY4ePSpRUVG+F2TeeustGTNmjAQGBnqWVVVV6Q9rQECAbnmp+VhDLTIdOnSQ9555RrrGxopNthQXS1ZenowbN05iLSu7+u8kOzubslPv1mCf5/Nu2+ddyc/Pl7Fjx54zyHita2nYsGGyZcuWWsvuuece6dGjhzz66KN1QowSGhqqpzO1jYyUjpddJjYpKivTt2rnjo+PF5u4m1gpO/VuC/Z5Pu+2fc+7DwZqDK8FmZYtW0rv3r1rLYuIiJCYmJg6ywEAAHzyqCUAAAAjj1o60wcffODtVQAAAAahRQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYK8jbK2CSjxYtkpzFixt8PDQiQh7IyBB/lJUVKuvXh8jmzcGyfXuQOJ0Oz2P79x/w6roBAOxFkEGjzJkTIVu3BrO1AAA+hSDTTJ3795dBEybUWhYQGCj+yuEQSUyslL59K6W4OEByckK8vUoAABBkmqtFq1aS0KuXNbvQsmUlEh5++v7s2REEGQCAT2CwLxrFHWIAAPAldC0109bsbD3V1GvoUBn54IMXol4AAEAj0CIDAACMRYvMBRzsGxEdfSHqBAAANBJBpplsG+wLAIAvomsJAAAYiyADAACMRdcSGiU9PVzy80+f8C83t/YZflNTIz33U1LKJTGxiq0KALgkCDJolKVLwxo8Cd68eRGe+8OHVxBkAACXDEGmCa6/8049AQAA30CQQaNkZh5mSwEAfA6DfQEAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADCWV4NMamqqOByOWlOPHj28uUoAAMAgQd5egV69esm7777rmQ8K8voqAQAAQ3g9Najgcvnll3t7NQAAgIG8PkZm586dEh8fL1dccYVMnDhRCgoKvL1KAADAEF5tkRk0aJCkp6fLlVdeKUVFRTJjxgy58cYb5fPPP5eWLVvWeX5FRYWe3EpLS/XttoMHpayqSmyyq6RE3+7YsUMOHjwoNnGHXcpOvduCfZ7Pu23f80phYaE0hsPlcrnERxw5ckQ6deokzzzzjNx77731Dg5WYedMKSkpEhISIrZRg6N9qPouKcpOvduGfZ593jZOp1M3dhw9elSioqLMCDLKwIEDJTk5WZ5++ulGtch06NBBlixZIomJiWIT1RqRnZ0t48aNk9jYWLEJZafe2eftwefdzs+7kp+fL2PHjj1nkPH6YN+aysrKZPfu3TJp0qR6Hw8NDdXTmdq0aaPH2djE3cyodm7Kbg/qnX2ez7s9bP68uzOBzw/2ffjhh2Xt2rU6dX388ccyZswYCQwMlDvuuMObqwUAAAzh1RaZr776SoeWQ4cO6cR5ww03yIYNG6xsQgMAAIYFmYyMDG++PQAAMJzXzyMDAADQXAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFhB3l4Bk2Rlhcr69SGyeXOwbN8eJE6nw/PY/v0HxF8VlRXJqi9XSc7XOZJ3OE+KTxRLqbNUokKipFdML5nQfYKeHI5vt4c/sbXebS+7zWyud8oeYly9E2SaYM6cCNm6NVhs88bON2Tmv2bWWV5yskQ+LPxQT8v3LJe0EWkSGBAo/sbWere97Dazud4pe7CYhiDTBKrBITGxUvr2rZTi4gDJyQkRm8S1iJNhHYdJp5adZN+xffLmzjflZNVJ/djqL1dLRl6GTOw5UfyNzfVuc9ltZnO9U/ZK4+qdINMEy5aVSHj46fuzZ0cYU8nnq31ke3lh6AsyuutoCQr4dpcZ022MjF823jOfXZDtl0HG1nq3vew2s7neKbsYV+8EmSZwf7BtM7bb2HqX39D+Bmkd1lp3MSnOaqf4I1vr3fay28zmeqfs5uGoJTSbe9CvW7+4fmxNAMAlRZBBs1RWV8rDax/Wt0qb8DZyd9LdbE0AwCVFkEGTlTnL5O6Vd+sBvkpkcKS8dstrOswAAHApMUYGTVJYViiTVk6SbYe26fmYsBhZcOsCupUAAF5BkEGjbS7eLJPfmSwHTpw+MVKXVl1k4a0LJbFVIlsRAOAVdC2hUVbsXSFjssZ4Qsy17a6V5WOWE2IAAF5Fi0wTpKeHS37+6TPX5ubWPvthamqk535KSrkkJlaJv8janSVT350q1a5qPa8uTTAkYYgs3r641vPU8ruS7hJ/Y2u92152m9lc75Q90Lh6J8g0wdKlYQ2eIGjevAjP/eHDK3yqks9XXkmeJ8Qo6pDrWRtn1XleQmSCXwYZW+vd9rLbzOZ6p+whxtU7XUsAAMBYtMg0QWbmYbHRIwMf0ZOtbK1328tuM5vrnbKbhxYZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjOX1IFNYWCh33XWXxMTESHh4uFx11VWSm5vr7dUCAAAGCPLmmx8+fFiuv/56uemmm2TlypUSGxsrO3fulOjoaG+uFgAAMIRXg8yf//xn6dChg6SlpXmWde7c2ZurBAAADOLVrqWsrCwZMGCATJgwQeLi4qRfv37yyiuveHOVAACAQbzaIrNnzx558cUX5aGHHpLf/e53snHjRvnlL38pISEhMnny5DrPr6io0JNbaWmpvt21a5eUl5eLTQoKCvTtjh075ODBg2ITyk69s8/bg8+7nZ939xjaxnC4XC6XeIkKLKpF5uOPP/YsU0FGBZqcnJw6z09NTZUZM2bUWZ6SkqJfyzYOh0O8WH1e5RARO0tueb1TdrERn3c7693pdEp6erocPXpUoqKifLNFpl27dpKUlFRrWc+ePeXNN9+s9/mPPfaYbr2p2SKjxtiMGjVKEhMTxSYqoWdnZ8u4ceP0IGkbyz6lXz9pFxkpNtlSXCxZeXlW1ztlt7Pe+bzbVe9Kfn6+DjLn4tUgo45YysvLq7PTdurUqd7nh4aG6ulMbdq0kfj4eLGJu5lR/ZjZWnYVYjpedpnYpKisTGyvd8puZ73zeber3pWy//9959ODfR988EHZsGGDPPXUU3qcy6JFi+Tll1+WadOmeXO1AACAIbwaZAYOHCiZmZmyePFi6d27tzz55JPy7LPPysSJE725WgAAwBBe7VpSfvCDH+gJAADAuEsUAAAANBdBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADBWkLdXAGbIygqV9etDZPPmYNm+PUicTofnsf37D4i/+2jRIslZvLjBx0MjIuSBjAzxN7bXu61sr3c+78FG1TtBBo0yZ06EbN0azNayDPVuJ+rdTnMM/Z4nyKBRHA6RxMRK6du3UoqLAyQnJ8TaLde5f38ZNGFCrWUBgYHij6h3O1Hv3+Lz7vsIMmiUZctKJDz89P3ZsyOsDjItWrWShF69xAbUu52o92/xefd9DPZFo7hDDOxCvduJerdTuKHf87TIAE20NTtbTzX1GjpURj74INsS8DN83n0fLTIAAMBYtMgAF2DwX0R0NNsR8EN83n0fQQZoIpsG/wG24/Pu++haAgAAxiLIAAAAY9G1hEZJTw+X/PzTJ33Lza195sfU1EjP/ZSUcklMrGKr+gnq3U7Uu53SDf2eJ8igUZYuDWvwJHjz5kV47g8fXuFTOzjOD/VuJ+rdTqbWO0EGaITr77xTTwD8H593sxBk0CiZmYfZUhai3u1Evdsp09DveQb7AgAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAADGIsgAAABjEWQAAICxCDIAAMBYBBkAAGAsggwAADAWQQYAABiLIAMAAIxFkAEAAMYiyAAAAGMRZAAAgLEIMgAAwFgEGQAAYCyvBpnExERxOBx1pmnTpnlztQAAgCGCvPnmGzdulKqqKs/8559/LsOHD5cJEyZ4c7UAAIAhvBpkYmNja83PmjVLunTpIoMHD/baOgEAAHP4zBgZp9MpCxYskClTpujuJQAAAJ9ukanprbfekiNHjkhKSkqDz6moqNCT29GjR/VtQUGB2KawsFCHv/z8fCkrKxMby77r4EE5Vl4uNikoKbG+3m3e520uO593u+q95m+7y+WSs3G4zvWMS2TEiBESEhIiy5Yta/A5qampMmPGjEu6XgAAwHv27dsnCQkJvh1kvvzyS7niiitkyZIl8sMf/rDRLTKqBadTp046tbVq1UpsUlpaKh06dNAVHBUVJTah7NQ7+7w9+Lzb+XlXVDw5duyYxMfHS0BAgG93LaWlpUlcXJx8//vfP+vzQkND9XQmFWJsrGRFlZuy24d65/NuG/Z5O/f5Vo1opPD6YN/q6modZCZPnixBQT6RqwAAgCG8HmTeffdd3TWkjlYCAABoCq83gdx8883nHJHcENXN9MQTT9Tb3eTvKDv1bhv2efZ529i8zzeFTwz2BQAAMLJrCQAAoLkIMgAAwFgEGQAAYCyjg8zcuXMlMTFRwsLCZNCgQfLJJ5+Iv1u3bp3cdttt+gRB6ppU6tIOtnj66adl4MCB0rJlS33eodGjR0teXp7Y4MUXX5Q+ffp4zqVx3XXXycqVK8VG6uKyat//9a9/Lf5Onc1clbXm1KNHD7Hp8gR33XWXxMTESHh4uFx11VWSm5sr/k79rp1Z72qaNm2at1fNJxkbZF5//XV56KGH9IjuTZs2Sd++ffVlDoqLi8WfHT9+XJdVhTjbrF27Vn+QN2zYIGvWrJFTp07po97UNvF36vTc6gf8008/1V/kQ4cO1WfB3rp1q9hk48aN8tJLL+lQZ4tevXpJUVGRZ1q/fr3Y4PDhw3L99ddLcHCwDu3btm2Tv/71rxIdHS027Oc161x93ykTJkzw9qr5JpehrrnmGte0adM881VVVa74+HjX008/7bKFqr7MzEyXrYqLi/U2WLt2rctG0dHRrvnz57tscezYMVe3bt1ca9ascQ0ePNj1q1/9yuXvnnjiCVffvn1dNnr00UddN9xwg7dXwyeofb1Lly6u6upqb6+KTzKyRUZdCVX9Z5qcnOxZpq7DoOZzcnK8um64dNxXP2/durVVm72qqkoyMjJ0S5TqYrKFao1TlzGp+bm3wc6dO3VXsroe3cSJEz1XBPZ3WVlZMmDAAN0KobqS+/XrJ6+88orYRv3eLViwQJ80VnUvoS4jg8w333yjv8zbtm1ba7ma379/v9fWC5f20hZqjIRqeu7du7cVm37Lli0SGRmpT441depUyczMlKSkJLGBCm6qC1mNk7KJGvuXnp4u77zzjh4ntXfvXrnxxhv1hfT83Z49e3SZu3XrJqtWrZJf/OIX8stf/lL+8Y9/iE3UOEh1geSUlBRvr4rP8vqZfYHm/nf++eefWzNeQLnyyitl8+bNuiXqjTfe0NcnU+OG/D3MqCv//upXv9LjBNTAfpuMHDnSc1+NC1LBplOnTvLPf/5T7r33XvH3f1ZUi8xTTz2l51WLjPrMz5s3T+/7tnj11Vf1fqBa5eBHLTJt2rSRwMBAOXDgQK3lav7yyy/32nrh0rj//vtl+fLl8v777+tBsLYICQmRrl27Sv/+/XXLhBr0PWfOHPF3qhtZDeL/zne+oy8sqyYV4J577jl9X7XO2uKyyy6T7t27y65du8TftWvXrk5I79mzpzVda8qXX36pr0f4k5/8xNur4tMCTP1CV1/m7733Xq30ruZtGjNgGzW+WYUY1aWSnZ0tnTt3Fpupfb6iokL83bBhw3S3mmqNck/qP3U1XkTdV//U2KKsrEx2796tf+T9neo2PvP0Cjt27NAtUrZIS0vT44PU2DD4YdeSOvRaNS+qL7RrrrlGnn32WT348Z577hF//yKr+d+Y6jNXX+ZqwGvHjh3F37uTFi1aJEuXLtXnknGPh2rVqpU+x4Q/e+yxx3TzsqpjNT5CbYcPPvhAjx3wd6quzxwHFRERoc8t4u/jox5++GF93ij14/3111/r002o4HbHHXeIv3vwwQflu9/9ru5a+tGPfqTPE/byyy/ryZZ/VFSQUb9zquURZ+Ey2PPPP+/q2LGjKyQkRB+OvWHDBpe/e//99/Uhx2dOkydPdvm7+sqtprS0NJe/mzJliqtTp056X4+NjXUNGzbMtXr1apetbDn8+vbbb3e1a9dO13v79u31/K5du1y2WLZsmat3796u0NBQV48ePVwvv/yyyxarVq3S3295eXneXhWfx9WvAQCAsYwcIwMAAKAQZAAAgLEIMgAAwFgEGQAAYCyCDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAPAJqampcvXVV3t7NQAYhiAD4IJQ17564IEH5IorrpDQ0FDp0KGDvk5QzYu7AsCFxpWoAJy3/Px8fbXiyy67TGbPni1XXXWVnDp1Sl/UUl3sc/v27WxlABcFLTIAztt9990nDodDX6F43Lhx0r17d+nVq5e+Sv2GDRv0cwoKCuSHP/yhREZGSlRUlL6i8YEDB8569d8//vGPkpCQoFt4VLfTO++8Uys8qfdcsmSJ3HTTTdKiRQvp27ev5OTkeJ6Tnp6uw5UKVD179tTvfcstt0hRUVGt95o/f75+PCwsTHr06CH/8z//w14BGIIgA+C8lJSU6IChWl4iIiLqPK6ChAolKsSo565du1bWrFkje/bskdtvv73B150zZ4789a9/lb/85S/yn//8R0aMGCGjRo2SnTt31nre73//e3n44Ydl8+bNOkDdcccdUllZ6Xn8xIkT+jX+93//V9atW6cDlXq+28KFC2X69Okyc+ZM+eKLL+Spp56Sxx9/XP7xj3+wZwAm8PbltwGY7V//+pdLfZUsWbKkweesXr3aFRgY6CooKPAs27p1q/67Tz75RM8/8cQTrr59+3oej4+Pd82cObPW6wwcONB133336ft79+7Vfz9//vw6r/nFF1/o+bS0ND2/a9cuz3Pmzp3ratu2rWe+S5curkWLFtV6nyeffNJ13XXXNWt7ALi0aJEBcL7/DJ3zOaqlQw3+VZNbUlKSbq1Rj52ptLRUvv76az3upiY1f+bz+/Tp47nfrl07fVtcXOxZprqcunTpUus57sePHz8uu3fvlnvvvVd3O7mnP/3pT3o5AN/HYF8A56Vbt256rIq3BvQGBwd77qv1UFRXVn2Pu5/jDl9lZWX69pVXXpFBgwbVel5gYOBFXW8AFwYtMgDOS+vWrfX4lblz5+oWjjMdOXJED6Tdt2+fnty2bdumH1MtM2dSg4Hj4+Plo48+qrVczdf3/OZq27atfh81Xqdr1661ps6dO1+w9wFw8dAiA+C8qRCjun2uueYafaSR6u5RA27VoN4XX3xRhxZ1SPbEiRPl2Wef1Y+pI50GDx4sAwYMqPc1H3nkEXniiSd0t5A6YiktLU0P6FWDcy+kGTNmyC9/+Utp1aqVPqKpoqJCcnNz5fDhw/qoKwC+jSAD4Lypk+Bt2rRJH/nzm9/8Rh/eHBsbK/3799dBRnXnLF26VJ8w73vf+54EBATo0PD88883+JoqXBw9elS/nhrTolpisrKydFfWhfSTn/xEj6NR579R4UkdeaVC169//esL+j4ALg6HGvF7kV4bAADgomKMDAAAMBZBBgAAGIsgAwAAjEWQAQAAxiLIAAAAYxFkAACAsQgyAADAWAQZAABgLIIMAAAwFkEGAAAYiyADAACMRZABAABiqv8Hi8GTtaf/lzcAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Nouvelle partie pour le solveur probabiliste\n",
+    "random.seed(123)\n",
+    "np.random.seed(123)\n",
+    "board_prob = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(4, 4))\n",
+    "board_prob.reveal(4, 4)\n",
+    "\n",
+    "solver_prob = ProbabilisticSolver(board_prob)\n",
+    "\n",
+    "start = time.time()\n",
+    "won = solver_prob.play_game(verbose=True)\n",
+    "elapsed = (time.time() - start) * 1000\n",
+    "\n",
+    "print(\"\\nResultat de la partie\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"Issue               : {'VICTOIRE' if won else 'DEFAITE'}\")\n",
+    "print(f\"Temps total         : {elapsed:.1f} ms\")\n",
+    "print(f\"Decisions par regles: {solver_prob.decisions['rules']}\")\n",
+    "print(f\"Decisions par CSP   : {solver_prob.decisions['csp']}\")\n",
+    "print(f\"Devinettes (guess)  : {solver_prob.decisions['guess']}\")\n",
+    "total_decisions = sum(solver_prob.decisions.values())\n",
+    "if total_decisions > 0:\n",
+    "    print(f\"\\nRepartition :\")\n",
+    "    for method, count in solver_prob.decisions.items():\n",
+    "        pct = count / total_decisions * 100\n",
+    "        print(f\"  {method:<8}: {count:>3} ({pct:.0f}%)\")\n",
+    "\n",
+    "if solver_prob.guesses_log:\n",
+    "    print(f\"\\nDevinettes effectuees :\")\n",
+    "    for cell, prob in solver_prob.guesses_log:\n",
+    "        result = \"mine !\" if cell in board_prob.mines else \"sure\"\n",
+    "        print(f\"  {cell} -> P(mine)={prob:.1%} -> {result}\")\n",
+    "\n",
+    "fig = draw_board(board_prob,\n",
+    "                 title=f\"Partie {'GAGNEE' if won else 'PERDUE'}\",\n",
+    "                 show_mines=True)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-26",
+   "metadata": {
+    "id": "cell-26",
+    "papermill": {
+     "duration": 0.006265,
+     "end_time": "2026-04-22T18:08:11.183522",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.177257",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : partie complete avec solveur probabiliste\n",
+    "\n",
+    "**Sortie obtenue** : le solveur a joue une partie complete en combinant les trois niveaux de raisonnement.\n",
+    "\n",
+    "| Methode | Decisions | Role |\n",
+    "|---------|-----------|------|\n",
+    "| Regles simples | Majorite des decisions | Deductions locales gratuites |\n",
+    "| CSP | Complement significatif | Deductions globales exactes |\n",
+    "| Devinettes | Quelques-unes | Choix sous incertitude |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. La grande majorite des decisions sont prises par les **regles simples**, qui sont instantanees\n",
+    "2. Le **CSP** intervient quand les regles se bloquent et resout les cas ambigus localement mais determines globalement\n",
+    "3. Les **devinettes** sont rares mais inevitables (le Demineur est NP-complet, certaines configurations sont intrinsequement ambigues)\n",
+    "4. Chaque devinette est faite de maniere **optimale** : on choisit la cellule la moins risquee"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-27",
+   "metadata": {
+    "id": "cell-27",
+    "papermill": {
+     "duration": 0.006115,
+     "end_time": "2026-04-22T18:08:11.195640",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.189525",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Visualisation des probabilites\n",
+    "\n",
+    "Repartons d'un plateau neuf et visualisons les probabilites calculees par le CSP a un instant ou le solveur doit deviner."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-28",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 624
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:11.210293Z",
+     "iopub.status.busy": "2026-04-22T18:08:11.209970Z",
+     "iopub.status.idle": "2026-04-22T18:08:11.349929Z",
+     "shell.execute_reply": "2026-04-22T18:08:11.348934Z"
+    },
+    "id": "cell-28",
+    "outputId": "adb67688-90e5-4b87-8ef3-1f270a97e92f",
+    "papermill": {
+     "duration": 0.14846,
+     "end_time": "2026-04-22T18:08:11.350592",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.202132",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Toutes les cellules ont ete determinees par le CSP.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASNZJREFUeJzt3Ql4VNX9//Fv9oSEfVEgQBBQBBQpIqKoyFJFq7JI/SuyiPZXKm641NpWCVUqLepPXCp1KdEiYIsggcpmoyAaFPRHRZCwhiACAQKEsCSQzP/5HjrjZJkQwjJz5rxfz3OfzJaZe+65c+dzzzn33giPx+MRAAAAC0UGewYAAACqiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIBPm0tLSJCIiwkw9evQI9uygDK0Tb/1oXQFVMXz4cN96k5qa6uRC03J7l4EuD7grOtgzgKrTH7q77rqr3OMxMTHSsGFD6dq1qzzwwANnLLC8+OKLsm/fPnNbNxwpKSln5HPCif+PzEMPPSR16tQJ6vyEM103dR31cvUHHqdfXl6evP766zJv3jxZs2aN7N+/X+rVqyfNmjWT6667ToYMGSIXXHCB7/XFxcXyxhtvyN///ndZvXq1HDx4UGrXri0NGjSQCy+8UC655BJ56qmnTAhT2dnZ0rJly3KfGxkZabYZF198sQwdOtQXYFGGXmsJdpg8ebJeF+uE00svvVTh/1xzzTWn9PktWrTwvdfHH398GkoU/vzrZfPmzeWe/+abbzyffvqpmXbu3BmUeQwXunz9l3c4GzZsmK+cY8aM8bhIy+1dBro8zpS5c+d66tWrV+k295Zbbin1PwMHDjzhdvro0aMB191Ak74vyqNFxmKffvqp+bt161az97lu3Tpz/7HHHpPbbrtNGjVqFOQ5xIlcdNFFZ3whFRQUSFJSEpXB8rNKKKy3n3zyifTv31+OHj1q7jdu3FgefPBB6dy5sxw7dkxWrVolU6dOLfc/77//vrkdFxcnY8aMkUsvvdTc37hxoyxYsEDmz59f6ee+9NJL0qlTJ9Py88orr/her+87e/ZsueWWW85QiS1VQbiBJS0y/jIyMko9N2vWrEpbZHbv3u355S9/6bnssss85557ricuLs4THx/vadWqleeee+7xbNy4scI9n4om/z3CPXv2eH7/+997Lr74Yk9iYqJ5z3bt2pnXHDhwoNQ8b9iwwXPXXXd5OnXq5GnUqJEnJibGU6NGDc+FF17oeeihh8q1UFS2B6Zl8z6nZa6KY8eOeSZNmuTp3r27p06dOubzmzdvbsq/adOmUq8tu8ek5bz33nvNsouNjTVlmD9/foV7zBVN3nmsbL5PZlmWrecvv/zS07t3b0/NmjVN2bwOHjzo+dOf/uTp0qWLeU7nvXXr1p7Ro0d7cnNzS72ntrp531Nb49auXeu54YYbzLw0bNjQc99993kOHTrkyc/PN7e1DnUer7rqKs/y5cvLLe9T+ewtW7Z47rzzTrNnrJ+hdeb/Gf7LsaLpRC2IZVs4/v73v3suueQS873w39veunWr58EHH/RccMEFZj50WfzkJz/xvPDCC56ioqJS77l3717PI4884nutlrdx48aeq6++2vPoo4+a5eFv5cqVniFDhph1UF+ry0iX1YQJEzxHjhypdH5P9Hh1WlTLft+01VCXs5ZZ16nbbrvNk5OTU+p/FixY4Bk0aJAps9ZVdHS0p1atWmY78/zzz5dbRlVd7lWZv+p+twMpLi72tG3bttR6uGPHjgpfu2rVKt9tXce9/9O/f/8KX1/2+1t2++JfP/od0/XH+5yufyiNIBMmQebrr78u9dx7771XaZD57rvvKt3w161b1xdmqhpk1q9f70lOTg74ug4dOpgfZ6958+ZV+r4pKSnmx+BMBBndOFx77bUBP1s3fl988UXADU2bNm3K/Y/++GRnZ5+WIHOyy9K/nps2bepJSEjw3a9du7Z5za5du8z/BXpP/T//jbx/mNDloUGl7P8MGDDA07Vr13KPN2jQwAQcr1P5bP0hrOiz/T/jdAaZsnXr/UHNzMw0yyHQZ+j65B84NLBUNk/bt2/3vXbatGnmxzbQazt37lxqeZ7tIKPLpKL503XUf4fj8ccfr7TMZcNJVZZ7VebPf3twst/tQLS+/f/vnXfe8VSFBijv/yQlJZmu/nXr1nlKSkoC/k9lQUbpd9j73K9+9asqzYdLOGopDHz//fdm4Jg/HUxWmbp168of/vAHee+990yzpTaHzpkzR+68807z/N69e+X55583t0eMGGG6sc4999xSTZ/6mE76vNL/1XlR1157rcyaNcu85zXXXGMe+/bbb82AV68WLVrI+PHjZcaMGbJw4UIzD/o/119/vW8AnA6YOxO0K+7jjz82t3WQ3eTJk808jBw50jdw9PbbbzfNxxXR5aPz9s9//lOaNm1qHisqKpJJkyaZ27/73e98XX9e+lrvMrvhhhsqnb+TXZb+tm3bZgYi6vxpmbSe1ahRo8z/edePadOmmcGLAwcO9P3fsGHDKnxPXR5NmjQx8+E/iHbmzJnyn//8xwyy1WZvb3fm7t27SzW5n8pn5+fnS2Jionk/rScdNFn2M15++WWzfP15l7VO2kxfVevXr5crr7zSfDf+9a9/yf/7f/9PCgsLTXetd7C7zrc+p+uuDsRUuj6NGzfON29Lliwxt3VA6PTp0+Xf//63TJkyRR5//HHp0KGDb9Dmjh075O677/Z1X/Tt29fU9V/+8hdfWb/66iv5zW9+I8Giy0Tna+7cuWZZe7t8dB3Vdd3r6quvNtuGDz74wJQ3IyND3n33XWndurV5XrtFli9fXuXlHozvtpcuc38//elPq/T5vXv3Nl1K3u4xPQDj/PPPN9tc3bbpNuLw4cNVei9d97VrSruYvE5mXXZGsJMUTv9gX/+9k8oG++ogthtvvNF0j2gTcNn30Sbzqu7RadOq9zndc9MmZu8g1hkzZpR6zr9ZVfdyevbsafauo6KiKtzjP90tMrpnpF0j3tdrt4B3XnXS5n/vc97uorJ7TP/4xz987zd+/PgK51edaLBvRfNdnWXpX88RERGe//znP6U+R1u2/Jfv1KlTfe+pdem/t61dSGVbRXRas2aNb/lp94L38V//+te+zxk1apTv8Ycffvi0fbZ2lXmNHDmy3GdUVEcnw79lQFuHDh8+XOr5OXPm+J7XdWfJkiW+Mrz88su+53TdUfr/3jJfdNFFnq+++qrce3pNnDix1Hv7v+6VV14p1TKlXSbBaJFp0qSJp7Cw0Pfcc889V6qFQ7thlHaXPfPMM6YFSedX18XKDkY40XKv6vx5twfV+W4HouUINDj3RN5+++1S35Gyk3bh+3enVnWwr3Z1aYsTSmOwbxjRQ7B1z/e3v/3tCV/7t7/9zewFVkZbHapKD0n00j1LPSSxIvpcVlaWGSynrUhPP/30aZuHqtq1a5eZvB5++OGAr9VWhIrK0qtXL9/t+vXrlzpM81RVZ1n6071fbyuBlw4E10NCve64445Ky+x/KKnSQ0D1sFGlLQna4qOHlKpu3br5XqeHl5ZdFqf62TVr1pQuXbqcseVdlraWxcfHB6wTXXe05aEi27dvlz179ph51BYm/Z7pgFCtIz2Utnnz5uY0CXoaBW+9rl271vf/OijU/7O7d+9eau/8hx9+MC08Z5vOc2xsbIXzpS0c2gKl2x9ddosXL67Wd7qi5R6M77ZX2VMlaL2ec845VZoPPVRay/OPf/zDtA5lZmaaVkcvHfT75JNP+lpwT0SXi7YI/vnPf5aEhIQq/Y9LCDIW83ZdeM8jo82oVT3HgHbpeGlz57333muaPlesWCGjR482j5eUlJyR+dbmVv0RfuGFF3yPDR482HSnaJO1NqvrF7bsPPiXrWyzsP/G63TPa0X0h9wrOvrHr9HxRpizp6L50yMrTvd7ers4vPRH2SvQuXGqsywq+mz/ZX02lvfpWH4aZPS8Iz179jTdMfqjuWHDBtNdqpN2n2j3y+k++qSy74iGjTNJf6y9ISYqKsp08VxxxRUmAGn35qJFiyrdrpzqcj9d322vsjsIH330kdlOVZWGet2u6qQ00Go3vG5j1RdffHHCo5a855HRnRP/IInSCDIW898rOlk5OTm+2xMmTDB99krHqQTi/+NVdmPk3VtXusege6Zlf/yU7sXreAcdF+Ddo1e6Z+Ltdw90hlsNWl7e8SPevnVtmagqDX26kfFu2PVwyIr6v73zeqo/LN4f26oGw5NdlhV9ZlnaR68/Lt6WEV1e+lhV3/NUnK3P9l8/vcu77GNVUdHy868TbVXRPWr/QFVRGfSz9YfP++On86PhXU+PoHSckAaZtm3blhqXceTIEV/LxGeffeZ7rlatWif8sQ/0HdGxKv7ft5P15Zdfmp0P3WkqO1/eE73pZ3jpOKjf//73vkDlv70J5HSc6O10frcvu+wyU+/fffedua8tKH369KnwtBZ60rv27dv7Aot+b73jgvxPtXDrrbf6gkxl2wN97als311DkHHUeeed5/uCPvPMM6abSTei3sGKFdG9zM2bN5vbb7/9ttlQ68ZcuzH0i6fN/zqQTwey6Z6oDnLTZnBtLdH/0w2dfnl1z0abaHVD4t24anfYTTfdZF6jg/Mq4v/jpwMptdlYf1R078W/66IqG0xt2tcA520G1oGUGuZ0L003usuWLTN70tqcfyp0mXk3qhrWfvazn5nlphvJQHtYJ7ssq0L36gYMGOAbEKvN3vqDqhtb7RrYsmWLWabazeHf1XE6nK3P1pYb/+D4v//7v2Y56/LWQaSnQn/AdPnrOZt0/dAuiV/84hfmR02DpgYbHVDapk0b3/qr5dOy6p69DpTWddQ7AFhpYFE///nP5YknnpBDhw5Jbm6u+bHTgallB9Jqi2VF4SnQd0SDkrbSaijyruvVpd0iOp/33HOPaVEaO3as7zmdX13Guk3x+uabb8xgZf18bZk6mR2NU3E6v9taJi2DBiENcfq901YSHWSvf/X7pwFGBzMnJyebFjZvS8svf/lL0/2oA6Q14NSoUcMsA/9WaP8uWZyiMmNmYOnh11X5H//Bvv6HCPpPPXr08N3WwYH+nnjiiQr/RwfRKT3EsLJDhsvOw29+85sTzoP/63Wgo/95HbyTHprYrFmzcoNmK6MD5vw/J9BUlYGklQ2ovv322yt8Xz0fSWWDlE92WVblDM46uLCyQ6DL1nnZc7lUZeBooAHZp/OzKxv03a1bt3Lvq4NuT8eZcj///PNKD78uOz96LpTKXvv++++f1OHX+/fvP+H86mvq169f7v91XfKf95Md7KvnL6qoPDpA13tuFR3we8UVV5R7jQ561fPhVDS/p3KG4soOvz6Z7/bpPrPvG2+8ccLP1gMs9NxIVT38GpXj8GtH6R7Da6+9Zpq1dY9N9yT1ENqyh3H706Zi/T/dC62oGVjfQ/fE9D10j0W7ivQwRG010b0Tbe3xH9ymA3110j05nQdt2dG9m0CH4Wr3hB6+qWN6dA9HB4Fq07zuYfnvDVaFNv1qa4buLeq1qXRvXvd2taVI96B1nFBl3WxVNXHiRDNIz9taUFUnuyyr2uyuXQTPPfecXH755aZLQLsKtLVA7+vev/eMpKfb2fpsvbaNtoLounG66R60dhtoS6B3L1vXI2110BYbbQHyHuqunn32Wbn55pvNNcm0/nT91eWg6++HH35oWqm89FBjXT7a6qItP7ps9H90XdTxYkuXLjVdSyeir9H31m4JXV90vdPrAGkrQUXdk1WlLYQ6/kVbB7UlVd9LW2i0i8k7AFZbMPT7qdcD8ra46qkD9HvUrl07OVtO93f7xhtvNN3XWp9XXXWV6brS+tHtoL6ftib7jznUMwFri7Uuh44dO5rTVujrdX3RliFdf1auXGm+yzg9IjTNnKb3AgCECR2s6+1C0p0Lrs6OUEWLDAAAsBZBBgAAWIsgAwAArMUYGQAAYC1aZAAAgLUIMgAAwFpWn9lXz6yoF1HTc0acjtNbAwCA0KBnhzlw4IA531RllxuxOsgE60qwAADg7NBLg+hlIMIyyHjP3jllyhTnzpKoV9LV67bomUP1TJMuoezUO+u8O/i+L5EhF18s5/z3orou2bR7t9z829+e8EzdVgcZb3eShpiKrqYbzvRignrRQT39uTa7uYSyU++s8+7g+x4rrRs2lOZ16oirIk4wdITBvgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFgrOtgzACB0pafHydKlsbJyZYysXRstRUURvud27Ngp4Yyyu1nv2wu2y4ItCyTzh0zJ2psluYdyJb8oX2rF1pL29dvLoPMHmSki4sdlguAiyAAIaOLERFm9OsbJJUTZ3az3GetnyLgvxpV7PO9Inny67VMzzd00VyZfN1miIqMk3Hw2dapkTpsW8Pm4xES5f/p0CSUEGQAB6U5nSsox6djxmOTmRkpmZqwzS4uyu1nvXo1qNJJezXtJi5otZOuBrfL++vflSPER89zCLQtletZ0GXzh4GDPJggyACozZ06eJCQcvz1hQqJTP2iU3c16b5rUVF7p+Yr0a91PoiN/3Nfv36a/3DrnVt/9jJyMsA8yLTt3lq6DBpV6LDIq9FqhaJEBEJA3xLiIsrtpQJsBFT7evWl3qRdfz3QxqaKSIgl3NWrXluT27SXUcdQSAAAn4B3069WpUSeWWYigRQYAgEocKzkmjy5+1PxVDRIayNB2Q8N+ma3OyDCTv/Y9e0rf0aMllNAiAwBAAAVFBTJ03lAzwFclxSTJO9e/Y8IMQgMtMgAAVGBbwTYZMm+IrNmzxtyvH19fptwwxZlupZYVDPZNrFtXQg1BBgCAMlbmrpRh84fJzkPHTwDYqnYrefeGdyWldoozy6oGg30BALDPh5s/lP7p/X0h5vLGl8vc/nOdCjE2oUUGQEBpaQmSnX38vBErVpQ+02tqapLv9vDhhyUlpTisliRld7Pe0zemy8iPRkqJp8Tc10sT9EjuIdPWlj7brT5+Z7s7gzSX8EeQARDQ7NnxAU+GNmlSou92nz6FYfeDRtndrPesvCxfiFF6yPX45ePLvS45KZkgEyI4agkAAFiLFhkAAc2atdfZpUPZ3fRYl8fM5Kor77jDTDahRQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1QiLIvPrqq5KSkiLx8fHStWtX+fLLL4M9SwAAwAJBDzLvvfeePPzwwzJmzBj5+uuvpWPHjnLddddJbm5usGcNAACEuKAHmRdeeEF+8YtfyF133SXt2rWTSZMmSY0aNeRvf/tbsGcNAACEuOhgfnhRUZF89dVX8sQTT/gei4yMlN69e0tmZma51xcWFprJKz8/3/zdsGGDHD58WFySk5Nj/q5bt0527dolLqHs1DvrvDv4vousys2V7QUF4pqcvLzQDzK7d++W4uJiOeecc0o9rvfXrl1b7vXPPvusjB07ttzjS5YskdjYWHFNRESEZGRkiIsou6P1LsI67yCnv+8ikp6VJS4qKioK/SBzsrTlRsfT+LfINGvWTG6++WYzWNgl2hKjX+yBAwdKw4YNxSWU3e16H9GpkzROShKX6B65/pi5XO8ul93FdV5t2LVL0iTEg0yDBg0kKipKdu7cWepxvX/uueeWe31cXJyZKnqfJk2aiEu8Tev6xabs7qDexWzQm9epIy7xdivwfXdzO+/iOq8OVHHISFAH+2p3UOfOneXf//6377GSkhJzv1u3bsGcNQAAYIGgdy1pV9GwYcPk0ksvlcsuu0xefPFFOXjwoDmKCQAAIKSDzG233Waaz5566inZsWOHXHLJJTJ//vxyA4ABAABCLsio++67z0wAAABWnRAPAACguggyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGtFB3sGbJKeHidLl8bKypUxsnZttBQVRfie27Fjp4Qzl8vuMurdTdsLtsuCLQsk84dMydqbJbmHciW/KF9qxdaS9vXby6DzB5kpIuLH7UA4GzZsvixYkO27361bY5k165agzhN+RJA5CRMnJsrq1THiIpfL7jLX6/2zqVMlc9q0gM/HJSbK/dOnS7iZsX6GjPtiXLnH847kyafbPjXT3E1zZfJ1kyUqMkrC2T//ua5UiAl3n1m4zhNkToLufKSkHJOOHY9Jbm6kZGbGiitcLrvLqHe3NarRSHo17yUtaraQrQe2yvvr35cjxUfMcwu3LJTpWdNl8IWDJVzt2HFQnnzys2DPBk6AIHMS5szJk4SE47cnTEh06sfc5bK7jHr/UcvOnaXroEGllk9kVHi2RjRNaiqv9HxF+rXuJ9GRP/5M9G/TX26dc6vvfkZORlgHmcceWyL79hVK06ZJUq9evKxatVtc0tKSdZ4gcxK8P+QucrnsLqPef1Sjdm1Jbt9eXDCgzYAKH+/etLvUi69nuphUUUmRhKvp09fKokVbTKvkiy/2kBde+EpcU8OSdZ6jlgAAVeId9OvVqVGnsFxy27cXyJgxn5vbQ4e2k6uuSg72LKEStMgAQBWszsgwk7/2PXtK39GjnVh+x0qOyaOLHzV/VYOEBjK03VAJR488slj27y+S5s1rylNPdRNXrbZknadFBgBQqYKiAhk6b6gZ4KuSYpLknevfMWEm3EydulYyMrb+t0vpWklMdPeoPVvQIgMA1Rz4mFi3btgvu20F22TIvCGyZs8ac79+fH2ZcsOUsOxWOnLkmKSmHu9SGjGig1xxRRNxWUtL1nmCDACE0cDH02ll7koZNn+Y7Dx0/KSXrWq3kndveFdSaqdIOCosLJb8/OMDmN9661szVSQzc7uce+6ksD8xXg1L1nm6lgAA5Xy4+UPpn97fF2Iub3y5zO0/N2xDDOxFi8xJSEtLkOzs48fQr1hRut80NTXJd3v48MOSklIs4cTlsruMendT+sZ0GfnRSCnxlJj7emmCHsk9ZNra0md81cfvbHenhIuYmEi58cbzKnwuM/MHycs7fjJAPadMt25N5IILQq+bxUUEmZMwe3Z8wBPBTZqU6Lvdp09h2P2Yu1x2l1HvbsrKy/KFGKWHXI9fPr7c65KTksMqyNSoESNvvfXTCp/r33+26VJSGmACvQ5nH11LAADAWrTInIRZs/aKq1wuu8tcr/cr77jDTK55rMtjZsKPwnlQr+3rPC0yAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArBXUILNkyRK56aabpEmTJhIRESEffPBBMGcHAABYJqhB5uDBg9KxY0d59dVXgzkbAADAUtHB/PC+ffuaCQAAwLogc7IKCwvN5JWfn2/+btiwQQ4fPiwuycnJMX/XrVsnu3btEpdQdrfrfVVurmwvKBCXbMjLE9fr3eWyu7jOq5z/rvcnEuHxeDwSAnSMzKxZs6Rfv34BX5Oamipjx44t9/jw4cMlNjZWXKPLLESq76yj7NS7ayJExM1ad/z77nC9FxUVSVpamuzfv19q1aoVHi0yTzzxhDz88MOlWmSaNWsmQy6+WFo3bCgu0YSenpUlAwcOlIaOlV33zDIyMig79e7cOj+iUydpnJQkLmFb52a9qw27dkmanJhVQSYuLs5MZZ2TlCTN69QRl3ibGfXHTI/6com3eZmyU++urfP6Y8a2zh0u17s6UMUhI5xHBgAAWCuoLTIFBQVmoK7X5s2bZeXKlVKvXj1p3rx5MGcNAABYIKhBZsWKFXLttdf67nvHvwwbNswM8AEAAAjZINOjRw9nR6IDAIBTxxgZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFrRwZ4B2CE9PU6WLo2VlStjZO3aaCkqivA9t2PHzqDOG84cl+t9e8F2WbBlgWT+kClZe7Mk91Cu5BflS63YWtK+fnsZdP4gM0VE/LhMEAaOHJGkF16Q6P/8R6I3bpSIvXslorBQPLVqybHzzpOi3r3l0IgR5j5CA0HmJHw2dapkTpsW8Pm4xES5f/p0CUcTJybK6tUxwZ4NnGUu1/uM9TNk3Bfjyj2edyRPPt32qZnmbpork6+bLFGRURJuXN3eRRw8KIkvvVT+8bw8idVpxQqJnz5d8ubNE0/duhJuPrOw3gkyqBLd6UxJOSYdOx6T3NxIycyMZck5gHoXaVSjkfRq3kta1GwhWw9slffXvy9Hio+Y5bNwy0KZnjVdBl84ONhVhdOouHFjOXrppVKcnCwldetK5J49Ev+vf0nU99+b56OzsyVhyhQ5dP/9LPcQQJCpppadO0vXQYNKPRYZFX57ZV5z5uRJQsLx2xMmJBJkHOFyvTdNaiqv9HxF+rXuJ9GRP24q+7fpL7fOudV3PyMnI+yDjEvbO0/9+rL7//6v3OOHRo6Uhp06+e5Hbd0q4a6lJfVOkKmmGrVrS3L79uIK748Z3OJyvQ9oM6DCx7s37S714uuZLiZVVFIk4c617V0pxcUSmZtrWmD8HbvgAgl3NSypd4IMAJwE76Bfr06NftxLR/iIXbJE6v785xU+V3T55XJ4cHi3wtmEIFNNqzMyzOSvfc+e0nf06NNRLwBC0LGSY/Lo4kfNX9UgoYEMbTdUwh3bux8dHjBADkyYIBIfL+FutSW/cwQZAKiCgqIC+Z9F/yMZW49v2JNikuSd698xYQbhRw+1PvDUUxJRVCSR338v8R9+KJF5eZIwc6bErFole6dOlZJmzYI9myDInN5BUIlheCgeAJFtBdtkyLwhsmbPGrM46sfXlyk3THGmW8nF7V1JcrIcuvde3/2Cxx+X+r17S9TOnRK9fr3UfOop2T95soSzlpbUOy0yYT4ICsCpWZm7UobNHyY7Dx0/AWCr2q3k3RvelZTaKc4sWrZ3Ip6GDeVo584S9eGHZpnEfv65hLsalvzOcYkCAAjgw80fSv/0/r4Qc3njy2Vu/7lOhRjXxCxdKhEFBeUej9izR2K+/trvAc7oHCpokUGVpKUlSHb28fMHrFhR+kyvqalJvtvDhx+WlJRilmqYcLne0zemy8iPRkqJp8Tc10sT9EjuIdPWlj7rqT5+Z7s7gzSXON1qvPmmxC1eLEVXXSVH27UTT0KCRG3fLnF6Qrxdu3yvK+zdm4UfIggyqJLZs+MDngxt0qRE3+0+fQrD7gfNZS7Xe1Zeli/EKD3kevzy8eVel5yUTJAJMxGHD0vcwoVmqsjRDh3kQGrqWZ8vVIwgAwDAfx2+6y4padTIdCNF7tghkfv2iURHS0mDBnKsXTs50revHLn1VpEYN69BFooIMifhyjvuMJOLZs3aG+xZQBC4XO+PdXnMTK5ydXtXdM01ZnLVlRbWO4N9AQCAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWCuoQebZZ5+VLl26SM2aNaVRo0bSr18/ycrKCuYsAQAAiwQ1yCxevFhGjRoly5Ytk0WLFsnRo0flpz/9qRw8eDCYswUAACwRHcwPnz9/fqn7aWlppmXmq6++kquvvjpo8wUAAOwQ1CBT1v79+83fevXqVfh8YWGhmbzy8/PN3zW7dklBcbG4ZENenvm7bt062bVrl7gkJyfH/KXs1Ltr6/yq3FzZXlAgLmFb52a9q5z//s6dSITH4/FICCgpKZGbb75Z9u3bJ0uXLq3wNampqTJ27Nhyjw8fPlxiY2PFNRERERIi1XfWUXbq3TWs86zzrikqKjI9NdrIUatWrdAPMr/61a9k3rx5JsQkJydXuUWmWbNmMnPmTElJSRGXaGtERkaGDBw4UBo2bCguoezUO+u8O/i+u/l9V9nZ2TJgwIATBpmQ6Fq67777ZO7cubJkyZKAIUbFxcWZqawGDRpIkyZNxCXe7iRduSm7O6h31nm+7+5w+fuuCqrYnRbUIKONQffff7/MmjVLPvnkE2nZsmUwZwcAAFgmqEFGD72eOnWqzJ4925xLZseOHebx2rVrS0JCQjBnDQAAWCCo55F57bXXTN9Xjx49pHHjxr7pvffeC+ZsAQAASwS9awkAAKC6uNYSAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZ0sGfAJunpcbJ0aaysXBkja9dGS1FRhO+5HTt2Sjhzuexwk8vrvMtllyNHJOmFFyT6P/+R6I0bJWLvXokoLBRPrVpy7LzzpKh3bzk0YoS5H262F2yXBVsWSOYPmZK1N0tyD+VKflG+1IqtJe3rt5dB5w8yU0TEj+tDKCDInISJExNl9eoYcZHLZYebXF7nXS57xMGDkvjSS+Ufz8uTWJ1WrJD46dMlb9488dStK+FkxvoZMu6LceUezzuSJ59u+9RMczfNlcnXTZaoyCgJFQSZk6AhNCXlmHTseExycyMlMzNWXOFy2eEml9d5l8uuihs3lqOXXirFyclSUreuRO7ZI/H/+pdEff+9eT46O1sSpkyRQ/ffL+GoUY1G0qt5L2lRs4VsPbBV3l//vhwpPmKeW7hloUzPmi6DLxwsoYIgcxLmzMmThITjtydMSHTqy+1y2eEml9d5l8vuqV9fdv/f/5V7/NDIkdKwUyff/aitWyXcNE1qKq/0fEX6te4n0ZE/xoP+bfrLrXNu9d3PyMkgyNjK+8V2kctlh5tcXuddLns5xcUSmZtrWmD8HbvgAgk3A9oMqPDx7k27S734eqaLSRWVFEkooUUGAIAyYpcskbo//3mFy6Xo8svl8ODQ6Vo507yDfr06NfqxZSoUcPg1AABVdHjAANn37rsi8fFOLLNjJcfk0cWPmr+qQUIDGdpuqIQSWmQAAChDD7U+8NRTElFUJJHffy/xH34okXl5kjBzpsSsWiV7p06VkmbNwnq5FRQVyP8s+h/J2Jph7ifFJMk7179jwkwoIcgAAFBGSXKyHLr3Xt/9gscfl/q9e0vUzp0SvX691HzqKdk/eXLYLrdtBdtkyLwhsmbPGnO/fnx9mXLDlJDrVlJ0LQEAcAKehg3laOfOvvuxn38etstsZe5KuWHmDb4Q06p2K/lX/3+FZIhRBBkAAP4rZulSiSgoKLc8IvbskZivv/Z7ILTObnu6fLj5Q+mf3l92Hjp+BufLG18uc/vPlZTaKRKq6Fo6CWlpCZKdffxshitWlD7rZWpqku/28OGHJSWlWMKJy2WHm1xe510ue40335S4xYul6Kqr5Gi7duJJSJCo7dslTk+It2uX73WFvXtLuEnfmC4jPxopJZ4Sc18vTdAjuYdMWzut1Ov08Tvb3SmhgiBzEmbPjg94YqhJkxJ9t/v0KQy7L7fLZYebXF7nXS67ijh8WOIWLjRTRY526CAHUlMl3GTlZflCjNJDrscvH1/udclJyQQZAABC0eG77pKSRo1MN1Lkjh0SuW+fSHS0lDRoIMfatZMjffvKkVtvFYlx81pUoYgWmZMwa9ZecZXLZYebXF7nXS570TXXmMlFj3V5zEy2YbAvAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAOBukDly5MjpmRMAAICzEWRKSkrk6aeflqZNm0pSUpJs2rTJPP7kk0/KW2+9VZ23BAAAODtB5plnnpG0tDT585//LLGxP15YrEOHDvLmm29W5y0BAADOTpB555135PXXX5fBgwdLVNTxS72rjh07ytq1a6vzlgAAAGcnyGzbtk1at25dYZfT0aNHq/OWAAAAZyfItGvXTj799NNyj8+YMUM6depUnbcEAAA4adEn/y8iTz31lAwbNsy0zGgrzMyZMyUrK8t0Oc2dO7c6bwkAAHB2WmRuueUWmTNnjnz00UeSmJhogs13331nHuvTp0913hIAAODstMioq666ShYtWlTdfwcAAAhekFFFRUWSm5trupf8NW/e/FTnCwAA4MwEmfXr18uIESPk888/L/W4x+ORiIgIKS4urs7bAgAAnPkgM3z4cImOjjYDexs3bmzCCwAAgBVBZuXKlfLVV19J27ZtT+nDX3vtNTNlZ2eb++3btzcDh/v27XtK7wsAANxQ7fPI7N69+5Q/PDk5WcaPH29C0YoVK6Rnz57miKjVq1ef8nsDAIDwV60g86c//Ul+/etfyyeffCJ79uyR/Pz8UlNV3XTTTXLDDTdImzZt5Pzzz5dx48aZi1AuW7asOrMFAAAcU62upd69e5u/vXr1Om2DffV//vnPf8rBgwelW7du1ZktAADgmGoFmY8//vi0zcCqVatMcDly5IhpjZk1a5bpuqpIYWGhmby8rT8bNmyQw4cPi0tycnLM33Xr1smuXbvEJZSdemeddwffdze/70qvHlAVER5tRgkiPReNrqj79+8312p68803ZfHixRWGmdTUVBk7dmyFR1HFxsaKa7T1K8jVFzSUnXp3Deu8o+u89naIm4qKiiQtLc3kg1q1ap3eIPPNN99U/GYRERIfH29OiBcXFyfV7bZq1aqV/PWvf61Si0yzZs3MtZ5SUlLEJZrQMzIyZODAgdKwYUNxCWWn3lnn3cH3PUNGdOokjZOSxDUbdu2SXg8/fMIgU62upUsuuaTSc8fExMTIbbfdZsKIBpuToWcJ9g8r/jQcVRSQGjRoIE2aNBGXeJsZdYNO2d1BvbPO83137/uuIaZ5nTrimgNVHDJSraOWdByLHmn0+uuvm3PK6KS3L7jgApk6daq89dZbprXg97//faXv88QTT8iSJUvMeWR0rIze1yOhBg8eXJ3ZAgAAjqlWi4weJj1x4kS57rrrfI9ddNFF5rwwTz75pHz55ZfmqtiPPPKIPPfccwHfR6/TNHToUNm+fbvUrl1bLr74YlmwYAFX0AYAAGcuyGjrSYsWLco9ro/pc97uJw0oldGWGwAAgOqqVteSXppAz8irI4q9jh49ah7zXrZAD5s655xzqj1jAAAAZ6RF5tVXX5Wbb77ZdCVpd5DSlhg9qZ1eSFJt2rRJ7r333uq8PQAAwJkLMldccYVs3rxZ3n33XXNonBo0aJDccccdUrNmTXN/yJAh1XlrAACAMxtklAaWkSNHVvffAQAAzl6QSU9Pl759+5pzxOjtymi3EwAAQMgEmX79+smOHTukUaNG5nYg1b1oJAAAwBkLMnrG3Ypu+9u6dav84Q9/OOmZAAAAOGuHXweSl5cnf/vb307nWwIAAJydIAMAAHA2EWQAAIC1CDIAAMCN88gMGDCg0uf37dt3qvMDAABwZoKMXqH6RM/r1awBAABCLshMnjz5zM0JAADASWKMDAAAsBZBBgAAWIsgAwAA3Lv6NYDwl54eJ0uXxsrKlTGydm20FBVF+J7bsWOnhDPKTr27ts6rz6ZOlcxp0ySQuMREuX/6dAklBBkAAU2cmCirV8c4uYQoO/UOOxBkAAQUESGSknJMOnY8Jrm5kZKZGevM0qLs1Ltr63xZLTt3lq6DBpV6LDIqSkINQQZAQHPm5ElCwvHbEyYkOrVRp+zHlwP17s46X1aN2rUluX17CXUM9gUQkDfEuIiyu8nlercVLTIAAKCc1RkZZvLXvmdP6Tt6tIQSWmQAAIC1aJEBAABVGuybWLeuhBqCDAAAKIfBvgAAAGcYY2QAAIC16FoCEFBaWoJkZx8/AdaKFaXP9JqamuS7PXz4YUlJKQ6rJUnZqXfX1nlbEWQABDR7dnzAk+BNmpTou92nT2HYbdQpO/Xu2jpvK4IMAAAwrrzjDjPZhCADIKBZs/Y6u3Qou5tcrndbMdgXAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAa4VMkBk/frxERETIQw89FOxZAQAAlgiJILN8+XL561//KhdffHGwZwUAAFgk6EGmoKBABg8eLG+88YbUrVs32LMDAAAsEvQgM2rUKLnxxhuld+/ewZ4VAABgmehgfvj06dPl66+/Nl1LVVFYWGgmr/z8fPN3w4YNcvjwYXFJTk6O+btu3TrZtWuXuISyU++s8+7g+y6yKjdXthcUiGty8vKq9LoIj8fjkSDYunWrXHrppbJo0SLf2JgePXrIJZdcIi+++GKF/5Oamipjx44t9/jw4cMlNjZWXKODo4NUfUFH2R2tdxFxs+Ss82zr3FNUVCRpaWmyf/9+qVWrVugFmQ8++ED69+8vUVFRvseKi4vND1RkZKRpefF/LlCLTLNmzWTmzJmSkpIiLtGWmIyMDBk4cKA0bNhQXELZ3a73EZ06SeOkpGDPzlmle+TpWVlO1ztld6veVXZ2tgwYMOCEQSZoXUu9evWSVatWlXrsrrvukrZt28rjjz9eLsSouLg4M5XVoEEDadKkibjE27SuGzXK7g7qXUyIaV6njrjE263A953tvEsKqtidFrQgU7NmTenQoUOpxxITE6V+/frlHgcAAAjJo5YAAACsPGqprE8++STYswAAACxCiwwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwVnSwZwBA6EpPj5OlS2Nl5coYWbs2WoqKInzP7dixU8LdZ1OnSua0aQGfj0tMlPunT5dw43K9U/ZY6+qdIAMgoIkTE2X16hiWkGNcrnfKHiO2IcgACCgiQiQl5Zh07HhMcnMjJTMz1tml1bJzZ+k6aFCpxyKjoiQcuVzvlP2YdfVOkAEQ0Jw5eZKQcPz2hAmJ1mzYzoQatWtLcvv24gKX652yi3X1zmBfAAF5f8zgFpfrnbLbhxYZAKiC1RkZZvLXvmdP6Tt6NMsPCCJaZAAAgLVokQGAag72Taxbl2UHBBlBBgCqwKXBvoBN6FoCAADWIsgAAABr0bUEIKC0tATJzj5+0rcVK0qf8TM1Ncl3e/jww5KSUsySDBMu1ztlj7Ku3gkyAAKaPTs+4EmxJk1K9N3u06cwpDZsODUu1ztlj7Wu3gkyABDAlXfcYSYAoYsgAyCgWbP2snQc5HK9U3b7MNgXAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAawU1yKSmpkpERESpqW3btsGcJQAAYJHoYM9A+/bt5aOPPvLdj44O+iwBAABLBD01aHA599xzgz0bAADAQkEfI7N+/Xpp0qSJnHfeeTJ48GDJyckJ9iwBAABLBLVFpmvXrpKWliYXXHCBbN++XcaOHStXXXWVfPvtt1KzZs1yry8sLDSTV35+vvm7YcMGOXz4sLjEG/jWrVsnu3btEpdQdrfrfVVurmwvKBCXbMjLE9frnbK7Ve9q27ZtUhURHo/HIyFi37590qJFC3nhhRfk7rvvrnBwsIadsoYPHy6xsbHiGh0cHULVd1ZRdurdNazzrPOuKSoqMo0d+/fvl1q1atkRZFSXLl2kd+/e8uyzz1apRaZZs2Yyc+ZMSUlJEZfo3klGRoYMHDhQGjZsKC6h7NQ767w7+L67+X1X2dnZMmDAgBMGmaAP9vVXUFAgGzdulCFDhlT4fFxcnJnKatCggRln4xJv87Ku3JTdHdQ76zzfd3e4/H33ZoKQH+z76KOPyuLFi03q+vzzz6V///4SFRUlt99+ezBnCwAAWCKoLTLff/+9CS179uwxibN79+6ybNkyJ5vQAACAZUFm+vTpwfx4AABguaCfRwYAAKC6CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtaKDPQMAQtf2gu2yYMsCyfwhU7L2ZknuoVzJL8qXWrG1pH399jLo/EFmioiIkHBD2d2s9/T0OFm6NFZWroyRtWujpajoxzLu2LFTwlm6pWUnyAAIaMb6GTLui3HlHs87kiefbvvUTHM3zZXJ102WqMiosFqSlN3Nep84MVFWr44RF020tOwEGQAn1KhGI+nVvJe0qNlCth7YKu+vf1+OFB8xzy3cslCmZ02XwRcODsslSdndqndtZEpJOSYdOx6T3NxIycyMFVdEWFp2ggyAgJomNZVXer4i/Vr3k+jIHzcX/dv0l1vn3Oq7n5GTEXY/aJTdzXqfMydPEhKO354wIdGaH3OXy06QARDQgDYDKny8e9PuUi++nulqUEUlRWG3FCm7m/Xu/SF3UYKlZeeoJQAnzTv406tTo07OLEXK7ma9I3QRZACclGMlx+TRxY+av6pBQgMZ2m6oE0uRsrtZ7whtBBkAVVZQVCBD5w01Az1VUkySvHP9O+ZHLdxRdjfrHaGPMTIAqmRbwTYZMm+IrNmzxtyvH19fptwwxYnuBcruZr3DDgQZACe0MnelDJs/THYeOn5SrFa1W8m7N7wrKbVTwn7pUXY36x32oGsJQKU+3Pyh9E/v7/sxu7zx5TK3/1wnfswou5v1DrvQIgMgoPSN6TLyo5FS4ikx9/UU9T2Se8i0tdNKvU4fv7PdnWG1JCm7m/WelpYg2dnHz1a8YkXps9ympib5bg8fflhSUoolnKRZWnaCDICAsvKyfD9mSg+5Hr98fLnXJSclh90PGmV3s95nz44PeCK4SZMSfbf79CkMqR9zl8tO1xIAALAWLTIAAnqsy2NmchFld7PeZ83aK66aZWnZaZEBAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWkEPMtu2bZM777xT6tevLwkJCXLRRRfJihUrgj1bAADAAtHB/PC9e/fKlVdeKddee63MmzdPGjZsKOvXr5e6desGc7YAAIAlghpk/vSnP0mzZs1k8uTJvsdatmwZzFkCAAAWCWrXUnp6ulx66aUyaNAgadSokXTq1EneeOONYM4SAACwSFBbZDZt2iSvvfaaPPzww/Lb3/5Wli9fLg888IDExsbKsGHDyr2+sLDQTF75+fnm74YNG+Tw4cPikpycHPN33bp1smvXLnEJZafeWefdwffdze+7dwxtVUR4PB6PBIkGFm2R+fzzz32PaZDRQJOZmVnu9ampqTJ27Nhyjw8fPty8l2siIiIkiNUXVJTd0XoXETdLzjrv7LbO4XW+qKhI0tLSZP/+/VKrVq3QbJFp3LixtGvXrtRjF154obz//vsVvv6JJ54wrTf+LTI6xubmm2+WlJQUcYkm9IyMDBk4cKAZJO0Syu52vY/o1EkaJyWJS1bl5kp6VpbT9e5y2V1c59WGXbskTU4sqEFGj1jKysoqV3EtWrSo8PVxcXFmKqtBgwbSpEkTcYm3mVG/2JTdHdS7mA168zp1xCXbCwrMX77vbm7nXVzn1YEqDhkJ6mDf0aNHy7Jly+SPf/yjGecydepUef3112XUqFHBnC0AAGCJoAaZLl26yKxZs2TatGnSoUMHefrpp+XFF1+UwYMHB3O2AACAJYLataR+9rOfmQkAAMC6SxQAAABUF0EGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZ0sGcAQOhKT4+TpUtjZeXKGFm7NlqKiiJ8z+3YsVPC3WdTp0rmtGkBn49LTJT7p0+XcONyvbtcdlvXeYIMgIAmTkyU1atjWEKOcbneXS67rQgyAAKKiBBJSTkmHTsek9zcSMnMjHV2abXs3Fm6DhpU6rHIqCgJRy7Xu8tlt3WdJ8gACGjOnDxJSDh+e8KERKc36jVq15bk9u3FBS7Xu8tlt3WdZ7AvgIC8G3S4xeV6d7nstqJFBgCqYHVGhpn8te/ZU/qOHs3yQ1habck6T4sMAACwFi0yAFDNgY+Jdeuy7BC2WlqyzhNkACCMBj4Crq3zdC0BAABrEWQAAIC16FoCEFBaWoJkZx8/AdaKFaXPdpqamuS7PXz4YUlJKWZJhgmX693lstuKIAMgoNmz4wOeEGzSpETf7T59CtmohxGX693lstuKIAMAAVx5xx1mAlxxpYXrPEEGQECzZu1l6TjI5Xp3uey2YrAvAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1gpqkElJSZGIiIhy06hRo4I5WwAAwBLRwfzw5cuXS3Fxse/+t99+K3369JFBgwYFc7YAAIAlghpkGjZsWOr++PHjpVWrVnLNNdcEbZ4AAIA9QmaMTFFRkUyZMkVGjBhhupcAAABCukXG3wcffCD79u2T4cOHB3xNYWGhmbz2799v/ubk5Ihrtm3bZsJfdna2FBQUiEsou9v1vmHXLjlw+LC4JCcvj+8767y4ZtPu3eavx+Op9HURnhO94iy57rrrJDY2VubMmRPwNampqTJ27NizOl8AACB4tm7dKsnJyaEdZLZs2SLnnXeezJw5U2655ZYqt8hoC06LFi1Mi0zt2rXFJfn5+dKsWTNTwbVq1RKXUHbqnXXeHXzf3fy+K40nBw4ckCZNmkhkZGRody1NnjxZGjVqJDfeeGOlr4uLizNTWRpiXKxkpeWm7O6h3vm+u4Z13s11vnYVGimCPti3pKTEBJlhw4ZJdHRI5CoAAGCJoAeZjz76yHQN6dFKAAAAJyPoTSA//elPTzgiORDtZhozZkyF3U3hjrJT765hnWedd43L6/zJCInBvgAAAFZ2LQEAAFQXQQYAAFiLIAMAAKxldZB59dVXJSUlReLj46Vr167y5ZdfSrhbsmSJ3HTTTeYEQXpNKr20gyueffZZ6dKli9SsWdOcd6hfv36SlZUlLnjttdfk4osv9p1Lo1u3bjJv3jxxkV5cVtf9hx56SMKdns1cy+o/tW3bVly6LMWdd94p9evXl4SEBLnoootkxYoVEu70d61sves0atSoYM9aSLI2yLz33nvy8MMPmxHdX3/9tXTs2NFc5iA3N1fC2cGDB01ZNcS5ZvHixeaLvGzZMlm0aJEcPXrUHPWmyyTc6em59Qf8q6++Mhvynj17mrNgr169WlyyfPly+etf/2pCnSvat28v27dv901Lly4VF+zdu1euvPJKiYmJMaF9zZo18vzzz0vdunXFhfXcv851e6cGDRoU7FkLTR5LXXbZZZ5Ro0b57hcXF3uaNGniefbZZz2u0OqbNWuWx1W5ublmGSxevNjjorp163refPNNjysOHDjgadOmjWfRokWea665xvPggw96wt2YMWM8HTt29Ljo8ccf93Tv3j3YsxESdF1v1aqVp6SkJNizEpKsbJHRK+Dqnmnv3r19j+l1GPR+ZmZmUOcNZ4/36uf16tVzarEXFxfL9OnTTUuUdjG5Qlvj9DIm/t97F6xfv950Jev16AYPHmxOIOqC9PR0ufTSS00rhHYld+rUSd544w1xjf7eTZkyxZw0VruXUJ6VQWb37t1mY37OOeeUelzv79ixI2jzhbN7aQsdI6FNzx06dHBi0a9atUqSkpLMybFGjhwps2bNknbt2okLNLhpF7KOk3KJjv1LS0uT+fPnm3FSmzdvlquuuspcSC/cbdq0yZS5TZs2smDBAvnVr34lDzzwgLz99tviEh0HqRdIHj58eLBnJWQF/cy+QHX3zr/99ltnxguoCy64QFauXGlaombMmGGuT6bjhsI9zOiVfx988EEzTkAH9rukb9++vts6LkiDTYsWLeQf//iH3H333RLuOyvaIvPHP/7R3NcWGf3OT5o0yaz7rnjrrbfMeqCtcgijFpkGDRpIVFSU7Ny5s9Tjev/cc88N2nzh7Ljvvvtk7ty58vHHH5tBsK6IjY2V1q1bS+fOnU3LhA76njhxooQ77UbWQfw/+clPzIVlddIA99JLL5nb2jrrijp16sj5558vGzZskHDXuHHjciH9wgsvdKZrTW3ZssVcj/Cee+4J9qyEtEhbN+i6Mf/3v/9dKr3rfZfGDLhGxzdriNEulYyMDGnZsqW4TNf5wsJCCXe9evUy3WraGuWddE9dx4vobd2pcUVBQYFs3LjR/MiHO+02Lnt6hXXr1pkWKVdMnjzZjA/SsWEIw64lPfRamxd1g3bZZZfJiy++aAY/3nXXXRLuGzL/vTHtM9eNuQ54bd68uYR7d9LUqVNl9uzZ5lwy3vFQtWvXNueYCGdPPPGEaV7WOtbxEbocPvnkEzN2INxpXZcdB5WYmGjOLRLu46MeffRRc94o/fH+4YcfzOkmNLjdfvvtEu5Gjx4tV1xxhela+vnPf27OE/b666+byZUdFQ0y+junLY+ohMdiL7/8sqd58+ae2NhYczj2smXLPOHu448/Noccl52GDRvmCXcVlVunyZMne8LdiBEjPC1atDDresOGDT29evXyLFy40OMqVw6/vu222zyNGzc29d60aVNzf8OGDR5XzJkzx9OhQwdPXFycp23btp7XX3/d44oFCxaY7VtWVlawZyXkcfVrAABgLSvHyAAAACiCDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZACEhNTVVLrnkkmDPBgDLEGQAnBZ67av7779fzjvvPImLi5NmzZqZ6wT5X9wVAE43rkQF4JRlZ2ebqxXXqVNHJkyYIBdddJEcPXrUXNRSL/a5du1aljKAM4IWGQCn7N5775WIiAhzheKBAwfK+eefL+3btzdXqV+2bJl5TU5Ojtxyyy2SlJQktWrVMlc03rlzZ6VX//3DH/4gycnJpoVHu53mz59fKjzpZ86cOVOuvfZaqVGjhnTs2FEyMzN9r0lLSzPhSgPVhRdeaD77+uuvl+3bt5f6rDfffNM8Hx8fL23btpW//OUvrBWAJQgyAE5JXl6eCRja8pKYmFjueQ0SGko0xOhrFy9eLIsWLZJNmzbJbbfdFvB9J06cKM8//7w899xz8s0338h1110nN998s6xfv77U6373u9/Jo48+KitXrjQB6vbbb5djx475nj906JB5j7///e+yZMkSE6j09V7vvvuuPPXUUzJu3Dj57rvv5I9//KM8+eST8vbbb7NmADYI9uW3Adjtiy++8OimZObMmQFfs3DhQk9UVJQnJyfH99jq1avN/3355Zfm/pgxYzwdO3b0Pd+kSRPPuHHjSr1Ply5dPPfee6+5vXnzZvP/b775Zrn3/O6778z9yZMnm/sbNmzwvebVV1/1nHPOOb77rVq18kydOrXU5zz99NOebt26VWt5ADi7aJEBcKo7Qyd8jbZ06OBfnbzatWtnWmv0ubLy8/Plhx9+MONu/On9sq+/+OKLfbcbN25s/ubm5voe0y6nVq1alXqN9/mDBw/Kxo0b5e677zbdTt7pmWeeMY8DCH0M9gVwStq0aWPGqgRrQG9MTIzvts6H0q6sip73vsYbvgoKCszfN954Q7p27VrqdVFRUWd0vgGcHrTIADgl9erVM+NXXn31VdPCUda+ffvMQNqtW7eayWvNmjXmOW2ZKUsHAzdp0kQ+++yzUo/r/YpeX13nnHOO+Rwdr9O6detSU8uWLU/b5wA4c2iRAXDKNMRot89ll11mjjTS7h4dcKuDel977TUTWvSQ7MGDB8uLL75ontMjna655hq59NJLK3zPxx57TMaMGWO6hfSIpcmTJ5sBvTo493QaO3asPPDAA1K7dm1zRFNhYaGsWLFC9u7da466AhDaCDIATpmeBO/rr782R/488sgj5vDmhg0bSufOnU2Q0e6c2bNnmxPmXX311RIZGWlCw8svvxzwPTVc7N+/37yfjmnRlpj09HTTlXU63XPPPWYcjZ7/RsOTHnmloeuhhx46rZ8D4MyI0BG/Z+i9AQAAzijGyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAAAgtvr/SMzPCuIkM5EAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Creer un plateau et avancer jusqu'au premier blocage\n",
+    "random.seed(77)\n",
+    "np.random.seed(77)\n",
+    "board_viz = MinesweeperBoard(rows=8, cols=8, n_mines=10, safe_cell=(3, 3))\n",
+    "board_viz.reveal(3, 3)\n",
+    "\n",
+    "# Appliquer les regles simples\n",
+    "rule_solver_viz = RuleBasedSolver(board_viz)\n",
+    "rule_solver_viz.solve()\n",
+    "\n",
+    "# Calculer le CSP et les probabilites\n",
+    "csp_solver_viz = CSPSolver(board_viz)\n",
+    "safe, mines, solutions_viz = csp_solver_viz.solve()\n",
+    "\n",
+    "# Appliquer les deductions sures\n",
+    "for cell in mines:\n",
+    "    board_viz.flag(*cell)\n",
+    "for cell in safe:\n",
+    "    board_viz.reveal(*cell)\n",
+    "\n",
+    "# Relancer regles + CSP jusqu'au blocage complet\n",
+    "for _ in range(5):\n",
+    "    rs = RuleBasedSolver(board_viz)\n",
+    "    rs.solve()\n",
+    "    cs = CSPSolver(board_viz)\n",
+    "    s, m, sols = cs.solve()\n",
+    "    if not s and not m:\n",
+    "        break\n",
+    "    for cell in m:\n",
+    "        board_viz.flag(*cell)\n",
+    "    for cell in s:\n",
+    "        board_viz.reveal(*cell)\n",
+    "\n",
+    "# Calculer les probabilites finales\n",
+    "csp_final = CSPSolver(board_viz)\n",
+    "_, _, solutions_final = csp_final.solve()\n",
+    "probs = csp_final.get_probabilities(solutions_final)\n",
+    "\n",
+    "if probs:\n",
+    "    print(\"Probabilites de mine pour les cellules non determinees :\")\n",
+    "    print(\"=\" * 50)\n",
+    "    for cell in sorted(probs.keys()):\n",
+    "        p = probs[cell]\n",
+    "        if 0 < p < 1:  # Seulement les cellules non determinees\n",
+    "            print(f\"  {cell} : P(mine) = {p:.1%}\")\n",
+    "\n",
+    "    fig = draw_board(board_viz,\n",
+    "                     title=\"Probabilites de mine (cellules non determinees)\",\n",
+    "                     probabilities=probs)\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print(\"Toutes les cellules ont ete determinees par le CSP.\")\n",
+    "    fig = draw_board(board_viz, title=\"Plateau entierement resolu par le CSP\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-29",
+   "metadata": {
+    "id": "cell-29",
+    "papermill": {
+     "duration": 0.006315,
+     "end_time": "2026-04-22T18:08:11.364700",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.358385",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : carte de probabilites\n",
+    "\n",
+    "**Sortie obtenue** : les pourcentages sur les cellules non determinees representent la probabilite qu'elles contiennent une mine.\n",
+    "\n",
+    "| P(mine) | Interpretation | Action |\n",
+    "|---------|---------------|--------|\n",
+    "| 0% | Sure dans toutes les solutions | Reveler sans risque |\n",
+    "| 100% | Mine dans toutes les solutions | Poser un drapeau |\n",
+    "| 10-30% | Faible risque | Bon candidat pour une devinette |\n",
+    "| 40-60% | Incertitude forte | Eviter si possible |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Les probabilites sont **exactes** (calculees par enumeration complete)\n",
+    "2. Le solveur choisit toujours la cellule a **0%** si elle existe, puis la plus faible probabilite sinon\n",
+    "3. Les probabilites dependent des solutions **globales** du CSP, pas seulement des voisins locaux"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-30",
+   "metadata": {
+    "id": "cell-30",
+    "papermill": {
+     "duration": 0.006405,
+     "end_time": "2026-04-22T18:08:11.377387",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.370982",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Analyse des performances (~7 min)\n",
+    "\n",
+    "Comparons les trois approches sur un grand nombre de parties pour mesurer leur taux de victoire et leur temps d'execution.\n",
+    "\n",
+    "### Protocole experimental\n",
+    "\n",
+    "- 100 parties par approche\n",
+    "- Plateau 8x8 avec 10 mines (difficulte standard \"debutant\")\n",
+    "- Premier clic garanti sur (4, 4)\n",
+    "- Meme sequence aleatoire pour toutes les approches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cell-31",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:11.391461Z",
+     "iopub.status.busy": "2026-04-22T18:08:11.391150Z",
+     "iopub.status.idle": "2026-04-22T18:08:11.398615Z",
+     "shell.execute_reply": "2026-04-22T18:08:11.397801Z"
+    },
+    "id": "cell-31",
+    "outputId": "ecbb40a3-0a60-47bb-f716-62ab4c9028ac",
+    "papermill": {
+     "duration": 0.015617,
+     "end_time": "2026-04-22T18:08:11.399195",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.383578",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonctions de simulation definies.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def play_rule_only(board):\n",
+    "    \"\"\"Joue une partie avec les regles simples uniquement.\n",
+    "\n",
+    "    Quand les regles se bloquent, choisit une cellule aleatoire.\n",
+    "    \"\"\"\n",
+    "    decisions = {'rules': 0, 'random': 0}\n",
+    "    while not board.game_over and not board.won:\n",
+    "        solver = RuleBasedSolver(board)\n",
+    "        solver.solve()\n",
+    "        if solver.moves_log:\n",
+    "            decisions['rules'] += len(solver.moves_log)\n",
+    "            continue\n",
+    "\n",
+    "        if board.game_over or board.won:\n",
+    "            break\n",
+    "\n",
+    "        # Choisir aleatoirement parmi les inconnues\n",
+    "        unknown = [\n",
+    "            (r, c) for r in range(board.rows) for c in range(board.cols)\n",
+    "            if (r, c) not in board.revealed and (r, c) not in board.flagged\n",
+    "        ]\n",
+    "        if not unknown:\n",
+    "            break\n",
+    "        cell = random.choice(unknown)\n",
+    "        board.reveal(*cell)\n",
+    "        decisions['random'] += 1\n",
+    "\n",
+    "    return board.won, decisions\n",
+    "\n",
+    "\n",
+    "def play_csp_only(board):\n",
+    "    \"\"\"Joue une partie avec regles + CSP.\n",
+    "\n",
+    "    Quand le CSP se bloque, choisit une cellule aleatoire.\n",
+    "    \"\"\"\n",
+    "    decisions = {'rules': 0, 'csp': 0, 'random': 0}\n",
+    "    while not board.game_over and not board.won:\n",
+    "        # Regles simples\n",
+    "        solver = RuleBasedSolver(board)\n",
+    "        solver.solve()\n",
+    "        if solver.moves_log:\n",
+    "            decisions['rules'] += len(solver.moves_log)\n",
+    "            continue\n",
+    "\n",
+    "        if board.game_over or board.won:\n",
+    "            break\n",
+    "\n",
+    "        # CSP\n",
+    "        csp_solver = CSPSolver(board)\n",
+    "        safe, mines, _ = csp_solver.solve()\n",
+    "        if safe or mines:\n",
+    "            for cell in mines:\n",
+    "                board.flag(*cell)\n",
+    "            for cell in safe:\n",
+    "                board.reveal(*cell)\n",
+    "            decisions['csp'] += len(safe) + len(mines)\n",
+    "            continue\n",
+    "\n",
+    "        if board.game_over or board.won:\n",
+    "            break\n",
+    "\n",
+    "        # Aleatoire\n",
+    "        unknown = [\n",
+    "            (r, c) for r in range(board.rows) for c in range(board.cols)\n",
+    "            if (r, c) not in board.revealed and (r, c) not in board.flagged\n",
+    "        ]\n",
+    "        if not unknown:\n",
+    "            break\n",
+    "        cell = random.choice(unknown)\n",
+    "        board.reveal(*cell)\n",
+    "        decisions['random'] += 1\n",
+    "\n",
+    "    return board.won, decisions\n",
+    "\n",
+    "\n",
+    "def play_probabilistic(board):\n",
+    "    \"\"\"Joue une partie avec le solveur probabiliste complet.\"\"\"\n",
+    "    solver = ProbabilisticSolver(board)\n",
+    "    won = solver.play_game()\n",
+    "    return won, solver.decisions\n",
+    "\n",
+    "\n",
+    "print(\"Fonctions de simulation definies.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9cg0uqgn9b",
+   "metadata": {
+    "id": "f9cg0uqgn9b",
+    "papermill": {
+     "duration": 0.006691,
+     "end_time": "2026-04-22T18:08:11.411923",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.405232",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "Lançons le benchmark sur 100 parties pour chaque approche. L'execution peut prendre quelques secondes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cell-32",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:11.426230Z",
+     "iopub.status.busy": "2026-04-22T18:08:11.425969Z",
+     "iopub.status.idle": "2026-04-22T18:08:12.435197Z",
+     "shell.execute_reply": "2026-04-22T18:08:12.434276Z"
+    },
+    "id": "cell-32",
+    "outputId": "78b9fba7-dd46-428a-ba55-a5d78e50f1ca",
+    "papermill": {
+     "duration": 1.017782,
+     "end_time": "2026-04-22T18:08:12.435926",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:11.418144",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + aleatoire\n",
+      "  Victoires : 75/100 (75%)\n",
+      "  Temps moyen : 0.7 ms\n",
+      "  Decisions : {'rules': 2309, 'random': 131}\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + CSP + aleatoire\n",
+      "  Victoires : 89/100 (89%)\n",
+      "  Temps moyen : 5.0 ms\n",
+      "  Decisions : {'rules': 2316, 'csp': 378, 'random': 46}\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regles + CSP + probabilites\n",
+      "  Victoires : 87/100 (87%)\n",
+      "  Temps moyen : 3.8 ms\n",
+      "  Decisions : {'rules': 2365, 'csp': 395, 'guess': 59}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Benchmark sur 100 parties\n",
+    "N_GAMES = 100\n",
+    "ROWS, COLS, MINES = 8, 8, 10\n",
+    "\n",
+    "approaches = [\n",
+    "    (\"Regles + aleatoire\", play_rule_only),\n",
+    "    (\"Regles + CSP + aleatoire\", play_csp_only),\n",
+    "    (\"Regles + CSP + probabilites\", play_probabilistic),\n",
+    "]\n",
+    "\n",
+    "results = []\n",
+    "\n",
+    "for name, play_func in approaches:\n",
+    "    wins = 0\n",
+    "    total_time = 0\n",
+    "    total_decisions = defaultdict(int)\n",
+    "\n",
+    "    for game_id in range(N_GAMES):\n",
+    "        # Meme graine pour chaque approche\n",
+    "        random.seed(1000 + game_id)\n",
+    "        np.random.seed(1000 + game_id)\n",
+    "\n",
+    "        board_bench = MinesweeperBoard(ROWS, COLS, MINES, safe_cell=(4, 4))\n",
+    "        board_bench.reveal(4, 4)\n",
+    "\n",
+    "        # Remettre le generateur aleatoire pour le solveur\n",
+    "        random.seed(2000 + game_id)\n",
+    "\n",
+    "        start = time.time()\n",
+    "        won, decisions = play_func(board_bench)\n",
+    "        total_time += time.time() - start\n",
+    "\n",
+    "        if won:\n",
+    "            wins += 1\n",
+    "        for k, v in decisions.items():\n",
+    "            total_decisions[k] += v\n",
+    "\n",
+    "    win_rate = wins / N_GAMES * 100\n",
+    "    avg_time = total_time / N_GAMES * 1000\n",
+    "    results.append({\n",
+    "        'name': name,\n",
+    "        'wins': wins,\n",
+    "        'win_rate': win_rate,\n",
+    "        'avg_time_ms': avg_time,\n",
+    "        'decisions': dict(total_decisions)\n",
+    "    })\n",
+    "\n",
+    "    print(f\"{name}\")\n",
+    "    print(f\"  Victoires : {wins}/{N_GAMES} ({win_rate:.0f}%)\")\n",
+    "    print(f\"  Temps moyen : {avg_time:.1f} ms\")\n",
+    "    print(f\"  Decisions : {dict(total_decisions)}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-33",
+   "metadata": {
+    "id": "cell-33",
+    "papermill": {
+     "duration": 0.005798,
+     "end_time": "2026-04-22T18:08:12.448555",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.442757",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Tableau comparatif et visualisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "cell-34",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 448
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:12.461232Z",
+     "iopub.status.busy": "2026-04-22T18:08:12.460979Z",
+     "iopub.status.idle": "2026-04-22T18:08:12.571560Z",
+     "shell.execute_reply": "2026-04-22T18:08:12.570785Z"
+    },
+    "id": "cell-34",
+    "outputId": "11157cf1-7ebc-4f51-ab64-f1b6139f8e47",
+    "papermill": {
+     "duration": 0.117882,
+     "end_time": "2026-04-22T18:08:12.572141",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.454259",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Comparaison des approches - Demineur 8x8, 10 mines\n",
+      "=================================================================\n",
+      "Approche                        Victoires     Taux   Temps (ms)\n",
+      "-----------------------------------------------------------------\n",
+      "Regles + aleatoire                 75/100     75%         0.7\n",
+      "Regles + CSP + aleatoire           89/100     89%         5.0\n",
+      "Regles + CSP + probabilites        87/100     87%         3.8\n",
+      "=================================================================\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWsAAAHvCAYAAAAivo00AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAh3dJREFUeJzt3QncFeP///Grfd+F9k0q2myRLYQQypIkSiFLkbWQJGUXKSl7opC0KNJCWYuQnUQrbSqttM//8b5+/2u+c859tnvrnvu+X8/H49R95syZM3PNnDPXfOZzXVcBz/M8AwAAAAAAAADIUQVz9uMBAAAAAAAAAEKwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAJDl5s6dawoUKGAftWvXzhMlrO1w26Ttyw5u+XosW7bM5FX7oyzziiuvvNIvq/vuuy+nVydU8sv3Jejyyy+321uuXDmzadOmnF4dxHHKKaf4x+bo0aMpJ4TymOnfv7/9vCJFiphFixbtl88EAKSGYC0AhIwq6cEghHuULFnS1K1b11x66aXms88+y+nVBJAHg+fuwr1s2bKmXr165uyzzzbDhg0zmzdvzunVzPe++uorM27cOFsON9xwgylfvnxEmei80KFDB1OzZk1TrFgxU7RoUVO9enVz4YUXmo8++ijT5bd8+XLTq1cv07BhQ1OqVClTuHBhU7lyZXPqqaeal156yXiel+nP2Lhxow0gnXXWWeaAAw5IOSD/448/mssuu8xUrVrVbrf+1/Offvop0+uESNoPffr0Maeddpq9aRDcR4no+GzXrp09ZnR81qpVy/To0cOsWLEi5vzbt283AwcONI0bN7b1H33WiSeeaMaMGZMlx9r+pptt7hGWGy0333yz/S7v2bPH7lMAQIh4AIBQefnll3UVkvBRqFAhb+rUqV5YzZkzx1/XWrVqeXmBtsNtk7YvOwT38dKlS728an+UZV7RtWtXv6wGDBiQ7fsj3qNy5crezJkzvTD55JNP/MeOHTu8vO68886z+6JAgQLeihUrIl6bNGmSV7Bgwbj7T+954403MvzZy5Yt8ypWrJjwGLn++uszvY0LFy6Mu/x4v4nvvfeeV6xYsZjvKV68eI4ct99//71/bK5du9bLS3SsxdtH8bzwwgv2GIz1Hh1X3377bcT8Gzdu9Jo1axb3c7p37+7lNsmO5Zw6Zq666ip/vfT9AwCEA5m1ABByn3zyiX2MHTvWHHTQQXba3r17zRNPPJHTq5YvbNu2LadXASG0b98+899//5m8plu3bvb3ZurUqaZfv342u1H+/vtvc+6559rXwkJZdu6hTL3cavfu3WbXrl1Js1rfffdd+7e2t0aNGhGvP/744/aYFGUiTp482UyaNMlmwYpiRZk5Zzz//PM261WUda1M2hkzZpjzzjvPn+e5557L9O+lsmJPOOEE07t3b7tNyfzzzz+mS5cuZufOnfa5/taxq/9lx44dtuuI/Z0Z3qRJE//YPPDAA01eoixXZVPfcccd5u677046/++//2569uzpZ8Pedttt5p133jFt27a1z3VcderUydZrHC37u+++s38feuihZvz48eaZZ54xJUqUsNN0/L3++usm7HSOcN/LsB4zKntn1KhR++1zAQBJ5HS0GACQOLM26LbbbvOnN2jQIE3R/fzzzzZLok6dOjbTqEyZMt7xxx9vl7lv376EGXtTpkzxjj32WJuJdMABB3g9evTwtm3bluYzfv/9d++GG26wn1+iRAmvZMmS9u9rrrnGz26LzqxdtWqVd+WVV3qVKlWyyz/xxBO9BQsWRCxX6+Deo3V79913vSOPPNJuR926db3hw4fb+X777TebYaZtK1eunNexY0dv3bp1EcsaN26cd/7553v16tWz8xQuXNhm75x88sneiy++mKYsWrVq5X/2Sy+95D355JNew4YNvSJFini9e/eOmw2q5QSzUmrXru398ccfSQ/pDz/80GvZsqUtiwMPPNBmpP3zzz8JM2/Ss2///PNPu/80b9GiRe3nVK9e3Tv99NO9e++910vFL7/84l122WX2fSoH7WeVQdu2bb2nnnoqzfw6fs4++2ybgany1r4+44wzvLfeeivNvLHK8rjjjvOnaf8FLV++3M/K0jG3adMm/7UvvvjCu/TSS/31LF++vNe6dWu7Pql8rqis433ngtO/++4776abbvKqVq1qsxiVYSavvvqqPab12cp617HWuHFjexzPmzcvpfLWMaxsMZWbylrH5Oeff54ws3b79u3eI4884h1zzDH2eNC+PuSQQ7xbbrklzXcikWC5RH+GjqWaNWv6rx9++OHe3r17I+ZJzz6I/q49/vjj9jjVMartmD17tp1v+vTpXosWLex0lfddd93l7dmzJ2JZ8b4vwe3R8h577DGvfv36tnz0HR0yZEjMcpgxY4b93TjooIPsduh3UL81H3/8cZp54312vFYF0ceYfhO1b/V90bGdLKNN2+De+/DDD6d5XfvFve5+K6Pf17x5cztt165dtmzd9IEDB/rz//jjj36Wqsrrm2++sdN79uzpz3/RRRf58+t3PLhdwe9mZkWXWaxsxGHDhvmvH3roof5voY5R7XP32tNPP53087LyHBQ8zvUbndnz7v7+/U9V8HiPd1l56623+q9rHZx///3Xbod7bdq0aXb6+vXr7Xq76Z9++qn/nsGDB/vTjz766HQfQxs2bPCuu+46+x1XOR511FFpfqf0+ddee639jhx88MF2PpWh6hNXX311mnN89Hd+0aJF3gUXXGB/BzWtXbt2cTOEg8dHvGNGtN733HOP17RpU69UqVJ2fQ477DB7DG3dujViXtXD9J3WvDqX6LdM26tz7I033uitXr06Yn79rmqZ+twKFSqk+X0HAOQMgrUAkEuCtStXrrQXjm76JZdcEvE+BY5UgY93QdC5c+eIi7rgRaMCPLHeowuWIF1MqfIf7zMUcIy+eNEFiy4Uo+fVhemWLVtiXijroihWk96+ffvGbIrbpk2biPXUxXOiiyMXgHWCF0nBC/zgvNGBPpWlAtRumgLW2kfJKCCkYGb0Oh1xxBFxAxPp2bcKxKj84s2rC89kdLGaqMlz9I0CXQAmKm8FDpIFTZ9//nl/2rnnnhsx/0MPPeS/dsUVV/jTR4wYkbDptwJ8yT43PcHa6GND+0UBx0TbrnVPRsEZXXjH2lfB6cFA6t9//20DwvE+t1q1at6SJUuSfnZ0ucTqakHB6OCyFZzN6D4IftcUXIueX4GFQYMGxWwyHV2W8b4vwe2J3mfu8frrr0csS78t8bZB2zdy5MgsDdZGr1eyYK2+E7GOXUcBeve6jovJkyfb41M3ndz0YJBaAScXKFOZKyir347gOWbo0KH+/Apouelly5a1x726F3BdM+ihv7NSKsHa9u3b+6/rhmBQ8Bx34YUXJv28rDwHpRKsTfW8u79//7M6WKubBO71++67L245KagrOnbdNJ0rd+/eHfPz9BuxefPmdB1DsX5ntZyxY8dG3KiMV34uoBkM2AbXScF73YAJzp/ZYO3ixYtj1qGC33cFc50uXbok/LxYNxB1I9u97m7QAAByFsFaAMiFfdaqcq4+BB1l9ZQuXdp/XZkj77//vg2yBAMXyiqNddGoR6dOnWwwVlmewQsll7Whz9BFuntNmUbPPvusDT4qkKHsoFjBWj2U4aNsSW2bLmbc9FGjRsW8UNZDAVdlNimLKzhd2/Pmm2/aLKfg9F9//dVfli68tOx33nnHrssHH3xgt10BYs2r7MdgdknwIkkPZdfpAlkXjS7bJ1iOyoxVGbvnTZo08dasWZN03ypjJXghrQtHZZ6+9tprXo0aNWIGJtK7b4OZbsqs0XbMmjXLe+WVV2zgWRl4yWid3DJOPfVUWwbazwrQKLPotNNOixnE0UNBI/UhqaBGMOA2fvz4hEFTBe5ddo+CRwoYOypfN//cuXP9DEAXTNH//fr1s8EjHZO6mHbza98n+tz0BGv1OcpuV9anyl99DCrTOBiI0OepzJ944gnvrLPOigh4xaP3uWUoo0yZkyrz6GM/GEjVzRo3XcEQBR+1XsH3nHTSSUk/O5VgrY7t4HooQJvRfRD8ruk9+jx9zxs1ahTxGcrMVb/cwRsiynJLb7BW33V9hsoz+NnKMnN0vLrpytx+9NFH7XdGwU2XZarfQmXMZVWwVsu9//777ffqueeeS3qjJ7hNypyMpixFlVUwI9E9qlSpYr+70fS7Ezyn9OnTJ+4NE1GLg1iBSn3m3Xffbddhfwdr9RvnXr/zzjvjBuDV/2kyWXkOSiVYm+p5d3///md1sDZYbwie86NvrCqoKfrtjPedjw6kJrvJEX0MKUt/9OjRtlxUZwneVHYZzfq903dT+1hlrXOOfosuv/xyf361LopXBlqWfvf1W6hWKK4v2uA8OsdG908b75gJrqfOx1p3rU9w/uBNTHceVV1Ly1F9Rf1V6zyj1gvBm22OzutuWSofAEDOI1gLALkwWKvK+w8//OC/J3jRqIvu4MA7CqDEClAELxp1ARdsPhrMntWFhqgZqZumi8dYAYN4Fy9ffvml/1owyOkyaaIvlHVB5bJp9N7gshRYidX0V4FZR4E+XagryKcLl1hZesH5gxc9ahYZS/DCONhkXxc/wayWRL766qs0zepjBYyCgYn07ls10Q0GvH766SebbZUeush0y1BXCMrsiW6C7qi5Z7zMuosvvth/7ZxzzkkaNO3WrZs//ZlnnrHTdPwFM9HccRrsEkRNa4Plou4E3Gtqnp9Vwdrg8eqofNzrCpgq4zW9ghmyCnY72m/KkI0OpOqmiIKQbrpuhLht13Yp2B0rgJTRYK2+i8FyeOCBBzK8D4LftWDrAAVI3XRlEbrvlMoz+NnBbPxY35fo7QkGVebPn+9PV9DRCQbjFPQIboeO21jBwMwGa9V8Pz2Cv8n//fdfmtf1/dR+UXPnWOcM3WCJ9ZsdHTx0v7+xjmMFmII3ToIPfTdjdReR3cHa4M2v6Cb+/fv391/TfMlk5TkolWBtKufdnPj9z+pgbfC3Kvqmgb5vwfUVZda7aeqCJUgZrcHPUzmk5xhS8N1RVyTBmxsTJ070X1MAXTfiFCyO1RJGGejxyiB4HAQlO5ZjHTOq57lp+l3XzR23/ydMmBDxmgvw69h1x/Bnn30Ws1uNaMEbNfotBgDkvMLJ+rQFAOQsN6CPBlJ58sknzZw5c8wXX3xhzjrrLPPHH3/YgXV+/vlnf/4ff/zRnHTSSTGXpddiOe2000yBAgXs3wULFjQVKlQw//77r33uBpUJfsaxxx5rqlWrltL6lylTxhxzzDH+80qVKvl/u2VHa9GihSlcuHCa+aVly5b+327wo+CyNKCHBqhZtGhRwvVSecZy4YUXJtkiY+bPn+9//qxZs0y5cuVMKjTQSnCQlqZNm/rPtc6xpHffHnLIIeb00083s2fPNh988IE5/PDDTaFChUy9evVs2V133XXmuOOOS7ie+gy976effjLjxo2zDw38U79+fXPyySebXr16mcMOO8zO++uvv/rv08AoQXo+YcKENPPFc9VVV5mXX37Z/q0B9a6//nr72U737t394zRYLtpWPRKVS1a46KKL0ky75pprzJtvvmkHx3EDtej7o32rAbluuOEGu69TPS6Cx3eRIkXsd0EDRQX99ttvEYPxXHbZZXGXre1v0KCByQwNLhZUvnz5LNkHxx9/vP938Huu9a1YsWKa77j7nus3JVWtW7dO+tsT3I5XX33VPtKzHVl1LKXKDdQUpONMA3xJu3bt7GBMOu40SJz+/vDDD+1gYF999ZX9jXeefvpp8+mnn9pziaPtjy53DebkjjP9Duh7rd8a/X/llVfaY/jss8+2v7upnhuyQqlSpfy/3SBjsZ6XLl06XcvNzDkoVek97+6v3//s2EdbtmxJeR+luk+D70lV8BxVpUoVU7duXf/ctHjxYn/wMp2LMlJ/UH1Mv/tZJbj/NRBhmzZtYs6n1/TdO+qoo+w+vvfee82qVav8eoW+k3pN3+GOHTum9JsCAMhZ/6utAQBCyY0OrAvtYODqr7/+Mh999FG6lhVvpG4XGHHcRWpWVOIzsuxg8DMYWAgGiqK5ZSmw5QK1uugbNmyYDXAr6K3Rlp14IzTrAi4ZXfzK+vXrUxoNe39w+1YX/xoNXaM6X3DBBTbwpTJUgO+VV16xwVYFbBIpXry4+eyzz+xo7BqxWxf6Cg4qeDty5EgbZFuxYkWWb4MuLF1g8fPPPzdLly71R/xWmXft2jXdywwe8y4wInv27IkbjIwn1rFxyimn2PLU6PVafwVvdCGv76ZGNO/cubPJSfG+8+kxc+bMiOdHH310lqxDvO95vO94Rn6Pgr8/wd+ejIi3HVl1LCVSuXLluEFBBbBefPFF//l9991nqlatasvxwQcf9KcvXLjQD0g569atS7POmi+aAr7BwLBuRigY3KVLF9OsWTM7ffv27WbatGlmf1KwzVmzZk3Ea6tXr/b/1m9YemTmHJSqrDzvZuXvf07vo+D8GzZsiPh+BefXtgbnzSoPP/yw/7duir/zzju2/qCb5cnqDwcddFDEeWZ/csdA//797TrrfHnEEUfYgLbqi5p26aWXmqeeeirNe4O/KQceeOB+XW8AQGwEawEgF4m+gHMV7EaNGvnTFEj7/93cpHlkJnDjMilFmb3K2gijYBBRF1o33nijDagpuPDnn38mfX8qF1oKYpYtW9YPYigol4pgwEAZVD/88IP/XMHJWNK7b/W3gq3XXnutmThxos0aUhDlpptu8jNwXLZrPFqGghW33XabDb4oa06ZUS4bcPPmzea9996zfzds2NB/nwK8QcHnwfkSUfasWwdl8C5fvtw+P+ecc2wAKla5KKM1XrkEsyGVueYEjwUFN1IR69jQZzRv3twMHTrUZigq8KXychlfU6ZM8bPlUjkuXNa2KEixYMGCNPMfeuih/g0D0c2JeMdERgLcQSqne+65J+J3wAVrM7IPwii4HXfddVfMbdDNiunTp2frsZRI8EZTdKsB3RwIZlq7LEb3XQ0KPtfxpUw7N78LFuoG1DfffBPxvmBAN7h8lU2iz8tuyk4N/oa6IJr+D/7+BOfLTXLi9z+rBcvetRQSrXPwOHPz6ea0WhW4Y3TevHn+PB9//LH/tzJF3Xk4VcFjQoHjJUuW+M+VlRxdh3jsscfsjXKtUyr1p0Tf6+Br8YK9ifZ/iRIlzKZNm+Lu/1atWtn59FzrPHr0aFu++n6OHz/eX467ARoU/E0J/tYAAHIO3SAAQMgpABTsBiFWAFXN2nSBrQq7LlgvvvhiexGugJsyKlQRV3Ctffv2ZsCAARlaj0suucQGMrZu3epfGPTp08fUrl3bLFu2zDZf12ckyorbH4KZNmoGqia9KgcFWOM1XUwvBecUlFGTxB07dthlK8ts4MCBCd935JFH2vVzF4jaR8qCU2ZcvAzd9O7btWvX2gxPBVZ10aUMPgULg9lUWudEvvzyS9u832VmHXzwwfbGgDJro5ehJtCumb7K5Pbbb7fNcHVR/fbbb/vza75UKFNPTbd1ke4CwhLdLFXLU4BUF726+FTTeDU/VTNUBc/UfFSZRCo799kKcrqsQQUgdSwre1fZ1xl1yy232CbkZ555pqlRo4bdL7pAdgFaXThr/ybqCkH71JXtiBEjbHmr+bIutmPdYNB3TN11vPXWW34gWzcMFGzQxbwC3Cp/BWpS6X4iSIEK/eYo6KYgiTL0lN0m6gpDz12mYUb2QRjp2FJgywVntD3KQNR2qjy+//57G3TXb4lu/LhjSTetpGfPnvbx9ddfx+1CIbP0uS5rVd/PYABMmXA6ZlzWotZFvwUK2j366KP+fDoGdVw5+g64bVAXBsq6U3B/165d9m8dx+6mg7JnXUBH5yF9pn7L9B0PBryCXd7ot839Jmq5Op6T0ffGZXIr6zdI013Wn37v5PLLL7efoWNUWcM6znSueuONN/z1UrZ7Tme4Z1R2//6rvJRxK3q/9lkyalHi6iXRN2ImT57sH2v6TRQ1y1d3Gzqu1B2HbgLqeNaNTgWS3c083Vx13U5ov7oucfT9fOCBB+wNg0ceecT/rJtvvjnd5dmjRw+7LJWflqV1cr+pbn11XP/yyy/278GDB9vP13db78sMbZfKTvQ7qt9K/caoyw39tsaifajvlG7aqYsnfe8VeNe5RuWh85fKVL9ZrhsaBZZVnur2Qjc4Ffh+//33457/daPHBc1VLqrfAABCIKc7zQUApH+AMT06d+4c8T4NjqGBeRK9Jzh4UHCgk+hBheINxDRlyhQ7Wnq85Wvgo0SD7EQP4qJ1SDY90eBPsQbk2L59u1e3bt0066aBQho2bBhz0Jd4g8EkKxOVR3DwkUceeSTp4Tx9+vSYA5Y0aNAg7gAk6dm3q1evTjifPjvWaNBB8+bNS7iMMmXKeMuWLfPn79WrV8L5NUp9srIM0qjgwfdr0CQ32E+QBr0rWLBgws8O7s9PP/005jzBAb6ij7F4+8S59tprE37++eef7yWjgWGCx6Z7aGCe4ABKwe+pRomPXu/oR/R3L57g/oj3qFy5sh14LrP7IN53Lfi7p3lS2QfxpmdkILngADvxHsFljR07NumxlGiAsfRavny5X84nnnhimte1Psn2Q3BQs9mzZ/vzV6pUyf5uSIcOHfz5u3Tp4s//888/exUqVEi4fA3UFhTvNz2R6HKK9wjSYFDBgaKCj2LFitnf3FRk1Tko0fSMnHez8/c/0frEEz2gViq/Pc8++2zMgT710HH19ddfR8yvAQbjDWaXmePpiCOOSLMsrdeYMWP894waNSrmZ55yyikxty9RfSeoU6dOMZe7cuXKhMeMBo2rXr16wvIO/mZG1yWiH0888UTEes2aNSvuuRoAkHPoBgEAcgk1e1ZmhjJSNJCMy4ZxlAWprEFljijDTllV6rNVfyuDQ5kc6mswM84//3zz7bff2kwZDTKjz1AGjbLMrr76attML6dpfZRpovJQn4DKFNF6KxNI/cllJS33hRde8Js39u3b1wwfPjzhe5Q9pCwXDfKiDETtU2U3BZt3RkvPvlWG0KBBg2yWUM2aNe0+UfNmZdgoG1PNUJXJk4iWq+xWZU/rfVpPZedoecp4UjZerVq1/Pm1zcqu1bYpi02fp7JXhq2aX7qBj1IVnUWrrLxY/Y0qg1DdBihrTuum7CQ1i1U2cIcOHcyYMWMiBoxTxpm+N3rdbY/693MZqhmh5v869pUBpX2p76n2jfoKvP/+++3gY8koe1F93Oo4ULlpnykrSsdJ9KBtwT5MlWGprG4dSzrOtU3aX3qu/RfMbE4PZXtpnZRhpn2qzGNlLZ5xxhmZ3gdhpSw7ZW7qu6ZsRJWlujpQ6wVle6vpeHBgJmU3KgtX3wPNq9/DJ554ImZ/kFlBZav+o11T7ug+o7U++o1TRqzbD+54UNaltk1dwoiy+6644gq/KbZ+P5SZK88++6w/QJj2nesnXc2x9duvZahM9DurY13Hq34n9L7oYz3YNYN+s7KLykWZh8pC1XZou/W/ykLTXcZmbpWdv//7ax9p3efOnWvXV7+T2kfKDtVvp7I61eokSMeVMok1UJaOPa2bMvfVFYQybl3WbXqp/3r9Zun40HlNn6vfSX0fHHUhob7ZlZ2qz9V3Wy0ItC6Zod8GHaPatvR0g6LPV3a/Pt/1Qat11/5VCwBl/OoYcO68807726vjQ7/F7nuquqMy/9UaJCjYLYIG9QQAhEMBRWxzeiUAAAAAxKem7Aq0qequLmiCTcLDSF0r6IaDAoYKNrk+QREeCoSqqxTdyFS3JdGDnuV26qKpTp06/nMueyPpxo1uOKmrDN18VncvAIBwILMWAAAACDkN7Ob6XlXmn/onDiv1BeoGk1KfsgRqw0d93ro+rdU6Iq8FapFatq8Ctcq+DvZvDQDIeWTWAgAAAMgy6tZF3SMowKxuMtQUG+Gibi7UxYy6yXCDROY1ZNYCAHIrgrUAAAAAgDyFYC0AILciWAsAAAAAAAAAIUCftQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFgGx0yimnmAIFCtjHsmXLcqSs9bluHbQ+OSlM64LczR1HtWvXzulVAQAAyDajR4/26z333XcfJR2HysaVk8oMyM0I1gLIUQq0uJNqssfcuXPZWzkUYFXlR4/JkyezD7LIrl27bJmeeeaZply5cikFsX///XfTuXNnc9BBB5lixYqZevXqmb59+5otW7akmXffvn1m5MiR5ogjjjAlS5a0n3H66aebDz74IFfsQx1r7rjLqRsdAABkNeq+yOrgZH4JTG7atMmvG+aXbUb+VTinVwAAkL2qVKliPvnkE/u3AnbppUDZwIED7d9du3Y17du3z7F1yUv+/fdfv1xT8d1335lWrVqZzZs3+9OWLFliHn30UTNz5kzz8ccfmzJlyvivde/e3bzyyiv+8//++88Gaj/88ENbwe3SpYsJe7DWrb8C2NEZtO44Kl68eI6sHwAAAPZvsNbVnVUnvvLKKyNeV91XiQly6KGHsmuQqxGsBZCjJkyYYHbs2OE/79Chg1mzZo39e9iwYTYr0GnSpEmOrGNupwzME0880eTGdVF2qDJQc2NALtm6FyxY0Bx77LHm+OOPN4ULFzaPPfZYwuV169bND9T26NHDtG3b1gwZMsQGab/99ltz//33+8t45513/EBn1apVzRNPPGFWr15t7rjjDrNnzx7Ts2dP06ZNG5uhGzbbt283pUqVSjpfWI5pAADSg7ovkD1q1qxpH0BeQDcIAHLU0UcfbYMu7qFgXjA466bXqVPH3HLLLaZZs2bmgAMOMEWKFDEVK1Y0p512Wpqm+fH6dYrVX+qiRYtMiRIl/L4vFSgSBcUU5NJ0BY7U/DyRvXv32s+qVq2abXJ+6qmn2kzIRKZMmWLv/laoUMFud4MGDezdYmVAJrJ7925bBlq3SpUq2eBbkJaj1xQk/OeffxL2E6vPevDBB82RRx5pSpcubbf18MMPN/fee699XfNrWxwFAN2ygnezFWC/6aabbLN8bUv58uXte996662Iz4u3LsE+pl566SUzePBgU6tWLbuf58+fb+fxPM+8/PLL5oQTTjBly5a1+03Hw1NPPWUDo6l4++237fGkrN6iRYuagw8+2D5XVwJafnqPn1TXPRZtg15XIFXHcSJffvmlWbhwof27UaNGZtSoUeb88883b7zxhv1cefHFF+2xIXrdUUC3Y8eO5uabbzZXXXWVnbZt2zbz2muvJfxMdTsS3NczZsyw31cdV/o+Dh06NGL+v/76y2Y0pPIdjV72xIkTTfPmze2xo0CypgezgnUMRneHEq/PWpWByvSoo46yx7MeCorH2l4tS99BrafWt3LlyqZFixamd+/eERnMAADs77qvHoUKFbL1jMaNG9t6j+oOqoNMnz49YpnRdZQ5c+bY86DeozqeO3eqe6S6devac7nqU9F11eBYCz/88IM9J+vcqHPpueeea/7444+I+fX+du3amQMPPNCeR1Uv1fn8uuuuMytWrEhYDtF1AdUZVcdRPfqkk06yn6/6nW5Gu/r12WefbZYvX55mWd98841N+FC9ztXvLr74YvP111/786ie5D5vwIABaerk7rUbb7zRn676UkbKf8GCBbbuonXWutxzzz0p11XVAuqYY46x+0j16hEjRpj0+vvvv82tt95q6tevb48vXWvoJn+wXrpz505z2GGH2XXWvgseC5rXbc/rr7+e7vJw3n//fXPOOefYY0j7RftR+8Xtw/TUuXWMqP7pfPTRR2nmSdRnbSrHSKx1Uv1R26tyVLbu+PHj070/gAzxACBEatWqpYiZfcyZM8efPm/ePH96rMcrr7ziz/vyyy/70wcMGOBPX7p0qT+9VatW/vTHH3/cn37bbbfZaT169PCnDR8+POl69+zZM806lS1b1qtdu7b/XJ/v9O/fP+62nHTSSd7OnTsTft51113nzz9z5kx/+nfffedPv+CCCxJu9+bNm73mzZvHXAftB9H88daza9eudp4lS5Z4Bx98cNz5+vbtm3QfaD+56XXr1o14vzsOunTpEvczOnbsmHQfzZ071ytYsGDcZezevTtDx08q657M9OnTYy7bGTJkiP96t27dIl6rU6eO/9rChQu9ffv22WPPTVu+fLk/r74nbnq7du0SrpPW3c1br149r1ChQmnK7KGHHsrQdzS4bK1/gQIFIo6rRMtxZRp9rMquXbu81q1bx31vnz59/Hl//fVXr0SJEnHnXbx4cUr7DgCA7Kj7btq0yWvSpEnc89SIESNi1lGqVavmFS9ePGJene9uv/32NMtQPdXVf6LrfQ0aNEgzv5a9fv16O6/+r1y5ctz1mzVrVsLtTlQX0EN1y2uuuSbNck844YSI5UyZMsUrUqRIzHXQdL0uW7du9UqXLm2nH3LIIRHL6N69u/+ezz//PFPlX6VKlZj1i+effz7psfDZZ595RYsWTfPepk2bxqybujqo6q6O6n3Vq1dPWh4yf/58v37XokULb+/evd64ceP8+S+66KIMHY8ycODApHW59NS5E9UP3TzBOnmwTFI9RqLXKbper4euJVSHBLIbmbUAcgXd/Xz44YdtZuTs2bNtxoAy73SnVpTNmFHK2FVTdFGW5vDhw83zzz9vn+uuuLIKEvn111/NM8884zdt113YadOmmZYtW8YcGEl32wcNGuT34ao7/brzrLvYri/OJ598MuFnXn755RHN6WL9HZwnln79+tnm86LMQn2m1kPb37BhQztdf6s7CkcZDVo/PfR+ueGGG/yuK3RnW03wldnomv8/8sgj5osvvjCpUj+sGkTr3XffNWPGjLF34bVd+ttlDusu/9SpU81xxx1np7355pv2kYjmd1kNyiZW/63KTFW2g8ssyKxY654VgsdRdNcFymZxli5darOpgwOOBeePnjdVyqRRdq62S98XR8f6+vXrM/Ud1Xooy0gZNcrA7dSpkz2+dKw5OgbdcRfsGiWavr9uADUdG5MmTbLHjo4ZUf++7licNWuWn8WuTFq9T/NqPbU+WXE8AACQUapnKbtUlJ3o6hY634rOxytXrkzzPrV0UasRze9a7uh89/jjj5urr77a1lFdPU/1C7WciWXDhg22RZPOz8rGdctWHUrmzZtnMzhF526dV3Ue1+eoP1FlBadKdQFlTmqdXbdnqluqPn7XXXfZ87mrz3z22Wfmp59+sn+rRZxaDbmWRddff7157733bN1UNF2vaz61ILvkkkvsdLWYc/UB1Q31uaLWOqq/Z6b81e2UspmVratWZ86zzz6btBxuu+0224WWaB+q7qprBre90VQP0/3rYGs3bfuff/5p/9b4BKrbK6Na26/yUCso15JQLY9uv/12vxWX6kBqiSWqv+l9TnrK46uvvorIXtY+0Lao/q7sVl0vpZc+P9hiTxncrm6o65V40nOMxKrX6zV9Z1q3bu0fLy+88EK61x9It2wPBwNAFmQXyOjRo23Wafny5dPcfddDmaIZyYyURYsWpbkLXqZMGW/ZsmVJ1/mRRx7x39OhQ4eIO9AlS5ZMk1nbu3dvf9rdd9/tffLJJ/YxdepUf3rjxo0TfqayJ11G5YEHHujt2bPHTm/UqJGdpjLasWNH3O3WnfOKFSv602fMmJFS5oPLpnU2bNjg74tixYr52RaiLGX3Pm1zon0QvBMenTEhygJ1rw8bNswvM2UpuOnnnntuwjK78847/XnfeuutiHUNykxmbax1z4rM2mDGx7333hvxmr4T7rVXX33VW7FiRcRxrGPF+eCDDyKyZRMJ7veaNWv6x5hoO91rY8aMSfd3NLhsZbnoOIoWzKCIlaEcK7O2WbNm/vTx48f7x8n999/vT+/Vq5edd9SoUf60oUOHeqtXr05YHgAA7K+6r+ppFSpUsNOUaTl79mz/nHbDDTf486t1WHQdRfVZd75VfSd4Lnd1gsceeyziHBgrszaYCaos2WC2obz//vsRLVdU/wjWOZIJ1gVq1Khhtzl63VSniNWKbfLkyXbaxIkT/WlHHXVUxPL13L02adIkP3PVTbvxxhvTtAxSXTGz5a/516xZ4y/HXQuobpTI2rVr/WWoTh2sG3Xu3Dlm3TRasF6uzGS3znqoxZ1bxoQJE/z36HrhsMMOS1Nne/vtt/150lsewWudTp06xV3f9Na5E13LxcusTe8xElwn1SuDWchuevv27eNuE5BVGGAMQK6grE/1vZRshFD1nZQR6oNId67d3WWXEaq+R5PRXVdHfUw56hdVGX2ur1Hnt99+8/9WdoLLUIjO1k1EWX+XXXaZeeCBB8y6devsIFPKOPjll1/s6+qDKdgHWjRlQ27cuNH+rfncyKnptXjxYr+vV/Wrpb7KHPX9GWubk1GfaNGC7w9mKQS5bY9HGa86jtRHl+7qu0xT9dmmu+sZLYNk654VggNuaf2DXAaGmy96cC7N77Kco+dNlTJNgxky2rfKbAke/xn9jqr8ldmdFYLHicueiXecqI89ZWkoc0hZJHqoTzdlmSjrxB0jAADsb6qnqaWMO3fHq6PEqvuo7unOtcHzq/qwda1G1Ld88Nwci86Hsep0ysZV3U/9yqpPVNUF1XJFjzJlytisUtW5lJGYagal1s3NG1xn1T+cWOscPO8H19ets+uP1M2nlnTKKlY9Wy2yVHdRizBHGcKZLX8t32UBa5tUt/j333/jlnOs6wnVqYPloG0ZO3asSUYZw65ersxk7aNk663rAPXTqvJz71Ud6sILL/TnSW95BPdLdtWNU5XeYyRIGeJO8Bon2b4EsgLdIADIFYLNW/r06WObLKvZi2sqJa6Je7D5sgb+clxz7XiiK1w//vhjptc7o02pNWhYdFAuWVcIwS4QVElOzzpmR5PvjC4zupl/qmI1XwrS4ACqkCnYq8qagukKdKtpXZs2bcznn3+eqeMnM+ueTHAQrbVr10a85rqgEA28oIuCYEA0OH/0vFm5b9PzHd0fZZbsOFGzPR0PGlxOg7ioEq4LETUX1EWKusgAACDMYtV9VL9xgsHSeAkNLkCX3vO+Bs/SjVsNAKbuFnRe3bp1qx34qUePHjZ4m6r9tc7iBltVHXDmzJl+sFYD7DZt2tRktvxVDwsqXDjz+XFZXU+PXm8NuBwsUz133QZkZrnJZKbOnRWSlWtwXwb3YyrHH5BZBGsB5ArqI0sUUFHGqyqF6rvSTY9X4QsGpxSEiUevqe9YcRmE6qdJ/W4m4/rxcn00ORpNXpWdWFm8jvoC0wk/+qHKTqLMWHfnXtkLMnHiRL8fpxo1akTcCY5F2QmuArJjxw7bx2g8wUpzdLDtkEMO8Ss66tdUWYpOsJ/a4DZnpOIUfL/2Sawyix6hOJrmUUVc/ZpqNFzdFXcBbm2X+lnL6PGTaN2zgoKJjvqIc5VEHf9utGXtT22f1kHZqo4LQrv3OvGyLWJRUDO474P7NtiPXarf0VTKLNFxF0/wOFGGSqzjxPVpq7+VOa9+dhVU1oWB+pN29J0CACAnBOtp6mtUQdDo85mCW6pHZhf1YRrrvK8byDp3ax3Ur2n//v3tuVV9tercq/XdX+fR4Hk/uL7Rz4PzqR/XIkWK2L/VQs31B+uyanOq/IM30VWOLpNVUh37IVgvV3aukj+i11uZsQqwO9pvrtWauwb67rvvbNlktDyC5e36A44lvXXuzNYNUz1GgDCgGwQAuYKCKmpmpWCggiu6862gm2vKH11RcV577TVbWdm2bVvcO/wKql5zzTX+HXwNCKCO8zUYg5pDqzN9V/GM5bzzzrPZeaLBldSdgppzPf300zHvMKv7Aq2764xf26DtUfBQAUfd5df2vvTSS0nLRdm133zzja3guEqOlp8saKjKjuYbMWKE/x5VthUAVgVRWQbqfD/6rvKnn35qpk+fbpu5qVKjbgSUlapKlTKBlZGobdJ2uEHXoivAGaFMYe0XueKKK2zzdTW908AWOi5UEdSAVMHBDKJp/8+dO9cO5FazZk3bDUBwUA2XyZze4yczXLDYDfQm2iY3XQOf6aFmWgp8qksN3QC49tprbbOyIUOG+IFbZYq4i4/rrrvO7ic3WIWOBx0f7oaEjudkA9AFLV++3HTt2tUeJ7ogc10g6IbCWWedle7vaCqCx532gy4g9AgGrmMdJ7rAEJWPMnyrV69uL0TU5FHHkMpDA3FokItRo0aZ9u3b2wskXTB8+OGH/rKSZbYDAJBdVE9T3Ul1KdVBzjzzTBtQU9BMg0ep9ZeCoaoranDX7KCBvZRNqPqS/nbUjZC7Gax1uuiii2ydTOv2/fff2yb/++s8qnLRTWLVPZQw0atXL1vPUx3WJVBovc444wz/Paq7qo6gllWuPiOXXnppjpa/Whqp5ZcCs0qk0ProM1WvSbW1j7pOUH1Y26+6+Pnnn2/rh6q3qy6neqTWWzfvXast1SldYHj8+PH2euDnn3+23bSpjqSBvNJbHqqPuWudcePG2WNIx42ui1QX02eefPLJ6a5zB+uGuj5TooXWQfV6PbLqGAFCIct6vwWAbBxgLDjYgHsccMABXoMGDdIM4CUtW7ZMM78bfCu6U/orr7zSnz5y5Mg0g4Zdf/31Sdf7uuuuS/N5GuChWrVqMdevf//+aeYPPqIH8opn1apVXqFChSLe+/3330fME68zfg2A1rRp05ifHxy0affu3XaQguh5XMf9f/zxR8zX3aNv375J1yXWgADRunTpkrDMEg24IIMGDYr73oIFC3qffvppho6fVNY9nkTbE71NCxcu9MqVKxdzvubNm3tbtmyJO0BX8KGBJ1555ZV0DfyhbS9SpEiaZQ0ePDhD39FEg9Y5wQH3go/osgseqzt37vRat26dsEzdPtJgbInme/3119O1LwEAyMq67z///OM1adIk4bnKzR+vfhXvfBtvYKfgAGOx6ohVqlTx1q1bZ+fV4FKJ1u2hhx5KuN3pXbd49S0NNharjqKHpk+ZMiXNZ0+bNi1ivhYtWqSZJyvKP3r/JvPxxx/H3Jb69eunXN9dvny5V7169YTr7epjGhjWTevYsaM/4JrqxW6ArV27dqW7PEQD4qYyX3rq3NGDgkWXSVYcIxkZqBrIDnSDACBXULbm4MGDbfae+sjSXVtlwal/rFjUCb8yPjWwkppo9e7d2+8mIEh3VdWpvqjpuO70irLv3KAGyr5zTafjUX+duhNdpUoV+5lalt4TvGMcpOZH06ZNs1mJuturjMhq1arZrEFlJQ4cODClctHnqbm5o2zGYB+hiSiTUHfWlQncrFkzU6JECVu2jRo1sk3EHGVVKNNW66Y789HUDF7ZvbpTrQxFbYsylHXHXIM3aHuywiuvvGLGjBlju3jQuhctWtTeRW/durUZNmyYHSQsEWVLa/+q71rdmVeWpjIQdMddGbbBrgNSPX72J2U2qJm+sluVFaLtV3kre1T9w0XvG2U3KHNa79N2aJ+orGbNmhWxf1OhzF5lT2sAPWXT6nuorF5lOGf0O5qMsl4ef/xxm2WRan9vKhOtp44HrbPKRNuuclIWhTKLL7jgAjtvy5Yt7X5VVyLKqNDxoONK3UPouA1m2AAAsL+VL18+Zj1NWawaSFYtRI477rhs+3wtX9mTqgfps5WxqQFt9VzUwkoty7QOygrVuVotd1RXUP3DtTrLbsrYVDmpTFQ/0npoHTVAlrJ/lV0aTfXvqlWrJmwBlhPlrzqIrk1UN1GdRnUqdS0VzGxORnVjZdDecccdtsWc6kGqD+lv1f9Up1eXaatWrbKDq4rqxS4TVtvkukVQVq+2PyPloWsZtXwLXuuozLVfgl0+pLfOrc/RMqP7Bs7qYwTIaQUUsc3plQAAAOGiLiNOPfVU+7e6QHA3NQAAQN6kG626ASxLly6NGOA0r1FXZ+pjVU381ZRfCRAAEBb0WQsAAAAAAPI0N4iv+nN1A1+pr1ICtQDChmAtAAAAAADI0zTIVrAJvgZgveeee3J0nQAgFvqsBQAAAAAA+YL6qW/QoIEZN26cHZMBAMKGPmsBAAAAAAAAIATIrAUAAAAAAACAECBYCwAAAAAAAAAhwABjQDbYt2+fWbVqlSlTpoztuB4AgLw4qvbWrVtN1apVTcGC3P8Hwog6KQAgr/PyYJ2UYC2QDRSorVGjBmULAMjzVq5caapXr57TqwEgBuqkAID8YmUeqpMSrAWygTJq3Y9F2bJlKWMAQJ6zZcsWe2PSnfMAhA91UgBAXrclD9ZJCdYC2cB1faBALcFaAEBeRnc/QHhRJwUA5BcF8lAXlHmjMwcAAAAAAAAAyOUI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIRA4ZxeASBPe6mcMSVyeiUAADniWo+CBxAO1EkB5HXUu5CHkFkLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAABgP9m7d6/p37+/qVOnjilRooSpV6+eGTRokPE8z5+nQIECMR+PPfaYfX3nzp3miiuuMGXLljWHHnqomT17dsRnaL4bb7yRfQoAABBSI0eONE2bNrX1OT1atmxppk+fnvA9Q4cONQ0aNLB1yBo1aphbbrnF7NixY7+tM/J5sHb06NGmfPnyOb0ayKH9Vrt2bfsjlIguWidPnmz/XrZsmX3+7bff2udz5861zzdt2pTpdQEAICs98sgjtnL+9NNPm19++cU+f/TRR83w4cP9eVavXh3xeOmll+x57aKLLrKvP/fcc+brr7828+bNMz169DCXXXaZH+xdunSpef75580DDzzAjssk6qO5E/VRAEBuUL16dfPwww/bOt1XX31lTjvtNNOuXTvz008/xZx/3Lhx5s477zQDBgywdcgXX3zRvPnmm+buu+/e7+uOkAVrr7zySj+7o0iRIjYrpE+fPvkykr9r1y57cdWsWTNTsmRJc8ABB5gTTjjBvPzyy2b37t12nr///ttcf/31pmbNmqZYsWLm4IMPNm3atDGfffZZRGDSlWmpUqXMkUcead56660c3LLcQRevZ599dszXjj/+ePt6uXLl7HMutgAAYfH555/binjbtm1tHeDiiy82Z555pvnyyy/9eVRfCD6mTJliTj31VFO3bl37uiro559/vjn88MNNz549bX1j/fr19jXVOxQAVoZGXkV99H+oj+Ys6qMAgIw677zzzDnnnGPq169vW0rpRnvp0qXN/Pnz49YhFXPSTXrVIVV/7NSpU0QdEvk4s/ass86yFZMlS5aYJ5980jz77LM2sp+b3Xfffbbin56KsYKuuguijBZ9afQF0QWTMmPcnRBlwCxcuNC88sor5rfffjPvvPOOOeWUU8yGDRsilnf//ffbMtW8xxxzjOnYsaNdZiqURaovanY32dy3b58JE128KgAeS9GiRe3rCoADABAmuqH4wQcf2HqBfPfdd+bTTz+NewNy7dq15t133zVXXXWVP003ivWe//77z8yYMcNUqVLF3jQeO3asKV68uLngggtMXkd9lPpoGFAfBQBkVczljTfeMNu3b7fdIcSrQyoL1wVnFZN77733bMAXeU+6g7UuQ1T9Y7Rv396cfvrpZtasWf7rCuo99NBDfl9suqCYMGFCxDIUtNTdA11QKFNEwcxkzdaVVaKsU71HmSUDBw40e/bssa+p6Z8Cri6DtWrVquamm24y2UVN9D/++GN7saUAbfPmze066Q7HF198YbdN2/LJJ5/Y7BZtY61atUyLFi3MXXfdZbNhgsqUKWPLVHdTRowYYctt6tSp2bLurosAXfipfxSV53HHHWd+/PFHfx6Xiar9dNhhh9kyXbFihfnnn39Mly5dTIUKFWw2sS4sFy9enOYz1D2B278Kaq9cudJ/7Y8//rAZRQcddJC9a6TgdHRfe7J161Z7l0jZxtWqVbPlEq8bhHjbqH2gv7t162Y2b97sZzDrWHF9/t1+++12+fqcY4891s7vLF++3N7t0vbqdWUw6ccQAICMUvO1Sy+91DRs2NC2UjriiCPMzTffbDp37hxzftWRVE+48MIL/Wndu3e39Sudo5WFMX78eHuOvvfee+1N43vuuccccsgh9hz8119/5cmdRX2U+ij1UQBAbvfDDz/YuIjqNdddd52ZNGmSrd/FoniTEv1OPPFEW4fUuAdKBqQbhLwpU33WKsCnDFBlMjoK1I4ZM8aMGjXKZpiqw+PLL7/cfPTRR35famryp0CvskmuvfZa069fv4Sfo6CngoS9e/c2P//8s83mVUDR9cf29ttv+1m+Ch4qiNekSROTXZS5oiC1LrCi6UujwJ6+cHpoXRQUTFXhwoXtMpS9m53uuOMOM2TIELNgwQJTuXJlG5R03TfIv//+awPNL7zwgt2PBx54oM0+Vl8qCuKqnzwFyXUXJ/p92i86BtTdgwKmuih1tm3bZt+jQLcyiZUZo89WMDh6cBRdiGoeXdhq3wdvCqRKd58UXFdzUNf3nwK00qtXL7sduoP1/fffmw4dOtj1cQFoBeK17xSY14+oykP7NBbNt2XLlogHAADRFFhVPUL9jn3zzTc2GPv444/b/2NRf7UK5OoGqKN6gm5iqk6l87gq7bfddpu9Ua3zpuoeqmPpZmx23rwOC+qj1Eepj/4PdVIAyD00WJjG3lHSn7qy6tq1q415xaLEsgcffNA888wztg45ceJEm4SngWqR9xRO7xumTZtmA1bKalVloGDBgnaQDNFzHTzKlHSp28o4VVM9BVJbtWpl/9cB6UY01t+qZCcaCENZtArY6cB1y9QBqf5y1QWDAn3KTFUAVRcwyrBVFmt2UTBPdzCSBV0VUL7mmmts4FpZwdp+BS6V0RqLArQKoCoLVJ1LZyeV2xlnnGH/1gWiOrfWXZxLLrnETlMAVj8CCpi6bVaQVgFYBUBFF5vKsNZFoQKd7n06HpSl6pbdqFEjm6qvfaLluWWK9qM+V8tW8NRRXyza56KMY32uAvJunVOlGwnqu1YZtTpGHB0z6l9Y/ysTWxTEff/99+10Hcd6TV1ZuMC/6yswFt2k0HEKAECym6Uuu1Z0jlFLDp1HXD0neLN60aJFdvCIRObMmWNvrOoGq5avwJVuHOuc7upoeQ31Ueqj1Edjo04KALmH4hVqDSVHHXWUvQn/1FNP2bhZtP79+5srrrjCXH311X4dUt0mqGtOJUAqNoe8I917U036XeRfFxVqYu5GJ/79999tZqUCai6zVA9lWar5u+iiQ03fg5IFVpUdonTv4DIVBFWWpD5PgUL126ZgmqYr+Oe6SIhFFz/BZSkwp8BjcJqex+NGXE5G5bJq1SobiFTGpu6EKGirIG5Q37597WeqawFlb6ovXA08Ek9wPdUVgYKKwWlKn08m2A9KxYoVbdBcA5YEfzSCQWW9pgC0C8JKpUqV0rxP8wT3r5p5qksFN48yaxUUVQBX07W+ei06sza6nxY9D35OZilTVv3CKBAcLDtlgLtjVdlIgwcPtoFjBbeVfRuPurdQkN09gl0/AADgqN4SXZkuVKhQzL7hNcqvKu7Bm5zRNMirWoKoUq/l6NzmWrzofz3Pi6iPUh91qI9Gok4KALmX6oPxWmbHq0OmJ0aFPJxZq0wNF/lX0zxdQOhiQgNfKBAnSsVWP6BB8QaDSoWWq6zFYH9tjpoFKrtTQWBl9Kqp/A033GAzdxV4U6ZttKOPPtoGnJ1hw4bZPt0UKHXUp2o8CvD9+uuvKa271k/Baz10J0R3QRT4Cw5opiwYPVewUJ+bbGCs4LoraK5gb7Cv1awYAVr95mbHAF0K1GofqcmnjiN9jrrFyO5uH2IdU/phUwfd7gfOcV0daF+pvz8dzzNnzrSZCsp8vvHGG9MsT8d3Zo5xAED+oK5/1JpIrYDUF7q6LXjiiSdsP7RB6k7nrbfesuedRNRCRZm0rmsm3WBUvUI305VVq+d5EfVR6qOZkVfro0KdFAByB91cU/Kd6oQas0ddZCmuo8FjRV2BKq6m331Xh1SdUXU+JdEpWVIxJk2PPocgHwZrgxTVV2fGt956q+3sODgYlZr8x6JMzOhBmpTqnYiyURWMdUHiWFTJ0kGqhzJMlNGp7Em9N9a8wWUps1QXRYmWH6Rt1XbrAiu631plsaiip4uIWFRG0QNjaQTnVD9bgvP++eefNps1Pe+X+fPn2x8F0aAkGpVa2a7x6DVlKys47Jqdbdiwwe6XYAfYmkf92rpsab2ufmvdstWdgQLTbqRqVVKXLVsWc/2inydav0SUJRydWaT9pmnr1q0zJ510Utz36kaAMpX10I/p888/H7dyDABAMhoATBVr3VjWOUhd8aj/fg0OFqT+1JUlocE241E3UuoDN3gTVwEnVfR1blOdSxX/vI76KPVR6qMAgNxG9UAFZNViXF03qmWzArWu60fF1YKZtBpAVgl1+l/Jhm7soURdiiKfBmtFXRAog0MDXegutR4aVEzp2xrwQk3CFaBTtqe6TdAFie4GKBtU2bi6wHDdAsTL5NQFzLnnnmuDi7oI0QGrrhF0kaJm6nq/Am+6u6CuBF577TUbkK1Vq5bJDhq1WXe3W7dubTNatJ0aqVlBSmXnKtNYQT6VjTJl9KVzrz/66KOmXbt2JqepWwk1G1Mmr/o3UcBYg77FU79+fbve6mZCTS21PepzT3d6gtujTGYFM5WtrCCy+qHVACcueKvlqCNs/ahof+uCNVbTTx0zKiutkzIflF2kMs+I2rVr26CwBjVTJriOEWVHa8AW/TgqO0HB27///tvOo/2lbii0n3WnS/MqoK0+ATMaMAYAQHT+1MCXeiSi/sf0SKRx48b+oJiO6kjqc16P/IT6KPVR6qMAgNxEcaNEgq2nRfEVtdLWA3lfpnsgdgE5BdbUubGClwrAKVVbgS311aogW506dez8+n/ChAk2YKeg2MiRI22wUOI1I1fTHw0koaY/6g9VwT8NNuWCser7VBmPauqnZao7hKlTp9pgZHbQeiqAqAHOFLjU+mi9FKBUP6e6eFLTJQWPtZ4nn3yynaZyUbAzDIN9qF/c3r17277w1qxZY8tLGaiJaOAtza/AufqQVcaPsqSDXU0oEKpAvLKPtT9UDsGBURSor1Chgs3OVcBW+zZW9rNGtVZwW0FUBeT1Ps2bEfosZcZ27NjR3n3Sseq2R8FafZayjxQYVpa3yzjWDQBlabvjWEHb/HbxCwBAbkB9lPoo9VEAAJBXFPBC0BOx0rZHjRrFoEz7ge7OaFAOZYoqyI3soW411JRh85PGlC1BKQNAvnRtjlex9s+5bvPmLOkvP6dRH91/qI/uP9RJAeQbebzehfxTJ82SbhAyQtmJykRV5quau2swMGXnAgAAANRHAQAAkF/lSLBW/aupafvGjRttk3M1Q9fgTQAAAAD1UQAAAORXoegGAchraHIGAMjrzfHyYpMzIK+hTgog38jj9S7krzpppgcYAwAAAAAAAABkHsFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhUDinVwDI07pvNqZs2ZxeCwAAAORn1EkBAMg1yKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBArn9AoAedkl0y4zRUoWyenVAACE1NT2k3J6FQDkA9RJAQBhQf03OTJrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAhMjevXtN//79TZ06dUyJEiVMvXr1zKBBg4znef48a9euNVdeeaWpWrWqKVmypDnrrLPM4sWLI5Zz6623mooVK5oaNWqYsWPHRrz21ltvmfPOO2+/bRMAAACQ29x3332mQIECEY+GDRsmfI/q2ZqnePHipkmTJua9995L9+fmi2Dt6NGjTfny5XN6NfItXUy2b9/ehEGY1gUAgFgeeeQRM3LkSPP000+bX375xT5/9NFHzfDhw+3rCtrqXLZkyRIzZcoUs3DhQlOrVi1z+umnm+3bt9t5pk6dasaNG2dmzpxp33v11Veb9evX29c2b95s+vXrZ0aMGMEO2M+ok+asMNUDw7QuAAAgvsMPP9ysXr3af3z66adx5/38889Np06dzFVXXWXr6DrX6/Hjjz+aXBOsVSXFRaaLFCliM0j69OljduzYYfKbXbt22YupZs2a2QyZAw44wJxwwgnm5ZdfNrt377bz/P333+b66683NWvWNMWKFTMHH3ywadOmjfnss8/85dSuXdsv01KlSpkjjzzSRvXzmoxWcJ966il7oQQAQFipkteuXTvTtm1be16/+OKLzZlnnmm+/PJL+7oyaOfPn28Dusccc4xp0KCB/fu///4zr7/+up1HQd5TTjnFHH300bbCWLZsWbN06VL7muparj6B/0Od9H+ok6YPdVIAAPK2woUL2/ibeyhelyjmpBZvd9xxh2nUqJFtHae4nJIwclVmrTZCkWllhzz55JPm2WefNQMGDDC5PU1aFbf0VIoVdH344YdNjx497EWaLsh69uxps2h++uknO99FF11kI/OvvPKK+e2338w777xjL8Q2bNgQsbz777/flqnm1UVcx44d7TJTMXfuXHthmFeVK1cuYZa19gUAADnp+OOPNx988IE918t3331n7+CfffbZ9vnOnTvt/2pa5RQsWNDeyHV3+nXz96uvvjL//POP+frrr20g95BDDrGvf/PNN+amm27KkW0LM+qk1En3J+qkAADkDosXL7Zdj9WtW9d07tzZrFixIu688+bNs63dghTv0/RcFax1GaLqT02ZktqoWbNm+a/v27fPPPTQQ36/bbr4mDBhQsQyFLSsX7++vWg59dRTbTBTmaWbNm2K+7lqNqjott6jAh84cKDZs2eP37xQAVeXwaqdkp0XNUOHDjUff/yxvTBTgLZ58+Z2nS677DLzxRdf2G3TtnzyySe2KaS2Uc0dW7RoYe666y5z/vnnRyyvTJkytkwPPfRQ28RR5abmkNnVr57Su93+UXaP7iQkkmyfJlum9o32sfahyyJWkFl++OEHc9ppp9n3VapUyQa/t23bFjf7QcHuXr16mZtvvtneHdGXSJSirovi0qVLm4MOOshcccUVfvNRAACy05133mkuvfRS29eVWh4dccQR9jylyqFouuooqgMoGKsbjaof/Pnnn/Zmreh8dvnll9ubtjr36bypFjfKqB01apTNxNX5Va143E3h/I46KXVS6qQAACDo2GOPta2z33//fVt/Vku1k046yWzdutXEsmbNGhtDCtJzTU+PwiZEFCBTBqgCkY6Ceq+99pq9sFDQUkFNXXxUrlzZtGrVyhaUmgf27t3b9sembNLbb7894eco6NmlSxczbNgwW8h//PGHDeqJsnrffvttm+X7xhtv2L4pVKjKaskuGvRDQWpdjEXTRZoeCiQrcDh58mRz3HHH2QuKVNO19f7syhhV4LV69eq2qwUFR7X/VJZVqlQxl1xyScz3JNunyZap/avmnVu2bLHdRIgGUFE/fbo4bdmypVmwYIFZt26dPSYUjE3U9YEuYHXx6rqTUGBcAV+9V8eBspH69u1rP/vDDz+MuQxlOblMJ9G6AQCQEePHj7d1A/U5q3rIt99+a4O1unnctWtXe16fOHGivbGp81+hQoVsPUI3GYODkOnmph6ObkxrPr1/8ODB9gbntGnTbJ1I2bf4H+qk1EmpkwIAgLP/f8s2adq0qQ3eKmap+rrq4tklx4O1ukhQEFLBSAW71IzP9eWg5w8++KCZPXu2DcCJMk7VhE/dJagSpf+VGfLYY4/Z1/W3KtgPPPBA3M/UxYqyVnTB45apfiTUh5uCtUppVmaqu6BR9oqyWLMzpVoZnsmCrgo4XnPNNTbIqaxgbb8yb3TAxKIA7ZAhQ+xAIgo+ZgeVj8rTUTas0rt14MYK1qayT5MtU8eLMme1LO2nYNBV/R2PGTPGZg+JjiWNdq2Mo+i7G44Cxuov2NEFrALnWk/npZdestnfapKqjOVYAejgOgMAkFHq48pl14pGkV2+fLk917i6y1FHHWWDuDrH63yvG56qPKqP2lh+/fVXe6NUN7V1Tjv55JPte3Re7d69u80OUMuc/Iw6KXVS6qQAACARdaupmNDvv/8e83XFqNauXRsxTc+Dsatc0Q2CmvTrYkPN/XUB0q1bN9s3q2jj//33X3PGGWfYAJ17KBinbFhZtGiRbeIXlCywqixZ9esaXKaCoGo6qM/r0KGDzaZUhU3TJ02a5HeREC9TN7gsBfmUEROcpufxBLNgElG5rFq1ynb7oH7V1PRfQdvorFFlgeozNVCZgpTqC1eDlMQTXE/dNVCwOjjtuuuuS7he6mpBF4266NP8zz33XNw+PFLZp+ldpqNsWzVfc4FaUfNOZerqOIlHnxN9fMyZMydi/dTkVILrGKSmqLpgdo+VK1cmXFcAAOLReVI3r4OUPavzWax+L3Wu1I1f9VGrgcli1TOuvfZa88QTT9hzmrobcoOXuv81Lb+jTkqdlDopAABIRN1sKi6klt+xKClRXZwGqatXl6yYazJrFVjTgBeiTA8F21588UWbTuz6Gn333XdNtWrVIt6XajcAsWi5yoK88MIL07ymPmyVQangnrI/Vag33HCDzdz96KOPbNZnNGWxKODsqHuFv/76ywZKnXhZnaKovDJeUqH1U6BTj/79+9um+soGDg5opowcPXf9rapP10SC666guYK9rg9Y0QjS8airCHVLoAxeHXzKylFZaTmxpLJP07vMzAoGd906umzcaPG+kFr3zByTAAA4OgephZBa9qgbBGXDKtCqDFhHXQUpSKt51J2BuoNSn+xnnnlmmoJ84YUX7LxarruRqe4R5s+fb6ZPn24OO+ywhINv5hfUSamTOtRJAQCAKDalOrS6PlDypOJvSqLo1KmTfV3diSm2pRZwojq5WowrnqWkScW3lFChBMRcFawNUhbJ3XffbW699VY7uJYuHlRZUkalNjYWdXvw3nvvRUxTf6WJKBtVwVgXJI5Fzey1Q/TQoF/KrNTFkN4ba97gstR/nPosTbT8IG2rtlsXY9H91irjRc0bowOKjspI/dgGaaCsVD9bgvNqcBJ1uZDq+9XPq0atVkDbiZd96tY32T5NZZlFixZNkwXUqFEjm2WsvmtdeWlZOq50nKRK+1j9FteuXduWBQAA+9Pw4cPtDVmdB9X/uvqqVWbsvffe68+j1kCqL6lZlW4kqqKo90TT6wr8qv/3YAuk2267zVYgDzzwQNuNECJRJ6VOKtRJAQDI3/78808bmN2wYYNNfjjxxBNtwoP+FsW2gi3iFMvSuBP33HOPjfOp203F7Bo3bpy7ukGIpi4IFKVWM3hlVCqKfcstt9gLCQXsvvnmG3sR4y4sdPGirFRlg6o/UfVr6roFiJdRqosdNbtXdq1GQFbzeUW7VZii9yu7V33fLlmyxPbxpoBscOCzrKRBQ5Tl0rp1a7vdaoavz9W2aDAxNW3UgaF+Z7Uu33//vR1YTVk16ms1VpPH/UUHnu4SzJgxw5a/LhQTBctT2aepLFOBVJWDgu7r16+3QW2Nkq3MY3WnoX2nrgxuvPFGc8UVVyTMbI6m4PzGjRvtF1Kfq3XUuqiLDpqJAgCym86VQ4cOtf3UqlsmnYfUn7puVDo33XST7XJHN3Q1n/reD77u6Py3bNkyG/CNrgupbqE6UHb2y5+bUSelTkqdFACA/O2NN96wGbUaM0mBWz2vV6+e/7papUd3Tao6pGJVeo9iU+ecc066Pzd0wVplMvbq1csGIZUhqYsPBeuUUqzMSfXVqib0GnRK9P+ECRPsqMgaaGvkyJGmX79+9rV4zdLbtGljB5GYOXOm7e9WAdEnn3zSD8aqKeDzzz9vA6haprpDmDp1qqlUqVK2bLPWU90taIAzDbKl9dF6qTsFXYwpAq8uDTRwiNZTg4JomspFfeq6AdlygoLl6k6iY8eOdv104RfMiI0l2T5NZZnabmXLqgsK3dFQ5oP66FVQVYFWld/FF19sA+DpLR9d0Gp5CsyqOakGdlFAXcdFdB+CAAAgb6JOSp2UOikAAMgJBbxUR7fKRdTcb9SoUQzyhByjbjA06EubsW1NkZJp+zkGAECmtp+U6891GlgzUf/2+Rl1UuQ06qQAgLxe/92SB+ukeaJDzmeeecZmUirzVRmRGoxK2bkAAAAAdVIAAADkFnkiWKs+XdWXm5q/a1RkDZpx11135fRqAQAAIB+hTgoAAIDMyhPBWvXjqgcAAACQU6iTAgAAILMYLQkAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgUzukVAPKy8eeOM2XLls3p1QAAAEA+Rp0UAIDcg8xaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQqBwTq8AkJc1fWGbKViCeyIAkMyS60tTSACQTfJbnZRzCgAgN8s/Z2wAAAAAAAAACDGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEa3OB0aNHm/Lly5vcrHbt2mbo0KEmDMK0LgCAxL/XBQoUSPPo2bOnff2UU05J89p1113nv3/jxo3mvPPOM6VLlzZHHHGEWbhwYcTytZwhQ4awC4AUUB/NWtRHEW3EiBH2uChevLg59thjzZdffhm3kGKd//Ro27YtBQsAeQDB2ky48sor/RNjkSJFTJ06dUyfPn3Mjh07sm4PIcsruQsWLDA9evSgZAEg5PR7vXr1av8xa9YsO71Dhw7+PNdcc03EPI8++qj/2gMPPGC2bt1qvvnmG3thq3md+fPnmy+++MLcfPPN+3mrgKxFfTRnUR9FVnjzzTfNrbfeagYMGGDPWc2aNTNt2rQx69atizn/xIkTI859P/74oylUqFDE+REAkHsRrM2ks846y54glyxZYp588knz7LPP2pNsbnbffffZin9eVblyZVOyZMm4r+/evXu/rg8AIP7v9cEHH+w/pk2bZurVq2datWrlz6Pf8+A8ZcuW9V/75ZdfzKWXXmoOPfRQe5NOz93vvDJwR40aZS9ugdyO+mjuQ30UQU888YS9oditWzdz2GGH2fOTzm8vvfRSzIKqWLFixLlPNzM1P8FaAMgbCNZmUrFixewJskaNGqZ9+/bm9NNP9zN/ZN++feahhx6yWbclSpSwd0knTJgQsYx33nnH1K9f3zZ5OfXUU80rr7xis3U3bdoU93OnTJlijjzySPueunXrmoEDB5o9e/bY1zzPswHXmjVr2vWrWrWquemmm0x2+eOPP0y7du3MQQcdZJuaHnPMMWb27NkJ36Ntu/rqq21FVRfWp512mvnuu+9SXqYypJYvX25uueUWP7vZefvtt83hhx9ut13ZDtFNXKMzIPTekSNHmvPPP9+UKlXKZmIlK2MAwP61a9cu89prr5nu3btH/OaPHTvWHHDAAaZx48bmrrvuMv/++6//ms65H374of3tnjFjhmnatKmdruxbnUeOPvpodiPyBOqj1EeRu89vX3/9tb2OdAoWLGifz5s3L6VlvPjii/bmpK5lAAC5H8HaLKTmJ59//rkpWrSoP02B2jFjxti7oz/99JMNLl5++eXmo48+sq8vXbrUXHzxxTbQq2Dltddea/r165fwcz755BPTpUsX07t3b/Pzzz/bbF71I+aCjApWuizfxYsXm8mTJ5smTZqY7LJt2zZzzjnnmA8++MD2B6jsDvURuGLFirjv0V1fNeuZPn26rZwoKNq6dWvbv2Aqy1TTn+rVq5v777/fb/4jWtYll1xiKys//PCDDVr379/flk8imu+CCy6w71EgIFkZAwD2L53LdKMv2PLjsssuswHcOXPm2EDtq6++as+xzp133mkKFy5ss3EnTZpkL2Z1XtRNUZ0blF2rm3E6b2zevJldijyB+ij1UeQu69evN3v37rVJKkF6vmbNmqTvV9+2+t4rEQYAkDcUzukVyO3UJFOZn8ra2blzp70L+vTTT9vX9PzBBx+0GaEtW7a003RR+Omnn9rgn5px6v8GDRqYxx57zL6uv3WyTRQUVIanLkC7du3qL3PQoEG2v1x1waCAprJ9dTdWfekqw7ZFixbZVgbKXNLD0broolgZw7169Uozv7ZflQoFa5UJIo8//ri9EFfWsZqqJlummv6o6WqZMmXstgabECnoq4twUdNXBVtVvom6dtAFv5odOQrYJirjaNrXejhbtmxJVxkCABJToPXss8+2rUWcYP/juilZpUoVew5Q6wwFaMuVK2fGjRsXsRy15NA5QRm56sJo0aJFtumpbv4x2BhyK+qj1Ecd6qT58/yoc2B2Xu8BAPYvgrWZpG4L1IR++/btNptVGTwXXXSRfe3333+3zTHPOOOMNE1dNCq16CJRTfyDkp1olYH72WefRQR0dTdWA5vp85S1qmb+CjAqI1UZqspK1brFoixSXQAH109dKQS7a1BQuXPnzjHfryxYZaa+++67NsNVgev//vsvbmat1l/vqVSpUsR0vUcX2BlZpqP+CNV9QtAJJ5xgy0NlFK9vwuimsMnKOLrPW2VQK4gOAMh66vZGNz7VqiIRjZ7tzr8K1kZ7+eWXTfny5e154sILL7StWnRTU+fNe++9l12HXIv6KPVRhzpp7qOufHSNsnbt2ojpeh5MSolF16BvvPGGveEIAMg7CNZmkvoFOuSQQ+zf6gBe2aC6u3nVVVfZgKMo4FitWrWI97mM0ozQchUY1IVmNPWvqv5zFQTWha36z73hhhtsFpG6XtBFaaxA5bfffus/HzZsmPnrr7/MI4884k+LbpYTdPvtt9vPUXasykJ986prBwV9462/sp/mzp2b5jVdRGdkmZkV3b9TsjKOpua3GsE1mFmr/QAAyDwFWQ888EDTtm3bhPO5c5nOMdH+/vtvezGr1h3uBpwbUFL/6zmQW1EfpT7qUCfNfdSF3lFHHWW7f9NNRDfuiZ7HaqUY9NZbb9ls6mAXQACA3I9gbRZSFwh33323DdqpWb1G8lRQVtmgwZGrg9TtwXvvvRcxbcGCBQk/R/27KhjrgsSxKLipbFo9evbsaRo2bGj7Y9V7Y80bXJa6GFCwMdHyg5SBqi4G1OerC3QuW7Ys4fqr/yVl+mqwr4wuUxWb6IvrRo0a2fdGL0vdIaRnxO9UyjhI+zkzAXgAQGy6YFWwVt3SBFuIqCWGujhQ6xG11Pj+++9tv/Ann3yyP5BY0M0332xuu+02/+apWl2oj9szzzzTPPfcc/Y5kBdQH82/9VGhTpo76fpR5zkl0aiVpVoFKmvWddOmsTR0/lLmdJCShBTgjW6xCADI3QjWZjE1pbzjjjvMiBEjbHaoHrp41MXmiSeeaAcwUWWtbNmy9oSsAcXUz2rfvn1tNq6ygtxgWMHRroPUVPPcc8+1fdEq21SVcjXbV1+3gwcPtu9XpVHNQdVcX4OvKCBbq1Ytkx3q169vm6YqMKx1Vn+x2t541Jeu+vBVxUIjcqviumrVKpuBrMqwKimpLFMV648//tgOJqaKqZoQ6UJc3Uqof9mOHTvaEVTVh/AzzzyTrm1KVsYAgP1DrUR001N9iUcHSPSau6BVawZ1Q3TPPfekWcaMGTNs1wgKzjrKVvrqq6/suVIXxrH6IwdyK+qj1EeRu+i6RS1AdA2imwjNmzc377//vt+6UedBXY8EKZCv1iIzZ87MobUGAGSXyF98ZJruzusCUEFIXTwqaKhAo+6C6i67+pBVULJOnTp2fv2vvmEVmFQmkPq/7devn30tXqZmmzZt7EASOjErMHncccfZ/nJdMFZdCTz//PM2S0jL1MXs1KlTs+2Oq4LNFSpUMMcff7wNrmr9YmXwOgq+KptY2U+6W6xgrQKu6pPQVUhSWaaasyq7Qf0SVq5c2U7TPOPHj7d9NzVu3NhWeDRfosHFMlLGAID9Q5mv6kdd54ogBWfVvc+GDRtsf+KLFy+2517dDI31m/7FF19EXOjqZqbOF2pJovOkulkA8grqo9RHkfvoGlLXQ+rWQOcs1w+7qPs4l9ATbKGp82P0+CgAgNyvgKdfeISKBrUaNWqUWblyZU6vCjJIF/8ahbzWkL9MwRJpAwcAgEhLri9NkeTSc51aDcUKkiN3oz6aN+TXOinnFADIP7bkwTop3SCEgJroK3tTma/qIkGDgSXrTB4AAACgPgoAAJC3EKwNATXdVD+oGzdutH2kqt9VjeQKAAAAUB8FAADIP+gGAcgG+bXJGQBkFE1Wc5+82OQMyGvya52UcwoA5B9b8mCdlAHGAAAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAgBgrUAAAAAAAAAEAIEawEAAAAAAAAgBAjWAgAAAAAAAEAIEKwFAAAAAAAAgBAgWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQIFgLAAAAAAAAACFAsBYAAAAAAAAAQoBgLQAAAAAAAACEAMFaAAAAAAAAAAiBwjm9AkBe9v3VpU3ZsqVzejUAAACQj1EnBQAg9yCzFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAAABACBCsBQAAAAAAAIAQKJzTKwDkRZ7n2f+3bNmS06sCAEC2cOc4d84DED7USQEAed2WPFgnJVgLZIMNGzbY/2vUqEH5AgDy/DmvXLlyOb0aAGKgTgoAyC+2bt2aZ+qkBGuBbFCxYkX7/4oVK/LMj0UY754pGL5y5UpTtmzZnF6dPIfypYzzAo7j7LV582ZTs2ZN/5wHIHyok2YtziuUZ5hxfFKe+fUY9TzPBmqrVq1q8gqCtUA2KFjw/7qDVqCWQGL2UvlSxpRvbsYxTBnnlXMegPChTpo9OHdTnmHG8Ul55sdjtFweS5Kjdg0AAAAAAAAAIUCwFgAAAAAAAABCgGAtkA2KFStmBgwYYP9H9qCMsxflm/0oY8o4t+MYBsKP7ynlGWYcn5RnmHF8UqY5qYCnnngBAAAAAAAAADmKzFoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYC2WDEiBGmdu3apnjx4ubYY481X375JeWcAQ899JA55phjTJkyZcyBBx5o2rdvbxYtWhQxz44dO0zPnj1NpUqVTOnSpc1FF11k1q5dS3lnwMMPP2wKFChgbr75Zso3C/3111/m8ssvt8doiRIlTJMmTcxXX33lv66u4++9915TpUoV+/rpp59uFi9enJWrkKft3bvX9O/f39SpU8eWX7169cygQYNsuTqUcfp8/PHH5rzzzjNVq1a1vwmTJ0+OeD2V8ty4caPp3LmzKVu2rClfvry56qqrzLZt2zK1rwGkD/XR/fe7iKyv4yN1I0eONE2bNrXnXD1atmxppk+fThFm4zUSUnfffffZ8gs+GjZsSBEmQbAWyGJvvvmmufXWW82AAQPMN998Y5o1a2batGlj1q1bR1mn00cffWQDsfPnzzezZs0yu3fvNmeeeabZvn27P88tt9xipk6dat566y07/6pVq8yFF15IWafTggULzLPPPmsrekGUb+b8888/5oQTTjBFihSxleaff/7ZDBkyxFSoUMGf59FHHzXDhg0zo0aNMl988YUpVaqU/c3QjQgk98gjj9iLlKefftr88ssv9rnKdPjw4ZRxBuk3VucuBXpiSeWYVaD2p59+sr/d06ZNs4GOHj16cEgD+wn10f37u4isr+MjddWrV7cBxa+//tomBJx22mmmXbt29jyM7LlGQvocfvjhZvXq1f7j008/pQiT8QBkqRYtWng9e/b0n+/du9erWrWq99BDD1HSmbRu3TqlynkfffSRfb5p0yavSJEi3ltvveXP88svv9h55s2bR3mnaOvWrV79+vW9WbNmea1atfJ69+5N+WaRvn37eieeeGLc1/ft2+cdfPDB3mOPPeZP03FdrFgx7/XXX8+q1cjT2rZt63Xv3j1i2oUXXuh17tzZ/k0ZZ45+TydNmuQ/T6U8f/75Z/u+BQsW+PNMnz7dK1CggPfXX39lco0ApIL66P77XUTW1/GReRUqVPBeeOEFijIbrpGQPgMGDPCaNWtGsaUTmbVAFtq1a5e9o6kmoU7BggXt83nz5lHWmbR582b7f8WKFe3/KmvdiQ+Wt5pU1KxZk/JOB2U2tG3bNqIcKd+s8c4775ijjz7adOjQwTbzO+KII8zzzz/vv7506VKzZs2aiLIvV66c7T6F34zUHH/88eaDDz4wv/32m33+3Xff2bv1Z599NmWcDVI5ZvW/uj7Qse9ofp0PlYkLIHtRH0Vur+Mjc91DvfHGGzZLWd0hIOuvkZB+6i5L3cjUrVvXtr5asWIFxZhE4WQzAEjd+vXr7QnyoIMOipiu57/++itFmQn79u2z/QSpSXnjxo3tNAUMihYtaoMC0eWt15CcKnPqrkNNfKJRvpm3ZMkS20RfXaPcfffdtpxvuukme9x27drVP05j/WZwDKfmzjvvNFu2bLE3agoVKmR/gx944AFbEXTHMWWcdVIpT/2vmxNBhQsXthfhHNdA9qM+itxex0f6/fDDDzY4qy6JNI7HpEmTzGGHHUZRZsM1EtJHN/RHjx5tGjRoYLtAGDhwoDnppJPMjz/+aPutRmwEawHkmjub+kGnf5uss3LlStO7d2/bV5gGw0P2XIAou/DBBx+0z5VZq+NYfX0qWIvMGz9+vBk7dqwZN26c7Q/r22+/tRd9untPGQMAEG7U8bOGAmGqAylLecKECbYOpL6BCdimH9dIWcu1dhP1/avgba1atWwdXgPQIja6QQCy0AEHHGAzu9auXRsxXc8PPvhgyjqDevXqZQeomTNnju1A31GZqqnfpk2bKO8MUDcSGvjuyCOPtFlveqhSp4GD9Lcy5SjfzKlSpUqaSnKjRo38pj/ud4HfjIy74447bHbtpZdeapo0aWKuuOIKOzCeRpqmjLNeKses/o8eVHPPnj1m48aNnAuB/YD6KHJ7HR/pp1ZbhxxyiDnqqKNsHUgD4j311FMUZTZcI6kVFzJOrWIPPfRQ8/vvv1OMCRCsBbL4JKkTpPpPDGbW6Tl9BqWfxnBQJU7NeD788ENTp06diNdV1kWKFIko70WLFtlAGOWdXOvWrW2TKd2Fdw9lgar5uPub8s0cNenTMRmkvlV1N1l0TCuwFTyG1aRf/XpyDKfm33//tX2hBummmX57KeOsl8oxq/91E00XO45+w7VPlE0BIHtRH0Vur+Mj83TO3blzJ0WZDddIqmci47Zt22b++OMPm9SC+OgGAchi6ptSzU70g96iRQszdOhQ28F7t27dKOsMNItS0+YpU6bY/mxcX4cazKZEiRL2fzWdUJmrL8SyZcuaG2+80QYKjjvuOMo7CZVpdN9gpUqVMpUqVfKnU76ZowxPDYClbhAuueQS8+WXX5rnnnvOPqRAgQK2yf7gwYNN/fr17cVK//79bRP+9u3bcwyn4LzzzrN91GpgQXWDsHDhQvPEE0+Y7t27U8aZqEQHsx00qJguTvQ7q3JOdswqe/yss84y11xzje3yQwNB6qJc2c+aD0D2oz66f38XkbV1fKTPXXfdZZua61jcunWrLdu5c+eaGTNmUJTZdI2E1N1+++22vq5klVWrVpkBAwbYgHenTp0oxkQ8AFlu+PDhXs2aNb2iRYt6LVq08ObPn08pZ4B+omI9Xn75ZX+e//77z7vhhhu8ChUqeCVLlvQuuOACb/Xq1ZR3BrVq1crr3bs35ZuFpk6d6jVu3NgrVqyY17BhQ++5556LeH3fvn1e//79vYMOOsjO07p1a2/RokVZuQp52pYtW+wxq9/c4sWLe3Xr1vX69evn7dy505+HMk6fOXPmxPzt7dq1a8rluWHDBq9Tp05e6dKlvbJly3rdunXztm7dmiX7HEBqqI/uv99FZH0dH6nr3r27V6tWLXvtWblyZXtenjlzJkWYjddISF3Hjh29KlWq2OOzWrVq9vnvv/9OESZRQP8kjOYCAAAAAAAAALIdfdYCAAAAAAAAQAgQrAUAAAAAAACAECBYCwAAAAAAAAAhQLAWAAAAAAAAAEKAYC0AAAAAAAAAhADBWgAAAAAAAAAIAYK1AAAAAAAAABACBGsBAAAAAAAAIAQI1gIAAAAAACCpAgUKmMmTJ2e6pPr372969OiRbSW+fv16c+CBB5o///wz2z4DyC4EawEA2eq+++4zzZs3z/WfkZWV01g2bNhgK5TLli3L8DKolAIAkH+oXpLoofoRkNX169WrV5uzzz47UwW7Zs0a89RTT5l+/fpl2w464IADTJcuXcyAAQOy7TOA7EKwFgByKSro/3P77bebDz74INuDrllROY3ngQceMO3atTO1a9e2zzdu3GjOO+88U7p0aXPEEUeYhQsXRszfs2dPM2TIkIhpVEoBAMg/VC9xj6FDh5qyZctGTFP9CHnDrl279ttneZ5n9uzZE/f1gw8+2BQrVixTn/HCCy+Y448/3tSqVctkp27dupmxY8faejWQmxCsBYBcigr6/yigWalSpWwv82SV0927d2douf/++6958cUXzVVXXRURvN26dav55ptvzCmnnGKuueYa/7X58+ebL774wtx8881plkWlFACA/EH1EvcoV66cvRkdnPbGG2+YRo0ameLFi5uGDRuaZ555xn+vWvJo/vHjx5uTTjrJlChRwhxzzDHmt99+MwsWLDBHH320rV/pJvXff//tv+/KK6807du3NwMHDjSVK1e2AeLrrrsuIpg4YcIE06RJE7tM1c9OP/10s3379pjbMHfuXLseM2bMsDen9Z7TTjvNrFu3zkyfPt2uvz7jsssus/UlZ+fOneamm26yrZK0fSeeeKJdbxdsPOSQQ8zjjz8e8Vnffvut/azff//dPt+0aZO5+uqr/e3Q53733XdpMktfffVVezNdZXzppZfa+lk8o0ePNuXLl7dJAfXr17fr1qZNG7Ny5Up/nj/++MPeoD/ooINsGavcZ8+eHbEcfd6gQYNsZqjWLV53Aaoj9urVyz60frpxr+4FVAaO1l/7s0yZMva4UFmqfKP3gcr7qKOOsnXd1157ze5jlYdLENG2xUp60LZdcskldrsrVqxoty1ZSzEdm0pKiN6WG2+80dZvK1SoYMvn+eeft8eO6rdaf+1Xrafzzz//mM6dO9t9qGNHZf7yyy/7rx9++OGmatWqZtKkSQnXBwgbgrUAkAcr6KrUqOKSqBIYK7tUlSxXERszZox97+LFi/3Xb7jhBlvZD1aWoz388MP2c1WhUvBxx44dMe+mx7t4iPbcc8/ZSta+ffsipqsi2L1797jNtF566SVbQVOFs0qVKrYSKy5z9YILLrBl4J7LyJEjTb169UzRokVNgwYNbOU2Xpm5i5w333zTtGrVym6L7tynd/vkvffes+t53HHH+dN++eUXe0Fw6KGH2gq6nruAsC6KRo0aZQoVKpRmWVRKAQCA6iT33nuvvfmrOsSDDz5og3ivvPJKROGoifg999xjbw4XLlzYBvL69Oljm6h/8sknNrCp5QSpNZOWqSDf66+/biZOnGgDey6ZoFOnTraO5ua58MILI4KHsagu9/TTT5vPP//cD/4pW3jcuHHm3XffNTNnzjTDhw/359c6vv3223Z7tO4K4ikoqgxK1c/0+cGgnej5ySefbOeVDh06+EHhr7/+2hx55JGmdevWEVmYCqyq7jdt2jT7+Oijj2xdNxHVk1Xuqkt/9tlnNiisOp2zbds2c84559hyVMups846ywYuV6xYEbEcBZubNWtm59G+i0dloH335Zdf2v32xBNP2Lqoo7qjAr8KvGpbVIdV0D3anXfeabdN++2MM84wt912m61XugSRjh07pnmPlq1yV71fx4u2V9cP2qZ42cAq359//tkGkGNtiwLO2hYFbq+//nq7n5SFq/185plnmiuuuMK/FlG5aFnah1pv1eX1/qAWLVrYdQNyFQ8AkOu9/PLLXrly5fzn3377rTdq1Cjvhx9+8H777Tfvnnvu8YoXL+4tX77cn0engEmTJkUsR8vQspwOHTp4xxxzjLd7925v2rRpXpEiRbyvvvoq7nq8+eabXrFixbwXXnjB+/XXX71+/fp5ZcqU8Zo1a+bP89prr3lVqlTx3n77bW/JkiX2/4oVK3qjR4+OucyNGzd6RYsW9WbPnu1P27BhQ8S0AQMGRHzGM888Y7d36NCh3qJFi7wvv/zSe/LJJ+1r69ats9uu7Vy9erV9LhMnTrTbN2LECPueIUOGeIUKFfI+/PDDmGW2dOlS+7x27dr+tqxatSrd2yc33XSTd9ZZZ0VMu/POO235q+y17scdd5ydPnjwYK93795eIh07dvS6du2acB4AAJB364L16tXzxo0bFzHPoEGDvJYtW0bUY1Rnc15//XU77YMPPvCnPfTQQ16DBg3856pfqF6zfft2f9rIkSO90qVLe3v37vW+/vpru4xly5altN5z5syx8wfrefpMTfvjjz/8addee63Xpk0b+/e2bdtsnW3s2LH+67t27fKqVq3qPfroo/b5X3/9ZetxX3zxhf/6AQcc4NfHPvnkE69s2bLejh07ItZH5fbss8/69cuSJUt6W7Zs8V+/4447vGOPPTbhftC6z58/35/2yy+/2GluXWI5/PDDveHDh/vPa9Wq5bVv3z5J6Xleq1atvEaNGnn79u3zp/Xt29dOi2fBggV2fbZu3RqxDyZPnhwxX3T9OlZ9+NVXX7XHR/Dzd+7c6ZUoUcKbMWNGzM9fuHChXcaKFSvSbMuJJ57oP9+zZ49XqlQp74orrvCnqe6u986bN88+P++887xu3bolKCHPu+WWW7xTTjkl4TxA2JBZCwB5kO7CX3vttaZx48a2OZDupitj9J133knXcp599ll7J13NzJQlq6wHNY+KRxkQmk8PZaYOHjzYHHbYYWkyONTXqrIs6tSpY/+/5ZZb7GfFomZQaoKnzIpg8zrdNT/11FNjvkefq2yA3r1728xUZRa7LgPUTMplESsL2T1X9oKyDJQ9rPfceuutdt2im9BF03LdtiiDN73bJ8uXL7fZw9HZDcqS0H5T0y11k6AsZ2UcKItA2bV169a1mSebN2+OeK+WpWUCAID8Ry2slBGq+piyHN1D9SNND2ratKn/t1pGibowCE4LNpl39cySJUv6z1u2bGmzRZURq9eUnaplKCNSzdjVVD2Z6PXQ8lXPibUe2gZldJ5wwgn+60WKFLEZlK4lkupCbdu2tS2tZOrUqbbrBK2TKMtU66xuGoJltHTp0ogyUgssZY06qutFl0c01d9U93TUykr1Trdu+lz1J6xWWJquz9Vr0Zm1sTJPY1HLLGUTB/eH6ox79+61z5U1rMzdmjVr2m1RizDJ6OcFqRyVfa3lujJUVwhqWRd9rDn//fef/V8t0BIdB2pBpv0TfTyK2wfKvFWXCmphp2xrZWZHU/cIiVoFAmFUOKdXAACQ9VQJVGBVzcYUbNUgAaoYRVfKklGgVEFCNW9S8yMFEBNRRVNBxCBVGOfMmZPm4iHYB6vWT105xKMuHTS/uhNQdwFq2qfmZAULpr3nqMrbqlWr7IVCemjdo/sD00WAmpMlEqzYZnT7tG+iK6yaPxigFvWl9thjj9ntX7JkiVm0aJH9nPvvvz9isDEqpQAA5O96oChQeuyxx0a8Ft2FkoKcjgv4RU+L7ooqES1/1qxZNmjmui7o16+f7WtfN7Hjif7M4POMrIeoP1o1mX/yySdtFwhqxu+CzCojBV7VTUM0BVBjrVdG1yOaArUqIyUEqEsG1dsuvvjiNN0GlCpVymSW6qaqx+uh+qOSFHQ9oOdZ8XkqRyVyuK7AglxCRDTXTYGC+NHzxCrvWMeo2wdK6FCCgroUU5mq/q9BeIPJFup2Id66AGFFsBYA8qBUKoGq7ET3HxZrgKyPP/7YVrwV9FWFL5hdkJ0XD0HKBtC6KvisTAX1O6WKdyza1v0pWLHN6Pap0pos60QXGbp4UF+9ytbV4B6qvCpDJLovOSqlAADkX8o+VGapbuzqhndWUzalbjS7OpcGPlVGZY0aNfw6pm5466E6Sq1atWwrIbVaygpufAH1j6pluzqsBhgLDr6qfmFVT1M/pu+//76t0zrqn3bNmjU2CzY4fkFW0E36r776ymb6im6uq99aZdKK1lutuTR+gqs/JhuQKxEFwoO0P9SyTnXPX3/91WzYsMH2Rev2j9YtFSpjl50bj8pR4zdooDcNhJbq/tO86mtWrdkyS4HYrl272ocGy7vjjjsigrU//vijHbwMyE3oBgEA8qBgJVBNh9TcP7oSqIqNArCOmktFNxFSVsQjjzxim46pEu4G6YpHldBYFcZYFw8KIgcfibItlHWqAKXu2msgC3WxoMphLAomq9KtQRviUZAzuvKpdVe5Bel5dDcOiWR0+zT6sSqs8WgUZmXPuoE1tO4usK7/o7dFlVItEwAA5E8a8Ouhhx4yw4YNM7/99pv54Ycf7I1fDT6VWbr5r1ZEqrsoo1FdQKmOqBZPqgdqMDMFBJXBqcHHVI9xgcqsoACsmr8rKKcgrNZDLY1Uj9V6OQpWqj5811132eClWns5p59+un2um9/KAFY9WfVeZQGnGsxMVM/U4FgqC3VBoHVQVwUueKt1Ubl8++23NvCtQd0yk62rclYgXEFh1ZNVX1RXYKKuDxR01TTVT9UlmrpHS4Xq0+oWQuu5fv16241ENN0MUNKBkgmUTKH5la2sLtT+/PPPmMvVcaLy//TTT01m6WbAlClTbFcMP/30kx0ELnis6ZjQPtDAZEBuQmYtAORBrhKojFRlN6iP0+hKoJrUa9RdVVQV7Ovbt29EM6OtW7fapmOqbKmJUfXq1W1Wq5apLN1YVDFUhVRdAyibQsFVVZyCfY7p4kHLVDN/jRSrip8qxcosTZRxocrgueeea5d3+eWXJ9x+dQGh7hh0l1/rrm1R4FUVZ3HBXK2julVQdw+q8Kv/VwU5VYFUgFplOHv27JTLPaPbp6ZoupDQPFqXaMoSUR+81apVs8+13q+++qqteD733HMRfba5SqkulAAAQP6kLgDU5F/dJ6mOowCnbuAHM08zSk3NVdc8+eSTbT2nU6dOtu4lyphUBqvGMdiyZYvNfFVXTaqPZSVliqpuq7qq6nmqe86YMSNNPUrBW9WJunXrFjFd9WMFmhWc1WsKKCu5Qdvk+kXNKJW76tUKwv71118221PdijkKmHfv3t12MaZAp+ZVWWVUly5dbKazgsEKUKs+7rr2UnLG6NGjzd13320D90p2UNbp+eefn3S5F110ka0La4wIZQYr2K96fvS2an9rG5RYoX2h+qqOkUSZtjo+FWB/9NFHY3ZrlioFolWHVrBdmd4qa/Vh6yiQq4C1pgO5Sk6PcAYAyPoRgDXC76mnnmpHYq1Ro4b39NNP2xFWe/fu7c+jUXLPPPNMO8pq/fr1vffee88uQ8sSjazapEmTiFFyhwwZYkcA/vPPP+OuywMPPGBH29WowBoxuE+fPmlGktXovc2bN/eKFi3qVahQwTv55JO9iRMnJtxGjTBcpUqVNKMDxxutdtSoUXZ0Wo0WrPfdeOON/mvvvPOOd8ghh3iFCxe2o+06zzzzjFe3bl37nkMPPdQbM2ZM3NFv3SjKGtE2Wka2r0WLFnado73//vv2NW2/oxGYO3To4JUpU8Zr3bq1t3btWv81jfwcHLUZAAAgq6hu165du1xToB9//LGt161ZsyZH6uTZLbp+n1vs27fPO+aYY2y9NTsde+yxtl4O5DYF9E9OB4wBAMjv1B+vMl/UhUFmMgzUzE6ZvcrmAAAAyErKrFSW5eTJk0NdsMr4Vbas+jFVxmysAbCyg7JYlb2sMtof1Bdr8+bNbSZzbqPuFdQ9h7Kjs4O6bnjppZds/doNTAbkFnSDAABACLRt29b2G6zmcm4AiIxUStUETc0RAQAA8iv13aouEBTIHDNmTE6vDmLQvtEju6iLiT59+lD2yJXIrAUAAAAAAACAEMh4O0sAAAAAAAAAQJYhWAsAAAAAAAAAIUCwFgAAAAAAAABCgGAtAAAAAAAAAIQAwVoAAAAAAAAACAGCtQAAAAAAAAAQAgRrAQAAAAAAACAECNYCAAAAAAAAQAgQrAUAAAAAAAAAk/P+H4wNq0IvBdXmAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1400x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Tableau comparatif\n",
+    "print(\"Comparaison des approches - Demineur 8x8, 10 mines\")\n",
+    "print(\"=\" * 65)\n",
+    "print(f\"{'Approche':<30} {'Victoires':>10} {'Taux':>8} {'Temps (ms)':>12}\")\n",
+    "print(\"-\" * 65)\n",
+    "for r in results:\n",
+    "    print(f\"{r['name']:<30} {r['wins']:>6}/{N_GAMES}  {r['win_rate']:>5.0f}%  {r['avg_time_ms']:>10.1f}\")\n",
+    "print(\"=\" * 65)\n",
+    "\n",
+    "# Visualisation\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(14, 5))\n",
+    "\n",
+    "names = [r['name'] for r in results]\n",
+    "win_rates = [r['win_rate'] for r in results]\n",
+    "avg_times = [r['avg_time_ms'] for r in results]\n",
+    "\n",
+    "# Taux de victoire\n",
+    "colors = ['#2196F3', '#4CAF50', '#FF9800']\n",
+    "bars1 = axes[0].barh(names, win_rates, color=colors)\n",
+    "axes[0].set_xlabel('Taux de victoire (%)')\n",
+    "axes[0].set_title('Taux de victoire sur 100 parties', fontweight='bold')\n",
+    "axes[0].set_xlim(0, 100)\n",
+    "for bar, val in zip(bars1, win_rates):\n",
+    "    axes[0].text(val + 1, bar.get_y() + bar.get_height()/2,\n",
+    "                 f'{val:.0f}%', va='center', fontsize=10)\n",
+    "\n",
+    "# Temps moyen\n",
+    "bars2 = axes[1].barh(names, avg_times, color=colors)\n",
+    "axes[1].set_xlabel('Temps moyen par partie (ms)')\n",
+    "axes[1].set_title('Temps moyen d\\'execution', fontweight='bold')\n",
+    "for bar, val in zip(bars2, avg_times):\n",
+    "    axes[1].text(val + 0.5, bar.get_y() + bar.get_height()/2,\n",
+    "                 f'{val:.1f}', va='center', fontsize=10)\n",
+    "\n",
+    "plt.suptitle(f'Benchmark des solveurs de Demineur ({ROWS}x{COLS}, {MINES} mines, {N_GAMES} parties)',\n",
+    "             fontsize=13, fontweight='bold')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-35",
+   "metadata": {
+    "id": "cell-35",
+    "papermill": {
+     "duration": 0.006281,
+     "end_time": "2026-04-22T18:08:12.584798",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.578517",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : comparaison des approches\n",
+    "\n",
+    "**Sortie obtenue** : le tableau et les graphiques montrent les performances des trois approches.\n",
+    "\n",
+    "| Approche | Taux de victoire | Temps moyen | Compromis |\n",
+    "|----------|-----------------|-------------|----------|\n",
+    "| Regles + aleatoire | ~30-45% | Tres rapide | Simplement des deductions locales |\n",
+    "| Regles + CSP + aleatoire | ~50-65% | Modere | Deductions globales mais choix aleatoire |\n",
+    "| Regles + CSP + probabilites | ~60-80% | Plus lent | Choix optimal sous incertitude |\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le **CSP** apporte un gain significatif par rapport aux regles seules, en deduisant des cellules que le raisonnement local ne voit pas\n",
+    "2. Les **probabilites** ameliorent encore le taux de victoire en remplacant le choix aleatoire par un choix optimal\n",
+    "3. Le **cout** du CSP (enumeration des solutions) est visible dans le temps moyen, mais reste acceptable sur 8x8\n",
+    "4. Meme le meilleur solveur ne gagne pas 100% du temps : certaines configurations du Demineur sont **fondamentalement ambigues** (consequence de la NP-completude)\n",
+    "\n",
+    "> **A retenir** : le triplet regles/CSP/probabilites illustre une strategie generale en IA -- commencer par les methodes les moins couteuses, puis monter en puissance si necessaire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-36",
+   "metadata": {
+    "id": "cell-36",
+    "papermill": {
+     "duration": 0.005937,
+     "end_time": "2026-04-22T18:08:12.596639",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.590702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Replay d'une partie (etape par etape)\n",
+    "\n",
+    "Visualisons les etapes cles d'une partie pour mieux comprendre le comportement du solveur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "cell-37",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 499
+    },
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:12.610164Z",
+     "iopub.status.busy": "2026-04-22T18:08:12.609881Z",
+     "iopub.status.idle": "2026-04-22T18:08:12.773739Z",
+     "shell.execute_reply": "2026-04-22T18:08:12.772678Z"
+    },
+    "id": "cell-37",
+    "outputId": "11bbf96d-2a2a-4e58-c85d-1df2fa239732",
+    "papermill": {
+     "duration": 0.171759,
+     "end_time": "2026-04-22T18:08:12.774608",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.602849",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7MAAAHvCAYAAACGzYjKAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAQlVJREFUeJzt3QuYXVV9P+6V+yQhiQkSCQZTDAGhoiIICUoVqY3GUi5GTU2Qtmk1Sb1QinKxPxSt5SIVFTURpShFwFKvGGioNJUUg4IohAoa0QiJl2CA3CYTQnL+z3f3Oed/ZpiZTELIzFrzvs9znjlzrnvtvc9a+7PX2nsPqNVqtQQAAAAZGdjbEwAAAAC7SpgFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gF2Av+4i/+Ig0YMKC6fehDH+qz8/yLX/xiYzpf85rX9Pbk9Fv//d//3VgOf/AHf7DXv7/+3XFbtWrVXv/+vsrvA6BvEWaBIjc0m2/Dhw9PBx98cBUo//d//7e3JzNbws2eDauxUyNu3/jGN1J/DutxGzhwYBo2bFh67nOfm17ykpekt7/97enWW29NtVqttycVgD5scG9PAMCzra2tLT300EPV7d///d/T9773vWqDGXozzF144YXV/TPOOCOdcsop7Z4/8sgj07Jly6r7LS0tqXQRWp988sm0bt266rZixYr0r//6r+l1r3td+vKXv5z222+/1BfMmDGjsVzGjBnT25MD0O8Js0CxYqNz27Zt6e67707nnXde2r59e9q8eXP69Kc/na688srenjz6oU2bNqV99tlnp6+LoPSqV70q9Rc33nhjFVjXrFmTvvWtb6V/+7d/qwLuf/7nf6bXv/716X/+53+qERa9bfz48dWtP62LAH2ZYcZAsSIMnHDCCel973tftUFc9/DDDz/ttatXr05nnnlmetGLXlRtNMdG3lFHHZUuv/zyKhA3i6Gh9eGRMXQ5NrTj+NJ4z9ixY9OsWbPSI4880qNpjKA9Z86cdMQRR1Qb80OGDEmjRo1KL3vZy9IHP/jBaoMz/PKXv0yDBg2qvjO+p/543aWXXtqYpje/+c07/d6nnnoqfeQjH6mOx4yev/j+GKa9q6Lc9e/t+P6ujruM76w/ftttt6XLLrssHXLIIdUw04MOOih9/OMf7/S7YtjpySefnPbff/80dOjQan792Z/9WaOnbHeOXY4hvsccc0y1zCOkvPOd70yPP/54u/dcf/311ffGUPXnPOc51TLad99906tf/er0L//yL08bCts8T66++ur0iU98Ih122GHVNMeyjsfrvbLhS1/60tOOj93ZMbN7Yl6EpUuXpuOOO64q//Oe97y0YMGC9MQTT3T7ngceeCD99V//dXrhC19YrTujR49Or3zlK6vlv7vDgo8++uhqfr7tbW9LN9xwQ7rmmmsaz91zzz3pU5/6VLvXx46pz33uc+n444+vfnMxDyZNmpT+5m/+pvqtNIt1r3ld/M1vfpP+/M//vNphEO+NZRK9wdEzfMEFF6QDDzywKlf8/mM+9+SY2Y7LK+qY008/vVpPYt7GdMZvvaPW1tbqtxvrYMzH+A1MmTIlnXXWWenRRx/t0Xd3d0x+x7pqyZIl1fIeOXJkv9pZAhSsBlCIq6++OrakG7dmb3zjGxuPz507t91zy5cvrz3nOc9p997m2wknnFBra2trvP6DH/xg47kpU6bUhgwZ8rT3TJw4sfa73/2u8Z4zzjij8Vy8v27hwoVdfm/cjjrqqNq2bdueVoYvfOEL7cpw9NFHN55bvHjxTufV29/+9k6/78gjj2zcf/WrX93uPfXHf/nLXzYei9fUH4/539nrO75n0qRJ7eZfZ9Nx/fXXt/usc845p8t5NHDgwGo+9kTzcjjssMM6/byXvvSltdbW1sZ73vrWt3a7jN773ve2+47medKxfCeffHK3nxXzJixduvRpj+3pebFkyZLa4MGDu10HOi67r3/967WWlpYuv3/27Nm1HTt27PS7m8vX8TvqTjzxxHbLqi6WTfwmu5qG+C1///vfb7w+Prv5+UMOOeRp75k2bVrt1FNPfdrjQ4cOra1atarTOqb599FcntGjR9fGjx//tM967nOfW9uwYUPjPY8++mjtxS9+cZfleP7zn1/7xS9+sdPv7q5+aa6rXvjCF1brR/N6DpA7PbNAsaLHNHpM/vmf/7nqkQjRgzN//vzGa7Zu3Zre+ta3Nnqj3vSmN6XFixdXx9bWj6uN3quPfvSjnX7HypUr0xve8Ib07W9/O11xxRWNYXvR0/uBD3xgp9MY3xHT9/Wvfz195zvfqb4rhly+4hWvqJ7/4Q9/WD0X/vZv/7bxvquuuqpx/1e/+lWj12fChAlp+vTp3X7nd7/73XY9X9HLdvPNN1fTe++993b5vsincduTZ9f9xS9+UfVAx/yLnrm6T37yk437t9xyS7rkkkuq+9HLFT1ZMfw05lv0ZO3YsSO9+93vTj/72c926bujh3Hu3LlV2f/xH/+x6nENMQ+ae4ejx3PRokXV8NdYPtGbHPM/TlYUYtj6b3/72y7Xj3h/LMPoBf7Lv/zLqvc0/tbF+hOPxS3Wu+7sqXkRr4te2OihD4cffni13l177bXp97//fafviZ7C6G2MY9DDvHnz0n/8x39Ux7ZGr2iI41ujN3pPiONlm5dV9GLWextjOYToyY/vix7UmJ4Qv+Xoea2XraP4zUfv72c/+9mqxzIsX748ffOb36w+O9bFGCkQorc2lv2u2LBhQ9Xzed1111XTVj+2NuZrPFYXv+f777+/uh8jMWIEQCzfqINCDLmO46n35G8tRp7E8or6MNYTgOz1dpoGeLZ6Zjveovdy2bJl7d5z0003NZ7fb7/9arfffnv1mrhdccUVjecmTJjQaW/HAQccUNu6dWvjucsuu6xdD9H27du77TmJXtf4nle+8pW1sWPHtus5qd/OOuus6rXR4zV58uTG4z/5yU+e9p3vf//7dzqf3vWud7XrhWv2lre8pcven848057ZBQsWNB6/8847G4+PGzeu8fib3vSmxuOnn356Y/nEbcaMGY3nzj333J1Ob/NyeMUrXtHlfHnJS17SePz3v/991Rt6xBFH1EaOHFkbMGDA05bRt771rU7nSfSsd6Z5HYpp6qirntk9NS/uvvvudtN/7733Np67+eabO112zb+H6FFs/u4PfOADjeemTp26R3pmP//5z7d7zZo1a6rfQPxO6499/OMfbzcd8TutP/cf//EfnfbMRvnqDj/88Mbjse7XfexjH2s8ftppp+1Sz2zcfvCDHzSemzdv3tN+y48//nht0KBBjcevu+66Rhnis5pHezz44IPdfndPe2ZHjBhR++1vf7vTZQOQEyeAAvqNn/zkJ1WPacfHmnue/uiP/qjT98ZxdnFcXRwD1+zYY4+tenvrmo9Dix6i6I3p7oQxf/VXf1X1lHSnfgxn9CJFr/LZZ59d/R+9g3G8aXNvXhwXtzM///nPG/enTZvW7rk49jFOvrO3nHjiiY37zfP2scce63QZxbzqan7Ve7l6quMxg/F/9LLWe1TDli1bqnny05/+tNvP6nicbd1pp52W9qQ9NS+a14ERI0a0O7t3lHdn3x2fH8eB7s5391THY0bjeOV4rPnxOLa0KzEdnY1SiGNGO1vnmn8L9V73jutiT8Qx7/WRFR2/o/5Z0XMex/3WxbHC3ZXj0EMPTc9ULNc4LhqgJIYZA8WKzsG1a9dW16wMMUwxhu01b5Tvio4nXXqmYhhhcxiJE1DFcMkYblqf5vqQ0LoYnlo/q2u8N0528/3vf78RrONEQ3tTfZhmaB7W2TGIdGXcuHGN+4MHP7P9q3t6+YQYHlwPsjF0NE5EFENcYxnFSbM6W0bNYth3b3g25sXe/u7mky/Feh2he09MR/MldeL6ts1huTO7elKr5nW643q9OyfIqpejq99aT39vvbUuAjybhFmgaHGW17gMTxxbVz8G7txzz2083xz+XvCCF1RnLq4fG9p8iw3K+nGBzX7wgx+0O9vxHXfc0W6jubmHp6PmMx5H702cOTmOE4wewgi6XW0ox/GAIYJ6HPNZ30DuSa9smDx5cuP+nXfe2e65uAbvroizwdY193rfdNNNaU9pXkZxiaXOlk/0csXxhruieVl1/D/OXNzxzNdxRuw4zjDOJBs9mR17+TvTHECaNYeoroLwszkvmteB2MkT13Xd2TrQ/N3Ru9nZd9d/K89UnLk3jnevqx87Gr/n5t9UHPvZ1TTEsdh9VRyTG2cnr4sdJl2Vo1725t9ac/0QI0Di/AC7uy4C5MwwY6B4cWKcOLlRnOioHrR+9KMfpSOPPLIKj3EpjgiWEVxiWGJc3iOGBsfQ4oceeqjqIYrLZXR2YpvYqHzLW95SfXZcAqT5kiszZ85sF1o6ikub1MUQ5jjJVFyiJIYNx0mGuhInjolLwoT6iXDiUiJxSaCeiOn6zGc+07jsSVyO5tRTT61CTJwEaFfUT5QTIozHEMs4AU4Mf95TIrB/7Wtfq+5/7GMfq8JfDAePeRvL7L777qtO3hM91R0vWdKd2BHxjne8oxoKHOtDXOqlLpZpx2UUyyS+I3ZSRPm6GlrcE81DT6OXN046Fp8bl9qpB+lnc168/OUvr8oWJwWqD3ONkx/FyZHOP//8Tt8TJ0qL5yJgxboS61G8L6Y7fgcRyOJkWqeccsouB8k4gVmcyCw+J6a/eah7TOt73vOeRiCL0QlR9hAjGGLn1Itf/OJqumIexA6aOIlTrId9VfQCx3pX/73NmDGjuoRYLPsIpzEvbr/99vTggw9Wt46/tahrYudV1BdxuEFfLivAs6q3D9oF2BuX5nnyySdrL3jBCxrPnXLKKY3nvve973V7aZ6OJ+lpPqlKnEBm2LBhnV5Wo/lkK12doGXWrFlPe2+cGOb444/v9gRBcZKd5vfE5+yKuIRKZ+U89NBDd+kEUHHpkLh8ScfP6XjJka5OABUnu6nreKKeZnFiq+6WT8fP6krzcnjZy17W6cmc4kRPmzdvrl4ff+OSJh1fs//++9de9KIXdXryq+5OilUXJ+/q7GRf9ctGdXdpnj01L2655ZZOL83TvA50XHZf+9rXur00T8f1uysdT5jU1e11r3tdbe3ate3eG5fmec1rXrPT9/ZkvepqWXV1sqWenACq4/Lq6mRfUa7uLs3T2WfF/Oj4mvj9NV9uqKsTQHVWjwDkzjBjoF+Iy66cc845jf+j9yd6seonfolhlnEymT/8wz+sjs2L41JjaHL03EaP44c//OFOPzdO9BKXunnta19bHVMZvVTRqxdDVntyspUvfOEL1bGyEydOrL4zjnuN3q34vO40X6YnNF/qpafDOKMnLoZWxwms4gQzcWmh5iHYPRHzKC45E5cWic+JnsV3vetdVW/jnhSXo4ke8uhBjmP/YnnGsMu4pEz0zkVv9tSpU3fpM08++eSqRzTmefRsx/DV6JWP3u768Znx97/+67+q740h3rF841I7MazzmZxMJ4bsxuWRYn2rXxJob8+LGDYdl9aJ18bohegtjt6+6BHsSnxn9GJHj3b0IsZ8i/U+7v/pn/5pdRmbuOTP7ohyxDTEschxCaAYQhy3GFrcLH4ncRmrOHwgep9jucRxqbE8jjrqqPR3f/d37YYo91VRrhgdEL38sQxi3Yp5cMABB1T/x2iSr371q+3eE+tM1C+jR4+u1s04gVosr44ncgPoLwZEou3tiQDISYTA+nDiOJ4tguHeFkMqY4M2qvAIwjEssbshzfyfCGtf+tKXqvsxFDaWJQCQJ8fMAmQkLhUTJ+z55Cc/2TjxUxyvK8gCAP2NMAuQkTe84Q3VsOa6GGb63ve+t1enCQCgNxiTBpChGGIcxzz+53/+Z5fXxwQAKJljZgEAAMiOnlkAAACyI8wCAACQHWEWAACA7Aiz7BVxAfsBAwakP/iDP9irc/ycc86pvvdrX/vaXv3eUq1ataqan3HrjeuDxvfWrwsaf+P/eLwn/uzP/iwNHjw4/e///u+zPKUAlCauJx5tzmte85pn9XtuueWW6nve8573pP7u17/+dWppaUnTpk3r7UmhDxNm6VaEz3p4GTZsWHUZkDiD6je+8Y0+H4ofeeSR6lqcBx98cDr11FP3yvT1hzPoxmVg+sKlYKZOnVpNx5/8yZ/06PXve9/70vbt26sdHAAlttPNt0984hO9ujO5O3/1V3+VXvjCFzamNYIiqbp2+Nlnn11dNzz+1sW2zEtf+tJqh2xXO3Gvv/76dNRRR6V99tkn7bfffukd73hH2rBhQ9az9YADDkizZ89Od955Z/r3f//33p4c+ijXmaVHXvva16bJkyenH//4x2nJkiXV7f3vf3+65JJL+uwcXLhwYdq6dWtVET7bPYlPPfVUGjRoUK/0WHZm27ZtaciQIXv8c8eNG9fYQHomnnzyyTR06NBn9BmxUyVuPfWqV70qTZo0Kd18883p5z//ebWTA6CkdvqII45o/H/kkUemvuqOO+5Ihx9+ePrtb3+btmzZ8qyGw9iJGSEwB3GptZ/85Cfp1a9+dXrBC17QePzuu++uLsEWj/3yl7982vti9Nnb3va2qhdz1qxZ1Wd8/vOfT7/73e/SN7/5zZSzOXPmpH/5l39Jn/rUp9LMmTN7e3Log/TM0iNvfvOb05VXXpl+8IMfpH/+53+uHrv00kvTD3/4w+p+W1tb+shHPpIOO+ywNHLkyHTooYemf/qnf6pCVUexhzH2tu27777VnsN6Q1YfwtO897h5aGk8f8IJJ1SP/+pXv2rs0Y2hr535+te/Xv098cQTG4898MAD6ZWvfGV67nOfW4W9CGcnnXRSeuihh562lzvKefTRR6cRI0ZUQ1zuvffexmvq3/2Zz3ymKmv0Wq9fv766nXXWWVVQivnw4he/uJpv0aCG1atXV8Ndo+zxnghX8X9X6uX/27/926p3OablkEMOSTfccEPjNTHkKV5z/vnnpz/6oz+qQuLixYurBvyzn/1seslLXlJNS+wFjz29mzZtetqQ4SjHQQcdlEaNGlW95he/+EXVmMb74vOjl7vje+p+85vfVHvZoyyxRzjmWfOw7vpw4FiHTj/99Oo1sSOkM7FhM2/evGrHSTTK0XB/4Qtf6PS1nQ0zXrp0abVBF3ulY169/OUvr9aV+jKL52JZ5N64A3QUdWzsbKzfog7vrt38t3/7t6p9GDNmTBX2ol2eP39+am1tfVp9/6//+q9V2xivje9Zt25du6AVOxbHjx9ftalxv7m97MxPf/rT9O1vf7sa7dNT9bZ50aJFO31N7GiPMB/t/P3339+jbZQoY7Q90Q7+zd/8TfrzP//znR7KsrOyf/WrX616VOM7o6wxv2NHe1c6226pT9t3v/vddMwxx3T6vvo2wRlnnJGuvvrqqsMhfOtb36o6IbrSXZu5Zs2a6vOiHY55Es9de+21T2uDm4dd17dH6j3tPdmG2dk8im222F76n//5n/T73/++y7LQfwmz7LK/+7u/S8973vOq+/XhxrHn7IILLqiCQuwdjCEyH/jAB6qA1SxCUVRSb3jDG6qwFXsOm4fSdCf24r7pTW+q7kfFWh/u2lljGAH5wQcfbLyvLhrgHTt2VAE2gnRU0tGgxp7Mjv7f//t/VRh90YteVA1xmT59eiMI1v393/99Fd6icY8KO4a8Xn755VWDHz3CMcTnne98ZxUqQ8yPm266qfrMuXPnVpX2smXLdlr2mGcxv6LRWblyZTWPY8dCs4svvrgKgG9/+9ursBzDaaMBeeKJJ9Jb3/rWKsBHQI/g2dFHP/rRdPzxx1cbMfUQv//++1fviQb0H/7hHzqdrs2bN1dBPxrPCLPR+Mde41hOEaibRYMVjXysK7Eh0dVnfe5zn6s2POJ1Mf/ry3FnYjnGBkA0zjF/Y/5HD/Djjz/eeM0f/uEfVn/vuuuuHn0mQC5uvPHGdOaZZzZuMQKlu3YzQksE2Gj/6oEtguIHP/jBp312tOd//Md/XO2MjOGe0c6Ee+65pwobUe/G3whz3/nOd6pQE2Got0RbGztoox2IALWzbZTly5dXZYoduTHtsYM7wn53dlb2aMfiu6KXNJZB9CpGYKt3AnT1mR23W3oi2v76DvvY7mjePvjRj360y21mbEPFc9dcc021HRDTH+WIHdLR3u+qrrZhejKPYgf9lClTqmUXOw+gozzGXdCnRGiL4BLDV+IWATWCSn0oZ1REsZctQkiEuOahyNGA3H777dVezGgYoxKL4SOf/vSnd/q9sUfyXe96V/VdOxvu2hxgIljWxfRFz3AcQ/Too49WYTICVlSQ8Z6xY8e2C3gR3KNSjwY/ytox+MZnRVgNEUqjco493NGwRVkjjMX8ifJFsIxhz+G4446rKu36XuKdifBd702MUH3rrbdW8615L20E1jhmJkSDFK+rH1saGy4ve9nLqhAXGzxRlo4Nzcknn5zuu+++an7E9H3lK19JV1xxRXUSiq4a3+iBjQ2imMex1zZEmWIIWZT5jW98Y+O1seMg5nNXw4vjs6InIDY84vsiTIfOevc7EzsRorE77bTTGutjfQh4XX3Hx2OPPdajzwTIxX/9139Vt7pTTjmlClZdtZvRvkWIiTo/6sS4HyNton352Mc+1u6zo/2Jns4IfdE+xOEa8doY1RPtTewojO2CMHHixKpdiF68PXmOgttuu61qD+ptQ3di9M9FF11U3e/JNko9oL3uda+rdjiHeE20iV3ZWdmjzY/2J3YARPsaATV6JbtT33Zp3m7piRgRFr26sX3V8b0x4mlX28zoqIje8xjaHO358OHDq53QEf5jh/df/uVf7tL0dbUNc9lll/VoHmm76Y4wyy6Lyq8+DCV6aB9++OHGc1dddVW710ZPX5yNri728EWQbd7zGHvmIlh2pjmI7IqogOtiL2U04iEq4a56gteuXdsuzNanLyrxGLoUQ3Wayxqah9fUn4tpjhDYLPZEhg9/+MNVwxIbFFGJR+CNij32dEeI60rzXtq4Hw1Bd9MS87M+fDvCa0cxPdHoduyxrM+3CKT1PfmhY490xzLH8OoI9p2VuS56Xbs7Trb+WTHMq3ljpafH/tbfHzsSmjUfK1U/GUbzcgYoQeyUjMM0eiqGfcYO2s7awq7aoOa2KEJivd6Ns8R3PFN8xzbgmYq2oac6a5u720aJQ4BC7ICui7J2F2Z3VvYIaHGYUbT79WM9I5TFcOeuzlRcb4N39cRNsbP6Zz/7WbUTOpZfjK6K4BmBtL7NtSttZv243Nj2iW2g5mXf2TG7O9tm62obpqfzSNtNdwwzZpd9/OMfb/TsxZ605lAUQ0Ui7NZvMVSn+fk43qEeXOO19eExEXKjUgsxLLYujnVpFidZCjFUuDsRDOtDWevfE+rHe7z73e+uekljL3Nd/bjW5rKECIX143IPPPDAdq+J4zjq6uWMij+GM9fnQQytieFe9YYhhu1u3Lix2hseZx6M0/A37xXtTHMZ6ve7m5aYn/VhR7EHvXmZxLTE3ulmHU+OUZ/PO1Mvc0xL7JSof0fsrY6hS11NX2fqJ7uIYV7NPcc93aFRf//3vve9do83v78+7+q9yACl66zdjHa2HmQjAEU7Ve/J7NgWNtedzW1R1Pv1NuAtb3lLu3Ymeno79u4+U7E9Eb2pzdsIXemsbe5uG6XenjYf1tJc1s70pOwxvDl2/sd2Txy/GqEszqzfVbtWb5t29t0dxedF50IML49jgWMHfgTZ2GEeQ3t3tc2MIdohtn3qO8ZjCHOoP1ffZqv3Jke7H4F6V7dhdjaPoje+vg3Vl09qRu/RM0uPRO9eHMsRvZP14w1jGE/s/asPIYmhOXGiiT/90z+tKr8YUhqX8okhvXXRmMaxmbEnsB7gYrhKVLhRScXf6OWLyi2Ooex4Eol65Rt7UeOY09jjWG+AO4ohVjF8KIYm1cNbvccvKszYIxvPdSWOmY3vjz2z0XjGd0XZuhLfEXtHYx7FfInhSlHJx/G20ZjECRHi5BpRkUfPZ/Q41vdc76ynMDY6YsdBzL/Yoxk6O/a1uSGPE1hED3EMi455Eepl6W7P6q6I4Ulx3FHsoX/FK15RDT+LvcJxooYFCxY0rgnb016CCPvReEbIj+Oqo3GLIUdxsrGdiUY8AnSsV3Hik9iZEetgDGWK5RLqQ/BiXgKU1k43h7E4DCUO5ems3YyesBh5EztWY8RSnOOgu0vuRRsSbVrsfA1RP0f7Hm1a7CSO40ujvYsTDUYdHjtt47VdXZM1RkjFzu1o70Oc6C+2FeJ76u1VR3EMZ4SeXe2BjiHAO9tGie2Q6CGMaY62KOZLx53pHfWk7HFipWiPIvjWjyGOnseudhhH2eO8EbFt0nyuipg/0a5+//vfr/6P+3GccwwNP/fcc6vvjeUT3xllqy/LaBfr4XNX2sw4RCiOU41tlNi2ibNkx06P+vD0EO10WLFiRdXeR9jtapRdd9swO5tHEbZjZ3kcMtWTIeb0QzXoxqRJk2IXbXUbMmRIbf/9969Nnz699s1vfrPd6zZv3lz70Ic+VHvRi15Ua2lpqT33uc+tveY1r6lde+211fNLly6tPiM+75Of/GRtwoQJtbFjx9bmzp1b27RpU+NzPvWpT1XfEe8//fTTa6ecckr1vg9+8ION15x33nm1cePGVY+PGTOmy2lftWpVbejQobUpU6bUduzYUT324IMP1o477rhqGg877LDaNddc0yjfAw880K7MMZ3HHHNM9dr4+8Mf/rDx2fX3/PKXv2z3nevWrau9973vrU2ePLk2bNiwqixveMMbajfffHP1/Be+8IXakUceWRs9enQ1bS984QtrF154YZdlOOOMM6rvec973lObOXNmbfjw4bWDDz64MV/Dq1/96uo1V199dbv3btu2rSrDEUccURs5cmQ1v6dOnVr7xCc+UT0f096xHPXPOuecc6r/4zPry63je+oefvjh2l/8xV9Ur4kyT5w4sXbaaafVli9fXj0fyy5eH2XZmd/85je1d7zjHbWDDjqomj/xWZ///OfbzYv6utDZ59522221E044obbvvvtW8yrmdawHYdmyZdXrY/0FKLGdbr41142dtZs33XRT1Z5EvX3iiSfW/vEf/7F6/nnPe97T6vuvfOUrVb08atSoqn5fu3Zt47Ojro96dfz48Y02KurxX//617s8zc1tfVfvWbhw4U5fE9scu7KNEmJ7IMoY7WVsm5x66qnVZ8X95vYw2smelv3Nb35zo22MeRfbH//93//d5fTHtkpM48CBA2u/+tWvGo/X27+Ot/q0/O53v6va9/iOaDsPP/zwanuqvu3Tle7azGjb58yZU3v+859fzZOXvexltS9+8Yvt3h/bCvHe2KaL7ZSYhubtkZ5sw+xsHsX8j8+4/vrruy0L/ZcwS9He9773VZXgV7/61R6/p6vGsDd0DHDsvpNOOqk2aNCg2n333Wc2AuxEZzsvS/b444837m/fvr126KGHVmWPkL83LV68uPred7/73bXcPdNtmNgpECH32GOP3Wkwp/8yzJiixfDUngxRpXwxtBwAOhOHysQw3TiWMw5JiWNO4xCg7q4z+2yYMWNGp8ct90cxDDyGGEN3hFkAAPq1OMY4Lh8Tx/FGiIrrrl544YXp+c9/fm9PGtCNAdE9290LAAAAoK9xaR4AAACyI8wCAACQHWEWAACAMk8AFRc5/vWvf11dYHvAgAHP/lQBwB4Wp4jYuHFjOuCAA9LAgWXuy9VeA9Cf2uwehdkIsnGqcgDI3SOPPJImTpyYSqS9BqA/tdk9CrPRIxtuvPHGNGLEiFSS2267LZ144ompRMuWLUtz585NpbnqqquKLFfJZSu1XIsWLUqvfe1rU4lKrBtbW1vTm9/85kabVqJ62e65554iy/nFz3wmvX/atFSai+65J839679OJSq1/leu/JRaf3z4zjvTa//4j1Npetpm9yjM1ocWR5AdOXJkKsmwYcOKK1Nz2UrcmGlpaSmyXCWXrdRylV5/lFq2kg+XqZctfm8l/uZahg1LowvbqV4vV4nLq+T6X7nyU2r9Mazg9ronbXaZBw0BAABQNGEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7Azu7QkgX8uXD0lXXDEy/fjHQ9Jjj/3ffpFLLtmQzjhjS29PGv3IwnsXpltX3ZoeWv9QeqLtibTfiP3ScQccl84++uw0afSk3p48KE7Jv7kbzjsvrb7//k6fO/n889OUadNSjrTX9BWl1h+l1h05EGbZbStWDEm33z40TZq0vRFmYW+7asVVac2mNeng5xycWga1pIc3Ppxu/NmN6burv5vumHVHGjV0lIUCfnO7ZNDgwWn85MntHmsZlW9dor2mryi9zS6t7siBMMtumzlzSzr99Nb06KMD0zHH7GdO0ivmHDYnzTxkZpo4amL1/wV3XJCuXHFlWtu6Ni1bsyzNOGiGJQN+c7tk5LhxafZllxWz3miv6StKb7NLqztyoDuN3TZuXC0NH24G0rvOPOrMRqMYjp1wbOP+0IFDe2mqoFx+c/nRXtNXqD/Y0/TMAsXYvmN7uvaBa6v7cezN8ROP7+1JgqKV+pvbsHZtuuykk9o9dvZNN/Xa9ECJSqw/1B17nzALFGHzts1p/nfmp6WPLE3jR4xP17z+mjRs0LDeniwoVsm/uc6OewP2nFLrD3XH3ifMAtmLY23m3DIn3ffofWnymMnpujdel/VZEaGvK/0357g3ePaUXH+oO/Y+YRbI2oOPPZjm3Dwnrd60Ok2dMDVdPf3qNLZlbG9PFhTLbw5Qf9BXCLPstsWLh6WPfGSf9NRTAxqPXXrpPmnhwhHp5S/flj772Q3mLs+6uUvmVkE2bHpyU5p98+zGc7MPm13dAL+5/kx7TV+hzWZPE2bZbRs3DkirVrVfhdatG1jdJkzYYc6yV2zdvrVx//517S9YfsKBJ1gK4DfX72mv6Su02expwiy7bdastuoGvenuOXdbAOA3t0fMuuiiItcl7TV9Raltdql1Rw5cZxYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHYG1Gq12s5etGHDhjRmzJh01llnpWHDhqWStLW1pZaWllSip556Ko0cOTKVprW1NY0YMSKVqNSylVquqBtLqxNLrhu3bt2aPv7xj6f169en0aNHpxLV2+sPnHlmailw3dy0fXsaXmBd0trWVmQdWXL9r1z5aVu/Pu0zZEgqzaYnn0wjCqzv27ZuTf/0iU/stM0evCsfeuKJJxYXjpYsWZKmT5+eSrR06dI0b968VJpFixYVWa6Sy1ZquT71qU+lP/mTP0klKrFu3Lx5cxVm+4P3T5uWRhcYIC686640b8GCVJpS68iSy6Zc+fn85ZenD7zqVak0H122rMhybWhtrcLszhhmDAAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsDO7tCSBPC+9dmG5ddWt6aP1D6Ym2J9J+I/ZLxx1wXDr76LPTpNGTenvy6Eesi7B33XDeeWn1/fd3+tzJ55+fpkyblu0iGXHllanlhhvSoNWr04C2trRj333TtqOOSpvPOis9dfjhKVfqSfqKUtfFkuvFG/p42YRZdstVK65KazatSQc/5+DUMqglPbzx4XTjz25M31393XTHrDvSqKGjzFn2Cusi9I5Bgwen8ZMnt3usZVTedf+Q5cvTwHXr0vZJk6owO+ihh1LLt7+dht5xR3r07rtTGjky5Ug9SV9R+rpYYr3Y18smzLJb5hw2J808ZGaaOGpi9f8Fd1yQrlxxZVrbujYtW7MszThohjnLXmFdhN4xcty4NPuyy4qa/esXLkyppaXx/8hLLkn7XH55Gvj442nwz3+ennrpS1OO1JP0FaWviyXWi329bI6ZZbecedSZjYooHDvh2Mb9oQOHmqvsNdZFYI9paUnDbr45jZ0xI+17/PFp5Cc/WT0cw423d+iRyIl6kr7CusiepmeWZ2z7ju3p2geure7H8Q7HTzzeXKVXWBdh79mwdm267KST2j129k03Zb8IBj76aBp6zz2N/596wQvSE9dck2r77JNKoJ6kryhxXSy1XuzLZRNmeUY2b9uc5n9nflr6yNI0fsT4dM3rr0nDBg0zV9nrrIvQ+8dPlWDLGWekLW9/exq4Zk0a9ZGPpJZvfjM9553vTI8tXpx9oFVP0leUui6WWi/25bIJs+y2OL5hzi1z0n2P3pcmj5mcrnvjdVmfiY58WRdh7+urx0/tEQMGpB0TJ6bN731vFWYH//SnqeXrX09bTj895Uo9SV9R8rpYcr04so+WzTGz7JYHH3swzfjajKoimjphavr2qd8upiIiL9ZFYE8Y8NhjqeXGG1N68snGY0Nvu+3/f761NdsZrZ6kr7AusqfpmWW3zF0yN63etLq6v+nJTWn2zbMbz80+bHZ1g73BugjsCQM2bUpj3v3uNPr9709PTZqUBm7cmAatWVM9t2OffVLbjHzPsqqepK+wLrKnCbPslq3btzbu37+u/YWUTzjwBHOVvca6COwJtTFjUtspp6TBP/pRGvyrX6W0bVva/vznpyenTUub3/OetOPAA7Od0epJ+grrInuaMMtuuXvO3eYcfYJ1EfauWRddVGyYXb9oUSqRepK+otR1sdR6MYeyOWYWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2BtRqtdrOXrRhw4Y0ZsyYdNZZZ6Vhw4alkrS1taWWlpZUoqeeeiqNHDkylaa1tTWNGDEilajUspVcruHDh6cSbdmypbiybd26NV188cVp/fr1afTo0alE9fb63HPOSS2FtdehbePGNHLo0FSaTTt2pOEFttel1//KleEyK3Cbv3XLljSisPY6tEWbfcklO22zdynMLl68uLhwtGTJkjR9+vRUoqVLl6b58+en0ixatCjNmzcvlajUsilXfkpcZhs3bkxTpkzpF2F25cqVadSoUak0n7/88vQPr3pVKs2Fd92V5i1YkEpUYl0SlCs/llmZbbZhxgAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZGdzbE0C+li8fkq64YmT68Y+HpMce+7/9IpdcsiGdccaW3p40+plS18WF9y5Mt666NT20/qH0RNsTab8R+6XjDjgunX302WnS6EkpV6WWq78oefndcN55afX993f63Mnnn5+mTJuWclRqHUl+Sl0XS64XF/bxsumZZbetWDEk3X770DR27A5zkV5V6rp41Yqr0p2/uTONGTom7T9y/7Rm05p0489uTCd946S08cmNKVellqu/6A/Lb9DgwWnCoYe2u7WMGpVyVWodSX5KXRdLrhev6uNlE2bZbTNnbkkrV65N11//uLlIryp1XZxz2Jx01+y70rJZy9IPZv8gveOId1SPr21dm5atWZZyVWq5+ov+sPxGjhuXZl92WbvbgS9+ccpVqXUk+Sl1XSy5XpzTx8smzLLbxo2rpeHDzUB6X6nr4plHnZkmjprY+P/YCcc27g8dODTlqtRy9ReWX35KrSPJT6nrYsn14pl9vGyOmQXIwPYd29O1D1xb3Y9jVI6feHwqQanl6i9KXX4b1q5Nl510UrvHzr7ppl6bHiAfpdaLfbVswixAH7d52+Y0/zvz09JHlqbxI8ana15/TRo2aFjKXanl6i9KXn5xzOz4yZN7ezKAzJRcL27uo2UTZgH6sDgmZc4tc9J9j96XJo+ZnK5743V94uyBz1Sp5eovSl9+9WNmAXqq5HpxbR8umzAL0Ec9+NiDac7Nc9LqTavT1AlT09XTr05jW8am3JVarv7C8gPoP/Xig328bMIsu23x4mHpIx/ZJz311IDGY5deuk9auHBEevnLt6XPfnaDucteUeq6OHfJ3KrxCJue3JRm3zy78dzsw2ZXtxyVWq7+wvLLT6l1JPkpdV0suV6c28fLJsyy2zZuHJBWrWq/Cq1bN7C6TZhQ1vXD6NtKXRe3bt/auH//uvvbPXfCgSekXJVarv7C8stPqXUk+Sl1XSy5Xtzax8smzLLbZs1qq27Q20pdF++ec3cqUanl6i9KXn6zLroolajUOpL8lLoullwv3t3Hy+Y6swAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsjOgVqvVdvaiDRs2pDFjxqRzzz03DRs2LJVky5Ytafjw4alEUbYRI0ak0rS2thZZrpLLplz5KXGZtbW1pYsvvjitX78+jR49OpWoub1uaWlJRa6XJZarra2431vJdUlQrvxYZmW22bsUZleuXJlGjRqVSrJo0aI0b968VKJSy1ZquUoum3Llp8RltnHjxjRlypR+EWZLbK9LXS9LLlfJZVOu/FhmZbbZhhkDAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZKfPhNnly4ekt73tOenww/dL++//vOr2pS8NT7krtVyllw2A/lf3l1q2UssF0GfC7IoVQ9Lttw9NY8fuSCUptVyllw2A/lf3l1q2UssF0GfC7MyZW9LKlWvT9dc/nkpSarlKLxsA/a/uL7VspZYLYHBfmQXjxtVSiUotV+llA6D/1f2llq3UcgH0mZ5ZAAAA6ClhFgAAgOwIswAAAGRHmAUAACA7fSbMLl48LE2dum867bRxjccuvXSf6rEFC0anXJVartLLBkD/q/tLLVup5QLoM2cz3rhxQFq1qv3krFs3sLpNmJDvddFKLVfpZQOg/9X9pZat1HIB9JkwO2tWW3UrTanlKr1sAPS/ur/UspVaLoA+M8wYAAAAekqYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyM6BWq9V29qINGzakMWPGpHPPPTe1tLSkkrS2tqYRI0akEpVatlLLVXLZlCs/JS6ztra2dPHFF6f169en0aNHpxKV3F6Xul6WXK6Sy6Zc+bHMymyzdynMrly5Mo0aNWpPT2uvWrRoUZo3b14qUallK7VcJZdNufJT4jLbuHFjmjJlSr8IsyW216WulyWXq+SyKVd+LLMy22zDjAEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7Ayo1Wq1nb1ow4YNacyYMencc89NLS0tqSStra1pxIgRqUSllq3UcpVcNuXKT4nLrK2tLV188cVp/fr1afTo0alEJbfXpa6XJZer5LIpV34sszLb7F0KsytXrkyjRo1KJVm0aFGaN29eKlGpZSu1XCWXTbnyU+Iy27hxY5oyZUq/CLMlttelrpcll6vksilXfiyzMttsw4wBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAsiPMAgAAkB1hFgAAgOwIswAAAGRHmAUAACA7wiwAAADZEWYBAADIjjALAABAdoRZAAAAstNnwuzy5UPS2972nHT44ful/fd/XnX70peGp9yVWq6Sy6Zc+Sl1mUFfVPLvrdSylVquksumXJBZmF2xYki6/fahaezYHakkpZar5LIpV35KXWbQF5X8eyu1bKWWq+SyKRdkFmZnztySVq5cm66//vFUklLLVXLZlCs/pS4z6ItK/r2VWrZSy1Vy2ZQLemZw6iPGjaulEpVarpLLplz5KXWZQV9U8u+t1LKVWq6Sy6ZckFnPLAAAAPSUMAsAAEB2hFkAAACyI8wCAACQnT4TZhcvHpamTt03nXbauMZjl166T/XYggWjU65KLVfJZVOu/JS6zKAvKvn3VmrZSi1XyWVTLsjsbMYbNw5Iq1a1n5x16wZWtwkT8r12WKnlKrlsypWfUpcZ9EUl/95KLVup5Sq5bMoFmYXZWbPaqltpSi1XyWVTrvyUusygLyr591Zq2UotV8llUy7IbJgxAAAA9JQwCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkZ0CtVqvt7EUbNmxIY8aMSX//93+fhg0blkqyZcuWNHz48FSiUstWarlKLtu2bdvSyJEjU2laW1vTiBEjUolKLFtbW1u6+OKL0/r169Po0aNTiert9bnnnptaWlpSadrWr08jhw5Npdm0Y0caXmAdWWpdEqyL+Sl1XWwttFw9bbN3KcwuXry4uA3SJUuWpOnTp6cSlVq2UstVctmWLl2a5s+fn0qzaNGiNG/evFSiEsu2cePGNGXKlH4RZleuXJlGjRqVSvP5yy9P//CqV6XSXHjXXWneggWpRCXWJcG6mJ9S18VFhZarp222YcYAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2RFmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAABkR5gFAAAgO8IsAAAA2Rnc2xMA8EwtXz4kXXHFyPTjHw9Jjz32f/voLrlkQzrjjC1mLuxhC+9dmG5ddWt6aP1D6Ym2J9J+I/ZLxx1wXDr76LPTpNGTsp7fN5x3Xlp9//2dPnfy+eenKdOmpRyVXEeWWjbrIvSMMAtkb8WKIen224emSZO2NzZmgGfHVSuuSms2rUkHP+fg1DKoJT288eF0489uTN9d/d10x6w70qiho7Kf9YMGD07jJ09u91jLqHzLVXIdWXLZgnURuifMAtmbOXNLOv301vToowPTMcfs19uTA0Wbc9icNPOQmWniqInV/xfccUG6csWVaW3r2rRszbI046AZKXcjx41Lsy+7LJWi5Dqy5LIF6yJ0r7xdWEC/M25cLQ0f3ttTAf3DmUed2Qiy4dgJxzbuDx04tJemiv5aR5ZcthJZXuxpemYBgN2yfcf2dO0D11b343jZ4yceX8Sc3LB2bbrspJPaPXb2TTf12vTQf1kXoXvCLACwyzZv25zmf2d+WvrI0jR+xPh0zeuvScMGDSv2OEXoDdZF6J4wCwDskjg+ds4tc9J9j96XJo+ZnK5743XZn8m45OMUyZd1EbonzAIAPfbgYw+mOTfPSas3rU5TJ0xNV0+/Oo1tGWsOArDXOQEUkL3Fi4elqVP3TaedNq7x2KWX7lM9tmDB6F6dNijN3CVzqyAbNj25Kc2+eXaa8bUZ1e3LD3y5tyePflZHlly2Elle7Gl6ZoHsbdw4IK1a1b46W7duYHWbMGFHr00XlGjr9q2N+/evu7/dcycceEIvTBH9uY4suWwlsrzY04RZIHuzZrVVN+DZd/ecu4udzbMuuiiVqOQ6stSyWRehZwwzBgAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7Ayo1Wq1nb1ow4YNacyYMemss85Kw4YNSyVpa2tLLS0tqUSllq3UcpVctqeeeiqNHDkylaa1tTWNGDEilajEssXv6+KLL07r169Po0ePTiWqt9cfOPPM1FJYex02bd+ehhe2XobWtrbifm8l1yWNchXYXlsX89Na6G+sp232LoXZxYsXF7dBumTJkjR9+vRUolLLVmq5Si7b0qVL0/z581NpFi1alObNm5dKVGLZNm7cmKZMmdIvwuz6r3wljS5w4+bCu+5K8xYsSKUp8fdWetmUKz+WWZlttmHGAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkZ3NsTAPBMLV8+JF1xxcj04x8PSY899n/76C65ZEM644wtZi7sYTecd15aff/9nT538vnnpynTpmU5zxfeuzDduurW9ND6h9ITbU+k/Ubsl4474Lh09tFnp0mjJ6WclVxHllo25YKe0TMLZG/FiiHp9tuHprFjd/T2pEC/MWjw4DTh0EPb3VpGjUq5umrFVenO39yZxgwdk/YfuX9as2lNuvFnN6aTvnFS2vjkxpSzkuvIUsumXNAzemaB7M2cuSWdfnprevTRgemYY/br7cmBfmHkuHFp9mWXpVLMOWxOmnnIzDRx1MTq/wvuuCBdueLKtLZ1bVq2ZlmacdCMlKuS68hSy6Zc0DN6ZoHsjRtXS8OH9/ZUADk786gzG0E2HDvh2Mb9oQOHppyVXEeWWjblgp7RMwsA7LINa9emy046qd1jZ990UxFzcvuO7enaB66t7sfxssdPPL63JwmATgizAMBuHTM7fvLk4ubc5m2b0/zvzE9LH1maxo8Yn655/TVp2KBhvT1ZAHRCmAUAUn8/ZjbE8bFzbpmT7nv0vjR5zOR03Ruvy/5MxgAlE2YBgH7vwcceTHNunpNWb1qdpk6Ymq6efnUa2zK2388XgL7MCaCA7C1ePCxNnbpvOu20cY3HLr10n+qxBQtG9+q0AXmYu2RuFWTDpic3pdk3z04zvjajun35gS+nnJVcR5ZaNuWCntEzC2Rv48YBadWq9tXZunUDq9uECWVdexB4dmzdvrVx//5197d77oQDT8h6tpdcR5ZaNuWCnhFmgezNmtVW3YC98Hu76KIiZ/Pdc+5OpSq5jiy1bMoFPWOYMQAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQHWEWAACA7AizAAAAZEeYBQAAIDvCLAAAANkRZgEAAMiOMAsAAEB2hFkAAACyI8wCAACQncE9eVGtVqv+tra2ptJs3bo1bd68OZWo1LKVWq6Syxbl2rhxYypNW1tbkeUqtWz18tTbtBLVy7ahwPY6tKlLslNiXRKUKz+WWZlt9oBaD1r11atXpwMPPHDPTR0A9JJHHnkkTZw4scj5r70GoD+12T0Kszt27Ei//vWv06hRo9KAAQP29DQCwLMumrvY03vAAQekgQPLPMpGew1Af2qzexRmAQAAoC8pc9c0AAAARRNmAQAAyI4wCwAAQHaEWQAAALIjzAIAAJAdYRYAAIDsCLMAAACk3Px/VeesQJwR0z8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Issue : VICTOIRE\n",
+      "Etapes totales : 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Replay d'une partie avec snapshots\n",
+    "random.seed(42)\n",
+    "np.random.seed(42)\n",
+    "board_replay = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
+    "board_replay.reveal(4, 4)\n",
+    "\n",
+    "snapshots = []\n",
+    "snapshots.append((board_replay.copy(), \"Debut (apres premier clic)\"))\n",
+    "\n",
+    "step = 0\n",
+    "while not board_replay.game_over and not board_replay.won and step < 20:\n",
+    "    # Regles\n",
+    "    rs = RuleBasedSolver(board_replay)\n",
+    "    rs.solve()\n",
+    "    if rs.moves_log:\n",
+    "        snapshots.append((board_replay.copy(),\n",
+    "                          f\"Etape {step+1} : regles ({len(rs.moves_log)} coups)\"))\n",
+    "        step += 1\n",
+    "        continue\n",
+    "\n",
+    "    if board_replay.game_over or board_replay.won:\n",
+    "        break\n",
+    "\n",
+    "    # CSP\n",
+    "    cs = CSPSolver(board_replay)\n",
+    "    safe, mines, sols = cs.solve()\n",
+    "    if safe or mines:\n",
+    "        for cell in mines:\n",
+    "            board_replay.flag(*cell)\n",
+    "        for cell in safe:\n",
+    "            board_replay.reveal(*cell)\n",
+    "        snapshots.append((board_replay.copy(),\n",
+    "                          f\"Etape {step+1} : CSP ({len(safe)} sures, {len(mines)} mines)\"))\n",
+    "        step += 1\n",
+    "        continue\n",
+    "\n",
+    "    if board_replay.game_over or board_replay.won:\n",
+    "        break\n",
+    "\n",
+    "    # Probabilites\n",
+    "    probs_replay = cs.get_probabilities(sols)\n",
+    "    if probs_replay:\n",
+    "        best = min(probs_replay, key=probs_replay.get)\n",
+    "        p = probs_replay[best]\n",
+    "        board_replay.reveal(*best)\n",
+    "        snapshots.append((board_replay.copy(),\n",
+    "                          f\"Etape {step+1} : devinette {best} (P={p:.0%})\"))\n",
+    "    else:\n",
+    "        # Choix aleatoire\n",
+    "        unknown = [(r, c) for r in range(8) for c in range(8)\n",
+    "                   if (r, c) not in board_replay.revealed\n",
+    "                   and (r, c) not in board_replay.flagged]\n",
+    "        if unknown:\n",
+    "            cell = random.choice(unknown)\n",
+    "            board_replay.reveal(*cell)\n",
+    "            snapshots.append((board_replay.copy(),\n",
+    "                              f\"Etape {step+1} : aleatoire {cell}\"))\n",
+    "        else:\n",
+    "            break\n",
+    "    step += 1\n",
+    "\n",
+    "# Afficher les snapshots cles (max 6)\n",
+    "display_snapshots = snapshots[:6] if len(snapshots) > 6 else snapshots\n",
+    "n_snap = len(display_snapshots)\n",
+    "cols_per_row = min(3, n_snap)\n",
+    "rows_needed = (n_snap + cols_per_row - 1) // cols_per_row\n",
+    "\n",
+    "fig, axes = plt.subplots(rows_needed, cols_per_row,\n",
+    "                         figsize=(5 * cols_per_row, 5 * rows_needed))\n",
+    "if rows_needed == 1 and cols_per_row == 1:\n",
+    "    axes = np.array([axes])\n",
+    "axes = np.atleast_2d(axes)\n",
+    "\n",
+    "for idx, (snap_board, snap_title) in enumerate(display_snapshots):\n",
+    "    row_idx = idx // cols_per_row\n",
+    "    col_idx = idx % cols_per_row\n",
+    "    ax = axes[row_idx, col_idx]\n",
+    "\n",
+    "    for r in range(snap_board.rows):\n",
+    "        for c in range(snap_board.cols):\n",
+    "            if (r, c) in snap_board.revealed:\n",
+    "                bg = '#E8E8E8'\n",
+    "            elif (r, c) in snap_board.flagged:\n",
+    "                bg = '#FFB3B3'\n",
+    "            else:\n",
+    "                bg = '#C0C0C0'\n",
+    "            rect = plt.Rectangle((c, snap_board.rows - 1 - r), 1, 1,\n",
+    "                                 facecolor=bg, edgecolor='#666', linewidth=0.5)\n",
+    "            ax.add_patch(rect)\n",
+    "            cx, cy = c + 0.5, snap_board.rows - 1 - r + 0.5\n",
+    "            if (r, c) in snap_board.revealed:\n",
+    "                num = snap_board.numbers[r, c]\n",
+    "                if num > 0:\n",
+    "                    ax.text(cx, cy, str(num), ha='center', va='center',\n",
+    "                            fontsize=10, fontweight='bold',\n",
+    "                            color=NUMBER_COLORS.get(num, 'black'))\n",
+    "            elif (r, c) in snap_board.flagged:\n",
+    "                ax.text(cx, cy, 'F', ha='center', va='center',\n",
+    "                        fontsize=10, fontweight='bold', color='darkred')\n",
+    "\n",
+    "    ax.set_xlim(0, snap_board.cols)\n",
+    "    ax.set_ylim(0, snap_board.rows)\n",
+    "    ax.set_aspect('equal')\n",
+    "    ax.set_title(snap_title, fontsize=9, fontweight='bold')\n",
+    "    ax.set_xticks([])\n",
+    "    ax.set_yticks([])\n",
+    "\n",
+    "# Masquer les axes vides\n",
+    "for idx in range(n_snap, rows_needed * cols_per_row):\n",
+    "    row_idx = idx // cols_per_row\n",
+    "    col_idx = idx % cols_per_row\n",
+    "    axes[row_idx, col_idx].set_visible(False)\n",
+    "\n",
+    "plt.suptitle('Replay d\\'une partie de Demineur', fontsize=13, fontweight='bold')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print(f\"\\nIssue : {'VICTOIRE' if board_replay.won else 'DEFAITE'}\")\n",
+    "print(f\"Etapes totales : {len(snapshots)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-38",
+   "metadata": {
+    "id": "cell-38",
+    "papermill": {
+     "duration": 0.0102,
+     "end_time": "2026-04-22T18:08:12.793167",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.782967",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : replay de partie\n",
+    "\n",
+    "**Sortie obtenue** : la sequence d'etapes montre la progression du solveur.\n",
+    "\n",
+    "**Points cles** :\n",
+    "1. Le premier clic ouvre une zone (propagation des zeros)\n",
+    "2. Les regles simples font des progres rapides dans les premieres etapes\n",
+    "3. Le CSP intervient quand les regles se bloquent, souvent pres des bords de la zone revelee\n",
+    "4. Les devinettes sont rares mais chaque erreur est fatale\n",
+    "\n",
+    "> **Lien avec la NP-completude** : meme avec un solveur parfait, certaines configurations exigent une devinette. La probabilite de succes depend de la densite de mines et de la taille du plateau."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-39",
+   "metadata": {
+    "id": "cell-39",
+    "papermill": {
+     "duration": 0.008603,
+     "end_time": "2026-04-22T18:08:12.809945",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.801342",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Exercices\n",
+    "\n",
+    "### Exercice 1 : contraintes couplees\n",
+    "\n",
+    "**Enonce** : dans le solveur CSP, les contraintes sont posees independamment pour chaque cellule revelee. Cependant, on peut renforcer le modele en ajoutant une **contrainte globale** : le nombre total de mines dans la grille est connu.\n",
+    "\n",
+    "Implementez cette contrainte globale dans `CSPSolver.build_csp()` et mesurez l'impact sur le nombre de solutions et le taux de victoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e6a64f44",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:12.832865Z",
+     "iopub.status.busy": "2026-04-22T18:08:12.832392Z",
+     "iopub.status.idle": "2026-04-22T18:08:13.058964Z",
+     "shell.execute_reply": "2026-04-22T18:08:13.058203Z"
+    },
+    "papermill": {
+     "duration": 0.239269,
+     "end_time": "2026-04-22T18:08:13.059671",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:12.820402",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lancement du benchmark sur 50 parties...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Resultats :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Taux de victoire (Standard) : 86.0%\n",
+      "Taux de victoire (Enhanced) : 88.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple resolu : solveur CSP avec contrainte globale\n",
+    "\n",
+    "class EnhancedCSPSolver(CSPSolver):\n",
+    "    def build_csp(self):\n",
+    "        problem, frontier = super().build_csp()\n",
+    "        if problem is None:\n",
+    "            return None, frontier\n",
+    "\n",
+    "        # Contrainte globale : si toutes les cases inconnues sont\n",
+    "        # dans la frontiere, on impose la somme exacte des mines.\n",
+    "        all_unknown = [\n",
+    "            (r, c)\n",
+    "            for r in range(self.board.rows)\n",
+    "            for c in range(self.board.cols)\n",
+    "            if (r, c) not in self.board.revealed\n",
+    "            and (r, c) not in self.board.flagged\n",
+    "        ]\n",
+    "\n",
+    "        if len(all_unknown) == len(frontier) and len(frontier) > 0:\n",
+    "            problem.addConstraint(\n",
+    "                ExactSumConstraint(self.board.remaining_mines()),\n",
+    "                list(frontier),\n",
+    "            )\n",
+    "\n",
+    "        return problem, frontier\n",
+    "\n",
+    "\n",
+    "# Benchmark pour comparer\n",
+    "N_GAMES_EX1 = 50\n",
+    "wins_std = 0\n",
+    "wins_enhanced = 0\n",
+    "\n",
+    "print(f\"Lancement du benchmark sur {N_GAMES_EX1} parties...\")\n",
+    "\n",
+    "for i in range(N_GAMES_EX1):\n",
+    "    seed = 4000 + i\n",
+    "\n",
+    "    # Test Standard\n",
+    "    random.seed(seed)\n",
+    "    np.random.seed(seed)\n",
+    "    b1 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
+    "    b1.reveal(4, 4)\n",
+    "    s1 = ProbabilisticSolver(b1)\n",
+    "    if s1.play_game():\n",
+    "        wins_std += 1\n",
+    "\n",
+    "    # Test Enhanced\n",
+    "    random.seed(seed)\n",
+    "    np.random.seed(seed)\n",
+    "    b2 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
+    "    b2.reveal(4, 4)\n",
+    "    original_csp = CSPSolver\n",
+    "    import __main__\n",
+    "    __main__.CSPSolver = EnhancedCSPSolver\n",
+    "    s2 = ProbabilisticSolver(b2)\n",
+    "    if s2.play_game():\n",
+    "        wins_enhanced += 1\n",
+    "    __main__.CSPSolver = original_csp\n",
+    "\n",
+    "print(\"\\nResultats :\")\n",
+    "print(f\"Taux de victoire (Standard) : {wins_std/N_GAMES_EX1:.1%}\")\n",
+    "print(f\"Taux de victoire (Enhanced) : {wins_enhanced/N_GAMES_EX1:.1%}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "300af637",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006919,
+     "end_time": "2026-04-22T18:08:13.073449",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.066530",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1b : comptage total des mines\n",
+    "\n",
+    "**Enonce** : au lieu d'ajouter une contrainte `ExactSumConstraint` quand toute\n",
+    "la frontiere est couverte, ajoutez systematiquement une contrainte sur le\n",
+    "**nombre total de mines** parmi toutes les cellules inconnues (meme celles\n",
+    "hors frontiere), des le premier appel a `build_csp`.\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Creez une classe `GlobalMineCountSolver(CSPSolver)` qui surcharge `build_csp`\n",
+    "2. Ajoutez une contrainte `ExactSumConstraint` sur toutes les variables inconnues\n",
+    "3. Lancez le meme benchmark que l'exemple et comparez les taux de victoire\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "475850e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:13.088639Z",
+     "iopub.status.busy": "2026-04-22T18:08:13.088340Z",
+     "iopub.status.idle": "2026-04-22T18:08:13.092289Z",
+     "shell.execute_reply": "2026-04-22T18:08:13.091200Z"
+    },
+    "papermill": {
+     "duration": 0.012752,
+     "end_time": "2026-04-22T18:08:13.092983",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.080231",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1b : contrainte globale systematique\n",
+    "\n",
+    "# TODO: creez la classe GlobalMineCountSolver et lancez le benchmark\n",
+    "# Indice : ajoutez ExactSumConstraint sur toutes les variables inconnues,\n",
+    "# pas seulement celles de la frontiere\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-42",
+   "metadata": {
+    "id": "cell-42",
+    "papermill": {
+     "duration": 0.006321,
+     "end_time": "2026-04-22T18:08:13.105859",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.099538",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : garantie du premier clic\n",
+    "\n",
+    "**Enonce** : dans notre implementation, `safe_cell` empeche de placer des mines sur la cellule cliquee et ses voisines. Mais certains jeux ne generent les mines qu'**apres** le premier clic.\n",
+    "\n",
+    "Modifiez `MinesweeperBoard` pour supporter une generation differee : le plateau est cree vide, et les mines ne sont placees qu'au premier appel a `reveal()`, en excluant la cellule cliquee et ses voisines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "bfe73ad6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:13.119224Z",
+     "iopub.status.busy": "2026-04-22T18:08:13.118976Z",
+     "iopub.status.idle": "2026-04-22T18:08:13.216191Z",
+     "shell.execute_reply": "2026-04-22T18:08:13.215289Z"
+    },
+    "papermill": {
+     "duration": 0.10491,
+     "end_time": "2026-04-22T18:08:13.216865",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.111955",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avant reveal : 0 mines\n",
+      "Apres reveal : 10 mines\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAJOCAYAAACtLO3jAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPolJREFUeJzt3Ql4FFW6//E3JCREQqIhoIQtCiibBhRUFEcUEFcEEb0alrjdy4C7qOO4EHQQvC4DowyoKBlFxBFBAldWoyAKAjIZESTsBCMhKEsMgQRI/Z/3+O+eTtIhIUC6T+r7eZ560l1dqa6tu391zqlTIY7jOAIAAGChWoFeAAAAgKoiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIANUsISFBQkJCzPDll19au7zdunXzjk9NTS3xP7/88osMGTLE/G9YWJiZRh97bNu2Te68805p0qSJhIaGmtd1fjXZgAEDzHrGxMTIvn37jvv/dZt5trcOvnzH63Q4OQYOHGi26RlnnCG//vormzVIEWRQJQsWLJBBgwbJueeeK/Xq1ZM6depI06ZNpXPnzvLII4/I559/7sotqz9QKSkp3sGt7r77bnnzzTdl+/btcvTo0RKvFRcXS9++feXDDz+U7Oxs87ymW7VqlUydOtU8Hjp0qJx++umBXiRrHD58WMaOHSsXXXSRREVFmaFTp04ybtw489rx+vrrr+Xmm2+WBg0aSEREhDRv3lz++7//W7KysspM+9RTT5kgo5/r559//iStEU62EO61hOOxe/duc2apQaYiBw8eNAHHTfRs+Oyzz/Y+93crM/1RO3TokHl8/vnnmzP0YKYlKRpI1BdffOEtOVmzZo3s37/fPNZA27BhQ/O4qKhITjvtNG+Aef3116VDhw7mWNAfoM2bN0vLli3Na1pa8/7775uSGd0Ouj1qot69e8vs2bPNj6JuSw39J/PYWrp0qfexnkzoD3RNoMfSDTfcIIsWLfL7eq9evcx2rV27dqXm984778h9993n93MZGxsr6enpkpiYWGJ8jx49zIlZeHi47Nixw3ucI4hokAEq4+DBg85FF12k3wDe4dZbb3U++OADJz093Zk9e7YzZswYp2vXruY1nd5Wv/32W5X+b+vWrSW2T03QvHlz7/p88cUXFU6/ffv2EtuguLi4xOuLFy/2vtasWbOg3I8n07Zt25xatWqZ9b3iiiuqPJ+aeGxV5IUXXvCub4MGDZz33nvPDA0bNvSOf/HFFys1r40bNzoRERHe/3vsscectLQ054YbbvCOa9OmjXPkyJES/zdp0iTv66NHjz5Fa4oT4Y5PA04KDSm+X6T6AS/Pv/71rzJfCL/++qvzzDPPOBdccIFTt25dp06dOk7btm2dESNGlPnBmTx5svd9rrzySueHH35wevfu7URHRzunnXaac91115kvptJO5D1WrFjh9OjRw6lXr55z+umnm2lWrlzpJCUlOe3bt3fi4uKcsLAwJyoqyklMTHSee+65EvPUefhun9KDJwQcKxhs3rzZGTJkiNOiRQvzpavroOvy7LPPOnv37i0xra6TZz6DBw92li5d6lx11VVm++h2uu2225xdu3Y5lZWRkeH07NnT/P8ZZ5zh3Hnnnc5PP/1U7vL6rq9uy4q2gS6j77xKD7o+HuvWrXPuuece5+yzzzbbQffJZZddZt6ndDDS+frO4/3333c6dOhg/u/mm2/2Trdjxw7noYcecs477zxzXOi2vfDCC53XXnvNKSoqKrM9Dhw44Lz00ktO586dzfuHh4c7LVu2dB555BEnNze30tv15Zdf9i6ffob82blzp/PEE084559/vve41XUfMGCAdx8eK8j4jtfpfG3atMkZOnSoWe/IyEizf/Xxfffd5xw6dKhS6/Dtt986//Vf/+U0adLEqV27tvl8dO/e3Zk1a1aZaUsfF++88445hnV/NGrUyPnTn/5U5rvBH53GN7BMmTLF+5o+9ow/66yzKjW/Rx991Ps/+jn3KCgoMPvX89qcOXPK7BvPa/q5R/AhyKDSWrduXeKH/3ho6NAvwfJ+xDQoaAjxFzL0y0+/3Ev/jwaUo0ePnpT3aNy4sfmS9zyPiYkx00yYMOGY4URLqA4fPnxSgsyXX35pQlJ5/68/bBos/AUZfU1DVun/6dWrV6X2z7///W+/763LGhsbW61BZubMmeaHvLzpNFj6hhnfINOqVasS03qCzLJly8yPb3nz1ADo+6O+e/duc7yUN70eL1u2bKnUtr3xxhv9bj8PDcv169cv9730pKCqQUZ/lDW4lDfv0uHYn/Hjx3tLlPwNTz31VInpfY+B0vvjeEo2NFj7/o+WbHmU3hbff/99hfPTcOuZPiUlpdxl1sBTmpYc6mshISElvkMQHAgyqBQ9Oz3WF9Hq1audr776qsTg+8VzySWXlPjR0B8rrYry/QIZOHCg35Chg545f/LJJ87YsWPNGaFn/Lx5807ae+iP09tvv+0sWLDAGTdunJnm66+/dl599VUzr0WLFpkfoo8//ticpXv+75///KeZVr9M9TXfefpuj3379pUbZLQaLj4+3jv+4osvdmbMmGGK0XW5POOvv/56v0FGBy1N0aLy0uPXr19f4f7t1q1bie2g76vbW0sIfOdVUZA51jbYsGGD+dH+29/+VuJs2vO6VklpSYdvoNLSKd3HWsriu930LN9fkNHh8ssvdz766CPn//7v/5wPP/zQBBTPD5EO/fr1M69Nnz7dlBR4xmupl4eWZnnG6w+gzmfu3Lnmfz3jK1tN5LvcvkFU6bIlJCR4X9cSiL/+9a/O/PnznXfffdfsU/1Br0qQ0W2pJXOe8eecc47z5ptvmnlrQNfPS0VBRktCPSFG/z799NPm86Hz0VI7z7w///xzv8eFDg888IDZ3loN7bvfK6LHv+98fIOmfl58X9PPZ0V8t8XEiRNLvHb77bd7X/MtxfPQEhzP63rCgeBCkEGl6Bew7xeH/uD7ateuXZmzrieffNK8tmbNGu84DSH6Rer58dIfE9/XPFU1viFDx/v+AFx77bXe1/RH8WS8h55paalEaVra8vrrr5sfR/3i9ndm6nsGV5l2DP6CjBbRe8ZpFcbPP/9c4qzadzk9VQ2+gUWrvbSI3F/pmYabY9HSB99l9q0u0Cqe4wkyldkGOg/Pa7otfOm29rymJSK+QVB/RD2vXXrppX6DjIaw0m2zNMz6trNYsmSJd56+76clf0p/3ENDQ73jp06d6p1el903SFcmJPqWiJReNt99q8eWnhCU53iDzBtvvOEdp+GwdIiqDG1H4pmH/pj77o+7777b+5pWO/k7LnyDd05OTonlzMvLO+Z7a3j1nd63FE5LYn1f02kr4rtPNST60hMcz2taZVaab7D1nLggeIQFurEx7FD6ctHj6VNh3bp13sd6uaReaeCPvpaZmWkus/TVunVrady4sfd5/fr1vY/37NlzUt5Dr6K54IIL/F5GrFfVHMvevXvlRK1fv977uEWLFtKoUSPv865du3of62+WLn/pKye6dOkikZGRx9xG5dGriErPy6NNmzamD42TsY6V4bsff/jhB7niiiv8Tqev+XP99deXuVLOd5561d0f/vAHv/+7c+dOc1zr9vC9ZFz7uymPLsd5550nlVX6ahnfZdMrkjp27Cgni++8L7nkkhKfoarMQ68cKu/qofL2R/fu3f0ek57jUrtuKE/dunVLPC8sLPTuW33sSy/JrojOLy8vz+//+z73Ny9/VzkheNCPDCpFvwR8v7AXLlxY5otMP+xXXnnlCW3R/Px8v5dF+tJLdk/kC8bfe/gGBw/t48Q3xDz88MPmsvOvvvrK9KHjEQz9oJzsbRTs/O3D8vbjyZjviUyv/ZVUNlTaqrzt4Htc+h6TlTkuzznnnBLPc3JySoROXxr+K+I7P995lZ6fv3n57jcuvw4+BBlUWnJysvex9qswbdq0Sv2fntV7aKmBdi71/6s1Swz6ZVjVIHSi71G6p1SlfUb4nk3+9a9/lZ49e5oSEg05/tSqVfIjVdmQo6VOHloi4PtFqx14+S7n8ZQAVEbpL+7ly5eXKCmqrtKY0vvxsssu87sPPfvRH3/70XeezZo1M6Vy5c1TO0fTPnG0t2EPLQErb/rBgwdXuE6+fePovHy1bdvW+3jr1q3y73//u8z/VzWI+s7722+/lZ9//vm45+G77e64445y90d5JTInon379iVCg55AeCxZssT7+MwzzyyxruW5+uqr/c5L9+Pq1av9Tld6v+nxpcuF4ELVEirtoYceMuHF82WblJQkc+fOlZtuukni4uJMt/T+esfUL3LtpGvlypWmkzz9onjwwQdNp2Ba1K9f4NoRlf7ol1d0XZFT8R6+Z3Ba5TBq1CjTodv06dPL7blYz0D1y87z46Ph5+KLLzYB5/LLLy/3va655hqJj483PzbaCZj2fPvkk0+aL1ntXdTjuuuuO+lnhLrvNNwtXrzYPB82bJjp6E47tavu3kxvv/12+fOf/2zW+5tvvpFbb73VVO1oZ3kaHvUH5bPPPpM+ffrIiBEjKjVPDZ96HGgw1eNTqx21UzTdjnomrsFRS9patWolkydPNtWot9xyi3z88cfe6qrHH3/cVD9qQNYO7fSHVEOeb5VgebQDwTlz5pjHK1asKPFDqZ2taXjSeeqxee2115r9rQFCl00/b6NHjy7TSVtl3HbbbWZev/32mzfAP/HEE6aDQ+1cT9dVt+WxehnWkxftVVeXTXti1qqgG2+80XS499NPP5mqp7S0NLPPfE90TgYNk3osevbzo48+6v1cDR8+3DvdAw88UCJ4lteBo94y44033jCfL/0ueOyxx8xrf//73+XAgQPeEwrdB750P+i6qnbt2pWpIkMQCHQjHdhFG+xVdJmxv6tA9IqVY10aXfqS7tJ9vByr35BT8R4e2oix9Dy00aBeseJ5rsvjq0uXLn7/x+NELr/WvlDK60fGV3kNccujl/j6u8Rdr6LRS9Grq7Gv52qVY11+XXq/l3c8+Prmm2+Oefl16W2oV/wc6/Lr8pbdH70ay9NIXDuL9NdHi+8VQCfz8mttuO3brUBVLr/WRsPHuvy69P4/1rFX3nKWp7Cw0Ln66qvLfV9tgFy6D6Bj9dOkV1tpg3l/89J98N1335VZBr2wwTPNqFGjKlxmVD+qlnBctBhXz3JmzZplzvj07Ecb4GkX4doWQBuKalsSLfUYOXKk9//0bPf777+X5557zjRo1AZ1elanRf3a+FJLOyZOnHhCe+NUvMekSZPM+mgX+lplpY0m9SzWX/Gzh7ar0bP4YzVk9EfPmDMyMuR//ud/TGmQdomu76mlTc8884wp/tblOBX0FgJa3K4lBFoSoyUgWiqhpSLVfV8gLY3617/+Ze5/o6UgenxpGy19rKUBug/1fkXHQ49LvaWCntXrWbWuo25bbWCrJTZacuZb+qTHspaevPLKK3LppZea7aHHuJaa6fOnn35aPvnkk0q9tx5/2s2+p5qwdKmllthp1YyWMmi1hS6brrMum5Z66nueyK0R9JjS0gj9fOh8df5afXbvvfeWaCBeHi0V0epGXRZdFz0uo6OjTRVn//795b333jPHyqmg76Wlvq+99pr5TOuy66CPdZx+FkvfnsC3oXbpht96TOmNT/U40pIV/V8trdNtoZ+vCy+8sMwyaEmU0mnvueeeU7KeODHcawkATjG9v5YGFi2U0Oqdl156iW1+CuzatUvOOuss81gDamXuCXcsa9euNScSut+0qlpvVIngQ4kMAJxi2rZKSzTUhAkTTFsbnHye9m9agvfWW2+d8PzGjBljQoyWSmpJL4ITJTIAgBpB+33SRszaQFkvToA7EGQAAIC1qFoCAADWIsgAAABrEWQAAIC1rO7ZV3ub1J5Qtb8Of12TAwAAO+kVY9oztfalVPr2LzUmyGiI0c6MAABAzaS3FzlWZ6BWBxlPz6lTpkwxPU66yaZNm8z9XrTnTr1XjhvXXTsY0x5G3UTDu97fhnVnv7sFx7w7P++eDg71nlgV9ZJudZDxVCdpiNEut91Eb4yo3XfrLQJOpAtzm9dde/DUmzS6id65mXVnv7sJx7w7v+t8VdR0hMa+AADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWCss0AsAO6SlRcjSpeGSkVFb1q8Pk6KiEO9rOTm7ArpsAAD3IsigUsaNqytr19ZmawEAggpBBpUSEiKSkHBEEhOPSG5uLVm2LJwtBwAIOIIMKmX27D0SGfn745dfrkuQAQAEBRr7olI8IQYAgGBCkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBb9yKBSUlMjZdu2UPN41aqSPfympER5HycnH5SEhKNsVQBAtSDIoFJmzapTbid4EyfW9T7u2bOQIAMAqDZULQEAAGtRIoNKmTlzL1sKABB0KJEBAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgraAIMuPHj5eEhASpU6eOXHLJJbJixYpALxIAALBAwIPMRx99JI8++qiMGDFCVq9eLYmJidKrVy/Jzc0N9KIBAIAgF/Ag89prr8l9990nd911l7Rt21YmTpwop512mrz77ruBXjQAABDkwgL55kVFRfLdd9/JU0895R1Xq1Yt6dGjhyxbtqzM9IWFhWbwyMvLM383bdokBw8eFDfJysoyfzds2CC7d+8WN657dna27N+/X9zEs69Zd/a7W3DMu/Pzrir72xbQIPPLL7/I0aNH5cwzzywxXp+vX7++zPSjR4+WkSNHlhm/ZMkSCQ8PF7cJCQmR9PR0cas1a9aIW7Hu7sR+dye37veioqLgDzLHS0tutD2Nb4lM06ZNpXfv3qaxsJtoSYyGmH79+kmDBg3EjevepUsXiYmJETfRMzP9UmPd2e9uwTHvzs+7ysnJkdTUVAnqIBMXFyehoaGya9euEuP1+VlnnVVm+oiICDP4m098fLy4schNQ4xb110/2LGxseImnuJl1p397hYc8+78vKuCggIJ+sa+Wh100UUXyeeff+4dV1xcbJ5rAgUAAAjqqiWtKho8eLB06tRJLr74Yhk7dqwcOHDAXMUEAAAQ1EHm9ttvN1UFzz33nKkP69Chg8ybN69MA2AAAICgCzLq/vvvNwMAAIBVHeIBAABUFUEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYK2wQC8Agt/O/J0yf/t8WfbzMsncmym5BbmSV5Qn0eHR0q5+O+l/bn8zhISEBHpRAQAuQ5BBhaZvnC6jvh1VZvyeQ3vkq+yvzDBnyxyZ3GuyhNYKZYsCAKoNVUuotIanNZQ7Wt8hf+r8J0lqnSR1Qut4X1uwfYFMy5zG1gQAVCtKZFChxlGN5Y2r35A+LftIWK3/HDJ9W/WVW2ff6n2enpUuSW2S2KIAgGpDkEGFbml1i9/xXRt3ldg6saaKSRUVF7E1AQDViqolVJmn0a9Hx4Yd2ZoAgGpFkEGVHCk+IsMXDzd/VVxknAxqO4itCQCoVgQZHLf8onwZNHeQaeCrompHyXvXvmfCDAAA1Yk2Mjgu2fnZMnDuQFn36zrzvH6d+jLl+ilUKwEAAoIgg0rLyM2QwfMGy66CXeZ5i5gW8sH1H0hCTAJbEQAQEFQtoVI+2/qZ9E3r6w0xlza6VOb0nUOIAQAEFCUyqFDa5jQZsmiIFDvF5rnemqBbk27y4foPS0yn4we0HcAWBQBUG4IMKpS5J9MbYpRecj1m5Zgy0zWJakKQAQBUK6qWAACAtSiRQYUe7/y4GQAACDaUyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALBWQIPMkiVL5KabbpL4+HgJCQmRTz/9NJCLAwAALBPQIHPgwAFJTEyU8ePHB3IxAACApcIC+ebXXXedGQAAAKwLMsersLDQDB55eXnm76ZNm+TgwYPiJllZWebvhg0bZPfu3eLGdc/Ozpb9+/eLm3j2NevOfncLjnl3ft5VZX/bQhzHcSQIaBuZmTNnSp8+fcqdJiUlRUaOHFlmfHJysoSHh4vb6DYLkt0HAMBJVVRUJKmpqSbERUdH14wg469EpmnTpjJjxgxJSEgQN9GSmPT0dOnXr580aNBA3LjuXbp0kZiYGHETPTNbs2YN685+dw2OeXd+3lVOTo4MHTq0wiBjVdVSRESEGUqLi4szVz65iafITUOMW9ddP9ixsbHiJp7iZdad/e4WHPPu/LyrgoICqQz6kQEAANYKaIlMfn6+aajrsXXrVsnIyDDJs1mzZoFcNAAAYIGABplVq1bJVVdd5X3+6KOPmr+DBw82DXwAAACCNsh069aNq24AAECV0UYGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZYoBcAwW9n/k6Zv32+LPt5mWTuzZTcglzJK8qT6PBoaVe/nfQ/t78ZQkJCAr2oAACXIcigQtM3TpdR344qM37PoT3yVfZXZpizZY5M7jVZQmuFskUBANWGqiVUWsPTGsodre+QP3X+kyS1TpI6oXW8ry3YvkCmZU5jawIAqhUlMqhQ46jG8sbVb0ifln0krNZ/Dpm+rfrKrbNv9T5Pz0qXpDZJbFEAQLUhyKBCt7S6xe/4ro27SmydWFPFpIqKi9iaAIBqRdUSqszT6NejY8OObE0AQLUiyKBKjhQfkeGLh5u/Ki4yTga1HcTWBABUK4IMjlt+Ub4MmjvINPBVUbWj5L1r3zNhBgCA6kQbGRyX7PxsGTh3oKz7dZ15Xr9OfZly/RSqlQAAAUGQQaVl5GbI4HmDZVfBLvO8RUwL+eD6DyQhJoGtCAAICKqWUCmfbf1M+qb19YaYSxtdKnP6ziHEAAACihIZVChtc5oMWTREip1i81xvTdCtSTf5cP2HJabT8QPaDmCLAgCqDUEGFcrck+kNMUovuR6zckyZ6ZpENSHIAACqFVVLAADAWpTIoEKPd37cDAAABBtKZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFgroEFm9OjR0rlzZ6lXr540bNhQ+vTpI5mZmYFcJAAAYJGABpnFixfLsGHDZPny5bJw4UI5fPiwXHPNNXLgwIFALhYAALBEWCDffN68eSWep6ammpKZ7777Tv7whz8EbLkAAIAdAhpkStu/f7/5Gxsb6/f1wsJCM3jk5eWZv5s2bZKDBw+Km2RlZZm/GzZskN27d4sb1z07O9t7zLiFZ1+z7ux3t+CYd+fnXVX2ty3EcRxHgkBxcbH07t1b9u3bJ0uXLvU7TUpKiowcObLM+OTkZAkPDxe3CQkJkSDZfdWOdXfnfgfgHkVFRaamRkNcdHR08AeZP/7xjzJ37lwTYpo0aVLpEpmmTZvKjBkzJCEhQdxES2LS09OlX79+0qBBA3ET1t3d+71Lly4SExMjbqJn5GvWrGHd2e+ukpOTI0OHDq0wyARF1dL9998vc+bMkSVLlpQbYlRERIQZSouLi5P4+HhxY5Gb/pix7u7BfhcTYsqrfq6pPNUKrDv73U0KCgoqNV1Ag4wWBj3wwAMyc+ZM+fLLL+Xss88O5OIAAADLBDTI6KXXU6dOlVmzZpm+ZLQYyXPWERkZGchFAwAAFghoPzITJkwwRabdunWTRo0aeYePPvookIsFAAAsEfCqJQAAgKriXksAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWmGBXgDYIS0tQpYuDZeMjNqyfn2YFBWFeF/LydklNdXO/J0yf/t8WfbzMsncmym5BbmSV5Qn0eHR0q5+O+l/bn8zhIT8Z3vUJG5ffwDBjyCDShk3rq6sXVvbdVtr+sbpMurbUWXG7zm0R77K/soMc7bMkcm9JktorVCpady+/gCCH0EGlaIn3AkJRyQx8Yjk5taSZcvCXbXlGp7WULo36y7N6zWXHb/tkE82fiKHjh4yry3YvkCmZU6TpDZJUlO5ff0BBC+CDCpl9uw9Ehn5++OXX67rmiDTOKqxvHH1G9KnZR8Jq/Wfj0vfVn3l1tm3ep+nZ6XXyB9yt68/gOBHkEGleEKM29zS6ha/47s27iqxdWJNFYsqKi6Smsjt6w8g+HHVElAFnkavHh0bdnTVdnT7+gMIHgQZ4DgdKT4iwxcPN39VXGScDGo7yDXb0e3rDyC4EGSA45BflC+D5g4yDVxVVO0oee/a98yPuRu4ff0BBB/ayACVlJ2fLQPnDpR1v64zz+vXqS9Trp/immoVt68/gOBEkAEqISM3QwbPGyy7Cn7v/K9FTAv54PoPJCEmwRXbz+3rDyB4UbUEVOCzrZ9J37S+3h/xSxtdKnP6znHNj7jb1x9AcKNEBpWSmhop27b93nPrqlUle/hNSYnyPk5OPigJCUdrzFZN25wmQxYNkWKn2DzXrvm7NekmH67/sMR0On5A2wFS07h9/QEEP4IMKmXWrDrldoI3cWJd7+OePQtrVJDJ3JPp/RFXesnxmJVjykzXJKpJjfwhd/v6Awh+VC0BAABrUSKDSpk5c68rt9TjnR83g1u5ff0BBD9KZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAA9waZQ4cOnZwlAQAAqI4gU1xcLC+88II0btxYoqKiZMuWLWb8s88+K++8805VZgkAAFA9QeYvf/mLpKamyv/+7/9KePh/biTYvn17mTRpUlVmCQAAUD1B5r333pO33npLkpKSJDQ01Ds+MTFR1q9fX5VZAgAAVE+Qyc7OlpYtW/qtcjp8+HBVZgkAAFA9QaZt27by1VdflRk/ffp06dixY1VmCQAAcNzCjv9fRJ577jkZPHiwKZnRUpgZM2ZIZmamqXKaM2dOVWYJAABQPSUyN998s8yePVsWLVokdevWNcHmxx9/NON69uxZlVkCAABUT4mMuuKKK2ThwoVV/XcAAIDABRlVVFQkubm5pnrJV7NmzU50uQAAAE5NkNm4caPcfffd8s0335QY7ziOhISEyNGjR6syWwAAgFMfZJKTkyUsLMw07G3UqJEJLwAAAFYEmYyMDPnuu++kdevWJ/TmEyZMMMO2bdvM83bt2pmGw9ddd90JzRcAALhDlfuR+eWXX074zZs0aSJjxowxoWjVqlVy9dVXmyui1q5de8LzBgAANV+VgsxLL70kTzzxhHz55Zfy66+/Sl5eXomhsm666Sa5/vrrpVWrVnLuuefKqFGjzE0oly9fXpXFAgAALlOlqqUePXqYv927dz9pjX31fz7++GM5cOCAdOnSpSqLBQAAXKZKQeaLL744aQuwZs0aE1wOHTpkSmNmzpxpqq78KSwsNIOHp/Rn06ZNcvDgQXGTrKws83fDhg2ye/ducRPW3d37XXsU379/v7iJZ1+z7ux3N9ldye+4EEeLUQJI+6LRLyj9YtJ7NU2aNEkWL17sN8ykpKTIyJEj/V5FFR4eLm6jpV8B3n0Bw7q7c78DcI+ioiJJTU01+SA6OvrkBpnvv//e/8xCQqROnTqmQ7yIiAiparVVixYt5M0336xUiUzTpk3NvZ4SEhLETfSMPD09Xfr16ycNGjQQN2Hd3b3ftQQ3JiZG3ERLYjyl16y7e7h5v6ucnBwZOnRohUGmSlVLHTp0OGbfMbVr15bbb7/dhBENNsdDewn2DSu+NBz5C0hxcXESHx8vbixy0x8z1t092O9ivtBjY2PFTTxVaaw7+91NCgoKTt1VS9qORa80euutt0yfMjro4/POO0+mTp0q77zzjjlzeuaZZ445n6eeekqWLFli+pHR1KnP9UqopKSkqiwWAABwmSqVyOhl0uPGjZNevXp5x51//vmmX5hnn31WVqxYYe6K/dhjj8krr7xS7nz0Pk2DBg2SnTt3mjONCy64QObPn88dtAEAwKkLMlp60rx58zLjdZy+5ql+0oByLFpyAwAAUFVVqlrSWxNoj7zaotjj8OHDZpzntgXaSOnMM8+s8oIBAACckhKZ8ePHS+/evU1VklYHKS2J0U7t9EaSasuWLaa1MQAAQFAFmcsuu0y2bt0qH3zwgbkkUvXv31/uvPNOqVevnnk+cODAk7ukAAAAJyPIKA0sQ4YMqeq/AwAAVF+QSUtLk+uuu870EaOPj0WrnQAAAIImyPTp08f0stewYUPzuDxVvWkkAADAKQsy2uOuv8e+duzYIc8///xxLwQAAEC1XX5dnj179si77757MmcJAABQPUEGAACgOhFkAACAtQgyAADAHf3I3HLLLcd8fd++fSe6PAAAAKcmyOgdqit6Xe9mDQAAEHRBZvLkyaduSQAAAI4TbWQAAIC1CDIAAMBaBBkAAOC+u18DqPnS0iJk6dJwycioLevXh0lRUYj3tZycXQFdNgBQBBkA5Ro3rq6sXVubLQQgaBFkAJQrJEQkIeGIJCYekdzcWrJsWThbC0BQIcgAKNfs2XskMvL3xy+/XJcgAyDo0NgXQLk8IQYAghVBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWvQjA6BcqamRsm1bqHm8alXJHn5TUqK8j5OTD0pCwlG2JIBqR5ABUK5Zs+qU2wnexIl1vY979iwkyAAICKqWAACAtSiRAVCumTP3snUABDVKZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALBW0ASZMWPGSEhIiDz88MOBXhQAAGCJoAgyK1eulDfffFMuuOCCQC8KAACwSMCDTH5+viQlJcnbb78tZ5xxRqAXBwAAWCTgQWbYsGFyww03SI8ePQK9KAAAwDJhgXzzadOmyerVq03VUmUUFhaawSMvL8/83bRpkxw8eFDcJCsry/zdsGGD7N69W9yEdXf3fs/Ozpb9+/eLm3j2NevOfneT3ZX8jgtxHMeRANixY4d06tRJFi5c6G0b061bN+nQoYOMHTvW7/+kpKTIyJEjy4xPTk6W8PBwcRttHB2g3RdwrLs79zsA9ygqKpLU1FRz4hIdHR18QebTTz+Vvn37SmhoqHfc0aNHzQ9UrVq1TMmL72vllcg0bdpUZsyYIQkJCeImekaenp4u/fr1kwYNGoibsO7u3u9dunSRmJiYQC9OtdKSmDVr1rDu7HdXycnJkaFDh1YYZAJWtdS9e3fzwfR11113SevWreXJJ58sE2JURESEGUqLi4uT+Ph4cWORm/6Yse7uwX4XE2JiY2PFTTxVaaw7+91NCgoKKjVdwIJMvXr1pH379iXG1a1bV+rXr19mPAAAQFBetQQAAGDlVUulffnll4FeBAAAYBFKZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1wgK9AECwS0uLkKVLwyUjo7asXx8mRUUh3tdycnZJTbYzf6fM3z5flv28TDL3ZkpuQa7kFeVJdHi0tKvfTvqf298MISH/2SYAUJ0IMkAFxo2rK2vX1nbldpq+cbqM+nZUmfF7Du2Rr7K/MsOcLXNkcq/JElorNCDLCMDdCDJABbSwISHhiCQmHpHc3FqybFm467ZZw9MaSvdm3aV5veay47cd8snGT+TQ0UPmtQXbF8i0zGmS1CYp0IsJwIUIMkAFZs/eI5GRvz9++eW6rgoyjaMayxtXvyF9WvaRsFr/+bro26qv3Dr7Vu/z9Kx0ggyAgCDIABXwhBg3uqXVLX7Hd23cVWLrxJoqJlVUXFTNSwYAv+OqJQDHzdPo16Njw45sRQABQZABcFyOFB+R4YuHm78qLjJOBrUdxFYEEBAEGQCVll+UL4PmDjINfFVU7Sh579r3TJgBgECgjQyASsnOz5aBcwfKul/Xmef169SXKddPoVoJQEARZABUKCM3QwbPGyy7Cn7vALBFTAv54PoPJCEmga0HIKCoWgJwTJ9t/Uz6pvX1hphLG10qc/rOIcQACAqUyAAVSE2NlG3bfu+1dtWqkj38pqREeR8nJx+UhISjNWp7pm1OkyGLhkixU2ye660JujXpJh+u/7DEdDp+QNsBAVpKAG5GkAEqMGtWnXI7wZs4sa73cc+ehTUuyGTuyfSGGKWXXI9ZOabMdE2imhBkAAQEVUsAAMBalMgAFZg5c69rt9HjnR83AwAEK0pkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZAg0xKSoqEhISUGFq3bh3IRQIAABYJC/QCtGvXThYtWuR9HhYW8EUCAACWCHhq0OBy1llnBXoxAACAhQLeRmbjxo0SHx8v55xzjiQlJUlWVlagFwkAAFgioCUyl1xyiaSmpsp5550nO3fulJEjR8oVV1whP/zwg9SrV6/M9IWFhWbwyMvLM383bdokBw8eFDfxBL4NGzbI7t27xU1Yd3fv9+zsbNm/f7+4iWdfs+7sdzfZXcnvuBDHcRwJEvv27ZPmzZvLa6+9Jvfcc4/fxsEadkpLTk6W8PBwcRttHB1Eu69auXndAcANioqKTGGHnrhER0fbEWRU586dpUePHjJ69OhKlcg0bdpUZsyYIQkJCeImekaenp4u/fr1kwYNGoibsO7p0qVLF4mJiRE30dKINWvWsO7sd9dw8zGvcnJyZOjQoRUGmYA39vWVn58vmzdvloEDB/p9PSIiwgylxcXFmXY2bixy0xDDurtvv+uXWmxsrLiJpzqJdWe/u4Wbj3lVUFAgQd/Yd/jw4bJ48WLZtm2bfPPNN9K3b18JDQ2VO+64I5CLBQAALBHQEpmffvrJhJZff/3VlCx07dpVli9f7rqqEgAAYGGQmTZtWiDfHgAAWC7g/cgAAABUFUEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsFZYoBcACHZpaRGydGm4ZGTUlvXrw6SoKMT7Wk7OroAuGwC4HUEGqMC4cXVl7drabCcACEIEGaACISEiCQlHJDHxiOTm1pJly8LZZgAQJAgyQAVmz94jkZG/P3755boEGQAIIjT2BSrgCTEAgOBDkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBb9yAAVSE2NlG3bQs3jVatK9vCbkhLlfZycfFASEo6yPQGgGhFkgArMmlWn3E7wJk6s633cs2chQQYAqhlVSwAAwFqUyAAVmDlzL9sIAIIUJTIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYK+BBJjs7WwYMGCD169eXyMhIOf/882XVqlWBXiwAAGCBsEC++d69e+Xyyy+Xq666SubOnSsNGjSQjRs3yhlnnBHIxQIAAJYIaJB56aWXpGnTpjJ58mTvuLPPPjuQiwQAACwS0KqltLQ06dSpk/Tv318aNmwoHTt2lLfffjuQiwQAACwS0BKZLVu2yIQJE+TRRx+VP//5z7Jy5Up58MEHJTw8XAYPHlxm+sLCQjN45OXlmb+bNm2SgwcPiptkZWWZvxs2bJDdu3eLm7Duv7ct279/v7iJ5zhn3dnvbuHmY15V9rctxHEcRwJEA4uWyHzzzTfecRpkNNAsW7aszPQpKSkycuTIMuOTk5PNvNwmJCREArj7AsrN6w4AblBUVCSpqakmxEVHRwdniUyjRo2kbdu2Jca1adNGPvnkE7/TP/XUU6b0xrdERtvY9O7dWxISEsRNtCQmPT1d+vXrZxpJuwnrni5dunSRmJgYcRM9K12zZg3rzn53DTcf8yonJ8cEmYoENMjoFUuZmZllfqSaN2/ud/qIiAgzlBYXFyfx8fHixiI3DTGsu/v2u36pxcbGipt4itZZd/a7W7j5mFcFBQUS9I19H3nkEVm+fLm8+OKLpp3L1KlT5a233pJhw4YFcrEAAIAlAhpkOnfuLDNnzpQPP/xQ2rdvLy+88IKMHTtWkpKSArlYAADAEgGtWlI33nijGQAAAKy7RQEAAEBVEWQAAIC1CDIAAMBaBBkAAGAtggwAALAWQQYAAFiLIAMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAa4UFegGAYJeWFiFLl4ZLRkZtWb8+TIqKQryv5eTsCuiyAYDbEWSACowbV1fWrq3NdgKAIESQASoQEiKSkHBEEhOPSG5uLVm2LJxtBgBBgiADVGD27D0SGfn745dfrkuQAYAgQmNfoAKeEAMACD4EGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAa9GPDFCB1NRI2bYt1DxetapkD78pKVHex8nJByUh4SjbEwCqEUEGqMCsWXXK7QRv4sS63sc9exYSZACgmlG1BAAArEWJDFCBmTP3so0AIEhRIgMAAKxFkAEAANYiyAAAAGsRZAAAgLUIMgAAwFoEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAACsRZABAADWIsgAAABrEWQAAIC1AhpkEhISJCQkpMwwbNiwQC4WAACwRFgg33zlypVy9OhR7/MffvhBevbsKf379w/kYgEAAEsENMg0aNCgxPMxY8ZIixYt5MorrwzYMgEAAHsETRuZoqIimTJlitx9992megkAACCoS2R8ffrpp7Jv3z5JTk4ud5rCwkIzeOzfv9/8zcrKErfJzs424W/btm2Sn58vbsK6F0lOTo4UFBSIm+zevdsc86w7+90t3HzMq127dpm/juPIsYQ4FU1RTXr16iXh4eEye/bscqdJSUmRkSNHVutyAQCAwNmxY4c0adIkuIPM9u3b5ZxzzpEZM2bIzTffXOkSGS3Bad68uSmRiYmJETfJy8uTpk2bmh0cHR0tbsK6s9855t2Dz7s7P+9K48lvv/0m8fHxUqtWreCuWpo8ebI0bNhQbrjhhmNOFxERYYbSNMS4cScrXW/W3X3Y73ze3YZj3p3HfEwlCikC3ti3uLjYBJnBgwdLWFhQ5CoAAGCJgAeZRYsWmaohvVoJAADgeAS8COSaa66psEVyebSaacSIEX6rm2o61p397jYc8xzzbuPmY/54BEVjXwAAACurlgAAAKqKIAMAAKxFkAEAANayOsiMHz9eEhISpE6dOnLJJZfIihUrpKZbsmSJ3HTTTaaDIL0nld7awS1Gjx4tnTt3lnr16pl+h/r06SOZmZniBhMmTJALLrjA25dGly5dZO7cueJGenNZPfYffvhhqem0N3NdV9+hdevW4qbbkQwYMEDq168vkZGRcv7558uqVaukptPftdL7XYdhw4YFetGCkrVB5qOPPpJHH33UtOhevXq1JCYmmtsc5ObmSk124MABs64a4txm8eLF5oO8fPlyWbhwoRw+fNhc9abbpKbT7rn1B/y7774zX+RXX3216QV77dq14iYrV66UN99804Q6t2jXrp3s3LnTOyxdulTcYO/evXL55ZdL7dq1TWhft26dvPrqq3LGGWeIG45z332u33eqf//+gV604ORY6uKLL3aGDRvmfX706FEnPj7eGT16tOMWuvtmzpzpuFVubq7ZBosXL3bc6IwzznAmTZrkuMVvv/3mtGrVylm4cKFz5ZVXOg899JBT040YMcJJTEx03OjJJ590unbtGujFCAp6rLdo0cIpLi4O9KIEJStLZPRuoHpm2qNHD+84vQ+DPl+2bFlAlw3Vx3P389jYWFdt9qNHj8q0adNMSZRWMbmFlsbpbUx8P/dusHHjRlOVrPejS0pKMh2IukFaWpp06tTJlEJoVXLHjh3l7bffFrfR37spU6aYTmO1egllWRlkfvnlF/NlfuaZZ5YYr8/1dueo+fTWFtpGQoue27dvL26wZs0aiYqKMp1jDRkyRGbOnClt27YVN9DgplXI2k7KTbTtX2pqqsybN8+0k9q6datcccUV5kZ6Nd2WLVvMOrdq1Urmz58vf/zjH+XBBx+Uf/zjH+Im2g5Sb5CcnJwc6EUJWgHv2Reo6tn5Dz/84Jr2Auq8886TjIwMUxI1ffp0c38ybTdU08OM3vn3oYceMu0EtGG/m1x33XXex9ouSINN8+bN5Z///Kfcc889UtNPVrRE5sUXXzTPtURGP/MTJ040x75bvPPOO+Y40FI51KASmbi4OAkNDZVdu3aVGK/PzzrrrIAtF6rH/fffL3PmzJEvvvjCNIJ1i/DwcGnZsqVcdNFFpmRCG32PGzdOajqtRtZG/BdeeKG5sawOGuD+9re/mcdaOusWp59+upx77rmyadMmqekaNWpUJqS3adPGNVVravv27eZ+hPfee2+gFyWo1bL1C12/zD///PMS6V2fu6nNgNto+2YNMVqlkp6eLmeffba4mR7zhYWFUtN1797dVKtpaZRn0DN1bS+ij/Wkxi3y8/Nl8+bN5ke+ptNq49LdK2zYsMGUSLnF5MmTTfsgbRuGGli1pJdea/GifqFdfPHFMnbsWNP48a677pKa/kXmezamdeb6Za4NXps1ayY1vTpp6tSpMmvWLNOXjKc9VExMjOljoiZ76qmnTPGy7mNtH6Hb4csvvzRtB2o63del20HVrVvX9C1S09tHDR8+3PQbpT/eP//8s+luQoPbHXfcITXdI488IpdddpmpWrrttttMP2FvvfWWGdxyoqJBRn/ntOQRx+BY7PXXX3eaNWvmhIeHm8uxly9f7tR0X3zxhbnkuPQwePBgp6bzt946TJ482anp7r77bqd58+bmWG/QoIHTvXt3Z8GCBY5bueXy69tvv91p1KiR2e+NGzc2zzdt2uS4xezZs5327ds7ERERTuvWrZ233nrLcYv58+eb77fMzMxAL0rQ4+7XAADAWla2kQEAAFAEGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAIJCSkqKdOjQIdCLAcAyBBkAJ4Xe++qBBx6Qc845RyIiIqRp06bmPkG+N3cFgJONO1EBOGHbtm0zdys+/fTT5eWXX5bzzz9fDh8+bG5qqTf7XL9+PVsZwClBiQyAEzZ06FAJCQkxdyju16+fnHvuudKuXTtzl/rly5ebabKysuTmm2+WqKgoiY6ONnc03rVr1zHv/vv8889LkyZNTAmPVjvNmzevRHjS95wxY4ZcddVVctppp0liYqIsW7bMO01qaqoJVxqo2rRpY9772muvlZ07d5Z4r0mTJpnX69SpI61bt5a///3vHBWAJQgyAE7Inj17TMDQkpe6deuWeV2DhIYSDTE67eLFi2XhwoWyZcsWuf3228ud77hx4+TVV1+VV155Rb7//nvp1auX9O7dWzZu3FhiuqefflqGDx8uGRkZJkDdcccdcuTIEe/rBQUFZh7vv/++LFmyxAQqnd7jgw8+kOeee05GjRolP/74o7z44ovy7LPPyj/+8Q+ODMAGgb79NgC7ffvtt45+lcyYMaPcaRYsWOCEhoY6WVlZ3nFr1641/7dixQrzfMSIEU5iYqL39fj4eGfUqFEl5tO5c2dn6NCh5vHWrVvN/0+aNKnMPH/88UfzfPLkyeb5pk2bvNOMHz/eOfPMM73PW7Ro4UydOrXE+7zwwgtOly5dqrQ9AFQvSmQAnOjJUIXTaEmHNv7VwaNt27amtEZfKy0vL09+/vln0+7Glz4vPf0FF1zgfdyoUSPzNzc31ztOq5xatGhRYhrP6wcOHJDNmzfLPffcY6qdPMNf/vIXMx5A8KOxL4AT0qpVK9NWJVANemvXru19rMuhtCrL3+ueaTzhKz8/3/x9++235ZJLLikxXWho6CldbgAnByUyAE5IbGysab8yfvx4U8JR2r59+0xD2h07dpjBY926deY1LZkpTRsDx8fHy9dff11ivD73N31VnXnmmeZ9tL1Oy5YtSwxnn332SXsfAKcOJTIATpiGGK32ufjii82VRlrdow1utVHvhAkTTGjRS7KTkpJk7Nix5jW90unKK6+UTp06+Z3n448/LiNGjDDVQnrF0uTJk02DXm2cezKNHDlSHnzwQYmJiTFXNBUWFsqqVatk79695qorAMGNIAPghGkneKtXrzZX/jz22GPm8uYGDRrIRRddZIKMVufMmjXLdJj3hz/8QWrVqmVCw+uvv17uPDVc7N+/38xP27RoSUxaWpqpyjqZ7r33XtOORvu/0fCkV15p6Hr44YdP6vsAODVCtMXvKZo3AADAKUUbGQAAYC2CDAAAsBZBBgAAWIsgAwAArEWQAQAA1iLIAAAAaxFkAACAtQgyAADAWgQZAABgLYIMAACwFkEGAABYiyADAADEVv8P0KzQ+qvuBnkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Exemple resolu : generation differee des mines\n",
+    "\n",
+    "class LazyMinesweeperBoard(MinesweeperBoard):\n",
+    "    def __init__(self, rows=8, cols=8, n_mines=10):\n",
+    "        self.rows = rows\n",
+    "        self.cols = cols\n",
+    "        self.n_mines = n_mines\n",
+    "        self.revealed = set()\n",
+    "        self.flagged = set()\n",
+    "        self.game_over = False\n",
+    "        self.won = False\n",
+    "        self.mines_placed = False\n",
+    "        self.mines = set()\n",
+    "        self.numbers = np.zeros((rows, cols), dtype=int)\n",
+    "\n",
+    "    def _place_mines(self, safe_cell):\n",
+    "        all_cells = [(r, c) for r in range(self.rows)\n",
+    "                     for c in range(self.cols)]\n",
+    "        excluded = {safe_cell}\n",
+    "        excluded.update(self.get_neighbors(*safe_cell))\n",
+    "\n",
+    "        candidates = [cell for cell in all_cells\n",
+    "                      if cell not in excluded]\n",
+    "        self.mines = set(\n",
+    "            random.sample(candidates, min(self.n_mines, len(candidates)))\n",
+    "        )\n",
+    "\n",
+    "        self.numbers = np.zeros((self.rows, self.cols), dtype=int)\n",
+    "        for r in range(self.rows):\n",
+    "            for c in range(self.cols):\n",
+    "                if (r, c) not in self.mines:\n",
+    "                    self.numbers[r, c] = sum(\n",
+    "                        1 for nr, nc in self.get_neighbors(r, c)\n",
+    "                        if (nr, nc) in self.mines\n",
+    "                    )\n",
+    "        self.mines_placed = True\n",
+    "\n",
+    "    def reveal(self, r, c):\n",
+    "        if not self.mines_placed:\n",
+    "            self._place_mines((r, c))\n",
+    "        return super().reveal(r, c)\n",
+    "\n",
+    "\n",
+    "# Test de la generation differee\n",
+    "random.seed(42)\n",
+    "board_lazy = LazyMinesweeperBoard(8, 8, 10)\n",
+    "print(\"Avant reveal :\", len(board_lazy.mines), \"mines\")\n",
+    "board_lazy.reveal(0, 0)\n",
+    "print(\"Apres reveal :\", len(board_lazy.mines), \"mines\")\n",
+    "draw_board(board_lazy, title=\"Generation differee (clic en 0,0)\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d9daad3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007172,
+     "end_time": "2026-04-22T18:08:13.230968",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.223796",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2b : zone de securite configurable\n",
+    "\n",
+    "**Enonce** : modifiez `MinesweeperBoard` pour que la zone de securite lors du\n",
+    "premier clic soit configurable : au lieu d'exclure les 8 voisins, l'utilisateur\n",
+    "choisit le rayon d'exclusion.\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Creez une classe `ConfigurableSafeBoard(MinesweeperBoard)` avec un parametre\n",
+    "   `safe_radius` (par defaut 1 = voisins directs, 0 = seule la case cliquee)\n",
+    "2. Generez les mines apres le premier clic, en excluant toutes les cases dans\n",
+    "   le rayon donne\n",
+    "3. Testez avec `safe_radius=2` sur une grille 10x10, 15 mines, premier clic en (5,5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "1001739b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:13.245623Z",
+     "iopub.status.busy": "2026-04-22T18:08:13.245266Z",
+     "iopub.status.idle": "2026-04-22T18:08:13.249355Z",
+     "shell.execute_reply": "2026-04-22T18:08:13.248550Z"
+    },
+    "papermill": {
+     "duration": 0.012718,
+     "end_time": "2026-04-22T18:08:13.250029",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.237311",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2b : zone de securite configurable\n",
+    "\n",
+    "# TODO: creez la classe ConfigurableSafeBoard avec safe_radius\n",
+    "# Indice : get_neighbors fonctionne en rayon 1,\n",
+    "# pour rayon > 1 il faut iterer les offsets (dr, dc) avec max(|dr|,|dc|) <= radius\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-45",
+   "metadata": {
+    "id": "cell-45",
+    "papermill": {
+     "duration": 0.007557,
+     "end_time": "2026-04-22T18:08:13.264012",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.256455",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : scalabilite sur 16x16\n",
+    "\n",
+    "**Enonce** : testez le solveur probabiliste sur un plateau 16x16 avec 40 mines (difficulte \"intermediaire\" standard). Mesurez :\n",
+    "- Le taux de victoire sur 30 parties\n",
+    "- Le temps moyen par partie\n",
+    "- Le nombre moyen de devinettes\n",
+    "\n",
+    "Comparez avec les resultats 8x8 et commentez la scalabilite."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "89b7fc75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:13.279121Z",
+     "iopub.status.busy": "2026-04-22T18:08:13.278896Z",
+     "iopub.status.idle": "2026-04-22T18:08:15.520926Z",
+     "shell.execute_reply": "2026-04-22T18:08:15.519997Z"
+    },
+    "papermill": {
+     "duration": 2.251267,
+     "end_time": "2026-04-22T18:08:15.521676",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:13.270409",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16x16 (40 mines) :\n",
+      "  Victoires : 25/30\n",
+      "  Temps moyen : 74 ms\n",
+      "  Devinettes moyennes : 0.8\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exemple resolu : benchmark 16x16\n",
+    "\n",
+    "N_GAMES_16 = 30\n",
+    "wins_16 = 0\n",
+    "total_time_16 = 0\n",
+    "total_guesses_16 = 0\n",
+    "\n",
+    "for game_id in range(N_GAMES_16):\n",
+    "    random.seed(3000 + game_id)\n",
+    "    np.random.seed(3000 + game_id)\n",
+    "    board_16 = MinesweeperBoard(16, 16, 40, safe_cell=(8, 8))\n",
+    "    board_16.reveal(8, 8)\n",
+    "    solver_16 = ProbabilisticSolver(board_16)\n",
+    "    start = time.time()\n",
+    "    won = solver_16.play_game()\n",
+    "    total_time_16 += time.time() - start\n",
+    "    if won:\n",
+    "        wins_16 += 1\n",
+    "    total_guesses_16 += solver_16.decisions['guess']\n",
+    "\n",
+    "print(\"16x16 (40 mines) :\")\n",
+    "print(f\"  Victoires : {wins_16}/{N_GAMES_16}\")\n",
+    "print(f\"  Temps moyen : {total_time_16/N_GAMES_16*1000:.0f} ms\")\n",
+    "print(f\"  Devinettes moyennes : {total_guesses_16/N_GAMES_16:.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29df0b0f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006638,
+     "end_time": "2026-04-22T18:08:15.536088",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:15.529450",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3b : difficulte experte (30x16, 99 mines)\n",
+    "\n",
+    "**Enonce** : testez le solveur sur la difficulte \"experte\" du Demineur\n",
+    "(grille 30x16 avec 99 mines). Mesurez les memes indicateurs.\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Lancez 20 parties sur grille 30x16, 99 mines, premier clic au centre\n",
+    "2. Affichez le taux de victoire, le temps moyen et les devinettes moyennes\n",
+    "3. Comparez avec les resultats 8x8 et 16x16 obtenus plus haut\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "52f0ccbb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:08:15.551704Z",
+     "iopub.status.busy": "2026-04-22T18:08:15.551415Z",
+     "iopub.status.idle": "2026-04-22T18:08:15.554907Z",
+     "shell.execute_reply": "2026-04-22T18:08:15.553938Z"
+    },
+    "papermill": {
+     "duration": 0.013154,
+     "end_time": "2026-04-22T18:08:15.555559",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:15.542405",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3b : difficulte experte\n",
+    "\n",
+    "# TODO: lancez le benchmark 30x16 avec 99 mines\n",
+    "# Indice : utilisez le meme pattern que l'exemple 16x16\n",
+    "# avec MinesweeperBoard(30, 16, 99, safe_cell=(15, 8))\n",
+    "\n",
+    "# Votre code ici\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1UwVQOn1ah1L",
+   "metadata": {
+    "id": "1UwVQOn1ah1L",
+    "papermill": {
+     "duration": 0.006473,
+     "end_time": "2026-04-22T18:08:15.568672",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:15.562199",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Analyse de la scalabilit&eacute; : 8x8 vs 16x16\n",
+    "\n",
+    "En comparant les r&eacute;sultats obtenus pr&eacute;c&eacute;demment, nous pouvons observer l'impact de l'augmentation de la taille du plateau :\n",
+    "\n",
+    "| Param&egrave;tre | D&eacute;butant (8x8, 10 mines) | Interm&eacute;diaire (16x16, 40 mines) | Facteur d'augmentation |\n",
+    "| :--- | :--- | :--- | :--- |\n",
+    "| **Nombre de cases** | 64 | 256 | x4 |\n",
+    "| **Nombre de mines** | 10 | 40 | x4 |\n",
+    "| **Temps moyen** | ~15 ms | ~136 ms | **~x9** |\n",
+    "| **Taux de victoire** | ~87% | ~83% | L&eacute;g&egrave;re baisse |\n",
+    "| **Devinettes moy.** | ~0.6 | ~0.8 | Augmentation mod&eacute;r&eacute;e |\n",
+    "\n",
+    "#### Commentaires sur la scalabilit&eacute;\n",
+    "\n",
+    "1.  **Complexit&eacute; du CSP** : Le temps d'ex&eacute;cution augmente beaucoup plus vite que le nombre de cases. C'est une cons&eacute;quence directe de la **NP-compl&eacute;tude** : sur un plateau plus grand, la \"fronti&egrave;re\" des cellules inconnues est plus longue, ce qui augmente de mani&egrave;re exponentielle le nombre de combinaisons possibles que le solveur CSP doit &eacute;num&eacute;rer.\n",
+    "2.  **D&eacute;terminisme vs Chance** : Le taux de victoire reste &eacute;lev&eacute; car le solveur utilise toujours les probabilit&eacute;s optimales. Cependant, la probabilit&eacute; de rencontrer une configuration n&eacute;cessitant une devinette (comme un \"50/50\") augmente avec la taille du plateau, ce qui explique la l&eacute;g&egrave;re baisse du taux de victoire.\n",
+    "3.  **Limites** : Sur un plateau \"Expert\" (16x30, 99 mines), l'&eacute;num&eacute;ration compl&egrave;te des solutions CSP pourrait devenir trop lente, n&eacute;cessitant des techniques plus avanc&eacute;es comme le d&eacute;coupage de la fronti&egrave;re en sous-probl&egrave;mes ind&eacute;pendants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-48",
+   "metadata": {
+    "id": "cell-48",
+    "papermill": {
+     "duration": 0.006481,
+     "end_time": "2026-04-22T18:08:15.581391",
+     "exception": false,
+     "start_time": "2026-04-22T18:08:15.574910",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Recapitulatif\n",
+    "\n",
+    "### Resume des approches\n",
+    "\n",
+    "| Approche | Principe | Avantage | Limitation |\n",
+    "|----------|----------|----------|------------|\n",
+    "| **Regles simples** | Deductions locales (1 cellule a la fois) | Rapide, sans erreur | Se bloque sur les cas ambigus |\n",
+    "| **CSP** | Enumeration des solutions globales | Deduit des cellules invisibles aux regles | Cout exponentiel (NP-complet) |\n",
+    "| **CSP + probabilites** | Choix optimal sous incertitude | Maximise les chances de victoire | Ne garantit pas la victoire |\n",
+    "\n",
+    "### Concepts cles\n",
+    "\n",
+    "| Concept | Definition | Application au Demineur |\n",
+    "|---------|------------|------------------------|\n",
+    "| **NP-completude** | Pas d'algorithme polynomial connu | Le Demineur n'est pas resolvable en temps polynomial (Kaye, 2000) |\n",
+    "| **CSP** | Variables + domaines + contraintes | Cellules binaires + sommes = indices |\n",
+    "| **Cellule forcee** | Meme valeur dans toutes les solutions | Certitude absolue sans deviner |\n",
+    "| **Raisonnement probabiliste** | Compter les solutions favorables | Choisir le coup le moins risque |\n",
+    "| **Frontiere** | Zone entre le connu et l'inconnu | Seules les cellules adjacentes aux revelees sont pertinentes |\n",
+    "\n",
+    "### Et ensuite ?\n",
+    "\n",
+    "Ce notebook a presente le Demineur comme un CSP avec extension probabiliste. Voici des pistes pour aller plus loin :\n",
+    "\n",
+    "- **Approches SAT** : encoder le probleme comme une formule booleenne et utiliser un solveur SAT\n",
+    "- **Apprentissage profond** : entrainer un reseau convolutionnel pour predire les mines\n",
+    "- **Hybride LLM + CSP** : utiliser un LLM pour guider l'exploration dans les cas ambigus (voir le projet etudiant original)\n",
+    "- **Plateau hexagonal** : generaliser a d'autres topologies de grille\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Kaye, R. (2000). *Minesweeper is NP-complete*. Mathematical Intelligencer, 22(2), 9-15\n",
+    "- Becerra, D. J. (2015). *Algorithmic Approaches to Playing Minesweeper*. Harvard University\n",
+    "- Projet etudiant EPITA 2025 : jsboigeEpita/2025-PPC RDER-minesweeper"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.289641,
+   "end_time": "2026-04-22T18:08:15.849664",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-6-Minesweeper.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Applications\\CSP\\App-6-Minesweeper_output.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-04-22T18:08:06.560023",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/scripts/fix_app6_recycle.py
+++ b/scripts/fix_app6_recycle.py
@@ -1,0 +1,313 @@
+"""
+Fix App-6-Minesweeper: recycle student solutions into Exemple cells + new stubs.
+
+Part of Issue #463: recyclage App-1..App-11.
+"""
+
+import json
+
+
+def fix_app6():
+    path = "MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb"
+    with open(path, encoding="utf-8") as f:
+        nb = json.load(f)
+
+    # --- Ex1: EnhancedCSPSolver with global constraint (cell 42) ---
+    nb["cells"][42] = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exemple resolu : solveur CSP avec contrainte globale\n",
+            "\n",
+            "class EnhancedCSPSolver(CSPSolver):\n",
+            "    def build_csp(self):\n",
+            "        problem, frontier = super().build_csp()\n",
+            "        if problem is None:\n",
+            "            return None, frontier\n",
+            "\n",
+            "        # Contrainte globale : si toutes les cases inconnues sont\n",
+            "        # dans la frontiere, on impose la somme exacte des mines.\n",
+            "        all_unknown = [\n",
+            "            (r, c)\n",
+            "            for r in range(self.board.rows)\n",
+            "            for c in range(self.board.cols)\n",
+            "            if (r, c) not in self.board.revealed\n",
+            "            and (r, c) not in self.board.flagged\n",
+            "        ]\n",
+            "\n",
+            "        if len(all_unknown) == len(frontier) and len(frontier) > 0:\n",
+            "            problem.addConstraint(\n",
+            "                ExactSumConstraint(self.board.remaining_mines()),\n",
+            "                list(frontier),\n",
+            "            )\n",
+            "\n",
+            "        return problem, frontier\n",
+            "\n",
+            "\n",
+            "# Benchmark pour comparer\n",
+            "N_GAMES_EX1 = 50\n",
+            "wins_std = 0\n",
+            "wins_enhanced = 0\n",
+            "\n",
+            "print(f\"Lancement du benchmark sur {N_GAMES_EX1} parties...\")\n",
+            "\n",
+            "for i in range(N_GAMES_EX1):\n",
+            "    seed = 4000 + i\n",
+            "\n",
+            "    # Test Standard\n",
+            "    random.seed(seed)\n",
+            "    np.random.seed(seed)\n",
+            "    b1 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
+            "    b1.reveal(4, 4)\n",
+            "    s1 = ProbabilisticSolver(b1)\n",
+            "    if s1.play_game():\n",
+            "        wins_std += 1\n",
+            "\n",
+            "    # Test Enhanced\n",
+            "    random.seed(seed)\n",
+            "    np.random.seed(seed)\n",
+            "    b2 = MinesweeperBoard(8, 8, 10, safe_cell=(4, 4))\n",
+            "    b2.reveal(4, 4)\n",
+            "    original_csp = CSPSolver\n",
+            "    import __main__\n",
+            "    __main__.CSPSolver = EnhancedCSPSolver\n",
+            "    s2 = ProbabilisticSolver(b2)\n",
+            "    if s2.play_game():\n",
+            "        wins_enhanced += 1\n",
+            "    __main__.CSPSolver = original_csp\n",
+            "\n",
+            'print("\\nResultats :")\n',
+            'print(f"Taux de victoire (Standard) : {wins_std/N_GAMES_EX1:.1%}")\n',
+            'print(f"Taux de victoire (Enhanced) : {wins_enhanced/N_GAMES_EX1:.1%}")\n',
+        ],
+    }
+
+    # Insert new Ex1b: alternate constraint strategy
+    new_ex1b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 1b : comptage total des mines\n",
+            "\n",
+            "**Enonce** : au lieu d'ajouter une contrainte `ExactSumConstraint` quand toute\n",
+            "la frontiere est couverte, ajoutez systematiquement une contrainte sur le\n",
+            "**nombre total de mines** parmi toutes les cellules inconnues (meme celles\n",
+            "hors frontiere), des le premier appel a `build_csp`.\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Creez une classe `GlobalMineCountSolver(CSPSolver)` qui surcharge `build_csp`\n",
+            "2. Ajoutez une contrainte `ExactSumConstraint` sur toutes les variables inconnues\n",
+            "3. Lancez le meme benchmark que l'exemple et comparez les taux de victoire\n",
+        ],
+    }
+
+    new_ex1b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 1b : contrainte globale systematique\n",
+            "\n",
+            "# TODO: creez la classe GlobalMineCountSolver et lancez le benchmark\n",
+            "# Indice : ajoutez ExactSumConstraint sur toutes les variables inconnues,\n",
+            "# pas seulement celles de la frontiere\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(43, new_ex1b_md)
+    nb["cells"].insert(44, new_ex1b_code)
+
+    # After insertion, indices shifted by +2:
+    # Old cell 43 (md Ex2) -> 45
+    # Old cell 44 (code Ex2) -> 46
+    # Old cell 45 (md Ex3) -> 47
+    # Old cell 46 (code Ex3) -> 48
+
+    # --- Ex2: LazyMinesweeperBoard (now cell 46) ---
+    nb["cells"][46] = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exemple resolu : generation differee des mines\n",
+            "\n",
+            "class LazyMinesweeperBoard(MinesweeperBoard):\n",
+            "    def __init__(self, rows=8, cols=8, n_mines=10):\n",
+            "        self.rows = rows\n",
+            "        self.cols = cols\n",
+            "        self.n_mines = n_mines\n",
+            "        self.revealed = set()\n",
+            "        self.flagged = set()\n",
+            "        self.game_over = False\n",
+            "        self.won = False\n",
+            "        self.mines_placed = False\n",
+            "        self.mines = set()\n",
+            "        self.numbers = np.zeros((rows, cols), dtype=int)\n",
+            "\n",
+            "    def _place_mines(self, safe_cell):\n",
+            "        all_cells = [(r, c) for r in range(self.rows)\n",
+            "                     for c in range(self.cols)]\n",
+            "        excluded = {safe_cell}\n",
+            "        excluded.update(self.get_neighbors(*safe_cell))\n",
+            "\n",
+            "        candidates = [cell for cell in all_cells\n",
+            "                      if cell not in excluded]\n",
+            "        self.mines = set(\n",
+            "            random.sample(candidates, min(self.n_mines, len(candidates)))\n",
+            "        )\n",
+            "\n",
+            "        self.numbers = np.zeros((self.rows, self.cols), dtype=int)\n",
+            "        for r in range(self.rows):\n",
+            "            for c in range(self.cols):\n",
+            "                if (r, c) not in self.mines:\n",
+            "                    self.numbers[r, c] = sum(\n",
+            "                        1 for nr, nc in self.get_neighbors(r, c)\n",
+            "                        if (nr, nc) in self.mines\n",
+            "                    )\n",
+            "        self.mines_placed = True\n",
+            "\n",
+            "    def reveal(self, r, c):\n",
+            "        if not self.mines_placed:\n",
+            "            self._place_mines((r, c))\n",
+            "        return super().reveal(r, c)\n",
+            "\n",
+            "\n",
+            "# Test de la generation differee\n",
+            "random.seed(42)\n",
+            "board_lazy = LazyMinesweeperBoard(8, 8, 10)\n",
+            'print(\"Avant reveal :\", len(board_lazy.mines), \"mines\")\n',
+            "board_lazy.reveal(0, 0)\n",
+            'print(\"Apres reveal :\", len(board_lazy.mines), \"mines\")\n',
+            'draw_board(board_lazy, title="Generation differee (clic en 0,0)")\n',
+            "plt.show()\n",
+        ],
+    }
+
+    # Insert new Ex2b: safe zone variant
+    new_ex2b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 2b : zone de securite configurable\n",
+            "\n",
+            "**Enonce** : modifiez `MinesweeperBoard` pour que la zone de securite lors du\n",
+            "premier clic soit configurable : au lieu d'exclure les 8 voisins, l'utilisateur\n",
+            "choisit le rayon d'exclusion.\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Creez une classe `ConfigurableSafeBoard(MinesweeperBoard)` avec un parametre\n",
+            "   `safe_radius` (par defaut 1 = voisins directs, 0 = seule la case cliquee)\n",
+            "2. Generez les mines apres le premier clic, en excluant toutes les cases dans\n",
+            "   le rayon donne\n",
+            "3. Testez avec `safe_radius=2` sur une grille 10x10, 15 mines, premier clic en (5,5)\n",
+        ],
+    }
+
+    new_ex2b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 2b : zone de securite configurable\n",
+            "\n",
+            "# TODO: creez la classe ConfigurableSafeBoard avec safe_radius\n",
+            "# Indice : get_neighbors fonctionne en rayon 1,\n",
+            "# pour rayon > 1 il faut iterer les offsets (dr, dc) avec max(|dr|,|dc|) <= radius\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(47, new_ex2b_md)
+    nb["cells"].insert(48, new_ex2b_code)
+
+    # After insertion, indices shifted by +4 total from original:
+    # Old cell 45 (md Ex3) -> 49
+    # Old cell 46 (code Ex3) -> 50
+
+    # --- Ex3: 16x16 benchmark (now cell 50) ---
+    nb["cells"][50] = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exemple resolu : benchmark 16x16\n",
+            "\n",
+            "N_GAMES_16 = 30\n",
+            "wins_16 = 0\n",
+            "total_time_16 = 0\n",
+            "total_guesses_16 = 0\n",
+            "\n",
+            "for game_id in range(N_GAMES_16):\n",
+            "    random.seed(3000 + game_id)\n",
+            "    np.random.seed(3000 + game_id)\n",
+            "    board_16 = MinesweeperBoard(16, 16, 40, safe_cell=(8, 8))\n",
+            "    board_16.reveal(8, 8)\n",
+            "    solver_16 = ProbabilisticSolver(board_16)\n",
+            "    start = time.time()\n",
+            "    won = solver_16.play_game()\n",
+            "    total_time_16 += time.time() - start\n",
+            "    if won:\n",
+            "        wins_16 += 1\n",
+            "    total_guesses_16 += solver_16.decisions['guess']\n",
+            "\n",
+            'print("16x16 (40 mines) :")\n',
+            'print(f"  Victoires : {wins_16}/{N_GAMES_16}")\n',
+            'print(f"  Temps moyen : {total_time_16/N_GAMES_16*1000:.0f} ms")\n',
+            'print(f"  Devinettes moyennes : {total_guesses_16/N_GAMES_16:.1f}")\n',
+        ],
+    }
+
+    # Insert new Ex3b: expert difficulty 30x16
+    new_ex3b_md = {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+            "### Exercice 3b : difficulte experte (30x16, 99 mines)\n",
+            "\n",
+            "**Enonce** : testez le solveur sur la difficulte \"experte\" du Demineur\n",
+            "(grille 30x16 avec 99 mines). Mesurez les memes indicateurs.\n",
+            "\n",
+            "**Consignes** :\n",
+            "1. Lancez 20 parties sur grille 30x16, 99 mines, premier clic au centre\n",
+            "2. Affichez le taux de victoire, le temps moyen et les devinettes moyennes\n",
+            "3. Comparez avec les resultats 8x8 et 16x16 obtenus plus haut\n",
+        ],
+    }
+
+    new_ex3b_code = {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+            "# Exercice 3b : difficulte experte\n",
+            "\n",
+            "# TODO: lancez le benchmark 30x16 avec 99 mines\n",
+            "# Indice : utilisez le meme pattern que l'exemple 16x16\n",
+            "# avec MinesweeperBoard(30, 16, 99, safe_cell=(15, 8))\n",
+            "\n",
+            "# Votre code ici\n",
+        ],
+    }
+
+    nb["cells"].insert(51, new_ex3b_md)
+    nb["cells"].insert(52, new_ex3b_code)
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(nb, f, ensure_ascii=False, indent=1)
+
+    print(f"App-6 updated: {len(nb['cells'])} cells (was 49, +6 new cells)")
+
+
+if __name__ == "__main__":
+    fix_app6()
+    print("Done.")


### PR DESCRIPTION
## Summary
- Recycle 3 student solutions into labeled `# Exemple resolu` cells in App-6-Minesweeper
- Add 3 new variant exercises (Ex1b, Ex2b, Ex3b) with `# Votre code ici` stubs

### Details
| Exercise | Original | New variant |
|----------|----------|-------------|
| Ex1 | EnhancedCSPSolver (global constraint) | Ex1b: systematic mine count on all unknowns |
| Ex2 | LazyMinesweeperBoard (deferred generation) | Ex2b: configurable safe zone radius |
| Ex3 | 16x16 benchmark (30 games) | Ex3b: expert 30x16, 99 mines |

### Validation
- Papermill: SUCCESS (11.8s)
- Source regression: 0 string-source cells
- Reference: Issue #463

## Test plan
- [x] Papermill execution passes
- [x] Source field regression check (0 string-source cells)
- [x] Cell structure verified (Exemple -> md -> stub pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)