### PR TITLE
docs(genai): weave fil rouge through all GenAI READMEs (#48 Track E)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/README.md
@@ -2,7 +2,9 @@
 
 [← Documentation Audio](../README.md) | [↑ ..](../README.md) | [→ Audio Advanced](../02-Advanced/)
 
-Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vocale (STT), synthèse vocale (TTS), et opérations audio de base.
+Ce module couvre les fondamentaux du traitement audio par IA : reconnaissance vocale (STT), synthese vocale (TTS), et operations audio de base.
+
+**Dans le cadre du fil rouge podcast** : avant de produire un episode, il faut maitriser les deux briques essentielles -- faire parler la machine (TTS) et comprendre la parole humaine (STT). [01-1](01-1-OpenAI-TTS-Intro.ipynb) et [01-2](01-2-OpenAI-Whisper-STT.ipynb) couvrent les API cloud (rapides a mettre en oeuvre), tandis que [01-4](01-4-Whisper-Local.ipynb) et [01-5](01-5-Kokoro-TTS-Local.ipynb) passent en local GPU pour l'autonomie et le controle. [01-3](01-3-Basic-Audio-Operations.ipynb) donne les bases techniques (spectrogrammes, MFCC) utiles pour comprendre ce que manipulent les modeles.
 
 ## Vue d'ensemble
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/README.md
@@ -2,7 +2,9 @@
 
 [← Audio Foundation](../01-Foundation/) | [↑ Audio](../README.md) | [→ Audio Orchestration](../03-Orchestration/)
 
-Ce module explore les techniques avancées : clonage vocal, génération musicale, séparation de sources, et modèles TTS expressifs.
+Ce module explore les techniques avancees : clonage vocal, generation musicale, separation de sources, et modeles TTS expressifs.
+
+**Dans le cadre du fil rouge podcast** : un podcast de qualite a besoin d'une voix coherente et d'une identite sonore. [02-2](02-2-XTTS-Voice-Cloning.ipynb) clone une voix a partir d'un echantillon pour creer un narrateur recurrent. [02-3](02-3-MusicGen-Generation.ipynb) genere le jingle et le fond musical. [02-4](02-4-Demucs-Source-Separation.ipynb) isole les pistes audio d'un mix existant (utile pour remasteriser un interview). [02-8](02-8-Expressive-TTS.ipynb) ajoute des emotions et de la prosodie pour varier le ton selon les passages.
 
 ## Vue d'ensemble
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/README.md
@@ -2,7 +2,9 @@
 
 [← Audio Advanced](../02-Advanced/) | [↑ Audio](../README.md) | [→ Audio Applications](../04-Applications/)
 
-Ce module couvre l'orchestration de plusieurs modèles audio, les pipelines complexes, et l'API temps réel d'OpenAI.
+Ce module couvre l'orchestration de plusieurs modeles audio, les pipelines complexes, et l'API temps reel d'OpenAI.
+
+**Dans le cadre du fil rouge podcast** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Audio-Comparison.ipynb) compare les modeles STT et TTS pour choisir le meilleur selon le budget et la qualite vises. [03-2](03-2-Audio-Pipeline-Orchestration.ipynb) construit le pipeline STT vers LLM vers TTS qui constitue le coeur du podcast automatise. [03-3](03-3-Realtime-Voice-API.ipynb) montre l'alternative temps reel d'OpenAI pour les interactions live.
 
 ## Vue d'overview
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
@@ -2,7 +2,9 @@
 
 [← Audio Orchestration](../03-Orchestration/) | [↑ Audio](../README.md) | [→ Video](../../Video/README.md)
 
-Ce module présente des cas d'usage concrets et des workflows de production pour l'audio génératif.
+Ce module presente des cas d'usage concrets et des workflows de production pour l'audio generatif.
+
+**Dans le cadre du fil rouge podcast** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Audio-Content.ipynb) automatise la narration de cours (texte vers TTS avec structuration LLM). [04-2](04-2-Transcription-Pipeline.ipynb) gere la transcription batch avec sous-titres SRT pour les episodes longs. [04-3](04-3-Music-Composition-Workflow.ipynb) compose des bandes sonores en plusieurs etapes. [04-4](04-4-Audio-Video-Sync.ipynb) synchronise l'audio genere avec la piste video.
 
 ## Vue d'overview
 

