### PR TITLE
docs: rewrite 2026 curriculum + CONTRIBUTING validation tooling (#48)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Vous pouvez contribuer de plusieurs façons :
 ### 2. Développement
 
 1. **Créez une branche** pour votre contribution :
-   ```
+
+   ```bash
    git checkout -b type/nom-court-descriptif
    ```
    Exemples : `feature/notebook-transformers`, `fix/ml-example-bug`, `docs/improve-readme`
@@ -38,13 +39,15 @@ Vous pouvez contribuer de plusieurs façons :
 ### 3. Soumission
 
 1. **Committez vos changements** avec des messages clairs et descriptifs :
-   ```
+
+   ```bash
    git commit -m "Type: description courte de la modification"
    ```
    Exemples : `"Add: notebook sur les Transformers"`, `"Fix: correction d'erreurs dans l'exemple ML.NET"`
 
 2. **Poussez votre branche** vers votre fork :
-   ```
+
+   ```bash
    git push origin nom-de-votre-branche
    ```
 
@@ -76,7 +79,7 @@ Vous pouvez contribuer de plusieurs façons :
 - **Complétude** : Couvrir les aspects importants du sujet
 - **Références** : Citer les sources et proposer des lectures complémentaires
 
-## 🧪 Tests et validation
+## Tests et validation
 
 Avant de soumettre votre contribution, assurez-vous que :
 
@@ -84,6 +87,27 @@ Avant de soumettre votre contribution, assurez-vous que :
 2. Le code est conforme aux standards du projet
 3. Les explications sont claires et pédagogiquement pertinentes
 4. Les dépendances sont correctement documentées
+
+### Validation automatisee
+
+Le depot dispose de scripts de validation pour verifier la qualite des notebooks :
+
+```bash
+# Validation structure (verifie metadata, outputs, kernel)
+python scripts/notebook_tools/notebook_tools.py validate <path>
+
+# Execution complete (Papermill, verifie que toutes les cellules passent)
+python scripts/notebook_tools/notebook_tools.py execute <path>
+
+# Analyse structure (stats cellules, outputs, index NIE)
+python scripts/notebook_tools/notebook_tools.py analyze <path>
+```
+
+### Conventions notebooks
+
+- **Pas d'erreur volontaire** : `raise NotImplementedError`, `assert False`, `1/0` sont interdits. Les cellules d'exercice utilisent `pass`, `print("Exercice a completer")`, ou `return None`
+- **Outputs inclus** : les notebooks sont committes avec leurs outputs d'execution (sauf donnees sensibles)
+- **Pas d'emojis** dans le code, les noms de variables ou les fichiers genere
 
 ## 📚 Ressources utiles
 

--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/README.md
@@ -2,6 +2,10 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Services](00-2-Docker-Services-Management.ipynb)
 
+## Introduction : Pourquoi cet setup est crucial
+
+Avant de plonger dans l'univers des modèles de génération IA, prenez un moment pour comprendre pourquoi une configuration rigoureuse évite 80% des problèmes techniques. Les notebooks GenAI font appel à des services externes, des conteneurs Docker et des modèles complexes – une seule variable d'environnement manquante peut bloquer toute votre exploration. Ce module vous guide pas à pas pour créer une base solide, vous permettant de vous concentrer sur l'essentiel : apprendre et expérimenter avec l'IA.
+
 ## Vue d'Ensemble
 [GREEN] Setup et Configuration
 
@@ -11,22 +15,30 @@
 
 | # | Notebook | Description | Validation |
 |---|----------|-------------|------------|
-| 1 | [00-1-Environment-Setup](00-1-Environment-Setup.ipynb) | Configuration environnement complet | ✅ |
-| 2 | [00-2-Docker-Services-Management](00-2-Docker-Services-Management.ipynb) | Gestion services conteneurisés | ✅ |
-| 3 | [00-3-API-Endpoints-Configuration](00-3-API-Endpoints-Configuration.ipynb) | Configuration endpoints API | ✅ |
-| 4 | [00-4-Environment-Validation](00-4-Environment-Validation.ipynb) | Tests et validation setup | ✅ |
-| 5 | [00-5-ComfyUI-Local-Test](00-5-ComfyUI-Local-Test.ipynb) | Test local des services ComfyUI | ✅ |
-| 6 | [00-6-Local-Docker-Deployment](00-6-Local-Docker-Deployment.ipynb) | Déploiement Docker local complet | ✅ |
+| 1 | [00-1-Environment-Setup](00-1-Environment-Setup.ipynb) | Configuration environnement complet | OK |
+| 2 | [00-2-Docker-Services-Management](00-2-Docker-Services-Management.ipynb) | Gestion services conteneurises | OK |
+| 3 | [00-3-API-Endpoints-Configuration](00-3-API-Endpoints-Configuration.ipynb) | Configuration endpoints API | OK |
+| 4 | [00-4-Environment-Validation](00-4-Environment-Validation.ipynb) | Tests et validation setup | OK |
+| 5 | [00-5-ComfyUI-Local-Test](00-5-ComfyUI-Local-Test.ipynb) | Test local des services ComfyUI | OK |
+| 6 | [00-6-Local-Docker-Deployment](00-6-Local-Docker-Deployment.ipynb) | Deploiement Docker local complet | OK |
 
-## Prerequis
-- Configuration .env avec cles API
-- Python 3.11+ avec dependances
+## Prérequis
+- Configuration .env avec clés API
+- Python 3.11+ avec dépendances
 - Variables d'environnement OpenRouter
 
-## Utilisation
-1. Configurer l'environnement selon 00-GenAI-Environment
-2. Executer les notebooks dans l'ordre numerique
-3. Verifier les outputs dans /outputs/
+## Ce que vous saurez faire
 
----
-*Genere automatiquement par Phase 2.1 - 20251008_050730*
+À l'issue de ce module, vous serez capable de :
+- Configurer un environnement Python complet pour le développement GenAI
+- Gérer des services Docker conteneurisés (ComfyUI, modèles de langue)
+- Paramétrer les endpoints API pour les services IA
+- Valifier que chaque composant fonctionne correctement
+- Déployer localement l'ensemble de l'infrastructure GenAI
+- Résoudre les problèmes courants de configuration
+
+## Utilisation
+
+1. Configurer l'environnement selon 00-GenAI-Environment
+2. Exécuter les notebooks dans l'ordre numérique
+3. Vérifier les outputs dans /outputs/

--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -2,17 +2,23 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Video Workflows](../Video/README.md)
 
-Serie complete de notebooks pour le traitement audio par IA generative : reconnaissance vocale, synthese vocale, clonage de voix, generation musicale et separation de sources.
+Bienvenue dans l'univers fascinant de l'audio IA ! Souvent négligé au profit des images et du texte, le traitement audio représente pourtant la modalité la plus accessible et naturelle de l'interaction humaine. Que ce soit à travers la voix, la musique ou le son, l'IA révolutionne notre manière de communiquer, créer et comprendre le monde sonore.
+
+Cette série vous emmène au cœur des technologies audio IA, des bases de reconnaissance vocale aux applications de production professionnelle. Parcourez 21 notebooks complets qui vous guideront des fondements aux cas d'usage avancés.
+
+## Fil rouge : Création d'un podcast automatisé
+
+Le projet phare de cette série est la création d'un podcast automatisé entièrement généré par IA :
+- Synthèse vocale personnalisée avec Kokoro TTS et XTTS v2
+- Génération de musique de fond adaptée au mood avec MusicGen
+- Orchestration complète des services pour une production audio cohérente
+- Integration avec des systèmes de transcription pour la post-production
+
+C'est le projet ultime pour démontrer comment ces technologies s'articulent pour créer une solution concrète et professionnelle.
 
 ## Vue d'ensemble
 
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 21 |
-| Sous-dossiers | 4 niveaux |
-| Kernel | Python 3 |
-| Duree totale | ~14-16h |
-| Validation | 100% (21/21 notebooks) |
+21 notebooks répartis sur 4 niveaux de progression, constituant un parcours complet d'environ 14 à 16 d'apprentissage pratique, 100% validés pour garantir une expérience sans erreur.
 
 ## Structure
 

--- a/MyIA.AI.Notebooks/GenAI/EPF/README.md
+++ b/MyIA.AI.Notebooks/GenAI/EPF/README.md
@@ -2,30 +2,31 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Projet Fort Boyard](fort-boyard-python.ipynb)
 
-Projets realises par les etudiants EPF dans le cadre du cours IA101, utilisant les technologies d'IA generative.
+Bienvenue dans la galerie de projets réalisés par les étudiants de l'EPF dans le cadre du cours IA101. Ces notebooks illustrent la créativité et les compétences acquises en utilisant les technologies d'IA générative pour résoudre des problèmes concrets et innovants.
 
-## Vue d'ensemble
+## Ce que ces projets illustrent
 
-| Statistique | Valeur |
-|-------------|--------|
-| Projets | 4 |
-| Kernel | Python |
-| Contexte | Cours IA101 EPF 2026 |
-| Validation | 100% (4/4 projets) |
-| Sous-READMEs | 3 |
+Cette collection démontre la richesse des applications de l'IA générative à travers quatre approches complémentaires :
+
+- **Création artistique** : génération d'images hybrides entre univers Barbie et Shrek
+- **Assistance quotidienne** : création intelligente de recettes de cuisine sur mesure
+- **Éducation santé** : chatbot médical pour apprentissage interactif
+- **Jeux interactifs** : réinvention du Fort Boyard avec une intelligence narrative
+
+Chaque projet explore comment l'IA générative peut transformer différents domaines de notre quotidien.
 
 ## Projets
 
 | Projet | Auteurs | Description |
 |--------|---------|-------------|
-| [barbie-schreck](Carole%20%26%20Cléo/barbie-schreck.ipynb) | Carole & Cleo | Generation d'images style Barbie/Shrek |
-| [receipe_maker](Dorian%20%26%20Bastien/cuisine/receipe_maker.ipynb) | Dorian & Bastien | Generateur de recettes de cuisine |
-| [medical_chatbot](Louise%20et%20Jeanne%20Céline/medical_chatbot.ipynb) | Louise & Jeanne Celine | Chatbot medical educatif |
+| [barbie-schreck](Carole%20%26%20Cléo/barbie-schreck.ipynb) | Carole & Cleo | Génération d'images style Barbie/Shrek |
+| [receipe_maker](Dorian%20%26%20Bastien/cuisine/receipe_maker.ipynb) | Dorian & Bastien | Générateur de recettes de cuisine |
+| [medical_chatbot](Louise%20et%20Jeanne%20Céline/medical_chatbot.ipynb) | Louise & Jeanne Céline | Chatbot médical éducatif |
 | [fort-boyard-python](fort-boyard-python.ipynb) | - | Jeu Fort Boyard en Python |
 
-## Structure
+## Structure des projets
 
-```
+```text
 EPF/
 ├── Carole & Cleo/
 │   ├── barbie-schreck.ipynb
@@ -51,13 +52,15 @@ EPF/
 | medical_chatbot | OpenAI GPT, Streamlit |
 | fort-boyard | OpenAI GPT |
 
-## Prerequisites
+## Prérequis techniques
+
+Les notebooks suivants nécessitent l'installation de ces bibliothèques Python :
 
 ```bash
 pip install openai langchain python-dotenv pillow
 ```
 
-Configuration API dans `GenAI/.env` :
+Configuration requise dans `GenAI/.env` :
 ```
 OPENAI_API_KEY=sk-...
 ```

--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -1,26 +1,31 @@
-# Image - Generation d'Images par IA
+# Image - Génération d'Images par IA
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Management](../00-GenAI-Environment/00-2-Docker-Services-Management.ipynb)
 
-Serie complete de notebooks pour la generation et l'edition d'images par IA generative, couvrant les modeles de base jusqu'aux workflows de production.
+La génération d'images par IA représente l'une des entrées les plus intuitives et captivantes dans le monde de l'intelligence artificielle. À l'intersection entre créativité artistique et contrôle technique, elle offre un moyen unique de transformer des concepts abstraits en contenus visuels concrets, parfaits pour enrichir les ressources éducatives.
+
+## Fil rouge : Construction d'un générateur de contenu visuel éducatif
+
+Ce parcours vous guide dans la création d'un système capable de générer divers types de contenu visuel pour l'éducation :
+- **Diagrammes pédagogiques** complexes expliquant des mécanismes abstraits
+- **Illustrations conceptuelles** pour rendre les idées scientifiques accessibles
+- **Modèles décoratifs** personnalisés pour l'identité visuelle des supports de cours
+- **Visualisations interactives** combinant texte et images pour une meilleure rétention
+
+Chaque étape de ce fil rouge est conçue pour vous apprendre à maîtriser à la fois les techniques de génération et leur application pratique dans un contexte éducatif.
 
 ## Vue d'ensemble
 
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 19 |
-| Sous-dossiers | 5 (4 niveaux + examples) |
-| Kernel | Python 3 |
-| Duree totale | ~6-8h |
-| Validation | 100% (19/19 notebooks) |
+19 notebooks organisés en 5 sous-dossiers, représentant environ 6 à 8 heures d'apprentissage intensif dans le domaine de la génération d'images par IA, avec un taux de validation de 100%.
+
 
 ## Structure
 
 ```
 Image/
-├── 01-Foundation/     # Modeles de base (5 notebooks)
-├── 02-Advanced/       # Modeles avances (4 notebooks)
-├── 03-Orchestration/  # Multi-modeles (3 notebooks)
+├── 01-Foundation/     # Modèles de base (5 notebooks)
+├── 02-Advanced/       # Modèles avancés (4 notebooks)
+├── 03-Orchestration/  # Multi-modèles (3 notebooks)
 ├── 04-Applications/   # Production (4 notebooks)
 └── examples/          # Cas d'usage (3 notebooks)
 ```

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -8,517 +8,210 @@ maturity: ALPHA=60, DRAFT=24, PRODUCTION=10, BETA=5
 updated: 2026-05-06
 -->
 
-Ecosysteme modulaire de generation de contenu par Intelligence Artificielle : images, texte, agents et vibe-coding.
+Ce parcours vous forme a la maitrise de l'IA generative dans toute sa diversite : generer des images, synthetiser la voix, composer de la musique, produire des videos, orchestrer des agents autonomes, et deployer des applications en production. Chaque modalite suit une progression en quatre niveaux, du premier pas avec une API jusqu'aux pipelines multi-modeles de production.
 
-## Vue d'ensemble
+**105 notebooks** | **9 sous-domaines** | **~90-100h** | **95%+ valides**
 
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 105 |
-| Sous-domaines | 9 (Environment, Image, Audio, Video, Texte, SemanticKernel, EPF, Vibe-Coding, Playwright-OWUI) |
-| Duree totale | ~90-100h |
-| Taux validation | 95%+ |
+## Pourquoi ce parcours ?
+
+L'IA generative a transforme la creation de contenu en 2024-2026. Un developpeur qui sait piloter DALL-E pour generer une illustration, Whisper pour transcrire un podcast, MusicGen pour composer un fond sonore, et orchestrer tout cela via des agents autonomes, possede un avantage decisive sur le marche. Ce parcours ne se contente pas d'enumerer des APIs : il vous apprend a **comprendre** les modeles (leurs forces, leurs limites, leurs pieges), a **comparer** les approches (open-source vs cloud, local vs API), et a **combiner** les modalites dans des pipelines reels.
 
 ## Structure
 
-```
+```text
 GenAI/
 ├── 00-GenAI-Environment/    # Setup et configuration (6 notebooks)
-├── Image/                   # Generation d'images (19 notebooks + 4 sub-READMEs)
-├── Audio/                   # Speech, TTS, musique, separation (21 notebooks + 4 sub-READMEs)
-├── Video/                   # Generation et comprehension video (16 notebooks + 4 sub-READMEs)
+├── Image/                   # Generation d'images (19 notebooks)
+├── Audio/                   # Speech, TTS, musique, separation (21 notebooks)
+├── Video/                   # Generation et comprehension video (16 notebooks)
 ├── Texte/                   # LLMs et generation de texte (10 notebooks)
-├── SemanticKernel/          # Microsoft Semantic Kernel (14 notebooks)
-├── EPF/                     # Projets etudiants (4 notebooks + 3 sub-READMEs)
-├── Playwright-OWUI/         # Tests E2E Playwright sur Open WebUI (5 modules, 30+ tests)
+├── SemanticKernel/          # Microsoft Semantic Kernel (20 notebooks)
+├── EPF/                     # Projets etudiants (4 notebooks)
+├── Playwright-OWUI/         # Tests E2E Playwright (5 modules, 30+ tests)
 └── Vibe-Coding/             # Tutorials Claude Code et Roo Code
 ```
 
-## Sous-domaines
+---
 
-### 00-GenAI-Environment - Setup et Infrastructure
-*Niveau Debutant | Prerequis obligatoires*
-*Validation: 100% (6/6 notebooks)*
+## Les sous-domaines
 
-| Notebook | Description | Technologies |
-|----------|-------------|--------------|
-| **00-1-Environment-Setup** | Configuration environnement complet | Python, Docker, API Keys |
-| **00-2-Docker-Services-Management** | Gestion services conteneurisés | Docker Compose, Portainer |
-| **00-3-API-Endpoints-Configuration** | Configuration endpoints API | OpenAI, Hugging Face, Local |
-| **00-4-Environment-Validation** | Tests et validation setup | Pytest, Monitoring |
-| **00-5-ComfyUI-Local-Test** | Test local des services ComfyUI | ComfyUI, Bearer Token |
-| **00-6-Local-Docker-Deployment** | Deploiement Docker local complet | Docker Compose, GPU |
+### 00-GenAI-Environment - Votre point de depart
 
-### 🖼️ **01-Images-Foundation** (Modèles Base)
-*🟢 Niveau Débutant | Introduction aux fondamentaux*
-*Validation: 100% (5/5 notebooks)*
+Avant de generer la moindre image ou le moindre son, il faut configurer l'environnement : cles API, services Docker, et validation que tout fonctionne. Ces 6 notebooks sont le passage obligatoire. Ils couvrent le setup Python, la gestion des conteneurs Docker (ComfyUI, Whisper, MusicGen), la configuration des endpoints API, et un test complet de validation.
 
-| Notebook | Description | Technologies |
-|----------|-------------|--------------|
-| **01-1-OpenAI-DALL-E-3** | Génération images DALL-E 3 | OpenAI API, PIL, Prompting |
-| **01-2-GPT-5-Image-Generation** | GPT-5 pour création visuelle | GPT-5 API, Vision multimodale |
-| **01-3-Basic-Image-Operations** | Opérations images de base | PIL, OpenCV, Transforms |
-
-### 🎨 **02-Images-Advanced** (Techniques Avancées)
-*🟠 Niveau Intermédiaire | Modèles spécialisés*
-*Validation: 100% (4/4 notebooks)*
-
-| Notebook | Description | Technologies |
-|----------|-------------|--------------|
-| **02-1-Qwen-Image-Edit-2509** | Édition avancée Qwen 2.5 | Qwen API, InPainting |
-| **02-2-FLUX-1-Advanced-Generation** | Génération haute qualité FLUX | FLUX.1, LoRA, Fine-tuning |
-| **02-3-Stable-Diffusion-3-5** | Stable Diffusion production | SD 3.5, ControlNet, Custom |
-| **02-4-Z-Image-Lumina2** | Génération Z-Image (Lumina-2) | ComfyUI, Gemma-2, WanVAE |
-
-### 🔄 **03-Images-Orchestration** (Multi-Modèles)
-*🔴 Niveau Expert | Orchestration complexe*
-*Validation: 100% (3/3 notebooks)*
-
-| Notebook | Description | Technologies |
-|----------|-------------|--------------|
-| **03-1-Multi-Model-Comparison** | Comparaison performances | Benchmarking, Métriques |
-| **03-2-Workflow-Orchestration** | Chaînage modèles complexes | Langchain, Workflows |
-| **03-3-Performance-Optimization** | Optimisation et scaling | Caching, Load Balancing |
-
-### 🏗️ **04-Images-Applications** (Applications Métier)
-*🔴 Niveau Expert | Cas d'usage production*
-*Validation: 100% (4/4 notebooks)*
-
-| Notebook | Description | Technologies |
-|----------|-------------|--------------|
-| **04-1-Educational-Content-Generation** | Contenu éducatif automatisé | Curriculum, Adaptive Learning |
-| **04-2-Creative-Workflows** | Workflows créatifs avancés | Design Systems, Branding |
-| **04-3-Production-Integration** | Intégration systèmes production | APIs, Microservices |
-| **04-3-Cross-Stitch-Pattern-Maker-Legacy** | Générateur motifs point de croix | DMC Colors, Pattern Generation |
-
-### Audio/ - Speech, Voix & Musique par IA
-
-*Serie complete pour le traitement audio par IA generative (16 notebooks)*
-*Validation: 100% (16/16 notebooks)*
-
-| Niveau | Notebooks | Contenu |
-|--------|-----------|---------|
-| **Foundation** | 01-1 a 01-5 | OpenAI TTS, Whisper STT, operations audio, Whisper local, Kokoro TTS |
-| **Advanced** | 02-1 a 02-4 | Chatterbox TTS, XTTS voice cloning, MusicGen, Demucs separation |
-| **Orchestration** | 03-1 a 03-3 | Multi-model comparison, pipelines, temps reel |
-| **Applications** | 04-1 a 04-4 | Contenu educatif, transcription, composition musicale, sync A/V |
-
-[README Audio](Audio/README.md)
-
-### Video/ - Generation & Comprehension Video par IA
-
-*Serie complete pour la generation et comprehension video par IA (16 notebooks)*
-*Validation: 100% (16/16 notebooks)*
-
-| Niveau | Notebooks | Contenu |
-|--------|-----------|---------|
-| **Foundation** | 01-1 a 01-5 | Operations video, GPT-5 understanding, Qwen-VL, ESRGAN, AnimateDiff |
-| **Advanced** | 02-1 a 02-4 | HunyuanVideo, LTX-Video, Wan, SVD image-to-video |
-| **Orchestration** | 03-1 a 03-3 | Multi-model comparison, workflows, ComfyUI Video |
-| **Applications** | 04-1 a 04-4 | Video educative, workflows creatifs, Sora API, production |
-
-[README Video](Video/README.md)
-
-### Texte/ - Generation de Texte par IA
-
-*Serie complete sur les LLMs et APIs OpenAI modernes (10 notebooks)*
-*Validation: 100% (10/10 notebooks)*
-
-| Tier | Notebooks | Contenu |
-|------|-----------|---------|
-| **Fondations** | 1-2 | OpenAI Intro, Prompt Engineering |
-| **Sorties Structurees** | 3-4 | Structured Outputs, Function Calling |
-| **Augmentation** | 5-7 | RAG moderne, PDF/Web Search, Code Interpreter |
-| **Avance** | 8-10 | Reasoning Models, Production Patterns, Local LLMs |
-
-[README Texte](Texte/README.md)
-
-### SemanticKernel/ - Microsoft Semantic Kernel
-
-*SDK pour integration LLMs dans applications .NET/Python (20 notebooks)*
-*Validation: 85% (17/20 notebooks)*
-
-| Section | Notebooks | Contenu |
-|---------|-----------|---------|
-| **Serie principale** | 01-08 | Fundamentals, Functions, Agents, Filters, VectorStores, Process, MultiModal, MCP |
-| **Interop avancee** | 09-10 | Python/C# CLR, NotebookMaker (3 variantes) |
-| **Templates** | 3 | Templates C# et Python |
-
-[README SemanticKernel](SemanticKernel/README.md)
-
-### EPF/ - Projets Etudiants
-
-*Projets realises par les etudiants EPF (4 notebooks)*
-
-| Projet | Auteurs | Description |
-|--------|---------|-------------|
-| barbie-schreck | Carole & Cleo | Generation images style Barbie/Shrek |
-| receipe_maker | Dorian & Bastien | Generateur de recettes |
-| medical_chatbot | Louise & Jeanne Celine | Chatbot medical educatif |
-| fort-boyard-python | - | Challenges style Fort Boyard |
-
-[README EPF](EPF/README.md)
-
-### Playwright-OWUI/ - Tests E2E sur Open WebUI
-
-*Serie pedagogique Playwright pour tester une application GenAI reelle (5 modules, 30+ tests)*
-*Technologies: Playwright, TypeScript, Open WebUI*
-
-| Module | Nom | Duree | Niveau |
-|--------|-----|-------|--------|
-| 01 | Decouverte de Playwright & OWUI | 2-3h | Debutant |
-| 02 | Navigation & Authentification | 2-3h | Debutant+ |
-| 03 | Chat & Streaming LLM | 3h | Intermediaire |
-| 04 | RAG, Outils MCP & Avances | 3h | Intermediaire+ |
-| 05 | Multi-tenant, API & CI/CD | 3-4h | Expert |
-
-[README Playwright-OWUI](Playwright-OWUI/README.md)
-
-### Vibe-Coding/ - Tutorials IA Generative pour Developpeurs
-
-*Ateliers Claude Code et Roo Code*
-
-| Section | Contenu | Duree |
-|---------|---------|-------|
-| Claude-Code | 5 modules (decouverte a automatisation) | 13-16h |
-| Roo-Code | 5 modules + ateliers avances | ~15h |
-
-[README Vibe-Coding](Vibe-Coding/README.md)
+[README complet](00-GenAI-Environment/README.md) | 6 notebooks | ~4h
 
 ---
 
-## Liens vers sous-README
+### Image - Generer, editer et orchestrer des images
 
-| Sous-domaine | README |
-|--------------|--------|
-| Image | [Image/README.md](Image/README.md) |
-| Audio | [Audio/README.md](Audio/README.md) |
-| Video | [Video/README.md](Video/README.md) |
-| Texte | [Texte/README.md](Texte/README.md) |
-| SemanticKernel | [SemanticKernel/README.md](SemanticKernel/README.md) |
-| EPF | [EPF/README.md](EPF/README.md) |
-| Playwright-OWUI | [Playwright-OWUI/README.md](Playwright-OWUI/README.md) |
-| Vibe-Coding | [Vibe-Coding/README.md](Vibe-Coding/README.md) |
+On commence par les fondamentaux : appeler DALL-E 3 et GPT-5 pour generer des images depuis un prompt texte, puis manipuler ces images avec PIL et OpenCV. Le niveau avance introduit les modeles open-source heberges localement (Qwen Image Edit pour l'edition, FLUX pour la qualite, Stable Diffusion 3.5 pour la production, Z-Image/Lumina pour l'experimental). En orchestration, on compare les modeles entre eux et on enchaine les workflows. Les applications metier montrent comment integrer tout cela dans des cas reels : contenu educatif, workflows creatifs, motifs decoratifs.
+
+**Fil rouge** : construire un generateur de contenu visuel pour l'education (diagrammes scientifiques, illustrations pedagogiques, motifs decoratifs).
+
+[README complet](Image/README.md) | 19 notebooks | ~6-8h
 
 ---
 
-## Statut des Modules
+### Audio - Parler, ecouter, composer
 
-| Module | Statut | Validation | Description |
-|--------|--------|------------|-------------|
-| 00-GenAI-Environment | Complet | 100% (6/6) | Setup et configuration |
-| 01-Images-Foundation | Complet | 100% (5/5) + README | DALL-E 3, GPT-5, Forge, Qwen |
-| 02-Images-Advanced | Complet | 100% (4/4) + README | Qwen 2509, FLUX, SD 3.5, Z-Image |
-| 03-Images-Orchestration | Complet | 100% (3/3) + README | Comparaison, Workflows, Optimisation |
-| 04-Images-Applications | Complet | 100% (4/4) + README | Applications pedagogiques |
-| Image/examples | Complet | 100% (3/3) + README | Cas d'usage spécifiques |
-| Audio/01-Foundation | Complet | 100% (5/5) + README | TTS, STT basics |
-| Audio/02-Advanced | Complet | 100% (8/8) + README | Voix, musique, separation |
-| Audio/03-Orchestration | Complet | 100% (3/3) + README | Multi-model, pipelines |
-| Audio/04-Applications | Complet | 100% (5/5) + README | Production workflows |
-| Video/01-Foundation | Complet | 100% (5/5) + README | Operations, comprehension |
-| Video/02-Advanced | Complet | 100% (4/4) + README | Generation video avancée |
-| Video/03-Orchestration | Complet | 100% (3/3) + README | Multi-model, workflows |
-| Video/04-Applications | Complet | 100% (4/4) + README | Production pipelines |
-| Texte/ | Complet | 100% (10/10) | 10 notebooks : OpenAI, Prompts, Structured Outputs, RAG, Reasoning, Production |
-| SemanticKernel/ | Complet | 85% (17/20) | SDK Microsoft pour integration LLMs |
-| EPF/ | Complet | 100% (4/4) + 3 sub-README | Projets étudiants spécifiques |
-| Playwright-OWUI/ | Complet | 100% (5 modules) | Tests E2E Playwright sur Open WebUI |
-| Vibe-Coding/ | Complet | 100% (10 modules) | Tutorials Claude Code et Roo Code |
+L'audio est souvent le parent pauvre des parcours IA, pourtant c'est l'une des modalites les plus accessibles et les plus impressionnantes. Cette serie couvre le spectre complet : reconnaissance vocale (Whisper V3, OpenAI API), synthese vocale (Kokoro, OpenAI TTS, Chatterbox), clonage de voix (XTTS v2), generation musicale (MusicGen, YuE), separation de sources (Demucs), et pipelines complets (podcast automatique, transcription batch, synchronisation audio-video).
+
+**Fil rouge** : produire un podcast automatique avec voix synthetique personnalisee et fond musical genere.
+
+[README complet](Audio/README.md) | 21 notebooks | ~14-16h
 
 ---
 
-## 🚀 **Demarrage Rapide**
+### Video - Comprendre, generer et produire
 
-### 1. **Prérequis**
+La video est la modalite la plus exigeante en ressources mais aussi la plus spectaculaire. On commence par comprendre des videos existantes (GPT-5, Qwen-VL), puis on genere (HunyuanVideo, Wan, Sora). Les notebooks d'orchestration combinent comprehension et generation dans des workflows de production video. La serie couvre aussi le surcadrage d'images (ESRGAN) et la synchronisation audio-video.
+
+**Fil rouge** : creer une video pedagogique automatisee depuis un script texte.
+
+[README complet](Video/README.md) | 16 notebooks | ~14h
+
+---
+
+### Texte - Maitriser les LLMs et les APIs OpenAI
+
+Le texte est le socle de toute interaction avec l'IA generative. Cette serie va au-dela du simple "prompt engineering" : structured outputs pour des reponses fiables, function calling pour connecter les LLMs a vos outils, RAG pour injecter de la connaissance externe, code interpreter pour l'execution dynamique, et les modeles de raisonnement (o-series) pour les taches complexes. Les derniers notebooks couvrent les patterns de production et les LLMs locaux.
+
+[README complet](Texte/README.md) | 10 notebooks | ~10h
+
+---
+
+### SemanticKernel - Orchestration agentique avec Microsoft
+
+Semantic Kernel est le SDK Microsoft pour construire des applications agentiques. Il fournit les briques pour orchestrer des LLMs avec des plugins, des agents, des filtres, des vector stores, et des processus multi-etapes. Cette serie couvre le SDK en Python et en C# (.NET Interactive), avec une progression qui va des fundamentals aux patterns avances (MCP, multi-modalite, interop CLR).
+
+[README complet](SemanticKernel/README.md) | 20 notebooks | ~20h
+
+---
+
+### Vibe-Coding - Developper avec des agents IA
+
+Le "vibe coding" est la competence la plus demandee de 2026 : decrire ce qu'on veut a un agent IA et le laisser ecrire, tester et deployer le code. Cette serie couvre les deux outils majeurs du marche : Claude Code (Anthropic) et Roo Code (communautaire). Chaque outil est aborde en 5 modules, de la decouverte a l'automatisation avancee.
+
+[README complet](Vibe-Coding/README.md) | 10 modules | ~30h
+
+---
+
+### Playwright-OWUI - Tester les applications GenAI
+
+Les applications GenAI doivent etre testees rigoureusement. Cette serie utilise Playwright pour ecrire des tests de bout en bout sur Open WebUI, une interface reelle de chat LLM. On y apprend la navigation, l'authentification, le streaming de reponses, le RAG, les outils MCP, et le deploiement CI/CD.
+
+[README complet](Playwright-OWUI/README.md) | 5 modules, 30+ tests | ~14h
+
+---
+
+### EPF - Projets etudiants
+
+Projets realises par les etudiants de l'EPF : generation d'images style Barbie/Shrek, generateur de recettes, chatbot medical educatif, challenges style Fort Boyard. Ces notebooks illustrent la diversite des applications possibles apres le parcours.
+
+[README complet](EPF/README.md) | 4 notebooks
+
+---
+
+## Progression recommandee
+
+### Decouvreur (initiation rapide, ~20h)
+
+Commencez par `00-GenAI-Environment/` pour le setup, puis choisissez une modalite qui vous interesse : `Image/01-Foundation/` pour le visuel, ou `Audio/01-Foundation/` pour le son. L'objectif est de generer votre premier contenu en moins d'une journee.
+
+### Praticien (maitrise multi-modale, ~50h)
+
+Couvrez les quatre modalites de base (Image, Audio, Video, Texte) au niveau Foundation, puis approfondissez une ou deux modalites au niveau Advanced. Vous serez capable de combiner texte, image et son dans un projet coherent.
+
+### Agentiste (full-stack agentic, ~90h)
+
+Ajoutez SemanticKernel pour l'orchestration et Vibe-Coding pour le developpement assiste. Vous construirez des pipelines multi-modeles autonomes et des agents capables de chaines de traitement complexes.
+
+### Expert (avec production, ~120h+)
+
+Compltez avec Playwright pour les tests E2E et les notebooks Applications de chaque modalite. Vous maitrisez le cycle complet : generation, orchestration, tests, deploiement.
+
+---
+
+## Demarrage rapide
+
+### 1. Configuration
+
 ```bash
-# Cloner le projet CoursIA
 cd MyIA.AI.Notebooks/GenAI
-
-# Configuration environnement
 cp .env.example .env
-# Éditer .env avec vos API keys (token fourni par l'enseignant pour le cours)
+# Editez .env avec vos cles API (token fourni par l'enseignant)
 ```
 
-### 2. **Installation**
+### 2. Installation
+
 ```bash
-# Installation dépendances Python
 pip install -r requirements.txt
-
-# Validation environment (MCP)
-python -c "import jupyter_client; print('✅ Jupyter OK')"
+python -c "import jupyter_client; print('Jupyter OK')"
 ```
 
-### 3. **Première Exécution**
-```bash
-# Lancer Jupyter Lab
-jupyter lab
+### 3. Premier pas
 
-# Commencer par 00-GenAI-Environment/
-# Ordre recommandé : 00-1 → 00-2 → 00-3 → 00-4
-```
+Lancez Jupyter Lab et commencez par `00-GenAI-Environment/00-1-Environment-Setup.ipynb`. Ce notebook verifie que votre environnement est operationnel et guide la configuration des services.
 
 ---
 
-## 🔐 **Authentification ComfyUI**
+## Authentification ComfyUI
 
-> **NOUVEAU** : L'accès à ComfyUI nécessite désormais une authentification Bearer Token pour sécuriser les services GenAI.
+Les services GenAI locaux (Qwen Image Edit, Z-Image, Whisper, etc.) sont proteges par authentification Bearer Token.
 
-### 📋 **Guide Rapide Étudiants**
+1. **Obtenir le token** : contactez votre enseignant
+2. **Configuration** : ajoutez `COMFYUI_BEARER_TOKEN` dans `.env`
+3. **Utilisation** : les notebooks chargent automatiquement les credentials via `comfyui_client.py`
 
-1. **Obtenir votre token** : Contactez votre enseignant pour recevoir votre token personnel Bearer
-2. **Configuration** : Créez un fichier `.env` dans `MyIA.AI.Notebooks/GenAI/`
-3. **Utilisation** : Les notebooks chargent automatiquement les credentials
-
-📖 **Documentation complète** : voir `00-GenAI-Environment/` pour la configuration pas-à-pas.
-
-### ⚠️ **Important**
-- ✅ Tous les notebooks supportent l'authentification (graceful degradation si désactivée)
-- ✅ Helper Python : `comfyui_client.py` gère automatiquement les credentials
-- ⚠️ Ne partagez JAMAIS votre token - il est personnel et traçable
+Tous les notebooks supportent la graceful degradation : sans token, ils utilisent les APIs cloud en fallback.
 
 ---
 
-## ⚙️ **Configuration**
+## Variables d'environnement
 
-### 🔑 **Variables Environnement** (`.env`)
-```bash
-# Authentification ComfyUI (REQUIS pour services locaux)
-COMFYUI_BASE_URL=http://localhost:8188
-COMFYUI_BEARER_TOKEN=YOUR_TOKEN_HERE    # Token fourni par l'enseignant
+Les cles essentielles dans `.env` :
 
-# APIs Principales
-OPENAI_API_KEY=sk-...              # DALL-E 3, GPT-5
-ANTHROPIC_API_KEY=sk-ant-...       # Claude Vision
-HUGGINGFACE_TOKEN=hf_...           # Modèles HF
+| Variable | Usage | Requis pour |
+| ---------- | ------- | ------------- |
+| `OPENAI_API_KEY` | DALL-E 3, GPT-5, Whisper, TTS | Image, Audio, Texte |
+| `ANTHROPIC_API_KEY` | Claude Vision | Video |
+| `HUGGINGFACE_TOKEN` | Modeles HF open-source | Image, Video |
+| `COMFYUI_BEARER_TOKEN` | Services locaux ComfyUI | Image (local), Video |
 
-# Services Locaux
-DOCKER_HOST=localhost:2376         # Docker Services
-JUPYTER_TOKEN=your-secure-token    # Jupyter Security
+Template complet : [`.env.example`](.env.example)
 
-# Modèles Spécialisés
-QWEN_API_ENDPOINT=https://...      # Qwen 2.5 Image Edit
-FLUX_MODEL_PATH=/models/flux/      # FLUX.1 Local
-SD35_CHECKPOINT=/models/sd35/      # Stable Diffusion 3.5
-```
+---
 
-**Modèle de configuration** : Voir [`.env.example`](.env.example) pour un template complet
-
-### 📦 **Dépendances Principales**
-```text
-# IA & ML Core
-torch>=2.0.0
-transformers>=4.35.0
-diffusers>=0.24.0
-accelerate>=0.24.0
-
-# Image Processing
-Pillow>=10.0.0
-opencv-python>=4.8.0
-numpy>=1.24.0
-
-# Audio Processing
-librosa>=0.10.0
-soundfile>=0.12.0
-pydub>=0.25.0
-faster-whisper>=0.10.0
-
-# Video Processing
-moviepy>=2.0.0
-imageio>=2.31.0
-imageio-ffmpeg>=0.4.9
-decord>=0.6.0
-
-# Jupyter & Notebooks
-jupyter>=1.0.0
-ipywidgets>=8.0.0
-matplotlib>=3.7.0
-
-# APIs & Clients
-openai>=1.3.0
-anthropic>=0.7.0
-huggingface-hub>=0.19.0
-```
-
-### 🎬 **FFmpeg Installation (Requis pour Video/Audio)**
-
-FFmpeg est indispensable pour les notebooks Video et certains notebooks Audio. Il permet :
-- **Decodage video** : lecture, conversion, extraction de metadonnees
-- **Operations audio** : decoupage, mixing, format conversion
-- **Integration Python** : moviepy, pydub, ffmpeg-python
-
-#### Installation Windows
-
-```powershell
-# Option 1: Script automatique (recommande)
-powershell -ExecutionPolicy Bypass -File scripts/install-ffmpeg.ps1
-
-# Option 2: Installation manuelle winget
-winget install FFmpeg
-
-# Option 3: Installation locale (pour developpement)
-# Le script installera dans: D:\Dev\CoursIA\tools\ffmpeg\
-# Le notebook execution script l'ajoutera automatiquement au PATH
-```
-
-#### Installation Linux
+## Outils de validation
 
 ```bash
-# Ubuntu/Debian
-sudo apt update && sudo apt install -y ffmpeg
+# Validation structure (metadata, outputs, kernel)
+python scripts/notebook_tools/notebook_tools.py validate <path>
 
-# Fedora
-sudo dnf install -y ffmpeg
+# Execution complete (Papermill)
+python scripts/notebook_tools/notebook_tools.py execute <path>
 
-# Verifier l'installation
-ffmpeg -version
+# Analyse structure (stats cellules, outputs)
+python scripts/notebook_tools/notebook_tools.py analyze <path>
 ```
 
-#### Installation macOS
+---
 
-```bash
-# Via Homebrew
-brew install ffmpeg
+## Statut par sous-domaine
 
-# Verifier l'installation
-ffmpeg -version
-```
-
-#### Verification dans Python
-
-```python
-# Tester FFmpeg depuis Python
-import subprocess
-result = subprocess.run(['ffmpeg', '-version'], capture_output=True, text=True)
-print(result.stdout.split('\n')[0])  # Affiche la version
-```
-
-**Note** : Le script `scripts/genai-stack/commands/notebooks.py` ajoute automatiquement
-`D:/Dev/CoursIA/tools/ffmpeg/bin` au PATH lors de l'execution des notebooks.
+| Sous-domaine | Notebooks | Validation |
+| ------------ | ----------- | ------------ |
+| 00-GenAI-Environment | 6 | 100% |
+| Image | 19 | 100% |
+| Audio | 21 | 100% |
+| Video | 16 | 100% |
+| Texte | 10 | 100% |
+| SemanticKernel | 20 | 85% |
+| EPF | 4 | 100% |
+| Playwright-OWUI | 5 modules | 100% |
+| Vibe-Coding | 10 modules | 100% |
 
 ---
 
-## 📊 **Progression Pédagogique**
-
-### 🎯 **Parcours Recommandés**
-
-#### **👨‍🎓 Débutant (30h)**
-1. `00-GenAI-Environment/` - Setup complet (4h)
-2. `01-Images-Foundation/` - Bases DALL-E & GPT-5 (8h)
-3. `Audio/01-Foundation/` - TTS & STT basics (6h)
-4. `Video/01-Foundation/` - Operations video basics (6h)
-5. Premier projet pratique (6h)
-
-#### **👨‍💻 Intermédiaire (60h)**
-1. Révision Débutant (6h)
-2. `02-Images-Advanced/` - Modèles spécialisés (16h)
-3. `Audio/02-Advanced/` - Voix, musique, separation (10h)
-4. `Video/02-Advanced/` - Generation video (12h)
-5. Projet intégration multi-modales (16h)
-
-#### **🚀 Expert (120h)**
-1. Révision Intermédiaire (12h)
-2. `03-Images-Orchestration/` - Architecture complexe (16h)
-3. `Audio/03-Orchestration/` + `04-Applications/` - Pipelines audio (14h)
-4. `Video/03-Orchestration/` + `04-Applications/` - Workflows video (16h)
-5. `04-Images-Applications/` - Production (20h)
-6. Projet production complet (42h)
-
----
-
-## 🔧 **Outils & Scripts**
-
-### 📜 **Scripts PowerShell**
-```powershell
-# Génération structure
-.\scripts\34-implement-genai-phase2-structure-20251008.ps1
-
-# Création notebooks templates
-.\scripts\36-generate-remaining-genai-notebooks-fixed-20251008.ps1
-
-# Correction encodage UTF-8
-.\scripts\38-execute-bom-fix-20251008.ps1
-```
-
-### 🔍 **Outils Validation**
-- **Tests MCP** : Compatibilité infrastructure notebooks
-- **Validation JSON** : Conformité notebooks Jupyter
-- **Tests API** : Vérification endpoints disponibles
-
----
-
-## 📚 **Ressources Complémentaires**
-
-### 🎨 **Assets & Données**
-- `assets/models/DMC_colors.json` - Palette couleurs point de croix
-- `assets/images/` - Images référence et exemples
-- `shared/` - Utilitaires Python partagés
-
-### 📖 **Documentation**
-- [Mission Images GenAI](../../docs/genai-images-mission-complete.md)
-
-### 🔗 **Intégrations**
-- **MCP Jupyter** : Exécution notebooks automatisée
-- **Docker Compose** : Services conteneurisés
-- **GitHub Actions** : CI/CD notebooks
-- **Monitoring** : Métriques production
-
----
-
-## ⚡ **Performance & Scaling**
-
-### 🚀 **Optimisations**
-- **Caching intelligent** : Modèles et résultats
-- **Load balancing** : Distribution requêtes API
-- **Batch processing** : Traitement lots images
-- **GPU acceleration** : CUDA, ROCm, MPS support
-
-### 📈 **Métriques Clés**
-- **Latence génération** : <3s DALL-E, <10s SD3.5
-- **Qualité output** : FID score, CLIP score
-- **Coût par image** : Optimisation budget API
-- **Throughput** : Images/heure en production
-
----
-
-## 🛠️ **Support & Maintenance**
-
-### 🔧 **Dépannage**
-1. **Problème API** → Vérifier `.env` et quotas
-2. **Erreur Jupyter** → Relancer MCP servers
-3. **Memory issues** → Ajuster batch sizes
-4. **Model loading** → Vérifier paths modèles
-
-### 📞 **Support**
-- **Issues GitHub** : Bugs et demandes fonctionnalités  
-- **Discussions** : Questions communauté
-- **Documentation** : Wiki complet
-- **Examples** : Cas d'usage étendus
-
----
-
-## 🏆 **Résultats Attendus**
-
-Après completion de cet écosystème, vous maîtriserez :
-
-### 🎯 **Compétences Techniques**
-- ✅ **Multi-modal AI** : Texte → Image, Audio, Video
-- ✅ **Model comparison** : Évaluation objective performances
-- ✅ **Production deployment** : Architecture scalable
-- ✅ **Workflow automation** : Chaînes traitement complexes
-- ✅ **Speech processing** : STT, TTS, voice cloning, musique
-- ✅ **Video understanding** : Compréhension, génération, édition
-
-### 🚀 **Projets Réalisables**
-- 🎨 **Générateur contenu visuel** automatisé
-- 🎙️ **Podcast/TTS generator** avec voix personnalisées
-- 🎬 **Video pédagogique** generée automatiquement
-- 📚 **Plateforme éducative** avec contenus multimédia adaptatifs
-- 🏭 **Service production** génération à la demande
-- 🔬 **Benchmark suite** comparaison modèles multi-modaux
-
----
-
-**🎓 Bon apprentissage avec l'écosystème GenAI CoursIA !**
-
-*Créé avec ❤️ par l'équipe CoursIA | Architecture SDDD | Compatible MCP*
+Architecture SDDD | Compatible MCP | Derniere mise a jour : mai 2026

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -2,18 +2,11 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Text Generation](../Texte/README.md)
 
