### PR TITLE
feat(ci): catalog drift check uses CATALOG-STATUS markers (#623 B-4)

### DIFF
--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -18,58 +18,66 @@ jobs:
 
     - name: Check notebook catalog drift
       run: |
-        python3 -c "
+        python3 scripts/notebook_tools/verify_catalog_readme.py 2>/dev/null || python3 -c "
         import os, re, sys
 
+        # Fallback if verify_catalog_readme.py is not available
         ERRORS = 0
         WARNINGS = 0
 
-        # Find all series directories with a README
         base = 'MyIA.AI.Notebooks'
+        EXCLUDE_ALWAYS = {'.ipynb_checkpoints', 'obj', 'bin', '__pycache__', '.git'}
+        EXCLUDE_PED = {'research', 'archive', '_output', 'ESGF', 'examples'}
+        CATALOG_RE = re.compile(r'<!--\s*CATALOG-STATUS\s*\n(.*?)\n\s*-->', re.DOTALL)
+
         for series in sorted(os.listdir(base)):
             series_path = os.path.join(base, series)
             readme_path = os.path.join(series_path, 'README.md')
             if not os.path.isdir(series_path) or not os.path.isfile(readme_path):
                 continue
 
-            # Collect actual .ipynb files (excluding checkpoints and subdirs with their own README)
-            actual_notebooks = set()
+            # Count actual pedagogical notebooks
+            actual = 0
             for root, dirs, files in os.walk(series_path):
-                # Skip .ipynb_checkpoints
-                dirs[:] = [d for d in dirs if d != '.ipynb_checkpoints']
-                # Skip subdirectories that have their own README (sub-series)
-                if root != series_path and os.path.isfile(os.path.join(root, 'README.md')):
+                dirs[:] = [d for d in dirs if d not in EXCLUDE_ALWAYS]
+                rel = os.path.relpath(root, series_path)
+                if any(exc in rel for exc in EXCLUDE_PED):
                     continue
                 for f in files:
                     if f.endswith('.ipynb'):
-                        actual_notebooks.add(f)
+                        actual += 1
 
-            # Parse README for .ipynb references
+            if actual == 0:
+                continue
+
+            # Parse CATALOG-STATUS marker
             with open(readme_path, 'r', encoding='utf-8') as f:
-                readme_content = f.read()
-            readme_notebooks = set(re.findall(r'[\w\-\.]+\.ipynb', readme_content))
+                text = f.read()
+            m = CATALOG_RE.search(text)
+            if not m:
+                print(f'WARN: {series} has no CATALOG-STATUS marker ({actual} notebooks)')
+                WARNINGS += 1
+                continue
 
-            # Only flag notebooks that are actual files (not just referenced in prose)
-            # Check for drift: notebooks in directory but not in README
-            missing_from_readme = actual_notebooks - readme_notebooks
-            # Check for stale references: notebooks in README but not on disk
-            stale_references = readme_notebooks - actual_notebooks
+            declared = None
+            for line in m.group(1).strip().splitlines():
+                key, _, val = line.partition(':')
+                if key.strip() == 'pedagogical_count':
+                    declared = int(val.strip())
 
-            if missing_from_readme:
-                for nb in sorted(missing_from_readme):
-                    print(f'WARN: {series}/{nb} exists on disk but not referenced in README.md')
-                    WARNINGS += 1
+            if declared is None:
+                print(f'WARN: {series} CATALOG-STATUS missing pedagogical_count')
+                WARNINGS += 1
+                continue
 
-            if stale_references:
-                for nb in sorted(stale_references):
-                    print(f'WARN: {series} README.md references {nb} but file not found')
-                    WARNINGS += 1
+            if declared != actual:
+                print(f'ERROR: {series} declared={declared} actual={actual} (drift={actual - declared:+d})')
+                ERRORS += 1
+            else:
+                print(f'OK: {series} {declared} notebooks')
 
         print()
-        print(f'Catalog drift check complete: {WARNINGS} warning(s), {ERRORS} error(s)')
-
-        # Warnings are informational for now (not blocking)
-        # Errors would block the PR
+        print(f'Catalog drift check: {WARNINGS} warning(s), {ERRORS} error(s)')
         if ERRORS > 0:
             sys.exit(1)
         "


### PR DESCRIPTION
## Summary
- Upgrade catalog drift CI to verify CATALOG-STATUS marker counts against actual notebook scans
- Tries `verify_catalog_readme.py` first (PR #645), falls back to inline Python
- Blocking ERROR on count drift, WARN on missing markers
- Uses same pedagogical exclusion rules as `count_notebooks_by_series.py`

## Test plan
- [x] Workflow syntax valid (YAML)
- [x] Inline fallback logic matches CATALOG-STATUS marker format
- [ ] CI passes on PRs that don't change notebook counts
- [ ] CI would block a PR that adds notebooks without updating markers

Depends on PR #645 and #646 (markers) for full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)