### PR TITLE
fix(ml): extend test-set contamination fix to PatchTST/iTransformer/Mamba (#722 follow-up)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_contamination_fix.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_contamination_fix.py
@@ -1,0 +1,170 @@
+"""Tests verifying the test-set contamination fix (val_ratio internal split).
+
+Ensures that PatchTST, iTransformer, and Mamba train_and_evaluate() use an
+internal validation split for early stopping and keep test_loader exclusively
+for final OOS metrics.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from data_utils import generate_synthetic_data
+from features import FeatureEngineer
+
+
+def _make_sequences(n_rows: int = 300, seq_len: int = 24, pred_len: int = 6) -> tuple:
+    """Generate synthetic sequence arrays for forecasting models."""
+    raw = generate_synthetic_data(n_rows)
+    engineer = FeatureEngineer(lookback=seq_len)
+    features = engineer.transform(raw)
+    features = features.dropna()
+
+    feature_cols = [c for c in features.columns if c != "target"]
+    data = features[feature_cols].values
+    targets = features["target"].values
+
+    X, y = [], []
+    for i in range(seq_len, len(data) - pred_len + 1):
+        X.append(data[i - seq_len : i])
+        y.append(targets[i : i + pred_len])
+
+    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), len(feature_cols)
+
+
+# ---------------------------------------------------------------------------
+# PatchTST
+# ---------------------------------------------------------------------------
+
+
+class TestPatchTSTContaminationFix:
+    def test_train_and_evaluate_returns_metrics(self):
+        from train_patchtst import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            patch_len=8, stride=4,
+            d_model=32, n_heads=2, n_layers=1,
+            epochs=1, batch_size=16, device="cpu",
+        )
+
+        assert "metrics" in result
+        assert "history" in result
+        assert "val_loss" in result["history"]
+        assert "train_loss" in result["history"]
+        assert result["model"] is not None
+
+    def test_val_ratio_creates_internal_split(self):
+        """Verify that val_ratio splits training data internally."""
+        from train_patchtst import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        n_train = split
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            patch_len=8, stride=4,
+            d_model=32, n_heads=2, n_layers=1,
+            epochs=1, batch_size=16, device="cpu",
+            val_ratio=0.2,
+        )
+
+        # train_samples should be 80% of original train (val_ratio=0.2)
+        expected_tr = int(n_train * 0.8)
+        assert result["metrics"]["train_samples"] == expected_tr
+
+
+# ---------------------------------------------------------------------------
+# iTransformer
+# ---------------------------------------------------------------------------
+
+
+class TestiTransformerContaminationFix:
+    def test_train_and_evaluate_returns_metrics(self):
+        from train_itransformer import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            d_model=32, n_heads=2, n_layers=1,
+            epochs=1, batch_size=16, device="cpu",
+        )
+
+        assert "metrics" in result
+        assert "history" in result
+        assert result["model"] is not None
+
+    def test_val_ratio_creates_internal_split(self):
+        from train_itransformer import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        n_train = split
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            d_model=32, n_heads=2, n_layers=1,
+            epochs=1, batch_size=16, device="cpu",
+            val_ratio=0.2,
+        )
+
+        expected_tr = int(n_train * 0.8)
+        assert result["metrics"]["train_samples"] == expected_tr
+
+
+# ---------------------------------------------------------------------------
+# Mamba
+# ---------------------------------------------------------------------------
+
+
+class TestMambaContaminationFix:
+    def test_train_and_evaluate_returns_metrics(self):
+        from train_mamba import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            d_model=32, d_state=8, d_conv=2, expand_factor=2,
+            n_layers=1, epochs=1, batch_size=16, device="cpu",
+        )
+
+        assert "metrics" in result
+        assert "history" in result
+        assert result["model"] is not None
+
+    def test_val_ratio_creates_internal_split(self):
+        from train_mamba import train_and_evaluate
+
+        X, y, n_vars = _make_sequences(300, seq_len=24, pred_len=6)
+        n = len(X)
+        split = int(n * 0.7)
+        n_train = split
+        result = train_and_evaluate(
+            X[:split], y[:split], X[split:], y[split:],
+            n_vars=n_vars, seq_len=24, pred_len=6,
+            d_model=32, d_state=8, d_conv=2, expand_factor=2,
+            n_layers=1, epochs=1, batch_size=16, device="cpu",
+            val_ratio=0.2,
+        )
+
+        expected_tr = int(n_train * 0.8)
+        assert result["metrics"]["train_samples"] == expected_tr

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
@@ -202,9 +202,20 @@ def train_and_evaluate(
     batch_size: int = 64,
     learning_rate: float = 5e-4,
     device: str = "cpu",
+    val_ratio: float = 0.15,
 ) -> dict:
-    """Train iTransformer model and return metrics with baseline comparison."""
+    """Train iTransformer model and return metrics with baseline comparison.
+
+    Test-set contamination fix: validation/early-stopping uses an internal
+    split from the training data only. test_loader is used exclusively for
+    final OOS metrics (never influences model selection).
+    """
     from torch.utils.data import DataLoader, TensorDataset
+
+    # Internal train/val split from training data only (prevent test leakage)
+    val_cutoff = int(len(X_train) * (1 - val_ratio))
+    X_tr, X_val = X_train[:val_cutoff], X_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
 
     model = iTransformerModel(
         n_vars=n_vars,
@@ -221,13 +232,11 @@ def train_and_evaluate(
     total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
     print(f"iTransformer params: {total_params:,}")
 
-    train_ds = TensorDataset(
-        torch.tensor(X_train), torch.tensor(y_train)
-    )
-    test_ds = TensorDataset(
-        torch.tensor(X_test), torch.tensor(y_test)
-    )
+    train_ds = TensorDataset(torch.tensor(X_tr), torch.tensor(y_tr))
+    val_ds = TensorDataset(torch.tensor(X_val), torch.tensor(y_val))
+    test_ds = TensorDataset(torch.tensor(X_test), torch.tensor(y_test))
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
     test_loader = DataLoader(test_ds, batch_size=batch_size)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
@@ -274,12 +283,12 @@ def train_and_evaluate(
         scheduler.step()
         avg_train = epoch_loss / max(n_batches, 1)
 
-        # Validation
+        # Validation on internal val set (NOT test set)
         model.eval()
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in test_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch), y_batch).item()
@@ -330,7 +339,7 @@ def train_and_evaluate(
         "edge_over_majority": round(direction_acc - majority_baseline["majority_class_accuracy"], 4),
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_tr),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -481,9 +481,20 @@ def train_and_evaluate(
     batch_size: int = 32,
     learning_rate: float = 5e-4,
     device: str = "cpu",
+    val_ratio: float = 0.15,
 ) -> dict:
-    """Train MambaTSModel and return metrics with baseline comparison."""
+    """Train MambaTSModel and return metrics with baseline comparison.
+
+    Test-set contamination fix: validation/early-stopping uses an internal
+    split from the training data only. test_loader is used exclusively for
+    final OOS metrics (never influences model selection).
+    """
     from torch.utils.data import DataLoader, TensorDataset
+
+    # Internal train/val split from training data only (prevent test leakage)
+    val_cutoff = int(len(X_train) * (1 - val_ratio))
+    X_tr, X_val = X_train[:val_cutoff], X_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
 
     model = MambaTSModel(
         n_vars=n_vars,
@@ -503,9 +514,11 @@ def train_and_evaluate(
     print(f"  d_model={d_model}, d_state={d_state}, d_conv={d_conv}, "
           f"expand={expand_factor}, n_layers={n_layers}")
 
-    train_ds = TensorDataset(torch.tensor(X_train), torch.tensor(y_train))
+    train_ds = TensorDataset(torch.tensor(X_tr), torch.tensor(y_tr))
+    val_ds = TensorDataset(torch.tensor(X_val), torch.tensor(y_val))
     test_ds = TensorDataset(torch.tensor(X_test), torch.tensor(y_test))
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
     test_loader = DataLoader(test_ds, batch_size=batch_size)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
@@ -552,12 +565,12 @@ def train_and_evaluate(
         scheduler.step()
         avg_train = epoch_loss / max(n_batches, 1)
 
-        # Validation
+        # Validation on internal val set (NOT test set)
         model.eval()
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in test_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch), y_batch).item()
@@ -614,7 +627,7 @@ def train_and_evaluate(
         ),
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_tr),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
     }

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -247,9 +247,20 @@ def train_and_evaluate(
     learning_rate: float = 5e-4,
     channel_independence: bool = True,
     device: str = "cpu",
+    val_ratio: float = 0.15,
 ) -> dict:
-    """Train PatchTST model and return metrics with baseline comparison."""
+    """Train PatchTST model and return metrics with baseline comparison.
+
+    Test-set contamination fix: validation/early-stopping uses an internal
+    split from the training data only. test_loader is used exclusively for
+    final OOS metrics (never influences model selection).
+    """
     from torch.utils.data import DataLoader, TensorDataset
+
+    # Internal train/val split from training data only (prevent test leakage)
+    val_cutoff = int(len(X_train) * (1 - val_ratio))
+    X_tr, X_val = X_train[:val_cutoff], X_train[val_cutoff:]
+    y_tr, y_val = y_train[:val_cutoff], y_train[val_cutoff:]
 
     model = PatchTSTModel(
         n_vars=n_vars,
@@ -270,13 +281,11 @@ def train_and_evaluate(
     print(f"PatchTST params: {total_params:,}")
     print(f"  num_patches={model.num_patches}, patch_len={patch_len}, stride={stride}")
 
-    train_ds = TensorDataset(
-        torch.tensor(X_train), torch.tensor(y_train)
-    )
-    test_ds = TensorDataset(
-        torch.tensor(X_test), torch.tensor(y_test)
-    )
+    train_ds = TensorDataset(torch.tensor(X_tr), torch.tensor(y_tr))
+    val_ds = TensorDataset(torch.tensor(X_val), torch.tensor(y_val))
+    test_ds = TensorDataset(torch.tensor(X_test), torch.tensor(y_test))
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
     test_loader = DataLoader(test_ds, batch_size=batch_size)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
@@ -323,12 +332,12 @@ def train_and_evaluate(
         scheduler.step()
         avg_train = epoch_loss / max(n_batches, 1)
 
-        # Validation
+        # Validation on internal val set (NOT test set)
         model.eval()
         val_loss = 0.0
         val_batches = 0
         with torch.no_grad():
-            for X_batch, y_batch in test_loader:
+            for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
                     val_loss += criterion(model(X_batch), y_batch).item()
@@ -382,7 +391,7 @@ def train_and_evaluate(
         "edge_over_majority": round(direction_acc - majority_baseline["majority_class_accuracy"], 4),
         "best_val_loss": round(best_val_loss, 6),
         "total_params": total_params,
-        "train_samples": len(X_train),
+        "train_samples": len(X_tr),
         "test_samples": len(X_test),
         "epochs_trained": epochs,
         "num_patches": model.num_patches,


### PR DESCRIPTION
## Summary
- Extends the test-set contamination fix from PR #726 to 3 additional training scripts: PatchTST, iTransformer, Mamba
- All 3 scripts were using `test_loader` for validation/early stopping, allowing test data to influence model selection (contamination)
- Fix: `val_ratio=0.15` internal split from training data, `val_loader` for early stopping, `test_loader` OOS only

## Changes
- **train_patchtst.py**: Added `val_ratio=0.15` param, internal train/val split, separate `val_loader`/`test_loader`
- **train_itransformer.py**: Same pattern
- **train_mamba.py**: Same pattern
- **tests/test_contamination_fix.py**: 6 new tests (2 per script) verifying correct internal split

## Test plan
- [x] `pytest tests/test_contamination_fix.py` — 6/6 passed
- [x] `python train_patchtst.py --dry-run` — pipeline validated
- [x] `python train_itransformer.py --dry-run` — pipeline validated
- [x] `python train_mamba.py --dry-run` — pipeline validated

## Context
Follow-up to #722 (test-set contamination issue) and #726 (fix for LSTM/Transformer/Classification/DQN/MTGNN/STGAT).
ai-01 confirmed PatchTST/iTransformer/Mamba runs were "TOUS contaminés" before this fix.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>