### PR TITLE
fix(ml): remove unused/orphaned imports from training + eval scripts

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
@@ -37,13 +37,8 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from data_utils import load_data
 
 from eval_kronos_zeroshot import (
-    KronosWrapper,
-    NaiveKronosWrapper,
     build_evaluation_windows,
-    compute_direction_accuracy,
     compute_majority_baseline,
-    compute_sharpe,
-    compute_transaction_cost,
     evaluate_window,
 )
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 
 import numpy as np

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_kronos_zeroshot.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_kronos_zeroshot.py
@@ -46,15 +46,6 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 
 from data_utils import load_data
 
-try:
-    from eval_finstsb import DirectionModel, detect_regimes
-except ImportError:
-    detect_regimes = None
-
-try:
-    from walk_forward import WalkForwardSplitter
-except ImportError:
-    WalkForwardSplitter = None
 
 KRONOS_MODEL_IDS = {
     "small": "shiyu-coder/Kronos-Small",

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_classification.py
@@ -44,7 +44,6 @@ def train_and_evaluate(
     """Train a classification model and return metrics."""
     from sklearn.ensemble import RandomForestClassifier
     from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
-    from sklearn.model_selection import TimeSeriesSplit
     from sklearn.preprocessing import StandardScaler
 
     X = features.drop(columns=["target"]).values

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -39,7 +39,6 @@ from walk_forward import WalkForwardSplitter
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from gpu_training import (
-    TrainingCheckpoint,
     batch_thermal_check,
     get_gpu_temp,
     setup_amp,


### PR DESCRIPTION
## Summary
- Remove 2 unused imports from training scripts (`TimeSeriesSplit` in train_classification.py, `TrainingCheckpoint` in train_transformer.py)
- Remove 5 orphaned imports from eval_chronos_bolt.py (`KronosWrapper`, `NaiveKronosWrapper`, `compute_direction_accuracy`, `compute_sharpe`, `compute_transaction_cost`)
- Remove 3 orphaned imports from eval_kronos_zeroshot.py (`DirectionModel`, `detect_regimes`, `WalkForwardSplitter` including try/except blocks)
- Remove unused `import sys` from eval_existing_checkpoints.py

Total: 10 unused imports removed across 5 files. All verified via grep (symbols only appear on import lines).

## Test plan
- [x] `pytest scripts/tests/ -x -q` — 386/386 pass
- [x] AST syntax check on all 5 modified files
- [x] Grep confirmation that removed symbols have zero usage beyond import lines