### PR TITLE
fix(ml): remove unused imports (TimeSeriesSplit, TrainingCheckpoint)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
@@ -44,7 +44,6 @@ def train_and_evaluate(
     """Train a classification model and return metrics."""
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
-    from sklearn.model_selection import TimeSeriesSplit
     from sklearn.preprocessing import StandardScaler
 
     X = features.drop(columns=["target"]).values

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -39,7 +39,6 @@ from walk_forward import WalkForwardSplitter
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
-    TrainingCheckpoint,
     batch_thermal_check,
     get_gpu_temp,
     setup_amp,


### PR DESCRIPTION
## Summary
- Remove `TimeSeriesSplit` from `train_classification.py` (imported but never used)
- Remove `TrainingCheckpoint` from `train_transformer.py` (imported but never used)

## Test plan
- [x] 386 tests pass (no regressions)
- [x] Both scripts import successfully after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)