### PR TITLE
fix(qc): launchers FeatureEngineer import via ScriptsDir

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launchers/launch_ai01_lstm_run5.ps1
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launchers/launch_ai01_lstm_run5.ps1
@@ -54,8 +54,10 @@ $verCheck = & $PythonExe -c "import sys; print(sys.version)" 2>&1
 Write-Host "[PRE-CHECK] Python: $verCheck"
 
 # Verify FeatureEngineer import (post-#673 sys.path.append fix)
+# FeatureEngineer lives in ML-Training-Pipeline/scripts/features.py, not shared/features.py
 $importCheck = & $PythonExe -c @"
 import sys
+sys.path.insert(0, r'$ScriptsDir')
 sys.path.append(r'$SharedDir')
 from features import FeatureEngineer
 print('OK')

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launchers/launch_ai01_transformer_run6.ps1
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/launchers/launch_ai01_transformer_run6.ps1
@@ -56,8 +56,10 @@ $verCheck = & $PythonExe -c "import sys; print(sys.version)" 2>&1
 Write-Host "[PRE-CHECK] Python: $verCheck"
 
 # Verify FeatureEngineer import (post-#673 sys.path.append fix)
+# FeatureEngineer lives in ML-Training-Pipeline/scripts/features.py, not shared/features.py
 $importCheck = & $PythonExe -c @"
 import sys
+sys.path.insert(0, r'$ScriptsDir')
 sys.path.append(r'$SharedDir')
 from features import FeatureEngineer
 print('OK')


### PR DESCRIPTION
## Summary
- Insert `\$ScriptsDir` at `sys.path[0]` before `\$SharedDir` in launcher pre-checks
- Aligns with how `train_lstm.py` / `train_transformer.py` resolve `from features import FeatureEngineer`
- Fixes immediate `ImportError: cannot import name 'FeatureEngineer' from 'features'` blocking #685 launchers

## Root cause
PR #685 launcher pre-checks point `\$SharedDir = QuantConnect/shared/`, but `FeatureEngineer` is in `ML-Training-Pipeline/scripts/features.py`. The training scripts work because Python sets `sys.path[0]` to the script's dir automatically — the launcher pre-check doesn't.

## Test plan
- [x] LSTM launcher DryRun reaches FeatureEngineer pre-check OK
- [ ] Full LSTM run5 launches and converges

🤖 Generated with [Claude Code](https://claude.com/claude-code)