### PR TITLE
fix(sudoku): strip count_solutions leak in Sudoku-2 (#362)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.004443,
-     "end_time": "2026-02-18T08:36:44.113231",
+     "duration": 0.002505,
+     "end_time": "2026-04-24T00:23:10.085462",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.108788",
+     "start_time": "2026-04-24T00:23:10.082957",
      "status": "completed"
     },
     "tags": []
@@ -54,10 +54,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.001532,
-     "end_time": "2026-02-18T08:36:44.116958",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:23:10.088464",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.115426",
+     "start_time": "2026-04-24T00:23:10.087464",
      "status": "completed"
     },
     "tags": []
@@ -92,10 +92,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.001905,
-     "end_time": "2026-02-18T08:36:44.120279",
+     "duration": 0.001998,
+     "end_time": "2026-04-24T00:23:10.092969",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.118374",
+     "start_time": "2026-04-24T00:23:10.090971",
      "status": "completed"
     },
     "tags": []
@@ -158,10 +158,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.001729,
-     "end_time": "2026-02-18T08:36:44.123667",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:23:10.095969",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.121938",
+     "start_time": "2026-04-24T00:23:10.094969",
      "status": "completed"
     },
     "tags": []
@@ -226,10 +226,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.002214,
-     "end_time": "2026-02-18T08:36:44.128148",
+     "duration": 0.001999,
+     "end_time": "2026-04-24T00:23:10.099970",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.125934",
+     "start_time": "2026-04-24T00:23:10.097971",
      "status": "completed"
     },
     "tags": []
@@ -299,11 +299,17 @@
    "execution_count": 1,
    "id": "cell-5",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.106154Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.105153Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.114690Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.114690Z"
+    },
     "papermill": {
-     "duration": 0.008275,
-     "end_time": "2026-02-18T08:36:44.137994",
+     "duration": 0.013531,
+     "end_time": "2026-04-24T00:23:10.115680",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.129719",
+     "start_time": "2026-04-24T00:23:10.102149",
      "status": "completed"
     },
     "tags": []
@@ -331,10 +337,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.002493,
-     "end_time": "2026-02-18T08:36:44.142315",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:23:10.118681",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.139822",
+     "start_time": "2026-04-24T00:23:10.117681",
      "status": "completed"
     },
     "tags": []
@@ -360,11 +366,17 @@
    "execution_count": 2,
    "id": "cell-7",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.126717Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.125716Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.145263Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.145263Z"
+    },
     "papermill": {
-     "duration": 0.010686,
-     "end_time": "2026-02-18T08:36:44.155972",
+     "duration": 0.024613,
+     "end_time": "2026-04-24T00:23:10.146823",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.145286",
+     "start_time": "2026-04-24T00:23:10.122210",
      "status": "completed"
     },
     "tags": []
@@ -428,10 +440,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.003369,
-     "end_time": "2026-02-18T08:36:44.162329",
+     "duration": 0.001999,
+     "end_time": "2026-04-24T00:23:10.150826",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.158960",
+     "start_time": "2026-04-24T00:23:10.148827",
      "status": "completed"
     },
     "tags": []
@@ -450,11 +462,17 @@
    "execution_count": 3,
    "id": "cell-9",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.155329Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.155329Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.178122Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.177122Z"
+    },
     "papermill": {
-     "duration": 0.016228,
-     "end_time": "2026-02-18T08:36:44.181838",
+     "duration": 0.027296,
+     "end_time": "2026-04-24T00:23:10.179122",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.165610",
+     "start_time": "2026-04-24T00:23:10.151826",
      "status": "completed"
     },
     "tags": []
@@ -734,10 +752,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.00167,
-     "end_time": "2026-02-18T08:36:44.185377",
+     "duration": 0.001,
+     "end_time": "2026-04-24T00:23:10.183126",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.183707",
+     "start_time": "2026-04-24T00:23:10.182126",
      "status": "completed"
     },
     "tags": []
@@ -754,11 +772,17 @@
    "execution_count": 4,
    "id": "cell-11",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.189145Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.188145Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.208886Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.208168Z"
+    },
     "papermill": {
-     "duration": 0.01129,
-     "end_time": "2026-02-18T08:36:44.198241",
+     "duration": 0.024052,
+     "end_time": "2026-04-24T00:23:10.209692",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.186951",
+     "start_time": "2026-04-24T00:23:10.185640",
      "status": "completed"
     },
     "tags": []
