### PR TITLE
fix(docker): comfyui-video libGL + torchao/diffusers conflict

### DIFF
--- a/docker-configurations/services/comfyui-video/entrypoint.sh
+++ b/docker-configurations/services/comfyui-video/entrypoint.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Demarrage de l'entrypoint ComfyUI-Video..."
 
+# System packages for OpenCV (cv2) and video processing
+apt-get update -qq && apt-get install -y -qq libgl1 libglib2.0-0 2>/dev/null || echo "System packages: already installed or not needed"
+
 # Clonage si necessaire
 if [ ! -f "main.py" ]; then
     echo "Clonage de ComfyUI..."
@@ -123,16 +126,17 @@ fi
 # =============================================================================
 # QUANTIZATION SUPPORT (INT8/FP8)
 # =============================================================================
-echo "Installation des outils de quantization INT8/FP8..."
+# NOTE: torchao is NOT installed here because torchao>=0.10 breaks diffusers
+# lazy imports (logger undefined in torchao_quantizer.py). If torchao is needed
+# later, pin torchao<0.10 or wait for a diffusers fix.
 
-# TorchAO pour INT8 quantization (PyTorch native)
-venv/bin/pip install torchao>=0.4.0 || echo "TorchAO: installation optionnelle echouee"
+echo "Installation des outils de quantization (sans torchao)..."
 
 # Optimum Quanto pour quantization Hugging Face
 venv/bin/pip install optimum-quanto>=0.2.0 || echo "Optimum-Quanto: installation optionnelle echouee"
 
 # bitsandbytes pour INT8 linear layers
-venv/bin/pip install bitsandbytes>=0.43.0 || echo "Bitsandbytes: installation optionnelle echouee (Windows peut echouer)"
+venv/bin/pip install bitsandbytes>=0.43.0 || echo "Bitsandbytes: installation optionnelle echouee"
 
 # =============================================================================
 # DEMARRAGE


### PR DESCRIPTION
## Summary
- Fix `ImportError: libGL.so.1` in ComfyUI-VideoHelperSuite by installing `libgl1` + `libglib2.0-0` system packages (Debian 13 trixie renamed `libgl1-mesa-glx` to `libgl1`)
- Fix `NameError: name 'logger' is not defined` in ComfyUI-HunyuanVideoWrapper by removing torchao from deps — torchao>=0.10 breaks diffusers 0.33-0.36 lazy imports
- All 5 custom nodes now load with 0 IMPORT FAILED messages

## Test plan
- [x] Container recreated with `docker compose up -d --force-recreate comfyui-video`
- [x] Verified all custom nodes import successfully:
  - ComfyUI-VideoHelperSuite: 1.3s
  - ComfyUI-HunyuanVideoWrapper: 40.3s
  - ComfyUI-AnimateDiff-Evolved: 1.0s
  - ComfyUI-Login: 0.5s
  - ComfyUI-GGUF: 0.2s
- [x] Server starts and listens on port 8188
- [x] Healthcheck passing (200 OK)

Closes #273

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>