### PR TITLE
fix(semanticweb): audit #786 - fix 3 notebooks (SW-5, SW-9, SW-13)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -5,10 +5,10 @@
    "id": "a08b7ef7",
    "metadata": {
     "papermill": {
-     "duration": 0.012647,
-     "end_time": "2026-05-02T00:02:45.035176+00:00",
+     "duration": 0.011237,
+     "end_time": "2026-05-07T11:43:35.387440",
      "exception": false,
-     "start_time": "2026-05-02T00:02:45.022529+00:00",
+     "start_time": "2026-05-07T11:43:35.376203",
      "status": "completed"
     },
     "tags": []
@@ -73,10 +73,10 @@
    "id": "da6683f9",
    "metadata": {
     "papermill": {
-     "duration": 0.015951,
-     "end_time": "2026-05-02T00:02:45.067236+00:00",
+     "duration": 0.007815,
+     "end_time": "2026-05-07T11:43:35.402202",
      "exception": false,
-     "start_time": "2026-05-02T00:02:45.051285+00:00",
+     "start_time": "2026-05-07T11:43:35.394387",
      "status": "completed"
     },
     "tags": []
@@ -93,28 +93,21 @@
    "id": "787a19fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:45.085335Z",
-     "iopub.status.busy": "2026-05-02T00:02:45.084966Z",
-     "iopub.status.idle": "2026-05-02T00:02:48.606539Z",
-     "shell.execute_reply": "2026-05-02T00:02:48.605767Z"
+     "iopub.execute_input": "2026-05-07T11:43:35.417962Z",
+     "iopub.status.busy": "2026-05-07T11:43:35.417259Z",
+     "iopub.status.idle": "2026-05-07T11:43:36.796202Z",
+     "shell.execute_reply": "2026-05-07T11:43:36.795295Z"
     },
     "papermill": {
-     "duration": 3.532935,
-     "end_time": "2026-05-02T00:02:48.607951+00:00",
+     "duration": 1.389178,
+     "end_time": "2026-05-07T11:43:36.798194",
      "exception": false,
-     "start_time": "2026-05-02T00:02:45.075016+00:00",
+     "start_time": "2026-05-07T11:43:35.409016",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Installation de reasonable...\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -148,10 +141,10 @@
    "id": "trans-002",
    "metadata": {
     "papermill": {
-     "duration": 0.007846,
-     "end_time": "2026-05-02T00:02:48.625625+00:00",
+     "duration": 0.007139,
+     "end_time": "2026-05-07T11:43:36.813435",
      "exception": false,
-     "start_time": "2026-05-02T00:02:48.617779+00:00",
+     "start_time": "2026-05-07T11:43:36.806296",
      "status": "completed"
     },
     "tags": []
@@ -166,16 +159,16 @@
    "id": "8ce4bd97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:48.644838Z",
-     "iopub.status.busy": "2026-05-02T00:02:48.644383Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.101143Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.100081Z"
+     "iopub.execute_input": "2026-05-07T11:43:36.832190Z",
+     "iopub.status.busy": "2026-05-07T11:43:36.831451Z",
+     "iopub.status.idle": "2026-05-07T11:43:37.685373Z",
+     "shell.execute_reply": "2026-05-07T11:43:37.683854Z"
     },
     "papermill": {
-     "duration": 0.46694,
-     "end_time": "2026-05-02T00:02:49.102334+00:00",
+     "duration": 0.864411,
+     "end_time": "2026-05-07T11:43:37.687646",
      "exception": false,
-     "start_time": "2026-05-02T00:02:48.635394+00:00",
+     "start_time": "2026-05-07T11:43:36.823235",
      "status": "completed"
     },
     "tags": []
@@ -185,7 +178,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Python: 3.13.12\n",
+      "Python: 3.13.3\n",
       "RDFLib: 7.6.0\n",
       "owlrl: 7.1.4\n"
      ]
@@ -212,10 +205,10 @@
    "id": "1b9c4df4",
    "metadata": {
     "papermill": {
-     "duration": 0.01013,
-     "end_time": "2026-05-02T00:02:49.119500+00:00",
+     "duration": 0.010369,
+     "end_time": "2026-05-07T11:43:37.709303",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.109370+00:00",
+     "start_time": "2026-05-07T11:43:37.698934",
      "status": "completed"
     },
     "tags": []
@@ -232,16 +225,16 @@
    "id": "6e3c4792",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.145700Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.145329Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.154939Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.154143Z"
+     "iopub.execute_input": "2026-05-07T11:43:37.731919Z",
+     "iopub.status.busy": "2026-05-07T11:43:37.731137Z",
+     "iopub.status.idle": "2026-05-07T11:43:37.742091Z",
+     "shell.execute_reply": "2026-05-07T11:43:37.740571Z"
     },
     "papermill": {
-     "duration": 0.026585,
-     "end_time": "2026-05-02T00:02:49.156304+00:00",
+     "duration": 0.024209,
+     "end_time": "2026-05-07T11:43:37.744155",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.129719+00:00",
+     "start_time": "2026-05-07T11:43:37.719946",
      "status": "completed"
     },
     "tags": []
@@ -293,10 +286,10 @@
    "id": "trans-005",
    "metadata": {
     "papermill": {
-     "duration": 0.0226,
-     "end_time": "2026-05-02T00:02:49.193026+00:00",
+     "duration": 0.006119,
+     "end_time": "2026-05-07T11:43:37.760793",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.170426+00:00",
+     "start_time": "2026-05-07T11:43:37.754674",
      "status": "completed"
     },
     "tags": []
@@ -311,16 +304,16 @@
    "id": "d54d3c88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.284942Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.284099Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.295524Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.294213Z"
+     "iopub.execute_input": "2026-05-07T11:43:37.777171Z",
+     "iopub.status.busy": "2026-05-07T11:43:37.776289Z",
+     "iopub.status.idle": "2026-05-07T11:43:37.788411Z",
+     "shell.execute_reply": "2026-05-07T11:43:37.786955Z"
     },
     "papermill": {
-     "duration": 0.032789,
-     "end_time": "2026-05-02T00:02:49.297042+00:00",
+     "duration": 0.022246,
+     "end_time": "2026-05-07T11:43:37.790356",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.264253+00:00",
+     "start_time": "2026-05-07T11:43:37.768110",
      "status": "completed"
     },
     "tags": []
@@ -371,10 +364,10 @@
    "id": "trans-006",
    "metadata": {
     "papermill": {
-     "duration": 0.009171,
-     "end_time": "2026-05-02T00:02:49.317069+00:00",
+     "duration": 0.010456,
+     "end_time": "2026-05-07T11:43:37.808694",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.307898+00:00",
+     "start_time": "2026-05-07T11:43:37.798238",
      "status": "completed"
     },
     "tags": []
@@ -389,16 +382,16 @@
    "id": "95be65b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.341571Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.341278Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.350410Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.349171Z"
+     "iopub.execute_input": "2026-05-07T11:43:37.824081Z",
+     "iopub.status.busy": "2026-05-07T11:43:37.823260Z",
+     "iopub.status.idle": "2026-05-07T11:43:37.831972Z",
+     "shell.execute_reply": "2026-05-07T11:43:37.830695Z"
     },
     "papermill": {
-     "duration": 0.025238,
-     "end_time": "2026-05-02T00:02:49.352273+00:00",
+     "duration": 0.0183,
+     "end_time": "2026-05-07T11:43:37.833395",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.327035+00:00",
+     "start_time": "2026-05-07T11:43:37.815095",
      "status": "completed"
     },
     "tags": []
@@ -453,10 +446,10 @@
    "id": "trans-007",
    "metadata": {
     "papermill": {
-     "duration": 0.01169,
-     "end_time": "2026-05-02T00:02:49.373554+00:00",
+     "duration": 0.009023,
+     "end_time": "2026-05-07T11:43:37.850224",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.361864+00:00",
+     "start_time": "2026-05-07T11:43:37.841201",
      "status": "completed"
     },
     "tags": []
@@ -471,16 +464,16 @@
    "id": "7d897e51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.397670Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.397341Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.411479Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.410782Z"
+     "iopub.execute_input": "2026-05-07T11:43:37.869404Z",
+     "iopub.status.busy": "2026-05-07T11:43:37.869101Z",
+     "iopub.status.idle": "2026-05-07T11:43:37.881444Z",
+     "shell.execute_reply": "2026-05-07T11:43:37.879896Z"
     },
     "papermill": {
-     "duration": 0.025871,
-     "end_time": "2026-05-02T00:02:49.412656+00:00",
+     "duration": 0.024197,
+     "end_time": "2026-05-07T11:43:37.883049",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.386785+00:00",
+     "start_time": "2026-05-07T11:43:37.858852",
      "status": "completed"
     },
     "tags": []
@@ -493,16 +486,16 @@
       "* Ontologie sauvegardee: data/pizza_test.owl\n",
       "\n",
       "--- Apercu des triples (10 premiers) ---\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#NonVegetarianPizza'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Restriction'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#ham'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#MeatTopping'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#mozzarella'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#CheeseTopping'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#PizzaOntology'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Ontology'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#thinBase'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#ThinAndCrispyBase'))\n",
       "(rdflib.term.URIRef('http://example.org/pizza#myPizza'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#Pizza'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#PizzaTopping'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianTopping'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#deepBase'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#DeepPanBase'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#pepperoni'), rdflib.term.URIRef('http://example.org/pizza#hasTopping'), rdflib.term.URIRef('http://example.org/pizza#ham'))\n",
-      "(rdflib.term.URIRef('http://example.org/pizza#MeatTopping'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n"
+      "(rdflib.term.URIRef('http://example.org/pizza#MeatTopping'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianPizza'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://example.org/pizza#Pizza'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#ham'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#MeatTopping'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#margherita'), rdflib.term.URIRef('http://example.org/pizza#hasTopping'), rdflib.term.URIRef('http://example.org/pizza#tomato'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Restriction'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianPizzaDef'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Class'))\n",
+      "(rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#allValuesFrom'), rdflib.term.URIRef('http://example.org/pizza#VegetarianTopping'))\n"
      ]
     }
    ],
@@ -527,10 +520,10 @@
    "id": "4e2eed58",
    "metadata": {
     "papermill": {
-     "duration": 0.007606,
-     "end_time": "2026-05-02T00:02:49.428612+00:00",
+     "duration": 0.007284,
+     "end_time": "2026-05-07T11:43:37.896011",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.421006+00:00",
+     "start_time": "2026-05-07T11:43:37.888727",
      "status": "completed"
     },
     "tags": []
@@ -546,10 +539,10 @@
    "id": "1f12cb7a",
    "metadata": {
     "papermill": {
-     "duration": 0.007299,
-     "end_time": "2026-05-02T00:02:49.444302+00:00",
+     "duration": 0.010763,
+     "end_time": "2026-05-07T11:43:37.916007",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.437003+00:00",
+     "start_time": "2026-05-07T11:43:37.905244",
      "status": "completed"
     },
     "tags": []
@@ -571,16 +564,16 @@
    "id": "6b923b65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.461223Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.460947Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.590978Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.589767Z"
+     "iopub.execute_input": "2026-05-07T11:43:37.934137Z",
+     "iopub.status.busy": "2026-05-07T11:43:37.933501Z",
+     "iopub.status.idle": "2026-05-07T11:43:38.041562Z",
+     "shell.execute_reply": "2026-05-07T11:43:38.040199Z"
     },
     "papermill": {
-     "duration": 0.140222,
-     "end_time": "2026-05-02T00:02:49.592538+00:00",
+     "duration": 0.11719,
+     "end_time": "2026-05-07T11:43:38.043411",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.452316+00:00",
+     "start_time": "2026-05-07T11:43:37.926221",
      "status": "completed"
     },
     "tags": []
@@ -590,7 +583,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Temps owlrl: 0.1227 secondes\n",
+      "✓ Temps owlrl: 0.0992 secondes\n",
       "✓ Triples avant raisonnement: 40\n",
       "✓ Triples après raisonnement: 251\n",
       "✓ Triples inférés: 211\n"
@@ -623,10 +616,10 @@
    "id": "trans-011",
    "metadata": {
     "papermill": {
-     "duration": 0.009096,
-     "end_time": "2026-05-02T00:02:49.614893+00:00",
+     "duration": 0.011543,
+     "end_time": "2026-05-07T11:43:38.064832",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.605797+00:00",
+     "start_time": "2026-05-07T11:43:38.053289",
      "status": "completed"
     },
     "tags": []
@@ -641,16 +634,16 @@
    "id": "17d2d96d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.642179Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.641903Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.647337Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.646635Z"
+     "iopub.execute_input": "2026-05-07T11:43:38.088098Z",
+     "iopub.status.busy": "2026-05-07T11:43:38.087597Z",
+     "iopub.status.idle": "2026-05-07T11:43:38.097070Z",
+     "shell.execute_reply": "2026-05-07T11:43:38.095383Z"
     },
     "papermill": {
-     "duration": 0.017233,
-     "end_time": "2026-05-02T00:02:49.648498+00:00",
+     "duration": 0.025523,
+     "end_time": "2026-05-07T11:43:38.099263",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.631265+00:00",
+     "start_time": "2026-05-07T11:43:38.073740",
      "status": "completed"
     },
     "tags": []
@@ -661,21 +654,21 @@
      "output_type": "stream",
      "text": [
       "--- Exemples de triples inférés par owlrl ---\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Nothing'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://example.org/pizza#CheeseTopping'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#domain'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#unsignedLong'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#unsignedLong'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#positiveInteger'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Datatype'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#ObjectProperty'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#isDefinedBy'))\n",
+      "  (rdflib.term.URIRef('http://example.org/pizza#CheeseTopping'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://example.org/pizza#CheeseTopping'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Literal'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Literal'))\n",
+      "  (rdflib.term.URIRef('http://example.org/pizza#margherita'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#base64Binary'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#base64Binary'))\n",
       "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#int'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Datatype'))\n",
-      "  (rdflib.term.URIRef('http://example.org/pizza#VegetarianTopping'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://example.org/pizza#VegetarianTopping'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#boolean'))\n",
-      "  (rdflib.term.URIRef('http://example.org/pizza#deepBase'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://example.org/pizza#deepBase'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#range'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#comment'))\n",
-      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#normalizedString'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#normalizedString'))\n",
+      "  (rdflib.term.URIRef('http://example.org/pizza#VegetarianPizza'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#subClassOf'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#Thing'))\n",
+      "  (rdflib.term.URIRef('http://example.org/pizza#myPizza'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://example.org/pizza#myPizza'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#decimal'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Datatype'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#AnnotationProperty'))\n",
       "  (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'))\n",
-      "  (rdflib.term.URIRef('http://example.org/pizza#VegetarianPizza'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://example.org/pizza#VegetarianPizza'))\n",
-      "  (rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://example.org/pizza#VegetarianRestriction'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#unsignedLong'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#unsignedLong'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#hexBinary'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('http://www.w3.org/2000/01/rdf-schema#Datatype'))\n",
+      "  (rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTimeStamp'), rdflib.term.URIRef('http://www.w3.org/2002/07/owl#sameAs'), rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#dateTimeStamp'))\n",
       "  ... et 196 autres\n"
      ]
     }
