### PR TITLE
feat(sudoku-6): reframe CBJ as cautionary example (#383)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -1050,20 +1050,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exemple guide : CBJ (Conflict-Based Backjumping)\n",
+    "## Exemple cautionnaire : CBJ (Conflict-Based Backjumping)\n",
     "\n",
     "### Principe\n",
     "\n",
-    "Le **CBJ** (Conflict-Based Backjumping) evite d'explorer des branches inutiles en remontant directement au niveau responsable du conflit. L'implementation ci-dessous illustre les points cles de l'algorithme :\n",
+    "Le **CBJ** (Conflict-Based Backjumping) est un algorithme qui remonte directement au niveau responsable d'un conflit au lieu de faire du backtracking chronologique. En theorie, cette approche devrait accelerer la resolution en evitant d'explorer des branches inutiles.\n",
+    "\n",
+    "**Attention** : comme nous allons le voir, CBJ illustre un piege classique en IA -- un algorithme theoretiquement superieur qui ne l'est pas toujours en pratique. L'etude de ce cas vous aidera a comprendre pourquoi le choix d'un algorithme depend fortement du probleme.\n",
+    "\n",
+    "L'implementation ci-dessous illustre les points cles de l'algorithme :\n",
     "\n",
     "1. **Conflict set** : Dictionnaire `conflict_sets[var] = set()` des variables anterieures qui ont cause un conflit avec `var`\n",
     "2. **Detection de conflit** : Quand `val` est inconsistant avec un voisin assigne `n`, ajouter `n` au conflict set de `var`\n",
     "3. **Backjumping** : Quand `var` n'a plus de valeur viable, remonter directement a la variable la plus recente dans son conflict set\n",
     "4. **Fusion** : Lors d'un backjump de Y vers X, fusionner `conflict_sets[Y] - {X}` dans `conflict_sets[X]`\n",
     "\n",
-    "### Resultats observes\n",
+    "### Pourquoi cet exemple est instructif\n",
     "\n",
-    "Sur les puzzles difficiles, CBJ sans heuristiques (MRV/LCV) ne resout pas les grilles mais montre un comportement different du backtracking classique : peu d'assignations (112 en moyenne) mais 0 succes. Cela illustre que **le backjumping seul ne suffit pas** pour le Sudoku -- il faut le combiner avec des heuristiques de selection de variable et de propagation de contraintes."
+    "Sur les puzzles faciles, CBJ avec MRV fonctionne bien (peu d'assignations). Mais sur les puzzles **difficiles**, CBJ sans propagation de contraintes (Forward Checking, AC-3) ne resout pas les grilles : peu d'assignations mais 0 succes. Cela illustre que **le backjumping seul ne suffit pas** -- il faut le combiner avec des heuristiques de selection de variable ET de propagation de contraintes.\n",
+    "\n",
+    "**Lecon** : ne jugez pas un algorithme seulement sur des instances faciles. Un algorithme qui semble efficace sur des problemes simples peut echouer sur des instances plus difficiles ou la propagation de contraintes est determinante.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Reframe CBJ section from "Exemple guide" to "Exemple cautionnaire" to clarify it demonstrates algorithm limitations
- Add pedagogical framing about why CBJ fails on hard puzzles without constraint propagation
- CBJ code was already complete (no TODOs to remove), Resume cell was already correctly positioned

## Test plan
- [ ] Verify notebook opens correctly in Jupyter
- [ ] Verify CBJ section reads as cautionary example
- [ ] Verify exercises (cells 31-32) are unchanged

Ref: #383 (Sudoku-6 item)

Generated with [Claude Code](https://claude.com/claude-code)