### PR TITLE
fix(qc): DQN intermediate checkpoint + sys.path priority for FeatureEngineer

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -31,7 +31,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "shared"))
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
     batch_thermal_check,
     get_gpu_temp,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -234,6 +234,8 @@ def train_dqn(
     replay_size: int = 50000,
     target_update: int = 10,
     device: str = "cpu",
+    intermediate_save_every: int = 0,
+    intermediate_save_dir: "Path | None" = None,
 ) -> dict:
     """Train DQN agent on trading environment."""
     import torch
@@ -341,6 +343,28 @@ def train_dqn(
             print(f"  Episode {episode+1}/{num_episodes}  reward={total_reward:.4f}  "
                   f"avg10={recent:.4f}  trades={trades}  eps={epsilon:.3f}{temp_str}")
 
+        if (
+            intermediate_save_every > 0
+            and intermediate_save_dir is not None
+            and best_state is not None
+            and (episode + 1) % intermediate_save_every == 0
+        ):
+            intermediate_save_dir.mkdir(parents=True, exist_ok=True)
+            torch.save(best_state, intermediate_save_dir / "best_state.pt")
+            (intermediate_save_dir / "progress.json").write_text(
+                json.dumps({
+                    "episode": int(episode + 1),
+                    "best_avg_reward_10": round(float(best_avg_reward), 4),
+                    "epsilon": round(float(epsilon), 4),
+                }),
+                encoding="utf-8",
+            )
+            print(
+                f"  [intermediate-save] episode={episode+1} "
+                f"best_avg10={best_avg_reward:.4f} -> {intermediate_save_dir}",
+                flush=True,
+            )
+
     # Load best model
     if best_state:
         policy_net.load_state_dict(best_state)
@@ -437,6 +461,14 @@ def main():
     )
     parser.add_argument("--dry-run", action="store_true", help="Synthetic, 50 episodes")
     parser.add_argument(
+        "--intermediate-save-every", type=int, default=0,
+        help="Save best_state every N episodes (0 = disabled). Useful for crash-resilient long runs.",
+    )
+    parser.add_argument(
+        "--intermediate-save-dir", default=None,
+        help="Directory for intermediate best_state.pt + progress.json (defaults to checkpoint-dir/intermediate)",
+    )
+    parser.add_argument(
         "--advanced", action="store_true",
         help="Use advanced features (regime, momentum, statistical, price_acceleration)",
     )
@@ -516,6 +548,14 @@ def main():
         "device": device,
     }
 
+    intermediate_dir = None
+    if args.intermediate_save_every > 0:
+        intermediate_dir = (
+            Path(args.intermediate_save_dir)
+            if args.intermediate_save_dir
+            else Path(args.checkpoint_dir) / "intermediate"
+        )
+
     result = train_dqn(
         env,
         hidden_size=args.hidden_size,
@@ -529,6 +569,8 @@ def main():
         replay_size=args.replay_size,
         target_update=args.target_update,
         device=device,
+        intermediate_save_every=args.intermediate_save_every,
+        intermediate_save_dir=intermediate_dir,
     )
 
     ckpt_dir = Path(args.checkpoint_dir)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "shared"))
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
     batch_thermal_check,
     get_gpu_temp,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -36,7 +36,7 @@ import numpy as np
 import pandas as pd
 
 # Import thermal-safe training utilities
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "shared"))
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
     TrainingCheckpoint,
     batch_thermal_check,


### PR DESCRIPTION
## Summary

Two minimal fixes for the ML Training Pipeline DQN script after diagnosing 4 failed ai-01 runs (run #1 buffered logs, runs #2-3 lost, run #4 ImportError).

### Fix 1 — Intermediate checkpoint save

`train_dqn_rl.py` only persisted the best DQN state at the very end of training via `save_checkpoint()`. A long run that crashes mid-training (compaction, hardware freeze, monitor timeout) leaves nothing behind. The 3 ai-01 runs at hidden=512/500ep all lost their best state for this reason.

- New CLI arg `--intermediate-save-every N` (default 0 = disabled)
- New optional `--intermediate-save-dir` (defaults to `<checkpoint-dir>/intermediate/`)
- Saves `best_state.pt` + `progress.json` (episode, best_avg_reward_10, epsilon) every N episodes
- Idempotent overwrite — single rolling file per run

### Fix 2 — `sys.path.insert(0, ...)` shadowed local features.py

PR #649 (thermal-safe DQN/LSTM) added `sys.path.insert(0, .../shared)` to make `gpu_training` importable. PR #655 (Track A3) then added `FeatureEngineer` to `ML-Training-Pipeline/scripts/features.py`. The combination broke `from features import FeatureEngineer`: the inserted `shared/` came before the script's auto-added `scripts/` in `sys.path`, so Python found `shared/features.py` (functional helpers, no class) first.

Switching to `sys.path.append(...)` keeps the script directory at index 0 — local `features.py` wins for `FeatureEngineer`, shared/ is consulted for `gpu_training` (no name clash). Same one-line fix applied to `train_lstm.py` and `train_transformer.py`, which had the identical pattern.

## Test plan

- [x] `python -c "from features import FeatureEngineer; print(FeatureEngineer.ALL_INDICATORS)"` succeeds
- [x] DQN run #4 v2 (PID 30892) starts cleanly: `Loaded 2516 rows for SPY / Features: 2457 rows, 19 columns / Device: cuda / State size: 382, Actions: 3` (vs run #3 broken state size 242 / 12 columns from misimport)
- [x] GPU 2 ai-01 consuming 536 MiB at 22% util, 35C, 35W — DQN training proceeding
- [x] Intermediate save dir created, awaiting first checkpoint at episode 25
- [ ] Full 500-episode completion + final checkpoint produced (in flight, ETA ~30 min)

## Related

- Closes (none — this is a fix-forward, no issue filed)
- Followup to #641 / #649 / #655 / #660 / #662
- Run metadata: `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/outputs/ai01_dqn_run4_20260502_105731/run_metadata.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)