### PR TITLE
fix(lint): eliminate C.1 false positives in notebook_lint.py

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -42,8 +42,14 @@ C1_PATTERNS = [
     (r"(?<!\w)1\s*/\s*0(?!\w)", "1/0"),
 ]
 
-# Allowed C.1 exception: inside comments (pedagogical explanations)
-C1_ALLOW_PATTERN = r"^\s*#\s*(TODO|Indice|Etape|NOTE|EXERCICE|Exemple)"
+def _is_in_docstring(line: str, in_doc: bool) -> tuple[bool, bool]:
+    """Track triple-quote state. Returns (in_docstring_after_line, line_is_inside_docstring)."""
+    for quote in ('"""', "'''"):
+        count = line.count(quote)
+        if count % 2 == 1:
+            in_doc = not in_doc
+    # A line is "inside" if it was in_doc at start or toggled within it
+    return in_doc, in_doc
 
 
 def check_c1(notebook: dict) -> list[dict]:
@@ -53,8 +59,15 @@ def check_c1(notebook: dict) -> list[dict]:
         if cell.get("cell_type") != "code":
             continue
         source = "".join(cell.get("source", []))
+        in_docstring = False
         for line in source.split("\n"):
-            if re.match(C1_ALLOW_PATTERN, line):
+            stripped = line.lstrip()
+            # Skip any comment line (commented-out code is not executable)
+            if stripped.startswith("#"):
+                continue
+            # Track and skip docstring content
+            in_docstring, is_inside = _is_in_docstring(line, in_docstring)
+            if is_inside:
                 continue
             for pattern, desc in C1_PATTERNS:
                 if re.search(pattern, line):


### PR DESCRIPTION
## Summary
- Skip any comment line (not just `# TODO|Indice|...`) — commented-out `#raise NotImplementedError` is not executable
- Track and skip docstring content (`"""..."""` / `'''...'''`) — `1/-1/0` in return value descriptions is documentation, not division by zero
- Result: **448/448 notebooks pass C.1** (was 447/448 with 2 false positives)

## Test plan
- [x] `python notebook_lint.py --check c1 --all` → 448/448 pass
- [x] `python notebook_lint.py --all` → C.2 violations unchanged (known BROKEN .NET notebooks)

## Context
- Closes #682 rationale (2 false positives identified: `#raise NotImplementedError` comment + `"1/-1/0"` in docstring)
- References #623 Phase 2 / B2

🤖 Generated with [Claude Code](https://claude.com/claude-code)