### PR TITLE
chore(slides): recover slide tooling scripts from orphan branch (#572)

### DIFF
--- a/slides/_tools/MARP_CORRECTION_GUIDE.md
+++ b/slides/_tools/MARP_CORRECTION_GUIDE.md
@@ -1,0 +1,316 @@
+# Marp Correction Guide
+
+Reference guide for correcting and improving Marp slides converted from PPTX.
+Based on visual comparison of deck 01-introduction (PPTX originals vs Marp renders).
+
+---
+
+## 1. Layout Patterns That Work Well
+
+### 1.1 `![bg right:X%]` / `![bg left:X%]` -- Single Image Positioning
+
+**Status**: Works correctly. Use consistently.
+
+```markdown
+# Slide Title
+
+- Bullet point content
+- More content here
+
+![bg right:35%](images/img_001.jpg)
+```
+
+**Notes**:
+- Percentages 30-40% work best for text-heavy slides
+- The image fills the right/left portion and scales proportionally
+- Verified on Marp slide 3 "Sommaire" -- image renders exactly as intended
+
+### 1.2 Markdown Tables
+
+**Status**: Works correctly. Tables render clean and readable.
+
+```markdown
+| Column A | Column B | Column C |
+|----------|----------|----------|
+| Data 1   | Data 2   | Data 3   |
+```
+
+**Notes**:
+- Verified on Marp slide 29 "PEAS table" -- content matches PPTX original
+- Tables scale to fit the available width
+- For wide tables (5+ columns), consider reducing font size or splitting
+
+### 1.3 `columns-layout` with Text + Images
+
+**Status**: Works correctly when HTML structure is valid.
+
+```markdown
+<!-- _class: columns-layout -->
+
+# Title
+
+<div class="columns">
+<div class="col-left">
+
+- Text content here
+- More bullets
+
+</div>
+<div class="col-right">
+
+![Image description](images/img_XXX.png)
+
+</div>
+</div>
+```
+
+**Critical**: Blank lines MUST surround the markdown content inside `<div>` tags,
+otherwise Marp treats it as raw HTML and doesn't parse markdown.
+
+**Verified**: Marp slide 33 "Agent reflexe" -- text left, diagrams right, renders well.
+
+---
+
+## 2. Known Problems and Fixes
+
+### 2.1 img-grid Overflow
+
+**Problem**: Logo/image grids overflow the slide bottom, overlapping with the footer.
+
+**Example**: Marp slide 17 "Qui fait de l'IA?" -- 12+ logos in a grid, bottom row clips.
+
+**Cause**: The `img-grid` CSS class doesn't enforce maximum height per item,
+and too many items push content below the slide boundary.
+
+**Fix options**:
+1. **Reduce items**: Show fewer logos per slide, split into 2 slides if needed
+2. **Constrain sizes**: Add inline `style="max-height:50px"` to img tags
+3. **Use img-grid-3 or img-grid-2x2**: Smaller grid variants from ia101.css
+
+```markdown
+<!-- BEFORE (overflows) -->
+<div class="img-grid">
+<img src="images/logo1.png" alt="Logo1">
+<img src="images/logo2.png" alt="Logo2">
+<!-- ... 10+ images ... -->
+</div>
+
+<!-- AFTER (constrained) -->
+<div class="img-grid">
+<img src="images/logo1.png" alt="Logo1" style="max-height:55px; max-width:90px; object-fit:contain;">
+<img src="images/logo2.png" alt="Logo2" style="max-height:55px; max-width:90px; object-fit:contain;">
+<!-- ... fewer images, or split into 2 slides ... -->
+</div>
+```
+
+### 2.2 Diagram-to-Text Degradation
+
+**Problem**: Complex PPTX diagrams (SmartArt trees, flowcharts, hierarchies) were
+converted to flat bulleted text lists, losing significant visual impact.
+
+**Example**: PPTX slide 28 "Intelligence de la pensee logique" had a beautiful
+hierarchical tree (Type -> Inference -> Modeles -> Apprentissage -> Agents) with
+colored boxes. Marp slide 27 "Intelligences" has a flat text list with thumbnails.
+
+**Cause**: pptx_to_marp.py cannot reproduce SmartArt/diagram objects.
+
+**Fix options** (in order of preference):
+1. **Extract diagram as image**: If the PPTX diagram is in `extracted/images/`,
+   use it directly as `![bg right:50%](images/extracted_diagram.png)`
+2. **Recreate with HTML table**: For simple hierarchies, use styled HTML
+3. **Accept text version**: For complex diagrams, keep the text but improve formatting
+4. **Create new diagram**: Use an external tool (draw.io, Mermaid) and save as PNG
+
+### 2.3 Footer/Content Overlap
+
+**Problem**: Content at the bottom of dense slides overlaps the Marp footer area.
+
+**Examples**: Marp slide 17 (logos), Marp slide 33 (Wolfram book at bottom).
+
+**Fix**:
+- Reduce content density (split into 2 slides if >8 bullet points or >150 words)
+- Move bottom-of-slide images to `![bg right]` or `![bg left]` instead
+- Add `<br>` spacing before footer-adjacent content
+
+### 2.4 Section Header Slides
+
+**Problem**: PPTX section headers had full-width colored backgrounds with
+sommaire/navigation showing the current position in the course outline.
+Marp section slides are minimal.
+
+**Example**: PPTX slide 21 "Systemes d'agents" shows the full course outline
+with grayed-out previous sections and highlighted current section.
+Marp slide 24 "Systemes d'agents" is just a title.
+
+**Fix**: Optionally add a mini-sommaire under the section title:
+
+```markdown
+<!-- _class: section -->
+
+# Systemes d'agents
+
+- ~~Introduction~~
+- ~~Qu'est-ce que l'IA?~~
+- **Systemes d'agents** -- *vous etes ici*
+- Types d'agents
+```
+
+### 2.5 Title Slides (Cosmetic)
+
+**Problem**: PPTX title slides had decorative gradients, card designs, visual effects.
+Marp `_class: title` produces a clean but simpler centered layout.
+
+**Status**: Acceptable trade-off. The ia101.css theme provides a professional look
+with the dark red accent. No action required unless specific visual impact is desired.
+
+### 2.6 Slide Numbering Drift
+
+**Problem**: PPTX and Marp have different slide counts (e.g., 43 vs 42 for deck 01).
+Slides don't align by position number.
+
+**Cause**: Marp conversion split or merged some slides differently.
+
+**Impact**: Cannot do automated positional comparison.
+Must match slides by title/content for PPTX vs Marp comparison.
+
+**For automated tools**: Use title extraction (grep `^# ` in slides.md) and
+compare against PPTX content.md titles for mapping.
+
+---
+
+## 3. Content Enrichment Rules
+
+### 3.1 Text Improvement
+
+- **Reformulate telegraphic fragments** into short, fluent sentences
+- **Develop cryptic points**: add examples, context, explanations
+- **Preserve all original meaning** -- enrich, never impoverish
+- **Update dated content**: add recent examples (GPT-4/5, Claude, DeepSeek, etc.)
+
+### 3.2 Slide Density
+
+- **Split slides with >8 bullet points or >150 words** into 2-3 slides
+- **Keep the "one idea per slide" principle** when possible
+- Splitting is better than cramming
+
+### 3.3 TODO Resolution
+
+For each `<!-- TODO: ... -->` comment in slides.md:
+1. **If an image exists** in `images/` or `extracted/images/` that matches: add it
+2. **If a free-use image can be found**: download, save to `images/`, reference it
+3. **If neither**: remove the TODO comment (don't leave orphan comments)
+
+### 3.4 Cross-References
+
+Add references to relevant notebooks where appropriate:
+```markdown
+> **Notebook associe:** `MyIA.AI.Notebooks/Search/` -- Resolution de problemes
+```
+
+---
+
+## 4. CSS Classes Reference (ia101.css)
+
+| Class | Usage | Notes |
+|-------|-------|-------|
+| `title` | First/last slide | Centered, large title, dark background |
+| `section` | Section dividers | Accent color header |
+| `questions` | Q&A slides | Centered "Questions?" |
+| `columns-layout` | Two-column HTML | Requires `<div class="columns">` |
+| `dense` | Compact slides | Smaller font, tighter spacing |
+| `crossref` | Reference slides | For "pour aller plus loin" |
+| `img-grid` | Image grid | Flexbox, auto-wrapping |
+| `img-grid-2x2` | 2x2 image grid | Fixed 2-column layout |
+| `img-grid-3` | 3-column grid | Three equal columns |
+| `image-row` | Horizontal images | Inline row layout |
+| `framed` | Bordered content | Adds border around content |
+
+---
+
+## 5. Quality Checklist (per deck)
+
+Before committing a corrected deck, verify:
+
+- [ ] All `images/img_XXX` references resolve to existing files
+- [ ] No `<!-- TODO: -->` comments remain (resolved or removed)
+- [ ] No slides exceed 8 bullet points or ~150 words
+- [ ] `columns-layout` divs have blank lines around markdown content
+- [ ] `img-grid` items have size constraints (no overflow)
+- [ ] Tables are readable (not too many columns for slide width)
+- [ ] Section headers include position context if relevant
+- [ ] Marp renders without errors (`marp slides.md --html -o test.html`)
+- [ ] Content matches PPTX original intent (no accidental deletions)
+
+---
+
+## 6. sk-agent Vision Prompts (calibrated on deck 01)
+
+**Important**: Always use French prompts. English prompts cause hallucination
+on logo-heavy slides. Keep prompts under ~50 words per question.
+
+### Primary layout verification prompt (recommended)
+```
+TEXTE EXTRAIT:
+{texte_slide}
+
+---
+Analyse UNIQUEMENT la mise en forme et les visuels (le texte est deja extrait ci-dessus).
+
+1. VISUELS: Diagrammes, images, icones presents ? Lesquels ? Qualite ?
+2. MISE EN FORME: Disposition, equilibre texte/visuel, hierarchie
+3. LISIBILITE: Note /10 pour projection amphitheatre
+4. 2 SUGGESTIONS concretes d'amelioration
+```
+
+Providing extracted text prevents the model from needing to read text,
+directing attention to layout and visual quality.
+
+### Retry prompt (on empty or hallucinated response)
+```
+Decris les visuels de cette slide et note la lisibilite /10.
+```
+
+### Content completeness check
+```
+Verifie le contenu de cette slide :
+1. Y a-t-il du contenu qui semble tronque ou absent ?
+2. Les images sont-elles visibles et correctement positionnees ?
+3. Le texte deborde-t-il du cadre de la slide ?
+```
+
+### Calibration findings (Phase 1.5)
+
+| Finding | Impact | Mitigation |
+|---------|--------|------------|
+| sk-agent misses content truncation | Over-rates broken slides | Add explicit "tronque ou absent?" question |
+| English prompts cause hallucination | Logo-heavy slides trigger fake web URLs | Always use French |
+| 2-column layouts convert best | Agent reflexe type = 4.5/5 | Prefer columns-layout for complex slides |
+| Logo grids are weakest | Overflow, lost associations | Use constrained img-grid with max-height |
+| sk-agent uses glm-4.6v internally | Ignores model parameter | No workaround needed |
+
+---
+
+## 7. Marp CLI Commands
+
+```bash
+# Render single deck to PNG (2x resolution)
+marp slides/XX-name/slides.md --images png --image-scale 2 --html \
+  --allow-local-files --theme-set slides/themes/ia101.css \
+  -o slides/XX-name/output/marp_renders/slide.png
+
+# Render to HTML (fastest, no Puppeteer dependency)
+marp slides/XX-name/slides.md --html \
+  --allow-local-files --theme-set slides/themes/ia101.css \
+  -o slides/XX-name/output/slides.html
+
+# Check image references
+python slides/_tools/slide_tools.py check-refs slides/XX-name
+
+# Compare slide counts PPTX vs Marp
+python slides/_tools/slide_tools.py compare slides/XX-name
+```
+
+**Known issue**: marp-cli PNG/PDF export crashes with `TargetCloseError` on
+some Windows systems (Puppeteer/Chrome incompatibility with Node.js v24+).
+Workaround: run via PowerShell `mcp__win-cli__execute_command`, or use
+HTML export and screenshot.

--- a/slides/_tools/batch_extract_all.py
+++ b/slides/_tools/batch_extract_all.py
@@ -1,0 +1,72 @@
+"""
+Batch extraction of all 12 course slide decks.
+Runs the full pipeline: render PNG + extract text + extract images + generate inventory.
+"""
+import os
+import sys
+import time
+
+# Add tools directory to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from slide_tools import full_extract
+
+SLIDES_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Mapping: directory name -> PPTX filename in original/
+DECKS = {
+    "01-introduction": "Intelligence Artificielle - 1 - Introduction.pptx",
+    "02-resolution-problemes": "Intelligence Artificielle - 2 - Résolution de problèmes.pptx",
+    "03-logique": "Intelligence Artificielle - 3 - Logique.pptx",
+    "04-probabilites": "Intelligence Artificielle - 4 - Probabilités.pptx",
+    "05-theorie-des-jeux": "Intelligence Artificielle - 5 - Théorie des jeux.pptx",
+    "06-apprentissage": "Intelligence Artificielle - 6 - Apprentissage.pptx",
+    "07-elargissements": "Intelligence Artificielle - 7 - Elargissements.pptx",
+    "08-ia-generative": "Intelligence Artificielle - 8 - IA Générative.pptx",
+    "S1-argumentation": "IA et Argumentation.pptx",
+    "S2-ia-exploratoire-symbolique": "IA exploratoire et symbolique.pptx",
+    "S3-acculturation": "JSBoige - Intelligence Artificielle - Acculturation.pptx",
+    "S4-trading-algorithmique": "MyIA - Trading algorithmique.pptx",
+}
+
+
+def main():
+    start = time.time()
+    results = {}
+
+    for dir_name, pptx_name in DECKS.items():
+        pptx_path = os.path.join(SLIDES_ROOT, dir_name, "original", pptx_name)
+        output_base = os.path.join(SLIDES_ROOT, dir_name, "extracted")
+
+        if not os.path.exists(pptx_path):
+            print(f"SKIP: {pptx_path} not found")
+            continue
+
+        print(f"\n{'='*60}")
+        print(f"Processing: {dir_name}")
+        print(f"{'='*60}")
+
+        try:
+            result = full_extract(pptx_path, output_base, render=True)
+            results[dir_name] = {
+                "slides": result.get("slide_count", 0),
+                "renders": result.get("render_count", 0),
+                "images": result.get("image_count", 0),
+                "status": "OK"
+            }
+        except Exception as e:
+            print(f"ERROR: {dir_name} - {e}")
+            results[dir_name] = {"status": f"ERROR: {e}"}
+
+    elapsed = time.time() - start
+    print(f"\n{'='*60}")
+    print(f"BATCH EXTRACTION COMPLETE in {elapsed:.1f}s")
+    print(f"{'='*60}")
+    for name, info in results.items():
+        if info["status"] == "OK":
+            print(f"  {name}: {info['slides']} slides, {info['renders']} renders, {info['images']} images")
+        else:
+            print(f"  {name}: {info['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/slides/_tools/compare_marp_pptx.py
+++ b/slides/_tools/compare_marp_pptx.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+Automated comparison tool for Marp vs PPTX slide decks.
+
+Compares:
+- Slide counts
+- Content structure
+- Image references
+- Layout differences
+
+Usage:
+    python compare_marp_pptx.py <deck_directory>
+"""
+
+import os
+import re
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def parse_markdown_slides(md_path: str) -> List[Dict]:
+    """Parse markdown file into slides separated by ---."""
+    with open(md_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Split by slide separator
+    raw_slides = re.split(r'^---$', content, flags=re.MULTILINE)
+
+    slides = []
+    slide_number = 1  # Start numbering from 1
+
+    for slide_content in raw_slides:
+        # Skip empty slides (before first --- or after last ---)
+        if not slide_content.strip():
+            continue
+
+        # Skip Marp metadata section (contains marp: true, theme, etc.)
+        if 'marp:' in slide_content and 'theme:' in slide_content:
+            continue
+
+        # Extract title
+        title_match = re.search(r'^#\s+(.+)$', slide_content, re.MULTILINE)
+        title = title_match.group(1).strip() if title_match else f"Slide {slide_number}"
+
+        # Extract image references
+        images = re.findall(r'!\[.*?\]\((.*?)\)', slide_content)
+
+        # Check for layout classes
+        layout_match = re.search(r'<!--\s*_class:\s*(\w+)\s*-->', slide_content)
+        layout = layout_match.group(1) if layout_match else 'default'
+
+        slides.append({
+            'number': slide_number,
+            'title': title,
+            'images': images,
+            'layout': layout,
+            'content_length': len(slide_content)
+        })
+
+        slide_number += 1  # Increment for next slide
+
+    return slides
+
+
+def parse_extracted_content(content_path: str) -> List[Dict]:
+    """Parse extracted content.md into slides."""
+    with open(content_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Split by slide markers
+    slide_blocks = re.split(r'<!-- Slide number:', content)
+
+    slides = []
+    for block in slide_blocks[1:]:  # Skip first empty split
+        lines = block.strip().split('\n')
+        if not lines:
+            continue
+
+        # Extract slide number
+        num_match = re.match(r'(\d+)\s*-->', lines[0])
+        if not num_match:
+            continue
+
+        slide_num = int(num_match.group(1))
+
+        # Extract title (first line starting with #)
+        title = f"Slide {slide_num}"
+        for line in lines[1:]:
+            if line.strip().startswith('#'):
+                title = line.strip().lstrip('#').strip()
+                break
+
+        # Extract image references
+        images = re.findall(r'!\[\]\((.*?)\)', block)
+
+        slides.append({
+            'number': slide_num,
+            'title': title,
+            'images': images
+        })
+
+    return sorted(slides, key=lambda x: x['number'])
+
+
+def compare_slides(marp_slides: List[Dict], pptx_slides: List[Dict]) -> Dict:
+    """Compare Marp and PPTX slides."""
+
+    comparison = {
+        'marp_count': len(marp_slides),
+        'pptx_count': len(pptx_slides),
+        'title_matches': [],
+        'title_mismatches': [],
+        'missing_in_pptx': [],
+        'missing_in_marp': [],
+        'image_issues': []
+    }
+
+    # Create lookup dicts
+    marp_by_num = {s['number']: s for s in marp_slides}
+    pptx_by_num = {s['number']: s for s in pptx_slides}
+
+    # Compare titles
+    all_numbers = sorted(set(marp_by_num.keys()) | set(pptx_by_num.keys()))
+
+    for num in all_numbers:
+        marp_slide = marp_by_num.get(num)
+        pptx_slide = pptx_by_num.get(num)
+
+        if marp_slide and pptx_slide:
+            # Normalize titles for comparison
+            marp_title = marp_slide['title'].lower().strip()
+            pptx_title = pptx_slide['title'].lower().strip()
+
+            # Check for key match (ignore parentheticals, numbering)
+            marp_key = re.sub(r'\(.*?\)|\d+/\d+', '', marp_title).strip()
+            pptx_key = re.sub(r'\(.*?\)|\d+/\d+', '', pptx_title).strip()
+
+            if marp_key == pptx_key or marp_key in pptx_key or pptx_key in marp_key:
+                comparison['title_matches'].append({
+                    'number': num,
+                    'marp_title': marp_slide['title'],
+                    'pptx_title': pptx_slide['title']
+                })
+            else:
+                comparison['title_mismatches'].append({
+                    'number': num,
+                    'marp_title': marp_slide['title'],
+                    'pptx_title': pptx_slide['title']
+                })
+
+            # Check image issues
+            if marp_slide['images']:
+                for img_ref in marp_slide['images']:
+                    img_path = Path(marp_slide.get('base_path', '')) / img_ref
+                    if not img_path.exists():
+                        comparison['image_issues'].append({
+                            'slide': num,
+                            'image': img_ref,
+                            'issue': 'File not found'
+                        })
+
+        elif marp_slide and not pptx_slide:
+            comparison['missing_in_pptx'].append({
+                'number': num,
+                'marp_title': marp_slide['title']
+            })
+
+        elif pptx_slide and not marp_slide:
+            comparison['missing_in_marp'].append({
+                'number': num,
+                'pptx_title': pptx_slide['title']
+            })
+
+    return comparison
+
+
+def generate_report(comparison: Dict, output_path: str):
+    """Generate markdown comparison report."""
+
+    report_lines = [
+        "# Rapport de Comparaison Marp vs PPTX",
+        "",
+        f"**Marp slides**: {comparison['marp_count']}",
+        f"**PPTX slides**: {comparison['pptx_count']}",
+        f"**Différence**: {comparison['marp_count'] - comparison['pptx_count']} slides",
+        "",
+        "---",
+        "",
+        "## Correspondance des Titres",
+        ""
+    ]
+
+    # Title matches
+    if comparison['title_matches']:
+        report_lines.append("### Slides Correspondantes")
+        report_lines.append("")
+        for match in comparison['title_matches']:
+            report_lines.append(f"- **Slide {match['number']}**: {match['marp_title']}")
+        report_lines.append("")
+
+    # Title mismatches
+    if comparison['title_mismatches']:
+        report_lines.append("### Slides avec Différences")
+        report_lines.append("")
+        for mismatch in comparison['title_mismatches']:
+            report_lines.append(f"- **Slide {mismatch['number']}**:")
+            report_lines.append(f"  - Marp: {mismatch['marp_title']}")
+            report_lines.append(f"  - PPTX: {mismatch['pptx_title']}")
+        report_lines.append("")
+
+    # Missing slides
+    if comparison['missing_in_pptx']:
+        report_lines.append("### Slides Absentes du PPTX")
+        report_lines.append("")
+        for missing in comparison['missing_in_pptx']:
+            report_lines.append(f"- Slide {missing['number']}: {missing['marp_title']}")
+        report_lines.append("")
+
+    if comparison['missing_in_marp']:
+        report_lines.append("### Slides Absentes du Marp")
+        report_lines.append("")
+        for missing in comparison['missing_in_marp']:
+            report_lines.append(f"- Slide {missing['number']}: {missing['pptx_title']}")
+        report_lines.append("")
+
+    # Image issues
+    if comparison['image_issues']:
+        report_lines.append("## Problèmes d'Images")
+        report_lines.append("")
+        for issue in comparison['image_issues']:
+            report_lines.append(f"- **Slide {issue['slide']}**: `{issue['image']}` - {issue['issue']}")
+        report_lines.append("")
+
+    # Summary
+    report_lines.extend([
+        "---",
+        "",
+        "## Résumé",
+        "",
+        f"- **Correspondances**: {len(comparison['title_matches'])} slides",
+        f"- **Différences**: {len(comparison['title_mismatches'])} slides",
+        f"- **Absentes PPTX**: {len(comparison['missing_in_pptx'])} slides",
+        f"- **Absentes Marp**: {len(comparison['missing_in_marp'])} slides",
+        f"- **Images manquantes**: {len(comparison['image_issues'])}",
+        ""
+    ])
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(report_lines))
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Compare Marp and PPTX slide decks')
+    parser.add_argument('deck_dir', help='Path to deck directory (e.g., 07-elargissements)')
+    parser.add_argument('--output', '-o', help='Output report path')
+    args = parser.parse_args()
+
+    deck_path = Path(args.deck_dir)
+    if not deck_path.is_absolute():
+        deck_path = Path.cwd() / deck_path
+
+    # File paths
+    md_path = deck_path / 'slides.md'
+    content_path = deck_path / 'extracted' / 'content.md'
+
+    if not md_path.exists():
+        print(f"Error: {md_path} not found")
+        return 1
+
+    if not content_path.exists():
+        print(f"Error: {content_path} not found")
+        return 1
+
+    # Parse files
+    print(f"Parsing {md_path}...")
+    marp_slides = parse_markdown_slides(str(md_path))
+
+    # Set base path for image validation
+    assets_path = deck_path / '_assets' / 'images'
+    for slide in marp_slides:
+        slide['base_path'] = str(assets_path)
+
+    print(f"Parsing {content_path}...")
+    pptx_slides = parse_extracted_content(str(content_path))
+
+    print(f"Marp slides: {len(marp_slides)}")
+    print(f"PPTX slides: {len(pptx_slides)}")
+
+    # Compare
+    print("Comparing...")
+    comparison = compare_slides(marp_slides, pptx_slides)
+
+    # Generate report
+    output_path = args.output or str(deck_path / 'analysis' / 'comparison_report.md')
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    print(f"Generating report: {output_path}")
+    generate_report(comparison, output_path)
+
+    print("Done!")
+    return 0
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/slides/_tools/extract_animations.py
+++ b/slides/_tools/extract_animations.py
@@ -1,0 +1,294 @@
+"""
+Extract animation sequences from PPTX files.
+
+For each deck, produces slides/XX/extracted/animations.json describing:
+- Which shapes appear on each click (click groups)
+- Shape types (title, text, image, table, chart)
+- Text content and image filenames
+
+This data drives v-click reconstruction in Slidev.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from pptx import Presentation
+from pptx.util import Inches
+import lxml.etree as etree
+
+PPTX_NS = {
+    'p': 'http://schemas.openxmlformats.org/presentationml/2006/main',
+    'a': 'http://schemas.openxmlformats.org/drawingml/2006/main',
+    'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+}
+
+SLIDES_DIR = Path(__file__).parent.parent
+
+
+def get_shape_text(shape) -> str:
+    """Extract text content from a shape."""
+    try:
+        if shape.has_text_frame:
+            lines = []
+            for para in shape.text_frame.paragraphs:
+                text = para.text.strip()
+                if text:
+                    lines.append(text)
+            return '\n'.join(lines)
+    except Exception:
+        pass
+    return ''
+
+
+def get_shape_type(shape) -> str:
+    """Classify a shape as title/text/image/table/chart/other."""
+    try:
+        from pptx.enum.shapes import MSO_SHAPE_TYPE, PP_PLACEHOLDER
+        # Placeholder types
+        if shape.is_placeholder:
+            ph = shape.placeholder_format
+            if ph.type in (PP_PLACEHOLDER.TITLE, PP_PLACEHOLDER.CENTER_TITLE):
+                return 'title'
+            if ph.type == PP_PLACEHOLDER.SUBTITLE:
+                return 'subtitle'
+            if ph.type == PP_PLACEHOLDER.PICTURE:
+                return 'image'
+            if ph.type == PP_PLACEHOLDER.BODY:
+                return 'text'
+        # Shape types
+        if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+            return 'image'
+        if shape.shape_type == MSO_SHAPE_TYPE.TABLE:
+            return 'table'
+        if shape.shape_type == MSO_SHAPE_TYPE.CHART:
+            return 'chart'
+        if shape.has_text_frame:
+            return 'text'
+    except Exception:
+        pass
+    return 'other'
+
+
+def get_image_filename(shape, slide_images: dict) -> str:
+    """Try to find the image filename for a picture shape."""
+    try:
+        from pptx.enum.shapes import MSO_SHAPE_TYPE
+        if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+            img = shape.image
+            # Match by content hash against known images
+            img_hash = hash(img.blob)
+            if img_hash in slide_images:
+                return slide_images[img_hash]
+    except Exception:
+        pass
+    return ''
+
+
+def build_shape_index(prs: Presentation) -> dict:
+    """Build a map of shape ID → shape object across all slides."""
+    index = {}
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            index[shape.shape_id] = shape
+    return index
+
+
+def extract_click_groups(slide_elem, shapes_on_slide: dict) -> dict:
+    """
+    Parse <p:timing> to extract click-triggered animation groups.
+
+    Each clickEffect par in OOXML represents one user click.
+    Paragraph-level animations use <p:pRg st="N" end="N"/> to specify
+    which paragraph in a text box becomes visible.
+
+    Returns dict: {
+        (shape_id, para_idx_or_None): click_index,
+        ...
+    }
+    For whole-shape animations, para_idx is None.
+    For paragraph animations, para_idx is the paragraph index.
+    """
+    ns = 'http://schemas.openxmlformats.org/presentationml/2006/main'
+    timing = slide_elem.find(f'.//{{{ns}}}timing')
+    if timing is None:
+        return {}
+
+    animated = {}  # (shape_id, para_idx) -> click_index
+    click_index = 0
+
+    for par in timing.findall(f'.//{{{ns}}}par'):
+        cTn = par.find(f'{{{ns}}}cTn')
+        if cTn is None:
+            continue
+        if cTn.get('nodeType') != 'clickEffect':
+            continue
+        click_index += 1
+
+        # Find all spTgt in this clickEffect subtree
+        sp_tgts = par.findall(f'.//{{{ns}}}spTgt')
+        for sp_tgt in sp_tgts:
+            spid = sp_tgt.get('spid')
+            if not spid:
+                continue
+            shape_id = int(spid)
+
+            # Check for paragraph-level targeting via <p:txEl><p:pRg st="N" end="N"/>
+            tx_el = sp_tgt.find(f'{{{ns}}}txEl')
+            if tx_el is not None:
+                p_rg = tx_el.find(f'{{{ns}}}pRg')
+                if p_rg is not None:
+                    st = int(p_rg.get('st', 0))
+                    end = int(p_rg.get('end', st))
+                    for para_idx in range(st, end + 1):
+                        key = (shape_id, para_idx)
+                        if key not in animated:
+                            animated[key] = click_index
+                    continue
+            # Whole-shape animation
+            key = (shape_id, None)
+            if key not in animated:
+                animated[key] = click_index
+
+    return animated
+
+
+def extract_slide_animations(slide, slide_num: int) -> dict:
+    """Extract animation data for a single slide."""
+    # animated: {(shape_id, para_idx_or_None): click_index}
+    animated = extract_click_groups(slide.element, {})
+
+    max_click = max(animated.values(), default=0)
+
+    # Build items list: each item is a text paragraph or whole shape revealed at a click
+    items = []
+    for shape in slide.shapes:
+        shape_type = get_shape_type(shape)
+
+        # Whole-shape animation?
+        whole_key = (shape.shape_id, None)
+        if whole_key in animated:
+            items.append({
+                'shape_id': shape.shape_id,
+                'shape_name': shape.name,
+                'type': shape_type,
+                'click': animated[whole_key],
+                'text': get_shape_text(shape)[:200] if shape.has_text_frame else '',
+                'is_image': shape_type == 'image',
+            })
+        elif shape.has_text_frame:
+            # Check paragraph-level animations
+            # Sub-paragraphs (level > 0) inherit the click of their parent level-0 paragraph
+            last_parent_click = 0
+            for para_idx, para in enumerate(shape.text_frame.paragraphs):
+                para_key = (shape.shape_id, para_idx)
+                text = para.text.strip()
+                level = para.level  # 0 = top level, 1+ = sub-levels
+
+                if para_key in animated:
+                    click = animated[para_key]
+                    if level == 0:
+                        last_parent_click = click
+                elif level > 0 and last_parent_click > 0:
+                    # Sub-paragraph: inherit parent's click
+                    click = last_parent_click
+                else:
+                    click = 0  # visible from start
+
+                if text:
+                    items.append({
+                        'shape_id': shape.shape_id,
+                        'shape_name': shape.name,
+                        'type': 'paragraph',
+                        'click': click,
+                        'para_idx': para_idx,
+                        'level': level,
+                        'text': text[:200],
+                        'is_image': False,
+                    })
+        elif shape_type == 'image' and whole_key not in animated:
+            # Image visible from start
+            items.append({
+                'shape_id': shape.shape_id,
+                'shape_name': shape.name,
+                'type': 'image',
+                'click': 0,
+                'text': '',
+                'is_image': True,
+            })
+
+    # Group by click index
+    click_groups = {}
+    for item in items:
+        c = item['click']
+        if c not in click_groups:
+            click_groups[c] = []
+        click_groups[c].append(item)
+
+    return {
+        'number': slide_num,
+        'has_animations': len(animated) > 0,
+        'animation_count': len(animated),
+        'click_count': max_click,
+        'click_groups': [
+            {'click': k, 'items': click_groups[k]}
+            for k in sorted(click_groups.keys())
+        ]
+    }
+
+
+def process_deck(deck_dir: Path) -> dict:
+    """Process one PPTX deck and return animation data."""
+    original_dir = deck_dir / 'original'
+    pptx_files = list(original_dir.glob('*.pptx'))
+    if not pptx_files:
+        return None
+
+    pptx_path = pptx_files[0]
+    print(f"  Processing: {pptx_path.name}")
+
+    prs = Presentation(pptx_path)
+
+    slides_data = []
+    animated_count = 0
+    for i, slide in enumerate(prs.slides):
+        slide_data = extract_slide_animations(slide, i + 1)
+        slides_data.append(slide_data)
+        if slide_data['has_animations']:
+            animated_count += 1
+
+    return {
+        'filename': pptx_path.name,
+        'slide_count': len(prs.slides),
+        'animated_slide_count': animated_count,
+        'slides': slides_data,
+    }
+
+
+def main():
+    decks = sorted([d for d in SLIDES_DIR.iterdir()
+                    if d.is_dir() and (d / 'original').exists()])
+
+    target = sys.argv[1] if len(sys.argv) > 1 else None
+
+    for deck_dir in decks:
+        if target and deck_dir.name != target:
+            continue
+
+        print(f"\n[{deck_dir.name}]")
+        data = process_deck(deck_dir)
+        if data is None:
+            print("  No PPTX found, skipping.")
+            continue
+
+        output_path = deck_dir / 'extracted' / 'animations.json'
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+        print(f"  Slides: {data['slide_count']}, Animated: {data['animated_slide_count']}")
+        print(f"  -> {output_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/slides/_tools/marp_to_slidev.py
+++ b/slides/_tools/marp_to_slidev.py
@@ -1,0 +1,311 @@
+"""
+Convert Marp slides.md to Slidev format.
+
+Key conversions:
+- Marp frontmatter → Slidev frontmatter
+- <!-- _class: title --> → layout: cover
+- <!-- _class: section --> → layout: section
+- <!-- _class: dense --> → layout: dense
+- <!-- _class: columns-layout --> → layout: two-cols
+- ![bg right:X%](img) → layout: image-right with image prop
+- ![bg right:X% vertical] + ![bg] patterns → layout: image-right with v-click images
+- Animations from animations.json → v-click directives
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SLIDES_DIR = Path(__file__).parent.parent
+
+
+def read_animations(deck_dir: Path) -> dict:
+    """Read animations.json for a deck."""
+    anim_path = deck_dir / 'extracted' / 'animations.json'
+    if anim_path.exists():
+        with open(anim_path, encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+def split_slides(marp_content: str) -> list:
+    """Split markdown content by --- separators."""
+    slides = []
+    current = []
+    for line in marp_content.split('\n'):
+        if line.strip() == '---':
+            slides.append('\n'.join(current))
+            current = []
+        else:
+            current.append(line)
+    if current:
+        slides.append('\n'.join(current))
+    return slides
+
+
+def parse_frontmatter(slide: str) -> tuple:
+    """Parse frontmatter (YAML between ---). Returns (frontmatter, content)."""
+    lines = slide.split('\n')
+    if lines[0].strip() == '---' and '---' in '\n'.join(lines[1:]):
+        end_idx = lines[1:].index('---') + 2
+        frontmatter = '\n'.join(lines[1:end_idx])
+        content = '\n'.join(lines[end_idx + 1:])
+        return frontmatter, content
+    return '', slide
+
+
+def apply_click_animations(content: str, slide_animations: dict) -> str:
+    """Apply v-click directives based on PPTX click_groups."""
+    if not slide_animations.get('has_animations', False):
+        return content
+
+    click_groups = slide_animations.get('click_groups', [])
+    if not click_groups or len(click_groups) <= 1:
+        return content
+
+    # Build mapping of level 0 text to click index
+    level0_to_click = {}
+    for group in click_groups[1:]:  # Skip click 0 (visible by default)
+        click_idx = group['click']
+        for item in group.get('items', []):
+            if item.get('type') == 'paragraph' and item.get('level', 0) == 0:
+                text = item.get('text', '').strip()
+                if text:
+                    key = text[:40].lower()
+                    level0_to_click[key] = click_idx
+
+    lines = content.split('\n')
+    result = []
+    parent_click = 0  # Track click for current level 0 parent
+
+    for line in lines:
+        # Detect indentation level
+        indent_match = re.match(r'^(\s*)-', line)
+        if indent_match:
+            indent = len(indent_match.group(1))
+            level = indent // 2 if indent else 0
+            stripped = line.strip()
+
+            if level == 0:
+                # Level 0 bullet - find its click
+                bullet_text = stripped[2:].strip()
+                parent_click = 0
+                for key, click_idx in level0_to_click.items():
+                    if key in bullet_text.lower() or bullet_text.lower() in key:
+                        parent_click = click_idx
+                        break
+
+                if parent_click > 0:
+                    result.append(f'<v-click="{parent_click}">{stripped}</v-click>')
+                else:
+                    result.append(line)
+            else:
+                # Level 1+ bullet - inherit parent's click
+                if parent_click > 0:
+                    result.append(f'<v-click="{parent_click}">{stripped}</v-click>')
+                else:
+                    result.append(line)
+        else:
+            result.append(line)
+
+    return '\n'.join(result)
+
+
+def convert_slide_content(content: str, slide_num: int, animations: dict) -> str:
+    """Convert Marp content to Slidev format."""
+    lines = content.split('\n')
+    result = []
+    i = 0
+
+    # Track animations for this slide
+    slide_animations = animations.get('slides', [{}])[slide_num - 1] if slide_num <= len(animations.get('slides', [])) else {}
+    has_animations = slide_animations.get('has_animations', False)
+    click_groups = slide_animations.get('click_groups', [])
+
+    # Collect multi-image vertical patterns first
+    vertical_images = []
+    in_vertical_block = False
+
+    # Track two-cols layout
+    in_two_cols = False
+    in_right_col = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Detect vertical multi-image pattern start
+        if re.match(r'^!\[bg right:\d+% vertical\]\(images/[^\)]+\)', line):
+            in_vertical_block = True
+            match = re.match(r'^!\[bg right:\d+% vertical\]\(([^)]+)\)', line)
+            if match:
+                vertical_images.append(match.group(1))
+            i += 1
+            # Collect following ![bg] patterns
+            while i < len(lines) and re.match(r'^!\[bg\]\(images/[^\)]+\)', lines[i]):
+                bg_match = re.match(r'^!\[bg\]\(([^)]+)\)', lines[i])
+                if bg_match:
+                    vertical_images.append(bg_match.group(1))
+                i += 1
+            continue
+
+        # If we collected vertical images, output them
+        if vertical_images:
+            result.append('layout: image-right')
+            result.append(f'image: ./{vertical_images[0]}')
+            # Additional images as inline markdown with v-click if animated
+            for idx, img in enumerate(vertical_images[1:], 1):
+                if has_animations:
+                    result.append(f'<div v-click="{idx}"><img src="./{img}" style="max-height:300px; margin-top:8px;"></div>')
+                else:
+                    result.append(f'<img src="./{img}" style="max-height:300px; margin-top:8px;">')
+            vertical_images = []
+            in_vertical_block = False
+            continue
+
+        # Class directives
+        if '<!-- _class: title -->' in line:
+            result.append('layout: cover')
+        elif '<!-- _class: section -->' in line:
+            result.append('layout: section')
+        elif '<!-- _class: dense -->' in line:
+            result.append('layout: dense')
+        elif '<!-- _class: columns-layout -->' in line:
+            result.append('layout: two-cols')
+            in_two_cols = True
+            # Skip empty lines that followed
+            i += 1
+            while i < len(lines) and lines[i].strip() == '':
+                i += 1
+            continue
+        # Image background patterns (single, non-vertical)
+        elif re.match(r'^!\[bg right:\d+%\]?\(images/[^\)]+\)', line):
+            match = re.match(r'^!\[bg right:(\d+)%\]?\(([^)]+)\)', line)
+            if match:
+                width = match.group(1)
+                img_path = match.group(2)
+                result.append(f'layout: image-right')
+                result.append(f'image: ./{img_path}')
+        # Img-grid div pattern
+        elif '<div class="img-grid"' in line:
+            # Extract images from grid until closing div
+            result.append('<div class="image-grid">')
+            i += 1
+            while i < len(lines) and '</div>' not in lines[i]:
+                img_match = re.search(r'<img src="([^"]+)"', lines[i])
+                if img_match:
+                    img_src = img_match.group(1)
+                    # Ensure path starts with ./
+                    if not img_src.startswith('./'):
+                        img_src = f'./{img_src}'
+                    result.append(f'<img src="{img_src}">')
+                i += 1
+            result.append('</div>')
+        # Columns div pattern - map to two-cols layout
+        elif '<div class="columns">' in line:
+            # We're already in two-cols layout, just skip the div wrapper
+            i += 1
+            continue
+        elif '<div class="col-left">' in line:
+            i += 1
+            continue
+        elif '<div class="col-right">' in line:
+            in_right_col = True
+            result.append('::right::')
+            i += 1
+            continue
+        elif '</div>' in line and (in_two_cols or in_right_col):
+            # End of column content
+            if in_right_col:
+                in_right_col = False
+            i += 1
+            continue
+        # Regular image (inline) - fix path
+        elif line.strip().startswith('![') and '](' in line:
+            # Keep as-is, will be fixed in post-process
+            result.append(line)
+        # Skip standalone ![bg] patterns (already handled in vertical block)
+        elif re.match(r'^!\[bg\]\(images/[^\)]+\)', line):
+            i += 1
+            continue
+        else:
+            result.append(line)
+        i += 1
+
+    # Post-process: fix all image paths to start with ./
+    content = '\n'.join(result)
+    # Fix HTML img tags: src="images/xxx" -> src="./images/xxx"
+    content = re.sub(r' src="(images/[^"]+)"', r' src="./\1"', content)
+    # Fix markdown images: ](images/xxx) -> ](./images/xxx)
+    content = re.sub(r'\]\((images/[^)]+)\)', r'](./\1)', content)
+    # Apply v-click animations from PPTX
+    content = apply_click_animations(content, slide_animations)
+    return content
+
+
+def convert_marp_to_slidev(marp_path: Path, slidev_path: Path, deck_name: str):
+    """Convert a Marp slides.marp.md to Slidev slides.md."""
+    with open(marp_path, encoding='utf-8') as f:
+        marp_content = f.read()
+
+    animations = read_animations(marp_path.parent)
+
+    # Parse global frontmatter
+    global_fm, rest = parse_frontmatter('\n'.join(['---'] + marp_content.split('\n')[1:]))
+
+    # Build Slidev frontmatter
+    slidev_fm = f"""---
+theme: ../theme-ia101
+title: "{deck_name}"
+info: Cours Intelligence Artificielle
+paginate: true
+drawings:
+  persist: false
+transition: slide-left
+mdc: true
+---
+
+"""
+
+    # Split into slides and convert each
+    marp_slides = split_slides(rest)
+    converted_slides = []
+
+    for i, slide in enumerate(marp_slides):
+        slide_num = i + 1
+        # Skip frontmatter slides
+        if slide.strip().startswith('marp:') or slide.strip().startswith('theme:'):
+            continue
+        converted = convert_slide_content(slide, slide_num, animations)
+        converted_slides.append(converted)
+
+    slidev_content = slidev_fm + '\n---\n\n'.join(converted_slides)
+
+    slidev_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(slidev_path, 'w', encoding='utf-8') as f:
+        f.write(slidev_content)
+
+    print(f"Converted: {marp_path.name} → {slidev_path.name} ({len(converted_slides)} slides)")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python marp_to_slidev.py <deck_name>")
+        print("Example: python marp_to_slidev.py 01-introduction")
+        sys.exit(1)
+
+    deck_name = sys.argv[1]
+    deck_dir = SLIDES_DIR / deck_name
+
+    marp_path = deck_dir / 'slides.marp.md'
+    slidev_path = deck_dir / 'slides.md'
+
+    if not marp_path.exists():
+        print(f"Error: {marp_path} not found")
+        sys.exit(1)
+
+    convert_marp_to_slidev(marp_path, slidev_path, deck_name.replace('-', ' ').title())
+
+
+if __name__ == '__main__':
+    main()

--- a/slides/_tools/pptx_to_marp.py
+++ b/slides/_tools/pptx_to_marp.py
@@ -1,0 +1,471 @@
+"""Convert extracted PowerPoint decks to Marp Markdown format.
+
+Reads the already-extracted artifacts (content.md, inventory.json, images/)
+and generates a Marp-compatible slides.md file per deck.
+
+Usage:
+    python pptx_to_marp.py slides/08-ia-generative
+    python pptx_to_marp.py --all
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+# Footers to strip from slide content
+FOOTER_PATTERNS = [
+    r'^IA 101$',
+    r'^CS 405$',
+    r'^Intelligence\(s\)$',
+    r'^CS405$',
+    r'^IA101$',
+]
+
+# Layout name -> Marp class mapping
+LAYOUT_CLASS_MAP = {
+    'Title Slide': 'title',
+    'Section Header': 'section',
+    'Blank': None,  # will detect Questions? slides separately
+}
+
+
+def parse_content_md(content_path: str) -> dict[int, dict]:
+    """Parse content.md into a dict of {slide_num: {title, body, notes}}."""
+    with open(content_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+
+    slides = {}
+    # Split by slide markers
+    parts = re.split(r'<!-- Slide number: (\d+) -->', text)
+    # parts[0] is before first marker (usually empty)
+    # parts[1] = slide number, parts[2] = content, parts[3] = number, parts[4] = content, ...
+    for i in range(1, len(parts), 2):
+        slide_num = int(parts[i])
+        raw_content = parts[i + 1].strip() if i + 1 < len(parts) else ''
+
+        # Split notes
+        notes_match = re.split(r'###\s*Notes:\s*', raw_content, maxsplit=1)
+        body = notes_match[0].strip()
+        notes = notes_match[1].strip() if len(notes_match) > 1 else ''
+
+        # Extract title (first # line)
+        title = ''
+        lines = body.split('\n')
+        body_lines = []
+        title_found = False
+        for line in lines:
+            if not title_found and line.startswith('# '):
+                title = line[2:].strip()
+                title_found = True
+            else:
+                body_lines.append(line)
+
+        body = '\n'.join(body_lines).strip()
+
+        slides[slide_num] = {
+            'title': title,
+            'body': body,
+            'notes': notes,
+        }
+
+    return slides
+
+
+def clean_slide_body(body: str, slide_num: int) -> str:
+    """Clean up slide body text: remove noise, format bullets."""
+    lines = body.split('\n')
+    cleaned = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Skip standalone slide numbers
+        if stripped == str(slide_num):
+            continue
+
+        # Skip footer patterns
+        skip = False
+        for pattern in FOOTER_PATTERNS:
+            if re.match(pattern, stripped):
+                skip = True
+                break
+        if skip:
+            continue
+
+        # Skip ALL markitdown image references (they point to internal PPTX names
+        # like Image6.jpg which don't exist in our structure - we use extracted images instead)
+        if re.match(r'^!\[.*\]\(.*\)$', stripped):
+            continue
+
+        cleaned.append(line)
+
+    # Remove leading/trailing blank lines
+    text = '\n'.join(cleaned).strip()
+
+    return text
+
+
+def map_images(deck_dir: str) -> dict[int, list[str]]:
+    """Map each slide number to its extracted image files."""
+    images_dir = os.path.join(deck_dir, 'extracted', 'images')
+    if not os.path.isdir(images_dir):
+        return {}
+
+    mapping = {}
+    for fname in sorted(os.listdir(images_dir)):
+        match = re.match(r'slide_(\d+)_img_\d+\.(png|jpg|jpeg|gif|bmp|svg)', fname, re.IGNORECASE)
+        if match:
+            slide_num = int(match.group(1))
+            mapping.setdefault(slide_num, []).append(fname)
+
+    return mapping
+
+
+def copy_images(deck_dir: str, image_map: dict[int, list[str]]) -> dict[str, str]:
+    """Copy images from extracted/images/ to deck/images/ with simplified names.
+
+    Returns a mapping of old_name -> new_name.
+    """
+    src_dir = os.path.join(deck_dir, 'extracted', 'images')
+    dst_dir = os.path.join(deck_dir, 'images')
+    os.makedirs(dst_dir, exist_ok=True)
+
+    name_map = {}
+    counter = 1
+
+    for slide_num in sorted(image_map.keys()):
+        for old_name in image_map[slide_num]:
+            ext = os.path.splitext(old_name)[1]
+            new_name = f'img_{counter:03d}{ext}'
+            src = os.path.join(src_dir, old_name)
+            dst = os.path.join(dst_dir, new_name)
+
+            if os.path.isfile(src):
+                shutil.copy2(src, dst)
+
+            name_map[old_name] = new_name
+            counter += 1
+
+    return name_map
+
+
+def load_inventory(deck_dir: str) -> dict:
+    """Load inventory.json and return slide metadata."""
+    inv_path = os.path.join(deck_dir, 'extracted', 'inventory.json')
+    if not os.path.isfile(inv_path):
+        return {}
+
+    with open(inv_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    # Index by slide number
+    slides_meta = {}
+    for slide in data.get('slides', []):
+        slides_meta[slide['number']] = slide
+
+    return slides_meta
+
+
+def detect_questions_slide(title: str, body: str) -> bool:
+    """Detect if a slide is a Questions? breathing slide."""
+    t = (title + ' ' + body).strip().lower()
+    return t in ('questions?', 'questions ?', 'questions', '?')
+
+
+def build_body_from_inventory(slide_meta: dict, slide_num: int) -> str | None:
+    """Try to build structured body from inventory text_content.
+
+    The inventory text_content preserves vertical tabs (\x0b) for sub-bullets
+    which gives us better hierarchy than content.md.
+    Returns None if inventory not available.
+    """
+    text_content = slide_meta.get('text_content', '')
+    if not text_content:
+        return None
+
+    title = slide_meta.get('title', '')
+    lines = text_content.split('\n')
+    result = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Skip the title (already handled separately)
+        if stripped == title:
+            continue
+        # Skip slide number
+        if stripped == str(slide_num):
+            continue
+        # Skip footers
+        skip = False
+        for pattern in FOOTER_PATTERNS:
+            if re.match(pattern, stripped):
+                skip = True
+                break
+        if skip:
+            continue
+
+        # Detect sub-bullets: lines containing vertical tab (\x0b) are sub-items
+        if '\x0b' in line:
+            # Split by vertical tab, each part after first is a sub-bullet
+            parts = line.split('\x0b')
+            for j, part in enumerate(parts):
+                p = part.strip()
+                if not p:
+                    continue
+                if j == 0:
+                    result.append(f'- **{p}**')
+                else:
+                    result.append(f'  - {p}')
+        else:
+            result.append(f'- {stripped}')
+
+    return '\n'.join(result) if result else None
+
+
+def generate_marp_slide(slide_num: int, slide_data: dict, slide_meta: dict,
+                         image_map: dict[int, list[str]], name_map: dict[str, str],
+                         deck_name: str) -> str:
+    """Generate Marp markdown for a single slide."""
+    title = slide_data['title']
+    body = clean_slide_body(slide_data['body'], slide_num)
+    notes = slide_data['notes']
+
+    layout_name = slide_meta.get('layout_name', 'Title and Content')
+    images = image_map.get(slide_num, [])
+
+    lines = []
+
+    # Determine slide class
+    marp_class = LAYOUT_CLASS_MAP.get(layout_name)
+
+    # Override: detect Questions? slides
+    if detect_questions_slide(title, body):
+        marp_class = 'questions'
+
+    # Add class directive if needed
+    if marp_class:
+        lines.append(f'<!-- _class: {marp_class} -->')
+        lines.append('')
+
+    # Title
+    if title:
+        lines.append(f'# {title}')
+        lines.append('')
+
+    # Body content
+    if marp_class != 'questions':
+        # Try inventory first (better hierarchy), fall back to content.md
+        inv_body = build_body_from_inventory(slide_meta, slide_num)
+        if inv_body:
+            lines.append(inv_body)
+            lines.append('')
+        elif body:
+            body_formatted = format_body_text(body)
+            lines.append(body_formatted)
+            lines.append('')
+
+    # Images
+    if images:
+        if len(images) == 1:
+            new_name = name_map.get(images[0], images[0])
+            if marp_class == 'title':
+                # Background image for title slides
+                lines.insert(0, f'![bg opacity:0.2](images/{new_name})')
+                lines.insert(1, '')
+            else:
+                # Side image for content slides
+                lines.append(f'![bg right:35%](images/{new_name})')
+                lines.append('')
+        elif len(images) == 2:
+            # Two images: one right, one below or both as bg
+            for img in images:
+                new_name = name_map.get(img, img)
+                lines.append(f'![w:400](images/{new_name})')
+            lines.append('')
+        else:
+            # Multiple images: inline with width
+            for img in images:
+                new_name = name_map.get(img, img)
+                lines.append(f'![w:250](images/{new_name})')
+            lines.append('')
+
+    # Notes
+    if notes:
+        lines.append(f'<!-- notes: {notes} -->')
+        lines.append('')
+
+    return '\n'.join(lines).rstrip()
+
+
+def format_body_text(body: str) -> str:
+    """Format body text: detect bullet structures, clean up."""
+    lines = body.split('\n')
+    result = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            result.append('')
+            continue
+
+        # Already has markdown formatting
+        if stripped.startswith(('- ', '* ', '> ', '1.', '2.', '3.', '4.', '5.',
+                                '6.', '7.', '8.', '9.', '#', '|', '```', '![',
+                                '<!--')):
+            result.append(line)
+            continue
+
+        # Detect indented lines (sub-bullets in extracted text)
+        leading_spaces = len(line) - len(line.lstrip())
+        if leading_spaces >= 4:
+            result.append(f'  - {stripped}')
+        elif leading_spaces >= 2:
+            result.append(f'  - {stripped}')
+        else:
+            # Top-level text: add as bullet
+            result.append(f'- {stripped}')
+
+    return '\n'.join(result)
+
+
+def generate_frontmatter(deck_name: str, total_slides: int) -> str:
+    """Generate Marp frontmatter."""
+    return f"""---
+marp: true
+theme: ia101
+paginate: true
+header: 'IA 101'
+footer: '{deck_name}'
+---"""
+
+
+# Mapping directory name -> clean display name for footer
+DECK_DISPLAY_NAMES = {
+    '01-introduction': 'I - Introduction',
+    '02-resolution-problemes': 'II - Resolution de problemes',
+    '03-logique': 'III - Logique',
+    '04-probabilites': 'IV - Probabilites',
+    '05-theorie-des-jeux': 'V - Theorie des jeux',
+    '06-apprentissage': 'VI - Apprentissage',
+    '07-elargissements': 'VII - Elargissements',
+    '08-ia-generative': 'VIII - IA Generative',
+    'S1-argumentation': 'S1 - Argumentation',
+    'S2-ia-exploratoire-symbolique': 'S2 - IA Exploratoire et Symbolique',
+    'S3-acculturation': 'S3 - Acculturation',
+    'S4-trading-algorithmique': 'S4 - Trading Algorithmique',
+}
+
+
+def convert_deck(deck_dir: str, verbose: bool = True) -> str:
+    """Convert a full deck to Marp format. Returns path to generated slides.md."""
+    deck_dir = os.path.normpath(deck_dir)
+    dir_name = os.path.basename(deck_dir)
+    deck_name = DECK_DISPLAY_NAMES.get(dir_name, dir_name.replace('-', ' ').title())
+
+    if verbose:
+        print(f"Converting: {deck_dir}")
+
+    # Load data
+    content_path = os.path.join(deck_dir, 'extracted', 'content.md')
+    if not os.path.isfile(content_path):
+        print(f"  ERROR: {content_path} not found")
+        return ''
+
+    slides_data = parse_content_md(content_path)
+    slides_meta = load_inventory(deck_dir)
+    image_map = map_images(deck_dir)
+
+    if verbose:
+        print(f"  Slides: {len(slides_data)}, Images: {sum(len(v) for v in image_map.values())}")
+
+    # Copy images
+    name_map = copy_images(deck_dir, image_map)
+    if verbose and name_map:
+        print(f"  Copied {len(name_map)} images to images/")
+
+    # Generate Marp markdown
+    output_lines = [generate_frontmatter(deck_name, len(slides_data))]
+
+    for slide_num in sorted(slides_data.keys()):
+        slide_data = slides_data[slide_num]
+        meta = slides_meta.get(slide_num, {})
+
+        slide_md = generate_marp_slide(
+            slide_num, slide_data, meta,
+            image_map, name_map, deck_name
+        )
+
+        output_lines.append('')
+        output_lines.append('---')
+        output_lines.append('')
+        output_lines.append(slide_md)
+
+    # Write output
+    output_path = os.path.join(deck_dir, 'slides.md')
+    content = '\n'.join(output_lines) + '\n'
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+    if verbose:
+        print(f"  Generated: {output_path}")
+
+    return output_path
+
+
+def find_all_decks(slides_root: str) -> list[str]:
+    """Find all deck directories under slides/."""
+    decks = []
+    for entry in sorted(os.listdir(slides_root)):
+        deck_dir = os.path.join(slides_root, entry)
+        content_path = os.path.join(deck_dir, 'extracted', 'content.md')
+        if os.path.isdir(deck_dir) and os.path.isfile(content_path):
+            decks.append(deck_dir)
+    return decks
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert extracted PPTX to Marp Markdown')
+    parser.add_argument('deck_dir', nargs='?', help='Path to a deck directory')
+    parser.add_argument('--all', action='store_true', help='Convert all decks under slides/')
+    parser.add_argument('--slides-root', default=None, help='Root slides directory')
+    parser.add_argument('-q', '--quiet', action='store_true', help='Suppress output')
+    args = parser.parse_args()
+
+    # Determine slides root
+    if args.slides_root:
+        slides_root = args.slides_root
+    else:
+        # Auto-detect: look for slides/ relative to script location
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        slides_root = os.path.dirname(script_dir)  # parent of _tools/
+
+    verbose = not args.quiet
+
+    if args.all:
+        decks = find_all_decks(slides_root)
+        if not decks:
+            print(f"No decks found under {slides_root}")
+            sys.exit(1)
+        print(f"Converting {len(decks)} decks...")
+        for deck_dir in decks:
+            convert_deck(deck_dir, verbose)
+        print(f"\nDone. {len(decks)} decks converted.")
+    elif args.deck_dir:
+        path = convert_deck(args.deck_dir, verbose)
+        if not path:
+            sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/slides/_tools/slide_inventory.py
+++ b/slides/_tools/slide_inventory.py
@@ -1,0 +1,344 @@
+"""
+slide_inventory.py - Batch inventory of student presentations.
+
+Scans multiple source directories for presentation files (.pptx, .ppt, .pdf, .odp)
+and generates a structured catalog with metadata, topic classification, and quality hints.
+
+Usage:
+    python slide_inventory.py scan [--sources FILE] [--output JSON]
+    python slide_inventory.py classify [--catalog JSON]
+    python slide_inventory.py report [--catalog JSON]
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Topic classification keywords
+# ---------------------------------------------------------------------------
+
+TOPIC_KEYWORDS = {
+    "search-csp": [
+        "sudoku", "backtracking", "constraint", "csp", "coloration", "graphe",
+        "dancing link", "dlx", "norvig", "a*", "bfs", "dfs", "genetic",
+        "exploration", "heuristique", "optimisation", "knapsack", "tsp",
+    ],
+    "game-theory": [
+        "game", "jeu", "nash", "minimax", "alpha-beta", "go ", "poker",
+        "trueskill", "cooperative", "strateg", "equilibr", "theorie des jeux",
+        "cfr", "regret", "echec", "chess",
+    ],
+    "ml-dl": [
+        "machine learning", "apprentissage", "neural", "deep learning", "cnn",
+        "classification", "regression", "random forest", "svm", "tensorflow",
+        "sentiment", "cancer", "detection", "image", "transfer learning",
+        "reseau de neurone", "perceptron", "pytorch", "keras", "sklearn",
+    ],
+    "probas": [
+        "probabilit", "bayes", "markov", "hmm", "infer", "gaussian",
+        "incertitude", "monte carlo", "stochast",
+    ],
+    "nlp": [
+        "langage", "nlp", "chatbot", "sentiment", "text", "bert", "gpt",
+        "traitement.*langue", "natural language", "tok",
+    ],
+    "trading": [
+        "trading", "finance", "portfolio", "crypto", "bitcoin", "quantconnect",
+        "algorithmique.*trading", "bourse", "action",
+    ],
+    "genai": [
+        "generati", "gan", "diffusion", "dall-e", "stable diffusion",
+        "ia generative", "llm", "chatgpt", "image.*generat",
+    ],
+    "medical": [
+        "medical", "cancer", "asthme", "diagnostic", "sante", "health",
+        "tumeur", "breast", "clinical",
+    ],
+}
+
+# Presentation file extensions to scan
+PRESENTATION_EXTENSIONS = {".pptx", ".ppt", ".odp", ".pdf", ".gslides", ".key"}
+
+
+@dataclass
+class PresentationEntry:
+    """Metadata for a single presentation file."""
+    filepath: str
+    filename: str
+    extension: str
+    file_size_mb: float
+    source_dir: str
+    school: str = ""
+    year: str = ""
+    topic: str = "misc"
+    topic_confidence: float = 0.0
+    slide_count: int = 0
+    image_count: int = 0
+    title_text: str = ""
+
+
+def scan_directory(root_dir: str, source_label: str = "") -> list:
+    """Scan a directory tree for presentation files.
+
+    Args:
+        root_dir: Root directory to scan.
+        source_label: Label for this source (e.g., "dropbox", "gdrive").
+
+    Returns:
+        List of PresentationEntry objects.
+    """
+    entries = []
+    root = Path(root_dir)
+
+    if not root.exists():
+        print(f"WARNING: Directory not found: {root_dir}")
+        return entries
+
+    for filepath in root.rglob("*"):
+        if filepath.suffix.lower() in PRESENTATION_EXTENSIONS:
+            try:
+                size_mb = filepath.stat().st_size / (1024 * 1024)
+            except OSError:
+                size_mb = 0
+
+            entry = PresentationEntry(
+                filepath=str(filepath),
+                filename=filepath.name,
+                extension=filepath.suffix.lower(),
+                file_size_mb=round(size_mb, 2),
+                source_dir=source_label or root_dir,
+            )
+
+            # Try to extract school and year from path
+            parts = filepath.relative_to(root).parts
+            for part in parts:
+                if part in ("EPF", "ECE", "ORT", "Epita", "ESGF", "ESIEE",
+                            "Simplon", "Aston", "Monaco"):
+                    entry.school = part
+                if part.isdigit() and len(part) == 4 and 2015 <= int(part) <= 2030:
+                    entry.year = part
+
+            entries.append(entry)
+
+    return entries
+
+
+def classify_entry(entry: PresentationEntry) -> PresentationEntry:
+    """Classify a presentation entry by topic using keyword matching.
+
+    Args:
+        entry: PresentationEntry to classify.
+
+    Returns:
+        The same entry with topic and topic_confidence set.
+    """
+    # Build search text from filename + path
+    search_text = (entry.filename + " " + entry.filepath).lower()
+
+    best_topic = "misc"
+    best_score = 0
+
+    for topic, keywords in TOPIC_KEYWORDS.items():
+        score = 0
+        for keyword in keywords:
+            if keyword.lower() in search_text:
+                score += 1
+        if score > best_score:
+            best_score = score
+            best_topic = topic
+
+    entry.topic = best_topic
+    entry.topic_confidence = min(best_score / 3.0, 1.0)  # Normalize to [0, 1]
+    return entry
+
+
+def enrich_pptx_metadata(entry: PresentationEntry) -> PresentationEntry:
+    """Enrich a PPTX entry with slide count and title (via python-pptx).
+
+    Args:
+        entry: PresentationEntry for a .pptx file.
+
+    Returns:
+        The same entry with slide_count, image_count, title_text set.
+    """
+    if entry.extension != ".pptx":
+        return entry
+
+    try:
+        from pptx import Presentation
+        from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+        prs = Presentation(entry.filepath)
+        entry.slide_count = len(prs.slides)
+
+        # Get title from first slide
+        if prs.slides and prs.slides[0].shapes.title:
+            entry.title_text = prs.slides[0].shapes.title.text.strip()[:200]
+
+        # Count images
+        for slide in prs.slides:
+            for shape in slide.shapes:
+                if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                    entry.image_count += 1
+
+    except Exception as e:
+        print(f"  WARNING: Could not read {entry.filename}: {e}")
+
+    return entry
+
+
+def build_catalog(sources: list, enrich: bool = True) -> list:
+    """Build a full catalog from multiple source directories.
+
+    Args:
+        sources: List of (directory_path, source_label) tuples.
+        enrich: Whether to enrich PPTX files with metadata (slower).
+
+    Returns:
+        List of PresentationEntry objects.
+    """
+    all_entries = []
+
+    for directory, label in sources:
+        print(f"Scanning: {label} ({directory})")
+        entries = scan_directory(directory, label)
+        print(f"  Found {len(entries)} presentation files")
+        all_entries.extend(entries)
+
+    print(f"\nTotal files found: {len(all_entries)}")
+
+    # Classify all entries
+    print("Classifying by topic...")
+    for entry in all_entries:
+        classify_entry(entry)
+
+    # Enrich PPTX files
+    if enrich:
+        pptx_entries = [e for e in all_entries if e.extension == ".pptx"]
+        print(f"Enriching {len(pptx_entries)} PPTX files with metadata...")
+        for i, entry in enumerate(pptx_entries, 1):
+            enrich_pptx_metadata(entry)
+            if i % 20 == 0:
+                print(f"  Enriched {i}/{len(pptx_entries)}")
+
+    return all_entries
+
+
+def save_catalog(entries: list, output_path: str):
+    """Save catalog to JSON file."""
+    data = [asdict(e) for e in entries]
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    print(f"Catalog saved to: {output_path} ({len(entries)} entries)")
+
+
+def print_report(entries: list):
+    """Print a summary report of the catalog."""
+    print(f"\n{'='*60}")
+    print(f"PRESENTATION CATALOG REPORT")
+    print(f"{'='*60}")
+    print(f"Total entries: {len(entries)}")
+
+    # By extension
+    ext_counts = {}
+    for e in entries:
+        ext_counts[e.extension] = ext_counts.get(e.extension, 0) + 1
+    print(f"\nBy format:")
+    for ext, count in sorted(ext_counts.items(), key=lambda x: -x[1]):
+        print(f"  {ext}: {count}")
+
+    # By school
+    school_counts = {}
+    for e in entries:
+        school = e.school or "(unknown)"
+        school_counts[school] = school_counts.get(school, 0) + 1
+    print(f"\nBy school:")
+    for school, count in sorted(school_counts.items(), key=lambda x: -x[1]):
+        print(f"  {school}: {count}")
+
+    # By topic
+    topic_counts = {}
+    for e in entries:
+        topic_counts[e.topic] = topic_counts.get(e.topic, 0) + 1
+    print(f"\nBy topic:")
+    for topic, count in sorted(topic_counts.items(), key=lambda x: -x[1]):
+        print(f"  {topic}: {count}")
+
+    # By source
+    source_counts = {}
+    for e in entries:
+        source_counts[e.source_dir] = source_counts.get(e.source_dir, 0) + 1
+    print(f"\nBy source:")
+    for source, count in sorted(source_counts.items(), key=lambda x: -x[1]):
+        print(f"  {source}: {count}")
+
+    # Top PPTX by visual richness (image_count / slide_count)
+    pptx_entries = [e for e in entries if e.extension == ".pptx" and e.slide_count > 0]
+    if pptx_entries:
+        pptx_entries.sort(key=lambda e: e.image_count / max(e.slide_count, 1), reverse=True)
+        print(f"\nTop 20 visually richest PPTX:")
+        for e in pptx_entries[:20]:
+            density = e.image_count / e.slide_count
+            print(f"  [{e.topic}] {e.filename} ({e.slide_count}s, {e.image_count}img, density={density:.1f}) - {e.school}")
+
+
+# ---------------------------------------------------------------------------
+# Default sources
+# ---------------------------------------------------------------------------
+
+DEFAULT_SOURCES = [
+    (r"D:\Dropbox\IA101\2017", "dropbox-2017"),
+    (r"D:\Dropbox\IA101\2018", "dropbox-2018"),
+    (r"D:\Dropbox\IA101\2019", "dropbox-2019"),
+    (r"D:\Dropbox\IA101\2020", "dropbox-2020"),
+    (r"D:\Dropbox\IA101\2021", "dropbox-2021"),
+    (r"D:\Dropbox\IA101\Vulgarisation", "dropbox-vulgarisation"),
+    (r"G:\Mon Drive\MyIA\Formation\EPF", "gdrive-EPF"),
+    (r"G:\Mon Drive\MyIA\Formation\ECE", "gdrive-ECE"),
+    (r"G:\Mon Drive\MyIA\Formation\Epita", "gdrive-Epita"),
+    (r"G:\Mon Drive\MyIA\Formation\ESGF", "gdrive-ESGF"),
+]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Student presentation inventory tool")
+    subparsers = parser.add_subparsers(dest="command")
+
+    p_scan = subparsers.add_parser("scan", help="Scan directories and build catalog")
+    p_scan.add_argument("--output", default="d:/dev/CoursIA/slides/_assets/student-catalog.json",
+                        help="Output JSON path")
+    p_scan.add_argument("--no-enrich", action="store_true",
+                        help="Skip PPTX metadata enrichment (faster)")
+
+    p_report = subparsers.add_parser("report", help="Print report from existing catalog")
+    p_report.add_argument("--catalog", default="d:/dev/CoursIA/slides/_assets/student-catalog.json",
+                          help="Catalog JSON path")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    if args.command == "scan":
+        entries = build_catalog(DEFAULT_SOURCES, enrich=not args.no_enrich)
+        save_catalog(entries, args.output)
+        print_report(entries)
+
+    elif args.command == "report":
+        with open(args.catalog, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        entries = [PresentationEntry(**d) for d in data]
+        print_report(entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/slides/_tools/slide_tools.py
+++ b/slides/_tools/slide_tools.py
@@ -1,0 +1,682 @@
+"""
+slide_tools.py - Outils d'extraction, de rendu et d'analyse de slides PowerPoint et Marp.
+
+Usage:
+    python slide_tools.py render <pptx_path> [--outdir DIR] [--width W] [--height H]
+    python slide_tools.py extract <pptx_path> [--outdir DIR]
+    python slide_tools.py inventory <pptx_path> [--output JSON_PATH]
+    python slide_tools.py batch-render <directory> [--outdir DIR]
+    python slide_tools.py batch-extract <directory> [--outdir DIR]
+    python slide_tools.py marp-render <deck_path> [--scale N]
+    python slide_tools.py marp-render-all [--scale N]
+    python slide_tools.py check-refs <deck_path>
+    python slide_tools.py compare <deck_path>
+
+Requires:
+    - pywin32 (COM automation for PowerPoint rendering)
+    - python-pptx (PPTX reading/writing)
+    - markitdown (text extraction to markdown)
+    - marp-cli (npm: @marp-team/marp-cli, for Marp rendering)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SlideInfo:
+    """Metadata for a single slide."""
+    number: int
+    title: str = ""
+    text_content: str = ""
+    word_count: int = 0
+    image_count: int = 0
+    shape_count: int = 0
+    has_title: bool = False
+    layout_name: str = ""
+    notes: str = ""
+
+
+@dataclass
+class DeckInventory:
+    """Full inventory of a PPTX deck."""
+    filename: str
+    filepath: str
+    slide_count: int = 0
+    total_images: int = 0
+    total_words: int = 0
+    file_size_mb: float = 0.0
+    slides: list = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Rendering (PowerPoint COM via pywin32)
+# ---------------------------------------------------------------------------
+
+def render_slides(pptx_path: str, output_dir: str, width: int = 1920, height: int = 1080) -> int:
+    """Export each slide of a PPTX to PNG via PowerPoint COM automation.
+
+    Args:
+        pptx_path: Path to the PPTX file.
+        output_dir: Directory where PNGs will be saved.
+        width: Output image width in pixels.
+        height: Output image height in pixels.
+
+    Returns:
+        Number of slides rendered.
+    """
+    try:
+        import win32com.client
+        import pythoncom
+    except ImportError:
+        print("ERROR: pywin32 is required for rendering. Install with: pip install pywin32")
+        sys.exit(1)
+
+    # Ensure absolute paths (COM requires them)
+    pptx_path = os.path.abspath(pptx_path)
+    output_dir = os.path.abspath(output_dir)
+
+    if not os.path.exists(pptx_path):
+        print(f"ERROR: File not found: {pptx_path}")
+        sys.exit(1)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Initialize COM in this thread
+    pythoncom.CoInitialize()
+
+    try:
+        ppt = win32com.client.Dispatch("PowerPoint.Application")
+        # Open presentation read-only, no window
+        presentation = ppt.Presentations.Open(
+            pptx_path,
+            ReadOnly=True,
+            Untitled=False,
+            WithWindow=False
+        )
+
+        slide_count = presentation.Slides.Count
+        print(f"Rendering {slide_count} slides from: {os.path.basename(pptx_path)}")
+
+        for i in range(1, slide_count + 1):
+            slide = presentation.Slides(i)
+            out_path = os.path.join(output_dir, f"slide_{i:02d}.png")
+            slide.Export(out_path, "PNG", width, height)
+            if i % 10 == 0 or i == slide_count:
+                print(f"  Rendered {i}/{slide_count}")
+
+        presentation.Close()
+        print(f"Done: {slide_count} slides -> {output_dir}")
+        return slide_count
+
+    except Exception as e:
+        print(f"ERROR during rendering: {e}")
+        raise
+    finally:
+        pythoncom.CoUninitialize()
+
+
+def batch_render(directory: str, output_base: str = None, width: int = 1920, height: int = 1080) -> dict:
+    """Render all PPTX files in a directory.
+
+    Args:
+        directory: Directory containing PPTX files.
+        output_base: Base output directory. If None, renders to extracted/renders/ subdirs.
+        width: Output image width.
+        height: Output image height.
+
+    Returns:
+        Dict mapping filename -> slide count.
+    """
+    results = {}
+    pptx_files = sorted(Path(directory).rglob("*.pptx"))
+
+    if not pptx_files:
+        print(f"No PPTX files found in: {directory}")
+        return results
+
+    print(f"Found {len(pptx_files)} PPTX files to render")
+
+    for pptx_path in pptx_files:
+        if output_base:
+            out_dir = os.path.join(output_base, pptx_path.stem)
+        else:
+            out_dir = os.path.join(os.path.dirname(pptx_path), "renders")
+
+        try:
+            count = render_slides(str(pptx_path), out_dir, width, height)
+            results[pptx_path.name] = count
+        except Exception as e:
+            print(f"FAILED: {pptx_path.name} - {e}")
+            results[pptx_path.name] = -1
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Marp rendering (marp-cli)
+# ---------------------------------------------------------------------------
+
+# Root of the slides directory (relative to this script)
+SLIDES_ROOT = Path(__file__).resolve().parent.parent
+THEME_PATH = SLIDES_ROOT / "themes" / "ia101.css"
+
+# All deck directory names
+DECK_NAMES = [
+    "01-introduction", "02-resolution-problemes", "03-logique",
+    "04-probabilites", "05-theorie-des-jeux", "06-apprentissage",
+    "07-elargissements", "08-ia-generative",
+    "S1-argumentation", "S2-ia-exploratoire-symbolique",
+    "S3-acculturation", "S4-trading-algorithmique",
+]
+
+
+def render_marp(deck_path: str, scale: int = 2) -> list:
+    """Render a Marp slides.md to individual PNG images via marp-cli.
+
+    Args:
+        deck_path: Path to the deck directory (must contain slides.md).
+        scale: Image scale factor (default 2 for high-DPI).
+
+    Returns:
+        List of generated PNG file paths.
+    """
+    import subprocess
+
+    deck_path = Path(deck_path).resolve()
+    slides_md = deck_path / "slides.md"
+    output_dir = deck_path / "output" / "marp_renders"
+
+    if not slides_md.exists():
+        print(f"ERROR: {slides_md} not found")
+        return []
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Output base: slide.png -> produces slide.001.png, slide.002.png, ...
+    output_base = output_dir / "slide.png"
+
+    cmd = [
+        "npx", "@marp-team/marp-cli",
+        str(slides_md),
+        "--images", "png",
+        "--image-scale", str(scale),
+        "--html",
+        "--allow-local-files",
+        "--theme-set", str(THEME_PATH),
+        "-o", str(output_base),
+    ]
+
+    print(f"Rendering Marp: {deck_path.name}")
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=120,
+            cwd=str(SLIDES_ROOT),
+        )
+        if result.returncode != 0:
+            print(f"  ERROR: marp-cli failed:\n{result.stderr}")
+            return []
+    except subprocess.TimeoutExpired:
+        print("  ERROR: marp-cli timed out (120s)")
+        return []
+    except FileNotFoundError:
+        print("  ERROR: marp-cli not found. Install with: npm i -g @marp-team/marp-cli")
+        return []
+
+    # Collect generated PNGs
+    pngs = sorted(output_dir.glob("slide.*.png"))
+    print(f"  Generated {len(pngs)} slides -> {output_dir}")
+    return [str(p) for p in pngs]
+
+
+def render_all_marp(scale: int = 2) -> dict:
+    """Render all Marp decks to PNG.
+
+    Returns:
+        Dict mapping deck name -> number of slides rendered.
+    """
+    results = {}
+    for deck_name in DECK_NAMES:
+        deck_path = SLIDES_ROOT / deck_name
+        if (deck_path / "slides.md").exists():
+            pngs = render_marp(str(deck_path), scale)
+            results[deck_name] = len(pngs)
+        else:
+            print(f"  SKIP: {deck_name} (no slides.md)")
+            results[deck_name] = 0
+    return results
+
+
+def check_image_refs(deck_path: str) -> dict:
+    """Check that all image references in slides.md exist on disk.
+
+    Args:
+        deck_path: Path to the deck directory.
+
+    Returns:
+        Dict with 'found', 'missing', and 'unreferenced' image lists.
+    """
+    import re
+
+    deck_path = Path(deck_path).resolve()
+    slides_md = deck_path / "slides.md"
+    images_dir = deck_path / "images"
+
+    if not slides_md.exists():
+        print(f"ERROR: {slides_md} not found")
+        return {}
+
+    content = slides_md.read_text(encoding="utf-8")
+
+    # Find all image references in markdown and HTML
+    md_refs = set(re.findall(r'images/[^\s\)\]"]+', content))
+
+    # Check existence
+    found = []
+    missing = []
+    for ref in sorted(md_refs):
+        full_path = deck_path / ref
+        if full_path.exists():
+            found.append(ref)
+        else:
+            missing.append(ref)
+
+    # Find unreferenced images
+    unreferenced = []
+    if images_dir.exists():
+        on_disk = {f"images/{f.name}" for f in images_dir.iterdir() if f.is_file()}
+        unreferenced = sorted(on_disk - md_refs)
+
+    result = {
+        "found": found,
+        "missing": missing,
+        "unreferenced": unreferenced,
+        "total_refs": len(md_refs),
+        "total_on_disk": len(found) + len(unreferenced),
+    }
+
+    print(f"Image refs in {deck_path.name}:")
+    print(f"  Referenced: {len(md_refs)} ({len(found)} found, {len(missing)} missing)")
+    if missing:
+        for m in missing:
+            print(f"    MISSING: {m}")
+    if unreferenced:
+        print(f"  Unreferenced on disk: {len(unreferenced)}")
+
+    return result
+
+
+def compare_slide_counts(deck_path: str) -> dict:
+    """Compare PPTX vs Marp slide counts for a deck.
+
+    Args:
+        deck_path: Path to the deck directory.
+
+    Returns:
+        Dict with pptx_count, marp_count, and drift.
+    """
+    deck_path = Path(deck_path).resolve()
+
+    # Count PPTX renders
+    pptx_renders = sorted((deck_path / "extracted" / "renders").glob("slide_*.png"))
+    pptx_count = len(pptx_renders)
+
+    # Count Marp slides (by --- separators)
+    slides_md = deck_path / "slides.md"
+    marp_count = 0
+    if slides_md.exists():
+        content = slides_md.read_text(encoding="utf-8")
+        # Count slide separators (--- at start of line, not in frontmatter)
+        lines = content.split("\n")
+        in_frontmatter = False
+        for i, line in enumerate(lines):
+            if i == 0 and line.strip() == "---":
+                in_frontmatter = True
+                continue
+            if in_frontmatter and line.strip() == "---":
+                in_frontmatter = False
+                continue
+            if not in_frontmatter and line.strip() == "---":
+                marp_count += 1
+        marp_count += 1  # First slide (before any ---)
+
+    result = {
+        "deck": deck_path.name,
+        "pptx_slides": pptx_count,
+        "marp_slides": marp_count,
+        "drift": marp_count - pptx_count,
+    }
+
+    drift_str = f"+{result['drift']}" if result['drift'] > 0 else str(result['drift'])
+    print(f"{deck_path.name}: PPTX={pptx_count}, Marp={marp_count}, drift={drift_str}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Text extraction (MarkItDown)
+# ---------------------------------------------------------------------------
+
+def extract_text(pptx_path: str, output_path: str = None) -> str:
+    """Extract text content from PPTX using MarkItDown.
+
+    Args:
+        pptx_path: Path to the PPTX file.
+        output_path: Optional path to save the markdown output.
+
+    Returns:
+        Markdown text content.
+    """
+    try:
+        from markitdown import MarkItDown
+    except ImportError:
+        print("ERROR: markitdown is required. Install with: pip install markitdown")
+        sys.exit(1)
+
+    md = MarkItDown()
+    result = md.convert(pptx_path)
+    text = result.text_content
+
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(text)
+        print(f"Text extracted to: {output_path}")
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Image extraction (python-pptx)
+# ---------------------------------------------------------------------------
+
+def extract_images(pptx_path: str, output_dir: str) -> int:
+    """Extract all embedded images from a PPTX file.
+
+    Args:
+        pptx_path: Path to the PPTX file.
+        output_dir: Directory to save extracted images.
+
+    Returns:
+        Number of images extracted.
+    """
+    from pptx import Presentation
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    prs = Presentation(pptx_path)
+    os.makedirs(output_dir, exist_ok=True)
+    count = 0
+
+    for slide_num, slide in enumerate(prs.slides, 1):
+        for shape in slide.shapes:
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                image = shape.image
+                ext = image.content_type.split("/")[-1]
+                if ext == "jpeg":
+                    ext = "jpg"
+                elif ext == "x-emf":
+                    ext = "emf"
+                elif ext == "x-wmf":
+                    ext = "wmf"
+                filename = f"slide_{slide_num:02d}_img_{count:03d}.{ext}"
+                filepath = os.path.join(output_dir, filename)
+                with open(filepath, "wb") as f:
+                    f.write(image.blob)
+                count += 1
+
+    print(f"Extracted {count} images from {os.path.basename(pptx_path)} -> {output_dir}")
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Inventory generation (python-pptx)
+# ---------------------------------------------------------------------------
+
+def generate_inventory(pptx_path: str, output_path: str = None) -> DeckInventory:
+    """Generate a structured inventory of a PPTX deck.
+
+    Args:
+        pptx_path: Path to the PPTX file.
+        output_path: Optional path to save the JSON inventory.
+
+    Returns:
+        DeckInventory object.
+    """
+    from pptx import Presentation
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+    prs = Presentation(pptx_path)
+    file_size = os.path.getsize(pptx_path) / (1024 * 1024)
+
+    inventory = DeckInventory(
+        filename=os.path.basename(pptx_path),
+        filepath=os.path.abspath(pptx_path),
+        slide_count=len(prs.slides),
+        file_size_mb=round(file_size, 2),
+    )
+
+    for slide_num, slide in enumerate(prs.slides, 1):
+        info = SlideInfo(number=slide_num)
+
+        # Layout name
+        if slide.slide_layout:
+            info.layout_name = slide.slide_layout.name
+
+        # Title
+        if slide.shapes.title:
+            info.title = slide.shapes.title.text.strip()
+            info.has_title = bool(info.title)
+
+        # Process all shapes
+        texts = []
+        for shape in slide.shapes:
+            info.shape_count += 1
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                info.image_count += 1
+            if shape.has_text_frame:
+                for para in shape.text_frame.paragraphs:
+                    text = para.text.strip()
+                    if text:
+                        texts.append(text)
+
+        info.text_content = "\n".join(texts)
+        info.word_count = len(info.text_content.split())
+
+        # Notes
+        if slide.has_notes_slide and slide.notes_slide.notes_text_frame:
+            info.notes = slide.notes_slide.notes_text_frame.text.strip()
+
+        inventory.slides.append(info)
+        inventory.total_images += info.image_count
+        inventory.total_words += info.word_count
+
+    if output_path:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(asdict(inventory), f, indent=2, ensure_ascii=False)
+        print(f"Inventory saved to: {output_path}")
+
+    return inventory
+
+
+# ---------------------------------------------------------------------------
+# Full extraction pipeline
+# ---------------------------------------------------------------------------
+
+def full_extract(pptx_path: str, output_base: str, render: bool = True,
+                 width: int = 1920, height: int = 1080) -> dict:
+    """Run the full extraction pipeline on a single PPTX.
+
+    Args:
+        pptx_path: Path to the PPTX file.
+        output_base: Base directory for outputs (e.g., slides/01-introduction/extracted/).
+        render: Whether to render slides as PNG (requires PowerPoint).
+        width: Render width.
+        height: Render height.
+
+    Returns:
+        Dict with paths to all generated artifacts.
+    """
+    os.makedirs(output_base, exist_ok=True)
+    results = {"pptx": pptx_path}
+
+    # 1. Render slides as PNG
+    if render:
+        renders_dir = os.path.join(output_base, "renders")
+        try:
+            count = render_slides(pptx_path, renders_dir, width, height)
+            results["renders"] = renders_dir
+            results["render_count"] = count
+        except Exception as e:
+            print(f"WARNING: Rendering failed: {e}")
+            results["renders"] = None
+
+    # 2. Extract text
+    text_path = os.path.join(output_base, "content.md")
+    extract_text(pptx_path, text_path)
+    results["text"] = text_path
+
+    # 3. Extract images
+    images_dir = os.path.join(output_base, "images")
+    img_count = extract_images(pptx_path, images_dir)
+    results["images"] = images_dir
+    results["image_count"] = img_count
+
+    # 4. Generate inventory
+    inventory_path = os.path.join(output_base, "inventory.json")
+    inventory = generate_inventory(pptx_path, inventory_path)
+    results["inventory"] = inventory_path
+    results["slide_count"] = inventory.slide_count
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Slide tools: render, extract, and analyze PowerPoint presentations.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # render
+    p_render = subparsers.add_parser("render", help="Render slides to PNG via PowerPoint COM")
+    p_render.add_argument("pptx_path", help="Path to PPTX file")
+    p_render.add_argument("--outdir", help="Output directory", default=None)
+    p_render.add_argument("--width", type=int, default=1920, help="Image width (default: 1920)")
+    p_render.add_argument("--height", type=int, default=1080, help="Image height (default: 1080)")
+
+    # extract
+    p_extract = subparsers.add_parser("extract", help="Full extraction (render + text + images + inventory)")
+    p_extract.add_argument("pptx_path", help="Path to PPTX file")
+    p_extract.add_argument("--outdir", help="Output base directory", default=None)
+    p_extract.add_argument("--no-render", action="store_true", help="Skip PNG rendering")
+
+    # inventory
+    p_inv = subparsers.add_parser("inventory", help="Generate JSON inventory of a PPTX")
+    p_inv.add_argument("pptx_path", help="Path to PPTX file")
+    p_inv.add_argument("--output", help="Output JSON path", default=None)
+
+    # batch-render
+    p_batch = subparsers.add_parser("batch-render", help="Render all PPTX in a directory")
+    p_batch.add_argument("directory", help="Directory containing PPTX files")
+    p_batch.add_argument("--outdir", help="Base output directory", default=None)
+    p_batch.add_argument("--width", type=int, default=1920)
+    p_batch.add_argument("--height", type=int, default=1080)
+
+    # batch-extract
+    p_batchex = subparsers.add_parser("batch-extract", help="Full extraction on all PPTX in a directory")
+    p_batchex.add_argument("directory", help="Directory containing PPTX files")
+    p_batchex.add_argument("--outdir", help="Base output directory", default=None)
+    p_batchex.add_argument("--no-render", action="store_true", help="Skip PNG rendering")
+
+    # marp-render
+    p_marp = subparsers.add_parser("marp-render", help="Render Marp slides.md to PNG")
+    p_marp.add_argument("deck_path", help="Path to deck directory (e.g., slides/01-introduction)")
+    p_marp.add_argument("--scale", type=int, default=2, help="Image scale factor (default: 2)")
+
+    # marp-render-all
+    p_marp_all = subparsers.add_parser("marp-render-all", help="Render all Marp decks to PNG")
+    p_marp_all.add_argument("--scale", type=int, default=2, help="Image scale factor (default: 2)")
+
+    # check-refs
+    p_check = subparsers.add_parser("check-refs", help="Check image references in slides.md")
+    p_check.add_argument("deck_path", help="Path to deck directory")
+
+    # compare
+    p_compare = subparsers.add_parser("compare", help="Compare PPTX vs Marp slide counts")
+    p_compare.add_argument("deck_path", nargs="?", help="Path to deck directory (or all if omitted)")
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    if args.command == "render":
+        outdir = args.outdir or os.path.join(os.path.dirname(args.pptx_path), "renders")
+        render_slides(args.pptx_path, outdir, args.width, args.height)
+
+    elif args.command == "extract":
+        outdir = args.outdir or os.path.join(os.path.dirname(args.pptx_path), "extracted")
+        full_extract(args.pptx_path, outdir, render=not args.no_render)
+
+    elif args.command == "inventory":
+        output = args.output or args.pptx_path.replace(".pptx", "_inventory.json")
+        inv = generate_inventory(args.pptx_path, output)
+        print(f"Slides: {inv.slide_count}, Images: {inv.total_images}, Words: {inv.total_words}")
+
+    elif args.command == "batch-render":
+        results = batch_render(args.directory, args.outdir, args.width, args.height)
+        print(f"\nBatch complete: {len(results)} files processed")
+        for name, count in results.items():
+            status = f"{count} slides" if count >= 0 else "FAILED"
+            print(f"  {name}: {status}")
+
+    elif args.command == "batch-extract":
+        pptx_files = sorted(Path(args.directory).rglob("*.pptx"))
+        for pptx_path in pptx_files:
+            if args.outdir:
+                outdir = os.path.join(args.outdir, pptx_path.stem)
+            else:
+                outdir = os.path.join(os.path.dirname(str(pptx_path)), "extracted")
+            print(f"\n--- Processing: {pptx_path.name} ---")
+            full_extract(str(pptx_path), outdir, render=not args.no_render)
+
+    elif args.command == "marp-render":
+        render_marp(args.deck_path, args.scale)
+
+    elif args.command == "marp-render-all":
+        results = render_all_marp(args.scale)
+        print(f"\nBatch Marp render complete:")
+        for name, count in results.items():
+            print(f"  {name}: {count} slides")
+
+    elif args.command == "check-refs":
+        check_image_refs(args.deck_path)
+
+    elif args.command == "compare":
+        if hasattr(args, "deck_path") and args.deck_path:
+            compare_slide_counts(args.deck_path)
+        else:
+            print("Comparing all decks:")
+            for deck_name in DECK_NAMES:
+                deck_path = SLIDES_ROOT / deck_name
+                if (deck_path / "slides.md").exists():
+                    compare_slide_counts(str(deck_path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Recover 8 utility scripts from orphan branch `fix/genai-enrichment` into `slides/_tools/` before branch cleanup
- Scripts: Marp/Slidev/PPTX converters, animation extractor, batch processor, inventory tool, correction guide
- No secrets, no modifications - exact copy from orphan branch

## Files recovered
- `marp_to_slidev.py` (311 lines) - Marp to Slidev conversion
- `pptx_to_marp.py` (471 lines) - PPTX to Marp markdown conversion
- `slide_tools.py` (682 lines) - General slide manipulation utilities
- `compare_marp_pptx.py` (308 lines) - Marp vs PPTX visual comparison
- `extract_animations.py` (294 lines) - Animation extraction from slides
- `batch_extract_all.py` (72 lines) - Batch processing wrapper
- `slide_inventory.py` (344 lines) - Slide deck inventory/scanning
- `MARP_CORRECTION_GUIDE.md` (316 lines) - Correction guide documentation

## Test plan
- [x] All 8 files present and non-empty (2,798 total lines)
- [x] No secrets/API keys in any file
- [x] Python scripts have valid imports and class/function definitions
- [ ] Review each script for relevance (some may need updates for current tool versions)

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)