### PR TITLE
fix(sudoku-17): recycle leaked CoT solver into example + variant exercise

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002296,
-     "end_time": "2026-02-21T19:44:14.500585",
+     "duration": 0.00883,
+     "end_time": "2026-04-22T18:17:45.035627",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.498289",
+     "start_time": "2026-04-22T18:17:45.026797",
      "status": "completed"
     },
     "tags": []
@@ -35,7 +35,22 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "f166be80-7bf6-408f-b027-031f96c338ff",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.053963Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.053381Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.078555Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.076917Z"
+    },
+    "papermill": {
+     "duration": 0.036971,
+     "end_time": "2026-04-22T18:17:45.081137",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.044166",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -59,10 +74,10 @@
    "id": "intro-llm",
    "metadata": {
     "papermill": {
-     "duration": 0.001583,
-     "end_time": "2026-02-21T19:44:14.504009",
+     "duration": 0.010459,
+     "end_time": "2026-04-22T18:17:45.101333",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.502426",
+     "start_time": "2026-04-22T18:17:45.090874",
      "status": "completed"
     },
     "tags": []
@@ -106,11 +121,17 @@
    "execution_count": 2,
    "id": "imports",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.120214Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.119722Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.127810Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.126857Z"
+    },
     "papermill": {
-     "duration": 0.01003,
-     "end_time": "2026-02-21T19:44:14.515483",
+     "duration": 0.019856,
+     "end_time": "2026-04-22T18:17:45.130135",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.505453",
+     "start_time": "2026-04-22T18:17:45.110279",
      "status": "completed"
     },
     "tags": []
@@ -144,7 +165,16 @@
   {
    "cell_type": "markdown",
    "id": "5a555dba",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007661,
+     "end_time": "2026-04-22T18:17:45.146068",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.138407",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Fonctions de chargement et d'affichage des puzzles Sudoku."
    ]
@@ -154,11 +184,17 @@
    "execution_count": 3,
    "id": "puzzle-loader",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.163765Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.163337Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.174990Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.174249Z"
+    },
     "papermill": {
-     "duration": 0.026585,
-     "end_time": "2026-02-21T19:44:14.543786",
+     "duration": 0.022826,
+     "end_time": "2026-04-22T18:17:45.176899",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.517201",
+     "start_time": "2026-04-22T18:17:45.154073",
      "status": "completed"
     },
     "tags": []
