### PR TITLE
fix(ml): save last fold model instead of best fold (selection bias)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -330,7 +330,6 @@ def train_walk_forward(
     fold_results = []
     oos_preds = np.full(len(y), np.nan)
     best_model_state = None
-    best_fold_diracc = -1.0
 
     for fold_idx, (train_idx, test_idx) in enumerate(splitter.split(X)):
         if len(test_idx) == 0:
@@ -371,9 +370,8 @@ def train_walk_forward(
             preds = fold_result["model"](X_test_t).squeeze(-1).cpu().numpy()
         oos_preds[test_idx] = preds
 
-        if fold_diracc > best_fold_diracc:
-            best_fold_diracc = fold_diracc
-            best_model_state = {k: v.cpu().clone() for k, v in fold_result["model"].state_dict().items()}
+        # Save last fold model (avoids test-set selection bias from cherry-picking best fold)
+        best_model_state = {k: v.cpu().clone() for k, v in fold_result["model"].state_dict().items()}
 
         print(f"  Fold {fold_idx+1}/{n_splits}  diracc={fold_diracc:.4f}  "
               f"train={len(train_idx)}  test={len(test_idx)}")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -385,7 +385,6 @@ def train_walk_forward(
     fold_results = []
     oos_preds = np.full(len(y), np.nan)
     best_model_state = None
-    best_fold_diracc = -1.0
 
     for fold_idx, (train_idx, test_idx) in enumerate(splitter.split(X)):
         if len(test_idx) == 0:
@@ -423,9 +422,8 @@ def train_walk_forward(
             preds = fold_result["model"](X_test_t).squeeze(-1).cpu().numpy()
         oos_preds[test_idx] = preds
 
-        if fold_diracc > best_fold_diracc:
-            best_fold_diracc = fold_diracc
-            best_model_state = {k: v.cpu().clone() for k, v in fold_result["model"].state_dict().items()}
+        # Save last fold model (avoids test-set selection bias from cherry-picking best fold)
+        best_model_state = {k: v.cpu().clone() for k, v in fold_result["model"].state_dict().items()}
 
         print(f"  Fold {fold_idx+1}/{n_splits}  diracc={fold_diracc:.4f}  "
               f"train={len(train_idx)}  test={len(test_idx)}")


### PR DESCRIPTION
## Summary
- Pipeline audit finding #8 (MEDIUM)
- Walk-forward CV previously saved the checkpoint from the fold with highest OOS direction accuracy — test-set selection bias
- Now saves the last fold's model state (most recent data), avoiding cherry-picking

## Changes
- `train_lstm.py`: remove `best_fold_diracc` tracking, unconditional save on every fold (last wins)
- `train_transformer.py`: same fix

## Impact
- Aggregate OOS DirAcc metric is **unchanged** (it averages all folds)
- Only the saved checkpoint changes: was cherry-picked best, now is last fold
- No impact on published metrics (Track B still PENDING, REGISTRY.md confirmed)

## Test plan
- [ ] Verify walk-forward output still runs without error
- [ ] Confirm checkpoint is from last fold (not highest diracc)