@@ -929,7 +953,16 @@
   {
    "cell_type": "markdown",
    "id": "18a74f95",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002059,
+     "end_time": "2026-04-24T00:23:10.213823",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.211764",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Structure de l'implementation DLX\n",
     "\n",
@@ -962,10 +995,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.001829,
-     "end_time": "2026-02-18T08:36:44.202065",
+     "duration": 0.002068,
+     "end_time": "2026-04-24T00:23:10.217961",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.200236",
+     "start_time": "2026-04-24T00:23:10.215893",
      "status": "completed"
     },
     "tags": []
@@ -981,11 +1014,17 @@
    "execution_count": 5,
    "id": "cell-13",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.227087Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.226083Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.240636Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.239635Z"
+    },
     "papermill": {
-     "duration": 0.009654,
-     "end_time": "2026-02-18T08:36:44.213838",
+     "duration": 0.019566,
+     "end_time": "2026-04-24T00:23:10.240636",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.204184",
+     "start_time": "2026-04-24T00:23:10.221070",
      "status": "completed"
     },
     "tags": []
@@ -1008,7 +1047,7 @@
       ". . . | 4 1 9 | . . 5 \n",
       ". . . | . 8 . | . 7 9 \n",
       "\n",
-      "Solution trouvee en 2.12 ms:\n",
+      "Solution trouvee en 3.50 ms:\n",
       "5 3 4 | 6 7 8 | 9 1 2 \n",
       "6 7 2 | 1 9 5 | 3 4 8 \n",
       "1 9 8 | 3 4 2 | 5 6 7 \n",
@@ -1051,7 +1090,16 @@
   {
    "cell_type": "markdown",
    "id": "0279b00f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002511,
+     "end_time": "2026-04-24T00:23:10.244651",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.242140",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Resolution du puzzle de test\n",
     "\n",
@@ -1076,10 +1124,10 @@
    "id": "cell-14",
    "metadata": {
     "papermill": {
-     "duration": 0.001863,
-     "end_time": "2026-02-18T08:36:44.219968",
+     "duration": 0.002,
+     "end_time": "2026-04-24T00:23:10.248652",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.218105",
+     "start_time": "2026-04-24T00:23:10.246652",
      "status": "completed"
     },
     "tags": []
@@ -1093,11 +1141,17 @@
    "execution_count": 6,
    "id": "cell-15",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.253156Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.253156Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.272313Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.271738Z"
+    },
     "papermill": {
-     "duration": 0.008101,
-     "end_time": "2026-02-18T08:36:44.229837",
+     "duration": 0.021661,
+     "end_time": "2026-04-24T00:23:10.272313",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.221736",
+     "start_time": "2026-04-24T00:23:10.250652",
      "status": "completed"
     },
     "tags": []
@@ -1154,7 +1208,16 @@
   {
    "cell_type": "markdown",
    "id": "1dad8bc9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002006,
+     "end_time": "2026-04-24T00:23:10.276827",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.274821",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Chargement des puzzles\n",
     "\n",
@@ -1178,10 +1241,10 @@
    "id": "cell-16",
    "metadata": {
     "papermill": {
-     "duration": 0.002078,
-     "end_time": "2026-02-18T08:36:44.233743",
+     "duration": 0.002506,
+     "end_time": "2026-04-24T00:23:10.281331",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.231665",
+     "start_time": "2026-04-24T00:23:10.278825",
      "status": "completed"
     },
     "tags": []
@@ -1195,11 +1258,17 @@
    "execution_count": 7,
    "id": "cell-17",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.286845Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.286845Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.394386Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.393883Z"
+    },
     "papermill": {
-     "duration": 0.008594,
-     "end_time": "2026-02-18T08:36:44.244015",
+     "duration": 0.11155,
+     "end_time": "2026-04-24T00:23:10.395390",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.235421",
+     "start_time": "2026-04-24T00:23:10.283840",
      "status": "completed"
     },
     "tags": []
@@ -1210,45 +1279,46 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "============================================================\n",
-      "Benchmark DLX: Puzzles Faciles (10 puzzles)\n",
-      "============================================================\n",
-      "  Puzzle  1: OK en    1.838 ms\n",
-      "  Puzzle  2: OK en    1.974 ms\n",
-      "  Puzzle  3: OK en    1.972 ms\n",
-      "  Puzzle  4: OK en    2.045 ms\n",
-      "  Puzzle  5: OK en    1.857 ms\n",
-      "  ... (5 autres puzzles resolus)\n",
-      "\n",
-      "Resultats:\n",
-      "  Resolus:     10/10\n",
-      "  Temps total:      21.34 ms\n",
-      "  Temps moyen:      2.134 ms\n",
-      "  Temps min:        1.793 ms\n",
-      "  Temps max:        3.891 ms\n",
-      "\n",
-      "============================================================\n",
-      "Benchmark DLX: Puzzles Difficiles (Top 11) (11 puzzles)\n",
-      "============================================================\n",
-      "  Puzzle  1: OK en    2.878 ms\n",
-      "  Puzzle  2: OK en    7.689 ms\n",
-      "  Puzzle  3: OK en    2.851 ms\n",
-      "  Puzzle  4: OK en    6.490 ms\n",
-      "  Puzzle  5: OK en    2.234 ms\n"
+      "============================================================"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\n",
+      "Benchmark DLX: Puzzles Faciles (10 puzzles)\n",
+      "============================================================\n",
+      "  Puzzle  1: OK en    2.641 ms\n",
+      "  Puzzle  2: OK en    3.513 ms\n",
+      "  Puzzle  3: OK en    2.000 ms\n",
+      "  Puzzle  4: OK en    4.512 ms\n",
+      "  Puzzle  5: OK en    3.001 ms\n",
+      "  ... (5 autres puzzles resolus)\n",
+      "\n",
+      "Resultats:\n",
+      "  Resolus:     10/10\n",
+      "  Temps total:      30.56 ms\n",
+      "  Temps moyen:      3.056 ms\n",
+      "  Temps min:        1.999 ms\n",
+      "  Temps max:        4.512 ms\n",
+      "\n",
+      "============================================================\n",
+      "Benchmark DLX: Puzzles Difficiles (Top 11) (11 puzzles)\n",
+      "============================================================\n",
+      "  Puzzle  1: OK en   16.233 ms\n",
+      "  Puzzle  2: OK en    6.555 ms\n",
+      "  Puzzle  3: OK en    2.004 ms\n",
+      "  Puzzle  4: OK en    7.041 ms\n",
+      "  Puzzle  5: OK en    1.536 ms\n",
       "  ... (6 autres puzzles resolus)\n",
       "\n",
       "Resultats:\n",
       "  Resolus:     11/11\n",
-      "  Temps total:      56.74 ms\n",
-      "  Temps moyen:      5.158 ms\n",
-      "  Temps min:        2.234 ms\n",
-      "  Temps max:       15.259 ms\n"
+      "  Temps total:      61.26 ms\n",
+      "  Temps moyen:      5.570 ms\n",
+      "  Temps min:        1.536 ms\n",
+      "  Temps max:       16.233 ms\n"
      ]
     }
    ],
