### PR TITLE
fix(ml): majority class baseline uses actual OOS targets instead of half-split

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -385,9 +385,16 @@ def train_walk_forward(
 
     oos_diracc = float(np.mean((oos_predictions > 0) == (oos_targets > 0)))
 
-    # Majority-class baseline on first half (train proxy) vs second half (test proxy)
-    y_binary = (y > 0).astype(int)
-    majority_bl = majority_class_baseline(y_binary[: len(y) // 2], y_binary[len(y) // 2 :])
+    # Majority-class baseline on actual OOS targets
+    y_binary_oos = (oos_targets > 0).astype(int)
+    majority_freq = float(np.mean(y_binary_oos == 1))
+    majority_bl = {
+        "accuracy": majority_freq,
+        "majority_class": 1,
+        "majority_freq": majority_freq,
+        "n_train": 0,
+        "n_test": len(y_binary_oos),
+    }
 
     # Rebuild best model
     input_size = X.shape[2]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -435,8 +435,16 @@ def train_walk_forward(
     oos_targets = y[valid_mask]
     oos_diracc = float(np.mean((oos_predictions > 0) == (oos_targets > 0)))
 
-    y_binary = (y > 0).astype(int)
-    majority_bl = majority_class_baseline(y_binary[: len(y) // 2], y_binary[len(y) // 2 :])
+    # Majority-class baseline on actual OOS targets
+    y_binary_oos = (oos_targets > 0).astype(int)
+    majority_freq = float(np.mean(y_binary_oos == 1))
+    majority_bl = {
+        "accuracy": majority_freq,
+        "majority_class": 1,
+        "majority_freq": majority_freq,
+        "n_train": 0,
+        "n_test": len(y_binary_oos),
+    }
 
     input_size = X.shape[2]
     best_model = build_transformer_model(


### PR DESCRIPTION
## Summary
- Pipeline audit finding #4 (LOW)
- `majority_class_baseline()` received a naive half-split of the full dataset, not aligned with actual walk-forward OOS folds
- Now computes majority class frequency directly from concatenated OOS targets across all folds

## Changes
- `train_lstm.py`: replace half-split with OOS-based majority frequency computation
- `train_transformer.py`: same fix

## Test plan
- [ ] Verify majority baseline value changes are reasonable (should be similar, just more precise)
- [ ] Confirm walk-forward output still runs without error
- [ ] Cross-check: majority_bl accuracy should equal the frequency of the dominant class in OOS targets