### PR TITLE
feat(lean): Sen impossibility theorem 0 sorry (issue #556 PR-1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16b-Lean-SocialChoice.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16b-Lean-SocialChoice.ipynb
@@ -1141,97 +1141,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Liberte minimale (Minimal Liberalism)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Chaque individu est &quot;decisif&quot; sur au moins une paire d&#39;alternatives</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>MinimalLiberalism<span class=\"w\"> </span>{I<span class=\"w\"> </span>A<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(swf<span class=\"w\"> </span>:<span class=\"w\"> </span>SocialWelfareFunction<span class=\"w\"> </span>I<span class=\"w\"> </span>A)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span><span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">∀</span><span class=\"w\"> </span>i<span class=\"w\"> </span>:<span class=\"w\"> </span>I,<span class=\"w\"> </span><span class=\"bp\">∃</span><span class=\"w\"> </span>x<span class=\"w\"> </span>y<span class=\"w\"> </span>:<span class=\"w\"> </span>A,<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">∧</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">∀</span><span class=\"w\"> </span>prefs<span class=\"w\"> </span>:<span class=\"w\"> </span>Profile<span class=\"w\"> </span>I<span class=\"w\"> </span>A,</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      (prefs<span class=\"w\"> </span>i)<span class=\"bp\">.</span>strict<span class=\"w\"> </span>x<span class=\"w\"> </span>y<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>(swf<span class=\"bp\">.</span>f<span class=\"w\"> </span>prefs)<span class=\"bp\">.</span>strict<span class=\"w\"> </span>x<span class=\"w\"> </span>y</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>check<span class=\"w\"> </span><span class=\"bp\">@</span>MinimalLiberalism</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">@</span>MinimalLiberalism<span class=\"w\"> </span>:<span class=\"w\"> </span>{I<span class=\"w\"> </span>A<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>SocialWelfareFunction<span class=\"w\"> </span>I<span class=\"w\"> </span>A<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Liberte minimale (Minimal Liberalism)\\n-- Chaque individu est \\\"decisif\\\" sur au moins une paire d'alternatives\\n\\ndef MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=\\n  \\u2200 i : I, \\u2203 x y : A, x \\u2260 y \\u2227\\n    \\u2200 prefs : Profile I A,\\n      (prefs i).strict x y \\u2192 (swf.f prefs).strict x y\\n\\n#check @MinimalLiberalism\", \"env\": 8}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"messages\":\r\n",
-       " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
-       "   \"data\":\r\n",
-       "   \"@MinimalLiberalism : {I A : Type} → SocialWelfareFunction I A → Prop\"}],\r\n",
-       " \"env\": 9}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Liberte minimale (Minimal Liberalism)\n",
-       "-- Chaque individu est \"decisif\" sur au moins une paire d'alternatives\n",
-       "\n",
-       "def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=\n",
-       "  ∀ i : I, ∃ x y : A, x ≠ y ∧\n",
-       "    ∀ prefs : Profile I A,\n",
-       "      (prefs i).strict x y → (swf.f prefs).strict x y\n",
-       "\n",
-       "#check @MinimalLiberalism\n",
-       "──────▶  @MinimalLiberalism : {I A : Type} → SocialWelfareFunction I A → Prop\n",
-       "--% env 9\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Liberte minimale (Minimal Liberalism)\\n-- Chaque individu est \\\"decisif\\\" sur au moins une paire d'alternatives\\n\\ndef MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=\\n  \\u2200 i : I, \\u2203 x y : A, x \\u2260 y \\u2227\\n    \\u2200 prefs : Profile I A,\\n      (prefs i).strict x y \\u2192 (swf.f prefs).strict x y\\n\\n#check @MinimalLiberalism\", \"env\": 8}\n",
-       "Raw output:\n",
-       "{\"messages\":\r\n",
-       " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 6},\r\n",
-       "   \"data\":\r\n",
-       "   \"@MinimalLiberalism : {I A : Type} → SocialWelfareFunction I A → Prop\"}],\r\n",
-       " \"env\": 9}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Liberte minimale (Minimal Liberalism)\n",
-    "-- Chaque individu est \"decisif\" sur au moins une paire d'alternatives\n",
-    "\n",
-    "def MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=\n",
-    "  ∀ i : I, ∃ x y : A, x ≠ y ∧\n",
-    "    ∀ prefs : Profile I A,\n",
-    "      (prefs i).strict x y → (swf.f prefs).strict x y\n",
-    "\n",
-    "#check @MinimalLiberalism"
-   ]
+   "outputs": [],
+   "source": "-- Liberte minimale (Minimal Liberalism) - version bidirectionnelle (Sen 1970)\n-- Chaque individu est \"decisif\" sur au moins une paire d'alternatives,\n-- dans les DEUX directions : s'il prefere x a y, la societe aussi,\n-- et s'il prefere y a x, la societe aussi.\n-- Cette bidirectionnalite est essentielle pour le theoreme d'impossibilite.\n\ndef MinimalLiberalism {I A : Type} (swf : SocialWelfareFunction I A) : Prop :=\n  ∀ i : I, ∃ x y : A, x ≠ y ∧\n    (∀ prefs : Profile I A,\n      (prefs i).strict x y → (swf.f prefs).strict x y) ∧\n    (∀ prefs : Profile I A,\n      (prefs i).strict y x → (swf.f prefs).strict y x)\n\n#check @MinimalLiberalism"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "La **Liberté Minimale** est une condition très faible : elle demande seulement que chaque individu ait le contrôle sur AU MOINS une paire d'alternatives (par exemple, ce qu'il lit dans sa sphère privée).\n",
-    "\n",
-    "Le théorème de Sen montre que même cette condition minimale entre en conflit avec l'efficacité Pareto."
-   ]
+   "source": "La **Liberte Minimale** est une condition tres faible : elle demande seulement que chaque individu ait le controle sur AU MOINS une paire d'alternatives (par exemple, ce qu'il lit dans sa sphere privee).\n\n**Bidirectionnalite** : la definition exige que l'individu soit decisif dans les deux sens — s'il prefere x a y, la societe prefere x a y, ET s'il prefere y a x, la societe prefere y a x. C'est la formulation originale de Sen (1970), et elle est essentielle pour construire le cycle dans la preuve du theoreme d'impossibilite.\n\nLe theoreme de Sen montre que meme cette condition minimale entre en conflit avec l'efficacite Pareto.\n\n> **Preuve complete** : la formalisation complete du theoreme de Sen avec 0 `sorry` se trouve dans le projet Lake `social_choice_lean/` (fichiers `Sen.lean` et `Arrow.lean`)."
   },
   {
    "cell_type": "code",
@@ -1568,42 +1486,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Resume\n",
-    "\n",
-    "### Theoremes formalises\n",
-    "\n",
-    "| Theoreme | Hypotheses | Conclusion |\n",
-    "|----------|------------|------------|\n",
-    "| **Arrow** | |A| >= 3, Pareto, IIA | Dictature |\n",
-    "| **Sen** | |A| >= 4, Pareto, Liberte | Contradiction |\n",
-    "| **Electeur Median** | Preferences unimodales, impair | Gagnant Condorcet existe |\n",
-    "\n",
-    "### Definitions cles\n",
-    "\n",
-    "| Concept | Definition Lean |\n",
-    "|---------|----------------|\n",
-    "| Preference | `Preference A` avec `R`, `complete`, `trans` |\n",
-    "| Profil | `Profile I A := I → Preference A` |\n",
-    "| SWF | `SocialWelfareFunction I A` avec `f : Profile I A → Preference A` |\n",
-    "| Pareto | `WeakPareto` : unanimite stricte → social strict |\n",
-    "| IIA | `IIA` : preference pairwise suffit |\n",
-    "| Non-dictature | `NonDictatorial` : pas de dictateur |\n",
-    "| SinglePeaked | `SinglePeaked` : preference unimodale avec pic |\n",
-    "\n",
-    "### References\n",
-    "\n",
-    "- [asouther4/lean-social-choice](https://github.com/asouther4/lean-social-choice) - Formalisation Lean 3 originale\n",
-    "- Arrow, K. (1951). \"Social Choice and Individual Values\"\n",
-    "- Sen, A. (1970). \"The Impossibility of a Paretian Liberal\"\n",
-    "- Black, D. (1948). \"On the Rationale of Group Decision-making\"\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Navigation** : [← GameTheory-8b-Lean-CombinatorialGames](GameTheory-8b-Lean-CombinatorialGames.ipynb) | [Index](GameTheory-1-Setup.ipynb) | [GameTheory-15b-Lean-CooperativeGames →](GameTheory-15b-Lean-CooperativeGames.ipynb)"
-   ]
+   "source": "---\n\n## Resume\n\n### Theoremes formalises\n\n| Theoreme | Hypotheses | Conclusion |\n|----------|------------|------------|\n| **Arrow** | |A| >= 3, Pareto, IIA | Dictature |\n| **Sen** | |A| >= 4, Pareto, Liberalisme (bidirectionnel) | Contradiction (cycle) |\n| **Electeur Median** | Preferences unimodales | Gagnant Condorcet existe |\n\n### Definitions cles\n\n| Concept | Definition Lean |\n|---------|----------------|\n| Preference | `Preference A` avec `R`, `complete`, `trans` |\n| Profil | `Profile I A := I → Preference A` |\n| SWF | `SocialWelfareFunction I A` avec `f : Profile I A → Preference A` |\n| Pareto | `WeakPareto` : unanimite stricte → social strict |\n| IIA | `IIA` : preference pairwise suffit |\n| Non-dictature | `NonDictatorial` : pas de dictateur |\n| Liberalisme | `MinimalLiberalism` : chaque individu decisif (bidirectionnel) sur une paire |\n| SinglePeaked | `SinglePeaked` : preference unimodale avec pic |\n\n### Preuves completes en Lean 4\n\nLes preuves completes (0 `sorry`) se trouvent dans le projet Lake `social_choice_lean/` :\n- **Arrow.lean** : Theoreme d'impossibilite d'Arrow (preuve Geanakoplos 2005)\n- **Sen.lean** : Theoreme d'impossibilite de Sen (liberalisme bidirectionnel)\n\n### References\n\n- [asouther4/lean-social-choice](https://github.com/asouther4/lean-social-choice) - Formalisation Lean 3 originale\n- Arrow, K. (1951). \"Social Choice and Individual Values\"\n- Sen, A. (1970). \"The Impossibility of a Paretian Liberal\"\n- Black, D. (1948). \"On the Rationale of Group Decision-making\"\n\n---\n\n**Navigation** : [← GameTheory-8b-Lean-CombinatorialGames](GameTheory-8b-Lean-CombinatorialGames.ipynb) | [Index](GameTheory-1-Setup.ipynb) | [GameTheory-15b-Lean-CooperativeGames →](GameTheory-15b-Lean-CooperativeGames.ipynb)"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Sen.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Sen.lean
@@ -22,9 +22,11 @@ variable {ι : Type*} {σ : Type*} [Fintype ι] [DecidableEq ι] [DecidableEq σ
 /-! ## Minimal Liberalism -/
 
 /-- Individual i is decisive over the pair (x, y):
-    If i strictly prefers x to y, society does too -/
+    Society follows i's strict preference in both directions.
+    Conforms to Sen 1970 and Holliday/Norman/Pacuit 2021 (bidirectional). -/
 def is_decisive_over (f : SWF ι σ) (i : ι) (x y : σ) : Prop :=
-  ∀ prof : Profile ι σ, P (prof i).rel x y → P (f prof).rel x y
+  (∀ prof : Profile ι σ, P (prof i).rel x y → P (f prof).rel x y) ∧
+  (∀ prof : Profile ι σ, P (prof i).rel y x → P (f prof).rel y x)
 
 /-- Minimal liberalism: At least two individuals each have at least one
     pair over which they are decisive -/
@@ -85,11 +87,11 @@ theorem sen_impossibility (f : SWF ι σ) (X : Finset σ)
         else maketop_pref base a
       use prof
       intro ⟨best, hbest⟩
-      have hPa_b : P (f prof).rel a b := hi_dec prof (by
+      have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
         unfold prof; simp only [hij]
         show maketop_rel (fun _ _ ↦ True) a a b ∧ ¬maketop_rel (fun _ _ ↦ True) a b a
         simp [maketop_rel, hab, hab.symm])
-      have hPb_a : P (f prof).rel b a := hj_dec prof (by
+      have hPb_a : P (f prof).rel b a := hj_dec.1 prof (by
         unfold prof; simp only [hij.symm]
         show maketop_rel (fun _ _ ↦ True) b b a ∧ ¬maketop_rel (fun _ _ ↦ True) b a b
         simp [maketop_rel, hab])
@@ -105,10 +107,10 @@ theorem sen_impossibility (f : SWF ι σ) (X : Finset σ)
         else maketop_pref (makebot_pref base a) d
       use prof
       intro ⟨best, hbest⟩
-      have hPa_b : P (f prof).rel a b := hi_dec prof (by
+      have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
         unfold prof; simp only [hij]
         simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hab, had, hbd])
-      have hPb_d : P (f prof).rel b d := hj_dec prof (by
+      have hPb_d : P (f prof).rel b d := hj_dec.1 prof (by
         unfold prof
         simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hab, hbd.symm, hij.symm])
       have hAll_d_a : ∀ k, P (prof k).rel d a := by
@@ -122,6 +124,7 @@ theorem sen_impossibility (f : SWF ι σ) (X : Finset σ)
       have hPad := P_trans (f prof).trans hPa_b hPb_d
       exact hPad.2 hPd_a.1
   · -- b≠c: i on (a,b), j on (c,d) with b≠c
+    have hcb : c ≠ b := fun h => hbc h.symm
     by_cases had : a = d
     · -- a=d: i on (a,b), j on (c,a) — chain-compatible overlap (a shared in
       -- different positions: 1st in i's pair, 2nd in j's). Cycle: a>b (i), b>c (Pareto), c>a (j)
@@ -134,27 +137,146 @@ theorem sen_impossibility (f : SWF ι σ) (X : Finset σ)
         else maketop_pref (makebot_pref base a) b
       use prof
       intro ⟨best, hbest⟩
-      have hPa_b : P (f prof).rel a b := hi_dec prof (by
+      have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
         unfold prof; simp only [hij]
         simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hab, hab.symm, hca, hca.symm])
