### PR TITLE
refactor(ml): dedup majority-class baseline from 5 seq2seq scripts

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/baselines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/baselines.py
@@ -229,6 +229,35 @@ def buy_and_hold_baseline(
     }
 
 
+def oos_direction_distribution(y: np.ndarray) -> dict:
+    """Compute the class distribution in OOS predictions (seq2seq baseline).
+
+    For multi-step forecasting models (iTransformer, PatchTST, Mamba, MTGNN, STGAT),
+    targets are continuous returns flattened across prediction horizons. This reports
+    the up/down split as a reference point -- any model must add value beyond this.
+
+    Distinct from majority_class_baseline which uses train data to predict test.
+    This is a descriptive statistic of the test distribution.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        Target array, shape (n_samples,) or (n_samples, pred_len).
+
+    Returns
+    -------
+    dict with keys: majority_class_accuracy, pct_up, pct_down.
+    """
+    flat = np.asarray(y).flatten()
+    pct_up = float(np.mean(flat > 0))
+    pct_down = 1.0 - pct_up
+    return {
+        "majority_class_accuracy": round(max(pct_up, pct_down), 4),
+        "pct_up": round(pct_up, 4),
+        "pct_down": round(pct_down, 4),
+    }
+
+
 def _sharpe_from_returns(returns: pd.Series, annualize: bool = True, risk_free: float = 0.0) -> float:
     """Compute Sharpe ratio from a returns series.
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_itransformer.py
@@ -9,10 +9,10 @@ import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from baselines import oos_direction_distribution
 from train_itransformer import (
     iTransformerModel,
     build_sequences,
-    compute_majority_class_baseline,
     normalize_sequences,
 )
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_mamba.py
@@ -9,11 +9,11 @@ import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from baselines import oos_direction_distribution
 from train_mamba import (
     MambaTSModel,
     SelectiveSSM,
     build_sequences,
-    compute_majority_class_baseline,
     normalize_sequences,
 )
 
@@ -172,17 +172,17 @@ class TestNormalizeSequences:
 class TestMajorityBaseline:
     def test_balanced(self):
         y = np.array([[1, -1, 1, -1]] * 10, dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 0.5
 
     def test_biased_up(self):
         y = np.ones((10, 4), dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 1.0
         assert baseline["pct_up"] == 1.0
 
     def test_all_down(self):
         y = -np.ones((10, 4), dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 1.0
         assert baseline["pct_down"] == 1.0

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_mtgnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_mtgnn.py
@@ -19,8 +19,8 @@ from train_mtgnn import (
     build_sector_adjacency,
     build_pearson_adjacency,
     normalize_sequences,
-    compute_majority_class_baseline,
 )
+from baselines import oos_direction_distribution
 
 
 class TestGraphConstructor:
@@ -215,11 +215,11 @@ class TestNormalizeSequences:
 class TestMajorityBaseline:
     def test_balanced(self):
         y = np.array([[1, -1, 1, -1]] * 10, dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 0.5
 
     def test_biased_up(self):
         y = np.ones((10, 4), dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 1.0
         assert baseline["pct_up"] == 1.0

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_patchtst.py
@@ -9,10 +9,10 @@ import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
+from baselines import oos_direction_distribution
 from train_patchtst import (
     PatchTSTModel,
     build_sequences,
-    compute_majority_class_baseline,
     normalize_sequences,
 )
 
@@ -96,11 +96,11 @@ class TestNormalizeSequences:
 class TestMajorityBaseline:
     def test_balanced(self):
         y = np.array([[1, -1, 1, -1]] * 10, dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 0.5
 
     def test_biased_up(self):
         y = np.ones((10, 4), dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 1.0
         assert baseline["pct_up"] == 1.0

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_stgat.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_stgat.py
@@ -17,8 +17,8 @@ from train_stgat import (
     STGATModel,
     build_sequences,
     normalize_sequences,
-    compute_majority_class_baseline,
 )
+from baselines import oos_direction_distribution
 
 
 class TestGraphAttentionLayer:
@@ -201,11 +201,11 @@ class TestNormalizeSequences:
 class TestMajorityBaseline:
     def test_balanced(self):
         y = np.array([[1, -1, 1, -1]] * 10, dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 0.5
 
     def test_biased_up(self):
         y = np.ones((10, 4), dtype=np.float32)
-        baseline = compute_majority_class_baseline(y)
+        baseline = oos_direction_distribution(y)
         assert baseline["majority_class_accuracy"] == 1.0
         assert baseline["pct_up"] == 1.0

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
@@ -40,6 +40,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from baselines import oos_direction_distribution
 from sequence_utils import build_sequences, normalize_sequences
 
 try:
@@ -136,18 +137,6 @@ class iTransformerModel(nn.Module):
 
         return preds
 
-
-def compute_majority_class_baseline(y_test: np.ndarray) -> dict:
-    """Compute majority-class baseline for direction prediction."""
-    flat = y_test.flatten()
-    pct_up = float(np.mean(flat > 0))
-    pct_down = 1.0 - pct_up
-    majority_acc = max(pct_up, pct_down)
-    return {
-        "majority_class_accuracy": round(majority_acc, 4),
-        "pct_up": round(pct_up, 4),
-        "pct_down": round(pct_down, 4),
-    }
 
 
 def train_and_evaluate(
@@ -294,7 +283,7 @@ def train_and_evaluate(
     # Direction accuracy at step 1 (first prediction step)
     direction_acc = float(np.mean((preds[:, 0] > 0) == (targets[:, 0] > 0)))
 
-    majority_baseline = compute_majority_class_baseline(targets)
+    majority_baseline = oos_direction_distribution(targets)
 
     metrics = {
         "mse": round(mse, 6),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -56,6 +56,7 @@ import torch.nn.functional as F
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from baselines import oos_direction_distribution
 from sequence_utils import build_sequences, normalize_sequences
 
 try:
@@ -395,18 +396,6 @@ class MambaTSModel(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-def compute_majority_class_baseline(y_test: np.ndarray) -> dict:
-    """Compute majority-class baseline for direction prediction."""
-    flat = y_test.flatten()
-    majority_up = float(np.mean(flat > 0))
-    majority_down = 1.0 - majority_up
-    baseline_acc = max(majority_up, majority_down)
-    return {
-        "majority_class_accuracy": round(baseline_acc, 4),
-        "pct_up": round(majority_up, 4),
-        "pct_down": round(majority_down, 4),
-    }
-
 
 # ---------------------------------------------------------------------------
 # Training
@@ -565,7 +554,7 @@ def train_and_evaluate(
     direction_acc = float(np.mean((pred_step1 > 0) == (target_step1 > 0)))
 
     # Majority-class baseline
-    majority_baseline = compute_majority_class_baseline(target_step1)
+    majority_baseline = oos_direction_distribution(target_step1)
 
     metrics = {
         "mse": round(mse, 6),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
@@ -48,6 +48,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from baselines import oos_direction_distribution
 from sequence_utils import build_sequences, normalize_sequences
 
 try:
@@ -406,18 +407,6 @@ class MTGNNModel(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-def compute_majority_class_baseline(y_test: np.ndarray) -> dict:
-    """Compute majority-class baseline for direction prediction."""
-    flat = y_test.flatten()
-    pct_up = float(np.mean(flat > 0))
-    pct_down = 1.0 - pct_up
-    majority_acc = max(pct_up, pct_down)
-    return {
-        "majority_class_accuracy": round(majority_acc, 4),
-        "pct_up": round(pct_up, 4),
-        "pct_down": round(pct_down, 4),
-    }
-
 
 # ---------------------------------------------------------------------------
 # Training and evaluation
@@ -585,7 +574,7 @@ def train_and_evaluate(
     mse = float(np.mean((preds - targets) ** 2))
     mae = float(np.mean(np.abs(preds - targets)))
     direction_acc = float(np.mean((preds[:, 0] > 0) == (targets[:, 0] > 0)))
-    majority_baseline = compute_majority_class_baseline(targets)
+    majority_baseline = oos_direction_distribution(targets)
 
     # Transaction cost-adjusted Sharpe (if Stage 0 module available)
     tcost_sharpe = None

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -48,6 +48,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from baselines import oos_direction_distribution
 from sequence_utils import build_sequences, normalize_sequences
 
 # Optional: walk_forward from Stage 0 (graceful fallback)
@@ -162,23 +163,6 @@ class PatchTSTModel(nn.Module):
 
         return preds
 
-
-def compute_majority_class_baseline(y_test: np.ndarray) -> dict:
-    """Compute majority-class baseline for direction prediction.
-
-    Financial time series baseline: always predict the sign of the mean training return.
-    If training mean > 0, always predict up; else always predict down.
-    """
-    # y_test shape: [n_samples, pred_len] or [n_samples]
-    flat = y_test.flatten()
-    majority_up = float(np.mean(flat > 0))
-    majority_down = 1.0 - majority_up
-    baseline_acc = max(majority_up, majority_down)
-    return {
-        "majority_class_accuracy": round(baseline_acc, 4),
-        "pct_up": round(majority_up, 4),
-        "pct_down": round(majority_down, 4),
-    }
 
 
 def train_and_evaluate(
@@ -335,7 +319,7 @@ def train_and_evaluate(
     direction_acc = float(np.mean((pred_step1 > 0) == (target_step1 > 0)))
 
     # Majority-class baseline
-    majority_baseline = compute_majority_class_baseline(target_step1)
+    majority_baseline = oos_direction_distribution(target_step1)
 
     metrics = {
         "mse": round(mse, 6),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
@@ -47,6 +47,7 @@ from gpu_training import (
 )
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
+from baselines import oos_direction_distribution
 from sequence_utils import build_sequences, normalize_sequences
 
 try:
@@ -356,24 +357,6 @@ class STGATModel(nn.Module):
 
 
 # ---------------------------------------------------------------------------
-# Baselines
-# ---------------------------------------------------------------------------
-
-
-def compute_majority_class_baseline(y_test: np.ndarray) -> dict:
-    """Compute majority-class baseline for direction prediction."""
-    flat = y_test.flatten()
-    pct_up = float(np.mean(flat > 0))
-    pct_down = 1.0 - pct_up
-    majority_acc = max(pct_up, pct_down)
-    return {
-        "majority_class_accuracy": round(majority_acc, 4),
-        "pct_up": round(pct_up, 4),
-        "pct_down": round(pct_down, 4),
-    }
-
-
-# ---------------------------------------------------------------------------
 # Training and evaluation
 # ---------------------------------------------------------------------------
 
@@ -527,7 +510,7 @@ def train_and_evaluate(
     mse = float(np.mean((preds - targets) ** 2))
     mae = float(np.mean(np.abs(preds - targets)))
     direction_acc = float(np.mean((preds[:, 0] > 0) == (targets[:, 0] > 0)))
-    majority_baseline = compute_majority_class_baseline(targets)
+    majority_baseline = oos_direction_distribution(targets)
 
     baseline_comparison = None
     if majority_class_baseline is not None:


### PR DESCRIPTION
## Summary
- Extract identical `compute_majority_class_baseline` from 5 seq2seq training scripts into shared `oos_direction_distribution` in `baselines.py`
- Function computes OOS target class distribution (up/down ratio) as a reference baseline for multi-step forecasting models
- Updated all 5 training scripts (iTransformer, PatchTST, Mamba, MTGNN, STGAT) + their test files
- `train_rl_dt.py` keeps its own copy (different domain: RL discrete actions)

**Net change**: -37 lines of duplicated code, +29 lines in baselines.py with proper docstring

## Files changed
- `baselines.py` — new `oos_direction_distribution(y)` function
- 5 training scripts — removed local function, added import
- 5 test files — updated import source

## Test plan
- [x] `pytest scripts/tests/ -x -q` — 417/417 pass
- [x] Grep confirms old function name only in train_rl_dt.py (intentionally kept)