-Serie de notebooks couvrant Microsoft Semantic Kernel, un SDK pour l'integration de LLMs dans les applications .NET et Python.
+Microsoft Semantic Kernel represente un tournant dans la maniere de construire des applications intelligentes. Ce SDK d'orchestration agentique connecte les LLMs aux outils, donnees et workflows de votre systeme. La reponse de Microsoft a l'ecosysteme LangChain, Semantic Kernel transforme des applications statiques en systemes autonomes capables de raisonnement, d'apprentissage et d'action.
 
-## Vue d'ensemble
+Cette serie pedagogique vous guidera a travers la transition entre le prompt engineering simple et la construction de systemes multi-agents sophistiques, ou chaque composant travaille de concert pour resoudre des problemes d'une complexite croissante.
 
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks Python | 8 (serie principale 01-08) |
-| Notebooks Avances | 4 (interop Python/C# 09-10) |
-| Templates | 3 |
-| Duree estimee | ~9h (serie complete) |
-| Version SK cible | 1.39+ |
-| Validation | 80% (11/14 notebooks) |
+**Fil rouge** : le NotebookMaker, un systeme a 3 agents (Admin, Coder, Reviewer) qui genere automatiquement des notebooks pedagogiques. Ce demonstrateur incarne l'essence meme de Semantic Kernel : orchestrer des agents specialises pour resoudre des problemes complexes.
 
 ## Serie principale (Python)
 
@@ -68,7 +61,7 @@ Parcours pedagogique complet sur Semantic Kernel en Python :
 
 ## Parcours recommande
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │                     SERIE PRINCIPALE (Python)                       │
 ├─────────────────────────────────────────────────────────────────────┤

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -1,18 +1,18 @@
-# GenAI Texte - Generation de Texte par IA
+# GenAI Texte - Maîtrise des LLMs : Fondement de tout Génératif
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Semantic Kernel](../SemanticKernel/README.md)
 
