### PR TITLE
fix(ml): resolve transactions.csv robustly in DSA Lab4/Lab5 (#488 M-42 M-43)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling/Lab4-DataWrangling.ipynb
@@ -5,10 +5,10 @@
    "id": "392b8b6a",
    "metadata": {
     "papermill": {
-     "duration": 0.003484,
-     "end_time": "2026-03-13T22:29:28.180840",
+     "duration": 0.004723,
+     "end_time": "2026-04-24T00:02:08.754200",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.177356",
+     "start_time": "2026-04-24T00:02:08.749477",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "954a7822",
    "metadata": {
     "papermill": {
-     "duration": 0.002244,
-     "end_time": "2026-03-13T22:29:28.185642",
+     "duration": 0.001572,
+     "end_time": "2026-04-24T00:02:08.757867",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.183398",
+     "start_time": "2026-04-24T00:02:08.756295",
      "status": "completed"
     },
     "tags": []
@@ -60,10 +60,10 @@
    "id": "c5a2b52c",
    "metadata": {
     "papermill": {
-     "duration": 0.002433,
-     "end_time": "2026-03-13T22:29:28.190514",
+     "duration": 0.001527,
+     "end_time": "2026-04-24T00:02:08.761454",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.188081",
+     "start_time": "2026-04-24T00:02:08.759927",
      "status": "completed"
     },
     "tags": []
@@ -78,46 +78,127 @@
    "id": "a6144429",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:47.537343Z",
-     "iopub.status.busy": "2026-04-21T00:14:47.537081Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.651727Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.650719Z"
+     "iopub.execute_input": "2026-04-24T00:02:08.765962Z",
+     "iopub.status.busy": "2026-04-24T00:02:08.765962Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.504165Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.503522Z"
     },
     "papermill": {
-     "duration": 0.517075,
-     "end_time": "2026-03-13T22:29:28.711057",
+     "duration": 1.741726,
+     "end_time": "2026-04-24T00:02:10.504683",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.193982",
+     "start_time": "2026-04-24T00:02:08.762957",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: 'transactions.csv'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpandas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpd\u001b[39;00m\n\u001b[32m      3\u001b[39m \u001b[38;5;66;03m# Charger le jeu de données\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m df = \u001b[43mpd\u001b[49m\u001b[43m.\u001b[49m\u001b[43mread_csv\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mtransactions.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[38;5;66;03m# Afficher les premières lignes\u001b[39;00m\n\u001b[32m      7\u001b[39m df.head()\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:873\u001b[39m, in \u001b[36mread_csv\u001b[39m\u001b[34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, skip_blank_lines, parse_dates, date_format, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, on_bad_lines, low_memory, memory_map, float_precision, storage_options, dtype_backend)\u001b[39m\n\u001b[32m    861\u001b[39m kwds_defaults = _refine_defaults_read(\n\u001b[32m    862\u001b[39m     dialect,\n\u001b[32m    863\u001b[39m     delimiter,\n\u001b[32m   (...)\u001b[39m\u001b[32m    869\u001b[39m     dtype_backend=dtype_backend,\n\u001b[32m    870\u001b[39m )\n\u001b[32m    871\u001b[39m kwds.update(kwds_defaults)\n\u001b[32m--> \u001b[39m\u001b[32m873\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_read\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:300\u001b[39m, in \u001b[36m_read\u001b[39m\u001b[34m(filepath_or_buffer, kwds)\u001b[39m\n\u001b[32m    297\u001b[39m _validate_names(kwds.get(\u001b[33m\"\u001b[39m\u001b[33mnames\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m))\n\u001b[32m    299\u001b[39m \u001b[38;5;66;03m# Create the parser.\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m300\u001b[39m parser = \u001b[43mTextFileReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    302\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mor\u001b[39;00m iterator:\n\u001b[32m    303\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m parser\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:1645\u001b[39m, in \u001b[36mTextFileReader.__init__\u001b[39m\u001b[34m(self, f, engine, **kwds)\u001b[39m\n\u001b[32m   1642\u001b[39m     \u001b[38;5;28mself\u001b[39m.options[\u001b[33m\"\u001b[39m\u001b[33mhas_index_names\u001b[39m\u001b[33m\"\u001b[39m] = kwds[\u001b[33m\"\u001b[39m\u001b[33mhas_index_names\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m   1644\u001b[39m \u001b[38;5;28mself\u001b[39m.handles: IOHandles | \u001b[38;5;28;01mNone\u001b[39;00m = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1645\u001b[39m \u001b[38;5;28mself\u001b[39m._engine = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_make_engine\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mengine\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:1904\u001b[39m, in \u001b[36mTextFileReader._make_engine\u001b[39m\u001b[34m(self, f, engine)\u001b[39m\n\u001b[32m   1902\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m mode:\n\u001b[32m   1903\u001b[39m         mode += \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m1904\u001b[39m \u001b[38;5;28mself\u001b[39m.handles = \u001b[43mget_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1905\u001b[39m \u001b[43m    \u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1906\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1907\u001b[39m \u001b[43m    \u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mencoding\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1908\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcompression\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcompression\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1909\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmemory_map\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmemory_map\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1910\u001b[39m \u001b[43m    \u001b[49m\u001b[43mis_text\u001b[49m\u001b[43m=\u001b[49m\u001b[43mis_text\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1911\u001b[39m \u001b[43m    \u001b[49m\u001b[43merrors\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mencoding_errors\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mstrict\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1912\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mstorage_options\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1913\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1914\u001b[39m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m.handles \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m   1915\u001b[39m f = \u001b[38;5;28mself\u001b[39m.handles.handle\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\common.py:926\u001b[39m, in \u001b[36mget_handle\u001b[39m\u001b[34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[39m\n\u001b[32m    921\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(handle, \u001b[38;5;28mstr\u001b[39m):\n\u001b[32m    922\u001b[39m     \u001b[38;5;66;03m# Check whether the filename is to be opened in binary mode.\u001b[39;00m\n\u001b[32m    923\u001b[39m     \u001b[38;5;66;03m# Binary mode does not support 'encoding' and 'newline'.\u001b[39;00m\n\u001b[32m    924\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m ioargs.encoding \u001b[38;5;129;01mand\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m ioargs.mode:\n\u001b[32m    925\u001b[39m         \u001b[38;5;66;03m# Encoding\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m926\u001b[39m         handle = \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[32m    927\u001b[39m \u001b[43m            \u001b[49m\u001b[43mhandle\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    928\u001b[39m \u001b[43m            \u001b[49m\u001b[43mioargs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    929\u001b[39m \u001b[43m            \u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m=\u001b[49m\u001b[43mioargs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    930\u001b[39m \u001b[43m            \u001b[49m\u001b[43merrors\u001b[49m\u001b[43m=\u001b[49m\u001b[43merrors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    931\u001b[39m \u001b[43m            \u001b[49m\u001b[43mnewline\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m    932\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    933\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    934\u001b[39m         \u001b[38;5;66;03m# Binary mode\u001b[39;00m\n\u001b[32m    935\u001b[39m         handle = \u001b[38;5;28mopen\u001b[39m(handle, ioargs.mode)\n",
-      "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: 'transactions.csv'"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>id_produit</th>\n",
+       "      <th>categorie</th>\n",
+       "      <th>quantite</th>\n",
+       "      <th>prix_unitaire</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>15.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2023-10-02</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>C303</td>\n",
+       "      <td>Maison</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>75.9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>15.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         date id_produit     categorie  quantite  prix_unitaire\n",
+       "0  2023-10-01       A101  Electronique       5.0          120.0\n",
+       "1  2023-10-01       B202         Livre      10.0           15.5\n",
+       "2  2023-10-02       A101  Electronique       3.0            NaN\n",
+       "3  2023-10-03       C303        Maison       2.0           75.9\n",
+       "4  2023-10-03       B202         Livre       6.0           15.5"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "import pandas as pd\n",
+    "from pathlib import Path\n",
     "\n",
-    "# Charger le jeu de données\n",
-    "df = pd.read_csv('transactions.csv')\n",
+    "# Resolution robuste : CWD = repertoire du notebook (Jupyter classique)\n",
+    "# OU parent contenant le chemin du notebook (Papermill depuis le depot).\n",
+    "_data = Path('transactions.csv')\n",
+    "if not _data.exists():\n",
+    "    for _p in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        _candidate = _p / 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling' / 'transactions.csv'\n",
+    "        if _candidate.exists():\n",
+    "            _data = _candidate\n",
+    "            break\n",
     "\n",
-    "# Afficher les premières lignes\n",
-    "df.head()"
+    "# Charger le jeu de donnees\n",
+    "df = pd.read_csv(_data)\n",
+    "\n",
+    "# Afficher les premieres lignes\n",
+    "df.head()\n"
    ]
   },
   {
@@ -125,10 +206,10 @@
    "id": "08ef4835",
    "metadata": {
     "papermill": {
-     "duration": 0.004937,
-     "end_time": "2026-03-13T22:29:28.721317",
+     "duration": 0.001561,
+     "end_time": "2026-04-24T00:02:10.509059",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.716380",
+     "start_time": "2026-04-24T00:02:10.507498",
      "status": "completed"
     },
     "tags": []
@@ -145,30 +226,37 @@
    "id": "1005c87a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.653881Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.653588Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.675874Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.674710Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.514143Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.513143Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.535336Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.534338Z"
     },
     "papermill": {
-     "duration": 0.032852,
-     "end_time": "2026-03-13T22:29:28.760301",
+     "duration": 0.024712,
+     "end_time": "2026-04-24T00:02:10.535336",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.727449",
+     "start_time": "2026-04-24T00:02:10.510624",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Obtenir un résumé des informations du DataFrame\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[43mdf\u001b[49m.info()\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 7 entries, 0 to 6\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column         Non-Null Count  Dtype  \n",
+      "---  ------         --------------  -----  \n",
+      " 0   date           7 non-null      object \n",
+      " 1   id_produit     7 non-null      object \n",
+      " 2   categorie      7 non-null      object \n",
+      " 3   quantite       6 non-null      float64\n",
+      " 4   prix_unitaire  6 non-null      float64\n",
+      "dtypes: float64(2), object(3)\n",
+      "memory usage: 408.0+ bytes\n"
      ]
     }
    ],
@@ -182,10 +270,10 @@
    "id": "a1298e68",
    "metadata": {
     "papermill": {
-     "duration": 0.005118,
-     "end_time": "2026-03-13T22:29:28.770528",
+     "duration": 0.002,
+     "end_time": "2026-04-24T00:02:10.539851",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.765410",
+     "start_time": "2026-04-24T00:02:10.537851",
      "status": "completed"
     },
     "tags": []
@@ -202,31 +290,35 @@
    "id": "5a45efe2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.678328Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.677942Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.698981Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.698002Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.544885Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.544885Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.550478Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.549893Z"
     },
     "papermill": {
-     "duration": 0.014152,
-     "end_time": "2026-03-13T22:29:28.790196",
+     "duration": 0.00912,
+     "end_time": "2026-04-24T00:02:10.550478",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.776044",
+     "start_time": "2026-04-24T00:02:10.541358",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Compter les valeurs manquantes par colonne\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[43mdf\u001b[49m.isnull().sum()\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
+     "data": {
+      "text/plain": [
+       "date             0\n",
+       "id_produit       0\n",
+       "categorie        0\n",
+       "quantite         1\n",
+       "prix_unitaire    1\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -239,25 +331,30 @@
    "id": "a5ec2961",
    "metadata": {
     "papermill": {
-     "duration": 0.003117,
-     "end_time": "2026-03-13T22:29:28.798495",
+     "duration": 0.003018,
+     "end_time": "2026-04-24T00:02:10.555500",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.795378",
+     "start_time": "2026-04-24T00:02:10.552482",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "**Observations :** Exécutez les cellules ci-dessus, puis notez vos observations :\n- Quel est le type de la colonne `date` ? Devrait-elle être convertie ?\n- Combien de valeurs manquantes y a-t-il dans chaque colonne ?\n- Quelles colonnes semblent avoir des types incorrects ?"
+   "source": [
+    "**Observations :** Exécutez les cellules ci-dessus, puis notez vos observations :\n",
+    "- Quel est le type de la colonne `date` ? Devrait-elle être convertie ?\n",
+    "- Combien de valeurs manquantes y a-t-il dans chaque colonne ?\n",
+    "- Quelles colonnes semblent avoir des types incorrects ?"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e1df5985",
    "metadata": {
     "papermill": {
-     "duration": 0.003067,
-     "end_time": "2026-03-13T22:29:28.804687",
+     "duration": 0.000999,
+     "end_time": "2026-04-24T00:02:10.558503",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.801620",
+     "start_time": "2026-04-24T00:02:10.557504",
      "status": "completed"
     },
     "tags": []
@@ -272,33 +369,21 @@
    "id": "89d7246b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.701309Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.701043Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.724315Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.723495Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.564026Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.564026Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.582072Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.581070Z"
     },
     "papermill": {
-     "duration": 0.013797,
-     "end_time": "2026-03-13T22:29:28.821548",
+     "duration": 0.022056,
+     "end_time": "2026-04-24T00:02:10.583074",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.807751",
+     "start_time": "2026-04-24T00:02:10.561018",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Supprimer les lignes où la quantité est manquante\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;66;03m# Une transaction sans quantité n'est pas exploitable\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m \u001b[43mdf\u001b[49m.dropna(subset=[\u001b[33m'\u001b[39m\u001b[33mquantite\u001b[39m\u001b[33m'\u001b[39m], inplace=\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Supprimer les lignes où la quantité est manquante\n",
     "# Une transaction sans quantité n'est pas exploitable\n",
@@ -310,10 +395,10 @@
    "id": "bfc306bb",
    "metadata": {
     "papermill": {
-     "duration": 0.005664,
-     "end_time": "2026-03-13T22:29:28.833066",
+     "duration": 0.00151,
+     "end_time": "2026-04-24T00:02:10.587581",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.827402",
+     "start_time": "2026-04-24T00:02:10.586071",
      "status": "completed"
     },
     "tags": []
@@ -330,31 +415,35 @@
    "id": "8eca96a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.726656Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.726411Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.747641Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.746721Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.593092Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.592094Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.613848Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.612745Z"
     },
     "papermill": {
-     "duration": 0.022727,
-     "end_time": "2026-03-13T22:29:28.862687",
+     "duration": 0.024787,
+     "end_time": "2026-04-24T00:02:10.614367",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.839960",
+     "start_time": "2026-04-24T00:02:10.589580",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Remplir le prix manquant avec la moyenne des prix du même produit\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;66;03m# C'est une stratégie d'imputation plus intelligente que la moyenne globale\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m df[\u001b[33m'\u001b[39m\u001b[33mprix_unitaire\u001b[39m\u001b[33m'\u001b[39m] = \u001b[43mdf\u001b[49m.groupby(\u001b[33m'\u001b[39m\u001b[33mid_produit\u001b[39m\u001b[33m'\u001b[39m)[\u001b[33m'\u001b[39m\u001b[33mprix_unitaire\u001b[39m\u001b[33m'\u001b[39m].transform(\u001b[38;5;28;01mlambda\u001b[39;00m x: x.fillna(x.mean()))\n\u001b[32m      5\u001b[39m \u001b[38;5;66;03m# Vérifions s'il reste des valeurs nulles\u001b[39;00m\n\u001b[32m      6\u001b[39m df.isnull().sum()\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
+     "data": {
+      "text/plain": [
+       "date             0\n",
+       "id_produit       0\n",
+       "categorie        0\n",
+       "quantite         0\n",
+       "prix_unitaire    0\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -371,10 +460,10 @@
    "id": "689f2818",
    "metadata": {
     "papermill": {
-     "duration": 0.00566,
-     "end_time": "2026-03-13T22:29:28.872312",
+     "duration": 0.00206,
+     "end_time": "2026-04-24T00:02:10.618488",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.866652",
+     "start_time": "2026-04-24T00:02:10.616428",
      "status": "completed"
     },
     "tags": []
@@ -389,33 +478,21 @@
    "id": "c7bdbd37",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.749657Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.749340Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.770849Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.769805Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.626034Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.625034Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.645061Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.644057Z"
     },
     "papermill": {
-     "duration": 0.019788,
-     "end_time": "2026-03-13T22:29:28.896478",
+     "duration": 0.024027,
+     "end_time": "2026-04-24T00:02:10.645061",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.876690",
+     "start_time": "2026-04-24T00:02:10.621034",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Convertir la colonne 'date' en datetime\u001b[39;00m\n\u001b[32m      2\u001b[39m \u001b[38;5;66;03m# errors='coerce' transformera les dates invalides en NaT (Not a Time)\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m df[\u001b[33m'\u001b[39m\u001b[33mdate\u001b[39m\u001b[33m'\u001b[39m] = pd.to_datetime(\u001b[43mdf\u001b[49m[\u001b[33m'\u001b[39m\u001b[33mdate\u001b[39m\u001b[33m'\u001b[39m], errors=\u001b[33m'\u001b[39m\u001b[33mcoerce\u001b[39m\u001b[33m'\u001b[39m)\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Convertir la colonne 'date' en datetime\n",
     "# errors='coerce' transformera les dates invalides en NaT (Not a Time)\n",
@@ -427,10 +504,10 @@
    "id": "51499ff6",
    "metadata": {
     "papermill": {
-     "duration": 0.004968,
-     "end_time": "2026-03-13T22:29:28.906868",
+     "duration": 0.002516,
+     "end_time": "2026-04-24T00:02:10.649574",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.901900",
+     "start_time": "2026-04-24T00:02:10.647058",
      "status": "completed"
     },
     "tags": []
@@ -447,30 +524,37 @@
    "id": "756a92f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.773087Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.772834Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.793012Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.792010Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.654593Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.654593Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.661111Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.660103Z"
     },
     "papermill": {
-     "duration": 0.018223,
-     "end_time": "2026-03-13T22:29:28.930750",
+     "duration": 0.011026,
+     "end_time": "2026-04-24T00:02:10.662112",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.912527",
+     "start_time": "2026-04-24T00:02:10.651086",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[7]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Vérifions les types à nouveau\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[43mdf\u001b[49m.info()\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Index: 6 entries, 0 to 5\n",
+      "Data columns (total 5 columns):\n",
+      " #   Column         Non-Null Count  Dtype         \n",
+      "---  ------         --------------  -----         \n",
+      " 0   date           5 non-null      datetime64[ns]\n",
+      " 1   id_produit     6 non-null      object        \n",
+      " 2   categorie      6 non-null      object        \n",
+      " 3   quantite       6 non-null      float64       \n",
+      " 4   prix_unitaire  6 non-null      float64       \n",
+      "dtypes: datetime64[ns](1), float64(2), object(2)\n",
+      "memory usage: 288.0+ bytes\n"
      ]
     }
    ],
@@ -484,10 +568,10 @@
    "id": "53beea6f",
    "metadata": {
     "papermill": {
-     "duration": 0.006315,
-     "end_time": "2026-03-13T22:29:28.944060",
+     "duration": 0.003512,
+     "end_time": "2026-04-24T00:02:10.669621",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.937745",
+     "start_time": "2026-04-24T00:02:10.666109",
      "status": "completed"
     },
     "tags": []
@@ -502,31 +586,119 @@
    "id": "302c7b24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.795422Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.795055Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.815660Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.814932Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.677648Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.676639Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.692203Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.691204Z"
     },
     "papermill": {
-     "duration": 0.019918,
-     "end_time": "2026-03-13T22:29:28.968237",
+     "duration": 0.020071,
+     "end_time": "2026-04-24T00:02:10.693203",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.948319",
+     "start_time": "2026-04-24T00:02:10.673132",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[8]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Créer une colonne 'chiffre_affaires'\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m df[\u001b[33m'\u001b[39m\u001b[33mchiffre_affaires\u001b[39m\u001b[33m'\u001b[39m] = \u001b[43mdf\u001b[49m[\u001b[33m'\u001b[39m\u001b[33mquantite\u001b[39m\u001b[33m'\u001b[39m] * df[\u001b[33m'\u001b[39m\u001b[33mprix_unitaire\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m      3\u001b[39m df.head()\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>id_produit</th>\n",
+       "      <th>categorie</th>\n",
+       "      <th>quantite</th>\n",
+       "      <th>prix_unitaire</th>\n",
+       "      <th>chiffre_affaires</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>120.0</td>\n",
+       "      <td>600.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>155.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2023-10-02</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>120.0</td>\n",
+       "      <td>360.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>C303</td>\n",
+       "      <td>Maison</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>75.9</td>\n",
+       "      <td>151.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>93.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date id_produit     categorie  quantite  prix_unitaire  \\\n",
+       "0 2023-10-01       A101  Electronique       5.0          120.0   \n",
+       "1 2023-10-01       B202         Livre      10.0           15.5   \n",
+       "2 2023-10-02       A101  Electronique       3.0          120.0   \n",
+       "3 2023-10-03       C303        Maison       2.0           75.9   \n",
+       "4 2023-10-03       B202         Livre       6.0           15.5   \n",
+       "\n",
+       "   chiffre_affaires  \n",
+       "0             600.0  \n",
+       "1             155.0  \n",
+       "2             360.0  \n",
+       "3             151.8  \n",
+       "4              93.0  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -540,10 +712,10 @@
    "id": "da25cf64",
    "metadata": {
     "papermill": {
-     "duration": 0.005381,
-     "end_time": "2026-03-13T22:29:28.977861",
+     "duration": 0.002145,
+     "end_time": "2026-04-24T00:02:10.697302",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.972480",
+     "start_time": "2026-04-24T00:02:10.695157",
      "status": "completed"
     },
     "tags": []
@@ -558,30 +730,30 @@
    "id": "74a4d912",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.818182Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.817942Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.839416Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.838349Z"
+     "iopub.execute_input": "2026-04-24T00:02:10.702497Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.702497Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.723905Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.723192Z"
     },
     "papermill": {
-     "duration": 0.014044,
-     "end_time": "2026-03-13T22:29:28.997706",
+     "duration": 0.025523,
+     "end_time": "2026-04-24T00:02:10.724910",
      "exception": false,
-     "start_time": "2026-03-13T22:29:28.983662",
+     "start_time": "2026-04-24T00:02:10.699387",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Question métier : Quel est le chiffre d'affaires total par catégorie de produit ?\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m ca_par_categorie = \u001b[43mdf\u001b[49m.groupby(\u001b[33m'\u001b[39m\u001b[33mcategorie\u001b[39m\u001b[33m'\u001b[39m)[\u001b[33m'\u001b[39m\u001b[33mchiffre_affaires\u001b[39m\u001b[33m'\u001b[39m].sum().reset_index()\n\u001b[32m      4\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mChiffre d\u001b[39m\u001b[33m'\u001b[39m\u001b[33maffaires total par catégorie :\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      5\u001b[39m \u001b[38;5;28mprint\u001b[39m(ca_par_categorie)\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chiffre d'affaires total par catégorie :\n",
+      "      categorie  chiffre_affaires\n",
+      "0  Electronique            1440.0\n",
+      "1         Livre             248.0\n",
+      "2        Maison             151.8\n"
      ]
     }
    ],
@@ -596,7 +768,16 @@
   {
    "cell_type": "markdown",
    "id": "kajesru0lv8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001528,
+     "end_time": "2026-04-24T00:02:10.729953",
+     "exception": false,
+     "start_time": "2026-04-24T00:02:10.728425",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 🎯 Exercices Pratiques\n",
     "\n",
@@ -616,22 +797,29 @@
    "id": "e55nqyc0vui",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.842011Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.841762Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.864112Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.862940Z"
-    }
+     "iopub.execute_input": "2026-04-24T00:02:10.736152Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.736152Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.753467Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.753467Z"
+    },
+    "papermill": {
+     "duration": 0.021508,
+     "end_time": "2026-04-24T00:02:10.754469",
+     "exception": false,
+     "start_time": "2026-04-24T00:02:10.732961",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Votre code pour l'Exercice 1\u001b[39;00m\n\u001b[32m      2\u001b[39m \n\u001b[32m      3\u001b[39m \u001b[38;5;66;03m# TODO: Extrait le mois de chaque transaction\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m \u001b[43mdf\u001b[49m[\u001b[33m'\u001b[39m\u001b[33mmois\u001b[39m\u001b[33m'\u001b[39m] = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m      6\u001b[39m \u001b[38;5;66;03m# TODO: Calculez le chiffre d'affaires total par mois\u001b[39;00m\n\u001b[32m      7\u001b[39m ca_par_mois = \u001b[38;5;28;01mNone\u001b[39;00m\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chiffre d'affaires par mois :\n",
+      "None\n",
+      "\n",
+      "Mois avec le CA le plus élevé : None\n"
      ]
     }
    ],
@@ -656,7 +844,16 @@
   {
    "cell_type": "markdown",
    "id": "yet5ddiee6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002503,
+     "end_time": "2026-04-24T00:02:10.758970",
+     "exception": false,
+     "start_time": "2026-04-24T00:02:10.756467",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Détection d'anomalies\n",
     "\n",
@@ -672,28 +869,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "gefzn49u41f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:14:48.866413Z",
-     "iopub.status.busy": "2026-04-21T00:14:48.866148Z",
-     "iopub.status.idle": "2026-04-21T00:14:48.892161Z",
-     "shell.execute_reply": "2026-04-21T00:14:48.891419Z"
-    }
+     "iopub.execute_input": "2026-04-24T00:02:10.764346Z",
+     "iopub.status.busy": "2026-04-24T00:02:10.764346Z",
+     "iopub.status.idle": "2026-04-24T00:02:10.768849Z",
+     "shell.execute_reply": "2026-04-24T00:02:10.768849Z"
+    },
+    "papermill": {
+     "duration": 0.009017,
+     "end_time": "2026-04-24T00:02:10.769853",
+     "exception": false,
+     "start_time": "2026-04-24T00:02:10.760836",
+     "status": "completed"
+    },
+    "tags": []
    },
-   "outputs": [],
-   "source": "# Votre code pour l'Exercice 2\n\ndef detecter_anomalies_iqr(data, colonne):\n    \"\"\"\n    Détecte les anomalies dans une colonne en utilisant la méthode IQR.\n    \n    Args:\n        data: DataFrame Pandas\n        colonne: Nom de la colonne à analyser\n    \n    Returns:\n        Tuple: (DataFrame des anomalies, borne inférieure, borne supérieure)\n    \"\"\"\n    # TODO: Calculer Q1 (25ème percentile) et Q3 (75ème percentile)\n    Q1 = None\n    Q3 = None\n    \n    # TODO: Calculer l'écart interquartile (IQR)\n    IQR = None\n    \n    # TODO: Calculer les bornes inférieure et supérieure\n    borne_inf = None\n    borne_sup = None\n    \n    # TODO: Filtrer les anomalies\n    anomalies = None\n    \n    return anomalies, borne_inf, borne_sup\n\n# Appliquer la fonction au chiffre d'affaires\nanomalies_ca, inf, sup = detecter_anomalies_iqr(df, 'chiffre_affaires')\n\nif inf is not None and sup is not None:\n    print(f\"Bornes IQR: [{inf:.2f}, {sup:.2f}]\")\n    print(f\"\\nNombre d'anomalies détectées: {len(anomalies_ca) if anomalies_ca is not None else 0}\")\n    if anomalies_ca is not None and len(anomalies_ca) > 0:\n        print(\"\\nDétail des anomalies:\")\n        print(anomalies_ca[['date', 'id_produit', 'chiffre_affaires']])\nelse:\n    print(\"Remplissez d'abord les TODO dans detecter_anomalies_iqr() pour voir les résultats.\")"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Remplissez d'abord les TODO dans detecter_anomalies_iqr() pour voir les résultats.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Votre code pour l'Exercice 2\n",
+    "\n",
+    "def detecter_anomalies_iqr(data, colonne):\n",
+    "    \"\"\"\n",
+    "    Détecte les anomalies dans une colonne en utilisant la méthode IQR.\n",
+    "    \n",
+    "    Args:\n",
+    "        data: DataFrame Pandas\n",
+    "        colonne: Nom de la colonne à analyser\n",
+    "    \n",
+    "    Returns:\n",
+    "        Tuple: (DataFrame des anomalies, borne inférieure, borne supérieure)\n",
+    "    \"\"\"\n",
+    "    # TODO: Calculer Q1 (25ème percentile) et Q3 (75ème percentile)\n",
+    "    Q1 = None\n",
+    "    Q3 = None\n",
+    "    \n",
+    "    # TODO: Calculer l'écart interquartile (IQR)\n",
+    "    IQR = None\n",
+    "    \n",
+    "    # TODO: Calculer les bornes inférieure et supérieure\n",
+    "    borne_inf = None\n",
+    "    borne_sup = None\n",
+    "    \n",
+    "    # TODO: Filtrer les anomalies\n",
+    "    anomalies = None\n",
+    "    \n",
+    "    return anomalies, borne_inf, borne_sup\n",
+    "\n",
+    "# Appliquer la fonction au chiffre d'affaires\n",
+    "anomalies_ca, inf, sup = detecter_anomalies_iqr(df, 'chiffre_affaires')\n",
+    "\n",
+    "if inf is not None and sup is not None:\n",
+    "    print(f\"Bornes IQR: [{inf:.2f}, {sup:.2f}]\")\n",
+    "    print(f\"\\nNombre d'anomalies détectées: {len(anomalies_ca) if anomalies_ca is not None else 0}\")\n",
+    "    if anomalies_ca is not None and len(anomalies_ca) > 0:\n",
+    "        print(\"\\nDétail des anomalies:\")\n",
+    "        print(anomalies_ca[['date', 'id_produit', 'chiffre_affaires']])\n",
+    "else:\n",
+    "    print(\"Remplissez d'abord les TODO dans detecter_anomalies_iqr() pour voir les résultats.\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "0a03c482",
    "metadata": {
     "papermill": {
-     "duration": 0.004156,
-     "end_time": "2026-03-13T22:29:29.006000",
+     "duration": 0.003509,
+     "end_time": "2026-04-24T00:02:10.775362",
      "exception": false,
-     "start_time": "2026-03-13T22:29:29.001844",
+     "start_time": "2026-04-24T00:02:10.771853",
      "status": "completed"
     },
     "tags": []
@@ -730,18 +984,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.798569,
-   "end_time": "2026-03-13T22:29:32.340901",
+   "duration": 4.893768,
+   "end_time": "2026-04-24T00:02:11.016528",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Lab4-DataWrangling.ipynb",
-   "output_path": "Lab4-DataWrangling_output.ipynb",
+   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day3\\Labs\\Lab4-DataWrangling\\Lab4-DataWrangling.ipynb",
+   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day3\\Labs\\Lab4-DataWrangling\\Lab4-DataWrangling_output.ipynb",
    "parameters": {},
-   "start_time": "2026-03-13T22:29:25.542332",
+   "start_time": "2026-04-24T00:02:06.122760",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -5,10 +5,10 @@
    "id": "3efdaa4e",
    "metadata": {
     "papermill": {
-     "duration": 0.002636,
-     "end_time": "2026-02-26T07:41:15.498496",
+     "duration": 0.002001,
+     "end_time": "2026-04-24T00:03:46.177701",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.495860",
+     "start_time": "2026-04-24T00:03:46.175700",
      "status": "completed"
     },
     "tags": []
@@ -20,7 +20,16 @@
   {
    "cell_type": "markdown",
    "id": "l0o8hy58zr",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-04-24T00:03:46.180701",
+     "exception": false,
+     "start_time": "2026-04-24T00:03:46.178701",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Lab 5 - De la Visualisation au Machine Learning\n",
     "\n",
@@ -49,10 +58,10 @@
    "id": "7fce93d0",
    "metadata": {
     "papermill": {
-     "duration": 0.001548,
-     "end_time": "2026-02-26T07:41:15.502184",
+     "duration": 0.002,
+     "end_time": "2026-04-24T00:03:46.183702",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.500636",
+     "start_time": "2026-04-24T00:03:46.181702",
      "status": "completed"
     },
     "tags": []
@@ -66,10 +75,10 @@
    "id": "67e889fb",
    "metadata": {
     "papermill": {
-     "duration": 0.002183,
-     "end_time": "2026-02-26T07:41:15.506511",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:03:46.185702",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.504328",
+     "start_time": "2026-04-24T00:03:46.184702",
      "status": "completed"
     },
     "tags": []
@@ -84,43 +93,136 @@
    "id": "90987bcc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:29.858505Z",
-     "iopub.status.busy": "2026-04-21T00:16:29.858230Z",
-     "iopub.status.idle": "2026-04-21T00:16:31.110919Z",
-     "shell.execute_reply": "2026-04-21T00:16:31.109574Z"
+     "iopub.execute_input": "2026-04-24T00:03:46.189702Z",
+     "iopub.status.busy": "2026-04-24T00:03:46.189702Z",
+     "iopub.status.idle": "2026-04-24T00:03:46.455175Z",
+     "shell.execute_reply": "2026-04-24T00:03:46.455175Z"
     },
     "papermill": {
-     "duration": 0.326277,
-     "end_time": "2026-02-26T07:41:15.835333",
+     "duration": 0.268473,
+     "end_time": "2026-04-24T00:03:46.456175",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.509056",
+     "start_time": "2026-04-24T00:03:46.187702",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: '../Lab4-DataWrangling/transactions.csv'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpandas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpd\u001b[39;00m\n\u001b[32m      3\u001b[39m \u001b[38;5;66;03m# Charger les données depuis le lab précédent\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m df = \u001b[43mpd\u001b[49m\u001b[43m.\u001b[49m\u001b[43mread_csv\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43m../Lab4-DataWrangling/transactions.csv\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[38;5;66;03m# Ré-appliquer les étapes de nettoyage du Lab 4 (révision)\u001b[39;00m\n\u001b[32m      7\u001b[39m \n\u001b[32m      8\u001b[39m \u001b[38;5;66;03m# 1. Gestion des valeurs manquantes - supprimer les lignes sans quantité\u001b[39;00m\n\u001b[32m      9\u001b[39m df.dropna(subset=[\u001b[33m'\u001b[39m\u001b[33mquantite\u001b[39m\u001b[33m'\u001b[39m], inplace=\u001b[38;5;28;01mTrue\u001b[39;00m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:873\u001b[39m, in \u001b[36mread_csv\u001b[39m\u001b[34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, skip_blank_lines, parse_dates, date_format, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, on_bad_lines, low_memory, memory_map, float_precision, storage_options, dtype_backend)\u001b[39m\n\u001b[32m    861\u001b[39m kwds_defaults = _refine_defaults_read(\n\u001b[32m    862\u001b[39m     dialect,\n\u001b[32m    863\u001b[39m     delimiter,\n\u001b[32m   (...)\u001b[39m\u001b[32m    869\u001b[39m     dtype_backend=dtype_backend,\n\u001b[32m    870\u001b[39m )\n\u001b[32m    871\u001b[39m kwds.update(kwds_defaults)\n\u001b[32m--> \u001b[39m\u001b[32m873\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_read\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:300\u001b[39m, in \u001b[36m_read\u001b[39m\u001b[34m(filepath_or_buffer, kwds)\u001b[39m\n\u001b[32m    297\u001b[39m _validate_names(kwds.get(\u001b[33m\"\u001b[39m\u001b[33mnames\u001b[39m\u001b[33m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m))\n\u001b[32m    299\u001b[39m \u001b[38;5;66;03m# Create the parser.\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m300\u001b[39m parser = \u001b[43mTextFileReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    302\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mor\u001b[39;00m iterator:\n\u001b[32m    303\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m parser\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:1645\u001b[39m, in \u001b[36mTextFileReader.__init__\u001b[39m\u001b[34m(self, f, engine, **kwds)\u001b[39m\n\u001b[32m   1642\u001b[39m     \u001b[38;5;28mself\u001b[39m.options[\u001b[33m\"\u001b[39m\u001b[33mhas_index_names\u001b[39m\u001b[33m\"\u001b[39m] = kwds[\u001b[33m\"\u001b[39m\u001b[33mhas_index_names\u001b[39m\u001b[33m\"\u001b[39m]\n\u001b[32m   1644\u001b[39m \u001b[38;5;28mself\u001b[39m.handles: IOHandles | \u001b[38;5;28;01mNone\u001b[39;00m = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m1645\u001b[39m \u001b[38;5;28mself\u001b[39m._engine = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_make_engine\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mengine\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\parsers\\readers.py:1904\u001b[39m, in \u001b[36mTextFileReader._make_engine\u001b[39m\u001b[34m(self, f, engine)\u001b[39m\n\u001b[32m   1902\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m mode:\n\u001b[32m   1903\u001b[39m         mode += \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m-> \u001b[39m\u001b[32m1904\u001b[39m \u001b[38;5;28mself\u001b[39m.handles = \u001b[43mget_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1905\u001b[39m \u001b[43m    \u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1906\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1907\u001b[39m \u001b[43m    \u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mencoding\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1908\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcompression\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcompression\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1909\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmemory_map\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mmemory_map\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1910\u001b[39m \u001b[43m    \u001b[49m\u001b[43mis_text\u001b[49m\u001b[43m=\u001b[49m\u001b[43mis_text\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1911\u001b[39m \u001b[43m    \u001b[49m\u001b[43merrors\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mencoding_errors\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mstrict\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1912\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moptions\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mstorage_options\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1913\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1914\u001b[39m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m.handles \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m   1915\u001b[39m f = \u001b[38;5;28mself\u001b[39m.handles.handle\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\AppData\\Roaming\\Python\\Python313\\site-packages\\pandas\\io\\common.py:926\u001b[39m, in \u001b[36mget_handle\u001b[39m\u001b[34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[39m\n\u001b[32m    921\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(handle, \u001b[38;5;28mstr\u001b[39m):\n\u001b[32m    922\u001b[39m     \u001b[38;5;66;03m# Check whether the filename is to be opened in binary mode.\u001b[39;00m\n\u001b[32m    923\u001b[39m     \u001b[38;5;66;03m# Binary mode does not support 'encoding' and 'newline'.\u001b[39;00m\n\u001b[32m    924\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m ioargs.encoding \u001b[38;5;129;01mand\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mb\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m ioargs.mode:\n\u001b[32m    925\u001b[39m         \u001b[38;5;66;03m# Encoding\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m926\u001b[39m         handle = \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[32m    927\u001b[39m \u001b[43m            \u001b[49m\u001b[43mhandle\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    928\u001b[39m \u001b[43m            \u001b[49m\u001b[43mioargs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    929\u001b[39m \u001b[43m            \u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m=\u001b[49m\u001b[43mioargs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mencoding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    930\u001b[39m \u001b[43m            \u001b[49m\u001b[43merrors\u001b[49m\u001b[43m=\u001b[49m\u001b[43merrors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    931\u001b[39m \u001b[43m            \u001b[49m\u001b[43mnewline\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m    932\u001b[39m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    933\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    934\u001b[39m         \u001b[38;5;66;03m# Binary mode\u001b[39;00m\n\u001b[32m    935\u001b[39m         handle = \u001b[38;5;28mopen\u001b[39m(handle, ioargs.mode)\n",
-      "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: '../Lab4-DataWrangling/transactions.csv'"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>id_produit</th>\n",
+       "      <th>categorie</th>\n",
+       "      <th>quantite</th>\n",
+       "      <th>prix_unitaire</th>\n",
+       "      <th>chiffre_affaires</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>5</td>\n",
+       "      <td>120.0</td>\n",
+       "      <td>600.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2023-10-01</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>10</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>155.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2023-10-02</td>\n",
+       "      <td>A101</td>\n",
+       "      <td>Electronique</td>\n",
+       "      <td>3</td>\n",
+       "      <td>75.9</td>\n",
+       "      <td>227.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>C303</td>\n",
+       "      <td>Maison</td>\n",
+       "      <td>2</td>\n",
+       "      <td>75.9</td>\n",
+       "      <td>151.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2023-10-03</td>\n",
+       "      <td>B202</td>\n",
+       "      <td>Livre</td>\n",
+       "      <td>6</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>93.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date id_produit     categorie  quantite  prix_unitaire  \\\n",
+       "0 2023-10-01       A101  Electronique         5          120.0   \n",
+       "1 2023-10-01       B202         Livre        10           15.5   \n",
+       "2 2023-10-02       A101  Electronique         3           75.9   \n",
+       "3 2023-10-03       C303        Maison         2           75.9   \n",
+       "4 2023-10-03       B202         Livre         6           15.5   \n",
+       "\n",
+       "   chiffre_affaires  \n",
+       "0             600.0  \n",
+       "1             155.0  \n",
+       "2             227.7  \n",
+       "3             151.8  \n",
+       "4              93.0  "
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Resolution robuste (cf. Lab 4) : fonctionne depuis n'importe quel CWD\n",
+    "_data = Path('../Lab4-DataWrangling/transactions.csv')\n",
+    "if not _data.exists():\n",
+    "    for _p in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        _candidate = _p / 'MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab4-DataWrangling' / 'transactions.csv'\n",
+    "        if _candidate.exists():\n",
+    "            _data = _candidate\n",
+    "            break\n",
     "\n",
     "# Charger les données depuis le lab précédent\n",
-    "df = pd.read_csv('../Lab4-DataWrangling/transactions.csv')\n",
+    "df = pd.read_csv(_data)\n",
     "\n",
     "# Ré-appliquer les étapes de nettoyage du Lab 4 (révision)\n",
     "\n",
@@ -135,7 +237,7 @@
     "# 3. Création de la colonne 'chiffre_affaires'\n",
     "df['chiffre_affaires'] = df['quantite'] * df['prix_unitaire']\n",
     "\n",
-    "df.head()"
+    "df.head()\n"
    ]
   },
   {
@@ -143,10 +245,10 @@
    "id": "8144b5f0",
    "metadata": {
     "papermill": {
-     "duration": 0.001996,
-     "end_time": "2026-02-26T07:41:15.839329",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:03:46.459174",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.837333",
+     "start_time": "2026-04-24T00:03:46.458174",
      "status": "completed"
     },
     "tags": []
@@ -161,16 +263,16 @@
    "id": "caa57012",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:31.114133Z",
-     "iopub.status.busy": "2026-04-21T00:16:31.113771Z",
-     "iopub.status.idle": "2026-04-21T00:16:33.312155Z",
-     "shell.execute_reply": "2026-04-21T00:16:33.310542Z"
+     "iopub.execute_input": "2026-04-24T00:03:46.463175Z",
+     "iopub.status.busy": "2026-04-24T00:03:46.463175Z",
+     "iopub.status.idle": "2026-04-24T00:03:52.229575Z",
+     "shell.execute_reply": "2026-04-24T00:03:52.228974Z"
     },
     "papermill": {
-     "duration": 1.152061,
-     "end_time": "2026-02-26T07:41:16.993908",
+     "duration": 5.768919,
+     "end_time": "2026-04-24T00:03:52.230094",
      "exception": false,
-     "start_time": "2026-02-26T07:41:15.841847",
+     "start_time": "2026-04-24T00:03:46.461175",
      "status": "completed"
     },
     "tags": []
@@ -189,10 +291,10 @@
    "id": "809423b5",
    "metadata": {
     "papermill": {
-     "duration": 0.003582,
-     "end_time": "2026-02-26T07:41:17.000495",
+     "duration": 0.001535,
+     "end_time": "2026-04-24T00:03:52.233687",
      "exception": false,
-     "start_time": "2026-02-26T07:41:16.996913",
+     "start_time": "2026-04-24T00:03:52.232152",
      "status": "completed"
     },
     "tags": []
@@ -207,36 +309,26 @@
    "id": "b6be9975",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:33.315536Z",
-     "iopub.status.busy": "2026-04-21T00:16:33.315009Z",
-     "iopub.status.idle": "2026-04-21T00:16:33.603369Z",
-     "shell.execute_reply": "2026-04-21T00:16:33.601937Z"
+     "iopub.execute_input": "2026-04-24T00:03:52.237836Z",
+     "iopub.status.busy": "2026-04-24T00:03:52.237836Z",
+     "iopub.status.idle": "2026-04-24T00:03:52.415727Z",
+     "shell.execute_reply": "2026-04-24T00:03:52.414726Z"
     },
     "papermill": {
-     "duration": 0.107972,
-     "end_time": "2026-02-26T07:41:17.111597",
+     "duration": 0.180805,
+     "end_time": "2026-04-24T00:03:52.416048",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.003625",
+     "start_time": "2026-04-24T00:03:52.235243",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m plt.figure(figsize=(\u001b[32m10\u001b[39m, \u001b[32m6\u001b[39m))\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m sns.barplot(x=\u001b[33m'\u001b[39m\u001b[33mcategorie\u001b[39m\u001b[33m'\u001b[39m, y=\u001b[33m'\u001b[39m\u001b[33mchiffre_affaires\u001b[39m\u001b[33m'\u001b[39m, data=\u001b[43mdf\u001b[49m, estimator=\u001b[38;5;28msum\u001b[39m, errorbar=\u001b[38;5;28;01mNone\u001b[39;00m)\n\u001b[32m      3\u001b[39m plt.title(\u001b[33m\"\u001b[39m\u001b[33mChiffre d\u001b[39m\u001b[33m'\u001b[39m\u001b[33mAffaires Total par Catégorie de Produit\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      4\u001b[39m plt.xlabel(\u001b[33m\"\u001b[39m\u001b[33mCatégorie\u001b[39m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
-    },
-    {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAJUCAYAAAD5IdzqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWbNJREFUeJzt3QmczWX///GPfV+yZkvIkuxrJZXSXaGSpYUsqchSd7dSIbIVScsdKkpZQyhJUlnaUES2NG5L9oSElHXM//G+/r/vPM6MGWb0PXPOnPN6Ph7zmDnne5bvWed6f6/r+lwZ4uLi4gwAAAAA8I9k/GdXBwAAAAAQrgAAAADAJ/RcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAIF2Ji4sL9S6ENZ6f6MbrD4QW4QpASKxbt8569epl119/vVWrVs0aN25s/fr1s507dya43A033GBPP/30OW9L23U5z969e61t27ZWtWpVu+qqq+zYsWP24osvWr169axGjRo2e/ZsSwuB+/7BBx9YxYoV7fvvvz/rco8//rjb9s477yR5O0ePHrWHH37YqlevbnXr1rVt27bZ+PHjrUGDBu65e/3111O0PyNHjnT3Ewq63/P96Dk6n5UrV1rnzp0v6P71+NPzZyElNm3aZPfee2+y2/U5qFKlii1fvtzSUuLPqJ/8el9rHxO/J6+44gq75ppr3Ovz66+/WrDoeyG574fk7Nq1K8Hn5siRI/bkk0/aDz/8ELT9BHB+mVNwGQDw1ZQpU+z555+3+vXru2BRpEgR2759u40bN84+//xzmzBhglWqVCnFt9etWzdr3759/Gldf/Xq1a4hWbRoUddIffvtt+2uu+6yO+64w8qWLZvmr2iGDBkS/Pb8+eeftmDBAqtQoYJNnz7d7r///rMuozC4ePFi69+/v5UvX94KFSpkL7zwgmuMd+rUyUqWLJmifWjdurU1bNjQQkGPLdDdd99trVq1cvvkueSSS857OzNmzLAtW7ZYpPD7szB//nz78ccfk9z2+++/23vvvWfPPvusO9CQlhJ/RsNV4cKFbdSoUfGnT58+bb/88ouNGDHCPa9z58617NmzWzjQe0WfK+9z8/PPP9tHH31kLVu2DPWuAVGNcAUgTann4bnnnnM9S3379o0/X41LHbFv3ry59enTJ0W9GMk1yg8dOuQaHk2aNHGnvaP0TZs2tTp16lioGm2isBdIjTXRc9GhQwf77rvvXG9b4scjbdq0ccFr9+7ddubMGfd8qScrpS6++GL3EwrqMUxqf5I6P1oE47NwLtmyZXNBvXTp0pbWUhKcw0HWrFnPek/qOyNLliz21FNP2cKFC933SLjuK4DQY1gggDSlI/J58uSxnj17nrWtQIECbmjOjTfeaH///Xf8+adOnbLhw4e7YXBqTKi3Rkf3kxpypN9qjO7Zsyd+KFi7du3cNoWXwMupx0DnaSiW17hVkFEP0dVXX+2GFaq3a9myZed9XDExMa7XqWbNmtaoUSObM2dOgu3qccqZM+dZjcxZs2a5MHXllVe6Ru+0adMSbNe+e8PZ1IOh/fYegxre3nCo2NhYGzt2rDVr1sw9Hj1P99xzjwtryQ2f0m0/8cQT9uijj7rLa//lxIkT7vm+7rrr3BCy2267zebNm5dgv9avX++eu9q1a7vH3LFjR9db+E/ofkePHm233HKLe+7/9a9/ucekIOm9zh9++KELl4HDoTQ8SsOhNHxLw7j0fOr0H3/8keL71m3r+Zg5c6Z7/fSY9Pj0ugZasWKFPfDAAy7U6rnRa6Hn1dtHb6jWu+++6x6HhnLqNfbjs3D8+HF76aWX3POi+65Vq5Z7zdRjIdoPr9clcBik9k3P45133umCwc0332yTJk1Kcn90f3r/6L2zaNGis4aqaQijHr8CoO5fw1U1FDHx8Da9j/U86jJLlixJcligeiG1P3os6oXV/up9fL73yNChQ913gV6j3r17u/MS09C4++67zz3/6qVTMDp48KBdKL0fRe890ePR+0O9gHqMOpCjfT/fe9ij50evg55r7ae+r1Iy1DHwdQ0cFqjn3esZ1G/vOw9A2qPnCkCaTrT+9ttvXSMrR44cSV7G620KpIa9Gs7Dhg2zAwcOuMbVf/7znySP6Ktx+eqrr9qGDRvc3+odUUN10KBBLjSpQRY4JEuN04ceeshy5crlGkZqMOk+dPvq/VLD+MEHH3TDChP3KHl+++0310C69NJL3VBEzZHSMCINw/KoxyrxcC01StVY/e9//+tOq6dC86d0/xr6J2q8qaGuRr+GAKnnat++fdajRw/r2rWra5SK7m/q1Knx87e0T2rk/fvf/7Yvv/wy2ef7008/tdtvv93eeOMN1wDUa9S9e3dbtWqVC13lypWzL774wj0fJ0+edPuox6fnRIFQDT2dr+ur0a37UmBILd2vGuoKaHpsCpJqMOq11LDOwYMHu6FlaiB7r62CqubTqTF50UUXuedK963nWds1fEuve0oppGzdutWFnXz58tlrr73mXle9//ReUNBSiFTD+ZVXXnH7/PHHH7v70lDTwB4NPS8K7Llz53YNfD8+C958Gu2fHrsOMOi9o9f8k08+cUMsNd/Qe694vZQDBgxwn5UuXbq4978Cog4saI6OXmvRY9D7Ra+hXtdvvvnGHnvssQT3r6Cu113BStfX52XMmDEuiL3//vvuveLR7T3zzDMuEOo+9TwF0vX0HOr5VUDSc6/nTPOadNvJ0dwn7ZvejzoYoceZ+Lb1+PS51uPQ++fw4cPuedL7RM/NhQzr09BACTw4otdCvYF63hSAM2bMeN73sEyePNn9re+aa6+91h280Ry7f0IHFfT95n3P6TUCEBqEKwBpRj0JapCldI5QYDBR6NDQHFGjUo15NfLVeA1UuXJlF6YCh8xcdtll8b+13VO8eHHXc+NRA1ENaP32GsRq/OgosMJLcj0QKi7h9RzpvqVMmTKu1+tcdHv58+ePP6KvngU1MNUAVCPN22evkew9Hh2x9hp63nkKXGpwBh6xVsPvkUcesY0bNyY7fEjP6cCBA93zJeplUONVDV+vca95Wgoxeg7UM7Z582b3WqqxqqP2onChhu5ff/11QeHq66+/tqVLl9rLL78cH1LUO6GGsNcwVu9f4tdWjXI9P5qDVqpUKXeeGtVr1qxJddEGzX97880344eOesUlJk6c6N4nem+oR1MBWg1pbx/Vw6NGdGC4uvXWW8859yW1nwUFWD23Cize66IeGX0GvIMOgcM+vedHoUDvZwUyrxCIDlQopCvgaKip3idvvfWWG57ofR50Gb3mgXPl1GumQKP3eaZMmeIvd9NNN7kg6h0kEN2uQmhyz7M+z5p3p8fj3Y4+CzqtYKTXOjEdjPjss89cWPSKdui9qZ5VvScD91OfPz0+bz/1edbro8+cHue5aJ6VR8+vDoDogI5eK+9ghnc5hRnvOf/qq6/O+x7W51mPXa+hep69x677SdxrnRr6Hgz8nvP+BpD2GBYIIM14DZ3zDf1JTI1cL1iJ1yDVkfd/4vLLL09wWkeQNTdKR4HVcNKP9lXDmzQMTkfAk5s7o8asF6y8xpzCW3I01FFDB9V419F9PRb1nmmYnRrDiYcRnY8alDoSrp4dHVFXI9IbmqiGeXIUirxg5T0HanhrSKD3HOhHAXD//v2ugeuFHAVAHSVXz5Z62tSrcKFzuhSEMmfOfFaDXL1q3vbkXkMVaShRooSroqgGroa3qQfqXI87KXpfBc7JU2+V19Mj6rVTCNFrp6Clhr5Chd4jOi/xfvn5WdBrpMelRrl6JdWLpMa4Cp1Ico9Vl1MvmV6/xK+nwp3eu+pp0Xsw8XOvIO1Rz4xChkKjt++SN29e9/lI/Pqc6/GrZ1H3l9Q+eQE/KV4VvMDhhQq5Gl7nUSBUsNb7V4/bu20Fb/WsJXfbHg370+ff+1EPkHrrChYs6HqoAnu9FAYD3+8peQ/rfakebT1ngfS8AogM9FwBSDMaaqUAkXh+QSA14tRQ1WU9mqsUyOs1SG0ASSzx7Wq+lQKEGlVJ0bbA/fIodCXVA+EVsUiKhs+pkaVeKv0kpt4jNRBTSg1f9UDpt4aZ6ci1F+7Ote6NXo/Ez4Eu7/VIJaYeMjWcNaRSvYcaVqjeDTU6VYlRPQ+BYS2l9BxqaF9gwz3wOVRvR3I0bFI9Ttp3hTzN4dFzcK7rJCVxsRFRo/qnn35yfysQaDiXKrKpwa7XXOFLDerEz3Hi95YfnwW9JzRkTg10XVfDzrz7Se419oqhJFeEQUHNu/3AgwPeY/foudR9eMNVA+m8xM/1uR6/t0/JldTXeywp3sENvU+S+5zpIIW+FxSC9ZOYeunORbel97VH72UFqKQ+94k/Oyl5D6fkMQBI3whXANKUhsBoCJWOmifV0FGvjYZ4KXAkF3KCRcPZNG9Kw9+SktwQLjWUNCwruUZkUtSzpKPpqhYXSA1YzddQr0RKw5U3B0pzrTT3Rr1RCqDqxVHvSmqfAzWMNRQuKV6lOd2Hhsep52Xt2rUucGjOl4Yqal9SS41XDZXT7QU2Tr2GduLGqEfzbTQsTr1mLVq0iA8ImmumoJkaSRXA0OvqhQy9Vno+NYdGwwO9AJHcXDw/Pwt6XTQ/Sj2dGu6m9456GBVyFbqSo54lUUn3xGFAFMC9+UQK+4HLFAQWgND96/6Sep/roIN6cVLK2yd9zvR5SyypABf4HtA+BPYKB37O9Bi1n5obl1SgTG5+W2CY8opXBOM97D2GwPmYiR+DeMsxBN6WhoUCCH8MCwSQplTpTw0JNVCTaqRpIV31uqR1sPLmsGhCvRrTamB5PxpKpIIWiY9IezTHR0Od1Avg0RyQ5BaB1eNUg1iNPw07CvzRbWlYkYJR4O2di3oy9Jx6czq8nj3NY0ptD5+eA/WYKOQFPgf/+9//3LAo9dhoLSXtpx6HnhP13mgejBrN5+qJOd/9ercdyBvaqOGS4j02j4a16X4V6LxgpUaozk9tz6aGFQauoaXnX6+rF550m16ZdC9YabioQsiF9KKm5rOg+1EIU2+PAqzX+PaClddzlfj58YY5qtEf+HpqnzUPSPevHjCFJw3vDKR1tjx6vOoRVE9l4FBG9caoF9Z7fVJCQ2Y1zFfPb+A+qQdQ85W8OYWJ6T0nid8j3tBIb+6R5lXqMxF42xrKqvmMqVmkNxjvYYXJYsWKnfMxeI9DVKDEo/ffuST3/QQgbdFzBSBNaW6SehXUoFRDVvNYdDRXc3k0p0QNyKQam2lBPR+q5KUJ9ZpPpEaQJqhreJGqmgXO+wqkuU7qXVClNRWQUONTBSGSu7zWGlIjLLmhWnpOVKZaPRe6vfPR5H01xjQ0Tg1U/aiHxRtuqHkoKaXeMpUZV2U+/WieinqmNLdIxQMUYDRkUGFCPSlq7Ku3QI1uNbRVevpCqHCIgouGFarRrQa/5qjouVehD2+CvoKUei4UPjU8UfPx1GOm3ivNY1Evgd5HukxSQ7lSUrFQhUHUUFXFO92GVyRE96XHqfvT86J5VxpCpqCTmuf4Qj4LClh6XdVbqFCmOVaqAKhgI165dq9XSOunKcSoN1NzflSNTvOJFJDUU6X3p3pi1djXY1U41Wusnh2FBD33epyBgU1VCfUe12uughUasqjiFtoXr+pgSugx6v4U7tTrqtddr7lO67lMbtFk9ZqqCIb2XZ8fvf7qMVXBlkBe8Q7trx67Po8KqpqLpfd0sKT0PayiIdo3XU4HUjTnzXuuAz+HKqKhOY16znXQRwc3kup99HiFZPSe0Ps2NYtPA/AP4QpAmlMJcR1d1pAmzSHRPAQFGVXi8kJNKOjovPZJxSHUiFVYUKEENYTUoD1XY1GNIw0b0/o3agCp8Zh4bSiPGsU6kl6hQoUkt+sItxq+ClgpaQyqUaUKZFqbSo113b8angqKKjOvQgCJ1xhKjhrSajCroavhZxq+pLlICpxeA1qFHtSTp8uo3LiChdcz4PUupJZXvU4NfFVfVM+KngM1lL31t7wArGClfVGpeD0+9XRomKUKW2hf1TBV41+BQqElsET4uWiomV5nvSf1mDT0T+HJG/Km11aBQoFHgUL7p/eyeilVMTC1hVpS81lQsND7UoFP11HjWeFM61Up/Ok1VpBSuFXg0L62atXK9Siqka7nVkNN1ROinlkVxlCpda+3Q2XaFS41f07BTsFMIUDXDRz+qPlteo30umgInXrGNHQxqep+56L71jwjvWZ6L+nx6PZ1u+eqNqly+xo2qPe2nisFfj1PgQdkNNxSj0HPld4jOsihcKp9D+aiuyl9D6tQiD5n+szqtdL3gKoOBq53pgMmel71/lNQ1HtY8/28cu5J0Wug2/aGinoLlANIWxnizjXTGQCAKKAwol4GhaRoo14gNcTV6xJ4YEON9CFDhrihdF6PGADg3Oi5AgAgimm4oYauqeiFesXUE6s5duoN0lBFghUApBzhCgCAKKf5eiomoWGEKmeuIZKaS6jhggCAlGNYIAAAAAD4gFLsAAAAAOADwhUAAAAA+IBwBQAAAAA+oKBFErQ4pkrTah0KrVsBAAAAIDrFxcW5fKDqqt7C6skhXCVBwWrdunXBen0AAAAApDNVq1Z1C6ifC+EqCV4i1RPorV4PAAAAIPrExsa6jpfz9VoJ4SoJ3lBABSvCFQAAAIAMKZguREELAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuQiz2zJlQ7wKQLvHZAQAA4SZzqHcg2mXKmNGeee8b+2Xf4VDvCpBulCmSz4a0aRjq3QAAAEiAcBUGFKxidh8M9W4AAAAA+AcYFggAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAABCuAAAAACA80HMFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAABAp4erkyZPWrFkz+/777+PPW716td1zzz1Ws2ZNu/nmm23GjBkJrrN06VJ3nerVq1v79u1t586dCbaPHz/eGjZs6K7fp08fO3bsWJo9HgAAAADRJ+Th6sSJE9azZ0/btGlT/Hn79++3hx56yOrVq2cffvihPfroozZ48GD78ssv3fY9e/ZY9+7drUWLFjZz5kwrUKCAdevWzeLi4tz2zz77zEaNGmWDBg2yCRMm2Jo1a+zFF18M2WMEAAAAEPlCGq42b95sd911l+3YsSPB+QsWLLBChQq50HXppZda06ZNrXnz5vbxxx+77erFqlKlinXq1MnKly9vQ4cOtd27d9vy5cvd9okTJ1qHDh2sUaNGVq1aNRs4cKDNmjWL3isAAAAAkRmuFIbq169v06dPT3C+hvMpMCV29OhR91s9UXXq1Ik/P0eOHHbFFVe4oYSxsbG2bt26BNtr1Khhp06dspiYmKA+HgAAAADRK3Mo77xNmzZJnl+yZEn34/n999/tk08+sUceeSR+2GCRIkUSXKdgwYK2d+9eO3LkiBtqGLg9c+bMlj9/frc9NRTUgi1TpkxBvw8gUqXFZxQAAES32FS0N0IarlLi+PHjLlRpmODdd9/tzlNxiqxZsya4nE6rMIYu751OantqqAcsmNTjVrly5aDeBxDJNm7cyHBfAAAQNsI6XP3111+uUMW2bdvsvffec2FEsmXLdlZQ0um8efO6bd7pxNu966dU1apV6VkCwljFihVDvQsAACDCxf7ftKN0Ha40v+rBBx90xS5U8U+FLTxFixa1AwcOJLi8Tl9++eVu+J8Clk6XK1fObTt9+rQdOnTIChcunOohewzbA8IXn08AABBOQl6KPSlnzpyxHj162K5du2zSpEmuImAgrW21cuXK+NMaJrhhwwZ3fsaMGV2PU+B2FbrQvKtKlSql6eMAAAAAED3CMlxp7SotKDxkyBA31E8FLPSj3idp2bKlrVq1ysaOHevWx+rdu7crgKHKg16hjHHjxrmS7mvXrrUBAwa4ku+pHRYIAAAAACkVlsMCtQiweq+6dOmS4HwtKqyeLAWpkSNH2vPPP2+jR4+2mjVrut8ZMmRwl9O6WFr3qn///m6u1b/+9S/r1atXiB4NAAAAgGiQIS4uLi7UOxGOk9Y0lFDrY6XFnI62r861mN0Hg34/QKSoVKKATXmsWah3AwAARIHYVGSDsBwWCAAAAADpDeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAgEgJVydPnrRmzZrZ999/H3/ezp07rWPHjlajRg1r0qSJffvttwmus3TpUned6tWrW/v27d3lA40fP94aNmxoNWvWtD59+tixY8fS7PEAAAAAiD4hD1cnTpywnj172qZNm+LPi4uLs+7du1uhQoVs1qxZdscdd1iPHj1sz549brt+a3uLFi1s5syZVqBAAevWrZu7nnz22Wc2atQoGzRokE2YMMHWrFljL774YsgeIwAAAIDIF9JwtXnzZrvrrrtsx44dCc7/7rvvXE+UwlG5cuWsS5curgdLQUtmzJhhVapUsU6dOln58uVt6NChtnv3blu+fLnbPnHiROvQoYM1atTIqlWrZgMHDnTXpfcKAAAAQESGK4Wh+vXr2/Tp0xOcr56mypUrW86cOePPq127tq1evTp+e506deK35ciRw6644gq3PTY21tatW5dgu4LZqVOnLCYmJk0eFwAAAIDokzmUd96mTZskz9+/f78VKVIkwXkFCxa0vXv3nnf7kSNH3FDDwO2ZM2e2/Pnzx18fAAAAACIqXCVHw/eyZs2a4DydVuGL820/fvx4/Onkrp9S6gULtkyZMgX9PoBIlRafUQAAEN1iU9HeCMtwlS1bNjt06FCC8xSMsmfPHr89cVDS6bx587pt3unE2zV8MDU0vDCYtD8a/gjgwmzcuJG5lAAAIGyEZbgqWrSoK3YR6MCBA/FD/bRdpxNvv/zyy93wPwUsnVYxDDl9+rQLa4ULF07VflStWpWeJSCMVaxYMdS7AAAAIlzs/9V0SLfhSmtXjR071g3x83qrVq5c6YpaeNt12qNhghs2bHDl2jNmzOhCkbarWIao0IXmXVWqVCnVQ/YYtgeELz6fAAAgnIR8nauk1KtXz4oVK2a9e/d2618paK1du9ZatWrltrds2dJWrVrlztd2Xa5kyZLxYUqFMsaNG2cLFixw1xswYIAr+Z7aYYEAAAAAkK7DlY5Gv/76664qoBYKnjNnjo0ePdqKFy/utitIjRw50q1dpcClIX/aniFDBre9adOmbm2s/v37u7WwtNZVr169QvyoAAAAAESyDHFxcXGh3olwHFepoYRaHysthh21fXWuxew+GPT7ASJFpRIFbMpjzUK9GwAAIArEpiIbhGXPFQAAAACkN4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAwhUAAAAAhAd6rgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB9kTsmFevfuneIbHDp06D/ZHwAAAABIl+i5AgAAAIC06rmiNwoAAAAAfAhXgeLi4mzhwoW2adMmi42NjT//5MmTtmHDBnv77bdTe5MAAAAAEH3havDgwTZz5kyrXLmyrV271mrWrGk7duywAwcO2L333hucvQQAAACASJtzNW/ePBsxYoRNmzbNLrnkEhswYIAtXrzYmjZtaqdOnQrOXgIAAABApIWro0ePWpUqVdzfFSpUcL1XmTNnti5duthXX30VjH0EAAAAgMgLV6VKlXJzq6R8+fIuXHlzsf7880//9xAAAAAAInHOVadOneyJJ56w559/3po0aWItWrRwPVc//vij1apVKzh7CQAAAACRFq5at25tl156qeXMmdPKlStno0aNshkzZrihgo8++mhw9hIAAAAAIi1cKUw98MADliNHDne6YcOG7kdzsbTt6aefDsZ+AgAAAED6D1dbt26133//3f09evRoq1SpkuXLly/BZf73v/+5CoKEKwAAAADRKEXhat++fdaxY8f40z169DjrMurJ6tChg797BwAAAACRFK6uvPJKi4mJcX/fcMMNbhHhAgUKBHvfAAAAACBy51wtWrTI/d62bZtt2bLFzpw5Y2XLlnXFLQAAAAAgWqU6XGktq6eeesqFLM27io2NdcUs6tWr5+Zj5cmTJzh7CgAAAACRtIjw4MGD7bfffrN58+bZ999/bz/88IPNnTvX/v77bxs6dGhw9hIAAAAAIi1cqcdqwIABbiig57LLLrP+/fvbwoUL/d4/AAAAAIjMcJUtWzbLmPHsq2XIkMENEQQAAACAaJTqcKVqgQMHDrQdO3bEn6fiFkOGDLHrrrvO7/0DAAAAgMgJV7Nnz7aTJ0+6v3v16uV6r26++WarX7+++7n11ltdcYt+/foFe38BAAAAIP1WC+zdu7c1bNjQChYsaHnz5rVJkybZxo0bXSl2Ba0yZcokmIMFAAAAANEmReEqLi7urPMqVqzofgAAAAAAqZhzpYIVae3XX3+1Ll26WK1atdxcr/Hjx8dv27Bhg7Vu3dqqV69uLVu2tPXr1ye4rsrDN27c2G3v3r27HTx4MM33HwAAAED0SPEiwg0aNEjR5X7++Wfzy2OPPWbFixe3Dz74wDZv3mxPPPGElShRwu1L586d7bbbbrNhw4bZ1KlTXQj74osvLGfOnLZ27Vrr27evK7xRqVIle+6559zQxjFjxvi2bwAAAABwQeHqtddec0Ur0srhw4dt9erVbtHiSy+91P1o3teyZcvcNs31evLJJ12PmoLU119/bfPnz7cWLVrY5MmTXZGN5s2bu9saPny4NWrUyHbu3GmlSpVKs8cAAAAAIHqkKFwpwGhongpapJXs2bNbjhw5XK/V448/7oLRqlWrXG/WmjVrrHbt2vFDFb39UxhTuNL2hx56KP62ihUr5nrAdD7hCgAAAEBYFbQINvVM9e/f3/VcTZw40S1QrOCkeVYLFy60yy67LMHlFfw2bdrk/t63b58VKVLkrO179+5N1T6kxaLImTJlCvp9AJGKhcsBAEA4tTdSFK569Ojh5jKlNZV613C++++/3wUnBa2rrrrKjh07ZlmzZk1wWZ321uI6fvz4Oben1Lp16yyY1DNXuXLloN4HEMm0JIS+DwAAAMJBisNVWtPcqpkzZ9pXX33lhghWrVrVfvvtN3vjjTfc0L7EQUmndTmv1yup7QozqaH7pGcJCF8sBwEAANKi5yqlnS4pLmiR1lRavXTp0vGBSdTL8+abb1qdOnXswIEDCS6v095QwKJFiya5vXDhwqnaBwUrwhUQvvh8AgCAdLnOVVpTUNq+fXuCHqitW7dayZIl3dpVP/74Y/xcMP1WsQudL/q9cuXKBOtl6cfbDgAAAABRE660aHCWLFnsmWeesV9++cUWLVrkeq3atWtnt9xyix05csStX6X1r/Rb8y5Ufl3uvfde++ijj2zGjBkWExPjSrZff/31VAoEAAAAED7h6ujRozZixAjXi3TmzBkXXGrUqGFt2rSx3bt3+7ZjefLksfHjx9v+/futVatWNnToUOvatavdfffdljt3brcgsHqnvNLrY8eOjS+6UbNmTRs0aJCNHj3aBS2tz6XrAwAAAECwZIhLZZ31Xr16ud4gLSq8du1ae/bZZ+355593C/iqSp9CTiRMWtOaWQqNaTGno+2rcy1m98Gg3w8QKSqVKGBTHmsW6t0AAABRIDYV2SDVBS1UvU/rTpUpU8ZefPFFVyq9SZMmrtjEnXfe+U/2GwAAAACiZ1igOro0F0q9VCqXft1117nzDx8+HJK1sAAAAAAgHKS65+rKK6+0fv36uSCVMWNGa9y4sQtZWuBXRSgAAAAAIBqluudK86s0BDBr1qyuYISKS2zcuNH1YKmyHwAAAABEo8wXUsUvcYjq2LGjn/sEAAAAANGxztWcOXNcCfQ6derYzp073TpTkVAlEAAAAADSLFy99957Nnz4cBeuTp065c6rUqWKjRs3zkaNGnXBOwIAAAAAURWuJk2aZEOGDLH77rvPFbSQO+64wwWuGTNmBGMfAQAAACDywtWePXusXLlyZ51fqlQpO3TokF/7BQAAAACRHa6qV69us2fPPmvtq3feeceqVavm574BAAAAQORWC1SlwM6dO9uXX35pJ0+etIEDB9q2bdvcosJvvfVWcPYSAAAAACItXFWoUME+++wz+/jjj23Lli0WGxtrN954o91+++2WK1eu4OwlAAAAAERauFKVwKFDh1qrVq2Cs0cAAAAAEA1zrvbt22eZMmUKzt4AAAAAQLT0XDVv3twefPBBNwywRIkSli1btrO2AwAAAEC0SXW4mjdvnlvfau7cuWdty5AhA+EKAAAAQFRKdbhatGhRcPYEAAAAACI9XK1YscJq1qxpmTNndn8nRz1XderU8XP/AAAAACBywlW7du1syZIlVrBgQff3ucLVzz//7Of+AQAAAEC6kKJwFRMTk+TfAAAAAIALnHMlp0+ftt9//90tICxxcXF28uRJ12vVpEmTC7lJAAAAAIiucLVgwQLr16+fHTp06KxthQsXJlwBAAAAiEqpXkT4pZdesptuusk++eQTy5s3r02bNs3efPNNt+bVY489Fpy9BAAAAIBI67nauXOnjRkzxi655BKrUqWK7d+/3xo3buzWvho+fLi1aNEiOHsKAAAAAJHUc6XeqmPHjrm/y5QpE1/gomzZsrZr1y7/9xAAAAAAIjFcXXfddTZw4EDbvHmz1a9f3z766CP76aefbPr06VakSJHg7CUAAAAARFq46tu3r5UuXdrWr1/vhgNWr17dWrVqZVOmTLGnnnoqOHsJAAAAAJEQrnr37m1//PGH+1vl1gcNGmTNmzd3iwaPGDHCVqxYYd99953dcMMNwd5fAAAAAEi/4UqVAQ8fPuz+bt++vf35558JtufOnduyZMkSnD0EAAAAgEipFlitWjUXqjQcUAsGd+/ePdkwNXHiRL/3EQAAAAAiI1yNHDnS5syZ43qsNASwRo0alitXruDvHQAAAABEUri66667bPLkyVa0aFF3+oEHHrAcOXIEe98AAAAAILLmXB04cMA2bdrk/h49enT8OlcAAAAAgFT0XDVr1swefPBBVx1Qc64aNGiQ7GVVTRAAAAAAok2KwtXgwYOtbdu2duTIEVfY4rXXXrN8+fIFf+8AAAAAIJLClVSqVCm+GmCtWrUsc+aEV923b5999NFHVq9ePf/3EgAAAAAiJVx5AsPTiRMn7IsvvrAPP/zQLSKswPXQQw/5vY8AAAAAEHnhSn744QebPXu2zZ8/3/766y8rVaqU9ezZ01q0aOH/HgIAAABAJIWrXbt2uUCloX87d+60iy++2Jo3b25Tp061119/3S677LLg7ikAAAAApPdwdd9999mqVausQoUK1qRJE7vxxhutWrVqbpvCFQAAAABEuxStc7V+/XorWbKkXX311VajRg2rWLFi8PcMAAAAACKt52rZsmW2aNEimzt3rk2aNMkVrtBaV+rB0tpX+gEAAACAaJainqscOXJY06ZN7Y033rAlS5ZYnz59XCGLZ555xk6fPm3PPfecqxqovwEAAAAgGqW6WmDevHmtdevW7ufAgQP26aef2ieffGKPPPKIFSxY0IUvAAAAAIg2F1SK3VOoUCFr166d+1E1wXnz5vm3ZwAAAAAQaeGqffv2bl6VwlTZsmWte/fuZ11GBS86d+4cjH0EAAAAgMgIV8WLF3fhSsP+ihYtGvy9AgAAAIBIDFfDhg0L/p4AAAAAQDQMC0ypiRMn/pP9AQAAAIDIDVf16tWL//uPP/6w6dOnW+PGja1q1aqWJUsW+/nnn10xi7Zt2wZzXwEAAAAgfYerHj16xP/dsWNHt85VmzZtElymbt26LnQBAAAAQDRK0SLCgVavXm1XXXXVWedXr17dNm7c6Nd+AQAAAEBkh6vKlSvb2LFj7cSJE/HnHT161F577TWrUaOG3/sHAAAAAJG5iPDgwYPdelYNGjSw0qVLW1xcnG3bts2Vax8zZkxw9hIAAAAAIi1clStXzj799FNbunSpbdmyxZ1Xvnx5u/rqqy1z5lTfHAAAAABE57BAyZo1q11//fX2wAMPuJ9rr702KMHq5MmTNnDgQFcsQ+Ht5Zdfdj1lsmHDBmvdurWb69WyZUtbv359guvOnTvXVTTU9u7du9vBgwd93z8AAAAA+EfhKq0MGTLE9ZCNGzfOXnrpJXv//fddRcK///7bDU2sU6eOffDBB1azZk3r0qWLO1/Wrl1rffv2dVUOdfkjR45Y7969Q/1wAAAAAESwsB3Hd+jQIZs1a5a9++67Vq1aNXdep06dbM2aNa6XLFu2bPbkk09ahgwZXJD6+uuvbf78+daiRQubPHmy3Xrrrda8eXN3veHDh1ujRo1s586dVqpUqRA/MgAAAACRKGx7rlauXGm5c+dOsICxequGDh3qAlbt2rVdsBL9rlWrlisTL9quXi1PsWLFXMENnQ8AAAAAYdNzFRsba998842rEqieol9++cXKli1refLk8W3H1MtUokQJmz17tr355pt26tQpd19du3a1/fv322WXXZbg8gULFrRNmza5v/ft22dFihQ5a/vevXtT/TiDLVOmTEG/DyBSpcVnFAAARLfYVLQ3Uh2ufv31V1fEQsP2Dh8+bDfeeKO9/fbb9uOPP7q5URUrVjQ/aP7U9u3bbdq0aa63SoGqf//+liNHDjt27JgrqhFIp1UAQ44fP37O7Sm1bt06CyY9Fq0bBuDCaOFyfR8AAACEg1SHq0GDBrkheQMGDIgfeqcqfpr3pAIUkyZN8mfHMmd2ixOrkIV6sGTPnj02depUt75W4qCk09mzZ3d/az5WUtsVZlKjatWq9CwBYcyvgzkAAADn6rlKaadLqsPVDz/84Kr2BQ5ny5Ili3Xr1s3uvPNO80vhwoVdSPKClZQpU8b1nGke1oEDBxJcXqe9oYBFixZNcrtuMzX0GBm2B4QvPp8AACBdF7RQ79Dvv/9+1vmad6UCFH7R+lQnTpxwt+vZunWrC1vapmGI3ppX+r1q1Sp3vnddFcTwKJDpx9sOAAAAACEPV/fcc4+b+/Tll1+60wo/Kpner18/a9WqlW87pgIZWqhY61PFxMS4Ahpjx461e++912655Ra3dtVzzz1nmzdvdr8170Ll10WX+eijj2zGjBnuuirZrtuiDDsAAACAYEn1sMDu3btb3rx53ZwrBRqVR1clvo4dO7pCF34aMWKEDR482IUlzZdq27attWvXzpVeHzNmjD377LNuiKLmXSh45cyZ011Piwprbthrr73mim40aNDA3Q4AAAAABEuGOG9sXQrNnTvXrrnmGsufP7+r6KcJXn6WYA8HekxaM6tGjRppMqej7atzLWb3waDfDxApKpUoYFMeaxbq3QAAAFEgNhXZINXDAgcOHGgHD/7/IKCeokgLVgAAAABwIVIdrurXr+96r1K7ZhQAAAAARLJUz7lSpcDXX3/d3nzzTStQoIArlx5o4cKFfu4fAAAAAEROuPrrr78sV65c7u+77rrL/QAAAAAAUhmuGjVq5EqbFytWzJYvX259+/b1dU0rAAAAAIiKcHXmzBlbsmSJXXXVVTZ79my777777KKLLkryssWLF/d7HwEAAAAgMsJVhw4d7JlnnnHrS6lye1KLBet8bf/555+DsZ8AAAAAkP7DVa1ateybb75xFQJvvPFGt3CvilkAAAAAAFIRrnr06GGffvqplShRwg3702/CFQAAAACkMlzlzZvXRo8e7Xqwfv31V5s3b16yBS2aN2+ekpsEAAAAgOgLV/3797eRI0fa0qVL3em3337bMmY8e/1hzbkiXAEAAACIRikKV5pnpR+54YYbbObMmQwLBAAAAIDUhqtAixYtSu1VAAAAACDipShcXX755fbtt99awYIFrVKlSm74X3IoxQ4AAAAgGqUoXE2YMMHy5cvn/p44cWKw9wkAAAAAIjNc1atXL8m/AQAAAAAXOOdKpdhHjBhhMTExduLECYuLi0uwfeHCham9SQAAAACIvnD15JNP2uHDh+3uu++2PHnyBGevAAAAACDSw9WaNWts1qxZVr58+eDsEQAAAACkQ2evBHwepUuXdj1XAAAAAIBU9lytWLEi/u9bb73VDQ3s2rWrlSpVyjJlypTgsnXr1k3JTQIAAABA9IWrdu3anXVev379zjpP61+xzhUAAACAaJSicKXKgAAAAAAAn+Zcbd++3U6dOpXgvGXLltnWrVtTczMAAAAAEJ3hSmtZDRkyxM23+vHHHxNsmzRpkjVt2tSGDRt21ppXAAAAABAtUhSuJk6caPPmzbPRo0dbvXr1Emx7/fXX3fkffvihTZ06NVj7CQAAAADpP1y9//77roBFo0aNktx+ww032BNPPEG4AgAAABC1UhSudu/ebdWqVTvnZa688krbuXOnX/sFAAAAAJEXrgoWLOgC1rns3bvX8ufP79d+AQAAAEDkhaubbrrJRo4ceValQM/p06dt1KhRds011/i9fwAAAAAQOetcdevWzVq1amUtWrRwCwpXqVLF8uTJY4cPH7affvrJJk+ebH/99ZcNHz48+HsMAAAAAOk1XOXNm9cVtRgxYoQruX7s2DF3vkqvK2Q1adLEHnnkEStUqFCw9xcAAAAA0m+4Es2n0lpX/fv3d4Urjhw54s675JJLLFOmTMHdSwAAAACIlHDlyZo1q5UrVy44ewMAAAAAkVzQAgAAAABwboQrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAACCawlXnzp3t6aefjj+9YcMGa926tVWvXt1atmxp69evT3D5uXPnWuPGjd327t2728GDB0Ow1wAAAACiRboIV5988ol99dVX8af//vtvF7bq1KljH3zwgdWsWdO6dOnizpe1a9da3759rUePHjZ9+nQ7cuSI9e7dO4SPAAAAAECkC/twdejQIRs+fLhVrVo1/rx58+ZZtmzZ7Mknn7Ry5cq5IJUrVy6bP3++2z558mS79dZbrXnz5lapUiV3fYWznTt3hvCRAAAAAIhkYR+uXnjhBbvjjjvssssuiz9vzZo1Vrt2bcuQIYM7rd+1atWy1atXx29Xr5anWLFiVrx4cXc+AAAAAERduFq2bJn98MMP1q1btwTn79+/34oUKZLgvIIFC9revXvd3/v27TvndgAAAADwW2YLUydOnLBnn33W+vfvb9mzZ0+w7dixY5Y1a9YE5+n0yZMn3d/Hjx8/5/aUio2NtWDLlClT0O8DiFRp8RkFAADRLTYV7Y2wDVejRo2yKlWqWMOGDc/apvlWiYOSTnshLLntOXLkSNU+rFu3zoJJ+1O5cuWg3gcQyTZu3OgOtgAAAISDzOFcIfDAgQOuEqB4Yemzzz6zZs2auW2BdNobCli0aNEktxcuXDhV+6AiGvQsAeGrYsWKod4FAAAQBT1X61LY6RK24WrSpEl2+vTp+NMjRoxwv5944glbsWKFvfXWWxYXF+eKWej3qlWr7OGHH3aX0dpWK1eutBYtWrjTv/76q/vR+amhYEW4AsIXn08AABBOwjZclShRIsFplVqX0qVLu+IUL730kj333HN2zz332LRp09zQIJVfl3vvvdfatWtnNWrUcL1Putz1119vpUqVCsljAQAAABD5wrpaYHJy585tY8aMie+dUon1sWPHWs6cOd12DSUcNGiQjR492gWtfPny2dChQ0O92wAAAAAiWNj2XCU2bNiwBKerVatmH374YbKXV+jyhgUCAAAAQLCly54rAAAAAAg3hCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAAB8QLgCAAAAAB8QrgAAAADAB4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAIsdgzZ0K9C0C6xGcHQLjJHOodAIBolyljRnvmvW/sl32HQ70rQLpRpkg+G9KmYah3AwASIFwBQBhQsIrZfTDUuwEAAP4BhgUCAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAJEern777Td79NFHrV69etawYUMbOnSonThxwm3buXOndezY0WrUqGFNmjSxb7/9NsF1ly5das2aNbPq1atb+/bt3eUBAAAAIOrCVVxcnAtWx44dsylTptgrr7xiixcvtldffdVt6969uxUqVMhmzZpld9xxh/Xo0cP27Nnjrqvf2t6iRQubOXOmFShQwLp16+auBwAAAADBkNnC1NatW2316tW2ZMkSF6JEYeuFF16wa6+91vVETZs2zXLmzGnlypWzZcuWuaD1yCOP2IwZM6xKlSrWqVMndz31eDVo0MCWL19u9evXD/EjAwAAABCJwrbnqnDhwvb222/HByvP0aNHbc2aNVa5cmUXrDy1a9d2YUy0vU6dOvHbcuTIYVdccUX8dgAAAACImp6rvHnzunlWnjNnztjkyZPtyiuvtP3791uRIkUSXL5gwYK2d+9e9/f5tqdUbGysBVumTJmCfh9ApEqLz2ha4HsAuHCR8j0AIDK+Z8I2XCX24osv2oYNG9wcqvHjx1vWrFkTbNfpkydPur81T+tc21Nq3bp1FkzqUVMPHIALs3HjRvd5T8/4HgD+mUj4HgAQOTKnl2A1YcIEV9SiQoUKli1bNjt06FCCyyg4Zc+e3f2t7YmDlE6rNyw1qlatyhFlIIxVrFgx1LsAIMT4HgCQFj1XKe10CftwNXjwYJs6daoLWDfffLM7r2jRorZ58+YElztw4ED8UEBt1+nE2y+//PJUD9VhuA4Qvvh8AuB7AEA4CduCFjJq1ChXEfDll1+2pk2bxp+vtat++uknO378ePx5K1eudOd723Xao+ECGlLobQcAAACAqAlXW7Zssddff90eeughVwlQRSq8Hy0qXKxYMevdu7dt2rTJxo4da2vXrrVWrVq567Zs2dJWrVrlztd2Xa5kyZKUYQcAAAAQfeFq4cKFbnzjG2+8Yddcc02CHw0BUPBS0NJCwXPmzLHRo0db8eLF3XUVpEaOHOnWvVLg0vwsbc+QIUOoHxYAAACACBW2c646d+7sfpJTunRpV5o9Odddd537AQAAAICo7rkCAAAAgPSEcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAEAZiz5wJ9S4A6U5smH1uMod6BwAAAGCWKWNGe+a9b+yXfYd5OoAUKFMknw1p09DCCeEKAAAgTChYxew+GOrdAHCBGBYIAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAAAAAPiBcAQAAAIAPCFcAAAAA4APCFQAAAAD4gHAFAAAAAD4gXAEAAACADwhXAAAAAOADwhUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgg4gNVydOnLA+ffpYnTp17JprrrF33nkn1LsEAAAAIIJltgg1fPhwW79+vU2YMMH27NljTz31lBUvXtxuueWWUO8aAAAAgAgUkeHq77//thkzZthbb71lV1xxhfvZtGmTTZkyhXAFAAAAICgiclhgTEyMnT592mrWrBl/Xu3atW3NmjV25syZkO4bAAAAgMgUkT1X+/fvt4suusiyZs0af16hQoXcPKxDhw5ZgQIFznn9uLg49/vkyZOWKVOmoO6rbr/8xfksa6YMQb0fIJKULpzXYmNj3U8k4HsASL1I+x4QvguA8Pwe8G7fywhRF66OHTuWIFiJd1qB6Xy83q0NGzZYWritfE4z/QBIsdWrV0fUs8X3AJB6kfY9IHwXAOH7PZCSEXARGa6yZct2VojyTmfPnv2818+cObNVrVrVMmbMaBky0KMEAAAARKu4uDgXrJQRojJcFS1a1P744w8378p7EjRUUMEqb968572+QlXini8AAAAAiLqCFpdffrkLVYHdhCtXrozvjQIAAAAAv0Vk0siRI4c1b97cBgwYYGvXrrUFCxa4RYTbt28f6l0DAAAAEKEyxKWk7EU6LWqhcPX5559b7ty57YEHHrCOHTuGercAAAAARKiIDVcAAAAAkJYiclggAAAAAKQ1whUAAAAA+IBwBQAAAAA+IFwBAAAAgA8IVwAAAADgA8IVAAAAAPiAcAUAwD9w5swZnj8AgJP5//8CEGxaUi5Dhgw80UAEfI5/++03y5QpkwtWRYoUCfVuAQgD/J+HEK6ANKAGWMaM/7+j+OTJk3b8+HHLmzcvX8hAOmw4LViwwF599VXLkiWL7d+/31q2bGlNmza1ChUqhHoXAYT4+2HZsmW2cOFCK1mypNWtW9euuOIKXpMokyFO7wYAaXIk6/XXX7e1a9e6n+bNm7svXTXKAKQPa9assU6dOlnPnj2tRYsWNmPGDHv++eft7bfftvr167vABSA6/8cvXrzYunfvbjVq1LA//vjDChYs6E5fddVVod5NpCHmXAFB5n3pjh492iZMmGC33367DRs2zFasWGFjx451w4sApA8bN260mjVrWtu2be3333+3KVOmuL+LFStmX3zxhbsMxyyB6Psfr//lu3fvtmeeecbee+89GzJkiJUqVcpGjhzperMQPQhXQBrQMMCffvrJBg0aZE2aNLHs2bO7Rlq3bt1cAy0mJobXAQhDXlDSZ1SNpxw5clj+/Plt27ZtLlSpt6pfv35u24ABA2zXrl3MrQSizN69e+26665zQSpnzpzuvNq1a9vdd99tpUuXttdee82+++67UO8m0gjhCgiCxEeudXrr1q0WGxtrS5YssS5duthTTz1lN998s40bN87N4QAQnsN9fvjhB7vvvvtsz549VqBAAfvmm2/szjvvtMaNG7sDJpIrVy4rVKgQwwKBKHTxxRfb4MGD3YHUzZs3x5+v4YH33HOPlS1b1vVkacQKIh8FLYAgDhNYtGiR+9KtXLmyC1KzZs1yDbW+ffvaXXfd5S6TNWvWBF/GAMLnc7xhwwZ78803rXXr1m44oKjHeejQoe70gQMHXE+WJrCremC2bNlCvdsA0ujAy8GDB93nXnMt9R2h371793Zzre6//3532erVq9upU6fcd4OGDyPyEa6AINmyZYubU1WiRAk3+V3hav78+VanTh2rV6+eu8yxY8ds586d7jwA4ddw0lAeHRBRgPJ06NDBjhw54o5UqydLw4DUq/XOO+8kuByAyK4aqmGAGpFy9OhRe+CBB9yw/+HDh9uTTz7pLtOxY0d3Hf2Pr1q1KgdfogTVAgGfy60HVg765JNP7KOPPnINLn3Zap6GhgZozpWOcOlo1l9//WUffvihZc7MsQ4gXGj4jobwajjgxIkT7a233nJDAHV02rNq1So31+rEiROu8aTSywAi38qVK93w/h49elj58uVt/fr17v94o0aN7KGHHrKvvvrK+vfvb4888oh17tw51LuLNEZrDvCJt46VqgV5jSyVWVfQ0nDAF154wfr06eMmtq5evdqVdFYlITXeFKxOnz5NwALChNav0nDA2267zZVS1udYR6n1WdV8K6lVq1aodxNACKj637XXXhvfM9WgQQMrWrSo+/+u//8qdqPebS2/oqIW+fLl43WKIvRcAT4uEKwj3RoaoDVvrrnmmvjLqAdr0qRJdskll7gjWQpVgTSsQOO2AYT2MxxIcyc0J1LVAFXVc/r06e5AyX/+8x+3Th2A6KQRKKoMqgMwgQdG//vf/9oHH3xgn376qRsu/Oeff1qePHlCvbtIY1QLBP7ph+j/GmUnT550R6/uvfde69q1qwtaHvVgNWzY0H3hPvfcc/bLL78kuA2CFZD2Jk+e7IbzeJ9hzX9USWWPeqbUw6y5Vzoq3apVKzcsUCXX586dy0sGRFH1X/2P96j63/fff2/bt293wUoHSOWyyy5zxSy8sEWwik6EK+AfHO32aHx1y5Yt3aTWZ5991g0D0Ljrb7/9Nv4ymsyqdS8UsrTuBYDQ2bFjh1t7zmv8qOqfwpPmSWixb1GQUkNJYUqKFy9uLVq0cNUCq1SpwssHRDhvDrX+x/fq1csN99P3Rps2baxu3bquuI2WWfEC2Nq1ay137tyuNwvRi2GBwAUILFrx/vvvu4aaNxTw5Zdftrx587oeqqlTp7rhA1dccYW9+uqrbligV0UouaFIANLG33//7YbuqHeqcOHCbo6E1rAaM2aMK7N+++23u7WrNFFdSyd4VT0ZxgtELvVQaTiwZ/Hixfbvf//bFaZQASoFKw3tVzGbl156yT777DN3sEXXWbdunesRr1SpUkgfA0KLcAX8A6NGjXIBqlOnTq4S4P/+9z8XnNQ40wRWBS2VY1eo0hoXGoutKoGB4QxA2gr8/B0+fNjNqVIhmueff94qVqzoGk2jR492v3WUWkeimzVr5iqDAYhcmkOl4KSS6qKKvo8++qj7XtBcSy2foiqhWqJBvdoqbqPKgd7/fi25cumll4b6YSDECFdACmlNGw0LUBl10ZesFgnUxHatwC4///yzqw6kSmMKVerB0nkq1axhgZpbRVVAIPwqf6lQhcKUGlCaa6XP7KFDh2zGjBnuAIoOiqgwjXq6ODACRKZhw4a54cDlypWL76FWj9XFF19sjRs3dksy6HtBB2VUFVChS0OJ+U5AIMYkASmg+Rg6sh1YeMJbODDwPH3RqpjFH3/84Rpp+gK+/PLL44OVrsN6VkDaUxGZwHmS4s2TuOqqq9ywPw0NfOWVV9xSCeppVhEL9VZpcWCFrFy5ctGIAiKQ913w9NNPu2Clde4+/vhjd55ClQ6sqNKvDq4+/PDD9vXXX1v9+vXd4uEEKyRGuAJSQPMuNFxAR6+1KLDGXWuokIKT5lrpKLf7QGXM6L6YL7roItu4caNbZFBHubweK6oCAmlPcyJvvfVWW7BgQYKApUaR16iqV6+e64FWwNI8Ck1MDzxoovMBRCYvIHnfBwpTL774os2ZM8cdeNHc6tmzZ7ueK1X/FR1c1fWOHz8e0n1H+GFYIJAK+jLVCuwKUBMnTnRr32iiq0KTjm7nyJHD9U6pmtjVV19tX375pQtVWlhQgQtAaKjaV8+ePd2wnxtvvDFBMZnAOVjLly93vVSbNm1yxWioCghEPu87QHOsdBBVVJRKxSzUe/2vf/3L9WZrHrUOmGr9qqVLl1K8Akmi5wo4h8TDiNRbpaNXWvdG47B1WqXX1VBTg03l1zVeW2vlaL2rxx57zFUk01wt3ZZ3VAxA2rruuutcw0ifxYULF5712faoB0vLKqjCJwdEgOgJVlq3SosA60cHSfv27esOpmoe9eeff+4uq+8FzbfWaJZp06ZRFRBJoucKSEZgqXSVWtUXqoYGaaFgzb9q166dlSlTxkaOHOkmub/33ntueICu1759e1eWVSVdVW1Mcze0Rg6A0PdgqbdZQ34S92D9+uuvrgdaRWq0GKiOVAOI/P/x8+fPtyeeeMIdXNGcSw0F1sGYYsWKuR4sfW+oB0vLMwDnQ7gCkhA4TEiNMK1boWpB6pHSpNYHH3wwPmCpYpDmXQWui5HUWhkAwitgDR8+3A33kX379rnPuiax66d8+fKh3k0AQaD/4/p/7tEQYI1E0XeCDqxs2bLFzavS0H4NIy5SpIgNHTrULaUycOBAu+WWW1z7gEIWSA7DAoEkeF+aKkqh9SymT5/uApSGCWiyu/4uUaKEC136om7RosVZk1oJVkD4DhHU0B8t6K0iFyrBrqD1xRdfuAWDCVZAZNISKRqur7mVHlX8UyVQrWWnIf8jRoxwCwXrfAUufT/07t3bjUjRsED1dhGscC6Zz7kViGJa20YNrzx58rhFAVWCVcP7NJRAR6/05frAAw/YuHHj3BFvbxIsgPQTsNTQKlu2rFsEXEN7VQEUQORREQotAKxhf+qF0gHRa6+91i2PoiH+GhasKQD58+d3B160fIMWCVbA6tSpkxu1AqQE4QpIYiigaG0qVQTUWlXr16+3OnXquN4o9VLpclpUWCXZtXq7qgGKt+gggPQRsF599VW3ZIIK1VSqVCnUuwQgSHSgtEmTJm5Y8Pbt2908Kx001fA/Fa9R79U333zjhgrrfP1/r1y5spsvrR4rIKUYFgj838RWL1ipFKtKrqsEs4YQ6EtXISsmJsZtV8DS0azHH3/cDRlUKPOqABKsgPQXsH788UeCFRDBvOqgKkjRqlUrN9Jk165dNmXKFFu5cqULUarsq96ratWqucsuWbLE9WgNGjTITQMAUoqCFoh6gT1WY8aMcYuH/u9//3NHuDSpVUe7VMCiQoUK7gi3d3RbIUzDCbyFSBmDDQBAePKKTKnnasWKFVarVi2bMGGC5cuXz9q2betO33333a4ycIECBVw7QAdWGSqM1CJcAf9n1KhRrkBF165d3SKBa9ascV/GGm+to1Zaw0pfsh06dHBDBj0EKwAAwu9/uopPaF5V4GLgKlrRrVs3u+2226xx48ZufpUOomqIv4YAKnDp//qtt95q5cqVC+ljQPpEuELU8kKRfh85csRNVlVw0to3omGAWiRQZVlfeeUV94V83333uYpBWu8CAACEHw3v0wLAorUpdYD0mWeecWFLI07WrVvnqv/qf7vaAJpDrR4stQFq164d6t1HOsecK0SlwN4mhSb9vXXrVheyPBr+pyEC+pLWMAINC5wxY4br2QIAAOFJi/+qB0pU/U/D/TXXSqNTdMBUo08033Lp0qVuwfBevXq5OVgzZ850wwKBf4JwhaguXqEV2LVulRYQVXhSBSFVCPJoGKC+pDdv3uxOly5d2hWtUFVAAAAQnurXr++WSlm8eLFbckFDABWyNIdaJdcLFSrkRqfoAKqGDT733HNuVEqOHDlCvetI5whXiBqaPyUaFiBaw0qLBN9zzz3uyJWGA7777rs2d+7c+B4sVQ08ceKEXXLJJQlui6qAAACENw0J1EHUp59+2vVWPfHEE259Sq1NuXfvXrdQ8BtvvOHWvNLBVKoCwg+sc4WooJ4pBakrr7zSlWDVsACNt9a6Fnnz5nWXUbUg9VqNHDnSlWDVtt27d7shAq1btw71QwAAAKl0/fXX2wsvvOB6r4YPH+7mTqsy4PLly93/eS3FcPr0aZ5X+IaCFogK6qXSYqH9+vVz5VUvvvhiO3DggD3//POukEXnzp0TXFaTXbdt22YlS5a0//znP24CLAsEAwCQPmnutP7fjxgxwi0U7I1OUXVg/a8H/EK4QtTQhNWvv/7ahaT333/fypYt6ya8Dh061IUu9VwlR0e1FLAAAED6DVg9e/Z0CwPfdNNNbt0rwG/MuULEVwX0ik/UrVvXLfyrcqsa7qc5WCq7qrHYKsP63nvvxV8vccEKghUAAOmbKgRqiOCwYcNcewAIBnquENFVAb3iFbJjxw4Xkt588003xloLBuqLVkeuxo8f7ya4aky2FgsGAACRSfOrNd8KCAbCFSJ+HauxY8fa999/74JWp06d7KqrrrLHH3/cNm3a5ALWDTfc4LYpYGm+1aRJk9z1vOsDAAAAKUG4QkRTL5XmValHSiVXVS1Q4Up69+5ta9ascZWDYmJi3BoY11577VnhDAAAAEgJwhUiksKRSqh36dLFmjRpYvfee2+C7aoGqDUvBgwY4IYIZsuWzc250rBBghUAAAAuBOXPELFUlOL333+PX23dq/i3f/9+VyFQwUvhavv27VaqVCk3NJBy6wAAALhQVAtExBSvCKQhfXny5LFLL73UJk6cmKDinyaxqldLCwlL6dKlXbDSbWTKlCkEew8AAIBIQLhCRFUFVEGKOXPmuHlWqgakghUKTIEVAHPmzGm5c+e27NmzJ7idwMqCAAAAQGox5wrpWuD8qOHDh9vcuXPtiiuuiC+7/uCDD1rBggVdmfUjR45YzZo1bdeuXfbnn3/aRx99xPpVAAAA8A3hCunSb7/9ZkWLFo0/vWzZMuvbt6+NHj3aLr/8clu8eLF17drVZsyYYSVLlnQBTKXWNadKoat79+7uN3OsAAAA4BcKWiDdefbZZ+3w4cNuyF/ZsmXdeeqVyp8/vwtW8+fPd0GrX79+bkjgyy+/bIMHD3bl2AMRrAAAAOAnJpkgXZk1a5bVrl3bfvrpJ9cT5RWlULAqVKiQffjhh9anTx/r1auXtW3b1p0/e/Zs17OVGMUrAAAA4Cd6rpButGrVyo4ePep6pkqUKGFPPvmkm3PVuXNnq1atmptLpYWB1WN1zz33uOv8/fffrhpgkSJFQr37AAAAiHD0XCFd0CLAmjelnitR79WwYcNs6dKlbp7ViRMn7N1337WLL77YlixZYp9//rmtWLHCRowY4SoDlilTJtQPAQAAABGOghZIF8FK4Wny5MmujPrJkycta9asbltMTIz16NHD6tataz179nTzqDQkUIsHK4yp6MWYMWMsS5YsCUq2AwAAAH4jXCGs3X///S4oaS6V5kgFBqvHH3/crV+loX8KVPXq1bOnnnrKLR6sghda58qrFHj69GnKrgMAACCoOIyPsLV9+3ZXiOKOO+5wPVfiBStVCtywYYMb8lerVi03RPCHH35wwwBV5KJAgQJWqlQpF6zUY6Wy6wAAAEAwEa4QtlSIQkMBp06datOnT7fjx4/HB6tffvnF3n77bdczpV4pDQscOnSoW0RY87ACMRQQAAAAaYFhgQh76pFSZcCHH37YFi1aZHv27LE33njDVQxUtUD1Tmmu1bRp01wPV4cOHSizDgAAgDRHuEK6oMp/Xbt2tezZs9tbb73lFgsOLFDRqVMn15u1YMECF6xYIBgAAABpjWGBSBc07E/DABWcVq1aZQcPHowPVipq8euvv7ry69qu0MUCwQAAAEhrhCukGzVq1HAFK8aNG2effvqpC1gaKrhjxw6bM2eOK7eu+VfMsQIAAEAoMCwQ6XIO1tNPP+2CVI4cORIEK6oCAgAAIFQIV0iXli9fbq+99pq9++67BCsAAACEBcIV0i2vUiA9VgAAAAgHhCtERMACAAAAQo2CFkjXCFYAAAAIF4QrAAAAAPAB4QoAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwBAunL48GEbNmyY3XDDDVa9enW79dZbbfz48XbmzJkUXX/ZsmW2ZcuWs84fN26cXX311bZ//34LlpEjR1q7du2CdvsAgNCiFDsAIN34448/7O6777YiRYpY9+7drWTJkrZu3TobPHiwNWnSxPr163fe26hYsaJNnDjR6tevH39ebGys3XTTTfbss8/addddF7T9/+uvv+zUqVOWP3/+oN0HACB0MofwvgEASJWXXnrJsmbN6nqZsmXL5s4rVaqUZc+e3bp162b33XeflSlT5oKWdZgzZ47lzp07qK9Irly5gnr7AIDQYlggACBdOHnypH3yySfWtm3b+GDladSokRsaWKJECdu8ebM98MADVrNmTatataq1adMmfhighhJK+/bt3RA9+eGHH6xVq1ZuSOBtt91mn332WYLb1u02bNjQatWqZUOGDHHD+j744AO37cSJE/biiy+63q4aNWrYww8/bL/++qvbtmvXLtdLNnr0aKtbt64NGjTorGGBuu8WLVpYtWrVkrxvAED6QrgCAKQLO3bssL///tsFpqR6nq688krLnDmzCzgKWR999JFNmzbNDflTAJKZM2e63wo5nTp1cvOrunTp4gLOxx9/bA8++KA9/fTTLvSIerNee+0169Onj02fPt0FphUrVsTfr4YRfvHFF/bCCy+4+zp9+rTrQQuc/7Vq1SqbNWuWC3SBznffAID0h2GBAIB04ciRI+53njx5kr3M8ePH7Z577nG9VTlz5nTn3Xnnnfb222+7vwsUKOB+58uXzw3Re+utt1yPlYYTSunSpe3nn3+2CRMmWJ06dey9996zDh06uKIZohDlzclSYQ0FON2Ggp2MGDHCrr/+eluyZEn88ERd/5JLLjlrX6dMmXLO+wYApD+EKwBAuuAVgVCoSY4C1b333muzZ8+29evX29atW23Dhg1WqFChJC+v7YsXL3ZDCD0qOOEFo40bN1rnzp3jtymUedu2bdvmeqhUsTBwH7VdwxC9y6kX7ULuGwCQ/hCuAADpgnp/1Gv1008/uTlKiXXt2tXuuusuGz58uF100UVuflWzZs1ciHnnnXeSvE0N49NcJw0lDKThhZIpUyaLi4tLsM07nXjel0fDEAOHBSZ3ufPdNwAg/WHOFQAgXVDoULl1DadTcYtAixYtcj87d+60ffv2uVLrmsOkYXd79uw5KyB51Eu0fft2NyTP+1m4cKGbAyWXXXaZC3Oeo0ePust7VQq1T6tXr05QKl7bU9L7dL77BgCkP4QrAEC68cgjj7iAo2qAy5cvd0UuZsyY4QpBqGCEil2o6MWCBQtc8QltSxzGNHRw06ZN9ueff7q5WRo++Morr7hhfgo2L7/8shUvXtxdVpX9FNQ+//xzN9RPhS10+yqgoTlbrVu3dmtsff/99xYTE2O9evWyiy++2Bo0aHDex3K++wYApD+MPQAApBuFCxe2qVOnump/TzzxhB06dMgNF3z00UfdXCsN49PiwgMHDnRl0lUKvX///ta3b1/77bffrGjRoi4waeiggpnC0ptvvukKUWjtLG1XULv99tvd/TVt2tT1LqkqoG5PCxhrDlWWLFnc9qeeesoVudD9K8Cpp0yl27UW1/nods513wCA9CdDXHJjJQAAiHLqHdPwv2LFisXPk1JlQK1dVb9+/VDvHgAgzNBzBQBAMjS88Mcff3Q9YRoGqCGCuXPndgsGAwCQGD1XAAAkQ/O7Bg0aZF999ZUbFqiy6RpiqEIXAAAkRrgCAAAAAB9QLRAAAAAAfEC4AgAAAAAfEK4AAAAAwAeEKwAAAADwAeEKAAAAAHxAuAIAAAAAHxCuAAAAAMAHhCsAAAAA8AHhCgAAAADsn/t/GXU+x0m1aNIAAAAASUVORK5CYII=",
       "text/plain": [
-       "<Figure size 1000x600 with 0 Axes>"
+       "<Figure size 1000x600 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -258,25 +350,27 @@
    "id": "6f7356f0",
    "metadata": {
     "papermill": {
-     "duration": 0.003184,
-     "end_time": "2026-02-26T07:41:17.117469",
+     "duration": 0.003271,
+     "end_time": "2026-04-24T00:03:52.422324",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.114285",
+     "start_time": "2026-04-24T00:03:52.419053",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "**Interprétation :** Ce graphique nous montre quelles catégories de produits génèrent le plus de revenus. Exécutez les cellules ci-dessus pour visualiser les résultats et identifier les catégories les plus performantes."
+   "source": [
+    "**Interprétation :** Ce graphique nous montre quelles catégories de produits génèrent le plus de revenus. Exécutez les cellules ci-dessus pour visualiser les résultats et identifier les catégories les plus performantes."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "57b5b47a",
    "metadata": {
     "papermill": {
-     "duration": 0.002778,
-     "end_time": "2026-02-26T07:41:17.122972",
+     "duration": 0.003001,
+     "end_time": "2026-04-24T00:03:52.428562",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.120194",
+     "start_time": "2026-04-24T00:03:52.425561",
      "status": "completed"
     },
     "tags": []
@@ -291,31 +385,30 @@
    "id": "4092c8b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:33.606602Z",
-     "iopub.status.busy": "2026-04-21T00:16:33.606116Z",
-     "iopub.status.idle": "2026-04-21T00:16:33.647353Z",
-     "shell.execute_reply": "2026-04-21T00:16:33.645763Z"
+     "iopub.execute_input": "2026-04-24T00:03:52.435068Z",
+     "iopub.status.busy": "2026-04-24T00:03:52.435068Z",
+     "iopub.status.idle": "2026-04-24T00:03:52.553963Z",
+     "shell.execute_reply": "2026-04-24T00:03:52.553275Z"
     },
     "papermill": {
-     "duration": 0.119322,
-     "end_time": "2026-02-26T07:41:17.244984",
+     "duration": 0.123406,
+     "end_time": "2026-04-24T00:03:52.554969",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.125662",
+     "start_time": "2026-04-24T00:03:52.431563",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m daily_revenue = \u001b[43mdf\u001b[49m.groupby(\u001b[33m'\u001b[39m\u001b[33mdate\u001b[39m\u001b[33m'\u001b[39m)[\u001b[33m'\u001b[39m\u001b[33mchiffre_affaires\u001b[39m\u001b[33m'\u001b[39m].sum().reset_index()\n\u001b[32m      3\u001b[39m plt.figure(figsize=(\u001b[32m12\u001b[39m, \u001b[32m6\u001b[39m))\n\u001b[32m      4\u001b[39m sns.lineplot(x=\u001b[33m'\u001b[39m\u001b[33mdate\u001b[39m\u001b[33m'\u001b[39m, y=\u001b[33m'\u001b[39m\u001b[33mchiffre_affaires\u001b[39m\u001b[33m'\u001b[39m, data=daily_revenue)\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA+oAAAIhCAYAAADZxkARAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAewRJREFUeJzt3Qd4VEUXxvE3hSSEJPTee09ogqKAICggKlLsWFFUsAuKKAqCKGAFLFg/O9KLCFaQpvQUeu+9QyD9e2bCxgAJJJCw7f97npC7e7fM3h02e+45M+OTkpKSIgAAAAAA4BJ8nd0AAAAAAADwHwJ1AAAAAABcCIE6AAAAAAAuhEAdAAAAAAAXQqAOAAAAAIALIVAHAC919OhRbdiwQYcOHXJ2UwAAAJAOgToAeKnevXvr/vvvV3x8vLObAgAAgHT8018AAHiH6OhoLViwQN9++62KFy/u7OYAAAAgHZ+UlJSU9FcAAOBs5k+Tj4+Ps5sBAADgFJS+A4CXePHFF1W9evVMf66++uocfb5///3XPq75nVWmDP+NN97Q1KlTz2h3q1at5CwX8zouNDfAyJEjddNNN6l+/fq66qqrdN999+nPP/8843YjRoywz5vdtg0bNkyNGzdWvXr1NGnSJP3zzz+64YYbVKdOHXXv3l2Xw9ltN9vmfTzbvHnz7D5zLDLz1Vdf2b4ZHh6uDz/8UGvWrFHHjh3t62nfvn2W2rN9+3b7PBMmTJAryOk+dTmZ/4uO99LVjisAeBJK3wHAixQtWtQGiRnJkyePnG3v3r363//+pyFDhqRd9/jjj+vee++VJzCT9z388MNKTk62r6lGjRqKjY21JyYee+wxPfXUU/b1ZlXt2rU1ZswYValSxV5eu3atPvvsM91222265ZZbVKlSJRucm+cbPXq0ChcuLGfJqEJi/Pjxqlatmm33kiVL1LBhwzP2Hz9+XG+99ZauvfZaPfjggypTpoztGzt37tSoUaNUqFChLD13sWLF7HEqV65cjr0ecFwBIDcRqAOAFwkICLCZVnfiKcFVQkKCnn76aXtC5Pvvvz8jaG7durVeeeUVvf/++zZjaQL4rAgJCTnj/Tx8+LD9feONN6pRo0Zp111xxRVq2rSpnHmCyATLZ1cW/P777xowYIA++eQT/fjjj+cE6keOHLEnGczxMa/BMKsUmOC+RYsWHt3v3QHHFQByD6XvAIAzfPzxx7as2ARJZ5cgmwzugQMH7OXNmzfrySeftGXJJgjq1q2bzYpmJqMS9vSls2b7uuuus9f37ds37bZn3y8pKUnfffedLZc25dAm2zp8+HDFxcWd8VxmRnuTsXWUfZsM899//33Bd9sEjOY+5rHvuecem73NSkm6uc7sy8zs2bNt5thkzTPKbJtjaZ4vMTHxjOtnzZqlm2++WXXr1rXtMuXsGZVQm+c274FhSunNMTP7duzYYe+T/nZt2rSxlRWmRP6aa65Je6/Hjh1rg3xzvMxxNbc1x/t8zHE3WW7TD0wpv3nv0r8Xhgmszz5mporAvNZmzZrZ1zdz5sy0Ew2G6ROO9/2ll15KG6KxcOFCLVq06IySa3P5oYcessG8abu5n2m7CfIzKtE2v2vVqmVfr2m3OQ7r16+3+8zJg06dOtnjbfYNGjTIVj04nDp1Sq+99pqaN29un6tt27b6/PPPdaku9P8ps3J5czvH+26Y126Gj5g+YPpwv3790u5rJpA0lQkRERH2ecwwifTv78GDB+2Jk5YtW9rXZo5Lz5497fHLSEal7+b/y7PPPmvva57HtGPlypXn3OfLL7+0x87cxvw/BQCciUAdALyMCY4y+nHMLWoCYHP5119/PeN+P//8sw3qTJBpghoTzJgv3S+//LINlE1ps/lSbgKpi2Eyro6yfFMGnlmJfv/+/W1gaLKsH330ke6++247e70pGU8/P2pMTIwNoEzwY8qk/fz89MQTT5xzAiI98zivvvqqzdaa8dAmiDCZ7pxgThKYNmSWCTZZZ/NcJkA6+/Wakw7mtZYoUcKehFi9evU59+/atau9reM+7777ri33No9rntNsmxMtjmDKnDgwtzGBdf78+W1W2zy/GTNvTtaY4/rpp59e8PWbZf5++ukn9ejRQ++99549vuakTnpffPHFOePJTXBmgvQiRYrYMeem4mDixIlp+82JgvT9wbTf/JgA2/yYbXMbcyzM8SlQoIB9PeY4mWoCc99ffvkl03abANW0a/DgwfYYVK5c2Z48MIGpGTJg+kyvXr00ZcqUM/qWCYLNe/nCCy/Y/mVOLg0dOvSSgs2c/v9kTmSZEw2mD3fp0iXt+ueff95WLZj3t0OHDnaYhDlZYZjXZ95DM2+AuZ15beb1m+De/J/IChPo33HHHVqxYoXtN2+//bY9WWL6khn2kZ45kWKGgZhjl9PzYwCAJ6D0HQC8iMmuOoK1s/Xp08dmJUuXLm0zk9OmTbPBn7F161ZFRUXZQMgwQZApe/36669t+bVhgibz5d988R43bly222Yer2bNmmnl7iYYyyigMY/93HPP6ZFHHrHXmS/5Jsg37TcBlCMQPnbsmM30OUrng4ODbcbaMbna2UygYgIbE1CaDK5hTkyYcdImy36pdu/erYIFCypfvnzZup/J6JrsrWFei8mGm+Dt7PJ4E8Q7xqqb3+Ykg+O4mrHc6Uu/zYkYE2g6yuPNsTKv/fbbb7eBouO1m+DXXH7ggQdUtWrVc9q2bt06mwk3GeY777zTXmeCb3Oyx5GhzoiZEM4Ecx988IG9XKpUKV155ZU2+DbPZZg2p+8PjvY7+pvjsnnPTVm/yQ77+vqm9QkzOZ/JJJsKgcw8+uijtt863n8TIJv2m98OFSpUsCcCzIkNc1tz7M3jOx63SZMmtm9dyvj/nP7/ZI6nCbYdHFl48//ZnIgwzAkZUz1gKjZMcG3mh8ibN+8Z/cK8NvN/37wvWWHmlzBVET/88IP9HDFM3zX/p8ywDsf7bbRr106dO3fO1usCAG9CoA4AXsRkV03GMSMlS5ZM2zalyCaLtm/fPnsfk003AYSjFNkEK6Y81hFUGP7+/jZ4MZnIEydO5Er7HdnFs4Mvc9lkRU1A4gjUTaCXfny7CWSNkydPZvjYGzdutGX95nWlZwKKnAjUTTb9QmXkGXEETYaZTM0xvvtSOYJgY9myZbak27y/6UvvHe+3ybJmFKgvXrz4jNsZJlg2J0LOF6ib7HNYWJh9bY7XYu5j+pw5kWKC9qwy2XjzY8rtN23apC1btmjVqlX2WJssfVaPgXn/zckUk1VOfwzMSSvTz80xMMGzCV5NfzC3NX3N/DiC34uV0/+f0r+u9MzQhPTM/wlHWX/x4sXtiQJzwsJk9s1xNMdk6dKldjWGrDDZd/Pc5rEcx9D0BxOsm8qErLQRAJCKQB0AvIjJ2pmS2AsxY0dff/11WzpsZic3gboJpIKCgux+U95sSpbPZq4zX/RNFjo3OMrWzcmD9ExQY7LVJjPsYLKDGc067hi3nNljm8dJ7+znulgmw2iylyboyiyrboI/xwkFB5OtdXBkjNOX+F+s9G1wjA13VCmczWRbc+qYmeDZBG0mQM9ogjsTBGcnUDcnGExfnTx5sg0OzckME5CaPnGh45T+2DqOgRmjbX4yOwZmzLd5j8xrMM9rfszzmaqCrE4CeLac/v+U/nWl5/j/m74/pT9G5jW988472rVrl62mMMH02fc5H3MMTYCfWdVO+pNkmbURAJCKQB0AcI7Q0FCbJTWBugmaTIlz+rHKZkzz/v37z7mfycA7AjczOdbZgfLZGeX0k3RlhXlex/M4SmsdwZ+ZDfzsgDE7HPd1TJbnkH6Cs/QBv3ktJktuZCXjaUrJv/nmG82ZM8eeCMlofK8Z73zXXXfZYPByMtltw5R8m1Lvs2UURKY/ZqYvmHLrzI5Zen/99Zd9r0yAW758+TP2mZJpU45t3oOslpKbMeam/N6MjzeBvyMANKXdF3MMzBAKMxFaZn3PnOwyY+bNjxnrb16PGTZghmOYE1pnM33VvC5T/u0YmuA4WeQIgrPy/8kEwOnv63C+Ez/ZYaojTNm7mZjODIExWXHDlN6fb5LIsz83zLEzxzAj5tgBALKGyeQAABkys6QvX77cBhkmCEsfvJhyYBOgpM/0mcDVBComY5/RF3ITTJgALf2M4GcHAI7ANzOONpwdEJnL5vnPXt4rO0yAasr/Z8yYccb15nWm5yhPNtlvh6wEMiZQN7Ofm3H+5jiczUy8ZTLCZnz35WbGs5tl4/bs2WPfP8ePyUqbDGtms347Mt8XOmZnl72bjLQZL23KyNP/mCDRnHTJzsRs5tib+5rJBR1BuplI0Jz4yKx6IiNmAjlzcsC81vTHwASs5r0xM5eb7L2pLDGT0Bnm/4WZKM2UqJ+9OoCD6e+mfN2UkDs4buuonsjK/6eM+p3JxJ89SdvFMsMfzPEyEy46gnTThvnz59vtrBxL8//TDD+oWLHiGcfQVDuYcfYX+v8NAPgPGXUA8CJmrKkJvjNjlk1ylIybSbVM+auZSKp79+5pmWTDzAZtJvEyZfGmXNoEeWbG9G3bttmZpDNixuCajLLJFpuZqM1SZWaJpvRf3k1GzjHW1czC7ZgQzcFkJG+99VY7KZUpozUBjhmPbCbjMsGaafPFMq/PTMBlMqNmAjWT9XacqEjPjEk2s86bmdVN5tGUCZtA7EJZTRP0muykWR7LTKJljp0plTYBpZn0zmTazXObJbUuN5OxNe+xmfDLBIvmWJqg3Vw2xyWzkm6TETcT0JmTD+YkgymVNkGZmSwuI6Z83LxOM5t5+v7kYE60mHkFTJ8zM4JnhTlepvLDvE+mz5hZ4M08DObxM5uPICOmHz7zzDP2fTXbpr+a8nyTLTfHwpRzmwy4+W36m+nz5v+LCUzNbPUZTVBomMoPc5/Ro0fbeRNM8Gv6S4MGDdIC4qz8fzLPZU4kmfuaoN28PjNT/9lDPC6Wo98NHDjQ9k9zEsDMHu9YYcBUv6QfQ58RM+meef/Nb9PPTb+aPn26XRXAzCEBAMg6AnUA8CKmlNYEVpkx6207JnlyTGZlgmszuVx6ZmKx77//3mZbzRdwEzSYL/pmMqr0k5+lZ2bKNqW15vFMqbIj4DEzTjuYQMDM+m0CNTPLtpnAK6NSZxMgmqyrWT7MzPhuAhyzhJZjDPfFMrNsm8cwwZkJOEwG3AQuZl1oB5MtfOutt2wwaIIqExw6xipfiDm2JrNoTlCYwNIEgCYLbIIwE5BdyomGS/X000/bseXmfTVtMeXYpnzcvHbHCZSMmAngTGm8CSxNcGdeg5lN3ZSiZ9S/TKB69lJtZ1dymKW7TEBvstwXYparM1l483zmRJQZo27K0s1kdmbm9+xM4Gey/OaEi3n9pg+a98YE1GZIQNmyZe1tTH8wz2Wy6ub/k8nCmxNPTz31VIaPaf5vmBMept+a1QRMZtpUV6Qf3pCV/0/m5IE5QWWWhzPviTnm5oSHmfDNnCy4VObkjDlJYfqmqZAwj2+uM/9HzWR5pnIhs6UFHcyJBzPHgKlAMGP2TTWBqVQxrz39MnEAgAvzScmJGWkAAAAAAECOYIw6AAAAAAAuhEAdAAAAAAAXQqAOAAAAAIALIVAHAAAAAMCFEKgDAAAAAOBCCNQBAAAAAHAhXruOulnHNDEx0a6Xa9YrBQAAAAAgN5nV0U0s6u/vb2PRzHhtoG6C9OjoaGc3AwAAAADgZerWrauAgIBM93ttoO44e2EOkJ+fn1xVUlKSPaHg6u2E66DPgD4DPmfgSvi7BPoM+Jw59zPxfNl0rw7UHeXuJvh1hwDYXdoJ10GfAX0GfM7AlfB3CfQZ8DnznwsNv2YyOQAAAAAAXAiBOgAAAAAALoRAHQAAAAAAF0KgDgAAAACACyFQBwAAAADAhRCoAwAAAADgQgjUAQAAAABwIQTqAAAAAAC4EAJ1AAAAAABcCIE6AAAAAAAuhEAdAAAAAAAXQqAOAAAAAIALIVAHAAAAAMCFEKgDAAAAAOBCCNQBAAAAAHAhBOoAAAAAALgQAnUXt2rXUR2LT3Z2MwAAAAAAl4n/5XoiZN+2g7G6adR8Fc/np9/qJSo0rx+HEQAAAAA8HBl1F1Y0NFAlwoK0+3iShs5c6+zmAAAAAAAuAwJ1FxaUx09vdqpjt7/5Z6vmb9jv7CYBAAAAAHIZgbqLu6ZKEV1fKa/d7jMuSifiEp3dJAAAAABALiJQdwP3hoeqdIEgbT90UkN+WeXs5gAAAAAAchGBuhvIm8dXb3aqa7e//Wer5q6jBB4AAAAAPBWBuptoWrmwul1Z3m6/MD5Kx04lOLtJAAAAAIBcQKDuRl5sV0NlC+XVjsMn9cZ0SuABAAAAwBMRqLuRfIH+GtYlwm7/sHCbZq/d5+wmAQAAAAByGIG6m7myUmHd37SC3X5xfJSOUgIPAAAAAB6FQN0N9WlbXRUKB2vXkVMaNG2ls5sDAAAAAMhBBOpuKDjAX8O6RsjHR/pp8Xb9tXqvs5sEAAAAAMghBOpu6ooKhfTg1RXt9osTonQkllngAQAAAMATEKi7seevr65KRfJpz9E4DaQEHgAAAAA8AoG6G8sb4GdL4H19pPFLt+v3lXuc3SQAAAAAwCUiUHdzDcsXVPdmlex234nROhwb7+wmAQAAAAAuAYG6B3i2TTVVLppP+47F6bUpK5zdHAAAAADAJSBQ9wBBefw0/HQJ/KTlOzVzxW5nNwkAAAAAcJEI1D1E/XIF1aNFZbvdb2K0Dp6gBB4AAAAA3BGBugd5unVVVSseov3H4/UqJfAAAAAA4JYI1D1IoH9qCbyfr4+mRu7U9Ohdzm4SAAAAACCbCNQ9THiZAnrsdAn8K5NidOB4nLObBAAAAADIBgJ1D/TEdVVUo0SoDpyIV//JzAIPAAAAAO6EQN2DS+D9fX30c/QuTYva6ewmAQAAAACyiEDdQ9UpnV+Pt6ySVgJv1lgHAAAAALg+AnUP1qtlFdUsGaZDsQl6eVK0UlJSnN0kAAAAAMAFEKh7sAB/X719ugR+5oo9mhJJCTwAAAAAuDoCdQ9Xq1SYnryuqt02E8vtPXrK2U0CAAAAAJwHgboXeOzayqpTOkxHTibopYmUwAMAAACAKyNQ9wJ5/HztLPB5/Hz0+6q9mrhsh7ObBAAAAADIBIG6l6hRIkxPt65mt1+bskJ7KIEHAAAAAJdEoO5FejSvpPAy+XX0VKL6TqAEHgAAAABcEYG6F/H3S50FPsDPV3+u3qtxS7Y7u0kAAAAAgLMQqHuZqsVD9Uyb1BL4gVNXateRk85uEgAAAAAgHQJ1L/Rws4qqV7aAjsUl6oXxlMADAAAAgCshUPfSEngzC3yAv6/+XrtPYxZtc3aTAAAAAACnEah7qSrFQtT7+up2e9DPq7TjMCXwAAAAAOAKCNS92IPXVFTD8gV13JTAj4tSSkqKs5sEAAAAAF6PQN2L+fn6aFiXcAX6+2ru+v36fuFWZzcJAAAAALwegbqXq1Q0RH3a1rDbb/y8StsOxjq7SQAAAADg1ZwWqE+YMEHVq1c/56dGjdSgceXKleratasiIiLUuXNnxcTEnHH/adOmqXXr1nZ/z549dfDgQSe9Evf3QNMKalyhkE7EJ+mF8VFKTqYEHgAAAAC8LlBv37695s6dm/Yza9YslS9fXvfee69iY2P1yCOPqFGjRjagr1+/vnr06GGvN6KiotSvXz/16tVLY8aM0dGjR9W3b19nvRS35+vro6FdwpU3j5/mbzig7/7d4uwmAQAAAIDXclqgHhQUpKJFi6b9TJkyxU5m9vzzz2v69OkKDAxUnz59VLlyZRuU58uXTzNmzLD3/fbbb9WuXTt17NjRZuCHDh2q2bNna9s2lhm7WBWK5NMLbVNngX9j+mptPUAJPAAAAAB47Rj1w4cP69NPP9Vzzz2ngIAARUZGqmHDhvLx8bH7ze8GDRpo+fLl9rLZb7LtDiVLllSpUqXs9bh4915VQU0qFtLJhCQ9Py6SEngAAAAAcAJ/uYAffvhBxYoVU9u2be3lffv2qUqVKmfcpnDhwlq3bp3d3rt3r7392ft3796d7edOSkqSK3O073K1881OdXTjiHlauOmgvpq/SfddVf6yPC/ct8/A/dFnQJ8BnzFwJfxdgif3may20emBuil3Hzt2rLp375523cmTJ21mPT1zOT4+3m6fOnXqvPuzIzo6Wu7gcrbz7jr59OnSo3rzl1UqlrRPJUOc3k1wEdylb8N10GdAnwGfMXAl/F2CN/cZf1c4mHv27NGNN96Ydp0Zn3520G0um3Ht59ufN2/ebD9/3bp15efnJ1c+42KO0eVsZ3h4ilYcWWwnlvtyZaJ+6N7QrrkO9+CMPgP3Rp8BfQZ8xsCV8HcJntxnHG11+UB9zpw5drx5/vz5064rXry49u/ff8btzGVHuXtm+82kdNll3khXfzMvdzvN05hZ4G94928t2XJYX/+zVd2bVbosz42c4y59G66DPgP6DPiMgSvh7xK8uc84fTI5s9SamSguPbM2+rJly2xZvGF+L1261F7v2L9kyZK02+/atcv+OPbj0pUpGKx+N9ay28NmrtGGfcc5rAAAAADgDYG6mSDu7InjzKRyZm30wYMHa/369fa3GbdulmQz7rzzTk2ePNmObV+9erVdxu3aa69V2bJlnfQqPNOdjcuqWdUiiktMVu+xkUpKTj1xAgAAAADw4EDdlKyHhYWdcV1ISIg++eQTmzXv1KmTXXZt9OjRCg4Otvvr16+vgQMHatSoUTZoN2XzQ4YMcdIr8FxmWby3OocrNNBfS7ce1udzNzq7SQAAAADg8fxdofQ9I+Hh4Zo4cWKm9zMBvPlB7ipVIK9e7lBTL4yP1vBf16pVjWKqUiyUww4AAAAAnppRh+u7rVFZtahWVPGJyXpubJQSk5Kd3SQAAAAA8FgE6shSCfybnesqNMhfkdsO69M5mzhqAAAAAJBLCNSRJSXz59WrN9W22+/+tlZr9xzjyAEAAABALiBQR5Z1blBa19UopvikZD33U6QSKIEHAAAAgBxHoI5slcC/0amuwoL8Fb3jiD6ZvYGjBwAAAAA5jEAd2VI8LEgDbkktgX//j3VatesoRxAAAAAAchCBOrKtY73SalOruBKSUvT8WErgAQAAACAnEajjokrgB99aRwWC82jFzqP68C9K4AEAAAAgpxCo46IUCw3SgJtTS+BH/LlOK3Ye4UgCAAAAQA4gUMdFuzmilNrWLqHE5BQ7C3x8YjJHEwAAAAAuEYE6LqkEftCtdVQoX4BW7z6mkX+t52gCAAAAwCUiUMclKRISqNdvqWO3R/21XjE7KIEHAAAAgEtBoI5LdmN4SfuTdLoEPi4xiaMKAAAAABeJQB05YuDNtVU4X4DW7DmmD/5Yx1EFAAAAgItEoI4cUTgkUIM6ppbAfzRrgyK3HebIAgAAAMBFIFBHjmlXt6SdCT45RXp+bKROJVACDwAAAADZRaCOHGXWVjcTzK3be1zv/U4JPAAAAABkF4E6clTBfAF649bUEvjRf2/Q0q2HOMIAAAAAkA0E6shx19cuoVvrl6YEHgAAAAAuAoE6csWrN9VSsdBAbdx3Qu/8tpajDAAAAABZRKCOXFEgOEBDOtW125/O2aglWw5ypAEAAAAgCwjUkWuuq1lcnRuUUYqdBT5KJ+OZBR4AAAAALoRAHbmq/021VDwsUJv2n9CwmWs42gAAAABwAQTqyFX58+bRm53D7faX8zdp4SZK4AEAAADgfAjUketaVi+m2xuVtSXwvcdFKjY+kaMOAAAAAJkgUMdl0a9DTZXKH6QtB2I1dAYl8AAAAACQGQJ1XBZhQf+VwH81f7MWbDjAkQcAAACADBCo47JpXq2o7mxczm6bEvgTcZTAAwAAAMDZCNRxWfW7saZKF8ir7YdO6s1fVnP0AQAAAOAsBOq4rEIC/TW0S2oJ/Df/bNG89ft5BwAAAAAgHQJ1XHZXVymie65MLYHvMy5Kx04l8C4AAAAAwGkE6nCKvu1qqkzBvNpx+KTemE4JPAAAAAA4EKjDKfIF+mtYlwi7/cPCrfp77T7eCQAAAAAgUIczXVW5sO5vWsFuvzg+SkcpgQcAAAAAMupwrj5tq6t84WDtPHJKg6et4u0AAAAA4PUofYdTBQeklsD7+EhjFm/TX2v28o4AAAAA8GoE6nC6xhUL6YGmFdNK4I+cZBZ4AAAAAN6LQB0uofcN1VWxSD7tORqn16etdHZzAAAAAMBpCNThEvIG+Gl413BbAj9uyXb9sWqPs5sEAAAAAE5BoA6X0bB8IXW/JrUEvu+EaB2OjXd2kwAAAADgsiNQh0t57vrqqlQ0n/Yei9OAqZTAAwAAAPA+BOpwKUF5TAl8hHx9pInLdujXFbud3SQAAAAAuKwI1OFyGpQrqEeaV7bbL02M0aETlMADAAAA8B4E6nBJT7euqqrFQrT/eJxenbLC2c0BAAAAgMuGQB0uXQLv5+ujKZE79Uv0Lmc3CQAAAAAuCwJ1uKyIsgX0aItKdvvlSTE6cDzO2U0CAAAAgFxHoA6X9uR1VVW9eKgOnIhXf0rgAQAAAHgBAnW4tEB/P719W2oJ/M9RuzQtaqezmwQAAAAAuYpAHS6vTun86nlt6izwr0yK0b5jlMADAAAA8FwE6nALvVpVVY0SoToUm2CD9ZSUFGc3CQAAAAByBYE63EKAv68tgff39dGMFbs1NYpZ4AEAAAB4JgJ1uI3apfLriVZV7Xb/yTHae+yUs5sEAAAAADmOQB1u5fGWlVW7VJgOxyao30RK4AEAAAB4HgJ1uJU8fqkl8Hn8fPTbyj2atHyHs5sEAAAAADmKQB1up0aJMD11XWoJ/KuTV2jPUUrgAQAAAHgOAnW4pUdbVFbd0vl19FSiXpoQzSzwAAAAADwGgTrckv/pEvgAP1/9sXqvxi+lBB4AAACAZyBQh9uqVjxUT7dJLYEfMHWFdh056ewmAQAAAMAlI1CHW3ukWSVFlC2gY6cS9eJ4SuABAAAAuD8Cdbh/CXzXcAX4+2r22n0au3i7s5sEAAAAAJeEQB1ur0qxUD1/fTW7/fq0ldpxmBJ4AAAAAO6LQB0e4aFrKqlBuQI6FmdK4KOYBR4AAACA2yJQh0fw8/XR8K4RCvT31Zx1+/XDwm3ObhIAAAAAXBQCdXiMSkVD1PuG6nZ78M8rte1grLObBAAAAADZRqAOj/LA1RV1RYWCOhGfpBfGRyk5OcXZTQIAAACAbCFQh8eVwA/rEqGgPL6av+GAvlu41dlNAgAAAIBsIVCHx6lQJJ9eaFvDbg+ZvkpbD1ACDwAAAMB9ODVQj4+P14ABA3TFFVeoadOmeuedd9Jm6165cqW6du2qiIgIde7cWTExMWfcd9q0aWrdurXd37NnTx08eNBJrwKu6L6rKqhxxUKKjU9S73GRlMADAAAAcBtODdQHDRqk+fPn6/PPP9fbb7+tn376SWPGjFFsbKweeeQRNWrUSBMmTFD9+vXVo0cPe70RFRWlfv36qVevXvb2R48eVd++fZ35UuBifM0s8F0iFBzgp383HdQ3/2xxdpMAAAAAwLUD9cOHD2v8+PF6/fXXFR4erquuukoPPvigIiMjNX36dAUGBqpPnz6qXLmyDcrz5cunGTNm2Pt+++23ateunTp27KgaNWpo6NChmj17trZtY0ku/Kdc4WD1bZdaAv/mL6u1ef8JDg8AAAAAl+e0QH3JkiUKCQlR48aN064zWfQhQ4bYYL1hw4by8fGx15vfDRo00PLly+1ls99k2x1KliypUqVK2euB9O5uUl5NKxfWyQRK4AEAAAC4B39nPbHJfpcuXVqTJk3Sxx9/rISEBHXq1EmPPfaY9u3bpypVqpxx+8KFC2vdunV2e+/evSpWrNg5+3fv3p3tdiQlJcmVOdrn6u10ZUNura32H8zTos2H9MXcjXrg6gryZPQZ0GfA5wxcCX+XQJ8BnzP/yWpc57RA3Yw337Jli3788UebRTfBef/+/ZU3b16dPHlSAQEBZ9zeXDaTzxmnTp067/7siI6Oljtwl3a6qnvq5NMnS49q6IzVKp68X6VCndb1Lxv6DOgz4HMGroS/S6DPgM+ZrHNatOLv76/jx4/bSeRMZt3YuXOnfvjhB5UvX/6coNtcDgoKsttm/HpG+02Qn11169aVn5+fXPmMi/nD5urtdHURESmKObJY8zYc0JcrE/Xjww3tmuueiD4D+gz4nIEr4e8S6DPgc+bcz0SXDdSLFi1qA25HkG5UrFhRu3btsuPW9+/ff8btzWVHuXvx4sUz3G8eM7tM8OsOAbC7tNOVDe0aoRve/VtLtx7W/xZs1cPNK8mT0WdAnwGfM3Al/F0CfQZ8zrjBZHJm/fO4uDht2rQp7bqNGzfawN3sW7ZsWdqa6ub30qVL7fWO+5rJ6BxMcG9+HPuBjJQukFcv31jTbg/7dY3W7z3OgQIAAADgcpwWqFeqVEnXXnutXf989erVmjNnjkaPHq0777xTbdu2tWujDx48WOvXr7e/zbh1sySbYW4zefJkjR071t7XLONmHqts2bLOejlwE7dfUVbNqxVVfGKynh8bqaTk1JNBAAAAACBvD9SN4cOHq1y5cjbwfuGFF3T33XerW7dudtm2Tz75xGbNzUzwZtk1E8QHBwfb+9WvX18DBw7UqFGj7H3z589vJ6QDLsQs9fdW57oKDfLX8m2H9emcjRw0AAAAAC7FqVNfh4aGaujQoRnuCw8P18SJEzO9rwngzQ+QXSXz51X/DrXUe1yU3vl1ra6rUUxVi4dyIAEAAAC4BKdm1AFn6dKwjFrVKKb4pGQ9NzZSiUnJvBkAAAAAXAKBOry2BH5Ip7oKC/JX1PYj+uRvSuABAAAAuAYCdXit4mFBeu3m2nb7vd/XavXuo85uEgAAAAAQqMO73Vq/tFrXLK6EpBQ7C3wCJfAAAAAAnIyMOuTtJfBvdKqjAsF5FLPjqD6atcHZTQIAAADg5QjU4fWKhQZpwOkS+A/+WKcVO494/TEBAAAA4DwE6oCkmyNK6YbaxZWYbErgoxSfyCzwAAAAAJyDQB04XQI/qGNdFQzOo1W7jmrUX+s5LgAAAACcgkAdOK1oaKBe71jHbptAPWYHJfAAAAAALj8CdSCdDuGl1L5uidMl8JGKS0zi+AAAAAC4rAjUgbO8fksdFc4XoNW7j2nEH5TAAwAAALi8CNSBsxQOCdSg0yXwH83eoKjthzlGAAAAAC4bAnUgA+3qltRNEaWUlJyi536iBB4AAADA5UOgDmRi4M21VSQkUOv2Htd7v6/jOAEAAAC4LAjUgUwUzBegwbemlsB/MnuDlm09xLECAAAAkOsI1IHzuKF2CXWsV0rJKbKzwJ9KYBZ4AAAAALmLQB24gNdurm3XWN+w74Te/W0txwsAAABAriJQBy6gQHCAhtxa126PnrNRS7Yc5JgBAAAAyDUE6kAWtK5VXJ0alFaKLYGP0sl4SuABAAAA5A4CdSCLXu1QW8XDArVp/wkN/3UNxw0AAABAriBQB7Iof3Aevdkp3G5/MW+TFm6iBB4AAABAziNQB7KhZY1iuq1RGVsC32dcpGLjEzl+AAAAAHIUgTqQTS93qKWS+YO0+UCshs6gBB4AAABAziJQB7IpLCiP3uycWgL/1fzN+mfjAY4hAAAAgBxDoA5chBbViurOxmXtdu9xkToRRwk8AAAAgJxBoA5cpJfa11TpAnm17eBJvTVjNccRAAAAQI4gUAcuUmhQHr11ugT+6wVbNH/9fo4lAAAAgEtGoA5cgmuqFtHdTcrZ7d7jonScEngAAAAAl4hAHbhEfdvXVJmCebXj8Em9MX0VxxMAAADAJSFQBy5RSKC/hnZJLYH//t+tmrNuH8cUAAAAwEUjUAdyQNPKRXTfVeXt9gvjonTsVALHFQAAAMDlCdSPHz+u4cOHa+PGjUpOTlafPn1Ur1493XXXXdqxY8fFtQLwAC+0q6FyhYK188gpDf6ZEngAAAAAlylQHzBggGbPni0fHx9NnTpVv/76q9544w0VKVLE7gO8VXCAv4adLoH/cdE2zVqz19lNAgAAAOANgboJ0ocNG6aKFStq5syZatmypdq3b69nn31WixYtyp1WAm6iSaXCeuDqCnb7xfHROnKSEngAAAAAuRyop6SkKE+ePDp16pQWLFigFi1a2OuPHDmi4ODg7D4c4HH63FBDFQoHa/fRUxo0baWzmwMAAADA0wP1K6+8Uq+88op69eolX19ftW7d2gbsffv2VatWrXKnlYAbyRvgp+FdI+TjI41dsl1/rt7j7CYBAAAA8ORA3YxHr1WrlgICAjRq1CiFhIRozZo1NrP+8ssv504rATfTqEIhPXR1xf9K4GMpgQcAAACQNf7KptDQ0HMC8vvvvz+7DwN4vOdvqK4/V+/Vxv0nNGDqCr1zez1nNwkAAACAp66jPmXKFHXq1EmNGjXStm3bNHjwYI0ePTrnWwe4saA8fhp+W4R8faQJy3bot5WUwAMAAADIhUD9+++/19ChQ22gnpCQWs5bp04dff755xo5cmR2Hw7waA3KFdTDzSvZ7ZcmRuvQiXhnNwkAAACApwXq33zzjQYNGqR77rnHTiZn3HLLLTZ4Hzt2bG60EXBrz7SupirFQrTvWJxem7rC2c0BAAAA4GmB+s6dO1W5cuVzri9btqwOHz6cU+0CPKsEvmtqCfzk5Ts1I2aXs5sEAAAAwJMC9YiICE2aNOmctdW/+OILhYeH52TbAI9Rr2wBPdoi9QTXy5NidJASeAAAAAA5FaibGd/Hjx+vzp07Kz4+XgMGDFCbNm00a9YsvfTSS9l9OMBrPNW6qqoVD9H+4/HqPznG2c0BAAAA4CnLs1WrVk0zZ87U1KlTtWHDBiUlJem6667TzTffrHz58uVOKwEPEOjvp7e71lPHD+dpWtQutauzSzeGl3R2swAAAAC4e6BuZnsfMmSIunTpkjstAjxY3TL59fi1lTXiz/V6ZXKMmlQqpCIhgc5uFgAAAAB3Ln3fu3ev/Pz8cqc1gBd4olVV1SgRasepvzIpxs7xAAAAAAAXnVHv2LGjunfvbkvdS5curcDAwHP2A8hcgL+vnQW+46h5+iVmty2DvymiFIcMAAAAwMUF6tOnT7frp0+bNu2cfT4+PgTqQBbUKZ1fvVpV0Xu/r0srgS8WGsSxAwAAAJD9QP3PP//ksAE5oGfLKvp1xR6t3HVU/SbGaHS3hvZkFwAAAADvlqVAfdGiRapfv778/f3tdmZMkNGoUaOcbB/gsfL4+ert2yJ088i5+m3lHk1evlMd65d2drMAAAAAuEOg3q1bN82bN0+FCxe22+cL1FetWpWT7QM8Ws2SYXqyVVW9/dtavTplhZpWLqxiYZTAAwAAAN4sS4H66tWrM9wGcOkevbayfl25R9E7juilidH69N5GlMADAAAAXizby7MZiYmJ2rNnj3bu3Gl/duzYoU2bNtmJ5gBkvwTezAIf4Oer31ft1YSlOziEAAAAgBfL9mRyv//+u1555RUdPnz4nH1FixZV+/btc6ptgNeoXiJUT7WuqmEz1+i1qSt0dZUiKpGfEngAAADAG2U7o/7222+rTZs2+vnnnxUWFqYff/xRH3/8sV1T/emnn86dVgJeoEfzSoook1/HTiXqxQlRSklJcXaTAAAAALhDoL5t2zZ1795dlSpVUp06dbRv3z61aNFCr776qr788svcaSXgBfwdJfD+vpq1Zp/GLtnu7CYBAAAAcIdA3WTRT548abcrVqyYNrmcCdy3byewAC5F1eKheq5NNbv9+tSV2nk49f8aAAAAAO+R7UDdZM8HDBig9evXq0mTJpo8ebJWrFihMWPGqFixYrnTSsCLdG9WSfXLFdCxuES9MJ4SeAAAAMDbZDtQ79evn8qXL6+YmBi1bt1aERER6tKli7777ju98MILudNKwIv4+frYEvhAf1/NWbdfPy7a5uwmAQAAAHC1QL1v3746dOiQ3V61apUGDhyojh072rWehw8frkWLFumff/5Rq1atcru9gFeoXDREvW+obrcHTVup7Ydind0kAAAAAK4UqJsZ3o8cOWK37733Xh07duyM/SEhIcqTJ0/utBDwUg9cXVGNyhfUifgkSuABAAAAL5KlddTDw8NtgG5K3s2SUT179sw0MP/6669zuo2A15bAD+saoXbv/6156w/ou3+36p4ryzu7WQAAAABcIVAfMWKEpkyZYjPppsy9Xr16ypcvX263DfB6FYvkU58bamjgtJV6Y/oqtahWVGULBXv9cQEAAADk7YH6bbfdpm+//VbFixe3lx966CHlzZs3t9sGQNL9TStoRsxuLdx8UL3HRer77lfK19eHYwMAAAB48xj1/fv3a926dXZ71KhRaeuoA8h9Jigf1jVcefP46Z+NB/Xtv1s47AAAAIC3Z9Q7dOig7t2721nezRj1q6++OtPbmlnhAeSs8oXzqW/7Guo/eYWGTF9tS+DNdQAAAAC8NFB//fXXdffdd+vo0aN2UrkPPvhA+fPnz/3WAUhzT5Py+iV6txZsPKDeY6P04yOUwAMAAABeW/pu1KhRQ40bN7azurds2dJup/+pUKGCIiMjs/Xkv/32m6pXr37Gz5NPPmn3rVy5Ul27dlVERIQ6d+6smJiYM+47bdo0tW7d2u43s9AfPHgwW88NuGMJ/NAu4QoO8LPj1b+av9nZTQIAAADgzEDdwQTl/v6pifi4uDgbMJvJ5UzwPnLkyGw91vr16+395s6dm/YzaNAgxcbG6pFHHlGjRo00YcIE1a9fXz169LDXG1FRUerXr5969eqlMWPG2Ex/3759s/tSALdjZnx/qX1Nuz105mpt2n/C2U0CAAAA4OxA3Vi8eLFefvllO1a9d+/e2rZtm5599lnNmjUrW4+zYcMGVatWTUWLFk37CQsL0/Tp0xUYGKg+ffqocuXKNig3y8HNmDHD3s/MQN+uXTt17NjRZvqHDh2q2bNn23YAnu7uJuV0TZUiOpWQrN5jI5WUnOLsJgEAAABwRqC+fft2mzFv06aN7rnnHpv9NoGyr6+vPvzwQ5tVL1iwYLYDdVMyfzZTQt+wYUM7eZ1hfjdo0EDLly9P22+y7Q4lS5ZUqVKlsl16D7gj8//hzc51FRLor8VbDunLeZuc3SQAAAAAl3syOROYL1261Ga/27dvr+uuu07h4eF23w8//HBRT2xmj9+0aZMN+D/55BMlJSWpbdu2doz6vn37VKVKlTNuX7hw4bQl4vbu3atixYqds3/37t3Zbod5XlfmaJ+rtxOXV8mwQPVtV139Jq3QsJlr1LxqYVUuGmL30WeQXfQZ0GeQm/iMAX0GuS3JjWKmrLYxS4G6mcitTJkyatq0qerVq2cnfbtUO3futOuxBwQE6L333rMZezM+/dSpU2nXp2cux8fH221zm/Ptz47o6Gi5A3dpJy6f6v4piigeoMg98er19b8a1KqQ/E5XoRj0GWQXfQb0GeQmPmNAn0Fui/agmClLgfqCBQv0559/2onjvvnmGzuZnBmfbjLrpgzXUaKeHaVLl9a///5rl3kz969Zs6aSk5PtmHczYd3ZQbe5HBQUZLfN+PWM9ufNmzfb7ahbt678/PzkymdcTIdz9XbCOUZWPKl2H8zT2oMJWnK8gB5pVpE+g2zjcwb0GeQmPmNAn0FuS3KjmMnR1hwJ1E0AfOONN9ofM8P6zJkz7YRvZkI580SDBw/WnXfeaWdwd8wInxUFChQ447KZOM7MJG8mldu/f/8Z+8xlR7l78eLFM9xv7pdd5o109TfTndqJy6ts4RD1v6mW+oyL0ru/r1PrmsVVqUiw3UefQXbRZ0CfQW7iMwb0GeQ2Pw+KmbI967uZld2sb/7ll1/amdbNjOxm2bQnnnhCLVq0yPLjzJkzR02aNLFl7g6rVq2ywbuZSG7ZsmV2HLthfpsx8mbNdMP8XrJkSdr9du3aZX8c+wFv0rVhGbWsXlTxicl6fmykEpOSnd0kAAAAAJd7eTaHIkWKqFu3bvrxxx/1+++/67777svyfc3a6KaE3WTlN27caIN+s8xa9+7d7aRyJnNvMvVmrXXz2wT0Zkk2w2TvJ0+erLFjx2r16tV2Gbdrr71WZcuWvZSXA7glM3RkSKdwhQb5K3L7EX06l1ngAQAAAHeWpTr1e++91wYDJjCvVKmSevbsec5tzGRzjzzySJafOCQkRJ9//rneeOMNde7c2a6Tfscdd9hA3TyXmQn+1Vdf1U8//WQnrxs9erSCg4PTgvyBAwfqgw8+0JEjR+x4+ddffz07rxvwKCXyB+m1m2rrubGRev+P9Sp9XSHVc3ajAAAAAOReoG7WKDfBs1kCzYwPzylVq1a1JfQZMcu/TZw4MdP7durUyf4AOP1/okFp/RKzS7+v2quRi46o3TXJHjNGBwAAAPAmWQrU33zzzdxvCYBLYk6mvXFrXS3a/Lc2HErQJ39v0lOtq3FUAQAAAE8tfc+qr7/++lLaA+ASFAsL0qsdaurZsVEa+dd6talVQrVKhXFMAQAAAE+bTM6sa+74MeXqZgb2QoUK2VneW7dubddEj4yMVJ06dXK/xQDO6+aIkmpcKlAJSSl2FvgEZoEHAAAAPC+j3qtXr7Tt+++/Xy+99JLuuuuuM25zxRVXaMyYMTnfQgDZLoHv0TBM6w4f1spdRzXqr/V6mhJ4AAAAwHOXZ1u+fLmuuuqqc643a5ivWbMmp9oF4BIUCPLTazfVstsj/1yvmB1HOJ4AAACApwbqtWrVskulxcXFpV13/Phxu1RavXosCAW4ihvrllC7OiWUmJxaAh+fmOzsJgEAAADIqdL39Mx65Wa9dLN2efny5ZWSkqLNmzfbJdzM2ucAXKcE/vWOdfTvpoNavfuYRvy5Ts9dX93ZzQIAAACQ04F65cqV9csvv2j+/PnasGGDvc5MMNe0aVP5+2f74QDkoiIhgXr9ljrq+f1SfThrg66vVUJ1y+TnmAMAAMBjHDuVqJ3HEuVJ9d0XFVkHBATo2muvtT8AXNuN4SX1S0xJTYvapefGLtfUJ65RoL+fs5sFAAAAXLJfonep36QYHToRr8rVjqlWqQLeOUYdgPsZeEsdFQkJ0No9x/X+7+uc3RwAAADgkhw4HmerRh/7bqkOnohXufz+Kl0gr8ccVQJ1wAsUyhegQR3r2u2PZ2/Q8m2Hnd0kAAAA4KJMj96l69/9Wz9H7ZKfr496XltZb11XWCGBnjMUm0Ad8BJt65TQLfVKKTlFeu6n5TqVkOTsJgEAAABZtt9k0b9bqse/W6oDJ+JVo0SoJve8Ws+2qao8fj4edSQvKlBPSkrSrFmz9NVXX+no0aOKjIzUsWPHcr51AHLUazfVVtHQQG3Yd0Lv/r6WowsAAACXl5KSomlRO1Oz6NG75O/royevq6opva5RndKeOVFytmsDdu3apYceekiHDx/WkSNHdN111+mzzz7TsmXL9Pnnn6t6dZZ/AlxVwXwBeuPWunr468X69O+Ndhb4huULOrtZAAAAQIb2HYtT/8kx+iVmt71ssujDu0Z4bIB+0Rn1gQMHqmHDhpozZ46d/d1455137PJsgwYNyo02AshBbWoVV6f6pW0JfO+xkZTAAwAAwCWz6FMiTRZ9tg3STRb9KQ/Pol9SoL548WI9+OCD8vP7b3mnPHny6PHHH1dMTExOtw9ALnj1ptoqFhqojftPaPjMNRxjAAAAuFQW/bFvl+rJH5bpUGyCapYM0+ReV+uZNtUU4O8d06xl+1UGBQXpwIED51y/adMmhYSE5FS7AOSi/MF59Gbn1FngP5+3SYs3H+R4AwAAwOlZ9MnLd6jNu7M1Y0VqFv3p1lXthHG1S3l+Fv2SAvU77rhD/fv3t5PJOQL08ePH65VXXlGXLl1yo40AckGrGsXVtWEZpaRIz4+N1Ml4ZoEHAACAc+w9dko9vlmip35crsOxCapVMsyWuT/d2nuy6Jc0mVzPnj0VFham1157TSdPntQjjzyiwoUL6/7777eTzAFwHy93qKW56/dr84FYDZ252pbEAwAAAJd7LPqrU1bYAN0ss/ZEq6p67NrKyuPnfQH6RQfq06ZN00033aRu3bopNjbWLtUWGhqaO60DkKvy5zUl8OG674uF+nLeZt1Qu4SurFSYow4AAIBct/foKfWbFKPfVu6xl2uXCrMzutcsGeb1Rz/bpygGDBiggwdTx7MGBwcTpANurkW1orrjirJ2u8+4KMXGJzq7SQAAAPDwLPrEZdvV5t2/bZBusujPtammST2vJki/2EC9SZMmNqseHx+f3bsCcFH9bqypUvmDtPVgrN76ZbWzmwMAAAAPtefoKT389WI9MyZSR04mqE7pME194ho9cV1Vry51v+TSdzPj+4cffqiPP/5YhQoVUmBg4Bn7//jjj+w+JAAnCw3Ko6FdInTP5//qfwu26IY6JdS0chFnNwsAAAAelEWfsHSHBkxdoaOnEm0W3UwU90jzSgToFxuonzhxQvny5bPbt912m/0B4FmuqVpEdzUpp+//3WpL4Gc83Vwhgdk+lwcAAACck0V/aUK0/li9114OL5Nfw7pEqHoJ5jrLTJa+hbds2VKTJ09WyZIltXDhQvXr14810wEP9FL7mpq9Zp+2HzqpIdNXafCtqWutAwAAABeTRR+/dIcGns6iB/j56qnWVdWjeSX5U+Z+XlkaBJCcnKx58+Zpx44dmjRpkrZs2aKdO3dm+APAfZkM+rAu4Xb7u3+3au66/c5uEgAAANzQ7iOn9OBXi/T82EgbpEeUya9pT16jni2rEKTnVEb9vvvu08svvywfHx97VqRLly7n3MZcb/avWrUqKw8JwEU1rVJE915VXl8v2KIXxpsS+GZ2DDsAAABwISYuHLdkuwZOW6ljp7Poz7SppoebVSRAz+lAvUGDBpozZ46d6f26667TTz/9ZCeSA+CZXmhbQ7PW7LOzwL8xfZWGdErNsgMAAACZ2XXkpPpOiLbfI42IsgU0vEu4qhZnLHquBOq9evXSL7/8otKlS6tUqVL2N4E64LnyBfpraJdw3TH6H/2wcJva1ilp11sHAAAAMsqij128Xa+bLHpcogL8ffVsm2rqfg1Z9FwN1MPCwjRq1CibWd+1a5emT5+e6WRyHTt2vOjGAHAdV1YqrPubVtBX8zfrxfFRmvlMc4VRAg8AAIB0dh4+qRcnROvvtalZ9Homi941XFWKkUXP9UC9f//+GjFihObPn28vf/bZZ/L1PXceOjNGnUAd8Bx92lbXrDV7tflArAZNW2nXWgcAAABMFn3Mom0a9PMqHT+dRX/++mp66JpK8vP14QBdjkDdjEs3P0arVq00btw4St8BLxAc4K9hXSN02ycL9NPi7WpXp6Ra1ijm7GYBAADAiXaYLPr4KM05vUJQg3IFbEKnSrGMq66RS8uzpffnn38SpANe5IoKhfTg1RXt9osTonQkNsHZTQIAAICTsug/LNyqG9792wbpgf6+6te+psY+2pQg3RkZ9Zo1a2ru3LkqXLiwatSoYUvcM8PybIDnef766vpr9V5t3H9CA6at0Du31XN2kwAAAHAZbT8Ua2d0d2TRG5YvaCcfrlyULLrTAvX//e9/yp8/v93++uuvc6UhAFxX3gA/WwLf9eP5mrB0h9rXKanWtYo7u1kAAAC4LFn0bXbJXjMW3WTRe99QXQ9cXZGx6M4O1Bs3bpzhNgDvYc6aPtyskj75e6P6ToxWowoFVSA4wNnNAgAAQC5m0V8cH62561Oz6I1OZ9ErkUV3jUA9PbM82/Dhw7V69WrFxcXZMyzp/fHHHznZPgAu5Jk21fT7qj3asO+EXpuyQu/dUd/ZTQIAAEAOMzHed/9u1ZDpq3QiPklBeUwWvYZdupcZ3V00UO/Tp4+OHDmi22+/XaGhrI0HeJOgPH56+7Z66vThPE1avlNt65RU2zolnN0sAAAA5JBtB2P1wvgozd9wwF6+ooLJokeoYpF8HGNXDtQjIyM1fvx4Va1aNXdaBMCl1StbQD1aVNZHszbo5UnRalyxkArlowQeAADAnSUnp+i7halZ9NjTWfQX2tbQfVdVkC/rorv+8mzly5e3GXUA3uvp1lVVrXiI9h+P16tTVji7OQAAALjELPrdn/2rVybF2CDdJGJmPNXcThhHkO7CGfVFixalbbdr186Wvz/22GMqW7as/Pz8zrjtFVdckfOtBOBSAv39NLxrhG79cL6mRu5Uuzol1L5uSWc3CwAAANnMon/77xa9+ctqG6DnzeOnF9pW171k0d0jUO/Wrds5173yyivnXGfWV2cddcA7hJcpoMdaVNbIv9br5Ukx9sxrkZBAZzcLAAAAWbD1QKx6j4vUv5sO2stNKhayM7qXL8xYdLcJ1M0M7wBwtieuq2JngV+9+5j6T47Rh3c35CABAAC4eBb9m39Ss+gnE1Kz6H3b19A9TcpT5u6uY9S3bNmihISEM65bsGCBNm7cmNPtAuBGJfD+vj6aHr1b06J2OrtJAAAAyMSWAyd0x6f/2DmGTJB+ZaVCmvl0c0rd3TVQN+voDRo0yI5PX7Zs2Rn7vvnmG91444168803z1lTHYDnq1M6v3q2rGK3zQQk+47FObtJAAAAOCuL/uW8TWr73hwt3HRQwQF+ev2W2vq++5UqVziYY+WugfrXX3+t6dOna9SoUWrcuPEZ+z788EN7/cSJE/XDDz/kVjsBuDATqNcqGaZDsQl2yTZO2gEAALiGzftP6I7R/2jA1JU2i35VpcI2i96NCePcP1D/6aef7ORxLVu2zHB/q1at9PzzzxOoA14qwN83rQR+5oo9mhJJCTwAAICzs+hfzN2ktu//rYWbT2fRO9bRd92bqGwhsugeEajv2LFD4eHh573NlVdeqW3btuVUuwC4mVqlwvTkdVXtdv/JK7T36ClnNwkAAMArbdp/QrePXqCB01bqVEKymlY+nUW/kgnjPCpQL1y4sA3Wz2f37t0qUKBATrULgBt67NrKqlM6TEdOJuiliZTAAwAAXE5JySn6bM5GtX3vby3afEj5Avw0+Fay6B4bqLdp00YjRow4Z8Z3h8TERI0cOVLXXHNNTrcPgBvJ4+ert7vWUx4/H/2+aq8mLjv/CT4AAADkjI37juu2TxZo0M+rFJeYrGuqFNHMZ5rr7ibl5ePjw2H2xED98ccf1549e9SpUyc7Xn3lypW2zD0mJkZjxozRrbfeai8/8cQTud9iAC6teolQPd26mt1+bcoK7T5CCTwAAEBuZ9HbvT9HS7YcUkigv4Z0qqtvHmqsMgUZi+6u/LNyo7CwMBugDx8+3C7DdvLkSXu9mdk5NDRU7du3t0F6kSJFcru9ANxAj+aVNHPFbkVtP6K+E6L0xf1XcCYXAAAgh23Yd1y9x0Zq6dbD9nKzqkX0ZudwlS6Ql2PtDYG6Ycafm7XU+/fvb7PnR48etdeVK1dOfn5+udtKAG7F35bAR+jGD+bqrzX7NG7JdnVtVNbZzQIAAPCYLPrnczfq7V/X2jJ3k0V/+caauv2KsiRHvC1QdwgICFDlypVzpzUAPEbV4qF69vpqevOX1Ro4daWuqVpEJfNzdhcAAOBSrN97XL3HRWrZ6Sx682pFbak7WXQvHKMOABfj4WaVVL9cAR2LS9QL45kFHgAA4FKy6J/M3qD2H8yxQXpooL/e6lxX/3vgCoJ0D0SgDiDX+Pn6aFiXCAX4++rvtfs0ZtE2jjYAAEA2rd97TJ0/mq8hv6xWfGKyWlQramd0v/2KcpS6eygCdQC5qkqxEPW+vrrdNsuF7DicOhklAAAAzi8xKVkfzTJZ9Llavi01iz60S7i+euAKlWLCOI9GoA4g1z14TUU1LF9Qx00J/Lgou2IEAAAAMrduT2oW/a0ZqVn0ltWL6tdnm+u2RkwY5w0I1AFcphL4cAXl8dXc9fv1/cKtHHUAAIBMsugfzlpvV8+J3H5EoUH+Gt41wi53y8S83oNAHcBlUaloiHrfUMNuD/55lbYdjOXIAwAApLN2zzF1+mi+hs5Yo/ikZLWqUUy/PdNCXRqWYSy6lyFQB3DZPNC0ghpXKKTY+CT1GRel5GRK4AEAAEwWfdRf69Xhg7mK2n5EYUH+ertrhD6/r5FK5A/iAHkhAnUAl+8Dx9fHToCSN4+fFmw8oO/+3cLRBwAAXm3N7mO69cP5GjYzNYt+ncmiP9tCncmiezUCdQCXVYUi+fRiu9QS+Demr9bWA5TAAwAA75OQlKyRf65ThxFzFL0jNYv+zm0R+uy+RioeRhbd2xGoA7jsul1ZXldWKqSTCUl6flwkJfAAAMCrrN59VLd+OE/Df12rhKQUta5ZTL8/20KdGjAWHakI1AE4pQR+WJcIBQf4aeGmg/rfgs28CwAAwCuy6CP+WKebRsxVzI6jyp83j967vZ4+vbeRipFFRzoE6gCcomyhYPVtX9Num/VBN+8/wTsBAAA81qpdR9Vx1Dy9/Zsji15cvz3TXB3rl2ZGd5yDQB2A09zduJyurlJYpxKS9fzYSCUxCzwAAPDALPr7v6dm0VfsPKoCwXn0/h0mi96QLDoyRaAOwKkl8G91Dle+AD8t3nJIX87bxLsBAAA8xoqdR3TLyHl69/e1SkxO0fW1iuvXZ5rrlnpk0eEmgfojjzyiF198Me3yypUr1bVrV0VERKhz586KiYk54/bTpk1T69at7f6ePXvq4MGDTmg1gEtVpmCw+t1Yy26bZUk27DvOQQUAAG4tPjFZ7/621gbpK3cdVcHgPPrgzvr6pFtDFQtlRne4SaD+888/a/bs2WmXY2NjbeDeqFEjTZgwQfXr11ePHj3s9UZUVJT69eunXr16acyYMTp69Kj69u3rxFcA4FLc2bismlUtorjEZPWmBB4AALh7Fn3UPL3/xzqbRW9bu4R+faaFbo4oxVh0uE+gfvjwYQ0dOlR169ZNu2769OkKDAxUnz59VLlyZRuU58uXTzNmzLD7v/32W7Vr104dO3ZUjRo17P1NoL9t2zYnvhIAF8vHJ7UEPjTQX0u3HtbnczdyMAEAgNtl0d85nUVfdTqLPuLO+vrongYqGhro7ObBzfg7uwFvvfWWbrnlFu3duzftusjISDVs2DDtjJP53aBBAy1fvlydOnWy+x9++OG025csWVKlSpWy15ctWzZbz5+UlCRX5mifq7cTrsNd+0zx0AD1a19DL06MsWuKtqhaRFWKhTi7WV7BXfsMnIc+A/oL+Iw5k5kkrs/4aK3efcxeblu7uAbcXEtFQgKVnJxMh+HvUpqsft9yaqC+YMECLV68WFOnTtVrr72Wdv2+fftUpUqVM25buHBhrVu3zm6boL5YsWLn7N+9e3e22xAdHS134C7thOtwxz5TxS9F9UsEaNnuePX65l8NbllIfr6pJ+yQ+9yxz8C56DOgv8DbP2MSklM0buVxTVh9QmbxmrAAHz3cIL+alvXR9vWrtN3ZDfQy0W7QZ7LKaYF6XFycXn31VfXv319BQWdOqHDy5EkFBASccZ25HB8fb7dPnTp13v3ZYUru/fz85MpnXEyHc/V2wnW4e58ZUemU2n0wV+sOJmjRsfx6tEUlZzfJ47l7n8HlR58B/QV8xkjRO47opfHRWrPnhD0c7euU0Ks31bRZdPB36UJ/Q102UB85cqTq1KmjZs2anbPPjE8/O+g2lx0BfWb78+bNm+12mC+l7vDF1F3aCdfhrn2mTKF8evWm2nZd9ff/WK82tUuoWvFQZzfLK7hrn4Hz0GdAf4E3fsbEJSZpxB/r9dHsDUpKTlHhfAEaeEsd3Rhe0tlN83p+LtpnLoa/M2d6379/v53R3XAE3jNnzlSHDh3svvTMZUe5e/HixTPcX7Ro0cvWfgC5p3OD0volepf+WL1Xz/0UqQmPN1UeP6fPfQkAALxc1PbDNpmwdk/qcrIdwktqwM21VZgsOnKY0775fvPNN3Zs+qRJk+xPq1at7I/ZNmujL1u2TCkpKfa25vfSpUvt9Yb5vWTJkrTH2rVrl/1x7Afg3swEkm90qqv8efPYsrJPZm9wdpMAAIAXM1n0oTNW69YP59sgvUhIgD66u4FG3tWAIB2elVEvXbr0GZfN8mtG+fLl7cRwb7/9tgYPHqw77rhDP/74ox23bpZkM+68805169ZN9erVs2Mqze2uvfbabM/4DsB1FQ8L0ms319IzY0wJ/DpdV7O4apYMc3azAACAl4nclppFX7c3NYt+U0Qpm0UvlO/MObOAnOSStaQhISH65JNPbNbcsRzb6NGjFRwcbPebcvmBAwdq1KhRNmjPnz+/hgwZ4uxmA8hhHeuVVptaxZWQlGL/QCYksbwJAAC4PE4lJOktm0WfZ4N0k0X/+J4Gdm10gnR4/DrqDm+++eYZl8PDwzVx4sRMb28CePMDwLNL4AffWkeLNh+065N++NcGPdW6qrObBQAAPNzybYfVO10W/ZZ6pfTaTbVVkCw6vDmjDgAOxUKD7Eyqxog/12nFziMcHAAAkGtZ9Dd/Wa1OaVn0QH3SraHev6M+QTouKwJ1AC7vpvCSalu7hBKTU+ws8PGJlMADAICctWzrId34wRx9PHuDklPMELxS+u2Z5rqhdgkONS47AnUAblECP+jWOnY82OrdxzTyz3XObhIAAPCgLPqQ6avU+aP52rDvhIqGBmp0t4Z6jyw6nIhAHYBbMKVnr58ugR81a4NidlACDwAALs2SLalZ9E/+3miz6LfWL22z6NeTRYeTEagDcBs3hpe0P0mnS+DNmqYAAAAXk0Uf/PNKdfn4vyz6p/c20ru311OBYJZdg/MRqANwKyarbpZHWbPnmD74gxJ4AACQPUu2HFT79+fo0zmblJIidWqQmkU3S8ICroJAHYBbMePUB3VMLYH/aNYGRW477OwmAQAAN3AyPkmDppks+gJt3H9CxcMC9fl9jfTObWTR4XoI1AG4nbZ1SurmiFJ2LNlzYyNt+RoAAEBmFm8+qPYfzNFnc1Oz6F0altGvT7fQdTXJosM1EagDcEsDbq5tJ5hbv/e43vudEngAAJBxFv31aSvV9ZMF2nQ6i/7l/VdoeNcI5Q/OwyGDyyJQB+CWCuYL0Bu3ppbAj/57g5ZuPeTsJgEAABeyaPNBtXv/b31+Oove1WTRn2mhljWKObtpwAURqANwW2bpFLOMiimBf54SeAAAcDqLPmDqCt32yQJtPhCrEmFB+vKBKzTMZNHzkkWHeyBQB+DWXr2ploqFBmrjvhN6+9c1zm4OAABwooWbDqrt+3/ry3mbbRb9tkZl9OuzzdWyOll0uBcCdQBuzax1OqRTXbttJogxS64AAADvEhufqNemrNDtoxdoy4FYlcwfpK8euEJDu0QoLIgsOtwPgToAt2dmbDWzt5oz58+PjbIlbwAAwDv8s/GA2r43R1/NT82i33FFWc18prmuJYsON0agDsAjvNKhlh2DZmZ0HTaTEngAADzdibhEvTo5RneM/kdbD8aqVP4g/e/BxnqzczhZdLg9AnUAHsFMDjOkc2oJ/JfzN+nfjQec3SQAAJBLFmw4YMei/2/BFnv5zsblbBa9RbWiHHN4BAJ1AB7DTBRze6Oytuyt97goO14NAAB4Vha9/+QY3fnpP9p28KRKF8irbx5qbOerCWUsOjwIgToAj9KvQ01b+mZK4IbOoAQeAABPMX/Dft3w3t/6+nQW/a4m5TTj6WZqVpUsOjwPgToAj2Jmdn2rS7jdNpPKmNI4AADg3ln0lydF665P/9X2Q6lZ9G8faqI3biWLDs9FoA7A45gz62asmtF7XKT9Aw8AANzP/PWpWfRv/9lqL9/dJHUs+jVVizi7aUCuIlAH4JH63VjTnnE3Z96H/LLK2c0BAADZcDIhWa9MXqG7Pvsvi/5d9yYafGtdhQT6cyzh8QjUAXgk80d86OkSeHMWft76/c5uEgAAyALzN/uZX/fr+4Xb7OVuV5a3WfSrq5BFh/cgUAfgscwfdPPH3egzLkrHTiU4u0kAACAT5u903wnRuvfLxdoXm6wyBfPq+4eb6PWOdciiw+sQqAPwaC+2q6GyhfJqx+GTemP6amc3BwAAZGDOun1q+94c/bAwdSx628rBmv7E1WpamSw6vBOBOgCPls+UwHeOsNvmj//fa/c5u0kAAOCMLHqUun2+0J5UL1coWN89dIUebhBm/4YD3opAHYDHu6pyYd3ftILdfmF8lI5SAg8AgNPNXrtPN7z7t344PRbd/K0266JfWamws5sGOB2BOgCv0KdtdZUvHKxdR05p8DRmgQcAwFnMCfMXxkXpvi8WaueRUzaL/uMjV+q1m2srOIAsOmAQqAPwCuYP/7AuEfLxkcYs3qa/1ux1dpMAAPA6s9bstVl087fYIIsOZIxAHYDXaFyxkB5oWtFuvzg+SkdimQUeAIDL4cjJBPUZF6n7v1xkq9tMldsYsuhApgjUAXiV3jdUV8Ui+bTnaJwGTlvp7OYAAODx/jqdRf9p8XZb2fbg1RU146nmasJYdCBTBOoAvEreAD8N7xpuvyiMX7pdf6za4+wmAQDgsVn03mMj9cCXi7T76ClVKBysn3pcpf431bJ/jwFkjkAdgNdpWL6QHm5WyW73nRCtw7Hxzm4SAAAe5c/Ve3T9u7M1dklqFv2hayrql6ea64oKhZzdNMAtEKgD8ErPtqmmykXzae+xOA2YSgk8AAA5wcz/8txPkXrwq8V2mJkZbja2x1V6pQNZdCA7CNQBeKWgPKYEPkK+PtLEZTs0c8VuZzcJAAC3ZoaTtXl3th1aZrLoDzerqOlPNlMjsuhAthGoA/Ba9csV1CPNK9vtfhNjdOgEJfAAAFxMFv3ZMcv10P8W20q1SkXyadyjV6nfjWTRgYtFoA7Aqz3duqqqFgvR/uNxenXKCmc3BwAAt/L7ytQs+oRlO2yV2iPNK2n6U83sfDAALh6BOgCv5iiB9/P10ZTInfolepezmwQAgMszE7E+M2a5un99OoteNJ/GPtpUL7Wvaf+2Arg0BOoAvF5E2QJ6tEXqLPAvT4rRgeNxXn9MAADIzG82i/63nePFZNF7tKhkx6I3LF+QgwbkEAJ1AJD05HVVVb14qA6ciFf/yZTAAwBwNjOXy9M/LtPDXy/WvmNxdvWU8Y81Vd92ZNGBnEagDgCSAv399PZtqSXwP0fv0rSonRwXAABOM6ujmCz6pOU7bRb90RaV9fOTzezErAByHoE6AJxWp3R+9WxZxW6/MinGZgsAAPBmB0/E68kflqnHN0vsxKtVioVowuNX68V2NRiLDuQiAnUASKdXyyqqWTJMh2IT9PKkaKWkpHB8AABeaUbMLl3/7mw72arJoj92bWVNe+Ia1StbwNlNAzwegToApBPg76vhXcPl7+ujmSv22C8nAAB4Wxa91/dL9ei3S7X/eLyqFQ/RxMev1gttyaIDlwuBOgCcpXap/HqiVVW7bdZW33vsFMcIAOAVzDKlbd6ZrWlRu+y8LT1bVtbUJ66xK6QAuHwI1AEgA4+3rKzapcJ0ODZB/SbGUAIPAPBoZmnSnt8v1WPfLbUroJiVUCY+3lS9b6hhJ1wFcHkRqANABvL4+dpZ4PP4+dj1Yict38FxAgB4pOnRZiz63/r5dBb9iVZVNOWJqxVehiw64CwE6gCQiRolwvTUdadL4Cev0J6jlMADADyHmcW953dL9fjpLHqNEqGa9PjVeu766mTRAScjUAeA8zDrxNYtnV9HTyWq7wRmgQcAeIZpUTtTs+jRqVn0J00Wvdc1qlsmv7ObBoBAHQDOz/90CXyAn6/+XL1X45dSAg8AcF/7jsXpsW+XqNf3y+zs7iaLPrnn1Xr2+up25RMAroH/jQBwAdWKh+qZNtXs9oCpK7TryEmOGQDAraSkpNglR8266L/E7LbLkD55XVWbRa9Tmiw64GoI1AEgCx5uVlH1yhbQsVOJenE8JfAAAHfLoi/Vkz8s06HYBNUsGaZJJovephpZdMBFEagDQBZL4Id3jbBfaGav3aefFm/juAEAXD6LPnn5DrV5d7ZmrEjNoj/duqotdSeLDrg2AnUAyKIqxUL0/PWpJfCDpq3SjsOUwAMAXNPeY6fU45sleurH5Tocm6BaJcNsmfvTrcmiA+6AQB0AsuGhayqpQbkCOhZnSuCjbLYCAABXy6KbGd1/XblHefx8bIn75F5Xq1apMGc3D0AWEagDQDaYJWxMCXygv6/mrNuvHxZSAg8AcA17j57SI+my6LVLpWbRzaRxefz42g+4E/7HAkA2VSoaot43VLfbg39eqW0HYzmGAACnZtEnLtuuNu/+rd9OZ9Gfa1PNThhnJo4D4H4I1AHgIjxwdUVdUaGgTsQn6YXxUUpOpgQeAOCcLPrDXy/RM2MideRkguqUDtPUJ67RE2TRAbdGoA4AF1kCP6xLhILy+Gr+hgP6buFWjiMA4LJm0Scs3a7W78zW76tSs+hmwtOJj1+tGiXIogPujkAdAC5ShSL59GLbGnZ7yPRV2nqAEngAQO7bc/SUuv9vsZ79KVJHTyWqbun8mvZEM/VqxVh0wFMQqAPAJbj3qgpqUrGQYuOT1HtcJCXwAIBczaKPW7Jdbd6ZrT9W71WAn6+dM2Xi401VvUQoRx7wIATqAHApH6KnS+CDA/z076aD+nrBZo4nACDH7T5ySg9+tUjPj03NokeUya9pT16jni2ryJ8Z3QGPQ6AOAJeoXOFg9W2XWgL/1ow12rz/BMcUAJBjWfSxi7epzbuz9deafTaL/kLbGhr/WFNVK04WHfBUBOoAkAPublJeTSsX1skESuABADlj15GTeuCrReo9LkrHTBa9bAH9/OQ1euzaymTRAQ9HoA4AOfFh6uujtzqHK1+AnxZtPqQv51MCDwC4+Cz6T4u26fp3/tYsk0X399WL7Wpo/KNXqSpZdMArEKgDQA4pWyhYL91Y024PnbFaG/cd59gCALJl5+GTuv/LReozPkrH4hJVr2wBTX/yGj3agiw64E0I1AEgB93VuJyuqVJEcYnJdsKfpOQUji8AIEtZ9DGLtuqGd//W7LWpWXQz/4kZi16lGGPRAW9DoA4AOcjHx0dvdQlXSKC/lm49rC/mbuL4AgDOa8fhk7r3i4V6YXy0zaLXL2ey6M3Uo0Vl+fn6cPQAL+TUQH3Lli166KGHVL9+fV177bX67LPP0vZt27ZN999/v+rVq6f27dtr7ty5Z9x3/vz56tChgyIiInTvvffa2wOAKyhdIK9e6ZBaAj/s1zVav5cSeABAxln0HxamZtHnrNuvQH9f9WtfU+MeNVn0EA4Z4MWcFqgnJyfrkUceUcGCBTVx4kQNGDBAH330kaZOnWo/tHr27KkiRYpo/PjxuuWWW9SrVy/t3LnT3tf8Nvs7deqkcePGqVChQnr88cft/QDAFdzWqKxaVCuq+MRkPTc2UolJyc5uEgDAhWw/FGuz6H0nROt4XKIamCz6U830cPNKZNEBOC9Q379/v2rWrKnXXntNFSpUUIsWLXTVVVdpyZIl+ueff2yGfODAgapcubJ69OhhM+smaDfGjh2rOnXq6MEHH1TVqlU1ZMgQ7dixQwsXLuQtBeAyJfBvdq6r0CB/RW47rE/nUAIPAEjNon//71a1fW9OWhb95RtrauyjTVW5KFl0AE4O1IsVK6b33ntPISEh9gPLBOiLFi1S48aNFRkZqVq1aik4ODjt9g0bNtTy5cvtttnfqFGjtH158+ZV7dq10/YDgCsomT+v+neoZbff/W2t1u055uwmAQCcnEXv9vlCvTQxNYveqHxB/fJUM3VvRhYdwJn85QJatWply9lbtmypG264QW+88YYN5NMrXLiwdu/ebbf37dt33v3ZkZSUJFfmaJ+rtxOugz7jWm6tV1LTo3fprzX79OxPyzWux5Xy93OteTzpM6DPgM+YyzEWfZvenLFGJ+KTFJTHV8+3qaZ7rypvy9z5nsffJXjPd5mkLLbRJQL1Dz74wJbCmzJ4U8Z+8uRJBQQEnHEbczk+Pt5uX2h/dkRHR8sduEs74TroM67jrqrSwo0+it5xVAN+mq/ONV2ztJE+A/oM+IzJeXtPJOrDxUcVvTf1e2rNInn0eKP8KpXvsKKjDtPp+LuEHBTtQTGTSwTqdevWtb/j4uL0/PPPq3PnzjYYT88E4UFBQXY7MDDwnKDcXA4LC7uo5/bz85Mrn3ExHc7V2wnXQZ9xTQOCduj5cdEau+qE7mkZoeolXGdNXPoM6DPgMybnJSen6IdF2/Tm72sU68iiX19N911ZXr4sucbfJXjtd5mk02112UDdZNDNmPLWrVunXVelShUlJCSoaNGi2rhx4zm3d5S7Fy9e3F7OaHK67DJvpKu/me7UTrgO+oxr6dywrGas2KvfV+1R7/HRmtTzauVxsRJ4+gzoM+AzJmdsOxirPuOitGDjAXu5cYVCGtolXBWK5KOT8XcJucjPg2Imp31L3L59u11ybc+ePWnXxcTE2KXWzMRxK1as0KlTp9L2mcnmzJrphvltLjuY7PvKlSvT9gOAK84C/0anOioQnEcrdh7VR7M2OLtJAIBcyKJ/vWCzbnjvbxuk583jp9duqqUfH7mSIB2AewTqpizBzNT+0ksvaf369Zo9e7aGDRumRx991M78XrJkSfXt21fr1q3T6NGjFRUVpS5dutj7mtL4pUuX2uvNfnO7MmXKqEmTJs56OQBwQcVCgzTg5tp2+4M/1mnFziMcNQDwEFsPxOrOT/9R/8krbKl744qFNOPpZrr/6oqUugNwn0DdlCR8+OGHdmm122+/Xf369VO3bt107733pu0zs7t36tRJU6ZM0ahRo1SqVCl7XxOUjxgxwq6rboL3w4cP2/0mYwUAruzmiFK6oXZxJSan6PmxUYpPTHZ2kwAAl5hF/9/81Cz6v5sO2iy6OSn748NXqnxhSt0BuOFkcmas+ciRIzPcV758eX377beZ3rdFixb2BwDciTmhOKhjXS3cdFCrdh3VyL/W69k21ZzdLADARdhy4IR6j4uyn+lGk4qFNKxLhMoVDuZ4ArgkrjWTEQB4gaKhgXq9Yx27/eFf6xWzgxJ4AHC3LPqX8zap7XtzbJAeHOCn12+prR8evpIgHUCOIFAHACfoEF5KN9YteboEPlJxiUm8DwDgBjbvP6E7Rv+jAVNX6mRCkq6qVFgzn26ubldVYCw6gBxDoA4ATjLwltoqnC9Aq3cf04g/1vM+AICLZ9G/mLtJbd//Wws3n86id6yj77o3UdlClLoDyFkE6gDgJIVDAjXodAn8R7M3KHLbYd4LAHBBm/af0O2jF2jgtJU6lZCsppVPZ9GvLE8WHUCuIFAHACdqV7ekbooopaTTJfCnEiiBBwBXYT6bP5+7Se3e/1uLNh9SvgA/Db6VLDqA3EegDgBONvDm2ioSEqh1e4/r/T/WObs5AABJG/cd1+2fLNDrp7PoV1cprBlPN9fdTcqzJDCAXEegDgBOVjBfgN64NbUE/pPZG7Rs6yFnNwkAvDqL/tmcjWr3/hwt3pKaRX/j1rr69iHGogO4fAjUAcAFXF+7hDrWK6XkFFECDwBOsmHfcXX9eL4G/bxKcYnJala1iGY+01x3NSlHFh3AZUWgDgAu4rWba9s11jfsO6F3flvr7OYAgFdl0Uf/vUHt35+jpVsPKyTQX0M61dXXDzZWmYLM6A7g8iNQBwAXUSA4QENurWu3P52zUUu2HHR2kwDA463fe1xdPp6vN6avPiOLfmdjsugAnIdAHQBcSOtaxdW5QRml2BL4KJ2MZxZ4AMitLLqZF6T9B3O0bOthhQb6663OqVn00gXyctABOBWBOgC4mP431VLxsEC7bu/wX9c4uzkA4HHW7z2mzh/N15BfVis+MVktqhW1WfTbryCLDsA1EKgDgIvJnzeP3uwcbre/mLdJCzdRAg8AOSExKVkf2yz6XC3flppFH9olXF89cIVKkUUH4EII1AHABbWsXky3NUotge89LlKx8YnObhIAuLV1e46p88cL9ObpLPq11Yvq12eb67ZGZZnRHYDLIVAHABf1codaKpk/SFsOxGroDErgAeBis+gfzlqvGz+Yq0iTRQ/y17Au4fry/itUMj9j0QG4JgJ1AHBRYUF59NbpEviv5m/WPxsPOLtJAOBW1u45pk4fzbcnO+OTktWyelH99kwLdSWLDsDFEagDgAtrXq2o7mxc1m6bEvgTcZTAA0BWsuij/lqvDh/MVdT2IzaLPrxrhL64/wqVyB/EAQTg8gjUAcDFvdS+pl0qaNvBk3ZsJQAgc2t2H9OtH87XsJmpWfRWNYrZLHqXhmUYiw7AbRCoA4CLC01XAv/NP1s0f/1+ZzcJAFxOQlKyRv65Th1GzFH0jiMKC/LXO7dF6PP7GpFFB+B2CNQBwA1cU7WI7rmynN3uPS5KxymBB4A0q3cf1a0fztPwX9cqISlFrWsW02/PtlCnBmTRAbgnAnUAcBN929VUmYJ5tePwSb0xfZWzmwMALpFFH/HHOt00Yq5idhxV/rx59N7t9fTpvY1UPIyx6ADcF4E6ALiJfIFmSaEIu/39v1s1Z90+ZzcJAJxm1a6j6jhqnt7+zZFFL67fnmmujvVLMxYdgNsjUAcAN3JV5cK676rydvuFcVE6dirB2U0CgMueRX//93W6eeRcrdh5VAWC8+j9O0wWvaGKkUUH4CEI1AHAzbzQrobKFQrWziOnNPhnSuABeI8VO4/olpHz9O7vqVn062sV16/PNNct9ciiA/AsBOoA4GaCA1LXA/bxkX5ctE2z1ux1dpMAIFfFJybr3d/W2iB95a7/suifdGuoYqGMRQfgeQjUAcANNa5YSPc3rWC3XxwfrSMnKYEH4MFZ9FHz9P4f65SYnKIbapux6C3IogPwaATqAOCm+txQQxUKB2v30VN6fdpKZzcHAHI8i/7O6Sy6mTiuYHAejbizvj6+p6GKhgZytAF4NAJ1AHBTeQP80krgxy3Zrj9X73F2kwAgR8TsOGIni/vgdBa9be0S+vWZFropohQzugPwCgTqAODGGlUopO7XVPyvBD6WEngAbp5F/3WNLXVfvfuYCuUL0Mi76uujexqQRQfgVQjUAcDNPXd9dVUqmk97j8VpwNQVzm4OAFyU6O2ns+h/rldScopurFvSzujeIZwsOgDvQ6AOAG4uKE9qCbyvjzRh2Q79tpISeADuIy4xScNnrlHHD1Oz6IXzBWjUXQ006u4GKhLCWHQA3olAHQA8QINyBfVw80p2+6WJ0Tp0It7ZTQKAC4raflg3j5inkX+dzqKHp2bRzW8A8GYE6gDgIZ5pXU1VioVo37E4vUYJPAAXz6IPm7lat344X2v2pGbRP7y7gc2kFyaLDgAE6gDgSSXwb3eNkJ+vjyYv36kZMbuc3SQAOEfktsPq8MFcjfprg82im5ncf3u2hdrXJYsOAA5k1AHAg0SULaAep0vg+02M0YHjcc5uEgBYcQlJemuGyaLP07q9x1UkJEAf39PAro1uZncHAPyHQB0APMxTrauqWvEQHTgRr/5TmAUegPOtOxivWz5coI9mbVByinRzRCm7LnrbOmTRASAj/hleCwBwW4H+pgS+np1B+eeoXWpfZxcTMwHIlpSUFMUlJis2Pkkn4hJ1Ij5RJ+KSFGt/p26nv+54XKJi064zt0+9n+P+Zu6MFMnO4j6oYx21rVOCdwQAzoNAHQA8UN0y+dXz2sp2PeJXJseoSaVCLHMEeLDEpOR0wfHpQPp0wJw+kD7u2O8IwNMH3+a2cadvG5+kRJP6zkE3R5TUgJvrqCBl7gBwQQTqAOCherWqql9X7rHrEr8yKcbOqOzj4+PsZgFeLzk5RScT/gukUwPm1OD4+AUCbUfG+r/bpt7OZL9zS1AeX+UL8Fe+QH8FB/gpxPwO9Fe+AD97nfltLtvr064zt0m9bZCfj3ZtWafrroqQn5+f17//AJAVBOoA4KEC/H319m0RumXkPP0Ss1tTo3bZcaEAsl8CntVA+uyMdWbl4Lklj5/Pf4GyI2gO9Ds30LaX/TK9zt7/9P3MShKXIikpSfF7CdABIDsI1AHAg9UulV+9WlXRe7+vU//JMbqyUiEVCw1ydrOAXJOQlJxhcHy+QPuMcvEMMtZmCbHcYOLffI6AOF1wnVHGOt851/2XsU4faJsTdAAA90egDgAermfLKvp1xR6t3HXULtk2ultDSuDhMiXgsQlZC6RNAG0DcMe247ZnZbHjc7EEPG8ev3RZ6HRB81kZ64zKwTPKWJuScoajAAAyQqAOAB4uj19qCfzNI+fqt5V7NHn5TnWsX9rZzYKbloCboPjYyXhtPpygxC2HdCox5byB9jnXpZspPDdLwAP8fG1QfE45d1rG+kJZ7DNLw4NzoAQcAICsIlAHAC9Qs2SYnmxVVW//tlavTlmhqyoXVvEwSuA9mcksnzm795lB83ETLGdU+p1uKa6zs9jnVoAfyLkS8POUczsy1mcE0hmNu3ZksikBBwC4OQJ1APASj15b2c4CH73jiF6aEK3P7mtE2a2LMGOgHRnmzJfR+m+G7xMXyFib+8cn5V4JuAmMA3xSlD8k6IzM8zkTmGUxYx3oTwk4AADpEagDgBeVwA/vGqGbRszVH6v3asLSHercsIyzm+WWJeCnElJLwM+egOy/QPnMGb4vlMU2S3XlFjO5WGbl3GdksU9nrEPSl4tnkLEOzuOnlJRkLV++XPXq1WO5LQAAcgGBOgB4keolQvV0m6oaOmONXpu6QldXKaKiIXnk6SXgGZVzn7uM1ulA+kJZ7PhEpeTOJOB2DHTaDN8ZLqN1ViCdQcY6bf/pANycoMlpSbl3XgEAABCoA4D3eaRZJc1csUeR2w7rxQlR+qxbA7lSCfg5gfRZ46YzX0brv4x1+usSknIpqpbSZvY+O2Od+TJamQfalIADAAAHMuoA4GX8zSzwXcPV/oO5mrVmn8Yt2aGq/hdXAm5Kth1jqjObgMyxxFZmGeu028cn2pLy3GLGQaefhCx96bfj+swC6TNKxU/f3yzV5css4AAAIBcQqAOAF6pSLFTPtammIb+s1qDpq9WtbrBiTm1VbMLpmcIzCrTPmsDscpSAp01Alm42bxtIn5PF/i/Q/m9s9ZnrXZsTFAAAAO6AQB0AvFT3ZpU0Y8VuLdt6WB8tPipp5UU9jo9ZWuus2b4dwXFWMtap1515f7MGto95YAAAAC9EoA4AXspkrd+/vb76T47R4SNHVKJIQeULzJNpxtqMs853xprWqRnvIH9KwAEAAHISgToAeLFyhYP1+X0NWWoLAADAhTBgDwAAAAAAF0KgDgAAAACACyFQBwAAAADAhRCoAwAAAADgQgjUAQAAAABwIQTqAAAAAAC4EAJ1AAAAAABcCIE6AAAAAAAuhEAdAAAAAAAXQqAOAAAAAIALIVAHAAAAAMCFEKgDAAAAAOBCCNQBAAAAAHAhBOoAAAAAALgQAnUAAAAAAFwIgToAAAAAAC6EQB0AAAAAABdCoA4AAAAAgAvxl5dKSUmxv5OSkuTKHO1z9XbCddBnQJ8BnzNwJfxdAn0GfM6c+5noiEcz45NyoVt4qPj4eEVHRzu7GQAAAAAAL1O3bl0FBARkut9rA/Xk5GQlJibK19dXPj4+zm4OAAAAAMDDpaSk2FjU39/fxqKZ8dpAHQAAAAAAV8RkcgAAAAAAuBACdQAAAAAAXAiBOgAAAAAALoRAHQAAAAAAF0KgDgAAAACACyFQBwAAAADAhRCoAwAAAADgQgjUL1F8fLw6dOigf//994zrt23bpvvvv1/16tVT+/btNXfu3PM+jlnOfvjw4bryyivVuHFjDR06VMnJyefc7vDhw2ratKm2b99+3sebP3++bVdERITuvfde2570vvrqKzVr1kz169fXSy+9pJMnT2brdcPz+ozDlClT1K1bt3Pa/NZbb6l58+a64oor1LNnT+3evTtLjwf36TMbNmzQgw8+qAYNGqhVq1b6+OOPM+xTDnzOuC5X7TMOfM54b5+Jjo7WHXfcYb+f3HDDDZo0adJ5H4/PGdflqn3Ggc8Z13O5vwMnJibqlltu0YgRI877eNOmTVPr1q1tHzPfcQ8ePJjt58oVKbhop06dSunZs2dKtWrVUv7555+065OTk1NuuummlOeeey5l/fr1KR9//HFKREREyo4dOzJ9rM8//zylRYsWKYsWLUpZsGBByjXXXJPy2WefnXGbw4cPp9x+++32+bZt25bpY5nnqVevnn3MtWvXpjz11FMpHTp0sO0yZsyYkdKwYcOUP//8MyUyMjKlffv2KQMGDKAneHGfcTCPY573nnvuOeP6YcOGpbRu3Trl33//TVm3bl3KI488ktK5c+e0PgX37zOxsbEprVq1SnnxxRdTNmzYkDJr1qyUK6+8MuXbb7/N8LH4nHFdrtpnHPic8d4+c/To0ZQmTZqkvPnmmylbt25NmTx5ckrt2rVTFi9enOFj8Tnjuly1zzjwOeN6Lvd3YOOTTz6xz/fBBx+kZMbEQuHh4SkTJ05MWbVqlf0ObL7nZve5cgOB+kUywcrNN99sO9bZHW7+/Pk2UD5x4kTadffdd995O4npAOPHj0+7PGnSpJSWLVumXTadw3whcjzf+YKu995774xAy3yZql+/flob77rrrjPaYh7bdFBzO3hnnzFGjBiRUqdOHXtS5+xAvWnTpik///xz2uU9e/bYx9y0aVM2jgBcuc/Mnj3bnsCLi4tL22/+WJoTPRnhc8Y1uXKfMfic8e4+s2bNmpTevXufcZK3Y8eOKaNHj87wsficcU2u3GcMPmdcz+X+Dmxs3rw55eqrr7YJyfM9lulfL7zwQtrlnTt3plSvXt2eGMrqc+UWSt8v0sKFC9WkSRONGTPmnH2RkZGqVauWgoOD065r2LChli9fnuFj7dmzR7t27bIlxelvv2PHDu3du9deNiUgnTt3vmDphuP5GzVqlHY5b968ql27tn3+pKQkW0KUfr8pM0lISNDq1auzcQTgSX3GmDdvnj7//HNdf/31Z1xvynuGDRtmy+fPduzYsSw9Nly/z9SsWVOjRo1SQEDAGfc7fvx4ho/H54xrcuU+Y/A54919plq1arZs1MfHx/5t+fPPP7Vp06Yzbn/28/N9xvW4cp8x+JxxPZf7O7DRv39/PfHEEypUqJDO5+zPmZIlS6pUqVL2+qw+V27xz/Vn8FB33XVXpvv27dunYsWKnXFd4cKFMx3Ta25vpL9PkSJF7G9zH3P9008/bS9nZZzx+Z7/6NGjiouLO2O/v7+/ChQowJhjL+4zxg8//GB/nz1uyNfX95wg/euvv1bBggVVvXr1LD02XL/PhIeHq2jRomn7Tp06pZ9++kktW7bM9vPzOeM8rtxnDD5nXM/l/tvkGKdq5jUwSQIz9tgkDLL7/HzOOI8r9xmDzxnXc7n7zPjx4228c9ttt9nx5+djAu7Mnj+r/TO3kFHPBWZitrMzDOay+ZDJiPly47hN+tsbmd3nYp8/o+e6UPvg+X0mO37//Xd98cUXeu65585pMzyjz5isxYsvvqgTJ06oR48e2X5+Pmdck7P7THbwOeP5fcZk1swETdOnT9eXX36Z7efnc8Y1ObvPZAefM57ZZw4cOKB33nlHAwcOtJUYF2IeLzufM5fr+7ZBRj0XBAYG2pm20zNvZlBQkN02M62nL5948skn025j7uvYdpStX8zzn915zOWwsLBzHj/9/ot5LnhGn8nOHzWTqb/nnnvUtWvXXHseOK/PmBlSX3jhBc2aNcuekEmfMT37+fmccS/O7jNZxeeM5/cZ80XXDMkzPyab9c033+iBBx7I8Pn5nHEvzu4zWcXnjOf2mcGDB6tTp0522ERWnz+zuCh9UH45v287EKjnguLFi2v9+vVnXLd///608oj0y0o4OqFhyivKlCmTtm1czBce8/zm+c5+fjOe0JS4m45mLleuXDntS5b5D3KpX67gvn0mK37++Wf16dPHlpyZJf3geX3GlBQ+88wzdnzf6NGjbZnh+Z6fzxn34uw+kxV8znh2nzFLMG3evNkuD+tQpUoVHTp0KNPn53PGvTi7z2QFnzOe3Wd+/vlne7tvv/3WXmey4suWLdOMGTPsvqx+zpjHMvvO91y5jdL3XGDW4FuxYkVauYSxZMkSe71Rvnz5tB/TAcyPmbTA3Cb97c11FzP2wTxP+scyJSUrV66015vxxnXr1j1jv5mswYxTr1GjxiW8arhzn7mQBQsW2CD97rvv1iuvvJLjjw/X6DNm4hUTcH366ad2rdALPT+fM+7F2X3mQvic8fw+ExUVZU/spH+8mJgYVapUKdPn53PGvTi7z1wInzOe32d+/fVXTZkyxQb45qdOnTo2yWROJmf2/Okfy0weZ37M9Zf7+/bZyKjnAvNlxcwY2LdvXz3++OP666+/7AfNkCFDMr3PnXfeacfdlChRwl5+++239eCDD17U85uZvs3s3aZDmkl9zKy85iyQmW3RMaGD+XJlSkJMJ3vttdfsZAuUvntvnzkfU3FhMuhmxsuHH3447UyikT9/fsape0ifMcHWhAkT7Jgu88fQ8T77+fllOGMqnzPux9l95nz4nPGOPnPttdcqNDTUfgd57LHHbMD12Wef2ZVFMsLnjPtxdp85Hz5nvKPPlC9f/ozbmuy6+b5aunTpTB+rW7dudoJCk8w0pfOm35UtW/aCz5XrLssicB7u7PUAHWv33X333XZd6htvvDFl3rx5532MxMTElDfeeCOlUaNGKU2aNEkZNmzYGWtGOpi1sLOyJvasWbNSrr/+ers+ulmL0LEWoMMnn3ySctVVV9k1cPv27Zty6tSpbL1meF6fcTBrTaZfR33ZsmX2/hn9nP0a4L595pVXXsnwPT7fWqF8zrg2V+wzDnzOeO/fpvXr19vvJWbdZNNXfvrpp/M+Hp8zrs0V+4wDnzOu6XJ+BzbMd9rzraNumHXSzXrppo/17Nkz5eDBgxf1XDnNx/xzeU4JAAAAAACAC2GMOgAAAAAALoRAHQAAAAAAF0KgDgAAAACACyFQBwAAAADAhRCoAwAAAADgQgjUAQAAAABwIQTqAAAAAAC4EAJ1AAAAAABciL+zGwAAAJynVatW2rFjh9328fFR3rx5Vb16dfXs2VPNmjXL0mMsWLBAxYoVU+XKlXO5tQAAeAcy6gAAeLmXXnpJc+fO1ezZszVmzBg1aNBAPXr00Pz587N0//vvv1/79+/P9XYCAOAtyKgDAODlQkNDVbRoUbtdvHhx9enTR/v27dOQIUM0depUZzcPAACvQ0YdAACc4/bbb9fatWu1ZcsWrV+/Xg899JDq16+vunXr6q677tKGDRvSSueNe++9VyNGjLDbixcvVqdOnRQeHq6bbrpJM2fO5AgDAJANBOoAAOAcjvHmJkh/9NFHVbp0aU2ePFk//vijkpKSNGzYMLt/3Lhx9rcJ0h988EGbiTdl8yZQN9n47t2768UXX7TBOwAAyBpK3wEAQIbl8MaJEyd0xx132Cx6cHCwve7WW2/VZ599ZrcLFSpkf+fPn1/58uXTp59+qqZNm+qee+6x15cvX16rVq3S//73PzVq1IgjDQBAFhCoAwCAcxw/ftz+DgkJ0XXXXadJkyYpJiZGGzdu1MqVK1WkSJEMj5rZ/9dff9kyeYeEhARVrFiRowwAQBYRqAMAgHOsWbPG/jYl7126dFHBggXtePQOHTrYYPyLL77I8KglJibacemmXP6MLxz+fOUAACCr+KsJAADOMX78eNWuXVs7d+7U3r177XhzR7BtlnJLSUnJ8KiZzPmyZctsybuDCerj4+PPCd4BAEDGmEwOAAAvd+zYMTsJnAnITSZ98ODBmj59up0ErkCBAoqNjdXvv/+u7du3a+zYsfruu+9s4O1gxq6vW7fOPo4Zy25K5N99911t3rzZBvjvvPOOSpUq5dTXCACAO/FJyeyUOAAA8HimnH3Hjh1228fHx04OV6tWLZv9dkz+NnLkSBucx8XFqXr16rYUvl+/fpo9e7Zdd90E4l999ZWddO6ll17S/PnzNXz4cLu8m9n/wAMPpE0uBwAALoxAHQAAAAAAF0LpOwAAAAAALoRAHQAAAAAAF0KgDgAAAACACyFQBwAAAADAhRCoAwAAAADgQgjUAQAAAABwIQTqAAAAAAC4EAJ1AAAAAABcCIE6AAAAAAAuhEAdAAAAAAAXQqAOAAAAAIBcx/8BQ34Bc2pfr2IAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1200x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -334,25 +427,27 @@
    "id": "387401eb",
    "metadata": {
     "papermill": {
-     "duration": 0.003078,
-     "end_time": "2026-02-26T07:41:17.250808",
+     "duration": 0.00201,
+     "end_time": "2026-04-24T00:03:52.559482",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.247730",
+     "start_time": "2026-04-24T00:03:52.557472",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "**Interprétation :** Ce graphique linéaire permet de visualiser les tendances des ventes au fil du temps. Exécutez les cellules pour repérer d'éventuelles saisonnalités, pics de vente, ou périodes de creux."
+   "source": [
+    "**Interprétation :** Ce graphique linéaire permet de visualiser les tendances des ventes au fil du temps. Exécutez les cellules pour repérer d'éventuelles saisonnalités, pics de vente, ou périodes de creux."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3f987ccf",
    "metadata": {
     "papermill": {
-     "duration": 0.003276,
-     "end_time": "2026-02-26T07:41:17.256425",
+     "duration": 0.00175,
+     "end_time": "2026-04-24T00:03:52.563392",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.253149",
+     "start_time": "2026-04-24T00:03:52.561642",
      "status": "completed"
     },
     "tags": []
@@ -366,10 +461,10 @@
    "id": "64f9475a",
    "metadata": {
     "papermill": {
-     "duration": 0.003006,
-     "end_time": "2026-02-26T07:41:17.262194",
+     "duration": 0.002314,
+     "end_time": "2026-04-24T00:03:52.567764",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.259188",
+     "start_time": "2026-04-24T00:03:52.565450",
      "status": "completed"
     },
     "tags": []
@@ -384,33 +479,21 @@
    "id": "abba522b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:33.650965Z",
-     "iopub.status.busy": "2026-04-21T00:16:33.650398Z",
-     "iopub.status.idle": "2026-04-21T00:16:34.078987Z",
-     "shell.execute_reply": "2026-04-21T00:16:34.077137Z"
+     "iopub.execute_input": "2026-04-24T00:03:52.573353Z",
+     "iopub.status.busy": "2026-04-24T00:03:52.572836Z",
+     "iopub.status.idle": "2026-04-24T00:03:53.578660Z",
+     "shell.execute_reply": "2026-04-24T00:03:53.577458Z"
     },
     "papermill": {
-     "duration": 0.131279,
-     "end_time": "2026-02-26T07:41:17.396989",
+     "duration": 1.009443,
+     "end_time": "2026-04-24T00:03:53.579484",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.265710",
+     "start_time": "2026-04-24T00:03:52.570041",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 10\u001b[39m\n\u001b[32m      7\u001b[39m target = \u001b[33m'\u001b[39m\u001b[33mcategorie\u001b[39m\u001b[33m'\u001b[39m\n\u001b[32m      9\u001b[39m \u001b[38;5;66;03m# S'assurer qu'il n'y a pas de valeurs manquantes dans les features\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m10\u001b[39m df_clean = \u001b[43mdf\u001b[49m.dropna(subset=features + [target])\n\u001b[32m     12\u001b[39m X = df_clean[features]\n\u001b[32m     13\u001b[39m y = df_clean[target]\n",
-      "\u001b[31mNameError\u001b[39m: name 'df' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.linear_model import LogisticRegression\n",
@@ -435,10 +518,10 @@
    "id": "03c22654",
    "metadata": {
     "papermill": {
-     "duration": 0.004191,
-     "end_time": "2026-02-26T07:41:17.404130",
+     "duration": 0.004174,
+     "end_time": "2026-04-24T00:03:53.588895",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.399939",
+     "start_time": "2026-04-24T00:03:53.584721",
      "status": "completed"
     },
     "tags": []
@@ -453,30 +536,26 @@
    "id": "998fec65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:34.082691Z",
-     "iopub.status.busy": "2026-04-21T00:16:34.082196Z",
-     "iopub.status.idle": "2026-04-21T00:16:34.118491Z",
-     "shell.execute_reply": "2026-04-21T00:16:34.116715Z"
+     "iopub.execute_input": "2026-04-24T00:03:53.598567Z",
+     "iopub.status.busy": "2026-04-24T00:03:53.598043Z",
+     "iopub.status.idle": "2026-04-24T00:03:53.671360Z",
+     "shell.execute_reply": "2026-04-24T00:03:53.669661Z"
     },
     "papermill": {
-     "duration": 0.025968,
-     "end_time": "2026-02-26T07:41:17.432341",
+     "duration": 0.079193,
+     "end_time": "2026-04-24T00:03:53.672408",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.406373",
+     "start_time": "2026-04-24T00:03:53.593215",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'X_train' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Instancier et entraîner le modèle\u001b[39;00m\n\u001b[32m      2\u001b[39m model = LogisticRegression()\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m model.fit(\u001b[43mX_train\u001b[49m, y_train)\n\u001b[32m      5\u001b[39m \u001b[38;5;66;03m# Faire des prédictions\u001b[39;00m\n\u001b[32m      6\u001b[39m y_pred = model.predict(X_test)\n",
-      "\u001b[31mNameError\u001b[39m: name 'X_train' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Précision du modèle : 1.00\n"
      ]
     }
    ],
@@ -499,25 +578,30 @@
    "id": "5e3a09e6",
    "metadata": {
     "papermill": {
-     "duration": 0.002466,
-     "end_time": "2026-02-26T07:41:17.437920",
+     "duration": 0.003552,
+     "end_time": "2026-04-24T00:03:53.680186",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.435454",
+     "start_time": "2026-04-24T00:03:53.676634",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "**Interprétation du score :** Le score de précision (accuracy) nous indique le pourcentage de prédictions correctes que notre modèle a faites sur l'ensemble de test. Exécutez les cellules ci-dessus pour obtenir le score, puis interprétez-le :\n- **> 0.7** : le modèle distingue bien les catégories à partir du prix et de la quantité.\n- **0.4-0.7** : les features choisies donnent des résultats mitigés.\n- **< 0.4** : le prix et la quantité seuls ne suffisent pas à différencier les catégories de produits."
+   "source": [
+    "**Interprétation du score :** Le score de précision (accuracy) nous indique le pourcentage de prédictions correctes que notre modèle a faites sur l'ensemble de test. Exécutez les cellules ci-dessus pour obtenir le score, puis interprétez-le :\n",
+    "- **> 0.7** : le modèle distingue bien les catégories à partir du prix et de la quantité.\n",
+    "- **0.4-0.7** : les features choisies donnent des résultats mitigés.\n",
+    "- **< 0.4** : le prix et la quantité seuls ne suffisent pas à différencier les catégories de produits."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "c111b9db",
    "metadata": {
     "papermill": {
-     "duration": 0.002862,
-     "end_time": "2026-02-26T07:41:17.443462",
+     "duration": 0.003663,
+     "end_time": "2026-04-24T00:03:53.688399",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.440600",
+     "start_time": "2026-04-24T00:03:53.684736",
      "status": "completed"
     },
     "tags": []
@@ -531,10 +615,10 @@
    "id": "e1d050cf",
    "metadata": {
     "papermill": {
-     "duration": 0.003284,
-     "end_time": "2026-02-26T07:41:17.450139",
+     "duration": 0.004408,
+     "end_time": "2026-04-24T00:03:53.696841",
      "exception": false,
-     "start_time": "2026-02-26T07:41:17.446855",
+     "start_time": "2026-04-24T00:03:53.692433",
      "status": "completed"
     },
     "tags": []
@@ -553,7 +637,16 @@
   {
    "cell_type": "markdown",
    "id": "jwygopq4ls",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00475,
+     "end_time": "2026-04-24T00:03:53.705111",
+     "exception": false,
+     "start_time": "2026-04-24T00:03:53.700361",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple guidé\n",
     "\n",
@@ -566,11 +659,19 @@
    "id": "m8r5k70drr8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:16:34.121581Z",
-     "iopub.status.busy": "2026-04-21T00:16:34.121058Z",
-     "iopub.status.idle": "2026-04-21T00:16:34.126679Z",
-     "shell.execute_reply": "2026-04-21T00:16:34.125201Z"
-    }
+     "iopub.execute_input": "2026-04-24T00:03:53.715810Z",
+     "iopub.status.busy": "2026-04-24T00:03:53.715290Z",
+     "iopub.status.idle": "2026-04-24T00:03:53.734460Z",
+     "shell.execute_reply": "2026-04-24T00:03:53.733955Z"
+    },
+    "papermill": {
+     "duration": 0.026335,
+     "end_time": "2026-04-24T00:03:53.735968",
+     "exception": false,
+     "start_time": "2026-04-24T00:03:53.709633",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -624,18 +725,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.031821,
-   "end_time": "2026-02-26T07:41:17.906060",
+   "duration": 9.453957,
+   "end_time": "2026-04-24T00:03:54.517111",
    "environment_variables": {},
    "exception": null,
-   "input_path": "Lab5-Viz-ML.ipynb",
-   "output_path": "Lab5-Viz-ML.ipynb",
+   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day3\\Labs\\Lab5-Viz-ML\\Lab5-Viz-ML.ipynb",
+   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\ML\\DataScienceWithAgents\\PythonAgentsForDataScience\\Day3\\Labs\\Lab5-Viz-ML\\Lab5-Viz-ML_output.ipynb",
    "parameters": {},
-   "start_time": "2026-02-26T07:41:13.874239",
+   "start_time": "2026-04-24T00:03:45.063154",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

- **M-42 Lab4-DataWrangling** and **M-43 Lab5-Viz-ML** failed with `FileNotFoundError` on `transactions.csv` when executed via Papermill or from JupyterLab launched at the repo root (CWD != notebook directory).
- Fix wraps `pd.read_csv(...)` with a tiny pathlib-based resolver that searches up the parent chain for the canonical file location on miss.
- Pedagogical code remains simple: the happy path (`Path('transactions.csv')`) still works unchanged in Jupyter-classic; the fallback only triggers if the CWD-relative lookup fails.
- **71% FP rate** observed across 62 audit items reviewed (ai-01 + po-2025). This M-42/M-43 pair is in the 11 CONFIRMED minority — a genuine student-facing bug.

## Validation (Papermill from repo root)

| Notebook | Before (NanoClaw audit) | After (this PR) |
|----------|------------------------|-----------------|
| Lab4-DataWrangling | 9 cascade NameError from failed `df` load | **SUCCESS 6.1s, 11/11 cells, 0 errors** |
| Lab5-Viz-ML | 4 cascade NameError from failed `df` load | **SUCCESS 10.6s, 7/7 cells, 0 errors** |

Jupyter-classic CWDs also verified (Lab4 dir → `transactions.csv`, Lab5 dir → `../Lab4-DataWrangling/transactions.csv`, repo root → parent-search hits canonical path).

## Related

- Issue #488 (audit NanoClaw 483 notebooks)
- Protocol #499 (mechanical reassessment before fix)
- po-2025 debrief 2026-04-23: flagged M-42/M-43 CONFIRMED MINOR but non-actionnable at the time ("fix est execution-context, pas code logic bug"). Addressing it here since the fix is minimal and the bug does hit students using JupyterLab-from-repo-root.

## Test plan

- [x] Papermill Lab4 SUCCESS from repo root
- [x] Papermill Lab5 SUCCESS from repo root
- [x] Path resolver tested from 3 CWDs (Lab4 dir, Lab5 dir, repo root)
- [x] `notebook_tools.py validate` PASS post-execution (0 errors)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>