### PR TITLE
fix(dqn): train/test split with OOS Sharpe evaluation (#703)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -68,7 +68,11 @@ SPY majority class baseline = **54.59%**. Values will be populated by `python ev
 
 Checkpoints: 5
 
-### 20260501_120415 [OK] [BASELINE] [SPY-ONLY]
+**WARNING**: All DQN checkpoints below trained WITHOUT train/test split (Issue #703).
+Sharpe estimates are in-sample only, NOT reliable out-of-sample metrics.
+Marked `[INVALID-NO-SPLIT]` until re-trained with `--test-ratio 0.2`.
+
+### 20260501_120415 [INVALID-NO-SPLIT] [BASELINE] [SPY-ONLY]
 
 - Data hash: `17cb43b404e3ddf1`
 - Metrics: best_avg_reward_10=2.2865, max_reward=3.0876, mean_reward=1.0177, mean_trades=749.3, min_reward=-1.8051, sharpe_estimate=0.8921
@@ -76,7 +80,7 @@ Checkpoints: 5
 - Config: device=cuda, hidden_size=256, num_episodes=50, symbol=SPY
 - Files: metadata.json, model.pt
 
-### 20260501_142319 [OK] [ADVANCED-FEATURES] [SPY-ONLY]
+### 20260501_142319 [INVALID-NO-SPLIT] [ADVANCED-FEATURES] [SPY-ONLY]
 
 - Data hash: `4ec8b44b93f4024f`
 - Metrics: best_avg_reward_10=0.3888, max_reward=1.8077, mean_reward=-0.0138, mean_trades=782.5, min_reward=-1.2372, sharpe_estimate=-0.0171
@@ -84,7 +88,7 @@ Checkpoints: 5
 - Config: device=cuda, hidden_size=256, num_episodes=20, symbol=SPY, advanced=true
 - Files: metadata.json, model.pt
 
-### 20260501_140955 [OK] [SPY-ONLY]
+### 20260501_140955 [INVALID-NO-SPLIT] [SPY-ONLY]
 
 - Data hash: `4ec8b44b93f4024f`
 - Metrics: best_avg_reward_10=-0.4572, max_reward=-0.0334, mean_reward=-0.4572, mean_trades=759.3, min_reward=-0.836, sharpe_estimate=-1.6905
@@ -92,7 +96,7 @@ Checkpoints: 5
 - Config: device=cuda, hidden_size=128, num_episodes=10, symbol=SPY, advanced=true
 - Files: metadata.json, model.pt
 
-### 20260501_112641 [OK] [SPY-ONLY]
+### 20260501_112641 [INVALID-NO-SPLIT] [SPY-ONLY]
 
 - Data hash: `17cb43b404e3ddf1`
 - Metrics: best_avg_reward_10=-0.1559, max_reward=0.9312, mean_reward=-0.5358, mean_trades=739.6, min_reward=-1.5861, sharpe_estimate=-0.8096
@@ -100,7 +104,7 @@ Checkpoints: 5
 - Config: device=cpu, hidden_size=32, num_episodes=20, symbol=SPY
 - Files: metadata.json, model.pt
 
-### 20260501_111005 [OK] [SPY-ONLY]
+### 20260501_111005 [INVALID-NO-SPLIT] [SPY-ONLY]
 
 - Data hash: `synthetic-dryrun`
 - Metrics: best_avg_reward_10=-0.0017, max_reward=0.1665, mean_reward=-0.0017, mean_trades=44.1, min_reward=-0.2395, sharpe_estimate=-0.0134

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -348,6 +348,55 @@ def train_dqn(
     }
 
 
+def evaluate_dqn(
+    model: "torch.nn.Module",
+    env: TradingEnv,
+    device: str = "cpu",
+    num_episodes: int = 10,
+) -> dict:
+    """Evaluate a trained DQN on a test environment (greedy policy, no exploration)."""
+    import torch
+
+    rewards = []
+    trades_list = []
+    model.eval()
+
+    for _ in range(num_episodes):
+        state = env.reset()
+        total_reward = 0.0
+        ep_trades = 0
+
+        while True:
+            with torch.no_grad():
+                state_t = torch.tensor(state, dtype=torch.float32).unsqueeze(0).to(device)
+                action = model(state_t).argmax(dim=1).item()
+
+            next_state, reward, done, info = env.step(action)
+            total_reward += reward
+            if info.get("trade"):
+                ep_trades += 1
+            state = next_state
+
+            if done:
+                break
+
+        rewards.append(total_reward)
+        trades_list.append(ep_trades)
+
+    rewards_arr = np.array(rewards)
+    sharpe = float(rewards_arr.mean() / (rewards_arr.std() + 1e-8))
+
+    return {
+        "oos_mean_reward": round(float(rewards_arr.mean()), 4),
+        "oos_std_reward": round(float(rewards_arr.std()), 4),
+        "oos_sharpe": round(sharpe, 4),
+        "oos_max_reward": round(float(rewards_arr.max()), 4),
+        "oos_min_reward": round(float(rewards_arr.min()), 4),
+        "oos_mean_trades": round(float(np.mean(trades_list)), 1),
+        "oos_episodes": num_episodes,
+    }
+
+
 def save_checkpoint(
     model, result: dict, hyperparams: dict, data_hash: str, checkpoint_dir: Path
 ) -> Path:
@@ -407,7 +456,8 @@ def main():
     parser.add_argument("--target-update", type=int, default=10)
     parser.add_argument("--commission", type=float, default=0.001, help="Trading commission")
     parser.add_argument("--lookback", type=int, default=20)
-    parser.add_argument("--test-ratio", type=float, default=0.2)
+    parser.add_argument("--test-ratio", type=float, default=0.2, help="Fraction of data for OOS test set")
+    parser.add_argument("--val-ratio", type=float, default=0.0, help="Fraction of training data for validation (0=disabled)")
     parser.add_argument(
         "--checkpoint-dir",
         default=str(Path(__file__).resolve().parent.parent / "checkpoints" / "dqn"),
@@ -468,18 +518,28 @@ def main():
     feature_cols = [c for c in features_df.columns]
     features_arr = features_df.values.astype(np.float32)
 
-    # Normalize features
-    mean = features_arr[: int(len(features_arr) * 0.8)].mean(axis=0)
-    std = features_arr[: int(len(features_arr) * 0.8)].std(axis=0)
+    # Normalize features using training portion only (avoid lookahead bias)
+    n = len(features_arr)
+    train_end = int(n * (1 - args.test_ratio))
+    mean = features_arr[:train_end].mean(axis=0)
+    std = features_arr[:train_end].std(axis=0)
     std = np.where(std < 1e-8, 1.0, std)
     features_arr = (features_arr - mean) / std
 
     prices = raw.loc[features_df.index, "Close"].values.astype(np.float32)
 
+    # Train/test split (time-series: train = first 80%, test = last 20%)
+    train_prices = prices[:train_end]
+    train_features = features_arr[:train_end]
+    test_prices = prices[train_end:]
+    test_features = features_arr[train_end:]
+
     print(f"Features: {len(features_df)} rows, {len(feature_cols)} columns")
+    print(f"Train/test split: {len(train_prices)} train ({100*(1-args.test_ratio):.0f}%) / "
+          f"{len(test_prices)} test ({100*args.test_ratio:.0f}%)")
     print(f"Device: {device}")
 
-    env = TradingEnv(prices, features_arr, window=args.window, commission=args.commission)
+    env = TradingEnv(train_prices, train_features, window=args.window, commission=args.commission)
     print(f"State size: {env.state_size}, Actions: 3 (hold/buy/sell)")
 
     hyperparams = {
@@ -499,6 +559,9 @@ def main():
         "lookback": args.lookback,
         "symbol": args.symbol,
         "device": device,
+        "test_ratio": args.test_ratio,
+        "train_samples": len(train_prices),
+        "test_samples": len(test_prices),
     }
 
     intermediate_dir = None
@@ -529,11 +592,28 @@ def main():
     ckpt_dir = Path(args.checkpoint_dir)
     save_checkpoint(result["model"], result, hyperparams, data_hash, ckpt_dir)
 
+    # Out-of-sample evaluation on test set
+    test_env = TradingEnv(test_prices, test_features, window=args.window, commission=args.commission)
+    oos_metrics = evaluate_dqn(result["model"], test_env, device=device)
+    result["oos_metrics"] = oos_metrics
+
+    # Update saved metadata with OOS results
+    import glob
+    ckpt_subdirs = sorted(ckpt_dir.glob("*"))
+    if ckpt_subdirs:
+        latest_meta = ckpt_subdirs[-1] / "metadata.json"
+        if latest_meta.exists():
+            meta = json.loads(latest_meta.read_text(encoding="utf-8"))
+            meta["oos_metrics"] = oos_metrics
+            latest_meta.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+    o = oos_metrics
+    m = result["metrics"]
+    print(f"Training complete (in-sample). MeanReward={m['mean_reward']}, Sharpe~={m['sharpe_estimate']}")
+    print(f"OOS evaluation.       MeanReward={o['oos_mean_reward']}, OOS Sharpe={o['oos_sharpe']}")
+
     if args.dry_run:
         print("DRY-RUN complete. Pipeline validated successfully.")
-    else:
-        m = result["metrics"]
-        print(f"Training complete. MeanReward={m['mean_reward']}, Sharpe~={m['sharpe_estimate']}")
 
 
 if __name__ == "__main__":

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/tests/test_train_dqn_rl_split.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/tests/test_train_dqn_rl_split.py
@@ -1,0 +1,137 @@
+"""Tests for DQN train/test split functionality (Issue #703)."""
+
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+# Add scripts directory to path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from train_dqn_rl import TradingEnv, evaluate_dqn, build_dqn
+
+
+def _make_env(n_rows: int = 500, window: int = 20):
+    """Create a simple TradingEnv with synthetic data."""
+    np.random.seed(42)
+    prices = 100.0 + np.cumsum(np.random.randn(n_rows) * 0.5).astype(np.float32)
+    n_features = 10
+    features = np.random.randn(n_rows, n_features).astype(np.float32)
+    env = TradingEnv(prices, features, window=window)
+    return prices, features, env
+
+
+class TestTrainTestSplit:
+    """Verify time-series train/test split logic."""
+
+    def test_split_ratios(self):
+        """80/20 split produces correct sizes."""
+        prices, features, _ = _make_env(500)
+        test_ratio = 0.2
+        train_end = int(len(prices) * (1 - test_ratio))
+        train_prices = prices[:train_end]
+        test_prices = prices[train_end:]
+
+        assert len(train_prices) == 400
+        assert len(test_prices) == 100
+        assert len(train_prices) + len(test_prices) == 500
+
+    def test_no_data_leakage(self):
+        """Train and test sets are temporally disjoint."""
+        prices, features, _ = _make_env(500)
+        train_end = int(len(prices) * (1 - 0.2))
+        train_prices = prices[:train_end]
+        test_prices = prices[train_end:]
+
+        # Last train price < first test price index (no overlap)
+        assert train_end == len(train_prices)
+        assert train_end < len(prices)
+
+    def test_normalization_uses_train_only(self):
+        """Feature normalization computed on training portion only."""
+        prices, features, _ = _make_env(500)
+        train_end = int(len(features) * 0.8)
+        mean = features[:train_end].mean(axis=0)
+        std = features[:train_end].std(axis=0)
+        normalized = (features - mean) / np.where(std < 1e-8, 1.0, std)
+
+        # Training portion should have ~0 mean and ~1 std
+        train_norm = normalized[:train_end]
+        assert np.abs(train_norm.mean()) < 0.05
+        assert np.abs(train_norm.std() - 1.0) < 0.05
+
+
+class TestEvaluateDQN:
+    """Verify OOS evaluation function."""
+
+    def test_evaluate_returns_expected_keys(self):
+        """evaluate_dqn returns all required OOS metrics."""
+        prices, features, env = _make_env(200)
+        model = build_dqn(env.state_size, hidden_size=32, n_actions=3)
+
+        oos = evaluate_dqn(model, env, device="cpu", num_episodes=3)
+
+        expected_keys = [
+            "oos_mean_reward", "oos_std_reward", "oos_sharpe",
+            "oos_max_reward", "oos_min_reward", "oos_mean_trades",
+            "oos_episodes",
+        ]
+        for key in expected_keys:
+            assert key in oos, f"Missing key: {key}"
+
+    def test_evaluate_is_greedy(self):
+        """Evaluation uses greedy policy (no randomness)."""
+        prices, features, env = _make_env(200)
+        model = build_dqn(env.state_size, hidden_size=32, n_actions=3)
+
+        oos1 = evaluate_dqn(model, env, device="cpu", num_episodes=5)
+        oos2 = evaluate_dqn(model, env, device="cpu", num_episodes=5)
+
+        # Greedy policy on same data should give identical results
+        assert oos1["oos_mean_reward"] == oos2["oos_mean_reward"]
+
+    def test_oos_episodes_count(self):
+        """Evaluation runs the requested number of episodes."""
+        prices, features, env = _make_env(200)
+        model = build_dqn(env.state_size, hidden_size=32, n_actions=3)
+
+        oos = evaluate_dqn(model, env, device="cpu", num_episodes=7)
+        assert oos["oos_episodes"] == 7
+
+
+class TestTradingEnv:
+    """Verify TradingEnv behavior with split data."""
+
+    def test_env_terminates_at_data_end(self):
+        """Env stops when reaching the end of its price array."""
+        prices, features, env = _make_env(100, window=10)
+
+        state = env.reset()
+        steps = 0
+        while True:
+            _, _, done, _ = env.step(0)
+            steps += 1
+            if done or steps > 200:
+                break
+
+        # Should terminate at len(prices) - 1
+        assert done
+        assert steps <= 90  # 100 - window - 1
+
+    def test_separate_envs_independent(self):
+        """Train and test envs don't share state."""
+        prices, features, _ = _make_env(500)
+        train_end = 400
+
+        train_env = TradingEnv(prices[:train_end], features[:train_end], window=20)
+        test_env = TradingEnv(prices[train_end:], features[train_end:], window=20)
+
+        # Run train env for a while
+        state = train_env.reset()
+        for _ in range(50):
+            train_env.step(0)
+
+        # Test env should still be at start
+        test_env.reset()
+        assert test_env.step_idx == test_env.window
+        assert test_env.total_reward == 0.0


### PR DESCRIPTION
## Summary

Stage 0a infrastructure for EPIC #705: walk-forward validation and baseline evaluation.

### Commit 1: DQN Train/Test Split (Issue #703)
- `evaluate_dqn()`: greedy OOS evaluation on separate test env
- Temporal split (80/20) with train-only normalization (fix lookahead bias)
- All 5 existing DQN checkpoints marked `[INVALID-NO-SPLIT]` in REGISTRY.md
- 8 unit tests (split logic, OOS eval, env independence) — all passing

### Commit 2: Walk-Forward Validation + Baselines (Stage 0a)
- `walk_forward.py`: Purged k-fold (Lopez de Prado) with embargo gaps
  - `WalkForwardValidator`: configurable splits, purge, embargo, min_train_size
  - `compute_majority_baseline()`: per-symbol and per-fold
  - `compute_baselines_multi_asset()`: panier-wide baselines
- `baselines.py`: Baseline models with walk-forward OOS evaluation
  - Majority class: always predict most frequent direction
  - SMA crossover: price > SMA50 = predict up
  - Random Forest: 100 trees, depth 5, basic features
- 14 tests passing (split logic, temporal ordering, purge, baselines)

### Panier Baselines (26 symbols)
Average majority frequency: **52.85%** across all assets.

| Symbol | Majority | Freq |
|--------|----------|------|
| XLK | up | 55.97% |
| SPY | up | 54.78% |
| RSP | up | 53.90% |
| VIX | down | 54.95% |
| DBA | down | 51.58% |

## Test plan

- [x] `python walk_forward.py --dry-run` passes
- [x] `python baselines.py --dry-run` passes
- [x] `python walk_forward.py --panier ../../datasets/panier` — 26/26 symbols OK
- [x] `pytest tests/` — 22/22 tests passing (8 DQN + 14 walk_forward)
- [ ] Run `python baselines.py --panier ../../datasets/panier` for full RF baselines
- [ ] Update REGISTRY.md with walk-forward columns

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)