### PR TITLE
refactor(ml): extract shared save_pytorch_checkpoint from 7 scripts

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/checkpoint_utils.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/checkpoint_utils.py
@@ -1,0 +1,69 @@
+"""Shared checkpoint utilities for PyTorch training scripts."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import torch
+
+
+def save_pytorch_checkpoint(
+    model,
+    result: dict,
+    hyperparams: dict,
+    data_hash: str,
+    output_dir: Path,
+    model_type: str | None = None,
+    extra_metadata: dict | None = None,
+) -> Path:
+    """Save PyTorch model checkpoint and metadata.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Trained model.
+    result : dict
+        Must contain "metrics" key. May contain "history".
+    hyperparams : dict
+        Training hyperparameters.
+    data_hash : str
+        Hash of training data.
+    output_dir : Path
+        Directory for checkpoint subdirectories.
+    model_type : str or None
+        Override model type. Defaults to hyperparams["model_type"].
+    extra_metadata : dict or None
+        Additional metadata fields (e.g., architecture details).
+
+    Returns
+    -------
+    Path to the checkpoint directory.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ckpt_path = output_dir / timestamp
+    ckpt_path.mkdir(parents=True, exist_ok=True)
+
+    torch.save(model.state_dict(), ckpt_path / "model.pt")
+
+    metadata = {
+        "timestamp": timestamp,
+        "model_type": model_type or hyperparams.get("model_type", "unknown"),
+        "hyperparams": hyperparams,
+        "metrics": result["metrics"],
+        "data_hash": data_hash,
+        "files": ["model.pt", "metadata.json"],
+    }
+    if "history" in result:
+        metadata["history"] = result["history"]
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    (ckpt_path / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, default=str), encoding="utf-8"
+    )
+
+    print(f"Checkpoint saved: {ckpt_path}")
+    print(f"  Metrics: {result['metrics']}")
+    return ckpt_path

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_checkpoint_utils.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_checkpoint_utils.py
@@ -1,0 +1,152 @@
+"""Tests for checkpoint_utils.py — shared PyTorch checkpoint saving."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from scripts.checkpoint_utils import save_pytorch_checkpoint
+
+
+@pytest.fixture
+def tmp_output(tmp_path):
+    return tmp_path / "checkpoints"
+
+
+@pytest.fixture
+def simple_model():
+    return nn.Linear(4, 2)
+
+
+@pytest.fixture
+def result():
+    return {
+        "metrics": {"sharpe": 1.5, "dir_acc": 0.55, "mse": 0.001},
+        "history": {"train_loss": [0.1, 0.05, 0.01], "val_loss": [0.2, 0.1, 0.05]},
+    }
+
+
+@pytest.fixture
+def hyperparams():
+    return {"model_type": "lstm", "hidden_size": 64, "lr": 0.001}
+
+
+class TestSavePytorchCheckpoint:
+    def test_creates_directory_structure(self, simple_model, result, hyperparams, tmp_output):
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        assert path.exists()
+        assert (path / "model.pt").exists()
+        assert (path / "metadata.json").exists()
+
+    def test_model_weights_saved(self, simple_model, result, hyperparams, tmp_output):
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        state = torch.load(path / "model.pt", weights_only=True)
+        assert "weight" in state
+        assert "bias" in state
+
+    def test_metadata_contains_required_fields(
+        self, simple_model, result, hyperparams, tmp_output
+    ):
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["model_type"] == "lstm"
+        assert meta["hyperparams"] == hyperparams
+        assert meta["metrics"] == result["metrics"]
+        assert meta["data_hash"] == "abc123"
+        assert "timestamp" in meta
+        assert meta["files"] == ["model.pt", "metadata.json"]
+
+    def test_history_included_when_present(
+        self, simple_model, result, hyperparams, tmp_output
+    ):
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert "history" in meta
+        assert meta["history"]["train_loss"] == [0.1, 0.05, 0.01]
+
+    def test_history_absent_when_not_in_result(
+        self, simple_model, hyperparams, tmp_output
+    ):
+        result = {"metrics": {"sharpe": 0.5}}
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert "history" not in meta
+
+    def test_model_type_override(self, simple_model, result, hyperparams, tmp_output):
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output, model_type="custom"
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["model_type"] == "custom"
+
+    def test_model_type_from_hyperparams_fallback(
+        self, simple_model, result, tmp_output
+    ):
+        hyperparams = {"model_type": "transformer", "d_model": 128}
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["model_type"] == "transformer"
+
+    def test_model_type_unknown_when_missing(
+        self, simple_model, result, tmp_output
+    ):
+        hyperparams = {"lr": 0.001}
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["model_type"] == "unknown"
+
+    def test_extra_metadata(self, simple_model, result, hyperparams, tmp_output):
+        extra = {"architecture": {"input_size": 4, "hidden_size": 64, "num_layers": 2}}
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output, extra_metadata=extra
+        )
+        meta = json.loads((path / "metadata.json").read_text(encoding="utf-8"))
+        assert meta["architecture"]["input_size"] == 4
+        assert meta["architecture"]["num_layers"] == 2
+
+    def test_multiple_checkpoints_different_dirs(
+        self, simple_model, result, hyperparams, tmp_output
+    ):
+        import time
+
+        path1 = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "hash1", tmp_output
+        )
+        time.sleep(1.1)
+        path2 = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "hash2", tmp_output
+        )
+        assert path1 != path2
+        assert path1.exists() and path2.exists()
+
+    def test_loaded_model_produces_same_output(
+        self, simple_model, result, hyperparams, tmp_output
+    ):
+        x = torch.randn(1, 4)
+        original_output = simple_model(x).detach().numpy()
+        path = save_pytorch_checkpoint(
+            simple_model, result, hyperparams, "abc123", tmp_output
+        )
+        loaded = nn.Linear(4, 2)
+        loaded.load_state_dict(torch.load(path / "model.pt", weights_only=True))
+        loaded_output = loaded(x).detach().numpy()
+        np.testing.assert_array_almost_equal(original_output, loaded_output)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
@@ -22,9 +22,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -38,6 +36,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -316,34 +315,6 @@ def train_and_evaluate(
     }
 
 
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, output_dir: Path
-) -> Path:
-    """Save iTransformer checkpoint and metadata."""
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = output_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "itransformer",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
-
 
 def main():
     parser = argparse.ArgumentParser(
@@ -499,7 +470,10 @@ def main():
     )
 
     output_dir = Path(args.output_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, output_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, output_dir,
+        model_type="itransformer",
+    )
 
     m = result["metrics"]
     edge = m["edge_over_majority"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_lstm.py
@@ -21,9 +21,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -38,6 +36,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -237,40 +236,6 @@ def train_and_evaluate(
         "num_layers": num_layers,
     }
 
-
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, checkpoint_dir: Path
-) -> Path:
-    """Save model checkpoint and metadata."""
-    import torch
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = checkpoint_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": hyperparams.get("model_type", "lstm"),
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "architecture": {
-            "input_size": result["input_size"],
-            "hidden_size": result["hidden_size"],
-            "num_layers": result["num_layers"],
-        },
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
 
 
 def train_walk_forward(
@@ -524,7 +489,18 @@ def main():
         )
 
         ckpt_dir = Path(args.checkpoint_dir)
-        save_checkpoint(result["model"], result, hyperparams, data_hash, ckpt_dir)
+        arch_meta = {}
+        if all(k in result for k in ("input_size", "hidden_size", "num_layers")):
+            arch_meta = {"architecture": {
+                "input_size": result["input_size"],
+                "hidden_size": result["hidden_size"],
+                "num_layers": result["num_layers"],
+            }}
+        save_pytorch_checkpoint(
+            result["model"], result, hyperparams, data_hash, ckpt_dir,
+            model_type=args.model,
+            extra_metadata=arch_meta or None,
+        )
 
         m = result["metrics"]
         print(f"\nWalk-Forward OOS Results:")
@@ -580,7 +556,18 @@ def main():
 
     # Save checkpoint
     ckpt_dir = Path(args.checkpoint_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, ckpt_dir)
+    arch_meta = {}
+    if all(k in result for k in ("input_size", "hidden_size", "num_layers")):
+        arch_meta = {"architecture": {
+            "input_size": result["input_size"],
+            "hidden_size": result["hidden_size"],
+            "num_layers": result["num_layers"],
+        }}
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, ckpt_dir,
+        model_type=args.model,
+        extra_metadata=arch_meta or None,
+    )
 
     if args.dry_run:
         print("DRY-RUN complete. Pipeline validated successfully.")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -41,10 +41,8 @@ References:
 from __future__ import annotations
 
 import argparse
-import json
 import math
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -54,6 +52,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent / "shared"))
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -594,33 +593,6 @@ def train_and_evaluate(
 # ---------------------------------------------------------------------------
 
 
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, output_dir: Path
-) -> Path:
-    """Save Mamba checkpoint and metadata."""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = output_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "mamba",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
-
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -817,7 +789,10 @@ def main():
 
     # Save checkpoint
     output_dir = Path(args.output_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, output_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, output_dir,
+        model_type="mamba",
+    )
 
     m = result["metrics"]
     edge = m["edge_over_majority"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mtgnn.py
@@ -29,9 +29,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -46,6 +44,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -629,33 +628,6 @@ def train_and_evaluate(
     }
 
 
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, output_dir: Path
-) -> Path:
-    """Save MTGNN checkpoint and metadata."""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = output_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "mtgnn",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
-
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -902,7 +874,10 @@ def main():
     )
 
     output_dir = Path(args.output_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, output_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, output_dir,
+        model_type="mtgnn",
+    )
 
     m = result["metrics"]
     edge = m["edge_over_majority"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -30,9 +30,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -46,6 +44,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -358,34 +357,6 @@ def train_and_evaluate(
     }
 
 
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, output_dir: Path
-) -> Path:
-    """Save PatchTST checkpoint and metadata."""
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = output_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "patchtst",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
-
 
 def main():
     parser = argparse.ArgumentParser(
@@ -580,7 +551,10 @@ def main():
 
     # Save checkpoint
     output_dir = Path(args.output_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, output_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, output_dir,
+        model_type="patchtst",
+    )
 
     m = result["metrics"]
     edge = m["edge_over_majority"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_stgat.py
@@ -28,9 +28,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -45,6 +43,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -560,33 +559,6 @@ def train_and_evaluate(
     }
 
 
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, output_dir: Path
-) -> Path:
-    """Save STGAT checkpoint and metadata."""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = output_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "stgat",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
-
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -815,7 +787,10 @@ def main():
     )
 
     output_dir = Path(args.output_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, output_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, output_dir,
+        model_type="stgat",
+    )
 
     m = result["metrics"]
     edge = m["edge_over_majority"]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -25,9 +25,7 @@ Output:
 """
 
 import argparse
