### PR TITLE
fix(search): PyGad-EdgeDetection robust image path resolution (#488)

### DIFF
--- a/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
@@ -613,13 +613,19 @@
    "source": [
     "from PIL import Image\n",
     "# Test de la fonction fitness\n",
-    "image_path = str(Path().resolve() / \"MRI_Prostate_Cancer.jpg\")\n",
+    "# Resolution robuste du chemin image (CWD peut differer sous Papermill)\n",
+    "_here = Path().resolve()\n",
+    "for _candidate in [_here, _here / \"MyIA.AI.Notebooks\" / \"Search\"]:\n",
+    "    if (_candidate / \"MRI_Prostate_Cancer.jpg\").exists():\n",
+    "        _here = _candidate\n",
+    "        break\n",
+    "image_path = str(_here / \"MRI_Prostate_Cancer.jpg\")\n",
     "original_image = Image.open(image_path)\n",
     "fitness = EdgeFitness(original_image)\n",
     "\n",
     "# Test d'un chromosome\n",
     "chromosome = EdgeChromosome(20)\n",
-    "print(f\"Score de fitness : {fitness.evaluate(np.concatenate([gene.flatten() for gene in chromosome.genes]), 0)}\")"
+    "print(f\"Score de fitness : {fitness.evaluate(np.concatenate([gene.flatten() for gene in chromosome.genes]), 0)}\")\n"
    ]
   },
   {
@@ -688,7 +694,13 @@
     "# A) Charger l'image avec PIL ou cv2, puis créer l'objet Fitness\n",
     "# -------------------------------------------------------------------\n",
     "\n",
-    "image_path = str(Path().resolve() / \"MRI_Prostate_Cancer.jpg\")  # Remplacez par le chemin de votre image\n",
+    "# Resolution robuste du chemin image (CWD peut differer sous Papermill)\n",
+    "_here = Path().resolve()\n",
+    "for _candidate in [_here, _here / \"MyIA.AI.Notebooks\" / \"Search\"]:\n",
+    "    if (_candidate / \"MRI_Prostate_Cancer.jpg\").exists():\n",
+    "        _here = _candidate\n",
+    "        break\n",
+    "image_path = str(_here / \"MRI_Prostate_Cancer.jpg\")  # Remplacez par le chemin de votre image\n",
     "\n",
     "original_image = Image.open(image_path)\n",
     "\n",
@@ -747,7 +759,7 @@
     "    mutation_type = \"random\",\n",
     "    mutation_percent_genes = 10,\n",
     "    on_generation = on_generation\n",
-    ")"
+    ")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fix NO-OP in PR #521 where `Path().resolve()` resolved to CWD, producing the same result as the original relative path
- Apply multi-location fallback pattern (same as Sudoku-4/5) to resolve `MRI_Prostate_Cancer.jpg` regardless of CWD
- 2 cells fixed in PyGad-EdgeDetection.ipynb

## Context
- Issue #488 M-71 PyGad-EdgeDetection
- ai-01 detected PR #521's fix was a NO-OP: `Path().resolve()` = CWD = same as relative path
- po-2025 pushed fix branch from secondary account, PR created from main account

## Test plan
- [ ] Validate notebook structure passes CI
- [ ] Verify image path resolution works from both notebook dir and repo root

Co-Authored-By: po-2025 <noreply@myia.ai>