### PR TITLE
feat(docker): Qwen3-ASR-1.7B API with ISO 639-1 language support

### DIFF
--- a/docker-configurations/services/qwen-asr-api/.env.example
+++ b/docker-configurations/services/qwen-asr-api/.env.example
@@ -1,0 +1,21 @@
+# Qwen ASR API Configuration
+QWEN_ASR_PORT=8195
+GPU_DEVICE_ID=1
+CUDA_VISIBLE_DEVICES=1
+NVIDIA_VISIBLE_DEVICES=1
+
+# Model configuration
+QWEN_ASR_MODEL=Qwen/Qwen3-ASR-1.7B
+QWEN_ASR_DTYPE=bfloat16
+FORCED_ALIGNER=Qwen/Qwen3-ForcedAligner-0.6B
+PRELOAD_MODEL=false
+
+# Paths
+MODELS_PATH=./models
+TZ=Europe/Paris
+
+# Authentication (bearer token for API access)
+QWEN_ASR_API_KEY=
+
+# HuggingFace token (for model downloads)
+HF_TOKEN=

--- a/docker-configurations/services/qwen-asr-api/.gitignore
+++ b/docker-configurations/services/qwen-asr-api/.gitignore
@@ -1,0 +1,2 @@
+.env
+models/

--- a/docker-configurations/services/qwen-asr-api/Dockerfile
+++ b/docker-configurations/services/qwen-asr-api/Dockerfile
@@ -1,0 +1,56 @@
+# Qwen ASR API - FastAPI wrapper for Qwen3-ASR-1.7B
+# Multilingual ASR with auto language detection, OpenAI-compatible API
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    curl \
+    git \
+    python3.11 \
+    python3.11-venv \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python \
+    && ln -sf /usr/bin/python3.11 /usr/bin/python3
+
+# Install PyTorch with CUDA 12.1 support first (large, cached layer)
+RUN pip install --no-cache-dir \
+    torch \
+    torchaudio \
+    --index-url https://download.pytorch.org/whl/cu121
+
+# Install numpy first (required by sox dependency of qwen-asr)
+RUN pip install --no-cache-dir numpy
+
+# Install qwen-asr package and API dependencies
+RUN pip install --no-cache-dir \
+    qwen-asr \
+    fastapi \
+    uvicorn \
+    python-multipart \
+    soundfile \
+    librosa \
+    transformers \
+    sentencepiece
+
+# Copy application files
+COPY app.py /app/
+COPY start.sh /app/
+RUN chmod +x /app/start.sh
+# Shared modules (lazy_model, auth_middleware) are mounted at runtime via volume
+
+# Create directories
+RUN mkdir -p /app/models /app/uploads
+
+# Expose port
+EXPOSE 8195
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:8195/health || exit 1
+
+# Start
+CMD ["/app/start.sh"]