--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -2,23 +2,13 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Video Workflows](../Video/README.md)
 
-Bienvenue dans l'univers fascinant de l'audio IA ! Souvent négligé au profit des images et du texte, le traitement audio représente pourtant la modalité la plus accessible et naturelle de l'interaction humaine. Que ce soit à travers la voix, la musique ou le son, l'IA révolutionne notre manière de communiquer, créer et comprendre le monde sonore.
+Le traitement audio est souvent le parent pauvre de l'IA generative, eclipsé par les images et le texte. Pourtant, la voix et la musique sont les modalites les plus naturelles de l'interaction humaine. Cette serie couvre l'ensemble de la chaine audio IA : reconnaissance vocale, synthese, clonage, generation musicale, et orchestration de pipelines.
 
-Cette série vous emmène au cœur des technologies audio IA, des bases de reconnaissance vocale aux applications de production professionnelle. Parcourez 21 notebooks complets qui vous guideront des fondements aux cas d'usage avancés.
+21 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production.
 
-## Fil rouge : Création d'un podcast automatisé
+## Fil rouge : construire un podcast automatise
 
-Le projet phare de cette série est la création d'un podcast automatisé entièrement généré par IA :
-- Synthèse vocale personnalisée avec Kokoro TTS et XTTS v2
-- Génération de musique de fond adaptée au mood avec MusicGen
-- Orchestration complète des services pour une production audio cohérente
-- Integration avec des systèmes de transcription pour la post-production
-
-C'est le projet ultime pour démontrer comment ces technologies s'articulent pour créer une solution concrète et professionnelle.
-
-## Vue d'ensemble
-
-21 notebooks répartis sur 4 niveaux de progression, constituant un parcours complet d'environ 14 à 16 d'apprentissage pratique, 100% validés pour garantir une expérience sans erreur.
+L'objectif fil rouge de cette serie est de construire un podcast entierement genere par IA. Chaque niveau apporte une brique supplementaire : TTS pour donner une voix au contenu (niveau 1), clonage vocal et musique pour l'identite sonore (niveau 2), pipelines STT vers LLM vers TTS pour l'assemblage (niveau 3), et workflows de production pour le deploiement (niveau 4).
 
 ## Structure
 
@@ -34,6 +24,8 @@ Audio/
 
 ### 01-Foundation - Bases Speech & Audio
 
+Avant de produire un podcast, il faut maitriser les deux briques de base : la synthese vocale (TTS) pour generer de la parole, et la reconnaissance vocale (STT) pour transcrire des fichiers audio existants. Ce niveau commence par les API cloud (simples et immediates), puis passe en local GPU pour l'autonomie et le controle fin. A la fin de ce niveau, vous savez faire parler une machine et comprendre de la parole.
+
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
 | [01-1-OpenAI-TTS-Intro](01-Foundation/01-1-OpenAI-TTS-Intro.ipynb) | API TTS (6 voix, formats, vitesse) | OpenAI API | 0 |
@@ -43,6 +35,8 @@ Audio/
 | [01-5-Kokoro-TTS-Local](01-Foundation/01-5-Kokoro-TTS-Local.ipynb) | Kokoro 82M, TTS legere | Local GPU | ~2 GB |
 
 ### 02-Advanced - Voix, Musique & Separation
