### PR TITLE
fix(ml-5): split #r/using cells, audit #488 ML/Probas complement reassessment

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -57,40 +57,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "metadata": {},
-     "data": {
-      "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML</span></li><li><span>Microsoft.ML.TimeSeries</span></li><li><span>XPlot.Plotly.Interactive</span></li></ul></div><div></div></div>"
-      ]
-     }
-    },
-    {
-     "output_type": "display_data",
-     "metadata": {},
-     "data": {
-      "text/plain": [
-       "Loading extensions from `C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll`"
-      ]
-     }
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "Failed to load kernel extension \"KernelExtension\" from assembly C:\\Users\\jsboi\\.nuget\\packages\\xplot.plotly.interactive\\4.1.0\\lib\\net7.0\\XPlot.Plotly.Interactive.dll"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#r \"nuget: Microsoft.ML\"\n",
     "#r \"nuget: Microsoft.ML.TimeSeries\"\n",
-    "#r \"nuget: XPlot.Plotly.Interactive\"\n",
-    "\n",
+    "#r \"nuget: XPlot.Plotly.Interactive\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "source": [
     "using System;\n",
     "using System.IO;\n",
     "using System.Linq;\n",
@@ -99,8 +77,11 @@
     "using XPlot.Plotly;\n",
     "using System.Collections.Generic;\n",
     "\n",
-    "Console.WriteLine(\"Packages chargés avec succès !\");"
-   ]
+    "Console.WriteLine(\"Packages et using charges avec succes !\");"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -136,25 +117,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(20,21): error CS0246: Le nom de type ou d'espace de noms 'MLContext' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,16): error CS0103: Le nom 'Path' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Définition du schéma de données\n",
     "public class DailySalesData\n",
@@ -243,39 +206,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,15): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,47): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(2,63): error CS0103: Le nom 'fullData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,17): error CS0246: Le nom de type ou d'espace de noms 'Scatter' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,16): error CS0246: Le nom de type ou d'espace de noms 'Line' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(19,18): error CS0246: Le nom de type ou d'espace de noms 'Layout' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(22,17): error CS0246: Le nom de type ou d'espace de noms 'Xaxis' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,17): error CS0246: Le nom de type ou d'espace de noms 'Yaxis' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(28,13): error CS0103: Le nom 'Chart' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Extraire les données pour la visualisation\n",
     "var allData = mlContext.Data.CreateEnumerable<DailySalesData>(fullData, reuseRowObject: false)\n",
@@ -348,39 +279,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(4,17): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,51): error CS0103: Le nom 'fullData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,16): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,50): error CS0103: Le nom 'fullData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,27): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(8,44): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(8,76): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,36): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(9,68): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Microsoft.ML.Transforms.TimeSeries;\n",
     "\n",
@@ -438,35 +337,7 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,19): error CS0103: Le nom 'forecaster' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,40): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,14): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,46): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,62): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(9,16): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(9,48): error CS0246: Le nom de type ou d'espace de noms 'SalesForecast' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Faire des prédictions sur les données de test\n",
     "var predictions = forecaster.Transform(testData);\n",
@@ -520,49 +391,7 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,22): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,54): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(2,70): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(11,26): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(11,58): error CS0246: Le nom de type ou d'espace de noms 'SalesForecast' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,73): error CS0103: Le nom 'predictions' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(17,23): error CS0246: Le nom de type ou d'espace de noms 'Scatter' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,16): error CS0246: Le nom de type ou d'espace de noms 'Line' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(26,25): error CS0246: Le nom de type ou d'espace de noms 'Scatter' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(32,16): error CS0246: Le nom de type ou d'espace de noms 'Line' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(35,18): error CS0246: Le nom de type ou d'espace de noms 'Layout' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(38,17): error CS0246: Le nom de type ou d'espace de noms 'Xaxis' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(39,17): error CS0246: Le nom de type ou d'espace de noms 'Yaxis' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(44,13): error CS0103: Le nom 'Chart' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Extraire les 30 premiers jours de 2024\n",
     "var comparisonData = mlContext.Data.CreateEnumerable<DailySalesData>(testData, reuseRowObject: false)\n",
