### PR TITLE
chore(qc): remove ECE-QC-QUICKSTART references from notebooks

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -42,7 +42,6 @@
     "> \n",
     "> **Pour votre projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/` dans votre projet QC Lab, puis cliquez Backtest.\n",
     "> \n",
-    "> **Etudiants ECE Projet 2** : Consultez [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md) pour le guide complet.\n",
     "\n",
     "---"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -64,7 +64,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -31,7 +31,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -60,7 +60,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -42,7 +42,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -57,7 +57,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -60,7 +60,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -40,7 +40,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -60,7 +60,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -62,7 +62,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -58,7 +58,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -57,7 +57,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -73,7 +73,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -59,7 +59,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -60,7 +60,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -58,7 +58,6 @@
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
     "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -64,7 +64,6 @@
     "> 2. Sauvegardez-le via **Object Store** dans un research.ipynb QC (QuantBook)\n",
     "> 3. Chargez-le dans votre `main.py` (Algorithm) pour trader\n",
     "> \n",
-    "> Voir le guide complet : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -62,7 +62,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -63,7 +63,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -76,7 +76,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -104,7 +104,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -102,7 +102,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
@@ -95,7 +95,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -62,7 +62,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -62,7 +62,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -1461,7 +1461,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -99,7 +99,6 @@
     "> 2. **Sections integration QC** (classes `QCAlgorithm`) : **code de reference a copier dans `main.py`** de votre projet QC Lab\n",
     ">\n",
     "> Les cellules QCAlgorithm sont marquees `# [REFERENCE QC]` et ne sont pas executables localement.\n",
-    "> Voir le guide : [ECE-QC-QUICKSTART.md](../ECE-QC-QUICKSTART.md)\n",
     "\n",
     "---"
    ]


### PR DESCRIPTION
## Summary
- Remove dead `ECE-QC-QUICKSTART.md` references from 27 QC-Py notebooks (file deleted in PR #744)
- Markdown-only changes, no code cells modified
- 1 line removed per notebook (QC-Py-01 had "Etudiants ECE Projet 2" tag, others had "Voir le guide" links)

## Verification
- `grep -c ECE` = 0 across all QC notebooks (excluding "Item 5.02" book reference preserved)
- No cellule code modifiee (`git diff` shows only markdown cell changes)
- Scope strict CLAUDE.md C.3: no Papermill re-execution (only markdown source changed)

## Files affected (27)
QC-Py-01 through QC-Py-31 (all notebooks with dead ECE-QC-QUICKSTART links)

Followup to PR #744 (trading section cleanup + school neutrality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)