+
+Un podcast de qualite demande une voix naturelle et une identite sonore distincte. Ce niveau couvre le clonage vocal (creer un narrateur unique a partir d'un echantillon), la generation musicale (jingle et fond sonore), la separation de sources (isoler la voix d'un mix existant), et les modeles TTS expressifs (varier le ton et l'emotion). Deux parcours possibles : voix ou musique, selon l'objectif.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -57,6 +51,8 @@ Audio/
 
 ### 03-Orchestration - Multi-modeles & Temps reel
 
+Les composants existent, il faut les assembler. Ce niveau construit les pipelines qui transforment un audio en texte (STT), l'enrichissent via un LLM, puis le reconvertissent en parole (TTS). Le notebook 03-2 realise explicitement un pipeline de podcast. L'API Realtime d'OpenAI (03-3) montre la version temps reel pour les interactions live.
+
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
 | [03-1-Multi-Model-Audio-Comparison](03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb) | Benchmark STT et TTS | Mixed | ~12 GB |
@@ -64,6 +60,8 @@ Audio/
 | [03-3-Realtime-Voice-API](03-Orchestration/03-3-Realtime-Voice-API.ipynb) | OpenAI Realtime API, WebSocket | OpenAI API | 0 |
 
 ### 04-Applications - Cas d'usage production
+
+Application directe : les notebooks de ce niveau mettent en oeuvre des workflows complets. 04-1 automatise la narration de cours (TTS + LLM), 04-2 traite la transcription batch avec sous-titres SRT, 04-3 compose de la musique en plusieurs etapes, 04-4 synchronise audio et video, et 04-5 explore le live coding musical avec un LLM.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -132,6 +130,18 @@ Video/ (serie complementaire)
 | Speech complet | 01-1 a 02-2 |
 | Musique | 02-3, 02-6, 02-7, 02-4, 04-3 |
 | Production | Tous + 03 + 04 |
+
+## Recette : construire un podcast automatise
+
+Le fil rouge de cette serie est la creation d'un podcast genere par IA. Voici comment les niveaux s'articulent pour y parvenir :
+
+1. **01-Foundation** (TTS + STT) : [01-1](01-Foundation/01-1-OpenAI-TTS-Intro.ipynb) et [01-5](01-Foundation/01-5-Kokoro-TTS-Local.ipynb) vous donnent les bases de la synthese vocale. [01-2](01-Foundation/01-2-OpenAI-Whisper-STT.ipynb) et [01-4](01-Foundation/01-4-Whisper-Local.ipynb) couvrent la reconnaissance vocale. A la fin de ce niveau, vous savez transformer du texte en audio et inversement.
+
+2. **02-Advanced** (voix + musique) : [02-2](02-Advanced/02-2-XTTS-Voice-Cloning.ipynb) clone une voix pour creer un narrateur coherent. [02-3](02-Advanced/02-3-MusicGen-Generation.ipynb) genere le jingle et le fond sonore. [02-4](02-Advanced/02-4-Demucs-Source-Separation.ipynb) isole les pistes si besoin, et [02-8](02-Advanced/02-8-Expressive-TTS.ipynb) ajoute de l'expressivite.
+
+3. **03-Orchestration** (assemblage) : [03-1](03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb) compare les modeaux pour choisir le meilleur STT/TTS selon le budget. [03-2](03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb) assemble le pipeline STT vers LLM vers TTS qui constitue le coeur du podcast automatise.
+
+4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Audio-Content.ipynb) applique le pipeline a la narration de cours. [04-2](04-Applications/04-2-Transcription-Pipeline.ipynb) gere la transcription batch pour les episodes longs. [04-4](04-Applications/04-4-Audio-Video-Sync.ipynb) synchronise avec la piste video si le podcast a une composante visuelle.
 
 ## Licence
 

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/README.md
@@ -4,6 +4,8 @@
 
 Ce module couvre les fondamentaux de la génération d'images par IA : modèles cloud, ComfyUI, et opérations de base.
 
+**Dans le cadre du fil rouge contenu visuel educatif** : avant de produire des visuels, il faut savoir generer une image a partir d'un texte. [01-1](01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-2-GPT-5-Image-Generation.ipynb) couvrent les API cloud (simples et immediates). [01-4](01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-5-Qwen-Image-Edit.ipynb) passent en local via ComfyUI pour le controle fin. [01-3](01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation (PIL, OpenCV) utiles pour comprendre ce que font les modeles.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/README.md
@@ -4,6 +4,8 @@
 
 Ce module explore les modèles de pointe : Qwen Image Edit avancé, FLUX, SD 3.5, et Z-Image/Lumina.
 
