### PR TITLE
fix(search-3): recycle 3 leaked solutions + add variant TODO exercises (#463)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
@@ -5,10 +5,10 @@
    "id": "nav-header",
    "metadata": {
     "papermill": {
-     "duration": 0.028729,
-     "end_time": "2026-04-22T20:59:01.289308",
+     "duration": 0.009048,
+     "end_time": "2026-04-23T21:50:57.049864",
      "exception": false,
-     "start_time": "2026-04-22T20:59:01.260579",
+     "start_time": "2026-04-23T21:50:57.040816",
      "status": "completed"
     },
     "tags": []
@@ -40,16 +40,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:01.318754Z",
-     "iopub.status.busy": "2026-04-22T20:59:01.318558Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.248342Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.247931Z"
+     "iopub.execute_input": "2026-04-23T21:50:57.071097Z",
+     "iopub.status.busy": "2026-04-23T21:50:57.069955Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.246998Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.246100Z"
     },
     "papermill": {
-     "duration": 0.938377,
-     "end_time": "2026-04-22T20:59:02.249202",
+     "duration": 4.188991,
+     "end_time": "2026-04-23T21:51:01.248302",
      "exception": false,
-     "start_time": "2026-04-22T20:59:01.310825",
+     "start_time": "2026-04-23T21:50:57.059311",
      "status": "completed"
     },
     "tags": []
@@ -95,10 +95,10 @@
    "id": "intro-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005155,
-     "end_time": "2026-04-22T20:59:02.259806",
+     "duration": 0.00782,
+     "end_time": "2026-04-23T21:51:01.266666",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.254651",
+     "start_time": "2026-04-23T21:51:01.258846",
      "status": "completed"
     },
     "tags": []
@@ -144,10 +144,10 @@
    "id": "framework-section",
    "metadata": {
     "papermill": {
-     "duration": 0.004327,
-     "end_time": "2026-04-22T20:59:02.273705",
+     "duration": 0.008307,
+     "end_time": "2026-04-23T21:51:01.282431",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.269378",
+     "start_time": "2026-04-23T21:51:01.274124",
      "status": "completed"
     },
     "tags": []
@@ -166,16 +166,16 @@
    "id": "node-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.285186Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.284892Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.293691Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.292923Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.299262Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.298363Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.316355Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.315259Z"
     },
     "papermill": {
-     "duration": 0.015839,
-     "end_time": "2026-04-22T20:59:02.294736",
+     "duration": 0.028416,
+     "end_time": "2026-04-23T21:51:01.317966",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.278897",
+     "start_time": "2026-04-23T21:51:01.289550",
      "status": "completed"
     },
     "tags": []
@@ -330,10 +330,10 @@
    "id": "problem-example-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004306,
-     "end_time": "2026-04-22T20:59:02.303862",
+     "duration": 0.011392,
+     "end_time": "2026-04-23T21:51:01.339310",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.299556",
+     "start_time": "2026-04-23T21:51:01.327918",
      "status": "completed"
     },
     "tags": []
@@ -350,16 +350,16 @@
    "id": "graph-problem",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.313906Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.313707Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.319797Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.319298Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.359650Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.358793Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.373126Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.372121Z"
     },
     "papermill": {
-     "duration": 0.012178,
-     "end_time": "2026-04-22T20:59:02.320508",
+     "duration": 0.025873,
+     "end_time": "2026-04-23T21:51:01.374717",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.308330",
+     "start_time": "2026-04-23T21:51:01.348844",
      "status": "completed"
     },
     "tags": []
@@ -439,10 +439,10 @@
    "id": "heuristic-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004854,
-     "end_time": "2026-04-22T20:59:02.330280",
+     "duration": 0.012532,
+     "end_time": "2026-04-23T21:51:01.399369",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.325426",
+     "start_time": "2026-04-23T21:51:01.386837",
      "status": "completed"
     },
     "tags": []
@@ -462,16 +462,16 @@
    "id": "heuristic-function",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.341261Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.341047Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.345541Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.345027Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.425398Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.424745Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.434082Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.432427Z"
     },
     "papermill": {
-     "duration": 0.011079,
-     "end_time": "2026-04-22T20:59:02.346232",
+     "duration": 0.024215,
+     "end_time": "2026-04-23T21:51:01.435716",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.335153",
+     "start_time": "2026-04-23T21:51:01.411501",
      "status": "completed"
     },
     "tags": []
@@ -531,10 +531,10 @@
    "id": "greedy-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005069,
-     "end_time": "2026-04-22T20:59:02.356471",
+     "duration": 0.015003,
+     "end_time": "2026-04-23T21:51:01.461515",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.351402",
+     "start_time": "2026-04-23T21:51:01.446512",
      "status": "completed"
     },
     "tags": []
@@ -568,16 +568,16 @@
    "id": "greedy-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.367256Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.367042Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.372885Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.372196Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.482330Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.482041Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.491890Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.490763Z"
     },
     "papermill": {
-     "duration": 0.012184,
-     "end_time": "2026-04-22T20:59:02.373628",
+     "duration": 0.022081,
+     "end_time": "2026-04-23T21:51:01.494840",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.361444",
+     "start_time": "2026-04-23T21:51:01.472759",
      "status": "completed"
     },
     "tags": []
@@ -667,10 +667,10 @@
    "id": "340234eb",
    "metadata": {
     "papermill": {
-     "duration": 0.004968,
-     "end_time": "2026-04-22T20:59:02.383705",
+     "duration": 0.014526,
+     "end_time": "2026-04-23T21:51:01.525624",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.378737",
+     "start_time": "2026-04-23T21:51:01.511098",
      "status": "completed"
     },
     "tags": []
@@ -685,16 +685,16 @@
    "id": "greedy-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.394177Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.393977Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.397640Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.397072Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.552166Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.551685Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.558314Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.557057Z"
     },
     "papermill": {
-     "duration": 0.009834,
-     "end_time": "2026-04-22T20:59:02.398403",
+     "duration": 0.022787,
+     "end_time": "2026-04-23T21:51:01.560551",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.388569",
+     "start_time": "2026-04-23T21:51:01.537764",
      "status": "completed"
     },
     "tags": []
@@ -716,7 +716,7 @@
       "  Noeuds explores  : 2\n",
       "  Noeuds generes   : 8\n",
       "  Frontiere max    : 5\n",
-      "  Temps            : 0.06 ms\n"
+      "  Temps            : 0.12 ms\n"
      ]
     }
    ],
@@ -734,10 +734,10 @@
    "id": "dcjquopv3vv",
    "metadata": {
     "papermill": {
-     "duration": 0.005012,
-     "end_time": "2026-04-22T20:59:02.408062",
+     "duration": 0.014273,
+     "end_time": "2026-04-23T21:51:01.587565",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.403050",
+     "start_time": "2026-04-23T21:51:01.573292",
      "status": "completed"
     },
     "tags": []
@@ -764,10 +764,10 @@
    "id": "greedy-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004923,
-     "end_time": "2026-04-22T20:59:02.417785",
+     "duration": 0.012202,
+     "end_time": "2026-04-23T21:51:01.612613",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.412862",
+     "start_time": "2026-04-23T21:51:01.600411",
      "status": "completed"
     },
     "tags": []
@@ -794,10 +794,10 @@
    "id": "astar-section",
    "metadata": {
     "papermill": {
-     "duration": 0.006432,
-     "end_time": "2026-04-22T20:59:02.429359",
+     "duration": 0.008594,
+     "end_time": "2026-04-23T21:51:01.629813",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.422927",
+     "start_time": "2026-04-23T21:51:01.621219",
      "status": "completed"
     },
     "tags": []
@@ -845,16 +845,16 @@
    "id": "astar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.440453Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.440256Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.445529Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.445196Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.647913Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.647370Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.658290Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.657312Z"
     },
     "papermill": {
-     "duration": 0.011953,
-     "end_time": "2026-04-22T20:59:02.446506",
+     "duration": 0.021782,
+     "end_time": "2026-04-23T21:51:01.659814",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.434553",
+     "start_time": "2026-04-23T21:51:01.638032",
      "status": "completed"
     },
     "tags": []
@@ -947,10 +947,10 @@
    "id": "8a172994",
    "metadata": {
     "papermill": {
-     "duration": 0.004677,
-     "end_time": "2026-04-22T20:59:02.455799",
+     "duration": 0.012401,
+     "end_time": "2026-04-23T21:51:01.684069",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.451122",
+     "start_time": "2026-04-23T21:51:01.671668",
      "status": "completed"
     },
     "tags": []
@@ -965,16 +965,16 @@
    "id": "astar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.466639Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.466442Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.469438Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.469107Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.699519Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.699122Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.703710Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.702926Z"
     },
     "papermill": {
-     "duration": 0.009162,
-     "end_time": "2026-04-22T20:59:02.470111",
+     "duration": 0.013736,
+     "end_time": "2026-04-23T21:51:01.704818",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.460949",
+     "start_time": "2026-04-23T21:51:01.691082",
      "status": "completed"
     },
     "tags": []
@@ -997,7 +997,7 @@
       "  Noeuds explores  : 3\n",
       "  Noeuds generes   : 11\n",
       "  Frontiere max    : 6\n",
-      "  Temps            : 0.07 ms\n"
+      "  Temps            : 0.10 ms\n"
      ]
     }
    ],
@@ -1015,10 +1015,10 @@
    "id": "1mddry1upc6",
    "metadata": {
     "papermill": {
-     "duration": 0.00479,
-     "end_time": "2026-04-22T20:59:02.479736",
+     "duration": 0.006662,
+     "end_time": "2026-04-23T21:51:01.718583",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.474946",
+     "start_time": "2026-04-23T21:51:01.711921",
      "status": "completed"
     },
     "tags": []
@@ -1042,10 +1042,10 @@
    "id": "astar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004961,
-     "end_time": "2026-04-22T20:59:02.489340",
+     "duration": 0.006925,
+     "end_time": "2026-04-23T21:51:01.732881",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.484379",
+     "start_time": "2026-04-23T21:51:01.725956",
      "status": "completed"
     },
     "tags": []
@@ -1071,10 +1071,10 @@
    "id": "comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005292,
-     "end_time": "2026-04-22T20:59:02.499449",
+     "duration": 0.007905,
+     "end_time": "2026-04-23T21:51:01.747428",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.494157",
+     "start_time": "2026-04-23T21:51:01.739523",
      "status": "completed"
     },
     "tags": []
@@ -1091,16 +1091,16 @@
    "id": "comparison-greedy-astar",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.513560Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.513359Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.521853Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.521365Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.766206Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.765667Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.786594Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.785940Z"
     },
     "papermill": {
-     "duration": 0.016263,
-     "end_time": "2026-04-22T20:59:02.522833",
+     "duration": 0.031706,
+     "end_time": "2026-04-23T21:51:01.787605",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.506570",
+     "start_time": "2026-04-23T21:51:01.755899",
      "status": "completed"
     },
     "tags": []
@@ -1113,8 +1113,8 @@
       "Comparaison : Greedy vs A*\n",
       "======================================================================\n",
       "Algorithme                          Chemin  Cout (km)  Longueur  Noeuds explores Temps (ms)\n",
-      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.04\n",
-      "        A* Bordeaux -> Paris -> Strasbourg       1075         2                3       0.03\n",
+      "    Greedy Bordeaux -> Paris -> Strasbourg       1075         2                2       0.05\n",
+      "        A* Bordeaux -> Paris -> Strasbourg       1075         2                3       0.04\n",
       "\n",
       "======================================================================\n",
       "NOTE : Greedy a trouve un chemin de meme cout qu'A* (coincidence !)\n"
@@ -1167,10 +1167,10 @@
    "id": "comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.005108,
-     "end_time": "2026-04-22T20:59:02.534901",
+     "duration": 0.007272,
+     "end_time": "2026-04-23T21:51:01.802266",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.529793",
+     "start_time": "2026-04-23T21:51:01.794994",
      "status": "completed"
     },
     "tags": []
@@ -1194,10 +1194,10 @@
    "id": "ida-section",
    "metadata": {
     "papermill": {
-     "duration": 0.004599,
-     "end_time": "2026-04-22T20:59:02.544035",
+     "duration": 0.007101,
+     "end_time": "2026-04-23T21:51:01.816758",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.539436",
+     "start_time": "2026-04-23T21:51:01.809657",
      "status": "completed"
     },
     "tags": []
@@ -1231,16 +1231,16 @@
    "id": "idastar-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.554456Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.554289Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.559082Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.558609Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.833555Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.832924Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.841761Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.840897Z"
     },
     "papermill": {
-     "duration": 0.010874,
-     "end_time": "2026-04-22T20:59:02.559846",
+     "duration": 0.018743,
+     "end_time": "2026-04-23T21:51:01.842856",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.548972",
+     "start_time": "2026-04-23T21:51:01.824113",
      "status": "completed"
     },
     "tags": []
@@ -1334,10 +1334,10 @@
    "id": "40f8a8e5",
    "metadata": {
     "papermill": {
-     "duration": 0.005155,
-     "end_time": "2026-04-22T20:59:02.570017",
+     "duration": 0.007858,
+     "end_time": "2026-04-23T21:51:01.859331",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.564862",
+     "start_time": "2026-04-23T21:51:01.851473",
      "status": "completed"
     },
     "tags": []
@@ -1352,16 +1352,16 @@
    "id": "idastar-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.582693Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.582531Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.585885Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.585381Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.877921Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.877548Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.883309Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.882255Z"
     },
     "papermill": {
-     "duration": 0.011866,
-     "end_time": "2026-04-22T20:59:02.586646",
+     "duration": 0.017302,
+     "end_time": "2026-04-23T21:51:01.884435",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.574780",
+     "start_time": "2026-04-23T21:51:01.867133",
      "status": "completed"
     },
     "tags": []
@@ -1385,7 +1385,7 @@
       "  Noeuds explores  : 8\n",
       "  Noeuds generes   : 24\n",
       "  Frontiere max    : 4\n",
-      "  Temps            : 0.09 ms\n"
+      "  Temps            : 0.26 ms\n"
      ]
     }
    ],
@@ -1403,10 +1403,10 @@
    "id": "0gzwacp0hfbq",
    "metadata": {
     "papermill": {
-     "duration": 0.005982,
-     "end_time": "2026-04-22T20:59:02.598355",
+     "duration": 0.008907,
+     "end_time": "2026-04-23T21:51:01.901094",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.592373",
+     "start_time": "2026-04-23T21:51:01.892187",
      "status": "completed"
     },
     "tags": []
@@ -1430,10 +1430,10 @@
    "id": "idastar-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.005898,
-     "end_time": "2026-04-22T20:59:02.609916",
+     "duration": 0.006794,
+     "end_time": "2026-04-23T21:51:01.915040",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.604018",
+     "start_time": "2026-04-23T21:51:01.908246",
      "status": "completed"
     },
     "tags": []
@@ -1461,10 +1461,10 @@
    "id": "all-comparison-section",
    "metadata": {
     "papermill": {
-     "duration": 0.0052,
-     "end_time": "2026-04-22T20:59:02.620760",
+     "duration": 0.006889,
+     "end_time": "2026-04-23T21:51:01.928898",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.615560",
+     "start_time": "2026-04-23T21:51:01.922009",
      "status": "completed"
     },
     "tags": []
@@ -1481,16 +1481,16 @@
    "id": "all-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.632201Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.632000Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.637727Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.637263Z"
+     "iopub.execute_input": "2026-04-23T21:51:01.944700Z",
+     "iopub.status.busy": "2026-04-23T21:51:01.944285Z",
+     "iopub.status.idle": "2026-04-23T21:51:01.952559Z",
+     "shell.execute_reply": "2026-04-23T21:51:01.951936Z"
     },
     "papermill": {
-     "duration": 0.012548,
-     "end_time": "2026-04-22T20:59:02.638497",
+     "duration": 0.017321,
+     "end_time": "2026-04-23T21:51:01.953527",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.625949",
+     "start_time": "2026-04-23T21:51:01.936206",
      "status": "completed"
     },
     "tags": []
@@ -1588,10 +1588,10 @@
    "id": "all-comparison-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004926,
-     "end_time": "2026-04-22T20:59:02.648627",
+     "duration": 0.007048,
+     "end_time": "2026-04-23T21:51:01.967683",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.643701",
+     "start_time": "2026-04-23T21:51:01.960635",
      "status": "completed"
     },
     "tags": []
@@ -1618,10 +1618,10 @@
    "id": "heuristic-design-section",
    "metadata": {
     "papermill": {
-     "duration": 0.004912,
-     "end_time": "2026-04-22T20:59:02.658483",
+     "duration": 0.00747,
+     "end_time": "2026-04-23T21:51:01.982048",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.653571",
+     "start_time": "2026-04-23T21:51:01.974578",
      "status": "completed"
     },
     "tags": []
@@ -1637,10 +1637,10 @@
    "id": "admissibility-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005185,
-     "end_time": "2026-04-22T20:59:02.668740",
+     "duration": 0.017278,
+     "end_time": "2026-04-23T21:51:02.006450",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.663555",
+     "start_time": "2026-04-23T21:51:01.989172",
      "status": "completed"
     },
     "tags": []
@@ -1669,10 +1669,10 @@
    "id": "consistency-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005335,
-     "end_time": "2026-04-22T20:59:02.679082",
+     "duration": 0.007908,
+     "end_time": "2026-04-23T21:51:02.022449",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.673747",
+     "start_time": "2026-04-23T21:51:02.014541",
      "status": "completed"
     },
     "tags": []
@@ -1704,10 +1704,10 @@
    "id": "dominance-section",
    "metadata": {
     "papermill": {
-     "duration": 0.00509,
-     "end_time": "2026-04-22T20:59:02.690016",
+     "duration": 0.012392,
+     "end_time": "2026-04-23T21:51:02.044572",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.684926",
+     "start_time": "2026-04-23T21:51:02.032180",
      "status": "completed"
     },
     "tags": []
@@ -1738,10 +1738,10 @@
    "id": "puzzle-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005473,
-     "end_time": "2026-04-22T20:59:02.700826",
+     "duration": 0.011751,
+     "end_time": "2026-04-23T21:51:02.067243",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.695353",
+     "start_time": "2026-04-23T21:51:02.055492",
      "status": "completed"
     },
     "tags": []
@@ -1765,16 +1765,16 @@
    "id": "puzzle-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.712196Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.711985Z",
-     "iopub.status.idle": "2026-04-22T20:59:02.719753Z",
-     "shell.execute_reply": "2026-04-22T20:59:02.719162Z"
+     "iopub.execute_input": "2026-04-23T21:51:02.090215Z",
+     "iopub.status.busy": "2026-04-23T21:51:02.089716Z",
+     "iopub.status.idle": "2026-04-23T21:51:02.104090Z",
+     "shell.execute_reply": "2026-04-23T21:51:02.103053Z"
     },
     "papermill": {
-     "duration": 0.014386,
-     "end_time": "2026-04-22T20:59:02.720486",
+     "duration": 0.030623,
+     "end_time": "2026-04-23T21:51:02.105494",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.706100",
+     "start_time": "2026-04-23T21:51:02.074871",
      "status": "completed"
     },
     "tags": []
@@ -1910,10 +1910,10 @@
    "id": "b3189c7b",
    "metadata": {
     "papermill": {
-     "duration": 0.005751,
-     "end_time": "2026-04-22T20:59:02.731762",
+     "duration": 0.009301,
+     "end_time": "2026-04-23T21:51:02.126882",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.726011",
+     "start_time": "2026-04-23T21:51:02.117581",
      "status": "completed"
     },
     "tags": []
@@ -1928,16 +1928,16 @@
    "id": "puzzle-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:02.744387Z",
-     "iopub.status.busy": "2026-04-22T20:59:02.744180Z",
-     "iopub.status.idle": "2026-04-22T20:59:07.561673Z",
-     "shell.execute_reply": "2026-04-22T20:59:07.561247Z"
+     "iopub.execute_input": "2026-04-23T21:51:02.144775Z",
+     "iopub.status.busy": "2026-04-23T21:51:02.144002Z",
+     "iopub.status.idle": "2026-04-23T21:51:10.598416Z",
+     "shell.execute_reply": "2026-04-23T21:51:10.597265Z"
     },
     "papermill": {
-     "duration": 4.824464,
-     "end_time": "2026-04-22T20:59:07.562456",
+     "duration": 8.465687,
+     "end_time": "2026-04-23T21:51:10.600259",
      "exception": false,
-     "start_time": "2026-04-22T20:59:02.737992",
+     "start_time": "2026-04-23T21:51:02.134572",
      "status": "completed"
     },
     "tags": []
@@ -1957,7 +1957,7 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees            1        1         0.03\n",
+      "Tuiles mal placees            1        1         0.04\n",
       "Distance Manhattan            1        1         0.02\n",
       "\n",
       "Reduction des noeuds explores : 0.0%\n",
@@ -1975,8 +1975,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       181440      inf      1573.41\n",
-      "Distance Manhattan       181440      inf      1782.42\n",
+      "Tuiles mal placees       181440      inf      2668.55\n",
+      "Distance Manhattan       181440      inf      3113.51\n",
       "\n",
       "Reduction des noeuds explores : 0.0%\n",
       "\n",
@@ -1993,8 +1993,8 @@
       "\n",
       "Heuristique              Noeuds     Cout   Temps (ms)\n",
       "----------------------------------------------------------------------\n",
-      "Tuiles mal placees       143839       31      1236.46\n",
-      "Distance Manhattan        20290       31       186.49\n",
+      "Tuiles mal placees       143839       31      2212.48\n",
+      "Distance Manhattan        20290       31       384.87\n",
       "\n",
       "Reduction des noeuds explores : 85.9%\n"
      ]
@@ -2002,8 +2002,8 @@
     {
      "data": {
       "text/plain": [
-       "(<__main__.SearchResult at 0x1de67081640>,\n",
-       " <__main__.SearchResult at 0x1de67081f40>)"
+       "(<__main__.SearchResult at 0x27916632d50>,\n",
+       " <__main__.SearchResult at 0x279428cbf50>)"
       ]
      },
      "execution_count": 14,
@@ -2055,10 +2055,10 @@
    "id": "k292t2mslp",
    "metadata": {
     "papermill": {
-     "duration": 0.00535,
-     "end_time": "2026-04-22T20:59:07.573350",
+     "duration": 0.014589,
+     "end_time": "2026-04-23T21:51:10.629824",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.568000",
+     "start_time": "2026-04-23T21:51:10.615235",
      "status": "completed"
     },
     "tags": []
@@ -2083,10 +2083,10 @@
    "id": "puzzle-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004831,
-     "end_time": "2026-04-22T20:59:07.583359",
+     "duration": 0.015025,
+     "end_time": "2026-04-23T21:51:10.659551",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.578528",
+     "start_time": "2026-04-23T21:51:10.644526",
      "status": "completed"
     },
     "tags": []
@@ -2114,10 +2114,10 @@
    "id": "visualization-section",
    "metadata": {
     "papermill": {
-     "duration": 0.004813,
-     "end_time": "2026-04-22T20:59:07.593097",
+     "duration": 0.014197,
+     "end_time": "2026-04-23T21:51:10.687628",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.588284",
+     "start_time": "2026-04-23T21:51:10.673431",
      "status": "completed"
     },
     "tags": []
@@ -2134,16 +2134,16 @@
    "id": "puzzle-visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:07.603703Z",
-     "iopub.status.busy": "2026-04-22T20:59:07.603527Z",
-     "iopub.status.idle": "2026-04-22T20:59:07.860518Z",
-     "shell.execute_reply": "2026-04-22T20:59:07.859899Z"
+     "iopub.execute_input": "2026-04-23T21:51:10.719132Z",
+     "iopub.status.busy": "2026-04-23T21:51:10.718296Z",
+     "iopub.status.idle": "2026-04-23T21:51:11.345230Z",
+     "shell.execute_reply": "2026-04-23T21:51:11.344253Z"
     },
     "papermill": {
-     "duration": 0.263307,
-     "end_time": "2026-04-22T20:59:07.861434",
+     "duration": 0.645411,
+     "end_time": "2026-04-23T21:51:11.346755",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.598127",
+     "start_time": "2026-04-23T21:51:10.701344",
      "status": "completed"
     },
     "tags": []
@@ -2151,7 +2151,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0cAAAJRCAYAAACOQsyxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAciFJREFUeJzt3Qd8G/X9//GPhvdO4jh7OWRPIAmQFggzhBE2ZRUo0EHZUHb/YRRo2RQKhQ5+lFFaNqVQSiChQIBAEgIhg4QMk70db8vS/R+fu0iWbEm2LNuSfK/n4yGwRqTz6e7t+3y/3/uewzAMQwAAAADA5pyJXgAAAAAASAYURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEICa33nqrOBwO8/Z///d/Yjf33nuv+bsXFRVJVVWVpLJBgwYFvsv2ptuG/711m7Gz888/P7Au5s6dm+jFQZLtK8lK801zTn9nzT3ALiiOYLsD+uBbQUGBTJ06Vf7yl7+IYRiJXkzEYcSIESHf7aeffhr19Yceeqh50BqLyspKueeee8yfL7roIsnJyQk8F/zZa9euDfl3ekDsf04PsrrSfqW3hx56SOwg+HvUm8vlktzcXBk8eLAcc8wx8qc//Ulqa2s7pND0r+vdu3dLV6T7TNN1u379+mavGzduXMjr/vjHP0qqe+211wLfb9PsaM3zHUXz7eKLLzZ/1uJI8w+wBQOwgVmzZmnlE/V2wQUXJHoxU8K6deuMDz/80Lxt2bLFSAYLFy5s9n1eccUVzV73wgsvGKtXrzZ/PuSQQ4zzzjvP/Hnx4sXGW2+91eLnPPLII4H3X758echzwZ+9Zs2akOfmzJkTeG7gwIFGsvj8888D32VbRPuddNvwv7duM11B8PcY6TZ8+PBm28a3334bWBe7d++O+XN1W420bXUV+ns1XZe33XZbyGs++eSTZq95/PHHO2X5dBv3f2Z70xzyv7duY7E+35FWrFgR+GzNP8AO6DmC7WgL74cffijvvvuu2frv99RTT8kXX3wR9d/6fL4OaRlurWQYxjVgwAD5wQ9+YN569uwpyeDvf/97s8defPFF8/vy02N57fUZOXKk3HDDDea63L59u/z0pz+ViRMnypNPPtni5+g2okaPHi3Dhw+XVOXfjvbff//Ad9nedNvwv7duM11Nr169zBz5z3/+I3feeaeUlJSYj69YsUKmT58e0sOzzz77BNaF9lajdXR/C+7R1545dK5hw4aZeafsOIwaNpXo6gzo7J4jf2+B8vl8xuDBgwPPPfDAA81e/5e//MW44447jAEDBhhOpzPQcqf/9oknnjCmTJli5ObmGhkZGWar8Y033hi2dfjFF180Ro8ebb5O//+Pf/wj5HOeeuqpsK2U2up+8sknG/n5+cagQYMCr9m6datx1VVXGUOHDjXS09ONwsJCY8aMGWbralN//OMfjf3228/IyckxX9unTx/j8MMPN373u98FXuP1eo3f/OY35rJlZmaay9m/f3/zPf/85z+HXZfBy6wWLFhgnHrqqUZJSYmRlpZm/v+UU04xvvjii5DX6b/zv4e+3zPPPGN+ri7bPvvsY66b1tLvQb8bfS9d7pkzZ0ZsZW1oaDD+9Kc/GX379g28Rj/vn//8Z4ufo9+D/9/oem+qrT1Huvx//etfjYMOOsjIy8szf4dx48YZDz30kPmdhPuMpu8RrmchuCVen//ggw+MAw44wHx//z4QqTW8pe0lWk+sf9mafsfB/v73vxujRo1q1b4Qy+/s99prr5nLq/uELv+wYcOMW2+91aiuro74vQTnQiTRvsfvv//eKCgoCDx/yy23tNjyrz/rchYVFRlut9vo0aOHMWnSJOPyyy83M6Slnir/73311VcbBx54oNGrVy/z99XvbeLEica9995reDyekOUMXn7t0Tr++OPN1+sy/OxnPzNqamqa/d7PP/+8ceihhwbWp/7bc845JyTn6uvrjfvvv9/Yd999jezsbPM2efJkc99ujeDtNSsry3C5XObP77zzjvn8nj17zOXUx3Q/Cddz9Oqrr5q/j+akZrJmkGbD+eef32wbCf5O9DN+/etfm7mg26Tui19++WXI64P3lW3btpn/XteHfs7pp59u7NixI+T1rflOwvWWBd+C96FwN/+2dPfdd5v7gy6/7t+6/kaOHGncfPPNRlVVVcTfY9OmTeb3GO33UFdeeWXg35SVlbXq+wRSGcURbF0cqfHjxwee++1vf9vs9UOGDGn2B0kPaH/0ox9F/KM1YsQIY+fOnYHPePnllw2Hw9HsdcGfHak4Cv58/wGZHqj369cv7GfrAcHrr78eeK+//e1vEZdT/5j63X777RFfN3Xq1LDrMniZ9TP1s1uzTMF/9JuuX71pEdp0aFIkH330UeDfnXTSSeaBsf/+T3/602bFkRa7wetOi6OXXnqpxc/RA0T/vwl3wBfuoLU1B9U//vGPI673M844o12KIy1u9KCp6T4QrjhqzfYST3GkhVG4fxdpX4jld1Z6kBtp2X74wx8adXV1HVIcKW1c8D9fWloatTjS7VsPYiMt68qVK1tdHOkBfWuHC/sf18aW7t27N3u9HlAH+8lPftLi52thpEVepNddd911La7b4O1VG1W0yNGfTzvtNPN5LYL0vh7I60F8uOJIi7tIy6DvGTwMOPg7CZdBWmAFF5bB+4oWHk1ff/bZZ4f8Pq35TtqrONJGuUivmTZtWshyRfrbEun3aJoJuv8CXR3D6mBbdXV18swzz8hXX30VeGzs2LHNXrd69Wo5++yz5d///rf87W9/k759+8o///lPeeGFF8zndTYfHZL16quvmicLq+XLl8tNN91k/uz1euXKK68MDA857bTTzPe6/PLLZfHixS0u55YtW+SBBx6Q//73v4H3vOSSSwInK//4xz82h/Y8/vjj5snhHo9HfvKTnwSGTr3++uvm/91ut3ny8nvvvSfPPfecXHPNNeaJ5H7+1xUWFsqzzz4rs2fPNn/fn//859K7d++oy6ifdeGFF5qfrX7xi1/IW2+9ZS6n0sf1+XDDAnX96nNvvvmmHH744eZjOhzuz3/+s8Q6pO7UU0+Vo48+WvLy8sz7L7/8sjQ0NJg/6/o/8MADzWU788wzzSFlxx57rBx88MFy+umnyymnnBL1c5YtWxb4eejQoVFfq+s1+KTxadOmhX3dSy+9ZK5jpcP09Hf517/+JQcccID52D/+8Q/zFq+NGzdKv379zO9Vv5cTTzwx4mtbs73o9qVDypoOMdOb/k6R6L5w7bXXBu7/6Ec/MveFq666qlX7Qks+//xzueOOO8yfdZvViVZ039DvWenyPfjgg9JRdPvy++6776KewK7Demtqasyfr7jiCnM967r7zW9+Y26but3ocE9d5gkTJoQMF/Wva/9+efPNN5vbjv6uOmnEK6+8IlOmTAkMhQo3scGePXukuLjY3Ef860w98cQTgZ/1ub/+9a/mzzpBgn53uv3oNnvkkUcGZm57+OGHzeVXuu1qFurv4h96qsNZP/vss5jWpX/Is26POvzVP6TurLPOkqysrLD/5qijjjKXX/chXQ+6PnS79edopEz5/vvv5Xe/+5253vr3728+phMfvPPOO2Ffr0MmdV967LHHJD093XxM/x6Ul5cHXtOa70S/P/0edai33+9///vA93vSSSdFfV63D6UZrX/L9LvRz3rjjTdkxowZ5nNz5syRefPmhf09dPtr6fdomndLly4N+15Al5Lo6gxIlgkZ9t9/f7Nnoenrg3tN/E444YSwJ6l+/fXXgcd1mIr2MH322WeBx3SIhbay+ukwp+BWwnCte08++WTIZ+uwB38vlL6f/0RvvWnPif/f+XtD/D1cOsxl9uzZRnl5edh15F8W7R3QoXlNh2OEW5f+ZX7llVcCj+lwrGB63/+cDntRwS2i2mPg9+mnnwYeP/HEE42W6PelLcL6em2p1aE3wb+z3oInWnjuueeMVatWNZuQQSd0+Ne//hX1s37xi18E3jNcr1ZL21e4HofgIYC///3vA9+jDv3zP37cccfF3XMUqScuXM9Ra7eXaMsTqecoeF/Q3qzglnndz8LtC7H8zjoJh/+xm266KbA+9bv1Pz5mzBijrVrqOVq6dGnId71+/fqIPUc6dNH/mA6h1CFObZ2QQXtPdVvSPNDheU23ueBe2+DHFy1aFHhce7v9j/uHywVvnzpcOJLgXj8doupf78G90ZdeemlMPUe6b/fu3TvQm+F/TvfV4PUZ3HOk2ajD2bQnJVyvnOajX/B7BE/eoqMHgr+XcPuKP8fU9OnTA48HD8WL5TuJd0KGJUuWmPut9oiH671/+OGH2/x7qGXLlgWe0xwEujp3ooszING0xUx7DnQ6Ym0dbeq4445r9ti3334b+NnfGqjGjBkj2dnZUl1dLbt27ZJt27aZPSN+++67r6SlpYW0NLc05fTxxx8fcn/VqlWBXqjNmzfLD3/4w6g9HRdccIHZ+6DLdMQRR5iPaS/CIYccYvZoaSu10t4bXZYNGzaYy6WtwkOGDDF7c7T1VU/MjSTS+lCTJ0+WBQsWNHudny6HX/fu3QM/t2bK4vfff99sEfa3Gvt7jLR3zt+zp623/pZXbXUOR1tg/a2wrdHStO/auq+9KX6LFi0yewqbCl4f4Z5v2mPVVjohQGsnkGjt9tIWwfuC9oZo71TwdvLxxx9LPILX51133WXemtJe3Y6i+06waJMvzJw50+xd2LFjh7le9aa90Lr/aM+cbsOtMX/+fLNn0t9rG064fSk/Pz+kR6rpvqfLHrw+w+WgX/DrNEvbYzvWLNZtUb9D7blU++23X8T9VHsldXvVfS2SSJkSawa19Pq2fidtsW7dOjnooIPMnsCO+r25zAXshmF1sO1sdR999JE5lEf/EOiQhOA/DsH8s1C1h7ZcQLCtn+8fwqZFgx506vUq9MBCizcd0qEHHPrH0X/AqsNY3n77bTn33HPNIk+LRh0apEMG9XVt/WPe0u+sB4R+wQfLrfmD7C+AlA6l8Q9jCx4ip8Nyws0wqMNPYpl9qUePHoGftfCNJngWOL2FG67ZWuGGIuqBYDAddhRNLNtQa7eX9tbSdhLr7xyJDrPUIbUdIbi4Ky0tNYe5RqLFszYaXH/99eY2ovmj25UOw9ICI3jbjkaHPvoPwrWA0aFVmm863NYveNbGcPtdW/a9zphpUxtsgreL4NlFw617f2Gkw9Wefvpp+d///hcy7DbcemhLBrX0+rZ+J22hv6e/MNJGLb0mkn7Wdddd126/d3DeBecg0FVRHMF2/FMM68Vf9RyhSOPXox20BfeiaCuh35IlS8wWd/8fHh3TrwdJfvrHO/gg75NPPmlxeZt+vo7/9j+m760He3snVwnc6uvr5fbbbw8510aLnIULF0pFRYXcf//95nO6rHow5n+dTkGs5xN8/fXX5vkS2prt76GKNG492vpoej9a71Os9HfUcfwt0QMHPTiJl04BHtx71x6C14eeG9D0e9SbFqhNeyK0t8F/8KXnRrTUGxJLUd7a7SX4fVt7oKc9kX5ffvllyL4Q6ZyUWH7n4PXpnwa66U0P0jMyMqS9lZWVmecG+p1xxhlRX6/LMnDgQPntb39rHsxqsafnTPkFb9tOZ+Of6qbrOri36u677zYbfzTf/D2q8Qhen3puWGtep8VzuPXuPycpFrq9+M/X0yI9Us9v0/Wgr9NCJFKvekeL9TuJ9v229HzwZ+k5qdojqZ/V9LyheATn3ahRo9rtfYFkxbA6oA30j6+e9Kr+3//7f+bBlrao3XbbbSEHR3rwqEPp9CRfPelXT4zXP9o6wYOe7NvSkLpwunXrZv6x1QN+PXA+4YQTzBZWHVKmQyy0ANMDKy28Bg0aZA7X2rRpk3kCtS6HthAGn0zvb0XXyQz0PfSAQodRadEVfN2naK3t2tugLd96AKv/5tJLLzVPgtdl9L+Hrh9dhvaivVz+3ixdxzoEJ9g333xjtuAqbT0++eST4/o8Lab9tGjQHrZ46XbgnwBB30+HWekQOB2OuXLlSvOAVL/rWbNmBQpj7W3QE6l1G9TJJPRk6qa9KvFo7fbibwDYuXOnuV1rz5Ie7Gsvlf4O4eiwKJ3QRA/o/PvCOeecYx44RxpSF8vvrM/r5ABKJ3nQZdMGEN1OdF/RSU10Gf2TDGjvof/g+7zzzoupJ1HXg/Y+a8GoRY2eKO9vwdfPCJ54IhzdJnX71MkxdKILLQJ1mGjw+4dr4deJCfRke23U0R5K/azgA3H9PXTfiDSZQCz0u/FvnzqpgmaCri/dz/VEfl1+/Xzdjv0TamhPifZaaIbodqRFrL6HDs09//zzY14GvYaUFuS6HehQwEiC14NOJKEFgvZ46DXNOlus30nw96vrVYcU6s1//bFozwd/lm6D2uOvDQ06GUl7CR6qGJyDQJeV6JOegERP5d3S65tey0fpRAs6zXK8U3mPHTs27Oe0dDX2aFN5Nz1x+8ILL4z4Gj1p+bvvvjNfF20qXj1B2n+SdqR1o1Not2Uq7+Bpnptemyea4EkXwl25XU/O9l8rRX/PiooKI17+ySXCndQfbt3HO5V30/Wj19Vq+rxenyR4W4h0naNwwm1nrd1elF7Dqulr/PtXrFN5R9oXYvmdW5rKu+n+H89U3pFuOjV808kvwp1Qr9PBR3uf4CmTdftu+rx/O9JJLppmi97Xa+yEW5+RtsNIkz4EL3ukjNHp0aPlR9NlaM2EDNGEm5BBJ3DQ64M1/dzgiT6C94NIkxxE2m4jZXK494n1OwmeMCT41prn9W+BTp4S7fdu6+/hp9ci809aBNgBw+qANtAeoeeff95sOdUTyXNycszeIx1eoi2V2iMU3NqnvRY6/bcOSdCWPR2ipf/eP3W1f9hIaw0YMMBszfvVr34lI0aMkMzMTLPXR3/W1njt1fJPSaututpyqSfka+u0tjjq0EJtsdYeAf9QJ512W3u7/OdKaI+BtvLrv9cW8mgnlysdzqG9VdoDpe+v/16HFervrkPytIervejQKH/PnQr33trDpicqK+118LeAx8PfO6XDJ7Vnp73OGdChjHo+j65j3T70+9VtQ1uC/dOh+8+5uPHGG831qz0Hhx12mPkdBg/djFdrtxf16KOPmufH6PfcWjp9t/aa6D4QvC9E6tmL9XfW4aQ6LbwOEdXeTJ0ARbdjbWXXIWzBvbvtkQO632rrvfae6nT62oPSmskvdOiiTuGtvZ7aq6rrWde39tzqhBi6nvx+9rOfmecm6XYRPMRKaf7o1Nl6XpvmwOjRo80JQXR52oP2puk5mU23T91O/Bmnj2nvjm6vujyaRbos2iOmPcjai6HTUnckXX/a06o5pMup26Su39ZeEqA9xfqdaG/bfffdZ27Twef+tOZ5/S60R1Q/U/cPfY32rEY7PysWOtmG9sKrtvT8AanIoRVSohcC6Op0Nwt33odeE8R/roUO1YplxjR0Pj0PSw/49PwQHTqk10ZB+7j11lsDhYueL8SBGJB4mnP33nuvWWyuWbPGbAgEujp6joBOoC3deuFRHXOu5wVp6/Ivf/nLQGGkLc3jx49P9GKiBdqj5p8FSicsaMsMXACQCjTf/Bff1dyjMIJdMCED0Al0hiGdmjfc9Lw6BEWHrjQdLoPkpEMZ9QYAXZkWQy1dtgDoijgaAzqBnqehMz/peHA9R0HPT9LZl37xi1+YvUg6vA4AAACJxTlHAAAAAEDPEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFUXI5//zzxeFwNLtNnz498Bq9/9prr0myuPPOO+Wggw6S7OxsKSwsTPTiAOgAqZZNa9eulQsvvFAGDx4sWVlZUlpaKrNmzZL6+vpELxoAG2eTOuGEE2TAgAGSmZkpvXv3lnPPPVc2btyY6MVCEHfwHSSe7tBPPfVUyGMZGRmSrPRg47TTTpMDDzxQ/vKXvyR6cQB0kFTKpuXLl4vP55MnnnhChg4dKkuWLJGLL75Yqqqq5L777kv04gGwaTapadOmyU033WQWRhs2bJBrr71WTj31VJk3b16iFw170XOUZHSH7tWrV8itqKjIfG7QoEHm/0866SSzJcR//7vvvpOZM2dKSUmJ5ObmyqRJk2T27Nkh76uvveOOO+TMM8+UnJwc6du3r/zhD38Iec3u3bvloosukuLiYsnPz5fDDjtMFi9eHHV5b7vtNrnqqqtk7Nix7bwmACSTVMom/8HSUUcdJUOGDDFbavUA5JVXXumANQMgkVIpm5QeMx1wwAEycOBAc+TNDTfcIJ9++ql4PJ52XjNoK4qjFPL555+b/9c/+ps2bQrcr6yslBkzZsh7770nixYtMg8Mjj/+eCkrKwv59/fee6+MHz/efI3ujFdccYW8++67gee1B2jr1q3y9ttvy4IFC2TfffeVww8/XHbu3NnJvymAVJIK2VReXi7dunVrt98ZQPJL9mzS1z333HNmkZSWltauvzviYCBpnHfeeYbL5TJycnJCbnfeeWfgNfqVvfrqqy2+1+jRo41HHnkkcH/gwIHG9OnTQ15zxhlnGMccc4z584cffmjk5+cbtbW1Ia8pLS01nnjiiRY/76mnnjIKCgpa9XsCSC2pnE1q5cqV5ns8+eSTrXo9gNSQqtl03XXXGdnZ2eayHXDAAcb27dtb/Tuj43HOURKORX388cdDHmuptVNbQG699Vb597//bbaMNDQ0SE1NTbMWED0vqOn9hx56yPxZu4H1fbp37x7yGn0f7X4GYG+pmk06pl9bhbWFV887AtC1pGI2/epXvzInjVm3bp15esKPf/xjefPNN82hf0g8iqMko+Na9QTiWOhYeu3m1RON9d/q7Ex6cl8sMzPpDq4nB86dO7fZc8xCByAVs0lngNIDJx2y8uSTT8a07ABSQypmU48ePczbsGHDZOTIkdK/f3/zvKOmxRgSg+IoxeiYVK/XG/LYxx9/bE5nqScc+ndYncq2Kd3xmt7XnVLpONnNmzeL2+0OnLAIAKmaTdpjpIXRfvvtZ55v4HRyii1gR8mWTU3pzJqqrq6uze+B9kVxlGR059CdLZjueNrCoHQH1BMIp06das7QojOy7LPPPuYsTHoyoXbJ/vrXvw7sbE3D4J577pETTzzRbDF58cUXzS5ldcQRR5gtFvqcvkZbM7TVVZ/X8Nh///3DLq92QesJhfp/DZ8vv/zSfFxbYnQGGABdQyplkxZGhx56qDkblLYMb9u2LfCczmQFoOtIpWz67LPPzEkhfvCDH5jLocPv9LP1Wmz0GiWRTjivCTGcWKhfSdPb8OHDA6954403jKFDhxput9s8WVCtWbPGmDZtmpGVlWX079/fePTRR41DDjnEuOKKKwL/Tl972223Gaeddpp5EmCvXr2Mhx9+OOTz9+zZY1x22WVGnz59jLS0NPO9zj77bKOsrCzmZZ4zZ06HrCMAnS/VskkniAm3vPzJA7qWVMumr776yvzcbt26GRkZGcagQYOMn//858b69es7bB0hdg79T6ILNHQ8bTm58sorzRsAJAuyCUAyIpvsi0HYAAAAAEBxBAAAAAAWhtUBAAAAAD1HAAAAAGChOEpxOi+/TkPpn0I7kfRq0yUlJebyvPbaa4leHAAJlixZoBeA1Yss6rWO/Fe3B2BfZBOioThKMnq9oGOPPVays7OlZ8+e8qtf/UoaGho6dRnuvvtumTRpkuTl5ZnLoHP4r1ixIuq/WbZsmdx2223yxBNPyKZNm+SYY46J6TP1WkmXXXaZDB8+3LxS9YABA+Tyyy+X8vLyOH8bAO1B90e9oKpeJ2TChAkJWQa9LoleO0SvPp+Tk2MuxzPPPBP13+zZs0cuvfRSuf76683rH/30pz+Naxl+/vOfmwdWHMgAyYFsspBN7YeLwCYRvYiqFkZ6kcJ58+aZRcaPf/xj8+rOd911V6ctxwcffCC//OUvzQJJC7ObbrpJjjrqKFm6dKm504ejFzJTM2fONHfOWOmF0/SmF2wcNWqUrFu3ztzR9bGXXnop7t8JQPx+8pOfmBcx/OqrrxLy+d26dZObb75ZRowYIenp6fLmm2/KBRdcYDbiHH300REbnDwej5mtvXv3juvzX331Vfn000+lT58+cb0PgPZFNpFN7aoN10ZC0MW/zjrrrMDFwR544IFmFxGLxVtvvWU4nU5j8+bNgccef/xxIz8/36irqwv7b/RCZvo1vvzyy8ahhx5qXtBs3Lhxxrx584z2snXrVvMzPvjgg7DPz5o1q0MutPjPf/7TSE9PNzweT7u8H2AX7Z1NTff38ePHt+q1mgV/+tOfjBNPPNHMJr0Q4+uvv260p4kTJxq33HJLqy8Gq5nZFnqRxr59+xpLliwxLw754IMPxrnkgP2QTRayKbkxrC4OV199tXz88cfyxhtvyLvvvisffvihLFy4MOQ12vuRm5sb9eb3ySefyNixY83zdvy0xUG7Xr/55puoy6ItFtdee6157tGwYcPkzDPPDAzH09aJlpYhWs+Uf2ibtoyEo5/71FNPmT9rb5fe1HPPPdfi5+o6i/a5+fn54nbTwQkkMpviocNtTz/9dLNFd8aMGXL22Webw2j9WloGXc5w9PjmvffeM4f8HnzwwWFfc8YZZ8js2bPNn+fPn29mk47v1/XR0udqfvn5fD4599xzzWHOo0ePbpf1AtgR2WQhm5IbR51tVFFRIU8//bQ8//zzcvjhh5uPaYHQtEvz9ttvN4uH1ti8eXNIYaT89/W5aPQztGvWv8PrTrJq1Sqzi1eXqaUJGyIVPrrj6dWhp06dKmPGjAn7Gt1ZdZyt0iGBfieccIJMmTIl6uf27ds37OPbt2+XO+64I+4xuIDddEQ2xeP88883G2uUNsL8/ve/Nw8Gpk+fbj7WUjZpA0nTRhPNjbq6OnG5XPLYY4/JkUceGfbf6vmL3bt3N38uLi4O5JOeG9DS5wZn8e9+9zuzkUbPbQDQNmRTI7IpuVEctdHq1avNsaKTJ08OPFZQUGBOKBBMx5vqraONGzcu8LN/7OrWrVvN4kh3nKFDh7bpffXcoyVLlshHH30U87/VCR30FivtKdNCT8890hnwAHSNbNJzFvWAQrPJL9Zs0kzRg4fKykqzdVZboocMGSKHHnpoq99DD0xa+7kLFiyQhx9+2Gzdbsv5lAAsZFPLyKbkwLC6DhZL97C2HGzZsiXk3/vvB/fIhKOTNvj5dxLt9YlnWJ3OoqInFc6ZM0f69esX8+/elmF12rKkrTYaMnqCYfDvBaD9dNbQlab7sOaTP5vaMnRFp7zVgwedDeqaa66RU0891ZxhMxaxDF3R1+oBk86gqQ1NetMJY/SzBw0aFNe6AdAc2UQ2JRo9R22krQG6Y33++efmhunvUv32229DxpjG0j184IEHyp133mlu7P5WEx2Tq60Z2ovSVrEOq9PxsjqtthYnc+fOlcGDB7fpc2MdVqc9RnqOlU7HqeORMzMz2/S5gJ11RDZ1pFiHrjSlBzM6jCUWsQxd0fH8RxxxRMhzmlP6uM5GBaB1yKaWkU3JgeKojbRn47zzzjNPgtPCQouZWbNmmS0Hwd2bsXQP63TZWgTphn3PPfeY5xndcsst5tA2LRjaKtZhdfp5Oib49ddfN39P//lO2v2tXb4dMaxOCyP9/aurq+XZZ5817+vNPx5Xx+8CSEw2KT2HUYeLaB7U1NQE/oBrZunUtW0VSzZpK6wePJSWlpoHHW+99ZZ5LZHHH388ps+MZeiKnhfgPzfATw/wtDe/6XAgAJGRTS0jm5IDxVEcHnjgAbNb9bjjjjNbEK677jr5/vvv29zjoQWADmP7xS9+YfYi6RhYDRJtRelM/p256ThZPXFST2DsCDpmVq9RoJoGw5o1a+giBhKYTeqiiy4yr4HmN3HixE7fP6uqquSSSy6R9evXmwcRek6lNqbozE8Akh/ZhFTg0Pm8E70QXYXuHDpM7P7775cLL7ww0YsDACayCUAyIpuQjOg5isOiRYtk+fLl5swrOm7W38Mzc+bMRC8aABsjmwAkI7IJqYDiKE733XefeaEvHde63377mbOH9OjRI9GLBcDmyCYAyYhsQrJjWB0AAAAAcJ0jAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAi1vaUa3HJzsrPeL1GWJnaS6HdMtNk3R3aO25u8ojFbVesbucDJcU5bjF4XAEHmvwGrKjol7qvfbedpwOkaKcNMnOcCV6UboUsslCNkVHNkVGNnUMsslCNkVHNnVuNrVLcfR1WYXc/+8yeX/JTnNHh7UhHz2+u1x73ACZu3S3PPfRJvlmfVWiFytplJZkyWkHlMgZB5bIvf9aJ28t2i67qxsSvVhJwe10yMEjC+Wy6QNk6vDCRC9OSiObmiOboiObIiOb2g/Z1BzZFB3Z1HnZ5DAMI66S88u1FXLqg4tlTw2VfTjZ6U6prif4IsnNdEklrUJhZbgd8rdfjpFpo7slelFSEtkUHdkUHdkUGdkUH7IpOrIpOrKp47Mp7uLoxPu+lHnflps/u9wuySnME4fD3qcy+Xw+qdq9R3ze0J07Kzdb0rMydLWLfRniqfNI9Z7KkEe1qzi3KF+cLnsP2dDdUddNQ73HvD+kZ5Z8csekkK50tA7Z1PpsGt03S/p3zxA7b2b6l3DrHo8sXBvaUk02Wcim9kM2NcdxUzQcN3V2NsU1rG7bnnr5ZKW1g6dlpMk+k8aaOzrE/JKWf7LY/NJUcf9e0qu0f6IXK2lsX79FNq0qC9zfZ9IYycjOTOgyJdMfie8WLJXaqhpZvbVGlm2oklH9chO9WCmFbGp9Nl10aE+5ZkbfRC9W0nj2421y5+vrA/fJpkZkU/zIpsg4boqO46bOy6a4miq+31FrtrapvO6F7OBB3Olp5s2voKR7Qpcn2RT0aBwTmpWfww4exOl0SkHPxi7hNdtqE7o8qYhsan02HTuhKKHLk2yOGlsQ+JlsCkU2xY9siozjpug4buq8bIqrOPIEzZChC4Ymgnr0WD+hHEHrg3XTXPA6aWgyzAAtI5tan02ZaayfYG6yKSqyKT5kUws4boqI46bOyybWLgAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAIuKWFNc7xyFT+rpkeHenjOjmlH75DnE6HIHnr55dK4u3+sSO3E6R8T2dMrbYJSN7OKU42yFFmQ7JcotUe0TW7fHJJxu88ubKBqluENs5crBLxhW7pLTIId2yHJKf7hDddHTdbKjwyZdbfPKvVQ2yrdpI9KIiBZFNaCuyCR2JbIqM46bo7JJNKV8cHTnELeeNTUv0YiSlIYVOueewzLDPFbhExmW6ZFxPl5w83C03za2T1btTe2OO1blj0qRvXvPO03SXSGGmS0YXu+TkEW65/aM6mb/Rnn8o0HZkE9qKbEJHIpsi47gpOrtkU5caVlfXYEhtg7021NbyeA1Zut0rn27wysaK0A22ONsptx2cIWldamtoHZ9h7G3tsNbNuvLQdZPldsj1B2SYrUlAW5FNiBXZhM5ANkXGcZN9synle46+2eaV+z/zyYodPllTbsi9h2XIhBJXohcraWyv9skLSxvkv2sapMrT+Pg5Y9xywbj0wP0+uU6Z1Nsl8zZ4xS6eXOQxg29nbejjB/d3yawfZgTuF2Y6ZHCBQ1bu4g8IWo9sQluRTehIZFN0HDdFZpdsSvniaMHm1O2262jr9/jkvH/VSm2Y/fbZJQ1ybKlbeuY0lvYD8h0yb4PYxkfrwwfa/773SkW9IXnpjWOw6+2TfWgnZBPaimxCRyKbIuO4KTq7ZFMKd3qhJXqyYLgd3G9nbWhFXxnUQmJnP+jnCtnBtfv4+4rUbP0A0HWQTUDH4ripbbpaNqV8zxHapkeWQ0oLnSFjSHX8qB2dPy5NBuY7JMPtkD65Dumf37hetlT55I6P6sSXuvs4gBRFNgHJg+Mm+2QTxZEN6QmENx6ULmmuxir//bVeWZ/CVX48Jui0nT2bj7deudMnd39SJ+vK7bleACQW2QQkB46b7JVNDKuzmZw0kbsPDT35Uk/OfGB+fUKXKxnt080pTx6TKccNpQ0BQPIgm4DOw3GT/bIptZceMXcJ3z0tw5zH32/RZq/8+n91UmfPnmHTlbPrzP9nu0V65Trk2KFuOXGYdQ0It9Mhl++fJku2eWVtireEAEgtZBOQWBw32TOb6DmyiUEFDnnkqNAdfPbaBrlhbp3U2PAqz5FOxNQLuj3yhUc+/r5xpbicDvlhf6Y5BZAYZBPQ+Thusm820XNkA+N7WhcrC55J5LklHvnrV0yzEsn2mtDWjm5ZjesOABKFbAI6HsdN9s4miqMubtpAl1x3QLqk7z2JsMFnyEPz6+Xt1TbuDxaRY4a4RC8KPm+9N+Qib2pUD6dMGxi6a2y06UmXADoX2QQkFsdN4dkpm1K+OJrSxynnjLHGOaqBBaEjBa+YlC5VnsYv6LL/WuMk7WCfIofcdFC6OB2N1fu2akMm93GZt6bmlnnlgzJ77PyDC51yyog08XgNKdtjmOtFV1OvHEezbUgvbPbeWvrQERuyCW1BNqGjkU2RcdwUmZ2yKeWLo8IMh4zqEXlcY9MvzE6y0xwhO7jqnes0b+GsMU+cs8dO7qfTcpYW6S388ztqDHO+/p21nb1kSHVkE+JBNqGjkE2RcdzUMjtkU8oXR0BbvP1dg9myoX8g+uQ5pCDDYc66Uu+1roC9drdP5m/yyew1DVGvlg0A7YlsApCM3rZRNqV8cfTOGq+8s6Y60YuRlBZv9cnhz7NuIrX2rCnXLt/U7fZFciOb0BZkEzoa2RQZx02R2Smb7Nt3CgAAAABBKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAQDsURy6nI/CzYRjxvFXXFLRKWD+hgtcH66a54HUSvJ+hdcimFgStEo+X9RPMZ/gCP7PtNEc2xYdsagHHTRFx3NR52RRXcdSnKCPwc+XOPWL4+LL8fF6fNHg8gfsVO3YndHmSTdXuisDPNRVV0lDfuK7sTnfwih3lYfcztA7Z1Pps+nDFnoQuT7L5bFVl4GeyKRTZFD+yKTKOm6LjuKnzsslhxFl+HnXnQvlynfWFudPdkpaRIWL3xiRDpL6mTrwNDSEPZ+RkitPpsvf6MUQMn09qq2pCHna6XJKelSEOu7dEGiIN9fXiqbNCr3dhuiz67QHitPt6aQOyqfXZtE9JpmRlOG2/emo9Plm5uVaCj1fJpr3IpnZDNoXBcVNkHDd1ejbFXRy99/UOOfvRJSF/TIDW0m2XbSeyh88bJmdO7Z3oxUhJZBPiQTZFRza1HdmEeJBNHZ9NcU/IsHRDFV8S2oxtJ7ol31clehFSFtmEeLDtREc2tR3ZhHiw7XR8NsXVc6T/dN8bPpMNu+rM+9379pS87oXicNi7i0+7P3dv3Sm7t+wIPNYj1y2XHd1bBnTPMKt+u9KtbXO5Rx6bvUnKdtQHHtftplvvYnG67D2Bou5TOq54W9km8352hlOW3X+QZKW7Er1oKYVsan02udPcUjK4nzk8w+48dfWyde1Gqa+1thtFNlnIpvZBNoVHNkVHNnVuNrnb/C9FZOXm6sAOnluUL332GRjP23UputHqyYTeBq95/9cn9ZejxhYmerGSxoDu6XLWYysDAThwzFDb/3Hwy+tWYAah/pGorvPJ59/tkYNHFiV6sVIK2dT6bOozbKAUFHdL9GIljfTMDFn95XLzZ7IpFNkUP7IpMrIpOrKp87IprnJzd3XjiXMZOVnxvFWX5HS7Qk54RqMBPTJCth128FCZQfvT7qrQE1TRMrKp9dkUvK1BJD2rMavJpubIpviQTdGRTZGRTZ2XTXEVR8ED8viKomMbDuVgi4kqOPSM4As/oFXIpliwhoKR1dGRTfEhm2LBGgpGNnVeNtl7oCIAAAAA7EVxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALC4pYvJdIk8OSNT+uaF1n1nvV4jW6qMhC0Xktuk3k45YpBbRhU7pSjTYT5WXmvIxkpDvt7mk9e/9Uh5XaKXEqmMbGrkdoqM7+mUscUuGdnDKcXZDnO/y3KLVHtE1u3xyScbvPLmygapbhBbI5vQ0cimUD2zHTJzmFsmlDilT65TstNEvD6R3XWGrNrlk7nrvDK3zCs++60a22RTlyuOfjoxrdkODkSSkyZyy9QMmdzH1ey5rFyH9MoV2beXSxZu9kr5Nl9ClhFdA9nUaEihU+45LDPscwUukXGZLhnX0yUnD3fLTXPrZPVu+x2FkE3oLGRTo8m9nTLrhxmS6bYO9oMbdErcDinJccrUfm6ZUeqVG+fWiceGu16ODbKpS+0N+/VyysxhaYleDKQIDbt7Dgvdweu9hny3yyefbvDKsu1eqai330EZ2h/ZFJnHa8jS7V5zn9tYEfqHtDjbKbcdnCFpXeovVcvIJnQWsqmRyyFy3YGhhdGeOkM+2+iV5Tu8Ia+d2Mslpwzvcv0LLXLbJJvcXamSvXZKuvlzZb0h+tXkpYdW/kCwc8akyYjujTu4tnLc/1m9bA4aRuB0iEzo6ZTNlam/syMxyKbwtlf75IWlDfLfNQ1S5Wl8/JwxbrlgnLW+lA5rmdTbJfM2hB6cdGVkEzoD2RRqSKE1vDe4MLrgzRrZvXdo2Plj0+TcsY2F5NieLnlhmb3G/Z5jk2zqMu1xl+6fLj1zrF/nkS/qpaoLVK7o2DHWJw1rbBvYWWPI7R/VhezgSscUL9zik+01bE9oG7KpufV7fHLev2rl1W9DCyP17JIG2VoV2oM0IN8+B2xkEzoL2RSq6RC5TZW+QGGkVuwMfUGlx17rK9NG2dQleo6m9nPJUYOtX+V/ZQ0ye61XLhhHNzEiG1filNygFjJtle6T55SpfV1SkusQj1dkzW6ffFDmTekdHIlFNoXX0iQLO2sN6ZnTeL+ySQHVlZFN6AxkU3Pf79HJBHxmb7UaWuSUaQNdMm+9VwoyHHJSk2F07621V6/ROBtlU8oXRwUZIldNsrqFd9UY8tDn9YleJKSA4d1CO02n9HHKcUObnyB+8QRD/rLYIy8ut1cIIn5kU9v0yHJIaWHj/ukzDPlyi32G1JFN6GhkU3heQ+TOj+vl9oMzpHuWQ1xOhznxQFN6Ts2Ti+pl/sbUnGygrYbbKJtSfljdlZPSpSjLqmQfmF+fstMGonMVBo0r9p/4HU6ayyE/3zddZpQ2n5UFiIZsip1OvHDjQenmfuf3/lqvrK9I7VbIWJBN6GhkU2TLd/jkkv/UmpPEhKOTD7zwjceczttuCm2UTSldHB0xyCUHD7A6v95Z3WCrE3YRH7eeMdjEnHUNcvqrNXLSy9Xy0vLQcTwXjk83TzIEWoNsatvJ4XcfmiETShr/oH6zzWsevNkJ2YSORDa1PNzwr8dlyqgersB1e+YHzVaX7nLIxRPT5bHpmVKSY68dz22jbHKmcgujnkyotlT55NEv7PUHFPGpbnIipddnyEPz62VHjSF76kSeWOSRXbVGSItJaWGK7uXoVGRT24bSPXRkpjk9rt+izV65fk6d1Nns2I1sQkchm6Lrm6fD6NIlJ83an1bv9sm5/6oxr2f0y3fq5J5PGrvY+uc75fK969Iuqm2UTSl7zlG6q3HKycIMhzx7QlbI87lNttk/Ts8UwxB5ZEG9zLFhdyhCbWgyTEdnpAk+6VtnW9GZaop0epa98jN0e7PP8B60DdkUm0EFDrPHyD9rlpq9tkHu/bReGuw1pN9ENqGjkE3R6eQL2jPk99/VobNpvrPGK5fub0j23uJp/95O87o/dsmpDTbKppQtjoJluB2S0cJvYn1BIukp21eG9rRkW2jQ56aJNN2F85tc7yG4RQRoDbIpuvE9rYu8Bl9b5bklHvnrVzaanq4JsgmdgWxqrnjveVh+4fYqo8kws7x03f/EFpbYKJtssskDodaWGyFXvNY/FEcPaWztmFjilH75jbuHzuizZndq7uRAsrbS/nZaY2HU4DPkvk/rbF0YKbIJSIyt1aH7kU51nh1UQB412BUYcqeqPIatJrNYa6NsStmeI+3qPPz56ojPP3dCpvTaO1e9Ouv1GtnS5EJVsLc/LPDIQ0c4zek61TVT0uWYUp/ZRT66R2i7wf997UnBjmEkAtnUsn2KHHLTQXqybuOBxrZqQyb3cZm3puaWec1rZ9gF2YSOQDZFpzlz7hgjMFtmaZFTnjkhS77d6ZP8DJER3UOzafaaBnMomZ38wSbZlLLFERCvpdt9cvcn9XLdAenmOGM9UBtTHBp+eo2Vv3/TIG+uSt35+oFko2P2gwsj1TvXad7CWVOuf2LtUxyRTUBizql5cH69XDW58XICOqlAuAabxVu88ucv7dfLvdQm2URxBFvTk0yXba+VU0e4Zb9eLinOcZhjTXX2la+3+eT1lQ2yYodNzrYEkDTIJqDz6aQLX2+rleOGumVCiVP65DnNoXXaM6Lnz6za5TN7mPQ6R6naKxKvOTbIpi5bHJ39hk3OkEPcNlcZ8ugCbQGyXysQOh/ZJLJ4qy/q8B5YyCZ0JrLJsrHSkCdt2CsUi81dPJuYkAEAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOOomR6AVIMgZrJCrWDoBkRDYB6OrZFFdxlJXW+M8bPA3tsTxdiuFr/Kp2VbF+glXVegM/N9Szbpry1nsCP2eluxK6LKmIbGp9NjV4Grc1iHgbyKZoyKb4kE3RkU2RkU2dl01xFUdDe2VLdrr1FuXbdkrlrj1iGLQr6TrYs32XNAR9UY++u1l2VLKjq4oarzz8zqbA/brqGtm5aVtIKNpZTUWV7Ny83fzZ4RAZNyA30YuUcsim1mfT1rUbQ+7bmbehQbas3RC4TzaFIpviRzaFRzZFRzZ1bjY5jDj3yp//eZm8Mn9rXAthNw6xL3bj2Bw0rEBeu3ZCohcjJZFNQMchm9qObAKSO5viPufoqhkDJMNt58P96NJcjrAFgl1vTbHtROZyilx3wqBEL0bKIptizyY0YtuJjGyKD9kUHdkUHdtOx2dT3D1H5z22RN7+ckfgflpmujgc9p7nwfD5xFNX3+xxh9MpaRlptu870rGyPm/j2Fk/d3qaOF02H8NuGFJfWxe4u++gPPnPTfsmdJFSFdnUHNkUDdkUFdnUbsim1meTnqNVnJ8mThtHkx6k62kZlbW+Zs+RTdIh2eSO5x9X1jbI+0t2mj87XU4pnThSMnOz41qgrqK6vFK+W7QscD+/R5H0HznEXE92pyG4cVWZ7Ny4LfDYwDH7SF73AnHoYFGbq6+pk9VfLhNPnUcWrq2Qsu21MqBHZqIXK6WQTZGRTZGRTdGRTfEjm1qfTUeOKZB7zhwkmUGTWNiVx2vIXW+slxc+sc6rUWRTx2VTXFvcqs01UtdgdTwVFHdjBw+SXZC7tyXWUjygFwcfQa3Uxf17B+7rdpPfo5AdfK/0rAwp7NUjcH/p+sqELk8qIpsiI5siI5uiI5viRza1PpsuOrSEwihoqOFFh/QM3CebOjab4trq6hoau/hcbpt364UTtNG63HF10nU5wQdjbDvNBW8vwfsZWodsagHZFBHZFB3ZFB+yqfXZlJfF+gmWuXeWQ8W207HZREkOJCHaggAkI7IJnYVtLZSDNRJVe64diiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAxS0p7Mdj0+S8sWmtfv2XW7xyzXt1Yic9sx0yc5hbJpQ4pU+uU7LTRLw+kd11hqza5ZO567wyt8wrPkNs57oD0uXoIS3vAvM3euXGufbabhAfsqllZFNkZBM6CtmEeFxnk2xK6eII0U3u7ZRZP8yQTLcj5HG3U6TE7ZCSHKdM7eeWGaXWRuzxJWxRAdgI2QQASFYpXRytK/fJ/8oaIj4/tqdLijIb//iu2GGfv7Auh8h1B4YefOypM2TZDp8UZIiM6O4KPD6xl0tOGe6WF5ZFXpdd3e5aQ77a6g373Mpd9tlu0D7IpsjIptiQTWhPZBPay+4unE0pXRx9UOY1b+HoH9nnZ2YF7nu8hryywj5/YIcUOkICTg8+LnizRnbv7eU8f2yanBvUta6BaOcDkLXlPrnto/pELwa6CLIpMrIpNmQT2hPZhPaytgtnU5edkOGEfdwhLZNzyryyvcY+g9ebDkPZVOkLHHyoFTtDX1Dpsc+6ARKJbAq9TzYBycHu2QR0iZ6jSNKcIjP3CT3h8MVlHrGT7/cYsrHSZ57orIYWOWXaQJfMW++VggyHnDQ89Kt/b629W4eKsx1yyb5pZot2ndc6YFuw2SfLGVKAdkQ2kU2xIpvQGcgmxKq4C2dTlyyOjhzskqKsxtaPzzd5ZfVue7V+eA2ROz+ul9sPzpDuWQ5xOR1yy9SMZq+rqDfkyUX1Mn9j6m/M8eib55RTRoR2pP5kvMiizV757Sf1tJ6hXZBNZFOsyCZ0BrIJserbhbOpSw6rO3UErR9Kq/dL/lMrS7eHH19c7zXkhW885pS5CE9PCL/3sAzJaDxHHGgzsslCNsWPbEJ7IpvQXiZ2gWzqcj1HB/RxysCCxppPr5eh3Xx2NLWfS64/MF1y0qzWoPJawxzPn793Rqh0l0Munpgu00vdcv2cOtlSlbpVflvo7/v8Nx6zlWN9hSG7ag2zm/iYUrf8aJRbnA5rvQ0ocJrXY/mnjU8KR/zIpkZkU3RkEzoT2YTW2mKTbOpyxdFpI2n9UH3zdKhKunmQoVbv9smV79ZK1d7VcfRglzmdruqf75TL90+Xmz9I3Qt2tcXTXzffNjZWGvKXxR7JdIucPLxxW5rSx5WyOzmSA9lkIZtaRjahM5FNaK2nbZJNXWpY3T5FDplQ0tiPt6XKJ+/bdFiGnuDsP/hQ/13dEDj4UO+s8Up10CxQ+/d2mhdghGVhk1YzPTcCaCuyqRHZFB+yCe2JbEJ7WdiFssnZlVs/Xl3RID57jcYIKG6yUYZbDcGPuZ0OyUsX2wg6Ngurd27oC6qYThhxIJsakU3RkU3oTGQTWstlo2zqMsWRjnk8ZEBj60dlvSH/XpWa3XntYWt16EZ51GC3ZAcNojxqsCsw3t+/EZfbaOTKmGKnPHREhnnuQ9Mdflg3p5wzOvQPxpJtjL9G25BNocim6MgmdBayCbEYY6Ns6jLnHJ083G22MPrpDl5t4318bplXzh1jSNreLbi0yCnPnJAl3wad9Bxs9hr7tRaN7ekybzUewzwBVacOLs52SmmRI3BSof/g7MUUHTeLxCObQpFNLSOb0BnIJsRqrE2yqUsUR9rqOKO08VfxeA15ZUXqfintYUOFIQ/Or5erJqcHDkIKMx0yuU/zuRUXb/HKn7+01wmYwcdaWWkOc2cPZ0eNIbd/VJfS8/Ujccim5sim6MgmdAayCbEybJRNXaI4mjHULbnpjRXrnDJvSn8p7UVPbP56W60cN9QtE0qc0ifPaQZig0/M6Re16tdWXL2WiN3W1ldbrRmydDaVkT2c0i/PIfkZDtGtqLJeZG25Tz7d6JW3vws9WRyIBdkUHtkUGdmEzkA2IVZf2SibukRx9NLyBvMGCTvF4pM2a3ltra+3+cwb0FHIpsjIpsjIJnQ0sglt8bVNsqnLTMgAAAAAAPGgOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAA7VAcORyNPxvxvJENGAZrKFjI6mDVRN1enME7GlqFbGo9sikU2RQd2RQfsqn1fKygyFnNuunQbIqrOOqRmxb4uWZPVVwL0hW/JG+DN3C/poL1E6y2qjrkZ5/Pl9DlSTbB20u3oP0MrUM2RUY2RUc2RUc2xYdsan02LVnfuC9CZOXmmsDPZFPHZpM7nn88uGeWeVuztUaq91RK2TffSV73AnE47T1az/D5pHzrTvEF7eQbV5aJp65e0jMzQpuObMcQT51Htn+/OfCIhuGaL1dIUe8e4nS5xNYMQyp3V0j5tl3m3fwsl0wqzU/0UqUcsik8sikasikqsqldkE2tz6bfvLZeNu2ul37dMsRp42jSDpEt5fXy1/9tDTxGNnVsNjmMOMdU/N8HG+W651bGtRAAwrv62AFyw8zBiV6MlEQ2AR2HbGo7sglI7myKu6ni/EP6yK2nDpHsdHu3eoSTl+mSu380VKYOK0j0oiSlsf1z5eHzhkl3hmY0k+52yKVH95frTxiU6EVJWWRTZGRTdGRTZGRT/MimyMim6MimzsmmuHuO/KrqvPLB0l2ycVedNHjtfaZYmsshA4sz5YcjiiQjzQq/tdtqZN6K3bKnprHL2K5yMl0yuTRfhvfJMe/r9jLv292ycnO1eBrsve3oyIqSgnSZNqqb5GfHNeoVe5FNjcim6MimyMim9kc2NSKboiObOjeb2q04AgAAAIBURp8uAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOEou559/vjgcjma36dOnB16j91977TVJNnV1dTJhwgRz+b788stELw4Am2fToEGDmi3vb3/720QvFgCbZ5P697//LVOmTJGsrCwpKiqSE088MdGLhCDu4DtIPN2hn3rqqZDHMjIyJNldd9110qdPH1m8eHGiFwVAB0jFbLr99tvl4osvDtzPy8tL6PIAaH+plk0vv/yymUt33XWXHHbYYdLQ0CBLlixJ9GIhCD1HSUZ36F69eoXctFXB3xKqTjrpJLMlxH//u+++k5kzZ0pJSYnk5ubKpEmTZPbs2SHvq6+944475Mwzz5ScnBzp27ev/OEPfwh5ze7du+Wiiy6S4uJiyc/PN3fa1hQ7b7/9tvz3v/+V++67rx3XBIBkkorZpMVQ8PLq+wPoWlIpm7QQuuKKK+Tee++Vn//85zJs2DAZNWqUnH766R2wZtBWFEcp5PPPPzf/ry0kmzZtCtyvrKyUGTNmyHvvvSeLFi0yW1GOP/54KSsrC/n3ujOOHz/efM0NN9xg7qDvvvtu4PnTTjtNtm7dahY7CxYskH333VcOP/xw2blzZ8Rl2rJli9kC8swzz0h2dnaH/e4AklcyZpPSYXTdu3eXiRMnmp+hByYA7CPZsmnhwoWyYcMGcTqdZi717t1bjjnmGHqOko2BpHHeeecZLpfLyMnJCbndeeedgdfoV/bqq6+2+F6jR482HnnkkcD9gQMHGtOnTw95zRlnnGEcc8wx5s8ffvihkZ+fb9TW1oa8prS01HjiiSfCfobP5zPf84477jDvr1mzxly+RYsWxfibA0hmqZZN6v777zfmzJljLF682Hj88ceNwsJC46qrrorp9waQ3FItm/7+97+byzNgwADjpZdeMr744gvjzDPPNLp3727s2LEj5t8fHYNzjpLMtGnT5PHHHw95rFu3blH/jbaA3HrrreYJftoyoq2jNTU1zVpADjzwwGb3H3roIfNn7QbW99FW1mD6Ptr9HM4jjzwiFRUVcuONN8b0OwJIPamUTerqq68O/Dxu3DhJT0+Xn/3sZ3L33Xcn9fkIALpuNvl8PvP/N998s5xyyimBXq1+/frJiy++aGYUEo/iKMnouNahQ4fG9G+uvfZas5tXz/nRf6uzn5x66qlSX1/f6vfQHVy7d+fOndvsucLCwrD/5v3335dPPvmk2YHG/vvvL2effbY8/fTTMf0eAJJXKmVTODozlB4ArV27VoYPH97qfwcguaVSNunrlZ5n5KfHUEOGDGlWmCFxKI5STFpamni93pDHPv74Y3M6Sz3h0L/D6gFAU59++mmz+yNHjjR/1nGymzdvFrfbHThhsSW///3v5Te/+U3g/saNG+Xoo4+Wf/zjH+aBCAD7SKZsCkcvMaDj/Hv27Nnm9wCQepIpm/bbbz+zGFqxYoX84Ac/MB/zeDzmZw8cOLDNvyPaF8VREl4vSHe2YLrj9ejRw/xZd0A9gXDq1KnmDqYzsuyzzz7yyiuvmCcT6mwsv/71rwNdt03D4J577jHn09cWE+3C1S5ldcQRR5jdxfqcvkZnUNFiR5/X8NDeoKYGDBgQcl9nfFGlpaVmFzGAriOVskl7tD/77DNzuI3OWKf3r7rqKjnnnHMCs1gB6BpSKZt0RjudpW7WrFnSv39/syDSSR/8kzsgSXTQuUxo44mF+pU0vQ0fPjzwmjfeeMMYOnSo4Xa7zZMF/RMhTJs2zcjKyjL69+9vPProo8YhhxxiXHHFFYF/p6+97bbbjNNOO83Izs42evXqZTz88MMhn79nzx7jsssuM/r06WOkpaWZ73X22WcbZWVlrVp+JmQAuqZUy6YFCxYYU6ZMMQoKCozMzExj5MiRxl133dXsxGkAqS3VsknV19cb11xzjdGzZ08jLy/POOKII4wlS5Z0yPpB2zj0P4ku0NDxtOXkyiuvNG8AkCzIJgDJiGyyL65zBAAAAAAURwAAAABgYVgdAAAAANBzBAAAAAAWiiMAAAAAoDjqGnSO/tdeey3RiyFPPvmkOW+/XmjxoYceSvTiAEgwsglAstELrmo26YWhE+3WW2+VkpKSpMlKWCiOkszll18euILyhAkTErIMemE0vXhZYWGh5OTkmMvxzDPPRP03e/bskUsvvVSuv/562bBhg/z0pz+Naxn0ImkaFhzIAMmBbLKQTUDyWLx4sZx55plm40dWVpaMHDlSHn744U5fjrvvvlsmTZpkXnS6Z8+e5oVhV6xYEfXfLFu2TG677TZ54oknZNOmTXLMMce0+fN1+gD99xRZ7cPdTu+DdvSTn/zEvLr7V199lZDP79atm9x8880yYsQISU9PlzfffFMuuOACc4c/+uijw/6bsrIy8Xg8cuyxx0rv3r3j+vxXX31VPv30U+nTp09c7wOgfZFNZBOQTBYsWGDu/88++6xZIM2bN89sAHG5XGajSGf54IMP5Je//KVZIDU0NMhNN90kRx11lCxdutRsyAnnu+++M/8/c+ZMs6iJhzbWxPseCNLGi8di75WRzzrrrMCVkx944IFmV1huq1mzZhnjx49v1Wv1a/zTn/5knHjiiebVnvVK0K+//rrRniZOnGjccsstYZ976qmnml2dWq8+3Rbr1683+vbta14tWq9O/eCDD8a55ID9kE0WsgmwTzb5XXLJJca0adMiPq8ZoFnw8ssvG4ceeqiZTePGjTPmzZvXbsuwdetW8zM++OCDiDnaNJvaatGiRWY2bdq0yXyfV199NY4lh2JYXRyuvvpq+fjjj+WNN96Qd999Vz788ENZuHBhsyEYubm5UW/tQbtmTz/9dLNFd8aMGXL22WfLzp07A8+3tAy6nOHo8c17771ndg8ffPDBYV9zxhlnyOzZs82f58+fb3YPawuOro+WPve5554LvI/P55Nzzz1XfvWrX8no0aPbZb0AdkQ2WcgmwH7ZVF5ebvYyt0R7oa+99lrz3KNhw4aZw/O018ff49zSMtx1111Rl0FFWg793Keeesr8WXNJb0pzp6XP1XXmV11dLWeddZb84Q9/kF69erX4O6N1GFbXRhUVFfL000/L888/L4cffrj5mG7oTYdb3H777eZO0NHOP/98c8dWusP+/ve/Nw8Gpk+fbj7W0omH+fn5zXbsvn37Sl1dndk9/dhjj8mRRx4Z9t/qON/u3bubPxcXFwd2UD03oKXP1RMR/X73u9+J2+02z20A0DZkUyOyCbBXNumwun/84x/y73//u8XX6mfocFt/I442fKxatcoctqvL1FJGRCp8tDHlyiuvlKlTp8qYMWPCvkaLHD13UgUXNSeccIJMmTIl6udq/vldddVVctBBB5lD89B+KI7aaPXq1eY49smTJwceKygokOHDh4e8TsfC6q2jjRs3LvCzjm/VA4qtW7cGHhs6dGhM76cnFWowVFZWmq2z2tozZMgQOfTQQ1v9Hnpg0trP1XHDehKltiAxbhZoO7KpZWQT0PWyacmSJWaRMGvWLPN8n1iyyX8+omaTFkfaGBJrNvnpuUe6LB999FHM/1bzTW+tob1v77//vixatKgNS4loGFbXwTpr6EpaWlrIff0jrq0XbR26olPeajDobFDXXHONnHrqqeZsLLGIZeiKvlZDacCAAWYo6W3dunXmZw8aNCiudQOgObKJbAK6SjbpxAfaG6WTMdxyyy0xZ5O/4cOfTW0dVqeTQOhEMXPmzJF+/frF/LvHMqxOCyOd1EF7oPzZpE455ZSYGovQHD1HbaQtlbpjff755+YfTf9wj2+//TZk/HtnDV1pSaxDV5rSwNBhLLGIZeiKjuc/4ogjQp7T2af0cZ2NCkDrkE0tI5uArpNN33zzjRx22GFy3nnnyZ133tkuyxrrsDo9B/Kyyy4zZ7ScO3euDB48uE2fG8uwuhtuuEEuuuiikOfGjh0rDz74oBx//PFt+nxYKI7aSLs9dUfUE3R1B9EuYO3K1VbN4KEXsXYP63hXHS6yefNmqampCeyco0aNMqeubatYuoe1FVYPHkpLS82Djrfeesu8lsjjjz8e02fGMnRFzwvwnxvgpyGqY3GbdrkDiIxsahnZBHSNbNLha1oYaYOFDrHVfFJ6PqKeZ9hWsQ6r06F0ei7V66+/bv6e/uXQYYOaNx0xrE4zKNwkDFp4trU4g4XiKA4PPPCA2f173HHHma2b1113nXz//feSmZnZ5vfUVgCdL99v4sSJ5v/XrFnTaUM4qqqq5JJLLpH169ebO7WOv9VrCOjMTwCSH9kEwA7Z9NJLL8m2bdvMHNCb38CBA2Xt2rXSWfwNNE2Hs+mEEzopDVKLQ+fzTvRCdBX6h1u7O++//3658MILE704AGAimwAkI7IJyYieozjoDCHLly83Z17RcbM6TlYxpSKARCKbACQjsgmpgOIoTvfdd595EUIdc7/ffvuZs4j06NEj0YsFwObIJgDJiGxCsmNYHQAAAABwnSMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAACLW9qJz2fI4rIKWb+jTnyGIXbmdjllYI9MGd0vRxwOh/lYRU2DfP7dHqmobRC7y8lwycRB+dI9Ly3w2MpN1bJyc7V4vD6xM6fDIT0L0mW/wfnidlnbDuJDNjUim6IjmyIjm9of2dSIbIqObOrcbGqX4uiV+Vvl9pdXy8Zdde3xdl2G7ui3nTZE3ly4Xd5YsE3qG+wdfsFcTpEjxnSXC6f1kVkvrpZlG6sSvUhJpUdemlx97EC56LC+iV6UlEY2hUc2RUY2RUc2tQ+yKTyyKTKyqfOyyWEY8TVXvPHFNrn4T0vF5o0eEWkDCOsmMqdDxMf6ieiuHw3lIKSNyKboyKboyKboyKa2I5uiI5uiI5s6PpviLo4Oue0LWbbBql6zC3Ilr1uhOPWbszGfzyfl23ZJbWV14DHtJi7q3UPSszLFzmtHNzZPXb3s2rRNfEFdwRlZmVJQ0k1cLpfYme6OVbsrpGJneaAl5Kt7DmQYSxuQTc2RTZGRTdGRTe2HbGqObIqMbOr8bIprWF3Z9trADp6ZkyVDJowIjBW1u+L+vWXpxwsDG3LvoQOke9+eiV6spJFTkCtl33xn/ux0OaV0v1Hictt7B/crHtBb1nz1rVTuLJftFR5ZsGaPTBlakOjFSilkU2RkU3RkU2RkU/zIpsjIpujIps7Lprhmq9tS3jhWNqcwjx08iMPpEFeaO2T9oFF2QeP6yMzNZgdvIjdoe9laXp/QZUlFZFNkZFN0ZFN0ZFN8yKbIyKboyKbOy6a4iqPgMY/s4NGxfkIFrw3WTXPB68Tusxi1BdnUeqyfUGRTdGRTfMim1mP9hCKbOi+buM4RAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAi4pYU1zvHIVP6umR4d6eM6OaUfvkOcTocgeevnl0ri7f6xI7cTpHxPZ0yttglI3s4pTjbIUWZDslyi1R7RNbt8cknG7zy5soGqW4Q2zlysEvGFbuktMgh3bIckp/uEN10dN1sqPDJl1t88q9VDbKt2kj0oiIFkU2RkU3RkU3oSGRTZGRTdHbJppQvjo4c4pbzxqYlejGS0pBCp9xzWGbY5wpcIuMyXTKup0tOHu6Wm+bWyerdqb0xx+rcMWnSN69552m6S6Qw0yWji11y8gi33P5RnczfaM8/FGg7sikysik6sgkdiWyKjGyKzi7Z1KWG1dU1GFLbYK8NtbU8XkOWbvfKpxu8srEidIMtznbKbQdnSFqX2hpax2cYe1s7rHWzrjx03WS5HXL9ARlmaxLQVmRTZGRTeGQTOgPZFBnZZN9sSvmeo2+2eeX+z3yyYodP1pQbcu9hGTKhxJXoxUoa26t98sLSBvnvmgap8jQ+fs4Yt1wwLj1wv0+uUyb1dsm8DV6xiycXeczg21kb+vjB/V0y64cZgfuFmQ4ZXOCQlbv4A4LWI5uiI5siI5vQkcim6MimyOySTSlfHC3YnLrddh1t/R6fnPevWqkNs98+u6RBji11S8+cxtJ+QL5D5m0Q2/hoffhA+9/3XqmoNyQvvXEMdr19sg/thGyKjGyKjmxCRyKbIiOborNLNqVwpxdaoicLhtvB/XbWhlb0lUEtJHb2g36ukB1cu4+/r0jN1g8gGZFNbUM2AR2LbGqbrpZNKd9zhLbpkeWQ0kJnyBhSHT9qR+ePS5OB+Q7JcDukT65D+uc3rpctVT6546M68aXuPg6kFLKpEdkEJA+yyT7ZRHFkQ3oC4Y0HpUuaq7HKf3+tV9ancJUfjwk6bWfP5uOtV+70yd2f1Mm6cnuuF6CzkU2hyCYgOZBN9somhtXZTE6ayN2Hhp58qSdnPjC/PqHLlYz26eaUJ4/JlOOG0oYAdDSyqfXIJqDzkE32y6bUXnrE3CV897QMcx5/v0WbvfLr/9VJnT17hk1Xzq4z/5/tFumV65Bjh7rlxGHWNSDcTodcvn+aLNnmlbUp3hICJCuyKTyyCUgsssme2UTPkU0MKnDII0eF7uCz1zbIDXPrpMaGV3mOdCKmXtDtkS888vH3jSvF5XTID/szzSnQEcimlpFNQOcjm+ybTfQc2cD4ntbFyoJnEnluiUf++hXTrESyvSa0taNbVuO6A9A+yKbYkU1AxyOb7J1NFEdd3LSBLrnugHRJ33sSYYPPkIfm18vbq23cHywixwxxiV4UfN56b8hF3tSoHk6ZNjB019ho05MugY5CNoVHNgGJRTaFZ6dsSvniaEofp5wzxhrnqAYWhI4UvGJSulR5Gr+gy/5rjZO0g32KHHLTQenidDRW79uqDZncx2Xemppb5pUPyuyx8w8udMopI9LE4zWkbI9hrhddTb1yHM22Ib2w2Xtr6UNHbMimyMimyMgmdDSyKTKyKTI7ZVPKF0eFGQ4Z1SPyuMamX5idZKc5QnZw1TvXad7CWWOeOGePndxPp+UsLdJb+Od31BjmfP07azt7yZDqyKbIyKaWkU3oKGRTZGRTy+yQTSlfHAFt8fZ3DWbLhv6B6JPnkIIMhznrSr3XugL22t0+mb/JJ7PXNES9WjYAtCeyCUAyettG2ZTyxdE7a7zyzprqRC9GUlq81SeHP8+6idTas6Zcu3xTt9sXyY1sioxsioxsQkcjmyIjmyKzUzbZt+8UAAAAAIJQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAACAdiiO0t2OwM8+ry+et+qajMYffV5vIpck6fh8jSuHbac5b9D2kuaiDSNWZFMLyKaIyKboyKb4kE0tIJsiIps6L5vi+teDirPE//nl23eJp84T18J0JfU1teKpb1wfOzZuE8MI2uttTNfDrs3bAvdrKqqkek9VQpcpmXgbGqR8y87A/X16ZSd0eVIR2RQZ2RQZ2RQd2RQ/sikysikysqlzs8lhxLnlnfHwVzLnm12B+06XS6SxYcSejPAtHg6nQxxOWtoMnyGGr3mrB9uOxdfQuO2M7JMjH9y6f0KXJ1WRTWGQTVGRTdGRTe2DbAqDbIqKbOrcbHLH9a9F5P+dPEQ+Xr5Q6r1WjUU3aChtIfL3flobN+snWLrLwbYTgdMhcuvpQxK9GCmLbIqObIqObIqMbIoP2RQd2RQd2dTx2RR3Of7UBxsDXxKaY1hodGw7kenw4r++vzHRi5GyyKboyKbo2HYiI5viQzZFRzZFx7bT8dkUV89RfYNPXv9iW6DSv/v0gXLIyHzbn6RZ6/HJf77aJbe/uj7wWFZutvQdMVjSMzPEYfMuUB1jvXHlOqnctSfwWM9BfaRbn57isvm2o4Ncq3ZXyPfLvjNPuJy9ZIfsqPBI97y0RC9aSgnOJtVv5BDJ71ZgDtGw+wm95Vt3mvufH9kUPZsuPbKXnHFAD8nJcImdeX2GfL66Uq59fq1U15NNbUU2hUc2RcdxU+ceN8VVHH27qVrKqxvMn48cUyjH79stnrfrMrLSnXLmgcXyx/c2y9Y91vrpVdrf3NEhkpHtkt5D+8vKz78x76dnZUjJoL6JXqykkd+jUIp6F8uO9VvMFrRFa/fIEWO7J3qxUkpwNhUUF0lRCetPOV0i3fv2lK3rNkrD3hOfyabI2TSwR4b88sjeiV6spDFtVIGcNqW7PP3hNrKpjcim8Mim6Dhu6tzjprjKzaq6xrGOvQpoPWoq3d24etMy0hO6LMnGnda4vbBumgteJ8H7GVoneJ2xfTUX3ErN+omcTfxda65XAdkUD7IpOrIpMo6bOu+4qd364hx27/ME2hF7E5B4/FkDgNTQnnFt74GKAAAAALAXxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAABExJ3oBUDnynSJPDkjU/rmhdbFZ71eI1uqDLGrSb2dcsQgt4wqdkpRpsN8rLzWkI2Vhny9zSevf+uR8rpELyVSGfteeOx7QGKRTaF6Zjtk5jC3TChxSp9cp2SniXh9IrvrDFm1yydz13llbplXfPZbNbbJboojm/npxLRmAWhnOWkit0zNkMl9XM2ey8p1SK9ckX17uWThZq+Ub/MlZBnRNbDvhWLfA5ID2dRocm+nzPphhmS6rYN9P7dTpMTtkJIcp0zt55YZpV65cW6deGwYTTk2yG6KIxvZr5dTZg5LS/RiJA0Nu3sOy5AR3Rt38HqvId/vMWRbtSEFGSL98p2Slx4akkCs2PdCse8ByYFsauRyiFx3YGhhtKfOkGU7fGYmBefVxF4uOWW4W15Y1iB24rZJdlMc2ajSv3ZKuvlzZb0h2huc6htvvM4Zkxayg2srx/2f1cvmoGEETofIhJ5O2Vxp8/5ztBn7XnPse0DikU2hhhQ6AsPD/IXRBW/WyO69Q8POH5sm545tLCTH9nTZrjg6xybZTT+qTVy6f7r0zLG+7ke+qJeq+tTdaNtrjPVJwxrbBnbWGHL7R3UhO7jSMcULt/hke4291xfajn0vFPsekBzIplBNh8htqvQFCiO1YmfoCyo99lpfmTbKbnqObGBqP5ccNdj6qv9X1iCz13rlgnH27kYfV+KU3KAWsnkbvNInzylT+7qkJNchHq/Imt0++aDMm9I7OBKLfa859j0g8cim5nRo2MZKnzkJgxpa5JRpA10yb71XCjIcctLw0EPm99baq9donI2ym+Koi9Pxn1dNsrrNd9UY8tDn9YlepKQwvFtop+mUPk45bmhms9ddPMGQvyz2yIvL7RWCiB/7Xnjse0BikU3heQ2ROz+ul9sPzpDuWQ5xOR3mxANNVdQb8uSiepm/MTUnG2ir4TbKbobVdXFXTkqXoiyr0n9gfn3KTqvY3gqDxhWr4uzwu0KayyE/3zddZpQ2n5UFiIZ9Lzz2PSCxyKbIlu/wySX/qZWl271hn9fJB174xmNO5203hTbKboqjLuyIQS45eIDVOfjO6gazCxQWt54x2MScdQ1y+qs1ctLL1fLSck/IcxeOTzdPMgRag30vMvY9IHHIppaHG/71uEwZ1cMVuG7P/I1eWb7DWk/pLodcPDFdHpueKSU59gomt42ym+Koi0pzWidbqi1VPnn0C7rNg1U3OZHS6zPkofn1sqPGkD11Ik8s8siuWiOkxaS0MEX3cnQq9r3o2PeAxCCbouubp8Po0iUnzcqb1bt9cu6/aszrGf3ynTq555PGLrb++U65fO+6tItqG2U35xx1Uemuxik5CzMc8uwJWSHP5zbZp/84PVMMQ+SRBfUyxwbdxRsqQndynZGm0hM624rOVFOk07PslZ+h6zO1TzJEx2Pfi459D0gMsik6nXxBe4b8/ru6QaqCsumdNV65dH9DsvcWT/v3dprX/WmwyalHG2yU3RRHNpDhdkhGC9+0tQGLpNukL3HJttCgz00TaboL5ze53kNwiwjQGux7zbHvAYlHNjVXvPc8LL9wqWM0GWaWl675JLawxEbZbZNNHgi1ttwIjCH2/6E4ekjQ1a9LnOZVnv10Rp81u1NzJweSCfsegGS0tTo0Z3Sq8+ygAvKowa7AkDtV5TFsNZnFWhtlNz1HXZR2BR/+fHXE5587IVN67Z3LX531eo1saXIhr67uDws88tARTnO6TnXNlHQ5ptRndpGP7hHabvB/X3tSsGMYicC+1zL2PaDzkU3RzS3zyrljDHO2NVVa5JRnTsiSb3f6JD9DZET30NnXZq9pMIeS2ckfbJLd9BzBtpZu98ndn9SbU3Mqp8MhY4pdMqHEFQhHn2HIc0s88uaq1J2vH0g27HsAkvGcmgfn14tnby75JxWY3MfVrDBavMUrf/4ydHY2O1hqk+ym5wi2pieZLtteK6eOcMt+vVxSnOMwWwx09pWvt/nk9ZUNsmKHTc62BDoR+x6AZKOTLny9rVaOG+qWCSVO6ZPnNIfWac+Inj+zapfP7GHS6xylaq9IvObYILspjmzq7DdscgZhK2yuMuTRBdoCZL9WIHQ+9r1G7HtA8iCbLBsrDXnShr1CsdjcxbObYXUAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAADtWRz5DKO93qrrCFklrJ9gbC7RsXraD+uyJayhSNnk8yVySZKTQXi3G9ZkS1hDwdj1ojOSpTjKy3QFfv5+R317LE+XUuNp/MtaX1OX0GVJNp76+pB1wx/cUPU1tYGf87LcCV2WVBScTex7zfm8ZFNrsun7nWRTU2U7G9cP2RQ7sik6sikyjps677gprn89vE+O9MhLk+0VHnl/abk89u5GGdM/R1xOh9iZ12fI/O8qZUdlQ+CxjavKpMTTIK50XeU2Xz8NXtm2bmPgvqeuXtavWCsFPQrF4bT3SE8Nu7qqWtm1abt5P8PtkElD8hO9WCknOJsqduyWLWs2SHZ+jojD3vuebl9VuyrE6yGbWpNNm3Z75NcvlskRYwolzW3vdaPHYSs318jL83eY98mmtiGbwiObouO4qXOPmxxGnKXnHa+slkf+831cCwEgvFOn9JTHLhyZ6MVISWQT0HHIprYjm4Dkzqa4y83p47uL22Xvij4al70L+ha5bd7LGI02JB67b49EL0bKIpuiI5uiI5siI5viQzZFRzZFRzZ1fDbF3XN0wr1fyqcry82fXWluyS3Ms30Xn8/nk8qde8Tn9YY8npWfIxmZGbbvPtfu4KrdFSGP6TaT1y1fnK7G8dh2pLtjdXmFeOo85v1BxZny2W8mi8Pm20xbkE3NkU3RkU2RkU3th2xqjmyKPZsy0xwydVi+5GTYe9tp8BqycG2VbC5vv2yK65yjrXvq5bNV1g6elpEuwyaPsf0fEL8GT4Msn/dl4IS54gG9pdeQfolerKSxY8NW2bhynXXH4ZBhk0ZLelZmohcrKRg+Q1YtXCq1ldWydlutfLO+Ssb0z030YqUUsikysik6sikysil+ZFNkZFPrs8ntFHnj6pHSv3tGohcraQqkMx5dIUs31LRLNsVVbq7fURuYWjCveyE7eBB3mlvcGWmB+wU9uyV0eZJNfo/CwM/ZedkcfARxOB1SUFwUuL9ue+MMLGgdsikysik6sikysil+ZFNkZFPrs0knP6MwaqTDVI8aW9hu2RRXceTxNo7IczIGMiqnzbvMmwru7rT7cIKWtpeGoKlN0TpkU+uRTaHIpujIpviQTa1HNkXOJh1Sh1AZ2p3WTtnElgcAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAgIi4JYX9eGyanDc2rdWv/3KLV655r07spGe2Q2YOc8uEEqf0yXVKdpqI1yeyu86QVbt8MnedV+aWecVniO1cd0C6HD2k5V1g/kav3DjXXtsN4kM2tYxsioxsQkchm1rG/oeULo4Q3eTeTpn1wwzJdDtCHnc7RUrcDinJccrUfm6ZUWrt4B5fwhYVgI2QTQCAZJXSxdG6cp/8r6wh4vNje7qkKLPxj++KHfb5C+tyiFx3YOjBx546Q5bt8ElBhsiI7q7A4xN7ueSU4W55YVnkddnV7a415Kut3rDPrdxln+0G7YNsioxsig3ZhPZENsWG/c+eUro4+qDMa97C0T+yz8/MCtz3eA15ZYV9/sAOKXSEBJwefFzwZo3s3tsDfP7YNDk3qGtdA9HOByBry31y20f1iV4MdBFkU2RkU2zIJrQnsik27H/21GUnZDhhH3dIy+ScMq9sr7HP4PWmw1A2VfoCBx9qxc7QF1R67LNugEQim0Lvk01AcrB7NgFdoucokjSnyMx9Qk84fHGZR+zk+z2GbKz0mSc6q6FFTpk20CXz1nulIMMhJw0P/erfW2vv1qHibIdcsm+a2aJd57UO2BZs9slymw8pQPsim8imWJFN6AxkU3jsf/bUJYujIwe7pCirsfXj801eWb3bXq0fXkPkzo/r5faDM6R7lkNcTofcMjWj2esq6g15clG9zN9o7x29b55TThkR2pH6k/EiizZ75bef1NN6hnZBNpFNsSKb0BnIpvDY/+ypSw6rO3UErR9KWzYu+U+tLN0efnxxvdeQF77xmFPmIjw9IfzewzIko/EccaDNyCYL2RQ/sgntiWyKDftf19bleo4O6OOUgQWNNZ9eL0O7QO1oaj+XXH9guuSkWa1B5bWGOZ4/f++MUOkuh1w8MV2ml7rl+jl1sqXKXi0g+vs+/43HbAFaX2HIrlrD7EI/ptQtPxrlFqfDWm8DCpzm9Vj+aeOTwhE/sqkR2RQd2YTORDaFYv9DlyuOThtJ64fqm6dDVdLNgwy1erdPrny3Vqr2ro6jB7vM6XRV/3ynXL5/utz8gb0uZvb01823jY2VhvxlsUcy3SInD2/clqb0cRGAiAvZZCGbWkY2oTORTaHY/9ClhtXtU+SQCSWNfZxbqnzyvk2HZegJzv6DD/Xf1Q2Bgw/1zhqvVAfNArV/b6d5AUZYFjZpNdNzI4C2IpsakU3xIZvQnsim2LD/2YOzK7d+vLqiQXz2Go0RUNxkhw23GoIfczsdkpcuthF0bBZW79zQF1QxnTDiQDY1IpuiI5vQmcimUOx/6FLFkY4HPWRAY+tHZb0h/15l367OrdWhO+xRg92SHTSI8qjBrsB4f/8OXm6jkStjip3y0BEZ5rkPTcNwWDennDM69A/Gkm32HX+N+JBNocim6MgmdBayqTn2P3Spc45OHu42Wxj9dAevtvE+PrfMK+eOMSRt795dWuSUZ07Ikm+DTnoONnuN/VqLxvZ0mbcaj2GegKpTBxdnO6W0yBE44dJ/cPYiY4rRRmRTKLKpZWQTOgPZFB77H7pEcaStjjNKG38Vj9eQV1bYe4PdUGHIg/Pr5arJ6YGDkMJMh0zu03zeycVbvPLnL+11AmbwsVZWmsMMwnB21Bhy+0d1XMsAbUI2NUc2RUc2oTOQTeGx/6HLFEczhrolN72xmp9T5mWD3Xti89fbauW4oW6ZUOKUPnlOMxAbfGJOTaktItqKq9cSsdva+mqrNUOWzjQzsodT+uU5JD/DIboVVdaLrC33yacbvfL2d6EniwOxIJvCI5siI5vQGcim8Nj/0GWKo5eWN5g3SNjpJ5+0Wctra329zWfegI5CNkVGNkVGNqGjkU2Rsf+hy0zIAAAAAADxoDgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAAO1QHLmcjsDPhmHE81ZdU9AqYf2ECl4fho9105QvaJ0E72doHbKpBWRTRGRTdGRTfMimFpBNEQWvj/oG1k1THq+v3bIpruKob1FG4OeKneVi+BoXzO58Xq80eDyB+xU7did0eZJN5a49gZ9rKqrEU9e4ruxOA7BiZ+P20rdb436G1iGbIiOboiObIiOb4kc2RUY2tT6blqyvlm0VZFNwNn2wbE+7ZZPDiLM0n37XQlm4tsL8OT0rQ/K6FYjDYe/WJG1Z053aU1cf8nhe90JzHdl77Yi5Xsq37Qp5zJXmloIeReJ02Xukp+6OVbsrpLaqJvCHdMHdU8RJC23MyKbmyKboyKbIyKb2QzY1RzbFnk3dctxyxJgCyclwiZ01eA35fHWlLN/UftkUd3H0wdJdcs6jX0sdXXxhuZ0OaWBoRkTpbgfdwxHo38rHLxwpJ0/umehFSUlkU3RkU3RkU2RkU3zIpujIpujIpo7Ppribwg4ZVSTPXjpW9hucF+9bdbkv6MB9CuS1a8fLZdP7S4+8tEQvUlIpyHbLeYf0lv/cOFGmjS4ywxCNRvXLkT9dPIqDjziQTeGRTdGRTdGRTfEjm8Ijm6Ijmzovm+LuOQq2aVedbNxVZ/uKP83lkH7dM6VnfnrgMa/PkG83VcuemgaxO+0CHtY7W9LdjbX5riqPrN1WY/vWEM26koIMGdAjM9GL0qWQTRayKTqyKTKyqWOQTRayKTqyqXOzqV2LIwAAAABIVfY+wxQAAAAA9qI4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAgEDk/wPA1KVKJZUXZwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0cAAAJRCAYAAACOQsyxAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAciFJREFUeJzt3Qd8G/X9//GPhvdO4jh7OWRPIAmQFggzhBE2ZRUo0EHZUHb/YRRo2RQKhQ5+lFFaNqVQSiChQIBAEgIhg4QMk70db8vS/R+fu0iWbEm2LNuSfK/n4yGwRqTz6e7t+3y/3/uewzAMQwAAAADA5pyJXgAAAAAASAYURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEICa33nqrOBwO8/Z///d/Yjf33nuv+bsXFRVJVVWVpLJBgwYFvsv2ptuG/711m7Gz888/P7Au5s6dm+jFQZLtK8lK801zTn9nzT3ALiiOYLsD+uBbQUGBTJ06Vf7yl7+IYRiJXkzEYcSIESHf7aeffhr19Yceeqh50BqLyspKueeee8yfL7roIsnJyQk8F/zZa9euDfl3ekDsf04PsrrSfqW3hx56SOwg+HvUm8vlktzcXBk8eLAcc8wx8qc//Ulqa2s7pND0r+vdu3dLV6T7TNN1u379+mavGzduXMjr/vjHP0qqe+211wLfb9PsaM3zHUXz7eKLLzZ/1uJI8w+wBQOwgVmzZmnlE/V2wQUXJHoxU8K6deuMDz/80Lxt2bLFSAYLFy5s9n1eccUVzV73wgsvGKtXrzZ/PuSQQ4zzzjvP/Hnx4sXGW2+91eLnPPLII4H3X758echzwZ+9Zs2akOfmzJkTeG7gwIFGsvj8888D32VbRPuddNvwv7duM11B8PcY6TZ8+PBm28a3334bWBe7d++O+XN1W420bXUV+ns1XZe33XZbyGs++eSTZq95/PHHO2X5dBv3f2Z70xzyv7duY7E+35FWrFgR+GzNP8AO6DmC7WgL74cffijvvvuu2frv99RTT8kXX3wR9d/6fL4OaRlurWQYxjVgwAD5wQ9+YN569uwpyeDvf/97s8defPFF8/vy02N57fUZOXKk3HDDDea63L59u/z0pz+ViRMnypNPPtni5+g2okaPHi3Dhw+XVOXfjvbff//Ad9nedNvwv7duM11Nr169zBz5z3/+I3feeaeUlJSYj69YsUKmT58e0sOzzz77BNaF9lajdXR/C+7R1545dK5hw4aZeafsOIwaNpXo6gzo7J4jf2+B8vl8xuDBgwPPPfDAA81e/5e//MW44447jAEDBhhOpzPQcqf/9oknnjCmTJli5ObmGhkZGWar8Y033hi2dfjFF180Ro8ebb5O//+Pf/wj5HOeeuqpsK2U2up+8sknG/n5+cagQYMCr9m6datx1VVXGUOHDjXS09ONwsJCY8aMGWbralN//OMfjf3228/IyckxX9unTx/j8MMPN373u98FXuP1eo3f/OY35rJlZmaay9m/f3/zPf/85z+HXZfBy6wWLFhgnHrqqUZJSYmRlpZm/v+UU04xvvjii5DX6b/zv4e+3zPPPGN+ri7bPvvsY66b1tLvQb8bfS9d7pkzZ0ZsZW1oaDD+9Kc/GX379g28Rj/vn//8Z4ufo9+D/9/oem+qrT1Huvx//etfjYMOOsjIy8szf4dx48YZDz30kPmdhPuMpu8RrmchuCVen//ggw+MAw44wHx//z4QqTW8pe0lWk+sf9mafsfB/v73vxujRo1q1b4Qy+/s99prr5nLq/uELv+wYcOMW2+91aiuro74vQTnQiTRvsfvv//eKCgoCDx/yy23tNjyrz/rchYVFRlut9vo0aOHMWnSJOPyyy83M6Slnir/73311VcbBx54oNGrVy/z99XvbeLEica9995reDyekOUMXn7t0Tr++OPN1+sy/OxnPzNqamqa/d7PP/+8ceihhwbWp/7bc845JyTn6uvrjfvvv9/Yd999jezsbPM2efJkc99ujeDtNSsry3C5XObP77zzjvn8nj17zOXUx3Q/Cddz9Oqrr5q/j+akZrJmkGbD+eef32wbCf5O9DN+/etfm7mg26Tui19++WXI64P3lW3btpn/XteHfs7pp59u7NixI+T1rflOwvWWBd+C96FwN/+2dPfdd5v7gy6/7t+6/kaOHGncfPPNRlVVVcTfY9OmTeb3GO33UFdeeWXg35SVlbXq+wRSGcURbF0cqfHjxwee++1vf9vs9UOGDGn2B0kPaH/0ox9F/KM1YsQIY+fOnYHPePnllw2Hw9HsdcGfHak4Cv58/wGZHqj369cv7GfrAcHrr78eeK+//e1vEZdT/5j63X777RFfN3Xq1LDrMniZ9TP1s1uzTMF/9JuuX71pEdp0aFIkH330UeDfnXTSSeaBsf/+T3/602bFkRa7wetOi6OXXnqpxc/RA0T/vwl3wBfuoLU1B9U//vGPI673M844o12KIy1u9KCp6T4QrjhqzfYST3GkhVG4fxdpX4jld1Z6kBtp2X74wx8adXV1HVIcKW1c8D9fWloatTjS7VsPYiMt68qVK1tdHOkBfWuHC/sf18aW7t27N3u9HlAH+8lPftLi52thpEVepNddd911La7b4O1VG1W0yNGfTzvtNPN5LYL0vh7I60F8uOJIi7tIy6DvGTwMOPg7CZdBWmAFF5bB+4oWHk1ff/bZZ4f8Pq35TtqrONJGuUivmTZtWshyRfrbEun3aJoJuv8CXR3D6mBbdXV18swzz8hXX30VeGzs2LHNXrd69Wo5++yz5d///rf87W9/k759+8o///lPeeGFF8zndTYfHZL16quvmicLq+XLl8tNN91k/uz1euXKK68MDA857bTTzPe6/PLLZfHixS0u55YtW+SBBx6Q//73v4H3vOSSSwInK//4xz82h/Y8/vjj5snhHo9HfvKTnwSGTr3++uvm/91ut3ny8nvvvSfPPfecXHPNNeaJ5H7+1xUWFsqzzz4rs2fPNn/fn//859K7d++oy6ifdeGFF5qfrX7xi1/IW2+9ZS6n0sf1+XDDAnX96nNvvvmmHH744eZjOhzuz3/+s8Q6pO7UU0+Vo48+WvLy8sz7L7/8sjQ0NJg/6/o/8MADzWU788wzzSFlxx57rBx88MFy+umnyymnnBL1c5YtWxb4eejQoVFfq+s1+KTxadOmhX3dSy+9ZK5jpcP09Hf517/+JQcccID52D/+8Q/zFq+NGzdKv379zO9Vv5cTTzwx4mtbs73o9qVDypoOMdOb/k6R6L5w7bXXBu7/6Ec/MveFq666qlX7Qks+//xzueOOO8yfdZvViVZ039DvWenyPfjgg9JRdPvy++6776KewK7Demtqasyfr7jiCnM967r7zW9+Y26but3ocE9d5gkTJoQMF/Wva/9+efPNN5vbjv6uOmnEK6+8IlOmTAkMhQo3scGePXukuLjY3Ef860w98cQTgZ/1ub/+9a/mzzpBgn53uv3oNnvkkUcGZm57+OGHzeVXuu1qFurv4h96qsNZP/vss5jWpX/Is26POvzVP6TurLPOkqysrLD/5qijjjKXX/chXQ+6PnS79edopEz5/vvv5Xe/+5253vr3728+phMfvPPOO2Ffr0MmdV967LHHJD093XxM/x6Ul5cHXtOa70S/P/0edai33+9///vA93vSSSdFfV63D6UZrX/L9LvRz3rjjTdkxowZ5nNz5syRefPmhf09dPtr6fdomndLly4N+15Al5Lo6gxIlgkZ9t9/f7Nnoenrg3tN/E444YSwJ6l+/fXXgcd1mIr2MH322WeBx3SIhbay+ukwp+BWwnCte08++WTIZ+uwB38vlL6f/0RvvWnPif/f+XtD/D1cOsxl9uzZRnl5edh15F8W7R3QoXlNh2OEW5f+ZX7llVcCj+lwrGB63/+cDntRwS2i2mPg9+mnnwYeP/HEE42W6PelLcL6em2p1aE3wb+z3oInWnjuueeMVatWNZuQQSd0+Ne//hX1s37xi18E3jNcr1ZL21e4HofgIYC///3vA9+jDv3zP37cccfF3XMUqScuXM9Ra7eXaMsTqecoeF/Q3qzglnndz8LtC7H8zjoJh/+xm266KbA+9bv1Pz5mzBijrVrqOVq6dGnId71+/fqIPUc6dNH/mA6h1CFObZ2QQXtPdVvSPNDheU23ueBe2+DHFy1aFHhce7v9j/uHywVvnzpcOJLgXj8doupf78G90ZdeemlMPUe6b/fu3TvQm+F/TvfV4PUZ3HOk2ajD2bQnJVyvnOajX/B7BE/eoqMHgr+XcPuKP8fU9OnTA48HD8WL5TuJd0KGJUuWmPut9oiH671/+OGH2/x7qGXLlgWe0xwEujp3ooszING0xUx7DnQ6Ym0dbeq4445r9ti3334b+NnfGqjGjBkj2dnZUl1dLbt27ZJt27aZPSN+++67r6SlpYW0NLc05fTxxx8fcn/VqlWBXqjNmzfLD3/4w6g9HRdccIHZ+6DLdMQRR5iPaS/CIYccYvZoaSu10t4bXZYNGzaYy6WtwkOGDDF7c7T1VU/MjSTS+lCTJ0+WBQsWNHudny6HX/fu3QM/t2bK4vfff99sEfa3Gvt7jLR3zt+zp623/pZXbXUOR1tg/a2wrdHStO/auq+9KX6LFi0yewqbCl4f4Z5v2mPVVjohQGsnkGjt9tIWwfuC9oZo71TwdvLxxx9LPILX51133WXemtJe3Y6i+06waJMvzJw50+xd2LFjh7le9aa90Lr/aM+cbsOtMX/+fLNn0t9rG064fSk/Pz+kR6rpvqfLHrw+w+WgX/DrNEvbYzvWLNZtUb9D7blU++23X8T9VHsldXvVfS2SSJkSawa19Pq2fidtsW7dOjnooIPMnsCO+r25zAXshmF1sO1sdR999JE5lEf/EOiQhOA/DsH8s1C1h7ZcQLCtn+8fwqZFgx506vUq9MBCizcd0qEHHPrH0X/AqsNY3n77bTn33HPNIk+LRh0apEMG9XVt/WPe0u+sB4R+wQfLrfmD7C+AlA6l8Q9jCx4ip8Nyws0wqMNPYpl9qUePHoGftfCNJngWOL2FG67ZWuGGIuqBYDAddhRNLNtQa7eX9tbSdhLr7xyJDrPUIbUdIbi4Ky0tNYe5RqLFszYaXH/99eY2ovmj25UOw9ICI3jbjkaHPvoPwrWA0aFVmm863NYveNbGcPtdW/a9zphpUxtsgreL4NlFw617f2Gkw9Wefvpp+d///hcy7DbcemhLBrX0+rZ+J22hv6e/MNJGLb0mkn7Wdddd126/d3DeBecg0FVRHMF2/FMM68Vf9RyhSOPXox20BfeiaCuh35IlS8wWd/8fHh3TrwdJfvrHO/gg75NPPmlxeZt+vo7/9j+m760He3snVwnc6uvr5fbbbw8510aLnIULF0pFRYXcf//95nO6rHow5n+dTkGs5xN8/fXX5vkS2prt76GKNG492vpoej9a71Os9HfUcfwt0QMHPTiJl04BHtx71x6C14eeG9D0e9SbFqhNeyK0t8F/8KXnRrTUGxJLUd7a7SX4fVt7oKc9kX5ffvllyL4Q6ZyUWH7n4PXpnwa66U0P0jMyMqS9lZWVmecG+p1xxhlRX6/LMnDgQPntb39rHsxqsafnTPkFb9tOZ+Of6qbrOri36u677zYbfzTf/D2q8Qhen3puWGtep8VzuPXuPycpFrq9+M/X0yI9Us9v0/Wgr9NCJFKvekeL9TuJ9v229HzwZ+k5qdojqZ/V9LyheATn3ahRo9rtfYFkxbA6oA30j6+e9Kr+3//7f+bBlrao3XbbbSEHR3rwqEPp9CRfPelXT4zXP9o6wYOe7NvSkLpwunXrZv6x1QN+PXA+4YQTzBZWHVKmQyy0ANMDKy28Bg0aZA7X2rRpk3kCtS6HthAGn0zvb0XXyQz0PfSAQodRadEVfN2naK3t2tugLd96AKv/5tJLLzVPgtdl9L+Hrh9dhvaivVz+3ixdxzoEJ9g333xjtuAqbT0++eST4/o8Lab9tGjQHrZ46XbgnwBB30+HWekQOB2OuXLlSvOAVL/rWbNmBQpj7W3QE6l1G9TJJPRk6qa9KvFo7fbibwDYuXOnuV1rz5Ie7Gsvlf4O4eiwKJ3QRA/o/PvCOeecYx44RxpSF8vvrM/r5ABKJ3nQZdMGEN1OdF/RSU10Gf2TDGjvof/g+7zzzoupJ1HXg/Y+a8GoRY2eKO9vwdfPCJ54IhzdJnX71MkxdKILLQJ1mGjw+4dr4deJCfRke23U0R5K/azgA3H9PXTfiDSZQCz0u/FvnzqpgmaCri/dz/VEfl1+/Xzdjv0TamhPifZaaIbodqRFrL6HDs09//zzY14GvYaUFuS6HehQwEiC14NOJKEFgvZ46DXNOlus30nw96vrVYcU6s1//bFozwd/lm6D2uOvDQ06GUl7CR6qGJyDQJeV6JOegERP5d3S65tey0fpRAs6zXK8U3mPHTs27Oe0dDX2aFN5Nz1x+8ILL4z4Gj1p+bvvvjNfF20qXj1B2n+SdqR1o1Not2Uq7+Bpnptemyea4EkXwl25XU/O9l8rRX/PiooKI17+ySXCndQfbt3HO5V30/Wj19Vq+rxenyR4W4h0naNwwm1nrd1elF7Dqulr/PtXrFN5R9oXYvmdW5rKu+n+H89U3pFuOjV808kvwp1Qr9PBR3uf4CmTdftu+rx/O9JJLppmi97Xa+yEW5+RtsNIkz4EL3ukjNHp0aPlR9NlaM2EDNGEm5BBJ3DQ64M1/dzgiT6C94NIkxxE2m4jZXK494n1OwmeMCT41prn9W+BTp4S7fdu6+/hp9ci809aBNgBw+qANtAeoeeff95sOdUTyXNycszeIx1eoi2V2iMU3NqnvRY6/bcOSdCWPR2ipf/eP3W1f9hIaw0YMMBszfvVr34lI0aMkMzMTLPXR3/W1njt1fJPSaututpyqSfka+u0tjjq0EJtsdYeAf9QJ512W3u7/OdKaI+BtvLrv9cW8mgnlysdzqG9VdoDpe+v/16HFervrkPytIervejQKH/PnQr33trDpicqK+118LeAx8PfO6XDJ7Vnp73OGdChjHo+j65j3T70+9VtQ1uC/dOh+8+5uPHGG831qz0Hhx12mPkdBg/djFdrtxf16KOPmufH6PfcWjp9t/aa6D4QvC9E6tmL9XfW4aQ6LbwOEdXeTJ0ARbdjbWXXIWzBvbvtkQO632rrvfae6nT62oPSmskvdOiiTuGtvZ7aq6rrWde39tzqhBi6nvx+9rOfmecm6XYRPMRKaf7o1Nl6XpvmwOjRo80JQXR52oP2puk5mU23T91O/Bmnj2nvjm6vujyaRbos2iOmPcjai6HTUnckXX/a06o5pMup26Su39ZeEqA9xfqdaG/bfffdZ27Twef+tOZ5/S60R1Q/U/cPfY32rEY7PysWOtmG9sKrtvT8AanIoRVSohcC6Op0Nwt33odeE8R/roUO1YplxjR0Pj0PSw/49PwQHTqk10ZB+7j11lsDhYueL8SBGJB4mnP33nuvWWyuWbPGbAgEujp6joBOoC3deuFRHXOu5wVp6/Ivf/nLQGGkLc3jx49P9GKiBdqj5p8FSicsaMsMXACQCjTf/Bff1dyjMIJdMCED0Al0hiGdmjfc9Lw6BEWHrjQdLoPkpEMZ9QYAXZkWQy1dtgDoijgaAzqBnqehMz/peHA9R0HPT9LZl37xi1+YvUg6vA4AAACJxTlHAAAAAEDPEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFUXI5//zzxeFwNLtNnz498Bq9/9prr0myuPPOO+Wggw6S7OxsKSwsTPTiAOgAqZZNa9eulQsvvFAGDx4sWVlZUlpaKrNmzZL6+vpELxoAG2eTOuGEE2TAgAGSmZkpvXv3lnPPPVc2btyY6MVCEHfwHSSe7tBPPfVUyGMZGRmSrPRg47TTTpMDDzxQ/vKXvyR6cQB0kFTKpuXLl4vP55MnnnhChg4dKkuWLJGLL75Yqqqq5L777kv04gGwaTapadOmyU033WQWRhs2bJBrr71WTj31VJk3b16iFw170XOUZHSH7tWrV8itqKjIfG7QoEHm/0866SSzJcR//7vvvpOZM2dKSUmJ5ObmyqRJk2T27Nkh76uvveOOO+TMM8+UnJwc6du3r/zhD38Iec3u3bvloosukuLiYsnPz5fDDjtMFi9eHHV5b7vtNrnqqqtk7Nix7bwmACSTVMom/8HSUUcdJUOGDDFbavUA5JVXXumANQMgkVIpm5QeMx1wwAEycOBAc+TNDTfcIJ9++ql4PJ52XjNoK4qjFPL555+b/9c/+ps2bQrcr6yslBkzZsh7770nixYtMg8Mjj/+eCkrKwv59/fee6+MHz/efI3ujFdccYW8++67gee1B2jr1q3y9ttvy4IFC2TfffeVww8/XHbu3NnJvymAVJIK2VReXi7dunVrt98ZQPJL9mzS1z333HNmkZSWltauvzviYCBpnHfeeYbL5TJycnJCbnfeeWfgNfqVvfrqqy2+1+jRo41HHnkkcH/gwIHG9OnTQ15zxhlnGMccc4z584cffmjk5+cbtbW1Ia8pLS01nnjiiRY/76mnnjIKCgpa9XsCSC2pnE1q5cqV5ns8+eSTrXo9gNSQqtl03XXXGdnZ2eayHXDAAcb27dtb/Tuj43HOURKORX388cdDHmuptVNbQG699Vb597//bbaMNDQ0SE1NTbMWED0vqOn9hx56yPxZu4H1fbp37x7yGn0f7X4GYG+pmk06pl9bhbWFV887AtC1pGI2/epXvzInjVm3bp15esKPf/xjefPNN82hf0g8iqMko+Na9QTiWOhYeu3m1RON9d/q7Ex6cl8sMzPpDq4nB86dO7fZc8xCByAVs0lngNIDJx2y8uSTT8a07ABSQypmU48ePczbsGHDZOTIkdK/f3/zvKOmxRgSg+IoxeiYVK/XG/LYxx9/bE5nqScc+ndYncq2Kd3xmt7XnVLpONnNmzeL2+0OnLAIAKmaTdpjpIXRfvvtZ55v4HRyii1gR8mWTU3pzJqqrq6uze+B9kVxlGR059CdLZjueNrCoHQH1BMIp06das7QojOy7LPPPuYsTHoyoXbJ/vrXvw7sbE3D4J577pETTzzRbDF58cUXzS5ldcQRR5gtFvqcvkZbM7TVVZ/X8Nh///3DLq92QesJhfp/DZ8vv/zSfFxbYnQGGABdQyplkxZGhx56qDkblLYMb9u2LfCczmQFoOtIpWz67LPPzEkhfvCDH5jLocPv9LP1Wmz0GiWRTjivCTGcWKhfSdPb8OHDA6954403jKFDhxput9s8WVCtWbPGmDZtmpGVlWX079/fePTRR41DDjnEuOKKKwL/Tl972223Gaeddpp5EmCvXr2Mhx9+OOTz9+zZY1x22WVGnz59jLS0NPO9zj77bKOsrCzmZZ4zZ06HrCMAnS/VskkniAm3vPzJA7qWVMumr776yvzcbt26GRkZGcagQYOMn//858b69es7bB0hdg79T6ILNHQ8bTm58sorzRsAJAuyCUAyIpvsi0HYAAAAAEBxBAAAAAAWhtUBAAAAAD1HAAAAAGChOEpxOi+/TkPpn0I7kfRq0yUlJebyvPbaa4leHAAJlixZoBeA1Yss6rWO/Fe3B2BfZBOioThKMnq9oGOPPVays7OlZ8+e8qtf/UoaGho6dRnuvvtumTRpkuTl5ZnLoHP4r1ixIuq/WbZsmdx2223yxBNPyKZNm+SYY46J6TP1WkmXXXaZDB8+3LxS9YABA+Tyyy+X8vLyOH8bAO1B90e9oKpeJ2TChAkJWQa9LoleO0SvPp+Tk2MuxzPPPBP13+zZs0cuvfRSuf76683rH/30pz+Naxl+/vOfmwdWHMgAyYFsspBN7YeLwCYRvYiqFkZ6kcJ58+aZRcaPf/xj8+rOd911V6ctxwcffCC//OUvzQJJC7ObbrpJjjrqKFm6dKm504ejFzJTM2fONHfOWOmF0/SmF2wcNWqUrFu3ztzR9bGXXnop7t8JQPx+8pOfmBcx/OqrrxLy+d26dZObb75ZRowYIenp6fLmm2/KBRdcYDbiHH300REbnDwej5mtvXv3juvzX331Vfn000+lT58+cb0PgPZFNpFN7aoN10ZC0MW/zjrrrMDFwR544IFmFxGLxVtvvWU4nU5j8+bNgccef/xxIz8/36irqwv7b/RCZvo1vvzyy8ahhx5qXtBs3Lhxxrx584z2snXrVvMzPvjgg7DPz5o1q0MutPjPf/7TSE9PNzweT7u8H2AX7Z1NTff38ePHt+q1mgV/+tOfjBNPPNHMJr0Q4+uvv260p4kTJxq33HJLqy8Gq5nZFnqRxr59+xpLliwxLw754IMPxrnkgP2QTRayKbkxrC4OV199tXz88cfyxhtvyLvvvisffvihLFy4MOQ12vuRm5sb9eb3ySefyNixY83zdvy0xUG7Xr/55puoy6ItFtdee6157tGwYcPkzDPPDAzH09aJlpYhWs+Uf2ibtoyEo5/71FNPmT9rb5fe1HPPPdfi5+o6i/a5+fn54nbTwQkkMpviocNtTz/9dLNFd8aMGXL22Webw2j9WloGXc5w9PjmvffeM4f8HnzwwWFfc8YZZ8js2bPNn+fPn29mk47v1/XR0udqfvn5fD4599xzzWHOo0ePbpf1AtgR2WQhm5IbR51tVFFRIU8//bQ8//zzcvjhh5uPaYHQtEvz9ttvN4uH1ti8eXNIYaT89/W5aPQztGvWv8PrTrJq1Sqzi1eXqaUJGyIVPrrj6dWhp06dKmPGjAn7Gt1ZdZyt0iGBfieccIJMmTIl6uf27ds37OPbt2+XO+64I+4xuIDddEQ2xeP88883G2uUNsL8/ve/Nw8Gpk+fbj7WUjZpA0nTRhPNjbq6OnG5XPLYY4/JkUceGfbf6vmL3bt3N38uLi4O5JOeG9DS5wZn8e9+9zuzkUbPbQDQNmRTI7IpuVEctdHq1avNsaKTJ08OPFZQUGBOKBBMx5vqraONGzcu8LN/7OrWrVvN4kh3nKFDh7bpffXcoyVLlshHH30U87/VCR30FivtKdNCT8890hnwAHSNbNJzFvWAQrPJL9Zs0kzRg4fKykqzdVZboocMGSKHHnpoq99DD0xa+7kLFiyQhx9+2Gzdbsv5lAAsZFPLyKbkwLC6DhZL97C2HGzZsiXk3/vvB/fIhKOTNvj5dxLt9YlnWJ3OoqInFc6ZM0f69esX8+/elmF12rKkrTYaMnqCYfDvBaD9dNbQlab7sOaTP5vaMnRFp7zVgwedDeqaa66RU0891ZxhMxaxDF3R1+oBk86gqQ1NetMJY/SzBw0aFNe6AdAc2UQ2JRo9R22krQG6Y33++efmhunvUv32229DxpjG0j184IEHyp133mlu7P5WEx2Tq60Z2ovSVrEOq9PxsjqtthYnc+fOlcGDB7fpc2MdVqc9RnqOlU7HqeORMzMz2/S5gJ11RDZ1pFiHrjSlBzM6jCUWsQxd0fH8RxxxRMhzmlP6uM5GBaB1yKaWkU3JgeKojbRn47zzzjNPgtPCQouZWbNmmS0Hwd2bsXQP63TZWgTphn3PPfeY5xndcsst5tA2LRjaKtZhdfp5Oib49ddfN39P//lO2v2tXb4dMaxOCyP9/aurq+XZZ5817+vNPx5Xx+8CSEw2KT2HUYeLaB7U1NQE/oBrZunUtW0VSzZpK6wePJSWlpoHHW+99ZZ5LZHHH388ps+MZeiKnhfgPzfATw/wtDe/6XAgAJGRTS0jm5IDxVEcHnjgAbNb9bjjjjNbEK677jr5/vvv29zjoQWADmP7xS9+YfYi6RhYDRJtRelM/p256ThZPXFST2DsCDpmVq9RoJoGw5o1a+giBhKYTeqiiy4yr4HmN3HixE7fP6uqquSSSy6R9evXmwcRek6lNqbozE8Akh/ZhFTg0Pm8E70QXYXuHDpM7P7775cLL7ww0YsDACayCUAyIpuQjOg5isOiRYtk+fLl5swrOm7W38Mzc+bMRC8aABsjmwAkI7IJqYDiKE733XefeaEvHde63377mbOH9OjRI9GLBcDmyCYAyYhsQrJjWB0AAAAAcJ0jAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAi1vaUa3HJzsrPeL1GWJnaS6HdMtNk3R3aO25u8ojFbVesbucDJcU5bjF4XAEHmvwGrKjol7qvfbedpwOkaKcNMnOcCV6UboUsslCNkVHNkVGNnUMsslCNkVHNnVuNrVLcfR1WYXc/+8yeX/JTnNHh7UhHz2+u1x73ACZu3S3PPfRJvlmfVWiFytplJZkyWkHlMgZB5bIvf9aJ28t2i67qxsSvVhJwe10yMEjC+Wy6QNk6vDCRC9OSiObmiOboiObIiOb2g/Z1BzZFB3Z1HnZ5DAMI66S88u1FXLqg4tlTw2VfTjZ6U6prif4IsnNdEklrUJhZbgd8rdfjpFpo7slelFSEtkUHdkUHdkUGdkUH7IpOrIpOrKp47Mp7uLoxPu+lHnflps/u9wuySnME4fD3qcy+Xw+qdq9R3ze0J07Kzdb0rMydLWLfRniqfNI9Z7KkEe1qzi3KF+cLnsP2dDdUddNQ73HvD+kZ5Z8csekkK50tA7Z1PpsGt03S/p3zxA7b2b6l3DrHo8sXBvaUk02Wcim9kM2NcdxUzQcN3V2NsU1rG7bnnr5ZKW1g6dlpMk+k8aaOzrE/JKWf7LY/NJUcf9e0qu0f6IXK2lsX79FNq0qC9zfZ9IYycjOTOgyJdMfie8WLJXaqhpZvbVGlm2oklH9chO9WCmFbGp9Nl10aE+5ZkbfRC9W0nj2421y5+vrA/fJpkZkU/zIpsg4boqO46bOy6a4miq+31FrtrapvO6F7OBB3Olp5s2voKR7Qpcn2RT0aBwTmpWfww4exOl0SkHPxi7hNdtqE7o8qYhsan02HTuhKKHLk2yOGlsQ+JlsCkU2xY9siozjpug4buq8bIqrOPIEzZChC4Ymgnr0WD+hHEHrg3XTXPA6aWgyzAAtI5tan02ZaayfYG6yKSqyKT5kUws4boqI46bOyybWLgAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAIuKWFNc7xyFT+rpkeHenjOjmlH75DnE6HIHnr55dK4u3+sSO3E6R8T2dMrbYJSN7OKU42yFFmQ7JcotUe0TW7fHJJxu88ubKBqluENs5crBLxhW7pLTIId2yHJKf7hDddHTdbKjwyZdbfPKvVQ2yrdpI9KIiBZFNaCuyCR2JbIqM46bo7JJNKV8cHTnELeeNTUv0YiSlIYVOueewzLDPFbhExmW6ZFxPl5w83C03za2T1btTe2OO1blj0qRvXvPO03SXSGGmS0YXu+TkEW65/aM6mb/Rnn8o0HZkE9qKbEJHIpsi47gpOrtkU5caVlfXYEhtg7021NbyeA1Zut0rn27wysaK0A22ONsptx2cIWldamtoHZ9h7G3tsNbNuvLQdZPldsj1B2SYrUlAW5FNiBXZhM5ANkXGcZN9synle46+2eaV+z/zyYodPllTbsi9h2XIhBJXohcraWyv9skLSxvkv2sapMrT+Pg5Y9xywbj0wP0+uU6Z1Nsl8zZ4xS6eXOQxg29nbejjB/d3yawfZgTuF2Y6ZHCBQ1bu4g8IWo9sQluRTehIZFN0HDdFZpdsSvniaMHm1O2262jr9/jkvH/VSm2Y/fbZJQ1ybKlbeuY0lvYD8h0yb4PYxkfrwwfa/773SkW9IXnpjWOw6+2TfWgnZBPaimxCRyKbIuO4KTq7ZFMKd3qhJXqyYLgd3G9nbWhFXxnUQmJnP+jnCtnBtfv4+4rUbP0A0HWQTUDH4ripbbpaNqV8zxHapkeWQ0oLnSFjSHX8qB2dPy5NBuY7JMPtkD65Dumf37hetlT55I6P6sSXuvs4gBRFNgHJg+Mm+2QTxZEN6QmENx6ULmmuxir//bVeWZ/CVX48Jui0nT2bj7deudMnd39SJ+vK7bleACQW2QQkB46b7JVNDKuzmZw0kbsPDT35Uk/OfGB+fUKXKxnt080pTx6TKccNpQ0BQPIgm4DOw3GT/bIptZceMXcJ3z0tw5zH32/RZq/8+n91UmfPnmHTlbPrzP9nu0V65Trk2KFuOXGYdQ0It9Mhl++fJku2eWVtireEAEgtZBOQWBw32TOb6DmyiUEFDnnkqNAdfPbaBrlhbp3U2PAqz5FOxNQLuj3yhUc+/r5xpbicDvlhf6Y5BZAYZBPQ+Thusm820XNkA+N7WhcrC55J5LklHvnrV0yzEsn2mtDWjm5ZjesOABKFbAI6HsdN9s4miqMubtpAl1x3QLqk7z2JsMFnyEPz6+Xt1TbuDxaRY4a4RC8KPm+9N+Qib2pUD6dMGxi6a2y06UmXADoX2QQkFsdN4dkpm1K+OJrSxynnjLHGOaqBBaEjBa+YlC5VnsYv6LL/WuMk7WCfIofcdFC6OB2N1fu2akMm93GZt6bmlnnlgzJ77PyDC51yyog08XgNKdtjmOtFV1OvHEezbUgvbPbeWvrQERuyCW1BNqGjkU2RcdwUmZ2yKeWLo8IMh4zqEXlcY9MvzE6y0xwhO7jqnes0b+GsMU+cs8dO7qfTcpYW6S388ztqDHO+/p21nb1kSHVkE+JBNqGjkE2RcdzUMjtkU8oXR0BbvP1dg9myoX8g+uQ5pCDDYc66Uu+1roC9drdP5m/yyew1DVGvlg0A7YlsApCM3rZRNqV8cfTOGq+8s6Y60YuRlBZv9cnhz7NuIrX2rCnXLt/U7fZFciOb0BZkEzoa2RQZx02R2Smb7Nt3CgAAAABBKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAQDsURy6nI/CzYRjxvFXXFLRKWD+hgtcH66a54HUSvJ+hdcimFgStEo+X9RPMZ/gCP7PtNEc2xYdsagHHTRFx3NR52RRXcdSnKCPwc+XOPWL4+LL8fF6fNHg8gfsVO3YndHmSTdXuisDPNRVV0lDfuK7sTnfwih3lYfcztA7Z1Pps+nDFnoQuT7L5bFVl4GeyKRTZFD+yKTKOm6LjuKnzsslhxFl+HnXnQvlynfWFudPdkpaRIWL3xiRDpL6mTrwNDSEPZ+RkitPpsvf6MUQMn09qq2pCHna6XJKelSEOu7dEGiIN9fXiqbNCr3dhuiz67QHitPt6aQOyqfXZtE9JpmRlOG2/emo9Plm5uVaCj1fJpr3IpnZDNoXBcVNkHDd1ejbFXRy99/UOOfvRJSF/TIDW0m2XbSeyh88bJmdO7Z3oxUhJZBPiQTZFRza1HdmEeJBNHZ9NcU/IsHRDFV8S2oxtJ7ol31clehFSFtmEeLDtREc2tR3ZhHiw7XR8NsXVc6T/dN8bPpMNu+rM+9379pS87oXicNi7i0+7P3dv3Sm7t+wIPNYj1y2XHd1bBnTPMKt+u9KtbXO5Rx6bvUnKdtQHHtftplvvYnG67D2Bou5TOq54W9km8352hlOW3X+QZKW7Er1oKYVsan02udPcUjK4nzk8w+48dfWyde1Gqa+1thtFNlnIpvZBNoVHNkVHNnVuNrnb/C9FZOXm6sAOnluUL332GRjP23UputHqyYTeBq95/9cn9ZejxhYmerGSxoDu6XLWYysDAThwzFDb/3Hwy+tWYAah/pGorvPJ59/tkYNHFiV6sVIK2dT6bOozbKAUFHdL9GIljfTMDFn95XLzZ7IpFNkUP7IpMrIpOrKp87IprnJzd3XjiXMZOVnxvFWX5HS7Qk54RqMBPTJCth128FCZQfvT7qrQE1TRMrKp9dkUvK1BJD2rMavJpubIpviQTdGRTZGRTZ2XTXEVR8ED8viKomMbDuVgi4kqOPSM4As/oFXIpliwhoKR1dGRTfEhm2LBGgpGNnVeNtl7oCIAAAAA7EVxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALC4pYvJdIk8OSNT+uaF1n1nvV4jW6qMhC0Xktuk3k45YpBbRhU7pSjTYT5WXmvIxkpDvt7mk9e/9Uh5XaKXEqmMbGrkdoqM7+mUscUuGdnDKcXZDnO/y3KLVHtE1u3xyScbvPLmygapbhBbI5vQ0cimUD2zHTJzmFsmlDilT65TstNEvD6R3XWGrNrlk7nrvDK3zCs++60a22RTlyuOfjoxrdkODkSSkyZyy9QMmdzH1ey5rFyH9MoV2beXSxZu9kr5Nl9ClhFdA9nUaEihU+45LDPscwUukXGZLhnX0yUnD3fLTXPrZPVu+x2FkE3oLGRTo8m9nTLrhxmS6bYO9oMbdErcDinJccrUfm6ZUeqVG+fWiceGu16ODbKpS+0N+/VyysxhaYleDKQIDbt7Dgvdweu9hny3yyefbvDKsu1eqai330EZ2h/ZFJnHa8jS7V5zn9tYEfqHtDjbKbcdnCFpXeovVcvIJnQWsqmRyyFy3YGhhdGeOkM+2+iV5Tu8Ia+d2Mslpwzvcv0LLXLbJJvcXamSvXZKuvlzZb0h+tXkpYdW/kCwc8akyYjujTu4tnLc/1m9bA4aRuB0iEzo6ZTNlam/syMxyKbwtlf75IWlDfLfNQ1S5Wl8/JwxbrlgnLW+lA5rmdTbJfM2hB6cdGVkEzoD2RRqSKE1vDe4MLrgzRrZvXdo2Plj0+TcsY2F5NieLnlhmb3G/Z5jk2zqMu1xl+6fLj1zrF/nkS/qpaoLVK7o2DHWJw1rbBvYWWPI7R/VhezgSscUL9zik+01bE9oG7KpufV7fHLev2rl1W9DCyP17JIG2VoV2oM0IN8+B2xkEzoL2RSq6RC5TZW+QGGkVuwMfUGlx17rK9NG2dQleo6m9nPJUYOtX+V/ZQ0ye61XLhhHNzEiG1filNygFjJtle6T55SpfV1SkusQj1dkzW6ffFDmTekdHIlFNoXX0iQLO2sN6ZnTeL+ySQHVlZFN6AxkU3Pf79HJBHxmb7UaWuSUaQNdMm+9VwoyHHJSk2F07621V6/ROBtlU8oXRwUZIldNsrqFd9UY8tDn9YleJKSA4d1CO02n9HHKcUObnyB+8QRD/rLYIy8ut1cIIn5kU9v0yHJIaWHj/ukzDPlyi32G1JFN6GhkU3heQ+TOj+vl9oMzpHuWQ1xOhznxQFN6Ts2Ti+pl/sbUnGygrYbbKJtSfljdlZPSpSjLqmQfmF+fstMGonMVBo0r9p/4HU6ayyE/3zddZpQ2n5UFiIZsip1OvHDjQenmfuf3/lqvrK9I7VbIWJBN6GhkU2TLd/jkkv/UmpPEhKOTD7zwjceczttuCm2UTSldHB0xyCUHD7A6v95Z3WCrE3YRH7eeMdjEnHUNcvqrNXLSy9Xy0vLQcTwXjk83TzIEWoNsatvJ4XcfmiETShr/oH6zzWsevNkJ2YSORDa1PNzwr8dlyqgersB1e+YHzVaX7nLIxRPT5bHpmVKSY68dz22jbHKmcgujnkyotlT55NEv7PUHFPGpbnIipddnyEPz62VHjSF76kSeWOSRXbVGSItJaWGK7uXoVGRT24bSPXRkpjk9rt+izV65fk6d1Nns2I1sQkchm6Lrm6fD6NIlJ83an1bv9sm5/6oxr2f0y3fq5J5PGrvY+uc75fK969Iuqm2UTSl7zlG6q3HKycIMhzx7QlbI87lNttk/Ts8UwxB5ZEG9zLFhdyhCbWgyTEdnpAk+6VtnW9GZaop0epa98jN0e7PP8B60DdkUm0EFDrPHyD9rlpq9tkHu/bReGuw1pN9ENqGjkE3R6eQL2jPk99/VobNpvrPGK5fub0j23uJp/95O87o/dsmpDTbKppQtjoJluB2S0cJvYn1BIukp21eG9rRkW2jQ56aJNN2F85tc7yG4RQRoDbIpuvE9rYu8Bl9b5bklHvnrVzaanq4JsgmdgWxqrnjveVh+4fYqo8kws7x03f/EFpbYKJtssskDodaWGyFXvNY/FEcPaWztmFjilH75jbuHzuizZndq7uRAsrbS/nZaY2HU4DPkvk/rbF0YKbIJSIyt1aH7kU51nh1UQB412BUYcqeqPIatJrNYa6NsStmeI+3qPPz56ojPP3dCpvTaO1e9Ouv1GtnS5EJVsLc/LPDIQ0c4zek61TVT0uWYUp/ZRT66R2i7wf997UnBjmEkAtnUsn2KHHLTQXqybuOBxrZqQyb3cZm3puaWec1rZ9gF2YSOQDZFpzlz7hgjMFtmaZFTnjkhS77d6ZP8DJER3UOzafaaBnMomZ38wSbZlLLFERCvpdt9cvcn9XLdAenmOGM9UBtTHBp+eo2Vv3/TIG+uSt35+oFko2P2gwsj1TvXad7CWVOuf2LtUxyRTUBizql5cH69XDW58XICOqlAuAabxVu88ucv7dfLvdQm2URxBFvTk0yXba+VU0e4Zb9eLinOcZhjTXX2la+3+eT1lQ2yYodNzrYEkDTIJqDz6aQLX2+rleOGumVCiVP65DnNoXXaM6Lnz6za5TN7mPQ6R6naKxKvOTbIpi5bHJ39hk3OkEPcNlcZ8ugCbQGyXysQOh/ZJLJ4qy/q8B5YyCZ0JrLJsrHSkCdt2CsUi81dPJuYkAEAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOOomR6AVIMgZrJCrWDoBkRDYB6OrZFFdxlJXW+M8bPA3tsTxdiuFr/Kp2VbF+glXVegM/N9Szbpry1nsCP2eluxK6LKmIbGp9NjV4Grc1iHgbyKZoyKb4kE3RkU2RkU2dl01xFUdDe2VLdrr1FuXbdkrlrj1iGLQr6TrYs32XNAR9UY++u1l2VLKjq4oarzz8zqbA/brqGtm5aVtIKNpZTUWV7Ny83fzZ4RAZNyA30YuUcsim1mfT1rUbQ+7bmbehQbas3RC4TzaFIpviRzaFRzZFRzZ1bjY5jDj3yp//eZm8Mn9rXAthNw6xL3bj2Bw0rEBeu3ZCohcjJZFNQMchm9qObAKSO5viPufoqhkDJMNt58P96NJcjrAFgl1vTbHtROZyilx3wqBEL0bKIptizyY0YtuJjGyKD9kUHdkUHdtOx2dT3D1H5z22RN7+ckfgflpmujgc9p7nwfD5xFNX3+xxh9MpaRlptu870rGyPm/j2Fk/d3qaOF02H8NuGFJfWxe4u++gPPnPTfsmdJFSFdnUHNkUDdkUFdnUbsim1meTnqNVnJ8mThtHkx6k62kZlbW+Zs+RTdIh2eSO5x9X1jbI+0t2mj87XU4pnThSMnOz41qgrqK6vFK+W7QscD+/R5H0HznEXE92pyG4cVWZ7Ny4LfDYwDH7SF73AnHoYFGbq6+pk9VfLhNPnUcWrq2Qsu21MqBHZqIXK6WQTZGRTZGRTdGRTfEjm1qfTUeOKZB7zhwkmUGTWNiVx2vIXW+slxc+sc6rUWRTx2VTXFvcqs01UtdgdTwVFHdjBw+SXZC7tyXWUjygFwcfQa3Uxf17B+7rdpPfo5AdfK/0rAwp7NUjcH/p+sqELk8qIpsiI5siI5uiI5viRza1PpsuOrSEwihoqOFFh/QM3CebOjab4trq6hoau/hcbpt364UTtNG63HF10nU5wQdjbDvNBW8vwfsZWodsagHZFBHZFB3ZFB+yqfXZlJfF+gmWuXeWQ8W207HZREkOJCHaggAkI7IJnYVtLZSDNRJVe64diiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAxS0p7Mdj0+S8sWmtfv2XW7xyzXt1Yic9sx0yc5hbJpQ4pU+uU7LTRLw+kd11hqza5ZO567wyt8wrPkNs57oD0uXoIS3vAvM3euXGufbabhAfsqllZFNkZBM6CtmEeFxnk2xK6eII0U3u7ZRZP8yQTLcj5HG3U6TE7ZCSHKdM7eeWGaXWRuzxJWxRAdgI2QQASFYpXRytK/fJ/8oaIj4/tqdLijIb//iu2GGfv7Auh8h1B4YefOypM2TZDp8UZIiM6O4KPD6xl0tOGe6WF5ZFXpdd3e5aQ77a6g373Mpd9tlu0D7IpsjIptiQTWhPZBPay+4unE0pXRx9UOY1b+HoH9nnZ2YF7nu8hryywj5/YIcUOkICTg8+LnizRnbv7eU8f2yanBvUta6BaOcDkLXlPrnto/pELwa6CLIpMrIpNmQT2hPZhPaytgtnU5edkOGEfdwhLZNzyryyvcY+g9ebDkPZVOkLHHyoFTtDX1Dpsc+6ARKJbAq9TzYBycHu2QR0iZ6jSNKcIjP3CT3h8MVlHrGT7/cYsrHSZ57orIYWOWXaQJfMW++VggyHnDQ89Kt/b629W4eKsx1yyb5pZot2ndc6YFuw2SfLGVKAdkQ2kU2xIpvQGcgmxKq4C2dTlyyOjhzskqKsxtaPzzd5ZfVue7V+eA2ROz+ul9sPzpDuWQ5xOR1yy9SMZq+rqDfkyUX1Mn9j6m/M8eib55RTRoR2pP5kvMiizV757Sf1tJ6hXZBNZFOsyCZ0BrIJserbhbOpSw6rO3UErR9Kq/dL/lMrS7eHH19c7zXkhW885pS5CE9PCL/3sAzJaDxHHGgzsslCNsWPbEJ7IpvQXiZ2gWzqcj1HB/RxysCCxppPr5eh3Xx2NLWfS64/MF1y0qzWoPJawxzPn793Rqh0l0Munpgu00vdcv2cOtlSlbpVflvo7/v8Nx6zlWN9hSG7ag2zm/iYUrf8aJRbnA5rvQ0ocJrXY/mnjU8KR/zIpkZkU3RkEzoT2YTW2mKTbOpyxdFpI2n9UH3zdKhKunmQoVbv9smV79ZK1d7VcfRglzmdruqf75TL90+Xmz9I3Qt2tcXTXzffNjZWGvKXxR7JdIucPLxxW5rSx5WyOzmSA9lkIZtaRjahM5FNaK2nbZJNXWpY3T5FDplQ0tiPt6XKJ+/bdFiGnuDsP/hQ/13dEDj4UO+s8Up10CxQ+/d2mhdghGVhk1YzPTcCaCuyqRHZFB+yCe2JbEJ7WdiFssnZlVs/Xl3RID57jcYIKG6yUYZbDcGPuZ0OyUsX2wg6Ngurd27oC6qYThhxIJsakU3RkU3oTGQTWstlo2zqMsWRjnk8ZEBj60dlvSH/XpWa3XntYWt16EZ51GC3ZAcNojxqsCsw3t+/EZfbaOTKmGKnPHREhnnuQ9Mdflg3p5wzOvQPxpJtjL9G25BNocim6MgmdBayCbEYY6Ns6jLnHJ083G22MPrpDl5t4318bplXzh1jSNreLbi0yCnPnJAl3wad9Bxs9hr7tRaN7ekybzUewzwBVacOLs52SmmRI3BSof/g7MUUHTeLxCObQpFNLSOb0BnIJsRqrE2yqUsUR9rqOKO08VfxeA15ZUXqfintYUOFIQ/Or5erJqcHDkIKMx0yuU/zuRUXb/HKn7+01wmYwcdaWWkOc2cPZ0eNIbd/VJfS8/Ujccim5sim6MgmdAayCbEybJRNXaI4mjHULbnpjRXrnDJvSn8p7UVPbP56W60cN9QtE0qc0ifPaQZig0/M6Re16tdWXL2WiN3W1ldbrRmydDaVkT2c0i/PIfkZDtGtqLJeZG25Tz7d6JW3vws9WRyIBdkUHtkUGdmEzkA2IVZf2SibukRx9NLyBvMGCTvF4pM2a3ltra+3+cwb0FHIpsjIpsjIJnQ0sglt8bVNsqnLTMgAAAAAAPGgOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAA7VAcORyNPxvxvJENGAZrKFjI6mDVRN1enME7GlqFbGo9sikU2RQd2RQfsqn1fKygyFnNuunQbIqrOOqRmxb4uWZPVVwL0hW/JG+DN3C/poL1E6y2qjrkZ5/Pl9DlSTbB20u3oP0MrUM2RUY2RUc2RUc2xYdsan02LVnfuC9CZOXmmsDPZFPHZpM7nn88uGeWeVuztUaq91RK2TffSV73AnE47T1az/D5pHzrTvEF7eQbV5aJp65e0jMzQpuObMcQT51Htn+/OfCIhuGaL1dIUe8e4nS5xNYMQyp3V0j5tl3m3fwsl0wqzU/0UqUcsik8sikasikqsqldkE2tz6bfvLZeNu2ul37dMsRp42jSDpEt5fXy1/9tDTxGNnVsNjmMOMdU/N8HG+W651bGtRAAwrv62AFyw8zBiV6MlEQ2AR2HbGo7sglI7myKu6ni/EP6yK2nDpHsdHu3eoSTl+mSu380VKYOK0j0oiSlsf1z5eHzhkl3hmY0k+52yKVH95frTxiU6EVJWWRTZGRTdGRTZGRT/MimyMim6MimzsmmuHuO/KrqvPLB0l2ycVedNHjtfaZYmsshA4sz5YcjiiQjzQq/tdtqZN6K3bKnprHL2K5yMl0yuTRfhvfJMe/r9jLv292ycnO1eBrsve3oyIqSgnSZNqqb5GfHNeoVe5FNjcim6MimyMim9kc2NSKboiObOjeb2q04AgAAAIBURp8uAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOEou559/vjgcjma36dOnB16j91977TVJNnV1dTJhwgRz+b788stELw4Am2fToEGDmi3vb3/720QvFgCbZ5P697//LVOmTJGsrCwpKiqSE088MdGLhCDu4DtIPN2hn3rqqZDHMjIyJNldd9110qdPH1m8eHGiFwVAB0jFbLr99tvl4osvDtzPy8tL6PIAaH+plk0vv/yymUt33XWXHHbYYdLQ0CBLlixJ9GIhCD1HSUZ36F69eoXctFXB3xKqTjrpJLMlxH//u+++k5kzZ0pJSYnk5ubKpEmTZPbs2SHvq6+944475Mwzz5ScnBzp27ev/OEPfwh5ze7du+Wiiy6S4uJiyc/PN3fa1hQ7b7/9tvz3v/+V++67rx3XBIBkkorZpMVQ8PLq+wPoWlIpm7QQuuKKK+Tee++Vn//85zJs2DAZNWqUnH766R2wZtBWFEcp5PPPPzf/ry0kmzZtCtyvrKyUGTNmyHvvvSeLFi0yW1GOP/54KSsrC/n3ujOOHz/efM0NN9xg7qDvvvtu4PnTTjtNtm7dahY7CxYskH333VcOP/xw2blzZ8Rl2rJli9kC8swzz0h2dnaH/e4AklcyZpPSYXTdu3eXiRMnmp+hByYA7CPZsmnhwoWyYcMGcTqdZi717t1bjjnmGHqOko2BpHHeeecZLpfLyMnJCbndeeedgdfoV/bqq6+2+F6jR482HnnkkcD9gQMHGtOnTw95zRlnnGEcc8wx5s8ffvihkZ+fb9TW1oa8prS01HjiiSfCfobP5zPf84477jDvr1mzxly+RYsWxfibA0hmqZZN6v777zfmzJljLF682Hj88ceNwsJC46qrrorp9waQ3FItm/7+97+byzNgwADjpZdeMr744gvjzDPPNLp3727s2LEj5t8fHYNzjpLMtGnT5PHHHw95rFu3blH/jbaA3HrrreYJftoyoq2jNTU1zVpADjzwwGb3H3roIfNn7QbW99FW1mD6Ptr9HM4jjzwiFRUVcuONN8b0OwJIPamUTerqq68O/Dxu3DhJT0+Xn/3sZ3L33Xcn9fkIALpuNvl8PvP/N998s5xyyimBXq1+/frJiy++aGYUEo/iKMnouNahQ4fG9G+uvfZas5tXz/nRf6uzn5x66qlSX1/f6vfQHVy7d+fOndvsucLCwrD/5v3335dPPvmk2YHG/vvvL2effbY8/fTTMf0eAJJXKmVTODozlB4ArV27VoYPH97qfwcguaVSNunrlZ5n5KfHUEOGDGlWmCFxKI5STFpamni93pDHPv74Y3M6Sz3h0L/D6gFAU59++mmz+yNHjjR/1nGymzdvFrfbHThhsSW///3v5Te/+U3g/saNG+Xoo4+Wf/zjH+aBCAD7SKZsCkcvMaDj/Hv27Nnm9wCQepIpm/bbbz+zGFqxYoX84Ac/MB/zeDzmZw8cOLDNvyPaF8VREl4vSHe2YLrj9ejRw/xZd0A9gXDq1KnmDqYzsuyzzz7yyiuvmCcT6mwsv/71rwNdt03D4J577jHn09cWE+3C1S5ldcQRR5jdxfqcvkZnUNFiR5/X8NDeoKYGDBgQcl9nfFGlpaVmFzGAriOVskl7tD/77DNzuI3OWKf3r7rqKjnnnHMCs1gB6BpSKZt0RjudpW7WrFnSv39/syDSSR/8kzsgSXTQuUxo44mF+pU0vQ0fPjzwmjfeeMMYOnSo4Xa7zZMF/RMhTJs2zcjKyjL69+9vPProo8YhhxxiXHHFFYF/p6+97bbbjNNOO83Izs42evXqZTz88MMhn79nzx7jsssuM/r06WOkpaWZ73X22WcbZWVlrVp+JmQAuqZUy6YFCxYYU6ZMMQoKCozMzExj5MiRxl133dXsxGkAqS3VsknV19cb11xzjdGzZ08jLy/POOKII4wlS5Z0yPpB2zj0P4ku0NDxtOXkyiuvNG8AkCzIJgDJiGyyL65zBAAAAAAURwAAAABgYVgdAAAAANBzBAAAAAAWiiMAAAAAoDjqGnSO/tdeey3RiyFPPvmkOW+/XmjxoYceSvTiAEgwsglAstELrmo26YWhE+3WW2+VkpKSpMlKWCiOkszll18euILyhAkTErIMemE0vXhZYWGh5OTkmMvxzDPPRP03e/bskUsvvVSuv/562bBhg/z0pz+Naxn0ImkaFhzIAMmBbLKQTUDyWLx4sZx55plm40dWVpaMHDlSHn744U5fjrvvvlsmTZpkXnS6Z8+e5oVhV6xYEfXfLFu2TG677TZ54oknZNOmTXLMMce0+fN1+gD99xRZ7cPdTu+DdvSTn/zEvLr7V199lZDP79atm9x8880yYsQISU9PlzfffFMuuOACc4c/+uijw/6bsrIy8Xg8cuyxx0rv3r3j+vxXX31VPv30U+nTp09c7wOgfZFNZBOQTBYsWGDu/88++6xZIM2bN89sAHG5XGajSGf54IMP5Je//KVZIDU0NMhNN90kRx11lCxdutRsyAnnu+++M/8/c+ZMs6iJhzbWxPseCNLGi8di75WRzzrrrMCVkx944IFmV1huq1mzZhnjx49v1Wv1a/zTn/5knHjiiebVnvVK0K+//rrRniZOnGjccsstYZ976qmnml2dWq8+3Rbr1683+vbta14tWq9O/eCDD8a55ID9kE0WsgmwTzb5XXLJJca0adMiPq8ZoFnw8ssvG4ceeqiZTePGjTPmzZvXbsuwdetW8zM++OCDiDnaNJvaatGiRWY2bdq0yXyfV199NY4lh2JYXRyuvvpq+fjjj+WNN96Qd999Vz788ENZuHBhsyEYubm5UW/tQbtmTz/9dLNFd8aMGXL22WfLzp07A8+3tAy6nOHo8c17771ndg8ffPDBYV9zxhlnyOzZs82f58+fb3YPawuOro+WPve5554LvI/P55Nzzz1XfvWrX8no0aPbZb0AdkQ2WcgmwH7ZVF5ebvYyt0R7oa+99lrz3KNhw4aZw/O018ff49zSMtx1111Rl0FFWg793Keeesr8WXNJb0pzp6XP1XXmV11dLWeddZb84Q9/kF69erX4O6N1GFbXRhUVFfL000/L888/L4cffrj5mG7oTYdb3H777eZO0NHOP/98c8dWusP+/ve/Nw8Gpk+fbj7W0omH+fn5zXbsvn37Sl1dndk9/dhjj8mRRx4Z9t/qON/u3bubPxcXFwd2UD03oKXP1RMR/X73u9+J2+02z20A0DZkUyOyCbBXNumwun/84x/y73//u8XX6mfocFt/I442fKxatcoctqvL1FJGRCp8tDHlyiuvlKlTp8qYMWPCvkaLHD13UgUXNSeccIJMmTIl6udq/vldddVVctBBB5lD89B+KI7aaPXq1eY49smTJwceKygokOHDh4e8TsfC6q2jjRs3LvCzjm/VA4qtW7cGHhs6dGhM76cnFWowVFZWmq2z2tozZMgQOfTQQ1v9Hnpg0trP1XHDehKltiAxbhZoO7KpZWQT0PWyacmSJWaRMGvWLPN8n1iyyX8+omaTFkfaGBJrNvnpuUe6LB999FHM/1bzTW+tob1v77//vixatKgNS4loGFbXwTpr6EpaWlrIff0jrq0XbR26olPeajDobFDXXHONnHrqqeZsLLGIZeiKvlZDacCAAWYo6W3dunXmZw8aNCiudQOgObKJbAK6SjbpxAfaG6WTMdxyyy0xZ5O/4cOfTW0dVqeTQOhEMXPmzJF+/frF/LvHMqxOCyOd1EF7oPzZpE455ZSYGovQHD1HbaQtlbpjff755+YfTf9wj2+//TZk/HtnDV1pSaxDV5rSwNBhLLGIZeiKjuc/4ogjQp7T2af0cZ2NCkDrkE0tI5uArpNN33zzjRx22GFy3nnnyZ133tkuyxrrsDo9B/Kyyy4zZ7ScO3euDB48uE2fG8uwuhtuuEEuuuiikOfGjh0rDz74oBx//PFt+nxYKI7aSLs9dUfUE3R1B9EuYO3K1VbN4KEXsXYP63hXHS6yefNmqampCeyco0aNMqeubatYuoe1FVYPHkpLS82Djrfeesu8lsjjjz8e02fGMnRFzwvwnxvgpyGqY3GbdrkDiIxsahnZBHSNbNLha1oYaYOFDrHVfFJ6PqKeZ9hWsQ6r06F0ei7V66+/bv6e/uXQYYOaNx0xrE4zKNwkDFp4trU4g4XiKA4PPPCA2f173HHHma2b1113nXz//feSmZnZ5vfUVgCdL99v4sSJ5v/XrFnTaUM4qqqq5JJLLpH169ebO7WOv9VrCOjMTwCSH9kEwA7Z9NJLL8m2bdvMHNCb38CBA2Xt2rXSWfwNNE2Hs+mEEzopDVKLQ+fzTvRCdBX6h1u7O++//3658MILE704AGAimwAkI7IJyYieozjoDCHLly83Z17RcbM6TlYxpSKARCKbACQjsgmpgOIoTvfdd595EUIdc7/ffvuZs4j06NEj0YsFwObIJgDJiGxCsmNYHQAAAABwnSMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAACLW9qJz2fI4rIKWb+jTnyGIXbmdjllYI9MGd0vRxwOh/lYRU2DfP7dHqmobRC7y8lwycRB+dI9Ly3w2MpN1bJyc7V4vD6xM6fDIT0L0mW/wfnidlnbDuJDNjUim6IjmyIjm9of2dSIbIqObOrcbGqX4uiV+Vvl9pdXy8Zdde3xdl2G7ui3nTZE3ly4Xd5YsE3qG+wdfsFcTpEjxnSXC6f1kVkvrpZlG6sSvUhJpUdemlx97EC56LC+iV6UlEY2hUc2RUY2RUc2tQ+yKTyyKTKyqfOyyWEY8TVXvPHFNrn4T0vF5o0eEWkDCOsmMqdDxMf6ieiuHw3lIKSNyKboyKboyKboyKa2I5uiI5uiI5s6PpviLo4Oue0LWbbBql6zC3Ilr1uhOPWbszGfzyfl23ZJbWV14DHtJi7q3UPSszLFzmtHNzZPXb3s2rRNfEFdwRlZmVJQ0k1cLpfYme6OVbsrpGJneaAl5Kt7DmQYSxuQTc2RTZGRTdGRTe2HbGqObIqMbOr8bIprWF3Z9trADp6ZkyVDJowIjBW1u+L+vWXpxwsDG3LvoQOke9+eiV6spJFTkCtl33xn/ux0OaV0v1Hictt7B/crHtBb1nz1rVTuLJftFR5ZsGaPTBlakOjFSilkU2RkU3RkU2RkU/zIpsjIpujIps7Lprhmq9tS3jhWNqcwjx08iMPpEFeaO2T9oFF2QeP6yMzNZgdvIjdoe9laXp/QZUlFZFNkZFN0ZFN0ZFN8yKbIyKboyKbOy6a4iqPgMY/s4NGxfkIFrw3WTXPB68Tusxi1BdnUeqyfUGRTdGRTfMim1mP9hCKbOi+buM4RAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAi4pYU1zvHIVP6umR4d6eM6OaUfvkOcTocgeevnl0ri7f6xI7cTpHxPZ0yttglI3s4pTjbIUWZDslyi1R7RNbt8cknG7zy5soGqW4Q2zlysEvGFbuktMgh3bIckp/uEN10dN1sqPDJl1t88q9VDbKt2kj0oiIFkU2RkU3RkU3oSGRTZGRTdHbJppQvjo4c4pbzxqYlejGS0pBCp9xzWGbY5wpcIuMyXTKup0tOHu6Wm+bWyerdqb0xx+rcMWnSN69552m6S6Qw0yWji11y8gi33P5RnczfaM8/FGg7sikysik6sgkdiWyKjGyKzi7Z1KWG1dU1GFLbYK8NtbU8XkOWbvfKpxu8srEidIMtznbKbQdnSFqX2hpax2cYe1s7rHWzrjx03WS5HXL9ARlmaxLQVmRTZGRTeGQTOgPZFBnZZN9sSvmeo2+2eeX+z3yyYodP1pQbcu9hGTKhxJXoxUoa26t98sLSBvnvmgap8jQ+fs4Yt1wwLj1wv0+uUyb1dsm8DV6xiycXeczg21kb+vjB/V0y64cZgfuFmQ4ZXOCQlbv4A4LWI5uiI5siI5vQkcim6MimyOySTSlfHC3YnLrddh1t/R6fnPevWqkNs98+u6RBji11S8+cxtJ+QL5D5m0Q2/hoffhA+9/3XqmoNyQvvXEMdr19sg/thGyKjGyKjmxCRyKbIiOborNLNqVwpxdaoicLhtvB/XbWhlb0lUEtJHb2g36ukB1cu4+/r0jN1g8gGZFNbUM2AR2LbGqbrpZNKd9zhLbpkeWQ0kJnyBhSHT9qR+ePS5OB+Q7JcDukT65D+uc3rpctVT6546M68aXuPg6kFLKpEdkEJA+yyT7ZRHFkQ3oC4Y0HpUuaq7HKf3+tV9ancJUfjwk6bWfP5uOtV+70yd2f1Mm6cnuuF6CzkU2hyCYgOZBN9somhtXZTE6ayN2Hhp58qSdnPjC/PqHLlYz26eaUJ4/JlOOG0oYAdDSyqfXIJqDzkE32y6bUXnrE3CV897QMcx5/v0WbvfLr/9VJnT17hk1Xzq4z/5/tFumV65Bjh7rlxGHWNSDcTodcvn+aLNnmlbUp3hICJCuyKTyyCUgsssme2UTPkU0MKnDII0eF7uCz1zbIDXPrpMaGV3mOdCKmXtDtkS888vH3jSvF5XTID/szzSnQEcimlpFNQOcjm+ybTfQc2cD4ntbFyoJnEnluiUf++hXTrESyvSa0taNbVuO6A9A+yKbYkU1AxyOb7J1NFEdd3LSBLrnugHRJ33sSYYPPkIfm18vbq23cHywixwxxiV4UfN56b8hF3tSoHk6ZNjB019ho05MugY5CNoVHNgGJRTaFZ6dsSvniaEofp5wzxhrnqAYWhI4UvGJSulR5Gr+gy/5rjZO0g32KHHLTQenidDRW79uqDZncx2Xemppb5pUPyuyx8w8udMopI9LE4zWkbI9hrhddTb1yHM22Ib2w2Xtr6UNHbMimyMimyMgmdDSyKTKyKTI7ZVPKF0eFGQ4Z1SPyuMamX5idZKc5QnZw1TvXad7CWWOeOGePndxPp+UsLdJb+Od31BjmfP07azt7yZDqyKbIyKaWkU3oKGRTZGRTy+yQTSlfHAFt8fZ3DWbLhv6B6JPnkIIMhznrSr3XugL22t0+mb/JJ7PXNES9WjYAtCeyCUAyettG2ZTyxdE7a7zyzprqRC9GUlq81SeHP8+6idTas6Zcu3xTt9sXyY1sioxsioxsQkcjmyIjmyKzUzbZt+8UAAAAAIJQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAACAdiiO0t2OwM8+ry+et+qajMYffV5vIpck6fh8jSuHbac5b9D2kuaiDSNWZFMLyKaIyKboyKb4kE0tIJsiIps6L5vi+teDirPE//nl23eJp84T18J0JfU1teKpb1wfOzZuE8MI2uttTNfDrs3bAvdrKqqkek9VQpcpmXgbGqR8y87A/X16ZSd0eVIR2RQZ2RQZ2RQd2RQ/sikysikysqlzs8lhxLnlnfHwVzLnm12B+06XS6SxYcSejPAtHg6nQxxOWtoMnyGGr3mrB9uOxdfQuO2M7JMjH9y6f0KXJ1WRTWGQTVGRTdGRTe2DbAqDbIqKbOrcbHLH9a9F5P+dPEQ+Xr5Q6r1WjUU3aChtIfL3flobN+snWLrLwbYTgdMhcuvpQxK9GCmLbIqObIqObIqMbIoP2RQd2RQd2dTx2RR3Of7UBxsDXxKaY1hodGw7kenw4r++vzHRi5GyyKboyKbo2HYiI5viQzZFRzZFx7bT8dkUV89RfYNPXv9iW6DSv/v0gXLIyHzbn6RZ6/HJf77aJbe/uj7wWFZutvQdMVjSMzPEYfMuUB1jvXHlOqnctSfwWM9BfaRbn57isvm2o4Ncq3ZXyPfLvjNPuJy9ZIfsqPBI97y0RC9aSgnOJtVv5BDJ71ZgDtGw+wm95Vt3mvufH9kUPZsuPbKXnHFAD8nJcImdeX2GfL66Uq59fq1U15NNbUU2hUc2RcdxU+ceN8VVHH27qVrKqxvMn48cUyjH79stnrfrMrLSnXLmgcXyx/c2y9Y91vrpVdrf3NEhkpHtkt5D+8vKz78x76dnZUjJoL6JXqykkd+jUIp6F8uO9VvMFrRFa/fIEWO7J3qxUkpwNhUUF0lRCetPOV0i3fv2lK3rNkrD3hOfyabI2TSwR4b88sjeiV6spDFtVIGcNqW7PP3hNrKpjcim8Mim6Dhu6tzjprjKzaq6xrGOvQpoPWoq3d24etMy0hO6LMnGnda4vbBumgteJ8H7GVoneJ2xfTUX3ErN+omcTfxda65XAdkUD7IpOrIpMo6bOu+4qd364hx27/ME2hF7E5B4/FkDgNTQnnFt74GKAAAAALAXxREAAAAAUBwBAAAAgIXiCAAAAAAojgAAAADAQnEEAAAAABRHAAAAAGChOAIAAAAAiiMAAAAAsFAcAQAAAADFEQAAAABYKI4AAAAAgOIIAAAAACwURwAAAABAcQQAAAAAFoojAAAAAKA4AgAAAAALxREAAAAAUBwBAAAAgIXiCAAAAABExJ3oBUDnynSJPDkjU/rmhdbFZ71eI1uqDLGrSb2dcsQgt4wqdkpRpsN8rLzWkI2Vhny9zSevf+uR8rpELyVSGfteeOx7QGKRTaF6Zjtk5jC3TChxSp9cp2SniXh9IrvrDFm1yydz13llbplXfPZbNbbJboojm/npxLRmAWhnOWkit0zNkMl9XM2ey8p1SK9ckX17uWThZq+Ub/MlZBnRNbDvhWLfA5ID2dRocm+nzPphhmS6rYN9P7dTpMTtkJIcp0zt55YZpV65cW6deGwYTTk2yG6KIxvZr5dTZg5LS/RiJA0Nu3sOy5AR3Rt38HqvId/vMWRbtSEFGSL98p2Slx4akkCs2PdCse8ByYFsauRyiFx3YGhhtKfOkGU7fGYmBefVxF4uOWW4W15Y1iB24rZJdlMc2ajSv3ZKuvlzZb0h2huc6htvvM4Zkxayg2srx/2f1cvmoGEETofIhJ5O2Vxp8/5ztBn7XnPse0DikU2hhhQ6AsPD/IXRBW/WyO69Q8POH5sm545tLCTH9nTZrjg6xybZTT+qTVy6f7r0zLG+7ke+qJeq+tTdaNtrjPVJwxrbBnbWGHL7R3UhO7jSMcULt/hke4291xfajn0vFPsekBzIplBNh8htqvQFCiO1YmfoCyo99lpfmTbKbnqObGBqP5ccNdj6qv9X1iCz13rlgnH27kYfV+KU3KAWsnkbvNInzylT+7qkJNchHq/Imt0++aDMm9I7OBKLfa859j0g8cim5nRo2MZKnzkJgxpa5JRpA10yb71XCjIcctLw0EPm99baq9donI2ym+Koi9Pxn1dNsrrNd9UY8tDn9YlepKQwvFtop+mUPk45bmhms9ddPMGQvyz2yIvL7RWCiB/7Xnjse0BikU3heQ2ROz+ul9sPzpDuWQ5xOR3mxANNVdQb8uSiepm/MTUnG2ir4TbKbobVdXFXTkqXoiyr0n9gfn3KTqvY3gqDxhWr4uzwu0KayyE/3zddZpQ2n5UFiIZ9Lzz2PSCxyKbIlu/wySX/qZWl271hn9fJB174xmNO5203hTbKboqjLuyIQS45eIDVOfjO6gazCxQWt54x2MScdQ1y+qs1ctLL1fLSck/IcxeOTzdPMgRag30vMvY9IHHIppaHG/71uEwZ1cMVuG7P/I1eWb7DWk/pLodcPDFdHpueKSU59gomt42ym+Koi0pzWidbqi1VPnn0C7rNg1U3OZHS6zPkofn1sqPGkD11Ik8s8siuWiOkxaS0MEX3cnQq9r3o2PeAxCCbouubp8Po0iUnzcqb1bt9cu6/aszrGf3ynTq555PGLrb++U65fO+6tItqG2U35xx1Uemuxik5CzMc8uwJWSHP5zbZp/84PVMMQ+SRBfUyxwbdxRsqQndynZGm0hM624rOVFOk07PslZ+h6zO1TzJEx2Pfi459D0gMsik6nXxBe4b8/ru6QaqCsumdNV65dH9DsvcWT/v3dprX/WmwyalHG2yU3RRHNpDhdkhGC9+0tQGLpNukL3HJttCgz00TaboL5ze53kNwiwjQGux7zbHvAYlHNjVXvPc8LL9wqWM0GWaWl675JLawxEbZbZNNHgi1ttwIjCH2/6E4ekjQ1a9LnOZVnv10Rp81u1NzJweSCfsegGS0tTo0Z3Sq8+ygAvKowa7AkDtV5TFsNZnFWhtlNz1HXZR2BR/+fHXE5587IVN67Z3LX531eo1saXIhr67uDws88tARTnO6TnXNlHQ5ptRndpGP7hHabvB/X3tSsGMYicC+1zL2PaDzkU3RzS3zyrljDHO2NVVa5JRnTsiSb3f6JD9DZET30NnXZq9pMIeS2ckfbJLd9BzBtpZu98ndn9SbU3Mqp8MhY4pdMqHEFQhHn2HIc0s88uaq1J2vH0g27HsAkvGcmgfn14tnby75JxWY3MfVrDBavMUrf/4ydHY2O1hqk+ym5wi2pieZLtteK6eOcMt+vVxSnOMwWwx09pWvt/nk9ZUNsmKHTc62BDoR+x6AZKOTLny9rVaOG+qWCSVO6ZPnNIfWac+Inj+zapfP7GHS6xylaq9IvObYILspjmzq7DdscgZhK2yuMuTRBdoCZL9WIHQ+9r1G7HtA8iCbLBsrDXnShr1CsdjcxbObYXUAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAADtWRz5DKO93qrrCFklrJ9gbC7RsXraD+uyJayhSNnk8yVySZKTQXi3G9ZkS1hDwdj1ojOSpTjKy3QFfv5+R317LE+XUuNp/MtaX1OX0GVJNp76+pB1wx/cUPU1tYGf87LcCV2WVBScTex7zfm8ZFNrsun7nWRTU2U7G9cP2RQ7sik6sikyjps677gprn89vE+O9MhLk+0VHnl/abk89u5GGdM/R1xOh9iZ12fI/O8qZUdlQ+CxjavKpMTTIK50XeU2Xz8NXtm2bmPgvqeuXtavWCsFPQrF4bT3SE8Nu7qqWtm1abt5P8PtkElD8hO9WCknOJsqduyWLWs2SHZ+jojD3vuebl9VuyrE6yGbWpNNm3Z75NcvlskRYwolzW3vdaPHYSs318jL83eY98mmtiGbwiObouO4qXOPmxxGnKXnHa+slkf+831cCwEgvFOn9JTHLhyZ6MVISWQT0HHIprYjm4Dkzqa4y83p47uL22Xvij4al70L+ha5bd7LGI02JB67b49EL0bKIpuiI5uiI5siI5viQzZFRzZFRzZ1fDbF3XN0wr1fyqcry82fXWluyS3Ms30Xn8/nk8qde8Tn9YY8npWfIxmZGbbvPtfu4KrdFSGP6TaT1y1fnK7G8dh2pLtjdXmFeOo85v1BxZny2W8mi8Pm20xbkE3NkU3RkU2RkU3th2xqjmyKPZsy0xwydVi+5GTYe9tp8BqycG2VbC5vv2yK65yjrXvq5bNV1g6elpEuwyaPsf0fEL8GT4Msn/dl4IS54gG9pdeQfolerKSxY8NW2bhynXXH4ZBhk0ZLelZmohcrKRg+Q1YtXCq1ldWydlutfLO+Ssb0z030YqUUsikysik6sikysil+ZFNkZFPrs8ntFHnj6pHSv3tGohcraQqkMx5dIUs31LRLNsVVbq7fURuYWjCveyE7eBB3mlvcGWmB+wU9uyV0eZJNfo/CwM/ZedkcfARxOB1SUFwUuL9ue+MMLGgdsikysik6sikysil+ZFNkZFPrs0knP6MwaqTDVI8aW9hu2RRXceTxNo7IczIGMiqnzbvMmwru7rT7cIKWtpeGoKlN0TpkU+uRTaHIpujIpviQTa1HNkXOJh1Sh1AZ2p3WTtnElgcAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAACiOAAAAAMBCcQQAAAAAFEcAAAAAYKE4AgAAAACKIwAAAACwUBwBAAAAgIi4JYX9eGyanDc2rdWv/3KLV655r07spGe2Q2YOc8uEEqf0yXVKdpqI1yeyu86QVbt8MnedV+aWecVniO1cd0C6HD2k5V1g/kav3DjXXtsN4kM2tYxsioxsQkchm1rG/oeULo4Q3eTeTpn1wwzJdDtCHnc7RUrcDinJccrUfm6ZUWrt4B5fwhYVgI2QTQCAZJXSxdG6cp/8r6wh4vNje7qkKLPxj++KHfb5C+tyiFx3YOjBx546Q5bt8ElBhsiI7q7A4xN7ueSU4W55YVnkddnV7a415Kut3rDPrdxln+0G7YNsioxsig3ZhPZENsWG/c+eUro4+qDMa97C0T+yz8/MCtz3eA15ZYV9/sAOKXSEBJwefFzwZo3s3tsDfP7YNDk3qGtdA9HOByBry31y20f1iV4MdBFkU2RkU2zIJrQnsik27H/21GUnZDhhH3dIy+ScMq9sr7HP4PWmw1A2VfoCBx9qxc7QF1R67LNugEQim0Lvk01AcrB7NgFdoucokjSnyMx9Qk84fHGZR+zk+z2GbKz0mSc6q6FFTpk20CXz1nulIMMhJw0P/erfW2vv1qHibIdcsm+a2aJd57UO2BZs9slymw8pQPsim8imWJFN6AxkU3jsf/bUJYujIwe7pCirsfXj801eWb3bXq0fXkPkzo/r5faDM6R7lkNcTofcMjWj2esq6g15clG9zN9o7x29b55TThkR2pH6k/EiizZ75bef1NN6hnZBNpFNsSKb0BnIpvDY/+ypSw6rO3UErR9KWzYu+U+tLN0efnxxvdeQF77xmFPmIjw9IfzewzIko/EccaDNyCYL2RQ/sgntiWyKDftf19bleo4O6OOUgQWNNZ9eL0O7QO1oaj+XXH9guuSkWa1B5bWGOZ4/f++MUOkuh1w8MV2ml7rl+jl1sqXKXi0g+vs+/43HbAFaX2HIrlrD7EI/ptQtPxrlFqfDWm8DCpzm9Vj+aeOTwhE/sqkR2RQd2YTORDaFYv9DlyuOThtJ64fqm6dDVdLNgwy1erdPrny3Vqr2ro6jB7vM6XRV/3ynXL5/utz8gb0uZvb01823jY2VhvxlsUcy3SInD2/clqb0cRGAiAvZZCGbWkY2oTORTaHY/9ClhtXtU+SQCSWNfZxbqnzyvk2HZegJzv6DD/Xf1Q2Bgw/1zhqvVAfNArV/b6d5AUZYFjZpNdNzI4C2IpsakU3xIZvQnsim2LD/2YOzK7d+vLqiQXz2Go0RUNxkhw23GoIfczsdkpcuthF0bBZW79zQF1QxnTDiQDY1IpuiI5vQmcimUOx/6FLFkY4HPWRAY+tHZb0h/15l367OrdWhO+xRg92SHTSI8qjBrsB4f/8OXm6jkStjip3y0BEZ5rkPTcNwWDennDM69A/Gkm32HX+N+JBNocim6MgmdBayqTn2P3Spc45OHu42Wxj9dAevtvE+PrfMK+eOMSRt795dWuSUZ07Ikm+DTnoONnuN/VqLxvZ0mbcaj2GegKpTBxdnO6W0yBE44dJ/cPYiY4rRRmRTKLKpZWQTOgPZFB77H7pEcaStjjNKG38Vj9eQV1bYe4PdUGHIg/Pr5arJ6YGDkMJMh0zu03zeycVbvPLnL+11AmbwsVZWmsMMwnB21Bhy+0d1XMsAbUI2NUc2RUc2oTOQTeGx/6HLFEczhrolN72xmp9T5mWD3Xti89fbauW4oW6ZUOKUPnlOMxAbfGJOTaktItqKq9cSsdva+mqrNUOWzjQzsodT+uU5JD/DIboVVdaLrC33yacbvfL2d6EniwOxIJvCI5siI5vQGcim8Nj/0GWKo5eWN5g3SNjpJ5+0Wctra329zWfegI5CNkVGNkVGNqGjkU2Rsf+hy0zIAAAAAADxoDgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAABaKIwAAAACgOAIAAAAAC8URAAAAAFAcAQAAAICF4ggAAAAAKI4AAAAAwEJxBAAAAAAURwAAAABgoTgCAAAAAIojAAAAALBQHAEAAAAAxREAAAAAWCiOAAAAAIDiCAAAAAAsFEcAAAAAQHEEAAAAAO1QHLmcjsDPhmHE81ZdU9AqYf2ECl4fho9105QvaJ0E72doHbKpBWRTRGRTdGRTfMimFpBNEQWvj/oG1k1THq+v3bIpruKob1FG4OeKneVi+BoXzO58Xq80eDyB+xU7did0eZJN5a49gZ9rKqrEU9e4ruxOA7BiZ+P20rdb436G1iGbIiOboiObIiOb4kc2RUY2tT6blqyvlm0VZFNwNn2wbE+7ZZPDiLM0n37XQlm4tsL8OT0rQ/K6FYjDYe/WJG1Z053aU1cf8nhe90JzHdl77Yi5Xsq37Qp5zJXmloIeReJ02Xukp+6OVbsrpLaqJvCHdMHdU8RJC23MyKbmyKboyKbIyKb2QzY1RzbFnk3dctxyxJgCyclwiZ01eA35fHWlLN/UftkUd3H0wdJdcs6jX0sdXXxhuZ0OaWBoRkTpbgfdwxHo38rHLxwpJ0/umehFSUlkU3RkU3RkU2RkU3zIpujIpujIpo7Ppribwg4ZVSTPXjpW9hucF+9bdbkv6MB9CuS1a8fLZdP7S4+8tEQvUlIpyHbLeYf0lv/cOFGmjS4ywxCNRvXLkT9dPIqDjziQTeGRTdGRTdGRTfEjm8Ijm6Ijmzovm+LuOQq2aVedbNxVZ/uKP83lkH7dM6VnfnrgMa/PkG83VcuemgaxO+0CHtY7W9LdjbX5riqPrN1WY/vWEM26koIMGdAjM9GL0qWQTRayKTqyKTKyqWOQTRayKTqyqXOzqV2LIwAAAABIVfY+wxQAAAAA9qI4AgAAAACKIwAAAACwUBwBAAAAAMURAAAAAFgojgAAAACA4ggAAAAALBRHAAAAAEBxBAAAAAAWiiMAAAAAoDgCAAAAAAvFEQAAAABQHAEAAACAheIIAAAAgEDk/wPA1KVKJZUXZwAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 900x600 with 6 Axes>"
       ]
@@ -2265,10 +2265,10 @@
    "id": "visualization-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.005897,
-     "end_time": "2026-04-22T20:59:07.879272",
+     "duration": 0.012009,
+     "end_time": "2026-04-23T21:51:11.370335",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.873375",
+     "start_time": "2026-04-23T21:51:11.358326",
      "status": "completed"
     },
     "tags": []
@@ -2291,10 +2291,10 @@
    "id": "summary-table-section",
    "metadata": {
     "papermill": {
-     "duration": 0.005265,
-     "end_time": "2026-04-22T20:59:07.890506",
+     "duration": 0.011224,
+     "end_time": "2026-04-23T21:51:11.391578",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.885241",
+     "start_time": "2026-04-23T21:51:11.380354",
      "status": "completed"
     },
     "tags": []
@@ -2311,16 +2311,16 @@
    "id": "final-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:07.905160Z",
-     "iopub.status.busy": "2026-04-22T20:59:07.904958Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.038383Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.037803Z"
+     "iopub.execute_input": "2026-04-23T21:51:11.416547Z",
+     "iopub.status.busy": "2026-04-23T21:51:11.416095Z",
+     "iopub.status.idle": "2026-04-23T21:51:11.748655Z",
+     "shell.execute_reply": "2026-04-23T21:51:11.747895Z"
     },
     "papermill": {
-     "duration": 0.142165,
-     "end_time": "2026-04-22T20:59:08.039110",
+     "duration": 0.347726,
+     "end_time": "2026-04-23T21:51:11.749789",
      "exception": false,
-     "start_time": "2026-04-22T20:59:07.896945",
+     "start_time": "2026-04-23T21:51:11.402063",
      "status": "completed"
     },
     "tags": []
@@ -2334,15 +2334,15 @@
       "Tableau recapitulatif : Algorithmes de recherche\n",
       "================================================================================\n",
       "Algorithme Complet Optimal Cout  Noeuds explores Temps (ms)\n",
-      "       BFS     Oui     Non 1075                2       0.03\n",
-      "       UCS     Oui     Oui 1075               10       0.05\n",
-      "    Greedy     Non     Non 1075                2       0.02\n",
-      "        A*     Oui     Oui 1075                3       0.02\n"
+      "       BFS     Oui     Non 1075                2       0.05\n",
+      "       UCS     Oui     Oui 1075               10       0.11\n",
+      "    Greedy     Non     Non 1075                2       0.05\n",
+      "        A*     Oui     Oui 1075                3       0.05\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHvCAYAAAAvoP1zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe/9JREFUeJzt3QmcTfX7wPFnFmYsY+xbloTskTVLKpRsEb+ilAlRCqG/pGzJEiGRUIlkKRSVpGSd7LuslYSsyb6NMXP/r+db53bvzL3MjDtzz8x83r1Oc+8533vu95575vrOc5/zfAMcDodDAAAAAAAAAAC2EOjvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAACka4MGDZKAgACz3H777f7uDhLpmWeecb5/999/v7+7gzSMzwoAAJCSCNoCAGADJ06ckDfffFPuu+8+yZcvn2TMmFGyZMki5cqVk44dO8p3330nDofD391EOgqAui4hISGSP39+eeCBB2Ts2LFy5coVf3cVNrRu3Tp58sknTUAzNDTUfIYVLlxYqlWrZj7HJk+eHO8xGmi3zjM9/wAAAPCP4H9/AgAAP3n//ffl5ZdflqtXr7qtj46Olt27d5vl448/lgMHDpDdlQweeughyZo1q7kdHh7u7+7Y0rVr18wXC7qsWLFC5s6dKytXrpTgYIaS+MdHH30knTt3jvfl0uXLl+XPP/+UTZs2yRdffCHPPfec3/oIAACQmjDSBgDAj0aOHCl9+vRx3g8KCpImTZpIlSpVTObZb7/9Jt9//70JlsG78+fPS7Zs2ZL02Fq1apkF8b399tvm58WLF2XWrFny66+/mvtr1qyRhQsXSosWLZL1+S9cuCBhYWHJ+hzpyZgxY6R8+fJSv35981njK6dPn5bu3bs7A7aFChWS//3vf5I3b17zHu7cuVNWrVolyfWFgj6vZoMjeT8rAQBAyqI8AgAAfqIZtK+99przvgY4Nm7cKF999ZUMGDBA+vfvL5988okcPnxYPvjgA8mcObPb448cOSK9e/eWChUqmExRvRxZM3Gfeuop2bBhw03rMR47dkwiIiIkd+7c5o/4Zs2ayS+//GLabtmyRR5++GETMMuRI4c89thjph+uNOPS9RL633//3Vw6X7ZsWdOX2267TXr16mWCNnEDPK+88ooJHGk/9Dm0HISWhXjwwQfl008/jZetF/e5NJg9atQoKVOmjAnWtGvXzrTbtm2bvPDCC1KjRg3z/JkyZTJ9KVq0qLRu3Vp++umnmx4XVwcPHjSZgSVLlnTuS/dbu3Zt89r27NkTb39Lly41ASsNXGnf9NhWrlxZBg4caF57XPqc1vNrXzZv3ixNmzaV7Nmzm/f83nvv9djvG3G95PxW6rz+3//9n1m0X7Nnz3bbtnfv3njtb/Wc/Pvvv+XFF180x06DilOmTHG21aCfvha95D5nzpzmnNy/f/9NX4N+4aG/Z5UqVTLnmvapRIkS5nkOHToUr31SzqEb1dWNe+7+8ccfZv2kSZOc6zJkyGB+5yx6fuvrtLYPGTJEfOHrr7+Whg0bmpIF+j7t2LHDJ/vVY+JaMkPvv/POO9K3b18ZNmyYed5Tp07JnDlz4r33mrFt0c87T8cqbgkFDQLrFwa5cuUyv2PW76F+yaDr77zzTnOO6HHV36Pq1avL0KFD5dKlS/H6/vPPP5vzU88/3Ze+30WKFJF69eqZ/us57Y1+tulVEno89RzRz7733nvPYymbmJgYc8WEfu7pZ672TfuvJUc+/PBDuX79eoLOG2+fG4n9rLQ+37SchfZDf1/r1q0ry5Ytk2nTprntAwAA+IkDAAD4xfPPP69/2TuXL774IsGPXblypSNHjhxuj3ddAgMDHaNHj3Z7zMCBA53bc+bM6bj99tvjPS5PnjyO+fPnO0JCQuJtK1mypOPKlSvO/S1fvtxte7169Tz2pVq1am6P+/nnn73221rat2/v1ve4z3Xvvfe63W/evLlpN378+BvuNyAgwDF16lSvx6Vo0aLO9SdOnDDH40b7mzhxotu+evXqdcP2t912m2Pnzp1uj9HntLZXr17dkSFDhniP0/dj9+7dCT4/7rvvPudj9XZCRUREuD2v5eLFi44BAwa4bYt7HG/1nMydO7ejdOnSbo955513TLtvvvnGERwcHG+feh7XrFnT62tds2aN2a+3PoWHhztWrVrl9piknEOuxy1uH+KeuwcOHHBu0/PWWl+hQgVHVFSUIyYmxlG7dm3n+rp165p1vtCpUyfTf9f+VKxY0TFq1CjHsWPHkrxf/exy3edXX31108e4vvfeFutYuZ7Pd999tyNLlixu7bZu3Wra5cqV64b702N84cIFZx927drlyJw58w0f891333nsc758+RxVq1b1+Jhu3bq5vVb9/dH38UbPU6dOHbe+3ei8ifu5of1K7Gel7i9//vwef0+bNGni8XMAAACkLMojAADgJ5qRadFs1oRean727Flp2bKlnDlzxtzXzLD27dubjE7NhtTsqdjYWJMhqWUWdHKzuDTjUzPjXnrpJZN9pvUo1V9//SWPPvqoybrq2rWr2de8efPMNr00fsGCBdKmTRuP/dIMrebNm0vFihXNxGmaNaz0p5aB0OxhFRgYaLK+NPtNJ7fSTDit57t161b55ptvTJba1KlT5fnnnzdtPImMjDSTtGl2sLa3LvXWTLJ77rnHZFVa2WPnzp0zx1r7oW01M04zJvW43YjW39TjYb0/eox1n0ePHjVZptoHV5ohrJefW7R/eiy1vWYQaqadZu3pe7dr1y6P9WA1G1WzTNu2bWsym7UkgYqKipJ3333XZGemJG9ZdsWLFzfZxL48JzUTU5cGDRqYTGY99pp9rTVRdRIrKxNRMxQ7dOhg3pMZM2bI2rVrvV4Grr9Tuk9lZcpq3/Sc1vdAz41WrVqZc9uqZ+zLc+hmNJNY96nniGZ8Dh482Pw+rF692mzX2/oa9XfGFzRjXzP4P//8c/O+aHbv9u3bzaJlWjTT/emnnzbHLW5m/43osdJzxcow1c+BO+64wxxHzTLXbHGdjMz1fLJqSU+cONFk6auqVaua42rRbNm49HNCf3e0n5oBr7+LmuWq9HdHM1f1vdbzQ/ujtcD19ernnB5jrSGumf5Kfy/1/LIeqxm3muGsNXg1m1cnVrtRBree9/o5Zb1P+jg1fvx4c15Z57mWjnAtD6GvvWbNmmb/Wv7Gyk7WdpqN60vePiv18/348ePOdo0bNza/m99++61ZAACADaRwkBgAAPzLNcOrRo0aCX6cZh+6ZkEtWrTILTs0a9as8bKqPGW2zZgxw7nNNVtRl7lz55r1sbGxjoIFCzrXayapt4wuzeKzXLt2zVGuXDnntkKFCsV7HQcPHnTMmzfP8d5775lMv7fffttkolqPGTx4sNfnuueee9yyd+Pavn27eX3vvvuu2e+QIUPcHu+aXekt03bMmDHO9c8991y859DsuePHjzvva8ai1V6zmC9fvuzc9v7777s9v2Yze8qY0wzCI0eOOLe1aNHCua1y5cqOlM609bRoNuOOHTuS5Zzs0aNHvD7Nnj3brc1HH33k3KbZgq6Zya6vVd97a71mAP/9999u751rFrW2vZVzKKmZturHH390Zr9qNrFrlvucOXMcyWnfvn2OQYMGOUqVKuXWx7CwMMczzzzj2LNnT4L3pe/djc6bYsWKOT9XvJ2rehw9cW2jy4IFC7z24+zZs+b8mzRpksns1vfONctVrwiwdO/e3bl++PDh8fZ1+vRps3g7X2fOnOn1XGzbtq1Zf+rUKUdQUJBz/eOPP+72HHrf2qbttL0vM209fVYePXrULeO6devWzm1Xr16Ndz4AAAD/INMWAIBUxjWzME+ePNKoUSO3urh6f+7cufHautJMNdeMNq2PaLXVTEbNEFWaGVesWDGTCaisTEpPNPPNovt4/PHHTR1XpRlompmmmZNat1Rr6d4sm8vKWvNEMzat7DpXmjmoNRs1izKp+7ZotqeVPTh58mSTEak1K0uVKmUyAjWjT1+P0mw91/qgWm/VNQtT+6R1Ui16rD1lVmuGYsGCBZ339bksNzr2cWldS19PRLZo0SJzDPT909qXWov0rrvu8tk5qfr16xdv3aZNm9zuaw1O1/O2Tp06snz58niPs7JVrWOnWbPe6MRqmuXo63MoIbTGqZ7Peqw1m9jKKNZsYj2PEkrrompGcFydO3f2OvGU1n7V31FdNINVs281G1f3o3VNNWu+dOnSCXp+zTLX3w/NCPd07DTjVT8TNGNZf3eSSidS09+TuDST+9VXXzXPr5OTJeR90wzgcePGOc89rb2rr1d/77SmsW73NmGbfsbF/Qx1PRe1NrWVPa9Z9hb97HOl961av9pO27v+/twqT5+V2jfXuruudW410/yJJ55wq5MLAAD8g6AtAAB+opMc6WXZSicA0z+iEzLpi+tkVlbQ0JXrOm+BPg2kuV6erxOBuW5zDVS4ttPAiDf6OG/9UHopsa7TS90TcvmtlgTwxlMgScs96AReOsHarezboqUZNBCll5Nr0FKDea6TRelkQhqI1EmS9Di7BkHivna95FovBdf93Oh9iTsRmgZQEnLsk4sGfCyvv/66ucxaz1l9LzVApoFcX52Tejw9BVb1uSw6kVjckgSeni9un27GKoPhi3Mo7iRUCTnXdFK00aNHu73Hevl6YuhEW1qGIi4tY+EtaGvR8gRa0mTx4sVugd/ETEKlbTt16mQWDYxqcF6D4fPnz3f2S4+NTlB2K0Fbb0FkDb5aXzLciOv7ocdGz3EtZ6Drtc+uXypomQX9rNLzPi49V+MGdF3PReu8jXsexj1f49739vuRlPPK2/Fy/Z1SWqbmRvcBAIB/+KZAFgAASFKGnesf6l999VWCHuda51GzV+NyXad1Hb1liXnjqdZqQpw8edJrP5TWfdS6kgsXLnQ7Bvv37zfZhRqU0LqXCaFB0Li0ZqRrsE3rjmowTvfradb4hOjRo4d5HZodqEGhbt26mTqaSmulWllzepxdA1xxX7s+vxWwtdon5H2x08zt2jetXWrRgJwvz0lP76l13lguXLhgAqve9u3KtU8FChQwAT1vi2aj3so55FpzNm7/rC9mvNF9P/vss/GC8tqn6OhoSS4aWNUvJfTLCa1RrEF5rfmqX+BofWINtrpmhyeG1ofVLGEN0OoXUlrDOqHH42a8nSdat9ai2err1683gU09vr179/a6P33/9RzSLyD0eGiNWivbXYPN3o6BZpy7ZtDGPRet8zZuXd6452vc+9bvR9w6xq7nldZr9nbeJ+R4uf5Oefrsdq11CwAA/IegLQAAfqKZdK6ZWl26dDETAsWlgRudKMz6w7pWrVrObRpQ0gw5i7Zxve/aNrnpRFyufbYu+bWyijWjTLP4XAMdTZo0MRMW6XHYt2+fW4mBxNIgiiudzEuzN5VrXxJKS0JoYEQnZKpXr54J2Grg1jU4dOjQIfO82kYvJbdoBq5rkGX69Olu+07u90WzfzXgq4ve9gUNrG/bts153/V9TM5zUktRuLImZ1N//PGHmcDJk7h90smfNKvSddGgrAairQnvknoOuQbB9Dy2Mhn1fJ8wYcINX59m2P7444/O/VhZjloWwpq8LyH0WGiAMu7imr2tx0En4tLyFkWKFDGv35owUCfG0knBNGCnk/Bp+Y4bfbkT93J7LS+gk+d5+hLI9fL8uAFD1+ewJgVLCtf3Ts8ZfU81AK2THOoEh55oyQZ9r3QSOi1J0LNnT3MM3nvvPWcb1+x6V/oZ5/pZEPdc1Em9lPbD9XNeJz9z5Xpf21nnYtzj5Dop2vDhw+Nl3iaG9s31CyEti2HRQLfrfQAA4D+URwAAwE/0kts333xTXnvtNXNfgyUabNDLs++++27zR/Vvv/1mZhfX4GGDBg1MO83u1MdZQQqdpVzrX+ol0BrQsjI69fGaKZpStKamBoW0zqkG6VzrWuol01YJBQ1GWEGtIUOGmKCeBgR11vSEXvLriWv9V6UzwWvNSQ2muAaUE0qzLjVop3UqNVNQs+80UPnll18622hQSAO2SgNgVl1ffU7NGtbawBr8dQ3MaB1RDVanBqNGjTI/NctU31PXLEmt+WtJznPykUceMXVyrRIG+uWGBho1I3HGjBles1GfeeYZc35pRrSeX9pfzf4sUaKEOc80uKq1f/V3S+uQau3mpJ5DrhnimgWpv78afNO6ukeOHPH6OK0jqxmuFg0WagCxWbNm5v7IkSOlYcOGPgu8a01Z13rH+oWJvkataarZtkmlGdBanmHYsGEmIKj1YPX3RQOmS5YsMa/T8vDDD7s9Vr/QsWgpAi27oYFyXfQ9TCh976zzU7P5n3vuORMAnzdvnuzdu9fjYzToqvV89fhqBr1mZOu57hq0jBs8daXneGRkpGkT91zU7GmrjIK+jilTpjiD//r5p0FyDcTq57tF3werRIiWNdByIHpslWb86uvSfyduVBc6IfR16meQddWDfqmkXzDoF0+6Tn83AACADfhpAjQAAPAvnZ3edcZ4b4vr7OErV650ZM+e3WvbwMBAx6hRo9yex3Xmc5153JXO2u5tm7fZ3ePOUt6kSROPfalSpYrj8uXLzse99dZbHtuVL1/etE3Ic8WdSd3y8MMPe9y36+vTZerUqTc9LrNnz77pe9KrVy+359f7N2pfsGBBx86dOxM0C/zN3rMbcX3P9HZCxT1O3hY997Zv3+72WF+fk66++uorR1BQULx9hoWFOSpXruz1ta5evdqRO3fum74ePb9u5Ry6cuWKo2TJkh4f17hxY4/n7qVLlxylS5d2rm/VqpVzfx07dnSuL1SokOP06dMJfg9vRI+PvkedOnVyREZGOnwl7u+nt0Xfq/Pnz8d7bz21LVeunFu/PX0uuNLXExwcHG8/WbNmdbRs2dLjeTZ8+PCb9nncuHEez1c9r7SPnh7zwgsvuPXt4sWLjrp1697weWrXru24cOGC2+P69evnsW3VqlUdefPm9fi5kdDPSl2fP3/+ePsOCAhw+x3Q+wAAwD8ojwAAgJ/prPV6ma7O1q1ZnZpVqJcUawanZnhqZqFmx+mkOBa9vHnnzp0mu1MzdrWtZn3qJc+aHar1RnVbStLJfDRTUGeQ1wm0NJvrpZdekmXLlrlNHtWnTx9zybhmnOql0ZoNp5m4K1euNJN13Qq9rFszOfW59XhoVqVm/1lZbomh74VmD2pGmmYhatabvi/6/mgt3mnTpplL213pfc0s1ExTzTTU16evSS/B1wnNtPyDp0mN7E4zZPX1ayZer169zOvQjGpXyXlOaratlhDQ59BzSTMbmzdvbuqWVqhQwevjtESCZnzrsdcMUM381UvQ9fF6X0uU6Pul+72Vc0gv/9e6x5rJqvvW+5ptqnVhvdVT1UvxrQxQzUDXy/ItWgtWM3+t2rNWpvqt0sxdzdT84IMPzPntK3qc9fVr1rBmreox02Otvy+aOarHd+zYseYc0PMo7nurnxv6Wec6IWJi6evRrFXti37+aMZy48aNzXN6O0e0BISWoNCrGLSMhJ6z2mcrE/Xrr782ZVG81YrVcgi6XbOFte+a7fvuu++6lVew2urx0TI3Ogmb1rnV59Fs8fvuu08mT55sPuPjfv4NHjzYnHt6Luhnif4b0LdvX/NZGXdCvsTS16uZvm3atDHnrO5Ps38121n7lJBMYwAAkLzMV6fJ/BwAACAN0iCD6yzwGnh2rZ8JALAnnfhOy4bEDZRrCRgNfG/YsMHcf/DBB+WHH37wUy8BAEjfqGkLAAAAAOmI1l7WOr5PPvmkuRJAs721/rJeQWAFbK0rQQAAgH8QtAUAAACAdEYn6Rs3bpzXkihvvPGGmRgTAAD4B0FbAAAAAEhHtH6v1sddvny5/P7773LmzBlTN7dw4cKmPvBzzz0n1apV83c3AQBI16hpCwAAAAAAAAA2EujvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAEhmt99+uwQEBJglrXnmmWecr23FihX+7g4AAABs5I8//nCOFe+///5024ebYUwNwBOCtgBsYdCgQc6Bii6LFi3yOpCZNGmS3/oJAAAAJIdLly7JO++8I3Xr1pVcuXJJaGioFCtWTJo2bSozZsyQa9eupUg/pk2bZsbmupw9ezZFnhMAEF+wh3UA4HdDhw6Vxo0b+7sbAAAAQLLbvXu3NGvWTH7//fd4WaK6fPvtt1K+fHmpVKlSigRtV65c6UycyJ49e7I/Z3r3+uuvy7PPPmtuV6hQwd/dAWATBG0B2NKaNWtk2bJlUq9ePX93BX4SGxtrMko0ywQAACCtOn36tDRq1EgOHTpk7hcsWFB69+5tgncXLlwwAdSpU6f6u5tIRiVLljQLALiiPAIA2xoyZEiC2v3222/Svn17KVy4sGTMmNFcTqZZukuXLo3X1uFwmEFv7dq1JVu2bJIpUyapWLGivPvuuyZI6Moqx6A1aV1pLSxrm2Y+WC5fvizdu3eXPHnySNasWeWRRx5x2x7X5MmTpWrVqqZtSEiI3HbbbdKgQQMZOXJkgl73X3/9Jb169TIDPH18jhw5pEmTJrJu3Tpnm6ioKClbtqzpa4YMGWT79u3ObdrWeh2zZ8+OV6ZCj5Neole8eHETOK1SpYosWbJEEkqD7vocuXPnNu+Lvj+arfHrr7+6tXN9zo8//ti870WLFjX9tV5LYt43fY3NmzeXvHnzmn3o+aBZKc8//7zzjyEAAAC7GDVqlHOMEh4eLhs2bJAePXpI/fr1pUWLFmY89ssvv0iRIkWcj9EvtkeMGGHGOFmyZJHMmTObsdFbb70Vr4xCQse0WktVb1tZtkrLM3ga93py4MABM/7V/ug47KWXXjLj48TUcNUsX2u9jhETQseLjz32mAl265gzf/785m+Bbdu2eWyvY0U9tnrMtG2/fv3ijSejo6NlzJgxZvyrr0eXGjVqmDIVcbke3x07dpjyFrrv0qVLy7x580wb/VmuXDkzZtf3ScfJCTkervvWMbQeX/3bIWfOnGZse/Xq1QQdIwCplAMAbGDgwIEO/UjSpWrVqs7ba9asMdsjIiKc6yZOnOh83Pr16x1hYWHOba5LQECA4/3333d7nnbt2nlsq0vr1q3d2lrrixYt6rb+vvvuc247cOCAc32TJk3i7bNQoUKOnDlzOu9bpk+f7rUft912202P18GDB82+PT0+Q4YMjq+++srZdt26dY6goCCzrXr16o6YmBjHrFmznO1btWrl8X0oVaqUx32vWrXK2d71fVm+fLlz/YQJE8zx99Q/fb82bNjg8TnvuOMOt7bWPhP6vp06dcqRJ08er22XLFly02MLAACQklzHP4MGDbpp+6tXrzrq1q3rdbyj26KiohI9ptVxl7d9xh33xvX33387ChcuHO8xd911l/O2Pt/NxpBTp051rtcx4s18/PHHznFu3EX3pbTfrmPzrFmzxmv74YcfOvd57do1R/369b0eh1deecWtD9b67NmzO3LlyhXv75F+/fp5HA+fPn36psfDWpctW7Z4+9bl9ddfv+kxApB6kWkLwHb0m+977rnH3H7zzTe9ttNxjGbY6mVj6n//+5+p99W/f38JDAw02zVL4fDhw85vuKdPn25ulypVymSXfvPNN87n+vzzz82SFN9//715bqVZoGPHjpUFCxaYb+/1kre4vvrqK/MzODjYTKymWcEzZ86Ul19+2WQ03MwLL7wgf/75p7ndrl07Wbx4sUycONF8866ZAR06dDCTWSjNCvi///s/c1szNzSTVY+L0qxgfZy3DObBgwfLwoULpWHDhmad7tt6rDd6vHv27GmOv74Pmr2gx0YzIJS+X5pN8M841J3WcWvbtq1pr++VZh8n5n1bu3atyUBWTzzxhMkM1vdBM1juu+8+CQoKuumxBQAASCkXL150q2N777333vQxOs5ctWqVua1XMs2aNcuMj6xMXN2m2bmJdffdd0tkZKRb3dy5c+eadboUKFDA62Pffvtt55hbs0J1bKZZs0ePHpXkcuTIEenSpYvExMSY+5qVPH/+fDN27NSpk8m6jUvHz5rpqmNxvULO9Qo4i17JZV2xp+NNa586DlV6Vdz69evj7VsnbdMr4L7++mtp06aNWafjXR1761VgOqauU6eOczys71tCnT9/3ozbv/jiC7e/j1z7DSAN8nfUGADiZlv26dPH8c033zjvb9q0yWOm7ZYtW5zr8ufPb74Vt2j2qLXtnXfeMeuaN2/uXDdu3DhHZGSkWfSbdWt906ZNE52VoLp06eJc17t3b2fbX375xe3bcEubNm3M/cyZMzt+/PFHx7lz5xJ8rDSTwcpi1ddtvQ5dHn30UedzzZs3zy0jo2zZsvG+nf/iiy+8vg9t27Z1rj979qzpq7Xt0KFDXrMCxowZ4zGLV98f7a+1bevWrfGes3bt2vFeb2Let8WLF7tlQWg/Y2NjE3xsAQAAUtKff/7pNjbbs2fPTR/jmr2qY2aL6/i5YsWKSRrT3mj9jZQpU8b5mG+//da53nW85utMWx3jW21r1arltZ1rpm3GjBkdx48fN+v16jNrfKtZshY9dlb7OXPmOMeegwcPdq7v2rWrs73r+6djf7Vx40bnOn2O8+fPm/Vz5851ru/Ro8dNj4frvq2xsypdurRzvY7TAaRNTEQGwJaaNm1qvu3funWr+XZa63vFpbW9LJUrVzb1Sy3Vq1c330S7tnNt7/rNuqs9e/Ykqb+uGRLVqlVz3tZv27XW7JkzZ9zaa4awZiBonS+tY6sKFSpkskE1k1Vr3XqjGbBWlurx48e9ZmS4vhatn6XZDpp1az328ccfl5YtW3p9Hm1r0eOv2QX6flivVzM7PHE9zq770PdH39PvvvvO2S7uDMj6vt9ofzd73/RY6DHXml+aBaFLWFiYOT80g7djx44m+xcAAMAO4o5xNTNVa6HeiLexlo5/PbVJCd7Gwq598jXX16jzKCSEHtt8+fKZ2zom1HG6jsc1S9bTfnW8nNC/GbJnz+6cTExrzlp0DK3jUaVzPVhcn/NmdE4H13Gzztnguh9PfysBSP34yxWAbb3++uvmp16+tHPnzkQ9Vgv2J4VVUsCVdcmV5dSpU7fcl4ceekhWr15tLt3SQKZOVqCXa2mJBA3cug58kyrua9m3b59bSQK9r+UOkvuYJmYf1iA6qa9Vj6MeVy3rUK9ePVOewpp1uXPnzgme5A0AACAlaGmrO+64w3lfxzHJNc661TGtL/vkut61X8ndJw3SutJSZb76m8E1cOqaJKABV088lQpLSr8Tsx8AqQtBWwC2pVmgZcuWNQORzZs3x9t+5513Om9rBuj169ed913rTFntXNsvX77c7Dfusn///ngDr7///tsZ3NRZc/fu3RuvL66D7U2bNrllxXqqaavPVbNmTfnggw9ky5YtJrA4evRos02/7dcatd6UKFHCOdAtXry4ed1xX4fOGqyBS8uxY8ecWapWXVedOXfo0KFen0fr31rOnTtngryeXm9crsfZdR96DK1M3bjtbjSwT8z7pre13pfWNdZaZPq6NQCufxCpL7/80mu/AQAA/KF169bO22PGjPFYB/bkyZPOMaW3sZan8W9ix7RxA46xsbEJeg3exsKear+69sm6csxyozFwXK6vcdGiRQl+XGL2q+NIT2NPq+YtACQngrYAbEsDeK+99prX7XqJUJkyZcxtDc7p5e966f2gQYPMhAFKJyBo1aqVua3bLU8//bRzArDPPvvMFPTXiQZ0EgXX4Ki6cuWKPPnkkzJ+/Hhp1KhRvCwF9cgjjzhvv/fee6atTkLg+pyuNICqE6fp5AE6yPzxxx/NBA+WqKgor69bL7fSfigNVupzazBSJ9366KOP5MUXXzQTUejkDJbnnnvOWaJhzpw5Jhiuhg0bJtu2bfP4PDqhhQZ1tX86qZeVUaCZwd5KIyh9XVapCu3XwIEDzfuix1zfJ6XPr5NAJERi3rc1a9ZIlSpVzOvSiTM0yKvvgwbCb3ZcAQAA/EEnjLUmEdNL3bXkgU6GtWzZMnPFmU7wqoHEQ4cOmTY6LrXouE/HRFp2q1u3bs71OnZLypg2blbnhx9+aMaoroFYT1zHwl27djXjsE8//dR55VxcVp+UTlo7YcIEM+ZLTDBUJ7nVEmBWhrKO+fV46d8BOmmvXsGWFK5jTy3d9cknn5h+zZgxw/S1QoUKZjwNAMnO30V1AaQ/K1euNBNHFShQwBTPnz9/vttkVDqBVP/+/c2kVSEhIY5MmTK5FeG3JiJT69evd4SFhcWbYEsXnazr/fffd3vudu3aeWzracKDyZMnx9ueNWtWR6FChTxOztCoUaN47fPkyeMIDw+PNxFZx44dvfZBX+/+/ftveAwPHjzo1g9Pi9W3adOmOde1bt3arFu7dq0jMDDQOVGFNYmb6/vgOsmFtQQHB7tNjuBt0oQJEyY4J0uLu+j7tWHDBmdb1+fUySc8Sej7ppNE3Kjd8OHDb3hcAQAA/GHXrl2OO+6444bjGGsiKp1g9t577/Xarm7duo6oqKgkj2nHjx8fr33cScziOnXqlOO2226L97iSJUt6nIhM22sf4rZ3ndDsZhORWROdWWPauIs1rnSdiMy1D0pfV9xxuh67+vXr3/C9cB2zejpG3p5Tx8vWeh1HJ3QisoROIgcgbSHTFkCK04xNzbLUb9Q90cuoxo0bZzIq9ZIvLd7vjU5uoKUTIiIi5LbbbjP1nTQ74OGHH5YffvhBunTp4tZevymfPn26qRurl2VpJq5mNtSvX988p34rb3n22Welb9++kjdvXsmUKZOpkaqZBlqSwBPNKNBsB50YQGurNmzYUFatWmUmJfD0Db72WV+b9kNLFujztGjRwjzHjcoPKO2zlhro3bu3mVAhNDTUTHCgt9u1a2eySzUbVi+v04nNlB4XzdpQmp1qlUvQMgmasRqXZnVo1rC+Xj1OmmG7cOFCuf/+++Vm9Dhq5q9mcWhmsL4vBQsWNH3T98t1goqESOj7plkoffr0Ma9P6+Pq82ppBH0+Pd90GwAAgN3oVUg7duww5RHq1Kljxk863tHxnI4pdSxkXSml2aU6znrrrbfkrrvuMuNUHQtqBujw4cPNGFgfm9QxrV6hpWMmHWsldAJXHf/quFczU3UcrP3XuRt0fOyt/YIFC0z/ta/aFx2rvfLKK4k6bvra9LVoWTVr7KevU8egcSe8TSjtj5Zp0DGm/q2hY2w9vsWKFTMTnk2ZMkUeffTRJO0bABIjQCO3iXoEAPi4BIJewqTBSqUfSRrce/nll82lYlY9VR2ETZs2Tdq0aePnHqdtWlrijTfeMLenTp0qzzzzjL+7BAAAAABAukOmLQBbOXDggJmMoEGDBs51mlmptb3Wrl3r174BAAAAAACkBIK2AGzFmj1WM2td6X3XmWUBAAAAAADSKoK2AAAAAAAAAGAjBG0B2Er+/PnNzxMnTrit1/vWNiRvTVutK6wL9WwBAAAAAPAPgrYAbEVnZdXg7NKlS53rzp8/L+vXr5eaNWv6tW8AAAAAAAApIThFngUAXFy8eFF+++03t8nHtm3bJjlz5pQiRYpIjx49ZMiQIVKyZEkTxO3fv78ULFhQWrRo4dd+AwAAAAAApIQAh14Dm4bFxsbK0aNHJSwsTAICAvzdHQAiEhkZKU2bNo23/sknn5SJEyeaS/OHDRsm06ZNk3Pnzsk999wjY8aMkRIlSvilvwCAlKGf/xcuXDBf1AUGckFYYjDmBQAASFtj3jQftP3zzz+lcOHC/u4GAAAAEujw4cNSqFAhf3cjVWHMCwAAkLbGvGm+PIJmG1gHIlu2bP7uDgAAALzQGuYaeLTGb0g4xrwAAABpa8yb5oO21uVhOnhlAAsAAGB/XN6feIx5AQAA0taYl2JhAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAABI81atWiXNmjUzMzXr5YgLFixw267zMw8YMEAKFCggmTJlkgYNGsivv/7q3L5ixQrzOE/Lxo0bTZs//vjD4/Z169al+OtF8uOcgi9xPsHXOKdSP4K2AAAAANK8S5cuScWKFWXChAket48cOVLGjRsnkyZNkvXr10uWLFmkYcOGcvXqVbO9Vq1acuzYMbfl2WeflWLFiknVqlXd9vXjjz+6tatSpUqKvEakLM4p+BLnE3yNcyr1S/MTkQEAAABAo0aNzOKJZhuNHTtW+vXrJ82bNzfrpk+fLvny5TOZSW3atJGMGTNK/vz5nY+Jjo6Wr776Srp16xZvIpFcuXK5tUXaxDkFX+J8gq9xTqV+ZNoCAAAASNcOHDggx48fN5eGWsLDw6VGjRqydu1aj4/5+uuv5e+//5b27dvH2/bII49I3rx5pU6dOqYd0h/OKfgS5xN8jXMqdSBoCwAAACBd0z9clWYYudL71ra4pkyZYi4jLVSokHNd1qxZZfTo0TJ37lz59ttvzR+vLVq04A/YdIhzCr7E+QRf45xKHSiPAAAAAACJ8Oeff8r3338vc+bMcVufO3du6dWrl/N+tWrV5OjRo/L222+bLCTAG84p+BLnE3yNc8o/yLQFAAAAkK5ZdfhOnDjhtl7ve6rRN3XqVFO/LyF/kOqlpr/99psPe4vUgHMKvsT5BF/jnEodCNoCAAAASNd0Jmz9I3Xp0qXOdefPnzezadesWTPe5C36x2u7du0kQ4YMN933tm3bpECBAsnSb9gX5xR8ifMJvsY5lTpQHgEAAABAmnfx4kW3zB+dhEX/sMyZM6cUKVJEevToIUOGDJGSJUuaP2b79+8vBQsWNLX5XC1btsw89tlnn433HJ988omZbfvuu+8297/88kv5+OOP5aOPPkqBV4iUxjkFX+J8gq9xTqUBDj9auXKlo2nTpo4CBQo4tCvz58932x4bG+vo37+/I3/+/I7Q0FBH/fr1Hb/88kuinuPcuXNm3/oTAAAA9sW4Lek4dje3fPlyc4ziLhEREW5/e+TLl88REhJi/vbYt29fvP088cQTjlq1anl8jmnTpjnKlCnjyJw5syNbtmyO6tWrO+bOnZvsrw3+wTkFX+J8gq9xTqX+cVuA/s9fAePvvvtOVq9eLVWqVJGWLVvK/Pnz3SL6I0aMkOHDh5vIvRX1//nnn2X37t0SGhqaoOfQ9O7w8HA5d+6cZMuWLRlfDQAAAG4F47ak49gBAACkrXGbX8sjNGrUyCyeaCx57Nix0q9fP2nevLlZN336dMmXL58sWLBA2rRpk8K9BQAAAAAAAIB0XNNW62UcP35cGjRo4FynUWidhW7t2rUEbQEAAIC4rl4VyZgx/vrAQPf12s6bW2kbFaXZF57bBgSIhIQkre21ayKxsd774XoVnr/aan+13yo6WiQmxvdtr1//Z/FFW33f9P3zdVudpCYoKPFt9RjosfAmOPifJbFt9T3T987XbfXc1XPYF231GFiT+/iybUr93vMZkbC2fEb8g8+IxLflMyLtfUbc6JikhqCtBmyVZta60vvWNk+ioqLM4ppyDKR2hw4dklOnTvm7G0gGuXPnNkXgAQDwiXbt/vtjzVXVqiIDB/53/6mnvP8hV768yPDh/93v2FEH1fGaXblyRc7nzy9HevVyrisyeLBkOH3a426v5csnh/v2dd4vPHy4ZDxxwmPb6Jw55dCAAc77t40ZI6GHDnlsG5Mli/wxdKjzfsHx4yXT/v0e28ZmzCgHRo503s//wQeSZfdu8Wb/2LHO2/mmTpWs27d7bfv7iBHi+PcPxDyzZkm2DRu8tj3w5psSGxZmbueeO1fCV6/22vbggAFyPWdOczvXV19J9uXLvbY91KePRP87Y3eO776TnN9/77Xtn716SdS/Y5Dsy5ZJrq+/dm7TSWUyZcr0X+Nhw0QqVPjntu5z0iSv+xV936pV++f2ypUiLscwnj59ROrU+ef22rVyZdAgueYlIHLyySflQvXq5nbmXbukwIcfet3tX61ayfl77zW3Q3/9VW6bMMFr278feUTO1qtnboccOiSFxozx2vZ0w4Zy5t8rRTMcOyZFRozw2vbsAw/I3/9eMRp8+rQUHTzYa9tztWvLqcceM7cDL1yQYv37e217vnp1+evJJ83tgKgouUOPoRcXK1aUE+3bO+8X79HDa9tLZcvK8c6dnfeLvfKKBHp5L64ULy5Hu3Vz3r/99dcl6NIlj22vFiliPiOcY94XXhA5edJzJwoXFnn//f/u9+wpcviw57Z584pMmfLf/VdfFfn11/h9vXJFrmTIwGeEjz8j4jry4otytWRJcztbZKTk+eILr22Pdeokl8uVM7fDNmyQvLNmeW17PCJCLv07wVWWrVsl/yefeP+c0vO7fv1/bm/ZInKD3zl5/nmRJk3+ub1rl8hrr3lvq79DLVv+c3v/frnSpYvXzyk+I5L+GWGHcURu63NKx0s7d3psawLB8+b9d1/HS5s2iVfffPPfbf33xfpdvtGXCqkhaJtUWgP3jTfe8Hc3AJ8GbEuVLiVXryTsmxikLqGZQmXf3n0EbgEAqYoGQpYtXy77YmPl5Zkznet1rui8Xh6joZcXXf7Q0TBaYS9tNaTz7FdfOe+PFpF/wgHxaTj5qcWLnfeHadzZS1sNUz9WpYrzvv45V1W8e8Slrf7ZW/sGbR+rVcvsX70kIv+GDjx66v77Tb/V8yLS+AZtOz74oPz172390/rRG7R9MTLSHGf1xL+LN70iI8WaU1z32d4t8SlQ6j3wgHtAJJmdOHFCNi1fLrFeMpbGRkbKsn9v63v235/i8U2KjJRF/94u/+854c3UyEiZ/+/tEvo39Q3azo6MlNn9+pnbeu56DwWLzI+MlKn/BmHyiIhLeDGeRZGRMumtt8xtrWw44wZtl0ZGyruj9TdCRMN/c2/QdnVkpIx47z3nfe8hN5FNkZEyePJk533dr0uOmpudkZHy2rRpzvvaX28VGTWMqp8RzjGvpOzn1PLly+VMbCyfET7+jIjrtchIsUJcjf/tszeDIyPFCnHp1yXew4QiIyIjxQpX67F1DT8GBQbKAyn8OXX06FHZtny5xHj5nOIzIumfEXYYR2QKzSR79+1N0c+pm/HrRGSuAgIC3CYi+/3336V48eKydetWqVSpkrPdfffdZ+6/++67Cc60LVy4MJMyINXasmWLmawvzxN5JGNeD5c7ItW6dvKa/DX7L9m8ebNUrlzZ390BAL9jMi0fHLsTJzwfOx9f1qhj9Jq1akmpB0ZJxlylneszxERLgJmcOj6HBEh0UIYktQ2OjZbAG/zZci0oo//bBmZwXnYcFHtdghyxydA2RoIcMT5pGx0YLI6AwHhtL53ZL3tX9Ja1a9bI3f9muKXEpc9bNm6UWtWrS57Hc0vGPPHHvNcDRWIC/3ltgbEOyXCDq1Fd2wY4HJIxxvdt9ZLcEB+1jQkQuR7k+7axASLRVlsNsFx3+KXtpb+j/xvzaoZlCl36bH1OTW0tUqqAy0P1mN0gCuIITqa2eqpbhy1Gz7dkaBsrEhBr87b6URJ4a233/iXS/nNx/5xKgfIIWzZtklrVqklreVzymFCru1gJNMu/vZdgffO8SFzbAImVIJ+31X9rY5xtNavzut/bBsl156kUl/4axLjkniaubYzXMYc6Kqdltsz+53NKrzhK5vIIZtyWL5+9JyK7kWLFikn+/Pll6dKlzqCtvqj169dLly5dvD4uJCTELEBaowHbkEKc2wAAQG78x4HrHwg3apeYfcahl/hqmoQGbMPyVEj4rhL+rIlqm5gREm1v3FYD1fremsu4PZ0nrsGOm0lM26Cgf563QIiIhzFvcCL+eE1tbTVcEZQMbQMTcU4kZ9uMLgFet0DrzSSmrYda3tbnlAZsKxdK+K5gfxosv+HnlH4ZZH15dDP6hVRC/00MDDTPm0MKSH7hpEpLrrt+YnuaG8CbpLa90RcFdgnaXrx4UX777Te3yce2bdsmOXPmNJcK9+jRQ4YMGSIlS5Y0Qdz+/ftLwYIFndm4AAAAAAAAAJDW+DVou2nTJlODxNLr3+LDERERMm3aNHnllVfk0qVL0rlzZzl79qzUqVNHFi9eLKGJyQwAAAAAAAAAgFTEr0Hb+++/X25UUlfr3A4ePNgsAAAAAAAAAJAeWFWPAQAAAAAAAAA2QNAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAvFi1apU0a9ZMChYsKAEBAbJgwQK37Q6HQwYMGCAFChSQTJkySYMGDeTXX391a3P69Glp27atZMuWTbJnzy4dO3aUixcvurXZsWOH3HvvvRIaGiqFCxeWkSNHpsjrAwAAgD0RtAUAAAC8uHTpklSsWFEmTJjgcbsGV8eNGyeTJk2S9evXS5YsWaRhw4Zy9epVZxsN2O7atUuWLFkiCxcuNIHgzp07O7efP39eHnroISlatKhs3rxZ3n77bRk0aJB88MEHKfIaAQAAYD/B/u4AAAAAYFeNGjUyiyeaZTt27Fjp16+fNG/e3KybPn265MuXz2TktmnTRvbs2SOLFy+WjRs3StWqVU2b8ePHS+PGjWXUqFEmg3fmzJly7do1+fjjjyVjxoxSrlw52bZtm4wZM8YtuAsAAID0g0xbAAAAIAkOHDggx48fNyURLOHh4VKjRg1Zu3atua8/tSSCFbBV2j4wMNBk5lpt6tatawK2Fs3W3bdvn5w5cyZFXxMAAADsgUxbAAAAIAk0YKs0s9aV3re26c+8efO6bQ8ODpacOXO6tSlWrFi8fVjbcuTIEe+5o6KizOJaYgEAAABpB5m2AAAAQCozfPhwk9VrLTp5GQAAANIOgrYAAABAEuTPn9/8PHHihNt6vW9t058nT5502379+nU5ffq0WxtP+3B9jrj69u0r586dcy6HDx/24SsDAACAvxG0BQAAAJJASxpoUHXp0qVuZQq0Vm3NmjXNff159uxZ2bx5s7PNsmXLJDY21tS+tdqsWrVKoqOjnW2WLFkipUqV8lgaQYWEhEi2bNncFgAAAKQdBG0BAAAALy5evCjbtm0zizX5mN4+dOiQBAQESI8ePWTIkCHy9ddfy88//yzt2rWTggULSosWLUz7MmXKyMMPPyydOnWSDRs2yOrVq6Vr167Spk0b0049+eSTZhKyjh07yq5du+Tzzz+Xd999V3r16uXX1w4AAAD/YSIyAAAAwItNmzbJAw884LxvBVIjIiJk2rRp8sorr8ilS5ekc+fOJqO2Tp06snjxYgkNDXU+ZubMmSZQW79+fQkMDJRWrVrJuHHjnNu1Ju0PP/wgL774olSpUkVy584tAwYMMPsEAABA+kTQFgAAAPDi/vvvF4fD4XW7ZtsOHjzYLN7kzJlTZs2adcPnueuuuyQyMvKW+goAAIC0g/IIAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABsxNZB25iYGOnfv78UK1ZMMmXKJMWLF5c333xTHA6Hv7sGAAAAAAAAAMkiWGxsxIgRMnHiRPnkk0+kXLlysmnTJmnfvr2Eh4dL9+7d/d09AAAAAAAAAEhfQds1a9ZI8+bNpUmTJub+7bffLrNnz5YNGzb4u2sAAAAAAAAAkP7KI9SqVUuWLl0qv/zyi7m/fft2+emnn6RRo0ZeHxMVFSXnz593WwAAAAAAAAAgtbB1pu2rr75qgq6lS5eWoKAgU+N26NCh0rZtW6+PGT58uLzxxhsp2k8AAAAAAAAASBeZtnPmzJGZM2fKrFmzZMuWLaa27ahRo8xPb/r27Svnzp1zLocPH07RPgMAAAAAAABAms207d27t8m2bdOmjblfoUIFOXjwoMmmjYiI8PiYkJAQswAAAAAAAABAamTrTNvLly9LYKB7F7VMQmxsrN/6BAAAAAAAAADpNtO2WbNmpoZtkSJFpFy5crJ161YZM2aMdOjQwd9dAwAAAAAAAID0F7QdP3689O/fX1544QU5efKkFCxYUJ577jkZMGCAv7sGAAAAAAAAAOkvaBsWFiZjx441CwAAAAAAAACkB7auaQsAAAAAAAAA6Q1BWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIIliYmKkf//+UqxYMcmUKZMUL15c3nzzTXE4HM42envAgAFSoEAB06ZBgwby66+/uu3n9OnT0rZtW8mWLZtkz55dOnbsKBcvXvTDKwIAAIAdELQFAAAAkmjEiBEyceJEee+992TPnj3m/siRI2X8+PHONnp/3LhxMmnSJFm/fr1kyZJFGjZsKFevXnW20YDtrl27ZMmSJbJw4UJZtWqVdO7c2U+vCgAAAP4W7O8OAAAAAKnVmjVrpHnz5tKkSRNz//bbb5fZs2fLhg0bnFm2Y8eOlX79+pl2avr06ZIvXz5ZsGCBtGnTxgR7Fy9eLBs3bpSqVauaNhr0bdy4sYwaNUoKFizox1cIAAAAfyDTFgAAAEiiWrVqydKlS+WXX34x97dv3y4//fSTNGrUyNw/cOCAHD9+3JREsISHh0uNGjVk7dq15r7+1JIIVsBWafvAwECTmQsAAID0h0xbAAAAIIleffVVOX/+vJQuXVqCgoJMjduhQ4eacgdKA7ZKM2td6X1rm/7Mmzev2/bg4GDJmTOns01cUVFRZrFoHwAAAJB2kGkLAAAAJNGcOXNk5syZMmvWLNmyZYt88sknpqSB/kxOw4cPNxm71lK4cOFkfT4AAACkLIK2AAAAQBL17t3bZNtqbdoKFSrI008/LT179jRBVZU/f37z88SJE26P0/vWNv158uRJt+3Xr1+X06dPO9vE1bdvXzl37pxzOXz4cDK9QgAAAPgDQVsAAAAgiS5fvmxqz7rSMgmxsbHmdrFixUzgVeveupYy0Fq1NWvWNPf159mzZ2Xz5s3ONsuWLTP70Nq3noSEhEi2bNncFgAAAKQd1LQFAAAAkqhZs2amhm2RIkWkXLlysnXrVhkzZox06NDBbA8ICJAePXrIkCFDpGTJkiaI279/fylYsKC0aNHCtClTpow8/PDD0qlTJ5k0aZJER0dL165dTfautgMAAED6Q9AWAAAASKLx48ebIOwLL7xgShxokPW5556TAQMGONu88sorcunSJencubPJqK1Tp44sXrxYQkNDnW20Lq4GauvXr28yd1u1aiXjxo3z06sCAACAvxG0BQAAAJIoLCxMxo4daxZvNNt28ODBZvEmZ86cZjIzAAAAQFHTFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAApKWgbUxMjGzbtk3OnDnjmx4BAAAAAAAAQDqW6KBtjx49ZMqUKc6A7X333SeVK1eWwoULy4oVK5KjjwAAAAAAAACQbiQ6aDtv3jypWLGiuf3NN9/IgQMHZO/evdKzZ095/fXXk6OPAAAAAAAAAJBuJDpoe+rUKcmfP7+5vWjRInnsscfkzjvvlA4dOsjPP/+cHH0EAAAAAAAAgHQj0UHbfPnyye7du01phMWLF8uDDz5o1l++fFmCgoKSo48AAAAAAAAAkG4EJ/YB7du3l8cff1wKFCggAQEB0qBBA7N+/fr1Urp06eToIwAAAAAAAACkG4kO2g4aNEjKly8vhw8fNqURQkJCzHrNsn311VeTo48AAAAAAAAAkG4kOmir/ve//8VbFxER4Yv+AAAAAAAAAEC6lqCg7bhx4xK8w+7du99KfwAAAAAAAAAgXUtQ0Padd95xu//XX3+ZiceyZ89u7p89e1YyZ84sefPmJWgLAAAAAAAAALcgMCGNDhw44FyGDh0qlSpVkj179sjp06fNorcrV64sb7755q30BQAAAAAAAADSvQQFbV31799fxo8fL6VKlXKu09uajduvXz9f9w8AAAAAAAAA0pVEB22PHTsm169fj7c+JiZGTpw44at+AQAAAAAAAEC6lOigbf369eW5556TLVu2ONdt3rxZunTpIg0aNPB1/wAAAAAAAAAgXUl00Pbjjz+W/PnzS9WqVSUkJMQs1atXl3z58slHH32UPL0EAAAAAAAAgHQiOLEPyJMnjyxatEh++eUX2bt3r1lXunRpufPOO5OjfwAAAAAAAACQriQ6aGvRIC2BWgAAAAAAAADwc9C2Q4cONy2fAAAAAAAAAABIoaDtmTNn3O5HR0fLzp075ezZs1KvXr0kdgMAAAAAAAAAkKSg7fz58+Oti42NlS5dukjx4sU5qgAAAAAAAABwCwJ9spPAQOnVq5e88847vtgdAAAAAAAAAKRbPgnaqv3798v169d9tTsAAAAAAAAASJcSXR5BM2pdORwOOXbsmHz77bcSERHhy74BAAAAAAAAQLqT6KDt1q1b45VGyJMnj4wePVo6dOjgy74BAAAAAAAAQLqT6KDt8uXLk6cnAAAAAAAAAICk1bTV2rU//vijTJ48WS5cuGDWHT16VC5evOjr/gEAAAAAAABAupLoTNuDBw/Kww8/LIcOHZKoqCh58MEHJSwsTEaMGGHuT5o0KXl6CgAAAAAAAADpQKIzbV966SWpWrWqnDlzRjJlyuRc/+ijj8rSpUt93T8AAAAAAAAASFcSnWkbGRkpa9askYwZM7qtv/322+XIkSO+7BsAAAAAAAAApDuJzrSNjY2VmJiYeOv//PNPUyYBAAAAAAAAAJCCQduHHnpIxo4d67wfEBBgJiAbOHCgNG7c+Ba6AgAAAAAAAABIdHmE0aNHS8OGDaVs2bJy9epVefLJJ+XXX3+V3Llzy+zZs5OnlwAAAAAAAACQTiQ6aFuoUCHZvn27fPbZZ7Jjxw6TZduxY0dp27at28RkAAAAgL9ER0fL8ePH5fLly5InTx7JmTOnv7sEAAAAJF/Q1jwoOFieeuopSQk6uVmfPn3ku+++M4PuEiVKyNSpU6Vq1aop8vwAAABIHS5cuCAzZswwyQUbNmyQa9euicPhMOW8NPFAy3x17txZqlWr5u+uAgAAAL4P2u7fv9/Utd2zZ4+5X65cOenevbsUL15cfOnMmTNSu3ZteeCBB0zQVrMktBRDjhw5fPo8AAAASN3GjBkjQ4cONePRZs2ayWuvvSYFCxY0V4KdPn1adu7cKZGRkSZwW6NGDRk/fryULFnS390GAAAAfBO0/f777+WRRx6RSpUqmYCqWr16tUyePFm++eYbefDBB8VXRowYIYULFzaZtZZixYr5bP8AAABIGzZu3CirVq0yyQSeVK9eXTp06CCTJk0yY0sN4BK0BQAAQJoJ2r766qvSs2dPeeutt+Kt1zIGvgzafv3112bSs8cee0xWrlwpt912m7zwwgvSqVMnr4+Jiooyi+X8+fM+6w8AAADsKaET4oaEhMjzzz+f7P0BAAAAbkVgYh+gJRF04rG4NHNh9+7d4ku///67TJw40WRBaIZvly5dTBmGTz75xOtjhg8fLuHh4c5FM3UBAAAAAAAAIM1m2mpd2W3btsW7nEzX5c2b15d9k9jYWDPh2LBhw8z9u+++29Qj08vaIiIiPD6mb9++0qtXL7dMWwK3AAAA6cfVq1dNzdrly5fLyZMnzZjS1ZYtW/zWNwAAACBZgrZamkBn3dUs2Fq1ajlr2mr9WddgqS8UKFBAypYt67auTJky8sUXX9zwkjddAAAAkD7pVWE//PCD/O9//zO1bAMCAvzdJQAAACB5g7b9+/eXsLAwGT16tMlqVToz76BBg0zpAl/Sic727dvntu6XX36RokWL+vR5AAAAkHYsXLhQFi1a5Jw0FwAAAEjzQVvNVNCJyHS5cOGCWadB3OSgz6HZvFoe4fHHH5cNGzbIBx98YBYAAADAE528NrnGpwAAAIAtJyJzpYPh5BwQV6tWTebPn29mAy5fvry8+eabMnbsWGnbtm2yPScAAABSN70irE+fPnLw4EF/dwUAAABImUzbEydOyP/93//J0qVLzcQODofDbXtMTIz4UtOmTc0CAAAAJIROZKuTkd1xxx2SOXNmyZAhg9v206dP+61vAAAAQLIEbZ955hk5dOiQqW2rE4UxsQMAAADs5IknnpAjR46YElv58uVjvAoAAIC0H7T96aefJDIyUipVqpQ8PQIAAABuwZo1a2Tt2rVSsWJFf3cFAAAASJmatoULF45XEgEAAACwi9KlS8uVK1f83Q0AAAAg5YK2OhHYq6++Kn/88UfSnxUAAABIJm+99Za8/PLLsmLFCvn777/l/PnzbgsAAACQ5oK2rVu3NgPg4sWLS1hYmOTMmdNtAQAAAPzp4YcfNuUR6tevL3nz5pUcOXKYJXv27Oanr2n93Keeekpy5colmTJlkgoVKsimTZuc2/UqtQEDBpj5IHR7gwYN5Ndff403OVrbtm0lW7Zspp8dO3aUixcv+ryvAAAASKM1bTXTFgAAALCr5cuXp9hznTlzRmrXri0PPPCAfPfdd5InTx4TkHUNDo8cOVLGjRsnn3zyiRQrVsxM6NuwYUPZvXu3hIaGmjYasD127JgsWbJEoqOjpX379tK5c2eZNWtWir0WAAAApOKgbURERPL0BAAAAPCBWrVqSYYMGTxuO3XqlE+fa8SIEWbOh6lTpzrXaWDWNctWkx769esnzZs3N+umT58u+fLlkwULFkibNm1kz549snjxYtm4caNUrVrVtBk/frw0btxYRo0aJQULFvRpnwEAAJAGyyMAAAAAdqaBUE8T5544cULuv/9+nz7X119/bQKtjz32mCnFcPfdd8uHH37o3H7gwAE5fvy4KYlgCQ8Plxo1apgSDkp/akkEK2CrtH1gYKCsX7/ep/0FAABA6kDQFgAAAGnKoUOH5Nlnn3Vbp6UHNGBbunRpnz7X77//LhMnTpSSJUvK999/L126dJHu3bubUghKA7ZKM2td6X1rm/7UgK+r4OBgM1+E1SauqKgoJlgDAABIwwjaAgAAIE1ZtGiRrFmzRnr16mXuHz161ARsdYKwOXPm+PS5YmNjpXLlyjJs2DCTZat1aDt16iSTJk2S5DR8+HCTsWstWqIBAAAAaQdBWwAAAKQpOhnYDz/8IF988YUJ3GrAVgOqs2fPNiUHfKlAgQJStmxZt3VlypQx2b4qf/78ztIMrvS+tU1/njx50m379evX5fTp0842cfXt21fOnTvnXA4fPuzT1wUAAAD/SvKo9bfffjOXgF25csXc91Q3DAAAAPAHzTxdsmSJzJw5U6pXr24CtkFBQT5/ntq1a8u+ffvc1v3yyy9StGhR56RkGnhdunSpc7uWMtBatTVr1jT39efZs2dl8+bNzjbLli0zWbxa+9aTkJAQyZYtm9sCAACAtCM4sQ/4+++/pXXr1mYgGRAQIL/++qvccccd0rFjR8mRI4eMHj06eXoKAAAAeKHjUB2bxnX58mX55ptvJFeuXM51msHqKz179pRatWqZ8giPP/64bNiwQT744AOzKO1Tjx49ZMiQIaburQZx+/fvLwULFpQWLVo4M3MffvhhZ1mF6Oho6dq1q5lQTdsBAAAg/QlOysBUJ0bQS750gGnRQK5efkbQFgAAAClt7NixfnneatWqyfz58025gsGDB5ugrPalbdu2zjavvPKKXLp0ydS71YzaOnXqyOLFiyU0NNTZRjOCNVBbv359U8KhVatWMm7cOL+8JgAAAKTCoK3WB9OyCIUKFXJbr5kDBw8e9GXfAAAAgASJiIjw23M3bdrULN5otq0GdHXxJmfOnDJr1qxk6iEAAADSfE1bzRLInDlzvPV6mZnW1gIAAABSmo5Rk7M9AAAAYOug7b333ivTp093yxzQSRJGjhwpDzzwgK/7BwAAANxUiRIl5K233pJjx455baMT5+rkZI0aNaL0AAAAANJWeQQNzmqtrU2bNsm1a9dMja5du3aZTNvVq1cnTy8BAACAG1ixYoW89tprMmjQIKlYsaJUrVrVTOKldWPPnDkju3fvlrVr15q5GbT+7HPPPefvLgMAAAC+C9qWL19efvnlF3nvvfckLCxMLl68KC1btpQXX3xRChQokNjdAQAAALesVKlS8sUXX5jJcufOnSuRkZGyZs0auXLliuTOnVvuvvtu+fDDD02WbVBQkL+7CwAAAPg2aKvCw8Pl9ddfT8pDAQAAgGRTpEgRefnll80CAAAApOmg7Y4dOxK8w7vuuutW+gMAAAAAAAAA6VqCgraVKlUyE47p5A3606L3leu6mJiY5OgnAAAAAAAAAKQLgQlpdODAAfn999/NT60VVqxYMXn//fdl27ZtZtHbxYsXN9sAAAAAAAAAAMmcaVu0aFHn7ccee0zGjRsnjRs3diuJULhwYenfv7+0aNHiFroDAAAAAAAAAOlbgjJtXf38888m0zYuXbd7925f9QsAAABIkkOHDjnLeLnSdboNAAAASHNB2zJlysjw4cPl2rVrznV6W9fpNgAAAMCfNJngr7/+irf+9OnTHpMPAAAAgFRZHsHVpEmTpFmzZlKoUCFTFkHt2LHDTEb2zTffJEcfAQAAgASLO3mu5eLFixIaGuqXPgEAAADJGrStXr26mZRs5syZsnfvXrOudevW8uSTT0qWLFkSuzsAAADAJ3r16mV+asBW51rInDmzc1tMTIysX79eKlWq5MceAgAAAMkUtFUanO3cuXNSHgoAAAAki61btzozbXUehowZMzq36e2KFSvK//3f//mxhwAAAEAyBm0BAAAAu1m+fLn52b59e3n33XclW7Zs/u4SAAAAkCQEbQEAAJCmTJ061d9dAAAAAG4JQVsAAACkKfXq1bvh9mXLlqVYXwAAAICkIGgLAACANEVr17qKjo6Wbdu2yc6dOyUiIsJv/QIAAACSNWh79uxZmTdvnuzfv1969+4tOXPmlC1btki+fPnktttuS8ouAQAAAJ945513PK4fNGiQXLx4McX7AwAAACRWYGIfsGPHDrnzzjtlxIgRMmrUKBPAVV9++aX07ds30R0AAAAAUsJTTz0lH3/8sb+7AQAAAPg+aNurVy955pln5Ndff5XQ0FDn+saNG8uqVasSuzsAAAAgRaxdu9Zt/AoAAACkmfIIGzdulMmTJ8dbr2URjh8/7qt+AQAAAEnSsmVLt/sOh0OOHTsmmzZtkv79+/utXwAAAECyBW1DQkLk/Pnz8db/8ssvkidPnsTuDgAAAPCp8PBwt/uBgYFSqlQpGTx4sDz00EN+6xcAAACQUIkO2j7yyCNmwDtnzhxzPyAgQA4dOiR9+vSRVq1aJXZ3AAAAgE9NnTrV310AAAAAUram7ejRo82su3nz5pUrV67IfffdJyVKlJCwsDAZOnTorfUGAAAA8JHNmzfLjBkzzLJ161Z/dwcAAABIvkxbvdxsyZIlsnr1atm+fbsJ4FauXFkaNGiQ2F0BAAAAPnfy5Elp06aNrFixQrJnz27WnT17Vh544AH57LPPKOkFAACAtBW0jY6OlkyZMsm2bdukdu3aZgEAAADspFu3bnLhwgXZtWuXlClTxqzbvXu3RERESPfu3WX27Nn+7iIAAADgu6BthgwZpEiRIhITE5OYhwEAAAApZvHixfLjjz86A7aqbNmyMmHCBCYiAwAAQNqsafv666/La6+9JqdPn06eHgEAAAC3IDY21iQbxKXrdBsAAACQ5mravvfee/Lbb79JwYIFpWjRopIlSxa37Vu2bPFl/wAAAIBEqVevnrz00kumDIKOWdWRI0ekZ8+eUr9+fX93DwAAAPB90LZFixaJfQgAAACQYjTJ4JFHHpHbb79dChcubNYdPnxYypcvLzNmzPB39wAAAADfB20HDhyY2IcAAAAAKUYDtXr1l9a13bt3r1mn9W0bNGjg764BAAAAyRO0tWzatEn27NnjnNihSpUqSd0VAAAA4FMBAQHy4IMPmgUAAABI8xOR/fnnn3LvvfdK9erVTa0wXapVqyZ16tQx2wAAAAB/WLZsmUkmOH/+fLxt586dk3LlyklkZKRf+gYAAAAka9D22WeflejoaJNle/r0abPobZ2JV7cBAAAA/jB27Fjp1KmTZMuWLd628PBwee6552TMmDF+6RsAAACQrEHblStXysSJE6VUqVLOdXp7/PjxsmrVqsTuDgAAAPCJ7du3y8MPP+x1+0MPPSSbN29O0T4BAAAAKRK01YkdNNM2rpiYGClYsGCSOgEAAADcqhMnTkiGDBm8bg8ODpa//vorRfsEAAAApEjQ9u2335Zu3bqZicgseltr244aNSpJnQAAAABu1W233SY7d+70un3Hjh1SoECBFO0TAAAAkBTBCWmUI0cOMwOv5dKlS1KjRg2TraCuX79ubnfo0EFatGiRpI4AAAAAt6Jx48bSv39/UyIhNDTUbduVK1dk4MCB0rRpU7/1DwAAAPBp0FYndQAAAADsrF+/fvLll1/KnXfeKV27dnXOwbB3716ZMGGCKef1+uuv+7ubAAAAgG+CthEREQlpBgAAAPhNvnz5ZM2aNdKlSxfp27evOBwOs16vGGvYsKEJ3GobAAAAIE0EbT05efKkWWJjY93W33XXXb7oFwAAAJBoRYsWlUWLFsmZM2fkt99+M4HbkiVLmnJfAAAAQJoN2m7evNlk3u7Zs8eZvWDRLAa97AwAAADwJw3SVqtWzd/dAAAAAFImaKuTjWmdsClTppjLy1wnKAMAAAAAAAAApHDQ9vfff5cvvvhCSpQocYtPDQAAAAAAAACIK1ASqX79+rJ9+/bEPgwAAAAAAAAAkByZth999JGpabtz504pX768ZMiQwW37I488kthdAgAAAAAAAACSGrRdu3atrF69Wr777rt425iIDAAAAAAAAABSuDxCt27d5KmnnpJjx45JbGys25LcAdu33nrLBIZ79OiRrM8DAAAAAAAAAKkmaPv3339Lz549JV++fJKSNm7cKJMnT5a77rorRZ8XAAAAAAAAAGwdtG3ZsqUsX75cUtLFixelbdu28uGHH0qOHDlS9LkBAAAAAAAAwNY1be+8807p27ev/PTTT1KhQoV4E5F1795dfO3FF1+UJk2aSIMGDWTIkCE+3z8AAAAAAAAApNqg7UcffSRZs2aVlStXmsWV1pv1ddD2s88+ky1btpjyCAkRFRVlFsv58+d92h8AAAAAAAAAsFXQ9sCBA5JSDh8+LC+99JIsWbJEQkNDE/SY4cOHyxtvvJHsfQMAAAAAAAAAW9S0deVwOMySXDZv3iwnT56UypUrS3BwsFk0u3fcuHHmdkxMTLzHaOmGc+fOORcN/AIAAAAAAABAmg7aTp8+3dSzzZQpk1nuuusu+fTTT33eufr168vPP/8s27Ztcy5Vq1Y1k5Lp7aCgoHiPCQkJkWzZsrktAAAAAAAAAJBmyyOMGTNG+vfvL127dpXatWubdTop2fPPPy+nTp2Snj17+qxzYWFhUr58ebd1WbJkkVy5csVbDwAAAAAAAADpMmg7fvx4mThxorRr18657pFHHpFy5crJoEGDfBq0BQAAAAAAAID0JtFB22PHjkmtWrXirdd1ui25rVixItmfAwAAAAAAAABSTU3bEiVKyJw5c+Kt//zzz6VkyZK+6hcAAACQ6rz11lsSEBAgPXr0cK67evWqvPjii6bEV9asWaVVq1Zy4sQJt8cdOnRImjRpIpkzZ5a8efNK79695fr16354BQAAAEiVmbZvvPGGtG7dWlatWuWsabt69WpZunSpx2AuAAAAkB5s3LhRJk+ebCbpdaXlw7799luZO3euhIeHm7khWrZsacbQKiYmxgRs8+fPL2vWrDFXr2kpsgwZMsiwYcP89GoAAACQqjJtNTNg/fr1kjt3blmwYIFZ9PaGDRvk0UcfTZ5eAgAA+JHW89dAXLZs2cxSs2ZN+e677/zdLdjIxYsXpW3btvLhhx9Kjhw5nOvPnTsnU6ZMMZP51qtXT6pUqSJTp041wdl169aZNj/88IPs3r1bZsyYIZUqVZJGjRrJm2++KRMmTJBr16758VUBAAAg1QRtlQ42dVC5efNms+jtu+++2/e9AwAAsIFChQqZy9513LNp0yYTfGvevLns2rXL312DTWj5A82WbdCggdt6PWeio6Pd1pcuXVqKFCkia9euNff1Z4UKFSRfvnzONg0bNpTz5897PceioqLMdtcFAAAA6bg8AgAAQHrTrFkzt/tDhw412beaKVmuXDm/9Qv28Nlnn8mWLVtMeYS4jh8/LhkzZpTs2bO7rdcArW6z2rgGbK3t1jZPhg8fbsqWAQAAIJ1n2gYGBkpQUNANl+BgYsAAACBt0/qjGqS7dOmSKZOA9O3w4cPy0ksvycyZMyU0NDTFnrdv376m9IK1aD8AAACQdiQ4yjp//nyv2/SSrnHjxklsbKyv+gUAAGArP//8swnSXr16VbJmzWrGRmXLlvV3t+BnWv7g5MmTUrlyZbfAvk7a+95778n3339v6tKePXvWLdv2xIkTZuIxpT91fghXut3a5klISIhZAAAAkM6Dtlq3La59+/bJq6++Kt98842ZeGHw4MG+7h8AAIAtlCpVSrZt22ayGufNmycRERGycuVKArfpXP369U1A31X79u1N3do+ffpI4cKFJUOGDLJ06VIzoa81hj506JAzU1t/askNDf7mzZvXrFuyZImZ9I7zCwAAIH1KUj2Do0ePysCBA+WTTz4xkyToHzDly5f3fe8AAABsQuuSlihRwjkpq9Yvfffdd2Xy5Mn+7hr8KCwsLN44OEuWLJIrVy7n+o4dO0qvXr0kZ86cJhDbrVs3E6i95557zPaHHnrIBGeffvppGTlypKlj269fPzO5Gdm0AAAA6VOigraaWTJs2DAZP368VKpUyWQM3HvvvcnXOwAAAJvSslBRUVH+7gZSgXfeecfMD6GZtnrOaNLD+++/79yuc0MsXLhQunTpYoK5GvTVTG6uYgMAAEi/Ehy01W/9R4wYYepqzZ4922O5BAAAgLRIJ31q1KiRFClSRC5cuCCzZs2SFStWmHqlQFx6brjSCcomTJhgFm+KFi0qixYtSoHeAQAAIE0FbbV2baZMmcxlgVoWQRdPvvzyS1/2DwAAwO+01mi7du3k2LFjEh4eLnfddZcJ2D744IP+7hoAAACA9By01T9UAgICkrc3AAAANjRlyhR/dwEAAABAOpLgoO20adOStycAAAAAAAAAAAn0dwcAAAAAAAAAAP8haAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjQT7uwMAACB1O3TokJw6dcrf3UAyyJ07txQpUsTf3QAAAADSHYK2AADglgK2pUuVlitXr/i7K0gGmUIzyd59ewncAgAAACmMoC0AAEgyzbDVgO0T8oTklbz+7g586KSclNlXZ5v3mKAtAAAAkLII2gIAgFumAdtCUsjf3QAAAACANIGJyAAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtEm348OFSrVo1CQsLk7x580qLFi1k3759/u4WADjxOQUAAAAASM0I2iLRVq5cKS+++KKsW7dOlixZItHR0fLQQw/JpUuX/N01ADD4nAIAAAAApGbB/u4AUp/Fixe73Z82bZrJZNu8ebPUrVvXb/0CAAufUwAAAACA1IxMW9yyc+fOmZ85c+b0d1cAwCM+pwAAAAAAqQlBW9yS2NhY6dGjh9SuXVvKly/v7+4AQDx8TgEAAAAAUhvKI+CWaM3InTt3yk8//eTvrgCAR3xOAQAAAABSG4K2SLKuXbvKwoULZdWqVVKoUCF/dwcA4uFzCgAAAACQGhG0RaI5HA7p1q2bzJ8/X1asWCHFihXzd5cAwA2fUwAAAACA1IygLZJ0qfGsWbPkq6++krCwMDl+/LhZHx4eLpkyZfJ39wCAzykAAAAAQKrGRGRItIkTJ5qZ2O+//34pUKCAc/n888/93TUAMPicAgAAAACkZmTaIkmXHQOAnfE5BQAAAABIzci0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgI7YO2g4fPlyqVasmYWFhkjdvXmnRooXs27fP390CAAAAAAAAgPQZtF25cqW8+OKLsm7dOlmyZIlER0fLQw89JJcuXfJ31wAAAAAAAAAgWQSLjS1evNjt/rRp00zG7ebNm6Vu3bp+6xcAAAAAAAAApMugbVznzp0zP3PmzOm1TVRUlFks58+fl5R26NAhOXXqVIo/L5Jf7ty5pUiRIv7uBnDL+JxKu/icAgAAAIDUL9UEbWNjY6VHjx5Su3ZtKV++/A3r4L7xxhviz0BIqdJl5OqVy37rA5JPaKbMsm/vHgIiSNX0c6pM6VJy+cpVf3cFySBzplDZs3cfn1MAAAAAkIqlmqCt1rbduXOn/PTTTzds17dvX+nVq5dbpm3hwoUlpWjmmgZsy9QfK1lylEix50Xyu3TmN9mztId5jwmGIDXTc1gDtjOeFCmT19+9gS/tOSny1KyrfE4BKUgTBr788kvZu3evZMqUSWrVqiUjRoyQUqVKOdtcvXpVXn75Zfnss8/MFWENGzaU999/X/Lly+f2hVqXLl1k+fLlkjVrVomIiDD7Dg5ONcN1AAAA+FCqGAV27dpVFi5cKKtWrZJChQrdsG1ISIhZ/E0DtmF5Kvi7GwDglQZsK9/4IxUAkMCJc6tVqybXr1+X1157zUycu3v3bsmSJYtp07NnT/n2229l7ty5Eh4ebsa2LVu2lNWrV5vtMTEx0qRJE8mfP7+sWbNGjh07Ju3atZMMGTLIsGHD/PwKAQAA4A+2Dto6HA7p1q2bzJ8/X1asWCHFihXzd5cAAACABE+cq3MyTJkyRWbNmiX16tUzbaZOnSplypSRdevWyT333CM//PCDCfL++OOPJvu2UqVK8uabb0qfPn1k0KBBkjFjRj+9OgAAAPhLoNiYZi3MmDHDDHLDwsLk+PHjZrly5Yq/uwYAAADcdOJcDd5GR0dLgwYNnG1Kly5tSpisXbvW3NefFSpUcCuXoCUUtMzXrl27PD6PllnQ7a4LAAAA0g5bB20nTpxoBr7333+/FChQwLl8/vnn/u4aAAAAcNOJczXhQDNls2fP7tZWA7S6zWrjGrC1tlvbPNF6t1pqwVpScg4HAAAAJD/bl0cAAAAA0tLEub7g78l3AQAAkI6DtgAAAEBqnjhXJxe7du2anD171i3b9sSJE2ab1WbDhg1u+9Pt1jY7T74LAACAdFgeAQAAALD7lWEasNWJc5ctWxZv4twqVapIhgwZZOnSpc51+/btk0OHDknNmjXNff35888/y8mTJ51tlixZItmyZZOyZcum4KsBAACAXZBpCwAAANxCSQSdNPerr75yTpyrtM5spkyZzM+OHTuaUgY6OZkGYrt162YCtffcc49p+9BDD5ng7NNPPy0jR440++jXr5/ZN9m0AAAA6RNBWwAAAOAWJs5VOnGuq6lTp8ozzzxjbr/zzjsSGBgorVq1kqioKGnYsKG8//77zrZBQUGmtEKXLl1MMDdLliwSEREhgwcPTuFXAwAAALsgaAsAAAAk48S5oaGhMmHCBLN4U7RoUVm0aJGPewcAAIDUipq2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADYS7O8OAAAAAEgZMTExEh0dfcv7cTgcUrRoUcmXM0iyhF/3Sd/SI4dD5MKVQImKJpcGAAC4I2gLAAAApHEaZD1+/LicPXvWJ/sLDg6WSZMmScbMeSUw8JJP9pkeOUTkeoxDNuzLIMu2ZRaHBPi7SwAAwCYI2gIAAABpnBWwzZs3r2TOnFkCAm4tOHj58mWTsRuarZAEBYX6rJ/pjUMcEnv9itTNeEqPqizdlsXfXQIAADZB0BYAAABI4yURrIBtrly5fLZPFRiUUQKDQ3yyz/QqKDhUcuQUqV7qpPy0K5ZSCQAAwGBEAAAAAKRhVg1bzbCFPQUGZ5LgoAAJyxTr764AAACbIGgLAAAApAO3WhIBySfA/Kfvkb97AgAA7IKgLQAAAAAAAADYCEFbAAAAAOnS+HfelBaNqqeZ5wEAAGkHQVsAAAAAtnXs6GF5rXdnubd6MalQMkzq1S4pQwe9LGfO/J2o/ZS+PVR+/P5rt3UdOveUqbO+83GPAQAAbh1BWwAAAAC2dPjQ7/K/R2rLwT9+k9HjPpHvV+ySQUPek3VrlkublvfJ2bOnb2n/WbJklRw5cvmsvwAAAL5C0BYAAACALQ3u30MyZMggUz79VqrfU1cK3lZE6j7QUD6esUhOHj8qY98eaNrVq32nvD9umPTq9rTcXSan1K1xh8ycPsm5H92uuj73uMm4te7HLVvw6svPyoudHpNJE0ZI7apFpFqFfDLh3aFy/fp1GTmsr9SoWEDuu6e4fDHnE7d+jhr+ujR8oLxUKp1DGtxbWt4dPUiio6NT6CgBAIC0iKAtAAAAkF5dvep9uXbthm0DoqIkIOqqBHhoq+viLomlWbQ/rVoiTzz1nISGZnLblidvfmnaoo18t3CeOBwOs27KB+9I6TJ3yZffrpdOXf5Phr3xsqyO/NFsm/f1avNz2NsfSOSGP5z3PVm3doWcPHFMPv38R3m1/wgT2H2+w6OSLTy7fL4gUtq0fVYGvd5Vjh/70/mYLFmzyvBRH8rCJVvltYGjZe7sqfLJlHGJfs0AAACWYOctAAAAAOnLY49531a1qsjAfzJZjaeeEomKMjdDYmKk+IULEpQhiwQEBknUnWXlVJ8hzqb5+zwngRcvuO3uyJQvE9W1gwd+MwHZ4iVKe9xevHhpOXfujJz++y9zv3KVmtL5hd7mdrE7SsrWTWvlkynjpfa9DSRnrjxmfbZs2U3A90bCw3NIv0FjJDAwUO4ofqd8NGmMXL16WZ5/sY/Z3vmFV+TDiaNk88Y10uSRx826Lt36Oh9fqPDtcqBzD1n0zVx59vmXE/WaAQAALARtAQAAANiWlUl7M5Uq14h3/5OPxyf6+UreWdYEbC25cueVO0uVc94PCgqS7Dlyyt//BouVBmg/nTZBDh88IJcvXzTlFLKGZUv0cwMAAFgI2gIAAADp1dy53re5BC6NGTOcN6MuXZL9e/dK5hzFJSgokzjitD0+YvItd63I7cUlICBA9u/fKw9K83jbdb1mxVpZtL4SHJzB7b72Ie46kQBxxMaaW1s3r5PePZ6Rbj37S+26D0pYWLgs+maOTP3wXZ/2CwAApC8EbQEAAID0KjQ0aW1jYsQREiKOkFBxBMffhyMx+/UiR45cUqtOfZn96QfyTMfubnVt/zp5XBYu+Eyat2xrgqpq+9YNbo/ftnW9W2kFndAsJjZGfG3rlnVmgrTnu77qXHf0yCGfPw8AAEhfmIgMAAAAgC31HzxWrl2LkmfbNZWN6yPl2NHDErniB+nwdBPJm7+g9Oj9hrPtls1r5aNJo+XA77/KzOmT5PtFX8rT7bs6txcsVFTWrV5uAr5aC9dXbr+9hOnXt1/PkUMH98v0qRNkyfdf+2z/AAAgfSJoCwAAAMCWbi9WQuZ9vVoKFS4mPV98Sh66r6wMeO0FqVHzPvnsy5WSPXtOZ9v2z74kO3/eIi2b1JBJ49+SPv1Gyr33Pejc3uf1EbLmp6XyQK0S8mhj9/q3t6Leg00lomN3eXNgT2nRuIZs27xOXnCZmAwAACApKI8AAAAAwLZuK1RU3hr90U3bZc2aTcZOmOl1e70GTcziSuvQ6mLx9Dyffr4k3rplq39xu9+77zCzuIro2M3r8wAAANwMmbYAAAAAAAAAYCMEbQEAAAAAAADARiiPAAAAACBVi1uuAAAAILUj0xYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIB2IjY31dxfghUNixWHeowB/dwUAANgENW0BAACANCxjxowSGBgoR48elTx58pj7AQG3FhyMiooyP2NjrkkAeSBJ5tD/YqPl0oW/5fwlh5y9xLEEAAD/IGgLAAAApGEasC1WrJgcO3bMBG594dq1a3Lq1CnJeDlQAgMz+GSf6ZFm18bEivx2JFAWbw6TGDJtAQDAvwjaAgAAAGmcZtcWKVJErl+/LjExMbe8v127dsnzzz8v5RtOkiw57/RJH9Mjh0PkyrVAuXw1QBxCwBYAAPyHoC0AAACQDmhJhAwZMpjFF/s6ePCg5DkdI2FB/EkBAADga6miaNKECRPk9ttvl9DQUKlRo4Zs2LDB310CAAAAfI5xLwAAAFJF0Pbzzz+XXr16ycCBA2XLli1SsWJFadiwoZw8edLfXQMAAAB8hnEvAAAAUk3QdsyYMdKpUydp3769lC1bViZNmiSZM2eWjz/+2N9dAwAAAHyGcS8AAAAsti5ApbPSbt68Wfr27es2+22DBg1k7dq1Hh8TFRVlFsu5c+fMz/Pnz6dAj0UuXrz4z/P9tVNioi+nyHMiZVw6+7vzPU6p88l6PnX1yFWJjYpNsedF8rt26ppfz6nNR0Qu/vdxiTRg3ylJ8XPKOp+OyBGJEk6otOSUnErx88l6HofOzpTOJHbcy5gXyYUxL3yNMS/SwpjXej7FuDftOZXC494Ej3kdNnbkyBHtvWPNmjVu63v37u2oXr26x8cMHDjQPIaFhYWFhYWFhSV1LocPH3akN4kd9zLmZWFhYWFhYWGRND3mtXWmbVJodoLWArPExsbK6dOnJVeuXGaWW/j+24HChQvL4cOHJVu2bP7uDlI5zif4GucUfI1zKnlptsGFCxekYMGC/u6K7THmTVn87sPXOKfgS5xP8DXOKXuMeW0dtM2dO7cEBQXJiRMn3Nbr/fz583t8TEhIiFlcZc+ePVn7CTG/xPwiw1c4n+BrnFPwNc6p5BMeHi7pUWLHvYx5/YPfffga5xR8ifMJvsY55d8xr60nIsuYMaNUqVJFli5d6pZFoPdr1qzp174BAAAAvsK4FwAAAKkm01bpZV8RERFStWpVqV69uowdO1YuXbpkZtUFAAAA0grGvQAAAEg1QdvWrVvLX3/9JQMGDJDjx49LpUqVZPHixZIvXz5/dw3/Xpo3cODAeJfnAUnB+QRf45yCr3FOITkx7rUvfvfha5xT8CXOJ/ga55Q9BOhsZP7uBAAAAAAAAAAgFdS0BQAAAAAAAID0hqAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAeDBo0CAzCRAAAACQVjHmBeyLoC3ieeaZZyQgIMC55MqVSx5++GHZsWOHs43rdmupU6eOc/uHH34oFStWlKxZs0r27Nnl7rvvluHDh/vpFcFf7r//funRo0e89dOmTTPnheX8+fPy+uuvS+nSpSU0NFTy588vDRo0kC+//FKsuRIPHDggTz75pBQsWNC0KVSokDRv3lz27t2boq8JyUdnSn/ppZekRIkS5j3W2dJr164tEydOlMuXL/u7e0in1q5dK0FBQdKkSROP2/XzTBcAqQ9jXvgS414kFGNe2BFjXnsiaAuPdMB67NgxsyxdulSCg4OladOmbm2mTp3qbKPL119/bdZ//PHHZsDSvXt32bZtm6xevVpeeeUVuXjxop9eDezs7NmzUqtWLZk+fbr07dtXtmzZIqtWrZLWrVub8+bcuXMSHR0tDz74oLmtA9p9+/bJ559/LhUqVDCPR+r3+++/mz90f/jhBxk2bJhs3brVDBz0HFi4cKH8+OOPHh+n5waQnKZMmSLdunUzn0tHjx51rn/nnXfkwoULzvt6W9cBSF0Y8yIlMe4FY17YFWNem3IAcURERDiaN2/uti4yMlK/9nWcPHnS3Nfb8+fP9/h4fewzzzyTIn2Fvd13332Ol156Kd76qVOnOsLDw83tLl26OLJkyeI4cuRIvHYXLlxwREdHO7Zu3WrOuT/++CNF+o2U17BhQ0ehQoUcFy9e9Lg9NjbW/NTz4P3333c0a9bMkTlzZsfAgQPN+gULFjjuvvtuR0hIiKNYsWKOQYMGmXPHcubMGUfHjh0duXPndoSFhTkeeOABx7Zt29yeY/jw4Y68efM6smbN6ujQoYOjT58+jooVK5ptK1eudAQHBzuOHTvm9hg9v+vUqePz4wF70M8gPR/27t3raN26tWPo0KFun2M1atQw55UuelvXAUg9GPPClxj3IiEY88KOGPPaF5m2uCnNFpgxY4a5fEMvG7sZvcRn3bp1cvDgwRTpH1Kv2NhY+eyzz6Rt27bm8q+49FJDzXjJkyePBAYGyrx58yQmJsYvfUXy+fvvv022wYsvvihZsmTx2EYvR3Wtu/Xoo4/Kzz//LB06dJDIyEhp166ducxs9+7dMnnyZHPpztChQ52Peeyxx+TkyZPy3XffyebNm6Vy5cpSv359OX36tNk+Z84cs1/NeNi0aZMUKFBA3n//fefj69atK3fccYd8+umnbhkPM2fONH1A2qTnhV6+WqpUKXnqqadMVp116apeVq3bNStGF72t6wCkXox5kZwY94IxL+yKMa+N+TtqDHtmHQQFBZlvgXXR06RAgQKOzZs3O9voutDQUGcbXawshKNHjzruuece0+bOO+80+/v8888dMTExfnxVsGPGwYkTJ8x5MmbMmJvu67333jPfMlvfGA8ePNixf//+ZOo5UtK6devMefDll1+6rc+VK5fz8+WVV14x67Rdjx493NrVr1/fMWzYMLd1n376qfncsrKmsmXL5rh69apbm+LFizsmT55sbtesWdPxwgsvuG3Xb5GtrAM1YsQIR5kyZZz3v/jiC/ONtLdMCaR+tWrVcowdO9bc1iwWzVpZvny58xzTc0QzVHTR27oOQOrBmBe+xLgXN8OYF3bFmNe+yLSFRw888ICpzaXLhg0bpGHDhtKoUSO3TAKtY2K10UVrLyn9tk7r8ug3gvot4PXr1yUiIsLUDNNvmAGL9e1dQug30lq0X7/lrVmzpsydO1fKlSsnS5YsSdY+wn/0s0c/W/R9joqKcq6vWrWqW7vt27fL4MGDTYaKtXTq1MnUHdTJHHS7Zk9p1pRrG53kY//+/WYfe/bskRo1arjtV88zV/qN8m+//WayqpRmNjz++ONeMyWQumkNQT0Hn3jiCXNfs5+05qDW+1KaxaKfP/fee69Z9LauA5C6MOZFSmHcC28Y88KfGPPaW7C/OwB70g9kvTTM8tFHH0l4eLiZIXfIkCHOS8Jc28RVvnx5s7zwwgvy/PPPm1/wlStXmsEx0ods2bKZSRTi0kkU9HzSy790Nt2EzoQbFhYmzZo1M4ueh/qHlf60/nhC6qSfI3opmA4YXOmlWSpTpkxu6+MOGHVw+sYbb0jLli3j7Vtn5NXt+of1ihUr4m13nc35ZvLmzWvOPZ2QplixYuayM0/7RNqgA1UNwLhewqp/cIeEhMh7770nvXr1ivf5FHcdAPtjzAtfYdyLm2HMCztizGtvBG2RIPqPi9ZWunLlSpIeX7ZsWfPz0qVLPu4Z7Exr4mjdprh0ptw777zTnFNt2rQxNZMGDhwYr76XDjx0AKLf9nk6J7Xuzpo1a5L1NSD5aTaA/gGigwKdsTSx3+JrrS4d/Hr7g1q3a7aKnke33367xzZlypSR9evXmzphFiu7wNWzzz5rvoUuVKiQFC9eXGrXrp2oviJ10IGrzuw9evRoeeihh9y2tWjRQmbPnm0CM4qaXkDawpgXScW4FzfDmBd2w5jX/gjawiO9LEM/8NWZM2fMPyw6kNBv3G6mS5cuZhBSr1498yGvl2vot8L67XLcSy+Qtum5oOdO9+7dzT/8+m3dt99+az78v/nmG9NGC+frN7d6mY7e1suAMmTIYArtDx8+XDZu3Ch//PGHGdw+/fTT5o+hjBkzmgwWLZDep08ff79M+IBOgKCDQX3/dXKEu+66y/xxo++/ZqRUqVLF62MHDBggTZs2lSJFisj//vc/8zi9PGznzp3ms6dBgwbms0cHHiNHjjR/OB09etScizq5gz6nXtaqAxG9rf3QyxF37drlzHywaJaLZtLofvXyNKRNOsmC/tvXsWNHkx3lqlWrViYjwRrAAkjdGPPCVxj3IiEY88JOGPOmAv4uqgv70UkU9NSwFi2AX61aNce8efOcbXS9NQlDXNqucePGpiB6xowZHQULFnS0atXKsWPHjhR8FbCLDRs2OB588EFHnjx5zCQMWrg87rlz9uxZx6uvvuooWbKkOWfy5cvnaNCggWkXGxvr+Ouvvxzdu3d3lC9f3hTB13OyQoUKjlGjRjHZRxqiE7p07drVUaxYMUeGDBnMe129enXH22+/7bh06dINP3sWL15sCuhnypTJTMCgj/vggw+c28+fP+/o1q2b+TzSfRcuXNjRtm1bx6FDh5xthg4daoru6/Pq56BOBOE6KYOlf//+ZuIa7S/SpqZNm5p/xzxZv369OQ+3b9+e4v0C4FuMeeFrjHuREIx5YReMee0vQP/n78AxAACphX4T/ddff8nXX3/t764AAAAAyYIxL+B/lEcAACABdHIRnSF81qxZDF4BAACQJjHmBeyDoC0AAAnQvHlz2bBhg6nrxMzNAAAASIsY8wL2QXkEAAAAAAAAALCRQH93AAAAAAAAAADwH4K2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAABD7+H+KiXSjiGkJMQAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHvCAYAAAAvoP1zAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe/9JREFUeJzt3QmcTfX7wPFnFmYsY+xbloTskTVLKpRsEb+ilAlRCqG/pGzJEiGRUIlkKRSVpGSd7LuslYSsyb6NMXP/r+db53bvzL3MjDtzz8x83r1Oc+8533vu95575vrOc5/zfAMcDodDAAAAAAAAAAC2EOjvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAACka4MGDZKAgACz3H777f7uDhLpmWeecb5/999/v7+7gzSMzwoAAJCSCNoCAGADJ06ckDfffFPuu+8+yZcvn2TMmFGyZMki5cqVk44dO8p3330nDofD391EOgqAui4hISGSP39+eeCBB2Ts2LFy5coVf3cVNrRu3Tp58sknTUAzNDTUfIYVLlxYqlWrZj7HJk+eHO8xGmi3zjM9/wAAAPCP4H9/AgAAP3n//ffl5ZdflqtXr7qtj46Olt27d5vl448/lgMHDpDdlQweeughyZo1q7kdHh7u7+7Y0rVr18wXC7qsWLFC5s6dKytXrpTgYIaS+MdHH30knTt3jvfl0uXLl+XPP/+UTZs2yRdffCHPPfec3/oIAACQmjDSBgDAj0aOHCl9+vRx3g8KCpImTZpIlSpVTObZb7/9Jt9//70JlsG78+fPS7Zs2ZL02Fq1apkF8b399tvm58WLF2XWrFny66+/mvtr1qyRhQsXSosWLZL1+S9cuCBhYWHJ+hzpyZgxY6R8+fJSv35981njK6dPn5bu3bs7A7aFChWS//3vf5I3b17zHu7cuVNWrVolyfWFgj6vZoMjeT8rAQBAyqI8AgAAfqIZtK+99przvgY4Nm7cKF999ZUMGDBA+vfvL5988okcPnxYPvjgA8mcObPb448cOSK9e/eWChUqmExRvRxZM3Gfeuop2bBhw03rMR47dkwiIiIkd+7c5o/4Zs2ayS+//GLabtmyRR5++GETMMuRI4c89thjph+uNOPS9RL633//3Vw6X7ZsWdOX2267TXr16mWCNnEDPK+88ooJHGk/9Dm0HISWhXjwwQfl008/jZetF/e5NJg9atQoKVOmjAnWtGvXzrTbtm2bvPDCC1KjRg3z/JkyZTJ9KVq0qLRu3Vp++umnmx4XVwcPHjSZgSVLlnTuS/dbu3Zt89r27NkTb39Lly41ASsNXGnf9NhWrlxZBg4caF57XPqc1vNrXzZv3ixNmzaV7Nmzm/f83nvv9djvG3G95PxW6rz+3//9n1m0X7Nnz3bbtnfv3njtb/Wc/Pvvv+XFF180x06DilOmTHG21aCfvha95D5nzpzmnNy/f/9NX4N+4aG/Z5UqVTLnmvapRIkS5nkOHToUr31SzqEb1dWNe+7+8ccfZv2kSZOc6zJkyGB+5yx6fuvrtLYPGTJEfOHrr7+Whg0bmpIF+j7t2LHDJ/vVY+JaMkPvv/POO9K3b18ZNmyYed5Tp07JnDlz4r33mrFt0c87T8cqbgkFDQLrFwa5cuUyv2PW76F+yaDr77zzTnOO6HHV36Pq1avL0KFD5dKlS/H6/vPPP5vzU88/3Ze+30WKFJF69eqZ/us57Y1+tulVEno89RzRz7733nvPYymbmJgYc8WEfu7pZ672TfuvJUc+/PBDuX79eoLOG2+fG4n9rLQ+37SchfZDf1/r1q0ry5Ytk2nTprntAwAA+IkDAAD4xfPPP69/2TuXL774IsGPXblypSNHjhxuj3ddAgMDHaNHj3Z7zMCBA53bc+bM6bj99tvjPS5PnjyO+fPnO0JCQuJtK1mypOPKlSvO/S1fvtxte7169Tz2pVq1am6P+/nnn73221rat2/v1ve4z3Xvvfe63W/evLlpN378+BvuNyAgwDF16lSvx6Vo0aLO9SdOnDDH40b7mzhxotu+evXqdcP2t912m2Pnzp1uj9HntLZXr17dkSFDhniP0/dj9+7dCT4/7rvvPudj9XZCRUREuD2v5eLFi44BAwa4bYt7HG/1nMydO7ejdOnSbo955513TLtvvvnGERwcHG+feh7XrFnT62tds2aN2a+3PoWHhztWrVrl9piknEOuxy1uH+KeuwcOHHBu0/PWWl+hQgVHVFSUIyYmxlG7dm3n+rp165p1vtCpUyfTf9f+VKxY0TFq1CjHsWPHkrxf/exy3edXX31108e4vvfeFutYuZ7Pd999tyNLlixu7bZu3Wra5cqV64b702N84cIFZx927drlyJw58w0f891333nsc758+RxVq1b1+Jhu3bq5vVb9/dH38UbPU6dOHbe+3ei8ifu5of1K7Gel7i9//vwef0+bNGni8XMAAACkLMojAADgJ5qRadFs1oRean727Flp2bKlnDlzxtzXzLD27dubjE7NhtTsqdjYWJMhqWUWdHKzuDTjUzPjXnrpJZN9pvUo1V9//SWPPvqoybrq2rWr2de8efPMNr00fsGCBdKmTRuP/dIMrebNm0vFihXNxGmaNaz0p5aB0OxhFRgYaLK+NPtNJ7fSTDit57t161b55ptvTJba1KlT5fnnnzdtPImMjDSTtGl2sLa3LvXWTLJ77rnHZFVa2WPnzp0zx1r7oW01M04zJvW43YjW39TjYb0/eox1n0ePHjVZptoHV5ohrJefW7R/eiy1vWYQaqadZu3pe7dr1y6P9WA1G1WzTNu2bWsym7UkgYqKipJ3333XZGemJG9ZdsWLFzfZxL48JzUTU5cGDRqYTGY99pp9rTVRdRIrKxNRMxQ7dOhg3pMZM2bI2rVrvV4Grr9Tuk9lZcpq3/Sc1vdAz41WrVqZc9uqZ+zLc+hmNJNY96nniGZ8Dh482Pw+rF692mzX2/oa9XfGFzRjXzP4P//8c/O+aHbv9u3bzaJlWjTT/emnnzbHLW5m/43osdJzxcow1c+BO+64wxxHzTLXbHGdjMz1fLJqSU+cONFk6auqVaua42rRbNm49HNCf3e0n5oBr7+LmuWq9HdHM1f1vdbzQ/ujtcD19ernnB5jrSGumf5Kfy/1/LIeqxm3muGsNXg1m1cnVrtRBree9/o5Zb1P+jg1fvx4c15Z57mWjnAtD6GvvWbNmmb/Wv7Gyk7WdpqN60vePiv18/348ePOdo0bNza/m99++61ZAACADaRwkBgAAPzLNcOrRo0aCX6cZh+6ZkEtWrTILTs0a9as8bKqPGW2zZgxw7nNNVtRl7lz55r1sbGxjoIFCzrXayapt4wuzeKzXLt2zVGuXDnntkKFCsV7HQcPHnTMmzfP8d5775lMv7fffttkolqPGTx4sNfnuueee9yyd+Pavn27eX3vvvuu2e+QIUPcHu+aXekt03bMmDHO9c8991y859DsuePHjzvva8ai1V6zmC9fvuzc9v7777s9v2Yze8qY0wzCI0eOOLe1aNHCua1y5cqOlM609bRoNuOOHTuS5Zzs0aNHvD7Nnj3brc1HH33k3KbZgq6Zya6vVd97a71mAP/9999u751rFrW2vZVzKKmZturHH390Zr9qNrFrlvucOXMcyWnfvn2OQYMGOUqVKuXWx7CwMMczzzzj2LNnT4L3pe/djc6bYsWKOT9XvJ2rehw9cW2jy4IFC7z24+zZs+b8mzRpksns1vfONctVrwiwdO/e3bl++PDh8fZ1+vRps3g7X2fOnOn1XGzbtq1Zf+rUKUdQUJBz/eOPP+72HHrf2qbttL0vM209fVYePXrULeO6devWzm1Xr16Ndz4AAAD/INMWAIBUxjWzME+ePNKoUSO3urh6f+7cufHautJMNdeMNq2PaLXVTEbNEFWaGVesWDGTCaisTEpPNPPNovt4/PHHTR1XpRlompmmmZNat1Rr6d4sm8vKWvNEMzat7DpXmjmoNRs1izKp+7ZotqeVPTh58mSTEak1K0uVKmUyAjWjT1+P0mw91/qgWm/VNQtT+6R1Ui16rD1lVmuGYsGCBZ339bksNzr2cWldS19PRLZo0SJzDPT909qXWov0rrvu8tk5qfr16xdv3aZNm9zuaw1O1/O2Tp06snz58niPs7JVrWOnWbPe6MRqmuXo63MoIbTGqZ7Peqw1m9jKKNZsYj2PEkrrompGcFydO3f2OvGU1n7V31FdNINVs281G1f3o3VNNWu+dOnSCXp+zTLX3w/NCPd07DTjVT8TNGNZf3eSSidS09+TuDST+9VXXzXPr5OTJeR90wzgcePGOc89rb2rr1d/77SmsW73NmGbfsbF/Qx1PRe1NrWVPa9Z9hb97HOl961av9pO27v+/twqT5+V2jfXuruudW410/yJJ55wq5MLAAD8g6AtAAB+opMc6WXZSicA0z+iEzLpi+tkVlbQ0JXrOm+BPg2kuV6erxOBuW5zDVS4ttPAiDf6OG/9UHopsa7TS90TcvmtlgTwxlMgScs96AReOsHarezboqUZNBCll5Nr0FKDea6TRelkQhqI1EmS9Di7BkHivna95FovBdf93Oh9iTsRmgZQEnLsk4sGfCyvv/66ucxaz1l9LzVApoFcX52Tejw9BVb1uSw6kVjckgSeni9un27GKoPhi3Mo7iRUCTnXdFK00aNHu73Hevl6YuhEW1qGIi4tY+EtaGvR8gRa0mTx4sVugd/ETEKlbTt16mQWDYxqcF6D4fPnz3f2S4+NTlB2K0Fbb0FkDb5aXzLciOv7ocdGz3EtZ6Drtc+uXypomQX9rNLzPi49V+MGdF3PReu8jXsexj1f49739vuRlPPK2/Fy/Z1SWqbmRvcBAIB/+KZAFgAASFKGnesf6l999VWCHuda51GzV+NyXad1Hb1liXnjqdZqQpw8edJrP5TWfdS6kgsXLnQ7Bvv37zfZhRqU0LqXCaFB0Li0ZqRrsE3rjmowTvfradb4hOjRo4d5HZodqEGhbt26mTqaSmulWllzepxdA1xxX7s+vxWwtdon5H2x08zt2jetXWrRgJwvz0lP76l13lguXLhgAqve9u3KtU8FChQwAT1vi2aj3so55FpzNm7/rC9mvNF9P/vss/GC8tqn6OhoSS4aWNUvJfTLCa1RrEF5rfmqX+BofWINtrpmhyeG1ofVLGEN0OoXUlrDOqHH42a8nSdat9ai2err1683gU09vr179/a6P33/9RzSLyD0eGiNWivbXYPN3o6BZpy7ZtDGPRet8zZuXd6452vc+9bvR9w6xq7nldZr9nbeJ+R4uf5Oefrsdq11CwAA/IegLQAAfqKZdK6ZWl26dDETAsWlgRudKMz6w7pWrVrObRpQ0gw5i7Zxve/aNrnpRFyufbYu+bWyijWjTLP4XAMdTZo0MRMW6XHYt2+fW4mBxNIgiiudzEuzN5VrXxJKS0JoYEQnZKpXr54J2Grg1jU4dOjQIfO82kYvJbdoBq5rkGX69Olu+07u90WzfzXgq4ve9gUNrG/bts153/V9TM5zUktRuLImZ1N//PGHmcDJk7h90smfNKvSddGgrAairQnvknoOuQbB9Dy2Mhn1fJ8wYcINX59m2P7444/O/VhZjloWwpq8LyH0WGiAMu7imr2tx0En4tLyFkWKFDGv35owUCfG0knBNGCnk/Bp+Y4bfbkT93J7LS+gk+d5+hLI9fL8uAFD1+ewJgVLCtf3Ts8ZfU81AK2THOoEh55oyQZ9r3QSOi1J0LNnT3MM3nvvPWcb1+x6V/oZ5/pZEPdc1Em9lPbD9XNeJz9z5Xpf21nnYtzj5Dop2vDhw+Nl3iaG9s31CyEti2HRQLfrfQAA4D+URwAAwE/0kts333xTXnvtNXNfgyUabNDLs++++27zR/Vvv/1mZhfX4GGDBg1MO83u1MdZQQqdpVzrX+ol0BrQsjI69fGaKZpStKamBoW0zqkG6VzrWuol01YJBQ1GWEGtIUOGmKCeBgR11vSEXvLriWv9V6UzwWvNSQ2muAaUE0qzLjVop3UqNVNQs+80UPnll18622hQSAO2SgNgVl1ffU7NGtbawBr8dQ3MaB1RDVanBqNGjTI/NctU31PXLEmt+WtJznPykUceMXVyrRIG+uWGBho1I3HGjBles1GfeeYZc35pRrSeX9pfzf4sUaKEOc80uKq1f/V3S+uQau3mpJ5DrhnimgWpv78afNO6ukeOHPH6OK0jqxmuFg0WagCxWbNm5v7IkSOlYcOGPgu8a01Z13rH+oWJvkataarZtkmlGdBanmHYsGEmIKj1YPX3RQOmS5YsMa/T8vDDD7s9Vr/QsWgpAi27oYFyXfQ9TCh976zzU7P5n3vuORMAnzdvnuzdu9fjYzToqvV89fhqBr1mZOu57hq0jBs8daXneGRkpGkT91zU7GmrjIK+jilTpjiD//r5p0FyDcTq57tF3werRIiWNdByIHpslWb86uvSfyduVBc6IfR16meQddWDfqmkXzDoF0+6Tn83AACADfhpAjQAAPAvnZ3edcZ4b4vr7OErV650ZM+e3WvbwMBAx6hRo9yex3Xmc5153JXO2u5tm7fZ3ePOUt6kSROPfalSpYrj8uXLzse99dZbHtuVL1/etE3Ic8WdSd3y8MMPe9y36+vTZerUqTc9LrNnz77pe9KrVy+359f7N2pfsGBBx86dOxM0C/zN3rMbcX3P9HZCxT1O3hY997Zv3+72WF+fk66++uorR1BQULx9hoWFOSpXruz1ta5evdqRO3fum74ePb9u5Ry6cuWKo2TJkh4f17hxY4/n7qVLlxylS5d2rm/VqpVzfx07dnSuL1SokOP06dMJfg9vRI+PvkedOnVyREZGOnwl7u+nt0Xfq/Pnz8d7bz21LVeunFu/PX0uuNLXExwcHG8/WbNmdbRs2dLjeTZ8+PCb9nncuHEez1c9r7SPnh7zwgsvuPXt4sWLjrp1697weWrXru24cOGC2+P69evnsW3VqlUdefPm9fi5kdDPSl2fP3/+ePsOCAhw+x3Q+wAAwD8ojwAAgJ/prPV6ma7O1q1ZnZpVqJcUawanZnhqZqFmx+mkOBa9vHnnzp0mu1MzdrWtZn3qJc+aHar1RnVbStLJfDRTUGeQ1wm0NJvrpZdekmXLlrlNHtWnTx9zybhmnOql0ZoNp5m4K1euNJN13Qq9rFszOfW59XhoVqVm/1lZbomh74VmD2pGmmYhatabvi/6/mgt3mnTpplL213pfc0s1ExTzTTU16evSS/B1wnNtPyDp0mN7E4zZPX1ayZer169zOvQjGpXyXlOaratlhDQ59BzSTMbmzdvbuqWVqhQwevjtESCZnzrsdcMUM381UvQ9fF6X0uU6Pul+72Vc0gv/9e6x5rJqvvW+5ptqnVhvdVT1UvxrQxQzUDXy/ItWgtWM3+t2rNWpvqt0sxdzdT84IMPzPntK3qc9fVr1rBmreox02Otvy+aOarHd+zYseYc0PMo7nurnxv6Wec6IWJi6evRrFXti37+aMZy48aNzXN6O0e0BISWoNCrGLSMhJ6z2mcrE/Xrr782ZVG81YrVcgi6XbOFte+a7fvuu++6lVew2urx0TI3Ogmb1rnV59Fs8fvuu08mT55sPuPjfv4NHjzYnHt6Luhnif4b0LdvX/NZGXdCvsTS16uZvm3atDHnrO5Ps38121n7lJBMYwAAkLzMV6fJ/BwAACAN0iCD6yzwGnh2rZ8JALAnnfhOy4bEDZRrCRgNfG/YsMHcf/DBB+WHH37wUy8BAEjfqGkLAAAAAOmI1l7WOr5PPvmkuRJAs721/rJeQWAFbK0rQQAAgH8QtAUAAACAdEYn6Rs3bpzXkihvvPGGmRgTAAD4B0FbAAAAAEhHtH6v1sddvny5/P7773LmzBlTN7dw4cKmPvBzzz0n1apV83c3AQBI16hpCwAAAAAAAAA2EujvDgAAAAAAAAAA/kPQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAEhmt99+uwQEBJglrXnmmWecr23FihX+7g4AAABs5I8//nCOFe+///5024ebYUwNwBOCtgBsYdCgQc6Bii6LFi3yOpCZNGmS3/oJAAAAJIdLly7JO++8I3Xr1pVcuXJJaGioFCtWTJo2bSozZsyQa9eupUg/pk2bZsbmupw9ezZFnhMAEF+wh3UA4HdDhw6Vxo0b+7sbAAAAQLLbvXu3NGvWTH7//fd4WaK6fPvtt1K+fHmpVKlSigRtV65c6UycyJ49e7I/Z3r3+uuvy7PPPmtuV6hQwd/dAWATBG0B2NKaNWtk2bJlUq9ePX93BX4SGxtrMko0ywQAACCtOn36tDRq1EgOHTpk7hcsWFB69+5tgncXLlwwAdSpU6f6u5tIRiVLljQLALiiPAIA2xoyZEiC2v3222/Svn17KVy4sGTMmNFcTqZZukuXLo3X1uFwmEFv7dq1JVu2bJIpUyapWLGivPvuuyZI6Moqx6A1aV1pLSxrm2Y+WC5fvizdu3eXPHnySNasWeWRRx5x2x7X5MmTpWrVqqZtSEiI3HbbbdKgQQMZOXJkgl73X3/9Jb169TIDPH18jhw5pEmTJrJu3Tpnm6ioKClbtqzpa4YMGWT79u3ObdrWeh2zZ8+OV6ZCj5Neole8eHETOK1SpYosWbJEEkqD7vocuXPnNu+Lvj+arfHrr7+6tXN9zo8//ti870WLFjX9tV5LYt43fY3NmzeXvHnzmn3o+aBZKc8//7zzjyEAAAC7GDVqlHOMEh4eLhs2bJAePXpI/fr1pUWLFmY89ssvv0iRIkWcj9EvtkeMGGHGOFmyZJHMmTObsdFbb70Vr4xCQse0WktVb1tZtkrLM3ga93py4MABM/7V/ug47KWXXjLj48TUcNUsX2u9jhETQseLjz32mAl265gzf/785m+Bbdu2eWyvY0U9tnrMtG2/fv3ijSejo6NlzJgxZvyrr0eXGjVqmDIVcbke3x07dpjyFrrv0qVLy7x580wb/VmuXDkzZtf3ScfJCTkervvWMbQeX/3bIWfOnGZse/Xq1QQdIwCplAMAbGDgwIEO/UjSpWrVqs7ba9asMdsjIiKc6yZOnOh83Pr16x1hYWHOba5LQECA4/3333d7nnbt2nlsq0vr1q3d2lrrixYt6rb+vvvuc247cOCAc32TJk3i7bNQoUKOnDlzOu9bpk+f7rUft912202P18GDB82+PT0+Q4YMjq+++srZdt26dY6goCCzrXr16o6YmBjHrFmznO1btWrl8X0oVaqUx32vWrXK2d71fVm+fLlz/YQJE8zx99Q/fb82bNjg8TnvuOMOt7bWPhP6vp06dcqRJ08er22XLFly02MLAACQklzHP4MGDbpp+6tXrzrq1q3rdbyj26KiohI9ptVxl7d9xh33xvX33387ChcuHO8xd911l/O2Pt/NxpBTp051rtcx4s18/PHHznFu3EX3pbTfrmPzrFmzxmv74YcfOvd57do1R/369b0eh1deecWtD9b67NmzO3LlyhXv75F+/fp5HA+fPn36psfDWpctW7Z4+9bl9ddfv+kxApB6kWkLwHb0m+977rnH3H7zzTe9ttNxjGbY6mVj6n//+5+p99W/f38JDAw02zVL4fDhw85vuKdPn25ulypVymSXfvPNN87n+vzzz82SFN9//715bqVZoGPHjpUFCxaYb+/1kre4vvrqK/MzODjYTKymWcEzZ86Ul19+2WQ03MwLL7wgf/75p7ndrl07Wbx4sUycONF8866ZAR06dDCTWSjNCvi///s/c1szNzSTVY+L0qxgfZy3DObBgwfLwoULpWHDhmad7tt6rDd6vHv27GmOv74Pmr2gx0YzIJS+X5pN8M841J3WcWvbtq1pr++VZh8n5n1bu3atyUBWTzzxhMkM1vdBM1juu+8+CQoKuumxBQAASCkXL150q2N777333vQxOs5ctWqVua1XMs2aNcuMj6xMXN2m2bmJdffdd0tkZKRb3dy5c+eadboUKFDA62Pffvtt55hbs0J1bKZZs0ePHpXkcuTIEenSpYvExMSY+5qVPH/+fDN27NSpk8m6jUvHz5rpqmNxvULO9Qo4i17JZV2xp+NNa586DlV6Vdz69evj7VsnbdMr4L7++mtp06aNWafjXR1761VgOqauU6eOczys71tCnT9/3ozbv/jiC7e/j1z7DSAN8nfUGADiZlv26dPH8c033zjvb9q0yWOm7ZYtW5zr8ufPb74Vt2j2qLXtnXfeMeuaN2/uXDdu3DhHZGSkWfSbdWt906ZNE52VoLp06eJc17t3b2fbX375xe3bcEubNm3M/cyZMzt+/PFHx7lz5xJ8rDSTwcpi1ddtvQ5dHn30UedzzZs3zy0jo2zZsvG+nf/iiy+8vg9t27Z1rj979qzpq7Xt0KFDXrMCxowZ4zGLV98f7a+1bevWrfGes3bt2vFeb2Let8WLF7tlQWg/Y2NjE3xsAQAAUtKff/7pNjbbs2fPTR/jmr2qY2aL6/i5YsWKSRrT3mj9jZQpU8b5mG+//da53nW85utMWx3jW21r1arltZ1rpm3GjBkdx48fN+v16jNrfKtZshY9dlb7OXPmOMeegwcPdq7v2rWrs73r+6djf7Vx40bnOn2O8+fPm/Vz5851ru/Ro8dNj4frvq2xsypdurRzvY7TAaRNTEQGwJaaNm1qvu3funWr+XZa63vFpbW9LJUrVzb1Sy3Vq1c330S7tnNt7/rNuqs9e/Ykqb+uGRLVqlVz3tZv27XW7JkzZ9zaa4awZiBonS+tY6sKFSpkskE1k1Vr3XqjGbBWlurx48e9ZmS4vhatn6XZDpp1az328ccfl5YtW3p9Hm1r0eOv2QX6flivVzM7PHE9zq770PdH39PvvvvO2S7uDMj6vt9ofzd73/RY6DHXml+aBaFLWFiYOT80g7djx44m+xcAAMAO4o5xNTNVa6HeiLexlo5/PbVJCd7Gwq598jXX16jzKCSEHtt8+fKZ2zom1HG6jsc1S9bTfnW8nNC/GbJnz+6cTExrzlp0DK3jUaVzPVhcn/NmdE4H13Gzztnguh9PfysBSP34yxWAbb3++uvmp16+tHPnzkQ9Vgv2J4VVUsCVdcmV5dSpU7fcl4ceekhWr15tLt3SQKZOVqCXa2mJBA3cug58kyrua9m3b59bSQK9r+UOkvuYJmYf1iA6qa9Vj6MeVy3rUK9ePVOewpp1uXPnzgme5A0AACAlaGmrO+64w3lfxzHJNc661TGtL/vkut61X8ndJw3SutJSZb76m8E1cOqaJKABV088lQpLSr8Tsx8AqQtBWwC2pVmgZcuWNQORzZs3x9t+5513Om9rBuj169ed913rTFntXNsvX77c7Dfusn///ngDr7///tsZ3NRZc/fu3RuvL66D7U2bNrllxXqqaavPVbNmTfnggw9ky5YtJrA4evRos02/7dcatd6UKFHCOdAtXry4ed1xX4fOGqyBS8uxY8ecWapWXVedOXfo0KFen0fr31rOnTtngryeXm9crsfZdR96DK1M3bjtbjSwT8z7pre13pfWNdZaZPq6NQCufxCpL7/80mu/AQAA/KF169bO22PGjPFYB/bkyZPOMaW3sZan8W9ix7RxA46xsbEJeg3exsKear+69sm6csxyozFwXK6vcdGiRQl+XGL2q+NIT2NPq+YtACQngrYAbEsDeK+99prX7XqJUJkyZcxtDc7p5e966f2gQYPMhAFKJyBo1aqVua3bLU8//bRzArDPPvvMFPTXiQZ0EgXX4Ki6cuWKPPnkkzJ+/Hhp1KhRvCwF9cgjjzhvv/fee6atTkLg+pyuNICqE6fp5AE6yPzxxx/NBA+WqKgor69bL7fSfigNVupzazBSJ9366KOP5MUXXzQTUejkDJbnnnvOWaJhzpw5Jhiuhg0bJtu2bfP4PDqhhQZ1tX86qZeVUaCZwd5KIyh9XVapCu3XwIEDzfuix1zfJ6XPr5NAJERi3rc1a9ZIlSpVzOvSiTM0yKvvgwbCb3ZcAQAA/EEnjLUmEdNL3bXkgU6GtWzZMnPFmU7wqoHEQ4cOmTY6LrXouE/HRFp2q1u3bs71OnZLypg2blbnhx9+aMaoroFYT1zHwl27djXjsE8//dR55VxcVp+UTlo7YcIEM+ZLTDBUJ7nVEmBWhrKO+fV46d8BOmmvXsGWFK5jTy3d9cknn5h+zZgxw/S1QoUKZjwNAMnO30V1AaQ/K1euNBNHFShQwBTPnz9/vttkVDqBVP/+/c2kVSEhIY5MmTK5FeG3JiJT69evd4SFhcWbYEsXnazr/fffd3vudu3aeWzracKDyZMnx9ueNWtWR6FChTxOztCoUaN47fPkyeMIDw+PNxFZx44dvfZBX+/+/ftveAwPHjzo1g9Pi9W3adOmOde1bt3arFu7dq0jMDDQOVGFNYmb6/vgOsmFtQQHB7tNjuBt0oQJEyY4J0uLu+j7tWHDBmdb1+fUySc8Sej7ppNE3Kjd8OHDb3hcAQAA/GHXrl2OO+6444bjGGsiKp1g9t577/Xarm7duo6oqKgkj2nHjx8fr33cScziOnXqlOO2226L97iSJUt6nIhM22sf4rZ3ndDsZhORWROdWWPauIs1rnSdiMy1D0pfV9xxuh67+vXr3/C9cB2zejpG3p5Tx8vWeh1HJ3QisoROIgcgbSHTFkCK04xNzbLUb9Q90cuoxo0bZzIq9ZIvLd7vjU5uoKUTIiIi5LbbbjP1nTQ74OGHH5YffvhBunTp4tZevymfPn26qRurl2VpJq5mNtSvX988p34rb3n22Welb9++kjdvXsmUKZOpkaqZBlqSwBPNKNBsB50YQGurNmzYUFatWmUmJfD0Db72WV+b9kNLFujztGjRwjzHjcoPKO2zlhro3bu3mVAhNDTUTHCgt9u1a2eySzUbVi+v04nNlB4XzdpQmp1qlUvQMgmasRqXZnVo1rC+Xj1OmmG7cOFCuf/+++Vm9Dhq5q9mcWhmsL4vBQsWNH3T98t1goqESOj7plkoffr0Ma9P6+Pq82ppBH0+Pd90GwAAgN3oVUg7duww5RHq1Kljxk863tHxnI4pdSxkXSml2aU6znrrrbfkrrvuMuNUHQtqBujw4cPNGFgfm9QxrV6hpWMmHWsldAJXHf/quFczU3UcrP3XuRt0fOyt/YIFC0z/ta/aFx2rvfLKK4k6bvra9LVoWTVr7KevU8egcSe8TSjtj5Zp0DGm/q2hY2w9vsWKFTMTnk2ZMkUeffTRJO0bABIjQCO3iXoEAPi4BIJewqTBSqUfSRrce/nll82lYlY9VR2ETZs2Tdq0aePnHqdtWlrijTfeMLenTp0qzzzzjL+7BAAAAABAukOmLQBbOXDggJmMoEGDBs51mlmptb3Wrl3r174BAAAAAACkBIK2AGzFmj1WM2td6X3XmWUBAAAAAADSKoK2AAAAAAAAAGAjBG0B2Er+/PnNzxMnTrit1/vWNiRvTVutK6wL9WwBAAAAAPAPgrYAbEVnZdXg7NKlS53rzp8/L+vXr5eaNWv6tW8AAAAAAAApIThFngUAXFy8eFF+++03t8nHtm3bJjlz5pQiRYpIjx49ZMiQIVKyZEkTxO3fv78ULFhQWrRo4dd+AwAAAAAApIQAh14Dm4bFxsbK0aNHJSwsTAICAvzdHQAiEhkZKU2bNo23/sknn5SJEyeaS/OHDRsm06ZNk3Pnzsk999wjY8aMkRIlSvilvwCAlKGf/xcuXDBf1AUGckFYYjDmBQAASFtj3jQftP3zzz+lcOHC/u4GAAAAEujw4cNSqFAhf3cjVWHMCwAAkLbGvGm+PIJmG1gHIlu2bP7uDgAAALzQGuYaeLTGb0g4xrwAAABpa8yb5oO21uVhOnhlAAsAAGB/XN6feIx5AQAA0taYl2JhAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAABI81atWiXNmjUzMzXr5YgLFixw267zMw8YMEAKFCggmTJlkgYNGsivv/7q3L5ixQrzOE/Lxo0bTZs//vjD4/Z169al+OtF8uOcgi9xPsHXOKdSP4K2AAAAANK8S5cuScWKFWXChAket48cOVLGjRsnkyZNkvXr10uWLFmkYcOGcvXqVbO9Vq1acuzYMbfl2WeflWLFiknVqlXd9vXjjz+6tatSpUqKvEakLM4p+BLnE3yNcyr1S/MTkQEAAABAo0aNzOKJZhuNHTtW+vXrJ82bNzfrpk+fLvny5TOZSW3atJGMGTNK/vz5nY+Jjo6Wr776Srp16xZvIpFcuXK5tUXaxDkFX+J8gq9xTqV+ZNoCAAAASNcOHDggx48fN5eGWsLDw6VGjRqydu1aj4/5+uuv5e+//5b27dvH2/bII49I3rx5pU6dOqYd0h/OKfgS5xN8jXMqdSBoCwAAACBd0z9clWYYudL71ra4pkyZYi4jLVSokHNd1qxZZfTo0TJ37lz59ttvzR+vLVq04A/YdIhzCr7E+QRf45xKHSiPAAAAAACJ8Oeff8r3338vc+bMcVufO3du6dWrl/N+tWrV5OjRo/L222+bLCTAG84p+BLnE3yNc8o/yLQFAAAAkK5ZdfhOnDjhtl7ve6rRN3XqVFO/LyF/kOqlpr/99psPe4vUgHMKvsT5BF/jnEodCNoCAAAASNd0Jmz9I3Xp0qXOdefPnzezadesWTPe5C36x2u7du0kQ4YMN933tm3bpECBAsnSb9gX5xR8ifMJvsY5lTpQHgEAAABAmnfx4kW3zB+dhEX/sMyZM6cUKVJEevToIUOGDJGSJUuaP2b79+8vBQsWNLX5XC1btsw89tlnn433HJ988omZbfvuu+8297/88kv5+OOP5aOPPkqBV4iUxjkFX+J8gq9xTqUBDj9auXKlo2nTpo4CBQo4tCvz58932x4bG+vo37+/I3/+/I7Q0FBH/fr1Hb/88kuinuPcuXNm3/oTAAAA9sW4Lek4dje3fPlyc4ziLhEREW5/e+TLl88REhJi/vbYt29fvP088cQTjlq1anl8jmnTpjnKlCnjyJw5syNbtmyO6tWrO+bOnZvsrw3+wTkFX+J8gq9xTqX+cVuA/s9fAePvvvtOVq9eLVWqVJGWLVvK/Pnz3SL6I0aMkOHDh5vIvRX1//nnn2X37t0SGhqaoOfQ9O7w8HA5d+6cZMuWLRlfDQAAAG4F47ak49gBAACkrXGbX8sjNGrUyCyeaCx57Nix0q9fP2nevLlZN336dMmXL58sWLBA2rRpk8K9BQAAAAAAAIB0XNNW62UcP35cGjRo4FynUWidhW7t2rUEbQEAAIC4rl4VyZgx/vrAQPf12s6bW2kbFaXZF57bBgSIhIQkre21ayKxsd774XoVnr/aan+13yo6WiQmxvdtr1//Z/FFW33f9P3zdVudpCYoKPFt9RjosfAmOPifJbFt9T3T987XbfXc1XPYF231GFiT+/iybUr93vMZkbC2fEb8g8+IxLflMyLtfUbc6JikhqCtBmyVZta60vvWNk+ioqLM4ppyDKR2hw4dklOnTvm7G0gGuXPnNkXgAQDwiXbt/vtjzVXVqiIDB/53/6mnvP8hV768yPDh/93v2FEH1fGaXblyRc7nzy9HevVyrisyeLBkOH3a426v5csnh/v2dd4vPHy4ZDxxwmPb6Jw55dCAAc77t40ZI6GHDnlsG5Mli/wxdKjzfsHx4yXT/v0e28ZmzCgHRo503s//wQeSZfdu8Wb/2LHO2/mmTpWs27d7bfv7iBHi+PcPxDyzZkm2DRu8tj3w5psSGxZmbueeO1fCV6/22vbggAFyPWdOczvXV19J9uXLvbY91KePRP87Y3eO776TnN9/77Xtn716SdS/Y5Dsy5ZJrq+/dm7TSWUyZcr0X+Nhw0QqVPjntu5z0iSv+xV936pV++f2ypUiLscwnj59ROrU+ef22rVyZdAgueYlIHLyySflQvXq5nbmXbukwIcfet3tX61ayfl77zW3Q3/9VW6bMMFr278feUTO1qtnboccOiSFxozx2vZ0w4Zy5t8rRTMcOyZFRozw2vbsAw/I3/9eMRp8+rQUHTzYa9tztWvLqcceM7cDL1yQYv37e217vnp1+evJJ83tgKgouUOPoRcXK1aUE+3bO+8X79HDa9tLZcvK8c6dnfeLvfKKBHp5L64ULy5Hu3Vz3r/99dcl6NIlj22vFiliPiOcY94XXhA5edJzJwoXFnn//f/u9+wpcviw57Z584pMmfLf/VdfFfn11/h9vXJFrmTIwGeEjz8j4jry4otytWRJcztbZKTk+eILr22Pdeokl8uVM7fDNmyQvLNmeW17PCJCLv07wVWWrVsl/yefeP+c0vO7fv1/bm/ZInKD3zl5/nmRJk3+ub1rl8hrr3lvq79DLVv+c3v/frnSpYvXzyk+I5L+GWGHcURu63NKx0s7d3psawLB8+b9d1/HS5s2iVfffPPfbf33xfpdvtGXCqkhaJtUWgP3jTfe8Hc3AJ8GbEuVLiVXryTsmxikLqGZQmXf3n0EbgEAqYoGQpYtXy77YmPl5Zkznet1rui8Xh6joZcXXf7Q0TBaYS9tNaTz7FdfOe+PFpF/wgHxaTj5qcWLnfeHadzZS1sNUz9WpYrzvv45V1W8e8Slrf7ZW/sGbR+rVcvsX70kIv+GDjx66v77Tb/V8yLS+AZtOz74oPz172390/rRG7R9MTLSHGf1xL+LN70iI8WaU1z32d4t8SlQ6j3wgHtAJJmdOHFCNi1fLrFeMpbGRkbKsn9v63v235/i8U2KjJRF/94u/+854c3UyEiZ/+/tEvo39Q3azo6MlNn9+pnbeu56DwWLzI+MlKn/BmHyiIhLeDGeRZGRMumtt8xtrWw44wZtl0ZGyruj9TdCRMN/c2/QdnVkpIx47z3nfe8hN5FNkZEyePJk533dr0uOmpudkZHy2rRpzvvaX28VGTWMqp8RzjGvpOzn1PLly+VMbCyfET7+jIjrtchIsUJcjf/tszeDIyPFCnHp1yXew4QiIyIjxQpX67F1DT8GBQbKAyn8OXX06FHZtny5xHj5nOIzIumfEXYYR2QKzSR79+1N0c+pm/HrRGSuAgIC3CYi+/3336V48eKydetWqVSpkrPdfffdZ+6/++67Cc60LVy4MJMyINXasmWLmawvzxN5JGNeD5c7ItW6dvKa/DX7L9m8ebNUrlzZ390BAL9jMi0fHLsTJzwfOx9f1qhj9Jq1akmpB0ZJxlylneszxERLgJmcOj6HBEh0UIYktQ2OjZbAG/zZci0oo//bBmZwXnYcFHtdghyxydA2RoIcMT5pGx0YLI6AwHhtL53ZL3tX9Ja1a9bI3f9muKXEpc9bNm6UWtWrS57Hc0vGPPHHvNcDRWIC/3ltgbEOyXCDq1Fd2wY4HJIxxvdt9ZLcEB+1jQkQuR7k+7axASLRVlsNsFx3+KXtpb+j/xvzaoZlCl36bH1OTW0tUqqAy0P1mN0gCuIITqa2eqpbhy1Gz7dkaBsrEhBr87b6URJ4a233/iXS/nNx/5xKgfIIWzZtklrVqklreVzymFCru1gJNMu/vZdgffO8SFzbAImVIJ+31X9rY5xtNavzut/bBsl156kUl/4axLjkniaubYzXMYc6Kqdltsz+53NKrzhK5vIIZtyWL5+9JyK7kWLFikn+/Pll6dKlzqCtvqj169dLly5dvD4uJCTELEBaowHbkEKc2wAAQG78x4HrHwg3apeYfcahl/hqmoQGbMPyVEj4rhL+rIlqm5gREm1v3FYD1fremsu4PZ0nrsGOm0lM26Cgf563QIiIhzFvcCL+eE1tbTVcEZQMbQMTcU4kZ9uMLgFet0DrzSSmrYda3tbnlAZsKxdK+K5gfxosv+HnlH4ZZH15dDP6hVRC/00MDDTPm0MKSH7hpEpLrrt+YnuaG8CbpLa90RcFdgnaXrx4UX777Te3yce2bdsmOXPmNJcK9+jRQ4YMGSIlS5Y0Qdz+/ftLwYIFndm4AAAAAAAAAJDW+DVou2nTJlODxNLr3+LDERERMm3aNHnllVfk0qVL0rlzZzl79qzUqVNHFi9eLKGJyQwAAAAAAAAAgFTEr0Hb+++/X25UUlfr3A4ePNgsAAAAAAAAAJAeWFWPAQAAAAAAAAA2QNAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAvFi1apU0a9ZMChYsKAEBAbJgwQK37Q6HQwYMGCAFChSQTJkySYMGDeTXX391a3P69Glp27atZMuWTbJnzy4dO3aUixcvurXZsWOH3HvvvRIaGiqFCxeWkSNHpsjrAwAAgD0RtAUAAAC8uHTpklSsWFEmTJjgcbsGV8eNGyeTJk2S9evXS5YsWaRhw4Zy9epVZxsN2O7atUuWLFkiCxcuNIHgzp07O7efP39eHnroISlatKhs3rxZ3n77bRk0aJB88MEHKfIaAQAAYD/B/u4AAAAAYFeNGjUyiyeaZTt27Fjp16+fNG/e3KybPn265MuXz2TktmnTRvbs2SOLFy+WjRs3StWqVU2b8ePHS+PGjWXUqFEmg3fmzJly7do1+fjjjyVjxoxSrlw52bZtm4wZM8YtuAsAAID0g0xbAAAAIAkOHDggx48fNyURLOHh4VKjRg1Zu3atua8/tSSCFbBV2j4wMNBk5lpt6tatawK2Fs3W3bdvn5w5cyZFXxMAAADsgUxbAAAAIAk0YKs0s9aV3re26c+8efO6bQ8ODpacOXO6tSlWrFi8fVjbcuTIEe+5o6KizOJaYgEAAABpB5m2AAAAQCozfPhwk9VrLTp5GQAAANIOgrYAAABAEuTPn9/8PHHihNt6vW9t058nT5502379+nU5ffq0WxtP+3B9jrj69u0r586dcy6HDx/24SsDAACAvxG0BQAAAJJASxpoUHXp0qVuZQq0Vm3NmjXNff159uxZ2bx5s7PNsmXLJDY21tS+tdqsWrVKoqOjnW2WLFkipUqV8lgaQYWEhEi2bNncFgAAAKQdBG0BAAAALy5evCjbtm0zizX5mN4+dOiQBAQESI8ePWTIkCHy9ddfy88//yzt2rWTggULSosWLUz7MmXKyMMPPyydOnWSDRs2yOrVq6Vr167Spk0b0049+eSTZhKyjh07yq5du+Tzzz+Xd999V3r16uXX1w4AAAD/YSIyAAAAwItNmzbJAw884LxvBVIjIiJk2rRp8sorr8ilS5ekc+fOJqO2Tp06snjxYgkNDXU+ZubMmSZQW79+fQkMDJRWrVrJuHHjnNu1Ju0PP/wgL774olSpUkVy584tAwYMMPsEAABA+kTQFgAAAPDi/vvvF4fD4XW7ZtsOHjzYLN7kzJlTZs2adcPnueuuuyQyMvKW+goAAIC0g/IIAAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABsxNZB25iYGOnfv78UK1ZMMmXKJMWLF5c333xTHA6Hv7sGAAAAAAAAAMkiWGxsxIgRMnHiRPnkk0+kXLlysmnTJmnfvr2Eh4dL9+7d/d09AAAAAAAAAEhfQds1a9ZI8+bNpUmTJub+7bffLrNnz5YNGzb4u2sAAAAAAAAAkP7KI9SqVUuWLl0qv/zyi7m/fft2+emnn6RRo0ZeHxMVFSXnz593WwAAAAAAAAAgtbB1pu2rr75qgq6lS5eWoKAgU+N26NCh0rZtW6+PGT58uLzxxhsp2k8AAAAAAAAASBeZtnPmzJGZM2fKrFmzZMuWLaa27ahRo8xPb/r27Svnzp1zLocPH07RPgMAAAAAAABAms207d27t8m2bdOmjblfoUIFOXjwoMmmjYiI8PiYkJAQswAAAAAAAABAamTrTNvLly9LYKB7F7VMQmxsrN/6BAAAAAAAAADpNtO2WbNmpoZtkSJFpFy5crJ161YZM2aMdOjQwd9dAwAAAAAAAID0F7QdP3689O/fX1544QU5efKkFCxYUJ577jkZMGCAv7sGAAAAAAAAAOkvaBsWFiZjx441CwAAAAAAAACkB7auaQsAAAAAAAAA6Q1BWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIIliYmKkf//+UqxYMcmUKZMUL15c3nzzTXE4HM42envAgAFSoEAB06ZBgwby66+/uu3n9OnT0rZtW8mWLZtkz55dOnbsKBcvXvTDKwIAAIAdELQFAAAAkmjEiBEyceJEee+992TPnj3m/siRI2X8+PHONnp/3LhxMmnSJFm/fr1kyZJFGjZsKFevXnW20YDtrl27ZMmSJbJw4UJZtWqVdO7c2U+vCgAAAP4W7O8OAAAAAKnVmjVrpHnz5tKkSRNz//bbb5fZs2fLhg0bnFm2Y8eOlX79+pl2avr06ZIvXz5ZsGCBtGnTxgR7Fy9eLBs3bpSqVauaNhr0bdy4sYwaNUoKFizox1cIAAAAfyDTFgAAAEiiWrVqydKlS+WXX34x97dv3y4//fSTNGrUyNw/cOCAHD9+3JREsISHh0uNGjVk7dq15r7+1JIIVsBWafvAwECTmQsAAID0h0xbAAAAIIleffVVOX/+vJQuXVqCgoJMjduhQ4eacgdKA7ZKM2td6X1rm/7Mmzev2/bg4GDJmTOns01cUVFRZrFoHwAAAJB2kGkLAAAAJNGcOXNk5syZMmvWLNmyZYt88sknpqSB/kxOw4cPNxm71lK4cOFkfT4AAACkLIK2AAAAQBL17t3bZNtqbdoKFSrI008/LT179jRBVZU/f37z88SJE26P0/vWNv158uRJt+3Xr1+X06dPO9vE1bdvXzl37pxzOXz4cDK9QgAAAPgDQVsAAAAgiS5fvmxqz7rSMgmxsbHmdrFixUzgVeveupYy0Fq1NWvWNPf159mzZ2Xz5s3ONsuWLTP70Nq3noSEhEi2bNncFgAAAKQd1LQFAAAAkqhZs2amhm2RIkWkXLlysnXrVhkzZox06NDBbA8ICJAePXrIkCFDpGTJkiaI279/fylYsKC0aNHCtClTpow8/PDD0qlTJ5k0aZJER0dL165dTfautgMAAED6Q9AWAAAASKLx48ebIOwLL7xgShxokPW5556TAQMGONu88sorcunSJencubPJqK1Tp44sXrxYQkNDnW20Lq4GauvXr28yd1u1aiXjxo3z06sCAACAvxG0BQAAAJIoLCxMxo4daxZvNNt28ODBZvEmZ86cZjIzAAAAQFHTFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAApKWgbUxMjGzbtk3OnDnjmx4BAAAAAAAAQDqW6KBtjx49ZMqUKc6A7X333SeVK1eWwoULy4oVK5KjjwAAAAAAAACQbiQ6aDtv3jypWLGiuf3NN9/IgQMHZO/evdKzZ095/fXXk6OPAAAAAAAAAJBuJDpoe+rUKcmfP7+5vWjRInnsscfkzjvvlA4dOsjPP/+cHH0EAAAAAAAAgHQj0UHbfPnyye7du01phMWLF8uDDz5o1l++fFmCgoKSo48AAAAAAAAAkG4EJ/YB7du3l8cff1wKFCggAQEB0qBBA7N+/fr1Urp06eToIwAAAAAAAACkG4kO2g4aNEjKly8vhw8fNqURQkJCzHrNsn311VeTo48AAAAAAAAAkG4kOmir/ve//8VbFxER4Yv+AAAAAAAAAEC6lqCg7bhx4xK8w+7du99KfwAAAAAAAAAgXUtQ0Padd95xu//XX3+ZiceyZ89u7p89e1YyZ84sefPmJWgLAAAAAAAAALcgMCGNDhw44FyGDh0qlSpVkj179sjp06fNorcrV64sb7755q30BQAAAAAAAADSvQQFbV31799fxo8fL6VKlXKu09uajduvXz9f9w8AAAAAAAAA0pVEB22PHTsm169fj7c+JiZGTpw44at+AQAAAAAAAEC6lOigbf369eW5556TLVu2ONdt3rxZunTpIg0aNPB1/wAAAAAAAAAgXUl00Pbjjz+W/PnzS9WqVSUkJMQs1atXl3z58slHH32UPL0EAAAAAAAAgHQiOLEPyJMnjyxatEh++eUX2bt3r1lXunRpufPOO5OjfwAAAAAAAACQriQ6aGvRIC2BWgAAAAAAAADwc9C2Q4cONy2fAAAAAAAAAABIoaDtmTNn3O5HR0fLzp075ezZs1KvXr0kdgMAAAAAAAAAkKSg7fz58+Oti42NlS5dukjx4sU5qgAAAAAAAABwCwJ9spPAQOnVq5e88847vtgdAAAAAAAAAKRbPgnaqv3798v169d9tTsAAAAAAAAASJcSXR5BM2pdORwOOXbsmHz77bcSERHhy74BAAAAAAAAQLqT6KDt1q1b45VGyJMnj4wePVo6dOjgy74BAAAAAAAAQLqT6KDt8uXLk6cnAAAAAAAAAICk1bTV2rU//vijTJ48WS5cuGDWHT16VC5evOjr/gEAAAAAAABAupLoTNuDBw/Kww8/LIcOHZKoqCh58MEHJSwsTEaMGGHuT5o0KXl6CgAAAAAAAADpQKIzbV966SWpWrWqnDlzRjJlyuRc/+ijj8rSpUt93T8AAAAAAAAASFcSnWkbGRkpa9askYwZM7qtv/322+XIkSO+7BsAAAAAAAAApDuJzrSNjY2VmJiYeOv//PNPUyYBAAAAAAAAAJCCQduHHnpIxo4d67wfEBBgJiAbOHCgNG7c+Ba6AgAAAAAAAABIdHmE0aNHS8OGDaVs2bJy9epVefLJJ+XXX3+V3Llzy+zZs5OnlwAAAAAAAACQTiQ6aFuoUCHZvn27fPbZZ7Jjxw6TZduxY0dp27at28RkAAAAgL9ER0fL8ePH5fLly5InTx7JmTOnv7sEAAAAJF/Q1jwoOFieeuopSQk6uVmfPn3ku+++M4PuEiVKyNSpU6Vq1aop8vwAAABIHS5cuCAzZswwyQUbNmyQa9euicPhMOW8NPFAy3x17txZqlWr5u+uAgAAAL4P2u7fv9/Utd2zZ4+5X65cOenevbsUL15cfOnMmTNSu3ZteeCBB0zQVrMktBRDjhw5fPo8AAAASN3GjBkjQ4cONePRZs2ayWuvvSYFCxY0V4KdPn1adu7cKZGRkSZwW6NGDRk/fryULFnS390GAAAAfBO0/f777+WRRx6RSpUqmYCqWr16tUyePFm++eYbefDBB8VXRowYIYULFzaZtZZixYr5bP8AAABIGzZu3CirVq0yyQSeVK9eXTp06CCTJk0yY0sN4BK0BQAAQJoJ2r766qvSs2dPeeutt+Kt1zIGvgzafv3112bSs8cee0xWrlwpt912m7zwwgvSqVMnr4+Jiooyi+X8+fM+6w8AAADsKaET4oaEhMjzzz+f7P0BAAAAbkVgYh+gJRF04rG4NHNh9+7d4ku///67TJw40WRBaIZvly5dTBmGTz75xOtjhg8fLuHh4c5FM3UBAAAAAAAAIM1m2mpd2W3btsW7nEzX5c2b15d9k9jYWDPh2LBhw8z9u+++29Qj08vaIiIiPD6mb9++0qtXL7dMWwK3AAAA6cfVq1dNzdrly5fLyZMnzZjS1ZYtW/zWNwAAACBZgrZamkBn3dUs2Fq1ajlr2mr9WddgqS8UKFBAypYt67auTJky8sUXX9zwkjddAAAAkD7pVWE//PCD/O9//zO1bAMCAvzdJQAAACB5g7b9+/eXsLAwGT16tMlqVToz76BBg0zpAl/Sic727dvntu6XX36RokWL+vR5AAAAkHYsXLhQFi1a5Jw0FwAAAEjzQVvNVNCJyHS5cOGCWadB3OSgz6HZvFoe4fHHH5cNGzbIBx98YBYAAADAE528NrnGpwAAAIAtJyJzpYPh5BwQV6tWTebPn29mAy5fvry8+eabMnbsWGnbtm2yPScAAABSN70irE+fPnLw4EF/dwUAAABImUzbEydOyP/93//J0qVLzcQODofDbXtMTIz4UtOmTc0CAAAAJIROZKuTkd1xxx2SOXNmyZAhg9v206dP+61vAAAAQLIEbZ955hk5dOiQqW2rE4UxsQMAAADs5IknnpAjR46YElv58uVjvAoAAIC0H7T96aefJDIyUipVqpQ8PQIAAABuwZo1a2Tt2rVSsWJFf3cFAAAASJmatoULF45XEgEAAACwi9KlS8uVK1f83Q0AAAAg5YK2OhHYq6++Kn/88UfSnxUAAABIJm+99Za8/PLLsmLFCvn777/l/PnzbgsAAACQ5oK2rVu3NgPg4sWLS1hYmOTMmdNtAQAAAPzp4YcfNuUR6tevL3nz5pUcOXKYJXv27Oanr2n93Keeekpy5colmTJlkgoVKsimTZuc2/UqtQEDBpj5IHR7gwYN5Ndff403OVrbtm0lW7Zspp8dO3aUixcv+ryvAAAASKM1bTXTFgAAALCr5cuXp9hznTlzRmrXri0PPPCAfPfdd5InTx4TkHUNDo8cOVLGjRsnn3zyiRQrVsxM6NuwYUPZvXu3hIaGmjYasD127JgsWbJEoqOjpX379tK5c2eZNWtWir0WAAAApOKgbURERPL0BAAAAPCBWrVqSYYMGTxuO3XqlE+fa8SIEWbOh6lTpzrXaWDWNctWkx769esnzZs3N+umT58u+fLlkwULFkibNm1kz549snjxYtm4caNUrVrVtBk/frw0btxYRo0aJQULFvRpnwEAAJAGyyMAAAAAdqaBUE8T5544cULuv/9+nz7X119/bQKtjz32mCnFcPfdd8uHH37o3H7gwAE5fvy4KYlgCQ8Plxo1apgSDkp/akkEK2CrtH1gYKCsX7/ep/0FAABA6kDQFgAAAGnKoUOH5Nlnn3Vbp6UHNGBbunRpnz7X77//LhMnTpSSJUvK999/L126dJHu3bubUghKA7ZKM2td6X1rm/7UgK+r4OBgM1+E1SauqKgoJlgDAABIwwjaAgAAIE1ZtGiRrFmzRnr16mXuHz161ARsdYKwOXPm+PS5YmNjpXLlyjJs2DCTZat1aDt16iSTJk2S5DR8+HCTsWstWqIBAAAAaQdBWwAAAKQpOhnYDz/8IF988YUJ3GrAVgOqs2fPNiUHfKlAgQJStmxZt3VlypQx2b4qf/78ztIMrvS+tU1/njx50m379evX5fTp0842cfXt21fOnTvnXA4fPuzT1wUAAAD/SvKo9bfffjOXgF25csXc91Q3DAAAAPAHzTxdsmSJzJw5U6pXr24CtkFBQT5/ntq1a8u+ffvc1v3yyy9StGhR56RkGnhdunSpc7uWMtBatTVr1jT39efZs2dl8+bNzjbLli0zWbxa+9aTkJAQyZYtm9sCAACAtCM4sQ/4+++/pXXr1mYgGRAQIL/++qvccccd0rFjR8mRI4eMHj06eXoKAAAAeKHjUB2bxnX58mX55ptvJFeuXM51msHqKz179pRatWqZ8giPP/64bNiwQT744AOzKO1Tjx49ZMiQIaburQZx+/fvLwULFpQWLVo4M3MffvhhZ1mF6Oho6dq1q5lQTdsBAAAg/QlOysBUJ0bQS750gGnRQK5efkbQFgAAAClt7NixfnneatWqyfz58025gsGDB5ugrPalbdu2zjavvPKKXLp0ydS71YzaOnXqyOLFiyU0NNTZRjOCNVBbv359U8KhVatWMm7cOL+8JgAAAKTCoK3WB9OyCIUKFXJbr5kDBw8e9GXfAAAAgASJiIjw23M3bdrULN5otq0GdHXxJmfOnDJr1qxk6iEAAADSfE1bzRLInDlzvPV6mZnW1gIAAABSmo5Rk7M9AAAAYOug7b333ivTp093yxzQSRJGjhwpDzzwgK/7BwAAANxUiRIl5K233pJjx455baMT5+rkZI0aNaL0AAAAANJWeQQNzmqtrU2bNsm1a9dMja5du3aZTNvVq1cnTy8BAACAG1ixYoW89tprMmjQIKlYsaJUrVrVTOKldWPPnDkju3fvlrVr15q5GbT+7HPPPefvLgMAAAC+C9qWL19efvnlF3nvvfckLCxMLl68KC1btpQXX3xRChQokNjdAQAAALesVKlS8sUXX5jJcufOnSuRkZGyZs0auXLliuTOnVvuvvtu+fDDD02WbVBQkL+7CwAAAPg2aKvCw8Pl9ddfT8pDAQAAgGRTpEgRefnll80CAAAApOmg7Y4dOxK8w7vuuutW+gMAAAAAAAAA6VqCgraVKlUyE47p5A3606L3leu6mJiY5OgnAAAAAAAAAKQLgQlpdODAAfn999/NT60VVqxYMXn//fdl27ZtZtHbxYsXN9sAAAAAAAAAAMmcaVu0aFHn7ccee0zGjRsnjRs3diuJULhwYenfv7+0aNHiFroDAAAAAAAAAOlbgjJtXf38888m0zYuXbd7925f9QsAAABIkkOHDjnLeLnSdboNAAAASHNB2zJlysjw4cPl2rVrznV6W9fpNgAAAMCfNJngr7/+irf+9OnTHpMPAAAAgFRZHsHVpEmTpFmzZlKoUCFTFkHt2LHDTEb2zTffJEcfAQAAgASLO3mu5eLFixIaGuqXPgEAAADJGrStXr26mZRs5syZsnfvXrOudevW8uSTT0qWLFkSuzsAAADAJ3r16mV+asBW51rInDmzc1tMTIysX79eKlWq5MceAgAAAMkUtFUanO3cuXNSHgoAAAAki61btzozbXUehowZMzq36e2KFSvK//3f//mxhwAAAEAyBm0BAAAAu1m+fLn52b59e3n33XclW7Zs/u4SAAAAkCQEbQEAAJCmTJ061d9dAAAAAG4JQVsAAACkKfXq1bvh9mXLlqVYXwAAAICkIGgLAACANEVr17qKjo6Wbdu2yc6dOyUiIsJv/QIAAACSNWh79uxZmTdvnuzfv1969+4tOXPmlC1btki+fPnktttuS8ouAQAAAJ945513PK4fNGiQXLx4McX7AwAAACRWYGIfsGPHDrnzzjtlxIgRMmrUKBPAVV9++aX07ds30R0AAAAAUsJTTz0lH3/8sb+7AQAAAPg+aNurVy955pln5Ndff5XQ0FDn+saNG8uqVasSuzsAAAAgRaxdu9Zt/AoAAACkmfIIGzdulMmTJ8dbr2URjh8/7qt+AQAAAEnSsmVLt/sOh0OOHTsmmzZtkv79+/utXwAAAECyBW1DQkLk/Pnz8db/8ssvkidPnsTuDgAAAPCp8PBwt/uBgYFSqlQpGTx4sDz00EN+6xcAAACQUIkO2j7yyCNmwDtnzhxzPyAgQA4dOiR9+vSRVq1aJXZ3AAAAgE9NnTrV310AAAAAUram7ejRo82su3nz5pUrV67IfffdJyVKlJCwsDAZOnTorfUGAAAA8JHNmzfLjBkzzLJ161Z/dwcAAABIvkxbvdxsyZIlsnr1atm+fbsJ4FauXFkaNGiQ2F0BAAAAPnfy5Elp06aNrFixQrJnz27WnT17Vh544AH57LPPKOkFAACAtBW0jY6OlkyZMsm2bdukdu3aZgEAAADspFu3bnLhwgXZtWuXlClTxqzbvXu3RERESPfu3WX27Nn+7iIAAADgu6BthgwZpEiRIhITE5OYhwEAAAApZvHixfLjjz86A7aqbNmyMmHCBCYiAwAAQNqsafv666/La6+9JqdPn06eHgEAAAC3IDY21iQbxKXrdBsAAACQ5mravvfee/Lbb79JwYIFpWjRopIlSxa37Vu2bPFl/wAAAIBEqVevnrz00kumDIKOWdWRI0ekZ8+eUr9+fX93DwAAAPB90LZFixaJfQgAAACQYjTJ4JFHHpHbb79dChcubNYdPnxYypcvLzNmzPB39wAAAADfB20HDhyY2IcAAAAAKUYDtXr1l9a13bt3r1mn9W0bNGjg764BAAAAyRO0tWzatEn27NnjnNihSpUqSd0VAAAA4FMBAQHy4IMPmgUAAABI8xOR/fnnn3LvvfdK9erVTa0wXapVqyZ16tQx2wAAAAB/WLZsmUkmOH/+fLxt586dk3LlyklkZKRf+gYAAAAka9D22WeflejoaJNle/r0abPobZ2JV7cBAAAA/jB27Fjp1KmTZMuWLd628PBwee6552TMmDF+6RsAAACQrEHblStXysSJE6VUqVLOdXp7/PjxsmrVqsTuDgAAAPCJ7du3y8MPP+x1+0MPPSSbN29O0T4BAAAAKRK01YkdNNM2rpiYGClYsGCSOgEAAADcqhMnTkiGDBm8bg8ODpa//vorRfsEAAAApEjQ9u2335Zu3bqZicgseltr244aNSpJnQAAAABu1W233SY7d+70un3Hjh1SoECBFO0TAAAAkBTBCWmUI0cOMwOv5dKlS1KjRg2TraCuX79ubnfo0EFatGiRpI4AAAAAt6Jx48bSv39/UyIhNDTUbduVK1dk4MCB0rRpU7/1DwAAAPBp0FYndQAAAADsrF+/fvLll1/KnXfeKV27dnXOwbB3716ZMGGCKef1+uuv+7ubAAAAgG+CthEREQlpBgAAAPhNvnz5ZM2aNdKlSxfp27evOBwOs16vGGvYsKEJ3GobAAAAIE0EbT05efKkWWJjY93W33XXXb7oFwAAAJBoRYsWlUWLFsmZM2fkt99+M4HbkiVLmnJfAAAAQJoN2m7evNlk3u7Zs8eZvWDRLAa97AwAAADwJw3SVqtWzd/dAAAAAFImaKuTjWmdsClTppjLy1wnKAMAAAAAAAAApHDQ9vfff5cvvvhCSpQocYtPDQAAAAAAAACIK1ASqX79+rJ9+/bEPgwAAAAAAAAAkByZth999JGpabtz504pX768ZMiQwW37I488kthdAgAAAAAAAACSGrRdu3atrF69Wr777rt425iIDAAAAAAAAABSuDxCt27d5KmnnpJjx45JbGys25LcAdu33nrLBIZ79OiRrM8DAAAAAAAAAKkmaPv3339Lz549JV++fJKSNm7cKJMnT5a77rorRZ8XAAAAAAAAAGwdtG3ZsqUsX75cUtLFixelbdu28uGHH0qOHDlS9LkBAAAAAAAAwNY1be+8807p27ev/PTTT1KhQoV4E5F1795dfO3FF1+UJk2aSIMGDWTIkCE+3z8AAAAAAAAApNqg7UcffSRZs2aVlStXmsWV1pv1ddD2s88+ky1btpjyCAkRFRVlFsv58+d92h8AAAAAAAAAsFXQ9sCBA5JSDh8+LC+99JIsWbJEQkNDE/SY4cOHyxtvvJHsfQMAAAAAAAAAW9S0deVwOMySXDZv3iwnT56UypUrS3BwsFk0u3fcuHHmdkxMTLzHaOmGc+fOORcN/AIAAAAAAABAmg7aTp8+3dSzzZQpk1nuuusu+fTTT33eufr168vPP/8s27Ztcy5Vq1Y1k5Lp7aCgoHiPCQkJkWzZsrktAAAAAAAAAJBmyyOMGTNG+vfvL127dpXatWubdTop2fPPPy+nTp2Snj17+qxzYWFhUr58ebd1WbJkkVy5csVbDwAAAAAAAADpMmg7fvx4mThxorRr18657pFHHpFy5crJoEGDfBq0BQAAAAAAAID0JtFB22PHjkmtWrXirdd1ui25rVixItmfAwAAAAAAAABSTU3bEiVKyJw5c+Kt//zzz6VkyZK+6hcAAACQ6rz11lsSEBAgPXr0cK67evWqvPjii6bEV9asWaVVq1Zy4sQJt8cdOnRImjRpIpkzZ5a8efNK79695fr16354BQAAAEiVmbZvvPGGtG7dWlatWuWsabt69WpZunSpx2AuAAAAkB5s3LhRJk+ebCbpdaXlw7799luZO3euhIeHm7khWrZsacbQKiYmxgRs8+fPL2vWrDFXr2kpsgwZMsiwYcP89GoAAACQqjJtNTNg/fr1kjt3blmwYIFZ9PaGDRvk0UcfTZ5eAgAA+JHW89dAXLZs2cxSs2ZN+e677/zdLdjIxYsXpW3btvLhhx9Kjhw5nOvPnTsnU6ZMMZP51qtXT6pUqSJTp041wdl169aZNj/88IPs3r1bZsyYIZUqVZJGjRrJm2++KRMmTJBr16758VUBAAAg1QRtlQ42dVC5efNms+jtu+++2/e9AwAAsIFChQqZy9513LNp0yYTfGvevLns2rXL312DTWj5A82WbdCggdt6PWeio6Pd1pcuXVqKFCkia9euNff1Z4UKFSRfvnzONg0bNpTz5897PceioqLMdtcFAAAA6bg8AgAAQHrTrFkzt/tDhw412beaKVmuXDm/9Qv28Nlnn8mWLVtMeYS4jh8/LhkzZpTs2bO7rdcArW6z2rgGbK3t1jZPhg8fbsqWAQAAIJ1n2gYGBkpQUNANl+BgYsAAACBt0/qjGqS7dOmSKZOA9O3w4cPy0ksvycyZMyU0NDTFnrdv376m9IK1aD8AAACQdiQ4yjp//nyv2/SSrnHjxklsbKyv+gUAAGArP//8swnSXr16VbJmzWrGRmXLlvV3t+BnWv7g5MmTUrlyZbfAvk7a+95778n3339v6tKePXvWLdv2xIkTZuIxpT91fghXut3a5klISIhZAAAAkM6Dtlq3La59+/bJq6++Kt98842ZeGHw4MG+7h8AAIAtlCpVSrZt22ayGufNmycRERGycuVKArfpXP369U1A31X79u1N3do+ffpI4cKFJUOGDLJ06VIzoa81hj506JAzU1t/askNDf7mzZvXrFuyZImZ9I7zCwAAIH1KUj2Do0ePysCBA+WTTz4xkyToHzDly5f3fe8AAABsQuuSlihRwjkpq9Yvfffdd2Xy5Mn+7hr8KCwsLN44OEuWLJIrVy7n+o4dO0qvXr0kZ86cJhDbrVs3E6i95557zPaHHnrIBGeffvppGTlypKlj269fPzO5Gdm0AAAA6VOigraaWTJs2DAZP368VKpUyWQM3HvvvcnXOwAAAJvSslBRUVH+7gZSgXfeecfMD6GZtnrOaNLD+++/79yuc0MsXLhQunTpYoK5GvTVTG6uYgMAAEi/Ehy01W/9R4wYYepqzZ4922O5BAAAgLRIJ31q1KiRFClSRC5cuCCzZs2SFStWmHqlQFx6brjSCcomTJhgFm+KFi0qixYtSoHeAQAAIE0FbbV2baZMmcxlgVoWQRdPvvzyS1/2DwAAwO+01mi7du3k2LFjEh4eLnfddZcJ2D744IP+7hoAAACA9By01T9UAgICkrc3AAAANjRlyhR/dwEAAABAOpLgoO20adOStycAAAAAAAAAAAn0dwcAAAAAAAAAAP8haAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjQT7uwMAACB1O3TokJw6dcrf3UAyyJ07txQpUsTf3QAAAADSHYK2AADglgK2pUuVlitXr/i7K0gGmUIzyd59ewncAgAAACmMoC0AAEgyzbDVgO0T8oTklbz+7g586KSclNlXZ5v3mKAtAAAAkLII2gIAgFumAdtCUsjf3QAAAACANIGJyAAAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtEm348OFSrVo1CQsLk7x580qLFi1k3759/u4WADjxOQUAAAAASM0I2iLRVq5cKS+++KKsW7dOlixZItHR0fLQQw/JpUuX/N01ADD4nAIAAAAApGbB/u4AUp/Fixe73Z82bZrJZNu8ebPUrVvXb/0CAAufUwAAAACA1IxMW9yyc+fOmZ85c+b0d1cAwCM+pwAAAAAAqQlBW9yS2NhY6dGjh9SuXVvKly/v7+4AQDx8TgEAAAAAUhvKI+CWaM3InTt3yk8//eTvrgCAR3xOAQAAAABSG4K2SLKuXbvKwoULZdWqVVKoUCF/dwcA4uFzCgAAAACQGhG0RaI5HA7p1q2bzJ8/X1asWCHFihXzd5cAwA2fUwAAAACA1IygLZJ0qfGsWbPkq6++krCwMDl+/LhZHx4eLpkyZfJ39wCAzykAAAAAQKrGRGRItIkTJ5qZ2O+//34pUKCAc/n888/93TUAMPicAgAAAACkZmTaIkmXHQOAnfE5BQAAAABIzci0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgI7YO2g4fPlyqVasmYWFhkjdvXmnRooXs27fP390CAAAAAAAAgPQZtF25cqW8+OKLsm7dOlmyZIlER0fLQw89JJcuXfJ31wAAAAAAAAAgWQSLjS1evNjt/rRp00zG7ebNm6Vu3bp+6xcAAAAAAAAApMugbVznzp0zP3PmzOm1TVRUlFks58+fl5R26NAhOXXqVIo/L5Jf7ty5pUiRIv7uBnDL+JxKu/icAgAAAIDUL9UEbWNjY6VHjx5Su3ZtKV++/A3r4L7xxhviz0BIqdJl5OqVy37rA5JPaKbMsm/vHgIiSNX0c6pM6VJy+cpVf3cFySBzplDZs3cfn1MAAAAAkIqlmqCt1rbduXOn/PTTTzds17dvX+nVq5dbpm3hwoUlpWjmmgZsy9QfK1lylEix50Xyu3TmN9mztId5jwmGIDXTc1gDtjOeFCmT19+9gS/tOSny1KyrfE4BKUgTBr788kvZu3evZMqUSWrVqiUjRoyQUqVKOdtcvXpVXn75Zfnss8/MFWENGzaU999/X/Lly+f2hVqXLl1k+fLlkjVrVomIiDD7Dg5ONcN1AAAA+FCqGAV27dpVFi5cKKtWrZJChQrdsG1ISIhZ/E0DtmF5Kvi7GwDglQZsK9/4IxUAkMCJc6tVqybXr1+X1157zUycu3v3bsmSJYtp07NnT/n2229l7ty5Eh4ebsa2LVu2lNWrV5vtMTEx0qRJE8mfP7+sWbNGjh07Ju3atZMMGTLIsGHD/PwKAQAA4A+2Dto6HA7p1q2bzJ8/X1asWCHFihXzd5cAAACABE+cq3MyTJkyRWbNmiX16tUzbaZOnSplypSRdevWyT333CM//PCDCfL++OOPJvu2UqVK8uabb0qfPn1k0KBBkjFjRj+9OgAAAPhLoNiYZi3MmDHDDHLDwsLk+PHjZrly5Yq/uwYAAADcdOJcDd5GR0dLgwYNnG1Kly5tSpisXbvW3NefFSpUcCuXoCUUtMzXrl27PD6PllnQ7a4LAAAA0g5bB20nTpxoBr7333+/FChQwLl8/vnn/u4aAAAAcNOJczXhQDNls2fP7tZWA7S6zWrjGrC1tlvbPNF6t1pqwVpScg4HAAAAJD/bl0cAAAAA0tLEub7g78l3AQAAkI6DtgAAAEBqnjhXJxe7du2anD171i3b9sSJE2ab1WbDhg1u+9Pt1jY7T74LAACAdFgeAQAAALD7lWEasNWJc5ctWxZv4twqVapIhgwZZOnSpc51+/btk0OHDknNmjXNff35888/y8mTJ51tlixZItmyZZOyZcum4KsBAACAXZBpCwAAANxCSQSdNPerr75yTpyrtM5spkyZzM+OHTuaUgY6OZkGYrt162YCtffcc49p+9BDD5ng7NNPPy0jR440++jXr5/ZN9m0AAAA6RNBWwAAAOAWJs5VOnGuq6lTp8ozzzxjbr/zzjsSGBgorVq1kqioKGnYsKG8//77zrZBQUGmtEKXLl1MMDdLliwSEREhgwcPTuFXAwAAALsgaAsAAAAk48S5oaGhMmHCBLN4U7RoUVm0aJGPewcAAIDUipq2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAALARgrYAAAAAAAAAYCMEbQEAAAAAAADARgjaAgAAAAAAAICNELQFAAAAAAAAABshaAsAAAAAAAAANkLQFgAAAAAAAABshKAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAAAAAAABgIwRtAQAAAAAAAMBGCNoCAAAAAAAAgI0QtAUAAAAAAAAAGyFoCwAAAAAAAAA2QtAWAAAAAAAAAGyEoC0AAAAAAAAA2AhBWwAAAAAAAACwEYK2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADYS7O8OAAAAAEgZMTExEh0dfcv7cTgcUrRoUcmXM0iyhF/3Sd/SI4dD5MKVQImKJpcGAAC4I2gLAAAApHEaZD1+/LicPXvWJ/sLDg6WSZMmScbMeSUw8JJP9pkeOUTkeoxDNuzLIMu2ZRaHBPi7SwAAwCYI2gIAAABpnBWwzZs3r2TOnFkCAm4tOHj58mWTsRuarZAEBYX6rJ/pjUMcEnv9itTNeEqPqizdlsXfXQIAADZB0BYAAABI4yURrIBtrly5fLZPFRiUUQKDQ3yyz/QqKDhUcuQUqV7qpPy0K5ZSCQAAwGBEAAAAAKRhVg1bzbCFPQUGZ5LgoAAJyxTr764AAACbIGgLAAAApAO3WhIBySfA/Kfvkb97AgAA7IKgLQAAAAAAAADYCEFbAAAAAOnS+HfelBaNqqeZ5wEAAGkHQVsAAAAAtnXs6GF5rXdnubd6MalQMkzq1S4pQwe9LGfO/J2o/ZS+PVR+/P5rt3UdOveUqbO+83GPAQAAbh1BWwAAAAC2dPjQ7/K/R2rLwT9+k9HjPpHvV+ySQUPek3VrlkublvfJ2bOnb2n/WbJklRw5cvmsvwAAAL5C0BYAAACALQ3u30MyZMggUz79VqrfU1cK3lZE6j7QUD6esUhOHj8qY98eaNrVq32nvD9umPTq9rTcXSan1K1xh8ycPsm5H92uuj73uMm4te7HLVvw6svPyoudHpNJE0ZI7apFpFqFfDLh3aFy/fp1GTmsr9SoWEDuu6e4fDHnE7d+jhr+ujR8oLxUKp1DGtxbWt4dPUiio6NT6CgBAIC0iKAtAAAAkF5dvep9uXbthm0DoqIkIOqqBHhoq+viLomlWbQ/rVoiTzz1nISGZnLblidvfmnaoo18t3CeOBwOs27KB+9I6TJ3yZffrpdOXf5Phr3xsqyO/NFsm/f1avNz2NsfSOSGP5z3PVm3doWcPHFMPv38R3m1/wgT2H2+w6OSLTy7fL4gUtq0fVYGvd5Vjh/70/mYLFmzyvBRH8rCJVvltYGjZe7sqfLJlHGJfs0AAACWYOctAAAAAOnLY49531a1qsjAfzJZjaeeEomKMjdDYmKk+IULEpQhiwQEBknUnWXlVJ8hzqb5+zwngRcvuO3uyJQvE9W1gwd+MwHZ4iVKe9xevHhpOXfujJz++y9zv3KVmtL5hd7mdrE7SsrWTWvlkynjpfa9DSRnrjxmfbZs2U3A90bCw3NIv0FjJDAwUO4ofqd8NGmMXL16WZ5/sY/Z3vmFV+TDiaNk88Y10uSRx826Lt36Oh9fqPDtcqBzD1n0zVx59vmXE/WaAQAALARtAQAAANiWlUl7M5Uq14h3/5OPxyf6+UreWdYEbC25cueVO0uVc94PCgqS7Dlyyt//BouVBmg/nTZBDh88IJcvXzTlFLKGZUv0cwMAAFgI2gIAAADp1dy53re5BC6NGTOcN6MuXZL9e/dK5hzFJSgokzjitD0+YvItd63I7cUlICBA9u/fKw9K83jbdb1mxVpZtL4SHJzB7b72Ie46kQBxxMaaW1s3r5PePZ6Rbj37S+26D0pYWLgs+maOTP3wXZ/2CwAApC8EbQEAAID0KjQ0aW1jYsQREiKOkFBxBMffhyMx+/UiR45cUqtOfZn96QfyTMfubnVt/zp5XBYu+Eyat2xrgqpq+9YNbo/ftnW9W2kFndAsJjZGfG3rlnVmgrTnu77qXHf0yCGfPw8AAEhfmIgMAAAAgC31HzxWrl2LkmfbNZWN6yPl2NHDErniB+nwdBPJm7+g9Oj9hrPtls1r5aNJo+XA77/KzOmT5PtFX8rT7bs6txcsVFTWrV5uAr5aC9dXbr+9hOnXt1/PkUMH98v0qRNkyfdf+2z/AAAgfSJoCwAAAMCWbi9WQuZ9vVoKFS4mPV98Sh66r6wMeO0FqVHzPvnsy5WSPXtOZ9v2z74kO3/eIi2b1JBJ49+SPv1Gyr33Pejc3uf1EbLmp6XyQK0S8mhj9/q3t6Leg00lomN3eXNgT2nRuIZs27xOXnCZmAwAACApKI8AAAAAwLZuK1RU3hr90U3bZc2aTcZOmOl1e70GTcziSuvQ6mLx9Dyffr4k3rplq39xu9+77zCzuIro2M3r8wAAANwMmbYAAAAAAAAAYCMEbQEAAAAAAADARiiPAAAAACBVi1uuAAAAILUj0xYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAIB2IjY31dxfghUNixWHeowB/dwUAANgENW0BAACANCxjxowSGBgoR48elTx58pj7AQG3FhyMiooyP2NjrkkAeSBJ5tD/YqPl0oW/5fwlh5y9xLEEAAD/IGgLAAAApGEasC1WrJgcO3bMBG594dq1a3Lq1CnJeDlQAgMz+GSf6ZFm18bEivx2JFAWbw6TGDJtAQDAvwjaAgAAAGmcZtcWKVJErl+/LjExMbe8v127dsnzzz8v5RtOkiw57/RJH9Mjh0PkyrVAuXw1QBxCwBYAAPyHoC0AAACQDmhJhAwZMpjFF/s6ePCg5DkdI2FB/EkBAADga6miaNKECRPk9ttvl9DQUKlRo4Zs2LDB310CAAAAfI5xLwAAAFJF0Pbzzz+XXr16ycCBA2XLli1SsWJFadiwoZw8edLfXQMAAAB8hnEvAAAAUk3QdsyYMdKpUydp3769lC1bViZNmiSZM2eWjz/+2N9dAwAAAHyGcS8AAAAsti5ApbPSbt68Wfr27es2+22DBg1k7dq1Hh8TFRVlFsu5c+fMz/Pnz6dAj0UuXrz4z/P9tVNioi+nyHMiZVw6+7vzPU6p88l6PnX1yFWJjYpNsedF8rt26ppfz6nNR0Qu/vdxiTRg3ylJ8XPKOp+OyBGJEk6otOSUnErx88l6HofOzpTOJHbcy5gXyYUxL3yNMS/SwpjXej7FuDftOZXC494Ej3kdNnbkyBHtvWPNmjVu63v37u2oXr26x8cMHDjQPIaFhYWFhYWFhSV1LocPH3akN4kd9zLmZWFhYWFhYWGRND3mtXWmbVJodoLWArPExsbK6dOnJVeuXGaWW/j+24HChQvL4cOHJVu2bP7uDlI5zif4GucUfI1zKnlptsGFCxekYMGC/u6K7THmTVn87sPXOKfgS5xP8DXOKXuMeW0dtM2dO7cEBQXJiRMn3Nbr/fz583t8TEhIiFlcZc+ePVn7CTG/xPwiw1c4n+BrnFPwNc6p5BMeHi7pUWLHvYx5/YPfffga5xR8ifMJvsY55d8xr60nIsuYMaNUqVJFli5d6pZFoPdr1qzp174BAAAAvsK4FwAAAKkm01bpZV8RERFStWpVqV69uowdO1YuXbpkZtUFAAAA0grGvQAAAEg1QdvWrVvLX3/9JQMGDJDjx49LpUqVZPHixZIvXz5/dw3/Xpo3cODAeJfnAUnB+QRf45yCr3FOITkx7rUvfvfha5xT8CXOJ/ga55Q9BOhsZP7uBAAAAAAAAAAgFdS0BQAAAAAAAID0hqAtAAAAAAAAANgIQVsAAAAAAAAAsBGCtgAAeDBo0CAzCRAAAACQVjHmBeyLoC3ieeaZZyQgIMC55MqVSx5++GHZsWOHs43rdmupU6eOc/uHH34oFStWlKxZs0r27Nnl7rvvluHDh/vpFcFf7r//funRo0e89dOmTTPnheX8+fPy+uuvS+nSpSU0NFTy588vDRo0kC+//FKsuRIPHDggTz75pBQsWNC0KVSokDRv3lz27t2boq8JyUdnSn/ppZekRIkS5j3W2dJr164tEydOlMuXL/u7e0in1q5dK0FBQdKkSROP2/XzTBcAqQ9jXvgS414kFGNe2BFjXnsiaAuPdMB67NgxsyxdulSCg4OladOmbm2mTp3qbKPL119/bdZ//PHHZsDSvXt32bZtm6xevVpeeeUVuXjxop9eDezs7NmzUqtWLZk+fbr07dtXtmzZIqtWrZLWrVub8+bcuXMSHR0tDz74oLmtA9p9+/bJ559/LhUqVDCPR+r3+++/mz90f/jhBxk2bJhs3brVDBz0HFi4cKH8+OOPHh+n5waQnKZMmSLdunUzn0tHjx51rn/nnXfkwoULzvt6W9cBSF0Y8yIlMe4FY17YFWNem3IAcURERDiaN2/uti4yMlK/9nWcPHnS3Nfb8+fP9/h4fewzzzyTIn2Fvd13332Ol156Kd76qVOnOsLDw83tLl26OLJkyeI4cuRIvHYXLlxwREdHO7Zu3WrOuT/++CNF+o2U17BhQ0ehQoUcFy9e9Lg9NjbW/NTz4P3333c0a9bMkTlzZsfAgQPN+gULFjjuvvtuR0hIiKNYsWKOQYMGmXPHcubMGUfHjh0duXPndoSFhTkeeOABx7Zt29yeY/jw4Y68efM6smbN6ujQoYOjT58+jooVK5ptK1eudAQHBzuOHTvm9hg9v+vUqePz4wF70M8gPR/27t3raN26tWPo0KFun2M1atQw55UuelvXAUg9GPPClxj3IiEY88KOGPPaF5m2uCnNFpgxY4a5fEMvG7sZvcRn3bp1cvDgwRTpH1Kv2NhY+eyzz6Rt27bm8q+49FJDzXjJkyePBAYGyrx58yQmJsYvfUXy+fvvv022wYsvvihZsmTx2EYvR3Wtu/Xoo4/Kzz//LB06dJDIyEhp166ducxs9+7dMnnyZHPpztChQ52Peeyxx+TkyZPy3XffyebNm6Vy5cpSv359OX36tNk+Z84cs1/NeNi0aZMUKFBA3n//fefj69atK3fccYd8+umnbhkPM2fONH1A2qTnhV6+WqpUKXnqqadMVp116apeVq3bNStGF72t6wCkXox5kZwY94IxL+yKMa+N+TtqDHtmHQQFBZlvgXXR06RAgQKOzZs3O9voutDQUGcbXawshKNHjzruuece0+bOO+80+/v8888dMTExfnxVsGPGwYkTJ8x5MmbMmJvu67333jPfMlvfGA8ePNixf//+ZOo5UtK6devMefDll1+6rc+VK5fz8+WVV14x67Rdjx493NrVr1/fMWzYMLd1n376qfncsrKmsmXL5rh69apbm+LFizsmT55sbtesWdPxwgsvuG3Xb5GtrAM1YsQIR5kyZZz3v/jiC/ONtLdMCaR+tWrVcowdO9bc1iwWzVpZvny58xzTc0QzVHTR27oOQOrBmBe+xLgXN8OYF3bFmNe+yLSFRw888ICpzaXLhg0bpGHDhtKoUSO3TAKtY2K10UVrLyn9tk7r8ug3gvot4PXr1yUiIsLUDNNvmAGL9e1dQug30lq0X7/lrVmzpsydO1fKlSsnS5YsSdY+wn/0s0c/W/R9joqKcq6vWrWqW7vt27fL4MGDTYaKtXTq1MnUHdTJHHS7Zk9p1pRrG53kY//+/WYfe/bskRo1arjtV88zV/qN8m+//WayqpRmNjz++ONeMyWQumkNQT0Hn3jiCXNfs5+05qDW+1KaxaKfP/fee69Z9LauA5C6MOZFSmHcC28Y88KfGPPaW7C/OwB70g9kvTTM8tFHH0l4eLiZIXfIkCHOS8Jc28RVvnx5s7zwwgvy/PPPm1/wlStXmsEx0ods2bKZSRTi0kkU9HzSy790Nt2EzoQbFhYmzZo1M4ueh/qHlf60/nhC6qSfI3opmA4YXOmlWSpTpkxu6+MOGHVw+sYbb0jLli3j7Vtn5NXt+of1ihUr4m13nc35ZvLmzWvOPZ2QplixYuayM0/7RNqgA1UNwLhewqp/cIeEhMh7770nvXr1ivf5FHcdAPtjzAtfYdyLm2HMCztizGtvBG2RIPqPi9ZWunLlSpIeX7ZsWfPz0qVLPu4Z7Exr4mjdprh0ptw777zTnFNt2rQxNZMGDhwYr76XDjx0AKLf9nk6J7Xuzpo1a5L1NSD5aTaA/gGigwKdsTSx3+JrrS4d/Hr7g1q3a7aKnke33367xzZlypSR9evXmzphFiu7wNWzzz5rvoUuVKiQFC9eXGrXrp2oviJ10IGrzuw9evRoeeihh9y2tWjRQmbPnm0CM4qaXkDawpgXScW4FzfDmBd2w5jX/gjawiO9LEM/8NWZM2fMPyw6kNBv3G6mS5cuZhBSr1498yGvl2vot8L67XLcSy+Qtum5oOdO9+7dzT/8+m3dt99+az78v/nmG9NGC+frN7d6mY7e1suAMmTIYArtDx8+XDZu3Ch//PGHGdw+/fTT5o+hjBkzmgwWLZDep08ff79M+IBOgKCDQX3/dXKEu+66y/xxo++/ZqRUqVLF62MHDBggTZs2lSJFisj//vc/8zi9PGznzp3ms6dBgwbms0cHHiNHjjR/OB09etScizq5gz6nXtaqAxG9rf3QyxF37drlzHywaJaLZtLofvXyNKRNOsmC/tvXsWNHkx3lqlWrViYjwRrAAkjdGPPCVxj3IiEY88JOGPOmAv4uqgv70UkU9NSwFi2AX61aNce8efOcbXS9NQlDXNqucePGpiB6xowZHQULFnS0atXKsWPHjhR8FbCLDRs2OB588EFHnjx5zCQMWrg87rlz9uxZx6uvvuooWbKkOWfy5cvnaNCggWkXGxvr+Ouvvxzdu3d3lC9f3hTB13OyQoUKjlGjRjHZRxqiE7p07drVUaxYMUeGDBnMe129enXH22+/7bh06dINP3sWL15sCuhnypTJTMCgj/vggw+c28+fP+/o1q2b+TzSfRcuXNjRtm1bx6FDh5xthg4daoru6/Pq56BOBOE6KYOlf//+ZuIa7S/SpqZNm5p/xzxZv369OQ+3b9+e4v0C4FuMeeFrjHuREIx5YReMee0vQP/n78AxAACphX4T/ddff8nXX3/t764AAAAAyYIxL+B/lEcAACABdHIRnSF81qxZDF4BAACQJjHmBeyDoC0AAAnQvHlz2bBhg6nrxMzNAAAASIsY8wL2QXkEAAAAAAAAALCRQH93AAAAAAAAAADwH4K2AAAAAAAAAGAjBG0BAAAAAAAAwEYI2gIAAAAAAACAjRC0BQAAAAAAAAAbIWgLAAAAAAAAADZC0BYAAAAAAAAAbISgLQAAAAAAAADYCEFbAAAAAAAAABD7+H+KiXSjiGkJMQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1400x500 with 2 Axes>"
       ]
@@ -2505,10 +2505,10 @@
    "id": "summary-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.006281,
-     "end_time": "2026-04-22T20:59:08.051611",
+     "duration": 0.045582,
+     "end_time": "2026-04-23T21:51:11.804008",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.045330",
+     "start_time": "2026-04-23T21:51:11.758426",
      "status": "completed"
     },
     "tags": []
@@ -2547,10 +2547,10 @@
    "id": "exercises-section",
    "metadata": {
     "papermill": {
-     "duration": 0.006159,
-     "end_time": "2026-04-22T20:59:08.063988",
+     "duration": 0.013365,
+     "end_time": "2026-04-23T21:51:11.827572",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.057829",
+     "start_time": "2026-04-23T21:51:11.814207",
      "status": "completed"
     },
     "tags": []
@@ -2558,9 +2558,9 @@
    "source": [
     "## 9. Exercices\n",
     "\n",
-    "### Exercice 1 : Vérifier l'admissibilité\n",
+    "### Exemple résolu 1 : Vérification de l'admissibilité\n",
     "\n",
-    "Pour le problème d'itinéraire, vérifiez que la distance à vol d'oiseau est bien une heuristique admissible. Pour cela, comparez la distance à vol d'oiseau avec la distance réelle (chemin le plus court selon UCS) pour toutes les paires de villes du graphe.\n"
+    "Cet exemple montre comment vérifier que la distance à vol d'oiseau est une heuristique **admissible** pour le problème d'itinéraire. On compare la distance à vol d'oiseau avec la distance réelle (chemin le plus court selon UCS) pour toutes les paires de villes.\n"
    ]
   },
   {
@@ -2569,16 +2569,16 @@
    "id": "exercise1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:08.078047Z",
-     "iopub.status.busy": "2026-04-22T20:59:08.077829Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.086334Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.085592Z"
+     "iopub.execute_input": "2026-04-23T21:51:11.852470Z",
+     "iopub.status.busy": "2026-04-23T21:51:11.852041Z",
+     "iopub.status.idle": "2026-04-23T21:51:11.866306Z",
+     "shell.execute_reply": "2026-04-23T21:51:11.865492Z"
     },
     "papermill": {
-     "duration": 0.016604,
-     "end_time": "2026-04-22T20:59:08.087215",
+     "duration": 0.029096,
+     "end_time": "2026-04-23T21:51:11.868102",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.070611",
+     "start_time": "2026-04-23T21:51:11.839006",
      "status": "completed"
     },
     "tags": []
@@ -2666,7 +2666,7 @@
     }
    ],
    "source": [
-    "# --- Exercice 1 : Vérifier l'admissibilité ---\n",
+    "# --- Exemple résolu 1 : Vérification de l'admissibilité ---\n",
     "\n",
     "def check_admissibility(graph, coords):\n",
     "    \"\"\"\n",
@@ -2725,10 +2725,10 @@
    "id": "59ad5327",
    "metadata": {
     "papermill": {
-     "duration": 0.006896,
-     "end_time": "2026-04-22T20:59:08.101020",
+     "duration": 0.011819,
+     "end_time": "2026-04-23T21:51:11.893182",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.094124",
+     "start_time": "2026-04-23T21:51:11.881363",
      "status": "completed"
     },
     "tags": []
@@ -2754,39 +2754,105 @@
   },
   {
    "cell_type": "markdown",
-   "id": "exercise2",
+   "id": "variant-ex1-md",
    "metadata": {
     "papermill": {
-     "duration": 0.007366,
-     "end_time": "2026-04-22T20:59:08.114986",
+     "duration": 0.01054,
+     "end_time": "2026-04-23T21:51:11.916492",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.107620",
+     "start_time": "2026-04-23T21:51:11.905952",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Créer une heuristique non admissible\n",
+    "### Exercice 1 : Vérifier la consistance d’une heuristique\n",
     "\n",
-    "Modifiez la distance à vol d'oiseau pour créer une heuristique non admissible (par exemple, en multipliant par 2). Observez comment A* se comporte avec cette heuristique. Trouve-t-il toujours une solution ? Est-elle optimale ?\n"
+    "La consistance (ou monotonie) est une propriété plus forte que l’admissibilité : pour tout nœud $n$ et tout successeur $n'$, on doit avoir $h(n) \\leq c(n, n') + h(n')$.\n",
+    "\n",
+    "**Votre mission** : vérifiez que la distance euclidienne est **consistante** pour le graphe de villes.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Pour chaque transition $(n, n')$, calculez le coût réel $c(n, n')$ et comparez avec $h(n) - h(n')$\n",
+    "- Listez toutes les violations éventuelles\n",
+    "- La consistance implique l’admissibilité, mais la réciproque est fausse\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "variant-ex1-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-23T21:51:11.951227Z",
+     "iopub.status.busy": "2026-04-23T21:51:11.950677Z",
+     "iopub.status.idle": "2026-04-23T21:51:11.954694Z",
+     "shell.execute_reply": "2026-04-23T21:51:11.954144Z"
+    },
+    "papermill": {
+     "duration": 0.020414,
+     "end_time": "2026-04-23T21:51:11.955679",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:11.935265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --- Exercice 1 : Vérifier la consistance ---\n",
+    "\n",
+    "def check_consistency(graph, coords, goal):\n",
+    "    \"\"\"\n",
+    "    Vérifie que l’heuristique euclidienne est consistante pour le graphe.\n",
+    "    Pour chaque transition (n, n'), vérifie h(n) <= c(n, n') + h(n').\n",
+    "    \"\"\"\n",
+    "    # TODO: Parcourir toutes les transitions du graphe\n",
+    "    # TODO: Pour chaque transition, calculer h(n), h(n'), et c(n, n')\n",
+    "    # TODO: Vérifier l’inégalité h(n) <= c(n, n') + h(n')\n",
+    "    # TODO: Lister les violations (s’il y en a)\n",
+    "    pass\n",
+    "\n",
+    "# Test\n",
+    "# violations = check_consistency(france_graph, france_coords, 'Strasbourg')\n",
+    "# print(f\"Violations de consistance : {len(violations)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercise2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008504,
+     "end_time": "2026-04-23T21:51:11.973530",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:11.965026",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple résolu 2 : Heuristique non admissible\n",
+    "\n",
+    "Cet exemple montre comment créer une heuristique **non admissible** en multipliant la distance à vol d'oiseau par un facteur > 1, et observe le comportement de A* avec cette heuristique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "id": "exercise2-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:08.129229Z",
-     "iopub.status.busy": "2026-04-22T20:59:08.129020Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.134250Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.133721Z"
+     "iopub.execute_input": "2026-04-23T21:51:11.996543Z",
+     "iopub.status.busy": "2026-04-23T21:51:11.996239Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.004063Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.003295Z"
     },
     "papermill": {
-     "duration": 0.013388,
-     "end_time": "2026-04-22T20:59:08.135069",
+     "duration": 0.021813,
+     "end_time": "2026-04-23T21:51:12.005400",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.121681",
+     "start_time": "2026-04-23T21:51:11.983587",
      "status": "completed"
     },
     "tags": []
@@ -2812,7 +2878,7 @@
     }
    ],
    "source": [
-    "# --- Exercice 2 : Heuristique non admissible ---\n",
+    "# --- Exemple résolu 2 : Heuristique non admissible ---\n",
     "\n",
     "def make_inadmissible_heuristic(goal, coords, factor=2.0):\n",
     "    \"\"\"Crée une heuristique non admissible en multipliant la distance par factor.\"\"\"\n",
@@ -2859,10 +2925,10 @@
    "id": "80754893",
    "metadata": {
     "papermill": {
-     "duration": 0.006803,
-     "end_time": "2026-04-22T20:59:08.148329",
+     "duration": 0.009184,
+     "end_time": "2026-04-23T21:51:12.023982",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.141526",
+     "start_time": "2026-04-23T21:51:12.014798",
      "status": "completed"
     },
     "tags": []
@@ -2888,21 +2954,88 @@
   },
   {
    "cell_type": "markdown",
-   "id": "exercise3",
+   "id": "variant-ex2-md",
    "metadata": {
     "papermill": {
-     "duration": 0.006644,
-     "end_time": "2026-04-22T20:59:08.161667",
+     "duration": 0.011025,
+     "end_time": "2026-04-23T21:51:12.044841",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.155023",
+     "start_time": "2026-04-23T21:51:12.033816",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Heuristique pour un autre problème\n",
+    "### Exercice 2 : Analyser l’impact d’une heuristique inconsistante\n",
     "\n",
-    "Soit un problème de « tour de villes » où l'objectif est de visiter toutes les villes exactement une fois (TSP). Proposez une heuristique admissible pour ce problème et discutez ses propriétés.\n",
+    "L’exemple résolu 2 montre une heuristique **non admissible**. Construisez maintenant une heuristique **inconsistante mais admissible** et observez son impact sur A*.\n",
+    "\n",
+    "**Votre mission** : créez une heuristique qui est admissible ($h(n) \\leq h^*(n)$) mais inconsistante ($h(n) > c(n, n') + h(n')$ pour certaines transitions).\n",
+    "\n",
+    "**Indices** :\n",
+    "- Ajoutez un « bump » local à certains nœuds tout en restant sous $h^*$\n",
+    "- Comparez le nombre de nœuds explorés avec l’heuristique euclidienne\n",
+    "- A* reste optimal même avec une heuristique inconsistante, mais peut rouvrir des nœuds\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "variant-ex2-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-23T21:51:12.070099Z",
+     "iopub.status.busy": "2026-04-23T21:51:12.069428Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.074716Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.073744Z"
+    },
+    "papermill": {
+     "duration": 0.017808,
+     "end_time": "2026-04-23T21:51:12.075973",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:12.058165",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --- Exercice 2 : Heuristique inconsistante mais admissible ---\n",
+    "\n",
+    "def make_inconsistent_heuristic(goal, coords):\n",
+    "    \"\"\"\n",
+    "    Crée une heuristique admissible mais inconsistante.\n",
+    "    Conseil : ajoutez un petit bump aléatoire ou directionnel\n",
+    "    qui reste sous h* mais viole la consistance sur certaines transitions.\n",
+    "    \"\"\"\n",
+    "    # TODO: Définir une fonction h(state) qui retourne\n",
+    "    # TODO: euclidean_distance * (1 +/- small_perturbation)\n",
+    "    # TODO: Vérifier qu’elle reste admissible mais est inconsistante\n",
+    "    pass\n",
+    "\n",
+    "# Test\n",
+    "# h_inc = make_inconsistent_heuristic('Strasbourg', france_coords)\n",
+    "# path, stats = a_star_search(nav_problem, h_inc)\n",
+    "# print(f\"Explorés : {stats['explored']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "exercise3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010743,
+     "end_time": "2026-04-23T21:51:12.094957",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:12.084214",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple résolu 3 : Heuristique MST pour le TSP\n",
+    "\n",
+    "Cet exemple montre comment construire une heuristique **admissible** pour le problème du voyageur de commerce (TSP) en utilisant le coût de l'arbre couvrant minimum (MST).\n",
     "\n",
     "**Indices** :\n",
     "- Pensez à la structure du problème (visiter toutes les villes restantes)\n",
@@ -2912,20 +3045,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "exercise3-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:08.176040Z",
-     "iopub.status.busy": "2026-04-22T20:59:08.175832Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.181783Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.181183Z"
+     "iopub.execute_input": "2026-04-23T21:51:12.113652Z",
+     "iopub.status.busy": "2026-04-23T21:51:12.113173Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.122054Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.120979Z"
     },
     "papermill": {
-     "duration": 0.014457,
-     "end_time": "2026-04-22T20:59:08.182672",
+     "duration": 0.020256,
+     "end_time": "2026-04-23T21:51:12.123836",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.168215",
+     "start_time": "2026-04-23T21:51:12.103580",
      "status": "completed"
     },
     "tags": []
@@ -2937,9 +3070,9 @@
      "text": [
       "Heuristique MST pour le TSP (sur le graphe des villes françaises)\n",
       "=================================================================\n",
-      "  current=Bordeaux     unvisited={'Paris', 'Lyon', 'Marseille'}                → h=1224 km\n",
-      "  current=Paris        unvisited={'Toulouse', 'Lyon', 'Nantes', 'Marseille'}   → h=1527 km\n",
-      "  current=Lyon         unvisited={'Nice', 'Grenoble'}                          → h=410 km\n",
+      "  current=Bordeaux     unvisited={'Lyon', 'Paris', 'Marseille'}                → h=1224 km\n",
+      "  current=Paris        unvisited={'Toulouse', 'Nantes', 'Lyon', 'Marseille'}   → h=1527 km\n",
+      "  current=Lyon         unvisited={'Grenoble', 'Nice'}                          → h=410 km\n",
       "\n",
       "Propriétés :\n",
       "  ✓ Admissible : le MST est une borne inférieure sur tout tour restant\n",
@@ -2949,7 +3082,7 @@
     }
    ],
    "source": [
-    "# --- Exercice 3 : Heuristique MST pour le TSP ---\n",
+    "# --- Exemple résolu 3 : Heuristique MST pour le TSP ---\n",
     "\n",
     "def mst_cost_prim(nodes, graph):\n",
     "    \"\"\"\n",
@@ -3033,10 +3166,10 @@
    "id": "bd7abed8",
    "metadata": {
     "papermill": {
-     "duration": 0.006887,
-     "end_time": "2026-04-22T20:59:08.195869",
+     "duration": 0.012452,
+     "end_time": "2026-04-23T21:51:12.146801",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.188982",
+     "start_time": "2026-04-23T21:51:12.134349",
      "status": "completed"
     },
     "tags": []
@@ -3062,13 +3195,83 @@
   },
   {
    "cell_type": "markdown",
+   "id": "variant-ex3-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008843,
+     "end_time": "2026-04-23T21:51:12.165441",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:12.156598",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Heuristique du plus proche voisin pour le TSP\n",
+    "\n",
+    "L’exemple résolu 3 utilise l’arbre couvrant minimum (MST) comme heuristique. Une autre approche classique est la **méthode gloutonne du plus proche voisin** : depuis chaque ville, aller toujours vers la ville non visitée la plus proche.\n",
+    "\n",
+    "**Votre mission** : implémentez la heuristique du plus proche voisin pour le TSP.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Choisissez une ville de départ\n",
+    "- À chaque étape, allez vers la ville non visitée la plus proche\n",
+    "- Le tour obtenu est une borne supérieure (pas admissible !)\n",
+    "- Comparez la qualité du tour avec la borne MST\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "variant-ex3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-23T21:51:12.187442Z",
+     "iopub.status.busy": "2026-04-23T21:51:12.186860Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.192598Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.191916Z"
+    },
+    "papermill": {
+     "duration": 0.019904,
+     "end_time": "2026-04-23T21:51:12.194433",
+     "exception": false,
+     "start_time": "2026-04-23T21:51:12.174529",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# --- Exercice 3 : Heuristique du plus proche voisin pour le TSP ---\n",
+    "\n",
+    "def nearest_neighbor_tour(start, cities, graph, coords):\n",
+    "    \"\"\"\n",
+    "    Construit un tour TSP par la méthode gloutonne du plus proche voisin.\n",
+    "    À chaque étape, choisit la ville non visitée la plus proche.\n",
+    "    Retourne (tour, total_cost).\n",
+    "    \"\"\"\n",
+    "    # TODO: Initialiser le tour avec la ville de départ\n",
+    "    # TODO: Tant qu’il reste des villes non visitées :\n",
+    "    # TODO:   Trouver la ville non visitée la plus proche (distance euclidienne)\n",
+    "    # TODO:   L’ajouter au tour et accumuler le coût\n",
+    "    # TODO: Retourner au point de départ\n",
+    "    pass\n",
+    "\n",
+    "# Test\n",
+    "# cities = list(france_graph.keys())\n",
+    "# tour, cost = nearest_neighbor_tour(\"Bordeaux\", cities, france_graph, france_coords)\n",
+    "# print(f\"Tour NN : {tour}, coût : {cost:.1f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exercise4",
    "metadata": {
     "papermill": {
-     "duration": 0.006604,
-     "end_time": "2026-04-22T20:59:08.209092",
+     "duration": 0.013483,
+     "end_time": "2026-04-23T21:51:12.220161",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.202488",
+     "start_time": "2026-04-23T21:51:12.206678",
      "status": "completed"
     },
     "tags": []
@@ -3083,20 +3286,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "exercise4-solution",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:08.221590Z",
-     "iopub.status.busy": "2026-04-22T20:59:08.221400Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.298628Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.298002Z"
+     "iopub.execute_input": "2026-04-23T21:51:12.245592Z",
+     "iopub.status.busy": "2026-04-23T21:51:12.245185Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.411504Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.410209Z"
     },
     "papermill": {
-     "duration": 0.084401,
-     "end_time": "2026-04-22T20:59:08.299334",
+     "duration": 0.181462,
+     "end_time": "2026-04-23T21:51:12.413633",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.214933",
+     "start_time": "2026-04-23T21:51:12.232171",
      "status": "completed"
     },
     "tags": []
@@ -3116,7 +3319,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAooAAAIDCAYAAACDyz+cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOy1JREFUeJzt3QeUFFXaxvF3MgiiZLMgQREVBCSoKIiioqgoGBZRMSLmhIEVFSMoiAl3TYCsWTCwC6JLEjNBjGsABAQRJedJ9Heeq9VfTXNnpmeYoafl/zunD0N3dfXt6gpP3XvrVkokEokYAAAAECM19gkAAABACIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAK90/9MAgHj997//tQ8++MDq169v559/fqKLAyQ1tqeKhRrFHdgFF1xgKSkp7jF16tTo88Fz9erViz43cuTI6PN33nmn7ai0nLQMtOzKg5Z5sJwrItaDrX3//ffWrVs3Gz16tHXs2NF2VMG6uyMpbB/6V5CobZ3tqeJJ6qDYp0+f6IqsxwMPPFDk9FrZw+EHFcvChQvdb6qzyKysLKtZs6a1bt3a7r///jKZ/8qVK61fv37WpEkTq1y5smVkZNhee+1lZ511ln3++edWnmbMmGG9e/e2Bg0auM+uUaOGHXrooa48//vf/8r1s//KvvjiC+vbt681b97c0tPTo/sCHeRiLV261AYNGmTHH3+8W8f0O+y8887Wrl07GzFiRKk+f+PGjda9e3fbbbfdbNq0abbPPvsUeH3BggVuv6PHm2++Werv+VcOWKmpqfbNN98UeL1Dhw7R1995552ElRPbV3Hb0/amY8att95qRx99tO20007RdbKwigLdEfmf//ynHXbYYValShWrWrWqtW3b1v71r39ZMkvapufc3Fx7/fXXCzz38ssv2y233FLguY8++sjy8vLsqKOOKvD8b7/9Zv/+97/twgsvtB1V//797eKLL3Z/H3zwwQkty4cffmhdunSxtWvXFthIg4c21m2RnZ3t1oHYA9KSJUvs1VdftbffftutKwpvZU3rpAJK2ObNm23VqlU2Z84c++GHH5ImROg3mj59uvs70TtxmTJlij355JNxTasDT+z+QT755BP3UOgcNmxYiT7/q6++cge2Sy65xPbYY4+tXldQvOuuu9zfakI77bTTSjT/HYEOrvfee6+9+OKLiS4KEqy47Wl7W7RoUbEVUGEKkM8//3yB5z799FP3+Pbbb+2+++6zZJS0NYrvvfeerVixosBz2tF/9913BZ577bXX3NmAVj7ttBUaBw8ebI0aNXJn+evXr7eKYsOGDdv1c7QMjjzySPfYZZddLFFWr15tPXr0cCExLS3N1Sq+8cYbribhiSeesJNOOmmr96gGaOLEid756YRB7w/TtEFI3HXXXV2zhk4UmjVrFg1uzz33XJl/t4ceeqhASFTt5dixY10fHAUcLftkUqdOneg6UxGCon7Lrl27uh3wEUccUez0lSpVsosuusjGjBnjfn8F38Cjjz5q8+fPL9Hnt2nTxu64444KcVBLZjpZ+/HHHxNdDCT4eFfRtqfMzExXwaATzOIqlSZPnhwNiXXr1nUnPq+88kr0uyhwqmUpKUWSVK9evSIqvh5nn3129O877rhjq2knTZoUOeyww6LT7LrrrpH7778/snHjxiI/Iz8/P3LPPfdEmjZtGqlUqVIkKysrsvfee0e6dOkSeeaZZ6LTnX/++dF5T5kyJfr8iBEjvOU6+uijo8/PmjUr0rt370jNmjXd/4vz2muvufKoLPr3lVdecfMO5qfPDOy7777R5xcuXBg5/fTTI9WqVYvUq1evyHIHz+n9xX0XmT9/fuTiiy+O7LPPPpHMzMxI7dq1I2eeeWbk22+/jcRj8ODB0XnffffdxU7/+eefR9LS0iI77bRT5MMPPyzw2vjx4yMZGRlu+cydOzf6/PPPPx/9jO7du0eff/zxx6PP9+nTp9jP1nLStFp2xVmxYkWkatWq0fnfcMMN3unCyyn8m/3+++/uc7S+aj5apppnrDfffDPSqVMnN52Wf+PGjSN33nnnVut3eL2bOXNmpGfPnm6+devWdb/pli1bIl988UWkQ4cObn3Xuv7II48UmEc867TmceWVV7r1QPM54YQTIgsWLCh2ecXO56effoqUxFlnneXdDsLL+eeffy7w3ObNm933D96n7Ske77//fqRr166RWrVqufVNv9s111xT4PcJf5fYR7D+TJs2za2PDRs2jOyyyy5uXrvvvnukR48ebjmGhbfz5557LjJ06NDIfvvt59b1Fi1aRN59992tyvnbb79FrrvuOjd/rRtaR7T/+vjjj7ea9h//+EekZcuWkSpVqrhp99hjD7deDRo0KK5lEqy78Qjve4KH9oO+ZTdhwoQC750xY0bkjDPOiNSpUye67G+55ZbIhg0bIosXL46cd955bt3Td2jQoEHkpptuiqxatSqu9aywfak89thjbnlrndbxRMeVwvah+lvLrnr16pH09HS3nug9V199dWT16tXFLp+cnJzIkCFD3O+q/ZwerVu3jowePbrAdFpmweerfAH9ZsHzl156abRM4fXvnXfecb+31h8dEx5++OEC8y5qn//jjz9GLrjggshee+3lfoMaNWpETjzxxMh///vfAtPFfuaYMWMizZo1c79NeJ7xbE+yfPnyyGWXXeaONZpO+69GjRq5DDB16tRil2tRv29xnnzyya2237Abb7wx+rr2v4EHHngg+ryOk8koKYPipk2bIjvvvLNb8Noh/Prrr25j1P/333//rabXCtSmTZsCQVEbkuZTlIEDBxa6oz/iiCPKJChqxxOeb1G0kaWkpGxVFm14xQXF8OcEAbAsgqKCrpanbxlpI/70008jxWnfvn30PXfddVfkoIMOcjtj7Qx0APD9Ttrggt9yzpw57rkPPvjA7VD1vA4OsWE2WEf0Hu1w//3vf0eXXWpqqjtol2VQDIdThYA1a9YU+57wb9akSZOtlqnCXdjtt99e6Dqq5Zqdne1d73QAjZ3+qquu8v6W77333jat07HbS6KCYmHCJ5FaJ4rz9NNPu/XFt8x10AoObvEERZ2wFjaN1uXwSUT4IKf9XOz0OnDqgBvQyaEO5L55a9q33nrLu67GPvbcc89yDYqtWrWKlik4oSgsKI4dO9ZN5ytnu3btCv2+BxxwQGTlypWlDooPPvigdxmGt9FgH/rdd99FKleuXOjyVMgqLiQqZBb2/n79+kWnVejU76PnVQmwZMkSd4IcfL4C4Nq1a7cKbdr+dbIdO2+tj8Vt69qnB8ff2IeOT8OHD49OG/7M+vXrFzh+BfOMd3uSY445ptDl0r9//4QGxUsuuST6utaXgAJ88LzWl2SUlE3PajJat26d+1t9flTNq87PwRVT4QsTbrzxRvfa7rvv7voI7bnnnnbzzTfbPffcYwcccECRTc9vvfVWtHlLnVHVXKiqZTWNan5l1QdCVe1qGn344YcLnS4/P9+uvfZa159H1FT7n//8x66++mrX5F6cZcuW2dChQ+3dd9+12267rUzKrrJomarpWG644QY3fzW1qglZy1YXcARlLoz6bgS0LL7++mvXFBz0Dzn11FO3moc6DJ955pnuszt37uz6q6qJWp2h1e9S3QvCdPHCCy+84JpO9Z5evXrZySef7JbdQQcd5Mod2491W4V/l0MOOcSqVatWovernFrvhg8f7ppAgmb1NWvWuL/VjHH33Xe7v7U+Pvvss665PmiqV1/CwtYpbT8vvfRSgT4zjz32mOtErmb7yy+/vMCyLonff//d/vGPf7iya9sJ+qDG9g+tCH766afo/kIdz9u3b1/k9OrTeuWVV9qWLVtcM/aQIUPcMte6KGo+DfpBanmqOTtw4oknut9ED/UPFl2spenUR1b9LdWlJuiqoHW5sN9v7ty5NnDgQLcv1MU5Qb9t7SMCushn8eLF7u/zzjvPlVPdHfQ9Na2a0oLmv2BfpwuC9NtNmjTJbS/aprXtlCeVbe+993Zliu3LG6b9ifquabrg+2kfqOfk448/dt9XFyhpmWqfqv2PqEtSafs5qy/xgAEDov+/6qqr3OeqG4nvQjT9hps2bXJ/X3PNNW5Zav+kY06rVq2KvTL8kUcece8RXQih7VHv33///d1z2repz5uoy9Azzzzj/lbXHR0PdHzS5+tz1J1GyyPWvHnzXPn1Pa677rro8+qOtXz58kLLpv2wlmlw/FWXLs3j9ttvdxcl6XWtgz///LN3W9P3V3cw9cnWtlaS7UmfqW1E1Jdc28yECRPc+nrGGWe4i0cSaf8/fx/Rvk/r4i+//GKjRo2KPu9bLkkhkoTU7BAk9IkTJ0abTXxnXNOnT49Mnjw5ejYR1JKpFvKpp54q8nPatm0bPaNWU42aNny2pUbxtttui+s76ywueM9uu+3mzjpjyxl7lhSunfJ9122tUVQTcPBc8+bN3bIOHjq7DzdzFiV8ZqumGtVu6KG/g+fVvBpLy0DNmuGzSjXPqsuAj5qpwzXLwUM1jX379o3k5uaWaY1iUOuph2q74hH+zd54443o8+HvGdSgqmkmvB4Fy37cuHHR51U761vvwutDuHlczWmiZu/wb1uSdTrchKXm/KJ+w7JU0hpFNWMdcsgh3qa7wui7BdPfeuut0edVc6smWz2v2pa8vDxv01ss7VPUTHXwwQdHa8PDj0MPPdRbGxKuWVatUvi9ixYtcrUwQe2N9hfhbbNbt27RaV9//XU3j6D7juaj5sN4ar/LqkZRNTVBrYuaQVUr5qtRVG1i8JyaTMPUDSe8nIPvqhrWYNmoVj/4XUpSo6juCMFzqn0OaF5q9Yjdh4aPRcOGDYssXbq0RMsx3EL06quvRr9LuIVLXTvCLrroIm8LQVh4XVS5g2UhqvEPXtO+t7Btffbs2YUeh8LH5WAfEP5M7Wdim5JLsj2pK01Q83jccce52vZ49tll5cliahTVzUNN57G/Q+yxJhklXY2izip0BiMaYuSYY45xf59++umuFkvUgTSogVKne99YTKqFDM5EC6NO76KzHg2hoTPxhg0b2mWXXeauVC0L6ogfj3An+xYtWrihXQIqW1l9TkmEl4Gu3tUZYvDQ2X2guOFfNBROQDVZqu3TQ2fGAdXmxtIyUI1N8LvrjFRXrerMNpZqFLSu6ExcNcmqedbV1Dpz1QVOqrWLrYXcVuELhHRmWVK6CCugoYICQQ1uePmrZjBY9uHfOvbiroBqsgLVq1eP/q0zfqlVq9ZWn1dW5a4INFSOyvnll1+6/19//fWuZqM44WWuYZuC4TK0Dge1c9pHxft7n3POOa4WR1d7qgYxVmHLTJ3+w+tZuDZD+wrVOAb7wF9//bXAthm+0CvYNlVLpO+hMhx77LFunqrlO/fcc23mzJlW3tQKoNpsjU7w4IMPFrvsw98/dn1WDU7wXdVKECxX1cTrdy+p8L5Xw54EtN9p2bLlVtOrBSRY71W7ptp+HatUo6zatOKEv6f2T8F3Cddqxu5T1Vqk1rKAaoGLulpX23mw34xdfkVd0BUuW+xxKDwP3/FRF5tpOZR2e9JwVtpeglrbAw880A1Zo9pFLZugpSVRateu7Y5T4ZEz9F1U2xkIWliSTdIFRVVZq1lSdKDXiqofQ02Kap4NxuMLB5WAdsi68rkkOy9VbSu0qHlSzX+qsn/qqafcQSbYiYebEoIySFFV+OHAWlKlGdS2NJ+zva7mDl89u++++3r/Dg+bE16+2ilrmWunp/XilFNOiTaLhOkqZx2EgoNi48aNXUBS01qgrIeoCa6oFgUSX7mKEg5wahIMFNeUH6YQHHzvwkJsOFj7msdL8nllVe7ypP2DDrxBU7iattTkVVI6SGk5+h7BPqoo6lqh5jPRSahOVjRoc3jgZjXJxaO0A10H26a6b6h7gE6edaDTd1PTmZqfta8r6dXgJaWTPHUTEu1f1X2hJOL9/sH33ZZ9dnGfq8A7a9Ys18VJFRUKjWq+DppU1X2krPep6lqk42F4+Dc9F6+yGCi9uHkUdwyKZ3vSaBfqCqP9vMak1W+nSgp1wVFTeqI1a9bMZs+e7ZrZ1TVII7Oo+0GgadOmloySLiiqX1U8ymJj1IHthBNOcP0SdcavPjJBHyCdpWvcvdiDrp4PxDNQbLwbqDaKgPpUhXduvlBc2s8pCYWtgA4mf14cVeChHZpqYIsSHtZEB0/f36rdCFNw1G+jM2ttnOrXqNpe1X6oRi3oI+Q7AIT7pYbDW1kPlaS+ggoAorNd9VHyKe2A2+Hlrx1oYcs/XGO7o1NNskKiTviCWoySDOgeXuaqhdTJYuxD662GnooN4bGhTy0VAfUzVG26tqN4fq/PPvss+rfWLX2vwH777ee2hWCb175DJwyx60ZOTo7r5yj6v1omFNJ0oNN2EYRn1chtj0Gv1YKgmmx9Xrjfsm/Zh79/7P///ve/F7otBDWvvn22fh/VVMXS8gyEa1e1D/bVtuqzdJKrGj31R9W+JzwsiobHKkr4eyqg+75L0IcxKLdOfrXPC2oJ9V3VIlbYyZmCbHh9DPo8xn7fosqm45DWK988wtMVdQwq6fakE89LL73U9alVrbkC+OGHH+5eUz/z7TXEXHF0Yw/V2uqkWUOkBdQvPhkl1YDbSufBhqwOurGDV2rHF9QQqYq/sGbIeKmjrj5HBxbdwUMbRXjHENTUaKcc3klp5VaIDG/M20rV/ApL6gyranh1AO/Zs6frsK3BghNBAU01rQppGsxYZdJFNqrlVc2tdt5q5tLGXFzNrTpda6emzvZqGhZ1Ug6Eq++1Q1QY1M5OOxDtIFSjrHVDZ/Aqi8qhzw6aRsJnchqbUTtDnenr4pmA7u5RltTMovnfdNNN7v9q2tbvp1oF1dyp2UU1NipHaWoz//a3v7mO76IO6apR0EUzWv8UhLRcdMAqj/Ehy4suPNPvJzorL+5OSqodDA7CwYUbou00COkaK1G1FQpTaopUbYto+9H6onvKhg9cWpeK2ieoBlLbvi680P5FJzoKNyqvmp70WtBVIly7qs9RC4X2KfqccI25xmDTSbAO9PFcbKZptZ2o9u/xxx+PHiD1/+CkSk2d48ePd+uCamAUHPTZWmY6yCuw6CRTy1gXQahZ9rjjjnPv1wE5GFhdfLXSZU0XI+hEXPtQH5VN25TWc/2+uqhEv61Cg/ZBAW1nKr+Cb/C7aF+soDJu3Lit9tmaj/ZBujDI12Sqz1WNp2q1tE9TGRXsVRkRPpkN/zbad+lCSzUBK5Tq9413WWq9DC6EU7DQ3Zt0/NHvo64k+r46zgV3B9EFT6oNFpVN278ubNOFH6qlvuKKK7b6DK0DuhBR+xAtm+D9OknRCXhhtI/Una10cqvyqKwqh0Ji0KVBLW/h/XVRSro96aRH89axR+MTalvWdKLjh6Yt6qIWtSoGA+Dr5Lq4W7GqHOPHj3d/hy+S1fILbvih7gjBtqzfXNuguiRofVFLVtBqoC4IwQ0ukk4kiYQ7CavjrI863gfTxI7pVFJFDVGgsdeC8bDUKT58QUDwCA+dUFjH/5IMAVLY8DjqCO/rxB++MMKnvIfHKeqzY2k4m8Lef/PNNxeYVsNP6DM1zp+GAAlTB2eNSanfR536AxoiQmPJFfYZ6jD99ddfl+nFLAGVv6jlc+qppxb7mxX2WxU1PE5sOQtb7wr7zJKsB6UZl86npNtGuDyFPYL5xDNtPGUsajgPPfQdAupsr07/hX3OSSedtNVr4QsLwss+vCzDF+GEO8qH142ihseJXTa+iyGCh4ZamTdvXrlezBLQPlUXnYQ/P3Z4nGCYq9iHxhks6vsef/zxBfYTvt9Qw+j41oXwWHjBQ+8PDwUVLHsNvVXUMn/ppZeKXDa6kKOoY0+4bNoXaiixYPgZXRylMSM1Fqee0wUhGhos9sISHZt8wwxp3ODyGh6nsH1mSbYn35A+vt+3MCXdH2n7sBLsM8IXIoUfGrpIw7clq9RkbXbWGbJPuCP/tjY/a/gF9XvQWYxqJ3SWqg7DOotS7UDQfBHUCKk2R2dTml61VjoTLEu6YEd3MFAnXn2Ozuw0+nunTp2i06jmZHtSTaf6iKjZSLV0Kpc67KqmUc/FW6uqWgB1QtfZmb6DHuqwrmEGYjtlq/lIFzSpBjH27iBaJqplVW1auLlaNSmqedWZuGpiVEOg31Nn6uqDqpqC8uo/ovJr/jqDVw2DPlvrjpaRagK35V7WwRApqgXQeqgaVK2jqinT5wZnzyg7qhV4//333faofldaj/SvOvNrmBDV4gT0mmoU9Hv4hilRjYPWCzW5arvRuhjUehVF641qErWv0TanWgytB8EwYaJtQ7UgqtEO1nmVQX+r9l/lCrYR7dNUDm1bWjdVs6maVdWQqGaxqObIsqTPVu1mYbp16+Zaa7TsdfGA1nfViKpWSrV2qhnTBTjqJ6jX9K/2I6pJCmrfg/2EavNVs6jlp21R+9bC+rmpv6Her89SrZtq1lSz5xtOSTWZ6pemfaN+Vy1LfS9Nqwstzz777CKXgcqjpn5dqKd1Sr+ZfjvtO9SdRbWFWg5qOlaNWNB/T7WY2m9qPQpua6maZt8QZZqvPkP7W30f1Yipq0EwbFNR9F615gTDzWkdV8259kHa74aH1irr7UmtiKrN1X5b5dZD66zW8XguFCpvPXv2dLWJWh76HbUNqqlcfdTjuXNURZWitJjoQiA++ql8/Tw01lbQP0T9i8rjfsX4gy400FX02kmOHDky0cXBDqSkzWbbm0KUmuQ4pFTsfZew/0JJJFWN4o5OZ/YaHkA1Ztohqx+L+p8EIVFnVuErbQEAAHaYi1l2dGpqUHO6r0ldzRM6Q9yWi3cAAADCSBVJRP2E1P9G/ZLUF0X9M9THRn1CVLuoJmgAAICyQh9FAAAAeFGjCAAAAC+CIgAAALwIigAAAPAiKAIAAGDbhseZ9uUsW7VpXbyTI6TylqqWmVE50cVISnm5OZaekZnoYiQdllvprV+13Lbk5ye6GEmpxq7VrGqV7Xt3qL+K7Jwcy8pkmy0pllvpHXrwgWUbFBUSb/ll1DYUacf1YO2+Niu3dqKLkZSapS62GSy7EmO5lV79DYvsvoefSnQxktLwQf1tn332SnQxktIPc+ez7EqB5Vb+aHoGAACAF0ERAAAAXtzCDwAAJPwWtfl5eVbyO4BELCcnp1zKlOxSzCwtPX2bb+1LUAQAAAmzefMmW7V8eaneWzk91Vb8tqzMy/RXUr1WLatUqfQX1BIUAQBAwmoSFRKrVq1qNWvUtJQU1YPFj6ueC6c7NK9YucIt37p77FnqmkWCIgAASAg1N4tCYuXKpaj1SkmxSllZZV+wv4iaNWra+vXr3XJOLWWg5mIWAACQEEGfxJLWJCI+wXIted/P/0eNIgAAqDCWblxhq3LWxzVtTm6OZcZ5c4HqmVVt951qWln56KOPbM2a1XbiiV3sr4ygCAAAKkxIPGlKf8vZ8keTdFnKTE23/3S8t9iw2LBhA8vKyrKsrEq2ceMGO/DAA+3GG2+yww8/PDrN5MmT7KWXXrbHHnuszMu5evVqe+qpf1q/fjdbRUDTMwAAqBBUk1geIVE033hrKl944UWbPXu2fffd99ar13l2yild7dNPP42+fswxnezpp5+2SpUqlWkZ8/LyXFAcPHiwVRTUKAIAABSiW7duNmPGZ/bww0Nt9Oh/2R13DLApU6ZYTk6uNW7cyIYPf9KqV69uF154obuy+Pvvv7MVK1ZYmzZtbfjw4e4inZdeeskee+xR9x5d6T1w4F128sld3fw7dTrGDj74EJs5c4abNjMz09atW2ctW7a09PT0AgE1EahRBAAAKELr1m3s22+/tSFDHrIqVarYxx9/YrNmzbKDDjrIBgwYEJ1OgXL8+An21Vdf26pVK+2RR4a55zt37mwffviRzZw508aOHWt9+vSx7Ozs6Pt+/PEHmzJlqr333n/tiSeG28477+zmn+iQKNQoAgAAFDMmobz11lu2du1aGzv2Dff/3Nwc23fffS3QvXt3F/Kkd+8L7fHHH7NbbrnVfvrpJzvvvF62ZMkSS0tLt5UrV7rnDjjgADft3/7W0zIyMqwiIigCAAAUYebMGda0aVP76acFNmzYMDvuuM4lGp7m3HN72r333mdnnHGG+3+dOrVt8+bN0ek04HhFRdMzAABAId5++2375z//addee52deuop9sgjj9jGjRvda/r3m2++iU47ZszYPwa4zs+3UaNGWqdOndzzq1atsnr16rm/X3jhBff/wlSrVs02bdpUYe5hTY0iAABASM+ef4sOj9OkSRN7++1x1qZNG3eBSXb23W6onKC28KabbnK1jdKqVSvr0uVEW758ubuY5eqrr3HPDx36sJ199lm2yy67WseOHWyfffYp9LNr1Khh557by1q0ONSqVKma8H6KBEUAAFAhaFBsjXdYXuMoav7FmTt3XqGvpaen25133uUePgcffLA988wzWz3fs2dP9wg8+OBD0b8nTZq81fSqwawoCIoAAKBC0GDYGhQ7Ge7MsqMgKAIAgApDYS7eQLc5O9sqZWVZRfDcc8/ZXxEXswAAAMCLoAgAAAAvgiIAAAC8CIoAAADw4mIWAABQYeT/vswia9fEN21ujuXFedVzSrVdLK12XatoJkwY78ZX1NiMFRFBEQAAVJiQuOqKXma58d+VZFO8E2ZkWvUnRscVFtetW2d7772X9ehxpj399NNxl2XcuHE2deoUGzJkaFzT6y4tX331pd133/1WUdH0DAAAKgRXk1iCkFgiuTlx11S++uqr1qJFC3vzzTfcLfl8dJu+sLy8POvatWvcIVE0CPcDDwyy1NSKG8cqbskAAAASYMSI59yt+dq3b+9Co4waNcqOPbaTnXlmD2vevLl99tlnlpGRbnfddae1bdvW+ve/zU1zxhmnu+lPOOF4GzNmTHSe06ZNdbf4C2osL7vsMmvXrq0deuih1qdPn+i9nX/99Vc755yz3Wv6nAEDbrdEIigCAAD86dtvv7XFixdb587HW+/eF7rQGFA4vPvue2zOnDnWrl0791xaWpp98sknNmjQ4ALzOf/8C+z550dF/z9y5Ci74IIL3N8KoUceeaR9/PEnNnv2bNuyZYs99tij7rULL+xtl19+uXtt5syZNmvWLHv99dctUeijCAAA8CcFw3PPPdcFwBNPPNH69r3c/ve//7nXFA7333//AtNfcEFv73xOO+00u+66a23p0qW288472/jx/7GHHvrjHs9vv/2WC5fDhg1z/9+8eZP7vA0bNtjkyZNt2bLfovPZsGG9/fDD95YoBEUAAAB1Y8zNdReYZGRk2Msvv+ye27hxowuPTZseZFWrVt3qPb7npHLlynbGGd3thRf+ZbVq1baOHTtazZp/3JowEom4Ju3GjRsXeE/QH/LDDz+0SpUqWUVA0zMAAMCfVy3Xr1/fFi5cZHPnznOPDz740IVHhciSOv/8812/RTVBB83Ocsopp9qDDz7oLoCRVatW2dy5c13o7NChgw0ePCg67S+//OKawhOFoAgAAPBns/M55/ytwHNNmjSxPfbY012AUlKtW7d2Tcrz5s2z447rHH1+yJAhrsaxVauW7mKWzp0728KFC9xrzz8/2gXU5s2buYtZevTobitWrLBEoekZAABUCBoUW+MdlssQORmZf8y/COPG/dv7/IwZM9y/1113XYHnc3P/qBEM1yDqETZnzhdbzU81h48++sfFK7Hq1Kljzz//vFUUBEUAAFAhaDBsDYod73iH2bk5lpXkd2ap6AiKAACgwnBhLs5Al5edbelZWeVeph0ZfRQBAADgRVAEAACAF0ERAAAAXvRRBAAAFUZk/WKLZK+Mb+KcHNuSGefFLFk1LKXqXttWuB0QQREAAFSYkJj9Zjuz/Oy43xP3QDppWZZ12sdxhUUNhH3//ffZK6+8Yunp6ZaWlm6HHXaYu6XfwIED3f2Xy3PQ76lTp9iQIUOtIiAoAgCACsHVJJYgJJZIfrabfzxB8ZJLLrFVq1ba9OkfWPXq1d0t98aMGWMrV8ZZ07kNunbt6h4VBX0UAQAA/qRb6Y0Z87o988yzLiRKSkqKde/e3fbbr77l5+fZlVdeaS1atLBmzQ6xmTNnRt/77rsT7eijj3J3ZGnXrq2rGZRp06a6O61cccUV7k4suuPKl19+aRdeeKH7+/DD29mSJUvctLrl3xlnnF7gfYV93vZAUAQAAPjT559/bg0bNrJatWp5X//uu++sV69eNnv2bOvb9wobMOB29/z8+fNds7Tu7vLZZ5/Z6NH/ctNlZ2dH36dgqPmfeuop1rnzcdavXz+bM2eOtWzZyh599JESfd72QlAEAACIU8OGDa1Nmzbu77Zt27qAKBMnTnT3dO7YsaO1bNnSzjrrLEtNTbVFixZF36fnRcGwQYMGdsABB7j/q/+jajJL8nnbC30UAQAA/qSm4blzf7QVK1ZYzZo1t3o9K6tS9O+0tDR34YuoH+Oxxx7rahJj/fLLkpj3pVqlSv75xPt52ws1igAAAKEavG7dTrdLL73EVq9eHQ2BY8eOtfnzfyr0fZ07d7ZJkya5vocBNUEnO2oUAQAAQp555hm777577YgjDnfD42zZssWOPLK9nXDCCUUGzNGjR1vfvpfbxo2bLDc3x12o4qthTCYpEcXkOLz56VS75ZdR5V+iv6AHa/e1r7bsm+hiJKVmqYvtiy0MkFpSLLfSq79ylt338FOJLkZSGj6ovx3YpHGii5GUfpg73xo33M92NDk5Obbit2VWb996rim2NOMoWjmMo/hXsXnzZluwcIHVrFPXMmMGJq+5S7W45kGNIgAAqBAU4hTm4r0zi4JmbAAqdN7cmaVUCIoAAKDCUJiLO9BlZ1tqVlZ5F2mHxsUsAAAA8CIoAgAAwIugCAAAAC+CIgAAALy4mAUAAFQYa7PzbWNuXCP3WU5uvmXmxnenkp0yUqxaVpolm7Vr19rIkSOtT58+cV/hXZYIigAAoMKExKdnr7b8+HLinzbFNVVaitklLXYtNiw2bNjAsrKyrFKlytHnFNQOPvhgK6lRo0bZ22+/ZWPGjLXS0J1hLr+8j916620JCYlCUAQAABWCahJLFhLjp/lq/tXiGE3nhRdedHdVSQTdBUZSU1Nt1113tZdeetkSiT6KAAAARfj++++tXr19bf78+e7/Q4cOsZNO6uJCnWoNjzvuWOvW7TQ75JCDrWPHDrZgwQLvfIYMeciaNTvEhdBevXrZmjVr3PMDB95lZ57Zw7p0OdGaN29mS5cutXffnWhHH32UtW7d2tq1a2tTp06xRKBGEQAAIKRnz78VaHr+4IMP7IEHBtk555xjgwcPsieffNI++uhjV+snH330kc2cOcuaNGliDz30oGsunjDhnQLzfOedCa4Je/r0D1xNofoc3nbbbfbEE0+41z/55BObMWOm1a1b1wXSgQMH2vjxE6xatWo2d+5cF0Dnzp3nmsW3J4IiAABAMU3PZ599tk2dOtW6dOliEye+a7Vr146+1q5dOxcS5eKLL7EBAwZYfn5+gfdPmjTJevTo4UKiXHbZZXbOOWdHXz/hhBNdSJSJEyfavHnzrGPHjtHXFUoXLVpkjRo1su2JoAgAAFCMvLw8++abr61GjRr2yy+/bPP8UlJSCvy/atWq0b8jkYgde+yxNnr0vyzR6KMIAABQjNtuu9UaN97fpkyZajff3M81BwfUbPzdd9+5v5977lnr0KGDpaUVvLq6U6dO9vrrr7vhbuTpp5+2Y489zvtZnTt3djWQX375ZfS5zz77zBKBGkUAAIAi+ijedded9u6777p+iTvttJM9+OBDrr/i9OnTo03PCpJqLlaN44gRI7eap5qWv/nmG2vf/khLSUl1w+08/vjj3s9v2LChjR492vr2vdw2btxkubk5rik8ETWMBEUAAFAhaFBsjXdYHkPkaL6af3F0wYjPySd3jf7dvXt39wjoghPfWInnn3++ewRuuOFG94g1YMAdWz3XqdOx7pFoBEUAAFAhaDBsDYod/51ZciwzI/MvfWeWRCMoAgCACkNhLp5BsWVzdr5VykpslDk/ptbwr4aLWQAAAOBFUAQAAIAXQREAAABeBEUAAAB4cTELAACoMJYu+91Wr1lX5lc977rLzrZ73f+/7R7iQ1AEAAAVJiSedsHVlpOTW+bzzszMsDdHPhpXWMzJybE77hhgb7zxhmVkZFhaWrpdf/31dt5559m0aVPt+utvsFmzZsX92XrP5s2b7fjjTyh1+RcsWGCtWrW05ctX2PZEUAQAABWCahLLIySK5qv5xxMUL7roQsvOzrZZs2ZblSpVXEjr2vVkd7/nBg32K/FnT5s2zVavXrNNQTFR6KMIAADwpx9//NHeeuste/LJf7iQKPXq1bPBgwfbPffc7f6fn59nF1xwgTVv3sxat25tc+bMib73qKPaW4sWLdwt9wYMuN299tRTT9lLL71oLVu2dPNQ4OzS5URr06aNNWt2iPXqda5t2LAhWoaRI0e6aTUfTaOgGmvGjBl23HHHutdbtWrl7iNdHqhRBAAA+JOCXcOGjaxmzZoFnm/btp39/PPP9vvvy909m4cOHeoC3WuvvWbnntvTvvrqaxs+fLiddNJJdvPNt7j3rFy50t37+dJLL3U1inqPRCIRd99mfYb+vvLKK+2JJx63fv1uds3U9957j73//nTbfffdbePGje49v/32W7Qsq1evtssvv9zGjRvnplm+fLm1bn2Yu+f0nnvuWabLg6AIAABQAvXq1bNjjunk/u7Ro4ddfnkfFyLbt29vt9xys61fv96OOuqoQu/VrHD4yCPDbPz4Ca52ce3aNS7kyfjx461nz54uAMpOO+201fs//vgj++mn+XbyyScXeP6HH75PXFCsmbvZntmlS5l++I5ixdoVVj9neaKLkZQ2padZ/bxliS5G0onsWt2apS9OdDGSUnZmpt1y9UWJLkZSys3Ltx/mzk90MZLS78tX2s+Ll9qOJiM9zfberZat37jRcvLybMOmP2rPyouukt6cnV3kNE0OPNDmzv3RlvzyS4Faxfenv2977bWX7bLLLi7oheeTkpJiObm51uWkk6xFyxY2efJke+zxx23YsGE2ZuwblpeX75qrg/e8/PJLNmnyZBs/YYJVq1bNnhw+3Ka9P829npef76aPLWd2To77V89n5+TaAU2a2KRJk7cqf/h9eo+C6IJFP6uUBaZr17J52QbFqml51uinPvFOjpDxNUbYfcNGJLoYSUkH7AcefTbRxUg69w28zb7csleii5GU6ucsY50rpeGD+lvjhiXv6A9zIfHuoU/Zjmb3OjXt5r69LGv5SktNTbPlK1aV6+dpKJ1KWUXfSPqgpk1dTd11115jI0eOcjV66iP49/79rX//v7urpxcuXGiffPyRdejQ0caMGWN169a1BvvtZ3PnzrUGDRrYhb0vtMPbHe76K+rzqlevbkuWLIl+9vp1661O7drusW7dOnvxxRdtn332dq+fduqpdtFFF9kVV1xRoOk5K/OPYYA0zdFHHWVXXXmFffjB9GitpZrMDzzwQMv8czonErH09HSrt0fdgs+XAE3PAAAAISNGjHQXohx6aHMXsNLS0tyQOL1793Z9CJs2bWqjRj1v1157nXtd/Q1Vqzh27BgX+jIyMm3Lli32xBPD3fxOO+00e+GFF9wFKt26nWZXXXW1jRv3tjVteqDVqlXLjjzySFu0aKGbtn37o+zvf7/dunTp4uap+b/yyisFyqfg+dZbb9vNN/ezm27qZ3l5ubb33nvbmDFjy3xZEBQBAECFsHPVKpaRnm65eXllPm/VBGrQ7XhkZWXZoEGD3SPW0Ud3sDlzvvC+TxexBBeyhNWvX99mzpxZ4LmJE98t9PM1XqMescJjKOqK6Pfe+6+VN4IiAACoEGrVqG4P393P1q3//6FiirJbnVqWlVl0U3KAO7OUDkERAABUqLCoRzz22Wt3q1ypUrmXaUfGgNsAAADwIigCAICE2BKJWCTRhfgLi0T+WLoFB8YpGZqeAQBAQujeyxs2bLTcnM2WkVnyJuSc7OxtCkF/9ZC4YuUfF7+kpZc+7hEUAQBAQmjg6BGv/sd6n3mSVamyU4lDX17OJsvIyCin0v01VK9Vy1JTS9+ATFAEAAAJM2/hErv7kRHuquTUlJJFxQE39LEGe3JzAZ+UP2sStyUkCkERAAAkvGZx2e8rS/w+9cAr7R1HEB8uZgEAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeKVEIpGIxeGT6ePNctfFMyliLNtUzdZvzk90MZLSbnVqWWZGeqKLkXQ25kUsz9ISXYyklL12lW3atCnRxUhKu9etbZUrZyW6GElp2e8rbMMG1ruSYp0rvXYtm8c1XdxH4Kz0Ldboh77bUKQd16IaI+yBR0ckuhhJafig/nZgk8aJLkbS+ezrefZF/p6JLkZSqp+zzB549NlEFyNpt9fGDfdLdDGS0s+Ll7LelQLrXPmj6RkAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXimRSCRicfhk+niz3HXxTIoYyzZVs/Wb8xNdjKS0e93aVrlyVqKLkXR+W77SNm7KTnQxklKdWtUtMz090cVITilm6Sy7Uln2+wrbsGFToouRdDhGlF67ls3jmi7uLTorfYs1+qHvNhRpx7Woxgh74NERiS5GUho+qL81brhfoouRdH5evNTue/ipRBcjade5A5s0TnQxktIPc+ezvW7DNvvAo88muhhJh2NE+aPpGQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeKZFIJGJx+GT6eLPcdfFMihhr0vayHMtMdDGSUrpOZVLTE12MpLNpzUrbtGlToouRlCplZVp+fn6ii5GU0tLTLD+PZVcaqamplp2Tm+hiJJ3d69a2ypWzEl2MpNSuZfO4pov7CJyVvsUa/dB3W8q0w5q+/wT7asu+iS5GUmqWsti+yN8z0cVIOvVzfrUHHn020cVISrdcfRHLrpRYdqXHsiud4YP6W+OG+yW6GH9pND0DAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8EqJRCIRi8Mn08eb5a6LZ1LEyE2pbGmWl+hiJKV8y7A0y010MZJOfiTdUrZsTnQxklIkNctStmQnuhhJiWVXeiy70onkVbW03C2JLkZSOrzryXFNlx7vDLPSt1ijH/puS5l2WF/XH24H/cSyKw2W3TYst4Ust9Jg2ZUey670WHal82XtZ2y/p4cmuhjJKc6gSNMzAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALxSIpFIxP8SAAAAdmTUKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwHz+D1xQkdUjdVVBAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAooAAAIDCAYAAACDyz+cAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOy1JREFUeJzt3QeUFFXaxvF3MgiiZLMgQREVBCSoKIiioqgoGBZRMSLmhIEVFSMoiAl3TYCsWTCwC6JLEjNBjGsABAQRJedJ9Heeq9VfTXNnpmeYoafl/zunD0N3dfXt6gpP3XvrVkokEokYAAAAECM19gkAAABACIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAK90/9MAgHj997//tQ8++MDq169v559/fqKLAyQ1tqeKhRrFHdgFF1xgKSkp7jF16tTo88Fz9erViz43cuTI6PN33nmn7ai0nLQMtOzKg5Z5sJwrItaDrX3//ffWrVs3Gz16tHXs2NF2VMG6uyMpbB/6V5CobZ3tqeJJ6qDYp0+f6IqsxwMPPFDk9FrZw+EHFcvChQvdb6qzyKysLKtZs6a1bt3a7r///jKZ/8qVK61fv37WpEkTq1y5smVkZNhee+1lZ511ln3++edWnmbMmGG9e/e2Bg0auM+uUaOGHXrooa48//vf/8r1s//KvvjiC+vbt681b97c0tPTo/sCHeRiLV261AYNGmTHH3+8W8f0O+y8887Wrl07GzFiRKk+f+PGjda9e3fbbbfdbNq0abbPPvsUeH3BggVuv6PHm2++Werv+VcOWKmpqfbNN98UeL1Dhw7R1995552ElRPbV3Hb0/amY8att95qRx99tO20007RdbKwigLdEfmf//ynHXbYYValShWrWrWqtW3b1v71r39ZMkvapufc3Fx7/fXXCzz38ssv2y233FLguY8++sjy8vLsqKOOKvD8b7/9Zv/+97/twgsvtB1V//797eKLL3Z/H3zwwQkty4cffmhdunSxtWvXFthIg4c21m2RnZ3t1oHYA9KSJUvs1VdftbffftutKwpvZU3rpAJK2ObNm23VqlU2Z84c++GHH5ImROg3mj59uvs70TtxmTJlij355JNxTasDT+z+QT755BP3UOgcNmxYiT7/q6++cge2Sy65xPbYY4+tXldQvOuuu9zfakI77bTTSjT/HYEOrvfee6+9+OKLiS4KEqy47Wl7W7RoUbEVUGEKkM8//3yB5z799FP3+Pbbb+2+++6zZJS0NYrvvfeerVixosBz2tF/9913BZ577bXX3NmAVj7ttBUaBw8ebI0aNXJn+evXr7eKYsOGDdv1c7QMjjzySPfYZZddLFFWr15tPXr0cCExLS3N1Sq+8cYbribhiSeesJNOOmmr96gGaOLEid756YRB7w/TtEFI3HXXXV2zhk4UmjVrFg1uzz33XJl/t4ceeqhASFTt5dixY10fHAUcLftkUqdOneg6UxGCon7Lrl27uh3wEUccUez0lSpVsosuusjGjBnjfn8F38Cjjz5q8+fPL9Hnt2nTxu64444KcVBLZjpZ+/HHHxNdDCT4eFfRtqfMzExXwaATzOIqlSZPnhwNiXXr1nUnPq+88kr0uyhwqmUpKUWSVK9evSIqvh5nn3129O877rhjq2knTZoUOeyww6LT7LrrrpH7778/snHjxiI/Iz8/P3LPPfdEmjZtGqlUqVIkKysrsvfee0e6dOkSeeaZZ6LTnX/++dF5T5kyJfr8iBEjvOU6+uijo8/PmjUr0rt370jNmjXd/4vz2muvufKoLPr3lVdecfMO5qfPDOy7777R5xcuXBg5/fTTI9WqVYvUq1evyHIHz+n9xX0XmT9/fuTiiy+O7LPPPpHMzMxI7dq1I2eeeWbk22+/jcRj8ODB0XnffffdxU7/+eefR9LS0iI77bRT5MMPPyzw2vjx4yMZGRlu+cydOzf6/PPPPx/9jO7du0eff/zxx6PP9+nTp9jP1nLStFp2xVmxYkWkatWq0fnfcMMN3unCyyn8m/3+++/uc7S+aj5apppnrDfffDPSqVMnN52Wf+PGjSN33nnnVut3eL2bOXNmpGfPnm6+devWdb/pli1bIl988UWkQ4cObn3Xuv7II48UmEc867TmceWVV7r1QPM54YQTIgsWLCh2ecXO56effoqUxFlnneXdDsLL+eeffy7w3ObNm933D96n7Ske77//fqRr166RWrVqufVNv9s111xT4PcJf5fYR7D+TJs2za2PDRs2jOyyyy5uXrvvvnukR48ebjmGhbfz5557LjJ06NDIfvvt59b1Fi1aRN59992tyvnbb79FrrvuOjd/rRtaR7T/+vjjj7ea9h//+EekZcuWkSpVqrhp99hjD7deDRo0KK5lEqy78Qjve4KH9oO+ZTdhwoQC750xY0bkjDPOiNSpUye67G+55ZbIhg0bIosXL46cd955bt3Td2jQoEHkpptuiqxatSqu9aywfak89thjbnlrndbxRMeVwvah+lvLrnr16pH09HS3nug9V199dWT16tXFLp+cnJzIkCFD3O+q/ZwerVu3jowePbrAdFpmweerfAH9ZsHzl156abRM4fXvnXfecb+31h8dEx5++OEC8y5qn//jjz9GLrjggshee+3lfoMaNWpETjzxxMh///vfAtPFfuaYMWMizZo1c79NeJ7xbE+yfPnyyGWXXeaONZpO+69GjRq5DDB16tRil2tRv29xnnzyya2237Abb7wx+rr2v4EHHngg+ryOk8koKYPipk2bIjvvvLNb8Noh/Prrr25j1P/333//rabXCtSmTZsCQVEbkuZTlIEDBxa6oz/iiCPKJChqxxOeb1G0kaWkpGxVFm14xQXF8OcEAbAsgqKCrpanbxlpI/70008jxWnfvn30PXfddVfkoIMOcjtj7Qx0APD9Ttrggt9yzpw57rkPPvjA7VD1vA4OsWE2WEf0Hu1w//3vf0eXXWpqqjtol2VQDIdThYA1a9YU+57wb9akSZOtlqnCXdjtt99e6Dqq5Zqdne1d73QAjZ3+qquu8v6W77333jat07HbS6KCYmHCJ5FaJ4rz9NNPu/XFt8x10AoObvEERZ2wFjaN1uXwSUT4IKf9XOz0OnDqgBvQyaEO5L55a9q33nrLu67GPvbcc89yDYqtWrWKlik4oSgsKI4dO9ZN5ytnu3btCv2+BxxwQGTlypWlDooPPvigdxmGt9FgH/rdd99FKleuXOjyVMgqLiQqZBb2/n79+kWnVejU76PnVQmwZMkSd4IcfL4C4Nq1a7cKbdr+dbIdO2+tj8Vt69qnB8ff2IeOT8OHD49OG/7M+vXrFzh+BfOMd3uSY445ptDl0r9//4QGxUsuuST6utaXgAJ88LzWl2SUlE3PajJat26d+1t9flTNq87PwRVT4QsTbrzxRvfa7rvv7voI7bnnnnbzzTfbPffcYwcccECRTc9vvfVWtHlLnVHVXKiqZTWNan5l1QdCVe1qGn344YcLnS4/P9+uvfZa159H1FT7n//8x66++mrX5F6cZcuW2dChQ+3dd9+12267rUzKrrJomarpWG644QY3fzW1qglZy1YXcARlLoz6bgS0LL7++mvXFBz0Dzn11FO3moc6DJ955pnuszt37uz6q6qJWp2h1e9S3QvCdPHCCy+84JpO9Z5evXrZySef7JbdQQcd5Mod2491W4V/l0MOOcSqVatWovernFrvhg8f7ppAgmb1NWvWuL/VjHH33Xe7v7U+Pvvss665PmiqV1/CwtYpbT8vvfRSgT4zjz32mOtErmb7yy+/vMCyLonff//d/vGPf7iya9sJ+qDG9g+tCH766afo/kIdz9u3b1/k9OrTeuWVV9qWLVtcM/aQIUPcMte6KGo+DfpBanmqOTtw4oknut9ED/UPFl2spenUR1b9LdWlJuiqoHW5sN9v7ty5NnDgQLcv1MU5Qb9t7SMCushn8eLF7u/zzjvPlVPdHfQ9Na2a0oLmv2BfpwuC9NtNmjTJbS/aprXtlCeVbe+993Zliu3LG6b9ifquabrg+2kfqOfk448/dt9XFyhpmWqfqv2PqEtSafs5qy/xgAEDov+/6qqr3OeqG4nvQjT9hps2bXJ/X3PNNW5Zav+kY06rVq2KvTL8kUcece8RXQih7VHv33///d1z2repz5uoy9Azzzzj/lbXHR0PdHzS5+tz1J1GyyPWvHnzXPn1Pa677rro8+qOtXz58kLLpv2wlmlw/FWXLs3j9ttvdxcl6XWtgz///LN3W9P3V3cw9cnWtlaS7UmfqW1E1Jdc28yECRPc+nrGGWe4i0cSaf8/fx/Rvk/r4i+//GKjRo2KPu9bLkkhkoTU7BAk9IkTJ0abTXxnXNOnT49Mnjw5ejYR1JKpFvKpp54q8nPatm0bPaNWU42aNny2pUbxtttui+s76ywueM9uu+3mzjpjyxl7lhSunfJ9122tUVQTcPBc8+bN3bIOHjq7DzdzFiV8ZqumGtVu6KG/g+fVvBpLy0DNmuGzSjXPqsuAj5qpwzXLwUM1jX379o3k5uaWaY1iUOuph2q74hH+zd54443o8+HvGdSgqmkmvB4Fy37cuHHR51U761vvwutDuHlczWmiZu/wb1uSdTrchKXm/KJ+w7JU0hpFNWMdcsgh3qa7wui7BdPfeuut0edVc6smWz2v2pa8vDxv01ss7VPUTHXwwQdHa8PDj0MPPdRbGxKuWVatUvi9ixYtcrUwQe2N9hfhbbNbt27RaV9//XU3j6D7juaj5sN4ar/LqkZRNTVBrYuaQVUr5qtRVG1i8JyaTMPUDSe8nIPvqhrWYNmoVj/4XUpSo6juCMFzqn0OaF5q9Yjdh4aPRcOGDYssXbq0RMsx3EL06quvRr9LuIVLXTvCLrroIm8LQVh4XVS5g2UhqvEPXtO+t7Btffbs2YUeh8LH5WAfEP5M7Wdim5JLsj2pK01Q83jccce52vZ49tll5cliahTVzUNN57G/Q+yxJhklXY2izip0BiMaYuSYY45xf59++umuFkvUgTSogVKne99YTKqFDM5EC6NO76KzHg2hoTPxhg0b2mWXXeauVC0L6ogfj3An+xYtWrihXQIqW1l9TkmEl4Gu3tUZYvDQ2X2guOFfNBROQDVZqu3TQ2fGAdXmxtIyUI1N8LvrjFRXrerMNpZqFLSu6ExcNcmqedbV1Dpz1QVOqrWLrYXcVuELhHRmWVK6CCugoYICQQ1uePmrZjBY9uHfOvbiroBqsgLVq1eP/q0zfqlVq9ZWn1dW5a4INFSOyvnll1+6/19//fWuZqM44WWuYZuC4TK0Dge1c9pHxft7n3POOa4WR1d7qgYxVmHLTJ3+w+tZuDZD+wrVOAb7wF9//bXAthm+0CvYNlVLpO+hMhx77LFunqrlO/fcc23mzJlW3tQKoNpsjU7w4IMPFrvsw98/dn1WDU7wXdVKECxX1cTrdy+p8L5Xw54EtN9p2bLlVtOrBSRY71W7ptp+HatUo6zatOKEv6f2T8F3Cddqxu5T1Vqk1rKAaoGLulpX23mw34xdfkVd0BUuW+xxKDwP3/FRF5tpOZR2e9JwVtpeglrbAw880A1Zo9pFLZugpSVRateu7Y5T4ZEz9F1U2xkIWliSTdIFRVVZq1lSdKDXiqofQ02Kap4NxuMLB5WAdsi68rkkOy9VbSu0qHlSzX+qsn/qqafcQSbYiYebEoIySFFV+OHAWlKlGdS2NJ+zva7mDl89u++++3r/Dg+bE16+2ilrmWunp/XilFNOiTaLhOkqZx2EgoNi48aNXUBS01qgrIeoCa6oFgUSX7mKEg5wahIMFNeUH6YQHHzvwkJsOFj7msdL8nllVe7ypP2DDrxBU7iattTkVVI6SGk5+h7BPqoo6lqh5jPRSahOVjRoc3jgZjXJxaO0A10H26a6b6h7gE6edaDTd1PTmZqfta8r6dXgJaWTPHUTEu1f1X2hJOL9/sH33ZZ9dnGfq8A7a9Ys18VJFRUKjWq+DppU1X2krPep6lqk42F4+Dc9F6+yGCi9uHkUdwyKZ3vSaBfqCqP9vMak1W+nSgp1wVFTeqI1a9bMZs+e7ZrZ1TVII7Oo+0GgadOmloySLiiqX1U8ymJj1IHthBNOcP0SdcavPjJBHyCdpWvcvdiDrp4PxDNQbLwbqDaKgPpUhXduvlBc2s8pCYWtgA4mf14cVeChHZpqYIsSHtZEB0/f36rdCFNw1G+jM2ttnOrXqNpe1X6oRi3oI+Q7AIT7pYbDW1kPlaS+ggoAorNd9VHyKe2A2+Hlrx1oYcs/XGO7o1NNskKiTviCWoySDOgeXuaqhdTJYuxD662GnooN4bGhTy0VAfUzVG26tqN4fq/PPvss+rfWLX2vwH777ee2hWCb175DJwyx60ZOTo7r5yj6v1omFNJ0oNN2EYRn1chtj0Gv1YKgmmx9Xrjfsm/Zh79/7P///ve/F7otBDWvvn22fh/VVMXS8gyEa1e1D/bVtuqzdJKrGj31R9W+JzwsiobHKkr4eyqg+75L0IcxKLdOfrXPC2oJ9V3VIlbYyZmCbHh9DPo8xn7fosqm45DWK988wtMVdQwq6fakE89LL73U9alVrbkC+OGHH+5eUz/z7TXEXHF0Yw/V2uqkWUOkBdQvPhkl1YDbSufBhqwOurGDV2rHF9QQqYq/sGbIeKmjrj5HBxbdwUMbRXjHENTUaKcc3klp5VaIDG/M20rV/ApL6gyranh1AO/Zs6frsK3BghNBAU01rQppGsxYZdJFNqrlVc2tdt5q5tLGXFzNrTpda6emzvZqGhZ1Ug6Eq++1Q1QY1M5OOxDtIFSjrHVDZ/Aqi8qhzw6aRsJnchqbUTtDnenr4pmA7u5RltTMovnfdNNN7v9q2tbvp1oF1dyp2UU1NipHaWoz//a3v7mO76IO6apR0EUzWv8UhLRcdMAqj/Ehy4suPNPvJzorL+5OSqodDA7CwYUbou00COkaK1G1FQpTaopUbYto+9H6onvKhg9cWpeK2ieoBlLbvi680P5FJzoKNyqvmp70WtBVIly7qs9RC4X2KfqccI25xmDTSbAO9PFcbKZptZ2o9u/xxx+PHiD1/+CkSk2d48ePd+uCamAUHPTZWmY6yCuw6CRTy1gXQahZ9rjjjnPv1wE5GFhdfLXSZU0XI+hEXPtQH5VN25TWc/2+uqhEv61Cg/ZBAW1nKr+Cb/C7aF+soDJu3Lit9tmaj/ZBujDI12Sqz1WNp2q1tE9TGRXsVRkRPpkN/zbad+lCSzUBK5Tq9413WWq9DC6EU7DQ3Zt0/NHvo64k+r46zgV3B9EFT6oNFpVN278ubNOFH6qlvuKKK7b6DK0DuhBR+xAtm+D9OknRCXhhtI/Una10cqvyqKwqh0Ji0KVBLW/h/XVRSro96aRH89axR+MTalvWdKLjh6Yt6qIWtSoGA+Dr5Lq4W7GqHOPHj3d/hy+S1fILbvih7gjBtqzfXNuguiRofVFLVtBqoC4IwQ0ukk4kiYQ7CavjrI863gfTxI7pVFJFDVGgsdeC8bDUKT58QUDwCA+dUFjH/5IMAVLY8DjqCO/rxB++MMKnvIfHKeqzY2k4m8Lef/PNNxeYVsNP6DM1zp+GAAlTB2eNSanfR536AxoiQmPJFfYZ6jD99ddfl+nFLAGVv6jlc+qppxb7mxX2WxU1PE5sOQtb7wr7zJKsB6UZl86npNtGuDyFPYL5xDNtPGUsajgPPfQdAupsr07/hX3OSSedtNVr4QsLwss+vCzDF+GEO8qH142ihseJXTa+iyGCh4ZamTdvXrlezBLQPlUXnYQ/P3Z4nGCYq9iHxhks6vsef/zxBfYTvt9Qw+j41oXwWHjBQ+8PDwUVLHsNvVXUMn/ppZeKXDa6kKOoY0+4bNoXaiixYPgZXRylMSM1Fqee0wUhGhos9sISHZt8wwxp3ODyGh6nsH1mSbYn35A+vt+3MCXdH2n7sBLsM8IXIoUfGrpIw7clq9RkbXbWGbJPuCP/tjY/a/gF9XvQWYxqJ3SWqg7DOotS7UDQfBHUCKk2R2dTml61VjoTLEu6YEd3MFAnXn2Ozuw0+nunTp2i06jmZHtSTaf6iKjZSLV0Kpc67KqmUc/FW6uqWgB1QtfZmb6DHuqwrmEGYjtlq/lIFzSpBjH27iBaJqplVW1auLlaNSmqedWZuGpiVEOg31Nn6uqDqpqC8uo/ovJr/jqDVw2DPlvrjpaRagK35V7WwRApqgXQeqgaVK2jqinT5wZnzyg7qhV4//333faofldaj/SvOvNrmBDV4gT0mmoU9Hv4hilRjYPWCzW5arvRuhjUehVF641qErWv0TanWgytB8EwYaJtQ7UgqtEO1nmVQX+r9l/lCrYR7dNUDm1bWjdVs6maVdWQqGaxqObIsqTPVu1mYbp16+Zaa7TsdfGA1nfViKpWSrV2qhnTBTjqJ6jX9K/2I6pJCmrfg/2EavNVs6jlp21R+9bC+rmpv6Her89SrZtq1lSz5xtOSTWZ6pemfaN+Vy1LfS9Nqwstzz777CKXgcqjpn5dqKd1Sr+ZfjvtO9SdRbWFWg5qOlaNWNB/T7WY2m9qPQpua6maZt8QZZqvPkP7W30f1Yipq0EwbFNR9F615gTDzWkdV8259kHa74aH1irr7UmtiKrN1X5b5dZD66zW8XguFCpvPXv2dLWJWh76HbUNqqlcfdTjuXNURZWitJjoQiA++ql8/Tw01lbQP0T9i8rjfsX4gy400FX02kmOHDky0cXBDqSkzWbbm0KUmuQ4pFTsfZew/0JJJFWN4o5OZ/YaHkA1Ztohqx+L+p8EIVFnVuErbQEAAHaYi1l2dGpqUHO6r0ldzRM6Q9yWi3cAAADCSBVJRP2E1P9G/ZLUF0X9M9THRn1CVLuoJmgAAICyQh9FAAAAeFGjCAAAAC+CIgAAALwIigAAAPAiKAIAAGDbhseZ9uUsW7VpXbyTI6TylqqWmVE50cVISnm5OZaekZnoYiQdllvprV+13Lbk5ye6GEmpxq7VrGqV7Xt3qL+K7Jwcy8pkmy0pllvpHXrwgWUbFBUSb/ll1DYUacf1YO2+Niu3dqKLkZSapS62GSy7EmO5lV79DYvsvoefSnQxktLwQf1tn332SnQxktIPc+ez7EqB5Vb+aHoGAACAF0ERAAAAXtzCDwAAJPwWtfl5eVbyO4BELCcnp1zKlOxSzCwtPX2bb+1LUAQAAAmzefMmW7V8eaneWzk91Vb8tqzMy/RXUr1WLatUqfQX1BIUAQBAwmoSFRKrVq1qNWvUtJQU1YPFj6ueC6c7NK9YucIt37p77FnqmkWCIgAASAg1N4tCYuXKpaj1SkmxSllZZV+wv4iaNWra+vXr3XJOLWWg5mIWAACQEEGfxJLWJCI+wXIted/P/0eNIgAAqDCWblxhq3LWxzVtTm6OZcZ5c4HqmVVt951qWln56KOPbM2a1XbiiV3sr4ygCAAAKkxIPGlKf8vZ8keTdFnKTE23/3S8t9iw2LBhA8vKyrKsrEq2ceMGO/DAA+3GG2+yww8/PDrN5MmT7KWXXrbHHnuszMu5evVqe+qpf1q/fjdbRUDTMwAAqBBUk1geIVE033hrKl944UWbPXu2fffd99ar13l2yild7dNPP42+fswxnezpp5+2SpUqlWkZ8/LyXFAcPHiwVRTUKAIAABSiW7duNmPGZ/bww0Nt9Oh/2R13DLApU6ZYTk6uNW7cyIYPf9KqV69uF154obuy+Pvvv7MVK1ZYmzZtbfjw4e4inZdeeskee+xR9x5d6T1w4F128sld3fw7dTrGDj74EJs5c4abNjMz09atW2ctW7a09PT0AgE1EahRBAAAKELr1m3s22+/tSFDHrIqVarYxx9/YrNmzbKDDjrIBgwYEJ1OgXL8+An21Vdf26pVK+2RR4a55zt37mwffviRzZw508aOHWt9+vSx7Ozs6Pt+/PEHmzJlqr333n/tiSeG28477+zmn+iQKNQoAgAAFDMmobz11lu2du1aGzv2Dff/3Nwc23fffS3QvXt3F/Kkd+8L7fHHH7NbbrnVfvrpJzvvvF62ZMkSS0tLt5UrV7rnDjjgADft3/7W0zIyMqwiIigCAAAUYebMGda0aVP76acFNmzYMDvuuM4lGp7m3HN72r333mdnnHGG+3+dOrVt8+bN0ek04HhFRdMzAABAId5++2375z//addee52deuop9sgjj9jGjRvda/r3m2++iU47ZszYPwa4zs+3UaNGWqdOndzzq1atsnr16rm/X3jhBff/wlSrVs02bdpUYe5hTY0iAABASM+ef4sOj9OkSRN7++1x1qZNG3eBSXb23W6onKC28KabbnK1jdKqVSvr0uVEW758ubuY5eqrr3HPDx36sJ199lm2yy67WseOHWyfffYp9LNr1Khh557by1q0ONSqVKma8H6KBEUAAFAhaFBsjXdYXuMoav7FmTt3XqGvpaen25133uUePgcffLA988wzWz3fs2dP9wg8+OBD0b8nTZq81fSqwawoCIoAAKBC0GDYGhQ7Ge7MsqMgKAIAgApDYS7eQLc5O9sqZWVZRfDcc8/ZXxEXswAAAMCLoAgAAAAvgiIAAAC8CIoAAADw4mIWAABQYeT/vswia9fEN21ujuXFedVzSrVdLK12XatoJkwY78ZX1NiMFRFBEQAAVJiQuOqKXma58d+VZFO8E2ZkWvUnRscVFtetW2d7772X9ehxpj399NNxl2XcuHE2deoUGzJkaFzT6y4tX331pd133/1WUdH0DAAAKgRXk1iCkFgiuTlx11S++uqr1qJFC3vzzTfcLfl8dJu+sLy8POvatWvcIVE0CPcDDwyy1NSKG8cqbskAAAASYMSI59yt+dq3b+9Co4waNcqOPbaTnXlmD2vevLl99tlnlpGRbnfddae1bdvW+ve/zU1zxhmnu+lPOOF4GzNmTHSe06ZNdbf4C2osL7vsMmvXrq0deuih1qdPn+i9nX/99Vc755yz3Wv6nAEDbrdEIigCAAD86dtvv7XFixdb587HW+/eF7rQGFA4vPvue2zOnDnWrl0791xaWpp98sknNmjQ4ALzOf/8C+z550dF/z9y5Ci74IIL3N8KoUceeaR9/PEnNnv2bNuyZYs99tij7rULL+xtl19+uXtt5syZNmvWLHv99dctUeijCAAA8CcFw3PPPdcFwBNPPNH69r3c/ve//7nXFA7333//AtNfcEFv73xOO+00u+66a23p0qW288472/jx/7GHHvrjHs9vv/2WC5fDhg1z/9+8eZP7vA0bNtjkyZNt2bLfovPZsGG9/fDD95YoBEUAAAB1Y8zNdReYZGRk2Msvv+ye27hxowuPTZseZFWrVt3qPb7npHLlynbGGd3thRf+ZbVq1baOHTtazZp/3JowEom4Ju3GjRsXeE/QH/LDDz+0SpUqWUVA0zMAAMCfVy3Xr1/fFi5cZHPnznOPDz740IVHhciSOv/8812/RTVBB83Ocsopp9qDDz7oLoCRVatW2dy5c13o7NChgw0ePCg67S+//OKawhOFoAgAAPBns/M55/ytwHNNmjSxPfbY012AUlKtW7d2Tcrz5s2z447rHH1+yJAhrsaxVauW7mKWzp0728KFC9xrzz8/2gXU5s2buYtZevTobitWrLBEoekZAABUCBoUW+MdlssQORmZf8y/COPG/dv7/IwZM9y/1113XYHnc3P/qBEM1yDqETZnzhdbzU81h48++sfFK7Hq1Kljzz//vFUUBEUAAFAhaDBsDYod73iH2bk5lpXkd2ap6AiKAACgwnBhLs5Al5edbelZWeVeph0ZfRQBAADgRVAEAACAF0ERAAAAXvRRBAAAFUZk/WKLZK+Mb+KcHNuSGefFLFk1LKXqXttWuB0QQREAAFSYkJj9Zjuz/Oy43xP3QDppWZZ12sdxhUUNhH3//ffZK6+8Yunp6ZaWlm6HHXaYu6XfwIED3f2Xy3PQ76lTp9iQIUOtIiAoAgCACsHVJJYgJJZIfrabfzxB8ZJLLrFVq1ba9OkfWPXq1d0t98aMGWMrV8ZZ07kNunbt6h4VBX0UAQAA/qRb6Y0Z87o988yzLiRKSkqKde/e3fbbr77l5+fZlVdeaS1atLBmzQ6xmTNnRt/77rsT7eijj3J3ZGnXrq2rGZRp06a6O61cccUV7k4suuPKl19+aRdeeKH7+/DD29mSJUvctLrl3xlnnF7gfYV93vZAUAQAAPjT559/bg0bNrJatWp5X//uu++sV69eNnv2bOvb9wobMOB29/z8+fNds7Tu7vLZZ5/Z6NH/ctNlZ2dH36dgqPmfeuop1rnzcdavXz+bM2eOtWzZyh599JESfd72QlAEAACIU8OGDa1Nmzbu77Zt27qAKBMnTnT3dO7YsaO1bNnSzjrrLEtNTbVFixZF36fnRcGwQYMGdsABB7j/q/+jajJL8nnbC30UAQAA/qSm4blzf7QVK1ZYzZo1t3o9K6tS9O+0tDR34YuoH+Oxxx7rahJj/fLLkpj3pVqlSv75xPt52ws1igAAAKEavG7dTrdLL73EVq9eHQ2BY8eOtfnzfyr0fZ07d7ZJkya5vocBNUEnO2oUAQAAQp555hm777577YgjDnfD42zZssWOPLK9nXDCCUUGzNGjR1vfvpfbxo2bLDc3x12o4qthTCYpEcXkOLz56VS75ZdR5V+iv6AHa/e1r7bsm+hiJKVmqYvtiy0MkFpSLLfSq79ylt338FOJLkZSGj6ovx3YpHGii5GUfpg73xo33M92NDk5Obbit2VWb996rim2NOMoWjmMo/hXsXnzZluwcIHVrFPXMmMGJq+5S7W45kGNIgAAqBAU4hTm4r0zi4JmbAAqdN7cmaVUCIoAAKDCUJiLO9BlZ1tqVlZ5F2mHxsUsAAAA8CIoAgAAwIugCAAAAC+CIgAAALy4mAUAAFQYa7PzbWNuXCP3WU5uvmXmxnenkp0yUqxaVpolm7Vr19rIkSOtT58+cV/hXZYIigAAoMKExKdnr7b8+HLinzbFNVVaitklLXYtNiw2bNjAsrKyrFKlytHnFNQOPvhgK6lRo0bZ22+/ZWPGjLXS0J1hLr+8j916620JCYlCUAQAABWCahJLFhLjp/lq/tXiGE3nhRdedHdVSQTdBUZSU1Nt1113tZdeetkSiT6KAAAARfj++++tXr19bf78+e7/Q4cOsZNO6uJCnWoNjzvuWOvW7TQ75JCDrWPHDrZgwQLvfIYMeciaNTvEhdBevXrZmjVr3PMDB95lZ57Zw7p0OdGaN29mS5cutXffnWhHH32UtW7d2tq1a2tTp06xRKBGEQAAIKRnz78VaHr+4IMP7IEHBtk555xjgwcPsieffNI++uhjV+snH330kc2cOcuaNGliDz30oGsunjDhnQLzfOedCa4Je/r0D1xNofoc3nbbbfbEE0+41z/55BObMWOm1a1b1wXSgQMH2vjxE6xatWo2d+5cF0Dnzp3nmsW3J4IiAABAMU3PZ599tk2dOtW6dOliEye+a7Vr146+1q5dOxcS5eKLL7EBAwZYfn5+gfdPmjTJevTo4UKiXHbZZXbOOWdHXz/hhBNdSJSJEyfavHnzrGPHjtHXFUoXLVpkjRo1su2JoAgAAFCMvLw8++abr61GjRr2yy+/bPP8UlJSCvy/atWq0b8jkYgde+yxNnr0vyzR6KMIAABQjNtuu9UaN97fpkyZajff3M81BwfUbPzdd9+5v5977lnr0KGDpaUVvLq6U6dO9vrrr7vhbuTpp5+2Y489zvtZnTt3djWQX375ZfS5zz77zBKBGkUAAIAi+ijedded9u6777p+iTvttJM9+OBDrr/i9OnTo03PCpJqLlaN44gRI7eap5qWv/nmG2vf/khLSUl1w+08/vjj3s9v2LChjR492vr2vdw2btxkubk5rik8ETWMBEUAAFAhaFBsjXdYHkPkaL6af3F0wYjPySd3jf7dvXt39wjoghPfWInnn3++ewRuuOFG94g1YMAdWz3XqdOx7pFoBEUAAFAhaDBsDYod/51ZciwzI/MvfWeWRCMoAgCACkNhLp5BsWVzdr5VykpslDk/ptbwr4aLWQAAAOBFUAQAAIAXQREAAABeBEUAAAB4cTELAACoMJYu+91Wr1lX5lc977rLzrZ73f+/7R7iQ1AEAAAVJiSedsHVlpOTW+bzzszMsDdHPhpXWMzJybE77hhgb7zxhmVkZFhaWrpdf/31dt5559m0aVPt+utvsFmzZsX92XrP5s2b7fjjTyh1+RcsWGCtWrW05ctX2PZEUAQAABWCahLLIySK5qv5xxMUL7roQsvOzrZZs2ZblSpVXEjr2vVkd7/nBg32K/FnT5s2zVavXrNNQTFR6KMIAADwpx9//NHeeuste/LJf7iQKPXq1bPBgwfbPffc7f6fn59nF1xwgTVv3sxat25tc+bMib73qKPaW4sWLdwt9wYMuN299tRTT9lLL71oLVu2dPNQ4OzS5URr06aNNWt2iPXqda5t2LAhWoaRI0e6aTUfTaOgGmvGjBl23HHHutdbtWrl7iNdHqhRBAAA+JOCXcOGjaxmzZoFnm/btp39/PPP9vvvy909m4cOHeoC3WuvvWbnntvTvvrqaxs+fLiddNJJdvPNt7j3rFy50t37+dJLL3U1inqPRCIRd99mfYb+vvLKK+2JJx63fv1uds3U9957j73//nTbfffdbePGje49v/32W7Qsq1evtssvv9zGjRvnplm+fLm1bn2Yu+f0nnvuWabLg6AIAABQAvXq1bNjjunk/u7Ro4ddfnkfFyLbt29vt9xys61fv96OOuqoQu/VrHD4yCPDbPz4Ca52ce3aNS7kyfjx461nz54uAMpOO+201fs//vgj++mn+XbyyScXeP6HH75PXFCsmbvZntmlS5l++I5ixdoVVj9neaKLkZQ2padZ/bxliS5G0onsWt2apS9OdDGSUnZmpt1y9UWJLkZSys3Ltx/mzk90MZLS78tX2s+Ll9qOJiM9zfberZat37jRcvLybMOmP2rPyouukt6cnV3kNE0OPNDmzv3RlvzyS4Faxfenv2977bWX7bLLLi7oheeTkpJiObm51uWkk6xFyxY2efJke+zxx23YsGE2ZuwblpeX75qrg/e8/PJLNmnyZBs/YYJVq1bNnhw+3Ka9P829npef76aPLWd2To77V89n5+TaAU2a2KRJk7cqf/h9eo+C6IJFP6uUBaZr17J52QbFqml51uinPvFOjpDxNUbYfcNGJLoYSUkH7AcefTbRxUg69w28zb7csleii5GU6ucsY50rpeGD+lvjhiXv6A9zIfHuoU/Zjmb3OjXt5r69LGv5SktNTbPlK1aV6+dpKJ1KWUXfSPqgpk1dTd11115jI0eOcjV66iP49/79rX//v7urpxcuXGiffPyRdejQ0caMGWN169a1BvvtZ3PnzrUGDRrYhb0vtMPbHe76K+rzqlevbkuWLIl+9vp1661O7drusW7dOnvxxRdtn332dq+fduqpdtFFF9kVV1xRoOk5K/OPYYA0zdFHHWVXXXmFffjB9GitpZrMDzzwQMv8czonErH09HSrt0fdgs+XAE3PAAAAISNGjHQXohx6aHMXsNLS0tyQOL1793Z9CJs2bWqjRj1v1157nXtd/Q1Vqzh27BgX+jIyMm3Lli32xBPD3fxOO+00e+GFF9wFKt26nWZXXXW1jRv3tjVteqDVqlXLjjzySFu0aKGbtn37o+zvf7/dunTp4uap+b/yyisFyqfg+dZbb9vNN/ezm27qZ3l5ubb33nvbmDFjy3xZEBQBAECFsHPVKpaRnm65eXllPm/VBGrQ7XhkZWXZoEGD3SPW0Ud3sDlzvvC+TxexBBeyhNWvX99mzpxZ4LmJE98t9PM1XqMescJjKOqK6Pfe+6+VN4IiAACoEGrVqG4P393P1q3//6FiirJbnVqWlVl0U3KAO7OUDkERAABUqLCoRzz22Wt3q1ypUrmXaUfGgNsAAADwIigCAICE2BKJWCTRhfgLi0T+WLoFB8YpGZqeAQBAQujeyxs2bLTcnM2WkVnyJuSc7OxtCkF/9ZC4YuUfF7+kpZc+7hEUAQBAQmjg6BGv/sd6n3mSVamyU4lDX17OJsvIyCin0v01VK9Vy1JTS9+ATFAEAAAJM2/hErv7kRHuquTUlJJFxQE39LEGe3JzAZ+UP2sStyUkCkERAAAkvGZx2e8rS/w+9cAr7R1HEB8uZgEAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeKVEIpGIxeGT6ePNctfFMyliLNtUzdZvzk90MZLSbnVqWWZGeqKLkXQ25kUsz9ISXYyklL12lW3atCnRxUhKu9etbZUrZyW6GElp2e8rbMMG1ruSYp0rvXYtm8c1XdxH4Kz0Ldboh77bUKQd16IaI+yBR0ckuhhJafig/nZgk8aJLkbS+ezrefZF/p6JLkZSqp+zzB549NlEFyNpt9fGDfdLdDGS0s+Ll7LelQLrXPmj6RkAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXimRSCRicfhk+niz3HXxTIoYyzZVs/Wb8xNdjKS0e93aVrlyVqKLkXR+W77SNm7KTnQxklKdWtUtMz090cVITilm6Sy7Uln2+wrbsGFToouRdDhGlF67ls3jmi7uLTorfYs1+qHvNhRpx7Woxgh74NERiS5GUho+qL81brhfoouRdH5evNTue/ipRBcjade5A5s0TnQxktIPc+ezvW7DNvvAo88muhhJh2NE+aPpGQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeBEUAAAB4ERQBAADgRVAEAACAF0ERAAAAXgRFAAAAeBEUAQAA4EVQBAAAgBdBEQAAAF4ERQAAAHgRFAEAAOBFUAQAAIAXQREAAABeKZFIJGJx+GT6eLPcdfFMihhr0vayHMtMdDGSUrpOZVLTE12MpLNpzUrbtGlToouRlCplZVp+fn6ii5GU0tLTLD+PZVcaqamplp2Tm+hiJJ3d69a2ypWzEl2MpNSuZfO4pov7CJyVvsUa/dB3W8q0w5q+/wT7asu+iS5GUmqWsti+yN8z0cVIOvVzfrUHHn020cVISrdcfRHLrpRYdqXHsiud4YP6W+OG+yW6GH9pND0DAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8EqJRCIRi8Mn08eb5a6LZ1LEyE2pbGmWl+hiJKV8y7A0y010MZJOfiTdUrZsTnQxklIkNctStmQnuhhJiWVXeiy70onkVbW03C2JLkZSOrzryXFNlx7vDLPSt1ijH/puS5l2WF/XH24H/cSyKw2W3TYst4Ust9Jg2ZUey670WHal82XtZ2y/p4cmuhjJKc6gSNMzAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALwIigAAAPAiKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwIugCAAAAC+CIgAAALxSIpFIxP8SAAAAdmTUKAIAAMCLoAgAAAAvgiIAAAC8CIoAAADwIigCAADAi6AIAAAAL4IiAAAAvAiKAAAA8CIoAgAAwHz+D1xQkdUjdVVBAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 660x520 with 1 Axes>"
       ]
@@ -3259,10 +3462,10 @@
    "id": "31c54d60",
    "metadata": {
     "papermill": {
-     "duration": 0.006083,
-     "end_time": "2026-04-22T20:59:08.312043",
+     "duration": 0.01245,
+     "end_time": "2026-04-23T21:51:12.441705",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.305960",
+     "start_time": "2026-04-23T21:51:12.429255",
      "status": "completed"
     },
     "tags": []
@@ -3291,10 +3494,10 @@
    "id": "97bc629e",
    "metadata": {
     "papermill": {
-     "duration": 0.005948,
-     "end_time": "2026-04-22T20:59:08.324521",
+     "duration": 0.010164,
+     "end_time": "2026-04-23T21:51:12.465803",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.318573",
+     "start_time": "2026-04-23T21:51:12.455639",
      "status": "completed"
     },
     "tags": []
@@ -3323,20 +3526,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "2a6adc42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-22T20:59:08.338132Z",
-     "iopub.status.busy": "2026-04-22T20:59:08.337915Z",
-     "iopub.status.idle": "2026-04-22T20:59:08.342562Z",
-     "shell.execute_reply": "2026-04-22T20:59:08.342015Z"
+     "iopub.execute_input": "2026-04-23T21:51:12.490532Z",
+     "iopub.status.busy": "2026-04-23T21:51:12.489644Z",
+     "iopub.status.idle": "2026-04-23T21:51:12.497259Z",
+     "shell.execute_reply": "2026-04-23T21:51:12.496138Z"
     },
     "papermill": {
-     "duration": 0.012547,
-     "end_time": "2026-04-22T20:59:08.343441",
+     "duration": 0.021323,
+     "end_time": "2026-04-23T21:51:12.498829",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.330894",
+     "start_time": "2026-04-23T21:51:12.477506",
      "status": "completed"
     },
     "tags": []
@@ -3426,10 +3629,10 @@
    "id": "conclusion-section",
    "metadata": {
     "papermill": {
-     "duration": 0.00708,
-     "end_time": "2026-04-22T20:59:08.357606",
+     "duration": 0.010786,
+     "end_time": "2026-04-23T21:51:12.520528",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.350526",
+     "start_time": "2026-04-23T21:51:12.509742",
      "status": "completed"
     },
     "tags": []
@@ -3479,10 +3682,10 @@
    "id": "nav-footer",
    "metadata": {
     "papermill": {
-     "duration": 0.007202,
-     "end_time": "2026-04-22T20:59:08.371858",
+     "duration": 0.00922,
+     "end_time": "2026-04-23T21:51:12.540026",
      "exception": false,
-     "start_time": "2026-04-22T20:59:08.364656",
+     "start_time": "2026-04-23T21:51:12.530806",
      "status": "completed"
     },
     "tags": []
@@ -3512,18 +3715,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.293368,
-   "end_time": "2026-04-22T20:59:08.702439",
+   "duration": 18.50276,
+   "end_time": "2026-04-23T21:51:13.004850",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed_output.ipynb",
+   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed.ipynb",
+   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-3-Informed_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-22T20:58:59.409071",
+   "start_time": "2026-04-23T21:50:54.502090",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary
- Convert Exercice 1-3 (full leaked solutions) to "Exemple resolu" format with pedagogical framing
- Add 3 new variant exercises with TODO stubs:
  - Ex1: `check_consistency` - verify heuristic consistency (stronger than admissibility)
  - Ex2: `make_inconsistent_heuristic` - admissible but inconsistent heuristic
  - Ex3: `nearest_neighbor_tour` - greedy TSP heuristic
- Papermill execution: SUCCESS (20.2s)
- Supersedes PR #487 (rebase had 72 JSON conflicts)

## Test plan
- [x] Papermill execution passes
- [x] Cell structure verified (71 cells: 65 original + 6 new)
- [x] No "Exercice 1/2/3" labels remain in renamed cells
- [x] Variant exercises have proper TODO stubs (no solutions)

Closes #463 (Search-3-Informed part)