### PR TITLE
fix(sc): update Certora CLI + fix nav link in SC-14

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "cell-7",
    "metadata": {
     "execution": {
@@ -419,59 +419,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "INSTALLATION:\n",
-      "# Via npm\n",
-      "npm install -g @certora/certora-cli\n",
-      "\n",
-      "# Configurer la cle API\n",
-      "export CERTORAKEY=your_api_key\n",
-      "\n",
-      "EXECUTION:\n",
-      "# Verifier un contrat\n",
-      "certoraRun.py Vault.sol --verify Vault:Vault.spec\n",
-      "\n",
-      "# Avec optimisations\n",
-      "certoraRun.py Vault.sol --verify Vault:Vault.spec --optimistic_loop\n",
-      "\n",
-      "# Debug mode\n",
-      "certoraRun.py Vault.sol --verify Vault:Vault.spec --debug\n",
-      "\n",
-      "# Lister les regles\n",
-      "certoraRun.py Vault.sol --verify Vault:Vault.spec --rule depositIncreasesBalance\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Commandes Certora\n",
-    "print(\"\"\"\n",
-    "INSTALLATION:\n",
-    "# Via npm\n",
-    "npm install -g @certora/certora-cli\n",
-    "\n",
-    "# Configurer la cle API\n",
-    "export CERTORAKEY=your_api_key\n",
-    "\n",
-    "EXECUTION:\n",
-    "# Verifier un contrat\n",
-    "certoraRun.py Vault.sol --verify Vault:Vault.spec\n",
-    "\n",
-    "# Avec optimisations\n",
-    "certoraRun.py Vault.sol --verify Vault:Vault.spec --optimistic_loop\n",
-    "\n",
-    "# Debug mode\n",
-    "certoraRun.py Vault.sol --verify Vault:Vault.spec --debug\n",
-    "\n",
-    "# Lister les regles\n",
-    "certoraRun.py Vault.sol --verify Vault:Vault.spec --rule depositIncreasesBalance\n",
-    "\"\"\")"
-   ]
+   "outputs": [],
+   "source": "# Commandes Certora\nprint(\"\"\"\nINSTALLATION:\n# Via npm\nnpm install -g @certora/certora-cli\n\n# Configurer la cle API\nexport CERTORAKEY=your_api_key\n\nEXECUTION:\n# Verifier un contrat\ncertoraRun Vault.sol --verify Vault:Vault.spec\n\n# Avec optimisations\ncertoraRun Vault.sol --verify Vault:Vault.spec --optimistic_loop\n\n# Debug mode\ncertoraRun Vault.sol --verify Vault:Vault.spec --debug\n\n# Lister les regles\ncertoraRun Vault.sol --verify Vault:Vault.spec --rule depositIncreasesBalance\n\"\"\")"
   },
   {
    "cell_type": "markdown",
@@ -752,33 +701,7 @@
     },
     "tags": []
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## 6. Resume\n",
-    "\n",
-    "| Concept | Description |\n",
-    "|--------|-------------|\n",
-    "| Invariant | Propriete toujours vraie |\n",
-    "| Regle | Comportement attendu apres une action |\n",
-    "| `methods` | Declaration des fonctions du contrat |\n",
-    "| `envfree` | Fonction sans effets de bord |\n",
-    "| `env` | Environnement (msg.sender, msg.value, |\n",
-    "\n",
-    "### Avantages\n",
-    "- Couverture complete (tous les cas possibles)\n",
-    "- Preuves mathematiques rigoureuses\n",
-    "- Detection de bugs subtils\n",
-    "\n",
-    "### Limites\n",
-    "- Complexite de configuration\n",
-    "- Temps de verification\n",
-    "- Faux positifs possibles\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Notebook suivant** : [SC-21-Move-Sui](../05-Alternative-Chains/SC-21-Move-Sui.ipynb)"
-   ]
+   "source": "---\n\n## 6. Resume\n\n| Concept | Description |\n|--------|-------------|\n| Invariant | Propriete toujours vraie |\n| Regle | Comportement attendu apres une action |\n| `methods` | Declaration des fonctions du contrat |\n| `envfree` | Fonction sans effets de bord |\n| `env` | Environnement (msg.sender, msg.value, block.timestamp) |\n\n### Avantages\n- Couverture complete (tous les cas possibles)\n- Preuves mathematiques rigoureuses\n- Detection de bugs subtils\n\n### Limites\n- Complexite de configuration\n- Temps de verification\n- Faux positifs possibles\n\n---\n\n**Notebook suivant** : [Zero-Knowledge Proofs](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Replace deprecated `certoraRun.py` with modern `certoraRun` CLI command (5 occurrences)
- Fix broken navigation link at end of notebook: pointed to SC-21 instead of SC-15
- Fix truncated `env` description in summary table

## Test plan
- [x] Verify nav link points to correct SC-15 notebook
- [x] Certora CLI commands use modern `certoraRun` syntax
- [x] No source code changes (only print content + markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)