### PR TITLE
docs(cross-series): add cross-series bridge sections to 3 READMEs

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -288,6 +288,34 @@ BATCH_MODE=true python scripts/verify_notebooks.py MyIA.AI.Notebooks/GameTheory
 | **Core** | Ensemble des allocations stables en jeu cooperatif |
 | **Theoreme d'Arrow** | Impossibilite d'agregation parfaite des preferences |
 
+## Connections cross-series
+
+### GameTheory et Lean (Verification Formelle)
+
+Les side tracks Lean (16b-16f) formalisent en Lean 4 les resultats theoriques etudies en Python dans les notebooks principaux. Cette dualite Python (simulation) / Lean (preuve formelle) est un fil rouge du curriculum.
+
+| Concept GameTheory | Notebook Python | Formalisation Lean | Statut |
+|--------------------|----------------|--------------------|--------|
+| Jeux 2x2, strategies | GameTheory-2 | `Game2x2.lean` (notebook 2b) | Prouve |
+| Existence Nash | GameTheory-4 | `NashExistence.lean` (notebook 4b) | Prouve |
+| Jeux combinatoires | GameTheory-8 | `PGame.lean` (notebook 8b) | Prouve |
+| Theoreme d'Arrow | GameTheory-16 | `Arrow.lean` (notebook 16d) | 0 sorry |
+| Theoreme de Sen | GameTheory-16 | `Sen.lean` (notebook 16e) | 0 sorry |
+| Valeur de Shapley | GameTheory-16b | `Shapley.lean` (cooperative games) | 2 sorry |
+| Modeles de vote | GameTheory-16f | `Voting.lean` (Banks, STV) | 4 sorry |
+
+Voir [SymbolicAI/Lean/README.md](../SymbolicAI/Lean/README.md) pour les prerequis Lean (notebooks 1-6 recommandes).
+
+### GameTheory et SmartContracts
+
+Les concepts de theorie des jeux et de choix social apparaissent directement dans les smart contracts :
+
+- **SC-9 DAO Governance** : mecanismes de vote on-chain = application directe du theoreme d'Arrow et des modeles de vote etudies en 16f.
+- **SC-17 E2E Verifiable Voting** : le vote electronique verifiable combine les resultats de choix social (Arrow, Banks, STV) avec la cryptographie (ZKP, chiffrement homomorphique).
+- **SC-14 Formal Verification** : la verification formelle de smart contracts rejoint les methodes de preuve formelle utilisees pour les formalisations Lean de cette serie.
+
+Voir [SymbolicAI/SmartContracts/README.md](../SymbolicAI/SmartContracts/README.md) pour la serie complete.
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -209,6 +209,31 @@ Lean/
     └── test_wsl_lean4_jupyter.py   # Tests backend WSL
 ```
 
+## Connections cross-series
+
+Les concepts de verification formelle et de preuve assistee par LLM presentes dans cette serie se retrouvent dans d'autres series du curriculum :
+
+### Lean et Theorie des Jeux (GameTheory)
+
+Les notebooks GameTheory side tracks (16b-16f) formalisent en Lean 4 des resultats fondamentaux de theorie des jeux et de choix social :
+
+| resultat | Fichier Lean | Notebook GameTheory | Statut |
+|----------|-------------|---------------------|--------|
+| Theoreme d'Arrow (impossibilite) | `social_choice_lean/SocialChoice/Arrow.lean` | 16d | 0 sorry (Geanakoplos 2005) |
+| Theoreme de Sen (liberalisme) | `social_choice_lean/SocialChoice/Sen.lean` | 16e | 0 sorry (bidirectionnel) |
+| Valeur de Shapley | `cooperative_games_lean/CooperativeGames/Shapley.lean` | 16b | 2 sorry (en cours) |
+| Modeles de vote (Banks, STV) | `social_choice_lean/SocialChoice/Voting.lean` | 16f | 4 sorry (open problems) |
+
+Le notebook Lean-5 (tactiques) et Lean-6 (Mathlib) sont des prerequis directs pour les side tracks Lean de GameTheory.
+
+### Lean et SmartContracts
+
+La verification formelle en Lean (type theory, Curry-Howard) est conceptuellement liee a la verification formelle des smart contracts :
+
+- **SC-14 Formal Verification** : Certora/SMTChecker vs. Lean -- la meme idee de preuve mathematique de correction, mais sur des cibles differentes (Solidity vs. mathematiques). Les methodes different : SMT solving (automatique, borne) vs. tactiques interactives (expressif, guidable).
+- **SC-11 LLM-Assisted Contracts** : Le meme paradigme d'assistance LLM que les notebooks Lean-7/8/9, applique a la generation de smart contracts au lieu de preuves.
+- **SC-17 E2E Verifiable Voting** : Les resultats de `Voting.lean` (theoreme du median voter, proprietes Banks/STV) eclairent les proprietes theoriques des systemes de vote verifiable.
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -141,6 +141,22 @@ anvil  # dans un terminal separe
 - [ElectionGuard](https://www.electionguard.vote/)
 - [XRP Ledger Docs](https://xrpl.org/docs.html)
 
+## Connections cross-series
+
+### SmartContracts et Lean (Verification Formelle)
+
+Les techniques de verification formelle presentees dans cette serie (SC-14, fuzzing SC-13) complementent les methodes de preuve formelle de la serie Lean :
+
+- **SC-14 Formal Verification** (Certora, SMTChecker) vs. **Lean 4** : deux approches de la meme idee -- prouver mathematiquement la correction d'un programme. Les SMT solvers (Z3, CVC5) sont automatiques mais bornes ; Lean est interactif mais expressif ( Curry-Howard, types dependants).
+- **SC-11 LLM-Assisted Contracts** : le meme paradigme d'assistance LLM que les notebooks [Lean-7/8/9](../Lean/), applique a la generation de smart contracts.
+
+### SmartContracts et Theorie des Jeux (GameTheory)
+
+Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instances concretes des resultats formels de la serie GameTheory :
+
+- **SC-9 DAO Governance** : les systemes de vote on-chain sont soumis aux memes limitations que le **theoreme d'Arrow** (formalise dans `social_choice_lean/Arrow.lean`, 0 sorry).
+- **SC-17 E2E Verifiable Voting** : les proprietes des systemes de vote (Banks sets, monotonicite STV) sont etudiees formellement dans `social_choice_lean/Voting.lean`. Le chiffrement homomorphique (SC-16) et les ZKP (SC-15) sont les briques cryptographiques qui rendent le vote E2E possible.
+
 ---
 
 *Serie creee pour CoursIA (EPITA IA Symbolique) - Issue #129*


### PR DESCRIPTION
## Summary
- Add "Connections cross-series" sections to Lean, GameTheory, and SmartContracts READMEs
- Maps Lean formalizations (Arrow 0 sorry, Sen 0 sorry, Shapley 2 sorry, Voting 4 sorry) to GameTheory notebooks and SmartContracts applications
- Documents the dual Python (simulation) / Lean (formal proof) pedagogical approach

## Connections documented
- **Lean <-> GameTheory**: Arrow, Sen, Shapley, Voting formalizations linked to GT-2b through GT-16f
- **Lean <-> SmartContracts**: SC-14 (Certora vs Lean), SC-11 (LLM-assisted), SC-17 (Voting.lean)
- **GameTheory <-> SmartContracts**: SC-9 (Arrow on-chain), SC-17 (E2E voting), SC-14 (formal verification)

## Test plan
- [x] Verify README markdown renders correctly (table formatting)
- [x] Cross-reference links point to correct files/sections
- [x] Sorry counts match current state (Arrow=0, Sen=0, Shapley=2, Voting=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)