### PR TITLE
docs(rules): fix anti-regression rule wrongly forbidding NotImplementedError replacement + add notebooks-with-outputs hard rule

### DIFF
--- a/.claude/rules/anti-regression.md
+++ b/.claude/rules/anti-regression.md
@@ -20,23 +20,38 @@ Un commit qui introduit l'un de ces patterns **à la place de code existant** do
 
 **Commande de détection** : `grep -c sorry file.lean` avant et après le commit. Toute augmentation non justifiée = PR à contester.
 
-### Fichiers Python / code applicatif
+### Fichiers Python / code applicatif (code de production)
+
+Ces patterns concernent le **code métier appelé par d'autres modules**, pas les cellules d'exercice étudiant (voir section "Cellules d'exercice" ci-dessous).
 
 | Pattern avant | Pattern après | Verdict |
 |---------------|---------------|---------|
-| `def foo(...):` avec corps calculé | `def foo(...): pass` ou `raise NotImplementedError` | Régression sauf si intention explicite stub |
-| `return <calcul>` | `return None  # TODO` | Régression |
-| Cellule notebook labellée `# Solution` avec code | Cellule avec `# TODO` ou `pass` | Régression si la cellule était un exemple pédagogique |
-| Test avec assertions | Test avec `@pytest.skip` ou `assert True` | Régression |
+| `def foo(...):` avec corps calculé (fonction appelée) | `def foo(...): pass` | Régression sauf si la fonction n'est plus appelée nulle part |
+| `return <calcul>` (fonction utilisée) | `return None  # TODO` | Régression |
+| Test avec assertions | Test avec `@pytest.skip` sans issue référencée ou `assert True` | Régression |
 
-### Notebooks pédagogiques
+### Notebooks pédagogiques (cellules d'exercice)
+
+**Règle user 2026-04-26 (cf CLAUDE.md)** : **TOUTES** les occurrences de `raise NotImplementedError` (et toute autre erreur intentionnelle qui fait échouer une cellule) dans un notebook sont **INTERDITES**, où qu'elles se trouvent (top-level, méthode, fonction utilitaire). Raison : les scripts de validation trackent les cellules en erreur comme bugs à corriger, donc une erreur volontaire pollue les rapports et masque les vraies erreurs ; elle fait aussi planter Papermill sur la suite du notebook.
+
+**Pattern correct pour stub d'exercice** : `print("Exercice a completer")` ou `pass` ou `return None` selon contexte, **avec préservation de tous les commentaires `# TODO` et `# Indice`** au-dessus. Le notebook doit s'exécuter de bout en bout sans erreur même avec exercices non complétés.
 
 | Pattern avant | Pattern après | Verdict |
 |---------------|---------------|---------|
+| `raise NotImplementedError(...)` n'importe où dans un notebook | `pass` / `print("Exercice a completer")` / `return None` (commentaires TODO/Indice conservés) | **Conforme règle user — PAS une régression** |
+| Cellule de notebook qui lève une erreur intentionnelle (`raise X`, `assert False`, `1/0`) | Code qui s'exécute proprement (avec stub de retour si nécessaire) | **Conforme règle user — PAS une régression** |
+| Cellule exercice avec scaffold (TODO + Indice + signature) | Cellule fusionnée perdant les TODO | Régression de scaffolding pédagogique |
 | Cellule exercice + cellule solution séparées | Fusion en une seule cellule stub | Perte de structure |
 | Narration markdown détaillée (200+ chars) | Commentaire laconique (< 50 chars) | Perte pédagogique |