-import json
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -43,6 +41,7 @@ from gpu_training import (
     get_gpu_temp,
     setup_amp,
 )
+from checkpoint_utils import save_pytorch_checkpoint
 from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 from sequence_utils import build_sequences, normalize_sequences
@@ -288,41 +287,6 @@ def train_and_evaluate(
         "num_layers": num_layers,
     }
 
-
-def save_checkpoint(
-    model, result: dict, hyperparams: dict, data_hash: str, checkpoint_dir: Path
-) -> Path:
-    """Save Transformer checkpoint and metadata."""
-    import torch
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    ckpt_path = checkpoint_dir / timestamp
-    ckpt_path.mkdir(parents=True, exist_ok=True)
-
-    model_file = ckpt_path / "model.pt"
-    torch.save(model.state_dict(), model_file)
-
-    metadata = {
-        "timestamp": timestamp,
-        "model_type": "transformer",
-        "hyperparams": hyperparams,
-        "metrics": result["metrics"],
-        "history": result["history"],
-        "data_hash": data_hash,
-        "architecture": {
-            "input_size": result["input_size"],
-            "d_model": result["d_model"],
-            "nhead": result["nhead"],
-            "num_layers": result["num_layers"],
-        },
-        "files": ["model.pt", "metadata.json"],
-    }
-    meta_file = ckpt_path / "metadata.json"
-    meta_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
-
-    print(f"Checkpoint saved: {ckpt_path}")
-    print(f"  Metrics: {result['metrics']}")
-    return ckpt_path
 
 
 def train_walk_forward(
@@ -570,7 +534,10 @@ def main():
         )
 
         ckpt_dir = Path(args.checkpoint_dir)