@@ -695,10 +688,10 @@
    "id": "60666422",
    "metadata": {
     "papermill": {
-     "duration": 0.010611,
-     "end_time": "2026-05-02T00:02:49.668571+00:00",
+     "duration": 0.007614,
+     "end_time": "2026-05-07T11:43:38.115153",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.657960+00:00",
+     "start_time": "2026-05-07T11:43:38.107539",
      "status": "completed"
     },
     "tags": []
@@ -719,10 +712,10 @@
    "id": "68f64dd9",
    "metadata": {
     "papermill": {
-     "duration": 0.008834,
-     "end_time": "2026-05-02T00:02:49.687940+00:00",
+     "duration": 0.010398,
+     "end_time": "2026-05-07T11:43:38.135809",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.679106+00:00",
+     "start_time": "2026-05-07T11:43:38.125411",
      "status": "completed"
     },
     "tags": []
@@ -738,10 +731,10 @@
    "id": "b4e1bfc9",
    "metadata": {
     "papermill": {
-     "duration": 0.012913,
-     "end_time": "2026-05-02T00:02:49.709915+00:00",
+     "duration": 0.011629,
+     "end_time": "2026-05-07T11:43:38.156799",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.697002+00:00",
+     "start_time": "2026-05-07T11:43:38.145170",
      "status": "completed"
     },
     "tags": []
@@ -763,16 +756,16 @@
    "id": "304002fa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.744171Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.743801Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.749225Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.748450Z"
+     "iopub.execute_input": "2026-05-07T11:43:38.178312Z",
+     "iopub.status.busy": "2026-05-07T11:43:38.177808Z",
+     "iopub.status.idle": "2026-05-07T11:43:38.184047Z",
+     "shell.execute_reply": "2026-05-07T11:43:38.182801Z"
     },
     "papermill": {
-     "duration": 0.025213,
-     "end_time": "2026-05-02T00:02:49.750548+00:00",
+     "duration": 0.019095,
+     "end_time": "2026-05-07T11:43:38.186057",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.725335+00:00",
+     "start_time": "2026-05-07T11:43:38.166962",
      "status": "completed"
     },
     "tags": []
@@ -802,10 +795,10 @@
    "id": "trans-016",
    "metadata": {
     "papermill": {
-     "duration": 0.012118,
-     "end_time": "2026-05-02T00:02:49.773620+00:00",
+     "duration": 0.011959,
+     "end_time": "2026-05-07T11:43:38.207017",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.761502+00:00",
+     "start_time": "2026-05-07T11:43:38.195058",
      "status": "completed"
     },
     "tags": []
@@ -820,16 +813,16 @@
    "id": "2bcbb98f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.888315Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.888022Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.896591Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.895917Z"
+     "iopub.execute_input": "2026-05-07T11:43:38.230119Z",
+     "iopub.status.busy": "2026-05-07T11:43:38.229295Z",
+     "iopub.status.idle": "2026-05-07T11:43:38.243299Z",
+     "shell.execute_reply": "2026-05-07T11:43:38.241867Z"
     },
     "papermill": {
-     "duration": 0.106972,
-     "end_time": "2026-05-02T00:02:49.897654+00:00",
+     "duration": 0.027953,
+     "end_time": "2026-05-07T11:43:38.244990",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.790682+00:00",
+     "start_time": "2026-05-07T11:43:38.217037",
      "status": "completed"
     },
     "tags": []
@@ -839,7 +832,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Ontologie créée dans OWLReady2\n"
+      "✓ Ontologie créée dans OWLReady2"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -894,10 +894,10 @@
    "id": "trans-017",
    "metadata": {
     "papermill": {
-     "duration": 0.007287,
-     "end_time": "2026-05-02T00:02:49.913947+00:00",
+     "duration": 0.006479,
+     "end_time": "2026-05-07T11:43:38.257961",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.906660+00:00",
+     "start_time": "2026-05-07T11:43:38.251482",
      "status": "completed"
     },
     "tags": []
@@ -912,16 +912,16 @@
    "id": "c50ac732",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.932159Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.931828Z",
-     "iopub.status.idle": "2026-05-02T00:02:49.938815Z",
-     "shell.execute_reply": "2026-05-02T00:02:49.937990Z"
+     "iopub.execute_input": "2026-05-07T11:43:38.280286Z",
+     "iopub.status.busy": "2026-05-07T11:43:38.279569Z",
+     "iopub.status.idle": "2026-05-07T11:43:38.289239Z",
+     "shell.execute_reply": "2026-05-07T11:43:38.287529Z"
     },
     "papermill": {
-     "duration": 0.016905,
-     "end_time": "2026-05-02T00:02:49.940197+00:00",
+     "duration": 0.026214,
+     "end_time": "2026-05-07T11:43:38.291377",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.923292+00:00",
+     "start_time": "2026-05-07T11:43:38.265163",
      "status": "completed"
     },
     "tags": []
@@ -960,10 +960,10 @@
    "id": "trans-018",
    "metadata": {
     "papermill": {
-     "duration": 0.010242,
-     "end_time": "2026-05-02T00:02:49.964692+00:00",
+     "duration": 0.013827,
+     "end_time": "2026-05-07T11:43:38.317347",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.954450+00:00",
+     "start_time": "2026-05-07T11:43:38.303520",
      "status": "completed"
     },
     "tags": []
@@ -978,16 +978,16 @@
    "id": "286ae58e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:49.989820Z",
-     "iopub.status.busy": "2026-05-02T00:02:49.989325Z",
-     "iopub.status.idle": "2026-05-02T00:02:50.963633Z",
-     "shell.execute_reply": "2026-05-02T00:02:50.956959Z"
+     "iopub.execute_input": "2026-05-07T11:43:38.337301Z",
+     "iopub.status.busy": "2026-05-07T11:43:38.336491Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.366941Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.366130Z"
     },
     "papermill": {
-     "duration": 0.993831,
-     "end_time": "2026-05-02T00:02:50.969142+00:00",
+     "duration": 1.044071,
+     "end_time": "2026-05-07T11:43:39.369084",
      "exception": false,
-     "start_time": "2026-05-02T00:02:49.975311+00:00",
+     "start_time": "2026-05-07T11:43:38.325013",
      "status": "completed"
     },
     "tags": []
@@ -1005,14 +1005,14 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx2000M -cp C:\\ProgramData\\miniconda3\\Lib\\site-packages\\owlready2\\hermit;C:\\ProgramData\\miniconda3\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpkzuk6g8f\n"
+      "    java -Xmx2000M -cp C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\AppData\\Roaming\\Python\\Python313\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpu3u0p3he\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ Temps HermiT (via OWLReady2): 0.9481 secondes\n",
+      "✓ Temps HermiT (via OWLReady2): 1.0186 secondes\n",
       "\n",
       "--- Types inférés pour Margherita ---\n",
       "  Classes directes: [pizza.VegetarianPizza]\n",
@@ -1024,7 +1024,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.9434623718261719 seconds\n",
+      "* Owlready2 * HermiT took 1.015308141708374 seconds\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
@@ -1072,10 +1072,10 @@
    "id": "316bcd32",
    "metadata": {
     "papermill": {
-     "duration": 0.01896,
-     "end_time": "2026-05-02T00:02:51.029235+00:00",
+     "duration": 0.006816,
+     "end_time": "2026-05-07T11:43:39.384282",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.010275+00:00",
+     "start_time": "2026-05-07T11:43:39.377466",
      "status": "completed"
     },
     "tags": []
@@ -1093,10 +1093,10 @@
    "id": "90365c67",
    "metadata": {
     "papermill": {
-     "duration": 0.032417,
-     "end_time": "2026-05-02T00:02:51.086094+00:00",
+     "duration": 0.008368,
+     "end_time": "2026-05-07T11:43:39.399273",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.053677+00:00",
+     "start_time": "2026-05-07T11:43:39.390905",
      "status": "completed"
     },
     "tags": []
@@ -1112,10 +1112,10 @@
    "id": "1ff62e93",
    "metadata": {
     "papermill": {
-     "duration": 0.022497,
-     "end_time": "2026-05-02T00:02:51.129301+00:00",
+     "duration": 0.007012,
+     "end_time": "2026-05-07T11:43:39.413265",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.106804+00:00",
+     "start_time": "2026-05-07T11:43:39.406253",
      "status": "completed"
     },
     "tags": []
@@ -1137,16 +1137,16 @@
    "id": "598d58b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.154245Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.153886Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.165332Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.163923Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.438543Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.437861Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.445765Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.444374Z"
     },
     "papermill": {
-     "duration": 0.024595,
-     "end_time": "2026-05-02T00:02:51.167214+00:00",
+     "duration": 0.023562,
+     "end_time": "2026-05-07T11:43:39.447902",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.142619+00:00",
+     "start_time": "2026-05-07T11:43:39.424340",
      "status": "completed"
     },
     "tags": []
@@ -1156,14 +1156,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "⚠ reasonable n'est pas disponible: cannot import name 'Reasonable' from 'reasonable' (C:\\ProgramData\\miniconda3\\Lib\\site-packages\\reasonable\\__init__.py)\n",
-      "  Installation: pip install reasonable\n"
+      "✓ reasonable est disponible\n"
      ]
     }
    ],
    "source": [
     "try:\n",
-    "    from reasonable import Reasonable\n",
+    "    from reasonable import PyReasoner\n",
     "    REASONABLE_AVAILABLE = True\n",
     "    print(\"✓ reasonable est disponible\")\n",
     "except ImportError as e:\n",
@@ -1177,10 +1176,10 @@
    "id": "trans-023",
    "metadata": {
     "papermill": {
-     "duration": 0.012155,
-     "end_time": "2026-05-02T00:02:51.200575+00:00",
+     "duration": 0.012775,
+     "end_time": "2026-05-07T11:43:39.470472",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.188420+00:00",
+     "start_time": "2026-05-07T11:43:39.457697",
      "status": "completed"
     },
     "tags": []
@@ -1195,16 +1194,16 @@
    "id": "a3234357",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.250922Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.250312Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.264220Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.262327Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.491778Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.491277Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.504208Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.503053Z"
     },
     "papermill": {
-     "duration": 0.049267,
-     "end_time": "2026-05-02T00:02:51.269548+00:00",
+     "duration": 0.02469,
+     "end_time": "2026-05-07T11:43:39.506628",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.220281+00:00",
+     "start_time": "2026-05-07T11:43:39.481938",
      "status": "completed"
     },
     "tags": []
@@ -1214,23 +1213,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "⚠ Test reasonable skip (non disponible)\n"
+      "✓ Temps reasonable: 0.0006 secondes\n",
+      "✓ Triples avant raisonnement: 40\n",
+      "✓ Triples après raisonnement: 44\n",
+      "✓ Triples inférés: 4\n"
      ]
     }
    ],
    "source": [
     "if REASONABLE_AVAILABLE:\n",
     "    # Copie du graphe pour reasonable\n",
-    "    g_reasonable = Graph()\n",
+    "    g_reasonable = rdflib.Graph()\n",
     "    for t in g:\n",
     "        g_reasonable.add(t)\n",
     "    \n",
-    "    # Raisonnement avec reasonable\n",
+    "    # Raisonnement avec reasonable (PyReasoner API)\n",
     "    start = time.time()\n",
     "    \n",
-    "    # reasonable s'utilise comme un wrapper autour de rdflib\n",
-    "    reasoner = Reasonable(g_reasonable)\n",
-    "    reasoner.reason()\n",
+    "    # PyReasoner retourne les triples inférés sans modifier le graphe\n",
+    "    reasoner = PyReasoner(g_reasonable)\n",
+    "    inferred_triples = reasoner.reason()\n",
+    "    for s, p, o in inferred_triples:\n",
+    "        g_reasonable.add((s, p, o))\n",
     "    \n",
     "    time_reasonable = time.time() - start\n",
     "    triples_reasonable = len(g_reasonable)\n",
@@ -1252,10 +1256,10 @@
    "id": "f5776cf1",
    "metadata": {
     "papermill": {
-     "duration": 0.022511,
-     "end_time": "2026-05-02T00:02:51.314815+00:00",
+     "duration": 0.008446,
+     "end_time": "2026-05-07T11:43:39.524332",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.292304+00:00",
+     "start_time": "2026-05-07T11:43:39.515886",
      "status": "completed"
     },
     "tags": []
@@ -1271,10 +1275,10 @@
    "id": "9522fb85",
    "metadata": {
     "papermill": {
-     "duration": 0.025187,
-     "end_time": "2026-05-02T00:02:51.364686+00:00",
+     "duration": 0.009506,
+     "end_time": "2026-05-07T11:43:39.546983",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.339499+00:00",
+     "start_time": "2026-05-07T11:43:39.537477",
      "status": "completed"
     },
     "tags": []
@@ -1290,10 +1294,10 @@
    "id": "6684b07c",
    "metadata": {
     "papermill": {
-     "duration": 0.017749,
-     "end_time": "2026-05-02T00:02:51.398999+00:00",
+     "duration": 0.01297,
+     "end_time": "2026-05-07T11:43:39.571658",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.381250+00:00",
+     "start_time": "2026-05-07T11:43:39.558688",
      "status": "completed"
     },
     "tags": []
@@ -1317,16 +1321,16 @@
    "id": "fc4965a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.428522Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.428095Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.455246Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.454193Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.599338Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.598590Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.621827Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.620584Z"
     },
     "papermill": {
-     "duration": 0.042979,
-     "end_time": "2026-05-02T00:02:51.457589+00:00",
+     "duration": 0.040097,
+     "end_time": "2026-05-07T11:43:39.624389",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.414610+00:00",
+     "start_time": "2026-05-07T11:43:39.584292",
      "status": "completed"
     },
     "tags": []
@@ -1369,10 +1373,10 @@
    "id": "trans-028",
    "metadata": {
     "papermill": {
-     "duration": 0.012914,
-     "end_time": "2026-05-02T00:02:51.485048+00:00",
+     "duration": 0.013144,
+     "end_time": "2026-05-07T11:43:39.650673",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.472134+00:00",
+     "start_time": "2026-05-07T11:43:39.637529",
      "status": "completed"
     },
     "tags": []
@@ -1387,16 +1391,16 @@
    "id": "68c97c3d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.510886Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.510316Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.516598Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.515864Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.671633Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.670886Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.682254Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.680702Z"
     },
     "papermill": {
-     "duration": 0.021349,
-     "end_time": "2026-05-02T00:02:51.517783+00:00",
+     "duration": 0.022661,
+     "end_time": "2026-05-07T11:43:39.684440",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.496434+00:00",
+     "start_time": "2026-05-07T11:43:39.661779",
      "status": "completed"
     },
     "tags": []
@@ -1453,10 +1457,10 @@
    "id": "ffaa0d07",
    "metadata": {
     "papermill": {
-     "duration": 0.008689,
-     "end_time": "2026-05-02T00:02:51.535234+00:00",
+     "duration": 0.011188,
+     "end_time": "2026-05-07T11:43:39.706957",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.526545+00:00",
+     "start_time": "2026-05-07T11:43:39.695769",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1477,16 @@
    "id": "6af12143",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.552902Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.552088Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.573954Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.573167Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.733998Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.733019Z",
+     "iopub.status.idle": "2026-05-07T11:43:39.776956Z",
+     "shell.execute_reply": "2026-05-07T11:43:39.775675Z"
     },
     "papermill": {
-     "duration": 0.031851,
-     "end_time": "2026-05-02T00:02:51.575156+00:00",
+     "duration": 0.059762,
+     "end_time": "2026-05-07T11:43:39.778977",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.543305+00:00",
+     "start_time": "2026-05-07T11:43:39.719215",
      "status": "completed"
     },
     "tags": []
@@ -1494,8 +1498,9 @@
      "text": [
       "=== Tableau comparatif ===\n",
       "Raisonneur Langage OWL Profile  Temps (s)  Triples  Inférés\n",
-      "     owlrl  Python          RL   0.122666      251    211.0\n",
-      "    HermiT    Java          DL   0.948125       43      NaN\n"
+      "     owlrl  Python          RL   0.099198      251    211.0\n",
+      "    HermiT    Java          DL   1.018618       43      NaN\n",
+      "reasonable    Rust          RL   0.000597       44      4.0\n"
      ]
     }
    ],
@@ -1553,10 +1558,10 @@
    "id": "trans-031",
    "metadata": {
     "papermill": {
-     "duration": 0.009119,
-     "end_time": "2026-05-02T00:02:51.592505+00:00",
+     "duration": 0.010834,
+     "end_time": "2026-05-07T11:43:39.799272",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.583386+00:00",
+     "start_time": "2026-05-07T11:43:39.788438",
      "status": "completed"
     },
     "tags": []
@@ -1571,16 +1576,16 @@
    "id": "cd7352e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.610083Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.609795Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.873342Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.872746Z"
+     "iopub.execute_input": "2026-05-07T11:43:39.818799Z",
+     "iopub.status.busy": "2026-05-07T11:43:39.817919Z",
+     "iopub.status.idle": "2026-05-07T11:43:40.109057Z",
+     "shell.execute_reply": "2026-05-07T11:43:40.107518Z"
     },
     "papermill": {
-     "duration": 0.27388,
-     "end_time": "2026-05-02T00:02:51.874446+00:00",
+     "duration": 0.301476,
+     "end_time": "2026-05-07T11:43:40.110858",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.600566+00:00",
+     "start_time": "2026-05-07T11:43:39.809382",
      "status": "completed"
     },
     "tags": []
@@ -1588,7 +1593,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATapJREFUeJzt3QeYVOX9P+yHIiAqqEFBkYi9CyiBoKImolhCrIktitiiP3tLrFiIwRhF7AV7x96DhaixEFFRo7HFCjECNkBBRWHf6/v8r9l3dxlgF/awlPu+rlHmzJkzz5w5M3s+52mNKioqKhIAAABQ7xrX/yYBAACAIHQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAtfKvf/0rnXHGGWnMmDENXRQAWGAI3QDzgY4dO6b99tsvLUi23HLLfGPeiLDbqFGjBnv9iRMnpp133jl99dVXqUOHDovkPqjpo48+yuW5/vrr04LkqaeeyuWO/wNQPKEbKNT777+ffv/736dVV101tWjRIrVq1Sptuumm6cILL0zffvttQxePBcyf//zndN999zV0MearizURROeFfv36pS5duqQLLrig0NeZMmVKfk8CIQuqL774Ip1wwglprbXWyn/3ll122dS7d+/00EMPVVtv/Pjx+eLHUUcdNcM2Ylk8dvrpp8/w2L777psWW2yx/F0JccF2ySWXLPAdAXOr6VxvAWAmHn744fSb3/wmNW/ePJ8krL/++mnq1Knp2WefzSck//73v9NVV13V0MWcL7zzzjupcWPXQWsTunfbbbe00047NXRRFilRo9u1a9d07LHHFn6cRpA488wz879rtqQ49dRT04knnljo6y8KNt9883zRs1mzZg1dlIXyt3yrrbZKn332Wb5QFd+bCRMmpFtuuSX16dMnHX/88emvf/1rXnf55ZdPa6yxRv6bWNNzzz2XmjZtmv9f7rG4ANayZct58p6AuSd0A4X48MMP0x577JFWXnnl9Pe//z2tsMIKlY8ddthh6b333suhfGE0ffr0fHEhajhqKy5MwPxco37yySc3dDFyCIkb1U2ePDktscQStV4/LpzU5fdpUfHjjz/m3+85vRjxww8/5IuC0QXjH//4R+revXvlY8ccc0zae++903nnnZeD+O67756Xb7bZZunGG29M33zzTWVtdXyer732Wvrtb3+bHnjggTRt2rTUpEmT/Ninn36aPvjgg7TjjjvWy3sG5g3VKkAhzj333HwScc0111QL3CWrr756tSZ1cbIzYMCAtNpqq+UAWjrJ//7776s9L5b/6le/yk1P48Rl8cUXTxtssEFlU9R77rkn348Tyo033ji98sor1Z5faoYXJy3R3C9OVFdcccV01llnpYqKimrrxsnRJptskn7yk5/k14nt3XXXXTO8l2gCePjhh+eajPXWWy+Xf9iwYXXaRs0+3XHyFrV9UQsS7yWeHydnjz/+eLXnxQWNnj175vex9NJL5xOxt956q2w/2LjQEa8R67Vu3TrXwpSaJ85OtEiIzybeQ7du3dIzzzxTdr34vKI5ZHy+sR+i7+8f/vCHGT7HeB/xfqIs8XlEM8zZhbp4D3EyesMNN+R/x63qPvvkk0/S/vvvn9q2bZtfOz6La6+9tmxf1jvuuCPv3/bt26ellloqnyhHn+Uo59FHH51roKJcsY9qlr3q511qPhqfa5xkV/X111/nbcVnG+WJbW699dZp1KhRs93fUfP1s5/9LG879vuVV16Zaitq1eJ1Y9/H68Zn8Ze//CWHiRDH+S9+8Yu03HLL5eatJXGhKL478Xqxn0tuvvnm/P7is49msnExrdxAai+88ELafvvt0zLLLJOPxw033DB3I5ndGADxGcY+KtWoR7lCfD6lz7nUhL5cn+66/nbEvo1jOPZtdHuJwFPb/Rplje9OHLd9+/bNy8p5++238zEV+yteJ36rIjxVVdvveE3Rfzz2wdNPP53+7//+Lx9XK620Un7s448/zsviuIzPK7YZrY1iv86uT/d//vOftOuuu6Z27drl8sQ247OO70VR+7r0XqLmNlpRxGcfx06MHRA1xTX97W9/q/y9i+/tDjvskFtMVVWb46xqf/z4jR48eHDle3rzzTfz4xdffHH+DYna5Dim4zO89dZbZ/nZ3H333emNN97IrTGqBu4QoTm+x3HsVO0SEp95hOp//vOf1b5Lsa+jVjz+jr766quVj5VqvuN5wILD5WKgEA8++GA+yYrAWRsHHnhgDlNxonrcccflk46BAwfmAHnvvfdWWzfC41577ZX7iv/ud7/LJ03RbO+KK67IJ4Bx0hni+VFTULPpdpzgbLvttunnP/95vjgQATmCYpzkRPguicDw61//OtdORCC5/fbb8wls9MuLk72a4TeCXISxNm3aVJ7c1WUbVcVJWZQ/9kuctE6aNCm99NJLObBFcAtPPPFE2m677fJ+jvWjuWicKEaf+Viv6glmiH2xyiqr5O3G41dffXU+YY9ANitx4ST2dXyWEebigkW8pwgUVQfUilAXy+NE++CDD07rrLNOev3113Mf4HfffbeyL3acJMcJeYSy2N9xohufablmlFXddNNNlfsjth/iRDmMGzcuf56lQBwn73GCfsABB+R9F+WuKvZBhJI4OY7Xjv0WfSTjOIlaqtifcRIcoSD2Wf/+/as9PwLP0KFD05FHHpnLf9lll+VjauTIkbkbRTjkkEPyBZYoz7rrrpv7eca+iWN6o402mun7jH22zTbb5PcQ5YjjMo7PuJgwO3ERZYsttsgXIOIz++lPf5qef/75dNJJJ+UasggXsY/iYkTs/yhjXKgK8Rrx2UQQK9Wann322em0007Lx07s+whCsa+ieXJc0IoAESIoxmcaF9jiYloEt3ifcZyX6686M/GeL7/88nTooYfm4LXLLrvk5VHW+vrtiPXiuIjQHPshwlhcVIiANTNxoSIuaMXnF/ssju3YdmyjptiH8R2MCzpxfMW+jN+G6BIRoSzeV22/47MSv3Oxv+LYLF0kefHFF/PnHWE5QnMEy9ifEUIjTM6sOXL8NsVFyAjPRxxxRP784hiKzy8uLMSFhiL3dbxmBNs4BqPMcZzG9ya+Y1W//7GdKGf8ZsWxHu8twmccizV/72rruuuuS999913+TYnvcvyuDRkyJH+3o/xx/MbjMXJ/vN/42zOrv3shulOVE/sxjqPYh7F/4oJYKTzHsdWrV6/87/gtXHPNNXMT8vgc437st9JjQeiGBUwFQD2bOHFiVBlX7LjjjrVa/9VXX83rH3jggdWWH3/88Xn53//+98plK6+8cl72/PPPVy579NFH87LFF1+84uOPP65cfuWVV+blTz75ZOWyvn375mVHHHFE5bLp06dX7LDDDhXNmjWr+OyzzyqXT5kypVp5pk6dWrH++utX/PKXv6y2PLbXuHHjin//+98zvLfabiPeV5StpFOnTrlMs9K5c+eK5ZdfvuKLL76oXPbaa6/lsuy7776Vy04//fRcxv3337/a83feeeeKn/zkJ7N8jShvvEa81vfff1+5/Kqrrsrb3GKLLSqX3XTTTfm1n3nmmWrbuOKKK/K6zz33XL5/wQUX5PtV93VtLbHEEtX2U8kBBxxQscIKK1R8/vnn1ZbvscceFa1bt678HOJYiNeOzyDeW8mee+5Z0ahRo4rtttuu2vN79OiRP5uq4vlxe+mllyqXxXHXokWLvE9L4nUPO+ywOr/HnXbaKW+r6rH85ptvVjRp0iS/7qwMGDAg76N333232vITTzwxP3/06NEzfD9uvvnmin/+85/58aOPPrry8Y8++igvO/vss6tt6/XXX69o2rRp5fIff/yxYpVVVsn76auvvqq2bny3SuJYqXq8lMTnWXUfx3ER5YrjtqbSsTw3vx3/+Mc/KpeNHz++onnz5hXHHXdcxazcd999+bnnnntu5bJ43z179szLr7vuusrlW221VcUGG2xQ8d1331XbD5tssknFGmusUafveDnxWvGam222WS7DrH5vwogRI/L6N954Y+Wy0veg9Nv4yiuv5Pt33nnnTF+3iH1dei+9evWqdqwcc8wx+dibMGFCvv/1119XLL300hUHHXRQtdceO3Zs/p5VXV7b4+zDDz/Mr92qVatctqrib9d6661XUVfxOxnlmZVBgwbl133ggQcql8VvbBw3Jb17967o169f/vdvf/vbit/85jeVj3Xt2rXacVR6b/G9B+ZfmpcD9S5qbEI0/6uNRx55JP8/mhdWFTUpoWbf76g17NGjR+X9UjO+X/7yl7lmr+byqJmtKWpRSkq1o1HbE7XHJVETWhK1n9HMMpo2lmseHLWLUa6a6rKNqqIGMWrMoslnOVFrGU0Oo+YoamZKokYwaslK+7SqqKGrKsoRta+lz6ucqHmLJsjx3Kr9HEvNbKu68847cw3g2muvnT7//PPKW3wu4cknn6x8b+H++++vbPI8NyIHRw1itHaIf1d97agVi31ec3+XRv+teqzEc6N5elWxPJpSR21zVXH8lWqeQhx3UYP16KOP5pYUpfcZNWP/+9//av1e4rmxjagVrXosx36N9zI78RnE5xq1hlX3Q9SgxbarNoGPmr3YZtQy7rPPPrnVQAxUVxI14PH5RC131W1FLWg0iS59nlHLGGM4RGuC0mdbUvT0XnPy2xH7pyRqiqMpdrnfiJqvE33Jowa+anPh2HdVffnll7nVS+yz6F5Q2mfxPYt9Hd/nqEGuzXd8dg466KDKfr7lfm+i+Xq8btSmxmvN6jen9F2OY29mXU6K3NdxLFY9VuJ5cbxGc/lSS4qocd9zzz2rHYvx/uM7WjoW50Q0qS91aSiJ/fXf//43txyoi/jMZ/d3r/R41d/daBkRvxXxnuM7F61sSq3E4rFS7XZ8NvG7r5YbFjxCN1DvYlqw0glIbcSJVTTrjZPDquLkPk5+SideJVXDSNUTxppzB5eWR9itKl4rmmRXFU35QtW+j9G0Mposl6Z8KTV9rdrHsSSaIJdTl21UFc2u4yQzyhX9bGO092jeWFLaJ3ESW1MEtDghrdovt9x+i2BWbv9UVXqdCFlVRWCtuQ8jPESIiPdY9Vbat6X+wzGAUJxIRlPVaDIdTWGj+e2cBvBo8hz7Kvqd13zt6JNd9bXn5BiKctX8vGrujxDvM06KS31Ro+tC9O+MbUbz4WhOPLtwF8+NbgLltl/us64pPoPoLlFzP5SardbcD9F1IMocz4um9FVDWyyLCxFRlprbi+bEpW3FtICh1Kx+Xprb347S92BW34HS60TT+ZrTMtX8TKLJcOyzaJJfc5+Vpn4q7bfZfcdnp9xvThw70dy81J8/urrEa8frzOo3J7YVYTq6nMRz4gLBpZdeWu05Re7r2f02lS5MxAW8mvv1sccem+G4roty+/GPf/xj/qzjexvHfwz+ObvuL6VAPbu/e6XHq4bzCNGlvtvxmxH7PX4jQ4TvuHAXf5tKfb2Fbljw6NMNFBK6Y3CyOHmoi9rWitWs3Znd8poDpNVGDBQW/ZOj72r0140T7gia0f+v3GA6VcPKnG6jqnhOhJmoDY6TyjgZjr7R0W89wuqcqM/9U06E0wgPgwYNKvt4KdDGvooa16iditqxCInRdzNOqOO9zqycs3rdEP37y/WxLdcneF4cQ1HbGTV20dc13ldMExR9UaMGOfriFyH2RbR0iMHryildACmJ/tulQbCiL3nVFiSxrfhORt/4cvulrvMCx7bK7cdSy4C5Mbe/HfX5HQgxANbMWiaUQuvcfsfL/eZEzXv8vkSrg/gs46JR7Ju4sDW7i1rnn39+bsFSKk/0aY7+2lHrWhqorah9Pbt1S2WPft0R8muqOqJ9XY+zcvsxLlzGWCBx0TR+n6IlTfyGxwWN0nR25cTzIjiPHj267EWHULqwUrVlVNV+3dGiKC7QRouh0Llz59wXPx6LFiVV1wcWHEI3UIgYVClqHkeMGFHtRL6cmFYsTqqiNiNOWkpicKyooYnH61O8VtQ4Vg0gMdBXKA3GEydZUTsdzS2rTucVJ7S1NbfbiBOvqKmNW9SCxEl61JbGCXlpn8SJYbmRk6O2qi5TCM1M6XXisyk1Ey81XY0TwE6dOlUui+bJMc1NzFE7uxPzqDGL9eIWIT2aNZ9yyik5iJdqZcspt92o7YpaozipntVz61O5JsFxDMXJcdWmqnGhJQa8ilvUxsUAajE42cxCdzw3QkC57Zf7rGuKzyCOldrsh+iiECEtBm2LE/1SUCx95rGtCC9RE1gzrNd8zRAX2Wb1ulF7Wa6mv2YNaV2apM+r347YzvDhw6tN61TuMym1/oiLa7X5DGb1HZ8TMXBfXHiKAF0Sg4DNbJT1muKiWdxiPvQYkC1qW+MiwJ/+9Kd5/jtd7hiLgR9nt19re5zNTvx+RqucuEXXoxjUL767MSjhzKZbi797t912Wx6lPfZhTdGkPC5qRKCu2mIgfhdKwTr+VsTfzNL3IC4oxEwGUdMev7mxD2b1fQTmT5qXA4WImrY4aYmTxzgpqylqeErTCcU0QyFGrK2qVGM6q1G+59Qll1xS+e8IFnE/TpQjBJZqXuKkp2rtSDTvK43AXRtzs43oi1lVnOjHSVqpVjLCXNSAxCi4VU+oI/hELVVpn86tmCYngmCceMeJZ0k0Ra55Ih81u9FfNUb+LdfstdTcPfq91hTvJdSceqimOKZqvm7s5+iXWZqup6ZyUw/NrbiYVLWPbPT7jpPpCLBRnvjMazbnjZPlaAEyq/cYz43gG8dI1JaVRHPuuHgzO/EZRNnKrRv7rWrf9OgTHCEqmpjHBbI4uY+Rpku1hBEyojxRs1ez5jDul47RCAwRzOP7W/Ozqfq8CE5xQajq5xEXaWo22y2NsF2boDivfjvidWLfRdeQkviMYyT3mp9xjBQeU0PFRY2aqr732X3H50R8XjU/qyjj7FoTRBisOW5BhO+4OFYqT0P8TpfEdyJaUMXFubjgN6v9WtvjbFZqfjZxUSpqpmPflnv9khjtPNY755xz8ngYVcV3LcYEiCbzpa4GJfHdi77pUca41Zz1I+5H66BodVBqdg4sWNR0A4WIE59oQh21BFErEgNXRZ/PCG5RgxIDPpXmWI7a0qidiRP/ONGOQcli6qUIlDGgVMwpXJ+iliKaDMZrxolONJ+NZs4x3VipljJOIONkMqaBiiliopYy+jjGSXFt+13OzTbixC1O3mOwrqgNixO40vRTJdFcOWpMo1YkwlJpyrBoUlp1Hti5ERciopYrpp+Kmu74PKO2JWrra/bpjsG4om92DLoWNdZxchgn+3ECHMsjCEaIj76scQIZ+ydqx2K/RNPNaMI6u2aTsT9isLvYrxFgI+zFZxgnufGa8e8Ik7H/ItxHMI71ywX9uRHHcgSBqlOGhVLT0+i3Ge8nTsLj+I5AFeWIgZmq1kKWE9uI4zOapkcNeYSh0pzBsztuol9wzAcdNW6l6ZniYkc0HY/jJy76RCuI+PzimI+LJ6Wmw/Ea0UQ/gmW8bnyH47OPmr14XnwXo0VBfP7RZD4Gv4ra8Qhm8ZwYyC4unkStbVwUis89+viXLgDEIHXxucV+i+M1Pve4mBPvq+qgUlHTH59fdDmIGr04/mN/l+szPq9+O+K9xfEcU4DFvojyRTeBcv2k4zsex3GE1jgW43sSFx7jYkgMzhUBsLbf8bqKzz2aYMdvQGw/XjOOu5ive1Zi8Ld43ZjOMPZ5HHOxndIFrYb4na4qAnccY/EbExd5orl8/FbHhak4juOzKV1Ire1xNitx8Syascd2Y9yJuOgV24/frFkNlBbhPD7DuHgbx0B8F+I3L/ZX/D2M36MYeC7KX1OsXxoQrmawjtAdTf1L65UTFwPi+1pTHFulaTSBBtTQw6cDC7eYuiimc+nYsWOekmuppZaq2HTTTSsuvvjialPq/PDDDxVnnnlmnnposcUWq+jQoUPFSSedVG2dEFO+lJtmJ37Oak7PVJoS5q9//esMU6u8//77Fdtss01Fy5YtK9q2bZunIpo2bVq1519zzTV5apaY5mbttdfO09vUnLJoZq9d123UnDLsT3/6U0W3bt3yNDkxFVo8N6ZoqjrNVXjiiSfy/ox1YuqbPn365Omlqiq9Xs0pukrT9cR+mp3LLrssfzbxPmLKmpgKqNzUPFG+v/zlL3m6nVh3mWWWqdh4443zZxtTyYXhw4fnKXlWXHHFfEzE/2PKrprTXJXz9ttvV2y++eb5/UbZq+6zcePG5c8hjp04htq1a5en4YnpzWpOlVRzaqTSvnjxxRdnu+9Kn3dMtVX6bLt06VJtarqYXu2EE07I00LFMR/HXPw79mNtPP3003m/xf5ZddVV87Rr5Y6bcmJ6pfjurL766vn5bdq0ydNVnXfeefnzGTNmTJ7WKI6VmmLKsyjrBx98ULns7rvvztNTxfK4xbEY7/+dd96p9txnn322Yuutt658vxtuuGH+nlcV+yzeT5QrpleK6f5qTuUUYkrA0vuvOn1YuX0wt78dM5tiqqaYmm+fffbJ37PYf/Hv0lRbVacMC/H7EtP2xTEYZWrfvn3Fr371q4q77rqrzt/xmmZ2rIaYsi2mmorPfMkll8xTT8V3pubvS80pw+LzjikFV1tttTxd3bLLLlvxi1/8Iv++FLmvZ/Zeapav6vJ4T7H/o5xR3v3226/a9H21Pc7K/X2oOp1e/M7ElIrx/Y7Xie9z6TdsdmIKsmOPPTZ/B+P58RnHtGhVpwmrqTT1ZUzHN3ny5BmOvZjSMB5/4YUXZnhuaSrMcrcoO9DwGsV/GjL0A8xLUfsXNRHRfxLmRHQZiNGMq3ZRAACYGX26AQAAoCBCNwAAABRE6AYAAICC6NMNAAAABVHTDQAAAAURugEAAKAgTdMiZvr06el///tfWmqppfK0LwAAAFBX0VP766+/TiuuuGJq3Hjm9dmLXOiOwN2hQ4eGLgYAAAALgTFjxqSVVlpppo8vcqE7arhLO6ZVq1YNXRwAAAAWQJMmTcoVuqWMOTOLXOguNSmPwC10AwAAMDdm123ZQGoAAABQEKEbAAAACiJ0AwAAQEGEbgAAqEeXXnpp6tixY2rRokXq3r17Gjly5EzX/eGHH9JZZ52VVltttbx+p06d0rBhw2a6/jnnnJP7jx599NHVlo8dOzbts88+qV27dmmJJZZIG220Ubr77rurrXP22WenTTbZJLVs2TItvfTS9fBOgdoQugEAoJ4MHTo0HXvssen0009Po0aNyiG6d+/eafz48WXXP/XUU9OVV16ZLr744vTmm2+mQw45JO28887plVdemWHdF198Ma+74YYbzvDYvvvum9555530wAMPpNdffz3tsssu6be//W217UydOjX95je/SYceemg9v2tgVoRuAACoJ4MGDUoHHXRQ6tevX1p33XXTFVdckWuWr7322rLr33TTTenkk09O22+/fVp11VVzII5/n3/++dXW++abb9Lee++dhgwZkpZZZpkZtvP888+nI444InXr1i1vJ8J81Ga//PLLleuceeaZ6ZhjjkkbbLBB2bJ89dVX+TWWW265tPjii6c11lgjXXfddXO9T2BRJ3QDAEA9iJrkCLm9evWqXNa4ceN8f8SIEWWf8/333+dm5VVF4H322WerLTvssMPSDjvsUG3bVUWz8ahl//LLL9P06dPT7bffnr777ru05ZZb1rr8p512Wq5t/9vf/pbeeuutdPnll6c2bdrU+vlAeYvcPN0AAFCEzz//PE2bNi21bdu22vK4//bbb5d9TjQ9j9rxzTffPPfrHj58eLrnnnvydkoiQEdT9WhePjN33HFH2n333dNPfvKT1LRp01y7fu+996bVV1+91uUfPXp06tKlS+ratWu+H/3SgbmnphsAABrIhRdemJtxr7322qlZs2bp8MMPz03To4Y8jBkzJh111FHplltumaFGvGYt9YQJE9ITTzyRXnrppdyvPPp0R//u2oqm7RHwO3funP7whz/kJuvA3BO6AQCgHkRT7CZNmqRx48ZVWx73Y1TxcqL/9H333ZcmT56cPv7441wjvuSSS+Z+2SGaq8cgbDEaedRgx+3pp59OF110Uf531Ii///776ZJLLsn9xrfaaqs8eFsM5BY11jGSem1tt912uQzR7/t///tf3tbxxx8/l3sFELoBAKAeRE31xhtvnJuIl0T/6rjfo0ePWT43arHbt2+ffvzxxzzV14477piXR/CN2upXX3218hZhOgY8i39HyJ8yZUpet1Q7XhKPxevXRVwE6Nu3b7r55pvT4MGD01VXXVWn5wMz0qcbAADqSTTrjtAawThGEo/gGrXY0WS8NLVXhOuBAwfm+y+88EL65JNPcpPu+P8ZZ5yRg3I07w5LLbVUWn/99au9RszDHX23S8ujaXr03f7973+fzjvvvPxY1J4//vjj6aGHHqrWZzsGWov/Rw15hPYQz43a9f79++eLBuutt14e4C2eu84668yzfQcLK6EbAADqSQxm9tlnn+UAO3bs2Bymhw0bVjm4WgTeqjXSMcJ4TO/1wQcf5OAb04XFNGIx3VdtLbbYYumRRx5JJ554YurTp0+eXiyC9A033JC3VxJlimUlMWhaePLJJ/Mo51FTf9JJJ6WPPvooj6Des2fP3McbmDuNKioqKtIiZNKkSal169Zp4sSJqVWrVg1dHAAAABbibKlPNwAAABRE6AYAAICC6NMNACxUxvbp2dBFAGAutXvwmbSwUNMNAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAwMIaui+99NLUsWPH1KJFi9S9e/c0cuTIWa4/ePDgtNZaa6XFF188dejQIR1zzDHpu+++m2flBQAAgAUidA8dOjQde+yx6fTTT0+jRo1KnTp1Sr17907jx48vu/6tt96aTjzxxLz+W2+9la655pq8jZNPPnmelx0AAADm69A9aNCgdNBBB6V+/fqlddddN11xxRWpZcuW6dprry27/vPPP5823XTTtNdee+Xa8W222Sbtueees60dBwAAgEUqdE+dOjW9/PLLqVevXv9/YRo3zvdHjBhR9jmbbLJJfk4pZH/wwQfpkUceSdtvv/1MX+f7779PkyZNqnYDAACAeaFpaiCff/55mjZtWmrbtm215XH/7bffLvucqOGO52222WapoqIi/fjjj+mQQw6ZZfPygQMHpjPPPLPeyw8AAADz/UBqdfHUU0+lP//5z+myyy7LfcDvueee9PDDD6cBAwbM9DknnXRSmjhxYuVtzJgx87TMAAAALLoarKa7TZs2qUmTJmncuHHVlsf9du3alX3OaaedlvbZZ5904IEH5vsbbLBBmjx5cjr44IPTKaeckpun19S8efN8AwAAgEWmprtZs2Zp4403TsOHD69cNn369Hy/R48eZZ8zZcqUGYJ1BPcQzc0BAABgftJgNd0hpgvr27dv6tq1a+rWrVuegztqrmM087Dvvvum9u3b537ZoU+fPnnE8y5duuQ5vd97771c+x3LS+EbAAAA5hcNGrp333339Nlnn6X+/funsWPHps6dO6dhw4ZVDq42evToajXbp556amrUqFH+/yeffJKWW265HLjPPvvsBnwXAAAAUF6jikWsXXZMGda6des8qFqrVq0aujgAQD0b26dnQxcBgLnU7sFn0sKSLReo0csBAABgQSJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgII0nZMn/fDDD2ns2LFpypQpabnllkvLLrts/ZcMAAAAFpWa7q+//jpdfvnlaYsttkitWrVKHTt2TOuss04O3SuvvHI66KCD0osvvlhsaQEAAGBhC92DBg3KIfu6665LvXr1Svfdd1969dVX07vvvptGjBiRTj/99PTjjz+mbbbZJm277bbpP//5T/ElBwAAgIWheXnUYP/jH/9I6623XtnHu3Xrlvbff/90xRVX5GD+zDPPpDXWWKO+ywoAAAALX+i+7bbbarWx5s2bp0MOOWRuywQAAAALhbkevXzSpEm5uflbb71VPyUCAACARTV0//a3v02XXHJJ/ve3336bunbtmpdtuOGG6e677y6ijAAAALBohO7o292zZ8/873vvvTdVVFSkCRMmpIsuuij96U9/KqKMAAAAsGiE7okTJ1bOyz1s2LC06667ppYtW6YddtjBqOUAAAAwN6G7Q4cOeZqwyZMn59Ad04SFr776KrVo0aKumwMAAIBFe/Tyqo4++ui09957pyWXXDL99Kc/TVtuuWVls/MNNtigiDICAADAohG6/+///i/Pyz1mzJi09dZbp8aN/19l+aqrrqpPNwAAAMxN6A4xYnmMVv7hhx+m1VZbLTVt2jT36QYAAADmok/3lClT0gEHHJAHT1tvvfXS6NGj8/IjjjginXPOOXXdHAAAACy06hy6TzrppPTaa6+lp556qtrAab169UpDhw6t7/IBAADAohO677vvvnTJJZekzTbbLDVq1KhyedR6v//++3UuwKWXXpo6duyYA3z37t3TyJEjZ7l+zAl+2GGHpRVWWCE1b948rbnmmumRRx6p8+sCAADAfNen+7PPPkvLL7/8DMtjCrGqIbw2omb82GOPTVdccUUO3IMHD069e/dO77zzTtnXmDp1ah68LR676667Uvv27dPHH3+cll566bq+DQAAAJj/arpjELWHH3648n4paF999dWpR48eddrWoEGD0kEHHZT69euX1l133Ry+o6/4tddeW3b9WP7ll1/m2vZNN90015BvscUWqVOnTnV9GwAAADD/1XT/+c9/Ttttt1168803048//pguvPDC/O/nn38+Pf3007XeTtRav/zyy7mPeElMPxZ9w0eMGFH2OQ888EAO9tG8/P7770/LLbdc2muvvdIf//jH1KRJk7LP+f777/OtZNKkSXV6vwAAADDParqjL/err76aA/cGG2yQHnvssdzcO4LyxhtvXOvtfP7552natGmpbdu21ZbH/bFjx5Z9zgcffJCblcfzoh/3aaedls4///xZzg8+cODA1Lp168pbhw4d6vBuAQAAYB7P0x1zcw8ZMiTNa9OnT88B/6qrrso12xHyP/nkk/TXv/41nX766WWfEzXp0W+8ak234A0AAMB8E7rr0iS7VatWtVqvTZs2OTiPGzeu2vK4365du7LPiRHLF1tssWpNyddZZ51cMx7N1Zs1azbDc2KE87gBAADAfNm8PEYHX2aZZWp1q60IyFFTPXz48Go12XF/ZgOyxeBp7733Xl6v5N13381hvFzgBgAAgPm+pvvJJ5+s/PdHH32UTjzxxLTffvtVhuPoz33DDTfk/tN1Ec2++/btm0dE79atW54yLKYei9HMw7777punBStt99BDD81zhB911FHpiCOOSP/5z3/ywG5HHnlknV4XAAAA5pvQHdNylZx11ll5qq8999yzctmvf/3rPKha9LWOEF1bu+++e573u3///rmJeOfOndOwYcMqB1cbPXp0HtG8JPpiP/roo+mYY45JG264YQ7kEcBj9HIAAACY3zSqqKioqMsTYh7t1157La2xxhrVlkcz7wjNU6ZMSfOz6J8eo5hPnDix1v3PAYAFx9g+PRu6CADMpXYPPpPmd7XNlnWeMixqm8uNXH711VcbFRwAAADmZsqwCy64IO26667pb3/7W+revXteNnLkyNy/+u67767r5gAAAGChVeea7u233z4H7D59+qQvv/wy3+Lf0bw8HgMAAADmsKY7rLTSSnnUcAAAAKCeQ/eECRNyk/Lx48dXmzO7NM0XAAAAMAeh+8EHH0x77713+uabb/IIbY0aNap8LP4tdAMAAMAc9uk+7rjj0v77759Dd9R4f/XVV5W36N8NAAAAzGHo/uSTT9KRRx6Z5+sGAAAA6jF09+7dO7300kt1fRoAAAAscurcp3uHHXZIJ5xwQnrzzTfTBhtskBZbbLFqj//617+uz/IBAADAohO6DzrooPz/s846a4bHYiC1adOm1U/JAAAAYFEL3TWnCAMAAADqqU83AAAAUGDofvrpp1OfPn3S6quvnm/Rj/uZZ56Zk00BAADAQqvOofvmm29OvXr1ylOGxdRhcVt88cXTVlttlW699dZiSgkAAAALoEYVFRUVdXnCOuuskw4++OB0zDHHVFs+aNCgNGTIkPTWW2+l+dmkSZNS69at08SJE1OrVq0aujgAQD0b26dnQxcBgLnU7sH5vyV1bbNlnWu6P/jgg9y0vKZoYv7hhx/WvaQAAACwkKpz6O7QoUMaPnz4DMufeOKJ/BgAAAAwh1OGHXfccbkf96uvvpo22WSTvOy5555L119/fbrwwgvrujkAAABYaNU5dB966KGpXbt26fzzz0933HFHZT/voUOHph133LGIMgIAAMCiEbrDzjvvnG8AAABAPfbpfvHFF9MLL7www/JY9tJLL9V1cwAAALDQqnPoPuyww9KYMWNmWP7JJ5/kxwAAAIA5DN1vvvlm2mijjWZY3qVLl/wYAAAAMIehu3nz5mncuHEzLP/0009T06Zz1EUcAAAAFkp1Dt3bbLNNOumkk9LEiRMrl02YMCGdfPLJaeutt67v8gEAAMACq85V0+edd17afPPN08orr5yblIeYs7tt27bppptuKqKMAAAAsGiE7vbt26d//etf6ZZbbkmvvfZaWnzxxVO/fv3SnnvumRZbbLFiSgkAAAALoDnqhL3EEkukgw8+uP5LAwAAAItyn+4Qzcg322yztOKKK6aPP/44L7vgggvS/fffX9/lAwAAgEUndF9++eXp2GOPTdttt1366quv0rRp0/LyZZZZJg0ePLiIMgIAAMCiEbovvvjiNGTIkHTKKadUmyKsa9eu6fXXX6/v8gEAAMCiE7o//PDDylHLa87fPXny5PoqFwAAACx6oXuVVVbJU4TVNGzYsLTOOuvUV7kAAABg0Ru9PPpzH3bYYem7775LFRUVaeTIkem2225LAwcOTFdffXUxpQQAAIBFIXQfeOCBeW7uU089NU2ZMiXttddeeRTzCy+8MO2xxx7FlBIAAAAWlXm6995773yL0P3NN9+k5Zdfvv5LBgAAAItan+5vv/02h+3QsmXLfD+mCnvssceKKB8AAAAsOqF7xx13TDfeeGP+94QJE1K3bt3S+eefn5fHHN4AAADAHIbuUaNGpZ49e+Z/33XXXaldu3bp448/zkH8oosuquvmAAAAYKFV59AdTcuXWmqp/O9oUr7LLrukxo0bp5///Oc5fAMAAABzGLpXX331dN9996UxY8akRx99NG2zzTZ5+fjx41OrVq3qujkAAABYaNU5dPfv3z8df/zxqWPHjql79+6pR48elbXeXbp0KaKMAAAAsGhMGbbbbrulzTbbLH366aepU6dOlcu32mqrtPPOO9d3+QAAAGDRmqc7Bk+LW1UxijkAAABQx+blhxxySPrvf/9bm1XT0KFD0y233FKrdQEAACAt6jXdyy23XFpvvfXSpptumvr06ZO6du2aVlxxxdSiRYv01VdfpTfffDM9++yz6fbbb8/Lr7rqquJLDgAAAPO5RhUVFRW1WXHcuHHp6quvzsE6QnZVMYVYr1690oEHHpi23XbbND+bNGlSat26dZo4caLR1gFgITS2T8+GLgIAc6ndg8+k+V1ts2WtQ3dVUbs9evTo9O2336Y2bdqk1VZbLTVq1CgtCIRuAFi4Cd0AC752C1HonqOB1JZZZpl8AwAAAOpxnm4AAACgdoRuAAAAKIjQDQAAAAURugEAAGB+Cd0xYvmUKVMq73/88cdp8ODB6bHHHqvvsgEAAMCiFbp33HHHdOONN+Z/T5gwIXXv3j2df/75efnll19eRBkBAABg0Qjdo0aNSj17/r/5L++6667Utm3bXNsdQfyiiy4qoowAAACwaITuaFq+1FJL5X9Hk/JddtklNW7cOP385z/P4RsAAACYw9C9+uqrp/vuuy+NGTMmPfroo2mbbbbJy8ePH59atWpV180BAADAQqvOobt///7p+OOPTx07dkzdunVLPXr0qKz17tKlSxFlBAAAgAVS07o+YbfddkubbbZZ+vTTT1OnTp0ql2+11VZp5513ru/yAQAAwKITukO7du3yLZqYhw4dOuRabwAAAGAumpf/+OOP6bTTTkutW7fOTczjFv8+9dRT0w8//FDXzQEAAMBCq8413UcccUS655570rnnnlvZn3vEiBHpjDPOSF988YW5ugEAAGBOQ/ett96abr/99rTddttVLttwww1zE/M999xT6AYAAIA5bV7evHnz3KS8plVWWSU1a9asrpsDAACAhVadQ/fhhx+eBgwYkL7//vvKZfHvs88+Oz8GAAAAzGHz8ldeeSUNHz48rbTSSpVThr322mtp6tSpedqwXXbZpXLd6PsNAAAAi6o6h+6ll1467brrrtWWRX9uAAAAYC5D93XXXVfXpwAAAMAiqc59uotw6aWX5sHZWrRokbp3755GjhxZq+fFKOqNGjVKO+20U+FlBAAAgMJDd8zFfdhhh6V11103tWnTJi277LLVbnU1dOjQdOyxx6bTTz89jRo1KvcT7927dxo/fvwsn/fRRx+l448/PvXs2bPOrwkAAADzZfPyffbZJ7333nvpgAMOSG3bts01zXNj0KBB6aCDDkr9+vXL96+44or08MMPp2uvvTadeOKJZZ8zbdq0tPfee6czzzwzPfPMM2nChAlzVQYAAACYL0J3hNxnn322cuTyuREjnr/88svppJNOqlzWuHHj1KtXrzRixIiZPu+ss85Kyy+/fA7+UZ5ZienMqk5vNmnSpLkuNwAAABTSvHzttddO3377baoPn3/+ea61jhrzquL+2LFjyz4nAv8111yThgwZUqvXGDhwYGrdunXlzUjrAAAAzLeh+7LLLkunnHJKevrpp3P/7qg5rnor0tdff52bt0fgjv7ktRG16BMnTqy8jRkzptAyAgAAwFzN0x3h+pe//GW15RUVFbl/d9Rc11YE5yZNmqRx48ZVWx7327VrN8P677//fh5ArU+fPpXLpk+f/v/eSNOm6Z133kmrrbZatec0b9483wAAAGC+D90xgNliiy2Wbr311rkeSK1Zs2Zp4403TsOHD6+c9itCdNw//PDDyzZtf/3116stO/XUU3MN+IUXXqjpOAAAAAt26H7jjTfSK6+8ktZaa616KUBMF9a3b9/UtWvX1K1btzR48OA0efLkytHM991339S+ffvcNzvm8V5//fVnqHkPNZcDAADAAhe6IxxHv+j6Ct277757+uyzz1L//v3z4GmdO3dOw4YNqxxcbfTo0XlEcwAAAFjQNKqIzth1cOedd6YzzjgjnXDCCWmDDTbITc2r2nDDDdP8LPqjxyjmMahaq1atGro4AEA9G9unZ0MXAYC51O7BWU8NvSBly6ZzUjMd9t9//8pl0a97TgZSAwAAgIVZnUP3hx9+WExJAAAAYFEP3SuvvHIxJQEAAICFzByNUHbTTTelTTfdNK244orp448/zsti1PH777+/vssHAAAAi07ovvzyy/M0X9tvv32aMGFCZR/umLorgjcAAAAwh6H74osvTkOGDEmnnHJKatKkSbWpxF5//fW6bg4AAAAWWo3nZCC1Ll26zLC8efPmafLkyfVVLgAAAFj0Qvcqq6ySXn311RmWDxs2LK2zzjr1VS4AAABYdEYvP+uss9Lxxx+f+3Mfdthh6bvvvstzc48cOTLddtttaeDAgenqq68utrQAAACwAGlUEcm5FqL/9qeffpqWX375dMstt6Qzzjgjvf/++/mxGMX8zDPPTAcccECa302aNCm1bt06TZw4MbVq1aqhiwMA1LOxfXo2dBEAmEvtHnwmLSzZstY13VWz+d57751vU6ZMSd98800O4gAAAMAchu7QqFGjavdbtmyZbwAAAMBchu4111xzhuBd05dfflmXTQIAAMBCq06hO/ptR5t1AAAAoJ5D9x577KH/NgAAANT3PN2za1YOAAAAzGHoruXMYgAAAEBdm5dPnz69tqsCAAAAdanpBgAAAOpG6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAAFubQfemll6aOHTumFi1apO7du6eRI0fOdN0hQ4aknj17pmWWWSbfevXqNcv1AQAAYJEN3UOHDk3HHntsOv3009OoUaNSp06dUu/evdP48ePLrv/UU0+lPffcMz355JNpxIgRqUOHDmmbbbZJn3zyyTwvOwAAAMxKo4qKiorUgKJm+2c/+1m65JJL8v3p06fnIH3EEUekE088cbbPnzZtWq7xjufvu+++s11/0qRJqXXr1mnixImpVatW9fIeAID5x9g+PRu6CADMpXYPPpPmd7XNlg1a0z116tT08ssv5ybilQVq3Djfj1rs2pgyZUr64Ycf0rLLLltgSQEAAKDumqYG9Pnnn+ea6rZt21ZbHvfffvvtWm3jj3/8Y1pxxRWrBfeqvv/++3yrejUCAAAAFok+3XPjnHPOSbfffnu699578yBs5QwcODBX+Zdu0XQdAAAAFvrQ3aZNm9SkSZM0bty4asvjfrt27Wb53PPOOy+H7sceeyxtuOGGM13vpJNOym3sS7cxY8bUW/kBAABgvg3dzZo1SxtvvHEaPnx45bIYSC3u9+jRY6bPO/fcc9OAAQPSsGHDUteuXWf5Gs2bN8+d2qveAAAAYKHv0x1iurC+ffvm8NytW7c0ePDgNHny5NSvX7/8eIxI3r59+9xMPPzlL39J/fv3T7feemue23vs2LF5+ZJLLplvAAAAML9o8NC9++67p88++ywH6QjQnTt3zjXYpcHVRo8enUc0L7n88svzqOe77bZbte3EPN9nnHHGPC8/AAAAzLfzdM9r5ukGgIWbeboBFnztzNMNAAAAzI7QDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AZm6tJLL00dO3ZMLVq0SN27d08jR46c6br//ve/06677prXb9SoURo8ePAM6wwcODD97Gc/S0sttVRafvnl00477ZTeeeedyse//PLLdMQRR6S11lorLb744umnP/1pOvLII9PEiRMr17n++uvz9svdxo8fX8BeAACAOSd0A2UNHTo0HXvssen0009Po0aNSp06dUq9e/eeabCdMmVKWnXVVdM555yT2rVrV3adp59+Oh122GHpn//8Z3r88cfTDz/8kLbZZps0efLk/Pj//ve/fDvvvPPSG2+8kQP2sGHD0gEHHFC5jd133z19+umn1W5Rri222CIHeQAAmJ80qqioqEiLkEmTJqXWrVvnmrNWrVo1dHFgvhU121Erfckll+T706dPTx06dMg10SeeeOIsnxu13UcffXS+zcpnn32Wg3KE8c0337zsOnfeeWf63e9+l4N506ZNy26jffv26Zprrkn77LNPXvbaa6/l137ppZdyDfgaa6yRrrzyytS1a9c67AFgQTW2T8+GLgIAc6ndg8+khSVbqukGZjB16tT08ssvp169elUua9y4cb4/YsSIenudUrPxZZdddpbrxI9YucAdbrzxxtSyZcu02267VS7be++900orrZRefPHF/D7iIsFiiy1Wb+UGAIDaKn8WCyzSPv/88zRt2rTUtm3basvj/ttvv10vrxE151Ebvemmm6b1119/puUYMGBAOvjgg2e6najh3muvvXIf8JLRo0enE044Ia299tr5ftR0AwBAQ1DTDTSI6Nsd/bZvv/32mTbX2WGHHdK6666bzjjjjLLrRK37W2+9Va3Pd4i+6AceeGCumY8+5u+//34h7wEAAGZH6AZm0KZNm9SkSZM0bty4asvj/swGSauLww8/PD300EPpySefzM3Aa/r666/Ttttum0c5v/fee2faNPzqq69OnTt3ThtvvHG15RHSYzT1CO1///vfc3CP7QAAwLwmdAMzaNasWQ6yw4cPr9YcPO736NFjjrcb4zZG4I4AHGF4lVVWKVvDHSOaRxkeeOCBPF1ZOd9880264447ZqjlLllzzTXTMccckx577LG0yy67pOuuu26Oyw0AAHNKn26grGii3bdv3zzid7du3fK82zGCeL9+/fLj++67bx41PObeLg2+9uabb1b++5NPPkmvvvpqWnLJJdPqq69e2aT81ltvTffff3+uxR47dmxeHqM+Rp/sUuCO6cduvvnmfD9uYbnllsu171WnNPvxxx/zyOZVffvtt7k/dwysFqH+v//9bx5QLeYQBwCAeU3oBsqK+bBjOq7+/fvncBzNuGPO7NLgajFYWYxoXhLza3fp0qXyfsy1HbeYP/upp57Kyy6//PL8/y233LLaa0Ut9H777ZfnA3/hhRfyslJQL/nwww/zVGRVB1CLGuyll1662noRzL/44ot8USCaw0dT+VjvzDPPrMe9AwAAtWOebgBgoWKeboAFXzvzdAMAAACzI3QDAABAQfTpno/97Mr3GroIAMylF39ffXwCAGDRoqYbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAAC3PovvTSS1PHjh1TixYtUvfu3dPIkSNnuf6dd96Z1l577bz+BhtskB555JF5VlYAAABYYEL30KFD07HHHptOP/30NGrUqNSpU6fUu3fvNH78+LLrP//882nPPfdMBxxwQHrllVfSTjvtlG9vvPHGPC87AAAAzNehe9CgQemggw5K/fr1S+uuu2664oorUsuWLdO1115bdv0LL7wwbbvttumEE05I66yzThowYEDaaKON0iWXXDLPyw4AAADzbeieOnVqevnll1OvXr3+/wI1bpzvjxgxouxzYnnV9UPUjM9sfQAAAGgoTRvslVNKn3/+eZo2bVpq27ZtteVx/+233y77nLFjx5ZdP5aX8/333+dbycSJE/P/J02alOZ30779uqGLAMBcWhD+3ixsvv7hx4YuAgBzqeUC8Pez9De+oqJi/g3d88LAgQPTmWeeOcPyDh06NEh5AFi0tD6moUsAAAug1q3TguLrr79OrWdR3gYN3W3atElNmjRJ48aNq7Y87rdr167sc2J5XdY/6aST8kBtJdOnT09ffvll+slPfpIaNWpUL+8DmPOrg3EBbMyYMalVq1YNXRwAWCD4+wnzh6jhjsC94oorznK9Bg3dzZo1SxtvvHEaPnx4HoG8FIrj/uGHH172OT169MiPH3300ZXLHn/88by8nObNm+dbVUsvvXS9vg9g7sQJg5MGAKgbfz+h4c2qhnu+aV4etdB9+/ZNXbt2Td26dUuDBw9OkydPzqOZh3333Te1b98+NxMPRx11VNpiiy3S+eefn3bYYYd0++23p5deeildddVVDfxOAAAAYD4L3bvvvnv67LPPUv/+/fNgaJ07d07Dhg2rHCxt9OjReUTzkk022STdeuut6dRTT00nn3xyWmONNdJ9992X1l9//QZ8FwAAADCjRhWzG2oNoCAxs0C0YomxF2p2AwEAyvP3ExYsQjcAAAAU5P9vtw0AAADUK6EbAAAACiJ0A/OVjh075lkMZuWpp55KjRo1ShMmTJhn5QKAReFvLFD/hG4AAKhn++23X9ppp53mqwvHL774Yjr44IMryzCrW6wDLCRThgHUxQ8//NDQRQCABjN16tTUrFmzOXrucsstVzkF76efflq5/KijjkqTJk1K1113XeWyZZddth5KCwQ13UC9TF1y5JFHpuWXXz61aNEibbbZZvlqeujatWs677zzKteNq/6LLbZY+uabb/L9//73v/mK+nvvvVd22/HY5Zdfnn7961+nJZZYIp199tnz6F0BQPGeffbZ1LNnz7T44ounDh065L+nkydPrtYkfMCAAWnfffdNrVq1yjXV119/fVp66aXTQw89lNZaa63UsmXLtNtuu6UpU6akG264IT9nmWWWyduaNm3aDM3LI7S3a9eu8havHVOPVV02p8EemJHQDcy1P/zhD+nuu+/Of+hHjRqVVl999dS7d+/05Zdfpi222KKyiVrMUPjMM8/kE4U4yQhPP/10at++fX7OzJxxxhlp5513Tq+//nraf//959n7AoAivf/++2nbbbdNu+66a/rXv/6Vhg4dmv8+Hn744dXWi4vXnTp1Sq+88ko67bTT8rII2BdddFG6/fbb07Bhw/Lf2vhb+cgjj+TbTTfdlK688sp01113NdC7A0o0LwfmSlyNj5rouOq+3Xbb5WVDhgxJjz/+eLrmmmvSlltumf8fV9rfeOONfOV89913zycHcaIR/49gPit77bVX6tevX+X9Dz74oPD3BQBzK2qil1xyyWrLqtY8Dxw4MO29997p6KOPzvfXWGONHKTj72L8bY3WY+GXv/xlOu644yqfFxewo7tVrLPaaqvlZVHTHUF73Lhx+TXXXXfd9Itf/CI9+eST+e8u0HDUdANzfZU+/vBvuummlcui+Xi3bt3SW2+9lZvMff311/nqfNRqx4lEBPFS7Xcsi/uzEk3UAWBBE6H31VdfrXa7+uqrKx9/7bXX8kXrCMmlW7QUmz59evrwww9n+XcwmpSXAndo27Ztbj5eNeTHsvHjxxf6HoHZU9MNFCqakkeTuAjZI0aMSFtvvXXafPPN81X3d999N/3nP/+ZbU139OUGgAVN/P2q2X0qxjIpifFNfv/73+e+1zX99Kc/rbadmuICd80xUMotiwAPNCw13cBciavs0WT8ueeeq1wWNd8xkFo0bQsRqqN52z/+8Y9cqx0joq6zzjp5ULQVVlghrbnmmg34DgCgYWy00UbpzTffzMG85s1AZrDwELqBuRJX3w899NB0wgkn5IFc4uThoIMOygO8HHDAAXmdCNqPPvpoatq0aVp77bUrl91yyy2zreUGgIXVH//4x/T888/ngdOi6Xm0/rr//vtnGEgNWLAJ3cBcO+ecc/LIq/vss0++ah/Tf0XIjulKQvTrjuZtVQN2hO4YTGZ2/bkBYGG14YYb5rFNortV/K3s0qVL6t+/f1pxxRUbumhAPWpUEXP4AAAAAPVOTTcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAsBLbccst09NFHN3QxAIAahG4AaGD77bdfatSoUb4ttthiaZVVVkl/+MMf0nfffVfrbdxzzz1pwIABhZYTAKi7pnPwHACgnm277bbpuuuuSz/88EN6+eWXU9++fXMI/8tf/lKr5y+77LJpUTB16tTUrFmzhi4GANSamm4AmA80b948tWvXLnXo0CHttNNOqVevXunxxx/Pj33xxRdpzz33TO3bt08tW7ZMG2ywQbrttttm2bz8sssuS2ussUZq0aJFatu2bdptt90qH/v+++/TkUcemZZffvn8+GabbZZefPHFysefeuqpHPiHDx+eunbtml9zk002Se+8807lOmeccUbq3Llzuummm1LHjh1T69at0x577JG+/vrrynWmT5+eBg4cmGvuF1988dSpU6d01113VT5+/fXXp6WXXrra+7jvvvvya9d8nauvvjpvJ8oLAAsSoRsA5jNvvPFGev755ytrdKOZ+cYbb5wefvjh/NjBBx+c9tlnnzRy5Miyz3/ppZdyqD7rrLNyUB42bFjafPPNKx+Pput33313uuGGG9KoUaPS6quvnnr37p2+/PLLats55ZRT0vnnn5+317Rp07T//vtXe/z999/PIfmhhx7Kt6effjqdc845lY9H4L7xxhvTFVdckf7973+nY445Jv3ud7/L69XFe++9l8sbTehfffXVOj0XABqa5uUAMB+I0LrkkkumH3/8MddEN27cOF1yySX5sajhPv744yvXPeKII9Kjjz6a7rjjjtStW7cZtjV69Oi0xBJLpF/96ldpqaWWSiuvvHLq0qVLfmzy5Mnp8ssvz7XM2223XV42ZMiQXKt+zTXXpBNOOKFyO2effXbaYost8r9PPPHEtMMOO+QLAKXa5qjJju3Ea4S4EBC14/G8eA9//vOf0xNPPJF69OiRH1911VXTs88+m6688srK7da2SXmE9+WWW26O9i0ANCShGwDmA7/4xS9yGI5QfMEFF+Sa5V133TU/Nm3atBxgI2R/8sknOYRGqI1m3+VsvfXWOWhHyI2+4nHbeeed8/pROx39xjfddNPK9WPwtgjvb731VrXtbLjhhpX/XmGFFfL/x48fn37605/mf0ez8lLgLq0Tj5dqp6dMmZLLUlWUvXQBoLbivQjcACyohG4AmA9EzXQ08w7XXntt7v8cNc8HHHBA+utf/5ouvPDCNHjw4NyfO9aN/tsRYMuJIBzNxqNv9mOPPZb69++f+0ZX7bddGxHGS0r9rKN2u9zjpXVKj3/zzTf5/9EkPmrqa/ZfD1GbX1FRUe2xuCBQbt8AwIJKn24AmM9EGD355JPTqaeemr799tv03HPPpR133DH3h44wHjXY77777iy3ETXlMRjbueeem/71r3+ljz76KP39739Pq622Wu4rHtusGnQjkK+77rr19h5iWxGuo6l7XEyoeovB4kLUXsfAa1G7X6LPNgALGzXdADAf+s1vfpP7V1966aV5FPIY9TsGV1tmmWXSoEGD0rhx42YakqN/+AcffJAHT4v1H3nkkVwDvdZaa+Va40MPPTRvO6YZi6biEcyjKXjUqteXqG2PfugxeFq8doyQPnHixBz2W7VqladE6969e27yHhcYYuC3F154IfcRB4CFidANAPOhqKk+/PDDcyB+5ZVXcoiOEcYjpMbo5TGtWITYcmIarhjpO5qUx8BnEdpjirH11lsvPx4jjEcQjoHPoqY5pgWLgdkioNenAQMG5NrsGMU8yh/l2mijjXLIDhH6b7755nwBIAZz22qrrXKZ4/0BwMKiUUXNzlQAAABAvdCnGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAACpGP8fAzr7mgNRB80AAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAV0RJREFUeJzt3Qm8TeXb//HLPNU5kuFEMpaUMSJzZUoSjciDjNWvFErRQCUpZSqiKJUGSqVJhkwRZW40JEL9jJnnaf9f3/v/rP3svW1ncpZzjvN5v167zl7Tvvdaay/rWtc9ZAoEAgEDAAAAAAApLnPKbxIAAAAAABB0AwAAAADgIzLdAAAAAAD4hKAbAAAAAACfEHQDAAAAAOATgm4AAAAAAHxC0A0AAAAAgE8IugEAAAAA8AlBNwAAAAAAPiHoBgAAifLzzz/b008/bZs2bWKPAQCQSATdAJAGFC9e3O6++25LT6699lr3wtmhYDdTpkyptrv37Nljt9xyi+3atcuKFi2aIfdBpL/++suV5+2337b0ZM6cOa7c+j8AwH8E3QB89eeff9o999xjJUuWtJw5c1pMTIzVqlXLhg8fbocOHWLvI0mef/55mzx5Mnst5GGNAtGzoUOHDla5cmUbOnSor59z8OBB950ICJFe/fvvv9arVy8rU6aM+3cvX7581rhxY/vqq6/Cltu2bZt7+PHQQw+dsg1N07x+/fqdMq9du3aWLVs291sRPbA977zzfPxGAM5U1jPeAgCcxtdff2133HGH5ciRw90klCtXzo4ePWrz5893NyS//fabvfHGG+w/M1u9erVlzsxz0MQE3bfffru1aNGC8+YsZ3SrVq1qPXv29P08VSDxzDPPuL8ja1I8+eST1rt3b18/PyOoW7eue+iZPXv21C7KOXktr1+/vm3fvt09qNLvZvfu3fb+++9bs2bN7JFHHrGXXnrJLVuwYEG79NJL3b+Jkb7//nvLmjWr+3+0eXoAljt37rPynQCcOYJuAL5Yv369tWrVyooVK2azZs2yiy66KDjv/vvvt7Vr17qg/Fx08uRJ93BBGY7E0oMJIC1n1B9//PHULoYLQvRCuAMHDliePHkSvVv04CQp16eM4vjx4+76ndyHEceOHXMPBdUE47vvvrPq1asH5/Xo0cPatGljL7/8sgvEW7Zs6abXrl3b3n33Xdu/f38wW63j+dNPP9mdd95pX3zxhZ04ccKyZMni5m3evNnWrVtnzZs3T5HvDODsIK0CwBeDBg1yNxFvvvlmWMDtKV26dFiVOt3s9O/f30qVKuUCUO8m/8iRI2HrafpNN93kqp7qxiVXrlxWvnz5YFXUTz/91L3XDWWVKlVs+fLlYet71fB006LqfrpRLVy4sD377LMWCATCltXNUc2aNe3CCy90n6PtTZo06ZTvoiqADzzwgMtkXHnlla78U6dOTdI2Itt06+ZN2T5lQfRdtL5uzmbMmBG2nh5o1KlTx32PvHnzuhuxlStXRm0Hqwcd+gwtFxsb67IwXvXEhKhGgo6NvkO1atVs3rx5UZfT8VJ1SB1f7Qe1/X300UdPOY76Hvo+KouOh6phJhTU6TvoZvSdd95xf+sVus/++ecf69ixoxUqVMh9to7FW2+9FbUt60cffeT2b5EiRez88893N8pqs6xydu/e3WWgVC7to8iyhx5vr/qojqtuskPt27fPbUvHVuXRNhs2bGjLli1LcH8r83X11Ve7bWu/v/7665ZYyqrpc7Xv9bk6Fi+++KILJkTn+XXXXWcFChRw1Vs9elCk344+T/vZ895777nvp2OvarJ6mBatI7Uff/zRbrzxRrvgggvc+VihQgXXjCShPgB0DLWPvIy6yiU6Pt5x9qrQR2vTndRrh/atzmHtWzV7UcCT2P2qsuq3o/O2ffv2blo0q1atcueU9pc+R9cqBU+hEvsbj6T249oHc+fOtf/85z/uvLr44ovdvA0bNrhpOi91vLRN1TbSfk2oTfcff/xht912m8XFxbnyaJs61vpd+LWvve+izK1qUejY69xR3wHKFEf65ptvgtc7/W6bNm3qakyFSsx5FtoeX9foYcOGBb/T77//7ua/+uqr7hqibLLOaR3DDz74IN5j88knn9ivv/7qamOEBtyioFm/Y507oU1CdMwVVP/www9hvyXta2XF9e/oihUrgvO8zLfWA5B+8LgYgC++/PJLd5OlgDMxOnfu7IIp3ag+/PDD7qZj4MCBLoD87LPPwpZV8HjXXXe5tuL/8z//426aVG1v9OjR7gZQN52i9ZUpiKy6rRucG264wa655hr3cEABsgJF3eQo+PYoYLj55ptddkIByYQJE9wNrNrl6WYvMvhVIKdgLH/+/MGbu6RsI5RuylR+7RfdtO7du9eWLFniAjYFbvLtt99akyZN3H7W8qouqhtFtZnXcqE3mKJ9UaJECbddzR87dqy7YVdAFh89ONG+1rFUMKcHFvpOCihCO9RSUKfputHu2rWrlS1b1n755RfXBnjNmjXBtti6SdYNuYIy7W/d6OqYRqtGGWr8+PHB/aHti26UZevWre54egGxbt51g96pUye371TuUNoHCkp0c6zP1n5TG0mdJ8pSaX/qJlhBgfZZ3759w9ZXwDNx4kR78MEHXflfe+01d04tWrTINaOQe++91z1gUXmuuOIK185T+0bn9FVXXXXa76l91qhRI/cdVA6dlzo/9TAhIXqIUq9ePfcAQsfskksusQULFlifPn1chkzBhfaRHkZo/6uMelAl+gwdGwViXtZ0wIAB9tRTT7lzR/tegZD2laon64GWAghRoKhjqgdsepimwE3fU+d5tPaqp6PvPGrUKLvvvvtc4HXrrbe66SprSl07tJzOCwXN2g8KxvRQQQHW6ehBhR5o6fhpn+nc1ra1jUjah/oN6oGOzi/tS10b1CRCQZm+V2J/4/HRdU77S+em95Bk8eLF7ngrWFbQrMBS+1NBqILJ01VH1rVJDyEVPHfr1s0dP51DOn56sKAHDX7ua32mAludgyqzzlP9bvQbC/39azsqp65ZOtf13RR86lyMvN4l1rhx4+zw4cPumqLfsq5rY8aMcb9tlV/nr+ar5359X/3bE9+/e6LmVNFoP+o80j7U/tEDMS941rnVoEED97euhZdddpmrQq7jqPfab948IegG0pkAAKSwPXv2KGUcaN68eaKWX7FihVu+c+fOYdMfeeQRN33WrFnBacWKFXPTFixYEJw2bdo0Ny1XrlyBDRs2BKe//vrrbvrs2bOD09q3b++mdevWLTjt5MmTgaZNmwayZ88e2L59e3D6wYMHw8pz9OjRQLly5QLXX3992HRtL3PmzIHffvvtlO+W2G3oe6lsnooVK7oyxadSpUqBggULBv7999/gtJ9++smVpV27dsFp/fr1c2Xs2LFj2Pq33HJL4MILL4z3M1RefYY+68iRI8Hpb7zxhttmvXr1gtPGjx/vPnvevHlh2xg9erRb9vvvv3fvhw4d6t6H7uvEypMnT9h+8nTq1Clw0UUXBXbs2BE2vVWrVoHY2NjgcdC5oM/WMdB387Ru3TqQKVOmQJMmTcLWr1Gjhjs2obS+XkuWLAlO03mXM2dOt089+tz7778/yd+xRYsWbluh5/Lvv/8eyJIli/vc+PTv39/tozVr1oRN7927t1t/48aNp/w+3nvvvcAPP/zg5nfv3j04/6+//nLTBgwYELatX375JZA1a9bg9OPHjwdKlCjh9tOuXbvCltVvy6NzJfR88eh4hu5jnRcql87bSN65fCbXju+++y44bdu2bYEcOXIEHn744UB8Jk+e7NYdNGhQcJq+d506ddz0cePGBafXr18/UL58+cDhw4fD9kPNmjUDl156aZJ+49Hos/SZtWvXdmWI73ojCxcudMu/++67wWne78C7Ni5fvty9//jjj0/7uX7sa++7NGjQIOxc6dGjhzv3du/e7d7v27cvkDdv3kCXLl3CPnvLli3udxY6PbHn2fr1691nx8TEuLKF0r9dV155ZSCpdJ1UeeIzZMgQ97lffPFFcJqusTpvPI0bNw506NDB/X3nnXcG7rjjjuC8qlWrhp1H3nfT7x5A2kX1cgApThkbUfW/xJgyZYr7v6oXhlImRSLbfitrWKNGjeB7rxrf9ddf7zJ7kdOVmY2kLIrHy44q26PssUeZUI+yn6pmqaqN0aoHK7uockVKyjZCKYOojJmqfEajrKWqHCpzpMyMRxlBZcm8fRpKGbpQKoeyr97xikaZN1VB1rqh7Ry9arahPv74Y5cBvPzyy23Hjh3Bl46LzJ49O/jd5PPPPw9WeT4TioOVQVRtB/0d+tnKimmfR+5vr/ff0HNF66p6eihNV1VqZZtD6fzzMk+i804ZrGnTprmaFN73VGbsv//9b6K/i9bVNpQVDT2XtV/1XRKiY6Djqqxh6H5QBk3bDq0Cr8yetqksY9u2bV2tAXVU51EGXMdHWe7QbSkLqirR3vFUllF9OKg2gXdsPX4P75Wca4f2j0eZYlXFjnaNiPwctSVXBj60urD2XaidO3e6Wi/aZ2pe4O0z/c60r/V7VgY5Mb/xhHTp0iXYzjfa9UbV1/W5yqbqs+K75ni/ZZ17p2ty4ue+1rkYeq5oPZ2vqi7v1aRQxr1169Zh56K+v36j3rmYHKpS7zVp8Gh//f33367mQFLomCf07543P/S6q5oRulboO+s3p1o2Xi0xzfOy2zo2uu6T5QbSH4JuAClOw4J5NyCJoRsrVevVzWEo3dzr5se78fKEBiOhN4yRYwd70xXshtJnqUp2KFXlk9C2j6paqSrL3pAvXtXX0DaOHlVBjiYp2wilate6yVS51M5Wvb2reqPH2ye6iY2kAE03pKHtcqPtNwVm0fZPKO9zFGSFUsAauQ8VPCiI0HcMfXn71ms/rA6EdCOpqqqqMq2qsKp+m9wAXFWeta/U7jzys9UmO/Szk3MOqVyRxytyf4i+p26Kvbaoarqg9p3apqoPqzpxQsGd1lUzgWjbj3asI+kYqLlE5H7wqq1G7gc1HVCZtZ6q0ocGbZqmBxEqS+T2VJ3Y25aGBRSvWv3ZdKbXDu93EN9vwPscVZ2PHJYp8pioyrD2markR+4zb+gnb78l9BtPSLRrjs4dVTf32vOrqYs+W58T3zVH21IwrSYnWkcPCEaOHBm2jp/7OqFrk/dgQg/wIvfr9OnTTzmvkyLafnzsscfcsdbvVue/Ov9MqPmLF1An9O+eNz80OFcQ7bXd1jVD+13XSFHwrQd3+rfJa+tN0A2kP7TpBuBL0K3OyXTzkBSJzYpFZncSmh7ZQVpiqKMwtU9W21W119UNtwJNtf+L1plOaLCS3G2E0joKZpQN1k2lbobVNlrt1hWsJkdK7p9oFJwqeBgyZEjU+V5Aq32ljKuyU8qOKUhU203dUOu7nq6c8X2uqH1/tDa20doEn41zSNlOZezU1lXfS8MEqS2qMshqi+8H7QvVdFDnddF4D0A8ar/tdYKltuShNUi0Lf0m1TY+2n5J6rjA2la0/ejVDDgTZ3rtSMnfgKgDrNPVTPCC1jP9jUe75ijzruuLah3oWOqhkfaNHmwl9FBr8ODBrgaLVx61aVZ7bWVdvY7a/NrXCS3rlV3tuhXkRwrt0T6p51m0/agHl+oLRA9NdX1STRpdw/VAwxvOLhqtp8B548aNUR86iPdgJbRmVGi7btUo0gNa1RiSSpUqubb4mqcaJaHLA0g/CLoB+EKdKinzuHDhwrAb+Wg0rJhuqpTN0E2LR51jKUOj+SlJn6WMY2gAoo6+xOuMRzdZyk6rumXocF66oU2sM92GbryUqdVLWRDdpCtbqhtyb5/oxjBaz8nKViVlCKHT8T5Hx8arJu5VXdUNYMWKFYPTVD1Zw9xojNqEbsyVMdNyeilIV7XmJ554wgXiXlY2mmjbVbZLWSPdVMe3bkqKViVY55BujkOrqupBizq80kvZOHWgps7JThd0a10FAdG2H+1YR9Ix0LmSmP2gJgoK0tRpm270vUDRO+baloIXZQIjg/XIzxQ9ZIvvc5W9jJbpj8yQJqVK+tm6dmg7M2fODBvWKdox8Wp/6OFaYo5BfL/x5FDHfXrwpADao07ATtfLeiQ9NNNL46GrQzZlW/UQ4Lnnnjvr1+lo55g6fkxovyb2PEuIrp+qlaOXmh6pUz/9dtUp4emGW9O/ex9++KHrpV37MJKqlOuhhgLq0BoDui54gbX+rdC/md7vQA8UNJKBMu265mofxPd7BJA2Ub0cgC+UadNNi24edVMWSRkebzghDTMk6rE2lJcxja+X7+QaMWJE8G8FFnqvG2UFgV7mRTc9odkRVe/zeuBOjDPZhtpihtKNvm7SvKykgjllQNQLbugNtQIfZam8fXqmNEyOAkHdeOvG06OqyJE38srsqr2qev6NVu3Vq+6udq+R9F0kcuihSDqnIj9X+1ntMr3heiJFG3roTOlhUmgbWbX71s20AliVR8c8sjqvbpZVAyS+76h1FfjqHFG2zKPq3Hp4kxAdA5Ut2rLab6Ft09UmWEGUqpjrAZlu7tXTtJclVJCh8iizF5k51HvvHFXAoMBcv9/IYxO6ngInPRAKPR56SBNZbdfrYTsxgeLZunboc7Tv1DTEo2Osntwjj7F6CtfQUHqoESn0uyf0G08OHa/IY6UyJlSbQMFgZL8FCr71cMwrT2pcpz36TagGlR7O6YFffPs1sedZfCKPjR5KKTOtfRvt8z3q7VzLvfDCC64/jFD6ralPAFWZ95oaePTbU9t0lVGvyFE/9F61g1TrwKt2DiB9IdMNwBe68VEVamUJlBVRx1Vq86nATRkUdfjkjbGsbKmyM7rx1422OiXT0EsKKNWhlMYUTknKUqjKoD5TNzqqPqtqzhpuzMtS6gZSN5MaBkpDxChLqTaOuilObLvLM9mGbtx0867OupQN0w2cN/yUR9WVlTFVVkTBkjdkmKqUho4Deyb0IEJZLg0/pUy3jqeyLcrWR7bpVmdcaputTteUsdbNoW72dQOs6QoEFcSrLatuILV/lB3TflHVTVVhTajapPaHOrvTflUAq2BPx1A3ufpM/a1gUvtPwb0CYy0fLdA/EzqXFQiEDhkmXtVTtdvU99FNuM5vBVQqhzpmCs1CRqNt6PxU1XRlyBUMeWMGJ3TeqF2wxoNWxs0bnkkPO1R1XOePHvqoFoSOn855PTzxqg7rM1RFX4GlPle/YR17Zfa0nn6LqlGg468q8+r8StlxBWZaRx3Z6eGJsrZ6KKTjrjb+3gMAdVKn46b9pvNVx10Pc/S9QjuVUqZfx09NDpTR0/mv/R2tzfjZunbou+l81hBg2hcqn5oJRGsnrd+4zmMFrToX9TvRg0c9DFHnXAoAE/sbTyodd1XB1jVA29dn6rzTeN3xUedv+lwNZ6h9rnNO2/EeaKXGdTqUAm6dY7rG6CGPqsvrWq0HUzqPdWy8B6mJPc/io4dnqsau7arfCT300vZ1zYqvozQF5zqGenirc0C/BV3ztL/076GuR+p4TuWPpOW9DuEiA2sF3arq7y0XjR4G6PcaSeeWN4wmgFSU2t2nAzi3aegiDedSvHhxNyTX+eefH6hVq1bg1VdfDRtS59ixY4FnnnnGDT2ULVu2QNGiRQN9+vQJW0Y05Eu0YXZ0OYscnskbEuall146ZWiVP//8M9CoUaNA7ty5A4UKFXJDEZ04cSJs/TfffNMNzaJhbi6//HI3vE3kkEWn++ykbiNyyLDnnnsuUK1aNTdMjoZC07oaoil0mCv59ttv3f7UMhr6plmzZm54qVDe50UO0eUN16P9lJDXXnvNHRt9Dw1Zo6GAog3No/K9+OKLbrgdLXvBBRcEqlSp4o6thpKTmTNnuiF5Chcu7M4J/V9DdkUOcxXNqlWrAnXr1nXfV2UP3Wdbt251x0Hnjs6huLg4NwyPhjeLHCopcmgkb18sXrw4wX3nHW8NteUd28qVK4cNTafh1Xr16uWGhdI5r3NOf2s/JsbcuXPdftP+KVmypBt2Ldp5E42GV9Jvp3Tp0m79/Pnzu+GqXn75ZXd8Nm3a5IY10rkSSUOeqazr1q0LTvvkk0/c8FSarpfORX3/1atXh607f/78QMOGDYPft0KFCu53Hkr7TN9H5dLwShruL3IoJ9GQgN73Dx0+LNo+ONNrx+mGmIqkofnatm3rfmfaf/rbG2ordMgw0fVFw/bpHFSZihQpErjpppsCkyZNSvJvPNLpzlXRkG0aakrH/LzzznNDT+k3E3l9iRwyTMdbQwqWKlXKDVeXL1++wHXXXeeuL37u69N9l8jyhU7Xd9L+VzlV3rvvvjts+L7EnmfR/n0IHU5P1xkNqajftz5Hv2fvGpYQDUHWs2dP9xvU+jrGGhYtdJiwSN7QlxqO78CBA6ecexrSUPN//PHHU9b1hsKM9lLZAaS+TPpPagb9AHA2KfunTITaTwLJoSYD6s04tIkCAADA6dCmGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QptuAAAAAAB8QqYbAAAAAACfEHQDAAAAAOCTrJbBnDx50v773//a+eef74Z9AQAAAAAgqTT69r59+6xw4cKWOfPp89kZLuhWwF20aNHULgYAAAAA4BywadMmu/jii087P8MF3cpwezsmJiYmtYsDAAAAAEiH9u7d6xK6Xox5Ohku6PaqlCvgJugGAAAAAJyJhJot05EaAAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAgHTku+++s2bNmrnhSdSGbPLkyQmuM2fOHLvqqqssR44cVrp0aXv77beTvM39+/fbAw884HpnzZUrl11xxRU2evToU5ZbuHChXX/99ZYnTx7Xd0rdunXt0KFDZ/itAQBIvwi6AQBIRw4cOGAVK1a0kSNHJmr59evXW9OmTe26666zFStWWPfu3a1z5842bdq0JG2zZ8+eNnXqVHvvvfds5cqVbjsKwr/44ouwgPuGG26wRo0a2aJFi2zx4sVumfjGLgUA4FyXKaARvTNYt+6xsbG2Z88eei8HAKRrykp/9tln1qJFi9Mu89hjj9nXX39tv/76a3Baq1atbPfu3S6ITuw2y5UrZy1btrSnnnoqOK1KlSrWpEkTe+6559z7a665xho2bGj9+/ePWpajR4+64P2TTz6xXbt2WaFChezee++1Pn36JOv7AwCQHmJLHj0DAHAOU/a5QYMGYdMaN27spidFzZo1XVb7n3/+MT2vnz17tq1Zs8ZltWXbtm32448/WsGCBd2yCqjr1atn8+fPD27jlVdecdv46KOPbPXq1fb+++9b8eLFU+ibAgCQNmW4cboBAMhItmzZ4gLgUHqvp/Nqa6322Ynx6quvWteuXV2b7qxZs7oq42PGjHFttmXdunXu/08//bS9/PLLVqlSJXv33Xetfv36Lst+6aWX2saNG93/a9eu7TLqxYoV8+EbAwCQtpDpBgAAiQq6f/jhB5epXrp0qQ0ePNjuv/9++/bbb938kydPuv/fc8891qFDB6tcubINHTrUypQpY2+99Zabd/fdd7t25Zr24IMP2vTp09nzAIBzHpluAADOYXFxcbZ169awaXqvtmeJzXIrI/7444+7tt7qlE0qVKjgAmhltVV9/aKLLnLT1at5qLJly7oMt6gHdXXs9s0337hg/c4773TrTpo0KYW+LQAAaQ+ZbgAAzmE1atSwmTNnhk2bMWOGm55Yx44dc6/IXsizZMkSzHCrbbaGHFNb7VBq9x1ajVzBvjpkU9X0iRMnuk7Vdu7cmcxvBwBA2kemGwCAdETjZa9duzb4XpljZZzz5ctnl1xyiesJXJ2dqT21qHfwESNG2KOPPmodO3a0WbNmuY7M1KN5YrepQFmdovXq1ctlxxVEz507133GkCFD3Dpqo635/fr1c8OPqU33O++8Y6tWrQpmsrWsMuKqeq4A/uOPP3aZ+Lx5857FPQgAwNlF0A0AQDqyZMkSN+a2R0NwSfv27e3tt9+2zZs3B6tzS4kSJVyA3aNHDxs+fLjrCG3s2LGuB/PEblMmTJjgAvo2bdq4zLQC7wEDBrig3qOxuw8fPuw+S8so+FZWvVSpUm7++eefb4MGDbI//vjDZcmvvvpqmzJlCuN4AwDOaYzTDQAAAABAEjFONwAAAAAAqYyO1AAAAAAA8AltugEAybalWR32HpAOxX05L7WLAAAZBpluAAAAAAB8QtANAAAAAMC5GHR/99131qxZMytcuLAb33Py5MkJrjNnzhy76qqrLEeOHFa6dOngUCYAAAAAAKQ1qRp0HzhwwI3hOXLkyEQtv379emvatKkbS3TFihVuPNDOnTvbtGnTfC8rAAAAAADpqiO1Jk2auFdijR492kqUKGGDBw9278uWLWvz58+3oUOHWuPGjX0sKQAAAAAA53ib7oULF1qDBg3CpinY1vTTOXLkiBu0PPQFAAAAAMDZkK6C7i1btlihQoXCpum9AulDhw5FXWfgwIEWGxsbfBUtWvQslRYAAAAAkNGlq6A7Ofr06WN79uwJvjZt2pTaRQIAAAAAZBCp2qY7qeLi4mzr1q1h0/Q+JibGcuXKFXUd9XKuFwAAAAAAZ1u6ynTXqFHDZs6cGTZtxowZbjoAAAAAAGlNqgbd+/fvd0N/6eUNCaa/N27cGKwa3q5du+Dy9957r61bt84effRRW7Vqlb322mv20UcfWY8ePVLtOwAAAAAAkCaD7iVLlljlypXdS3r27On+7tu3r3u/efPmYAAuGi7s66+/dtltje+tocPGjh3LcGEAAAAAgDQpUyAQCFgGop7O1Yu5OlVTW3AAQPJtaVaH3QekQ3FfzkvtIgBAhokt01WbbgAAAAAA0hOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAgHM16B45cqQVL17ccubMadWrV7dFixbFu/ywYcOsTJkylitXLitatKj16NHDDh8+fNbKCwAAAABAugi6J06caD179rR+/frZsmXLrGLFita4cWPbtm1b1OU/+OAD6927t1t+5cqV9uabb7ptPP7442e97AAAAAAApOmge8iQIdalSxfr0KGDXXHFFTZ69GjLnTu3vfXWW1GXX7BggdWqVcvuuusulx1v1KiRtW7dOsHsOAAAAAAAGSroPnr0qC1dutQaNGjwf4XJnNm9X7hwYdR1atas6dbxgux169bZlClT7MYbbzxr5QYAAAAAILGyWirZsWOHnThxwgoVKhQ2Xe9XrVoVdR1luLVe7dq1LRAI2PHjx+3ee++Nt3r5kSNH3Muzd+/eFPwWAAAAAACk4Y7UkmLOnDn2/PPP22uvvebagH/66af29ddfW//+/U+7zsCBAy02Njb4UudrAAAAAACc05nu/PnzW5YsWWzr1q1h0/U+Li4u6jpPPfWUtW3b1jp37uzely9f3g4cOGBdu3a1J554wlVPj9SnTx/XWVtoppvAGwAAAABwTme6s2fPblWqVLGZM2cGp508edK9r1GjRtR1Dh48eEpgrcBdVN08mhw5clhMTEzYCwAAAACAczrTLcpAt2/f3qpWrWrVqlVzY3Arc63ezKVdu3ZWpEgRV0VcmjVr5no8r1y5shvTe+3atS77rele8A0AAAAAQFqRqkF3y5Ytbfv27da3b1/bsmWLVapUyaZOnRrsXG3jxo1hme0nn3zSMmXK5P7/zz//WIECBVzAPWDAgFT8FgAAAAAARJcpcLp62ecotelWh2p79uyhqjkAnKEtzeqwD4F0KO7LealdBADIMLFluuq9HAAAAACA9ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+CRrclY6duyYbdmyxQ4ePGgFChSwfPnypXzJAAAAAADIKJnuffv22ahRo6xevXoWExNjxYsXt7Jly7qgu1ixYtalSxdbvHixv6UFAAAAAOBcC7qHDBniguxx48ZZgwYNbPLkybZixQpbs2aNLVy40Pr162fHjx+3Ro0a2Q033GB//PGH/yUHAAAAAOBcqF6uDPZ3331nV155ZdT51apVs44dO9ro0aNdYD5v3jy79NJLU7qsAAAAAACce0H3hx9+mKiN5ciRw+69994zLRMAAAAAAOeEM+69fO/eva66+cqVK1OmRAAAAAAAZNSg+84777QRI0a4vw8dOmRVq1Z10ypUqGCffPKJH2UEAAAAACBjBN1q212nTh3392effWaBQMB2795tr7zyij333HN+lBEAAAAAgIwRdO/Zsyc4LvfUqVPttttus9y5c1vTpk3ptRwAAAAAgDMJuosWLeqGCTtw4IALujVMmOzatcty5syZ1M0BAAAAAJCxey8P1b17d2vTpo2dd955dskll9i1114brHZevnx5P8oIAAAAAEDGCLr/85//uHG5N23aZA0bNrTMmf9/srxkyZK06QYAAAAA4EyCblGP5eqtfP369VaqVCnLmjWra9MNAAAAAADOoE33wYMHrVOnTq7ztCuvvNI2btzopnfr1s1eeOGFpG4OAAAAAIBzVpKD7j59+thPP/1kc+bMCes4rUGDBjZx4sSULh8AAAAAABmnevnkyZNdcH3NNddYpkyZgtOV9f7zzz9TunwAAAAAAGScTPf27dutYMGCp0zXEGKhQTgAAAAAABld5uR0ovb1118H33uB9tixY61GjRopWzoAAAAAADJS9fLnn3/emjRpYr///rsdP37chg8f7v5esGCBzZ07159SAgAAAACQETLdtWvXthUrVriAu3z58jZ9+nRX3XzhwoVWpUoVf0oJAAAAAEBGGadbY3OPGTMm5UsDAAAAAEBGC7r37t2b6A3GxMScSXkAAAAAAMhYQXfevHkT3TP5iRMnzrRMAAAAAABknKB79uzZwb//+usv6927t919993B3srVnvudd96xgQMH+ldSAAAAAADOxaC7Xr16wb+fffZZGzJkiLVu3To47eabb3adqr3xxhvWvn17f0oKAAAAAMC53nu5stoaqzuSpi1atCilygUAAAAAQMYLuosWLRq15/KxY8e6eQAAAAAAIJlDhg0dOtRuu+02++abb6x69epumjLcf/zxh33yySdJ3RwAAAAAAOesJGe6b7zxRhdgN2vWzHbu3Ole+nvNmjVuHgAAAAAASGamWy6++GJ7/vnnk7MqAAAAAAAZRrKC7t27d7sq5du2bbOTJ0+GzWvXrl1KlQ0AAAAAgIwVdH/55ZfWpk0b279/v8XExFimTJmC8/Q3QTcAAAAAAMls0/3www9bx44dXdCtjPeuXbuCL7XvTqqRI0da8eLFLWfOnK5jtoSGHdNn3n///XbRRRdZjhw57LLLLrMpU6Yk+XMBAAAAAEhzme5//vnHHnzwQcudO/cZf/jEiROtZ8+eNnr0aBdwDxs2zBo3bmyrV6+2ggULnrL80aNHrWHDhm7epEmTrEiRIrZhwwbLmzfvGZcFAAAAAIBUD7oVFC9ZssRKlix5xh8+ZMgQ69Kli3Xo0MG9V/D99ddf21tvvWW9e/c+ZXlNVzZ9wYIFli1bNjdNWXIAAAAAAM6JoLtp06bWq1cv+/333618+fLB4Ndz8803J2o7ylovXbrU+vTpE5yWOXNma9CggS1cuDDqOl988YXVqFHDVS///PPPrUCBAnbXXXfZY489ZlmyZIm6zpEjR9zLs3fv3kR+UwAAAAAAznLQrcy0PPvss6fMU0dqJ06cSNR2duzY4ZYtVKhQ2HS9X7VqVdR11q1bZ7NmzXIduakd99q1a+0///mPHTt2zPr16xd1nYEDB9ozzzyTqDIBAAAAAJCqHalpiLDTvRIbcCeXPkPtud944w2rUqWKtWzZ0p544glXLf10lEnfs2dP8LVp0yZfywgAAAAAwBmN050S8ufP76qEb926NWy63sfFxUVdRz2Wqzp7aFXysmXL2pYtW1x19ezZs5+yjno41wsAAAAAgDSf6Za5c+das2bNrHTp0u6ldtzz5s1L0jYUICtbPXPmzLBMtt6r3XY0tWrVclXKtZxnzZo1LhiPFnADAAAAAJCugu733nvPdXamIcM0dJheuXLlsvr169sHH3yQpG1puLAxY8bYO++8YytXrrT77rvPDhw4EOzNvF27dmEdrWm+ei9/6KGHXLCtns6ff/5517EaAAAAAADpvnr5gAEDbNCgQdajR4/gNAXeGv6rf//+rjfxxFKb7O3bt1vfvn1dFfFKlSrZ1KlTg52rbdy40fVo7ilatKhNmzbNfXaFChXcON0KwNV7OQAAAAAAaU2mQCAQSMoKah/922+/uWrloVTtu1y5cnb48GFLyzRkWGxsrOtULSYmJrWLAwDp2pZmdVK7CACSIe7LpDULBAAkP7ZMcvVyZZtD22F7vv32WzcPAAAAAAAks3r5ww8/7KqTr1ixwmrWrOmmff/99/b222/b8OHDk7o5AAAAAADOWUkOutWZmYb0Gjx4sH300UfBYbsmTpxozZs396OMAAAAAABknHG6b7nlFvcCAAAAAACWcm26Fy9ebD/++OMp0zVtyZIlSd0cAAAAAADnrCQH3RoTe9OmTadM/+effxgvGwAAAACAMwm6f//9d7vqqqtOmV65cmU3DwAAAAAAJDPo1jjdW7duPWX65s2bLWvWZDURBwAAAADgnJTkoLtRo0bWp08fNwC4Z/fu3fb4449bw4YNU7p8AAAAAACkW0lOTb/88stWt25dK1asmKtSLhqzu1ChQjZ+/Hg/yggAAAAAQMYIuosUKWI///yzvf/++/bTTz9Zrly5rEOHDta6dWvLli2bP6UEAAAAACAdSlYj7Dx58ljXrl1TvjQAAAAAAGTkNt2iauS1a9e2woUL24YNG9y0oUOH2ueff57S5QMAAAAAIOME3aNGjbKePXtakyZNbNeuXXbixAk3/YILLrBhw4b5UUYAAAAAADJG0P3qq6/amDFj7IknnggbIqxq1ar2yy+/pHT5AAAAAADIOEH3+vXrg72WR47ffeDAgZQqFwAAAAAAGS/oLlGihBsiLNLUqVOtbNmyKVUuAAAAAAAyXu/las99//332+HDhy0QCNiiRYvsww8/tIEDB9rYsWP9KSUAAAAAABkh6O7cubMbm/vJJ5+0gwcP2l133eV6MR8+fLi1atXKn1ICAAAAAJBRxulu06aNeyno3r9/vxUsWDDlSwYAAAAAQEZr033o0CEXbEvu3Lndew0VNn36dD/KBwAAAABAxgm6mzdvbu+++677e/fu3VatWjUbPHiwm64xvAEAAAAAQDKD7mXLllmdOnXc35MmTbK4uDjbsGGDC8RfeeWVpG4OAAAAAIBzVpKDblUtP//8893fqlJ+6623WubMme2aa65xwTcAAAAAAEhm0F26dGmbPHmybdq0yaZNm2aNGjVy07dt22YxMTFJ3RwAAAAAAOesJAfdffv2tUceecSKFy9u1atXtxo1agSz3pUrV/ajjAAAAAAAZIwhw26//XarXbu2bd682SpWrBicXr9+fbvllltSunwAAAAAAGSscbrVeZpeodSLOQAAAAAASGL18nvvvdf+/vvvxCxqEydOtPfffz9RywIAAAAAYBk9012gQAG78sorrVatWtasWTOrWrWqFS5c2HLmzGm7du2y33//3ebPn28TJkxw09944w3/Sw4AAAAAQBqXKRAIBBKz4NatW23s2LEusFaQHUpDiDVo0MA6d+5sN9xwg6Vle/futdjYWNuzZw+9rQPAGdrSrA77EEiH4r6cl9pFAIB0L7GxZaKD7lDKbm/cuNEOHTpk+fPnt1KlSlmmTJksPSDoBoCUQ9ANpE8E3QBw9mLLZHWkdsEFF7gXAAAAAABIwXG6AQAAAABA4hB0AwAAAADgE4JuAAAAAAB8QtANAAAAAEBaCbrVY/nBgweD7zds2GDDhg2z6dOnp3TZAAAAAADIWEF38+bN7d1333V/796926pXr26DBw9200eNGuVHGQEAAAAAyBhB97Jly6xOnTru70mTJlmhQoVctluB+CuvvOJHGQEAAAAAyBhBt6qWn3/++e5vVSm/9dZbLXPmzHbNNde44BsAAAAAACQz6C5durRNnjzZNm3aZNOmTbNGjRq56du2bbOYmJikbg4AAAAAgHNWkoPuvn372iOPPGLFixe3atWqWY0aNYJZ78qVK/tRRgAAAAAA0qWsSV3h9ttvt9q1a9vmzZutYsWKwen169e3W265JaXLBwAAAABAxgm6JS4uzr1UxVyKFi3qst4AAAAAAOAMqpcfP37cnnrqKYuNjXVVzPXS308++aQdO3YsqZsDAAAAAOCcleRMd7du3ezTTz+1QYMGBdtzL1y40J5++mn7999/GasbAAAAAIDkBt0ffPCBTZgwwZo0aRKcVqFCBVfFvHXr1gTdAAAAAAAkt3p5jhw5XJXySCVKlLDs2bMndXMAAAAAAJyzkhx0P/DAA9a/f387cuRIcJr+HjBggJsHAAAAAACSWb18+fLlNnPmTLv44ouDQ4b99NNPdvToUTds2K233hpcVm2/AQAAAADIqJIcdOfNm9duu+22sGlqzw0AAAAAAM4w6B43blxSVwEAAAAAIENKcptuAAAAAADgU6ZbY3H37dvXZs+ebdu2bbOTJ0+Gzd+5c2dSNwkAAAAAwDkpyUF327Ztbe3atdapUycrVKiQZcqUyZ+SAQAAAACQ0YLuefPm2fz584M9lwMAAAAAgBRq03355ZfboUOHkroaAAAAAAAZTpKD7tdee82eeOIJmzt3rmvfvXfv3rAXAAAAAAA4g3G6FVxff/31YdMDgYBr333ixImkbhIAAAAAgHNSkoPuNm3aWLZs2eyDDz6gIzUAAAAAAFIy6P71119t+fLlVqZMmaSuCgAAAABAhpLkNt1Vq1a1TZs2+VMaAAAAAAAycqa7W7du9tBDD1mvXr2sfPnyrqp5qAoVKqRk+QAAAAAAyDiZ7pYtW9rKlSutY8eOdvXVV1ulSpWscuXKwf8nx8iRI6148eKWM2dOq169ui1atChR602YMMF13taiRYtkfS4AAAAAAGkq071+/foULcDEiROtZ8+eNnr0aBdwDxs2zBo3bmyrV6+2ggULnna9v/76yx555BGrU6dOipYHAAAAAICUkimgsb5SkQJtZcxHjBjh3p88edKKFi3qqrH37t076joalqxu3bou2z5v3jzbvXu3TZ48OVGfp+HOYmNjbc+ePRYTE5Oi3wUAMpotzXjwCaRHcV/OS+0iAEC6l9jYMsnVy2X8+PFWq1YtK1y4sG3YsMFNU4b6888/T9J2jh49akuXLrUGDRr8X4EyZ3bvFy5ceNr1nn32WZcF79SpU3KKDwAAAADAWZHkoHvUqFGuOviNN97oMszKOkvevHld4J0UO3bscOsXKlQobLreb9myJeo68+fPtzfffNPGjBmTqM84cuSIewIR+gIAAAAAIE0G3a+++qoLeJ944gnLkiVL2FBiv/zyi/lp37591rZtW/f5+fPnT9Q6AwcOdCl/76Wq6wAAAAAApNmO1KL1Up4jRw47cOBAkralwFmB+9atW8Om631cXNwpy//555+uA7VmzZoFp6kNuGTNmtV1vlaqVKmwdfr06eMy8x5lugm8AQAAAABpMtNdokQJW7FixSnTp06damXLlk3StrJnz25VqlSxmTNnhgXRel+jRo1Tlr/88stdNl2f771uvvlmu+6669zf0YJpPQxQo/bQFwAAAAAAaSrTrc7LNESXssb333+/HT582NTxucbU/vDDD1017rFjxya5ANpe+/btXfX0atWquXbhyph36NDBzW/Xrp0VKVLEbV/jeJcrVy5sfbUll8jpAAAAAACkm6D7mWeesXvvvdc6d+5suXLlsieffNIOHjxod911l+vFfPjw4daqVaskF6Bly5a2fft269u3r+s8rVKlSi5r7nWutnHjRtejOQAAAAAA5+w43Qp8FRRrqC6Pgu79+/eHTUvrGKcbAFIO43QD6RPjdAPA2Ystk9SRWqZMmcLe586d270AAAAAAMAZBt2XXXbZKYF3pJ07dyZlkwAAAAAAnLOSFHSrXbfS5wAAAAAAIIWDbnWUlp7abwMAAAAAkJoS3S14QtXKAQAAAABAMoPuRHZyDgAAAAAAklq9/OTJk4ldFAAAAAAAJCXTDQAAAAAAkoagGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAACAcznoHjlypBUvXtxy5sxp1atXt0WLFp122TFjxlidOnXsggsucK8GDRrEuzwAAAAAABk26J44caL17NnT+vXrZ8uWLbOKFSta48aNbdu2bVGXnzNnjrVu3dpmz55tCxcutKJFi1qjRo3sn3/+OetlBwAAAAAgPpkCgUDAUpEy21dffbWNGDHCvT958qQLpLt162a9e/dOcP0TJ064jLfWb9euXYLL792712JjY23Pnj0WExOTIt8BADKqLc3qpHYRACRD3Jfz2G8AcIYSG1umaqb76NGjtnTpUldFPFigzJnde2WxE+PgwYN27Ngxy5cvX9T5R44ccTsj9AUAAAAAwNmQqkH3jh07XKa6UKFCYdP1fsuWLYnaxmOPPWaFCxcOC9xDDRw40D198F7KogMAAAAAkCHadJ+JF154wSZMmGCfffaZ64Qtmj59+rh0v/fatGnTWS8nAAAAACBjypqaH54/f37LkiWLbd26NWy63sfFxcW77ssvv+yC7m+//dYqVKhw2uVy5MjhXgAAAAAAZKhMd/bs2a1KlSo2c+bM4DR1pKb3NWrUOO16gwYNsv79+9vUqVOtatWqZ6m0AAAAAACko0y3aLiw9u3bu+C5WrVqNmzYMDtw4IB16NDBzVeP5EWKFHFts+XFF1+0vn372gcffODG9vbafp933nnuBQAAAABAWpHqQXfLli1t+/btLpBWAF2pUiWXwfY6V9u4caPr0dwzatQo1+v57bffHrYdjfP99NNPn/XyAwAAAACQZsfpPtsYpxsAUg7jdAPpE+N0A0AGGacbAAAAAIBzGUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGIowcOdKKFy9uOXPmtOrVq9uiRYvi3Ucff/yxXX755W758uXL25QpU8Lmb9261e6++24rXLiw5c6d22644Qb7448/wpb5888/7ZZbbrECBQpYTEyM3XnnnW49z19//WWdOnWyEiVKWK5cuaxUqVLWr18/O3r0KMcPAAAASMMIuoEQEydOtJ49e7qAdtmyZVaxYkVr3Lixbdu2Lep+WrBggbVu3doFxMuXL7cWLVq416+//urmBwIB937dunX2+eefu2WKFStmDRo0sAMHDrhl9P9GjRpZpkyZbNasWfb999+7YLpZs2Z28uRJt8yqVavc36+//rr99ttvNnToUBs9erQ9/vjjHD8AAAAgDcsUUFSQgezdu9diY2Ntz549LqMIhFJm++qrr7YRI0a49wp0ixYtat26dbPevXufsrNatmzpguavvvoqOO2aa66xSpUquaB4zZo1VqZMGReEX3nllcFtxsXF2fPPP2+dO3e26dOnW5MmTWzXrl3Bc1Ln5wUXXODmKUCP5qWXXrJRo0a5gF42bNhgDzzwgM2fP98F7crWa5kbb7yRgwzfbGlWh70LpENxX85L7SIAQIaJLcl0A/9LgerSpUvDgtzMmTO79wsXLoy6nzQ9MihWZtxb/siRI+7/qnoeus0cOXK44NhbRlluTfNoeS3nLRONftz58uULvr///vvdtr777jv75Zdf7MUXX7TzzjuP4wsAAACkIoJu4H/t2LHDTpw4YYUKFQrbJ3q/ZcuWqPtJ0+NbXm29L7nkEuvTp4/LZCuwVzD8999/2+bNm4OZ8Tx58thjjz1mBw8edJnzRx55xJXFWybS2rVr7dVXX7V77rknOG3jxo1Wq1Yt1668ZMmSdtNNN1ndunU5vgAAAEAqIugGfJQtWzb79NNPXTVzZaXVkdrs2bNddXJlskWdp6kzti+//NJlplVFZffu3XbVVVcFlwn1zz//uM7Y7rjjDuvSpUtw+oMPPmjPPfecC7zVJv3nn3/m2AIAAACpjKAb+F/58+e3LFmyhPUaLnqvNtjRaHpCy1epUsVWrFjhAmllrqdOnWr//vuvy0Z71JGaejBXh23KuI8fP94F16HLyH//+1+77rrrrGbNmvbGG2+EzVP7cLXvbtu2rateXrVqVZcNBwAAAJB6CLqB/5U9e3YXIM+cOTO4T9Tpmd7XqFEj6n7S9NDlZcaMGVGXVwZbWW0NF7ZkyRJr3rx51MA/b968rhdzBeA333xzcJ6C8GuvvdaVcdy4cVGz4Or07d5773XZ9YcfftjGjBnD8QUAAABSUdbU/HAgrdFwYe3bt3dZ4mrVqtmwYcNcG+sOHTq4+e3atbMiRYrYwIED3fuHHnrI6tWrZ4MHD7amTZvahAkTXEAdmoVW1XEF22rbrQy01tEwYspuexREly1b1i2nTti0TI8ePVzP56EBt4Ybe/nll2379u3Bdb2sevfu3V219csuu8y1H1c1dm0TAAAAQOoh6AYihgBTQNu3b1/XGZqG/lJ1cK+zNHVWFpphVjXvDz74wJ588kk3Zvall15qkydPtnLlygWXUZVyBfOqdn7RRRe5wP2pp54K2++rV692na3t3LnTDfX1xBNPuKA7NHuuztP0uvjii8PW9Ub9U8dr6sFcnbRpyAK1+9Z43gAAAABSD+N0AwCSjXG6gfSJcboB4MwxTjcAAAAAAKmMjtQAAAAAAPAJbbrTsKtfX5vaRQCQDIvvKc1+AwAAgEOmGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAAAA+ISgGwAAAAAAnxB0AwAAAADgE4JuAAAAAAB8QtANAAAAAIBPCLoBAAAAAPAJQTcAAAAAAD4h6AYAAAAAwCcE3QAAAABS3MiRI6148eKWM2dOq169ui1atCje5T/++GO7/PLL3fLly5e3KVOmhM0PBALWt29fu+iiiyxXrlzWoEED++OPP8KW2blzp7Vp08ZiYmIsb9681qlTJ9u/f/8p23n55Zftsssusxw5cliRIkVswIABKfjNgXAE3QAAAABS1MSJE61nz57Wr18/W7ZsmVWsWNEaN25s27Zti7r8ggULrHXr1i5IXr58ubVo0cK9fv311+AygwYNsldeecVGjx5tP/74o+XJk8dt8/Dhw8FlFHD/9ttvNmPGDPvqq6/su+++s65du4Z91kMPPWRjx451gfeqVavsiy++sGrVqnEGwDeZAnrUk4Hs3bvXYmNjbc+ePe4JWFp29etrU7sIAJJh8T2lM8x+29KsTmoXAUAyxH05j/0GXymzffXVV9uIESPc+5MnT1rRokWtW7du1rt371OWb9mypR04cMAFyp5rrrnGKlWq5IJshSyFCxe2hx9+2B555BE3X/fzhQoVsrfffttatWplK1eutCuuuMIWL15sVatWdctMnTrVbrzxRvv777/d+lqmQoUKLpgvU6ZM1LL/9NNP1r17d1uyZIllypTJLr30Unv99deD2wSSGluS6QYAAACQYo4ePWpLly511b+DQUfmzO79woULo66j6aHLi7LY3vLr16+3LVu2hC2jYEfBvbeM/q8q5aHBsZbXZyszLl9++aWVLFnSBfclSpRw1d87d+7sqqWHZssvvvhiF7zre+ghQbZs2VJs/yDjyZraBQAAAABw7tixY4edOHHCZaFD6b2qc0ejgDra8pruzfemxbdMwYIFw+ZnzZrV8uXLF1xm3bp1tmHDBtd+/N1333Xl7NGjh91+++02a9Yst8zGjRutV69ern25KNMNnAmCbgAAAAAZgqq5HzlyxAXc6khN3nzzTatSpYqtXr3aVTlXW3Rlv8ePH+8y5XfccYeVKlUqtYuOdIzq5QAAAABSTP78+S1Lliy2devWsOl6HxcXF3UdTY9vee//CS0T2VHb8ePHXdVxbxn1fK7stxdwS9myZYMZbnn66addZ2xNmzZ12W+1E//ss8+SuTcAgm4AAAAAKSh79uwuczxz5sywDLPe16hRI+o6mh66vKgHcm95tb9W4By6jDqxUlttbxn9f/fu3a4dtkdBsz5bbb+lVq1aLhD/888/g8usWbPG/b9YsWLBaQrKVe18+vTpduutt9q4cePOeL8g4yLTDQAAACBFqYr2mDFj7J133nE9ht93332ud/IOHTq4+e3atbM+ffqEDeOlnsYHDx7s2n0r26zewx944AE3X72Iq0fx5557zg3x9csvv7htqEdyDS3mZaxvuOEG69KlixsT/Pvvv3frq2dzLSeqLn7VVVdZx44d3dBkCtDvuecea9iwoQu0Dx065NaZM2eOa/utbahDNS8bDqTboHvkyJGu58CcOXO6p1D6kcRHHR+oYwMtX758eZsyZcpZKysAAACA+GkIMI2D3bdvXzfs14oVK1xQ7XWEpqrcmzdvDi5fs2ZN++CDD+yNN95wY3pPmjTJJk+ebOXKlQsu8+ijj7ohxzTutoYj279/v9umYgLP+++/7+KE+vXru6HCateu7bbpUU/m6sFcVeDr1q3rqpAroJ4wYYKbr2rx//77rwvoFYTfeeed1qRJE3vmmWc45Ei/43RPnDjRndQaf08B97Bhw1xQrY4MInsflAULFrgfyMCBA+2mm25yP84XX3zRli1bFvajPB3G6QbgN8bpBpDWMU43AGSgcbqHDBniqoCoqok6KVDwnTt3bnvrrbeiLj98+HBXbUTd+OupVP/+/V0VkREjRpz1sgMAAAAAEJ9UDbqPHj3q2lGEDnKvKh967w1yH0nTQ5eXxo0bn3Z5AAAAAAAy5DjdO3bscAPSRxvkXh0oRKOB7aMt7w14H0nj8OnlUerfqwqQ1p04tC+1iwAgGdLD9SWl7Dt2PLWLACAZcmeg65TUXP5/HXYBSB8WVB5o6eWeL6EW26kadJ8NavsdreODokWLpkp5AJz7YnukdgkAIAGxsewiAGlarL1m6cW+fftc2+40GXSr10D1EBjfIPeRND0py2soAg1Z4NE4fTt37rQLL7zQDT0ApMYTMT302bRpU7wdLgBAauJaBSCt4zqF1KYMtwJub0i6NBl0Z8+e3apUqeIGuffG11NQrPfemHyRNOi95mucPs+MGTPc9Ghy5MjhXqHy5s2bot8DSA4F3ATdANI6rlUA0jquU0hN8WW400z1cmWh27dvb1WrVrVq1aq5IcMOHDjgejMXDSdWpEgRV01cHnroIatXr54NHjzYjaunMfWWLFkSNv4eAAAAAABpQaoH3S1btrTt27db3759XWdolSpVcoPce52lbdy40fVo7qlZs6Ybm/vJJ5+0xx9/3C699FKbPHlyosboBgAAAADgbMoUSKirNQApSr3pq+aG+huIbPoAAGkF1yoAaR3XKaQXBN0AAAAAAPjk/+ptAwAAAACAFEXQDQAAAACATwi6gTSgePHiruf++MyZM8eNLb979+6zVi4A8ON6BgBpyV9//eXusVasWHHaZbgPw5kg6AYAIJ26++67rUWLFmnq5nDx4sXWtWvXYBnie2kZAADOdak+ZBiAhB07dozdBOCsOXr0qGXPnj1Z6xYoUCA4xOfmzZuD0x966CHbu3evjRs3LjgtX758KVBaAOnxWgFkJGS6gTMYpuLBBx+0ggULWs6cOa127douwyNVq1a1l19+ObisMlHZsmWz/fv3u/d///23y/KsXbs26rY1b9SoUXbzzTdbnjx5bMCAARwnAMk2f/58q1OnjuXKlcuKFi3qrl0HDhwIqxLev39/a9euncXExLhM9dtvv2158+a1r776ysqUKWO5c+e222+/3Q4ePGjvvPOOW+eCCy5w2zpx4sQp1ct1Ix4XFxd86bM1TGLoNG7WgfTl2muvtQceeMC6d+9u+fPnt8aNG9uvv/5qTZo0sfPOO88KFSpkbdu2tR07dgTXmTp1qrtH0vXkwgsvtJtuusn+/PPPsMBd27zooovc/VSxYsXc0KqejRs3WvPmzd32dX268847bevWrcH5Tz/9tFWqVMnGjx/vrj+xsbHWqlUr27dvX6LL4Fm1apV7YKhylCtXzubOnXtG11bAQ9ANJNOjjz5qn3zyibv5XLZsmZUuXdr947Nz506rV69esNpkIBCwefPmuQu9Ls6ii3iRIkXcOqejf0RuueUW++WXX6xjx44cJwDJohvLG264wW677Tb7+eefbeLEie5apJvcUHpQWLFiRVu+fLk99dRTbpoC7FdeecUmTJjgblp1XdN1acqUKe6lm9zXX3/dJk2axNEBMgjd9+iB2ffff28vvPCCXX/99Va5cmVbsmSJu04oIFZg7FEQ2rNnTzd/5syZljlzZncdOXnypJuva8wXX3xhH330ka1evdref/99FzyLllHArXsr3TvNmDHD1q1bZy1btjzlOjd58mT3kFAvLauyJbYMnl69etnDDz/sroM1atSwZs2a2b///ntG11bACQBIsv379weyZcsWeP/994PTjh49GihcuHBg0KBBgS+++CIQGxsbOH78eGDFihWBuLi4wEMPPRR47LHH3LKdO3cO3HXXXcF1ixUrFhg6dGjwvX6a3bt3D/vM2bNnu+m7du3iiAFw2rdvH8iSJUsgT548Ya+cOXMGrxedOnUKdO3aNWyPzZs3L5A5c+bAoUOHgtegFi1ahC0zbtw4t421a9cGp91zzz2B3LlzB/bt2xec1rhxYzf9dNez0LI2b96cIwekY/Xq1QtUrlw5+L5///6BRo0ahS2zadMmd+1YvXp11G1s377dzf/ll1/c+27dugWuv/76wMmTJ09Zdvr06e4at3HjxuC03377za2/aNEi975fv37uurR3797gMr169QpUr179tN8jsgzr169371944YXgMseOHQtcfPHFgRdffDHqfVhirq2Ah0w3kAx6uql21rVq1QpOU/XxatWq2cqVK11VI1Vr0pNSPW1V5ltVsrzst6bpfXxURR0AEnLddde5HndDX2PHjg3O/+mnn1xVcVXN9F6qlaMMz/r16+O95qhKealSpYLvVXVUGShtI3Tatm3bOFBABlGlSpWw68vs2bPDri+XX365m+dV3/7jjz+sdevWVrJkSVc93Mtiq9q41yGkrltqxqLq2dOnTw9uX/dUqratl+eKK65wtQc1z6Ntnn/++cH3qqoeel1KqAweZbc9WbNmddfF0M8JldhrK+DOJ3YDkPL0j4GqaSrIXrhwoTVs2NDq1q3rqkOtWbPGXfwViMdHbbkBICG6VkQ2VVG/ER71JXHPPfe4m9lIl1xySbzXHD1MjOxvItq0yCqaAM5dodcKXV9UBfvFF188ZTkFvqL5aqc9ZswYK1y4sLteqL202nLLVVdd5YLUb775xr799ltXNb1BgwZJaraS0HUpoTIkR2KvrYAQdAPJoMyP155JF3FR5lsdqalzEVFQrae/ixYtch2hqZfesmXLur/1D9Fll13GvgfgO93Q/v777/H2IQEAyb2+qH8bZY6VGY6k9tBqp61gV7UAxevfJpSyz0pM6KUOG9VWWu24dd+0adMm9/Ky3bqeaThEZbwTI7FlkB9++MElSeT48eO2dOnS07bR5tqKpKB6OZDMp7z33Xef63BDnYboH4AuXbq4Toc6derkllH18WnTprl/hLyqVpqmDkISynIDQEp57LHHbMGCBe7GUVU4VdPm888/p7MfAGfs/vvvd8Gxqm4r8aAq5br36dChgxvVQCMcqLfwN954w43YMmvWLNehWaghQ4bYhx9+6HoOV23Ajz/+2I1uoFqDyniXL1/e2rRp4zqtVSJDoyzoPiqxzfASUwbPyJEj7bPPPnNl0XfbtWvXaTuz5dqKpCDoBpJJvWKqx0oNjaGnnbqQ6x8aXdxFT1NVfSk0wFbQrX+EEmrPDQAppUKFCq4fCd3M6rqkXob79u3rqlgCwJnQdUS1/nRv06hRIxcgq8afAmb1EK6XRj9QxljVuXv06GEvvfRS2DbUFnvQoEEuiL766qvtr7/+cqMjaF1VE9dDQt1bKQOtIFztstVTeGIlpgyh93Z6qYmgsuHqVV1Do0XDtRVJkUm9qSVpDQAAAAAAkChkugEAAAAA8AlBNwAAAAAAPiHoBgAAAADAJwTdAAAAAAD4hKAbAAAAAACfEHQDAAAAAOATgm4AAAAAAHxC0A0AAAAAgE8IugEAOAdce+211r1799QuBgAAiEDQDQBAKrv77rstU6ZM7pUtWzYrUaKEPfroo3b48OFEb+PTTz+1/v37+1pOAACQdFmTsQ4AAEhhN9xwg40bN86OHTtmS5cutfbt27sg/MUXX0zU+vny5csQx+To0aOWPXv21C4GAACJRqYbAIA0IEeOHBYXF2dFixa1Fi1aWIMGDWzGjBlu3r///mutW7e2IkWKWO7cua18+fL24Ycfxlu9/LXXXrNLL73UcubMaYUKFbLbb789OO/IkSP24IMPWsGCBd382rVr2+LFi4Pz58yZ4wL+mTNnWtWqVd1n1qxZ01avXh1c5umnn7ZKlSrZ+PHjrXjx4hYbG2utWrWyffv2BZc5efKkDRw40GXuc+XKZRUrVrRJkyYF57/99tuWN2/esO8xefJk99mRnzN27Fi3HZUXAID0hKAbAIA05tdff7UFCxYEM7qqZl6lShX7+uuv3byuXbta27ZtbdGiRVHXX7JkiQuqn332WRcoT5061erWrRucr6rrn3zyib3zzju2bNkyK126tDVu3Nh27twZtp0nnnjCBg8e7LaXNWtW69ixY9j8P//80wXJX331lXvNnTvXXnjhheB8BdzvvvuujR492n777Tfr0aOH/c///I9bLinWrl3ryqsq9CtWrEjSugAApDaqlwMAkAYoaD3vvPPs+PHjLhOdOXNmGzFihJunDPcjjzwSXLZbt242bdo0++ijj6xatWqnbGvjxo2WJ08eu+mmm+z888+3YsWKWeXKld28AwcO2KhRo1yWuUmTJm7amDFjXFb9zTfftF69egW3M2DAAKtXr577u3fv3ta0aVP3AMDLNiuTre3oM0QPApQd13r6Ds8//7x9++23VqNGDTe/ZMmSNn/+fHv99deD201slXIF7wUKFEjWvgUAIDURdAMAkAZcd911LhhWUDx06FCXWb7tttvcvBMnTrgAVkH2P//844JQBbWq9h1Nw4YNXaCtIFdtxfW65ZZb3PLKTqvdeK1atYLLq/M2Be8rV64M206FChWCf1900UXu/9u2bbNLLrnE/a1q5V7A7S2j+V52+uDBg64soVR27wFAYum7EHADANIrgm4AANIAZaZVzVveeust1/5ZmedOnTrZSy+9ZMOHD7dhw4a59txaVu23FcBGo0BY1cbVNnv69OnWt29f1zY6tN12YigY93jtrJXdjjbfW8abv3//fvd/VYlXpj6y/boomx8IBMLm6YFAtH0DAEB6RZtuAADSGAWjjz/+uD355JN26NAh+/7776158+auPbSCcWWw16xZE+82lClXZ2yDBg2yn3/+2f766y+bNWuWlSpVyrUV1zZDA10F5FdccUWKfQdtS8G1qrrrYULoS53FibLX6nhN2X0PbbYBAOcaMt0AAKRBd9xxh2tfPXLkSNcLuXr9VudqF1xwgQ0ZMsS2bt162iBZ7cPXrVvnOk/T8lOmTHEZ6DJlyris8X333ee2rWHGVFVcgbmqgiurnlKUbVc7dHWeps9WD+l79uxxwX5MTIwbEq169equyrseMKjjtx9//NG1EQcA4FxC0A0AQBqkTPUDDzzgAuLly5e7IFo9jCtIVe/lGlZMQWw0GoZLPX2rSrk6PlPQriHGrrzySjdfPYwrEFbHZ8o0a1gwdcymAD0l9e/f32Wz1Yu5yq9yXXXVVS7IFgX97733nnsAoM7c6tev78qs7wcAwLkiUyCyMRUAAAAAAEgRtOkGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAA4BOCbgAAAAAAfELQDQAAAACATwi6AQAAAADwCUE3AAAAAAA+IegGAAAAAMAnBN0AAAAAAPiEoBsAAAAAAJ8QdAMAAAAAYP74f9UAlKeXyh9LAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -1629,10 +1634,10 @@
    "id": "trans-032",
    "metadata": {
     "papermill": {
-     "duration": 0.022798,
-     "end_time": "2026-05-02T00:02:51.913463+00:00",
+     "duration": 0.007365,
+     "end_time": "2026-05-07T11:43:40.130022",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.890665+00:00",
+     "start_time": "2026-05-07T11:43:40.122657",
      "status": "completed"
     },
     "tags": []
@@ -1647,27 +1652,30 @@
    "id": "fc8adb55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:51.965951Z",
-     "iopub.status.busy": "2026-05-02T00:02:51.965503Z",
-     "iopub.status.idle": "2026-05-02T00:02:51.980431Z",
-     "shell.execute_reply": "2026-05-02T00:02:51.978625Z"
+     "iopub.execute_input": "2026-05-07T11:43:40.147143Z",
+     "iopub.status.busy": "2026-05-07T11:43:40.146569Z",
+     "iopub.status.idle": "2026-05-07T11:43:40.350803Z",
+     "shell.execute_reply": "2026-05-07T11:43:40.349071Z"
     },
     "papermill": {
-     "duration": 0.037271,
-     "end_time": "2026-05-02T00:02:51.983987+00:00",
+     "duration": 0.21528,
+     "end_time": "2026-05-07T11:43:40.352901",
      "exception": false,
-     "start_time": "2026-05-02T00:02:51.946716+00:00",
+     "start_time": "2026-05-07T11:43:40.137621",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Pas assez de données RL pour la comparaison\n"
-     ]
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAATfhJREFUeJzt3QmcXeP9P/BnIotYkggiQhJL7BFLLLXUGlF7SFXRonY/a1IEtYUSS1taFEWFoqrW0tLGltjFEkIJIZooEWsiQWSZ/+v7/P53fjPJhJkxJ7O936/Xfc2955x77nPPvcnM53yf5zll5eXl5QkAAACod63qf5cAAACA0A0AAAAFUukGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwDNxsSJE9PZZ5+dxo4dW+d9jBo1Kp1zzjlp6tSp9do2AKBlEroBmqhtttkm3+rioIMOSiuttFJqKu0Nf/rTn9Kaa66Z2rRpkzp16jTf+lmzZqUf/ehH6eWXX07rrLNOnV7jP//5TxowYEBacsklU8eOHevc1uaorKwsn9Cg9nbeeed02GGHOXT16JRTTkmbbrqpYwo0CUI3QAOGmJrcHn300Rb/Gb3++uv5RMGqq66arrnmmvSHP/xhvmNy8sknp0UWWSTdfPPNqVWr2v96i9C+zz775NcZNGhQiz/m1I8nnngi/etf/0pDhgyptmfGkUcemU+AtWvXLnXp0iWf9InnVPbss8/m/wsuueSS+faxxx575HXXX3/9fOu22mqrtMIKK1Q8jpNevXv3rtO/v/j3tf766+cTUssvv3zaZZdd0nPPPVej5w8fPrzK/2mtW7fO7Yp/a//973/n274m7TzhhBPSSy+9lP72t7/V+v0ALGytF/orAlBRua3sxhtvTCNGjJhv+VprrVXtEYs/5JuS79LeOPEwd+7c9Nvf/jb16tVrvvWfffZZWmqppfIf4O3bt6/Ta7z66qvpxz/+cTr++OPr3M7m7Msvv8xhidq5+OKL0/bbbz/f9zaCdVTAw6GHHprWXnvtNHny5BxQv//97+fv+rHHHpvXb7jhhmmxxRZLjz/++HwnhJ588sn8ucT+fvazn1Us//rrr9Po0aPTbrvt9p0/smuvvTZdd911aeDAgel//ud/8tCLq6++On3ve99LDzzwQOrXr1+N9hPDNlZeeeX01Vdfpaeffjq/13hPr7zySlp00UVr1aauXbvmEw6/+tWv0u67717HdwawcPjtCdBAfvKTn1R5HH+ERuied/m8vvjii/wHeNu2bVNT8l3aO2XKlPyzum7lpeVnnnlmrfY5Y8aMtPjii1c8jipe3JqiCDFxfGta4Z89e3Y+iVGbz6S2oaglKC8vz8d+QSd64nv797//PV111VVVln/66afphz/8YX5ehOXowVEyePDgtOOOO+ZKbt++fdPmm2+eQ3V0pZ63Aj5u3Lj00Ucfpf322y+H18qef/753LYtt9zyO7/PfffdNw8tWGKJJSqWHXzwwfmEYCyvaejeaaed0kYbbVRxomGZZZZJF154YT5ZFkNDaiues/fee6e33347rbLKKrV+PsDCons5QCNW6mYZf0BHV9EI26eddlq1Y6SjGhxdN//yl7/kbaISFKEyqkCTJk361teKEHbppZfm8dARsJZbbrl0xBFH5IBQWXQpjVAQfzBHaIjKVfwBXpP3Ul17b7vttnTeeeelFVdcMb9uVAXHjx9fsV10vT3rrLPy/WWXXXa+scX3339/rgzGe42ur9HtNarWlUU31ggMb731Vq4uxnb777//Qnnf0f5dd901V/oj1MdrRFXzzjvvrLLdJ598kk488cS07rrr5rZ26NAhh5ToQltZ6bjdeuut6fTTT8/ddON7MW3atGpf/5133snbR0Uw3mcEvOjK/O9//ztXQ+NkRYS7GMMexzCO5SOPPDLffuY97p9//nkOhpW7Ru+www7phRdeqPK8v/71r3n/cczi2MVJpXm7FJc+n1ge3avjfnzWcTzmzJlT7XuJIQal97Lxxhvnqm513aIj3Hbu3Dkf9wh883ZHjvcU+1xQl+h4zXk/y3/+8595X/GeouK7IBG44wTHvKE0nhNV7aiCVw7cIfZ5ww035NeOynBJhOcPPvigyr+NCOHxPTn88MMrAnjldaXnfVfx+VUO3GHppZfO35XXXnutzvuN54f4d1kXpeN6zz331LkNAAuDSjdAI/fxxx/n8BVdnyOwRCj8JhFg4w/2GEMalbYIWvHH6ZgxY76x63UEzQga0UX1uOOOSxMmTEiXX355evHFF/Mf8DGBWeyvf//+ORDFREZRYY5QMm+ArI0LLrggV2gjYEW31YsuuigH4meeeSavj/ZH1/u77rorXXnllfmP/z59+uR10RX/wAMPzGE4KmbRCyC2iaAR7a48WVyEn9gu1kVoi6C6sN73m2++mceLx/jdaG+Mv40KXXTNjaAaolp399135+UR6CNgRTjbeuutc0Du1q1blX2ee+65uVIdx23mzJnfWrWO14zKZwS0CKoRRCOoR9fhqGTGRF8RpKMbcRynGEf8TZX/eC+33357OuaYY/JJhPieRrU1Qlh0hw6l4xqheNiwYfk9RbfpOK5xfCv3XIhwHa8bFd34fB588MH061//OofSo446qspr33LLLbmt8dnFdz2+M3vttVc+hvF5hTjxssUWW+STEvGZxQmFOMETof6OO+5Ie+65Z6qLCLdxvOK145itscYaC9w2un5HOO3Zs2eV5ffee28+CbCg6m58/vE9ffjhh3O3/vh3WwrPcYxLXdXjOEYX7zhm8b7j9UpdrWNdnFxab731UlHixEGcSKmr0gmNGBpSF3GiKL4f8V7NwwA0auUANApHH310+bz/LW+99dZ52VVXXTXf9rEubiWPPPJI3naFFVYonzZtWsXy2267LS//7W9/W7HswAMPLO/Zs2fF48ceeyxvc/PNN1d5jQceeKDK8rvuuis/Hj16dK3f34Lau9Zaa5XPnDmzYnm0M5aPHTu2YtlZZ52Vl3344YcVyz7//PPyTp06lR922GFVXmfy5MnlHTt2rLI83m88/5RTTqmy7cJ433Gc47l33HFHxbKpU6eWL7/88uUbbLBBxbKvvvqqfM6cOVWeO2HChPJ27dqVn3POOfMdt1VWWaX8iy+++NbXj33E9h06dCifMmVKlXWzZ8+ucuzDp59+Wr7ccsuVH3zwwVWWxz7icyiJYxzf2QX5+uuvy7t06VLeu3fv8i+//LJi+X333Zf3deaZZ873+VR+nyGOT9++fed7L0svvXT5J598UrH8nnvuycvvvffeimXbb799+brrrpuPa8ncuXPLN9988/LVVlttvu/WvK6//vq8PF5z3s8yvh81seWWW1Zpf0l8b9dbb71vfO5xxx2XX+vll1/Oj+Pf9CKLLFJ+yCGHVGyzxhprlA8dOjTf32STTcpPOumkinXLLrts+Q477FBln/Hvb5111imvD6NGjSovKysrP+OMM75129KxfPDBB/O/4UmTJpXffvvtuY3x/Y7HdW1n//798/8hAI2Z7uUAjVxUJStPkPRtDjjggFzhKonutTHb8D/+8Y8FPie6AEfVKKqu0UW1dCt1Ky11Ny5VJu+7774823d9iPdWuUpb6nIaVctvEuPfYwK1qDpWbnPMYB6Vv+q6SM9bMV1Y7zuq1JUrq9ElOD6nqPZGtbD0OZfGZEfVNyrH0YaopM7bZTtExbw2k8bFJFhRqa8sjlXp2Ec3++jiHj0Cout0da9ZWRyT6I3w3nvvVbs+uuNHD4GYeKvyePDo/h+Xfouu19VVzyuL70J134PoNVC5OjrvdybeR1SJo5IcFfHS5xrHNKrp0fOgulmzayKq0LGPmojXq66KG22q/G+0OqX1pWED8Th6eJTGbsf7iap7jPkOUdUvdSl/44030ocfflgvXcurE59rjCOPYxGzmtdU9LiJ72D37t3z/0vR+yC6+8fQkrqK41u5Wz1AYyR0AzRy0T22NhNerbbaalUeR/fb6I5aeWzqvCKERNfuGJcbfxRXvk2fPr1iIrPo6hzhbejQoblbacweHN2Wo3tzXfXo0aPK41JImXdMdXVtDtttt918bY7x06U2l8RkVPP+cb+w3ncc/3nHDa+++ur5Z+lzidAbl4SKzy8CeLxOtCOuOx5tnFcEntpY0PYxfjjCXATj6AodrxmBuLrXrCy6dMes0xGgNtlkkzw2unJAjmueh+q6X0foLq0videf96RAfBeq+x5823cmxj1Hcf6MM86Y73MtzQ8w7/ejpmp73P+3k0BVEaAjeH+T0vrK4TxCdGnsdnQlj5Mm0b08RPiOuR/iO1mf47mrm4AwxrVH+2Is9bxjvb/JFVdckU+WxbCEmFsh3kd817+LOL7VjckHaEyM6QZo5Op6CazaiMAXwTOucV2dUhiKP27jD+aYaT3GpcaEUjGZWIy9jWW1+QO8JIJDTcPKvG0ujeuOSePmNe/lrSpXkhvD+57X+eefn0Ni7DfGa8eY62hvTFZWeq/f5XtR3fY33XRTnsQsxjmfdNJJ+VjE5xHjr79tcquoIkeFOcbax0mOmBQsxtXHOPeYg6C+vgd1+c6UjleMd19QVbo0LnpBga3yBG51Pe5xEqO6kwYx63f0coiAvKDQGSdbYpx25ZNoEaIvu+yyHKojdJcm3SuF7thfTCgX1fD4/pcCeX2Jifdi7Hy0Lf4N1Paa33FypjR7eXzn4v1ExTxOJNT131Ac3+8yrhxgYRC6AZqZUgW4chCJyl9p8rHqxGREMXFVdFGtSaiIP+bjFpO2xaRWMfFZzKYdlwFaWEqzPkdQrOklixrqfZcqr5UDXnQBDqXJ3iLUb7vttnkis8qiC31RoSJeMy61FEG5cttK1eBvE8MWovt43KJyHBOoxbGJ0F2aPCwCVfRGqCyWzTu5WH0qXT4qQuu3fTdKVfI4zpUndpu3El8XUdGPSdvmFZXip556Kg9vqO4SgdH74bHHHsttr/y9rDyZWjw/vreVhzDEMY1AHrcNNtigYrLA+hAnMmJIxEMPPZQnpIveH99F6eROfOdj4sKY7K4uYuLDIieLA6gPupcDNDMx03flrqsRrN5///1vrD5G1TIqe1FhnVeM8Y1AUqoqzVuBLs1w/V26mNdFVDBjbHRUiKsbZx1jWr/NwnrfMe45KsIlMU43PqfYR6lKHyFk3teIUFbXsce1qRhXft0Ypx2B7pvEMZu3+3mc/IjgVzoeUdGMZXGN6srHKC7xFjOcx9juosTrxuXpYvb3+O5/03ejdPJm1KhRVbpQR7f772qzzTbL3515x6XHzOfRxuhdMO+6mGE+5jmIz2Tea8/H8Y3u7RF8Y8x8aTx3STyOGfDjpEZ9dy0/9thj8+UIf//73+dqd32Izyiq33GFgnjftRXfweiRMe9xAGhsVLoBmpnolhx/cMcf7nGJpviDNrrSxuWNFiSqVhEEovIUlxaLy2NFlTCq5hH84jJPMfFRBJH4ozsmBYuwEuH+mmuuyeE3xmguTPGacXmwn/70p7nCGpdUi+7gEydOzGOSowoYFbRvsrDed4zfPuSQQ3LX37jk2x//+Mf82cS48MrVz7guc3xuESLGjh2bu72XqrZFiNeMKne8rwjBUTWMkByXAIsx7QsS7z/Gx8exiSpjdA2OHgPx/qLLfYjjGN3N4/3EcY4J70qXDIvqftGXeIrxw/HvILpgx3c/jmO8fpxQePfddyuufx6feYwRj88nQnCciIjPp/Rd+i7imEY37zg2cam2yt3O42RYrI/vbvSUiGMek+rFZdaiZ0Qcp+rCZLynGFIRKle6Q2z/5z//uWK76sQJh1/+8pfzLY8wX7p2/bzi/5D4/sdJhKiex7CEyuL7E5Oi1UUc87hMXrzvyhPp1aSdcVzj5ETMsQDQmAndAM3MaaedlsdcRpCMcLT99tvnP5i/ratphK2YtTuqg7GPCAsRjqL7a+mP+whPcf3m6FIdASZm/o5KVYTD2k4wVR9iPGhU/+Ja3zGmOCqqMfFcjDWu6YzvC+N9x7jcGIsbASOqkPGcqBpWHm8crx0V1ui2HusijMXJg7p2u62JGM8dQS/ee4zRjeAXgSpOODz66KMLfF58l6JLeYzljtAeXY/jxE58zyrPEB/7j23j84nrxkcwi4AWYbxyV+4ixHuJanBMfheBLmYSj+pydLuuXEGOkwPRCyHeT4ypj54HMY4+up3X5qoB1YkTLHFSJrpjVw7dIb6j8e80emrE8Y6KfHyvIjhH6F9QaC6F7viez9tFv3IIX9DzYxhAvM95xf8TCwrdcUIqxAmL6npBxMmauobuqJrHiay4NnucHCn1vqhJO+O4xfss9VYAaKzK4rphDd0IAL67CEkxPjL+EI0KJI1DBPiYcCouN0bLE2Ozoxv166+/Pt+VBai7OFkUJ6/iRJhKN9DYGdMNAFCQqGhHF/a4xBr1J7q8x9ABgRtoCnQvBwAoUEweR/2KIQsATYVKNwAAABTEmG4AAAAoiEo3AAAAFEToBgAAgIKYSC2lfH3R9957Ly255JKprKysqGMNAABAMxFX3/78889Tt27dUqtWC65nC90p5cDdvXv3hfn5AAAA0AxMmjQprbjiigtcL3SnlCvcpYPVoUOHhffpAAAA0CRNmzYtF29LeXJBhO6Ywv3/dymPwC10AwAAUFPfNkTZRGoAAABQEKEbAAAACiJ0AwAAQEGEbqAww4YNSxtvvHGeXKJLly5pwIABady4cVW2+cMf/pC22WabPJ9CjIf57LPP5tvPeeedlzbffPO02GKLpU6dOvnEAABoMoRuoDAjR45MRx99dHr66afTiBEj0qxZs1L//v3TjBkzKrb54osv0g9+8IN02mmnLXA/X3/9ddp7773TUUcd5dMCAKBJKSuPK3q3cDHVe8eOHdPUqVPNXg4F+vDDD3PFO8L4VlttVWXdo48+mrbddtv06aefLrCaPXz48HTCCSdUWw0HAIDGmCNVuoGFJv5DCp07d3bUAQBoEYRuYKGYO3durlJvscUWqXfv3o46AAAtQuuGbgDQMsTY7ldeeSU9/vjjDd0UAABYaIRuoHDHHHNMuu+++9KoUaPSiiuu6IgDANBiCN1AYWKexmOPPTbdddddeaK0lVde2dEGAKBFEbqBQruU33LLLemee+7J1+qePHlyXh6zPLZv3z7fj2VxGz9+fH48duzYvG2PHj0qJlybOHFi+uSTT/LPOXPmpDFjxuTlvXr1SksssYRPEACARsslw1wyDIr7D6asrNrl119/fTrooIPy/bPPPjsNHTr0G7eJnzfccMN82zzyyCNpm222qfd2AwBAfV0yTOgWugEAAKgl1+kGAACABuY63QAAAFAQE6k1MRtf/b+TTQHQ9Iw+oldDNwEAWMhUugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAAGiOoXvYsGFp4403TksuuWTq0qVLGjBgQBo3blyVbb766qt09NFHp6WXXjotscQSaeDAgemDDz6oss3EiRPTLrvskhZbbLG8n5NOOinNnj17Ib8bAAAAaEShe+TIkTlQP/3002nEiBFp1qxZqX///mnGjBkV2wwaNCjde++96a9//Wve/r333kt77bVXxfo5c+bkwP3111+nJ598Mt1www1p+PDh6cwzz2ygdwUAAAD/q6y8vLw8NRIffvhhrlRHuN5qq63S1KlT07LLLptuueWW9MMf/jBv8/rrr6e11lorPfXUU+l73/teuv/++9Ouu+6aw/hyyy2Xt7nqqqvSkCFD8v7atm37ra87bdq01LFjx/x6HTp0SI3ZxlePb+gmAFBHo4/o5dgBQDNR0xzZqMZ0R2ND586d88/nn38+V7/79etXsc2aa66ZevTokUN3iJ/rrrtuReAOO+64Yz4Ar776arWvM3PmzLy+8g0AAADqW6MJ3XPnzk0nnHBC2mKLLVLv3r3zssmTJ+dKdadOnapsGwE71pW2qRy4S+tL6xY0ljzOSJRu3bt3L+hdAQAA0JI1mtAdY7tfeeWVdOuttxb+WqeeemquqpdukyZNKvw1AQAAaHlap0bgmGOOSffdd18aNWpUWnHFFSuWd+3aNU+Q9tlnn1Wpdsfs5bGutM2zzz5bZX+l2c1L28yrXbt2+QYAAADNttIdc7hF4L7rrrvSww8/nFZeeeUq6/v27ZvatGmTHnrooYplcUmxuETYZpttlh/Hz7Fjx6YpU6ZUbBMzocdA9rXXXnshvhsAAABoRJXu6FIeM5Pfc889+VrdpTHYMc66ffv2+echhxySBg8enCdXiyB97LHH5qAdM5eHuMRYhOuf/vSn6aKLLsr7OP300/O+VbMBAABosaH7yiuvzD+32WabKsuvv/76dNBBB+X7l1xySWrVqlUaOHBgnnU8Zib//e9/X7HtIosskrumH3XUUTmML7744unAAw9M55xzzkJ+NwAAANCIr9PdUFynG4CFwXW6AaD5aJLX6QYAAIDmROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAIDmGrpHjRqVdtttt9StW7dUVlaW7r777irrY1l1t4svvrhim5VWWmm+9RdccEEDvBsAAABoRKF7xowZab311ktXXHFFtevff//9Krc//vGPOVQPHDiwynbnnHNOle2OPfbYhfQOAAAAoHqtUwPbaaed8m1BunbtWuXxPffck7bddtu0yiqrVFm+5JJLzrctAAAAtOhKd2188MEH6e9//3s65JBD5lsX3cmXXnrptMEGG+Su57Nnz26QNgIAAECjqXTXxg033JAr2nvttVeV5ccdd1zacMMNU+fOndOTTz6ZTj311NzF/De/+U21+5k5c2a+lUybNq3wtgMAANDyNKnQHeO5999//7ToootWWT548OCK+3369Elt27ZNRxxxRBo2bFhq167dfPuJ5UOHDl0obQYAAKDlajLdyx977LE0bty4dOihh37rtptuumnuXv7OO+9Uuz4q4VOnTq24TZo0qYAWAwAA0NI1mUr3ddddl/r27ZtnOv82Y8aMSa1atUpdunSpdn1Uv6urgAMAAECzCt3Tp09P48ePr3g8YcKEHJpjfHaPHj0qxlz/9a9/Tb/+9a/ne/5TTz2VnnnmmTyjeYz3jseDBg1KP/nJT9JSSy21UN8LAAAANKrQ/dxzz+XAPO/47AMPPDANHz4837/11ltTeXl52nfffed7flSsY/3ZZ5+dJ0dbeeWVc+iuPM4bAAAAGkJZeaTZFi4q6R07dszjuzt06JAas42v/r9eAQA0LaOP6NXQTQAAFnKObDITqQEAAEBTI3QDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAANBYQvcDDzyQHn/88YrHV1xxRVp//fXTfvvtlz799NP6bh8AAAA0WbUO3SeddFKaNm1avj927Nj085//PO28885pwoQJafDgwUW0EQAAAJqk1rV9QoTrtddeO9+/44470q677prOP//89MILL+TwDQAAANSx0t22bdv0xRdf5PsPPvhg6t+/f77fuXPnigo4AAAAUIdK95Zbbpm7kW+xxRbp2WefTX/5y1/y8jfeeCOtuOKKjikAAADUtdJ9+eWXp9atW6fbb789XXnllWmFFVbIy++///70gx/8oLa7AwAAgGar1pXuHj16pPvuu2++5Zdcckl9tQkAAABa7nW633rrrXT66aenfffdN02ZMqWi0v3qq6/Wd/sAAACg+YbucePGVXk8cuTItO6666Znnnkm3XnnnWn69Ol5+UsvvZTOOuus4loKAAAAzS10R7Def//905w5c/LjU045Jf3yl79MI0aMyDOZl2y33Xbp6aefLra1AAAA0JxC94knnpgvB7bjjjvmx2PHjk177rnnfNt16dIlffTRR8W0EgAAAJpj6G7Tpk267LLL0hFHHJEfd+rUKb3//vvzbffiiy9WzGReG6NGjUq77bZb6tatWyorK0t33313lfUHHXRQXl75Nu8s6Z988kmuxnfo0CG375BDDqno9g4AAACNfiK1vffeO//88Y9/nIYMGZImT56cA/DcuXPTE088kSviBxxwQK0bMGPGjLTeeuulK664YoHbRMiOoF+6/fnPf66yPgJ3TOIWXd5jZvUI8ocffnit2wIAAAANesmw888/Px199NGpe/fueZz32muvnX/ut99+eUbz2tppp53y7Zu0a9cude3atdp1r732WnrggQfS6NGj00YbbZSXRWV+5513Tr/61a9yBR0AAAAa/SXDysvLc4X7d7/7XXr77bdzVfmmm25Kr7/+evrTn/6UFllkkUIa+eijj+Yx42ussUY66qij0scff1yx7qmnnspdykuBO/Tr1y+1atUqz7BenZkzZ6Zp06ZVuQEAAECDVrojdPfq1St35V5ttdVytbto0bV8r732SiuvvHK+Pvhpp52WK+MRtiPkx0mACOSVtW7dOk/+FuuqM2zYsDR06NDC2w4AAEDLVqvQHdXjCNtRaY6fC0OMIS+J64P36dMnrbrqqrn6vf3229dpn6eeemoaPHhwxeOodC+MEwgAAAC0LLXqXh4uuOCCdNJJJ6VXXnklNYRVVlklLbPMMmn8+PH5cYz1njJlSpVtZs+enWc0X9A48BgjHjOdV74BAABAg0+kFjOUf/HFF3nG8bZt26b27dtXWR9ht0jvvvturrQvv/zy+fFmm22WPvvss/T888+nvn375mUPP/xwnlV90003LbQtAAAAUK+h+9JLL031Ka6nXapahwkTJqQxY8bkMdlxi7HXAwcOzFXrGNN98skn53HlO+64Y95+rbXWyuO+DzvssHTVVVelWbNmpWOOOSZ3SzdzOQAAAE0qdB944IH12oDnnnsubbvtthWPS2Ot43WuvPLK9PLLL6cbbrghV7MjRPfv3z+de+65uYt4yc0335yDdozxjnHnEdJjhnUAAABoUqE7RMX5+uuvzz9/+9vf5tnD77///tSjR4+0zjrr1Gpf22yzTZ4VfUH++c9/fus+oiJ+yy231Op1AQAAoMEnUhs3blyVxyNHjsyziMc1sO+8887cPTy89NJL6ayzziqupQAAANDcQncE6/333z/NmTMnPz7llFPSL3/5yzRixIg8kVrJdtttl55++uliWwsAAADNKXSfeOKJuft2aeKysWPHpj333HO+7aKL+UcffVRMKwEAAKA5hu42bdqkyy67LB1xxBH5cadOndL7778/33YvvvhiWmGFFYppJQAAADTH0F2y9957559xKa4hQ4akyZMnp7Kysnw97CeeeCJXxOMa3gAAAEAtQ3fJ+eefn9Zcc83UvXv3PIna2muvnbbaaqu0+eabp9NPP722uwMAAICWfcmwadOmpQ4dOuT7MXnaNddck84888w8vjuC9wYbbJBWW221otsKAAAAzS90L7XUUnkcd0yWFrOUx4zmUemOGwAAAPAdupcvscQS6eOPP873H3300TRr1qyaPA0AAABatBpVuvv165e23XbbtNZaa+XHccmwytforuzhhx+u3xYCAABAcw7dN910U7rhhhvSW2+9lUaOHJnWWWedtNhiixXfOgAAAGjuobt9+/bpyCOPzPefe+65dOGFF+brdQMAAADfMXRX9sgjj9T2KQAAANAi1Tp0z5kzJw0fPjw99NBDacqUKWnu3LlV1hvTDQAAAHUM3ccff3wO3bvsskvq3bt3Kisrq+0uAAAAoEWodei+9dZb02233ZZ23nnnYloEAAAALek63ZXFpcJ69epVTGsAAACgJYfun//85+m3v/1tKi8vL6ZFAAAA0FK7lz/++ON5BvP7778/X6+7TZs2Vdbfeeed9dk+AAAAaDmhO67PveeeexbTGgAAAGjJofv6668vpiUAAADQ0sd0AwAAAPVY6d5www3TQw89lJZaaqm0wQYbfOO1uV944YUavjQAAAA0bzUK3XvssUdq165dvj9gwICi2wQAAADNQlm5a3+ladOmpY4dO6apU6emDh06pMZs46vHN3QTAKij0Uf0cuwAoIXlSGO6AQAAoCBCNwAAABRE6AYAAICCCN0AAADQWEP3nDlz0pgxY9Knn35aPy0CAACAlhq6TzjhhHTddddVBO6tt946X8e7e/fu6dFHHy2ijQAAANAyQvftt9+e1ltvvXz/3nvvTRMmTEivv/56GjRoUPrFL35RRBsBAACgZYTujz76KHXt2jXf/8c//pH23nvvtPrqq6eDDz44jR07tog2AgAAQMsI3cstt1z697//nbuWP/DAA2mHHXbIy7/44ou0yCKLFNFGAAAAaBmh+2c/+1n60Y9+lHr37p3KyspSv3798vJnnnkmrbnmmrVuwKhRo9Juu+2WunXrlvd39913V6ybNWtWGjJkSFp33XXT4osvnrc54IAD0nvvvVdlHyuttFJ+buXbBRdcUOu2AAAAQH1qXdsnnH322TlwT5o0KXctb9euXV4eVe5TTjml1g2YMWNGHiMe3dP32muvKuuiev7CCy+kM844I28TM6Qff/zxaffdd0/PPfdclW3POeecdNhhh1U8XnLJJWvdFgAAAGjQ0B1++MMf5p9fffVVxbIDDzywTg3Yaaed8q06HTt2TCNGjKiy7PLLL0+bbLJJmjhxYurRo0eVkF0aaw4AAABNsnt5jOU+99xz0worrJCWWGKJ9Pbbb+flUY0uXUqsSFOnTs3dxzt16lRleXQnX3rppdMGG2yQLr744jR79uzC2wIAAAD1GrrPO++8NHz48HTRRReltm3bViyPLufXXnttKlJU1mOM97777ps6dOhQsfy4445Lt956a3rkkUfSEUcckc4///x08sknL3A/M2fOTNOmTatyAwAAgAbvXn7jjTemP/zhD2n77bdPRx55ZMXyGHMd1+suSkyqFhO4lZeXpyuvvLLKusGDB1fc79OnTz4ZEOF72LBhFWPOK4vlQ4cOLaytAAAAUKdK93//+9/Uq1ev+ZbPnTs3B+MiA/d//vOfPMa7cpW7OptuumnuXv7OO+9Uu/7UU0/N3dRLt5gUDgAAABq80r322munxx57LPXs2bPK8ttvvz2Ppy4qcL/55pu5+3iM2/42Y8aMSa1atUpdunSpdn1Uv6urgAMAAECDhu4zzzwzz1QeFe+obt95551p3Lhxudv5fffdV+sGTJ8+PY0fP77i8YQJE3Jo7ty5c1p++eXzTOlx2bDYd0ziNnny5LxdrI9u5E899VS+Rvi2226bZzCPx4MGDUo/+clP0lJLLVXr9gAAAEB9KSuPQdK1FJXuuC72Sy+9lEPzhhtumMN4//79a92ARx99NAfmeUWwj2uCr7zyytU+L6re22yzTQ7k//M//5PHk8cEabH9T3/60zzOu6bV7JhILS5PFl3Nv63rekPb+Or/O0EBQNMy+oj5h2cBAE1TTXNknUJ3cyN0A7AwCN0A0PJyZK0nUgMAAADqcUx3jI0uKyur0Q4/+eSTGr40AAAANG81Ct2XXnpp8S0BAACAlhi6Y1IzAAAAoOBLhoW4dNddd92VXnvttYprd++xxx6pdes67Q4AAACapVqn5FdffTXtvvvu+XrZa6yxRl524YUXpmWXXTbde++9qXfv3kW0EwAAAJqcWs9efuihh6Z11lknvfvuu/ka2XGbNGlS6tOnTzr88MOLaSUAAAC0hEr3mDFj0nPPPZdnNC+J++edd17aeOON67t9AAAA0HIq3auvvnr64IMP5ls+ZcqU1KtXr/pqFwAAALS80D1s2LB03HHHpdtvvz13MY9b3D/hhBPy2O5p06ZV3AAAAKAlq3X38l133TX//NGPfpTKysry/fLy8vxzt912q3gc62KWcwAAAGipah26H3nkkWJaAgAAAC09dG+99dbFtAQAAABaYuh++eWX8/W3W7Vqle9/k7h0GAAAAFDD0L3++uunyZMnpy5duuT7MV67NI67MuO4AQAAoJahe8KECWnZZZetuA8AAADUU+ju2bNn/jlr1qw0dOjQdMYZZ6SVV165Jk8FAACAFqtW1+lu06ZNuuOOO4prDQAAALTU0B0GDBiQ7r777mJaAwAAAC35kmGrrbZaOuecc9ITTzyR+vbtmxZffPEq64877rj6bB8AAAA0WWXl1U1D/g2+aSx3zF7+9ttvp6Zm2rRpqWPHjmnq1KmpQ4cOqTHb+OrxDd0EAOpo9BG9HDsAaCZqmiNrXek2ezkAAAAUNKY7upZ/8cUX8y3/8ssv8zoAAACgjqE7Lhk2ffr0+ZZHEI91AAAAQB1DdwwBj7Hb83rppZdS586da7s7AAAAaLZqPKZ7qaWWymE7bquvvnqV4D1nzpxc/T7yyCOLaicAAAA039B96aWX5ir3wQcfnLuRxyxtJW3btk0rrbRS2myzzYpqJwAAADTf0H3ggQdWXDJsiy22SK1b13ricwAAAGhRap2ct95662JaAgAAAC19IjUAAACgZoRuAAAAKIjQDQAAAI0tdI8fPz7985//TF9++WV+HDObAwAAAN8hdH/88cepX79++VrdO++8c3r//ffz8kMOOST9/Oc/r+3uAAAAoNmqdegeNGhQvlzYxIkT02KLLVaxfJ999kkPPPBAfbcPAAAAWk7o/te//pUuvPDCtOKKK1ZZvtpqq6X//Oc/tW7AqFGj0m677Za6deuWysrK0t13311lfXRbP/PMM9Pyyy+f2rdvn6vsb775ZpVtPvnkk7T//vunDh06pE6dOuWq+/Tp02vdFgAAAGjQ0D1jxowqFe7Kwbddu3apLvtbb7310hVXXFHt+osuuij97ne/S1dddVV65pln0uKLL5523HHH9NVXX1VsE4H71VdfTSNGjEj33XdfDvKHH354rdsCAAAADRq6v//976cbb7yx4nFUp+fOnZvD8bbbblvrBuy0007pl7/8Zdpzzz3nWxdV7ksvvTSdfvrpaY899kh9+vTJr/3ee+9VVMRfe+213K392muvTZtuumnacsst02WXXZZuvfXWvB0AAAA0lNa1fUKE6+233z4999xz6euvv04nn3xyrjJHpfuJJ56o18ZNmDAhTZ48OXcpL+nYsWMO10899VT68Y9/nH9Gl/KNNtqoYpvYvlWrVrkyXl2YnzlzZr6VTJs2rV7bDQAAAHWqdPfu3Tu98cYbuaIc1efoHr7XXnulF198Ma266qr1elQjcIfllluuyvJ4XFoXP7t06VJlfUz01rlz54pt5jVs2LAc3ku37t2712u7AQAAIOfTuhyGCKq/+MUvmuwRPPXUU9PgwYOrVLoFbwAAABokdL/88ss13mGMu64vXbt2zT8/+OCDPHt5STxef/31K7aZMmVKlefNnj07d3cvPX9eMeFbXSZ9AwAAgHoP3RFwY8K0mNgsfpbE41B52Zw5c1J9WXnllXNwfuihhypCdlSlY6z2UUcdlR9vttlm6bPPPkvPP/986tu3b1728MMP58ndYuw3AAAANOrQHROalcTY7RNPPDGddNJJOfCGmMzs17/+dZ5krbbietrjx4+v8lpjxozJY7J79OiRTjjhhDy7eVwHPEL4GWecka/pPWDAgLz9WmutlX7wgx+kww47LF9WbNasWemYY47Jk6zFdgAAANCoQ3fPnj0r7u+99975utk777xzlS7lMSY6AnEpDNdUzIJe+VJjpbHWBx54YBo+fHieHT0ma4vrbkdFOyZwi0uELbroohXPufnmm3PQjlnVY9bygQMH5jYCAABAQyorL/URr6H27dunF154IVeYK4vrZW+44Ybpyy+/TE1NdFmPyeGmTp2aOnTokBqzja/+v14BADQto4/o1dBNAAAWco6s9SXDImzHJbfiGt0lcT+WzRvEAQAAoCWr9SXDYtz0brvtllZcccWKmcpjdvOYTO3ee+8too0AAADQMkL3Jptskt5+++08jvr111/Py/bZZ5+03377pcUXX7yINgIAAEDLCN0hwnVMbAYAAACk+hvTDQAAANSM0A0AAAAFEboBAACgIEI3AAAANKbQ/dlnn6Vrr702nXrqqemTTz7Jy1544YX03//+t77bBwAAAC1n9vK4Jne/fv1Sx44d0zvvvJMOO+yw1Llz53TnnXemiRMnphtvvLGYlgIAAEBzr3QPHjw4HXTQQenNN99Miy66aMXynXfeOY0aNaq+2wcAAAAtJ3SPHj06HXHEEfMtX2GFFdLkyZPrq10AAADQ8kJ3u3bt0rRp0+Zb/sYbb6Rll122vtoFAAAALS9077777umcc85Js2bNyo/LysryWO4hQ4akgQMHFtFGAAAAaBmh+9e//nWaPn166tKlS/ryyy/T1ltvnXr16pWWXHLJdN555xXTSgAAAGgJs5fHrOUjRoxITzzxRHrppZdyAN9www3zjOYAAABAHUN3dClv3759GjNmTNpiiy3yDQAAAKiH7uVt2rRJPXr0SHPmzKnN0wAAAKBFqvWY7l/84hfptNNOS5988kkxLQIAAICWOqb78ssvT+PHj0/dunVLPXv2TIsvvniV9S+88EJ9tg8AAABaTugeMGBAMS0BAACAlh66zzrrrGJaAgAAAC09dJc899xz6bXXXsv311577dS3b9/6bBcAAAC0vND97rvvpn333Tdfp7tTp0552WeffZY233zzdOutt6YVV1yxiHYCAABA85+9/NBDD83X644qd8xgHre4P3fu3LwOAAAAqGOle+TIkenJJ59Ma6yxRsWyuH/ZZZel73//+7XdHQAAADRbta50d+/ePVe65zVnzpx8GTEAAACgjqH74osvTscee2yeSK0k7h9//PHpV7/6VW13BwAAAC27e/lSSy2VysrKKh7PmDEjbbrppql16/99+uzZs/P9gw8+2HW8AQAAoDah+9JLL63JZgAAAEBtQ/eBBx5Yk80AAACA7zJ7ecmUKVPyLS4VVlmfPn3quksAAABo2aH7+eefz5XvuDZ3eXl5lXUx7jtmMQcAAADqELpjsrTVV189XXfddWm55ZarMsEaAAAA8B0uGfb222+niy66KM9evtJKK6WePXtWudW3eI0I9vPejj766Lx+m222mW/dkUceWe/tAAAAgMIr3dtvv3166aWXUq9evdLCMHr06Cpd1l955ZW0ww47pL333rti2WGHHZbOOeeciseLLbbYQmkbAAAA1Gvovvbaa/OY7gi/vXv3Tm3atKmyfvfdd0/1adlll63y+IILLkirrrpq2nrrrauE7K5du9br6wIAAMBCD91PPfVUeuKJJ9L9998/37qiJ1L7+uuv00033ZQGDx5cZSz5zTffnJdH8N5tt93SGWecodoNAABA0wvdxx57bPrJT36Sg21MpLYw3X333emzzz5LBx10UMWy/fbbL48l79atW3r55ZfTkCFD0rhx49Kdd965wP3MnDkz30qmTZtWeNsBAABoeWoduj/++OM0aNCghR64Q8yYvtNOO+WAXXL44YdX3F933XXT8ssvn8edv/XWW7kbenWGDRuWhg4dulDaDAAAQMtV69nL99prr/TII4+khe0///lPevDBB9Ohhx76jdvFrOph/PjxC9zm1FNPTVOnTq24TZo0qd7bCwAAALWudMc1uiO0Pv7447myPO9Eascdd1whR/X6669PXbp0Sbvssss3bjdmzJj8MyreC9KuXbt8AwAAgCKVlZeXl9fmCSuvvPKCd1ZWlq/jXd/mzp2bX3fffffNs5eXRBfyW265Je28885p6aWXzmO6o+v7iiuumEaOHFnj/ceY7o4dO+aqd4cOHVJjtvHVC67gA9C4jT5i4VxuEwAoXk1zZK0r3RMmTEgLW3QrnzhxYjr44IOrLG/btm1ed+mll6YZM2ak7t27p4EDB6bTTz99obcRAAAAvnPorqxUJK98+a4i9O/fv+K1KouQXZuKNgAAADTqidTCjTfemMdzt2/fPt/69OmT/vSnP9V/6wAAAKAlVbp/85vf5Gt0H3PMMWmLLbbIy2JStSOPPDJ99NFHeUw1AAAAUIfQfdlll6Urr7wyHXDAARXLdt9997TOOuuks88+W+gGAACAunYvf//999Pmm28+3/JYFusAAACAOobuXr16pdtuu22+5X/5y1/SaqutVtvdAQAAQLNV6+7lQ4cOTfvss08aNWpUxZjuJ554Ij300EPVhnEAAABoqWpd6Y7rYD/zzDNpmWWWSXfffXe+xf1nn3027bnnnsW0EgAAAFrKdbr79u2bbrrppvpvDQAAALT063QDAAAA9VjpbtWqVSorK/vGbWL97Nmza7pLAAAAaNZqHLrvuuuuBa576qmn0u9+97s0d+7c+moXAAAAtJzQvccee8y3bNy4cemUU05J9957b9p///3TOeecU9/tAwAAgJY1pvu9995Lhx12WFp33XVzd/IxY8akG264IfXs2bP+WwgAAAAtIXRPnTo1DRkyJPXq1Su9+uqr+drcUeXu3bt3cS0EAACA5t69/KKLLkoXXnhh6tq1a/rzn/9cbXdzAAAA4P+UlZeXl6cazl7evn371K9fv7TIIosscLs777wzNTXTpk1LHTt2zJX8Dh06pMZs46vHN3QTAKij0Uf0cuwAoJmoaY6scaX7gAMO+NZLhgEAAAB1CN3Dhw+v6aYAAABAXWcvBwAAAL6d0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAABoqaH77LPPTmVlZVVua665ZsX6r776Kh199NFp6aWXTksssUQaOHBg+uCDDxq0zQAAANAkQndYZ5110vvvv19xe/zxxyvWDRo0KN17773pr3/9axo5cmR677330l577dWg7QUAAIDQuikchtatW6euXbvOt3zq1KnpuuuuS7fcckvabrvt8rLrr78+rbXWWunpp59O3/ve9xqgtQAAANCEKt1vvvlm6tatW1pllVXS/vvvnyZOnJiXP//882nWrFmpX79+FdtG1/MePXqkp556qgFbDAAAAE2g0r3pppum4cOHpzXWWCN3LR86dGj6/ve/n1555ZU0efLk1LZt29SpU6cqz1luueXyugWZOXNmvpVMmzat0PcAAABAy9ToQ/dOO+1Ucb9Pnz45hPfs2TPddtttqX379nXa57Bhw3J4BwAAgNTSu5dXFlXt1VdfPY0fPz6P8/7666/TZ599VmWbmL28ujHgJaeeemoeD166TZo0aSG0HAAAgJamyYXu6dOnp7feeistv/zyqW/fvqlNmzbpoYceqlg/bty4POZ7s802W+A+2rVrlzp06FDlBgAAAC2ue/mJJ56Ydtttt9ylPC4HdtZZZ6VFFlkk7bvvvqljx47pkEMOSYMHD06dO3fO4fnYY4/NgdvM5QAAADS0Rh+633333RywP/7447TsssumLbfcMl8OLO6HSy65JLVq1SoNHDgwT4624447pt///vcN3WwAAABIZeXl5eUt/TjE7OVRNY/x3Y29q/nGV49v6CYAUEejj+jl2AFAC8uRTW5MNwAAADQVQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICWGrqHDRuWNt5447TkkkumLl26pAEDBqRx48ZV2WabbbZJZWVlVW5HHnlkg7UZAAAAmkToHjlyZDr66KPT008/nUaMGJFmzZqV+vfvn2bMmFFlu8MOOyy9//77FbeLLrqowdoMAAAAoXVjPwwPPPBAlcfDhw/PFe/nn38+bbXVVhXLF1tssdS1a9cGaCEAAAA00Ur3vKZOnZp/du7cucrym2++OS2zzDKpd+/e6dRTT01ffPHFAvcxc+bMNG3atCo3AAAAaHGV7srmzp2bTjjhhLTFFlvkcF2y3377pZ49e6Zu3bqll19+OQ0ZMiSP+77zzjsXOE586NChC7HlAAAAtERl5eXl5amJOOqoo9L999+fHn/88bTiiisucLuHH344bb/99mn8+PFp1VVXrbbSHbeSqHR37949V9E7dOiQGrONrx7f0E0AoI5GH9HLsQOAZiJyZMeOHb81RzaZSvcxxxyT7rvvvjRq1KhvDNxh0003zT8XFLrbtWuXbwAAAFCkRh+6oxB/7LHHprvuuis9+uijaeWVV/7W54wZMyb/XH755RdCCwEAAKCJhu64XNgtt9yS7rnnnnyt7smTJ+flUcZv3759euutt/L6nXfeOS299NJ5TPegQYPyzOZ9+vRp6OYDAADQgjX60H3llVfmn9tss02V5ddff3066KCDUtu2bdODDz6YLr300nzt7hibPXDgwHT66ac3UIsBAACgiYTub5vnLUL2yJEjF1p7AAAAoNlepxsAAACaCqEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAQBN0wQUXpLKysnTCCSc0dFOAbyB0AwBAEzN69Oh09dVXpz59+jR0U4BvIXQDAEATMn369LT//vuna665Ji211FIN3RzgWwjdAADQhBx99NFpl112Sf369WvopgA10LomGwEAAA3v1ltvTS+88ELuXg40DUI3AAA0AZMmTUrHH398GjFiRFp00UUbujlADQndAADQBDz//PNpypQpacMNN6xYNmfOnDRq1Kh0+eWXp5kzZ6ZFFlmkQdsIzE/oBgCAJmD77bdPY8eOrbLsZz/7WVpzzTXTkCFDBG5opIRuAABoApZccsnUu3fvKssWX3zxtPTSS8+3HGg8zF4OAAAABVHpBgCAJurRRx9t6CYA30KlGwAAAAoidAMAAEBBdC8HAJqlja8e39BNAKCORh/RKzUXKt0AAABQEKEbAAAACtKsQvcVV1yRVlpppbToooumTTfdND377LMN3SQAAABasGYTuv/yl7+kwYMHp7POOiu98MILab311ks77rhjmjJlSkM3DQAAgBaq2YTu3/zmN+mwww5LP/vZz9Laa6+drrrqqrTYYoulP/7xjw3dNAAAAFqoZhG6v/766/T888+nfv36VSxr1apVfvzUU081aNsAAABouZrFJcM++uijNGfOnLTccstVWR6PX3/99fm2nzlzZr6VTJ06Nf+cNm1aauzmfPl5QzcBgDpqCr9nmhO/MwGarmlN4HdmqY3l5eXNP3TX1rBhw9LQoUPnW969e/cGaQ8ALUPHQQ3dAgBoGjo2od+Zn3/+eerYsWPzDt3LLLNMWmSRRdIHH3xQZXk87tq163zbn3rqqXnStZK5c+emTz75JC299NKprKxsobQZmP9MYZz4mjRpUurQoYPDAwDfwO9NaHhR4Y7A3a1bt2/crlmE7rZt26a+ffumhx56KA0YMKAiSMfjY445Zr7t27Vrl2+VderUaaG1F1iwCNxCNwDUjN+b0LC+qcLdrEJ3iMr1gQcemDbaaKO0ySabpEsvvTTNmDEjz2YOAAAADaHZhO599tknffjhh+nMM89MkydPTuuvv3564IEH5ptcDQAAABaWZhO6Q3Qlr647OdD4xZCPs846a76hHwCA35vQlJWVf9v85gAAAECdtKrb0wAAAIBvI3QDAABAQYRuoNFaaaWV8pUIvsmjjz6aysrK0meffbbQ2gUAzcU777yTf4+OGTNmgdv4XQvfjdANAAAABRG6gSZr1qxZDd0EAFqor7/+uqGbADQRQjdQr2bOnJmOO+641KVLl7ToooumLbfcMo0ePTqv22ijjdKvfvWrim0HDBiQ2rRpk6ZPn54fv/vuu7mL2/jx46vdd6y78sor0+67754WX3zxdN555/n0AFgottlmm3xp2hNOOCEts8wyaccdd0yvvPJK2mmnndISSyyRlltuufTTn/40ffTRRxXPeeCBB/LvwU6dOqWll1467brrrumtt96qEtxjn8svv3z+ndmzZ880bNiwivUTJ05Me+yxR95/hw4d0o9+9KP0wQcfVKw/++yz0/rrr5/+9Kc/5SFZHTt2TD/+8Y/T559/XuM2lLz++utp8803z+3o3bt3Gjly5Dcej8cffzx9//vfT+3bt0/du3fPv/tnzJjxnY4xNFdCN1CvTj755HTHHXekG264Ib3wwgupV69e+Q+TTz75JG299dZ5XFiIqxU+9thj+Y+A+MUd4hf8CiuskJ+zIPEHxp577pnGjh2bDj74YJ8eAAtN/G5r27ZteuKJJ9IFF1yQtttuu7TBBhuk5557LofbCMQRjEsihA4ePDivf+ihh1KrVq3y77C5c+fm9b/73e/S3/72t3TbbbelcePGpZtvvjmH5xDbROCO35/x+3HEiBHp7bffTvvss0+VNkWAvvvuu9N9992Xb7FttK2mbSg56aST0s9//vP04osvps022yzttttu6eOPP672OMRr/uAHP0gDBw5ML7/8cvrLX/6Sf5fHCQSgGnGdboD6MH369PI2bdqU33zzzRXLvv766/Ju3bqVX3TRReV/+9vfyjt27Fg+e/bs8jFjxpR37dq1/Pjjjy8fMmRI3vbQQw8t32+//Sqe27Nnz/JLLrmk4nH8l3XCCSdUec1HHnkkL//00099iAAUZuutty7fYIMNKh6fe+655f3796+yzaRJk/LvpHHjxlW7jw8//DCvHzt2bH587LHHlm+33Xblc+fOnW/bf/3rX+WLLLJI+cSJEyuWvfrqq/n5zz77bH581llnlS+22GLl06ZNq9jmpJNOKt90000X+D7mbcOECRPy4wsuuKBim1mzZpWvuOKK5RdeeGG1v2sPOeSQ8sMPP7zKfh977LHyVq1alX/55ZcLfG1oqVS6gXoTZ75jnPUWW2xRsSy6j2+yySbptddey93QostbnEWPM/FR+Y7ueqXqdyyLx98kuqgDQEPo27dvxf2XXnopPfLII7nrd+m25ppr5nWl7ttvvvlm2nfffdMqq6ySu4eXqtjRbTwcdNBBedbwNdZYI3fP/te//lWx//i9Gd2241ay9tpr5x5isa4k9rnkkktWPI6u6lOmTKl4/G1tKInqdknr1q3z79vKr1NZvPfhw4dXee/Rqy2q5xMmTKjDkYXmrXVDNwBoOeIPhfXWWy+H7KeeeirtsMMOaauttspd5d544438h0EE8W8SY7kBoCFU/h0U85FEF+wLL7xwvu0i+IZYH+O0r7nmmtStW7ccSmO8dGkStg033DCH1Pvvvz89+OCDuWt6v3790u23317jNsXJ7XnnP6ncdfzb2lAX8d6POOKIfKJgXj169KjzfqG5ErqBerPqqqtWjHWLX/AhKt8xkVpMPBMiVEdl4Nlnn80ToXXu3DmttdZa+X78kbL66qv7RABo9CIwxxwmUTmOyvC8Yjx0jNOOsBs9vUJpDpPKovocJ5/j9sMf/jCPlY5x3PG7cdKkSflWqnb/+9//Tp999lmueNdETdsQnn766XwiPMyePTs9//zzCxyjHe892vJNc7AA/0f3cqBeKwBHHXVUnowlJpSJX8iHHXZY+uKLL9IhhxySt4nu4//85z/zHyilbnixLCaP+bYqNwA0FkcffXQOx9F1O04uR5fy+P32s5/9LM2ZMycttdRSebbwP/zhD/mqHA8//HCe0Kyy3/zmN+nPf/5znjk8enz99a9/TV27ds09w6Live6666b9998/T0waJ6sPOOCA/LuypkOtatKGkiuuuCLddddduS3x3j799NMFTlg6ZMiQ9OSTT+ZQHt3jo6faPffcYyI1WAChG6hXMWNqzGYal02JM+HxSz7+CIlf/CHOtEfXtsoBO0J3/IHybeO5AaCxiK7a0bMrfn/1798/B+To1RWBOWYIj9utt96aK8bRnXvQoEHp4osvrrKPGIt90UUX5RC98cYbp3feeSf94x//yM+NbuIRZOP3Z1SgI4THuOyYKbymatKGyr+/4xbDwKIaHrOqx6XRqtOnT588D0ucKIjf6zGD+5lnnpmPCTC/sphNrZrlAAAAwHek0g0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQDNyDbbbJNOOOGEhm4GAPD/Cd0A0EgcdNBBqaysLN/atGmTVl555XTyySenr776qsb7uPPOO9O5555baDsBgJprXYttAYCC/eAHP0jXX399mjVrVnr++efTgQcemEP4hRdeWKPnd+7cuUV8Rl9//XVq27ZtQzcDAL6VSjcANCLt2rVLXbt2Td27d08DBgxI/fr1SyNGjMjrPv7447TvvvumFVZYIS222GJp3XXXTX/+85+/sXv573//+7TaaqulRRddNC233HLphz/8YcW6mTNnpuOOOy516dIlr99yyy3T6NGjK9Y/+uijOfA/9NBDaaONNsqvufnmm6dx48ZVbHP22Wen9ddfP/3pT39KK620UurYsWP68Y9/nD7//POKbebOnZuGDRuWK/ft27dP6623Xrr99tsr1g8fPjx16tSpyvu4++6782vP+zrXXntt3k+0FwCaAqEbABqpV155JT355JMVFd3oZt63b9/097//Pa87/PDD009/+tP07LPPVvv85557Lofqc845JwflBx54IG211VYV66Pr+h133JFuuOGG9MILL6RevXqlHXfcMX3yySdV9vOLX/wi/frXv877a926dTr44IOrrH/rrbdySL7vvvvybeTIkemCCy6oWB+B+8Ybb0xXXXVVevXVV9OgQYPST37yk7xdbYwfPz63N7rQjxkzplbPBYCGons5ADQiEVqXWGKJNHv27FyJbtWqVbr88svzuqhwn3jiiRXbHnvssemf//xnuu2229Imm2wy374mTpyYFl988bTrrrumJZdcMvXs2TNtsMEGed2MGTPSlVdemavMO+20U152zTXX5Kr6ddddl0466aSK/Zx33nlp6623zvdPOeWUtMsuu+QTAKVqc1SyYz/xGiFOBER1PJ4X7+H8889PDz74YNpss83y+lVWWSU9/vjj6eqrr67Yb027lEd4X3bZZet0bAGgIQjdANCIbLvttjkMRyi+5JJLcmV54MCBed2cOXNygI2Q/d///jeH0Ai10e27OjvssEMO2hFyY6x43Pbcc8+8fVSnY9z4FltsUbF9TN4W4f21116rsp8+ffpU3F9++eXzzylTpqQePXrk+9GtvBS4S9vE+lJ1+osvvshtqSzaXjoBUFPxXgRuAJoaoRsAGpGoTEc37/DHP/4xj3+OyvMhhxySLr744vTb3/42XXrppXk8d2wb47cjwFYngnB0G4+x2f/617/SmWeemcdGVx63XRMRxktK46yjul3d+tI2pfXTp0/PP6NLfFTq5x2/HqKaX15eXmVdnBCo7tgAQFNjTDcANFIRRk877bR0+umnpy+//DI98cQTaY899sjjoSOMRwX7jTfe+MZ9RKU8JmO76KKL0ssvv5zeeeed9PDDD6dVV101jxWPfVYOuhHI11577Xp7D7GvCNfR1T1OJlS+xWRxIarXMfFaVPdLjNkGoLlQ6QaARmzvvffO46uvuOKKPAt5zPodk6sttdRS6Te/+U364IMPFhiSY3z422+/nSdPi+3/8Y9/5Ar0GmuskavGRx11VN53XGYsuopHMI+u4FFVry9RbY9x6DF5Wrx2zJA+derUHPY7dOiQL4m26aab5i7vcYIhJn575pln8hhxAGgOhG4AaMSiUn3MMcfkQPziiy/mEB0zjEdIjdnL47JiEWKrE5fhipm+o0t5THwWoT0uMbbOOuvk9THDeAThmPgsKs1xWbCYmC0Cen0699xzczU7ZjGP9ke7NtxwwxyyQ4T+m266KZ8AiMnctt9++9zmeH8A0NSVlc87iAoAAACoF8Z0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAACAV4/8BqY3ZWgjy3rEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1706,10 +1714,10 @@
    "id": "a80aceaa",
    "metadata": {
     "papermill": {
-     "duration": 0.028509,
-     "end_time": "2026-05-02T00:02:52.035821+00:00",
+     "duration": 0.012792,
+     "end_time": "2026-05-07T11:43:40.379341",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.007312+00:00",
+     "start_time": "2026-05-07T11:43:40.366549",
      "status": "completed"
     },
     "tags": []
@@ -1739,10 +1747,10 @@
    "id": "b25a7a06",
    "metadata": {
     "papermill": {
-     "duration": 0.014845,
-     "end_time": "2026-05-02T00:02:52.082109+00:00",
+     "duration": 0.013523,
+     "end_time": "2026-05-07T11:43:40.406944",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.067264+00:00",
+     "start_time": "2026-05-07T11:43:40.393421",
      "status": "completed"
     },
     "tags": []
@@ -1791,16 +1799,16 @@
    "id": "ex-sw13-1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:52.101090Z",
-     "iopub.status.busy": "2026-05-02T00:02:52.100743Z",
-     "iopub.status.idle": "2026-05-02T00:02:52.105589Z",
-     "shell.execute_reply": "2026-05-02T00:02:52.104795Z"
+     "iopub.execute_input": "2026-05-07T11:43:40.434698Z",
+     "iopub.status.busy": "2026-05-07T11:43:40.433751Z",
+     "iopub.status.idle": "2026-05-07T11:43:40.440937Z",
+     "shell.execute_reply": "2026-05-07T11:43:40.439603Z"
     },
     "papermill": {
-     "duration": 0.015217,
-     "end_time": "2026-05-02T00:02:52.106915+00:00",
+     "duration": 0.024215,
+     "end_time": "2026-05-07T11:43:40.442820",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.091698+00:00",
+     "start_time": "2026-05-07T11:43:40.418605",
      "status": "completed"
     },
     "tags": []
@@ -1842,10 +1850,10 @@
    "id": "trans-036",
    "metadata": {
     "papermill": {
-     "duration": 0.009027,
-     "end_time": "2026-05-02T00:02:52.124519+00:00",
+     "duration": 0.008424,
+     "end_time": "2026-05-07T11:43:40.463339",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.115492+00:00",
+     "start_time": "2026-05-07T11:43:40.454915",
      "status": "completed"
     },
     "tags": []
@@ -1860,16 +1868,16 @@
    "id": "ex-sw13-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:52.143986Z",
-     "iopub.status.busy": "2026-05-02T00:02:52.143611Z",
-     "iopub.status.idle": "2026-05-02T00:02:52.148093Z",
-     "shell.execute_reply": "2026-05-02T00:02:52.147403Z"
+     "iopub.execute_input": "2026-05-07T11:43:40.483911Z",
+     "iopub.status.busy": "2026-05-07T11:43:40.483272Z",
+     "iopub.status.idle": "2026-05-07T11:43:40.489950Z",
+     "shell.execute_reply": "2026-05-07T11:43:40.488312Z"
     },
     "papermill": {
-     "duration": 0.016503,
-     "end_time": "2026-05-02T00:02:52.149235+00:00",
+     "duration": 0.018615,
+     "end_time": "2026-05-07T11:43:40.491558",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.132732+00:00",
+     "start_time": "2026-05-07T11:43:40.472943",
      "status": "completed"
     },
     "tags": []
@@ -1908,10 +1916,10 @@
    "id": "trans-037",
    "metadata": {
     "papermill": {
-     "duration": 0.015053,
-     "end_time": "2026-05-02T00:02:52.173941+00:00",
+     "duration": 0.007996,
+     "end_time": "2026-05-07T11:43:40.507808",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.158888+00:00",
+     "start_time": "2026-05-07T11:43:40.499812",
      "status": "completed"
     },
     "tags": []
@@ -1926,16 +1934,16 @@
    "id": "ex-sw13-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:52.198603Z",
-     "iopub.status.busy": "2026-05-02T00:02:52.198234Z",
-     "iopub.status.idle": "2026-05-02T00:02:52.203089Z",
-     "shell.execute_reply": "2026-05-02T00:02:52.201862Z"
+     "iopub.execute_input": "2026-05-07T11:43:40.533959Z",
+     "iopub.status.busy": "2026-05-07T11:43:40.533293Z",
+     "iopub.status.idle": "2026-05-07T11:43:40.540232Z",
+     "shell.execute_reply": "2026-05-07T11:43:40.538690Z"
     },
     "papermill": {
-     "duration": 0.016979,
-     "end_time": "2026-05-02T00:02:52.205039+00:00",
+     "duration": 0.027003,
+     "end_time": "2026-05-07T11:43:40.542602",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.188060+00:00",
+     "start_time": "2026-05-07T11:43:40.515599",
      "status": "completed"
     },
     "tags": []
@@ -1976,10 +1984,10 @@
    "id": "2fbcec7d",
    "metadata": {
     "papermill": {
-     "duration": 0.009717,
-     "end_time": "2026-05-02T00:02:52.226922+00:00",
+     "duration": 0.008362,
+     "end_time": "2026-05-07T11:43:40.560620",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.217205+00:00",
+     "start_time": "2026-05-07T11:43:40.552258",
      "status": "completed"
     },
     "tags": []
@@ -2018,10 +2026,10 @@
    "id": "7oyuh5l3sdw",
    "metadata": {
     "papermill": {
-     "duration": 0.009127,
-     "end_time": "2026-05-02T00:02:52.251796+00:00",
+     "duration": 0.010315,
+     "end_time": "2026-05-07T11:43:40.580172",
      "exception": false,
-     "start_time": "2026-05-02T00:02:52.242669+00:00",
+     "start_time": "2026-05-07T11:43:40.569857",
      "status": "completed"
     },
     "tags": []
@@ -2049,18 +2057,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.303205,
-   "end_time": "2026-05-02T00:02:52.628406+00:00",
+   "duration": 8.326025,
+   "end_time": "2026-05-07T11:43:41.159465",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SW-13-Python-Reasoners.ipynb",
-   "output_path": "SW-13-Python-Reasoners.ipynb",
+   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners.ipynb",
+   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-13-Python-Reasoners_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-02T00:02:43.325201+00:00",
+   "start_time": "2026-05-07T11:43:32.833440",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "## Installation et imports\n",
     "\n",
-    "Nous utilisons **dotNetRDF 3.2.1**. La classe `SparqlRemoteEndpoint` permet d'interroger des endpoints SPARQL distants comme DBpedia ou Wikidata."
+    "Nous utilisons **dotNetRDF 3.2.1**. La classe `SparqlQueryClient` (async) permet d'interroger des endpoints SPARQL distants comme DBpedia ou Wikidata."
    ]
   },
   {
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -183,35 +183,16 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Fonctions utilitaires definies.\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(4,5): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n",
-      "(35,5): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "// Fonctions utilitaires pour les requetes SPARQL distantes\n",
+    "// Fonctions utilitaires pour les requetes SPARQL distantes (async)\n",
     "\n",
-    "public static void ExecuteAndDisplaySparqlQuery(\n",
-    "    SparqlRemoteEndpoint endpoint, string query, int resultLimit = 10)\n",
+    "public static async Task ExecuteAndDisplaySparqlQuery(\n",
+    "    SparqlQueryClient client, string query, int resultLimit = 10)\n",
     "{\n",
     "    try\n",
     "    {\n",
-    "        SparqlResultSet results = endpoint.QueryWithResultSet(query);\n",
+    "        SparqlResultSet results = await client.QueryWithResultSetAsync(query);\n",
     "        if (results != null && results.Count > 0)\n",
     "        {\n",
     "            int count = 0;\n",
@@ -237,12 +218,12 @@
     "    }\n",
     "}\n",
     "\n",
-    "public static void ExecuteAndDisplaySparqlDescribe(\n",
-    "    SparqlRemoteEndpoint endpoint, string query, int resultLimit = 10)\n",
+    "public static async Task ExecuteAndDisplaySparqlDescribe(\n",
+    "    SparqlQueryClient client, string query, int resultLimit = 10)\n",
     "{\n",
     "    try\n",
     "    {\n",
-    "        IGraph graph = endpoint.QueryWithResultGraph(query);\n",
+    "        IGraph graph = await client.QueryWithResultGraphAsync(query);\n",
     "        if (graph != null && graph.Triples.Count > 0)\n",
     "        {\n",
     "            int count = 0;\n",
@@ -268,7 +249,8 @@
     "    }\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Fonctions utilitaires definies.\");"
+    "Console.WriteLine(\"Fonctions utilitaires definies.\");\n",
+    ""
    ]
   },
   {
@@ -277,12 +259,12 @@
    "source": [
     "### Connexion a DBpedia et test\n",
     "\n",
-    "La classe `SparqlRemoteEndpoint` encapsule l'URI de l'endpoint et le graphe par defaut."
+    "La classe `SparqlQueryClient` encapsule un `HttpClient` et l'URI de l'endpoint. Un `User-Agent` est requis par la plupart des endpoints publics."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -291,114 +273,22 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Test de connexion - Types dans DBpedia :\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#FunctionalProperty\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/1999/02/22-rdf-syntax-ns#Property\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#Thing\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#Class\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#Ontology\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#ObjectProperty\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://www.w3.org/2002/07/owl#DatatypeProperty\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://xmlns.com/foaf/0.1/Organization\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://xmlns.com/foaf/0.1/Person\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "?Concept = http://dbpedia.org/ontology/Company\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "...affiche 10 resultats sur 10.\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,1): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n",
-      "(2,37): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "// Connexion a l'endpoint DBpedia\n",
-    "SparqlRemoteEndpoint endpoint = new SparqlRemoteEndpoint(\n",
-    "    new Uri(\"http://dbpedia.org/sparql\"), \n",
-    "    \"http://dbpedia.org\"\n",
-    ");\n",
+    "// Connexion a l'endpoint DBpedia avec SparqlQueryClient\n",
+    "var httpClient = new HttpClient();\n",
+    "httpClient.DefaultRequestHeaders.Add(\"User-Agent\", \"CoursIA-SemanticWeb/1.0 (educational)\");\n",
+    "\n",
+    "SparqlQueryClient endpoint = new SparqlQueryClient(\n",
+    "    httpClient,\n",
+    "    new Uri(\"http://dbpedia.org/sparql\"));\n",
+    "endpoint.DefaultGraphs.Add(\"http://dbpedia.org\");\n",
     "\n",
     "// Test : lister les types (classes) disponibles\n",
     "string testQuery = \"SELECT DISTINCT ?Concept WHERE {[] a ?Concept} LIMIT 10\";\n",
     "Console.WriteLine(\"Test de connexion - Types dans DBpedia :\");\n",
-    "ExecuteAndDisplaySparqlQuery(endpoint, testQuery);"
+    "await ExecuteAndDisplaySparqlQuery(endpoint, testQuery);\n",
+    ""
    ]
   },
   {
@@ -1284,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1293,38 +1183,15 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "=== Albert Einstein sur Wikidata ===\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Erreur SPARQL : A HTTP Error occurred while trying to make the SPARQL Query, see inner exception for details\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(2,1): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n",
-      "(2,45): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "// Connexion a l'endpoint Wikidata\n",
-    "SparqlRemoteEndpoint wikidataEndpoint = new SparqlRemoteEndpoint(\n",
-    "    new Uri(\"https://query.wikidata.org/sparql\")\n",
-    ");\n",
+    "// Connexion a l'endpoint Wikidata avec SparqlQueryClient\n",
+    "var wdHttpClient = new HttpClient();\n",
+    "wdHttpClient.DefaultRequestHeaders.Add(\"User-Agent\", \"CoursIA-SemanticWeb/1.0 (educational)\");\n",
+    "\n",
+    "SparqlQueryClient wikidataEndpoint = new SparqlQueryClient(\n",
+    "    wdHttpClient,\n",
+    "    new Uri(\"https://query.wikidata.org/sparql\"));\n",
     "\n",
     "// Requete Wikidata 1 : Proprietes d'Albert Einstein (Q937)\n",
     "string wd1 = @\"\n",
@@ -1339,13 +1206,14 @@
     "try\n",
     "{\n",
     "    Console.WriteLine(\"=== Albert Einstein sur Wikidata ===\");\n",
-    "    ExecuteAndDisplaySparqlQuery(wikidataEndpoint, wd1, 15);\n",
+    "    await ExecuteAndDisplaySparqlQuery(wikidataEndpoint, wd1, 15);\n",
     "}\n",
     "catch (Exception ex)\n",
     "{\n",
     "    Console.WriteLine($\"Erreur Wikidata : {ex.Message}\");\n",
     "    Console.WriteLine(\"Note : Wikidata peut refuser les requetes sans User-Agent (HTTP 403).\");\n",
-    "}"
+    "}\n",
+    ""
    ]
   },
   {
@@ -1722,14 +1590,14 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. SparqlRemoteEndpoint en .NET : gestion des timeouts et erreurs\n",
+    "## 5. SparqlQueryClient en .NET : gestion des timeouts et erreurs\n",
     "\n",
     "En production, il faut gerer les problemes courants des endpoints distants : timeouts, indisponibilite, limites de requetes. dotNetRDF permet aussi de sauvegarder et recharger des resultats SPARQL dans plusieurs formats."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1738,54 +1606,17 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Sauvegarde JSON : 50 resultats -> data/example.srj\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Sauvegarde XML : 50 resultats -> data/example.srx\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "\n",
-      "Recharge depuis XML : 50 resultats\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Variables : type\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(4,5): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n",
-      "(4,35): warning CS0618: 'SparqlRemoteEndpoint' est obsolète : 'This class is obsolete and will be removed in a future release. Replaced by VDS.RDF.Query.SparqlQueryClient.'\r\n",
-      "\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Sauvegarde et rechargement de resultats SPARQL\n",
     "try\n",
     "{\n",
-    "    SparqlRemoteEndpoint ep = new SparqlRemoteEndpoint(new Uri(\"http://dbpedia.org/sparql\"));\n",
-    "    SparqlResultSet results = ep.QueryWithResultSet(\n",
+    "    var saveClient = new HttpClient();\n",
+    "    saveClient.DefaultRequestHeaders.Add(\"User-Agent\", \"CoursIA-SemanticWeb/1.0 (educational)\");\n",
+    "    SparqlQueryClient ep = new SparqlQueryClient(\n",
+    "        saveClient, new Uri(\"http://dbpedia.org/sparql\"));\n",
+    "\n",
+    "    SparqlResultSet results = await ep.QueryWithResultSetAsync(\n",
     "        \"SELECT DISTINCT ?type WHERE { ?s a ?type } LIMIT 50\"\n",
     "    );\n",
     "\n",
@@ -1808,7 +1639,7 @@
     "catch (Exception ex)\n",
     "{\n",
     "    Console.WriteLine($\"Erreur endpoint : {ex.Message}\");\n",
-    "    \n",
+    "\n",
     "    // Fallback : lire les fichiers locaux pre-calcules\n",
     "    if (System.IO.File.Exists(\"data/example.srx\"))\n",
     "    {\n",
@@ -1821,7 +1652,8 @@
     "    {\n",
     "        Console.WriteLine(\"Aucun fichier local disponible.\");\n",
     "    }\n",
-    "}"
+    "}\n",
+    ""
    ]
   },
   {
@@ -1972,7 +1804,7 @@
     "| **Wikidata** | Base collaborative, QIDs/PIDs, `SERVICE wikibase:label` |\n",
     "| **owl:sameAs** | Pont entre datasets equivalents (DBpedia <-> Wikidata) |\n",
     "| **Requetes federees** | Clause `SERVICE` pour combiner endpoints |\n",
-    "| **SparqlRemoteEndpoint** | Classe .NET pour interroger des endpoints distants |\n",
+    "| **SparqlQueryClient** | Classe .NET async pour interroger des endpoints distants |\n",
     "| **Gestion d'erreurs** | `try-catch`, fallback local, `LIMIT` obligatoire |\n",
     "\n",
     "### Quand utiliser quel endpoint ?\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -5,10 +5,10 @@
    "id": "header-nav",
    "metadata": {
     "papermill": {
-     "duration": 0.011553,
-     "end_time": "2026-05-02T00:02:33.997979+00:00",
+     "duration": 0.013358,
+     "end_time": "2026-05-07T11:43:05.282874",
      "exception": false,
-     "start_time": "2026-05-02T00:02:33.986426+00:00",
+     "start_time": "2026-05-07T11:43:05.269516",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "install-section",
    "metadata": {
     "papermill": {
-     "duration": 0.030993,
-     "end_time": "2026-05-02T00:02:34.043756+00:00",
+     "duration": 0.009563,
+     "end_time": "2026-05-07T11:43:05.308013",
      "exception": false,
-     "start_time": "2026-05-02T00:02:34.012763+00:00",
+     "start_time": "2026-05-07T11:43:05.298450",
      "status": "completed"
     },
     "tags": []
@@ -60,16 +60,16 @@
    "id": "install-pip",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:34.119054Z",
-     "iopub.status.busy": "2026-05-02T00:02:34.116501Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.321811Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.321164Z"
+     "iopub.execute_input": "2026-05-07T11:43:05.325732Z",
+     "iopub.status.busy": "2026-05-07T11:43:05.325185Z",
+     "iopub.status.idle": "2026-05-07T11:43:24.754920Z",
+     "shell.execute_reply": "2026-05-07T11:43:24.753876Z"
     },
     "papermill": {
-     "duration": 1.243438,
-     "end_time": "2026-05-02T00:02:35.323070+00:00",
+     "duration": 19.441976,
+     "end_time": "2026-05-07T11:43:24.756352",
      "exception": false,
-     "start_time": "2026-05-02T00:02:34.079632+00:00",
+     "start_time": "2026-05-07T11:43:05.314376",
      "status": "completed"
     },
     "tags": []
@@ -80,6 +80,17 @@
      "output_type": "stream",
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
+      "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
+      "\n",
+      "[notice] A new release of pip is available: 25.0.1 -> 26.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -92,10 +103,10 @@
    "id": "section1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.008623,
-     "end_time": "2026-05-02T00:02:35.340073+00:00",
+     "duration": 0.005951,
+     "end_time": "2026-05-07T11:43:24.769063",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.331450+00:00",
+     "start_time": "2026-05-07T11:43:24.763112",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +142,16 @@
    "id": "demo-json-vs-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.386440Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.384756Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.401624Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.398011Z"
+     "iopub.execute_input": "2026-05-07T11:43:24.785615Z",
+     "iopub.status.busy": "2026-05-07T11:43:24.784988Z",
+     "iopub.status.idle": "2026-05-07T11:43:24.794425Z",
+     "shell.execute_reply": "2026-05-07T11:43:24.792834Z"
     },
     "papermill": {
-     "duration": 0.052918,
-     "end_time": "2026-05-02T00:02:35.406940+00:00",
+     "duration": 0.020886,
+     "end_time": "2026-05-07T11:43:24.795955",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.354022+00:00",
+     "start_time": "2026-05-07T11:43:24.775069",
      "status": "completed"
     },
     "tags": []
@@ -195,10 +206,10 @@
    "id": "interpretation-json-vs-jsonld",
    "metadata": {
     "papermill": {
-     "duration": 0.029848,
-     "end_time": "2026-05-02T00:02:35.471109+00:00",
+     "duration": 0.007163,
+     "end_time": "2026-05-07T11:43:24.811089",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.441261+00:00",
+     "start_time": "2026-05-07T11:43:24.803926",
      "status": "completed"
     },
     "tags": []
@@ -219,10 +230,10 @@
    "id": "section2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.01429,
-     "end_time": "2026-05-02T00:02:35.507895+00:00",
+     "duration": 0.008126,
+     "end_time": "2026-05-07T11:43:24.828567",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.493605+00:00",
+     "start_time": "2026-05-07T11:43:24.820441",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +251,10 @@
    "id": "section2-context",
    "metadata": {
     "papermill": {
-     "duration": 0.012461,
-     "end_time": "2026-05-02T00:02:35.540237+00:00",
+     "duration": 0.008139,
+     "end_time": "2026-05-07T11:43:24.846697",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.527776+00:00",
+     "start_time": "2026-05-07T11:43:24.838558",
      "status": "completed"
     },
     "tags": []
@@ -263,16 +274,16 @@
    "id": "context-examples",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.559698Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.558904Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.585791Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.581379Z"
+     "iopub.execute_input": "2026-05-07T11:43:24.870697Z",
+     "iopub.status.busy": "2026-05-07T11:43:24.870069Z",
+     "iopub.status.idle": "2026-05-07T11:43:24.877709Z",
+     "shell.execute_reply": "2026-05-07T11:43:24.876655Z"
     },
     "papermill": {
-     "duration": 0.041202,
-     "end_time": "2026-05-02T00:02:35.589351+00:00",
+     "duration": 0.022526,
+     "end_time": "2026-05-07T11:43:24.880114",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.548149+00:00",
+     "start_time": "2026-05-07T11:43:24.857588",
      "status": "completed"
     },
     "tags": []
@@ -366,10 +377,10 @@
    "id": "section2-id-type",
    "metadata": {
     "papermill": {
-     "duration": 0.012351,
-     "end_time": "2026-05-02T00:02:35.609376+00:00",
+     "duration": 0.00964,
+     "end_time": "2026-05-07T11:43:24.901121",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.597025+00:00",
+     "start_time": "2026-05-07T11:43:24.891481",
      "status": "completed"
     },
     "tags": []
@@ -387,16 +398,16 @@
    "id": "id-type-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.655941Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.653451Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.665388Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.664437Z"
+     "iopub.execute_input": "2026-05-07T11:43:24.917406Z",
+     "iopub.status.busy": "2026-05-07T11:43:24.916977Z",
+     "iopub.status.idle": "2026-05-07T11:43:24.923888Z",
+     "shell.execute_reply": "2026-05-07T11:43:24.922550Z"
     },
     "papermill": {
-     "duration": 0.03894,
-     "end_time": "2026-05-02T00:02:35.667937+00:00",
+     "duration": 0.016975,
+     "end_time": "2026-05-07T11:43:24.926203",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.628997+00:00",
+     "start_time": "2026-05-07T11:43:24.909228",
      "status": "completed"
     },
     "tags": []
@@ -459,10 +470,10 @@
    "id": "section2-graph",
    "metadata": {
     "papermill": {
-     "duration": 0.015173,
-     "end_time": "2026-05-02T00:02:35.698844+00:00",
+     "duration": 0.010904,
+     "end_time": "2026-05-07T11:43:24.950095",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.683671+00:00",
+     "start_time": "2026-05-07T11:43:24.939191",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +490,16 @@
    "id": "graph-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.721058Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.720777Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.727299Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.726609Z"
+     "iopub.execute_input": "2026-05-07T11:43:24.970124Z",
+     "iopub.status.busy": "2026-05-07T11:43:24.969212Z",
+     "iopub.status.idle": "2026-05-07T11:43:24.978428Z",
+     "shell.execute_reply": "2026-05-07T11:43:24.976963Z"
     },
     "papermill": {
-     "duration": 0.018182,
-     "end_time": "2026-05-02T00:02:35.728570+00:00",
+     "duration": 0.020782,
+     "end_time": "2026-05-07T11:43:24.980247",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.710388+00:00",
+     "start_time": "2026-05-07T11:43:24.959465",
      "status": "completed"
     },
     "tags": []
@@ -542,10 +553,10 @@
    "id": "section2-forms",
    "metadata": {
     "papermill": {
-     "duration": 0.008272,
-     "end_time": "2026-05-02T00:02:35.744315+00:00",
+     "duration": 0.012629,
+     "end_time": "2026-05-07T11:43:25.002680",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.736043+00:00",
+     "start_time": "2026-05-07T11:43:24.990051",
      "status": "completed"
     },
     "tags": []
@@ -568,16 +579,16 @@
    "id": "forms-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.760869Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.760596Z",
-     "iopub.status.idle": "2026-05-02T00:02:35.766200Z",
-     "shell.execute_reply": "2026-05-02T00:02:35.765629Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.030883Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.030105Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.040083Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.038453Z"
     },
     "papermill": {
-     "duration": 0.015406,
-     "end_time": "2026-05-02T00:02:35.767372+00:00",
+     "duration": 0.025306,
+     "end_time": "2026-05-07T11:43:25.042834",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.751966+00:00",
+     "start_time": "2026-05-07T11:43:25.017528",
      "status": "completed"
     },
     "tags": []
@@ -681,10 +692,10 @@
    "id": "interpretation-forms",
    "metadata": {
     "papermill": {
-     "duration": 0.007389,
-     "end_time": "2026-05-02T00:02:35.782600+00:00",
+     "duration": 0.009713,
+     "end_time": "2026-05-07T11:43:25.064174",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.775211+00:00",
+     "start_time": "2026-05-07T11:43:25.054461",
      "status": "completed"
     },
     "tags": []
@@ -700,10 +711,10 @@
    "id": "section3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.007337,
-     "end_time": "2026-05-02T00:02:35.798534+00:00",
+     "duration": 0.007632,
+     "end_time": "2026-05-07T11:43:25.080881",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.791197+00:00",
+     "start_time": "2026-05-07T11:43:25.073249",
      "status": "completed"
     },
     "tags": []
@@ -735,10 +746,10 @@
    "id": "section3-explore",
    "metadata": {
     "papermill": {
-     "duration": 0.012722,
-     "end_time": "2026-05-02T00:02:35.821708+00:00",
+     "duration": 0.008363,
+     "end_time": "2026-05-07T11:43:25.103139",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.808986+00:00",
+     "start_time": "2026-05-07T11:43:25.094776",
      "status": "completed"
     },
     "tags": []
@@ -755,16 +766,16 @@
    "id": "schema-namespace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:35.842284Z",
-     "iopub.status.busy": "2026-05-02T00:02:35.841997Z",
-     "iopub.status.idle": "2026-05-02T00:02:36.312221Z",
-     "shell.execute_reply": "2026-05-02T00:02:36.311309Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.129131Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.128284Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.405130Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.403846Z"
     },
     "papermill": {
-     "duration": 0.481617,
-     "end_time": "2026-05-02T00:02:36.313721+00:00",
+     "duration": 0.293676,
+     "end_time": "2026-05-07T11:43:25.407143",
      "exception": false,
-     "start_time": "2026-05-02T00:02:35.832104+00:00",
+     "start_time": "2026-05-07T11:43:25.113467",
      "status": "completed"
     },
     "tags": []
@@ -831,10 +842,10 @@
    "id": "section3-load-product",
    "metadata": {
     "papermill": {
-     "duration": 0.032188,
-     "end_time": "2026-05-02T00:02:36.362199+00:00",
+     "duration": 0.006114,
+     "end_time": "2026-05-07T11:43:25.419818",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.330011+00:00",
+     "start_time": "2026-05-07T11:43:25.413704",
      "status": "completed"
     },
     "tags": []
@@ -851,16 +862,16 @@
    "id": "load-product",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:36.390017Z",
-     "iopub.status.busy": "2026-05-02T00:02:36.389204Z",
-     "iopub.status.idle": "2026-05-02T00:02:36.420881Z",
-     "shell.execute_reply": "2026-05-02T00:02:36.420055Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.433987Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.433344Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.453621Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.452446Z"
     },
     "papermill": {
-     "duration": 0.044023,
-     "end_time": "2026-05-02T00:02:36.422046+00:00",
+     "duration": 0.030101,
+     "end_time": "2026-05-07T11:43:25.456031",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.378023+00:00",
+     "start_time": "2026-05-07T11:43:25.425930",
      "status": "completed"
     },
     "tags": []
@@ -943,10 +954,10 @@
    "id": "interpretation-product",
    "metadata": {
     "papermill": {
-     "duration": 0.074752,
-     "end_time": "2026-05-02T00:02:36.505017+00:00",
+     "duration": 0.007499,
+     "end_time": "2026-05-07T11:43:25.474864",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.430265+00:00",
+     "start_time": "2026-05-07T11:43:25.467365",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +985,10 @@
    "id": "section4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.016145,
-     "end_time": "2026-05-02T00:02:36.530155+00:00",
+     "duration": 0.009596,
+     "end_time": "2026-05-07T11:43:25.490769",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.514010+00:00",
+     "start_time": "2026-05-07T11:43:25.481173",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +1006,10 @@
    "id": "section4-build",
    "metadata": {
     "papermill": {
-     "duration": 0.016093,
-     "end_time": "2026-05-02T00:02:36.573931+00:00",
+     "duration": 0.009591,
+     "end_time": "2026-05-07T11:43:25.512349",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.557838+00:00",
+     "start_time": "2026-05-07T11:43:25.502758",
      "status": "completed"
     },
     "tags": []
@@ -1015,16 +1026,16 @@
    "id": "build-graph-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:36.598083Z",
-     "iopub.status.busy": "2026-05-02T00:02:36.597816Z",
-     "iopub.status.idle": "2026-05-02T00:02:36.631640Z",
-     "shell.execute_reply": "2026-05-02T00:02:36.630821Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.537128Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.536532Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.603681Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.602044Z"
     },
     "papermill": {
-     "duration": 0.045579,
-     "end_time": "2026-05-02T00:02:36.632885+00:00",
+     "duration": 0.080987,
+     "end_time": "2026-05-07T11:43:25.605860",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.587306+00:00",
+     "start_time": "2026-05-07T11:43:25.524873",
      "status": "completed"
     },
     "tags": []
@@ -1035,31 +1046,9 @@
      "output_type": "stream",
      "text": [
       "Graphe construit : 9 triples\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "=== Serialisation JSON-LD ===\n",
       "[\n",
-      "  {\n",
-      "    \"@id\": \"https://example.org/people/charles_babbage\",\n",
-      "    \"@type\": [\n",
-      "      \"https://schema.org/Person\"\n",
-      "    ],\n",
-      "    \"https://schema.org/jobTitle\": [\n",
-      "      {\n",
-      "        \"@value\": \"Inventor\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Charles Babbage\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
       "  {\n",
       "    \"@id\": \"https://example.org/people/ada_lovelace\",\n",
       "    \"@type\": [\n",
@@ -1089,6 +1078,22 @@
       "    \"https://schema.org/name\": [\n",
       "      {\n",
       "        \"@value\": \"Ada Lovelace\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  {\n",
+      "    \"@id\": \"https://example.org/people/charles_babbage\",\n",
+      "    \"@type\": [\n",
+      "      \"https://schema.org/Person\"\n",
+      "    ],\n",
+      "    \"https://schema.org/jobTitle\": [\n",
+      "      {\n",
+      "        \"@value\": \"Inventor\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"https://schema.org/name\": [\n",
+      "      {\n",
+      "        \"@value\": \"Charles Babbage\"\n",
       "      }\n",
       "    ]\n",
       "  }\n",
@@ -1139,10 +1144,10 @@
    "id": "interpretation-build",
    "metadata": {
     "papermill": {
-     "duration": 0.008207,
-     "end_time": "2026-05-02T00:02:36.650659+00:00",
+     "duration": 0.012285,
+     "end_time": "2026-05-07T11:43:25.628393",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.642452+00:00",
+     "start_time": "2026-05-07T11:43:25.616108",
      "status": "completed"
     },
     "tags": []
@@ -1163,10 +1168,10 @@
    "id": "section4-person-compact",
    "metadata": {
     "papermill": {
-     "duration": 0.010912,
-     "end_time": "2026-05-02T00:02:36.671610+00:00",
+     "duration": 0.009361,
+     "end_time": "2026-05-07T11:43:25.645514",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.660698+00:00",
+     "start_time": "2026-05-07T11:43:25.636153",
      "status": "completed"
     },
     "tags": []
@@ -1183,16 +1188,16 @@
    "id": "compact-serialization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:36.692689Z",
-     "iopub.status.busy": "2026-05-02T00:02:36.692009Z",
-     "iopub.status.idle": "2026-05-02T00:02:36.698136Z",
-     "shell.execute_reply": "2026-05-02T00:02:36.697585Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.674530Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.673808Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.682235Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.680861Z"
     },
     "papermill": {
-     "duration": 0.016611,
-     "end_time": "2026-05-02T00:02:36.699242+00:00",
+     "duration": 0.024557,
+     "end_time": "2026-05-07T11:43:25.683779",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.682631+00:00",
+     "start_time": "2026-05-07T11:43:25.659222",
      "status": "completed"
     },
     "tags": []
@@ -1218,12 +1223,6 @@
       "  },\n",
       "  \"@graph\": [\n",
       "    {\n",
-      "      \"@id\": \"ex:charles_babbage\",\n",
-      "      \"@type\": \"schema:Person\",\n",
-      "      \"jobTitle\": \"Inventor\",\n",
-      "      \"name\": \"Charles Babbage\"\n",
-      "    },\n",
-      "    {\n",
       "      \"@id\": \"ex:ada_lovelace\",\n",
       "      \"@type\": \"schema:Person\",\n",
       "      \"birthDate\": {\n",
@@ -1234,6 +1233,12 @@
       "      \"jobTitle\": \"Mathematician and Writer\",\n",
       "      \"knows\": \"ex:charles_babbage\",\n",
       "      \"name\": \"Ada Lovelace\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"@id\": \"ex:charles_babbage\",\n",
+      "      \"@type\": \"schema:Person\",\n",
+      "      \"jobTitle\": \"Inventor\",\n",
+      "      \"name\": \"Charles Babbage\"\n",
       "    }\n",
       "  ]\n",
       "}\n"
@@ -1270,10 +1275,10 @@
    "id": "section5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.007978,
-     "end_time": "2026-05-02T00:02:36.715635+00:00",
+     "duration": 0.0122,
+     "end_time": "2026-05-07T11:43:25.705581",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.707657+00:00",
+     "start_time": "2026-05-07T11:43:25.693381",
      "status": "completed"
     },
     "tags": []
@@ -1291,10 +1296,10 @@
    "id": "section5-parse",
    "metadata": {
     "papermill": {
-     "duration": 0.016767,
-     "end_time": "2026-05-02T00:02:36.747244+00:00",
+     "duration": 0.009694,
+     "end_time": "2026-05-07T11:43:25.726445",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.730477+00:00",
+     "start_time": "2026-05-07T11:43:25.716751",
      "status": "completed"
     },
     "tags": []
@@ -1309,16 +1314,16 @@
    "id": "parse-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:36.778700Z",
-     "iopub.status.busy": "2026-05-02T00:02:36.778389Z",
-     "iopub.status.idle": "2026-05-02T00:02:36.962575Z",
-     "shell.execute_reply": "2026-05-02T00:02:36.960882Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.746313Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.745616Z",
+     "iopub.status.idle": "2026-05-07T11:43:25.947472Z",
+     "shell.execute_reply": "2026-05-07T11:43:25.945917Z"
     },
     "papermill": {
-     "duration": 0.201815,
-     "end_time": "2026-05-02T00:02:36.965316+00:00",
+     "duration": 0.213001,
+     "end_time": "2026-05-07T11:43:25.949516",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.763501+00:00",
+     "start_time": "2026-05-07T11:43:25.736515",
      "status": "completed"
     },
     "tags": []
@@ -1331,17 +1336,17 @@
       "Triples charges : 11\n",
       "\n",
       "=== Tous les triples ===\n",
-      "  ex:pycon2025  http://schema.org/startDate  2025-10-23\n",
-      "  ex:pycon2025  http://schema.org/endDate  2025-10-26\n",
-      "  N1ea34d4ae642417bbf8a79b4e756dcbf  http://schema.org/name  AFPy\n",
-      "  ex:pycon2025  http://schema.org/organizer  N1ea34d4ae642417bbf8a79b4e756dcbf\n",
-      "  Ne360b2996d994403a65a12210170da3b  http://schema.org/name  Strasbourg\n",
-      "  Ne360b2996d994403a65a12210170da3b  http://schema.org/address  Palais de la Musique et des Congres\n",
-      "  ex:pycon2025  http://schema.org/name  PyCon France 2025\n",
+      "  Na655690d08c6434fbf0253e3eee9d5ea  http://schema.org/address  Palais de la Musique et des Congres\n",
+      "  Na655690d08c6434fbf0253e3eee9d5ea  rdf:type  http://schema.org/Place\n",
+      "  ex:pycon2025  http://schema.org/organizer  N2363111302064ef3913b2cfd2a8d47be\n",
       "  ex:pycon2025  rdf:type  http://schema.org/Event\n",
-      "  N1ea34d4ae642417bbf8a79b4e756dcbf  rdf:type  http://schema.org/Organization\n",
-      "  Ne360b2996d994403a65a12210170da3b  rdf:type  http://schema.org/Place\n",
-      "  ex:pycon2025  http://schema.org/location  Ne360b2996d994403a65a12210170da3b\n"
+      "  ex:pycon2025  http://schema.org/location  Na655690d08c6434fbf0253e3eee9d5ea\n",
+      "  ex:pycon2025  http://schema.org/name  PyCon France 2025\n",
+      "  ex:pycon2025  http://schema.org/endDate  2025-10-26\n",
+      "  N2363111302064ef3913b2cfd2a8d47be  rdf:type  http://schema.org/Organization\n",
+      "  ex:pycon2025  http://schema.org/startDate  2025-10-23\n",
+      "  N2363111302064ef3913b2cfd2a8d47be  http://schema.org/name  AFPy\n",
+      "  Na655690d08c6434fbf0253e3eee9d5ea  http://schema.org/name  Strasbourg\n"
      ]
     }
    ],
@@ -1388,10 +1393,10 @@
    "id": "section5-sparql",
    "metadata": {
     "papermill": {
-     "duration": 0.010698,
-     "end_time": "2026-05-02T00:02:36.991662+00:00",
+     "duration": 0.008865,
+     "end_time": "2026-05-07T11:43:25.967597",
      "exception": false,
-     "start_time": "2026-05-02T00:02:36.980964+00:00",
+     "start_time": "2026-05-07T11:43:25.958732",
      "status": "completed"
     },
     "tags": []
@@ -1408,16 +1413,16 @@
    "id": "sparql-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.012971Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.012703Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.421093Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.420279Z"
+     "iopub.execute_input": "2026-05-07T11:43:25.991706Z",
+     "iopub.status.busy": "2026-05-07T11:43:25.991043Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.306946Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.305347Z"
     },
     "papermill": {
-     "duration": 0.41996,
-     "end_time": "2026-05-02T00:02:37.422683+00:00",
+     "duration": 0.330458,
+     "end_time": "2026-05-07T11:43:26.309415",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.002723+00:00",
+     "start_time": "2026-05-07T11:43:25.978957",
      "status": "completed"
     },
     "tags": []
@@ -1431,12 +1436,21 @@
       "Nom                                 Type                      Date debut\n",
       "---------------------------------------------------------------------------\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AFPy                                http://schema.org/Organization -\n",
+      "PyCon France 2025                   http://schema.org/Event   2025-10-23\n",
+      "Strasbourg                          http://schema.org/Place   -\n"
+     ]
     }
    ],
    "source": [
     "# Requete SPARQL sur le graphe charge depuis JSON-LD\n",
     "query = \"\"\"\n",
-    "PREFIX schema: <https://schema.org/>\n",
+    "PREFIX schema: <http://schema.org/>\n",
     "\n",
     "SELECT ?name ?type ?startDate\n",
     "WHERE {\n",
@@ -1463,10 +1477,10 @@
    "id": "section5-convert",
    "metadata": {
     "papermill": {
-     "duration": 0.015913,
-     "end_time": "2026-05-02T00:02:37.449084+00:00",
+     "duration": 0.00742,
+     "end_time": "2026-05-07T11:43:26.324369",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.433171+00:00",
+     "start_time": "2026-05-07T11:43:26.316949",
      "status": "completed"
     },
     "tags": []
@@ -1483,16 +1497,16 @@
    "id": "convert-turtle",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.542246Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.540223Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.572541Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.568909Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.345116Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.344294Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.354672Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.353265Z"
     },
     "papermill": {
-     "duration": 0.088731,
-     "end_time": "2026-05-02T00:02:37.576785+00:00",
+     "duration": 0.022725,
+     "end_time": "2026-05-07T11:43:26.356655",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.488054+00:00",
+     "start_time": "2026-05-07T11:43:26.333930",
      "status": "completed"
     },
     "tags": []
@@ -1531,10 +1545,10 @@
    "id": "section5-roundtrip",
    "metadata": {
     "papermill": {
-     "duration": 0.012749,
-     "end_time": "2026-05-02T00:02:37.608053+00:00",
+     "duration": 0.007161,
+     "end_time": "2026-05-07T11:43:26.376923",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.595304+00:00",
+     "start_time": "2026-05-07T11:43:26.369762",
      "status": "completed"
     },
     "tags": []
@@ -1551,16 +1565,16 @@
    "id": "roundtrip-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.627872Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.627460Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.641250Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.640351Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.392153Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.391794Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.405481Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.404301Z"
     },
     "papermill": {
-     "duration": 0.02528,
-     "end_time": "2026-05-02T00:02:37.642489+00:00",
+     "duration": 0.022955,
+     "end_time": "2026-05-07T11:43:26.406776",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.617209+00:00",
+     "start_time": "2026-05-07T11:43:26.383821",
      "status": "completed"
     },
     "tags": []
@@ -1592,7 +1606,7 @@
       "    ],\n",
       "    \"http://schema.org/location\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n29b891c34cdc4993a60b6fef093cec66b1\"\n",
+      "        \"@id\": \"_:na76d2a62854f4a78bdf86b042229582bb1\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -1602,7 +1616,7 @@
       "    ],\n",
       "    \"http://schema.org/organizer\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n29b891c34cdc4993a60b6fef093cec66b2\"\n",
+      "        \"@id\": \"_:na76d2a62854f4a78bdf86b042229582bb2\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/startDate\": [\n",
@@ -1613,7 +1627,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n29b891c34cdc4993a60b6fef093cec66b1\",\n",
+      "    \"@id\": \"_:na76d2a62854f4a78bdf86b042229582bb1\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Place\"\n",
       "    ],\n",
@@ -1629,7 +1643,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n29b891c34cdc4993a60b6fef093cec66b2\",\n",
+      "    \"@id\": \"_:na76d2a62854f4a78bdf86b042229582bb2\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Organization\"\n",
       "    ],\n",
@@ -1684,10 +1698,10 @@
    "id": "interpretation-roundtrip",
    "metadata": {
     "papermill": {
-     "duration": 0.009583,
-     "end_time": "2026-05-02T00:02:37.661116+00:00",
+     "duration": 0.008909,
+     "end_time": "2026-05-07T11:43:26.423956",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.651533+00:00",
+     "start_time": "2026-05-07T11:43:26.415047",
      "status": "completed"
     },
     "tags": []
@@ -1708,10 +1722,10 @@
    "id": "section6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.01004,
-     "end_time": "2026-05-02T00:02:37.680177+00:00",
+     "duration": 0.010729,
+     "end_time": "2026-05-07T11:43:26.443392",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.670137+00:00",
+     "start_time": "2026-05-07T11:43:26.432663",
      "status": "completed"
     },
     "tags": []
@@ -1729,10 +1743,10 @@
    "id": "section6-recipe",
    "metadata": {
     "papermill": {
-     "duration": 0.009864,
-     "end_time": "2026-05-02T00:02:37.700214+00:00",
+     "duration": 0.010829,
+     "end_time": "2026-05-07T11:43:26.462703",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.690350+00:00",
+     "start_time": "2026-05-07T11:43:26.451874",
      "status": "completed"
     },
     "tags": []
@@ -1749,16 +1763,16 @@
    "id": "recipe-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.728594Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.727900Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.738652Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.736174Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.480985Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.480164Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.491976Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.490444Z"
     },
     "papermill": {
-     "duration": 0.028197,
-     "end_time": "2026-05-02T00:02:37.742493+00:00",
+     "duration": 0.023478,
+     "end_time": "2026-05-07T11:43:26.493966",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.714296+00:00",
+     "start_time": "2026-05-07T11:43:26.470488",
      "status": "completed"
     },
     "tags": []
@@ -1899,10 +1913,10 @@
    "id": "section6-event",
    "metadata": {
     "papermill": {
-     "duration": 0.011553,
-     "end_time": "2026-05-02T00:02:37.764754+00:00",
+     "duration": 0.008452,
+     "end_time": "2026-05-07T11:43:26.509316",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.753201+00:00",
+     "start_time": "2026-05-07T11:43:26.500864",
      "status": "completed"
     },
     "tags": []
@@ -1919,16 +1933,16 @@
    "id": "event-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.784956Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.784560Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.791328Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.789846Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.535477Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.534919Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.541605Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.540449Z"
     },
     "papermill": {
-     "duration": 0.01937,
-     "end_time": "2026-05-02T00:02:37.793355+00:00",
+     "duration": 0.019706,
+     "end_time": "2026-05-07T11:43:26.543687",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.773985+00:00",
+     "start_time": "2026-05-07T11:43:26.523981",
      "status": "completed"
     },
     "tags": []
@@ -2021,10 +2035,10 @@
    "id": "section6-breadcrumb-faq",
    "metadata": {
     "papermill": {
-     "duration": 0.010413,
-     "end_time": "2026-05-02T00:02:37.813026+00:00",
+     "duration": 0.006795,
+     "end_time": "2026-05-07T11:43:26.559606",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.802613+00:00",
+     "start_time": "2026-05-07T11:43:26.552811",
      "status": "completed"
     },
     "tags": []
@@ -2043,16 +2057,16 @@
    "id": "breadcrumb-faq-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.835732Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.835368Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.844062Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.842355Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.582618Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.582245Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.591991Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.590621Z"
     },
     "papermill": {
-     "duration": 0.022542,
-     "end_time": "2026-05-02T00:02:37.845387+00:00",
+     "duration": 0.026393,
+     "end_time": "2026-05-07T11:43:26.593609",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.822845+00:00",
+     "start_time": "2026-05-07T11:43:26.567216",
      "status": "completed"
     },
     "tags": []
@@ -2158,10 +2172,10 @@
    "id": "interpretation-usecases",
    "metadata": {
     "papermill": {
-     "duration": 0.010122,
-     "end_time": "2026-05-02T00:02:37.866465+00:00",
+     "duration": 0.010239,
+     "end_time": "2026-05-07T11:43:26.610934",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.856343+00:00",
+     "start_time": "2026-05-07T11:43:26.600695",
      "status": "completed"
     },
     "tags": []
@@ -2192,10 +2206,10 @@
    "id": "section7-title",
    "metadata": {
     "papermill": {
-     "duration": 0.009593,
-     "end_time": "2026-05-02T00:02:37.886684+00:00",
+     "duration": 0.007015,
+     "end_time": "2026-05-07T11:43:26.625575",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.877091+00:00",
+     "start_time": "2026-05-07T11:43:26.618560",
      "status": "completed"
     },
     "tags": []
@@ -2214,16 +2228,16 @@
    "id": "format-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:37.907169Z",
-     "iopub.status.busy": "2026-05-02T00:02:37.906488Z",
-     "iopub.status.idle": "2026-05-02T00:02:37.927962Z",
-     "shell.execute_reply": "2026-05-02T00:02:37.927129Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.650438Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.649798Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.666707Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.665564Z"
     },
     "papermill": {
-     "duration": 0.032613,
-     "end_time": "2026-05-02T00:02:37.929297+00:00",
+     "duration": 0.031717,
+     "end_time": "2026-05-07T11:43:26.668806",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.896684+00:00",
+     "start_time": "2026-05-07T11:43:26.637089",
      "status": "completed"
     },
     "tags": []
@@ -2286,8 +2300,8 @@
       "============================================================\n",
       "=== N-Triples (314 octets, 3 lignes) ===\n",
       "============================================================\n",
-      "<https://example.org/people/curie> <https://schema.org/name> \"Marie Curie\" .\n",
       "<https://example.org/people/curie> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Person> .\n",
+      "<https://example.org/people/curie> <https://schema.org/name> \"Marie Curie\" .\n",
       "<https://example.org/people/curie> <https://schema.org/birthDate> \"1867-11-07\"^^<http://www.w3.org/2001/XMLSchema#date> .\n",
       "\n"
      ]
@@ -2334,10 +2348,10 @@
    "id": "interpretation-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.022548,
-     "end_time": "2026-05-02T00:02:37.964864+00:00",
+     "duration": 0.010029,
+     "end_time": "2026-05-07T11:43:26.691315",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.942316+00:00",
+     "start_time": "2026-05-07T11:43:26.681286",
      "status": "completed"
     },
     "tags": []
@@ -2367,10 +2381,10 @@
    "id": "section8-title",
    "metadata": {
     "papermill": {
-     "duration": 0.008949,
-     "end_time": "2026-05-02T00:02:37.989960+00:00",
+     "duration": 0.007886,
+     "end_time": "2026-05-07T11:43:26.712093",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.981011+00:00",
+     "start_time": "2026-05-07T11:43:26.704207",
      "status": "completed"
     },
     "tags": []
@@ -2389,16 +2403,16 @@
    "id": "load-product-rdflib",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:38.012022Z",
-     "iopub.status.busy": "2026-05-02T00:02:38.011573Z",
-     "iopub.status.idle": "2026-05-02T00:02:38.168469Z",
-     "shell.execute_reply": "2026-05-02T00:02:38.167077Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.732821Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.732062Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.918524Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.916917Z"
     },
     "papermill": {
-     "duration": 0.170407,
-     "end_time": "2026-05-02T00:02:38.170236+00:00",
+     "duration": 0.199326,
+     "end_time": "2026-05-07T11:43:26.919960",
      "exception": false,
-     "start_time": "2026-05-02T00:02:37.999829+00:00",
+     "start_time": "2026-05-07T11:43:26.720634",
      "status": "completed"
     },
     "tags": []
@@ -2418,8 +2432,27 @@
       "\n",
       "\n",
       "=== Proprietes du produit ===\n",
+      "  http://schema.org/description  Cours complet sur le Web Semantique, de RDF aux graphes de connaissances\n",
+      "  http://schema.org/educationalLevel University\n",
+      "  http://schema.org/image        https://example.org/images/semantic-web-course.png\n",
+      "  http://schema.org/name         Semantic Web avec Python et .NET\n",
+      "  http://schema.org/teaches      RDF et triples\n",
+      "  http://schema.org/teaches      SPARQL queries\n",
+      "  http://schema.org/teaches      OWL ontologies\n",
+      "  http://schema.org/teaches      SHACL validation\n",
+      "  http://schema.org/teaches      JSON-LD et Schema.org\n",
+      "  http://schema.org/teaches      Knowledge Graphs\n",
+      "  http://schema.org/teaches      GraphRAG\n",
+      "  rdf:type                       http://schema.org/Product\n",
       "\n",
       "=== Sujets enseignes ===\n",
+      "  1. RDF et triples\n",
+      "  2. SPARQL queries\n",
+      "  3. OWL ontologies\n",
+      "  4. SHACL validation\n",
+      "  5. JSON-LD et Schema.org\n",
+      "  6. Knowledge Graphs\n",
+      "  7. GraphRAG\n",
       "\n",
       "=== Representation Turtle ===\n",
       "@prefix schema1: <http://schema.org/> .\n",
@@ -2462,7 +2495,7 @@
     "\n",
     "# Requete SPARQL : extraire les informations du produit\n",
     "query_product = \"\"\"\n",
-    "PREFIX schema: <https://schema.org/>\n",
+    "PREFIX schema: <http://schema.org/>\n",
     "\n",
     "SELECT ?property ?value\n",
     "WHERE {\n",
@@ -2483,7 +2516,7 @@
     "\n",
     "# Requete : sujets enseignes\n",
     "query_teaches = \"\"\"\n",
-    "PREFIX schema: <https://schema.org/>\n",
+    "PREFIX schema: <http://schema.org/>\n",
     "\n",
     "SELECT ?topic\n",
     "WHERE {\n",
@@ -2508,10 +2541,10 @@
    "id": "interpretation-product-rdflib",
    "metadata": {
     "papermill": {
-     "duration": 0.011189,
-     "end_time": "2026-05-02T00:02:38.194671+00:00",
+     "duration": 0.008052,
+     "end_time": "2026-05-07T11:43:26.936736",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.183482+00:00",
+     "start_time": "2026-05-07T11:43:26.928684",
      "status": "completed"
     },
     "tags": []
@@ -2532,10 +2565,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.016567,
-     "end_time": "2026-05-02T00:02:38.221624+00:00",
+     "duration": 0.008585,
+     "end_time": "2026-05-07T11:43:26.954530",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.205057+00:00",
+     "start_time": "2026-05-07T11:43:26.945945",
      "status": "completed"
     },
     "tags": []
@@ -2562,16 +2595,16 @@
    "id": "exercise1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:38.261834Z",
-     "iopub.status.busy": "2026-05-02T00:02:38.261276Z",
-     "iopub.status.idle": "2026-05-02T00:02:38.267024Z",
-     "shell.execute_reply": "2026-05-02T00:02:38.266274Z"
+     "iopub.execute_input": "2026-05-07T11:43:26.980210Z",
+     "iopub.status.busy": "2026-05-07T11:43:26.979876Z",
+     "iopub.status.idle": "2026-05-07T11:43:26.987612Z",
+     "shell.execute_reply": "2026-05-07T11:43:26.986000Z"
     },
     "papermill": {
-     "duration": 0.022447,
-     "end_time": "2026-05-02T00:02:38.268370+00:00",
+     "duration": 0.020612,
+     "end_time": "2026-05-07T11:43:26.989294",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.245923+00:00",
+     "start_time": "2026-05-07T11:43:26.968682",
      "status": "completed"
     },
     "tags": []
