### PR TITLE
fix(vibe-coding): update Haiku mapping to Qwen 3.6 35B-A3B (#311)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/CHEAT-SHEET.md
@@ -464,7 +464,7 @@ export ANTHROPIC_MODEL="claude-sonnet-4-5-20250929"
 # Aliases de modeles OpenRouter
 export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.6-35b-a3b"
 
 # Tokens max en sortie (defaut: 32000, max: 64000)
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=32000

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -166,7 +166,7 @@ Contenu :
     "ANTHROPIC_API_KEY": "",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen/qwen3.6-plus",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax/minimax-m2.7",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.5-27b"
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.6-35b-a3b"
   }
 }
 ```
@@ -244,7 +244,7 @@ $env:ANTHROPIC_API_KEY = ""
 # Mapping des aliases de modeles (optionnel - voir section Modeles Alternatifs)
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL = "qwen/qwen3.6-plus"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = "minimax/minimax-m2.7"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.5-27b"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.6-35b-a3b"
 ```
 
 Sauvegardez et rechargez :
@@ -297,7 +297,7 @@ export ANTHROPIC_API_KEY=""
 # Mapping des aliases de modeles (optionnel - voir section Modeles Alternatifs)
 export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.6-35b-a3b"
 ```
 
 Rechargez le fichier (adaptez selon le fichier que vous avez modifie) :
@@ -366,7 +366,7 @@ OpenRouter permet d'utiliser des modeles alternatifs a Claude, souvent moins che
 | ------------ | ----------------- | ---------------------- | ------- | ------------------------- |
 | `opus` | Qwen 3.6 Plus | `qwen/qwen3.6-plus` | 262K | voir OpenRouter |
 | `sonnet` | MiniMax M2.7 | `minimax/minimax-m2.7` | 205K | $0.30 / $1.20 |
-| `haiku` | Qwen 3.5 27B | `qwen/qwen3.5-27b` | 262K | $0.20 / $1.56 |
+| `haiku` | Qwen 3.6 35B-A3B | `qwen/qwen3.6-35b-a3b` | 262K | $0.20 / $1.56 |
 
 ### Commandes CLI
 
@@ -377,7 +377,7 @@ claude -p "Explique ce code"
 # Utiliser explicitement un modele
 claude --model opus -p "Refactore ce projet"    # Qwen 3.6 Plus
 claude --model sonnet -p "Corrige ce bug"       # MiniMax M2.7
-claude --model haiku -p "Liste les fichiers"    # Qwen 3.5 27B
+claude --model haiku -p "Liste les fichiers"    # Qwen 3.6 35B-A3B
 
 # Forcer un modele specifique (bypass alias)
 claude --model qwen/qwen3.6-plus -p "Question complexe"
@@ -407,9 +407,9 @@ Modele de derniere generation optimise pour la productivite et le coding :
 - **Cas d'usage ideaux** : Developpement quotidien, debug, generation de tests, refactoring
 - **Prix** : $0.30 / $1.20 per million tokens (input/output)
 
-#### Qwen 3.5 27B (Alias Haiku)
+#### Qwen 3.6 35B-A3B (Alias Haiku)
 
-**Identifiant :** `qwen/qwen3.5-27b`
+**Identifiant :** `qwen/qwen3.6-35b-a3b`
 
 Modele dense compact et rapide :
 
@@ -421,7 +421,7 @@ Modele dense compact et rapide :
 
 ### Comparaison avec les Modeles Claude Natifs
 
-| Aspect | Claude Opus | Qwen 3.6 Plus | Claude Sonnet | MiniMax M2.7 | Claude Haiku | Qwen 3.5 27B |
+| Aspect | Claude Opus | Qwen 3.6 Plus | Claude Sonnet | MiniMax M2.7 | Claude Haiku | Qwen 3.6 35B-A3B |
 | ---------------- | ----------- | ------------- | ------------- | ------------ | ------------ | ------------ |
 | **Context** | 200K | 262K | 200K | 205K | 200K | 262K |
 | **Prix Input** | $15.00 | voir OR | $3.00 | $0.30 | $0.25 | $0.20 |
@@ -896,7 +896,7 @@ Editez `.claude/settings.json` :
 - [Tarifs et modeles](https://openrouter.ai/models)
 - [Qwen 3.6 Plus sur OpenRouter](https://openrouter.ai/qwen/qwen3.6-plus)
 - [MiniMax M2.7 sur OpenRouter](https://openrouter.ai/minimax/minimax-m2.7)
-- [Qwen 3.5 27B sur OpenRouter](https://openrouter.ai/qwen/qwen3.5-27b)
+- [Qwen 3.6 35B-A3B sur OpenRouter](https://openrouter.ai/qwen/qwen3.6-35b-a3b)
 
 ### Communaute
 

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/OPENROUTER_SETUP.md
@@ -111,7 +111,7 @@ C'est l'etape la plus importante. Vous devez definir **3 variables obligatoires*
 | `ANTHROPIC_API_KEY` | *(vide)* | Doit etre vide pour ne pas conflit avec OpenRouter |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | `qwen/qwen3.6-plus` | Modele "opus" = Qwen 3.6 Plus (raisonnement complexe) |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | `minimax/minimax-m2.7` | Modele "sonnet" = MiniMax M2.7 (usage quotidien) |
-| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `qwen/qwen3.5-27b` | Modele "haiku" = Qwen 3.5 27B (taches rapides) |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `qwen/qwen3.6-35b-a3b` | Modele "haiku" = Qwen 3.6 35B-A3B (taches rapides) |
 
 ### Pourquoi le mapping des modeles ?
 
@@ -137,7 +137,7 @@ Contenu (remplacez `sk-or-v1-VOTRE_CLE` par votre vraie cle) :
     "ANTHROPIC_API_KEY": "",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "qwen/qwen3.6-plus",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "minimax/minimax-m2.7",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.5-27b"
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "qwen/qwen3.6-35b-a3b"
   }
 }
 ```