@@ -271,7 +307,16 @@
   {
    "cell_type": "markdown",
    "id": "6e41d8bb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008803,
+     "end_time": "2026-04-22T18:17:45.194313",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.185510",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation du Chargement des Puzzles\n",
     "\n",
@@ -308,10 +353,10 @@
    "id": "api-setup",
    "metadata": {
     "papermill": {
-     "duration": 0.001618,
-     "end_time": "2026-02-21T19:44:14.548649",
+     "duration": 0.00857,
+     "end_time": "2026-04-22T18:17:45.211571",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.547031",
+     "start_time": "2026-04-22T18:17:45.203001",
      "status": "completed"
     },
     "tags": []
@@ -343,7 +388,22 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "171c8f00-f501-4be4-9130-b4422d35c895",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.234290Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.234010Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.330431Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.329670Z"
+    },
+    "papermill": {
+     "duration": 0.108427,
+     "end_time": "2026-04-22T18:17:45.332404",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.223977",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -362,11 +422,17 @@
    "execution_count": 5,
    "id": "llm-client",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.352112Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.351810Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.362083Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.361087Z"
+    },
     "papermill": {
-     "duration": 0.010878,
-     "end_time": "2026-02-21T19:44:14.561047",
+     "duration": 0.022687,
+     "end_time": "2026-04-22T18:17:45.364157",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.550169",
+     "start_time": "2026-04-22T18:17:45.341470",
      "status": "completed"
     },
     "tags": []
@@ -524,10 +590,10 @@
    "id": "approach-1-zero-shot",
    "metadata": {
     "papermill": {
-     "duration": 0.001669,
-     "end_time": "2026-02-21T19:44:14.564752",
+     "duration": 0.009633,
+     "end_time": "2026-04-22T18:17:45.383208",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.563083",
+     "start_time": "2026-04-22T18:17:45.373575",
      "status": "completed"
     },
     "tags": []
@@ -572,11 +638,17 @@
    "execution_count": 6,
    "id": "zero-shot-solver",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.404522Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.404056Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.413543Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.412469Z"
+    },
     "papermill": {
-     "duration": 0.010488,
-     "end_time": "2026-02-21T19:44:14.577005",
+     "duration": 0.022376,
+     "end_time": "2026-04-22T18:17:45.415597",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.566517",
+     "start_time": "2026-04-22T18:17:45.393221",
      "status": "completed"
     },
     "tags": []
@@ -683,7 +755,16 @@
   {
    "cell_type": "markdown",
    "id": "1b1995fd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009111,
+     "end_time": "2026-04-22T18:17:45.434082",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.424971",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation du Test Zero-Shot\n",
     "\n",
@@ -714,10 +795,10 @@
    "id": "approach-2-few-shot",
    "metadata": {
     "papermill": {
-     "duration": 0.002258,
-     "end_time": "2026-02-21T19:44:14.581743",
+     "duration": 0.009207,
+     "end_time": "2026-04-22T18:17:45.453054",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.579485",
+     "start_time": "2026-04-22T18:17:45.443847",
      "status": "completed"
     },
     "tags": []
@@ -771,11 +852,17 @@
    "execution_count": 7,
    "id": "few-shot-solver",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.472088Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.471808Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.478539Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.477560Z"
+    },
     "papermill": {
-     "duration": 0.008373,
-     "end_time": "2026-02-21T19:44:14.592363",
+     "duration": 0.018419,
+     "end_time": "2026-04-22T18:17:45.480469",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.583990",
+     "start_time": "2026-04-22T18:17:45.462050",
      "status": "completed"
     },
     "tags": []
@@ -901,7 +988,16 @@
   {
    "cell_type": "markdown",
    "id": "dec74b42",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008834,
+     "end_time": "2026-04-22T18:17:45.497940",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.489106",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation du Test Few-Shot\n",
     "\n",
@@ -932,10 +1028,10 @@
    "id": "approach-3-code-interpreter",
    "metadata": {
     "papermill": {
-     "duration": 0.002669,
-     "end_time": "2026-02-21T19:44:14.597286",
+     "duration": 0.008016,
+     "end_time": "2026-04-22T18:17:45.514496",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.594617",
+     "start_time": "2026-04-22T18:17:45.506480",
      "status": "completed"
     },
     "tags": []
@@ -976,11 +1072,17 @@
    "execution_count": 8,
    "id": "code-interpreter",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.532920Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.532430Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.541382Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.540667Z"
+    },
     "papermill": {
-     "duration": 0.012224,
-     "end_time": "2026-02-21T19:44:14.612764",
+     "duration": 0.020615,
+     "end_time": "2026-04-22T18:17:45.543264",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.600540",
+     "start_time": "2026-04-22T18:17:45.522649",
      "status": "completed"
     },
     "tags": []
@@ -1080,7 +1182,16 @@
   {
    "cell_type": "markdown",
    "id": "a197dc35",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008911,
+     "end_time": "2026-04-22T18:17:45.561628",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.552717",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation du Test Code Interpreter\n",
     "\n",
@@ -1113,10 +1224,10 @@
    "id": "benchmark",
    "metadata": {
     "papermill": {
-     "duration": 0.002995,
-     "end_time": "2026-02-21T19:44:14.618772",
+     "duration": 0.009072,
+     "end_time": "2026-04-22T18:17:45.580074",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.615777",
+     "start_time": "2026-04-22T18:17:45.571002",
      "status": "completed"
     },
     "tags": []
@@ -1132,11 +1243,17 @@
    "execution_count": 9,
    "id": "benchmark-llm",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.600606Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.599949Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.613959Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.613138Z"
+    },
     "papermill": {
-     "duration": 0.012016,
-     "end_time": "2026-02-21T19:44:14.632646",
+     "duration": 0.027001,
+     "end_time": "2026-04-22T18:17:45.616141",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.620630",
+     "start_time": "2026-04-22T18:17:45.589140",
      "status": "completed"
     },
     "tags": []
@@ -1281,7 +1398,16 @@
   {
    "cell_type": "markdown",
    "id": "fd98ca7b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009518,
+     "end_time": "2026-04-22T18:17:45.635620",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.626102",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation des Resultats du Benchmark\n",
     "\n",
@@ -1309,10 +1435,10 @@
    "id": "analysis",
    "metadata": {
     "papermill": {
-     "duration": 0.002075,
-     "end_time": "2026-02-21T19:44:14.636730",
+     "duration": 0.015118,
+     "end_time": "2026-04-22T18:17:45.660040",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.634655",
+     "start_time": "2026-04-22T18:17:45.644922",
      "status": "completed"
     },
     "tags": []
@@ -1363,10 +1489,10 @@
    "id": "exercises",
    "metadata": {
     "papermill": {
-     "duration": 0.00242,
-     "end_time": "2026-02-21T19:44:14.641435",
+     "duration": 0.010444,
+     "end_time": "2026-04-22T18:17:45.680802",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.639015",
+     "start_time": "2026-04-22T18:17:45.670358",
      "status": "completed"
     },
     "tags": []
@@ -1402,7 +1528,22 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "avt0s3bqehi",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.700208Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.699932Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.713859Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.713167Z"
+    },
+    "papermill": {
+     "duration": 0.025866,
+     "end_time": "2026-04-22T18:17:45.715774",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.689908",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1523,7 +1664,9 @@
     }
    ],
    "source": [
-    "# Exemple de solution : Solveur LLM avec Chain-of-Thought et validation iterative\n",
+    "# Exemple resolu : Solveur LLM avec Chain-of-Thought et validation iterative\n",
+    "# Ce code sert de reference pour comprendre l'approche CoT.\n",
+    "# Ne pas modifier - implementez votre propre version dans l'exercice ci-dessous.\n",
     "\n",
     "class ChainOfThoughtSudokuSolver:\n",
     "    \"\"\"Solveur Sudoku utilisant un LLM avec Chain-of-Thought et validation.\"\"\"\n",
@@ -1660,10 +1803,133 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "10dc39c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008989,
+     "end_time": "2026-04-22T18:17:45.734176",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.725187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice variant : Solveur LLM sans backtracking\n",
+    "\n",
+    "L'exemple resolu ci-dessus utilise un mecanisme de backtracking (pile d'affectations + retour en arriere). Implementez une version simplifiee sans backtracking :\n",
+    "\n",
+    "**Principe** : A chaque iteration, demandez au LLM une seule affectation. Si elle est valide, appliquez-la. Si elle est invalide, relancez la demande en precisant la contrainte violee, sans annuler les affectations precedentes.\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Implementez `build_single_cell_prompt(grid, failed_attempt)` qui construit un prompt different de l'exemple\n",
+    "2. Implementez `solve(puzzle)` avec une boucle simple (pas de pile, pas de retour arriere)\n",
+    "3. Ajoutez un compteur de tentatives consecutives echouees ; apres 5 echecs, arreter proprement\n",
+    "4. Testez sur `easy_puzzles[1]`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "35ffea28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.753664Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.753388Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.759456Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.758703Z"
+    },
+    "papermill": {
+     "duration": 0.018558,
+     "end_time": "2026-04-22T18:17:45.761597",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.743039",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Test SinglePassLLMSolver ===\n",
+      "Echec de la resolution\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice variant : Solveur LLM sans backtracking\n",
+    "\n",
+    "class SinglePassLLMSolver:\n",
+    "    \"\"\"Solveur Sudoku avec LLM, sans mecanisme de backtracking.\"\"\"\n",
+    "    \n",
+    "    def __init__(self, client: LLMClient, max_failures: int = 5):\n",
+    "        self.client = client\n",
+    "        self.max_failures = max_failures\n",
+    "    \n",
+    "    def build_single_cell_prompt(self, grid: List[List[int]], failed_attempt: str = None) -> str:\n",
+    "        \"\"\"Construit un prompt demandant une seule affectation.\n",
+    "        \n",
+    "        TODO : Construire un prompt qui :\n",
+    "        - Presente la grille actuelle au LLM\n",
+    "        - Demande UNE seule case a remplir avec justification\n",
+    "        - Si failed_attempt est fourni, indique la contrainte violee\n",
+    "        \"\"\"\n",
+    "        # TODO : implementer\n",
+    "        pass\n",
+    "    \n",
+    "    def solve(self, puzzle: List[List[int]]) -> Optional[List[List[int]]]:\n",
+    "        \"\"\"Resout le puzzle sans backtracking.\n",
+    "        \n",
+    "        TODO : Implementer la boucle :\n",
+    "        1. Construire le prompt\n",
+    "        2. Appeler le LLM\n",
+    "        3. Parser l'affectation (reutiliser parse_assignment de l'exemple)\n",
+    "        4. Si valide : appliquer et reset le compteur d'echecs\n",
+    "        5. Si invalide : incrementer le compteur, informer le LLM\n",
+    "        6. Si compteur >= max_failures : arreter et retourner None\n",
+    "        \"\"\"\n",
+    "        # TODO : implementer\n",
+    "        pass\n",
+    "\n",
+    "\n",
+    "# Test du solveur sans backtracking\n",
+    "print(\"=== Test SinglePassLLMSolver ===\")\n",
+    "sp_solver = SinglePassLLMSolver(client, max_failures=5)\n",
+    "test_grid = puzzle_to_grid(easy_puzzles[1])\n",
+    "sp_solution = sp_solver.solve(test_grid)\n",
+    "if sp_solution:\n",
+    "    print(\"Solution trouvee :\")\n",
+    "    print_grid(sp_solution)\n",
+    "    print(f\"Valide : {validate_solution(sp_solution, test_grid)}\")\n",
+    "else:\n",
+    "    print(\"Echec de la resolution\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "d68e18a5-c358-4804-b906-ef0ee0cc4f12",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.783358Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.782902Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.787169Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.786453Z"
+    },
+    "papermill": {
+     "duration": 0.016857,
+     "end_time": "2026-04-22T18:17:45.788910",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.772053",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1690,11 +1956,20 @@
   {
    "cell_type": "markdown",
    "id": "99q8jpxuu94",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009935,
+     "end_time": "2026-04-22T18:17:45.809273",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.799338",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
-    "## Exemple : Solveur LLM avec Chain-of-Thought et Validation\n",
+    "## Exemple resolu : Solveur LLM avec Chain-of-Thought et Validation\n",
     "\n",
     "### Objectif\n",
     "\n",
@@ -1703,7 +1978,7 @@
     "2. **Validation locale** : A chaque etape, verifier que l'affectation proposee est valide\n",
     "3. **Correction interactive** : Si une erreur est detectee, demander au LLM de se corriger\n",
     "\n",
-    "### Solution implementee\n",
+    "### Solution de reference\n",
     "\n",
     "La classe `ChainOfThoughtSudokuSolver` ci-dessous illustre une implementation complete :\n",
     "\n",
@@ -1720,6 +1995,16 @@
   {
    "cell_type": "markdown",
    "id": "78722786",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009353,
+     "end_time": "2026-04-22T18:17:45.828154",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.818801",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1751,12 +2036,38 @@
     "- Les exemples few-shot doivent contenir au moins 3 etapes de deduction avec explication\n",
     "- Le format de sortie attendu doit etre : `Etape N : (row, col) = valeur -- [explication]`\n",
     "- Gerer le cas ou le LLM ne respecte pas le format demande"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "id": "3c6c33f4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-22T18:17:45.848446Z",
+     "iopub.status.busy": "2026-04-22T18:17:45.847927Z",
+     "iopub.status.idle": "2026-04-22T18:17:45.856851Z",
+     "shell.execute_reply": "2026-04-22T18:17:45.856273Z"
+    },
+    "papermill": {
+     "duration": 0.021055,
+     "end_time": "2026-04-22T18:17:45.858443",
+     "exception": false,
+     "start_time": "2026-04-22T18:17:45.837388",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Test Few-Shot avec Raisonnement Guide ===\n",
+      "Echec de la resolution\n"
+     ]
+    }
+   ],
    "source": [
     "# A COMPLETER : Solveur LLM avec Few-Shot raisonne\n",
     "\n",
@@ -1817,18 +2128,6 @@
     "    print(f\"Valide : {validate_solution(fs_solution, test_grid)}\")\n",
     "else:\n",
     "    print(\"Echec de la resolution\")"
-   ],
-   "metadata": {},
-   "execution_count": 12,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Test Few-Shot avec Raisonnement Guide ===\n",
-      "Echec de la resolution\n"
-     ]
-    }
    ]
   },
   {
@@ -1836,10 +2135,10 @@
    "id": "conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.001907,
-     "end_time": "2026-02-21T19:44:14.648518",
+     "duration": 0.009184,
+     "end_time": "2026-04-22T18:17:45.877204",
      "exception": false,
-     "start_time": "2026-02-21T19:44:14.646611",
+     "start_time": "2026-04-22T18:17:45.868020",
      "status": "completed"
     },
     "tags": []
@@ -1911,18 +2210,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.5"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.089584,
-   "end_time": "2026-02-21T19:44:14.881138",
+   "duration": 3.995533,
+   "end_time": "2026-04-22T18:17:46.145184",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-02-21T19:44:12.791554",
+   "start_time": "2026-04-22T18:17:42.149651",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary
- Relabel leaked `ChainOfThoughtSudokuSolver` (cell `avt0s3bqehi`) as "Exemple resolu" with clear reference markers
- Update markdown header (cell `99q8jpxuu94`) to "Exemple resolu" for consistency
- Insert new variant exercise stub: `SinglePassLLMSolver` — a simplified LLM solver without the backtracking stack mechanism, requiring students to implement their own error recovery approach

## Validation
- Papermill: SUCCESS (23.4s) — all cells execute without error
- Papermill baseline (before): SUCCESS (17.5s) — no regression

Refs #463

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>