### PR TITLE
feat(ml): add walk-forward + multi-seed validation to eval_chronos_bolt

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_chronos_bolt.py
@@ -18,6 +18,13 @@ Usage:
     # Evaluate on SPY
     python eval_chronos_bolt.py --data-dir ../datasets/yfinance --symbol SPY
 
+    # Walk-forward 5-fold evaluation
+    python eval_chronos_bolt.py --data-dir ../datasets/yfinance --symbol SPY \
+        --walk-forward --n-splits 5
+
+    # Multi-seed validation (>=4 seeds, edge >= 2*std required for BEATS claim)
+    python eval_chronos_bolt.py --dry-run --seeds 0,1,7,42,99
+
 Output:
     results.json with metrics, regime breakdown, majority-class comparison
 """
@@ -141,7 +148,7 @@ def run_evaluation(args: argparse.Namespace) -> dict:
         symbol = args.symbol
 
     print(f"Data: {symbol}, {len(prices)} points")
-    baseline = compute_majority_baseline(prices.pct_change().dropna().values)
+    baseline = compute_majority_baseline(np.asarray(prices.pct_change().dropna().values))
     print(f"  Majority baseline: {baseline['majority_class_accuracy']:.4f}")
 
     windows = build_evaluation_windows(
@@ -199,6 +206,198 @@ def run_evaluation(args: argparse.Namespace) -> dict:
     return summary
 
 
+def run_walk_forward(args: argparse.Namespace) -> dict:
+    """Walk-forward K-fold evaluation respecting temporal ordering.
+
+    Each fold uses expanding window: train on [0..split_i], evaluate on
+    [split_i..split_i+pred_len]. No shuffle, no data leakage.
+    """
+    device = "cpu" if args.dry_run else "auto"
+    model = load_chronos_model(args.model_size, device=device)
+
+    if args.dry_run:
+        np.random.seed(42)
+        n_points = 500
+        dates = pd.date_range("2020-01-01", periods=n_points, freq="B")
+        prices = pd.Series(
+            np.cumsum(np.random.randn(n_points) * 0.01 + 100), index=dates
+        )
+        symbol = "SYNTHETIC"
+    else:
+        data_path = Path(args.data_dir)
+        prices_df = load_data(data_path, symbol=args.symbol)
+        prices = prices_df["Close"]
+        symbol = args.symbol
+
+    returns = prices.pct_change().dropna().values
+    n = len(returns)
+    n_splits = args.n_splits
+    fold_size = n // (n_splits + 1)
+
+    baseline = compute_majority_baseline(np.asarray(returns))
+    fold_results = []
+
+    for fold_i in range(n_splits):
+        split_point = fold_size * (fold_i + 1)
+        if split_point < args.seq_len:
+            continue
+        eval_end = min(split_point + args.pred_len + args.seq_len, n)
+        if split_point + args.seq_len >= eval_end:
+            continue
+
+        ctx = prices.iloc[split_point - args.seq_len : split_point].values
+        actual = prices.iloc[split_point : eval_end].values
+        actual_rets = returns[split_point : eval_end - 1]
+
+        window = {
+            "context": ctx,
+            "actual_prices": actual,
+            "actual_returns": actual_rets,
+            "start_date": str(prices.index[split_point - args.seq_len]),
+            "end_date": str(prices.index[min(eval_end - 1, n - 1)]),
+        }
+        metrics = evaluate_window(model, window, pred_len=args.pred_len, cost_bps=args.cost_bps)  # type: ignore[arg-type]
+        metrics["fold"] = fold_i
+        metrics["train_size"] = split_point
+        fold_results.append(metrics)
+        print(
+            f"  Fold {fold_i}: DirAcc={metrics['direction_accuracy']:.4f}, "
+            f"Sharpe={metrics['sharpe']:.3f} (train={split_point} pts)"
+        )
+
+    if not fold_results:
+        print("[WARN] No valid folds produced")
+        return {"n_folds": 0, "error": "insufficient data for walk-forward"}
+
+    avg_dir_acc = np.mean([r["direction_accuracy"] for r in fold_results])
+    avg_sharpe = np.mean([r["sharpe"] for r in fold_results])
+    edge = avg_dir_acc - baseline["majority_class_accuracy"]
+
+    summary = {
+        "model": model.model_id,
+        "is_mock": model.is_mock,
+        "symbol": symbol,
+        "evaluation_type": "walk_forward",
+        "n_splits": n_splits,
+        "n_folds": len(fold_results),
+        "avg_direction_accuracy": float(avg_dir_acc),
+        "avg_sharpe": float(avg_sharpe),
+        "majority_baseline": baseline,
+        "edge_vs_majority": float(edge),
+        "folds": fold_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    print(f"\n=== Walk-Forward Results ({len(fold_results)} folds) ===")
+    print(f"  Avg DirAcc: {avg_dir_acc:.4f}")
+    print(f"  Majority:   {baseline['majority_class_accuracy']:.4f}")
+    print(f"  Edge:       {edge:+.4f}")
+
+    if args.output_dir:
+        out_path = Path(args.output_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        out_file = out_path / f"chronos_wf_{symbol}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        with open(out_file, "w") as f:
+            json.dump(summary, f, indent=2)
+
+    return summary
+
+
+def run_multi_seed(args: argparse.Namespace) -> dict:
+    """Multi-seed validation per feedback_multi_seed_required.md.
+
+    BEATS claim requires >=4 seeds with edge >= 2*std cross-seed.
+    """
+    seeds = [int(s) for s in args.seeds.split(",")]
+    if len(seeds) < 4:
+        print(f"[WARN] {len(seeds)} seeds provided, >=4 recommended for BEATS claims")
+
+    device = "cpu" if args.dry_run else "auto"
+    model = load_chronos_model(args.model_size, device=device)
+
+    if args.dry_run:
+        symbol = "SYNTHETIC"
+    else:
+        symbol = args.symbol
+
+    seed_results = []
+    for seed in seeds:
+        np.random.seed(seed)
+
+        if args.dry_run:
+            n_points = args.seq_len + args.pred_len + args.n_windows * args.pred_len
+            dates = pd.date_range("2020-01-01", periods=n_points, freq="B")
+            prices = pd.Series(
+                np.cumsum(np.random.randn(n_points) * 0.01 + 100), index=dates
+            )
+        else:
+            data_path = Path(args.data_dir)
+            prices_df = load_data(data_path, symbol=symbol)
+            prices = prices_df["Close"]
+
+        baseline = compute_majority_baseline(
+            np.asarray(prices.pct_change().dropna().values)
+        )
+        windows = build_evaluation_windows(
+            prices, seq_len=args.seq_len, pred_len=args.pred_len, n_windows=args.n_windows
+        )
+
+        window_metrics = []
+        for window in windows:
+            m = evaluate_window(model, window, pred_len=args.pred_len, cost_bps=args.cost_bps)  # type: ignore[arg-type]
+            window_metrics.append(m)
+
+        avg_dir_acc = np.mean([m["direction_accuracy"] for m in window_metrics])
+        edge = avg_dir_acc - baseline["majority_class_accuracy"]
+
+        seed_results.append({
+            "seed": seed,
+            "avg_direction_accuracy": float(avg_dir_acc),
+            "majority_baseline": baseline["majority_class_accuracy"],
+            "edge_vs_majority": float(edge),
+        })
+        verdict = "BEATS" if edge > 0 else "FAILS"
+        print(f"  Seed {seed}: DirAcc={avg_dir_acc:.4f}, Edge={edge:+.4f} [{verdict}]")
+
+    edges = np.array([r["edge_vs_majority"] for r in seed_results])
+    mean_edge = float(np.mean(edges))
+    std_edge = float(np.std(edges))
+    n_beats = int(np.sum(edges > 0))
+
+    beats_valid = len(seeds) >= 4 and mean_edge > 0 and (
+        std_edge < 1e-10 or mean_edge >= 2 * std_edge
+    )
+
+    summary = {
+        "model": model.model_id,
+        "is_mock": model.is_mock,
+        "symbol": symbol,
+        "evaluation_type": "multi_seed",
+        "seeds": seeds,
+        "n_beats": n_beats,
+        "n_seeds": len(seeds),
+        "mean_edge": mean_edge,
+        "std_edge": std_edge,
+        "beats_valid": beats_valid,
+        "seed_results": seed_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    print(f"\n=== Multi-Seed Results ({len(seeds)} seeds) ===")
+    print(f"  Mean Edge: {mean_edge:+.4f} (std={std_edge:.4f})")
+    print(f"  BEATS: {n_beats}/{len(seeds)} seeds")
+    print(f"  Valid BEATS claim: {beats_valid}")
+
+    if args.output_dir:
+        out_path = Path(args.output_dir)
+        out_path.mkdir(parents=True, exist_ok=True)
+        out_file = out_path / f"chronos_multiseed_{symbol}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        with open(out_file, "w") as f:
+            json.dump(summary, f, indent=2)
+
+    return summary
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Chronos-Bolt zero-shot evaluation on financial time series"
@@ -211,11 +410,22 @@ def main():
     parser.add_argument("--seq-len", default=96, type=int)
     parser.add_argument("--pred-len", default=24, type=int)
     parser.add_argument("--n-windows", default=5, type=int)
+    parser.add_argument("--n-splits", default=5, type=int,
+                        help="Number of walk-forward folds")
     parser.add_argument("--cost-bps", default=10.0, type=float)
     parser.add_argument("--output-dir", default=None, type=str)
+    parser.add_argument("--walk-forward", action="store_true",
+                        help="Use walk-forward K-fold evaluation")
+    parser.add_argument("--seeds", default=None, type=str,
+                        help="Comma-separated seeds for multi-seed validation (e.g. 0,1,7,42,99)")
     args = parser.parse_args()
 
-    run_evaluation(args)
+    if args.seeds:
+        run_multi_seed(args)
+    elif args.walk_forward:
+        run_walk_forward(args)
+    else:
+        run_evaluation(args)
 
 
 if __name__ == "__main__":

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_chronos_bolt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_eval_chronos_bolt.py
@@ -15,6 +15,8 @@ from eval_chronos_bolt import (
     NaiveChronosWrapper,
     load_chronos_model,
     run_evaluation,
+    run_multi_seed,
+    run_walk_forward,
 )
 
 
@@ -169,3 +171,162 @@ class TestRunEvaluationDryRun:
         result = run_evaluation(args)
         expected = result["avg_direction_accuracy"] - result["majority_baseline"]["majority_class_accuracy"]
         assert abs(result["edge_vs_majority"] - expected) < 1e-6
+
+
+class TestRunWalkForwardDryRun:
+    """Walk-forward K-fold dry-run tests."""
+
+    def _make_wf_args(self, **overrides):
+        defaults = {
+            "dry_run": True,
+            "data_dir": "",
+            "symbol": "SPY",
+            "model_size": "base",
+            "seq_len": 30,
+            "pred_len": 5,
+            "n_windows": 3,
+            "n_splits": 3,
+            "cost_bps": 10.0,
+            "output_dir": None,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_returns_summary_dict(self):
+        args = self._make_wf_args()
+        result = run_walk_forward(args)
+        assert isinstance(result, dict)
+
+    def test_evaluation_type(self):
+        args = self._make_wf_args()
+        result = run_walk_forward(args)
+        assert result["evaluation_type"] == "walk_forward"
+
+    def test_has_expected_keys(self):
+        args = self._make_wf_args()
+        result = run_walk_forward(args)
+        for key in [
+            "model", "is_mock", "symbol", "n_splits", "n_folds",
+            "avg_direction_accuracy", "avg_sharpe", "majority_baseline",
+            "edge_vs_majority", "folds", "timestamp",
+        ]:
+            assert key in result, f"Missing key: {key}"
+
+    def test_folds_produced(self):
+        args = self._make_wf_args(n_splits=3)
+        result = run_walk_forward(args)
+        assert result["n_folds"] > 0
+        assert len(result["folds"]) == result["n_folds"]
+
+    def test_fold_keys(self):
+        args = self._make_wf_args(n_splits=2, seq_len=30, pred_len=5)
+        result = run_walk_forward(args)
+        if result["folds"]:
+            fold = result["folds"][0]
+            for key in ["direction_accuracy", "mse", "sharpe", "fold", "train_size"]:
+                assert key in fold, f"Missing fold key: {key}"
+
+    def test_direction_accuracy_bounded(self):
+        args = self._make_wf_args()
+        result = run_walk_forward(args)
+        assert 0.0 <= result["avg_direction_accuracy"] <= 1.0
+
+    def test_edge_vs_majority(self):
+        args = self._make_wf_args()
+        result = run_walk_forward(args)
+        expected = result["avg_direction_accuracy"] - result["majority_baseline"]["majority_class_accuracy"]
+        assert abs(result["edge_vs_majority"] - expected) < 1e-6
+
+    def test_output_dir_creates_file(self, tmp_path):
+        args = self._make_wf_args(output_dir=str(tmp_path / "wf_results"))
+        result = run_walk_forward(args)
+        out_files = list((tmp_path / "wf_results").glob("chronos_wf_*.json"))
+        assert len(out_files) == 1
+        data = json.loads(out_files[0].read_text())
+        assert data["evaluation_type"] == "walk_forward"
+
+    def test_insufficient_data_returns_error(self):
+        args = self._make_wf_args(seq_len=400, pred_len=100, n_splits=20)
+        result = run_walk_forward(args)
+        assert result.get("n_folds", 0) == 0 or "error" in result
+
+
+class TestRunMultiSeedDryRun:
+    """Multi-seed validation dry-run tests."""
+
+    def _make_ms_args(self, **overrides):
+        defaults = {
+            "dry_run": True,
+            "data_dir": "",
+            "symbol": "SPY",
+            "model_size": "base",
+            "seq_len": 50,
+            "pred_len": 10,
+            "n_windows": 3,
+            "n_splits": 5,
+            "cost_bps": 10.0,
+            "output_dir": None,
+            "seeds": "0,1,7,42",
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_returns_summary_dict(self):
+        args = self._make_ms_args()
+        result = run_multi_seed(args)
+        assert isinstance(result, dict)
+
+    def test_evaluation_type(self):
+        args = self._make_ms_args()
+        result = run_multi_seed(args)
+        assert result["evaluation_type"] == "multi_seed"
+
+    def test_has_expected_keys(self):
+        args = self._make_ms_args()
+        result = run_multi_seed(args)
+        for key in [
+            "model", "is_mock", "symbol", "seeds", "n_seeds",
+            "n_beats", "mean_edge", "std_edge", "beats_valid",
+            "seed_results", "timestamp",
+        ]:
+            assert key in result, f"Missing key: {key}"
+
+    def test_seed_count(self):
+        args = self._make_ms_args(seeds="0,1,7,42")
+        result = run_multi_seed(args)
+        assert result["n_seeds"] == 4
+        assert len(result["seed_results"]) == 4
+
+    def test_seed_results_structure(self):
+        args = self._make_ms_args(seeds="0,42")
+        result = run_multi_seed(args)
+        for sr in result["seed_results"]:
+            for key in ["seed", "avg_direction_accuracy", "majority_baseline", "edge_vs_majority"]:
+                assert key in sr, f"Missing seed result key: {key}"
+
+    def test_beats_count_consistent(self):
+        args = self._make_ms_args(seeds="0,1,7,42")
+        result = run_multi_seed(args)
+        edges = [sr["edge_vs_majority"] for sr in result["seed_results"]]
+        expected_beats = sum(1 for e in edges if e > 0)
+        assert result["n_beats"] == expected_beats
+
+    def test_beats_valid_requires_4_seeds(self):
+        args = self._make_ms_args(seeds="0,1")
+        result = run_multi_seed(args)
+        assert result["beats_valid"] is False
+
+    def test_output_dir_creates_file(self, tmp_path):
+        args = self._make_ms_args(output_dir=str(tmp_path / "ms_results"))
+        result = run_multi_seed(args)
+        out_files = list((tmp_path / "ms_results").glob("chronos_multiseed_*.json"))
+        assert len(out_files) == 1
+        data = json.loads(out_files[0].read_text())
+        assert data["evaluation_type"] == "multi_seed"
+
+    def test_mean_edge_is_average(self):
+        args = self._make_ms_args(seeds="0,42")
+        result = run_multi_seed(args)
+        edges = [sr["edge_vs_majority"] for sr in result["seed_results"]]
+        expected_mean = float(np.mean(edges))
+        assert abs(result["mean_edge"] - expected_mean) < 1e-6


### PR DESCRIPTION
## Summary
- Add **walk-forward K-fold** evaluation mode (`--walk-forward --n-splits 5`) with expanding window, temporal ordering, no shuffle, no data leakage
- Add **multi-seed validation** mode (`--seeds 0,1,7,42,99`) per `feedback_multi_seed_required.md` rule: BEATS claim requires >=4 seeds with edge >= 2*std cross-seed
- Fix `seq_len` guard for insufficient data edge case (empty context crash)
- Fix `np.asarray` wrappers for pandas `.values` type safety

## Test plan
- [x] 18 new tests added (9 walk-forward, 9 multi-seed) — all passing
- [x] Full ML test suite: 575/575 passed (no regression)
- [x] Dry-run mode validates synthetic data end-to-end
- [x] Edge cases: insufficient data, <4 seeds, output file creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)