### PR TITLE
fix(csp): resolve cross-notebook redundancies

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.011759,
-     "end_time": "2026-04-22T15:42:44.859899",
+     "duration": 0.055969,
+     "end_time": "2026-04-22T21:17:37.542113",
      "exception": false,
-     "start_time": "2026-04-22T15:42:44.848140",
+     "start_time": "2026-04-22T21:17:37.486144",
      "status": "completed"
     },
     "tags": []
@@ -47,10 +47,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.013343,
-     "end_time": "2026-04-22T15:42:44.884077",
+     "duration": 0.059794,
+     "end_time": "2026-04-22T21:17:37.665857",
      "exception": false,
-     "start_time": "2026-04-22T15:42:44.870734",
+     "start_time": "2026-04-22T21:17:37.606063",
      "status": "completed"
     },
     "tags": []
@@ -92,16 +92,16 @@
      "start_time": "2026-04-21T09:21:42.034476200Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:44.909093Z",
-     "iopub.status.busy": "2026-04-22T15:42:44.908647Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.431586Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.430836Z"
+     "iopub.execute_input": "2026-04-22T21:17:37.796125Z",
+     "iopub.status.busy": "2026-04-22T21:17:37.795740Z",
+     "iopub.status.idle": "2026-04-22T21:17:38.414853Z",
+     "shell.execute_reply": "2026-04-22T21:17:38.413587Z"
     },
     "papermill": {
-     "duration": 0.538162,
-     "end_time": "2026-04-22T15:42:45.433780",
+     "duration": 0.688375,
+     "end_time": "2026-04-22T21:17:38.416753",
      "exception": false,
-     "start_time": "2026-04-22T15:42:44.895618",
+     "start_time": "2026-04-22T21:17:37.728378",
      "status": "completed"
     },
     "tags": []
@@ -139,10 +139,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.010587,
-     "end_time": "2026-04-22T15:42:45.453832",
+     "duration": 0.07035,
+     "end_time": "2026-04-22T21:17:38.552183",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.443245",
+     "start_time": "2026-04-22T21:17:38.481833",
      "status": "completed"
     },
     "tags": []
@@ -163,16 +163,16 @@
      "start_time": "2026-04-21T09:23:43.387968700Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.469404Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.468932Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.477248Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.476756Z"
+     "iopub.execute_input": "2026-04-22T21:17:38.698940Z",
+     "iopub.status.busy": "2026-04-22T21:17:38.698316Z",
+     "iopub.status.idle": "2026-04-22T21:17:38.708301Z",
+     "shell.execute_reply": "2026-04-22T21:17:38.707133Z"
     },
     "papermill": {
-     "duration": 0.018007,
-     "end_time": "2026-04-22T15:42:45.478323",
+     "duration": 0.083832,
+     "end_time": "2026-04-22T21:17:38.709798",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.460316",
+     "start_time": "2026-04-22T21:17:38.625966",
      "status": "completed"
     },
     "tags": []
@@ -260,10 +260,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.006086,
-     "end_time": "2026-04-22T15:42:45.490614",
+     "duration": 0.067131,
+     "end_time": "2026-04-22T21:17:38.830827",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.484528",
+     "start_time": "2026-04-22T21:17:38.763696",
      "status": "completed"
     },
     "tags": []
@@ -282,16 +282,16 @@
      "start_time": "2026-04-21T09:23:45.191530200Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.505622Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.505020Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.515309Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.514499Z"
+     "iopub.execute_input": "2026-04-22T21:17:38.972287Z",
+     "iopub.status.busy": "2026-04-22T21:17:38.971767Z",
+     "iopub.status.idle": "2026-04-22T21:17:38.985717Z",
+     "shell.execute_reply": "2026-04-22T21:17:38.984382Z"
     },
     "papermill": {
-     "duration": 0.019695,
-     "end_time": "2026-04-22T15:42:45.516551",
+     "duration": 0.084571,
+     "end_time": "2026-04-22T21:17:38.987197",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.496856",
+     "start_time": "2026-04-22T21:17:38.902626",
      "status": "completed"
     },
     "tags": []
@@ -388,10 +388,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.006545,
-     "end_time": "2026-04-22T15:42:45.529517",
+     "duration": 0.071515,
+     "end_time": "2026-04-22T21:17:39.125082",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.522972",
+     "start_time": "2026-04-22T21:17:39.053567",
      "status": "completed"
     },
     "tags": []
@@ -428,16 +428,16 @@
      "start_time": "2026-04-21T09:23:47.580530600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.545825Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.545484Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.552294Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.551459Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.256322Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.255481Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.265459Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.264379Z"
     },
     "papermill": {
-     "duration": 0.016375,
-     "end_time": "2026-04-22T15:42:45.553601",
+     "duration": 0.076494,
+     "end_time": "2026-04-22T21:17:39.267242",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.537226",
+     "start_time": "2026-04-22T21:17:39.190748",
      "status": "completed"
     },
     "tags": []
@@ -504,10 +504,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.007977,
-     "end_time": "2026-04-22T15:42:45.568757",
+     "duration": 0.074409,
+     "end_time": "2026-04-22T21:17:39.401586",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.560780",
+     "start_time": "2026-04-22T21:17:39.327177",
      "status": "completed"
     },
     "tags": []
@@ -536,10 +536,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.008262,
-     "end_time": "2026-04-22T15:42:45.585759",
+     "duration": 0.054184,
+     "end_time": "2026-04-22T21:17:39.528154",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.577497",
+     "start_time": "2026-04-22T21:17:39.473970",
      "status": "completed"
     },
     "tags": []
@@ -579,10 +579,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.007937,
-     "end_time": "2026-04-22T15:42:45.600838",
+     "duration": 0.066566,
+     "end_time": "2026-04-22T21:17:39.651764",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.592901",
+     "start_time": "2026-04-22T21:17:39.585198",
      "status": "completed"
     },
     "tags": []
@@ -601,16 +601,16 @@
      "start_time": "2026-04-21T09:23:53.768571300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.616305Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.615820Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.623272Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.622624Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.807402Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.806620Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.818864Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.817426Z"
     },
     "papermill": {
-     "duration": 0.017198,
-     "end_time": "2026-04-22T15:42:45.624860",
+     "duration": 0.095989,
+     "end_time": "2026-04-22T21:17:39.820812",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.607662",
+     "start_time": "2026-04-22T21:17:39.724823",
      "status": "completed"
     },
     "tags": []
@@ -709,10 +709,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.00852,
-     "end_time": "2026-04-22T15:42:45.643925",
+     "duration": 0.067868,
+     "end_time": "2026-04-22T21:17:39.960866",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.635405",
+     "start_time": "2026-04-22T21:17:39.892998",
      "status": "completed"
     },
     "tags": []
@@ -733,16 +733,16 @@
      "start_time": "2026-04-21T09:23:55.079096200Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.662856Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.662410Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.667884Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.667157Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.091951Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.091492Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.099537Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.098251Z"
     },
     "papermill": {
-     "duration": 0.018273,
-     "end_time": "2026-04-22T15:42:45.669704",
+     "duration": 0.077718,
+     "end_time": "2026-04-22T21:17:40.101030",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.651431",
+     "start_time": "2026-04-22T21:17:40.023312",
      "status": "completed"
     },
     "tags": []
@@ -800,10 +800,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.012362,
-     "end_time": "2026-04-22T15:42:45.694634",
+     "duration": 0.049656,
+     "end_time": "2026-04-22T21:17:40.215512",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.682272",
+     "start_time": "2026-04-22T21:17:40.165856",
      "status": "completed"
     },
     "tags": []
@@ -827,10 +827,10 @@
    "id": "cell-16",
    "metadata": {
     "papermill": {
-     "duration": 0.012254,
-     "end_time": "2026-04-22T15:42:45.719890",
+     "duration": 0.061181,
+     "end_time": "2026-04-22T21:17:40.324287",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.707636",
+     "start_time": "2026-04-22T21:17:40.263106",
      "status": "completed"
     },
     "tags": []
@@ -851,16 +851,16 @@
      "start_time": "2026-04-21T09:26:34.658072600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.745862Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.745353Z",
-     "iopub.status.idle": "2026-04-22T15:42:45.750738Z",
-     "shell.execute_reply": "2026-04-22T15:42:45.749899Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.437190Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.436457Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.443800Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.442512Z"
     },
     "papermill": {
-     "duration": 0.019741,
-     "end_time": "2026-04-22T15:42:45.751859",
+     "duration": 0.059244,
+     "end_time": "2026-04-22T21:17:40.445472",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.732118",
+     "start_time": "2026-04-22T21:17:40.386228",
      "status": "completed"
     },
     "tags": []
@@ -923,10 +923,10 @@
    "id": "cell-18",
    "metadata": {
     "papermill": {
-     "duration": 0.009756,
-     "end_time": "2026-04-22T15:42:45.769609",
+     "duration": 0.059736,
+     "end_time": "2026-04-22T21:17:40.563362",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.759853",
+     "start_time": "2026-04-22T21:17:40.503626",
      "status": "completed"
     },
     "tags": []
@@ -956,10 +956,10 @@
    "id": "cell-19",
    "metadata": {
     "papermill": {
-     "duration": 0.011849,
-     "end_time": "2026-04-22T15:42:45.790407",
+     "duration": 0.079328,
+     "end_time": "2026-04-22T21:17:40.719085",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.778558",
+     "start_time": "2026-04-22T21:17:40.639757",
      "status": "completed"
     },
     "tags": []
@@ -980,16 +980,16 @@
      "start_time": "2026-04-21T09:35:43.708368300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:45.811895Z",
-     "iopub.status.busy": "2026-04-22T15:42:45.811621Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.400237Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.399528Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.833068Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.832549Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.782185Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.780885Z"
     },
     "papermill": {
-     "duration": 0.601116,
-     "end_time": "2026-04-22T15:42:46.401415",
+     "duration": 1.005356,
+     "end_time": "2026-04-22T21:17:41.784248",
      "exception": false,
-     "start_time": "2026-04-22T15:42:45.800299",
+     "start_time": "2026-04-22T21:17:40.778892",
      "status": "completed"
     },
     "tags": []
@@ -1071,10 +1071,10 @@
    "id": "cell-21",
    "metadata": {
     "papermill": {
-     "duration": 0.008868,
-     "end_time": "2026-04-22T15:42:46.421857",
+     "duration": 0.068166,
+     "end_time": "2026-04-22T21:17:41.929752",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.412989",
+     "start_time": "2026-04-22T21:17:41.861586",
      "status": "completed"
     },
     "tags": []
@@ -1097,10 +1097,10 @@
    "id": "cell-22",
    "metadata": {
     "papermill": {
-     "duration": 0.007924,
-     "end_time": "2026-04-22T15:42:46.437393",
+     "duration": 0.080868,
+     "end_time": "2026-04-22T21:17:42.095452",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.429469",
+     "start_time": "2026-04-22T21:17:42.014584",
      "status": "completed"
     },
     "tags": []
@@ -1121,16 +1121,16 @@
      "start_time": "2026-04-21T09:36:10.052557400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.459623Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.458940Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.467053Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.465962Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.206635Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.206065Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.215032Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.213830Z"
     },
     "papermill": {
-     "duration": 0.018717,
-     "end_time": "2026-04-22T15:42:46.468837",
+     "duration": 0.063375,
+     "end_time": "2026-04-22T21:17:42.216831",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.450120",
+     "start_time": "2026-04-22T21:17:42.153456",
      "status": "completed"
     },
     "tags": []
@@ -1198,10 +1198,10 @@
    "id": "cell-24",
    "metadata": {
     "papermill": {
-     "duration": 0.008095,
-     "end_time": "2026-04-22T15:42:46.490005",
+     "duration": 0.106838,
+     "end_time": "2026-04-22T21:17:42.377415",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.481910",
+     "start_time": "2026-04-22T21:17:42.270577",
      "status": "completed"
     },
     "tags": []
@@ -1229,10 +1229,10 @@
    "id": "cell-25",
    "metadata": {
     "papermill": {
-     "duration": 0.011451,
-     "end_time": "2026-04-22T15:42:46.512322",
+     "duration": 0.053483,
+     "end_time": "2026-04-22T21:17:42.488394",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.500871",
+     "start_time": "2026-04-22T21:17:42.434911",
      "status": "completed"
     },
     "tags": []
@@ -1270,10 +1270,10 @@
    "id": "46v1yvn2tk6",
    "metadata": {
     "papermill": {
-     "duration": 0.007435,
-     "end_time": "2026-04-22T15:42:46.533373",
+     "duration": 0.044749,
+     "end_time": "2026-04-22T21:17:42.577441",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.525938",
+     "start_time": "2026-04-22T21:17:42.532692",
      "status": "completed"
     },
     "tags": []
@@ -1294,16 +1294,16 @@
      "start_time": "2026-04-21T09:36:18.828922700Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.554776Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.553974Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.581029Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.579957Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.671751Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.671454Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.689020Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.688119Z"
     },
     "papermill": {
-     "duration": 0.037531,
-     "end_time": "2026-04-22T15:42:46.582266",
+     "duration": 0.071889,
+     "end_time": "2026-04-22T21:17:42.690428",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.544735",
+     "start_time": "2026-04-22T21:17:42.618539",
      "status": "completed"
     },
     "tags": []
@@ -1469,10 +1469,10 @@
    "id": "3623b6a515ef7ac7",
    "metadata": {
     "papermill": {
-     "duration": 0.007736,
-     "end_time": "2026-04-22T15:42:46.597637",
+     "duration": 0.04743,
+     "end_time": "2026-04-22T21:17:42.793618",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.589901",
+     "start_time": "2026-04-22T21:17:42.746188",
      "status": "completed"
     },
     "tags": []
@@ -1491,16 +1491,16 @@
      "start_time": "2026-04-21T09:36:22.308542800Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.616340Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.615635Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.789348Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.787984Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.902281Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.901322Z",
+     "iopub.status.idle": "2026-04-22T21:17:43.290092Z",
+     "shell.execute_reply": "2026-04-22T21:17:43.288699Z"
     },
     "papermill": {
-     "duration": 0.185448,
-     "end_time": "2026-04-22T15:42:46.791078",
+     "duration": 0.442482,
+     "end_time": "2026-04-22T21:17:43.291879",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.605630",
+     "start_time": "2026-04-22T21:17:42.849397",
      "status": "completed"
     },
     "tags": []
@@ -1581,10 +1581,10 @@
    "id": "f0a45e1a5401ca28",
    "metadata": {
     "papermill": {
-     "duration": 0.011988,
-     "end_time": "2026-04-22T15:42:46.814227",
+     "duration": 0.068017,
+     "end_time": "2026-04-22T21:17:43.422312",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.802239",
+     "start_time": "2026-04-22T21:17:43.354295",
      "status": "completed"
     },
     "tags": []
@@ -1603,16 +1603,16 @@
      "start_time": "2026-04-21T09:36:38.899872700Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.837058Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.836425Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.844161Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.842960Z"
+     "iopub.execute_input": "2026-04-22T21:17:43.543150Z",
+     "iopub.status.busy": "2026-04-22T21:17:43.542497Z",
+     "iopub.status.idle": "2026-04-22T21:17:43.549733Z",
+     "shell.execute_reply": "2026-04-22T21:17:43.549006Z"
     },
     "papermill": {
-     "duration": 0.019542,
-     "end_time": "2026-04-22T15:42:46.845618",
+     "duration": 0.058363,
+     "end_time": "2026-04-22T21:17:43.551090",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.826076",
+     "start_time": "2026-04-22T21:17:43.492727",
      "status": "completed"
     },
     "tags": []
@@ -1676,10 +1676,10 @@
    "id": "185ea3e89a531765",
    "metadata": {
     "papermill": {
-     "duration": 0.014815,
-     "end_time": "2026-04-22T15:42:46.871705",
+     "duration": 0.071948,
+     "end_time": "2026-04-22T21:17:43.686596",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.856890",
+     "start_time": "2026-04-22T21:17:43.614648",
      "status": "completed"
     },
     "tags": []
@@ -1698,16 +1698,16 @@
      "start_time": "2026-04-21T09:37:14.417838400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.901993Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.901498Z",
-     "iopub.status.idle": "2026-04-22T15:42:46.911810Z",
-     "shell.execute_reply": "2026-04-22T15:42:46.910359Z"
+     "iopub.execute_input": "2026-04-22T21:17:43.812979Z",
+     "iopub.status.busy": "2026-04-22T21:17:43.812551Z",
+     "iopub.status.idle": "2026-04-22T21:17:43.822562Z",
+     "shell.execute_reply": "2026-04-22T21:17:43.821158Z"
     },
     "papermill": {
-     "duration": 0.028372,
-     "end_time": "2026-04-22T15:42:46.913911",
+     "duration": 0.078583,
+     "end_time": "2026-04-22T21:17:43.824080",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.885539",
+     "start_time": "2026-04-22T21:17:43.745497",
      "status": "completed"
     },
     "tags": []
@@ -1771,10 +1771,10 @@
    "id": "g5zmk00nuqu",
    "metadata": {
     "papermill": {
-     "duration": 0.013536,
-     "end_time": "2026-04-22T15:42:46.941840",
+     "duration": 0.047055,
+     "end_time": "2026-04-22T21:17:43.930178",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.928304",
+     "start_time": "2026-04-22T21:17:43.883123",
      "status": "completed"
     },
     "tags": []
@@ -1800,10 +1800,10 @@
    "id": "b1b042g5n7",
    "metadata": {
     "papermill": {
-     "duration": 0.013142,
-     "end_time": "2026-04-22T15:42:46.968644",
+     "duration": 0.075299,
+     "end_time": "2026-04-22T21:17:44.059302",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.955502",
+     "start_time": "2026-04-22T21:17:43.984003",
      "status": "completed"
     },
     "tags": []
@@ -1824,16 +1824,16 @@
      "start_time": "2026-04-21T09:37:53.375353100Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:46.997456Z",
-     "iopub.status.busy": "2026-04-22T15:42:46.996505Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.007337Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.006021Z"
+     "iopub.execute_input": "2026-04-22T21:17:44.185969Z",
+     "iopub.status.busy": "2026-04-22T21:17:44.185198Z",
+     "iopub.status.idle": "2026-04-22T21:17:44.195771Z",
+     "shell.execute_reply": "2026-04-22T21:17:44.194724Z"
     },
     "papermill": {
-     "duration": 0.026751,
-     "end_time": "2026-04-22T15:42:47.009193",
+     "duration": 0.065796,
+     "end_time": "2026-04-22T21:17:44.197499",
      "exception": false,
-     "start_time": "2026-04-22T15:42:46.982442",
+     "start_time": "2026-04-22T21:17:44.131703",
      "status": "completed"
     },
     "tags": []
@@ -1922,10 +1922,10 @@
    "id": "cell-27",
    "metadata": {
     "papermill": {
-     "duration": 0.012582,
-     "end_time": "2026-04-22T15:42:47.035967",
+     "duration": 0.070741,
+     "end_time": "2026-04-22T21:17:44.327198",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.023385",
+     "start_time": "2026-04-22T21:17:44.256457",
      "status": "completed"
     },
     "tags": []
@@ -1946,16 +1946,16 @@
      "start_time": "2026-04-21T09:37:55.967056400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.064934Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.064415Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.074422Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.073507Z"
+     "iopub.execute_input": "2026-04-22T21:17:44.548539Z",
+     "iopub.status.busy": "2026-04-22T21:17:44.547415Z",
+     "iopub.status.idle": "2026-04-22T21:17:44.562803Z",
+     "shell.execute_reply": "2026-04-22T21:17:44.561218Z"
     },
     "papermill": {
-     "duration": 0.026816,
-     "end_time": "2026-04-22T15:42:47.075580",
+     "duration": 0.148824,
+     "end_time": "2026-04-22T21:17:44.564899",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.048764",
+     "start_time": "2026-04-22T21:17:44.416075",
      "status": "completed"
     },
     "tags": []
@@ -2057,10 +2057,10 @@
    "id": "cell-29",
    "metadata": {
     "papermill": {
-     "duration": 0.008832,
-     "end_time": "2026-04-22T15:42:47.095833",
+     "duration": 0.205511,
+     "end_time": "2026-04-22T21:17:44.874433",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.087001",
+     "start_time": "2026-04-22T21:17:44.668922",
      "status": "completed"
     },
     "tags": []
@@ -2091,10 +2091,10 @@
    "id": "cell-30",
    "metadata": {
     "papermill": {
-     "duration": 0.012177,
-     "end_time": "2026-04-22T15:42:47.118646",
+     "duration": 0.050069,
+     "end_time": "2026-04-22T21:17:45.041373",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.106469",
+     "start_time": "2026-04-22T21:17:44.991304",
      "status": "completed"
     },
     "tags": []
@@ -2136,16 +2136,16 @@
      "start_time": "2026-04-21T09:38:08.636057400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.148893Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.148567Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.157534Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.156444Z"
+     "iopub.execute_input": "2026-04-22T21:17:45.149492Z",
+     "iopub.status.busy": "2026-04-22T21:17:45.149185Z",
+     "iopub.status.idle": "2026-04-22T21:17:45.156123Z",
+     "shell.execute_reply": "2026-04-22T21:17:45.154990Z"
     },
     "papermill": {
-     "duration": 0.026277,
-     "end_time": "2026-04-22T15:42:47.158897",
+     "duration": 0.054171,
+     "end_time": "2026-04-22T21:17:45.157716",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.132620",
+     "start_time": "2026-04-22T21:17:45.103545",
      "status": "completed"
     },
     "tags": []
@@ -2209,10 +2209,10 @@
    "id": "cell-32",
    "metadata": {
     "papermill": {
-     "duration": 0.012451,
-     "end_time": "2026-04-22T15:42:47.183467",
+     "duration": 0.044705,
+     "end_time": "2026-04-22T21:17:45.249481",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.171016",
+     "start_time": "2026-04-22T21:17:45.204776",
      "status": "completed"
     },
     "tags": []
@@ -2233,16 +2233,16 @@
      "start_time": "2026-04-21T09:38:09.826720500Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.212631Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.212205Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.219239Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.217991Z"
+     "iopub.execute_input": "2026-04-22T21:17:45.343927Z",
+     "iopub.status.busy": "2026-04-22T21:17:45.343505Z",
+     "iopub.status.idle": "2026-04-22T21:17:45.349498Z",
+     "shell.execute_reply": "2026-04-22T21:17:45.348464Z"
     },
     "papermill": {
-     "duration": 0.02336,
-     "end_time": "2026-04-22T15:42:47.221045",
+     "duration": 0.057902,
+     "end_time": "2026-04-22T21:17:45.350836",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.197685",
+     "start_time": "2026-04-22T21:17:45.292934",
      "status": "completed"
     },
     "tags": []
@@ -2289,10 +2289,10 @@
    "id": "cell-34",
    "metadata": {
     "papermill": {
-     "duration": 0.013901,
-     "end_time": "2026-04-22T15:42:47.249992",
+     "duration": 0.044858,
+     "end_time": "2026-04-22T21:17:45.451203",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.236091",
+     "start_time": "2026-04-22T21:17:45.406345",
      "status": "completed"
     },
     "tags": []
@@ -2313,16 +2313,16 @@
      "start_time": "2026-04-21T09:38:11.692028600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.278546Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.278030Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.290324Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.289270Z"
+     "iopub.execute_input": "2026-04-22T21:17:45.540536Z",
+     "iopub.status.busy": "2026-04-22T21:17:45.539923Z",
+     "iopub.status.idle": "2026-04-22T21:17:45.550350Z",
+     "shell.execute_reply": "2026-04-22T21:17:45.549442Z"
     },
     "papermill": {
-     "duration": 0.028176,
-     "end_time": "2026-04-22T15:42:47.291977",
+     "duration": 0.056679,
+     "end_time": "2026-04-22T21:17:45.551459",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.263801",
+     "start_time": "2026-04-22T21:17:45.494780",
      "status": "completed"
     },
     "tags": []
@@ -2337,8 +2337,8 @@
       "Algorithme                   Assigns   Backtracks   Temps (ms)\n",
       "-----------------------------------------------------------------\n",
       "Backtracking + MRV               876          105         0.87\n",
-      "Forward Checking + MRV            67           59         0.55\n",
-      "MAC + MRV                         20           12         1.16\n",
+      "Forward Checking + MRV            67           59         0.53\n",
+      "MAC + MRV                         20           12         1.04\n",
       "=================================================================\n"
      ]
     }
@@ -2384,10 +2384,10 @@
    "id": "cell-36",
    "metadata": {
     "papermill": {
-     "duration": 0.013955,
-     "end_time": "2026-04-22T15:42:47.317655",
+     "duration": 0.077397,
+     "end_time": "2026-04-22T21:17:45.690838",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.303700",
+     "start_time": "2026-04-22T21:17:45.613441",
      "status": "completed"
     },
     "tags": []
@@ -2421,16 +2421,16 @@
      "start_time": "2026-04-21T09:38:39.456701300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.346202Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.345672Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.637604Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.636399Z"
+     "iopub.execute_input": "2026-04-22T21:17:45.808542Z",
+     "iopub.status.busy": "2026-04-22T21:17:45.808005Z",
+     "iopub.status.idle": "2026-04-22T21:17:45.988964Z",
+     "shell.execute_reply": "2026-04-22T21:17:45.988053Z"
     },
     "papermill": {
-     "duration": 0.30774,
-     "end_time": "2026-04-22T15:42:47.639585",
+     "duration": 0.247314,
+     "end_time": "2026-04-22T21:17:45.990272",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.331845",
+     "start_time": "2026-04-22T21:17:45.742958",
      "status": "completed"
     },
     "tags": []
@@ -2460,10 +2460,10 @@
    "id": "dc499092",
    "metadata": {
     "papermill": {
-     "duration": 0.013132,
-     "end_time": "2026-04-22T15:42:47.668762",
+     "duration": 0.067091,
+     "end_time": "2026-04-22T21:17:46.104789",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.655630",
+     "start_time": "2026-04-22T21:17:46.037698",
      "status": "completed"
     },
     "tags": []
@@ -2493,10 +2493,10 @@
    "id": "cell-38",
    "metadata": {
     "papermill": {
-     "duration": 0.014096,
-     "end_time": "2026-04-22T15:42:47.694603",
+     "duration": 0.066978,
+     "end_time": "2026-04-22T21:17:46.231238",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.680507",
+     "start_time": "2026-04-22T21:17:46.164260",
      "status": "completed"
     },
     "tags": []
@@ -2519,16 +2519,16 @@
      "start_time": "2026-04-21T09:38:52.747595900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.724191Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.723670Z",
-     "iopub.status.idle": "2026-04-22T15:42:47.741015Z",
-     "shell.execute_reply": "2026-04-22T15:42:47.740161Z"
+     "iopub.execute_input": "2026-04-22T21:17:46.349738Z",
+     "iopub.status.busy": "2026-04-22T21:17:46.349366Z",
+     "iopub.status.idle": "2026-04-22T21:17:46.366916Z",
+     "shell.execute_reply": "2026-04-22T21:17:46.365533Z"
     },
     "papermill": {
-     "duration": 0.033644,
-     "end_time": "2026-04-22T15:42:47.742295",
+     "duration": 0.067391,
+     "end_time": "2026-04-22T21:17:46.368566",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.708651",
+     "start_time": "2026-04-22T21:17:46.301175",
      "status": "completed"
     },
     "tags": []
@@ -2542,17 +2542,17 @@
       "===========================================================================\n",
       "  N Algorithme                   Assigns   Backtracks   Temps (ms)\n",
       "---------------------------------------------------------------------------\n",
-      "  4 Backtracking + MRV                26            4         0.07\n",
-      "  4 Forward Checking + MRV             8            4         0.07\n",
-      "  4 MAC + MRV                          5            1         0.08\n",
+      "  4 Backtracking + MRV                26            4         0.05\n",
+      "  4 Forward Checking + MRV             8            4         0.05\n",
+      "  4 MAC + MRV                          5            1         0.07\n",
       "---------------------------------------------------------------------------\n",
-      "  8 Backtracking + MRV               876          105         0.56\n",
-      "  8 Forward Checking + MRV            67           59         0.33\n",
-      "  8 MAC + MRV                         20           12         0.68\n",
+      "  8 Backtracking + MRV               876          105         0.78\n",
+      "  8 Forward Checking + MRV            67           59         0.45\n",
+      "  8 MAC + MRV                         20           12         0.79\n",
       "---------------------------------------------------------------------------\n",
-      " 12 Backtracking + MRV              3066          249         2.86\n",
-      " 12 Forward Checking + MRV           120          108         1.02\n",
-      " 12 MAC + MRV                         51           39         3.53\n",
+      " 12 Backtracking + MRV              3066          249         2.63\n",
+      " 12 Forward Checking + MRV           120          108         0.96\n",
+      " 12 MAC + MRV                         51           39         4.08\n",
       "---------------------------------------------------------------------------\n",
       "===========================================================================\n"
      ]
@@ -2596,10 +2596,10 @@
    "id": "bxm1kdp2o59",
    "metadata": {
     "papermill": {
-     "duration": 0.015069,
-     "end_time": "2026-04-22T15:42:47.770981",
+     "duration": 0.046361,
+     "end_time": "2026-04-22T21:17:46.472702",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.755912",
+     "start_time": "2026-04-22T21:17:46.426341",
      "status": "completed"
     },
     "tags": []
@@ -2625,16 +2625,16 @@
      "start_time": "2026-04-21T09:38:58.312937800Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:47.795200Z",
-     "iopub.status.busy": "2026-04-22T15:42:47.794721Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.193799Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.192719Z"
+     "iopub.execute_input": "2026-04-22T21:17:46.583323Z",
+     "iopub.status.busy": "2026-04-22T21:17:46.582530Z",
+     "iopub.status.idle": "2026-04-22T21:17:46.889942Z",
+     "shell.execute_reply": "2026-04-22T21:17:46.889274Z"
     },
     "papermill": {
-     "duration": 0.412589,
-     "end_time": "2026-04-22T15:42:48.195304",
+     "duration": 0.366381,
+     "end_time": "2026-04-22T21:17:46.891005",
      "exception": false,
-     "start_time": "2026-04-22T15:42:47.782715",
+     "start_time": "2026-04-22T21:17:46.524624",
      "status": "completed"
     },
     "tags": []
@@ -2686,10 +2686,10 @@
    "id": "cell-41",
    "metadata": {
     "papermill": {
-     "duration": 0.014139,
-     "end_time": "2026-04-22T15:42:48.221557",
+     "duration": 0.055945,
+     "end_time": "2026-04-22T21:17:46.994162",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.207418",
+     "start_time": "2026-04-22T21:17:46.938217",
      "status": "completed"
     },
     "tags": []
@@ -2734,16 +2734,16 @@
      "start_time": "2026-04-21T09:39:15.927210200Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:48.250449Z",
-     "iopub.status.busy": "2026-04-22T15:42:48.250109Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.388722Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.387832Z"
+     "iopub.execute_input": "2026-04-22T21:17:47.105302Z",
+     "iopub.status.busy": "2026-04-22T21:17:47.104779Z",
+     "iopub.status.idle": "2026-04-22T21:17:47.236757Z",
+     "shell.execute_reply": "2026-04-22T21:17:47.236064Z"
     },
     "papermill": {
-     "duration": 0.156421,
-     "end_time": "2026-04-22T15:42:48.389861",
+     "duration": 0.184556,
+     "end_time": "2026-04-22T21:17:47.237839",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.233440",
+     "start_time": "2026-04-22T21:17:47.053283",
      "status": "completed"
     },
     "tags": []
@@ -2787,10 +2787,10 @@
    "id": "cell-43",
    "metadata": {
     "papermill": {
-     "duration": 0.043389,
-     "end_time": "2026-04-22T15:42:48.442989",
+     "duration": 0.04722,
+     "end_time": "2026-04-22T21:17:47.334590",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.399600",
+     "start_time": "2026-04-22T21:17:47.287370",
      "status": "completed"
     },
     "tags": []
@@ -2824,16 +2824,16 @@
    "id": "2abd2246",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:48.461726Z",
-     "iopub.status.busy": "2026-04-22T15:42:48.461263Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.467678Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.466921Z"
+     "iopub.execute_input": "2026-04-22T21:17:47.431746Z",
+     "iopub.status.busy": "2026-04-22T21:17:47.431457Z",
+     "iopub.status.idle": "2026-04-22T21:17:47.438376Z",
+     "shell.execute_reply": "2026-04-22T21:17:47.437522Z"
     },
     "papermill": {
-     "duration": 0.017115,
-     "end_time": "2026-04-22T15:42:48.468857",
+     "duration": 0.057937,
+     "end_time": "2026-04-22T21:17:47.439739",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.451742",
+     "start_time": "2026-04-22T21:17:47.381802",
      "status": "completed"
     },
     "tags": []
@@ -2895,10 +2895,10 @@
    "id": "025d62b7",
    "metadata": {
     "papermill": {
-     "duration": 0.010185,
-     "end_time": "2026-04-22T15:42:48.489070",
+     "duration": 0.064097,
+     "end_time": "2026-04-22T21:17:47.553519",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.478885",
+     "start_time": "2026-04-22T21:17:47.489422",
      "status": "completed"
     },
     "tags": []
@@ -2925,16 +2925,16 @@
    "id": "88e74a41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:48.509868Z",
-     "iopub.status.busy": "2026-04-22T15:42:48.509585Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.513814Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.513057Z"
+     "iopub.execute_input": "2026-04-22T21:17:47.677835Z",
+     "iopub.status.busy": "2026-04-22T21:17:47.677526Z",
+     "iopub.status.idle": "2026-04-22T21:17:47.681559Z",
+     "shell.execute_reply": "2026-04-22T21:17:47.680691Z"
     },
     "papermill": {
-     "duration": 0.015862,
-     "end_time": "2026-04-22T15:42:48.514883",
+     "duration": 0.068016,
+     "end_time": "2026-04-22T21:17:47.682945",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.499021",
+     "start_time": "2026-04-22T21:17:47.614929",
      "status": "completed"
     },
     "tags": []
@@ -2954,10 +2954,10 @@
    "id": "cell-46",
    "metadata": {
     "papermill": {
-     "duration": 0.009513,
-     "end_time": "2026-04-22T15:42:48.533721",
+     "duration": 0.074488,
+     "end_time": "2026-04-22T21:17:47.839541",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.524208",
+     "start_time": "2026-04-22T21:17:47.765053",
      "status": "completed"
     },
     "tags": []
@@ -2980,16 +2980,16 @@
      "start_time": "2026-04-21T09:46:34.529553400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:48.554633Z",
-     "iopub.status.busy": "2026-04-22T15:42:48.554234Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.563782Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.562612Z"
+     "iopub.execute_input": "2026-04-22T21:17:47.951274Z",
+     "iopub.status.busy": "2026-04-22T21:17:47.950635Z",
+     "iopub.status.idle": "2026-04-22T21:17:47.960766Z",
+     "shell.execute_reply": "2026-04-22T21:17:47.959964Z"
     },
     "papermill": {
-     "duration": 0.021546,
-     "end_time": "2026-04-22T15:42:48.564958",
+     "duration": 0.065002,
+     "end_time": "2026-04-22T21:17:47.961959",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.543412",
+     "start_time": "2026-04-22T21:17:47.896957",
      "status": "completed"
     },
     "tags": []
@@ -3115,20 +3115,25 @@
    "id": "cell-49",
    "metadata": {
     "papermill": {
-     "duration": 0.010171,
-     "end_time": "2026-04-22T15:42:48.584893",
+     "duration": 0.055139,
+     "end_time": "2026-04-22T21:17:48.065503",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.574722",
+     "start_time": "2026-04-22T21:17:48.010364",
      "status": "completed"
     },
     "tags": []
    },
+   "outputs": [],
    "source": [
-    "### Exercice 3 : FC vs MAC sur Sudoku 4x4\n",
+    "### Exercice 3 : FC vs MAC sur N-Reines 6x6\n",
     "\n",
-    "Un Sudoku 4x4 utilise les chiffres 1 a 4 dans une grille 4x4 divisee en 4 blocs 2x2. Les regles sont les memes que le 9x9 : chaque chiffre apparait exactement une fois par ligne, colonne et bloc.\n",
+    "Le probleme des **N-Reines** place N reines sur un echiquier NxN sans qu aucune paire ne se menace.\n",
     "\n",
-    "**Question** : modelisez un Sudoku 4x4 comme CSP et comparez FC et MAC en termes d'assignations et de backtracks."
+    "**Question** : comparez les trois approches de backtracking (simple, avec Forward Checking, et avec MAC)\n",
+    "sur les 6-Reines en termes de nombre d assignations et de retours en arriere.\n",
+    "\n",
+    "La fonction `make_nqueens_csp(n)` est deja definie dans ce notebook (section 1).\n",
+    "Utilisez `backtracking_simple`, `forward_checking` et `backtracking_mac` des sections precedentes."
    ]
   },
   {
@@ -3141,16 +3146,16 @@
      "start_time": "2026-04-21T10:00:56.627946700Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-22T15:42:48.606298Z",
-     "iopub.status.busy": "2026-04-22T15:42:48.605708Z",
-     "iopub.status.idle": "2026-04-22T15:42:48.617476Z",
-     "shell.execute_reply": "2026-04-22T15:42:48.616522Z"
+     "iopub.execute_input": "2026-04-22T21:17:48.187439Z",
+     "iopub.status.busy": "2026-04-22T21:17:48.187083Z",
+     "iopub.status.idle": "2026-04-22T21:17:48.196413Z",
+     "shell.execute_reply": "2026-04-22T21:17:48.195219Z"
     },
     "papermill": {
-     "duration": 0.024136,
-     "end_time": "2026-04-22T15:42:48.618755",
+     "duration": 0.079367,
+     "end_time": "2026-04-22T21:17:48.198398",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.594619",
+     "start_time": "2026-04-22T21:17:48.119031",
      "status": "completed"
     },
     "tags": []
@@ -3160,114 +3165,69 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Exercice 3 : FC vs MAC sur Sudoku 4x4 ===\n",
-      "\n",
-      "Grille initiale (0 = vide) :\n",
-      "  [1, 0, 3, 0]\n",
-      "  [0, 4, 0, 2]\n",
-      "  [2, 0, 4, 0]\n",
-      "  [0, 3, 0, 1]\n",
-      "\n",
-      "--- Comparaison FC vs MAC ---\n",
-      "Algorithme                   Assigns   Backtracks   Temps (ms)\n",
-      "-----------------------------------------------------------------\n",
-      "Forward Checking + MRV            16            0         0.12\n",
-      "MAC + MRV                         16            0         0.27\n",
-      "\n",
-      "Solution trouvee par MAC :\n",
-      "  1 2 | 3 4 \n",
-      "  3 4 | 1 2 \n",
-      "  ----+----\n",
-      "  2 1 | 4 3 \n",
-      "  4 3 | 2 1 \n"
+      "N-Reines 6x6 : comparaison des approches\n",
+      "=======================================================\n",
+      "Backtracking simple : 171 assignations, 25 backtracks\n",
+      "Backtracking + FC   : 25 assignations, 19 backtracks\n",
+      "Backtracking + MAC  : 11 assignations, 5 backtracks\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 3 : Sudoku 4x4 comme CSP\n",
-    "\n",
-    "def make_sudoku4_csp(grid):\n",
-    "    \"\"\"Cree un CSP pour un Sudoku 4x4.\n",
-    "\n",
-    "    Args:\n",
-    "        grid: liste de 16 valeurs (0 = case vide, 1-4 = valeur fixee)\n",
-    "              par lignes : [g[0][0], g[0][1], ..., g[3][3]]\n",
-    "    \"\"\"\n",
-    "    variables = [(i, j) for i in range(4) for j in range(4)]\n",
-    "\n",
-    "    domains = {}\n",
-    "    for idx, var in enumerate(variables):\n",
-    "        val = grid[idx]\n",
-    "        domains[var] = [val] if val != 0 else [1, 2, 3, 4]\n",
-    "\n",
-    "    neighbors = {v: set() for v in variables}\n",
-    "    for i in range(4):\n",
-    "        for j in range(4):\n",
-    "            var = (i, j)\n",
-    "            for jj in range(4):         # meme ligne\n",
-    "                if jj != j:\n",
-    "                    neighbors[var].add((i, jj))\n",
-    "            for ii in range(4):         # meme colonne\n",
-    "                if ii != i:\n",
-    "                    neighbors[var].add((ii, j))\n",
-    "            bi, bj = (i // 2) * 2, (j // 2) * 2   # meme bloc 2x2\n",
-    "            for di in range(2):\n",
-    "                for dj in range(2):\n",
-    "                    nb = (bi + di, bj + dj)\n",
-    "                    if nb != var:\n",
-    "                        neighbors[var].add(nb)\n",
-    "\n",
-    "    neighbors = {v: list(s) for v, s in neighbors.items()}\n",
-    "    return CSP(variables, domains, neighbors, different_values)\n",
+    "# Exercice 3 : N-Reines 6x6 - FC vs MAC\n",
+    "#\n",
+    "# Comparer les performances de backtracking_simple (sans propagation),\n",
+    "# backtracking avec forward_checking, et backtracking_mac sur les 6-Reines.\n",
+    "# La fonction make_nqueens_csp est deja definie dans ce notebook (cellule 6).\n",
     "\n",
     "\n",
-    "def print_sudoku4(solution, n=4):\n",
-    "    \"\"\"Affiche la grille Sudoku 4x4.\"\"\"\n",
-    "    for i in range(n):\n",
-    "        if i == 2:\n",
-    "            print(\"  ----+----\")\n",
-    "        row = \"\"\n",
-    "        for j in range(n):\n",
-    "            if j == 2:\n",
-    "                row += \"| \"\n",
-    "            val = solution.get((i, j), '?') if solution else '?'\n",
-    "            row += f\"{val} \"\n",
-    "        print(\" \", row)\n",
+    "def run_fc_backtrack(csp):\n",
+    "    \"\"\"Backtracking avec forward checking manuel.\"\"\"\n",
+    "    assignment = {}\n",
+    "    domains = csp.copy_domains()\n",
+    "\n",
+    "    def _solve():\n",
+    "        if csp.is_complete(assignment):\n",
+    "            return True\n",
+    "        var = select_mrv(csp, assignment, domains)\n",
+    "        for val in list(domains[var]):\n",
+    "            csp.n_assigns += 1\n",
+    "            if csp.consistent(var, val, assignment):\n",
+    "                assignment[var] = val\n",
+    "                removals, ok = forward_checking(csp, var, val, assignment, domains)\n",
+    "                if ok:\n",
+    "                    if _solve():\n",
+    "                        return True\n",
+    "                # Restauration\n",
+    "                for nv, removed_val in removals:\n",
+    "                    domains[nv].append(removed_val)\n",
+    "                del assignment[var]\n",
+    "                csp.n_backtracks += 1\n",
+    "        return False\n",
+    "\n",
+    "    success = _solve()\n",
+    "    return dict(assignment) if success else None\n",
     "\n",
     "\n",
-    "# Grille de test\n",
-    "# 1 . | 3 .\n",
-    "# . 4 | . 2\n",
-    "# ----+----\n",
-    "# 2 . | 4 .\n",
-    "# . 3 | . 1\n",
-    "grid_4x4 = [1, 0, 3, 0,\n",
-    "            0, 4, 0, 2,\n",
-    "            2, 0, 4, 0,\n",
-    "            0, 3, 0, 1]\n",
+    "# --- Comparaison ---\n",
+    "n = 6\n",
+    "print(f\"N-Reines {n}x{n} : comparaison des approches\")\n",
+    "print(\"=\" * 55)\n",
     "\n",
-    "print(\"=== Exercice 3 : FC vs MAC sur Sudoku 4x4 ===\\n\")\n",
-    "print(\"Grille initiale (0 = vide) :\")\n",
-    "for i in range(4):\n",
-    "    print(\" \", grid_4x4[i*4:(i+1)*4])\n",
+    "# 1. Backtracking simple\n",
+    "csp1 = make_nqueens_csp(n)\n",
+    "sol1 = backtracking_simple(csp1)\n",
+    "print(f\"Backtracking simple : {csp1.n_assigns} assignations, {csp1.n_backtracks} backtracks\")\n",
     "\n",
-    "print(\"\\n--- Comparaison FC vs MAC ---\")\n",
-    "print(f\"{'Algorithme':<25} {'Assigns':>10} {'Backtracks':>12} {'Temps (ms)':>12}\")\n",
-    "print(\"-\" * 65)\n",
+    "# 2. Backtracking + Forward Checking\n",
+    "csp2 = make_nqueens_csp(n)\n",
+    "sol2 = run_fc_backtrack(csp2)\n",
+    "print(f\"Backtracking + FC   : {csp2.n_assigns} assignations, {csp2.n_backtracks} backtracks\")\n",
     "\n",
-    "for name, solver in [(\"Forward Checking + MRV\", backtracking_fc),\n",
-    "                     (\"MAC + MRV\", backtracking_mac)]:\n",
-    "    csp_s = make_sudoku4_csp(grid_4x4)\n",
-    "    t0 = time.time()\n",
-    "    sol = solver(csp_s)\n",
-    "    elapsed = (time.time() - t0) * 1000\n",
-    "    print(f\"{name:<25} {csp_s.n_assigns:>10} {csp_s.n_backtracks:>12} {elapsed:>12.2f}\")\n",
-    "\n",
-    "print()\n",
-    "csp_show = make_sudoku4_csp(grid_4x4)\n",
-    "sol_show = backtracking_mac(csp_show)\n",
-    "print(\"Solution trouvee par MAC :\")\n",
-    "print_sudoku4(sol_show)"
+    "# 3. Backtracking + MAC\n",
+    "csp3 = make_nqueens_csp(n)\n",
+    "sol3 = backtracking_mac(csp3)\n",
+    "print(f\"Backtracking + MAC  : {csp3.n_assigns} assignations, {csp3.n_backtracks} backtracks\")"
    ]
   },
   {
@@ -3275,10 +3235,10 @@
    "id": "cell-52",
    "metadata": {
     "papermill": {
-     "duration": 0.010396,
-     "end_time": "2026-04-22T15:42:48.640703",
+     "duration": 0.076091,
+     "end_time": "2026-04-22T21:17:48.358839",
      "exception": false,
-     "start_time": "2026-04-22T15:42:48.630307",
+     "start_time": "2026-04-22T21:17:48.282748",
      "status": "completed"
     },
     "tags": []
@@ -3357,14 +3317,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.08634,
-   "end_time": "2026-04-22T15:42:49.000326",
+   "duration": 13.688774,
+   "end_time": "2026-04-22T21:17:48.767069",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-2-Consistency.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-2-Consistency_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-22T15:42:42.913986",
+   "start_time": "2026-04-22T21:17:35.078295",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-3-Advanced.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.006289,
-     "end_time": "2026-04-22T17:27:03.709507",
+     "duration": 0.051165,
+     "end_time": "2026-04-22T21:17:37.522266",
      "exception": false,
-     "start_time": "2026-04-22T17:27:03.703218",
+     "start_time": "2026-04-22T21:17:37.471101",
      "status": "completed"
     },
     "tags": []
@@ -43,10 +43,10 @@
    "id": "section-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005512,
-     "end_time": "2026-04-22T17:27:03.720720",
+     "duration": 0.052743,
+     "end_time": "2026-04-22T21:17:37.630478",
      "exception": false,
-     "start_time": "2026-04-22T17:27:03.715208",
+     "start_time": "2026-04-22T21:17:37.577735",
      "status": "completed"
     },
     "tags": []
@@ -93,16 +93,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:03.733271Z",
-     "iopub.status.busy": "2026-04-22T17:27:03.732885Z",
-     "iopub.status.idle": "2026-04-22T17:27:04.645269Z",
-     "shell.execute_reply": "2026-04-22T17:27:04.644426Z"
+     "iopub.execute_input": "2026-04-22T21:17:37.738028Z",
+     "iopub.status.busy": "2026-04-22T21:17:37.737717Z",
+     "iopub.status.idle": "2026-04-22T21:17:38.934345Z",
+     "shell.execute_reply": "2026-04-22T21:17:38.933134Z"
     },
     "papermill": {
-     "duration": 0.920041,
-     "end_time": "2026-04-22T17:27:04.646452",
+     "duration": 1.254539,
+     "end_time": "2026-04-22T21:17:38.936813",
      "exception": false,
-     "start_time": "2026-04-22T17:27:03.726411",
+     "start_time": "2026-04-22T21:17:37.682274",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +157,10 @@
    "id": "section-2-global",
    "metadata": {
     "papermill": {
-     "duration": 0.006008,
-     "end_time": "2026-04-22T17:27:04.658648",
+     "duration": 0.055081,
+     "end_time": "2026-04-22T21:17:39.048264",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.652640",
+     "start_time": "2026-04-22T21:17:38.993183",
      "status": "completed"
     },
     "tags": []
@@ -185,10 +185,10 @@
    "id": "alldiff-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005865,
-     "end_time": "2026-04-22T17:27:04.670424",
+     "duration": 0.055485,
+     "end_time": "2026-04-22T21:17:39.160387",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.664559",
+     "start_time": "2026-04-22T21:17:39.104902",
      "status": "completed"
     },
     "tags": []
@@ -213,16 +213,16 @@
    "id": "alldiff-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:04.683895Z",
-     "iopub.status.busy": "2026-04-22T17:27:04.683375Z",
-     "iopub.status.idle": "2026-04-22T17:27:04.692819Z",
-     "shell.execute_reply": "2026-04-22T17:27:04.692179Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.272404Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.271706Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.284996Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.283893Z"
     },
     "papermill": {
-     "duration": 0.017521,
-     "end_time": "2026-04-22T17:27:04.693937",
+     "duration": 0.068965,
+     "end_time": "2026-04-22T21:17:39.286774",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.676416",
+     "start_time": "2026-04-22T21:17:39.217809",
      "status": "completed"
     },
     "tags": []
@@ -235,7 +235,7 @@
       "Mini-Sudoku 4x4 avec AllDifferent\n",
       "========================================\n",
       "Solutions trouvees : 18\n",
-      "Temps : 1.48 ms\n",
+      "Temps : 1.61 ms\n",
       "\n",
       "Premiere solution :\n",
       "  1 4 | 3 2\n",
@@ -313,10 +313,10 @@
    "id": "alldiff-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.00618,
-     "end_time": "2026-04-22T17:27:04.706123",
+     "duration": 0.063463,
+     "end_time": "2026-04-22T21:17:39.411349",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.699943",
+     "start_time": "2026-04-22T21:17:39.347886",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +343,10 @@
    "id": "cumulative-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005847,
-     "end_time": "2026-04-22T17:27:04.717939",
+     "duration": 0.051696,
+     "end_time": "2026-04-22T21:17:39.501668",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.712092",
+     "start_time": "2026-04-22T21:17:39.449972",
      "status": "completed"
     },
     "tags": []
@@ -369,16 +369,16 @@
    "id": "cumulative-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:04.731024Z",
-     "iopub.status.busy": "2026-04-22T17:27:04.730710Z",
-     "iopub.status.idle": "2026-04-22T17:27:04.756053Z",
-     "shell.execute_reply": "2026-04-22T17:27:04.755380Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.591220Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.590539Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.617676Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.616805Z"
     },
     "papermill": {
-     "duration": 0.03339,
-     "end_time": "2026-04-22T17:27:04.757215",
+     "duration": 0.074291,
+     "end_time": "2026-04-22T21:17:39.618961",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.723825",
+     "start_time": "2026-04-22T21:17:39.544670",
      "status": "completed"
     },
     "tags": []
@@ -469,10 +469,10 @@
    "id": "s8zo94of1fc",
    "metadata": {
     "papermill": {
-     "duration": 0.006477,
-     "end_time": "2026-04-22T17:27:04.769898",
+     "duration": 0.058725,
+     "end_time": "2026-04-22T21:17:39.714904",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.763421",
+     "start_time": "2026-04-22T21:17:39.656179",
      "status": "completed"
     },
     "tags": []
@@ -494,10 +494,10 @@
    "id": "2iu8j8r9vmh",
    "metadata": {
     "papermill": {
-     "duration": 0.010702,
-     "end_time": "2026-04-22T17:27:04.786978",
+     "duration": 0.058427,
+     "end_time": "2026-04-22T21:17:39.836322",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.776276",
+     "start_time": "2026-04-22T21:17:39.777895",
      "status": "completed"
     },
     "tags": []
@@ -512,16 +512,16 @@
    "id": "cumulative-viz",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:04.803839Z",
-     "iopub.status.busy": "2026-04-22T17:27:04.803250Z",
-     "iopub.status.idle": "2026-04-22T17:27:05.021484Z",
-     "shell.execute_reply": "2026-04-22T17:27:05.020730Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.962809Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.962094Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.259199Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.258080Z"
     },
     "papermill": {
-     "duration": 0.228653,
-     "end_time": "2026-04-22T17:27:05.022597",
+     "duration": 0.361628,
+     "end_time": "2026-04-22T21:17:40.260572",
      "exception": false,
-     "start_time": "2026-04-22T17:27:04.793944",
+     "start_time": "2026-04-22T21:17:39.898944",
      "status": "completed"
     },
     "tags": []
@@ -589,10 +589,10 @@
    "id": "cumulative-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.006901,
-     "end_time": "2026-04-22T17:27:05.036146",
+     "duration": 0.044297,
+     "end_time": "2026-04-22T21:17:40.339690",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.029245",
+     "start_time": "2026-04-22T21:17:40.295393",
      "status": "completed"
     },
     "tags": []
@@ -620,10 +620,10 @@
    "id": "circuit-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.006104,
-     "end_time": "2026-04-22T17:27:05.048713",
+     "duration": 0.035681,
+     "end_time": "2026-04-22T21:17:40.431232",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.042609",
+     "start_time": "2026-04-22T21:17:40.395551",
      "status": "completed"
     },
     "tags": []
@@ -642,16 +642,16 @@
    "id": "circuit-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:05.062743Z",
-     "iopub.status.busy": "2026-04-22T17:27:05.062257Z",
-     "iopub.status.idle": "2026-04-22T17:27:05.072085Z",
-     "shell.execute_reply": "2026-04-22T17:27:05.071230Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.525590Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.524802Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.539735Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.538420Z"
     },
     "papermill": {
-     "duration": 0.018221,
-     "end_time": "2026-04-22T17:27:05.073235",
+     "duration": 0.065883,
+     "end_time": "2026-04-22T21:17:40.541186",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.055014",
+     "start_time": "2026-04-22T21:17:40.475303",
      "status": "completed"
     },
     "tags": []
@@ -667,7 +667,7 @@
       "\n",
       "Ordre des villes (AllDifferent):\n",
       "       Paris: position 0\n",
-      "        Lyon: position 222685189485101056\n",
+      "        Lyon: position 1726576852992\n",
       "   Marseille: position 0\n",
       "    Bordeaux: position 0\n",
       "       Lille: position 0\n",
@@ -675,7 +675,7 @@
       "Planification de taches (Cumulative, capacite = 5):\n",
       "  Tache 0: debut 0, duree 3, demande 2\n",
       "  Tache 1: debut 0, duree 5, demande 1\n",
-      "  Tache 2: debut 2823559329146208256, duree 4, demande 3\n"
+      "  Tache 2: debut 1898375544832, duree 4, demande 3\n"
      ]
     }
    ],
@@ -752,10 +752,10 @@
    "id": "circuit-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.007628,
-     "end_time": "2026-04-22T17:27:05.088255",
+     "duration": 0.066724,
+     "end_time": "2026-04-22T21:17:40.662415",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.080627",
+     "start_time": "2026-04-22T21:17:40.595691",
      "status": "completed"
     },
     "tags": []
@@ -782,10 +782,10 @@
    "id": "table-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.0107,
-     "end_time": "2026-04-22T17:27:05.108876",
+     "duration": 0.058877,
+     "end_time": "2026-04-22T21:17:40.792073",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.098176",
+     "start_time": "2026-04-22T21:17:40.733196",
      "status": "completed"
     },
     "tags": []
@@ -805,16 +805,16 @@
    "id": "table-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:05.126034Z",
-     "iopub.status.busy": "2026-04-22T17:27:05.125536Z",
-     "iopub.status.idle": "2026-04-22T17:27:05.138727Z",
-     "shell.execute_reply": "2026-04-22T17:27:05.137684Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.919044Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.918395Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.941275Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.939729Z"
     },
     "papermill": {
-     "duration": 0.023391,
-     "end_time": "2026-04-22T17:27:05.140083",
+     "duration": 0.088063,
+     "end_time": "2026-04-22T21:17:40.943452",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.116692",
+     "start_time": "2026-04-22T21:17:40.855389",
      "status": "completed"
     },
     "tags": []
@@ -928,10 +928,10 @@
    "id": "table-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.008607,
-     "end_time": "2026-04-22T17:27:05.157580",
+     "duration": 0.064167,
+     "end_time": "2026-04-22T21:17:41.069037",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.148973",
+     "start_time": "2026-04-22T21:17:41.004870",
      "status": "completed"
     },
     "tags": []
@@ -967,10 +967,10 @@
    "id": "section-3-ortools",
    "metadata": {
     "papermill": {
-     "duration": 0.007126,
-     "end_time": "2026-04-22T17:27:05.171705",
+     "duration": 0.060393,
+     "end_time": "2026-04-22T21:17:41.191243",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.164579",
+     "start_time": "2026-04-22T21:17:41.130850",
      "status": "completed"
     },
     "tags": []
@@ -1010,10 +1010,10 @@
    "id": "nqueens-cpsat-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00664,
-     "end_time": "2026-04-22T17:27:05.185780",
+     "duration": 0.058035,
+     "end_time": "2026-04-22T21:17:41.303253",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.179140",
+     "start_time": "2026-04-22T21:17:41.245218",
      "status": "completed"
     },
     "tags": []
@@ -1030,16 +1030,16 @@
    "id": "nqueens-cpsat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:05.201637Z",
-     "iopub.status.busy": "2026-04-22T17:27:05.201182Z",
-     "iopub.status.idle": "2026-04-22T17:27:05.224232Z",
-     "shell.execute_reply": "2026-04-22T17:27:05.223594Z"
+     "iopub.execute_input": "2026-04-22T21:17:41.418408Z",
+     "iopub.status.busy": "2026-04-22T21:17:41.417928Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.444283Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.442916Z"
     },
     "papermill": {
-     "duration": 0.0322,
-     "end_time": "2026-04-22T17:27:05.225476",
+     "duration": 0.082398,
+     "end_time": "2026-04-22T21:17:41.446341",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.193276",
+     "start_time": "2026-04-22T21:17:41.363943",
      "status": "completed"
     },
     "tags": []
@@ -1051,7 +1051,7 @@
      "text": [
       "N-Reines avec CP-SAT\n",
       "========================================\n",
-      "N = 8 : solution trouvee en 14.47 ms\n",
+      "N = 8 : solution trouvee en 13.90 ms\n",
       "Solution : {0: 4, 1: 7, 2: 3, 3: 0, 4: 6, 5: 1, 6: 5, 7: 2}\n"
      ]
     }
@@ -1117,10 +1117,10 @@
    "id": "22jzbure7v3",
    "metadata": {
     "papermill": {
-     "duration": 0.007382,
-     "end_time": "2026-04-22T17:27:05.241838",
+     "duration": 0.058931,
+     "end_time": "2026-04-22T21:17:41.571119",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.234456",
+     "start_time": "2026-04-22T21:17:41.512188",
      "status": "completed"
     },
     "tags": []
@@ -1142,10 +1142,10 @@
    "id": "w2lk5hu7uc",
    "metadata": {
     "papermill": {
-     "duration": 0.007112,
-     "end_time": "2026-04-22T17:27:05.255427",
+     "duration": 0.035051,
+     "end_time": "2026-04-22T21:17:41.668166",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.248315",
+     "start_time": "2026-04-22T21:17:41.633115",
      "status": "completed"
     },
     "tags": []
@@ -1160,16 +1160,16 @@
    "id": "nqueens-scale",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:05.270431Z",
-     "iopub.status.busy": "2026-04-22T17:27:05.269978Z",
-     "iopub.status.idle": "2026-04-22T17:27:07.851095Z",
-     "shell.execute_reply": "2026-04-22T17:27:07.849960Z"
+     "iopub.execute_input": "2026-04-22T21:17:41.779375Z",
+     "iopub.status.busy": "2026-04-22T21:17:41.779025Z",
+     "iopub.status.idle": "2026-04-22T21:17:45.009203Z",
+     "shell.execute_reply": "2026-04-22T21:17:45.007956Z"
     },
     "papermill": {
-     "duration": 2.59069,
-     "end_time": "2026-04-22T17:27:07.852912",
+     "duration": 3.285509,
+     "end_time": "2026-04-22T21:17:45.011086",
      "exception": false,
-     "start_time": "2026-04-22T17:27:05.262222",
+     "start_time": "2026-04-22T21:17:41.725577",
      "status": "completed"
     },
     "tags": []
@@ -1183,43 +1183,37 @@
       "==================================================\n",
       "     N   Temps (ms)   Solution\n",
       "-----------------------------------\n",
-      "     8        10.52        Oui\n",
-      "    12        15.41        Oui\n"
+      "     8        26.58        Oui\n",
+      "    12        30.18        Oui\n",
+      "    20        57.99        Oui\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    20        49.26        Oui\n"
+      "    30       155.15        Oui\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    30        95.43        Oui\n"
+      "    50       349.08        Oui\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    50       311.93        Oui\n"
+      "    75       871.48        Oui\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    75       717.35        Oui\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "   100      1362.17        Oui\n",
+      "   100      1714.36        Oui\n",
       "\n",
       "Comparaison avec notre backtracking (Search-6) :\n",
       "  - Backtracking + MRV : N=12 peut prendre des secondes\n",
@@ -1252,10 +1246,10 @@
    "id": "nqueens-scale-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.009245,
-     "end_time": "2026-04-22T17:27:07.874206",
+     "duration": 0.038289,
+     "end_time": "2026-04-22T21:17:45.111140",
      "exception": false,
-     "start_time": "2026-04-22T17:27:07.864961",
+     "start_time": "2026-04-22T21:17:45.072851",
      "status": "completed"
     },
     "tags": []
@@ -1284,10 +1278,10 @@
    "id": "nqueens-all-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.011154,
-     "end_time": "2026-04-22T17:27:07.895068",
+     "duration": 0.035463,
+     "end_time": "2026-04-22T21:17:45.181189",
      "exception": false,
-     "start_time": "2026-04-22T17:27:07.883914",
+     "start_time": "2026-04-22T21:17:45.145726",
      "status": "completed"
     },
     "tags": []
@@ -1304,16 +1298,16 @@
    "id": "nqueens-count",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:07.913119Z",
-     "iopub.status.busy": "2026-04-22T17:27:07.912818Z",
-     "iopub.status.idle": "2026-04-22T17:27:24.007962Z",
-     "shell.execute_reply": "2026-04-22T17:27:24.007098Z"
+     "iopub.execute_input": "2026-04-22T21:17:45.250039Z",
+     "iopub.status.busy": "2026-04-22T21:17:45.249191Z",
+     "iopub.status.idle": "2026-04-22T21:18:02.260206Z",
+     "shell.execute_reply": "2026-04-22T21:18:02.259135Z"
     },
     "papermill": {
-     "duration": 16.104577,
-     "end_time": "2026-04-22T17:27:24.009208",
+     "duration": 17.04601,
+     "end_time": "2026-04-22T21:18:02.261474",
      "exception": false,
-     "start_time": "2026-04-22T17:27:07.904631",
+     "start_time": "2026-04-22T21:17:45.215464",
      "status": "completed"
     },
     "tags": []
@@ -1327,39 +1321,39 @@
       "=============================================\n",
       "   N    Solutions   Temps (ms)\n",
       "------------------------------\n",
-      "   4            2          1.1 OK\n",
-      "   5           10          4.0 OK\n",
-      "   6            4          6.4 OK\n",
-      "   7           40         11.0 OK\n",
-      "   8           92         59.5 OK\n"
+      "   4            2          1.3 OK\n",
+      "   5           10          3.7 OK\n",
+      "   6            4          4.9 OK\n",
+      "   7           40          7.8 OK\n",
+      "   8           92         51.6 OK\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   9          352        249.3 OK\n"
+      "   9          352        270.3 OK\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10          724        578.5 OK\n"
+      "  10          724        684.4 OK\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  11         2680       2897.0 OK\n"
+      "  11         2680       2798.9 OK\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  12        14200      12275.5 OK\n"
+      "  12        14200      13173.5 OK\n"
      ]
     }
    ],
@@ -1385,10 +1379,10 @@
    "id": "nqueens-count-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.006943,
-     "end_time": "2026-04-22T17:27:24.023453",
+     "duration": 0.042056,
+     "end_time": "2026-04-22T21:18:02.339670",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.016510",
+     "start_time": "2026-04-22T21:18:02.297614",
      "status": "completed"
     },
     "tags": []
@@ -1416,10 +1410,10 @@
    "id": "wr0rxz0hj6l",
    "metadata": {
     "papermill": {
-     "duration": 0.006584,
-     "end_time": "2026-04-22T17:27:24.036805",
+     "duration": 0.038632,
+     "end_time": "2026-04-22T21:18:02.416955",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.030221",
+     "start_time": "2026-04-22T21:18:02.378323",
      "status": "completed"
     },
     "tags": []
@@ -1448,16 +1442,16 @@
    "id": "xigolmh79cr",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:24.051835Z",
-     "iopub.status.busy": "2026-04-22T17:27:24.051430Z",
-     "iopub.status.idle": "2026-04-22T17:27:24.059825Z",
-     "shell.execute_reply": "2026-04-22T17:27:24.058854Z"
+     "iopub.execute_input": "2026-04-22T21:18:02.503072Z",
+     "iopub.status.busy": "2026-04-22T21:18:02.502434Z",
+     "iopub.status.idle": "2026-04-22T21:18:02.511029Z",
+     "shell.execute_reply": "2026-04-22T21:18:02.510171Z"
     },
     "papermill": {
-     "duration": 0.017303,
-     "end_time": "2026-04-22T17:27:24.060819",
+     "duration": 0.051845,
+     "end_time": "2026-04-22T21:18:02.512104",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.043516",
+     "start_time": "2026-04-22T21:18:02.460259",
      "status": "completed"
     },
     "tags": []
@@ -1553,10 +1547,10 @@
    "id": "d1f86552",
    "metadata": {
     "papermill": {
-     "duration": 0.00696,
-     "end_time": "2026-04-22T17:27:24.074580",
+     "duration": 0.034123,
+     "end_time": "2026-04-22T21:18:02.580858",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.067620",
+     "start_time": "2026-04-22T21:18:02.546735",
      "status": "completed"
     },
     "tags": []
@@ -1571,16 +1565,16 @@
    "id": "lppmj6rfz8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:24.089857Z",
-     "iopub.status.busy": "2026-04-22T17:27:24.089465Z",
-     "iopub.status.idle": "2026-04-22T17:27:24.099610Z",
-     "shell.execute_reply": "2026-04-22T17:27:24.098685Z"
+     "iopub.execute_input": "2026-04-22T21:18:02.651146Z",
+     "iopub.status.busy": "2026-04-22T21:18:02.650832Z",
+     "iopub.status.idle": "2026-04-22T21:18:02.659245Z",
+     "shell.execute_reply": "2026-04-22T21:18:02.658561Z"
     },
     "papermill": {
-     "duration": 0.01913,
-     "end_time": "2026-04-22T17:27:24.100767",
+     "duration": 0.043588,
+     "end_time": "2026-04-22T21:18:02.660251",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.081637",
+     "start_time": "2026-04-22T21:18:02.616663",
      "status": "completed"
     },
     "tags": []
@@ -1594,16 +1588,16 @@
       "Probleme : Choisir les participants a une reunion\n",
       "\n",
       "Variable : participants_reunion\n",
-      "Elements possibles : {'Charlie', 'Bob', 'Diana', 'Alice'}\n",
+      "Elements possibles : {'Alice', 'Charlie', 'Bob', 'Diana'}\n",
       "Taille : [2, 3]\n",
       "\n",
       "Domaine (10 ensembles possibles) :\n",
-      "  1. {'Charlie', 'Bob'}\n",
-      "  2. {'Charlie', 'Diana'}\n",
-      "  3. {'Charlie', 'Alice'}\n",
-      "  4. {'Diana', 'Bob'}\n",
-      "  5. {'Bob', 'Alice'}\n",
-      "  6. {'Diana', 'Alice'}\n",
+      "  1. {'Charlie', 'Alice'}\n",
+      "  2. {'Bob', 'Alice'}\n",
+      "  3. {'Diana', 'Alice'}\n",
+      "  4. {'Charlie', 'Bob'}\n",
+      "  5. {'Charlie', 'Diana'}\n",
+      "  6. {'Bob', 'Diana'}\n",
       "  ... et 4 autres\n",
       "\n",
       "Contraintes typiques sur les Set Variables :\n",
@@ -1699,10 +1693,10 @@
    "id": "oco91jvy6h9",
    "metadata": {
     "papermill": {
-     "duration": 0.00725,
-     "end_time": "2026-04-22T17:27:24.115489",
+     "duration": 0.032947,
+     "end_time": "2026-04-22T21:18:02.727965",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.108239",
+     "start_time": "2026-04-22T21:18:02.695018",
      "status": "completed"
     },
     "tags": []
@@ -1727,10 +1721,10 @@
    "id": "section-4-symmetry",
    "metadata": {
     "papermill": {
-     "duration": 0.006672,
-     "end_time": "2026-04-22T17:27:24.129653",
+     "duration": 0.034693,
+     "end_time": "2026-04-22T21:18:02.796294",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.122981",
+     "start_time": "2026-04-22T21:18:02.761601",
      "status": "completed"
     },
     "tags": []
@@ -1768,16 +1762,16 @@
    "id": "symmetry-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:24.145523Z",
-     "iopub.status.busy": "2026-04-22T17:27:24.145059Z",
-     "iopub.status.idle": "2026-04-22T17:27:49.015380Z",
-     "shell.execute_reply": "2026-04-22T17:27:49.014543Z"
+     "iopub.execute_input": "2026-04-22T21:18:02.866698Z",
+     "iopub.status.busy": "2026-04-22T21:18:02.866386Z",
+     "iopub.status.idle": "2026-04-22T21:18:27.820403Z",
+     "shell.execute_reply": "2026-04-22T21:18:27.819219Z"
     },
     "papermill": {
-     "duration": 24.879984,
-     "end_time": "2026-04-22T17:27:49.017161",
+     "duration": 24.993461,
+     "end_time": "2026-04-22T21:18:27.822990",
      "exception": false,
-     "start_time": "2026-04-22T17:27:24.137177",
+     "start_time": "2026-04-22T21:18:02.829529",
      "status": "completed"
     },
     "tags": []
@@ -1790,36 +1784,36 @@
       "Impact du cassage de symetries sur N-Reines\n",
       "=================================================================\n",
       "   N    Sans SB      Temps    Avec SB      Temps  Ratio sol\n",
-      "-----------------------------------------------------------------\n",
-      "   6          4       4.8ms          2       2.3ms       2.0x\n"
+      "-----------------------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   8         92      49.3ms         35      22.2ms       2.6x\n"
+      "   6          4       5.1ms          2       2.3ms       2.0x\n",
+      "   8         92      49.8ms         35      21.6ms       2.6x\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  10        724     599.2ms        289     602.2ms       2.5x\n"
+      "  10        724     648.1ms        289     637.7ms       2.5x\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  11       2680    2443.7ms       1133    1319.7ms       2.4x\n"
+      "  11       2680    2523.9ms       1133    1317.9ms       2.4x\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  12      14200   13578.9ms       5564    6227.6ms       2.6x\n"
+      "  12      14200   13174.8ms       5564    6550.9ms       2.6x\n"
      ]
     }
    ],
@@ -1890,10 +1884,10 @@
    "id": "symmetry-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.00865,
-     "end_time": "2026-04-22T17:27:49.037915",
+     "duration": 0.049407,
+     "end_time": "2026-04-22T21:18:27.940779",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.029265",
+     "start_time": "2026-04-22T21:18:27.891372",
      "status": "completed"
     },
     "tags": []
@@ -1925,16 +1919,16 @@
    "id": "symmetry-pigeonhole",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:49.066144Z",
-     "iopub.status.busy": "2026-04-22T17:27:49.065426Z",
-     "iopub.status.idle": "2026-04-22T17:27:49.085499Z",
-     "shell.execute_reply": "2026-04-22T17:27:49.084467Z"
+     "iopub.execute_input": "2026-04-22T21:18:28.010073Z",
+     "iopub.status.busy": "2026-04-22T21:18:28.009583Z",
+     "iopub.status.idle": "2026-04-22T21:18:28.021908Z",
+     "shell.execute_reply": "2026-04-22T21:18:28.021013Z"
     },
     "papermill": {
-     "duration": 0.036671,
-     "end_time": "2026-04-22T17:27:49.087296",
+     "duration": 0.04785,
+     "end_time": "2026-04-22T21:18:28.022896",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.050625",
+     "start_time": "2026-04-22T21:18:27.975046",
      "status": "completed"
     },
     "tags": []
@@ -1948,11 +1942,11 @@
       "============================================================\n",
       " Pigeons  Trous   Sans SB (ms)   Avec SB (ms)  Speedup\n",
       "-------------------------------------------------------\n",
-      "       6      5           0.2           0.4     0.5x\n",
-      "       9      8           0.1           0.2     0.7x\n",
-      "      11     10           0.1           0.2     0.6x\n",
-      "      16     15           0.1           0.4     0.3x\n",
-      "      21     20           0.1           0.3     0.4x\n",
+      "       6      5           0.1           0.1     1.0x\n",
+      "       9      8           0.1           0.1     0.5x\n",
+      "      11     10           0.1           0.1     0.7x\n",
+      "      16     15           0.1           0.1     0.4x\n",
+      "      21     20           0.1           0.1     0.5x\n",
       "\n",
       "Note : CP-SAT detecte rapidement l'infaisabilite grace a\n",
       "son propagateur AllDifferent. Le gain est surtout visible\n",
@@ -2009,10 +2003,10 @@
    "id": "section-5-lns",
    "metadata": {
     "papermill": {
-     "duration": 0.012468,
-     "end_time": "2026-04-22T17:27:49.113183",
+     "duration": 0.03521,
+     "end_time": "2026-04-22T21:18:28.092282",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.100715",
+     "start_time": "2026-04-22T21:18:28.057072",
      "status": "completed"
     },
     "tags": []
@@ -2059,16 +2053,16 @@
    "id": "lns-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:49.141056Z",
-     "iopub.status.busy": "2026-04-22T17:27:49.140430Z",
-     "iopub.status.idle": "2026-04-22T17:27:49.412827Z",
-     "shell.execute_reply": "2026-04-22T17:27:49.411737Z"
+     "iopub.execute_input": "2026-04-22T21:18:28.165097Z",
+     "iopub.status.busy": "2026-04-22T21:18:28.164680Z",
+     "iopub.status.idle": "2026-04-22T21:18:28.434408Z",
+     "shell.execute_reply": "2026-04-22T21:18:28.433656Z"
     },
     "papermill": {
-     "duration": 0.287522,
-     "end_time": "2026-04-22T17:27:49.414395",
+     "duration": 0.308805,
+     "end_time": "2026-04-22T21:18:28.436112",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.126873",
+     "start_time": "2026-04-22T21:18:28.127307",
      "status": "completed"
     },
     "tags": []
@@ -2205,10 +2199,10 @@
    "id": "36xj38bu0fm",
    "metadata": {
     "papermill": {
-     "duration": 0.008075,
-     "end_time": "2026-04-22T17:27:49.433361",
+     "duration": 0.03992,
+     "end_time": "2026-04-22T21:18:28.526365",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.425286",
+     "start_time": "2026-04-22T21:18:28.486445",
      "status": "completed"
     },
     "tags": []
@@ -2230,10 +2224,10 @@
    "id": "nbq7h7xm8ib",
    "metadata": {
     "papermill": {
-     "duration": 0.010775,
-     "end_time": "2026-04-22T17:27:49.453271",
+     "duration": 0.048833,
+     "end_time": "2026-04-22T21:18:28.613526",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.442496",
+     "start_time": "2026-04-22T21:18:28.564693",
      "status": "completed"
     },
     "tags": []
@@ -2248,16 +2242,16 @@
    "id": "lns-viz",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:49.474294Z",
-     "iopub.status.busy": "2026-04-22T17:27:49.473840Z",
-     "iopub.status.idle": "2026-04-22T17:27:49.905709Z",
-     "shell.execute_reply": "2026-04-22T17:27:49.904397Z"
+     "iopub.execute_input": "2026-04-22T21:18:28.730078Z",
+     "iopub.status.busy": "2026-04-22T21:18:28.729688Z",
+     "iopub.status.idle": "2026-04-22T21:18:29.058146Z",
+     "shell.execute_reply": "2026-04-22T21:18:29.057247Z"
     },
     "papermill": {
-     "duration": 0.44591,
-     "end_time": "2026-04-22T17:27:49.907621",
+     "duration": 0.391921,
+     "end_time": "2026-04-22T21:18:29.059214",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.461711",
+     "start_time": "2026-04-22T21:18:28.667293",
      "status": "completed"
     },
     "tags": []
@@ -2265,7 +2259,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAo1NJREFUeJzs3Qd4U1UbwPE33S1QoOxRKCBDkGVFHCBLQUSGqAiioLhFRfFTxI0LBbei4AQnOBAHbhRxoYIiKooiu2xKN53J97ynJiRtUpo2zWj/v+e5Te/Nzc3Jm5ubc9+ce47FZrPZBAAAAAAAAAAQFMICXQAAAAAAAAAAwCEkbQEAAAAAAAAgiJC0BQAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAAAAAACCIkbQEAAAAAAAAgiJC0BQAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAAAAAACCIkbQEAAAAgyM2fP18sFouZ+vfv71i+fPlyx/KkpCTH8s2bNzuW6wT3iBOq2nnnnWf2rbp160paWpoEA+d9Xj8DqN7++ecfCQ8PN+/3bbfdFujiwAskbQFUC1arVd59910ZM2aMOWGJjY2V+Ph4OfLII01F6f333xebzRboYiIITnTLc0LmvG50dHSpyuydd97puP+4444r9fiFCxfKoEGDpGHDhhIZGSkJCQnSvn17Of300+WWW26R9PR0n74+AEDgvlN0+uWXX0qtt3Tp0lLraYIVQOjQz6zW+3RasmSJ149ftWqVvPbaa+b/K6+8UurVq1cFpUSoe/TRR+Xss8+WNm3auHxn6PeNJy+99JKcfPLJ0rhxY3O+oee/HTp0kMsvv1w2btzosq6eh+j21cMPPywpKSlV/prgGxE+2g4ABMzu3btNsnbFihUuy3Nzc+Wvv/4y06uvvioHDhygogSv5efnm4p6WZUmZ9dff72pDDnTfU+nDRs2mJP4Cy+80LS2AABUD0888YS88MILLssef/xxnz7HaaedJl9//bX5n+8QwH9J2xkzZpj/J06cKKNGjfLq8XfddZdpOKIJOE3aAu7ouYY3jTrcnW8UFhaaFrU6aQOSn376ySRr7a666ipZtGiR5OTkyOzZs02iGMGPlrYAQpp+6QwZMsSRsA0LC5NJkybJ4sWLZdmyZSbRds4555hfH2uKgwcPmpbH8J1XXnnFJP8PR3/VfuSRR8z/Wjm/4YYb5KOPPpLPP/9cnn/+eRk/frxpAQ4AqF5ef/112b9/v2NevzM+++wznz6Htqbq06ePmbp27SqhSusoWlfxl6ysLL89F+Bsy5Yt5sd6pZ/bxMTEQBcJQUqP6XoO+9RTT5lj/eHOf/WHQrvRo0fLp59+Ks8995zUqlXLLNMEsM47O/HEE6VVq1aOVrr+PA6j4kjaAghpjz32mPz666+OeW1Rq8mxM844QwYOHGh+EddfGn///XeJi4tzrKe/eGtCd8CAAebSdU3qNm3aVEaOHGmSvSU5X6aybt06c4l769atzaXznTp1Mkk9u08++cSxrt5X0kUXXeS4/+abb3b5Ap41a5Yce+yxJrGn29ZfR6dOnSp79+512UbJ/uv+/vtv84Vdv3598zozMjIclUW9FEZb5Og29fJ8Lb/2hefpspvU1FTT11H37t2ldu3a5lKbLl26mF+AS574lOxf748//jAx1OfTSoO2CtLWpSVpReKee+6RXr16mXX1tWol4qyzzpL169e7rPvjjz/KuHHjTEU3KirKvEa9FOi9994TfykqKipX/096CZy9G44ePXqY9/PUU081XSVoRUz3kz179ph9BwAQ+vQ7MiIiwlzd8+yzzzqW6wm1fh8c7oe6ynznVpY3369a13DXxUNZ/cE6L1+7dq1MmTJFWrRoYepcWlc6HK3fTZgwwVHf0lhqHenBBx+UvLw8l3UvuOACx3Np7PT7tmfPnhITE2O6ybJ78803zfezLtfXrfU5fe/Kog0DzjzzTGnevLkjTn379jUJkZI/kpesX2nra31v9fn08dOnTzd1iorWMZX+OKCXP/fu3VuaNWtmtq37zRFHHCGXXHJJqcuiS9YZt27dKueff740aNDAPE5fi9ZfStIYa2txTTbqa9bXrq9B65Lff/+9y7p//vmnXHzxxdK2bVtTHn2vNEGkMSjZPVnJ92rBggXSuXNn87ijjjrKtARU2kpQ6/Jan2zUqJF5zVpXLqkyz637unZzpXHQ57jsssskOzvbZd+2t7JVWlZ3/Ud7ovubfR8ZNmxYqfud95cXX3xRHnroIfM6tDy6r9vPST7++GPzfuty/Qzp+UPJ/Uhfj9Y3tT6txxL7+6XnROXtlkXfc62728uUnJws+/bt8/o8RV+z7jv2dfUzr/HV7WmMnRtClHxPtAsKfZy+Vk1e6vp6tVrJH8n0fEP3eb2KUrev+3O/fv3MZ67k+16Rz6UnWo//5ptvyjW5+1x5oldR6DnsFVdcYV57WfS9KCgocMzrPnrKKaeYc0zn7wa9WtCZvv6hQ4ea/zWm5TkOIwjYACCEdezYUb+VzTRw4MByPaawsNA2atQox+PcTffee6/LY5zva9++vdvHfPfdd2bdoqIiW2JiomP5qlWrHNvJzc211a1b1yy3WCy2DRs2mOV79+61HXXUUR7L06JFC9vGjRsd2/nyyy8d9+n2GjVq5LL+gQMHbDt37rQ1b9681Lbq169va9OmjWP+xRdfdGz3n3/+sbVs2dJjObSM+/fvd6yvj7Xf16xZM1utWrVKPaZz584mJnb6OpKSkjw+xzvvvONYd86cObawsDCP606fPr1c77lzOcvz1ee87nHHHed4v1avXm3uv+OOOxz39+7d2/G4jz/+2LE8IiLCdvfdd9t+++03l9cPAAhtzt8pTZo0sY0ZM8b836pVK1PHSEtLs9WuXdssmzJlist3in5/++I7t1+/fm7rBK1bt3Ys37Rpk8fvPm+/X3W77l5DWc9RVt3J+bvenddff90WGRnpsXzJycm2jIwMx/oTJ070+FwjR4406zz//PNut9WzZ0+Pr2H27Nnm+99TOU477TRbQUGBY319Xw5XX5w5c2a541Syjqn+/PNPj+Wx1/P+/fdft/tHfHy8rXHjxqUe07BhQ5d46n5XMi7O0yOPPOJYV9/LmJgYj+uOHz/eZrVa3b5XHTp0cPuYu+66yxYdHV1q+WWXXeYSu8o89xFHHOH2MfbnKLlvl5ycP2uenH766W4/N+72F3ex0M+A1iXd7YMl9yM9Fnkqqz7+7bff9rjf6WvNy8uzDRs2zLHshBNOMMeyipyn3H777WXGTj/f7t6TI4880u363bt3t+Xk5Dgec84555S5fT3ueopzeT+X5T2nqOw+4o7z8db5PM2Z8+dz9OjRtk8//dT23HPPOc7F9Dxk5cqVpR73wgsvOB53zTXXVKh88C+StgBCVlZWlssX4/3331+uxz322GMulSGtGH744Ye2iy++2GV7P/zwg+Mxzsvj4uJsDz/8sO3dd991qcCMHTvWbWXluuuucyzXCpN9ef/+/R3L7Sd8OvXo0cNUZj766CPbmWee6Vjet29ftxVwnerVq2d79NFHzRe2vj6t2EyaNMmlkq4naFpm3Y7zY50rA5qAtC8fMGCAqQy///77LpWd888/32PF5eijjzavUcvifLKlyUy7448/3rG8Tp06pjKq97/88su2s88+2/bee++Z9X7//XfHCaXe3nLLLeb1zZs3z5yQ2LexbNmyKk3aLlq0yNagQQPz/9ChQ8tM2mqy3L5uyX1GYzhr1ixbamrqYZ8fABA6SdsVK1Y45hcvXmzqCPZEyd9//+3yfeCcuKnMd25lkrYV+X6tbNJWn+f66683dRv9vl+7dq3H+OqPzvq9aX+sfvdqXJ566inHD986XXnllW4TPzqdeOKJ5vt76dKlpk6lCUmtC9nv79Onj6kT6WvWOpS717BmzRqXZJm+F7o9rW9GRUU5lut3u53ze6fT1VdfbR5z1llnOZY1bdrUY5zKU8fctWuXqbvq69P60/Lly018zjvvPLexKVln1B/uX3vtNbM/Ocdz7ty5jseMGzfOsVxf6w033GBex8KFC20XXXSReS/Unj17HD9Q6HT55Zc76nTO+4wmzD29V5MnTzb18JNOOslludaHlyxZYrv11lsdyzQRlZmZ6bPn1tf5wQcf2K644opSz6ENLb7++mvbhRde6LIv6jKdfvrpJ9vhOJdj+/btpe533l/0M6L1S41zyeTloEGDzHt8ySWXeNyPNOm4YMEC83jdJz755BPbfffd59KIwtN+p8ep4cOHuzSE0fOsip6ndOnSxRHLJ554wvbFF1/Y3nzzTVNGfc1vvfWWx/dE9y/dH+655x6Xcwmdt3v11VfN/qrnDLp/67FK32f98UHXDQ8PN8eRynwugz1pq8de/d5w97zHHHOM2Ufd+eabb9yeiyJ4kbQFELK08uP8BfXss8+W63HOv0zql7Yz/ZJzV+F1fh7nyrlWXp0Tls5fpPaKvrZAtbe01F9C7etrpdKe6NPKhX25VqTtFUKtiDhXWP766y+3FXB7otNOn8/55ERPAOz013LnVgn2yoC2CLUv0+fUyp69HFq5cr7PXmF2rrjocucK6amnnuq47/HHH3ecKDqXW09KPNGTO/t6J598sqMsOjknpJ1PZKoiaauVUn3P7fP6/J6Stkrj5i5xa5+0hYu2kgEAVI+krdKWYDqvyYF27dqZ//V7UDl/B9gTnpX9zq1M0rYi36+VTdpOnTq13PF1/nFdryQ6ePCg474nn3zScZ/Wc7Rlc8nEj7b6c36Mco6ptuDUhJ+dJiDdvQb90d2+rGvXri7b+9///uc2GeacHNJWuM6JVufncG7V6m0dU2miUVtFaqJJE2Ml6xrO65esM/7444+O+zTRWfI90taVztvU98MTTcjZ19Mks/O+pD8GOF+1ZOf8Xh177LGO5W+88YZLOdetW+eo0+qP/Pbl9oR/ZZ9bE4v2Vrj6HM4/FDj/qOBc59PHe8N5myX3yZL7iyZG7ZzrnVpnt7e41zq8p/3ojz/+sE2YMMEk5d21Ui5rv7NfVaaT7lfOZa3IeYq20tX52NhYc2yzt9h1x/k96dWrl8t9V111leO+bt26OZbv27fPNm3aNPO51Jal7loiO58bVeRzGUjlSdpqDDSJ7+691vdEP9v6w0NJ+rlyd+xC8IoIdPcMAFBR2oeRM+cBQMri3I+S9tPlTOft/Q95GnhK+4uy0/6TnPuls9N+rnQ9HYBq586d8sUXX5j+mT788ENzv/bjqv2jKe2P1rkfpXPPPddj2bVv3o4dO7os0z6ltH+xkv0t2fu1Vdq3l13Dhg1NH2lr1qxxeYz2o2an/STpAG/u6H3a76z2S+VMt6n9bJUVG+fn0HK769/LXXk0jjp5iklV09FWdYAxfS+1rzntC9mTwYMHy6ZNm+Stt94y77v2+/bvv/+6vDfXXnut6Z8MAFA9XH311aZfza+++splmSeV/c6tjEB8v9rrPOXhXP865phjTL+T7uptWs/ZsWNHqcGdtE9O58co5/7127VrZ/rXdFdH8qa+qH3r2utxmgMr2aevp/qivV5Up06dCtUxtT9O7buyLCX7ALXT59TxBMp6Dn09Ogq9nY6ZUJ59SfcX7R/Xm33phBNOcFsWrScfeeSRjkGGdfyJzMxMl3JW9rm1v1z7e6bPof322vvMdY63r5TsZ7W8sdB6v75+ex3e3X7022+/yfHHH+/oj7es/cLdfrdy5Upzq30Lv/POOy4DOFfkPEX7H/7uu+/MQFf2Y5v2T6v9SeuxQMd50L7AS3L3OXvyySfN///884+51W3qZ7bkGBjuXqs7FflcOtN6vMakPPQ4pMcwX9PPp/bfq2OJqLvuusucW+i5sPbh/e2338rcuXPNudajjz7q1X6I4MNAZABClg5M4JzA9HTS4Wv2ipNyrnCU/BLUConzAGlvv/22Y7ALrfAcrpP58o6A3KRJE7eDf5Q1X1nuyuEcl8PFpqrL4mv6Xt16662OAUl0hNayaIXvwgsvlJdfftmcKGrS1t7xv/rhhx+qvMwAAP/R73Xn70EdIMf5uB/s33OHe17neoRzQq/kAESe6IBZ/uLP56pIfbGselF56pj333+/438d7FQH09JBjPTHZbuSA6S5235Zz+FrnvZhTc7aaeLUU8MMZ96W09Nz+yMWzj8OHC4RXJlY6MCH9oStDg6m5x1aXy05AJmn/SI8PNyRCC+Z5KtIrHWgO/0BSwcR00Yr+ho02an1Z112ww03VPg5NKlsT9jquaAOePbll1+az0DXrl29+gyU93PpTBvg6A8E5Zl0gOWqoLG1J2w1tjqYpZ57aKMh59jaB/Vz5rwfaiIdwY+kLYCQpiOOOidtdZRWd/TXWfsImtoi1E5/iXTmPO+8XkXoaK36q71avHixaRlhp61x7Dp06OCoLCmtiPzXfY3LpBWhiRMnlnoedwlZrSQ6V/7sv6ArHQXWXStie4sGe5IyLS3NYzn0192K0F/wnUeotbc8dldhci6Pjm7triw6+aOlrdIRmdu0aWP+Lzlqsp2ONPzLL7+UWq4jATu/d54qkgCA0KTfm87f7ZMnTy7zB1N/fOeW57nL+/1qr8+o7du3O/5///33y/Wc3vx47Fz/Wr16teMH75L1NB2V3l2C1t1zaetaO/0hVetCdtoi8HDlKKu+qPU4X/84XpatW7c6/p89e7YMHz7ctEj0VXK/ZL1Uk2TlqatpS1FP+1JV/PDgr+d2TqB6W39zTiIermWor/aJa665xvyIpElD5/exLHPmzHG0rr3xxhsdrVsrep6i8yeddJJp7akNFbTVq3ODhddff91tOcr6nOkPYSVfq/5ooVc09O/fX7p16+ZybKrOnH8s0/MpnezS09Pd/u9uP3TePxG86B4BQEibMmWKLFy4UH799VfHyYf+iqvdBWhlPiUlxVyGrsnc3bt3S1RUlEn02hNrWpnQXxn1skOtlP7000+ObbtLkHpDL4kZP368qfjoJXzffPONWa6XBh199NGO9fQXUr30zJ5w1sv69FdSrZzoSdyWLVvMr+WaaPXUZYO7Cqb+uvv888+b+dtvv9289ubNm5sKvvMJkPMXt14ypzHQS4/0sjGt+Ollh1o50Ev+9XJ/rbBWtFVzly5d5LjjjnMkkfUSnmnTppn46yU9H3zwgXkP9QRE3yf9tV+fTyt3+guyvq96qY9WyrQ1gLYuufnmm12S9+Vx0003lVqmJ8133HGHx8doZfbOO+8sc7/QVrWnnHKKiaOWtXv37mY/1Armvffe61hPL2EDAFQv+p1pv4pGr7Yoiz++cz2pyPerJm7sdSe98kQvVdcyais3XxszZoxMnz7dXKqurfO0PqOXW2vZtIsiO61DuLvE2h29RFtfp5ZbExx6ifb1119v6obO23Q2YcIEEydNQK1du9a8p1o2TWY7v25v6yCVpT8E//nnn+b/e+65x3SVoMlt53pGZeiP/meffbapXyutk2p9Wn880MTcsmXLTP3miiuukHPOOcfsJ7pck9/6XmnCULehj9EEkf5AP2rUqDLrWBXhr+d2voReW3MuXbrUPEfTpk0diURPNJmodVv1448/ms95Ve0Tds8995xpcaktKu1XiZXn8/HSSy+Z8xY9LuixKC4uzlw1WJHzFN1/9LOpr1+7TtMWsc5Xqbk7D7HH6NJLLzXPp8ebefPmOe7Tz17J16r7ol7Vpu+HdlfiqUsEX9LPe1V85jU+9u457Lfq559/drS21h9ntIsM/fzZ6ffH2LFjTQtm/THK+T137grFOcZ2vv5BEFUk0J3qAkBl6eigJUecdTdpR/pKB60YNWpUmes6j1CqnO/TQTcON/iH3S+//FJq2zpwQkk6IIbzKMHuJuftH+557XFp3rx5qe3oSMFJSUluO7jX0WNbtmxZZjmcBz/xNChKyYEFdBAHu3///deWmJjocfs6erbzgCP2Ea49TZ466Pd2pFeNi6eByOx0oIqSI/o6D0T22WefHfZ5dKTj1atXH7bMAIDQGYisLM7fAc6DePnqO9fbgcgq8v3qPOK481Sy7lKeulN56Oj0zgMclZySk5Nt6enph61zONMBa91tq2PHjh5fw+zZs90OcuQ8qFF+fr7bAY9K1k88xcPTck/v69y5c92WRUeC97bO6GmQLR3kSAd+8vS6H3nkEce6ixcvdhng1t3k/J54eq/KKqengfB89dxlPYcO3OTus3LRRRfZDmfLli2Ox/bp06fU/Z72l7Lq1+72Fx04zd3nxXmfKM9+N2fOHMcyLbcOOlaR85QhQ4aUue4111zj9j3p0aOH28+bDjiWnZ1t1tfbtm3bllpHB+Xr1KmT23hW5HPpb877n6fJeb+87LLLylxXB8FbuXKly3PowHv2c7B69eo5YorgRvcIAEKe/tKtfRlpS1n9lb1Vq1amlWvt2rVNn7f6q/u7777r6C5AL/Gxd1egvzDqr5f6a7C2uB0xYoRp0eKp1YW3Sraqtbe+ddedgf7yqb8Sa0tULau27NSWsTqv5dE+cb2Ni15WpK1JtHWJxkN/SdcWv879Y+mv33baD5a2JtGWuT179jSP0ZY3GlO9zElbcWjr5MrQX8j1OWbMmGFio8+hrYC1dZGW1flyN728VFvlasy0DLqetlzV91V/xddWAWUNkOFr2oL57rvv9ni/tqDV/qO0RZC2HtbWBVpmfd+1lZL+Cq4tB5z3CQBAzeSP71xPvP1+1YF/FixYYO7X+ok+RvtR9NQtVWVpyzGtF2lrWq0f6HNqfPS7ddasWaYuo+X1hnZfoa1H9TJqfb3atYJesaUDh3ryv//9z9QxNRZar9L6otbRNB7aClC7h3AetMkftC7x9NNPm+4btH6h+5G2CNb9yFe0dalezv7www+buo29Xqox05aWvXv3dukOTOs22kJSW19qmbRuqf9rC27dh6+88kqpCv54bq2X6udBrxbz9r3Wz4l90F2tkztf2u9L2nL/s88+M++Vvn7dV3UQ3fJ2X2KnsdL6udIWt9raXM+vvD1P0VbY2q+t7qPatYqee+ljdN3HHnvMpf9lZyNHjjQtmXX/0vdSW5Vq92T6GdSWv0pv9SoEfe+1f1rdrp6/6TFBx/moKfQY8Morr5gBkPUcVo9N+v2h+74e6/Rz4fw5VRqjbdu2mf/1vbXHFMHNopnbQBcCAFA13I1mrJca6mVTejmNWrNmjctlNgAAAAAqb9WqVWYwLq2Ta3+xDzzwQKCLFFS0qwH9QUhpNxbaFRmqhnYxoT+0abL277//No1LEPxoaQsA1digQYPkmWeeMb+26i+r2opYf8W2J2w1WastTgAAAAD41jHHHOO4yk5bR2o/sIC/aZLW3hp66tSpJGxDCAORAUA1poOJ6GV07uilNHpZjT9HPAYAAABqEh0sSycgULSbtqKiokAXAxVAS1sAqMa0Tyntz0j7hNK+jrRvW+1PVUcW/eOPP+Soo44KdBEBAAAAAEAJ9GkLAAAAAAAAAEGElrYAAAAAAAAAEERI2gIAAAAAAABAEGEgsgqyWq2yY8cO0z8kg/gAAACEHu0lLDMzU5o3by5hYaHRloE6KAAAQM2og5K0rSCtLCcmJga6GAAAAKikbdu2ScuWLSUUUAcFAACoGXVQkrYVpK0b7AGOj4/3S6uKvXv3SqNGjUKmJUigETPvEC/vEC/vEC/vEC/vEC/vEK9DMjIyTALUXq8LBfaybtmyRerVqxfo4oQ0Pgu+Qyx9h1j6DrH0HWLpO8QyyGLZqZPIzp0izZqJ/PWXBFsdlKRtBdkvR9OErb+Strm5uea5+GCXDzHzDvHyDvHyDvHyDvHyDvHyDvEqLZS6GfB3HbQ647PgO8TSd4il7xBL3yGWvkMsgyyWYWGHbgNQrzpcHZQ9BAAAAAAAAACCCElbAAAAAAAAAAgiJG0BAAAAAAAAIIjQpy0AAKgWbDabFBQUSFFRUaCLEvT9f2mctA+wmtCXWmRkpISHhwe6GAAAAIBXSNoCAICQp4nabdu2ycGDBwNdlJBIbmviNjMzM6QG4KoofY0tW7aU2rVrB7ooAAAAQLmRtAUAACFNE5AHDhyQmJgYad68uURFRdWIZGRlkraFhYUSERFR7eOkr3Xv3r2yfft2ad++PS1uAQAAcMj27RLMSNoCAICQlp+fb26bNWsmtWrVCnRxgl5NStqqRo0ayebNm02XECRtAQAAECqqf0dmAACgRqgJ/bPCezUhMQ0AAIDqh7MbAAAAAAAAAAgiJG0BAABCyKuvvionnHCCYz4pKUmWLFli/p8/f7706NEjgKUDAAAAQsSMGSJTpxbfBiGStgAAAH7Qv39/c6n+559/7rJ89uzZZvm1115bru2MHz9evvvuOwl1v//+uwwZMkQaNmxoXn9aWprL/drvrsZEB5erW7eu9OnTR1avXh2w8gIAAKCaefZZkUceKb4NQiRtAQAA/KRjx47y4osvuizT+U6dOkmw04G8fCkyMlLGjBljWge78+STT8r7778v33//vaSmpsqpp54qI0aMMAOpAQAAANUdSVsAAFAt5Rfle5wKrYXlXregyDVZ6Xyft8aOHSsfffSRpKenm/kffvjB3Pbu3dtlvX///VeGDx8ujRo1ktatW8s999wjVqvV6y4QsrKy5KqrrpJWrVpJ48aNZcKECY7nXr58udSrV89l/VGjRsmdd97pcv/TTz9tHu/cJYOvEtgXXXSRHHXUUW7v37hxowwaNMi8/vDwcLnwwgtlx44dsn//fp+WAwAAAAhGEYEuAAAAQFW47+v7PN7XPqG9jO823jE/+9vZUmB135I0qV6SXNDjAsf8oysflZyCHPP/nf2LE5zlpUlQbTH6+uuvy+WXXy4vvPCCSUb+8ccfjnVycnJMslK7Bnj77bdl165dctppp0mzZs1MktMbkyZNkoiICFm7dq1p2XrxxRfL1VdfbZ63PDIzM+XXX3+Vv/76y+M63bp1k61bt3q8v2S3B+Wlr1XLrwlsTRo/99xzcvzxx5vuFAAAAIDqjqQtAACAH2mS9tZbb5WJEyeapKz27XrTTTc57l+6dKnUr1/f0cetJiynTJkir732mldJ271795rt79u3z9Gi9q677pIuXbrIs+Xst0tb995///0SFxfncR1NCFeFtm3bmhbFRxxxhGlp26RJE9NKGQAAAKgJSNoCAIBq6ea+N3u8L8zi2kPUDSfe4HFdi1hc5q89rnwDhnmirWg1+Xr33XeblqNNmzZ1uX/z5s0mkevcdYEmTxMTE716Ht2OPq5NmzYuy8PCwkzr3fKoU6dOqS4U/OXKK6+UnTt3mi4RtJuIJUuWyMCBA02SWAcnq+kyMjLMe4mK08+HtmwnlpVHLF1FRUVJTExMoIsBAAhxJG0BAEC1FBUeFfB13dGEhrayvffee+Wtt94qdb8mZ5OTk2XlypWVeh7djj6XJj2dW8rqQF6FhYWmJe7BgwfNvMVSnJjWJKlzf7nlSb5oy90tW7aU2a9uRfzyyy+mBbJ2C6HOOussmTZtmnz33Xfm/5ouKSmJQdkqSfdv/aytXr3a0Wc0KoZYumrcpKls2byJxC0AoFJI2gIAAPjZddddJ/369TNTSaeffrpMnz5dnnrqKdOnq/ZFu2HDBpNQ7d+/f7mfQ1vw6sBiOhDZrFmzTF+w2sJWk546yFmHDh3MtrXbBR0g7Y033jCJ0qFDh3r1Wpz74/WGJhzz8vLMpPQ2NzdXoqOjTRJZWyG/9NJLMmTIEGnQoIG8++67sn37dunatWuFnq+6uXvpMqnflBbHlWKzSczBLMmNrS3y3w8XqCBi6XAwK1P+d1Ivyc/PJ2kLAKgUkrYAAAB+lpCQICeffLLb+2rXri2ff/653HjjjaYPWk1ktmvXTm64wXMXDp7Mnz9f7rjjDunVq5fs37/f9As7ZswYk7SNj483fdvq80yePFnOO+88kyD1F22d69x1g72biE2bNplWpA8++KBMnTrVDHSWnZ1tlmkSt2PHjn4rYzCLqVVHYmvXCXQxQpvNJpFiFYvGsYYnGiuNWAIA4HMWG9dVVYj211S3bl1JT083Jz1VTS8z2rNnjzRu3Jh+osqJmHmHeHmHeHmHeHmHeHlH+1HcuHGjSWzGxsYGujhBz949QkREhKNbhOpMk96aCNYEcclWb/6uz/mCvcwPfvWTJDSjpW2lE41Z6VJQuy6Jxsoili4tbScf3anCxxXqAL5DLH2HWPoOsQyyWI4fL7Jvn0jDhiKvvir+Ut46KC1tAQAAAAAAANQsr/ovUVsRpPUBAAAAAAAAIIjQ0hYAAAAAfOiGAb1lf8p2t/edeMbZkp+bK3+v+kHS9+4xy174O8Vx//4dKfL8tCmy+fffJDc7Szoee7xMe+Utv5UdAAAEB1raAgAAABXQo0cPM3Xu3FnCw8Md8+ecc45kZWWZgd0aNmwo9erVc3lcWfehehh/291y2cNPyTk33W7ma9dPMPM69T93gulPus+Z57h9bGF+nsQ3aCTJg4f6udQAACCY0NIWAAAAqIA1a9aY282bN5tkrX1e5eXlybRp0yQhIUH69+/v8rjIyEiP96F66DFwsLnd+e8GWXT/XRIdFye9Tx/puL/do09LQV6uLJ37RKnHNklqK5c/+rT8tuJL+fadN/1abgAAapSBA0V27xZp0kTkiy8k2NDSFgAAAPCx6OhoGThwoNuWtGXdBwAAAD/5+2+RdeuKb4MQLW0BAACAIKUtdnWyy8jICGh5AAAA4B+0tAUAAACC1MyZM6Vu3bqOKTExMdBFAgAAgB+QtAUAAIBs3bpVateuLenp6eVaPzc3V8444wxzif+xxx5b5eWrqaZPn27eE/u0bdu2QBcJPvDj0nflm8VvOOZXvPGa/Prl5+b/3OxsM//7N8vNfNre3WZ+yx+/Bay8AADA/0jaAgAA+IEOOKV9mWpitE6dOtKlSxd5883gGWSoVatWkpWVZVpzlsdbb70l69evl927d8uPP/7o07J8+eWXMmDAAFMWd/2+ahcBEydOlMaNG5vBvE499VT5999/pTrSfSY+Pt5lQuh788H75OU7pjvm5996g3z8/Fzzf9aBVDP/2fznzPzuTRvN/C/LPg1YeQEAgP/Rpy0AAICfPPDAA3LttdeKzWaTDz/80LRU1VaqrVu39npbBQUFEhkZKYGyadMm6dChg0kq+lqtWrVk0qRJct5558n1119f6v7bb7/dJIzXrVtnEuBTpkwx637//fcSTLp16yZ79+41SeaWLVuaRPTLL7982PtQfTRrd4S88HdKqeWzv/zB42Matkx0+xgAAFCz0NIWAABUT/n5xZPNdmhZUVHxssJC367rJYvFIsOGDTOtSDX5aPfpp59Kz549TQvTo48+Wj7/vPhyaXXBBRfIRRddJGPGjDGtLefOnWta7+rl80OGDDHJS33Mb78duoRaW85eddVVphWttkqdMGGCx+4PNm/ebMqVlpbmeL5LLrlExo4da7bdsWNHWb68+HJtTaTefffd8sEHH5iWw3fccYf4kiayzz//fGnXrp3b+zdu3CgjRoyQhg0bmqSxruv8uv0tKSnJETdna9eulZ07d4rVapXt27e7JGXLug8AAAAgaQsAAKqn++4rnnJyDi379tviZR9+6Lru7NnFy50Tmj/9VLzs3Xdd13300eLle/dWuGiaqHv33Xfl4MGD0qNHD7Nsw4YNMnLkSLnttttk//79cvPNN5vEpLZotXv99ddN4lYThHqrNNk3a9YsOXDggBxzzDFy9dVXO9bX1qqpqakmQajb0da5zvcfzqJFi+Tyyy83z6eJUU3kqoceesiU7/TTTzeJ4RkzZrh9vCalPU3a0rSiNBH9ySefyK5du0wM58+fL8OHD6/w9gAAAIBgQ9IWAADAT7RVrCYs9fL/0aNHy6233mpawNoTpNpyVpdHRETIWWedJX369DGJWrvBgwebVrVhYWESFxdnlmm3AN27dzeP0X5eV69ebZbrpfdvv/22zJkzx/Gcd911l3meIm1FXA6nnXaaKVN4eLhceOGFsmXLFpNQLi9N9nqaNJFcUfp6tTVys2bNTCvgb775RmZr4h0AAACoJujTFgAAVE8331x869zv64knihx3nEhYid+tb7ih9Lq9eokcfXTpda+9tvS65TRz5kzTp629Za22pNWE6mWXXWYukdfL7J21bdvWLLfTbg5Katq0qeN/Tcxqy1d7dwfaordNmzYu62vCV1uolqcf3ZLbVpmZmdKgQQMJJE1oa/m1FbGW6+mnn5a+ffvKH3/84UhmAwAAAGW6/XbtT0ykdm0JRrS0BQAA1VNUVPFksRxaFh5evCwiwrfrVsARRxxhWrJqv7BKB6PSRKszndflzgnX8kpMTDTr79ixw6WFq3Yn0KJFC/EH7e/W09SlS5cKb/eXX34x3TbUr19foqKi5JprrjHJbR2YDAAAACiXSy8VmTq1+DYIkbQFAAAIAE3Ifvjhh9K1a1czf84555iBvrSv28LCQlm8eLGsWLHCDARWEdpKdtSoUab/13379pll2sL2nXfeEX/RVr+eJm0V64m2EM7NzZV8HfBNxPyvk93xxx8vzz77rGn1q7F66qmnJCYmxiTCAQAAgOqA7hEAAAD8ZNq0aaYfW6XdImj/tbfrZVn/tbzVRK32e6uDfmnXCJpg1duK0gG67rjjDunVq5fpi7ZJkyYyZsyYoB+0S5PVAwYMcMzHxsaaW5vNZm5ffPFF082ExkYHV+vYsaMsWbLExLSmyM3OlINZmYEuRmiz2cR2MEdytR1LJVvO13jE0oHPJQDAVyw2e+0XXsnIyDADYKSnp0t8fHyVP5+2ONmzZ48ZrMSbSyNrMmLmHeLlHeLlHeLlHeLlnZycHNm4caO0a9fOkdyDZ1r109apOnCZpQYkV7SF7qZNm0zfvtoaN5D1OV+wl1nfO6rxlaPH1+TkZDN4nx53UXHE0lXjJk1ly+ZNpY455UEdwHeIpe8QS98hlkEWy507RXSAXu0WrVkz8Zfy1kFpaQsAAACEYPcaNallcVWd7OlgdgkJCZw4VxKxdKV9bVckYQsA8LNevURSUkR0vAenwX+DBUlbAAAAIMRoq4xQaR0crOx9J2scSTRWDrEEAMD3+EYFAAAAAAAAgCASFuhBJnQgjObNm5t+uXQACWc6srCOeNyyZUvTR13nzp1l7ty5ZW6zf//+Zlslp2HDhjnWueCCC0rdf+qpp1bZ6wQAAAAAAACAkOgeITs7W7p37y6TJk0yoyeXNHXqVPniiy/klVdekaSkJPn000/lyiuvNEneESNGuN2mjrqcn5/vmNeRkvU5zj77bJf1NEmrIw/bRUdH+/S1AQAA/2JQJrjDfgEAAIBQFNCk7dChQ83kyXfffScTJ040rWfVpZdeKvPmzZMff/zRY9JWO793tnDhQomLiyuVtNUkbdOmTX3yOgAAQOBERkaaxFxOTo75zgec2X/MD9dRgQEAAIAQEdQDkZ1wwgny3nvvmZa42rp2+fLl8vfff8sjjzxS7m08//zzMnbsWKlVq5bLct1W48aNpX79+jJw4EC55557pEGDBh63k5eXZya7jIwMR6f7OlU1fQ49IfXHc1UXxMw7xMs7xMs7xMs7xMs72s2R/hi7Z88eM6+JW10GzwoKCkyyu7rTz5DuF9rNlg6OVPIzxWcMAAAAwSqok7ZPPPGEaV2rfdpGRESYyvazzz4rJ510Urkery1yf//9d5O4Ldk1gnbH0KZNG/n333/l5ptvNi1+v//+e4+tMGbOnCkzZswotXzv3r1mpNSqpicV6enp5iSeEVnLh5h5h3h5h3h5h3h5h3h5H6/CwkLzHb5z504StuWMWU3atzSRr3W2kjIzMwNSHgDVm54fOnfZ5+3xWa8c0UZCNek4XRWIpe9Up1hGRUVJTExMoIsBVI+k7cqVK01r29atW5uByyZPnmxa3Z588smHfbwma7t27SrHHnusy3JteWun93fr1k3atWtnWt8OGjTI7bamT59u+ti104NVYmKiNGrUSOLj48UfB0k9CdXnC/WDpL8QM+8QL+8QL+8QL+8Qr4rHSxPd2ooUZccrNTXVdClV3fcv3S+0RbGn18lJG4CqSNi2TEqS/bt3V+jxerxKTk6W1atXczVAJRFL36lOsWzQpIls37yZOgBCQtAmbQ8ePGhawL7zzjsybNgws0yTq2vWrJEHH3zwsElbHeRM+7O96667Dvtcbdu2lYYNG8qGDRs8Jm31skt3g5XpwctfJzx64uHP56sOiJl3iJd3iJd3iJd3iFfF41UTLvuvDD3ZysrKMq1Pa/r+VdNfPwDf0xa2mrBtuOhjscS5dtFXHmE2m8RLgTSSSLFy5UilEEvfqS6xtOVky75zTjWfU5K2CAVBm7TVVjI6laxM66WP5fll58033zR90J533nmHXXf79u2yf/9+adasWaXKDAAAAACAJmzDatWuUHIsrPCghEXE6i+SVVK2moJY+k51iWVotxFGlVi2TKSwUCQiONOjAS2VtvLQ1q12mzZtMi1p9XK9Vq1aSb9+/eSGG24wg0do9whfffWVvPTSS/Lwww87HjNhwgRp0aKF6XO2ZNcIo0aNKjW4mD6n9k175plnStOmTU2ftjfeeKMcccQRMmTIED+8agAAAAAAAAAB1bGjBLOAJm1XrVolAwYMcMzb+4ydOHGizJ8/33RvoH3Jjh8/3vS9ponbe++9Vy6//HLHY7Zu3VqqNe769evlm2++kU8//bTUc2pL3bVr18qCBQskLS3N9I87ePBgufvuu912fwAAAAAAAAAANSZp279/fzNgiCfaEvbFF18scxs6eFhJHTt29LhdbbX7ySefVKC0AAAAAAAAAFD1grPTBgAAAAAAgCqwd9xpYt290+19MUOGiy0vTwrW/izW1H1mWZMvfnHcrw3Ecl57QXLefUOs6Qckos0RUufK/0lUt6P9Vn4APvLaayI5OSJxcSLnnivBhiFzAQAAgAro0aOHmTp37my64LLPn3POOWYcBR0voWHDhlKvXr1Sj/3ggw+kU6dO0r59exk9erRkZGQE5DUAQE0Uf/U0qXvrTKl9RXEXjZa69cy8TnEjzhaxiMQOHen2sbmfvi9Zzz8pEa2STLK2aPdOSbtlilgz0v38KgBU2o03ilxySfFtEKKlLQAAAFABOoCu2rx5s0nW2udVXl6eTJs2zQywq12COdOE7kUXXWQG2dXE7VVXXWXGV5g9e7bfXwMA1ETRJ/Qzt4VbN0nW0w+LJSZWYgae6ri/3m0PiC0/T7Jffb7UY3OWLDK3ta/8n0S2bS9Fe3eblrcHP3lfap19nh9fBYDqjpa2AAAAgI/pALcDBw5028r2o48+kp49e5qErbryyivl9ddfD0ApAQDeKtq+1dyGN25afNuk2X/LtwS0XACqH1raAgAAAH60detWad26tWM+KSlJdu7cKYWFhRIR4Vo91xa7OtnRjQIABJkyBlcHgMqgpS0AAAAQpGbOnCl169Z1TImJiYEuEgDUaOEtW5lb7cvW3O7Z5bIcAHyFpC0AAADgR61atZItWw5dRqt94jZr1qxUK1s1ffp0SU9Pd0zbtm3zc2kBoObJ/fITOfjxe475nKWLJW/l1+b/uBFjzG3W0w9JzrtvyMGli8USV0tiBw8PWHkBVE90jwAAAAD40amnniqTJ0+Wv/76y/Rr+9RTT8nYsWM99o2rEwDAfzKfeUys/7WkNfMP3S2R3ZMl+ri+EnPqCCnat1sOvveW5K+dLRFt2kudK6dKWN3SfZgDQGWQtAUAAACqQLdu3WTv3r2mH9qWLVvKgAED5OWXX5Y6derIc889J6NGjTL92B511FGyYMGCQBcXAGqciFZtpMkXv5Ra3uj1Dz0+xmKxSO3zLzUTAFQlkrYAAABAJehAYmlpaaWWr1271uNjRowYYSYAAADAHZK2AAAAAAAAAGqWpk1db4MMSVsAAAAAAAAANcuqVRLMwgJdAAAAAAAAAADAISRtAQAAAAAAACCIkLQFAAAAAAAAgCBCn7YAAAAAAPiQLSdbrBV6oE2sUiDWvCKxWiy+L1hNQix9p5rEUj+XgIvLLhNJTRVJSBCZN0+CDUlbAAAAAAB8ICoqSho0aSL7zjm1Qo8PCwuTjORk2bt6tVitFUr74j/E0neqUyz186mfU8BYulQkJUWkRQsJRiRtAQAAAADwgZiYGNm+ebPk5+dX6PGaEEtNTZWEhASTKEPFEUvfqU6x1IStfk6BUEDSFgAAAAAAH9GEUEWTQpocy83Nlfj4+JBPjgUasfQdYgkEBp82AAAAAAAAAAgiJG0BAAAAAAAAIIiQtAUAAAAAAACAIELSFgAAAAAAAACCCElbAAAAAAAAAAgiJG0BAAAAAAAAIIhEBLoAAAAAAAAAAPwnNzdX8vPzJVRZrVbJycmRjIwMCQurWJvU6NGjJTwzUyIaNpRgRNIWAAAAAAAAqEEJ26SklrJ7934JVWFhYZKcnCyrV682CdyKatKkgWzevF1iJPiQtAUAAAAAAABqCG1hqwnb1xe2kri40Ow51WbTcjcWkSSxWCqWtM3Jscq4sVtNPGJigi9tS9IWAAAAAAAAqGE0YVurVugmbYuKLBIeHiYWi1RLofnOAAAAAAAAAEA1RdIWAAAAAAAAQI0y4Irtki4itY45RoIR3SMAAAAAAAAAqFEicm0SKyLW7GwJRiRtAQAAAAAAAPjU+HO3yu7dhW7vGzy4tvToGSuLFqbJzp2F0qBBuIwbV09OGxbv93IGK5K2AAAAgI/16NHD3OpoxOvXr5euXbua+Y4dO8qiRYtk9uzZsmDBArFarWbZiy++KPXq1QtwqQEAAHznqqsaSG6uTfbvL5S5c1Olbt0wueqqhuY+TebOemCvJLWJlKuvaSDvLM6Qhx/eJ82bR5pkLujTFgAAAPC5NWvWmOnDDz+UOnXqOOY1YfvZZ5+ZJO33338v69atk+TkZLnlllsCXWQAAACfOv6EWjJgYG05tnecmY+JCTPzOqWmFrfAHTo03kzDRxS3sF3yrvYyC0XSFgAAAPCjX3/9Vfr06WOSueq0006Tl19+OdDFAgAA8Jv6CcUX//+29qBpdbtmzUEzvyPFfXcKNRFJWwAAAMCPtGXt559/Lrt27RKbzSavvvqqZGZmSmpqaql18/LyJCMjw2UCAAAIdSNHxkvnztHyzTc5pu/bVT8VJ22tNlugixY06NMWAAAA8KMBAwbI//73Pzn99NMlPDxczjjjDLM8IqJ01XzmzJkyY8aMAJQSAACg6sTFhcljjzeXrVsKJOegVTZvzpeHHtwnHdpHB7poQYOWtgAAAICfXXnllbJq1Sr54YcfpH///tKyZUuJjy89WvL06dMlPT3dMW3bti0g5QUAAPClrCyrPDVnv/z1V5788vNBeWZeqkRHW2TMOQzMakdLWwAAAMDPdu7cKc2aNZOcnBy5/fbb5cYbb3S7XnR0tJkAAACqk7AwkbVrc2Xp0kyxWEQ6dYqWiy5OkKSkqEAXLWgEtKXtihUrZPjw4dK8eXOxWCyyZMkSl/uzsrLkqquuMi0PYmNjpXPnzjJ37twytzl//nyzLecpJibGZR3tO0wrx1pR1u2efPLJ8s8//1TJawQAAABKGjx4sHTp0kW6d+9uBiXTOi8AAEB11KpVlHy+rK28+lorl+4R5j3TUj78qI0s/bCNPPRwc+nc2TV/V9XWXtlAzhaR3EcekWAU0Ja22dnZpqI6adIkGT16dKn7p06dKl988YW88sorkpSUJJ9++qm5lEyTvCNGjPC4Xb20bP369Y55Tdw6mzVrljz++OOyYMECadOmjdx2220yZMgQWbduXakELwAAAFBRWodNS0srtfy3334LSHkAAABQbHevOHlLRJ4/9VQJRgFN2g4dOtRMnnz33XcyceJE08+XuvTSS2XevHny448/lpm01SRt06ZN3d6nrWwfffRRufXWW2XkyJFm2UsvvSRNmjQxLX3Hjh1b6dcFAAAAAAAAANWyT9sTTjhB3nvvPdMSV1vXLl++XP7++2955DDNlrVbhdatW4vVapWjjz5a7rvvPnP5mdq0aZPs2rXLdIlgV7duXendu7d8//33HpO2eXl5ZrLLyMgwt/ocOlU1fQ5NOPvjuaoLYuYd4uUd4uUd4uUd4uUd4uUd4nUIMQAAAECwCuqk7RNPPGFa12qfthERERIWFibPPvusnHTSSR4f07FjR3nhhRekW7duZoTdBx980CR///jjD7MdTdgqbVnrTOft97kzc+ZMmTFjRqnle/fuldzcXPHHSYW+Hj3J0jjg8IiZd4iXd4iXd4iXd4iXd4iXd4jXIZmZmYEuAgAAAAKk7oY8OU4H/PrlF5F+/STYBH3SduXKlaa1rbac1YHLJk+ebFrdOreUdXb88cebyU4TtkceeaTpVuHuu++ucFmmT59u+th1bmmbmJgojRo1Mn3o+uMES7t90Oer6SdY5UXMvEO8vEO8vEO8vEO8vEO8vEO8DmEsAwAAgJrr2Hv3yPdaPz73XJGUFAk2QZu0PXjwoNx8883yzjvvyLBhw8wybT27Zs0a03rWU9K2pMjISOnZs6ds2LDBzNv7ut29e7c0a9bMsZ7O9+jRw+N2oqOjzVSSnuz464RHT7D8+XzVATHzDvHyDvHyDvHyDvHyDvHyDvEqVtNfPwAAAIJX0CZtCwoKzFSyMh0eHu5V/2NFRUVmdN7TTjvNzLdp08YkbpctW+ZI0mqr2R9++EGuuOIKH78KAAAAAAAAIPjk5IRu//42m/mr7WTFYrFWYhvBK6BJWx0wzN4C1j5ImLakTUhIkFatWkm/fv3khhtukNjYWNM9wldffSUvvfSSPPzww47HTJgwQVq0aGH6nFV33XWXHHfccXLEEUdIWlqazJ49W7Zs2SIXX3yxo2XJtddeK/fcc4+0b9/eJHFvu+020+XCqFGjAhAFAAAAAAAAwD+ioqKkSZMGMm7sVglVYWFhkpzcQFav3lzhwWW3iUic5golOAU0abtq1SoZMGCAY97eZ+zEiRNl/vz5snDhQtOX7Pjx4yU1NdUkbu+99165/PLLHY/ZunWrS2vcAwcOyCWXXGIGFatfv74kJyfLd999J507d3asc+ONN0p2drYZ5EwTu3369JGPP/6Yfs0AAAAAAABQrWn+a/Pm7ZKfny+hymq1mlyhNvysaJdXtY88UmTHDtPAMxgFNGnbv39/M3KxJ9qNwYsvvljmNpYvX+4y/8gjj5ipLPpmaItcnQAAAAAAAICalrgN5caLVqtVcnNzJT4+vuLjFARpstaO0RcAAAAAAAAAIIiQtAUAAAAAAACAIELSFgAAAAAAAACCCElbAAAAAAAAAAgiAR2IDAAAAAAAAAD87s8/RWy2oB2QjKQtAAAAEGIyMjIqPlIyHKNO5+TkEEsfIJauoqKiQnpEdgCoMerUkWBG0hYAAAAIMUlJSWLTliGoME0uJicny+rVq03SERVHLF01atRItm7dSuIWAFApJG0BAACAEHPFFVdIfHx8oIsR8urVqyeDBg0KdDGqBWJZLC8vTx555BHJz88naQsAqBSStgAAAECIiY6ONhMqJzIykjj6CLEEAISchx/WPqdE9IfwqVMl2JC0BQAAAAAAAFDzkrYpKSItWgRl0pZe4gEAAAAAAAAgiJC0BQAAAAAAAIAgQvcIAAAAAFCFHn30UUlPT3d7X9euXaV27dryxx9/SHZ2thm8ql27djJ06FAGsgIAoAYjaQsAAAD4WI8ePcytjiC/fv16k5hTHTt2lEWLFskDDzwgCxYskKioKJOYe/zxx+XYY48NcKlRVTQBW1BQIJmZmfLpp59KXFycWabS0tJk2bJl0qhRI+nXr5+sWbNG1q5dK/Hx8TJo0KBAFx0AAAQISVsAAADAxzTxpjZv3mwSuPZ5+31PPfWUaVmpLSxfeeUVueqqq+THH38MYIlRlTRZr/bt22eStpGRkXLUUUeZZT///LO5rVevnrRt21a2b98u27Ztk9jY2ICWGQAABBZJWwAAAMCPLBaLaXWpl8Jr0lZbWrZs2TLQxUKAdO/eXVJSUkzy9rHHHjPLNKF7/PHHB7poAAAggEjaAgAAAH5O0l133XXSpk0bSUhIkOjoaFmxYoXbdfPy8sxkl5GR4ceSwh80Yfvbb79J8+bN5aSTTpJffvlFfv/9d5PI7927d6CLBwAAAiQsUE8MAAAA1ESbNm2SxYsXy4YNG8yl8JrAPeecc9yuO3PmTKlbt65jSkxM9Ht5UbU0Qastr7V1rXajkJycbJZrX8gAAKDmImkLAAAA+NHbb79tBibTlpXqwgsvlG+//dYMWlbS9OnTJT093TFpX6eoXho0aGButYWtTt99952Zb9y4cYBLBgBANXf00SLHHVd8G4ToHgEAAADwIx1s6sUXX5SsrCzTp+0HH3wgHTp0kKioqFLratcJOqH66tWrl0nIr1u3TpYuXWoGIOvZs6cMHDgw0EUDAKB6e+89CWYkbQEAAAA/OuOMM+Snn36SY445xiRka9WqJa+99lqgiwU/aNiwodxxxx0uy8LCwmTw4MFmAgAAsCNpCwAAAFSRpKQkSUtLc1lmsVhMX7U6AQAAAO7Qpy0AAAAAAAAABBFa2gIAAAAAAACoWUaMENm7V6RRo6Ds35akLQAAAAAAAICa5eefRVJSRFq0kGBE9wgAAAAAAAAAEERI2gIAAAAAAABAEKF7BAAAACDE5OXlmQmVU1BQQBx9hFgWIwYAAF8haQsAAACEmKefflpsNlugixHSwsLCJDk5WVavXi1WqzXQxQlpxNJVo0aNJCoqKtDFAACEOJK2AAAAQIjZvHmz1KtXL9DFCGmaXExNTZWEhASTdETFEUtXmrCNiYkJdDEAACGOpC0AAAAQYuLj482EyiUac3NzTRxJNFYOsQQAwPf4RgUAAAAAAACAIELSFgAAAAAAAACCCN0jAAAAAAAAAKhZpk4VycjQfqckGJG0BQAAAAAAAFDzkrZBjO4RAAAAAAAAACCI0NIWAAAAAAAA8IP8/HzJyMiQsDDaUVaG1WqVnJycSscyKipKYmJiJBiRtAUAAAAAAACqWG5urlw86WJZ9uUyk3RExYWFhUlycrKsXr26wrGsLSJNGzSS3/78Q2IaNZJgQ9IWAAAAAAAA8EMr27SMNPn+8jekTlStQBcnpNksNslOsEqtPmFisVkqtI12z46XqP17xdqjh0hKigQbkrYAAAAAAACAn9SOjiNpW0k2sYk1skDqREWKRSqWtLVYKvY4fwloBxorVqyQ4cOHS/PmzU2glixZ4nJ/VlaWXHXVVdKyZUuJjY2Vzp07y9y5c8vc5rPPPit9+/aV+vXrm+nkk0+WH3/80WWdCy64wDyf83TqqadWyWsEAAAAAAAAgJBJ2mZnZ0v37t1lzpw5bu+fOnWqfPzxx/LKK6/In3/+Kddee61J4r733nset7l8+XIZN26cfPnll/L9999LYmKiDB48WFJKNHPWJO3OnTsd0+uvv+7z1wcAAAAAAAAAIdU9wtChQ83kyXfffScTJ06U/v37m/lLL71U5s2bZ1rOjhgxwu1jXn31VZf55557Tt5++21ZtmyZTJgwwbE8OjpamjZt6rPXAgAAAAAAAADVvk/bE044wbSqnTRpkulCQVvR/v333/LII4+Uexs5OTlSUFAgCQkJLst1W40bNzZdKAwcOFDuueceadCggcft5OXlmckuIyPD3OoIdf4Y8U+fw2azMbqgF4iZd4iXd4iXd4iXd4iXd4iXd4jXIcQAAADAs+OfHiPbM3a5ve+so06Vt37/2O3yR4bd7IfSVX9BnbR94oknTOta7dM2IiJCwsLCTJ+1J510Urm3MW3aNJPw1b5tnbtGGD16tLRp00b+/fdfufnmm02LX+1OITw83O12Zs6cKTNmzCi1fO/evZKbmyv+OKlIT083J1kaBxweMfMO8fIO8fIO8fIO8fIO8fIO8TokMzOzyrbdQ0ch/m+U6PXr10vXrl3NfMeOHU2DBK2j2u3Zs8dcAfbzzz9XWXkAAAC8ddcpUyQnP1d2Z+2Tu7+cIwmxdeWuk6819zWu3UD6t+ntWPfJlS/LX3s3Ss/mnQNY4uol6JO2K1euNK1tW7dubQYumzx5cqkkrCf333+/LFy40LSqjYmJcSwfO3as43+tQHfr1k3atWtn1hs0aJDbbU2fPt30sevc0lb7y23UqJHEx8eLP06wdMA0fb6afoJVXsTMO8TLO8TLO8TLO8TLO8TLO8TrEOf6oa+tWbPG3G7evNkkcO3zdkOGDHH8f/rpp8uAAQOqrCwAAAAVccoRJ5rbDfu3mKRtXGSsjOxcOm+WkrHbrKNJ3bOP8twNKqpJ0vbgwYOmBew777wjw4YNM8s0uaoV3gcffPCwSVtdR5O2n3/+uXlcWdq2bSsNGzaUDRs2eEzaah+4OpWkJzv+OuHREyx/Pl91QMy8Q7y8Q7y8Q7y8Q7y8Q7y8Q7yKBcPr37Fjhxl74YUXXgh0UQAAACrk+VVvSqG1SCYefYbERpbOnaGaJW21H1qdSlamtfuCw/U/NmvWLLn33nvlk08+kWOOOeawz7V9+3bZv3+/NGvWrNLlBgAAAMpr/vz5ctppp5mxFrwZVwEAACAYZOZly8Jfl0pMRLRMPHp0oItTrQS0eUFWVpZpOWu/XGzTpk3m/61bt5ouB/r16yc33HCD6bZA79NK7UsvvSRnnHGGYxsTJkwwXRfYPfDAA3LbbbeZ1gpJSUmya9cuM+lz2Z9Tt6ndLujlatqyYeTIkXLEEUe4XKYGAAAAVCXtV1jrrBdddJHHdXRchbp16zom7Z4LAAAgWLy65j3JzM82A5A1iKsnoWT78DvkeBHJee01CUYBTdquWrVKevbsaSalfcbq/7fffruZ1/5oe/XqJePHj5fOnTub7g60Be3ll1/u2IYmeHfu3OmYf/rpp82AD2eddZZpOWuftLsEe0vdtWvXyogRI6RDhw6mkpycnCxff/212+4PAAAAgKrw1VdfmQFty2o4oI0TdOA4+7Rt2za/lhEAAMCTQmuhvLj6bQmzhMmlvcZIqMlt0l5W6pgP/+Ulg01Au0fo37+/aWHgiY6i++KLL5a5DW2F60xbz5YlNjbWdJsAAAAABNLzzz8vF1xwgWlU4ImncRUAAAAC7f2/vpQdmXvk1A59pU0CVwPVmD5tAQAAgOpKW80uXrxYfvvtt0AXBQAAoExHNGgt26atKLX8jM6nmAlVI/BD5gIAAADVlI6xkJaWVmq59k+bnZ0tbdu2DUi5AAAAarraG3+Qs7RF68cfSzAiaQsAAAAAAACgRmn6xRPypojEXHedBCOStgAAAAAAAAAQREjaAgAAAAAAAEAQIWkLAAAAAAAAAEGEpC0AAAAAAAAABJGIQBcAAAAAAAAAqCmy8nLEYrMEuhghzWaxycECq4Tl51c4lo1tNglmJG0BAAAAAACAKhYVFSX14uvJ8XPHiNVqDXRxQlpYWJgkJyfL6tWrKxzLbSLSUkSCNX1O0hYAAAAAAACoYjExMfLcC89JfHy8STqi4qxWq6SmpkpCQkKFY1n7yCNFduwQiyU407YkbQEAAAAAAAA/tbYlaeubpG1ubm7lYhmkyVo79hAAAAAAAAAANUvt2iJ16hTfBiFa2gIAAAAAAACoWf76S4IZLW0BAAAAAAAAINSTtrt375bzzz9fmjdvLhERERIeHu4yAQAAAAAAAAD82D3CBRdcIFu3bpXbbrtNmjVrFrSjrAEAAAAAAABAjUjafvPNN/L1119Ljx49fF8iAAAAAAAAAKhKN9wgcuCASP36IrNnS7VI2iYmJorNZvN9aQAAAAAACGG5ubmSn59focdarVbJycmRjIwMCQtjCJrK0FhW9H0AUEO8/rpISopIixbVJ2n76KOPyk033STz5s2TpKQk35cKAAAAAIAQTNi2SkyUvfv2VejxmqhNTk6W1atXm6QjKk5jOWDAAHnvvfckLi4u0MUBAP8kbc855xzz61+7du3MwS8yMtLl/tTU1IpsFgAAAACAkKUtOzVhe+vpAyUmsgKn2xaL1GnRSkYmJohwdWul5BYWySe7Msx7QtIWQCiqcEtbAAAAAABQmiZsY0o0bioXi0UiI/57LEnbymHAdAA1MWk7ceJE35cEAAAAAAAAAFCxpO3hOlmPj4+v7GYBAAAAAAAAoEaq0HCU2dnZctVVV0njxo2lVq1aUr9+fZcJAAAAAAAAAODHlrY33nijfPnll/L000/L+eefL3PmzJGUlBSZN2+e3H///RUsCgAAAAAA8Id7P/hCDuQcdHvfMUktZWSPzvLhb3/J7ym7JSe/QOJjo+X0bkdK98Rmfi8rANREFUravv/++/LSSy9J//795cILL5S+ffvKEUccIa1bt5ZXX31Vxo8f7/uSAgAAACGiR48e5la7EVu/fr107drVzHfs2FEWLVokW7dulcmTJ8vff/8t4eHhcsUVV8jVV18d4FIDqElGHd1F8guLJONgrrz/659SKzpKRvXsYu5LqBUrz3/zk2zed0B6tmou7Rs3NAneIqs10MUGgBqjQknb1NRUadu2raP/Wp1Xffr0MRVOAAAAoCZbs2aNud28ebNJ4Nrnlc1mkzPOOENuuukmOfvss82y3bt3B6ysAGqmLs2bmNs9GVkmaRsVHm4StGrDnn0mYdumYX0Z17uHSdZGhocHuMQA4GPDhmmSUyQhQapN0lYTtps2bZJWrVpJp06d5I033pBjjz3WtMCtV6+e70sJAAAAVBPLli2T6OhoR8JWNWlSnDwBgGCwLTXd3Gbk5sktiz+RwqIiaVG/row9trs0rVsn0MUDAN+YN0+q3UBk2iXCr7/+av7XFgLap21MTIxcd911csMNN/i6jAAAAEC1sW7dOmnUqJGMHTtWevbsaVrdbty40e26eXl5kpGR4TIBQFULs1jMbcbBPDnrmKNk4JHtZPuBdFn4Y3EeAAAQpC1tNTlrd/LJJ8uff/4pP//8s+nXtlu3br4sHwAAAFCtFBYWyhdffCErV66ULl26yNy5c2XMmDGyatWqUuvOnDlTZsyYEZByAqi5GtapZW6b1a0jya1bysH8Aln257+yLys70EUDgBqjQi1tS0pKSpLRo0eTsAUAAAAOQ7sY0xa2mrBV559/vmkAUVBQUGrd6dOnS3p6umPatm1bAEoMoKbp1LSRNKgdJylpGbLi703y4W9/meU6IBkAIMiTttoX1+mnny7t2rUzk/7/+eef+7Z0AAAAQDUzdOhQ2b59u6SkpJj5Dz/8UI488kiJjIwsta72fasD/zpPAFDVwsPC5MITj5GkhvVNwva37bvkmKSWctYxXQNdNADwnWOOEWnZsvi2unSP8NRTT8mUKVPkrLPOMrdKL+867bTT5JFHHpHJkyf7upwAAABAtVCrVi3TJcKwYcPEZrNJ3bp1ZeHChYEuFoAaqnF8bXlwzLBSy3XAsSv6HxeQMgGAX+zaJfLfj+jVJml73333meTsVVdd5Vh2zTXXyIknnmjuI2kLAAAAFHcjlpaWVmr54MGDzQQAAAD4rHsErXieeuqppZZrxVP72gIAAAAAAAAA+DFpO2LECHnnnXdKLX/33XdN37YAAAAAAAAAAD92j9C5c2e59957Zfny5XL88cc7+rT99ttv5frrr5fHH3/cpdsEAAAAAAAAAEAVJm2ff/55qV+/vqxbt85MdvXq1TP32VksFpK2AAAAAAAAAFDVSdtNmzZV5GEAAAAAAAAAgKpI2pZUVFQkv/32m7Ru3dq0wAUAAAAAoKbKLSis2AMtFoksLJTcggIRm83XxapRcguLAl0EAPB/0vbaa6+Vrl27ykUXXWQStieddJJ8//33EhcXJx988IH079+/XNtZsWKFzJ49W1avXi07d+40g5uNGjXKcX9WVpbcdNNNsmTJEtm/f7+0adPGdLdw+eWXl7ndN998U2677TbZvHmztG/fXh544AE57bTTHPfbbDa544475Nlnn5W0tDQ58cQT5emnnzbrBqOiIpGvvhJZvz5GOnYU6ddPJDw8OMr19dciO3eKNGsm0rdvcJRLETPvy0W8vCsX8fKuXMTLu3IRL+/KRby8KxfxAoCqExUVJY0aNpR7PviiQo8PCwuT5ORkc45stVp9Xr6aRGM5YMAA854AQI1J2r711lty3nnnmf/ff/99kxz966+/5OWXX5ZbbrnFDEhWHtnZ2dK9e3eZNGmSjB49utT9U6dOlS+++EJeeeUVSUpKkk8//VSuvPJKad68uYwYMcLtNr/77jsZN26czJw5U04//XR57bXXTCL4559/lqOOOsqsM2vWLDNY2oIFC0wiWBO8Q4YMMf3zxsTESDBZvFhkyhSR7dvDtNdgs6xlS5HHHhNxE7IAlOvQsmAolyJmFS0X8fKuXMTLu3IRL+/KRby8Kxfx8q5cxAsAqoqeT27dtk3y8/Mr9HhN1KampkpCQoJJOqLiNJYZGRlBd44PIIjMmiWSkyMSFydByVYB0dHRtm3btpn/L7nkEtuUKVPM/xs3brTVqVOnIpvU6z5s77zzjsuyLl262O666y6XZUcffbTtlltu8bidMWPG2IYNG+ayrHfv3rbLLrvM/G+1Wm1Nmza1zZ4923F/WlqaeU2vv/56ucubnp5uyqy3VeXtt202i0Vj4zrpMp30/kAI1nIFc9koF+WiXJSLclEuyhV85fJHfa6qynzgwIFAFyXkFRUV2Xbu3GluUTnE0neIpe8QS98hlr5DLH2nKIRjWd46qEX/eJvo1b5rtWuBQYMGmZaq2rXAsGHD5I8//pA+ffrIgQMHvE4eWyyWUt0jXHrppfLLL7+Y7hG0de3y5ctNC9ulS5eaLhncadWqlWmhq1042GlXCLqNX3/9VTZu3Cjt2rUz2+3Ro4djnX79+pn5x7RZRznoL3Z169aVvbtSJL5BA9P3kOP6vqIiCQuPkIioQ7/o5R/MKv4nMrLUupawcImMjnVZV+9q3zlSUnYUrxtmK5JwKRKrLVyKbLFmE9oK5e8/cyQszCoSEaHXfxRvQC+jKSwUiyVMImMO/VpQkJsjNlvl1i3KK5QjO1tky7ZajnUjLDlisVilUCLEZgkrLtdfVgm3FZrXGhVzaN3C/FyxFhUWX/Nov+7xvzKUa13dXbV/Jw1lTC2z39jXLcgvlI6dw2XbjkPrRkrxugXW4nW1bP+szxWLlLHd6Dix/Peaiwrypagw37t1dV7j9p+ig/nSubPI5m36HhdvI0zyJTwsX6wSJkWWiOKY/S0SXlT8i3xEdKyEhYWXuV1TBpvN7Ge6v3m7rsarwxG5sj3FIoWWyEPvp61ALGKTQlu0tGwZKTruoMZLY2x2PN2HS2w3PDJawiOKl+t7Vpl1dd/vdESh7EyxSpE1Sqxiv5zJKpFhOea/JolRxfHSEOm+Y7VKeESUhEcWr2uzWqUgr3hdcb4c6r91wyIiJSIy2qt1tVytW1tlz87idQvk0GfZ/vls3iJC/t0U49hVyvrcV/YYYV+3yGoR7dll53bXY4Tj/QzLkcSWVvljfYSER1b9McL+WQ6PrCVJScUt50oeI5TFZpWkloXyxzqLxNbyzzFC19Uote8ULikppY8Ruqfr6q1a5sqf6wolPMo/xwjJzy8+5neKlZQU98cIZY4Tv+ebp/HHMULjlXcwt/iYv8PNMcIaLWKJNOX6d0Oh2Ir8c4wwryOvUDp3ssrWbe6PEQWWqEPHVZt/jhFmUYFV2rfLMfuXu2OE1RYhzVvGmOOqvo/+OEbourpaxyOKZFeKm2PEf5/Ppi0jZP0/YcW7sR+OEfpZ1nLpcWJXivtjRIQUSouWFtmwsZbj4+XrY0RmZqapz6Wnp0t8fLyEAnsdVOvb9eoVt5hGxVvh7dmzRxo3bkyLxkoilr5DLH2HWPoOsfQdYuk71hCOpb0+d7g6aIW6R7jwwgtlzJgx0qxZM3NCfPLJJ5vlP/zwg3Tq1El85YknnjCJ25YtW0pERIR5EzRZ7Clhq3bt2iVNmjRxWabzutx+v32Zp3XcycvLM5NzgNXKa8+WNeefJAWxxSdyrX/dIm1+2SRy9NHS7+qHHOt/e/Uoc5Kw8qzjJLd28UlYy3Xb5YgfN4i1axcZMPXJQ+tOHSNpO7IlP/FYkXbFJx89MnfI8H1/y19h7WXRpmfNOce2bSK39zxX6lsOyPxWR8vO2OI3ukvGbhmx80/ZEtlKPkh7ybHdsXUukAbW3fJqYg/ZGldcyW+fuU/O2vG77IhsKu+kLXSse1adS6WJdZu82aKrbKjdwCxrk50qY7aulVMjG8g8WexYd3zLayQpbIO82bizrKvVWPTqxu6npcmFKb/IgYja8lr6B451T6t9nbSxrZMPmnaS3+o2Ncsa52bJRVtWSWZEtLyU/olj3cF1bpL21l/k08btZXX9FmZZQn6OXLbpR8kNi5Dnsj8Ui7U47gNq3ymdir6XxIbtZFu7VmZZncI8mbrte7FaLHJ3ygdiK6hlYnZet5lydNhy+bpBknzTMMmsG11UKFM3fGP+n5P/tkhB8Ws+rvaDkmz7RH6onyhfNG5nloXZrDLt7xXm/3kFL0lhfvHzJdeaI8fJEvm5XnP5pEkHx+u44a+vZGKYyMO150pmVvHn47jGz8spsYtkTe2m8m6jTiZmDc6wyQ0bv5EYa6G8ZH1EMg/2LH4/416R/pYF8ledRvJO8y6O7V717/fmNb4q90pa9olmWYfYxXJK2NPyb60G8kbLro51L9/4g9QvOChvyq2yJ7v485oY8YFMDHtUNrevJwuaHfoB46KUVdI0P0tezr5eNm4bLk2b2uSIup/LiPCZsjOmjsxvnexY9/ytv0jLg+nyftiVsjVzjFnWLPp7GR1xq+yLqiXPtunlWHfctl8lKeeAfBx2ofybOdEsaxT1i4yJ/J+kR8bIU22PM8t0vIARtf+QTon75P38cfLzzsuK1437U65sNFlywiNldqsTTbwiwkVG7PhTumTuluURZ8gf6VPMurXDt8rEmIlSYAmXBzv0dZRh6K710iN9p3wXMVR+SZ9W/N6H7ZWLY4vLPrPjof64T96zQXod2C4/RgyUn9JvF/34p6fmyM2Jp5v772vdVwr+S5r1P7BR+qZtlZW2E6Rp03slujh/I5NrDTO3j7U7QXIiivfVE/ZvkX77NslvkcmyIu3QMeKyWqMkQgpMHDQeSp9fy/Fn5FHyRdqhY8Sk2mMk1pYtzyb1kl0RteRgW4sc3cj1GGE3OXG81JMD0nVYT9lTq+qPEWO3r5U9kQnyyu7Fsm+fxe0xQrXMTZcJO3+R246pJQsz/XOM6Gz7Xj5LaCspbVuLtC19jJCCWubY2qXofnm455fybSP/HCOm/f2VSJFNMtLniYj7Y4TS48R9x3wtcTb/HCPaxn4gQ+QR6R9XXxb09XCM2DfcHFdPaP+5jI7xzzFCjdr2u0wM2y/vN/N8jLAfV0fv9s8xQhXlZ8tlccNFEj0fIz7Zep85rupxwh/HiH3Rtcxx9cjGO2VSmJtjRKviY8SzzY+WBmfUMcdVfxwj3kxbbI6repyYmOj+GDFp5y+SGl5bvvrqPbEPl7DyweukYP06+atPJ9l1RPExonZqlhzz3irJj4uWU+Z87CjDD49Pk/zf1sg/vdtLypHFx4jY9Bzp/c6PUhgVIX2fWkp/kQAAAAhaFUra3nnnnaZ/2G3btsnZZ58t0f9lKMLDw83AYb5M2q5cuVLee+8907pXBy6bPHmyaXVrTxT7i/aRO2PGjFLLCwoLJCcnR/Ktxa02cnNzpaCgQApyckzG3077NLIUFpp+fHMtxaNYHjx48L91c0usmyc5OeUb6TI/3yJ5YpGsbItkFhYnSLKzLZKXZ5GcAoukpPzXGkefr5VInsUiWVkWySwqsW6h67o59nV1u7bi5VkHLVJQYLE3Fi1T7sHi7eaW2G52S4vkhVvM82aGFS+PyyteN69IXNbNsq+bY5HMiOLlkQX/rRtmkR3aCvm/15HZwiIF/61zODk5FsmLtJjbzMzix+QXFW9X7dxlEet//2c0s0helEVyDh5aN8x2aN1dey2Sl1P8/xFNLJIX47qu0piFyeEbtB/UcuVZxGK1yJ4DFknNKN5G80YWyYuzyMEI1+3qyW5UoUX2ZVhk94Hi5Q0bWCSvtkUOhovLurkaswKL7Mu0SEpq8fK69S0i5WhUpCfU9QstklfXItpG2WW7uVoOi6QetEjKnuLlEXUskpdgkVybaxkO5ha/vgO5FknZXbzcVssieQ0tklvkut3y0HgVb7e4DOnZh/a1utEWyWtqkYKwEmX4b79Mzzm0blyERfJa/LcfOa1r9pM8i2QcPLSuvaHq4eJll9f6v+1mWSQn3OKy3aw81/09t7VFIv+Lb2ak6+czO9/1c5TbWltiFn+WD0aVL2762jOtVX+M0HUP6n7pFIfDHcP8dYzIi/jvs1uObs30c+uvY4SuG1bOa14K9Jjvx2NEQXz5jvnpGRazP/jrGJH/X3zLc5zw7zHCIlKO7rDsnw9/HCMy8y1eH1f9cYxwXvdw1q/PkM6dc4vLcPCg2AoKzK3WqVRYTo6pT+nxxLk+dTDnoFh13dxD69py/qt7SXHLjLycQz/IAwAAoIZZv774ii29OkxH6Q0yFeoewZkmKX3RsXfJ7hG0Mq5NhXWZdr1gd/HFF8v27dvl448PtaTwR/cI7lraJiYmyu4d26qke4QVK0SGnK6XnrrvHsGuSaNsiYl2f0mhzRYmRU5nj+Hi+fLD8q6rl6Tu2x8mheZS4mLuLn1umFAktaILxSYWKbIdWjdMciXMUnyJstUS7lqGcqzrcjmzrZZezOxYVy/337M/wv26/136rBo3PCixMWVs1xpnLvM0ZdNLlC35Xq3rfDmzsubmy/79Fimweu4eQTVoYJPaUcXdI+i6Fnt8PGz30CXKMSL/Lfdm3bzcQkk/kGfi7rZ7BGu06Ctt2NAm0VGFEhGW63ldm/5w899yW+XW1Y9Z2r4iCRPP3SPopc8aL/29SC99NuvaosT237p6Sa7zuo792rFupNgk2qt1i1uE2Q6t6+HS5/oNoh0tbSMsWWWua3XKHpa9brhYJdbtunn5FrN/eTpG2D+fdRuES1RM1R8j7J/lnNxajsSUp+4RdN2EBiIRUf45Rui6OXnhsjc1osxjRLglVxo1LJCIaP8cIyJt+Wb/2rU3rsxjhGqakGf2L38cI/TzWVSQW3zML+MYoRo2KJBasf45RqjC3EI5sN9W5jFC6XEiLso/xwiVm2uVjAMHy/zcF9liio+r0f45Rui6un8d2Gct8xihn8+EhhZTLn8cI/SzbG9pW9YxQtf95LNYR0vbqugeoX79+nSPUEOF8mWVwYZY+g6x9B1i6TvE0neIZZDFsmVLbSkh0qKF66i4odw9QlFRkdx3330yd+5c2b17t/z999/Stm1bue222yQpKUkuuugiqSzTCqKgoFTgtTVvWZeyHX/88bJs2TKXpO1nn31mlivtg7dp06ZmHXvSVoOlXTtcccUVHrerrYntLYqdxdSKl5ioQyc/9vNMd+uVUsa6gwaLtGxevO/o+YW+YudXbe/TdtOmQ/28Hd6hE5mKrmvvf85eLlVoixN7Q9JD5Tp0fuTKKVaH5Wlddz8SxLotW8F/J9KuZYv1UDZ329XHR1dq3aKi6FLl0iSD9b/Ltl1jFu1FGSq3blFRpCQlRRb37em0cxXKoXIlmnJZJDw80sMO6+65Kreuy/vock+YFFhrF5erhfM+5m67ekedcpahfOsWl0tbh9V2vI92Gj6b233f3XY9qdi6zvEqcPMTnCZRWrrEq2qPEe7K5XyMcLCINHV7rKi6Y0TJcpncTYn3Wfev4j5HD/VNXNXHCF1WslzOxwh7uYr3ryg35aqaY4R+NouPEyWO+eKuXJH/HSfKt93KHk+cj6uH9q3iY0T5jqu+P0YUlytckpJqlyjXoe9wc/xKtB9X/XOMKC5X6e9HO/18agq47O9u3x8jXMsVJ9r9rTMtpl5ApOXq1+9Qt7hRTv3mHu6t87iuU72NkyUAAAAEqwolbe+9915ZsGCBzJo1Sy655BLHcu0y4dFHHy130jYrK0s2bNjgmN+0aZOsWbNGEhISTItZbf16ww03SGxsrOke4auvvpKXXnpJHn74YcdjJkyYIC1atDDdF6gpU6aYxz300EOmhe7ChQtl1apV8swzzzha9GpC95577pH27dubJK4mm7XLBedB0AJNT5q00e9ZZxWf5DmfZNkb6j76aHmSMDWjXMFcNspFuSgX5aJclItyhU65AACojvQqae22sSK04Zx2C6kN3vjBs3I0lhV9H1AD2SqgXbt2ts8//9z8X7t2bdu///5r/v/zzz9t9erVK/d2vvzyS62el5omTpxo7t+5c6ftggsusDVv3twWExNj69ixo+2hhx6yWa1Wxzb69evnWN/ujTfesHXo0MEWFRVl69Kli23p0qUu9+vjb7vtNluTJk1s0dHRtkGDBtnWr1/vVQzS09NNWfW2Kr39ts3WsqWexhyaEhOLlwdSsJYrmMtGuSgX5aJclItyUa7gKpe/6nNVUeYDBw4Euighr6ioyJxv6C0qh1j6DrH0HWJ5yMGDB21NGjdxm38pzxQWFmbr1auXua3oNpgOxfKUk0+xZWdnB3q3CHlFvviMt2hRXPnUWz8qbx20Qn3aasvXv/76y7R+rVOnjukrVrtHWLdunRx77LGmBW11V97+J3xBLx/86iurGYijY8d46dcvLChanWi5vv5aZOdOkWbNRPr2DZ7WMMTM+3IRL+/KRby8Kxfx8q5cxMu7chEv78pFvAJTn/MV+rT1HfoV9B1i6TvE0neIZenvjneeWya14oq7k/KGTWxSFJ4n4UXRjjEjUDHZOZly37zp8umnn/I9XklW+rR1r3PnzvL111+bpK2zt956S3r27FmRTaIMetKiA3DoyMmNG8c7+nULlnIFI2LmHeLlHeLlHeLlHeLlHeLlHeIFAEDNpQnbiiZt88UiUXJooF9UjMYSKK8KJW1vv/12mThxoqSkpJjM9uLFi2X9+vWmv9kPPvigIpsEAAAAAAAAAJihlitg5MiR8v7778vnn38utWrVMkncP//80yw75ZRTfF9KAAAAAAAAAKghKtTSdvv27dK3b1/57LPPSt23cuVKOe6443xRNgAAAAAAAACocSqUtB08eLB88803kpCQ4LL822+/lWHDhklaWpqvygcAAAAAAIAa4MxLTpFde3e4vW/ogJHy0Zfvllr+8SvfS53aoTGgKFDlSVttSauJ2y+//FLq1Kljlq1YsUKGDx8ud955Z0U2CQAAAFQbPXr0MLf5+flm7IeuXbua+Y4dO8oDDzwg7dq1cyxTb7/9tlkGAEBNdt0lN0tu3kHZl7pHnnhxttSLr2+WqWZNWpqkbf/jT5EBJwx2PCY2JjaAJUZI++knkaKi4lFxq0vS9rnnnpOzzjrLJGk/+eQT+e6772TEiBFyzz33yJQpU3xfSgAAACCErFmzxtxu3rzZJHDt8/Zl2vDBeRkAABDpc+wAc7tl+0aTtI2JjpWT+55mlu3cnWJu27Q6Qo4/pp/Uiq0V0LKiGmjWTKrdQGRhYWGycOFCiYyMlIEDB5qE7cyZM0nYAgAAAAAAoMrMf2OuDB53rAw59ziZM/9BsVqtgS4SENiWtmvXri21TLtCGDdunJx33nly0kknOdbp1q2bb0sJAAAAVCPZ2dnSq1cvKSoqklGjRsktt9wi4W4uzcvLyzOTXUZGhp9LCgBAcIiJiZULxlwuHdoeKbl5ufLCwjny2pIXJbFFkow45axAFw8IXNJWL+uyWCxis9kcy+zz8+bNk2eeecb8r8u08gkAAACgtGbNmklKSoo0btxYUlNT5ZxzzpGHHnpIbrzxxlLr6tVsM2bMCEg5AQAIJvXrJsgl517tmN+3f7c89dLD8u/mvwNaLoSwZ54RycoSqV1b5NJLJWSTtps2barakgAAAAA1QHR0tEnYqoSEBJk0aZK89tprbpO206dPl6lTp7q0tE1MTPRreQEACAbvfvKGrP3rF+naqacUFBTIW0tfM8u7HXl0oIuGUHXXXSIpKSItWoR20rZ169ZVWxIAAACgBtizZ4/Ur1/fjA+hXR8sXrxYevbs6THBqxMAADVdqxZt5OPl78u3Py6XvII8ad6kpfzvrNtkUJ9TA100ILBJW3fWrVsnW7dulfz8fJflOjAZAAAAgNK++eYbuf32200ftoWFhWZgX+3TFgAAFGvdsq18u+QPl2U9j+olT898OWBlAkIiabtx40Y544wz5LfffnPp51b/V/RpCwAAAIgkJSVJWlqay7LRo0ebCQAAAPAkTCpgypQp0qZNG3NpV1xcnPzxxx+yYsUKOeaYY2T58uUV2SQAAAAAAAAAoKItbb///nv54osvpGHDhhIWFmamPn36mNFtr7nmGvnll198X1IAAAAAAAAAqAEq1NJWuz+oU6eO+V8Ttzt27HAMVrZ+/XrflhAAAAAAAAAAapAKtbQ96qij5NdffzVdJPTu3VtmzZolUVFR8swzz0jbtm19X0oAAAAAAAAAqCEqlLS99dZbJTs72/w/Y8YMGT58uPTt21caNGggCxcu9HUZAQAAAAAAAKDGqFDSdsiQIY7/27dvL3/99ZekpqZK/fr1xWKx+LJ8AAAAAAAAqKTsnKwKPc4mNikKz5OCIptYhJxPZeRU8D1AFenQQaRuXZEmTSTkk7aTJk0q13ovvPBCRcsDAAAAAAAAH9HuLJs0biJnXDyoQo/XweeTk5Nl9erVYrVafV6+mkRjOWjgIPOeIAh88YUEM6+StvPnzzeDjfXs2VNsNlvVlQoAAAAAAACVFhMTI5u3bJb8/PwKPV4TtXp1dUJCgkk6ouI0lhkZGeY9AXyatL3iiivk9ddfl02bNsmFF14o5513nvnQAgAAAAAAIDhpkrCiiUJNNObm5kp8fDxJ20qyxxIoD68+bXPmzJGdO3fKjTfeKO+//74kJibKmDFj5JNPPqHlLQAAAAAAAAD4gNc/kURHR8u4cePks88+k3Xr1kmXLl3kyiuvlKSkJMnKokNlAAAAAAAAAEFu/HiRIUOKb0O9e4SStFm8xWIxrWyLiop8VyoAAAAAAAAAqCpffSWSkiLSooVUi5a2eXl5pl/bU045RTp06CC//fabPPnkk7J161apXbt21ZQSAAAAAAAAAGoIr1raajcICxcuNH3ZTpo0ySRvGzZsWHWlAwAAAAAAAIAaxquk7dy5c6VVq1bStm1b+eqrr8zkzuLFi31VPgAAAAAAAACoUbxK2k6YMMH0YQsAAAAAAACEktzcXMnPzw/Y81utVsnJyZGMjAwzThQCG8vaNpv3/cYGa9J2/vz5VVcSAAAAAAAAoIoStm1at5Zde/YErAyaXExOTpbVq1ebpCMCG8ttItJSRGw2m1hCPWkLAAAAAAAAhBptYasJ220z75X4mJiAlEFTi6mxcZJw7tigbuEZCqw+iGXcHTNEMjLEJkLSFgAAAAAAAAgUTdjGx8YGLNGYGx0l8RLcl+WHAqsPYmkN8i5g2UcAAAAAAAAAIIiQtAUAAAAAAABQo+Qf11se1tuJEyUYkbQFAAAAAAAAUKPknzpErtfbm26SYESftgAAAAAAAEA1knTzrbIlNdXtfROPO07mXzBBCoqK5LgHZsnPW7dJk/h42TXrfr+XE56RtAUAAAB8rEePHo6RqtevXy9du3Y18x07dpRFixY51rvgggtkwYIFcuDAAalXr17AygsAAKqXJ8aOkey8fNmRni7Xv/W2NKxdW544Z4y5r03DBub2liXvyt+79wS4pPCEpC0AAADgY2vWrDG3mzdvNglc+7yzxYsXS2RkZABKBwAAqrvh3bqZ27927TJJ21pRUTK21zGO+5f99Zc8vOwLmTd+nFz88qsBLCk8oU9bAAAAwM92794t9913nzz8sA5/AQAA4D/7s7JkwosL5PqTB8mgjp2kpqp9511i09sjj5RgFNCk7YoVK2T48OHSvHlzsVgssmTJEpf7dZm7afbs2R63mZSU5PYxkydPdqzTv3//UvdffvnlVfpaAQAAALtLLrlEZs2aJXXq1Clzvby8PMnIyHCZAAAAKuN/by+W6MgIueD442RL6n6zrMhqlQ179ojVag108RAMSdvs7Gzp3r27zJkzx+39O3fudJleeOEFk2A988wzPW7zp59+cnnMZ599ZpafffbZpSrKzutppRkAAACoas8995y0atVKBg4ceNh1Z86cKXXr1nVMiYmJfikjAACovjbt22+mzjPulv4PP2qW7cvKkva33ykZubmBLh6CoU/boUOHmsmTpk2busy/++67MmDAAGnbtq3HxzRq1Mhl/v7775d27dpJv379XJbHxcWV2j4AAABQ1b788ktzxdkHH3zgWNatWzdT1+3Zs6fLutOnT5epU6c65rWlLYlbAABQGTOGD5O9mVnm/71ZWXLl6wulXlysPDt+vNSKjg508RBqA5Fpv19Lly41o+uWl47W+8orr5iKrrbQdfbqq6+a+zRxq1003HbbbSaRCwAAAFQlrYc603rq2rVrpV69eqXWjY6ONhMAAICv9OvQwfH/5n3F3SNER0TKWclHB7BUCNmkrSZrtc+v0aNHl/sx2kduWlqaXHDBBS7Lzz33XGndurXpS1cryNOmTZP169ebEXzL6k9MJzt7f2La14c/+vvQ57DZbPQt4gVi5h3i5R3i5R3i5R3i5R3i5R3idQgxAAAA1V2npk3FNvcpj/cnNWxQ5v0InJBJ2mp/tuPHj5eYmJhyP+b555833S9octbZpZde6vi/a9eu0qxZMxk0aJD8+++/pisFT/2JzZgxo9TyvXv3Sq4f+vvQk4r09HRzkhUWFtCuiEMGMfMO8fIO8fIO8fIO8fIO8fIO8TokMzOzyp9DB8nVRgRl0fcCAAAACLmk7ddff21awi5atKjcj9myZYt8/vnnZbaetevdu7e53bBhg8ekraf+xLQP3fj4ePHHCZZeOqfPV9NPsMqLmHmHeHmHeHmHeHmHeHmHeHmHeB3iTWMAAAAAwJ9CImmrLWaTk5Ole/fu5X7Miy++KI0bN5Zhw4Yddt01a9aYW21x64mn/sT0ZMdfJzx6guXP56sOiJl3iJd3iJd3iJd3iJd3iJd3iFexmv76AQAAELwCWlPNysoyCVN70nTTpk3m/61bt7q0aH3zzTfl4osvdrsN7dbgySefLNWCRJO2EydOlIgI17y0doFw9913y+rVq2Xz5s3y3nvvyYQJE+Skk04yo/YCAAAAAAAAQI1N2q5atUp69uxpJqXdD+j/t99+u2OdhQsXmn6+xo0b53YbmoTdt2+fyzLtFkETv5MmTSq1flRUlLl/8ODB0qlTJ7n++uvlzDPPlPfff9/nrw8AAAAAAABA8Dl43rkyRG+feUaCUUC7R+jfv/9hB17QQcOcBw4rSVvLlqQJWU/b1X5ov/rqqwqUFgAAAAAAAEB1UHTEEfKp3vbtK8EoJPq0BQAAAAAAACorIzc3YM9tFZEcsUjGwYOBvfS9GrD6IJaB3BfKg6QtAAAAAAAAqjXtLrNp48aSOP2WgA6CmpycbMZZ0vGYEPhYNm3c2OwbwYikLQAAAAAAAKq1mJgY2bRli+Tn5wesDJpcTE1NlYSEBJN0RGBjGf711xJptUrUypXah6sEG5K2AAAAAAAAqBGJW50CmWjMzc2V+Ph4krbBEMvLLhNJSRFp0UJk+3YJNuwhAAAAAAAAABBESNoCAAAAAAAAQBAhaQsAAAAAAAAAQYSkLQAAAAAAAAAEEZK2AAAAAAAAABBEIgJdAAAAAADeycjIYNRpH4w6nZOTQyx9gFi6ioqKCujo9ACA6oGkLQAAABBikpKSxGazBboYIU2Ti8nJybJ69WqTdETFEUtXjZs0ki2bt5K4BQBUCklbAAAAIMTc/slUqde0bqCLEdpsIrE5deTcuOEilkAXJsQRS4fcrFyZfsJ9kp+fT9IWAFApJG0BAACAEBNTK1pi65AQqhSbSLQtSkTjWMMTjZVGLAEA8DmStgAAAAAAAABqlu3bJZjRSzwAAAAAAAAABBGStgAAAAAAAAAQROgeAQAAAACq0M19ZkpqygG39/Ua0UN2/L1b9m3dL9YiqyS0qC8DJp4o/Sec4PdyAgCA4EHSFgAAAPCxHj16mFsdQX79+vXStWtXM9+xY0e5//775ayzzpKioiIpLCyUI488Up555hmpX79+gEuNqjL2zpGSdzBf0ndnyFv3fiC1E2rJOXeONPc1bJkgv36+Thq3aSg5aTny/qOfysI7lkiH49pK8w5NA110AACqrxkzRNLTRerWFbnjDgk2JG0BAAAAH1uzZo253bx5s0ng2udVXl6efPPNNxIbG2vmp0yZInfeeac89thjASsvqla3kzub213/7jFJ26jYKOk1vDixr1p3ayk56QflwK50+fz5ryUvOz+ApQUAoIZ49lmRlBSRFi1I2gIAAAA1XXR0tON/bW2bnZ0ttWvXDmiZEFg7N+yRu0992PwfFh4mZ98+gla2AADUcCRtAQAAAD/TbhOOPfZY2bJli3Tr1k3ee+89t+tpq1yd7DIyMvxYSvhLw8QEueali2X/9gPy3kOfyEdPLpNuA4+URq0bBLpoAAAgQMIC9cQAAABATRUVFWW6TNi9e7d06tRJ5s2b53a9mTNnSt26dR1TYmKi38uKqhcdFyWd+3aQvuN6S8+hXSUrNVvWfPp7oIsFAAACiKQtAAAAEMDk7YUXXigvv/yy2/unT58u6enpjmnbtm1+LyOq1kdzvjD93H735k/yydzlsuq94v6PWx7ZPNBFAwAAAUT3CAAAAIAfaZcIjRo1kri4OLFarfLmm2+aLhI89X/r3Acuqp/4hrVNwnb5S99JRFS4NE5qKP0nnihH9mkf6KIBAIAAImkLAAAA+NHatWvllltuMf9r0vboo4+Wxx9/PNDFgh80bddY5m6a5bLsxHOONRMAAIAzkrYAAABAFUlKSpK0tDSXZcOHDzcTAAAA4Al92gIAAAAAAABAEKGlLQAAAAAAAICapV8/kX37RBo2lGBE0hYAAAAAAABAzfLqqxLM6B4BAAAAAAAAAIIISVsAAAAAAAAACCJ0jwAAAACEmNzsPDmYmRvoYoQ2m4gcjJSDllwRS6ALE+KIpUNuFp9LAIBvkLQFAAAAQsxdQx4Wm00zZaiosLAwSU5OltWrV4vVag10cUIasXTVuEkjiYqKCnQxAACHM3CgyO7dIk2aiHzxhQQbkrYAAABAiNm8ebPUq1cv0MUIaZpcTE1NlYSEBJN0RMURS1easI2JiQl0MQAAh/P33yIpKSLp6RKMSNoCAAAAISY+Pt5MqFyiMTc318SRRGPlEEsAAHyPb1QAAAAAAAAACCIkbQEAAAAAAAAgiJC0BQAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAAAAAACCIBTdquWLFChg8fLs2bNxeLxSJLlixxuV+XuZtmz57tcZt33nlnqfU7derkso6ObDp58mRp0KCB1K5dW84880zZvXt3lb1OAAAAAAAAACivCAmg7Oxs6d69u0yaNElGjx5d6v6dO3e6zH/00Udy0UUXmSRrWbp06SKff/65Yz4iwvVlXnfddbJ06VJ58803pW7dunLVVVeZ5//2228r/ZoAAAAAAAAQfLQRX35+fsCe32q1Sk5OjmRkZEhYWGAvfo+KipKYmJiAlgFBnLQdOnSomTxp2rSpy/y7774rAwYMkLZt25a5XU3SlnysXXp6ujz//PPy2muvycCBA82yF198UY488khZuXKlHHfccRV6LQAAAAAAAAjehG2bpFaya/fegJVBE7XJycmyevVqk8ANpKZNGsmmzVtrduL29ttFsrJEateWYBTQpK03tPsCbR27YMGCw677zz//mC4XdMc7/vjjZebMmdKqVStzn34wCgoK5OSTT3asr90n6P3ff/89SVsAAAAAAIBqRlvYasJ222tXSnxcdEDKoGnaVGkgCdInoP2VZuTkSeK5T5mY1Oik7aWXSjALmaStJmvr1KnjthsFZ71795b58+dLx44dTfcKM2bMkL59+8rvv/9uHr9r1y7TBLxevXouj2vSpIm5z5O8vDwz2WlTdqW/jPjj1xF9DpvNFvBfYkIJMfMO8fIO8fIO8fIO8fIO8fIO8TqEGAAAUPNowja+VoCStjaR3KIIiQ+PljBLQIqAEBIySdsXXnhBxo8ff9hfAJy7W+jWrZtJ4rZu3VreeOMN0x9uRWlrXU0Al7R3717TxN4fJxXatYOeZAW635NQQcy8Q7y8Q7y8Q7y8Q7y8Q7y8Q7wOyczMDHQRAAAAgNBN2n799deyfv16WbRokdeP1Ra1HTp0kA0bNph57etWm3+npaW5tLbV7hc89YOrpk+fLlOnTnVpaZuYmCiNGjWS+Ph48ccJlsViMc9X00+wyouYeYd4eYd4eYd4eYd4eYd4eYd4HVKjLwcEAACo6XbuFCkqEgkPF2nWTIJNSCRtdeAw7ai5e/fuXj82KytL/v33Xzn//PPNvG4nMjJSli1bJmeeeaZZpgnhrVu3mv5vPYmOjjZTSXqy468THj3B8ufzVQfEzDvEyzvEyzvEyzvEyzvEyzvEq1hNf/0AAAA1Wq9eIikpIi1aiGzfLsEmoElbTajaW8CqTZs2yZo1ayQhIcExcJi2aH3zzTfloYcecruNQYMGyRlnnCFXXXWVmf/f//4nw4cPN10i7NixQ+644w4JDw+XcePGmfvr1q1ruknQVrP6PNpK9uqrrzYJWwYhAwAAAAAAQGUknfeUbNldPBZSSf2TO4it4KD8sWWfZB0skHbN68nN446Xcwd28Xs5EdwCmrRdtWqVDBgwwDFv735g4sSJZjAxtXDhQtPnmj3pWpK2ot23b59jfvv27Wbd/fv3m8v++vTpIytXrjT/2z3yyCOmZYW2tNXBxYYMGSJPPfVUFb5SAAAA1CQ9evQwt9otl17V1bVrVzOvg+XeeuutMnnyZNmzZ49ERETIscceK3PmzJHY2NgAlxoAAPjCE5NPkezcAtmxP0uun/eFNKwba5bpQGS/bMuRVb/9Lbece4IczCuUO1/+Rs5/4APp0rqhdG/XJNBFRxAJaNK2f//+JiFblksvvdRMnmzevNllXpO85em/TCvGOgEAAAC+pleP2euqmsC1z6t//vlHnnzySTNoblFRkZx77rnywAMPyJ133hnAEgMAAF8Zfnx7c/vX1v0maVsrJlLGDuhskrYnHqwtiROOkTBL8bo/rt8hS779R9Zu3EvSFqHXpy0AAABQXbRvX3wip7Qbr169esnvv/8e0DIBAAD/iI46lIrbcyBbVv65Q6Ijw6XPUS0DWi4EH0ZfAAAAAAIkOztbnnvuORk5cqTb+7UrLx3jwXkCAAChb/veDBl040LZl35QXpp2urRpVi/QRUKQIWkLAAAABID2d3vOOefI4MGDzcC67sycOdMMpGufEhMT/V5OAADgW79t2iPHT3lZNu5KkyUzRsuYfkcGukgIQiRtAQAAAD8rKCgwCdtmzZrJY4895nG96dOnS3p6umPatm2bX8sJAAB86/d/d0i/qa/K9r2ZctmwHpKZky8Lv1wnv2/aG+iiIcjQpy0AAADgR4WFhTJ27FhJSEiQZ555RiyW/0YicSM6OtpMAACgevhj4w5Jz84z/z/y9k+O5Xecf6Ic1aZRAEuGYEPSFgAAAPCjRYsWyeLFi6Vbt27Ss2dPs+zEE0+UOXPmBLpoAADAhzq1aiC2z25yWXbOKcfI1aceIWGef7MFDJK2AAAAQBVJSkqStLQ0l2Xjx483EwAAAAJo2TK9BEokIjjTo8FZKgAAAAAAAACoKh07SjBjIDIAAAAAAAAACCIkbQEAAAAAAAAgiNA9AgAAAAAAAICa5bXXRHJyROLiRM49V4INSVsAAAAAAADUCBk5eQF7bquI5EihZEheQC99D2QMgsqNN4qkpIi0aEHSFgAAAAAAAPC3qKgoadqkkSSe+1TAyhAWFibJycmyevVqsVo1hRs4GguNCYIXSVsAAAAAAABUazExMbJp81bJz88PWBk0UZuamioJCQkmgRtImrDVmCB4kbQFAAAAAABAtadJykAmKjVpm5ubK/Hx8QFP2iL4sYcAAAAAAAAAQBAhaQsAAAAAAAAAQYSkLQAAAAAAAAAEEZK2AAAAAAAAABBESNoCAAAAAAAAQBCJCHQBAAAAAAAAAMCvmjZ1vQ0yJG0BAAAAAEC1k5+fLxkZGRIWxkXGUVFREhMTE+hiAMFl1SoJZiRtAQAAAABAtZKbmysXXXyxfLFsmVitVqnpGjdpKls2byJxC4QQkrYAAAAAAKDatbJNT0uTuYt/krja8VKT5WRnyqUjjzYxIWkLhA6StgAAAAAAoFqKq1XHTAAQakjaAgAAAAAAAKhZLrtMJDVVJCFBZN48CTYkbQEAAAAAAADULEuXiqSkiLRoIcGIIRQBAAAAAAAAIIjQ0hYAAAAAAKCCLjvjGNm7a7vb+wacNkby8nJl3ZqVkrZ/j1m2+Ptdfi4hgFBE0hYAAADwsR49ephbHal7/fr10rVrVzPfsWNHef755+XMM8+U1atXS2FhoaSlpQW4tACAyrh46n2Sl5sjqft2yfzH75T4eglmmWrcvJW8v3CeDDp9nLy94LFAFxVACCFpCwAAAPjYmjVrzO3mzZtNAtc+r/Ly8mTatGmSkJAg/fv3D2ApAQC+0KvvYHO7ffM/JmkbHRMnfU4Z5bj/+rvnSX5eLklbAF6hT1sAAADAj6Kjo2XgwIFSr169QBcFAAAAQYqWtgAAAECQ0la5OtllZGQEtDwAAADwD1raAgAAAEFq5syZUrduXceUmJgY6CIBAADAD0jaAgAAAEFq+vTpkp6e7pi2bdsW6CIBALz0zedL5Mulixzzn733qqz69rOAlglA8KN7BAAAACCI+7/VCQAQul6ec4/s3bXdMf/0zOulS8/j5ZgTTwlouYAab9w4kQMHROrXl2BE0hYAAADws27dusnevXtNH7UtW7aUAQMGyMsvvxzoYgEAKqFlUntZ/P2uUsvnvbMqIOUBcBizZ0swI2kLAAAAVJGkpCRJS0srtXzt2rUBKQ8AAABCA33aAgAAAAAAAEAQIWkLAAAAAAAAAEEkoEnbFStWyPDhw6V58+ZisVhkyZIlLvfrMnfT7DL6nJg5c6b06tVL6tSpI40bN5ZRo0bJ+vXrXdbp379/qW1efvnlVfY6AQAAAAAAAASRTp1E4uOLb4NQQJO22dnZ0r17d5kzZ47b+3fu3OkyvfDCCybBeuaZZ3rc5ldffSWTJ0+WlStXymeffSYFBQUyePBg81zOLrnkEpdtz5o1y+evDwAAAAAAAEAQysoSycwsvg1CAR2IbOjQoWbypGnTpi7z7777rhlZt23bth4f8/HHH7vMz58/37S4Xb16tZx00kmO5XFxcaW2DwAAAAAAAAA1Omnrjd27d8vSpUtlwYIFXj0uPT3d3CYkJLgsf/XVV+WVV14xiVvtouG2224ziVwAAAAAAFA95GRnat+LIjU9BgBCTsgkbTVZq/3Ujh49utyPsVqtcu2118qJJ54oRx11lGP5ueeeK61btzZ96a5du1amTZtm+r1dvHixx23l5eWZyS4jI8PxHDpVNX0Om83ml+eqLoiZd4iXd4iXd4iXd4iXd4iXd4jXIcQAAKqvqKgoqVuvnlw+uhfHexFp3KSpiQmA0BEySVvtz3b8+PESExNT7sdo37a///67fPPNNy7LL730Usf/Xbt2lWbNmsmgQYPk33//lXbt2nkc4GzGjBmllu/du1dyc3OlqumXjLYa1pOssLCAdkUcMoiZd4iXd4iXd4iXd4iXd4iXd4jXIZnahxkAoFrS3MHzzz0n8fHxNf77TmnC1pt8CoDAC4mk7ddff21awi5atKjcj7nqqqvkgw8+kBUrVkjLli3LXLd3797mdsOGDR6TttOnT5epU6e6tLRNTEyURo0amS8Bf5xg6SBs+nx84ZQPMfMO8fIO8fIO8fIO8fIO8fIO8TqEk1cAqP6JSpK2AEJVSCRtn3/+eUlOTpbu3bsfdl1tNXL11VfLO++8I8uXL5c2bdoc9jFr1qwxt9ri1pPo6GgzlaQHf399AegJlj+frzogZt4hXt4hXt4hXt4hXt4hXt4hXsVq+usHAABA8Apo0jYrK8u0brXbtGmTSaDqoGGtWrVytGh988035aGHHnK7De3W4IwzzjAta+1dIrz22mvy7rvvmj5wd+3aZZbXrVtXYmNjTRcIev9pp50mDRo0MH3aXnfddXLSSSdJt27d/PK6AQAAAAAAACAok7arVq2SAQMGOObt3Q9MnDhR5s+fb/5fuHChaT07btw4t9vQJOy+ffsc808//bS57d+/v8t6L774olxwwQXm8ojPP/9cHn30UcnOzjZdHJx55ply6623VslrBAAAAAAAAICQSdpqYlUTsmXRQcOcBw4rafPmzS7zh9ueJmm/+uorL0sKAAAAAAAAoNqYO1fk4EGR2FgJRiHRpy0AAAAAAAAA+Mzpp0swI2kLAAAAAICP5ObmSn5+foUea7VaJScnx4ztwmCJlUMsfac6xVK7zIyJiQl0MYByIWkLAAAAAICPErYtW7WW/Xv3VOjxmhBLTk6W1atXm0QZKo5Y+k51imWDRo1l+9YtJG4REkjaAgAAAADgA9rCVhO2La6YL2HRcV4/Pswi0jDBIol9bGIte7gWHAax9J3qEktrXo6kPH2B+ZyStIWxerUeuLUJtkhysgQbkrYAAAAAAPiQJmwrlLQVm1gibRIWZRERnVBRxNJ3iCWqrZEjRVJSRFq0ENm+XYJNaHdGAgAAAAAAAADVDElbAAAAAAAAAAgiJG0BAAAAAAAAIIjQpy0AAAAAAKiRtj89SYoy9ri9r9ZRgySuwwmStmKBFBzYIeG1G0jd486SOj2G+r2cAGoekrYAAACAj/Xo0cPc6gjV69evl65du5r5jh07yqJFi+SDDz6Q//3vf1JUVGTumz9/vsTHxwe41ABQ8ySccpnY8nOlKCtVDnz5vITFxkvCyZeZ+yLqNZVdr94o4XUaSsKgSyXrt88k9ZM5ElGvmcQmFR/nAaCq0D0CAAAA4GNr1qwx04cffih16tRxzGvCNisrSy666CJZsmSJ/PPPP9K8eXO5++67A11kAKiR4o7oLbU695PYdseYeUtkjJnXKWf9tyLWIonvNUrq9DxN6vU936yTufr9AJcaQE1A0hYAAADwo48++kh69uwpnTp1MvNXXnmlvP7664EuFgCgBO0SQUXEN/rvtnHx8tSUgJYLQM1A9wgAAACAH23dulVat27tmE9KSpKdO3dKYWGhRES4Vs/z8vLMZJeRkeHXsgIAnNkCXQAANQgtbQEAAIAgNXPmTKlbt65jSkxMDHSRAKDGiKzf3NwWphcPVFaYsbd4eULxcgCoSiRtAQAAAD9q1aqVbNmyxTG/efNmadasWalWtmr69OmSnp7umLZt2+bn0gJAzVW7+xARS5hkrHpXMtd8JGlfv2yW1zl6eKCLBsAX/vxTJD29+DYIkbQFAAAA/OjUU0+Vn3/+Wf766y8z/9RTT8nYsWPdrhsdHS3x8fEuEwDAPyITWkijUdMlLCJaUj+bJ0XZ6ZJwyhUS26ZnoIsGwBfq1BHRupXeBiH6tAUAAAD8qE6dOvLcc8/JqFGjTD+2Rx11lCxYsCDQxQKAGi2yQaK0nvZBqeVxHY43EwD4G0lbAAAAoIroIGNpaWmllo8YMcJMAAAAgDskbQEAAAAAAADULA8/LJKRUdxFwtSpEmxI2gIAAAAAAACoeUnblBSRFi2CMmnLQGQAAAAAAAAAEERI2gIAAAAAAABAECFpCwAAAAAAAABBhD5tAQAAAADwIWteTsUeaBGxFVjEmm8Tq83XpaphiKXvVJNYVvhzCQQISVsAAAAAAHwgKipKGjRqLClPX1Chx4eFhUnj5GTZtnq1WK1Wn5evJiGWvlOdYqmfT/2cAqGApC0AAAAAAD4QExMj27dukfz8/Ao9XhNiqampkpCQYBJlqDhi6TvVKZaasNXPKRAKSNoCAAAAAOAjmhCqaFJIk2O5ubkSHx8f8smxQCOWvkMsgcDg0wYAAAAAAAAAQYSWtgAAAAAAAABqlqOPFklMFGnUSIIRSVsAAAAAAAAANct770kwo3sEAAAAAAAAAAgiJG0BAAAAAAAAIIiQtAUAAAAAAACAIEKftgAAAAAAAABqlhEjRPbuLR6ILAj7tyVpCwAAAAAAAKBm+flnkZQUkRYtJBjRPQIAAAAAAAAABBGStgAAAAAAAAAQREjaAgAAAAAAAEAQIWkLAAAAAAAAAEGEpC0AAAAAAAAABBGStgAAAAAAAAAQREjaAgAAAAAAAEAQiQh0AUKVzWYztxkZGX55PqvVKpmZmRITEyNhYeTay4OYeYd4eYd4eYd4eYd4eYd4eYd4HWKvx9nrdaFWB63p719l8VnwHWLpO8TSd4il7xBL3yGWQRZLq/XQrZ/ye97UQUnaVpDuGCoxMTHQRQEAAEAl63V169aVULB//35z27p160AXBQAAoHrYuVMkAHXBw9VBLbZQaloQZBn9HTt2SJ06dcRisfglC68J4m3btkl8fHyVP191QMy8Q7y8Q7y8Q7y8Q7y8Q7y8Q7wO0WqwVpabN28eMq1d0tLSpH79+rJ169aQSTQHKz4LvkMsfYdY+g6x9B1i6TvE0ncyQjiW5a2D0tK2gjSoLVu29Pvz6o4YajtjoBEz7xAv7xAv7xAv7xAv7xAv7xCvYqGW+LRX7LXcvH++wWfBd4il7xBL3yGWvkMsfYdY+k58iMayPHXQ0GhSAAAAAAAAAAA1BElbAAAAAAAAAAgiJG1DRHR0tNxxxx3mFuVDzLxDvLxDvLxDvLxDvLxDvLxDvEIb75/vEEvfIZa+Qyx9h1j6DrH0HWLpO9E1IJYMRAYAAAAAAAAAQYSWtgAAAAAAAAAQREjaAgAAAAAAAEAQIWkLAAAAAAAAAEGEpG2ImDNnjiQlJUlMTIz07t1bfvzxx0AXKSjNnDlTevXqJXXq1JHGjRvLqFGjZP369YEuVsi4//77xWKxyLXXXhvoogStlJQUOe+886RBgwYSGxsrXbt2lVWrVgW6WEGpqKhIbrvtNmnTpo2JVbt27eTuu+8WulI/ZMWKFTJ8+HBp3ry5+ewtWbLE5X6N1e233y7NmjUzMTz55JPln3/+kZqqrHgVFBTItGnTzGeyVq1aZp0JEybIjh07pKY63P7l7PLLLzfrPProo34tI3xT73vzzTelU6dOZn39DHz44YdS01WkTjh//nzzOXCeNKY13Z133lkqLrq/lYV90jP9bJeMp06TJ092uz77ZdXXm2riuXZV1KkqcqyoCfvlBRdcUCoup5566mG3y35ZOpbujp06zZ49u9rulyRtQ8CiRYtk6tSpZlS8n3/+Wbp37y5DhgyRPXv2BLpoQeerr74yFZ6VK1fKZ599Zr5wBg8eLNnZ2YEuWtD76aefZN68edKtW7dAFyVoHThwQE488USJjIyUjz76SNatWycPPfSQ1K9fP9BFC0oPPPCAPP300/Lkk0/Kn3/+aeZnzZolTzzxRKCLFjT02KTHdK2UuaPxevzxx2Xu3Lnyww8/mIqzHv9zc3OlJiorXjk5OeY7Un8o0NvFixebBM2IESOkpjrc/mX3zjvvmO9NrSAj9Op93333nYwbN04uuugi+eWXX0xyUqfff/9darKK1gnj4+Nl586djmnLli1+K3Mw69Kli0tcvvnmG4/rsk8evs7tHEvdP9XZZ5/t8THsl1VXb6qp59pVVafy5lhRk+pbmqR1jsvrr79e5jbZL93HcqdTDHV64YUXTBL2zDPPrL77pQ1B79hjj7VNnjzZMV9UVGRr3ry5bebMmQEtVyjYs2ePNumzffXVV4EuSlDLzMy0tW/f3vbZZ5/Z+vXrZ5syZUqgixSUpk2bZuvTp0+gixEyhg0bZps0aZLLstGjR9vGjx8fsDIFMz1WvfPOO455q9Vqa9q0qW327NmOZWlpabbo6Gjb66+/bqvpSsbLnR9//NGst2XLFltN5yle27dvt7Vo0cL2+++/21q3bm175JFHAlI+VLzeN2bMGHO8dda7d2/bZZddVuVlrW51whdffNFWt25dv5YrFNxxxx227t27l3t99knvaL27Xbt25nvfHfbLqq03ca7tuzqVt8eKmhLLiRMn2kaOHOnVdtgvy7dfjhw50jZw4MAy1wn1/ZKWtkEuPz9fVq9ebS7tsAsLCzPz33//fUDLFgrS09PNbUJCQqCLEtS0JcqwYcNc9jOU9t5778kxxxxjWkLopZY9e/aUZ599NtDFClonnHCCLFu2TP7++28z/+uvv5pfNYcOHRroooWETZs2ya5du1w+l3Xr1jWXR3H8L/93gP76Xq9evUAXJShZrVY5//zz5YYbbjAtEBCa9T5dXvL7W1vjcJyoWJ0wKytLWrduLYmJiTJy5Ej5448//FTC4KaXmGtr/LZt28r48eNl69atHtdln/TuM//KK6/IpEmTzPeVJ+yXVVNv4lzb93Uqb44VNcny5cvN+WPHjh3liiuukP3793tcl/2yfHbv3i1Lly41V3UcTijvlyRtg9y+fftMv5BNmjRxWa7z+qWEsk9GtW9WvZz9qKOOCnRxgtbChQvNJRfa9xvKtnHjRnO5f/v27eWTTz4xX7jXXHONLFiwINBFC0o33XSTjB071vQZpF1KaJJbP5P6RYnDsx/jOf5XjF4Kqf2x6SW6elkpStMuSyIiIsxxDKFb79PlHCd8UyfUk2m91PLdd981iTR9nP4AuX37dqnJNOml/ap+/PHHph6kybG+fftKZmam2/XZJ8tP+2tMS0szfV56wn5ZdfUmzrV9W6fy9lhRU2jXCC+99JJpzKJ1L+2+Rxux6L7nDvtl+SxYsMD0Wz969Ogy1wv1/TIi0AUAqrL1qPadFVL9lfjZtm3bZMqUKaYvrZo6oIE3tJKsLW3vu+8+M69JSN3HtN+siRMnBrp4QeeNN96QV199VV577TXTim/NmjXmpFl/5SReqErad+WYMWPMgCRaOUNp2oLjscceMz/aldW6C6hJdcLjjz/eTHaaGDvyyCNNn/86kGZN5XyFjI59oCfA/2/v3oOsnv84jr/Ttiok2lWRstFKRezSkCFsooYYhg0ToRqyiE01kyhEbuuSW6jNpZGGLtM2bquNppFLWa1q0q5M/ijl0oVS0ec3r48553d292y7217O93Sej5mv2f2e23e/vn2/7/P+vj/vj6o+dZ2vSYUTqjZt2jS/f/fXU5zjEvESU3GuiE5FLCGa3E37RhM0q/o2KysrptsWz6ZPn+6LgarLY8T7cUmlbcClpKRY06ZNfel3JP3erl27mG1X0OXk5FhBQYEVFRVZhw4dYr05gf7SrmbmGRkZvtpKi+78qYG/fq7q7l+i0ky03bp1K7dOQXM8Da9oTBpyHaq2VYCiYdj33HMPVd01FDrHc/4/sC8XmqRFN6Soso1uyZIl/vzfsWPH8Plf+yw3N9fPVIz4ifu0nvNEw8SEoVEipaWlDbZ98UjDo9PT06vcLxyTNaNzbmFhoQ0dOrRWr+O4rL+4ie/aDRtTVXeuSFQaoq9jr6r9wnFZszh27dq1tT5/xuNxSdI24JKTky0zM9OX0kdW++n3yDuu+I/uACo410zYixYtsrS0tFhvUqDpzl5JSYmvgAwtqiTVHSv9rIsF/k/DKnVxiKR+rbpTB4s686z6L0XSMaVzGKqn85cCs8jz//bt2/1syJz/9//lQn2r9EW4TZs2sd6kwNJNlJUrV5Y7/6vSSzdb1P4F8RP3aX3k80VfrhP9PFEfMaFuXitO0k1blO+vWlZWVuV+4Zismfz8fN/jUvNK1AbHZf3FTXzXbtiYqrpzRaJSaxP1tK1qv3Bc1myUQmZmpvXs2fPgPy5jPRMaqjdr1iw/6+WMGTPc6tWr3fDhw13r1q3dpk2bYr1pgXP77bf72VUXL17sNm7cGF527twZ602LG3369PGz2CL6rKlJSUlu0qRJbt26dW7mzJmuZcuW7u233471pgWSZkrVrPQFBQVu/fr1bs6cOS4lJcWNHj061psWGDt27HDffvutX3RJzsvL8z+HZuadPHmyP9/Pnz/frVy50s+QmpaW5nbt2uUS0f721549e9zAgQNdhw4dXHFxcblrwO7du10iqu74qqhTp07umWeeafTtRO3ivsGDB7uxY8eGn7906VJ/bXrqqafcmjVr/CzJzZo1cyUlJS6R1SQmrLgvJ06c6D766CNXVlbmli9f7gYNGuSaN2/uVq1a5RJZbm6u34+6lut469u3r7+eb9682T/OMVl7mgm+Y8eObsyYMZUe47hs2LhJM81PmTLFJfp37fqIqSruy+rOFYm4L/XYqFGj3BdffOH3S2FhocvIyHBdunRxf//9d/g9OC5rHrtu27bNfwd/+eWXo77HwXZckrSNEzrodGFPTk52vXr1csuWLYv1JgWS/mFHW/Lz82O9aXGDpO3+LViwwPXo0cNfRLt27epeffXVWG9SYG3fvt0fSzp36ctF586d3bhx4xI2gRZNUVFR1HOWEt6yb98+N378eNe2bVt/zGVlZbm1a9e6RLW//aVArKprgF6XiKo7vioiaRsfcZ+u0xX/H86ePdulp6f753fv3t0tXLjQJbqaxIQV9+XIkSPD+13n3QEDBrgVK1a4RJedne3at2/v94tuxur30tLS8OMck7WnJKyOx2jXdI7Lho2bdK3TjYRE/65dHzFVxX1Z3bkiEfelbhT269fPpaam+ptX2mfDhg2rlHzluKx57Dp16lTXokULt3Xr1qjvcbAdl030n1hX+wIAAAAAAAAA/kNPWwAAAAAAAAAIEJK2AAAAAAAAABAgJG0BAAAAAAAAIEBI2gIAAAAAAABAgJC0BQAAAAAAAIAAIWkLAAAAAAAAAAFC0hYAAAAAAAAAAoSkLQAAAAAAAAAECElbAICdcMIJ9uyzz8Z6MwAAAAAAAElbAGhcQ4YMsSuvvDL8+wUXXGAjR45stM+fMWOGtW7dutL6r7/+2oYPH96gn7148WJr0qSJbd26NerjEyZM8I/fdttt5dYXFxf79T/99FN43dy5c+3ss8+2I4880o444gjr3r17o+5HAAAAmI/R9rcovgMAHBiStgBwENizZ0+dXp+ammotW7a0WGvevLlNmzbN1q1bV+VzPv30U8vOzrarr77avvrqK1u+fLlNmjTJ9u7d26jbCgAAkOg2btwYXjRqq1WrVuXWjRo1KtabCABxi6QtAMSw6vazzz6z5557LlyNEKom/f77761///52+OGHW9u2bW3w4MH266+/lqvQzcnJ8dWlKSkpdskll/j1eXl5duqpp9phhx1mxx9/vI0YMcL+/PPPcKXrzTffbNu2batU/VCxPcKGDRvsiiuu8J+v4Pvaa6+1X375Jfy4Xnf66afbW2+95V+ritdBgwbZjh076rRPTj75ZLvwwgtt3LhxVT5nwYIFdu6559p9993nn5+enu6rl1988cU6fTYAAABqp127duFF8aDiy8h1s2bNslNOOcXfmO/atau99NJL4dcq7tXzZ8+ebeedd561aNHCzjrrLPvhhx/8KLAzzzzTx6KKibds2VJp5NrEiRN94YFiVY3UiixieO+993xMrPds06aN9e3b1/76669G3z8AUBckbQEgRpSsPeecc2zYsGHhagQlWtU+4KKLLrIzzjjDvvnmG/vwww99wlSJ00hvvPGGJScn29KlS+2VV17x6w455BB7/vnnbdWqVf7xRYsW2ejRo/1jvXv3rlQBEa36Yd++fT5h+/vvv/uk8ieffGI//vijr26NVFZWZvPmzbOCggK/6LmTJ0+u837Re7z//vv+b49GXwD09ymxDQAAgGCaOXOmPfDAA35E1Jo1a+zRRx+18ePH+xg10oMPPmj333+/rVixwpKSkuz666/38ati5SVLllhpaal/n4ojr/SeKkp45513bM6cOT6JK4pxr7vuOrvlllvCz7nqqqvMOdeofz8A1FVSnd8BAHBAVI2gpKvaEigRGfLCCy/4hK0C25Dp06f7hK4qD1RZKl26dLEnnnii3HtG9nVVBewjjzziKw9U1aDPiqyAqIqC4JKSElu/fr3/THnzzTd931hVPagCIpTcVY9c9ZQVVQPrtQrM6yIjI8MnqMeMGePfr6I777zTB/CqnujUqZPvbduvXz+74YYb7NBDD63TZwMAAKB+KBn79NNP+4SppKWl2erVq23q1Kl20003hZ+nIoLQqLG7777bJ1wVA2pkldx6660+5oykuFbxseJoxagPPfSQH4X18MMP+6TtP//84z9XsaIobgSAeEOlLQAEzHfffWdFRUV+OFho0XCyUHVrSGZmZqXXFhYWWlZWlh133HE+mapE6m+//WY7d+6s8eerIkHJ2lDCVrp16+YnMNNjkUnhUMJW2rdvb5s3b7b6oGSzErMff/xxpcfU+mHhwoW+6kJVGdo/ubm51qtXr1r9nQAAAGgYakWguFUJ18iYVjFeZDwrp512WvhntQWrmGTVuooxZs+ePcvNx6DRa2oJ9vPPP/vHFA/rPa655hp77bXX7I8//mjAvxYAGgZJWwAIGAWcl19+uRUXF5dbNDnX+eefXy55GUl9wS677DIf+Kq9gCboCvV5retEZdE0a9as3O+q4FX1bX048cQTfduIsWPHVjmUTc8ZOnSovf766344nSo33n333Xr5fAAAABy40JwKSphGxrNqb7Vs2bIqY0rFk9HW1SbGbNq0qW/v9cEHH/jCgylTpvh5EDSKDADiCe0RACCGNLTr33//rdQeQElXVbKqr1dNKUmrgFbD0NTbVjSxQ3WfV5Emi1CVgpZQta0Souq1q8C3sah3mRKzmsCiOtpXqrZgggkAAIDYU3Xsscce6+dFUAurhhiZtmvXLj/RmCgRrEreUOyqRK/aK2hRTKk2CXPnzrV777233rcFABoKSVsAiCElG7/88ktfJatA8+ijj7Y77rjDVyWon5cmYdA6tQJQ8lJVpaoeiOakk06yvXv3+moCVepGTlAW+XmqfFCfsNCwssihZaLZdTWcTAG2Ji5TT7ARI0ZYnz59/Cy+daV+uZFtFRRUa1uiBfsKrJ988sly6ydMmODbIAwYMMAH4Eoma/I1/e0XX3xxnbcPAAAAdaeJwe666y4/p8Kll15qu3fv9hPNqlVBXZOnGkWm1gtqlaU4Wv1zc3JyfOGCYmvFuprz4JhjjvG/b9myxRcmAEA8oT0CAMSQJl5QElYVrKmpqbZhwwZflaCEqypiFWwqgaoJxtRTNlRBG40Sn3l5efb4449bjx49/Iy9jz32WLnn9O7d209Mlp2d7T+v4kRmoSTq/Pnz7aijjvLtGJTE7dy5c721HtB7aqK10BKtN2/k/lEyO5KSx6rauPHGG32v3/79+9umTZt8/1sNfQMAAEDshdpY5efn+3hWMZwmFNOEZHWlnrWalFdxpeLagQMH+hv70qpVK/v888/9DX5N4KvErkaiKWYEgHjSxFXVLBAAAAAAACBAhgwZ4kdazZs3L9abAgANikpbAAAAAAAAAAgQkrYAAAAAAAAAECC0RwAAAAAAAACAAKHSFgAAAAAAAAAChKQtAAAAAAAAAAQISVsAAAAAAAAACBCStgAAAAAAAAAQICRtAQAAAAAAACBASNoCAAAAAAAAQICQtAUAAAAAAACAACFpCwAAAAAAAAABQtIWAAAAAAAAACw4/gesFVB8Ri8ZmAAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAo5ZJREFUeJzs3Qd4U+X3wPGT7hYoUPYoFBBBkGVFHCBLQUSGqAiiorhFRfGviBsXCm5FxQU44aciqLgH4kIFRVQURZllU7rpTP7PeWtC0ialadOM5vt5nkvIzU3y5uTm9s3Je89rsdlsNgEAAAAAAAAABIWIQDcAAAAAAAAAAHAQSVsAAAAAAAAACCIkbQEAAAAAAAAgiJC0BQAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAAAAAACCIkbQEAAAAAAAAgiJC0BQAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAACHLz588Xi8VilgEDBjjWL1++3LE+JSXFsX7Tpk2O9brAPeKEmnbuueeafat+/fqSkZEhwcB5n9fPAGq3v//+WyIjI837fdtttwW6OfACSVsAtYLVapWlS5fK2LFjzReW+Ph4SUxMlCOOOMJ0lN59912x2WyBbiaC4ItuZb6QOW8bGxtbrjN75513Om4/9thjy91/4cKFMnjwYGncuLFER0dLUlKSdOzYUU477TS55ZZbJDMz06evDwAQuL8puvz888/ltlu2bFm57TTBCiB06GdW+326LFmyxOv7r1q1Sl577TXz/yuvvFIaNGhQA61EqHv00UflrLPOknbt2rn8zdC/N5689NJLctJJJ0nTpk3N9w39/nv44YfL5ZdfLv/++6/Ltvo9RB9fPfzww5KWllbjrwm+EeWjxwGAgNm1a5dJ1q5YscJlfX5+vvz5559mefXVV2X//v10lOC1wsJC01GvqNPk7PrrrzedIWe67+myYcMG8yX+wgsvNKMtAAC1wxNPPCEvvviiy7rHH3/cp89x6qmnyldffWX+z98QwH9J2xkzZpj/T5w4UUaPHu3V/e+66y4zcEQTcJq0BdzR7xreDOpw932juLjYjKjVRQeQ/PjjjyZZa3fVVVfJokWLJC8vT2bPnm0SxQh+jLQFENL0j87QoUMdCduIiAiZNGmSLF68WD777DOTaDv77LPNr4/h4sCBA2bkMXznlVdeMcn/Q9FftR955BHzf+2c33DDDfLBBx/Ip59+Ki+88IJMmDDBjAAHANQur7/+uuzbt89xXf9mfPLJJz59Dh1N1bdvX7N069ZNQpX2UbSv4i85OTl+ey7A2ebNm82P9Uo/t8nJyYFuEoKUHtP1O+xTTz1ljvWH+v6rPxTajRkzRj7++GN5/vnnpU6dOmadJoD1urMTTjhB2rRp4xil68/jMKqOpC2AkPbYY4/JL7/84riuI2o1OXb66afLoEGDzC/i+kvjb7/9JgkJCY7t9BdvTegOHDjQnLquSd3mzZvLqFGjTLK3LOfTVNatW2dOcW/btq05db5z584mqWf30UcfObbV28q66KKLHLfffPPNLn+AZ82aJcccc4xJ7Olj66+jU6dOlT179rg8Rtn6dX/99Zf5g92wYUPzOrOyshydRT0VRkfk6GPq6fnafq2F5+m0m/T0dFPrqEePHlK3bl1zqk3Xrl3NL8Blv/iUra/3+++/mxjq82mnQUcF6ejSsrQjcc8990jv3r3NtvpatRNx5plnyvr16122/eGHH2T8+PGmoxsTE2Neo54K9M4774i/lJSUVKr+k54CZy/D0bNnT/N+nnLKKaZUgnbEdD/ZvXu32XcAAKFP/0ZGRUWZs3uee+45x3r9Qq1/Dw71Q111/uZWlzd/X7Wv4a7EQ0X1YJ3Xr127VqZMmSKtWrUyfS7tKx2K9u/OP/98R39LY6l9pAcffFAKCgpctr3gggscz6Wx07+3vXr1kri4OFMmy+6NN94wf591vb5u7c/pe1cRHRhwxhlnSMuWLR1x6tevn0mIlP2RvGz/Skdf63urz6f3nz59uulTVLWPqfTHAT39uU+fPtKiRQvz2LrfHHbYYXLJJZeUOy26bJ9xy5Ytct5550mjRo3M/fS1aP+lLI2xjhbXZKO+Zn3t+hq0L/ndd9+5bPvHH3/IxRdfLO3btzft0fdKE0Qag7Llycq+VwsWLJAuXbqY+x155JFmJKDSUYLal9f+ZJMmTcxr1r5yWdV5bt3XtcyVxkGf47LLLpPc3FyXfds+ylZpW93Vj/ZE9zf7PjJ8+PBytzvvL/PmzZOHHnrIvA5tj+7r9u8kH374oXm/db1+hvT7Q9n9SF+P9je1P63HEvv7pd+JKluWRd9z7bvb25Samip79+71+nuKvmbdd+zb6mde46uPpzF2HghR9j3REhR6P32tmrzU7fVstbI/kun3Dd3n9SxKfXzdn/v3728+c2Xf96p8Lj3RfvzXX39dqcXd58oTPYtCv8NeccUV5rVXRN+LoqIix3XdR08++WTzHdP5b4OeLehMX/+wYcPM/zWmlTkOIwjYACCEderUSf8qm2XQoEGVuk9xcbFt9OjRjvu5W+69916X+zjf1rFjR7f3+fbbb822JSUltuTkZMf6VatWOR4nPz/fVr9+fbPeYrHYNmzYYNbv2bPHduSRR3psT6tWrWz//vuv43G++OILx236eE2aNHHZfv/+/bYdO3bYWrZsWe6xGjZsaGvXrp3j+rx58xyP+/fff9tat27tsR3axn379jm21/vab2vRooWtTp065e7TpUsXExM7fR0pKSken+Ptt992bDtnzhxbRESEx22nT59eqffcuZ2V+dPnvO2xxx7reL9Wr15tbr/jjjsct/fp08dxvw8//NCxPioqynb33Xfbfv31V5fXDwAIbc5/U5o1a2YbO3as+X+bNm1MHyMjI8NWt25ds27KlCkuf1P077cv/ub279/fbZ+gbdu2jvUbN270+LfP27+v+rjuXkNFz1FR38n5b707r7/+ui06Otpj+1JTU21ZWVmO7SdOnOjxuUaNGmW2eeGFF9w+Vq9evTy+htmzZ5u//57aceqpp9qKiooc2+v7cqj+4syZMysdp7J9TPXHH394bI+9n/fPP/+43T8SExNtTZs2LXefxo0bu8RT97uycXFeHnnkEce2+l7GxcV53HbChAk2q9Xq9r06/PDD3d7nrrvussXGxpZbf9lll7nErjrPfdhhh7m9j/05yu7bZRfnz5onp512mtvPjbv9xV0s9DOgfUl3+2DZ/UiPRZ7aqvd/6623PO53+loLCgpsw4cPd6w7/vjjzbGsKt9Tbr/99gpjp59vd+/JEUcc4Xb7Hj162PLy8hz3Ofvssyt8fD3ueopzZT+Xlf1OUd19xB3n463z9zRnzp/PMWPG2D7++GPb888/7/gupt9DVq5cWe5+L774ouN+11xzTZXaB/8iaQsgZOXk5Lj8Ybz//vsrdb/HHnvMpTOkHcP333/fdvHFF7s83vfff++4j/P6hIQE28MPP2xbunSpSwdm3Lhxbjsr1113nWO9dpjs6wcMGOBYb//Cp0vPnj1NZ+aDDz6wnXHGGY71/fr1c9sB16VBgwa2Rx991PzB1tenHZtJkya5dNL1C5q2WR/H+b7OnQFNQNrXDxw40HSG3333XZfOznnnneex43LUUUeZ16htcf6ypclMu+OOO86xvl69eqYzqre//PLLtrPOOsv2zjvvmO1+++03xxdKvbzlllvM65s7d675QmJ/jM8++6xGk7aLFi2yNWrUyPx/2LBhFSZtNVlu37bsPqMxnDVrli09Pf2Qzw8ACJ2k7YoVKxzXFy9ebPoI9kTJX3/95fL3wDlxU52/udVJ2lbl72t1k7b6PNdff73p2+jf+7Vr13qMr/7orH837ffVv70al6eeesrxw7cuV155pdvEjy4nnHCC+fu9bNky06fShKT2hey39+3b1/SJ9DVrH8rda1izZo1LskzfC3087W/GxMQ41uvfdjvn906Xq6++2tznzDPPdKxr3ry5xzhVpo+5c+dO03fV16f9p+XLl5v4nHvuuW5jU7bPqD/cv/baa2Z/co7nM88847jP+PHjHev1td5www3mdSxcuNB20UUXmfdC7d692/EDhS6XX365o0/nvM9owtzTezV58mTTDz/xxBNd1mt/eMmSJbZbb73VsU4TUdnZ2T57bn2d7733nu2KK64o9xw60OKrr76yXXjhhS77oq7T5ccff7QdinM7tm3bVu525/1FPyPav9Q4l01eDh482LzHl1xyicf9SJOOCxYsMPfXfeKjjz6y3XfffS6DKDztd3qcGjFihMtAGP2eVdXvKV27dnXE8oknnrB9/vnntjfeeMO0UV/zm2++6fE90f1L94d77rnH5buEXrd79dVXzf6q3xl0/9Zjlb7P+uODbhsZGWmOI9X5XAZ70laPvfp3w93zHn300WYfdefrr792+10UwYukLYCQpZ0f5z9Qzz33XKXu5/zLpP7RdqZ/5Nx1eJ2fx7lzrp1X54Sl8x9Se0dfR6DaR1rqL6H27bVTaU/0aefCvl470vYOoXZEnDssf/75p9sOuD3RaafP5/zlRL8A2Omv5c6jEuydAR0Ral+nz6mdPXs7tHPlfJu9w+zccdH1zh3SU045xXHb448/7vii6Nxu/VLiiX65s2930kknOdqii3NC2vmLTE0kbbVTqu+5/bo+v6ekrdK4uUvc2hcd4aKjZAAAtSNpq3QkmF7X5ECHDh3M//XvoHL+G2BPeFb3b251krZV+fta3aTt1KlTKx1f5x/X9UyiAwcOOG578sknHbdpP0dHNpdN/OioP+f7KOeY6ghOTfjZaQLS3WvQH93t67p16+byeP/3f//nNhnmnBzSUbjOiVbn53Ae1eptH1NpolFHRWqiSRNjZfsaztuX7TP+8MMPjts00Vn2PdLRlc6Pqe+HJ5qQs2+nSWbnfUl/DHA+a8nO+b065phjHOv/97//ubRz3bp1jj6t/shvX29P+Ff3uTWxaB+Fq8/h/EOB848Kzn0+vb83nB+z7D5Zdn/RxKidc79T++z2Effah/e0H/3++++2888/3yTl3Y1Srmi/s59VpovuV85trcr3FB2lq9fj4+PNsc0+Ytcd5/ekd+/eLrddddVVjtu6d+/uWL93717btGnTzOdSR5a6G4ns/N2oKp/LQKpM0lZjoEl8d++1vif62dYfHsrSz5W7YxeCV1SgyzMAQFVpDSNnzhOAVMS5jpLW6XKm1+31hzxNPKX1ouy0fpJzXTo7rXOl2+kEVDt27JDPP//c1Gd6//33ze1ax1XroymtR+tcR+mcc87x2HatzdupUyeXdVpTSuuLla23ZK9rq7S2l13jxo1NjbQ1a9a43EfrqNlpnSSd4M0dvU3rzmpdKmf6mFpnq6LYOD+HtttdfS937dE46uIpJjVNZ1vVCcb0vdRac1oL2ZMhQ4bIxo0b5c033zTvu9Z9++eff1zem2uvvdbUJwMA1A5XX321qav55ZdfuqzzpLp/c6sjEH9f7X2eynDufx199NGm7qS7fpv2c7Zv315ucietyel8H+VcX79Dhw6mvqa7PpI3/UWtrWvvx2kOrGxNX0/9RXu/qF69elXqY2o9Tq1dWZGyNUDt9Dl1PoGKnkNfj85Cb6dzJlRmX9L9RevjerMvHX/88W7bov3kI444wjHJsM4/kZ2d7dLO6j631su1v2f6HFq3114z1znevlK2zmplY6H9fn399j68u/3o119/leOOO85Rj7ei/cLdfrdy5UpzqbWF3377bZcJnKvyPUXrD3/77bdmoiv7sU3r02o9aT0W6DwPWgu8LHefsyeffNL8/++//zaX+pj6mS07B4a71+pOVT6XzrQfrzGpDD0O6THM1/TzqfV7dS4Rddddd5nvFvpdWGt4f/PNN/LMM8+Y71qPPvqoV/shgg8TkQEIWToxgXMC09OXDl+zd5yUc4ej7B9B7ZA4T5D21ltvOSa70A7PoYrMV3YG5GbNmrmd/KOi69Xlrh3OcTlUbGq6Lb6m79Wtt97qmJBEZ2itiHb4LrzwQnn55ZfNF0VN2toL/6vvv/++xtsMAPAf/bvu/HdQJ8hxPu4H+9+5Qz2vcz/COaFXdgIiT3TCLH/x53NVpb9YUb+oMn3M+++/3/F/nexUJ9PSSYz0x2W7shOkuXv8ip7D1zztw5qctdPEqaeBGc68baen5/ZHLJx/HDhUIrg6sdCJD+0JW50cTL93aH+17ARknvaLyMhIRyK8bJKvKrHWie70ByydREwHrehr0GSn9p913Q033FDl59Cksj1hq98FdcKzL774wnwGunXr5tVnoLKfS2c6AEd/IKjMohMs1wSNrT1hq7HVySz1u4cOGnKOrX1SP2fO+6Em0hH8SNoCCGk646hz0lZnaXVHf521z6CpI0Lt9JdIZ87XnberCp2tVX+1V4sXLzYjI+x0NI7d4Ycf7ugsKe2I/Fe+xmXRjtDEiRPLPY+7hKx2Ep07f/Zf0JXOAutuFLF9RIM9SZmRkeGxHfrrblXoL/jOM9TaRx676zA5t0dnt3bXFl38MdJW6YzM7dq1M/8vO2uync40/PPPP5dbrzMBO793njqSAIDQpH83nf+2T548ucIfTP3xN7cyz13Zv6/2/ozatm2b4//vvvtupZ7Tmx+Pnftfq1evdvzgXbafprPSu0vQunsuHV1rpz+kal/ITkcEHqodFfUXtR/n6x/HK7JlyxbH/2fPni0jRowwIxJ9ldwv2y/VJFll+mo6UtTTvlQTPzz467mdE6je9t+ck4iHGhnqq33immuuMT8iadLQ+X2syJw5cxyja2+88UbH6Naqfk/R6yeeeKIZ7akDFXTUq/OAhddff91tOyr6nOkPYWVfq/5ooWc0DBgwQLp37+5ybKrNnH8s0+9TuthlZma6/b+7/dB5/0TwojwCgJA2ZcoUWbhwofzyyy+OLx/6K66WC9DOfFpamjkNXZO5u3btkpiYGJPotSfWtDOhvzLqaYfaKf3xxx8dj+0uQeoNPSVmwoQJpuOjp/B9/fXXZr2eGnTUUUc5ttNfSPXUM3vCWU/r019JtXOiX+I2b95sfi3XRKunkg3uOpj66+4LL7xgrt9+++3mtbds2dJ08J2/ADn/4dZT5jQGeuqRnjamHT897VA7B3rKv57urx3Wqo5q7tq1qxx77LGOJLKewjNt2jQTfz2l57333jPvoX4B0fdJf+3X59POnf6CrO+rnuqjnTIdDaCjS26++WaX5H1l3HTTTeXW6ZfmO+64w+N9tDN75513Vrhf6Kjak08+2cRR29qjRw+zH2oH895773Vsp6ewAQBqF/2baT+LRs+2qIg//uZ6UpW/r5q4sfed9MwTPVVd26ij3Hxt7NixMn36dHOquo7O0/6Mnm6tbdMSRXbah3B3irU7eoq2vk5ttyY49BTt66+/3vQNnR/T2fnnn2/ipAmotWvXmvdU26bJbOfX7W0fpLr0h+A//vjD/P+ee+4xpRI0ue3cz6gO/dH/rLPOMv1rpX1S7U/rjweamPvss89M/+aKK66Qs88+2+wnul6T3/peacJQH0Pvowki/YF+9OjRFfaxqsJfz+18Cr2O5ly2bJl5jubNmzsSiZ5oMlH7tuqHH34wn/Oa2ifsnn/+eTPiUkdU2s8Sq8zn46WXXjLfW/S4oMeihIQEc9ZgVb6n6P6jn019/Vo6TUfEOp+l5u57iD1Gl156qXk+Pd7MnTvXcZt+9sq+Vt0X9aw2fT+0XImnkgi+pJ/3mvjMa3zs5Tnsl+qnn35yjLbWH2e0RIZ+/uz078e4cePMCGb9Mcr5PXcuheIcYztf/yCIGhLooroAUF06O2jZGWfdLVpIX+mkFaNHj65wW+cZSpXzbTrpxqEm/7D7+eefyz22TpxQlk6I4TxLsLvF+fEP9bz2uLRs2bLc4+hMwSkpKW4L3Ovssa1bt66wHc6Tn3iaFKXsxAI6iYPdP//8Y0tOTvb4+Dp7tvOEI/YZrj0tngr0ezvTq8bF00RkdjpRRdkZfZ0nIvvkk08O+Tw60/Hq1asP2WYAQOhMRFYR578BzpN4+epvrrcTkVXl76vzjOPOS9m+S2X6TpWhs9M7T3BUdklNTbVlZmYess/hTCesdfdYnTp18vgaZs+e7XaSI+dJjQoLC91OeFS2f+IpHp7We3pfn3nmGbdt0Zngve0zeppkSyc50omfPL3uRx55xLHt4sWLXSa4dbc4vyee3quK2ulpIjxfPXdFz6ETN7n7rFx00UW2Q9m8ebPjvn379i13u6f9paL+tbv9RSdOc/d5cd4nKrPfzZkzx7FO262TjlXle8rQoUMr3Paaa65x+5707NnT7edNJxzLzc012+tl+/bty22jk/J17tzZbTyr8rn0N+f9z9PivF9edtllFW6rk+CtXLnS5Tl04j37d7AGDRo4YorgRnkEACFPf+nWWkY6UlZ/ZW/Tpo0Z5Vq3bl1T81Z/dV+6dKmjXICe4mMvV6C/MOqvl/prsI64HTlypBnR4mnUhbfKjqq1j751V85Af/nUX4l1JKq2VUd26shYva7t0Zq43sZFTyvS0SQ6ukTjob+k64hf5/pY+uu3ndbB0tEkOjK3V69e5j468kZjqqc56SgOHZ1cHfoLuT7HjBkzTGz0OXQUsI4u0rY6n+6mp5fqqFyNmbZBt9ORq/q+6q/4OiqgogkyfE1HMN99990eb9cRtFo/SkcE6ehhHV2gbdb3XUcp6a/gOnLAeZ8AAIQnf/zN9cTbv6868c+CBQvM7do/0ftoHUVPZamqS0eOab9IR9Nq/0CfU+Ojf1tnzZpl+jLaXm9o+QodPaqnUevr1dIKesaWThzqyf/93/+ZPqbGQvtV2l/UPprGQ0cBankI50mb/EH7Ek8//bQp36D9C92PdESw7ke+oqNL9XT2hx9+2PRt7P1SjZmOtOzTp49LOTDt2+gISR19qW3SvqX+X0dw6z585ZVXSk3wx3Nrv1Q/D3q2mLfvtX5O7JPuap/c+dR+X9KR+5988ol5r/T1676qk+hWtnyJncZK++dKR9zqaHP9fuXt9xQdha11bXUf1dIq+t1L76PbPvbYYy71l52NGjXKjGTW/UvfSx1VquXJ9DOoI3+VXupZCPrea31afVz9/qbHBJ3nI1zoMeCVV14xEyDrd1g9NunfD9339Vinnwvnz6nSGG3dutX8X99be0wR3CyauQ10IwAANcPdbMZ6qqGeNqWn06g1a9a4nGYDAAAAoPpWrVplJuPSPrnWi33ggQcC3aSgoqUG9AchpWUstBQZaoaWmNAf2jRZ+9dff5nBJQh+jLQFgFps8ODB8uyzz5pfW/WXVR1FrL9i2xO2mqzVEScAAAAAfOvoo492nGWnoyO1Dizgb5qktY+Gnjp1KgnbEMJEZABQi+lkInoanTt6Ko2eVuPPGY8BAACAcKKTZekCBIqWaSspKQl0M1AFjLQFgFpMa0ppPSOtCaW1jrS2rdZT1ZlFf//9dznyyCMD3UQAAAAAAFAGNW0BAAAAAAAAIIgw0hYAAAAAAAAAgghJWwAAAAAAAAAIIkxEVkVWq1W2b99u6kMyiQ8AAEDo0Sph2dnZ0rJlS4mICI2xDPRBAQAAwqMPStK2irSznJycHOhmAAAAoJq2bt0qrVu3llBAHxQAACA8+qAkbatIRzfYA5yYmOiXURV79uyRJk2ahMxIkEAjZt4hXt4hXt4hXt4hXt4hXt4hXgdlZWWZBKi9XxcK7G3dvHmzNGjQINDNCWl8FnyHWPoOsfQdYuk7xNJ3iGWQxbJzZ5EdO0RatBD5808Jtj4oSdsqsp+OpglbfyVt8/PzzXPxwa4cYuYd4uUd4uUd4uUd4uUd4uUd4lVeKJUZ8HcftDbjs+A7xNJ3iKXvEEvfIZa+QyyDLJYREQcvA9CvOlQflD0EAAAAAAAAAIIISVsAAAAAAAAACCIkbQEAAAAAAAAgiFDTFgAA1Ao2m02KioqkpKQk0E0J+vpfGietARYOtdSio6MlMjIy0M0AAAAAvELSFgAAhDxN1G7dulUOHDgQ6KaERHJbE7fZ2dkhNQFXVelrbN26tdStWzfQTQEAAAAqjaQtAAAIaZqA3L9/v8TFxUnLli0lJiYmLJKR1UnaFhcXS1RUVK2Pk77WPXv2yLZt26Rjx46MuAUAAMBB27ZJMCNpCwAAQlphYaG5bNGihdSpUyfQzQl64ZS0VU2aNJFNmzaZkhAkbQEAABAqan8hMwAAEBbCoT4rvBcOiWkAAADUPny7AQAAAAAAAIAgQtIWAAAghLz66qty/PHHO66npKTIkiVLzP/nz58vPXv2DGDrAAAAgBAxY4bI1Kmll0GIpC0AAIAfDBgwwJyq/+mnn7qsnz17tll/7bXXVupxJkyYIN9++62Eut9++02GDh0qjRs3Nq8/IyPD5Xatu6sx0cnl6tevL3379pXVq1cHrL0AAACoZZ57TuSRR0ovgxBJWwAAAD/p1KmTzJs3z2WdXu/cubMEO53Iy5eio6Nl7NixZnSwO08++aS8++678t1330l6erqccsopMnLkSDORGgAAAFDbkbQFAAC1UmFJocel2Fpc6W2LSlyTlc63eWvcuHHywQcfSGZmprn+/fffm8s+ffq4bPfPP//IiBEjpEmTJtK2bVu55557xGq1el0CIScnR6666ipp06aNNG3aVM4//3zHcy9fvlwaNGjgsv3o0aPlzjvvdLn96aefNvd3LsngqwT2RRddJEceeaTb2//9918ZPHiwef2RkZFy4YUXyvbt22Xfvn0+bQcAAAAQjKIC3QAAAICacN9X93m8rWNSR5nQfYLj+uxvZkuR1f1I0pQGKXJBzwsc1x9d+ajkFeWZ/985oDTBWVmaBNURo6+//rpcfvnl8uKLL5pk5O+//+7YJi8vzyQrtTTAW2+9JTt37pRTTz1VWrRoYZKc3pg0aZJERUXJ2rVrzcjWiy++WK6++mrzvJWRnZ0tv/zyi/z5558et+nevbts2bLF4+1lyx5Ulr5Wbb8msDVp/Pzzz8txxx1nyikAAAAAtR1JWwAAAD/SJO2tt94qEydONElZre160003OW5ftmyZNGzY0FHjVhOWU6ZMkddee82rpO2ePXvM4+/du9cxovauu+6Srl27ynOVrNulo3vvv/9+SUhI8LiNJoRrQvv27c2I4sMOO8yMtG3WrJkZpQwAAACEA5K2AACgVrq5380eb4uwuFaIuuGEGzxuaxGLy/Vrj63chGGe6ChaTb7efffdZuRo8+bNXW7ftGmTSeQ6ly7Q5GlycrJXz6OPo/dr166dy/qIiAgzercy6tWrV66Egr9ceeWVsmPHDlMSQctELFmyRAYNGmSSxDo5WbjLysoy7yWqTj8fOrKdWFYfsXQVExMjcXFxgW4GACDEkbQFAAC1UkxkTMC3dUcTGjrK9t5775U333yz3O2anE1NTZWVK1dW63n0cfS5NOnpPFJWJ/IqLi42I3EPHDhgrlsspYlpTZI618utTPJFR+5u3ry5wrq6VfHzzz+bEchaFkKdeeaZMm3aNPn222/N/8NdSkoKk7JVk+7f+llbvXq1o2Y0qoZYumrarLls3rSRxC0AoFpI2gIAAPjZddddJ/379zdLWaeddppMnz5dnnrqKVPTVWvRbtiwwSRUBwwYUOnn0BG8OrGYTkQ2a9YsUwtWR9hq0lMnOTv88MPNY2vZBZ0g7X//+59JlA4bNsyr1+Jcj9cbmnAsKCgwi9LL/Px8iY2NNUlkHYX80ksvydChQ6VRo0aydOlS2bZtm3Tr1q1Kz1fb3L3sM2nYnBHH1WKzSdyBHMmPryvy3w8XqCJi6XAgJ1v+78TeUlhYSNIWAFAtJG0BAAD8LCkpSU466SS3t9WtW1c+/fRTufHGG00NWk1kdujQQW64wXMJB0/mz58vd9xxh/Tu3Vv27dtn6sKOHTvWJG0TExNNbVt9nsmTJ8u5555rEqT+oqNznUs32MtEbNy40YwiffDBB2Xq1KlmorPc3FyzTpO4nTp18lsbg1lcnXoSX7deoJsR2mw2iRarWDSOYZ5orDZiCQCAz1lsnFdVJVqvqX79+pKZmWm+9NQ0Pc1o9+7d0rRpU+pEVRIx8w7x8g7x8g7x8g7x8o7WUfz3339NYjM+Pj7QzQl69vIIUVFRjrIItZkmvTURrAnisqPe/N2f8wV7mx/88kdJasFI22onGnMypahufRKN1UUsXUbaTj6qc5WPK/QBfIdY+g6x9B1iGWSxnDBBZO9ekcaNRV59Vfylsn1QRtoCAAAAAAAACC+v+i9RWxWk9QEAAAAAAAAgiDDSFgAAAAB86IaBfWRf2ja3t51w+llSmJ8vf636XjL37DbrXvwrzXH7vu1p8sK0KbLpt18lPzdHOh1znEx75U2/tR0AAAQHRtoCAAAAVdCzZ0+zdOnSRSIjIx3Xzz77bMnJyTETuzVu3FgaNGjgcr+KbkPtMOG2u+Wyh5+Ss2+63Vyv2zDJXNdlwDnnm3rSfc842+19iwsLJLFRE0kdMszPrQYAAMGEkbYAAABAFaxZs8Zcbtq0ySRr7ddVQUGBTJs2TZKSkmTAgAEu94uOjvZ4G2qHnoOGmMsd/2yQRfffJbEJCdLntFGO2zs8+rQUFeTLsmeeKHffZint5fJHn5ZfV3wh37z9hl/bDQBAWBk0SGTXLpFmzUQ+/1yCDSNtAQAAAB+LjY2VQYMGuR1JW9FtAAAA8JO//hJZt670Mggx0hYAAAAIUjpiVxe7rKysgLYHAAAA/sFIWwAAACBIzZw5U+rXr+9YkpOTA90kAAAA+AFJWwAAAMiWLVukbt26kpmZWant8/Pz5fTTTzen+B9zzDE13r5wNX36dPOe2JetW7cGuknwgR+WLZWvF//PcX3F/16TX7741Pw/PzfXXP/t6+XmesaeXeb65t9/DVh7AQCA/5G0BQAA8AOdcEprmWpitF69etK1a1d5443gmWSoTZs2kpOTY0ZzVsabb74p69evl127dskPP/zg07Z88cUXMnDgQNMWd3VftUTAxIkTpWnTpmYyr1NOOUX++ecfqY10n0lMTHRZEPreePA+efmO6Y7r82+9QT584Rnz/5z96eb6J/OfN9d3bfzXXP/5s48D1l4AAOB/1LQFAADwkwceeECuvfZasdls8v7775uRqjpKtW3btl4/VlFRkURHR0ugbNy4UQ4//HCTVPS1OnXqyKRJk+Tcc8+V66+/vtztt99+u0kYr1u3ziTAp0yZYrb97rvvJJh0795d9uzZY5LMrVu3Nonol19++ZC3ofZo0eEwefGvtHLrZ3/xvcf7NG6d7PY+AAAgvDDSFgAA1E6FhaWLzXZwXUlJ6briYt9u6yWLxSLDhw83o0g1+Wj38ccfS69evcwI06OOOko+/bT0dGl1wQUXyEUXXSRjx441oy2feeYZM3pXT58fOnSoSV7qfX799eAp1Dpy9qqrrjKjaHVU6vnnn++x/MGmTZtMuzIyMhzPd8kll8i4cePMY3fq1EmWLy89XVsTqXfffbe89957ZuTwHXfcIb6kiezzzjtPOnTo4Pb2f//9V0aOHCmNGzc2SWPd1vl1+1tKSoojbs7Wrl0rO3bsEKvVKtu2bXNJylZ0GwAAAEDSFgAA1E733Ve65OUdXPfNN6Xr3n/fddvZs0vXOyc0f/yxdN3Spa7bPvpo6fo9e6rcNE3ULV26VA4cOCA9e/Y06zZs2CCjRo2S2267Tfbt2yc333yzSUzqiFa7119/3SRuNUGol0qTfbNmzZL9+/fL0UcfLVdffbVjex2tmp6ebhKE+jg6Otf59kNZtGiRXH755eb5NDGqiVz10EMPmfaddtppJjE8Y8YMt/fXpLSnRUeaVpUmoj/66CPZuXOnieH8+fNlxIgRVX48AAAAINiQtAUAAPATHRWrCUs9/X/MmDFy6623mhGw9gSpjpzV9VFRUXLmmWdK3759TaLWbsiQIWZUbUREhCQkJJh1WhagR48e5j5a53X16tVmvZ56/9Zbb8mcOXMcz3nXXXeZ5ynRUcSVcOqpp5o2RUZGyoUXXiibN282CeXK0mSvp0UTyVWlr1dHI7do0cKMAv76669ltibeAQAAgFqCmrYAAKB2uvnm0kvnuq8nnCBy7LEiEWV+t77hhvLb9u4tctRR5be99try21bSzJkzTU1b+8haHUmrCdXLLrvMnCKvp9k7a9++vVlvp2UOymrevLnj/5qY1ZGv9nIHOqK3Xbt2LttrwldHqFamjm7Zx1bZ2dnSqFEjCSRNaGv7dRSxtuvpp5+Wfv36ye+//+5IZgMAAAAVuv12rScmUreuBCNG2gIAgNopJqZ0sVgOrouMLF0XFeXbbavgsMMOMyNZtS6s0smoNNHqTK/reueEa2UlJyeb7bdv3+4ywlXLCbRq1Ur8Qevdelq6du1a5cf9+eefTdmGhg0bSkxMjFxzzTUmua0TkwEAAACVcumlIlOnll4GIZK2AAAAAaAJ2ffff1+6detmrp999tlmoi+tdVtcXCyLFy+WFStWmInAqkJHyY4ePdrUf927d69ZpyNs3377bfEXHfXradFRsZ7oCOH8/Hwp1AnfRMz/dbE77rjj5LnnnjOjfjVWTz31lMTFxZlEOAAAAFAbUB4BAADAT6ZNm2bq2Coti6D1a2/X07L+G3mriVqte6uTfmlpBE2w6mVV6QRdd9xxh/Tu3dvUom3WrJmMHTs26Cft0mT1wIEDHdfj4+PNpc1mM5fz5s0zZSY0Njq5WqdOnWTJkiUmpuEiPzdbDuRkB7oZoc1mE9uBPMnXcSzVHDkf9oilA59LAICvWGz23i+8kpWVZSbAyMzMlMTExBp/Ph1xsnv3bjNZiTenRoYzYuYd4uUd4uUd4uUd4uWdvLw8+ffff6VDhw6O5B48066fjk7VicssYZBc0RG6GzduNLV9dTRuIPtzvmBvs753dOOrR4+vqampZvI+Pe6i6oilq6bNmsvmTRvLHXMqgz6A7xBL3yGWvkMsgyyWO3aI6AS9WhatRQvxl8r2QRlpCwAAAIRgeY1wGllcU1/2dDK7pKQkvjhXE7F0pbW2q5KwBQD4We/eImlpIjrfg9Pkv8GCpC0AAAAQYnRURqiMDg5W9trJGkcSjdVDLAEA8D3+ogIAAAAAAABAEIkI9CQTOhFGy5YtTV0unUDCmc4srDMet27d2tSo69KlizzzzDMVPuaAAQPMY5Vdhg8f7tjmggsuKHf7KaecUmOvEwAAAAAAAABCojxCbm6u9OjRQyZNmmRmTy5r6tSp8vnnn8srr7wiKSkp8vHHH8uVV15pkrwjR450+5g663JhYaHjus6UrM9x1llnuWynSVqdedguNjbWp68NAAD4F5MywR32CwAAAISigCZthw0bZhZPvv32W5k4caIZPasuvfRSmTt3rvzwww8ek7Za/N7ZwoULJSEhoVzSVpO0zZs398nrAAAAgRMdHW0Sc3l5eeZvPuDM/mN+pM4KDAAAAISIoJ6I7Pjjj5d33nnHjMTV0bXLly+Xv/76Sx555JFKP8YLL7wg48aNkzp16ris18dq2rSpNGzYUAYNGiT33HOPNGrUyOPjFBQUmMUuKyvLUXRfl5qmz6FfSP3xXLUFMfMO8fIO8fIO8fIO8fKOljnSH2N3795trmviVtfBs6KiIpPsru30M6T7hZbZ0smRyn6m+IwBAAAgWAV10vaJJ54wo2u1pm1UVJTpbD/33HNy4oknVur+OiL3t99+M4nbsqURtBxDu3bt5J9//pGbb77ZjPj97rvvPI7CmDlzpsyYMaPc+j179piZUmuafqnIzMw0X+KZkbVyiJl3iJd3iJd3iJd3iJf38SouLjZ/w3fs2EHCtpIxC6d9SxP52mcrKzs7OyDtAVC76fdD55J93h6f9cwRHSQUTsfpmkAsfac2xTImJkbi4uIC3QygdiRtV65caUbbtm3b1kxcNnnyZDPq9qSTTjrk/TVZ261bNznmmGNc1uvIWzu9vXv37tKhQwcz+nbw4MFuH2v69Ommxq6dHqySk5OlSZMmkpiYKP44SOqXUH2+UD9I+gsx8w7x8g7x8g7x8g7xqnq8NNGto0hRcbzS09NNSanavn/pfqEjij29Tr60AaiJhG3rlBTZt2tXle6vx6vU1FRZvXo1ZwNUE7H0ndoUy0bNmsm2TZvoAyAkBG3S9sCBA2YE7Ntvvy3Dhw836zS5umbNGnnwwQcPmbTVSc60nu1dd911yOdq3769NG7cWDZs2OAxaaunXbqbrEwPXv76wqNfPPz5fLUBMfMO8fIO8fIO8fIO8ap6vMLhtP/q0C9bOTk5ZvRpuO9f4f76AfiejrDVhG3jRR+KJcG1RF9lRNhskihF0kSixcqZI9VCLH2ntsTSlpcre88+xXxOSdoiFARt0lZHyehStjOtpz5W5pedN954w9SgPffccw+57bZt22Tfvn3SokWLarUZAAAAAABN2EbUqVul5FhE8QGJiIrXXyRrpG3hglj6Tm2JZWiPEUaN+OwzkeJikajgTI8GtFU6ykNHt9pt3LjRjKTV0/XatGkj/fv3lxtuuMFMHqHlEb788kt56aWX5OGHH3bc5/zzz5dWrVqZmrNlSyOMHj263ORi+pxam/aMM86Q5s2bm5q2N954oxx22GEydOhQP7xqAAAAAAAAAAHVqZMEs4AmbVetWiUDBw50XLfXjJ04caLMnz/flDfQWrITJkwwtdc0cXvvvffK5Zdf7rjPli1byo3GXb9+vXz99dfy8ccfl3tOHam7du1aWbBggWRkZJj6uEOGDJG7777bbfkDAAAAAAAAAAibpO2AAQPMhCGe6EjYefPmVfgYOnlYWZ06dfL4uDpq96OPPqpCawEAAAAAAACg5gVn0QYAAAAAAIAasGf8qWLdtcPtbXFDR4itoECK1v4k1vS9Zl2zz3923K4DxPJee1Hylv5PrJn7JardYVLvyv+TmO5H+a39AHzktddE8vJEEhJEzjlHgg1T5gIAAABV0LNnT7N06dLFlOCyXz/77LPNPAo6X0Ljxo2lQYMG5e773nvvSefOnaVjx44yZswYycrKCshrAIBwlHj1NKl/60ype0VpiUZL/Qbmui4JI88SsYjEDxvl9r75H78rOS88KVFtUkyytmTXDsm4ZYpYszL9/CoAVNuNN4pccknpZRBipC0AAABQBTqBrtq0aZNJ1tqvq4KCApk2bZqZYFdLgjnThO5FF11kJtnVxO1VV11l5leYPXu2318DAISj2OP7m8viLRsl5+mHxRIXL3GDTnHc3uC2B8RWWCC5r75Q7r55SxaZy7pX/p9Et+8oJXt2mZG3Bz56V+qcda4fXwWA2o6RtgAAAICP6QS3gwYNcjvK9oMPPpBevXqZhK268sor5fXXXw9AKwEA3irZtsVcRjZtXnrZrMV/6zcHtF0Aah9G2gIAAAB+tGXLFmnbtq3jekpKiuzYsUOKi4slKsq1e64jdnWxo4wCAASZCiZXB4DqYKQtAAAAEKRmzpwp9evXdyzJycmBbhIAhLXI1m3MpdayNZe7d7qsBwBfIWkLAAAA+FGbNm1k8+aDp9FqTdwWLVqUG2Wrpk+fLpmZmY5l69atfm4tAISf/C8+kgMfvuO4nrdssRSs/Mr8P2HkWHOZ8/RDkrf0f3Jg2WKxJNSR+CEjAtZeALUT5REAAAAAPzrllFNk8uTJ8ueff5q6tk899ZSMGzfOY21cXQAA/pP97GNi/W8krbn+0N0S3SNVYo/tJ3GnjJSSvbvkwDtvSuHa2RLVrqPUu3KqRNQvX8McAKqDpC0AAABQA7p37y579uwxdWhbt24tAwcOlJdfflnq1asnzz//vIwePdrUsT3yyCNlwYIFgW4uAISdqDbtpNnnP5db3+T19z3ex2KxSN3zLjULANQkkrYAAABANehEYhkZGeXWr1271uN9Ro4caRYAAADAHZK2AAAAAAAAAMJL8+aul0GGpC0AAAAAAACA8LJqlQSziEA3AAAAAAAAAABwEElbAAAAAAAAAAgiJG0BAAAAAAAAIIhQ0xYAAAAAAB+y5eWKtUp3tIlVisRaUCJWi8X3DQsnxNJ3akks9XMJuLjsMpH0dJGkJJG5cyXYkLQFAAAAAMAHYmJipFGzZrL37FOqdP+IiAjJSk2VPatXi9VapbQv/kMsfac2xVI/n/o5BYxly0TS0kRatZJgRNIWAAAAAAAfiIuLk22bNklhYWGV7q8JsfT0dElKSjKJMlQdsfSd2hRLTdjq5xQIBSRtAQAAAADwEU0IVTUppMmx/Px8SUxMDPnkWKARS98hlkBg8GkDAAAAAAAAgCBC0hYAAAAAAAAAgghJWwAAAAAAAAAIIiRtAQAAAAAAACCIkLQFAAAAAAAAgCBC0hYAAAAAAAAAgkhUoBsAAAAAAAAAwH/y8/OlsLBQQpXVapW8vDzJysqSiIiqjUmNHTNGIrOzJapxYwlGJG0BAAAAAACAMErYpqS0ll279kmoioiIkNTUVFm9erVJ4FZVs2aNZNOmbRInwYekLQAAAAAAABAmdIStJmxfX9hGEhJCs3KqzabtbioiKWKxVC1pm5dnlfHjtph4xMUFX9qWpC0AAAAAAAAQZjRhW6dO6CZtS0osEhkZIRaL1Eqh+c4AAAAAAAAAQC1F0hYAAAAAAABAWBl4xTbJFJE6Rx8twYjyCAAAAAAAAADCSlS+TeJFxJqbK8GIpC0AAAAAAAAAn5pwzhbZtavY7W1DhtSVnr3iZdHCDNmxo1gaNYqU8eMbyKnDE/3ezmBF0hYAAADwsZ49e5pLnY14/fr10q1bN3O9U6dOsmjRIpk9e7YsWLBArFarWTdv3jxp0KBBgFsNAADgO1dd1Ujy822yb1+xPPNMutSvHyFXXdXY3KbJ3FkP7JGUdtFy9TWN5O3FWfLww3ulZctok8wFNW0BAAAAn1uzZo1Z3n//falXr57juiZsP/nkE5Ok/e6772TdunWSmpoqt9xyS6CbDAAA4FPHHV9HBg6qK8f0STDX4+IizHVd0tNLR+AOG5ZolhEjS0fYLlmqVWahSNoCAAAAfvTLL79I3759TTJXnXrqqfLyyy8HulkAAAB+0zCp9OT/X9ceMKNu16w5YK5vT3NfTiEckbQFAAAA/EhH1n766aeyc+dOsdls8uqrr0p2drakp6eX27agoECysrJcFgAAgFA3alSidOkSK19/nWdq3676sTRpa7XZAt20oEFNWwAAAMCPBg4cKP/3f/8np512mkRGRsrpp59u1kdFle+az5w5U2bMmBGAVgIAANSchIQIeezxlrJlc5HkHbDKpk2F8tCDe+XwjrGBblrQYKQtAAAA4GdXXnmlrFq1Sr7//nsZMGCAtG7dWhITy8+WPH36dMnMzHQsW7duDUh7AQAAfCknxypPzdknf/5ZID//dECenZsusbEWGXs2E7PaMdIWAAAA8LMdO3ZIixYtJC8vT26//Xa58cYb3W4XGxtrFgAAgNokIkJk7dp8WbYsWywWkc6dY+Wii5MkJSUm0E0LGgEdabtixQoZMWKEtGzZUiwWiyxZssTl9pycHLnqqqvMyIP4+Hjp0qWLPPPMMxU+5vz5881jOS9xcXEu22jtMO0ca0dZH/ekk06Sv//+u0ZeIwAAAFDWkCFDpGvXrtKjRw8zKZn2eQEAAGqjNm1i5NPP2surr7VxKY8w99nW8v4H7WTZ++3koYdbSpcurvm7mrb2ykZylojkP/KIBKOAjrTNzc01HdVJkybJmDFjyt0+depU+fzzz+WVV16RlJQU+fjjj82pZJrkHTlypMfH1VPL1q9f77iuiVtns2bNkscff1wWLFgg7dq1k9tuu02GDh0q69atK5fgBQAAAKpK+7AZGRnl1v/6668BaQ8AAABK7eqdIG+KyAunnCLBKKBJ22HDhpnFk2+//VYmTpxo6nypSy+9VObOnSs//PBDhUlbTdI2b97c7W06yvbRRx+VW2+9VUaNGmXWvfTSS9KsWTMz0nfcuHHVfl0AAAAAAAAAUCtr2h5//PHyzjvvmJG4Orp2+fLl8tdff8kjhxi2rGUV2rZtK1arVY466ii57777zOlnauPGjbJz505TEsGufv360qdPH/nuu+88Jm0LCgrMYpeVlWUu9Tl0qWn6HJpw9sdz1RbEzDvEyzvEyzvEyzvEyzvEyzvE6yBiAAAAgGAV1EnbJ554woyu1Zq2UVFREhERIc8995yceOKJHu/TqVMnefHFF6V79+5mht0HH3zQJH9///138ziasFU6staZXrff5s7MmTNlxowZ5dbv2bNH8vPzxR9fKvT16JcsjQMOjZh5h3h5h3h5h3h5h3h5h3h5h3gdlJ2dHegmAAAAIEDqbyiQY3XCr59/FunfX4JN0CdtV65caUbb6shZnbhs8uTJZtSt80hZZ8cdd5xZ7DRhe8QRR5iyCnfffXeV2zJ9+nRTY9d5pG1ycrI0adLE1ND1xxcsLfugzxfuX7Aqi5h5h3h5h3h5h3h5h3h5h3h5h3gdxFwGAAAA4euYe3fLd9o/PucckbQ0CTZBm7Q9cOCA3HzzzfL222/L8OHDzTodPbtmzRozetZT0ras6Oho6dWrl2zYsMFct9e63bVrl7Ro0cKxnV7v2bOnx8eJjY01S1n6ZcdfX3j0C5Y/n682IGbeIV7eIV7eIV7eIV7eIV7eIV6lwv31AwAAIHgFbdK2qKjILGU705GRkV7VHyspKTGz85566qnmert27Uzi9rPPPnMkaXXU7Pfffy9XXHGFj18FAAAAAAAAEHzy8kK3vr/NZv7VcbJisVir8RjBK6BJW50wzD4C1j5JmI6kTUpKkjZt2kj//v3lhhtukPj4eFMe4csvv5SXXnpJHn74Ycd9zj//fGnVqpWpOavuuusuOfbYY+Wwww6TjIwMmT17tmzevFkuvvhix8iSa6+9Vu655x7p2LGjSeLedtttpuTC6NGjAxAFAAAAAAAAwD9iYmKkWbNGMn7cFglVERERkpraSFav3lTlyWW3ikiC5golOAU0abtq1SoZOHCg47q9ZuzEiRNl/vz5snDhQlNLdsKECZKenm4St/fee69cfvnljvts2bLFZTTu/v375ZJLLjGTijVs2FBSU1Pl22+/lS5duji2ufHGGyU3N9dMcqaJ3b59+8qHH35IXTMAAAAAAADUapr/2rRpmxQWFkqoslqtJleoAz+rWvKq7hFHiGzfbgZ4BqOAJm0HDBhgZi72RMsYzJs3r8LHWL58ucv1Rx55xCwV0TdDR+TqAgAAAAAAAIRb4jaUBy9arVbJz8+XxMTEqs9TEKTJWjtmXwAAAAAAAACAIELSFgAAAAAAAACCCElbAAAAAAAAAAgiJG0BAAAAAAAAIIgEdCIyAAAAAAAAAPC7P/4QsdmCdkIykrYAAABAiMnKyqr6TMlwzDqdl5dHLH2AWLqKiYkJ6RnZASBs1KsnwYykLQAAABBiUlJSxKYjQ1BlmlxMTU2V1atXm6Qjqo5YumrSpIls2bKFxC0AoFpI2gIAAAAh5oorrpDExMRANyPkNWjQQAYPHhzoZtQKxLJUQUGBPPLII1JYWEjSFgBQLSRtAQAAgBATGxtrFlRPdHQ0cfQRYgkACDkPP6w1p0T0h/CpUyXYkLQFAAAAAAAAEH5J27Q0kVatgjJpS5V4AAAAAAAAAAgiJG0BAAAAAAAAIIhQHgEAAAAAatCjjz4qmZmZbm/r1q2b1K1bV37//XfJzc01k1d16NBBhg0bxkRWAACEMZK2AAAAgI/17NnTXOoM8uvXrzeJOdWpUydZtGiRPPDAA7JgwQKJiYkxibnHH39cjjnmmAC3GjVFE7BFRUWSnZ0tH3/8sSQkJJh1KiMjQz777DNp0qSJ9O/fX9asWSNr166VxMREGTx4cKCbDgAAAoSkLQAAAOBjmnhTmzZtMglc+3X7bU899ZQZWakjLF955RW56qqr5Icffghgi1GTNFmv9u7da5K20dHRcuSRR5p1P/30k7ls0KCBtG/fXrZt2yZbt26V+Pj4gLYZAAAEFklbAAAAwI8sFosZdamnwmvSVkdatm7dOtDNQoD06NFD0tLSTPL2scceM+s0oXvccccFumkAACCASNoCAAAAfk7SXXfdddKuXTtJSkqS2NhYWbFihdttCwoKzGKXlZXlx5bCHzRh++uvv0rLli3lxBNPlJ9//ll+++03k8jv06dPoJsHAAACJCJQTwwAAACEo40bN8rixYtlw4YN5lR4TeCeffbZbredOXOm1K9f37EkJyf7vb2oWZqg1ZHXOrpWyyikpqaa9VoLGQAAhC+StgAAAIAfvfXWW2ZiMh1ZqS688EL55ptvzKRlZU2fPl0yMzMdi9Y6Re3SqFEjc6kjbHX59ttvzfWmTZsGuGUAANRyRx0lcuyxpZdBiPIIAAAAgB/pZFPz5s2TnJwcU9P2vffek8MPP1xiYmLKbaulE3RB7dW7d2+TkF+3bp0sW7bMTEDWq1cvGTRoUKCbBgBA7fbOOxLMSNoCAAAAfnT66afLjz/+KEcffbRJyNapU0dee+21QDcLftC4cWO54447XNZFRETIkCFDzAIAAGBH0hYAAACoISkpKZKRkeGyzmKxmFq1ugAAAADuUNMWAAAAAAAAAIIII20BAAAAAAAAhJeRI0X27BFp0iQo69uStAUAAAAAAAAQXn76SSQtTaRVKwlGlEcAAAAAAAAAgCBC0hYAAAAAAAAAggjlEQAAAIAQU1BQYBZUT1FREXH0EWJZihgAAHyFpC0AAAAQYp5++mmx2WyBbkZIi4iIkNTUVFm9erVYrdZANyekEUtXTZo0kZiYmEA3AwAQ4kjaAgAAACFm06ZN0qBBg0A3I6RpcjE9PV2SkpJM0hFVRyxdacI2Li4u0M0AAIQ4krYAAABAiElMTDQLqpdozM/PN3Ek0Vg9xBIAAN/jLyoAAAAAAAAABBGStgAAAAAAAAAQRCiPAAAAAAAAACC8TJ0qkpWldackGJG0BQAAAAAAABB+SdsgRnkEAAAAAAAAAAgijLQFAAAAAACoxfLz86WwsLBK97VarZKXlydZWVkSEcHYv+rQWFb1fUD4IWkLAAAAAABQixO27dqkyM49u6p0f03UpqamyurVq03SEVWnsRw8cLAseWeJJCQkBLo5yM4WsdlELBaRevUk2JC0BQAAAAAAqKV0ZKcmbH+44k2pG1vH6/vbLDbJTbJKnb4RYrFZaqSN4SK7MFeu+vEB856QtA0CRxwhkpYm0qqVyLZtEmxI2gIAAAAAANRymrCtV5WkrdjEGl0k9WKixSIkbatDE+BAZQW0GMmKFStkxIgR0rJlS7FYLLJkyRKX23NycuSqq66S1q1bS3x8vHTp0kWeeeaZCh/zueeek379+knDhg3NctJJJ8kPP/zgss0FF1xgns95OeWUU2rkNQIAAAAAAABAyCRtc3NzpUePHjJnzhy3t0+dOlU+/PBDeeWVV+SPP/6Qa6+91iRx33nnHY+PuXz5chk/frx88cUX8t1330lycrIMGTJE0nS4sxNN0u7YscOxvP766z5/fQAAAAAAAAAQUuURhg0bZhZPvv32W5k4caIMGDDAXL/00ktl7ty5ZuTsyJEj3d7n1Vdfdbn+/PPPy1tvvSWfffaZnH/++Y71sbGx0rx5c5+9FgAAAAAAAACo9TVtjz/+eDOqdtKkSaaEgo6i/euvv+SRRx6p9GPk5eVJUVGRJCUluazXx2ratKkpoTBo0CC55557pFGjRh4fp6CgwCx2WVlZ5lJnTvTH7In6HDabjZkavUDMvEO8vEO8vEO8vEO8vEO8vEO8DiIGAAAEl+OeHivbsna6ve3MI0+RN3/70O36R4bf7IfWAf4V1EnbJ554woyu1Zq2UVFREhERYWrWnnjiiZV+jGnTppmEr9a2dS6NMGbMGGnXrp38888/cvPNN5sRv1pOITIy0u3jzJw5U2bMmFFu/Z49eyQ/P1/88aUiMzPTfMnSOODQiJl3iJd3iJd3iJd3iJd3iJd3iNdB2dnZNfbYPXv2NJc6O/T69eulW7du5nqnTp3MgATto9rt3r3bnAH2008/1Vh7AAAIBXedPEXyCvNlV85eufuLOZIUX1/uOulac1vTuo1kQLs+jm2fXPmy/LnnX+nVsksAWwyEcdJ25cqVZrRt27ZtzcRlkydPLpeE9eT++++XhQsXmlG1cXFxjvXjxo1z/F870N27d5cOHTqY7QYPHuz2saZPn25q7DqPtNV6uU2aNJHExETxxxcsnTBNny/cv2BVFjHzDvHyDvHyDvHyDvHyDvHyDvE6yLl/6Gtr1qwxl5s2bTIJXPt1u6FDhzr+f9ppp8nAgQNrrC0AAISKkw87wVxu2LfZJG0TouNlVJfyeZq0rF1mG03qnnWk57KbQCgL2qTtgQMHzAjYt99+W4YPH27WaXJVO7wPPvjgIZO2uo0mbT/99FNzv4q0b99eGjduLBs2bPCYtNUauLqUpV92/PWFR79g+fP5agNi5h3i5R3i5R3i5R3i5R3i5R3iVSoYXv/27dvN3AsvvvhioJsCAEDIeGHVG1JsLZGJR50u8dHlczVAbRC0SVutQ6tL2c60li84VP2xWbNmyb333isfffSRHH300Yd8rm3btsm+ffukRYsW1W43AAAAUFnz58+XU0891cy14M28CgAAhKvsglxZ+MsyiYuKlYlHjQl0c4DambTNyckxo1vtNm7caEbS6qRhbdq0kf79+8sNN9wg8fHxpjzCl19+KS+99JI8/PDDjvucf/750qpVK1NzVj3wwANy++23y2uvvSYpKSmyc2dpAeu6deuaRZ9Ta9OeccYZpnaY1rS98cYb5bDDDnM5TQ0AAACoSVpXWEfYPv744x638TSvAgAA4erVNe9IdmGunNtzlDRKaBDo5iCULV2qExCIxMRIMApo0nbVqlUu9bvsNWMnTpxoRh1oPVqtJTthwgRJT083iVsdQXv55Zc77rNlyxaX0bhPP/20mfDhzDPPdHmuO+64Q+68804zUnft2rWyYMECycjIMPVxhwwZInfffbfb8gcAAABATdABCTqhbUUDBzzNqwAAQDgqthbLvNVvSYQlQi7tPTbQzUGoS02VYBbQpO2AAQPMCANPdCTsvHnzKnwMnTzMmU72UBEdtatlEwAAAIBAeuGFF+SCCy4wgwo88TSvAgAA4ejdP7+Q7dm75ZTD+0m7JH7ERO0WtDVtAQAAgNoqMzNTFi9eLL/++mugmwIAQNA5rFFb2TptRbn1p3c52SxAOCBpCwAAANQQnWNBS3KVVb9+fcnNzQ1ImwAAACAi770ncuCAnpYvctppEmxI2gIAAAAAAAAIL5dfLpKWJtKqlci2bRJsDs7gBQAAAAAAAAAIOJK2AAAAAAAAABBESNoCAAAAAAAAQBAhaQsAAAAAAAAAQYSJyAAAAAAAAGq5nILcKt3PZrHJgSKrRBQWisVm8Xm7wklOYV6gm4AQQtIWAAAAAACgloqJiZHmTZrJMU+fWaX7R0RESGpqqqxevVqsVqvP2xdONJaDBw427wlwKCRtAQAAAAAAaqm4uDjZuGWTFBYWVun+mqhNT0+XpKQkk3RE1Wkss7KyzHsCHApJWwAAAAAAgFpMk4RVTRRqojE/P18SExNJ2laTPZZAZfBpAwAAAAAAABBe6tYVqVev9DIIMdIWAAAAAAAAQHj5808JZoy0BQAAAAAAAIBQT9ru2rVLzjvvPGnZsqVERUVJZGSkywIAAAAAAAAA8GN5hAsuuEC2bNkit912m7Ro0UIsFksVnx4AAAAAAAAAUO2k7ddffy1fffWV9OzZsyp3BwAAAAAAAIDAueEGkf37RRo2FJk9W2pF0jY5OVlsNpvvWwMAAAAAAEJefn6+FBYWBuz5rVar5OXlSVZWlkREMJ1PTEyMxMXFBboZQHB5/XWRtDSRVq1qT9L20UcflZtuuknmzp0rKSkpvm8VAAAAAAAI2YRtm+Rk2bN3b8DaoIna1NRUWb16tUnghrsmjRvLlq1bSdwCIaRKSduzzz7b/GLVoUMHSUhIkOjoaJfb09PTfdU+AAAAAAAQQnSErSZsbz1tkMRFVyntUH0Wi9Rr1UZGJSeJhPmZwvlFxXLPe5+b94WkLRA6qjzSFgAAAAAAwBNN2MaVGeTlNxaLREf99/xhnrQFEEZJ24kTJ/q+JQAAAAAAAACAqiVtD1VcPDExsboPCwAAAAAAAABhqUpTKObm5spVV10lTZs2lTp16kjDhg1dFgAAAAAAAACAH0fa3njjjfLFF1/I008/Leedd57MmTNH0tLSZO7cuXL//fdXsSkAAAAAAAD+c+97n8v+vANubzs6pbWM6tlF3v/1T/ktbZfkFRZJYnysnNb9COmR3MLvbQUQXqqUtH333XflpZdekgEDBsiFF14o/fr1k8MOO0zatm0rr776qkyYMMH3LQUAAABCRM+ePc2llhFbv369dOvWzVzv1KmTLFq0SLZs2SKTJ0+Wv/76SyIjI+WKK66Qq6++OsCtBoDwM/qorlJYXCJZB/Ll3V/+kDqxMTK6V1dzW1KdeHnh6x9l09790qtNS+nYtLFJ8JZYrYFuNoAwUKWkbXp6urRv395Rv1avq759+5oOJwAAABDO1qxZYy43bdpkErj268pms8npp58uN910k5x11llm3a5duwLWVgAIZ11bNjOXu7NyTNI2JjLSJGjVht17TcK2XeOGMr5PT5OsjY6MDHCLAfjM8OGa5BRJSpJak7TVhO3GjRulTZs20rlzZ/nf//4nxxxzjBmB26BBA9+3EgAAAKglPvvsM4mNjXUkbFWzZqVJAwBA8Nianmkus/IL5JbFH0lxSYm0alhfxh3TQ5rXrxfo5gGorrlzpdZNRKYlEX755Rfzfx0hoDVt4+Li5LrrrpMbbrjB120EAAAAao1169ZJkyZNZNy4cdKrVy8z6vbff/91u21BQYFkZWW5LAAA/4iwWMxl1oECOfPoI2XQER1k2/5MWfhDaT4EAIJupK0mZ+1OOukk+eOPP+Snn34ydW27d+/uy/YBAAAAtUpxcbF8/vnnsnLlSunatas888wzMnbsWFm1alW5bWfOnCkzZswISDsBINw1rlfHXLaoX09S27aWA4VF8tkf/8jenNxANw1AGKjSSNuyUlJSZMyYMSRsAQAAgEPQEmM6wlYTtuq8884zAyCKiorKbTt9+nTJzMx0LFu3bg1AiwEgPHVu3kQa1U2QtIwsWfHXRnn/1z/Nep2QDACCNmmrtbhOO+006dChg1n0/59++qlvWwcAAADUMsOGDZNt27ZJWlqauf7+++/LEUccIdHR0eW21dq3OvGv8wIA8I/IiAi58ISjJaVxQ5Ow/XXbTjk6pbWceXS3QDcNgC8cfbRI69all7WlPMJTTz0lU6ZMkTPPPNNcKj2969RTT5VHHnlEJk+e7Ot2AgAAALVCnTp1TEmE4cOHi81mk/r168vChQsD3SwACGtNE+vKg2OHl1uvE45dMeDYgLQJQA3buVPkvx/Ra03S9r777jPJ2auuusqx7pprrpETTjjB3EbSFgAAACgtI5aRkVFu/ZAhQ8wCAAAA+Kw8gnY8TznllHLrteOptbYAAAAAAAAAAH5M2o4cOVLefvvtcuuXLl1qatsCAAAAAAAAAPxYHqFLly5y7733yvLly+W4445z1LT95ptv5Prrr5fHH3/cpWwCAAAAAAAAAKAGk7YvvPCCNGzYUNatW2cWuwYNGpjb7CwWC0lbAAAAAAAAAKjppO3GjRurcjcAAAAAAAAAQE0kbcsqKSmRX3/9Vdq2bWtG4AIAAAAAgPCWX1QcuCe3WCS6uFjyi4pEbDYJZwF9HwD4N2l77bXXSrdu3eSiiy4yCdsTTzxRvvvuO0lISJD33ntPBgwYUKnHWbFihcyePVtWr14tO3bsMJObjR492nF7Tk6O3HTTTbJkyRLZt2+ftGvXzpRbuPzyyyt83DfeeENuu+022bRpk3Ts2FEeeOABOfXUUx2322w2ueOOO+S5556TjIwMOeGEE+Tpp5822wajkhKRL78UWb8+Tjp1EunfXyQyMjja9dVXIjt2iLRoIdKvX3C0SxEz79tFvLxrF/Hyrl3Ey7t2ES/v2kW8vGsX8QIA1LSYmBhp0rix3PPe5wFrQ0REhKSmppp8g9VqlXCn74e+LwBqedL2zTfflHPPPdf8/9133zXJ0T///FNefvllueWWW8yEZJWRm5srPXr0kEmTJsmYMWPK3T516lT5/PPP5ZVXXpGUlBT5+OOP5corr5SWLVvKyJEj3T7mt99+K+PHj5eZM2fKaaedJq+99ppJBP/0009y5JFHmm1mzZplJktbsGCBSQRrgnfo0KGmPm9cXJwEk8WLRaZMEdm2LUKrBpt1rVuLPPaYiJuQBaBdB9cFQ7sUMatqu4iXd+0iXt61i3h51y7i5V27iJd37SJeAICapd+rt2zdKoWFhQFrgyZq09PTJSkpySRww50mbIMt3wEE3KxZInl5IgkJEpRsVRAbG2vbunWr+f8ll1ximzJlivn/v//+a6tXr15VHlLPVbC9/fbbLuu6du1qu+uuu1zWHXXUUbZbbrnF4+OMHTvWNnz4cJd1ffr0sV122WXm/1ar1da8eXPb7NmzHbdnZGSY1/T6669Xur2ZmZmmzXpZU956y2azWDQ2rouu00VvD4RgbVcwt4120S7aRbtoF+2iXcHXLn/052qqzfv37w90U0JeSUmJbceOHeYS1UMsfYdY+g6x9B1i6TvE0ndKQjiWle2DWvQfbxO9WrtWSwsMHjzYjFTV0gLDhw+X33//Xfr27Sv79+/3OnlssVjKlUe49NJL5eeffzblEXR07fLly80I22XLlpmSDO60adPGjNDVEg52WgpBH+OXX36Rf//9Vzp06GAet2fPno5t+vfvb64/psM6KiErK0vq168ve3amSWKjRqZejuP8vpISiYiMkqiYg79iFR7IKf1PdHS5bS0RkRIdG++yrd7UsUu0pG0v3TbCViKRUiJWW6SU2OLNQ+golL/+yJOICKtIVJSe/1H6AHrqR3GxWCwREh138NeCovw8sdmqt21JQbEc0cUim7fWcWwbZckTi8UqxRIlNktEabv+tEqkrdi81pi4g9sWF+aLtaS49JxH+3mP/7WhUtvq7qo1iTSUcXXMfmPftqiwWDp1iZSt2w9uGy2l2xZZS7fVtv29Pl8sUsHjxiaI5b/XXFJUKCXFhd5tq9c1bv8pOVAoXbqIbNqq73HpY0RIoURGFIpVIqTEElUas79EIktKf4mOio2XiIjICh/XtMFmM/uZ7m/ebqvxOvywfNmWZpFiS/TB99NWJBaxSbEtVlq3jhadd1DjpTE2O57uw2UeNzI6ViKjStfre1adbXXf73xYsexIs0qJNUasYj+FxyrREXnmf82SY0rjpSHSfcdqlcioGImMLt3WZrVKUUHptuJ8CtB/20ZERUtUdKxX22q72ra1yu4dpdsWycHPsv3z2bJVlPyzMc6xq1T0ua/uMcK+bYnVIlrZZcc212OE4/2MyJPk1lb5fX2UREbX/DHC/lmOjK4jKSmlI+fKHiOUxWaVlNbF8vs6i8TX8c8xQrfVKHXsHClpaeWPEbqn6+ZtWufLH+uKJTLGP8cIKSwsPeZ3jpe0NPfHCGWOE78VmqfxxzFC41VwIL/0mL/dzTHCGitiiTbt+mdDsdhK/HOMMK+joFi6dLbKlq3ujxFFlpiDx1Wbf44RZlWRVTp2yDP7l7tjhNUWJS1bx5njqr6P/jhG6La6WafDSmRnmptjxH+fz+ato2T93xGlu7EfjhH6WdZ26XFiZ5r7Y0SUFEur1hbZ8G8dx8fL18eI7Oxs05/LzMyUxMRECQX2Pqj2txs0KB0xjaqPwtu9e7c0bdqUUXjVRCx9h1j6DrH0HWLpO8TSd6whHEt7f+5QfdAqlUe48MILZezYsdKiRQvzhfikk04y67///nvp3Lmz+MoTTzxhEretW7eWqKgo8yZosthTwlbt3LlTmjVr5rJOr+t6++32dZ62caegoMAszgFWK689S9acd6IUxZd+kWv7y2Zp9/NGkaOOkv5XP+TY/purR5svCSvPPFby65Z+CWu9bpsc9sMGsXbrKgOnPnlw26ljJWN7rhQmHyPSofTLR8/s7TJi71/yZ0RHWbTxOfOdY+tWkdt7nSMNLftlfpujZEd86RvdNWuXjNzxh2yObiPvZbzkeNxx9S6QRtZd8mpyT9mSUNrJ75i9V87c/ptsj24ub2csdGx7Zr1LpZl1q7zRqptsqNvIrGuXmy5jt6yVU6IbyVxZ7Nh2QutrJCVig7zRtIusq9NU9OzGHqdmyIVpP8v+qLryWuZ7jm1PrXudtLOtk/ead5Zf6zc365rm58hFm1dJdlSsvJT5kWPbIfVuko7Wn+Xjph1ldcNWZl1SYZ5ctvEHyY+Ikudz3xeLtTTuA+veKZ1LvpPkxh1ka4c2Zl294gKZuvU7sVoscnfae2IrqmNidm73mXJUxHL5qlGKfN04xWwbW1IsUzd8bf4/p/AtkaLS13xs3Qcl1faRfN8wWT5v2sGsi7BZZdpfK8z/5xa9JMWFpc+XWmeOHCtL5KcGLeWjZoc7XscNf34pEyNEHq77jGTnlH4+jm36gpwcv0jW1G0uS5t0NjFrdLpNbvj3a4mzFstL1kck+0Cv0vcz4RUZYFkgf9ZrIm+37Op43Kv++c68xlflXsnIPcGsOzx+sZwc8bT8U6eR/K91N8e2l//7vTQsOiBvyK2yO7f085oc9Z5MjHhUNnVsIAtaHPwB46K0VdK8MEdezr1e/t06Qpo3t8lh9T+VkZEzZUdcPZnfNtWx7XlbfpbWBzLl3YgrZUv2WLOuRex3MibqVtkbU0eea9fbse34rb9ISt5++TDiQvkne6JZ1yTmZxkb/X+SGR0nT7U/1qwrLhEZWfd36Zy8V94tHC8/7bisdNuEP+TKJpMlLzJaZrc5wcQrKlJk5PY/pGv2Llkedbr8njnFbFs3cotMjJsoRZZIefDwfo42DNu5Xnpm7pBvo4bJz5nTSt/7iD1ycXxp22d2OliP+6TdG6T3/m3yQ9Qg+THzdtGPf2Z6ntycfJq5/b62/aTov6TZgP3/Sr+MLbLSdrw0b36vxJbmb2RyneHm8rEOx0teVOm+evy+zdJ/70b5NTpVVmQcPEZcVme0REmRiYPGQ+nzazv+iD5SPs84eIyYVHesxNty5bmU3rIzqo4caG+Ro5q4HiPsJidPkAayX7oN7yW769T8MWLctrWyOzpJXtm1WPbutbg9RqjW+Zly/o6f5baj68jCbP8cI7rYvpNPktpLWvu2Iu3LHyOkqI45tnYtuV8e7vWFfNPEP8eIaX99KVJik6zMuSLi/hih9Dhx39FfSYLNP8eI9vHvyVB5RAYkNJQF/TwcI/aOMMfV4zt+KmPi/HOMUKO3/iYTI/bJuy08HyPsx9Uxu/xzjFAlhblyWcIIkWTPx4iPttxnjqt6nPDHMWJvbB1zXD2i6Q6ZFOHmGNGm9BjxXMujpNHp9cxx1R/HiDcyFpvjqh4nJia7P0ZM2vGzpEfWlS+/fEfs0yWsfPA6KVq/Tv7s21l2HlZ6jKibniNHv7NKChNi5eQ5Hzra8P3j06Tw1zXyd5+OknZE6TEiPjNP+rz9gxTHREm/p5ZR4xAAAABBq0pJ2zvvvNPUh926daucddZZEvtfhiIyMtJMHObLpO3KlSvlnXfeMaN7deKyyZMnm1G39kSxv2iN3BkzZpRbX1RcJHl5eVJoLR21kZ+fL0VFRVKUl2cy/nZay8dSXGzq+OZbSsy6AwcO/LdtfpltCyQvr3SbQykstEiBWCQn1yLZxaUJktxcixQUWCSvyCJpaf+NxtHnayNSYLFITo5FskvKbFvsum2efVt9XFvp+pwDFikqstgHi1Yo/0Dp4+aXedzc1hYpiLSY582OKF2fUFC6bUGJuGybY982zyLZUaXro4v+2zbCItt1FPJ/ryO7lUWK/tvmUPLyLFIQbTGX2dml9yksKX1ctWOnRaz//T+rhUUKYiySd+DgthG2g9vu3GORgrzS/x/WzCIFca7bKo1ZhBx6QPsBbVeBRSxWi+zeb5H0rNLHaNnEIgUJFjkQ5fq4+mU3ptgie7Mssmt/6frGjSxSUNciByLFZdt8jVmRRfZmWyQtvXR9/YYWkUoMKtIv1A2LLVJQ3yI6RtnlcfO1HRZJP2CRtN2l66PqWaQgySL5Ntc2HMgvfX378y2Stqt0va2ORQoaWyS/xPVxK0PjVfq4pW3IzD24r9WPtUhBc4sURZRpw3/7ZWbewW0ToixS0Oq//chpW7OfFFgk68DBbe0DVQ8VL7uCtv89bo5F8iItLo+bU+C6v+e3tUj0f/HNjnb9fOYWun6O8tvqSMzSz/KBmMrFTV97trXmjxG67QHdL53icKhjmL+OEQVR/312K1HKSz+3/jpG6LYRlTznpUiP+X48RhQlVu6Yn5llMfuDv44Rhf/FtzLHCf8eIywilSiHZf98+OMYkV1o8fq46o9jhPO2h7J+fZZ06ZJf2oYDB8RWVGQutU+lIvLyTH9KjyfO/akDeQfEqtvmH9zWlvdf30tKR2YU5B38QR4AAABhZv360jO29OwwnaU3yFSpPIIzTVL6oph12fII2hnXocK6Tksv2F188cWybds2+fDDgyMp/FEewd1I2+TkZNm1fWuNlEdYsUJk6Gl66qn78gh2zZrkSlys+1MKbbYIKXH69hgpnk8/rOy2ekrq3n0RUmxOJS7l7tTnxkklUie2WGxikRLbwW0jJF8iLKWnKFstka5tqMS2Lqcz2+roycyObfV0/937otxv+9+pz6pp4wMSH1fB41oTzGmepm16irKl0KttnU9nVtb8Qtm3zyJFVs/lEVSjRjapG1NaHkG3tdjj4+FxD56iHCfy33pvti3IL5bM/QUm7m7LI1hjRV9p48Y2iY0plqiIfM/b2vSHm//W26q3rX7MMvaWSIR4Lo+gpz5rvPT3Ij312WxrixHbf9vqKbnO2zr2a8e20WKTWK+2LR0RZju4rYdTnxs2inWMtI2y5FS4rdUpe1jxtpFilXi32xYUWsz+5ekYYf981m8UKTFxNX+MsH+W8/LrOBJTnsoj6LZJjUSiYvxzjNBt8woiZU96VIXHiEhLvjRpXCRRsf45RkTbCs3+tXNPQoXHCNU8qcDsX/44Rujns6Qov/SYX8ExQjVuVCR14v1zjFDF+cWyf5+twmOE0uNEQox/jhEqP98qWfsPVPi5L7HFlR5XY/1zjNBtdf/av9da4TFCP59JjS2mXf44Ruhn2T7StqJjhG770SfxjpG2NVEeoWHDhpRHCFOhfFplsCGWvkMsfYdY+g6x9B1iGWSxbN1aR0qItGrlOituKJdHKCkpkfvuu0+eeeYZ2bVrl/z111/Svn17ue222yQlJUUuuugiqS4zCqKoqFzgdTRvRaeyHXfccfLZZ5+5JG0/+eQTs15pDd7mzZubbexJWw2Wlna44oorPD6ujia2jyh2FlcnUeJiDn75sX/PdLddORVsO3iISOuWpfuOfr/QV+z8qu01bTduPFjn7dAOfpGp6rb2+nP2dqliW4LYB5IebNfB70eunGJ1SJ62dfcjQbzbthX990XatW3xHtrm7nH1/rHV2rakJLZcuzTJYP3vtG3XmMV60YbqbVtSEi0pKdGltT2ddq5iOdiuZNMui0RGRnvYYd09V/W2dXkfXW6JkCJr3dJ2tXLex9w9rt5Qr5JtqNy2pe3S0WF1He+jnYbP5nbfd/e4nlRtW+d4Fbn5CU6TKK1d4lWzxwh37XI+RjhYRJq7PVbU3DGibLtM7qbM+6z7V2nN0YO1iWv6GKHryrbL+Rhhb1fp/hXjpl01c4zQz2bpcaLMMV/ctSv6v+NE5R63uscT5+PqwX2r9BhRueOq748Rpe2KlJSUumXadfBvuDl+JduPq/45RpS2q/zfRzv9fGoKuOK/3b4/Rri2K0G0/K0zbaaeQKTt6t//YFncGKe6uYd66zxu69Rv48sSAAAAglWVkrb33nuvLFiwQGbNmiWXXHKJY72WTHj00UcrnbTNycmRDRs2OK5v3LhR1qxZI0lJSWbErI5+veGGGyQ+Pt6UR/jyyy/lpZdekocffthxn/PPP19atWplyheoKVOmmPs99NBDZoTuwoULZdWqVfLss886RvRqQveee+6Rjh07miSuJpu15ILzJGiBpl+adNDvmWeWfslz/pJlH6j76KOVScKER7uCuW20i3bRLtpFu2gX7QqddgEAANQkLZ+pgwf58bh6rFarKVdanVjWtdkkqN8FWxV06NDB9umnn5r/161b1/bPP/+Y///xxx+2Bg0aVPpxvvjiC+2el1smTpxobt+xY4ftggsusLVs2dIWFxdn69Spk+2hhx6yWa1Wx2P079/fsb3d//73P9vhhx9ui4mJsXXt2tW2bNkyl9v1/rfddputWbNmttjYWNvgwYNt69ev9yoGmZmZpq16WZPeestma91av8YcXJKTS9cHUrC2K5jbRrtoF+2iXbSLdtGu4GqXv/pzNdHm/fv3B7opIa+kpMR839BLVA+x9B1i6TvE0neIpe/k5ubaTj7pZFtEhJnVgqUaS0REhK13797ViuXW/zqf1pYt/bofVLYPWqWatjry9c8//zSjX+vVq2dqxWp5hHXr1skxxxxjRtDWdpWtP+ELevrgl19azUQcnTolSv/+EUEx6kTb9dVXIjt2iLRoIdKvX/CMhiFm3reLeHnXLuLlXbuIl3ftIl7etYt4edcu4hWY/pyvUNPWd6gr6DvE0neIpe8QS98hlr6TkZEhQ4YMkZsvmyl1Erwpf4WybGKTksgCiSyJdcxl4q2+k4dL/P69Ym3ZUiJMjbNaUNO2S5cu8tVXX5mkrbM333xTevXqVZWHRAX0S4tOwKEzJzdtmuio6xYs7QpGxMw7xMs7xMs7xMs7xMs7xMs7xAsAACDwEhLqSp2E0vkYUPWkbaFYJEYOTkDtLS2hGsyqlLS9/fbbZeLEiZKWlmZ+cVm8eLGsX7/e1Jt97733fN9KAAAAAAAAAAgTVRpfMWrUKHn33Xfl008/lTp16pgk7h9//GHWnXzyyb5vJQAAAAAAAACEiSqNtN22bZv069dPPvnkk3K3rVy5Uo499lhftA0AAAAAAAAAwk6VkrZaNPnrr7+WpKQkl/XffPONDB8+3BRWBgAAAAAAABCazrjkZNm5Z7vb24YNHCUffLG03PoPX/lO6tUNjQlea2XSVkfSauL2iy++kHr1Sme7W7FihYwYMULuvPNOX7cRAAAACCk9e/Y0l4WFhWbuh27dupnrnTp1kgceeEA6dOjgWKfeeustsw4AACBYXHfJzZJfcED2pu+WJ+bNlgaJDc061aJZa5O0HXDcyTLw+CGO+8THxUuo+P7u+TJh8nD5Q/ObUkuSts8//7yceeaZJkn70UcfybfffisjR46Ue+65R6ZMmeL7VgIAAAAhZM2aNeZy06ZNJoFrv25fpwMfnNcBAAAEm77HDDSXm7f9a5K2cbHxclK/U826HbvSzGW7NofJcUf3lzrxdSTUFDZsLPoqbM2bS62ZiCwiIkIWLlwo0dHRMmjQIJOwnTlzJglbAAAAAAAAIEzM/98zMmT8MTL0nGNlzvwHxWq1BrpJtUalR9quXbu23DothTB+/Hg599xz5cQTT3Rs0717d9+2EgAAAKhFcnNzpXfv3lJSUiKjR4+WW265RSIjI8ttV1BQYBa7rKwsP7cUAACgvLi4eLlg7OVyePsjJL8gX15cOEdeWzJPklulyMiTzwx088IraaundVksFrHZbI519utz586VZ5991vxf12nnEwAAAEB5LVq0kLS0NGnatKmkp6fL2WefLQ899JDceOON5bbVs9lmzJgRkHYCAAB40rB+klxyztWO63v37ZKnXnpY/tn0l4SKVp+9LdeJSPS8eSJBWD2g0knbjRs31mxLAAAAgDAQGxtrErYqKSlJJk2aJK+99prbpO306dNl6tSpLiNtk5OT/dpeAACAspZ+9D9Z++fP0q1zLykqKpI3l71m1nc/4igJFe3ffkEeFhHrrFmhnbRt27ZtzbYEAAAACAO7d++Whg0bmvkhtPTB4sWLpVevXh4TvLoAAAAEkzat2smHy9+Vb35YLgVFBdKyWWv5vzNvk8F9Twl002qNSidt3Vm3bp1s2bJFCgsLXdbrxGQAAAAAyvv666/l9ttvNzVsi4uLzcS+WtMWAAAgGLVt3V6+WfK7y7peR/aWp2e+HLA2hYMqJW3//fdfOf300+XXX391qXOr/1fUtAUAAABEUlJSJCMjw2XdmDFjzAIAAAB4EiFVMGXKFGnXrp05tSshIUF+//13WbFihRx99NGyfPnyqjwkAAAAAAAAAKCqI22/++47+fzzz6Vx48YSERFhlr59+5rZba+55hr5+eeffd9SAAAAAAAAAAgDVRppq+UP6tWrZ/6vidvt27c7Jitbv369b1sIAAAAAAAAAGGkSiNtjzzySPnll19MiYQ+ffrIrFmzJCYmRp599llp376971sJAAAAAAAAAGGiSknbW2+9VXJzc83/Z8yYISNGjJB+/fpJo0aNZOHChb5uIwAAAAAAAACEjSolbYcOHer4f8eOHeXPP/+U9PR0adiwoVgsFl+2DwAAAAAAAKg18vJyxCLkz6rDJjYpiSyQohJblWOZ3bSV/JO+Rzp16FC1+rHBlLSdNGlSpbZ78cUXq9oeAAAAAAAAoNbR0qIN6jeQMy4dIlarNdDNCWkRERGSmpoqq1evrlYsmzVtJps+/rhqo1prmFdtmj9/vplsrFevXmKz2WquVQAAAAAAAEAtEhcXJ8+/8LwkJiaapCOqzmq1mrP+k5KSqhVLTaTr+yKhnrS94oor5PXXX5eNGzfKhRdeKOeee64JDgAAAAAAAIBDJwlJ2vomaZufn1+rY+nVq5ozZ47s2LFDbrzxRnn33XclOTlZxo4dKx999BEjbwEAAAAAAADAB7xORcfGxsr48ePlk08+kXXr1knXrl3lyiuvlJSUFMnJyfFFmwAAAAAAAACg5kyYIDJ0aOllEKpWnV0dfmyxWMwo25KSEt+1CgAAAAAAAABqypdfiqSlibRqJbVipG1BQYGpa3vyySfL4YcfLr/++qs8+eSTsmXLFqlbt27NtBIAAAAAAAAAwoRXI221DMLChQtNLdtJkyaZ5G3jxo1rrnUAAAAAAAAAEGa8Sto+88wz0qZNG2nfvr18+eWXZnFn8eLFvmofAAAAAAAAAIQVr5K2559/vqlhCwAAAAAAAISS/Px8KSwsDNjzW61WycvLk6ysLDNPFAIby7o2m/d1Y4M1aTt//vyaawkAAAAAAABQQwnbdm3bys7duwPWBk0upqamyurVq03SEYGN5VYRaS0iNptNLKGetAUAAAAAAABCjY6w1YTt1pn3SmJcXEDaoKnF9PgESTpnXFCP8AwFVh/EMuGOGSJZWWITIWkLAAAAAAAABIombBPj4wOWaMyPjZFECe7T8kOB1QextAZ5CVj2EQAAAAAAAAAIIiRtAQAAAAAAAISVwmP7yMN6OXGiBCOStgAAAAAAAADCSuEpQ+V6vbzpJglG1LQFAAAAAAAAapGUm2+Vzenpbm+beOyxMv+C86WopESOfWCW/LRlqzRLTJSds+73ezvhGUlbAAAAwMd69uzpmKl6/fr10q1bN3O9U6dOsmjRIsd2F1xwgSxYsED2798vDRo0CFh7AQBA7fLEuLGSW1Ao2zMz5fo335LGdevKE2ePNbe1a9zIXN6yZKn8tWt3gFsKT0jaAgAAAD62Zs0ac7lp0yaTwLVfd7Z48WKJjo4OQOsAAEBtN6J7d3P5586dJmlbJyZGxvU+2nH7Z3/+KQ9/9rnMnTBeLn751QC2FJ5Q0xYAAADws127dsl9990nDz+s018AAAD4z76cHDl/3gK5/qTBMrhTZwlXde+8S2x6ecQREowCmrRdsWKFjBgxQlq2bCkWi0WWLFnicruuc7fMnj3b42OmpKS4vc/kyZMd2wwYMKDc7ZdffnmNvlYAAADA7pJLLpFZs2ZJvXr1KtyuoKBAsrKyXBYAAIDq+L+3FktsdJRccNyxsjl9n1lXYrXKht27xWq1Brp5CIakbW5urvTo0UPmzJnj9vYdO3a4LC+++KJJsJ5xxhkeH/PHH390uc8nn3xi1p911lnlOsrO22mnGQAAAKhpzz//vLRp00YGDRp0yG1nzpwp9evXdyzJycl+aSMAAKi9Nu7dZ5YuM+6WAQ8/atbtzcmRjrffKVn5+YFuHoKhpu2wYcPM4knz5s1dri9dulQGDhwo7du393ifJk2auFy///77pUOHDtK/f3+X9QkJCeUeHwAAAKhpX3zxhTnj7L333nOs6969u+nr9urVy2Xb6dOny9SpUx3XdaQtiVsAAFAdM0YMlz3ZOeb/e3Jy5MrXF0qDhHh5bsIEqRMbG+jmIdQmItO6X8uWLTOz61aWztb7yiuvmI6ujtB19uqrr5rbNHGrJRpuu+02k8gFAAAAapL2Q51pP3Xt2rXSoEGDctvGxsaaBQAAwFf6H3644/+b9paWR4iNipYzU48KYKsQsklbTdZqza8xY8ZU+j5aIzcjI0MuuOACl/XnnHOOtG3b1tTS1Q7ytGnTZP369WYG34rqieliZ68nprU+/FHvQ5/DZrNRW8QLxMw7xMs7xMs7xMs7xMs7xMs7xOsgYgAAAGq7zs2bi+2ZpzzentK4UYW3I3BCJmmr9WwnTJggcXFxlb7PCy+8YMovaHLW2aWXXur4f7du3aRFixYyePBg+eeff0wpBU/1xGbMmFFu/Z49eyTfD/U+9EtFZmam+ZIVERHQUsQhg5h5h3h5h3h5h3h5h3h5h3h5h3gdlJ2dXePPoZPk6iCCiuh7AQAAAIRc0varr74yI2EXLVpU6fts3rxZPv300wpHz9r16dPHXG7YsMFj0tZTPTGtoZuYmCj++IKlp87p84X7F6zKImbeIV7eIV7eIV7eIV7eIV7eIV4HeTMYAAAAAPCnkEja6ojZ1NRU6dGjR6XvM2/ePGnatKkMHz78kNuuWbPGXOqIW0881RPTLzv++sKjX7D8+Xy1ATHzDvHyDvHyDvHyDvHyDvHyDvEqFe6vHwAAAMEroD3VnJwckzC1J003btxo/r9lyxaXEa1vvPGGXHzxxW4fQ8saPPnkk+VGkGjSduLEiRIV5ZqX1hIId999t6xevVo2bdok77zzjpx//vly4oknmll7AQAAAAAAACBsk7arVq2SXr16mUVp+QH9/+233+7YZuHChabO1/jx490+hiZh9+7d67JOyyJo4nfSpEnlto+JiTG3DxkyRDp37izXX3+9nHHGGfLuu+/6/PUBAAAAAAAACD4Hzj1Hhurls89KMApoeYQBAwYccuIFnTTMeeKwsnS0bFmakPX0uFqH9ssvv6xCawEAAAAAAADUBiWHHSYf62W/fhKMQqKmLQAAAAAAAFBdWfn5AXtuq4jkiUWyDhwI7KnvtYDVB7EM5L5QGSRtAQAAAAAAUKtpuczmTZtK8vRbAjoJampqqplnSedjQuBj2bxpU7NvBCOStgAAAAAAAKjV4uLiZOPmzVJYWBiwNmhyMT09XZKSkkzSEYGNZeRXX0m01SoxK1dqDVcJNiRtAQAAAAAAEBaJW10CmWjMz8+XxMREkrbBEMvLLhNJSxNp1Upk2zYJNuwhAAAAAAAAABBESNoCAAAAAAAAQBAhaQsAAAAAAAAAQYSkLQAAAAAAAAAEEZK2AAAAAAAAABBEogLdAAAAAADeycrKYtZpH8w6nZeXRyx9gFi6iomJCejs9ACA2oGkLQAAABBiUlJSxGazBboZIU2Ti6mpqbJ69WqTdETVEUtXTZs1kc2btpC4BQBUC0lbAAAAIMTc/tFUadC8fqCbEdpsIvF59eSchBEilkA3JsQRS4f8nHyZfvx9UlhYSNIWAFAtJG0BAACAEBNXJ1bi65EQqhabSKwtRkTjGOaJxmojlgAA+BxJWwAAAAAAAADhZds2CWZUiQcAAAAAAACAIELSFgAAAAAAAACCCOURAAAAAKAG3dx3pqSn7Xd7W++RPWX7X7tk75Z9Yi2xSlKrhjJw4gky4Pzj/d5OAAAQPEjaAgAAAD7Ws2dPc6kzyK9fv166detmrnfq1Enuv/9+OfPMM6WkpESKi4vliCOOkGeffVYaNmwY4Fajpoy7c5QUHCiUzF1Z8ua970ndpDpy9p2jzG2NWyfJL5+uk6btGkteRp68++jHsvCOJXL4se2l5eHNA910AABqrxkzRDIzRerXF7njDgk2JG0BAAAAH1uzZo253LRpk0ng2q+rgoIC+frrryU+Pt5cnzJlitx5553y2GOPBay9qFndT+piLnf+s9skbWPiY6T3iNLEvmrbvbXkZR6Q/Tsz5dMXvpKC3MIAthYAgDDx3HMiaWkirVqRtAUAAADCXWxsrOP/Oto2NzdX6tatG9A2IbB2bNgtd5/ysPl/RGSEnHX7SEbZAgAQ5kjaAgAAAH6mZROOOeYY2bx5s3Tv3l3eeecdt9vpqFxd7LKysvzYSvhL4+Qkueali2Xftv3yzkMfyQdPfibdBx0hTdo2CnTTAABAgEQE6okBAACAcBUTE2NKJuzatUs6d+4sc+fOdbvdzJkzpX79+o4lOTnZ721FzYtNiJEu/Q6XfuP7SK9h3SQnPVfWfPxboJsFAAACiKQtAAAAEMDk7YUXXigvv/yy29unT58umZmZjmXr1q1+byNq1gdzPjd1br9940f56Jnlsuqd0vrHrY9oGeimAQCAAKI8AgAAAOBHWhKhSZMmkpCQIFarVd544w1TIsFT/VvnGriofRIb1zUJ2+UvfStRMZHSNKWxDJh4ghzRt2OgmwYAAAKIpC0AAADgR2vXrpVbbrnF/F+TtkcddZQ8/vjjgW4W/KB5h6byzMZZLutOOPsYswAAADgjaQsAAADUkJSUFMnIyHBZN2LECLMAAAAAnlDTFgAAAAAAAACCCCNtAQAAAAAAAISX/v1F9u4VadxYghFJWwAAAAAAAADh5dVXJZhRHgEAAAAAAAAAgghJWwAAAAAAAAAIIpRHAAAAAEJMfm6BHMjOD3QzQptNRA5EywFLvogl0I0JccTSIT+HzyUAwDdI2gIAAAAh5q6hD4vNppkyVFVERISkpqbK6tWrxWq1Bro5IY1YumrarInExMQEuhkAgEMZNEhk1y6RZs1EPv9cgg1JWwAAACDEbNq0SRo0aBDoZoQ0TS6mp6dLUlKSSTqi6oilK03YxsXFBboZAIBD+esvkbQ0kcxMCUYkbQEAAIAQk5iYaBZUL9GYn59v4kiisXqIJQAAvsdfVAAAAAAAAAAIIiRtAQAAAAAAACCIkLQFAAAAAAAAgCBC0hYAAAAAAAAAgghJWwAAAAAAAAAIIgFN2q5YsUJGjBghLVu2FIvFIkuWLHG5Xde5W2bPnu3xMe+8885y23fu3NllG53ZdPLkydKoUSOpW7eunHHGGbJr164ae50AAAAAAAAAUFlREkC5ubnSo0cPmTRpkowZM6bc7Tt27HC5/sEHH8hFF11kkqwV6dq1q3z66aeO61FRri/zuuuuk2XLlskbb7wh9evXl6uuuso8/zfffFPt1wQAAAAACF86SKiwsLBK97VarZKXlydZWVkSERHaJ8bGxMRIXFxcoJsBACEroEnbYcOGmcWT5s2bu1xfunSpDBw4UNq3b1/h42qStux97TIzM+WFF16Q1157TQYNGmTWzZs3T4444ghZuXKlHHvssVV6LQAAAACA8KYJ23YpbWTnrj1Vur8malNTU2X16tUmgRvKmjdrIhs3bSFxCyB43X67SE6OSN26EowCmrT1hpYv0NGxCxYsOOS2f//9tym5oH8cjjvuOJk5c6a0adPG3KZ//IqKiuSkk05ybK/lE/T27777jqQtAAAAAKBKdIStJmy3vnalJCbEen1/TdOmSyNJkr4hPQFNVl6BJJ/zlIkHSVsAQevSSyWYhUzSVpO19erVc1tGwVmfPn1k/vz50qlTJ1NeYcaMGdKvXz/57bffzP137txpTtNo0KCBy/2aNWtmbvOkoKDALHZ6uorSXz/98QuoPofNZgv5X1v9iZh5h3h5h3h5h3h5h3h5h3h5h3gdRAwA1BRN2CbWqULS1iaSXxIliZGxEmGpkaYBAEJEyCRtX3zxRZkwYcIhf6VzLrfQvXt3k8Rt27at/O9//zP1cKtKR+tqArisPXv2mFNg/PGlQks76JesUK9t5C/EzDvEyzvEyzvEyzvEyzvEyzvE66Ds7OxANwEAAAAI3aTtV199JevXr5dFixZ5fV8dUXv44YfLhg0bzHWtdaunaGRkZLiMttXyC57q4Krp06fL1KlTXUbaJicnS5MmTSQxMVH88QXLYrGY5wv3L1iVRcy8Q7y8Q7y8Q7y8Q7y8Q7y8Q7wO4pRdAACAMLZjh0hJiUhkpEiLFhJsQiJpqxOHaTH2Hj16eH3fnJwc+eeff+S8884z1/VxoqOj5bPPPpMzzjjDrNOE8JYtW0z9W09iY2PNUpZ+2fHXFx79guXP56sNiJl3iJd3iJd3iJd3iJd3iJd3iFepcH/9AAAAYa13b5G0NJFWrUS2bZNgE9CkrSZU7SNg1caNG2XNmjWSlJTkmDhMR7S+8cYb8tBDD7l9jMGDB8vpp58uV111lbn+f//3fzJixAhTEmH79u1yxx13SGRkpIwfP97cXr9+fVMmQUfN6vPoKNmrr77aJGyZhAwAAAAAEOxSzn1KNu8qnWelrKFHt5P8wmL5ffNeyTlQJB1aNpCbxx8n5wzq6vd2AgBCNGm7atUqGThwoOO6vfzAxIkTzWRiauHChabmmj3pWpaOot27d6/j+rZt28y2+/btM6f99e3bV1auXGn+b/fII4+YkRU60lYnFxs6dKg89dRTNfhKAQAAEE569uxpLrUsl57V1a1bN3NdJ8u99dZbZfLkybJ7926JioqSY445RubMmSPx8fEBbjWAUPHE5JMlN79Itu/Lkevnfi6N68ebdWr9tnRZ/ssWueWc4+VAQbHc+fLXct4D70nXto2lR4dmgW46ACAUkrYDBgwwCdmKXHrppWbxZNOmTS7XNclbmfpl2jHWBQAAAPA1PXvM3lfVBK79uvr777/lySefNJPmlpSUyDnnnCMPPPCA3HnnnQFsMYBQMuK4jubyzy37TNK2Tly0jBvYxawrKCyWO87r69j2h/XbZck3f8vaf/eQtAWAEBISNW0BAACA2qJjx9Jki9IyXr1795bffvstoG0CUHvExhz8mr97f66s/GO7xEZHSt8jWwe0XQAA7zD7AgAAABAgubm58vzzz8uoUaPc3q6lvHSOB+cFACpj254sGXzjQtmbeUBemnaatGvRINBNAgB4gaQtAAAAEABa7/bss8+WIUOGmIl13Zk5c6aZSNe+JCcn+72dAELPrxt3y3FTXpZ/d2bIkhljZGz/IwLdJACAl0jaAgAAAH5WVFRkErYtWrSQxx57zON206dPl8zMTMeydetWv7YTQOhZs2GX9LvuVdm2J1suG95TsvMKZeEX6+S3jXsC3TQAgBeoaQsAAAD4UXFxsYwbN06SkpLk2WefFYvF4nHb2NhYswBAZa35Z5dk5haY/z/y1o+O9Xecd4Ic2a5JAFsGAPAGSVsAAADAjxYtWiSLFy+W7t27S69evcy6E044QebMmRPopgEIMZ3bNBLbJze5rLtgaHezAABCG0lbAAAAoIakpKRIRkaGy7oJEyaYBQAAAAH02Wd6CpRIVHCmR4OzVQAAAAAAAABQUzp1kmDGRGQAAAAAAAAAEERI2gIAAAAAAABAEKE8AgAAAAAAAIDw8tprInl5IgkJIuecI8GGpC0AAAAAAD6UlVdQpftZRSRPiiVLCkL6tNiqvn4A8KsbbxRJSxNp1YqkLQAAAAAAtVVMTIw0b9ZEks95qkr3j4iIkNTUVFm9erVYrZrCDV0aB40HAKBqSNoCAAAAAOADcXFxsnHTFiksLKzS/TVRm56eLklJSSaBG8o0YavxAABUDUlbAAAAAAB8RBOVVU1WatI2Pz9fEhMTQz5pCwCoHv4KAAAAAAAAAEAQIWkLAAAAAAAAAEGEpC0AAAAAAAAABBGStgAAAAAAAAAQREjaAgAAAAAAAEAQiQp0AwAAAAAAAADAr5o3d70MMiRtAQAAAAAAUOvl5+dLYWFhwJ7farVKXl6eZGVlSUREYE9+j4mJkbi4OAlrq1ZJMCNpCwAAAAAAgFqfsG2b0k5279oZsDZoojY1NVVWr15tEriB1LRZc9m8aSOJ2yBG0hYAAAAAAAC1mo6w1YTts0t/koQ69QLTCJtNIktypCSyrojFEpg2iEhebrZcOuooExOStsGLpC0AAAAAAADCgiZsA5m0lcISkZh6AU3aIjSQtAUAAAAAAAAQXi67TCQ9XSQpSWTuXAk2JG0BAAAAAAAAhJdly0TS0kRatZJgFNip6gAAAAAAAAAALhhpCwAAAAAAAPjIZacfLXt2bnN728Cho6Wg2Crr1qyUjH27zbrF3+30cwsRCkjaAgAAAD7Ws2dPc6mzMq9fv166detmrnfq1EleeOEFOeOMM2T16tVSXFwsGRkZAW4tAADwpYun3icF+XmSvnenzH/8TklskGTW6URkTZs0lHffel0GnzZe3lrwWKCbiiBG0hYAAADwsTVr1pjLTZs2mQSu/boqKCiQadOmSVJSkgwYMCCArQQAADWhd78h5nLbpr9N0jY2LkH6njzaJG2lMEOu79lfCgsLSNqiQtS0BQAAAPwoNjZWBg0aJA0aNAh0UwAAABCkGGkLAAAABCkdlauLXVZWVkDbAwAAAP9gpC0AAAAQpGbOnCn169d3LMnJyYFuEgAAAPyApC0AAAAQpKZPny6ZmZmOZevWrYFuEgAAqKavP10qXyxb5Lj+yTuvyqpvPglomxB8KI8AAAAABHH9W10AAEDt8fJT98iendsc15+eeb107XWcHH3CyQFtV9gZP15k/36Rhg0lGJG0BQAAAPyse/fusmfPHlOjtnXr1jJw4EB5+eWXA90sAADgQ61TOsri73aWWz938Y8iFktA2gQns2dLMCNpCwAAANSQlJQUycjIKLd+7dq1AWkPAAAAQgM1bQEAAAAAAAAgiJC0BQAAAAAAAIAgEtCk7YoVK2TEiBHSsmVLsVgssmTJEpfbdZ27ZXYFNSdmzpwpvXv3lnr16knTpk1l9OjRsn79epdtBgwYUO4xL7/88hp7nQAAAAAAAACCSOfOIomJpZdBKKBJ29zcXOnRo4fMmTPH7e07duxwWV588UWTYD3jjDM8PuaXX34pkydPlpUrV8onn3wiRUVFMmTIEPNczi655BKXx541a5bPXx8AAAAAAACAIJSTI5KdXXoZhAI6EdmwYcPM4knz5s1dri9dutTMrNu+fXuP9/nwww9drs+fP9+MuF29erWceOKJjvUJCQnlHh8AAAAAAAAAwjpp641du3bJsmXLZMGCBV7dLzMz01wmJSW5rH/11VfllVdeMYlbLdFw2223mUQuAAAAAAAAaqe83OzAPbnNJpElB6SkKFJrgoZnDFD7kraarNU6tWPGjKn0faxWq1x77bVywgknyJFHHulYf84550jbtm1NLd21a9fKtGnTTN3bxYsXe3ysgoICs9hlZWU5nkOXmqbPYbPZ/PJctQUx8w7x8g7x8g7x8g7x8g7x8g7xOogYAAAQPmJiYqRps+Zy6aijAtaGiIgISU1NNWeDB7oforHQmCB4hUzSVuvZTpgwQeLi4ip9H61t+9tvv8nXX3/tsv7SSy91/L9bt27SokULGTx4sPzzzz/SoUMHjxOczZgxo9z6PXv2SH5+vtQ0/TDrqGH9kqUfchwaMfMO8fIO8fIO8fIO8fIO8fIO8TooW2uYAQCAsKD5pM2bNkphYWFA+2Hp6enmbPBA98M0YetNjg3+FxJJ26+++sqMhF20aFGl73PVVVfJe++9JytWrJDWrVtXuG2fPn3M5YYNGzwmbadPny5Tp051GWmbnJwsTZo0kUSdac4PH2ydhE2fL9Af7FBBzLxDvLxDvLxDvLxDvLxDvLxDvA7iiwoAAOH3tz+Qf/+1H6YD/zSPFO79MNSSpO0LL7xgho/36NHjkNvqqJGrr75a3n77bVm+fLm0a9fukPdZs2aNudQRt57ExsaapSz9kPnrg6ZfsPz5fLUBMfMO8fIO8fIO8fIO8fIO8fIO8SoV7q8fAAAAwSugSducnBwzutVu48aNJoGqw8TbtGnjGNH6xhtvyEMPPeT2MbSswemnn25G1tpLIrz22muydOlSUwN3586dZn39+vUlPj7elEDQ20899VRp1KiRqWl73XXXyYknnijdu3f3y+sGAAAAAAAAgKBM2q5atUoGDhzouG4vPzBx4kSZP3+++f/ChQvN6Nnx48e7fQxNwu7du9dx/emnnzaXAwYMcNlu3rx5csEFF5iaHZ9++qk8+uijkpuba0ocnHHGGXLrrbfWyGsEAAAAAAAAgJBJ2mpiVROyFdFJw5wnDitr06ZNLtcP9XiapP3yyy+9bCkAAAAAAACAWuOZZ0QOHBCJj5dgFBI1bQEAAAAAAADAZ047TYIZSVsAAAAAAHxEZ4YvLCys8szyeXl5Zm4XJkusHmLpO7UplloyMy4uLtDNACqFpC0AAAAAAD5K2LZu01b27dldpftrQiw1NVVWr15tEmWoOmLpO7Uplo2aNJVtWzaTuEVIIGkLAAAAAIAP6AhbTdi2umK+RMQmeH3/CItI4ySLJPe1ibXi6VpwCMTSd2pLLK0FeZL29AXmc0rSFsbq1Xrg1iHYIqmpEmxI2gIAAAAA4EOasK1S0lZsYom2SUSMRUR0QVURS98hlqi1Ro0SSUsTadVKZNs2CTahXYwEAAAAAAAAAGoZkrYAAAAAAAAAEERI2gIAAAAAAABAEKGmLQAAAAAACEvbnp4kJVm73d5W58jBknD48ZKxYoEU7d8ukXUbSf1jz5R6PYf5vZ0Awg9JWwAAAMDHevbsaS51hur169dLt27dzPVOnTrJokWL5L333pP/+7//k5KSEnPb/PnzJTExMcCtBoDwk3TyZWIrzJeSnHTZ/8ULEhGfKEknXWZui2rQXHa+eqNE1mssSYMvlZxfP5H0j+ZIVIMWEp9SepwHgJpCeQQAAADAx9asWWOW999/X+rVq+e4rgnbnJwcueiii2TJkiXy999/S8uWLeXuu+8OdJMBICwlHNZH6nTpL/EdjjbXLdFx5roueeu/EbGWSGLv0VKv16nSoN95Zpvs1e8GuNUAwgFJWwAAAMCPPvjgA+nVq5d07tzZXL/yyivl9ddfD3SzAABlaEkEFZXY5L/LpqXr09MC2i4A4YHyCAAAAIAfbdmyRdq2beu4npKSIjt27JDi4mKJinLtnhcUFJjFLisry69tBQA4swW6AQDCCCNtAQAAgCA1c+ZMqV+/vmNJTk4OdJMAIGxEN2xpLoszSycqK87aU7o+qXQ9ANQkkrYAAACAH7Vp00Y2b97suL5p0yZp0aJFuVG2avr06ZKZmelYtm7d6ufWAkD4qttjqIglQrJWLZXsNR9Ixlcvm/X1jhoR6KYB8IU//hDJzCy9DEIkbQEAAAA/OuWUU+Snn36SP//801x/6qmnZNy4cW63jY2NlcTERJcFAOAf0UmtpMno6RIRFSvpn8yVktxMSTr5Colv1yvQTQPgC/XqiWjfSi+DEDVtAQAAAD+qV6+ePP/88zJ69GhTx/bII4+UBQsWBLpZABDWohslS9tp75Vbn3D4cWYBAH8jaQsAAADUEJ1kLCMjo9z6kSNHmgUAAABwh6QtAAAAAAAAgPDy8MMiWVmlJRKmTpVgQ9IWAAAAAAAAQPglbdPSRFq1CsqkLRORAQAAAAAAAEAQIWkLAAAAAAAAAEGEpC0AAAAAAAAABBFq2gIAAAAA4EPWgryq3dEiYiuyiLXQJlabr1sVZoil79SSWFb5cwkECElbAAAAAAB8ICYmRho1aSppT19QpftHRERI09RU2bp6tVitVp+3L5wQS9+pTbHUz6d+ToFQQNIWAAAAAAAfiIuLk21bNkthYWGV7q8JsfT0dElKSjKJMlQdsfSd2hRLTdjq5xQIBSRtAQAAAADwEU0IVTUppMmx/Px8SUxMDPnkWKARS98hlkBg8GkDAAAAAAAAgCDCSFsAAAAAAAAA4eWoo0SSk0WaNJFgRNIWAAAAAAAAQHh55x0JZpRHAAAAAAAAAIAgQtIWAAAAAAAAAIIISVsAAAAAAAAACCLUtAUAAAAAAAAQXkaOFNmzp3QisiCsb0vSFgAAAAAAAEB4+eknkbQ0kVatJBhRHgEAAAAAAAAAgghJWwAAAAAAAAAIIiRtAQAAAAAAACCIkLQFAAAAAAAAgCBC0hYAAAAAAAAAgghJWwAAAAAAAAAIIiRtAQAAAAAAACCIRAW6AaHKZrOZy6ysLL88n9VqlezsbImLi5OICHLtlUHMvEO8vEO8vEO8vEO8vEO8vEO8DrL34+z9ulDrg4b7+1ddfBZ8h1j6DrH0HWLpO8TSd4hlkMXSaj146af8njd9UJK2VaQ7hkpOTg50UwAAAFDNfl39+vUlFOzbt89ctm3bNtBNAQAAqB127BAJQF/wUH1Qiy2UhhYEWUZ/+/btUq9ePbFYLH7JwmuCeOvWrZKYmFjjz1cbEDPvEC/vEC/vEC/vEC/vEC/vEK+DtBusneWWLVuGzGiXjIwMadiwoWzZsiVkEs3Bis+C7xBL3yGWvkMsfYdY+g6x9J2sEI5lZfugjLStIg1q69at/f68uiOG2s4YaMTMO8TLO8TLO8TLO8TLO8TLO8SrVKglPu0de203759v8FnwHWLpO8TSd4il7xBL3yGWvpMYorGsTB80NIYUAAAAAAAAAECYIGkLAAAAAAAAAEGEpG2IiI2NlTvuuMNconKImXeIl3eIl3eIl3eIl3eIl3eIV2jj/fMdYuk7xNJ3iKXvEEvfIZa+Qyx9JzYMYslEZAAAAAAAAAAQRBhpCwAAAAAAAABBhKQtAAAAAAAAAAQRkrYAAAAAAAAAEERI2oaIOXPmSEpKisTFxUmfPn3khx9+CHSTgtLMmTOld+/eUq9ePWnatKmMHj1a1q9fH+hmhYz7779fLBaLXHvttYFuStBKS0uTc889Vxo1aiTx8fHSrVs3WbVqVaCbFZRKSkrktttuk3bt2plYdejQQe6++26hlPpBK1askBEjRkjLli3NZ2/JkiUut2usbr/9dmnRooWJ4UknnSR///23hKuK4lVUVCTTpk0zn8k6deqYbc4//3zZvn27hKtD7V/OLr/8crPNo48+6tc2wjf9vjfeeEM6d+5sttfPwPvvvy/hrip9wvnz55vPgfOiMQ13d955Z7m46P5WEfZJz/SzXTaeukyePNnt9uyXNd9vCsfv2jXRp6rKsSIc9ssLLrigXFxOOeWUQz4u+2X5WLo7duoye/bsWrtfkrQNAYsWLZKpU6eaWfF++ukn6dGjhwwdOlR2794d6KYFnS+//NJ0eFauXCmffPKJ+YMzZMgQyc3NDXTTgt6PP/4oc+fOle7duwe6KUFr//79csIJJ0h0dLR88MEHsm7dOnnooYekYcOGgW5aUHrggQfk6aeflieffFL++OMPc33WrFnyxBNPBLppQUOPTXpM106ZOxqvxx9/XJ555hn5/vvvTcdZj//5+fkSjiqKV15envkbqT8U6OXixYtNgmbkyJESrg61f9m9/fbb5u+mdpARev2+b7/9VsaPHy8XXXSR/PzzzyY5qctvv/0m4ayqfcLExETZsWOHY9m8ebPf2hzMunbt6hKXr7/+2uO27JOH7nM7x1L3T3XWWWd5vA/7Zc31m8L1u3ZN9am8OVaEU39Lk7TOcXn99dcrfEz2S/ex3OEUQ11efPFFk4Q944wzau9+aUPQO+aYY2yTJ092XC8pKbG1bNnSNnPmzIC2KxTs3r1bh/TZvvzyy0A3JahlZ2fbOnbsaPvkk09s/fv3t02ZMiXQTQpK06ZNs/Xt2zfQzQgZw4cPt02aNMll3ZgxY2wTJkwIWJuCmR6r3n77bcd1q9Vqa968uW327NmOdRkZGbbY2Fjb66+/bgt3ZePlzg8//GC227x5sy3ceYrXtm3bbK1atbL99ttvtrZt29oeeeSRgLQPVe/3jR071hxvnfXp08d22WWX1Xhba1ufcN68ebb69ev7tV2h4I477rD16NGj0tuzT3pH+90dOnQwf/fdYb+s2X4T37V916fy9lgRLrGcOHGibdSoUV49Dvtl5fbLUaNG2QYNGlThNqG+XzLSNsgVFhbK6tWrzakddhEREeb6d999F9C2hYLMzExzmZSUFOimBDUdiTJ8+HCX/QzlvfPOO3L00UebkRB6qmWvXr3kueeeC3Szgtbxxx8vn332mfz111/m+i+//GJ+1Rw2bFigmxYSNm7cKDt37nT5XNavX9+cHsXxv/J/A/TX9wYNGgS6KUHJarXKeeedJzfccIMZgYDQ7Pfp+rJ/v3U0DseJqvUJc3JypG3btpKcnCyjRo2S33//3U8tDG56irmOxm/fvr1MmDBBtmzZ4nFb9knvPvOvvPKKTJo0yfy98oT9smb6TXzX9n2fyptjRThZvny5+f7YqVMnueKKK2Tfvn0et2W/rJxdu3bJsmXLzFkdhxLK+yVJ2yC3d+9eUxeyWbNmLuv1uv5RQsVfRrU2q57OfuSRRwa6OUFr4cKF5pQLrf2Giv3777/mdP+OHTvKRx99ZP7gXnPNNbJgwYJANy0o3XTTTTJu3DhTM0hLSmiSWz+T+ocSh2Y/xnP8rxo9FVLrsekpunpaKcrTkiVRUVHmOIbQ7ffpeo4TvukT6pdpPdVy6dKlJpGm99MfILdt2ybhTJNeWlf1ww8/NP0gTY7169dPsrOz3W7PPll5Wq8xIyPD1Lz0hP2y5vpNfNf2bZ/K22NFuNDSCC+99JIZzKJ9Ly3fo4NYdN9zh/2ychYsWGDq1o8ZM6bC7UJ9v4wKdAOAmhw9qrWzQqpeiZ9t3bpVpkyZYmppheuEBt7QTvL/t3fnsVFVbRzHD1IqoCJKK6AIFKWyKdoqEYyiFlGIotFIUYOgAlGsihaBBFFQQXApIm6oUFyq2ChLKHGrFCVEXMBKBYK0YvAPEFxYFASU8+Z3zMw7M51uTKdzh/l+kmvaO9vt9XLvM899znNUaTtt2jT3u5KQOsbUN2vYsGGx3jzPKSwsNAUFBebtt992VXylpaXuS7PucrK/EE3qXTl48GA3IYmCM1SmCo5Zs2a5m3bVVXcBiRQT9u7d2y0+Sox17drV9fzXRJqJKnCEjOY+0BdgVX3qOl+bCidUbe7cuW7/VtdTnOMS8RJTca4IT0UsPprcTftGEzSr+jYrKyum2xbP5s2b54qBaspjxPtxSaWtx6WkpJjGjRu70u9A+r1NmzYx2y6vy8nJMUVFRaakpMS0a9cu1pvj6S/tamaekZHhqq206M6fGvjr56ru/iUqzUTbrVu3oHUKmuNpeEVD0pBrX7WtAhQNw77//vup6q4l3zme8/+RfbnQJC26IUWVbXgrV6505//27dv7z//aZ7m5uW6mYsRP3Kf1nCeiExP6RomUl5dHbfvikYZHp6enV7lfOCZrR+fc4uJiM2LEiDq9juOy/uImvmtHN6aq6VyRqDREX8deVfuF47J2ceymTZvqfP6Mx+OSpK3HJScnm8zMTFdKH1jtp98D77jiP7oDqOBcM2EvX77cpKWlxXqTPE139srKylwFpG9RJanuWOlnXSzwfxpWqYtDIPVr1Z06mLAzz6r/UiAdUzqHoWY6fykwCzz/79mzx82GzPm/+i8X6lulL8KtWrWK9SZ5lm6irFu3Luj8r0ov3WxR+xfET9yn9YHPF325TvTzRH3EhLp5rThJN20R3F+1oqKiyv3CMVk7+fn5rsel5pWoC47L+oub+K4d3ZiqpnNFolJrE/W0rWq/cFzWbpRCZmam6dmz59F/XMZ6JjTUbMGCBW7Wy/nz59sNGzbYUaNG2ZYtW9rt27fHetM856677nKzq65YscJu27bNv+zbty/WmxY3+vbt62axRfhZU5OSkuzUqVPt5s2bbUFBgW3evLl96623Yr1pnqSZUjUrfVFRkd2yZYtduHChTUlJsePGjYv1pnnG3r177bfffusWXZLz8vLcz76ZeadPn+7O90uWLLHr1q1zM6SmpaXZ/fv320RU3f46ePCgHTRokG3Xrp0tLS0NugYcOHDAJqKajq9QHTp0sDNnzmzw7UTd4r6hQ4faCRMm+J+/atUqd216+umn7caNG90syU2aNLFlZWU2kdUmJgzdl1OmTLEfffSRraiosGvWrLFDhgyxTZs2tevXr7eJLDc31+1HXct1vPXr189dz3fs2OEe55isO80E3759ezt+/PhKj3FcRjdu0kzzs2fPton+Xbs+YqrQfVnTuSIR96UeGzt2rP3iiy/cfikuLrYZGRm2c+fO9u+///a/B8dl7WPX3bt3u+/gL730Utj3ONqOS5K2cUIHnS7sycnJtlevXnb16tWx3iRP0j/scEt+fn6sNy1ukLSt3tKlS22PHj3cRbRLly72lVdeifUmedaePXvcsaRzl75cdOrUyU6cODFhE2jhlJSUhD1nKeEthw8ftpMmTbKtW7d2x1xWVpbdtGmTTVTV7S8FYlVdA/S6RFTT8RWKpG18xH26Tof+PywsLLTp6enu+d27d7fLli2zia42MWHovhwzZox/v+u8O3DgQLt27Vqb6LKzs23btm3dftHNWP1eXl7uf5xjsu6UhNXxGO6aznEZ3bhJ1zrdSEj079r1EVOF7suazhWJuC91o7B///42NTXV3bzSPhs5cmSl5CvHZe1j1zlz5thmzZrZXbt2hX2Po+24bKT/xLraFwAAAAAAAADwH3raAgAAAAAAAICHkLQFAAAAAAAAAA8haQsAAAAAAAAAHkLSFgAAAAAAAAA8hKQtAAAAAAAAAHgISVsAAAAAAAAA8BCStgAAAAAAAADgISRtAQAAAAAAAMBDSNoCAEzHjh3Ns88+G+vNAAAAAAAAJG0BoGENHz7cXHfddf7fL730UjNmzJgG+/z58+ebli1bVlr/9ddfm1GjRkX1s1esWGEaNWpkdu3aFfbxyZMnu8fvvPPOoPWlpaVu/U8//eRft2jRInPhhReaE0880Zxwwgmme/fuDbofAQAAYFyMVt2i+A4AcGRI2gLAUeDgwYMRvT41NdU0b97cxFrTpk3N3LlzzebNm6t8zqeffmqys7PNDTfcYL766iuzZs0aM3XqVHPo0KEG3VYAAIBEt23bNv+iUVstWrQIWjd27NhYbyIAxC2StgAQw6rbzz77zMyaNctfjeCrJv3+++/NgAEDzPHHH29at25thg4dan799degCt2cnBxXXZqSkmKuvPJKtz4vL8+cffbZ5rjjjjOnn366GT16tPnzzz/9la633Xab2b17d6Xqh9D2CFu3bjXXXnut+3wF34MHDza//PKL/3G97txzzzVvvvmme60qXocMGWL27t0b0T4566yzzGWXXWYmTpxY5XOWLl1qLrroIvPggw+656enp7vq5RdeeCGizwYAAEDdtGnTxr8oHlR8GbhuwYIFpmvXru7GfJcuXcyLL77of63iXj2/sLDQXHzxxaZZs2bmggsuMD/88IMbBXb++ee7WFQx8c6dOyuNXJsyZYorPFCsqpFagUUM7733nouJ9Z6tWrUy/fr1M3/99VeD7x8AiARJWwCIESVre/fubUaOHOmvRlCiVe0DLr/8cnPeeeeZb775xnz44YcuYarEaaDXX3/dJCcnm1WrVpmXX37ZrTvmmGPMc889Z9avX+8eX758uRk3bpx7rE+fPpUqIMJVPxw+fNglbH///XeXVP7kk0/Mjz/+6KpbA1VUVJjFixeboqIit+i506dPj3i/6D3ef/9997eHoy8A+vuU2AYAAIA3FRQUmIcfftiNiNq4caOZNm2amTRpkotRAz3yyCPmoYceMmvXrjVJSUnm5ptvdvGrYuWVK1ea8vJy9z6hI6/0nipKeOedd8zChQtdElcU4950003m9ttv9z/n+uuvN9baBv37ASBSSRG/AwDgiKgaQUlXtSVQItLn+eefdwlbBbY+8+bNcwldVR6oslQ6d+5snnzyyaD3DOzrqgrYxx9/3FUeqKpBnxVYAVEVBcFlZWVmy5Yt7jPljTfecH1jVfWgCghfclc9ctVTVlQNrNcqMI9ERkaGS1CPHz/evV+oe+65xwXwqp7o0KGD623bv39/c8stt5hjjz02os8GAABA/VAy9plnnnEJU0lLSzMbNmwwc+bMMcOGDfM/T0UEvlFj9913n0u4KgbUyCq54447XMwZSHGt4mPF0YpRH330UTcK67HHHnNJ23/++cd9rmJFUdwIAPGGSlsA8JjvvvvOlJSUuOFgvkXDyXzVrT6ZmZmVXltcXGyysrLMaaed5pKpSqT+9ttvZt++fbX+fFUkKFnrS9hKt27d3ARmeiwwKexL2Erbtm3Njh07TH1QslmJ2Y8//rjSY2r9sGzZMld1oaoM7Z/c3FzTq1evOv2dAAAAiA61IlDcqoRrYEyrGC8wnpVzzjnH/7PagoUmWbUuNMbs2bNn0HwMGr2mlmA///yze0zxsN7jxhtvNK+++qr5448/ovjXAkB0kLQFAI9RwHnNNdeY0tLSoEWTc11yySVByctA6gt29dVXu8BX7QU0QZevz2ukE5WF06RJk6DfVcGr6tv6cMYZZ7i2ERMmTKhyKJueM2LECPPaa6+54XSq3Hj33Xfr5fMBAABw5HxzKihhGhjPqr3V6tWrq4wpFU+GW1eXGLNx48auvdcHH3zgCg9mz57t5kHQKDIAiCe0RwCAGNLQrn///bdSewAlXVXJqr5etaUkrQJaDUNTb1vRxA41fV4oTRahKgUtvmpbJUTVa1eBb0NR7zIlZjWBRU20r1RtwQQTAAAAsafq2FNPPdXNi6AWVtEYmbZ//3430ZgoEaxKXl/sqkSv2itoUUypNgmLFi0yDzzwQL1vCwBEC0lbAIghJRu//PJLVyWrQPPkk082d999t6tKUD8vTcKgdWoFoOSlqkpVPRDOmWeeaQ4dOuSqCVSpGzhBWeDnqfJBfcJ8w8oCh5aJZtfVcDIF2Jq4TD3BRo8ebfr27etm8Y2U+uUGtlVQUK1tCRfsK7B+6qmngtZPnjzZtUEYOHCgC8CVTNbka/rbr7jiioi3DwAAAJHTxGD33nuvm1PhqquuMgcOHHATzapVQaTJU40iU+sFtcpSHK3+uTk5Oa5wQbG1Yl3NeXDKKae433fu3OkKEwAgntAeAQBiSBMvKAmrCtbU1FSzdetWV5WghKsqYhVsKoGqCcbUU9ZXQRuOEp95eXlmxowZpkePHm7G3ieeeCLoOX369HETk2VnZ7vPC53IzJdEXbJkiTnppJNcOwYlcTt16lRvrQf0nppozbeE680buH+UzA6k5LGqNm699VbX63fAgAFm+/btrv+thr4BAAAg9nxtrPLz8108qxhOE4ppQrJIqWetJuVVXKm4dtCgQe7GvrRo0cJ8/vnn7ga/JvBVYlcj0RQzAkA8aWSrahYIAAAAAADgIcOHD3cjrRYvXhzrTQGAqKLSFgAAAAAAAAA8hKQtAAAAAAAAAHgI7REAAAAAAAAAwEOotAUAAAAAAAAADyFpCwAAAAAAAAAeQtIWAAAAAAAAADyEpC0AAAAAAAAAeAhJWwAAAAAAAADwEJK2AAAAAAAAAOAhJG0BAAAAAAAAwENI2gIAAAAAAACAh5C0BQAAAAAAAADjHf8DZnFqGsM0udcAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 1400x500 with 2 Axes>"
       ]
@@ -2319,10 +2313,10 @@
    "id": "lns-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.012154,
-     "end_time": "2026-04-22T17:27:49.933309",
+     "duration": 0.03833,
+     "end_time": "2026-04-22T21:18:29.136806",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.921155",
+     "start_time": "2026-04-22T21:18:29.098476",
      "status": "completed"
     },
     "tags": []
@@ -2359,10 +2353,10 @@
    "id": "section-6-combined",
    "metadata": {
     "papermill": {
-     "duration": 0.009601,
-     "end_time": "2026-04-22T17:27:49.957793",
+     "duration": 0.038833,
+     "end_time": "2026-04-22T21:18:29.214624",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.948192",
+     "start_time": "2026-04-22T21:18:29.175791",
      "status": "completed"
     },
     "tags": []
@@ -2395,16 +2389,16 @@
    "id": "combined-model",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:49.982695Z",
-     "iopub.status.busy": "2026-04-22T17:27:49.982194Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.039109Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.037644Z"
+     "iopub.execute_input": "2026-04-22T21:18:29.291603Z",
+     "iopub.status.busy": "2026-04-22T21:18:29.291257Z",
+     "iopub.status.idle": "2026-04-22T21:18:29.338294Z",
+     "shell.execute_reply": "2026-04-22T21:18:29.336883Z"
     },
     "papermill": {
-     "duration": 0.072695,
-     "end_time": "2026-04-22T17:27:50.040862",
+     "duration": 0.08828,
+     "end_time": "2026-04-22T21:18:29.340441",
      "exception": false,
-     "start_time": "2026-04-22T17:27:49.968167",
+     "start_time": "2026-04-22T21:18:29.252161",
      "status": "completed"
     },
     "tags": []
@@ -2516,10 +2510,10 @@
    "id": "31a8t3se5i3",
    "metadata": {
     "papermill": {
-     "duration": 0.013695,
-     "end_time": "2026-04-22T17:27:50.068515",
+     "duration": 0.05682,
+     "end_time": "2026-04-22T21:18:29.473455",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.054820",
+     "start_time": "2026-04-22T21:18:29.416635",
      "status": "completed"
     },
     "tags": []
@@ -2541,10 +2535,10 @@
    "id": "e7odetcr96k",
    "metadata": {
     "papermill": {
-     "duration": 0.013531,
-     "end_time": "2026-04-22T17:27:50.095881",
+     "duration": 0.035823,
+     "end_time": "2026-04-22T21:18:29.557450",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.082350",
+     "start_time": "2026-04-22T21:18:29.521627",
      "status": "completed"
     },
     "tags": []
@@ -2559,16 +2553,16 @@
    "id": "combined-viz",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.125260Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.124780Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.260853Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.260143Z"
+     "iopub.execute_input": "2026-04-22T21:18:29.696689Z",
+     "iopub.status.busy": "2026-04-22T21:18:29.696110Z",
+     "iopub.status.idle": "2026-04-22T21:18:29.860088Z",
+     "shell.execute_reply": "2026-04-22T21:18:29.858751Z"
     },
     "papermill": {
-     "duration": 0.152533,
-     "end_time": "2026-04-22T17:27:50.262076",
+     "duration": 0.225896,
+     "end_time": "2026-04-22T21:18:29.861901",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.109543",
+     "start_time": "2026-04-22T21:18:29.636005",
      "status": "completed"
     },
     "tags": []
@@ -2647,10 +2641,10 @@
    "id": "combined-interp",
    "metadata": {
     "papermill": {
-     "duration": 0.010833,
-     "end_time": "2026-04-22T17:27:50.282495",
+     "duration": 0.044302,
+     "end_time": "2026-04-22T21:18:29.970433",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.271662",
+     "start_time": "2026-04-22T21:18:29.926131",
      "status": "completed"
     },
     "tags": []
@@ -2681,10 +2675,10 @@
    "id": "section-7-summary",
    "metadata": {
     "papermill": {
-     "duration": 0.012837,
-     "end_time": "2026-04-22T17:27:50.307430",
+     "duration": 0.055208,
+     "end_time": "2026-04-22T21:18:30.074241",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.294593",
+     "start_time": "2026-04-22T21:18:30.019033",
      "status": "completed"
     },
     "tags": []
@@ -2743,24 +2737,25 @@
    "id": "exercises-header",
    "metadata": {
     "papermill": {
-     "duration": 0.013866,
-     "end_time": "2026-04-22T17:27:50.332816",
+     "duration": 0.04282,
+     "end_time": "2026-04-22T21:18:30.184959",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.318950",
+     "start_time": "2026-04-22T21:18:30.142139",
      "status": "completed"
     },
     "tags": []
    },
+   "outputs": [],
    "source": [
-    "### Exercice 1 : SEND + MORE = MONEY avec CP-SAT\n",
+    "### Exercice 1 : CROSS + ROADS = DANGER avec CP-SAT\n",
     "\n",
-    "**Enonce** : modelisez le cryptarithme SEND + MORE = MONEY avec OR-Tools CP-SAT.\n",
+    "**Enonce** : modelisez le cryptarithme CROSS + ROADS = DANGER avec OR-Tools CP-SAT.\n",
     "\n",
-    "Rappel : chaque lettre represente un chiffre different (0-9), S et M ne sont pas 0.\n",
+    "Chaque lettre represente un chiffre different (0-9), C, R et D ne sont pas 0.\n",
     "\n",
-    "$$\\text{SEND} + \\text{MORE} = \\text{MONEY}$$\n",
+    "$$\text{CROSS} + \text{ROADS} = \text{DANGER}$$\n",
     "\n",
-    "Comparez avec la version backtracking de Search-6 en termes de lignes de code et de temps d'execution."
+    "Ce cryptarithme implique 9 lettres distinctes (C, R, O, S, A, D, N, G, E). Comparez la difficulte de modelisation avec le SEND+MORE=MONEY du notebook Search-6."
    ]
   },
   {
@@ -2769,16 +2764,16 @@
    "id": "1a1e7939",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.363397Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.362574Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.389617Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.388475Z"
+     "iopub.execute_input": "2026-04-22T21:18:30.275396Z",
+     "iopub.status.busy": "2026-04-22T21:18:30.275037Z",
+     "iopub.status.idle": "2026-04-22T21:18:30.305425Z",
+     "shell.execute_reply": "2026-04-22T21:18:30.304791Z"
     },
     "papermill": {
-     "duration": 0.044711,
-     "end_time": "2026-04-22T17:27:50.391162",
+     "duration": 0.073775,
+     "end_time": "2026-04-22T21:18:30.306487",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.346451",
+     "start_time": "2026-04-22T21:18:30.232712",
      "status": "completed"
     },
     "tags": []
@@ -2789,63 +2784,66 @@
      "output_type": "stream",
      "text": [
       "Assignation :\n",
-      "  S = 9\n",
-      "  E = 5\n",
-      "  N = 6\n",
-      "  D = 7\n",
-      "  M = 1\n",
-      "  O = 0\n",
-      "  R = 8\n",
-      "  Y = 2\n",
+      "  C = 9\n",
+      "  R = 6\n",
+      "  O = 2\n",
+      "  S = 3\n",
+      "  D = 5\n",
+      "  A = 1\n",
+      "  N = 8\n",
+      "  G = 7\n",
+      "  E = 4\n",
       "\n",
-      "   SEND  = 9567\n",
-      " + MORE  = 1085\n",
-      " -------\n",
-      " = MONEY = 10652\n",
+      "   CROSS  = 96233\n",
+      " + ROADS  = 62513\n",
+      " --------\n",
+      " = DANGER = 158746\n",
       "\n",
-      "Verification : 9567 + 1085 = 10652  (attendu 10652)\n"
+      "Verification : 96233 + 62513 = 158746  (attendu 158746)\n"
      ]
     }
    ],
    "source": [
-    "# Exemple resolu : SEND + MORE = MONEY avec CP-SAT\n",
+    "# Exercice 1 : CROSS + ROADS = DANGER avec CP-SAT\n",
     "\n",
     "model = cp_model.CpModel()\n",
     "\n",
-    "# S et M != 0 (chiffres de tete). Les autres ont un domaine [0, 9].\n",
-    "S = model.new_int_var(1, 9, \"S\")\n",
-    "E = model.new_int_var(0, 9, \"E\")\n",
-    "N = model.new_int_var(0, 9, \"N\")\n",
-    "D = model.new_int_var(0, 9, \"D\")\n",
-    "M = model.new_int_var(1, 9, \"M\")\n",
+    "C = model.new_int_var(1, 9, \"C\")\n",
+    "R = model.new_int_var(1, 9, \"R\")\n",
     "O = model.new_int_var(0, 9, \"O\")\n",
-    "R = model.new_int_var(0, 9, \"R\")\n",
-    "Y = model.new_int_var(0, 9, \"Y\")\n",
+    "S = model.new_int_var(0, 9, \"S\")\n",
+    "A = model.new_int_var(0, 9, \"A\")\n",
+    "D = model.new_int_var(1, 9, \"D\")\n",
+    "N = model.new_int_var(0, 9, \"N\")\n",
+    "G = model.new_int_var(0, 9, \"G\")\n",
+    "E = model.new_int_var(0, 9, \"E\")\n",
     "\n",
-    "model.add_all_different([S, E, N, D, M, O, R, Y])\n",
+    "model.add_all_different([C, R, O, S, A, D, N, G, E])\n",
     "\n",
-    "SEND  = S * 1000 + E * 100 + N * 10 + D\n",
-    "MORE  = M * 1000 + O * 100 + R * 10 + E\n",
-    "MONEY = M * 10000 + O * 1000 + N * 100 + E * 10 + Y\n",
-    "model.add(SEND + MORE == MONEY)\n",
+    "CROSS_val  = C * 10000 + R * 1000 + O * 100 + S * 10 + S\n",
+    "ROADS_val  = R * 10000 + O * 1000 + A * 100 + D * 10 + S\n",
+    "DANGER_val = D * 100000 + A * 10000 + N * 1000 + G * 100 + E * 10 + R\n",
+    "model.add(CROSS_val + ROADS_val == DANGER_val)\n",
     "\n",
     "solver = cp_model.CpSolver()\n",
     "status = solver.solve(model)\n",
     "\n",
     "if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):\n",
-    "    s, e, n, d = solver.value(S), solver.value(E), solver.value(N), solver.value(D)\n",
-    "    m, o, r, y = solver.value(M), solver.value(O), solver.value(R), solver.value(Y)\n",
-    "    send = 1000 * s + 100 * e + 10 * n + d\n",
-    "    more = 1000 * m + 100 * o + 10 * r + e\n",
-    "    money = 10000 * m + 1000 * o + 100 * n + 10 * e + y\n",
+    "    c, r, o, s = solver.value(C), solver.value(R), solver.value(O), solver.value(S)\n",
+    "    a, d, n, g, e = solver.value(A), solver.value(D), solver.value(N), solver.value(G), solver.value(E)\n",
+    "    cross  = 10000*c + 1000*r + 100*o + 10*s + s\n",
+    "    roads  = 10000*r + 1000*o + 100*a + 10*d + s\n",
+    "    danger = 100000*d + 10000*a + 1000*n + 100*g + 10*e + r\n",
     "    print(\"Assignation :\")\n",
-    "    for lbl, v in zip(\"SENDMORY\", (s, e, n, d, m, o, r, y)):\n",
+    "    for lbl, v in zip(\"CROSDANGE\", (c, r, o, s, a, d, n, g, e)):\n",
     "        print(f\"  {lbl} = {v}\")\n",
-    "    print(f\"\\n   SEND  = {send}\")\n",
-    "    print(f\" + MORE  = {more}\")\n",
-    "    print(f\" -------\")\n",
-    "    print(f\" = MONEY = {money}\")\n",
-    "    print(f\"\\nVerification : {send} + {more} = {send + more}  (attendu {money})\")\n",
+    "    print()\n",
+    "    print(f\"   CROSS  = {cross}\")\n",
+    "    print(f\" + ROADS  = {roads}\")\n",
+    "    print(f\" --------\")\n",
+    "    print(f\" = DANGER = {danger}\")\n",
+    "    print()\n",
+    "    print(f\"Verification : {cross} + {roads} = {cross + roads}  (attendu {danger})\")\n",
     "else:\n",
     "    print(f\"Aucune solution (status = {solver.status_name(status)})\")\n"
    ]
@@ -2855,10 +2853,10 @@
    "id": "3b8a5162",
    "metadata": {
     "papermill": {
-     "duration": 0.01301,
-     "end_time": "2026-04-22T17:27:50.416311",
+     "duration": 0.04626,
+     "end_time": "2026-04-22T21:18:30.397596",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.403301",
+     "start_time": "2026-04-22T21:18:30.351336",
      "status": "completed"
     },
     "tags": []
@@ -2890,16 +2888,16 @@
    "id": "81e589aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.445784Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.445483Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.449876Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.448791Z"
+     "iopub.execute_input": "2026-04-22T21:18:30.497195Z",
+     "iopub.status.busy": "2026-04-22T21:18:30.496501Z",
+     "iopub.status.idle": "2026-04-22T21:18:30.500703Z",
+     "shell.execute_reply": "2026-04-22T21:18:30.499782Z"
     },
     "papermill": {
-     "duration": 0.020956,
-     "end_time": "2026-04-22T17:27:50.451447",
+     "duration": 0.057384,
+     "end_time": "2026-04-22T21:18:30.501791",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.430491",
+     "start_time": "2026-04-22T21:18:30.444407",
      "status": "completed"
     },
     "tags": []
@@ -2920,10 +2918,10 @@
    "id": "exercise-2-header",
    "metadata": {
     "papermill": {
-     "duration": 0.013717,
-     "end_time": "2026-04-22T17:27:50.478648",
+     "duration": 0.043658,
+     "end_time": "2026-04-22T21:18:30.602669",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.464931",
+     "start_time": "2026-04-22T21:18:30.559011",
      "status": "completed"
     },
     "tags": []
@@ -2947,16 +2945,16 @@
    "id": "ff85cdbc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.510037Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.509517Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.554337Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.553305Z"
+     "iopub.execute_input": "2026-04-22T21:18:30.690388Z",
+     "iopub.status.busy": "2026-04-22T21:18:30.689997Z",
+     "iopub.status.idle": "2026-04-22T21:18:30.718588Z",
+     "shell.execute_reply": "2026-04-22T21:18:30.717838Z"
     },
     "papermill": {
-     "duration": 0.063103,
-     "end_time": "2026-04-22T17:27:50.555571",
+     "duration": 0.071572,
+     "end_time": "2026-04-22T21:18:30.719633",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.492468",
+     "start_time": "2026-04-22T21:18:30.648061",
      "status": "completed"
     },
     "tags": []
@@ -3066,10 +3064,10 @@
    "id": "886855b4",
    "metadata": {
     "papermill": {
-     "duration": 0.013113,
-     "end_time": "2026-04-22T17:27:50.583116",
+     "duration": 0.039411,
+     "end_time": "2026-04-22T21:18:30.798985",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.570003",
+     "start_time": "2026-04-22T21:18:30.759574",
      "status": "completed"
     },
     "tags": []
@@ -3093,16 +3091,16 @@
    "id": "0d4dd0dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.654188Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.653292Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.658695Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.657574Z"
+     "iopub.execute_input": "2026-04-22T21:18:30.880381Z",
+     "iopub.status.busy": "2026-04-22T21:18:30.879969Z",
+     "iopub.status.idle": "2026-04-22T21:18:30.883388Z",
+     "shell.execute_reply": "2026-04-22T21:18:30.882786Z"
     },
     "papermill": {
-     "duration": 0.022484,
-     "end_time": "2026-04-22T17:27:50.660370",
+     "duration": 0.047654,
+     "end_time": "2026-04-22T21:18:30.884581",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.637886",
+     "start_time": "2026-04-22T21:18:30.836927",
      "status": "completed"
     },
     "tags": []
@@ -3122,10 +3120,10 @@
    "id": "exercise-3-header",
    "metadata": {
     "papermill": {
-     "duration": 0.011985,
-     "end_time": "2026-04-22T17:27:50.684023",
+     "duration": 0.039919,
+     "end_time": "2026-04-22T21:18:30.964113",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.672038",
+     "start_time": "2026-04-22T21:18:30.924194",
      "status": "completed"
     },
     "tags": []
@@ -3149,16 +3147,16 @@
    "id": "bd6a9365",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.714790Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.714447Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.905559Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.904075Z"
+     "iopub.execute_input": "2026-04-22T21:18:31.067274Z",
+     "iopub.status.busy": "2026-04-22T21:18:31.066954Z",
+     "iopub.status.idle": "2026-04-22T21:18:31.212693Z",
+     "shell.execute_reply": "2026-04-22T21:18:31.211704Z"
     },
     "papermill": {
-     "duration": 0.207672,
-     "end_time": "2026-04-22T17:27:50.907372",
+     "duration": 0.201889,
+     "end_time": "2026-04-22T21:18:31.213851",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.699700",
+     "start_time": "2026-04-22T21:18:31.011962",
      "status": "completed"
     },
     "tags": []
@@ -3169,12 +3167,12 @@
      "output_type": "stream",
      "text": [
       "Distance totale optimale : 85\n",
-      "Route optimale : Depot -> C2 -> C4 -> C3 -> C1 -> Depot\n"
+      "Route optimale : Depot -> C1 -> C3 -> C4 -> C2 -> Depot\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkkAAAJOCAYAAACjhZOMAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAls5JREFUeJzt3QVUVFsXB/BtIIooJnagYiulYnd3PhVb1Kc+22d3d/tssespdmJ3Una3YqGoiKLAfGuf+ea+AQYkZuZO/H9rzfJeuAxnRu7MnnP32TuJQqFQEAAAAABEkjTyLgAAAAAwBEkAAAAAGiBIAgAAANAAQRIAAACABgiSAAAAADRAkAQAAACgAYIkAAAAAA0QJAEAAABogCAJAAAAQAMESQAmYO3atZQkSRJxq1q1KhmC8ePHS2Pq3LmzTn/X6NGjxe9JliwZPXjwIE4/oxob354+fSp9PW/evNLXT506pcNRg6EICgqitGnTiv/zDh06yD0cMCAIkrRI/cU1Ljf1F+CtW7dSjRo1KFOmTGRhYUEZMmQge3t7atiwIY0aNYo+f/4c6Xdpur+kSZNSunTpqGzZsjR//nz6+fOn3h9v8uTJKWPGjFSpUiVavHgxhYWFkRz48fObNN/U3wCN1e7du6XHgzfuyF6+fElz584V23/88Yc4bwwhaFX9f/n5+ck9HKP34cMHGj58OJUsWZLSpEkjXmfSp09P5cuXp3nz5kV7rVP/0BDTLTg4WDqeXzd79+4ttjdt2kTe3t56f4xgoLh3G2hHnjx5uA9enG8nT54UPzdo0KDfHvvgwYNIvysu91++fHnFjx8/ZH287du319nvj+vYVM+zMevUqZP0eMaNGxft+2/fvlWcPXtW3K5fv64wBDxO1Zh5/LrSt29f6fecO3cuzj+n/nf65MkT6etXr16VnsugoKAEjalKlSrSfa9ZsyZB9wFK/H9gZ2cX6+tMvXr1Iv0MP+e/e236+vVrpJ95/vy5IkmSJOJ7TZo00fOjBEOVXO4gzZTs2LGDfvz4Ie17eHjQmjVrxHbWrFlp+/btkY4vUaIEPX78WHwSYvzp5u+//6bq1auL2aRnz57RiRMnaN++fbH+3pEjR1K9evXo27dv4lPQhg0bxNcvXLhAy5Yto/79+5OudenShbp27UqBgYE0c+ZM8bvZxo0bacaMGZQ9e3adj8Gc2draipu54b/5devWie08efKImYXEKlWqlBZGBtrCr5tPnjwR2zyDNHv2bCpWrJiYfV+9erX4+qFDh+jOnTtUpEiRGF8fo7Kysoq0nytXLqpQoQKdO3eO9u/fT69evaIcOXLo7HGBkZA7SjNl6p+keWZDk23btknHODk5aTyGZ4N+/vwZ6Wvqn4jUP6mGh4cr8ubNK31Pl5+I1Gdr1Gc3+JO4+vguXrwY6eciIiLEmKtWrapInz69Inny5IosWbIoGjdurDh27FikY/kTvvp9xfRpkT+5R33ONd3UxxkYGKgYPXq0omTJkorUqVMrUqZMqShatKg4JuqnzN/Zs2eP+DSbOXNm8XgyZsyoqFWrlmL79u2xPm/8eGfMmKEoUKCAIkWKFIp8+fIppk+fLv4fGc+CxfZ4VI9b03MR9ef59969e1dRv3598Xh5rH369FGEhIQovnz5IrZtbW3F81CpUiXx/6iO99u1a6coXry4IlOmTOJxWltbKxwcHBRjx46N9pzFNpMUFhamWLZsmaJixYqKdOnSKSwsLBS5c+dWdOvWTfH48eM4P+/8/Kp+R8+ePTUec+LECUW5cuXE4+LH16tXL8WnT59inEmKaRbyzp07Cjc3N0XOnDnFeK2srMSxDRo0UCxYsCDa/4Omm+p5SOxzyTNm1apVE2NImzat4o8//hCziVEFBAQohg4dqihRooT0N86zMjzDG/X4I0eOiHOQz0V+fDyuRo0aKc6cOROvWR/VLFxcbnExa9Ys6bG7uLhIX3///n2k59bPz0/6nvr/Q3xm8qZNmyb93Lx58+L8c2C6ECTJHCQdPnxYOoZfKCdNmqS4ceOG9CYZk5iCJMZv+jFNQ8sRJL148SLSm2PTpk1jfSOZMmWKzoMkvnzJb3YxHcdvXhxExfdyj6Zbjx49YnzeOCiL7We0GSRxMMJBQtT7aN68ucLV1TXa1/lNkoMnlaVLl8Y6Fn4D+/Xr12+DJA7K+A0+pvvhcV6+fDlOzz0HdrG9GfIbP59XUX8HfyCJT5D04cMHRYYMGWIcc6FCheIVJCXmueQgR9NjqlOnTqTHzuchB+sx/Q5fX1/p2GHDhsV4XNKkScV44+J3f69Rb3HB41RdBuPHPX/+fMXRo0cV7u7u0v04OjqK1xYV9f+HrFmzKlKlSiVuxYoVU4wcOTLGy6gcUKt+jgNGAARJMgdJ/IlW0wsZf0LkN7uZM2cqPn78GO3n1I9VvTl8+/ZNsXz58kjf4xcEXVF/M+nSpYv4ZMgzKjw7oP4GrI4/cau+x59WJ06cqDh48KCYQVAft+pNMr5B0rNnz8Q4+IVR9b2FCxdKn1z5+0w9KOA37F27din27dsXKZekQ4cOv30O+PGqj2/gwIHi8fCbjuqFnW///vuvxueNZ4+mTp0qfkY974hvPFug+mTOwW7U51o9/yguQZLqzYQf6/jx4yN9nWcY+M3H09MzUiDFsz0q58+fV8yZM0f8PM+A8X3zTE7p0qU1Ps6YgiSe2VB/w+exe3l5iZkg1dd5Rk09SIiJ+v9X1Hwk/qCRP3/+SAEpj3fjxo2KXLlyxStIUp+x4r+X/fv3iwDMw8ND/O1Wr149Um4YP8/q56Dq/+v+/fuJfi75xrOUe/fujfZ1nilUzT6rzyjz/ynPjKjGzD+vmnnhvz3VcRxI8GsOByE8PktLSyk4uXfvnixBEtuyZYsiR44c0X6ezzH+u4n6geZ3waq9vb3i3bt30X7Py5cvpWP4+QNAkCRzkMT4hSu2T3z8AsdT/eri8gLE0+Y83Z6Q6fG4JKzGlrjNL64jRoyIljiu/gmeZ2DUlSpVSvpe7969ExQkxSVxm2fq1AM1fv5Vj3vHjh2Rvve7y27NmjWTjudLE+patmwpfY8vcWka25AhQyL9DF8WUX2vX79+cU7cjmuQdPv2bemSJ19+UX2dAxeVv/76S/o6LypQ4aBl0aJFigoVKojLpDzDEPX/Xf14TUES/16+zKf6+ty5cyP93WXLlk36Hs+y/o76TFzUc+TatWuRxubv7y99Tz0wiEuQxEGc6mt8yY1nItVnLuKbuJ2Y55Jn+Hg2TqVw4cLS9zhwYhzEqb7G9+3j4xPjWFu0aBHpg4H6/wf/3aq+N3z4cIVceIaHF6Joeq3Jnj27OG/VcSBcu3Zt8QHpwIEDit27d0f7EMKXXaPi51X9gyoAErcNQO3atUViIid+c6L2xYsX6dGjR9L33717RwMGDKDDhw/H6f44uZFLB8yZM0ckjMfG19eXqlWrFu3rJ0+eTFS9ndDQUPE4eGmupaWl9PW7d+9K2xUrVoz0M7x/7dq1aMdp2+3bt6XtX79+UZ06dTQex9+7d+8eubi4xHhfv3s8/H8a9biox6jjxNEbN26I7bjW+4krXuasSmzlRQJcZoITn1m5cuWk47gMhcrHjx+lbU7MVy0KiMmnT59i/f779+/FTWXQoEExHnvz5s0Y/280UX52+M/Dhw8jJeny8nH15zk+uKQFJwvfunWLNm/eLG4pUqQQ5QYqV65Mffr0oaJFi8b5/hLzXPL/VapUqaR9LrkR9f9L/W/czs6OnJycYvw96sfymGIaF/9//A6XKlH9/cZF1L9/Tc6ePUu1atWi8PBw8bfJ5TCcnZ3p9OnT1KxZM3r9+rUo/XD16lXxddauXTtxU9ekSRPxusQJ34wXxCxZsiTWvyEABEkGgmt/8AoxvjFe9cYvvLxqg12+fDnGn1Wt3uA6SdbW1lSgQIFoKzd0bdy4caKgH79wtWzZUhRn43o+XHvkd28GseE3c3Vcd4mDQKb+Zqsr6rVUjJ2NjU2kff57UQ+gNFG9afBKH/X/Rw7a69evL96sV65cSevXrxdfj4iI0OtznzlzZo0BnbalTJmSzp8/T6tWrRIfIDjo5fpbHDSpAqfr169T7ty5f3tfiX0uObhVpzofdP0mH5f/j5g+dMUkLuNdsWKFCJAYBz6qALdu3brixkETP1e8Ck4VJMWEf1YVJL19+zba99X/hsxxtShEh2KSMuMXWn5hiSpfvnzUqVMnaT+2Nx/+NMufyHj5M39ajk+AxLNF/7/sGumWkFkkfrHmgphcAkCFSwCoF2YrXLiwtM1vOurU91XHccG4qIUDVXiZbkzUA4Coz536MmF+Y+KATtNzwG8KVapUifUxx/fxRBX1Z1SlExgHu3F5PPrw4sWLSDMXXLaCP93z3x2/6ccVBzXqM1VHjhyJ8bnnwPt3uIyGCs/6qcufP7+0HRISEmmGQ/15jgseEweZgwcPFn93PEv15csXatGihTSDcvDgwTj9f2nruYyN+qwWz1L7+/trfExRz4cRI0Zo/P/gIEX1gU3f1D8M8XOuTr3Irvr2pUuXNN4XL+9XyZYtW7Tvq/8Nqf9tgfnCTJLM+MWWXyBLly4tLpE5ODiI8vjPnz+nKVOmSMepXw4xdDwbNm3aNKm2ycSJE2nPnj1im9tTqIJCruHEn9b4ctauXbvEdLmKKkDk5yJLlizSp7727duLT5NeXl505syZGMfAbz6q3891dPhNi4M4DiL5xY+fb/59379/F3Wp+vXrJ+qk8Asy/xxf9uQ3t2PHjsX6WPnx8NhV0/dc56pmzZpibJ6enpGO02TBggViZoDHxZ+EeTZChS8hqD8eFX4z5jdUDoa5NhCPW9c4aFfhWlj8t8n1hPhy4vHjx+M1M8h/H7NmzRL7HTt2FJWUixcvLgIj/rvnNzgORKK+IWrCwTxXdmdXrlwRl7FUeFaBx82zsszNzU1UwOZLLjz7Gh983927dxeXdwoVKiQuY/OsA88iqajXSFP//+L/V65Oz5fn+Ge19VzGhv8G+W+Da63x3zHPuHAAxAFRQECAmE3hc5Rfb9zd3Wnnzp3i5/j/hY/nS4h8zvD/B/9N8vnLs1+/+/Ck+tClTTxGDqYZ14Hjx+Do6ChmrXlWT4XPaZU2bdqI84r/5Z/n/3N+jNu2bdN4fqn/P6v87gMSmAm5k6LMPXGbV5H8LgGb66d4e3tH+jn178tV0TemEgCMV0Wpr0BRraSJSwmAyZMnR7ovLgkQ0zL9mBK3OWlc08+oarPwKqPYSgBous+4LEPXdOvevXuMz1vUpeiqGy9vVsfJ5ZqO45IR8amTFJfk9phWpbVp0yba70+WLJmoqaTp+NhKAHCNrN/93ccFr+i0sbERx3OdJU4MV3fo0CGNy+V5yX58Ere51ldsY02TJo3i6dOn0n1EXWWqum3YsEGrz2VsSeK8QpSTwuNSAkB9xWFMN7kq179580b838Y2trJly0aqJfe7bgC8ulW9vIUKJ9Kr/i+4AjcALrfJjGeI+NNNz549xYwKV3jlT5ycA1GwYEH6888/xczL7661GxqeLciZM6fY5piOZ5MYNyDlT3RcjZw/qXEuDM/w8IxS48aNxcwN96pTN3ToUBo2bJj49M7PDc+6cN4GX/qICedH8XPH9xs1r0l1iZI/IY8dO1YktXIuFyeYc04Jf4rmT/c80xUXixYtErNJ/GmdLyXx4+FPsfxp/t9//xU5FTHh6sHcd4zHw4+Nk2ynTp1Ky5cvj5bcz8fxJSR+DuXA+TicP8P/r3yZ0tXVVcxq8UxcfPDP8v8zPy8888DPFT9nPGPI58DAgQPj3J+OZ9N4NorxrIf65RTG/ye84IH7GfL/L8/w8KxebLOQmvClT/675L9Zrh7P98VV8fnvhWc3OWeQZ25UeHaGZ274uVK/9Kbt5zI2ZcqUEcnWPLvJM3X8XPHrCv+N8WysehV8rorPs7M8U8aXofix8aVuvmzHzy/PcvFzKAf+u/Dx8RGzfzwrxOcqP6c8y8zPG89+8YwSj1m9dxt3GuBzm3+e/774tYZnYPl85WRwzgNVx38/qsuwDRo00MsMLRi+JBwpyT0IAHPCl174Mog2VhGCMk+NP1DwpVO+hKJ+SQUgrvjDGAdc/KGKL8XHtqoVzAdmkgDAqPFsjGpWkWc8tF06AUwfL95QzRzzLBsCJFDBTBKAnmEmCQDAOGAmCQAAAEADzCQBAAAAaICZJAAAAAANECQBAAAAaIAgCQBAD7iWEq+c4tpKXGeJa3hxKyFuRM2Nhrnae9++fUVNNK7rw0vR+abLZs8AEDvkJAEA6Bi3AOFilDG93Kpa9XDxw6ju3LkTY+8/ANAtzCQBAOgQV2PnatEcIHHV69WrV4u6PNyrjnu11a9fXxzHFaEHDRokaj01adJE7mEDAGaSAAB0i5ux+vv7i+2lS5eKFkRRhYeHR2o3w61TuDEzw0wSgHwwkwQAoCNv3ryRAiTuFcY93TSRqx8fAMQOQRIAgI6oKquzfPnyRWrCCgCGD0ESAICO8Oo0ADBeCJIAAHSEl/urPH78mMLCwmQdDwDED4IkAAAdyZo1Kzk4OIjtr1+/koeHh8bjOHEbAAwPgiQAAB0aN26ctD148GBau3YtffnyRRSQPHHihCgBcOPGDYqIiKAPHz6IW2hoqPQzXC6Av8YlAwBAv1ACAABAx6ZOnUqjR4+OtZgk10mys7OL8T46deokAiwA0B/MJAEA6BgXk7xw4QK1bduWcubMSSlSpKBMmTJR2bJladasWWRvby/3EAFAA8wkAQAAAGiAmSQAAAAADRAkAQAAAGiQXNMXAQDMUeDXH/TiQzD9Co8g65QWZGebhlKmwMskgLnC2Q8AZi3gUwgd8H5GR/1fUlDIz0jf43rZ+bKmpYYueah6iRyU0gI91gDMCRK3AcAshYVH0NZzD2nT2QciHIqI4aWQAyX+TqY0KWlIEwdytMuk97ECgDwQJAGA2QkJDaPRW67QrRef4vwzSZMQRSiIutcsQi3L5dPp+ADAMCBxGwDMSnhEBI3depXuvIx7gMQ4QGIrj92hgz7PdTM4ADAoCJIAwKzsuPiEbjz/KAU9CbHk8C16FfhNm8MCAAOEIAkAzMbH4B+0/tS9RN9PuEJBS47c0sqYAMBwIUgCALNx2PeFCHASKyJCQdcevafXHzGbBGDKECQBgNk4fuMVaWupCidyn73zRjt3BgAGCUESAJiFHz/DtJ5HdD8gSKv3BwCGBUESAJiFN0HfRb0jbeHE7+fvg7V4jwBgaBAkAYDZLP3X/n2izByAKUNbEgAwC2mtUsT52F8R38j/wzRKliQlFc/QnyySpdF4XLrUcb9PADA+mEkCALPAbUVSp4zb58LA7z708Ycfvf9+iW59XECaGhMkS5qECmZPp4ORAoChQJAEAGYhSZIk5GSXSQQ36iIUYfTky056H3JF+lqGlCXJImlasf3u+yV6GXxI46U2hzwZ9TByAJALgiQAMBsNXfJIeUQKRTgFfDtJp161pwdBHuT7YSJ9/flUfC9FMhsqnnGA9HP3Pq2UvqeSPrUllbHPrOdHAAD6hCAJAMyGY96MVCRHOnr//QJdeNOXbgTOobCI/1aohUX8VyIgc6oylNu6kdiOoF90PXAmhUf8kL7fvoo9JUuKl1AAU4YzHADMhs9zHzr5vC/5vp9K335FbVKbhNJa2kf6in36LpTGwk5s8/H3glZT0iRJqGSejFTfObceRw4AckCQBABmo9mSZnT9la/G71klz0bJkkRercb7JTMNpaRJLMU+5yb9THqNRrd0FsESAJg2BEkAYDbsbZUzRTnT54z2vdQWmmeGUlvkosLp/5T2vd/Mo8/f0Y4EwBwgSAIAs3Gg3wE63P8wvf/6Ptr3rC1yR1r5xhNFqtmiUjmbUJUCDcX25+9B1H51ewoLD9PjyAFADkkUmgqAAACYoO8/v1PpKaXp1utbYr98/vJ04dEFsT2yzkLKnbYGPf8QTL/CIihNKgvKnzUtFc+dgUrkzkCfv38mx4mO9CzwmTh+fKPxNK7xOFkfDwDoFoIkADAbvTf1pqWnlortkjlLUu+qvannxp5kmdyS7k2+R3ky5on15y88vECVZ1Wm8IhwSpokKZ36+xRVKlhJT6MHAH1DkAQAZmGXzy5qvrS52E6VIhV5j/amglkK0rar2yhvxrxUvkD5ON3PlANTaPTu0WI7V4Zc5DfWjzKkzqDTsQOAPBAkAYDJe/HxBTlMcKBPIZ/E/sqOK6lbpW4Jui+eRao5tyadundK7Dd3bk47eu4QFb0BwLQgcRsATBoHNe1WtZMCpFYurci9onuC7y9Z0mS00X2jNHu002cnrTizQmvjBQDDgSAJAEwaXx47++Cs2OacoxUdVyR61idH+hy0pvMaaX/AtgF089XNRI8VAAwLgiQAMFnnHpyjCfsmSDNAm7ttpnRW6bRy340dG1Ofan3E9o9fP6jNijZi9RwAmA4ESQBgkj59+0Ruq9woQhEhLdmPa3J2XM1qNYtK5CghtrmswODtg7V6/wAgLwRJAGByeD1K9/XdRcI2q1KwCo2oP0LrvyelRUra2mOrWC3HuLwAr6IDANOAIAkATM7KsyvJ08dTbHOCNSda8+U2XSiavSgtaL1A2ndf5y4FZwBg3BAkAYBJufXqFvXf2l/a9+jsQTkzRO/Vpk1cTqClS0uxzavoeDUdr6oDAOOGIAkATAYnTrdd2VYkUrO/qv1FTRyb6Pz38mq5FR1WUO4Myia5vJqOV9UBgHFDkAQAJmPIjiF049UNsc0J1bNaztLb706fOj1t7r5ZtCthvKqOV9cBgPFCkAQAJmGP3x765+Q/YpsTqdUTqvWlQoEKNL7xeLHNq+p4dR2vsgMA44QgCQCM3suPL6nr2q7S/vzW80VCtRxG1h9JlQtWFtucwM2r7ND9CcA4IUgCAKPGCdLtV7enj98+iv0Wzi2oe6Xuso2HV9Ftct8ktS3hVXa82g4AjA+CJAAwatMOTqPT90+L7VwZconmtXI3m+XVdKs7rZb2ebUdr7oDAOOCIAkAjNb5h+dp/D5lDhAnTHPbEU6gNgRNnZpS76q9xTavtuNVd2hbAmBcECQBgFEKCgkit5VuUj2icY3GUUX7imRIZreaTcVzFBfbvOqOV98BgPFAkAQARocToXus70HPPz4X+5woParBKDI0YpVd962ifQnj1Xe8Cg8AjAOCJAAwOqvPrabt3tvFdnqr9DptO5JYxXIUE6vtVHgVHq/GAwDDhyAJAIzKnYA71G9rP2mfE6Q5YduQ9ajcg5o7NxfbvAqPV+OhbQmA4UOQBABGgxOg26xoIyVA96zSk5o5NyNDx6vteNWdKpjj1Xi8Kg8ADBuCJAAwGkN3DKXrL6+L7WLZi9HcP+aSseC6SVw/SdW2hFfl8eo8ADBcCJIAwCjs899Hi04sEtucCC1H25HEqlSwEo1tOFZs8+U2Xp3Hq/QAwDAhSAIAg/fq0yvqsraLtM8zSKql9caGV+FVsq8ktnl1Hq/SQ9sSAMOEIAkADBrPuHRY3YECgwPFflPHpiIXyVglT5ZcrMbjVXmMV+nxaj0AMDwIkgDAoM04NINO3jsptnOmz0mrO6+Wve1IYuXOmJtWdVol7fNqPV61BwCGBUESABisi48u0ti9yhweTnjmGRhV41hjxyUBVDNivFqPV+3x6j0AMBwIkgDAIHFCM/c7U9UTGt1gNFUpVIVMCedW8So9xqv2ePUeABgOBEkAYHA4kbnnxp70LPCZ2K9QoAKNaTiGTI1oW9Ljv7YlvHqPV/EBgGFAkAQABmfN+TW07eo2sZ3OKh1t6rZJJDybIl6lp17viVfx8Wo+AJAfgiQAMCh3A+5S3y19pX2uVJ0nYx4yZZybxKv2GK/i49V8aFsCID8ESQBgcG1HQn6GSD3PWrq0JFPHq/V41R6v3mO8mo9X9QGAvBAkAYDBGO45nPxf+ovtItmK0Lw/5pG54FV7vHpP1baEV/Xx6j4AkA+CJAAwCPv999OC4wvEtmVyS5HQbGVpReaEV+/xKj7Gl9t4dR/algDIB0ESAMjuddDrSG1H5vwxh0rmLEnmiFfx8Wo+xqv7eJUf2pYAyANBEgAYRNuRD8EfxH5jh8bUu2pvMle8io9X8/GqPsar/Hi1HwDoH4IkAJDVrCOz6MTdE2I7R7oc5NHZw+jbjiQWr+bjVX0qvNqPV/0BgH4hSAIA2Vx6dIlG71bm4HBgtLHbRsponVHuYRkEXtXHq/sYr/ZD2xIA/UOQBACy+BzymdxWuUn1gEbVH0VVC1WVe1gGhVf38So/xqv+ePUfAOgPgiQAkK3tyJMPT8R+ufzlaFyjcXIPy+Dw6j5e5cer/Riv/uNVgACgHwiSAEDv1l1YR1uvbhXbNqlsaHO3zSbbdiSxeJUfr/ZT4VWAvBoQAHQPQRIA6NW9N/eoz5Y+0j4nKOfNlFfWMRk6Xu3Hq/4YrwJE2xIA/UCQBAB6E/orVBRI/Bb6Tex3q9SNWpVqJfewDB4ntfOqP179x3g1IK8KBADdQpAEAHozYucI8n3uK7YLZy1M81vPl3tIRoNX/fHqP1V5BF4VyKsDAUB3ECQBgF4cvHGQ5h1T9mJLkTyFSEhObZla7mEZFV79x6sAGV9u49WBvEoQAHQDQRIA6FxAUAB1XtNZ2p/dcjY55HKQdUzGilcB8mpAxqsD0bYEQHcQJAGATkVERFBHj470/ut7sd+wZEPqU/2/xG2IH14FyKsBeVUg41WCvFoQALQPQRIA6NRsr9l07M4xsZ3NJhut6bzG7NuOJBavBlRvW8KrBXnVIABoF4IkANCZK0+u0Kjdo/5rO+K+kTKlyST3sEwCrwrk1YGMVwvyqkFePQgA2oMgCQB04sv3L+KNOyw8TOyPqDeCqhepLvewTAqvDuRVgoxXDfLqQQDQHgRJAKB1nEjca2Mvevz+sdgvm68sjW80Xu5hmRxeHcirBHm1IOPVg7yKEAC0A0ESAGjdhosbaPOVzWI7baq0ItHYIrmF3MMySbxKkFcLqvAqQl5NCACJhyAJALTq/pv71Htzb2l/RYcVZJfZTtYxmTpeLcirBhmvIuTVhLyqEAASB0ESAGjNz7CfkdqOdK3QlVqXbi33sEweJ8XzqkFePch4NSGvKgSAxEGQBABaM3LXSPJ57iO2C2UtRAvbLpR7SGaDVw3y6kFVeQVeVcirCwEg4RAkAYBWHL55mOZ4zRHbnEi8pfsWtB3RM149yKsIGa8q5Fk9XmUIAAmDIAkAEu3N5zfUyaOTtD+zxUxyyu0k65jMFa8idLVzFdu8upBXGaJtCUDCmGyQdPnyZWrXrh3lzp2bLC0tydbWlsqXL09z5syhb9++0dmzZ8nd3Z2KFi1K6dOnpzRp0pCDg4P4fmgoCrIBxBUnCHOA9O7rO7HfoEQD6lejn9zDMlu8ipBn8XhVIeNVhrzaEADiL4nCBD9iTJs2jUaNGhXjpydfX19atmwZLV++XOP369evTwcOHNDxKAFMw+wjs2nIjiFiO6tNVro+7jplTpNZ7mGZvS2Xt5DbKjexzZc9fUb7UMGsBeUeFoBRMbmZpF27dtHIkSNFgGRlZUWrV6+moKAgCg4OpuPHj4sAiCVLlow6d+5MV69epZCQEDpx4gSlTav85HXw4EG6du2azI8EwPBdfXKVRuwaEantCAIkw9DWtS11qdAlUtsSXn0IAGY8k+To6Ej+/v5ie+nSpdSzZ89ox4SHh4vAiC+xqevbty8tXrxYbG/evJnatm2rp1EDGJ+vP76S00QnevT+kdgfXm84TWs+Te5hgZrgH8HkMtmF7r+9L/YH1x5Ms1uhNACAWc4kvXnzRgqQOADinCNNeBYpaoDEfvz4IW3nyJFDhyMFMH5/bfpLCpDK2JWhiY0nyj0kiMI6pXWktiW8+pBXIQKAGQZJz549k7bz5ctHFhZxb4Nw7949MXvEChUqRBUrVtTJGAFMAScCb7ikTAZOkzKNSBRG2xHDxKsMZ7SYIe1zkj2vRgQAMwuSVEXU4uvx48dUp04dcQmO85L+/fdfSprUpJ4aAK15+O4h9d70X9uR5e2XU77M+WQdE8Suf43+VL+EMh+TVyFyoIS2JQC/Z1KRAC/3Vw98wsLC4jSDVLlyZTELxQESJ22XLFlSxyMFMOK2IyvaUnBosNjvXL6zSBAG42hbwqsPmddtL5p7dK7cwwIweCYVJGXNmlXUOmJfv34lDw8Pjcdx4ja7desWValShV69ekUZMmQQq98qVKig1zEDGJPRu0fTtWfKlZ/2tva0qO0iuYcEcWSb1pY2dN0gzbjzqkRenQgAZhIksXHjxknbgwcPprVr19KXL19EAUle5s8lAG7cuEF+fn5UtWpVevv2LWXJkoVOnTpFpUqVknXsAIbM65YXzToyS2xbJLMQCcGcGAzGo2bRmjS0ztBIbUt4lSIAmEmQ1KxZM5oyZYr4tMS1kbp06UI2NjZkbW1NNWrUoEOHDonj5s+fTx8+fBDbHCjxJTb+GdVt/PjxMj8SAMPx9stb6ujRUdrnRGDnPM6yjgkSZlKTSWI1IuPVibxKEQDMJEhiXEzywoULos5Rzpw5KUWKFJQpUyYqW7YszZo1i+zt7eUeIoDR4ATfzms6i0CJ1SteTyQCg3HiVYibu20WqxIZr1JE2xIAMykmCQDaNddrLg3ePlhsZ0mbRbQd4fwWMG6bL2+mdqvaiW1rS2vyHetLBWwLyD0sAINikjNJAKAd3s+8afjO4dL+BvcNCJBMhJurG3Uq10ls82pFXrWItiUAkSFIAgCNOKG3zYo29Cv8l9jnhN9aRWvJPSzQokVui8QqRcarFnn1IgAYSJAUoVBQwKcQehDwmZ6++0qhv5RL8wFAfn039xWFI1npvKVpUtNJcg8JtExUS++xRaxWZLx6kVcxAoBMOUnhEQq68uAd7fd+Rjeff6QfaoERl+/Ik8maajnkotoOOSmtlbLfEADo16ZLm6j96vbSG6nvGF/Kb5tf7mGBnvLO/Mf5i38BzJ1eg6SHAZ9pxm4/ev4hmJImSSJmkjQOKglRimRJqUftotTAOXeC240AQPw9eveInCY5SfVzNrpvpHZllQm+YLorGBssaiA1v61bvC4d6HsA7ZnA7OntDDjq/5L6rj5HLwO/if2YAiTG3woNi6BFB2/SxO3e9DMMl+EA9NZ2RK3AYMdyHREgmQEOhtZ2WSvNHnGwNP/YfLmHBWAeQdLpW69p9l5/ilDEHhxpcvH+W5q205dQqQBA98buGUtXnypbVfBy8MVui+UeEugJB0jru66X9nlVI69uBDBnOg+S3n3+TnP3XU/wz3NsdOHeWzrk+0Kr4wKAyI7ePkozDs+I1HZEVXAQzEPtYrVpSJ0hYptXNfLqRrQtAXOm8yBpuddt+hkWkej7WeZ1m758Rw0PAF149+VdpLYj05pPI5c8LrKOCeQxuelkKpVH2ceSVzfyKkcAc5VU17NI5+++ifclNk1+/gqnY/4vtTIuAIjeduTN5zdiv06xOjSw5kC5hwUySZE8hSgLwFW42bqL68RqRwBzpNMg6cztACItLUzjMOvodQRJANq28MRCOnRT2fjZNo0treu6DquazBznoy1tv1Ta77Wpl1j1CGBudPpKeP91kLZiJOHZ+2CsdAPQIp9nPjR0x1BpnxN3UR8HWPuy7alD2Q5im/OSeNUj2paAudFpkPT0/Vexok2bhSjvvX4ldSMHgIQL/hEs3vhUbUf+rv031SleR+5hgQH5p90/UtNbXvXIqx8BzIlOi0l2+eckvf4YkqCfDQ37RG++n6PwiB/0Pew1fQt7Rd9+vaJfEZ/F96c0nUIjG4zU8ogBzEfXtV1pzfk1YpuTtC8MvyDyUQDUXXt6jcpNL0dh4WFi32ugF3r4gdnQ6UxSmpRxf8F9/nU/+bwbR19+PqTwiF905nUXuvdpOT38vI5efTtKQaG3pQCJ+b/019GoAUzflstbpACJE3S3dN+CAAk0KpW3FE1rNk3a51WQvBoSwBzoNEgqmN2GkiX9fVaSQhFO94M86MMPb/J9P5FCwwJJQcpPLZElEfkSDUs2pKnNpupkzACm7vH7x9RzU09pf0m7JWSfRdkJHkCTQbUGUe2itcU2r4Lk1ZC8KhLA1Ok0SCqeO4PII/qdJEmSUcaUjmI7NPwj3Q1aTgVsOmk4UiHykfZf308OEx2o9fLW9O/Vf0VuBQD83q+wX+S20o2+fP/yX3JuOWVyLkBMeLUjr3rk1Y+MV0PyqkgAU6fTnCReidZ23jEK/qFpViiy0PBPdDGgL/2MCBL7hdL3IMtkGejGh1mkIOWKtmRJk1N4RPT7SmmRkuoWq0stXFpQo5KNyMbKRgePBsD4jdw5kqYdUl46yZ85P/mM8aG0qdLKPSwwEtzTrd6CelJV9ksjLpFzHme5hwVgnEES+/fCI1p9/G6cjv3w3Zt83o9TDoySk2vWufQ97A1d/zBDCpS4O3U2m2y0x28Pffz2Mdp98Ilbs0hNauHcgpo4NqFMaTJp+REBGKfjd45TrXm1RB/E5MmS04VhF6i0XWm5hwVG5u/tf9Mcrzliu2CWguQ92pusUyoLTwKYGp0HSeEREdRv9Xl6/JbLAfz+V937tJqefd0ltq2S56SyWedT0E9/uhE4XSxV5lmjLwuVlwpO3z9NO7x30C7fXfTua/REwmRJk1HVQlVFwNTMqRlltcmqg0cIYPjef31PDhMcKOBzgNif2XKm1KMLID64VlL56eWl5rddKnQhj84ecg8LwDiDJFV7kgFrzlPQt5+/zVGKUPyiK2+HiFVuLEfq2rTe3YPCk92mifsmUiOHRjS07n/F71h4RDidf3iePH08aafPTnr5KXpl7iRJklCF/BWopUtLau7cnHJlyKXlRwlgmPgUb7SoER24cUDs8/Ltw/0Po6o2JNiDtw/IaZITfQv9JvY3d9tMbV3byj0sAOMMklSB0sTt1+hBgHIWKDZcD+nSm/4Urvgh9rkbeevSreP0e3jFBRc94xkmDpqefHii8bgydmXEDBPf8tvmj+ejATAeC48vpP5b+4vtzGky0/Vx1zGrCom2/sJ66rRGucCG89p8x/hSvsz55B4WgHEGSapLbzsvP6Ft5x/R1++/RHkA9ZmlpEmSkIIUopWJtY037bg+TjoB/cb4kV1mu3j9Pn5ofi/8yNPbUwRMd99ozo1yyOkgZpg48btItiKJfJQAhsPvuR+5TnOV2kkc7HeQ6pVQJt4CJAa/vnZY3YE2XVY2v3W1c6WzQ8+SRXILuYcGYJxBkvqqt0v339HN5x/pQUCQCJiSJ0tKdrZpqGD2dFS5aDbKYG0Z6QQsm68snRlyJlEn4O3Xt6UZpusvr2s8hoMk1QyTQy4HcZkOwBjxpRCXyS507809qdbNnD+UCbcA2sClJPiyG9feYiPqjaCpzVHDDkyHLEFSQk/AUfVH0eRmk7Vy3w/fPZRmmPjynCa8RFoETC4tqHTe0giYwKh0W9eNVp9bLbadczuLtiOWFpZyDwtMzJUnV6jCjAqibQm/Rh4deJRqFKkh97AATD9I0nQCHh90nKoVrqbV3/Es8JlI+OaA6cKjC2IaOSpO9G7u1FwETeULlBcr5wAM1bar26jNijZiO7VlavIZ7UMFsxaUe1hgomYenknDPIeJbS7R4j/OX+S/ARg7gw+Sop6A2dNlJ/+x/jqrfxQQFCBKCvBlOS4xEKGIXnqfk165pAAHTFUKVhE1ZwAMxZP3T8hxkqNUVXttl7XUqbymCvYA2sELZurMr0PH7hwT+w1KNKB9ffdh9h2MnlEESVFPQC4DsOevPTo/Abm2DBet5BkmLsTHdZqiymidkZo4NBGJ3zzFjCahIHfbkcqzKtOlx5fEvlsZN9rYbSPerEDn+AMmt4vi1022oM0C6lejn9zDAjD9IEnTCbio7SLqU72P3n5/UEgQ7fPfJ2aYjtw6QqFhodGOsUllIwI4nmGqU6wOpUqRSm/jA2Cjd42mKQeniG27THbkN9YPbUdAbw7eOEgNFjYQ2/yB8fKIy+SYW9mXE8AYGU2QFPUEtExuSZdHXhYr0PTt64+vYiyc+M0F+kJ+hkQ7hvNA6hevL2aY6peoj7L9oHMn756kGnNrSG1Hzg09R675XOUeFpiZQdsG0bxj88R2oayFRNsSfj0EMEZGFSRFPQELZy1M10Zfk/UE/P7zu5hZ4hmmfdf3SXkg6riVCs8s8QwTzzSls0ony1jBdH34+kHMtL4Oei32pzefTsPqKfP4APQp9FcolZtejnyf+4p994rutKrTKrmHBWAeQVLUE7B7pe60ouMKMpSxHb97XMww7fbbHWMDXs5dauncEg14QSv4FG7yTxNxOZhxg+cjA46g7QjI5v6b++Q82VlqWxKfrgkAhsTogiRNJ+C/f/5LrUq1IkPCJQvUG/C+/fI22jFcRoBXx6ka8GZLl02WsYJxW3xiMfXd0ldsZ7LOJNqO4G8J5Lb2/FrqsrZLoromAMjNKIOkqCcgJ0xzXY48GfOQIeIGvBceXhCr5PgWWwNeLlzJ9ZhyZ8wty1jBuPi/8CfXqa7SQoID/Q6IHDgAufFbS7tV7WjLlS1a65oAoG9GGyRFPQHL5y9Pp4ecNviaRaoGvKqASVVNPCqu8K2q9l3AtoDexwmGj2dSS00uJfUkHFBzAM1rrczXAzAEn0M+i64Jqkbj2uyaAKAPRhskaToBxzQcQxObTCRjwU89zwRwsMSX5WJrwMvBEgdNRbMX1fs4wTD1WN+DVp5dKbYdcznSpRGX0HYEDM7lx5ep4syKOu2aAKArRh0kaToBTww+QVULVSVjxA14xQyTtyf5v/TXeAyv6ONgiUsLoAGv+dp+bTv9sfwPsW2Vwop8xviI5dYAhmj6oek0YucIvXRNANAmow+Sop6AOdLlEPlJXAnbmHEDXu4nxzNMMTXgzZc5n/KSnHMLKmNXBgGTmeBegw4THOjz989i36OzB3WpoMzPAzDUNIPa82uLzgX67JoAkFgmESRFPQF5af2u3rtM5gR8HvicdvruFDNM5x+d19iAN2f6nNTcubkoLYAGvKaLZ0yrzKoiGjGzNqXb0Obum03mbx1MF9fw4uD+Q/AHWbomAJhtkKTpBPzH7R/qXa03mRpVA16+LMclBnjlXFRZ0maRGvDypUdDT2aHuBu7ZyxN2j9JbOfNmFe0HbGxspF7WABxcuD6AWq4qKHsXRMAzC5I0nQCXh11lUrkLEGmXGVZ1YCXm//G1oCXE79rFK6BxF4jdureKao+p7qYSeSZQm47UjZ/WbmHBRAvA7YOoAXHFxhM1wQAswmSop6ARbMVFYGSlaUVmTpVA14OmLhNyo9fP6IdwwXdGpVUNuCtW7wuGvAakcDgQDFT+iroldif2mwqjaivzMMDMCbcmaDstLLk98JP7Her1I1WdlSu0gQwNCYXJEU9Af+s/Cct67CMzEnwj2BlA14fZQNeVWVyTQ14eYaJiw+mSZlGlrHC7/Ep2mxJMzFryKoXrk5eA72QdwZG696be+Q8yVlqDm6IXRMATDJIYncD7pLLZBfpBNzRc4cIBsyRqgEvB0w806RaEaWOL02qGvA2dmyMBrwGZsnJJfTX5r+ky6fcdoSXUQMYM49zHuS+zt0ouiaA+TLJICnqCchv+lyXw9xbffwM+ylWAHLAxA14+RJOTA14OWDiVYKZ02SWZaygdOPlDSo9pbTUdmRfn33U0EGZdwdgzPitp+3KtrTt6jaj6poA5sVkg6SoJ2DFAhXp5N8ncQJGacDLAROvlnvz+U20Y5ImSSoa8HLhSjTg1b+Q0BARIN0OuC32+9XoRwvaKPPtAEwll9JpohM9DXxqlF0TwPSZbJCk6QQc12gcjW88Xu5hGRwuI3Dx0UVRuJLrMb34+CLaMVyHhz/pqYpXmvusnD703NCTlp9ZLrWmuTTyEqW0SCn3sAC0il97Ks2sJF6HjL1rApgekw6Sop6APDPCs0mVC1aWe1gGi/8cRANeb2UD3kfvH2k8Dg14dYuf/5bLWkptR7xHe1PhbIXlHhaATkw9MJVG7R5lUl0TwDSYfJAU9QTkytR8AmZInUHuYRk8/tO4/vK6mGHigOlOwB2Nx5XMWVLqJ4cGvNqpsO4w0UHMhLJVHVeReyVlfh2AKeIPsbXm1qKT906aZNcEMF5mESRFPQE5v8azlydOwHjiIEk1w6QqsRBTA16eYeLO9HiO458rVm12NTr38JzY/6PUH7S1x1Y8j2DyXn16JT4cqBaUmGrXBDAuZhEkaToBl7ZbSj2r9pR7WEbr0btHIlji25UnV2JswNvcqbmYYeLLc0mTJtX7OI3N+L3jacK+CWKbl0Nz2xGUZABzwWVKGi9ubDZdE8DwmU2QFPUE5ARYPgGL5ygu97CMHid67/TZKQImngGJrQEvzzJVKFABhRA1OHP/jJhFilBEiOfnzJAzolkxgDnpt6UfLTqxyOy6JoBhMqsgKeoJWCx7MXECoj2H9nApAVUDXu41FlMD3qaOTcUME5cYsEhuQebu47ePou3Iy08vxf7kppNpVANlHh2AOeGWSq5TXUU+pLl2TQDDYXZBUtQTsFfVXrSk3RK5h2WyDXj3+u8VAdPR20c1NuDlBHpO0uQZpppFapplA14+BVssbSGCS8bLn48NOobZNjDr/EfumsAdA8y9awLIy+yCJE0n4M5eO6mZczO5h2XSeKXW/uv7ReL34VuHf9uAl9ukmMsU+7JTy6jXpl5S0MhtR3KkzyH3sABktersKuq+vrvYRtcEkItZBklRT8D0VulFWYBcGXLJPSyzacB76OYhUVogpga8XBuIG+9ywNSgZAOTbcB789VNUVVbFTTu+WuP6J8HYO74ran18ta03Xu72EfXBJCD2QZJUU/ASvaVxAmISxz6xbN5Xre9xAwTX5r7XQPeRg6NKH3q9GQqj50DpFuvb4n9PtX60CI3Zb4cAChnoB0nOtKzwGdiH10TQN/MNkjSdAJOaDyBxjYaK/ewzLoB74m7J8QMU0wNePlTZI3Cyga8TZ2aGnUD3t6betPSU0vFdokcJejKqCtoOwIQxYWHF6jyrMromgCyMOsgSdMJyF2oK9pXlHtYZo+LKvKSeE765n5ysTXg5YROLhCaPV12Mha7fHZR86XNxTavrrw26hqqlQPEYPL+yTRmzxixja4JoE9mHyRFPQE5L4kTBE3lko4piIiIoIuP/9+A12cnPf/4PNoxXJG6XL5yUrVvLsRoyHWleLn/p5BPYn9FhxXUvbIyPw4AouMPsTXm1KDT90+LfXRNAH1BkKThBOQ32u09t+MENED853rt6TWp2vfDdw81HlcqTykRLPH/pX0WezKkvzUuGHn2wVmxz7Wi/v3zX/ytAfzGy48vRdcErinG0DUB9AFBUgwn4PIOy6lH5R5yDwtiwX+6N17dUDbg9fak2wG3Y23Ayze+pCVnQDJx30Qat3ec2M6dIbdoO4JZS4C42eO3h5r+01Rso2sC6AOCpFhOQM4TKZajmNzDgji6G3BXmmHyfe6r8ZhCWQtJAZNTbie9BkznHpyjKrOqiLYjnE91ZugZ0aIFAOKuz+Y+9M/Jf8Q2uiaAriFIiuUE5BVHl0dexglohB6/f6wMmLw96fKTyxqPsctkJwVMZezK6LQB76dvn8RMJecjsYlNJtKYhso8OACIX+kM7prAs8gMXRNAlxAk/eYE/KvaX7TYbbHcw4JE4MCEW37wZbmYGvDmSJdDasDLqxu1WS+Lf1+rZa1E0MZ4+fKJwSdQkwsggW6/vk2lppRC1wTQOQRJcTgBd/+1W/QXA+PHpQR2++4WAcvJeyc1NuC1TWMrVs9w4nfVglUT3YB3xZkV9OeGP8U2L1vm1ZM5M+RM1H0CmDv18wpdE0BXECTFAG9spo+LVXKVb55hiq0Bb2OHxmKGqVbRWvFuwHvr1S0RcKvajuzqvUsUwQQA7c7QomsC6AKCpDiegFy08Pjg4zgBTdTnkM/KBrw+nqKvXEwNeBuWaChmmOoWq/vbBrxRL932rtqb/mmnzHcDAO3n+qFrAmgbgqR4nICTmkyi0Q1Hyz0s0DFuuCs14L1+gIJDgxPUgFd9EQAvU74y8goWAQDoeNUouiaANiFIiscJyLNIfAJi2bb54Bklr1teYoaJL81xvz9NDXhrF6stAia+NMd1j1BOAkCe+mPomgDahCApAQUAOUEwnVU6uYcFMjTgPXn3JO3w2SGSvz8Ef9DYgLdC/gqiKvi3n9/E15a1X0Z/VlHmtwGA9vECjOpzqot+jwxdE0BbECQl4ARs5dKKtv25DSegmTfg5dYiogGvz04K+Byg8bhM1plobMOxIo/JmBrwAhibqD0R0TUBtAFBUgJPwJUdV1K3St3kHhYYSAPeS48viRwmj/Me9Pn7Z43Hlc9fXnzC5XpMeTPl1fs4AUzdLp9d1Hxpc7GNy9ygDQiS4oFnDFosbSG2OQHXe7Q3FclWRO5hgYE4//C8yF/jmccklETMHL0KeqXxWJc8LlK174JZC+p9rACmqvem3rT01FKxja4JkFgIkuKp18ZetOz0MqlxKp+A/IkFzBsndPNM4/OPz8X++EbjxVJkXv7PrVH4styt17c0/iy/kIuAyaWF6EWFy7gACcelN0pPKS2db+iaAImBICmRJ2Df6n1pYduFcg8LZMSnUOvlrWm793apqB23HeEkbnX33twTARMnfsfUgLdgloLU0qWlLA14AUzFzVc3xeu0qt4ZuiZAQiFI0sIJuLfPXmrk0EjuYYFMVp1dRd3Xd5faI/iN9aPcGXP/tgEvX77lGSbOZ9Ikb8a8YnaJAyZXO1edNuAFMDXLTi2jXpt6iW10TYCEQpCUQHzNm699s4zWGcUJmCN9DrmHBXp2J+AOuUx2kfr8efbyFInZ8fHy40tlA16fHWLFnL4b8AKYIj6POIeUzy2GrgmQEAiSEoiftuZLmtNuv91iv1qhanR00FGcgGaEZxK57cj1l9fFfs8qPWlpe2XCaEK9/fJWasB74u6JGBvwcv83Dpj47y6xDXgBTNXHbx9FruDLTy/FPromQHwhSNLiCTil6RQa2WCk3MMCPem3pR8tOrFIbHPC9dVRV7W6iob/vvb6/b8B752jophlVHx5j3MtEtqAF8DUcX27arOroWsCJAiCpEQ6fe+0KDSpOgHPDj1L5fKXk3tYoGP7/PdR48WNxTavbuQAifuz6cqX718iNeBVXd5Tx/3jGpZsKAKmesXr/bYBL4C5GL93PE3YN0Fso2sCxAeCJC0Yt2ccTdw/UWznyZhHJO7iBDRdrz69Eo2PA4MDxf6SdkuoV1Vlgqi+GvAevnlYzDBx4BRTA14OlFQNeNOmSqu38QEYYoV8nk069/Cc2EfXBIgrBElaOgGrzq4qigmy1qVb05buW3ACmiDOEao1txadvHdS7Dd1bEo7e++U7f+a86KO3j4qSgvs8d+jsQFviuQpqHbR2qK0gKoBL4C5eR74XHy4UZ0j6JoAcYEgSUueBT4jx4mO0gm4utNq6lqxq9zDAi2bemAqjdo9SmznTJ9TTNvz8mJDasDLl+R4QcH7r++jHcO1m6oXqi5KC3CAZ5vWVpaxAsiBP0y0XNZSbKNrAsQFgiQt4ssfrZa1ki538AlYOFthuYcFWnLx0UWqNLOSmE1KmiSpKBhZpVAVMtTZTb60oKr2rakBLz8GLnzJM0zNnJqhhAWYhZ4betLyM8vFNromwO8gSNKyPzf8SSvOrBDbDjkd6NLISzgBTQDPEPJMIc8YsrENx9KEJspEUGNpwMvBEt9UjyEqXnCg6ieHBrxgqkJCQ0Qx4NsBt8U+uiZAbBAk6eAELDWllCgyyPrX6E/z28yXe1iQCHyKtF3ZlrZd3Sb2efnwqb9PRWs7YiyPxee5j7I9ivcOevDugcbjnHM7S+1R0IAXTM2NlzdEoBQaFir20TUBYoIgSQe4uGCZKWWkE3Bfn33U0KGh3MOCBPI450Hu69zFNq9a5NWLvIrR2PGpzy12VDNMvK0JlzbgYImDJjTgBVOx5OQS+mvzX2IbXRMgJgiSdOSfk/9Qn819xHYm60wiwTd7uuxyDwvi6W7AXdF2JORniNjf3nO7CBZM0f0390WwxDNMPNsUUwNecUnOpYWYbULABMaK3/qaLWlGe/z2iH10TQBNECTpCD+tTf9pSnv994r96oWrk9dAL5yARoSX15edWpb8X/qL/R6Ve9DyDsqET1P35P0T2umrbMDLCesxNeDlfnIcNKIBLxgjrnXGXRNeBb0S++iaAFEhSNLjCTit+TQaXm+43MOCOBqwdQAtOL5AbPMy4WujrpllFWsunika8HorG/BydfmoeJa0uVNzMcPEK+bwYQCMqWtCtTnVxAdbdE2AqBAk6dipe6dE2xLVCXhu6Dkqm7+s3MOC39jvv58aLVYmclomt6Qro66I5cLm7t2Xd6IGEyd+n7h3QpQaiCpzmsyiBhPPMKEBLxiDsXvG0qT9k6QZUs47tLGykXtYYAAQJOnBmN1jaPKByWLbLpMd+Y7xxQlowF4HvRYzgB+CP4j9xW6L6a9qygRPiN6Aly/Jed32irEBL1f55hkmbsCLchhgiDjYrzKrCl14dEHso2sCqCBI0tMJWHlWZSm3o03pNrS5+2acgAaIC0XWnlebTtw9Ifb5DX73X7vxfxWHBrwHrh8QAdPBmwdjbMDboEQDMcNUt3hdSm2ZWpaxAmjC9cP4w9Hn75/FvkdnD+pSoYvcwwKZIUjSk6cfnopihKoTcE3nNdS5Qme5hwVRTD80nUbsHCG2c6TLIVYl8vJgiH8DXg6YuAHv1x9fox3DLSFUDXgblmyIBrxgELZf205/LP9D6prgM8aHCmUtJPewQEYIkmQ6AflTNLctwQloOC49ukQVZ1YUs0k8c8RtR6oWqir3sIx+heCx28dEwMRLrT+FfNLYgLdWkVrKBryOjQ2mFx6Ypx7re9DKsyvFtmMuR7o04hJZWljKPSyQCYIkPeu+vjutOrtKbDvldqKLwy/iBDQAn0M+k9MkJ3ry4YnYH91gNE1qqkzkBO34FfaLTt5TNuDl1XIxNeDlZG+eYWrq1JSypM0iy1jBfEXtmjCg5gCa13qe3MMCmSBIkuFSRKnJpejum7tif2DNgTS39Vy5h2XW+BRwW+lGW69uFfu8/PfMkDNG2XbEWPBs3bkH56Rq35wsH1MDXg6YuB4TqiGDvvi/8CfXqa5S14T9ffdTg5IN5B4WyABBkkwnYJmpZaTVQAf6HaD6JerLPSyztfb8WuqyVpmgaZPKRiz/RYNX/TbgvfzksjJg8vakp4FPNR5XNl9ZqQGvXWY7vY8TzMviE4up75a+UteE6+OuU7Z02eQeFugZgiSZLDq+iPpt7SfVleG+QTgB9e/em3ui7QjP8LF///yXWpVqJfewzBa/HPk+95Xao9x/e1/jcdwSRdUeBXl9oKu/xSb/NKF9/vvEfo0iNchrgBcqy5sZBEky4ae98eLGYvUPq1mkJh0ZcAQnoB6F/gqlctPLiTdl1q1SN1rZUZmwCYZxjtx6fUvMLnHQdOPVDY3HcdNdVQNebsaLcg2gLR++fiCHiQ7S5eDpzafTsHrD5B4W6BGCJJlPwJITSlLA5wCxP6PFDBpad6jcwzIbg7YNonnHlAmZhbMWpmujr6F2jxE04OWb9zNvjcfY29qL2SUOmlzyuCBggkQ7efck1ZhbQwTtnKfIXRNc87nKPSzQEwRJMjtx5wTVnFdTOgHPDztPZezKyD0sk3fwxkFqsLCBtAT9ysgr5JDLQe5hQTzqju30UTbgVVVJjipPxjyinxzPMHE+E2ZpIaFG7xpNUw5OEdvommBeECQZgFG7RtHUg1PFdr7M+cQJiOJ6uhMQFCCm0FVL0Be2WUh9aygTNMF4G/BywHTm/pkYG/A2c2omZph4xRxWLkJ8y1dUmV1F6prQtkxb2tRtE2YqzQCCJAM5AbltyaXHl8S+Wxk32thtI05AHa2kqjO/Dh27c0zsc7XnvX324rk2oQa8XLSSA6bjd49rbMDLK5W4BlNL55ZUrXA1MZMIEJfZS/5wxS142Noua6lT+U5yDwt0DEGSgXjy/gk5TnKUTsB1XdZRx/Id5R6WyZl5eCYN81QmXmazySaW9WZKk0nuYYEOfPr2ifb6/78B7y0vqeaNunRW6ZQNeJ1bUO1itdGAF2K17eo2arOijdjm/EWf0T5UMGtBuYcFOoQgyYDgBNStK0+uUIUZFcTsAs8cHRt4jKoXqS73sEAPuH+c1ID3xkEK+RkS7RhrS2tRMJBzmLivHJL4QZNu67rR6nOrxTa6Jpg+BEkGxn2tO3mc95BqwVwccRGXA7SAZ+i47cjj94/F/sj6I2lKM2UiJphf24nDtw6L0gL7ru+LsQFv3WJ1pQa8SNIFFa6pxrXVuMYaG1RrEM35Y47cwwIdQZBk4Cfg4NqDaXar2XIPy6jxn3j7Ve1p85XNYp9XOnHbEYvkFnIPDQygVhbnp/EM027f3bE24OXSAnxpLqN1RlnGCobD77kfuU5zlbomHOx3kOqVqCf3sEAHECQZIC5uWHZaWekEPNT/ENUtXlfuYRmt9RfWU6c1ygRLXjXoN8YPbS1A4wKKU/dPiRkmXi337uu7aMckS5pMasDbzLkZGvCasYXHF1L/rf2lrgmc35jVJqvcwwItQ5BkoBYcW0ADtg0Q27ZpbMl/nD9OwAQWIHSe7Cy1HdnaYyu1Lt1a7mGBETTgPf/wvNRP7lXQq2jHcF6b1IDXqTnlzJBTlrGCPPits9GiRnTgxgGxX6toLTrc/zDqcZkYBElGcgLWLlpbzCjhBIw7nokrN60c+Tz3EftdK3Sl1Z2VCZcA8SkbwUn/qmrfTz480Xicq52rVO2b652B6eNaaw4THKSuCTNbzqQhdYbIPSzQIgRJBn4CctuSN5/fiP1ZLWfR33X+lntYRuPv7X/THC9lQiU3QfUe7Y0VS6C1Brx8U+UORsWrnkQDXucWVDhbYb2PE/Tn+J3jVGteLalrwoVhF6i0XWm5hwVagiDJwOEETJjDNw9TvQX1pMTbSyMuiTcuAG3hc/L269tSwHT95XWNxxXNVlTMMHFpgRI5SqBwqQkauXMkTTs0TWznz5yffMb4oGuCiUCQZARG7BxB0w9Nl05A37G+lCZlGrmHZbB45o2nwFWJt/Nbz6f+NZUJlgC68uDtAymH6dqzaxqPKWBbQJphKpW3FAImE0r6rzSzEl1+clnsty/bnja4b5B7WKAFCJKM5ASsOLOiyItgHcp2oPXu6+UelsHmj/AMktdtL7HfoEQD2td3H96MQK+eBT6TGvByArgmuTPkpubOyga85fKVQ76hiXVNWN91PXUo10HuYUEiIUgyElwE0XGio1T4DiegZrOPzKYhO5SJk7wakJfl8vJcALm8DnqtbMDr7Umn75/W2ICXW+SoGvBWLlgZDXiN1JbLW8htlZtUwZ0vu9lnsZd7WJAICJKM+ATky248fQ9KV59cpfIzykttR44OPEo1itSQe1gAkRZjqBrwchHL2BrwcsBUvXB1VNw3Ml3XdqU159eIbZc8LnRh+AX8HxoxBElGpsuaLrT2wlqxXSpPKTo//DxOwP/35nKa6ESP3j8S+8PrDadpzZWJlACG2oB3n/8+ETAduXUkxga8jUo2EonfXAaE26WAYQv+ESy6Jtx/e1/s/137b5rVapbcw4IEQpBkhCeg8yRnevDugdjnmhxcm8PcdVzdkTZcUiZKlrErQ+eGnkPbETCqIJ8b7/IlOa6NFlsDXp5h4ga81imtZRkrxL9rAheZrFO8jtzDggRAkGSEfJ75iBPwV/gvsX9kwBGqXaw2masNFzdQR4+OYptX/fmN9UMxPzDqBrw8s8QzTNyAV5UIrC6lRUplA16XFmKmCQ14Dc/8Y/Np4LaBUteE6+Ovo42NEUKQZKTmHZ1Hg/4dJLb5xOO2JeZ4Aj5891BcZgsODRb7m7ptIjdXZd4WgCk04D1+9zjt8N4hcpk+fvsY7RiLZBaiJQbPMDVxbIIGvAaC31obLmooZghZnWJ1RCNcrGI0LgiSjHipO5+Ah24eEvvcAPdA3wNmdQLyVHaF6RWkmjSdy3emNV2UCZMAplgKhFfH8QwTr5Z7++Wtxga8VQtVVTbgdWqGfo8ye/flHTlMdJC6JsxuNZsG1x4s97AgHhAkGfkJyG1LVC+Wc1rNoUG1lbNL5mDojqE064gyIdLe1l4st0WeBphbA16ux/Ty08tox/AKz4oFKiob8Do3p1wZcskyVnN37PYxqj2/tphZ4lk/Xu3GhUTBOCBIMnJHbx+l2vOU+Uh8Al4ccVEsOzV1Xre8qM78OtLj5rYjznmc5R4WgCyzylefXpXao3BNNU14QYOq2nd+2/x6H6c5G+45nGYcniG2uWwLf6BD1wTjgCDJBAzbMYxmHplpNicgz5xx2xHVDNrcP+bSwFrKBEkAc8Yv534v/MQqOQ6Y7r65q/E4x1yOyoDJpQUVyVZE7+M0964JHct1pHVd18k9LIgDBEkmkptTcUZF8WmSdSrXidZ2VdZSMsVPzQ0WNRANbBkvhd7fd79Z5WIBxJXUgNfbk/xf+ms8hoMkDpi4PUrJnCXRwkdHHr17RE6TnKSuCdzbjXu8gWFDkGSiJ+BG943Urmw7MjVzvebS4O3KxEdezcdtR2zT2so9LACjWAmqmmFSfaCKihtoq2aYSuctjYBJyzZf3kztVrWT6l5xuRJc+jRsCJJMyKZLm6j9auUnE77c5jvG16ROQO9n3lRuWjmpPpTXQC+x9BkA4ud54HPa6btTBE3nH50Xl+liasDLQVP5/OUxW6slnT0607qLykttHIieG3YOXRMMGIIkE9PJoxOtv7je5E5AniHjSuP8aZgNrTOUZrRUJkICQMIFBAUoG/D6eNKpe6c0NuDlUgKqBrxVClZBA95Evpa5THKRuibgtcywIUgyMVGDiWF1h9H0FtPJ2OHTF4Duffj6IVIDXtWsrTouVtnUUdmAlxtI4zxM/Ky4uXdNMGQIkkyQqV2WMvXLiACGKCgkSGrAywslNDXgtUllQ40cGomAiStKowFv3CG/0jggSDJRc7zm0N/b/5amyv3H+hvlCWguCekAxtKA9+DNg/Qt9Fu0Y1JbpqYGJZQNeOuXqI/CrvFcqWuOXROMAYIkEz4B6y+sLxplGutS+ailDVBbBEB+339+lxrw7vXfG2MDXp5Z4oCJZ5rSWaWTZayGDjXfDB+CJBPGJ17J8SXp3dd3Yn9e63k0oOYAMhaoUgtgHA14eYZpj/8eCgwOjHYMV8SvWaSm1IA3U5pMsozVUKF7gGFDkGTijtw8QnUX1DW6E9Bc260AGKuw8DCpAS/3k4upAS+vjlM14M2WLpssYzU06ENpuBAkmYEh24fQbK/ZYrtgloLkPdrboE9AdM4GMP4GvBceXlAGTL476cXHF9GO4UKVFfJXEIUrmzs1p9wZc5O54tSCCtMr0LVn18R+5/KdaU2XNXIPCxAkmc8JWH56ebHqjXWp0IU8OnuQoeZSNVzUkA7dPCT2Oa/hYL+DRpVLBQD/4bcY0YDX25N2+OyIsQEvl/bg1ijm2oCXy7Y4TXSi4NBgsb+p2yZyc3WTe1hmD0GSmXjw9oGon6Q6ATd320xtXduSoZl/bD4N3KZMXLRNY0vXx18Xy2MBwPjx243/C39lPzkfT7oTcEfjcQ45HcQMEwdMRbMXJXOx8dJG6rC6g9jm/EtuW5Ivcz65h2XWECSZkQ0XN1BHj45iO22qtKLekCGdgD7PfKjstLJSfafD/Q9TneLKhEYAMD0cJIkZJu8dv23AyzeHXA4m30+u4+qOtOHSBrFdxq4MnRt6jiySW8g9LLOFIMnM8KcU/rTCXO1c6ezQswZxAgb/CCaXyS50/+19sf937b9pVitlIiMAmD6uiaaaYbry5IrGY/hDnSpg4gDCFAOmqF0ThtcbTtOaT5N7WGYLQZKZ4ZomfAI+ev9I7I+oN4KmNp8q97Co69qutOa8MlGRV7FdGH4B7Q4AzBQnevMKOZ5hiqkBb64MuUTCt2jAW6C8WDlnKq49vUblppcTKwY5EPQa4EU1i9YkQ9C5c2dat05Zr47HliJFCkqfPj0VKFCAGjVqRH/++SfZ2NiQIQgKCqL58+eL7apVq4pbfCFIMkNXn1yl8jPKSyfg0YFHRQ8muWy5vIXcVikTFK0trcXyV/ss9rKNBwAMqwHvbr/dUgNeXjkXFectqhrwVi1U1SQa8M4+MpuG7BgidU3gtiWZ02Q2qCBJkzx58tDBgwepaFH5c8mePn1KdnZ2YnvcuHE0fvz4eN8HlgyZodJ2pWlqM+XsEcfIfAnu/df3soyFV7r03NRT2l/SbgkCJACQcC2lXlV70bFBx+jN7De0quMq0UGA66epcE2mZaeXUa15tSjr31nJfa27aKPCxS6N1aBag6h2UWWtOC6H0nlNZ40zanI6efIk/fz5k27cuEGtW7cWX3v27Bk1bNiQvn2L3rrGGCFIMlODaw2Wmt4GfA6gLmu66P0E/BX2i9xWukltDdqXbU8dyilXdgAARMXVut0rudPB/gfp3dx3tMF9AzV1bCraoKhw1W+P8x7UYGEDsh1sS+1XtaddPrtEOxVjwmVPuA0Tr/JlHPQtPL6QDI2FhQUVL16ctm7dSuXKlRNfe/LkCXl4KMvMcBA1bdo0cUyqVKkoTZo0VL16dTp+/Hik++FLYXxlI2/evHTu3DlydXWllClTUr58+WjlypXRfu+WLVuofPnyZG1tLe63ZMmSNHfuXAoPV8408qyRahaJTZgwQdw/306dOhX3B8iX28A8BQQFKDIPzKygbiRuC44t0OvvH+E5Qvrd+UfkV3wO+azX3w8ApuHr96+KbVe2Kf5Y9oci9V+ppdcV9Rt/vdXSVoqtV7Yqvnz/ojAWh24ckh5Dip4pFD7PfGQdT6dOnfjTtLidPHky0ve2bdsmfa9evXqKsLAwRc2aNaWvqd+SJEmi2Lp1q/SzVapUEV+3srJSpEqVKtrxa9askY4dPXq0xvvkW6tWrcQx48aNi/GYqOOODYIkM3fw+sFIJ6DvM1+9/N5jt48pknRPIn5v8j+TK648vqKX3wsApi0kNESx23e3osOqDgqbvjYaAybLnpaKxosaK9adX6f49O2TwtAN/newNPaCowqKoNAQgyRfX1/pe0WKFFFs2LBB2l+yZIni27dvipcvXyrKlSsnvpY1a1YRSKkHSXzr37+/IigoSOHl5aWwtLQUX8uRI4ciPDxc8fjxY0WyZMnE1+zt7RV37txRBAQEKCpVqiT9PP8ce/LkifQ1DpoSApfbzFy9EvXEtW9VZe42K9vQt1DdXkvm/CfOg1Jd3uP8KM6TAgBIrFQpUolGuuvd14tLclyx372iO2W0zigdExoWSnv991KnNZ3IdpAt1VtQj1adXUUfvn4gQ8SvkarelVwmpf/W/mSoHRNU+LIWJ3Cr9O7dm1KnTk05c+akixcviq+9efOGbt++TVEv302dOlWskKtVq5ZYMcdevXpFDx48IC8vL+mSWv/+/alw4cKUNWtWGjt2rHQfhw8fJm1BkATiBHTOrWx6e+/NPZ2egBwYcf4T50Exzovi/CgAAG3jMiL8QXBVp1Ui6fv4oOPUu2pvsVpMhYvXHr55mLqv705ZBmehGnNq0JKTS8SqOkN6HFu6b6HUlqnFPudcbb2ylQzN/fvKOneMc4vev//9gqCPHz9G2s+YMSNZWVlJ+xxUqXz48EHcVHLlyqVxOy6/N64QJAFZWlhGOgFXn1tN265u08nvWnRiER24cUBs83LW9V3Xoy8bAOgclwWoXqQ6/dPuH3o185UopDug5gBRb0klQhFBJ+6eoL82/0U5huagijMq0ryj8+h54HOSG6/6XeK2RNr/c+Of9OT9EzIkCxYskLbr169PmTP/V7IgICBAfEhWv/HMU5UqVSLdR2BgIH3//l+S/cuXL6XtTJkyiZum77148V8TZdUx2ig2incnEApmLUj/uP0j7ffY0EPrJ6Dfcz+p7gdb12VdpE90AAD6wB/MKtpXpHmt59Gz6c/oysgrNKzuMMqf+b/Guvwmfv7heRr07yDKMzwPlZlShmYcmiFVwpYDr/5t59pObPOqYK4vx6uE5fTr1y+6efMmtW3bli5duiS+xivSunTpQvXq1ZOO4yKTXB6AV7vduXNHXFLjn9F0f6NGjaIvX77Q0aNHad++feLrOXLkIHt7e3EJTvXBeuHChWL2ii/bTZ48WbqPunXrin+5yKXK3bt3xX3HmxbyuMBEREREKNxWuEkJgmWnllX8/PVTK/cd/CNYUWh0Iem+B20bpJX7BQDQ5mug33M/xZjdYxRFxxTVmPTNt5LjSyom7J2guPXqlt7HyKuA843IJ41l5M6RsiVuk4Zb3rx5FbduKZ8XTsquUaNGjMdysraKKnHb2tpa3GJb3TZixIgY77N58+aRxluwYMFox/z69SvOjxdBEkQ7Ae2G20kn4Kido7Ryv+5r3aX7dJ7orPjx84dW7hcAQFduv76tmLRvksJxgmOMAVPh0YXF6yQvzecgSx8uP74sVgXz7+dVwsdvH1fIFSSlSJFCrFKrWLGiYubMmWJVmrrQ0FDFtGnTFMWLF1ekTJlSkSZNGrHy7c8//1ScO3cuWpCUJ08exaVLlxRly5YVK9s46Fq+fHm0caxfv17h6uoqSgbwcXz//PujBkAXL15UlC5dOlJZgfgESWhLAtFcfnyZKs6sKLUt4WTHaoWrJfj+OL+pzYo2YpvznnxG+4jLewAAxtSAd6fvTvL09qTLTy7H2ICX+8m1dGlJpfOW1mm+5czDM2mY5zCxnc0mm2hbwsU2jVXVqlXp9OnToq0JtxMxFAiSQCO+9j5853CxnT1ddvIf65+gE5DzmhwnOUpVtdd2WUudynfS+ngBAPTdgJf7yZ17eE5jt4Kc6XNSc2dlA94KBSpovQEvJz3XmV+Hjt05JvYblmxIe/vsFR9suR0LL8gxJlURJIExiXoCNnJoRHv+2hOv1QKcUFh5VmW69FiZzOdWxo02dtuolRUHAACGgPuq7fZVNuA9ee9kjA14uX0KzzBVKViFLJL/13cuMbhMgcNEB6n35sI2C8VqvbYr21LNIjWloMkYVEWQBMaGT8CSE0rSh2BlXYpFbRdRn+p94vzzo3eNpikHp4htu0x25DfWj9KmSquz8QIAyIn7xu3x2yMCpqO3j4oaTFFlSJ1BFLvkGSYOZBI748M93bhPnaqeUv3i9Wm3326xf2eMPxUODCd69IiICzDy0ngnJ6IMGRL1O80JgiSI8wlomdySLo+8TA65HH77cyfvnqQac2uIaWiuT3Ju6DlyzeeqhxEDAMjvc8hn2n99vwiYDt08RD9+/Yh2DH9obFSykQiY6hSrQ1aW/xVRjI9B2wbRvGPzxHbG1Bkp8Fug2PY8mYyaP4o+s0UlShD17UvUvj1RqlQJ+p3mAkES/NbAbQNp/rH5Yrtw1sJ0bfQ1qfCkJlzan6eAXwe9FvvTm0+nYfWUCYYAAOYm+EewCJQ4YDpw/QAFhwZHO8YqhRXVL1FfBEwNSjagNCnT/PZ++e177J6xdOXJFbr39h49C3wW6fsTrxGN8dPwg3wJjt/68+Yl2rCBqGLFRD0+U4YgCX6LkwDLTitLfi+UZ1v3St1pRccVGo/lP6cm/zShff7KAmA8nXxkwBFU1QYAIBIzSl63vETAxJfmPn//HO0YnrXnmSUOmDgfNH3q/4oiqvv47SNlHPBfT7okCiKFWgpSm0dEW07GMphkyTgBlWjVKqKuXRP3wEwUgiSIE+7p5jzJmUJ+hoj9f//8l1qVahXtuMUnFlPfLX3FdibrTGJZarZ02fQ+XgAAQ8dNxbkNCgdMnPytyv9Ux+kKNQrXEAFTU6emop2TCr99d17TmdZfXK/x/gt/IrrjGYeB8MzSjh1EzZsn6vGYIgRJEGdrzq+hrmuVnzZsUtmQ/zh/ypMxj/R9/xf+5DrVVXTYZgf6HRDTxwAAEDuuS3f2wVna4b2DdvnukpqAq0uaJKlYHdfCpQU1c2omyrOwEx1q0KgvJ+iSbeTjeWbppwdRckUcgiQbG+7dQZQlizYfltFDkARxxn8qbivdaOtVZffp8vnL0+khp8UnnW+h36jU5FJ0981d8T1uHMl9kQAAIP4lWC4+vigKV/Is0/OP0Rvs8tL+cvnKUYsMLtRi8CLKHUx0IBfRiNJEN1WL1xREgRuIMvyMwy9NnpzI3Z1o2TKtPx5jhiAJ4r1iw3GiIz0NVNaxGNNwDE1sMpF6rO9BK8+uFF9zzOVIl0ZcMrpiZgAAhobfoq89vSaCJb7F1GC31HuiFk+Imj0lOpiLaHZJovJvibafiMcvS5mS6M0b5awSCAiSIN4uPbok2pZw0TT+NDO24ViasG+CtELDZ4wPFcpaSO5hAgCYFH67vvHqhjTDdOv1LY3HlfioDJhaPiEqFhTPX7JlC1EbZRspQJAECTTt4DQauWuk2E5CSUgh+gYSeXT2oC4Vusg8OgAA03f39F7yHNCEPPMS+cbQNWqkH9GUa3G8QwsLov79iWbN0uYwjRrWZUOCDK07lKoWqiq2VQFSm9JtqHP5zjKPDADAPBQOUtAoPyKf3USPthHNukxU9m3kY/bniscdhoUpq3ODJPl/mwBxx80aOffo1L1T0tdK5SllNH2CAACMHrca+b98X4n+vqG8vbQi2mlHdCsdUacH8bg/vrCkdp+AIAkSiIOjBccXRPraqN2jqHax2lQiZwnZxgUAYDYy/1czSV3OEKJ+mtOVfr/CLYb7NFe43AYJauLYflV7kUTIyuUvJ/7l+khtVrShkFBlwUkAANAhR0dljSNt4VkkFxft3Z8JQJAE8cKBkfs6d3oV9ErsVy9cnY4OPEoOOZVNb28H3KZB/w6SeZQAAGYgTRplUKOttk/8wbd6de3cl4lAkATxsuz0MtFviGW0zkgb3DeIZrdbe2wVy//Z8jPLxRJVAADQsb59lf3XEov7uFWtSlQI5VvUIUiCOLvx8gYN3DZQ2l/bea1UFr9wtsK0sM1C6Xvd1nej54HRq8QCAIAWtW5NVLCgMshJDA60Jk3S1qhMBoIkiBPOM2q7sq3Ul61fjX7U0KFhpGO6VuxKf5T6Q2wHhQRRu1XtRD8iAADQEUtLoo0blZfKEorzmvr1I6pYUZsjMwkIkiBOBm8fLFV35fyjGS1mRDuGl/8v77Bcanp77uE5mnxgst7HCgBgVkqXJtqwQRnsxDeRm49v2BAFJGOAIAl+a6fPTpGLxDjviPOPUlqk1HhsOqt0tLnbZlFHiU3aP4nO3D+j1/ECAJgdNzei/fuJMmSI26U3PoYDJK6w7emprLYN0SBIglhxXhGvZlPhvCPOP4pN+QLlaUJjZS+3CEWEuOz28dtHnY8VAMCs1a9PdO8e0V9/EaVO/V/tI179xgERb6twkvbZs0Tz5iFAigV6t0GMOJ+o+pzqdPbBWbHP+UY8ixSXqtrc/Lbm3JpSRe5mTs3Is5cnKnIDAOhDcDCRlxeRtzfRw4fKGkhcKNLZmahaNaICBeQeoVFAkAQxmrB3Ao3fN15sc56R31g/cTktrl59ekUlJ5SUZpGWtltKPav21Nl4AQAAtAmX20Cjs/fP0sT9E8U25xdxnlF8AiSWI30OWtN5jbQ/8N+BdPPVTa2PFQAAQBcQJEE0PPPTbnU7kU/EOL+I84wSorFjY+pTrY/Y/vHrh2hb8v3nd62OFwAAQBcQJEEkfPW1+/ru9OLjC7FftVBVGl5veKLuc1arWVQih7LpLZcR4HICAAAAhg5BEkSy4swKseSfZUidgTa6b5SW8ycUlwvghO9UKVKJ/aWnltIun11aGS8AAICuIEgCya1Xt2jAtgHSPucTcV6RNhTNXpQWtF4g7XNZAdVsFQAAgCFCkAQC5wm1WdlG5A0xziPifCJt6lapG7V0aSm2P4V8EvWTuFQAAACAIUKQBMLf2/+WVp5x/hDnEWkb10ha0WEF5c6QW+xz/aUpB6Zo/fcAAABoA4IkoN2+u2nJqSVim/OGYms7kljpU6enzd03U9Ikyj+9Cfsm0LkH53TyuwAAABIDQZKZ47ygrmu7SvucN8T5Q7pUoUAFGt9YWaSSywy4rXKjT98+6fR3AgAAxBeCJDPG+UDtV7cX+UGM84U4b0gfRtYfSZULVpYCNS47gOLvAABgSBAkmbGpB6fSmftnxDbnCXG+kL56q3FZgU3um0SZAebp40krz67Uy+8GAACICwRJZur8w/M0fq/ykhfnB3GeEOcL6VPODDlpdafV0n7/rf1FGQIAAABDgCDJDHH+j9tKN6ntCOcHcZ6QHJo6NaXeVXuLbS4/0HZlW7QtAQAAg4AgyUzbjjz/+Fzsc14Q5wfJaXar2VQ8R3GxfePVDRqyY4is4wEAAGAIkszMqrOrRP4P43wgzgtKbNuRxBJlB7r/V3bgn5P/0B6/PbKOCQAAAEGSGbn9+jb139Zf2ud8IM4LMgTFchSj+a3nS/tcluDlx5eyjgkAAMwbgiQzwfk+bVa0kfJ9OA+I84EMSY/KPai5c3Ox/fHbR1GeAG1LAABALgiSzMSQ7UNEvg/j/B/OAzI0XH5gZceVlCtDLrF/+v5pmnZwmtzDAgAAM4UgyQzs9dtLi08uFtuc98P5P5wHZIhUeVKqtiXj940X5QoAAAD0DUGSiXv16RV1WdtF2ue8H87/MWSVClaisQ3Him2+3MblCoJCguQeFgAAmBkESWbQdoTzexjn+3DejzEY1WAUVbKvJLa5XEGP9T3QtgQAAPQKQZIJm35oOp26d0psc54P5/voq+1IYiVPlpw2um+k9FbKKuDbvbfT6nP/VecGAADQNQRJJurCwws0bu84sc35Pep90oxF7oy5aVWnVdJ+v6396E7AHVnHBAAA5gNBkgni/B23VW7S8nnO7+E8H2PElwh7Vukptrl8AZcx4HIGAAAAuoYgycRw3g7n7zwLfCb2Oa+H83uM2dw/5lKx7Mpk8+svr9PQHUPlHhIAAJgBBEkmxuOch8jfYZzPw3k9nN9jzETbkh7/tS1ZdGIR7fPfJ/ewAADAxCFIMiGcr8N5Oyqcz8N5PaaAC2DyjJIKlzXg8gYAAAC6giDJRHCeTtsVbSnkZ4jY5zweVYsPU8GPqamjspVKYHAgdVjdAW1LAABAZxAkmYhhnsPI/6W/2Ob8HfVZF1PB5QtWd15NOdMrm/KevHeSZhyaIfewAADARCFIMgGcn7Pw+ML/2o70MNy2I4nFZQw4z0rVtmTs3rF08dFFuYcFAAAmCEGSkXsd9DpS2xGeQeL8HVNWpVAVGt1gtNjmy21tV7ZF2xIAANA6BEnG3nZkVXuRn8M4X0dVU8jUjWk4hioUqCC2udxBz4090bYEAAC0CkGSEZt5eKbIy2Gcp8P5OsbSdiSxuKzBpm6bKJ1VOrG/7eo2WnN+jdzDAgAAE4IgyUhdenSJxuwZI7Y5P4fzdIyt7Uhi5cmYR/SjU+m7pS/dDbgr65gAAMB0IEgyQp9DPos8HNXyd87P4Twdc9TSpSX1qNxDbHP5A7QtAQAAbUGQZGQ47+bPjX/S08CnYp/zcjg/x5zN+2MeFclWRGxzGYThnsPlHhIAAJgABElGZu2FtSL/htmkshF5OcbediSxrCytRNkDy+SWYn/B8QW033+/3MMCAAAjhyDJiNx7c4/6bO4j7XM+DuflAFHJnCVpzh9zpH0ui8DlEQAAABIKQZKRCP0VKvJtVG1HulfqTq1KtZJ7WAald9Xe1Nihsdj+EPwBbUsAACBRECQZieE7h5PfCz+xzfk381vPl3tIBofLH3h09qAc6XKI/RN3T9CsI7PkHhYAABgpBElG4MD1AzT/mDIo4rybLd23iDwciC6jdUba2G2jVC9q9O7RolwCAABAfCFIMnABQQHUeU1naX92q9nkkMtB1jEZuqqFqtKo+qPENl9uc1vlJsomAAAAxAeCJAMWERFBHTw6iPwa1sihEf1V7S+5h2UUxjUaR+XylxPbTz48QdsSAACINwRJBozzaY7fOS62s6fLTh6dPMym7UhicVmEzd02izIJbOvVrbTuwjq5hwUAAEYEQZKBuvz4Mo3eo+x0z4ERtx3JlCaT3MMyKnkz5Y3UtqTPlj6ijAIAAEBcIEgy4LYjYeFhYn9kvZFUrXA1uYdllLhMQrdK3cT2t9Bv4nnlcgoAAAC/gyDJwHDeTK9NvUQeDeO8Gs6vgYTjcgmFsxYW277PfWnEzhFyDwkAAIwAgiQDs/7ietpyZYvYTpsqrcirsUhuIfewjFpqy9SibUmK5CnE/rxj8+jgjYNyDwsAAAwcgiQDcv/Nffpr83+r11Z0WCHyaiDxuGzC7JazpX0uq8DlFQAAAGKCIMmQ2o6sbCPyZph7RXdqXbq13MMyKX2q96GGJRuK7fdf31NHj46izAIAAIAmCJIMxMhdI0W+DCuUtRAtaLNA7iGZHF4luKbzGspmk03sH7tzjOYc/a8pLgAAgDoESQbg0I1DNPfoXLHNeTNbu28VeTSgfVxGgcspqOpNcXB69clVuYcFAAAGCEGSzN58fkOd1nSS9me1nEWOuR1lHZOpq16kOo2op1zhxmUWuCzAl+9f5B4WAAAYGARJMuJ8GM6L4fwY1qBEA+pbva/cwzIL4xuNp7L5yortR+8fRUqYBwAAYAiSZMT5MEdvHxXbnCezpssatB3REy6rwOUVuMwC23hpI224uEHuYQEAgAFBkCQTzoPhfBjGgdEG9w2UOU1muYdlVuwy24kyCyq9N/WmB28fyDomAAAwHAiSZMD5L+ptR4bXHU41itSQe1hmicssdK3QVWwHhwaL/5efYT/lHhYAABgABEky4PwXzoNhrnauNKHxBLmHZNYWtl0oyi4w72feNGrXKLmHBAAABgBBkp5x3gvnvzDOh9nSfQvajsiMyy3w/4Oqbclsr9l05OYRuYcFAAAyQ5CkR5zvwnkvKsvaLRN5MSA/p9xONLPFTGmfVx2+/fJW1jEBAIC8ECTpCee5cL4L572wLhW6UFvXtnIPC9T0q9FPlGFg776+o04endC2BADAjCFI0hPOc+F8F1YwS0Fa2Gah3EMCTW1LuqyhrDZZxf6RW0do3rF5cg8LAABkgiBJDzi/hfNcpLYjPbaSdUpruYcFGnAZBvW2JSN2jqBrT6/JPSwAAJABgiQd47wWzm9RmdFihsh/AcPF5RiG1R0mtn+F/xKXSb/++Cr3sAAAQM8QJOkQ57NwXgvnt7D6JepT/xr95R4WxMHExhOpjF0Zsf3w3UPqs7mP3EMCAAA9Q5CkQ5zPwnktjPNc1nRG2xFjwWUZuCxAmpRpxP76i+ul0g0AAGAeECTpCOexcD6L1Hak6wayTWsr97AgHvJlzkfL2y+X9ntt7EWP3imLgAIAgOlDkKQDnL/CeSycz8KG1hlKNYvWlHtYkABcpqFz+c5iG21LAADMC4IkHeD8Fc5jYZzXMqnJJLmHBImwqO0isre1F9tXn16lMbvHyD0kAADQAwRJWsZ5K5y/wjifZXO3zWg7YuS4XAOXbbBIpvx/nHlkJnnd8pJ7WAAAoGMIkrSI81U4b0VlWftllN82v6xjAu1wzuMsyjeocFmHd1+UqxYBAMA0IUjSUduRTuU6kZurm9zDAi3i8g31iteT6l91WoO2JQAApgxBkpZwngrnqzDOX1nktkjuIYGWJU2alNZ2WUtZ0mYR+4dvHqYFxxfIPSwAANARBElawPkpnKfCOG9lS4//6uuAaeEyDhvcN0j7wzyHkc8zH1nHBAAAuoEgKZE4L0W97cj05tPJJY+LrGMC3apVtJYo68C4zEObFW0o+IfyMisAAJgOBEmJbTuyppPIT2F1i9elATUHyD0s0INJTSdR6bylxfaDdw+o75a+cg8JAAC0DEFSInA+CuelMM5T4XwVzlsB05cieYpIbUvWXlhLmy9vlntYAACgRXhHTyDOQ+F8FJX1XddLCb1gHri8w9J2S6X9nht70uP3j2UdEwAAaA+CpATg/BPOQ1G1HRlSZwjVLlZb7mGBDNqVbUcdy3WM3I4mTPl3AQAAxg1BUgJw/gnnobBSeUrR5KaT5R4SyGix22IqYFtAbF95coXG7h0r95AAAEALECTFE+edcP4Js7a0Fsv9OT8FzBfnJam3LZlxeAYdu31M7mEBAEAiIUiKB8434bwTlaXtl0ozCGDeuOzDtObTxLZCoaAOHh3o/df3cg8LAAASAUFSHHGeCeebcN4J61C2A7Uv217uYYEBGVhzINUpVkdsv/n8hjqv6SwCJgAAME4IkuKI80w434Tx7NE/7f6Re0hgYLj8w7qu68g2ja3YP3jjIC08vlDuYQEAQAIhSIoDzi/hPBOWPFnySPVxANRxGQguB6Ey1HMo+T73lXVMAACQMAiSfoPzSji/RHXZZFqzaVQqbym5hwUGrE7xOvR37b/F9s+wn2hbAgBgpBAkxYIDI84r4fwSVrtobRpUa5DcwwIjMKXZFKmH3/2396n/1v5yDwkAAOIJQVIsOJ+E80oY55lwvgnajkB82pZwmQjmcd6Dtl7ZKvewAAAgHvCOHwPOI+F8EhUOkLLaZJV1TGBc7LPY05J2S6T9Pzf+SU/eP5F1TAAAEHcIkmJpO8L5JGxw7cFUt3hduYcFRqhDuf9KRXz5/oXcVrmhbQkAgJFAkKQB549wHgnjvJKpzabKPSQwYv+4/UP5M+cX25ceX6Lx+8bLPSQAAIgDBElRcN4I54+w1JapRV4J2o5AYqRNlVb8HXH5CDbt0DQ6ceeE3MMCAIDfQJCkhvNFOG9EZYnbEpFXApBYpe1KSzOSvGqy/er29OHrB7mHBQAAsUCQ9H+cJ8L5Ipw3wtq5thP5JADaMrjWYKpVtJbYDvgcQF3WdkHbEgAAA4Yg6f84T4TzRVi+zPnEqqQkSZLIPSwwIVw+gqtxZ06TWezvv76fFp9YLPewAAAgBgiSiER+COeJqLcd4TwSAG3jMhLruqyT9v/e8Tf5v/CXdUwAAKCZ2QdJnBfC+SGqyx5Tmk6hMnZl5B4WmLB6JepJldtVbUu+hX6Te1gAABCFWQdJHBhxXgjnh7CaRWpKPbcAdImTuJ1zO4vtu2/u0oBtA+QeEgAARGHWQRLng3BeCOM8Ec4XQdsR0AdLC0txWZfLTLBVZ1fRv1f/lXtYAACgxmwjAs4D4XwQlbVd1lK2dNlkHROYl4JZC4pCkyo9NvSgpx+eyjomAAAw8yCJ8z/U244MrDmQ6peoL/ewwAx1LNeR3Mq4ie3P3z+LMhRh4WFyDwsAAMw1SOL8D84DYU65nWhac+XKNgB94zITS9svJbtMdmL/4qOLNGHfBLmHBQAA5hgkcd4H538wzgfZ2n2ryA8BMJS2JVMOTqFT907JPSwAALNnVkES53tw3ofK4raLRV4IgNxc87nS5CaTpVWX7Va1Q9sSAACZmU2QxHkenO/BeR+sbZm21Kl8J7mHBSAZUmeIKEPBXge9Jvd17mhbAgAgI7MJkjjPg/M9GOd/LG23FG1HwCDblmSyziT29/rvpSWnlsg9LAAAs2UWQRLnd3Ceh3rbERsrG7mHBRANl6FY1/W/tiWD/x1M119el3VMAADmyuSDJM7r4PwO1WWLSU0mifwPAEPF5SgG1FRW4A4NCxXlKkJCQ+QeFgCA2THpIIkDI87r4PwOVqNIDRpaZ6jcwwL4renNp5NjLkexfSfgDg38d6DcQwIAMDsmHSRxPgfndTDO80DbETAWXJZia4+tZJXCSuyvOLOCdnjvkHtYAABmxWQjBs7j4HwO9bYj2dNll3VMAPFRKGshWuy2WNrvvr47PQt8JuuYAADMiUkGSZy/wXkcnM/B+tfoTw1KNpB7WADx1rl8Z2pTuo3YDgoJEvl1aFsCAKAfJhkkcf4G53EwzuuY0WKG3EMCSBAuU7Gs/TLKmzGv2D//8DxN2j9J7mEBAJgFkwuSOG+D8zcY53Pwcn+0HQFjxuUq+O84WdJkYn/ygcl0+t5puYcFAGDyTCpI4nwNzttQWdR2ERXOVljWMQFoQ9n8ZUX5ChahiKD2q9tTYHCg3MMCADBpJhMkcZ4G52tw3gZrXbo1danQRe5hAWjN0LpDqXrh6mL75aeX1G1dN7QtAQDQIZMJkjhPg/M1GOdvdCvcjdq3b0+5c+cmS0tLsrW1pfLly9OcOXPo27dvdPnyZWrYsKH4fqpUqcQxBQoUoL59+9L79+/lfjgA0fDltg3uGyijdUaxv9tvNy07vUzuYQEAmKwkChP4KMr5GdXnVBeXIfiNpHvW7rR80vIYP2X7+vrStWvXqHv3/y7NqStWrBhdv34dNZXAIO3z30eNFzcW25bJLenqqKtUImcJuYcFAGByjD4K4LwMzs/gAIm1LtCalk1cJgIkKysrWr16NQUFBVFwcDAdP36c6tevL44rVKgQbdy4kV68eEE/fvygM2fOUMaMyk/ot27dIn9/f1kfF0BMGjk0or7V+4ptLnPRdmVbtC0BANABo55J4qE3X9JcXHZg1QpVo8CNgXTdX9kQdOnSpdSzZ89oPxceHk7JkilXCqlr0aIF7dy5U2zfuHGDihcvrvPHAJAQP379INeprlLz255VetLS9kvlHhYAgEkx6iBp6aml1HtTb7HNeRpHex0l50LOYj9NmjQUGBhIFhYWv72f0NBQkaPUrFkz+vjxI1WqVIlOnz4tatQAGCquBeYy2YW+//wu9j17eVJz5+ZyDwsAwGQY7eW2Gy9v0MBt/zX9XNN5Df389FPaz5cvX5wCpJQpU4pblSpVRIBUtWpV2rdvHwIkMHhFshWhhW0WSvvczPl54HNZxwQAYEqMMkji/AvOw1C1HeH8DM7T0EZgc+rUKWrSpAmFhaH1Axg+94ru1Mqlldjm8hecn4e2JQAAZhwkDd4+mG69viW2S+YsSTNbzhTbvJxf5fHjx3EKdDhp+/v373T16lUqUUK5Qogvte3Zs0dn4wfQFv5gsKLjCsqTMY/YP/vgLE05MEXuYQEAmASjC5J2+uyUasOkSpGKtvbYSiktUor9rFmzkoODg9j++vUreXh4aLwPTtxWx5fbSpUqRe7u7tLXHjx4oMNHAaA96azS0eZum6W2JRP3T6Sz98/KPSwAAKNnVEES51tw3oUK52NwXoa6cePGSduDBw+mtWvX0pcvX0QByRMnTogSALxyjb934MABCggIEInbfn5+4lj1nCYAY1G+QHka32i82OZyGO1Wt6OP3z7KPSwAAKNmNKvbOM+CC0by5QTGeRjb/tymMQ9p6tSpNHr06FiLSTZt2pSePXum8fs8q3T+/HlKkSKFlh8FgO6ER4RTjTk16PR9ZfNbXum2o+cOLEIAADD1mSTOs1AFSJx/wXkYMb34jxw5ki5cuEBt27alnDlzimAnU6ZMVLZsWZo1axbZ29tTjx49qFy5cpQ5c2ZKnjw5WVtbk7OzM02aNIlOnjyJAAmMDl9u2+i+kTKkziBdml5xZoXcwwIAMFpGMZPE+RVVZ1eV2o6cGXJGXF4AgOj2+O2hpv80Fducr3dt1DUqlqOY3MMCADA6Bj+TxHkVnF+hajvCeRcIkABi1sSxCf1V7S+pMneblW2kgpMAAGAiQRJPcnVf351efHwh9qsUrEIj6o+Qe1gABm9Wy1lUIoeypMXNVzfp7+1/yz0kAACjI9vlth8/w+hBwGd69PYLffsRRsmTJaVcGVNTwezpKFNa5ZL+5aeXU8+Nyt5rnGfhP9afcmbIKcdwAYzO7de3qdSUUtIs0q7eu6ipk/IyHAAAGGCQ9OJDMHleekzHrr+iX+ERxLnXSZMkIR5FxP+HUjx3enLM/4t6bK4rLhew3X/tFpcRACDuOHH7zw1/iu30VunJf5w/5cqQS+5hAQAYBb0FSeERCtpx8TGtO3VP2o+JQhFKF98MouBfyiX6nF+x2G2xPoYJYFL49G61rBV5+niK/coFK9OJwSekwpMAACBzTlJ4RATN2OVLHifuiuAotgCJ3f3kIQVINpZ2NLCGskgeAMQPl8lY2XGlNHt05v4ZmnpwqtzDAgAwCnoJklYcvUOnbwfE6dh3IRfpRfABsZ00iSWVyDCUxm/1p5BQNO0ESIj0qdOLtiVJkyhP9/F7x9P5h+flHhYAgMHTeZDk9+QD7b7yNE7H/gh7Tzc/LpD2C6fvTlYWuejD1x+08thtHY4SwLRVtK9I4xopW/ZwOQ23lW706dsnuYcFAGC+QRLnQyzzuk1J49AVQaEIpxuBcygsIljs26YqTzlS1xHbfHXuoM8Lev5B+T0AiL9RDUaJnCT2/ONzUV7DCGrJAgCYZpB091UQPXn3VQQ5v/Pky3b6FHpTbKdMlpmKZewXqe0Ir4A74K251xoAxL1tCa9yY5zMversKrmHBQBgnkHS5QfvKFkcppF4Funpl53SkEpk/JssklpHOobLA5y/+0ZHIwUwD5zAvbrTamm//7b+op4SAADoOUi69zqIIuIyjURJKW0Ke0pCSalQOndKn1Jzn6n3X37Q1++/tD5OAHPSzLkZ9araS2xzock2K9pI9cgAAEBPdZLcl5yil4Hf4nQsDyNM8S3aDJLKr4hvFPLrFbWubE02VslE5WBVt3MAiB8OjkpPKU23Xt8S+32q9aFFbovkHhYAgPkESV3/OUWvPsYtSIrq5dcj9PLbEVIowig0/CP9jAiK9P1O5TrR2q5rtTRSAPPDPd04UFLNIu35aw81dmws97AAAMzjcputjbIHW3z9igih258W0Zef9+nrr8fRAiSWOU1mLYwQwHwVz1Gc5v0xT9rvsrYLvfr0StYxAQCYTZDEzWrjkrgdVTKypKRkofF7qS1TU73i9ahG4Rr0Kwz5SQCJ8WeVP6mZUzOx/fHbR2q/uj2FR4TLPSwAANO/3Hbz+UcavO5ign72y8/HdO3dSKlukibprNJRY4fG1MK5BdUuVptSWiRs5grAnHFw5DDBgV5+ein2JzedLGoqAQCYO50GSXzXPZadoReBwZSQ3xIS9oauvR1BP8Lfi32rFKkpQhGucSWOtaU1NSzZkFq4tBAzTTzjBABxwz3dqs2uJqpxcz2lM0POUPkC5eUeFgCA6QZJ7Nqj9zRq85UE//z3sLd07e1I+h7+VuyXylOKhtUdRjt9d9L+6/vp64+v0X4mVYpUVLdYXTHDxIGTjZVNoh4DgDngnm4T9k0Q23ky5iG/sX5ithYAwFzpPEhiCw5cp0M+Lyghv4grbadIEUQ3Po2hJx8ei2X/b2a/IYvkFmJG6djtY6Jy8B6/PfQpJHovqhTJU1CtIrXEDBNfmstonVErjwnA1ISFh4nZpHMPz4n9Vi6taNuf2yJVvgcAMCd6CZLCwiNo0g4funz/bbwCJU76tk5pQbM7laOUKULI47wHVbavrPEyACdxn7x3UgRMu3x30fuv7zXcXzKqVqgatXRpKeosZUmbJZGPDMC0PA98Tg4THSgoRLmidFXHVeReyV3uYQEAmG6QxMIjImjz2Ye0+ewD8ck0PJZK3PzBlUflkDcj/d3YgWxtUsXzd4XTuQfnRMDEt9dBrzX8jiRUyb6SuCTX3Kk55cyQM0GPC8DUeHp7UstlLcW2VQorujb6GhXJVkTuYQEAmG6QpPL47RfafuERnb4dIAIlvpzGVQJ4EKrAyT6bDTV3taNqxbMneqo/IiKCLj+5rAyYvD3paeBTjceVzVdWBEx8s8tsl6jfCWDsem7oScvPLBfbDjkd6NLIS1g9CgBmR+9Bkgr3YOPebo/efKFvP35R8mRJKVem1KK2Uo4MulmZxg/V97kv7fDeIYKm+2/vazzOKbeTFDAVzlZYJ2MBMGQhoSGiGvftAGXz2341+tGCNgvkHhYAgHkESXLjh819q3h2iQOmG69uaDyuWPZiyoDJpQWVyFECSaxgNm68vCECpdCwULG/t89eauTQSO5hAQDojdkGSVHdf3NfymHyfuat8ZgCtgWkGaZSeUshYAKTt+TkEvpr819im1eGXh93nbKnyy73sAAA9AJBkgZPPzylnT47RcB04dEFjcdwHRlO+OYZpnL5ylHSpDrt8AIgC355aLakmSixwXh16NFBR8VKUQAAU4cg6Te44SeXFOCAiasSc0XiqLLZZBP9r3iGqXLBypQ8WXJZxgqgC4HBgaJtyasgZfPbqc2m0oj6I+QeFgCAziFIiod3X96JT9QcMB2/e1wU34sqk3UmUYOJA6bqhauLYpYAxu70vdNUbU41MbPEs0jnhp6jsvnLyj0sAACdQpCUQJ++faK9/ntFwOR1y0tKblXHLR0alWwkLsnVLlpbtEsBMFZj94ylSfsnie28GfOKtiVo+QMApgxBkhZw/7gD1w+IgOngjYMU8jNEYwPeBiUbiBkmbsBrndJalrECJBTPnFaZVUXK02tdujVt6b4FCxgAwGQhSNJBfZnDtw6L0gL7ru/T2ICXi/JxA15uj4IGvGBMngU+E/lJn79/FvsenT2oS4Uucg8LAEAnECTpUOivUDp6++hvG/DWLFJTzDA1cWyCBrxg8LZf205/LP9DalviM8aHCmUtJPewAAC0DkGSnnAD3lP3T4kZJl4t9+7ruxgb8HLAxMnfWW2yyjJWgN/psb4HrTy7Umw75nKkSyMukaWFpdzDAgDQKgRJMlBvwMv1mFRLq9VxnkfFAhWVDXidm1OuDLlkGStATJeVS00pRXcC7oj9ATUH0LzW8+QeFgCAViFIkhk34L3y5IpU7fvJhycaj3O1cxWr5Dhoypc5n97HCRCV/wt/cp3qKq3s3N93v1icAABgKhAkGRBVA15VwHTvzT2Nx/HlDVU/uSLZiuh9nAAqi08spr5b+ko1wrhtSbZ02eQeFgCAViBIMlD833L79W0pYLr+8rrG44pmKyrNMJXMWRLLsUHvf6dN/mlC+/z3if0aRWqQ1wAvtOkBAJOAIMlIPHj7QBkweXvStWfXNB6TP3N+aYapdN7SCJhALz58/UAOEx3oddBrsT+9+XQaVm+Y3MMCAEg0BElGWqtG1YD3/MPzGo/JnSG3SPjmoKl8/vL4ZA86dfLuSaoxt4aYWeLehdy2xDWfq9zDAgBIFARJRo4/vYsGvN6edPr+aY0NeLmUgKoBb5WCVdCAF3Ri9K7RNOXgFLFtl8mOfMf4olAqABg1BEkm5P3X97Tbd3esDXi5WGVTR2UDXs4fQQNe0GYtsCqzq9DFRxfFftsybWlTt0247AsARgtBkgk34OVkWg6Yjtw6orEBr00qG2rk0Ei0R0EDXtCGpx+eivykL9+/iP21XdZSp/Kd5B4WAECCIEgyA3FpwJvaMjU1KKFswFu/RH004IUE23Z1G7VZ0Ub6u/IZ7UMFsxaUe1gAAPGGIMkMKyXzzBIHTNyAV/WJX1MDXl4l16hkI+SVQLx1W9eNVp9bLbadcjvRxeEX0bYEAIwOgiQzb8B77M4xqQHvx28fox1jkcwiUgPeTGkyyTJWMC7fQr+Ry2QXqSDqoFqDaM4fc+QeFgBAvCBIAinpllfHccDEq+XefnmrsQFv1UJVRcDEq+XQgBdi4/fcj1ynudLPsJ9i/2C/g1SvRD25hwUAEGcIkkBjA16uv6RqwPvy08tox/CKpQr5K4hLcs2dmlPujLllGSsYtoXHF1L/rf3FduY0mUXbEgTXAGAsECTBbxvwXn16VWqP8vj9Y43HlbEro6z27dyC8tvm1/s4wTDxy0ujRY3owI0DYr9W0Vp0uP9hFDcFAKOAIAnijP9U/F74icKVHDDdfXNX43EOOR2kfnJFsxfV+zjB8Op3OUxwoIDPAWJ/ZsuZNKTOELmHBQDwWwiSIMG4Ae8O7x2xNuAtkq2INMPkkMsBhQXN1PE7x6nWvFpS25ILwy5QabvScg8LACBWCJJAKx6+eyjNMPHlOU3yZc4nBUx8eQ4Bk3kZuXMkTTs0TWrG7DPGh9KmSiv3sAAAYoQgCXTagPfCowti9iCqXBlyiYRv0YC3QHmxcg5MfwVlpZmV6PKTy2K/fdn2tMF9g9zDAgCIEYIk0KmAoABlA14fTzp17xQa8Jq5J++fkOMkR6mI6fqu66lDuQ5yDwsAQCMESaDXBF4uWika8N45Tr/Cf2lswNvEoYlI/OYilmjAa3q2XN5CbqvcxLa1pbW47GafxV7uYQEARIMgCWQRFBIkNeA9fPOwxga8nK/S2KGxmGGqU6wOGvCakK5ru9Ka82vEtkseF7ow/AICYgAwOAiSwCAa8HLjXU78PnjzoGhpERU3Sq1fvL6YYeJGvGjAa9yCfwSLtiX3394X+3/X/ptmtZol97AAACJBkAQG5fvP71ID3r3+ezU24LVMbkl1i9cVM0yNHBpROqt0sowVEsf3uS+VnVZWalvCRSbrFK8j97AAACQIksCgG/Aev3tczDDt9tsdYwPeGkVqiICpqWNTNOA1MvOPzaeB2waKbds0tnR9/HXKkjaL3MMCABAQJIFRCAsPEw14uXhlTA14kyZJGqkBb7Z02WQZK8Qdv/w0XNRQXG5lnHvGjXDRtgQADAGCJDDKBrwXHl6Q+snF1IC3fP7yUvFKNOA1XO++vCOHiQ705vMbsT+71WwaXHuw3MMCAECQBMaN/3y5wreqPUpMDXhL5y2tDJhcWlAB2wJ6HyfE7tjtY1R7fm3x/8mXUHm1W6m8peQeFgCYOQRJYDL4T9n/hb80w3Qn4I7G40rmLCkCppYuLdGA14AM9xxOMw7PENscyHL9pDQp08g9LAAwYwiSwKQb8IqAyduT/F/6azymcNbC0gyTYy5H9JOTuW1JxZkV6cqTK2K/Y7mOtK7rOrmHBQBmDEESmE0DXlU/OdWbcFRowCu/R+8ekdMkJ1E7i3FvN+7xBgAgBwRJYHaeBz6nnb47xQzT+UfnNTbgzZk+JzV3VjbgrVCgAhrw6tHmy5up3ap2UtsSv7F+lN82v9zDAgAzhCAJyNwb8HINJk785hIDvHIuKq7bo96A1yK5hSxjNSedPTrTuovrpKT7c8POoW0JAOgdgiSA//vw9YPUgPfYnWMaG/BmSJ2Bmjg2EQETN+C1tLCUZaymji+3uUxyoQfvHoj9oXWG0oyWyqRuAAB9QZAE8JsGvNwm5cevHxob8DYq2UhqwGtlaSXLWE2V9zNvKjetnBSsHhlwhGoXqy33sADAjCBIAohDM1bRgNfHkw7cOKCxAa9VCiuqX6K+CJgalGyApetaMtdrLg3ePli67Hl93HWyTWsr97AAwEwgSAJIYANenmn6/P2zxga8PLOkasCbPnV6WcZqCiIiIqjBogZ0+OZhsc+NjQ/0PYC2JQCgFwiSABKIu9cfv3NcBEyc/B0YHBjtmOTJklONwv9vwOvUlDKnySzLWI0Z9+lzmOAg9eub+8dcGlhL2RQXAECXECQBaLEBLwdM3IBX1YcsagNeXh3HhSt5tVz2dNllGasx8rrlRXXm1xHb3Lbk0ohL5JzHWe5hAYCJQ5AEoGVcRuDio4tSe5QXH1/E2oCX6zHlyZhHlrEak6E7htKsI7PEtr2tvWhbYp3SWu5hAYAJQ5AEoIcGvFy4kgOmR+8faTyuVJ5SYoaJgyb7LPZ6H6exXN6sML0CXXt2Tex3Lt+Z1nRZI/ewAMCEIUgC0BM+1a6/vC71k7sdcDvWBrx84wa8aI8Sub2M00QnCg4NFvubum0iN1c3uYcFACYKQRKATO4E3JFmmPxe+Gk8plDWQlLA5JTbCQETEW28tJE6rO4gtrnUArct4b57AADahiAJwEAau6pymGJqwGuXyS5SA15zXgbfcXVH2nBpg9jm5+Lc0HNoFwMAWocgCcDAcKL3Tp+dImA69/Ccxga8OdLlkBrwVrSvaHYNeLltifMkZ3H5jQ2vN5ymNZ8m97AAwMQgSAIwYFxKgEsKcMB06t4pjQ14bdPYKhvwurSgqgWrms2MyrWn16jc9HKi/AJfhvQa4EU1i9aUe1gAYEIQJAEYUQPevf57RcB09PbRGBvwNnZoLGaYahWtZfINeGcfmU1DdgwR21ltsoq2JSjYCQDagiAJwEgb8O6/vl8kfh++dTjGBrwNSzQUM0x1i9U1yQa83Lak3oJ65HXbS+xz/7z9ffcjwR0AtAJBEoAJNOA9dPOQsgHv9QPS8vioDXjrFa9HLV1amlwDXr4kyW1L3n19J/bnt55P/Wv2J0Nz+fJlWrhwIZ09e5bevn1LNjY2VKBAAWrRogX17NmTUqdOLR377t07KlSoEAUFBYn9YcOG0fTp02UcPYB5QpAEYGINeHlWhWeY+NJcTA14axerLS7J8aU5U2jAyw1weUaJpUieQrQt4ZIJhmLatGk0atQojUn4zNfXlxwdHaX9zp0707p166R9BEkA8jDfNcQAJihVilTUxLEJrXdfT+/mvqND/Q9Rt0rdKJN1JumY0LBQ2ue/jzqv6Uy2g22p7vy6tPLMSnr/9T0Zq7rF69Lg2oOlytxtVrQRM2yGYNeuXTRy5EgRIFlZWdHq1avFDFFwcDAdP36c6tevH+n4c+fO0fr16yPNLAGAPDCTBGAGeAXYmftnxCW5nb47Y2zAW7lgZamfnLE14OXgqPz08uT9zFvsd63QlVZ3Xi33sMQMkb+/v9heunSpuLQWVXh4OCVLlozCwsLI2dmZbt68SVOmTBHBFcNMEoA8ECQBmBlOdr74+CLt8N4h6jE9//hc43HqDXjzZspLxuDB2wfkNMmJvoV+E/tbum+hNmXayDaeN2/eULZs2cR2mjRpKDAwkCwsYi7RMG/ePBo0aBC5u7tT+/btqVq1auLrCJIA5IEgCcCM8enP9YZU1b5VxRmjcsnjIlX7Lpi1IBmy9RfWU6c1naQVfn5j/Mgus51sydply5YV2w4ODuTnp7n9DAsICKDChQtT8uTJ6d69e2I2CUESgLyQkwRgxnipfGm70jS9xXS6P/k++Y/zpzENx1DRbEUjHceXsEbuGkmFxhSikuNL0oS9E+jmq5sxJiLLqUO5DtTOtZ3Y/vL9C7mtcqNfYdFrSulDfEoRDB48mL58+SKSvDNl+i+HDADkg5kkANDobsBdaYbJ97mvxmMKZimonGFyaUHOuZ0Npj4RB0d82e3x+8dif2T9kTSl2RTZL7d9/PhRzBRF9fDhQ7K3t6e8efOSp6en6Mt37do16t69u/h+ly5dqF+/flSiRAmRuwQA+oEgCQB+i4MNETB5e9LlJ5c1HpM3Y14RLHHQ5GrnKnsDXm4UXGFGBaltybGBx6h6keqyJm4vX76cevToEe0Yb29vKlWq1G/v69OnT5QuXTqdjBMAokOQBADxbsCr6id39sHZGBvwcj85Ll4pZwPemYdn0jDPYWI7m0020bYkU5pMei8B0Lx5c7FtbW1NixYtEvs8I8Q5S7Nnz6apU6eSk9Pv6zohSALQLwRJAJBgXEpgt+9uETCdvHcyxga8TZ2aihmmaoWq6bUBL6/kqzO/Dh27c0zsNyzZkPb22av3y4IcBI0ePTrOxSTZqVOnkLgNIDMESQCgFYHBgcoGvN6edPTOUVG3KKr0VulFsUt9NuANCAogh4kOUrHMhW0WUt8afUnfLl26JLUl4bYjadOmldqS9OrVK1rxSARJAPJDkAQAWvc55LOyAa+PsgEvt0uJivvH8cwOB0zcV06XDXgP3jhIDRY2kNqWXBl5hRxyOejs9wGAaUCQBAA6xYUdRQNeb08ROGlqwMvtVOoXry8CJm7Ay/WNtG3QtkE079g8sV04a2G6NvoapbZMLQI665TWsuVNAYDhQpAEAHrz49cP8rrlJWaY+NJcUIiyy706numpXfT/DXgdG1OG1Bm08rtDf4VSuenlpHIG3NOuU7lOImeJW7D4j/XX6WwWABgfBEkAIAvOWTp59yTt8Nkhkr8/BH+IdkzyZMmpeqHqorRAU8emZJvWNlG/8/6b++Q82VlqW9KmdBvaenWr2PbstZsK21amFx+CKSw8glKntKD8WdJSjoypKamB1H8CAP1CkAQAsuNaRlxOQDTg9dlJAZ8DNDbgrWRfSeonlyN9jgT9rrXn11KXtV3EdiqLVPT9lzJfqmC6zpQ3bctox6e1SkENnHNTo1J5KGOalAn6nQBgnBAkAYBB4WX7lx5fEg14OWiKqQFvufzlpH5ycW3AO+PQDHG/oWGhdOPVjUjfy2ZVjUpkGqzx55ImIbK0SEa96hSj2g45DaayOADoFoIkADBY/PLEfeNU1b4fvHug8ThuiaJqj1Ioa6EY7y9dv3T0+fvn/+9xRfAI6XtpUxSgslnn/3ZMTUrnpV51iiJQAjADCJIAwCjwSxU31VXNMN16fUvjccVzFJdmmHhbPZiZ4zVHVODWVPQyKVlQjVyelCTJ79updKhSkNpXtk/kIwIAQ4cgCQCM0r0398TsEgdMPs99NB5jb2svWqOoN+CdvOsQ/XNqBr0JOcOhV6TjK2RbRqktcv72d3PctbBrBSqYHS1CAEwZgiQAMHpP3j9RXpLz8RT5TDE14K1TtBH53s9NNikKUfCv5/Tw8wZ6//2/hr3OmSdSplTOv/19nKNUKEc6mt+lglYfBwAYFgRJAGBSXn58KTXgPfPgjMZ+aZbJMpBtqvKUxao8hUf8pPtBqylV8izklHlsnC63qSztUYnyZdF+4UsAMAwIkgDAZL398lZqwHvi7gmNuUgWSW3INlVZETBlSOlISZPErfI2105qV9keuUkAJgxBEgCYhReBb6nezOn0NuQ8Bf7wJQWFRTsmU8rS5Gw7Lk73x3lJrgVsaUKb0joYLQAYguRyDwAAQB/CwlJRDuua4hYWEULvv1+htyEX6MMPb4pQhIpjgkJvictzcVnezx8vX30K0cPIAUAuCJIAwCxEqM2ZJ09qRdlSVxW3sIgfFPjDmz6H3qOMqVziVf8IE/EApg1BEgCYhQzWlhq/njxpSspiVUHc4gttSgBMW9yXcQAAGLH01pZkY5VCa/eXLGkSKpjNRmv3BwCGB0ESAJiNMgUyi+BGG8IjFOSSP7NW7gsADBOCJAAwGw1L5RXBTWJxmJUtvRU55s2olXEBgGFCkAQAZqNQdhsqWzCLqHGUGBxmuVcvjCa3ACYOQRIAmA0Oavo3KE6pUiQTrUUSgn+uStFsVKloNm0PDwAMDIIkADArGaxT0rT2rmRpwYFSkngHSEVzpadBjR10Nj4AMByouA0AZunpu680bacvPXv/VVw+iw0HUxEKBTV0yU09ahUVARYAmD4ESQBgtsLCI2jv1ae08/ITev/lh2g1oj67pErydrLLSG0r2pMDErUBzAqCJAAwezxLdOflJ7r/+jO9CAwWwVPqlBaUP0taKp4rA2VNbyX3EAFABgiSAAAAADRA4jYAAACABgiSAAAAADRAkAQAAACgAYIkAAAAAA0QJAEAAABogCAJAAAAQAMESQAAAAAaIEgCAAAA0ABBEgAAAIAGCJIAAAAANECQBAAAAKABgiQAAAAADRAkAQAAAGiAIAkAAABAAwRJAAAAABogSAIAAADQAEESAAAAgAYIkgAAAAA0QJAEAAAAoAGCJAAAAAANECQBAAAAaIAgCQAAAEADBEkAAAAAFN3/AIvhwuJdjQJLAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkkAAAJOCAYAAACjhZOMAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmDZJREFUeJzt3QVYU+8XB/CjgiiKqNjdrZTd3d1ii50/u7s7f3a3P8VOxO6g7E4URTERRYH9n/Puv+uAgSDb7uL7eR4e74XLeDd3t7P3nvecBAqFQkEAAAAAEEHCiLsAAAAAwBAkAQAAAGiAIAkAAABAAwRJAAAAABogSAIAAADQAEESAAAAgAYIkgAAAAA0QJAEAAAAoAGCJAAAAAANECQBmID169dTggQJxFflypXJEEyYMEEaU6dOnXT6t8aMGSP+TqJEiejhw4ex+h3V2Pjr2bNn0vdz5Mghff/06dM6HDUYik+fPlGKFCnE/3n79u3lHg4YEARJWqT+4hqbL/UX4O3bt1O1atUoTZo0ZGlpSalTp6a8efNS/fr1afTo0fT58+cIf0vT7SVMmJBSpkxJpUuXpgULFtDPnz/1fn8tLCzIzs6OKlSoQEuWLKHQ0FCSA99/fpPmL/U3QGO1d+9e6f7gjTsiPz8/mjdvnthu2bKlOG8MIWhV/X/5+PjIPRyj9/79exoxYgQVK1aMbGxsxOtMqlSpqGzZsjR//vwor3XqHxqi+woKCpKO59fN3r17i+0tW7aQp6en3u8jGCju3QbakT17du6DF+uvU6dOid8bNGjQH499+PBhhL8Vm9svW7as4sePH7Le33bt2uns78d2bKrH2Zh17NhRuj/jx4+P8vO3b98qzp07J75u3LihMAQ8TtWYefy60q9fP+nvnD9/Pta/p/48ffr0qfT9a9euSY/lp0+f/mpMlSpVkm573bp1f3UboMT/Bzlz5ozxdaZOnToRfocf8z+9Nn39+jXC77x48UKRIEEC8bNGjRrp+V6CobKQO0gzJbt27aIfP35I+2vXrqV169aJ7QwZMtDOnTsjHF+0aFF68uSJ+CTE+NPNkCFDqGrVqmI26fnz53Ty5Ek6cOBAjH931KhRVKdOHfr27Zv4FLRp0ybx/YsXL9Ly5ctpwIABpGudO3emLl26UGBgIM2aNUv8bbZ582aaOXMmZcqUSedjMGfp0qUTX+aGn/MbNmwQ29mzZxczC/FVvHhxLYwMtIVfN58+fSq2eQZpzpw5VLhwYTH7vmbNGvH9I0eO0N27d6lgwYLRvj5GZm1tHWE/a9asVK5cOTp//jwdPHiQXr16RZkzZ9bZ/QIjIXeUZsrUP0nzzIYmO3bskI5xdHTUeAzPBv38+TPC99Q/Eal/Ug0LC1PkyJFD+pkuPxGpz9aoz27wJ3H18V26dCnC74WHh4sxV65cWZEqVSqFhYWFIn369IqGDRsqPDw8IhzLn/DVbyu6T4v8yT3yY67pS32cgYGBijFjxiiKFSumSJYsmSJJkiSKQoUKiWMif8r8k3379olPs2nTphX3x87OTlGjRg3Fzp07Y3zc+P7OnDlTkSdPHkXixIkVuXLlUsyYMUP8PzKeBYvp/qjut6bHIvLv89+9d++eom7duuL+8lj79u2rCA4OVnz58kVsp0uXTjwOFSpUEP+P6ni/bdu2iiJFiijSpEkj7mfy5MkV9vb2inHjxkV5zGKaSQoNDVUsX75cUb58eUXKlCkVlpaWimzZsim6du2qePLkSawfd358VX+jZ8+eGo85efKkokyZMuJ+8f3r1auX4uPHj9HOJEU3C3n37l2Fi4uLIkuWLGK81tbW4th69eopFi5cGOX/QdOX6nGI72PJM2ZVqlQRY0iRIoWiZcuWYjYxMn9/f8WwYcMURYsWlZ7jPCvDM7yRjz927Jg4B/lc5PvH42rQoIHi7NmzcZr1Uc3CxeYrNmbPni3dd2dnZ+n77969i/DY+vj4SD9T/3+Iy0ze9OnTpd+bP39+rH8PTBeCJJmDpKNHj0rH8Avl5MmTFTdv3pTeJKMTXZDE+E0/umloOYKkly9fRnhzbNy4cYxvJFOnTtV5kMSXL/nNLrrj+M2Lg6i4Xu7R9NW9e/doHzcOymL6HW0GSRyMcJAQ+TaaNm2qKFWqVJTv85skB08qy5Yti3Es/Ab269evPwZJHJTxG3x0t8PjvHLlSqweew7sYnoz5Dd+Pq8i/w3+QBKXIOn9+/eK1KlTRzvm/PnzxylIis9jyUGOpvtUq1atCPedz0MO1qP7G97e3tKxw4cPj/a4hAkTivHGxp+er5G/YoPHqboMxvd7wYIFiuPHjytcXV2l23FwcBCvLSrq/w8ZMmRQJE2aVHwVLlxYMWrUqGgvo3JArfo9DhgBECTJHCTxJ1pNL2T8CZHf7GbNmqX48OFDlN9TP1b15vDt2zfFihUrIvyMXxB0Rf3NpHPnzuKTIc+o8OyA+huwOv7ErfoZf1qdNGmS4vDhw2IGQX3cqjfJuAZJz58/F+PgF0bVzxYtWiR9cuWfM/WggN+w9+zZozhw4ECEXJL27dv/8THg+6s+voEDB4r7w286qhd2/vrvv/80Pm48ezRt2jTxO+p5R/zFswWqT+Yc7EZ+rNXzj2ITJKneTPi+TpgwIcL3eYaB33zc3NwiBFI826Ny4cIFxdy5c8Xv8wwY3zbP5JQoUULj/YwuSOKZDfU3fB67u7u7mAlSfZ9n1NSDhOio/39FzkfiDxq5c+eOEJDyeDdv3qzImjVrnIIk9Rkrfr4cPHhQBGBr164Vz92qVatGyA3jx1n9HFT9fz148CDejyV/8Szl/v37o3yfZwpVs8/qM8r8f8ozI6ox8++rZl74uac6jgMJfs3hIITHZ2VlJQUn9+/flyVIYtu2bVNkzpw5yu/zOcbPm8gfaP4UrObNm1cREBAQ5e/4+flJx/DjB4AgSeYgifELV0yf+PgFjqf61cXmBYinzXm6/W+mx2OTsBpT4ja/uI4cOTJK4rj6J3iegVFXvHhx6We9e/f+qyApNonbPFOnHqjx46+637t27Yrwsz9ddmvSpIl0PF+aUNe8eXPpZ3yJS9PYhg4dGuF3+LKI6mf9+/ePdeJ2bIOkO3fuSJc8+fKL6vscuKj06dNH+j4vKlDhoGXx4sWKcuXKicukPMMQ+f9d/XhNQRL/Xb7Mp/r+vHnzIjzvMmbMKP2MZ1n/RH0mLvI5cv369Qhj8/X1lX6mHhjEJkjiIE71Pb7kxjOR6jMXcU3cjs9jyTN8PBunUqBAAelnHDgxDuJU3+Pb9vLyinaszZo1i/DBQP3/g5+3qp+NGDFCIRee4eGFKJpeazJlyiTOW3UcCNesWVN8QDp06JBi7969UT6E8GXXyPhxVf+gCoDEbQNQs2ZNkZjIid+cqH3p0iV6/Pix9POAgAD6559/6OjRo7G6PU5u5NIBc+fOFQnjMfH29qYqVapE+f6pU6fiVW8nJCRE3A9emmtlZSV9/969e9J2+fLlI/wO71+/fj3Kcdp2584dafvXr19Uq1Ytjcfxz+7fv0/Ozs7R3taf7g//n0Y+LvIx6jhx9ObNm2I7tvV+YouXOasSW3mRAJeZ4MRnVqZMGek4LkOh8uHDB2mbE/NViwKi8/Hjxxh//u7dO/GlMmjQoGiPvXXrVrT/N5ooPzv89ujRowhJurx8XP1xjgsuacHJwrdv36atW7eKr8SJE4tyAxUrVqS+fftSoUKFYn178Xks+f8qadKk0j6X3Ij8/6X+HM+ZMyc5OjpG+3fUj+UxRTcu/v/4Ey5Vonr+xkbk578m586doxo1alBYWJh4bnI5DCcnJzpz5gw1adKEXr9+LUo/XLt2TXyftW3bVnypa9SokXhd4oRvxgtili5dGuNzCABBkoHg2h+8Qoy/GK964xdeXrXBrly5Eu3vqlZvcJ2k5MmTU548eaKs3NC18ePHi4J+/MLVvHlzUZyN6/lw7ZE/vRnEhN/M1XHdJQ4Cmfqbra6o11Ixdra2thH2+fmiHkBponrT4JU+6v+PHLTXrVtXvFmvWrWKNm7cKL4fHh6u18c+bdq0GgM6bUuSJAlduHCBVq9eLT5AcNDL9bc4aFIFTjdu3KBs2bL98bbi+1hycKtOdT7o+k0+Nv8f0X3oik5sxrty5UoRIDEOfFQBbu3atcUXB038WPEqOFWQFB3+XVWQ9Pbt2yg/V38OmeNqUYgKxSRlxi+0/MISWa5cuahjx47SfkxvPvxplj+R8fJn/rQclwCJZ4v+f9k1wtffzCLxizUXxOQSACpcAkC9MFuBAgWkbX7TUae+rzqOC8ZFLhyowst0o6MeAER+7NSXCfMbEwd0mh4DflOoVKlSjPc5rvcnssi/oyqdwDjYjc390YeXL19GmLngshX86Z6fd/ymH1sc1KjPVB07dizax54D7z/hMhoqPOunLnfu3NJ2cHBwhBkO9cc5NnhMHGQOHjxYPO94lurLly/UrFkzaQbl8OHDsfr/0tZjGRP1WS2epfb19dV4nyKfDyNHjtT4/8FBiuoDm76pfxjix1ydepFd9e3Lly9rvC1e3q+SMWPGKD9Xfw6pP7fAfGEmSWb8YssvkCVKlBCXyOzt7UV5/BcvXtDUqVOl49Qvhxg6ng2bPn26VNtk0qRJtG/fPrHN7SlUQSHXcOJPa3w5a8+ePWK6XEUVIPJjkT59eulTX7t27cSnSXd3dzp79my0Y+A3H9Xf5zo6/KbFQRwHkfzix483/73v37+LulT9+/cXdVL4BZl/jy978pubh4dHjPeV7w+PXTV9z3WuqlevLsbm5uYW4ThNFi5cKGYGeFz8SZhnI1T4EoL6/VHhN2N+Q+VgmGsD8bh1jYN2Fa6Fxc9NrifElxNPnDgRp5lBfn7Mnj1b7Hfo0EFUUi5SpIgIjPh5z29wHIhEfkPUhIN5ruzOrl69Ki5jqfCsAo+bZ2WZi4uLqIDNl1x49jUu+La7desmLu/kz59fXMbmWQeeRVJRr5Gm/v/F/69cnZ4vz/HvauuxjAk/B/m5wbXW+HnMMy4cAHFA5O/vL2ZT+Bzl1xtXV1favXu3+D3+f+Hj+RIinzP8/8HPST5/efbrTx+eVB+6tInHyME04zpwfB8cHBzErDXP6qnwOa3SunVrcV7xv/z7/H/O93HHjh0azy/1/2eVP31AAjMhd1KUuSdu8yqSPyVgc/0UT0/PCL+n/nO5KvpGVwKA8aoo9RUoqpU0sSkBMGXKlAi3xSUBolumH13iNieNa/odVW0WXmUUUwkATbcZm2Xomr66desW7eMWeSm66ouXN6vj5HJNx3HJiLjUSYpNcnt0q9Jat24d5e8nSpRI1FTSdHxMJQC4RtafnvexwSs6bW1txfFcZ4kTw9UdOXJE43J5XrIfl8RtrvUV01htbGwUz549k24j8ipT1demTZu0+ljGlCTOK0Q5KTw2JQDUVxxG9yVX5fo3b96I/9uYxla6dOkIteT+1A2AV7eql7dQ4UR61f8FV+AGwOU2mfEMEX+66dmzp5hR4Qqv/ImTcyDy5ctHPXr0EDMvf7rWbmh4tiBLlixim2M6nk1i3ICUP9FxNXL+pMa5MDzDwzNKDRs2FDM33KtO3bBhw2j48OHi0zs/NjzrwnkbfOkjOpwfxY8d327kvCbVJUr+hDxu3DiR1Mq5XJxgzjkl/CmaP93zTFdsLF68WMwm8ad1vpTE94c/xfKn+f/++0/kVESHqwdz3zEeD983TrKdNm0arVixIkpyPx/Hl5D4MZQD5+Nw/gz/v/JlylKlSolZLZ6Jiwv+Xf5/5seFZx74seLHjGcM+RwYOHBgrPvT8Wwaz0YxnvVQv5zC+P+EFzxwP0P+/+UZHp7Vi2kWUhO+9MnPS37OcvV4vi2uis/PF57d5JxBnrlR4dkZnrnhx0r90pu2H8uYlCxZUiRb8+wmz9TxY8WvK/wc49lY9Sr4XBWfZ2d5powvQ/F940vdfNmOH1+e5eLHUA78vPDy8hKzfzwrxOcqP6Y8y8yPG89+8YwSj1m9dxt3GuBzm3+fn1/8WsMzsHy+cjI454Gq4+eP6jJsvXr19DJDC4YvAUdKcg8CwJzwpRe+DKKNVYSgzFPjDxR86ZQvoahfUgGILf4wxgEXf6jiS/ExrWoF84GZJAAwajwbo5pV5BkPbZdOANPHizdUM8c8y4YACVQwkwSgZ5hJAgAwDphJAgAAANAAM0kAAAAAGmAmCQAAAEADBEkAAAAAGiBIAgDQA66lxCunuLYS11niGl7cSogbUXOjYa723q9fP1ETjev68FJ0/tJls2cAiBlykgAAdIxbgHAxyuheblWterj4YWR3796NtvcfAOgWZpIAAHSIq7FztWgOkLjq9Zo1a0RdHu5Vx73a6tatK47jitCDBg0StZ4aNWok97ABADNJAAC6xc1YfX19xfayZctEC6LIwsLCIrSb4dYp3JiZYSYJQD6YSQIA0JE3b95IARL3CuOebprI1Y8PAGKGIAkAQEdUldVZrly5IjRhBQDDhyAJAEBHeHUaABgvBEkAADrCy/1Vnjx5QqGhobKOBwDiBkESAICOZMiQgezt7cX2169fae3atRqP48RtADA8CJIAAHRo/Pjx0vbgwYNp/fr19OXLF1FA8uTJk6IEwM2bNyk8PJzev38vvkJCQqTf4XIB/D0uGQAA+oUSAAAAOjZt2jQaM2ZMjMUkuU5Szpw5o72Njh07igALAPQHM0kAADrGxSQvXrxIbdq0oSxZslDixIkpTZo0VLp0aZo9ezblzZtX7iECgAaYSQIAAADQADNJAAAAABogSAIAAADQwELTNwEAzFHg1x/08n0Q/QoLp+RJLClnOhtKkhgvkwDmCmc/AJg1/4/BdMjzOR339aNPwT8j/IzrZefKkILqO2enqkUzUxJL9FgDMCdI3AYAsxQaFk7bzz+iLeceinAoPJqXQg6U+CdpbJLQ0Eb25JAzjd7HCgDyQJAEAGYnOCSUxmy7Srdffoz17yRMQBSuIOpWvSA1L5NLp+MDAMOAxG0AMCth4eE0bvs1uusX+wCJcYDEVnncpcNeL3QzOAAwKAiSAMCs7Lr0lG6++CAFPX9j6dHb9CrwmzaHBQAGCEESAJiND0E/aOPp+/G+nTCFgpYeu62VMQGA4UKQBABm46j3SxHgxFd4uIKuP35Hrz9gNgnAlCFIAgCzceLmK9LWUhVO5D539412bgwADBKCJAAwCz9+hmo9j+iB/yet3h4AGBYESQBgFt58+i7qHWkLJ36/eBekxVsEAEODIAkAzGbpv/ZvE2XmAEwZgiQAMAsprBPH+PMPP27QJf8B9PjztljfZspkMd8mABg3BEkAYBa4rUiyJJrbVX4PDSCfd1Pp66/H9PTLTlIowv54e4kSJqB8mVLqYKQAYCgQJAGAWUiQIAE55kwjght14Yowuhk4h0IVyqTu9EnLUoIEyka24eGh9PTzTnr/3UvjpTb77HZ6Gj0AyEHzxyoAABNU3zk7nY+0bP/J5+30KeSO2E6SKD0VSN1T+tnNwHn09vtZsZ3KqhgVSNWdbBLnUO4ns6KSedPqdfwAoF+YSQIAs+GQw44KZUklzSZ9+HGLnnzZIbYTUEIqlmYIWSZMLh0fGv5V2v4YcoMuvelHN97Ppm+/XlG7SnkpUUK8hAKYMpzhAGBWl9yGNLKnhAkT0K+wr+IyG5Fy1Vtu23aU0qpghOPTWZeNdAsKehN8hi7696Y9tyZRcEiwHkcPAPqGIAkAzErm1MlobDMnuvNxEYWEvZcupeVM0SzKsTaJc2m8DQWF0drza2nyock6Hy8AyAdBEgCYHe/Xe+ht8CWxbZkwBRW1GyQla6tLbpk1yvesLJJQiiQpxHbedHn1MFoAkAuCJAAwK7de3aKB/w2U9l1LTyPbpOnFtvrKtwQJiBInSkZJEimTsxMlVK5zCQn9QYUzFaZHUx9Rl/Jd9D5+ANAfrG4DALPx/ed3ar2yNf349UPs96vajxa16UPBIaF05eFbevD6M714H0S/QsPJJqkl5c6Qgr6cL0oXn5yksPBQypwqM736+IouPblEmy5vogkNJ8h9lwBAhxIoFNrqiQ0AYNh6b+lNy04vE9vFshSjK6OuUBLLJDH+zpxjc2jorqFkkciCjvY/SrUW1qKw8DBKmCAhnRpyiirmq6in0QOAviFIAgCzsMdrDzVd1lRsJ02clDzHeFLBjBFXs2nyM/Qn/Xf9PyqQoQAVz1Gcph6aSmP2jhE/y5IqC/mO96XUyVLrfPwAoH8IkgDA5L388JLsJ9rTx+CPYn9Vh1XUtULXv7otnkWqPq86nb5/Wuw3cWxCbr3cRHkBADAtSNwGAJPGQU3b1W2lAKmFcwtyLe/617eXKGEi2uy6WZo92uO9h1acWaG18QKA4UCQBAAmjS+PnXt4Tmxnt8tOKzusjPesDydwr+u0Ttrn1XK8ag4ATAuCJAAwWecfnqeJByZKM0Bbu26llNYptXLbDR0aUt8qfcU2r5bjVXO8eg4ATAeCJAAwSR+/fSSX1S4UrlC2HZnQYAKVzRO5zUj8zG4xm4pmLiq2b7++TYN3Dtbq7QOAvBAkAYDJ4fUo3TZ2EwnbrFK+SjSy7kit/x0uH7C9+3axWo5xeQFeRQcApgFBEgCYnFXnVpGbl5vY5gRrTrTmy226UChTIVrYaqG077rBVQrOAMC4IUgCAJNy+9VtGrB9gLS/ttNaypI6i07/JpcTaO7cXGzzKjpeTcer6gDAuCFIAgCTwYnTbVa1kdqO9KnShxo5NNL53+XVcivbr6RsqbOJfV5Nx6vqAMC4IUgCAJPB7UNuvroptjmhenbz2Xr726mSpaKt3baKdiWMV9Xx6joAMF4IkgDAJOzz2Uf/nvpXbHMitXpCtb6Uy1NOanrLq+pEEctvyiKWAGB8ECQBgNHz++BHXdZ3kfYXtFogEqrlMKruKKnp7YsPL8QqO3R/AjBOCJIAwKhxgnS7Ne3ow7cPYr+ZUzPqVqGbbOPhVXRbXLdIbUt4ld3qc6tlGw8A/D0ESQBg1KYfnk5nHpwR21lTZxXNa+VuNsur6dZ0XCPtD9gxgO68viPrmAAg7hAkAYDRuvDoAk04oMwB4oRpbjvCCdSGoLFjY+pdube06o7blqhW3QGAcUCQBABG6VPwJ3JZ5SLVIxrfYDyVz1ueDMmcFnOoSOYiYptX3Q3dOVTuIQFAHCBIAgCjw4nQ3Td2F4nRjBOlR9cbTYZGrLLrtl20L2FLTi2h/T775R4WAMQSgiQAMDprzq+hnZ47xXYq61Q6bTsSX4UzFxar7VQ6r+9Mrz6+knVMABA7CJIAwKjc9b9L/bf3l/Y5QZoTtg1Z94rdqalTU7HNq/B4NR7algAYPgRJAGA0OPGZE6A5EZr1qtyLmjg1IUPHq+141Z0qmDt9/zTNODJD7mEBwB8gSAIAozFs1zC64XdDbBfOVJjmtphLxoLrJnH9JFXbkvH7x9PFRxflHhYAxABBEgAYhQO+B2jxycVimxOh5Wg7El8V8lWgcfXHiW2+3Oay2kWs0gMAw4QgCQAMHic6c8KzyvyW86Wl9caGV+FVyFtBbD8PfC5W6aFtCYBhQpAEAAaNZ1zar2lPgUGBYr+xQ2PqUakHGSuLRBZiNR6vymO8Sm/t+bVyDwsANECQBAAGbeaRmXTq/imxnSVVFlrTaY3sbUfiK5tdNlrd8Xc/N16tx6v2AMCwIEgCAIN16fElGrdfmcPDCc88A6NqHGvsuCRAj4rKGbHgn8HUZmUbtC0BMDAIkgDAIHFCc5tVbaR6QmPqjaFK+SuRKZnXch4VylhIbPv6+dJwt+FyDwkA1CBIAgCDw4nMPTf3FInNrFyecjS2/lgyNdZW1mKVnpWFldhfdGKRWMUHAIYBQRIAGJx1F9bRjms7xHZK65S0pesWkfBsiopmKSpmlFR4Fd/rT69lHRMAKCFIAgCDcs//HvXb1k/a50rV2e2ykynjyuGNHBqJbV7F12412pYAGAIESQBgcG1HOJFZ1fOsuXNzMnW8Wo970GVOmVns82q+WUdnyT0sALOHIAkADMYItxEigZkVzFhQFI00F3bJ7cRlRVV5g7H7xtLlx5flHhaAWUOQBAAG4aDvQVp4YqHY5kRmTmjmxGZzwqv3eBUf48ttvLrvc/BnuYcFYLYQJAGA7DhRWb3tyNyWc6lYlmJkjri3W9ncZcX2s8Bn1GNzD7QtAZAJgiQAMIi2I++D3ov9hvYNqXfl3mSueBXf1m5byTaprdjnVX7rL66Xe1gAZglBEgDIavax2XTy3kmxzYnLazutNfq2I/HFq/l4VZ9K36196f6b+7KOCcAcIUgCANlwYvKYvcocHA6MNnfdLBKYgahF8RbUrUI3sc2r/XjVX8ivELmHBWBWECQBgCw4IdlltYtUD2h03dFUOX9luYdlUBa0WiBW+TGflz40YvcIuYcEYFYQJAGAbG1Hnr5/KvbL5C5D4xuMl3tYBodX923rtk1qW7LAYwEdunFI7mEBmA0ESQCgdxsubqDt17aLbU5Q3tp1q8m2HYkv+6z2NKfFHGm/07pO5P/JX9YxAZgLBEkAoFecgNx3W19pnxOUc6TJIeuYDF2fKn2ogX0Dsc2rANuvbU/h4eFyDwvA5CFIAgC94cRjLpD4LeSb2O9aoatIUIaYcVL72o5rKVPKTGL/xN0TYlUgAOgWgiQA0JuRu0eS9wtvsV0gQwGRmAyxk8YmDW123SyVRxizbwxdeXJF7mEBmDQESQCgF4dvHqb5HspebIktEou2I8msksk9LKNSpUAVGlVnlNgODQtF2xIAHUOQBAA6x4nGnHCsMqf5HJGQDHHHqwB5NSDj1YG9tvRC2xIAHUGQBAA6xQnGHdZ2oHdf34n9+sXqU9+qvxO3IW4sLSzFasAUSVOI/W1Xt9HGSxvlHhaASUKQBAA6Ncd9Dnnc9RDbGW0z0rpO68y+7Uh88WrAle1XSvt9tvahB28eyDomAFOEIAkAdObq06s0eu/o321HXDeLBGSIv1YlWpFreVexzasFW69C2xIAbUOQBAA68eX7F5FYzAnGbGSdkVS1YFW5h2VSFrZeSPkz5BfbvGpw1B5lUjcAaAeCJADQOk4k7rW5Fz1590Tsl85VmiY0mCD3sEwOrw7c3m27WC3I5h2fR0duHpF7WAAmA0ESAGjdpkubaOvVrWKbE4w50ZgTjkH7HLI50OzmvwtLdlzXkd58fiPrmABMBYIkANAqTiDuvbW3tM8JxjnT5pR1TKauX9V+VK9oPbHNqwh5NSHalgDEH4IkANCan6E/I7Qd6VKui0gwBt3ipPh1ndeJ1YPs+J3jNPf4XLmHBWD0ECQBgNZw4rDXCy+xzQnFi9oskntIZiOtTVra5LpJKq/A/xfXnl6Te1gARg1BEgBoxdFbR2muu3L2ghOJt3XbhrYjelatYDUaUXtEhLYlvMoQAP4OgiQAiDdOFO64tqO0P6vZLHLM5ijrmMzVxIYTqVTOUmL78bvHotAkAPwdkw2Srly5Qm3btqVs2bKRlZUVpUuXjsqWLUtz586lb9++0blz58jV1ZUKFSpEqVKlIhsbG7K3txc/DwlBQTaA2OIEYQ6QAr4GiH1OIO5frb/cwzJbvIqQZ/FUbUs2X94sVhsCQNwlUJhgZ8Tp06fT6NGjo2366O3tTcuXL6cVK1Zo/HndunXp0KFDOh4lgGmYc2wODd01VGxnsM1AN8bfEPkxIK9tV7aRy2oXsZ3cKjl5jfWivOnzyj0sAKNicjNJe/bsoVGjRokAydramtasWUOfPn2ioKAgOnHihAiAWKJEiahTp0507do1Cg4OppMnT1KKFMpPXocPH6br16/LfE8ADB8nBo/cMzJC2xEESIahTak21LlcZ7EdFBIk8pN49SEAmPFMkoODA/n6+ortZcuWUc+ePaMcExYWJgIjvsSmrl+/frRkyRKxvXXrVmrTpo2eRg1gfL7++EqOkxxF3gsbUWcETW86Xe5hgZqgH0HkPMWZHrxVNr8dUnMIzW7xu/AkAJjRTNKbN2+kAIkDIM450oRnkSIHSOzHjx/SdubMmXU4UgDj12dLHylAKpmzJE1qOEnuIUEkyZMkp+3df7ctmeM+h47dOib3sACMhkkFSc+fP5e2c+XKRZaWsW+DcP/+fTF7xPLnz0/ly5fXyRgBTAEnAm+6rEwGtkliIxKF0XbEMPEqw5nNZkr7XI377Ze3so4JwFiYVJCkKqIWV0+ePKFatWqJS3Ccl/Tff/9RwoQm9dAAaM2jgEfUe8vvtiMr2q2gXGlzyTomiNmAagOoblFlPiavQuTViGhbAvBnJhUJ8HJ/9cAnNDQ0VjNIFStWFLNQHCBx0naxYsV0PFIAI247srKNSARmncp2EgnCYARtSzqtE6sP2bHbx2i+x3y5hwVg8EwqSMqQIYOodcS+fv1Ka9eu1XgcJ26z27dvU6VKlejVq1eUOnVqsfqtXLlyeh0zgDEZs3cMXX+uXPmZN11eWtxmsdxDglhKlyIdberyu23JyN0j6fozrOIFMJsgiY0fP17aHjx4MK1fv56+fPkiCkjyMn8uAXDz5k3y8fGhypUr09u3byl9+vR0+vRpKl68uKxjBzBk7rfdafYx5cooy0SWIiGYE4PBeFQvVJ2G1Romtn+F/RJlAXiVIgCYSZDUpEkTmjp1qvi0xLWROnfuTLa2tpQ8eXKqVq0aHTlyRBy3YMECev/+vdjmQIkvsfHvqL4mTJgg8z0BMByc6MsJvyqcCOyU3UnWMcHfmdxosliNqMov67u1r9xDAjBYJhckMS4mefHiRVHnKEuWLJQ4cWJKkyYNlS5dmmbPnk1586LqLEBscYJvp3WdpBVRdYrUEYnAYJx4FeLWrlvFqkS28dJG0boEAMygmCQAaNc893k0eOdgsZ0+RXrRdoTzW8C4bb2yldqubiu1LfEZ50O50+WWe1gABsUkZ5IAQDs8n3vSiN0jpP1NrpsQIJkIl1Iu1LFMR7GNtiUAmiFIAgCNOKG39crWIsGXccJvjUI15B4WaNFil8VilSK79uwajd07Vu4hARgUWYOkcIWC/D8G00P/z/Qs4CuF/FIuzQcA+fXb2k8k9rISOUrQ5MaT5R4SaJmolt59m1ityGYdmyVWMQKATDlJYeEKuvowgA56PqdbLz7QD7XAiMt3ZE+TnGrYZ6Wa9lkohbWy3xAA6NeWy1uo3Zp20hup91hv5KuYMOSdARhAkPTI/zPN3OtDL94HUcIECcRMksZBJSBKnCghda9ZiOo5ZfvrdiMAEHePAx6T42RHqX7OZtfN1La0MsEXTHcFY73F9ejoraNiv3aR2nSo3yG0ZwKzp7cz4LivH/Vbc578Ar+J/egCJMY/CgkNp8WHb9GknZ70MxSX4QD01nZErcBghzIdECCZAQ6G1ndeL2aRGAdLC08slHtYAOYRJJ25/Zrm7PelcEXMwZEmlx68pem7vQmVCgB0b9y+cSKBl+VJl4eWuCyRe0igJxwgbeyyUdof7jacvJ57yTomAJMPkgI+f6d5B2789e9zbHTx/ls64v1Sq+MCgIiO3zlOM4/OjNB2RFVwEMxDzcI1aWitoWKbVzXy6sagH8pmxgDmSOdB0gr3O/QzNDzet7Pc/Q59+Y4aHgC6EPAlIELbkelNp5NzdmdZxwTymNJ4ChXPruxj+TDgIfXb1k/uIQGYZpDEs0gX7r2J8yU2TX7+CiMPXz+tjAsAorYdefP5jdivVbgWDaw+UO5hgUwSWyQWZQG4Cjdbf3G9qM4NYI50GiSdveNPpKWFaRxmHb+BIAlA2xadXERHbikbP6ezSUcbumzAqiYzx/loy9otk/Z7bu5JT949kXVMAHLQ6Svhg9eftBUjCc/fBWGlG4AWcWLusF3DpH1O3FWtcALz1q50O2pfur3Y5tWOvOrxV6iy+jqAudBpkPTs3Vexoi22whW/6HtoACkU4dEWonzzMVh7AwQwY5yQK974/t92ZEjNIVSrSC25hwUG5N+2/4pZJXb16VUat3+c3EMCMJ0g6VdY7BO2eYn/9bej6NzrLnT2dSe6+2EZBf7gsgERZ45+haEUAIA29N/enx68fSC2OUl7apOpcg8JDLFtSbdtZJHIQuzz6kePOx5yDwvANIIkmySxbyvCVbW/hSpzjkLCPtDLoEPkGTCazrxqT7cDF9H7755ipskmqbLHEAD8vW1XttG6C+vENifo8hshJ+wCRFY8R3Ga3mS69GG2/dr29O7rO7mHBWD8QVK+TLaUKGHss5Kc0k6itElLUUL6HQj9Cv9Cr765k9e78SJgGrKrB+3z2Ufff37X0agBTBsn4Pbc0lPaX9p2KeVNr+wED6DJoBqDqGahmmKbV0HyakgU+AVzoNPebadvvxbVsuPiy8/HFPTzOSVIYEEBwRfo3Y/rFK4IiXIcf/qtV6weNXNqRnWK1KHkSZTLVQEgepx4W2FWBbry9IqUnLvJdZPcwwIjwMGR/UR7CvgaIPYXtFpAA6oPkHtYAMYbJPFKtDbzPSjoR2isjv/2048uvFF+wk2SKB0VtutPtpb5KTDEmwKCL9KXUE/69lPZU0pdEsskVLtwbWrm3IwaFGtAtta2Wr8vAKZg1O5RNP2I8tJJ7rS5yWusF6VImkLuYYGR4J5udRbWEdt8efbyyMvkmM1R7mEBGGeQxP67+JjWnLgXq2Pff/cmr3djI3wvlVVRypeyAzlkK0nzOpakU/dPkJuXm7jk9uHbhyi3we0UahSqIWaYGjk0Irvkdlq7LwDG7MTdE1Rjfg1xmYQTcS8Ov0glcpaQe1hgZIbsHEJz3eeK7Xzp85HnGE/M5IPJ0nmQFBYeTv3XXKAnb7kcQMx/KjT8O530a6HxZ5Xz1aSVHZZIuRN82eDMgzMiYNrjvYfefnkb5XcSJUxElfNXFgFTE8cmlME2g5buFYBx4URbvlTi/9lf7M9qPkvq0QUQFz9Df1LZGWXJ87mn2O9Srgut6bRG7mEBGGeQpGpP8s+6C/Tp209R6ygmZ191ph9hmldO8KeW+1PuR/l+WHgYXXh0QQRMu712k99HP42r58rnKS8CpqZOTSlr6qzxuEcAxoNP8QaLG9Chm4fEPs+0Hh1wFFW14a89fPuQHCc70reQb2KfV0e2Ltla7mEBGGeQpAqUJu28Tg/9v8R4nFfABHr/43qE79kls6PAb4FUMmdJujJKmXAaUx+qa8+uiYCJv6Irpc+31dy5uQiacqXN9Rf3CMA4LDqxiAZsVybYprVJSzfG38CsKsTbxosbqeO6jmKb89p8xvpQzrQ55R4WgHEGSapLb7uvPKUdFx7T1++/RHkA9ZmlhAkS0L2Pa+jZl91RCppt7LyRqhSoEqekbL5rPi99yM1TGTDde6M5N8ohq4MIljjxu2DGgvG4hwCGxeeFD5WaXkpcImGH+x+mOkWVibcA8SFqJq1pT1uubBH7pXOVprNDz5KlBWrZgenQa5Ckvurt8oMAuvXiAz30/yQCJotECSlnOhvyC/KgJWeVvaScsjmR1wsvrZ2Ad17fUc4webqRr5+vxmMKZSwkgiUOmoplKSYu0wEYI74U4jzFme6/uS/VupnbUplwC6ANX75/EZfdVDP2o+qOQuV2MCmyBEkxefDmARUcV5DCFeGiDgd3KNfFCfgo4JE0w8SX5zThJdKqGaYSOUogYAKj0nVDV1pzfo30gePiiItkZWkl97DAxHBPt3Izy1FoWKh4jfQY6EFVC1aVe1gAphkksQO+B5RVgSv1FDM+uj4BXwS+oN3eu2mX5y66+Piixkqy2VJnEwnfHDSVzV0WSa9g0HZc20GtVyoTaZNZJSOvMV6UL0M+uYcFJmrW0Vk03G242M5om1HkvaWxSSP3sABMM0iS8wT0/+QvSgrwDNPp+6fFjFZknPTKJQU4YKqUr5LU/BHAEDx995QcJjuISyFsfef11LGsMsEWQBd4wUytBbXI466y+W39YvVpf9/9mH0Ho2cUQZJcJyDXluGilRwwcSG+X2G/ohzDxSobOzQWAVO1gtXQJBRkxfXDKs6uSJefXBb7LiVdaHPXzXizAp3jD5j2k+yl5reLWi+iftX6yT0sANMPkgzhBPwU/ElcBuSAiUvzh4RG7Sdnm9SWGtg3EAFTrcK1KGnipHobHwAbs2cMTT2szNvLmSYn+YzzQdsR0JvDNw9TvUX1xDZ/YLw66irZZ7WXe1gAph8kGdIJ+PXHVzEWTvw+fOuwVFBNHeeB1CuqbMBbt2hdlO0HnTt17xRVm1dNajtyfth5KpWrlNzDAjMzaMcgmu8xX2wXyFCAro+5Ll4PAYyRUQVJhngCfv/5nY7dPiZmmPb77pfyQCI34OWZJS5eiQa8oAvvv74XM62vP70W+zOazqDhdZR5fAD6FPIrhMrMKEPeL7zFftcKXWlVh1VyDwvAPIKkyCdgtwrdaGWHlWQoYztx74SYYdrnu48CgwI1NuCtXrC61IAXK0AgvvgUbvRvI3E5mPHz69g/x7ACE2Qt5eI0xUmaZd/RfQe1LNFS7mEBmH6QpOkE/K/Hf9SiuObGuHLhkgWqBrzcTw4NeEFXlpxcQv22KfPz0iRPI1Z/ZkyZUe5hgZlbf2E9dV7fWcrX5Py4HGlyyD0sANMPkjSdgL7jfSm7XXYyRNyA9+Kji8qAyXs3vfzwMsoxvPqoXO5yonBlU8emlM0umyxjBePi+9KXSk0rJS0kONT/kMiBA5Abv7W0Xd2Wtl3dJvbL5C4juiagZAoYE6MNkiKfgFzg8czQMwZ/AvK4RQNeTzfa5bUrxga8otq3UzPKnS633scJho9nUotPKS71JPyn+j80v5UyXw/AEHwO/izaljx9/1Tsj6k3hiY3niz3sABMP0jSdAKOrT+WJjWaRMaCH3qeCRD95Lzc6K7/XY3H2Wexl/rJFcpUSO/jBMPUfWN3WnVuldSk+fLIy2g7AgbnypMrVH5WealrwsnBJ0WaAYAxMOogydROwNg04C2YsaA0w8TlD1Ak0DztvL6TWq5QJsJaJ7Ymr7FelD9DfrmHBaDRjCMzaOTukWI7U8pM5DvOF4tWwCgYfZAU+QTMnDKzyE/iStjGjBvwcsI3B03cQFKTXGlzSQETX55DwGQengc+J/uJ9vT5+2exv7bTWupcTpmfB2CoXRNqLqgpOhewhvYNaW+fvXjNAoNnEkFS5BOQl9bv6b3HZE5AVQNenmG68PiCxga8WVNnFQnfogFvnrJi5RyYHp4xrTS7kmjEzFqXaE1bu201mec6mC6u4cXB/fug92J/icsS6lOlj9zDAjD9IEnTCfivy7/Uu0pvMjXcnmWvz16pAS+vnIssfYr01NRJGTChAa9pGbdvHE0+qEx8zWGXQyyrRnFSMBaHbhyi+ovri20rCyu6OvoqFctSTO5hAZh+kKTpBLw2+hoVzVKUTLnKsqoBLzf/ja4BbyP7RiLxm4sMogGv8eKguOrcqmImkWcKue1I6dyl5R4WQJz8s/0fWnhioZRjeX30dbK2spZ7WACmHyRFPgELZSwkAiVzOAG5Ae/BGwfFJbmjt4/Sj18/ohzDjU45FwANeI0PV2/nmdJXn16J/WlNptHIuso8PABjwp0JSk8vTT4vfcR+94rdaUX7FXIPC8A8gqTIJ2CPij1oefvlZE6CfgQpG/B6udGhm4eibcBbt0hdMcPEjXjRgNdw8SnaZGkTMWvIqhaoSu4D3ZF3Bkbrnv89cp7iTME/g8X+zp47RW9LAENjckGSphNwV89dIhgwR9yA1/2OO+3y3CV6e6lWRKnjS5O1i9QWM0wN7BtQSuuUsowVNFt6ain12dpHunzKbUd4GTWAMVt7fi25bnAV2/yaw/l1hto1AcyXSQZJmk5Arsth7q0+fob+FCsAeYaJk7+ja8BbrWA1ETA1dmiMWiYyu+l3k0pMLSG1HTnQ9wDVt1fm3QEYM37rabOqDe24tkPsl8tTjk4POY2FJmBQTDZIinwCls9Tnk4NOYUTUEMD3j3ee+jN5zdRjkmYIGGEBrxomqpfwSHBIkC6439H7Pev1p8Wtlbm2wGYSi6l4yRHehb4TOyPqz+OJjaaKPewAEw/SNJ0Ao5vMJ4mNJwg97AMDpcRuPT4ktQeJboGvNwfT1W80txn5fSh56aetOLsCqk1zeVRlymJZRK5hwWgVfzaU2FWBfE6xB/MuGtCpfyV5B4WgOkHSZpOQJ5NqpivotzDMooGvBwwPX73WONxJXKUUAZMzs0oT7o8eh+nqePHv/ny5lLbEc8xnlQgYwG5hwWgE9MOTaPRe0eL7Sypsoj8JGPvmgCmweSDJE0nILctSZ0stdzDMnj81Ljhd0PqJ6e67BMZF4PjlSlowKu9Cuv2k+zFTChb3WE1uVZQ5tcBmCL+EFtjXg06df+U2Od8yN29d6OSPMjOLIKkyCcg59e49XLDCRhHd/3vSjNMqhILkRXIUECaYeLO9HiM454rVmVOFTr/6LzYb1m8JW3vvh2PI5i8Vx9fiQ8HqgUlS9supV6Ve8k9LDBzZhEkaToBl7VdRj0r95R7WEbrccBjqZ/cladXNB6DBrxxN2H/BJp4QJm4ysuh+bIDSjKAueAyJQ2XNDSbrglg+MwmSIp8AnICLJ+ARTIXkXtYRo8TvXd77RYzTDwDoukpxZc5Vf3keKkvCiFGdfbBWTGLFK4IF4/P2aFnRbNiAHPSf1t/WnxysdgunKkwXR111Sy6JoBhMqsgSdMJyIES2nNoD5cS2Ou9l3Z57YqxAS9f8lQ14LW0sCRz9+HbB9F2xO+jn9if0ngKja6nzKMDMCfcUqnUtFIiH5L1rNSTlrVbJvewwEyZXZAU+QTka9587Rt004B3v+9+McN0/M5xjQ14OYG+kUMjETBxA14rSysyN3wKNlvWTNSrYlybymOQB2bbwKzzH7lrAncMYJxDyjPRAPpmdkESu/P6DhWfWlw6AXf32k1NnJrIPSyTFtsGvA2KNZAa8JrLFPvy08up15ZeUtDIbUcyp8os97AAZLX63GrqtrGb2EbXBJCLWQZJbNXZVdR9U3exnco6lSgLkDV1VrmHZTYNeI/cOqJswHvjEAWFBEU5hmsD1S1aVwRM9YrVI5skNmSKbr26Japqq4LGfX32UUMHZd4cgDnjt6ZWK1rRTs+dYr9C3gqi0CS6JoA+mW2QxHe75YqWovGr6gTkQpO4xCFPA16eYeJLc9E14OWZJVUD3lTJUpGp3HcOkG6/vi32+1bpS4tdlPlyAKCcgXaY5EDPA5+L/QkNJtD4huPlHhaYEbMNktjHbx/FCfjiwwuxP7HhRBrXYJzcwzLrBrwn751UNuD13kvvg95HOYY/RXLuEgdMnMuU1iYtGaveW3rTstPKhNSimYvS1dFX0XYEIJKLjy5SxdkVpa4J3AS3Qr4Kcg8LzIRZB0nswqMLVHFWRbHsmk/AM0PPUPm85eUeltnjooq8JF7VgNf/s3+UY/j/i1fHceFKXi2XKWUmMhZ7vPZQ02XKRFReXXl99HVUKweIxpSDU2jsvrFim9MiuH4YuiaAPph9kMQmH5xM4/aNk05AThA0lUs6piA8PJwuPbkkVftWzfxF14CXV8FwIUZDrivFy/0/Bn8U+yvbr6RuFZUJqgAQFc8iVZtbjc48OCP2+Rzf1XMXCtSCziFI+v8JWHVuVTFzwfiNdmfPnTgBDRA/Xa8/u67sJ+flRo8CHmk8rnj24mKGif8v86bPS4b0XOOCkecenhP73PPuvx7/4bkG8Ad+H/xE1wSuKcaWt1tOPSr1kHtYYOIQJEVzAq5ov4K6V1SufgPDxE/dm69uihkmTsCPqQGvqj0KX9KSMyCZdGASjd+vTDzNljqbuGyAWUuA2Nnns48a/9tYbHP+Hl+mLpy5sNzDAhOGIEkNJws3Waqsl4QT0Pjc878nzTB5v/DWeEz+DPmlgMkxm6NeA6bzD89TpdmVpPy3s8POihYtABB7fbf2pX9P/Su2ua0Uty1B1wTQFQRJkfTZ0oeWnl4qrTi6MuoKTkAj9OTdE2XAFEMD3pxpckZowJswYUKdrqTkmUrOR2KTGk2isfWViagAELfSGdw1gWeRWe/KvenftsqgCUDbECRpOAFLTispivyxPlX60BKXJXIPC+KBAxNeIcdBE+cCaXrKZ06ZWWrAy6sbtVkvi/9ei+UtxN9nFfNVFEXxUJMLQDtdE/b03kONHZWX4QC0CUGSBrdf3RYnoKoK8t4+e0VNHjCdBrwcsJy6f0pjA950NumUDXidm1HlfJXj3YB35dmV1GOTMsGUly3z6sksqbPE6zYBzJ36eYWuCaArCJKiseLMCuq5uafYxhubaQoMClQ24PV0o+N3j4tiltpuwBs54MYnXgDtwAwt6AOCpGjww9J8eXPa7bVb7HPRwhODT+AENFGfgz8rG/B6KRvwqqbxIzfgrV+0vphhql249h8b8CJ3AkC3kOsHuoYgKQZcDoDblqhOwMmNJtOY+mPkHhbo2LeQb8oGvJ5uInD62wa8WIUDoHtYNQq6hCDpD849OEeV51QWJyDPInHbEpyA5oMvk7nfdhczTHxpjhtuamrAW7NwTREwNbRvKOoeoZ4LgP6g/hjoCoKkWJi4fyJNODBBOgE5QTCldUq5hwV6xjlLp+6dkvrJRdeAt1zucnTt2TUK/hksvofKwAC6ha4JoCsIkmLZbJVPQFUriRbOLWhHjx04Ac38OcHPBw6YOG9NUwNeliZ5GhpXf5zIYzKmBrwAxgY9EUEXECTF0ovAFyI/SXUCruqwirpW6Cr3sMBAGvBefnJZtEZZe2Etff7+WeNx6g14c6TJofdxApi6PV57qOmypmKb8//4Mje3IgL4WwiS4oBnDJotayadgJ5jPKlgxoJyDwsMxIVHF6jirIoif41lSZWF/D76aTzWObuzVO07X4Z8eh4pgOnqvaU3LTu9TOqacHX0VZEXCPA3ECTFUa/NvWj5meVS41RuW4ITEDihm6f6X3x4IfYnNJhA4xqME5XbeYaJL8vdfn1b4+/yC7kImJybUeFMhXEZFyAeuPRGiaklpPOtb5W+tNhlsdzDAiOFICmeJ2C/qv1oUZtFcg8LZMSnUKsVrWin506xXyFvBVHUjpO41d1/c1+UFeCAyeuFl8bbypc+HzV3bi5LA14AU8EfTvh1WlXEdV+ffdTQoaHcwwIjhCBJCyfg/r77qYF9A7mHBTJZfW41ddvYTWqPwMuPs9lli/F3nr57qmzA6+Um8pk0yWGXQ8wuccBUKmcpnTbgBTA1y08vp15bekmV82+Mv0GZU2WWe1hgZBAk/SW+5s3XvpldcjvRtgQnoPm563+XnKc4SxW63Xq5icTsuPD74BehAa8qp0lfDXgBTBG/tXEOKZ9brHL+yuQxyAPnDsQJgqS/xA9b06VNaa/PXrFfJX8VOj7oOE5AM8Izidx25IbfDbHfs1JPWtZOmTD6t95+eSs14D1572S0DXi5/xsHTPy8i28DXgBT7prAuYKqBRRTGk+h0fVGyz0sMCIIkrR4Ak5tPJVG1Rsl97BAT/pv60+LTyoTQjnh+troa1ptO8LPr/0++0Xid3QNePnynqoBb41CNeLcgBfA1HGBySpzqkhdE84OPUtl85SVe1hgJBAkxdOZ+2dEoUnVCXhu2Dkqk7uM3MMCHTvge4AaLlEmgvLqRg6QuD+brnz5/kVqwMt95TQ14OX+cfWL1RcBU50idf7YgBfAXEzYP4EmHpgotrPbZRd5g+iaALGBIEkLxu8bT5MOThLbOAFN36uPr0Tn8cCgQLG/tO1S6lVZmSCqrwa8R28dFTNM0TXg5RmtukV+N+BNkTSF3sYHYIgV8nk26fyj82IfXRMgthAkaekE5Ca4XEyQtSrRirZ124YT0ARxjlCNeTXo1P1TYr+xQ2Pa3Xu3bP/XnBd1/M5xUVpgn+8+jQ14E1skppqF/t+A16GhWOkDYI5dE/jDjeocWd1hNblWcJV7WGDgECRpyfPA56JtieoEXNNxDXUp30XuYYGWTTs0jUbvHS1V1OZmx4YSdPwK/SWCN55h4gUF776+i3IM126qmr+qKC3AAV66FOlkGSuAHPjDRPPlzcW2dWJruj7mOromQIwQJGkRvzm1WN5COgG5bUmBjAXkHhZoyaXHl6jCrApiNilhgoSiYGSl/JXIEPEYRQNeTzfa7b2bXn96HeUYvg9c+JKLVzZxbIISFmAWem7qSSvOrhDb9lns6fKoy+iaANFCkKRlPTb1oJVnV4ptnICmg2cIeaaQZwzZuPrjaGIjZSKoMTTgvfL0itQeRXUfIuMFB6p+cmjAC6YqOCRYFAO+439H7Pev1p8Wtl4o97DAQCFI0sEJWHxqcVFkkA2oNoAWtF4g97AgHvgUabOqDe24tkPsl8tTjk4POR2l7Yix3BduiaJqj/Lg7QONxzllc5Lao6ABL5iam343RaAUEhoi9tE1AaKDIEkHuLhgyaklpRPwQN8DVN++vtzDgr+09vxact2gTPDkVYu8epFXMRo7PvW5B6Fqhonb7WjCpQ1UM0y8jQUJYAqWnlpKfbb2kbomcNuSTCkzyT0sMDAIknTk31P/Ut+tfcV2muRpRIIvTkDjc8//nmg7EvwzWOzv7LlTzLCYogdvHohgiYOm6Brw5k2XVyR982PAs00ImMBY8Vtfk6VNaJ/PPrGPrgmgCYIkHeGHtfG/jWm/736xX7VAVXIf6I4T0Ijw8vrS00qTr5+v2O9esTutaK9M+DR13ICXE745aOKE9ega8Kr6yZXOVRoNeMHocK0z7prw6tMrsT+tyTQaWXek3MMCA4IgSY8n4PSm02lEnRFyDwti6Z/t/9DCE8qETl4mfH30dbOsYs3FM7lJKM8wRdeAl2dJmzo2FbNMvGIOHwbAmLomVJlbRXyw5eft+WHnqXTu0nIPCwwEgiQdO33/tGhbghPQuBz0PUgNligTOa0srOjq6KtULEsxMncBXwJEDSZO/D55/6QopBpZWpu0ogYTzzDxDCoa8IKhG7dvHE0+OFmaIeW8Q1trW7mHBQYAQZIejN07lqYcmiK2c6bJSd5jvXECGjCuKcQzgO+D3ov9JS5LqE8VZYInRGzAyz3seIbJ/Y67xga8nOjeyL6RmGHiBrwohwGGiIP9SrMr0cXHF8U+uiaACoIkPZ2AFWdXlHI7WpdoTVu7bcUJaKBFGGvOr0kn750U+w3tG9LePnvxfxWLBryHbhwSOUyHbx3W2IA3uVVy0YCXk75rF6lNyaySyTJWAE24fhh/OPr8/bPYX9tpLXUu11nuYYHMECTpybP3z0QxQtUJuK7TOupUrpPcw4JIZhyZQSN3KxM3M6fMLFYl8vJgiFutsKO3fzfg/frjq8YGvHWK1BGX5DhwQgNeMAQ7r++klitaSl0TvMZ6Uf4M+eUeFsgIQZJMJyB/iua2JTgBDcflx5ep/KzyYjaJZ4647Ujl/JXlHpbRrxD0uOMhZph4qfXH4I8aG/DWKFhDzDChAS/IrfvG7rTq3Cqx7ZDVgS6PvExWllZyDwtkgiBJz7pt7Earz60W247ZHOnSiEs4AQ3A5+DP5DjZkZ6+fyr2x9QbQ5MbKxM5QbsNeDlg4tVy0TXg5Xo1PMPU2LExpU+RXpaxgvmK3DXhn+r/0PxW8+UeFsgEQZKefQv5RsWnFKd7b+6J/YHVB9K8VvPkHpZZ41PAZZULbb+2XephdnboWaNsO2IseLbu/MPzImDir+ga8JbPW56aOzUX9ZjQgBf0xfelL5WaVkrqmnCw30GqV6ye3MMCGSBIkukELDmtpLQa6FD/Q1S3aF25h2W21l9YT53XKxM0OTfGd5wvGrzK0IBXBEyebvQs8JnG47hgpao9Ss60OfU+TjAvS04uoX7b+kldE7htScaUGeUeFugZgiSZLD6xmPpv7y/VleE3ZpyA+nf/zX3RdoRn+Nj27tvF8l+QB78ceb/wltqjRNeAly9V8wwTlxZAXh/o6rnY6N9GoswFq1awGrn/447K8mYGQZJM+GFvuKShWP3DqhesTsf+OYYTUI9CfoVQmRllxJsycy3vSqs7KvPFwHAa8PLsEgdNN1/d1Hhc4UyFlTNMzs2oaOaiKNcAWvP+63uyn2QvXQ6e0XQGDa8zXO5hgR4hSJL5BCw2sRj5f/YX+zObzaRhtYfJPSyzMWjHIJrvoUzI5NkIXm2I2j2G3YCX+8nxDJPnc0+Nx+RJl0eskuOgyTm7MwImiLdT905RtXnVRNDOeYrcNaFUrlJyDwv0BEGSzE7ePUnV51eXTsALwy9QyZwl5R6WyTt88zDVW1RPWoJ+ZeQVcsjmIPewIA51x3Z7KRvwqqokR5bdLrvUT65MrjKYpYW/NmbPGJp6eKrYRtcE84IgyQCM3jOaph2eJrZzpc0lTkAU19Md/0/+YgpdtQR9YeuF1L+aMj8MjLcBLwdMZx+c1diAN6NtRrFCjmeYuAEvVi5CXMtXVJpTSeqa0KZkG9rSdQtmKs0AgiQDOQG5bcnlJ5fFvktJF9rcdTNOQB2tpKq1oBZ53PUQ+/WK1qMD/Q7gsTahBrxctJIDphP3TmhswMsrlbgGEyd+VylQRcwkAsRm9pI/XHELHra+83rqWLaj3MMCHUOQZCCevntKDpMdpBNwQ+cN1KFsB7mHZXJmHZ1Fw92GS7ML3HaEVxeC6fn47SPt990vAib32+5SzZvIDXi5Px/PMNUsXBMNeCFGO67toNYrW4ttzl/0GuNF+TLkk3tYoEMIkgwITkDduvr0KpWbWU7MLvDM0fGBx8WyXjB93D9OasB78zAF/wzW2ICXCwZy4jf3lUMSP2jSdUNXWnN+jdhG1wTThyDJwLiud6W1F9aKbadsTnRp5CVcDtACnqHjtiNP3j0R+yPrjKRpTZV5YGCeDXi5tMCBGweibcBbu3BtqQEvknRBhWuqcW01rrHGBtUYRHNbzpV7WKAjCJIM/AQcXHMwzWkxR+5hGTV+irdb3Y62Xt0q9kvlLEXnhp0jSwtLuYcGBlAri/PTeIZpr/feaBvwch0z0YDXviHZJbeTZaxgOHxe+FCp6aWkrgmH+x+mOkXryD0s0AEESQaIixuWnl5aOgGPDDhCtYvUlntYRmvjxY3UcZ0ywZJXDfqM9UFbC9C4gOL0g9NiholXywV8DYhyTKKEiaQGvE2cmqABrxlbdGIRDdg+QGxzXiO3Lclgm0HuYYGWIUgyUAs9FtI/O/4R2+ls0okEY5yAf1eA0GmKk9R2ZGvXrdSmVBu5hwVG0ID3wqMLonAl12N69elVlGM4r618nvJihonrMWVJnUWWsYI8+K2zweIGdOjmIbFfo1ANOjrgKOpxmRgESUZyAtYsVFPMKOEEjD2eiSszvQx5vfAS+53Ldaa1nZT5XgBxKRvBSf+iAa+XGz19/1TjcXwZlwtX8iwT1zsD08e11uwn2ktdE2Y1n0VDaw2Ve1igRQiSDPwE5LYlbz6/Efuzm8+mIbWGyD0sozFk5xCa665MqMyXPp9oO5I8SXK5hwUm0oCXv1S5g5E5ZHWQ2qMUyFhA7+ME/Tlx9wTVmF9D6ppwcfhFKpGzhNzDAi1BkGTgcAL+naO3jlKdhXWkxNvLIy+L5boA2sLn5J3Xd6SA6YbfDY3HFcpYSJphKpalGAqXmqBRu0fR9CPTxXbutLnJa6wXuiaYCARJRmDk7pE048gM6QT0HudNNkls5B6WweKZN54CVyXezm81n/6prszvAtCVh28fKgMmTze6/vx6tA14OVjir+I5iiNgMqGk/wqzKtCVp1fEfrvS7WiT6ya5hwVagCDJSE7A8rPKi7wI1r50e9roulHuYRls/gjPILnfcRf7dYvWpYP9DuLNCPTqeeBzqQEvJ4Brki11NtFPji/LoQGv6XVN2NhlI7Uv017uYUE8IUgyElwE0WGSg1T4DiegZnOOzaGhu5SJk7wa0HecL6VLkU7uYYEZe/3ptbIBr6cbnXlwJtoGvE0cm4gZpor5KqIBr5HadmUbuax2kSq482W3vOnzyj0siAcESUZ8AvJlN56+B6VrT69R2ZllpbYj7v+4U/VC1eUeFkCExRiqBrxcxDK6BryNHBqJGaaqBaqi4r6R6bK+C627sE5sO2d3posjLuL/0IghSDIyndd1pvUX14vt4tmL04URF3AC/r83l+MkR3r87rHYH157OM1opszjAjDUBrwHfA+IgOnY7WMaG/DaJrVVNuB1bibKgHC7FDBsQT+CRNeEB28fiP0hNYfQ7Baz5R4W/CUESUZ4AjpNdqKHAQ/FPtfk4Noc5q7Dmg606bIyUbJkzpJ0fth5tB0Bk2rAyw136xX93YAX5SyMp2sCF5msVaSW3MOCv4AgyQh5PfcSJ+CvsF9i/9g/x6hm4ZpkrjZd2kQd1nYQ27zqz3usN+VOl1vuYQH8dQNenlnigIkb8KoSgdUlsUyibMDr3IwaFGuABrwGaIHHAhq4Y6DUNeHGhBtoY2OEECQZqfnH59Og/waJbT7xuG2JOZ6AjwIeictsQSFBYn9L1y3kUkqZtwVgSg14OZfpw7cPUY6xTGQpNeDlXCY04DUM/NZaf3F9MTPIahWuJRrhYhWjcUGQZMRL3fkEPHLriNjnBriH+h0yqxOQp7LLzSgn1aTpWKYjre+izNcCMMVSILw6jgMmXi339stbjQ14K+evrGzA69gE/R5lFvAlgOwn2UtdE+a0mEODaw6We1gQBwiSjPwE5LYlqhfLuS3m0qCaytklczBs1zCafUyZEJk3XV7yHOuJIptgVg14OWDiekx+H/2iHMMrPMvlLqdswOvUlLKmzirLWM2dxx0PqrmgpphZ4lk/Xu3GhUTBOCBIMnLH7xynmvOV+Uh8Al4aeUksOzV17rfdqdaCWmZ3vwE0zSpfe3ZNao/CNdU04QUNqmrfyNnTrxFuI2jm0Zlim8u2cP0kfKAzDgiSTMDwXcNp1rFZZnMC8swZtx0x1xk0gOjwy7nPSx9RuJIDpntv7kXbgFcETM7NqGDGgnofp7l3TehQpgNt6LJB7mFBLCBIMpHcnPIzy4tPk6aem8Ofmustrica2JprLhZAbHED3l2eu2JswMtBEgdMfFkODXh153HAY3Kc7Ch1TeDebtzjDQwbgiQTPQE3u26mtqXbkqmZ5z6PBu9UJj6a86o+gL9ZCaqaYVJ9oIqMG2irZphK5CiBgEnLtl7ZSm1Xt5W6JviM88GlTwOHIMmEbLm8hdqtaWey9YI8n3tSmellUB8KQIsNeC8+vigu00XGid5NHZUNeMvmLovZWi3ptLYTbbikvNTGgej54efRNcGAIUgyMR3XdqSNlzaa3AmISuMAuuH/yV/ZgNfLjU7fP62xAS+XElA14K2UrxIa8MYDz/Y7T3aWXsuG1RpGM5srk7rB8CBIMsETkIMJnlo3pR5m6FkHoN8GvCfunpBmbdVxscpG9soGvNUKVsN5+BcwK248ECSZwQnoPtCdahSqQaZyHd97nLdYxQcAuvMp+JPUgJcXSkTXgLeBfQMxw8QVpdGA9+/zK2+Mv0HpUqSTe1gQCYIkEzXXfS4N2TlEmir3HedrlCcg13xxmOSAFSEAMuLzj9trcOL34VuH6VvIN40NeOsWqStmmOoWrYsGvH+AlbrGAUGSCZ+AdRfVFY0yGXcNP9jvoFGdgJFri7Qv3Z42uirzrQBAHt9/fpca8O733R9tA16eWeIZJp5pSmmdUpaxGlvNt3kt59HAGsqmuGAYECSZMD7xik0oRgFfA8T+/Fbz6Z/q/5CxGLl7JM04MsNsimQCGGMD3hP3TogZpr0+e6NtwMu5S82dlA1409ikkWWsxtI94PLIy+SU3UnuYcH/IUgyccduHaPaC2sb3Qmo3u+IV9JcGnEJ/Y4ADFhoWKhowMvFK2NqwMur41QNeDOmzCjLWA29DyV/IMTlSsOAIMkMDN05lOa4zxHb+dLnI88xngZ9AvIKG27cq+qcPbv5bBpSS5lfBQDG0YD34qOLUj+5mBrwcuFKrseUzS4bmXPXhHIzytH159fFfqeynWhd53VyDwsQJJnPCVh2Rlmx6o11LteZ1nZaS4aIn471F9cXSaKsZqGadGTAEaPKpQKAiOc0V/hWtUeJrgEv13VTVfs2x9WrXLbFcZIjBYUEif0tXbeQSykXuYdl9hAkmYmHbx+K+kmqE3Br163UplQbMjQLPRbSPzuUeVPpbNKJtiO8Og8AjB+/3fi+9JVmmO7639V4nH0WexEscdBUKFMhMhebL2+m9mvai23Ov+S2JbnS5pJ7WGYNQZIZ2XRpE3VY20Fsp0iaQrQtMaQT0PuFN5WeXlrMfDGeQeJlsQBgug14RcDk6Ua+fr4ajymQoYDUgNc+q73J95PrsKYDbbq8SWyXzFmSzg87T5YWlnIPy2whSDIz/CmFP62wUjlL0blh5wziBOS2I85TnOnB2wdif3DNwTSnhTKPCgDM43IT95Pjy3LRNeDlD3XikpxTMxFAmGLAFLlrwog6I2h60+lyD8tsIUgyM1zThE/Ax+8ei/2RdUbStKbT5B4Wua53pbUXlHlSztmd6eKIi2h3AGCmXgS+oN3eu8UM04XHFzQ24M2SKgs1dWoqSguUzVNWrJwzFdefXacyM8qIFYMcCLr/407VC1UnQ9CpUyfasEHZoJfHljhxYkqVKhXlyZOHGjRoQD169CBbW1syBJ8+faIFCxaI7cqVK4uvuEKQZIauPb1GZWeWlU7A4wOPizomctl+dTu1WdVGqtrLlwHzps8r23gAwDAb8HKJAV45Fxm39VA14K2cv7JJNOCdc2wODd01VGxzXia3LUlrk9aggiRNsmfPTocPH6ZCheTPJXv27BnlzJlTbI8fP54mTJgQ59vAkiEzVCJnCZrWRDl7xDEyX4LjZfdyePruKfXY3EPaX+qyFAESAEi4llLvKr3pxOAT9GbOG1rdYbXoIMB131S4JtPyM8upxvwalH5weuqyvotYIcvFLo3VoBqDxOpexuVQOq3rpHFGTU6nTp2inz9/0s2bN6lVq1bie8+fP6f69evTt29RW9cYIwRJZmpwjcFS01v/z/7UeV1nvZ+A3HbEZbWL1Nagbam21L6McmUHAEBkXK3btYIrHR5wmALmBdDGLhtFFW9ug6LCVb/XXVhH9RbVo3SD01G71e1oj9ce0U7FmHDZkw1dNohVvoyDvkUnFpGhsbS0pCJFitD27dupTJky4ntPnz6ltWuV6RMcRE2fPl0ckzRpUrKxsaGqVavSiRMnItwOXwrjKxs5cuSg8+fPU6lSpShJkiSUK1cuWrVqVZS/u23bNipbtiwlT55c3G6xYsVo3rx5FBamnGnkWSPVLBKbOHGiuH3+On36dOzvIF9uA/Pk/8lfkXZgWgV1JfG10GOhXv/+qN2jpL+da2Quxefgz3r9+wBgGr5+/6rYcXWHouXylopkfZJJryvqX9a9rRUtlrVQbL+6XfHl+xeFsThy84h0HxL3TKzweu4l63g6duzIn6bF16lTpyL8bMeOHdLP6tSpowgNDVVUr15d+p76V4IECRTbt2+XfrdSpUri+9bW1oqkSZNGOX7dunXSsWPGjNF4m/zVokULccz48eOjPSbyuGOCIMnMHb5xOMIJ6P3cWy9/98SdE4oE3RKIv2vRw0Jx5ckVvfxdADBtwSHBij1eexTtVrdT2Paz1RgwWfW0UjRc3FCx4cIGxYegDwpDN/i/wdLY843OJ4JCQwySvL29pZ8VLFhQsWnTJml/6dKlim/fvin8/PwUZcqUEd/LkCGDCKTUgyT+GjBggOLTp08Kd3d3hZWVlfhe5syZFWFhYYonT54oEiVKJL6XN29exd27dxX+/v6KChUqSL/Pv8eePn0qfY+Dpr+By21mrk7ROuLaN+P6RK1XtaZvIbq9lvz+63tqt6addHlvauOpYjkvAEB8JU2clBo7NqZNrpvEJbnD/Q+Ta3lXsktuJx0TEhpC+333U8d1HcUluToL69Dqc6tly838E84h5VW/jMukDNg+gAxReHi4tM2XtTiBW6V3796ULFkyypIlC126dEl8782bN3Tnzp0ol++mTZsmVsjVqFFDrJhjr169oocPH5K7u7t0SW3AgAFUoEABypAhA40bN066jaNHj2rtPiFIAnECOmVTNr29/+a+Tk9ADow6r+8s8qBY9YLVaUhN9GUDAO3jMiL8QXB1x9Ui6dtjkAf1qtwrQhV/XuV79NZR6raxG2UYnIGqzqlKS08tFavqDOl+bOu2Taz+ZVwuhVcFG5oHD5R17hjnFr179+eg88OHDxH27ezsyNraWtrnoErl/fv34ksla9asGrdj83djC0ESkJWlVYQTcM35NbTj2g6d/K0lJ5fQwRsHxTYvZ+XES/RlAwBd47IAXOpkadul5DfLTxTSHVBtAGVN/fvNNVwRTqfun6I+W/tQ5mGZqfzM8jT/+Hx6Hvic5Marfnn1rwqvCubVwYZk4cKF0nbdunUpbdrfJQv8/f3Fh2T1L555qlSpUoTbCAwMpO/ffyfZ+/n9bo6cJk0a8aXpZy9fvoxwHNNGsVG8O4GQL0M++tflX2m/+6buWj8BuWfTkF2/Z43Wd14vlvcCAOgTF54sn7c8LWi9gJ7PeE5XRl2hYbWGUe60uaVj+E38wqMLNOi/QZRjRA4qMaUEzTwyU6qELQde/curgBmvCubVwbxKWE6/fv2iW7duUZs2bejy5cvie7wirXPnzlSnTh3pOC4yyeUBeLXb3bt3xSU1/h1Ntzd69Gj68uULHT9+nA4cOCC+nzlzZsqbN6+4BKf6YL1o0SIxe8WX7aZMmSLdRu3aynZWXORS5d69e+K240wLeVxgIsLDwxUuK12kBMHS00orfv76qZXbDvoRpCgwpoB02wO3D9TK7QIAaPM10OeFj2LMnjGKgmMLakz65q9iE4opJu6fqLjld0v8jj7xKmBeDawaC68SlitxmzR85ciRQ3H79m1xLCdlV6tWLdpjOVlbRZW4nTx5cvEV0+q2kSNHRnubTZs2jTDefPnyRTnm169fsb6/CJIgygmYc0RO6QQcvXu0Vm6364au0m06TnJU/Pj5Qyu3CwCgK3de31FMPjBZ4TDRIdqAKf+Y/OJ1kpfm6ytg4tXAvCqY/z6vEubVwnIFSYkTJxar1MqXL6+YNWuWWJWmLiQkRDF9+nRFkSJFFEmSJFHY2NiIlW89evRQnD9/PkqQlD17dsXly5cVpUuXFivbOOhasWJFlHFs3LhRUapUKVEygI/j2+e/HzkAunTpkqJEiRIRygrEJUhCWxKI4sqTK1R+VnmpbcmJQSeoSoEqf317/137j1qtVFZj5bwnrzFe4vIeAICxeBzwWLRG4a+rT69qPCZnmpwRGvDqMt9y1tFZNNxtuNjOaJtRtC3hYpvGqnLlynTmzBnR1oTbiRgKBEmgEV97H7F7hNjOlDIT+Y7z/asT8Nn7Z+QwyYE+f/8s9td1WkedynXS+ngBAPTl5YeXtNtrtwiYzj86r7FbQeaUmamZszJgKpennNYb8HLSc60FtcjjrofYr1+sPu3vu18rycpyqIwgCYxJ5BOwgX0D2tdnX5xOQJ6Jqji7Il16rKyJ0aZkG9rSdYvRnsQAAJFxXzVVA97T909rbMDLrUVEA17nZlQ5X2WytPjddy4+uEyB/SR7qb7TotaLqF+1fmSMKiNIAmPDJ2CxicXofZCyLsXiNoupb9W+sf79sXvH0pRDU6RpaO+x3mRrbauz8QIAyIkL5XKRyl2eu8QHzF9hUVdTpU6WWvSb4xkmrhPHJVjig3u6cZ86VT2lq6Oukn1We+UPf/4kun2b6PFjIi7AyEvjHR2JUqeO1980JwiSINYnoJWFlVgqK52AMeBPVFXnVhXT0Fyf5Pyw81QqVyk9jBgAQH6fgj+JmnBunm509PZR+vHrR5RjUiRNQfWL1hczTLUL1yZrq99FFONi0I5BNN9jvtgukKEAXa+ykJKtWEO0Zw+vqY/6C0WLEvXrR9SuHVHSpH/1N80FgiT4o4E7BtICjwW/T8Ax16XCk9F9muIp4NefXov96U2n04g6yvwmAABzE/QjiI7cOiJmmA7dPKSx9ZN1YmuqW7SumGGqV6we2SSxifXth/wKoTIzypD3C2+x3/Ue0arLFkShoZp/gVMe+K0/Rw6iTZuIypf/+ztn4hAkQaxOwNLTS5PPSx+x361CN1rZYaXGY/np1PjfxmLKmXGFW/d/3FFVGwCAiL7//E7ud9zFDBO/TqoWtajjWfuahWtSc6fmIh80VbLfRRHVPXn3RFQDr5SvEj3yPEVOS2vQNwvlW/qOE0Qt/1QPOFEiTkAlWr2aqEsXrdw/U4MgCWKFe7o5TXai4J/BYv+/Hv9Ri+Itohz376l/qe9WZd5SmuRpyHe8r1gdBwAAEXFT8ZP3TooZpr0+eykwKFBzO5UC1cQMEzfu5XZOqst5mYZmEkFXO8cWtH76RdqU3J86l1c2mbUNIfLZQ5QjKBYD4ZmlXbuImjbV+n00dgiSINbWXVhHXdYrP23YJrUVAVB2u+zSz2/43aCSU0uKDtvsYL+DYtoYAAD+vBr47IOzYpXcbu/dYtVcZAkTJKSK+SpSc+fmInAqPrW4dOmuzeMEtOG0gjpWItqWR3l8mbdEZw8S/X9yKeYgydaWe3cQpU+vi7tntBAkQazxU8VllQttv6bsPl02d1k6M/SM+KQTHBIsTti7/nfFz7hxJPdFAgCAuJdgufTkkphh4npMLz680Hgc54g+fPuAwhTK2aMWT4iWnicq2ZjoaQrlMWO8iSZ7xuKPWlgQuboSLV+uzbti9BAkQZx8Dv4sikM+C1TWsRhbfyxNajSJemzqQSvPKvOUHLI60OWRl+O9tBUAwNzxW/T1Z9elat9/arBb049orBdRlfpEoQn5TZ7o5GGiyv6x+GNJkhC9eaOcVQIBQRLE2eXHl0XbEi6axoUhx9cfTxMOTJBWaHiO8aQCGQvIPUwAAJPCb9ec1sDB0rYr2+jRO80Bk8N7olZPiEaW/H3Z7eKBWP6RbduIWrfW3qCNHJYcQZyVzl2aJjeaLJ20Ew9OlH7GBScRIAEAaB9/KOU6dZysHV2AxG6mJhp2g6je/6/S2SnTRP/M0pLIMzbX5syHhdwDAOM0rPYwOn7nOJ26f0rqW9SyeEvqXK6z3EMDADBpXEJAk2S/iKxDifreVs6A7Hcn8kxDVORjLG+Y6ypxdW6QIEiCv8LNGjn3iIMklRI5SqAvGwCAjq3qsIrWX1xPqV6+pXxrd1P+T0T5vhCljjRjxIFSCWVXqdjhD7zcvgQkyEmCv3Lm/hnRdiT8/6sqVAXQro2+RkWzFJV1bAAAZuHcOaKKFbV3e7zCrWNHZXFJEJCTBHHGBc/arWknBUhlcpUR/3J9pNYrW4tyAAAAoGMODsoaR9rCs0jOztq7PROAIAnihCceu27oSn4f/cR+lfxV6Pig42SfRdn09o7/HRr03yCZRwkAYAZsbJRBjbbaPvGFpapVtXNbJgJBEsTJ8jPLRfl8Zpfcjja5bhLNbrd33y6W/7MVZ1eIvkQAAKBj/fop+6/FF/dxq1yZKH9+bYzKZCBIgli76XeTBu4YKO2v67SOMqfKLLZ52f+i1oukn3Xd2JVeBGquEgsAAFrSqhVRvnzKICc+ONCarCztAr8hSIJY4TyjNqvaSH3Z+lXtJ7pTq+tSvosoA6Bqvth2dVvRjwgAAHTEyopo82blpbK/xXlN/fsTlS+vzZGZBARJECuDdw6m269vi+1iWYrRrOazohzDy/9XtF8hNb09/+g8TTk0Re9jBQAwKyVKEG3apAx24prIzcfXr080e7auRmfUECTBH3GDRc5FYkkTJxX5R0ksk2g8NqV1Stradauoo8QmH5wsOlsDAIAOubgQHTxIlDp17C698TEcIA0YQOTmpqy2DVEgSIIYcV6R6wZXaZ/zjgpmLBjj75TNU5YmNlS2KuEyAXzZ7cO3DzofKwCAWatbl+j+faI+fYiSJftd+4hXv3FAxNsqnKTNdZbmz0eAFAMUk4RocT4RF4w89/Cc2G/h3IJ29NgRq6ra3Py2+rzqdPr+abHfxLEJufVyQ0VuAAB9CAoicue+JJ5Ejx4payClTUvk5ERUpQpRnjxyj9AoIEiCaE3cP5EmHJggtjnPyGecj7icFluvPr6iYhOLSbNIy9ouo56Ve+psvAAAANqEy22g0bkH52jSwUlim/OLOM8oLgES4/IAXCZAZeB/A+nWq1taHysAAIAuIEiCKHjmp+2atlLbkQkNJog8o7/R0KEh9a3SV2z/+PVDtC35/vO7VscLAACgCwiSIAK++tptYzd6+eGl2K+UrxKNrDsyXrc5u8VsKppZ2fSWywhwOQEAAABDhyAJIlh5dqVY8s9SJ0tNm103S8v5/xaXC+CyAVw+gC07vYz2eO3RyngBAAB0BUESSG6/uk3/7PhH2l/baS1lSZ1FK7ddKFMhWthqobTPZQVUs1UAAACGCEESCJwn1HpVa5E3xPpU6UONHBpp9W90rdCVmjs3F9sfgz+K+klcKgAAAMAQIUgCYcjOIdLKM84fmt1c+yXquUbSyvYrKVvqbGKf6y9NPTRV638HAABAGxAkAe313ktLTy+N0HZElT+kbamSpaKt3bZSwgTKp97EAxPp/MPzOvlbAAAA8YEgycxxXlCX9V2k/QWtFoj8IV0ql6ccTWioLFLJZQZcVrvQx28fdfo3AQAA4gpBkhnjfKB2a9qJ/CDWzKkZdavQTS9/e1TdUVQxX0UpUOOyAyj+DgAAhgRBkhmbdnganX1wVmxnTZ2VVnVYpbfealxWYIvrFlFmgLl5udGqc6v08rcBAABiA0GSmbrw6AJN2K+85MX5Qdx2hPOF9InLC6zpuEbaH7B9gChDAAAAYAgQJJkhzv9xWeUitR0Z32A8lc9bXpaxNHZsTL0r9xbbXH6gzao2aFsCAAAGAUGSmbYdefHhhdjnvKDR9UbLOqY5LeZQkcxFxPbNVzdp6K6hso4HAACAIUgyM6vPrRb5PyyVdSqttB2JL1F2oNt20b6E/XvqX9rns0/WMQEAACBIMiN3Xt+hATsGSPucD8QJ24agcObCovyACpcl8PvgJ+uYAADAvCFIMhOc79N6ZWsp36dX5V7UxKkJGZLuFbtTU6emYvvDtw+iPAHalgAAgFwQJJmJoTuHinwfVjhTYZrbYi4ZGi4/wGUIVLNbZx6coemHp8s9LAAAMFMIkszAfp/9tOTUErHNeT+6bDsSX1w3iesnqdqWTDgwQZQrAAAA0DcESSbu1cdX1Hl9Z2l/fsv50koyQ1UhXwUaV3+c2ObLbVyu4FPwJ7mHBQAAZgZBkhm0HeH8HtbEsQn1qNSDjAGXJaiQt4LY5nIF3Td2R9sSAADQKwRJJmzGkRl0+v5psZ0lVRZa3XG13tqOxJdFIgtRnoDLFLCdnjtpzfnf1bkBAAB0DUGSibr46CKN3z9ebHN+z5auv/ukGYtsdtlEYKfSf3t/uut/V9YxAQCA+UCQZII4f8dltYu0fH5s/bGisrYx4pIAPSv1FNtcvoDLGHA5AwAAAF1DkGRiOG+H83eeBz4X++XzlKcx9caQMZvXcp4oW8Bu+N2gYbuGyT0kAAAwAwiSTMza82tF/g5LaZ1SXGbj/B5jJtqWdP/dtmTxycV0wPeA3MMCAAAThyDJhHC+DuftqKzusFrk9ZgCLlvAM0oqXNaAyxsAAADoCoIkE8F5Om1WtqHgn8Fiv0fFHtTMuRmZEs5NauzQWGwHBgVS+zXt0bYEAAB0BkGSiRjuNpx8/XzFdqGMhSLMupgKLl+wptMaUc6Anbp/imYemSn3sAAAwEQhSDIBnJ+z6MQisW1lYSXyd6ytrMkUcRkDrp+kalsybv84uvT4ktzDAgAAE4Qgyci9/vQ6QtsRnkEqmqUombJK+StJK/b4clubVW3QtgQAALQOQZKxtx1Z3U7k57BGDo2oV+VeZA649lO5POXENpc76Lm5J9qWAACAViFIMmKzjs4SeTksc8rMtKbjGqNpOxJfXNaAyxtwmQO249oOWndhndzDAgAAE4IgyUhdfnyZxu4bK7Y5MOKAwS65HZmT7HbZaVWHVdJ+v2396J7/PVnHBAAApgNBkhH6HPxZ5OGolr9zfg7n6Zij5s7NqXvF7mKbyx+gbQkAAGgLgiQjw3k3PTb3oGeBz8R+2dxlaVz9cWTO5recTwUzFhTbXAaByyEAAADEF4IkI7P+4nqRf8Nsk9rS1m5bjb7tSHxxuQMue8DlDxiXQzjoe1DuYQEAgJFDkGRE7r+5T3239pX2OR+H83KAqFiWYjS35Vxpn8sicHkEAACAv4UgyUiE/AoR+TaqtiPdKnSjFsVbyD0sg9K7cm9qaN9QbL8Peo+2JQAAEC8IkozEiN0jyOelj9jm/JsFrRbIPSSDw6v81nZaK8ohsJP3TtLsY7PlHhYAABgpBElG4NCNQ7TAQxkUcd7Ntm7bTLbtSHxxGYTNXTdL9aLG7B0jyiUAAADEFYIkA+f/yZ86resk7c9pMYfss9rLOiZDVzl/ZRpdd7TY5sttLqtdRNkEAACAuECQZMDCw8Op/dr2Ir+GNbBvQH2q9JF7WEZhfIPxVCZ3GbH99P1TtC0BAIA4Q5BkwDif5sTdE2I7U8pMtLbjWrNpOxJfXBZha9etokwC235tO224uEHuYQEAgBFBkGSgrjy5QmP2KTvdc2C02XUzpbFJI/ewjEqONDkitC3pu62vKKMAAAAQGwiSDLjtSGhYqNgfVWcUVSlQRe5hGSUuk9C1Qlex/S3km3hcuZwCAADAnyBIMjCcN9NrSy+RR8M4r4bza+DvcbmEAhkKiG3vF940cvdIuYcEAABGAEGSgdl4aSNtu7pNbKdImkLk1VhaWMo9LKOWzCqZaFuS2CKx2J/vMZ8O3zws97AAAMDAIUgyIA/ePKA+W3+vXlvZfqXIq4H447IJc5rPkfa5rAKXVwAAAIgOgiRDajuyqrXIm2Gu5V2pVYlWcg/LpPSt2pfqF6svtt99fUcd1nYQZRYAAAA0QZBkIEbtGSXyZVj+DPlpYeuFcg/J5PAqwXWd1lFG24xi3+OuB81x/z27BAAAoA5BkgE4cvMIzTs+T2xz3sz2bttFHg1oH5dR4HIKqnpTo/eOpqtPr8o9LAAAMEAIkmT25vMb6riuo7Q/u/lscsjmIOuYTF3VglVpZB3lCjcus8BlAb58/yL3sAAAwMAgSJIR58NwXgznx7B6RetRv6r95B6WWZjQYAKVzlVabD9594R6be6FtiUAABABgiQZzT0+l47fOS62OU9mXed1aDuiJ1xWgcsrcJkFtvXqVtp0aZPcwwIAAAOCIEkm155eE8najAOjTa6bKK1NWrmHZVZyps0pyiyo9N7aW5RhAAAAYAiSZMD5L+ptR0bUHkHVClaTe1hmicssdCnXJULbkp+hP+UeFgAAGAAESTLggpGP3z0W26VylqKJDSfKPSSztqjNIlF2gXm98JJm+AAAwLwhSNIzznvZfHmz2OZ8mG3dtqHtiMy43AL/P6jalsx1n0tHbx2Ve1gAACAzBEl69PDtQ+q9pbe0v7ztcpEXA/JzzOZIs5rNkvY7ru0oyjMAAID5QpCkJ5znwvkuQSFBYr9zuc7UplQbuYcFavpX6y/KMLCArwEiUELbEgAA84UgSU9G7xlNns89xXa+9PloUetFcg8JNLUt6byOMthmEPvud9ylSugAAGB+ECTpwbFbx6QeYZaJLEX+S/IkyeUeFmjAZRjU25aM3DNSlGsAAADzgyBJx95+eSuqaqvMbDaTnLI7yTomiBmXYxhee3iEtiVff3yVe1gAAKBnCJJ0iPNZOK+F81tYnSJ1aEC1AXIPC2JhUsNJVDJnSbHN5Rr6bOkj95AAAEDPECTp0HyP+XTs9jGxnT5FelrfeT0lTIiH3BhwWQa+LGqTxEbsb7q8CW1LAADMDN6xdeT6s+s0crey0zzjtiPpUqSTdUwQN7nS5qIV7VZI+1y+4VHAI1nHBAAA+oMgSQc4f4XzWH6F/RL7w2oNoxqFasg9LPgLXKahU9lOYpvLN7RZibYlAADmAkGSDvTd2leacSiRowRNbjxZ7iFBPCxus5jypssrtq8/v05j9o6Re0gAAKAHCJK0jFuObLy0UWxzPot6uwswTlyuYXv37aJ8A5t9bDa533aXe1gAAKBjCJK06HHAY+q1uZe0v6ztMsqdLresYwLt4LINXL5Bhcs6cHkHAAAwXQiSdNR2pEOZDtS2dFu5hwVaxOUbuIwD4wCp07pOaFsCAGDCECRpydi9Y+naM2Vl5jzp8tASlyVyDwm0jMs3cBkHLufAjt46Sgs8Fsg9LAAA0BEESVrA+Smzjik7yHPeCuevqOrrgGnhMg5czkFlxO4RUk8+AAAwLQiS4ingS0CEtiPTm04n5+zOso4JdIvLOXBZB8ZlHlqvbI22JQAAJghBUnzbjqzrKCXw1ipciwZWHyj3sEAPuKwDl3dgXO6h39Z+cg8JAAC0DEFSPCw8sVDkpbB0NuloQ5cNaDtiJrisg3rbkg2XNtCWy1vkHhYAAGgR3tH/ktdzLxrupuwUzzZ22Sgl9IJ54PIOXOZBpdeWXqIMBAAAmAYESX8h6EeQyENRtR0ZUnMI1SpSS+5hgQy4zAOXe1BvR4O2JQAApgFB0l/ot60fPQx4KLY5SXtqk6lyDwlkxOUeuOwD4zIQ4/aNk3tIAACgBQiS4mjrla20/uJ6sZ3cKjnajoDIS1JvWzLz6Ew6fue43MMCAIB4QpAUB0/ePaGem3tK+0vbLqW86ZWNT8G88Ywil39Q4bIQXB4CAACMF4KkWPoV+kvkm6jq4bQr3Y7al2kv97DAgHD5By4Dwd58foO2JQAARg5BUiyN2z+Orj69KrZzp81N/7r8K/eQwMBw+QcuA8HlINiRW0do0clFcg8LAAD+EoKkWPC44yHyTJhFIguRh5QiaQq5hwUGiMtAcDkIlWG7holyEQAAYHwQJP3Bu6/vqP3a9qRQKMT+tCbTqEROZaVlAE24HASXhWBcJoIv03LZCAAAMC4IkmLAgRHnlXB+iapn1+Aag+UeFhgBLguh6uH34O0D6r+9v9xDAgCAOEKQFINFJxbR4ZuHxXZam7TiMgrajkBc2pZwmQi27sI62nZlm9zDAgCAOMA7fjS8X3jTMDdlp3e2ofMGymCbQdYxgXHh8hBcJkKl55aeoowEAAAYBwRJMbQdUbWXGFRjENUpWkfuYYER4jIRXC6Cffn+hVxWuYhyEgAAYPgQJGkwYPsAkUfCnLI5iWRtgL/F5SK4bAS78vQKTTgwQe4hAQBALCBIimT71e209sJasZ3MKpnIK7GytJJ7WGDEuFwEP4+4fASbfmQ6nbx7Uu5hAQDAHyBIUvP03VPqsblHhBmAfBnyyTomMA1cNkI1I8mrJtutaUfvv76Xe1gAABADBEn/x3kiLqtdRN4IcynpQh3KdJB7WGBCuHwEl5Fg/p/9qfP6zlL9LQAAMDwIkv6P80QuP7kstnOmyUnL2i2jBAkSyD0sMCFcPoLLSHA5CXbwxkFacnKJ3MMCAIBoIEgiEvkhnCfC0HYEdInLSHA5CZUhu4aQ70tfWccEAACamX2QxHkhnB+iuuwxpdEUKpWrlNzDAhPG5SS4rATjMhNcbuJbyDe5hwUAAJGYdZDEgRHnhXB+CKtesDoNrTVU7mGBGeAkbi4vwe69uUf/7PhH7iEBAEAkZh0kcT4I54WwNMnToO0I6A2XleDLulxmgq0+t5r+u/af3MMCAAA1ZhsRcB4I54OobOiygTKmzCjrmMC8cHkJLjOh0n1Td3r2/pmsYwIAADMPkjj/Q73tyD/V/6G6RevKPSwwQ1xmgstNsM/fP4syFKFhoXIPCwAAzDVI4vwPzgNhDlkdaEbTGXIPCcwUl5ngchNcdoJdenyJJh6YKPewAADAHIMkzvvg/A9mndiatnffjrYjYFBtS6Yenkqn75+We1gAAGbPrIIkzvfgvA+VJS5LKH+G/LKOCYBx2QkuP6Faddl2dVu0LQEAkJnZBEmc58H5Hpz3wVqXaE2dynaSe1gAEi4/wWUo2OtPr8l1gyvalgAAyMhsgiTO8+B8D5bDLgctb7ccbUfAINuWcDkKtt93Py09vVTuYQEAmC2zCJI4v4PzPFiihIlE/oetta3cwwKIgstQcDkKlcH/DaYbfjdkHRMAgLky+SCJ8zo4v0N12WJyo8lUOndpuYcFEC0uR8FlKVhIaIgoVxEcEiz3sAAAzI5JB0kcGHFeB+d3sKoFqtKw2sPkHhbAH3FZCi5Pwe7636WB/w2Ue0gAAGbHpIMkzufgvA5ml9yONrluEpfbAAwdl6Xg8hRcpoKtPLuSdnnukntYAABmxWSDJM7j4HwOlfWd1lOmlJlkHRNAXHB5Ci5TodJtYzd6Hvhc1jEBAJgTkwySOH+D8zg4n4P1r9af6tvXl3tYAHHGZSq4XAX7FPxJ5NehbQkAgH6YZJDE+Rucx8Hss9jTzGYz5R4SwF/hMhVcroLLVrALjy7Q5IOT5R4WAIBZMLkgifM2OH9Dve1IEsskcg8L4K9xuQouW6HKp5tyaAqduX9G7mEBAJg8kwqSOF+D8zZUFrVeRAUyFpB1TADawGUruHwFC1eEU7s17SgwKFDuYQEAmDSTCZI4T4PzNThvg7Us3pK6lO8i97AAtIbLV3AZC+b30Y+6buiKtiUAADpkMkES52lwvgbLbpeduhXsRu3ataNs2bKRlZUVpUuXjsqWLUtz586lb9++0ZUrV6h+/fri50mTJhXH5MmTh/r160fv3r2T++4ARMGX27iMBZezYHt99tLyM8vlHhYAgMlKoDCBj6Kcn1F1blVxGYLfSLpm6EorJ6+M9lO2t7c3Xb9+nbp1+31pTl3hwoXpxo0bopcWgKE56HuQGixpILatLKzo2uhrVDRLUbmHBQBgcow+CuC8DM7P4ACJtcrTilZMWiECJGtra1qzZg19+vSJgoKC6MSJE1S3bl1xXP78+Wnz5s308uVL+vHjB509e5bs7JSf0G/fvk2+vr6y3i+A6HA5Cy5rwbjMRZtVbdC2BABAB4x6JomH3nRpU3HZgVXOX5k+bP5AN3yVDUGXLVtGPXv2jPJ7YWFhlChR1MrbzZo1o927d4vtmzdvUpEiRXR+HwD+xo9fP6j0tNLk66cM5ntW6knL2i2Te1gAACbFqIOkZaeXUe8tvcV26mSpyaO3BznldxL7NjY2FBgYSJaWln+8nZCQEJGj1KRJE/rw4QNVqFCBzpw5I2rUABiqe/73yHmKMwX/VM4iufVyo6ZOTeUeFgCAyTDay203/W7SwB2/m36u67SOfn78Ke3nypUrVgFSkiRJxFelSpVEgFS5cmU6cOAAAiQweFzegstcqHAz5xeBL2QdEwCAKTHKIInzLzgPQ9V2pG+VvtTQoaFWApvTp09To0aNKDQUrR/A8HGZCy53wbj8BefnoW0JAIAZB0mDdw6m269vi+2imYvS7BazxTYv51d58uRJrAIdTtr+/v07Xbt2jYoWVa4Q4ktt+/bt09n4AbSFPxisaL9ClL1g5x6eo6mHpso9LAAAk2B0QdJur91SbZikiZNGaDuSIUMGsre3F9tfv36ltWvXarwNTtxWx5fbihcvTq6urtL3Hj58qMN7AaA9Ka1T0tauW6W2JZMOTqJzD87JPSwAAKNnVEES51tw3oXKwlYLqVCmQhGOGT9+vLQ9ePBgWr9+PX358kUUkDx58qQoAcAr1/hnhw4dIn9/f5G47ePjI45Vz2kCMBZl85SliQ0nim0uh9F2TVv68O2D3MMCADBqRrO6jfMsuGAkX05gzZ2b0389/tOYhzRt2jQaM2ZMjMUkGzduTM+fP9f4c55VunDhAiVOnFjL9wJAd8LCw6j6vOp0+v5psc8r3Xb13IVFCAAApj6TxHkWqgApW+pstLL9ymhf/EeNGkUXL16kNm3aUJYsWUSwkyZNGipdujTNnj2b8ubNS927d6cyZcpQ2rRpycLCgpInT05OTk40efJkOnXqFAIkMDp8uW2z62ZRDkN1aXrl2ZVyDwsAwGgZxUwS51dUnlNZXEZImCAhnR12lsrlKSf3sAAM0n6f/dTo30Zim/P1ro++ToUzF5Z7WAAARscgZ5K+/vhKzwOVl8I4r4LzK1RtRyY0nIAACSAGXA6Dy2KoKnO3XtWavv/8LvewAACMjsEFSVzrJe/ovJR7VG5yv+1O3TZ2o5cfXoqfVcxXkUbVHSX3EAEMHpfF4PIY7NarWzRk5xC5hwQAYHRku9z242coPfT/TI/ffqFvP0LJIlFCymqXjB68P02dN7QRxzR2aCz1ZeM8C99xvpQldRY5hgtgdO68vkPFpxaXZpH29N5DjR0byz0sAACjofcg6eX7IHK7/IQ8bryiX2HhxLnXCRMkIB5FuEJBjz9vo8eft4hjLRNZ0q+wX2IbL/AAcbfq7Crqvqm72E5lnYp8x/tS1tRZ5R4WAIBR0NvltrBwBe248Jh6rDhL7r5+IkBiHBzxzzhAYt9+KS+tMVWAxJcNBmwfQMN2DdPXcAFMQtcKXUW5DPYx+KNoW8KlAgAAwEBmksLCw2nmHh86c8f/j8de9O9LQb+eqX2Hl/krpE/CHxaiQB5AXHz89pEcJjnQiw/K5reTGk2isfXHyj0sAACDp5eZpJXH78YqQApXhEWYSVJSBkjJEiej+a3m62iEAKYrVbJUtKXrFlE+g03YP4EuPLog97AAAAyezoMkn6fvae9V9Zmh6AX9fE4KingpICFZUnabRjSi2gHqWLajjkYJYNrK5y1P4xsoW/ZwOQ2XVS5ihgkAAGQKkvhK3nL3O5Qwll0Rfim+qu0loMzJalP5TKsof6pudO52ML14H6SroQKYvNH1RosyGowvvXF5DSOoJQsAYJpB0r1Xn+hpwFcKj+XrcGqrYpQ5WU1KZVWESmdYTIXt+lISizTKgSZIQIc8NfdaA4DYty3h3D7m5uVGq8+tlntYAADmGSRdeRhAiWI7jcRzRwkSUGG7/lQi/QxKkThHhJ/x6rcL997oYJQA5oOX/6/puEbaH7BjgKinBAAAeg6S7r/+ROGxnUaKhXdfftDX78qyAADwd5o4NaFelXuJbS402Xpla9G+BAAA9BgkBXz+/v+1abHz9eczevH1EH0OeRhtrkTgV7yYA8TX3BZzqXAmZdPbm69u0tCdQ+UeEgCAwbHQ5Y3HJSeUgyLPgDH0M/yT2E+SKB2lty5L6a3LkW3i/JTg/8uXkWgKEH9JEyel7d23U4mpJcQs0pJTS6hGoRqiOS4AAOhhJimdbZI45SMlsUgr7f8IC6DnX/fS1bdD6ezrTnT3wzL68OMG2VrrNK4DMBtFMheh+S1/1x7rvL4zvfr4StYxAQCYTcXttSfv0a5LT0TbkdgIDQ+mN8Fn6W3wBREQRa6ZxNLapBWNb5s5NaOqBaqSpYWlDkYOYB749G+2rBnt8d4j9ivnr0wegzzESjgAAHOn0yDp1osPNHjDpb/63V9hXyng+xURMAX+8CYFhUY5JqV1Smpo31AETDUL16QklrGfuQIApQ/fPpD9RHvy++gn9qc0niJqKgEAmDudBkl8092Xn6WXgUFxyk/SNMP07vs1ypzhAZ156C5W5ESW3Co51S9Wn5o5N6M6RepQMqtk8Rs8gBk5++AsVZlTRVTj5lmks0PPUtk8ZeUeFgCAaTe4vf74HY3eejVet8GllqoVzUxDGjnQt5BvdPTWUVEI7+CNg/T1h3qV7t9JqbUL1xYzTBw42VrbxuvvA5gD7uk28cBEsZ3dLjv5jPMRs7UAAOZK50ESW3joBh3xehmncgAqXGk7VbLEtLJXJUqeJGL+Ea/K8bjjIQKmfT776GNw1F5UiS0SU42CNcQME1+as0tuF497AmC6QsNCxWzS+UfnxX4L5xa0o8cOsagCAMAc6SVICg0Lp8m7vOjKg7dxCpS4WjcHRnM6lqFsaZLHeOyv0F906v4pETBxEuq7r+803F4iqpK/iphh4oJ66VOk/4t7A2C6XgS+IPtJ9vQpWFmKY3WH1eRawVXuYQEAmG6QxMLCw2nruUe09dxD8ck0phVv/MGVR2Wfw46GNLSndLZJ4/i3wuj8w/MiYOKv159ea/gbCahC3goiYGrq2JSypM7yV/cLwNS4ebpR8+XNxbZ1Ymu6PuY6FcxYUO5hAQCYbpCk8uTtF9p58TGdueMvAiW+nMY5RzwIVeCUN6MtNS2Vk6oUyRTvqf7w8HC68vSKMmDydKNngc80Hlc6V2kRMPFXzrQ54/U3AYxdz009acXZFWLbPos9XR51GatHAcDs6D1IUuEebNzb7fGbL/Ttxy+ySJSQsqZJRvkypaTMqXWzMo3vqvcLb9rluUsETQ/ePtB4nGM2RylgKpCxgE7GAmDIgkOCRTXuO/7K5rf9q/Wnha0Xyj0sAADzCJLkxnf79uvbYnaJAybuX6UJ97cSAZNzMyqauSiSWMFs3PS7KQKlkNAQsb+/735qYN9A7mEBAOiN2QZJkT1480DKYfJ87qnxmDzp8kgzTMVzFEfABCZv6aml1GdrH7HNK0NvjL9BmVJmkntYAAB6gSBJg2fvn9Fur90iYLr4+KLGY7iODCd88wxTmVxlKGFCnbbBA5AFvzw0WdpElNhgvDr0+KDjaFsCAGYBQdIfcMNPLinAARNXJeaKxJFltM1ITRybiBmmivkqkkUiNOEF0xEYFCjalrz6pGx+O63JNBpZd6TcwwIA0DkESXEQ8CVAfKLmgOnEvROi+F5kaZKnocaOvxvwcjFLAGN35v4ZqjK3iphZ4lmk88POU+ncpeUeFgCATiFI+ksfv32k/b77RcDkfttdSm5Vxy0dGhRrIC7J1SxUU7RLATBW4/aNo8kHJ4vtHHY5RNsStPwBAFOGIEkLuH/coRuHRMB0+OZhCv4ZrLEBb71i9cQMU92iddGAF4wOz5xWml1JytNrVaIVbeu2DQsYAMBkIUjSQX2Zo7ePitICB24c0NiAl4vy1SlSBw14weg8D3wu8pM+f/8s9td2Wkudy3WWe1gAADqBIEmHQn6F0PE7x//YgLd6weoiYGrk0AgNeMHg7by+k1quaCm1LfEa60X5M+SXe1gAAFqHIElPuAHv6QenxQwTr5YL+BoQYwNeTv7OYJtBlrEC/En3jd1p1blVYtshqwNdHnmZrCyt5B4WAIBWIUiSgXoDXq7HpFparY7zPMrnKa9swOvUlLKmzirLWAGiu6xcfGpxuut/V+z/U/0fmt9qvtzDAgDQKgRJMuMGvFefXpWqfT99/1TjcaVylhKr5DhoypU2l97HCRCZ70tfKjWtlLSy82C/g2JxAgCAqUCQZEBUDXhVAdP9N/c1HseXN1T95ApmLKj3cQKoLDm5hPpt6yfVCOO2JRlTZpR7WAAAWoEgyUDxf8ud13ekgOmG3w2NxxXKWEiaYSqWpRiWY4Pen6eN/m1EB3wPiP1qBauR+z/uaNMDACYBQZKRePj2oTJg8nSj68+vazwmd9rc0gxTiRwlEDCBXrz/+p7sJ9nT60+vxf6MpjNoeJ3hcg8LACDeECSZaAPebKmziYRvDprK5i6LT/agU6funaJq86qJmSXuXchtS0rlKiX3sAAA4gVBkpHjT++iAa+nG515cEZjA14uJcANeJs7NUcDXtCZMXvG0NTDU8V2zjQ5yXusNwqlAoBRQ5BkQt59fUd7vff+sQEvF63kGSbOH0EDXtBmLbBKcyrRpceXxH6bkm1oS9ctuOwLAEYLQZIJN+DlZFoOmI7dPqaxAa9tUltqaN8QDXhBq5eCOT/py/cvYn995/XUsWxHuYcFAPBXECSZgdg04OWGu/WK/m7AmzxJclnGCsZvx7Ud1Hpla+l55TXGi/JlyCf3sAAA4gxBkhlWSuaZJQ6YuAGv6hN/5Aa8tQvXFjNMDYo1QF4JxFnXDV1pzfk1YtsxmyNdGnEJbUsAwOggSDLzBrwedz2kBrwfvn2IcoxlIssIDXjT2KSRZaxgXL6FfCPnKc5SQdRBNQbR3JZz5R4WAECcIEgCKemWV8ep+slF14C3cv7KImDi1XJowAsx8XnhQ6Wml6KfoT/F/uH+h6lO0TpyDwsAINYQJIHGBrwXHl2QAia/j35RjuEVS+VylxOX5Jo6NqVsdtlkGSsYtkUnFtGA7QPEdlqbtKJtCYJrADAWCJLgjw14rz27Rrs8d8XYgLdkzpLKat9OzSh3utx6HycYJn55abC4AR26eUjs1yhUg44OOIripgBgFBAkQazxU8XnpY8oXMkB07039zQeZ5/Fnpo7N0cDXpDqd9lPtCf/z/5if1bzWTS01lC5hwUA8EcIkuCvcQNe1QxTdA14OUhSzTDZZ7VHYUEzdeLuCaoxv4bUtuTi8ItUImcJuYcFABAjBEmgFY8CHkkzTHx5ThM04DVvo3aPoulHpkvPBa+xXpQiaQq5hwUAEC0ESaB1zwOfR2jAq+kpljV1VpHwLRrw5ikrVs6B6a+grDCrAl15ekXstyvdjja5bpJ7WAAA0UKQBDrl/8lf2YDXy41O3z8dYwNeDpgq5auEBrwm7Om7p+Qw2UEqYrqxy0ZqX6a93MMCANAIQRLoNYGXi1aKBrx3T9CvsF9RjrFLbkeN7BuJS3JcxBINeE3PtivbyGW1i9hObpVcXHbLmz6v3MMCAIgCQRLI4lPwJ9GAlxO/o2vAy/kqogGvUzOqVbgWGvCakC7ru9C6C+vEtnN2Z7o44iICYgAwOAiSwCAa8HLjXU785no60TXgrVukrphh4ka8aMBr3IJ+BIm2JQ/ePhD7Q2oOodktZss9LACACBAkgUH5/vO7mFniGaboGvBaWVhR7SK1xQxTA/sGlNI6pSxjhfjxfuFNpaeXltqWcJHJWkVqyT0sAAAJgiQw6Aa8J+6dEDNMe332RtuAt1rBaiJgauzQGA14jcwCjwU0cMdAsZ3OJh3dmHCD0qdIL/ewAAAEBElgFELDQkUDXp5h4tVyb7+8jXIMlxHg1XGqBrwZU2aUZawQe/zyU39xfXG5lXHuGTfCRdsSADAECJLAKBvwXnx0UayS46/oGvCWzV1WtEdBA17DFvAlgOwn2dObz2/E/pwWc2hwzcFyDwsAAEESGDd++qo34H3y7onG47jCt6rad550efQ+ToiZxx0Pqrmgpvj/5EuovNqteI7icg8LAMwcgiQwGfxU9n3pK4IlDpqia8BbLEsxZQNep2ZUKFMhvY8TNBvhNoJmHp0ptjmQ5fpJNkls5B4WAJgxBElg0g14xSU5Tzfy9fPVeEyBDAWkGSaHrA7oJydz25Lys8rT1adXxX6HMh1oQ5cNcg8LAMwYgiQwmwa83E+OZ5iia8CbK20uZcDk1IxK5iyJgEkGjwMek+NkR1E7i3FvN+7xBgAgBwRJYHZeBL6g3d67xQzThccXNDbgzZIqCzV1akrNnZqjAa+ebb2yldqubiu1LfEZ50O50+WWe1gAYIYQJIFZU2/AyyUGeOVcZFy3R9WAt3L+ymjAqwed1naiDZc2SEn354efR9sSANA7BEkA//f+63upAa/HXQ+NDXhTJ0tNjRwaicTvagWqkZWllSxjNXV8uc15sjM9DHgo9ofVGkYzmyuTugEA9AVBEkAMDXg5YOI2KT9+/dDYgLdBsQZihonbpKABr3Z5PvekMtPLSMHqsX+OUc3CNeUeFgCYEQRJALFoxioa8HopG/B+C/kW5RjrxNai8S6vkqtbtC6WrmvJPPd5NHjnYOmy543xNyhdinRyDwsAzASCJIC/aMDLARPPNH3+/lljA15ur6FqwJsqWSpZxmoKwsPDqd7ienT01lGxzzN2h/odQtsSANALBEkAf4m715+4e0IETNyANzAoMMoxnORdvWB1ETBxLlNam7SyjNWYcZ8++4n2Ur++eS3n0cAayqa4AAC6hCAJQIsNeDlg4tVyqj5k6hImSCga8HLSNxrwxo37bXeqtaCW2Oa2JZdHXian7E5yDwsATByCJAAt4zIClx5fkhrwvvzwMtoGvDzDxPWYsttll2WsxmTYrmE0+9hssZ03XV7RtiR5kuRyDwsATBiCJAA9NODlwpUcMD1+91jjccWzF1f2k0MD3hgvb5abUY6uP78u9juV7UTrOq+Te1gAYMIQJAHoCZ9qN/xuiNYoHDDd9b8bbQNeVXsUbsCL9igR28s4TnKkoJAgsb+l6xZyKeUi97AAwEQhSAKQCQdJqhkmn5c+Go/JnyG/aI2CBry/bb68mdqvaS+2udQCty3hvnsAANqGIAnAQBq7qnKYrj69qvGYnGlyRmjAa87L4Dus6UCbLm8S2/xYnB92niwtLOUeFgCYGARJAAaGE713e+0WAdP5R+djbMDLAVO5POXMrgEvty1xmuwkLr+xEXVG0PSm0+UeFgCYGARJAAaMSwmoGvCevn862ga8jR0ai8RvLjFgLjMq159dpzIzyojyC3wZ0v0fd6peqLrcwwIAE4IgCcCIGvDu990vAqbjd47H2ICXZ5i4iKWpN+Cdc2wODd01VGxnsM0g2pagYCcAaAuCJAAjbcB78MZBkfh99PbRaBvw1i9aX8wwcZsUaytrMsW2JXUW1iH3O+5in/vmHex3EAnuAKAVCJIATKAB75FbR5QNeG8ckpbHR27AywEEzzDVK1bPpBrw8iVJblsS8DVA7C9otYAGVB9AhubKlSu0aNEiOnfuHL19+5ZsbW0pT5481KxZM+rZsyclS5ZMOjYgIIDy589Pnz59EvvDhw+nGTNmyDh6APOEIAnAxBrw8qwKzzDxpTlzacDLDXB5Rokltkgs2pY4ZnMkQzF9+nQaPXq0xiR85u3tTQ4ODtJ+p06daMOGDdI+giQAeZjvGmIAE5Q0cVKRk7TRdSMFzAugIwOOUNcKXckuuZ10TEhoiAigOq7rSOkGp6PaC2rTqrOr6N3Xd2SsahepTYNrDpYqc7de2VrMsBmCPXv20KhRo0SAZG1tTWvWrBEzREFBQXTixAmqW7duhOPPnz9PGzdujDCzBADywEwSgBngFWBnH5wVl+R2e++OsQEvF67kBryZUmYiY8LBUdkZZcnzuafY71KuC63ptEbuYYkZIl9fX7G9bNkycWktsrCwMEqUKBGFhoaSk5MT3bp1i6ZOnSqCK4aZJAB5IEgCMDOc7HzpySXRHoXrMb348CLKMZz4XCZXGWXxSudmRtOA9+Hbh+Q42ZG+hXwT+9u6baPWJVvLNp43b95QxowZxbaNjQ0FBgaSpWX0JRrmz59PgwYNIldXV2rXrh1VqVJFfB9BEoA8ECQBmDE+/bnekKrat6o4o6YGvBwscdCUN31eMmQbL24UlxJVK/x8xvpQzrQ5ZUvWLl26tNi2t7cnHx/N7WeYv78/FShQgCwsLOj+/ftiNglBEoC8kJMEYMZ4xqhEzhI0o9kMejDlAfmO96Wx9cdSoYyFIhx3/fl1Grl7JOUbk4+KTShGE/dPpNuvbkebiCyn9mXaU9tSbcX2l+9fyGW1C/0KjVpTSh/iUopg8ODB9OXLF5HknSZNGp2OCwBiBzNJAKDRPf970gyT9wvvaBvwqvrJ8WoyQ6lPxMERX3Z78u6J2B9VdxRNbTJV9sttHz58EDNFkT169Ijy5s1LOXLkIDc3N9GX7/r169StWzfx886dO1P//v2paNGiIncJAPQDQRIA/BEHGyJg8nSjK0+vGEUDXm4UXG5mOalticdAD6pasKqsidsrVqyg7t27RznG09OTihcv/sfb+vjxI6VMmVIn4wSAqBAkAUCcG/Cq+smde3hO4yW3zCkzSw14y+ctL1sD3llHZ9Fwt+FiO6NtRtG2JI1NGr2XAGjatKnYTp48OS1evFjs84wQ5yzNmTOHpk2bRo6Of67rhCAJQL8QJAHAX+NSAnu994qA6dT9Uxob8KazSSdKCnDid+V8lfXagJdX8tVaUIs87nqI/frF6tP+vvv1flmQg6AxY8bEupgkO336NBK3AWSGIAkAtCIwKFDZgNfTjY7fPS7qFmlqwNvQvqGYYapRqIZeGvD6f/In+0n2UrHMRa0XUb9q/UjfLl++LLUl4bYjKVKkkNqS9OrVK0rxSARJAPJDkAQAWvc5+LOyAa+Xm+grF1MDXp5hql24tk4b8B6+eZjqLaontS25Ouoq2We119nfAwDTgCAJAHSKCztyoMTFK2NqwFunSB2pAS8HUNo2aMcgmu8xX2wXyFCAro+5Tsms0PoDAKKHIAkA9IZnlNxvu4sZJr409ylY2eU+cgPemoVrioCJL81pqwFvyK8QKjOjjFTOgHvareqwSiu3DQCmCUESAMiCc5ZO3TtFu7x2ieTv90HvoxxjkciCqhWoJgKmxo6NKa1N2nj9zQdvHpDTFCepbcmO7juoZYmWYvvHrzB68vYLvXwfRKFh4ZQsiSXlTp+CMtslo4QGUv8JAPQLQRIAyI5rGXE5AdGA12s3+X/219iAt2K+iiJg4vICf9uAd/2F9dR5fWexbZvUlnZ0PU3XHoTRhXtvKVzDy2EK68RUzykbNSienexskvzV3wQA44QgCQAMCi/bv/zksshh4qBJUwNeVjZ3WSlgypEmR6xvn1/y2q5uS9uubhP7tokLUOmMs0ihiL74ZcIERFaWiahXrcJU0z6LwVQWBwDdQpAEAAaLX548n3tK1b4fBjzUeJxzdmep2ne+DPk0HvM44DFde3aNGjk0ojefvlCxiY4U9FM5Y5UrRSvKk7J9rMbUqEQO6lWrEAIlADOAIAkAjAK/VN16dUuaYbr9+rbG44pmLqoMmJybUeFMhUUww5fzsg3PJi7jlcxRkvKnGEuPAh7Q5TfDSEFcADMBFU83lVInKRarsbSvlI/aVcyr5XsIAIYGQRIAGKX7b+6L2SUOmLxeeGk8Jl/6fNIlOb7E9uDtA/H9FInzknO6yeT39Qg9/LxBfM8qUWoqk2ExJU5k+8e/zZNIi7qUo3yZ0CIEwJQhSAIAo/f03VPlJTkvN5HPpEkm20z0Ifgj/fj1XezbWOYmp7QT6WbgbPoQomxAmzZpKXJIM+aPl9I4Ryl/5pS0oHM5HdwbADAUCJIAwKT4ffCL0IA3XBEe7bFJLTKSvd1I8nw3hn6FfxHfK5CqJ2WzqR+rv7WsewXKlV77hS8BwDAgSAIAk/X2y1tRg2njpY1ihklTwGSRIBkVsRtMPu8niX3LhCmocuYtsZhNSkBtK+ZFbhKACYt+zSsAgJFLnyK9qOp98fHFaGeUQhXfKJVVEcqZQllUMqlFek4T/+NtK0hBD19HrRgOAKbDQu4BAADo0vXn1zV8NwFZJrShhAkSU0brSmSZyJrypuxAmZPXpCSJ7ChBgj9/fuQ5+Fcfg3UyZgAwDAiSAMCkzWkxhwpmLEjffhB5+PyiZBZZyNoiIyVKaBXlWGuLDHG6bWQrAJg2BEkAYNKy22WnSY0m0cegELr1wEOrt402JQCmDTlJAGAWUiW3IlvrxFq7vUQJE1C+jH+uqQQAxgtBEgCYjZJ50orgRhvCwhXknDutVm4LAAwTgiQAMBv1i+cQwU18cZiVMZU1OeSw08q4AMAwIUgCALORP5Mtlc6XXtQ4ig8Os1yrFkCTWwAThyAJAMwGBzUD6hWhpIkTidYif4N/r1KhjFShUEZtDw8ADAyCJAAwK6mTJ6Hp7UqRlSUHSgniHCAVypqKBjW019n4AMBwoC0JAJilZwFfafpub3r+7usf62tzMBWuUFB952zUvUYhEWABgOlDkAQAZis0LJz2X3tGu688pXdffhBPLKnPLqmSvB1z2lGb8nnJHonaAGYFQRIAmD2eJbrr95EevP5MLwODRPCULIkl5U6fgopkTU0ZUlnLPUQAkAGCJAAAAAANkLgNAAAAoAGCJAAAAAANECQBAAAAaIAgCQAAAEADBEkAAAAAGiBIAgAAANAAQRIAAACABgiSAAAAADRAkAQAAACgAYIkAAAAAA0QJAEAAABogCAJAAAAQAMESQAAAAAaIEgCAAAA0ABBEgAAAIAGCJIAAAAANECQBAAAAKABgiQAAAAADRAkAQAAAGiAIAkAAABAAwRJAAAAABogSAIAAADQAEESAAAAAEX1P/kA3inHDQGMAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x600 with 1 Axes>"
       ]
@@ -3259,10 +3257,10 @@
    "id": "05329ef2",
    "metadata": {
     "papermill": {
-     "duration": 0.013684,
-     "end_time": "2026-04-22T17:27:50.932799",
+     "duration": 0.047225,
+     "end_time": "2026-04-22T21:18:31.308320",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.919115",
+     "start_time": "2026-04-22T21:18:31.261095",
      "status": "completed"
     },
     "tags": []
@@ -3296,16 +3294,16 @@
    "id": "da576e77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:27:50.961324Z",
-     "iopub.status.busy": "2026-04-22T17:27:50.960738Z",
-     "iopub.status.idle": "2026-04-22T17:27:50.965960Z",
-     "shell.execute_reply": "2026-04-22T17:27:50.964736Z"
+     "iopub.execute_input": "2026-04-22T21:18:31.393621Z",
+     "iopub.status.busy": "2026-04-22T21:18:31.392865Z",
+     "iopub.status.idle": "2026-04-22T21:18:31.397364Z",
+     "shell.execute_reply": "2026-04-22T21:18:31.396424Z"
     },
     "papermill": {
-     "duration": 0.021869,
-     "end_time": "2026-04-22T17:27:50.967618",
+     "duration": 0.049409,
+     "end_time": "2026-04-22T21:18:31.398666",
      "exception": false,
-     "start_time": "2026-04-22T17:27:50.945749",
+     "start_time": "2026-04-22T21:18:31.349257",
      "status": "completed"
     },
     "tags": []
@@ -3341,14 +3339,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 49.592482,
-   "end_time": "2026-04-22T17:27:51.451937",
+   "duration": 56.732769,
+   "end_time": "2026-04-22T21:18:31.807471",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-3-Advanced.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-3-Advanced_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-22T17:27:01.859455",
+   "start_time": "2026-04-22T21:17:35.074702",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
@@ -5,10 +5,10 @@
    "id": "4dc70eb7",
    "metadata": {
     "papermill": {
-     "duration": 0.004748,
-     "end_time": "2026-04-22T17:40:21.329391",
+     "duration": 0.034766,
+     "end_time": "2026-04-22T21:17:37.718581",
      "exception": false,
-     "start_time": "2026-04-22T17:40:21.324643",
+     "start_time": "2026-04-22T21:17:37.683815",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "6651185b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:21.338681Z",
-     "iopub.status.busy": "2026-04-22T17:40:21.338392Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.242367Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.241317Z"
+     "iopub.execute_input": "2026-04-22T21:17:37.793927Z",
+     "iopub.status.busy": "2026-04-22T21:17:37.793386Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.051347Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.050070Z"
     },
     "papermill": {
-     "duration": 0.910097,
-     "end_time": "2026-04-22T17:40:22.243617",
+     "duration": 1.29769,
+     "end_time": "2026-04-22T21:17:39.053488",
      "exception": false,
-     "start_time": "2026-04-22T17:40:21.333520",
+     "start_time": "2026-04-22T21:17:37.755798",
      "status": "completed"
     },
     "tags": []
@@ -98,10 +98,10 @@
    "id": "51f45b56",
    "metadata": {
     "papermill": {
-     "duration": 0.005577,
-     "end_time": "2026-04-22T17:40:22.254065",
+     "duration": 0.036221,
+     "end_time": "2026-04-22T21:17:39.129392",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.248488",
+     "start_time": "2026-04-22T21:17:39.093171",
      "status": "completed"
     },
     "tags": []
@@ -133,16 +133,16 @@
    "id": "e3003150",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.269346Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.268822Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.356490Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.355787Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.201366Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.200552Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.336049Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.334448Z"
     },
     "papermill": {
-     "duration": 0.097458,
-     "end_time": "2026-04-22T17:40:22.358013",
+     "duration": 0.172101,
+     "end_time": "2026-04-22T21:17:39.338368",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.260555",
+     "start_time": "2026-04-22T21:17:39.166267",
      "status": "completed"
     },
     "tags": []
@@ -155,10 +155,10 @@
       "Démonstration LCG (CP-SAT utilise LCG en interne):\n",
       "   N |  Temps (s) |     Branches |   Conflits |   Status\n",
       "-------------------------------------------------------\n",
-      "   8 |     0.0150 |          154 |          6 |   SOLVED\n",
-      "  10 |     0.0146 |          223 |          7 |   SOLVED\n",
-      "  12 |     0.0152 |          332 |         15 |   SOLVED\n",
-      "  14 |     0.0324 |         1646 |         68 |   SOLVED\n"
+      "   8 |     0.0252 |          154 |          6 |   SOLVED\n",
+      "  10 |     0.0304 |          223 |          7 |   SOLVED\n",
+      "  12 |     0.0302 |          332 |         15 |   SOLVED\n",
+      "  14 |     0.0336 |         1626 |         57 |   SOLVED\n"
      ]
     }
    ],
@@ -214,10 +214,10 @@
    "id": "d9bf2c20",
    "metadata": {
     "papermill": {
-     "duration": 0.005961,
-     "end_time": "2026-04-22T17:40:22.371597",
+     "duration": 0.037618,
+     "end_time": "2026-04-22T21:17:39.416766",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.365636",
+     "start_time": "2026-04-22T21:17:39.379148",
      "status": "completed"
     },
     "tags": []
@@ -246,10 +246,10 @@
    "id": "ffe181fd",
    "metadata": {
     "papermill": {
-     "duration": 0.007588,
-     "end_time": "2026-04-22T17:40:22.386663",
+     "duration": 0.038129,
+     "end_time": "2026-04-22T21:17:39.493824",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.379075",
+     "start_time": "2026-04-22T21:17:39.455695",
      "status": "completed"
     },
     "tags": []
@@ -277,16 +277,16 @@
    "id": "7dbbabf9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.403622Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.403162Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.465886Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.465121Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.557485Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.556953Z",
+     "iopub.status.idle": "2026-04-22T21:17:39.619578Z",
+     "shell.execute_reply": "2026-04-22T21:17:39.618325Z"
     },
     "papermill": {
-     "duration": 0.072399,
-     "end_time": "2026-04-22T17:40:22.466918",
+     "duration": 0.097161,
+     "end_time": "2026-04-22T21:17:39.621135",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.394519",
+     "start_time": "2026-04-22T21:17:39.523974",
      "status": "completed"
     },
     "tags": []
@@ -298,9 +298,9 @@
      "text": [
       "           Stratégie | Makespan |    Temps |   Branches | Conflits\n",
       "-----------------------------------------------------------------\n",
-      "             Default |       11 |   0.0209 |         13 |        0\n",
-      "     No linear relax |       11 |   0.0147 |         13 |        0\n",
-      " Max SAT propagation |       11 |   0.0151 |         13 |        0\n"
+      "             Default |       11 |   0.0166 |         13 |        0\n",
+      "     No linear relax |       11 |   0.0144 |         13 |        0\n",
+      " Max SAT propagation |       11 |   0.0149 |         13 |        0\n"
      ]
     }
    ],
@@ -391,10 +391,10 @@
    "id": "34ddac94",
    "metadata": {
     "papermill": {
-     "duration": 0.004153,
-     "end_time": "2026-04-22T17:40:22.475871",
+     "duration": 0.040795,
+     "end_time": "2026-04-22T21:17:39.692546",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.471718",
+     "start_time": "2026-04-22T21:17:39.651751",
      "status": "completed"
     },
     "tags": []
@@ -423,10 +423,10 @@
    "id": "19305758",
    "metadata": {
     "papermill": {
-     "duration": 0.004114,
-     "end_time": "2026-04-22T17:40:22.484489",
+     "duration": 0.047863,
+     "end_time": "2026-04-22T21:17:39.778617",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.480375",
+     "start_time": "2026-04-22T21:17:39.730754",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "aa73b92c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.493578Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.493294Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.599979Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.599377Z"
+     "iopub.execute_input": "2026-04-22T21:17:39.858796Z",
+     "iopub.status.busy": "2026-04-22T21:17:39.858247Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.051539Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.050447Z"
     },
     "papermill": {
-     "duration": 0.112762,
-     "end_time": "2026-04-22T17:40:22.601167",
+     "duration": 0.235853,
+     "end_time": "2026-04-22T21:17:40.053515",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.488405",
+     "start_time": "2026-04-22T21:17:39.817662",
      "status": "completed"
     },
     "tags": []
@@ -524,10 +524,10 @@
    "id": "51c97e38",
    "metadata": {
     "papermill": {
-     "duration": 0.00756,
-     "end_time": "2026-04-22T17:40:22.621968",
+     "duration": 0.025124,
+     "end_time": "2026-04-22T21:17:40.115660",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.614408",
+     "start_time": "2026-04-22T21:17:40.090536",
      "status": "completed"
     },
     "tags": []
@@ -557,16 +557,16 @@
    "id": "cab22939",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.638753Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.638437Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.644890Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.644239Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.182743Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.182445Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.191923Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.190561Z"
     },
     "papermill": {
-     "duration": 0.016874,
-     "end_time": "2026-04-22T17:40:22.646509",
+     "duration": 0.04464,
+     "end_time": "2026-04-22T21:17:40.193671",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.629635",
+     "start_time": "2026-04-22T21:17:40.149031",
      "status": "completed"
     },
     "tags": []
@@ -626,10 +626,10 @@
    "id": "6bebux5qvr9",
    "metadata": {
     "papermill": {
-     "duration": 0.007013,
-     "end_time": "2026-04-22T17:40:22.660961",
+     "duration": 0.025116,
+     "end_time": "2026-04-22T21:17:40.255620",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.653948",
+     "start_time": "2026-04-22T21:17:40.230504",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +657,10 @@
    "id": "feba21ce",
    "metadata": {
     "papermill": {
-     "duration": 0.007584,
-     "end_time": "2026-04-22T17:40:22.674577",
+     "duration": 0.024639,
+     "end_time": "2026-04-22T21:17:40.307621",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.666993",
+     "start_time": "2026-04-22T21:17:40.282982",
      "status": "completed"
     },
     "tags": []
@@ -685,16 +685,16 @@
    "id": "1b5cf512",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.688468Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.688153Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.716791Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.715974Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.382052Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.381767Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.399221Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.398169Z"
     },
     "papermill": {
-     "duration": 0.036734,
-     "end_time": "2026-04-22T17:40:22.718132",
+     "duration": 0.058785,
+     "end_time": "2026-04-22T21:17:40.400404",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.681398",
+     "start_time": "2026-04-22T21:17:40.341619",
      "status": "completed"
     },
     "tags": []
@@ -801,10 +801,10 @@
    "id": "0b579d13",
    "metadata": {
     "papermill": {
-     "duration": 0.005696,
-     "end_time": "2026-04-22T17:40:22.729714",
+     "duration": 0.02769,
+     "end_time": "2026-04-22T21:17:40.460567",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.724018",
+     "start_time": "2026-04-22T21:17:40.432877",
      "status": "completed"
     },
     "tags": []
@@ -833,10 +833,10 @@
    "id": "960c4f67",
    "metadata": {
     "papermill": {
-     "duration": 0.004451,
-     "end_time": "2026-04-22T17:40:22.738788",
+     "duration": 0.033956,
+     "end_time": "2026-04-22T21:17:40.527404",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.734337",
+     "start_time": "2026-04-22T21:17:40.493448",
      "status": "completed"
     },
     "tags": []
@@ -859,16 +859,16 @@
    "id": "6b2e443e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.750124Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.749833Z",
-     "iopub.status.idle": "2026-04-22T17:40:22.806804Z",
-     "shell.execute_reply": "2026-04-22T17:40:22.806275Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.608678Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.607673Z",
+     "iopub.status.idle": "2026-04-22T21:17:40.695995Z",
+     "shell.execute_reply": "2026-04-22T21:17:40.694657Z"
     },
     "papermill": {
-     "duration": 0.064575,
-     "end_time": "2026-04-22T17:40:22.807879",
+     "duration": 0.132956,
+     "end_time": "2026-04-22T21:17:40.697998",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.743304",
+     "start_time": "2026-04-22T21:17:40.565042",
      "status": "completed"
     },
     "tags": []
@@ -880,9 +880,9 @@
      "text": [
       " Workers |  Temps (s) |   Résolu\n",
       "--------------------------------\n",
-      "       1 |     0.0095 |      Oui\n",
-      "       2 |     0.0247 |      Oui\n",
-      "       4 |     0.0149 |      Oui\n"
+      "       1 |     0.0186 |      Oui\n",
+      "       2 |     0.0234 |      Oui\n",
+      "       4 |     0.0311 |      Oui\n"
      ]
     }
    ],
@@ -932,10 +932,10 @@
    "id": "3b85c116",
    "metadata": {
     "papermill": {
-     "duration": 0.005197,
-     "end_time": "2026-04-22T17:40:22.817624",
+     "duration": 0.040287,
+     "end_time": "2026-04-22T21:17:40.787528",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.812427",
+     "start_time": "2026-04-22T21:17:40.747241",
      "status": "completed"
     },
     "tags": []
@@ -967,10 +967,10 @@
    "id": "2ae22819",
    "metadata": {
     "papermill": {
-     "duration": 0.004613,
-     "end_time": "2026-04-22T17:40:22.827653",
+     "duration": 0.025445,
+     "end_time": "2026-04-22T21:17:40.851096",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.823040",
+     "start_time": "2026-04-22T21:17:40.825651",
      "status": "completed"
     },
     "tags": []
@@ -985,16 +985,16 @@
    "id": "ab41ac5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:22.842038Z",
-     "iopub.status.busy": "2026-04-22T17:40:22.841501Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.037513Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.036713Z"
+     "iopub.execute_input": "2026-04-22T21:17:40.930759Z",
+     "iopub.status.busy": "2026-04-22T21:17:40.930405Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.280287Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.279192Z"
     },
     "papermill": {
-     "duration": 0.203068,
-     "end_time": "2026-04-22T17:40:23.038602",
+     "duration": 0.387479,
+     "end_time": "2026-04-22T21:17:41.282100",
      "exception": false,
-     "start_time": "2026-04-22T17:40:22.835534",
+     "start_time": "2026-04-22T21:17:40.894621",
      "status": "completed"
     },
     "tags": []
@@ -1002,7 +1002,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfsRJREFUeJzt3Qd4VNX29/EFIaH33kFAehOkiYKCglJEURG8goh45a+IXVBREXsFBQX0KuqVC2JBEaQIIgpIB5EOgoDSe2+Z9/nt+565kzAJSUgyk8n343NMzpkzZ/ZMQmbP2muvncXn8/kMAAAAAAAASEdZ0/PBAAAAAAAAACEoBQAAAAAAgHRHUAoAAAAAAADpjqAUAAAAAAAA0h1BKQAAAAAAAKQ7glIAAAAAAABIdwSlAAAAAAAAkO4ISgEAAAAAACDdEZQCgHR2+vRpe/nll23ixImhbgoAAAAAhAxBKQCZ0ubNmy1Lliw2evTodH/s/v372wcffGBNmjRJs8fQ89Lz0/NMTS1btnQbAAAIH3rPf/bZZ0PdjIhUoUIFa9++faibAUQsglJAJu24JGWbNWtWqJsacb755hv797//bVOmTLGiRYtaOFq1apXr2KZ2QAsAgHC2YsUKu+mmm6x8+fKWI0cOK126tF199dX2zjvvhLppmdKCBQtcf/Stt94657brr7/e3fbRRx+dc9sVV1zhfnYAMoZsoW4AgPT36aefxtn/5JNPbPr06eccr169ejq3LPIp0PP9999b5cqVLVwpKDVo0CCXEaXRwUDTpk0LWbsAAEgrc+fOtSuvvNLKlStnvXv3thIlStjWrVvt119/taFDh1rfvn1D3cRM55JLLrFcuXLZL7/8Yg8++OA5P69s2bLZnDlzrGfPnv7jp06dsoULF1qHDh1C0GIAKUFQCsiE/vGPf8TZV4dLQan4x3Fhzpw5Y7GxsRYTE+M/1q9fP8vIAp8LAACR4oUXXrD8+fO7gEaBAgXi3LZr166QtSszU9CpcePGLvAUaO3atbZnzx7r1q2bC1gFWrx4sZ04ccKaN29+wY9/7NgxFxRLa0ePHrXcuXOn+eMA4YrpewCCUjBlyJAhVrNmTZfCXrx4cfvnP/9p+/fvDzrPXlP9GjZsaDlz5rTatWv7p/599dVXbl/XaNCggS1dujTO/e+44w7LkyeP/fHHH9amTRv3plyqVCl77rnnzOfzxTl37Nix7hp58+a1fPnyuetq9PJ8Dhw44B5HnU11NHv06OGOBbNmzRqXul+oUCHXZj2nb7/9Nsk1ql5//XX3ulWqVMmyZ8/uso6Sel0VQFeGUpUqVdw5hQsXdp0qBQwDzZw50y6//HL3Wun5KIV99erVKa43oZ+hXh+vFtXNN9/svteIcfypnMFqSqmz3qtXL/c7onbXrVvXPv744wRfn1GjRvlfn0svvdR9AAAAIJQ2btzo+jzxA1JSrFixOPt6P7vvvvvss88+s6pVq/r7OLNnzz7nvn/99Zfdeeed7j1S73t6jA8//PCc806ePGnPPPOMy6TWeWXLlrXHHnvMHY9/nrKGVAJA/aGOHTvatm3bzrme3tfjZzuL+gFqf0qfT6CdO3e6wJH6LvEpcKTrDhs2LFl9nPh0jh5nw4YN/mMKUqkfePfdd/sDVIG3effzvPvuu+511+uqPua99957Tj9QfZtatWq5oJam/ykY9cQTTyTYLvVz9NwfffRR/7H58+db27ZtXX9T92/RosU5ATXv9Vf/UEG1ggUL+tu6Y8cOl/VVpkwZ19aSJUu6Ph7lFBDpyJQCEJQCUApQ6M3x/vvvt02bNrmOhYJKeoONjo72n6uOgt5YdR9lWynwoLTpESNGuDf0//u//3PnvfTSS3bLLbe4DkTWrP+LiZ89e9a9iavw96uvvurqLaljpkwjBadEnZauXbtaq1at7JVXXnHHFIhRWxLLPlJgS2/oGkm755573JTEr7/+2gWm4lu5cqVddtllrg6BipEr6PP5559bp06d7Msvv7QbbrjhvK+bahtohE4dJXUoFIRK6nXVUdFrdNddd1mjRo3s0KFDtmjRIluyZImraSE//PCDXXvttXbRRRe5848fP+5qXej6Oi9YBzQ51BHTz/vtt992PztvCmdCUzn1+OrI6XdAHdqKFSva+PHjXWdYHb74P5sxY8bY4cOH3e+KOmX6ed94440uKBn4OwUAQHpSHal58+bZ77//7oIT5/PTTz/ZuHHj3Hum3u8V+FBfRnWQvPsrmKK+jRf0USBJU/g1kKP3+AceeMA/EKjgkvoq6j/oPVf1rVRLad26dTZhwgT/46qPoNqU6nc1a9bMDVS1a9fugp9/Up5PfAq0KfCiPo36bYF0raioKP9AV1L6OMF4ARu9Nl7pA/X99Loqi0p9B03l0+vn3aZgnQbIvMdVMKx169bWp08f1wd977333IBY/P7s3r17XR/r1ltvdf1ZPb9gNLimPqX6Sc8//7w7pp+D7qtgnl4L9XPVJ7zqqqvs559/ds85kF4XBehefPFF/yBs586dXZ9RU0XVn9Ogn/q/W7ZsueD+HRDWfAAyvXvvvVfvhv79n3/+2e1/9tlncc6bMmXKOcfLly/vjs2dO9d/bOrUqe5Yzpw5fX/++af/+MiRI93xH3/80X+sR48e7ljfvn39x2JjY33t2rXzxcTE+Hbv3u2O9evXz5cvXz7fmTNnkvXcJkyY4K7/6quv+o/pGpdffrk7/tFHH/mPt2rVyle7dm3fiRMn4rSlWbNmvipVqiT6OJs2bXLXUxt37doV57akXrdu3brueSemXr16vmLFivn27t3rP7Z8+XJf1qxZfd27d/cf0/NSe9Quj/afeeaZc66pn6F+Dp7x48ef83PytGjRwm2eIUOGuHP//e9/+4+dOnXK17RpU1+ePHl8hw4divP6FC5c2Ldv3z7/ud988407PnHixESfNwAAaWnatGm+qKgot+k97LHHHnP9Gb2nxaf3LW2LFi3yH1N/J0eOHL4bbrjBf6xXr16+kiVL+vbs2RPn/rfeeqsvf/78vmPHjrn9Tz/91L2Pq/8VaMSIEe5x5syZ4/aXLVvm9v/v//4vznndunU75z1e7+t6f49P58T/CJjU5xOM17dbsWJFnOM1atTwXXXVVcnq4wSjfoR+JnotPVWrVvUNGjTIfd+oUSPfo48+6r+taNGivquvvtp9r/6Y+pLXXHON7+zZs/5zhg0b5tr84Ycf+o+pb6Njes3j0+votX3o0KG+LFmy+AYPHhynT6f+XJs2bdz3Hv18K1as6G9P4OvftWvXOI+xf/9+d/y1115L9msEZHRM3wNwDmW6KPVYI1dKifY2jf5oqt2PP/4Y5/waNWpY06ZN/fsauRKNDqlgaPzjyoqJTyOIHm9EUcUqlRkkSqfXnPvzpXnHN3nyZJderdExj0bu4hcs3bdvnxvlUiaXMnm856xRM00rXL9+vUvBPx+NcgWuqpec6+o5aoRMx4LZvn27LVu2zGUhKQPLU6dOHfez0nNNb3pMFYNVFptHo44aaT1y5IgbeQ3UpUsXl6ru0TTEhH4nAABIL3ofVaaUMm6WL1/uMnn1Pq0s52DT+NXvUb/Io/6OMrOnTp3qMsAV61E2tDLH9X1gf0rXPXjwoMsS8vpdyo6qVq1anPPUjxKv3+W9z+s9NpCXcXUhzvd8EqJsZ/WzlBnlUbaZpqfpPd9zvj5OQpT1pH6OVztKr4uynZQlJsoU96bIKats9+7d/uwq9SHVl9TrE5ihr0L2mv43adKkOI+lDLHAounx6XdCGeDK2H/qqaf8x9U30/NS9pr6d97PT/1WZfhrGqSy4QIp0yqQyl+obqfKJcQvlQFEOoJSAM6hN1Z1llRDQQGWwE2BhvgFPwMDT6KAlqgeQrDj8d9s1VHQdLRAF198sfvqzaPXFEAdU2q05tqrPoOm+Z3Pn3/+6ebkK5gWSDUTAmn6mTqNAwcOPOc5eynpSSl0qulrKb2upipqypuep+plqU7Bb7/9Fue5BGu7qDPrdYDSk9qk9PPAzp7XHu/2xH5XvAAVHTAAQKipzqFqYeo9SdPWBgwY4AaUVBPSqxHp0XtffHr/VnFsBUa06T1dU73iv/97gQ/v/V/9LgVs4p/n9YW88/Seqvdb1WUMFKxfkFznez4JKVKkiAu8aAqfRwEqBaoUsPKcr4+TGAWZvNpRmqqnwUVN3xMFp1QHSrW24teTSqjfpOCP+p3x+ygKQCa0oIsG2R5//HG3BdaREi/QptIQ8X+GH3zwgWub+tWJ9RcVEFOwS9M7NW1Q5RQUBFOdKSDSUVMKwDk0mqOAlApeBhOYCSTqHAST0PH4BcyTQu3RSJRG7PSGrU1z9bt3735OUe2U8EawHnnkETeCGYxXyyAxGulK6XXVAVGh1W+++camTZvmOjKqJ6HaXKrBkFYSGwFNban5OwEAQFpQYEIBKm0KoiiIpGym+HWTEuO9/6s2UbA6lqIMIO9cBWrefPPNoOfFH+RLivjFzNPyPV81mPQaqZ9Wr149F6BSoEoBK8+F9HEUZFL9TAWdFJTSa+UNNioopaCPakQpm0rBMC9glVzx+3CBVChdQbVPP/3U1cUMDCp5P+vXXnvNPf9g4g+OBnssZXQps041xNTf1YCm6nAp475+/fopek5ARkBQCsA5NAKnlGelRCf2Bp1a9Gau6VveiKCXgi2BhR3VSdSbtTbdR9lTI0eOdG/aCQWMVLh0xowZLsMrsEOgEbdAXqaWpp6pGGZqSe51NS1PHTttarM6cSrSqQ6bnkuwtnur+6nzl9iSwspKir/ajNLaNS0wKR3ZYNQmjXTq5xGYLaX2eLcDAJBRabVcif9eGWwamvouWnXNG7zT1DMFgc73/q9+l6YMKpCT2Huw3lP1fqvgTmD2T7B+QbD3fImfHZSc55MQLdyiQI03hU/3U5ZZcvo4iQksdq4pluqferSanl4XBay0KXijNktgvykwI199Hy3gk5z+nvpYX3zxhWuLfk5qix5bvMw1TQm80D6krvXwww+7TT8TBbneeOMNV9weiFRM3wNwDtU/Uidq8ODB59ymFfGCdXIulLdksJc1o30FcvTGL5qjH0gBEG+EMf5yyYGuu+4612attOLRc9OIW/xMLK0ipyBX/I6nJJa6npjkXDf+c1QQTcE27/lpGqI6J8oMC/wZqHaDRh31XM/X0Ym/vLOmFcQfNfUCW0n5OesxlVoeWEtCr7deX7Vfq/IAABDuVLcpWNauV8cp/hQwBUe8mlCydetWlwV0zTXXuKxgbaozqbpSep9O7P1f/S7Vl3z//feDrnLrTc1XCQPRCrmBhgwZEvQ9X1PGAqfIqR+iFYiDOd/zSYzqRSkbXBlSY8eOdYOIClQFOl8fJzEK/igzSYOMWrHPqyfl0b6yixR88gJYogCR2qLXK/Bn+69//cu9NsldtVDlIzRoq5+JapB5z0m1uPR6a/VpBdtS0ofUNEmt3hxI11RgMymvEZCRkSkF4BwKJGjESynDSsVWh0QBIo3YKH196NChrr5CasmRI4erD6X0dhVD19Q8FZ/UUrve6JxG0VQ0XEU/1SnQSJ8CHwrSePWLglFWlUbU+vfv7+pTqSi76kXEn9svw4cPd50ZpYWrCKZG1bScszpq27Ztc6OYKZHU66ptCmCpc6PRRHW8NCoXWAReqeHqlKogqZaUVsdIr4PqdWm0MTF6DVVYU51kdab0uEoPD0yvF72m6oCqtoFeJ9U50OuuAFt8WrpaATcVX1dNB2W2qc0arVQnWZ0pAADCnRZAUWDghhtucAXHlU2jqWIadNF7W/wC2LVq1XKBGBUd1/vku+++644PGjTIf87LL7/sgl3q2+j9X+/z6sso+KPghr6X22+/3QV09B6t89Vv0YCRso51XO/VytjS+7MWFtFj6f1ZwRgFalS/MtiUOtU/0vNRG/XcNECnrPTA4FNynk9iVNRcUxV1P11HgapASenjJEb9KE2dk8BMKdHr8J///Md/nkd9SGVs6Tm0bdvWFbFX4Ept1NRMtTe5FEjTQKCei56nptYpQ0rTEdU/0zQ//a6oPpUCjfp56vaJEycmel1ll2kgVgFKvVaahqgAovqL+lkCES3Uy/8BCL177733nOWBZdSoUb4GDRr4cubM6cubN6+vdu3abonkv//+O+gyuYF0PV030KZNm85Z7lZLFufOndu3ceNGt2Rvrly5fMWLF3dL5gYu3/vFF1+424sVK+aW9y1Xrpzvn//8p2/79u3nfX579+713X777b58+fK5JZj1/dKlS11bPvroozjnqh3du3f3lShRwhcdHe0rXbq0r3379u7xExPsuSX3us8//7xb2rhAgQLuNa9WrZrvhRdeOGc56h9++MF32WWXuXP0nDp06OBbtWpVnHP0vNQetcuj1/Pxxx/3FSlSxL3OWrp4w4YN7meon0Og999/33fRRRe5ZZh1nR9//NG/ZLK2QDt37vT17NnTXVc/G/2exH9dE3t94i9jDQBAevv+++99d955p3vvzZMnj3s/q1y5sq9v377ufS5YH+ff//63r0qVKr7s2bP76tev73+vDKT76tyyZcu693/1A1q1auX6WIH0Xv/KK6/4atas6a5XsGBB1wcbNGiQ7+DBg/7zjh8/7rv//vt9hQsXdv0n9QG2bt0a9L102rRpvlq1arnnUrVqVddenRO/z5ec55OQQ4cOuX6JrqXrxJfUPk5CRo4c6a6t/lN8S5Yscbdpi/+zkmHDhrnH0+uvPmafPn18+/fvj3OO+jZ67YMJ1tedP3++6xtfccUVvmPHjrlj6lveeOON7mej11D3u+WWW3wzZszw3897/Xfv3h3nenv27HE/A7VTP1f1Vxs3buz7/PPPk/T6ABlZFv0v1IExAJmXMmw0UhYs3RkAACDcqO7TvffeG6f0QEYWac8HQMZCTSkAAAAAAACkO4JSAAAAAAAASHcEpQAAAAAAAJDuqCkFAAAAAACAdEemFAAAAAAAANIdQSkAAAAAAACkO4JSAAAAAAAASHfZ0v8hI0NsbKz9/fffljdvXsuSJUuomwMAAEJE5TkPHz5spUqVsqxZM/d4H/0jAACQnP4RQakUUoerbNmyoW4GAAAIE1u3brUyZcpYZkb/CAAAJKd/RFAqhTQC6L3A+fLlC3VzAABAiBw6dMgFYry+QWZG/wgAACSnf0RQKoW8lHR1uOh0AQAApqvRPwIAAMnrH2XuwgcAAAAAAAAICYJSAAAAAAAASHcEpQAAAAAAAJDuwqKm1PDhw+21116zHTt2WN26de2dd96xRo0aJXj++PHjbeDAgbZ582arUqWKvfLKK3bddde5206fPm1PPfWUTZ482f744w/Lnz+/tW7d2l5++WW3FKGnQoUK9ueff8a57ksvvWT9+/dPw2cKAACQuZ09e9b114BIEBMTk+hS5wCAMA9KjRs3zh566CEbMWKENW7c2IYMGWJt2rSxtWvXWrFixc45f+7cuda1a1cXQGrfvr2NGTPGOnXqZEuWLLFatWrZsWPH3PcKWinAtX//fuvXr5917NjRFi1aFOdazz33nPXu3du/z6o5AAAAacPn87kByAMHDoS6KUCqUUCqYsWKLjgFAEi+LD71EEJIgahLL73Uhg0b5vZjY2PdsoF9+/YNmrXUpUsXO3r0qH333Xf+Y02aNLF69eq5wFYwCxcudJlXyowqV66cP1PqgQcecFtKlzdUFtbBgwdZXQYAgEyMPkHSXovt27e7gJQGHXPlysVqhcjw9Lnl77//tujoaPcZg99pAEh+/yikmVKnTp2yxYsX24ABA+KMNmi63bx584LeR8eVWRVImVUTJkxI8HH0IuhNokCBAnGOa0rf4MGD3ZtIt27d7MEHH7Rs2YK/JCdPnnRb4AsMAACQEajPo/6WsseVlZ6SEgkXOmXPC0gVLlz4gq8HhIuiRYu6wNSZM2dccAoAkDwhnQC9Z88e10kpXrx4nOPaV3p3MDqenPNPnDhhjz/+uJvyFxidu//++23s2LH2448/2j//+U978cUX7bHHHkuwrZouqCiftymbCwAAINwpY3zkyJFWp06dRM/zSiT06tXLli5d6sojaPv9998vuA1eDSllSAGRxJu2p880AIDki+iqfOoA3XLLLa6GwXvvvRfnNmVbtWzZ0nXQ7rnnHnvjjTdcgfXAbKhAGl1UxpW3bd26NZ2eBQAAQMocOXLEbrvtNnv//fetYMGCiZ47dOhQa9u2rT366KNWvXp1l01+ySWX+EsspAamN53fsmXL3AJAyrxJ6swDDa6uXr3aMrvkvnapgd9pAMjAQakiRYpYVFSU7dy5M85x7ZcoUSLofXQ8Ked7ASnVkZo+ffp5azyotpXewJSuHkz27NndNQI3AACAcHbvvfdau3btXGmE81GJhPjnqURCQiUVkPr27dtnnTt3dkHBwJISGkhNqA7qww8/bCtWrLBq1aqlWbueffZZV781PQI8iZXkUD9d5yj4lNTX7nwSuyYAIMKDUkp3bdCggc2YMSNOwUDtN23aNOh9dDzwfFHQKfB8LyC1fv16++GHH5JUu0BvRKpnFWzFPwAAgIxGZQq0IrFKECRFckskiDLMVWczcItUCs5pMFVBvrSgzP7u3bu7shNaYTopPv/8c1u5cqV9/PHHqZaxEyww9Mgjj5zT/04LKoZ/7bXXpstrBwCZ2Zo1a1w2dTgIaaFzbxpdjx49rGHDhm6FPBXf1Op6PXv2dLfrDaZ06dL+DpUKdLZo0cJNt1OnQB2uRYsW2ahRo/wBqZtuusl1wrRCn+Z3e52pQoUKuUCYOhXz58+3K6+80vLmzev2VeT8H//4x3lT2wGYtRk8KdRNQJiaOjBtPqwBSB6VGVCfSQN3OXLkSLPHUf9s0KBBlhn861//cqtD66sKW5cqVSpVr69gUODq0kmhQVht56P+sK6vAdiUyJMnj9vSWkIzJdLitQOAzOjIkSP2/fff26pVq6xGjRp28803h7pJoa8p1aVLF3v99dft6aefdmnByliaMmWKf6Ruy5YtbtTE06xZMxszZowLQtWtW9e++OILN5pTq1Ytd/tff/1l3377rW3bts1dr2TJkv5NBTy9qXgKZim4VbNmTXvhhRdcUMoLbAEAAGRkWt14165driaUpjJp++mnn+ztt9923wcrypzUEgmZseamOvHjxo2zPn36uEHR0aNHn3POxIkT7dJLL3VBQJWouOGGG+JklCmLRwvlqB9auXJlF9zyqJi8MoQU+FEf+Pbbb3cLAiVE11P2kgZuc+fO7cpQzJo1y3+72qdVp9Un1ocOPab61Cp6f/XVV7v2aeEe9YU1kOupUKGC+6q2K9Dj7cefvqeZDc8995yVKVPGXVu3qf8ef0rcV1995QaBVeBe/fbzTQWNn6W1YMECq1+/vntNNYCtAvzxne+1U7uaN2/uXg/NnlAm1caNGxNtR3J/HgAQ7nw+ny1fvtyGDx/uAlL6e6ukHf09t8welJL77rvP1X7SG6wymPTG6tEbbPw3fkXz1q5d687Xm0bgUsV689QLHmzTfHxRB+3XX391SxMfP37c/VDUqdKbKgAAQEbXqlUrV2dIg33epg/1Knqu7zUNLSUlEtKi5qYKdSe0xS9Yndi53gp/5zs3JTRNTjWbqlat6jLrP/zwQ9e39EyaNMkFctQnVeBEr6NmAHiU+f+f//zHBQVVkFyrIXqZR+qPXnXVVS74oux/BVEUDEwsA0p9ZwV4NMj622+/ub6xitSrdIXn2LFj9sorr9gHH3zgpvipRMXhw4fdDIVffvnF9YWrVKni2qzjoqCVfPTRR25Q2NsPVhRfsxY0sKzHV+2xjh07xnl8efLJJ13wTL9zF198sVvdMalFyBUIVABJQTUFWRUY07UCJeW10wwMzczQ7fq5KFtMP6uEPoil5OcBAOHs4MGDLrFHQf8TJ064wabevXu7vkJKM2gjavoeAAAAUpfKE3hZ5B5l1ChTxDue3BIJaSWxmlcKmnTr1s2/ryBI/OCTp3z58nbHHXfECZwoMBPfM888k+w2KqtJwShR8EcdfGWeeQOeyrq/9dZb40xlVGaQrFu3zgW1FODzCslfdNFF/vO0uqECIFpBz6Ogl7KqdF8FcwIp40lBI331phAqWKPgiY5719Hr9O677/rbIQq2BNLPVhlEei4KABUtWtQd17HEMuT0c1Dml56zKPj1448/ujIcGoX3qF1eDS69NpqhsGHDhiQVZdcHKAWO9NorU0r31UwIZasl57VT8fNAul3PU4PS8f+NJPWaAJBR/Pnnn+7vqQZlNCCl93nNPgs2OBUqoQ+LAQAAIN0lt0RCZqXsfE0jU5aPaPqjyk8ETr9TJpBGnIPxMtP0QSAYTadQQMer26TNC9oEm2amDDhNv1RwJPA+CiwFnq86qnXq1IlzX2X8aHRcwT5N31NmmzKS9LuQVCpmr5pal112WZzj2lcWWKDAx1cpDdG00qTQtXT/wJpo8bP2kvLaKXtLPzsFAvV8vSmJCT3n5P48ACCclShRwv0dVWD9nnvuscsvvzysAlJCphQAAEAmEFhzKNi+aBpYehc9VQmFhMSfVhB/+lag+KvPKfMrNSj4pClngYXNNXVPUxeVVaPgTs6cORO8f2K3iYJCHTp0cNlG8XmBnPjn6wOFprTF/2ARWIxcjxv/NdHUvb1797osMmWW6Tko0JPSaY3nEx0d7f/ea0tq1i9Jymun2/Vc33//ffcz1OMr0JrQc07uzwMAwklsbKwrcVS7dm33d1d/57WInN6rUmuV1tRGUAoAAAAho4yeUJ+bEAWjPvnkEzel8ZprrolzW6dOnVydKI08K6NH9Yq81aMD6YOBPiQok8mbvhdItU6//PJLl8GjLKzz0dQyZUop40gj3skxZ84cN6XPq8eqwvTxC3grkBSsEL5H2UYK7uhagdlf2g+so3Whqlevbp9++qmrf+JlS6kOVnJeOwXglOmmgJT3WqmeVmKS+/MAgHCxY8cOt8CFsqA1hbtBgwb+KdnhjOl7AAAAQBDfffed7d+/33r16uWyawI31SrypvCpTpUCVPqqaWeaYudl2ii4oQylO++8002H3LRpk8tSU50puffee23fvn1uipkKi2uK2NSpU12AK1hwSNP2VLBeNcG0up2up+mFqs2lguuJ0bQ9BXrURi0upOvEz+RSexVg04cbPfdgHn30Uff8tCKhgj79+/d30xRTKztNVEtMo/qabqj6T5MnT3a1rAKd77UrWLCgq6OmKamqZTVz5kxX9Dwxyf15AEConTlzxv3d1t86BaQUyE+NgZn0QlAKAAAACEJBJ2U3adpDfApKqRC8Vp9TwfPx48e7Eep69eq5guIKFHnee+89u+mmm+z//u//XH0iBVq0Kpx4WUcKeCgbS5lVDzzwgBvZTmhVJBU0V1Dq4YcfdisCKmtLAZRy5cqd9/ko0KRsoNtvv93uv/9+typfIGWFqSi76o8oKysY3U/BHT2+2qsi63ruCnqlFk1FnDhxogvwqR1ayS/+lLrzvXbaVLBfUx0VSHzwwQfttddeS/RxU/LzAIBQ2bp1q1vRVVmgmlquFUsVXNffrowiiy9wPVskq8ijOihafSUlyx8DGVmbwYmPxCLzmjrwv6ssAZkJfYLzvxaagqWMnooVK8YpXA1kdPxuAwiVuXPnukEEb4VdrXaqqc8ZrX/ERGkAAAAAAIAMpHz58m6as1bMVWbn+RbWCFcEpQAAAAAAAMLY8ePH3XQ91RaU0qVLu6l6qp2XkRGUAgAAAAAACFOrV692Cz4oMKVVX4sUKeKOZ/SAlBCUAgAAAAAACDNHjhxxwSgFpUTBqNOnT1skISgFAAAAAAAQJrQe3fLly23q1KluQQXVjmrevLldccUVli1bZIVxIuvZAAAAIGyx6DMiDb/TANLi78q4ceNs7dq1br9kyZLWsWNHK1GihEUiglIAAABIU9HR0e7rsWPHMuzqQEAwp06dcl+joqJC3RQAESJLlixWpkwZ27Bhg7Vs2dKaNWtmWbNmtUhFUAoAAABpSh/YCxQoYLt27XL7uXLlcp1uICOLjY213bt3u9/nSJtOAyB97dmzx86cOePPhmratKnVqFHDChUqZJGOv54AAABIc15H2wtMAZFA2QvlypUjyAogRc6ePWtz5861n376yQoWLGj//Oc/XZBbgzmZISAlBKUAAACQ5vShXXUxihUrFnErByHziomJiehpNQDSzvbt2+3bb7+1HTt2uH1lFGtKcGbLvMxczxYAAAAhpdFf6u8AADIrTdNTZtScOXNcUXPVWmzTpo3VqVMnU2ZdEpQCAAAAAABIY0eOHLHRo0fb3r173X6NGjXs2muvtTx58lhmRVAKAAAAAAAgjeXOndvy5ctnJ0+etOuuu86qV69umR1BKQAAAAAAgDTwxx9/WOnSpS179uxuel6nTp0sOjraTdsDQSkAAAAAAIBUdfz4cZs6daotX77cGjZsaO3atXPHlSmF/yEoBQAAAAAAkEpWrVplkydPtqNHj7p9rainouaZsZD5+RCUAgAAAAAAuECHDx+277//3lavXu32ixQpYh07drSyZcuGumlhi6AUAAAAAADABdi8ebONGzfOTpw4YVmzZrXmzZvb5Zdf7rKkkDBeHQAAAAAAgAtQtGhRNz2vZMmSLjuqRIkSoW5ShkBQCgAAAAAAIBliY2Ntw4YNdvHFF7v93Llz2x133OGm7ClTCknDKwUAAAAAAJBEu3fvttGjR9t//vMff/0oKVasGAGpZCJTCgAAAAAA4DzOnj1rc+bMsdmzZ7vvY2Ji7NSpU6FuVoZGUAoAAAAAACAR27dvt2+//dZ27Njh9itXrmzt27e3/Pnzh7ppGRp5ZQAAABHmvffeszp16li+fPnc1rRpU7dEdUI0BUHFWQO3HDlypGubAQAIV/PmzbP333/fBaRy5sxpN9xwg3Xr1o2AVCogUwoAACDClClTxl5++WWrUqWK+Xw++/jjj+3666+3pUuXWs2aNYPeR8GrtWvX+vcVmAIAAP9dWU/vp3oPvfbaa11Rc6QOglIAAAARpkOHDnH2X3jhBZc99euvvyYYlFIQiuWrAQAwO3nypO3cudPKlSvnn6p39913W8mSJUPdtIjD9D0AAIAIpkKsY8eOtaNHj7ppfAk5cuSIlS9f3sqWLeuyqlauXJmu7QQAIBysX7/e3n33Xfvss8/s0KFD/uMEpNIGmVIAAAARaMWKFS4IdeLECcuTJ499/fXXVqNGjaDnVq1a1T788ENXh+rgwYP2+uuvW7NmzVxgSlMBExtJ1uYJ7LwDAJCRHDt2zKZOnWq//fab2y9QoIAbsNH0dqQdglIAAAARSIGmZcuWuSDTF198YT169LCffvopaGBKwavALCoFpKpXr24jR460wYMHJ/gYL730kg0aNCjNngMAAGlNtaJWrVrlFgRRVrE0adLErrzySouJiQl18yIeQSkAAIAIpI60amBIgwYNbOHChTZ06FAXaDqf6Ohoq1+/vm3YsCHR8wYMGGAPPfRQnEwpTf8DACCjBKQ0cKOglFfQvGPHjolmCSN1EZQCAADIBGJjY+NMtTtfHSpN/7vuuusSPS979uxuAwAgI9IiH/nz57esWbNa8+bN7fLLL7ds2QiTpCdebQAAgAijDCYtWa1Vgw4fPmxjxoyxWbNmuVoZ0r17dytdurSbfifPPfecm6qgzKoDBw7Ya6+9Zn/++afdddddIX4mAACkrv3797sMqUKFCrl9TdOrW7euFS9ePNRNy5QISgEAAESYXbt2ucDT9u3b3QiwCpgrIHX11Ve727ds2eJGhQM76L1797YdO3ZYwYIF3XS/uXPnJlgYHQCAjJgxvGDBAps5c6YLQPXs2dO9F2rKOgGp0CEoBQAAEGH+9a9/JXq7sqYCvfXWW24DACAS7d6927799lvbtm2b24+KinJT2nPmzBnqpmV6BKUAAAAAAEDEUY3EOXPm2OzZs933WgREWcPKCFY9KYQeQSkAAAAAABBRtCKsairu3LnT7VepUsXat29v+fLlC3XTEICgFAAAAAAAiCh58uRxNaM0RU+Lf9SqVYvsqDBEUAoAAAAAAGR4W7dutZIlS1q2bNlcQKpz586WI0cOy507d6ibhgT8b9kVAAAAAACADEZFyydNmmQffvihqx/lKVy4MAGpMEemFAAAAAAAyJDWr19v3333nashJcePHzefz8dUvQwiLDKlhg8fbhUqVHBpdY0bN7YFCxYkev748eOtWrVq7vzatWvb5MmT/bedPn3aHn/8cXdcEdFSpUpZ9+7d7e+//45zjX379tltt93mipwVKFDAevXqZUeOHEmz5wgAAAAAAFLHsWPH7Ouvv3bFzBWQKliwoPvs365dOwJSGUjIg1Ljxo2zhx56yJ555hlbsmSJ1a1b19q0aWO7du0Kev7cuXOta9euLoi0dOlS69Spk9t+//13/y+mrjNw4ED39auvvrK1a9dax44d41xHAamVK1fa9OnTXVRVKX533313ujxnAAAAAACQMps3b3bJLb/99psLQDVt2tT69OljFStWDHXTkExZfMprCyFlRl166aU2bNgwtx8bG2tly5a1vn37Wv/+/c85v0uXLnb06FEXSPI0adLE6tWrZyNGjAj6GAsXLrRGjRrZn3/+aeXKlbPVq1dbjRo13PGGDRu6c6ZMmWLXXXedbdu2zWVXnY8isfnz57eDBw+ypCQynTaDJ4W6CQhTUwe2C3UTgHRHn+B/eC0AAOlh//799t5777nsKCWglC5dOtRNQgr7BCHNlDp16pQtXrzYWrdu/b8GZc3q9ufNmxf0PjoeeL4osyqh80UvgqKnmqbnXUPfewEp0TX12PPnz0+FZwYAAAAAAFKDcmm2bNni3/em6mm2EwGpjC2khc737NljZ8+eteLFi8c5rv01a9YEvc+OHTuCnq/jwZw4ccLVmNKUPy86p3OLFSsW5zwtGVmoUKEEr6Nq/to8XhE1AAAAAACQdllREydOtE2bNlmPHj1cPWopU6ZMqJuGVBDRq++p6Pktt9zioqpK7bsQL730kg0aNCjV2gYAAAAAAIJTaR8tgjZz5kz32V6JJAcOHAh1sxBJQakiRYpYVFSU7dy5M85x7ZcoUSLofXQ8Ked7ASnVkdIvceAcRp0bv5D6mTNn3Ip8CT3ugAEDXEH2wEwp1b4CAAAAAACpR5/Xv/32W/vrr7/cvrKjOnTo4GY3IbKEtKZUTEyMNWjQwGbMmBEnGqp9Vc8PRscDzxetoBd4vheQWr9+vf3www9WuHDhc66hCKvqWXkUuNJjq/B6MNmzZ3eBrcANAAAAAACknl9//dVGjhzpAlL6HN6+fXtXP4qAVGQK+fQ9ZR9pXqiKjmuFvCFDhrjV9Xr27Olu1y+fCpdp+pz069fPWrRoYW+88Ya1a9fOxo4da4sWLbJRo0b5A1I33XSTLVmyxK3Qp5pVXp0o/RIrEFa9enVr27at9e7d263Yp/vcd999duuttyZp5T0AAAAAAJD6cuXK5RJGLr74YveZn4SQyBbyoFSXLl1s9+7d9vTTT7vgUb169WzKlCn+YuaqsK9V8TzNmjWzMWPG2FNPPWVPPPGEValSxSZMmGC1atVytyuaqjQ/0bUC/fjjj9ayZUv3/WeffeYCUa1atXLX79y5s7399tvp+MwBAAAAAMjclCSyd+9efymd2rVrW968ed2UvSxZsoS6eUhjWXyqAo5kU02p/Pnz28GDB4ncItNpM3hSqJuAMDV1YLtQNwFId/QJ/ofXAgCQHJs3b3Yr62ml+3vvvddy5swZ6iYhnfsEIc+UAgAAAAAAmYeCUKoN7dV5VmbU/v37CUplQgSlAAAAAABAuli3bp1NmjTJZdKIFj9r3bq15ciRI9RNQwgQlAIAAAAAAGlKxctVD3rFihVuv2DBgtaxY0dXOwqZF0EpAAAAAACQprTAWFRUlCte3qRJE7vyyistOjo61M1CiBGUAgAAAAAAqU5T9BSEUs0oueaaa6xhw4ZWunTpUDcNYSJrqBsAAAAAAAAih8/nc0XM3333Xbe6nvZFhcwJSCEQmVIAAAAAACBV7Nu3zwWiNm/e7PaPHTvmVtujkDmCISgFAAAAAAAuuJD5/PnzbebMmXbmzBnLli2bXXXVVda4cWNXTwoIhqAUAAAAAABIsYMHD9r48ePtr7/+cvsVK1a0Dh06uBX2gMQQlAIAAAAAACmWK1cuO378uGXPnt0VM69fv74rcA6cD0EpAAAAAACQLDt37rSiRYu6qXnR0dF20003We7cuS1fvnyhbhoyECZ2AgAARJj33nvP6tSp4z4YaGvatKl9//33id5H0y6qVavmCtHWrl3bJk+enG7tBQBkHKdPn7Zp06bZyJEjbcGCBf7jJUuWJCCFZCMoBQAAEGHKlCljL7/8sluOe9GiRa7Q7PXXX28rV64Mev7cuXOta9eu1qtXL1u6dKl16tTJbb///nu6tx0AEL42bdrkBj7mzZtnPp/Pdu/eHeomIYPL4tNvEpLt0KFDlj9/flfQjWgwMps2gyeFugkIU1MHtgt1E4B0l1H6BIUKFbLXXnvNBZ7i69Klix09etS+++47/7EmTZpYvXr1bMSIERH3WgAAkufEiRM2ffp0W7JkidvX3/h27drZxRdfHOqmIUwltU9ATSkAAIAIdvbsWTc1T0EnTeMLRiPeDz30UJxjbdq0sQkTJiR67ZMnT7otsAMKAIgsmzdvtq+++soOHz7s9hs2bGitW7d2Rc2BC0VQCgAAIAKtWLHCBaE0up0nTx77+uuvrUaNGkHP3bFjhxUvXjzOMe3reGJeeuklGzRoUKq2GwAQXlRrUAMbyrjt0KGDVahQIdRNQgShphQAAEAEqlq1qi1btszmz59vffr0sR49etiqVatS9TEGDBjg0vK9bevWral6fQBA+lOFH62s5ylRooSrO3jPPfcQkEKqI1MKAAAgAsXExFjlypXd9w0aNLCFCxfa0KFD3WpJ8ekDR+AHENG+jidGUzeYvgEAkUPTsCdNmmQbNmyw3r17+98HvPcTILWRKQUAAJAJxMbGxqn/FEjT/GbMmBHnmAraJlSDCgAQedlRWq11+PDhtm7dOsuSJct5p3ADqYFMKQAAgAijaXXXXnutlStXzhWmHTNmjM2aNcumTp3qbu/evbuVLl3a1YSSfv36WYsWLeyNN95wqymNHTvWfTgZNWpUiJ8JACCt7du3zyZOnOgKmkuZMmWsY8eOVrRo0VA3DZkAQSkAAIAIs2vXLhd42r59u1uOuU6dOi4gdfXVV7vbt2zZYlmz/i9hvlmzZi5w9dRTT9kTTzxhVapUcSvv1apVK4TPAgCQ1hYsWOAyY8+cOWPR0dF21VVXWaNGjeK8RwBpiaAUAABAhPnXv/6V6O3Kmorv5ptvdhsAIHNN21NAqmLFim5lvYIFC4a6SchkCEoBAAAAAJAJnD171q2WWqhQIbd/6aWXWr58+axatWqujhSQ3ghKAQAAAAAQ4f766y/75ptvXGZUnz593HQ9TdOrXr16qJuGTIygFAAAAAAAEerUqVP2448/2vz58910vdy5c9uePXusZMmSoW4aQFAKAAAAAIBItGnTJrey3v79+92+Fr5o06aN5cqVK9RNAxyCUgAAAAAARFjtqEmTJtnSpUvdvupGtW/f3q2uCoQTglIAAAAAAEQQ1Yo6evSov5h5q1atLHv27KFuFnAOglIAAAAAAGRwCkIpGJUzZ063kl67du2sWbNmVr58+VA3DUgQQSkAAAAAADIoFS9fsWKFTZkyxS6++GLr1KmTf8qeNiCcEZQCAAAAACADOnjwoKsdtX79ere/Y8cOt9peTExMqJsGJAlBKQAAAAAAMlh21OLFi2369OkuCBUVFWVXXHGFXXbZZe57IKMgKAUAAAAAQAbKjvr666/tzz//dPtlypSxjh07WtGiRUPdNCDZCEoBAAAAAJBBaGrenj17LDo62q2qp9X1VOAcyIgISgEAAAAAEMb27dtnBQsWdKvqaXW9m2++2fLnz28FChQIddOAC0I4FQAAAACAMHTmzBn78ccfbfjw4W6FPU/58uUJSCEikCkFAAAQJmJjY23Dhg22a9cu930gFbAFAGQe27Zts2+//dZ2797t9jdv3mx16tQJdbOAVEVQCgAAIAz8+uuv1q1bN1e4VqsqBdJ0jbNnz4asbQCA9KPV9GbOnGnz5893+7lz57brrrvOatSoEeqmAamOoBQAAEAYuOeee6xhw4Y2adIkK1mypAtEAQAyFw1MTJgwwQ4cOOD269ata23atHF1pIBIRFAKAAAgDKxfv96++OILq1y5cqibAgAIIQWkVMS8ffv2vCcg4hGUAgAACAONGzd29aT4AAIAmS8I5RUtVwHzm266yb0XZM+ePdRNA9IcQSkAAIAw0LdvX3v44Ydtx44dVrt2bYuOjo5zO8VtASCyHDlyxKZMmWLr1q2zPn36WMGCBd3xmjVrhrppQLohKAUAABAGOnfu7L7eeeed/mOqK6Wi5xQ6B4DIob/rK1ascAGp48ePu7/xqiXlBaWAzISgFAAAQBjYtGlTqJsAAEhjBw8etO+++85N15YSJUpYx44d3QIXQGZEUAoAACAMqI4IACByLV682KZNm2anTp2yqKgoa9GihTVr1sx9D2RWKQpKbdmyxaUXHjt2zIoWLermvFKEDQAA4MJs3LjRhgwZYqtXr3b7NWrUsH79+lmlSpVC3TQAwAU6dOiQC0iVLVvWZUcVKVIk1E0CMk5QavPmzfbee+/Z2LFjbdu2bW4erCcmJsYuv/xyu/vuu109hKxZs6ZVewEAACLS1KlT3YeUevXq2WWXXeaOzZkzxw3+TZw40a6++upQNxEAkAyxsbF29OhRy5s3r9vXZ2bVjapbt66rIwXALEnRo/vvv9/9w1Gtg+eff95WrVrl5sIqyqsVYiZPnmzNmze3p59+2q0Ms3DhwrRvOQAAQATp37+/PfjggzZ//nx788033abvH3jgAXv88cdD3TwAQDLoc/IHH3xgY8aM8S9UkS1bNjfwQEAKSGZQKnfu3PbHH3/Y559/brfffrtVrVrVRXv1j6pYsWJ21VVX2TPPPONSzV9//XXbunWrJdXw4cOtQoUKliNHDmvcuLEtWLAg0fPHjx9v1apVc+druWQFxAJ99dVXds0111jhwoXdP/Zly5adc42WLVu62wK3e+65J8ltBgAASG3qR/Xq1euc41qNTwOCAIDwd+bMGZs5c6a9//77tn37djtw4IDt2bMn1M0CMnZQ6qWXXnJBnqRo27at3XjjjUk6d9y4cfbQQw+5gNaSJUtcNlabNm1s165dQc+fO3eude3a1XXYli5dap06dXLb77//7j9H6ZHK2nrllVcSfezevXu7PxLe9uqrryapzQAAAGlBdTqDDabpmAYBk0N9t0svvdQNIuq+6i+tXbs20fuMHj36nEE7DQICAJJGyRkjR460n3/+2U3dq169ut17771WvHjxUDcNiJxC58ePH3f1pHLlyuX2VfD866+/dv/gFFBKDqWlKzjUs2dPtz9ixAibNGmSffjhhy6FPb6hQ4e6oNejjz7q9gcPHmzTp0+3YcOGufuKMrm8GliJUfu1/CYAAEA4UJ9I9TmVna7VmLyaUhpo0yBecvz000/ug5ACUxq1f+KJJ1wmuTKulAGfkHz58sUJXjHFBADOT39n9bnUm/Wjv7PXXXedW6wCQCoHpa6//nqXCaXpbkpF1JS76Ohol5KoIFOfPn2SdB3Vo9KSmAMGDPAfU4H01q1b27x584LeR8fjd8oUCJswYUJyn4Z99tln9u9//9sFpjp06GADBw70B9oAAADSm/oiymx64403/P2jUqVK2bPPPuvqeybHlClTzsmCUsaU+l5XXHFFgvdTEIpBOwBIHn2O1ewbUc0oDQLkzJkz1M0CIjMopWl2b731lvv+iy++cKmImkr35ZdfukLnSQ1KKYilgm/xUxm1v2bNmgSLxQU7X8eTo1u3bla+fHnX0fvtt99c8VCNCqoeVUJOnjzptsDlPAEAAFKLAkIqdK7t8OHD7pi3YtOF0gI1UqhQoUTPO3LkiOsjadrJJZdcYi+++KJb/S8h9I8AZFaaQaQay0rQUFBKq6fqb22lSpVC3TQgsoNSx44d83eQpk2b5rKm9I+wSZMmbipfRqDUeI+KpZcsWdJatWplGzduTPCPiGozDBo0KB1bCQAAMqvUCkaJAkxawe+yyy6zWrVqJXieFrJRCQWtpKwPVlq8RtMIV65caWXKlAl6H/pHADLrwhRacEufJZUVJUWKFHEbgDQOSlWuXNlNl7vhhhts6tSpbjRPVJxcdQiSSv9go6KibOfOnXGOaz+htHEdT875SaUpiLJhw4YEg1JKow+cOqiRwLJly17Q4wIAUl+bwZNC3QSEqakD21m4UTbSjBkzrGDBgla/fv1EazgpWz0lVFtKi8L88ssviZ7XtGlTt3kUkFLNUBXtVR3PYOgfAchMlE36/fff+1dE1edHrUSvjCkAKZPsfz2aoqfpbwpGKbvI67woa0qdqaSKiYmxBg0auI6YVoTxRvK0f9999wW9jx5Lt2u0z6OCcoEdqJTwVrpRxlRCsmfP7jYAAIDUolqdXv9C36d2YXH1qb777jubPXt2gtlOCdGUFPXt9KErIfSPAGQGWuhLZV9Ur+/EiRPub7WyT1u0aEFACrhAyf4XdNNNN1nz5s1dIbe6dev6jytApeyp5NDIWo8ePaxhw4bWqFEjGzJkiB09etS/Gl/37t2tdOnSLjVc+vXr5/7hqwBou3btbOzYsbZo0SIbNWqU/5r79u2zLVu22N9//+32vRVklE2lTVP0xowZ41ZDKFy4sPvjogCbin4qXR0AACC9PPPMM/7vVdA8NT9A9e3b162QPGvWLKtYsWKyr6HanytWrHB9JgDIrJQBOnHiRH+AXp8pNYjAohBA6khRWNcL8ARSUCm5unTpYrt373bZVypWrpUKFH32ipkruKR6VYFp5AooPfXUU25p4ypVqriphIH1Eb799lt/UEtuvfVWf6dPnT1laP3www/+AJhSzDt37uyuCQAAECoXXXSRLVy40A2aBdJqx5rm98cffyRryp76TN98842rT+UtCpM/f37/ilDxB/+ee+45VyNUpRr0mK+99pqrF3rXXXel6vMEgIxm69atrvRMy5Yt3SwdfQ8gdWTxaSjtPO655x4XtElK2ve4cePszJkzdtttt1mkR8zVsVMh0OTU0gIiATV7EM41e/j9RHr/fqZWn0ADcQoeFStW7Jz6mRpEO3XqVJKvldA0wI8++sjuuOMO970+XFWoUMFGjx7t9pU5rpWI1QbVuFKZheeffz5Z5RnoHwGIlNpRefLk8e+vW7fOrV5KIXPAUr1PkKRMqaJFi7rlgDVvtkOHDm66XalSpSxHjhy2f/9+V+hNxTM1nU7HA6fTAQAAIGHK8vZoERl14AKn0KmeZnKn3yVhzNFN6wv01ltvuQ0AMiv9zZ03b577+6hZPZqZIxdffHGomwZErCQFpbTiigplfvDBB/buu+/6VxvwKC28devWLhjVtm3btGorAABAxPEWfFF2k2ptxi82rmwm1dMEAKQd1UzWIIE33Xn16tX+oBSAMKgppTpPTz75pNuUHaV6T8ePH3cpjJUqVUr11WIAAAAyA60+LMqGUk0ppocAQPpR6ZmffvrJ5syZ47JMVXevTZs2LIIFhHOhc9UZ0AYAAIDUsWnTplA3AQAylW3btrkFIfbs2eP2a9SoYddee22celIAwjAoBQAAgNSnlYE1Yq+M9PiFze+///6QtQsAItHhw4ddQEpBqOuuu86qV68e6iYBmQ5BKQAAgDCwdOlS96Ho2LFjLjillZ70YSlXrlxuRT6CUgBw4fT3NXfu3O57BaHatWvnFvXStD0A6S9rCB4TAAAA8Tz44INulWPV7tSHo19//dX+/PNPa9Cggb3++uuhbh4AZGiqh6ypesOHD7cjR474j2tleQJSQOgQlAIAAAgDy5Yts4cfftiyZs1qUVFRdvLkSStbtqy9+uqr9sQTT4S6eQCQYWn1eAWj9HdWwamNGzeGukkAUjp9T/+ItSqBUslFI3hff/21Kwp3zTXXJPdyAAAAMLPo6GgXkBJN11NdKU0tyZ8/v23dujXUzQOADEcZUZMnT7bVq1e7fa1u2rFjRxfwB5BBg1LXX3+93XjjjXbPPffYgQMHrHHjxq4TpZoHb775pvXp0ydtWgoAABDB6tevbwsXLrQqVapYixYt7Omnn3b9q08//dRq1aoV6uYBQIayfPlymzJlip04ccIF/C+77DK74oorLFs2yioDGXr63pIlS+zyyy9333/xxRdWvHhxly31ySef2Ntvv50WbQQAAIh4L774opUsWdJ9/8ILL1jBggXdYN/u3btt1KhRoW4eAGQo27ZtcwEp/V3t3bu3XXXVVQSkgDCU7H+VWhEmb9687vtp06a5rClFnps0aeKCUwAAAEgelUbQlD0vI0rfa4QfAJD0v6MKQnlFy1u3bu2m61166aX+qdEAwk+y/3VWrlzZJkyY4GobTJ061V9HateuXZYvX760aCMAAEDEf5hSH4vaUQCQfJrq/NFHH9n48ePd31PJnj27KzVDQAoIb8n+F6r6Bo888ohVqFDBGjVqZE2bNvVnTakWAgAAAJJHH5pUS2rv3r2hbgoAZBhnz561n3/+2UaMGOGC+n/99ZcLUAGI4Ol7N910kzVv3ty2b99udevW9R9v1aqV3XDDDandPgAAgEzh5ZdftkcffdTee+89CpsDwHno8+i3335rO3bscPvKNm3fvr1bsRRAxpGiSm8lSpRwm5diriU1lTUFAACAlOnevbur3alBv5iYGH9dFM++fftC1jYACBdnzpyxWbNm2dy5c91UPf2tbNOmjdWpU8eyZMkS6uYBSOuglP4IDBo0yK20d+TIEXcsT5481rdvX3vmmWcsOjo6uZcEAADI9IYMGRLqJgBAhrBu3ToXkKpZs6a1bdvWfR4FkEmCUgo+ffXVV/bqq6/660nNmzfPnn32WVcHQSnnAAAASJ4ePXqEugkAEJZOnjxp2bJls6ioKPf1+uuvt8OHD1u1atVC3TQA6R2UGjNmjI0dO9auvfZa/zGlSmoKX9euXQlKAQAApNDGjRvdClL6OnToUCtWrJh9//33Vq5cOZcRAACZzYYNG+y7776zBg0a2OWXX+6OlS5dOtTNAhCq1fe0tKZW3ouvYsWKrv4BAAAAzm/t2rVx9n/66SerXbu2zZ8/32Wle2USli9f7kokAEBmcvz4cZswYYJ99tlndvDgQfvtt9/cansAMnlQ6r777rPBgwe7FEqPvn/hhRfcbQAAADg/BZ5uu+02/4es/v372/PPP2/Tp0+PM9B31VVX2a+//hrClgJA+lq1apUNHz7cBeWlcePG1rt3bzd9D0Amn763dOlSmzFjhpUpU8atDiP6Y3Hq1Clr1aqV3XjjjXE6WwAAADjXI488Yg899JBbNeqHH36wFStWuDIJ8WkK3549e0LSRgBIT8oQnTx5sq1evdrtFy1a1Dp27Og+ewKITMkOShUoUMA6d+4c55jqSQEAACDptGLxO++8Y+PHj/f3sbZv3+5KIsQfEKR+CoDM4MSJE25lvaxZs1rz5s1dDSkVNgcQuZL9L1zFNwEAAJA6br75Zvf11ltvtccff9wFqbJkyWKxsbE2Z84cl1HVvXv3UDcTANIsEJUjRw73fZEiRaxDhw5WokQJK168eKibBiAca0oBAAAg9b344otueXNloGsKS40aNeyKK66wZs2a2VNPPRXq5gFAqlLgXQs7vPXWW7Zt2zb/cZWIISAFZB7JzpTau3evPf300/bjjz/arl273B+TQPv27UvN9gEAAGQKKm7+/vvv28CBA+333393gan69etblSpVQt00AEhVu3fvtm+//dYfjNI0ZepGAZlTsoNSt99+u23YsMF69erlIthKLwcAAEDqKFeunNsAINJotVFNS549e7b7XsH4q6++2ho0aBDqpgHIKEGpn3/+2X755Rf/ynsAAABIGa2+l1RvvvlmmrYFANKSFnL45ptvbOfOnW5fWaDt2rWz/Pnzh7ppADJSUEq1Do4fP542rQEAAMhENGUlKZKbmf7SSy/ZV199ZWvWrLGcOXO6ulSvvPKKVa1aNdH7qci6pg9u3rzZfWDUfa677rpkPTYAJBSUUkBKf5Patm1rtWvXZtYNgOQHpd59913r37+/qytVq1Ytt5xxoHz58qVm+wAAACKWanSmhZ9++snuvfdeu/TSS+3MmTP2xBNP2DXXXGOrVq2y3LlzB73P3LlzrWvXri6g1b59exszZox16tTJlixZ4vp8AJBcJ0+etOzZs7vvVSNPtfI0VS+hv0MAMp9kB6UKFChghw4dsquuuirOcZ/P5yLdmhsMAACAlFHtzo0bN7qV95RR4PWxkmPKlClx9kePHm3FihWzxYsXu+sGM3ToUJe98Oijj7r9wYMH2/Tp023YsGE2YsSIC3hGADJjMOqHH36w9evXW58+fVxgSn/HEvr7AyDzSnZQ6rbbbnPZURo9o9A5AABAymgF46xZs8ZZ4fiWW25x2VPqX+nD3EUXXeQWlylYsKC98cYbKX6sgwcPuq+FChVK8Jx58+adU+OqTZs2NmHChEQ/eGrzaOASQOZ17NgxN21Y2Zre34N169a5qXoAkCpBKS1RrPoH56tJAAAAgMQLl9eoUcNfs+nBBx90A39btmyx6tWr+8/r0qWLCxalNCil4NcDDzxgl112WaLT8Hbs2OEGHANpX8cToql+gwYNSlG7AESGU6dO2fLly2316tWuHp2yO0XB9A4dOljFihVD3UQAkRSUatiwoW3dupWgFAAAwAXQMuidO3d2xX+VDTVt2jSbOnWqlSlTJs55Kjj+559/pvhxVFtKg4paPTm1DRgwIE52lTIjypYtm+qPAyC8nD592l9bWIFv/e3yyriUKFHCatasaY0aNbKYmJgQtxRAxAWl+vbta/369XP1BpSGGb/QeZ06dVKzfQAAABGpbt26tmDBAuvRo4cLSh09etRy5cp1znn79u3zFwpOrvvuu8++++47mz179jnBrvj0QdJbqt2jfR1PiNqV0rYByFj0t0jZUNqUDdW7d293PEeOHNa4cWP390tZnolNEwaACw5KKYVc7rzzTv8x1T2g0DkAAEDy6MPbxIkT3feXX365ffLJJ67AuKhfpQyEV1991a688spkXVf9Mg0kfv311zZr1qwkTZ9p2rSpzZgxw03186jQuY4DyJx2797tVu1UICowaK2/T1pJL0+ePP7MTwBIl6DUpk2bUvRAAAAASJiCT61atbJFixa5Gi2PPfaYrVy50mUnzJkzJ9lT9rQozTfffGN58+b114XKnz+/W9FPunfvbqVLl3Z1oUSZ8C1atHC1q9q1a2djx451bRk1alQaPFsA4U6reM6fPz9OIEoBbmVDVatWzR+QAoB0DUqVL1/+gh4QAAAA51IRcq1SNWzYMBdIUhbCjTfe6AJMJUuWTNa13nvvPfe1ZcuWcY5/9NFHdscdd7jvVVA9cPW/Zs2auUDWU089ZU888YSrZaWV9xIrjg4g41Nm5V9//eWyoS655BIrXLiwO676cAsXLrRKlSq5QJRqCgebYgwA6RqUkk8//dRGjBjhsqa0fLACVUOGDHGR8+uvv/6CGgQAAJBZKZPpySefvODreKtfJUbT+uK7+eab3QYgsmlqsBav0tS8NWvWuEUKRDXirrjiCve9glCqI6yaUQCQVv43PJaMkTetsqLliw8cOOCvIVWgQAEXmAIAAEDyKYtp/Pjx5xzXsY8//jgkbQIQWY4dO+YWP3jzzTdt9OjRbrEFBaS0Sp5WzAtcECFbtmwEpACEX1DqnXfesffff9+N4kVFRfmPN2zY0FasWJHa7QMAAMgUVNupSJEi5xwvVqyYvfjiiyFpE4CM7cyZM7Z3717/voJP+sym1T4VcNIqoLfeeqvLiLrpppvsoosuCml7AWQ+KSp0Xr9+/XOOK9VTf9wAAACQfKrxFGyVPJVJ0G0AkBSnT5+2DRs2uBpRqlOXO3duu++++1yhcmU/tWnTxvLly+f+3gQmGQBAhghK6Y/XsmXLzil4rtUZVAAPAAAAyaeMqN9++80qVKgQ5/jy5cv9hYcBIJiTJ0/a+vXrXSBKXxWY8kRHR7vkAW+1PBUzB4AMF5R67rnn7JFHHnH1pLQKzIkTJ1wRTc1D/s9//uNSzj/44IO0bS0AAECE6tq1q91///1u5T2v0PBPP/1k/fr1c9NrACAh06ZNsyVLlsRZNEEJA9q0ip6ypAAgQwelBg0aZPfcc4/dddddljNnTrdcsArldevWzUqVKmVDhw6lwwQAAJBCgwcPts2bN1urVq3cFBtvhazu3btTUwqAo4yntWvXuoyoli1bWunSpd3xatWqub8fCkLVqFHDSpYsSSAKQGQFpQKXFr7tttvcpqDUkSNHXLo5AAAAUk4FiMeNG2fPP/+8K5WgQcDatWufUzIBQOZy+PBhW7Nmja1atcr+/PNP/+eyokWL+oNSlStX9teNAoCIrSkV/49crly53AYAAIDUUaVKFbcByNwUjBo/frxt3bo1znFlQXkZUR6CUQAyRVDq4osvPu8fvH379l1omwAAADKdzp07W6NGjezxxx+Pc/zVV1+1hQsXug+nACLX3r177cCBA1apUiW3r1XzvM9WZcqU8deIKliwYIhbCgAhCkqprpSK5qWm4cOH22uvvWY7duywunXr2jvvvOM6ZAlRh2zgwIFuzrRGEV955RW77rrr/Ld/9dVXNmLECFu8eLH7I7506VKrV69enGuoSPvDDz9sY8eOdStVaFnUd99914oXL56qzw0AACCpZs+ebc8+++w5x6+99lp74403QtImAGlH0/B2797t6kNpat6uXbvcCnlaWEqJAFmzZnXBaq2+mS9fvlA3FwBCH5RSIfPUrB+lugn6o6sgUuPGjW3IkCEuQKTifcEeZ+7cuW5lGq301759exszZox16tTJrTRRq1Ytf/G/5s2b2y233GK9e/cO+rgPPvigTZo0yQW4FGTT/Osbb7zR5syZk2rPDQAAIDlUp1N1peLTcu6HDh0KSZsApD4Fn1asWOGCUcqO8igQpc9AqturLCmpWLFiCFsKAGEUlEqLecpvvvmmCxz17NnT7Ss4pWDRhx9+aP379z/nfK3w17ZtW3v00Uf9q9RMnz7dhg0b5u4rt99+u/uqTKpgDh48aP/6179cQOuqq65yxz766COXCvvrr79akyZNUv15AgAAnI+KmmvA7umnn45zXJndgbVjAGQsXmFy7/OUZnLoc4dERUW56Xr6LFK1alW3wAEAZCYpWn0vNZw6dcpNsRswYID/mFJUW7dubfPmzQt6Hx1XZlUgZVZNmDAhyY+rxzx9+rR7HI+WUC1Xrpy7fkJBKU3z0+ZhxBIAAKQmlSdQ5vbGjRv9A2czZsxwA2lffPFFqJsHIBliY2Nty5YtLhtK2/XXX++vFVWzZk03UK5AlGr2Zs+ePdTNBYDwD0rpD2tq2rNnj509e/acOk7a15KnwajuVLDzdTypdK5S4wsUKJCs62jKoGpqAQAApIUOHTq4gbYXX3zRBaGUMaF6mzNnzrRChQqFunkAzkOfbTRbQ0EofZ5RWRGPypN4QSkVLVepEQBAMmtKZWbK6ArM0lKmVNmyZUPaJgAAEFnatWvnNq+v8Z///MceeeQRl+mtD7wAwpP+vb733ntuQSVPjhw53JQ8ZUR5ASkAQJgEpYoUKeLmUO/cuTPOce2XKFEi6H10PDnnJ3QNTR3UcquB2VLnu47SakmtBQAA6bEKn+pffvnll1aqVCk3pU+rFQMIDyoFsmHDBpcJ1bBhQ3csb968LrtR5UhUGkR14CpUqOA+7wAAwjAopSl0DRo0cLUStIKeN0VQ+1oNL5imTZu62x944AH/MRU61/Gk0mNqFRtdR0useum0mvOdnOsAAACkFpUQGD16tAtGKeNCU3tUy1LT+ShyDoSe/j2uX7/eVq1a5QJSCkxpwLp+/fou8KQi5lpwSSt7KzAFAMgA0/c0Ha5Hjx5uhKFRo0Y2ZMgQN+LgrcbXvXt3K126tKvnJP369bMWLVrYG2+84VLbtRrNokWLbNSoUf5r7tu3zwWY/v77b3/ASZQFpU1vFL169XKPrfoM+fLls759+7qAFCvvAQCAUNSSUnaU+jbqC2mlYX3I9VYWBhA669atc9NntQBB4BRazbjQtDwFp7xsqIIFC4awpQCQMYU0KNWlSxfbvXu3W/pYI4T16tWzKVOm+IuZK7gUONLQrFkztwLNU089ZU888YRVqVLFjSDWqlXLf863337rD2rJrbfe6r4+88wz9uyzz7rv33rrLXddZUpp1EMr+L377rvp+MwBAAD+6/vvv7f777/f+vTp4/o2AEJHA+TKgMqW7b8fkzTQrcCUFC5c2AWilL2owW5lRwEALkwWn8/nu8BrZEpKrVfWlZZzVbZVamszeFKqXxORYerA/xbADSV+P5EQfj+RGX8/L7RP8Ouvv7ppe+PGjXMfeDUFSINqJUuWtOXLl2eo6Xtp3T8C0ur3VivmadOg+E033eT/d6cVw3///Xe3X7RoUQJRAJDKfQJW3wMAAAghlQ/Qpql7Ckx9+OGHrsyAam2qdqZW+1URZQCpR4seqT6UAlHbtm2Lc9v27dv9QSktztSyZcsQtRIAIh9BKQAAgDCQO3duu/POO92mmpjKnnr55Zetf//+dvXVV7sSBQAunEbthw4dGudYmTJlXKaiNmpDAUD6ISgFAAAQZqpWrWqvvvqqW+xl4sSJLnsKQPKoSonq1yojyqsjK5pOoumxqh2lIFS1atWYbgoAIUJQCgAAIExpVa9OnTq5DUDSAlGafufViNq7d6//35Km4SkQJVqN21s1DwAQOgSlAAAAAGR4CxcutLlz57p6UR4FnipVquQyogJX9SYgBQDhgaAUAAAAgAxFCwFopbwSJUpYjhw53LEzZ864gFR0dLRVrlzZFSuvUqWKPzsKABB+CEoBAAAACHtnz561zZs3uxpRa9assWPHjlnHjh2tfv367vZatWpZgQIFXEBKgSkAQPgjKAUAABBhZs+eba+99potXrzY1df5+uuvE61LNWvWLLvyyivPOa77KhMFCGUgasOGDa4+lFalPHHihP+2nDlz2qlTp/z7efPmddP0AAAZB0EpAACACHP06FGrW7eu3XnnnXbjjTcm+X760B+4ClmxYsXSqIVA4sXKs2TJ4r4/fvy4jR071n9b7ty53Wp5mppXvnx5akMBQAZHUAoAACDCXHvttW5LLgWhNP0JSG/KgFq3bp3LiFJ2VLdu3dzxPHnyuGl5uXLlcoGosmXLxilYDgDI2AhKAQAAwKlXr56dPHnSBQGeffZZu+yyy0LdJEQwZUGpNpQCUX/88YcLRomypJTtp6wo6dy5c4hbCgBIKwSlAAAAMrmSJUvaiBEjrGHDhi4o9cEHH1jLli1t/vz5dskllyR4P52rzXPo0KF0ajEyupkzZ9ovv/zipup5Chcu7GpCKSNKmVEAgMhHUAoAACCTq1q1qts8zZo1s40bN9pbb71ln376aYL3e+mll2zQoEHp1EpkVApWKhtKASevZpmmiSogVbx4cXdcW9GiRf21pAAAmQNBKQAAAJyjUaNGLpMlMQMGDLCHHnooTvBBNX+A/fv3u0CUtm3btrljCkI1adLEfa9sqAoVKlihQoVC3FIAQCgRlAIAAMA5li1b5qb1JSZ79uxuA7xi5QsWLHCBqB07dsS5TcHKwJUdc+TI4TYAQOZGUAoAACDCHDlyxDZs2ODf37RpkwsyKSulXLlyLsPpr7/+sk8++cTdPmTIEKtYsaLVrFnTBRZUU0o1f6ZNmxbCZ4Fwp8wn/b7kzJnT7Wvq3ezZs13Bcn1fvnx5lxFVrVo1y5s3b6ibCwAIQwSlAAAAIsyiRYvsyiuv9O97U+x69Ohho0ePtu3bt9uWLVv8t586dcoefvhhF6hSgek6derYDz/8EOcagBeI+vvvv/1T85Qpd/fdd7vb9H3z5s1dRpRqlHmr5wEAkBCCUgAAABFGK+cFrmoWnwJTgR577DG3AcHod2nr1q3+QNTBgwf9t2XLls2OHTvmXy1Pv3sAACQVQSkAAAAACfruu+9syZIl/v3o6GirUqWKm5qnrzExMSFtHwAg4yIoBQAAAMDVglL9sVWrVlmzZs2sSJEi7vhFF11kK1eudFPyqlevbpUqVXKBKQAALhRBKQAAACCTOn36tG3cuNFNy1u7dq2dPHnSHc+fP7+1aNHCfa9C5QpIaaoeAACpiXcWAAAAIBOu0DhlyhRbt26dC0x5VJxcQShlQ3mioqJC1EoAQKQjKAUAAABEuBMnTtiBAwesRIkSbj9Hjhy2fv16F5DSanmalqetbNmyljVr1lA3FwCQSRCUAgAAACKQVsXTlDxNzfvjjz/clLz77rvPsmTJ4qbitW/f3goVKmSlSpVyxwAASG8EpQAAAIAImpanIJS2zZs3m8/n89+mDKjjx49brly53H7t2rVD2FIAAAhKAQAAABFj5syZtnTpUv9+8eLFrUaNGm5qXtGiRUPaNgAA4iMoBQAAAGQw+/bt82dEtW3b1sqUKeOOKwC1a9cuf40oTc8DACBcEZQCAAAAMoDdu3f7A1E7duzwH1+1apU/KFW5cmW3AQCQERCUAgAAAMLYwYMH7d///rft2bPHf0yFyStUqODPiAIAICMiKAUAAACECRUm//vvv+3w4cNWrVo1dyxv3ryuQLkKlVeqVMkFoapWreovWA4AQEZFUAoAAAAIodjYWNu6dat/at6hQ4csT548LvCkjCgFo7p27WqFCxe2HDlyhLq5AACkGoJSAAAAQAgoEPXbb7/ZmjVr7MiRI/7jMTExVr58eTtx4oTlzJnTHStdunQIWwoAQNogKAUAAACkg7Nnz/ozn7wC5YsWLXLfZ8+e3U3X09Q8TdHLlo1uOgAg8vFuBwAAAKSR06dP28aNG920vLVr19rNN9/sgk5Su3ZtO3nypNWoUcMqVqxoUVFRoW4uAADpiqAUAAAAkIpOnTpl69atc4Go9evXu8CUZ8OGDf6gVKlSpaxjx44hbCkAAKFFUAoAAABIJQcOHLBhw4a5qXqe/Pnzu2l52sqWLRvS9gEAEE4ISgEAAAApcOzYMVekXAXJmzVr5g9A5cuXz9WOUhBKU/NKlizp9gEAQFwEpQAAAIAkOnz4sAtEaWre5s2bzefzuSLljRo1csXJFXzq1auX5cqVi0AUAADnQVAKAAAAOI8VK1bYwoULbevWrXGOlyhRwmVEabqet2Je7ty5Q9RKAAAyFoJSAAAAQDz79u2zvHnzWnR0tNvfu3evPyBVpkwZf42oggULhrilAABkXASlAAAAkOlpGt7u3bvdtDxtO3futJtvvtnVhJLatWtbzpw5XSBKNaMAAMCFIygFAACATBuI2rFjhwtCrVq1ymVDeVQPKnC/cOHCbgMAAKmHoBQAAADCPni09/heO3LqiOWJyWOFcxZOlSLiBw8etFGjRvn3o6Ki7KKLLnLZUVWrVnWZUQAAIO0QlAIAAEBYOnDigH287GN7Z8E7tnH/Rv/xSgUrWd9Gfa1HvR5WIEeB814nNjbW1YNSNpQKkrdv394dL1CggJUtW9by5MnjpuVdfPHFbiU9AACQPghKAQAAIOxM3TDVOn/e2Y6dPnbObX/s/8MenPqgPTnzSfvyli+tTeU255yj4NPmzZvd1Lw1a9bY0aNH/dlQV199tT/41LNnz1TJugIAAMmXNQX3AQAAQBibPXu2dejQwUqVKuUCLhMmTDjvfWbNmmWXXHKJC9ZUrlzZRo8ebaEMSLUb086Onz5uvv//XyDvmG7XeTo/0Jw5c+yNN96wf//737Z48WIXkMqRI4fVrVvXFS/Plu1/47IEpAAACB0ypQAAACKMgjAKwNx555124403nvf8TZs2Wbt27eyee+6xzz77zGbMmGF33XWXlSxZ0tq0OTcLKa2n7ClDSnWkYi020XN1e4wvxvqP7W91761rJQqWcMezZs1qx48ft1y5clm1atVcjagKFSq4LCkAABA+CEoBAABEmGuvvdZtSTVixAirWLGiyy4S1Vf65Zdf7K233kr3oJRqSGnKXvzsqEAxFmMX28VW3apbFatiMWdj7NOZn9qjnR91t9euXdsF1MqVK+cCVAAAIDyFxbv08OHD3eiV0qobN25sCxYsSPT88ePHu1Evna9Ox+TJk+PcrpG1p59+2nVGtGpK69atbf369XHO0eMpXTtwe/nll9Pk+QEAAISzefPmuf5SIAWjdDw9qQ+noubBRFu01bW61tW62mP2mN1kN1lNq+kCVAfsgP3wxw/u/qLC5errEZACACC8hfydety4cfbQQw/ZM888Y0uWLHGp5uoE7dq1K+j5c+fOta5du1qvXr1s6dKl1qlTJ7f9/vvv/nNeffVVe/vtt92o3/z58y137tzumidOnIhzreeee862b9/u3/r27ZvmzxcAACDc7Nixw4oXLx7nmPYPHTrkpsEl5OTJk+6cwO1C7D2+162yFyxLSsGnTtbJqlpVy2bZbK/ttZ/tZxtpI22IDbFpx6bZvuP7LujxAQBAJpu+9+abb1rv3r3dyieiQNKkSZPsww8/tP79+59z/tChQ61t27b26KP/Tc8ePHiwTZ8+3YYNG+buqxGyIUOG2FNPPWXXX3+9O+eTTz5xHSsV+bz11lv918qbN6+VKPHf2gMAAABInpdeeskGDRqUatc7cupIgrcdtaO2xJbYYTtsq2yV7bJzBzAbjmpoTco2sQYlG7jtkpKXWP4c+VOtfQAAIIIypU6dOuVWRAlMF1eatfYTShc/X3q5CnVqtC/wnPz587tpgfGvqel6hQsXtvr169trr71mZ86cSbeRQAAAgHChQbqdO3fGOab9fPnyuVIICRkwYIAdPHjQv23duvWC2pEnJk+it0+0iTbLZgUNSMnmg5tt7O9j7dHpj9pVn1xlBV4pYFXeqWJdv+xqr8993X7c9KMdPHHwgtoIAAAiJFNqz549dvbs2aDp4mvWrElWermOe7d7xxI6R+6//3637HGhQoXclEB1qjSFT5lb6TESCAAAEC6aNm16To1OZaLreGKyZ8/uttRSOGdhq1Swkv2x/49EC50HbUvUf9tx8uzJOMc37NvgNgWrPJULVbaGpRqSUQUAQGafvhcqqmPlqVOnjsXExNg///lPF3wK1rlS0CrwPsqUKlu2bLq1FwAAIKmOHDliGzZs8O8rk3zZsmVuME4r0qlf89dff7kSB3LPPfe4UgiPPfaY3XnnnTZz5kz7/PPPXUmF9KSFZ/o26msPTn0wefezLPbq1a9an4Z9bNXuVbZ4+2Jb/Pdi93X5zuV24kzcuqIEqgAACA8hDUoVKVLEoqKigqaLJ1TrKaH0cu9876uOafW9wHPq1auXYFs0vU/T9zZv3mxVq1ZN85FAAACAtLJo0SK78sor/fvewFqPHj1s9OjRLjt8y5Yt/tsrVqzoAlAPPvigq99ZpkwZ++CDD1yJhPTWo14Pe3Lmk3b89HGLtdjznp81S1bLmS2nda/b3aKjoq1uibpuu7P+ne7202dP2+o9q23R34tSFKhSgMoLVhGoAgAggoJSyk5q0KCBzZgxw62gJ7GxsW7/vvvuC3ofpZHr9gceeCBoerk6VQpM6RwvCKWsJq3C16dPnwTbotFD1bMqVqxYKj9LAACA9NWyZUu3+EtCFJgKdh+tbBxqBXIUsC9v+dLajWlnWX1ZEw1MZbWsLkvqqy5fufsFo0BVneJ13JbSQNW4leP8xwhUAQAQQdP3NHKnUbuGDRtao0aN3Mp5R48e9a/G1717dytdurSbVif9+vWzFi1a2BtvvGHt2rWzsWPHutHAUaNG+dO+FbB6/vnnrUqVKi5INXDgQCtVqpQ/8KWC5wpSaQRRK/BpXyOD//jHP6xgwYIhfDUAAADQpnIbm9RtknX+vLMdO33MHQusMaVAlOSMzukCUtdUuiZZ1ydQBQBAeAh5UKpLly62e/due/rpp10hcmU3TZkyxV+oXKnlymDyNGvWzMaMGWNPPfWUPfHEEy7wNGHCBKtVq5b/HNVDUGDr7rvvtgMHDljz5s3dNXPkyOFu1zQ8BbOeffZZt6qeAlcKSgXWjAIAAEBoA1PbHtpmnyz/xN6e/7Zt3L/Rf9tFBS+y+xvfbz3q9ki14E9igSoFqVywikAVAACpKosvsdxuJEhTAvPnz++WP9ZyyamtzeD0LSyKjGPqwHahbgK/n0gQv5/IjL+fad0nyEjS6rVQd3Xf8X12+NRhyxuT1wrlLOSy40MhqYGqYLxAlResIlAFAMjsfYKQZ0oBAAAAiVEAqnCuwm4LtcCMqp71e6ZaRhWBKgBAZkRQCgAAALgABKoAAEgZglIAAABAOgeqFKRSsColgaoGpf5boyqhFQcBAMgoCEoBAAAAIQpUnYk9Y6t2ryJQBQDIlAhKAQAAACGSLWs2AlUAgEyLoBQAAACQwQJV2pbtWEagCgCQoRGUAgAAAMIcgSoAQCQiKAUAAABkQASqAAAZHUEpAAAAIEIQqAIAZCQEpQAAAIAIltqBqkoFK1nDUg0JVAEALhhBKQAAACCTuZBA1cb9G91GoAoAcKEISgEAAAAgUAUAmYTP57O9x/fakVNHLE9MHiucs7BlyZIlJG0hKAUAAAAgWYGq1btX26K/F6UoUKUAVcOSDQlUAUA6O3DigH287GN7Z8E77u9z4N/mvo36Wo96PdL9bzJBKQAAAADJClTVLl7bbSkNVH2+8nP/MQJVAJD2pm6Yap0/72zHTh8757Y/9v9hD0590J6c+aR9ecuX1qZyG0svBKUAAAAAXBACVQAQ3gGpdmPauWl7+i8+79jx08fdeZO6TUq3wBRBKQAAAADpGqhSgMoLVhGoAoC0nbKnDCkFpGItNtFzdXtWX1Z3/raHtqXL31iCUgAAAADSPVB1R707Ui1QpWLqKqpOoAoA4lINKU3ZC5YhlVBgSud/svwTu7/x/ZbWCEoBAAAACBkCVQCQ+k6eOWm7ju6y1+e9nuSAVKC357/tip+n9ap8BKUAAAAAZKhA1eK/F9ui7YsIVAHINI6eOmq7j+223Ud3B/8a79jhU4dT/FgKYunv6L7j+6xwrsKWlghKAQAAAMjUgSptClQVzFkw3Z8XgMxH9Z0OnjwYJ4i059ieRINMx88cT/d2KrBFUAoAAAAAgiBQBSAcxPpiXVZRUrOYFIA6HXs6TdpSMEdBK5q7qBXNVdTyZc9n32/4PsXXyhuT19IaQSkAAAAAEYNAFYALpb8ZLnMpiUGmvcf3usBUasuaJasVyVXEBZi8QJP3/TnHcxe1wjkLW3RUdJyMrCrvVLE/9v+RrLpSWSyLXVTwIiuUs5ClNYJSAAAAACyzB6q8Yurxp8gQqAIio+h3cuox7T+xP03aEZ01Ok4QqWhAkCnYV/1dUWAqpVSkXMXKH5z6YLLvq5X30rrIuRCUAgAAAJDpEKgCMiZl/xw9fTRZU+UupOh3YnJmy5msIJOm06VHoCdQj3o97MmZT9rx08ct1s6fzaUgmJ5X97rdLT0QlAIAAAAAAlVA2BT9TizIpK/xp96mFgWNEpouF+xr7pjcFu4K5ChgX97ypbUb086y+rImGpjKalnd1L2vunyVbiuUEpQCAACIUMOHD7fXXnvNduzYYXXr1rV33nnHGjVqFPTc0aNHW8+ePeMcy549u504kTYdfyCjIFAFZNyi36qJlNQAk4JR2bNlt0jUpnIbm9RtknX+vLMdO33MHQusMaVAlOSMzukCUtdUuibd2kZQCgAAIAKNGzfOHnroIRsxYoQ1btzYhgwZYm3atLG1a9dasWLFgt4nX7587nZPek8xADJroEoFhRuWakigCmHp9NnT/y36HSSYFC5Fv4N9LZyrsPu3iv8FprY9tM0+Wf6JvT3/bfd3KPBvkGpI9ajbw/LnyG/piZ8QAABABHrzzTetd+/e/uwnBacmTZpkH374ofXv3z/ofRSEKlGiRDq3FIgMFxKo0spY2ghUIT1o6luCWUxBspkOnDgQEUW/YW5KnoJPKn6ubDbV2sobk9dllIVqIIqgFAAAQIQ5deqULV682AYMGOA/ljVrVmvdurXNmzcvwfsdOXLEypcvb7GxsXbJJZfYiy++aDVr1kzw/JMnT7rNc+jQoVR8FkDGR6AK4Vb0W1+PnDqSJm3JFZ0rwWlx4VL0G/+l112ZZNpCjaAUAABAhNmzZ4+dPXvWihcvHue49tesWRP0PlWrVnVZVHXq1LGDBw/a66+/bs2aNbOVK1damTJlgt7npZdeskGDBqXJcwAyW6BqzZ41tujvRSkKVClA5QWrCFRlbOFW9DupWUz6qqAUkFwEpQAAAGBNmzZ1m0cBqerVq9vIkSNt8ODBQe+jTCzVrQrMlCpbtmy6tBeItEBVrWK13JbSQNX4VeNDHqhSQEX1hJSJkycmjxXOWTjTZ8KcjT3736LfSZwqpzpN+tmnBYp+IxwRlAIAAIgwRYoUsaioKNu5c2ec49pPas2o6Ohoq1+/vm3YsCHBc7Q6nzYAmTtQpZpDHy/72N5Z8E6c4slaaVC1a3rU65Fuy8untYSKficUZFJAKi2KfkdliXJTryj6jYyO30oAAIAIExMTYw0aNLAZM2ZYp06d3DHVidL+fffdl6RraPrfihUr7Lrrrkvj1gJIjUCVglQuWJXOgaqpG6bGWWY+/mM+OPVBe3Lmk/blLV+61b/CTbgU/Y6JigkeVEog0KQgH0W/EQkISgEAAEQgTavr0aOHNWzY0Bo1amRDhgyxo0eP+lfj6969u5UuXdrVhZLnnnvOmjRpYpUrV7YDBw7Ya6+9Zn/++afdddddIX4mAJIaqFJGUmoFqrxgVWKBKgWk2o1p56bt6b/4vGPHTx93503qNilNA1Nqh6YOetPgwrHod0JBJq2AltmnOiJzIigFAAAQgbp06WK7d++2p59+2nbs2GH16tWzKVOm+Iufb9myxa3I59m/f7/17t3bnVuwYEGXaTV37lyrUaNGCJ8FgHANVCmAogwpBYJiLfHpabo9qy+rO3/bQ9uSPJVP11ZmUnLqMVH0G8hYsvj0Lx3JpkKe+fPnd6vT5MuXL9Wv32bwpFS/JiLD1IHtQt0Efj+RIH4/kRl/P9O6T5CR8FoAGUtgoEpBKgWrggWqglERcxU1T44slsWev+p561StU0iLfqsdruh3kOLeFP0G0rdPQKYUAAAAAGRC58uoSixQldyAlDedT/WltKV20W8XUEriVDkFpCj6DYQH/iUCAAAAAJIcqJq3dZ4t2r4ozdpA0W8g8yAoBQAAAABIcqBq84HNVnFoxRRf78bqN1rFAhUp+g2AoBQAAAAAIOnyxOS5oPuPaj/KCucqnGrtAZBxkeMIAAAAAEgyFTmvVLCSKxieHDpf91NNJwAQglIAAAAAgCTT1Lq+jfqm6L73N76fqXkA/AhKAQAAAACSRbWlckXnsqxJ/EipQuQ6v3vd7mneNgAZB0EpAAAAAECyaMW7L2/50mU9nS8wpds1de+rLl+5+wGAh6AUAAAAACDZ2lRuY5O6TbKc0Tld0Cl+jSnvmG6ffNtku6bSNSFrK4DwRFAKAAAAAJDiwNS2h7bZkLZD7KKCF8W5Tfs6/tdDfxGQAhBUtuCHAQAAAAA4P03JUwFzFT/fd3yfHT512PLG5HWr7FHUHEDYZ0oNHz7cKlSoYDly5LDGjRvbggULEj1//PjxVq1aNXd+7dq1bfLkyXFu9/l89vTTT1vJkiUtZ86c1rp1a1u/fn2cc/bt22e33Xab5cuXzwoUKGC9evWyI0eOpMnzAwAAAIBIpwBU4VyFrUKBCu4rASkAYR+UGjdunD300EP2zDPP2JIlS6xu3brWpk0b27VrV9Dz586da127dnVBpKVLl1qnTp3c9vvvv/vPefXVV+3tt9+2ESNG2Pz58y137tzumidOnPCfo4DUypUrbfr06fbdd9/Z7Nmz7e67706X5wwAAAAAAJDZhTwo9eabb1rv3r2tZ8+eVqNGDRdIypUrl3344YdBzx86dKi1bdvWHn30UatevboNHjzYLrnkEhs2bJg/S2rIkCH21FNP2fXXX2916tSxTz75xP7++2+bMGGCO2f16tU2ZcoU++CDD1xmVvPmze2dd96xsWPHuvMAAAAAAAAQwUGpU6dO2eLFi930On+DsmZ1+/PmzQt6Hx0PPF+UBeWdv2nTJtuxY0ecc/Lnz++CT945+qopew0bNvSfo/P12MqsAgAAAAAAQAQXOt+zZ4+dPXvWihcvHue49tesWRP0Pgo4BTtfx73bvWOJnVOsWLE4t2fLls0KFSrkPye+kydPus1z8OBB9/XQoUOWFs6cOJYm10XGl1a/c8nB7ycSwu8nMuPvp3ddZWtndt5rEA5/CwAAQOgktX/E6ntJ9NJLL9mgQYPOOV62bNmQtAeZV/4XQ90CIGH8fiKcpfXv5+HDh112dmam10DoHwEAgKT0j0IalCpSpIhFRUXZzp074xzXfokSJYLeR8cTO9/7qmNafS/wnHr16vnPiV9I/cyZM25FvoQed8CAAa4guyc2NtadX7gwq0qkR4RVndutW7e61RKBcMLvJ8IZv5/pQyOA6nCVKlXKMju9Bvp9y5s3b6r3j/h9BjIG/q0CGcOhNP63mtT+UUiDUjExMdagQQObMWOGW0HPC/Zo/7777gt6n6ZNm7rbH3jgAf8xraCn41KxYkUXWNI5XhBKL7ZqRfXp08d/jQMHDrh6Vnp8mTlzpnts1Z4KJnv27G4LpLpUSD/6h8IbG8IVv58IZ/x+pr3MniHlUX3OMmXKpOlj8PsMZAz8WwUyhnxp+G81Kf2jkE/fU/ZRjx49XNHxRo0auZXzjh496lbjk+7du1vp0qXd9Dnp16+ftWjRwt544w1r166dWzFv0aJFNmrUKHe7RuUUsHr++eetSpUqLkg1cOBAF53zAl9atU8r+GnVP632d/r0aRcEu/XWWxnlBAAAAAAASAchD0p16dLFdu/ebU8//bQrMq7spilTpvgLlW/ZssWNunmaNWtmY8aMsaeeesqeeOIJF3iaMGGC1apVy3/OY4895gJbd999t8uIat68ubtmjhw5/Od89tlnLhDVqlUrd/3OnTvb22+/nc7PHgAAAAAAIHPK4mOpGIQ5rXqoTDnV9Yo/hRIINX4/Ec74/UQk4fcZyBj4twpkDCfD5N8qQSkAAAAAAACku//NiwMAAAAAAADSCUEpAAAAAAAApDuCUgAAAAAAAEh3BKUQtmbPnm0dOnSwUqVKWZYsWdwqi0A4UEHASy+91PLmzWvFihWzTp062dq1a0PdLCCol19+2f0NfeCBB0LdFCBF6A8AGQP9IyBjejnEfUWCUghbR48etbp169rw4cND3RQgjp9++snuvfde+/XXX2369Ol2+vRpu+aaa9zvLBBOFi5caCNHjrQ6deqEuilAitEfADIG+kdAxrMwDPqK2UL2yMB5XHvttW4Dws2UKVPi7I8ePdqNCC5evNiuuOKKkLULCHTkyBG77bbb7P3337fnn38+1M0BUoz+AJAx0D8CMpYjYdJXJFMKAC7QwYMH3ddChQqFuimAn0ar27VrZ61btw51UwAAmRD9IyC83RsmfUUypQDgAsTGxrr515dddpnVqlUr1M0BnLFjx9qSJUtcSjYAAOmN/hEQ3saGUV+RoBQAXOAIw++//26//PJLqJsCOFu3brV+/fq5eh45cuQIdXMAAJkQ/SMgfG0Ns74iQSkASKH77rvPvvvuO7cyVJkyZULdHMBR7Y5du3bZJZdc4j929uxZ93s6bNgwO3nypEVFRYW0jQCAyEX/CAhvi8Osr0hQCgCSyefzWd++fe3rr7+2WbNmWcWKFUPdJMCvVatWtmLFijjHevbsadWqVbPHH3+cgBQAIE3QPwIyhlZh1lckKIWwXg1gw4YN/v1NmzbZsmXLXLHEcuXKhbRtyNyUkj5mzBj75ptvLG/evLZjxw53PH/+/JYzZ85QNw+ZnH4n49fvyJ07txUuXJi6HsiQ6A8AGQP9IyBjyBtmfcUsPoW0gTCkEZYrr7zynOM9evRwS8wCoZIlS5agxz/66CO744470r09wPm0bNnS6tWrZ0OGDAl1U4Bkoz8AZAz0j4CMq2UI+4oEpQAAAAAAAJDusqb/QwIAAAAAACCzIygFAAAAAACAdEdQCgAAAAAAAOmOoBQAAAAAAADSHUEpAAAAAAAApDuCUgAAAAAAAEh3BKUAAAAAAACQ7ghKAQAAAAAAIN0RlAKQIY0ePdoKFCgQssffvHmzZcmSxZYtW2bhrmXLlvbAAw+EuhkAACAN0TdKOvpGQPggKAUgRe644w7X8Xj55ZfjHJ8wYYI7DgAAkJnQNwKA5CMoBSDFcuTIYa+88ort37/fMoJTp05ZZpJWzzezvY4AACQVfaPwRt8ICD8EpQCkWOvWra1EiRL20ksvJXrel19+aTVr1rTs2bNbhQoV7I033ohzu449//zz1r17d8uTJ4+VL1/evv32W9u9e7ddf/317lidOnVs0aJF51xbo49VqlRxncA2bdrY1q1b/bc9++yzVq9ePfvggw+sYsWK7hw5cOCA3XXXXVa0aFHLly+fXXXVVbZ8+fJEn8OCBQusfv367hoNGza0pUuXnnPO77//btdee61rb/Hixe3222+3PXv2BL2ez+dzj//FF1/4j6mtJUuW9O//8ssv7jU7duyY29+yZYv/9VC7b7nlFtu5c+d5n298kyZNsvz589tnn33m9vWa6VpK+S9UqJB7DKXgB478durUyV544QUrVaqUVa1a1R1/9913/a+9nu9NN92U6GsIAECko28UF30j+kbA+RCUApBiUVFR9uKLL9o777xj27ZtC3rO4sWL3Zv6rbfeaitWrHCdg4EDB7q6B4Heeustu+yyy1yHpl27dq7Too7YP/7xD1uyZIlVqlTJ7avD4lGHRJ2BTz75xObMmeM6VHqcQBs2bHAdv6+++spf4+Dmm2+2Xbt22ffff+/ad8kll1irVq1s3759QZ/DkSNHrH379lajRg13vp7DI488EuccPbY6cOqcqYM4ZcoU1ynScw9GafxXXHGFzZo1y+1rRHX16tV2/PhxW7NmjTv2008/2aWXXmq5cuWy2NhY1yFSG3V8+vTp9scff1iXLl3O+3wDjRkzxrp27eo6XbfddpudPn3adVjz5s1rP//8s3sd1bFr27ZtnFG/GTNm2Nq1a93jfvfdd+453n///fbcc8+543q+ej4AAGRm9I3+h74RfSMgSXwAkAI9evTwXX/99e77Jk2a+O688073/ddff62ekf+8bt26+a6++uo493300Ud9NWrU8O+XL1/e949//MO/v337dneNgQMH+o/NmzfPHdNt8tFHH7n9X3/91X/O6tWr3bH58+e7/WeeecYXHR3t27Vrl/+cn3/+2ZcvXz7fiRMn4rSpUqVKvpEjRwZ9rjpeuHBh3/Hjx/3H3nvvPfdYS5cudfuDBw/2XXPNNXHut3XrVnfO2rVrg1737bff9tWsWdN9P2HCBF/jxo3da6prS+vWrX1PPPGE+37atGm+qKgo35YtW/z3X7lypbv+ggULEny+0qJFC1+/fv18w4YN8+XPn983a9Ys/22ffvqpr2rVqr7Y2Fj/sZMnT/py5szpmzp1qv9nXbx4cXfc8+WXX7rX8dChQ0GfGwAAmQ19I/pG9I2A5CNTCsAFU+2Ejz/+2I1mxadjGuULpP3169fb2bNn/ceUgu5RurPUrl37nGMaxfNky5bNjZZ5qlWr5tKsA9uhdHelgnuUiq7RvcKFC7tRL2/btGmTbdy4Mejz0/XUvsCU76ZNm8Y5R9f98ccf41xT7ZGErtuiRQtbtWqVS8XXCJ9WgtGmEUKN0s2dO9fte20oW7as2zwanTzf8/UoFf7BBx90o3l63MB2awRRo4Feu5WmfuLEiTjt1s8iJibGv3/11Ve7x7rooovcyK1GF71UegAAMjv6RvSN6BsBSZMtiecBQIKUmqw05wEDBrg59ikRHR3t/95boSbYMaVqJ0fu3Lnj7KvTpdoEXmp4oAtZRlnX7dChg+uExhdYCyGQOjPq5KjTpU3p9qpDoWssXLjQdb6aNWt2Qc/Xo9R5pfp/+OGHru6D93qq3Q0aNPDXUAgU2IGLf1111HQ9vY7Tpk2zp59+2qXuq92hXI4aAIBwQN+IvhF9IyBpCEoBSBVa/liFJL1Cj57q1au7ufiBtH/xxRe7ugsX4syZM27+fqNGjdy+5u+rfoEeMyGqkbBjxw43kqgiokmh63366aduhMwbEfz111/Pua7qFeiaunZSqPNz+eWX2zfffGMrV6605s2buxoJJ0+etJEjR7oOktfhURtUdFObNyKokUQ9X40Kno/qTqiIqkYX9boPGzbM3+5x48ZZsWLFXIHQ5NDzVEFXbc8884zrcM2cOdNuvPHGZF0HAIBIRN+IvhF9I+D8mL4HIFVoZEvFId9+++04xx9++GFXCHLw4MG2bt06l8quN/34xTBTQqOFffv2tfnz57simxqJbNKkib8jFow6CUov14opGsXSSipKBX/yySeDrmAj3bp1c52k3r17u87O5MmT7fXXX49zzr333usKbapQpkbElN49depU69mzZ5xU/PjUEfrPf/7jOq1KD8+aNasbXdXoXGAqudrtvcYahdOKNypuqnPUQUsKdXaVRq8O4gMPPOCO6XpFihRxhUJVzFOp+hrhU6HOhAq0igp66metgqF//vmnK6iqkdr4HW8AADIr+kb0jegbAedHUApAqtFqI/FTyDXa9Pnnn9vYsWOtVq1aLpVZ56U0lT2QRs4ef/xx1zFSLQZ1XDSylRh1oNRxUudGnSJ1RrQqjToPXm2G+HTdiRMnuhVylOqtTlr8VHQtB6xRTnWyrrnmGtdJUudGI2TqTCVEHSfdx6uPIPo+/jG1W6OGBQsWdG1XR0w1C873fONTx0gjdursqVOs13D27NlWrlw5N4qnUcdevXq5kc/ERgf1vLSKjVbV0X1GjBjhrqnlrQEAwH/RN6JvRN8ISFwWVTs/zzkAAAAAAABAqiJTCgAAAAAAAOmOoBQAAAAAAADSHUEpAAAAAAAApDuCUgAAAAAAAEh3BKUAAAAAAACQ7ghKAQAAAAAAIN0RlAIAAAAAAEC6IygFAAAAAACAdEdQCgAAAAAAAOmOoBQAAAAAAADSHUEpAAAAAAAApDuCUgAAAAAAALD09v8A8v0w/hNRzEEAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAgttJREFUeJzt3Qd8VFX6//EnoYXee2/Si6AgoKJ0RIpiAQuoqKsLiL0tiIiKZVFQVMQC6oogKk2QIoqKSAcXkC4KSu+dAJn/63v+vzs7mRQyIcmkfN77upu5d+7cOTOJzJnnPOc5ET6fz2cAAAAAAABAGopMyycDAAAAAAAAhKAUAAAAAAAA0hxBKQAAAAAAAKQ5glIAAAAAAABIcwSlAAAAAAAAkOYISgEAAAAAACDNEZQCAAAAAABAmiMoBQAAAAAAgDRHUAoA0tiZM2fspZdesunTp4e7KQAAAAAQNgSlAGRJf/zxh0VERNi4cePS/LmffPJJe//99+2yyy5LtefQ69Lr0+tMSVdddZXbAABA+qHP/GeffTbczciUKlWqZNdee224mwFkWgSlgCzacUnKNn/+/HA3NdOZOnWq/ec//7FZs2ZZ8eLFLT367bffXMc2pQNaAACkZ6tXr7YbbrjBKlasaFFRUVa2bFlr27atvfnmm+FuWpa0ZMkS1x99/fXX49zXtWtXd9/YsWPj3HfllVe63x2AjCF7uBsAIO198sknsfY//vhjmzt3bpzjtWrVSuOWZX4K9HzzzTdWrVo1S68UlBoyZIjLiNLoYKA5c+aErV0AAKSWhQsX2tVXX20VKlSwe+65x0qVKmXbt2+3RYsW2ciRI61///7hbmKW06hRI8uTJ48tWLDAHnrooTi/r+zZs9vPP/9sd955p/94dHS0LV261Dp37hyGFgNIDoJSQBZ02223xdpXh0tBqeDjuDBnz561mJgYy5kzp//YgAEDLCMLfC0AAGQWL7zwghUsWNAFNAoVKhTrvj179oStXVmZgk5NmzZ1gadAGzZssH379tktt9ziAlaBli9fbqdOnbLLL7/8gp//xIkTLiiW2o4fP2558+ZN9ecB0ium7wGIl4IpI0aMsDp16rgU9pIlS9o//vEPO3jwYLzz7DXV75JLLrHcuXNbvXr1/FP/vvrqK7evazRu3NhWrlwZ6/F33HGH5cuXz37//Xdr3769+1AuU6aMPffcc+bz+WKdO2HCBHeN/PnzW4ECBdx1NXp5PocOHXLPo86mOpq9e/d2x+Kzfv16l7pfpEgR12a9pmnTpiW5RtW///1v975VrVrVcuXK5bKOknpdFUBXhlL16tXdOUWLFnWdKgUMA3333Xd2xRVXuPdKr0cp7OvWrUt2vQn9DvX+eLWobrzxRndbI8bBUznjqymlznqfPn3c34ja3aBBA/voo48SfH/GjBnjf38uvfRS9wUAAIBw2rJli+vzBAekpESJErH29XnWr18/+/TTT61GjRr+Ps6PP/4Y57F///233XXXXe4zUp97eo4PP/wwznmnT5+2wYMHu0xqnVe+fHl7/PHH3fHg85Q1pBIA6g916dLF/vrrrzjX0+d6cLazqB+g9if39QTavXu3Cxyp7xJMgSNdd9SoUSH1cYLpHD3P5s2b/ccUpFI/8N577/UHqALv8x7nefvtt937rvdVfcy+ffvG6Qeqb1O3bl0X1NL0PwWjnn766QTbpX6OXvtjjz3mP7Z48WLr0KGD62/q8S1btowTUPPef/UPFVQrXLiwv627du1yWV/lypVzbS1durTr41FOAZkdmVIA4qUAlAIU+nB84IEHbOvWra5joaCSPmBz5MjhP1cdBX2w6jHKtlLgQWnTo0ePdh/o//znP915w4YNs5tuusl1ICIj/xcTP3funPsQV+HvV155xdVbUsdMmUYKTok6LT179rTWrVvbyy+/7I4pEKO2JJZ9pMCWPtA1knbfffe5KYmTJ092galga9eutRYtWrg6BCpGrqDP559/bt26dbMvv/zSrrvuuvO+b6ptoBE6dZTUoVAQKqnXVUdF79Hdd99tTZo0sSNHjtiyZctsxYoVrqaFfPvtt9axY0erUqWKO//kyZOu1oWur/Pi64CGQh0x/b7feOMN97vzpnAmNJVTz6+OnP4G1KGtXLmyTZo0yXWG1eEL/t2MHz/ejh496v5W1CnT7/v66693QcnAvykAANKS6kj98ssvtmbNGhecOJ8ffvjBJk6c6D4z9XmvwIf6MqqD5D1ewRT1bbygjwJJmsKvgRx9xj/44IP+gUAFl9RXUf9Bn7mqb6VaShs3brQpU6b4n1d9BNWmVL+refPmbqCqU6dOF/z6k/J6ginQpsCL+jTqtwXStbJly+Yf6EpKHyc+XsBG741X+kB9P72vyqJS30FT+fT+efcpWKcBMu95FQxr06aN3X///a4P+s4777gBseD+7P79+10fq0ePHq4/q9cXHw2uqU+pftLzzz/vjun3oMcqmKf3Qv1c9QlbtWplP/30k3vNgfS+KED34osv+gdhu3fv7vqMmiqq/pwG/dT/3bZt2wX374B0zQcgy+vbt68+Df37P/30k9v/9NNPY503a9asOMcrVqzoji1cuNB/bPbs2e5Y7ty5fX/++af/+LvvvuuOf//99/5jvXv3dsf69+/vPxYTE+Pr1KmTL2fOnL69e/e6YwMGDPAVKFDAd/bs2ZBe25QpU9z1X3nlFf8xXeOKK65wx8eOHes/3rp1a1+9evV8p06ditWW5s2b+6pXr57o82zdutVdT23cs2dPrPuSet0GDRq4152Yhg0b+kqUKOHbv3+//9ivv/7qi4yM9PXq1ct/TK9L7VG7PNofPHhwnGvqd6jfg2fSpElxfk+eli1bus0zYsQId+5//vMf/7Ho6Ghfs2bNfPny5fMdOXIk1vtTtGhR34EDB/znTp061R2fPn16oq8bAIDUNGfOHF+2bNncps+wxx9/3PVn9JkWTJ9b2pYtW+Y/pv5OVFSU77rrrvMf69Onj6906dK+ffv2xXp8jx49fAULFvSdOHHC7X/yySfuc1z9r0CjR492z/Pzzz+7/VWrVrn9f/7zn7HOu+WWW+J8xutzXZ/vwXRO8FfApL6e+Hh9u9WrV8c6Xrt2bV+rVq1C6uPER/0I/U70Xnpq1KjhGzJkiLvdpEkT32OPPea/r3jx4r62bdu62+qPqS/Zrl0737lz5/znjBo1yrX5ww8/9B9T30bH9J4H0/votX3kyJG+iIgI39ChQ2P16dSfa9++vbvt0e+3cuXK/vYEvv89e/aM9RwHDx50x1999dWQ3yMgo2P6HoA4lOmi1GONXCkl2ts0+qOpdt9//32s82vXrm3NmjXz72vkSjQ6pIKhwceVFRNMI4geb0RRxSqVGSRKp9ec+/OleQebOXOmS6/W6JhHI3fBBUsPHDjgRrmUyaVMHu81a9RM0wo3bdrkUvDPR6NcgavqhXJdvUaNkOlYfHbu3GmrVq1yWUjKwPLUr1/f/a70WtOanlPFYJXF5tGoo0Zajx075kZeA918880uVd2jaYgJ/U0AAJBW9DmqTCll3Pz6668uk1ef08pyjm8av/o96hd51N9RZvbs2bNdBrhiPcqGVua4bgf2p3Tdw4cPuywhr9+l7KiaNWvGOk/9KPH6Xd7nvD5jA3kZVxfifK8nIcp2Vj9LmVEeZZtpepo+8z3n6+MkRFlP6ud4taP0vijbSVliokxxb4qcssr27t3rz65SH1J9Sb0/gRn6KmSv6X8zZsyI9VzKEAssmh5MfxPKAFfG/sCBA/3H1TfT61L2mvp33u9P/VZl+GsapLLhAinTKpDKX6hup8olBJfKADI7glIA4tAHqzpLqqGgAEvgpkBDcMHPwMCTKKAlqocQ3/HgD1t1FDQdLdBFF13kfnrz6DUFUMeUGq259qrPoGl+5/Pnn3+6OfkKpgVSzYRAmn6mTuOgQYPivGYvJT0phU41fS2519VURU150+tUvSzVKfjvf/8b67XE13ZRZ9brAKUltUnp54GdPa893v2J/a14ASo6YACAcFOdQ9XC1GeSpq099dRTbkBJNSG9GpEeffYF0+e3imMrMKJNn+ma6hX8+e8FPrzPf/W7FLAJPs/rC3nn6TNVn7eqyxgovn5BqM73ehJSrFgxF3jRFD6PAlQKVClg5TlfHycxCjJ5taM0VU+Di5q+JwpOqQ6Uam0F15NKqN+k4I/6ncF9FAUgE1rQRYNsTzzxhNsC60iJF2hTaYjg3+H777/v2qZ+dWL9RQXEFOzS9E5NG1Q5BQXBVGcKyOyoKQUgDo3mKCClgpfxCcwEEnUO4pPQ8eAC5kmh9mgkSiN2+sDWprn6vXr1ilNUOzm8EaxHH33UjWDGx6tlkBiNdCX3uuqAqNDq1KlTbc6cOa4jo3oSqs2lGgypJbER0JSWkn8TAACkBgUmFKDSpiCKgkjKZgqum5QY7/NftYniq2MpygDyzlWg5rXXXov3vOBBvqQILmaemp/5qsGk90j9tIYNG7oAlQJVClh5LqSPoyCT6mcq6KSglN4rb7BRQSkFfVQjStlUCoZ5AatQBffhAqlQuoJqn3zyiauLGRhU8n7Xr776qnv98QkeHI3vuZTRpcw61RBTf1cDmqrDpYz7iy++OFmvCcgICEoBiEMjcEp5Vkp0Yh/QKUUf5pq+5Y0IeinYEljYUZ1EfVhr02OUPfXuu++6D+2EAkYqXDpv3jyX4RXYIdCIWyAvU0tTz1QMM6WEel1Ny1PHTpvarE6cinSqw6bXEl/bvdX91PlLbElhZSUFrzajtHZNC0xKRzY+apNGOvX7CMyWUnu8+wEAyKi0Wq4Ef1bGNw1NfRetuuYN3mnqmYJA5/v8V79LUwYVyEnsM1ifqfq8VXAnMPsnvn5BfJ/5EpwdFMrrSYgWblGgxpvCp8cpyyyUPk5iAouda4ql+qceraan90UBK20K3qjNEthvCszIV99HC/iE0t9TH+uLL75wbdHvSW3Rc4uXuaYpgRfah9S1HnnkEbfpd6Ig1/Dhw11xeyCzYvoegDhU/0idqKFDh8a5TyvixdfJuVDeksFe1oz2FcjRB79ojn4gBUC8Ecbg5ZIDXXPNNa7NWmnFo9emEbfgTCytIqcgV3DHUxJLXU9MKNcNfo0KoinY5r0+TUNU50SZYYG/A9Vu0KijXuv5OjrByztrWkHwqKkX2ErK71nPqdTywFoSer/1/qr9WpUHAID0TnWb4sva9eo4BU8BU3DEqwkl27dvd1lA7dq1c1nB2lRnUnWl9Dmd2Oe/+l2qL/nee+/Fu8qtNzVfJQxEK+QGGjFiRLyf+ZoyFjhFTv0QrUAcn/O9nsSoXpSywZUhNWHCBDeIqEBVoPP1cRKj4I8ykzTIqBX7vHpSHu0ru0jBJy+AJQoQqS16vwJ/tx988IF7b0JdtVDlIzRoq9+JapB5r0m1uPR+a/VpBduS04fUNEmt3hxI11RgMynvEZCRkSkFIA4FEjTipZRhpWKrQ6IAkUZslL4+cuRIV18hpURFRbn6UEpvVzF0Tc1T8UktteuNzmkUTUXDVfRTnQKN9CnwoSCNV78oPsqq0ojak08+6epTqSi76kUEz+2Xt956y3VmlBauIpgaVdNyzuqo/fXXX24UMzmSel21TQEsdW40mqiOl0blAovAKzVcnVIVJNWS0uoY6X1QvS6NNiZG76EKa6qTrM6Unlfp4YHp9aL3VB1Q1TbQ+6Q6B3rfFWALpqWrFXBT8XXVdFBmm9qs0Up1ktWZAgAgvdMCKAoMXHfdda7guLJpNFVMgy76bAsugF23bl0XiFHRcX1Ovv322+74kCFD/Oe89NJLLtilvo0+//U5r76Mgj8Kbui23H777S6go89ona9+iwaMlHWs4/qsVsaWPp+1sIieS5/PCsYoUKP6lfFNqVP9I70etVGvTQN0ykoPDD6F8noSo6Lmmqqox+k6ClQFSkofJzHqR2nqnARmSoneh88++8x/nkd9SGVs6TV06NDBFbFX4Ept1NRMtTdUCqRpIFCvRa9TU+uUIaXpiOqfaZqf/lZUn0qBRv0+df/06dMTva6yyzQQqwCl3itNQ1QAUf1F/S6BTC3cy/8BCL++ffvGWR5YxowZ42vcuLEvd+7cvvz58/vq1avnlkjesWNHvMvkBtL1dN1AW7dujbPcrZYszps3r2/Lli1uyd48efL4SpYs6ZbMDVy+94svvnD3lyhRwi3vW6FCBd8//vEP386dO8/7+vbv3++7/fbbfQUKFHBLMOv2ypUrXVvGjh0b61y1o1evXr5SpUr5cuTI4Stbtqzv2muvdc+fmPheW6jXff75593SxoUKFXLvec2aNX0vvPBCnOWov/32W1+LFi3cOXpNnTt39v3222+xztHrUnvULo/ezyeeeMJXrFgx9z5r6eLNmze736F+D4Hee+89X5UqVdwyzLrO999/718yWVug3bt3++688053Xf1u9HcS/L4m9v4EL2MNAEBa++abb3x33XWX++zNly+f+zyrVq2ar3///u5zLr4+zn/+8x9f9erVfbly5fJdfPHF/s/KQHqszi1fvrz7/Fc/oHXr1q6PFUif9S+//LKvTp067nqFCxd2fbAhQ4b4Dh8+7D/v5MmTvgceeMBXtGhR139SH2D79u3xfpbOmTPHV7duXfdaatSo4dqrc4L7fKG8noQcOXLE9Ut0LV0nWFL7OAl599133bXVfwq2YsUKd5+24N+VjBo1yj2f3n/1Me+//37fwYMHY52jvo3e+/jE19ddvHix6xtfeeWVvhMnTrhj6ltef/317nej91CPu+mmm3zz5s3zP857//fu3Rvrevv27XO/A7VTv1f1V5s2ber7/PPPk/T+ABlZhP4v3IExAFmXMmw0UhZfujMAAEB6o7pPffv2jVV6ICPLbK8HQMZCTSkAAAAAAACkOYJSAAAAAAAASHMEpQAAAAAAAJDmqCkFAAAAAACANEemFAAAAAAAANIcQSkAAAAAAACkOYJSAAAAAAAASHPZ0/4pM4eYmBjbsWOH5c+f3yIiIsLdHAAAECYqz3n06FErU6aMRUZm7fE++kcAACCU/hFBqWRSh6t8+fLhbgYAAEgntm/fbuXKlbOsjP4RAAAIpX9EUCqZNALovcEFChQId3MAAECYHDlyxAVivL5BVkb/CAAAhNI/IiiVTF5KujpcdLoAAADT1egfAQCA0PpHWbvwAQAAAAAAAMKCoBQAAAAAAADSHEEpAAAAAAAApDlqSgEAACDNnDt3zs6cORPuZgApImfOnIkudQ4ASBxBKQAAAKQ6n89nu3btskOHDoW7KUCKUUCqcuXKLjgFAAgdQSkAAACkOi8gVaJECcuTJw+rFSLDi4mJsR07dtjOnTutQoUK/E0DQDIQlAIAAMjkXnrpJXvqqadswIABNmLEiATPmzRpkg0aNMj++OMPq169ur388st2zTXXpMiUPS8gVbRo0Qu+HpBeFC9e3AWmzp49azly5Ah3cwAgw2ECNAAAQCa2dOlSe/fdd61+/fqJnrdw4ULr2bOn9enTx1auXGndunVz25o1ay64DV4NKWVIAZmJN21PgVcAQOgISgEAAGRSx44ds1tvvdXee+89K1y4cKLnjhw50jp06GCPPfaY1apVy4YOHWqNGjWyUaNGpVh7mN50fqtWrbJXX33VZd4kRXR0tL344ou2bt06y+pCfe9SAn/TAHBhCEoBAABkUn379rVOnTpZmzZtznvuL7/8Eue89u3bu+NIGwcOHLDu3bu7oGD27P+rsnHVVVfZgw8+GO9jHnnkEVu9erXVrFkz1dr17LPPWsOGDS0tAjxTpkxJ8H5NK9U5Cj4l9b07n8SuCQCZ2enTp90iJOFGUAoAACATmjBhgq1YscKGDRuW5ELkJUuWjHVM+zqeWIf2yJEjsbbMSsG5bNmyuSBfatAXg169etkTTzxh1157bZIe8/nnn9vatWvto48+SrGMnfgCQ48++qjNmzfPUpsKhnfs2DFN3jsAyMp+//13e/vtt+3XX38Nd1ModA4AyFzaD50R7iYgnZo9KHWCCenR9u3bXVHzuXPnWlRUVKo9jwJeQ4YMsazggw8+sP79+7ufKmxdpkyZFL2+gkFff/11SI+56aab3HY+qnek60dGJm88Ol++fG5LbaVKlUqz9w4AsqIzZ87Yt99+a0uWLHH7+tmgQYOwTkUmUwoAACCTWb58ue3Zs8fVhNJUJm0//PCDvfHGG+52fEWZFRDYvXt3rGPaTyxQoBX9Dh8+7N8UDMustbkmTpxo999/v8uUGjduXJxzpk+fbpdeeqkLAhYrVsyuu+66WBllyuIpX7685cqVy6pVq+aCWx4Vk1eGkAI/yk67/fbbbd++fQm2R9dT9lLZsmUtb9681rRpU5s/f77/frWvUKFCNm3aNKtdu7Z7zm3btrmi923btnXtK1iwoLVs2dJl03kqVarkfqrt+oLi7QdP34uJibHnnnvOypUr566t+2bNmhVnStxXX31lV199tStwry8955sKGpylpS9LF198sXtPL7nkEleAP9j53ju16/LLL3fvh1Z+VCbVli1bEm1HqL8PAMgoJk2a5A9I6d/VO+64I+y18QhKAQAAZDKtW7d2dYZUJ8fb1PlU0XPd1jS0YM2aNYszRUuZVjqeEAUkChQoEGsLlQp1J7QFF6xO7Fxvhb/znZscmianmk01atSw2267zT788MNYdThmzJjhAjnXXHONC5zofWzSpIn/fk0t++yzz1xQUAXJtRqil3l06NAha9WqlQu+LFu2zAVRFAxMLAOqX79+LsCjKZr//e9/7cYbb3RF6jdt2uQ/58SJE/byyy/b+++/76b4lShRwo4ePWq9e/e2BQsW2KJFi6x69equzTouClrJ2LFj3VQ6bz++ovjDhw+3f//73+75VXusS5cusZ5f/vWvf7ngmf7mLrroIre6Y1KLkCsQqACSgmoKsiowpmsFSsp7d/z4cXv44Yfd/fq9KFtMvysF1uKTnN8HAGQUl19+ufusVn9AgyzeCqLhxPQ9AACATCZ//vxWt27dWMeUUaNMEe+4AiXKtPFqTmm6nzJnFGxQR1UBD30pHzNmTKq2NbGaVwqa3HLLLf59BUGCg0+eihUruhHfwMCJAjPBBg8eHHIbldWkYJQo+KOsMGWeqQC5vPDCC9ajR49YUxmVGSQbN250QS0F+LxC8lWqVPGfp9UNFQDRCnoeBb2UVaXHKpgTSBlPChrppzeFUMEaBU903LuO3ifVC/HaIQq2BNLvVhlEei0KABUvXtwd17HEMuT0e1Dml16zKPj1/fff24gRI+ytt97yn6d2eTW49N7UqVPHNm/enKSi7OPHj3eBI733ypTSY//66y+XrRbKe6fi54F0v17nb7/9Fue/kaReEwAyin379rnMaQX4pUKFCm4qeigLQqQ2MqUAAACyIAU1lA3jad68uQsEKFChQMYXX3zhplLF98U9K9mwYYOb6qAsH1FH/uabb441/U6ZQMpOi4+XmaaAX3xUZFYBHa9ukzYvaBPfNDNlwGn6pYIjgY9RYCnwfI1+169fP9ZjlfFzzz33uGCfpu9ptFwZSfpbSCoVs1dNrRYtWsQ6rn1lgQUKfP7SpUu7n/pylBS6lh4fWBMtOGsvKe+dsrf0u1MgUK/Xm5KY0GsO9fcBAOmRz+dzn13KzJ08eXKsKcjpKSAl6as1AAAASBWBNYfi2xdNA9OWllSXKiHBhbmDp28FCq6JocyvlKDgk6acBRY2V2dfUxeVVaPgTu7cuRN8fGL3iYJCnTt3dtlGwbxATvD5CnJpSlvwNMzAYuR63uD3RFP39u/f77LIlFmm16BAT3KnNZ5Pjhw5/Le9tiQ0bS45kvLe6X691vfee8/9DvX8CrQm9JpD/X0AQHpz5MgRmzp1qlthTxSUTw/T9NJ1ppTSfDVqoZEQFWr0Cm8lVpxLIxY6v169ejZz5sxY92vOue5XmnrhwoVdqvTixYtjnXPgwAE3j1IjJkpR7tOnj/sQAgAAQNpRRzmhLXg0N7FzAwMgiZ0bCgWjPv74YzelMbA+l7JpFOBQnShRRk9wPS6P+qoKhCiTKT4qRq+aT+oLqwB64Ka+bDBNLVOmlDKOgs8/3+p1P//8sz3wwAOujpSmwykoFVzAW+9jfIXwPeo767XrWsHX9qaHpIRatWq5elWnTp3yH1MdrFDeOwXglOk2cOBAl8mmax48eDDR5w319wEA6YXP53P/bmrqtgJS+gzVog2afp6cmo9ZJiillUxUfFDz+7X6h9LFVSwxodTehQsXuhRcBZFUSLJbt25u0yoZHqUza+RK6c0q5KgPlXbt2tnevXv95yggpQ8cze/XErI//vij3XvvvWnymgEAAJD+qY+oIIb6ncquCdxUq8ibwqd+rAJU+qlpZ+qDepk26ocqQ+muu+5y0yG3bt3qstRUZ0r69u3rBkvVv1VhcU0Rmz17tt15553xBofUz1U/VjXBtLqdrqcBXdXmUsH1xGja3ieffOLaqAFbXSc4k0vtVYBt165dCQZwHnvsMff61I9X0OfJJ590wbqUyk4T1RJTdpWmG6r+kwahVcsq0PneOw1Oq46apqSqltV3333nvnckJtTfBwCkl4DU5MmT3aYVWlUz8h//+IdbdCPcq+ul+6DUa6+95j5s9A+9RldGjx7tlo1VQcH4KN1YBSb1YajRjqFDh7oRDQWhAj/ElB2lNDWNAuk5lMKmqKHog1jFILUaiTKzVIH+zTffdAU9NUceAAAAUNBJfUpN0QumoJQKwat/qYLnyuSfNm2aNWzY0BUUD8z8f+edd+yGG26wf/7zny6bX31frQonXtaRAh4aRFVm1YMPPugy+YOnL3pU0FxBqUceecStCKgBWgVQVMD2fK9HgSb1nW+//XaXNaVV+QIpK0yDtirsrays+OhxCu7o+dVe9av12hX0Simaijh9+nQX4FM7tJJf8JS687132tS/11RHBRIfeughe/XVVxN93uT8PgAg3CIiIlwQXv9O6TNJAyHFihWzjCDCF7iebRrTXG4FoFRIUx+mHo0maTlWzYMMpg9bfQjqw8GjUSmNPCmVOr7n0PK7zz//vBsh0S9GAS99iAaO/ig9W9MB1aHQMrHnoyCXOihafSU9p8IBQFbTfmjimQLIumYP+v+rgKU0+gTnfy80BUsZPZUrV45VuBrI6PjbBhAu0dHRbpVZBc1FwXRNyS5ZsqSlB0ntH4W10LneML1xwW+a9tevXx/vY5RKHN/5Oh6cbq1lavVLUlFCjfh4kUKdGzwqpPmWRYoUiXMdj1LgtAW+wQAAAAAAAGlp+/btbqqeaiXefffdLp6hxS/SS0AqFJk2B/Xqq692c9tVg0rT/W666aYkL0EbH83TV5TP25TSDAAAAAAAkBbOnTvn6v5pGrdmfp08edLNMsvIwhqUUuaSonm7d++OdVz7Ca0eouNJOV+rY2iVjMsuu8zNn1fk0CtGqXODA1Savqeihgk9r5YrVtqZtykyCQAAAAAAkNr27Nnj6mJrMTdVYdLKr/fff3+GqR2VLoNSSjVr3LhxrCV0tWSu9ps1axbvY3Q8eMldTc1L6PzA63rT73SuookqeujRahw6R4XP46MlczUPMnADAAAAAABILT6fz80A00qiKjekVVNvvPFGVws7M9SyC2tNKVHRchU2v+SSS9xyhSNGjHCrkWg1PtHKIlrOUNPnREvNtmzZ0q0M0qlTJ7eihlY+0S9I9NgXXnjBunTp4mpJqW7VW2+9ZX///bf7xYlW7dOUPq18otX+zpw5Y/369XM1qLTiBgAAAAAAQLgpKLVhwwY3dU+rnHbu3Nny589vmUXYg1I333yz7d2715555hkX9dMyulpW1ivQtW3btljLrzZv3tzGjx9vAwcOtKefftr9UrTynpZ5FU0HVJH0jz76yAWktCzipZdeaj/99JPVqVPHf51PP/3UBaJat27trq9lfbVKHwAAAFJHGBd9BlIFf9MAUuvfFp/P52IV2rp162a///67NWrUyCIiIiwzifDxL2mysPwzAKRP7YfOCHcTkE7NHtQpVa5Ln+D874VGdzdu3OhWP9aAIZBZ6G99x44drpZtjhw5wt0cAJnA8ePH7euvv3afox07drSMKqn9o7BnSgEAACBzUyZ7oUKF/AvN5MmTJ9ON9CLrUT1azfjQ37MWVQKAC7VhwwabPn26C0zps7NFixaZfsCLfz0BAACQ6rwVjoNXQAYyMk2rqVChAkFWABfk9OnTrozRqlWr3L4yi1XIPLMHpISgFAAAAFKdvrRrERp1tLXIDJAZaDXxwPq3ABCqP//809XJPnTokL+O9tVXX51lMjCzxqsEAABAuqDpCNoAAMjqoqOjbeLEiXby5Ek3zV0FzStWrGhZCUEpAAAAAACAMGRbduzY0bZu3Wrt27e3XLlyWVZDUAoAAAAAACANFkj4+eefrWTJknbRRRe5Y/Xq1XNbVkVQCgAAAAAAIBUdOHDA1Y7avn275c2b1/r162dRUVGW1RGUAgAAAAAASAU+n8+WL19uc+bMcQt9aIpe27Zts+RUvfgQlAIAAAAAAEhhR48etenTp9umTZvcfqVKlaxr166uqDn+P4JSAAAAAAAAKejYsWP2zjvvuJX1tOps69at7bLLLrOIiIhwNy1dISgFAAAAAACQgvLly+eKme/evduuu+46K1GiRLiblC4RlAIAAAAAALhAv//+uxUvXtzy58/v9q+55hqXJaUN8YtM4DgAAAAAAADOQwXMZ86caZ988omrIaXi5pIzZ04CUudBphQAAAAAAEAy/P333zZ58mTbv3+/2y9YsKDFxMQQjEoiglIAAAAAAAAhOHfunP3000/2448/uswoTdnr0qWLVatWLdxNy1AISgEAAAAAACTR4cOH7fPPP7cdO3a4/bp167r6Ublz5w530zIcglIAAAAAAABJpODTyZMnLSoqyjp16uSCUkgeglIAAAAAAACJOHr0qOXLl88iIiJcAfObbrrJ8uTJYwUKFAh30zI0Vt8DAAAAAACIh+pF/fe//7W33nrLlixZ4j9eqlQpAlIpgKAUAABAJvPOO+9Y/fr1XWdZW7Nmzeybb75J8Pxx48a5kd/ATVMSAADIyk6cOGFffPGFW13v9OnTtn79ehekQsph+h4AAEAmU65cOXvppZesevXqrvP80UcfWdeuXW3lypVWp06deB+j4NWGDRv8+wpMAQCQVW3atMmmTZtmx44ds8jISGvZsqVdfvnlfD6mMIJSAAAAmUznzp1j7b/wwgsue2rRokUJBqXUydZUBAAAsrLo6GibPXu2rVixwu0XK1bMrrvuOitTpky4m5YpEZQCAADIxM6dO2eTJk2y48ePu2l8CdFIcMWKFS0mJsYaNWpkL774YoIBLI+mMmjzHDlyJEXbDgBAWtu/f7+tWrXK3b7sssusVatWliNHjnA3K9MiKAUAAJAJrV692gWhTp065VYLUj2M2rVrx3tujRo17MMPP3R1qA4fPmz//ve/rXnz5rZ27Vo3FTAhw4YNsyFDhqTiqwAAIPVpqrs3La906dLWoUMHlyFVuXLlcDct04vwUaUrWTQSWLBgQddxo+I+AKQf7YfOCHcTkE7NHtQpS/UJNP1g27Ztrl0q0vr+++/bDz/8kGBgKtCZM2esVq1a1rNnTxs6dGhImVLly5dPd+8FAAAJ2b17t02fPt2uvfZaprGHoX9EphQAAEAmlDNnTqtWrZq73bhxY1u6dKmNHDnS3n333fM+VtMULr74Ytu8eXOi5+XKlcttAABkNJqurlqL3333nZvqPmfOHOvVq1e4m5XlEJQCAADIIp3vwKymxKhzrul/11xzTaq3CwCAtHbw4EGbOnWq/fnnn27/oosuirNICNIGQSkAAIBM5qmnnrKOHTtahQoV7OjRozZ+/HibP3++W01INBJctmxZVxNKnnvuOVfMVZlVhw4dsldffdV11O++++4wvxIAAFKOqhepiPmsWbPcNHdlFbdv395lB3s1pZC2CEoBAABkMnv27HGBp507d7p6DipgroBU27Zt3f2qNRUZGRlrxPiee+6xXbt2WeHChd10v4ULFyap/hQAABnFunXrbNq0ae62Bm66devmPvcQPgSlAAAAMpkPPvgg0fuVNRXo9ddfdxsAAJlZzZo1rUqVKm7TCrWBAzQID4JSAAAAAAAg0zl16pQtWLDAWrZs6RbxUBDqtttuY6peOkJQCgAAAAAAZCp//PGHTZkyxQ4fPmxnzpxxtRaFgFT6QlAKAAAAAABkCmfPnrV58+bZokWL3H6hQoWsTp064W4WEkBQCgAAAAAAZHha4GPy5Mm2d+9et9+oUSNr166d5cqVK9xNQwIISgEAAAAAgAxtzZo1LiAVExNjefPmtS5duthFF10U7mbhPAhKAQAAAACADK1ChQqWM2dOq1y5snXq1MkFppD+pYv1D9966y2rVKmSRUVFWdOmTW3JkiWJnj9p0iS3lKPOr1evns2cOdN/nwqYPfHEE+64/gjLlCljvXr1sh07dsS6hp5PBc4Ct5deeinVXiMAAAAAAEgZPp/PFTP3FChQwP7xj3/YjTfeSEAqAwl7UGrixIn28MMP2+DBg23FihXWoEEDa9++ve3Zsyfe8xcuXGg9e/a0Pn362MqVK61bt25uU6qenDhxwl1n0KBB7udXX31lGzZscKl7wZ577jk359Tb+vfvn+qvFwAAAAAAJN/Ro0dt/Pjx9tFHH7nv+x4VNWd1vYwl7NP3XnvtNbvnnnvszjvvdPujR4+2GTNm2IcffmhPPvlknPNHjhxpHTp0sMcee8ztDx061ObOnWujRo1yjy1YsKDbD6T7mjRpYtu2bXMpfZ78+fNbqVKlUv01AgAAAACAC7d27VoXMzh58qRly5bNjh8/Hu4mIaNmSkVHR9vy5cutTZs2/2tQZKTb/+WXX+J9jI4Hni/KrErofDl8+LCLlipqGkjT9YoWLWoXX3yxvfrqq27pyIScPn3ajhw5EmsDAAAAAACpT0GoL7/80r744gt3u3Tp0m66nlbYQ8YV1kypffv22blz56xkyZKxjmt//fr18T5m165d8Z6v4/E5deqUqzGlKX+aY+p54IEH3B9vkSJF3JTAp556yk3hU+ZWfIYNG2ZDhgxJxqsEAAAAAADJtXXrVreynqbtKeHkiiuusCuvvNJlSiFjC/v0vdSkouc33XSTK4D2zjvvxLpPdaw89evXd1X6FWVV8ClXrlxxrqWgVeBjlClVvnz5VH4FAAAAAABkbZq5pICUZjqppnS5cuXC3SRkhqBUsWLFXGRz9+7dsY5rP6FaTzqelPO9gNSff/5p3333Xawsqfho1T9N31P1/ho1asS5X4Gq+IJVAAAAAAAg5QNR3nfwmjVr2nXXXWe1atWyHDlyhLtpyCw1pZSd1LhxY5s3b57/WExMjNtv1qxZvI/R8cDzRYXNA8/3AlKbNm2yb7/91kVTz2fVqlWunlWJEiUu6DUBAAAAAIDkUYmf77//3t58802XHRU4w4mAVOYT9ul7mhLXu3dvu+SSS9wKeSNGjHDV873V+Hr16mVly5Z10+pkwIAB1rJlSxs+fLh16tTJJkyYYMuWLbMxY8b4A1I33HCDrVixwr7++mv3B+3Vm1L9KAXCVBR98eLFdvXVV7sV+LT/0EMP2W233WaFCxcO47sBAAAAAEDWtHfvXlc7SvWeZfXq1da8efNwNwuZOSh18803uz+8Z555xgWPGjZsaLNmzfIXM9+2bZvLYPLoD3L8+PE2cOBAe/rpp6169eo2ZcoUq1u3rrv/77//tmnTprnbulYgRVuvuuoqlwKoYNazzz7rUgIrV67sglKBNaMAAAAAAEDqUx1oJY5oVpTK6kRFRbkkFO97PjKvCJ9++wiZCp0XLFjQDh8+fN56VQCAtNN+6IxwNwHp1OxBnVLluvQJ/of3AgAQKn1mTJ061a2wJ1WrVrUuXbrwOZJF+gRhz5QCAAAAAABZ06JFi1xASvWi2rZt60r7REREhLtZSCMEpQAAAAAAQFio1vOxY8dcqZ2kLFKGzCWsq+8BAAAAAICsY+PGjfbll1+6OlKixci6d+9OQCqLIlMKAAAAAACkqujoaJs9e7atWLHC7WvBsUaNGoW7WQgzglIAAAAAACDVbNu2zaZMmWIHDx50+5dddpnVq1cv3M1COkBQCgAAAAAApLizZ8/a/PnzbeHChW66nlZj69q1q8uSAoSgFAAAAAAASHFTp061NWvWuNsNGjSwDh06WFRUVLibhXSEoBQAAAAAAEhxzZs3tz///NM6duxotWrVCndzkA4RlAIQsvZDZ4S7CUinZg/qFO4mAAAAIExUM+qvv/7y14sqXbq0PfDAA5Y9O6EHxI+/DAAAAAAAkGyqF7Vy5Uq3up7qSBUvXtxKlSrl7iMghcTw1wEAAAAAAJLl2LFjNn36dNu4caPbr1ChguXKlSvczUIGQVAKAAAAAACEbN26dfb111/biRMnLFu2bHb11Vdbs2bNLDIyMtxNQwbBXwoAAEAm884771j9+vWtQIECbtMXhG+++SbRx0yaNMlq1qzpVkVSLZCZM2emWXsBABmPglGff/65C0iVLFnS7rnnHmvRogUBKYSEvxYAAIBMply5cvbSSy/Z8uXLbdmyZdaqVSvr2rWrrV27Nt7zFy5caD179rQ+ffq4miDdunVzm7eMNwAAwYoUKWIREREuEHX33Xe7wBQQKqbvAQAAZDKdO3eOtf/CCy+47KlFixZZnTp14pw/cuRI69Chgz322GNuf+jQoTZ37lwbNWqUjR49Os3aDQBIv1TA/MiRIy4YJcrCrVy5slthD0guMqUAAAAysXPnztmECRPs+PHj7gtEfH755Rdr06ZNrGPt27d3xwEA2Llzp40ZM8bGjx9vZ86ccceUJUVACheKTCkAAIBMaPXq1S4IderUKcuXL59NnjzZateuHe+5u3btijPtQvs6npjTp0+7zaMRdABA5hETE2MLFiywH374wd3Omzev7d+/30qVKhXupiGTICgFAACQCdWoUcNWrVplhw8fti+++MJ69+7tvlQkFJhKjmHDhtmQIUNS7HoAgPRDwacpU6bYX3/95fZr1apl1157reXJkyfcTUMmQlAKAAAgE8qZM6dVq1bN3W7cuLEtXbrU1Y56991345yrEe/du3fHOqb9842EP/XUU/bwww/HypQqX758ir0GAEDa8/l8bpEM1RbUVL1cuXLZNddc41Zm1ZQ9ICVRUwoAACAL0LSLwKl2gTTNb968ebGO6ctIQjWoPPqiUqBAgVgbACDj27BhgwtIqZD5/fffb/Xr1ycghVRBphQAAEAmowymjh07WoUKFezo0aOuMO38+fNt9uzZ7v5evXpZ2bJl3fQ7GTBggLVs2dKGDx9unTp1coXRNUquorYAgKwzeBEZGemCT126dLH169fbpZdeSjAKqYqgFAAAQCazZ88eF3jSakkFCxZ0I9wKSLVt29bdv23bNvfFw9O8eXMXuBo4cKA9/fTTVr16dVdHpG7dumF8FQCAtHDy5EmbOXOm5ciRwwWjRJmvTZo0CXfTkAUQlAIAAMhkPvjgg0TvV9ZUsBtvvNFtAICsY8uWLTZ16lSXVauMqBYtWljRokXD3SxkIQSlAAAAAADIQqKjo+3bb791i2CIAlHXXXcdASmkOYJSAAAAAABkEX/99ZdNnjzZDhw44PZVN0rTuzV9D0hrBKUAAAAAAMgCzp49axMnTrRjx45Z/vz5rWvXrla1atVwNwtZGEEpAAAAAACygOzZs7tVVteuXWvXXHON5c6dO9xNQhZHUAoAAAAAgEzI5/PZ4sWL3Wp6tWvXdsdq1qzpNiA9ICgFAAAAAEAmc/jwYbey3tatWy0qKsoqVqxoefPmDXezgFgISgEAAAAAkImyo/773//aN998Y6dPn3YFzFu1amV58uQJd9OAOAhKAQAAAACQCZw4ccK+/vprW7dundsvV66cdevWzYoWLRrupgHxIigFAAAAAEAGd/LkSXvnnXfcynqRkZHWsmVLu/zyy91tIL0iKAUAAAAAQAanlfRUwPzPP/+06667zkqXLh3uJgHnRVAKAAAgnYiJibHNmzfbnj173O1AV155ZdjaBQBIn7Zt2+ZW1itUqJDbb9eunUVERFj27HzVR8bAXyoAAEA6sGjRIrvlllvcCLeK1AbSF4xz586FrW0AgPTl7NmzNn/+fPv555+tUqVK1qtXL/dZoaLmQEaSLiaXvvXWW+4/JC1T2bRpU1uyZEmi50+aNMmlJer8evXq2cyZM/33nTlzxp544gl3XMtdlilTxv0HumPHjljXOHDggN16663+qHKfPn3c3FsAAIBwuO++++ySSy6xNWvWuH7KwYMH/Zv2AQCQ3bt32/vvv+8CUqLvswpSARlR2INSEydOtIcfftgGDx5sK1assAYNGlj79u1d2np8Fi5caD179nRBpJUrV7qVBLSpA+etNqDrDBo0yP386quvbMOGDdalS5dY11FAau3atTZ37ly3OsGPP/5o9957b5q8ZgAAgGCbNm2yF1980WrVquW+YBQsWDDWBgDI2jStW4Go9957zwWm8uTJYzfddJN17dqVDClkWBG+4PzwNKbMqEsvvdRGjRrl/w+tfPny1r9/f3vyySfjnH/zzTfb8ePHXSDJc9lll1nDhg1t9OjR8T7H0qVLrUmTJi4dvkKFCm55zNq1a7vjGpGUWbNm2TXXXGN//fWXy646nyNHjrgO4uHDh122FZCVtB86I9xNQDo1e1CncDeBv0+k+d9nSvUJWrVqZY8//rh16NDBMir6RwCQOjSrRzOGVENKLrroIuvcubPly5cv3E0DLqhPENaaUtHR0bZ8+XJ76qmn/Me0XGWbNm3sl19+ifcxOq7MqkDKrJoyZUqCz6M3QfNrveJvuoZuewEp0XPquRcvXuxWKgAAAEhLGpB75JFHbNeuXa4MQfCod/369cPWNgBAeKl0zcmTJy1nzpxu8EJJGfqOC2R0YQ1K7du3zxXtLFmyZKzj2l+/fn28j1FHLb7zdTw+p06dcjWmNOXPi87p3BIlSsQ6T6sTFClSJMHrnD592m2BUT8AAICU0r17d/fzrrvu8h/TFw4ltVPoHACyHs0Qyp07t0ue0PfVG264wQ1YFC5cONxNA1JMpl59T0XPNcdWnbl33nnngq41bNgwGzJkSIq1DQAAINDWrVvD3QQAQDqhkjMqWaNSNVdccYU7FpxYAWQGYQ1KFStWzLJly+aKtAXSfqlSpeJ9jI4n5XwvIKU6Ut99912sOYw6N7iQulYr0Mo2CT2vphgGThtUppRqXwEAAKSEihUrhrsJAIAw00wf1Tv+9ddf3b5mELVo0cJlSwGZUbL+slVc7aeffrLZs2e7Fe4Cp7WFQvNhGzdubPPmzfMfU6Fz7Tdr1izex+h44PmiFfQCz/cCUlrF5ttvv7WiRYvGucahQ4dcPSuPAld6bhVej0+uXLlcYCtwAwAASElbtmxxtaVU61LbAw884I4BALJGxqwW71JAStO2FYy68847CUghU0typtQff/zhpsBNmDDBrVAXuGifgktKKbz33ntdPYRQ/qNR9lHv3r1d0XGtkDdixAg3d1b/8UmvXr2sbNmybvqcDBgwwFq2bGnDhw+3Tp06ufYsW7bMxowZ4w9Iaa6tgmVKd1T9Ba9OlGpGqa1aalnF4e655x73H70e069fP+vRo0eSVt4DAABIaRrs69Kliyteqy8ioqW/69SpY9OnT7e2bduGu4kAgFSg76NKkli0aJHbV82obt26uZXjgcwuSUEpjdJ99NFHbpW7559/3gWPFLxR0TVNeVuzZo3LnHrmmWdc3aWxY8fapZdemqQG3HzzzbZ37173WAWP1BFTuqJXzFxZWYFBrubNm9v48eNt4MCB9vTTT1v16tXdynt169Z19//99982bdo0d1vXCvT999/bVVdd5W5/+umnLhDVunVrd30F0954442kvm8AAAAp6sknn7SHHnrIXnrppTjHtWgLQSkAyJy0WvzSpUvd7UaNGrnv3UqmALKCCF9gylMCVE/p0UcfjTMNLj4KKJ04ccKuv/56y8xUU6pgwYLuHxCm8iGraT90RribgHRq9qBO4W4Cf59I87/PlOoTaLnv1atXuwG3QBs3brT69eu7OiPpHf0jAEgab2VVj2b65MuXzy666KKwtgtI6z5BkjKlvKlzSaFpcQAAAAhN8eLFbdWqVXGCUjrGiksAkHns37/fpk6dau3atbNy5cr5M6SArCjk1fdOnjzporp58uRx+1rdbvLkya5Ok9IMAQAAEDrVulR9zt9//92VK/BqSr388suxVgAGAGRM+h6teshz5sxxq79rllGfPn1iZUwBWU3IQamuXbu6qXn33XefW8FOq9XlyJHD9u3bZ6+99prdf//9qdNSAACATGzQoEGWP39+t5iLSieIang+++yzrr4nACBjT2VS7WNvRdXKlSu779YEpJDVhby2pOa6aqU9+eKLL1xBcmVLffzxxxQKBwAASCZ9MVGhc61yrPoL2nRbKw/zpQUAMi4tDKaV7BWQyp49uyt5c/vtt7t6O0BWF3KmlIqYaxRPlHaorCmtXnfZZZe54BQAAAAujNfXAgBkbApEffnll+526dKl7brrrnM1BAEkMyhVrVo1mzJlivuPafbs2W5ET/bs2cMqKwAAACFQYdt58+ZZ4cKF7eKLL040I0rZ6gCAjKVKlSpuRb1SpUrZlVdeadmyZQt3k4CMHZR65pln7JZbbnHBqNatW1uzZs38WVPqTAEAACBpVE8kV65c/ttM0wOAjC06OtoWLFhgLVq0cP++69/1Hj168O87kFJBqRtuuMEuv/xy27lzpzVo0MB/XAEqZU8hZbQfOiPcTUA6NXtQp3A3AQCQQgYPHuy/rYLmKWXYsGH21Vdf2fr16y137txuNT+t4lejRo0EHzNu3Di78847Yx3TF6pTp06lWLsAIDNTHUCtTH/gwAE7evSoG2wQAlJAChY6F6UeKitKtaQ8TZo0sZo1aybncgAAAFmepnjs378/znGtdqz7QvHDDz9Y3759bdGiRTZ37lw7c+aMtWvXzo4fP57o41SKQQOP3ka9UAA4v3Pnztl3331nH374oQtIqS5g3bp1w90sIPNkSt133302cOBAK1eu3HnPnThxop09e9ZuvfXWlGgfAABAlvDHH3+4LzbBTp8+7UbfQzFr1qw4WVAlSpSw5cuXu5omCdFovgYfAQBJs3fvXpcdpUC+1KtXzzp27OiyVAGkUFBKqwPUqVPHzYvt3LmzXXLJJVamTBmLioqygwcP2m+//ebmzU6YMMEdHzNmTFIuCwAAkOVNmzbNf1uLyAQuEa4glQqhV65c+YKe4/Dhw+5nkSJFEj3v2LFjVrFiRYuJiXFF2F988UXXB0yIAmbaPEeOHLmgdgJARrJx40b7/PPP3b/VCkJ16tQp0X8zASQzKDV06FDr16+fvf/++/b222+7IFQgpSe2adPGBaM6dOiQlEsCAADAzLp16+bPUurdu3es+3LkyGGVKlWy4cOHJ/v6CjA9+OCDbnAxsekkqjelqSf169d3Qax///vfrhbV2rVrE8yWV+2qIUOGJLttAJCRlS1b1iVqlC5d2rp06eK+FwNIpULnJUuWtH/9619uU3bUtm3b7OTJk1asWDGrWrUqxdsAAACSGTQSZUMtXbrU9a1SkmpLrVmzxmW1J0YrKnurKosCUrVq1bJ3333XDVDG56mnnrKHH344VqZU+fLlU7D1AJB++Hw+V2tPgwWSN29eu/vuu12GK9+HgTRafU8KFy7sNgAAAKSMrVu3pvg1len+9ddf248//pik2qDBWVpa2Gbz5s0JnqPV+bQBQGanhSJmzJhh69ats+7du/szTwsVKhTupgFZLygFAACA1PnSo5XzlJEeHR0d674HHnggpNH8/v37u+K78+fPT1ZNKtVIWb16tV1zzTUhPxYAMlvtKNX/07/RWoH+fCuZAkg6glIAAADpwMqVK10A6MSJE+4Lj4qS79u3z/LkyeNWzgslKKUpe+PHj7epU6e6Gie7du1yxzXFxFsRqlevXq4eiupCyXPPPWeXXXaZVatWzQ4dOmSvvvqqm6aiqSkAkBVpIQctQKF/n70FwK677jpXQwpAyiAoBQAAkA489NBDbpXj0aNHu+DRokWL3BS62267zQYMGBDStd555x3386qrrop1fOzYsXbHHXe428rG0oi/RzVD77nnHhfAUpmGxo0b28KFC6127dop8voAICPZvn27ffXVVy5IL6q516pVK8uena/QQErivygAAIB0YNWqVa6ouAJF2bJlcyP0VapUsVdeecWtynf99deHNH3vfDStL9Drr7/uNgCAuSnUCkhpkECrpHrFzQGEOSilFffU0VEquSitW/UKNIrWrl27FG4eAABA1qCsKC9zSdP1lMmk1e/0hUgj9gCA1A9E5cyZ093WCvOaqlejRg0WdABS0f9ytpOoa9eu9vHHH7vbihw3bdrUhg8f7o57qeIAAAAIjVa6W7p0qbvdsmVLe+aZZ+zTTz+1Bx980L/KEwAg5cXExNiCBQts5MiR/ul6Ur9+fQJSQHoLSq1YscKuuOIKd/uLL76wkiVLumwpBareeOON1GgjAABApvfiiy/6i+e+8MILrq7T/fffb3v37rUxY8aEu3kAkCmpnt64ceNs3rx5bqEJTaUGkI6n7+k/VK3iInPmzHH1DZRqrtVaFJwCAABAaFQaQVP2vIwo3Z41a1a4mwUAmfrfXSVcaHW9M2fOuGl7HTp0sIYNG4a7aUCWEnKmlJYJnjJliqttoP+AvTpSe/bssQIFCqRGGwEAADL9lyP1sagdBQCp79ixYzZhwgT7+uuvXUCqYsWKdt9997lp1BEREeFuHpClhByUUn2DRx991K0+0KRJE7c0ppc1pf+IAQAAEBplnVevXt32798f7qYAQKa3ZMkS27hxo1vptG3bttarVy83ZRpABpi+d8MNN9jll19uO3futAYNGviPt27d2q1OAAAAgNC99NJL9thjj7mFYyhsDgCp58orr3S1pPS9VjWSAWSgoJSUKlXKbV6Kefny5V3WFAAAAJJHI/Wq3alBP9U2yZ07d6z7Dxw4ELa2AUBGtnXrVlu2bJl1797dZaZmz57d3QaQAYNSZ8+etSFDhriV9jQXV/Lly2f9+/e3wYMHW44cOVKjnQAAAJnaiBEjwt0EAMhUVC9Kq+otXrzY7VeoUMGaNm0a7mYBuJCglIJPX331lb3yyiv+elK//PKLPfvss64OglLOAQAAEJrevXuHuwkAkGns2LHDJk+ebPv27XP7jRs3pgYykBmCUuPHj3crFXTs2NF/rH79+m4KX8+ePQlKAQAAJNOWLVts7Nix7ufIkSOtRIkS9s0337jR/Tp16oS7eQCQ7sXExNhPP/1kP/74o7utWT1dunRxi0kAyASr7+XKlcutvBescuXKrv4BAAAAzm/Dhg2x9n/44QerV6+em2airHSvTMKvv/7qSiQAAM7v66+/tvnz57uAVO3ate3+++8nIAVkpqBUv379bOjQoXb69Gn/Md1+4YUX3H0AAAA4PwWebr31Vjt37pzbf/LJJ+3555+3uXPnxhroa9WqlS1atCiMLQWAjEMlZpQdpZXhtXJ8njx5wt0kACk5fW/lypWuWFy5cuXc6jDeCF50dLS1bt3arr/++lidLQAAAMT16KOP2sMPP2zt27e3b7/91lavXu3KJATTFD6vJgoAILYjR47YH3/84UrKSPHixW3AgAFuhT0A6V/I/6UWKlQozvKZqicFAACApNOKxW+++aZNmjTJ38fauXOnK4kQPCBYtmzZMLUSANKvNWvW2IwZM9zMncKFC/u/lxKQAjKOkP9rVfFNAAAApIwbb7zR/ezRo4c98cQTLkgVERHh6qH8/PPPLqOqV69e4W4mAKQbJ0+edMGotWvXuv0yZcpY7ty5w90sAMlACBkAACAdePHFF61v375upF91plSgVz9vueUWGzhwYLibBwDpwubNm23atGl29OhRF8C/8sor7YorrrBs2bKFu2kA0iIotX//fnvmmWfs+++/tz179rhRvEAHDhxITjsAAACyNBU3f++992zQoEFuSopW37v44otZNQoA/o8Wgli4cKG7XbRoUVfMnOnNQBYLSt1+++0uOt2nTx8rWbKki05fiLfeesteffVV27VrlyucrtoKTZo0SfB8pbSrs6Ziduqkvfzyy3bNNdfEKq4+evRoW758uQuQqQ5Dw4YNY13jqquucssuB/rHP/7hHgcAABBOFSpUcBsAIDbVjRJ9X2zTpo2rzQcgiwWlfvrpJ1uwYIF/5b0LMXHiRLfqjIJBTZs2tREjRrgVaDZs2OBWmgmmqHjPnj1t2LBhdu2117oVarp162YrVqywunXrunOOHz9ul19+ud100012zz33JPjcuu+5557z77NUKAAASGvqByXVa6+9lqptAYD0RlOYDx8+bEWKFHH7jRs3dvWjtAHIokGpmjVrusJyKUGdKwWH7rzzTrev4JQK1n344Yf25JNPxjl/5MiR1qFDB3vsscfc/tChQ10K56hRo/xZTsrkEmVSJUZBqFKlSqXI6wAAAEgOZXQnxYVmpgNARrN3716bPHmynThxwu6//37LlSuX+7eQgBSQxYNSb7/9tgsYqa6UspOCUyYLFCiQpOtER0e7KXZPPfWU/1hkZKRLw/zll1/ifYyOB48oKrNqypQpob4M+/TTT+0///mPC0x17tzZTQlMLFtKy4xq8xw5ciTk5wQAAAikGp0AgP/x+Xy2aNEimzdvnsuU0qp6ClCVK1cu3E0DkB6CUoUKFXIBmVatWsX5x0ORa/3DkRT79u1z56ouVSDtr1+/Pt7HqO5UfOfreCi0ik3FihVdlP2///2vW35ZUwZVjyohmjI4ZMiQkJ4HAAAgVKrduWXLFreilL6MeX0sAMjsNFVPCQferJdq1apZly5dLH/+/OFuGoD0EpS69dZbXXaU6jmlRKHzcLj33nv9t+vVq2elS5e21q1buw5g1apV432MMroCs7QUmNOSzQAAAMmhFYyVJR64wrFqYip7Sv2rTZs2WZUqVdziMiruO3z48LC2FwBSi4Lvv/76q82aNcvNTtH3zXbt2rkaUhnx+yaAVAxKaYli1T+oUaOGXYhixYpZtmzZbPfu3bGOaz+hWk86Hsr5SaUi697IZEJBKc1h1gYAAJBStTVr167tX0X4oYcecl/Etm3bZrVq1fKfd/PNN7uBMYJSADIzzVxRQErT9K677jp/cXMAmdv/hueS6JJLLrHt27df8BPnzJnTRb41VzhwxFD7zZo1i/cxOh54vqjQeULnJ9WqVavcT2VMAQAApIW2bdvaAw88YB988IHbnzNnjr388stx6qZUr17d/vzzzzC1EgBSj77/ibKhtLq6/l3UIlgEpICsI+RMqf79+9uAAQPcCnia+hZc6Lx+/fpJvpZG/Xr37u0CXU2aNLERI0bY8ePH/avx9erVy8qWLevqOYmet2XLlm6ksFOnTjZhwgRbtmyZjRkzxn/NAwcOuBHGHTt2+CPuomwqbZqip6mHGpUsWrSoqymlkUnVbQil7QAAABeiQYMGtmTJEtcX0hQ99YHiW3RFfRuytQFkJsqI0lS9s2fPWvfu3d2xvHnzWvPmzcPdNADpPSilFHK56667/McU2Q610Ll3La2koJX8VKy8YcOG7h8nr5i5gkuBtRb0j5QCSgMHDrSnn37ajRyqEJ5WAfRMmzbNH9SSHj16uJ+DBw+2Z5991mVoffvtt/4AmOpC6R9CXRMAACAtKRtg+vTp7vYVV1xhH3/8sQ0dOtTtq1+lLIJXXnnFrr766jC3FABShjI/9R3u0KFDbr9FixYXXI4FQBYKSm3dujVFG9CvXz+3xWf+/Plxjt14441uS8gdd9zhtoQoCPXDDz8ks7UAAACpQ8EnLbyiLPDo6Gh7/PHHbe3atS5T6ueffw538wDggigrSgs5LFy40O0XLFjQ1Y4iIAVkbSEHpSpWrJg6LQEAAMjClPm9ceNGGzVqlFv+/NixY3b99ddb3759qXsJIEPTrJjJkyfbnj173L5myHTo0IGpyQBCL3Qun3zyiUuzLFOmjL/wpqbDTZ06NaXbBwAAkGUoc+Bf//qXff755zZz5kx7/vnnkxWQUj3OSy+91AW3SpQoYd26dfPX2UzMpEmTrGbNmhYVFeVqh6oNAHAhNA1Z/6YpIKW6eSrh0rVrVwJSAJIXlHrnnXdcgXIVCtc8YK+GVKFChVxgCgAAAKEbO3asCwoF07GPPvoopGupVIEyrBYtWuRWKj5z5oy1a9fO1dNMiKbU9OzZ0xVdX7lypQtkaVuzZk2yXg8AiGoEa2U9Bbz/+c9/up8AkOyg1JtvvmnvvfeeG8XLli2b/7hW0Fu9enWolwMAAMD/ZTcVK1YsznFlOr344oshXUsLx6jGZp06ddwqf+PGjXMLyCxfvjzBx4wcOdJNp9EKy7Vq1XIF1xs1auSmEwJAUmkBLP1bo1XOPVWqVHEZUlphDwAuuND5xRdfHOe40i8TG30DAABAwhQ0qly5crz1PHXfhTh8+LB/tb+E/PLLLy4bPlD79u3dKlmJLeuuzXPkyJELaieAjEuzaLQ4gxIVdu/e7VY9r1SpkhUoUCDcTQOQmYJS6iytWrUqTsFzjchpVA0AAAChU0aUMgv0JS7Qr7/+akWLFr2gei4PPvigqweqYuqJFSIuWbJkrGPa1/HEsruGDBmS7LYByNi0IMNvv/3mpvlu377df1wzaq666ipX1w4AUiQo9dxzz9mjjz7qRtBUo+DUqVMuNXPJkiX22WefuU7J+++/n9TLAQAAIIDqOT3wwAPuS9yVV17prw01YMAA69GjR7Kvq36bvjAuWLDAUtpTTz0VK7tKmVLly5dP8ecBkD5pmt78+fP9+wqqK/itZAUVNQeAFAtKaRTsvvvus7vvvtty585tAwcOtBMnTtgtt9ziVuFTHYIL6TABAABkZarh9Mcff1jr1q0te/bs/iynXr16hVxTytOvXz/7+uuv7ccff7Ry5colem6pUqXclJtA2tfxhKh8AytoAZlfdHS0W8FTAW6VcvGKlSsAtWnTJvdTNezIjAKQakEpZUV5br31VrcpKKWUTaWbAwAAIPlUf2XixIn2/PPPu1IJGgSsV69enJIJSe239e/f3yZPnuyyGOKrVRWsWbNmNm/ePDfVz6OV+3QcQNZz9uxZF3BSIGrjxo1u35ua5wWlNLVYSQsAkCY1pSIiImLtKyWTtEwAAICUU716dbddCE3ZGz9+vE2dOtVlLnh1oQoWLOiCXaIMrLJly7oSDKJpgi1btrThw4dbp06dbMKECbZs2TIbM2ZMCrwqABnFuXPnbPr06bZ+/fpYCxlooQRlRCVWmw4AUjUoddFFF8UJTAU7cOBAyI0AAADI6rp3725NmjSxJ554ItbxV155xZYuXWqTJk1K8rXeeecd91OFhgONHTvW7rjjDndbK/pFRkb672vevLkLZKlEw9NPP+0CY1p5jy+gQOamacL79u3zz35RJtTevXtdQEor52lanv4dKF269Hm/CwJAqgalVFdKI2wAAABIWar79Oyzz8Y53rFjR5e9FIrAsgsJCSxO7LnxxhvdBiBz078RO3bssNWrV7vV81SWRYtaRUVFufu92nZauIBAFIB0E5RSIXPqRwEAAKQ81elUXalgOXLkcKvaAcCF0uIFqhG1du1aO3jwoP+4FizYs2ePVahQwe1XqVIljK0EkJUkOShFhBwAACD1qKi5Cp0/88wzsY6rtlPt2rXD1i4AmcPKlStt2rRpsQLeNWrUcFPzqlat6l/1EwDS/ep7AAAASFmDBg2y66+/3rZs2WKtWrVyx7Qanuo8ffHFF+FuHoAMRNmVyogqVqyYqwss1apVc4En/VSdKB2PLzsTANJlUEoF8AAAAJA6Onfu7AqLv/jiiy4IpVXyGjRoYN99951b9QoAEnP8+HFXH0rBKC1k4E3D84JSWonzscceIxAFIF0hRxMAACCd6NSpk9u8TIfPPvvMFR9evny5W6YdAIL9+uuvrmD577//Hmt2i+pD1apVK9a5BKQApDcEpQAAANLZKnwffPCBffnll1amTBk3pe+tt94Kd7MApBNnz56NVf9JQamtW7e62/o3Q1PztLFqOoCMgKAUAABAmO3atcvGjRvnglHKkLrpppvs9OnTbjofRc4BKBC1efNmt2rexo0brX///pYvXz5336WXXmqVKlVyBcuZ6gsgoyEoBQAAEOZaUsqO0rS9ESNGWIcOHSxbtmw2evTocDcNQBippq8yoFQjat26dS5Q7VFgqlGjRu62pugFT9MDgIyCoBQAAEAYffPNN/bAAw/Y/fffb9WrVw93cwCkA9u3b7cJEybYiRMn/MdUqFzT8pQRpWl6AJAZEJQCAAAIowULFrhpe40bN3bZDrfffrv16NEj3M0CkEZUnHznzp125swZq1ixojtWrFgxO3XqlFuFU1N469Wr5wqXR0REhLu5AJCiCEoBAACE0WWXXeY2Td2bOHGiffjhh/bwww+7qTtz58618uXLuwwJAJnLnj173NQ81Yk6cOCAlS1b1u6++253n4JRffr0sZIlS7rpvACQWRGUAgAASAfy5s1rd911l9s2bNjgsqdeeukle/LJJ61t27Y2bdq0cDcRwAU6ePCgC0RpU1DKo9X0ChUqZOfOnfMHoZiiByArICgFAACQztSoUcNeeeUVGzZsmE2fPt1lTwHI+ObMmWPr1693tyMjI61atWquRpT+m8+ZM2e4mwcAaY6gFAAAQDqljIlu3bq5DUDGoQLlv/32m5uapxU2ixQp4o6rNlR0dLQrWK4acpqmBwBZGUEpAAAAALhAp0+fdllQmpr3+++/u7pwov0rr7zS3VbRcm0AgP+PoBQAAAAAJNORI0ds1qxZtnHjRlcTylOqVCk3NU8bACB+BKUAAAAAIIkUeDp8+LB/Sp6m4G3ZssUdL1asmAtCaXqebgMAEkdQCgAAAAASoal4f/zxh5uKt27dOsuXL5/985//tIiICMuRI4erG6UgVMmSJd0xAEDSEJQCAAAAgCA+n8/++usvF4hSwfLjx4/778uePbvbV3BKmKIHAMlDUAoAAAAAgsyePdsWL17s39c0Pa2YpwBUxYoVLTIyMqztA4DMgKAUAAAAgCxt3759LiNKK+OVKFHCHatataqtXLnSatas6QJRVapUsWzZsoW7qQCQqRCUAgAAAJDlHDp0yAWitO3evdsdO3v2rLVp08YflHr00UddzSgAQOogKAUAAAAgS1DQafny5S4QpXpRHk3FUxCqXLlysY4xRQ8AUlfY/5V96623rFKlShYVFWVNmza1JUuWJHr+pEmTXAqtzq9Xr57NnDkz1v1fffWVtWvXzooWLepWvli1alWca5w6dcr69u3rzlFxwu7du/tHRwAAAABkHufOnfPfVpDpxx9/9Aek9D3k2muvtUceecRuueUW9z0DAJBFglITJ060hx9+2AYPHmwrVqywBg0aWPv27W3Pnj3xnr9w4ULr2bOn9enTx83v7tatm9s00uHRKhiXX365vfzyywk+70MPPWTTp093Aa4ffvjBduzYYddff32qvEYAAAAAaev06dP23//+18aPH+8GwbWSnheU0neFDh06uO8hvXv3tsaNG1uePHnC3WQAyJLCOn3vtddes3vuucfuvPNOtz969GibMWOGffjhh/bkk0/GOX/kyJHuA+Sxxx5z+0OHDrW5c+faqFGj3GPl9ttvdz//+OOPeJ/z8OHD9sEHH7gPqFatWrljY8eOdStpLFq0yC677LJUe70AAAAAUm9q3qZNm9yA9caNG92+Z+fOnVamTBl3u1mzZmFsJQAgXQSloqOj3Xzup556yn9MIxcqLPjLL7/E+xgd14hGIGVWTZkyJcnPq+c8c+aMv4ChKE23QoUK7voEpQAAAICM5ddff3VlPfQdw1OkSBG3ap624sWLh7V9AIB0FpTSsqua312yZMlYx7W/fv36eB+za9eueM/X8aTSuTlz5rRChQqFdB2lAGvzHDlyJMnPCQAAACBlxMTE2LZt21xt2GLFirljhQsXdgGpAgUK+ANRpUqVcjVmAQDpF6vvJdGwYcNsyJAh4W4GAAAAkOWoJtTff//tpuatXbvWjh07Zpdccol16tTJ3V++fHm766673Op5BKIAIOMIW6FzjWpky5Ytzqp32teoRnx0PJTzE7qGRlEOHToU0nU0zVD1qLxt+/btSX5OAACAtKTVxTp37uxq6OgL+vlKHcyfP9+dF7yFko0OpEYgSn30efPm2RtvvOHqwi5evNgFpLQSt2Y/ePT3qsAUASkAyFjCFpTSh4hWutCHTGAqrvYTKj6o44Hniwqdh1KsUM+ZI0eOWNfZsGGDSwFO7Dq5cuVy6cCBGwAAQHqk1Yi1qrFWHQuF+kQqCO1tJUqUSLU2Aknx2Wef2YIFC9yAsvrw9erVsx49etijjz5qbdu2DXfzAAAZefqetwyrUm+bNGliI0aMcJ0obzW+Xr16WdmyZd3UORkwYIC1bNnShg8f7lJ1J0yYYMuWLbMxY8b4r3ngwAEXYNqxY4e/cyXKgtJWsGBB69Onj3tuFT9UcKl///4uIEWRcwAAkBl07NjRbaFSECq47iaQFjQTQdPyNm/ebLfeequbUaGsp4YNG7psKdWIuuiii1xgCgCQeYQ1KHXzzTfb3r177ZlnnnHp4frQmTVrlr+YuYJLWpHP07x5cxs/frwNHDjQnn76aatevbpLR9eHlGfatGn+oJZoJEUGDx5szz77rLv9+uuvu+t2797dFS/XCn5vv/12Gr5yAACA9Ed9MfWN1LdSv6lFixbhbhIyMU3D++2331ydqMDSGL///rvr58tVV10VxhYCADJ9ofN+/fq5LaH6BsFuvPFGtyXkjjvucFtiNAdd6eyhprQDAABkRqVLl7bRo0e77HUFpd5//30XDFD9nkaNGiX4OFYnRnJoRoNKaWzdutXVjfJUrFjR6tSp42ZKAACyhrAHpQAAABBeNWrUcFtgdvqWLVtcdvknn3yS4ONYnRhJoUWGFLzMnz+/29fUPGVDiYrxKzNPwShqtgJA1kNQCgAAAHGo3qcKTCdGqxOrTmdgppRWQAPOnj3r6kNpat7GjRutZs2adv311/trl6nmWbVq1VyNVwBA1kVQCgAAAHGsWrXKTetLjFYn1gZ4K2lrSp4CUevWrYs1tVN1ZDVVT8XLtSnoCQAAQSkAAIBMWEBaWSoeBQoUZFJWSoUKFVyG099//20ff/yxu18rIFeuXNlNoTp16pSrKfXdd9/ZnDlzwvgqkNFoqucff/zh39d0Pf1N1atXzwU4FYwCACAQQSkAAIBMZtmyZXb11Vf7970pdr1797Zx48bZzp073SrHgTV/HnnkEReoypMnj9WvX9++/fbbWNcAPMp40t+QMqJUED9nzpzueJUqVWzPnj1Wu3ZtVydKAVACUQCAxBCUAgAAyGQUKAhc1SyYAlOBHn/8cbcBiVHASYEobQcPHoxVqFyaNm1qLVq0sMjIyDC3FACQURCUAgAAABCv48eP24oVK1wgSkEpT/bs2d2KjQULFvQf8zKmAABIKoJSAAAAAGIVLPeynTS1U/XFRMeqV6/u6kQpIEUQCgBwoQhKAQAAAFnciRMn7LfffnMZUVFRUdajRw93vHDhwm5aXsmSJa1mzZqWO3fucDcVAJCJEJQCAAAAsiCttLh+/Xpbu3atbdmyxV+HLFu2bHb69GnLlSuX2+/QoUOYWwoAyKwISgEAAABZjKbkLVy40M6dO+c/Vrp0aTc1T4XLvYAUAACpiaAUAAAAkIkp8KRMqPLly/un3+XNm9cdL1asmAtCaStatGi4mwoAyGIISgEAAACZsFj5H3/84WpErVu3zk3Vu/baa61x48bu/vr161ulSpWsRIkSFhEREe7mAgCyKIJSAAAAQCagmlB//fWXrV692hUtP378uP++fPnyuUCVRxlTFC0HAIQbQSkAAAAgk6ygN3bsWH/BcgWdatWqZfXq1bMKFSpYZGRkuJsIAEAsBKUAAACADGbfvn0uI+rIkSPWtWtXf52omjVrWo4cOVyNqCpVqriV9AAASK8ISgEAAAAZwKFDh1yNKG27d+/2H7/66qutQIEC7vZNN90UxhYCABAaglIAAABAOrZhwwZbsGCBqxfl0VS8qlWruowoakMBADIqglIAAABAOnLy5Em3Il5UVJR/3wtIVa5c2QWiVCuKYBQAIKMjKAUAAACE2enTp11GlKbmbdmyxVq3bm3Nmzd396lOlO6vXbu25c+fP9xNBQAgxRCUAgAAAMLgzJkztmnTJlu7dq1t3LjRzp49679v165d/tvKmGratGmYWgkAQOohKAUAAACksXPnztnIkSPt+PHj/mNFixZ1U/Pq1KljxYsXD2v7AABICwSlAAAAgFQUExNjf/75p23bts1atmzpjmXLls0qVKhgO3bscEEoBaNKlSrlakkBAJBVEJQCAAAAUpjP57O///7b1YjS9Lxjx4654wpAFStWzN3u0qWL5cqVi0AUACDLIigFAAAApJADBw7YihUrXCDq0KFDsepCacW8yMjIWMcAAMjKCEoBAAAAFzg9zws27d69237++Wd3O0eOHG7lPE3Nq1q1qpuyBwAA/oegFAAAABCiw4cP+6fmVa9e3a6++mp3XLcVhFIw6qKLLnKBKQAAED+CUgAAAEASqC7Ub7/95oJR27dv9x8/c+aMPyiVPXt26969exhbCQBAxkFQCgAAADiPSZMm2bp161wBc0+lSpVc4fLatWuHtW0AAGRUBKUAAACAANHR0bZlyxY3Bc9bGS9nzpwuIFW2bFk3PU+BqAIFCoS7qQAAZGgEpQAAAJDlnT171jZt2uRqRG3YsMHt33333S4IJVdccYVdeeWVVrhw4XA3FQCATIOgFAAAALKkc+fO2datW12NqPXr19vp06f99yn4dOLECf9+kSJFwtRKAAAyL4JSAAAASNc0bW7/yf12LPqY5cuZz4rmLuqfVnchtm3bZp9++ql/P3/+/G5qnrbSpUunyHMAAICEEZQCAABAunTo1CH7aNVH9uaSN23LwS3+41ULV7X+Tfpb74a9rVBUoSQFtXbs2OEyovLkyeOm4knFihWtRIkSVqFCBReI0k8CUQAApB2CUgAAAEh3Zm+ebd0/724nzvxvCp3n94O/20OzH7J/ffcv+/KmL619tfbxXmPPnj0uEKXt4MGD7li+fPmsRYsWFhkZ6bb77ruPQBQAAGFCUAoAAADpLiDVaXwnl+Gk/wXzjp08c9KdN+OWGbECU0uXLrVly5a5oJQnR44cVqNGDatTp06saxGQAgAgfCItHXjrrbesUqVKFhUVZU2bNrUlS5Ykev6kSZPcEr06v169ejZz5sxY96sD88wzz7haALlz57Y2bdq41VQC6fnUCQncXnrppVR5fQAAAGnpxx9/tM6dO1uZMmVcH2fKlCnnfcz8+fOtUaNGlitXLqtWrZqNGzfOwjVlTxlS6s/FWEyi5+p+ndd7Ym87cOKA//j+/ftdQCpbtmwuENW9e3d79NFH3U/1IZUhBQAAwi/sn8gTJ060hx9+2AYPHmwrVqywBg0aWPv27WONbAVauHCh9ezZ0/r06WMrV660bt26uU1p2Z5XXnnF3njjDRs9erQtXrzY8ubN66556tSpWNd67rnnbOfOnf6tf//+qf56AQAAUtvx48ddn0oDf0mhFeg6depkV199ta1atcoefPBBu/vuu2327NmW1lRDSlP2zheQymN57BK7xHpbb7v/7P02dv5Y/30KrnXp0sUFonr06OHqReXMmTMNWg8AADLU9L3XXnvN7rnnHrvzzjvdvgJJM2bMsA8//NCefPLJOOePHDnSOnToYI899pjbHzp0qM2dO9dGjRrlHqvRshEjRtjAgQOta9eu7pyPP/7YSpYs6UYJ1TEJXGGlVKlSafZaAQAA0kLHjh3dllTqQ1WuXNmGDx/u9mvVqmULFiyw119/3Q3spRX141TUPCFRFmU1rabVtbpWxapYZMD46o9rfrSHOz7sMsNUvFwbAABI38IalIqOjrbly5fbU0895T+mdGpNt/vll1/ifYyOK7MqkDpLXlq6Rvp27drlruEpWLCgmxaoxwYGpTRdT0EtrbRyyy232EMPPWTZs8f/lpw+fdptniNHjlzAKwcAAEg/1EcK7Dt5/StlTCUmpftH+0/uj7XKXqDCVtj6Wl/LHtB9/dv+tjW2xtbaWjty8ojd9/V9Vq5AOSuSu4h/K5qnqP92gVwFLDIi7BMFAABAeghK7du3z86dO+eymAJpf/369fE+RgGn+M7Xce9+71hC58gDDzzgUruLFCnipgQqMKYpfMrcis+wYcNsyJAhyXylAAAA6VdC/SsFmU6ePOlqdKZF/+hY9LEE7ztoB+2IHbGzdtYFovS/A/a/OlIyZsWYRK+vgFRgwMoFrXIXTXw/T1GCWQAAZNbpe+ESmG1Vv359V2fgH//4h+tcqcBnMAWtAh+jTlr58uXTrL0AAADpTUr3j/LlzJfo/e/b+3bCTiT7+jG+GNt3Yp/bQqGAVOGowrGyrpIS0CoYVZBgFgAA6TUoVaxYMbcqyu7du2Md135CtZ50PLHzvZ86ptX3As9p2LBhgm3R9L6zZ8/aH3/84VZpCaZAVXzBKgAAgIwuof5VgQIFEsySSo3+kYI6VQtXtd8P/m4+88W5P6GAVIRFuGl7n3X/zA6eOmj7T+y3AycP+DdNCwzeP3L6SEjBLD1GW3KCWcHTCItEBe0HBbQIZgEAsoqwBqWUndS4cWObN2+eW0FPYmJi3H6/fv3ifUyzZs3c/YE1DlToXMdFRTrVsdI5XhBKo3Zahe/+++9PsC1aaUb1rCiKCQAAshr1o2bOnBnrWGD/Kq2oSHn/Jv3todkPhfzYR5s/ai0qtEjy+WfOnbFDpw7FH7TyglqngvZPHrDDpw8nK5i16cCmZAWzYtXGiopbJyswoEUwCwCQ0YR9+p5Svnv37m2XXHKJNWnSxK2cp2WMvdX4evXqZWXLlnXT6mTAgAHWsmVLtzqMli6eMGGCLVu2zMaMGePvzChg9fzzz1v16tVdkGrQoEFWpkwZf+BLxTwVpNKyx1qBT/sqcn7bbbdZ4cKFw/huAAAAXLhjx47Z5s2b/ftaCEYDcKqlqQVeNO3u77//disUy3333edWMn788cftrrvusu+++84+//xztyJyWuvdsLf967t/2ckzJy3GYs57voIwubPntl4NeoX0PDmy5bDieYu7LRRnY87awZMHE87CUgDr/4JZgQGt5AazQqGMscK5CyepTlbgfQSzAABZNih188032969e+2ZZ55xRTaV3TRr1ix/sc1t27a5DCZP8+bNbfz48TZw4EB7+umnXeBJK+/VrVvXf446VAps3XvvvXbo0CG7/PLL3TWjoqLc/UozVzDr2WefdSvGKHCloFTwqn4AAAAZkQbsNPjm8fo4GggcN26cW9xFfSyP+kIKQKk/NHLkSCtXrpy9//77bgW+tFYoqpB9edOX1ml8J4v0RSYamIq0SBeI+ermr9zj0kL2yOzJDmYpMyspUwsDA1qhBLM05dF7bHKCWUkt/O7d1ntOMAsAcCEifD5f3An7OC9NCSxYsKAdPnzY1VtIae2Hpv3IJDKG2YM6hbsJ/H0iQfx9Iiv+faZ2nyAjScn3Yvbm2db98+524sz/ryMVWGNKQRTJkyOPC0i1q9rOMisvmBU8jfB8AS09JrUFBrPiC2IlFNAqmKugZYvMlurtAwCk/z5B2DOlAAAAgGDtq7W3vx7+yz7+9WN7Y/EbtuXgFv99VQpXsQeaPmC9G/R2U88yM2VmFctTzG1WNOmPOxdzzhV9j7dWViJBrVCCWReSmaUsq1BWM9S5BLMAIPMhKAUAAIB0SYELBZ9U/FyBj6PRRy1/zvwuSKE6okiYgjf+YJaFFsxy0wwTKv7+fwXggwNcekx8KybGR+cpYKYtOcGsUFcz1GMIZgFA+kRQCgAAAOmaAlAKOmhD6lLwJjnvtRfMCrUAfHKDWYGZc6EEs2IFtM6zmiHBrNCpMox+98eij1m+nPnce0kAGUBiCEoBAAAACFswS8XcAzOvEquV5QW00iKYJW6a4XmmFQbflxWDWfp9fLTqI3tzyZux3uOqhau6TEetqplWixEAyFgISgEAAAAICwVvvIBOcoJZoRaAP3jyYJKDWV6wRVtygllJqZMVeF/hqMIZMpgVvChBoN8P/m4PzX7I/vXdv9yqmqoVBwCBCEoBAAAAyLDBrGpFqiX5cTG+mNjTDJMY0EpuMEtBmVDEmmaYSEArMKilx6ggfrgCUp3Gd3LT9uJ7f7xjJ8+cdOfNuGUGgSkAsRCUAgAAAJAlREZEJiszS8Gsw6cOh1wAXlMG9djUDmZpZcLAzKukBLQuNJildipDSgGpGEv8Ner+SF+kO1+rajKVD4CHoBQAAAAAnCeYVTh3YbclJ5gVXyaWP4D1fwXgAwNaoQazNJVRW3KCWcFTCc8X0NJ7oGCWakhpyl5SM8gUmNL5H//6sVtVEwCEoBQAAAAApHIwq6pVTXYwK6kF4JMbzNp6aGtIr6tAzgJ24mzSA1KB3lj8hit+zqp8AISgFAAAAABkkmDWkdNHzlsvKzigpS2UYNaR6CPJel0KYqlofK23alnxvMX9Bd61eVlYbj/3/+3/3239zJEtR7KeE0D6RlAKAAAAADJJMEv1mrRVKVwlWcGspBSA33VsV8jZVYE27N/gtlDky5kvTvAqOHAV577chd0UxYy4qiGQVRCUAgAAAIAsLNRg1r4T+6z4q8WT/Xy5s+e2k2dPhvSYY9HH3Lb9yPaQHhdhEVYwqmDc4FU8GVnBQa4CuQowzRBIZQSlAAAAAABJpuLnVQtXdYXVQ6krpQCRgl6b+m+y6HPRrgbWwZMH3U9X4P3/buunV/A9+D7d1mOTSu3zVjUMNbsrW0Q2F6iLE7yKipuRFRzYypMjDwEtIAkISgEAAAAAkkzBFhUrf2j2QyE/Vivv6fG5sueyUvlKuS0UPp/PZVnFClzFE9gKvC/w9jnfuSQ/l87V1EVtocoRmSPe6YTx1dAKDmxFZY8K+fmAjIqgFAAAAAAgJL0b9rZ/ffcvO3nmpMVYTJKmCGraXq8GvS7oeRXQUhaStrIFyoYc0NIUwIQCVoHZWcH3KdMqlKywMzFnbPfx3W4Lld6n+KYTnm/aobK6KAiPjIagFAAAAAAgJAqAfHnTl9ZpfCeL9EUmGpiKtEg3de+rm79yjwsXBbTy58rvtopWMaTHqhj84VOH48/ICpx2eCrufUejj4b0XMoEO3n0pO04uiPEV/j/C8LHG7w6zwqHFIRHuBCUAgAAAACErH219jbjlhnW/fPuduLMCXcsMJtIgSjJnSO3C0i1q9rOMiplermATu7CIa1sKGfOnXGZVqFONdTt5BaE33Z4W7ILwoe6wmH+nPmpn4VkIygFAAAAAEh2YOqvh/+yj3/92N5Y/IZtObjFf5+CN6oh1btBbxfwyKo0pa543uJuC9Xps6cTn2oYlJ0VeF9aFoQPzMBK6gqHuq2pigS0sjaCUgAAAACAZNOUPAWfVPxcARFNV1P2jIIOBBwuzIUWhE90qmECKxwmpyD8vhP73BaqnNlyxh+wSsIKh3pvkDz6+1ABf2XVacqnVtQM13+rBKUAAAAAABdMX2qL5inqNoRXYEH4cgXKhRywUGAxOSscqu5WKAXhlc11IQXhE1rFMLFph/qZPTJrhkIOnTpkH636yN5c8masrMaqhau6oLIWMEjrum9Z8zcBAAAAAADiDWgVyFXAbRULhVYQ/lzMOTty+kiyVjhMTkH4v4/+7bZQKZMvOSscahqq6otlRLM3z45V/y3Q7wd/t4dmP+RW1NQCBpqWm1YISgEAAAAAgAumFfy8gvChCiwIn+C0wwTuC7UgvAJg2pJbED4pKxwGZ2eFsyD87M2z3UqZyoKLL5PNO3byzEl3nhYwSKvAFEEpAAAAAACQYQvCnzp7KlZNrFBWODwTcyZZBeFDFVgQPtQVDnNfQEF4tVUZUgpIxVhMoufq/khfpDtfCxikxVQ+glIAAAAAACDDisoeZaXzl3ZbKBSo0XS25K5wGONLPMiTkgXhi4Q41dA7TzWk9BqTWutLgSmdrxU1tYBBaiMoBQAAAAAAshxlH+XNmddtyS0In5wVDkPNtIo+F227ju1yW6g05TCU4vOeNxa/4Yqfp/aUQ4JSAAAAAAAAySwIX6lQpZALwh8+fThZKxweiz4W0nMlJyClx2h1Pj1naq+mSVAKAAAAAAAgDQvCa5pdkdxFrKpVTVZB+KSscLjz6E5bumNpstupTDCCUgAAAAAAALBQCsKrflXxV0MvHO/RioGpLTLVnwEAAAAAAABpqmjuola1cFVXVyoUOl+PUyZXaiMoBQAAkEm99dZbVqlSJYuKirKmTZvakiVLEjx33Lhxrj5G4KbHAQCAjCkiIsIVK08OrbyX2kXOhaAUAABAJjRx4kR7+OGHbfDgwbZixQpr0KCBtW/f3vbs2ZPgYwoUKGA7d+70b3/++WeathkAAKSs3g17W54ceSwyieGfyIhId36vBr1SuCUJPF+aPAsAAADS1GuvvWb33HOP3XnnnVa7dm0bPXq05cmTxz788MMEH6MR0VKlSvm3kiVLpmmbAQBAyioUVci+vOlL9xl/vsCU7tfUva9u/so9Li0QlAIAAMhkoqOjbfny5damTRv/scjISLf/yy+/JPi4Y8eOWcWKFa18+fLWtWtXW7t2bRq1GAAApJb21drbjFtmWO4cuV3QKbjGlHdM98+8daa1q9rO0gpBKQAAgExm3759du7cuTiZTtrftWtXvI+pUaOGy6KaOnWq/ec//7GYmBhr3ry5/fXXXwk+z+nTp+3IkSOxNgAAkD4DU389/JeN6DDCqhSuEus+7ev43w//naYBKcmeps8GAACAdKlZs2Zu8yggVatWLXv33Xdt6NCh8T5m2LBhNmTIkDRsJQAASC5NyVMBcxU/P3DygB2NPmr5c+Z3q+ylRVHzdJspFcrKMDJp0iSrWbOmO79evXo2c+bMWPf7fD575plnrHTp0pY7d26Xqr5p06ZY5xw4cMBuvfVWV9CzUKFC1qdPH5eyDgAAkNEVK1bMsmXLZrt37451XPuqFZUUOXLksIsvvtg2b96c4DlPPfWUHT582L9t3779gtsOAABSlwJQRfMUtUqFKrmf4QpIpYugVKgrwyxcuNB69uzpgkgrV660bt26uW3NmjX+c1555RV74403XEHPxYsXW968ed01T5065T9HASnVSZg7d659/fXX9uOPP9q9996bJq8ZAAAgNeXMmdMaN25s8+bN8x/TdDztB2ZDJUbT/1avXu0G+RKSK1cuN8AXuAEAAGSYoFSoK8OMHDnSOnToYI899phLKVc6eaNGjWzUqFH+LKkRI0bYwIEDXYHO+vXr28cff2w7duywKVOmuHPWrVtns2bNsvfff99lZl1++eX25ptv2oQJE9x5AAAAGZ0G/d577z376KOPXN/n/vvvt+PHj7s+l/Tq1ctlOnmee+45mzNnjv3+++9uoPC2226zP//80+6+++4wvgoAAJCZRWa0lWF0PPB8URaUd/7WrVtdAc/AcwoWLOiCT945+qkpe5dccon/HJ2v51ZmFQAAQEZ3880327///W9X0qBhw4a2atUqNyjnFT/ftm2b7dy503/+wYMH3UChBv2uueYaV7RcGeoaNAQAAMh0hc4TWxlm/fr18T5GAafEVpLxfp7vnBIlSsS6P3v27FakSJEEV6TR6jLaPKqbIKm1yszZUydS5brI+NLDykb8fSIh/H0iK/59etdVtnZ6069fP7fFZ/78+bH2X3/9dbddCO89SA//FgAAgPBJav+I1feSKKHVZcqXLx+W9iDrKvhiuFsAJIy/T6Rnqf33efToUZednZXpPRD6RwAAICn9o+wZbWUYHU/sfO+njgUW5tS+Ute9c4ILqZ89e9atyJfQ86rmgmozBBYL1flFi4a3Un1WibCqc6sVfSigivSGv0+kZ/x9pg2NAKrDVaZMGcvq9B7o7y1//vwp3j/i7xnIGPhvFcgYjqTyf6tJ7R9lTy8rw2gFvcCVYRJKNdeKMbr/wQcf9B/TCnreSjKVK1d2gSWd4wWh9GarVpQKfHrXOHTokKtnpeeX7777zj23ak8ltLqMtkCqS4W0w6o+SM/4+0R6xt9n6svqGVIe1ecsV65cqj4Hf89AxsB/q0DGUCAV/1tNSv8o7NP3lH3Uu3dvV3S8SZMmbuW84JVhypYt66bPyYABA6xly5Y2fPhw69Spk1sxb9myZTZmzBh3v0blFLB6/vnnrXr16i5INWjQIBed8wJfKuCpFfxUzFOr/Z05c8YFwXr06MEoJwAAAAAAQBrInh5Whtm7d69bGUZFxpXdFLwyjEbdPM2bN7fx48fbwIED7emnn3aBpylTpljdunX95zz++OMusHXvvfe6jKjLL7/cXTMqKsp/zqeffuoCUa1bt3bX7969u73xxhtp/OoBAAAAAACypghfelwqBgigVQ+VKae6XsFTKIFw4+8T6Rl/n8hM+HsGMgb+WwUyhtPp5L9VglIAAAAAAABIc/+bFwcAAAAAAACkEYJSAAAAAAAASHMEpQAAAAAAAJDmCEoh3frxxx+tc+fOVqZMGYuIiHCrLALpgQoCXnrppZY/f34rUaKEdevWzTZs2BDuZgHxeumll9y/oQ8++GC4mwIkC/0BIGOgfwRkTC+Fua9IUArp1vHjx61Bgwb21ltvhbspQCw//PCD9e3b1xYtWmRz5861M2fOWLt27dzfLJCeLF261N59912rX79+uJsCJBv9ASBjoH8EZDxL00FfMXvYnhk4j44dO7oNSG9mzZoVa3/cuHFuRHD58uV25ZVXhq1dQKBjx47Zrbfeau+99549//zz4W4OkGz0B4CMgf4RkLEcSyd9RTKlAOACHT582P0sUqRIuJsC+Gm0ulOnTtamTZtwNwUAkAXRPwLSt77ppK9IphQAXICYmBg3/7pFixZWt27dcDcHcCZMmGArVqxwKdkAAKQ1+kdA+jYhHfUVCUoBwAWOMKxZs8YWLFgQ7qYAzvbt223AgAGunkdUVFS4mwMAyILoHwHp1/Z01lckKAUAydSvXz/7+uuv3cpQ5cqVC3dzAEe1O/bs2WONGjXyHzt37pz7Ox01apSdPn3asmXLFtY2AgAyL/pHQPq2PJ31FQlKAUCIfD6f9e/f3yZPnmzz58+3ypUrh7tJgF/r1q1t9erVsY7deeedVrNmTXviiScISAEAUgX9IyBjaJ3O+ooEpZCuVwPYvHmzf3/r1q22atUqVyyxQoUKYW0bsjalpI8fP96mTp1q+fPnt127drnjBQsWtNy5c4e7ecji9DcZXL8jb968VrRoUep6IEOiPwBkDPSPgIwhfzrrK0b4FNIG0iGNsFx99dVxjvfu3dstMQuES0RERLzHx44da3fccUeatwc4n6uuusoaNmxoI0aMCHdTgJDRHwAyBvpHQMZ1VRj7igSlAAAAAAAAkOYi0/4pAQAAAAAAkNURlAIAAAAAAECaIygFAAAAAACANEdQCgAAAAAAAGmOoBQAAAAAAADSHEEpAAAAAAAApDmCUgAAAAAAAEhzBKUAAAAAAACQ5ghKAciQxo0bZ4UKFQrb8//xxx8WERFhq1atsvTuqquusgcffDDczQAAAKmIvlHS0TcC0g+CUgCS5Y477nAdj5deeinW8SlTprjjAAAAWQl9IwAIHUEpAMkWFRVlL7/8sh08eNAygujoaMtKUuv1ZrX3EQCApKJvlL7RNwLSH4JSAJKtTZs2VqpUKRs2bFii53355ZdWp04dy5Url1WqVMmGDx8e634de/75561Xr16WL18+q1ixok2bNs327t1rXbt2dcfq169vy5Yti3NtjT5Wr17ddQLbt29v27dv99/37LPPWsOGDe3999+3ypUru3Pk0KFDdvfdd1vx4sWtQIEC1qpVK/v1118TfQ1Lliyxiy++2F3jkksusZUrV8Y5Z82aNdaxY0fX3pIlS9rtt99u+/bti/d6Pp/PPf8XX3zhP6a2li5d2r+/YMEC956dOHHC7W/bts3/fqjdN910k+3evfu8rzfYjBkzrGDBgvbpp5+6fb1nupZS/osUKeKeQyn4gSO/3bp1sxdeeMHKlCljNWrUcMfffvtt/3uv13vDDTck+h4CAJDZ0TeKjb4RfSPgfAhKAUi2bNmy2Ysvvmhvvvmm/fXXX/Ges3z5cveh3qNHD1u9erXrHAwaNMjVPQj0+uuvW4sWLVyHplOnTq7Too7YbbfdZitWrLCqVau6fXVYPOqQqDPw8ccf288//+w6VHqeQJs3b3Ydv6+++spf4+DGG2+0PXv22DfffOPa16hRI2vdurUdOHAg3tdw7Ngxu/baa6127drufL2GRx99NNY5em514NQ5Uwdx1qxZrlOk1x4fpfFfeeWVNn/+fLevEdV169bZyZMnbf369e7YDz/8YJdeeqnlyZPHYmJiXIdIbdTxuXPn2u+//24333zzeV9voPHjx1vPnj1dp+vWW2+1M2fOuA5r/vz57aeffnLvozp2HTp0iDXqN2/ePNuwYYN73q+//tq9xgceeMCee+45d1yvV68HAICsjL7R/9A3om8EJIkPAJKhd+/evq5du7rbl112me+uu+5ytydPnqyekf+8W265xde2bdtYj33sscd8tWvX9u9XrFjRd9ttt/n3d+7c6a4xaNAg/7FffvnFHdN9MnbsWLe/aNEi/znr1q1zxxYvXuz2Bw8e7MuRI4dvz549/nN++uknX4ECBXynTp2K1aaqVav63n333Xhfq44XLVrUd/LkSf+xd955xz3XypUr3f7QoUN97dq1i/W47du3u3M2bNgQ73XfeOMNX506ddztKVOm+Jo2bereU11b2rRp43v66afd7Tlz5viyZcvm27Ztm//xa9eudddfsmRJgq9XWrZs6RswYIBv1KhRvoIFC/rmz5/vv++TTz7x1ahRwxcTE+M/dvr0aV/u3Ll9s2fP9v+uS5Ys6Y57vvzyS/c+HjlyJN7XBgBAVkPfiL4RfSMgdGRKAbhgqp3w0UcfudGsYDqmUb5A2t+0aZOdO3fOf0wp6B6lO0u9evXiHNMonid79uxutMxTs2ZNl2Yd2A6luysV3KNUdI3uFS1a1I16edvWrVtty5Yt8b4+XU/tC0z5btasWaxzdN3vv/8+1jXVHknoui1btrTffvvNpeJrhE8rwWjTCKFG6RYuXOj2vTaUL1/ebR6NTp7v9XqUCv/QQw+50Tw9b2C7NYKo0UCv3UpTP3XqVKx263eRM2dO/37btm3dc1WpUsWN3Gp00UulBwAgq6NvRN+IvhGQNNmTeB4AJEipyUpzfuqpp9wc++TIkSOH/7a3Qk18x5SqHYq8efPG2lenS7UJvNTwQBeyjLKu27lzZ9cJDRZYCyGQOjPq5KjTpU3p9qpDoWssXbrUdb6aN29+Qa/Xo9R5pfp/+OGHru6D936q3Y0bN/bXUAgU2IELvq46arqe3sc5c+bYM88841L31e5wLkcNAEB6QN+IvhF9IyBpCEoBSBFa/liFJL1Cj55atWq5ufiBtH/RRRe5ugsX4uzZs27+fpMmTdy+5u+rfoGeMyGqkbBr1y43kqgiokmh633yySduhMwbEVy0aFGc66pega6payeFOj9XXHGFTZ061dauXWuXX365q5Fw+vRpe/fdd10HyevwqA0quqnNGxHUSKJer0YFz0d1J1REVaOLet9HjRrlb/fEiROtRIkSrkBoKPQ6VdBV2+DBg12H67vvvrPrr78+pOsAAJAZ0Teib0TfCDg/pu8BSBEa2VJxyDfeeCPW8UceecQVghw6dKht3LjRpbLrQz+4GGZyaLSwf//+tnjxYldkUyORl112mb8jFh91EpRerhVTNIqllVSUCv6vf/0r3hVs5JZbbnGdpHvuucd1dmbOnGn//ve/Y53Tt29fV2hThTI1Iqb07tmzZ9udd94ZKxU/mDpCn332meu0Kj08MjLSja5qdC4wlVzt9t5jjcJpxRsVN9U56qAlhTq7SqNXB/HBBx90x3S9YsWKuUKhKuapVH2N8KlQZ0IFWkUFPfW7VsHQP//80xVU1UhtcMcbAICsir4RfSP6RsD5EZQCkGK02khwCrlGmz7//HObMGGC1a1b16Uy67zkprIH0sjZE0884TpGqsWgjotGthKjDpQ6TurcqFOkzohWpVHnwavNEEzXnT59ulshR6ne6qQFp6JrOWCNcqqT1a5dO9dJUudGI2TqTCVEHSc9xquPILodfEzt1qhh4cKFXdvVEVPNgvO93mDqGGnETp09dYr1Hv74449WoUIFN4qnUcc+ffq4kc/ERgf1urSKjVbV0WNGjx7trqnlrQEAwP9H34i+EX0jIHERqnZ+nnMAAAAAAACAFEWmFAAAAAAAANIcQSkAAAAAAACkOYJSAAAAAAAASHMEpQAAAAAAAJDmCEoBAAAAAAAgzRGUAgAAAAAAQJojKAUAAAAAAIA0R1AKAAAAAAAAaY6gFAAAAAAAANIcQSkAAAAAAACkOYJSAAAAAAAASHMEpQAAAAAAAGBp7f8Bgp86ygpVqPwAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 1200x400 with 2 Axes>"
       ]
@@ -1044,10 +1044,10 @@
    "id": "iq53h8qd9u",
    "metadata": {
     "papermill": {
-     "duration": 0.004574,
-     "end_time": "2026-04-22T17:40:23.048276",
+     "duration": 0.026624,
+     "end_time": "2026-04-22T21:17:41.348525",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.043702",
+     "start_time": "2026-04-22T21:17:41.321901",
      "status": "completed"
     },
     "tags": []
@@ -1075,10 +1075,10 @@
    "id": "70d503f0",
    "metadata": {
     "papermill": {
-     "duration": 0.004426,
-     "end_time": "2026-04-22T17:40:23.057185",
+     "duration": 0.037759,
+     "end_time": "2026-04-22T21:17:41.417382",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.052759",
+     "start_time": "2026-04-22T21:17:41.379623",
      "status": "completed"
     },
     "tags": []
@@ -1094,10 +1094,10 @@
    "id": "9bff705d",
    "metadata": {
     "papermill": {
-     "duration": 0.004394,
-     "end_time": "2026-04-22T17:40:23.066086",
+     "duration": 0.046166,
+     "end_time": "2026-04-22T21:17:41.505823",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.061692",
+     "start_time": "2026-04-22T21:17:41.459657",
      "status": "completed"
     },
     "tags": []
@@ -1117,16 +1117,16 @@
    "id": "ff3052c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.077112Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.076514Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.094308Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.093580Z"
+     "iopub.execute_input": "2026-04-22T21:17:41.588291Z",
+     "iopub.status.busy": "2026-04-22T21:17:41.587617Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.628123Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.627195Z"
     },
     "papermill": {
-     "duration": 0.024678,
-     "end_time": "2026-04-22T17:40:23.095417",
+     "duration": 0.081011,
+     "end_time": "2026-04-22T21:17:41.629932",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.070739",
+     "start_time": "2026-04-22T21:17:41.548921",
      "status": "completed"
     },
     "tags": []
@@ -1256,10 +1256,10 @@
    "id": "a7d5c246",
    "metadata": {
     "papermill": {
-     "duration": 0.005052,
-     "end_time": "2026-04-22T17:40:23.105372",
+     "duration": 0.023443,
+     "end_time": "2026-04-22T21:17:41.692942",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.100320",
+     "start_time": "2026-04-22T21:17:41.669499",
      "status": "completed"
     },
     "tags": []
@@ -1295,16 +1295,16 @@
    "id": "c53078ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.116418Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.115964Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.120413Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.119724Z"
+     "iopub.execute_input": "2026-04-22T21:17:41.773238Z",
+     "iopub.status.busy": "2026-04-22T21:17:41.772395Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.780032Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.778276Z"
     },
     "papermill": {
-     "duration": 0.011248,
-     "end_time": "2026-04-22T17:40:23.121445",
+     "duration": 0.053874,
+     "end_time": "2026-04-22T21:17:41.782142",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.110197",
+     "start_time": "2026-04-22T21:17:41.728268",
      "status": "completed"
     },
     "tags": []
@@ -1335,10 +1335,10 @@
    "id": "333cc4ef",
    "metadata": {
     "papermill": {
-     "duration": 0.004434,
-     "end_time": "2026-04-22T17:40:23.130381",
+     "duration": 0.036473,
+     "end_time": "2026-04-22T21:17:41.862741",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.125947",
+     "start_time": "2026-04-22T21:17:41.826268",
      "status": "completed"
     },
     "tags": []
@@ -1355,16 +1355,16 @@
    "id": "2e54113f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.141699Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.141183Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.150640Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.149786Z"
+     "iopub.execute_input": "2026-04-22T21:17:41.954268Z",
+     "iopub.status.busy": "2026-04-22T21:17:41.953860Z",
+     "iopub.status.idle": "2026-04-22T21:17:41.970854Z",
+     "shell.execute_reply": "2026-04-22T21:17:41.969560Z"
     },
     "papermill": {
-     "duration": 0.016222,
-     "end_time": "2026-04-22T17:40:23.151618",
+     "duration": 0.062853,
+     "end_time": "2026-04-22T21:17:41.972926",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.135396",
+     "start_time": "2026-04-22T21:17:41.910073",
      "status": "completed"
     },
     "tags": []
@@ -1482,10 +1482,10 @@
    "id": "4fffa9c3",
    "metadata": {
     "papermill": {
-     "duration": 0.004811,
-     "end_time": "2026-04-22T17:40:23.161183",
+     "duration": 0.046792,
+     "end_time": "2026-04-22T21:17:42.063722",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.156372",
+     "start_time": "2026-04-22T21:17:42.016930",
      "status": "completed"
     },
     "tags": []
@@ -1512,16 +1512,16 @@
    "id": "8b92bcbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.172326Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.171767Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.176301Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.175553Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.138022Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.137660Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.142771Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.141666Z"
     },
     "papermill": {
-     "duration": 0.011464,
-     "end_time": "2026-04-22T17:40:23.177398",
+     "duration": 0.043934,
+     "end_time": "2026-04-22T21:17:42.144494",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.165934",
+     "start_time": "2026-04-22T21:17:42.100560",
      "status": "completed"
     },
     "tags": []
@@ -1550,18 +1550,36 @@
    "id": "7c78b6ba",
    "metadata": {
     "papermill": {
-     "duration": 0.004861,
-     "end_time": "2026-04-22T17:40:23.187126",
+     "duration": 0.025364,
+     "end_time": "2026-04-22T21:17:42.198405",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.182265",
+     "start_time": "2026-04-22T21:17:42.173041",
      "status": "completed"
     },
     "tags": []
    },
+   "outputs": [],
    "source": [
-    "### Exercice 3 : Portfolio dynamique\n",
+    "### Exercice 3 : Ordonnancement de graphe de taches avec strategies\n",
     "\n",
-    "Creez un portfolio solver qui change de strategie en fonction des metriques d'execution : si la strategie courante ne progresse pas (pas de nouvelle borne trouvee pendant N secondes), basculer vers une autre strategie. Utilisez le template `DynamicPortfolio` ci-dessous.\n"
+    "Un **graphe de taches** (task graph) est un ensemble de taches avec des precedences :\n",
+    "certaines taches doivent etre terminees avant que d autres puissent commencer.\n",
+    "\n",
+    "Soit le graphe suivant avec 8 taches et 3 processeurs :\n",
+    "\n",
+    "```\n",
+    "T0 (duree=3) ---> T2 (duree=4) ---> T5 (duree=2)\n",
+    "                  T2 -----------> T6 (duree=5)\n",
+    "T1 (duree=2) ---> T3 (duree=3) ---> T5\n",
+    "                  T3 -----------> T7 (duree=1)\n",
+    "     T0 ---------> T4 (duree=6) ---> T6\n",
+    "                                    T7\n",
+    "```\n",
+    "\n",
+    "**Objectif** : assigner chaque tache a un processeur et un creneau horaire (makespan minimum)\n",
+    "en respectant les precedences et la capacite (1 tache/processeur/creneau).\n",
+    "\n",
+    "Utilisez le template ci-dessous avec le solveur CP-SAT et comparez les strategies."
    ]
   },
   {
@@ -1570,16 +1588,16 @@
    "id": "8b557c4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.198236Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.197792Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.220217Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.219472Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.253677Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.253310Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.398223Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.397382Z"
     },
     "papermill": {
-     "duration": 0.029295,
-     "end_time": "2026-04-22T17:40:23.221216",
+     "duration": 0.171601,
+     "end_time": "2026-04-22T21:17:42.399819",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.191921",
+     "start_time": "2026-04-22T21:17:42.228218",
      "status": "completed"
     },
     "tags": []
@@ -1589,118 +1607,105 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Resultat : OPTIMAL (obj = 26.0, strategie = default)\n",
-      "Stats par strategie :\n",
-      "  default    calls=1 time=0.010s best_obj=26.0\n",
-      "  fixed      calls=0 time=0.000s best_obj=None\n",
-      "  portfolio  calls=0 time=0.000s best_obj=None\n"
+      "Strategie                    Makespan  Temps(s)  Branches\n",
+      "-----------------------------------------------------------------\n",
+      "Defaut                           14     0.0223          54\n",
+      "Linearisation                    14     0.0485         160\n",
+      "Plus de travail                  14     0.0548         160\n"
      ]
     }
    ],
    "source": [
-    "# Exemple resolu : Portfolio dynamique avec bascule\n",
-    "\n",
-    "import time\n",
+    "# Exercice 3 : Ordonnancement de graphe de taches avec CP-SAT\n",
     "\n",
     "\n",
-    "class DynamicPortfolio:\n",
-    "    \"\"\"Portfolio de strategies CP-SAT avec monitoring de progression.\n",
-    "\n",
-    "    Lance chaque strategie avec un budget temps limite (`patience`). Si une\n",
-    "    strategie retourne OPTIMAL, on arrete immediatement. Sinon on garde la\n",
-    "    meilleure solution faisable trouvee, direction-agnostique : on interroge\n",
-    "    le solveur via `BestObjectiveBound` et l'amelioration relative.\n",
-    "    \"\"\"\n",
-    "\n",
-    "    _STRATEGIES = {\n",
-    "        'default':   {'search_branching': cp_model.AUTOMATIC_SEARCH},\n",
-    "        'fixed':     {'search_branching': cp_model.FIXED_SEARCH},\n",
-    "        'portfolio': {'search_branching': cp_model.PORTFOLIO_SEARCH},\n",
-    "        'lp':        {'search_branching': cp_model.LP_SEARCH},\n",
+    "def solve_task_graph(strategies=None):\n",
+    "    # Definition du graphe de taches\n",
+    "    tasks = {\n",
+    "        \"T0\": {\"duration\": 3, \"successors\": [\"T2\", \"T4\"]},\n",
+    "        \"T1\": {\"duration\": 2, \"successors\": [\"T3\"]},\n",
+    "        \"T2\": {\"duration\": 4, \"successors\": [\"T5\", \"T6\"]},\n",
+    "        \"T3\": {\"duration\": 3, \"successors\": [\"T5\", \"T7\"]},\n",
+    "        \"T4\": {\"duration\": 6, \"successors\": [\"T6\"]},\n",
+    "        \"T5\": {\"duration\": 2, \"successors\": []},\n",
+    "        \"T6\": {\"duration\": 5, \"successors\": []},\n",
+    "        \"T7\": {\"duration\": 1, \"successors\": []},\n",
     "    }\n",
+    "    n_proc = 3\n",
+    "    horizon = sum(t[\"duration\"] for t in tasks.values())\n",
     "\n",
-    "    def __init__(self, strategies, patience: float = 1.0):\n",
-    "        self.strategies = [s for s in strategies if s in self._STRATEGIES]\n",
-    "        self.patience = patience\n",
-    "        self.stats = {s: {'calls': 0, 'best_obj': None, 'time': 0.0} for s in self.strategies}\n",
+    "    model = cp_model.CpModel()\n",
     "\n",
-    "    def _run_one(self, model, strategy, timeout):\n",
-    "        solver = cp_model.CpSolver()\n",
-    "        for k, v in self._STRATEGIES[strategy].items():\n",
-    "            setattr(solver.parameters, k, v)\n",
-    "        solver.parameters.max_time_in_seconds = timeout\n",
-    "        t0 = time.time()\n",
-    "        status = solver.Solve(model)\n",
-    "        elapsed = time.time() - t0\n",
+    "    starts, ends, procs, intervals = {}, {}, {}, {}\n",
+    "    for name, info in tasks.items():\n",
+    "        starts[name] = model.new_int_var(0, horizon, f\"start_{name}\")\n",
+    "        ends[name] = model.new_int_var(0, horizon, f\"end_{name}\")\n",
+    "        procs[name] = model.new_int_var(0, n_proc - 1, f\"proc_{name}\")\n",
+    "        intervals[name] = model.new_interval_var(\n",
+    "            starts[name], info[\"duration\"], ends[name], f\"interval_{name}\"\n",
+    "        )\n",
     "\n",
-    "        self.stats[strategy]['calls'] += 1\n",
-    "        self.stats[strategy]['time'] += elapsed\n",
+    "    for name, info in tasks.items():\n",
+    "        for succ in info[\"successors\"]:\n",
+    "            model.add(ends[name] <= starts[succ])\n",
     "\n",
-    "        has_obj = status in (cp_model.OPTIMAL, cp_model.FEASIBLE)\n",
-    "        obj = solver.ObjectiveValue() if has_obj else None\n",
-    "        bound = solver.BestObjectiveBound() if has_obj else None\n",
-    "        if has_obj:\n",
-    "            self.stats[strategy]['best_obj'] = obj\n",
-    "        return {\n",
-    "            'strategy': strategy, 'status': status,\n",
-    "            'objective': obj, 'bound': bound,\n",
-    "            'time': elapsed, 'solver': solver,\n",
+    "    for p in range(n_proc):\n",
+    "        proc_intervals = []\n",
+    "        for name in tasks:\n",
+    "            is_on_p = model.new_bool_var(f\"{name}_on_{p}\")\n",
+    "            model.add(procs[name] == p).only_enforce_if(is_on_p)\n",
+    "            model.add(procs[name] != p).only_enforce_if(~is_on_p)\n",
+    "            optional = model.new_optional_interval_var(\n",
+    "                starts[name], tasks[name][\"duration\"], ends[name],\n",
+    "                is_on_p, f\"opt_{name}_{p}\"\n",
+    "            )\n",
+    "            proc_intervals.append(optional)\n",
+    "        model.add_no_overlap(proc_intervals)\n",
+    "\n",
+    "    makespan = model.new_int_var(0, horizon, \"makespan\")\n",
+    "    for name in tasks:\n",
+    "        model.add(ends[name] <= makespan)\n",
+    "    model.minimize(makespan)\n",
+    "\n",
+    "    solver = cp_model.CpSolver()\n",
+    "    if strategies:\n",
+    "        for key, val in strategies:\n",
+    "            setattr(solver.parameters, key, val)\n",
+    "\n",
+    "    status = solver.solve(model)\n",
+    "    if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):\n",
+    "        schedule = {}\n",
+    "        for name in tasks:\n",
+    "            schedule[name] = {\n",
+    "                \"start\": solver.value(starts[name]),\n",
+    "                \"end\": solver.value(ends[name]),\n",
+    "                \"proc\": solver.value(procs[name]),\n",
+    "                \"duration\": tasks[name][\"duration\"],\n",
+    "            }\n",
+    "        return solver.value(makespan), schedule, {\n",
+    "            \"status\": solver.status_name(status),\n",
+    "            \"time\": solver.wall_time,\n",
+    "            \"branches\": solver.num_branches,\n",
     "        }\n",
-    "\n",
-    "    @staticmethod\n",
-    "    def _is_better(new, old):\n",
-    "        \"\"\"True si `new` represente une meilleure solution que `old`.\n",
-    "\n",
-    "        Direction-agnostique : on mesure l'ecart a la borne optimale\n",
-    "        `BestObjectiveBound`. Plus l'objectif est proche de la borne, meilleure\n",
-    "        est la solution, quel que soit le sens d'optimisation.\n",
-    "        \"\"\"\n",
-    "        gap_new = abs(new['objective'] - new['bound'])\n",
-    "        gap_old = abs(old['objective'] - old['bound'])\n",
-    "        return gap_new < gap_old\n",
-    "\n",
-    "    def solve(self, model: cp_model.CpModel, timeout: float = 10.0) -> Dict:\n",
-    "        remaining = timeout\n",
-    "        best = None\n",
-    "        for strat in self.strategies:\n",
-    "            if remaining <= 0:\n",
-    "                break\n",
-    "            budget = min(self.patience, remaining)\n",
-    "            result = self._run_one(model, strat, budget)\n",
-    "            remaining -= result['time']\n",
-    "            if result['objective'] is not None:\n",
-    "                if best is None or self._is_better(result, best):\n",
-    "                    best = result\n",
-    "                if result['status'] == cp_model.OPTIMAL:\n",
-    "                    break\n",
-    "        if best is None:\n",
-    "            return {'status': 'UNKNOWN', 'objective': None, 'stats': self.stats}\n",
-    "        return {\n",
-    "            'status':    'OPTIMAL' if best['status'] == cp_model.OPTIMAL else 'FEASIBLE',\n",
-    "            'objective': best['objective'],\n",
-    "            'strategy':  best['strategy'],\n",
-    "            'stats':     self.stats,\n",
-    "        }\n",
+    "    return None\n",
     "\n",
     "\n",
-    "# Test : petit knapsack (rapide a resoudre, interessant pour comparer les strategies)\n",
-    "def _build_knapsack(weights, values, capacity):\n",
-    "    m = cp_model.CpModel()\n",
-    "    x = [m.NewBoolVar(f\"x_{i}\") for i in range(len(weights))]\n",
-    "    m.Add(sum(w * xi for w, xi in zip(weights, x)) <= capacity)\n",
-    "    m.Maximize(sum(v * xi for v, xi in zip(values, x)))\n",
-    "    return m\n",
+    "# Comparaison de strategies\n",
+    "strategies_to_test = [\n",
+    "    (\"Defaut\", None),\n",
+    "    (\"Linearisation\", [(\"linearization_level\", 2)]),\n",
+    "    (\"Plus de travail\", [(\"max_deterministic_time\", 5.0)]),\n",
+    "]\n",
     "\n",
-    "knap_model = _build_knapsack([2, 3, 4, 5, 9, 7, 8, 6],\n",
-    "                             [3, 4, 5, 8, 10, 7, 9, 6],\n",
-    "                             capacity=20)\n",
-    "\n",
-    "portfolio = DynamicPortfolio(['default', 'fixed', 'portfolio'], patience=0.5)\n",
-    "result_e3 = portfolio.solve(knap_model, timeout=3.0)\n",
-    "print(f\"Resultat : {result_e3['status']} (obj = {result_e3['objective']}, strategie = {result_e3.get('strategy')})\")\n",
-    "print(\"Stats par strategie :\")\n",
-    "for s, st in result_e3['stats'].items():\n",
-    "    print(f\"  {s:10s} calls={st['calls']} time={st['time']:.3f}s best_obj={st['best_obj']}\")\n"
+    "print(\"Strategie\" + \" \" * 20 + \"Makespan  Temps(s)  Branches\")\n",
+    "print(\"-\" * 65)\n",
+    "for name, params in strategies_to_test:\n",
+    "    result = solve_task_graph(params)\n",
+    "    if result:\n",
+    "        ms, sched, stats = result\n",
+    "        print(f\"{name:28s}  {ms:5d}     {stats['time']:.4f}    {stats['branches']:>8d}\")\n",
+    "    else:\n",
+    "        print(f\"{name:28s}  PAS DE SOLUTION\")"
    ]
   },
   {
@@ -1708,10 +1713,10 @@
    "id": "4a00cf64",
    "metadata": {
     "papermill": {
-     "duration": 0.005028,
-     "end_time": "2026-04-22T17:40:23.232048",
+     "duration": 0.026227,
+     "end_time": "2026-04-22T21:17:42.455912",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.227020",
+     "start_time": "2026-04-22T21:17:42.429685",
      "status": "completed"
     },
     "tags": []
@@ -1742,16 +1747,16 @@
    "id": "6d6a5d84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.243283Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.242891Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.247024Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.246270Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.511388Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.510878Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.515102Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.514144Z"
     },
     "papermill": {
-     "duration": 0.011043,
-     "end_time": "2026-04-22T17:40:23.248033",
+     "duration": 0.036826,
+     "end_time": "2026-04-22T21:17:42.516703",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.236990",
+     "start_time": "2026-04-22T21:17:42.479877",
      "status": "completed"
     },
     "tags": []
@@ -1780,10 +1785,10 @@
    "id": "892cdaf1",
    "metadata": {
     "papermill": {
-     "duration": 0.005358,
-     "end_time": "2026-04-22T17:40:23.258513",
+     "duration": 0.023172,
+     "end_time": "2026-04-22T21:17:42.566156",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.253155",
+     "start_time": "2026-04-22T21:17:42.542984",
      "status": "completed"
     },
     "tags": []
@@ -1804,16 +1809,16 @@
    "id": "76d510bd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.269971Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.269561Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.312487Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.311571Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.630800Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.629873Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.673721Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.672603Z"
     },
     "papermill": {
-     "duration": 0.049998,
-     "end_time": "2026-04-22T17:40:23.313587",
+     "duration": 0.085941,
+     "end_time": "2026-04-22T21:17:42.675220",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.263589",
+     "start_time": "2026-04-22T21:17:42.589279",
      "status": "completed"
     },
     "tags": []
@@ -1823,13 +1828,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Demo 1 : coloration ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Demo 1 : coloration ---\n",
       "Statut : OPTIMAL\n",
       "  A = 0\n",
       "  B = 1\n",
@@ -1947,10 +1946,10 @@
    "id": "55719809",
    "metadata": {
     "papermill": {
-     "duration": 0.005444,
-     "end_time": "2026-04-22T17:40:23.324150",
+     "duration": 0.023801,
+     "end_time": "2026-04-22T21:17:42.726838",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.318706",
+     "start_time": "2026-04-22T21:17:42.703037",
      "status": "completed"
     },
     "tags": []
@@ -1982,16 +1981,16 @@
    "id": "59367060",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T17:40:23.335819Z",
-     "iopub.status.busy": "2026-04-22T17:40:23.335228Z",
-     "iopub.status.idle": "2026-04-22T17:40:23.339469Z",
-     "shell.execute_reply": "2026-04-22T17:40:23.338592Z"
+     "iopub.execute_input": "2026-04-22T21:17:42.792890Z",
+     "iopub.status.busy": "2026-04-22T21:17:42.792026Z",
+     "iopub.status.idle": "2026-04-22T21:17:42.797496Z",
+     "shell.execute_reply": "2026-04-22T21:17:42.796393Z"
     },
     "papermill": {
-     "duration": 0.01146,
-     "end_time": "2026-04-22T17:40:23.340612",
+     "duration": 0.036943,
+     "end_time": "2026-04-22T21:17:42.799123",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.329152",
+     "start_time": "2026-04-22T21:17:42.762180",
      "status": "completed"
     },
     "tags": []
@@ -2021,10 +2020,10 @@
    "id": "784066f1",
    "metadata": {
     "papermill": {
-     "duration": 0.005196,
-     "end_time": "2026-04-22T17:40:23.351503",
+     "duration": 0.021791,
+     "end_time": "2026-04-22T21:17:42.848543",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.346307",
+     "start_time": "2026-04-22T21:17:42.826752",
      "status": "completed"
     },
     "tags": []
@@ -2043,10 +2042,10 @@
    "id": "p9ea5852nb",
    "metadata": {
     "papermill": {
-     "duration": 0.005721,
-     "end_time": "2026-04-22T17:40:23.362047",
+     "duration": 0.024304,
+     "end_time": "2026-04-22T21:17:42.896419",
      "exception": false,
-     "start_time": "2026-04-22T17:40:23.356326",
+     "start_time": "2026-04-22T21:17:42.872115",
      "status": "completed"
     },
     "tags": []
@@ -2113,14 +2112,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.286362,
-   "end_time": "2026-04-22T17:40:23.713710",
+   "duration": 8.41701,
+   "end_time": "2026-04-22T21:17:43.473327",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-6-Hybridization.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-6-Hybridization_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-22T17:40:19.427348",
+   "start_time": "2026-04-22T21:17:35.056317",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

- **CSP-2 Ex3**: Replaced Sudoku 4x4 (redundant with CSP-1 Ex4) with N-Queens 6x6 FC vs MAC comparison exercise — leverages `make_nqueens_csp` already defined in CSP-2
- **CSP-3 Ex1**: Replaced SEND+MORE=MONEY (redundant with CSP-1 Ex3) with CROSS+ROADS=DANGER cryptarithm — same technique, different problem
- **CSP-6 Ex3**: Replaced DynamicPortfolio (redundant with CSP-5 portfolio) with task-graph scheduling using CP-SAT intervals and optional variables — novel CP-SAT feature

## Validation

All 3 notebooks executed successfully with Papermill before and after changes:
- CSP-2-Consistency: SUCCESS (15.6s)
- CSP-3-Advanced: SUCCESS (58.6s)
- CSP-6-Hybridization: SUCCESS

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)