@@ -2624,10 +2657,10 @@
    "id": "exercise2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.008606,
-     "end_time": "2026-05-02T00:02:38.286680+00:00",
+     "duration": 0.01048,
+     "end_time": "2026-05-07T11:43:27.009404",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.278074+00:00",
+     "start_time": "2026-05-07T11:43:26.998924",
      "status": "completed"
     },
     "tags": []
@@ -2658,16 +2691,16 @@
    "id": "exercise2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:38.309400Z",
-     "iopub.status.busy": "2026-05-02T00:02:38.308060Z",
-     "iopub.status.idle": "2026-05-02T00:02:38.313850Z",
-     "shell.execute_reply": "2026-05-02T00:02:38.313093Z"
+     "iopub.execute_input": "2026-05-07T11:43:27.038762Z",
+     "iopub.status.busy": "2026-05-07T11:43:27.037916Z",
+     "iopub.status.idle": "2026-05-07T11:43:27.045056Z",
+     "shell.execute_reply": "2026-05-07T11:43:27.043187Z"
     },
     "papermill": {
-     "duration": 0.018506,
-     "end_time": "2026-05-02T00:02:38.315172+00:00",
+     "duration": 0.022833,
+     "end_time": "2026-05-07T11:43:27.047042",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.296666+00:00",
+     "start_time": "2026-05-07T11:43:27.024209",
      "status": "completed"
     },
     "tags": []
