### PR TITLE
docs(cross-series): add bridges to Tweety/Planners/Argument_Analysis

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -136,11 +136,15 @@ Le pipeline genere un rapport JSON dans `output/analysis_report.json` :
 | **Belief Set** | Ensemble de croyances formalisees |
 | **SAT** | Satisfaisabilite logique |
 
-## Relation avec SymbolicAI
+## Ponts avec les autres series
 
-Ce pipeline utilise :
-- [Tweety](../Tweety/) - Bibliotheque Java d'argumentation
-- Logique propositionnelle et SAT solvers
+| Serie | Connection | Details |
+| ----- | ---------- | ------- |
+| **[Tweety](../Tweety/)** | Backend argumentatif | Utilise directement TweetyProject (JPype) pour le raisonnement formel. Les semantiques de Dung (Tweety-5) et la revision de croyances (Tweety-4) sont au coeur du pipeline. |
+| **[Lean](../Lean/)** | Preuves formelles | La formalisation logique des arguments (Agentic-2) suit le meme paradigme que les tactiques Lean. La verification de coherence via SAT est analogue aux proof checkers. |
+| **[Tweety-9](../Tweety/Tweety-9-Preferences.ipynb)** | Preferences et vote | L'analyse d'arguments de valeur croise les modeles de preference et la theorie du choix social (GameTheory/social_choice_lean/). |
+
+> **Note** : Cette serie est en statut DRAFT — les notebooks definissent l'architecture mais n'ont pas encore d'execution complete. Voir [RECONSTRUCTION_PLAN.md](RECONSTRUCTION_PLAN.md) pour le statut.
 
 ## Ressources
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -295,10 +295,15 @@ La planification automatique est une branche de l'IA symbolique :
 - Recherche dans espace d'etats
 - Heuristiques admissibles pour optimalite
 
-Voir aussi :
-- [Tweety](../Tweety/) - Logique et argumentation
-- [Lean](../Lean/) - Verification formelle
-- [Z3](../Z3/) - Solveur SMT
+### Ponts avec les autres series
+
+| Serie | Connection | Details |
+| ----- | ---------- | ------- |
+| **[Tweety](../Tweety/)** | Logique et argumentation | Les solveurs SAT/CSP de Tweety complementent les planificateurs PDDL. Les dialogues argumentatifs (Tweety-8) sont des instances de planification multi-agents. |
+| **[Lean](../Lean/)** | Verification formelle | Les plans generes peuvent etre verifies formellement. Les heuristiques d'admissibilite (h-max, LM-cut) reposent sur des preuves de correction similaires aux tactiques Lean. |
+| **[SmartContracts](../SmartContracts/)** | Execution planifiee | Les smart contracts DeFi (liquidations, arbitrage) sont des problemes de planification sous contraintes temporelles et de gaz. Le notebook SC-14 (verification formelle) croise OR-Tools (Planners-7). |
+| **[GameTheory](../../GameTheory/)** | Jeux sequentiels | La recherche adversariale (A*, minimax) est commune a la planification classique et a la theorie des jeux. Les jeux cooperatifs (Shapley) sont des problemes d'allocation de taches planifiables. |
+| **[Search](../../Search/)** | Fondements communs | La serie Search couvre les algorithmes de base (BFS, DFS, A*) utilises dans les planificateurs. CSP (Search Part2) correspond a OR-Tools CP-SAT (Planners-7). |
 
 ## Contribution
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -263,6 +263,16 @@ La version est configurable dans `Tweety-1-Setup.ipynb` (variable `TWEETY_VERSIO
 - **GitHub** : https://github.com/TweetyProjectTeam/TweetyProject
 - **JPype** : https://jpype.readthedocs.io/
 
+## Ponts avec les autres series
+
+| Serie | Connection | Details |
+|-------|------------|---------|
+| **[Argument_Analysis](../Argument_Analysis/)** | Argumentation agentique | Utilise Tweety comme backend Java pour le raisonnement argumentatif. Les semantiques de Dung (notebook 5) sont directement appliquees dans l'analyse de textes. |
+| **[Lean](../Lean/)** | Verification formelle | Les logiques propositionnelles et FOL (notebooks 2-3) correspondent aux tactiques de preuve Lean. Les SAT solvers de Tweety completent la verification Lean. |
+| **[SmartContracts](../SmartContracts/)** | Methods formelles | La verification formelle SC-14 (Certora/SMTChecker) utilise les memes solveurs SAT/SMT. La logique propositionnelle de Tweety est la base des invariants Solidity. |
+| **[GameTheory](../../GameTheory/)** | Theorie du vote | Le notebook 9 (Preferences/Vote) couvre les concepts de choix social formalises dans `social_choice_lean/` (Arrow, Sen, Voting). |
+| **[Planners](../Planners/)** | Planification argumentative | Les dialogues argumentatifs (notebook 8) peuvent etre modelises comme des problemes de planification PDDL. |
+
 ## Licence
 
 Les notebooks sont distribues sous licence MIT.


### PR DESCRIPTION
## Summary
- Add cross-series bridge sections to 3 SymbolicAI sub-series READMEs (Tweety, Planners, Argument_Analysis)
- Each bridge table links to relevant series with specific pedagogical connections
- Flag Argument_Analysis as DRAFT with reference to RECONSTRUCTION_PLAN.md
- Complements PR #787 (Lean/GameTheory/SmartContracts bridges)

## Test plan
- [x] README markdown renders correctly (table formatting)
- [x] Cross-references use relative paths that resolve in GitHub
- [x] No broken links (all referenced series exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)