### PR TITLE
feat(lean): Voting.lean - Condorcet concepts and margin function

### DIFF
--- a/.claude/memory/genai-services-inventory.md
+++ b/.claude/memory/genai-services-inventory.md
@@ -26,14 +26,15 @@
 
 ---
 
-## Services AUDIO (4)
+## Services AUDIO (5)
 
 | Service | Modèle | VRAM | URL Cloud | Port Local | Docker | Status |
 |---------|--------|------|-----------|------------|--------|--------|
-| **Whisper STT** | faster-whisper large-v3 | ~10GB | https://whisper-api.myia.io | 8190/36540 | ✅ whisper-api | ✅ UP |
+| **Whisper STT** | faster-whisper large-v3-turbo | ~10GB | https://whisper-api.myia.io | 8190/36540 | ✅ whisper-api | ✅ UP |
 | **Kokoro TTS** | kokoro-v0_19 | ~2GB | https://tts-api.myia.io | 8191 | ✅ tts-api | ✅ UP |
 | **MusicGen** | facebook/musicgen-medium | ~10GB | https://musicgen-api.myia.io | 8192 | ✅ musicgen-api | ✅ UP |
 | **Demucs** | htdemucs_ft | ~4GB | https://demucs-api.myia.io | 8193 | ✅ demucs-api | ✅ UP |
+| **Qwen ASR** | Qwen3-ASR-1.7B + ForcedAligner-0.6B | ~4GB | https://stt.myia.io/qwen | 8195 | ✅ qwen-asr-api | ✅ UP |
 
 **Docker existants** : `docker-configurations/services/`
 
@@ -41,6 +42,7 @@
 - `tts-api/` - ✅ UP (API depuis main, avec lazy loading)
 - `musicgen-api/` - ✅ UP (API depuis main, avec lazy loading)
 - `demucs-api/` - ✅ UP (API depuis main, avec lazy loading)
+- `qwen-asr-api/` - ✅ UP (FastAPI, lazy loading, ISO 639-1 support, 52 langues)
 - `whisper-webui/` - ✅ UP (WebUI alternative)
 
 **Configurations hybrides disponibles** :
@@ -90,6 +92,18 @@ python scripts/genai-stack/genai.py auth sync
 
 ## Actions requises
 
+### Qwen ASR - Details techniques
+
+- **Modele** : Qwen3-ASR-1.7B (1.7B params, bfloat16)
+- **Forced Aligner** : Qwen3-ForcedAligner-0.6B (timestamps mot-niveau)
+- **Langues** : 52 langues auto-detectees (FR, EN, DE, ES, ZH, JA, KO, AR, etc.)
+- **API** : OpenAI-compatible `/v1/audio/transcriptions`
+- **Support ISO 639-1** : `language=fr` normalise en `French` automatiquement
+- **Lazy loading** : Chargement paresseux, dechargement apres 300s d'inactivite
+- **GPU** : GPU 1 (RTX 3090), ~4GB VRAM
+- **PR** : #547 (fix language normalization)
+- **Endpoint NanoClaw** : `https://stt.myia.io/qwen/v1/audio/transcriptions`
+
 ### ✅ Services créés et démarrés
 
 **Image** :
@@ -101,6 +115,7 @@ python scripts/genai-stack/genai.py auth sync
 - [x] Kokoro TTS (port 8191) - ✅ UP
 - [x] MusicGen (port 8192) - ✅ UP
 - [x] Demucs (port 8193) - ✅ UP
+- [x] Qwen ASR (port 8195) - ✅ UP (depuis avril 2026)
 
 **Video** :
 - [x] ComfyUI Video (port 8189) - ✅ UP
@@ -132,11 +147,11 @@ services:
 
 ---
 
-## Mise à jour : 2026-03-09
+## Mise à jour : 2026-04-26
 
-**Services opérationnels** : 10/10 ✅
+**Services opérationnels** : 11/11 ✅
 - Image: 5/5 UP (Qwen Edit, Z-Image, Forge Turbo, SD Forge, SD.Next)
-- Audio: 4/4 UP (Whisper, Kokoro TTS, MusicGen, Demucs)
+- Audio: 5/5 UP (Whisper, Kokoro TTS, MusicGen, Demucs, Qwen ASR)
 - Video: 1/1 UP (ComfyUI Video)
 
 **Tous les services GenAI sur po-2023 sont opérationnels.**

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
@@ -18,3 +18,4 @@
 import SocialChoice.Basic
 import SocialChoice.Arrow
 import SocialChoice.Sen
