### PR TITLE
refactor(ml): extract shared sequence_utils from 8 training scripts

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
@@ -44,6 +44,7 @@ from scripts.baselines import (
 from scripts.data_utils import generate_synthetic_data, load_data
 from scripts.eval_finstsb import eval_per_regime
 from scripts.features import FeatureEngineer
+from scripts.sequence_utils import build_sequences
 from scripts.transaction_costs import TransactionCostModel, compare_gross_vs_net
 from scripts.walk_forward import WalkForwardSplitter
 
@@ -157,22 +158,6 @@ def predict_direction(model, X: np.ndarray, model_type: str) -> np.ndarray:
     if model_type == "rf":
         return raw.astype(int)
     return (raw > 0).astype(int)
-
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 20, target_col: str = "target"
-) -> tuple:
-    """Build sequence arrays from feature DataFrame."""
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data)):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
 
 
 def evaluate_checkpoint(

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sequence_utils.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sequence_utils.py
@@ -1,0 +1,97 @@
+"""Shared sequence building and normalization for time-series ML models.
+
+Provides build_sequences (sliding window) and normalize_sequences (z-score
+using training statistics only, preventing test-set leakage).
+
+Previously duplicated across 8 training scripts. Unified here for
+consistency and deduplication.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def build_sequences(
+    features: pd.DataFrame,
+    seq_len: int = 20,
+    pred_len: int = 1,
+    target_col: str = "target",
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Build sliding-window sequences from a feature DataFrame.
+
+    Parameters
+    ----------
+    features : DataFrame
+        Feature matrix with a target column.
+    seq_len : int
+        Input sequence length (lookback window).
+    pred_len : int
+        Prediction horizon. When 1, produces scalar targets (seq2one).
+        When >1, produces multi-step targets (seq2seq).
+    target_col : str
+        Name of the target column to exclude from features.
+
+    Returns
+    -------
+    X : ndarray of shape (n_samples, seq_len, n_features), float32
+    y : ndarray of shape (n_samples,) or (n_samples, pred_len), float32
+    feature_cols : list of str
+    """
+    feature_cols = [c for c in features.columns if c != target_col]
+    data = features[feature_cols].values
+    targets = features[target_col].values
+
+    X, y = [], []
+    if pred_len == 1:
+        # seq2one: scalar targets (backward-compatible with LSTM/Transformer)
+        for i in range(seq_len, len(data)):
+            X.append(data[i - seq_len : i])
+            y.append(targets[i])
+    else:
+        # seq2seq: multi-step targets
+        for i in range(seq_len, len(data) - pred_len + 1):
+            X.append(data[i - seq_len : i])
+            y.append(targets[i : i + pred_len])
+
+    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
+
+
+def normalize_sequences(
+    X_train: np.ndarray,
+    X_test: np.ndarray,
+    X_val: np.ndarray | None = None,
+) -> tuple:
+    """Z-normalize features using training statistics only (anti-leakage).
+
+    Parameters
+    ----------
+    X_train : ndarray
+        Training data (used to compute mean and std).
+    X_test : ndarray
+        Test data to normalize.
+    X_val : ndarray or None
+        Optional validation data to normalize.
+
+    Returns
+    -------
+    If X_val is None:
+        (X_train_norm, X_test_norm, mean, std)
+    If X_val is provided:
+        (X_train_norm, X_test_norm, X_val_norm, mean, std)
+    """
+    mean = X_train.mean(axis=(0, 1), keepdims=True)
+    std = X_train.std(axis=(0, 1), keepdims=True)
+    std = np.where(std < 1e-8, 1.0, std)
+
+    result = [
+        (X_train - mean) / std,
+        (X_test - mean) / std,
+        mean.squeeze(),
+        std.squeeze(),
+    ]
+    if X_val is not None:
+        result.insert(2, (X_val - mean) / std)
+        return tuple(result)
+    return tuple(result)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_sequence_utils.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_sequence_utils.py
@@ -1,0 +1,123 @@
+"""Tests for sequence_utils.py -- shared build_sequences and normalize_sequences."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from sequence_utils import build_sequences, normalize_sequences
+
+
+@pytest.fixture
+def feature_df():
+    """Feature DataFrame with enough rows for sequence building."""
+    np.random.seed(42)
+    n = 200
+    return pd.DataFrame(
+        {
+            "feat_a": np.random.randn(n).cumsum(),
+            "feat_b": np.random.randn(n).cumsum(),
+            "feat_c": np.random.randn(n),
+            "target": np.random.randn(n),
+        }
+    )
+
+
+class TestBuildSequences:
+    def test_seq2one_default(self, feature_df):
+        X, y, cols = build_sequences(feature_df)
+        assert X.shape[0] == len(feature_df) - 20
+        assert X.shape[1] == 20  # seq_len
+        assert X.shape[2] == 3  # 3 features (excl target)
+        assert y.ndim == 1  # scalar targets
+        assert len(y) == X.shape[0]
+        assert "target" not in cols
+
+    def test_seq2one_custom_seq_len(self, feature_df):
+        X, y, cols = build_sequences(feature_df, seq_len=10)
+        assert X.shape[1] == 10
+        assert X.shape[0] == len(feature_df) - 10
+
+    def test_seq2seq_multistep(self, feature_df):
+        X, y, cols = build_sequences(feature_df, seq_len=20, pred_len=5)
+        assert X.shape[1] == 20
+        assert y.shape[1] == 5  # multi-step targets
+        assert X.shape[0] == len(feature_df) - 20 - 5 + 1
+
+    def test_seq2seq_pred_len_1_produces_scalar(self, feature_df):
+        """pred_len=1 should produce scalar targets (backward compat)."""
+        X, y, cols = build_sequences(feature_df, seq_len=20, pred_len=1)
+        assert y.ndim == 1
+
+    def test_feature_cols_excludes_target(self, feature_df):
+        _, _, cols = build_sequences(feature_df)
+        assert "target" not in cols
+        assert len(cols) == 3
+
+    def test_dtype_float32(self, feature_df):
+        X, y, _ = build_sequences(feature_df)
+        assert X.dtype == np.float32
+        assert y.dtype == np.float32
+
+    def test_custom_target_col(self, feature_df):
+        df = feature_df.rename(columns={"target": "label"})
+        X, y, cols = build_sequences(df, target_col="label")
+        assert "label" not in cols
+        assert X.shape[2] == 3
+
+
+class TestNormalizeSequences:
+    def test_basic_two_arrays(self):
+        X_train = np.random.randn(50, 10, 5).astype(np.float32)
+        X_test = np.random.randn(20, 10, 5).astype(np.float32)
+        result = normalize_sequences(X_train, X_test)
+        assert len(result) == 4
+        X_train_n, X_test_n, mean, std = result
+        assert X_train_n.shape == X_train.shape
+        assert X_test_n.shape == X_test.shape
+        assert mean.shape == (5,)
+        assert std.shape == (5,)
+
+    def test_with_validation(self):
+        X_train = np.random.randn(50, 10, 5).astype(np.float32)
+        X_test = np.random.randn(20, 10, 5).astype(np.float32)
+        X_val = np.random.randn(10, 10, 5).astype(np.float32)
+        result = normalize_sequences(X_train, X_test, X_val=X_val)
+        assert len(result) == 5
+        X_train_n, X_test_n, X_val_n, mean, std = result
+        assert X_val_n.shape == X_val.shape
+
+    def test_train_mean_near_zero(self):
+        X_train = np.random.randn(500, 10, 3).astype(np.float32) * 5 + 10
+        X_test = np.random.randn(100, 10, 3).astype(np.float32)
+        X_train_n, X_test_n, mean, std = normalize_sequences(X_train, X_test)
+        assert np.abs(X_train_n.mean(axis=(0, 1))).max() < 0.1
+
+    def test_train_std_near_one(self):
+        X_train = np.random.randn(500, 10, 3).astype(np.float32) * 5 + 10
+        X_test = np.random.randn(100, 10, 3).astype(np.float32)
+        X_train_n, _, _, _ = normalize_sequences(X_train, X_test)
+        assert np.abs(X_train_n.std(axis=(0, 1)) - 1.0).max() < 0.1
+
+    def test_no_leakage_from_test(self):
+        """Normalization stats come only from training data."""
+        rng = np.random.default_rng(42)
+        X_train = rng.standard_normal((100, 10, 3)).astype(np.float32)
+        X_test = rng.standard_normal((50, 10, 3)).astype(np.float32) * 100 + 50
+        _, X_test_n, mean, std = normalize_sequences(X_train, X_test)
+        mean_manual = X_train.mean(axis=(0, 1))
+        std_manual = X_train.std(axis=(0, 1))
+        np.testing.assert_allclose(mean, mean_manual, atol=1e-5)
+        np.testing.assert_allclose(std, std_manual, atol=1e-5)
+
+    def test_constant_features_no_division_by_zero(self):
+        X_train = np.ones((50, 10, 3), dtype=np.float32)
+        X_test = np.ones((20, 10, 3), dtype=np.float32) * 2
+        X_train_n, X_test_n, _, std = normalize_sequences(X_train, X_test)
+        assert np.all(std == 1.0)  # fallback for zero std
+        assert not np.any(np.isnan(X_train_n))
+        assert not np.any(np.isnan(X_test_n))

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
@@ -40,6 +40,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from sequence_utils import build_sequences, normalize_sequences
 
 try:
     from walk_forward import WalkForwardSplitter
@@ -134,42 +135,6 @@ class iTransformerModel(nn.Module):
         preds = preds.mean(dim=1)
 
         return preds
-
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 96, pred_len: int = 24, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-sequence arrays for iTransformer."""
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data) - pred_len + 1):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i : i + pred_len])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_test: np.ndarray, X_val: np.ndarray | None = None
-) -> tuple:
-    """Z-normalize using training statistics only (anti-leakage)."""
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    result = [
-        (X_train - mean) / std,
-        (X_test - mean) / std,
-        mean.squeeze(),
-        std.squeeze(),
-    ]
-    if X_val is not None:
-        result.insert(2, (X_val - mean) / std)
-        return tuple(result)
-    return tuple(result)
 
 
 def compute_majority_class_baseline(y_test: np.ndarray) -> dict:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -40,35 +40,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
