### PR TITLE
fix(lean): prover debug logging + cumulative size guard

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -336,6 +336,7 @@ class AutonomousProver:
 
         # Main loop — single event loop for the entire session
         session_start = time.time()
+        original_file_content = Path(filepath).read_text(encoding="utf-8")
         compile_data = {}
         context_history = [context_msg]  # ACCUMULATE instead of replace
         proof_tactics_found = []  # Lean-9 _proof_tactics_found tracking
@@ -364,8 +365,24 @@ class AutonomousProver:
 
                 try:
                     response = await agent.run(full_context)
+                    # Debug: inspect response structure
+                    resp_type = type(response).__name__
+                    has_msgs = hasattr(response, 'messages')
+                    n_msgs = len(response.messages) if has_msgs and response.messages else 0
+                    print(f"  [DEBUG] Response type={resp_type}, has_messages={has_msgs}, n_messages={n_msgs}", flush=True)
+                    if n_msgs > 0:
+                        first_msg = response.messages[0]
+                        print(f"  [DEBUG] First msg type={type(first_msg).__name__}, has_contents={hasattr(first_msg, 'contents')}", flush=True)
+                        if hasattr(first_msg, 'contents') and first_msg.contents:
+                            print(f"  [DEBUG] First msg {len(first_msg.contents)} contents, types={[getattr(c, 'type', '?') for c in first_msg.contents[:5]]}", flush=True)
+                        elif hasattr(first_msg, 'text'):
+                            print(f"  [DEBUG] First msg has .text ({len(getattr(first_msg, 'text', '') or '')} chars)", flush=True)
+                        else:
+                            print(f"  [DEBUG] First msg attrs={[a for a in dir(first_msg) if not a.startswith('_')][:10]}", flush=True)
+                    else:
+                        print(f"  [DEBUG] Response attrs={[a for a in dir(response) if not a.startswith('_')][:10]}", flush=True)
                     response_text = ""
-                    if hasattr(response, 'messages') and response.messages:
+                    if has_msgs and n_msgs > 0:
                         last = response.messages[-1]
                         response_text = last.text if hasattr(last, 'text') else str(last)
                     # Log FULL agent response: thinking, tool calls, text
@@ -423,6 +440,19 @@ class AutonomousProver:
                 sorry_line_set_new = {i + 1 for i, l in enumerate(
                     Path(filepath).read_text(encoding="utf-8").split("\n")) if "sorry" in l}
                 state.local_lemmas = extract_local_lemmas(filepath, sorry_line_set_new)
+
+                # Cumulative file size guard — detect multi-edit rewrites that bypass per-edit guard
+                current_content = Path(filepath).read_text(encoding="utf-8")
+                original_len = len(original_file_content)
+                current_len = len(current_content)
+                if original_len > 0:
+                    cumulative_ratio = abs(current_len - original_len) / original_len
+                    if cumulative_ratio > 0.5:
+                        print(f"  CUMULATIVE SIZE GUARD: file changed {cumulative_ratio:.0%} "
+                              f"({current_len} vs {original_len} chars). RESTORING original.", flush=True)
+                        Path(filepath).write_text(original_file_content, encoding="utf-8")
+                        current_sorry = original_sorry_count
+                        state.best_sorry_count = min(state.best_sorry_count, original_sorry_count)
 
                 # Phase transitions — from Lean-9 ProofPhase routing
                 if compile_data.get("success") and current_sorry == 0:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/trace.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/trace.py
@@ -119,14 +119,21 @@ class TraceLogger:
         # Log usage if available
         if hasattr(response, 'usage_details') and response.usage_details:
             usage = response.usage_details
-            self.log(
-                agent=agent, role="usage",
-                content=f"tokens: in={usage.input_token_count}, out={usage.output_token_count}",
-                duration_s=duration_s,
-                tokens={"input": usage.input_token_count,
-                        "output": usage.output_token_count,
-                        "total": (usage.input_token_count or 0) + (usage.output_token_count or 0)},
-            )
+            try:
+                if isinstance(usage, dict):
+                    in_tok = usage.get('input_token_count') or usage.get('input_tokens', 0)
+                    out_tok = usage.get('output_token_count') or usage.get('output_tokens', 0)
+                else:
+                    in_tok = getattr(usage, 'input_token_count', None) or 0
+                    out_tok = getattr(usage, 'output_token_count', None) or 0
+                self.log(
+                    agent=agent, role="usage",
+                    content=f"tokens: in={in_tok}, out={out_tok}",
+                    duration_s=duration_s,
+                    tokens={"input": in_tok, "output": out_tok, "total": in_tok + out_tok},
+                )
+            except Exception:
+                pass
 
     def _extract_reasoning_text(self, content) -> str:
         """Extract reasoning text from a text_reasoning Content item."""


### PR DESCRIPTION
## Summary
- Add response structure debug logging to diagnose missing thinking traces in prover runs
- Add cumulative file size guard that detects multi-edit rewrites bypassing the per-edit guard
- Fix `usage_details` crash when response returns dict instead of object with attributes
- Key finding: z.ai / GLM-5.1 does not expose `text_reasoning` content in Agent Framework responses

## Context
After the thinking trace capture was added (PR #791), a test run showed no thinking traces were captured. Debug logging revealed the LLM response has 81 messages with `function_call` contents but zero `text_reasoning` — the reasoning is done internally by GLM-5.1 but not returned via the z.ai API.

## Test plan
- [x] Ran prover 1 iteration with debug logging — confirmed response structure diagnosis
- [x] Sorry guard worked (blocked 6 sorry attempts multiple times)
- [x] Cumulative size guard not triggered in this run (no multi-edit rewrite)
- [x] usage_details dict fix tested (no more crash on token logging)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>