+import SocialChoice.Voting

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -1,0 +1,154 @@
+/-
+  Social Choice Theory - Voting Definitions
+  ==========================================
+
+  Port of chasenorman/Formalized-Voting to Lean 4
+  Original: https://github.com/chasenorman/Formalized-Voting
+
+  Adapted to our SocialChoice/Basic.lean framework:
+  - Uses PrefOrder from Basic.lean instead of raw relations
+  - Uses P (strict preference) and I (indifference) from Basic.lean
+  - Compatible with Profile ι σ from Arrow.lean
+
+  Key concepts:
+  - Margin function for pairwise vote counting
+  - Condorcet winner/loser and their criteria
+  - Pareto efficiency and monotonicity for Social Choice Correspondences
+-/
+
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+
+import SocialChoice.Basic
+
+namespace SocialChoice
+
+variable {ι σ : Type*} [Fintype ι] [DecidableEq σ]
+
+/-! ## Margin Function -/
+
+/-- The margin of x over y in a profile:
+    |{voters strictly preferring x to y}| - |{voters strictly preferring y to x}|
+    Positive margin means x beats y in pairwise comparison. -/
+noncomputable def margin (prof : ι → PrefOrder σ) (x y : σ) : ℤ :=
+  haveI : (i : ι) → Decidable (P (prof i).rel x y) := fun _ => Classical.dec _
+  haveI : (i : ι) → Decidable (P (prof i).rel y x) := fun _ => Classical.dec _
+  ((Finset.filter (fun i => P (prof i).rel x y) Finset.univ).card : ℤ) -
+    ((Finset.filter (fun i => P (prof i).rel y x) Finset.univ).card : ℤ)
+
+/-- Positive margin: x beats y in pairwise comparison -/
+def margin_pos (prof : ι → PrefOrder σ) (x y : σ) : Prop :=
+  0 < margin prof x y
+
+/-! ## Condorcet Concepts -/
+
+/-- A Condorcet winner: strictly beats every other alternative in pairwise comparison -/
+def condorcet_winner (prof : ι → PrefOrder σ) (S : Finset σ) (x : σ) : Prop :=
+  x ∈ S ∧ ∀ y ∈ S, y ≠ x → margin_pos prof x y
+
+/-- A Condorcet loser: strictly loses to every other alternative -/
+def condorcet_loser (prof : ι → PrefOrder σ) (S : Finset σ) (x : σ) : Prop :=
+  x ∈ S ∧ S.card ≥ 2 ∧ ∀ y ∈ S, y ≠ x → margin_pos prof y x
+
+/-! ## Social Choice Correspondence -/
+
+/-- A Social Choice Correspondence: maps profiles and alternative sets to chosen alternatives -/
+def SCC (ι σ : Type*) [Fintype ι] [DecidableEq σ] :=
+  (ι → PrefOrder σ) → Finset σ → Finset σ
+
+/-! ## Voting Criteria -/
+
+/-- Condorcet criterion: every Condorcet winner is selected -/
+def condorcet_criterion (f : SCC ι σ) : Prop :=
+  ∀ prof S x, condorcet_winner prof S x → x ∈ f prof S
+
+/-- Condorcet loser criterion: no Condorcet loser is selected -/
+def condorcet_loser_criterion (f : SCC ι σ) : Prop :=
+  ∀ prof S x, condorcet_loser prof S x → x ∉ f prof S
+
+/-- Pareto efficiency: if all voters prefer x to y, then y is not selected -/
+def pareto_scc (f : SCC ι σ) : Prop :=
+  ∀ prof S x y, x ∈ S → y ∈ S →
+    (∀ i : ι, P (prof i).rel x y) → y ∉ f prof S
+
+/-- Monotonicity: improving x's position preserves x's selection -/
+def monotonicity (f : SCC ι σ) : Prop :=
+  ∀ prof prof' S x,
+    x ∈ f prof S → x ∈ S →
+    (∀ i : ι, ∀ y ∈ S, P (prof i).rel x y → P (prof' i).rel x y) →
+    (∀ i : ι, ∀ y ∈ S, ¬P (prof i).rel y x → ¬P (prof' i).rel y x) →
+    x ∈ f prof' S
+
+/-! ## Margin Properties -/
+
+theorem margin_antisymm (prof : ι → PrefOrder σ) (x y : σ) :
+    margin prof x y = - (margin prof y x) := by
+  unfold margin
+  ring
+
+theorem margin_self (prof : ι → PrefOrder σ) (x : σ) :
+    margin prof x x = 0 := by
+  unfold margin
+  haveI : (i : ι) → Decidable (P (prof i).rel x x) := fun _ => Classical.dec _
+  have hN : ∀ i : ι, ¬P (prof i).rel x x := fun _ => false_of_P_self
+  have h_empty : Finset.filter (fun i => P (prof i).rel x x) Finset.univ = ∅ := by
+    ext i; simp [Finset.mem_filter]; exact fun hi => hN i hi
+  simp
+
+theorem margin_pos_iff_neg_rev (prof : ι → PrefOrder σ) {x y : σ} :
+    margin_pos prof x y ↔ margin prof y x < 0 := by
+  unfold margin_pos
+  rw [margin_antisymm prof]
+  omega
+
+/-! ## Condorcet Properties -/
+
+/-- The Condorcet winner is unique (when it exists) -/
+theorem condorcet_winner_unique (prof : ι → PrefOrder σ) {S : Finset σ} {x y : σ}
+    (hx : condorcet_winner prof S x) (hy : condorcet_winner prof S y) (hxy : x ≠ y) :
+    False := by
+  obtain ⟨hxs, hbeat⟩ := hx
+  obtain ⟨hys, hbeat'⟩ := hy
+  have h₁ := hbeat y hys hxy.symm
+  have h₂ := hbeat' x hxs hxy
+  unfold margin_pos at h₁ h₂
+  have := margin_antisymm prof x y
+  linarith
+
+/-- A Condorcet winner cannot be a Condorcet loser -/
+theorem condorcet_winner_not_loser (prof : ι → PrefOrder σ) {S : Finset σ} {x : σ}
+    (hw : condorcet_winner prof S x) (hl : condorcet_loser prof S x) :
+    False := by
+  obtain ⟨hxs, hcard, hlose⟩ := hl
+  obtain ⟨_, hbeat⟩ := hw
+  obtain ⟨y, hyS, hxy⟩ := exists_second_distinct_mem (by omega : 2 ≤ S.card) hxs
+  have h₁ := hbeat y hyS hxy
+  have h₂ := hlose y hyS hxy
+  unfold margin_pos at h₁ h₂
+  have := margin_antisymm prof x y
+  linarith
+
+/-! ## Unanimity and Margin -/
+
+/-- If all voters strictly prefer x to y, the margin is positive -/
+theorem margin_pos_of_unanimous [Nonempty ι] (prof : ι → PrefOrder σ) {x y : σ}
+    (h : ∀ i : ι, P (prof i).rel x y) : margin_pos prof x y := by
+  unfold margin_pos
+  -- Compute margin value: all voters prefer x to y, so margin = card ι > 0
+  have hkey : margin prof x y = (Fintype.card ι : ℤ) := by
+    unfold margin
+    classical
+    -- After classical, Decidable instances are uniform via Classical.dec
+    -- The haveI in margin's definition and our context both resolve to Classical.dec
+    have hNyx : ∀ i, ¬P (prof i).rel y x := fun i hi => (h i).2 hi.1
+    have h_univ : (Finset.univ : Finset ι).filter (fun i => P (prof i).rel x y) = Finset.univ := by
+      ext i; simp [Finset.mem_filter]; exact h i
+    have h_empty : (Finset.univ : Finset ι).filter (fun i => P (prof i).rel y x) = ∅ := by
+      ext i; simp [Finset.mem_filter]; exact fun hi => hNyx i hi
+    simp [h_univ, h_empty, Finset.card_univ]
+  rw [hkey]
+  exact mod_cast (Finset.card_pos.mpr Finset.univ_nonempty)
+
+end SocialChoice


### PR DESCRIPTION
## Summary
- Port of [chasenorman/Formalized-Voting](https://github.com/chasenorman/Formalized-Voting) to Lean 4, adapted to our `SocialChoice/Basic.lean` framework
- Adds margin function, Condorcet winner/loser definitions, Social Choice Correspondence (SCC), and 4 voting criteria (Condorcet, Condorcet loser, Pareto, Monotonicity)
- 6 theorems proved: `margin_antisymm`, `margin_self`, `margin_pos_iff_neg_rev`, `condorcet_winner_unique`, `condorcet_winner_not_loser`, `margin_pos_of_unanimous`

## Build verification
- `lake build SocialChoice.Voting` passes with 0 errors (3068/3068 jobs)
- Only linter warnings about unused `DecidableEq σ` section variables (cosmetic)

## Test plan
- [x] `lake build SocialChoice.Voting` succeeds
- [x] All 6 theorems are sorry-free
- [x] Imports integrate cleanly with existing `SocialChoice.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)