### PR TITLE
feat(ml): shared regime detector module (Issue #754 Phase B prep)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/regime_detector.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/regime_detector.py
@@ -1,0 +1,419 @@
+"""
+Regime detection for financial time series — shared module.
+
+Provides two complementary approaches:
+1. Price-based regime classification (rolling return + volatility + drawdown)
+2. HMM-based regime detection (Gaussian HMM with Baum-Welch EM)
+
+Used by:
+- MoE routing: route to expert NN per regime (Issue #754 Phase B)
+- FinTSB-style per-regime evaluation (eval_finstsb.py)
+- Walk-forward training with regime-aware splitting
+
+References:
+- Hamilton (1989), "A New Approach to the Economic Analysis of Nonstationary
+  Time Series and the Business Cycle"
+- Almgren & Chriss (2001), optimal execution under regime uncertainty
+- Hands-On AI Trading, Pik et al., Wiley 2025 — regime-aware strategies
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from dataclasses import dataclass
+
+
+# ---------------------------------------------------------------------------
+# Price-based regime detection (from eval_finstsb.py, made standalone)
+# ---------------------------------------------------------------------------
+
+def detect_regimes_price(
+    prices: pd.Series | np.ndarray,
+    lookback_days: int = 60,
+    uptrend_threshold: float = 0.10,
+    downtrend_threshold: float = -0.10,
+    volatility_percentile: float = 75,
+    black_swan_drawdown: float = -0.20,
+    black_swan_window: int = 30,
+) -> pd.Series:
+    """Classify each date into a market regime using price statistics.
+
+    Regimes: "uptrend", "downtrend", "volatility", "black_swan".
+
+    Parameters
+    ----------
+    prices : array-like
+        Daily price series.
+    lookback_days : int
+        Rolling window for regime detection.
+    uptrend_threshold : float
+        Minimum rolling return to classify as uptrend.
+    downtrend_threshold : float
+        Maximum rolling return to classify as downtrend.
+    volatility_percentile : float
+        Percentile threshold for high-volatility regime (0-100).
+    black_swan_drawdown : float
+        Drawdown threshold for black swan (e.g. -0.20 = -20%).
+    black_swan_window : int
+        Window for drawdown calculation.
+
+    Returns
+    -------
+    pd.Series of regime labels aligned to prices index.
+    """
+    prices = pd.Series(prices).reset_index(drop=True)
+    returns = prices.pct_change()
+
+    rolling_return = prices.pct_change(lookback_days)
+    rolling_std = returns.rolling(lookback_days).std() * np.sqrt(252)
+    vol_threshold = rolling_std.quantile(volatility_percentile / 100)
+
+    rolling_max = prices.rolling(black_swan_window, min_periods=1).max()
+    drawdown = (prices - rolling_max) / rolling_max
+
+    regimes = pd.Series("normal", index=prices.index, dtype="object")
+
+    # Priority order: black_swan > uptrend > downtrend > volatility
+    regimes[drawdown <= black_swan_drawdown] = "black_swan"
+
+    mask_up = (rolling_return >= uptrend_threshold) & (regimes == "normal")
+    regimes[mask_up] = "uptrend"
+
+    mask_down = (rolling_return <= downtrend_threshold) & (regimes == "normal")
+    regimes[mask_down] = "downtrend"
+
+    mask_vol = (rolling_std >= vol_threshold) & (regimes == "normal")
+    regimes[mask_vol] = "volatility"
+
+    # Remaining "normal" -> mild uptrend or downtrend
+    normal_mask = regimes == "normal"
+    regimes[normal_mask & (rolling_return > 0)] = "uptrend"
+    regimes[normal_mask & (rolling_return <= 0)] = "downtrend"
+
+    # Fill NaN from rolling calculations
+    regimes = regimes.fillna("normal")
+    # Replace remaining "normal" after fill
+    regimes[regimes == "normal"] = "uptrend"
+
+    return regimes
+
+
+# ---------------------------------------------------------------------------
+# HMM-based regime detection (from HMM-KMeans-Voting, standalone)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HMMRegimeResult:
+    """Result from HMM regime detection."""
+    labels: np.ndarray          # Integer state labels (0, 1, ..., n_states-1)
+    regime_names: list[str]     # Human-readable regime names per state
+    log_likelihood: float       # Final log-likelihood
+    n_states: int               # Number of HMM states
+    transition_matrix: np.ndarray  # State transition probabilities
+
+
+class GaussianHMM:
+    """Gaussian HMM with Baum-Welch EM and Viterbi decoding (pure numpy).
+
+    Suitable for financial regime detection where observations are
+    continuous (returns, volatility, momentum, etc.).
+
+    Parameters
+    ----------
+    n_states : int
+        Number of hidden states (regimes). Default 3 (bull/bear/neutral).
+    n_iter : int
+        Maximum EM iterations.
+    tol : float
+        Convergence tolerance for log-likelihood.
+    """
+
+    def __init__(self, n_states: int = 3, n_iter: int = 60, tol: float = 1e-4):
+        self.n_states = n_states
+        self.n_iter = n_iter
+        self.tol = tol
+
+    def _init_params(self, X: np.ndarray) -> None:
+        T, D = X.shape
+        K = self.n_states
+        self.pi = np.ones(K) / K
+        self.A = np.full((K, K), 0.05 / (K - 1))
+        np.fill_diagonal(self.A, 0.95)
+        sorted_idx = np.argsort(X[:, 0])
+        terciles = np.array_split(sorted_idx, K)
+        self.mu = np.array([X[idx].mean(axis=0) for idx in terciles])
+        self.sig = np.array([np.var(X, axis=0) + 1e-6] * K)
+
+    def _log_emission(self, X: np.ndarray) -> np.ndarray:
+        T, D = X.shape
+        log_p = np.zeros((T, self.n_states))
+        for k in range(self.n_states):
+            diff = X - self.mu[k]
+            log_det = np.sum(np.log(self.sig[k]))
+            mahal = np.sum(diff ** 2 / self.sig[k], axis=1)
+            log_p[:, k] = -0.5 * (D * np.log(2 * np.pi) + log_det + mahal)
+        return log_p
+
+    def _forward(self, log_emit: np.ndarray) -> np.ndarray:
+        T, K = log_emit.shape
+        log_A = np.log(self.A + 1e-300)
+        alpha = np.zeros((T, K))
+        alpha[0] = np.log(self.pi + 1e-300) + log_emit[0]
+        for t in range(1, T):
+            for k in range(K):
+                alpha[t, k] = log_emit[t, k] + np.logaddexp.reduce(
+                    alpha[t - 1] + log_A[:, k]
+                )
+        return alpha
+
+    def _backward(self, log_emit: np.ndarray) -> np.ndarray:
+        T, K = log_emit.shape
+        log_A = np.log(self.A + 1e-300)
+        beta = np.zeros((T, K))
+        for t in range(T - 2, -1, -1):
+            for k in range(K):
+                beta[t, k] = np.logaddexp.reduce(
+                    log_A[k] + log_emit[t + 1] + beta[t + 1]
+                )
+        return beta
+
+    def fit(self, X: np.ndarray) -> GaussianHMM:
+        """Fit HMM parameters via Baum-Welch EM.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (T, D)
+            Observation matrix (T timesteps, D features).
+
+        Returns
+        -------
+        self
+        """
+        self._init_params(X)
+        prev_ll = -np.inf
+        K = self.n_states
+
+        for _ in range(self.n_iter):
+            log_emit = self._log_emission(X)
+            alpha = self._forward(log_emit)
+            beta = self._backward(log_emit)
+            ll = np.logaddexp.reduce(alpha[-1])
+
+            log_gamma = alpha + beta
+            log_gamma -= np.logaddexp.reduce(log_gamma, axis=1, keepdims=True)
+            gamma = np.exp(log_gamma)
+
+            log_A_mat = np.log(self.A + 1e-300)
+            log_xi = np.zeros((len(X) - 1, K, K))
+            for t in range(len(X) - 1):
+                for i in range(K):
+                    for j in range(K):
+                        log_xi[t, i, j] = (
+                            alpha[t, i]
+                            + log_A_mat[i, j]
+                            + log_emit[t + 1, j]
+                            + beta[t + 1, j]
+                        )
+                log_xi[t] -= np.logaddexp.reduce(log_xi[t].reshape(-1))
+            xi = np.exp(log_xi)
+
+            self.pi = gamma[0] / (gamma[0].sum() + 1e-300)
+            self.A = xi.sum(axis=0)
+            self.A /= self.A.sum(axis=1, keepdims=True)
+
+            g_sum = gamma.sum(axis=0)
+            for k in range(K):
+                w = gamma[:, k]
+                self.mu[k] = (w[:, None] * X).sum(axis=0) / (g_sum[k] + 1e-300)
+                diff = X - self.mu[k]
+                self.sig[k] = (
+                    (w[:, None] * diff ** 2).sum(axis=0)
+                    / (g_sum[k] + 1e-300)
+                    + 1e-6
+                )
+
+            if abs(ll - prev_ll) < self.tol:
+                break
+            prev_ll = ll
+
+        self.log_likelihood_ = ll
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        """Decode most likely state sequence via Viterbi.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (T, D)
+            Observation matrix.
+
+        Returns
+        -------
+        np.ndarray of int, shape (T,)
+            Most likely state sequence.
+        """
+        T = len(X)
+        K = self.n_states
+        log_A = np.log(self.A + 1e-300)
+        log_emit = self._log_emission(X)
+
+        viterbi = np.zeros((T, K))
+        backptr = np.zeros((T, K), dtype=int)
+        viterbi[0] = np.log(self.pi + 1e-300) + log_emit[0]
+
+        for t in range(1, T):
+            for k in range(K):
+                scores = viterbi[t - 1] + log_A[:, k]
+                backptr[t, k] = np.argmax(scores)
+                viterbi[t, k] = scores[backptr[t, k]] + log_emit[t, k]
+
+        states = np.zeros(T, dtype=int)
+        states[-1] = np.argmax(viterbi[-1])
+        for t in range(T - 2, -1, -1):
+            states[t] = backptr[t + 1, states[t + 1]]
+        return states
+
+
+def detect_regimes_hmm(
+    prices: pd.Series | np.ndarray,
+    n_states: int = 3,
+    lookback: int = 400,
+    min_samples: int = 80,
+) -> HMMRegimeResult:
+    """Detect market regimes using Gaussian HMM on price features.
+
+    Features computed from prices:
+    - Daily log returns
+    - 20-day rolling volatility
+    - 60-day momentum
+    - Volatility ratio (20d / 60d)
+
+    State naming convention (based on mean return):
+    - Highest mean return -> "bull"
+    - Lowest mean return -> "bear"
+    - Middle -> "neutral"
+
+    Parameters
+    ----------
+    prices : array-like
+        Daily price series.
+    n_states : int
+        Number of HMM states (default 3: bull/neutral/bear).
+    lookback : int
+        Maximum history to use for feature computation.
+    min_samples : int
+        Minimum samples required for fitting.
+
+    Returns
+    -------
+    HMMRegimeResult with labels, regime_names, and metadata.
+    """
+    original_prices = pd.Series(prices).reset_index(drop=True)
+    original_len = len(original_prices)
+
+    prices = original_prices.iloc[-lookback:] if original_len > lookback else original_prices
+    offset = original_len - len(prices)
+
+    close = prices.values.astype(float)
+    ret = np.diff(np.log(close + 1e-10))
+    n = len(ret)
+
+    if n < min_samples:
+        return HMMRegimeResult(
+            labels=np.zeros(original_len, dtype=int),
+            regime_names=["unknown"] * n_states,
+            log_likelihood=0.0,
+            n_states=n_states,
+            transition_matrix=np.eye(n_states),
+        )
+
+    vol20 = np.array([ret[max(0, i - 19):i + 1].std() for i in range(n)])
+    vol60 = np.array([ret[max(0, i - 59):i + 1].std() for i in range(n)])
+    mom60 = np.array([(close[i + 1] / close[max(0, i - 58)] - 1) for i in range(n)])
+    vol_ratio = vol20 / (vol60 + 1e-9)
+
+    start = 60
+    X_raw = np.column_stack([ret[start:], vol20[start:], mom60[start:], vol_ratio[start:]])
+
+    # MAD winsorization
+    for col in range(X_raw.shape[1]):
+        m = np.median(X_raw[:, col])
+        mad = np.median(np.abs(X_raw[:, col] - m)) * 1.4826
+        X_raw[:, col] = np.clip(X_raw[:, col], m - 4 * mad, m + 4 * mad)
+
+    hmm = GaussianHMM(n_states=n_states)
+    hmm.fit(X_raw)
+    labels_raw = hmm.predict(X_raw)
+
+    # Name states by mean return (column 0)
+    state_means = []
+    for k in range(n_states):
+        mask = labels_raw == k
+        if mask.sum() > 0:
+            state_means.append((k, X_raw[mask, 0].mean()))
+        else:
+            state_means.append((k, 0.0))
+
+    sorted_states = sorted(state_means, key=lambda x: x[1], reverse=True)
+    state_names = ["unknown"] * n_states
+    if n_states >= 3:
+        state_names[sorted_states[0][0]] = "bull"
+        state_names[sorted_states[-1][0]] = "bear"
+        for i in range(1, n_states - 1):
+            state_names[sorted_states[i][0]] = "neutral"
+    elif n_states == 2:
+        state_names[sorted_states[0][0]] = "bull"
+        state_names[sorted_states[-1][0]] = "bear"
+
+    # Map labels to original price series length
+    full_labels = np.zeros(original_len, dtype=int)
+    full_labels[offset + start + 1:] = labels_raw
+
+    return HMMRegimeResult(
+        labels=full_labels,
+        regime_names=state_names,
+        log_likelihood=hmm.log_likelihood_,
+        n_states=n_states,
+        transition_matrix=hmm.A.copy(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience: combined regime detection
+# ---------------------------------------------------------------------------
+
+def detect_regimes(
+    prices: pd.Series | np.ndarray,
+    method: str = "price",
+    **kwargs,
+) -> pd.Series:
+    """Detect market regimes using specified method.
+
+    Parameters
+    ----------
+    prices : array-like
+        Daily price series.
+    method : str
+        "price" for price-based (fast, deterministic) or
+        "hmm" for HMM-based (slower, probabilistic).
+    **kwargs
+        Additional arguments passed to the underlying detector.
+
+    Returns
+    -------
+    pd.Series of regime labels (string).
+    """
+    if method == "price":
+        return detect_regimes_price(prices, **kwargs)
+    elif method == "hmm":
+        result = detect_regimes_hmm(prices, **kwargs)
+        labels = result.labels
+        names = result.regime_names
+        return pd.Series(
+            [names[l] for l in labels],
+            index=pd.Series(prices).index,
+            dtype="object",
+        )
+    else:
+        raise ValueError(f"Unknown method: {method}. Use 'price' or 'hmm'.")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_regime_detector.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_regime_detector.py
@@ -1,0 +1,205 @@
+"""Tests for regime_detector.py — market regime detection."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from regime_detector import (
+    GaussianHMM,
+    HMMRegimeResult,
+    detect_regimes,
+    detect_regimes_hmm,
+    detect_regimes_price,
+)
+
+
+# ---------------------------------------------------------------------------
+# Price-based regime detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRegimesPrice:
+    @pytest.fixture
+    def trending_up(self):
+        return pd.Series(np.linspace(100, 200, 252))
+
+    @pytest.fixture
+    def trending_down(self):
+        return pd.Series(np.linspace(200, 100, 252))
+
+    @pytest.fixture
+    def crash_prices(self):
+        rng = np.random.default_rng(42)
+        n = 200
+        returns = rng.normal(0.0003, 0.008, n)
+        returns[100:115] = -0.025
+        returns[115:130] = 0.015
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    def test_uptrend_detected(self, trending_up):
+        regimes = detect_regimes_price(trending_up, lookback_days=20)
+        assert "uptrend" in regimes.values
+
+    def test_downtrend_detected(self, trending_down):
+        regimes = detect_regimes_price(trending_down, lookback_days=20)
+        assert "downtrend" in regimes.values
+
+    def test_output_length_matches_input(self, trending_up):
+        regimes = detect_regimes_price(trending_up)
+        assert len(regimes) == len(trending_up)
+
+    def test_no_normal_after_lookback(self, trending_up):
+        regimes = detect_regimes_price(trending_up, lookback_days=20)
+        after_lookback = regimes.iloc[20:]
+        assert "normal" not in after_lookback.values
+
+    def test_black_swan_in_crash(self, crash_prices):
+        regimes = detect_regimes_price(
+            crash_prices,
+            lookback_days=20,
+            black_swan_drawdown=-0.20,
+            black_swan_window=30,
+        )
+        assert "black_swan" in regimes.values
+
+    def test_known_regimes_count(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0003, 0.015, 500)
+        returns[300:315] = -0.03
+        prices = pd.Series(100 * np.cumprod(1 + returns))
+        regimes = detect_regimes_price(prices, lookback_days=30)
+        unique = set(regimes.iloc[30:].values)
+        assert len(unique) >= 3
+
+    def test_custom_thresholds(self, trending_up):
+        low = detect_regimes_price(trending_up, uptrend_threshold=0.01, lookback_days=20)
+        high = detect_regimes_price(trending_up, uptrend_threshold=0.50, lookback_days=20)
+        assert (low == "uptrend").sum() >= (high == "uptrend").sum()
+
+
+# ---------------------------------------------------------------------------
+# Gaussian HMM tests
+# ---------------------------------------------------------------------------
+
+
+class TestGaussianHMM:
+    @pytest.fixture
+    def bull_bear_data(self):
+        """Two-regime data: bull (positive mean) and bear (negative mean)."""
+        rng = np.random.default_rng(42)
+        n_bull = 200
+        n_bear = 200
+        bull = rng.normal(0.002, 0.01, (n_bull, 2))
+        bear = rng.normal(-0.003, 0.015, (n_bear, 2))
+        return np.vstack([bull, bear])
+
+    def test_fit_converges(self, bull_bear_data):
+        hmm = GaussianHMM(n_states=2, n_iter=50)
+        hmm.fit(bull_bear_data)
+        assert hasattr(hmm, "log_likelihood_")
+        assert np.isfinite(hmm.log_likelihood_)
+
+    def test_predict_shape(self, bull_bear_data):
+        hmm = GaussianHMM(n_states=2, n_iter=50)
+        hmm.fit(bull_bear_data)
+        labels = hmm.predict(bull_bear_data)
+        assert labels.shape == (len(bull_bear_data),)
+        assert set(labels) <= {0, 1}
+
+    def test_two_states_found(self, bull_bear_data):
+        hmm = GaussianHMM(n_states=2, n_iter=50)
+        hmm.fit(bull_bear_data)
+        labels = hmm.predict(bull_bear_data)
+        assert len(np.unique(labels)) == 2
+
+    def test_transition_matrix_shape(self, bull_bear_data):
+        hmm = GaussianHMM(n_states=3, n_iter=30)
+        hmm.fit(bull_bear_data)
+        assert hmm.A.shape == (3, 3)
+        # Rows should sum to 1
+        np.testing.assert_allclose(hmm.A.sum(axis=1), 1.0, atol=1e-6)
+
+    def test_reproducible_with_same_data(self, bull_bear_data):
+        hmm1 = GaussianHMM(n_states=2, n_iter=30)
+        hmm1.fit(bull_bear_data)
+        labels1 = hmm1.predict(bull_bear_data)
+
+        hmm2 = GaussianHMM(n_states=2, n_iter=30)
+        hmm2.fit(bull_bear_data)
+        labels2 = hmm2.predict(bull_bear_data)
+        np.testing.assert_array_equal(labels1, labels2)
+
+
+# ---------------------------------------------------------------------------
+# HMM regime detection (full pipeline) tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRegimesHMM:
+    @pytest.fixture
+    def spy_like_prices(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0004, 0.01, 500)
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    def test_returns_hmm_result(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=3)
+        assert isinstance(result, HMMRegimeResult)
+        assert result.n_states == 3
+
+    def test_labels_match_prices_length(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=3)
+        assert len(result.labels) == len(spy_like_prices)
+
+    def test_regime_names_populated(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=3)
+        assert "bull" in result.regime_names
+        assert "bear" in result.regime_names
+        assert "neutral" in result.regime_names
+
+    def test_two_state_names(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=2)
+        assert "bull" in result.regime_names
+        assert "bear" in result.regime_names
+
+    def test_transition_matrix_square(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=3)
+        assert result.transition_matrix.shape == (3, 3)
+
+    def test_insufficient_data(self):
+        prices = pd.Series([100, 101, 102])
+        result = detect_regimes_hmm(prices, n_states=3, min_samples=80)
+        assert all(name == "unknown" for name in result.regime_names)
+
+    def test_log_likelihood_finite(self, spy_like_prices):
+        result = detect_regimes_hmm(spy_like_prices, n_states=3)
+        assert np.isfinite(result.log_likelihood)
+
+
+# ---------------------------------------------------------------------------
+# Unified detect_regimes() convenience function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRegimes:
+    @pytest.fixture
+    def prices(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.0004, 0.01, 300)
+        return pd.Series(100 * np.cumprod(1 + returns))
+
+    def test_price_method(self, prices):
+        regimes = detect_regimes(prices, method="price")
+        assert isinstance(regimes, pd.Series)
+        assert len(regimes) == len(prices)
+
+    def test_hmm_method(self, prices):
+        regimes = detect_regimes(prices, method="hmm", n_states=3)
+        assert isinstance(regimes, pd.Series)
+        assert len(regimes) == len(prices)
+
+    def test_invalid_method_raises(self, prices):
+        with pytest.raises(ValueError, match="Unknown method"):
+            detect_regimes(prices, method="invalid")