@@ -641,33 +470,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,26): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,58): error CS0246: Le nom de type ou d'espace de noms 'SalesForecast' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(2,73): error CS0103: Le nom 'predictions' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(9,17): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(9,49): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,65): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Extraire les intervalles de confiance pour les 7 premiers jours\n",
     "var forecastWithBounds = mlContext.Data.CreateEnumerable<SalesForecast>(predictions, reuseRowObject: false)\n",
@@ -725,37 +528,7 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(15,20): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(26,30): error CS0103: Le nom 'trainData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,33): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(29,22): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(29,54): error CS0246: Le nom de type ou d'espace de noms 'DailySalesData' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(29,70): error CS0103: Le nom 'testData' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(31,24): error CS0103: Le nom 'mlContext' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(31,56): error CS0246: Le nom de type ou d'espace de noms 'SalesForecast' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Tester différentes configurations\n",
     "var configs = new[]\n",
@@ -891,31 +664,7 @@
    ],
    "metadata": {},
    "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(22,1): error CS0246: Le nom de type ou d'espace de noms 'MLContext' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,1): error CS0246: Le nom de type ou d'espace de noms 'IDataView' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(29,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n",
-      "(32,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n",
-      "(35,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ]
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

**Issue #488 (NanoClaw audit) — ML/Probas complement reassessment by po-2025**

Scope: 37 notebooks NOT covered by po-2024's PR #490 (ML.Net, Infer, DataScienceWithAgents, NumPy/Pandas).

### Confirmed fix

- **ML-5-TimeSeries.ipynb**: P-1 + P-3 confirmed. Root cause was `#r` NuGet + `using` + code all in one cell. When `XPlot.Plotly.Interactive` kernel extension failed to load, `using` directives didn't persist, causing cascading compilation errors in all 8 code cells. Fixed by splitting into separate cells matching ML-1's proven pattern. Cleared all stale error outputs.

### Reassessment report (37 notebooks)

| Family | Count | Result |
|--------|-------|--------|
| Infer (Probas/) | 18 | PASS — all cells have real executed outputs |
| ML.Net | 8 | 1 P-1+P-3 fixed (ML-5), 1 P-3 exercise TODO (ML-7), 6 PASS |
| DSA AgenticDataScience (Lab9-17) | 9 | P-3 dependency config (`from config import` fails), NOT P-1 |
| NumPy/Pandas (01-PythonForDataScience) | 2 | PASS — core cells executed, exercises have expected TODO stubs |
| **Total** | **37** | **1 confirmed P-1 fixed, 36 reassessed** |

### Breakdown of 36 reassessed

- **25 false positives**: NanoClaw reported 0% execution for notebooks with 90%+ cells executed. The audit tool cannot parse .NET Interactive or Python exercise cells with `None` outputs correctly.
- **10 P-3 dependency issues**: DSA Lab9-17 need `config.py` module configured (local setup issue, not a notebook content bug). ML-7 has exercise TODO stubs producing expected errors.
- **1 P-3 exercise TODO**: ML-7 TimeSeries exercise cell (expected, not a bug).

### What this PR changes

- `ML-5-TimeSeries.ipynb`: Split cell 1 into two cells (#r only + using only), cleared 8 stale compilation error outputs

### What this PR does NOT change

- All other notebooks are either PASS or have P-3 dependency issues beyond notebook content scope
- ML-5 needs re-execution to populate fresh outputs (kernel-specific, requires .NET Interactive)

## Test plan

- [ ] Open ML-5-TimeSeries.ipynb in VS Code with .NET Interactive kernel
- [ ] Execute cell 1 (#r directives) — verify packages install
- [ ] Execute cell 2 (using directives) — verify types resolve
- [ ] Execute remaining cells — verify no compilation errors
- [ ] Verify all other notebooks in scope still have their existing outputs (no regressions)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>