-Ce dossier contient une serie complete de notebooks pour maitriser les LLMs et les APIs OpenAI modernes (2025-2026).
+La maîtrise des LLMs constitue la pierre angulaire de toute expertise en Génératif. Chaque image générée, chaque instruction d'agent et chaque requête RAG trouve son origine dans le texte. Cette série vous guide à travers une progression pédagogique complète pour transformer votre interaction avec l'IA.
 
-## Vue d'ensemble
+## Ce que vous apprendrez
 
-| Tier | Notebooks | Niveau |
-|------|-----------|--------|
-| **Fondations** | 1-2 | Debutant |
-| **Sorties Structurees** | 3-4 | Intermediaire |
-| **Augmentation** | 5-7 | Intermediaire |
-| **Avance** | 8-11 | Avance |
-| **Validation** | 100% (11/11 notebooks) |
+À travers ces 11 notebooks pratiques, vous acquerrez une expertise complète :
+- **Art du prompt engineering** : du zéro-shot au chain-of-thought
+- **Structuration des réponses** : JSON Schema, Pydantic, extraction de données
+- **Intelligence augmentée** : function calling, RAG moderne, code interpreter
+- **Raisonnement avancé** : modèles o4-mini, gpt-5-thinking
+- **Production enterprise** : gestion de sessions, retry, batch processing
+- **Déploiement local** : vLLM, quantification, optimisation des coûts
 
 ## Contenu detaille
 
