### PR TITLE
feat(qc): research notebook validator (#756 Phase D)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/scripts/tests/test_validate_qc_research.py
+++ b/MyIA.AI.Notebooks/QuantConnect/scripts/tests/test_validate_qc_research.py
@@ -1,0 +1,261 @@
+"""Tests for ResearchNotebookValidator in validate_qc_notebooks.py."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from validate_qc_notebooks import ResearchNotebookValidator, validate_projects
+
+
+def _make_notebook(cells, kernelspec_name="python3"):
+    """Build a minimal notebook dict with the given cells."""
+    return {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {
+            "kernelspec": {
+                "name": kernelspec_name,
+                "display_name": "Python 3",
+            },
+            "language_info": {"name": "python"},
+        },
+        "cells": cells,
+    }
+
+
+def _code_cell(source, outputs=None, execution_count=1):
+    """Build a code cell with optional outputs."""
+    cell = {
+        "cell_type": "code",
+        "source": source.split("\n"),
+        "metadata": {},
+        "execution_count": execution_count,
+        "outputs": outputs or [],
+    }
+    return cell
+
+
+def _markdown_cell(source):
+    return {
+        "cell_type": "markdown",
+        "source": source.split("\n"),
+        "metadata": {},
+    }
+
+
+def _output_text(text):
+    return [{"output_type": "execute_result", "data": {"text/plain": [text]}, "metadata": {}}]
+
+
+def _write_nb(path: Path, nb: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(nb), encoding="utf-8")
+
+
+class TestExecutionCheck:
+    def test_zero_percent_executed_fails(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("x = 1"),
+            _code_cell("y = 2"),
+            _code_cell("z = 3"),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        valid, errors, _ = v.validate_project(tmp_path)
+        assert not valid
+        assert any("0% code cells executed" in e for e in errors)
+
+    def test_above_30_percent_passes(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("x = 1", outputs=_output_text("1")),
+            _code_cell("y = 2"),
+            _code_cell("z = 3"),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        valid, errors, _ = v.validate_project(tmp_path)
+        assert valid
+        assert not any("executed" in e for e in errors)
+
+    def test_below_30_percent_fails(self, tmp_path):
+        # 1/5 = 20% < 30%
+        cells = [_code_cell(f"x = {i}", outputs=(_output_text(str(i)) if i == 0 else [])) for i in range(5)]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        valid, errors, _ = v.validate_project(tmp_path)
+        assert not valid
+        assert any("20%" in e for e in errors)
+
+    def test_all_executed_passes(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("x = 1", outputs=_output_text("1")),
+            _code_cell("y = 2", outputs=_output_text("2")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        valid, _, _ = v.validate_project(tmp_path)
+        assert valid
+
+
+class TestSectionCheck:
+    def test_all_sections_present(self, tmp_path):
+        nb = _make_notebook([
+            _markdown_cell("# Exploration des donnees"),
+            _code_cell("qb = QuantBook()", outputs=_output_text("QB")),
+            _markdown_cell("# Iterations et Grid Search"),
+            _code_cell("for p in params: ...", outputs=_output_text("done")),
+            _markdown_cell("# Conclusion et Calibration"),
+            _code_cell("print('done')", outputs=_output_text("done")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        section_warnings = [w for w in warnings if "Section" in w and "not found" in w]
+        assert len(section_warnings) == 0
+
+    def test_missing_iterations_section(self, tmp_path):
+        nb = _make_notebook([
+            _markdown_cell("# Exploration"),
+            _code_cell("qb = QuantBook()", outputs=_output_text("QB")),
+            _markdown_cell("# Conclusion"),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert any("Iterations" in w for w in warnings)
+
+
+class TestQuantBookCheck:
+    def test_quantbook_present(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("from AlgorithmImports import *\nqb = QuantBook()", outputs=_output_text("QB")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert not any("QuantBook" in w for w in warnings)
+
+    def test_quantbook_missing_warns(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("x = 1", outputs=_output_text("1")),
+            _code_cell("y = 2", outputs=_output_text("2")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert any("QuantBook" in w for w in warnings)
+
+    def test_csharp_project_skips_quantbook_check(self, tmp_path):
+        (tmp_path / "Main.cs").write_text("// C# algo", encoding="utf-8")
+        nb = _make_notebook([
+            _code_cell("x = 1", outputs=_output_text("1")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert not any("QuantBook" in w for w in warnings)
+
+
+class TestStubCopyPaste:
+    def test_identical_cells_warns(self, tmp_path):
+        same_src = "print('hello')"
+        nb = _make_notebook([
+            _code_cell(same_src, outputs=_output_text("hello")),
+            _code_cell(same_src, outputs=_output_text("hello")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert any("identique" in w.lower() or "copy-paste" in w.lower() for w in warnings)
+
+    def test_different_cells_no_warning(self, tmp_path):
+        nb = _make_notebook([
+            _code_cell("x = 1", outputs=_output_text("1")),
+            _code_cell("y = 2", outputs=_output_text("2")),
+        ])
+        nb_path = tmp_path / "research.ipynb"
+        _write_nb(nb_path, nb)
+
+        v = ResearchNotebookValidator()
+        _, _, warnings = v.validate_project(tmp_path)
+        assert not any("copy-paste" in w.lower() for w in warnings)
+
+
+class TestNoResearchNotebook:
+    def test_project_without_notebook_passes(self, tmp_path):
+        (tmp_path / "main.py").write_text("pass", encoding="utf-8")
+        # No notebook files
+
+        v = ResearchNotebookValidator()
+        valid, _, warnings = v.validate_project(tmp_path)
+        assert valid
+        assert any("no research notebook" in w for w in warnings)
+
+    def test_empty_project_passes(self, tmp_path):
+        v = ResearchNotebookValidator()
+        valid, errors, _ = v.validate_project(tmp_path)
+        assert valid
+        assert len(errors) == 0
+
+
+class TestValidateProjects:
+    def test_batch_validation(self, tmp_path):
+        proj1 = tmp_path / "GoodProject"
+        nb1 = _make_notebook([
+            _code_cell("qb = QuantBook()", outputs=_output_text("QB")),
+            _code_cell("# Grid search iteration\nprint('done')", outputs=_output_text("done")),
+            _markdown_cell("# Exploration des donnees"),
+            _markdown_cell("# Conclusion"),
+        ])
+        _write_nb(proj1 / "research.ipynb", nb1)
+
+        proj2 = tmp_path / "BadProject"
+        nb2 = _make_notebook([_code_cell("x = 1")])
+        _write_nb(proj2 / "research.ipynb", nb2)
+
+        results = validate_projects(tmp_path)
+        assert results["total"] == 2
+        assert results["valid"] == 1
+        assert results["invalid"] == 1
+
+    def test_skips_dirs_without_notebooks(self, tmp_path):
+        proj = tmp_path / "CodeOnly"
+        proj.mkdir()
+        (proj / "main.py").write_text("pass", encoding="utf-8")
+
+        results = validate_projects(tmp_path)
+        assert results["total"] == 0
+
+    def test_skips_underscore_dirs(self, tmp_path):
+        hidden = tmp_path / "_archives"
+        hidden.mkdir()
+        nb = _make_notebook([_code_cell("x = 1")])
+        _write_nb(hidden / "research.ipynb", nb)
+
+        results = validate_projects(tmp_path)
+        assert results["total"] == 0

--- a/MyIA.AI.Notebooks/QuantConnect/scripts/validate_qc_notebooks.py
+++ b/MyIA.AI.Notebooks/QuantConnect/scripts/validate_qc_notebooks.py
@@ -306,6 +306,221 @@ class NotebookValidator:
             )
 
 
+class ResearchNotebookValidator:
+    """Validates QC project research notebooks per Issue #756 Phase D.
+
+    Checks:
+    1. Research notebook present in project directory
+    2. Executed (>30% code cells with outputs)
+    3. No stub copy-paste detected (identical source across cells)
+    4. Required sections present (Exploration, Iterations, Calibration/Conclusion)
+    5. Real QuantBook usage (qb = QuantBook() in code, not just markdown mention)
+    """
+
+    MIN_OUTPUT_RATIO = 0.30
+    REQUIRED_SECTIONS = [
+        (r'explor|charg.*donn|data.*load|history', 'Exploration/Data Loading'),
+        (r'it.rat|grid.?search|walk.?forward|backtest.*multi', 'Iterations/Grid Search'),
+        (r'calibrat|conclusion|recommand|résultat.*final|synth.se', 'Calibration/Conclusion'),
+    ]
+
+    STUB_PATTERNS = [
+        r'^\s*pass\s*$',
+        r'^\s*print\(["\']Exercice',
+        r'^\s*# TODO',
+        r'^\s*raise NotImplementedError',
+    ]
+
+    def __init__(self, verbose: bool = False):
+        self.verbose = verbose
+        self.errors = []
+        self.warnings = []
+
+    def log(self, message: str, level: str = 'INFO'):
+        if self.verbose or level in ('ERROR', 'WARNING'):
+            prefix = {'INFO': '✓', 'WARNING': '⚠', 'ERROR': '✗'}.get(level, ' ')
+            print(f"{prefix} {message}")
+
+    def validate_project(self, project_dir: Path) -> Tuple[bool, List[str], List[str]]:
+        """Validate research notebook(s) in a QC project directory.
+
+        Returns (is_valid, errors, warnings).
+        """
+        self.errors = []
+        self.warnings = []
+
+        if not project_dir.is_dir():
+            self.errors.append(f"Not a directory: {project_dir}")
+            return False, self.errors, self.warnings
+
+        # Find research notebooks
+        research_nbs = self._find_research_notebooks(project_dir)
+
+        if not research_nbs:
+            has_main = (project_dir / "main.py").exists()
+            if has_main:
+                self.warnings.append(
+                    f"Project {project_dir.name} has main.py but no research notebook"
+                )
+            return len(self.errors) == 0, self.errors, self.warnings
+
+        for nb_path in research_nbs:
+            self._validate_single_notebook(nb_path, project_dir)
+
+        return len(self.errors) == 0, self.errors, self.warnings
+
+    def _find_research_notebooks(self, project_dir: Path) -> List[Path]:
+        """Find research notebook files in project directory."""
+        patterns = ["research*.ipynb", "quantbook*.ipynb", "*_research.ipynb"]
+        found = []
+        for pattern in patterns:
+            found.extend(project_dir.glob(pattern))
+        return sorted(set(found))
+
+    def _validate_single_notebook(self, nb_path: Path, project_dir: Path):
+        """Run all research notebook checks on a single notebook."""
+        self.log(f"Validating research notebook: {nb_path.name}")
+
+        try:
+            with open(nb_path, "r", encoding="utf-8") as f:
+                nb = json.load(f)
+        except (json.JSONDecodeError, Exception) as e:
+            self.errors.append(f"{nb_path.name}: JSON error: {e}")
+            return
+
+        cells = nb.get("cells", [])
+        code_cells = [c for c in cells if c.get("cell_type") == "code"]
+
+        if not code_cells:
+            self.errors.append(f"{nb_path.name}: No code cells found")
+            return
+
+        self._check_execution(nb_path, code_cells)
+        self._check_no_stub_copy_paste(nb_path, code_cells)
+        self._check_sections(nb_path, cells)
+        self._check_quantbook_real(nb_path, code_cells)
+
+    def _check_execution(self, nb_path: Path, code_cells: List[dict]):
+        """Check that >30% of code cells have outputs."""
+        executed = [c for c in code_cells if c.get("outputs")]
+        ratio = len(executed) / len(code_cells) if code_cells else 0
+
+        if ratio == 0:
+            self.errors.append(
+                f"{nb_path.name}: 0% code cells executed ({len(code_cells)} cells) "
+                "- notebook must be executed via QC Cloud"
+            )
+        elif ratio < self.MIN_OUTPUT_RATIO:
+            self.errors.append(
+                f"{nb_path.name}: {ratio:.0%} code cells executed "
+                f"({len(executed)}/{len(code_cells)}), "
+                f"minimum {self.MIN_OUTPUT_RATIO:.0%} required"
+            )
+        else:
+            self.log(f"{nb_path.name}: {ratio:.0%} executed ({len(executed)}/{len(code_cells)})")
+
+    def _check_no_stub_copy_paste(self, nb_path: Path, code_cells: List[dict]):
+        """Detect identical code cells (copy-paste stub detection)."""
+        sources = []
+        for c in code_cells:
+            src = "".join(c.get("source", [])).strip()
+            if src:
+                sources.append(src)
+
+        if len(sources) < 2:
+            return
+
+        seen = {}
+        for i, src in enumerate(sources):
+            key = src[:200]
+            if key in seen:
+                self.warnings.append(
+                    f"{nb_path.name}: Cellules {seen[key]} et {i} "
+                    "ont un source identique (copy-paste suspect)"
+                )
+            else:
+                seen[key] = i
+
+    def _check_sections(self, nb_path: Path, cells: List[dict]):
+        """Check required research sections are present."""
+        all_text = ""
+        for c in cells:
+            src = "".join(c.get("source", []))
+            all_text += src + "\n"
+
+        all_text_lower = all_text.lower()
+
+        for pattern, section_name in self.REQUIRED_SECTIONS:
+            if re.search(pattern, all_text_lower):
+                self.log(f"{nb_path.name}: Section '{section_name}' found")
+            else:
+                self.warnings.append(
+                    f"{nb_path.name}: Section '{section_name}' not found "
+                    f"(pattern: {pattern})"
+                )
+
+    def _check_quantbook_real(self, nb_path: Path, code_cells: List[dict]):
+        """Check that QuantBook is actually instantiated in code (not just markdown)."""
+        has_qb_code = any(
+            "QuantBook()" in "".join(c.get("source", []))
+            for c in code_cells
+        )
+
+        if not has_qb_code:
+            # Check if it's a C# project (no QuantBook expected)
+            main_py = nb_path.parent / "main.py"
+            main_cs = nb_path.parent / "Main.cs"
+            if main_cs.exists() and not main_py.exists():
+                self.log(f"{nb_path.name}: C# project, QuantBook check skipped")
+                return
+
+            self.warnings.append(
+                f"{nb_path.name}: No QuantBook() instantiation found in code cells"
+            )
+        else:
+            self.log(f"{nb_path.name}: QuantBook() instantiation found")
+
+
+def validate_projects(
+    projects_dir: Path, verbose: bool = False
+) -> Dict[str, any]:
+    """Validate research notebooks across all QC projects.
+
+    Returns dict with total/valid/invalid counts and per-project results.
+    """
+    validator = ResearchNotebookValidator(verbose=verbose)
+    results = {"total": 0, "valid": 0, "invalid": 0, "results": []}
+
+    if not projects_dir.is_dir():
+        print(f"Not a directory: {projects_dir}")
+        return results
+
+    project_dirs = sorted(
+        d for d in projects_dir.iterdir()
+        if d.is_dir() and not d.name.startswith("_")
+    )
+
+    for proj_dir in project_dirs:
+        has_nb = any(proj_dir.glob("*.ipynb"))
+        if not has_nb:
+            continue
+
+        results["total"] += 1
+        is_valid, errors, warnings = validator.validate_project(proj_dir)
+        results["results"].append({
+            "project": proj_dir.name,
+            "valid": is_valid,
+            "errors": errors,
+            "warnings": warnings,
+        })
+        if is_valid:
+            results["valid"] += 1
+        else:
+            results["invalid"] += 1
+
+    return results
+
+
 def validate_directory(directory: Path, quick: bool = False, fix: bool = False,
                       verbose: bool = False, python_only: bool = False,
                       csharp_only: bool = False) -> Dict[str, any]:
@@ -396,6 +611,8 @@ def main():
     parser.add_argument('--verbose', action='store_true', help='Affichage détaillé')
     parser.add_argument('--python-only', action='store_true', help='Valider uniquement Python')
     parser.add_argument('--csharp-only', action='store_true', help='Valider uniquement C#')
+    parser.add_argument('--research', action='store_true',
+                        help='Validate research notebooks in QC projects')
 
     args = parser.parse_args()
 
@@ -410,37 +627,67 @@ def main():
     print("QuantConnect Notebooks Validator")
     print("=" * 70)
     print(f"Chemin : {path}")
-    print(f"Mode : {'Quick' if args.quick else 'Full'}")
+    print(f"Mode : {'Research' if args.research else 'Quick' if args.quick else 'Full'}")
     print(f"Fix : {'Enabled' if args.fix else 'Disabled'}")
     print(f"Verbose : {'Yes' if args.verbose else 'No'}")
     print("=" * 70)
     print()
 
-    # Valider
-    results = validate_directory(
-        path,
-        quick=args.quick,
-        fix=args.fix,
-        verbose=args.verbose,
-        python_only=args.python_only,
-        csharp_only=args.csharp_only
-    )
+    if args.research:
+        # Research notebook validation mode
+        projects_dir = path
+        if (path / "projects").is_dir():
+            projects_dir = path / "projects"
 
-    # Résumé
-    print()
-    print("=" * 70)
-    print("Résumé")
-    print("=" * 70)
-    print(f"Total notebooks : {results['total']}")
-    print(f"✓ Valides : {results['valid']}")
-    print(f"✗ Invalides : {results['invalid']}")
+        results = validate_projects(projects_dir, verbose=args.verbose)
 
-    if results['total'] > 0:
-        success_rate = (results['valid'] / results['total']) * 100
-        print(f"Taux de succès : {success_rate:.1f}%")
+        print()
+        print("=" * 70)
+        print("Research Notebooks Summary")
+        print("=" * 70)
+        print(f"Projects with notebooks : {results['total']}")
+        print(f"Valid : {results['valid']}")
+        print(f"Invalid : {results['invalid']}")
 
-    # Exit code
-    sys.exit(0 if results['invalid'] == 0 else 1)
+        if results['total'] > 0:
+            for r in results['results']:
+                status = "PASS" if r['valid'] else "FAIL"
+                print(f"  [{status}] {r['project']}")
+                for err in r['errors']:
+                    print(f"    ERROR: {err}")
+                if args.verbose:
+                    for warn in r['warnings']:
+                        print(f"    WARN: {warn}")
+
+            success_rate = (results['valid'] / results['total']) * 100
+            print(f"\nSuccess rate : {success_rate:.1f}%")
+
+        sys.exit(0 if results['invalid'] == 0 else 1)
+    else:
+        # Standard notebook validation
+        results = validate_directory(
+            path,
+            quick=args.quick,
+            fix=args.fix,
+            verbose=args.verbose,
+            python_only=args.python_only,
+            csharp_only=args.csharp_only
+        )
+
+        # Résumé
+        print()
+        print("=" * 70)
+        print("Résumé")
+        print("=" * 70)
+        print(f"Total notebooks : {results['total']}")
+        print(f"✓ Valides : {results['valid']}")
+        print(f"✗ Invalides : {results['invalid']}")
+
+        if results['total'] > 0:
+            success_rate = (results['valid'] / results['total']) * 100
+            print(f"Taux de succès : {success_rate:.1f}%")
+
+        sys.exit(0 if results['invalid'] == 0 else 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Add `ResearchNotebookValidator` class to `validate_qc_notebooks.py` implementing Issue #756 Phase D checks
- New `--research` CLI flag for project-level validation of QC research notebooks
- 16 unit tests covering all validation checks

## Checks Implemented
| Check | Criterion |
|-------|-----------|
| Execution rate | >30% code cells must have outputs |
| Required sections | Exploration, Iterations/Grid Search, Calibration/Conclusion |
| QuantBook real | `qb = QuantBook()` in code cells (skipped for C# projects) |
| Stub copy-paste | Identical code cell sources detected as warning |
| Project presence | Warns if project has main.py but no research notebook |

## Validation Results (63 QC projects with notebooks)
- **18 PASS** (28.6%) — executed research notebooks
- **45 FAIL** (71.4%) — primarily unexecuted notebooks needing QC Cloud execution

## Test plan
- [x] 16/16 unit tests pass (`test_validate_qc_research.py`)
- [x] Validated against all 63 QC projects in `projects/`
- [x] Existing `validate_qc_notebooks.py` standard mode unchanged
- [x] `--research` flag isolated from standard validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)