@@ -2705,10 +2738,10 @@
    "id": "exercise3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.013865,
-     "end_time": "2026-05-02T00:02:38.344462+00:00",
+     "duration": 0.01359,
+     "end_time": "2026-05-07T11:43:27.072388",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.330597+00:00",
+     "start_time": "2026-05-07T11:43:27.058798",
      "status": "completed"
     },
     "tags": []
@@ -2732,16 +2765,16 @@
    "id": "exercise3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T00:02:38.364579Z",
-     "iopub.status.busy": "2026-05-02T00:02:38.364267Z",
-     "iopub.status.idle": "2026-05-02T00:02:38.369308Z",
-     "shell.execute_reply": "2026-05-02T00:02:38.368372Z"
+     "iopub.execute_input": "2026-05-07T11:43:27.098477Z",
+     "iopub.status.busy": "2026-05-07T11:43:27.098126Z",
+     "iopub.status.idle": "2026-05-07T11:43:27.103352Z",
+     "shell.execute_reply": "2026-05-07T11:43:27.102377Z"
     },
     "papermill": {
-     "duration": 0.01731,
-     "end_time": "2026-05-02T00:02:38.371098+00:00",
+     "duration": 0.01976,
+     "end_time": "2026-05-07T11:43:27.105394",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.353788+00:00",
+     "start_time": "2026-05-07T11:43:27.085634",
      "status": "completed"
     },
     "tags": []