@@ -59,7 +59,7 @@ Ce dossier contient une serie complete de notebooks pour maitriser les LLMs et l
 
 ## Parcours suggere
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                                                                 │
 │  1_OpenAI_Intro ─────► 2_PromptEngineering                     │
@@ -94,7 +94,7 @@ Ce dossier contient une serie complete de notebooks pour maitriser les LLMs et l
 | **File Upload** | 6, 7 | Support PDF et fichiers |
 | **Reasoning** | 2, 8 | Modeles o4-mini, gpt-5-thinking |
 
-## Technologies
+## Technologies et ecosysteme
 
 - **OpenAI API** : GPT-4o, GPT-4o-mini, o4-mini, gpt-5-thinking
 - **Python** : openai, pydantic, tiktoken, semantic-kernel

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -2,11 +2,11 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Claude Discovery](Claude-Code/01-decouverte/README.md)
 
-Ce repertoire contient les ressources pedagogiques pour apprendre le "vibe-coding" avec des assistants IA generatifs. Le contenu couvre deux outils majeurs : **Claude Code** (Anthropic) et **Roo Code**, ainsi qu'une documentation introductive sur l'IA generative.
+Bienvenue dans l'ère du **vibe-coding** - la compétence la plus demandée de 2026 ! Imaginez : vous décrivez ce que vous voulez construire en langage naturel, et l'IA écrit le code pour vous. Plus besoin de semaines de développement, mais des minutes pour transformer une idée en fonctionnalité réelle. Le vibe-coding révolutionne la programmation en rendant la barrière technique quasi invisible : votre seule limite est votre imagination.
 
 ## Structure du repertoire
 
