### PR TITLE
feat(qc-notebooks): add QC CLOUD execution badge to 23 notebooks (#562 B1)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-01 : Configuration et Premier Backtest QuantConnect\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "**Durée estimée** : 45 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-04 - Research Workflow with QuantBook\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **De la recherche exploratoire à l'algorithme de production**\n",
     "> Durée: 75 minutes | Niveau: Intermédiaire | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-06 : Options Trading dans QuantConnect\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "**Duree estimee** : 75 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-07 : Futures et Forex Trading dans QuantConnect\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "**Duree estimee** : 75 minutes\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-08 - Multi-Asset Portfolio Strategies\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Diversification, correlation et allocation tactique**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-10 - Risk Management et Portfolio Management\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Position sizing, stop-loss, drawdown control et risk models QuantConnect**\n",
     "> Duree: 90 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-11 - Indicateurs Techniques dans QuantConnect\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Analyse technique et signaux de trading**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-12 - Backtesting et Analyse de Performance\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Evaluer et analyser les performances de vos strategies de trading**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-13 - Alpha Models et Algorithm Framework\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Architecture modulaire pour strategies quantitatives**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-14 - Portfolio Construction et Execution Models\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Transformer les Insights en positions optimales et les executer efficacement**\n",
     "> Duree: 90 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-15 - Parameter Optimization et Walk-Forward Analysis\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Optimiser les parametres de trading tout en evitant l'overfitting**\n",
     "> Duree: 75 minutes | Niveau: Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-16 - Alternative Data dans QuantConnect\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Donnees non-traditionnelles pour generer de l'alpha**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-17 - Sentiment Analysis pour le Trading\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Exploiter le sentiment de marche pour generer des signaux alpha**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-19 - Machine Learning Classification pour Direction Prediction\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Predire la direction du marche avec Random Forest et XGBoost**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-20 - Machine Learning Regression pour Price Prediction\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Predire les rendements avec des modeles de regression**\n",
     "> Duree: 75 minutes | Niveau: Intermediaire-Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-21 - Portfolio Optimization avec Machine Learning\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **De Markowitz aux methodes ML modernes pour l'allocation d'actifs**\n",
     "> Duree: 90 minutes | Niveau: Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-22 - Modern Time Series Deep Learning (SOTA 2024-2026)\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Architectures PyTorch SOTA pour la prediction de series temporelles financieres**\n",
     "> Duree: 100 minutes | Niveau: Avance | Python + PyTorch + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-23 - State Space Models (Mamba) pour Trading\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Au-delà des Transformers : Complexité O(n) pour séries temporelles longues**\n",
     "> Durée : 100 minutes | Niveau : Avancé | Python + PyTorch\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-24 - Modèles Génératifs pour Anomaly Detection et Régimes\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **VAE-Transformer + Hidden Markov Models pour la détection d'anomalies et de régimes**\n",
     "> Durée : 90 minutes | Niveau : Avancé | Python + PyTorch\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-25 - Reinforcement Learning pour le Trading\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Des agents RL adaptatifs pour la prise de decision en temps reel**\n",
     "> Duree: 90 minutes | Niveau: Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-26 - LLM Trading Signals\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Large Language Models pour l'analyse de marche et la generation de signaux**\n",
     "> Duree: 90 minutes | Niveau: Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-27 - Production Deployment\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "> **Du backtest au trading live : deploiement, monitoring et operations**\n",
     "> Duree: 75 minutes | Niveau: Avance | Python + QuantConnect\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -5,6 +5,7 @@
    "metadata": {},
    "source": [
     "# QC-Py-28 - Market Regime Detection\n",
+    "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",
     "**Navigation** : [Index](../README.md) | [<< Precedent](QC-Py-27-Production-Deployment.ipynb) | [Suivant >>](../README.md)\n",
     "\n",


### PR DESCRIPTION
## Summary
- Add `[QC CLOUD]` execution badge to 23/28 QC-Py-* notebooks that use QuantBook/AlgorithmImports
- Badge clearly indicates these notebooks require QuantConnect Cloud and cannot execute locally
- 4 notebooks already marked `[REFERENCE QC]` — no change needed
- 1 notebook (QC-Py-18) already has outputs and runs locally — no change needed

## Analysis findings (corrects issue #562 assumptions)
- **B1 original**: "re-execute with yfinance via papermill" — **not applicable**: 0/28 notebooks use yfinance
- **B2**: "split 16 mixed QuantBook/yfinance" — **not applicable**: no notebooks are mixed, all are pure QuantBook
- **B3**: "fix BTC-ML-Researcher/research.ipynb" — **not applicable**: file does not exist in the repo

## Classification of 28 notebooks
| Type | Count | Notebooks |
|------|-------|-----------|
| QC Cloud | 23 | QC-Py-01, 04, 06-08, 10-17, 19-28 |
| Reference-only | 4 | QC-Py-02, 03, 05, 09 |
| Local executable | 1 | QC-Py-18 (already has outputs) |

## Test plan
- [x] All 28 notebooks valid JSON (nbformat=4)
- [x] Badge correctly placed in header of all 23 QC-CLOUD notebooks
- [x] No code cell content modified
- [x] No output changes

Ref: #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)