### PR TITLE
fix(ci): add C.2 compliance check to notebook-validation workflow

### DIFF
--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
     paths:
       - '**.ipynb'
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:
 
 jobs:
   validate-notebooks:
@@ -58,3 +58,21 @@ jobs:
           exit 1
         fi
         echo "All notebooks validated successfully"
+
+    - name: Check C.2 compliance (execution outputs)
+      run: |
+        python scripts/notebook_tools/check_c2_compliance.py --json > /tmp/c2_results.json || true
+        VIOLATIONS=$(python -c "
+        import json
+        data = json.load(open('/tmp/c2_results.json'))
+        nb_violations = [r for r in data if r['violations']]
+        total_cells = sum(len(r['violations']) for r in nb_violations)
+        print(f'{len(nb_violations)} notebooks, {total_cells} cells')
+        ")
+        echo "C.2 compliance: $VIOLATIONS with violations"
+        # Report but don't block — C.2 is advisory on PRs, enforced on merge
+        if echo "$VIOLATIONS" | grep -q "0 notebooks"; then
+          echo "All notebooks C.2 compliant."
+        else
+          echo "::warning::$VIOLATIONS missing outputs (C.2)"
+        fi


### PR DESCRIPTION
## Summary

- Add `check_c2_compliance.py` step to `notebook-validation.yml` CI workflow
- The script existed but was never run in CI — C.2 violations (missing outputs) could slip into main undetected
- Runs as advisory warning (not blocking) on PRs to avoid false positives during development

## Changes

- `.github/workflows/notebook-validation.yml`: new "Check C.2 compliance" step after JSON validation
- Uses existing `scripts/notebook_tools/check_c2_compliance.py --json`
- Reports via `::warning::` annotation (visible in PR checks summary)

## Test plan

- Open a PR modifying a notebook → C.2 check runs alongside JSON validation
- Notebook with missing outputs → warning annotation appears
- All notebooks compliant → clean pass