### PR TITLE
fix(lean): correct FORMAL_STATUS.md sorry counts and certification

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -57,23 +57,24 @@ sorry locations:
 
 ### Fully Certified (0 sorry)
 
-None yet.
+| Theorem | File | Statement |
+|---------|------|-----------|
+| `superadditive_empty_nonneg` | Basic.lean | Superadditive games have v(empty) >= 0 |
+| `superadditive_grand_coalition_nonneg_of_nonneg_singletons` | Basic.lean | Grand coalition value nonneg |
+| `shapley_efficient` | Shapley.lean | Shapley value is efficient |
+| `shapley_additive` | Shapley.lean | Shapley value is additive |
+| `dummy_shapley_zero` | Shapley.lean | Dummy players get zero Shapley value |
 
 ### Partially Proved (contains sorry)
 
 | Theorem | File | sorry | Statement |
 |---------|------|-------|-----------|
-| `superadditive_empty_nonneg` | Basic.lean | 0 | Superadditive games have v(empty) >= 0 |
-| `superadditive_grand_coalition_nonneg_of_nonneg_singletons` | Basic.lean | 0 | Grand coalition value nonneg |
 | `bondareva_shapski` | Basic.lean | 3 | Core nonempty iff balanced (Bondareva-Shapley) |
 | `convex_core_nonempty` | Basic.lean | 2 | Convex games have nonempty core |
 | `shapley_null_player` | Shapley.lean | 1 | Shapley value = 0 for null players |
 | `shapley_unanimity` | Shapley.lean | 1 | Shapley value on unanimity games |
-| `shapley_efficient` | Shapley.lean | 0 | Shapley value is efficient |
 | `shapley_symmetric` | Shapley.lean | 1 | Shapley value treats symmetric players equally |
-| `shapley_additive` | Shapley.lean | 0 | Shapley value is additive |
 | `shapley_uniqueness` | Shapley.lean | 1 | Shapley value is the unique solution satisfying axioms |
-| `dummy_shapley_zero` | Shapley.lean | 0 | Dummy players get zero Shapley value |
 
 ## Certification Level
 

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/FORMAL_STATUS.md
@@ -7,7 +7,7 @@
 | Lean toolchain | `leanprover/lean4:v4.29.1` |
 | Mathlib | `v4.29.1` (`5e932f97dd25`) |
 | Last CI verified | 2026-04-30 (CI GREEN) |
-| Total sorry | **0** (all files) |
+| Total sorry | **3** (Voting.lean only) |
 | Total lines | 1,872 |
 | Total theorems | 62 |
 | Total definitions | 60 |
@@ -78,13 +78,18 @@ Theorems:
 | Lines | 340 |
 | Definitions | 20 |
 | Theorems | 14 |
-| sorry | **0** |
-| Status | FORMAL-CERTIFIED |
+| sorry | **3** |
+| Status | FORMAL-PARTIAL |
 
 Key results: margin function antisymmetry, Condorcet winner uniqueness,
 Condorcet loser disjointness, single-peaked preferences, Split Cycle, clone properties.
 
 Port of chasenorman/Formalized-Voting.
+
+Sorry locations:
+- Line 231: proof requires Finset counting + sorting machinery
+- Line 298: needs IsChain construction for rotated list
+- Line 304: needs List.IsChain contradiction on irreflexive transitive relation
 
 ## Theorem Inventory
 
@@ -101,9 +106,11 @@ Port of chasenorman/Formalized-Voting.
 | `pivot_is_dictator_except_b` | Arrow.lean | Pivot = dictator on non-b pairs |
 | `partial_dictator_is_full_dictator` | Arrow.lean | Partial = full dictatorship |
 
-### In Progress
+### In Progress (contains sorry)
 
-None. All production theorems are sorry-free.
+| Theorem | File | sorry | Statement |
+|---------|------|-------|-----------|
+| Various | Voting.lean | 3 | Condorcet/sorting/IsChain proofs (see sorry locations above) |
 
 ## Certification Level
 
@@ -113,9 +120,9 @@ None. All production theorems are sorry-free.
 | Framework.lean | CERTIFIED (0 sorry) |
 | Arrow.lean | CERTIFIED (0 sorry) |
 | Sen.lean | CERTIFIED (0 sorry) |
-| Voting.lean | CERTIFIED (0 sorry) |
+| Voting.lean | PARTIAL (3 sorry — in progress) |
 
-**Project certification: FULL** — all source files compile with 0 sorry.
+**Project certification: PARTIAL** — Arrow/Sen/Basic/Framework fully certified (0 sorry), Voting.lean has 3 sorry remaining.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Fix factual errors found in post-merge review of PR #624
- **social_choice_lean**: total sorry was `0` but Voting.lean has `3` sorry; Voting.lean listed as CERTIFIED instead of PARTIAL; theorem inventory missing sorry entries; "In Progress" section said "None"
- **cooperative_games_lean**: 5 theorems with `sorry: 0` were under "Partially Proved" instead of "Fully Certified" (`superadditive_empty_nonneg`, `superadditive_grand_coalition_nonneg_of_nonneg_singletons`, `shapley_efficient`, `shapley_additive`, `dummy_shapley_zero`)

## Test plan
- [x] Verified sorry counts match actual source files (`grep -c sorry *.lean`)
- [x] Certification tables now accurately reflect per-file sorry counts
- [x] Theorem inventory tables correctly separate 0-sorry from sorry>0 theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)