-
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 20, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-one arrays for LSTM training."""
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data)):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_test: np.ndarray
-) -> tuple:
-    """Z-normalize features using training statistics only."""
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    X_train_norm = (X_train - mean) / std
-    X_test_norm = (X_test - mean) / std
-    return X_train_norm, X_test_norm, mean.squeeze(), std.squeeze()
+from sequence_utils import build_sequences, normalize_sequences
 
 
 def build_model(

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -56,6 +56,7 @@ import torch.nn.functional as F
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from sequence_utils import build_sequences, normalize_sequences
 
 try:
     from gpu_training import batch_thermal_check, get_gpu_temp, setup_amp
@@ -392,57 +393,6 @@ class MambaTSModel(nn.Module):
 # ---------------------------------------------------------------------------
 # Data pipeline (shared with PatchTST)
 # ---------------------------------------------------------------------------
-
-
-def build_sequences(
-    features: pd.DataFrame,
-    seq_len: int = 96,
-    pred_len: int = 24,
-    target_col: str = "target",
-) -> tuple:
-    """Build sequence arrays from feature DataFrame.
-
-    Returns
-    -------
-    X : [n_samples, seq_len, n_features]
-    y : [n_samples, pred_len]
-    feature_cols : list of column names
-    """
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data) - pred_len + 1):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i : i + pred_len])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray,
-    X_test: np.ndarray,
-    X_val: np.ndarray | None = None,
-) -> tuple:
-    """Z-normalize using training statistics only (anti-leakage).
-
-    Returns (normalized arrays, mean, std).
-    """
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    result = [
-        (X_train - mean) / std,
-        (X_test - mean) / std,
-        mean.squeeze(),
-        std.squeeze(),
-    ]
-    if X_val is not None:
-        result.insert(2, (X_val - mean) / std)
-        return tuple(result)  # (X_train_n, X_val_n, X_test_n, mean, std)
-    return tuple(result)
 
 
 def compute_majority_class_baseline(y_test: np.ndarray) -> dict:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
@@ -48,6 +48,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from sequence_utils import build_sequences, normalize_sequences
 
 try:
     from walk_forward import WalkForwardSplitter
@@ -401,46 +402,8 @@ class MTGNNModel(nn.Module):
 
 
 # ---------------------------------------------------------------------------
-# Sequence building and normalization (same interface as Stage 2)
+# Baselines
 # ---------------------------------------------------------------------------
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 96, pred_len: int = 24, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-sequence arrays for MTGNN.
-
-    Returns:
-        X: [n_samples, seq_len, n_features]
-        y: [n_samples, pred_len]
-        feature_cols: list of feature column names
-    """
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data) - pred_len + 1):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i : i + pred_len])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_val: np.ndarray | None = None, X_test: np.ndarray | None = None
-) -> tuple:
-    """Z-normalize using training statistics only (anti-leakage)."""
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    result = [(X_train - mean) / std]
-    if X_val is not None:
-        result.append((X_val - mean) / std)
-    if X_test is not None:
-        result.append((X_test - mean) / std)
-    result.extend([mean.squeeze(), std.squeeze()])
-    return tuple(result)
 
 
 def compute_majority_class_baseline(y_test: np.ndarray) -> dict:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -48,6 +48,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from sequence_utils import build_sequences, normalize_sequences
 
 # Optional: walk_forward from Stage 0 (graceful fallback)
 try:
