### PR TITLE
chore(image): flag Cross-Stitch Legacy as NEEDS_INFRA (#501)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
@@ -16,10 +16,17 @@
     "4. Générer une grille adaptée, avec un symbole distinct pour chaque couleur, afin de faciliter la broderie.\n",
     "\n",
     "Les étapes suivantes vous guideront pas à pas :\n",
+    "\n",
+    "\n",
+    "\n",
+    "> **Note d'infrastructure** : Ce notebook necessite un service Stable Diffusion (SD Forge) pour la generation img2img. Les cellules de traitement dependent de ce service. En mode batch, une image de test est generee mais le widget interactif bloque Papermill. Tag : `NEEDS_INFRA`\n",
+    "\n",
     "- **Installation des dépendances**  \n",
     "- **Imports et configuration**  \n",
     "- **Upload de l’image**  \n",
-    "- … *(à compléter ensuite)* …\n"
+    "- … *(à compléter ensuite)* …\n",
+    "\n",
+    "\n"
    ]
   },
   {
@@ -840,7 +847,10 @@
      }
     ]
    }
-  }
+  },
+  "tags": [
+   "NEEDS_INFRA"
+  ]
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
## Summary
- **Investigation**: No non-Legacy version of Cross-Stitch notebook exists anywhere in GenAI directory
- **No archive needed**: Since there's no newer version, the Legacy notebook stays in place
- **NEEDS_INFRA flag**: 4 unexecuted cells (imports, upload/generate, block reduction, DMC matching) require SD Forge API service + interactive ipywidgets
- **Exercise exists**: Notebook already has a comprehensive 40-45 min exercise (cell 15) with TODO stubs
- **Papermill timeout**: Even with `--batch-mode`, the notebook hangs on ipywidgets (cell 9) despite batch fallback creating a test checkerboard image

## Changes
- Added `NEEDS_INFRA` tag in notebook metadata
- Added infrastructure note in intro cell explaining SD Forge dependency

## Mission reference
- Issue #501 (M-23): ai-01 dispatched investigation of Cross-Stitch Legacy
- Per instructions: "Si non [non-Legacy exists] -> re-executer 4 cellules restantes (si service GenAI requis, flag NEEDS_INFRA)"

## Test plan
- [x] Confirmed no non-Legacy version exists (`find` across entire GenAI directory)
- [x] Attempted Papermill execution with `--batch-mode` — timeout at 180s
- [x] Verified DMC_colors.json path resolves correctly
- [x] Verified exercise section already comprehensive (cell 15)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>