### PR TITLE
fix(csp-9): correct ABT/AWC implementation (Laqwad bugfix restored)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -5,10 +5,10 @@
    "id": "ea8598c0",
    "metadata": {
     "papermill": {
-     "duration": 0.005252,
-     "end_time": "2026-04-25T15:42:25.316399",
+     "duration": 0.005199,
+     "end_time": "2026-04-28T13:16:51.514336+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:25.311147",
+     "start_time": "2026-04-28T13:16:51.509137+00:00",
      "status": "completed"
     },
     "tags": []
@@ -37,16 +37,16 @@
    "id": "2a7dbea6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:25.326109Z",
-     "iopub.status.busy": "2026-04-25T15:42:25.325823Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.145248Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.144316Z"
+     "iopub.execute_input": "2026-04-28T13:16:51.523070Z",
+     "iopub.status.busy": "2026-04-28T13:16:51.523070Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.491850Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.491850Z"
     },
     "papermill": {
-     "duration": 0.825601,
-     "end_time": "2026-04-25T15:42:26.146391",
+     "duration": 0.97391,
+     "end_time": "2026-04-28T13:16:52.492852+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:25.320790",
+     "start_time": "2026-04-28T13:16:51.518942+00:00",
      "status": "completed"
     },
     "tags": []
@@ -81,10 +81,10 @@
    "id": "995917d9",
    "metadata": {
     "papermill": {
-     "duration": 0.004598,
-     "end_time": "2026-04-25T15:42:26.155798",
+     "duration": 0.004004,
+     "end_time": "2026-04-28T13:16:52.499854+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.151200",
+     "start_time": "2026-04-28T13:16:52.495850+00:00",
      "status": "completed"
     },
     "tags": []
@@ -117,16 +117,16 @@
    "id": "6c494cba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.166355Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.165770Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.172613Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.171930Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.506847Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.506847Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.523408Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.523408Z"
     },
     "papermill": {
-     "duration": 0.013449,
-     "end_time": "2026-04-25T15:42:26.173750",
+     "duration": 0.021232,
+     "end_time": "2026-04-28T13:16:52.524091+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.160301",
+     "start_time": "2026-04-28T13:16:52.502859+00:00",
      "status": "completed"
     },
     "tags": []
@@ -176,10 +176,10 @@
    "id": "a52e94c9",
    "metadata": {
     "papermill": {
-     "duration": 0.004484,
-     "end_time": "2026-04-25T15:42:26.183184",
+     "duration": 0.004,
+     "end_time": "2026-04-28T13:16:52.531094+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.178700",
+     "start_time": "2026-04-28T13:16:52.527094+00:00",
      "status": "completed"
     },
     "tags": []
@@ -212,16 +212,16 @@
    "id": "9393a18d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.193988Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.193569Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.206521Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.205874Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.538267Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.538267Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.555353Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.555353Z"
     },
     "papermill": {
-     "duration": 0.019833,
-     "end_time": "2026-04-25T15:42:26.207671",
+     "duration": 0.022247,
+     "end_time": "2026-04-28T13:16:52.556354+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.187838",
+     "start_time": "2026-04-28T13:16:52.534107+00:00",
      "status": "completed"
     },
     "tags": []
@@ -239,102 +239,125 @@
     "class ABTAgent:\n",
     "    \"\"\"\n",
     "    Agent pour l'algorithme Asynchronous Backtracking.\n",
-    "    \n",
-    "    Base sur Yokoo et al. (1992)\n",
+    "\n",
+    "    Base sur Yokoo et al. (1992).\n",
     "    \"\"\"\n",
-    "    \n",
-    "    def __init__(self, agent_id: int, domain: List[Any], \n",
+    "\n",
+    "    def __init__(self, agent_id: int, domain: List[Any],\n",
     "                 constraint_func, neighbors: List[int]):\n",
     "        self.id = agent_id\n",
     "        self.domain = domain\n",
     "        self.constraint_func = constraint_func  # Fonction de contrainte locale\n",
     "        self.neighbors = neighbors\n",
-    "        \n",
+    "\n",
     "        # Etat de l'agent\n",
     "        self.value = None\n",
     "        self.agent_view: Dict[int, Any] = {}  # Vue des agents de haute priorite\n",
     "        self.nogoods: Set[Nogood] = set()     # Nogoods appris\n",
     "        self.higher_priority: List[int] = []  # Agents de haute priorite\n",
     "        self.lower_priority: List[int] = []   # Agents de basse priorite\n",
-    "        \n",
-    "        # File de messages\n",
+    "\n",
+    "        # File de messages locale (non utilisee par ABTSystem)\n",
     "        self.message_queue: List[Message] = []\n",
-    "        \n",
-    "        # Statistiques\n",
+    "\n",
+    "        # Statistiques (nogoods_generated : nogoods emis dans _backtrack, pas recus)\n",
     "        self.messages_sent = 0\n",
     "        self.nogoods_generated = 0\n",
-    "    \n",
+    "        self._system = None  # Renseigne par ABTSystem pour AWC / reordonnancement\n",
+    "\n",
+    "    def priority_sort_key(self) -> Tuple[float, int]:\n",
+    "        \"\"\"Cle de tri pour l'ordre entre agents (ABT pur : identique a l'id).\"\"\"\n",
+    "        return (float(self.id), self.id)\n",
+    "\n",
     "    def set_priority_order(self, higher: List[int], lower: List[int]):\n",
     "        \"\"\"Definit l'ordre de priorite des agents.\"\"\"\n",
     "        self.higher_priority = higher\n",
     "        self.lower_priority = lower\n",
-    "    \n",
+    "\n",
     "    def check_consistency(self, value: Any) -> bool:\n",
-    "        \"\"\"Verifie si une valeur est coherente avec l'agent_view.\"\"\"\n",
-    "        # Verifier avec l'agent_view\n",
+    "        \"\"\"\n",
+    "        Coherence locale : contraintes avec chaque agent deja present dans agent_view\n",
+    "        (en pratique : agents de priorite superieure ayant envoye un ok?).\n",
+    "        Quand la file de messages est vide, la vue contient tous les voisins prioritaires :\n",
+    "        la coherence locale coincide alors avec les aretes du graphe pour cet agent.\n",
+    "        \"\"\"\n",
     "        for var_id, val in self.agent_view.items():\n",
     "            if not self.constraint_func(self.id, value, var_id, val):\n",
     "                return False\n",
-    "        \n",
-    "        # Verifier avec les nogoods\n",
+    "\n",
+    "        # Verifier avec les nogoods appris\n",
     "        for nogood in self.nogoods:\n",
-    "            # Si le nogood est applicable (toutes les vars dans agent_view)\n",
     "            if self._nogood_applicable(nogood, value):\n",
     "                return False\n",
-    "        \n",
+    "\n",
     "        return True\n",
-    "    \n",
+    "\n",
     "    def _nogood_applicable(self, nogood: Nogood, value: Any) -> bool:\n",
-    "        \"\"\"Verifie si un nogood elimine la valeur courante.\"\"\"\n",
-    "        for var_id, val in nogood.assignments.items():\n",
-    "            if var_id == self.id:\n",
-    "                if val == value:\n",
-    "                    # Verifier que les autres variables correspondent\n",
-    "                    for v, v_val in nogood.assignments.items():\n",
-    "                        if v != self.id and self.agent_view.get(v) != v_val:\n",
-    "                            return False\n",
-    "                    return True\n",
-    "        return False\n",
-    "    \n",
+    "        \"\"\"Le nogood contient self avec une certaine valeur, et toutes les autres\n",
+    "        variables de priorite superieure doivent coincider avec agent_view.\"\"\"\n",
+    "        if self.id not in nogood.assignments:\n",
+    "            return False\n",
+    "        if nogood.assignments[self.id] != value:\n",
+    "            return False\n",
+    "        for v, v_val in nogood.assignments.items():\n",
+    "            if v == self.id:\n",
+    "                continue\n",
+    "            if self.agent_view.get(v) != v_val:\n",
+    "                return False\n",
+    "        return True\n",
+    "\n",
     "    def choose_value(self) -> Optional[Any]:\n",
     "        \"\"\"Choisit une valeur coherente avec l'agent_view.\"\"\"\n",
     "        for val in self.domain:\n",
     "            if self.check_consistency(val):\n",
     "                return val\n",
     "        return None\n",
-    "    \n",
-    "    def process_ok_message(self, msg: Message):\n",
-    "        \"\"\"Traite un message 'ok?' (assignation d'un agent de haute priorite).\"\"\"\n",
+    "\n",
+    "    def process_ok_message(self, msg: Message) -> List[Message]:\n",
+    "        \"\"\"Traite un message 'ok?' (assignation d'un agent de haute priorite).\n",
+    "\n",
+    "        Si l'agent n'a pas encore choisi de valeur, il en choisit une\n",
+    "        immediatement et la propage. Sans ce cas, un agent recevant son premier\n",
+    "        ok? avant son init resterait silencieux et l'algorithme atteindrait\n",
+    "        une fausse quiescence.\n",
+    "        \"\"\"\n",
     "        var_id, value = msg.content\n",
     "        self.agent_view[var_id] = value\n",
-    "        \n",
-    "        # Verifier si la valeur courante est toujours valide\n",
-    "        if self.value is not None and not self.check_consistency(self.value):\n",
+    "\n",
+    "        if self.value is None:\n",
     "            self.value = self.choose_value()\n",
     "            if self.value is not None:\n",
     "                return self._send_ok_messages()\n",
-    "            else:\n",
-    "                return self._backtrack()\n",
+    "            return self._backtrack()\n",
+    "\n",
+    "        if not self.check_consistency(self.value):\n",
+    "            self.value = self.choose_value()\n",
+    "            if self.value is not None:\n",
+    "                return self._send_ok_messages()\n",
+    "            return self._backtrack()\n",
     "        return []\n",
-    "    \n",
+    "\n",
     "    def process_nogood_message(self, msg: Message) -> List[Message]:\n",
-    "        \"\"\"Traite un message 'nogood' (contrainte apprise).\"\"\"\n",
+    "        \"\"\"Traite un message 'nogood' (contrainte apprise).\n",
+    "\n",
+    "        Si le nogood mentionne un agent inconnu, on l'ajoute a higher_priority\n",
+    "        et on demande un addlink. Si la valeur courante reste valide, on\n",
+    "        renvoie un ok? a l'expediteur (qui a probablement retire self de sa\n",
+    "        vue en backtrackant et a besoin de la valeur a jour).\n",
+    "        \"\"\"\n",
     "        nogood = msg.content\n",
     "        self.nogoods.add(nogood)\n",
-    "        self.nogoods_generated += 1\n",
-    "        \n",
-    "        # Verifier si de nouveaux liens sont necessaires\n",
+    "\n",
+    "        # Liens manquants : tout agent du nogood pas encore dans la vue doit envoyer addlink\n",
     "        new_links = []\n",
     "        for var_id in nogood.assignments:\n",
     "            if var_id != self.id and var_id not in self.agent_view:\n",
     "                if var_id not in self.higher_priority:\n",
-    "                    # Ajouter aux agents de haute priorite\n",
     "                    self.higher_priority.append(var_id)\n",
-    "                    new_links.append(var_id)\n",
-    "        \n",
-    "        messages = []\n",
-    "        \n",
-    "        # Envoyer addlink si necessaire\n",
+    "                new_links.append(var_id)\n",
+    "\n",
+    "        messages: List[Message] = []\n",
+    "\n",
     "        for var_id in new_links:\n",
     "            messages.append(Message(\n",
     "                sender=self.id,\n",
@@ -343,17 +366,32 @@
     "                content=self.id\n",
     "            ))\n",
     "            self.messages_sent += 1\n",
-    "        \n",
+    "\n",
     "        # Verifier la valeur courante\n",
+    "        value_changed = False\n",
     "        if self.value is not None and not self.check_consistency(self.value):\n",
+    "            old_value = self.value\n",
     "            self.value = self.choose_value()\n",
+    "            value_changed = (self.value != old_value)\n",
     "            if self.value is not None:\n",
     "                messages.extend(self._send_ok_messages())\n",
     "            else:\n",
     "                messages.extend(self._backtrack())\n",
-    "        \n",
+    "\n",
+    "        # Si la valeur n'a pas change, renvoyer un ok? a l'expediteur :\n",
+    "        # il a probablement retire self de son agent_view en backtrackant et doit\n",
+    "        # recuperer la valeur courante (sinon il peut converger sur un etat global incoherent).\n",
+    "        if not value_changed and self.value is not None and msg.sender != self.id:\n",
+    "            messages.append(Message(\n",
+    "                sender=self.id,\n",
+    "                receiver=msg.sender,\n",
+    "                msg_type='ok?',\n",
+    "                content=(self.id, self.value),\n",
+    "            ))\n",
+    "            self.messages_sent += 1\n",
+    "\n",
     "        return messages\n",
-    "    \n",
+    "\n",
     "    def _send_ok_messages(self) -> List[Message]:\n",
     "        \"\"\"Envoie la valeur courante aux agents de basse priorite.\"\"\"\n",
     "        messages = []\n",
@@ -366,41 +404,47 @@
     "            ))\n",
     "            self.messages_sent += 1\n",
     "        return messages\n",
-    "    \n",
+    "\n",
     "    def _backtrack(self) -> List[Message]:\n",
-    "        \"\"\"Genere un nogood et l'envoie a l'agent de haute priorite responsable.\"\"\"\n",
-    "        if not self.higher_priority:\n",
-    "            # Pas de solution\n",
+    "        \"\"\"ABT standard : construit un nogood compose des seuls agents de priorite\n",
+    "        superieure (la cible peut les voir), l'envoie au plus prioritaire d'entre eux,\n",
+    "        puis retire la cible de sa vue et re-essaie une affectation locale.\n",
+    "        Si plus aucune valeur n'est compatible, on backtracke recursivement.\n",
+    "        \"\"\"\n",
+    "        relevant = {v: self.agent_view[v] for v in self.higher_priority if v in self.agent_view}\n",
+    "        if not relevant:\n",
     "            return [Message(\n",
     "                sender=self.id,\n",
-    "                receiver=-1,  # Broadcast\n",
+    "                receiver=-1,\n",
     "                msg_type='stop',\n",
     "                content='no_solution'\n",
     "            )]\n",
-    "        \n",
-    "        # Construire un nogood a partir de l'agent_view\n",
-    "        nogood_assignments = dict(self.agent_view)\n",
-    "        nogood_assignments[self.id] = self.value if self.value else self.domain[0]\n",
-    "        nogood = Nogood(nogood_assignments)\n",
-    "        \n",
-    "        # Envoyer au plus haut agent dans le nogood\n",
-    "        target = max(nogood.assignments.keys())\n",
-    "        if target == self.id:\n",
-    "            target = max([v for v in nogood.assignments if v != self.id])\n",
-    "        \n",
-    "        return [Message(\n",
+    "\n",
+    "        target = max(relevant.keys())\n",
+    "        nogood = Nogood(relevant)\n",
+    "        messages: List[Message] = [Message(\n",
     "            sender=self.id,\n",
     "            receiver=target,\n",
     "            msg_type='nogood',\n",
-    "            content=nogood\n",
+    "            content=nogood,\n",
     "        )]\n",
-    "    \n",
+    "        self.messages_sent += 1\n",
+    "        self.nogoods_generated += 1\n",
+    "\n",
+    "        self.agent_view.pop(target, None)\n",
+    "        self.value = self.choose_value()\n",
+    "        if self.value is not None:\n",
+    "            messages.extend(self._send_ok_messages())\n",
+    "        else:\n",
+    "            messages.extend(self._backtrack())\n",
+    "        return messages\n",
+    "\n",
     "    def initialize(self) -> List[Message]:\n",
     "        \"\"\"Initialise l'agent et envoie les premiers messages.\"\"\"\n",
     "        self.value = self.choose_value()\n",
     "        if self.value is not None:\n",
     "            return self._send_ok_messages()\n",
-    "        return []\n",
+    "        return self._backtrack()\n",
     "print(\"Classe ABTAgent definie.\")\n"
    ]
   },
@@ -409,10 +453,10 @@
    "id": "fdba305e",
    "metadata": {
     "papermill": {
-     "duration": 0.004926,
-     "end_time": "2026-04-25T15:42:26.217787",
+     "duration": 0.004001,
+     "end_time": "2026-04-28T13:16:52.563354+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.212861",
+     "start_time": "2026-04-28T13:16:52.559353+00:00",
      "status": "completed"
     },
     "tags": []
@@ -436,16 +480,16 @@
    "id": "4055fe66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.229175Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.228627Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.237833Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.237009Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.570117Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.570117Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.588118Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.587118Z"
     },
     "papermill": {
-     "duration": 0.01637,
-     "end_time": "2026-04-25T15:42:26.239071",
+     "duration": 0.021763,
+     "end_time": "2026-04-28T13:16:52.588118+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.222701",
+     "start_time": "2026-04-28T13:16:52.566355+00:00",
      "status": "completed"
     },
     "tags": []
@@ -463,9 +507,9 @@
     "class ABTSystem:\n",
     "    \"\"\"\n",
     "    Systeme de simulation pour l'algorithme ABT.\n",
-    "    Simule la communication asynchrone entre agents.\n",
+    "    Simule la communication asynchrone entre agents via une file FIFO globale.\n",
     "    \"\"\"\n",
-    "    \n",
+    "\n",
     "    def __init__(self, agents: Dict[int, ABTAgent]):\n",
     "        self.agents = agents\n",
     "        self.message_queue: List[Message] = []\n",
@@ -473,37 +517,57 @@
     "        self.no_solution = False\n",
     "        self.total_messages = 0\n",
     "        self.total_nogoods = 0\n",
-    "        \n",
-    "        # Initialiser l'ordre de priorite\n",
+    "        self.message_type_counts: Dict[str, int] = {}  # types traites dans la file\n",
+    "\n",
+    "        for ag in self.agents.values():\n",
+    "            ag._system = self\n",
+    "\n",
     "        self._setup_priority_order()\n",
-    "    \n",
+    "\n",
     "    def _setup_priority_order(self):\n",
-    "        \"\"\"Configure l'ordre de priorite pour chaque agent.\"\"\"\n",
-    "        agent_ids = sorted(self.agents.keys())\n",
+    "        \"\"\"Configure higher/lower selon priority_sort_key() de chaque agent (ABT ou AWC).\"\"\"\n",
+    "        agent_ids = sorted(self.agents.keys(), key=lambda i: self.agents[i].priority_sort_key())\n",
     "        for i, agent_id in enumerate(agent_ids):\n",
     "            higher = agent_ids[:i]\n",
-    "            lower = agent_ids[i+1:]\n",
+    "            lower = agent_ids[i + 1:]\n",
     "            self.agents[agent_id].set_priority_order(higher, lower)\n",
-    "    \n",
-    "    def run(self, max_iterations: int = 1000) -> Optional[Dict[int, Any]]:\n",
-    "        \"\"\"Execute l'algorithme ABT jusqu'a convergence.\"\"\"\n",
-    "        # Phase d'initialisation\n",
+    "\n",
+    "    def _on_awc_reorder(self):\n",
+    "        \"\"\"Apres promotion AWC : recalcul des priorites + nouvelle vague de ok?.\"\"\"\n",
+    "        self._setup_priority_order()\n",
+    "        for ag in self.agents.values():\n",
+    "            if ag.value is not None:\n",
+    "                self.message_queue.extend(ag._send_ok_messages())\n",
+    "\n",
+    "    def run(self, max_iterations: int = 10000) -> Optional[Dict[int, Any]]:\n",
+    "        \"\"\"\n",
+    "        Execute ABT jusqu'a quiescence (file vide), puis valide la solution.\n",
+    "        On ne declare le succes qu'apres vidage de la file : sinon des ok? peuvent\n",
+    "        encore modifier les vues et donner une fausse coherence locale.\n",
+    "        \"\"\"\n",
+    "        self.message_type_counts = {}\n",
     "        for agent in self.agents.values():\n",
     "            messages = agent.initialize()\n",
     "            self.message_queue.extend(messages)\n",
-    "        \n",
-    "        # Boucle principale\n",
+    "\n",
     "        iteration = 0\n",
-    "        while iteration < max_iterations and self.message_queue:\n",
-    "            # Prendre le prochain message\n",
+    "        while iteration < max_iterations:\n",
+    "            if not self.message_queue:\n",
+    "                if self.no_solution:\n",
+    "                    return None\n",
+    "                if self._check_solution() and self._verify_global_constraints():\n",
+    "                    self.solution = {a.id: a.value for a in self.agents.values()}\n",
+    "                    return self.solution\n",
+    "                break\n",
+    "\n",
     "            msg = self.message_queue.pop(0)\n",
     "            self.total_messages += 1\n",
-    "            \n",
+    "            self.message_type_counts[msg.msg_type] = self.message_type_counts.get(msg.msg_type, 0) + 1\n",
+    "\n",
     "            if msg.msg_type == 'stop':\n",
     "                self.no_solution = True\n",
     "                return None\n",
-    "            \n",
-    "            # Traiter le message\n",
+    "\n",
     "            receiver = self.agents.get(msg.receiver)\n",
     "            if receiver:\n",
     "                if msg.msg_type == 'ok?':\n",
@@ -512,31 +576,55 @@
     "                    new_messages = receiver.process_nogood_message(msg)\n",
     "                    self.total_nogoods += 1\n",
     "                elif msg.msg_type == 'addlink':\n",
-    "                    # Ajouter le lien (simplifie)\n",
+    "                    # L'agent de haute priorite renvoie son assignement courant au demandeur\n",
+    "                    requester = msg.content\n",
     "                    new_messages = []\n",
+    "                    if receiver.value is not None:\n",
+    "                        new_messages.append(Message(\n",
+    "                            sender=receiver.id,\n",
+    "                            receiver=requester,\n",
+    "                            msg_type='ok?',\n",
+    "                            content=(receiver.id, receiver.value)\n",
+    "                        ))\n",
+    "                        receiver.messages_sent += 1\n",
     "                else:\n",
     "                    new_messages = []\n",
-    "                \n",
+    "\n",
     "                self.message_queue.extend(new_messages)\n",
-    "            \n",
-    "            # Verifier convergence\n",
-    "            if self._check_solution():\n",
-    "                self.solution = {a.id: a.value for a in self.agents.values()}\n",
-    "                return self.solution\n",
-    "            \n",
+    "\n",
     "            iteration += 1\n",
-    "        \n",
+    "\n",
     "        return None\n",
-    "    \n",
+    "\n",
     "    def _check_solution(self) -> bool:\n",
-    "        \"\"\"Verifie si tous les agents ont une valeur coherente.\"\"\"\n",
+    "        \"\"\"Tous les agents ont une valeur et sont localement coherents avec leur vue.\"\"\"\n",
     "        for agent in self.agents.values():\n",
     "            if agent.value is None:\n",
     "                return False\n",
     "            if not agent.check_consistency(agent.value):\n",
     "                return False\n",
     "        return True\n",
-    "    \n",
+    "\n",
+    "    def _verify_global_constraints(self) -> bool:\n",
+    "        \"\"\"Verifie chaque arete du graphe (via les listes de voisins des agents).\n",
+    "        Une coherence locale chez chaque agent ne suffit pas : deux agents non\n",
+    "        relies par priorite mais relies par contrainte pourraient choisir des\n",
+    "        valeurs incompatibles. Cette passe finale rejette ces faux succes.\n",
+    "        \"\"\"\n",
+    "        assignment = {a.id: a.value for a in self.agents.values()}\n",
+    "        if any(v is None for v in assignment.values()):\n",
+    "            return False\n",
+    "        seen_edges: Set[Tuple[int, int]] = set()\n",
+    "        for aid, agent in self.agents.items():\n",
+    "            for nb in agent.neighbors:\n",
+    "                edge = tuple(sorted((aid, nb)))\n",
+    "                if edge in seen_edges:\n",
+    "                    continue\n",
+    "                seen_edges.add(edge)\n",
+    "                if not agent.constraint_func(aid, assignment[aid], nb, assignment[nb]):\n",
+    "                    return False\n",
+    "        return True\n",
+    "\n",
     "    def get_statistics(self) -> Dict:\n",
     "        \"\"\"Retourne les statistiques d'execution.\"\"\"\n",
     "        return {\n",
@@ -553,10 +641,10 @@
    "id": "f7e21456",
    "metadata": {
     "papermill": {
-     "duration": 0.005129,
-     "end_time": "2026-04-25T15:42:26.249783",
+     "duration": 0.003002,
+     "end_time": "2026-04-28T13:16:52.595123+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.244654",
+     "start_time": "2026-04-28T13:16:52.592121+00:00",
      "status": "completed"
     },
     "tags": []
@@ -605,10 +693,10 @@
    "id": "f4c51bed",
    "metadata": {
     "papermill": {
-     "duration": 0.004946,
-     "end_time": "2026-04-25T15:42:26.259926",
+     "duration": 0.003,
+     "end_time": "2026-04-28T13:16:52.602128+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.254980",
+     "start_time": "2026-04-28T13:16:52.599128+00:00",
      "status": "completed"
     },
     "tags": []
@@ -625,16 +713,16 @@
    "id": "d0fc21ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.271177Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.270615Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.278618Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.277854Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.612836Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.612836Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.619187Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.619187Z"
     },
     "papermill": {
-     "duration": 0.014858,
-     "end_time": "2026-04-25T15:42:26.279773",
+     "duration": 0.013345,
+     "end_time": "2026-04-28T13:16:52.620180+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.264915",
+     "start_time": "2026-04-28T13:16:52.606835+00:00",
      "status": "completed"
     },
     "tags": []
@@ -645,14 +733,14 @@
      "output_type": "stream",
      "text": [
       "=== Resultat ABT ===\n",
-      "Solution: {0: 'R', 1: 'G', 2: 'R', 3: 'R'}\n",
-      "Statistiques: {'total_messages': 1, 'total_nogoods': 0, 'solution_found': True, 'solution': {0: 'R', 1: 'G', 2: 'R', 3: 'R'}}\n",
+      "Solution: {0: 'R', 1: 'G', 2: 'R', 3: 'B'}\n",
+      "Statistiques: {'total_messages': 10, 'total_nogoods': 0, 'solution_found': True, 'solution': {0: 'R', 1: 'G', 2: 'R', 3: 'B'}}\n",
       "\n",
       "Verification:\n",
       "  Arete 0-1: R vs G -> OK\n",
       "  Arete 1-2: G vs R -> OK\n",
-      "  Arete 2-3: R vs R -> ECHEC\n",
-      "  Arete 3-0: R vs R -> ECHEC\n"
+      "  Arete 2-3: R vs B -> OK\n",
+      "  Arete 3-0: B vs R -> OK\n"
      ]
     }
    ],
@@ -703,10 +791,10 @@
    "id": "27c153c7",
    "metadata": {
     "papermill": {
-     "duration": 0.004998,
-     "end_time": "2026-04-25T15:42:26.290088",
+     "duration": 0.007335,
+     "end_time": "2026-04-28T13:16:52.633516+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.285090",
+     "start_time": "2026-04-28T13:16:52.626181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -714,46 +802,31 @@
    "source": [
     "### Interpretation : Analyse de la solution ABT\n",
     "\n",
-    "**Resultat critique** : La solution `{0: 'R', 1: 'G', 2: 'R', 3: 'R'}` contient des **violations de contraintes**!\n",
+    "**Resultat attendu** : la solution retournee par `system.run()` doit satisfaire **toutes** les aretes\n",
+    "du cycle 0-1, 1-2, 2-3, 3-0 ; chaque arete relie deux couleurs differentes.\n",
     "\n",
-    "| Arete | Couleurs | Statut | Attendu |\n",
-    "|-------|----------|--------|---------|\n",
-    "| 0-1 | R vs G | OK | Differentes |\n",
-    "| 1-2 | G vs R | OK | Differentes |\n",
-    "| 2-3 | R vs R | **ECHEC** | Devraient etre differentes |\n",
-    "| 3-0 | R vs R | **ECHEC** | Devraient etre differentes |\n",
+    "**Verification automatique** : la cellule precedente verifie chaque arete et imprime `OK` ou `ECHEC`.\n",
+    "Si l'execution affiche autre chose que 4 `OK`, c'est qu'un bug est present (a remonter via une issue).\n",
     "\n",
-    "**Diagnostic du probleme** :\n",
+    "**Comment l'algorithme y arrive** :\n",
     "\n",
-    "Cette erreur revele un bug dans l'implementation simplifiee d'ABT. Le probleme provient de la logique de verification de solution :\n",
+    "1. Chaque agent commence par choisir la premiere valeur compatible avec sa vue. Comme la vue est\n",
+    "   vide a l'init, l'agent 0 choisit `R`, puis 1 choisit `G` (different de `R`), puis 2 choisit\n",
+    "   la premiere valeur differente de `R` qu'il connaisse (`G`), puis 3 examine sa vue.\n",
+    "2. Si un agent decouvre que sa valeur est en conflit (apres avoir recu un `ok?` qui change sa vue),\n",
+    "   il essaie une autre valeur de son domaine. Si plus aucune valeur n'est compatible, il **backtracke** :\n",
+    "   il envoie un `nogood` a l'agent de plus haute priorite present dans sa vue, retire celui-ci\n",
+    "   de la vue et re-choisit.\n",
+    "3. Le `nogood` est appris par la cible : a sa prochaine evaluation, elle saura que cette combinaison\n",
+    "   de valeurs est interdite.\n",
+    "4. **Apprentissage `addlink`** : si un nogood mentionne un agent inconnu de la cible, celle-ci\n",
+    "   demande un `addlink` pour ouvrir un canal et recevoir sa valeur.\n",
+    "5. Le systeme s'arrete quand la file est vide (quiescence). A ce moment, `_verify_global_constraints`\n",
+    "   parcourt **chaque arete** du graphe pour valider la solution avant de la retourner.\n",
     "\n",
-    "1. **Agent 0** (priorite la plus haute) choisit 'R' et l'envoie aux agents 1, 2, 3\n",
-    "2. **Agent 1** recoit 'R' de l'agent 0, choisit 'G' (different de 'R')\n",
-    "3. **Agent 2** recoit 'R' de l'agent 0, choisit 'R' (pas de conflit avec 0 dans sa vue)\n",
-    "4. **Agent 3** recoit 'R' de l'agent 0, choisit 'R' (pas de conflit avec 0 dans sa vue)\n",
-    "5. **Le systeme declare la solution trouvee** sans verifier que 2 et 3 ont des couleurs differentes!\n",
-    "\n",
-    "**Root cause** :\n",
-    "\n",
-    "Les agents ne verifient les contraintes qu'avec les agents de **priorite superieure** (leur `agent_view`). Ils ne verifient pas les contraintes avec les agents de **priorite inferieure** ou de **meme niveau**.\n",
-    "\n",
-    "> **Bug identifie** : La methode `_check_solution()` verifie que chaque agent est coherent avec sa vue, mais ne verifie pas les contraintes entre agents de meme priorite ou entre agents de priorite inferieure.\n",
-    "\n",
-    "**Solution correcte** :\n",
-    "\n",
-    "Une implementation complete d'ABT devrait :\n",
-    "1. Continuer a envoyer des messages jusqu'a ce que TOUTES les aretes soient verifiees\n",
-    "2. Utiliser des nogoods pour apprendre que (2=R, 3=R) est invalide\n",
-    "3. Backtracker sur l'agent 2 ou 3 pour resoudre le conflit\n",
-    "\n",
-    "**Pourquoi ce bug existe dans ce notebook** :\n",
-    "\n",
-    "Cette implementation simplifiee a pour but de montrer le **flux des messages** ABT sans la complexite d'un algorithme complet. Elle illustre les concepts de :\n",
-    "- Priorite entre agents\n",
-    "- Messages ok? pour propager les valeurs\n",
-    "- Vue partielle (agent_view)\n",
-    "\n",
-    "Mais elle ne montre pas correctement le **backtracking distribue** qui resoudrait les conflits."
+    "**Note** : `_check_solution` (coherence locale agent par agent) ne suffirait pas a elle seule, car\n",
+    "deux agents non lies par priorite mais lies par contrainte pourraient choisir des valeurs\n",
+    "incompatibles si la file est encore active. La verification globale finale rejette ces faux succes.\n"
    ]
   },
   {
@@ -761,10 +834,10 @@
    "id": "61ec286b",
    "metadata": {
     "papermill": {
-     "duration": 0.005034,
-     "end_time": "2026-04-25T15:42:26.300149",
+     "duration": 0.006518,
+     "end_time": "2026-04-28T13:16:52.645005+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.295115",
+     "start_time": "2026-04-28T13:16:52.638487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -779,16 +852,16 @@
    "id": "b959393f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.311863Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.311376Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.557852Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.556883Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.657632Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.656632Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.852524Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.852524Z"
     },
     "papermill": {
-     "duration": 0.254059,
-     "end_time": "2026-04-25T15:42:26.559167",
+     "duration": 0.203508,
+     "end_time": "2026-04-28T13:16:52.853523+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.305108",
+     "start_time": "2026-04-28T13:16:52.650015+00:00",
      "status": "completed"
     },
     "tags": []
@@ -796,7 +869,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAJOCAYAAADMCCWlAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAt21JREFUeJzs3QV4VFfTwPEJBHcoFHcpUiQEC15ciganeHGXUqhRalTQFoqVIoVSCO5Q3CFIW4q0FHd3T/Z75vBuviQkIcTuZvf/e55bkt27d2elcO7cOXPcbDabTQAAAAAAAAAADiGO1QEAAAAAAAAAAP4fSVsAAAAAAAAAcCAkbQEAAAAAAADAgZC0BQAAAAAAAAAHQtIWAAAAAAAAABwISVsAAAAAAAAAcCAkbQEAAAAAAADAgZC0BQAAAAAAAAAHQtIWAAAAAAAAABwISVsAAAAAAAAAcCAkbQGLVapUSdzc3KL1OaZPn26eQ/90dLEp1uA0bv08Y5Ps2bObzdH07dtXXnvtNbl7967EBq1bt5Zs2bLJo0ePrA4FAAA4sXbt2kVo7Hbq1KlYO8YGAFdF0hZ4ifv378uXX34pHh4ekjRpUkmQIIFkzpxZypcvL0OGDJH//vvP6hADBmE6iAMC0++Efjf0OxJb/PvvvzJhwgQZOHCgJEuWLMR9bDab5M6d27y2OnXqhHk83Sf4lihRIsmXL58MGDBArl69GrDvsGHDQtw/tE33Vx9//LGcP39exowZE8XvBgAAiE10DKNjhFKlSkX4GBcuXDBjjIMHD0p0WrlyZcBYBjFvx44d5v2/deuW1aEAcFDuVgcAODKt8itXrpz8+eefJkGk1XRp0qSRa9euyZ49e2TEiBGSK1cuszmyhg0bSunSpSVDhgxWhwIHs379enE0n332mcSLF0969OgR6j6bNm0yF0z0pGjNmjXm5CZjxoyh7q//3/bs2TPg9+vXr5tjjBo1SpYsWSL79++X5MmTh1gprSdMuk/FihVfuN/+e968eaV+/frm74RevXpJkiRJIvjqAQBAbDZ79mxTCavnCsePHzfnEK9KxzWffvqpOU7RokWD3DdlyhTx9/d/5WPqjKCHDx+aMVbgpO348eNJ3FqYtNXPWYssUqZMaXU4ABwQSVsgDFo1pwnbTp06yeTJk19oY3Dy5El5/PixOLoUKVKYDQjO0S44aDJ13rx54u3tHWqVrfrpp5/Mn1op+91335mpfkOHDg11f221EPyERKt13377bVmxYoX4+PhIhw4dTBI2eGJWj61JW709rJMavaizcOFCmTt3rnTs2PEVXjUAAHAGem6giTgdD3Tp0sUkcD/55JMofY7ASddXoecxCRMmFGehiesnT5441WsCgOBojwCEYefOneZPrfgLqe9sjhw55I033njh9kOHDknTpk0lXbp0pp2C7qc9OjUhFR72KdpaCfiynq/6px5fzZgxI8jUbfvjw+oTu337djO9PHXq1GbQo69HB5cPHjwItWfr5cuXpW3btiYRptPMtYo3pFjDcuPGDenatau8/vrrkjhxYilRooQsWrQozMdoAr158+amYjh+/PimYkCrGsP7vtpduXLFJPt0erzGr69dp7Bp8i+4ZcuWSeXKlU3SW/ctUqSIqc589uxZuJ9PK7P189fPSb8P+r3Q74d+T0JrZ3DixAkZOXKkFChQwDzG3vpCKy/089H33P790iqM7t27m9cVmN6u3wmlz23/XgROSobW01bbgujz6PdBvxf6Hun3RL8vYX1f58yZYypC9L3Sz6lPnz6mqiO8fv31V3MhpEmTJqHuo1PIFixYIIUKFZLhw4eb5O60adNMEvZVaMw1atQI+IwiS98f/S7TKw4AANekSdpUqVKZMYFegNbfQxvL9OvXz4zB7K3X2rRpY8YjOp7ScbFq3759wPjNPr4I3NP26dOnZoym+wV3584dM4bTdlMh9bTV42iVrQp8/hA4KaoFLAULFjTH0TG7JqJv3rz50vdBj61t5XQ8q2MtnYGkM6J03BZ8vKbjby8vLzMrSsePxYsXNxfTg9PYdNaUvqcak75vq1evDjUGveCun4M+r+6rhQo6m8vPz++FffV9yJkzp3n+kiVLytatW0O8kK9jVB0fa/W0HjNLlizy3nvvvVDEY4918eLFZryq+2rMgePV8fOgQYNeGKfHppZmAKIflbZAGHTwoP75558XpiaFZtu2bWZwold+dbCmgypN/o4dO1aWL18uu3btMsnOqKJxaWJMj68JxQYNGgTc97JFCubPny8tWrQwA4lmzZqZJODatWvNgEqnnOugMfjVax1kassITWK+8847JlH422+/mde8b98+MzB5GU0I6yDor7/+kjJlyphp52fPnjUxVK9ePcTHLF261CQ648SJY6ah6yDp8OHD8sMPP5hYd+/ebQbJL3Ps2DGThL148aJ5Hfp+aYLy77//Nr2L7QNbpclZTe7qYLhly5ZmwKlx6G06mNMqipctIqf9UvU16lR+fc2adNYqDB2MaoWnxq5xBKfJaP2u6GBTq0H1s1FbtmwxydwqVaqYRLNWWxw4cEB+/PFHcyyd5m+vqtZEsQ7M//jjD/MdsU+7etn3QhfTeuutt8y0Pu3lrMfRRL1+zvocmlgNKamqn4UORvXz0cfrz+PGjTMnIKGdtITWrkGT0qHRxLDGqCc3OrjW/89+/vln2bx58ysvBLdu3Trzp77OyNILCXqiof+/63eKFgkAALgWHe80atTIjAl0jK3js7179wYkYdW9e/fM2hhHjhwxs3x0DKJjJR1jnjt3TvLnz2/G4tovv3PnzmZfpYnN4HQcqG3QdEw6adIk87x2mjDUZKKOPUOiCVgtBtCx0KxZs0K8X8eRmhDu3bu3Gb/qWE/HnXoR/2UVv5ocrVmzphnTffPNN2ZcqAlPLXzQ12en5zD16tWTVq1amfMnnbGk40w9bwq+bsGGDRvMjCxNiOr5VFhjWo1dE8f9+/c3f+pj9T3VZPa3334bsJ9+Rno8fZ81ka5JUz0/0PMKTaYHTmJrnHqup5+Lfk56LjN69Ghzrqjvd2C6n34uWlihBQY6Jm7cuLGcOXPGnGPq90Qfp+NqPYb9/DBt2rRhvq8AXIwNQKiWLFmil4JtyZIlsw0YMMC2Zs0a27Vr10Ld38/Pz5YrVy7zmNWrVwe5b9CgQeb2Dh06BLm9YsWK5vbAPvnkE3Pbxo0bX3iOn3/+2dynf9qdPHnS3Na2bdsQ4wrpMbdv37alSJHCliBBAtsff/wR5DU0a9bM7D98+PAgx9HbdOvevbvZz27q1Knm9i5duoT63oT0+t59990gt+t7Zn+OwLHqe548eXJbpkyZbKdOnQrymF9//dXs37Nnz3A9t6enp9l/8uTJL9x39uzZgJ+PHz9uc3d3t6VLl8525syZgNsfPXpkK1eunDnGzJkzgzxeb9PPM7D27dub24cMGRLk9hUrVpjbc+fOHeS91M9Qb8+cObPt9OnTL8R4+fJl2927d1+4fcaMGeZxn3/+eZDb7cfT70hIsmXLZrbAPv30U/OYVq1a2fz9/QNu379/vy1+/Pi2lClT2u7cufPC56nfp6NHjwbc/uDBA1vevHltceLEsZ0/f94WHmnTpjWfc1g8PDyCHHPDhg3m+Vu3bh3i/npfmjRpTJz2rXfv3rbChQubz7hPnz5hPp/9/x993Mv069fP7KsxAQAA1+Hr62vGAOvWrTO/6xhKx3PBxxkff/yx2W/hwoUvHMM+7tq7d+8L4+HAY7vAYzc9P9F9ly1bFmS/2rVr23LmzPnC+ULgY/bo0eOF8xC1detWc/vs2bNDHKsHvz2kGHW/Xr16BXltderUMWPJq1evBhkvBvbkyRNboUKFbG+99VaQ2/V4Ov77+++/w3zu0I6r9FwlceLEZjyvHj9+bMaIJUqUsD19+jRgv+nTp78wrp81a5Z5fn1vAps4caLZd/v27UFi1dep5xN2er6lt3///fcBt3377bdhjtMBgPYIQBj0aqpWNeq/vfqnVpPqVVCdEqNXZHWV+8D0qrNWVNaqVStg2rWdXtnVik2tEtSryFbTKUO3b982V/gLFy4ccLtWsurVcHd39xCneWv14Ndff232s9NWCbq/VhKEx8yZM00lQOCr7ErfM60gDWl/vSr+1VdfmZYIgWn1gFYo6FX5l9HKUV9fX6lQoYK8++67L9wf+Gq6fk5aCaBVtVrVa6dVyfr61cumwevnrFfP9Wr6hx9+GOS+2rVrS7Vq1cwCFSG1HNDpUlmzZn3hdq241WqB4LTqWRfS+v333yWytKWCVk/oolqBK4mLFStmPmuttg5eTaC0mldbTthpFaxWmWhlglZhv4y+X1qZrNPvQqOLgmk1sX5P7AuPaXWtvlfaMkG/0yHRFhq60IN902oHbbeh1R+Bq9Mjyx67VsoAAADXqrLVcYDO6FI6htJZZDpGDTwlX8crOjtOK2SDe9kMrpDo7CY9P9EZUXbawkAraPX5I0Jn4+nMLR2rahWwfdMZRToO3bhxY7iOE3gRWHvLAB3vBR6v6ngxcNw6ltOqVx3vBaez87R1WHgEPq4uLq3x63F1xt/Ro0fN7XpeoGNEPS/Qcxk7rfoNPoNP3xOtrtXWYYHfE33/VfD3pGrVqkHWjtDzLR2ra8sIAAgvkrbAS+iUGp06pFNxdJq4TmXXaS3a+0j/8dWpTHY6XUiFNEVbBzienp5mWrdO0bdaWLFqAkz7OumgQgc5geXNm/eFpKEOcnSQqsm8l9Hkq06v0sR3+vTpX7jfPgUsMG0ToLQFgvZ/Cr7pe2ofOL0saatCa8EQ3vdH2x1o2whNIIZFB4Qam/bG0l6nwdkH9SEdRx8TGp1qpQlunT6l770OgjWJru+tflcjQ4+hn7t+PoGT2OGJWQfywdmPEZ7vhr03cVir506dOtX8qa0R7PT16yJg2jtXk+0h0WSyXnyxb3pSoK0Y9Putg+qX9VMOL70wE1U9cgEAQOygSVlNzuo4Sce5elFeN21lpS2m7O2flBZ4hKedWHjpWFCn3WtBhr23qo4Vtd9tRJO2WpiiyVMtFtDxZuBN2zsEX0chJDo21fOJ4OcRKnDfVm2DoBfR7Wso6HNoy4KQLsTb1/EID219polxTT5rslSPq+NFZT/26dOnzZ867g3+ngZvvaDviR4z+Pthf03B35OQii80ERyensAAYEdPWyActA+R9lay9/HUf+h1pfoJEyaYVeLPnz9vKkc14aVCqxTUhZmUfT8rhSdW7bOk++nrt9NBT0h0cBNSY//QntfeozW4kOLRRcuUfbGE0Ggf0bD6BdsHaJkyZQp3nCHFo0lCvV0/94ge42Xfh9AeoxXf2ndXB4mafNakqL2SQBeLCL4QwquKTMwhfTfsVQvh+W7YX4cmukOit2sVi1400D5ggWkSV3sS64Jk3bp1e+lzaWJYKyO0t3CePHnMIhIhVby8KvuiayEl6QEAgHPSfqm6XoImbkOa/aXjl/AUDUSUzjzTnrarVq0yM4i02EQrQrWiNyJ0lpSO1UNbkyCq+q7qGhE6s1Fnwel5lY4zdbaXrlUQ0oX4wNWzYdFiAa3K1bGpzuzTildNCmv17uDBg83re1X6mDfffNOseRGSwDPzVNy4cUPc71UXzgXg2kjaAhGgV2y1Eb8uJKVXaLUJvVYZ2pNWekU9JJcuXQoz8Wlnbz2g0/ODC23696uKqlgj+ryhXaEPKR77Y/R9jkxlgr2C82XJ1sDPqfEEb8mggy29/WXvTWTe45Cmx+n3QVe91QGtVroGTnxrTNrWIrZ+L+yfjw7U7Un64LRqxF6xG9oiXzrNTdseBG75ERatrNCqDq2G0WOHVeUbHvbYWUQCAADXoclNHZeFVGCg4xed0TNx4kSTdNQE4qFDh8I83qu2SdCkp44PtUWCzgrUJPIHH3zw0seF9jwao7YwKFu2bLgTpSElOXX2lr0SVWlBiLJXsWqrCE2m6kK32oLMTpO2kaGLKesMLn3v9b2x0yrowOxjfB0H2meT2cfcWg0ceDyp74ku7qstuiLSxiIkUXUcAM6L9ghAJP6RDZ440p6f9oFCSFWgmlDSgU/gvp8hsfdQCim5aJ+2H9KV3PBUM4Yn1rNnz5qpWzqlKXCVbVTQZJ9ObdLBkT0BGPyKe3A6tUzt3LkzUs9tbzmwdu3aSL0/2qZBqz6LFi0a5jG0wkEHotrrV/tnBWc/9suOY6dT7jVpr+0Zglcq63fLXuUZme+Gfj76uevnE9L371VjflWalNcBdUh9n3/66Sfzp1a8a4V78M3eR9q+X3jooNzeAiQiVRfB2VufaCUGAABwfjr+0uRg3bp1xdvb+4VN+7jqWMPeUk1bGWjyL6TWTPYqTPs5RnjaS9kLPvS5li1bJrNmzTLjm/C0RgjteZo2bWrGjlosEJweO7xxaZFL4Nemv+sFevsaFjpO1XOqwONUTZaGtHbCq7CPfwNXterYUqt5A9PWdbr2xJQpU4IUy2gSPngbA31PdGys+4b0HdBzvVf1qp8zANdD0hYIg04zCm1xLR1MHDlyxFTm2as/9Wq0XoXVqUnBF4T6/PPPzRVfXZhJWymEpUSJEgELcAVOJGnSMqRpSprk1QGPJlvDq379+qZiWK9ka38mOx3c6LQhHbi0a9dOooMumqUDJ12cLTBNpgbu+WXXvn17kzzWioHAsdppQtTe9/Zl76tuW7ZsCXHAFThJ2bJlSzO1X6dABe4Tq3Hr+6Ne9v7o56yftyZbdRG1wFavXm2qCrTSU7834aGJWk3669SuwElgHVT26tUrzB6rr/Ld0MXGtA/akCFDggx2tYJVF1/T701ULt4VmE5l0xYPejITmCZydYEHrczQKhLtbRt809v1/fnll1/C3SZCTx70tRYsWDDgvYoMTehrpYu2XAAAAM5Pk7GalNVp/iHRfq06A8c+htfFZnUxLb0I3blzZ3O+oeNEvSivYy2l5xN6jqHVuXoxWlsuBK8SDU6TtJo4/OSTT8zFY10062Xs6xH07t3bxGdv7aDjsS5dupi4dPFcbcGlVcS6vodWp4Zn4VstXNDxro4rNVmq74/OUtTXb5+RVKdOHTOmrVmzpnmt2spAizWC95h9VV5eXub8SJ9bx/KjR482n0Pw1gQ6Vtf1MfR8T9tm6bhQ25DpQsT6GQSuhNXzF30vunbtasb3uu/YsWNNWy5tV6bnha/K/v7rOY4m2/X9j0jyF4ATswEIVf369fVfdlvu3Lltbdu2tQ0ZMsTWu3dvW/ny5c3tceLEsc2ZMyfIY7Zu3WpLnDixLV68eLaWLVuax1SqVMnsnytXLtuVK1eC7F+xYkVzX3Bly5Y1t5csWdI2cOBAW5MmTWzx48e3NWzY0Nz+888/B9lf93Nzc7O1bt3a9umnn9o+++wz26lTp8x9um9Ij5k3b54tbty4tiRJktg6dOhgGzx4sK148eIBz/vw4cMg++vtGm9IsmXLZrbwuHfvnq1QoULmeF5eXrb333/f1qpVK/Oe1alTJ8RYly9fbkuUKJGJV/cZMGCArWfPnra6devakiVLZqtRo0a4nvuff/6xZcyY0TyHfo7vvfee+UyrVKliS506dZB9R44cafZLkyaNrVu3buZzyJcvn7lNvxv+/v4vfX/0886ZM6e576233jLfhxYtWtjc3d3N90S/L4Hp90z3PXnyZIjx6+u2fyf79etn69ixo3k9ZcqUMX8G/wxWrlxp9s+TJ495n/V7MXPmzDA/N/3c9fPXx3l6eprvRfv27U28+v7r9yawTz75xOy7cePGF+IN7bsXms2bN5v9v/jiiyC3f/jhh+Z2fa6w6P9zut/cuXMDbrN/hvpY+9a3b19bhQoVzH0JEiSwbdiwIdRj2l/Dy577+PHjZj/9rgAAANfw9ttv2xImTGi7f/9+qPu0a9fOjHOvXbtmfr9+/boZx2bKlMmM7zNnzmzGgPb71ZIlS2wFChQwY8bAYyndL6Qxt45Ls2TJYvb9/PPPX7hfx5bBx2TPnj2z9erVy5Y2bVpzHhH8nGTy5Mnm3EDH4DrefvPNN83Y+cKFC2G+Jxqjnl/8999/turVq5sx5Ouvv27GUn5+fkH2/emnn8w4Vcdjb7zxhonPPrYMTH/v0aOHLby2b99uK126tIldx8ga95o1a0Ics44bN868pxqDjoH1sfq6a9asGWS/J0+e2L7++mtbwYIFzb6pUqUy++m51+3bt18aqz6HvjeB6dhcvwd6XhnWOQAA10TSFgjD0aNHbd98842tWrVqthw5cpgBmW6afNV/cH19fUN83J9//mnz9va2vfbaa2aApv9A9+nTx3b16tUX9g0taauDtjZt2phEog42dNChA43QkmDHjh2z1a5d25YyZcqAQZd9QBJW4mzLli22WrVqmcfpoDFv3ry2jz76yCRWg4uqpK19sNq5c2czSNT3VAc8CxcuDDNW/Tw0SanPo7HqQEkHj5p03bNnT7if+9KlS+bz0GSqHkff41KlStlGjRr1wr46YNbXrANVHZzp82ky9+nTp+F+f/Rz1xg1bv0+6PdCvx9//fXXC/u+LGmrg0VNaNoHt1mzZjWJ3Lt374b6Geh3WPfX5w4eY2iP0c9fvwf6fdD3SL8f+j0JnmSO6qSt0hMU3ex0cK8nM/q9PnHiRJiPXbdunXk+/X/WTn8Pvul7oe/dO++8Yzt06FCYxwxv0nbYsGFmv4MHD4b7tQIAADgbe9I2ttKxp54fdOrUyepQALg4N/2P1dW+AADY6TTATp06ybZt28LdOsJq2k5EWyJov2Zd/AMAAMBVaQsxHx8fuXfvnjg6XadCF0EL3ApB24FpezZtudWqVStL4wPg2tytDgAAgOADfe099umnn4Zr0ThHMGPGDDl9+rRZBRkAAACxg66L0a9fP9NjWBcl07UjtIBA1yzR2wDASiRtAQAORVf8nTZtmlnQTxf20EXoHJ1WZ+jidh4eHlaHAgAAgHDSRW6zZMki48aNkxs3bpiFadu0aSMjRox46eLRABDdaI8AAAAAAAAAAA4kjtUBAAAAAAAAAAD+H0lbAAAAAAAAAHAg9LQFAAAAooi/v79cuHDB9OMOvBo5AAAAoLRTra7fkjFjRokTJ/R6WpK2AAAAQBTRhK0uagMAAACE5ezZs5I5c+ZQ7ydpCwAAAEQRrbC1D8KTJ09udTgAAABwMHfu3DEX+e3jxtCQtAUAAACiiL0lgiZsSdoCAAAgNC9rpcVCZAAAAAAAAADgQEjaAgAAAAAAAIADIWkLAAAAAAAAAA6EnrYAAAAAAABwGH5+fvL06VOrwwAiJF68eBI3blyJLJK2AAAAAAAAsJzNZpNLly7JrVu3rA4FiJSUKVNK+vTpX7rYWFhI2gIAAAAAAMBy9oRtunTpJHHixJFKeAFWXXh48OCBXLlyxfyeIUOGCB+LpC0AAAAAAAAsb4lgT9imSZPG6nCACEuUKJH5UxO3+n2OaKsEFiIDAAAAAACApew9bLXCFojt7N/jyPRmJmkLAAAAAAAAh0BLBDgDtyj4HpO0BQAAAAAAAAAHQtIWAAAAAAAAABwIC5EBAAAAAADAIdXzeRSjz7fUO+Er7d+uXTuZMWOGdOnSRSZOnBjkvh49esiECROkbdu2Mn369CiOFM6OSlsAAAAAAAAggrJkySJz586Vhw8fBtz26NEjmTNnjmTNmtXS2BB7kbQFAAAAAAAAIsjDw8MkbhcuXBhwm/6sCdtixYoF2dff31+++uoryZEjhyRKlEiKFCkiPj4+AfffvHlTWrVqJWnTpjX358mTR37++Wdz35MnT6Rnz56SIUMGSZgwoWTLls0cy27UqFHy5ptvSpIkSUw83bt3l3v37gV5/ilTppj7EidOLA0bNjSPSZkyZZB9lixZYl6TPkfOnDnl008/lWfPnpn7bDabDBs2zLy2BAkSSMaMGaV3795hvj9hHc++aNfUqVNNPBqXvualS5cGvF+ZM2eWH3/8McgxDxw4IHHixJHTp0+b38+cOSP169eXpEmTSvLkyaVp06Zy+fJlc9+pU6fMvr6+vkGOMWbMGPMe6nOoQ4cOSa1atcwxXn/9dXnnnXfk2rVrAfvr56Tvr34uadKkkapVq8r9+/clupC0BQAAAAAAACKhQ4cOAclVNW3aNGnfvv0L+2mSdebMmaaVwt9//y39+vWT1q1by+bNm839H330kRw+fFhWrVolR44cMcnK1157zdw3btw4k8ycN2+eHDt2TGbPni3Zs2cPOLYmJnUfPa62bNiwYYO89957Afdv375dunbtKn369JGDBw9KtWrV5IsvvggS39atW6VNmzZmH41j0qRJprWDfb8FCxbI6NGjze3//vuvLF682CQyQ/Oy49lpIlcTrX/++afUrl3bJK5v3LhhXlOLFi1M1XJg+trLli0bkHTVhK3ur+/junXr5MSJE9KsWTOzr75HmmAN/Pko/V3bW+hz3Lp1S9566y2TZNfk7urVq03SV2NSFy9eNHHo56yfy6ZNm6RRo0YmiR1d3GzReXQAAADAhdy5c0dSpEght2/fNlUeAAAgfLSdwMmTJ00FqlZkxqaetprws1ewajJVvfHGG3L27Fnp1KmTqWTVROXjx48lderU8vvvv0uZMmUCjqH7PHjwwCQm69WrZ5K0mvQNTitaNSGrj9fq1JfRylBN0tqrRZs3b24qb5cvXx6wjyaM9Xd9DUqTm1WqVJEhQ4YE7PPLL7+Y5O+FCxdMZa4mXrUqNV68eC+N4WXHU/paPvzwQ/nss8/M71q9mjRpUpO4rlmzpkkwa6WuVsxqha8mafVPfYy+Pk3SaoWsfn/0M1CaIC5YsKDs2bNHSpQoYRLduq8mX7VCeP/+/eLp6WmSu5rU/fzzz02Cec2aNQFxnjt3LuAz1fetePHiJgZNFEf0+/wq40UqbQEAAAAAAIBI0HYGderUMclZreDUn+0VsnbHjx83yVmtcNWkpH3Tytv//vvP7NOtWzfTH7do0aImsbljx44gCWJNYObLl88kcNeuXRvk+JrM1QRppkyZJFmyZGZ6//Xr181zKk0+lixZMshjgv/+xx9/yPDhw4PE9+6775pkpx6nSZMmpnevtjnQ2xctWhSk1UFwLzueXeHChQN+1vYOyZMnlytXrpjf9b3Inz9/QLWtVtPqfRqL0spXTa7aE7aqQIECJlmu96kGDRpI3LhxTbxKP6fKlSsHVCprnBs3bgwSpybelX422sZC31utKtbn1SS9trKITiRtAQAA4PRGjBhhqjj69u0b5n7z5883A3StiNBB+cqVK2MsRgAAELvp1HlNBmprAv05OHt/2RUrVpjkq33TqlB7X1utGNU+rdo2QStRNVE4cOBAc59Wm2r1plakauJUp+57e3ub+7QCtG7duib5qS0M9u3bJ+PHjw/ohRteGqO2Kggc319//WVaIej4yF55OmHCBNPbVfvmVqhQQZ4+fRqh49kFr9p1c3ML6DWrtF2CPWmrf2oFrvaVDa/48eObNg2aUNf3Q48R+DPSON9+++0gceqmcerr04SvVvRq9a8mhL///nuTPNfPI7q4R9uRAQAAAAewd+9eM40vcAVHSLSSRXuVaa85PenRwbxWZej0uUKFCsVYvAAAIHbSRKImBDXhWKNGjRfu12SfTs3XRbMqVqwYZtVu27ZtzVa+fHkZNGiQfPfdd+Y+rUDVXq26acJWn1N7uWqSVpOcI0eOND1albYECEyTjDouCiz475oY1qRs7ty5Q41Pk7Wa4NStR48e5oK3JmL1scGF53jh0bJlS9MOQV+nJri1J7CdVuFqKwrdArdH0JYP+p4HbkOhYzpNOGt1sPakDRynJru18tbdPeR0qX6u2kdXt48//ti0SdDK3f79+0t0IGkLAAAAp6VVE1qZoVPYtFdZWMaOHWtOfPTESGkVi1ZU/PDDD0FODAAAAEKi1Zj26fj6c3DaskCrZrWKVhOs5cqVM31NdYEwTcZqklaTgdo7Vfuxag9c7TerSUml/WQzZMhgFsvSxKzOEEqfPr1pA6BJUa121QpQTabqMYOPX3r16mWqRvU4uo8uVKaVo4H74+rz68Vr7RmrSWF9Hm0doD1sdSyllcR+fn5SqlQpSZw4selPq0nc0Pq8vux44ZU9e3bx8vKSjh07mufX3r+B++bqDCkd840ZM8YkZLUCWBPj2rfWTt/H0qVLy+DBg02VrcZtp8lnHS/qBXxtS6G9h7WdhbaqmDp1qlmcbP369VK9enVJly6d7N69W65evRrw2UQH2iMAQDj52fzk9MPzcvDOYdlz+6Dsuf2HHLx7WC48uiz+tv+ftgEAcBw6ANeecjqYf5mdO3e+sJ9WyejtodGTKV1MIvAGAABclyZfw1pcSi8Kf/TRR2Zmjyb89IKxtkvQBavs0/h10S6dIWSflq+JQ3vS95tvvjGJSF1cS1siaCsnTYRqz1VNxn799demmnT27NnmOQLTClFN5Op+uv/q1atNAjlwmwId+2iiWPvl6nNoknP06NEBSVlNEGtyU4+lMWof3WXLloXaquBlx3sVrVq1Mgnfhg0bBkm4atJ5yZIlkipVKvOe6XhOe+7+9ttvLxxDk75aDR28fUXGjBlNolsTwpqY1SSwttXS16vvr36mW7Zskdq1a0vevHlN1a9WNWs7i+jiZrPZbNF2dACIxTQR++e9o7L39h/yz/2TcvrReXlmC7nBeoI48SVnoqySJ3EOKZuyuORJ8vwfXACAdfQE54svvjDT/vRkpFKlSmYhC63ACImeJGkPOq2wsNPpc9qH7fLlyyE+ZtiwYeb+4F62GjDgbGJ6dfeY9qqryQN4dY8ePTL9QTV5GTiJiOili4IdPXpUtm7dKq7gs88+MxXKf/75p2XfZ73InyJFipeOF2mPAADB3Ht2Xzbe2Ckrrm2QK0+uS1yJI34SdiXtY/8ncuT+cfnn/glZenWd5EiURWq/VlnKpSphEroAgJilPc369Olj2htE54mfVsIE7mOmg/DAKxcDAAA4Eu2NW61aNUmSJIlpjaAXrPUitSu0zDp16pRpe/UqbRmsRNIWAP5HJx6svb5Vpl+YL0/8n4pNnk9EeFnCNjD7vqcenpPxZ2fKrAsLpXvWNlIyRZFoixsA8CJdpOLKlStBFsTQ6W46rU0H69rWIHivOe0JF7yiVn/X20Oji4noBgAAEBvs2bPHtFi4e/euaSEwbtw4s0CXs+vZs6f8+uuvZpHZ4K0RHBVJWwAQMRW1P5yZIYfuHYuS49kTvnf97suIkxOkfKqS0ilTc0nmniRKjg8ACFuVKlXMKsaBtW/f3qxurItPhLQ4SJkyZcwCE9q/zE4rdfV2AAAAZzBv3jxxRdOnTzdbbELSFoDL23/nkHx7apI89Q+5X21UJG+339wrf9w9Ip/k7CM5EjNtFgCimy7UoYtwBKbTAHWRDPvtbdq0kUyZMgUs0qHtFHSVYV1UQhcv0564ulLw5MmTLXkNAAAAcF1xrA4AAKy089Z++fLEeNMOwf8V2iC8Kn+xmV65Hxz/Vo7d/y/angcAEH5nzpyRixcvBvzu5eUlc+bMMUlaXVHZx8dHFi9e/ELyFwAAAIhuVNoCcFn77vwlI09NidZkbWD6PLpg2af/jZUv8gwyi5UBAGLOpk2bwvxdNWnSxGwAAACAlai0BeCSLj2+Kt+cnBjQviCm6PNpVe9n/42T+88exOhzAwAAAACA2IGkLQCX42/zl3FnfhY/m3+MJ23N84u/3Hl2T6add80G8AAAAAAAIGwkbQG4nFXXNsnR+//FWFuEkOhzb7y507RoAAAAAAAACIykLQCXcvPpbZl5YYE4Ajdxk/FnZspT/6dWhwIAAAAAcGFubm5mAVY4DhYiA+BS1l3fJs9sfuIItDXDrWd3ZNftA1I+VUmrwwEAAAAAx/N9oZh9vl6HXmn3du3ayYwZM+Srr76S999/P+B2TYA2bNhQbLaYb8kH50DSFoDL8LP5yeprmyLUx/b8uhNyZfd5uXX4qtw5fkP8n/5/a4WGBzpHOKY44iYrrm4kaQsAAAAAsVTChAnl66+/li5dukiqVKmsDgeBPH36VOLFiyexEe0RALiMvbf/MJWtEXFs6gE5teCI3DpyLUjCNrJ0KbR/HpyQUw/PRdkxAQAAAAAxp2rVqpI+fXpTbRuWBQsWSMGCBSVBggSSPXt2GTlyZJD7L168KHXq1JFEiRJJjhw5ZM6cOWa/MWPGBOxz5swZqV+/viRNmlSSJ08uTZs2lcuXLwc5zo8//ii5cuWS+PHjS758+WTWrFlB7v/333+lQoUKJtlcoEABWbduXZD7nzx5Ij179pQMGTKYfbJlyxbma3v27Jn07t1bUqZMKWnSpJHBgwdL27ZtpUGDBgH7+Pv7m2Po69LXV6RIEfHx8Qm4f9OmTaZFw/r168XT01MSJ04sXl5ecuzYsSDPtWTJEvHw8DBx5cyZUz799FPz/HZ6DH399erVkyRJksgXX3zx0sdpNfSwYcMka9as5rPJmDGjeT1WI2kLwGXsvH1A4kT0rz03kSRZkkum6jnlteIZojQujWnXrf1RekwAAAAAQMyIGzeufPnll/L999/LuXMhF+Ts27fPJFibN28uf/31l0kSfvTRRzJ9+vSAfdq0aSMXLlwwCUxN8E6ePFmuXLkSJPGpCdsbN27I5s2bTbL1xIkT0qxZs4B9Fi1aJH369JEBAwbIoUOHTPVv+/btZePGjQHHaNSokUno7t69WyZOnGiSrIGNGzdOli5dKvPmzTNJ09mzZ5vkcWi0ylj3+fnnn2X79u1y586dF/rjasJ25syZ5vn+/vtv6devn7Ru3dq8jsA++OADk8z29fUVd3d36dChQ8B9W7duNe+Rvr7Dhw/LpEmTzPtnT8za6XurrSn0fdbHv+xx+l6PHj3a3K4JbY39zTffFKvRHgGAyzh2/4T4S8SqZCtOry9xEz7/K/PIRF+5tu9ilMWl7RqOPzgdZccDAAAAAMQsTRIWLVpUPvnkE/npp59euH/UqFFSpUoVk6hVefPmNQnEb7/91vTFPXr0qPz++++yd+9eU2mqpk6dKnny5Ak4hlahaiLy5MmTkiVLFnObJkK1elcfV6JECfnuu+/M8bp3727u79+/v+zatcvcXrlyZfMc+lxr1qwxFaVKE861atUKUs2rz1uuXDlTuaqVtmHRZPWQIUPMe6B++OEHWblyZcD9jx8/Ns+hz12mTBlzm1a7btu2zSRKK1asGLCvJlLtv7///vum8vjRo0emQlarY/U2reK1H+Ozzz6T9957z7zvdi1btjSJajtN3Ib1OH29WimtFdPaSkErbkuWtL6FIZW2AFzCA7+HcuXJtQg/3p6wjQ6atP33wcloOz4AAAAAIPppxakuSnbkyJEX7tPbypYtG+Q2/V0rO/38/ExFq1aW6hR+u9y5cwfpkavH0GStPWGrtL2BtiWwP2dozxP4fn28PWGr7IlUO036Hjx40LRW0DYBa9euDfU1375927RnCJzk1Mrj4sWLB/x+/PhxefDggVSrVs20dbBvmnD+77//ghyvcOHCAT9nyPB8lqu92viPP/6Q4cOHBznGu+++a9pK6PHt7Elvu5c9rkmTJvLw4UOTzNXbtVo5cMsFq1BpC8AlnHx4VhzZXb/7cuPpLUkdL6XVoQAAAAAAIkD7xNaoUcNUnWriM7bSxLFW865atcpUx2pbB61CDdyD9lXcu3fP/LlixQrJlClTkPu0h2xggRcNc3NzC2jpYD+OVttqe4fgtBLXTnvZBn/+sB6nSWxNmutr1ZYTWqWsFdDausHKRcxI2gJwCdee3BBHd/XJDZK2AAAAABCLjRgxwrRJ0CrVwPLnz2/6vQamv2ubBK1M1f21uvPAgQMBVapaoXrz5s0gxzh79qzZ7NW22mLh1q1bpuI28PPYWwHYnyfw/fp4rTK1V7Jq+4TgdJEz7ZWrm7e3t9SsWdP00k2dOnWQ/VKkSCGvv/66ac+gSWullcP79+8374PS59bkrLYhCNwKISLJ5GPHjpkK5Kh+nC6O9vbbb5utR48e8sYbb5hWFIErn2MaSVsALuGJzfqpDS/zLBbECAAAAAAInS5g1apVK7OYV2C6MJj2nNVeqpoI3blzp+n9OmHCBHO/Jgm1mrVz587y448/mgpPfYwmE+0Vp3q//fhjxowxSV6tCtVEqL0lwKBBg0xlbLFixcz+y5Ytk4ULF5oqUvsxNFGsSV2tJtVFw3Txr+D9dzWhq8eIEyeOzJ8/3/R81TYMIenVq5dZaEyTovo6tMetJpvtcSdLlkwGDhxoFh/TqlntlattFTSZrMnhwAnmsHz88cdSt25d03NWE8kam7Y+0AXXPv/88wg/Thcl00RzqVKlJHHixPLLL7+Y9/1lvXyjGz1tAbgImzg6f5vjxwgAAAAACJv2T7VP6bfTis158+bJ3LlzpVChQiaRqPsFbqOgPV61alUrVnVRL+2vqglP+9R/TYIuWbLE9LnVfTQBq31Yf/vtt4BjNGjQQMaOHWsWHtMFynShr59//lkqVapk7teEpfZs1R6u2oe2U6dOZvGvwPQ5v/nmG5MI1kTzqVOnzMJi+tiQDB48WFq0aCFt2rQx/XG1Z6y2iQjcskCT1boImyZ3tdpXK3e1XUKOHDnC/b7WqFFDli9fbnrsalylS5eW0aNHvzS5+rLHaTJ6ypQppvev9tTVBLcmu9OkSSNWcrPZyBIAcH6bb+ySsWd+jpJjHZnoK0cn7Q/4veGBzlFy3K/yDJZ8SXJGybEAANbQahWdJqjVI1o5AriKej6PxJkt9f7/xAOA6PHo0SPTR1WTeIGTfa7s3Llzpg2CJhGrVKkisYUmrDUxqxW/mqx1RY/C+D6Hd7xIewQALiFNvP9fcdNRvRYLYgQAAAAARI8NGzaYRbO0BYL2nH3vvfcke/bsAb1iHdXp06dNFau2aXj8+LFp+6AJy5YtW1odWqxG0haAS8iROGukHn9i3mG5f+6O+fnGH5eD3PfXqP9v2p6jSQFJmuXVK6uSxk3CImQAAAAA4MKePn0qQ4cOlRMnTpgWBV5eXjJ79mzT39aRadsE7QurfWt1Qr+2f9DqYK22RcSRtAXgEpLETSTp4qeRK0+uR+jx59f+J9f2XQzxvuOz/gz4OX2FrK+ctHUTN8mTOHtAk3YAAAAAgOvR3qu6xTbawkEXFUPUYiEyAC4jb+KcEscB/9rTpG3uxNmtDgMAAAAAADgIKm0BuIzSKYvJtlt7I/TY8lPflujiL/5SKkXRaDs+AAAAAACIXRyv5AwAoknJFEUluXtSccQq25yR7LkLAAAAAM7A39/f6hAAh/geU2kLwGW4u8WVmmkqic/lFeIvNnEENrFJndcqWx0GAAAAAFgqfvz4ZkGrCxcuSNq0ac3vrPuB2EYXYnvy5IlcvXrVfJ/1exxRJG0BuJRqacrJwiurxN/m5xBVtsnck0qZlMWtDgUAAAAALKUJrhw5csjFixdN4haIzRInTixZs2Y13+uIImkLwKWkiZ9KWmVoKDMu+DhElW33LO9I/DjxrA4FAAAAACynVYma6Hr27Jn4+VlfaANERNy4ccXd3T3SleIkbQG4nLppq8jac5vlgu2yuMW1prW3zc8mxRMUlJIpiljy/AAAAADgiDTRFS9ePLMBroyFyAC4XH+ZKZMmy6/NJmmpq2VtEfzuPZUxtb6QZcuWWRMEAAAAAABwWCRtAbiMBw8eSNu2baVbt27SonpTGZi9s0mgxiR9vvhu8eTTNwZIueJeUq9ePRk6dKiZ/gMAAAAAAKBojwDAJfzzzz/SuHFjOXHihPzyyy/SqlUrc7t/XJuMOT3tfx1mo1cccRN3N3f5MFcvKZg0ryxatEi+/fZbGTJkiOzevVt+/fVXSZcuXTRHAQAAAAAAHB2VtgCc3sKFC8XT01OePHlikqP2hK0qn6qkDM7RzSRT40TjX4l67MRxE8lneQaahK29V9N7770n69evl7///luKFSsm27dvj7YYAAAAAABA7EDSFoDTevr0qQwcONBU2NaoUUP27t0rhQoVemE/XQxszBufSJ7EOaI8BrdAzzHujU8lT+LsL+xTqVIl2b9/v+TMmdP8PHbsWNN7FwAAAAAAuCaStgCc0sWLF6VKlSoyZswYGTVqlMybN0+SJ08e6v4ZEqSTL/IMlI6Zmkk8N/dI97q1Pzpx3MSmd+57ObpKynihP3/GjBllw4YN0rt3b+nbt680b95c7t69G6kYAAAAAABA7ERPWwBOZ/PmzdKsWTOJEyeObNq0ScqVKxeux8VxiyN10r4l5VKVkPXXt8vKaxvlxtNbElfiiJ/4h+sY9n0zJkgvddO+JRVSlZJEcROG67Hx4sWTkSNHSpkyZaRDhw5SokQJWbBggRQsWDBcjwcAAAAAAM7BzcYcXABOQv86++6778zCXuXLlzcLe6VPnz7Cx/Oz+cv+O3/J3tt/yj8PTsi5R5fEP5TkrbtbXMmWMLPkTZJDyqb0lPxJcpuetRF17Ngx09bh5MmTMnXqVGnRokWEjwUAiDl37tyRFClSyO3bt8Oc4QE4m3o+j8SZLfUO30V4AACiarxIpS0Ap6B/2bVv314WLVokgwcPls8//1zc3SP3V1xctzhSIkURs6mn/k/l9KPzcvPpbXni/9QkZeO7xZO08dNI5oTpJa5b3Ch6NSL58uUzi6Z16dJFWrZsKTt27DBVuPHjx4+y5wAAAAAAAI6JpC2AWO/PP/80ValXr16VxYsXS/369aPleeLFiSe5Q1hILLokSZJEZs2aJWXLlpU+ffqYhdTmz58vWbJkibEYAAAAAABAzGMhMgCx2syZM6V06dKSOHFi8fX1jbaErVW0mrdbt26ybds2uXDhgnh4eMi6deusDgsAAAAAAEQjkrYAYqVHjx5J165dpW3btmbRsZ07d0ru3LnFWZUsWVL2799vkrY1atQw7R/8/cO3OBoAAAAAAIhdSNoCiHVOnTol5cqVk+nTp8uUKVNk2rRpptLW2b322muycuVK+fjjj8329ttvy40bN6wOCwAAAAAARDGStgBilVWrVplq0+vXr8v27dulU6dOpoWAq4gbN64MGzbMJG937dpl3ot9+/ZZHRYAAAAAAIhCJG0BxAp+fn6murROnTri5eVlEpXFixcXV1WzZk3TLiFt2rTm/Zg8ebLYbDarwwIAAAAAAFGApC0Ah3ft2jWpVauW6eP62WefydKlSyV16tTi6rJly2YWKOvQoYN06dJF2rdvLw8ePLA6LAAAAAAAEEnukT0AAESn3bt3S5MmTeThw4eydu1aqVq1qtUhOZQECRLIjz/+aKptNXF74MABWbBggVMvygYAAAAAgLOj0haAQ9Kp/hMmTJDy5ctLpkyZTCsAErahe+edd0yCW5Pb2jZi8eLFVocEAAAAAAAiiKQtAIdz//59ad26tfTo0UO6du0qmzdvlixZslgdlsN78803Ze/evVKlShVp2LChDB48WJ49e2Z1WAAAAAAA4BWRtAXgUI4dOyalSpWSJUuWyK+//irjxo2T+PHjWx1WrJEiRQrTHuG7776TkSNHmurkS5cuWR0WAAAAAAB4BSRtATgMHx8f8fT0FD8/P9mzZ480b97c6pBiJTc3NxkwYIBs2LDBJME9PDxk69atVocFAAAAAADCiaQtAMs9ffpU+vfvbxYcq127tknYFihQwOqwYr0KFSqYXsB58uSRypUry6hRo0yvYAAAAAAA4NhI2gKw1Pnz501C8fvvv5exY8fK3LlzJVmyZFaH5TQyZMgg69evN0lxrb7VxPidO3esDgsAAAAAAISBpC0Ay2zcuNFM3T958qRZbKx3795maj+ilru7u3zzzTeycOFCWbdunWlBcejQIavDAgAAAAAAoSBpCyDG+fv7y4gRI8wiWYUKFZIDBw6Il5eX1WE5vYYNG4qvr68kTJjQLPb2yy+/WB0SAESrH3/8UQoXLizJkyc3W5kyZWTVqlWh7j99+nRz8TDwpn9nAgAAADGNpC2AGHXr1i2TPBwyZIi8//77snbtWkmXLp3VYbkM7W+7a9cu8fb2lnfeeUe6d+8ujx8/tjosAIgWmTNnNhcJ9+3bZy5avfXWW1K/fn35+++/Q32MJncvXrwYsJ0+fTpGYwYAAACUO28DgJhy8OBBkyy8du2aLF26VN5++22rQ3JJiRMnNtVkZcuWlV69eplExvz58yVbtmxWhwYAUSr4vzNffPGFqb7Vi1cFCxYM8TFaXZs+ffoYihAAAAAIGZW2AGKEJgl1WqpWMO3fv5+ErcU0KdG5c2fZvn27XLlyxfQWXrNmjdVhAUC08fPzM4td3r9/3/x7FJp79+6Zi1hZsmR5aVWu0tkKusBj4A0AAACILJK2AKLVo0eP5N1335X27dtLq1atTJIwZ86cVoeF/9FFyXTacMmSJaVWrVry6aefmp7DAOAs/vrrL0maNKkkSJBAunbtKosWLZICBQqEuG++fPlk2rRpsmTJEtP3W/8+1J7r586dC/X4X331laRIkSJg02QvAAAAEFluNpvNFumjAEAITp48adohHD58WMaPHy8dOnSwOiSEQhMTOm34k08+kRo1aphkRZo0aawOCwAi7cmTJ3LmzBm5ffu2+Pj4yNSpU2Xz5s2hJm4De/r0qeTPn19atGghn332WaiVtoF7g2ulrSZu9fl0dgngKur5PBJnttSbRQkBAFFDx4t6sf9l40UqbQFEixUrVpgp97rw2I4dO0jYOrg4ceLIRx99JKtXr5a9e/eaz07/BIDYLn78+JI7d24pXry4qYotUqSIjB07NlyPjRcvnhQrVkyOHz8e6j5awauD7cAbAAAAEFkkbQFEec/ADz/8UOrWrSvly5c3i1zpCS9ih+rVq5uew7oIT7ly5WTixInChAwAzjazIHBl7Mv+TdP2ChkyZIj2uAAAAIDASNoCiDJXr141U+u1kkm3xYsXS6pUqawOC68oa9assmXLFtOLuFu3btKmTRuzcA8AxDZDhgwxf5+dOnXKJF/1902bNpke60r/ftPb7IYPHy5r166VEydOmAtYrVu3ltOnT0unTp0sfBUAAABwRe5WBwDAOezcuVOaNGliegeuW7dO3nrrLatDQiTodN8ffvjBLMCjyduDBw/KggULJG/evFaHBgDhduXKFZOYvXjxoukbVrhwYVmzZo1Uq1bN3K+9brU9jN3NmzfN33mXLl0yFx21pYK2+AlP/1sAAAAgKrEQGYBI0b9Cvv/+exkwYICULFlS5s2bJ5kyZbI6LEShv//+Wxo1amSSHtOnTzc/AwAit7AE4GxYiAwAgPBhITIA0e7evXtmRe0+ffpIz549zZRTErbOp2DBgmZRMm190bhxYxk4cKBZUR0AAAAAAEQPkrYAIuTIkSOmsnbFihXy22+/yejRo80q23BOevVPq6j1c9ZV16tUqWIqbwEAAAAAQNQjaQvglWmStkSJEuLm5mYqMJs2bWp1SIgB+nn37dtXNm7cKMePH5dixYrJ5s2brQ4LAAAAAACnQ9IWQLjpImPaCqF58+ZSr1492b17t7zxxhtWh4UYVq5cOTlw4IBZmEcrbr/99lvT2xgAAAAAAEQNkrYAwuXcuXNSqVIl+fHHH+WHH36Q2bNnS9KkSa0OCxZ5/fXXZe3atTJo0CB57733zOJk2kQdAAAAAABEHklbAC+1fv168fDwkLNnz8qWLVukR48eZqo8XJu7u7t89dVXsmTJEtMywdPTU/7880+rwwIAAAAAINYjaQsgVP7+/vLll19K9erVpWjRorJ//34pXbq01WHBwWirjH379kmSJEnM92PmzJlWhwQAAAAAQKxG0hZAiG7evCn169eXDz74wGyrVq2StGnTWh0WHFSuXLlk586dpt9x27ZtpUuXLvLo0SOrwwIAAAAAIFZytzoAAI5HK2q9vb3l1q1bsmLFCqldu7bVISEWSJQokUybNk3Kli1rWmho9a2Pj49kz57d6tAAAAAAAIhVqLQFEMRPP/0kXl5ekjp1apO8JWGLV9WxY0fZsWOHXL9+3fRCXrlypdUhAQAAAAAQq5C0BWA8fPhQOnToIJ06dTLT27dt20aFJCJMk7Wa9NcLAHXq1JGPP/5Y/Pz8rA4LAAAAAIBYgaQtAPnvv/9Mcu3XX3+V6dOny6RJkyRhwoRWh4VYLlWqVLJ06VL54osvzFarVi25du2a1WEBAAAAAODwSNoCLm7JkiVSvHhxuXv3ruzatctU2QJRJU6cODJ06FBZs2aNHDhwwFTg7t692+qwAAAAAABwaCRtARf17NkzGTJkiDRo0EAqV64svr6+UqRIEavDgpOqWrWqSdpmzpxZypcvL+PHjxebzWZ1WAAAAAAAOCSStoALunz5slSvXl2++eYbsy1cuFBSpkxpdVhwcpqw3bRpk3Tr1k169uwprVu3lvv371sdFgAAAAAADoekLeBitm/fLsWKFZPDhw/L+vXrZdCgQeLm5mZ1WHAR8ePHl7Fjx5r+ydqao2TJknL06FGrwwIAAAAAwKGQtAVchE5FHz16tFSqVEly5cplpqrrz4AVmjdvLnv37hV/f38pUaKEzJ8/3+qQAAAAAABwGCRtARegi4w1bdpU+vfvL3369JENGzZIhgwZrA4LLi5//vyyZ88eqVOnjvl+9uvXT54+fWp1WAAAAAAAWM7d6gAARK+///5bGjduLBcuXBAfHx/zM+AokiVLZlollC1b1lxU0Orb3377TTJlymR1aAAAAAAAWIZKW8CJzZkzx/QMjRcvnvj6+pKwhUPSnsq9evWSzZs3y6lTp8TDw0M2btxodVgAAAAAAFiGpC3ghB4/fiw9e/aUVq1aSaNGjWTXrl2SN29eq8MCwuTl5SX79++XQoUKSdWqVWXEiBGm5y0AAAAAAK6GpC3gZM6ePSsVK1aUKVOmyIQJE2TmzJmSJEkSq8MCwiVdunSydu1aGTJkiNkaNmwot27dsjosAAAAAABiFElbwIlosqtYsWJy8eJF2bp1q3Tr1s1MPQdik7hx48rnn38uy5Ytky1btkjx4sXl4MGDVocFAAAAAECMIWkLOAGdQv7ZZ59JzZo1xdPTU/bt22d62QKxWd26dc13OUWKFFKmTBn5+eefrQ4JAAAAAIAYQdIWiOWuX79ukluffPKJ2VasWCGvvfaa1WEBUSJnzpyyY8cOad26tXTo0EHeffddefTokdVhAQAAAAAQrdyj9/AAopOvr694e3vL3bt3ZeXKlabSFnA2CRMmND2adaGy7t27m+pbHx8fk9AFAAAAAMAZUWkLxEI2m00mTZokZcuWNQs37d+/n4QtnF779u1l586dcvv2bdPndvny5VaHBAAAAABAtCBpC8QyDx48kHbt2knXrl2lY8eOZsGxbNmyWR0WECOKFi1qKm0rVKggb7/9tnzwwQfi5+dndVgAAAAAAEQpkrZALPLvv/+aBZnmz58vM2fOlAkTJkiCBAmsDguIUSlTppRFixbJiBEjzFajRg25cuWK1WEBAAAAABBlSNoCscTixYvF09NTHj58KLt375Z33nnH6pAAy8SJE0cGDx4sv//+u/z111/i4eFhWicAAAAAAOAMSNoCDu7Zs2fy3nvvScOGDaVq1apm8bE333zT6rAAh1C5cmXT01lbhGjLhHHjxpmezwAAAAAAxGYkbQEHdunSJalSpYqMGjVKvvvuO/Hx8ZHkyZNbHRbgUDJlyiSbNm2SXr16SZ8+faRFixZy7949q8MCAAAAACDCSNoCDkoXGCtWrJj8888/snHjRhkwYIC4ublZHRbgkOLFi2cubsybN09WrFghJUuWlCNHjlgdFgAAAAAAEULSFnAwOrV75MiRZtp33rx55cCBA1K+fHmrwwJihSZNmsjevXvNBY4SJUrI3LlzrQ4JAAAAAIBXRtIWcCC3b98Wb29vGThwoKmsXb9+vaRPn97qsIBY5Y033jCL9dWrV8+0StCWCU+ePLE6LAAAAAAAws09/LsCiE5//fWXNG7cWC5fviwLFy40C48BiJikSZPK7NmzpWzZstKvXz9TfautEzJnzmx1aAAAAAAAvBSVtoADmDVrlpQqVUoSJUokvr6+JGyBKKAtEnr06GH6Q589e9b0iNbqdQAAAAAAHB1JW8BCjx8/lm7dukmbNm1ML86dO3dKnjx5rA4LcCp6QWT//v0maVu9enX54osvxN/f3+qwAAAAAAAIFUlbwCKnT582C4xNmzZNJk2aJNOnT5fEiRNbHRbglNKmTSurVq2SDz/80Gza7/bmzZtWhwUAAAAAQIhI2gIWWL16tXh4eMiVK1dk+/bt0rlzZzOVG0D0iRs3rnz66aeyYsUK2bFjhxQvXtxU4AIAAAAA4GhI2gIxyM/PT4YNGya1a9cOmLLt6elpdViAS9H///T/vdSpU4uXl5f89NNPVocEAAAAAEAQJG2BGHLt2jWpU6eODB8+3FT7LV++3CSNAMS87Nmzy7Zt26Rdu3bSqVMn6dChgzx8+NDqsAAAAAAAMNyf/wEgOu3Zs8csNHb//n1Zs2aNVKtWzeqQAJeXMGFCmThxopQpU0a6du1qqm8XLFgguXLlsjo0AAAAAICLo9IWiEY2m01+/PFHKVeunGTIkMEkhUjYAo6lbdu2snv3bnNRRfvcLlmyxOqQAAAAAAAujqQtEE00AdSmTRvp3r27dOnSRbZs2SJZs2a1OiwAIShcuLD4+vpK5cqVpUGDBjJkyBB59uyZ1WEBAAAAAFwUSVsgGvzzzz9mobGFCxfK7Nmz5fvvv5f48eNbHRaAMKRIkcL8P/vNN9/It99+K9WrV5fLly9bHRYAAAAAwAWRtAWimPbE9PT0NFV62su2ZcuWVocEIJzc3Nxk0KBBsn79ejl8+LAUK1ZMtm/fbnVYAAAAAAAXQ9IWiCJPnz6VgQMHire3t9SsWVP27t0rBQsWtDosABFQsWJFOXDggOTOnVsqVaoko0ePNj2qAQAAAACICSRtgShw4cIFeeutt2Ts2LEmufPbb79JsmTJrA4LQCTo4oFacdu3b1/p37+/NG3aVO7evWt1WAAAAAAAF0DSFoikzZs3i4eHh5w4cUI2bdpkEjw6xRpA7BcvXjzT39bHx0fWrFkjJUqUkL///tvqsACE048//mgWGkyePLnZypQpI6tWrQrzMfPnz5c33nhDEiZMKG+++aasXLkyxuIFAAAA7EjaAhGkU6V1waIqVapIgQIFZP/+/VK2bFmrwwIQDRo3biy+vr4miVuyZEmZM2eO1SEBCIfMmTPLiBEjZN++feb/YZ0VU79+/VAvvuzYsUNatGghHTt2NC1SGjRoYLZDhw7FeOwAAABwbW42mvQBr+z27dvSrl07Wbx4sbz//vvy2Wefibu7u9VhAYhm9+/fl65du8ovv/wiPXr0kJEjR0qCBAmsDgvAK0idOrWpoNfEbHDNmjUz/58vX7484LbSpUtL0aJFZeLEieE6/p07dyRFihRmrKDVvYCrqOfzSJzZUu+EVocAAHAS4R0vUmkLvKI//vhDPD09ZePGjbJkyRL56quvSNgCLiJJkiQyc+ZMM+V6ypQpZsGys2fPWh0WgHDw8/OTuXPnmqSstkkIyc6dO6Vq1apBbqtRo4a5PTSPHz82A+/AGwAAABBZZJqAVzBjxgxTZZcvXz5ZvXq15MqVy+qQAMQw7Vmtfw8UL15cvL29pVixYqZdQvXq1a0ODUAI/vrrL5OkffTokSRNmlQWLVpk2hqF5NKlS/L6668HuU1/19tDoxdvP/30U3EEVDoCAAA4DyptgXDQE70uXbqYlgja604rbkjYAq5NFyXTXtZaeV+zZk3TJsXf39/qsAAEoxdaDx48KLt375Zu3bpJ27Zt5fDhw1F2/CFDhpipbfaN6nsAAABEBSptgZc4efKkqabTRUumTp0aYg88AK4pTZo0smLFCvn888/lk08+MRd0Zs2aZW4H4Bjix48vuXPnNj9rhfzevXtl7NixMmnSpBf2TZ8+vVy+fDnIbfq73h4a7WtNb2sAAABENSptgTCsXLnSnODdvHnTrChNwhZAcHHjxjUJ21WrVplKPv07Q1epB+CYtCJe+9CGRNsorF+/Psht69atC7UHLgAAABBdSNoCoSxW8vHHH0udOnWkbNmysm/fPvHw8LA6LAAOTBcr0nYJ6dKlM39vaBWfzWazOizApWnrgi1btsipU6dMb1v9fdOmTdKqVStzf5s2bcxtdn369DE960eOHClHjx6VYcOGmYswPXv2tPBVAAAAwBWRtAWCuXr1qtSqVUu++OILsy1ZskRSpUpldVgAYoFs2bLJ1q1bTVW+LlamfbAfPHhgdViAy7py5YpJzGpf2ypVqpjWCGvWrJFq1aqZ+8+cOSMXL14M2N/Ly8ssLDh58mQpUqSI+Pj4yOLFi6VQoUIWvgoAAAC4IjcbZUBAgF27dkmTJk3MtMlff/3VnOABQET88ssv0rlzZ8mTJ49J/OifAJzfnTt3JEWKFGZRsuTJk8foc9fzeSTObKl3QqtDQBj4/gEAELXjRSptAREzhfmHH36QChUqSJYsWcwUZxK2ACKjdevWpsftw4cPxdPT01TrAQAAAAAQHiRt4fLu3bsnLVu2lF69ekm3bt1Mr7vMmTNbHRYAJ/Dmm2+afphVq1aVhg0bynvvvSfPnj2zOiwAAAAAgIMjaQuXpouMlCxZUpYtWyZz586VsWPHSvz48a0OC4AT0eku2h5BFzYaNWqUqeK/dOmS1WEBAAAAABwYSVu4rHnz5kmJEiXMz7owSbNmzawOCYCTcnNzk/79+8vGjRvl33//lWLFipkFywAAAAAACAlJW7icJ0+eSN++fU2Stk6dOrJnzx7Jnz+/1WEBcAHly5c3PbN1JfvKlSvLd999Z3pqAwAAAAAQGElbuJTz58+bRMn48eNl3Lhx8uuvv0rSpEmtDguAC0mfPr38/vvvMmDAABk0aJB4e3ubVUMBAAAAALAjaQuXsWHDBjMl+fTp07Jlyxaz8JhOWQaAmObu7i5ff/21LFq0yCRwtVXLX3/9ZXVYAAAAAAAHQdIWTs/f31+++uorqVatmhQuXNhMTS5TpozVYQGANGjQQHx9fSVRokRSqlQpmTVrltUhAQAAAAAcAElbOLWbN2+apMjQoUNlyJAhsmbNGkmXLp3VYQFAgDx58sjOnTulSZMm0qZNG+nWrZs8fvzY6rAAAAAAABZyt/LJgeh04MABady4sUncLlu2TOrWrWt1SAAQosSJE8v06dOlbNmypnWLVt/6+PhItmzZrA4NAAAAAGABKm3hlKZNm2ZaIKRMmdK0QyBhC8DRaY/tzp07y/bt2+Xq1avi4eEhq1evtjosAAAAAIAFSNrCqTx8+FA6duxotnfeeUd27NghOXLksDosAAg3T09Pc7FJe9zWrl1bhg0bJn5+flaHBQAAAACIQSRt4TROnDghXl5eMmfOHFNpO2XKFEmYMKHVYQHAK0udOrUsX75chg8fbjZN3l67ds3qsAAAAAAAMYSkLZyC9qwtXry43Llzxyzo0759e6tDAoBIiRMnjnz44YdmAcV9+/aZdgl79uyxOiwAAAAAQAwgaYtY7dmzZzJ06FCpV6+eVKhQwSQ2ihYtanVYABBlqlWrZhZWzJgxo5QrV04mTJggNpvN6rAAAAAAANGIpC1irStXrkiNGjXk66+/lhEjRsiiRYvMwmMA4GyyZMkiW7ZskS5dukiPHj1Mz+779+9bHRYAAAAAIJqQtEWspAuMFStWTA4dOiS///67DB482EwlBgBnFT9+fPn+++9N3269SKULlR07dszqsAAAAAAA0YAsF2IVnRI8duxYqVixouTIkcOssF65cmWrwwKAGNOiRQvT21bbw5QoUUIWLFhgdUgAAAAAgChG0haxxt27d6V58+bSt29f6dWrl2zcuFEyZcpkdVgAEOMKFiwoe/fulZo1a4q3t7cMGDBAnj59anVYAAAAAIAo4h5VBwKi0+HDh6Vx48Zy7tw5mTdvnjRp0sTqkADAUsmSJZPffvtNvLy8ZNCgQab6Vn/XBcsAAAAAALEblbZweL/++quULFnS9Kz19fUlYQsA/+Pm5mZmH2zatElOnDghHh4e5mcAAAAAQOxG0hYO68mTJ6YNQsuWLaV+/fqye/duyZcvn9VhAYDDKVu2rOnxXaBAAalSpYp88803pgc4AAAAACB2ImkLh3T27Fmz2NikSZNk/Pjx8ssvv0jSpEmtDgsAHNbrr78ua9eulcGDB5utYcOGcuvWLavDAgAAAABEAElbOJzff//dTPE9f/68bN26Vbp3726mAAMAwubu7i5ffvmlLFmyxLRJ8PT0lD/++MPqsAAAAAAAr4ikLRyGv7+/fPHFF1K9enUpVqyYmepbqlQpq8MCgFinXr16sm/fPrNYWenSpWX69OlWhwQAAAAAeAUkbeEQbty4YZIMH374oXz00UeyatUqee2116wOCwBirVy5csmOHTtMX/D27dtL586d5dGjR1aHBQAAAAAIB/fw7AREJ60G8/b2ltu3b8uKFSukdu3aVocEAE4hUaJE8tNPP4mXl5f06NHD/H3r4+MjOXLksDo0AAAAAEAYqLSFZXRl8ylTpphVz9OkSWPaIZCwBYCo17FjR1N1e/PmTSlevLisXLnS6pAAAAAAAGEgaQtLPHjwQDp06GCm67Zr1062bdsm2bNntzosAHBausCjVtrqhbI6deqYVjR+fn5WhwUAAAAACAFJW8S448ePm6m6v/32m8yYMUMmTpwoCRMmtDosAHB6qVKlkiVLlphFH7/88kupWbOmXL161eqwAAAAAADBkLRFjNJkgU7NvX//vuzatUvatGljdUgA4FLixIkjQ4cOlbVr18off/xhKnD172MAAAAAgOMgaYsY8ezZMxk8eLA0aNBA3nrrLfH19ZXChQtbHRYAuKwqVaqYXuJZsmSRChUqyA8//GB6jQMAAAAArEfSFtHu0qVLUq1aNRk5cqR8++23snDhQkmRIoXVYQGAy8ucObNs2rRJunfvLr169ZKWLVvKvXv3rA4LAAAAAFweSVtEK11gTKfeHjlyRNavXy8DBw4UNzc3q8MCAPxP/PjxZcyYMTJ37lxZtmyZlCxZUo4ePWp1WAAAAADg0kjaIlroFNvRo0dLpUqVJHfu3HLgwAGpWLGi1WEBAELRrFkz2bt3r/m5RIkSMm/ePKtDAgAAAACXRdIWUe7OnTvStGlT6d+/v/Tr189U2GbIkMHqsAAAL5E/f37Zs2eP1K1b1yRx+/btK0+ePLE6LAAAAABwOe5WBwDncujQIWncuLFcvHhRFixYII0aNbI6JADAK0iaNKnMmTNHvLy8ZMCAAab6VqtuM2XKZHVoAAAAAOAyqLRFlJk9e7aUKlXK9Ef09fUlYQsAsZT2HteFyTZv3iynT5+WYsWKyYYNG6wOCwAAAABcBklbRNrjx4+lR48e0rp1a1Nlu2vXLsmbN6/VYQEAIqlMmTKmJ3mRIkWkWrVq8tVXX4m/v7/VYQEAAACA0yNpi0g5c+aMVKhQQaZOnSoTJ06UGTNmSJIkSawOCwAQRdKmTSurV6+WoUOHmq1BgwZy8+ZNq8MCAAAAAKdG0hYRtmbNGvHw8JBLly7Jtm3bpEuXLmZKLQDAucSNG1c+++wzWb58ufn7vnjx4qYCFwAAAAAQPUja4pXp1Njhw4dLrVq1pESJErJ//37zJwDAudWpU0f27dsnqVKlMq0Tpk2bZnVIAAAAAOCUSNrilVy/ft2ctA8bNsxsK1askDRp0lgdFgAghuTIkUO2b98ubdq0kY4dO5rt4cOHVocFAAAAAE7F3eoAEHvs3btXvL295d69e7Jq1SqpUaOG1SEBACyQMGFCmTx5snh5eUm3bt3MjIsFCxZIzpw5rQ4NAAAAAJwClbZ4KZvNJpMmTZJy5cpJ+vTpTR9DErYAgHbt2snOnTvl7t27ps/tsmXLrA4JAAAAAJwCSVuE6cGDB9K2bVvp2rWrdOrUSbZs2SJZs2a1OiwAgIMoWrSo+Pr6SoUKFaRevXoydOhQefbsmdVhAQAAAECsRtIWofr333+ldOnSZsrrL7/8IuPHj5cECRJYHRYAwMGkTJlSFi1aJCNGjJCvv/7azMa4cuWK1WEBAAAAQKxF0hYhWrhwoXh6esrjx49l9+7d0qpVK6tDAgA4sDhx4sjgwYNl/fr1cujQISlWrJjs2LHD6rAAAAAAIFYiaYsgdErroEGDpHHjxlKtWjWz+FihQoWsDgsAEEtUqlTJ9D7PkSOHVKxYUcaOHWt6owMAAAAAwo+kLQJcvHhRqlSpIqNHj5ZRo0bJ/PnzJXny5FaHBQCIZTJmzCgbN26U3r17S9++faV58+ZmsTIgpn311VdSokQJSZYsmaRLl04aNGggx44dC/Mx06dPFzc3tyBbwoQJYyxmAAAAQJG0hbF582YzlVX72OqJdr9+/cxJCgAAEREvXjwZOXKkuQC4atUqKVmypBw+fNjqsOCC45sePXrIrl27ZN26dfL06VOpXr263L9/P8zH6UVrvZht306fPh1jMQMAAACKpK2L0ymr3377ramwzZ8/v+zfv1/Kly9vdVgAACfh7e1tWu3EjRvXJG5//fVXq0OCC1m9erW0a9dOChYsKEWKFDFVtGfOnJF9+/aF+Ti9cJ0+ffqA7fXXX4+xmAEAAABF0taF3b592/Sufe+992TgwIGmAkVPTAAAiEr58uUzi1rq1PSWLVtKr1695MmTJ1aHBRcd+6jUqVOHud+9e/ckW7ZskiVLFqlfv778/fffoe6ri7beuXMnyAYAAABEFklbF/Xnn3+Kp6enWeV70aJFMmLECHF3d7c6LACAk0qSJInMmjVLJkyYIJMmTTKLlJ09e9bqsOBC/P39TY/lsmXLhrnIql5kmDZtmixZskR++eUX8zgvLy85d+5cqH1zU6RIEbBpohcAAACILJK2LmjmzJlSunRpSZw4sZkeqJVPAABEN51y3q1bN9m6daucP39ePDw85Pfff7c6LLgI7W176NAhmTt3bpj7lSlTRtq0aSNFixY1FxcWLlwoadOmNRcbQjJkyBBTwWvfuBgBAACAqEDS1oU8evRIunbtKm3btpWmTZvKzp07JXfu3FaHBQBwMaVKlTI91DVpq4tCffHFF6aaEYguPXv2lOXLl5vFVjNnzvzKi+rpYq3Hjx8P8f4ECRKYhcsCbwAAAEBkkbR1EadOnZJy5cqZBTgmT54sP//8s6m0BQDACq+99pqsXLlSPvroI7PVq1dPbty4YXVYcMIFVzVhq62gNmzYIDly5HjlY/j5+clff/0lGTJkiJYYAQAAgJCQtHUBq1atMtVM169fl+3bt8u7775rpqgCAGCluHHjyqeffiorVqwwsz+KFy9u2vYAUdkSQfvSzpkzR5IlSyaXLl0y28OHDwP20VYI2uLAbvjw4bJ27Vo5ceKEqQhv3bq1nD59Wjp16mTRqwAAAIArImnrxLQy5OOPP5Y6deqY/mx6IqwnxAAAOJJatWqZf6O0+lYXiZoyZYqpkAQi68cffzR9ZitVqmQqZe3bb7/9FrDPmTNn5OLFiwG/37x501zgzp8/v9SuXVvu3LkjO3bskAIFClj0KgAAAOCK3K0OANHj2rVr0rJlS7PAy2effWYqSOLEIUcPAHBM2bNnl23btknfvn2lc+fOJkk2fvx4WvkgUsKT/N+0aVOQ30ePHm02AAAAwEokbZ3Q7t27pUmTJmbq35o1a6RatWpWhwQAwEvpgk5aGamzQ3ThzAMHDoiPjw+LZgIAAABwOZReOlk1yYQJE6R8+fKSKVMm04eNhC0AILbRHqN6AfL+/fumrc+SJUusDgkAAAAAYhRJWyehJ7a6UIYuuKHVSZs3b5YsWbJYHRYAABHy5ptviq+vr1SpUkUaNGgggwcPlmfPnlkdFgAAAADECJK2TuDYsWNSqlQpWbx4sVkdedy4cRI/fnyrwwIAIFJSpEghCxYskG+//VZGjhxpZo9cunTJ6rAAAAAAINqRtI3ltNefp6en+Pn5yd69e6VFixZWhwQAQJRxc3OTgQMHyoYNG+To0aPi4eFhFiwDAAAAAGdG0jaWevr0qfTv398sOFa7dm3Zs2ePFChQwOqwAACIFhUqVDC92nVRskqVKsno0aNNL3cAAAAAcEYkbWOh8+fPS+XKleX777+XMWPGyNy5cyVZsmRWhwUAQLTKkCGDrF+/Xvr162cuXDZt2lTu3LljdVgAAAAAEOVI2sYyGzduNFNDT548aRYb69Onj5k6CgCAK4gXL57pcau9btesWSMlSpSQQ4cOWR0WAAAAAEQpkraxhL+/v4wYMUKqVq0qhQoVkgMHDoiXl5fVYQEAYIlGjRqJr6+vJEiQwCzGOXv2bKtDAgAAAIAoQ9I2Frh165Y0bNhQhgwZIu+//76sXbtW0qVLZ3VYAABYKm/evLJr1y5p3LixtG7dWnr06CGPHz+2OiwAAAAAiDT3yB8C0engwYPi7e0t165dk6VLl8rbb79tdUgAADiMxIkTy4wZM6Rs2bLSu3dvU307f/58yZo1q9WhAQAAAECEUWnrwKZPny5lypQxi4zpitkkbAEAeJH2du/SpYts375dLl++bHq/a79bAAAAAIitSNo6oEePHsm7774r7du3l1atWsmOHTskZ86cVocFAIBD8/T0lH379pnFyWrVqiXDhw83PeEBAAAAILYhaetgTp48aaZ4zpo1S6ZOnWq2RIkSWR0WAACxQpo0aWTFihUybNgws9WpU0euX79udVgAAAAA8EpI2joQPcnUKZ268NjOnTulY8eOVocEAECsEydOHPn4449l1apVsnfvXvNvq/4JAAAAALEFSVsH4OfnJx9++KHUrVtXypcvbxZRKVasmNVhAQAQq9WoUcP0hE+fPr2UK1dOJk2aJDabzeqwAAAAAOClSNpa7OrVq+ak8quvvpIvv/xSFi9eLKlSpbI6LAAAnELWrFlly5Yt0qlTJ+natau0bdtWHjx4YHVYAAAAABAmkrYW0hYIWlH7559/yrp162TIkCFmSicAAIg6CRIkkPHjx8svv/wiCxYskNKlS8u///5rdVh4CW0Xpb39dXx048YNc5tWTp8/f97q0AAAAIBoR4bQAjo1c9y4cVKhQgXJli2bHDhwQN566y2rwwIAwKm1atVKdu/eLY8fPxZPT09ZuHCh1SEhFHpBO2/evPL111/Ld999ZxK4Sj8zTeICAAAAzo6kbQy7d++etGjRQvr06SM9e/aUTZs2SaZMmawOCwAAl1CoUCGzKFn16tWlcePGMmjQIHn27JnVYSGY/v37S7t27UxFdMKECQNur127tml3AQAAADg7d3Fljx+LXLgg8vChiJ6wubvrHEqRDBlEEieO8qc7cuSIOUE8e/as/Pbbb9K0adMofw4AABC25MmTy7x582TMmDEmabtnzx6ZO3euZNB//6PanTsily+LPHki4u//fKyRJMnzsUa8eFH/fE5CE+u6cFxweqH70qVLlsQEAAAAxCTXSto+eiSyb5/I8eMiJ0+KXLsW+r66GFj27CI5c4qUKCGSNGmknlqTtB07djQLoujJYf78+SN1PAAAEHFubm7Sr18/KVGihLmIqj3mNZGrrYsiRXuv7t37fJxx+rTI3bsh76c97F9//flYI18+kSJFSOIG60N8RxPewfzzzz+SNm1aS2ICAAAAYpJrJG0vXhTZulVk167nlS56oqTVLmG5eVNXwBA5eFBk8WIRDw+RihVFsmXTM71wP/WTJ09MFY/2sNW2CJMnT5akkUwAAwCAqFGuXDmzuJX+G6395UeMGCEDBgwwSd1w0zHF0aMiOm3/77///3abLezH6PhEq3B37nw+w6dcuedb6tTi6urVqyfDhw83iXSln8eZM2dk8ODBZtYSAAAA4OzcbLoqlrN68EDEx0dkz57wJWrDYn/8G2/oSibPK3Ff4ty5c6Z6x9fXV0aNGiU9evR4tZNAAAAQI7Sv7YcffmgWvmrYsKH8/PPPkiJFipc/UNsszZyp/+hHfqxhHyNUqSJSp45LV97evn1bvL29zRjq7t27kjFjRtMWoUyZMrJy5UpJoi0mHJRWCOt3R1+DtuKISfV8HokzW+r9//2N4Xj4/gEAELXjRedN2v71l8js2SL374dd6fKq9IRM+9E1aSJSunSoVbfr1683VTs6vW/+/PlSWvcFAAAObcmSJdK2bVszBX/BggVSuHDhkHf08xNZt05k5crnv0cmWRucji1ee02kbdvn7RNc2Pbt2+WPP/4wC7l6eHhI1apVxdGRtI0+JM0cG98/AACidrwYR5yNnjTNny+ii1dEdcLWfnxtsaAJ4SlTRJ4+DXa3v3z55ZdmVeoiRYqYKZckbAEAiB3q169vqjsTJ05s/v2eNWvWizvduycyapTI8uXPxwVRmbBVOna5fl1k5Ei9Ciyu5unTp+Lu7i6HDh2SsmXLSvfu3eW9996LFQlbAAAAIKo4V9JWT5p0iuLmzc9/j+4iYq3mHT9e5PFj8+vNmzfNyd4HH3wgQ4cOldWrV7NYBgAAsUzu3Lll586d0qxZM2nTpo107dpVHulipkoXx9KE7dmz0T+m0XHMokXPk8NOOjEqJPHixTMLt/ppNTMAAADgopwnaasnM3PmiPj6xuxz/vefyOTJcmDvXilevLiZxrd8+XL57LPPJG7cuDEXCwAAiDJaaTtt2jSZMmWKTJ8+XcqXLy9njhwRGTtW5Nq1qK+uDcvq1SJr14orsV8Av3HjhtWhAAAAAJZwF2exYYPIrl0x/7w2m9iOHZNdCxdKqlSpTC/bHDlyxHwcAAAgSunioZ06dZJixYqZRbH++/BDyZwxo8Sxoup12TKRDBlEQuux62R++OEHOX78uFmALFu2bC8sPKbtpwAAAABn5hxJ28uXRZYutezpdSmybgULSseuXSU+CVsAAJyKzqQ5NHmyJFmyxLo2Bbo4mfbTz5VLJFgC0xk1aNDA6hAAAAAAS7k7TR9bq3u9ublJ/LlzRT76SCRBAmtjAQAAUefGDUmyapXY/neh1hI6znn48Pliq+3aibP75JNPrA4BAAAAsFTsT9pu3y5y+rTVUTw/mbp9W2TVKi0PsToaAAAQVTRR+uyZdQnbwBeqtXd/qVIi+fOLK/D19ZUj2ktYRAoUKGCqngEAAABXELuTtpoo/f13cah4tm4VqVWLalsAAJyBLjr211/iMOLEEdm40emTtufOnZMWLVqYBV5Tpkxpbrt165Z4eXnJ3LlzJXPmzFaHCAAAAESr2J20/ecfkevXX/lh5+/dk6WnTsnm8+fl7xs35NKDB3LryRNJGT++FHntNWmTL5+8ky+fWYDklT1+LLJvn4iX16s/FgAAON6MHk2UapVrBPxz65Z8vX+/rD93Ti7evy/J4seXYq+9Ju8WKCBN8+R59QNqHIcPP08mv/aaOCtdAO7p06emyjZfvnzmtmPHjkn79u3NfatXr7Y6RAAAACBaxe6k7ebNETqRmnXsmAzZteuF2689emROqnTz+e8/WVSrlsTV478KTfRqBUyZMs9/BgAAsdPTpyLbtkU4Ybvy1ClpvHq1PPLzC7jt+qNH8vu5c2ZbeeaM/PzWW69+kVjHJppMrl9fnNXmzZtlx44dAQlbpT9///33Ur58eUtjAwAAAGLCK2YkHexE6tChCJ9IqfSJE0uH/Pnl81KlpFOBApIwbtyA+5adOiU/Hz0asRYJFy8+r4ABAACx1/Hjzxf/igCd1dNi3bqAhG2BVKlkeMmS0jxQde2Mo0dlgo5lItrb1ollyZLFVNoG5+fnJxkzZrQkJgAAACAmxd5K2wsXIpywzZosmcyqWtWcOLkHqqRtmSePvLVkScDvq06fNsncCDl7ViRt2og9FgAAWO/MmQi3Rhj7559y58kT83OyePFka6NGkjphQvO7jjzm/Puv+fnLffuka8GCrz6z5+ZNkQcPRBInFmf07bffSq9evWT8+PHi6ekZsChZnz595LvvvrM6PAAAACDaucfqE6kIapk3b4i3V86cWdIkTGimLqonEa3i1RMvjc/DI8IxAgAAi50+/XwGTQQsPXky4OdKmTIFJGxV41y5ApK2F+7fF98rV6RU+vSv/iQ61njjDXEWqVKlCtIq4v79+1KqVClxd38+XH327Jn5uUOHDtKgQQMLIwUAAACiX+xN2molayQWBgnJpfv35fb/qmJUyXTpInYgjUlP9AAAQOx16lSEkraP/fzMAmR2OZMnD3J/8N//vH791ZO2mtzUsZATJW3HjBljdQgAAACAw4i9Sdvr16M0YfvM3186b9pk/lTpEiWSroUKRS4+AAAQO2my9s6dCD305qNHEjjVmzx+/CD3Jwv2u32GzyvRC9c3bogzadu2rdUhAAAAAA4j9iZtQ1icIqLuPnkizdaskVX/a7mgveeW1q4taRMlivhBnz2LsvgAAEAMi8J/x4PX6toi2HIh2EFcYqxx5coVs/kHu1BfuHBhy2ICAAAAYkLsTdpGxQmPdlm4e1fqrlhhpiYqTdSuqFNHSrz+ukPEBwAAYpdUCROKdma1Bbo4HNjdYBeeX4voRWInHmvs27fPVN4eOXLkhSS39r318/OzLDYAAAAgJsTepG2wqYURoQt/1FuxQi7q6ssikjdlSllZt67kSpEi8vHFixf5YwAAAGv8b/GriEgQN67kS5VKjt68aX4/EazNwn+3bwf5/c3UqV/9SbSnrROPNXSxsbx588pPP/0kr7/+epAFygAAAABXEHuTtqlSRWohskUnTkjrdevkwf+mFpbPkEEW164dZHXnSMcHAABiJ00SJksmcvduhB5eL3v2gKTtpvPn5cajRwFjjPn//RewX6YkScQzIgufavVpypTirE6cOCELFiyQ3LlzWx0KAAAAYInYm7TNkkVk9+4IPXT+8ePSfO1a8f/fdLsU8eNLjaxZZdqRI0H209vfLVjw1Z8gblyRbNkiFBsAAHAQ2bOLHDoUoTYEvQsXlol//y13njwx7RDKL1wozfPkkcM3b8q848cD9htSvLjE1YvQr0ovWmfNKs6qSpUq8scff5C0BQAAgMuKvUlbPVGJYC+3v2/cCEjYqttPnsiHISSAsyVLFrGkrfZZc+ITKQAAXIL+W/733xEab2RKmlTmVKsmjVevlsd+fiZZ+/GePUH2afvGG9K9UKHIXcB2UlOnTjU9bQ8dOiSFChWSeMFaQdSrV8+y2AAAAICYEHuTtpkyPZ+66KiLcDjxiRQAAC6TtI1gGyZVJ3t2+bN5cxmxb5/8fu6cXH7wQJLEiyfFXntNuhQsKE3z5Il4bNp/P2lScVY7d+6U7du3y6pVq164j4XIAAAA4Api90Jk+fOLHD36yidUw0qWNFu00d50EelPBwAAHIcmVRMkEHn8OMKH0EVOp1WpEqVhmZ7+Hh7izHr16iWtW7eWjz76yCxEBgAAALiaCDRRcyAVK0aqAibaVKr0vAoYAABIrL5A7OX1PEnqSHTsU66cOLPr169Lv379SNgCAADAZTnYWcgr0kpbR1s5WXuulShhdRQAACAqaHLUkS4Q60XhvHlFnDyZ2ahRI9m4cWOkj/PVV19JiRIlJFmyZJIuXTpp0KCBHDt27KWPmz9/vrzxxhuSMGFCefPNN2XlypWRjgUAAABwjfYISitfdMrhggXiMCdSWpGTKJHVkQAAgKigydE33hD55x/HSN5qL//KlcXZ5c2bV4YMGSLbtm0zSdPgC5H17t07XMfZvHmz9OjRwyRunz17JkOHDpXq1avL4cOHJUmSJCE+ZseOHdKiRQuT8K1bt67MmTPHJHv3799vFkUDAAAAYoKbzeaoK3mFky5E8c03IhcvWnsypQlbXRDko49EEie2Lg4AABC1rl4V+eILsT17Jm5WX6zWpOG77zp9G6YcOXKEep8uRHbixIkIHffq1aum4laTuRUqVAhxn2bNmsn9+/dl+fLlAbeVLl1aihYtKhMnTnzpc9y5c0dSpEght2/fluTJk0tMqufzSJzZUu+EVoeAMPD9AwAgfMI7XozdlbYqblyRNm1Evv7a2jhsNnnWooW4k7AFAMC5pE0rj2vVkgTLllkbhy6K1ry50yds1cmTJ6PluDowVqlTpw51n507d0r//v2D3FajRg1ZvHhxiPs/fvzYbIEH4QAAAIBr97S1y5RJpHZty55e63unHz0qlXv0kAsXLlgWBwAAiHo6lb5Y376y8/Jl82++ZZo1E4nhyk1HoJPComJimL+/v/Tt21fKli0bZpuDS5cuvbAAmv6ut4dE2yhopYR9y5IlS6RjBQAAAJwjaauqVxcpVizmq0/ixJE4OXJI3g8/lP/++088PDzMlDsAABD7zZ07V0qWLCluceLIa0OGSJw0aZ63KbBinOPpKa5k5syZpp9tokSJzFa4cGGZNWtWhI+nvW0PHTpkPtOopL13tYLXvp09ezZKjw8AAADX5DxJWz2Batv2ea+3mKIJ4syZRbp3F69KleTAgQOSP39+qVKlinzzzTdRUhUCAABi3pMnT8xiV7ogVb169WT37t2Sx8NDpE8fkZQpYzZxW6mSyNtviysZNWqUdOvWTWrXri3z5s0zW82aNaVr164yevToVz5ez549TY/ajRs3SmYdu4Uhffr0cvny5SC36e96e0gSJEhgepEF3gAAAIDIcp6krXJ3F+nUSaRkyZh5vrx5n5+8JUoUMHVu3bp1MnDgQBk8eLA0atQooHcaAACIHc6dOycVK1Y0i0798MMPMnv2bEmqi40q7YU6YID+ox+9s3vsx65VS6RxY5foYxvY999/Lz/++KN8/fXXJmmum14QnzBhgowbNy7cx9EL6JqwXbRokWzYsCHMBc7sypQpI+vXrw9ym47v9HYAAAAgpjhX0ta+MNk774i0ayeSMGHUV8Lo8TQ5rCdQPXo8XxQkEHd3dxkxYoQsWbLEVHN4enrKH3/8EbUxAACAaPH7779LsWLFTOJ269atZkq9W/CEaYoUIu+9J1K16vNkalSPNfSYWq3Zq5dInToul7BVFy9eFC8vrxdu19v0vvDSz++XX36ROXPmSLJkyUxfWt0ePnwYsE+bNm1MiwO7Pn36yOrVq2XkyJFy9OhRGTZsmPj6+prkLwAAABBTnC9pq/TkRvu+ffyxSMGCz2+L7AmV/fHZsokMHSpSuXKYx9SKkH379kmSJEmkdOnSMmPGjMg9PwAAiDa6SNUXX3wh1atXN0nb/fv3S6lSpUJ/QLx4IvXrP6+61T63KrLJVfu4omxZkY8+EsmXT1xV7ty5TUuE4H777TfJkydPuI+j1bo666lSpUqSIUOGgE2PY3fmzJkgiWBNDGuSd/LkyVKkSBHx8fGRxYsXh7l4GQAAABDV3GzO3nhVX97p0yJbtojs26dnZf9/e3jYT8B0oF6hwvMTqFdIAGslh1Z5/Pzzz9K5c2cZO3asJNQKYAAA4BBu3rwp77zzjqxYsUI+/vhjs8XVmTvh5ecn8uefIroQ6fHjz8cJ9vFGeMYZOiaJH1/n5YuUL69NVcXVLViwQJo1ayZVq1aVsprEFpHt27ebtgWazG3YsKE4qjt37kiKFClMsjim+9vW83kkzmypN2NoR8b3DwCAqB0vuouz05Oh7Nmfb40aieze/fyE6tQpkbt3Q39c4sQiWbOK5MolUrq0SKpUEXp6Xe142rRp5oRDk7c6vU4rNsLTUw0AAEQvraht3LixGTBp0lYXvnplmuAtVuz5dunS87HGyZNawqkrmoX+OB1b6PhELwiXKPFCyyVXpp+JLv6mC5JplavSxV737NljKqEBAAAAZ+f8lbZhuXNH5Px5kUePRJ49e37SpSdMGTM+Xxk6invIBT4x1P5qEToxBAAAkabDn59++sn0KdVp73pBNbsmUKOSVtteuyZy+bLI06fPK3K1L36SJCKZMz+/QAynQ6Vt9KHS0bHx/QMAIHyotA0PfWNicDDt4eFhErc6BbNOnTry0UcfySeffPJqUzABAECkBG5d1KVLFxkzZkz0tC7SNgnp0j3fEC5x4sR5ceG3YPT+Z3qxHQAAAHBirp20tUCqVKlk6dKlMmLECJO03bVrl8yePVvSpk1rdWgAADi948ePi7e3txw7dkymT58ubdu2tTokBLJo0aJQ79u5c6eMGzfOLBoHAAAAODuSthZVkQwdOlRKliwpLVq0MBW48+fPl9LaOxcAAESLJUuWmCStXijVfqmFCxe2OiQEU79+/Rdu0wT7+++/L8uWLZNWrVrJ8OHDLYkNAAAAiElxYvTZEISuiHzgwAHJkiWLVKhQQX744QfTYw8AAEQdnUqvSb8GDRpI5cqVzaKgJGwd34ULF+Tdd9+VN99803yGBw8elBkzZki2bNmsDg0AAACIdiRtLZY5c2bZtGmTdOvWTXr16mUqSO7du2d1WAAAOIXLly9LtWrV5LvvvpNvvvlGFi5caJr+w3HpggyDBw+W3Llzy99//y3r1683Vba6YBwAAADgKkjaOoD48ePL2LFj5ddffzX9bkuVKiVHjx61OiwAAGK1bdu2SbFixeTIkSMm8Tdo0KCXLnIFa2liPWfOnLJ8+XIzLtqxY4eUL1/e6rAAAACAGOdmYz6+Q9ETy0aNGsm5c+fkp59+kqZNm1odEgAAsYoObcaMGWOStF5eXvLbb79JhgwZrA4L4ez7nyhRItNCKm7cuKHupxXTjurOnTummlsrhpMnTx6jz13P55E4s6XeCa0OAWHg+wcAQNSOF1mIzMHkz59f9uzZY3q4NWvWzKyUrFUn8eLFszo0AABixQCoY8eO4uPjIwMHDpQvv/ySf0NjkTZt2lANDQAAAJC0dUzJkiUzUwLLli0r/fv3N0ncefPmSaZMmawODQAAh6X9Txs3bmwWsFqwYIGZuYLYZfr06VaHAAAAADgEeto6KK0y0YXJNm/eLKdPnxYPDw/ZsGGD1WEBAOCQZs+eLSVLljRVtb6+viRsAQAAAMRqJG0dnPbi279/v1kxWVe/HjFihPj7+1sdFgAADuHx48fSs2dPad26tUnU7tq1S/LmzWt1WAAAAAAQKSRtY4F06dLJ2rVrZciQIWZr0KCB3Lx50+qwAACw1JkzZ6RChQoyZcoU+fHHH2XmzJmSJEkSq8MCAAAAgEgjaRtL6ArKn3/+uSxbtky2bt0qnp6ecvDgQavDAgDAEnoxU1sHXbp0SbZt2yZdu3ZlASsAAAAAToOkbSxTt25d2bdvn6RIkULKlCkj06ZNszokAABijLYIGj58uNSsWVNKlChhWgjpnwAAAADgTEjaxkI5c+aUHTt2mP59HTt2lE6dOsnDhw+tDgsAgGh1/fp1c/Fy2LBhZluxYoWkSZPG6rAAAAAAIMq5R/0hERMSJkxoevjpQmXdu3c3lUY+Pj4moQsAgLPx9fUVb29vuXv3rqxatUpq1KhhdUgAAAAAEG2otI3l2rdvLzt37pTbt29L8eLFTc9bAACchc1mk0mTJknZsmXNwpx6kZKELQAAAABnR9LWCRQtWtT0udUVtOvVqycffPCB+Pn5WR0WAACR8uDBA2nXrp1ZZExbAelCnNmyZbM6LAAAAACIdiRtnUTKlCll0aJFMmLECLNVr15drly5YnVYAABEyL///iulS5eW+fPny6xZs2T8+PGSIEECq8MCAAAAgBhB0taJxIkTRwYPHiy///67HDp0SDw8PMyCZQAAxCZ6EdLT01MeP34se/bsMQtvAgAAAIArIWnrhCpXrmx6/ukU0ooVK8q4ceNMT0AAABzZs2fP5L333pNGjRpJtWrVZO/evVKoUCGrwwIAAACAGEfS1kllypRJNm3aJL169ZI+ffpI8+bNzYrbAAA4oosXL0qVKlVk1KhRMnLkSNMWIXny5FaHBQAAAACWIGnrxOLFi2dOfufNmycrV66UkiVLyuHDh60OCwCAILZs2WJa+mgf240bN0r//v3Fzc3N6rAAAAAAwDIkbV1AkyZNzBRT7Xmridu5c+daHRIAAKZ1z3fffSdvvfWW5MuXz7T2KV++vNVhAQAAAIDlSNq6iDfeeEN2794t9erVkxYtWkjv3r3lyZMnVocFAHBRt2/fFm9vbxk0aJAMHDjQLKKZPn16q8MCAAAAAIfgbnUAiDlJkyaV2bNnS9myZaVfv36m+lZ7BmbOnNnq0AAALuSvv/6Sxo0by+XLl2XRokXSoEEDq0MCAAAAAIdCpa2L0R6BPXr0kK1bt8q5c+ekWLFiproJAICYMGvWLClVqpQkSpRI9u3bR8IWAAAAAEJA0tZF6Qmz9g7UpG316tXliy++EH9/f6vDAgA4qcePH0u3bt2kTZs20rRpU9m5c6fkzp3b6rAAAAAAwCGRtHVhadOmlVWrVslHH30kH374oel3e/PmTavDAgA4mdOnT0u5cuVk2rRpMnnyZPn5558lceLEVocFAAAAAA6LpK2Lixs3rnz66aeyYsUK2bFjh3h4eJjpqgAARIXVq1ebf1uuXbtm/p159913TaseAAAAAEDoSNrCqF27tmmXkCZNGrNQ2dSpU8Vms1kdFgAglvLz85Nhw4aZf19Kly5tLggWL17c6rAAAAAAIFYgaYsA2bNnl23btkm7du1MJVSHDh3kwYMHVocFAIhltKpWk7XDhw8327JlyyR16tRWhwUAAAAAsYa71QHAsSRMmFAmTpwoZcqUka5du8qBAwfEx8eHxWIAAOGyZ88e8fb2locPH8qaNWukWrVqVocEAAAAALEOlbYIUdu2bWX37t1y//598fT0lCVLllgdEgDAgWlLnQkTJpgFxzJmzGha7pCwBQAAAICIIWmLUBUuXFh8fX2lcuXK0qBBA3n//ffl2bNnVocFAHAweoHvnXfekR49ephZGlu2bJEsWbJYHRYAAAAAxFokbRGmFClSyMKFC+Wbb76R7777zlRNXb582eqwAAAO4tixY1KqVClZtGiRzJkzR8aNGyfx48e3OiwAAAAAiNVI2uKl3NzcZNCgQbJ+/Xo5cuSIFCtWzCxYBgBwbQsWLJASJUqYWRjay7ZFixZWhwQAAAAAToGkLcKtYsWKZmEyXZSsUqVKMnr0aNPDEADgWp4+fSoDBgwwC47VqlVL9u7dKwULFrQ6LAAAAABwGiRt8UoyZMhgKm779esn/fv3l6ZNm8qdO3esDgsAEEMuXLggb731lmmDMGbMGJk7d64kS5bM6rAAAAAAwKmQtMUrixcvnnz77bfi4+Mja9asMVNjDx06ZHVYAIBotmnTJvHw8JATJ06Yn/v06WNa6AAAAAAAohZJW0RY48aNxdfX1yw4o4vQzJ492+qQAADRQFvh6IKUVapUkQIFCphWOWXLlrU6LAAAAABwWiRtESl58+aVXbt2SaNGjaR169bSo0cPefz4sdVhAQCiyK1bt6Rhw4YyePBgs61du1bSpUtndVgAAAAA4NTcrQ4AsV+SJElk5syZpupKp8pq9e38+fMla9asVocGAIiEP/74w8yquHbtmixdulTefvttq0MCAAAAAJdApS2ihPY07Nq1q2zbtk0uXbpkeh5qNRYAIHaaPn26lC5d2iwytm/fPhK2AAAAABCDSNoiSumiZPv37zd/1qxZU4YPHy7+/v5WhwUACKdHjx5J586dpX379tKyZUvZsWOH5MqVy+qwAAAAAMClkLRFlEuTJo2sWLFChg0bZra6devK9evXrQ4LAPASJ0+eNK1utOXN1KlT5aeffpJEiRJZHRYAAAAAuByStogWceLEkY8//lhWrVolu3fvNu0S9u7da3VYAIBQrFy5UooXLy43b96UnTt3SseOHa0OCYi0LVu2mNYeGTNmNK2cFi9eHOb+mzZtMvsF37T1EwAAABCTSNoiWtWoUcO0S3j99delXLlyMmnSJLHZbFaHBQD4Hz8/P/noo4+kTp065u9p7V9brFgxq8MCosT9+/elSJEiMn78+Fd63LFjx+TixYsBW7p06aItRgAAACAk7iHeCkShbNmyydatW6V///5msTLtj/jjjz9K4sSJrQ4NAFza1atXTd/aDRs2yJdffimDBw82MyUAZ1GrVi2zvSpN0qZMmTJaYgIAAADCgzMzxIgECRKYKpdZs2bJ/PnzzYrk//77r9VhAYDL2rVrl2ld88cff8jatWtlyJAhJGyB/ylatKhkyJBBqlWrJtu3b7c6HAAAALggzs4Qo1q3bi179uyRx48fi6enpyxatMjqkADApWiLmh9++EEqVKggWbJkkQMHDkiVKlWsDgtwCJqonThxoixYsMBs+v9IpUqVTKun0OiY5s6dO0E2AAAAILJI2iLGFSpUyCxKptUrjRo1kkGDBsmzZ8+sDgsAnN69e/dMO4RevXpJ9+7dzaJLmTJlsjoswGHky5dPunTpYhbl8/LykmnTppk/R48eHepjvvrqK0mRIkXApoleAAAAILJI2sISyZMnN20SRo4caU6EtMpLF/oAAESPo0ePSsmSJWXZsmXy22+/yZgxYyR+/PhWhwU4PP3/5vjx46Her61Fbt++HbCdPXs2RuMDAACAcyJpC8u4ubmZxck2btxo+ttqb8UtW7ZYHRYAOJ158+ZJiRIlzM8606Fp06ZWhwTEGgcPHjRtE8Lq268XowNvAAAAQGSRtIXlypcvb3rF6ZTEt956S7777jvTcxEAEDlPnjyRvn37SrNmzaRu3bqmp3j+/PmtDguI0ZYgmnTVTZ08edL8fObMmYAq2TZt2gTsrxXoS5YsMZW1hw4dMv//bNiwQXr06GHZawAAAIBrcrc6AEClT59efv/9d/nwww9Nj9udO3eaPnLaGw4A8OrOnz9vKmq1snbcuHHSs2dPM8MBcCW+vr5SuXLlgN91ho9q27atTJ8+3bRmsidw7Rc6BgwYYP7/SZw4sRQuXNiMTwIfAwAAAIgJbjZKGuFgFi9ebE6m0qVLZ1Zu1hMmAED4aWVg8+bNTc9a7R9epkwZq0MCXMadO3fMRWftbxvTrRLq+TwSZ7bUO6HVISAMfP8AAIja8SLtEeBwGjRoIPv27TMVLqVLl5ZZs2ZZHRIAxAr+/v5mJftq1apJkSJF5MCBAyRsAQAAACAWImkLh5Q7d27TIkGn9mqvuW7dusnjx4+tDgsAHNbNmzfNRa+hQ4eabfXq1ZI2bVqrwwIAAAAARAA9beGwtNL2559/lrJly5pejNqXTqf5Zs+e3erQAMChaEVt48aN5datW7J8+XKpU6eO1SEBAAAAACKBSls4NF00591335UdO3bItWvXpHjx4qZ6DADwnC7aqC0QUqVKZVrLkLAFAAAAgNiPpC1iBU3WajJCe9zWrl1bPvnkE/Hz87M6LACwzMOHD6Vjx45m0zYy27dvlxw5clgdFgAAAAAgCpC0RayROnVqWbZsmQwfPlw+++wzk7zV6lsAcDUnTpwQLy8vmTNnjmkjM3nyZEmYkFWtAQAAAMBZkLRFrBInThz58MMPZc2aNbJ//37x8PCQPXv2WB0WAMQYvXilsw/u3r1rFmxs166d1SEBAAAAAKIYSVvEStWqVTNJ24wZM0q5cuVkwoQJYrPZrA4LAKLNs2fPZOjQoVKvXj2pUKGCWZyxaNGiVocFAAAAAIgGJG0Ra2XJkkW2bNkiXbt2lR49esg777wj9+/ftzosAIhyV65ckRo1asjXX38tI0aMkEWLFknKlCmtDgsAAAAAEE1I2iJWix8/vowbN870ddQkRqlSpeTYsWNWhwUAUWbHjh1SrFgxOXTokKxfv14GDx5sWsUAAAAAAJwXZ31wCi1atDC9bXX6cIkSJcTHx8fqkAAgUrTly9ixY6VixYqSI0cOOXDggFSqVMnqsAAAAAAAMYCkLZxGwYIFZe/evVKrVi1p0qSJ9O/fX54+fWp1WADwynSRsebNm0vfvn2ld+/esnHjRtPDGwAAAADgGtytDgCISsmSJZO5c+eKl5eXDBw40FTfzps3j2QHgFjj8OHD0qhRI7lw4YLMnz9fvL29rQ4JAAAAABDDqLSF03Fzc5M+ffrIpk2b5OTJk6YXpP4MAI7u119/lZIlS4q7u7uZOUDCFgAAAABcE0lbOK2yZcuaHpDaNqFKlSpm1XXtEQkAjubJkyfSq1cvadmypTRo0EB2794t+fLlszosAAAAAIBFSNrCqaVLl07Wrl1rVlt///33pWHDhnLr1i2rwwKAAGfPnjWLjU2aNEkmTJggs2bNkiRJklgdFgAAAADAQiRt4fR0mvGXX34pS5cuNW0SPD095eDBg1aHBQDy+++/i4eHh5w/f162bt0q3bp1My1eAAAAAACujaQtXMbbb78t+/btM4uVlSlTRqZPn251SABclL+/v3z++edSvXp1k7Tdv3+/lCpVyuqwAAAAAAAOgqQtXEquXLlkx44dpm9k+/btpXPnzvLo0SOrwwLgQm7cuGEuIn388cfy0UcfycqVK+W1116zOiwAAAAAgANxtzoAIKYlSpRIfvrpJ/Hy8pIePXqY6lsfHx/JkSOH1aEBcHL69423t7fcuXNHVqxYIbVq1bI6JAAAAACAA6LSFi6rY8eOsnPnTrl586aZnqwJFACIDjabTaZMmWIuFmlVrSZvSdgCAAAAAEJD0hYurVixYiZ5Ur58ealbt658+OGH4ufnZ3VYAJzIgwcPAtqxdOjQQbZt2ybZs2e3OiwAAAAAgAMjaQuXlypVKlm8eLF8+eWX8tVXX0mNGjXk6tWrVocFwAkcP37cLHw4b948mTFjhvz444+SIEECq8MCAAAAADg4kraA/o8QJ44MGTJE1q5dK3/++adpl6CtEwAgovRiUPHixU2l7e7du6VNmzZWhwQAAAAAiCVI2gKBVKlSRQ4cOCBZsmSRChUqyPfff296UQJAeD179kwGDx4sDRs2NH+n+Pr6yptvvml1WAAAAACAWISkLRBMpkyZZNOmTdKjRw/p3bu3tGzZUu7du2d1WABigUuXLkm1atVk5MiR8u2338qCBQskRYoUVocFAAAAAIhlSNoCIYgfP76MGTNGfvvtN1m2bJmULFlSjhw5YnVYAByYLjCmrVWOHj0qGzZskIEDB4qbm5vVYQEAAAAAYiGStkAYmjZtKnv37jU/lyhRwiRxASAwbaEyatQoqVSpkuTOnVv2799v2qsAAAAAABBRJG2Bl8ifP7/s2bNH3n77bWnevLn07dtXnjx5YnVYABzAnTt3pEmTJjJgwADp16+frF+/XjJkyGB1WAAAAACAWM7d6gCA2CBp0qQyZ84c8fLyMskZTeLOmzdPMmfObHVoACxy6NAhady4sVy8eNH0rm3UqJHVIQEAAAAAnASVtkA4aW/KXr16yebNm+XMmTOmd6VW1QFwPbNnz5ZSpUpJggQJxNfXl4QtAAAAACBKkbQFXlGZMmXkwIEDUqRIEalevbp8+eWX4u/vb3VYAGLA48ePpXv37tK6dWtTZbtr1y7Jmzev1WEBAAAAAJwMSVsgAtKmTSurV6+WoUOHygcffCD169eXmzdvWh0WgGikFfbly5eXn376SSZOnCgzZsyQxIkTWx0WAAAAAMAJkbQFIihu3Ljy2WefyfLly2X79u1SvHhxU4ELwPmsWbPGtES5cuWK+f+9S5cupmUKAAAAAADRgaQtEEl16tSRffv2SapUqUzrBK3CA+ActPXJp59+KrVq1ZISJUqY/9c9PT2tDgsAAAAA4ORI2gJRIEeOHKb6rk2bNtKpUyfp2LGjPHz40OqwAETC9evXzUUZTdoOGzZMVqxYIWnSpLE6LAAAAACAC3C3OgDAWSRMmFAmT54sXl5e0q1bN9m/f7/4+PhIrly5rA4NwCvau3eveHt7y/3792XVqlVSo0YNq0MCAAAAALgQKm2BKNauXTuzovzdu3dNn9ulS5daHRKAcLLZbGaRsXLlykn69OnNxRcStgAAAACAmEbSFogGRYoUEV9fX6lUqZLUr19fhg4dKs+ePbM6LABhePDggbRt29ZUymubky1btkjWrFmtDgsAAAAA4IJI2gLRJGXKlLJo0SL5+uuvzVa9enW5fPmy1WEBCME///wjpUqVkgULFsgvv/wi48ePlwQJElgdFgAAAADARZG0BaKRm5ubvPfee7J+/Xo5fPiweHh4mAXLADiOhQsXiqenpzx58kR2794trVq1sjokAAAAAICLI2kLxABtk6C9MXPmzGl+HjNmjOmdCcA6T58+lYEDB0rjxo1N31pdfKxQoUJWhwUAAAAAAElbIKZkzJhRNmzYIL1795Z+/fpJs2bNzGJlAGLexYsXpUqVKuYCyqhRo2TevHmSPHlyq8MCAAAAAMAgaQvEoHjx4snIkSNl/vz5snr1ailRooT8/fffVocFuJTNmzdLsWLF5Pjx47Jp0yZzEUVbmQAAAAAA4ChI2gIW8Pb2NlOx3d3dpWTJkvLrr79aHRLg9LQlybfffmsqbPPnzy8HDhyQcuXKWR0WAAAAAAAvIGkLWCRfvnxm0aOGDRtKy5YtpVevXmYhJABR7/bt26Z3rS4MqH1s161bJ6+//rrVYQEAAAAAECL3kG8GEBOSJEkis2bNkrJly0qfPn1M9a22TsiSJYvVoQFO488//zQJ26tXr8rixYulfv36VocEAAAAAECYqLQFLKa9NLt16ybbtm2TCxcuiIeHh6kCBBB5M2fOlNKlS5sLJPv27SNhCwAAAACIFUjaAg5Ce9vu37/fJG1r1Kghn3/+ufj7+1sdFhArPXr0SLp27Spt27aVZs2ayc6dOyVXrlxWhwUAAAAAQLiQtAUcyGuvvSYrV66Ujz/+2Gxvv/223Lhxw+qwgFjl1KlTZoGx6dOny5QpU2TatGmSKFEiq8MCYIEtW7aYf0szZsxoZrZoi5SX2bRpk7mAmiBBAsmdO7f5uwQAAACIaSRtAQcTN25cGTZsmEne7tq1y5w46rRuAC+3atUq8//M9evXZceOHdKpUyeTqAHgmu7fvy9FihSR8ePHh2v/kydPSp06daRy5cpy8OBB6du3r/l7ZM2aNdEeKwAAABAYSVvAQdWsWdO0S0ibNq14eXnJ5MmTxWazWR0W4JD8/PxMdbomW/T/F73QoclbAK6tVq1apt1Qw4YNw7X/xIkTJUeOHDJy5EjJnz+/9OzZU7y9vWX06NHRHisAAAAQGElbwIFly5bNLFDWoUMH6dKli7Rv314ePHhgdViAQ7l27ZpJzHzxxRcmObN06VJJnTq11WEBiIW0/3XVqlWD3KZ95vV2AAAAICa5x+izAXhl2lPvxx9/NNWDmrg9cOCALFiwwPTZA1zd7t27pUmTJvLw4UMzfTl4sgUAXsWlS5fk9ddfD3Kb/n7nzh3z90xI/bEfP35sNjvdFwAAAIgskrZALPHOO+9I0aJFpXHjxlK8eHGZMWOGNGjQwOqwAEtoqxC9mKH9JvX/h/nz50vmzJmtDguAC/rqq6/k008/tToMAHBp9XweiTNb6p3Q6hAAWID2CEAs8uabb8revXulSpUqpj/f4MGD5dmzZ1aHBcT4wkKtW7eWHj16SNeuXWXz5s0kbAFEifTp08vly5eD3Ka/J0+ePMQqWzVkyBC5fft2wHb27NkYihYAAADOjEpbIJZJkSKFaY8watQok7TV6eFz5841J5qAszt27JipNj916pT8+uuv0rx5c6tDAuBEypQpIytXrgxy27p168ztYbUx0g0AAACISlTaArGQm5ubDBgwQDZs2GCSWB4eHrJ161arwwKilY+Pj3h6eoqfn5/s2bOHhC2Al7p3754cPHjQbOrkyZPm5zNnzgRUybZp0yZgf63eP3HihLz33nty9OhRmTBhgsybN0/69etn2WsAAACAayJpC8RiFSpUkP3790uePHmkcuXKpvpWe30CzuTp06fSv39/s+BYnTp1TMK2QIECVocFIBbw9fWVYsWKmU3p3yX688cff2x+v3jxYkACV+XIkUNWrFhhqmuLFCkiI0eOlKlTp0qNGjUsew0AAABwTbRHAGK5DBkyyPr162Xo0KGm+nbHjh0ybdo0038PiO3Onz8vzZo1M21Axo4dK7169TKV5gAQHpUqVQrzYub06dNDfMyBAweiOTIAAAAgbFTaAk7A3d1dvvnmG1m4cKGpDtIp5IcOHbI6LCBSNm7caFp/aP9aXWysd+/eJGwBAAAAAC6BpC3gRBo2bGimgiZMmFBKlSolv/zyi9UhAa/M399fRowYIVWrVpVChQqZFiBeXl5WhwUAAAAAQIwhaQs4Ge1vu2vXLvH29pZ33nlHunfvLo8fP7Y6LCBcbt26ZS4+6OJA77//vqxdu1bSpUtndVgAAAAAAMQoetoCTihx4sSmT1/ZsmVND1Ctvp0/f75ky5bN6tCAUOmK7nqx4fr167J06VJ5++23rQ4JAAAAAABLUGkLOCnt/dm5c2fZvn27XLlyxfQGXbNmjdVhASHSiwxlypQxC+jt27ePhC0AAAAAwKWRtAWcnC5KpkmwkiVLSq1ateTTTz81PUMBR/Do0SN59913pX379tKqVStzkSFnzpxWhwUAAAAAgKVI2gIuIE2aNLJixQqTsNWtTp06Zgo6YKWTJ0+aFh66YN5PP/0kU6dOlUSJElkdFgAAAAAAliNpC7iIOHHiyEcffSSrV6+WvXv3mnYJ+idgBb2IoN9BXXhsx44d0qFDB6tDAgAAAADAYZC0BVxM9erVZf/+/ZI+fXopV66cTJw4UWw2m9VhwUX4+fn9X3v3Aqdjnf9//D0nZsQQcsgxKxk5jqGcymyz2FQUhRIhyblUK8uyHaTHSuEnpzbJUpG1CLFYh5gJY4jIIeW0zqdhJoyZuf+P79d/Zk2GzPG6D6/n43E9Zu7ruu7r/tyz3x3d7/len6+GDRumRx55RM2aNbOtO+rVq+d0WQAAAAAAuBVCW8AHVaxYUWvXrrW9RHv37q0uXbooMTHR6bLg5U6ePKmWLVtq1KhRdps/f76KFSvmdFkAAAAAALgdQlvARxUsWFATJkzQrFmzNG/ePN1///3as2eP02XBS8XExNgZtdu3b9eKFSv0+uuv25YdAAAAAADgenxiBnzc008/rY0bNyopKUkRERE2wAVyi2m9MX78eD3wwAOqVKmSbc0RGRnpdFkAAAAAALg1QlsAuvfee+2iZObW9Xbt2unVV1/VlStXnC4LHi4hIUGdOnXSwIED1a9fP61evVrlypVzuiwAAAAAANweoS0AKzQ0VHPmzNEHH3ygcePG6aGHHtLRo0edLgse6ocfflDDhg21ePFizZ49246roKAgp8sCAAAAAMAjENoCSOfn56eXXnpJq1at0o8//mh7kK5Zs8bpsuBhTEjboEEDO57MDO6nnnrK6ZIAAAAAAPAohLYArtO0aVNt2bJFYWFhdsbt6NGjbW9S4GZMX2TTCqFjx4567LHHtGHDBlWvXt3psgAAAAAA8DiEtgAyVbp0aS1fvtz2t/3Tn/6kJ554QvHx8U6XBTd1+PBhNW/eXJMmTdKECRM0a9YsFS5c2OmyAAAAAADwSIS2AG4oMDBQ7777rubPn29bJkRERGjbtm1OlwU3s3LlSoWHh+vQoUNau3at+vbta1sjAAAAAACA7CG0BfCb2rRpo82bN+u2227T/fffrxkzZjhdEtxAamqq3nnnHbVo0UJ169ZVXFycHR8AAAAAACBnCG0B3JLf/e53iomJUYcOHdS1a1f16tVLly5dcrosOOTs2bM2zB86dKjdvv76a91xxx1OlwUAAAAAgFcIdLoAAJ4jJCRE06ZNU5MmTdSvXz87+3bu3LmqXLmy06UhH5kZte3bt9e5c+e0ePFiPfzww06XBAAAAACAV2GmLYAsMb1Kn3/+eUVHR+v06dO2l+mSJUucLgv55OOPP1bjxo1VvHhxG94S2AIAAAAAkPsIbQFkiwlrzUxbE+C1bt1aw4cPV0pKitNlIY9cvHhR3bt3t4G9aY+xbt06ZlgDAAAAAJBHCG0BZJuZbblw4UKNHDnSbn/84x916tQpp8tCLtu3b58N5z///HNNnz5dU6ZMUXBwsNNlAQAAAADgtQhtAeSIv7+//vznP2vZsmXasmWLnYG7YcMGp8tCLjGhfP369XXhwgV9++23dpYtAAAAAADIW4S2AHJFVFSUDW3Lly+vZs2a6cMPP5TL5XK6LGRTcnKyhgwZojZt2igyMlKxsbGqU6eO02UBAAAAAOATCG0B5BoT2K5evVq9e/dWv3791LlzZyUmJjpdFrLo+PHjatGihf72t7/Zbd68eSpWrJjTZQEAAAAA4DMIbQHkqgIFCmjcuHG2/+mCBQvUsGFD7dq1y+mycIvWr19vW1zs3LlTK1eu1GuvvSY/Pz+nywIAAAAAwKcQ2gLIEx07dtSmTZuUmpqqBg0a6Msvv3S6JNyEaWUxduxYNW/eXFWqVLGtLsz3AAAAAAAg/xHaAsgzYWFh2rhxo1q3bq2nnnpKL7/8sq5cueJ0WfgVs8hYhw4d7P8+AwcO1H/+8x+VLVvW6bIAAAAAAPBZgU4XAMC7FSlSxLZKaNKkiQYNGmRn386ePVvlypVzujRI2rFjh9q1a6cjR45o7ty59nsAAAAAAOAsZtoCyHOmJ2r//v21Zs0a7d+/3/ZMXbVqldNl+bzPPvvM9hwOCgpSbGwsgS0AAAAAAG6C0BZAvmncuLHi4uJUs2ZNRUVF6d1337U9b5G/kpKSbIj+zDPP6IknntC3336ratWqOV0WAAAAAAD4/whtAeSrUqVK6d///reGDBlit8cff1znzp1zuiyfcejQIT3wwAOaOnWqJk6cqBkzZui2225zuiwAAAAAAHANQlsA+S4gIEBvv/22vvrqK61du1b169fX1q1bnS7L6y1fvlz16tXT0aNH9c0336h37962dQUAAAAAAHAvhLYAHPPII49o8+bNKlq0qBo1aqRPPvnE6ZK8kmlB8dZbb6lly5aKiIiwP3PTyxYAAAAAALgnQlsAjqpSpYqio6PVuXNnde/eXT179tSlS5ecLstrnDlzxobjI0aMsNvixYtVsmRJp8sCAAAAAAA3EXizgwCQH4KDg/XRRx/Zhcr69OljZ4LOnTvXBrrIvtjYWLVv314XLlzQkiVL1KpVK6dLAgAAAAAAt4CZtgDcRrdu3RQTE6P4+Hjb53bRokVOl+SRXC6XXWisSZMmduG3uLg4AlsAAAAAADwIoS0At1K3bl070/aBBx7Qo48+qqFDhyolJcXpsjzGL7/8YsPvXr16qUePHnbBsUqVKjldFgAAAAAAyAJCWwBup1ixYvrXv/6ld999125mAa0TJ044XZbb27t3r13Qbc6cOZoxY4YmTpyoggULOl0WAAAAAADIIkJbAG7J399fgwcP1ooVK7R9+3aFh4fb1gnI3Pz58xUREaGLFy9qw4YNevbZZ50uCQAAAAAAZBOhLQC3FhkZaXuymlv8TcuE8ePH256tuCo5OdmG248//riioqLs4mO1atVyuiwAAAAAAJADhLYA3F65cuW0evVq9e/fXwMHDlSnTp2UkJAgX3fs2DEb1I4ZM0bvvfee5s6dq9DQUKfLAgAAAAAAOURoC8AjBAUF6f3337f9WhcvXqwGDRpo586d8lVmgbF69epp9+7dWrVqlV555RX5+fk5XRYAAAAAAMgFhLYAPMqTTz6pTZs22Z63DRs21BdffCFfYlpDmJm1pm1EtWrVtGXLFjVr1szpsgAAAAAAQC4itAXgcapXr24X23rsscdsq4QBAwYoKSlJ3i4+Pl7t27fXq6++amfWrly5UmXKlHG6LAAAAAAAkMsCc/uCAJAfChcurFmzZqlJkyZ6+eWX7ezbL7/8UuXLl5c32r59u9q1a6fjx49r3rx5duExAAAAAADgnZhpC8BjmR6uffv2tf1dDx8+bHu8rlixQt7mH//4h+677z6FhIQoNjaWwBYAAAAAAC9HaAvA45lAMy4uzoa2LVq00MiRI5Wampr7L2Suefy4tGePtGOHZBZC27tXOn3aNJvN9Ze7fPmyevfurS5duthevjExMbr77rtz/XUAwJt9+OGHqly5soKDg+2/Fxs3brzhudOnT7d/ELx2M88DAAAA8hvtEQB4hTvuuENff/213nzzTQ0bNswGnGaG6u233579i5og9scfpW3bpAMHpMOHpRv1zg0JkSpUkCpXlsLDpRy2aThw4IANar/77jtNmTJFPXv2tOEBAODWzZ49W4MGDdLkyZNtYDt27Fi1bNlSu3fvVqlSpTJ9TmhoqD2eht+9AAAAcAKhLQCvERAQoDfeeMN+MO/cubPCw8P1z3/+037NkosXpU2bpNWrpRMnJH//q7Nsf+s5ZgauCXn//W+pUiWpeXOpbl0pKChLL7906VI988wzKlKkiNavX6+IiIis1Q8AsN5//337R69u3brZxya8Xbx4saZNm6bXX3890+eYkJZFHgEAAOA02iMA8DoPP/ywbZdQokQJNW7cWH//+9/lupX2BeacmBhp2DBpzpyrga2RlVYLaecePCh9+qk0YsTVVgq3ICUlRX/9619t/WktHwhsASB7kpKStHnzZkVFRaXv8/f3t4/N3Rg3kpCQoEqVKqlChQpq06aNdtzi73AAAAAgNxHaAvBKpn/hunXr9Nxzz9lZVj169NBFMxv2Rs6dkyZOlGbNMs1kc15AWkh84YI0aZI0c6b0yy83PP3UqVNq3bq1be9gZgsvWrRIxYsXz3kdAOCjzO9V88ew0qVLZ9hvHh87dizT59xzzz12Fu6CBQs0c+ZM2x/d/PHPLHZ5s/7j58+fz7ABAAAAOUV7BABeyyweY26FbdSokV588UU7c3Xu3LmqWrVqxhNN78KpU6UrV3K/iLTwdsOGqwuX9e0rlSuX4RSzKI7pX5uYmKhly5bpD3/4Q+7XAQD4TebfC7OlMYFtWFiY7S3+1ltvZfqcUaNG2T+2AQAAALmJmbYAvF7Xrl21YcMGG4qadgNmBlU6s8jYhx9eXWAsK20QshPeJiRIH3xwdVEzu8ulSZMmqWnTpipbtqwNlQlsASB3lCxZ0vY6P378eIb95vGt9qwNCgpSvXr19KPpV34DQ4YMUXx8fPp26NChHNcOAAAAENoC8Am1a9dWbGysIiMj1bZtW7sATYrpU/j3v18Na2+l521OmdcxrRf+7//0y7596tKli/r06aNevXpp7dq1qlixYt7XAAA+okCBAqpfv75WrlyZvs+0OzCPr51NezOmvcL27dvtH9ZupGDBggoNDc2wAQAAADlFewQAPqNo0aKaN2+e3nvvPU155x399fx5+QcEyC8/i3C55Lp8WRfefVfLv/pKs2bN0tNPP52fFQCAzxg0aJC928LcZdGwYUONHTvW3nXRrVs3e9z88axcuXK2xYFh+orff//9to3OuXPnNHr0aB04cEDPP/+8w+8EAAAAvobQFoBP8fPz02uvvKKeiYkKPHFCfvkxw/bXNbhcKlmggHaOHKniBLYAkGc6dOigkydPavjw4Xbxsbp162rp0qXpi5MdPHhQ/v7/u/Hs7NmzdvFKc+7tt99uZ+pGR0erRo0aDr4LAAAA+CI/l2mqCAC+ZO1aac4cuQWzMFlYmNNVAAByyfnz5+2dHaa/bX63Snhs7iV5s4Xtg50uATfB+IOTGH8AvPG/F+lpC8C3nD8v/etfcgt+ftLMmVJystOVAAAAAAAAN0JoC8C3REe7T0hqbnSIj5e2bXO6EgAAAAAA4EboaQvAd6SkXG2NkMWuMJeSk/Xmpk2KPXlSe86d0+lLl3QpJUVFCxRQtWLF1LpSJfWrVUtFCxbM3mzb1aul8PCsPxcAAAAAAHglQlsAvmPHjqvtEbIo4coVjYqLu26/CW9jjh2z2yc//KCNTz6p4sFZ7DdlAuSffpKOHpXKls1ybQAAAAAAwPsQ2gLwHVu2SGaV8NTULD+13G23qXGZMqpUpIgNZk9dvKh//vSTDly4YI/vO39eU3fs0Ov162e9LlOTqY3QFgAAAAAAENoC8Ck//5ytwLZkSIgOP/fcdfsH1a2r8p9+mv44LcDNMjPb9uDB7D0XAAAAAAB4HUJbAL7h0iXp1KlcuVRKaqqO/fKLPtq5M8P+e4sXz35ou39/rtQGAAAAAAA8H6EtAN9w+HCOL7Hi0CH9YeHCTI89cOeder5GjexfPCFBio+XihbN/jUAAAAAAIBX8He6AADIF2fO5Nmln777bi1u3VrBgYFuWyMAAAAAAPAczLQF4BuSk3N8iWrFiml048a6nJJi+9fO++knnb50SZ/t3au4U6e09JFHVCk01NEaAQAAAACA52OmLQDfYPrG5lDFIkX0ar16GhoRoamRkdrZqZPKFipkj+06e1YvrVvneI0AAAAAAMDzEdoC8A1BQbl+yVKFCun+MmXSH68+csTtagQAAAAAAJ6H0BaAbyhWLNtPXXX4sC4kJV23/9TFi9pw/Hj6Yz85VyMAAAAAAPAe9LQF4BvKl8/2U8dt26blhw7pofLlVbtECRUKDNR/ExP1z337dPzixfTzHqlcOfv1mTYLhLYAAAAAAIDQFoDPMKFo8eLSmTPZevovycn6av9+u2WmbsmSGtOkSfZq8/OTKlW6+hUAAAAAAPg8QlsAvsPMhD13TkpNzdLT+taqpTKFCtlWCEcSE3Xm8mUF+vmpdKFCdubt41WqqHO1agoKCMhZaAsAAAAAAEBoC8Cn1KkjxcVl+Wl/qFDBbnnGhMi1a+fd9QEAAAAAgEdhITIAvhXa3nab3IqZZWsC4YoVna4EAAAAAAC4CUJbAL4jMFBq1sy9ese6XNKDDzpdBQAAAAAAcCOEtgB8i1kszN9NfvWZ8NjM/A0Pd7oSAAAAAADgRtwkuQCAfHL77dIjj8htZtl26iQVKOB0JQAAAAAAwI0Q2gLwPb///dU+sk7OuDWvbWbY1q3rXA0AAAAAAMAtEdoC8D0BAVKXLs71tjWvGxwsPfWUM68PAAAAAADcGqEtAN9Utqz03HP5H9ya1zMLovXuLRUunL+vDQAAAAAAPAKhLQDfVa+e1Llz/gW35nXMLN8XX5Tuuit/XhMAAAAAAHicQKcLAABH3Xff1YXApk+/ujBYamre9bA1r9Onj1SlSt68BgAAAAAA8AqEtgBgZtyadgkzZkgHD+bNa9SoIXXqJBUtmjfXBwAAAAAAXoPQFgCMMmWkV1+V/vMf6auvrs64NTNvc8osONahgxQR4dzCZwAAAAAAwKMQ2gLAtS0MoqKkBg2k6Ghp7VrpwoWr+2+1bULauSVLSs2bSw0bSoUK5XXlAAAAAADAixDaAsCvmRYGf/yj1KKFtG2btH27tH+/dPLkjWffmrDWzNY1C4yFh0vVqjGzFgAAAAAAZAuhLQDcSEDA1X63ZjMuX5b++18pPl66cuVqKBsYKJUocbUnblCQ0xUDAAAAAAAvQGgLALeqYEGpShWnqwAAAAAAAF7O3+kCAAAAAAAAAAD/Q2gLAAAAAAAAAG6E0BYAAAAAAAAA3AihLQAAAAAAAAC4EUJbAAAAAAAAAHAjhLYAAAAAAAAA4EYIbQEAAAAAAADAjRDaAgAAAAAAAIAbIbQFAAAAAAAAADdCaAsAAAAAAAAAboTQFgAAAAAAAADcCKEtAAAAAAAAALgRQlsAAAAAAAAAcCOEtgAAAAAAAADgRghtAQAAAAAAAMCNENoCAAAAAAAAgBshtAUAAAAAAAAAN0JoCwAAAK/14YcfqnLlygoODtZ9992njRs33vT8L7/8UtWrV7fn16pVS0uWLMm3WgEAAIA0hLYAAADwSrNnz9agQYM0YsQIxcXFqU6dOmrZsqVOnDiR6fnR0dHq1KmTevTooS1btqht27Z2+/777/O9dgAAAPg2QlsAAAB4pffff189e/ZUt27dVKNGDU2ePFmFChXStGnTMj1/3LhxatWqlV577TWFhYXprbfeUnh4uCZMmJDvtQMAAMC3EdoCAADA6yQlJWnz5s2KiopK3+fv728fx8TEZPocs//a8w0zM/dG5wMAAAB5JTDPrgwAAAA45NSpU0pJSVHp0qUz7DePd+3alelzjh07lun5Zv+NXL582W5p4uPj7dfz588rv1355VK+v2Z+On8+yekScBOMPziJ8QfAk6T9d6LL5brpeYS2AAAAQDaNGjVKb7zxxnX7K1So4Eg93qyo0wXApzH+4CTGH+CdLly4oKJFb/z/cEJbAAAAeJ2SJUsqICBAx48fz7DfPC5TpkymzzH7s3K+MWTIELvYWZrU1FSdOXNGJUqUkJ+fX47fB/43I8UE4YcOHVJoaKjT5cDHMP7gJMYfnMT4yxtmhq0JbO+8886bnkdoCwAAAK9ToEAB1a9fXytXrlTbtm3TA1XzuF+/fpk+p1GjRvb4Sy+9lL5v+fLldv+NFCxY0G7XKlasWK69D2RkPjDyoRFOYfzBSYw/OInxl/tuNsM2DaEtAAAAvJKZAdu1a1dFRESoYcOGGjt2rBITE9WtWzd7vEuXLipXrpxtcWAMHDhQDz74oMaMGaPWrVvriy++UGxsrKZOnerwOwEAAICvIbQFAACAV+rQoYNOnjyp4cOH28XE6tatq6VLl6YvNnbw4EH5+/unn9+4cWN99tlnGjZsmP785z/r7rvv1vz581WzZk0H3wUAAAB8EaEtAAAAvJZphXCjdgirV6++bt+TTz5pN7gX04JixIgR17WiAPID4w9OYvzBSYw/Z/m5TPdbAAAAAAAAAIBb+N/9YAAAAAAAAAAAxxHaAgAAAAAAAIAbIbQFAAAAAAAAADdCaAsAAAAgx2JiYhQQEKDWrVs7VsP+/fvl5+enrVu3/ua5Bw8etLUWKlRIpUqV0muvvabk5OR8qRO5z9PG34ABA1S/fn27uE/dunXzpT7kHU8af9999506deqkChUqKCQkRGFhYRo3bly+1QnfHn+nT59Wq1atdOedd9rff2YcmgVjz58/n2+1ehJCWwAAAAA59vHHH6t///5au3atjhw5IneWkpJiP9wmJSUpOjpan376qaZPn67hw4c7XRp8YPyl6d69uzp06OB0GfCx8bd582b7h6qZM2dqx44dGjp0qIYMGaIJEyY4XRp8YPz5+/urTZs2Wrhwofbs2WP/7V2xYoVefPFFp0tzTy4AAAAAyIELFy64Chcu7Nq1a5erQ4cOrpEjR153zoIFC1xVq1Z1FSxY0NW8eXPX9OnTXebjyNmzZ9PP+eabb1xNmzZ1BQcHu8qXL+/q37+/KyEhIf14pUqV7LW7detmX69ChQquKVOmpB8317t2e/DBBzOtd8mSJS5/f3/XsWPH0vdNmjTJFRoa6rp8+XIu/mSQHzxt/F1rxIgRrjp16uTKzwHO8OTxl6ZPnz6uyMjIHP0c4AxvGH/jxo2zr4nrMdMWAAAAQI7MmTNH1atX1z333KPOnTtr2rRpZnJI+vGff/5Z7du3V9u2be2tub169bKzu661b98+e8tku3bttG3bNs2ePVvr1q2zt01ea8yYMYqIiNCWLVvUp08f9e7dW7t377bHNm7caL+aWTtHjx7VvHnzbngraa1atVS6dOn0fS1btrS3Z5qZZ/Asnjb+4F28YfzFx8erePHiOfxJwAmePv7MzGBz7oMPPpgLPw0vlEmQCwAAAAC3rHHjxq6xY8fa769cueIqWbKka9WqVenHBw8e7KpZs2aG5wwdOjTDTJ8ePXq4XnjhhQznmJk/ZkbsxYsX02f6dO7cOf14amqqq1SpUnaWrPHzzz/ba27ZsuWm9fbs2dPVokWLDPsSExPtc80sXHgWTxt/12Kmrefz5PFnrF+/3hUYGOhatmxZlt87nOep469jx46ukJAQ+5xHH300/XWQETNtAQAAAGSbmWVjZtiYhW2MwMBA26fT9Ni79pwGDRpkeF7Dhg0zPDYzgExvu8KFC6dvZvZramqqnSmUpnbt2unfm0VPypQpoxMnTuThO4Q7Y/zBSZ4+/r7//nvbX3TEiBFq0aJFtq8DZ3jy+Pvggw8UFxenBQsW2Jm+gwYNytZ1vF2g0wUAAAAA8Fzmw2FycrJdCTqNuTXTrAptFrYpWrToLV0nISHB3rY5YMCA645VrFgx/fugoKAMx8wHR/PBMivMB820WznTHD9+PP0YPIcnjj94D08efzt37tRDDz2kF154QcOGDcvWNeAsTx5/5t9as5nWDqY1R7NmzfSXv/xFZcuWzdb1vBWhLQAAAIBsMR8WZ8yYYfvc/XqWlumf9/nnn9sVoU2vvSVLlmQ4vmnTpgyPw8PDbYhQtWrVbNdToEAB+zUlJeWm5zVq1EgjR460M4TMKurG8uXLFRoaqho1amT79ZG/PHX8wTt48vgzvbt///vfq2vXrvZ3ITyPJ4+/X0sLfi9fvpzt1/dWtEcAAAAAkC2LFi3S2bNn1aNHD9WsWTPDZhY0SbtF08zg2bVrlwYPHqw9e/bYhVPMrZhpM3UMcyw6OtoufLJ161bt3bvX3jb564VQbsYEsCEhIVq6dKmdOWsW18mM+YBrwtlnn33W3ha6bNkyO9Osb9++doYSPIOnjj/jxx9/tK9z7NgxXbx40X5vtqSkpBz/XJA/PHX8mZYIkZGR9veguSXdjEGznTx5Mld+Lsgfnjr+TID8ySef2HG4f/9+LV682IbLTZo0UeXKlXPlZ+NNCG0BAAAAZIv5UBgVFZXpLZjmQ2NsbKxdifquu+7S3Llz7QrRpifepEmT0levTgtJzf41a9bYD5XmNsl69epp+PDhGW77/C2mn9/48eM1ZcoU+zzTqzEzAQEB9gOv+Wpm3ZoVt7t06aI333wz2z8L5D9PHX/G888/b1/DnGte03xvNrOSOjyDp44/U4sJaGfOnGlvRU/bft33FO7NU8efCXY/+ugjNW3aVGFhYXr55Zf12GOP2X+TcT0/sxpZJvsBAAAAIM+YW3InT56sQ4cOOV0KfBDjD05i/MFJjD/PQU9bAAAAAHlu4sSJdiZXiRIltH79eo0ePTpLt14COcH4g5MYf3AS489zEdoCAAAAyHOmR97bb7+tM2fO2NWoX3nlFQ0ZMsTpsuAjGH9wEuMPTmL8eS7aIwAAAAAAAACAG2EhMgAAAAAAAABwI4S2AAAAAAAAAOBGCG0BAAAAAAAAwI0Q2gIAAAAAAACAGyG0BQAAAAAAAAA3QmgLAAAAAAAAAG6E0BYAAAAAAB8TExOjgIAAtW7d2rEa9u/fLz8/P23dujVL56U9TtuKFCmie++9V3379tXevXvzqXoAyFuEtgAAAAAA+JiPP/5Y/fv319q1a3XkyBF5ohUrVujo0aP67rvv9M477+iHH35QnTp1tHLlSqdLA4AcI7QFAAAAAMCHJCQkaPbs2erdu7edaTt9+vTrzlm4cKHuvvtuBQcHKzIyUp9++qmd1Xru3Ln0c9atW6dmzZopJCREFSpU0IABA5SYmJh+vHLlyjZM7d69u50NW7FiRU2dOjX9+F133WW/1qtXz167efPmWXofJUqUUJkyZVSlShW1adPGhrj33XefevTooZSUlGz+dADAPRDaAgAAAADgQ+bMmaPq1avrnnvuUefOnTVt2jS5XK704z///LPat2+vtm3b2lmsvXr10tChQzNcY9++fWrVqpXatWunbdu22RDYhLj9+vXLcN6YMWMUERGhLVu2qE+fPjYo3r17tz22cePGDDNm582bl6P35e/vr4EDB+rAgQPavHlzjq4FAE4jtAUAAAAAwMdaI5iw1jDBa3x8vNasWZN+fMqUKTbQHT16tP3asWNHPffccxmuMWrUKD3zzDN66aWX7Izcxo0ba/z48ZoxY4YuXbqUft7DDz9sw9qqVatq8ODBKlmypFatWmWP3XHHHRlmzBYvXjzH782E0Wl9bwHAkxHaAgAAAADgI8wsVzPDtVOnTvZxYGCgOnToYIPca89p0KBBhuc1bNgww2MzA9e0VShcuHD61rJlS6WmptqZumlq166d/r1pgWDC2RMnTuTZ+0ubMWxeCwA8WaDTBQAAAAAAgPxhwtnk5GTdeeedGYLOggULasKECSpatOgt98U1bRNMH9tfM71r0wQFBWU4ZsJUE+zmFbMY2bX9cgHAUxHaAgAAAADgA0xYa9oXmD6zLVq0yHDM9K/9/PPP9eKLL9qWCEuWLMlwfNOmTRkeh4eHa+fOnbbtQXYVKFDAfs2tRcNMGGxaNJjA1ixuBgCejPYIAAAAAAD4gEWLFuns2bPq0aOHatasmWEzC4qltUgwM2h37dple9Du2bPHLlxmWiFc23bAHIuOjrYLj23dulV79+7VggULrluI7GZKlSqlkJAQLV26VMePH7e9dbPi9OnTOnbsmH766SctXLhQUVFRtvWDeR8BAQFZuhYAuBtCWwAAAAAAfIAJM02wmVkLBBPaxsbGatu2bXam6ty5czVv3jzbk3bSpEkaOnSoPc+0UTDMfrN4mQl1mzVrZme2Dh8+PEPbhd9i+umambFm4TPzvDZt2mTp/Zj3UrZsWdWqVUuvv/66wsLCbP2RkZFZug4AuCM/V1qXbgAAAAAAgEyMHDlSkydP1qFDh5wuBQB8Aj1tAQAAAABABhMnTlSDBg1UokQJrV+/XqNHj85S6wMAQM4Q2gIAAAAAgAxMj9q3335bZ86cUcWKFfXKK69oyJAhTpcFAD6D9ggAAAAAAAAA4EZYiAwAAAAAAAAA3AihLQAAAAAAAAC4EUJbAAAAAAAAAHAjhLYAAAAAAAAA4EYIbQEAAAAAAADAjRDaAgAAAAAAAIAbIbQFAAAAAAAAADdCaAsAAAAAAAAAboTQFgAAAAAAAADkPv4fU2qdtv4FhV0AAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAJOCAYAAADMCCWlAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAty5JREFUeJzs3Qd4FFXXwPETCL2DIL0XEQQTQgtdepEaOtKV3kEEUSkiWJCiIE1EEER6r9I7hKIiRZHee+/Jfs+5vJsvCUkIabPZ/f+eZyTZnZ29e2eFO2fOPdfNZrPZBAAAAAAAAADgEOJY3QAAAAAAAAAAwP8jaAsAAAAAAAAADoSgLQAAAAAAAAA4EIK2AAAAAAAAAOBACNoCAAAAAAAAgAMhaAsAAAAAAAAADoSgLQAAAAAAAAA4EIK2AAAAAAAAAOBACNoCAAAAAAAAgAMhaAsAAAAAAAAADoSgLWCx8uXLi5ubW7S+x/Tp08176J+OLja1NThtt57P2CR79uxmczQ9e/aU1157Te7evSuxQYsWLSRbtmzy6NEjq5sCAACcWOvWrSM0djt16lSsHWMDgKsiaAu8xP379+WLL74QT09PSZo0qSRIkEAyZ84sZcqUkQEDBsh///1neR/aB2E6iAMC0++Efjf0OxJb/PvvvzJhwgTp27evJEuWLMR9bDab5M6d23y2mjVrhnk83Sf4lihRIsmXL5/06dNHrl69GrDv4MGDQ9w/tE33V59++qmcP39exowZE8W9AQAAYhMdw+gYoXjx4hE+xoULF8wY4+DBgxKdVq5cGTCWQczbsWOH6f9bt27R/QBC5B7ywwCUZvmVLl1a/vzzTxMg0my6NGnSyLVr12TPnj0ycuRIyZUrl9kcWb169aREiRKSIUMGq5sCB7N+/XpxNMOGDZN48eJJly5dQt1n06ZN5oaJXhStWbPGXNxkzJgx1P31/9uuXbsG/H79+nVzjG+//VaWLFki+/fvl+TJk4eYKa0XTLpPuXLlXnje/nvevHmlTp065u+Ebt26SZIkSSL46QEAQGw2a9Yskwmr1wrHjx831xCvSsc1Q4YMMcd5++23gzw3ZcoU8ff3f+Vj6oyghw8fmjFW4KDt+PHjCdxaGLTV86xJFilTprSqGQAcGEFbIAyaNacB2/bt28vkyZNfKGNw8uRJefz4scP3YYoUKcwGBOdoNxw0mDp37lzx8fEJNctW/fjjj+ZPzZT95ptvzFS/gQMHhrq/lloInkmi2brvvvuurFixQubPny9t27Y1QdjggVk9tgZt9fGwslH0ps7ChQtlzpw50q5du1f41AAAwBnotYEG4nQ80KFDBxPA/eyzz6L0PQIHXV+FXsckTJhQnIUGrp88eeJUnwkAgqM8AhCGnTt3mj814y+kurM5cuSQN95444XHDx06JI0aNZJ06dKZcgq6n9bo1IBUeNinaGsm4Mtqvuqfenz1888/B5m6bX99WHVit2/fbqaXp06d2gx69PPo4PLBgweh1my9fPmytGrVygTCdJq5ZvGG1Naw3LhxQzp27Civv/66JE6cWIoWLSqLFi0K8zUaQG/SpInJGI4fP77JGNCsxvD2q92VK1dMsE+nx2v79bPrFDYN/gW3bNkyqVChggl6676FCxc22ZnPnj0L9/tpZraefz1P+n3Q74V+P/R7Elo5gxMnTsioUaPkzTffNK+xl77QzAs9P9rn9u+XZmF07tzZfK7A9HH9Tih9b/v3InBQMrSatloWRN9Hvw/6vdA+0u+Jfl/C+r7Onj3bZIRoX+l56tGjh8nqCK9ff/3V3Ahp2LBhqPvoFLIFCxZIwYIFZejQoSa4O23aNBOEfRXa5qpVqwaco8jS/tHvMrXiAABwTRqkTZUqlRkT6A1o/T20sUyvXr3MGMxeeq1ly5ZmPKLjKR0XqzZt2gSM3+zji8A1bZ8+fWrGaLpfcHfu3DFjOC03FVJNWz2OZtmqwNcPgYOimsBSoEABcxwds2sg+ubNmy/tBz22lpXT8ayOtXQGks6I0nFb8PGajr+9vb3NrCgdPxYpUsTcTA9O26azprRPtU3ab6tXrw61DXrDXc+Dvq/uq4kKOpvLz8/vhX21H3LmzGnev1ixYrJ169YQb+TrGFXHx5o9rcfMkiWLfPjhhy8k8djbunjxYjNe1X21zYHbq+Pnfv36vTBOj00lzQBEPzJtgTDo4EH9888/L0xNCs22bdvM4ETv/OpgTQdVGvwdO3asLF++XHbt2mWCnVFF26WBMT2+BhTr1q0b8NzLFimYN2+eNG3a1AwkGjdubIKAa9euNQMqnXKug8bgd691kKklIzSI+d5775lA4W+//WY+8759+8zA5GU0IKyDoL/++ktKlixppp2fPXvWtKFKlSohvmbp0qUm0BknThwzDV0HSYcPH5bvv//etHX37t1mkPwyx44dM0HYixcvms+h/aUByr///tvULrYPbJUGZzW4q4PhZs2amQGntkMf08GcZlG8bBE5rZeqn1Gn8utn1qCzZmHoYFQzPLXt2o7gNBit3xUdbGo2qJ4btWXLFhPMrVixogk0a7bFgQMH5IcffjDH0mn+9qxqDRTrwPyPP/4w3xH7tKuXfS90Ma133nnHTOvTWs56HA3U63nW99DAakhBVT0XOhjV86Ov15/HjRtnLkBCu2gJrVyDBqVDo4FhbaNe3OjgWv8/++mnn2Tz5s2vvBDcunXrzJ/6OSNLbyTohYb+/67fKUokAADgWnS8U79+fTMm0DG2js/27t0bEIRV9+7dM2tjHDlyxMzy0TGIjpV0jHnu3DnJnz+/GYtrvfwPPvjA7Ks0sBmcjgO1DJqOSSdNmmTe104DhhpM1LFnSDQAq8kAOhaaOXNmiM/rOFIDwt27dzfjVx3r6bhTb+K/LONXg6PVqlUzY7qvvvrKjAs14KmJD/r57PQapnbt2tK8eXNz/aQzlnScqddNwdct2LBhg5mRpQFRvZ4Ka0yrbdfAce/evc2f+lrtUw1mf/311wH76TnS42k/ayBdg6Z6faDXFRpMDxzE1nbqtZ6eFz1Pei0zevRoc62o/R2Y7qfnRRMrNMFAx8QNGjSQM2fOmGtM/Z7o63RcrcewXx+mTZs2zH4F4GJsAEK1ZMkSvRVsS5Ysma1Pnz62NWvW2K5duxbq/n5+frZcuXKZ16xevTrIc/369TOPt23bNsjj5cqVM48H9tlnn5nHNm7c+MJ7/PTTT+Y5/dPu5MmT5rFWrVqF2K6QXnP79m1bihQpbAkSJLD98ccfQT5D48aNzf5Dhw4Nchx9TLfOnTub/eymTp1qHu/QoUOofRPS53v//feDPK59Zn+PwG3VPk+ePLktU6ZMtlOnTgV5za+//mr279q1a7je28vLy+w/efLkF547e/ZswM/Hjx+3ubu729KlS2c7c+ZMwOOPHj2ylS5d2hxjxowZQV6vj+n5DKxNmzbm8QEDBgR5fMWKFebx3LlzB+lLPYf6eObMmW2nT59+oY2XL1+23b1794XHf/75Z/O6zz//PMjj9uPpdyQk2bJlM1tgQ4YMMa9p3ry5zd/fP+Dx/fv32+LHj29LmTKl7c6dOy+cT/0+HT16NODxBw8e2PLmzWuLEyeO7fz587bwSJs2rTnPYfH09AxyzA0bNpj3b9GiRYj763Np0qQx7bRv3bt3txUqVMic4x49eoT5fvb/f/R1L9OrVy+zr7YJAAC4Dl9fXzMGWLdunfldx1A6ngs+zvj000/NfgsXLnzhGPZx1969e18YDwce2wUeu+n1ie67bNmyIPvVqFHDljNnzheuFwIfs0uXLi9ch6itW7eax2fNmhXiWD344yG1Uffr1q1bkM9Ws2ZNM5a8evVqkPFiYE+ePLEVLFjQ9s477wR5XI+n47+///47zPcO7bhKr1USJ05sxvPq8ePHZoxYtGhR29OnTwP2mz59+gvj+pkzZ5r3174JbOLEiWbf7du3B2mrfk69nrDT6y19/Lvvvgt47Ouvvw5znA4AlEcAwqB3UzWrUf/t1T81m1TvguqUGL0jq6vcB6Z3nTWjsnr16gHTru30zq5mbGqWoN5FtppOGbp9+7a5w1+oUKGAxzWTVe+Gu7u7hzjNW7MHv/zyS7OfnZZK0P01kyA8ZsyYYTIBAt9lV9pnmkEa0v56V3zEiBGmJEJgmj2gGQp6V/5lNHPU19dXypYtK++///4Lzwe+m67nSTMBNKtWs3rtNCtZP7962TR4Pc9691zvpg8aNCjIczVq1JDKlSubBSpCKjmg06WyZs36wuOacavZAsFp1rMupPX7779LZGlJBc2e0EW1AmcSe3h4mHOt2dbBswmUZvNqyQk7zYLVLBPNTNAs7JfR/tLMZJ1+FxpdFEyzifV7Yl94TLNrta+0ZIJ+p0OiJTR0oQf7ptkOWm5Dsz8CZ6dHlr3tmikDAABcK8tWxwE6o0vpGEpnkekYNfCUfB2v6Ow4zZAN7mUzuEKis5v0+kRnRNlpCQPNoNX3jwidjaczt3SsqlnA9k1nFOk4dOPGjeE6TuBFYO0lA3S8F3i8quPFwO3WsZxmvep4Lzidnaelw8Ij8HF1cWltvx5XZ/wdPXrUPK7XBTpG1OsCvZax06zf4DP4tE80u1ZLhwXuE+1/FbxPKlWqFGTtCL3e0rG6lowAgPAiaAu8hE6p0alDOhVHp4nrVHad1qK1j/QfX53KZKfThVRIU7R1gOPl5WWmdesUfauF1VYNgGldJx1U6CAnsLx5874QNNRBjg5SNZj3Mhp81elVGvhOnz79C8/bp4AFpmUClJZA0PpPwTftU/vA6WVBWxVaCYbw9o+WO9CyERpADIsOCLVtWhtLa50GZx/Uh3QcfU1odKqVBrh1+pT2vQ6CNYiufavf1cjQY+h51/MTOIgdnjbrQD44+zHC892w1yYOa/XcqVOnmj+1NIKdfn5dBExr52qwPSQaTNabL/ZNLwq0FIN+v3VQ/bJ6yuGlN2aiqkYuAACIHTQoq8FZHSfpOFdvyuumpay0xJS9/JPSBI/wlBMLLx0L6rR7Tciw11bVsaLWu41o0FYTUzR4qskCOt4MvGl5h+DrKIREx6Z6PRH8OkIFrtuqZRD0Jrp9DQV9Dy1ZENKNePs6HuGhpc80MK7BZw2W6nF1vKjsxz59+rT5U8e9wfs0eOkF7RM9ZvD+sH+m4H0SUvKFBoLDUxMYAOyoaQuEg9Yh0tpK9jqe+g+9rlQ/YcIEs0r8+fPnTeaoBrxUaJmCujCTsu9npfC0Vess6X76+e100BMSHdyEVNg/tPe112gNLqT26KJlyr5YQmi0jmhY9YLtA7RMmTKFu50htUeDhPq4nveIHuNl34fQXqMZ31p3VweJGnzWoKg9k0AXiwi+EMKrikybQ/pu2LMWwvPdsH8ODXSHRB/XLBa9aaB1wALTIK7WJNYFyTp16vTS99LAsGZGaG3hPHnymEUkQsp4eVX2RddCCtIDAADnpPVSdb0EDdyGNPtLxy/hSRqIKJ15pjVtV61aZWYQabKJZoRqRm9E6CwpHauHtiZBVNVd1TUidGajzoLT6yodZ+psL12rIKQb8YGzZ8OiyQKalatjU53ZpxmvGhTW7N3+/fubz/eq9DVvvfWWWfMiJIFn5qm4ceOGuN+rLpwLwLURtAUiQO/YaiF+XUhK79BqEXrNMrQHrfSOekguXboUZuDTzl56QKfnBxfa9O9XFVVtjej7hnaHPqT22F+j/RyZzAR7BufLgq2B31PbE7wkgw629PGX9U1k+jik6XH6fdBVb3VAq5mugQPf2iYtaxFbvxf286MDdXuQPjjNGrFn7Ia2yJdOc9OyB4FLfoRFMys0q0OzYfTYYWX5hoe97SwiAQCA69Dgpo7LQkow0PGLzuiZOHGiCTpqAPHQoUNhHu9VyyRo0FPHh1oiQWcFahD5448/funrQnsfbaOWMChVqlS4A6UhBTl19pY9E1VpQoiyZ7FqqQgNpupCt1qCzE6DtpGhiynrDC7te+0bO82CDsw+xtdxoH02mX3MrdnAgceT2ie6uK+W6IpIGYuQRNVxADgvyiMAkfhHNnjgSGt+2gcKIWWBakBJBz6B636GxF5DKaTgon3afkh3csOTzRietp49e9ZM3dIpTYGzbKOCBvt0apMOjuwBwOB33IPTqWVq586dkXpve8mBtWvXRqp/tEyDZn2+/fbbYR5DMxx0IKq1frV+VnD2Y7/sOHY65V6D9lqeIXimsn637Fmekflu6PnR867nJ6Tv36u2+VVpUF4H1CHVff7xxx/Nn5rxrhnuwTd7HWn7fuGhg3J7CZCIZF0EZy99opkYAADA+en4S4ODtWrVEh8fnxc2reOqYw17STUtZaDBv5BKM9mzMO3XGOEpL2VP+ND3WrZsmcycOdOMb8JTGiG092nUqJEZO2qyQHB67PC2S5NcAn82/V1v0NvXsNBxql5TBR6narA0pLUTXoV9/Bs4q1XHlprNG5iWrtO1J6ZMmRIkWUaD8MHLGGif6NhY9w3pO6DXeq/qVc8zANdD0BYIg04zCm1xLR1MHDlyxGTm2bM/9W603oXVqUnBF4T6/PPPzR1fXZhJSymEpWjRogELcAUOJGnQMqRpShrk1QGPBlvDq06dOiZjWO9ka30mOx3c6LQhHbi0bt1aooMumqUDJ12cLTANpgau+WXXpk0bEzzWjIHAbbXTgKi97u3L+lW3LVu2hDjgChykbNasmZnar1OgAteJ1XZr/6iX9Y+eZz3fGmzVRdQCW716tckq0ExP/d6EhwZqNeivU7sCB4F1UNmtW7cwa6y+yndDFxvTOmgDBgwIMtjVDFZdfE2/N1G5eFdgOpVNSzzoxUxgGsjVBR40M0OzSLS2bfBNH9f++eWXX8JdJkIvHvSzFihQIKCvIkMD+prpoiUXAACA89NgrAZldZp/SLReq87AsY/hdbFZXUxLb0J/8MEH5npDx4l6U17HWkqvJ/QaQ7Nz9Wa0llwIniUanAZpNXD42WefmZvHumjWy9jXI+jevbtpn720g47HOnToYNqli+dqCS7NItb1PTQ7NTwL32rigo53dVypwVLtH52lqJ/fPiOpZs2aZkxbrVo181m1lIEmawSvMfuqvL29zfWRvreO5UePHm3OQ/DSBDpW1/Ux9HpPy2bpuFDLkOlCxHoOAmfC6vWL9kXHjh3N+F73HTt2rCnLpeXK9LrwVdn7X69xNNiu/R+R4C8AJ2YDEKo6derov+y23Llz21q1amUbMGCArXv37rYyZcqYx+PEiWObPXt2kNds3brVljhxYlu8ePFszZo1M68pX7682T9Xrly2K1euBNm/XLly5rngSpUqZR4vVqyYrW/fvraGDRva4sePb6tXr555/Keffgqyv+7n5uZma9GihW3IkCG2YcOG2U6dOmWe031Des3cuXNtcePGtSVJksTWtm1bW//+/W1FihQJeN+HDx8G2V8f1/aGJFu2bGYLj3v37tkKFixojuft7W376KOPbM2bNzd9VrNmzRDbunz5cluiRIlMe3WfPn362Lp27WqrVauWLVmyZLaqVauG673/+ecfW8aMGc176Hn88MMPzTmtWLGiLXXq1EH2HTVqlNkvTZo0tk6dOpnzkC9fPvOYfjf8/f1f2j96vnPmzGmee+edd8z3oWnTpjZ3d3fzPdHvS2D6PdN9T548GWL79XPbv5O9evWytWvXznyekiVLmj+Dn4OVK1ea/fPkyWP6Wb8XM2bMCPO86XnX86+v8/LyMt+LNm3amPZq/+v3JrDPPvvM7Ltx48YX2hvady80mzdvNvsPHz48yOODBg0yj+t7hUX/n9P95syZE/CY/Rzqa+1bz549bWXLljXPJUiQwLZhw4ZQj2n/DC977+PHj5v99LsCAABcw7vvvmtLmDCh7f79+6Hu07p1azPOvXbtmvn9+vXrZhybKVMmM77PnDmzGQPan1dLliyxvfnmm2bMGHgspfuFNObWcWmWLFnMvp9//vkLz+vYMviY7NmzZ7Zu3brZ0qZNa64jgl+TTJ482Vwb6Bhcx9tvvfWWGTtfuHAhzD7RNur1xX///WerUqWKGUO+/vrrZizl5+cXZN8ff/zRjFN1PPbGG2+Y9tnHloHp7126dLGF1/bt220lSpQwbdcxsrZ7zZo1IY5Zx40bZ/pU26BjYH2tfu5q1aoF2e/Jkye2L7/80lagQAGzb6pUqcx+eu11+/btl7ZV30P7JjAdm+v3QK8rw7oGAOCaCNoCYTh69Kjtq6++slWuXNmWI0cOMyDTTYOv+g+ur69viK/7888/bT4+PrbXXnvNDND0H+gePXrYrl69+sK+oQVtddDWsmVLE0jUwYYOOnSgEVoQ7NixY7YaNWrYUqZMGTDosg9IwgqcbdmyxVa9enXzOh005s2b1/bJJ5+YwOoLf2FEUdDWPlj94IMPzCBR+1QHPAsXLgyzrXo+NEip76Nt1YGSDh416Lpnz55wv/elS5fM+dBgqh5H+7h48eK2b7/99oV9dcCsn1kHqjo40/fTYO7Tp0/D3T963rWN2m79Puj3Qr8ff/311wv7vixoq4NFDWjaB7dZs2Y1gdy7d++Geg70O6z763sHb2Nor9Hzr98D/T5oH+n3Q78nwYPMUR20VXqBopudDu71Yka/1ydOnAjztevWrTPvp//P2unvwTftC+279957z3bo0KEwjxneoO3gwYPNfgcPHgz3ZwUAAHA29qBtbKVjT70+aN++vdVNAeDi3PQ/Vmf7AgBgp9MA27dvL9u2bQt36QiraTkRLYmg9Zp18Q8AAABXpSXE5s+fL/fu3RNHp+tU6CJogUshaDkwLc+mJbeaN29uafsAuDZ3qxsAAEDwgb7WHhsyZEi4Fo1zBD///LOcPn3arIIMAACA2EHXxejVq5epMayLkunaEZpAoGuW6GMAYCWCtgAAh6Ir/k6bNs0s6KcLe+gidI5OszN0cTtPT0+rmwIAAIBw0kVus2TJIuPGjZMbN26YhWlbtmwpI0eOfOni0QAQ3SiPAAAAAAAAAAAOJI7VDQAAAAAAAAAA/D+CtgAAAAAAAADgQKhpCwAAAEQRf39/uXDhgqnHHXg1cgAAAEDZbDazfkvGjBklTpzQ82kJ2gIAAABRRAO2uqgNAAAAEJazZ89K5syZQ32eoC0AAAAQRTTD1j4IT548Of0KAACAIO7cuWNu8tvHjaEhaAsAAABEEXtJBA3YErQFAABAaF5WSouFyAAAAAAAAADAgRC0BQAAAAAAAAAHQtAWAAAAAAAAABwINW0BAAAAAADgMPz8/OTp06dWNwOIkHjx4kncuHElsgjaAgAAAAAAwHI2m00uXbokt27dsropQKSkTJlS0qdP/9LFxsJC0BYAAAAAAACWswds06VLJ4kTJ45UwAuw6sbDgwcP5MqVK+b3DBkyRPhYBG0BAAAAAABgeUkEe8A2TZo0nA3EWokSJTJ/auBWv88RLZXAQmQAAAAAAACwlL2GrWbYArGd/XscmdrMBG0BAAAAAADgECiJAGfgFgWlPQjaAgAAAAAAAIADIWgLAAAAAAAAAA6EhcgAAAAAAADgkGrPfxSj77fUJ+Er7d+6dWv5+eefpUOHDjJx4sQgz3Xp0kUmTJggrVq1kunTp0dxS+HsyLQFAAAAAAAAIihLliwyZ84cefjwYcBjjx49ktmzZ0vWrFnpV0QIQVsAAAAAAAAggjw9PU3gduHChQGP6c8asPXw8Aiyr7+/v4wYMUJy5MghiRIlksKFC8v8+fMDnr9586Y0b95c0qZNa57PkyeP/PTTT+a5J0+eSNeuXSVDhgySMGFCyZYtmzmW3bfffitvvfWWJEmSxLSnc+fOcu/evSDvP2XKFPNc4sSJpV69euY1KVOmDLLPkiVLzGfS98iZM6cMGTJEnj17Zp6z2WwyePBg89kSJEggGTNmlO7du4fZP2Edz75o19SpU017tF36mZcuXRrQX5kzZ5YffvghyDEPHDggceLEkdOnT5vfz5w5I3Xq1JGkSZNK8uTJpVGjRnL58mXz3KlTp8y+vr6+QY4xZswY04f6HurQoUNSvXp1c4zXX39d3nvvPbl27VrA/nqetH/1vKRJk0YqVaok9+/fl+hC0BYAAAAAAACIhLZt2wYEV9W0adOkTZs2L+ynQdYZM2aYUgp///239OrVS1q0aCGbN282z3/yySdy+PBhWbVqlRw5csQEK1977TXz3Lhx40wwc+7cuXLs2DGZNWuWZM+e/f+DfHHimH30uFqyYcOGDfLhhx8GPL99+3bp2LGj9OjRQw4ePCiVK1eW4cOHB2nf1q1bpWXLlmYfbcekSZNMaQf7fgsWLJDRo0ebx//9919ZvHixCWSG5mXHs9NArgZa//zzT6lRo4YJXN+4ccN8pqZNm5qs5cD0s5cqVSog6KoBW91f+3HdunVy4sQJady4sdlX+0gDrIHPj9LftbyFvsetW7fknXfeMUF2De6uXr3aBH21TerixYumHXqe9bxs2rRJ6tevb4LY0cXNFp1HBwAAAFzInTt3JEWKFHL79m2T5QEAAMJHywmcPHnSZKBqRmZsqmmrAT97BqsGU9Ubb7whZ8+elfbt25tMVg1UPn78WFKnTi2///67lCxZMuAYus+DBw9MYLJ27domSKtB3+A0o1UDsvp6zU59Gc0M1SCtPVu0SZMmJvN2+fLlAftowFh/18+gNLhZsWJFGTBgQMA+v/zyiwn+XrhwwWTmauBVs1LjxYv30ja87HhKP8ugQYNk2LBh5nfNXk2aNKkJXFerVs0EmDVTVzNmNcNXg7T6p75GP58GaTVDVr8/eg6UBogLFCgge/bskaJFi5pAt+6rwVfNEN6/f794eXmZ4K4GdT///HMTYF6zZk1AO8+dOxdwTrXfihQpYtqggeKIfp9fZbxIpi0AAAAAAAAQCVrOoGbNmiY4qxmc+rM9Q9bu+PHjJjirGa4alLRvmnn733//mX06depk6uO+/fbbJrC5Y8eOIAFiDWDmy5fPBHDXrl0b5PgazNUAaaZMmSRZsmRmev/169fNeyoNPhYrVizIa4L//scff8jQoUODtO/99983wU49TsOGDU3tXi1zoI8vWrQoSKmD4F52PLtChQoF/KzlHZInTy5Xrlwxv2tf5M+fPyDbVrNp9Tlti9LMVw2u2gO26s033zTBcn1O1a1bV+LGjWvaq/Q8VahQISBTWdu5cePGIO3UwLvSc6NlLLRvNatY31eD9FrKIjoRtAUAAIDTGzlypMni6NmzZ5j7zZs3zwzQNSNCB+UrV66MsTYCAIDYTafOazBQSxPoz8HZ68uuWLHCBF/tm2aF2uvaasao1mnVsgmaiaqBwr59+5rnNNtUszc1I1UDpzp138fHxzynGaC1atUywU8tYbBv3z4ZP358QC3c8NI2aqmCwO3766+/TCkEHR/ZM08nTJhgartq3dyyZcvK06dPI3Q8u+BZu25ubgG1ZpWWS7AHbfVPzcDVurLhFT9+fFOmQQPq2h96jMDnSNv57rvvBmmnbtpO/Xwa8NWMXs3+1YDwd999Z4Lnej6ii3u0HRkAAABwAHv37jXT+AJncIREM1m0VpnWmtOLHh3Ma1aGTp8rWLBgjLUXAADEThpI1ICgBhyrVq36wvMa7NOp+bpoVrly5cLM2m3VqpXZypQpI/369ZNvvvnGPKcZqFqrVTcN2Op7ai1XDdJqkHPUqFGmRqvSkgCBaZBRx0WBBf9dA8MalM2dO3eo7dNgrQY4devSpYu54a2BWH1tcOE5Xng0a9bMlEPQz6kBbq0JbKdZuFqKQrfA5RG05IP2eeAyFDqm04CzZgdrTdrA7dRgt2beuruHHC7V86p1dHX79NNPTZkEzdzt3bu3RAeCtgAAAHBamjWhmRk6hU1rlYVl7Nix5sJHL4yUZrFoRsX3338f5MIAAAAgJJqNaZ+Orz8HpyULNGtWs2g1wFq6dGlT11QXCNNgrAZpNRiotVO1HqvWwNV6sxqUVFpPNkOGDGaxLA3M6gyh9OnTmzIAGhTVbFfNANVgqh4z+PilW7duJmtUj6P76EJlmjkauD6uvr/evNaasRoU1vfR0gFaw1bHUppJ7OfnJ8WLF5fEiROb+rQaxA2tzuvLjhde2bNnF29vb2nXrp15f639G7hurs6Q0jHfmDFjTEBWM4A1MK51a+20H0uUKCH9+/c3WbbabjsNPut4UW/ga1kKrT2s5Sy0VMXUqVPN4mTr16+XKlWqSLp06WT37t1y9erVgHMTHSiPAADh5Gfzk9MPz8vBO4dlz+2Dsuf2H3Lw7mG58Oiy+Nv+f9oGAMBx6ABca8rpYP5ldu7c+cJ+miWjj4dGL6Z0MYnAGwAAcF0afA1rcSm9KfzJJ5+YmT0a8NMbxlouQRessk/j10W7dIaQfVq+Bg7tQd+vvvrKBCJ1cS0tiaClnDQQqjVXNRj75ZdfmmzSWbNmmfcITDNENZCr++n+q1evNgHkwGUKdOyjgWKtl6vvoUHO0aNHBwRlNUCswU09lrZR6+guW7Ys1FIFLzveq2jevLkJ+NarVy9IwFWDzkuWLJFUqVKZPtPxnNbc/e233144hgZ9NRs6ePmKjBkzmkC3BoQ1MKtBYC2rpZ9X+1fP6ZYtW6RGjRqSN29ek/WrWc1aziK6uNlsNlu0HR0AYjENxP5576jsvf2H/HP/pJx+dF6e2UIusJ4gTnzJmSir5EmcQ0qlLCJ5kjz/BxcAYB29wBk+fLiZ9qcXI+XLlzcLWWgGRkj0Iklr0GmGhZ1On9M6bJcvXw7xNYMHDzbPB/ey1YABZxPTq7vHtFddTR7Aq3v06JGpD6rBy8BBREQvXRTs6NGjsnXrVpfo6mHDhpkM5T///NOy77Pe5E+RIsVLx4uURwCAYO49uy8bb+yUFdc2yJUn1yWuxBE/CTuT9rH/Ezly/7j8c/+ELL26TnIkyiI1XqsgpVMVNQFdAEDM0ppmPXr0MOUNovPCTzNhAtcx00F44JWLAQAAHInWxq1cubIkSZLElEbQG9Z6k9oVSmadOnXKlL16lbIMViJoCwD/oxMP1l7fKtMvzJMn/k/FJs8nIrwsYBuYfd9TD8/J+LMzZOaFhdI5a0splqIw/QwAMUgXqbhy5UqQBTF0uptOa9PBupY1CF5rTmvCBc+o1d/18dDoYiK6AQAAxAZ79uwxJRbu3r1rSgiMGzfOLNDl7Lp27Sq//vqrWWQ2eGkER0XQFgBETEbt92d+lkP3jkVJf9gDvnf97svIkxOkTKpi0j5TE0nmnoT+BoAYULFiRbOKcWBt2rQxqxvr4hMhLQ5SsmRJs8CE1i+z00xdfRwAAMAZzJ07V1zR9OnTzRabELQF4PL23zkkX5+aJE/9Q65XGxXB2+0398ofd4/IZzl7SI7ETJsFgOimC3XoIhyB6TRAXSTD/njLli0lU6ZMAYt0aDkFXWVYF5XQxcu0Jq6uFDx58mROGAAAAGJUnJh9OwBwLDtv7ZcvTow35RD8X6EMwqvyF5uplfvx8a/l2P3/ou19AADhd+bMGbl48WLA797e3jJ79mwTpNUVlefPny+LFy9+IfgLAAAARDcybQG4rH13/pJRp6ZEa7A2MH0fXbBsyH9jZXiefmaxMgBAzNm0aVOYv6uGDRuaDQAAALASmbYAXNKlx1flq5MTA8oXxBR9P83qHfbfOLn/7EGMvjcAAAAAAIgdCNoCcDn+Nn8Zd+Yn8bP5x3jQ1ry/+MudZ/dk2nnXLAAPAAAAAADCRtAWgMtZdW2THL3/X4yVRQiJvvfGmztNiQYAAAAAAIDACNoCcCk3n96WGRcWiCNwEzcZf2aGPPV/anVTAAAAAAAuzM3NzSzACsfBQmQAXMq669vkmc1PHIGWZrj17I7sun1AyqQqZnVzAAAAAMDxfFcwZt+v26FX2r1169by888/y4gRI+Sjjz4KeFwDoPXq1RObLeZL8sE5ELQF4DL8bH6y+tqmCNWxPb/uhFzZfV5uHb4qd47fEP+n/19aod6BDyLcpjjiJiuubiRoCwAAAACxVMKECeXLL7+UDh06SKpUqaxuDgJ5+vSpxIsXT2IjyiMAcBl7b/9hMlsj4tjUA3JqwRG5deRakIBtZOlSaP88OCGnHp6LsmMCAAAAAGJOpUqVJH369CbbNiwLFiyQAgUKSIIECSR79uwyatSoIM9fvHhRatasKYkSJZIcOXLI7NmzzX5jxowJ2OfMmTNSp04dSZo0qSRPnlwaNWokly9fDnKcH374QXLlyiXx48eXfPnyycyZM4M8/++//0rZsmVNsPnNN9+UdevWBXn+yZMn0rVrV8mQIYPZJ1u2bGF+tmfPnkn37t0lZcqUkiZNGunfv7+0atVK6tatG7CPv7+/OYZ+Lv18hQsXlvnz5wc8v2nTJlOiYf369eLl5SWJEycWb29vOXbsWJD3WrJkiXh6epp25cyZU4YMGWLe306PoZ+/du3akiRJEhk+fPhLX6fZ0IMHD5asWbOac5MxY0bzeaxG0BaAy9h5+4DEiehfe24iSbIkl0xVcsprRTJEabu0Tbtu7Y/SYwIAAAAAYkbcuHHliy++kO+++07OnQs5IWffvn0mwNqkSRP566+/TJDwk08+kenTpwfs07JlS7lw4YIJYGqAd/LkyXLlypUggU8N2N64cUM2b95sgq0nTpyQxo0bB+yzaNEi6dGjh/Tp00cOHTpksn/btGkjGzduDDhG/fr1TUB39+7dMnHiRBNkDWzcuHGydOlSmTt3rgmazpo1ywSPQ6NZxrrPTz/9JNu3b5c7d+68UB9XA7YzZsww7/f3339Lr169pEWLFuZzBPbxxx+bYLavr6+4u7tL27ZtA57bunWr6SP9fIcPH5ZJkyaZ/rMHZu20b7U0hfazvv5lr9O+Hj16tHlcA9ra9rfeekusRnkEAC7j2P0T4i8Ry5ItN72OxE34/K/MIxN95dq+i1HWLi3XcPzB6Sg7HgAAAAAgZmmQ8O2335bPPvtMfvzxxxee//bbb6VixYomUKvy5s1rAohff/21qYt79OhR+f3332Xv3r0m01RNnTpV8uTJE3AMzULVQOTJkyclS5Ys5jENhGr2rr6uaNGi8s0335jjde7c2Tzfu3dv2bVrl3m8QoUK5j30vdasWWMySpUGnKtXrx4km1fft3Tp0iZzVTNtw6LB6gEDBpg+UN9//72sXLky4PnHjx+b99D3LlmypHlMs123bdtmAqXlypUL2FcDqfbfP/roI5N5/OjRI5Mhq9mx+phm8dqPMWzYMPnwww9Nv9s1a9bMBKrtNHAb1uv082qmtGZMaykFzbgtVsz6dWfItAXgEh74PZQrT65F+PX2gG100KDtvw9ORtvxAQAAAADRTzNOdVGyI0eOvPCcPlaqVKkgj+nvmtnp5+dnMlo1s1Sn8Nvlzp07SI1cPYYGa+0BW6XlDbQsgf09Q3ufwM/r6+0BW2UPpNpp0PfgwYOmtIKWCVi7dm2on/n27dumPEPgIKdmHhcpUiTg9+PHj8uDBw+kcuXKpqyDfdOA83///RfkeIUKFQr4OUOG57Nc7dnGf/zxhwwdOjTIMd5//31TVkKPb2cPetu97HUNGzaUhw8fmmCuPq7ZyoFLLliFTFsALuHkw7PiyO763ZcbT29J6ngprW4KAAAAACACtE5s1apVTdapBj5jKw0cazbvqlWrTHaslnXQLNTANWhfxb1798yfK1askEyZMgV5TmvIBhZ40TA3N7eAkg7242i2rZZ3CE4zce20lm3w9w/rdRrE1qC5flYtOaFZypoBraUbrFzEjKAtAJdw7ckNcXRXn9wgaAsAAAAAsdjIkSNNmQTNUg0sf/78pt5rYPq7lknQzFTdX7M7Dxw4EJClqhmqN2/eDHKMs2fPms2ebaslFm7dumUybgO/j70UgP19Aj+vr9csU3smq5ZPCE4XOdNaubr5+PhItWrVTC3d1KlTB9kvRYoU8vrrr5vyDBq0Vpo5vH//ftMPSt9bg7NahiBwKYSIBJOPHTtmMpCj+nW6ONq7775rti5dusgbb7xhSlEEznyOaQRtAbiEJzbrpza8zLNY0EYAAAAAQOh0AavmzZubxbwC04XBtOas1lLVQOjOnTtN7dcJEyaY5zVIqNmsH3zwgfzwww8mw1Nfo8FEe8apPm8//pgxY0yQV7NCNRBqLwnQr18/kxnr4eFh9l+2bJksXLjQZJHaj6GBYg3qajapLhqmi38Fr7+rAV09Rpw4cWTevHmm5quWYQhJt27dzEJjGhTVz6E1bjXYbG93smTJpG/fvmbxMc2a1Vq5WlZBg8kaHA4cYA7Lp59+KrVq1TI1ZzWQrG3T0ge64Nrnn38e4dfpomQaaC5evLgkTpxYfvnlF9PvL6vlG92oaQvARdjE0fnbHL+NAAAAAICwaf1U+5R+O83YnDt3rsyZM0cKFixoAom6X+AyClrjVbNWNWNVF/XS+qoa8LRP/dcg6JIlS0ydW91HA7Bah/W3334LOEbdunVl7NixZuExXaBMF/r66aefpHz58uZ5DVhqzVat4ap1aNu3b28W/wpM3/Orr74ygWANNJ86dcosLKavDUn//v2ladOm0rJlS1MfV2vGapmIwCULNFiti7BpcFezfTVzV8sl5MiRI9xfp6pVq8ry5ctNjV1tV4kSJWT06NEvDa6+7HUajJ4yZYqp/as1dTXArcHuNGnSiJXcbDaiBACc3+Ybu2TsmZ+i5FhHJvrK0Un7A36vd+CDKDnuiDz9JV+SnFFyLACANTRbRacJavaIZo4ArqL2/EfizJb6/H/gAUD0ePTokamjqkG8wME+V3bu3DlTBkGDiBUrVpTYQgPWGpjVjF8N1rqiR2F8n8M7XqQ8AgCXkCbe/6+46aheiwVtBAAAAABEjw0bNphFs7QEgtac/fDDDyV79uwBtWId1enTp00Wq5ZpePz4sSn7oAHLZs2aWd20WI2gLQCXkCNx1ki9/sTcw3L/3B3z840/Lgd57q9v/79oe46Gb0rSLK+eWZU0bhIWIQMAAAAAF/b06VMZOHCgnDhxwpQo8Pb2llmzZpn6to5MyyZoXVitW6sT+rX8g2YHa7YtIo6gLQCXkCRuIkkXP41ceXI9Qq8/v/Y/ubbvYojPHZ/5Z8DP6ctmfeWgrZu4SZ7E2QOKtAMAAAAAXI/WXtUtttESDrqoGKIWC5EBcBl5E+eUOA74154GbXMnzm51MwAAAAAAgIMg0xaAyyiR0kO23dobodeWmfquRBd/8ZfiKd6OtuMDAAAAAIDYxfFSzgAgmhRL8bYkd0/qkFm2OSNZcxcAAAAAnIG/v7/VTQAc4ntMpi0Al+HuFleqpSkv8y+vEH+xiSOwiU1qvlbB6mYAAAAAgKXix49vFrS6cOGCpE2b1vzOuh+IbXQhtidPnsjVq1fN91m/xxFF0BaAS6mcprQsvLJK/G1+DpFlm8w9qZRMWcTqpgAAAACApTTAlSNHDrl48aIJ3AKxWeLEiSVr1qzmex1RBG0BuJQ08VNJ8wz15OcL8x0iy7Zzlvckfpx4VjcFAAAAACynWYka6Hr27Jn4+VmfaANERNy4ccXd3T3SmeIEbQG4nFppK8rac5vlgu2yuMW1prS3zc8mRRIUkGIpClvy/gAAAADgiDTQFS9ePLMBroyFyAC4XH2ZKZMmy6+NJ2mqq2VlEfzuPZUx1YfLsmXLrGkEAAAAAABwWARtAbiMBw8eSKtWraRTp07StEoj6Zv9AxNAjUn6fvHd4smQN/pI6SLeUrt2bRk4cKCZ/gMAAAAAAKAojwDAJfzzzz/SoEEDOXHihPzyyy/SvHlz87h/XJuMOT3tfxVmo1cccRN3N3cZlKubFEiaVxYtWiRff/21DBgwQHbv3i2//vqrpEuXLppbAQAAAAAAHB2ZtgCc3sKFC8XLy0uePHligqP2gK0qk6qY9M/RyQRT40TjX4l67MRxE8mwPH1NwNZeq+nDDz+U9evXy99//y0eHh6yffv2aGsDAAAAAACIHQjaAnBaT58+lb59+5oM26pVq8revXulYMGCL+yni4GNeeMzyZM4R5S3wS3Qe4x7Y4jkSZz9hX3Kly8v+/fvl5w5c5qfx44da2rvAgAAAAAA10TQFoBTunjxolSsWFHGjBkj3377rcydO1eSJ08e6v4ZEqST4Xn6SrtMjSWem3uka93aX504bmJTO/fDHB0lZbzQ3z9jxoyyYcMG6d69u/Ts2VOaNGkid+/ejVQbAAAAAABA7ERNWwBOZ/PmzdK4cWOJEyeObNq0SUqXLh2u18VxiyM1074jpVMVlfXXt8vKaxvlxtNbElfiiJ/4h+sY9n0zJkgvtdK+I2VTFZdEcROG67Xx4sWTUaNGScmSJaVt27ZStGhRWbBggRQoUCBcrwcAAAAAAM7BzcYcXABOQv86++abb8zCXmXKlDELe6VPnz7Cx/Oz+cv+O3/J3tt/yj8PTsi5R5fEP5TgrbtbXMmWMLPkTZJDSqX0kvxJcpuatRF17NgxU9bh5MmTMnXqVGnatGmEjwUAiDl37tyRFClSyO3bt8Oc4QE4m9rzH4kzW+oTvpvwAABE1XiRTFsATkH/smvTpo0sWrRI+vfvL59//rm4u0fur7i4bnGkaIrCZlNP/Z/K6Ufn5ebT2/LE/6kJysZ3iydp46eRzAnTS1y3uFH0aUTy5ctnFk3r0KGDNGvWTHbs2GGycOPHjx9l7wEAAAAAABwTQVsAsd6ff/5pslKvXr0qixcvljp16kTL+8SLE09yh7CQWHRJkiSJzJw5U0qVKiU9evQwC6nNmzdPsmTJEmNtAAAAAAAAMY+FyADEajNmzJASJUpI4sSJxdfXN9oCtlbRbN5OnTrJtm3b5MKFC+Lp6Snr1q2zulkAAAAAACAaEbQFECs9evRIOnbsKK1atTKLju3cuVNy584tzqpYsWKyf/9+E7StWrWqKf/g7x++xdEAAAAAAEDsQtAWQKxz6tQpKV26tEyfPl2mTJki06ZNM5m2zu61116TlStXyqeffmq2d999V27cuGF1swAAAAAAQBQjaAsgVlm1apXJNr1+/bps375d2rdvb0oIuIq4cePK4MGDTfB2165dpi/27dtndbMAAAAAAEAUImgLIFbw8/Mz2aU1a9YUb29vE6gsUqSIuKpq1aqZcglp06Y1/TF58mSx2WxWNwsAAAAAAEQBgrYAHN61a9ekevXqpo7rsGHDZOnSpZI6dWpxddmyZTMLlLVt21Y6dOggbdq0kQcPHljdLAAAAAAAEEnukT0AAESn3bt3S8OGDeXhw4eydu1aqVSpEh0eSIIECeSHH34w2bYauD1w4IAsWLDAqRdlAwAAAADA2ZFpC8Ah6VT/CRMmSJkyZSRTpkymFAAB29C99957JsCtwW0tG7F48eIYPFsAAAAAACAqEbQF4HDu378vLVq0kC5dukjHjh1l8+bNkiVLFqub5fDeeust2bt3r1SsWFHq1asn/fv3l2fPnlndLAAAAAAA8IoI2gJwKMeOHZPixYvLkiVL5Ndff5Vx48ZJ/PjxrW5WrJEiRQpTHuGbb76RUaNGmezkS5cuWd0sAAAAAADwCgjaAnAY8+fPFy8vL/Hz85M9e/ZIkyZNrG5SrOTm5iZ9+vSRDRs2mCC4p6enbN261epmAQAAAACAcCJoC8ByT58+ld69e5sFx2rUqGECtm+++abVzYr1ypYta2oB58mTRypUqCDffvutqRUMAAAAAAAcG0FbAJY6f/68CSh+9913MnbsWJkzZ44kS5aMsxJFMmTIIOvXrzdBcc2+1cD4nTt36F8AAAAAABwYQVsAltm4caOZun/y5Emz2Fj37t3N1H5ELXd3d/nqq69k4cKFsm7dOlOC4tChQ3QzAAAAAAAOiqAtgBjn7+8vI0eONItkFSxYUA4cOCDe3t6ciWhWr1498fX1lYQJE5rF3n755Rf6HIBT++GHH6RQoUKSPHlys5UsWVJWrVoV6v7Tp083Nw8Db/p3JgAAABDTCNoCiFG3bt0ywcMBAwbIRx99JGvXrpV06dJxFmKI1rfdtWuX+Pj4yHvvvSedO3eWx48f0/8AnFLmzJnNTcJ9+/aZm1bvvPOO1KlTR/7+++9QX6PB3YsXLwZsp0+fjtE2AwAAAMqdbgAQUw4ePGiChdeuXZOlS5fKu+++S+dbIHHixCabrFSpUtKtWzcTyJg3b55ky5aN8wHAqQT/d2b48OEm+1ZvXhUoUCDE12h2bfr06WOohQAAAEDIyLQFECM0SKjTUjWDaf/+/QRsLaZBiQ8++EC2b98uV65cMbWF16xZY3WzACDa+Pn5mcUu79+/b/49Cs29e/fMTawsWbK8NCtX6WwFXeAx8AYAAABEFkFbANHq0aNH8v7770ubNm2kefPmJkiYM2dOet1B6KJkOm24WLFiUr16dRkyZIipOQwAzuKvv/6SpEmTSoIECaRjx46yaNEiefPNN0PcN1++fDJt2jRZsmSJqfutfx9qzfVz586FevwRI0ZIihQpAjYN9gIAAACR5Waz2WyRPgoAhODkyZOmHMLhw4dl/Pjx0rZtW/rJQWlgQqcNf/bZZ1K1alUTrEiTJo3VzQKASHvy5ImcOXNGbt++LfPnz5epU6fK5s2bQw3cBvb06VPJnz+/NG3aVIYNGxZqpm3g2uCaaauBW30/nV0CuIra8x+JM1vqw6KEAICooeNFvdn/svEimbYAosWKFSvMlHtdeGzHjh0EbB1cnDhx5JNPPpHVq1fL3r17zbnTPwEgtosfP77kzp1bihQpYrJiCxcuLGPHjg3Xa+PFiyceHh5y/PjxUPfRDF4dbAfeAAAAgMgiaAsgymsGDho0SGrVqiVlypQxi1zpBS9ihypVqpiaw7oIT+nSpWXixInChAwAzjazIHBm7Mv+TdPyChkyZIj2dgEAAACBEbQFEGWuXr1qptZrJpNuixcvllSpUtHDsUzWrFlly5YtphZxp06dpGXLlmbhHgCIbQYMGGD+Pjt16pQJvurvmzZtMjXWlf79po/ZDR06VNauXSsnTpwwN7BatGghp0+flvbt21v4KQAAAOCK3K1uAADnsHPnTmnYsKGpHbhu3Tp55513rG4SIkGn+37//fdmAR4N3h48eFAWLFggefPmpV8BxBpXrlwxgdmLFy+aumGFChWSNWvWSOXKlc3zWutWy8PY3bx50/ydd+nSJXPTUUsqaImf8NS/BQAAAKISC5EBiBSdOv/dd99Jnz59pFixYjJ37lzJlCkTvepE/v77b6lfv74JekyfPt38DACI3MISgLNhITIAAMKHhcgARLt79+6ZFbV79OghXbt2NVNOCdg6nwIFCphFybT0RYMGDaRv375mRXUAAAAAABA9qGkLIEKOHDliMmtXrFghv/32m4wePdqssg3npNlimkWt51lXXa9YsaLJvAUAAAAAAFGPoC2AV6ZB2qJFi4qbm5vJwGzUqBG96AL0fPfs2VM2btwox48fFw8PD9m8ebPVzQIAAAAAwOkQtAUQbrrImJZCaNKkidSuXVt2794tb7zxBj3oYkqXLi0HDhwwC/Noxu3XX39tahsDAAAAAICoQdAWQLicO3dOypcvLz/88IN8//33MmvWLEmaNCm956Jef/11Wbt2rfTr108+/PBDsziZLroDAAAAAAAij6AtgJdav369eHp6ytmzZ2XLli3SpUsXM1Uers3d3V1GjBghS5YsMSUTvLy85M8//7S6WQAAAAAAxHoEbQGEyt/fX7744gupUqWKvP3227J//34pUaIEPYYgtFTGvn37JEmSJOb7MWPGDHoIAAAAAIBIIGgLIEQ3b96UOnXqyMcff2y2VatWSdq0aekthChXrlyyc+dOU++4VatW0qFDB3n06BG9BQAAAABABLhH5EUAnJtm1Pr4+MitW7dkxYoVUqNGDaubhFggUaJEMm3aNClVqpQpoaHZt/Pnz5fs2bNb3TQAAAAAAGIVMm0BBPHjjz+Kt7e3pE6d2gRvCdjiVbVr10527Ngh169fN7WQV65cSScCAAAAAPAKCNoCMB4+fCht27aV9u3bm+nt27ZtI0MSEabBWg366w2AmjVryqeffip+fn70KAAAAAAA4UDQFoD8999/Jrj266+/yvTp02XSpEmSMGFCegaRkipVKlm6dKkMHz7cbNWrV5dr167RqwAAAAAAvARBW8DFLVmyRIoUKSJ3796VXbt2mSxbIKrEiRNHBg4cKGvWrJEDBw6YDNzdu3fTwQAAAAAAhIGgLeCinj17JgMGDJC6detKhQoVxNfXVwoXLmx1s+CkKlWqZIK2mTNnljJlysj48ePFZrNZ3SwAAAAAABwSQVvABV2+fFmqVKkiX331ldkWLlwoKVOmtLpZcHIasN20aZN06tRJunbtKi1atJD79+9b3SwAAAAAABwOQVvAxWzfvl08PDzk8OHDsn79eunXr5+4ublZ3Sy4iPjx48vYsWNN/WQtzVGsWDE5evSo1c0CAAAAAMChELQFXIRORR89erSUL19ecuXKZaaq68+AFZo0aSJ79+4Vf39/KVq0qMybN48TAQAAAADA/xC0BVyALjLWqFEj6d27t/To0UM2bNggGTJksLpZcHH58+eXPXv2SM2aNc33s1evXvL06VOrmwUAAAAAgOXcrW4AgOj1999/S4MGDeTChQsyf/588zPgKJIlS2ZKJZQqVcrcVNDs299++00yZcpkddMAAAAAALAMmbaAE5s9e7apGRovXjzx9fUlYAuHpDWVu3XrJps3b5ZTp06Jp6enbNy40epmAQAAAABgGYK2gBN6/PixdO3aVZo3by7169eXXbt2Sd68ea1uFhAmb29v2b9/vxQsWFAqVaokI0eONDVvAQAAAABwNQRtASdz9uxZKVeunEyZMkUmTJggM2bMkCRJkljdLCBc0qVLJ2vXrpUBAwaYrV69enLr1i16DwAAAADgUgjaAk5Eg10eHh5y8eJF2bp1q3Tq1MlMPQdik7hx48rnn38uy5Ytky1btkiRIkXk4MGDVjcLAAAAAIAYQ9AWcAI6hXzYsGFSrVo18fLykn379platkBsVqtWLfNdTpEihZQsWVJ++uknq5sEAAAAAECMIGgLxHLXr183wa3PPvvMbCtWrJDXXnvN6mYBUSJnzpyyY8cOadGihbRt21bef/99efToEb0LAAAAAHBq7lY3AEDE+fr6io+Pj9y9e1dWrlxpMm0BZ5MwYUJTo1kXKuvcubPJvp0/f74J6AIAAAAA4IzItAViIZvNJpMmTZJSpUqZhZv2799PwBZOr02bNrJz5065ffu2qXO7fPlyq5sEAAAAAEC0IGgLxDIPHjyQ1q1bS8eOHaVdu3ZmwbFs2bJZ3SwgRrz99tsm07Zs2bLy7rvvyscffyx+fn70PgAAAADAqRC0BWKRf//91yzING/ePJkxY4ZMmDBBEiRIYHWzgBiVMmVKWbRokYwcOdJsVatWlStXrnAWAAAAAABOg6AtEEssXrxYvLy85OHDh7J792557733rG4SYJk4ceJI//795ffff5e//vpLPD09TekEAAAAAACcAUFbwME9e/ZMPvzwQ6lXr55UqlTJLD721ltvWd0swCFUqFDB1HTWEiFaMmHcuHGm5jMAAAAAALEZQVvAgV26dEkqVqwo3377rXzzzTcyf/58SZ48udXNAhxKpkyZZNOmTdKtWzfp0aOHNG3aVO7du2d1swAAAAAAiDCCtoCD0gXGPDw85J9//pGNGzdKnz59xM3NzepmAQ4pXrx45ubG3LlzZcWKFVKsWDE5cuSI1c0CAAAAACBCCNoCDkando8aNcpM+86bN68cOHBAypQpY3WzgFihYcOGsnfvXnODo2jRojJnzhyrmwQAAAAAwCsjaAs4kNu3b4uPj4/07dvXZNauX79e0qdPb3WzgFjljTfeMIv11a5d25RK0JIJT548sbpZAAAAAACEm3v4dwUQnf766y9p0KCBXL58WRYuXGgWHgMQMUmTJpVZs2ZJqVKlpFevXib7VksnZM6cmS4FAAAAADg8Mm0BBzBz5kwpXry4JEqUSHx9fQnYAlFASyR06dLF1Ic+e/asqRGt2esAAAAAADg6graAhR4/fiydOnWSli1bmlqcO3fulDx58nBOgCikN0T2799vgrZVqlSR4cOHi7+/P30MAAAAAHBYBG0Bi5w+fdosMDZt2jSZNGmSTJ8+XRInTsz5AKJB2rRpZdWqVTJo0CCzab3bmzdv0tcAAAAAAIdE0BawwOrVq8XT01OuXLki27dvlw8++MBM5QYQfeLGjStDhgyRFStWyI4dO6RIkSImAxcAAAAAAEdD0BaIQX5+fjJ48GCpUaNGwJRtLy8vzgEQg/T/P/1/L3Xq1OLt7S0//vgj/Q8AAAAAcCgEbYEYcu3aNalZs6YMHTrUZPstX77cBI0AxLzs2bPLtm3bpHXr1tK+fXtp27atPHz4kFMBAAAAAHAI7lY3AHAFe/bsMQuN3b9/X9asWSOVK1e2ukmAy0uYMKFMnDhRSpYsKR07djTZtwsWLJBcuXK5fN8AAAAAAKxFpi0QjWw2m/zwww9SunRpyZAhgwkKEbAFHEurVq1k9+7d5qaK1rldsmSJ1U0CAAAAALg4grZANNEAUMuWLaVz587SoUMH2bJli2TNmpX+BhxQoUKFxNfXVypUqCB169aVAQMGyLNnz6xuFgAAAADARRG0BaLBP//8YxYaW7hwocyaNUu+++47iR8/Pn0NOLAUKVKY/2e/+uor+frrr6VKlSpy+fJlq5sFAAAAAHBBBG2BKKY1Mb28vEyWntaybdasGX0MxBJubm7Sr18/Wb9+vRw+fFg8PDxk+/btVjcLAAAAAOBiCNoCUeTp06fSt29f8fHxkWrVqsnevXulQIEC9C8QC5UrV04OHDgguXPnlvLly8vo0aNNjWoAAAAAAGICQVsgCly4cEHeeecdGTt2rAnu/Pbbb5IsWTL6FojFdPFAzbjt2bOn9O7dWxo1aiR37961ulkAAAAAABdA0BaIpM2bN4unp6ecOHFCNm3aZAI8OsUaQOwXL148U992/vz5smbNGilatKj8/fffVjcLQDj98MMPZqHB5MmTm61kyZKyatWqMF8zb948eeONNyRhwoTy1ltvycqVK+lvAAAAxDiCtkAE6VRpXbCoYsWK8uabb8r+/fulVKlS9CfghBo0aCC+vr4miFusWDGZPXu21U0CEA6ZM2eWkSNHyr59+8z/wzorpk6dOqHefNmxY4c0bdpU2rVrZ0qk1K1b12yHDh2ivwEAABCj3GwU6QNe2e3bt6V169ayePFi+eijj2TYsGHi7u5OTwJO7v79+9KxY0f55ZdfpEuXLjJq1ChJkCCB1c0C8ApSp05tMug1MBtc48aNzf/ny5cvD3isRIkS8vbbb8vEiRPDdfw7d+5IihQpzFhBs3sBV1F7/iNxZkt9ElrdBACAkwjveJFMW+AV/fHHH+Ll5SUbN26UJUuWyIgRIwjYAi4iSZIkMmPGDDPlesqUKWbBsrNnz1rdLADh4OfnJ3PmzDFBWS2TEJKdO3dKpUqVgjxWtWpV83hoHj9+bAbegTcAAAAgskgNBF7Bzz//bLLs8uXLJ6tXr5ZcuXLRf4CL0ZrV+vdAkSJFxMfHRzw8PEy5hCpVqljdNAAh+Ouvv0yQ9tGjR5I0aVJZtGiRKWsUkkuXLsnrr78e5DH9XR8Pjd68HTJkiEP0PZmOAFwVf/8BcEZk2gLhoBd6HTp0MCURtNadZtwQsAVcmy5KprWsNfO+WrVqpkyKv7+/1c0CEIzeaD148KDs3r1bOnXqJK1atZLDhw9HWT8NGDDATG2zb2TfAwAAICqQaQu8xMmTJ002nS5aMnXq1BBr4AFwTWnSpJEVK1bI559/Lp999pm5oTNz5kzzOADHED9+fMmdO7f5WTPk9+7dK2PHjpVJkya9sG/69Onl8uXLQR7T3/Xx0Ghda2pbAwAAIKqRaQuEYeXKleYC7+bNm2ZFaQK2AIKLGzeuCdiuWrXKZPLp3xm6Sj0Ax6QZ8VqHNiRaRmH9+vVBHlu3bl2oNXABAACA6ELQFghlsZJPP/1UatasKaVKlZJ9+/aJp6cnfQUgVLpYkZZLSJcunfl7Q7P4bDYbPQZYSEsXbNmyRU6dOmVq2+rvmzZtkubNm5vnW7ZsaR6z69Gjh6lZP2rUKDl69KgMHjzY3ITp2rWrhZ8CAAAAroigLRDM1atXpXr16jJ8+HCzLVmyRFKlSkU/AXipbNmyydatW01Wvi5WpnWwHzx4QM8BFrly5YoJzGpd24oVK5rSCGvWrJHKlSub58+cOSMXL14M2N/b29ssLDh58mQpXLiwzJ8/XxYvXiwFCxbkHAIAACBGUdMWCGTXrl3SsGFDM21y7dq15gIPAF6F1racMGGCCf588MEHZgEkDfzkyZOHjgRi2I8//hjm85p1G5yOA3QDAAAArESmLSBipjB///33UrZsWcmSJYuZ4kzAFkBktGjRwtS4ffjwoXh5eZlsPQAAAAAAwoOgLVzevXv3pFmzZtKtWzfp1KmTybrJnDmzy/cLgMh76623TD3MSpUqSb169eTDDz+UZ8+e0bUAAAAAgDARtIVL00VGihUrJsuWLZM5c+bI2LFjJX78+FY3C4ATSZ48uSmPoAsbffvttyaL/9KlS1Y3CwAAAADgwAjawmXNnTtXihYtan7WhUkaN25sdZMAOCk3Nzfp3bu3bNy4Uf7991/x8PAwC5YBAAAAABASgrZwOU+ePJGePXuaIG3NmjVlz549kj9/fqubBcAFlClTxtTM1pXsK1SoIN98842pqQ0AAAAAQGAEbeFSzp8/bwIl48ePl3Hjxsmvv/4qSZMmtbpZAFxI+vTp5ffff5c+ffpIv379xMfHR27fvm11swAAAAAADoSgLVzGhg0bzJTk06dPy5YtW8zCYzplGQBimru7u3z55ZeyaNEiE8DVUi1//fUXJwIAAAAAYBC0hdPz9/eXESNGSOXKlaVQoUJmanLJkiWtbhYASN26dcXX11cSJUokxYsXl5kzZ9IrAAAAAACCtnBuN2/eNEGRgQMHyoABA2TNmjWSLl06q5sFAAHy5MkjO3fulIYNG0rLli2lU6dO8vjxY3oIAAAAAFyYu9UNAKLLgQMHpEGDBiZwu2zZMqlVqxadDcAhJU6cWKZPny6lSpUypVs0+3b+/PmSLVs2q5sGAAAAALAA5RHglKZNm2ZKIKRMmdKUQyBgC8DRaY3tDz74QLZv3y5Xr14VT09PWb16tdXNAgAAAABYgKAtnMrDhw+lXbt2Znvvvfdkx44dkiNHDqubBQDh5uXlZW42aY3bGjVqyODBg8XPz48eBAAAAAAXQtAWTuPEiRPi7e0ts2fPNpm2U6ZMkYQJE1rdLAB4ZalTp5bly5fL0KFDzabB22vXrtGTAAAAAOAiCNrCKWjN2iJFisidO3fMgj5t2rSxukkAEClx4sSRQYMGmQUU9+3bZ8ol7Nmzh14FAAAAABdA0Bax2rNnz2TgwIFSu3ZtKVu2rAlsvP3221Y3CwCiTOXKlc3CihkzZpTSpUvLhAkTxGaz0cMAAAAA4MQI2iLWunLlilStWlW+/PJLGTlypCxatMgsPAYAziZLliyyZcsW6dChg3Tp0sXU7L5//77VzQIAAAAARBOCtoiVdIExDw8POXTokPz+++/Sv39/M5UYAJxV/Pjx5bvvvjN1u/UmlS5UduzYMaubBQAAAACIBkS5EKvolOCxY8dKuXLlJEeOHGaF9QoVKljdLACIMU2bNjW1bbU8TNGiRWXBggX0PgAAAAA4GYK2iDXu3r0rTZo0kZ49e0q3bt1k48aNkilTJqubBQAxrkCBArJ3716pVq2a+Pj4SJ8+feTp06ecCQAAAABwEu5WNwAIj8OHD0uDBg3k3LlzMnfuXGnYsCEdB8ClJUuWTH777Tfx9vaWfv36mexb/V0XLAMAAAAAxG5k2sLh/frrr1KsWDFTs9bX15eALQD8j5ubm5l9sGnTJjlx4oR4enqanwEAAAAAsRtBWzisJ0+emDIIzZo1kzp16sju3bslX758VjcLABxOqVKlTI3vN998UypWrChfffWVqQEOAAAAAIidCNrCIZ09e9YsNjZp0iQZP368/PLLL5I0aVKrmwUADuv111+XtWvXSv/+/c1Wr149uXXrltXNAgAAAABEAEFbOJzff//dTPE9f/68bN26VTp37mymAAMAwubu7i5ffPGFLFmyxJRJ8PLykj/++INuAwAAAIBYhqAtHIa/v78MHz5cqlSpIh4eHmaqb/Hixa1uFgDEOrVr15Z9+/aZxcpKlCgh06dPt7pJAAAAAIBXQNAWDuHGjRsmyDBo0CD55JNPZNWqVfLaa69Z3SwAiLVy5colO3bsMHXB27RpIx988IE8evTI6mYBAAAAAMLBPTw7AdFJs8F8fHzk9u3bsmLFCqlRowYdDgBRIFGiRPLjjz+Kt7e3dOnSxfx9O3/+fMmRIwf9CwAAAAAOjExbWEZXNp8yZYpZ9TxNmjSmHAIBWwCIeu3atTNZtzdv3pQiRYrIypUr6WYAAAAAcGAEbWGJBw8eSNu2bc103datW8u2bdske/bsnA0AiCa6wKNm2uqNspo1a5pSNH5+fvQ3AAAAADgggraIccePHzdTdX/77Tf5+eefZeLEiZIwYULOBABEs1SpUsmSJUvMoo9ffPGFVKtWTa5evUq/AwAAAICDIWiLGKXBAp2ae//+fdm1a5e0bNmSMwAAMShOnDgycOBAWbt2rfzxxx8mA1f/PgYAAAAAOA6CtogRz549k/79+0vdunXlnXfeEV9fXylUqBC9DwAWqVixoqklniVLFilbtqx8//33ptY4AAAAAMB6BG0R7S5duiSVK1eWUaNGyddffy0LFy6UFClS0PMAYLHMmTPLpk2bpHPnztKtWzdp1qyZ3Lt3z+pmAQAAAIDLI2iLaKULjOnU2yNHjsj69eulb9++4ubmRq8DgIOIHz++jBkzRubMmSPLli2TYsWKydGjR61uFgAAAAC4NIK2iBY6xXb06NFSvnx5yZ07txw4cEDKlStHbwOAg2rcuLHs3bvX/Fy0aFGZO3eu1U0CAAAAAJdF0BZR7s6dO9KoUSPp3bu39OrVy2TYZsiQgZ4GAAeXP39+2bNnj9SqVcsEcXv27ClPnjyxulkAAAAA4HLcrW4AnMuhQ4ekQYMGcvHiRVmwYIHUr1/f6iYBAF5B0qRJZfbs2eLt7S19+vQx2beadZspUyb6EQAAAABiCJm2iDKzZs2S4sWLm/qIvr6+BGwBIJbS2uO6MNnmzZvl9OnT4uHhIRs2bLC6WQAAAADgMgjaItIeP34sXbp0kRYtWpgs2127dknevHnpWQCI5UqWLGlqkhcuXFgqV64sI0aMEH9/f6ubBQAAAABOj6AtIuXMmTNStmxZmTp1qkycOFF+/vlnSZIkCb0KAE4ibdq0snr1ahk4cKDZ6tatKzdv3rS6WQAAAADg1AjaIsLWrFkjnp6ecunSJdm2bZt06NDBTKkFADiXuHHjyrBhw2T58uXm7/siRYqYDFwAAAAAQPQgaItXplNjhw4dKtWrV5eiRYvK/v37zZ8AAOdWs2ZN2bdvn6RKlcqUTpg2bZrVTQIAAAAAp0TQFq/k+vXr5qJ98ODBZluxYoWkSZOGXgQAF5EjRw7Zvn27tGzZUtq1a2e2hw8fWt0sAAAAAHAq7lY3ALHH3r17xcfHR+7duyerVq2SqlWrWt0kAIAFEiZMKJMnTxZvb2/p1KmTmXGxYMECyZkzJ+cDAAAAAKIAmbZ4KZvNJpMmTZLSpUtL+vTpTR1DArYAgNatW8vOnTvl7t27ps7tsmXL6BQAAAAAiAIEbRGmBw8eSKtWraRjx47Svn172bJli2TNmpVeAwAYb7/9tvj6+krZsmWldu3aMnDgQHn27Bm9AwAAAACRQNAWofr333+lRIkSZsrrL7/8IuPHj5cECRLQYwCAIFKmTCmLFi2SkSNHypdffmlmY1y5coVeAgAAAIAIImiLEC1cuFC8vLzk8ePHsnv3bmnevDk9BQAIfUARJ470799f1q9fL4cOHRIPDw/ZsWMHPQYAAAAAEUDQFkHolNZ+/fpJgwYNpHLlymbxsYIFC9JLAIBwKV++vKl9niNHDilXrpyMHTvW1EYHAAAAAIQfQVsEuHjxolSsWFFGjx4t3377rcybN0+SJ09ODwEAXknGjBll48aN0r17d+nZs6c0adLELFYGxLQRI0ZI0aJFJVmyZJIuXTqpW7euHDt2LMzXTJ8+Xdzc3IJsCRMmjLE2AwAAAIqgLYzNmzebqaxax1YvtHv16mUuUgAAiIh48eLJqFGjzA3AVatWSbFixeTw4cN0JmJ8fNOlSxfZtWuXrFu3Tp4+fSpVqlSR+/fvh/k6vWmtN7Pt2+nTp2OszQAAAIAiaOvidMrq119/bTJs8+fPL/v375cyZcpY3SwAgJPw8fExpXbixo1rAre//vqr1U2CC1m9erW0bt1aChQoIIULFzZZtGfOnJF9+/aF+Tq9cZ0+ffqA7fXXX4+xNgMAAACKoK0Lu337tqld++GHH0rfvn1NBopemAAAEJXy5ctnFrXUqenNmjWTbt26yZMnT+hkWDL2UalTpw5zv3v37km2bNkkS5YsUqdOHfn7779D3VcXbb1z506QDQAAAIgsgrYu6s8//xQvLy+zyveiRYtk5MiR4u7ubnWzAABOKkmSJDJz5kyZMGGCTJo0ySxSdvbsWaubBRfi7+9vaiyXKlUqzEVW9SbDtGnTZMmSJfLLL7+Y13l7e8u5c+dCrZubIkWKgE0DvQAAAEBkEbR1QTNmzJASJUpI4sSJzfRAzXwCACC66ZTzTp06ydatW+X8+fPi6ekpv//+Ox2PGKG1bQ8dOiRz5swJc7+SJUtKy5Yt5e233zY3FxYuXChp06Y1NxtCMmDAAJPBa9+4GQEAAICoQNDWhTx69Eg6duworVq1kkaNGsnOnTsld+7cVjcLAOBiihcvbmqoa9BWF4UaPny4yWYEokvXrl1l+fLlZrHVzJkzv/KierpY6/Hjx0N8PkGCBGbhssAbAAAAEFkEbV3EqVOnpHTp0mYBjsmTJ8tPP/1kMm0BALDCa6+9JitXrpRPPvnEbLVr15YbN25wMhDlC65qwFZLQW3YsEFy5Mjxysfw8/OTv/76SzJkyMDZAQAAQIwhaOsCVq1aZbKZrl+/Ltu3b5f333/fTFEFAMBKcePGlSFDhsiKFSvM7I8iRYqYsj1AVJZE0Lq0s2fPlmTJksmlS5fM9vDhw4B9tBSCljiwGzp0qKxdu1ZOnDhhMsJbtGghp0+flvbt23NiAAAAEGMI2joxzQz59NNPpWbNmqY+m14I6wUxAACOpHr16ubfKM2+1UWipkyZYjIkgcj64YcfTJ3Z8uXLm0xZ+/bbb78F7HPmzBm5ePFiwO83b940N7jz588vNWrUkDt37siOHTvkzTff5IQAAAAgxrjH3FshJl27dk2aNWtmFngZNmyYySCJE4cYPQDAMWXPnl22bdsmPXv2lA8++MAEycaPH08pH0RKeIL/mzZtCvL76NGjzQYAAABYiaCtE9q9e7c0bNjQTP1bs2aNVK5c2eomAQDwUrqgk2ZG6uwQXTjzwIEDMn/+fBbNBAAAAOBySL10smySCRMmSJkyZSRTpkymDhsBWwBAbKM1RvUG5P37901ZnyVLlljdJAAAAACIUQRtnYRe2OpCGbrghmYnbd68WbJkyWJ1swAAiJC33npLfH19pWLFilK3bl3p37+/PHv2jN4EAAAA4BII2jqBY8eOSfHixWXx4sVmdeRx48ZJ/PjxrW4WAACRkiJFClmwYIF8/fXXMmrUKDN75NKlS/QqAAAAAKdH0DaW01p/Xl5e4ufnJ3v37pWmTZta3SQAAKKMm5ub9O3bVzZs2CBHjx4VT09Ps2AZAAAAADgzgrax1NOnT6V3795mwbEaNWrInj175M0337S6WQAARIuyZcuaWu25c+eW8uXLy+jRo00tdwAAAABwRgRtY6Hz589LhQoV5LvvvpMxY8bInDlzJFmyZFY3CwCAaJUhQwZZv3699OrVy9y4bNSokdy5c4deBwAAAOB0CNrGMhs3bjRTQ0+ePGkWG+vRo4eZOgoAgCuIFy+eqXGrtW7XrFkjRYsWlUOHDlndLAAAAACIUgRtYwl/f38ZOXKkVKpUSQoWLCgHDhwQb29vq5sFAIAl6tevL76+vpIgQQKzGOesWbM4EwAAAACcBkHbWODWrVtSr149GTBggHz00Ueydu1aSZcundXNAgDAUnnz5pVdu3ZJgwYNpEWLFtKlSxd5/PgxZwUAAABArOdudQMQtoMHD4qPj49cu3ZNli5dKu+++y5dBgDA/yROnFh+/vlnKVWqlHTv3t1k386bN0+yZs1KHwEAAACItci0dWDTp0+XkiVLmkXGdMVsArYAALxIa7t36NBBtm/fLpcvXza137XeLQAAAADEVgRtHdCjR4/k/ffflzZt2kjz5s1lx44dkjNnTqubBQCAQ/Py8pJ9+/aZxcmqV68uQ4cONTXhAQAAACC2IWjrYE6ePGmmeM6cOVOmTp1qtkSJElndLAAAYoU0adLIihUrZPDgwWarWbOmXL9+3epmAQAAAMArIWjrQPQiU6d06sJjO3fulHbt2lndJAAAYp04ceLIp59+KqtWrZK9e/eaf1v1TwAAAACILQjaOgA/Pz8ZNGiQ1KpVS8qUKWMWUfHw8LC6WQAAxGpVq1Y1NeHTp08vpUuXlkmTJonNZrO6WQAAAADwUgRtLXb16lVzUTlixAj54osvZPHixZIqVSqrmwUAgFPImjWrbNmyRdq3by8dO3aUVq1ayYMHD6xuFgAAAACEiaCthbQEgmbU/vnnn7Ju3ToZMGCAmdIJAACiToIECWT8+PHyyy+/yIIFC6REiRLy77//0sUOTstFaW1/HR/duHHDPKaZ0+fPn7e6aQAAAEC0I0JoAZ2aOW7cOClbtqxky5ZNDhw4IO+8844VTQEAwGU0b95cdu/eLY8fPxYvLy9ZuHCh1U1CKPSGdt68eeXLL7+Ub775xgRwlZ4zDeICAAAAzo6gbQy7d++eNG3aVHr06CFdu3aVTZs2SaZMmWK6GQAAuKSCBQuaRcmqVKkiDRo0kH79+smzZ8+sbhaC6d27t7Ru3dpkRCdMmDDg8Ro1aphyFwAAAICzcxdX9vixyIULIg8fiugFm7u7zqEUyZBBJHHiKH+7I0eOmAvEs2fPym+//SaNGjWK8vcAAABhS548ucydO1fGjBljgrZ79uyROXPmSAb99z+q3bkjcvmyyJMnIv7+z8caSZI8H2vEi8epCoUG1nXhuOD0RvelS5foNwAAADg91wraPnoksm+fyPHjIidPily7Fvq+uhhY9uwiOXOKFC0qkjRppN5ag7Tt2rUzC6LoxWH+/PkjdTwAABBxbm5u0qtXLylatKi5iao15jWQq6WLIkVrr+7d+3yccfq0yN27Ie+nNexff/35WCNfPpHChQniBqtDfEcD3sH8888/kjZt2sidIwAAACAWcI2g7cWLIlu3iuza9TzTRS+UNNslLDdv6goYIgcPiixeLOLpKVKunEi2bHqlF+63fvLkicni0Rq2WhZh8uTJkjSSAWAAABA1SpcubRa30n+jtb78yJEjpU+fPiaoG246pjh6VESn7f/99/8/brOF/Rodn2gW7s6dz2f4lC79fEudWlxd7dq1ZejQoSaQrvR8nDlzRvr3729mLQEAAADOzrmDtg8eiMyfL7JnT9BA7csCtsEvtvz8nmfoaubMG2/oSibPM3Ff4ty5cyZ7x9fXV7777jvp0qXLq10EAgCAaJc+fXpZt26dDBo0yNxo3bFjh/z000+SIkWKl79YyyzNmKH/6D8fa4QVqA2JfUyiY5Z1655vFSuK1Kzp0pm3o0aNEh8fH0mXLp08fPhQypUrZ8oilCxZUoYPH2518wAAAIBo57xB27/+Epk1S+T+/VcL1IbG/vp//hEZNkykYUOREiVCzbpdv369ydrR6X26YEYJ3RcAADgkd3d3k2WrQcFWrVqJl5eXLFiwQAoVKhTyC/SGrgZYV678/8ciO9awB3zXrxf54w+RVq2el09wQRow10D69u3b5Y8//jALuXp6ekqlSpWsbhoAAAAQI+KIs9ELpnnzRHTxCg3YvmrGS3iOryUWNCA8ZYrI06fBnvaXL774wqxKXbhwYTPlkoAtAACxQ506dcwMmcSJE5t/v2fOnPniTvfuiXz7rcjy5c/HBZEN1ganY5fr1zXd9HkA18U8ffrUBNEPHTokpUqVks6dO8uHH35IwBYAAAAuxbmCtnrRpFMUN29+/ntUB2xDyuYdP17k8WPz682bN83F3scffywDBw6U1atXs1gGAACxTO7cuWXnzp3SuHFjadmypXTs2FEe6WKmShfH0oDt2bPRP6bRccyiRc+Dw9E9pnEg8eLFMwu3+mk2MwAAAOCinCdoqxczs2eL+PrG7Hv+95/I5MlyYO9eKVKkiJnGt3z5chk2bJjEjRs35toCAACijGbaTps2TaZMmSLTp0+XMmXKyJkjR0TGjhW5di3qs2vDsnq1yNq14krsN8Bv3LhhdVMAAAAASzhPTdsNG0R27Yr597XZxHbsmOxauFBSpUplatnmyJEj5tsBAACilC4e2r59e/Hw8DCLYv03aJBkzphR4liR9bpsmUiGDCKh1dh1Mt9//70cP35cMmbMKNmyZZMkSZIEeV7LTwEAAADOzDmCtpcviyxdatnb61JknQoUkHYdO0p8ArYAADgVnUlzaPJkSbJkiXVlCnThU62nnyuXSLAApjOqW7eu1U0AAAAALOXuNHVsra715uYm8efMEfnkE5EECaxtCwAAiDo3bkiSVavE9r8btZbQcc7Dh88XW23dWpzdZ599ZnUTAAAAAEvF/qDt9u0ip09b3YrnF1O3b4usWqXpIVa3BgAARBUNlD57Zl3ANvCNaq3dX7y4SP784gp8fX3liNYSFpE333zTZD0DAAAAriB2B201UPr77+JQ7dm6VaR6dbJtAQBwBrro2F9/icOIE0dk40anD9qeO3dOmjZtahZ4TZkypXns1q1b4u3tLXPmzJHMmTNb3UQAAAAgWsXuoO0//4hcv/7KLzt/754sPXVKNp8/L3/fuCGXHjyQW0+eSMr48aXwa69Jy3z55L18+cwCJK/s8WORfftEvL1f/bUAAMDxZvRooFSzXCPgn1u35Mv9+2X9uXNy8f59SRY/vni89pq8/+ab0ihPnlc/oLbj8OHnweTXXhNnpQvAPX361GTZ5suXzzx27NgxadOmjXlu9erVVjcRAAAAiFaxO2i7eXOELqRmHjsmA3bteuHxa48emYsq3eb/958sql5d4urxX4UGejUDpmTJ5z8DAIDY6elTkW3bIhywXXnqlDRYvVoe+fkFPHb90SP5/dw5s608c0Z+euedV79JrGMTDSbXqSPOavPmzbJjx46AgK3Sn7/77jspU6aMpW0DAAAAYsIrRiQd7ELq0KEIX0ip9IkTS9v8+eXz4sWl/ZtvSsK4cQOeW3bqlPx09GjESiRcvPg8AwYAAMRex48/X/wrAnRWT9N16wICtm+mSiVDixWTJoGya38+elQm6FgmorVtnViWLFlMpm1wfn5+kjFjRkvaBAAAAMSk2Jtpe+FChAO2WZMlk5mVKpkLJ/dAmbTN8uSRd5YsCfh91enTJpgbIWfPiqRNG7HXAgAA6505E+HSCGP//FPuPHlifk4WL55srV9fUidMaH7Xkcfsf/81P3+xb590LFDg1Wf23Lwp8uCBSOLE4oy+/vpr6datm4wfP168vLwCFiXr0aOHfPPNN1Y3DwAAAIh27rH6QiqCmuXNG+LjFTJnljQJE5qpi+pJRLN49cJL2+fpGeE2AgAAi50+/XwGTQQsPXky4OfymTIFBGxVg1y5AoK2F+7fF98rV6R4+vSv/iY61njjDXEWqVKlClIq4v79+1K8eHFxd38+XH327Jn5uW3btlK3bl0LWwoAAABEv9gbtNVM1kgsDBKSS/fvy+3/ZcWoYunSRexA2ia90AMAALHXqVMRCto+9vMzC5DZ5UyePMjzwX//8/r1Vw/aanBTx0JOFLQdM2aM1U0AAAAAHEbsDdpevx6lAdtn/v7ywaZN5k+VLlEi6ViwYOTaBwAAYicN1t65E6GX3nz0SAKHepPHjx/k+WTBfrfP8HkleuP6xg1xJq1atbK6CQAAAIDDiL1B2xAWp4iou0+eSOM1a2TV/0ouaO25pTVqSNpEiSJ+0GfPoqx9AAAghkXhv+PBc3VtESy5EOwgLjHWuHLlitn8g92oL1SokGVtAgAAAGJC7A3aRsUFj1ZZuHtXaq1YYaYmKg3UrqhZU4q+/rpDtA8AAMQuqRImFK3Magt0cziwu8FuPL8W0ZvETjzW2Ldvn8m8PXLkyAtBbq176+fnZ1nbAAAAgJgQe4O2waYWRoQu/FF7xQq5qKsvi0jelCllZa1akitFisi3L168yB8DAABY43+LX0VEgrhxJV+qVHL05k3z+4lgZRb+u307yO9vpU796m+iNW2deKyhi43lzZtXfvzxR3n99deDLFAGAAAAuILYG7RNlSpSC5EtOnFCWqxbJw/+N7WwTIYMsrhGjSCrO0e6fQAAIHbSIGGyZCJ370bo5bWzZw8I2m46f15uPHoUMMaY999/AftlSpJEvCKy8Klmn6ZMKc7qxIkTsmDBAsmdO7fVTQEAAAAsEXuDtlmyiOzeHaGXzjt+XJqsXSv+/5tulyJ+fKmaNatMO3IkyH76+PsFCrz6G8SNK5ItW4TaBgAAHET27CKHDkWoDEH3QoVk4t9/y50nT0w5hDILF0qTPHnk8M2bMvf48YD9BhQpInH1JvSr0pvWWbOKs6pYsaL88ccfBG0BAADgsmJv0FYvVCJYy+3vGzcCArbq9pMnMiiEAHC2ZMkiFrTVOmtOfCEFAIBL0H/L//47QuONTEmTyuzKlaXB6tXy2M/PBGs/3bMnyD6t3nhDOhcsGLkb2E5q6tSppqbtoUOHpGDBghIvWCmI2rVrW9Y2AAAAICbE3qBtpkzPpy466iIcTnwhBQCAywRtI1iGSdXMnl3+bNJERu7bJ7+fOyeXHzyQJPHiicdrr0mHAgWkUZ48EW+b1t9PmlSc1c6dO2X79u2yatWqF55jITIAAAC4gti9EFn+/CJHj77yBdXgYsXMFm20Nl1E6tMBAADHoUHVBAlEHj+O8CF0kdNpFStGabNMTX9PT3Fm3bp1kxYtWsgnn3xiFiIDAAAAXE0Eiqg5kHLlIpUBE23Kl3+eBQwAACRW3yD29n4eJHUkOvYpXVqc2fXr16VXr14EbAEAAOCyHOwq5BVppq2jrZysNdeKFrW6FQAAICpocNSRbhDrTeG8eUWcPPu0fv36snHjxkgfZ8SIEVK0aFFJliyZpEuXTurWrSvHjh176evmzZsnb7zxhiRMmFDeeustWblyZaTbAgAAALhGeQSlmS865XDBAnGYCynNyEmUyOqWAACAqKDB0TfeEPnnH8cI3mot/woVxNnlzZtXBgwYINu2bTNB0+ALkXXv3j1cx9m8ebN06dLFBG6fPXsmAwcOlCpVqsjhw4clSZIkIb5mx44d0rRpUxPwrVWrlsyePdsEe/fv328WRQMAAABigpvN5qgreYWTn5/IV1+JXLxo7cWUBmx1QZBPPhFJnNi6dgAAgKh19arI8OFie/ZM3Ky+Wa1Bw/ffd/oyTDly5Aj1OV2I7MSJExE67tWrV03GrQZzy5YtG+I+jRs3lvv378vy5csDHitRooS8/fbbMnHixJe+x507dyRFihRy+/ZtSZ48ucSk2vMfiTNb6pPQ6iYgDHz/YCW+fwBik/COF2N3pq2KG1ekZUuRL7+0th02mzxr2lTcCdgCAOBc0qaVx9WrS4Jly6xthy6K1qSJ0wds1cmTJ6PluDowVqlTpw51n507d0rv3r2DPFa1alVZvHhxiPs/fvzYbIEH4QAAAIBr17S1y5RJpEYNy95e83unHz0qFbp0kQsXLljWDgAAEPV0Kr1Hz56y8/Jl82++ZRo3FonhzE1HoJPComJimL+/v/Ts2VNKlSoVZpmDS5cuvbAAmv6uj4dEyyhopoR9y5IlS6TbCgAAADhH0FZVqSLi4RHz2Sdx4kicHDkk76BB8t9//4mnp6eZcgcAAGK/OXPmSLFixcQtThx5bcAAiZMmzfMyBVaMc7y8xJXMmDHD1LNNlCiR2QoVKiQzZ86M8PG0tu2hQ4fMOY1KWntXM3jt29mzZ6P0+AAAAHBNzhO01QuoVq2e13qLKRogzpxZpHNn8S5fXg4cOCD58+eXihUryldffRUlWSEAACDmPXnyxCx2pQtS1a5dW3bv3i15PD1FevQQSZkyZgO35cuLvPuuuJJvv/1WOnXqJDVq1JC5c+earVq1atKxY0cZPXr0Kx+va9eupkbtxo0bJbOO3cKQPn16uXz5cpDH9Hd9PCQJEiQwtcgCbwAAAEBkOU/QVrm7i7RvL1KsWMy8X968zy/eEiUKmDq3bt066du3r/Tv31/q168fUDsNAADEDufOnZNy5cqZRae+//57mTVrliTVxUaV1kLt00f/0Y/e2T32Y1evLtKggUvUsQ3su+++kx9++EG+/PJLEzTXTW+IT5gwQcaNGxfu4+gNdA3YLlq0SDZs2BDmAmd2JUuWlPXr1wd5TMd3+jgAAAAQU5wraGtfmOy990RatxZJmDDqM2H0eBoc1guoLl2eLwoSiLu7u4wcOVKWLFlisjm8vLzkjz/+iNo2AACAaPH777+Lh4eHCdxu3brVTKl3Cx4wTZFC5MMPRSpVeh5Mjeqxhh5TszW7dROpWdPlArbq4sWL4u3t/cLj+pg+F156/n755ReZPXu2JEuWzNSl1e3hw4cB+7Rs2dKUOLDr0aOHrF69WkaNGiVHjx6VwYMHi6+vrwn+AgAAADHF+YK2Si9utO7bp5+KFCjw/LHIXlDZX58tm8jAgSIVKoR5TM0I2bdvnyRJkkRKlCghP//8c+TeHwAARBtdpGr48OFSpUoVE7Tdv3+/FC9ePPQXxIsnUqfO86xbrXOrIhtctY8rSpUS+eQTkXz5xFXlzp3blEQI7rfffpM8efKE+ziarauznsqXLy8ZMmQI2PQ4dmfOnAkSCNbAsAZ5J0+eLIULF5b58+fL4sWLw1y8DAAAAIhq7uLMNEvlgw9ETp8W2bJFZN8+vSp7/lx4683aL8A0+Fu27PMLqHAGgHPlyiU7d+40WR6tW7eWHTt2yNixYyWhZgADAACHcPPmTXnvvfdkxYoV8umnn5otrs7cCY/s2UUGDRL5808RXYj0+PHn4wT7eCM84wwdk8SPr/PyRcqU0aKq4uqGDBkijRs3li1btkgpDWKLyPbt203ZgpCCuaEJz/oCmzZteuGxhg0bmg0AAACwinMHbe0XQ3pBpVv9+iK7dz+/oDp1SuTu3dBflzixSNasGnkVKVFCJFWqCL29rnY8bdo0c8GhwVudXqcZG+GpqQYAAKKXZtQ2aNDAZGNq0FYXvnplGuD18Hi+Xbr0fKxx8qSmcOqKZqG/TscWOj7RG8JFi75QcsmV6TnRxd90QTLNclW62OuePXtMJjQAAADg7Jw/aBuYLiJSseLzTd25I3L+vMijRyLPnj2/6NILpowZn68MHYU15Nq1a2cuMvQipEiRIqa+WoQuDAEAQKRpBuaPP/5o6pTqtHetQ59dA6iRpVmyWjZBabbttWsily+LPH0q4uf3vC5+kiQimTM/v0GMUOl4SReBAwAAAFyRawVtQyqfoFsM8fT0NBk9OgWzZs2a8sknn8hnn30W/imYAAAg0nQRKp398tNPP0mHDh1kzJgx0VO6SMskpEv3fEM4uyzOiwu/BaPPP9Ob7QAAAIATc+2grQVSpUolS5culZEjR5qg7a5du0wWSdq0aa1uGgAATu/48ePi4+Mjx44dk+nTp0urVq2sbhICWbRoUaj9oesEjBs3ziwaBwAAADg7grYWZZEMHDhQihUrJk2bNjUZuPPmzZMSWjsXAABEiyVLlpggrd4o1XqphQoVoqcdTB17aYlANMD+0UcfybJly6R58+YydOhQS9oGAAAAxKQ4MfpuCKJSpUpy4MAByZIli5QtW1a+//77cK1yDAAAwk+n0mvQr27dulKhQgWzKCgBW8d34cIFef/99+Wtt94y5/DgwYPy888/S7Zs2axuGgAAABDtCNpaLHPmzLJp0ybp1KmTdOvWzWSQ3Lt3z+pmAQDgFC5fviyVK1eWb775Rr766itZuHChpEiRwupmIQy3b9+W/v37S+7cueXvv/+W9evXmyxbXTAOAAAAcBUEbR1A/PjxZezYsfLrr7+aerfFixeXo0ePWt0sAABitW3btomHh4ccOXLEBP769ev30kWuYC0NrOfMmVOWL19uxkU7duyQMmXKcFoAAADgcqhp60CaNGkihQsXlvr160vRokXlxx9/lEaNGlndLAAAYhUtNTRmzBgTpPX29pbffvtNMmTIYHWzEA5axiJRokQmy1ZLIegWEs2YBgAAAJwZQVsHkz9/ftmzZ4+p4da4cWOzUrJmncSLF8/qpgEA4PDu3Lkj7dq1k/nz50vfvn3liy++4N/QWKRly5ZkQwMAAAAEbR1TsmTJzJTAUqVKSe/evU0Qd+7cuZIpUyarmwYAgMPS+qcNGjQwC1gtWLDAzFxB7DJ9+nSrmwAAAAA4BGraOiituacLk23evFlOnz4tnp6esmHDBqubBQCAQ5o1a5YUK1bMZNX6+voSsAUAAAAQqxG0dXBai2///v1mxWRd/XrkyJHi7+9vdbMAAHAIjx8/lq5du0qLFi1MoHbXrl2SN29eq5sFAAAAAJFC0DYWSJcunaxdu1YGDBhgtrp168rNmzetbhYAAJY6c+aMlC1bVqZMmSI//PCDzJgxQ5IkScJZAQAAABDrEbSNJeLGjSuff/65LFu2TLZu3SpeXl5y8OBBq5sFAIAl9Gamlg66dOmSbNu2TTp27MgCVgAAAACcBkHbWKZWrVqyb98+SZEihZQsWVKmTZtmdZMAAIgxWiJo6NChUq1aNSlatKgpIaR/AgAAAIAzIWgbC+XMmVN27Nhh6ve1a9dO2rdvLw8fPrS6WQAARKvr16+bm5eDBw8224oVKyRNmjT0OgAAAACn4251AxAxCRMmNDX8dKGyzp07m0yj+fPnm4AuAADOxtfXV3x8fOTu3buyatUqqVq1qtVNAgAAAIBoQ6ZtLNemTRvZuXOn3L59W4oUKWJq3gIA4CxsNptMmjRJSpUqZRbm1JuUBGwBAAAAODuCtk7g7bffNnVudQXt2rVry8cffyx+fn5WNwsAgEh58OCBtG7d2iwypqWAdCHObNmy0asAAAAAnB5BWyeRMmVKWbRokYwcOdJsVapUkStXrljdLAAAIuTff/+VEiVKyLx582TmzJkyfvx4SZAgAb0JAAAAwCUQtHUiceLEkf79+8vvv/8uhw4dEk9PT7NgGQAAsYnehPTy8pLHjx/Lnj17zMKbAAAAAOBKCNo6oQoVKpiafzqFtFy5cjJu3DhTExAAAEf27Nkz+fDDD6V+/fpSuXJl2bt3rxQsWNDqZgEAAABAjCNo66QyZcokmzZtkm7dukmPHj2kSZMmZsVtAAAc0cWLF6VixYry7bffyqhRo0xZhOTJk1vdLAAAAACwBEFbJxYvXjxz8Tt37lxZuXKlFCtWTA4fPmx1swAACGLLli2mpI/Wsd24caP07t1b3Nzc6CUAAAAALougrQto2LChmWKqNW81cDtnzhyrmwQAgCnd880338g777wj+fLlM6V9ypQpQ88AAAAAcHkEbV3EG2+8Ibt375batWtL06ZNpXv37vLkyROrmwUAcFG3b98WHx8f6devn/Tt29csopk+fXqrmwUAAAAADsHd6gYg5iRNmlRmzZolpUqVkl69epnsW60ZmDlzZk4DACDG/PXXX9KgQQO5fPmyLFq0SOrWrUvvAwAAAEAgZNq6GK0R2KVLF9m6daucO3dOPDw8THYTAAAxYebMmVK8eHFJlCiR7Nu3j4AtAAAAAISAoK2L0gtmrR2oQdsqVarI8OHDxd/f3+pmAQCc1OPHj6VTp07SsmVLadSokezcuVNy585tdbMAAAAAwCERtHVhadOmlVWrVsknn3wigwYNMvVub968aXWzAABO5vTp01K6dGmZNm2aTJ48WX766SdJnDix1c0CAAAAAIdF0NbFxY0bV4YMGSIrVqyQHTt2iKenp5muCgBAVFi9erX5t+XatWvm35n333/flOoBAAAAAISOoC2MGjVqmHIJadKkMQuVTZ06VWw2G70DAIgQPz8/GTx4sPn3pUSJEuaGYJEiRehNAAAAAAgHgrYIkD17dtm2bZu0bt3aZEK1bdtWHjx4QA8BAF6JZtVqsHbo0KFmW7ZsmaROnZpeBAAAAIBwcg/vjnANCRMmlIkTJ0rJkiWlY8eOcuDAAZk/fz6LxQAAwmXPnj3i4+MjDx8+lDVr1kjlypXpOQAAAAB4RWTaIkStWrWS3bt3y/3798XLy0uWLFlCTwEAQqUldSZMmGAWHMuYMaMpuUPAFgAAAAAihqAtQlWoUCHx9fWVChUqSN26deWjjz6SZ8+e0WMAgCD0Bt97770nXbp0MbM0tmzZIlmyZKGXAAAAACCCCNoiTClSpJCFCxfKV199Jd98843Jmrp8+TK9BgAwjh07JsWLF5dFixbJ7NmzZdy4cRI/fnx6BwAAAAAigaAtXsrNzU369esn69evlyNHjoiHh4dZsAwA4NoWLFggRYsWNbMwtJZt06ZNrW4SAAAAADgFgrYIt3LlypmFyXLnzi3ly5eX0aNHmxqGAADX8vTpU+nTp49ZcKx69eqyd+9eKVCggNXNAgAAAACnQdAWryRDhgwm47ZXr17Su3dvadSokdy5c4deBAAXceHCBXnnnXdMGYQxY8bInDlzJFmyZFY3CwAAAACcCkFbvLJ48eLJ119/LfPnz5c1a9aYqbGHDh2iJwHAyW3atEk8PT3lxIkT5ucePXqYEjoAAAAAgKhF0BYR1qBBA/H19TULzugiNLNmzaI3AcAJaSkcXZCyYsWK8uabb5pSOaVKlbK6WQAAAADgtAjaIlLy5s0ru3btkvr160uLFi2kS5cu8vjxY3oVAJzErVu3pF69etK/f3+zrV27VtKlS2d1swAAAADAqblb3QDEfkmSJJEZM2aYrCudKqvZt/PmzZOsWbNa3TQAQCT88ccfZlbFtWvXZOnSpfLuu+/SnwAAAAAQA8i0RZTQmoYdO3aUbdu2yaVLl0zNQ83GAgDETtOnT5cSJUqYRcb27dtHwBYAAAAAYhBBW0QpXZRs//795s9q1arJ0KFDxd/fn14GgFji0aNH8sEHH0ibNm2kWbNmsmPHDsmVK5fVzQIAAAAAl0LQFlEuTZo0smLFChk8eLDZatWqJdevX6enAcDBnTx50pS60ZI3U6dOlR9//FESJUpkdbMAAAAAwOUQtEX0fLHixJFPP/1UVq1aJbt37zblEvbu3UtvA4CDWrlypRQpUkRu3rwpO3fulHbt2lndJCDStmzZYkp7ZMyY0ZRyWrx4cZj7b9q0yewXfNPSTwAAAEBMImiLaFW1alVTLuH111+X0qVLy6RJk8Rms9HrAOAg/Pz85JNPPpGaNWuav6e1fq2Hh4fVzQKixP3796Vw4cIyfvz4V3rdsWPH5OLFiwFbunTpOCMAAACIUe4x+3ZwRdmyZZOtW7dK7969zWJlWh/xhx9+kMSJE1vdNABwaVevXjV1azds2CBffPGF9O/f38yUAJxF9erVzfaqNEibMmXKaGkTAAAAEB5cmSFGJEiQwGS5zJw5U+bNm2dWJP/333/pfQCwyK5du0zpmj/++EPWrl0rAwYMIGAL/M/bb78tGTJkkMqVK8v27dvpFwAAAMQ4graIUS1atJA9e/bI48ePxcvLSxYtWsQZAIAYpCVqvv/+eylbtqxkyZJFDhw4IBUrVuQcACImUDtx4kRZsGCB2fT/kfLly5tST6HRMc2dO3eCbAAAAEBkEbRFjCtYsKBZlEyzV+rXry/9+vWTZ8+ecSYAIJrdu3fPlEPo1q2bdO7c2Sy6lClTJvod+J98+fJJhw4dzKJ83t7eMm3aNPPn6NGjQ+2jESNGSIoUKQI2DfQCAAAAkUXQFpZInjy5KZMwatQocyGkWV660AcAIHocPXpUihUrJsuWLZPffvtNxowZI/Hjx6e7gZfQ/2+OHz8e6vNaWuT27dsB29mzZ+lTAAAARBpBW1jGzc3NLE62ceNGU99Waytu2bKFMwIAUWzu3LlStGhR87POdGjUqBF9DITTwYMHTdmEsOr2683owBsAAAAQWQRtYbkyZcqYWnE6JfGdd96Rb775xtRcBABEzpMnT6Rnz57SuHFjqVWrlqkpnj9/froVLlUSRIOuuqmTJ0+an8+cOROQJduyZcuA/TUDfcmSJSaz9tChQ+b/nw0bNkiXLl0s+wwAAABwTe5WNwBQ6dOnl99//10GDRpkatzu3LnT1JHT2nAAgFd3/vx5k1GrmbXjxo2Trl27mhkOgCvx9fWVChUqBPyuM3xUq1atZPr06aY0kz2Aa7/R0adPH/P/T+LEiaVQoUJmfBL4GAAAAEBMcLOR0ggHs3jxYnMxlS5dOrNys14wAQDCTzMDmzRpYmrWav3wkiVL0n1ADLlz54656az1bWO6VELt+Y/EmS31SWh1ExAGvn+wEt8/AM44XqQ8AhxO3bp1Zd++fSbDpUSJEjJz5kyrmwQAsYK/v79Zyb5y5cpSuHBhOXDgAAFbAAAAAIiFCNrCIeXOnduUSNCpvVprrlOnTvL48WOrmwUADuvmzZvmptfAgQPNtnr1akmbNq3VzQIAAAAARAA1beGwNNP2p59+klKlSplajFqXTqf5Zs+e3eqmAYBD0YzaBg0ayK1bt2T58uVSs2ZNq5sEAAAAAIgEMm3h0HTRnPfff1927Ngh165dkyJFipjsMQDAc7poo9asTZUqlSktQ8AWAAAAAGI/graIFTRYq8EIrXFbo0YN+eyzz8TPz8/qZgGAZR4+fCjt2rUzm5aR2b59u+TIkYMzAgAAAABOgKAtYo3UqVPLsmXLZOjQoTJs2DATvNXsWwBwNSdOnBBvb2+ZPXu2KSMzefJkSZiQVdUBAAAAwFkQtEWsEidOHBk0aJCsWbNG9u/fL56enrJnzx6rmwUAMUZvXunsg7t375oFG1u3bk3vAwAAAICTIWiLWKly5comaJsxY0YpXbq0TJgwQWw2m9XNAoBo8+zZMxk4cKDUrl1bypYtaxZnfPvtt+lxAAAAAHBCBG0Ra2XJkkW2bNkiHTt2lC5dush7770n9+/ft7pZABDlrly5IlWrVpUvv/xSRo4cKYsWLZKUKVPS0wAAAADgpAjaIlaLHz++jBs3ztR11CBG8eLF5dixY1Y3CwCizI4dO8TDw0MOHTok69evl/79+5tSMQAAAAAA58VVH5xC06ZNTW1bnT5ctGhRmT9/vtVNAoBI0ZIvY8eOlXLlykmOHDnkwIEDUr58eXoVAAAAAFwAQVs4jQIFCsjevXulevXq0rBhQ+ndu7c8ffrU6mYBwCvTRcaaNGkiPXv2lO7du8vGjRtNDW8AAAAAgGtwt7oBQFRKliyZzJkzR7y9vaVv374m+3bu3LkEOwDEGocPH5b69evLhQsXZN68eeLj42N1kwAAAAAAMYxMWzgdNzc36dGjh2zatElOnjxpakHqzwDg6H799VcpVqyYuLu7m5kDBGwBAAAAwDURtIXTKlWqlKkBqWUTKlasaFZd1xqRAOBonjx5It26dZNmzZpJ3bp1Zffu3ZIvXz6rmwUAAAAAsAhBWzi1dOnSydq1a81q6x999JHUq1dPbt26ZXWzACDA2bNnzWJjkyZNkgkTJsjMmTMlSZIk9BAAAAAAuDCCtnB6Os34iy++kKVLl5oyCV5eXnLw4EGrmwUA8vvvv4unp6ecP39etm7dKp06dTIlXgAAAAAAro2gLVzGu+++K/v27TOLlZUsWVKmT59udZMAuCh/f3/5/PPPpUqVKiZou3//filevLjVzQIAAAAAOAiCtnApuXLlkh07dpi6kW3atJEPPvhAHj16ZHWzALiQGzdumJtIn376qXzyySeycuVKee2116xuFgAAAADAgbhb3QAgpiVKlEh+/PFH8fb2li5dupjs2/nz50uOHDk4GQCilf594+PjI3fu3JEVK1ZI9erV6XEAAAAAwAvItIXLateunezcuVNu3rxppidrAAUAooPNZpMpU6aYm0WaVavBWwK2AAAAAIDQELSFS/Pw8DDBkzJlykitWrVk0KBB4ufnZ3WzADiRBw8eBJRjadu2rWzbtk2yZ89udbMAAAAAAA6MoC1cXqpUqWTx4sXyxRdfyIgRI6Rq1apy9epVl+8XAJF3/Phxs/Dh3Llz5eeff5YffvhBEiRIQNcCAAAAAMJE0BbQ/xHixJEBAwbI2rVr5c8//zTlErR0AgBElN4MKlKkiMm03b17t7Rs2ZLOBAAAAACEC0FbIJCKFSvKgQMHJEuWLFK2bFn57rvvTC1KAAivZ8+eSf/+/aVevXrm7xRfX19566236EAAAAAAQLgRtAWCyZQpk2zatEm6dOki3bt3l2bNmsm9e/foJwAvdenSJalcubKMGjVKvv76a1mwYIGkSJGCngMAAAAAvBKCtkAI4sePL2PGjJHffvtNli1bJsWKFZMjR47QVwBCpQuMaWmVo0ePyoYNG6Rv377i5uZGjwEAAAAAXhlBWyAMjRo1kr1795qfixYtaoK4ABCYllD59ttvpXz58pI7d27Zv3+/Ka8CAAAAAEBEEbQFXiJ//vyyZ88eeffdd6VJkybSs2dPefLkCf0GQO7cuSMNGzaUPn36SK9evWT9+vWSIUMGegYAAAAAECnukXs54BqSJk0qs2fPFm9vbxOc0SDu3LlzJXPmzFY3DYBFDh06JA0aNJCLFy+a2rX169fnXAAAAAAAogSZtkA4aW3Kbt26yebNm+XMmTOmdqVm1QFwPbNmzZLixYtLggQJxNfXl4AtAAAAACBKEbQFXlHJkiXlwIEDUrhwYalSpYp88cUX4u/vTz8CLuDx48fSuXNnadGihcmy3bVrl+TNm9fqZgEAAAAAnAxBWyAC0qZNK6tXr5aBAwfKxx9/LHXq1JGbN2/Sl4AT0wz7MmXKyI8//igTJ06Un3/+WRInTmx1swAAAAAAToigLRBBcePGlWHDhsny5ctl+/btUqRIEZOBC8D5rFmzxpREuXLlivn/vUOHDqZkCgAAAAAA0YGgLRBJNWvWlH379kmqVKlM6QTNwgPgHLT0yZAhQ6R69epStGhR8/+6l5eX1c0CAAAAADg5grZAFMiRI4fJvmvZsqW0b99e2rVrJw8fPqRvgVjs+vXr5qaMBm0HDx4sK1askDRp0ljdLAAAAACAC3C3ugGAs0iYMKFMnjxZvL29pVOnTrJ//36ZP3++5MqVy+qmAXhFe/fuFR8fH7l//76sWrVKqlatSh8CAAAAAGIMmbZAFGvdurVZUf7u3bumzu3SpUvpYyCWsNlsZpGx0qVLS/r06c3NFwK2AAAAAICYRtAWiAaFCxcWX19fKV++vNSpU0cGDhwoz549o68BB/bgwQNp1aqVyZTXMidbtmyRrFmzWt0sAAAAAIALImgLRJOUKVPKokWL5MsvvzRblSpV5PLly/Q34ID++ecfKV68uCxYsEB++eUXGT9+vCRIkMDqZgEAAAAAXBRBWyAaubm5yYcffijr16+Xw4cPi6enp1mwDIDjWLhwoXh5ecmTJ09k9+7d0rx5c6ubBAAAAABwcQRtgRigZRK0NmbOnDnNz2PGjDG1MwFY5+nTp9K3b19p0KCBqVuri48VLFiQUwIAAAAAsBxBWyCGZMyYUTZs2CDdu3eXXr16SePGjc1iZQBi3sWLF6VixYrmBsq3334rc+fOleTJk3MqAAAAAAAOgaAtEIPixYsno0aNknnz5snq1aulaNGi8vfff3MOgBi0efNm8fDwkOPHj8umTZvMTRQtZQIAAAAAgKMgaAtYwMfHx0zFdnd3l2LFismvv/7KeQCimZYk+frrr02Gbf78+eXAgQNSunRp+h0AAAAA4HAI2gIWyZcvn1n0qF69etKsWTPp1q2bWQgJQNS7ffu2qV2rCwNqHdt169bJ66+/TlcDAAAAABySu9UNAFxZkiRJZObMmVKqVCnp0aOHyb7V0glZsmSxummA0/jzzz9NwPbq1auyePFiqVOnjtVNAgAAAAAgTGTaAhbTWpqdOnWSbdu2yYULF8TT09NkAQKIvBkzZkiJEiXMDZJ9+/YRsAUAAAAAxAoEbQEHobVt9+/fb4K2VatWlc8//1z8/f2tbhYQKz169Eg6duworVq1ksaNG8vOnTslV65cVjcLAAAAAIBwIWgLOJDXXntNVq5cKZ9++qnZ3n33Xblx44bVzQJilVOnTpkFxqZPny5TpkyRadOmSaJEiaxuFgALbNmyxfxbmjFjRjOzRUukvMymTZvMDdQECRJI7ty5zd8lAAAAQEwjaAs4mLhx48rgwYNN8HbXrl3mwlGndQN4uVWrVpn/Z65fvy47duyQ9u3bm0ANANd0//59KVy4sIwfPz5c+588eVJq1qwpFSpUkIMHD0rPnj3N3yNr1qyJ9rYCAAAAgRG0BRxUtWrVTLmEtGnTire3t0yePFlsNpvVzQIckp+fn8lO12CL/v+iNzo0eAvAtVWvXt2UG6pXr1649p84caLkyJFDRo0aJfnz55euXbuKj4+PjB49OtrbCgAAAARG0BZwYNmyZTMLlLVt21Y6dOggbdq0kQcPHljdLMChXLt2zQRmhg8fboIzS5culdSpU1vdLACxkNa/rlSpUpDHtM68Pg4AAADEJPcYfTcAr0xr6v3www8me1ADtwcOHJAFCxaYOnuAq9u9e7c0bNhQHj58aKYvBw+2AMCruHTpkrz++utBHtPf79y5Y/6eCak+9uPHj81mp/sCAAAAkUWmLRBLvPfeeyZApReNRYoUCddiKoCz0lIhEyZMkDJlykimTJnMzQwCtgCsMGLECEmRIkXAliVLFk4EAAAAIo2gLRCLvPXWW7J3716pWLGiqc/Xv39/efbsmdXNAmJ8YaEWLVpIly5dpGPHjrJ582bJnDkzZwFApKVPn14uX74c5DH9PXny5CFm2aoBAwbI7du3A7azZ89yJgAAABBplEcAYhnN4tHyCN9++60J2mr27Zw5c8yFJuDsjh07Jg0aNJBTp07Jr7/+Kk2aNLG6SQCcSMmSJWXlypVBHlu3bp15PKwyRroBAAAAUYlMWyAWcnNzkz59+siGDRtMEMvT01O2bt1qdbOAaDV//nzx8vISPz8/2bNnDwFbAC917949OXjwoNnUyZMnzc9nzpwJyJJt2bJlwP6avX/ixAn58MMP5ejRo6YMy9y5c6VXr170NgAAAGIUQVsgFitbtqzs379f8uTJIxUqVDDZt1rrE3AmT58+ld69e5sFx2rWrGkCtm+++abVzQIQC/j6+oqHh4fZlP5doj9/+umn5veLFy8GBHBVjhw5ZMWKFSa7tnDhwjJq1CiZOnWqVK1a1bLPAAAAANdEeQQglsuQIYOsX79eBg4caLJvd+zYIdOmTTP194DY7vz589K4cWNTBmTs2LHSrVs3k2kOAOFRvnz5MG9mTp8+PcTX6OKGAAAAgJXItAWcgLu7u3z11VeycOFCkx2kU8gPHTpkdbOASNm4caMp/aH1a3Wxse7duxOwBQAAAAC4BIK2gBOpV6+emQqaMGFCKV68uPzyyy9WNwl4Zf7+/jJy5EipVKmSFCxY0JQA8fb2picBAAAAAC6DoC3gZLS+7a5du8THx0fee+896dy5szx+/NjqZgHhcuvWLXPzQRcH+uijj2Tt2rWSLl06eg8AAAAA4FKoaQs4ocSJE5s6faVKlTI1QDX7dt68eZItWzarmwaESld015sN169fl6VLl8q7775LbwEAAAAAXBKZtoCT0sWaPvjgA9m+fbtcuXLF1AZds2aN1c0CQqQ3GUqWLGkW0Nu3bx8BWwAAAACASyNoCzg5XZRMg2DFihWT6tWry5AhQ0zNUMARPHr0SN5//31p06aNNG/e3NxkyJkzp9XNAgAAAADAUgRtAReQJk0aWbFihQnY6lazZk0zBR2w0smTJ00JD10w78cff5SpU6dKokSJOCkAAAAAAJdH0BZwEXHixJFPPvlEVq9eLXv37jXlEvRPwAp6E0G/g7rw2I4dO6Rt27acCAAAAAAA/oegLeBiqlSpIvv375f06dNL6dKlZeLEiWKz2axuFlyEn5+fDBo0SGrVqiVlypQxpTs8PDysbhYAAAAAAA6FoC3ggrJmzSpbtmwxtUQ7deokLVu2lPv371vdLDi5q1evStWqVWXEiBFmW7x4saRMmdLqZgEAAAAA4HAI2gIuKkGCBP/X3p3A2Vzvfxx/n9nHMmTfScqS3VC2mNuEcouiUEpIspfqSorbovonhYcsdZPcJMt14yIuriVLGENEtq6ty9iNmTHMdv6P77c7c02GzGLO9no+Hr/HzPn9fud3vuc738dw3vP9fb6aOHGiZs6cqfnz5+vuu+/Wvn37XN0seKmNGzfaGbU7d+7UihUr9Morr9iSHQAAAAAA4Gp8YgZ83OOPP67NmzcrKSlJ4eHhNsAF8oopvTFhwgTdc889qly5si3NERERQQcDAAAAAHAdhLYAdOedd9pFycyt6506ddJLL72k5ORkega5Eh8fr27dumnIkCEaOHCgVq9erfLly9OrAAAAAAD8DkJbAFZYWJjmzJmjjz76SOPHj9e9996r48eP0zvIkZ9++klNmjTR4sWLNXv2bDuuAgMD6U0AAAAAAG4AoS2ADA6HQ88//7xWrVqlAwcO2Bqka9asoYeQLSakbdy4sR1PZgb3Y489Rg8CAAAAAJANhLYArtKiRQtt27ZNNWvWtDNux4wZY2uTAtdj6iKbUghdu3bVQw89pE2bNqlGjRp0GgAAAAAA2URoCyBLpUuX1vLly2192z/96U965JFHFBsbS28hS7/88otat26tyZMna+LEiZo5c6YKFSpEbwEAAAAAkAOEtgCuKSAgQO+9956++eYbWzIhPDxcO3bsoMeQycqVK9WwYUMdPXpUa9eu1YABA2xpBAAAAAAAkDOEtgB+V4cOHbR161YVLFhQd999t2bMmEGvQWlpaXrnnXfUpk0b1a9fX9HR0XZ8AAAAAACA3CG0BXBDbrvtNm3cuFFdunRRjx491LdvX126dIne81Hnzp2zYf6IESPs9u2336pkyZKubhYAAAAAAF4hwNUNAOA5QkNDNW3aNDVv3lwDBw60s2/nzZunKlWquLppyEdmRm3nzp11/vx5LV68WA888AD9DwAAAABAHmKmLYBsMbVKn3nmGW3YsEFnzpyxtUyXLFlCL/qIzz77TM2aNVOxYsVseEtgCwAAAABA3iO0BZAjJqw1M21NgNe+fXuNHDlSqamp9KaXSkxMVK9evWxgb8pjrFu3jhnWAAAAAADcJIS2AHLMzLZcuHChRo8ebbf7779fp0+fpke9zM8//2zD+VmzZmn69OmaOnWqQkJCXN0sAAAAAAC8FqEtgNz9EvHz06uvvqply5Zp27Ztdgbupk2b6FUvYUL5Ro0aKS4uTt9//72dZQsAAAAAAG4uQlsAeSIyMtKGthUqVFDLli318ccfy+l00rseKiUlRcOHD1eHDh0UERGhqKgo1atXz9XNAgAAAADAJxDaAsgzJrBdvXq1+vXrp4EDB6p79+5KSEighz3MiRMn1KZNG73//vt2mz9/vooWLerqZgEAAAAA4DMIbQHkqaCgII0fP97WP12wYIGaNGmiPXv20MseYv369bbExe7du7Vy5Uq9/PLLcjgcrm4WAAAAAAA+hdAWwE3RtWtXbdmyRWlpaWrcuLHmzp1LT7sxU8pi3Lhxat26tapWrWpLXZjvAQAAAABA/iO0BXDT1KxZU5s3b1b79u312GOP6YUXXlBycjI97mbMImNdunSxP58hQ4boX//6l8qWLevqZgEAAAAA4LMCXN0AAN6tcOHCtlRC8+bNNXToUDv7dvbs2SpfvryrmwZJu3btUqdOnXTs2DHNmzfPfg8AAAAAAFyLmbYAbjpTE3XQoEFas2aNDh06ZGumrlq1ip53sa+++srWHA4MDFRUVBSBLQAAAAAAboLQFkC+adasmaKjo1W7dm1FRkbqvffeszVvkb+SkpJsiP7EE0/okUce0ffff6877riDHwMAAAAAAG6C0BZAvipVqpT++c9/avjw4XZ7+OGHdf78eX4K+eTo0aO655579Mknn2jSpEmaMWOGChYsSP8DAAAAAOBGCG0B5Dt/f3+9/fbb+sc//qG1a9eqUaNG2r59Oz+Jm2z58uVq0KCBjh8/ru+++079+vWzpSsAAAAAAIB7IbQF4DJ//OMftXXrVhUpUkRNmzbV559/zk/jJjAlKN566y21bdtW4eHhts9NLVsAAAAAAOCeCG0BuFTVqlW1YcMGde/eXb169VKfPn106dIlfip55OzZszYcHzVqlN0WL16sEiVK0L8AAAAAALixAFc3AABCQkL06aef2oXK+vfvb2eCzps3zwa6yLmoqCh17txZcXFxWrJkidq1a0d3AgAAAADgAZhpC8Bt9OzZUxs3blRsbKytc7to0SJXN8kjOZ1Ou9BY8+bN7cJv0dHRBLYAAAAAAHgQQlsAbqV+/fp2pu0999yjBx98UCNGjFBqaqqrm+UxLl68aMPvvn37qnfv3nbBscqVK7u6WQAAAAAAIBsIbQG4naJFi+rvf/+73nvvPbuZBbROnjzp6ma5vf3799sF3ebMmaMZM2Zo0qRJCg4OdnWzAAAAAABANhHaAnBLfn5+GjZsmFasWKGdO3eqYcOGtnQCsvbNN98oPDxciYmJ2rRpk5588km6CgAAAAAAD0VoC8CtRURE2Jqs5hZ/UzJhwoQJtmYrfpWSkmLD7YcffliRkZF28bE6derQPQAAAAAAeDBCWwBur3z58lq9erUGDRqkIUOGqFu3boqPj5evi4mJsUHt2LFj9cEHH2jevHkKCwtzdbMAAAAAAEAuEdoC8AiBgYH68MMPbb3WxYsXq3Hjxtq9e7d8lVlgrEGDBtq7d69WrVqlF198UQ6Hw9XNAgAAAAAAeYDQFoBHefTRR7VlyxZb87ZJkyb6+uuv5UtMaQgzs9aUjbjjjju0bds2tWzZ0tXNAgAAAAAAeYjQFoDHqVGjhl1s66GHHrKlEgYPHqykpCR5u9jYWHXu3FkvvfSSnVm7cuVKlSlTxtXNAgAAAAAAeSwgry8IAPmhUKFCmjlzppo3b64XXnjBzr6dO3euKlSo4JU/gJ07d6pTp046ceKE5s+fbxceAwAAAAAA3omZtgA8lqnhOmDAAFvf9ZdffrE1XlesWCFv89e//lV33XWXQkNDFRUVRWALAAAAAICXI7QF4PFMoBkdHW1D2zZt2mj06NFKS0vL89dJczp16Hyqoo6laP3RZG04mqytx1N0LC7N1prNa5cvX1a/fv301FNP2Vq+Gzdu1O23357nrwMA3uzjjz9WlSpVFBISYv+92Lx58zXPnT59uv2D4JWbeR4AAACQ3yiPAMArlCxZUt9++63efPNNvfbaazbgNDNUb7nllhxf0wSx0TGpWnMoWbtOpWrvmVRdSsn63EJBUs0S/qpdKkCRVQNVvbh/zt+MpMOHD9ug9ocfftDUqVPVp08fGx4AAG7c7NmzNXToUE2ZMsUGtuPGjVPbtm21d+9elSpVKsvnhIWF2ePp+N0LAAAAVyC0BeA1/P399cYbb9gP5t27d1fDhg31t7/9zX7Njvgkp749kKSvf0zS4dg0+Tuk1N+ZSBufJG05lqro46n6fPtl1S7pry61g3TvrYEKMhfIhqVLl+qJJ55Q4cKFtX79eoWHh2fr+QCAX3344Yf2j149e/a0j014u3jxYk2bNk2vvPJKlt1kQloWeQQAAICrUR4BgNd54IEHbLmE4sWLq1mzZvrLX/5yQ+ULzDkL9ybpga8u6P31l3Qk9tcSC78X2F4p/dzdp1P1+qpEPTgrzpZSuKHnpqbqz3/+s21/eskHAlsAyJmkpCRt3bpVkZGRGfv8/PzsY3M3xrXEx8ercuXKqlixojp06KBdu3bxIwAAAEC+I7QF4JVM/cJ169bp6aeftrOsevfurcTExGuefzIhTYOXXtSbaxOVmCyZ7DU3VWrT/vvks4lODVl6UW+suai4y9e+4unTp9W+fXtb3sHMFl60aJGKFSuWixYAgG8zv1fNH8NKly6dab95HBMTk+VzqlevbmfhLliwQF9++aWtj27++GcWu7xe/fELFy5k2gAAAIDcIrQF4LXM4jHmVlizsMysWbPUtGlTHThw4KrzNv8nRZ3nxNmvRl4uKZZ+rcX7k9V5bpwOnE29+vU3b1ajRo0UFRWlZcuW6fXXX7ezwQAA+cv8O2EWf6xfv75atWql+fPn25rpprb4tbz77rsqUqRIxmZm6AIAAAC5RSoAwOv16NFDmzZtUkJCgi03YGZQpVtzOFmDvk1QYkr2yiDkZObt+UtO9V4Yr12n/hsOO52aPHmyWrRoobJly9pyCPfdd9/NawQA+JASJUrYWucnTpzItN88vtGatYGBgWrQoEGWf/BLN3z4cMXGxmZsR48ezXXbAQAAAEJbAD6hbt26diZrRESEOnbsaBegWX/4sv60/KINVG9iXpvBhMImHO6/OEE7/xNvZ3P1799fffv21dq1a1WpUqV8aAUA+IagoCB7F8PKlSsz9plyB+axmVF7I0x5hZ07d9o/rF1LcHCwwsLCMm0AAABAbgXk+goA4CHMbavmVtcPPvhAoz6YrBWVh8oRECSnHPnWBhMQJyY79fScGO1b/E/NnDlTjz/+eL69PgD4kqFDh9q7LcxdFk2aNNG4cePsXRc9e/a0x80fz8qXL29LHBimrvjdd9+tatWq6fz58xozZowOHz6sZ555xsXvBAAAAL6G0BaAT3E4HHrxpZe0pezj+jne3+zJ9zakmdcsUEzPfh6txzuUz/fXBwBf0aVLF506dUojR460i4+ZWrVLly7NWJzsyJEjmWqInzt3zi5eac695ZZb7EzdDRs2qFatWi58FwAAAPBFDqcpqggAPmTu7sv6v/WX5A4m3l9Ad1cIdHUzAAB55MKFC/bODlPfNr9LJTw0zz3+bbtZFnYOcXUTcB2MP7gS4w+AN/5/kZq2AHzKmYtpGve9e3yo9XNIb6xJVPLNXAENAAAAAAB4HEJbAD7lm71JSkqVWzD1bU9ddGr1oWRXNwUAAAAAALgRatoC8BkpaU7N3Z2k7M5rTUu+pOOL3lfCoW26fPKAUuLP2X3+oWEKKV1NReq0UamIPvIvUCRHs21n70rSfbcFZfu5AAAAAADAOxHaAvAZ646k6PTF7JciSLuUoJhvP7xqf2rCWSX8e7PdzmyYqRqv/ksBBW/J3rWd0vYTqfr5bKpuK2YWRgMAAAAAAL6O0BaAz1h5MFn+DiknJWQDi5ZToduaKKh4RfkXvEUp8Wd0Pnqhks4ctccvnzqo02unq8z9L2T72qZNpm2EtgAAAAAAwCC0BeAzdp5IzVFgG1C4uOq+v/uq/aUjB2jnsFoZjy+f/TXAzS4z23b3aTcptAsAAAAAAFyO0BaAT0hIcuo/cWl5ci1nWqqSY0/o9HdfZNofWrZGzq4n6ceThLYAAAAAAOBXhLYAfMLeM6nZXoDsty7sXq394zpmeazQ7c1UouVTOb72+UtOnb6YphIF/HLRQgAAAAAA4A1IBwD4hJj4vJllm5ViTR5VtUFz5BcYkqvrHM+jmcAAAAAAAMCzMdMWgE9IyoPqAyGlb1P5zm/JmXxZSWeP6lz0P5SacFZnN8/VxSM/qNqQeQouXinnbSSzBQAAAAAAzLQF4CtyWxrBCCpeUWXaDFLZ9i+p8pPjdecbmxRYpIw9dilmn36ZPTx3bcyLRgIAAAAAAI9HeQQAPiHYP++vGRhWUgWrhmc8jtu3zu3aCAAAAAAAPA+hLQCfUKpgzn/dxe1Zq9RLcVftT4k7o4SDW6/Y41BulMxFGwEAAAAAgPegpi0An1C9eM6nsZ5YOUVxP61W4Rr3KLRCbfkFhSr5/HGdi16olAsnM84rUrdtjl8jLFgqXTB3oS8AAAAAAPAOhLYAfELhYIfKFnLoeHzOCsemJV1U7I6ldstKaMU6qvDo6Bxd20S1d5YMkMNBaAsAAAAAAAhtAfiQ2qX8dSIhRWnZzG1LRfRRYJHSSjgYpeTzMUpJOCeHf4CtaRta/k4VbfBHFb+rixwBgTlql59DqlWSgrYAAAAAAOBXzLQF4DMiqgRq+b9Tsv28sFoRdrtZUp1S68o5C3wBAAAAAID3YdUbAD4V2hYJdq8SBKY1NUr4qSYzbQEAAAAAwH8R2gLwGYH+DnWuFWTLEbgLU6mh653Brm4GAAAAAABwI4S2AHzKwzXcJ7Q1zTAzfyOrUhoBAAAAAAD8D6EtAJ9SppCfnmsUIneZZTuiZahCAtwkRQYAAAAAAG6B0BaAz+leN8jWkfV3YVZqXvu+qgH6w63MsgUAAAAAAJkR2gLwOQF+Dr3ZuoAcjl9LFOQ3U56hUJBDw5qHuuDVAQAAAACAuyO0BeCTqt7ir7cjCuT765qQONBPGte2gIqG8CsYAAAAAABcjcQAgM8yC4CNahVqg1RHPs2wDfQ3gW1B1SkdkA+vCAAAAAAAPBGhLQCf9sc7gvReZAH5+/1aZ/ZmMdcuEChNaV9QjcsT2AIAAAAAgGsjtAXg8+69NVBfdyqk6iX887wv0nPgZhUDNO/RwqrLDFsAAAAAAPA7CG0BQFKVov76/KGCGnJXiAL8fi1lkBvpJRfM7Nq3IkL1YZsCKlGAX7kAAAAAAOD3cY8uAPyXv59DT9YN1v3VAvXNniTN2Z2ks4lOW9og1Xlj3ZR+bvnCfupaO0jtbw9S4eD8qJgLAAAAAAC8BaEtAPyGmRH7TMMQPV0/WGsOp2jt4WTtPJmqo7Fpcl4nrL31Fj/VKRWg+6oGqnE5fzkchLUAAAAAAIDQFgDyTICfw9a7NZuRmOzUvrOpOpXg1OVUpy2hEOTvULlCfrqtmJ/9HgAAAAAAILeYaQsANyg00KF6LCQGAAAAAABuMlbFAQAAAAAAAAA3QmgLAAAAAAAAAG6E0BYAAAAAAAAA3AihLQAAAAAAAAC4EUJbAAAAAAAAAHAjhLYAAAAAAAAA4EYIbQEAAAAAAADAjRDaAgAAAAAAAIAbIbQFAAAAAAAAADdCaAsAAAAAAAAAboTQFgAAAAAAAADcCKEtAAAAAAAAALgRQlsAAAAAAAAAcCOEtgAAAAAAAADgRghtAQAAAAAAAMCNENoCAAAAAAAAgBshtAUAAAAAAAAAN0JoCwAAAK/18ccfq0qVKgoJCdFdd92lzZs3X/f8uXPnqkaNGvb8OnXqaMmSJfnWVgAAACAdoS0AAAC80uzZszV06FCNGjVK0dHRqlevntq2bauTJ09mef6GDRvUrVs39e7dW9u2bVPHjh3t9uOPP+Z72wEAAODbCG0BAADglT788EP16dNHPXv2VK1atTRlyhQVKFBA06ZNy/L88ePHq127dnr55ZdVs2ZNvfXWW2rYsKEmTpyY720HAACAbyO0BQAAgNdJSkrS1q1bFRkZmbHPz8/PPt64cWOWzzH7rzzfMDNzr3U+AAAAcLME3LQrAwAAAC5y+vRppaamqnTp0pn2m8d79uzJ8jkxMTFZnm/2X8vly5ftli42NtZ+vXDhgvJb8sVL+f6a+enChSRXNwHXwfiDKzH+AHiS9P8nOp3O655HaAsAAADk0Lvvvqs33njjqv0VK1akT/NYEXoULsT4A+MPQF6Li4tTkSLX/heG0BYAAABep0SJEvL399eJEycy7TePy5Qpk+VzzP7snG8MHz7cLnaWLi0tTWfPnlXx4sXlcDhy/T7wvxkpJgg/evSowsLC6BbkK8YfXInxB8af9zEzbE1gW65cueueR2gLAAAArxMUFKRGjRpp5cqV6tixY0agah4PHDgwy+c0bdrUHn/++ecz9i1fvtzuv5bg4GC7Xalo0aJ59j6QmQlsCW3hKow/uBLjD4w/73K9GbbpCG0BAADglcwM2B49eig8PFxNmjTRuHHjlJCQoJ49e9rjTz31lMqXL29LHBhDhgxRq1atNHbsWLVv315ff/21oqKi9Mknn7j4nQAAAMDXENoCAADAK3Xp0kWnTp3SyJEj7WJi9evX19KlSzMWGzty5Ij8/Pwyzm/WrJm++uorvfbaa3r11Vd1++2365tvvlHt2rVd+C4AAADgiwhtAQAA4LVMKYRrlUNYvXr1VfseffRRu8G9mBIUo0aNuqoUBcD4g7fj9x8Yf77L4TTVbwEAAAAAAAAAbuF/94MBAAAAAAAAAFyO0BYAAAAAAAAA3AihLQAAAAAAAAC4EUJbAAAAALm2ceNG+fv7q3379i7rzUOHDsnhcGj79u2/e+6RI0dsWwsUKKBSpUrp5ZdfVkpKSr60E3nP08bf4MGD1ahRI7vIVP369fOlfbh5PGn8/fDDD+rWrZsqVqyo0NBQ1axZU+PHj8+3dsK3x9+ZM2fUrl07lStXzv7+M+PQLBh74cKFfGurJyG0BQAAAJBrn332mQYNGqS1a9fq2LFjbt2jqamp9sNtUlKSNmzYoC+++ELTp0/XyJEjXd00+MD4S9erVy916dLF1c2Aj42/rVu32j9Uffnll9q1a5dGjBih4cOHa+LEia5uGnxg/Pn5+alDhw5auHCh9u3bZ//tXbFihZ577jlXN809OQEAAAAgF+Li4pyFChVy7tmzx9mlSxfn6NGjrzpnwYIFzmrVqjmDg4OdrVu3dk6fPt1pPo6cO3cu45zvvvvO2aJFC2dISIizQoUKzkGDBjnj4+MzjleuXNleu2fPnvb1Klas6Jw6dWrGcXO9K7dWrVpl2d4lS5Y4/fz8nDExMRn7Jk+e7AwLC3NevnyZseBhPG38XWnUqFHOevXq5Uk/wDU8efyl69+/vzMiIiJX/QDX8IbxN378ePuauBozbQEAAADkypw5c1SjRg1Vr15d3bt317Rp08zkkIzjBw8eVOfOndWxY0d7a27fvn3t7K4r/fzzz/aWyU6dOmnHjh2aPXu21q1bZ2+bvNLYsWMVHh6ubdu2qX///urXr5/27t1rj23evNl+NbN2jh8/rvnz51/zVtI6deqodOnSGfvatm1rb880M8/gWTxt/MG7eMP4i42NVbFixXLZE3AFTx9/ZmawObdVq1Z50BteKIsgFwAAAABuWLNmzZzjxo2z3ycnJztLlCjhXLVqVcbxYcOGOWvXrp3pOSNGjMg006d3797OZ599NtM5ZuaPmRGbmJiYMdOne/fuGcfT0tKcpUqVsrNkjYMHD9prbtu27brt7dOnj7NNmzaZ9iUkJNjnmlm48CyeNv6uxExbz+fJ489Yv369MyAgwLls2bJsv3e4nqeOv65duzpDQ0Ptcx588MGM10FmzLQFAAAAkGNmlo2ZYWMWtjECAgJsnU5TY+/Kcxo3bpzpeU2aNMn02MwAMrXtChUqlLGZ2a9paWl2plC6unXrZnxvFj0pU6aMTp48yU/QRzH+wPjL+e+/H3/80dYXHTVqlNq0acNg8jCe/Pvvo48+UnR0tBYsWGBn+g4dOjRH1/F2Aa5uAAAAAADPZT4cpqSk2JWg05lbM82q0GZhmyJFitzQdeLj4+1tm4MHD77qWKVKlTK+DwwMzHTMfHA0Hyyzw3zQTL+VM92JEycyjsFzeOL4g/fw5PG3e/du3XvvvXr22Wf12muv5egacC1PHn/m31qzmdIOpjRHy5Yt9frrr6ts2bI5up63IrQFAAAAkCPmw+KMGTNsnbvfztIy9fNmzZplV4Q2tfaWLFmS6fiWLVsyPW7YsKENEapVq5bjn0ZQUJD9mpqaet3zmjZtqtGjR9sZQmYVdWP58uUKCwtTrVq1cvz6yF+eOv7gHTx5/Jna3X/4wx/Uo0cP+7sQnseTx99vpQe/ly9fzvHreyvKIwAAAADIkUWLFuncuXPq3bu3ateunWkzC5qk36JpZvDs2bNHw4YN0759++zCKeZWzPSZOoY5tmHDBrvwyfbt27V//3572+RvF0K5HhPAhoaGaunSpXbmrFlcJyvmA64JZ5988kl7W+iyZcvsTLMBAwbYGUrwDJ46/owDBw7Y14mJiVFiYqL93mxJSUm57hfkD08df6YkQkREhP09aG5JN2PQbKdOncqTfkH+8NTxZwLkzz//3I7DQ4cOafHixTZcbt68uapUqZInfeNNCG0BAAAA5Ij5UBgZGZnlLZjmQ2NUVJRdifrWW2/VvHnz7ArRpibe5MmTM1avTg9Jzf41a9bYD5XmNskGDRpo5MiRmW77/D2mnt+ECRM0depU+zxTqzEr/v7+9gOv+Wpm3ZoVt5966im9+eabjAQP4qnjz3jmmWfsa5hzzWua781mVlKHZ/DU8WfaYgLaL7/80t6Knr79tu4p3Junjj8T7H766adq0aKFatasqRdeeEEPPfSQ/TcZV3OY1ciy2A8AAAAAN425JXfKlCk6evQovYx8x/iDKzH+wPjDjaCmLQAAAICbbtKkSXYmV/HixbV+/XqNGTMmW7deAow/eCp+/4Hxh5wgtAUAAABw05kaeW+//bbOnj1rV6N+8cUXNXz4cHoe+YLxB1di/IHxh5ygPAIAAAAAAAAAuBEWIgMAAAAAAAAAN0JoCwAAAAAAAABuhNAWAAAAAAAAANwIoS0AAAAAAAAAuBFCWwAAAAAAAABwI4S2AAAAAAAAAOBGCG0BAAAAAPAxGzdulL+/v9q3b++yNhw6dEgOh0Pbt2/P1nnpj9O3woUL684779SAAQO0f//+fGo9ANxchLYAAAAAAPiYzz77TIMGDdLatWt17NgxeaIVK1bo+PHj+uGHH/TOO+/op59+Ur169bRy5UpXNw0Aco3QFgAAAAAAHxIfH6/Zs2erX79+dqbt9OnTrzpn4cKFuv322xUSEqKIiAh98cUXdlbr+fPnM85Zt26dWrZsqdDQUFWsWFGDBw9WQkJCxvEqVarYMLVXr152NmylSpX0ySefZBy/9dZb7dcGDRrYa7du3Tpb76N48eIqU6aMqlatqg4dOtgQ96677lLv3r2Vmpqaw94BAPdAaAsAAAAAgA+ZM2eOatSooerVq6t79+6aNm2anE5nxvGDBw+qc+fO6tixo53F2rdvX40YMSLTNX7++We1a9dOnTp10o4dO2wIbELcgQMHZjpv7NixCg8P17Zt29S/f38bFO/du9ce27x5c6YZs/Pnz8/V+/Lz89OQIUN0+PBhbd26NVfXAgBXI7QFAAAAAMDHSiOYsNYwwWtsbKzWrFmTcXzq1Kk20B0zZoz92rVrVz399NOZrvHuu+/qiSee0PPPP29n5DZr1kwTJkzQjBkzdOnSpYzzHnjgARvWVqtWTcOGDVOJEiW0atUqe6xkyZKZZswWK1Ys1+/NhNHpdW8BwJMR2gIAAAAA4CPMLFczw7Vbt272cUBAgLp06WKD3CvPady4cabnNWnSJNNjMwPXlFUoVKhQxta2bVulpaXZmbrp6tatm/G9KYFgwtmTJ0/etPeXPmPYvBYAeLIAVzcAAAAAAADkDxPOpqSkqFy5cpmCzuDgYE2cOFFFihS54bq4pmyCqWP7W6Z2bbrAwMBMx0yYaoLdm8UsRnZlvVwA8FSEtgAAAAAA+AAT1pryBabObJs2bTIdM/VrZ82apeeee86WRFiyZEmm41u2bMn0uGHDhtq9e7cte5BTQUFB9mteLRpmwmBTosEEtmZxMwDwZJRHAAAAAADAByxatEjnzp1T7969Vbt27UybWVAsvUSCmUG7Z88eW4N23759duEyUwrhyrID5tiGDRvswmPbt2/X/v37tWDBgqsWIrueUqVKKTQ0VEuXLtWJEydsbd3sOHPmjGJiYvTvf/9bCxcuVGRkpC39YN6Hv79/tq4FAO6G0BYAAAAAAB9gwkwTbGZVAsGEtlFRUdqxY4edqTpv3jzNnz/f1qSdPHmyRowYYc8zZRQMs98sXmZC3ZYtW9qZrSNHjsxUduH3mHq6ZmasWfjMPK9Dhw7Zej/mvZQtW1Z16tTRK6+8opo1a9r2R0REZOs6AOCOHM70Kt0AAAAAAABZGD16tKZMmaKjR4/SPwCQD6hpCwAAAAAAMpk0aZIaN26s4sWLa/369RozZky2Sh8AAHKH0BYAAAAAAGRiatS+/fbbOnv2rCpVqqQXX3xRw4cPp5cAIJ9QHgEAAAAAAAAA3AgLkQEAAAAAAACAGyG0BQAAAAAAAAA3QmgLAAAAAAAAAG6E0BYAAAAAAAAA3AihLQAAAAAAAAC4EUJbAAAAAAAAAHAjhLYAAAAAAAAA4EYIbQEAAAAAAADAjRDaAgAAAAAAAIDcx/8DfuSTo05wRYkAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 1400x600 with 2 Axes>"
       ]
@@ -855,10 +928,10 @@
    "id": "98c58c2e",
    "metadata": {
     "papermill": {
-     "duration": 0.005612,
-     "end_time": "2026-04-25T15:42:26.571177",
+     "duration": 0.004504,
+     "end_time": "2026-04-28T13:16:52.866026+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.565565",
+     "start_time": "2026-04-28T13:16:52.861522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -868,33 +941,31 @@
     "\n",
     "**Graphe de coloration** (gauche) :\n",
     "- Les noeuds representent les agents 0, 1, 2, 3\n",
-    "- Les couleurs indiquent la valeur choisie par chaque agent\n",
-    "- Les aretes montrent les contraintes entre agents\n",
-    "- **Probleme visible** : Les noeuds 2 et 3 ont la meme couleur (Rouge) mais sont connectes par une arete\n",
+    "- Les couleurs indiquent la valeur choisie par chaque agent **en fin de simulation** (apres quiescence)\n",
+    "- Les aretes montrent les contraintes ; chaque arete doit relier deux couleurs differentes\n",
     "\n",
     "**Statistiques par agent** (droite) :\n",
-    "- **Messages envoyes** : Tous les agents ont envoye 1 message (initialisation)\n",
-    "- **Nogoods generes** : 0 pour tous les agents\n",
-    "- **Analyse** : L'algorithme s'est arrete apres le premier cycle de messages\n",
+    "- **Messages envoyes** : combien d'`ok?` / `nogood` / `addlink` chaque agent a emis\n",
+    "- **Nogoods generes** : combien de fois cet agent a backtracke (envoye un nogood)\n",
     "\n",
-    "**Ce que cette visualisation revele** :\n",
+    "**Lecture du flux ABT** :\n",
     "\n",
-    "1. **Flux incomplet** : ABT necessite plusieurs cycles pour converger\n",
-    "2. **Absence de nogoods** : Les conflits n'ont pas ete detectes ni appris\n",
-    "3. **Termination prematuree** : L'algorithme a declare la solution trouvee trop tot\n",
+    "1. **Phase d'initialisation** : tous les agents diffusent leur valeur initiale aux agents de\n",
+    "   priorite inferieure (`ok?`). L'agent 0 (priorite la plus haute) emet vers 1, 2, 3 ; l'agent 1\n",
+    "   emet vers 2, 3 ; etc. Le compteur `messages_sent` reflete cette propagation.\n",
+    "2. **Phase de propagation** : chaque agent ajuste sa valeur en fonction des `ok?` recus. Si un\n",
+    "   conflit apparait (la valeur courante n'est plus compatible avec la vue), il choisit une autre\n",
+    "   valeur dans son domaine.\n",
+    "3. **Phase de backtracking** : quand un agent epuise son domaine, il emet un `nogood` vers le plus\n",
+    "   prioritaire des agents de sa vue, qui devra alors changer de valeur. Le compteur\n",
+    "   `nogoods_generated` recense ces emissions.\n",
+    "4. **Quiescence** : la file de messages se vide ; le systeme verifie la coherence globale et\n",
+    "   retourne la solution si toutes les aretes sont satisfaites.\n",
     "\n",
-    "**Comparaison avec ABT complet** :\n",
-    "\n",
-    "Dans une implementation correcte d'ABT, on observerait :\n",
-    "- Agent 2 envoie 'R' aux agents de priorite inferieure (aucun dans ce cas)\n",
-    "- Agent 3 recoit 'R' de l'agent 0, choisit 'R'\n",
-    "- Agent 3 detecte un conflit potentiel avec l'agent 2 (pas encore dans sa vue)\n",
-    "- Agent 3 envoie un message 'ok?' a l'agent 2\n",
-    "- Agent 2 detecte le conflit (R == R)\n",
-    "- Agent 2 genere un nogood et backtrackerait\n",
-    "- Le cycle continuerait jusqu'a une solution valide\n",
-    "\n",
-    "> **Note pedagogique** : Cette visualisation met en evidence la difference entre une implementation conceptuelle (qui montre le principe) et une implementation production (qui resout correctement le probleme)."
+    "> **A retenir** : les nogoods sont l'outil d'**apprentissage distribue** d'ABT. Plus le graphe est\n",
+    "> dense ou contraint, plus on en accumule. Sur un cycle 4-noeuds avec 3 couleurs, quelques nogoods\n",
+    "> suffisent ; sur des instances plus larges, leur nombre peut exploser et motive AWC ou des\n",
+    "> heuristiques d'oubli.\n"
    ]
   },
   {
@@ -902,10 +973,10 @@
    "id": "4766a546",
    "metadata": {
     "papermill": {
-     "duration": 0.005524,
-     "end_time": "2026-04-25T15:42:26.582523",
+     "duration": 0.003738,
+     "end_time": "2026-04-28T13:16:52.875949+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.576999",
+     "start_time": "2026-04-28T13:16:52.872211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -946,16 +1017,16 @@
    "id": "5fee8e73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.596310Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.595813Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.602181Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.601505Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.883732Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.883732Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.899944Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.899249Z"
     },
     "papermill": {
-     "duration": 0.015559,
-     "end_time": "2026-04-25T15:42:26.603223",
+     "duration": 0.021289,
+     "end_time": "2026-04-28T13:16:52.900469+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.587664",
+     "start_time": "2026-04-28T13:16:52.879180+00:00",
      "status": "completed"
     },
     "tags": []
@@ -972,40 +1043,41 @@
    "source": [
     "class AWCAgent(ABTAgent):\n",
     "    \"\"\"\n",
-    "    Agent pour l'algorithme Asynchronous Weak-Commitment.\n",
-    "    \n",
-    "    Etend ABT avec reordonnancement dynamique des agents.\n",
+    "    Couche pedagogique AWC au-dessus d'ABT : rang dynamique awc_rank utilise par\n",
+    "    ABTSystem.priority_sort_key pour reorder higher/lower a la volee. Ce n'est pas\n",
+    "    AWC complet (Yokoo 1995) mais le reordonnancement impacte reellement la simulation.\n",
     "    \"\"\"\n",
-    "    \n",
-    "    def __init__(self, agent_id: int, domain: List[Any], \n",
+    "\n",
+    "    def __init__(self, agent_id: int, domain: List[Any],\n",
     "                 constraint_func, neighbors: List[int]):\n",
     "        super().__init__(agent_id, domain, constraint_func, neighbors)\n",
-    "        self.priority = agent_id  # Priorite dynamique\n",
-    "        self.nogood_count = 0     # Compteur de nogoods recents\n",
-    "    \n",
+    "        self.awc_rank = float(agent_id)\n",
+    "        self.nogoods_received = 0  # nogoods recus (voir process_nogood_message)\n",
+    "\n",
+    "    def priority_sort_key(self) -> Tuple[float, int]:\n",
+    "        return (self.awc_rank, self.id)\n",
+    "\n",
     "    def process_nogood_message(self, msg: Message) -> List[Message]:\n",
-    "        \"\"\"Traite un nogood avec possible reordonnancement.\"\"\"\n",
+    "        \"\"\"Apres traitement ABT : compte les nogoods recus, promotion si blocage repete.\"\"\"\n",
     "        result = super().process_nogood_message(msg)\n",
-    "        self.nogood_count += 1\n",
-    "        \n",
-    "        # Si trop de nogoods, augmenter la priorite\n",
-    "        if self.nogood_count > 3:\n",
+    "        self.nogoods_received += 1\n",
+    "        if self.nogoods_received > 3:\n",
     "            self._increase_priority()\n",
-    "            self.nogood_count = 0\n",
-    "        \n",
+    "            self.nogoods_received = 0\n",
     "        return result\n",
-    "    \n",
+    "\n",
     "    def _increase_priority(self):\n",
-    "        \"\"\"Augmente la priorite de l'agent (diminue le numero).\"\"\"\n",
-    "        # Trouver la plus petite priorite actuelle\n",
-    "        min_priority = min(self.agent_view.keys()) if self.agent_view else 0\n",
-    "        self.priority = min_priority - 1\n",
-    "    \n",
+    "        \"\"\"Monter dans la hierarchie : diminuer awc_rank, puis synchroniser via le systeme.\"\"\"\n",
+    "        self.awc_rank -= 1.0\n",
+    "        sys = getattr(self, '_system', None)\n",
+    "        if sys is not None:\n",
+    "            sys._on_awc_reorder()\n",
+    "\n",
     "    def _backtrack(self) -> List[Message]:\n",
-    "        \"\"\"Backtrack avec augmentation de priorite.\"\"\"\n",
-    "        # Augmenter la priorite avant de backtracker\n",
-    "        self._increase_priority()\n",
+    "        if self.higher_priority:\n",
+    "            self._increase_priority()\n",
     "        return super()._backtrack()\n",
+    "\n",
     "print(\"Classe AWCAgent definie.\")\n"
    ]
   },
@@ -1014,10 +1086,10 @@
    "id": "070a53e6",
    "metadata": {
     "papermill": {
-     "duration": 0.005366,
-     "end_time": "2026-04-25T15:42:26.614097",
+     "duration": 0.003397,
+     "end_time": "2026-04-28T13:16:52.906955+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.608731",
+     "start_time": "2026-04-28T13:16:52.903558+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1077,10 +1149,10 @@
    "id": "19074682",
    "metadata": {
     "papermill": {
-     "duration": 0.005521,
-     "end_time": "2026-04-25T15:42:26.625338",
+     "duration": 0.002999,
+     "end_time": "2026-04-28T13:16:52.913955+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.619817",
+     "start_time": "2026-04-28T13:16:52.910956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1111,16 +1183,16 @@
    "id": "b578494c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.637486Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.637068Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.645158Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.644274Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.923268Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.922267Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.931267Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.931267Z"
     },
     "papermill": {
-     "duration": 0.015698,
-     "end_time": "2026-04-25T15:42:26.646496",
+     "duration": 0.013002,
+     "end_time": "2026-04-28T13:16:52.931267+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.630798",
+     "start_time": "2026-04-28T13:16:52.918265+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1215,10 +1287,10 @@
    "id": "fbec7ab7",
    "metadata": {
     "papermill": {
-     "duration": 0.0059,
-     "end_time": "2026-04-25T15:42:26.657865",
+     "duration": 0.003882,
+     "end_time": "2026-04-28T13:16:52.939614+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.651965",
+     "start_time": "2026-04-28T13:16:52.935732+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1281,10 +1353,10 @@
    "id": "f7a15c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.005611,
-     "end_time": "2026-04-25T15:42:26.669167",
+     "duration": 0.002517,
+     "end_time": "2026-04-28T13:16:52.944995+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.663556",
+     "start_time": "2026-04-28T13:16:52.942478+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1313,16 +1385,16 @@
    "id": "11eccc2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.682728Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.682413Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.688624Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.687929Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.953281Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.953281Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.962650Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.962148Z"
     },
     "papermill": {
-     "duration": 0.013702,
-     "end_time": "2026-04-25T15:42:26.689626",
+     "duration": 0.013249,
+     "end_time": "2026-04-28T13:16:52.962650+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.675924",
+     "start_time": "2026-04-28T13:16:52.949401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1337,14 +1409,14 @@
       "Solution trouvee:\n",
       "  Hopital 0: Lundi_AM\n",
       "  Hopital 1: Lundi_PM\n",
-      "  Hopital 2: Lundi_AM\n",
+      "  Hopital 2: Mardi_AM\n",
       "\n",
       "Rapports de confidentialite:\n",
       "  Agent 0: {'privacy_level': 'high', 'agents_with_access': [], 'private_constraints_count': 0}\n",
       "  Agent 1: {'privacy_level': 'high', 'agents_with_access': [], 'private_constraints_count': 0}\n",
       "  Agent 2: {'privacy_level': 'high', 'agents_with_access': [], 'private_constraints_count': 0}\n",
       "\n",
-      "Messages totaux: 1\n"
+      "Messages totaux: 4\n"
      ]
     }
    ],
@@ -1399,10 +1471,10 @@
    "id": "8f050be3",
    "metadata": {
     "papermill": {
-     "duration": 0.005446,
-     "end_time": "2026-04-25T15:42:26.700373",
+     "duration": 0.003124,
+     "end_time": "2026-04-28T13:16:52.969777+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.694927",
+     "start_time": "2026-04-28T13:16:52.966653+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1449,10 +1521,10 @@
    "id": "6473ecbe",
    "metadata": {
     "papermill": {
-     "duration": 0.005185,
-     "end_time": "2026-04-25T15:42:26.710858",
+     "duration": 0.00341,
+     "end_time": "2026-04-28T13:16:52.976929+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.705673",
+     "start_time": "2026-04-28T13:16:52.973519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1469,16 +1541,16 @@
    "id": "69eff4b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.723492Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.723022Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.733817Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.733207Z"
+     "iopub.execute_input": "2026-04-28T13:16:52.984659Z",
+     "iopub.status.busy": "2026-04-28T13:16:52.984659Z",
+     "iopub.status.idle": "2026-04-28T13:16:52.992662Z",
+     "shell.execute_reply": "2026-04-28T13:16:52.992662Z"
     },
     "papermill": {
-     "duration": 0.018659,
-     "end_time": "2026-04-25T15:42:26.734888",
+     "duration": 0.013874,
+     "end_time": "2026-04-28T13:16:52.993360+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.716229",
+     "start_time": "2026-04-28T13:16:52.979486+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1491,107 +1563,123 @@
       "=== Benchmark DisCSP ===\n",
       "\n",
       "Resultats ABT:\n",
-      "  Run 1: Resolu, 1 messages, 0 nogoods, 0.000s\n",
-      "  Run 2: Resolu, 1 messages, 0 nogoods, 0.000s\n",
-      "  Run 3: Resolu, 1 messages, 0 nogoods, 0.000s\n",
+      "  Run 1: Resolu, 10 messages, 0 nogoods, 0.000s\n",
+      "  Run 2: Resolu, 10 messages, 0 nogoods, 0.000s\n",
+      "  Run 3: Resolu, 10 messages, 0 nogoods, 0.000s\n",
       "\n",
       "Moyennes ABT:\n",
-      "  Messages: 1.0\n",
+      "  Messages: 10.0\n",
+      "  Nogoods: 0.0\n",
+      "  Taux de succes: 100.0%\n",
+      "\n",
+      "Resultats AWC:\n",
+      "  Run 1: Resolu, 10 messages, 0 nogoods, 0.000s\n",
+      "  Run 2: Resolu, 10 messages, 0 nogoods, 0.000s\n",
+      "  Run 3: Resolu, 10 messages, 0 nogoods, 0.000s\n",
+      "\n",
+      "Moyennes AWC:\n",
+      "  Messages: 10.0\n",
       "  Nogoods: 0.0\n",
       "  Taux de succes: 100.0%\n"
      ]
     }
    ],
    "source": [
-    "def benchmark_discsp(n_agents: int, domain_size: int, \n",
+    "def benchmark_discsp(n_agents: int, domain_size: int,\n",
     "                     constraint_density: float, n_runs: int = 5):\n",
     "    \"\"\"\n",
-    "    Compare les performances des algorithmes DisCSP.\n",
-    "    \n",
-    "    Parameters:\n",
-    "    -----------\n",
-    "    n_agents : Nombre d'agents\n",
-    "    domain_size : Taille du domaine\n",
-    "    constraint_density : Probabilite de contrainte entre deux agents\n",
-    "    n_runs : Nombre d'executions\n",
+    "    Compare les performances d'ABT et d'AWC sur des instances aleatoires.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    n_agents : nombre d'agents\n",
+    "    domain_size : taille du domaine\n",
+    "    constraint_density : probabilite de contrainte entre deux agents\n",
+    "    n_runs : nombre d'executions\n",
     "    \"\"\"\n",
     "    results = {'ABT': [], 'AWC': []}\n",
-    "    \n",
+    "\n",
     "    for run in range(n_runs):\n",
-    "        # Generer un probleme aleatoire\n",
     "        domain = list(range(domain_size))\n",
     "        edges = []\n",
     "        constraint_funcs = {}\n",
-    "        \n",
+    "\n",
     "        for i in range(n_agents):\n",
-    "            for j in range(i+1, n_agents):\n",
+    "            for j in range(i + 1, n_agents):\n",
     "                if random.random() < constraint_density:\n",
     "                    edges.append((i, j))\n",
-    "                    # Contrainte aleatoire\n",
-    "                    forbidden = (random.randint(0, domain_size-1), \n",
-    "                                 random.randint(0, domain_size-1))\n",
+    "                    forbidden = (random.randint(0, domain_size - 1),\n",
+    "                                 random.randint(0, domain_size - 1))\n",
     "                    constraint_funcs[(i, j)] = forbidden\n",
-    "        \n",
-    "        def make_constraint(forbidden):\n",
-    "            def constraint(v1, val1, v2, val2):\n",
-    "                if (val1, val2) == forbidden:\n",
-    "                    return False\n",
-    "                return True\n",
-    "            return constraint\n",
-    "        \n",
-    "        # Test ABT\n",
-    "        agents_abt = {}\n",
-    "        for i in range(n_agents):\n",
-    "            neighbors = [n for e in edges for n in e if i in e and n != i]\n",
-    "            relevant_constraints = {(min(k[0], k[1]), max(k[0], k[1])): v \n",
-    "                                   for k, v in constraint_funcs.items() if i in k}\n",
-    "            \n",
-    "            def constraint_func(v1, val1, v2, val2, rc=relevant_constraints):\n",
-    "                edge = (min(v1, v2), max(v1, v2))\n",
-    "                if edge in rc:\n",
-    "                    forbidden = rc[edge]\n",
-    "                    if v1 < v2 and (val1, val2) == forbidden:\n",
-    "                        return False\n",
-    "                    if v1 > v2 and (val2, val1) == forbidden:\n",
-    "                        return False\n",
-    "                return True\n",
-    "            \n",
-    "            agents_abt[i] = ABTAgent(i, domain.copy(), constraint_func, neighbors)\n",
-    "        \n",
-    "        system_abt = ABTSystem(agents_abt)\n",
+    "\n",
+    "        def build_agents(agent_cls):\n",
+    "            agents = {}\n",
+    "            for i in range(n_agents):\n",
+    "                neighbors = [n for e in edges for n in e if i in e and n != i]\n",
+    "                relevant_constraints = {(min(k[0], k[1]), max(k[0], k[1])): v\n",
+    "                                        for k, v in constraint_funcs.items() if i in k}\n",
+    "\n",
+    "                def constraint_func(v1, val1, v2, val2, rc=relevant_constraints):\n",
+    "                    edge = (min(v1, v2), max(v1, v2))\n",
+    "                    if edge in rc:\n",
+    "                        forb = rc[edge]\n",
+    "                        if v1 < v2 and (val1, val2) == forb:\n",
+    "                            return False\n",
+    "                        if v1 > v2 and (val2, val1) == forb:\n",
+    "                            return False\n",
+    "                    return True\n",
+    "\n",
+    "                agents[i] = agent_cls(i, domain.copy(), constraint_func, neighbors)\n",
+    "            return agents\n",
+    "\n",
+    "        max_it = 10000\n",
+    "\n",
+    "        system_abt = ABTSystem(build_agents(ABTAgent))\n",
     "        start = datetime.now()\n",
-    "        solution_abt = system_abt.run(max_iterations=500)\n",
+    "        solution_abt = system_abt.run(max_iterations=max_it)\n",
     "        time_abt = (datetime.now() - start).total_seconds()\n",
-    "        \n",
     "        results['ABT'].append({\n",
     "            'time': time_abt,\n",
     "            'messages': system_abt.total_messages,\n",
     "            'nogoods': system_abt.total_nogoods,\n",
     "            'solved': solution_abt is not None\n",
     "        })\n",
-    "    \n",
+    "\n",
+    "        system_awc = ABTSystem(build_agents(AWCAgent))\n",
+    "        start = datetime.now()\n",
+    "        solution_awc = system_awc.run(max_iterations=max_it)\n",
+    "        time_awc = (datetime.now() - start).total_seconds()\n",
+    "        results['AWC'].append({\n",
+    "            'time': time_awc,\n",
+    "            'messages': system_awc.total_messages,\n",
+    "            'nogoods': system_awc.total_nogoods,\n",
+    "            'solved': solution_awc is not None\n",
+    "        })\n",
+    "\n",
     "    return results\n",
     "\n",
-    "# Executer le benchmark\n",
+    "\n",
+    "def _print_bench_summary(name: str, rows: List[dict]):\n",
+    "    print(f\"\\nResultats {name}:\")\n",
+    "    for i, r in enumerate(rows):\n",
+    "        status = \"Resolu\" if r['solved'] else \"Non resolu\"\n",
+    "        print(f\"  Run {i+1}: {status}, {r['messages']} messages, \"\n",
+    "              f\"{r['nogoods']} nogoods, {r['time']:.3f}s\")\n",
+    "    avg_m = sum(r['messages'] for r in rows) / len(rows)\n",
+    "    avg_n = sum(r['nogoods'] for r in rows) / len(rows)\n",
+    "    sr = sum(1 for r in rows if r['solved']) / len(rows)\n",
+    "    print(f\"\\nMoyennes {name}:\")\n",
+    "    print(f\"  Messages: {avg_m:.1f}\")\n",
+    "    print(f\"  Nogoods: {avg_n:.1f}\")\n",
+    "    print(f\"  Taux de succes: {sr*100:.1f}%\")\n",
+    "\n",
+    "\n",
     "print(\"=== Benchmark DisCSP ===\")\n",
-    "results = benchmark_discsp(n_agents=5, domain_size=3, \n",
-    "                          constraint_density=0.5, n_runs=3)\n",
-    "\n",
-    "# Afficher les resultats\n",
-    "print(\"\\nResultats ABT:\")\n",
-    "for i, r in enumerate(results['ABT']):\n",
-    "    status = \"Resolu\" if r['solved'] else \"Non resolu\"\n",
-    "    print(f\"  Run {i+1}: {status}, {r['messages']} messages, \"\n",
-    "          f\"{r['nogoods']} nogoods, {r['time']:.3f}s\")\n",
-    "\n",
-    "avg_messages = sum(r['messages'] for r in results['ABT']) / len(results['ABT'])\n",
-    "avg_nogoods = sum(r['nogoods'] for r in results['ABT']) / len(results['ABT'])\n",
-    "success_rate = sum(1 for r in results['ABT'] if r['solved']) / len(results['ABT'])\n",
-    "\n",
-    "print(f\"\\nMoyennes ABT:\")\n",
-    "print(f\"  Messages: {avg_messages:.1f}\")\n",
-    "print(f\"  Nogoods: {avg_nogoods:.1f}\")\n",
-    "print(f\"  Taux de succes: {success_rate*100:.1f}%\")"
+    "random.seed(42)\n",
+    "results = benchmark_discsp(n_agents=5, domain_size=3,\n",
+    "                           constraint_density=0.5, n_runs=3)\n",
+    "_print_bench_summary('ABT', results['ABT'])\n",
+    "_print_bench_summary('AWC', results['AWC'])\n"
    ]
   },
   {
@@ -1599,10 +1687,10 @@
    "id": "7d6810ce",
    "metadata": {
     "papermill": {
-     "duration": 0.005305,
-     "end_time": "2026-04-25T15:42:26.745816",
+     "duration": 0.003,
+     "end_time": "2026-04-28T13:16:53.000364+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.740511",
+     "start_time": "2026-04-28T13:16:52.997364+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1610,28 +1698,38 @@
    "source": [
     "### Interpretation des resultats du benchmark\n",
     "\n",
-    "**Observation** : Les resultats montrent une performance anormalement elevee avec seulement 1 message et 0 nogoods.\n",
+    "**Lecture** : le benchmark genere `n_runs` instances aleatoires de coloration de graphe avec\n",
+    "`n_agents` agents, un domaine de taille `domain_size`, et une densite de contraintes\n",
+    "`constraint_density`. Pour chaque instance, ABT et AWC sont executes jusqu'a quiescence.\n",
     "\n",
-    "| Metrique | Valeur observee | Valeur attendue | Analyse |\n",
-    "|----------|----------------|-----------------|---------|\n",
-    "| Messages | 1 | 10-50 | Suspicieusement faible - indique un probleme possible |\n",
-    "| Nogoods | 0 | 2-10 | Aucun conflit detecte - peu probable pour densite 0.5 |\n",
-    "| Taux de succes | 100% | 60-90% | Tres eleve pour des problemes aleatoires |\n",
+    "**Ordres de grandeur attendus** (n_agents=5, domain_size=3, density=0.5) :\n",
     "\n",
-    "**Analyse** :\n",
+    "| Metrique | ABT | AWC | Lecture |\n",
+    "|----------|-----|-----|---------|\n",
+    "| Messages | 10-50 | similaire ou un peu moins | trafic d'`ok?` + `nogood` + `addlink` |\n",
+    "| Nogoods | 0-10 | 0-10 | depend du nombre de conflits rencontres |\n",
+    "| Taux de succes | 60-100% | 60-100% | depend de la satisfiabilite des instances |\n",
+    "| Temps | < 50 ms | < 50 ms | simulation FIFO en RAM |\n",
     "\n",
-    "Ce resultat simplifie indique que l'implementation d'ABT dans ce notebook pedagogique priorise la **simplicite conceptuelle** sur l'efficacite pratique. Les agents choisissent leurs valeurs initiales et convergent rapidement car :\n",
+    "**Comparaison ABT vs AWC** :\n",
     "\n",
-    "1. **Priorite statique** : L'agent 0 choisit en premier et impose sa valeur\n",
-    "2. **Verification prematuree** : Le systeme verifie la convergence avant que tous les conflits ne soient detectes\n",
-    "3. **Pas de backtracking reel** : Dans ce cas simple, aucun conflit ne necessite de nogood\n",
+    "- Sur des instances peu contraintes, les deux convergent en quelques messages : les chiffres se\n",
+    "  ressemblent.\n",
+    "- Sur des instances denses, AWC peut etre plus rapide en messages car il **promeut dynamiquement**\n",
+    "  les agents qui accumulent les nogoods (leur priorite augmente, ce qui change l'ordre de\n",
+    "  propagation et evite des conflits ulterieurs).\n",
+    "- AWC paye ce gain par un cout : a chaque promotion, le systeme reordonnance toutes les priorites\n",
+    "  et rediffuse les `ok?` (`_on_awc_reorder`). Sur les petites instances, ce cout peut effacer le\n",
+    "  benefice.\n",
     "\n",
-    "**Limitation** : Dans une implementation complete d'ABT, on observerait :\n",
-    "- Plusieurs cycles de messages (ok?, nogood)\n",
-    "- Accumulation de nogoods pour eviter de repeter les erreurs\n",
-    "- Messages addlink pour creer de nouveaux liens de priorite\n",
+    "**Si une instance n'est pas resolue** (`Resolu` = False) :\n",
     "\n",
-    "> **Note pedagogique** : Cette simplification volontaire permet de comprendre le **flux des messages** sans etre submerge par la complexite d'une implementation production. Les algorithmes ABT/AWC reels utilisent des heuristiques plus sophistiquees pour minimiser les communications."
+    "- Soit l'instance est **insatisfiable** (les contraintes aleatoires bloquent toute affectation)\n",
+    "- Soit `max_iterations` (ici 10 000) a ete atteint avant la quiescence\n",
+    "\n",
+    "> **A retenir** : un benchmark DisCSP n'est pas un classement absolu, c'est une mesure de\n",
+    "> **comportement** sur une distribution d'instances. Pour comparer rigoureusement ABT et AWC, il\n",
+    "> faut faire varier `n_agents`, `density`, et tracer messages/nogoods en fonction de ces parametres.\n"
    ]
   },
   {
@@ -1639,10 +1737,10 @@
    "id": "fd2c2032",
    "metadata": {
     "papermill": {
-     "duration": 0.005386,
-     "end_time": "2026-04-25T15:42:26.756520",
+     "duration": 0.004659,
+     "end_time": "2026-04-28T13:16:53.008524+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.751134",
+     "start_time": "2026-04-28T13:16:53.003865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1663,16 +1761,16 @@
    "id": "1j33o30supz",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.768838Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.768384Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.775877Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.775312Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.016526Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.016526Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.038843Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.038843Z"
     },
     "papermill": {
-     "duration": 0.015202,
-     "end_time": "2026-04-25T15:42:26.776954",
+     "duration": 0.027318,
+     "end_time": "2026-04-28T13:16:53.039844+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.761752",
+     "start_time": "2026-04-28T13:16:53.012526+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1682,9 +1780,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solution 6-reines : {0: 0, 1: 2, 2: 0, 3: 0, 4: 0, 5: 0}\n",
-      "Messages : 1, nogoods : 0\n",
-      "Solution valide ? False\n"
+      "Solution 6-reines : {0: 1, 1: 3, 2: 5, 3: 0, 4: 2, 5: 4}\n",
+      "Messages : 442, nogoods : 110\n",
+      "Solution valide ? True\n",
+      "\n",
+      "Plateau :\n",
+      ". . . Q . .\n",
+      "Q . . . . .\n",
+      ". . . . Q .\n",
+      ". Q . . . .\n",
+      ". . . . . Q\n",
+      ". . Q . . .\n"
      ]
     }
    ],
@@ -1754,10 +1860,10 @@
    "id": "4fa4608f",
    "metadata": {
     "papermill": {
-     "duration": 0.00564,
-     "end_time": "2026-04-25T15:42:26.788245",
+     "duration": 0.013003,
+     "end_time": "2026-04-28T13:16:53.056846+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.782605",
+     "start_time": "2026-04-28T13:16:53.043843+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1784,16 +1890,16 @@
    "id": "5afc844f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.800401Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.799878Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.803678Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.802975Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.065213Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.065213Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.070251Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.070251Z"
     },
     "papermill": {
-     "duration": 0.011169,
-     "end_time": "2026-04-25T15:42:26.804767",
+     "duration": 0.009748,
+     "end_time": "2026-04-28T13:16:53.070962+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.793598",
+     "start_time": "2026-04-28T13:16:53.061214+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1817,10 +1923,10 @@
    "id": "md-ex2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005562,
-     "end_time": "2026-04-25T15:42:26.815869",
+     "duration": 0.003999,
+     "end_time": "2026-04-28T13:16:53.078964+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.810307",
+     "start_time": "2026-04-28T13:16:53.074965+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1837,16 +1943,16 @@
    "id": "e8orxwoue1v",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.828260Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.827771Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.839055Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.838449Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.087227Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.087227Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.116919Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.116288Z"
     },
     "papermill": {
-     "duration": 0.018803,
-     "end_time": "2026-04-25T15:42:26.840006",
+     "duration": 0.035465,
+     "end_time": "2026-04-28T13:16:53.117437+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.821203",
+     "start_time": "2026-04-28T13:16:53.081972+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1856,11 +1962,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " density  abt_suc  awc_suc  abt_msgs  awc_msgs   abt_ng   awc_ng\n",
+      " density  abt_suc  awc_suc  abt_msgs  awc_msgs   abt_ng   awc_ng"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "----------------------------------------------------------------\n",
-      "    0.30     100%     100%       1.0       1.0      0.0      0.0\n",
-      "    0.50     100%     100%       1.0       1.0      0.0      0.0\n",
-      "    0.70     100%     100%       1.0       1.0      0.0      0.0\n"
+      "    0.30      80%      80%      94.6      42.0     16.0      1.2\n",
+      "    0.50     100%      80%      26.0      52.2      0.4      1.6\n",
+      "    0.70      40%      20%     575.6     124.6    137.8      5.8\n"
      ]
     }
    ],
@@ -1941,10 +2054,10 @@
    "id": "f44a1165",
    "metadata": {
     "papermill": {
-     "duration": 0.00584,
-     "end_time": "2026-04-25T15:42:26.851847",
+     "duration": 0.004031,
+     "end_time": "2026-04-28T13:16:53.125336+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.846007",
+     "start_time": "2026-04-28T13:16:53.121305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1972,16 +2085,16 @@
    "id": "bf001a5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.864174Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.863857Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.867858Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.867102Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.133456Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.133456Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.148498Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.147829Z"
     },
     "papermill": {
-     "duration": 0.011283,
-     "end_time": "2026-04-25T15:42:26.868842",
+     "duration": 0.020682,
+     "end_time": "2026-04-28T13:16:53.149021+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.857559",
+     "start_time": "2026-04-28T13:16:53.128339+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2002,10 +2115,10 @@
    "id": "md-ex3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00581,
-     "end_time": "2026-04-25T15:42:26.880307",
+     "duration": 0.004111,
+     "end_time": "2026-04-28T13:16:53.157406+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.874497",
+     "start_time": "2026-04-28T13:16:53.153295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2024,16 +2137,16 @@
    "id": "m1s5bmbfn4o",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.892863Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.892559Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.903067Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.902283Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.167599Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.167074Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.179246Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.178632Z"
     },
     "papermill": {
-     "duration": 0.018254,
-     "end_time": "2026-04-25T15:42:26.904141",
+     "duration": 0.017666,
+     "end_time": "2026-04-28T13:16:53.179246+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.885887",
+     "start_time": "2026-04-28T13:16:53.161580+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2044,14 +2157,14 @@
      "output_type": "stream",
      "text": [
       "Statut   : OK\n",
-      "Messages : 1\n",
-      "Bien-etre social : 20 / max theorique 20\n",
+      "Messages : 6\n",
+      "Bien-etre social : 19 / max theorique 20\n",
       "\n",
       "Allocation :\n",
       "  Agent 0 -> slot_1    (utilite privee = 5)\n",
       "  Agent 1 -> slot_3    (utilite privee = 5)\n",
       "  Agent 2 -> slot_0    (utilite privee = 5)\n",
-      "  Agent 3 -> slot_0    (utilite privee = 5)\n"
+      "  Agent 3 -> slot_2    (utilite privee = 4)\n"
      ]
     }
    ],
@@ -2152,10 +2265,10 @@
    "id": "d7dab799",
    "metadata": {
     "papermill": {
-     "duration": 0.00556,
-     "end_time": "2026-04-25T15:42:26.915511",
+     "duration": 0.004622,
+     "end_time": "2026-04-28T13:16:53.189602+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.909951",
+     "start_time": "2026-04-28T13:16:53.184980+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2183,16 +2296,16 @@
    "id": "d5cae7ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.928632Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.928101Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.932150Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.931472Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.198985Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.198985Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.210286Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.209734Z"
     },
     "papermill": {
-     "duration": 0.012027,
-     "end_time": "2026-04-25T15:42:26.933239",
+     "duration": 0.016622,
+     "end_time": "2026-04-28T13:16:53.210848+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.921212",
+     "start_time": "2026-04-28T13:16:53.194226+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2216,10 +2329,10 @@
    "id": "md-ex4-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005681,
-     "end_time": "2026-04-25T15:42:26.944653",
+     "duration": 0.003576,
+     "end_time": "2026-04-28T13:16:53.218040+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.938972",
+     "start_time": "2026-04-28T13:16:53.214464+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2242,16 +2355,16 @@
    "id": "t88fv0pcs1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.959007Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.958520Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.969006Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.968224Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.227041Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.226041Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.240297Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.240297Z"
     },
     "papermill": {
-     "duration": 0.01933,
-     "end_time": "2026-04-25T15:42:26.970030",
+     "duration": 0.019248,
+     "end_time": "2026-04-28T13:16:53.241289+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.950700",
+     "start_time": "2026-04-28T13:16:53.222041+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2263,15 +2376,15 @@
      "text": [
       " run  std_ok  min_ok  std_leak  min_leak  reduction\n",
       "------------------------------------------------------\n",
-      "   0    True    True        19         6        68%\n",
-      "   1    True    True        15         9        40%\n",
-      "   2    True    True        19         9        53%\n",
-      "   3    True    True        15         4        73%\n",
-      "   4    True    True        19         5        74%\n",
+      "   0    True    True        22         7        68%\n",
+      "   1    True    True        25        11        56%\n",
+      "   2    True    True        33        17        48%\n",
+      "   3    True    True        19         4        79%\n",
+      "   4    True    True        23         6        74%\n",
       "\n",
-      "Moyenne fuite ABT standard   : 17.4 revelations\n",
-      "Moyenne fuite disclosure min : 6.6 revelations\n",
-      "Reduction moyenne : 62%\n"
+      "Moyenne fuite ABT standard   : 24.4 revelations\n",
+      "Moyenne fuite disclosure min : 9.0 revelations\n",
+      "Reduction moyenne : 63%\n"
      ]
     }
    ],
@@ -2359,10 +2472,10 @@
    "id": "e666761d",
    "metadata": {
     "papermill": {
-     "duration": 0.005585,
-     "end_time": "2026-04-25T15:42:26.981277",
+     "duration": 0.004,
+     "end_time": "2026-04-28T13:16:53.248289+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.975692",
+     "start_time": "2026-04-28T13:16:53.244289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2394,16 +2507,16 @@
    "id": "950c3f32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:26.993891Z",
-     "iopub.status.busy": "2026-04-25T15:42:26.993435Z",
-     "iopub.status.idle": "2026-04-25T15:42:26.997020Z",
-     "shell.execute_reply": "2026-04-25T15:42:26.996351Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.257292Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.256291Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.272306Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.271564Z"
     },
     "papermill": {
-     "duration": 0.010881,
-     "end_time": "2026-04-25T15:42:26.998007",
+     "duration": 0.020015,
+     "end_time": "2026-04-28T13:16:53.272306+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:26.987126",
+     "start_time": "2026-04-28T13:16:53.252291+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2426,10 +2539,10 @@
    "id": "ed14da1e",
    "metadata": {
     "papermill": {
-     "duration": 0.005806,
-     "end_time": "2026-04-25T15:42:27.009612",
+     "duration": 0.003001,
+     "end_time": "2026-04-28T13:16:53.279325+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:27.003806",
+     "start_time": "2026-04-28T13:16:53.276324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2460,16 +2573,16 @@
    "id": "29ee3cf6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:42:27.022020Z",
-     "iopub.status.busy": "2026-04-25T15:42:27.021607Z",
-     "iopub.status.idle": "2026-04-25T15:42:27.026662Z",
-     "shell.execute_reply": "2026-04-25T15:42:27.025890Z"
+     "iopub.execute_input": "2026-04-28T13:16:53.287324Z",
+     "iopub.status.busy": "2026-04-28T13:16:53.287324Z",
+     "iopub.status.idle": "2026-04-28T13:16:53.302598Z",
+     "shell.execute_reply": "2026-04-28T13:16:53.302598Z"
     },
     "papermill": {
-     "duration": 0.012524,
-     "end_time": "2026-04-25T15:42:27.027792",
+     "duration": 0.020276,
+     "end_time": "2026-04-28T13:16:53.303600+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:27.015268",
+     "start_time": "2026-04-28T13:16:53.283324+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2521,10 +2634,10 @@
    "id": "dd2989fc",
    "metadata": {
     "papermill": {
-     "duration": 0.005786,
-     "end_time": "2026-04-25T15:42:27.039476",
+     "duration": 0.003999,
+     "end_time": "2026-04-28T13:16:53.311599+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:42:27.033690",
+     "start_time": "2026-04-28T13:16:53.307600+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2568,18 +2681,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.925274,
-   "end_time": "2026-04-25T15:42:27.393308",
+   "duration": 3.201666,
+   "end_time": "2026-04-28T13:16:53.552918+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-9-Distributed.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part2-CSP\\CSP-9-Distributed_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T15:42:23.468034",
+   "start_time": "2026-04-28T13:16:50.351252+00:00",
    "version": "2.6.0"
   }
  },

--- a/scripts/fix_csp9_abt.py
+++ b/scripts/fix_csp9_abt.py
@@ -1,0 +1,655 @@
+"""
+Apply Laqwad's algorithmic fixes (PR #429) to CSP-9-Distributed.ipynb,
+without the formatting noise.
+
+Cells modified:
+  5  ABTAgent class       (full rewrite : process_ok_message bootstrap,
+                           _backtrack with retry, _nogood_applicable,
+                           process_nogood_message addlink + replay,
+                           priority_sort_key hook for AWC)
+  7  ABTSystem class      (run() runs to quiescence then verifies global
+                           constraints, addlink replies with current value,
+                           _verify_global_constraints, _on_awc_reorder hook)
+  16 AWCAgent class       (uses awc_rank + priority_sort_key + _on_awc_reorder)
+  25 benchmark_discsp     (factored build_agents helper, AWC actually run)
+  11 markdown interp      (rewritten : algorithm now correct)
+  14 markdown interp      (rewritten : algorithm now correct)
+  26 markdown interp      (rewritten : algorithm now correct)
+
+Outputs are NOT cleared here ; Papermill will refresh them on re-execution.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+NB_PATH = Path("MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb")
+
+
+def to_list(src: str) -> list:
+    """Convert a multi-line string to list[str] preserving newlines (notebook source format)."""
+    lines = src.splitlines(keepends=True)
+    return lines
+
+
+CELL_ABT_AGENT = '''class ABTAgent:
+    """
+    Agent pour l'algorithme Asynchronous Backtracking.
+
+    Base sur Yokoo et al. (1992).
+    """
+
+    def __init__(self, agent_id: int, domain: List[Any],
+                 constraint_func, neighbors: List[int]):
+        self.id = agent_id
+        self.domain = domain
+        self.constraint_func = constraint_func  # Fonction de contrainte locale
+        self.neighbors = neighbors
+
+        # Etat de l'agent
+        self.value = None
+        self.agent_view: Dict[int, Any] = {}  # Vue des agents de haute priorite
+        self.nogoods: Set[Nogood] = set()     # Nogoods appris
+        self.higher_priority: List[int] = []  # Agents de haute priorite
+        self.lower_priority: List[int] = []   # Agents de basse priorite
+
+        # File de messages locale (non utilisee par ABTSystem)
+        self.message_queue: List[Message] = []
+
+        # Statistiques (nogoods_generated : nogoods emis dans _backtrack, pas recus)
+        self.messages_sent = 0
+        self.nogoods_generated = 0
+        self._system = None  # Renseigne par ABTSystem pour AWC / reordonnancement
+
+    def priority_sort_key(self) -> Tuple[float, int]:
+        """Cle de tri pour l'ordre entre agents (ABT pur : identique a l'id)."""
+        return (float(self.id), self.id)
+
+    def set_priority_order(self, higher: List[int], lower: List[int]):
+        """Definit l'ordre de priorite des agents."""
+        self.higher_priority = higher
+        self.lower_priority = lower
+
+    def check_consistency(self, value: Any) -> bool:
+        """
+        Coherence locale : contraintes avec chaque agent deja present dans agent_view
+        (en pratique : agents de priorite superieure ayant envoye un ok?).
+        Quand la file de messages est vide, la vue contient tous les voisins prioritaires :
+        la coherence locale coincide alors avec les aretes du graphe pour cet agent.
+        """
+        for var_id, val in self.agent_view.items():
+            if not self.constraint_func(self.id, value, var_id, val):
+                return False
+
+        # Verifier avec les nogoods appris
+        for nogood in self.nogoods:
+            if self._nogood_applicable(nogood, value):
+                return False
+
+        return True
+
+    def _nogood_applicable(self, nogood: Nogood, value: Any) -> bool:
+        """Le nogood contient self avec une certaine valeur, et toutes les autres
+        variables de priorite superieure doivent coincider avec agent_view."""
+        if self.id not in nogood.assignments:
+            return False
+        if nogood.assignments[self.id] != value:
+            return False
+        for v, v_val in nogood.assignments.items():
+            if v == self.id:
+                continue
+            if self.agent_view.get(v) != v_val:
+                return False
+        return True
+
+    def choose_value(self) -> Optional[Any]:
+        """Choisit une valeur coherente avec l'agent_view."""
+        for val in self.domain:
+            if self.check_consistency(val):
+                return val
+        return None
+
+    def process_ok_message(self, msg: Message) -> List[Message]:
+        """Traite un message 'ok?' (assignation d'un agent de haute priorite).
+
+        Si l'agent n'a pas encore choisi de valeur, il en choisit une
+        immediatement et la propage. Sans ce cas, un agent recevant son premier
+        ok? avant son init resterait silencieux et l'algorithme atteindrait
+        une fausse quiescence.
+        """
+        var_id, value = msg.content
+        self.agent_view[var_id] = value
+
+        if self.value is None:
+            self.value = self.choose_value()
+            if self.value is not None:
+                return self._send_ok_messages()
+            return self._backtrack()
+
+        if not self.check_consistency(self.value):
+            self.value = self.choose_value()
+            if self.value is not None:
+                return self._send_ok_messages()
+            return self._backtrack()
+        return []
+
+    def process_nogood_message(self, msg: Message) -> List[Message]:
+        """Traite un message 'nogood' (contrainte apprise).
+
+        Si le nogood mentionne un agent inconnu, on l'ajoute a higher_priority
+        et on demande un addlink. Si la valeur courante reste valide, on
+        renvoie un ok? a l'expediteur (qui a probablement retire self de sa
+        vue en backtrackant et a besoin de la valeur a jour).
+        """
+        nogood = msg.content
+        self.nogoods.add(nogood)
+
+        # Liens manquants : tout agent du nogood pas encore dans la vue doit envoyer addlink
+        new_links = []
+        for var_id in nogood.assignments:
+            if var_id != self.id and var_id not in self.agent_view:
+                if var_id not in self.higher_priority:
+                    self.higher_priority.append(var_id)
+                new_links.append(var_id)
+
+        messages: List[Message] = []
+
+        for var_id in new_links:
+            messages.append(Message(
+                sender=self.id,
+                receiver=var_id,
+                msg_type='addlink',
+                content=self.id
+            ))
+            self.messages_sent += 1
+
+        # Verifier la valeur courante
+        value_changed = False
+        if self.value is not None and not self.check_consistency(self.value):
+            old_value = self.value
+            self.value = self.choose_value()
+            value_changed = (self.value != old_value)
+            if self.value is not None:
+                messages.extend(self._send_ok_messages())
+            else:
+                messages.extend(self._backtrack())
+
+        # Si la valeur n'a pas change, renvoyer un ok? a l'expediteur :
+        # il a probablement retire self de son agent_view en backtrackant et doit
+        # recuperer la valeur courante (sinon il peut converger sur un etat global incoherent).
+        if not value_changed and self.value is not None and msg.sender != self.id:
+            messages.append(Message(
+                sender=self.id,
+                receiver=msg.sender,
+                msg_type='ok?',
+                content=(self.id, self.value),
+            ))
+            self.messages_sent += 1
+
+        return messages
+
+    def _send_ok_messages(self) -> List[Message]:
+        """Envoie la valeur courante aux agents de basse priorite."""
+        messages = []
+        for neighbor in self.lower_priority:
+            messages.append(Message(
+                sender=self.id,
+                receiver=neighbor,
+                msg_type='ok?',
+                content=(self.id, self.value)
+            ))
+            self.messages_sent += 1
+        return messages
+
+    def _backtrack(self) -> List[Message]:
+        """ABT standard : construit un nogood compose des seuls agents de priorite
+        superieure (la cible peut les voir), l'envoie au plus prioritaire d'entre eux,
+        puis retire la cible de sa vue et re-essaie une affectation locale.
+        Si plus aucune valeur n'est compatible, on backtracke recursivement.
+        """
+        relevant = {v: self.agent_view[v] for v in self.higher_priority if v in self.agent_view}
+        if not relevant:
+            return [Message(
+                sender=self.id,
+                receiver=-1,
+                msg_type='stop',
+                content='no_solution'
+            )]
+
+        target = max(relevant.keys())
+        nogood = Nogood(relevant)
+        messages: List[Message] = [Message(
+            sender=self.id,
+            receiver=target,
+            msg_type='nogood',
+            content=nogood,
+        )]
+        self.messages_sent += 1
+        self.nogoods_generated += 1
+
+        self.agent_view.pop(target, None)
+        self.value = self.choose_value()
+        if self.value is not None:
+            messages.extend(self._send_ok_messages())
+        else:
+            messages.extend(self._backtrack())
+        return messages
+
+    def initialize(self) -> List[Message]:
+        """Initialise l'agent et envoie les premiers messages."""
+        self.value = self.choose_value()
+        if self.value is not None:
+            return self._send_ok_messages()
+        return self._backtrack()
+print("Classe ABTAgent definie.")
+'''
+
+
+CELL_ABT_SYSTEM = '''class ABTSystem:
+    """
+    Systeme de simulation pour l'algorithme ABT.
+    Simule la communication asynchrone entre agents via une file FIFO globale.
+    """
+
+    def __init__(self, agents: Dict[int, ABTAgent]):
+        self.agents = agents
+        self.message_queue: List[Message] = []
+        self.solution: Optional[Dict[int, Any]] = None
+        self.no_solution = False
+        self.total_messages = 0
+        self.total_nogoods = 0
+        self.message_type_counts: Dict[str, int] = {}  # types traites dans la file
+
+        for ag in self.agents.values():
+            ag._system = self
+
+        self._setup_priority_order()
+
+    def _setup_priority_order(self):
+        """Configure higher/lower selon priority_sort_key() de chaque agent (ABT ou AWC)."""
+        agent_ids = sorted(self.agents.keys(), key=lambda i: self.agents[i].priority_sort_key())
+        for i, agent_id in enumerate(agent_ids):
+            higher = agent_ids[:i]
+            lower = agent_ids[i + 1:]
+            self.agents[agent_id].set_priority_order(higher, lower)
+
+    def _on_awc_reorder(self):
+        """Apres promotion AWC : recalcul des priorites + nouvelle vague de ok?."""
+        self._setup_priority_order()
+        for ag in self.agents.values():
+            if ag.value is not None:
+                self.message_queue.extend(ag._send_ok_messages())
+
+    def run(self, max_iterations: int = 10000) -> Optional[Dict[int, Any]]:
+        """
+        Execute ABT jusqu'a quiescence (file vide), puis valide la solution.
+        On ne declare le succes qu'apres vidage de la file : sinon des ok? peuvent
+        encore modifier les vues et donner une fausse coherence locale.
+        """
+        self.message_type_counts = {}
+        for agent in self.agents.values():
+            messages = agent.initialize()
+            self.message_queue.extend(messages)
+
+        iteration = 0
+        while iteration < max_iterations:
+            if not self.message_queue:
+                if self.no_solution:
+                    return None
+                if self._check_solution() and self._verify_global_constraints():
+                    self.solution = {a.id: a.value for a in self.agents.values()}
+                    return self.solution
+                break
+
+            msg = self.message_queue.pop(0)
+            self.total_messages += 1
+            self.message_type_counts[msg.msg_type] = self.message_type_counts.get(msg.msg_type, 0) + 1
+
+            if msg.msg_type == 'stop':
+                self.no_solution = True
+                return None
+
+            receiver = self.agents.get(msg.receiver)
+            if receiver:
+                if msg.msg_type == 'ok?':
+                    new_messages = receiver.process_ok_message(msg)
+                elif msg.msg_type == 'nogood':
+                    new_messages = receiver.process_nogood_message(msg)
+                    self.total_nogoods += 1
+                elif msg.msg_type == 'addlink':
+                    # L'agent de haute priorite renvoie son assignement courant au demandeur
+                    requester = msg.content
+                    new_messages = []
+                    if receiver.value is not None:
+                        new_messages.append(Message(
+                            sender=receiver.id,
+                            receiver=requester,
+                            msg_type='ok?',
+                            content=(receiver.id, receiver.value)
+                        ))
+                        receiver.messages_sent += 1
+                else:
+                    new_messages = []
+
+                self.message_queue.extend(new_messages)
+
+            iteration += 1
+
+        return None
+
+    def _check_solution(self) -> bool:
+        """Tous les agents ont une valeur et sont localement coherents avec leur vue."""
+        for agent in self.agents.values():
+            if agent.value is None:
+                return False
+            if not agent.check_consistency(agent.value):
+                return False
+        return True
+
+    def _verify_global_constraints(self) -> bool:
+        """Verifie chaque arete du graphe (via les listes de voisins des agents).
+        Une coherence locale chez chaque agent ne suffit pas : deux agents non
+        relies par priorite mais relies par contrainte pourraient choisir des
+        valeurs incompatibles. Cette passe finale rejette ces faux succes.
+        """
+        assignment = {a.id: a.value for a in self.agents.values()}
+        if any(v is None for v in assignment.values()):
+            return False
+        seen_edges: Set[Tuple[int, int]] = set()
+        for aid, agent in self.agents.items():
+            for nb in agent.neighbors:
+                edge = tuple(sorted((aid, nb)))
+                if edge in seen_edges:
+                    continue
+                seen_edges.add(edge)
+                if not agent.constraint_func(aid, assignment[aid], nb, assignment[nb]):
+                    return False
+        return True
+
+    def get_statistics(self) -> Dict:
+        """Retourne les statistiques d'execution."""
+        return {
+            'total_messages': self.total_messages,
+            'total_nogoods': self.total_nogoods,
+            'solution_found': self.solution is not None,
+            'solution': self.solution
+        }
+print("Classe ABTSystem definie.")
+'''
+
+
+CELL_AWC_AGENT = '''class AWCAgent(ABTAgent):
+    """
+    Couche pedagogique AWC au-dessus d'ABT : rang dynamique awc_rank utilise par
+    ABTSystem.priority_sort_key pour reorder higher/lower a la volee. Ce n'est pas
+    AWC complet (Yokoo 1995) mais le reordonnancement impacte reellement la simulation.
+    """
+
+    def __init__(self, agent_id: int, domain: List[Any],
+                 constraint_func, neighbors: List[int]):
+        super().__init__(agent_id, domain, constraint_func, neighbors)
+        self.awc_rank = float(agent_id)
+        self.nogoods_received = 0  # nogoods recus (voir process_nogood_message)
+
+    def priority_sort_key(self) -> Tuple[float, int]:
+        return (self.awc_rank, self.id)
+
+    def process_nogood_message(self, msg: Message) -> List[Message]:
+        """Apres traitement ABT : compte les nogoods recus, promotion si blocage repete."""
+        result = super().process_nogood_message(msg)
+        self.nogoods_received += 1
+        if self.nogoods_received > 3:
+            self._increase_priority()
+            self.nogoods_received = 0
+        return result
+
+    def _increase_priority(self):
+        """Monter dans la hierarchie : diminuer awc_rank, puis synchroniser via le systeme."""
+        self.awc_rank -= 1.0
+        sys = getattr(self, '_system', None)
+        if sys is not None:
+            sys._on_awc_reorder()
+
+    def _backtrack(self) -> List[Message]:
+        if self.higher_priority:
+            self._increase_priority()
+        return super()._backtrack()
+
+print("Classe AWCAgent definie.")
+'''
+
+
+CELL_BENCHMARK = '''def benchmark_discsp(n_agents: int, domain_size: int,
+                     constraint_density: float, n_runs: int = 5):
+    """
+    Compare les performances d'ABT et d'AWC sur des instances aleatoires.
+
+    Parameters
+    ----------
+    n_agents : nombre d'agents
+    domain_size : taille du domaine
+    constraint_density : probabilite de contrainte entre deux agents
+    n_runs : nombre d'executions
+    """
+    results = {'ABT': [], 'AWC': []}
+
+    for run in range(n_runs):
+        domain = list(range(domain_size))
+        edges = []
+        constraint_funcs = {}
+
+        for i in range(n_agents):
+            for j in range(i + 1, n_agents):
+                if random.random() < constraint_density:
+                    edges.append((i, j))
+                    forbidden = (random.randint(0, domain_size - 1),
+                                 random.randint(0, domain_size - 1))
+                    constraint_funcs[(i, j)] = forbidden
+
+        def build_agents(agent_cls):
+            agents = {}
+            for i in range(n_agents):
+                neighbors = [n for e in edges for n in e if i in e and n != i]
+                relevant_constraints = {(min(k[0], k[1]), max(k[0], k[1])): v
+                                        for k, v in constraint_funcs.items() if i in k}
+
+                def constraint_func(v1, val1, v2, val2, rc=relevant_constraints):
+                    edge = (min(v1, v2), max(v1, v2))
+                    if edge in rc:
+                        forb = rc[edge]
+                        if v1 < v2 and (val1, val2) == forb:
+                            return False
+                        if v1 > v2 and (val2, val1) == forb:
+                            return False
+                    return True
+
+                agents[i] = agent_cls(i, domain.copy(), constraint_func, neighbors)
+            return agents
+
+        max_it = 10000
+
+        system_abt = ABTSystem(build_agents(ABTAgent))
+        start = datetime.now()
+        solution_abt = system_abt.run(max_iterations=max_it)
+        time_abt = (datetime.now() - start).total_seconds()
+        results['ABT'].append({
+            'time': time_abt,
+            'messages': system_abt.total_messages,
+            'nogoods': system_abt.total_nogoods,
+            'solved': solution_abt is not None
+        })
+
+        system_awc = ABTSystem(build_agents(AWCAgent))
+        start = datetime.now()
+        solution_awc = system_awc.run(max_iterations=max_it)
+        time_awc = (datetime.now() - start).total_seconds()
+        results['AWC'].append({
+            'time': time_awc,
+            'messages': system_awc.total_messages,
+            'nogoods': system_awc.total_nogoods,
+            'solved': solution_awc is not None
+        })
+
+    return results
+
+
+def _print_bench_summary(name: str, rows: List[dict]):
+    print(f"\\nResultats {name}:")
+    for i, r in enumerate(rows):
+        status = "Resolu" if r['solved'] else "Non resolu"
+        print(f"  Run {i+1}: {status}, {r['messages']} messages, "
+              f"{r['nogoods']} nogoods, {r['time']:.3f}s")
+    avg_m = sum(r['messages'] for r in rows) / len(rows)
+    avg_n = sum(r['nogoods'] for r in rows) / len(rows)
+    sr = sum(1 for r in rows if r['solved']) / len(rows)
+    print(f"\\nMoyennes {name}:")
+    print(f"  Messages: {avg_m:.1f}")
+    print(f"  Nogoods: {avg_n:.1f}")
+    print(f"  Taux de succes: {sr*100:.1f}%")
+
+
+print("=== Benchmark DisCSP ===")
+random.seed(42)
+results = benchmark_discsp(n_agents=5, domain_size=3,
+                           constraint_density=0.5, n_runs=3)
+_print_bench_summary('ABT', results['ABT'])
+_print_bench_summary('AWC', results['AWC'])
+'''
+
+
+CELL_INTERP_COLORATION = '''### Interpretation : Analyse de la solution ABT
+
+**Resultat attendu** : la solution retournee par `system.run()` doit satisfaire **toutes** les aretes
+du cycle 0-1, 1-2, 2-3, 3-0 ; chaque arete relie deux couleurs differentes.
+
+**Verification automatique** : la cellule precedente verifie chaque arete et imprime `OK` ou `ECHEC`.
+Si l'execution affiche autre chose que 4 `OK`, c'est qu'un bug est present (a remonter via une issue).
+
+**Comment l'algorithme y arrive** :
+
+1. Chaque agent commence par choisir la premiere valeur compatible avec sa vue. Comme la vue est
+   vide a l'init, l'agent 0 choisit `R`, puis 1 choisit `G` (different de `R`), puis 2 choisit
+   la premiere valeur differente de `R` qu'il connaisse (`G`), puis 3 examine sa vue.
+2. Si un agent decouvre que sa valeur est en conflit (apres avoir recu un `ok?` qui change sa vue),
+   il essaie une autre valeur de son domaine. Si plus aucune valeur n'est compatible, il **backtracke** :
+   il envoie un `nogood` a l'agent de plus haute priorite present dans sa vue, retire celui-ci
+   de la vue et re-choisit.
+3. Le `nogood` est appris par la cible : a sa prochaine evaluation, elle saura que cette combinaison
+   de valeurs est interdite.
+4. **Apprentissage `addlink`** : si un nogood mentionne un agent inconnu de la cible, celle-ci
+   demande un `addlink` pour ouvrir un canal et recevoir sa valeur.
+5. Le systeme s'arrete quand la file est vide (quiescence). A ce moment, `_verify_global_constraints`
+   parcourt **chaque arete** du graphe pour valider la solution avant de la retourner.
+
+**Note** : `_check_solution` (coherence locale agent par agent) ne suffirait pas a elle seule, car
+deux agents non lies par priorite mais lies par contrainte pourraient choisir des valeurs
+incompatibles si la file est encore active. La verification globale finale rejette ces faux succes.
+'''
+
+
+CELL_INTERP_VISU = '''### Interpretation de la visualisation
+
+**Graphe de coloration** (gauche) :
+- Les noeuds representent les agents 0, 1, 2, 3
+- Les couleurs indiquent la valeur choisie par chaque agent **en fin de simulation** (apres quiescence)
+- Les aretes montrent les contraintes ; chaque arete doit relier deux couleurs differentes
+
+**Statistiques par agent** (droite) :
+- **Messages envoyes** : combien d'`ok?` / `nogood` / `addlink` chaque agent a emis
+- **Nogoods generes** : combien de fois cet agent a backtracke (envoye un nogood)
+
+**Lecture du flux ABT** :
+
+1. **Phase d'initialisation** : tous les agents diffusent leur valeur initiale aux agents de
+   priorite inferieure (`ok?`). L'agent 0 (priorite la plus haute) emet vers 1, 2, 3 ; l'agent 1
+   emet vers 2, 3 ; etc. Le compteur `messages_sent` reflete cette propagation.
+2. **Phase de propagation** : chaque agent ajuste sa valeur en fonction des `ok?` recus. Si un
+   conflit apparait (la valeur courante n'est plus compatible avec la vue), il choisit une autre
+   valeur dans son domaine.
+3. **Phase de backtracking** : quand un agent epuise son domaine, il emet un `nogood` vers le plus
+   prioritaire des agents de sa vue, qui devra alors changer de valeur. Le compteur
+   `nogoods_generated` recense ces emissions.
+4. **Quiescence** : la file de messages se vide ; le systeme verifie la coherence globale et
+   retourne la solution si toutes les aretes sont satisfaites.
+
+> **A retenir** : les nogoods sont l'outil d'**apprentissage distribue** d'ABT. Plus le graphe est
+> dense ou contraint, plus on en accumule. Sur un cycle 4-noeuds avec 3 couleurs, quelques nogoods
+> suffisent ; sur des instances plus larges, leur nombre peut exploser et motive AWC ou des
+> heuristiques d'oubli.
+'''
+
+
+CELL_INTERP_BENCH = '''### Interpretation des resultats du benchmark
+
+**Lecture** : le benchmark genere `n_runs` instances aleatoires de coloration de graphe avec
+`n_agents` agents, un domaine de taille `domain_size`, et une densite de contraintes
+`constraint_density`. Pour chaque instance, ABT et AWC sont executes jusqu'a quiescence.
+
+**Ordres de grandeur attendus** (n_agents=5, domain_size=3, density=0.5) :
+
+| Metrique | ABT | AWC | Lecture |
+|----------|-----|-----|---------|
+| Messages | 10-50 | similaire ou un peu moins | trafic d'`ok?` + `nogood` + `addlink` |
+| Nogoods | 0-10 | 0-10 | depend du nombre de conflits rencontres |
+| Taux de succes | 60-100% | 60-100% | depend de la satisfiabilite des instances |
+| Temps | < 50 ms | < 50 ms | simulation FIFO en RAM |
+
+**Comparaison ABT vs AWC** :
+
+- Sur des instances peu contraintes, les deux convergent en quelques messages : les chiffres se
+  ressemblent.
+- Sur des instances denses, AWC peut etre plus rapide en messages car il **promeut dynamiquement**
+  les agents qui accumulent les nogoods (leur priorite augmente, ce qui change l'ordre de
+  propagation et evite des conflits ulterieurs).
+- AWC paye ce gain par un cout : a chaque promotion, le systeme reordonnance toutes les priorites
+  et rediffuse les `ok?` (`_on_awc_reorder`). Sur les petites instances, ce cout peut effacer le
+  benefice.
+
+**Si une instance n'est pas resolue** (`Resolu` = False) :
+
+- Soit l'instance est **insatisfiable** (les contraintes aleatoires bloquent toute affectation)
+- Soit `max_iterations` (ici 10 000) a ete atteint avant la quiescence
+
+> **A retenir** : un benchmark DisCSP n'est pas un classement absolu, c'est une mesure de
+> **comportement** sur une distribution d'instances. Pour comparer rigoureusement ABT et AWC, il
+> faut faire varier `n_agents`, `density`, et tracer messages/nogoods en fonction de ces parametres.
+'''
+
+
+CELL_PATCHES = {
+    "9393a18d": ("code", CELL_ABT_AGENT),
+    "4055fe66": ("code", CELL_ABT_SYSTEM),
+    "5fee8e73": ("code", CELL_AWC_AGENT),
+    "69eff4b7": ("code", CELL_BENCHMARK),
+    "27c153c7": ("markdown", CELL_INTERP_COLORATION),
+    "98c58c2e": ("markdown", CELL_INTERP_VISU),
+    "7d6810ce": ("markdown", CELL_INTERP_BENCH),
+}
+
+
+def main():
+    nb = json.loads(NB_PATH.read_text(encoding='utf-8'))
+    by_id = {c.get("id"): (i, c) for i, c in enumerate(nb["cells"])}
+    missing = [k for k in CELL_PATCHES if k not in by_id]
+    if missing:
+        print(f"ERROR: cells not found: {missing}", file=sys.stderr)
+        sys.exit(1)
+
+    for cell_id, (cell_type, src) in CELL_PATCHES.items():
+        idx, cell = by_id[cell_id]
+        if cell["cell_type"] != cell_type:
+            print(f"ERROR: cell {cell_id} expected type {cell_type}, got {cell['cell_type']}", file=sys.stderr)
+            sys.exit(1)
+        cell["source"] = to_list(src)
+        # Reset outputs/execution_count for code cells (Papermill will refresh)
+        if cell_type == "code":
+            cell["outputs"] = []
+            cell["execution_count"] = None
+        print(f"Patched cell {idx} ({cell_id}, {cell_type}, {len(cell['source'])} lines)")
+
+    NB_PATH.write_text(json.dumps(nb, indent=1, ensure_ascii=False) + "\n", encoding='utf-8')
+    print(f"\nNotebook saved: {NB_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Contexte

Remontee Discord d'un etudiant du groupe 15 EPITA (28/04) signalant que CSP-9-Distributed a de nombreux problemes, et que sa PR de correction (#429) a ete fermee sans revue technique du fond. Apres audit historique : **l'etudiant a raison**.

## Diagnostic

Le notebook contenait 3 cellules markdown qui **reconnaissaient explicitement les bugs** sans corriger le code :

> "Probleme visible : Les noeuds 2 et 3 ont la meme couleur (Rouge) mais sont connectes par une arete"
> "Termination prematuree : L'algorithme a declare la solution trouvee trop tot"
> "Cette simplification volontaire permet de comprendre le flux des messages"

Les bugs reels :

1. **process_ok_message** : pas de bootstrap de la valeur quand l'agent n'en a pas encore -> agents silencieux apres reception du premier ok?
2. **_backtrack** : envoie un nogood mais ne reduit pas la vue ni ne re-essaie localement -> pas de remise en cause effective
3. **ABTSystem.run** : teste la solution apres chaque message au lieu d'attendre la quiescence -> succes declare alors que la file contient encore des ok?
4. **_check_solution** : seule la coherence locale agent-vue est verifiee, pas les contraintes globales -> deux agents non lies par priorite mais voisins par contrainte pouvaient choisir des valeurs incompatibles

Resultat : sur la coloration 4-noeuds 3-couleurs, solution `{0: 'R', 1: 'G', 2: 'R', 3: 'R'}` retournee comme valide alors que `2-3 (R/R)` et `3-0 (R/R)` violaient les aretes.

## Origine du fix

PR #429 (Laqwad / groupe 15) avait identifie et corrige ces bugs avec :
- ajout de `_verify_global_constraints` dans ABTSystem
- correction de `process_ok_message` (bootstrap)
- correction de `_backtrack` (vraie reduction de vue + retry)
- run-to-quiescence
- gestion correcte des `addlink`
- AWC fonctionnel via `priority_sort_key` + `_on_awc_reorder`

PR #429 a ete fermee le 22/04 a 14:35 (1 minute apres le merge de #457) avec pour motif **uniquement** :
- Reformatage massif (3827 lignes d'indentation 1->2 espaces)
- Completion partielle (Ex1 fait, Ex2/3/4 stubs)

Le bugfix substantiel n'a pas ete examine. Cette PR le restaure chirurgicalement, sans le bruit de reformatage.

## Changes

| Cellule | Type | Action |
|---------|------|--------|
| 5 | code | ABTAgent : process_ok_message bootstrap, _backtrack avec retry, _nogood_applicable, addlink + replay, priority_sort_key hook |
| 7 | code | ABTSystem : run jusqu'a quiescence + verification globale, addlink repond avec valeur courante, _verify_global_constraints, _on_awc_reorder |
| 11 | markdown | Reecrit : algorithme correct, plus de reconnaissance de bug |
| 14 | markdown | Reecrit : interpretation visualisation propre |
| 16 | code | AWCAgent : awc_rank dynamique + priority_sort_key + reorder via systeme |
| 25 | code | benchmark factore (build_agents helper), AWC effectivement execute |
| 26 | markdown | Reecrit : ordres de grandeur attendus realistes |

## Validation

Papermill 46/46 cells OK (Python 3.10).

| Test | Avant | Apres |
|------|-------|-------|
| Coloration 4-noeuds, 3-couleurs | `{0:R, 1:G, 2:R, 3:R}` (2 violations) | `{0:R, 1:G, 2:R, 3:B}` (0 violation) |
| Messages | 1 | 10 |
| 6-reines distribuees | non testee | 442 messages, 110 nogoods, solution valide |
| Etude densite ABT vs AWC density 0.7 | non distinguait | ABT 575 msgs / 137 nogoods, AWC 124 msgs / 5.8 nogoods |

## Test plan

- [x] Papermill 46/46 cells OK
- [x] Cellule 10 retourne solution valide (4 aretes OK)
- [x] Cellule 28 (N-reines 6) retourne solution valide via verify_nqueens
- [x] Cellule 32 (etude densite) montre des differences ABT/AWC realistes
- [x] Aucune erreur dans aucune cellule
- [ ] Re-review : verifier que les exercices stubs Ex1b/2b/3b/4b restent compatibles

## Credit

Fix base sur PR #429 de **Laqwad / groupe 15 EPITA**. Co-Authored-By dans le commit.

Closes references : remontee Discord 28/04, partial fix de #463 (CSP-9 restait casse algorithmiquement meme apres recycling #475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)