### PR TITLE
fix(qc): add batch_thermal_check to DQN training loop

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -33,6 +33,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
+    batch_thermal_check,
     get_gpu_temp,
     setup_amp,
     thermal_check,
@@ -264,6 +265,7 @@ def train_dqn(
         state = env.reset()
         total_reward = 0.0
         trades = 0
+        step = 0
 
         while True:
             # Epsilon-greedy action selection
@@ -310,6 +312,9 @@ def train_dqn(
                     loss.backward()
                     torch.nn.utils.clip_grad_norm_(policy_net.parameters(), 1.0)
                     optimizer.step()
+
+            step += 1
+            batch_thermal_check(step, check_every=10, max_temp=80, cool_sleep=30)
 
             if done:
                 break


### PR DESCRIPTION
## Summary
- Add `batch_thermal_check` import from `gpu_training`
- Add step counter and intra-episode thermal check (every 10 steps, max 80C, cool 30s)
- Fixes GPU overheating that caused display crash (91C+ during DQN training)

## Root Cause
`train_dqn_rl.py` only had `thermal_check()` between episodes (line 263), not inside the `while True` step loop. During sustained intra-episode compute (replay sampling + backprop), GPU temp could spike from ~80C to 91C+ without throttling. This is the same pattern already implemented in `train_transformer.py` (line 252).

## Test plan
- [x] Script imports `batch_thermal_check` successfully
- [ ] Next GPU training run will validate thermal protection triggers correctly (monitor with `nvidia-smi`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>