### PR TITLE
test(notebook-tools): 42 tests for count_notebooks_by_series + expand_catalog_markers

### DIFF
--- a/scripts/notebook_tools/tests/test_count_notebooks_by_series.py
+++ b/scripts/notebook_tools/tests/test_count_notebooks_by_series.py
@@ -1,0 +1,144 @@
+"""Tests for count_notebooks_by_series.py — notebook counting and README extraction."""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from count_notebooks_by_series import (
+    count_notebooks_in_dir,
+    extract_readme_count,
+    EXCLUDE_ALWAYS,
+    EXCLUDE_PEDAGOGICAL,
+)
+
+
+class TestCountNotebooksInDir:
+
+    def test_empty_dir(self, tmp_path):
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 0
+        assert result["by_subfolder"] == {}
+
+    def test_single_notebook(self, tmp_path):
+        (tmp_path / "test.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 1
+        assert result["by_subfolder"] == {"_root": 1}
+
+    def test_nested_notebook(self, tmp_path):
+        sub = tmp_path / "Part1"
+        sub.mkdir()
+        (sub / "lesson.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 1
+        assert result["by_subfolder"] == {"Part1": 1}
+
+    def test_multiple_subfolders(self, tmp_path):
+        for name in ["Part1", "Part2", "Part3"]:
+            sub = tmp_path / name
+            sub.mkdir()
+            (sub / "nb.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 3
+        assert len(result["by_subfolder"]) == 3
+
+    def test_excludes_checkpoints(self, tmp_path):
+        cp = tmp_path / ".ipynb_checkpoints"
+        cp.mkdir()
+        (cp / "test-checkpoint.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "real.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 1
+
+    def test_excludes_pycache(self, tmp_path):
+        pyc = tmp_path / "__pycache__"
+        pyc.mkdir()
+        (pyc / "mod.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 0
+
+    def test_pedagogical_excludes_research(self, tmp_path):
+        research = tmp_path / "research"
+        research.mkdir()
+        (research / "analysis.ipynb").write_text("{}", encoding="utf-8")
+        (tmp_path / "lesson.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path, pedagogical=True)
+        assert result["total"] == 1
+
+    def test_pedagogical_includes_research_when_all(self, tmp_path):
+        research = tmp_path / "research"
+        research.mkdir()
+        (research / "analysis.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path, pedagogical=False)
+        assert result["total"] == 1
+
+    def test_pedagogical_excludes_archive(self, tmp_path):
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        (archive / "old.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path, pedagogical=True)
+        assert result["total"] == 0
+
+    def test_pedagogical_excludes_output(self, tmp_path):
+        sub = tmp_path / "lessons"
+        sub.mkdir()
+        (sub / "lesson_output.ipynb").write_text("{}", encoding="utf-8")
+        (sub / "lesson.ipynb").write_text("{}", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path, pedagogical=True)
+        assert result["total"] == 1
+
+    def test_non_ipynb_ignored(self, tmp_path):
+        (tmp_path / "readme.md").write_text("hi", encoding="utf-8")
+        (tmp_path / "script.py").write_text("pass", encoding="utf-8")
+        result = count_notebooks_in_dir(tmp_path)
+        assert result["total"] == 0
+
+
+class TestExtractReadmeCount:
+
+    def test_bold_notebooks(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("# Title\n> **28 notebooks Python**\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 28
+
+    def test_table_row_notebooks(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("| Notebooks | 15 |\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 15
+
+    def test_inline_notebooks_python(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("This series has 42 notebooks Python.\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 42
+
+    def test_inline_notebooks(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("Contains 10 notebooks.\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 10
+
+    def test_total_row(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("| Total | 84 |\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 84
+
+    def test_exercices(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("La serie contient 7 exercices.\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 7
+
+    def test_nonexistent_file(self, tmp_path):
+        assert extract_readme_count(tmp_path / "nonexistent.md") is None
+
+    def test_no_match(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("# Series Title\nSome description.\n", encoding="utf-8")
+        assert extract_readme_count(readme) is None
+
+    def test_first_match_wins(self, tmp_path):
+        readme = tmp_path / "README.md"
+        readme.write_text("**10 notebooks** and then 20 notebooks later.\n", encoding="utf-8")
+        assert extract_readme_count(readme) == 10

--- a/scripts/notebook_tools/tests/test_expand_catalog_markers.py
+++ b/scripts/notebook_tools/tests/test_expand_catalog_markers.py
@@ -1,0 +1,157 @@
+"""Tests for expand_catalog_markers.py — catalog marker expansion."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from expand_catalog_markers import (
+    compute_counter,
+    compute_breakdown,
+    compute_maturity_distribution,
+    compute_status_distribution,
+    format_catalog_status_block,
+    expand_file,
+)
+
+
+def _entry(serie="ML", status="READY", maturity="PRODUCTION", sous_serie=None, **kw):
+    e = {"serie": serie, "status": status, "maturity": maturity}
+    if sous_serie:
+        e["sous_serie"] = sous_serie
+    e.update(kw)
+    return e
+
+
+SAMPLE_ENTRIES = [
+    _entry(serie="ML", status="READY", maturity="PRODUCTION"),
+    _entry(serie="ML", status="READY", maturity="PRODUCTION"),
+    _entry(serie="ML", status="BROKEN", maturity="EXPERIMENTAL"),
+    _entry(serie="GenAI", status="READY", maturity="PRODUCTION", sous_serie="Image"),
+    _entry(serie="GenAI", status="READY", maturity="PRODUCTION", sous_serie="Audio"),
+    _entry(serie="GenAI", status="NEEDS_IMPROVEMENT", maturity="EXPERIMENTAL", sous_serie="Image"),
+]
+
+
+class TestComputeCounter:
+
+    def test_total(self):
+        assert compute_counter(SAMPLE_ENTRIES, {}) == "6"
+
+    def test_filter_serie(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"serie": "ML"}) == "3"
+
+    def test_filter_status(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"status": "BROKEN"}) == "1"
+
+    def test_filter_serie_and_status(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"serie": "ML", "status": "READY"}) == "2"
+
+    def test_filter_maturity(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"maturity": "PRODUCTION"}) == "4"
+
+    def test_filter_sous_serie(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"sous_serie": "Image"}) == "2"
+
+    def test_no_match(self):
+        assert compute_counter(SAMPLE_ENTRIES, {"serie": "NonExistent"}) == "0"
+
+
+class TestComputeBreakdown:
+
+    def test_breakdown_genai(self):
+        bd = compute_breakdown(SAMPLE_ENTRIES, "GenAI")
+        assert bd["Image"] == 2
+        assert bd["Audio"] == 1
+
+    def test_breakdown_no_sous_serie(self):
+        bd = compute_breakdown(SAMPLE_ENTRIES, "ML")
+        assert bd["_root"] == 3
+
+    def test_breakdown_empty(self):
+        bd = compute_breakdown(SAMPLE_ENTRIES, "NonExistent")
+        assert bd == {}
+
+
+class TestComputeMaturityDistribution:
+
+    def test_all(self):
+        dist = compute_maturity_distribution(SAMPLE_ENTRIES)
+        assert dist["PRODUCTION"] == 4
+        assert dist["EXPERIMENTAL"] == 2
+
+    def test_by_serie(self):
+        dist = compute_maturity_distribution(SAMPLE_ENTRIES, "ML")
+        assert dist["PRODUCTION"] == 2
+        assert dist["EXPERIMENTAL"] == 1
+
+
+class TestComputeStatusDistribution:
+
+    def test_all(self):
+        dist = compute_status_distribution(SAMPLE_ENTRIES)
+        assert dist["READY"] == 4
+        assert dist["BROKEN"] == 1
+        assert dist["NEEDS_IMPROVEMENT"] == 1
+
+    def test_by_serie(self):
+        dist = compute_status_distribution(SAMPLE_ENTRIES, "GenAI")
+        assert dist["READY"] == 2
+        assert dist["NEEDS_IMPROVEMENT"] == 1
+
+
+class TestFormatCatalogStatusBlock:
+
+    def test_serie_block(self):
+        block = format_catalog_status_block(SAMPLE_ENTRIES, "ML")
+        assert "series: ML" in block
+        assert "pedagogical_count: 3" in block
+        assert "CATALOG-STATUS" in block
+
+    def test_all_block(self):
+        block = format_catalog_status_block(SAMPLE_ENTRIES, "ALL")
+        assert "series: ALL" in block
+        assert "total: 6" in block
+
+
+class TestExpandFile:
+
+    def test_no_markers(self):
+        content = "# Title\nSome text.\n"
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        assert new_content == content
+        assert changes == []
+
+    def test_counter_marker_preserved(self):
+        content = "<!-- CATALOG:counter:total -->\n"
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        # The marker itself is preserved (not replaced with a number)
+        assert "CATALOG:counter:total" in new_content
+
+    def test_counter_with_params(self):
+        content = "<!-- CATALOG:counter:serie=ML -->\n"
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        assert "CATALOG:counter:serie=ML" in new_content
+
+    def test_catalog_status_block_updated(self):
+        content = "<!-- CATALOG-STATUS\nseries: ML\n-->\n"
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        assert "series: ML" in new_content
+        assert "pedagogical_count: 3" in new_content
+
+    def test_catalog_status_block_all(self):
+        content = "<!-- CATALOG-STATUS\nseries: ALL\n-->\n"
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        assert "total: 6" in new_content
+
+    def test_mixed_markers(self):
+        content = (
+            "# Title\n"
+            "<!-- CATALOG:counter:total -->\n"
+            "<!-- CATALOG-STATUS\nseries: ML\n-->\n"
+        )
+        new_content, changes = expand_file(content, SAMPLE_ENTRIES)
+        assert "CATALOG:counter:total" in new_content
+        assert "series: ML" in new_content


### PR DESCRIPTION
## Summary
- 20 tests for `count_notebooks_by_series.py`: notebook counting with exclusion logic (checkpoints, pycache, research, archive, _output), README count extraction (7 pattern types)
- 22 tests for `expand_catalog_markers.py`: `compute_counter`, `compute_breakdown`, `compute_maturity_distribution`, `compute_status_distribution`, `format_catalog_status_block`, `expand_file`
- Continues Hermes audit finding #6 (test coverage for Python scripts)

## Test plan
- [x] All 42 tests pass (`pytest --import-mode=importlib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)