--- a/docker-configurations/services/qwen-asr-api/README.md
+++ b/docker-configurations/services/qwen-asr-api/README.md
@@ -1,0 +1,127 @@
+# Qwen ASR API - Multilingual Speech-to-Text
+
+Service FastAPI exposant une API OpenAI-compatible pour la transcription audio multilingue avec Qwen3-ASR-1.7B.
+
+## Vue d'ensemble
+
+| Parametre | Valeur |
+|-----------|--------|
+| **Modele** | Qwen/Qwen3-ASR-1.7B |
+| **Forced Aligner** | Qwen/Qwen3-ForcedAligner-0.6B (timestamps mot-niveau) |
+| **Port** | 8195 (configurable via `QWEN_ASR_PORT`) |
+| **GPU** | GPU 1 (RTX 3090, 24GB) |
+| **VRAM** | ~4GB |
+| **API** | OpenAI `/v1/audio/transcriptions` compatible |
+| **Langues** | 52 langues auto-detectees (FR, EN, DE, ES, ZH, JA, KO, AR, etc.) |
+| **Idle timeout** | 300s (dechargement automatique du modele) |
+| **URL cloud** | `https://stt.myia.io/qwen` |
+
+## Demarrage
+
+```bash
+# Configuration
+cp .env.example .env
+# Editer .env : ajouter HF_TOKEN (modele gated)
+
+# Build et demarrage
+docker-compose up -d --build
+
+# Verification
+curl http://localhost:8195/health
+```
+
+## API Endpoints
+
+### Health Check
+
+```bash
+curl http://localhost:8195/health
+```
+
+### Transcription (OpenAI-compatible)
+
+```bash
+# Transcription simple (auto-detection langue)
+curl -X POST http://localhost:8195/v1/audio/transcriptions \
+  -F "file=@audio.mp3" \
+  -F "model=qwen-asr-1"
+
+# Avec indication de langue (ISO 639-1 supporte)
+curl -X POST http://localhost:8195/v1/audio/transcriptions \
+  -F "file=@audio.mp3" \
+  -F "model=qwen-asr-1" \
+  -F "language=fr"
+
+# Format verbose avec timestamps
+curl -X POST http://localhost:8195/v1/audio/transcriptions \
+  -F "file=@audio.mp3" \
+  -F "model=qwen-asr-1" \
+  -F "response_format=verbose_json" \
+  -F "timestamp_granularities[]=word"
+```
+
+### Liste des modeles
+
+```bash
+curl http://localhost:8195/v1/models
+```
+
+### Dechargement force (admin)
+
+```bash
+curl -X POST http://localhost:8195/admin/unload
+```
+
+## Parametres supportes
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `file` | File | (requis) | Fichier audio (mp3, wav, ogg, flac, m4a, webm) |
+| `model` | string | `qwen-asr-1` | ID du modele |
+| `language` | string | auto | Code ISO 639-1 (`fr`, `en`, `de`...) ou nom complet |
+| `response_format` | string | `json` | `json`, `text`, `verbose_json` |
+| `timestamp_granularities` | list | `["segment"]` | `["word"]` ou `["segment"]` |
+| `temperature` | float | `0.0` | Temperature de generation |
+
+## Normalisation des langues
+
+Le service accepte les codes ISO 639-1 (`fr`, `en`, `de`, `es`...) et les normalise
+automatiquement vers les noms complets attendus par le modele (`French`, `English`, etc.).
+
+Codes supportes : zh, en, fr, de, es, pt, it, ko, ja, ru, ar, hi, tr, th, vi, id, ms,
+nl, sv, da, fi, pl, cs, fil, fa, el, ro, hu, mk, yue (30 codes + variantes).
+
+## Configuration (.env)
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `QWEN_ASR_PORT` | 8195 | Port d'ecoute |
+| `GPU_DEVICE_ID` | 1 | ID du GPU nvidia |
+| `QWEN_ASR_MODEL` | Qwen/Qwen3-ASR-1.7B | Modele ASR |
+| `QWEN_ASR_DTYPE` | bfloat16 | Precision (float16, bfloat16, float32) |
+| `FORCED_ALIGNER` | Qwen/Qwen3-ForcedAligner-0.6B | Modele d'alignement (vide = desactive) |
+| `PRELOAD_MODEL` | false | Charger le modele au demarrage |
+| `IDLE_TIMEOUT` | 300 | Secondes avant dechargement automatique |
+| `MAX_FILE_SIZE` | 52428800 | Taille max fichier (50MB) |
+| `QWEN_ASR_API_KEY` | (vide) | Cle API bearer token |
+| `HF_TOKEN` | (vide) | Token HuggingFace pour modeles gates |
+
+## Architecture
+
+- **Lazy loading** : Le modele est charge a la premiere requete, decharge apres 300s d'inactivite
+- **Shared modules** : `../shared/` monte en lecture seule (`lazy_model.py`, `auth_middleware.py`)
+- **FFmpeg** : Conversion automatique en WAV 16kHz mono
+- **CUDA fallback** : Bascule sur CPU si CUDA indisponible
+
+## Fichiers
+
+```
+qwen-asr-api/
+├── app.py              # Application FastAPI
+├── Dockerfile          # Image CUDA 12.1 + Python 3.11
+├── docker-compose.yml  # Orchestration Docker
+├── start.sh            # Script de demarrage uvicorn
+├── .env.example        # Template configuration
+├── .gitignore          # Exclut .env et models/
+└── README.md           # Ce fichier
+```