+**Dans le cadre du fil rouge contenu visuel educatif** : un visuel de qualite demande des outils precis. [02-1](02-1-Qwen-Image-Edit-2509.ipynb) edite une image existante pour corriger ou enrichir un diagramme. [02-2](02-2-FLUX-1-Advanced-Generation.ipynb) genere des images haute qualite. [02-4](02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage iteratif.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/README.md
@@ -4,6 +4,8 @@
 
 Ce module couvre l'orchestration de plusieurs modèles, les workflows complexes, et l'optimisation de performance.
 
+**Dans le cadre du fil rouge contenu visuel educatif** : en production, un seul modele ne suffit pas. [03-1](03-1-Multi-Model-Comparison.ipynb) compare les modeles pour choisir le meilleur selon le contexte. [03-2](03-2-Workflow-Orchestration.ipynb) assemble des pipelines (generation, edition, upscaling). [03-3](03-3-Performance-Optimization.ipynb) optimise les performances pour le deploiement.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/README.md
@@ -4,6 +4,8 @@
 
 Ce module présente des cas d'usage concrets et des workflows de production pour la génération d'images.
 
+**Dans le cadre du fil rouge contenu visuel educatif** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Content-Generation.ipynb) automatise la creation de visuels pedagogiques (brief texte vers images). [04-2](04-2-Creative-Workflows.ipynb) gere les workflows creatifs. [04-3](04-3-Production-Integration.ipynb) integre le pipeline en production.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -2,17 +2,11 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Management](../00-GenAI-Environment/00-2-Docker-Services-Management.ipynb)
 
-La génération d'images par IA représente l'une des entrées les plus intuitives et captivantes dans le monde de l'intelligence artificielle. À l'intersection entre créativité artistique et contrôle technique, elle offre un moyen unique de transformer des concepts abstraits en contenus visuels concrets, parfaits pour enrichir les ressources éducatives.
+La generation d'images par IA est la deuxieme modalite generative la plus accessible apres le texte. Elle couvre un spectre large : generation from scratch (DALL-E, FLUX), edition d'images existantes (Qwen Image Edit), upscaling (Real-ESRGAN), et orchestration de workflows multi-modeles via ComfyUI. 19 notebooks repartis sur 5 niveaux progressifs.
 
-## Fil rouge : Construction d'un générateur de contenu visuel éducatif
+## Fil rouge : construire un generateur de contenu visuel educatif
 
-Ce parcours vous guide dans la création d'un système capable de générer divers types de contenu visuel pour l'éducation :
-- **Diagrammes pédagogiques** complexes expliquant des mécanismes abstraits
-- **Illustrations conceptuelles** pour rendre les idées scientifiques accessibles
-- **Modèles décoratifs** personnalisés pour l'identité visuelle des supports de cours
-- **Visualisations interactives** combinant texte et images pour une meilleure rétention
-
-Chaque étape de ce fil rouge est conçue pour vous apprendre à maîtriser à la fois les techniques de génération et leur application pratique dans un contexte éducatif.
+L'objectif fil rouge de cette serie est de construire un systeme capable de produire des visuels pedagogiques de qualite : diagrammes, illustrations conceptuelles, et images d'identite pour des supports de cours. Chaque niveau apporte une brique supplementaire : generation simple via API cloud (niveau 1), modeles avances et edition fine (niveau 2), comparaison et orchestration multi-modeles (niveau 3), workflows de production (niveau 4), et cas d'usage concrets par domaine (examples).
 
 ## Vue d'ensemble
 
@@ -34,6 +28,8 @@ Image/
 
 ### 01-Foundation - Modeles de base
 
+Avant de produire des visuels pedagogiques, il faut maitriser les outils de generation. Ce niveau couvre les deux approches : API cloud (DALL-E 3, GPT-5) pour la simplicite, et modeles locaux via ComfyUI (SD XL Turbo, Qwen) pour le controle fin. [01-3](01-Foundation/01-3-Basic-Image-Operations.ipynb) donne les bases de manipulation d'image (PIL, OpenCV) necessaires pour comprendre ce que font les modeles.
+
 | Notebook | Contenu | Service |
 |----------|---------|---------|
 | [01-1-OpenAI-DALL-E-3](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) | Generation avec DALL-E 3 | OpenAI API |
@@ -46,6 +42,8 @@ Image/
 
 ### 02-Advanced - Modeles avances
 
+Un visuel educatif de qualite demande des outils plus precis : edition d'images existantes (Qwen), generation haute qualite (FLUX), ou modeles legers et rapides (Z-Image/Lumina). Ce niveau explore les modeles de pointe et leurs compromis entre qualite, vitesse et ressources GPU.
+
 | Notebook | Contenu | Service |
 |----------|---------|---------|
 | [02-1-Qwen-Image-Edit-2509](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) | Edition avancee Qwen | ComfyUI |
@@ -57,6 +55,8 @@ Image/
 
 ### 03-Orchestration - Multi-modeles
 