-      have hPc_a : P (f prof).rel c a := hj_dec prof (by
+      have hPc_a : P (f prof).rel c a := hj_dec.1 prof (by
         unfold prof; simp only [hij.symm]
-        simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hca.symm, hab, hab.symm, hca])
-      have hcb : ¬c = b := fun h => hbc h.symm
+        simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hca, hca.symm, hab, hab.symm, hcb])
+      have hcb_local : ¬c = b := fun h => hbc h.symm
       have hAll_b_c : ∀ k, P (prof k).rel b c := by
         intro k; unfold prof; split_ifs with hki
         · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
             hab, hab.symm, hca, hca.symm, hbc]
         · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
-            hab, hab.symm, hca, hca.symm, hcb]
+            hab, hab.symm, hca, hca.symm, hcb_local]
       have hPb_c : P (f prof).rel b c := hwp prof b c hb hc hAll_b_c
       exact (P_trans (f prof).trans hPa_b hPb_c).2 hPc_a.1
-    · -- a≠d: with b≠c, a≠d, the remaining cases (a=c, b=d, all-distinct)
-      -- require chain-compatible overlap or bidirectional decisiveness.
-      -- With one-directional is_decisive_over, the fork cases (a=c, b=d)
-      -- and all-distinct case cannot form a cycle from our profile constructions.
-      -- These cases need either bidirectional decisiveness or more expressive profiles.
-      sorry
+    · -- a≠d, b≠c: bidirectional decisiveness lets us handle fork cases
+      by_cases hac : a = c
+      · -- a=c (fork): i on (a,b), j on (a,d) with bidirectional j on (d,a).
+        subst hac
+        by_cases hbd_check : b = d
+        · -- b=d means both decisive on (a,b): same pair contradiction
+          subst hbd_check
+          let base : PrefOrder σ := ⟨fun _ _ => True, fun _ => trivial,
+            fun _ _ => Or.inl trivial, fun _ _ _ _ _ => trivial⟩
+          let prof : Profile ι σ := fun k =>
+            if k = i then maketop_pref base a
+            else maketop_pref base b
+          use prof
+          intro ⟨best, hbest⟩
+          have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
+            unfold prof; simp only [hij]
+            show maketop_rel (fun _ _ ↦ True) a a b ∧ ¬maketop_rel (fun _ _ ↦ True) a b a
+            simp [maketop_rel, hab, hab.symm])
+          have hPb_a : P (f prof).rel b a := hj_dec.2 prof (by
+            unfold prof; simp only [hij.symm]
+            show maketop_rel (fun _ _ ↦ True) b b a ∧ ¬maketop_rel (fun _ _ ↦ True) b a b
+            simp [maketop_rel, hab, hab.symm])
+          exact hPa_b.2 hPb_a.1
+        · -- b≠d: Cycle a>b (i.1), b>d (Pareto), d>a (j.2)
+          have hbd_ne : b ≠ d := fun h => hbd_check h
+          let base : PrefOrder σ := ⟨fun _ _ => True, fun _ => trivial,
+            fun _ _ => Or.inl trivial, fun _ _ _ _ _ => trivial⟩
+          let prof : Profile ι σ := fun k =>
+            if k = i then maketop_pref (makebot_pref base d) a
+            else maketop_pref (makebot_pref base a) b
+          use prof
+          intro ⟨best, hbest⟩
+          have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
+            unfold prof; simp only [hij]
+            show maketop_rel (makebot_rel (fun _ _ ↦ True) d) a a b ∧
+              ¬maketop_rel (makebot_rel (fun _ _ ↦ True) d) a b a
+            simp [maketop_rel, makebot_rel, hab, hab.symm, hbd_ne, hcd, hcd.symm])
+          have hPd_a : P (f prof).rel d a := hj_dec.2 prof (by
+            unfold prof; simp only [hij.symm]
+            show maketop_rel (makebot_rel (fun _ _ ↦ True) a) b d a ∧
+              ¬maketop_rel (makebot_rel (fun _ _ ↦ True) a) b a d
+            simp [maketop_rel, makebot_rel, hab, hab.symm, hbd_ne, hcd, hcd.symm])
+          have hAll_b_d : ∀ k, P (prof k).rel b d := by
+            intro k; unfold prof; split_ifs with hki
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hbd_ne, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hbd_ne, hcd, hcd.symm]; exact fun h => hbd_ne h.symm
+          have hPb_d : P (f prof).rel b d := hwp prof b d hb hd hAll_b_d
+          exact (P_trans (f prof).trans hPa_b hPb_d).2 hPd_a.1
+      · -- a≠c, b≠c, a≠d: check b=d fork
+        by_cases hbd2 : b = d
+        · -- b=d (fork): after subst, d→b. i on (a,b), j on (c,b) bidirectional.
+          -- Cycle: c>b (j.1), b>a (i.2), a>c (Pareto)
+          subst hbd2
+          have hac' : ¬a = c := hac
+          let base : PrefOrder σ := ⟨fun _ _ => True, fun _ => trivial,
+            fun _ _ => Or.inl trivial, fun _ _ _ _ _ => trivial⟩
+          let prof : Profile ι σ := fun k =>
+            if k = i then maketop_pref (maketop_pref (makebot_pref base c) a) b
+            else if k = j then maketop_pref (maketop_pref (makebot_pref base b) c) a
+            else maketop_pref (makebot_pref base c) a
+          use prof
+          intro ⟨best, hbest⟩
+          have hPc_b : P (f prof).rel c b := hj_dec.1 prof (by
+            unfold prof; simp only [hij.symm]
+            simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hac', hab, hab.symm, hcd, hcd.symm])
+          have hPb_a : P (f prof).rel b a := hi_dec.2 prof (by
+            unfold prof; simp only [hij]
+            simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hac', hab, hab.symm, hcd, hcd.symm])
+          have hca : c ≠ a := fun h => hac' h.symm
+          have hAll_a_c : ∀ k, P (prof k).rel a c := by
+            intro k; unfold prof; split_ifs with hki hkj
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hac', hca, hab, hab.symm, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hac', hca, hab, hab.symm, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hac', hca, hab, hcd]
+          have hPa_c : P (f prof).rel a c := hwp prof a c ha hc hAll_a_c
+          exact (P_trans (f prof).trans hPc_b hPb_a).2 hPa_c.1
+        · -- All distinct: 4-cycle a>b>c>d>a using 4 alternatives
+          -- i on (a,b) bidirectional, j on (c,d) bidirectional
+          -- Cycle: a>b (i.1), b>c (Pareto), c>d (j.1), d>a (Pareto)
+          let base : PrefOrder σ := ⟨fun _ _ => True, fun _ => trivial,
+            fun _ _ => Or.inl trivial, fun _ _ _ _ _ => trivial⟩
+          let prof : Profile ι σ := fun k =>
+            if k = i then maketop_pref (maketop_pref (maketop_pref (makebot_pref base c) b) a) d
+            else if k = j then maketop_pref (maketop_pref (maketop_pref (makebot_pref base a) d) c) b
+            else maketop_pref (maketop_pref (makebot_pref base c) b) d
+          use prof
+          intro ⟨best, hbest⟩
+          have hdb : ¬d = b := fun h => hbd2 h.symm
+          have hda : ¬d = a := fun h => had h.symm
+          have hca : ¬c = a := fun h => hac h.symm
+          have hPa_b : P (f prof).rel a b := hi_dec.1 prof (by
+            unfold prof; simp only [hij]
+            simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd])
+          have hPc_d : P (f prof).rel c d := hj_dec.1 prof (by
+            unfold prof; simp only [hij.symm]
+            simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm])
+          have hAll_b_c : ∀ k, P (prof k).rel b c := by
+            intro k; unfold prof; split_ifs with hki hkj
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+          have hAll_d_a : ∀ k, P (prof k).rel d a := by
+            intro k; unfold prof; split_ifs with hki hkj
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+            · simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel,
+                hab, hab.symm, hac, hca, had, hda, hbc, hcb, hbd2, hdb, hcd, hcd.symm]
+          have hPb_c : P (f prof).rel b c := hwp prof b c hb hc hAll_b_c
+          have hPd_a : P (f prof).rel d a := hwp prof d a hd ha hAll_d_a
+          exact (P_trans (f prof).trans hPa_b hPb_c).2
+            (P_trans (f prof).trans hPc_d hPd_a).1
 
 /-! ## Example: The Book Reading Paradox -/
 
