### PR TITLE
test(ml): add 39 tests for eval_chronos_bolt + eval_rl_dt (456 total)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
@@ -36,17 +36,17 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from scripts.baselines import (
+from baselines import (
     buy_and_hold_baseline,
     majority_class_baseline,
     naive_momentum_baseline,
 )
-from scripts.data_utils import generate_synthetic_data, load_data
-from scripts.eval_finstsb import eval_per_regime
-from scripts.features import FeatureEngineer
-from scripts.sequence_utils import build_sequences
-from scripts.transaction_costs import TransactionCostModel, compare_gross_vs_net
-from scripts.walk_forward import WalkForwardSplitter
+from data_utils import generate_synthetic_data, load_data
+from eval_finstsb import eval_per_regime
+from features import FeatureEngineer
+from sequence_utils import build_sequences
+from transaction_costs import TransactionCostModel, compare_gross_vs_net
+from walk_forward import WalkForwardSplitter
 
 
 def load_checkpoint_model(checkpoint_dir: Path) -> tuple:
@@ -85,7 +85,7 @@ def load_checkpoint_model(checkpoint_dir: Path) -> tuple:
 
         state_size = hp.get("state_size", metadata.get("architecture", {}).get("state_size", 242))
         hidden_size = hp.get("hidden_size", 256)
-        from scripts.train_dqn_rl import build_dqn
+        from train_dqn_rl import build_dqn
 
         model = build_dqn(state_size, hidden_size, n_actions=3)
         state = torch.load(model_path, map_location="cpu", weights_only=True)
@@ -102,7 +102,7 @@ def _build_model_from_metadata(model_type: str, hp: dict):
     import torch
 
     if model_type == "transformer":
-        from scripts.train_transformer import build_transformer_model
+        from train_transformer import build_transformer_model
 
         return build_transformer_model(
             input_size=hp.get("input_size", 38),
@@ -114,7 +114,7 @@ def _build_model_from_metadata(model_type: str, hp: dict):
             seq_len=hp.get("seq_len", 20),
         )
     elif model_type == "lstm":
-        from scripts.train_lstm import build_model
+        from train_lstm import build_model
 
         return build_model(
             input_size=hp.get("input_size", 38),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
@@ -43,7 +43,7 @@ from train_rl_dt import (
 )
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_baselines.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.baselines import (
+from baselines import (
     buy_and_hold_baseline,
     majority_class_baseline,
     naive_momentum_baseline,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_chronos_bolt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_chronos_bolt.py
@@ -1,0 +1,171 @@
+"""Tests for eval_chronos_bolt.py — Chronos-Bolt zero-shot evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from eval_chronos_bolt import (
+    CHRONOS_MODEL_IDS,
+    NaiveChronosWrapper,
+    load_chronos_model,
+    run_evaluation,
+)
+
+
+class TestChronosModelIds:
+    """Chronos model configuration tests."""
+
+    def test_three_sizes(self):
+        assert set(CHRONOS_MODEL_IDS.keys()) == {"small", "base", "large"}
+
+    def test_all_amazon_prefix(self):
+        for model_id in CHRONOS_MODEL_IDS.values():
+            assert model_id.startswith("amazon/chronos-bolt-")
+
+    def test_base_is_default(self):
+        assert "base" in CHRONOS_MODEL_IDS
+
+
+class TestNaiveChronosWrapper:
+    """Naive wrapper tests (used when chronos-forecasting not installed)."""
+
+    def test_predict_shape(self):
+        wrapper = NaiveChronosWrapper(model_id="test-model")
+        context = np.array([100.0, 101.0, 102.0, 103.0, 104.0])
+        pred = wrapper.predict(context, pred_len=10)
+        assert pred.shape == (10,)
+
+    def test_predict_last_value_persist(self):
+        wrapper = NaiveChronosWrapper()
+        context = np.array([50.0, 60.0, 70.0, 80.0, 90.0])
+        pred = wrapper.predict(context, pred_len=5)
+        np.testing.assert_array_equal(pred, np.full(5, 90.0))
+
+    def test_predict_2d_context(self):
+        wrapper = NaiveChronosWrapper()
+        context = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        pred = wrapper.predict(context, pred_len=3)
+        assert pred.shape == (3,)
+        assert pred[0] == 5.0
+
+    def test_is_mock_true(self):
+        wrapper = NaiveChronosWrapper()
+        assert wrapper.is_mock is True
+
+    def test_model_id_stored(self):
+        wrapper = NaiveChronosWrapper(model_id="amazon/chronos-bolt-small")
+        assert wrapper.model_id == "amazon/chronos-bolt-small"
+
+
+class TestLoadChronosModel:
+    """Model loading tests."""
+
+    def test_fallback_to_naive(self):
+        """Without chronos-forecasting installed, returns NaiveChronosWrapper."""
+        model = load_chronos_model("base", device="cpu")
+        assert isinstance(model, NaiveChronosWrapper)
+        assert model.is_mock is True
+
+    def test_invalid_size_defaults_to_base(self):
+        """Unknown model size falls back to base."""
+        model = load_chronos_model("nonexistent", device="cpu")
+        assert "base" in model.model_id
+
+    def test_small_size(self):
+        model = load_chronos_model("small", device="cpu")
+        assert "small" in model.model_id
+
+
+class TestRunEvaluationDryRun:
+    """Dry-run integration tests."""
+
+    def _make_args(self, **overrides):
+        defaults = {
+            "dry_run": True,
+            "data_dir": "",
+            "symbol": "SPY",
+            "model_size": "base",
+            "seq_len": 50,
+            "pred_len": 10,
+            "n_windows": 3,
+            "cost_bps": 10.0,
+            "output_dir": None,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_returns_summary_dict(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        assert isinstance(result, dict)
+
+    def test_summary_keys(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        for key in [
+            "model", "is_mock", "symbol", "seq_len", "pred_len",
+            "n_windows", "avg_direction_accuracy", "avg_sharpe",
+            "majority_baseline", "edge_vs_majority", "windows",
+            "timestamp",
+        ]:
+            assert key in result, f"Missing key: {key}"
+
+    def test_is_mock_in_dry_run(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        assert result["is_mock"] is True
+
+    def test_direction_accuracy_bounded(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        assert 0.0 <= result["avg_direction_accuracy"] <= 1.0
+
+    def test_windows_count(self):
+        args = self._make_args(n_windows=3)
+        result = run_evaluation(args)
+        assert result["n_windows"] == 3
+        assert len(result["windows"]) == 3
+
+    def test_window_metrics_keys(self):
+        args = self._make_args(seq_len=50, pred_len=10, n_windows=2)
+        result = run_evaluation(args)
+        window = result["windows"][0]
+        for key in [
+            "direction_accuracy", "mse", "sharpe", "net_sharpe",
+            "n_trades", "transaction_cost_bps", "forecast_mean",
+            "actual_mean", "window", "start", "end",
+        ]:
+            assert key in window, f"Missing window key: {key}"
+
+    def test_majority_baseline_present(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        bl = result["majority_baseline"]
+        assert "majority_class_accuracy" in bl
+        assert "pct_up" in bl
+        assert "pct_down" in bl
+
+    def test_output_dir_creates_file(self, tmp_path):
+        args = self._make_args(output_dir=str(tmp_path / "results"))
+        result = run_evaluation(args)
+        out_files = list((tmp_path / "results").glob("chronos_zeroshot_*.json"))
+        assert len(out_files) == 1
+        data = json.loads(out_files[0].read_text())
+        assert data["model"] == result["model"]
+
+    def test_sharpe_is_finite(self):
+        args = self._make_args(seq_len=50, pred_len=10, n_windows=3)
+        result = run_evaluation(args)
+        assert np.isfinite(result["avg_sharpe"])
+
+    def test_edge_vs_majority(self):
+        args = self._make_args()
+        result = run_evaluation(args)
+        expected = result["avg_direction_accuracy"] - result["majority_baseline"]["majority_class_accuracy"]
+        assert abs(result["edge_vs_majority"] - expected) < 1e-6

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_existing_checkpoints.py
@@ -14,15 +14,15 @@ import pytest
 # Ensure scripts/ is importable
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.eval_existing_checkpoints import (
+from eval_existing_checkpoints import (
     build_sequences,
     predict_direction,
     predict_sequences,
     run_dry_run,
     _wrap_model,
 )
-from scripts.data_utils import generate_synthetic_data
-from scripts.features import FeatureEngineer
+from data_utils import generate_synthetic_data
+from features import FeatureEngineer
 
 
 class TestBuildSequences:
@@ -231,7 +231,7 @@ class TestEvaluateCheckpointErrors:
     """Error handling for evaluate_checkpoint."""
 
     def test_missing_metadata_raises(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_checkpoint
+        from eval_existing_checkpoints import evaluate_checkpoint
 
         ckpt_dir = tmp_path / "fake_ckpt"
         ckpt_dir.mkdir()
@@ -239,7 +239,7 @@ class TestEvaluateCheckpointErrors:
             evaluate_checkpoint(ckpt_dir)
 
     def test_unknown_model_type_raises(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_checkpoint
+        from eval_existing_checkpoints import evaluate_checkpoint
 
         ckpt_dir = tmp_path / "unknown_ckpt"
         ckpt_dir.mkdir()
@@ -257,13 +257,13 @@ class TestEvaluateAllCheckpoints:
     """Batch evaluation scanning tests."""
 
     def test_empty_dir(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         results = evaluate_all_checkpoints(tmp_path)
         assert results == []
 
     def test_skips_non_checkpoint_dirs(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         model_dir = tmp_path / "transformer"
         model_dir.mkdir()
@@ -274,7 +274,7 @@ class TestEvaluateAllCheckpoints:
         assert results == []
 
     def test_output_json(self, tmp_path):
-        from scripts.eval_existing_checkpoints import evaluate_all_checkpoints
+        from eval_existing_checkpoints import evaluate_all_checkpoints
 
         output_path = tmp_path / "results.json"
         results = evaluate_all_checkpoints(tmp_path, output_path=output_path)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_finstsb.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.eval_finstsb import (
+from eval_finstsb import (
     detect_regimes,
     eval_per_regime,
     validate_no_regime_failure,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_rl_dt.py
@@ -1,0 +1,138 @@
+"""Tests for eval_rl_dt.py — Decision Transformer evaluation harness."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from eval_rl_dt import (
+    compute_max_drawdown,
+    compute_sharpe,
+    load_checkpoint,
+    run_dry_run,
+)
+
+
+class TestComputeSharpe:
+    """Sharpe ratio computation tests."""
+
+    def test_empty_returns(self):
+        assert compute_sharpe(np.array([])) == 0.0
+
+    def test_single_return(self):
+        assert compute_sharpe(np.array([0.01])) == 0.0
+
+    def test_constant_returns(self):
+        assert compute_sharpe(np.array([0.01] * 100)) == 0.0
+
+    def test_positive_sharpe(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.001, 0.01, 252)
+        assert compute_sharpe(returns) > 0
+
+    def test_negative_sharpe(self):
+        rng = np.random.default_rng(99)
+        returns = rng.normal(-0.005, 0.01, 252)
+        assert compute_sharpe(returns) < 0
+
+    def test_annualize_multiplier(self):
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0.001, 0.01, 252)
+        s_ann = compute_sharpe(returns, annualize=True)
+        s_raw = compute_sharpe(returns, annualize=False)
+        assert abs(s_ann) > abs(s_raw)
+
+
+class TestComputeMaxDrawdown:
+    """Max drawdown computation tests."""
+
+    def test_empty(self):
+        assert compute_max_drawdown(np.array([])) == 0.0
+
+    def test_single_value(self):
+        assert compute_max_drawdown(np.array([1.0])) == 0.0
+
+    def test_monotonic_increase(self):
+        cum = np.cumsum(np.array([0.01] * 50))
+        assert compute_max_drawdown(cum) == 0.0
+
+    def test_drawdown_detected(self):
+        cum = np.array([0.0, 0.1, 0.2, 0.1, 0.0, -0.1])
+        dd = compute_max_drawdown(cum)
+        assert dd < 0
+
+    def test_small_drawdown_on_dip(self):
+        cum = np.array([0.0, 0.1, 0.2, 0.15, 0.2, 0.3])
+        dd = compute_max_drawdown(cum)
+        assert dd < 0  # dip from 0.2 to 0.15
+        assert dd > -0.5  # but not catastrophic
+
+
+class TestLoadCheckpoint:
+    """Checkpoint loading tests."""
+
+    def test_missing_metadata_raises(self, tmp_path):
+        ckpt_dir = tmp_path / "no_meta"
+        ckpt_dir.mkdir()
+        with pytest.raises(FileNotFoundError, match="metadata.json"):
+            load_checkpoint(ckpt_dir)
+
+    def test_loads_model_and_metadata(self, tmp_path):
+        import torch
+        from train_rl_dt import DecisionTransformerModel
+
+        ckpt_dir = tmp_path / "valid_ckpt"
+        ckpt_dir.mkdir()
+
+        model = DecisionTransformerModel(
+            state_dim=10, d_model=32, nhead=2, num_layers=1,
+            context_length=5, n_actions=3,
+        )
+        torch.save(model.state_dict(), ckpt_dir / "model.pt")
+
+        metadata = {
+            "model_type": "decision_transformer",
+            "architecture": {
+                "state_dim": 10, "d_model": 32, "nhead": 2,
+                "num_layers": 1, "context_length": 5, "n_actions": 3,
+            },
+        }
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+
+        loaded_model, loaded_meta = load_checkpoint(ckpt_dir)
+        assert loaded_meta["model_type"] == "decision_transformer"
+        assert isinstance(loaded_model, DecisionTransformerModel)
+
+
+class TestRunDryRun:
+    """Dry-run integration tests."""
+
+    def test_returns_dict(self):
+        result = run_dry_run()
+        assert isinstance(result, dict)
+        assert result["dry_run"] is True
+
+    def test_has_expected_keys(self):
+        result = run_dry_run()
+        for key in [
+            "dry_run", "train_samples", "test_accuracy", "test_loss",
+            "majority_class_baseline", "edge_over_majority",
+            "sharpe", "max_drawdown",
+        ]:
+            assert key in result, f"Missing key: {key}"
+
+    def test_sharpe_finite(self):
+        result = run_dry_run()
+        assert np.isfinite(result["sharpe"])
+
+    def test_max_drawdown_non_positive(self):
+        result = run_dry_run()
+        assert result["max_drawdown"] <= 0.0
+
+    def test_train_samples_positive(self):
+        result = run_dry_run()
+        assert result["train_samples"] > 0

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_registry_update.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_registry_update.py
@@ -1,0 +1,160 @@
+"""Tests for registry_update.py — checkpoint registry management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from registry_update import (
+    build_registry_markdown,
+    scan_checkpoints,
+)
+
+
+class TestScanCheckpoints:
+    """Checkpoint scanning tests."""
+
+    def test_empty_dir(self, tmp_path):
+        entries = scan_checkpoints(tmp_path)
+        assert entries == []
+
+    def test_nonexistent_dir(self, tmp_path):
+        entries = scan_checkpoints(tmp_path / "nonexistent")
+        assert entries == []
+
+    def test_valid_checkpoint(self, tmp_path):
+        ckpt_dir = tmp_path / "lstm" / "20260505_120000"
+        ckpt_dir.mkdir(parents=True)
+        metadata = {
+            "model_type": "lstm",
+            "timestamp": "2026-05-05T12:00:00",
+            "data_hash": "abc123",
+            "hyperparams": {"hidden_size": 64},
+            "metrics": {"test_accuracy": 0.55},
+        }
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        (ckpt_dir / "model.pt").write_bytes(b"fake")
+
+        entries = scan_checkpoints(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["status"] == "OK"
+        assert entries[0]["model_type"] == "lstm"
+        assert entries[0]["data_hash"] == "abc123"
+
+    def test_missing_metadata_flagged(self, tmp_path):
+        ckpt_dir = tmp_path / "transformer" / "20260505_130000"
+        ckpt_dir.mkdir(parents=True)
+        # No metadata.json
+
+        entries = scan_checkpoints(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["status"] == "MISSING_METADATA"
+
+    def test_invalid_json_flagged(self, tmp_path):
+        ckpt_dir = tmp_path / "lstm" / "20260505_bad"
+        ckpt_dir.mkdir(parents=True)
+        (ckpt_dir / "metadata.json").write_text("not json{")
+
+        entries = scan_checkpoints(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["status"] == "INVALID_JSON"
+
+    def test_missing_model_flagged(self, tmp_path):
+        ckpt_dir = tmp_path / "dqn" / "20260505_nomodel"
+        ckpt_dir.mkdir(parents=True)
+        metadata = {"model_type": "dqn", "timestamp": "2026-05-05"}
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        # No model file
+
+        entries = scan_checkpoints(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["status"] == "MISSING_MODEL"
+
+    def test_multiple_checkpoints(self, tmp_path):
+        for model_type in ["lstm", "transformer", "classification"]:
+            ckpt_dir = tmp_path / model_type / "20260505_120000"
+            ckpt_dir.mkdir(parents=True)
+            metadata = {"model_type": model_type, "timestamp": "2026-05-05"}
+            (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+            (ckpt_dir / "model.pt").write_bytes(b"fake")
+
+        entries = scan_checkpoints(tmp_path)
+        assert len(entries) == 3
+        types = {e["model_type"] for e in entries}
+        assert types == {"lstm", "transformer", "classification"}
+
+    def test_files_listed(self, tmp_path):
+        ckpt_dir = tmp_path / "lstm" / "20260505_files"
+        ckpt_dir.mkdir(parents=True)
+        metadata = {"model_type": "lstm"}
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        (ckpt_dir / "model.pt").write_bytes(b"fake")
+        (ckpt_dir / "scaler.pkl").write_bytes(b"fake")
+
+        entries = scan_checkpoints(tmp_path)
+        assert "model.pt" in entries[0]["files"]
+        assert "scaler.pkl" in entries[0]["files"]
+
+
+class TestBuildRegistryMarkdown:
+    """Markdown generation tests."""
+
+    def test_empty_entries(self):
+        md = build_registry_markdown([])
+        assert "Total checkpoints: 0" in md
+
+    def test_header_present(self):
+        md = build_registry_markdown([])
+        assert "# Checkpoint Registry" in md
+
+    def test_model_type_section(self):
+        entries = [{
+            "model_type": "lstm",
+            "timestamp": "2026-05-05",
+            "status": "OK",
+            "data_hash": "abc",
+            "hyperparams": {},
+            "metrics": {},
+            "architecture": {},
+            "files": ["model.pt"],
+            "path": "checkpoints/lstm/2026-05-05",
+        }]
+        md = build_registry_markdown(entries)
+        assert "## lstm" in md
+        assert "OK" in md
+
+    def test_issues_section(self):
+        entries = [
+            {
+                "model_type": "lstm",
+                "timestamp": "2026-05-05",
+                "status": "MISSING_MODEL",
+                "data_hash": "",
+                "hyperparams": {},
+                "metrics": {},
+                "architecture": {},
+                "files": [],
+                "path": "checkpoints/lstm/2026-05-05",
+            }
+        ]
+        md = build_registry_markdown(entries)
+        assert "## Issues" in md
+        assert "MISSING_MODEL" in md
+
+    def test_metrics_displayed(self):
+        entries = [{
+            "model_type": "transformer",
+            "timestamp": "2026-05-05",
+            "status": "OK",
+            "data_hash": "",
+            "hyperparams": {},
+            "metrics": {"test_accuracy": 0.55, "sharpe": 1.2},
+            "architecture": {},
+            "files": ["model.pt"],
+            "path": "checkpoints/transformer/2026-05-05",
+        }]
+        md = build_registry_markdown(entries)
+        assert "Metrics:" in md
+        assert "test_accuracy" in md

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_train_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_train_rl_dt.py
@@ -426,7 +426,7 @@ class TestWalkForward:
     def test_walk_forward_splits(self):
         """Walk-forward splitter generates non-overlapping test folds."""
         try:
-            from scripts.walk_forward import WalkForwardSplitter
+            from walk_forward import WalkForwardSplitter
         except ImportError:
             pytest.skip("WalkForwardSplitter not available")
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_transaction_costs.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.transaction_costs import (
+from transaction_costs import (
     TransactionCostModel,
     compare_gross_vs_net,
     _sharpe_from_array,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_validate_training_package.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_validate_training_package.py
@@ -1,0 +1,170 @@
+"""Tests for validate_training_package.py — pipeline validation harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from validate_training_package import (
+    REQUIRED_METADATA_FIELDS,
+    TRAINING_SCRIPTS,
+    check_imports,
+    find_latest_checkpoint,
+    validate_checkpoint,
+)
+
+
+class TestTrainingScripts:
+    """Configuration tests."""
+
+    def test_four_scripts(self):
+        assert len(TRAINING_SCRIPTS) == 4
+
+    def test_all_py_files(self):
+        for s in TRAINING_SCRIPTS:
+            assert s.endswith(".py")
+
+
+class TestRequiredMetadataFields:
+    """Metadata field config tests."""
+
+    def test_required_fields_present(self):
+        expected = {"timestamp", "model_type", "hyperparams", "metrics", "data_hash", "files"}
+        assert set(REQUIRED_METADATA_FIELDS) == expected
+
+
+class TestCheckImports:
+    """Import check tests."""
+
+    def test_core_deps_available(self):
+        errors = check_imports("train_classification.py")
+        core_errors = [e for e in errors if "numpy" in e or "pandas" in e]
+        assert len(core_errors) == 0
+
+    def test_sklearn_required_for_classification(self):
+        errors = check_imports("train_classification.py")
+        sklearn_missing = [e for e in errors if "scikit-learn" in e]
+        # sklearn should be installed in test env
+        assert len(sklearn_missing) == 0
+
+    def test_torch_required_for_lstm(self):
+        errors = check_imports("train_lstm.py")
+        torch_missing = [e for e in errors if "torch" in e]
+        # torch should be installed in test env
+        assert len(torch_missing) == 0
+
+    def test_torch_required_for_transformer(self):
+        errors = check_imports("train_transformer.py")
+        torch_missing = [e for e in errors if "torch" in e]
+        assert len(torch_missing) == 0
+
+    def test_torch_required_for_dqn(self):
+        errors = check_imports("train_dqn_rl.py")
+        torch_missing = [e for e in errors if "torch" in e]
+        assert len(torch_missing) == 0
+
+
+class TestFindLatestCheckpoint:
+    """Checkpoint discovery tests."""
+
+    def test_nonexistent_dir(self, tmp_path):
+        result = find_latest_checkpoint(tmp_path / "nonexistent")
+        assert result is None
+
+    def test_empty_dir(self, tmp_path):
+        ckpt_dir = tmp_path / "checkpoints"
+        ckpt_dir.mkdir()
+        result = find_latest_checkpoint(ckpt_dir)
+        assert result is None
+
+    def test_finds_latest(self, tmp_path):
+        ckpt_dir = tmp_path / "checkpoints"
+        ckpt_dir.mkdir()
+        (ckpt_dir / "20250101_000000").mkdir()
+        (ckpt_dir / "20250102_120000").mkdir()
+        (ckpt_dir / "20250103_060000").mkdir()
+        result = find_latest_checkpoint(ckpt_dir)
+        assert result is not None
+        assert result.name == "20250103_060000"
+
+
+class TestValidateCheckpoint:
+    """Checkpoint validation tests."""
+
+    def test_nonexistent_dir(self, tmp_path):
+        errors = validate_checkpoint(tmp_path / "nope", "train_lstm.py")
+        assert len(errors) > 0
+
+    def test_missing_metadata(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        errors = validate_checkpoint(ckpt_dir, "train_lstm.py")
+        assert any("metadata.json" in e for e in errors)
+
+    def test_invalid_json_metadata(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        (ckpt_dir / "metadata.json").write_text("not json{")
+        errors = validate_checkpoint(ckpt_dir, "train_lstm.py")
+        assert any("Invalid" in e for e in errors)
+
+    def test_missing_required_fields(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        (ckpt_dir / "metadata.json").write_text(json.dumps({"only_field": 1}))
+        errors = validate_checkpoint(ckpt_dir, "train_lstm.py")
+        missing_fields = [e for e in errors if "Missing metadata field" in e]
+        assert len(missing_fields) > 0
+
+    def test_valid_checkpoint(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        metadata = {
+            "timestamp": "2026-01-01T00:00:00",
+            "model_type": "lstm",
+            "hyperparams": {"hidden_size": 64},
+            "metrics": {"test_accuracy": 0.54},
+            "data_hash": "abc123",
+            "files": {"model": "model.pt"},
+        }
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        (ckpt_dir / "model.pt").write_bytes(b"fake model")
+
+        errors = validate_checkpoint(ckpt_dir, "train_lstm.py")
+        assert errors == []
+
+    def test_empty_data_hash_flagged(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        metadata = {
+            "timestamp": "2026-01-01",
+            "model_type": "test",
+            "hyperparams": {},
+            "metrics": {},
+            "data_hash": "",
+            "files": {},
+        }
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        (ckpt_dir / "model.pt").write_bytes(b"")
+
+        errors = validate_checkpoint(ckpt_dir, "test.py")
+        assert any("data_hash" in e for e in errors)
+
+    def test_no_model_file_flagged(self, tmp_path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        metadata = {
+            "timestamp": "t",
+            "model_type": "test",
+            "hyperparams": {},
+            "metrics": {},
+            "data_hash": "abc",
+            "files": {},
+        }
+        (ckpt_dir / "metadata.json").write_text(json.dumps(metadata))
+        # No model file
+
+        errors = validate_checkpoint(ckpt_dir, "test.py")
+        assert any("model file" in e.lower() for e in errors)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_walk_forward.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from scripts.walk_forward import (
+from walk_forward import (
     PurgedKFold,
     WalkForwardSplitter,
     combinatorial_purged_split,

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -71,17 +71,17 @@ except ImportError:
         return False, None
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 
 try:
-    from scripts.baselines import majority_class_baseline
+    from baselines import majority_class_baseline
 except ImportError:
     majority_class_baseline = None
 
 try:
-    from scripts.transaction_costs import TransactionCostModel, compare_gross_vs_net
+    from transaction_costs import TransactionCostModel, compare_gross_vs_net
 except ImportError:
     TransactionCostModel = None
     compare_gross_vs_net = None

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_rl_dt.py
@@ -65,7 +65,7 @@ from data_utils import compute_data_hash, generate_synthetic_data, load_data
 from features import FeatureEngineer
 
 try:
-    from scripts.walk_forward import WalkForwardSplitter
+    from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
 


### PR DESCRIPTION
## Summary
- Add 21 tests for `eval_chronos_bolt.py` (NaiveChronosWrapper, model loading fallback, dry-run integration, output file creation, edge-vs-majority)
- Add 18 tests for `eval_rl_dt.py` (Sharpe ratio, MaxDrawdown, checkpoint loading, dry-run integration)
- Cherry-pick import fix from PR #775 (`from scripts.X` -> direct imports) for test collection compatibility

## Test plan
- [x] `python -m pytest tests/ -q` — 456 passed, 0 failed
- [x] New tests cover: model config, naive wrapper predict/mock behavior, checkpoint load errors, Sharpe/MaxDD edge cases, dry-run output keys and bounds

Related: Issue #754 (ESGF livrable 19/05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)