+En production, un seul modele ne suffit pas toujours. Ce niveau compare les modeaux entre eux pour choisir le bon selon le contexte, orchestre des pipelines de traitement (generation puis edition puis upscaling), et optimise les performances pour le deploiement.
+
 | Notebook | Contenu |
 |----------|---------|
 | [03-1-Multi-Model-Comparison](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) | Comparaison multi-modeles |
@@ -66,6 +66,8 @@ Image/
 [README 03-Orchestration](03-Orchestration/README.md)
 
 ### 04-Applications - Production
+
+Ce niveau met en oeuvre les workflows complets : generation automatisee de contenu educatif, pipelines creatifs, integration en production, et un exemple concret de conversion d'images en patrons de point de croix.
 
 | Notebook | Contenu |
 |----------|---------|
@@ -77,6 +79,8 @@ Image/
 [README 04-Applications](04-Applications/README.md)
 
 ### examples/ - Cas d'usage
+
+Applications directes par domaine : histoire-geographie (cartes, reconstitutions), litterature (illustrations de textes), et sciences (diagrammes, schemas techniques). Ces notebooks montrent comment adapter les techniques des niveaux precedents a des besoins concrets.
 
 | Notebook | Domaine |
 |----------|---------|
@@ -130,6 +134,18 @@ Acces : http://localhost:8188
 | Decouverte rapide | 01-1, 01-3 |
 | Generation avancee | 01-1 a 02-4 |
 | Production | Tous + 03 + 04 |
+
+## Recette : construire un generateur de contenu visuel educatif
+
+Le fil rouge de cette serie est la creation d'un systeme de visuels pedagogiques. Voici comment les niveaux s'articulent :
+
+1. **01-Foundation** (generation de base) : [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb) et [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb) couvrent la generation via API cloud. [01-4](01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb) et [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) introduisent les modeles locaux. A la fin, vous savez generer une image a partir d'un texte.
+
+2. **02-Advanced** (edition et qualite) : [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb) permet d'editer une image existante pour corriger ou enrichir un visuel. [02-4](02-Advanced/02-4-Z-Image-Lumina2.ipynb) offre une generation rapide pour le prototypage. [02-2](02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb) pousse la qualite plus loin.
+
+3. **03-Orchestration** (comparaison et pipelines) : [03-1](03-Orchestration/03-1-Multi-Model-Comparison.ipynb) compare les modeles pour choisir le meilleur rapport qualite/cout. [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) assemble un pipeline de generation complet.
+
+4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Content-Generation.ipynb) applique le pipeline au contenu educatif. Les notebooks [examples/](examples/) montrent des cas d'usage par domaine (histoire, sciences, litterature).
 
 ## Licence
 

--- a/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/examples/README.md
@@ -4,6 +4,8 @@
 
 Exemples concrets d'utilisation des notebooks GenAI Image dans différents domaines éducatifs et professionnels.
 