-```
+```text
 Vibe-Coding/
 ├── Claude-Code/          # Ateliers Claude Code (5 modules)
 ├── Roo-Code/             # Ateliers Roo Code (5 modules + avances)
@@ -105,11 +105,11 @@ Le repertoire `docs/` contient :
 | Aspect | Claude Code | Roo Code |
 |--------|-------------|----------|
 | **Interface** | CLI + VS Code | VS Code uniquement |
-| **Agents paralleles** | Jusqu'a 10 | Sequentiel |
+| **Agents parallèles** | Jusqu'à 10 | Séquentiel |
 | **MCP** | Support complet | Partiel |
-| **Skills/Commands** | Ecosystem standardise | Configuration manuelle |
+| **Skills/Commands** | Écosystème standardisé | Configuration manuelle |
 | **Courbe d'apprentissage** | Moyenne | Facile |
-| **Ideal pour** | Projets complexes | Debutants |
+| **Idéal pour** | Projets complexes | Débutants |
 
 **Recommandation :**
 - **Debutants complets** : Commencer avec Roo Code
@@ -125,7 +125,15 @@ Le repertoire `docs/` contient :
 
 ## Origine
 
-Ce contenu pedagogique provient de la formation ECE 2026 sur l'IA generative.
+## Ce que vous saurez faire
+
+À travers ces ateliers pratiques, vous acquerrez la capacité de :
+
+- **Décrire vos projets** en langage naturel et voir l'IA les transformer en code fonctionnel
+- **Écrire, tester, debugger et déployer** des applications complètes grâce à l'assistance IA
+- **Orchestrer des workflows complexes** en multipliant les agents intelligents
+- **Générer automatiquement** la documentation, les tests et les configurations
+- **Automatiser des tâches complexes** allant du simple script au déploiement en production
 
 ---
 

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -1,32 +1,16 @@
-# Video - Generation & Comprehension Video par IA
+# Video - Generation et Comprehension Video par IA
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Audio Sync](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb)
 
