### PR TITLE
feat(catalog): CATALOG-STATUS markers for remaining 7 series (#623 B-5)

### DIFF
--- a/MyIA.AI.Notebooks/EPF/README.md
+++ b/MyIA.AI.Notebooks/EPF/README.md
@@ -1,5 +1,12 @@
 # EPF - Devoirs et Evaluations
 
+<!-- CATALOG-STATUS
+series: EPF
+pedagogical_count: 4
+breakdown: IA101-Devoirs=4
+updated: 2026-05-01
+-->
+
 Controles continus du cours **IA101 - Intelligence Artificielle** (EPF 2026). Ces devoirs integrent les concepts des autres sections du repository (Probas, SymbolicAI, Search).
 
 ## Vue d'ensemble

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -1,5 +1,12 @@
 # Theorie des Jeux - Game Theory
 
+<!-- CATALOG-STATUS
+series: GameTheory
+pedagogical_count: 26
+breakdown: _root=26
+updated: 2026-05-01
+-->
+
 Cette serie de notebooks introduit la **Theorie des Jeux**, combinant **Python** (simulations, algorithmes) et **Lean 4** (formalisations, preuves).
 
 ## Structure

--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -1,5 +1,12 @@
 # IIT - Integrated Information Theory
 
+<!-- CATALOG-STATUS
+series: IIT
+pedagogical_count: 1
+breakdown: _root=1
+updated: 2026-05-01
+-->
+
 Introduction a la Theorie de l'Information Integree (IIT) avec PyPhi, une bibliotheque Python pour le calcul de Phi et l'analyse de la conscience computationnelle.
 
 ## Vue d'ensemble

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -1,5 +1,12 @@
 # Probas - Programmation Probabiliste
 
+<!-- CATALOG-STATUS
+series: Probas
+pedagogical_count: 22
+breakdown: Infer=20, _root=2
+updated: 2026-05-01
+-->
+
 Serie complete de notebooks sur la programmation probabiliste, couvrant l'inference bayesienne avec **Infer.NET** (C#) et **Pyro** (Python).
 
 ## Vue d'ensemble

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -1,5 +1,12 @@
 # QuantConnect AI Trading - Série Éducative CoursIA
 
+<!-- CATALOG-STATUS
+series: QuantConnect
+pedagogical_count: 93
+breakdown: ML-Training-Pipeline=1, Python=45, projects=47
+updated: 2026-05-01
+-->
+
 > **Trading algorithmique + Intelligence Artificielle**
 > 43 notebooks Python | Cloud-first | Free Tier compatible
 

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -1,5 +1,12 @@
 # RL - Reinforcement Learning
 
+<!-- CATALOG-STATUS
+series: RL
+pedagogical_count: 6
+breakdown: _root=6
+updated: 2026-05-01
+-->
+
 Introduction au Reinforcement Learning (apprentissage par renforcement) couvrant les **fondements theoriques**, les **algorithmes avec reseaux de neurones** et les **frameworks de production**.
 
 La serie se decompose en deux parties :

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -1,5 +1,12 @@
 # SymbolicAI - Intelligence Artificielle Symbolique
 
+<!-- CATALOG-STATUS
+series: SymbolicAI
+pedagogical_count: 90
+breakdown: Argument_Analysis=7, Lean=13, Planners=13, SemanticWeb=18, SmartContracts=27, Tweety=10, _root=2
+updated: 2026-05-01
+-->
+
 Collection de **151 notebooks Jupyter** pour l'apprentissage de l'IA symbolique : logiques formelles, argumentation computationnelle, verification formelle, web semantique, planification automatique, smart contracts et optimisation.
 
 ## Vue d'ensemble


### PR DESCRIPTION
## Summary
- Add CATALOG-STATUS HTML comment metadata blocks to the 7 remaining series READMEs
- All 11 series now have catalog markers (complements PR #645 for the 4 pilots)

## Series injected

| Series | Count | Breakdown |
|--------|-------|-----------|
| SymbolicAI | 90 | SmartContracts=27, SemanticWeb=18, Lean=13, Planners=13, Tweety=10, Argument_Analysis=7, _root=2 |
| QuantConnect | 93 | projects=47, Python=45, ML-Training-Pipeline=1 |
| GameTheory | 26 | _root=26 |
| Probas | 22 | Infer=20, _root=2 |
| IIT | 1 | _root=1 |
| RL | 6 | _root=6 |
| EPF | 4 | IA101-Devoirs=4 |

## Test plan
- [x] `python count_notebooks_by_series.py --check-readme` confirms all counts
- [x] Markers verified via grep on each README
- [x] HTML comment format invisible in rendered markdown
- [ ] CI workflow can consume markers (requires PR #645 script merge first)

Part of #623 Track B-5. Depends on PR #645 for the verification script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)