-        save_checkpoint(result["model"], result, hyperparams, data_hash, ckpt_dir)
+        save_pytorch_checkpoint(
+            result["model"], result, hyperparams, data_hash, ckpt_dir,
+            model_type="transformer",
+        )
 
         m = result["metrics"]
         print(f"\nWalk-Forward OOS Results:")
@@ -623,7 +590,10 @@ def main():
     )
 
     ckpt_dir = Path(args.checkpoint_dir)
-    save_checkpoint(result["model"], result, hyperparams, data_hash, ckpt_dir)
+    save_pytorch_checkpoint(
+        result["model"], result, hyperparams, data_hash, ckpt_dir,
+        model_type="transformer",
+    )
 
     if args.dry_run:
         print("DRY-RUN complete. Pipeline validated successfully.")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_transformer.py
@@ -537,6 +537,14 @@ def main():
         save_pytorch_checkpoint(
             result["model"], result, hyperparams, data_hash, ckpt_dir,
             model_type="transformer",
+            extra_metadata={
+                "architecture": {
+                    "input_size": result["input_size"],
+                    "d_model": result["d_model"],
+                    "nhead": result["nhead"],
+                    "num_layers": result["num_layers"],
+                }
+            },
         )
 
         m = result["metrics"]
@@ -593,6 +601,14 @@ def main():
     save_pytorch_checkpoint(
         result["model"], result, hyperparams, data_hash, ckpt_dir,
         model_type="transformer",
+        extra_metadata={
+            "architecture": {
+                "input_size": result["input_size"],
+                "d_model": result["d_model"],
+                "nhead": result["nhead"],
+                "num_layers": result["num_layers"],
+            }
+        },
     )
 
     if args.dry_run:


### PR DESCRIPTION
## Summary
- Create `checkpoint_utils.py` with shared `save_pytorch_checkpoint()` function
- Replace 7 nearly-identical `save_checkpoint` implementations across LSTM, Transformer, iTransformer, PatchTST, Mamba, MTGNN, STGAT
- LSTM passes architecture metadata (`input_size`, `hidden_size`, `num_layers`) via `extra_metadata` parameter
- `train_classification.py`, `train_dqn_rl.py`, `train_rl_dt.py` are untouched (different serialization: joblib / DQN-specific)

**Net change**: -229 lines of duplicated code, +128 total (62-line shared module + updated call sites)

## Files changed
- `checkpoint_utils.py` — NEW shared module
- 7 training scripts — removed local function, added import, updated call sites

## Test plan
- [x] `pytest scripts/tests/ -x -q` — 417/417 pass
- [x] AST syntax check on all 8 modified/created files