@@ -1310,7 +1380,16 @@
   {
    "cell_type": "markdown",
    "id": "1f9378c6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002762,
+     "end_time": "2026-04-24T00:23:10.400152",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.397390",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Benchmark Dancing Links\n",
     "\n",
@@ -1334,7 +1413,16 @@
   {
    "cell_type": "markdown",
    "id": "jnysngyinz",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004001,
+     "end_time": "2026-04-24T00:23:10.407155",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.403154",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple : Comptage du nombre de solutions avec Dancing Links\n",
     "\n",
@@ -1357,84 +1445,89 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "wdgjyorp0t",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.414170Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.414170Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.425674Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.424674Z"
+    },
+    "papermill": {
+     "duration": 0.01552,
+     "end_time": "2026-04-24T00:23:10.425674",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.410154",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test 1: grille avec une solution unique\n",
-      "  Nombre de solutions : 1 (attendu : 1)\n",
-      "Test 2: grille sous-contrainte (plusieurs solutions)\n",
-      "  Nombre de solutions trouvees (limite a 3) : 3\n",
-      "TODO: Implementez count_solutions() pour executer les tests\n"
+      "Exercice count_solutions a completer - voir les indices ci-dessus\n"
      ]
     }
    ],
    "source": [
     "def count_solutions(puzzle: SudokuGrid, max_count: int = 10) -> int:\n",
     "    \"\"\"Compte le nombre de solutions d'une grille Sudoku.\n",
-    "    \n",
+    "\n",
     "    Args:\n",
     "        puzzle: Grille de depart (0 = case vide)\n",
     "        max_count: Nombre maximum de solutions a chercher\n",
-    "    \n",
+    "\n",
     "    Returns:\n",
     "        Nombre de solutions trouvees (au plus max_count)\n",
+    "\n",
+    "    Indices d'implementation :\n",
+    "      1. Construire la matrice DLX comme dans `DLXSudokuSolver.solve` :\n",
+    "         - Creer `DancingLinks(solver.NUM_COLUMNS)`\n",
+    "         - Pour chaque case (r, c), si la case est remplie (val != 0) ajouter\n",
+    "           une seule ligne de contrainte ; sinon, ajouter 9 lignes (une par\n",
+    "           valeur 1-9)\n",
+    "         - Utiliser `solver._get_columns(r, c, v)` pour obtenir les colonnes\n",
+    "      2. Lancer `dlx.search2(find_all=True, limit=max_count)`\n",
+    "      3. Retourner `len(dlx.solutions_found)`\n",
+    "\n",
+    "    Le cas `puzzle is None` peut etre gere en tete pour robustesse.\n",
     "    \"\"\"\n",
-    "    # TODO: Implementer le comptage de solutions avec Dancing Links\n",
-    "    # Etape 1: Construire la matrice DLX comme dans DLXSudokuSolver.solve\n",
-    "    # Etape 2: Lancer dlx.search(find_all=True) pour trouver toutes les solutions\n",
-    "    # Etape 3: S'arreter quand max_count solutions sont trouvees\n",
-    "    if puzzle is None:\n",
-    "        return 0\n",
+    "    # TODO: votre implementation\n",
+    "    raise NotImplementedError(\"Exercice : implementez count_solutions avec Dancing Links\")\n",
     "\n",
-    "    # On utilise le solveur pour accéder à la logique des colonnes\n",
-    "    solver = DLXSudokuSolver()\n",
-    "    dlx = DancingLinks(solver.NUM_COLUMNS)\n",
-    "    row_info = {}\n",
-    "    row_id = 0\n",
     "\n",
-    "    # Construction de la matrice exacte\n",
-    "    for r in range(9):\n",
-    "        for c in range(9):\n",
-    "            val = puzzle.cells[r][c]\n",
-    "            # Si la case est remplie, on ne crée qu'une ligne de contrainte\n",
-    "            # Si elle est vide (0), on crée les 9 possibilités (1-9)\n",
-    "            values = [val] if val != 0 else range(1, 10)\n",
-    "            \n",
-    "            for v in values:\n",
-    "                cols = solver._get_columns(r, c, v)\n",
-    "                dlx.add_row(row_id, cols)\n",
-    "                row_info[row_id] = (r, c, v)\n",
-    "                row_id += 1\n",
+    "# Tests de votre implementation (decommentez apres implementation)\n",
+    "# print(\"Test 1: grille avec une solution unique\")\n",
+    "# puzzle_unique = SudokuGrid.from_string(\n",
+    "#     \"530070000600195000098000060800060003400803001700020006060000280000419005000080079\"\n",
+    "# )\n",
+    "# count = count_solutions(puzzle_unique, max_count=5)\n",
+    "# print(f\"  Nombre de solutions : {count} (attendu : 1)\")\n",
+    "#\n",
+    "# print(\"Test 2: grille sous-contrainte (plusieurs solutions)\")\n",
+    "# puzzle_multi = SudokuGrid.from_string(\n",
+    "#     \"000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
+    "# )\n",
+    "# count = count_solutions(puzzle_multi, max_count=3)\n",
+    "# print(f\"  Nombre de solutions trouvees (limite a 3) : {count}\")\n",
     "\n",
-    "    # On cherche toutes les solutions jusqu'à max_count\n",
-    "    dlx.search2(find_all=True, limit=max_count)\n",
-    "    \n",
-    "    return len(dlx.solutions_found)\n",
-    "\n",
-    "# Tests de votre implementation\n",
-    "print(\"Test 1: grille avec une solution unique\")\n",
-    "puzzle_unique = SudokuGrid.from_string(\n",
-    "    \"530070000600195000098000060800060003400803001700020006060000280000419005000080079\"\n",
-    ")\n",
-    "count = count_solutions(puzzle_unique, max_count=5)\n",
-    "print(f\"  Nombre de solutions : {count} (attendu : 1)\")\n",
-    "\n",
-    "print(\"Test 2: grille sous-contrainte (plusieurs solutions)\")\n",
-    "puzzle_multi = SudokuGrid.from_string(\n",
-    "    \"000000000000000000000000000000000000000000000000000000000000000000000000000000000\"\n",
-    ")\n",
-    "count = count_solutions(puzzle_multi, max_count=3)\n",
-    "print(f\"  Nombre de solutions trouvees (limite a 3) : {count}\")\n",
-    "\n",
-    "print(\"TODO: Implementez count_solutions() pour executer les tests\")"
+    "print(\"Exercice count_solutions a completer - voir les indices ci-dessus\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "a3575b81",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002501,
+     "end_time": "2026-04-24T00:23:10.431176",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.428675",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Resoudre le probleme des N-Reines avec Dancing Links\n",
     "\n",
@@ -1463,12 +1556,38 @@
     "### Indice\n",
     "\n",
     "Pour simplifier, commencez par ignorer les diagonales et utilisez uniquement les contraintes de ligne et de colonne (couverture exacte stricte : 2N colonnes, N^2 lignes). Verifiez ensuite que les solutions obtenues respectent aussi les diagonales. Le nombre de solutions pour N=8 est 92 (solutions distinctes), et pour N=4 c'est 2."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "ab4c4ac6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-24T00:23:10.437194Z",
+     "iopub.status.busy": "2026-04-24T00:23:10.437194Z",
+     "iopub.status.idle": "2026-04-24T00:23:10.455730Z",
+     "shell.execute_reply": "2026-04-24T00:23:10.455730Z"
+    },
+    "papermill": {
+     "duration": 0.023536,
+     "end_time": "2026-04-24T00:23:10.456723",
+     "exception": false,
+     "start_time": "2026-04-24T00:23:10.433187",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== N-Reines avec Dancing Links ===\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "def build_nqueens_matrix(n: int):\n",
     "    \"\"\"Construit la matrice de couverture exacte pour le probleme des N-Reines.\n",
@@ -1519,18 +1638,6 @@
     "# TODO: Test N=4 (attendu : 2 solutions)\n",
     "# TODO: Test N=8 (attendu : 92 solutions)\n",
     "# TODO: Afficher quelques solutions sous forme d'echiquier"
-   ],
-   "metadata": {},
-   "execution_count": 9,
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== N-Reines avec Dancing Links ===\n",
-      "\n"
-     ]
-    }
    ]
   },
   {
@@ -1538,10 +1645,10 @@
    "id": "cell-18",
    "metadata": {
     "papermill": {
-     "duration": 0.001813,
-     "end_time": "2026-02-18T08:36:44.247784",
+     "duration": 0.003053,
+     "end_time": "2026-04-24T00:23:10.461775",
      "exception": false,
-     "start_time": "2026-02-18T08:36:44.245971",
+     "start_time": "2026-04-24T00:23:10.458722",
      "status": "completed"
     },
     "tags": []
@@ -1593,18 +1700,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.404496,
-   "end_time": "2026-02-18T08:36:46.892851",
+   "duration": 2.215777,
+   "end_time": "2026-04-24T00:23:10.691560",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-Python-DancingLinks.ipynb",
-   "output_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-Python-DancingLinks.ipynb",
+   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-2-DancingLinks-Python.ipynb",
+   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-2-DancingLinks-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-02-18T08:36:42.488355",
+   "start_time": "2026-04-24T00:23:08.475783",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Follow-up to PR #514 (App-15 + App-7 leaks). Audit #362 triage pass also flagged **Sudoku-2-DancingLinks cell 23**: a `count_solutions` function with TODO markers followed by a complete 30+ line DLX implementation, including tests with expected output commented.

Pattern identical to App-15/App-7: `# TODO: implementer X` directly followed by the complete X implementation.

## Fix

- Function body → `raise NotImplementedError` + detailed hints:
  - Matrix construction (DLX columns from `DLXSudokuSolver._get_columns`)
  - Search call pattern (`dlx.search2(find_all=True, limit=max_count)`)
  - Return `len(dlx.solutions_found)`
- Test calls commented (`# Tests de votre implementation (decommentez apres implementation)`)

## Validation

- Papermill: **SUCCESS 3.3s** (post-fix, stubs raise only from commented tests)
- Notebook flow preserved; no impact on other exercises

## Audit #362 progress

| PR | Notebook(s) | Leaks stripped |
|----|-------------|----------------|
| #514 | App-15 (3), App-7 (1) | 4 |
| #515 (this) | Sudoku-2 (1) | 1 |
| **Total** | **3 notebooks** | **5 leaks** |

Remaining triage notes:
- Search-6 (5 exercises) — overlap with po-2026 #340 mission, deferred
- App-16 (2 cells) — pre-existing `Slot` bug unrelated, deferred

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>