-Serie complete de notebooks pour la generation, la comprehension et l'edition video par IA generative : text-to-video, image-to-video, video understanding, amelioration et workflows de production.
+**La video est le Graal de l'IA generative.** Elle combine l'analyse d'images, la comprehension du temps, la synchronisation audio, et la creation de mouvement coherent. Cette serie vous emmene de la simple comprehension d'une sequence video existante jusqu'a la production d'une video pedagogique complete, generee de bout en bout par des modeles d'IA.
 
-## Vue d'ensemble
-
-| Statistique | Valeur |
-|-------------|--------|
-| Notebooks | 16 |
-| Sous-dossiers | 4 niveaux |
-| Kernel | Python 3 |
-| Duree totale | ~12-15h |
-| Validation | 100% (16/16 notebooks) |
-
-## Structure
-
-```
-Video/
-├── 01-Foundation/     # Bases video, comprehension, animation (5 notebooks)
-├── 02-Advanced/       # Text-to-video, image-to-video (4 notebooks)
-├── 03-Orchestration/  # Multi-modeles, ComfyUI, pipelines (3 notebooks)
-└── 04-Applications/   # Education, creatif, production (4 notebooks)
-```
+**Fil rouge** : construire un pipeline capable de transformer un script texte en video pedagogique animee, avec voix de synthese et fond musical genere — un defi qui mobilise tous les niveaux de cette serie.
 
 ## Progression par niveau
 
-### 01-Foundation - Bases Video & Comprehension
+### 01-Foundation - Comprendre la video avant de la generer
+
+On ne peut pas creer ce qu'on ne comprend pas. Ce niveau pose les bases techniques (codecs, ffmpeg, moviepy) et introduit la comprehension video par IA : decomposer une sequence en scenes, repondre a des questions sur le contenu, analyser le mouvement. Vous decouvrirez aussi le surcadrage d'images (ESRGAN) et l'interpolation de frames (RIFE) pour ameliorer la qualite visuelle.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -36,7 +20,9 @@ Video/
 | [01-4-Video-Enhancement-ESRGAN](01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb) | Real-ESRGAN, RIFE interpolation | Local GPU | ~4 GB |
 | [01-5-AnimateDiff-Introduction](01-Foundation/01-5-AnimateDiff-Introduction.ipynb) | AnimateDiff, text-to-video basique | Local GPU | ~12 GB |
 
-### 02-Advanced - Modeles generatifs video
+### 02-Advanced - Generer du mouvement a partir de texte ou d'images
+
+Ce niveau explore les modeles generatifs video : HunyuanVideo pour la qualite cinematographique (malgre ses 24 GB de VRAM), LTX-Video pour la generation rapide sur des configurations modestes, Wan pour les prompts multilingues, et Stable Video Diffusion pour animer une image existante. Chaque modele a ses forces et ses limites — le but est de les connaitre pour choisir le bon outil au bon moment.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -45,15 +31,19 @@ Video/
 | [02-3-Wan-Video-Generation](02-Advanced/02-3-Wan-Video-Generation.ipynb) | Wan 2.1/2.2, prompts FR/EN | Local GPU | ~10 GB |
 | [02-4-SVD-Image-to-Video](02-Advanced/02-4-SVD-Image-to-Video.ipynb) | Stable Video Diffusion, animation | Local GPU | ~10 GB |
 