@@ -160,53 +161,6 @@ class PatchTSTModel(nn.Module):
             preds = preds.mean(dim=1)
 
         return preds
-
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 96, pred_len: int = 24, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-sequence arrays for PatchTST.
-
-    Returns:
-        X: [n_samples, seq_len, n_features]
-        y: [n_samples, pred_len, n_features] (future target values)
-        feature_cols: list of feature column names
-    """
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data) - pred_len + 1):
-        X.append(data[i - seq_len : i])
-        # Multi-step target: future returns for each variable
-        y.append(targets[i : i + pred_len])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_test: np.ndarray, X_val: np.ndarray | None = None
-) -> tuple:
-    """Z-normalize using training statistics only (anti-leakage).
-
-    Returns:
-        Normalized arrays + (mean, std) for audit
-    """
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    result = [
-        (X_train - mean) / std,
-        (X_test - mean) / std,
-        mean.squeeze(),
-        std.squeeze(),
-    ]
-    if X_val is not None:
-        result.insert(2, (X_val - mean) / std)
-        return tuple(result)  # (X_train_n, X_val_n, X_test_n, mean, std)
-    return tuple(result)
 
 
 def compute_majority_class_baseline(y_test: np.ndarray) -> dict:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
@@ -47,6 +47,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from sequence_utils import build_sequences, normalize_sequences
 
 try:
     from walk_forward import WalkForwardSplitter
@@ -355,40 +356,8 @@ class STGATModel(nn.Module):
 
 
 # ---------------------------------------------------------------------------
-# Sequence building and normalization (same interface as Stage 2)
+# Baselines
 # ---------------------------------------------------------------------------
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 96, pred_len: int = 24, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-sequence arrays for STGAT."""
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data) - pred_len + 1):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i : i + pred_len])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_val: np.ndarray | None = None, X_test: np.ndarray | None = None
-) -> tuple:
-    """Z-normalize using training statistics only (anti-leakage)."""
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    result = [(X_train - mean) / std]
-    if X_val is not None:
-        result.append((X_val - mean) / std)
-    if X_test is not None:
-        result.append((X_test - mean) / std)
-    result.extend([mean.squeeze(), std.squeeze()])
-    return tuple(result)
 
 
 def compute_majority_class_baseline(y_test: np.ndarray) -> dict:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -46,38 +46,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