@@ -216,13 +338,13 @@ theorem book_paradox_demonstrates_sen
     unfold prof; simp only [hne]
     simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hpr_np, hlr_np, hpr_lr]
   have hPprLr : P (f prof).rel pr lr :=
-    hprude prof hPrudePrLr
+    hprude.1 prof hPrudePrLr
   -- Step 3: Lewd prefers lr > np (decisive)
   have hLewdLrNp : P (prof lewd).rel lr np := by
     unfold prof; simp only [hne.symm]
     simp [P, maketop_pref, maketop_rel, makebot_pref, makebot_rel, hnp_lr]
   have hPlrNp : P (f prof).rel lr np :=
-    hlewd prof hLewdLrNp
+    hlewd.1 prof hLewdLrNp
   exact ⟨hPnpPr, hPprLr, hPlrNp⟩
 
 /-! ## Resolution Approaches -/


### PR DESCRIPTION
## Summary
- Closes the last `sorry` in `Sen.lean` by making `is_decisive_over` bidirectional (conforming to Sen 1970)
- Decisive over (x,y) now means both `P x y → P x y` AND `P y x → P y x`
- Full proof of `sen_impossibility` with 0 sorry, 0 errors
- Sync GameTheory-16b notebook with bidirectional definition

## Changes

### PR-1: Sen.lean (0 sorry)
- **Definition**: `is_decisive_over` changed from single-direction to bidirectional (lines 27-29)
- **Proof**: Complete rewrite of `sen_impossibility` with profile construction using `maketop`/`makebot` stacks
- **Book paradox**: Adapted to bidirectional definition

### PR-2: GameTheory-16b notebook sync
- **MinimalLiberalism**: Updated to bidirectional definition matching Sen 1970
- **Interpretation**: Added note about bidirectionality being essential for cycle construction
- **Summary**: Updated table and added reference to complete proof in Lake project

## Key proof techniques
- Ne-type vs Not-type inequality helpers for simp if-then-else resolution
- `subst` to eliminate variables in the b=d fork
- Bare `simp` (no `show`) for flexible goal simplification

## Test plan
- [x] `lake build SocialChoice.Sen` — 0 errors, 0 sorry
- [x] Build passes for all SocialChoice files (3069 jobs)
- [ ] GameTheory-16b notebook: needs re-execution with Lean 4 WSL kernel (outputs cleared by definition change)

Addresses issue #556 (PR-1 + PR-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)