@@ -159,7 +159,7 @@ $env:ANTHROPIC_AUTH_TOKEN = "sk-or-v1-VOTRE_CLE"
 $env:ANTHROPIC_API_KEY = ""
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL = "qwen/qwen3.6-plus"
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = "minimax/minimax-m2.7"
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.5-27b"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "qwen/qwen3.6-35b-a3b"
 ```
 
 Sauvegardez et rechargez :
@@ -185,7 +185,7 @@ export ANTHROPIC_AUTH_TOKEN="sk-or-v1-VOTRE_CLE"
 export ANTHROPIC_API_KEY=""
 export ANTHROPIC_DEFAULT_OPUS_MODEL="qwen/qwen3.6-plus"
 export ANTHROPIC_DEFAULT_SONNET_MODEL="minimax/minimax-m2.7"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.5-27b"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="qwen/qwen3.6-35b-a3b"
 ```
 
 Rechargez :
@@ -248,7 +248,7 @@ claude -p "Reponds 'Sonnet OK'"
 # Modele opus (Qwen 3.6 Plus)
 claude --model opus -p "Reponds 'Opus OK'"
 
-# Modele haiku (Qwen 3.5 27B)
+# Modele haiku (Qwen 3.6 35B-A3B)
 claude --model haiku -p "Reponds 'Haiku OK'"
 ```
 
@@ -287,14 +287,14 @@ Claude Code va analyser votre projet et creer un fichier `CLAUDE.md` avec le con
 |-------|--------|-----------------|
 | **sonnet** (defaut) | MiniMax M2.7 | Developpement quotidien, debug, questions |
 | **opus** | Qwen 3.6 Plus | Refactoring complexe, architecture, documentation |
-| **haiku** | Qwen 3.5 27B | Questions rapides, exploration, prototypage |
+| **haiku** | Qwen 3.6 35B-A3B | Questions rapides, exploration, prototypage |
 
 Pour changer de modele dans une session :
 
 ```bash
 claude --model opus    # utilise Qwen 3.6 Plus
 claude --model sonnet  # utilise MiniMax M2.7 (defaut)
-claude --model haiku   # utilise Qwen 3.5 27B
+claude --model haiku   # utilise Qwen 3.6 35B-A3B
 ```
 
 ---

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/docs/INSTALLATION-ROO.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Roo-Code/docs/INSTALLATION-ROO.md
@@ -73,7 +73,7 @@ Les profils vous permettent de basculer rapidement entre différents modèles d'
 | `OpenAI-o3`                 | `openai/o3`                   |
 | `Deepseek-Deepseek-r1`       | `deepseek/deepseek-r1`                 |
 | `MiniMax-M2.7`               | `minimax/minimax-m2.7`                 |
-| `Qwen-3.5-27B`               | `qwen/qwen3.5-27b`                    |
+| `Qwen-3.6-35B-A3B`               | `qwen/qwen3.6-35b-a3b`                    |
 | `Qwen-3.6-Plus`              | `qwen/qwen3.6-plus`                   |
 | `Mistral-Mistral-Small`    | `mistralai/mistral-small`         |
 


### PR DESCRIPTION
## Summary

- Updates Haiku model mapping from `qwen/qwen3.5-27b` to `qwen/qwen3.6-35b-a3b` across all Vibe-Coding documentation files
- 4 files updated: OPENROUTER_SETUP.md, INSTALLATION-CLAUDE-CODE.md, CHEAT-SHEET.md, INSTALLATION-ROO.md
- Pure text replacement: model IDs (`qwen/qwen3.5-27b` -> `qwen/qwen3.6-35b-a3b`) and descriptive names (`Qwen 3.5 27B` -> `Qwen 3.6 35B-A3B`, `Qwen-3.5-27B` -> `Qwen-3.6-35B-A3B`)
- No unrelated content modified

## Test plan

- [x] Verified zero remaining occurrences of `qwen3.5` or `Qwen 3.5` in the Vibe-Coding directory (except one pre-existing inaccurate comment about the Sonnet model on line 374 of INSTALLATION-CLAUDE-CODE.md, unrelated to this issue)
- [x] Diff stats: 4 files, +18/-18 (pure replacement)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)