-
-
-def build_sequences(
-    features: pd.DataFrame, seq_len: int = 20, target_col: str = "target"
-) -> tuple:
-    """Build sequence-to-one arrays for Transformer training."""
-    feature_cols = [c for c in features.columns if c != target_col]
-    data = features[feature_cols].values
-    targets = features[target_col].values
-
-    X, y = [], []
-    for i in range(seq_len, len(data)):
-        X.append(data[i - seq_len : i])
-        y.append(targets[i])
-
-    return np.array(X, dtype=np.float32), np.array(y, dtype=np.float32), feature_cols
-
-
-def normalize_sequences(
-    X_train: np.ndarray, X_test: np.ndarray
-) -> tuple:
-    """Z-normalize features using training statistics."""
-    mean = X_train.mean(axis=(0, 1), keepdims=True)
-    std = X_train.std(axis=(0, 1), keepdims=True)
-    std = np.where(std < 1e-8, 1.0, std)
-
-    return (
-        (X_train - mean) / std,
-        (X_test - mean) / std,
-        mean.squeeze(),
-        std.squeeze(),
-    )
+from sequence_utils import build_sequences, normalize_sequences
 
 
 class PositionalEncoding:


### PR DESCRIPTION
## Summary
- Extract `build_sequences` and `normalize_sequences` from 8 training scripts into shared `sequence_utils.py`
- Unified API supports both seq2one (LSTM/Transformer) and seq2seq (iTransformer/PatchTST/Mamba/MTGNN/STGAT) with backward-compatible defaults
- 283 lines of duplicated code removed (-283), replaced by single 93-line module

## Test plan
- [x] 13 new tests for `sequence_utils.py` (build_sequences: 7, normalize_sequences: 6)
- [x] All 399 existing tests pass (no regressions)
- [x] All 7 training scripts import successfully with new shared import
- [x] Verified callers work correctly despite parameter order differences (normalization is symmetric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)