### PR TITLE
feat(catalog): B-1 columns for generate_catalog.py (#623)

### DIFF
--- a/MyIA.AI.Notebooks/EPF/README.md
+++ b/MyIA.AI.Notebooks/EPF/README.md
@@ -5,7 +5,7 @@ series: EPF
 pedagogical_count: 4
 breakdown: IA101-Devoirs=4
 maturity: DRAFT=2, PRODUCTION=1, ALPHA=1
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Controles continus du cours **IA101 - Intelligence Artificielle** (EPF 2026). Ces devoirs integrent les concepts des autres sections du repository (Probas, SymbolicAI, Search).

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -5,7 +5,7 @@ series: GameTheory
 pedagogical_count: 26
 breakdown: =26
 maturity: ALPHA=20, DRAFT=3, BETA=3
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Cette serie de notebooks introduit la **Theorie des Jeux**, combinant **Python** (simulations, algorithmes) et **Lean 4** (formalisations, preuves).

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -5,7 +5,7 @@ series: GenAI
 pedagogical_count: 99
 breakdown: Audio=21, SemanticKernel=20, Image=16, Video=16, Texte=11, 00-GenAI-Environment=6, Vibe-Coding=5, EPF=4
 maturity: ALPHA=60, DRAFT=24, PRODUCTION=10, BETA=5
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Ecosysteme modulaire de generation de contenu par Intelligence Artificielle : images, texte, agents et vibe-coding.

--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -5,7 +5,7 @@ series: IIT
 pedagogical_count: 1
 breakdown: =1
 maturity: ALPHA=1
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Introduction a la Theorie de l'Information Integree (IIT) avec PyPhi, une bibliotheque Python pour le calcul de Phi et l'analyse de la conscience computationnelle.

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -5,7 +5,7 @@ series: ML
 pedagogical_count: 30
 breakdown: DataScienceWithAgents=22, ML.Net=8
 maturity: ALPHA=25, BETA=3, DRAFT=2
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Serie de notebooks couvrant le Machine Learning avec deux approches complementaires : **ML.NET** pour l'ecosysteme .NET/C# et **Python Data Science with Agents** pour les pipelines modernes avec LLMs.

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -5,7 +5,7 @@ series: Probas
 pedagogical_count: 22
 breakdown: Infer=20, =2
 maturity: ALPHA=18, PRODUCTION=4
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Serie complete de notebooks sur la programmation probabiliste, couvrant l'inference bayesienne avec **Infer.NET** (C#) et **Pyro** (Python).

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -5,7 +5,7 @@ series: QuantConnect
 pedagogical_count: 93
 breakdown: projects=47, Python=45, ML-Training-Pipeline=1
 maturity: DRAFT=78, PRODUCTION=12, ALPHA=2, BETA=1
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 > **Trading algorithmique + Intelligence Artificielle**

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -4,10 +4,10 @@ Ecosysteme complet de **448 notebooks** Jupyter pour l'apprentissage des technol
 
 <!-- CATALOG-STATUS
 series: ALL
-total: 447
-breakdown: GenAI=99, QuantConnect=93, SymbolicAI=89, Search=45, Sudoku=32, ML=30, GameTheory=26, Probas=22, RL=6, EPF=4, IIT=1
-maturity: ALPHA=237, DRAFT=123, BETA=56, PRODUCTION=31
-updated: 2026-05-03
+total: 448
+breakdown: GenAI=99, QuantConnect=93, SymbolicAI=90, Search=45, Sudoku=32, ML=30, GameTheory=26, Probas=22, RL=6, EPF=4, IIT=1
+maturity: ALPHA=238, DRAFT=123, BETA=56, PRODUCTION=31
+updated: 2026-05-04
 -->
 
 Dernière mise à jour : 2026-05-02

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -5,7 +5,7 @@ series: RL
 pedagogical_count: 6
 breakdown: =6
 maturity: ALPHA=6
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Introduction au Reinforcement Learning (apprentissage par renforcement) couvrant les **fondements theoriques**, les **algorithmes avec reseaux de neurones** et les **frameworks de production**.

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -5,7 +5,7 @@ series: Search
 pedagogical_count: 45
 breakdown: Applications=20, Part1-Foundations=11, Part2-CSP=9, =5
 maturity: ALPHA=33, DRAFT=7, BETA=4, PRODUCTION=1
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Cette serie explore les algorithmes de recherche et d'optimisation, de la formalisation des espaces d'etats a la programmation par contraintes, en passant par les metaheuristiques. Elle combine **fondements theoriques** et **applications du monde reel** adaptees de projets etudiants EPITA, EPF et ECE.

--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -5,7 +5,7 @@ series: Sudoku
 pedagogical_count: 32
 breakdown: =32
 maturity: ALPHA=19, BETA=11, PRODUCTION=2
-updated: 2026-05-03
+updated: 2026-05-04
 -->
 
 Cette serie de **32 notebooks** explore differentes techniques de resolution de Sudoku, des algorithmes classiques aux approches symboliques, probabilistes et neuronales. Les notebooks sont disponibles en **approche miroir C#/Python** pour permettre aux etudiants de choisir leur langage.

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -2,10 +2,10 @@
 
 <!-- CATALOG-STATUS
 series: SymbolicAI
-pedagogical_count: 89
-breakdown: SmartContracts=27, SemanticWeb=18, Lean=13, Planners=13, Tweety=10, Argument_Analysis=6, =2
-maturity: ALPHA=52, BETA=29, DRAFT=7, PRODUCTION=1
-updated: 2026-05-03
+pedagogical_count: 90
+breakdown: SmartContracts=27, SemanticWeb=18, Lean=13, Planners=13, Tweety=10, Argument_Analysis=7, =2
+maturity: ALPHA=53, BETA=29, DRAFT=7, PRODUCTION=1
+updated: 2026-05-04
 -->
 
 Collection de **90 notebooks Jupyter** pour l'apprentissage de l'IA symbolique : logiques formelles, argumentation computationnelle, verification formelle, web semantique, planification automatique, smart contracts et optimisation.

--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -44,7 +44,7 @@ SERIES_ORDER = [
 # Keywords indicating special requirements
 API_KEYWORDS = {"openai", "anthropic", "api_key", "API_KEY", "bearer", "endpoint"}
 GPU_KEYWORDS = {"cuda", "gpu", "torch.device", "ComfyUI", "VRAM"}
-CLOUD_KEYWORDS = {"QuantBook", "quantconnect", "qc-api", "lean-cli"}
+CLOUD_KEYWORDS = {"QuantBook", "quantconnect", "qc-api", "lean-cli", "AlgorithmImports", "QCAlgorithm"}
 WSL_KEYWORDS = {"wsl", "WSL"}
 
 OWNER_MAP = {
@@ -320,6 +320,13 @@ def analyze_notebook(nb_path: Path, pedagogical: bool, git_meta: dict | None = N
     title = extract_title(notebook)
     kernel = detect_kernel(notebook)
     requirements = detect_requirements(notebook)
+
+    # Directory-based requirement overrides (stronger than keyword detection)
+    if serie == "QuantConnect":
+        requirements["requires_cloud"] = True
+    if serie in ("GameTheory", "SymbolicAI") and any("Lean" in p for p in parts):
+        requirements["requires_wsl"] = True
+
     status = determine_status(nb_path, notebook, code_cells, requirements, pedagogical)
     maturity = classify_maturity(notebook, code_cells, kernel)
 

--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -25,6 +25,7 @@ Status heuristics (B-2 from #623):
 import argparse
 import json
 import re
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -45,6 +46,91 @@ API_KEYWORDS = {"openai", "anthropic", "api_key", "API_KEY", "bearer", "endpoint
 GPU_KEYWORDS = {"cuda", "gpu", "torch.device", "ComfyUI", "VRAM"}
 CLOUD_KEYWORDS = {"QuantBook", "quantconnect", "qc-api", "lean-cli"}
 WSL_KEYWORDS = {"wsl", "WSL"}
+
+OWNER_MAP = {
+    "GenAI": "po-2025",
+    "Search": "po-2025",
+    "ML": "po-2023",
+    "SymbolicAI": "po-2024",
+    "QuantConnect": "po-2026",
+    "GameTheory": "po-2024",
+    "Sudoku": "po-2023",
+    "Probas": "po-2023",
+    "IIT": "po-2025",
+    "RL": "po-2025",
+    "EPF": "ai-01",
+}
+
+
+def estimate_duration(cells_code: int, kernel: str, requirements: dict) -> str:
+    """Estimate notebook execution duration (heuristic)."""
+    if cells_code == 0:
+        return "5min"
+    is_dotnet = ".net" in kernel.lower() or "c#" in kernel.lower()
+    minutes_per_cell = 3 if is_dotnet else 2
+    total = max(5, cells_code * minutes_per_cell)
+    if requirements.get("requires_gpu") or requirements.get("requires_cloud"):
+        total = int(total * 1.5)
+    if total >= 120:
+        return "2h+"
+    if total >= 90:
+        return "1h30"
+    if total >= 60:
+        return "1h"
+    if total >= 30:
+        return "45min"
+    if total >= 15:
+        return "30min"
+    return "15min"
+
+
+def build_git_metadata() -> dict[str, dict]:
+    """Build last-commit metadata for all notebooks via git log.
+
+    Returns dict keyed by relative path (forward slashes) with:
+        last_validation: ISO date of last commit touching the file
+        last_validator: email of last committer
+        issues_prs: list of '#NNN' references from commit messages
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "--name-only", "--format=COMMIT:%ai|%ae|%s"],
+            capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=30,
+        )
+        if result.returncode != 0:
+            return {}
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+
+    metadata: dict[str, dict] = {}
+    current_date = ""
+    current_email = ""
+    current_subject = ""
+    prefix = "MyIA.AI.Notebooks/"
+
+    for line in result.stdout.split("\n"):
+        if line.startswith("COMMIT:"):
+            parts = line[7:].split("|", 2)
+            if len(parts) >= 3:
+                current_date = parts[0][:10]
+                current_email = parts[1]
+                current_subject = parts[2]
+        elif line.strip() and current_date:
+            path = line.strip()
+            if not path.endswith(".ipynb"):
+                continue
+            if not path.startswith(prefix):
+                continue
+            rel = path[len(prefix):].replace("\\", "/")
+            if rel not in metadata:
+                issues = re.findall(r"#(\d+)", current_subject)
+                metadata[rel] = {
+                    "last_validation": current_date,
+                    "last_validator": current_email,
+                    "issues_prs": [f"#{n}" for n in issues[:5]],
+                }
+
+    return metadata
 
 
 def detect_kernel(notebook: dict) -> str:
@@ -215,7 +301,7 @@ def classify_maturity(
     return "ALPHA"
 
 
-def analyze_notebook(nb_path: Path, pedagogical: bool) -> dict | None:
+def analyze_notebook(nb_path: Path, pedagogical: bool, git_meta: dict | None = None) -> dict | None:
     """Analyze a single notebook and return its catalog entry."""
     try:
         notebook = json.loads(nb_path.read_text(encoding="utf-8"))
@@ -241,14 +327,22 @@ def analyze_notebook(nb_path: Path, pedagogical: bool) -> dict | None:
     code_without_outputs = len(code_cells) - code_with_outputs
     md_cells = sum(1 for c in cells if c["cell_type"] == "markdown")
 
+    rel_str = str(rel).replace("\\", "/")
+    gm = (git_meta or {}).get(rel_str, {})
+
     return {
-        "path": str(rel).replace("\\", "/"),
+        "path": rel_str,
         "title": title or nb_path.stem,
         "serie": serie,
         "sous_serie": sous_serie,
         "kernel": kernel,
         "status": status,
         "maturity": maturity,
+        "duree_estimee": estimate_duration(len(code_cells), kernel, requirements),
+        "owner_logique": OWNER_MAP.get(serie, ""),
+        "last_validation": gm.get("last_validation", ""),
+        "last_validator": gm.get("last_validator", ""),
+        "issue_pr_associee": ", ".join(gm.get("issues_prs", [])),
         "cells_total": len(cells),
         "cells_code": len(code_cells),
         "cells_markdown": md_cells,
@@ -270,6 +364,7 @@ def analyze_notebook(nb_path: Path, pedagogical: bool) -> dict | None:
 def scan_all_notebooks(
     pedagogical: bool = True,
     series_filter: str | None = None,
+    git_meta: dict | None = None,
 ) -> list[dict]:
     """Scan all notebooks and return catalog entries."""
     entries = []
@@ -293,7 +388,7 @@ def scan_all_notebooks(
             ):
                 continue
 
-            entry = analyze_notebook(nb_path, pedagogical)
+            entry = analyze_notebook(nb_path, pedagogical, git_meta=git_meta)
             if entry:
                 entries.append(entry)
 
@@ -354,13 +449,15 @@ def generate_markdown_report(entries: list[dict]) -> str:
         )
         lines.append(f"### {serie} ({len(items)} notebooks) — {status_str} | {mat_str}")
         lines.append("")
-        lines.append(f"| # | Notebook | Kernel | Status | Maturity |")
-        lines.append(f"|---|----------|--------|--------|----------|")
+        lines.append(f"| # | Notebook | Kernel | Status | Maturity | Duration | Owner |")
+        lines.append(f"|---|----------|--------|--------|----------|----------|-------|")
         for i, e in enumerate(items, 1):
             name = e["title"][:50]
             kernel = e["kernel"][:30]
             maturity = e.get("maturity", "UNKNOWN")
-            lines.append(f"| {i} | {name} | {kernel} | {e['status']} | {maturity} |")
+            duration = e.get("duree_estimee", "")
+            owner = e.get("owner_logique", "")
+            lines.append(f"| {i} | {name} | {kernel} | {e['status']} | {maturity} | {duration} | {owner} |")
         lines.append("")
 
     # Requirements summary
@@ -419,7 +516,8 @@ def main():
     args = parser.parse_args()
 
     pedagogical = not args.all
-    entries = scan_all_notebooks(pedagogical=pedagogical, series_filter=args.series)
+    git_meta = build_git_metadata()
+    entries = scan_all_notebooks(pedagogical=pedagogical, series_filter=args.series, git_meta=git_meta)
 
     if args.status:
         entries = [e for e in entries if e["status"] == args.status]


### PR DESCRIPTION
## Summary
- **B-1**: Add 5 missing columns to `generate_catalog.py` per issue #623: `duree_estimee`, `owner_logique`, `last_validation`, `last_validator`, `issue_pr_associee`
- **Requirement detection**: All QuantConnect/ notebooks auto-flagged `requires_cloud`; Lean notebooks auto-flagged `requires_wsl`; added `AlgorithmImports`/`QCAlgorithm` to cloud keywords
- **README refresh**: Updated CATALOG-STATUS markers in all 12 READMEs (status counts changed after QC reclassification)

### Impact
- 20 QC notebooks reclassified BROKEN→DEMO (correct: they require QC Cloud, not locally fixable)
- BROKEN count: 40→20, DEMO: 166→198
- `executable_locally` false positives eliminated for QC notebooks

### Git metadata
- Extracted via single `git log --name-only` call, indexed by notebook path
- Coverage on 448 notebooks: last_validation 447/448, owner_logique 448/448, duree_estimee 448/448, issue_pr_associee 383/448

### Duration heuristic
- Python: 2 min/cell, .NET: 3 min/cell, GPU/cloud: ×1.5
- Buckets: 15min, 30min, 45min, 1h, 1h30, 2h+

## Test plan
- [x] `generate_catalog.py` runs on full repo (448 entries, ~5s)
- [x] `--check` flag works (status/maturity summary)
- [x] `catalog_coverage.py --short` compatible with new schema
- [x] `diagnose_broken.py` compatible (BROKEN count correctly shows 20)
- [x] `notebook_lint.py` unaffected
- [x] `expand_catalog_markers.py` correctly updates all 12 READMEs
- [x] All downstream scripts (`batch_reexecute`, `catalog_coverage`) compatible

Addresses #623 B-1 + B-5 (marker refresh). B-2 already implemented in prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)