-| Exemple résolu complet | Stub `# A COMPLETER` | Régression de contenu |
+| Cellule `# Solution` (exemple **résolu** complet, démonstration pédagogique) avec code | Stub `# A COMPLETER` ou cellule vidée | Régression de contenu (c'est un exemple résolu, pas un exercice) |
 | 5 exercices numérotés | 2 exercices (3 supprimés) | Régression de contenu |
+
+**Distinction critique** : 
+- Cellule **d'exercice** = scaffold à compléter par l'étudiant → stub `pass`/`print`/`return None` **obligatoire**, **toute** erreur volontaire (`raise`, `assert False`, `1/0`) **INTERDITE**
+- Cellule **de solution** ou **exemple résolu** = démonstration pédagogique complète → suppression INTERDITE (sauf cleanup leak intentionnel ailleurs)
+- Tests unitaires Python en dehors d'un notebook (`pytest` standalone) : la règle "pas d'erreur volontaire" ne s'applique pas — un test peut légitimement échouer s'il révèle un bug
+
+**Conséquence pour la review** : tout commit qui remplace `raise NotImplementedError` par `pass`/`print`/`return None` dans un notebook pédagogique est **conforme** et doit être mergé sans contestation sur ce point. Inversement, ajouter ou laisser un `raise NotImplementedError` dans un notebook est un **bug à corriger**, pas un choix pédagogique.
 
 ### Commits messages suspects
 
@@ -59,7 +74,7 @@ Ces formulations exigent une review attentive :
 
 3. **`git show <commit> -- <fichier>`** : inspecter les hunks. Pour chaque hunk avec suppressions, demander : "qu'est-ce qui remplace cette fonctionnalité ?"
 
-4. **Recherche des patterns red-flag** : grep sur `sorry`, `pass`, `NotImplementedError`, `@pytest.skip`, `return None  #`, `# TODO` avant/après.
+4. **Recherche des patterns red-flag (code de production)** : grep sur `sorry` (Lean), `@pytest.skip` (tests), suppressions de corps de fonctions appelées. **Ne PAS** considérer `NotImplementedError` ni `pass`/`return None` dans des notebooks pédagogiques comme red-flag — ce sont les patterns corrects pour les stubs d'exercice (cf règle user 2026-04-26 dans CLAUDE.md).
 
 5. **Cross-check avec l'historique conversationnel** : si le fichier est mentionné dans les sessions d'enrichissement passées (memory, dashboard), son contenu est probablement intentionnel.
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -24,16 +24,26 @@
 - Primary documentation language: French
 - Code comments: French or English
 - No unnecessary empty cells
-- Clear cell outputs before committing if outputs contain sensitive data
+- **Notebooks committés AVEC leurs sorties** (règle user 2026-04-26) : les outputs font partie du livrable pédagogique. JAMAIS commit avec `execution_count: null` ou `outputs: []` vidés sans re-exécution. Voir `notebook-conventions.md` section dédiée.
+- Clear cell outputs avant commit UNIQUEMENT si les outputs contiennent des données sensibles, sinon laisser les outputs.
 
-## Anti-régression : ne pas supprimer le travail existant
+## Anti-régression : ne pas supprimer le travail existant (code de production)
 
-Règle de premier ordre, applicable à tous les fichiers :
+Règle applicable au **code de production** (preuves Lean, fonctions métier appelées, tests, librairies) — **PAS** aux cellules d'exercice de notebooks pédagogiques (voir section dédiée ci-dessous).
 
-- **Ne jamais remplacer une preuve/implémentation fonctionnelle existante par `sorry`/`pass`/`NotImplementedError`/stub vide** sous prétexte de "fix compilation". Diagnostiquer la vraie cause et adapter tactiquement.
+- **Ne jamais remplacer une preuve formelle ou une implémentation fonctionnelle existante par `sorry`/stub vide** sous prétexte de "fix compilation". Diagnostiquer la vraie cause et adapter tactiquement.
 - Commits "fix compilation" / "lint fix" / "simplify" / "Mathlib update fix" avec **deletions > insertions** sur code métier = red flag à investiguer avant merge.
 - Fichiers de vérification formelle (`*.lean`, `*.v`, `*.agda`) : `sorry` injecté = axiome implicite = perte de confiance. Compter avec `grep -c sorry` avant/après chaque commit.
 - Tests : pas de `@pytest.skip` ni `assert True` pour contourner un test cassé — corriger le test ou documenter pourquoi on l'accepte.
-- Cellules notebook pédagogique : ne pas effacer une cellule `# Solution` existante sans issue explicite.
+- Cellules notebook pédagogique : ne pas effacer une cellule `# Solution` existante (exemple résolu démonstratif) sans issue explicite.
 
-**Voir `anti-regression.md` pour le workflow complet de détection + review.**
+## Notebooks pédagogiques : pas de cellule en erreur (règle user 2026-04-26)
+
+Règle distincte de l'anti-régression : dans un notebook, **aucune cellule ne doit échouer volontairement**. En particulier :
+
+- **`raise NotImplementedError(...)` est INTERDIT partout dans un notebook** (top-level, méthode, fonction utilitaire). Les scripts de validation trackent les cellules en erreur comme bugs à corriger, donc une erreur volontaire pollue les rapports.
+- **Pour signaler une cellule à compléter par l'étudiant** : utiliser `pass`, `print("Exercice a completer")`, ou `return None` selon le contexte. Préserver tous les commentaires `# TODO` et `# Indice` au-dessus.
+- **Toute autre erreur volontaire interdite aussi** : `assert False`, `1/0`, `raise X("...")`, etc. Le notebook doit s'exécuter de bout en bout sans erreur même quand les exercices ne sont pas complétés.
+- **Conséquence pour la review** : remplacer un `raise NotImplementedError` legacy par `pass`/`print`/`return None` dans un notebook est conforme à cette règle et doit être mergé sans contestation.
+
+**Voir `anti-regression.md` pour le workflow complet de détection + review du code de production, et CLAUDE.md section "RÈGLE CRITIQUE - Anti-régression" pour le détail des stubs d'exercice.**

--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -35,3 +35,39 @@ paths: MyIA.AI.Notebooks/**/*.ipynb
 - French as primary language for documentation
 - Code comments may be in French or English
 - Professional, descriptive naming (no "Pure", "Enhanced", "Advanced", "Ultimate" prefixes)
+
+## Notebooks committés AVEC leurs sorties (règle user 2026-04-26)
+
+**Tout notebook committé doit contenir ses sorties (outputs).** Les notebooks sont du contenu pédagogique : les sorties font partie du livrable.
+
+- **JAMAIS** commit un notebook avec `execution_count: null` partout ou `outputs: []` vidés sans re-exécution
+- **JAMAIS** "clean outputs avant commit" comme étape de routine
+- Toute modification de cellule code (source, dépendances, paramètres) implique une **re-exécution complète** du notebook avant commit
+- Format attendu : `execution_count: <int>` + `outputs: [<résultats>]` cohérents pour chaque cellule code exécutable
+- Exception : cellules d'exercice avec stub `pass`/`print("Exercice a completer")` → `execution_count: <int>` + `outputs: [{stdout: "Exercice a completer\n"}]` ou outputs vide selon le stub
+- Exception légitime : notebook qui n'est pas exécutable dans CI (kernel manquant, GPU requis, données privées) → documenter pourquoi dans le notebook (markdown), mais l'auteur DOIT exécuter localement avant commit
+
+**Workflow obligatoire avant commit d'un notebook modifié** :
+
+1. Re-exécuter intégralement via Papermill (`scripts/notebook_tools/notebook_tools.py execute <path>`) ou cell-by-cell pour .NET/Lean
+2. Vérifier qu'aucune cellule n'est en erreur (cf règle "Aucune cellule en erreur")
+3. Commit le notebook avec ses outputs
+4. Si l'exécution est impossible : annuler le commit et signaler le blocage
+
+**Pour la review** : un PR qui modifie un notebook **sans** mettre à jour ses outputs doit être rejeté avec demande de re-exécution. Exception : modifications uniquement dans les cellules markdown (introduction, conclusion, transitions) — alors les outputs des cellules code restent valides.
+
+**Conséquence pour la coordination Papermill** : la règle "scope strict" (re-exécuter UNIQUEMENT les notebooks dont la source change) **reste valide** — elle évite les collisions d'outputs entre agents. Mais quand la source d'un notebook change, ses outputs DOIVENT être mis à jour dans le même commit.
+
+## Aucune cellule en erreur (règle user 2026-04-26)
+
+**Aucune cellule de notebook ne doit échouer volontairement.** Les scripts de validation trackent les cellules en erreur comme bugs à corriger.
+
+- **`raise NotImplementedError(...)` est INTERDIT partout** dans un notebook (top-level, méthode, fonction utilitaire). Aucune exception.
+- **Toute autre erreur volontaire interdite aussi** : `assert False`, `1/0`, `raise X("...")`, etc.
+- **Pour signaler une cellule à compléter par l'étudiant**, utiliser selon le contexte :
+  - Top-level : `print("Exercice a completer")` ou `pass`
+  - Méthode/fonction : `pass  # TODO étudiant : <description>` ou `return None  # TODO étudiant`
+  - Variable attendue : `result = None  # TODO étudiant : remplacer par <calcul>`
+- **Préserver TOUS les commentaires `# TODO`, `# Indice`, `# Étape N`** au-dessus du stub (le scaffolding pédagogique est le livrable).
+- Le notebook doit s'exécuter de bout en bout sans erreur même quand les exercices ne sont pas complétés.
+- **Conséquence pour la review** : remplacer un `raise NotImplementedError` legacy par le pattern correct est conforme et doit être mergé sans contestation. La règle anti-régression (CLAUDE.md / `anti-regression.md`) **ne s'applique pas** à ce remplacement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,16 +129,46 @@ Si un seul de ces 5 points n'est pas vérifié personnellement : **ne pas merger
 
 **INCIDENT 2026-04-24** : Un commit prétendument "Mathlib compilation fixes" (`47975400`, merge PR #524) a remplacé **9 preuves structurelles fonctionnelles** d'Arrow.lean (`refl`/`total`/`trans` pour `maketop`/`makebot`/`makeabove`) par des `sorry`, et supprimé 3 proof sketches Geanakoplos 2005. -163 lignes nettes sur un port Lean qui avait coûté **une semaine de travail** en janvier 2026 (commit `1ce6a047`, port de [asouther4/lean-social-choice](https://github.com/asouther4/lean-social-choice)).
 
-**Diagnostic user** : "Ou est-ce que c'est passé ? Encore remplacé par de l'AI slop ?" L'agent a confondu "faire passer la compilation" avec "supprimer ce qui ne compile pas". Pattern récurrent identifié : remplacer une preuve/implémentation par `sorry` / `pass` / `NotImplementedError` pour obtenir un état "qui compile" au lieu de **diagnostiquer pourquoi ça ne compilait plus**.
+**Diagnostic user** : "Ou est-ce que c'est passé ? Encore remplacé par de l'AI slop ?" L'agent a confondu "faire passer la compilation" avec "supprimer ce qui ne compile pas". Pattern récurrent identifié : remplacer une **preuve formelle** ou une **implémentation fonctionnelle** par `sorry` pour obtenir un état "qui compile" au lieu de **diagnostiquer pourquoi ça ne compilait plus**.
 
-### ❌ INTERDIT : les régressions disguisées
+### Distinction fondamentale : code de production vs cellule d'exercice étudiant
 
-- **Remplacer une preuve/implémentation fonctionnelle existante par `sorry`/`pass`/`NotImplementedError`/`return None`/stub vide** sans preuve explicite que la version précédente était cassée **et** que le fix tactique est hors de portée
+Cette règle s'applique au **code de production** (preuves Lean, fonctions métier, tests, librairies). Elle ne s'applique **PAS** aux cellules d'exercice destinées aux étudiants — voir section dédiée plus bas.
+
+### ❌ INTERDIT : les régressions disguisées (code de production)
+
+- **Remplacer une preuve formelle ou une implémentation fonctionnelle existante par `sorry`/stub vide** sans preuve explicite que la version précédente était cassée **et** que le fix tactique est hors de portée
 - Commits "compilation fix" / "test fix" / "lint fix" / "Mathlib fix" / "typing fix" avec **deletions > insertions** sur du code métier — red flag systématique, investiguer avant tout autre geste
 - Supprimer des commentaires pédagogiques (proof sketches, docstrings, notes d'implémentation) "pour simplifier" sans accord explicite
 - Justifier la suppression par "le code ne compilait pas / ne passait pas les tests" sans citer l'erreur précise rencontrée
 - Traiter les fichiers de vérification formelle (Lean, Coq, Agda, Z3) comme du code ordinaire : y introduire un `sorry` = **injection d'axiome** = perte de confiance totale dans le théorème
 - Prétendre qu'un `rename` massif rend nécessaire de re-prouver tout : un rename (`P → prof`) se fait tactiquement sans toucher aux preuves
+
+### ❌ INTERDIT ABSOLU : `raise NotImplementedError` (et toute erreur volontaire) dans les notebooks (règle user 2026-04-26)
+
+Le user a explicitement interdit **TOUTES** les occurrences de `raise NotImplementedError` (et plus généralement toute erreur intentionnelle qui fait échouer une cellule) dans les notebooks pédagogiques, **où qu'elles se trouvent** (top-level cellule, corps de méthode, fonction utilitaire, etc.). Raisons :
+
+1. **Les scripts de validation trackent les cellules en erreur comme problèmes à corriger.** Une cellule qui lève une erreur "intentionnelle" pollue les rapports de validation et masque les vraies erreurs.
+2. **Une cellule en erreur fait planter Papermill** sur l'exécution complète du notebook, donc on n'a plus de validation utile sur la suite.
+3. **Ça pousse les agents à "résoudre" l'exercice** pour obtenir un notebook qui passe, plutôt que de le laisser en plan (perte du travail pédagogique de scaffolding).
+
+**Règle absolue** : **aucune cellule de notebook ne doit échouer volontairement.** Si on veut indiquer qu'une partie est à compléter par l'étudiant, on fait autrement (voir patterns ci-dessous).
+
+**Patterns de remplacement obligatoires** :
+
+| Cas | Pattern interdit | Pattern correct |
+|-----|------------------|-----------------|
+| Cellule d'exercice à compléter (top-level) | `raise NotImplementedError("A completer")` | `print("Exercice a completer")` ou `pass` |
+| Méthode d'une classe à implémenter par l'étudiant | `def foo(self): raise NotImplementedError` | `def foo(self): pass  # TODO étudiant : <description>` |
+| Fonction utilitaire stub d'exercice | `def helper(...): raise NotImplementedError` | `def helper(...): return None  # TODO étudiant` |
+| Bloc d'exercice avec valeur attendue | `result = compute_thing()  # raise NotImplementedError` | `result = None  # TODO étudiant : remplacer par compute_thing()` |
+
+Dans tous les cas :
+- Conserver **TOUS** les commentaires `# TODO`, `# Indice`, `# Étape N` (le scaffolding pédagogique est le livrable)
+- Le notebook entier doit s'exécuter de bout en bout sans erreur, même quand les exercices ne sont pas complétés
+- Si l'exercice "appelle" une fonction stub qui retourne `None`/`pass`, le code aval doit gérer ce cas (ou être lui-même commenté)
+
+**Note importante pour les agents qui font de la review** : remplacer un `raise NotImplementedError` legacy par le pattern correct n'est **PAS** une régression — c'est l'application directe de cette règle user. Toute table de patterns red-flag dans `.claude/rules/anti-regression.md` qui suggérerait l'inverse est obsolète et doit être ignorée. **Tout commit qui supprime des `raise NotImplementedError` dans des notebooks pédagogiques pour les remplacer par `pass`/`print`/`return None` est conforme et doit être mergé sans contestation sur ce point.**
 
 ### ✅ OBLIGATOIRE : protocole de préservation
 
@@ -147,7 +177,7 @@ Avant tout commit qui supprime des lignes de code/preuve non-triviales :
 1. **Diagnostic explicite** : citer l'erreur précise que la version précédente produisait (erreur compilateur exact, test échoué nommé, output comparaison). "Ça ne compilait pas" n'est **pas** un diagnostic.
 2. **Minimiser la suppression** : essayer d'adapter (tactique alternative, hypothèse ajoutée, rename localisé) avant de supprimer. `split_ifs <;>` cassé ? Essayer `split_ifs with h1 h2; · ...; · ...`. `Typeclass not found` ? Ajouter l'instance au lieu de supprimer la preuve.
 3. **Prouver l'équivalence** : si on remplace une preuve A par une preuve B, la signature doit être identique. Si on supprime une fonction, prouver qu'elle n'est plus appelée.
-4. **PR dédiée** : tout commit qui introduit `sorry`/`pass`/`NotImplementedError` **à la place de code existant** doit être dans une PR **explicitement labellisée `debt`/`regression-accepted`** avec sign-off utilisateur. Jamais dans une PR "fix" anodine.
+4. **PR dédiée** : tout commit qui introduit `sorry` à la place d'une preuve formelle existante, ou un stub vide à la place d'une fonction métier appelée, doit être dans une PR **explicitement labellisée `debt`/`regression-accepted`** avec sign-off utilisateur. Jamais dans une PR "fix" anodine. (Ne s'applique PAS aux stubs de cellules d'exercice étudiant — voir règle user ci-dessus.)
 5. **Diff check avant push** : relire `git diff` ligne par ligne sur chaque suppression et justifier. `git diff --stat` doit être cohérent avec l'intention.
 
 ### ✅ OBLIGATOIRE : review spécifique anti-régression
@@ -155,7 +185,7 @@ Avant tout commit qui supprime des lignes de code/preuve non-triviales :
 Lors de la review d'une PR prétendant "fix compilation" / "simplification" :
 
 - **Comparer avec l'historique** : `git log --all -- <file>` pour voir les versions antérieures. Si le commit initial contient plus de code que la PR, poser la question.
-- **Checker les patterns red-flag** : `sorry`, `pass  # TODO`, `raise NotImplementedError`, `return None  # placeholder`, cellules `# Solution` remplacées par stubs
+- **Checker les patterns red-flag (code de production uniquement)** : `sorry` dans un fichier Lean/Coq, suppression d'un corps de fonction métier appelée, `return None` à la place d'un calcul, cellules `# Solution` (exemple résolu pédagogique) remplacées par stubs. **Note** : un `raise NotImplementedError` remplacé par `print("Exercice a completer")` dans une cellule d'exercice n'est PAS un red-flag — c'est conforme à la règle user.
 - **Fichiers Lean/Coq** : `grep -c sorry <file>` avant/après. Toute augmentation = PR à contester sauf justification explicite
 - **Ne jamais auto-merger un commit "fix compilation"** avec deletions > insertions sur fichier Lean/formel/cœur métier
 
@@ -222,6 +252,63 @@ Toute PR doit faire l'objet d'une **review complete** avant merge :
 - Les cellules d'interpretation doivent etre placees **apres** la cellule de code qu'elles interpretent
 - Ne pas enrichir le meme notebook dans deux sessions paralleles (risque de doublons)
 - Verifier l'absence de doublons avec `git diff` avant de committer
+
+### Notebooks committes AVEC leurs sorties (regle hard, user 2026-04-26)
+
+**Tout notebook committe doit contenir ses sorties (outputs).** Les notebooks sont du contenu pedagogique : les outputs font partie du livrable affichable directement sur GitHub et reproductible par les etudiants.
+
+- **JAMAIS** commit un notebook avec `execution_count: null` partout ou `outputs: []` vidés sans re-execution
+- **JAMAIS** "clean outputs avant commit" comme etape de routine (sauf donnees sensibles)
+- Toute modification de cellule code (source, dependances, parametres) implique une **re-execution complete** du notebook avant commit
+- Format attendu : `execution_count: <int>` + `outputs: [<resultats>]` coherents pour chaque cellule code executable
+- Cellules d'exercice avec stub : `execution_count: <int>` + `outputs: [{stdout: "Exercice a completer\n"}]` (le stub doit lui-meme s'executer proprement)
+- Notebook non-executable en local (kernel manquant, GPU requis, donnees privees) : documenter pourquoi (markdown), executer ailleurs et committer avec outputs
+
+**VIOLATION = PR a rejeter avec demande de re-execution.** Exception : modifications uniquement dans cellules markdown (introduction, conclusion, transitions) -> outputs des cellules code restent valides.
+
+**Articulation avec scope strict Papermill** (section ci-dessous) : les deux regles coexistent. Le scope strict dit "ne re-execute que les notebooks dont la source change", la regle outputs dit "quand la source change, mets a jour les outputs dans le meme commit". Les agents qui modifient une cellule code DOIVENT re-executer ce notebook avant de stage le diff.
+
+### Scope strict des re-executions Papermill
+
+**INCIDENTS 2026-04-25** : 2 collisions PR causees par re-executions paralleles des memes notebooks par agents differents (#540 vs #541 sur Sudoku-4/5 ; #541 vs #542 sur 21 fichiers Search/CSP/Planners-8/SemanticWeb). Pattern : agent A re-execute notebook X via Papermill pour audit/inventaire, agent B fait la meme chose en parallele -> outputs serialises divergent (timestamps, ordre dict, cell_id, kernel hash) -> conflits Git non-resolvables sans rebase manuel.
+
+**Regle** : un agent ne commit QUE les notebooks qu'il a effectivement modifies (source code, paths, imports, cellules markdown). Les re-executions Papermill de notebooks dont **aucune cellule source n'a change** ne doivent **pas etre stagees**.
+
+**Procedure de verification scope avant commit** :
+
+```bash
+# Lister les fichiers .ipynb modifies
+git diff --name-only -- '*.ipynb'
+
+# Pour chaque .ipynb, verifier qu'au moins une ligne "source" a change
+# (et pas uniquement des outputs)
+for nb in $(git diff --name-only -- '*.ipynb'); do
+  source_changes=$(git diff "$nb" | grep -cE '^\+\s*"source"')
+  if [ "$source_changes" -eq 0 ]; then
+    echo "WARN: $nb a uniquement des changements d'outputs -> NE PAS COMMIT"
+    git restore --staged "$nb" 2>/dev/null
+    git checkout "$nb"
+  fi
+done
+
+# Stager explicitement les fichiers a garder, jamais `git add -A`
+git add MyIA.AI.Notebooks/<famille>/<notebook-modifie>.ipynb
+```
+
+**Cas legitimes pour committer une re-execution sans changement de source** :
+
+- Le notebook produit des outputs **deterministes** (pas de timestamp, seed fixe) ET les outputs precedents etaient stale/erreur, ET la mission est explicitement "rafraichir les outputs de cette famille" (avec accord coordinateur prealable)
+- Annoncer le scope sur le dashboard avant : `roosync_dashboard append tags=[INFO] "po-XXXX: re-execute famille Y notebooks pour mettre a jour outputs (mission Z)"`. Cela bloque les autres agents sur la meme famille pendant la duree de la mission.
+
+**Workflow recommande pour audit/inventaire (pas de commit)** :
+
+- Executer Papermill dans un repertoire temporaire (`--output /tmp/audit_<famille>_$(date +%s)/`)
+- Generer un rapport markdown sur le dashboard ou en commentaire d'issue (pas de fichier dans le repo)
+- Si bug detecte : ouvrir une PR ciblee qui modifie UNIQUEMENT le ou les fichiers source affectes (pas la re-execution complete de la famille)
+
+**Pourquoi** : 2 agents qui re-executent le meme notebook produisent des bytes differents meme si la logique est identique. C'est un cout de coordination evitable. Le scope strict reduit les rebases de 60-80% selon les sessions observees.
+
+**VIOLATION** : PR avec >5 fichiers .ipynb dont la diff source est vide -> rejeter et demander rebase scope.
 
 ### Emojis interdits
 


### PR DESCRIPTION
## Contexte

PR #530 (mergee 2026-04-24) introduisait une table anti-regression qui classait `raise NotImplementedError → pass` comme regression. Generalisation excessive de la lecon Lean (`sorry` = injection axiome). Resultat : pendant 2 jours (24-26/04), regle inverse contre la directive user **\"raise NotImplementedError INTERDIT dans tous les notebooks\"**.

Decouverte 26/04 quand l'audit ai-01 a contre-flag PR #549 (Search-8, NanoClaw) comme **\"regression pedagogique grave\"** alors qu'elle appliquait correctement la regle user.

User : *\"j'ai INTERDIT les NotImplementedError, qui font planter la validation des Notebooks et aboutissent a ce que les agents resolvent les exercices plutot que les laisser en plan. Je ne comprends pas comment l'instruction INVERSE s'est retrouvee dans Claude.md, c'est tres grave et ca nous a fait perdre une semaine de travail.\"*

## Changements

### 1. Regle anti-regression scope clarifie
- **CLAUDE.md** : section reformulee, distinction code de production vs cellule d'exercice etudiant
- **anti-regression.md** : tables Python / Notebooks reecrites, NotImplementedError sorti des red-flags
- **code-style.md** : scope clarifie au code de production

### 2. Nouvelle regle : aucune cellule en erreur dans les notebooks
- `raise NotImplementedError` INTERDIT partout (top-level, methode, fonction utilitaire)
- `assert False`, `1/0`, `raise X(\"...\")` egalement interdits
- Patterns de remplacement obligatoires par contexte
- Ajoutee dans CLAUDE.md, code-style.md, **notebook-conventions.md** (auto-loaded sur \`*.ipynb\`)

### 3. Nouvelle regle hard : notebooks committes AVEC leurs sorties
- JAMAIS commit avec \`execution_count: null\` ou \`outputs: []\` vidés sans re-execution
- Les outputs font partie du livrable pedagogique (visible sur GitHub, reproductible)
- Toute modification de cellule code implique re-execution avant commit
- Articulation explicite avec scope strict Papermill

### 4. Memoire
- \`feedback_no_notimplementederror_in_notebooks.md\` cree (formalise la regle + tracabilite du bug PR #530)
- \`session_20260425_audit529_final.md\` ligne corrigee (critere stub abusif inverse)
- MEMORY.md index mis a jour
- *(non-track dans git, hors PR)*

## Test plan

- [x] Lecture des 4 fichiers modifies pour coherence interne
- [x] Verifier qu'il n'y a plus d'occurrences \"NotImplementedError = regression\" dans le repo (\`grep -r NotImplementedError .claude CLAUDE.md\`)
- [ ] Pas de validation automatisee specifique pour ce PR (changements docs only)

## Audit follow-up

Apres merge de cette PR :
1. Re-evaluer PR #549 NanoClaw (precedemment contestee a tort)
2. Audit des notebooks committes recemment avec \`execution_count: null\` -> redispatch re-execution
3. Brief NanoClaw / agents pour eviter futurs faux positifs sur ce critere

🤖 Generated with [Claude Code](https://claude.com/claude-code)