### PR DESCRIPTION
## Summary

- Extract regime detection into standalone `regime_detector.py` shared module
- Two complementary approaches: price-based (fast, deterministic) and HMM-based (probabilistic)
- 22 tests covering both methods, edge cases, and unified `detect_regimes()` interface
- Supports Issue #754 Phase B: MoE expert-per-regime architecture

### What's included

**`scripts/regime_detector.py`** (~390 lines):
- `detect_regimes_price()`: Rolling return + volatility + drawdown classification (4 regimes: uptrend, downtrend, volatility, black_swan)
- `GaussianHMM`: Pure numpy HMM with Baum-Welch EM + Viterbi decoding
- `detect_regimes_hmm()`: Full pipeline (feature extraction, MAD winsorization, state naming)
- `detect_regimes()`: Unified convenience function with `method="price"|"hmm"`

**`scripts/tests/test_regime_detector.py`** (22 tests):
- Price-based: uptrend/downtrend detection, black swan, threshold customization
- GaussianHMM: convergence, shape, reproducibility, transition matrix
- HMM pipeline: result type, label length, regime naming, insufficient data
- Unified interface: both methods, invalid method raises

### Context

Existing implementations scattered across QC projects:
- `projects/HMM-KMeans-Voting/main.py` — HMM + KMeans ensemble (QC algorithm)
- `scripts/eval_finstsb.py` — price-based regime detection (FinTSB eval)

This module extracts the core logic into a standalone, testable, importable module for the ML training pipeline.

### References

- Hamilton (1989), regime-switching models
- Hands-On AI Trading, Pik et al., Wiley 2025
- Issue #754: "0 BEATS, 14 FAILS" — MoE+régimes as proposed solution

## Test plan

- [x] 22 new tests pass
- [x] 439 total tests pass (no regressions)
- [x] Both detection methods produce valid regime labels
- [x] Edge case: insufficient data returns graceful fallback
- [x] HMM reproducible with same input

🤖 Generated with [Claude Code](https://claude.com/claude-code)