### PR TITLE
fix(ml): replace broken from scripts.X imports (417 tests fixed)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
@@ -36,17 +36,17 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from scripts.baselines import (
+from baselines import (
     buy_and_hold_baseline,
     majority_class_baseline,
     naive_momentum_baseline,
 )
-from scripts.data_utils import generate_synthetic_data, load_data
-from scripts.eval_finstsb import eval_per_regime
-from scripts.features import FeatureEngineer
-from scripts.sequence_utils import build_sequences
-from scripts.transaction_costs import TransactionCostModel, compare_gross_vs_net
-from scripts.walk_forward import WalkForwardSplitter
+from data_utils import generate_synthetic_data, load_data
+from eval_finstsb import eval_per_regime
+from features import FeatureEngineer
+from sequence_utils import build_sequences
+from transaction_costs import TransactionCostModel, compare_gross_vs_net
+from walk_forward import WalkForwardSplitter
 
 
 def load_checkpoint_model(checkpoint_dir: Path) -> tuple:
@@ -85,7 +85,7 @@ def load_checkpoint_model(checkpoint_dir: Path) -> tuple:
 
         state_size = hp.get("state_size", metadata.get("architecture", {}).get("state_size", 242))
         hidden_size = hp.get("hidden_size", 256)
-        from scripts.train_dqn_rl import build_dqn
+        from train_dqn_rl import build_dqn
 
         model = build_dqn(state_size, hidden_size, n_actions=3)
         state = torch.load(model_path, map_location="cpu", weights_only=True)
@@ -102,7 +102,7 @@ def _build_model_from_metadata(model_type: str, hp: dict):
     import torch
 
     if model_type == "transformer":
-        from scripts.train_transformer import build_transformer_model
+        from train_transformer import build_transformer_model
 
         return build_transformer_model(
             input_size=hp.get("input_size", 38),
@@ -114,7 +114,7 @@ def _build_model_from_metadata(model_type: str, hp: dict):
             seq_len=hp.get("seq_len", 20),
         )
     elif model_type == "lstm":
-        from scripts.train_lstm import build_model
+        from train_lstm import build_model
 
         return build_model(
             input_size=hp.get("input_size", 38),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
@@ -43,7 +43,7 @@ from train_rl_dt import (
 )
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.baselines import (
+from baselines import (
     buy_and_hold_baseline,
     majority_class_baseline,
     naive_momentum_baseline,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_existing_checkpoints.py
@@ -14,15 +14,15 @@ import pytest
 # Ensure scripts/ is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.eval_existing_checkpoints import (
+from eval_existing_checkpoints import (
     build_sequences,
     predict_direction,
     predict_sequences,
     run_dry_run,
     _wrap_model,
 )
-from scripts.data_utils import generate_synthetic_data
-from scripts.features import FeatureEngineer
+from data_utils import generate_synthetic_data
+from features import FeatureEngineer
 
 
 class TestBuildSequences:
@@ -231,7 +231,7 @@ class TestEvaluateCheckpointErrors:
     """Error handling for evaluate_checkpoint."""
 
     def test_missing_metadata_raises(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_checkpoint
+        from eval_existing_checkpoints import evaluate_checkpoint
 
         ckpt_dir = tmp_path / "fake_ckpt"
         ckpt_dir.mkdir()
@@ -239,7 +239,7 @@ class TestEvaluateCheckpointErrors:
             evaluate_checkpoint(ckpt_dir)
 
     def test_unknown_model_type_raises(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_checkpoint
+        from eval_existing_checkpoints import evaluate_checkpoint
 
         ckpt_dir = tmp_path / "unknown_ckpt"
         ckpt_dir.mkdir()
@@ -257,13 +257,13 @@ class TestEvaluateAllCheckpoints:
     """Batch evaluation scanning tests."""
 
     def test_empty_dir(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         results = evaluate_all_checkpoints(tmp_path)
         assert results == []
 
     def test_skips_non_checkpoint_dirs(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         model_dir = tmp_path / "transformer"
         model_dir.mkdir()
@@ -274,7 +274,7 @@ class TestEvaluateAllCheckpoints:
         assert results == []
 
     def test_output_json(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         output_path = tmp_path / "results.json"
         results = evaluate_all_checkpoints(tmp_path, output_path=output_path)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.eval_finstsb import (
+from eval_finstsb import (
     detect_regimes,
     eval_per_regime,
     validate_no_regime_failure,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_train_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_train_rl_dt.py
@@ -426,7 +426,7 @@ class TestWalkForward:
     def test_walk_forward_splits(self):
         """Walk-forward splitter generates non-overlapping test folds."""
         try:
-            from scripts.walk_forward import WalkForwardSplitter
+            from walk_forward import WalkForwardSplitter
         except ImportError:
             pytest.skip("WalkForwardSplitter not available")
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.transaction_costs import (
+from transaction_costs import (
     TransactionCostModel,
     compare_gross_vs_net,
     _sharpe_from_array,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.walk_forward import (
+from walk_forward import (
     PurgedKFold,
     WalkForwardSplitter,
     combinatorial_purged_split,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -71,17 +71,17 @@ except ImportError:
         return False, None
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 
 try:
-    from scripts.baselines import majority_class_baseline
+    from baselines import majority_class_baseline
 except ImportError:
     majority_class_baseline = None
 
 try:
-    from scripts.transaction_costs import TransactionCostModel, compare_gross_vs_net
+    from transaction_costs import TransactionCostModel, compare_gross_vs_net
 except ImportError:
     TransactionCostModel = None
     compare_gross_vs_net = None

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_rl_dt.py
@@ -65,7 +65,7 @@ from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 


### PR DESCRIPTION
## Summary
- Replace all `from scripts.X import ...` with direct `from X import ...` across 10 files
- Fixes 5 collection errors that prevented 417 tests from running

## Root Cause
Tests and scripts used `from scripts.baselines import ...` which assumes the parent
directory is the working dir. When pytest runs from `scripts/` directly, this fails
with `ModuleNotFoundError: No module named 'scripts'`.

## Files Changed
- `eval_existing_checkpoints.py` — 10 import lines
- `eval_rl_dt.py` — 1 import line
- `train_mamba.py` — 3 import lines
- `train_rl_dt.py` — 1 import line
- `tests/test_baselines.py` — 1 import line
- `tests/test_eval_existing_checkpoints.py` — 8 import lines
- `tests/test_eval_finstsb.py` — 1 import line
- `tests/test_train_rl_dt.py` — 1 import line
- `tests/test_transaction_costs.py` — 1 import line
- `tests/test_walk_forward.py` — 1 import line

## Test plan
- [x] 417 passed, 0 failed (was 0 collected / 5 errors before)
- [x] No logic changes — only import paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)