### PR TITLE
fix(ml): RSI uses Wilder EMA instead of SMA (industry standard)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/features.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/features.py
@@ -72,8 +72,9 @@ def compute_rsi(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
     """Relative Strength Index."""
     feat = pd.DataFrame(index=df.index)
     delta = df["Close"].diff()
-    gain = delta.where(delta > 0, 0.0).rolling(period).mean()
-    loss = (-delta.where(delta < 0, 0.0)).rolling(period).mean()
+    alpha = 1.0 / period
+    gain = delta.where(delta > 0, 0.0).ewm(alpha=alpha, min_periods=period).mean()
+    loss = (-delta.where(delta < 0, 0.0)).ewm(alpha=alpha, min_periods=period).mean()
     rs = gain / loss.replace(0, 1e-10)
     feat[f"rsi_{period}"] = 100 - (100 / (1 + rs))
     return feat


### PR DESCRIPTION
## Summary

- Switches `compute_rsi()` in `features.py` from `rolling(period).mean()` (Simple Moving Average) to `ewm(alpha=1/period)` (Wilder exponential smoothing)
- Aligns RSI values with TradingView, Yahoo Finance, and all standard financial platforms
- Finding #2 from pipeline audit (#705)

## Changes

- `features.py` L75-77: `rolling(period).mean()` → `ewm(alpha=1.0/period, min_periods=period).mean()` for both gain and loss
- Added `alpha = 1.0 / period` variable for clarity
- No API changes — same function signature, same output column name

## Impact

- RSI values will change slightly for all existing checkpoints (Wilder EMA gives more weight to recent data)
- New values will match what students see on TradingView when comparing
- This is a **breaking change** for cached features — any existing `features_*.parquet` files should be regenerated

## Test plan

- Compare RSI output with TradingView RSI(14) on same SPY data — should match within floating point
- Verify existing tests still pass (function signature unchanged)