### PR TITLE
fix(lean): accurate README claims + attribution (PR-B)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -4,7 +4,7 @@ Cette serie de notebooks introduit la **Theorie des Jeux**, combinant **Python**
 
 ## Structure
 
-**17 notebooks principaux** + **9 side tracks** (b = Lean, c = Python approfondissement) = **26 notebooks**
+**17 notebooks principaux** + **10 side tracks** (b = Lean, c = Python approfondissement, d/e = Social Choice) = **27 notebooks**
 
 ### Partie 1 : Fondations et Jeux statiques (Notebooks 1-6)
 
@@ -45,6 +45,8 @@ Cette serie de notebooks introduit la **Theorie des Jeux**, combinant **Python**
 | 16 | [GameTheory-16-MechanismDesign](GameTheory-16-MechanismDesign.ipynb) | Python | Principe de revelation, VCG, matching | 65 min |
 | 16b | [GameTheory-16b-Lean-SocialChoice](GameTheory-16b-Lean-SocialChoice.ipynb) | Lean 4 | Arrow, Sen, Electeur Median | 70 min |
 | 16c | [GameTheory-16c-SocialChoice-Python](GameTheory-16c-SocialChoice-Python.ipynb) | Python | Condorcet, simulations, modele Downs | 45 min |
+| 16d | [GameTheory-16d-SocialChoice-SAT](GameTheory-16d-SocialChoice-SAT.ipynb) | Python | Arrow encode en SAT, z3, UNSAT | 50 min |
+| 16e | [GameTheory-16e-SocialChoiceLean-Tour](GameTheory-16e-SocialChoiceLean-Tour.ipynb) | Lean 4 | Tour DominikPeters, definitions simplifiees | 40 min |
 | 17 | [GameTheory-17-MultiAgent-RL](GameTheory-17-MultiAgent-RL.ipynb) | Python | NFSP, PSRO, AlphaZero intro | 55 min |
 
 **Duree totale** : ~18h30
@@ -57,6 +59,8 @@ Les **side tracks** approfondissent les concepts du notebook principal :
 |-------|------|-------------|
 | **b** | Lean 4 | Formalisation mathematique, preuves formelles |
 | **c** | Python | Approfondissement, exemples avances, visualisations |
+| **d** | Python | Social Choice as SAT/CSP (z3, Arrow encoding) |
+| **e** | Lean 4 | Tour des resultats DominikPeters/SocialChoiceLean |
 
 **Organisation** :
 - Chaque notebook principal inclut des liens vers ses side tracks
@@ -92,6 +96,8 @@ Les **side tracks** approfondissent les concepts du notebook principal :
 | 16 | MechanismDesign | ~40 | 3 | **COMPLET** |
 | 16b | Lean-SocialChoice | ~30 | 3 | **COMPLET** |
 | 16c | SocialChoice-Python | ~25 | 3 | **COMPLET** |
+| 16d | SocialChoice-SAT | ~20 | 2 | **COMPLET** |
+| 16e | SocialChoiceLean-Tour | ~24 | 0 | **COMPLET** |
 | 17 | MultiAgent-RL | ~35 | 3 | **COMPLET** |
 
 Tous les notebooks incluent :
