### PR TITLE
fix(ml): test-set contamination in 6 training scripts

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
@@ -171,8 +171,16 @@ def train_walk_forward_classification(
         y_test_fold = y[test_idx]
 
         # Per-fold train-only normalization (StandardScaler)
+        # Internal train/val split to avoid test-set contamination (issue #722)
+        val_cutoff = int(len(X_train_fold) * 0.85)
+        X_tr_fold = X_train_fold[:val_cutoff]
+        X_val_fold = X_train_fold[val_cutoff:]
+        y_tr_fold = y_train_fold[:val_cutoff]
+        y_val_fold = y_train_fold[val_cutoff:]
+
         scaler = StandardScaler()
-        X_train_norm = scaler.fit_transform(X_train_fold)
+        X_tr_norm = scaler.fit_transform(X_tr_fold)
+        X_val_norm = scaler.transform(X_val_fold)
         X_test_norm = scaler.transform(X_test_fold)
 
         if model_type == "xgb":
@@ -198,26 +206,34 @@ def train_walk_forward_classification(
                 n_estimators=n_estimators, max_depth=max_depth, random_state=42, n_jobs=-1,
             )
 
-        model.fit(X_train_norm, y_train_fold)
+        model.fit(X_tr_norm, y_tr_fold)
+
+        # Use validation accuracy for model selection (NOT test)
+        val_preds = model.predict(X_val_norm)
+        val_acc = accuracy_score(y_val_fold, val_preds)
+
+        # Test predictions for OOS reporting only
         fold_preds = model.predict(X_test_norm)
         fold_acc = accuracy_score(y_test_fold, fold_preds)
 
         fold_results.append({
             "fold": fold_idx,
-            "train_size": len(train_idx),
+            "train_size": val_cutoff,
+            "val_size": len(X_train_fold) - val_cutoff,
             "test_size": len(test_idx),
-            "accuracy": round(fold_acc, 4),
+            "val_accuracy": round(val_acc, 4),
+            "oos_accuracy": round(fold_acc, 4),
         })
 
         oos_preds[test_idx] = fold_preds
 
-        if fold_acc > best_fold_acc:
-            best_fold_acc = fold_acc
+        if val_acc > best_fold_acc:
+            best_fold_acc = val_acc
             import pickle
             best_model = pickle.loads(pickle.dumps(model))
 
-        print(f"  Fold {fold_idx+1}/{n_splits}  acc={fold_acc:.4f}  "
-              f"train={len(train_idx)}  test={len(test_idx)}")
+        print(f"  Fold {fold_idx+1}/{n_splits}  val_acc={val_acc:.4f}  oos_acc={fold_acc:.4f}  "
+              f"train={val_cutoff}  val={len(X_train_fold) - val_cutoff}  test={len(test_idx)}")
 
     # Aggregate OOS metrics
     valid_mask = ~np.array([p is np.nan for p in oos_preds]) if hasattr(np, 'nan') else np.array([not (isinstance(p, float) and np.isnan(p)) for p in oos_preds])

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -491,8 +491,10 @@ def train_walk_forward_dqn(
             oos_direction_correct += 1
         oos_direction_total += 1
 
-        if oos_eval["oos_mean_reward"] > best_fold_reward:
-            best_fold_reward = oos_eval["oos_mean_reward"]
+        # Select best fold model by in-sample reward, NOT OOS (issue #722)
+        in_sample_reward = fold_result["metrics"]["mean_reward"]
+        if in_sample_reward > best_fold_reward:
+            best_fold_reward = in_sample_reward
             best_model = fold_result["model"]
 
         print(f"  Fold {fold_idx+1}/{n_splits}  oos_reward={oos_eval['oos_mean_reward']:.4f}  "

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -122,21 +122,35 @@ def train_and_evaluate(
     learning_rate: float = 1e-3,
     model_type: str = "lstm",
     device: str = "cpu",
+    val_ratio: float = 0.15,
 ) -> dict:
-    """Train LSTM/GRU model and return metrics + training history."""
+    """Train LSTM/GRU model and return metrics + training history.
+
+    Splits X_train into train+val internally so test data is never used
+    for model selection (fixes test-set contamination, issue #722).
+    """
     import torch
     import torch.nn as nn
     from torch.utils.data import DataLoader, TensorDataset
 
     input_size = X_train.shape[2]
 
+    # Internal train/val split from training data only
+    val_cutoff = int(len(X_train) * (1 - val_ratio))
+    X_tr, X_val = X_train[:val_cutoff], X_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
+
     train_ds = TensorDataset(
-        torch.tensor(X_train), torch.tensor(y_train).unsqueeze(1)
+        torch.tensor(X_tr), torch.tensor(y_tr).unsqueeze(1)
+    )
+    val_ds = TensorDataset(
+        torch.tensor(X_val), torch.tensor(y_val).unsqueeze(1)
     )
     test_ds = TensorDataset(
         torch.tensor(X_test), torch.tensor(y_test).unsqueeze(1)
     )
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
     test_loader = DataLoader(test_ds, batch_size=batch_size)
 
     model = build_model(input_size, hidden_size, num_layers, dropout, model_type)
@@ -183,7 +197,7 @@ def train_and_evaluate(
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in test_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 pred = model(X_batch)
                 val_loss += criterion(pred, y_batch).item()
@@ -237,7 +251,8 @@ def train_and_evaluate(
         "direction_accuracy": round(direction_acc, 4),
         "direction_accuracy_significant": round(dir_acc_sig, 4) if dir_acc_sig else None,
         "best_val_loss": round(best_val_loss, 6),
-        "train_samples": len(X_train),
+        "train_samples": len(X_tr),
+        "val_samples": len(X_val),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
@@ -519,7 +519,16 @@ def train_and_evaluate(
         val_ds = TensorDataset(torch.tensor(X_val), torch.tensor(y_val))
         val_loader = DataLoader(val_ds, batch_size=batch_size)
     else:
-        val_loader = None
+        # Auto-split validation from training data (issue #722)
+        val_cutoff = int(len(X_train) * 0.85)
+        val_ds = TensorDataset(
+            torch.tensor(X_train[val_cutoff:]), torch.tensor(y_train[val_cutoff:])
+        )
+        train_ds = TensorDataset(
+            torch.tensor(X_train[:val_cutoff]), torch.tensor(y_train[:val_cutoff])
+        )
+        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+        val_loader = DataLoader(val_ds, batch_size=batch_size)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
@@ -572,11 +581,10 @@ def train_and_evaluate(
 
         # Evaluate on val set for early stopping (NOT test set)
         model.eval()
-        eval_loader = val_loader if val_loader is not None else test_loader
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in eval_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch, dynamic_adj=dynamic_adj), y_batch).item()
@@ -641,7 +649,8 @@ def train_and_evaluate(
         "edge_over_majority": round(direction_acc - majority_baseline["majority_class_accuracy"], 4),
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_train) if X_val is not None else int(len(X_train) * 0.85),
+        "val_samples": len(X_val) if X_val is not None else int(len(X_train) * 0.15),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
@@ -457,7 +457,16 @@ def train_and_evaluate(
         val_ds = TensorDataset(torch.tensor(X_val), torch.tensor(y_val))
         val_loader = DataLoader(val_ds, batch_size=batch_size)
     else:
-        val_loader = None
+        # Auto-split validation from training data (issue #722)
+        val_cutoff = int(len(X_train) * 0.85)
+        val_ds = TensorDataset(
+            torch.tensor(X_train[val_cutoff:]), torch.tensor(y_train[val_cutoff:])
+        )
+        train_ds = TensorDataset(
+            torch.tensor(X_train[:val_cutoff]), torch.tensor(y_train[:val_cutoff])
+        )
+        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+        val_loader = DataLoader(val_ds, batch_size=batch_size)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
@@ -508,11 +517,10 @@ def train_and_evaluate(
 
         # Evaluate on val set for early stopping (NOT test set)
         model.eval()
-        eval_loader = val_loader if val_loader is not None else test_loader
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in eval_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch, adj=static_adj), y_batch).item()
@@ -568,7 +576,8 @@ def train_and_evaluate(
         "edge_over_majority": round(direction_acc - majority_baseline["majority_class_accuracy"], 4),
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_train) if X_val is not None else int(len(X_train) * 0.85),
+        "val_samples": len(X_val) if X_val is not None else int(len(X_train) * 0.15),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -161,21 +161,35 @@ def train_and_evaluate(
     learning_rate: float = 5e-4,
     warmup_steps: int = 200,
     device: str = "cpu",
+    val_ratio: float = 0.15,
 ) -> dict:
-    """Train Transformer with AMP and thermal watchdog via shared.gpu_training."""
+    """Train Transformer with AMP and thermal watchdog via shared.gpu_training.
+
+    Splits X_train into train+val internally so test data is never used
+    for model selection (fixes test-set contamination, issue #722).
+    """
     import torch
     import torch.nn as nn
     from torch.utils.data import DataLoader, TensorDataset
 
     input_size = X_train.shape[2]
 
+    # Internal train/val split from training data only
+    val_cutoff = int(len(X_train) * (1 - val_ratio))
+    X_tr, X_val = X_train[:val_cutoff], X_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
+
     train_ds = TensorDataset(
-        torch.tensor(X_train), torch.tensor(y_train).unsqueeze(1)
+        torch.tensor(X_tr), torch.tensor(y_tr).unsqueeze(1)
+    )
+    val_ds = TensorDataset(
+        torch.tensor(X_val), torch.tensor(y_val).unsqueeze(1)
     )
     test_ds = TensorDataset(
         torch.tensor(X_test), torch.tensor(y_test).unsqueeze(1)
     )
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
     test_loader = DataLoader(test_ds, batch_size=batch_size)
 
     model = build_transformer_model(
@@ -236,7 +250,7 @@ def train_and_evaluate(
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in test_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch), y_batch).item()
@@ -292,7 +306,8 @@ def train_and_evaluate(
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
         "trainable_params": trainable_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_tr),
+        "val_samples": len(X_val),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }


### PR DESCRIPTION
## Summary
- Fixes #722: all training scripts used test data for model selection (validation loss, checkpointing, best-fold selection), inflating reported metrics
- Internal train/val split (85/15) added to LSTM, Transformer, MTGNN, STGAT so test data is never seen during training
- Classification walk-forward uses val split per fold for model selection; DQN walk-forward uses in-sample reward instead of OOS

## Changes per script
| Script | Fix |
|--------|-----|
| `train_lstm.py` | 85/15 train/val split from X_train, val_loader for epoch validation |
| `train_transformer.py` | Same pattern as LSTM |
| `train_mtgnn.py` | Auto-split when X_val=None, removed test_loader fallback |
| `train_stgat.py` | Same pattern as MTGNN |
| `train_classification.py` | Per-fold val split for model selection, test only for OOS |
| `train_dqn_rl.py` | Walk-forward best-fold by in-sample reward, not OOS |

## Test plan
- [x] Syntax check all 6 scripts (`ast.parse`)
- [ ] Run smoke tests (`--dry-run`) on LSTM, Transformer, Classification, DQN to verify training still works
- [ ] Verify val_samples appears in metrics output

🤖 Generated with [Claude Code](https://claude.com/claude-code)