@@ -2767,7 +2800,7 @@
     "\n",
     "# TODO : Requete SPARQL pour extraire les ingredients\n",
     "# query_ingredients = \"\"\"\n",
-    "# PREFIX schema: <https://schema.org/>\n",
+    "# PREFIX schema: <http://schema.org/>\n",
     "# SELECT ?ingredient\n",
     "# WHERE {\n",
     "#     ?recipe a schema:Recipe .\n",
@@ -2783,10 +2816,10 @@
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.02454,
-     "end_time": "2026-05-02T00:02:38.429711+00:00",
+     "duration": 0.014108,
+     "end_time": "2026-05-07T11:43:27.132048",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.405171+00:00",
+     "start_time": "2026-05-07T11:43:27.117940",
      "status": "completed"
     },
     "tags": []
@@ -2834,10 +2867,10 @@
    "id": "footer-nav",
    "metadata": {
     "papermill": {
-     "duration": 0.024303,
-     "end_time": "2026-05-02T00:02:38.472153+00:00",
+     "duration": 0.010471,
+     "end_time": "2026-05-07T11:43:27.156513",
      "exception": false,
-     "start_time": "2026-05-02T00:02:38.447850+00:00",
+     "start_time": "2026-05-07T11:43:27.146042",
      "status": "completed"
     },
     "tags": []
@@ -2869,18 +2902,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.476631,
-   "end_time": "2026-05-02T00:02:38.715364+00:00",
+   "duration": 25.390757,
+   "end_time": "2026-05-07T11:43:27.516295",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SW-9-Python-JSONLD.ipynb",
-   "output_path": "SW-9-Python-JSONLD.ipynb",
+   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-9-Python-JSONLD.ipynb",
+   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-9-Python-JSONLD_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-02T00:02:32.238733+00:00",
+   "start_time": "2026-05-07T11:43:02.125538",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary
- **SW-5**: Migrate deprecated `SparqlRemoteEndpoint` to async `SparqlQueryClient` (dotNetRDF 3.x API)
- **SW-9**: Fix SPARQL namespace mismatch — rdflib normalizes `https://schema.org/` to `http://schema.org/`, causing empty query results
- **SW-13**: Fix `reasonable` library API changes (`Reasonable` -> `PyReasoner`, `rdflib.Graph()` for owlready2 compatibility)

## Fixes per notebook

### SW-5-CSharp-LinkedData.ipynb
- 4 code cells + 4 markdown cells updated
- `SparqlRemoteEndpoint` -> `SparqlQueryClient` with `HttpClient` + User-Agent
- `endpoint.QueryWithResultSet()` -> `await client.QueryWithResultSetAsync()`
- `endpoint.QueryWithResultGraph()` -> `await client.QueryWithResultGraphAsync()`
- DBpedia and Wikidata connections now use proper User-Agent headers

### SW-9-Python-JSONLD.ipynb
- 3 SPARQL PREFIX declarations fixed: `<https://schema.org/>` -> `<http://schema.org/>`
- Cells `sparql-jsonld` and `load-product-rdflib` now return correct results (were empty before)
- Re-executed via Papermill (28.2s, all cells PASS)

### SW-13-Python-Reasoners.ipynb
- `from reasonable import Reasonable` -> `from reasonable import PyReasoner`
- `Graph()` -> `rdflib.Graph()` (owlready2 shadowing fix)
- `reasoner.reason()` returns inferred triples, added loop to add them back
- Re-executed via Papermill (10.9s, all cells PASS)

## Test plan
- [x] SW-9 Papermill execution: SUCCESS (28.2s)
- [x] SW-13 Papermill execution: SUCCESS (10.9s)
- [ ] SW-5 .NET cell-by-cell execution (requires .NET kernel — outputs cleared on modified cells, need re-execution on machine with .NET Interactive)
- [x] No `raise NotImplementedError` or intentional errors introduced
- [x] No regressions in existing content (anti-regression check: only deprecated API replaced, no solution cells affected)

Refs #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)