### PR TITLE
docs(rules): add SC-22 and SC-11 to audit false positives

### DIFF
--- a/.claude/rules/audit-reassessment.md
+++ b/.claude/rules/audit-reassessment.md
@@ -84,6 +84,8 @@ NanoClaw systematically misidentifies:
 - M-34 Video/01-3-Qwen-VL (9/10 exec 7 outputs)
 - M-40 IIT-Intro_to_PyPhi (11/11 exec 10 outputs 0 err)
 - M-68 App-9b-EdgeDetection-CSharp (11/11 exec 11 outputs 0 err)
+- SC-22 Solana-Anchor (6/6 exec 0 err — print-based demos are only viable approach for Solana/Rust in Python kernel)
+- SC-11 LLM-Assisted (15/15 exec 0 err — exercise stubs correctly have empty outputs)
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- Reassessed SC-22 (Solana-Anchor) and SC-11 (LLM-Assisted) per audit reassessment protocol
- Both notebooks: 100% execution, 0 errors, complete pedagogical content
- SC-22 print-based demos are the only viable approach for Solana/Rust in Python kernel
- SC-11 exercise stubs correctly have empty outputs (C.1 compliant)
- Added to confirmed false positives list in audit-reassessment.md

## Track
Cycle 7 Track H — SC-22 / SC-11 DRAFT documentation

## Test plan
- [x] Mechanical verification: SC-22 = 6/6 exec 0 err, SC-11 = 15/15 exec 0 err
- [x] Pedagogical verification: both have complete content, interpretation sections, exercises
- [x] Classification: FALSE POSITIVE per protocol Step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>