### PR TITLE
fix(qc): yfinance MultiIndex columns + hardcoded paths (#488 M-58 M-65)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/EMA-Cross-Crypto/research.ipynb
@@ -99,11 +99,14 @@
     "\n",
     "# Charger BTC-USD depuis Yahoo Finance\n",
     "btc = yf.download('BTC-USD', start='2020-01-01', end='2026-01-01', auto_adjust=True)\n",
+    "# yfinance >=0.2.x returns MultiIndex columns (Ticker, Field); flatten to single level\n",
+    "if isinstance(btc.columns, pd.MultiIndex):\n",
+    "    btc.columns = btc.columns.droplevel(0)\n",
     "btc.columns = [c.lower() for c in btc.columns]\n",
     "btc = btc[['open', 'high', 'low', 'close', 'volume']].copy()\n",
     "print(f\"Données BTC-USD: {btc.index[0].date()} à {btc.index[-1].date()} ({len(btc)} jours)\")\n",
     "print(f\"Prix actuel: ${btc['close'].iloc[-1]:,.0f}\")\n",
-    "btc.tail(3)"
+    "btc.tail(3)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/research.ipynb
@@ -244,6 +244,9 @@
     "\n",
     "# Download VIX data (2015-2026)\n",
     "vix = yf.download(\"^VIX\", start=\"2015-01-01\", end=\"2026-03-04\", progress=False)\n",
+    "# yfinance >=0.2.x returns MultiIndex columns; flatten to single level\n",
+    "if isinstance(vix.columns, pd.MultiIndex):\n",
+    "    vix.columns = vix.columns.droplevel(0)\n",
     "\n",
     "print(f\"\\nVIX data: {len(vix)} trading days\")\n",
     "print(f\"\\nVIX Summary Statistics:\")\n",
@@ -260,7 +263,7 @@
     "print(f\"VIX < 15 (Low):    {int(count_below_15)} days ({100*float(count_below_15)/total:.1f}%) - Weak premiums, skip\")\n",
     "print(f\"VIX 15-20 (Med):   {int(count_15_20)} days ({100*float(count_15_20)/total:.1f}%) - Medium premiums, OK\")\n",
     "print(f\"VIX >= 20 (High):  {int(count_above_20)} days ({100*float(count_above_20)/total:.1f}%) - Excellent premiums, optimal\")\n",
-    "print(f\"\\nVIX > 15 (tradable): {int(count_15_20 + count_above_20)} days ({100*(float(count_15_20)+float(count_above_20))/total:.1f}%)\")"
+    "print(f\"\\nVIX > 15 (tradable): {int(count_15_20 + count_above_20)} days ({100*(float(count_15_20)+float(count_above_20))/total:.1f}%)\")\n"
    ]
   },
   {
@@ -350,10 +353,10 @@
     "ax2.grid(alpha=0.3, axis='y')\n",
     "\n",
     "plt.tight_layout()\n",
-    "plt.savefig('/d/CoursIA/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/vix_analysis.png', dpi=100, bbox_inches='tight')\n",
+    "plt.savefig('vix_analysis.png', dpi=100, bbox_inches='tight')\n",
     "plt.show()\n",
     "\n",
-    "print(\"Chart saved: vix_analysis.png\")"
+    "print(\"Chart saved: vix_analysis.png\")\n"
    ]
   },
   {
@@ -480,7 +483,7 @@
     "ax2.invert_xaxis()\n",
     "\n",
     "plt.tight_layout()\n",
-    "plt.savefig('/d/CoursIA/MyIA.AI.Notebooks/QuantConnect/projects/OptionsIncome/theta_analysis.png', dpi=100, bbox_inches='tight')\n",
+    "plt.savefig('theta_analysis.png', dpi=100, bbox_inches='tight')\n",
     "plt.show()\n",
     "\n",
     "# Print key statistics\n",
@@ -494,7 +497,7 @@
     "print(f\"Rolling at 7 days:  Capture ${theta_captured_7:.2f} in theta\")\n",
     "print(f\"Rolling at 10 days: Capture ${theta_captured_10:.2f} in theta\")\n",
     "print(f\"\\nExtra theta from waiting 3 days: ${extra_theta:.2f} (+{extra_theta/theta_captured_7*100:.1f}% more)\")\n",
-    "print(f\"\\nWith ~50 rolls/year: +${50*extra_theta:.0f} annual return from extended roll timing\")"
+    "print(f\"\\nWith ~50 rolls/year: +${50*extra_theta:.0f} annual return from extended roll timing\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fix `yfinance >=0.2.x` MultiIndex columns breaking `[c.lower() for c in df.columns]` in EMA-Cross-Crypto and OptionsIncome research notebooks
- Replace hardcoded `/d/CoursIA/...` paths with relative paths in OptionsIncome savefig calls

## Context
Reassessment of audit #488 (issue #499) confirmed 2 real bugs:
- **M-58 EMA-Cross-Crypto**: 12/17 cells error cascade from `AttributeError: 'tuple' object has no attribute 'lower'`
- **M-65 OptionsIncome**: Same yfinance issue + `FileNotFoundError` on hardcoded absolute paths

## Fix
- Add `if isinstance(df.columns, pd.MultiIndex): df.columns = df.columns.droplevel(0)` before column rename operations
- Replace `plt.savefig('/d/CoursIA/.../file.png')` with `plt.savefig('file.png')`

## Test plan
- [ ] Execute `EMA-Cross-Crypto/research.ipynb` cell 0 → should load BTC-USD data without error
- [ ] Execute `OptionsIncome/research.ipynb` cells 1-3 → VIX download and charts should work
- [ ] Verify no regression in other QC research notebooks using yfinance

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)