@@ -185,7 +191,8 @@ cp .env.example .env
 - [math-xmum/Brouwer](https://github.com/math-xmum/Brouwer) - Nash existence
 - [MixedMatched/formalizing-game-theory](https://github.com/MixedMatched/formalizing-game-theory)
 - [mathlib4 PGame](https://leanprover-community.github.io/mathlib4_docs/Mathlib/SetTheory/PGame/Basic.html)
-- [asouther4/lean-social-choice](https://github.com/asouther4/lean-social-choice) - Arrow (Lean 3)
+- [asouther4/lean-social-choice](https://github.com/asouther4/lean-social-choice) - Arrow (Lean 3, source originale)
+- [DominikPeters/SocialChoiceLean](https://github.com/DominikPeters/SocialChoiceLean) - Gibbard-Satterthwaite, Split Cycle, 15+ regles (Lean 4, MIT)
 
 ## Structure des fichiers
 
@@ -201,6 +208,8 @@ GameTheory/
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb
 ├── GameTheory-15c-CooperativeGames-Python.ipynb
 ├── GameTheory-16c-SocialChoice-Python.ipynb
+├── GameTheory-16d-SocialChoice-SAT.ipynb
+├── GameTheory-16e-SocialChoiceLean-Tour.ipynb
 ├── README.md
 ├── requirements.txt
 ├── .env.example

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -6,9 +6,12 @@ Ce répertoire contient les formalisations mathématiques de la théorie du choi
 
 | Statistique | Valeur |
 |-------------|--------|
-| Formalisations Lean | 3 théorèmes majeurs |
-| Preuves | Complètes et vérifiées |
-| dépendances | Mathlib4, Lake |
+| Théorèmes formels | 2 certifiés (0 sorry) + 1 en cours |
+| sorry restants | 3 (dans Voting.lean : median voter) |
+| Référence commit | `d679d950` (main, 29/04/2026) |
+| Dépendances | Mathlib4, Lake |
+
+**Statut formel** : Arrow.lean et Sen.lean sont **FORMAL-CERTIFIED** (0 sorry). Voting.lean contient 3 sorry dans les preuves du Median Voter Theorem (en cours de complétion). Voir `FORMAL_STATUS.md` (PR-G) pour le détail par fichier.
 
 ## Théorèmes formalisés
 
@@ -36,7 +39,7 @@ Résultats formalisés par Peters :
 |--------|---------------------------|---------------|
 | Type de préférence | `PrefOrder α` (réflexif, total, transitif) | `LinearOrder A` (strict, Mathlib) |
 | Règle de vote | `SCC ι σ` (types fixés) | `VotingRule` (polymorphe sur V, A) |
-| Toolchain | `v4.28.0-rc1` | `v4.27.0-rc1` |
+| Toolchain | `v4.28.0-rc1` | `v4.27.0-rc1` (pin commit `d679d950`) |
 
 ```
 
@@ -66,7 +69,10 @@ Résultats formalisés par Peters :
 
 ### 3. Théorème de l'Électeur Médian (Median Voter Theorem)
 
-*À venir*
+**Dans `SocialChoice/Voting.lean`** :
+
+- **Énoncé** : Pour des préférences single-peaked, la règle de la majorité sélectionne l'alternative préférée de l'électeur médian.
+- **Statut** : **FORMAL-SKETCH** (3 sorry). Définitions complètes (single-peaked, peak), preuve en cours.
 
 ## Structure des fichiers
 
@@ -86,6 +92,8 @@ social_choice_lean/
     ├── arrow_simple.lean            # Exemple simple d'Arrow
     └── sen_liberal_paradox.lean     # Exemple du paradoxe de Sen
 ```
+
+Le projet `social_choice_lean_peters/` (adjacent) contient un projet Lake séparé qui importe DominikPeters/SocialChoiceLean en dépendance. Il sert de vérification de build et de référence pour le notebook 16e.
 
 ## Dépendances
 

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
@@ -2,17 +2,25 @@
   Social Choice Theory Library
   ============================
 
-  Complete port of asouther4/lean-social-choice from Lean 3 to Lean 4
+  Lean 4 formalizations inspired by asouther4/lean-social-choice (Lean 3)
+  and chasenorman/Formalized-Voting (Lean 4).
 
-  This library formalizes key results in social choice theory:
-  - Arrow's Impossibility Theorem
-  - Sen's Liberal Paradox
-  - Choice functions and acyclicality conditions
+  Arrow's proof follows the Geanakoplos 2005 approach.
+  Sen's liberal paradox uses a bidirectional formulation (Sen 1970).
+  Voting.lean adds margin-based definitions, Condorcet criteria,
+  single-peaked preferences, Split Cycle, and clone-proofness.
+
+  Arrow.lean and Sen.lean: FORMAL-CERTIFIED (0 sorry).
+  Voting.lean: FORMAL-SKETCH (3 sorry in median_voter_theorem).
 
   Reference: Amartya Sen, "Collective Choice and Social Welfare" (1970)
+  Reference: John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)
 
   Original Lean 3 repository:
   https://github.com/asouther4/lean-social-choice
+
+  Lean 4 reference (DominikPeters):
+  https://github.com/DominikPeters/SocialChoiceLean
 -/
 
 import SocialChoice.Basic


### PR DESCRIPTION
## Summary
- **B.1** `social_choice_lean/README.md`: Reformulate "3 théorèmes complets" to accurately state 2 FORMAL-CERTIFIED (Arrow, Sen: 0 sorry) + 1 FORMAL-SKETCH (Voting: 3 sorry). Pin commit `d679d950`. Reference FORMAL_STATUS.md.
- **B.2** `GameTheory/README.md`: Add 16d (SAT) and 16e (DominikPeters tour) to notebook table, file structure, side tracks, status table. Update count 26→27. Add DominikPeters reference.
- **B.3** `SocialChoice.lean`: Replace "Complete port of asouther4" with nuanced attribution: inspired by asouther4 (Lean 3) + chasenorman (Lean 4), Geanakoplos 2005 proof. Add DominikPeters link and certification status per module.

Part of issue #599 (Lean Social Choice extended sprint).

## Test plan
- [x] `git diff --stat` coherent: 3 files, +37/-12
- [x] No Lean code changes (documentation only)
- [x] Sorry count unchanged (still 3 in Voting.lean)
- [x] README links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)