### PR TITLE
fix(ml): extend majority baseline OOS fix to classification + cleanup dead imports

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
@@ -32,7 +32,6 @@ import pandas as pd
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from walk_forward import WalkForwardSplitter
-from baselines import majority_class_baseline
 
 
 def train_and_evaluate(
@@ -242,9 +241,16 @@ def train_walk_forward_classification(
 
     oos_diracc = float(np.mean(oos_predictions == oos_targets))
 
-    # Majority-class baseline on first half (train proxy) vs second half (test proxy)
-    y_binary = y.copy()
-    majority_bl = majority_class_baseline(y_binary[: len(y) // 2], y_binary[len(y) // 2 :])
+    # Majority-class baseline on actual OOS targets
+    y_binary_oos = oos_targets.copy()
+    majority_freq = float(np.mean(y_binary_oos == 1))
+    majority_bl = {
+        "accuracy": max(majority_freq, 1.0 - majority_freq),
+        "majority_class": 1 if majority_freq >= 0.5 else 0,
+        "majority_freq": majority_freq,
+        "n_train": 0,
+        "n_test": len(y_binary_oos),
+    }
 
     return {
         "model": best_model,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -31,7 +31,6 @@ import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parent))
 from walk_forward import WalkForwardSplitter
-from baselines import majority_class_baseline
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -37,7 +37,6 @@ import pandas as pd
 # Import thermal-safe training utilities
 sys.path.append(str(Path(__file__).resolve().parent))
 from walk_forward import WalkForwardSplitter
-from baselines import majority_class_baseline
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (


### PR DESCRIPTION
## Summary
- Follow-up to pipeline audit finding #7 (PR #737)
- `train_classification.py` had the same half-split majority baseline bug — now uses actual OOS targets
- Removed dead `majority_class_baseline` imports from `train_lstm.py` and `train_transformer.py` (unused since #737)

## Changes
- `train_classification.py`: inline OOS-based majority computation (same pattern as #737)
- `train_lstm.py`: remove dead import
- `train_transformer.py`: remove dead import

## Note
- `train_dqn_rl.py` retains the half-split proxy — its direction metric is per-fold (agent vs buy-and-hold sign), not per-sample, so the approximation is acceptable

## Test plan
- [ ] Verify classification walk-forward runs without error
- [ ] Confirm majority baseline values are reasonable