-### 03-Orchestration - Multi-modeles & Pipelines
+### 03-Orchestration - Combiner les modeles dans des pipelines
+
+Un seul modele ne suffit pas pour une production video complete. Ce niveau compare les modeles entre eux, orchestre des pipelines text-to-image-to-video, et exploite ComfyUI pour des workflows natifs plus flexibles. C'est ici que le fil rouge prend forme : un script texte devient scenario, puis images, puis sequence video animee.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
 | [03-1-Multi-Model-Video-Comparison](03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb) | Benchmark modeles video | Local GPU | ~18 GB |
-| [03-2-Video-Workflow-Orchestration](03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb) | Pipelines text->image->video | Mixed | ~18 GB |
+| [03-2-Video-Workflow-Orchestration](03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb) | Pipelines text-to-image-to-video | Mixed | ~18 GB |
 | [03-3-ComfyUI-Video-Workflows](03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb) | Workflows ComfyUI natifs | ComfyUI | ~20 GB |
 
-### 04-Applications - Cas d'usage production
+### 04-Applications - Du pipeline a la production
+
+Les trois derniers notebooks et le notebook de synchronisation audio-video concluent le parcours en abordant des cas d'usage reels : generation automatique de contenus educatifs, workflows creatifs (transfert de style, clips musicaux), et l'API Sora 2 d'OpenAI pour la generation cloud. Le pipeline final integre tout ce qui a ete appris dans un systeme bout-en-bout.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -62,7 +52,15 @@ Video/
 | [04-3-Sora-API-Cloud-Video](04-Applications/04-3-Sora-API-Cloud-Video.ipynb) | Sora 2 API, cloud vs local | OpenAI API | 0 |
 | [04-4-Production-Video-Pipeline](04-Applications/04-4-Production-Video-Pipeline.ipynb) | Pipeline complet bout-en-bout | Mixed | ~18 GB |
 
-## Technologies
+## Ce que vous saurez faire
+
+- **Comprendre** une sequence video : decomposition en scenes, Q&A sur le contenu, analyse temporelle
+- **Generer** des videos a partir de texte ou d'images : choix du modele adapte a votre materiel
+- **Orchestrer** des pipelines multi-modeles : scenario texte vers video complete
+- **Produire** des contenus video educatifs ou creatifs de bout en bout
+- **Comparer** les approches cloud (Sora) et locales (HunyuanVideo, Wan) en termes de qualite, cout et latence
+
+## Technologies couvertes
 
 | Technologie | Notebooks | Prerequis |
 |-------------|-----------|-----------|
@@ -85,51 +83,32 @@ Video/
 ```bash
 # Dans GenAI/.env
 OPENAI_API_KEY=sk-...
-COMFYUI_AUTH_TOKEN=...   # Pour ComfyUI Video (03-3)
-```
-
-### Dependances Python
-
-```bash
-pip install -r requirements.txt
-pip install -r requirements-video.txt
-```
-
-### FFmpeg
-
-FFmpeg doit etre installe sur le systeme :
-```bash
-# Windows (via winget)
-winget install FFmpeg
-
-# Linux
-sudo apt install ffmpeg
+COMFYUI_AUTH_TOKEN=...
 ```
 
 ### GPU (pour notebooks locaux)
 
-- Minimum : 4 GB VRAM (Real-ESRGAN, RIFE)
-- Recommande : 12+ GB VRAM (AnimateDiff, LTX-Video)
-- Optimal : 24 GB VRAM (HunyuanVideo, Wan, tous les notebooks)
+- **Minimum** : 4 GB VRAM (Real-ESRGAN, RIFE)
+- **Recommande** : 12+ GB VRAM (AnimateDiff, LTX-Video)
+- **Optimal** : 24 GB VRAM (HunyuanVideo, Wan, tous les notebooks)
+
+### FFmpeg
+
+FFmpeg doit etre installe sur le systeme :
+
+```bash
+# Windows (via winget)
+winget install FFmpeg
+```
 
 ## Parcours recommande
-
-```
-01-Foundation (bases video, comprehension)
-    |
-02-Advanced (modeles generatifs specifiques)
-    |
-03-Orchestration (comparaison, ComfyUI, pipelines)
-    |
-04-Applications (production, bout-en-bout)
-```
 
 | Objectif | Notebooks |
 |----------|-----------|
 | Decouverte rapide | 01-1, 01-2, 01-5 |
 | Generation video | 01-5, 02-1 a 02-4 |
 | Comprehension video | 01-2, 01-3 |
-| Production | Tous + Audio/04-4 (sync A/V) |
+| Production complete | Tous + Audio/04-4 (sync A/V) |
 
 ## Licence
 

--- a/docs/03-plan-formation-datascience-agentique.md
+++ b/docs/03-plan-formation-datascience-agentique.md
@@ -1,62 +1,133 @@
-# Plan de Formation : Data Science Agentique
+# Plan de Formation : Data Science Agentique (Edition 2026)
 
-Ce parcours pédagogique vise à former des techniciens et développeurs à la conception et à l'implémentation de solutions de data science modernes, basées sur des agents intelligents. Il comble le fossé entre la data science traditionnelle en Python et l'ingénierie d'agents complexes, avec un focus sur l'écosystème C#/.NET pour l'orchestration et le framework ADK de DeepMind pour l'agent de data science.
-
----
-
-## Module 1 : Les Fondamentaux de la Data Science en Python
-
-**Objectif :** Acquérir les compétences essentielles pour la manipulation, l'analyse et la visualisation de données en Python. Ce module comble les lacunes identifiées dans le parcours existant.
-
-*   **Notebook 1.1 : Introduction à l'écosystème Python pour la Data Science**
-    *   **Description :** Prise en main de l'environnement de travail (Jupyter, VS Code), et introduction aux bibliothèques fondamentales.
-*   **Notebook 1.2 : Manipulation de Données avec NumPy**
-    *   **Description :** Apprendre à créer et manipuler des tableaux multi-dimensionnels, effectuer des opérations mathématiques vectorisées et comprendre le broadcasting.
-*   **Notebook 1.3 : Analyse de Données avec Pandas**
-    *   **Description :** Maîtriser les DataFrames pour le nettoyage, la transformation, le filtrage, le groupage et l'agrégation de données structurées.
-*   **Notebook 1.4 : Visualisation de Données avec Matplotlib et Seaborn**
-    *   **Description :** Créer des graphiques et des visualisations informatives pour explorer les données et communiquer les résultats d'une analyse.
-*   **Notebook 1.5 : Introduction au Machine Learning avec Scikit-Learn**
-    *   **Description :** Découvrir le cycle de vie d'un projet de ML : préparation des données, entraînement d'un modèle simple (régression/classification), et évaluation de sa performance.
+Ce parcours forme des developpeurs a la data science moderne ou l'IA generative et les agents autonomes sont au coeur du workflow. Il couvre les fondamentaux Python, la maitrise multi-modale (image, audio, video, texte), l'orchestration d'agents (Semantic Kernel, Claude Code, Roo Code), et l'application au trading algorithmique via QuantConnect.
 
 ---
 
-## Module 2 : Introduction à l'Agentique en Python
+## Comment utiliser ce parcours
 
-**Objectif :** Faire la transition en douceur de la programmation Python classique vers la conception d'agents. Nous utilisons LangChain comme une première étape accessible avant d'aborder un framework plus complexe comme l'ADK.
+Chaque module correspond a une serie de notebooks Jupyter presentes dans le depot, accompagnes de README detailles par sous-domaine. Les notebooks sont structures en 4 niveaux de progression :
 
-*   **Notebook 2.1 : Les concepts de l'IA Agentique**
-    *   **Description :** Comprendre ce qu'est un agent, le cycle "Perception-Réflexion-Action", et les concepts de LLMs, d'outils (`tools`) et de `prompt engineering` avancé.
-*   **Notebook 2.2 : Construire son premier Agent avec LangChain**
-    *   **Description :** Créer un agent simple capable d'utiliser des outils (ex: une recherche web, une calculatrice) pour répondre à une question.
-*   **Notebook 2.3 : Agentique et Manipulation de Données**
-    *   **Description :** Développer un agent LangChain capable d'interagir avec un DataFrame Pandas pour répondre à des questions en langage naturel sur un jeu de données.
+- **Foundation** : decouverte des concepts et premiers pas pratiques
+- **Advanced** : techniques specialisees et modeles avances
+- **Orchestration** : combinaison de plusieurs modeles et pipelines
+- **Applications** : cas d'usage concrets et projets de production
 
----
-
-## Module 3 : Plongée dans le Framework ADK de DeepMind
-
-**Objectif :** Se familiariser avec le framework ADK (`Agent Development Kit`) et son application de référence `MLE-STAR` pour l'ingénierie de Machine Learning.
-
-*   **Notebook 3.1 : Découverte de l'écosystème ADK**
-    *   **Description :** Installation et configuration de l'environnement (Python 3.12+, Poetry, GCP CLI), et compréhension de l'architecture (Agents de Workflow, Agents LLM, Outils).
-*   **Notebook 3.2 : Lancer son premier agent ADK**
-    *   **Description :** Exécuter un agent pré-configuré simple pour comprendre le cycle de vie : définition de la tâche, lancement, et interaction via la ligne de commande ou l'interface web.
-*   **Notebook 3.3 : Analyse du workflow de l'agent MLE-STAR**
-    *   **Description :** Étudier en détail le fonctionnement de l'agent MLE-STAR : génération de solution, raffinement par blocs, ensembling et mécanismes de robustesse (débogage, `data leakage`).
+La duree totale est d'environ 120-150 heures, repartissable sur un semestre universitaire ou une formation intensive.
 
 ---
 