+**Dans le cadre du fil rouge contenu visuel educatif** : ces notebooks montrent l'application directe des techniques des niveaux precedents. [science-diagrams](science-diagrams.ipynb) genere des diagrammes et schemas techniques pour les cours de sciences. [history-geography](history-geography.ipynb) cree des cartes et reconstitutions historiques. [literature-visual](literature-visual.ipynb) illustre des textes litteraires.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -136,6 +136,18 @@ dotnet --version
 - [SK Blog](https://devblogs.microsoft.com/semantic-kernel/)
 - [MCP Specification](https://modelcontextprotocol.io/)
 
+## Recette : construire le NotebookMaker (systeme 3 agents)
+
+Le fil rouge de cette serie est le NotebookMaker, un systeme multi-agents qui genere automatiquement des notebooks pedagogiques. Voici comment les notebooks s'articulent :
+
+1. **Fondations (01-03)** : [01](01-SemanticKernel-Intro.ipynb) cree un Kernel et connecte un LLM. [02](02-SemanticKernel-Advanced.ipynb) ajoute le function calling et la memoire. [03](03-SemanticKernel-Agents.ipynb) introduit les agents autonomes et la collaboration via AgentGroupChat.
+
+2. **Observabilite et donnees (04-06)** : [04](04-SemanticKernel-Filters-Observability.ipynb) intercepte et log les appels. [05](05-SemanticKernel-VectorStores.ipynb) connecte une base vectorielle (RAG). [06](06-SemanticKernel-ProcessFramework.ipynb) orchestre des workflows avec etat.
+
+3. **Extensions (07-08)** : [07](07-SemanticKernel-MultiModal.ipynb) ajoute les capacites multimodales (images, audio). [08](08-SemanticKernel-MCP.ipynb) connecte le Kernel au protocole MCP pour l'interopabilite.
+
+4. **NotebookMaker (09-10)** : [09](09-SemanticKernel-Building-CLR.ipynb) prepare l'interop Python/C#. [10](10-SemanticKernel-NotebookMaker.ipynb) assemble le systeme 3 agents (Admin, Coder, Reviewer). Les versions [10a](10a-SemanticKernel-NotebookMaker-batch.ipynb) et [10b](10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb) ajoutent le mode batch et la parametrisation Papermill.
+
 ## Changelog
 
 ### Fevrier 2026

--- a/MyIA.AI.Notebooks/GenAI/Texte/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Texte/README.md
@@ -122,6 +122,18 @@ python scripts/notebook_tools/notebook_tools.py validate GenAI/Texte --quick
 python scripts/notebook_tools/notebook_tools.py execute GenAI/Texte --timeout 300
 ```
 
+## Recette : maitriser les LLMs pour piloter tout le generatif
+
+Le fil rouge de cette serie est la progression de l'interaction basique avec un LLM vers la maitrise complete en production. Voici comment les tiers s'articulent :
+
+1. **Tier 1** (fondations) : [1_OpenAI_Intro](1_OpenAI_Intro.ipynb) couvre l'API OpenAI et les tokens. [2_PromptEngineering](2_PromptEngineering.ipynb) explore les techniques de prompting (zero-shot, few-shot, chain-of-thought). A la fin, vous savez interagir efficacement avec un LLM.
+
+2. **Tier 2** (sorties structurees) : [3_Structured_Outputs](3_Structured_Outputs.ipynb) maitrise les formats JSON et Pydantic. [4_Function_Calling](4_Function_Calling.ipynb) connecte le LLM a des outils externes. Ces deux notebooks sont essentiels pour tout systeme qui pilote d'autres modeles generatifs (image, audio, video).
+
+3. **Tier 3** (augmentation) : [5_RAG_Modern](5_RAG_Modern.ipynb) et [6_PDF_Web_Search](6_PDF_Web_Search.ipynb) enrichissent le LLM avec des sources externes. [7_Code_Interpreter](7_Code_Interpreter.ipynb) lui donne la capacite d'executer du code.
+
+4. **Tier 4** (production et local) : [8_Reasoning_Models](8_Reasoning_Models.ipynb) exploite les modeles raisonnants. [9_Production_Patterns](9_Production_Patterns.ipynb) couvre les patterns enterprise. [10_LocalLlama](10_LocalLlama.ipynb) et [11_Quantization](11_Quantization.ipynb) deployent en local avec vLLM.
+
 ## Relation avec les autres series
 
 - **GenAI/Images** : Generation d'images (DALL-E, Stable Diffusion)

--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/README.md
@@ -4,6 +4,8 @@
 
 Ce module couvre les fondamentaux de la vidéo par IA : opérations vidéo, compréhension vidéo, et amélioration.
 
+**Dans le cadre du fil rouge pipeline video pedagogique** : avant de generer des videos, il faut savoir les analyser et les manipuler. [01-1](01-1-Video-Operations-Basics.ipynb) donne les bases techniques (ffmpeg, moviepy). [01-2](01-2-GPT-5-Video-Understanding.ipynb) et [01-3](01-3-Qwen-VL-Video-Analysis.ipynb) couvrent la comprehension video (decomposition en scenes, Q&A sur le contenu). [01-4](01-4-Video-Enhancement-ESRGAN.ipynb) ameliore la qualite visuelle. [01-5](01-5-AnimateDiff-Introduction.ipynb) introduit la generation de mouvement a partir de texte.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/README.md
@@ -4,6 +4,8 @@
 
 Ce module explore les modèles de génération vidéo de pointe : HunyuanVideo, LTX Video, Wan Video, et SVD.
 
+**Dans le cadre du fil rouge pipeline video pedagogique** : ce niveau fournit les modeles generatifs. [02-1](02-1-HunyuanVideo-Generation.ipynb) produit des videos haute qualite (cinematographique). [02-3](02-3-Wan-Video-Generation.ipynb) offre une generation rapide avec support multilingue. [02-4](02-4-SVD-Image-to-Video.ipynb) anime une image existante -- utile pour transformer un diagramme ou une illustration en sequence animee.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/README.md
@@ -4,6 +4,8 @@
 
 Ce module couvre l'orchestration de plusieurs modèles vidéo, les workflows complexes, et l'intégration ComfyUI.
 
+**Dans le cadre du fil rouge pipeline video pedagogique** : les briques existent, il faut les assembler. [03-1](03-1-Multi-Model-Video-Comparison.ipynb) compare les modeaux pour choisir le meilleur selon le materiel et le contexte. [03-2](03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video qui constitue le coeur du generateur. [03-3](03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs plus flexibles.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/README.md
@@ -4,6 +4,8 @@
 
 Ce module présente des cas d'usage concrets et des workflows de production pour la génération vidéo.
 
+**Dans le cadre du fil rouge pipeline video pedagogique** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Video-Generation.ipynb) genere automatiquement du contenu video educatif a partir d'un script. [04-3](04-3-Sora-API-Cloud-Video.ipynb) explore la generation cloud via l'API Sora. [04-4](04-4-Production-Video-Pipeline.ipynb) assemble le pipeline bout-en-bout.
+
 ## Vue d'overview
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -2,15 +2,17 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Audio Sync](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb)
 
-**La video est le Graal de l'IA generative.** Elle combine l'analyse d'images, la comprehension du temps, la synchronisation audio, et la creation de mouvement coherent. Cette serie vous emmene de la simple comprehension d'une sequence video existante jusqu'a la production d'une video pedagogique complete, generee de bout en bout par des modeles d'IA.
+La video est la modalite generative la plus exigeante : elle combine l'analyse d'images, la comprehension du temps, la synchronisation audio, et la creation de mouvement coherent. Cette serie couvre l'ensemble de la chaine video IA : comprehension de sequences existantes, generation a partir de texte ou d'images, orchestration de pipelines multi-modeles, et workflows de production. 16 notebooks repartis sur 4 niveaux progressifs.
 
-**Fil rouge** : construire un pipeline capable de transformer un script texte en video pedagogique animee, avec voix de synthese et fond musical genere — un defi qui mobilise tous les niveaux de cette serie.
+## Fil rouge : construire un pipeline texte vers video pedagogique
+
+L'objectif fil rouge de cette serie est de construire un pipeline capable de transformer un script texte en video pedagogique animee. Chaque niveau apporte une brique : comprehension video pour analyser les sequences (niveau 1), modeles generatifs pour creer du mouvement (niveau 2), orchestration pour assembler le pipeline (niveau 3), et workflows de production pour le deploiement (niveau 4).
 
 ## Progression par niveau
 
 ### 01-Foundation - Comprendre la video avant de la generer
 
-On ne peut pas creer ce qu'on ne comprend pas. Ce niveau pose les bases techniques (codecs, ffmpeg, moviepy) et introduit la comprehension video par IA : decomposer une sequence en scenes, repondre a des questions sur le contenu, analyser le mouvement. Vous decouvrirez aussi le surcadrage d'images (ESRGAN) et l'interpolation de frames (RIFE) pour ameliorer la qualite visuelle.
+On ne peut pas creer ce qu'on ne comprend pas. Ce niveau pose les bases techniques (codecs, ffmpeg, moviepy) et introduit la comprehension video par IA : decomposer une sequence en scenes, repondre a des questions sur le contenu, analyser le mouvement. Vous decouvrirez aussi le surcadrage d'images (ESRGAN) et l'interpolation de frames (RIFE) pour ameliorer la qualite visuelle. A la fin de ce niveau, vous savez analyser une video existante et en extraire des informations structurelles.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -51,6 +53,18 @@ Les trois derniers notebooks et le notebook de synchronisation audio-video concl
 | [04-2-Creative-Video-Workflows](04-Applications/04-2-Creative-Video-Workflows.ipynb) | Style transfer, music video | Mixed | ~16 GB |
 | [04-3-Sora-API-Cloud-Video](04-Applications/04-3-Sora-API-Cloud-Video.ipynb) | Sora 2 API, cloud vs local | OpenAI API | 0 |
 | [04-4-Production-Video-Pipeline](04-Applications/04-4-Production-Video-Pipeline.ipynb) | Pipeline complet bout-en-bout | Mixed | ~18 GB |
+
+## Recette : construire un pipeline texte vers video pedagogique
+
+Le fil rouge de cette serie est la creation d'un pipeline de video pedagogique generee par IA. Voici comment les niveaux s'articulent :
+
+1. **01-Foundation** (comprehension video) : [01-1](01-Foundation/01-1-Video-Operations-Basics.ipynb) donne les bases techniques (ffmpeg, moviepy). [01-2](01-Foundation/01-2-GPT-5-Video-Understanding.ipynb) et [01-3](01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb) couvrent la comprehension video (decomposition en scenes, Q&A). [01-4](01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb) ameliore la qualite. A la fin, vous savez analyser et manipuler une video existante.
+
+2. **02-Advanced** (generation video) : [02-1](02-Advanced/02-1-HunyuanVideo-Generation.ipynb) genere des videos haute qualite. [02-3](02-Advanced/02-3-Wan-Video-Generation.ipynb) offre une alternative rapide avec support multilingue. [02-4](02-Advanced/02-4-SVD-Image-to-Video.ipynb) anime une image existante (utile pour transformer un diagramme en animation).
+
+3. **03-Orchestration** (assemblage) : [03-1](03-Orchestration/03-1-Multi-Model-Video-Comparison.ipynb) compare les modeles pour choisir le bon. [03-2](03-Orchestration/03-2-Video-Workflow-Orchestration.ipynb) construit le pipeline text-to-image-to-video. [03-3](03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb) utilise ComfyUI pour des workflows natifs.
+
+4. **04-Applications** (production) : [04-1](04-Applications/04-1-Educational-Video-Generation.ipynb) applique le pipeline au contenu educatif. [04-4](04-Applications/04-4-Production-Video-Pipeline.ipynb) assemble le systeme bout-en-bout. Le notebook [04-4-Audio-Video-Sync](../Audio/04-Applications/04-4-Audio-Video-Sync.ipynb) de la serie Audio synchronise la video avec l'audio genere.
 
 ## Ce que vous saurez faire
 


### PR DESCRIPTION
## Summary
- Weave **fil rouge** (running pedagogical theme) through all 18 GenAI READMEs with precise notebook references
- Add **pedagogical level introductions** in Audio, Image, Video main READMEs
- Add **recipe summaries** in all 5 main series READMEs (Audio, Image, Video, Texte, SemanticKernel)
- Replace marketing language with professional tone across all main READMEs

## Changes per series

### Audio (5 files) — Fil rouge: podcast automatise
- `Audio/README.md`: 4 pedagogical level intros + recipe summary + tone fix
- `Audio/01-Foundation/README.md`: fil rouge paragraph (01-1 through 01-5)
- `Audio/02-Advanced/README.md`: fil rouge paragraph (02-2, 02-3, 02-4, 02-8)
- `Audio/03-Orchestration/README.md`: fil rouge paragraph (03-1, 03-2, 03-3)
- `Audio/04-Applications/README.md`: fil rouge paragraph (04-1 through 04-4)

### Image (6 files) — Fil rouge: generateur de contenu visuel educatif
- `Image/README.md`: pedagogical intros + recipe summary + tone fix
- `Image/01-Foundation/README.md` through `04-Applications/README.md`: fil rouge paragraphs
- `Image/examples/README.md`: fil rouge paragraph

### Video (5 files) — Fil rouge: pipeline video pedagogique
- `Video/README.md`: pedagogical intros + recipe summary + tone fix
- `Video/01-Foundation/README.md` through `04-Applications/README.md`: fil rouge paragraphs

### Texte (1 file)
- `Texte/README.md`: recipe summary (Tier 1-4 progression)

### SemanticKernel (1 file)
- `SemanticKernel/README.md`: recipe summary (01-10 NotebookMaker build-up)

## Test plan
- [x] All 18 files modified compile as valid markdown
- [x] No broken notebook links (references match actual filenames)
- [x] Professional tone verified (no marketing superlatives)
- [x] Fil rouge paragraphs reference existing notebooks only

🤖 Generated with [Claude Code](https://claude.com/claude-code)