### PR TITLE
feat(ml): Stage 0 discipline scripts (98/98 tests)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/baselines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/baselines.py
@@ -1,0 +1,263 @@
+"""
+Baseline models for financial direction prediction evaluation.
+
+Every ML model must beat these baselines to be considered useful.
+If your model's DirAcc <= majority_class or Sharpe <= random_walk,
+it is not adding value.
+
+References:
+    - Hands-On AI Trading with Python, Pik et al., Wiley 2025
+    - Lopez de Prado, "Advances in Financial Machine Learning" (AFML)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def majority_class_baseline(y_train: np.ndarray | pd.Series, y_test: np.ndarray | pd.Series) -> dict:
+    """Predict the most frequent class from training data for all test samples.
+
+    This is the absolute floor for direction accuracy. Any model with
+    DirAcc <= this baseline is a majority class predictor and adds no value.
+
+    Parameters
+    ----------
+    y_train : array-like
+        Training labels (0=down, 1=up or -1/1).
+    y_test : array-like
+        Test labels.
+
+    Returns
+    -------
+    dict with keys: accuracy, majority_class, majority_freq, n_train, n_test.
+    """
+    y_train = np.asarray(y_train)
+    y_test = np.asarray(y_test)
+
+    classes, counts = np.unique(y_train, return_counts=True)
+    majority_idx = np.argmax(counts)
+    majority = classes[majority_idx]
+    freq = counts[majority_idx] / len(y_train)
+
+    predictions = np.full(len(y_test), majority)
+    accuracy = np.mean(predictions == y_test)
+
+    return {
+        "accuracy": float(accuracy),
+        "majority_class": int(majority),
+        "majority_freq": float(freq),
+        "n_train": len(y_train),
+        "n_test": len(y_test),
+    }
+
+
+def naive_momentum_baseline(
+    prices: pd.Series | np.ndarray,
+    lookback: int = 20,
+    test_start: int | None = None,
+) -> dict:
+    """Simple moving average crossover: buy if price > MA(lookback), else sell.
+
+    Industry-standard naive baseline for direction prediction.
+
+    Parameters
+    ----------
+    prices : array-like
+        Price series.
+    lookback : int
+        Moving average window.
+    test_start : int or None
+        Index at which evaluation begins. If None, evaluates on all data
+        after the first lookback period.
+
+    Returns
+    -------
+    dict with keys: accuracy, sharpe, returns, n_signals, lookback.
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    ma = prices.rolling(lookback).mean()
+    direction = (prices > ma).astype(int)
+
+    # Shift to avoid look-ahead: predict tomorrow's direction from today's signal
+    forward_return = prices.pct_change().shift(-1)
+    predicted_up = direction
+
+    start = test_start if test_start is not None else lookback
+    valid = slice(start, len(prices) - 1)
+
+    actual_up = (forward_return[valid] > 0).astype(int)
+    predicted = predicted_up[valid]
+
+    accuracy = float(np.mean(predicted.values == actual_up.values))
+
+    # Calculate Sharpe from strategy returns
+    strategy_returns = forward_return[valid] * (2 * predicted.values - 1)
+    sharpe = _sharpe_from_returns(strategy_returns.dropna())
+
+    return {
+        "accuracy": accuracy,
+        "sharpe": float(sharpe),
+        "lookback": lookback,
+        "n_signals": int(len(predicted)),
+        "start": start,
+    }
+
+
+def random_walk_baseline(
+    prices: pd.Series | np.ndarray,
+    n_simulations: int = 1000,
+    seed: int = 42,
+    test_start: int | None = None,
+) -> dict:
+    """Distribution of Sharpe ratios under the null hypothesis of random trading.
+
+    Generates random long/short signals and computes the distribution of
+    resulting Sharpe ratios. Used for deflated Sharpe ratio testing
+    (AFML Chapter 14) to account for multiple testing.
+
+    Parameters
+    ----------
+    prices : array-like
+        Price series.
+    n_simulations : int
+        Number of random strategy simulations.
+    seed : int
+        Random seed for reproducibility.
+    test_start : int or None
+        Index at which evaluation begins.
+
+    Returns
+    -------
+    dict with keys: sharpe_mean, sharpe_std, sharpe_p95, diracc_mean,
+                    diracc_std, n_simulations, observed_sharpes.
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    returns = prices.pct_change().dropna()
+
+    start = test_start if test_start is not None else 0
+    test_returns = returns.iloc[start:]
+
+    rng = np.random.default_rng(seed)
+    sharpes = []
+    diraccs = []
+
+    for _ in range(n_simulations):
+        # Random long/short with 50/50 probability
+        signals = rng.choice([-1, 1], size=len(test_returns))
+        strategy_returns = test_returns.values * signals
+        sharpe = _sharpe_from_returns(pd.Series(strategy_returns))
+        sharpes.append(sharpe)
+
+        # Direction accuracy
+        predicted_up = (signals == 1).astype(int)
+        actual_up = (test_returns.values > 0).astype(int)
+        diraccs.append(np.mean(predicted_up == actual_up))
+
+    sharpes = np.array(sharpes)
+    diraccs = np.array(diraccs)
+
+    return {
+        "sharpe_mean": float(np.mean(sharpes)),
+        "sharpe_std": float(np.std(sharpes)),
+        "sharpe_p95": float(np.percentile(sharpes, 95)),
+        "diracc_mean": float(np.mean(diraccs)),
+        "diracc_std": float(np.std(diraccs)),
+        "n_simulations": n_simulations,
+        "n_test_samples": len(test_returns),
+    }
+
+
+def buy_and_hold_baseline(
+    prices: pd.Series | np.ndarray,
+    test_start: int | None = None,
+) -> dict:
+    """Buy-and-hold reference. Every long-only strategy must beat this.
+
+    Parameters
+    ----------
+    prices : array-like
+        Price series.
+    test_start : int or None
+        Index at which evaluation begins.
+
+    Returns
+    -------
+    dict with keys: total_return, cagr, sharpe, max_drawdown, volatility,
+                    n_days, start_price, end_price.
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    returns = prices.pct_change().dropna()
+
+    start = test_start if test_start is not None else 0
+    test_returns = returns.iloc[start:]
+    test_prices = prices.iloc[start:]
+
+    if len(test_returns) == 0:
+        return {
+            "total_return": 0.0,
+            "cagr": 0.0,
+            "sharpe": 0.0,
+            "max_drawdown": 0.0,
+            "volatility": 0.0,
+            "n_days": 0,
+        }
+
+    total_return = float(test_prices.iloc[-1] / test_prices.iloc[0] - 1)
+    n_years = len(test_returns) / 252
+    cagr = float((1 + total_return) ** (1 / max(n_years, 1e-6)) - 1) if total_return > -1 else -1.0
+
+    sharpe = _sharpe_from_returns(test_returns)
+
+    # Max drawdown
+    cummax = test_prices.cummax()
+    drawdown = (test_prices - cummax) / cummax
+    max_dd = float(drawdown.min())
+
+    volatility = float(test_returns.std() * np.sqrt(252))
+
+    return {
+        "total_return": total_return,
+        "cagr": cagr,
+        "sharpe": float(sharpe),
+        "max_drawdown": max_dd,
+        "volatility": volatility,
+        "n_days": len(test_returns),
+        "start_price": float(test_prices.iloc[0]),
+        "end_price": float(test_prices.iloc[-1]),
+    }
+
+
+def _sharpe_from_returns(returns: pd.Series, annualize: bool = True, risk_free: float = 0.0) -> float:
+    """Compute Sharpe ratio from a returns series.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Strategy or asset returns.
+    annualize : bool
+        Annualize using sqrt(252).
+    risk_free : float
+        Risk-free rate (annualized).
+
+    Returns
+    -------
+    float : Sharpe ratio.
+    """
+    if len(returns) == 0:
+        return 0.0
+
+    mean_ret = returns.mean()
+    std_ret = returns.std()
+
+    if std_ret < 1e-12 or np.isnan(std_ret):
+        return 0.0
+
+    daily_rf = risk_free / 252
+    sharpe = (mean_ret - daily_rf) / std_ret
+
+    if annualize:
+        sharpe *= np.sqrt(252)
+
+    return float(sharpe)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_finstsb.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_finstsb.py
@@ -1,0 +1,243 @@
+"""
+FinTSB-style evaluation with regime detection for financial ML models.
+
+Evaluates model performance across 4 market regimes (uptrend, downtrend,
+volatility, black_swan) to ensure strategies don't just work in one regime.
+
+References:
+    - FinTSB: TongjiFinLab/FinTSB (https://github.com/TongjiFinLab/FinTSB, 2025)
+    - Hands-On AI Trading with Python, Pik et al., Wiley 2025
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing import Protocol
+
+
+class DirectionModel(Protocol):
+    """Protocol for models that predict price direction."""
+
+    def predict(self, X: np.ndarray) -> np.ndarray: ...
+
+
+def detect_regimes(
+    prices: pd.Series | np.ndarray,
+    lookback_days: int = 60,
+    uptrend_threshold: float = 0.10,
+    downtrend_threshold: float = -0.10,
+    volatility_percentile: float = 75,
+    black_swan_drawdown: float = -0.20,
+    black_swan_window: int = 30,
+) -> pd.Series:
+    """Classify each date into a market regime.
+
+    Parameters
+    ----------
+    prices : array-like
+        Daily price series.
+    lookback_days : int
+        Rolling window for regime detection.
+    uptrend_threshold : float
+        Minimum rolling return to classify as uptrend (annualized ~10%).
+    downtrend_threshold : float
+        Maximum rolling return to classify as downtrend.
+    volatility_percentile : float
+        Percentile threshold for high-volatility regime (0-100).
+    black_swan_drawdown : float
+        Drawdown threshold for black swan (e.g. -0.20 = -20%).
+    black_swan_window : int
+        Window for drawdown calculation.
+
+    Returns
+    -------
+    pd.Series of regime labels: "uptrend", "downtrend", "volatility", "black_swan".
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    returns = prices.pct_change()
+
+    # Rolling return over lookback
+    rolling_return = prices.pct_change(lookback_days)
+
+    # Rolling volatility (annualized)
+    rolling_std = returns.rolling(lookback_days).std() * np.sqrt(252)
+    vol_threshold = rolling_std.quantile(volatility_percentile / 100)
+
+    # Rolling drawdown
+    rolling_max = prices.rolling(black_swan_window, min_periods=1).max()
+    drawdown = (prices - rolling_max) / rolling_max
+
+    regimes = pd.Series("normal", index=prices.index, dtype="object")
+
+    # Black swan first (highest priority)
+    black_swan_mask = drawdown <= black_swan_drawdown
+    regimes[black_swan_mask] = "black_swan"
+
+    # Uptrend: strong positive returns
+    uptrend_mask = (rolling_return >= uptrend_threshold) & (regimes == "normal")
+    regimes[uptrend_mask] = "uptrend"
+
+    # Downtrend: strong negative returns
+    downtrend_mask = (rolling_return <= downtrend_threshold) & (regimes == "normal")
+    regimes[downtrend_mask] = "downtrend"
+
+    # Volatility: high std (remaining non-classified)
+    vol_mask = (rolling_std >= vol_threshold) & (regimes == "normal")
+    regimes[vol_mask] = "volatility"
+
+    # Remaining = normal (subset of uptrend or quiet market)
+    # For evaluation purposes, fold "normal" into closest regime
+    normal_mask = regimes == "normal"
+    # If positive return and not classified, treat as mild uptrend
+    mild_up = normal_mask & (rolling_return > 0)
+    regimes[mild_up] = "uptrend"
+    # If negative return and not classified, treat as mild downtrend
+    mild_down = normal_mask & (rolling_return <= 0)
+    regimes[mild_down] = "downtrend"
+
+    # Fill NaN from rolling calculations
+    regimes[:lookback_days] = "normal"
+
+    return regimes
+
+
+def eval_per_regime(
+    model: DirectionModel,
+    X: np.ndarray,
+    y: np.ndarray,
+    prices: pd.Series | np.ndarray,
+    regimes: pd.Series | None = None,
+) -> dict:
+    """Evaluate model performance per market regime.
+
+    Parameters
+    ----------
+    model : DirectionModel
+        Model with a predict() method.
+    X : np.ndarray
+        Feature matrix.
+    y : np.ndarray
+        True labels (0=down, 1=up).
+    prices : array-like
+        Price series for regime detection.
+    regimes : pd.Series or None
+        Pre-computed regime labels. If None, computed from prices.
+
+    Returns
+    -------
+    dict with per-regime metrics and weighted average.
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    n = min(len(X), len(y), len(prices))
+    X = X[:n]
+    y = y[:n]
+    prices = prices[:n]
+
+    if regimes is None:
+        regimes = detect_regimes(prices)
+    regimes = regimes.iloc[:n].reset_index(drop=True)
+
+    predictions = model.predict(X)
+    returns = prices.pct_change().fillna(0).values[:n]
+
+    results = {}
+    regime_counts = {}
+
+    for regime in ["uptrend", "downtrend", "volatility", "black_swan"]:
+        mask = regimes.values == regime
+        n_samples = int(mask.sum())
+
+        if n_samples < 5:
+            results[regime] = {
+                "diracc": float("nan"),
+                "sharpe": float("nan"),
+                "n_samples": n_samples,
+            }
+            regime_counts[regime] = 0
+            continue
+
+        regime_y = y[mask]
+        regime_pred = predictions[mask]
+        regime_returns = returns[mask]
+
+        diracc = float(np.mean(regime_pred == regime_y))
+
+        # Strategy returns: long if predict up, short if predict down
+        strategy_returns = regime_returns * (2 * regime_pred - 1)
+        sharpe = _sharpe(strategy_returns)
+
+        results[regime] = {
+            "diracc": diracc,
+            "sharpe": sharpe,
+            "n_samples": n_samples,
+        }
+        regime_counts[regime] = n_samples
+
+    # Weighted average Sharpe
+    total = sum(regime_counts.values())
+    if total > 0:
+        weights = {r: c / total for r, c in regime_counts.items() if c > 0}
+        weighted_sharpe = sum(
+            weights.get(r, 0) * results[r]["sharpe"]
+            for r in weights
+            if not np.isnan(results[r].get("sharpe", float("nan")))
+        )
+        weighted_diracc = sum(
+            weights.get(r, 0) * results[r]["diracc"]
+            for r in weights
+            if not np.isnan(results[r].get("diracc", float("nan")))
+        )
+    else:
+        weighted_sharpe = float("nan")
+        weighted_diracc = float("nan")
+
+    results["weighted_avg"] = {
+        "diracc": weighted_diracc,
+        "sharpe": weighted_sharpe,
+        "n_samples": total,
+    }
+
+    return results
+
+
+def validate_no_regime_failure(eval_results: dict, min_sharpe: float = 0.0) -> tuple[bool, list[str]]:
+    """Check that no regime has Sharpe below minimum threshold.
+
+    A strategy that only works in one regime (e.g. uptrend) is fragile.
+
+    Parameters
+    ----------
+    eval_results : dict
+        Output from eval_per_regime().
+    min_sharpe : float
+        Minimum acceptable Sharpe per regime.
+
+    Returns
+    -------
+    (passed, failures) : tuple of bool and list of regime names that failed.
+    """
+    failures = []
+    for regime in ["uptrend", "downtrend", "volatility", "black_swan"]:
+        if regime not in eval_results:
+            continue
+        regime_data = eval_results[regime]
+        if regime_data["n_samples"] < 5:
+            continue
+        sharpe = regime_data.get("sharpe", float("nan"))
+        if np.isnan(sharpe):
+            failures.append(f"{regime}: insufficient data (Sharpe=NaN)")
+        elif sharpe < min_sharpe:
+            failures.append(f"{regime}: Sharpe={sharpe:.3f} < {min_sharpe}")
+
+    return len(failures) == 0, failures
+
+
+def _sharpe(returns: np.ndarray, annualize: bool = True) -> float:
+    """Compute Sharpe ratio from returns array."""
+    if len(returns) == 0 or np.std(returns) < 1e-12:
+        return 0.0
+    sharpe = np.mean(returns) / np.std(returns)
+    if annualize:
+        sharpe *= np.sqrt(252)
+    return float(sharpe)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
@@ -1,0 +1,200 @@
+"""Tests for baselines.py — baseline models for financial ML evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.baselines import (
+    buy_and_hold_baseline,
+    majority_class_baseline,
+    naive_momentum_baseline,
+    random_walk_baseline,
+    _sharpe_from_returns,
+)
+
+
+class TestMajorityClassBaseline:
+    def test_balanced_classes(self):
+        y_train = np.array([0, 1, 0, 1, 0, 1])
+        y_test = np.array([0, 1, 0, 1])
+        result = majority_class_baseline(y_train, y_test)
+        assert result["accuracy"] == 0.5
+        assert result["n_train"] == 6
+        assert result["n_test"] == 4
+
+    def test_imbalanced_majority_up(self):
+        y_train = np.array([1, 1, 1, 1, 0, 0])
+        y_test = np.array([1, 0, 1, 1])
+        result = majority_class_baseline(y_train, y_test)
+        assert result["majority_class"] == 1
+        assert result["majority_freq"] == pytest.approx(4 / 6)
+        assert result["accuracy"] == 0.75  # 3/4 correct
+
+    def test_imbalanced_majority_down(self):
+        y_train = np.array([0, 0, 0, 1, 1])
+        y_test = np.array([0, 0, 1])
+        result = majority_class_baseline(y_train, y_test)
+        assert result["majority_class"] == 0
+        assert result["accuracy"] == pytest.approx(2 / 3)
+
+    def test_all_same_class(self):
+        y_train = np.ones(100)
+        y_test = np.ones(20)
+        result = majority_class_baseline(y_train, y_test)
+        assert result["accuracy"] == 1.0
+        assert result["majority_freq"] == 1.0
+
+    def test_spy_like_frequency(self):
+        """SPY up-day frequency ~54% is a realistic check."""
+        rng = np.random.default_rng(42)
+        y_train = rng.choice([0, 1], size=1000, p=[0.46, 0.54])
+        result = majority_class_baseline(y_train, y_train)
+        assert 0.50 <= result["majority_freq"] <= 0.60
+
+
+class TestNaiveMomentumBaseline:
+    @pytest.fixture
+    def trending_prices(self):
+        """Monotonically increasing prices."""
+        return pd.Series(np.arange(100, 200, dtype=float))
+
+    @pytest.fixture
+    def mean_revert_prices(self):
+        """Oscillating prices around 100."""
+        t = np.arange(200)
+        return pd.Series(100 + 5 * np.sin(t * 2 * np.pi / 20))
+
+    def test_high_accuracy_trending(self, trending_prices):
+        result = naive_momentum_baseline(trending_prices, lookback=10)
+        assert result["accuracy"] > 0.8
+
+    def test_returns_lookback(self, trending_prices):
+        result = naive_momentum_baseline(trending_prices, lookback=5)
+        assert result["lookback"] == 5
+
+    def test_sharpe_positive_trending(self, trending_prices):
+        result = naive_momentum_baseline(trending_prices, lookback=10)
+        assert result["sharpe"] > 0
+
+    def test_oscillating_lower_accuracy(self, mean_revert_prices):
+        result = naive_momentum_baseline(mean_revert_prices, lookback=20)
+        # MA crossover on mean-reverting data should be near 50%
+        assert 0.3 <= result["accuracy"] <= 0.7
+
+    def test_test_start_parameter(self, trending_prices):
+        result = naive_momentum_baseline(trending_prices, lookback=10, test_start=50)
+        assert result["start"] == 50
+
+
+class TestRandomWalkBaseline:
+    @pytest.fixture
+    def spy_like_prices(self):
+        """Simulate SPY-like price series."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0004, 0.01, size=500)
+        prices = 100 * np.cumprod(1 + returns)
+        return pd.Series(prices)
+
+    def test_sharpe_centered_near_zero(self, spy_like_prices):
+        result = random_walk_baseline(spy_like_prices, n_simulations=500, seed=42)
+        assert abs(result["sharpe_mean"]) < 1.0
+
+    def test_diracc_near_50_percent(self, spy_like_prices):
+        result = random_walk_baseline(spy_like_prices, n_simulations=500, seed=42)
+        assert abs(result["diracc_mean"] - 0.5) < 0.05
+
+    def test_reproducible_with_seed(self, spy_like_prices):
+        r1 = random_walk_baseline(spy_like_prices, seed=123)
+        r2 = random_walk_baseline(spy_like_prices, seed=123)
+        assert r1["sharpe_mean"] == r2["sharpe_mean"]
+
+    def test_different_seeds_different_results(self, spy_like_prices):
+        r1 = random_walk_baseline(spy_like_prices, seed=1)
+        r2 = random_walk_baseline(spy_like_prices, seed=2)
+        assert r1["sharpe_mean"] != r2["sharpe_mean"]
+
+    def test_p95_greater_than_mean(self, spy_like_prices):
+        result = random_walk_baseline(spy_like_prices, n_simulations=500, seed=42)
+        assert result["sharpe_p95"] > result["sharpe_mean"]
+
+    def test_n_simulations(self, spy_like_prices):
+        result = random_walk_baseline(spy_like_prices, n_simulations=50)
+        assert result["n_simulations"] == 50
+
+
+class TestBuyAndHoldBaseline:
+    @pytest.fixture
+    def spy_like_prices(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0004, 0.01, size=500)
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    def test_positive_total_return(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["total_return"] > 0
+
+    def test_positive_cagr(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["cagr"] > 0
+
+    def test_positive_sharpe(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["sharpe"] > 0
+
+    def test_max_drawdown_negative(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["max_drawdown"] < 0
+
+    def test_volatility_positive(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["volatility"] > 0
+
+    def test_n_days_matches(self, spy_like_prices):
+        result = buy_and_hold_baseline(spy_like_prices)
+        assert result["n_days"] == 499  # n-1 returns
+
+    def test_declining_prices(self):
+        prices = pd.Series(np.linspace(100, 50, 100))
+        result = buy_and_hold_baseline(prices)
+        assert result["total_return"] < 0
+        assert result["cagr"] < 0
+
+    def test_flat_prices(self):
+        prices = pd.Series(np.full(100, 100.0))
+        result = buy_and_hold_baseline(prices)
+        assert result["total_return"] == pytest.approx(0.0)
+        assert result["sharpe"] == pytest.approx(0.0)
+
+    def test_test_start(self, spy_like_prices):
+        full = buy_and_hold_baseline(spy_like_prices)
+        half = buy_and_hold_baseline(spy_like_prices, test_start=250)
+        assert half["n_days"] < full["n_days"]
+
+
+class TestSharpeFromReturns:
+    def test_zero_returns(self):
+        assert _sharpe_from_returns(pd.Series([])) == 0.0
+
+    def test_constant_returns(self):
+        assert _sharpe_from_returns(pd.Series([0.01] * 100)) == 0.0
+
+    def test_positive_mean(self):
+        rng = np.random.default_rng(42)
+        returns = pd.Series(rng.normal(0.001, 0.01, 252))
+        sharpe = _sharpe_from_returns(returns)
+        assert sharpe > 0
+
+    def test_negative_mean(self):
+        rng = np.random.default_rng(99)
+        returns = pd.Series(rng.normal(-0.005, 0.01, 252))
+        sharpe = _sharpe_from_returns(returns)
+        assert sharpe < 0
+
+    def test_no_annualize(self):
+        rng = np.random.default_rng(42)
+        r = pd.Series(rng.normal(0.001, 0.01, 252))
+        s_ann = _sharpe_from_returns(r, annualize=True)
+        s_raw = _sharpe_from_returns(r, annualize=False)
+        assert abs(s_ann) > abs(s_raw)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
@@ -1,0 +1,294 @@
+"""Tests for eval_finstsb.py — FinTSB-style regime evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.eval_finstsb import (
+    detect_regimes,
+    eval_per_regime,
+    validate_no_regime_failure,
+    _sharpe,
+)
+
+
+class TestDetectRegimes:
+    """Market regime detection tests."""
+
+    @pytest.fixture
+    def trending_up_prices(self):
+        """Monotonically increasing prices → should detect uptrend."""
+        return pd.Series(np.linspace(100, 200, 252))
+
+    @pytest.fixture
+    def trending_down_prices(self):
+        """Monotonically decreasing prices → should detect downtrend."""
+        return pd.Series(np.linspace(200, 100, 252))
+
+    @pytest.fixture
+    def spy_2018_prices(self):
+        """SPY-like prices with 2018 Q4 selloff pattern.
+
+        Jan-Oct uptrend, Oct-Dec ~20% drawdown then recovery.
+        """
+        rng = np.random.default_rng(42)
+        # 200 days uptrend, 50 days selloff, 50 days recovery
+        n = 300
+        returns = rng.normal(0.0005, 0.005, n)
+        # Inject selloff at day 200
+        returns[200:220] = -0.02
+        returns[220:250] = 0.005  # recovery
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    @pytest.fixture
+    def covid_crash_prices(self):
+        """Prices with a sudden ~30% crash (march 2020-like)."""
+        rng = np.random.default_rng(42)
+        n = 200
+        returns = rng.normal(0.0003, 0.008, n)
+        # Sudden crash over 15 days
+        returns[100:115] = -0.025
+        returns[115:130] = 0.015  # bounce
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    def test_uptrend_detected(self, trending_up_prices):
+        regimes = detect_regimes(trending_up_prices, lookback_days=20)
+        assert "uptrend" in regimes.values
+
+    def test_downtrend_detected(self, trending_down_prices):
+        regimes = detect_regimes(trending_down_prices, lookback_days=20)
+        assert "downtrend" in regimes.values
+
+    def test_no_normal_remaining(self, trending_up_prices):
+        """All observations should be classified into a regime (not 'normal')."""
+        regimes = detect_regimes(trending_up_prices, lookback_days=20)
+        # Only the first lookback_days can be 'normal' (NaN fill)
+        non_initial = regimes.iloc[20:]
+        assert "normal" not in non_initial.values
+
+    def test_black_swan_in_crash(self, covid_crash_prices):
+        """A -30% drawdown should trigger black_swan regime."""
+        regimes = detect_regimes(
+            covid_crash_prices,
+            lookback_days=20,
+            black_swan_drawdown=-0.20,
+            black_swan_window=30,
+        )
+        assert "black_swan" in regimes.values
+
+    def test_returns_series_same_length(self, trending_up_prices):
+        regimes = detect_regimes(trending_up_prices)
+        assert len(regimes) == len(trending_up_prices)
+
+    def test_lookback_fill(self, trending_up_prices):
+        """First lookback_days observations should be 'normal' (NaN fill)."""
+        lookback = 30
+        regimes = detect_regimes(trending_up_prices, lookback_days=lookback)
+        assert (regimes.iloc[:lookback] == "normal").all()
+
+    def test_known_regimes_count(self):
+        """At least 3 different regimes in a varied price series."""
+        rng = np.random.default_rng(42)
+        n = 500
+        returns = rng.normal(0.0003, 0.015, n)
+        # Inject crash
+        returns[300:315] = -0.03
+        prices = pd.Series(100 * np.cumprod(1 + returns))
+        regimes = detect_regimes(prices, lookback_days=30)
+        unique = set(regimes.iloc[30:].values)  # skip initial fill
+        assert len(unique) >= 3
+
+    def test_custom_thresholds(self, trending_up_prices):
+        """Very high threshold should classify less as uptrend."""
+        low_thresh = detect_regimes(trending_up_prices, uptrend_threshold=0.01, lookback_days=20)
+        high_thresh = detect_regimes(trending_up_prices, uptrend_threshold=0.50, lookback_days=20)
+        n_up_low = (low_thresh == "uptrend").sum()
+        n_up_high = (high_thresh == "uptrend").sum()
+        assert n_up_low >= n_up_high
+
+
+class TestEvalPerRegime:
+    """Per-regime evaluation tests."""
+
+    @pytest.fixture
+    def perfect_model(self):
+        """Model that always predicts correctly."""
+
+        class Perfect:
+            def predict(self, X):
+                return np.array([1 if x[0] > 0 else 0 for x in X])
+
+        return Perfect()
+
+    @pytest.fixture
+    def random_model(self):
+        """Model that predicts randomly."""
+
+        class Random:
+            def __init__(self):
+                self.rng = np.random.default_rng(42)
+
+            def predict(self, X):
+                return self.rng.choice([0, 1], size=len(X))
+
+        return Random()
+
+    @pytest.fixture
+    def sample_data(self):
+        """Generate sample features, labels, and prices."""
+        rng = np.random.default_rng(42)
+        n = 300
+        prices = pd.Series(100 * np.cumprod(1 + rng.normal(0.0003, 0.01, n)))
+        returns = prices.pct_change().fillna(0).values
+        y = (returns > 0).astype(int)
+        X = rng.normal(0, 1, (n, 5))
+        # Make features predictive: X[:, 0] correlates with returns
+        X[:, 0] = returns + rng.normal(0, 0.1, n)
+        return X, y, prices
+
+    def test_perfect_model_high_diracc(self, perfect_model, sample_data):
+        X, y, prices = sample_data
+        results = eval_per_regime(perfect_model, X, y, prices)
+        # At least one regime should have high accuracy
+        max_acc = max(
+            results[r]["diracc"]
+            for r in ["uptrend", "downtrend", "volatility", "black_swan"]
+            if not np.isnan(results[r].get("diracc", float("nan")))
+        )
+        assert max_acc > 0.5
+
+    def test_weighted_avg_present(self, random_model, sample_data):
+        X, y, prices = sample_data
+        results = eval_per_regime(random_model, X, y, prices)
+        assert "weighted_avg" in results
+        assert "diracc" in results["weighted_avg"]
+        assert "sharpe" in results["weighted_avg"]
+
+    def test_all_regimes_present(self, random_model, sample_data):
+        X, y, prices = sample_data
+        results = eval_per_regime(random_model, X, y, prices)
+        for regime in ["uptrend", "downtrend", "volatility", "black_swan"]:
+            assert regime in results
+            assert "diracc" in results[regime]
+            assert "sharpe" in results[regime]
+            assert "n_samples" in results[regime]
+
+    def test_n_samples_sum(self, random_model, sample_data):
+        X, y, prices = sample_data
+        results = eval_per_regime(random_model, X, y, prices)
+        total = sum(
+            results[r]["n_samples"]
+            for r in ["uptrend", "downtrend", "volatility", "black_swan"]
+        )
+        assert total == results["weighted_avg"]["n_samples"]
+
+    def test_custom_regimes(self, random_model, sample_data):
+        """Passing pre-computed regimes should work."""
+        X, y, prices = sample_data
+        n = len(X)
+        regimes = detect_regimes(prices)
+        results = eval_per_regime(random_model, X, y, prices, regimes=regimes)
+        assert "weighted_avg" in results
+
+    def test_few_samples_nan(self, random_model):
+        """With very few samples in a regime, metrics should be NaN."""
+        X = np.random.randn(10, 3)
+        y = np.array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+        prices = pd.Series(np.linspace(100, 101, 10))
+        # Small lookback to get some regime labels
+        regimes = detect_regimes(prices, lookback_days=3)
+        # Override to force tiny regime
+        regimes.iloc[:3] = "black_swan"
+        results = eval_per_regime(random_model, X, y, prices, regimes=regimes)
+        # black_swan has < 5 samples → NaN
+        if results["black_swan"]["n_samples"] < 5:
+            assert np.isnan(results["black_swan"]["diracc"])
+
+
+class TestValidateNoRegimeFailure:
+    """Regime failure validation tests."""
+
+    def test_all_pass(self):
+        results = {
+            "uptrend": {"sharpe": 1.5, "n_samples": 100},
+            "downtrend": {"sharpe": 0.5, "n_samples": 80},
+            "volatility": {"sharpe": 0.2, "n_samples": 50},
+            "black_swan": {"sharpe": 0.1, "n_samples": 10},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.0)
+        assert passed is True
+        assert len(failures) == 0
+
+    def test_one_regime_fails(self):
+        results = {
+            "uptrend": {"sharpe": 1.5, "n_samples": 100},
+            "downtrend": {"sharpe": -0.5, "n_samples": 80},
+            "volatility": {"sharpe": 0.2, "n_samples": 50},
+            "black_swan": {"sharpe": 0.1, "n_samples": 10},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.0)
+        assert passed is False
+        assert any("downtrend" in f for f in failures)
+
+    def test_nan_sharpe_fails(self):
+        results = {
+            "uptrend": {"sharpe": 1.5, "n_samples": 100},
+            "downtrend": {"sharpe": float("nan"), "n_samples": 80},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.0)
+        assert passed is False
+
+    def test_few_samples_skipped(self):
+        """Regimes with < 5 samples are skipped."""
+        results = {
+            "uptrend": {"sharpe": 1.5, "n_samples": 100},
+            "black_swan": {"sharpe": -5.0, "n_samples": 3},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.0)
+        assert passed is True  # black_swan skipped due to n_samples < 5
+
+    def test_custom_min_sharpe(self):
+        results = {
+            "uptrend": {"sharpe": 1.5, "n_samples": 100},
+            "downtrend": {"sharpe": 0.3, "n_samples": 80},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.5)
+        assert passed is False
+        assert any("downtrend" in f for f in failures)
+
+    def test_missing_regime_ok(self):
+        """Missing regime key is simply ignored."""
+        results = {
+            "uptrend": {"sharpe": 1.0, "n_samples": 100},
+        }
+        passed, failures = validate_no_regime_failure(results, min_sharpe=0.0)
+        assert passed is True
+
+
+class TestSharpe:
+    """Internal Sharpe ratio helper tests."""
+
+    def test_empty_returns(self):
+        assert _sharpe(np.array([])) == 0.0
+
+    def test_zero_std(self):
+        assert _sharpe(np.array([0.01] * 100)) == 0.0
+
+    def test_positive_sharpe(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.001, 0.01, 252)
+        assert _sharpe(returns) > 0
+
+    def test_negative_sharpe(self):
+        rng = np.random.default_rng(99)
+        returns = rng.normal(-0.005, 0.01, 252)
+        assert _sharpe(returns) < 0
+
+    def test_no_annualize(self):
+        rng = np.random.default_rng(42)
+        r = rng.normal(0.001, 0.01, 252)
+        s_ann = _sharpe(r, annualize=True)
+        s_raw = _sharpe(r, annualize=False)
+        assert abs(s_ann) > abs(s_raw)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
@@ -1,0 +1,179 @@
+"""Tests for transaction_costs.py — transaction cost modeling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.transaction_costs import (
+    TransactionCostModel,
+    compare_gross_vs_net,
+    _sharpe_from_array,
+)
+
+
+class TestTransactionCostModel:
+    """TransactionCostModel unit tests."""
+
+    def test_default_cost_positive(self):
+        model = TransactionCostModel()
+        cost = model.cost_per_trade(order_size=100)
+        assert cost > 0
+
+    def test_commission_only(self):
+        model = TransactionCostModel(
+            commission_bps=5.0,
+            bid_ask_spread_bps=0.0,
+            market_impact_coeff=0.0,
+            slippage_bps=0.0,
+        )
+        cost = model.cost_per_trade(order_size=100)
+        assert cost == pytest.approx(5.0 / 10_000)
+
+    def test_spread_only(self):
+        model = TransactionCostModel(
+            commission_bps=0.0,
+            bid_ask_spread_bps=3.0,
+            market_impact_coeff=0.0,
+            slippage_bps=0.0,
+        )
+        cost = model.cost_per_trade(order_size=100)
+        assert cost == pytest.approx(3.0 / 10_000)
+
+    def test_market_impact_increases_with_size(self):
+        model = TransactionCostModel(
+            commission_bps=0.0,
+            bid_ask_spread_bps=0.0,
+            market_impact_coeff=0.1,
+            daily_volume=10_000,
+        )
+        cost_small = model.cost_per_trade(order_size=10)
+        cost_large = model.cost_per_trade(order_size=1000)
+        assert cost_large > cost_small
+
+    def test_zero_volume_handled(self):
+        """Zero daily volume should not crash."""
+        model = TransactionCostModel(daily_volume=0.0)
+        cost = model.cost_per_trade(order_size=100)
+        assert np.isfinite(cost)
+
+    def test_apply_to_returns_reduces_performance(self):
+        model = TransactionCostModel(commission_bps=5.0)
+        gross = np.array([0.01, -0.005, 0.02, 0.005, -0.01])
+        trades = np.array([1, 0, 1, 0, 1])
+        net = model.apply_to_returns(gross, trades, order_size=100)
+        assert net.sum() < gross.sum()
+
+    def test_no_trades_no_cost(self):
+        model = TransactionCostModel(commission_bps=5.0)
+        gross = np.array([0.01, 0.02, 0.01])
+        trades = np.array([0, 0, 0])
+        net = model.apply_to_returns(gross, trades, order_size=100)
+        np.testing.assert_array_equal(net, gross)
+
+    def test_round_trip_cost(self):
+        """Each trade gets one deduction (half spread + commission)."""
+        model = TransactionCostModel(
+            commission_bps=2.0,
+            bid_ask_spread_bps=2.0,
+            market_impact_coeff=0.0,
+            slippage_bps=0.0,
+        )
+        gross = np.array([0.0, 0.0, 0.0])
+        trades = np.array([1.0, 0.0, 1.0])
+        net = model.apply_to_returns(gross, trades, order_size=100)
+        expected_cost = 4.0 / 10_000  # commission + spread
+        assert net[0] == pytest.approx(-expected_cost)
+        assert net[1] == pytest.approx(0.0)
+        assert net[2] == pytest.approx(-expected_cost)
+
+
+class TestCompareGrossVsNet:
+    """compare_gross_vs_net integration tests."""
+
+    @pytest.fixture
+    def sample_strategy(self):
+        """Generate a simple long/short strategy."""
+        rng = np.random.default_rng(42)
+        n = 252
+        gross = rng.normal(0.001, 0.01, n)
+        positions = np.ones(n)
+        # Flip positions occasionally
+        flip_indices = rng.choice(range(10, n), size=20, replace=False)
+        for idx in flip_indices:
+            positions[idx:] *= -1
+        return gross, positions
+
+    def test_net_sharpe_lower(self, sample_strategy):
+        gross, positions = sample_strategy
+        result = compare_gross_vs_net(gross, positions)
+        assert result["net_sharpe"] < result["gross_sharpe"]
+
+    def test_net_return_lower(self, sample_strategy):
+        gross, positions = sample_strategy
+        result = compare_gross_vs_net(gross, positions)
+        assert result["net_total_return"] < result["gross_total_return"]
+
+    def test_trade_count_positive(self, sample_strategy):
+        gross, positions = sample_strategy
+        result = compare_gross_vs_net(gross, positions)
+        assert result["n_trades"] > 0
+
+    def test_cost_drag_positive(self, sample_strategy):
+        gross, positions = sample_strategy
+        result = compare_gross_vs_net(gross, positions)
+        assert result["cost_drag_bps"] > 0
+
+    def test_frequency_between_zero_one(self, sample_strategy):
+        gross, positions = sample_strategy
+        result = compare_gross_vs_net(gross, positions)
+        assert 0 < result["trade_frequency"] < 1
+
+    def test_default_model(self):
+        """Without explicit model, default institutional model is used."""
+        gross = np.array([0.01, -0.005, 0.02])
+        positions = np.array([1, -1, 1])
+        result = compare_gross_vs_net(gross, positions)
+        assert "gross_sharpe" in result
+        assert "net_sharpe" in result
+
+    def test_custom_model(self):
+        """High-cost model should have larger drag."""
+        gross = np.array([0.01, -0.005, 0.02, 0.01, -0.01])
+        positions = np.array([1, -1, 1, -1, 1])
+
+        cheap = TransactionCostModel(commission_bps=0.5, bid_ask_spread_bps=0.5)
+        expensive = TransactionCostModel(commission_bps=10.0, bid_ask_spread_bps=10.0)
+
+        r_cheap = compare_gross_vs_net(gross, positions, cost_model=cheap)
+        r_expensive = compare_gross_vs_net(gross, positions, cost_model=expensive)
+
+        assert r_expensive["cost_drag_bps"] > r_cheap["cost_drag_bps"]
+
+
+class TestSharpeFromArray:
+    """Internal Sharpe helper tests."""
+
+    def test_empty(self):
+        assert _sharpe_from_array(np.array([])) == 0.0
+
+    def test_constant(self):
+        assert _sharpe_from_array(np.full(100, 0.01)) == 0.0
+
+    def test_positive(self):
+        rng = np.random.default_rng(42)
+        r = rng.normal(0.001, 0.01, 252)
+        assert _sharpe_from_array(r) > 0
+
+    def test_negative(self):
+        rng = np.random.default_rng(99)
+        r = rng.normal(-0.005, 0.01, 252)
+        assert _sharpe_from_array(r) < 0
+
+    def test_no_annualize(self):
+        rng = np.random.default_rng(42)
+        r = rng.normal(0.001, 0.01, 252)
+        s_ann = _sharpe_from_array(r, annualize=True)
+        s_raw = _sharpe_from_array(r, annualize=False)
+        assert abs(s_ann) > abs(s_raw)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
@@ -1,0 +1,239 @@
+"""Tests for walk_forward.py — WalkForwardSplitter and PurgedKFold."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from scripts.walk_forward import (
+    PurgedKFold,
+    WalkForwardSplitter,
+    combinatorial_purged_split,
+)
+
+
+# ---------------------------------------------------------------------------
+# WalkForwardSplitter
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardSplitter:
+    """Walk-forward rolling window split tests."""
+
+    def test_basic_split_count(self):
+        X = np.arange(100)
+        wf = WalkForwardSplitter(n_splits=5, train_size=10, gap=0, test_size=5)
+        splits = list(wf.split(X))
+        assert len(splits) == 5
+
+    def test_non_overlapping_train_test(self):
+        X = np.arange(100)
+        wf = WalkForwardSplitter(n_splits=5, train_size=10, gap=0, test_size=5)
+        for train_idx, test_idx in wf.split(X):
+            assert len(np.intersect1d(train_idx, test_idx)) == 0
+
+    def test_gap_respected(self):
+        """Gap ensures no adjacency between train end and test start."""
+        X = np.arange(100)
+        gap = 3
+        wf = WalkForwardSplitter(n_splits=5, train_size=10, gap=gap, test_size=5)
+        for train_idx, test_idx in wf.split(X):
+            assert train_idx[-1] + gap < test_idx[0]
+
+    def test_expanding_window(self):
+        """Expanding window: train grows each split."""
+        X = np.arange(200)
+        wf = WalkForwardSplitter(n_splits=3, train_size=None, test_size=20)
+        sizes = [len(train) for train, _ in wf.split(X)]
+        # Expanding window should be non-decreasing
+        assert sizes == sorted(sizes)
+
+    def test_fixed_window_constant_size(self):
+        X = np.arange(100)
+        wf = WalkForwardSplitter(n_splits=5, train_size=10, gap=0, test_size=5)
+        sizes = [len(train) for train, _ in wf.split(X)]
+        assert all(s == 10 for s in sizes)
+
+    def test_monotonic_test_indices(self):
+        """Test indices should always be after train indices."""
+        X = np.arange(100)
+        wf = WalkForwardSplitter(n_splits=5, train_size=10, gap=0, test_size=5)
+        for train_idx, test_idx in wf.split(X):
+            assert train_idx[-1] < test_idx[0]
+
+    def test_covers_full_data(self):
+        """All indices should appear in at least one train or test set."""
+        X = np.arange(50)
+        wf = WalkForwardSplitter(n_splits=3, train_size=10, gap=0, test_size=10)
+        all_indices = set()
+        for train_idx, test_idx in wf.split(X):
+            all_indices.update(train_idx)
+            all_indices.update(test_idx)
+        # Should cover most of the data
+        assert len(all_indices) >= 30
+
+    def test_single_split(self):
+        X = np.arange(20)
+        wf = WalkForwardSplitter(n_splits=1, train_size=10, gap=0, test_size=5)
+        splits = list(wf.split(X))
+        assert len(splits) == 1
+        train, test = splits[0]
+        assert len(train) == 10
+        assert len(test) == 5
+
+    def test_invalid_params(self):
+        with pytest.raises(ValueError):
+            WalkForwardSplitter(n_splits=0)
+        with pytest.raises(ValueError):
+            WalkForwardSplitter(n_splits=5, gap=-1)
+        with pytest.raises(ValueError):
+            WalkForwardSplitter(n_splits=5, train_size=0)
+        with pytest.raises(ValueError):
+            WalkForwardSplitter(n_splits=5, test_size=0)
+
+    def test_too_few_data_produces_fewer_splits(self):
+        """If data is too small, fewer splits are yielded gracefully."""
+        X = np.arange(10)
+        wf = WalkForwardSplitter(n_splits=100, train_size=3, gap=1, test_size=2)
+        splits = list(wf.split(X))
+        assert len(splits) < 100
+        assert len(splits) > 0
+
+    def test_get_n_splits(self):
+        wf = WalkForwardSplitter(n_splits=7)
+        assert wf.get_n_splits() == 7
+
+
+# ---------------------------------------------------------------------------
+# PurgedKFold
+# ---------------------------------------------------------------------------
+
+
+class TestPurgedKFold:
+    """Purged k-fold cross-validation tests (AFML Ch. 7)."""
+
+    def test_basic_kfold_splits(self):
+        X = np.arange(100)
+        pkf = PurgedKFold(n_splits=5, pct_embargo=0.0)
+        splits = list(pkf.split(X))
+        assert len(splits) == 5
+
+    def test_non_overlapping_purged(self):
+        """Train and test should not overlap."""
+        X = np.arange(100)
+        pkf = PurgedKFold(n_splits=5, pct_embargo=0.0)
+        for train, test in pkf.split(X):
+            assert len(np.intersect1d(train, test)) == 0
+
+    def test_embargo_removes_post_test(self):
+        """Embargo should exclude observations immediately after test."""
+        X = np.arange(100)
+        pkf = PurgedKFold(n_splits=5, pct_embargo=0.05)
+        n_samples = len(X)
+        embargo_size = int(n_samples * 0.05)
+
+        for train, test in pkf.split(X):
+            test_end = test[-1]
+            embargo_zone = set(range(test_end + 1, test_end + embargo_size + 1))
+            for idx in train:
+                assert idx not in embargo_zone
+
+    def test_purging_with_t1_overlap(self):
+        """Observations whose label windows overlap with test are purged."""
+        n = 50
+        X = np.arange(n)
+        # Each observation's label extends 5 periods forward
+        t1 = pd.Series(
+            index=np.arange(n),
+            data=np.arange(n) + 5,
+        )
+
+        pkf = PurgedKFold(n_splits=5, t1=t1, pct_embargo=0.0)
+        for train, test in pkf.split(X):
+            test_start = test[0]
+            # No training observation should have t1 >= test_start
+            # if the observation is before the test period
+            for idx in train:
+                if idx < test_start:
+                    assert t1.iloc[idx] < test_start
+
+    def test_no_purge_without_t1(self):
+        """Without t1, no purging occurs — standard k-fold behavior."""
+        X = np.arange(100)
+        pkf_no_t1 = PurgedKFold(n_splits=5, pct_embargo=0.0)
+        train_sizes = [len(t) for t, _ in pkf_no_t1.split(X)]
+        # Each fold should have ~80 train samples (100 - 20)
+        for s in train_sizes:
+            assert s == 80
+
+    def test_embargo_percentage(self):
+        """Verify embargo size matches pct_embargo on non-last folds."""
+        X = np.arange(100)
+        pct = 0.05
+        pkf = PurgedKFold(n_splits=5, pct_embargo=pct)
+        expected_embargo = int(100 * pct)
+
+        for train, test in pkf.split(X):
+            test_end = test[-1]
+            embargo_end = min(test_end + expected_embargo + 1, len(X))
+            # Skip last fold where embargo may extend beyond data
+            if embargo_end >= len(X):
+                continue
+            embargo_zone = set(range(test_end + 1, embargo_end))
+            train_set = set(train)
+            excluded_after = sum(1 for i in embargo_zone if i not in train_set)
+            assert excluded_after >= expected_embargo - 1
+
+    def test_invalid_params(self):
+        with pytest.raises(ValueError):
+            PurgedKFold(n_splits=1)
+        with pytest.raises(ValueError):
+            PurgedKFold(n_splits=5, pct_embargo=-0.1)
+        with pytest.raises(ValueError):
+            PurgedKFold(n_splits=5, pct_embargo=1.5)
+
+    def test_get_n_splits(self):
+        pkf = PurgedKFold(n_splits=10)
+        assert pkf.get_n_splits() == 10
+
+    def test_all_indices_covered(self):
+        """Every index should appear in at least one train or test set."""
+        X = np.arange(50)
+        pkf = PurgedKFold(n_splits=5, pct_embargo=0.0)
+        all_idx = set()
+        for train, test in pkf.split(X):
+            all_idx.update(train)
+            all_idx.update(test)
+        assert all_idx == set(range(50))
+
+
+# ---------------------------------------------------------------------------
+# Combinatorial Purged Cross-Validation
+# ---------------------------------------------------------------------------
+
+
+class TestCombinatorialPurged:
+    """CPCV (AFML Ch. 12) tests."""
+
+    def test_basic_cpcv_count(self):
+        """Number of combinations = C(n_splits, n_test_groups)."""
+        from math import comb
+
+        X = np.arange(100)
+        n_splits = 5
+        n_test = 2
+        expected = comb(n_splits, n_test)
+        splits = list(combinatorial_purged_split(X, n_splits=n_splits, n_test_groups=n_test))
+        assert len(splits) == expected
+
+    def test_non_overlapping(self):
+        X = np.arange(100)
+        for train, test in combinatorial_purged_split(X, n_splits=5, n_test_groups=2):
+            assert len(np.intersect1d(train, test)) == 0
+
+    def test_single_test_group_equals_kfold(self):
+        """With n_test_groups=1, should produce n_splits combinations."""
+        X = np.arange(60)
+        splits = list(combinatorial_purged_split(X, n_splits=5, n_test_groups=1))
+        assert len(splits) == 5

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/transaction_costs.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/transaction_costs.py
@@ -1,0 +1,179 @@
+"""
+Transaction cost modeling for realistic backtest evaluation.
+
+Every backtest must account for costs to avoid inflated performance.
+A strategy that is profitable gross but unprofitable net is not viable.
+
+Components:
+    - Commission: broker fee per trade (basis points of notional)
+    - Slippage: execution price vs mid-price (bid-ask spread + market impact)
+    - Market impact: price movement caused by our own order (square-root model)
+
+References:
+    - Almgren & Chriss (2001), "Optimal Execution of Portfolio Transactions"
+    - Kissell (2013), "The Science of Algorithmic Trading and Portfolio Management"
+    - Lopez de Prado, "Advances in Financial Machine Learning" (AFML)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from dataclasses import dataclass
+
+
+@dataclass
+class TransactionCostModel:
+    """Configurable transaction cost model.
+
+    Parameters
+    ----------
+    commission_bps : float
+        Commission in basis points of notional traded (e.g. 1.0 = 0.01%).
+    bid_ask_spread_bps : float
+        Average bid-ask spread in basis points (e.g. 1.0 = 0.01%).
+    market_impact_coeff : float
+        Market impact coefficient for square-root model.
+        impact = coeff * sqrt(order_size / daily_volume).
+    daily_volume : float
+        Average daily trading volume (shares). Used for market impact.
+    slippage_bps : float
+        Additional fixed slippage in basis points (default 0).
+    """
+
+    commission_bps: float = 1.0
+    bid_ask_spread_bps: float = 1.0
+    market_impact_coeff: float = 0.1
+    daily_volume: float = 1_000_000.0
+    slippage_bps: float = 0.0
+
+    def cost_per_trade(self, order_size: float) -> float:
+        """Compute total transaction cost as fraction of notional.
+
+        Parameters
+        ----------
+        order_size : float
+            Number of shares traded.
+
+        Returns
+        -------
+        float : Total cost as fraction of notional (e.g. 0.0005 = 5bps).
+        """
+        commission = self.commission_bps / 10_000
+        spread = self.bid_ask_spread_bps / 10_000
+        slippage = self.slippage_bps / 10_000
+
+        # Square-root market impact model (Almgren-Chriss)
+        participation = order_size / max(self.daily_volume, 1.0)
+        impact = self.market_impact_coeff * np.sqrt(participation)
+
+        return commission + spread + slippage + impact
+
+    def apply_to_returns(
+        self,
+        strategy_returns: np.ndarray | pd.Series,
+        trades: np.ndarray | pd.Series,
+        order_size: float = 100.0,
+    ) -> np.ndarray:
+        """Apply transaction costs to strategy returns.
+
+        Each trade incurs a round-trip cost (buy + sell), deducted from returns.
+
+        Parameters
+        ----------
+        strategy_returns : array-like
+            Strategy returns series (gross of costs).
+        trades : array-like
+            Binary array: 1 = trade occurred (position change), 0 = hold.
+        order_size : float
+            Number of shares per trade.
+
+        Returns
+        -------
+        np.ndarray : Net returns after transaction costs.
+        """
+        strategy_returns = np.asarray(strategy_returns, dtype=float)
+        trades = np.asarray(trades, dtype=float)
+
+        cost_frac = self.cost_per_trade(order_size)
+        # Round-trip cost per trade signal
+        trade_costs = trades * cost_frac
+
+        net_returns = strategy_returns - trade_costs
+        return net_returns
+
+
+def compare_gross_vs_net(
+    gross_returns: np.ndarray | pd.Series,
+    positions: np.ndarray | pd.Series,
+    cost_model: TransactionCostModel | None = None,
+    order_size: float = 100.0,
+) -> dict:
+    """Compare gross vs net strategy performance.
+
+    Parameters
+    ----------
+    gross_returns : array-like
+        Strategy returns before transaction costs.
+    positions : array-like
+        Position sizes or signals. Trade occurs when position changes.
+    cost_model : TransactionCostModel or None
+        Cost model. Default: institutional equity model (1bp commission, 1bp spread).
+    order_size : float
+        Number of shares per trade.
+
+    Returns
+    -------
+    dict with keys: gross_sharpe, net_sharpe, total_costs_bps,
+                    n_trades, cost_drag_bps, net_total_return.
+    """
+    if cost_model is None:
+        cost_model = TransactionCostModel()
+
+    gross_returns = np.asarray(gross_returns, dtype=float)
+    positions = np.asarray(positions, dtype=float)
+
+    n = len(gross_returns)
+    gross_returns = gross_returns[:n]
+    positions = positions[:n]
+
+    # Detect trades: position change from one period to next
+    pos_changes = np.diff(positions, prepend=positions[0])
+    trades = (pos_changes != 0).astype(float)
+
+    net_returns = cost_model.apply_to_returns(gross_returns, trades, order_size)
+
+    gross_sharpe = _sharpe_from_array(gross_returns)
+    net_sharpe = _sharpe_from_array(net_returns)
+
+    total_costs = np.sum(trades) * cost_model.cost_per_trade(order_size)
+    n_trades = int(np.sum(trades))
+
+    gross_total = float(np.prod(1 + gross_returns) - 1)
+    net_total = float(np.prod(1 + net_returns) - 1)
+
+    cost_drag = gross_total - net_total
+
+    return {
+        "gross_sharpe": gross_sharpe,
+        "net_sharpe": net_sharpe,
+        "gross_total_return": gross_total,
+        "net_total_return": net_total,
+        "total_costs_bps": total_costs * 10_000,
+        "n_trades": n_trades,
+        "cost_drag_bps": cost_drag * 10_000,
+        "trade_frequency": n_trades / max(n, 1),
+    }
+
+
+def _sharpe_from_array(returns: np.ndarray, annualize: bool = True) -> float:
+    """Compute Sharpe ratio from numpy array of returns."""
+    if len(returns) == 0:
+        return 0.0
+    std = np.std(returns)
+    if std < 1e-12:
+        return 0.0
+    sharpe = np.mean(returns) / std
+    if annualize:
+        sharpe *= np.sqrt(252)
+    return float(sharpe)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/walk_forward.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/walk_forward.py
@@ -1,0 +1,309 @@
+"""
+Walk-forward validation and purged k-fold cross-validation for financial ML.
+
+Implements time-series aware splitting strategies that prevent data leakage
+from forward-looking features and overlapping training/test windows.
+
+References:
+    - Lopez de Prado, "Advances in Financial Machine Learning" (AFML), Chapter 7
+    - Hands-On AI Trading with Python, Pik et al., Wiley 2025
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import BaseCrossValidator
+
+
+class WalkForwardSplitter(BaseCrossValidator):
+    """Rolling walk-forward split for time-series cross-validation.
+
+    Generates non-overlapping train/test pairs that roll forward in time,
+    respecting a configurable gap between train and test to prevent
+    information leakage from forward-looking features.
+
+    Parameters
+    ----------
+    n_splits : int
+        Number of walk-forward splits to generate.
+    train_size : int or None
+        Fixed training window size. If None, uses expanding window
+        (all data up to test start).
+    gap : int
+        Number of observations between train end and test start.
+        Prevents leakage from autocorrelated features.
+    test_size : int or None
+        Fixed test window size per split. If None, uses remaining
+        data after train + gap.
+    """
+
+    def __init__(
+        self,
+        n_splits: int = 5,
+        train_size: int | None = None,
+        gap: int = 0,
+        test_size: int | None = None,
+    ) -> None:
+        if n_splits < 1:
+            raise ValueError(f"n_splits must be >= 1, got {n_splits}")
+        if gap < 0:
+            raise ValueError(f"gap must be >= 0, got {gap}")
+        if train_size is not None and train_size < 1:
+            raise ValueError(f"train_size must be >= 1, got {train_size}")
+        if test_size is not None and test_size < 1:
+            raise ValueError(f"test_size must be >= 1, got {test_size}")
+
+        self.n_splits = n_splits
+        self.train_size = train_size
+        self.gap = gap
+        self.test_size = test_size
+
+    def split(self, X: pd.DataFrame | np.ndarray, y=None, groups=None) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Generate train/test index pairs.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, ...)
+            Training data. Only the length is used for splitting.
+        y : ignored
+        groups : ignored
+
+        Yields
+        ------
+        train_indices : np.ndarray
+            Training set indices for this split.
+        test_indices : np.ndarray
+            Test set indices for this split.
+        """
+        n_samples = len(X)
+
+        # Determine test size per fold
+        test_size = self.test_size
+        if test_size is None:
+            # Divide remaining data evenly
+            if self.train_size is not None:
+                available = n_samples - self.train_size - self.gap
+            else:
+                available = n_samples // 2
+            test_size = max(1, available // self.n_splits)
+
+        # Calculate the step between each split start
+        total_needed = (self.train_size or 0) + self.gap + test_size
+        if self.train_size is not None:
+            step = max(1, (n_samples - total_needed) // max(1, self.n_splits - 1)) if self.n_splits > 1 else 1
+        else:
+            step = max(1, (n_samples - test_size) // max(1, self.n_splits))
+
+        splits_yielded = 0
+        for i in range(self.n_splits):
+            if self.train_size is not None:
+                # Fixed-size rolling window
+                train_end = self.train_size + i * step
+                train_start = i * step
+            else:
+                # Expanding window
+                train_end = min((i + 1) * step, n_samples - test_size)
+                train_start = 0
+
+            test_start = train_end + self.gap
+            test_end = test_start + test_size
+
+            if test_end > n_samples:
+                break
+            if train_end <= train_start:
+                continue
+
+            train_indices = np.arange(train_start, train_end)
+            test_indices = np.arange(test_start, test_end)
+
+            # Verify non-overlap and gap
+            assert train_indices[-1] + self.gap < test_indices[0] or self.gap == 0
+
+            splits_yielded += 1
+            yield train_indices, test_indices
+
+    def get_n_splits(self, X=None, y=None, groups=None) -> int:
+        return self.n_splits
+
+
+class PurgedKFold(BaseCrossValidator):
+    """Purged and embargoed k-fold cross-validation for financial data.
+
+    Implements the purged k-fold from Lopez de Prado (AFML, Chapter 7).
+    Prevents information leakage by:
+    1. Purging observations from the training set that overlap with
+       the test set's label window (t1).
+    2. Applying an embargo after each test fold to prevent leakage
+       from serially correlated features.
+
+    Parameters
+    ----------
+    n_splits : int
+        Number of folds.
+    t1 : pd.Series
+        Index = observation index, value = end time of the label window
+        for that observation. Observations whose label windows overlap
+        with the test fold are purged from training.
+    pct_embargo : float
+        Fraction of total observations to embargo after each test fold.
+        Default 0.01 (1% of data).
+    """
+
+    def __init__(
+        self,
+        n_splits: int = 5,
+        t1: pd.Series | None = None,
+        pct_embargo: float = 0.01,
+    ) -> None:
+        if n_splits < 2:
+            raise ValueError(f"n_splits must be >= 2 for k-fold, got {n_splits}")
+        if pct_embargo < 0 or pct_embargo > 1:
+            raise ValueError(f"pct_embargo must be in [0, 1], got {pct_embargo}")
+
+        self.n_splits = n_splits
+        self.t1 = t1 if t1 is not None else pd.Series(dtype=float)
+        self.pct_embargo = pct_embargo
+
+    def _get_embargo_indices(self, test_indices: np.ndarray, n_samples: int) -> set[int]:
+        """Compute embargo zone after test fold."""
+        if self.pct_embargo <= 0:
+            return set()
+
+        embargo_size = int(n_samples * self.pct_embargo)
+        if embargo_size == 0:
+            return set()
+
+        last_test = test_indices[-1]
+        embargo_end = min(last_test + embargo_size + 1, n_samples)
+        return set(range(last_test + 1, embargo_end))
+
+    def _get_purge_indices(self, test_indices: np.ndarray) -> set[int]:
+        """Purge training observations whose label windows overlap with test set."""
+        if self.t1.empty:
+            return set()
+
+        purge = set()
+        test_set = set(test_indices)
+
+        # For each test observation, find training observations whose t1
+        # overlaps with the test period
+        test_start = test_indices[0]
+        test_end = test_indices[-1]
+
+        for idx, end_time in self.t1.items():
+            if idx in test_set:
+                continue
+            # If this observation's label window extends into the test period
+            if idx < test_start and end_time >= test_start:
+                purge.add(idx)
+            # If this observation starts within the test period but its index
+            # is not in the test set (shouldn't happen but defensive)
+            if test_start <= idx <= test_end and idx not in test_set:
+                purge.add(idx)
+
+        return purge
+
+    def split(self, X: pd.DataFrame | np.ndarray, y=None, groups=None) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Generate purged train/test index pairs.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, ...)
+            Training data.
+        y : ignored
+        groups : ignored
+
+        Yields
+        ------
+        train_indices : np.ndarray
+            Training set indices (purged + embargoed).
+        test_indices : np.ndarray
+            Test set indices for this fold.
+        """
+        n_samples = len(X)
+        indices = np.arange(n_samples)
+        fold_size = n_samples // self.n_splits
+
+        for i in range(self.n_splits):
+            test_start = i * fold_size
+            test_end = test_start + fold_size if i < self.n_splits - 1 else n_samples
+            test_indices = indices[test_start:test_end]
+
+            # Get exclusion zones
+            purge_set = self._get_purge_indices(test_indices)
+            embargo_set = self._get_embargo_indices(test_indices, n_samples)
+            test_set = set(test_indices)
+
+            excluded = test_set | purge_set | embargo_set
+            train_indices = np.array([idx for idx in indices if idx not in excluded])
+
+            if len(train_indices) > 0 and len(test_indices) > 0:
+                yield train_indices, test_indices
+
+    def get_n_splits(self, X=None, y=None, groups=None) -> int:
+        return self.n_splits
+
+
+def combinatorial_purged_split(
+    X: pd.DataFrame | np.ndarray,
+    n_splits: int = 5,
+    n_test_groups: int = 1,
+    t1: pd.Series | None = None,
+    pct_embargo: float = 0.01,
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Combinatorial purged cross-validation (CPCV).
+
+    Generates all combinations of n_test_groups out of n_splits groups
+    as test sets, with purging and embargo. Provides more exhaustive
+    backtesting than single k-fold.
+
+    Reference: AFML Chapter 12.
+
+    Parameters
+    ----------
+    X : array-like
+        Data to split.
+    n_splits : int
+        Number of groups to divide data into.
+    n_test_groups : int
+        Number of groups to use as test set in each combination.
+    t1 : pd.Series or None
+        Label end times for purging.
+    pct_embargo : float
+        Embargo fraction.
+
+    Yields
+    ------
+    train_indices, test_indices : tuple of np.ndarray
+    """
+    from itertools import combinations
+
+    n_samples = len(X)
+    indices = np.arange(n_samples)
+    group_size = n_samples // n_splits
+
+    groups = []
+    for i in range(n_splits):
+        start = i * group_size
+        end = start + group_size if i < n_splits - 1 else n_samples
+        groups.append(indices[start:end])
+
+    purger = PurgedKFold(n_splits=2, t1=t1, pct_embargo=pct_embargo)
+
+    for test_combo in combinations(range(n_splits), n_test_groups):
+        test_indices = np.concatenate([groups[g] for g in test_combo])
+        train_groups = [g for g in range(n_splits) if g not in test_combo]
+        train_candidates = np.concatenate([groups[g] for g in train_groups])
+
+        # Apply purging and embargo
+        purge_set = purger._get_purge_indices(test_indices)
+        embargo_set = purger._get_embargo_indices(test_indices, n_samples)
+        excluded = set(test_indices) | purge_set | embargo_set
+
+        train_indices = np.array([idx for idx in train_candidates if idx not in excluded])
+
+        if len(train_indices) > 0:
+            yield train_indices, test_indices


### PR DESCRIPTION
## Summary
- **4 discipline scripts** for Stage 0 ML/Trading curriculum (Track A, RooSync directive)
- **98 tests passing** across all 4 scripts
- PEP 8, type hints, docstrings with academic references (Lopez de Prado AFML, FinTSB, Almgren-Chriss)

## Scripts

| Script | Tests | Purpose |
|--------|-------|---------|
| `walk_forward.py` | 23 | WalkForwardSplitter, PurgedKFold, CPCV (AFML Ch.7+12) |
| `baselines.py` | 30 | majority_class, naive_momentum, random_walk, buy_and_hold |
| `eval_finstsb.py` | 25 | FinTSB regime detection + per-regime DirAcc/Sharpe |
| `transaction_costs.py` | 20 | Almgren-Chriss cost model + gross vs net comparison |

## Quality Criteria (from directive)
- [x] pytest pass for all 4 scripts (98/98)
- [x] PEP 8 style
- [x] Type hints on all public functions
- [x] Docstrings with academic references
- [x] Anti-bias policy: no AAPL/MSFT/NVDA/etc. in tests

## Test plan
- [x] `python -m pytest scripts/tests/ -v` → 98 passed in 2.79s
- [ ] Review by ai-01 before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)