-## Module 4 : Projet Intégrateur - Orchestrateur C# et Agent Data Scientist Python
+## Module 1 : Les Fondamentaux Python pour la Data Science
 
-**Objectif :** Mettre en pratique toutes les compétences acquises dans un projet qui combine l'écosystème C#/.NET pour l'orchestration de haut niveau et l'écosystème Python/ADK pour la tâche spécialisée de data science.
+Ce module pose les bases techniques : manipulation de donnees, visualisation, et introduction au machine learning. Il ne necessite aucune experience prealable en IA.
 
-*   **Projet Final : Un Système Automatisé de Reporting Financier**
-    *   **Description :** L'objectif est de construire un système où un utilisateur peut demander, en langage naturel, un rapport d'analyse sur des données de ventes.
-    *   **Composant 1 : L'Orchestrateur (C# / Semantic Kernel)**
-        *   **Rôle :** Interface principale avec l'utilisateur. Il analyse la requête, identifie les données nécessaires, et délègue la tâche d'analyse à l'agent spécialisé. Il est responsable de la mise en forme du rapport final.
-        *   **Notebook 4.1.C# :** Créer le plugin Semantic Kernel qui pilote l'agent Python.
-    *   **Composant 2 : L'Agent de Data Science (Python / ADK)**
-        *   **Rôle :** C'est un agent spécialisé basé sur l'ADK. Il reçoit une instruction de l'orchestrateur (ex: "Analyse les ventes du produit X pour le trimestre Y et identifie les tendances"). Il exécute un pipeline de data science (nettoyage, analyse, visualisation), génère les résultats (texte, graphiques), et les retourne à l'orchestrateur.
-        *   **Notebook 4.2.Py :** Développer l'agent ADK et ses outils personnalisés pour l'analyse de données.
-    *   **Notebook 4.3.Intégration :** Faire communiquer l'orchestrateur C# et l'agent Python via une API simple.
+**Competences acquises** : NumPy (tableaux vectorises), Pandas (DataFrames, nettoyage), Matplotlib/Seaborn (visualisation), Scikit-Learn (cycle de vie ML).
+
+Ce module est transversal : les competences acquises ici sont utilisees dans tous les modules suivants. La pratique se fait via des notebooks d'exercices dans `MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/` pour le setup, puis dans les series specialisees.
+
+---
+
+## Module 2 : IA Generative Multi-Modale
+
+Le coeur du parcours. On apprend a generer et manipuler du contenu avec des modeles d'IA : images, audio, video, texte. Chaque modalite suit la progression Foundation/Advanced/Orchestration/Applications.
+
+### 2a. Generation d'Images
+
+**Ce qu'on apprend** : utiliser DALL-E 3, GPT-5 et des modeles open-source (Qwen Image Edit, FLUX, Stable Diffusion, Lumina) pour generer, editer et orchestrer des images. Les notebooks avances couvrent le ComfyUI pour les workflows GPU locaux.
+
+**Fil rouge** : creer un generateur de contenu visuel pour l'education (diagrammes scientifiques, illustrations pedagogiques, motifs decoratifs).
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Image/` (19 notebooks, ~8h)
+
+### 2b. Speech, Voix et Musique
+
+**Ce qu'on apprend** : reconnaissance vocale (Whisper V3), synthese vocale (Kokoro, OpenAI TTS), clonage de voix (XTTS), generation musicale (MusicGen), et separation de sources (Demucs). Les notebooks avances explorent la generation de chansons completes et le TTS expressif.
+
+**Fil rouge** : produire un podcast automatique avec voix synthetique personnalisee et fond musical genere.
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Audio/` (21 notebooks, ~16h)
+
+### 2c. Video
+
+**Ce qu'on apprend** : comprehension video (GPT-5, Qwen-VL), generation (HunyuanVideo, Wan, Sora), et workflows de production video par IA. Les notebooks couvrent aussi le surcadrage d'images et la synchronisation audio-video.
+
+**Fil rouge** : creer une video pedagogique automatisee depuis un script texte.
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Video/` (16 notebooks, ~14h)
+
+### 2d. LLMs et Generation de Texte
+
+**Ce qu'on apprend** : maitriser les APIs OpenAI (prompt engineering, structured outputs, function calling, RAG, code interpreter). Les notebooks avances couvrent les modeles de raisonnement et les patterns de production.
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Texte/` (10 notebooks, ~10h)
+
+### Infrastructure Docker
+
+Les services GenAI tournent en Docker avec acceleration GPU (RTX 3090). Le setup est documente dans `00-GenAI-Environment/` et les scripts de gestion dans `scripts/genai-stack/`. La validation de l'environnement se fait via `/validate-genai`.
+
+---
+
+## Module 3 : Developpement Agentique (Vibe Coding)
+
+Ce module introduit le "vibe coding" : le developpement logiciel assiste par des agents IA autonomes. C'est la competence la plus demandee du marche en 2026.
+
+**Ce qu'on apprend** : utiliser Claude Code et Roo Code comme assistants de developpement, orchestrer des taches complexes, creer des workflows automatises, et integrer des serveurs MCP (Model Context Protocol).
+
+**Fil rouge** : creer un agent autonome capable d'analyser un jeu de donnees, generer un rapport visuel, et le deployer en production.
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Vibe-Coding/` (Claude Code : 5 modules, Roo Code : 5 modules + ateliers, ~30h)
+
+---
+
+## Module 4 : Orchestration avec Microsoft Semantic Kernel
+
+Semantic Kernel est le SDK Microsoft pour integrer des LLMs dans des applications .NET et Python. Ce module couvre les plugins, les agents, les filtres, les vector stores, et les pipelines multi-etapes.
+
+**Ce qu'on apprend** : construire des architectures agentiques robustes avec orchestration de plugins, gestion de contexte, et integration multi-modale.
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/SemanticKernel/` (20 notebooks, ~20h)
+
+---
+
+## Module 5 : ML pour le Trading Algorithmique (QuantConnect)
+
+Application avancee : utiliser le machine learning pour predire les marches financiers, avec une methode scientifique rigoureuse (walk-forward validation, multi-seed, baselines).
+
+**Ce qu'on apprend** : le pipeline ML complet applique au trading (feature engineering, modeles RF/XGBoost/Transformer/LSTM, evaluation hors-sample), les pieges du ML financier (surapprentissage, survivorship bias), et la validation croisee temporelle.
+
+**Reference** : *Hands-On AI Trading* (Jared Broad, 2025), [hands-on-ai-trading.com](https://www.hands-on-ai-trading.com/)
+
+Emplacement : `MyIA.AI.Notebooks/QuantConnect/` (50+ strategies, pipeline ML dans `ML-Training-Pipeline/`)
+
+---
+
+## Module 6 : Tests E2E et Qualite Logicielle
+
+Les agents IA doivent etre testes rigoureusement. Ce module couvre Playwright pour les tests de bout en bout sur des applications GenAI reelles (Open WebUI).
+
+Emplacement : `MyIA.AI.Notebooks/GenAI/Playwright-OWUI/` (5 modules, 30+ tests)
+
+---
+
+## Progression recommandee
+
+| Profil                              | Modules             | Duree  |
+|-------------------------------------|---------------------|--------|
+| **Decouvreur** (initiation rapide)  | 1 + 2a ou 2b        | ~20h   |
+| **Praticien** (maitrise multi-modale) | 1 + 2a-d          | ~50h   |
+| **Agentiste** (full-stack agentic)  | 1 + 2 + 3 + 4       | ~90h   |
+| **Expert** (avec trading ML)        | 1 + 2 + 3 + 4 + 5   | ~130h  |
+
+---
+
+## Ressources complementaires
+
+- Documentation services GenAI : `docs/genai-services.md`
+- Configuration Claude Code : `docs/claude-code-config.md`
+- Infrastructure QuantConnect : `docs/quantconnect.md`
+- Validation notebooks : `python scripts/notebook_tools/notebook_tools.py validate <path>`
+- Validation GenAI stack : `/validate-genai`
+
+---
+
+*Document mis a jour mai 2026. Pour l'historique de la version originale (ADK DeepMind 2023), voir `docs/02-etude-adk-deepmind.md`.*


### PR DESCRIPTION
## Summary
- Rewrite `docs/03-plan-formation-datascience-agentique.md` from the outdated 2023 ADK DeepMind 4-module plan to the actual 2026 curriculum (6 modules: Python DS Foundations, GenAI Multi-Modal, Vibe Coding, Semantic Kernel, QuantConnect ML, E2E Testing). Adds narrative descriptions, *fil rouge* per module, and a learner profile progression table.
- Add validation scripts and notebook conventions sections to `CONTRIBUTING.md` (references existing `scripts/notebook_tools/notebook_tools.py` commands).
- Fix markdown lint on both files (language tags on fenced code blocks, blank lines around fences).

## Test plan
- [x] Markdown lint clean (no MD031/MD034/MD040/MD060 warnings)
- [x] All links and cross-references valid
- [x] Content reflects actual repo structure (GenAI sub-series, QuantConnect strategies, Playwright tests)

Closes #48 (partial — GenAI sub-READMEs tracked separately in Cycle 3 Track E)