### PR TITLE
docs(docker): rationalize GenAI service documentation (#550)

### DIFF
--- a/docker-configurations/README.md
+++ b/docker-configurations/README.md
@@ -1,149 +1,128 @@
-# Docker Configurations - GenAI Ecosystem
+# Docker Configurations - GenAI Services
 
-Ce repertoire contient les configurations Docker consolidees pour l'ecosysteme GenAI Images, en parfaite coherence avec les scripts `genai-auth`.
+Configurations Docker pour les 11 services GenAI sur po-2023.
 
-## Structure Organisee
+## Vue d'ensemble
 
-```
-docker-configurations/
-├── README.md                   (ce fichier)
-├── services/                   (configurations Docker des services)
-│   ├── comfyui-qwen/          (ComfyUI + Qwen Image-Edit) [PORT 8188]
-│   │   ├── docker-compose.yml
-│   │   ├── README.md
-│   │   └── .env.example
-│   ├── forge-turbo/           (Stable Diffusion Forge) [PORT 17861]
-│   │   ├── docker-compose.yml
-│   │   ├── Dockerfile
-│   │   └── README.md
-│   └── orchestrator/          (service d'orchestration - experimental)
-├── profiles/                   (profils de deploiement GPU)
-│   └── README.md              (guide qwen-only, forge-only, dual-gpu)
-├── shared/                     (ressources partagees entre services)
-├── cache/                      (cache HuggingFace, CivitAI)
-├── models/                     (modeles partages)
-├── .secrets/                   (tokens authentification - gitignore)
-├── docs/                       (documentation infrastructure)
-├── logs/                       (logs des services)
-└── _archive-20251125/         (configurations obsoletes archivees)
-```
+| Categorie | Services | Total |
+|-----------|----------|-------|
+| Image | Qwen Image Edit, Z-Image, SD Forge Turbo, SD Forge, SD.Next | 5 |
+| Audio | Whisper STT, Kokoro TTS, MusicGen, Demucs, Qwen ASR | 5 |
+| Video | ComfyUI Video | 1 |
+
+## Services
+
+### Image
+
+| Service | Modele | VRAM | Port | Cloud URL | Docker |
+|---------|--------|------|------|-----------|--------|
+| [comfyui-qwen](services/comfyui-qwen/) | qwen_image_edit_2509 | ~16GB | 8188 | https://qwen-image-edit.myia.io | comfyui-qwen |
+| [vllm-zimage](services/vllm-zimage/) | Lumina-Next-SFT | ~9GB | 8001 | https://z-image.myia.io | vllm-zimage |
+| [forge-turbo](services/forge-turbo/) | SDXL Turbo | ~2GB | 17861 | https://turbo.stable-diffusion-webui-forge.myia.io | forge-turbo |
+| [sd-forge-main](services/sd-forge-main/) | SDXL 1.0 | ~2GB | 7860 | https://stable-diffusion-webui-forge.myia.io | sd-forge-main |
+| [sdnext](services/sdnext/) | SDXL/SD1.5 | ~3GB | 7861 | https://sdnext.myia.io | sdnext |
+
+### Audio
+
+| Service | Modele | VRAM | Port | Cloud URL | Docker |
+|---------|--------|------|------|-----------|--------|
+| [whisper-api](services/whisper-api/) | faster-whisper large-v3-turbo | ~10GB | 8190 | https://whisper-api.myia.io | whisper-api |
+| [tts-api](services/tts-api/) | kokoro-v0_19 | ~2GB | 8191 | https://tts-api.myia.io | tts-api |
+| [musicgen-api](services/musicgen-api/) | facebook/musicgen-medium | ~10GB | 8192 | https://musicgen-api.myia.io | musicgen-api |
+| [demucs-api](services/demucs-api/) | htdemucs_ft | ~4GB | 8193 | https://demucs-api.myia.io | demucs-api |
+| [qwen-asr-api](services/qwen-asr-api/) | Qwen3-ASR-1.7B | ~4GB | 8195 | https://stt.myia.io/qwen | qwen-asr-api |
+
+### Video
+
+| Service | Modele | VRAM | Port | Cloud URL | Docker |
+|---------|--------|------|------|-----------|--------|
+| [comfyui-video](services/comfyui-video/) | HunyuanVideo, Wan, AnimateDiff | ~9GB | 8189 | https://comfyui-video.myia.io | comfyui-video |
 
 ## Allocation GPU
 
-| GPU | Modele | VRAM | Service | Port |
-|-----|--------|------|---------|------|
-| 0 (PyTorch) | RTX 3090 | 24 GB | ComfyUI Qwen | 8188 |
-| 1 (PyTorch) | RTX 3080 Ti | 16 GB | Forge Turbo | 17861 |
+| GPU | Modele | VRAM | Services |
+|-----|--------|------|----------|
+| 0 (nvidia-smi) | RTX 3080 Ti | 16GB | Qwen Image Edit |
+| 1 (nvidia-smi) | RTX 3090 | 24GB | Tous les autres services |
 
-**Note**: Le mapping PyTorch est inverse par rapport a nvidia-smi.
+Note: Le mapping PyTorch peut etre inverse par rapport a nvidia-smi selon la config CUDA.
 
-## Services Principaux
+## Gestion des services
 
-### `services/comfyui-qwen/` - ComfyUI + Qwen Image-Edit
-
-Configuration principale pour ComfyUI avec le modele Qwen-Image-Edit-2509-FP8.
-
-**Demarrage** :
 ```bash
-cd docker-configurations/services/comfyui-qwen
-cp .env.example .env
-docker-compose up -d
+# Statut
+python scripts/genai-stack/genai.py docker status
+
+# Demarrer / arreter
+python scripts/genai-stack/genai.py docker start all
+python scripts/genai-stack/genai.py docker stop all
+
+# Tester les endpoints
+python scripts/genai-stack/genai.py docker test --remote
+
+# Authentification
+python scripts/genai-stack/genai.py auth audit
+python scripts/genai-stack/genai.py auth sync
 ```
 
-**Acces** : http://localhost:8188 (authentification Bearer Token)
+## Authentification
 
-Voir [services/comfyui-qwen/README.md](services/comfyui-qwen/README.md)
+Tous les services utilisent l'authentification Bearer Token via le reverse proxy IIS :
+- Header: `Authorization: Bearer <token>`
+- Tokens dans les fichiers `.env` de chaque service
 
-### `services/forge-turbo/` - Stable Diffusion Forge
+## Architecture commune (services Audio)
 
-Service Docker pour Stable Diffusion WebUI Forge optimise SDXL Turbo.
+Les 5 services audio partagent une architecture identique :
 
-**Demarrage** :
+- **Lazy loading** : modele charge a la premiere requete, decharge apres 300s d'inactivite
+- **Shared modules** : `services/shared/` monte en lecture seule (`lazy_model.py`, `auth_middleware.py`)
+- **FFmpeg** : conversion automatique des formats audio
+- **CUDA fallback** : bascule sur CPU si CUDA indisponible
+- **API OpenAI-compatible** : endpoints `/v1/audio/transcriptions`, `/v1/audio/speech`, etc.
+
+### Configuration hybride
+
+Les services audio disposent de configurations hybrides (image ghcr.io + config locale) :
+
 ```bash
-cd docker-configurations/services/forge-turbo
-cp .env.example .env
-docker-compose up -d
+# Utiliser la config hybride
+cd docker-configurations/services/whisper-api
+docker-compose -f docker-compose-hybrid.yml up -d
 ```
 
-**Acces** : http://localhost:17861 (authentification Gradio Basic)
+## Structure
 
-Voir [services/forge-turbo/README.md](services/forge-turbo/README.md)
-
-## Profils de Deploiement
-
-Voir [profiles/README.md](profiles/README.md) pour les profils disponibles:
-
-| Profil | Services | GPUs |
-|--------|----------|------|
-| `qwen-only` | ComfyUI Qwen | RTX 3090 |
-| `forge-only` | Forge Turbo | RTX 3080 Ti |
-| `dual-gpu` | ComfyUI + Forge | Les deux |
-
-## Ressources Partagees
-
-### `models/` - Modeles Partages
-
-Volume partage pour tous les modeles GenAI.
-
-### `cache/` - Cache Partage
-
-Volume partage pour le cache HuggingFace, CivitAI, etc.
-
-## Integration avec Scripts GenAI-Auth
-
-Scripts de gestion dans `../scripts/genai-auth/core/`:
-
-| Script | Description |
-|--------|-------------|
-| `setup_complete_qwen.py` | Installation complete automatisee |
-| `validate_genai_ecosystem.py` | Validation de l'ecosysteme |
-| `diagnose_comfyui_auth.py` | Diagnostic authentification |
-
-## Configurations Archivees
-
-Les configurations obsoletes sont dans `_archive-20251125/`:
-- Anciens docker-compose.yml multi-services
-- Configurations incompletes (flux-1-dev, stable-diffusion-35)
-
-Voir `_archive-20251125/README.md` pour les details.
+```
+docker-configurations/
+├── README.md
+├── services/                   Configurations Docker des services
+│   ├── shared/                 Modules partages (lazy_model.py, auth_middleware.py)
+│   ├── comfyui-qwen/           Image - Qwen Image Edit [8188]
+│   ├── vllm-zimage/            Image - Z-Image/Lumina [8001]
+│   ├── forge-turbo/            Image - SD Forge Turbo [17861]
+│   ├── sd-forge-main/          Image - SD Forge principal [7860]
+│   ├── sdnext/                 Image - SD.Next [7861]
+│   ├── whisper-api/            Audio - Whisper STT [8190]
+│   ├── tts-api/                Audio - Kokoro TTS [8191]
+│   ├── musicgen-api/           Audio - MusicGen [8192]
+│   ├── demucs-api/             Audio - Demucs [8193]
+│   ├── qwen-asr-api/           Audio - Qwen ASR [8195]
+│   └── comfyui-video/          Video - ComfyUI Video [8189]
+├── profiles/                   Profils de deploiement GPU
+├── cache/                      Cache HuggingFace, CivitAI
+├── models/                     Modeles partages
+├── .secrets/                   Tokens (gitignore)
+└── _archive-20251125/         Configurations obsoletes
+```
 
 ## Prerequis
 
-- **Docker Desktop** avec support WSL2 et NVIDIA Docker Runtime
-- **GPU**: RTX 3090 (24GB) + RTX 3080 Ti (16GB) recommandes
-- **RAM**: 32GB+ recommande
-- **Stockage**: 100GB+ pour les modeles
-
-## Securite
-
-- **Tokens**: Stockes dans `.secrets/` (gitignore)
-- **ComfyUI**: Authentification Bearer Token (hash bcrypt)
-- **Forge**: Authentification Gradio Basic
-
-## Documentation
-
-- [Architecture GenAI](../docs/genai/architecture.md)
-- [Guide Utilisateur](../docs/genai/user-guide.md)
-- [Troubleshooting](../docs/genai/troubleshooting.md)
-- [Scripts GenAI-Auth](../scripts/genai-auth/README.md)
-
-## Depannage
-
-```bash
-# Logs container
-docker-compose logs comfyui-qwen
-
-# GPU disponible
-docker exec comfyui-qwen nvidia-smi
-
-# Diagnostic auth
-python scripts/genai-auth/core/diagnose_comfyui_auth.py
-```
-
-Voir [../docs/genai/troubleshooting.md](../docs/genai/troubleshooting.md) pour plus de details.
+- Docker Desktop avec support WSL2 et NVIDIA Container Toolkit
+- GPU: RTX 3090 (24GB) + RTX 3080 Ti (16GB)
+- RAM: 32GB+
+- Stockage: 100GB+ pour les modeles
 
 ---
 
-**Derniere mise a jour**: 2025-01-19
-**Version**: 3.0.0 - Structure consolidee Phase 3
-**Statut**: Production Ready
+Derniere mise a jour: 2026-04-26

--- a/docker-configurations/services/comfyui-video/README.md
+++ b/docker-configurations/services/comfyui-video/README.md
@@ -1,0 +1,97 @@
+# ComfyUI Video - Video Generation
+
+Configuration Docker pour ComfyUI avec support video (HunyuanVideo, Wan 2.1/2.2, AnimateDiff) sur GPU RTX 3090.
+
+## Overview
+
+| Parametre | Valeur |
+|-----------|--------|
+| Modeles | HunyuanVideo, Wan 2.1/2.2, AnimateDiff |
+| Port | 8189 |
+| GPU | RTX 3090 (PyTorch GPU 0 = nvidia-smi GPU 1) |
+| VRAM | ~9GB+ (selon modele charge) |
+| URL cloud | https://comfyui-video.myia.io |
+
+## Demarrage
+
+```bash
+# Depuis docker-configurations/services/comfyui-video/
+docker-compose up -d
+
+# Suivre les logs
+docker-compose logs -f
+
+# Arreter
+docker-compose down
+```
+
+## Custom Nodes
+
+| Node | Repository | Description |
+|------|-----------|-------------|
+| ComfyUI-AnimateDiff-Evolved | Kosinkadink/ComfyUI-AnimateDiff-Evolved | Animation et generation video |
+| ComfyUI-VideoHelperSuite | Kosinkadink/ComfyUI-VideoHelperSuite | Utilitaires video (load, save, combine) |
+| ComfyUI-HunyuanVideoWrapper | kijai/ComfyUI-HunyuanVideoWrapper | Tencent HunyuanVideo |
+| ComfyUI-GGUF | city96/ComfyUI-GGUF | Support modeles GGUF quantizes |
+
+## Configuration (.env)
+
+Copier `.env.example` vers `.env` et adapter les valeurs :
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `GPU_DEVICE_ID` | `0` | GPU PyTorch (0 = RTX 3090) |
+| `COMFYUI_VIDEO_PORT` | `8189` | Port externe |
+| `COMFYUI_WORKSPACE_PATH` | `./workspace` | Chemin workspace ComfyUI |
+| `CIVITAI_TOKEN` | - | Token CivitAI pour telechargement modeles |
+| `HF_TOKEN` | - | Token Hugging Face |
+| `COMFYUI_LOGIN_ENABLED` | `true` | Activer authentification |
+| `COMFYUI_USERNAME` | - | Utilisateur |
+| `COMFYUI_PASSWORD` | - | Mot de passe |
+| `COMFYUI_VIDEO_TOKEN` | - | Bearer token API |
+| `API_TIMEOUT` | `600` | Timeout requetes API (secondes) |
+
+### Mapping GPU
+
+**IMPORTANT** : Le mapping GPU est inverse entre PyTorch et nvidia-smi :
+
+```
+nvidia-smi GPU 0 = PyTorch GPU 1 (RTX 3080 Ti - 16GB)
+nvidia-smi GPU 1 = PyTorch GPU 0 (RTX 3090 - 24GB)  <-- ComfyUI Video
+```
+
+`GPU_DEVICE_ID=0` correspond a la RTX 3090.
+
+**EXCLUSIF avec comfyui-qwen** : Les deux services partagent le meme GPU. Ne pas les lancer simultanement.
+
+## Architecture
+
+- **Base** : ComfyUI compile depuis les sources, Python 3.11, PyTorch CUDA 12.1
+- **Quantization** : Support INT8/FP8 via Optimum Quanto + bitsandbytes
+- **GGUF** : Support modeles GGUF quantizes via ComfyUI-GGUF
+- **Idle Monitor** : Sidecar qui decharge les modeles apres inactivite (`IDLE_TIMEOUT=1200s`)
+- **Auth** : ComfyUI-Login avec bcrypt
+
+## Fichiers
+
+| Fichier | Description |
+|---------|-------------|
+| `docker-compose.yml` | Service principal + sidecar idle-monitor |
+| `entrypoint.sh` | Installation auto + lancement ComfyUI |
+| `install_video_nodes.sh` | Installation manuelle des custom nodes |
+| `.env.example` | Template de configuration |
+
+## Volumes
+
+Le workspace ComfyUI est separe de comfyui-qwen pour eviter les conflits de custom nodes et de configuration :
+
+| Source hote | Cible container | Description |
+|-------------|-----------------|-------------|
+| `COMFYUI_WORKSPACE_PATH` | `/workspace/ComfyUI` | Code + venv + custom nodes |
+| `../../shared/models` | `/workspace/ComfyUI/models` | Modeles partages |
+| `../../shared/cache` | `/workspace/ComfyUI/cache` | Cache Hugging Face |
+| `../../shared/outputs` | `/workspace/ComfyUI/output` | Sorties generees |

--- a/docker-configurations/services/demucs-api/README.md
+++ b/docker-configurations/services/demucs-api/README.md
@@ -1,0 +1,136 @@
+# Demucs API - Music Source Separation
+
+API HTTP pour la separation de sources audio (extraction de stems) avec Demucs v4.
+
+| Parametre | Valeur |
+|-----------|--------|
+| Modele | htdemucs_ft (Hybrid Transformer, fine-tune) |
+| Port | 8193 |
+| GPU | GPU 1, RTX 3090 (24 Go) |
+| VRAM | ~4 Go |
+| Idle timeout | 300s (auto-unload) |
+| URL cloud | https://demucs-api.myia.io |
+
+## Demarrage
+
+```bash
+# Image pre-construite (production, GPU 1)
+docker compose -f docker-compose.yml up -d
+
+# Build local (developpement, GPU 0)
+docker compose -f docker-compose-hybrid.yml up -d --build
+
+# Logs
+docker compose logs -f demucs-api
+```
+
+## Endpoints API
+
+### Health check
+
+```bash
+curl https://demucs-api.myia.io/health
+```
+
+```json
+{
+  "status": "healthy",
+  "model": "htdemucs_ft",
+  "device": "cuda",
+  "cuda_available": true,
+  "model_loaded": false,
+  "idle_timeout": 300
+}
+```
+
+### Separation de sources
+
+```bash
+# Separation complete (ZIP avec 4 stems)
+curl -X POST https://demucs-api.myia.io/v1/separate \
+  -H "Authorization: Bearer $DEMUCS_API_KEY" \
+  -F "file=@song.mp3" \
+  -F "model=htdemucs_ft" \
+  -o stems.zip
+
+# Extraction vocales uniquement
+curl -X POST https://demucs-api.myia.io/v1/separate/vocals \
+  -H "Authorization: Bearer $DEMUCS_API_KEY" \
+  -F "file=@song.mp3" \
+  -o vocals.wav
+
+# Extraction instrumentale
+curl -X POST https://demucs-api.myia.io/v1/separate/instrumental \
+  -H "Authorization: Bearer $DEMUCS_API_KEY" \
+  -F "file=@song.mp3" \
+  -o instrumental.zip
+```
+
+### Modeles disponibles
+
+```bash
+curl https://demucs-api.myia.io/v1/models
+```
+
+### Dechargement manuel (admin)
+
+```bash
+curl -X POST https://demucs-api.myia.io/admin/unload \
+  -H "Authorization: Bearer $DEMUCS_API_KEY"
+```
+
+## Parametres supportes
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `file` | fichier | (requis) | Fichier audio a separer (mp3, wav, flac, ogg) |
+| `model` | string | htdemucs_ft | Modele Demucs a utiliser |
+| `output_format` | string | wav | Format de sortie (wav, mp3, flac) |
+| `stems` | string | (tous) | Stems a extraire, separes par virgule |
+| `return_zip` | bool | true | Retourner un ZIP (true) ou un fichier unique (false) |
+
+## Variantes de modeles
+
+| Modele | Qualite | VRAM | Description |
+|--------|---------|------|-------------|
+| `htdemucs_ft` | Excellente | ~4 Go | Hybrid Transformer fine-tune (defaut, recommande) |
+| `htdemucs` | Meilleure | ~4 Go | Hybrid Transformer standard |
+| `mdx` | Bonne | ~2 Go | MDX Network, plus rapide |
+| `mdx_extra` | Bonne | ~3 Go | MDX avec poids supplementaires |
+
+## Sortie
+
+La separation retourne un fichier ZIP contenant les stems extraits :
+
+- `vocals.wav` -- Voix et chant
+- `drums.wav` -- Percussions et batterie
+- `bass.wav` -- Instruments basses
+- `other.wav` -- Autres instruments
+
+## Configuration (.env)
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `DEMUCS_MODEL` | htdemucs_ft | Modele par defaut |
+| `DEMUCS_DEVICE` | cuda | Peripherique (cuda / cpu) |
+| `IDLE_TIMEOUT` | 300 | Secondes avant auto-unload du modele |
+| `DEMUCS_SEGMENTS` | (auto) | Segments pour le traitement long |
+| `DEMUCS_API_KEY` | (requis) | Cle API bearer token |
+
+## Architecture
+
+- **Chargement paresseux** : le modele est charge en GPU uniquement a la premiere requete, puis decharge automatiquement apres `IDLE_TIMEOUT` secondes d'inactivite (module `../shared/lazy_model.py`)
+- **Modules partages** : `../shared/` fournit `lazy_model.py` (gestion du cycle de vie GPU) et `auth_middleware.py` (authentification Bearer token)
+- **Fallback CUDA** : detection automatique CUDA, fallback CPU si GPU indisponible
+- **Conversion audio** : FFmpeg pour la gestion des formats d'entree ; torchaudio pour le resampling automatique vers la frequence du modele (44100 Hz)
+
+## Fichiers
+
+| Fichier | Description |
+|---------|-------------|
+| `app.py` | Application FastAPI principale |
+| `Dockerfile` | Image Docker (Python 3.11, Demucs v4) |
+| `docker-compose.yml` | Configuration production (image ghcr.io, GPU 1) |
+| `docker-compose-hybrid.yml` | Configuration developpement (build local, GPU 0) |
+| `start.sh` | Script de demarrage uvicorn |
+| `.env` | Variables d'environnement locales |

--- a/docker-configurations/services/musicgen-api/README.md
+++ b/docker-configurations/services/musicgen-api/README.md
@@ -1,0 +1,133 @@
+# MusicGen API - Generation de musique par texte
+
+Service HTTP pour la generation de musique a partir de descriptions textuelles, base sur Meta MusicGen (transformers).
+
+| Parametre | Valeur |
+|-----------|--------|
+| Modele | `facebook/musicgen-medium` (1.5B params) |
+| Port | 8192 |
+| GPU | GPU 1, RTX 3090 (24 GB) |
+| VRAM | ~10 GB (medium) |
+| Idle timeout | 300 s (default), 1200 s (docker-compose) |
+| URL cloud | `https://musicgen-api.myia.io` |
+| Taux echantillonnage | 32000 Hz |
+
+## Demarrage
+
+```bash
+# Build et demarrage (local)
+docker compose up -d --build
+
+# Demarrage avec image pre-construite (hybride)
+docker compose -f docker-compose-hybrid.yml up -d
+
+# Arret
+docker compose down
+
+# Logs
+docker compose logs -f musicgen-api
+```
+
+## Endpoints API
+
+### Health check
+
+```bash
+curl http://localhost:8192/health
+```
+
+Retourne l'etat du service, la disponibilite CUDA, la memoire GPU et le statut du modele (charge/non charge).
+
+### Generer de la musique
+
+```bash
+curl -X POST http://localhost:8192/v1/generate \
+  -H "Authorization: Bearer $MUSICGEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "80s synthwave with heavy bass and arpeggiated synths",
+    "duration": 10,
+    "temperature": 1.0,
+    "top_k": 250,
+    "top_p": 0.0,
+    "cfg_coef": 3.0,
+    "seed": 42,
+    "format": "wav"
+  }' \
+  --output generated.wav
+```
+
+Retourne un fichier audio (`audio/wav` ou `audio/mpeg`). Headers de reponse : `X-Duration`, `X-Generation-Time`, `X-Sample-Rate`.
+
+### Modeles disponibles
+
+```bash
+curl http://localhost:8192/v1/models
+```
+
+### Dechargement manuel (admin)
+
+```bash
+curl -X POST http://localhost:8192/admin/unload \
+  -H "Authorization: Bearer $MUSICGEN_API_KEY"
+```
+
+Libere la memoire GPU en dechargeant le modele. Le modele sera recharge automatiquement a la prochaine requete.
+
+## Parametres de generation
+
+| Parametre | Type | Default | Plage | Description |
+|-----------|------|---------|-------|-------------|
+| `prompt` | string | (requis) | - | Description textuelle de la musique |
+| `duration` | int | 10 | 1-30 | Duree en secondes |
+| `temperature` | float | 1.0 | 0.5-1.5 | Temperature d'echantillonnage |
+| `top_k` | int | 250 | 0-1000 | Echantillonnage top-k |
+| `top_p` | float | 0.0 | 0.0-1.0 | Echantillonnage top-p (0 = desactive) |
+| `cfg_coef` | float | 3.0 | 1.0-10.0 | Coefficient de guidance classifier-free |
+| `seed` | int | null | - | Graine aleatoire pour reproductibilite |
+| `format` | string | "wav" | wav, mp3 | Format de sortie audio |
+| `model` | string | - | - | Surcharge du modele (non implemente) |
+
+## Variantes de modele
+
+| Modele | Params | VRAM | Commentaire |
+|--------|--------|------|-------------|
+| `facebook/musicgen-small` | 300M | ~4 GB | Rapide, qualite correcte |
+| `facebook/musicgen-medium` | 1.5B | ~10 GB | Bon compromis qualite/perf |
+| `facebook/musicgen-large` | 3.3B | ~20 GB | Meilleure qualite, lent |
+| `facebook/musicgen-melody` | 1.5B | ~10 GB | Conditionnement melody |
+
+Le modele se configure via `MUSICGEN_MODEL` dans `.env`.
+
+## Configuration (.env)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MUSICGEN_MODEL` | `facebook/musicgen-medium` | Modele HuggingFace a charger |
+| `MUSICGEN_DEVICE` | `cuda` | Peripherique (cuda / cpu) |
+| `MAX_DURATION` | `30` | Duree maximale en secondes |
+| `DEFAULT_DURATION` | `10` | Duree par defaut si non specifiee |
+| `PRELOAD_MODEL` | `false` | Charger le modele au demarrage |
+| `IDLE_TIMEOUT` | `300` / `1200` | Secondes d'inactivite avant decharge |
+| `MUSICGEN_API_KEY` | - | Cle Bearer token pour l'authentification |
+| `GPU_DEVICE_ID` | `1` | ID du GPU NVIDIA a utiliser |
+| `MODELS_PATH` | `./models` | Chemin des modeles en cache |
+| `OUTPUT_PATH` | `./outputs` | Chemin des fichiers de sortie |
+
+## Architecture
+
+- **Chargement paresseux** : le modele n'est charge en GPU qu'a la premiere requete. Apres `IDLE_TIMEOUT` secondes sans requete, le modele est decharge automatiquement pour liberer la VRAM. Module partage : `shared/lazy_model.py`.
+- **Modules partages** : `../shared/` est monte en lecture seule et fournit `LazyModelManager`, `idle_checker_task`, et `setup_auth` (authentification Bearer token).
+- **Fallback CUDA** : si CUDA n'est pas disponible, le service fonctionne sur CPU (tres lent). Verifier `/health` pour le statut GPU.
+- **Traitement asynchrone** : endpoint `/v1/generate/async` avec suivi via `/v1/jobs/{job_id}` pour les generations longues.
+
+## Fichiers
+
+| Fichier | Description |
+|---------|-------------|
+| `app.py` | Application FastAPI principale |
+| `Dockerfile` | Image Python 3.11-slim + torch + transformers |
+| `docker-compose.yml` | Configuration Docker (build local) |
+| `docker-compose-hybrid.yml` | Configuration Docker (image pre-construite ghcr.io) |
+| `.env` | Variables d'environnement du service |
+| `start.sh` | Script de demarrage uvicorn |

--- a/docker-configurations/services/sd-forge-main/README.md
+++ b/docker-configurations/services/sd-forge-main/README.md
@@ -1,0 +1,119 @@
+# SD Forge Main - Stable Diffusion WebUI Forge
+
+Service Docker pour Stable Diffusion WebUI Forge avec support SDXL 1.0 complet.
+
+## Vue d'ensemble
+
+| Parametre | Valeur |
+|-----------|--------|
+| Modele | SDXL 1.0 |
+| Port | 7860 |
+| GPU | GPU 1 (RTX 3090, 24 GB) |
+| VRAM | ~2 GB |
+| URL cloud | https://stable-diffusion-webui-forge.myia.io |
+| Image base | ghcr.io/ai-dock/stable-diffusion-webui-forge:latest-cuda |
+
+## Demarrage
+
+```powershell
+# Depuis la racine du projet
+docker compose -f docker-configurations/services/sd-forge-main/docker-compose.yml up -d
+
+# Arret
+docker compose -f docker-configurations/services/sd-forge-main/docker-compose.yml down
+
+# Logs
+docker logs sd-forge-main --tail 100 -f
+```
+
+## Configuration
+
+### Variables d'environnement (.env
+
+| Variable | Description | Defaut |
+|----------|-------------|--------|
+| `SD_FORGE_MAIN_API_KEY` | Cle API pour l'authentification | A definir |
+| `FORGE_USER` (via `WEB_USER`) | Utilisateur Gradio | `admin` |
+| `FORGE_PASSWORD` (via `WEB_PASSWORD`) | Mot de passe Gradio | `changeme` |
+
+### Arguments CLI
+
+Les arguments sont passes via `FORGE_ARGS` dans docker-compose.yml :
+
+| Argument | Description |
+|----------|-------------|
+| `--api` | Active l'API REST |
+| `--api-log` | Log des appels API |
+| `--listen` | Ecoute sur 0.0.0.0 |
+| `--gradio-auth` | Authentification Gradio |
+| `--gpu-device-id 1` | Utilise la RTX 3090 (GPU 1) |
+| `--xformers` | Optimisation attention (acceleration) |
+| `--skip-install` | Saute l'installation au demarrage |
+
+## Fonctionnalites
+
+- **Gradio WebUI** : Interface web complete pour la generation d'images
+- **Xformers** : Optimisation de la memoire et acceleration des calculs d'attention
+- **SDXL 1.0** : Support complet du modele SDXL (1024x1024 natif)
+- **API REST** : Endpoints `/sdapi/v1/` pour integration programmatique
+- **Stockage partage** : Modeles et outputs partages avec les autres services SD
+
+## Architecture
+
+```
+Image Docker (Dockerfile custom)
+  |
+  +-- Base: ghcr.io/ai-dock/stable-diffusion-webui-forge:latest-cuda
+  +-- Fix: compatibilite numpy < 2 + opencv-python-headless
+  |
+  +-- Gradio WebUI (port 7860)
+  |     |
+  |     +-- txt2img / img2img
+  |     +-- API REST (/sdapi/v1/)
+  |     +-- Gestion des modeles
+  |
+  +-- Volumes partages
+        |
+        +-- ../../shared/models  -> /opt/storage/stable_diffusion/models
+        +-- ../../shared/outputs -> /opt/storage/stable_diffusion/outputs
+```
+
+## Fichiers
+
+```
+sd-forge-main/
+  docker-compose.yml   # Configuration Docker Compose
+  Dockerfile           # Image custom avec fix numpy/opencv
+  .env.example         # Template des variables d'environnement
+```
+
+Note : pas de `.gitignore` dedie. Le fichier `.env` est exclu via le `.gitignore` global.
+
+## Volumes
+
+| Volume Host | Volume Container | Description |
+|-------------|------------------|-------------|
+| `../../shared/models` | `/opt/storage/stable_diffusion/models` | Modeles partages (SDXL, LoRA, VAE) |
+| `../../shared/outputs` | `/opt/storage/stable_diffusion/outputs` | Images generees |
+
+## Acces
+
+- **WebUI** : http://localhost:7860
+- **Cloud** : https://stable-diffusion-webui-forge.myia.io
+- **API** : http://localhost:7860/sdapi/v1/
+- **Auth** : admin / changeme (modifier dans `.env`)
+
+## Dockerfile Custom
+
+Le Dockerfile corrige une incompatibilite binaire entre numpy 2.x et les bibliotheques pre-compilees :
+
+```dockerfile
+# Fix numpy binary incompatibility
+RUN pip uninstall -y numpy opencv-python opencv-python-headless scikit-image Pillow && \
+    pip install "numpy<2" opencv-python-headless scikit-image Pillow
+```
+
+---
+
+**Derniere mise a jour** : 2026-04-26
+**Image** : sd-forge-main:latest

--- a/docker-configurations/services/sdnext/README.md
+++ b/docker-configurations/services/sdnext/README.md
@@ -1,0 +1,81 @@
+# SD.Next - Stable Diffusion WebUI
+
+## Vue d'ensemble
+
+| Propriete | Valeur |
+|-----------|--------|
+| Modele | SDXL / SD1.5 |
+| Port | 7861 |
+| GPU | GPU 1 (RTX 3090) |
+| VRAM | ~3 GB |
+| URL cloud | https://sdnext.myia.io |
+
+## Demarrage
+
+```bash
+# Construire et lancer
+docker-compose up -d --build
+
+# Arreter
+docker-compose down
+
+# Voir les logs
+docker-compose logs -f sdnext
+```
+
+## Configuration (.env)
+
+| Variable | Description | Defaut |
+|----------|-------------|--------|
+| `SDNEXT_API_KEY` | Cle API pour l'acces programmatique | - |
+| `WEB_USER` | Utilisateur Gradio (via `FORGE_USER`) | `admin` |
+| `WEB_PASSWORD` | Mot de passe Gradio (via `FORGE_PASSWORD`) | `changeme` |
+
+Parametres fixes dans `FORGE_ARGS` :
+
+- `--gpu-device-id 1` : utilise le GPU 1 (RTX 3090)
+- `--xformers` : acceleration memoire optimisee
+- `--api --api-log` : API REST activee avec logs
+- `--listen` : acces reseau (0.0.0.0)
+- `--gradio-auth` : authentification activee
+- `--skip-install` : pas de reinstallation au demarrage
+
+## Fonctionnalites
+
+- Interface web Gradio avec authentification
+- Optimisation xformers pour generation rapide
+- Support multi-modeles (SDXL et SD1.5)
+- Stockage partage des modeles et sorties entre services
+- Base image ai-dock/stable-diffusion-webui-forge avec corrections numpy/opencv
+
+## Architecture
+
+```
+Dockerfile (ai-dock/sd-webui-forge + numpy fix)
+    |
+docker-compose.yml
+    |- Port 7861:7860 (externe:interne)
+    |- GPU 1 (RTX 3090)
+    |- Volumes partages
+        |- ../../shared/models -> /opt/storage/stable_diffusion/models
+        |- ../../shared/outputs -> /opt/storage/stable_diffusion/outputs
+```
+
+## Fichiers
+
+| Fichier | Description |
+|---------|-------------|
+| `docker-compose.yml` | Configuration du service Docker |
+| `Dockerfile` | Image personnalisee avec corrections de dependances |
+| `.env.example` | Template des variables d'environnement |
+
+## Volumes
+
+Les modeles et sorties sont partages avec les autres services SD via les volumes communs :
+
+- `../../shared/models` : checkpoints, LoRA, VAE
+- `../../shared/outputs` : images generees
+
+## Notes
+
+Le port externe 7861 est utilise au lieu de 7860 (port interne par defaut de Gradio) pour eviter un conflit avec le service `sd-forge-main` qui tourne sur le port 7860 sur la meme machine.

--- a/docker-configurations/services/tts-api/README.md
+++ b/docker-configurations/services/tts-api/README.md
@@ -1,0 +1,132 @@
+# TTS API - Text-to-Speech (Kokoro)
+
+API OpenAI-compatible pour la synthese vocale, basee sur le modele Kokoro v0.19.
+
+| Champ | Valeur |
+|-------|--------|
+| Modele | kokoro-v0_19 |
+| Port | 8191 |
+| GPU | GPU 1, RTX 3090 (24 GB) |
+| VRAM | ~2 GB |
+| API | OpenAI `/v1/audio/speech` compatible |
+| Idle timeout | 300 s (default), 1200 s (prod) |
+| URL cloud | `https://tts-api.myia.io` |
+
+## Demarrage
+
+```bash
+# Build et lancement
+docker compose up -d --build
+
+# Image pre-build (hybride)
+docker compose -f docker-compose-hybrid.yml up -d
+
+# Logs
+docker compose logs -f tts-api
+```
+
+## Endpoints API
+
+### Health check
+
+```bash
+curl http://localhost:8191/health
+```
+
+### Synthese vocale
+
+```bash
+curl -X POST http://localhost:8191/v1/audio/speech \
+  -H "Authorization: Bearer $TTS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Bonjour, bienvenue sur le service de synthese vocale.",
+    "voice": "alloy",
+    "response_format": "mp3",
+    "speed": 1.0
+  }' --output speech.mp3
+```
+
+### Liste des voix
+
+```bash
+curl http://localhost:8191/v1/voices
+```
+
+### Liste des modeles
+
+```bash
+curl http://localhost:8191/v1/models
+```
+
+### Dechargement du modele (admin)
+
+```bash
+curl -X POST http://localhost:8191/admin/unload
+```
+
+## Parametres supportes
+
+| Parametre | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input` | string | (requis) | Texte a synthetiser (max 4096 caracteres) |
+| `voice` | string | `alloy` | Voix a utiliser (voir section Voix) |
+| `response_format` | string | `mp3` | Format de sortie (voir section Formats) |
+| `speed` | float | `1.0` | Vitesse de lecture (0.25 a 4.0) |
+| `model` | string | `tts-1` | Modele : `tts-1`, `tts-1-hd`, ou `kokoro` |
+
+## Voix
+
+Noms OpenAI-compatibles mappes aux voix Kokoro internes :
+
+| Nom API | Voix Kokoro | Genre |
+|---------|-------------|-------|
+| `alloy` | af_sky | F |
+| `echo` | am_adam | M |
+| `fable` | af_bella | F |
+| `onyx` | am_michael | M |
+| `nova` | af_nova | F |
+| `shimmer` | af_sarah | F |
+
+Les voix Kokoro natives (`af_sky`, `af_bella`, `am_adam`, `am_michael`) sont aussi acceptees directement.
+
+## Formats de sortie
+
+| Format | Media type | Remarque |
+|--------|-----------|----------|
+| `mp3` | audio/mpeg | Encodage via ffmpeg (128 kbps) |
+| `wav` | audio/wav | Direct |
+| `flac` | audio/flac | Sans perte |
+| `pcm` | audio/pcm | Float32 brut |
+| `opus` | audio/wav | Fallback WAV (opus non encode) |
+| `aac` | audio/wav | Fallback WAV |
+
+## Configuration (.env)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TTS_DEVICE` | `cuda` | Peripherique (`cuda` ou `cpu`) |
+| `DEFAULT_TTS_MODEL` | `kokoro` | Modele par defaut |
+| `DEFAULT_TTS_VOICE` | `af_sky` | Voix par defaut |
+| `SAMPLE_RATE` | `24000` | Taux d'echantillonnage (Hz) |
+| `PRELOAD_MODEL` | `true` | Charger le modele au demarrage |
+| `IDLE_TIMEOUT` | `300` | Dechargement apres inactivite (secondes) |
+| `TTS_API_KEY` | (vide) | Cle Bearer token pour l'authentification |
+
+## Architecture
+
+- **Chargement paresseux** : le modele est charge au premier appel et decharge automatiquement apres la periode d'inactivite (`IDLE_TIMEOUT`). Un checker en arriere-plan tourne toutes les 60 s.
+- **Modules partages** : utilise `../shared/` pour `lazy_model.py` (gestion du cycle de vie) et `auth_middleware.py` (authentification Bearer).
+- **Fallback CUDA** : si CUDA n'est pas disponible, le modele bascule sur CPU (`TTS_DEVICE=cpu`).
+
+## Fichiers
+
+| Fichier | Role |
+|---------|------|
+| `app.py` | Application FastAPI principale |
+| `Dockerfile` | Image Python 3.11 avec Kokoro, ffmpeg, espeak-ng |
+| `docker-compose.yml` | Configuration build local |
+| `docker-compose-hybrid.yml` | Configuration image pre-build (ghcr.io) |
+| `.gitignore` | Exclusions git |
+| `start.sh` | Script de demarrage du conteneur |
+| `.env` | Variables d'environnement (non commite) |

--- a/docker-configurations/services/whisper-api/README.md
+++ b/docker-configurations/services/whisper-api/README.md
@@ -1,0 +1,116 @@
+# Whisper API - Speech-to-Text
+
+Service de transcription audio utilisant faster-whisper avec une API compatible OpenAI.
+
+| Parametre | Valeur |
+|-----------|--------|
+| Modele | faster-whisper large-v3-turbo |
+| Port | 8190 |
+| GPU | GPU 1, RTX 3090 |
+| VRAM | ~10 GB |
+| API | OpenAI `/v1/audio/transcriptions` compatible |
+| Timeout inactivite | 300 s |
+| URL cloud | `https://whisper-api.myia.io` |
+
+## Demarrage
+
+```bash
+# Construction et lancement
+docker-compose up -d --build
+
+# Configuration hybride (image pre-construite, GPU 1)
+docker-compose -f docker-compose-hybrid.yml up -d
+
+# Verifier le statut
+docker-compose ps
+docker-compose logs -f whisper-api
+```
+
+## Endpoints API
+
+### Health check
+
+```bash
+curl http://localhost:8190/health
+```
+
+### Transcription
+
+```bash
+curl -X POST http://localhost:8190/v1/audio/transcriptions \
+  -H "Authorization: Bearer $WHISPER_API_KEY" \
+  -F file="@audio.mp3" \
+  -F model="whisper-1" \
+  -F response_format="json" \
+  -F timestamp_granularities[]="segment" \
+  -F language="fr"
+```
+
+Parametres supportes :
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `file` | file | (requis) | Fichier audio (mp3, mp4, mpeg, mpga, m4a, wav, webm) |
+| `model` | string | `whisper-1` | Identifiant du modele (compatibilite OpenAI) |
+| `language` | string | auto | Code langue ISO 639-1 (fr, en, de, es...) |
+| `response_format` | string | `json` | Format de reponse (json, text, srt, verbose_json, vtt) |
+| `timestamp_granularities` | list | `["segment"]` | Granularite des timestamps (`segment` ou `word`) |
+| `temperature` | float | `0.0` | Temperature d'echantillonnage (0.0 - 1.0) |
+
+Formats de reponse :
+
+| Format | Description |
+|--------|-------------|
+| `json` | Texte de la transcription |
+| `text` | Texte brut (plain text) |
+| `srt` | Sous-titres SRT avec timestamps |
+| `verbose_json` | JSON detaille avec segments et metadonnees |
+| `vtt` | Sous-titres WebVTT |
+
+### Liste des modeles
+
+```bash
+curl http://localhost:8190/v1/models
+```
+
+### Dechargement du modele (admin)
+
+```bash
+curl -X POST http://localhost:8190/admin/unload \
+  -H "Authorization: Bearer $WHISPER_API_KEY"
+```
+
+Libere la memoire GPU. Le modele sera recharge a la prochaine requete.
+
+## Configuration
+
+Variables d'environnement (fichier `.env`) :
+
+| Variable | Defaut | Description |
+|----------|--------|-------------|
+| `WHISPER_MODEL` | `large-v3-turbo` | Taille du modele faster-whisper |
+| `WHISPER_DEVICE` | `cuda` | Peripherique de calcul (cuda ou cpu) |
+| `WHISPER_COMPUTE_TYPE` | `float16` | Type de calcul (float16, int8) |
+| `MAX_FILE_SIZE` | `26214400` | Taille max des fichiers (25 MB) |
+| `PRELOAD_MODEL` | `true` | Charger le modele au demarrage |
+| `IDLE_TIMEOUT` | `300` | Timeout de dechargement automatique (secondes) |
+| `WHISPER_API_KEY` | (vide) | Cle API Bearer token |
+
+## Architecture
+
+- **Chargement paresseux** : Le modele est charge en memoire GPU lors de la premiere requete et decharge apres `IDLE_TIMEOUT` secondes d'inactivite via le module `LazyModelManager` (voir `../shared/lazy_model.py`).
+- **Modules partages** : Utilise `../shared/` pour `lazy_model.py` (gestion du cycle de vie modele) et `auth_middleware.py` (authentification Bearer token).
+- **Conversion FFmpeg** : Les fichiers audio sont convertis via faster-whisper qui utilise FFmpeg en interne. Les formats supportes sont mp3, mp4, mpeg, mpga, m4a, wav et webm.
+- **Fallback CUDA** : Si CUDA n'est pas disponible (ctranslate2 non detecte ou erreur cublas), le service bascule automatiquement sur CPU avec le type de calcul `int8`.
+
+## Fichiers
+
+| Fichier | Description |
+|---------|-------------|
+| `app.py` | Application FastAPI principale |
+| `Dockerfile` | Image Docker basee sur nvidia/cuda:12.1.0 |
+| `docker-compose.yml` | Configuration standard (GPU 0, build local) |
+| `docker-compose-hybrid.yml` | Configuration hybride (GPU 1, image ghcr.io pre-construite) |
+| `start.sh` | Script de demarrage uvicorn |
+| `.env` | Variables d'environnement (non commite) |
+| `models/` | Cache des modeles faster-whisper |


### PR DESCRIPTION
## Summary
- Rewrite `docker-configurations/README.md` from outdated 2-service version (Jan 2025) to comprehensive 11-service documentation (Apr 2026)
- Add per-service READMEs for 7 services that lacked documentation: whisper-api, tts-api, musicgen-api, demucs-api, sd-forge-main, sdnext, comfyui-video

## What changed
- `docker-configurations/README.md`: Complete rewrite with proper tables for all 11 services (model, VRAM, port, cloud URL), GPU allocation, auth section, shared audio architecture
- 7 new `README.md` files in service directories, each covering: model specs, API endpoints with curl examples, configuration variables, architecture details

## Coverage
All 11 GenAI services now have individual README documentation:
- **Previously documented**: comfyui-qwen, vllm-zimage, forge-turbo, qwen-asr-api (4)
- **Now documented**: whisper-api, tts-api, musicgen-api, demucs-api, sd-forge-main, sdnext, comfyui-video (7)

Closes #550

## Test plan
- [x] Verify all README.md files exist and are well-formed markdown
- [x] Verify technical accuracy against docker-compose.yml and app.py files
- [ ] Visual review of tables and formatting

Generated with [Claude Code](https://claude.com/claude-code)