--- a/docker-configurations/services/qwen-asr-api/app.py
+++ b/docker-configurations/services/qwen-asr-api/app.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Qwen ASR API - FastAPI wrapper for Qwen3-ASR-1.7B
+OpenAI-compatible API for multilingual speech-to-text
+
+Features:
+- Lazy loading with auto-unload after inactivity (shared LazyModelManager)
+- GPU memory management
+- OpenAI-compatible /v1/audio/transcriptions endpoint
+- Auto language detection (52 languages)
+- Optional word-level timestamps via Qwen3-ForcedAligner-0.6B
+"""
+
+import os
+import sys
+import time
+import tempfile
+import logging
+import asyncio
+from typing import Optional, List
+from pathlib import Path
+
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+# Add shared module to path
+sys.path.insert(0, "/app/shared")
+from lazy_model import LazyModelManager, idle_checker_task
+from auth_middleware import setup_auth
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("qwen-asr-api")
+
+# Set HuggingFace token for gated model downloads
+HF_TOKEN = os.getenv("HF_TOKEN", "")
+if HF_TOKEN:
+    os.environ["HUGGING_FACE_HUB_TOKEN"] = HF_TOKEN
+    os.environ["HF_TOKEN"] = HF_TOKEN
+    logger.info("HuggingFace token configured")
+
+# Configuration from environment
+QWEN_MODEL = os.getenv("QWEN_ASR_MODEL", "Qwen/Qwen3-ASR-1.7B")
+FORCED_ALIGNER = os.getenv("FORCED_ALIGNER", "")  # empty = disabled
+DEVICE = os.getenv("QWEN_ASR_DEVICE", "cuda")
+MAX_FILE_SIZE = int(os.getenv("MAX_FILE_SIZE", 50 * 1024 * 1024))  # 50MB
+IDLE_TIMEOUT = int(os.getenv("IDLE_TIMEOUT", "300"))  # 5 minutes
+PRELOAD_MODEL = os.getenv("PRELOAD_MODEL", "false").lower() == "true"
+DTYPE = os.getenv("QWEN_ASR_DTYPE", "bfloat16")
+
+app = FastAPI(
+    title="Qwen ASR API",
+    description="OpenAI-compatible ASR API using Qwen3-ASR-1.7B with auto-unload",
+    version="1.1.0"
+)
+
+# ISO 639-1 / common codes → qwen-asr full language names
+LANG_MAP = {
+    "zh": "Chinese", "cn": "Chinese", "chinese": "Chinese",
+    "en": "English", "english": "English",
+    "yue": "Cantonese", "cantonese": "Cantonese",
+    "ar": "Arabic", "arabic": "Arabic",
+    "de": "German", "german": "German",
+    "fr": "French", "french": "French",
+    "es": "Spanish", "spanish": "Spanish",
+    "pt": "Portuguese", "portuguese": "Portuguese",
+    "id": "Indonesian", "indonesian": "Indonesian",
+    "it": "Italian", "italian": "Italian",
+    "ko": "Korean", "korean": "Korean",
+    "ru": "Russian", "russian": "Russian",
+    "th": "Thai", "thai": "Thai",
+    "vi": "Vietnamese", "vietnamese": "Vietnamese",
+    "ja": "Japanese", "japanese": "Japanese",
+    "tr": "Turkish", "turkish": "Turkish",
+    "hi": "Hindi", "hindi": "Hindi",
+    "ms": "Malay", "malay": "Malay",
+    "nl": "Dutch", "dutch": "Dutch",
+    "sv": "Swedish", "swedish": "Swedish",
+    "da": "Danish", "danish": "Danish",
+    "fi": "Finnish", "finnish": "Finnish",
+    "pl": "Polish", "polish": "Polish",
+    "cs": "Czech", "czech": "Czech",
+    "fil": "Filipino", "tl": "Filipino", "filipino": "Filipino",
+    "fa": "Persian", "persian": "Persian",
+    "el": "Greek", "greek": "Greek",
+    "ro": "Romanian", "romanian": "Romanian",
+    "hu": "Hungarian", "hungarian": "Hungarian",
+    "mk": "Macedonian", "macedonian": "Macedonian",
+}
+
+
+def _normalize_language(lang: str) -> str:
+    """Convert ISO 639-1 code or case variant to qwen-asr full name."""
+    if not lang:
+        return lang
+    key = lang.strip().lower()
+    return LANG_MAP.get(key, lang)
+
+# CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Bearer token authentication
+setup_auth(app)
+
+
+def _get_torch_dtype():
+    import torch
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16, "float32": torch.float32}.get(
+        DTYPE, torch.bfloat16
+    )
+
+
+def _load_qwen_model():
+    """Load the Qwen3-ASR model with CUDA fallback to CPU."""
+    from qwen_asr import Qwen3ASRModel
+    import torch
+
+    device = DEVICE
+    dtype = _get_torch_dtype()
+
+    if device == "cuda":
+        try:
+            if not torch.cuda.is_available():
+                logger.warning("CUDA not available, falling back to CPU")
+                device = "cpu"
+        except Exception as e:
+            logger.warning(f"CUDA check failed: {e}, falling back to CPU")
+            device = "cpu"
+
+    device_map = f"{device}:0" if device == "cuda" else device
+
+    logger.info(f"Loading Qwen3-ASR model: {QWEN_MODEL} on {device_map} ({DTYPE})")
+
+    kwargs = dict(
+        dtype=dtype,
+        device_map=device_map,
+        max_inference_batch_size=32,
+        max_new_tokens=256,
+    )
+
+    # Optional forced aligner for word-level timestamps
+    if FORCED_ALIGNER:
+        logger.info(f"Loading forced aligner: {FORCED_ALIGNER}")
+        kwargs["forced_aligner"] = FORCED_ALIGNER
+        kwargs["forced_aligner_kwargs"] = dict(dtype=dtype, device_map=device_map)
+
+    try:
+        model = Qwen3ASRModel.from_pretrained(QWEN_MODEL, **kwargs)
+        return model
+    except RuntimeError as e:
+        if "cuda" in str(e).lower() or "cublas" in str(e).lower():
+            logger.warning(f"CUDA error: {e}, falling back to CPU")
+            kwargs["device_map"] = "cpu"
+            if FORCED_ALIGNER:
+                kwargs["forced_aligner_kwargs"] = dict(dtype=dtype, device_map="cpu")
+            return Qwen3ASRModel.from_pretrained(QWEN_MODEL, **kwargs)
+        raise
+
+
+def _unload_qwen_model(model):
+    """Unload Qwen model and free GPU memory."""
+    del model
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:
+        pass
+
+
+# Model manager with lazy loading and auto-unload
+model_manager = LazyModelManager(
+    model_name="qwen-asr",
+    load_fn=_load_qwen_model,
+    unload_fn=_unload_qwen_model,
+    idle_timeout=IDLE_TIMEOUT,
+    device=DEVICE,
+    preload=PRELOAD_MODEL
+)
+
+
+# Response models (OpenAI-compatible)
+class TranscriptionWord(BaseModel):
+    word: str
+    start: float
+    end: float
+
+
+class TranscriptionSegment(BaseModel):
+    id: int
+    start: float
+    end: float
+    text: str
+
+
+class TranscriptionResponse(BaseModel):
+    text: str
+    language: Optional[str] = None
+    duration: Optional[float] = None
+    words: Optional[List[TranscriptionWord]] = None
+    segments: Optional[List[TranscriptionSegment]] = None
+
+
+def _convert_audio_to_wav(input_path: str) -> str:
+    """Convert audio to 16kHz mono WAV using ffmpeg."""
+    output_path = input_path.rsplit(".", 1)[0] + "_converted.wav"
+    import subprocess
+    result = subprocess.run(
+        ["ffmpeg", "-y", "-i", input_path, "-ar", "16000", "-ac", "1",
+         "-f", "wav", output_path],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        logger.warning(f"ffmpeg conversion warning: {result.stderr}")
+        return input_path
+    return output_path
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    cuda_available = False
+    gpu_name = None
+    gpu_memory = 0
+
+    try:
+        import torch
+        cuda_available = torch.cuda.is_available()
+        if cuda_available:
+            import subprocess
+            result = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name,memory.used", "--format=csv,noheader,nounits"],
+                capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                parts = result.stdout.strip().split("\n")[0].split(",")
+                gpu_name = parts[0].strip()
+                gpu_memory = float(parts[1].strip()) / 1024
+    except Exception as e:
+        logger.debug(f"GPU check failed: {e}")
+
+    status = model_manager.status
+
+    return {
+        "status": "healthy",
+        "model": QWEN_MODEL,
+        "forced_aligner": FORCED_ALIGNER or None,
+        "device": DEVICE,
+        "dtype": DTYPE,
+        "cuda_available": cuda_available,
+        "gpu_name": gpu_name,
+        "gpu_memory_gb": round(gpu_memory, 2),
+        "model_loaded": status["loaded"],
+        "idle_seconds": status.get("idle_seconds"),
+        "idle_timeout": IDLE_TIMEOUT
+    }
+
+
+@app.get("/v1/models")
+async def list_models():
+    """List available models (OpenAI-compatible)."""
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": "qwen-asr-1",
+                "object": "model",
+                "created": 1742400000,
+                "owned_by": "qwen"
+            }
+        ]
+    }
+
+
+@app.post("/v1/audio/transcriptions", response_model=TranscriptionResponse)
+async def transcribe_audio(
+    file: UploadFile = File(...),
+    model: str = Form("qwen-asr-1"),
+    language: Optional[str] = Form(None),
+    prompt: Optional[str] = Form(None),
+    response_format: str = Form("json"),
+    temperature: float = Form(0.0),
+    timestamp_granularities: List[str] = Form(["segment"])
+):
+    """
+    Transcribe audio file (OpenAI-compatible endpoint).
+
+    - **file**: Audio file (mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, flac)
+    - **model**: Model to use (qwen-asr-1)
+    - **language**: Language hint (auto-detected if not specified)
+    - **response_format**: 'json', 'text', 'verbose_json'
+    - **timestamp_granularities**: ['word'] or ['segment']
+    """
+    start_time = time.time()
+
+    # Validate file size
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail=f"File too large. Max: {MAX_FILE_SIZE / 1024 / 1024}MB")
+
+    # Save to temp file
+    suffix = Path(file.filename or "audio.wav").suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    converted_path = None
+    try:
+        # Convert to WAV for consistent processing
+        converted_path = _convert_audio_to_wav(tmp_path)
+        audio_path = converted_path
+
+        # Get duration using soundfile
+        import soundfile as sf
+        try:
+            info_data, sr = sf.read(audio_path)
+            audio_duration = len(info_data) / sr
+        except Exception:
+            audio_duration = 0.0
+
+        # Load model (lazy with auto-unload)
+        qwen_model = model_manager.get_model()
+
+        # Run transcription
+        transcribe_kwargs = {}
+        if language:
+            normalized = _normalize_language(language)
+            if normalized != language:
+                logger.info(f"Language normalized: {language} → {normalized}")
+            transcribe_kwargs["language"] = normalized
+
+        # Request timestamps if forced aligner is loaded or verbose output requested
+        return_timestamps = (
+            response_format == "verbose_json"
+            or "word" in timestamp_granularities
+            or "segment" in timestamp_granularities
+        )
+        if return_timestamps and FORCED_ALIGNER:
+            transcribe_kwargs["return_time_stamps"] = True
+
+        res = qwen_model.transcribe(audio=audio_path, **transcribe_kwargs)
+
+        # Parse results
+        full_text = ""
+        detected_language = None
+        segments_data = []
+        words_data = []
+
+        if res and len(res) > 0:
+            result = res[0]
+            full_text = result.text.strip() if hasattr(result, "text") else str(result).strip()
+            if hasattr(result, "language"):
+                detected_language = result.language
+
+            # Extract word-level timestamps if available
+            if hasattr(result, "tokens") and "word" in timestamp_granularities:
+                for i, token in enumerate(result.tokens):
+                    if hasattr(token, "start") and hasattr(token, "end"):
+                        words_data.append({
+                            "word": token.text if hasattr(token, "text") else str(token),
+                            "start": token.start / 1000.0,
+                            "end": token.end / 1000.0,
+                        })
+
+        elapsed = time.time() - start_time
+        logger.info(f"Transcribed {audio_duration:.1f}s audio in {elapsed:.2f}s (lang={detected_language})")
+
+        # Format response
+        if response_format == "text":
+            return JSONResponse(content=full_text, media_type="text/plain")
+
+        response = TranscriptionResponse(
+            text=full_text,
+            language=detected_language,
+            duration=audio_duration
+        )
+
+        if response_format == "verbose_json":
+            if words_data:
+                response.words = [TranscriptionWord(**w) for w in words_data]
+
+        return response
+
+    finally:
+        for path in [tmp_path, converted_path]:
+            if path:
+                try:
+                    os.unlink(path)
+                except Exception:
+                    pass
+
+
+@app.post("/admin/unload")
+async def force_unload():
+    """Force unload the model (admin endpoint)."""
+    unloaded = model_manager.force_unload()
+    return {"unloaded": unloaded, "status": model_manager.status}
+
+
+@app.on_event("startup")
+async def startup_event():
+    """Start background idle checker."""
+    asyncio.create_task(idle_checker_task(interval=60))
+    logger.info(f"Started idle checker (timeout: {IDLE_TIMEOUT}s)")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8195)

--- a/docker-configurations/services/qwen-asr-api/docker-compose.yml
+++ b/docker-configurations/services/qwen-asr-api/docker-compose.yml
@@ -1,0 +1,78 @@
+# Qwen ASR API - Multilingual ASR with Qwen3-ASR-1.7B
+# OpenAI-compatible API with auto language detection and auto-unload
+#
+# GPU: RTX 3090 (24GB) - GPU 1 (shared with other services)
+# Port: 8195
+# URL: stt.myia.io/qwen (reverse proxy path)
+
+services:
+  qwen-asr-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: qwen-asr-api
+    hostname: qwen-asr-api
+
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${GPU_DEVICE_ID:-1}']
+              capabilities: [gpu]
+
+    ports:
+      - "${QWEN_ASR_PORT:-8195}:8195"
+
+    volumes:
+      - type: bind
+        source: ${MODELS_PATH:-./models}
+        target: /app/models
+      - type: bind
+        source: ../shared
+        target: /app/shared
+        read_only: true
+      - type: volume
+        source: qwen-asr-cache
+        target: /root/.cache
+
+    environment:
+      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-1}
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-1}
+      - PYTHONUNBUFFERED=1
+      - QWEN_ASR_MODEL=${QWEN_ASR_MODEL:-Qwen/Qwen3-ASR-1.7B}
+      - QWEN_ASR_DTYPE=${QWEN_ASR_DTYPE:-bfloat16}
+      - FORCED_ALIGNER=${FORCED_ALIGNER:-Qwen/Qwen3-ForcedAligner-0.6B}
+      - QWEN_ASR_DEVICE=cuda
+      - MAX_FILE_SIZE=52428800
+      - PRELOAD_MODEL=${PRELOAD_MODEL:-false}
+      - IDLE_TIMEOUT=${IDLE_TIMEOUT:-300}
+      - TZ=${TZ:-Europe/Paris}
+      - API_KEY=${QWEN_ASR_API_KEY:-}
+      - HF_TOKEN=${HF_TOKEN:-}
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:8195/health | grep -q healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+    restart: unless-stopped
+
+    networks:
+      - qwen-asr-network
+
+    labels:
+      - "com.myia.service=qwen-asr-api"
+      - "com.myia.gpu=rtx-3090"
+      - "com.myia.model=Qwen3-ASR-1.7B"
+
+networks:
+  qwen-asr-network:
+    driver: bridge
+    name: qwen-asr-network
+
+volumes:
+  qwen-asr-cache:
+    name: qwen-asr-cache

--- a/docker-configurations/services/qwen-asr-api/start.sh
+++ b/docker-configurations/services/qwen-asr-api/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Starting Qwen ASR API..."
+echo "Model: ${QWEN_ASR_MODEL}"
+echo "Device: ${QWEN_ASR_DEVICE}"
+echo "Dtype: ${QWEN_ASR_DTYPE}"
+echo "Forced Aligner: ${FORCED_ALIGNER:-disabled}"
+echo "Idle Timeout: ${IDLE_TIMEOUT}s"
+
+# Start uvicorn
+exec uvicorn app:app --host 0.0.0.0 --port 8195 --log-level info


### PR DESCRIPTION
## Summary
- Add Qwen3-ASR-1.7B FastAPI service (port 8195) with OpenAI-compatible `/v1/audio/transcriptions` endpoint
- ISO 639-1 language code normalization (`fr`→`French`, `en`→`English`, etc.) for 30 languages
- LazyModelManager with 300s idle timeout, CUDA→CPU fallback, bfloat16 on GPU 1 (RTX 3090)
- Shared auth middleware, health endpoint with GPU info, ffmpeg audio conversion

## Test plan
- [x] `language=fr` returns 200 (was 500 before normalization)
- [x] `language=en`, `language=de` return 200 with correct language detection
- [x] Auto-detect mode (no language param) works
- [x] Container healthy, model loads on first request
- [x] `.env` excluded via `.gitignore` (contains HF_TOKEN)

## Context
- Fixes HTTP 500 reported by NanoClaw when sending `language=fr` (ISO code)
- Replaces FunASR (insufficient French quality) as primary FR ASR
- Related to ASR investigation request from NanoClaw (SOTA benchmarking still pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)