### PR TITLE
fix(ml): ML-7 Recommendation Purchased type mismatch (#488 M-45)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -1109,7 +1109,7 @@
     "{\n",
     "    public float UserId { get; set; }\n",
     "    public float ProductId { get; set; }\n",
-    "    public float Purchased { get; set; }  // 0 = non acheté, 1 = acheté\n",
+    "    public bool Purchased { get; set; }  // false = non acheté, true = acheté\n",
     "}\n",
     "\n",
     "public class ProductRecommendationPrediction\n",
@@ -1127,7 +1127,7 @@
     "    {\n",
     "        // Probabilité d'achat basée sur des préférences cachées\n",
     "        float purchaseProb = ((userId % 5 == productId % 5) ? 0.7f : 0.1f);\n",
-    "        float purchased = (rand.NextDouble() < purchaseProb) ? 1.0f : 0.0f;\n",
+    "        bool purchased = rand.NextDouble() < purchaseProb;\n",
     "        \n",
     "        purchaseData.Add(new ProductPurchase\n",
     "        {\n",
@@ -1139,9 +1139,10 @@
     "}\n",
     "\n",
     "// Filtrer uniquement les achats positifs pour l'entraînement\n",
-    "var positivePurchases = purchaseData.Where(x => x.Purchased == 1).ToList();\n",
+    "var positivePurchases = purchaseData.Where(x => x.Purchased).ToList();\n",
     "\n",
-    "Console.WriteLine($\"Total achats positifs : {positivePurchases.Count}\");\n"
+    "Console.WriteLine($\"Total achats positifs : {positivePurchases.Count}\");\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fix `System.ArgumentOutOfRangeException: Schema mismatch for label column 'Purchased': expected Boolean, got Single` in ML-7-Recommendation.ipynb

## Context
Reassessment of audit #488 (issue #499) confirmed 1 real bug:
- **M-45 ML-7-Recommendation**: `SdcaLogisticRegression` requires Boolean label but `Purchased` was `float`, causing error cascade in cells 9-10

## Fix
- Change `ProductPurchase.Purchased` from `float` to `bool`
- Update data generation from `(rand.NextDouble() < purchaseProb) ? 1.0f : 0.0f` to `rand.NextDouble() < purchaseProb`
- Update filter from `x.Purchased == 1` to `x.Purchased`

## Test plan
- [ ] Execute ML-7 cells 17-19 → model should train without SchemaMismatch error
- [ ] Verify Top-5 recommendations display scores (not NaN)
- [ ] Cell 13 evaluation should produce valid RMSE/MAE metrics

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)