### PR TITLE
fix(slides): deck-2 slide 20 text overflow

### DIFF
--- a/slides/S4-trading-algorithmique/deck-2-strategies.md
+++ b/slides/S4-trading-algorithmique/deck-2-strategies.md
@@ -515,6 +515,8 @@ imageClass: mid-right visible
 </div>
 
 ---
+layout: compact
+---
 
 # Autres Types de Risques
 


### PR DESCRIPTION
## Summary
- Fix text overflow on deck-2-strategies.md slide 20 "Autres Types de Risques"
- Added `layout: compact` to reduce padding and fit 3 dense v-click sections within viewport
- Detected during visual audit of all 119 S4-trading-algorithmique slides

## Test plan
- [x] Screenshot before fix: text truncated at bottom (FAIL)
- [x] Screenshot after fix: all content visible within 1280x720 viewport (PASS)
- [x] No other slides affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)