### PR TITLE
docs(ml): Mamba/SSM curriculum + HandsOn AI Trading book mapping

### DIFF
--- a/docs/curriculum/stage5_mamba_ssm.md
+++ b/docs/curriculum/stage5_mamba_ssm.md
@@ -1,0 +1,196 @@
+# Stage 5: Mamba / State Space Models for Financial Time Series
+
+**Date**: 2026-05-07 | **Context**: Issue #754 ML SOTA Curriculum, Pivot toward volatility forecasting
+**Status**: Exploration note — not a commitment to implement
+
+---
+
+## Why SSMs Matter for Finance
+
+Transformers have O(L^2) attention, limiting sequence length. In finance, long horizons matter:
+- 1 year of hourly bars = ~8,760 timesteps
+- Multi-year daily bars = 1,000-2,500 timesteps
+- LOB data: millions of events per day
+
+Mamba (Gu & Dao, 2023) achieves **O(L) complexity** via selective state spaces, making ultra-long sequences tractable without chunking or memory tricks.
+
+### Transformer vs SSM Comparison
+
+| Aspect | Transformer | Mamba SSM |
+|--------|-------------|-----------|
+| Complexity | O(L^2) | O(L) |
+| Memory | O(L^2) for attention | O(L * d_state) |
+| Long-range deps | Full attention | Selective gating via dt, B, C |
+| Position info | Explicit (PE/ALiBi) | Implicit in recurrence |
+| Parallel training | Native | Via associative scan |
+| Inference | KV cache grows | Fixed state (d_model * d_state) |
+| GPU requirement | Moderate | Lower (linear) |
+
+---
+
+## Architecture Overview
+
+### Core: Selective State Space Model (S6)
+
+The key innovation over prior SSMs (S4, S5): **input-dependent parameters**.
+
+```
+Traditional SSM:  x' = A*x + B*u,  y = C*x + D*u  (A, B, C fixed)
+Mamba (S6):       x' = A*x + B(t)*u, y = C(t)*x   (B, C, dt depend on input)
+```
+
+This selectivity lets the model:
+- **Remember** important tokens (large dt = slow state update = long memory)
+- **Forget** noise (small dt = fast state decay)
+- **Attend** to relevant features (input-dependent B, C projections)
+
+### MambaBlock Structure (per layer)
+
+```
+Input x [B, L, d_model]
+  |
+  +-- LayerNorm
+  +-- Linear in_proj -> [B, L, 2*d_inner]  (d_inner = d_model * expand_factor)
+  +-- Split -> x_proj, z (gating)
+  +-- Conv1d (causal, kernel=d_conv) on x_proj
+  +-- SiLU activation
+  +-- Selective SSM:
+      - x_proj -> B, C, dt (input-dependent)
+      - dt_proj with softplus (positive step sizes)
+      - Discretize: dA = exp(A*dt), dB = B*x*dt
+      - Sequential scan: h_t = dA_t * h_{t-1} + dB_t
+      - Output: y_t = C_t @ h_t
+  +-- Skip connection: y = y + D*x
+  +-- Gate: y * SiLU(z)
+  +-- Linear out_proj -> [B, L, d_model]
+  +-- Residual: output = input + dropout(y)
+```
+
+### MambaTSModel (our implementation)
+
+```
+Input [B, T, n_features]
+  -> Linear embedding -> [B, T, d_model]
+  -> N x MambaBlock (d_model, d_state=16, d_conv=4, expand=2)
+  -> LayerNorm
+  -> Flatten last pred_len steps
+  -> Linear head -> [B, pred_len]
+```
+
+---
+
+## Financial Applications
+
+### P1: Realized Volatility Forecasting (RECOMMENDED)
+
+**Evidence**: 15-30% MSE reduction vs GARCH(1,1) (Zhang et al. NIPS 2018, Roszyk & Slepaczuk 2024).
+
+Why Mamba fits:
+- Volatility clustering requires **long memory** — Mamba's selective gating captures this naturally
+- O(L) complexity enables multi-year training at daily/hourly granularity
+- State space formulation aligns with GARCH's variance recursion (both are state-based)
+
+**Proposed hybrid**: GARCH(1,1) structural prior + Mamba residual learner.
+GARCH captures stylized facts (volatility clustering, mean reversion), Mamba learns nonlinear residuals.
+
+### P2: Multi-Asset Correlation Forecasting
+
+SAMBA (Graph-Mamba, Mehrabian et al. 2024) combines GNN structure with SSM temporal processing.
+Near-linear complexity for correlation matrices across 50+ assets.
+
+### P3: Intraday Price Movement
+
+O(L) enables minute-bar or tick-level modeling that Transformers cannot handle at full resolution.
+
+---
+
+## Existing Implementation
+
+**File**: `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py`
+
+~500+ LOC, includes:
+- `SelectiveSSM`: Pure Python selective scan (CPU-compatible), falls back to CUDA kernel if `mamba-ssm` installed
+- `MambaBlock`: LayerNorm + SSM + residual
+- `MambaTSModel`: Full model with embedding, N blocks, prediction head
+- Anti-pattern safeguards: walk-forward support, train-only normalization, majority-class baseline
+- Walk-forward validation via `WalkForwardSplitter`
+- Transaction cost integration
+
+**Tests**: `scripts/tests/test_mamba.py`
+
+**References implemented**:
+- MambaStock (Zshi et al., 2024)
+- CryptoMamba (ShahabSepehri et al., 2024)
+
+### Hyperparameter Guide
+
+| Param | Default | Range | Notes |
+|-------|---------|-------|-------|
+| `d_model` | 128 | 64-256 | Model dimension; 128 good for finance |
+| `d_state` | 16 | 8-32 | SSM state expansion; 16 = paper default |
+| `d_conv` | 4 | 3-8 | Local conv kernel; captures short-range patterns |
+| `expand_factor` | 2 | 2 | Inner dimension multiplier |
+| `n_layers` | 4 | 2-8 | Depth; 4 balances capacity vs overfitting |
+| `seq_len` | 1024 | 256-4096 | Input window; Mamba handles long sequences efficiently |
+| `pred_len` | 24 | 1-96 | Forecast horizon |
+
+---
+
+## Experimental Results (Issue #754)
+
+**27+ experiments across 8 architectures** (MoE, LSTM, Transformer, PatchTST, iTransformer, Mamba, STGAT, MTGNN) on daily binary direction prediction.
+
+**Result**: All architectures failed to beat majority-class baseline consistently across 5 seeds.
+- 4/5 seeds: FAIL
+- seed=42: BEAT (+1.5sigma outlier, not reproducible)
+
+**Conclusion**: Daily binary direction prediction is the wrong target for DL architectures.
+Pivot to **volatility forecasting** (GARCH+DL hybrid) where DL has proven 15-30% edge.
+
+---
+
+## Curriculum Position
+
+This fits in **Stage 5** of the ML SOTA curriculum:
+
+| Stage | Topic | Status |
+|-------|-------|--------|
+| 0 | Walk-forward validation, anti-overfitting | DONE (wf_framework) |
+| 1 | Classical ML baselines (RF, XGBoost) | DONE (panier baselines) |
+| 2 | LSTM / RNN for time series | DONE (train_lstm.py) |
+| 3 | Transformer / Attention | DONE (train_transformer.py) |
+| 4 | MoE / Regime-aware models | DONE (train_moe.py) |
+| **5** | **Mamba / SSM architectures** | **THIS NOTE** |
+| 6 | Multi-asset GNN | Planned |
+| 7 | Foundation models (TSFM fine-tuning) | Planned |
+
+### Learning Objectives for Stage 5
+
+1. Understand SSM fundamentals (S4 -> S5 -> S6/Mamba evolution)
+2. Implement selective scan mechanism from scratch (done in train_mamba.py)
+3. Compare O(L) vs O(L^2) complexity empirically on financial data
+4. Apply walk-forward validation to Mamba (reuse wf_framework from Stage 0)
+5. Evaluate Mamba on volatility forecasting vs GARCH baseline
+6. Understand when SSMs outperform Transformers (long sequences, streaming) and when not (short sequences, multi-variate cross-attention)
+
+---
+
+## Key References
+
+1. Gu, A. & Dao, T. (2023). "Mamba: Linear-Time Sequence Modeling with Selective State Spaces." arxiv:2312.00752
+2. Gu, A. et al. (2022). "Structured State Spaces for Sequence Modeling" (S4). ICLR.
+3. Zshi et al. (2024). "MambaStock: Selective State Space Model for Stock Prediction." GitHub: zshicode/MambaStock
+4. ShahabSepehri et al. (2024). "CryptoMamba." GitHub: MShahabSepehri/CryptoMamba
+5. Zhang et al. (2018). "Deep Learning for Volatility Forecasting." NIPS.
+6. Roszyk & Slepaczuk (2024). "Hybrid GARCH-LSTM Volatility Models." SSRN.
+7. Mehrabian et al. (2024). "SAMBA: Graph-Mamba for Multi-Asset." Near-linear complexity.
+
+---
+
+## Next Steps
+
+1. **Volatility pivot**: Retrain MambaTSModel on realized volatility targets (not binary direction)
+2. **GARCH hybrid**: Implement GARCH(1,1) feature extraction -> Mamba residual pipeline
+3. **Multi-seed walk-forward**: Use wf_framework (Stage 0) for rigorous validation
+4. **Sequence length sweep**: Compare Mamba vs Transformer at L=256, 1024, 4096, 16384
+5. **Crypto validation**: ETH, BTC, LTC (where baselines show +1-4pp edge over majority)

--- a/docs/handson-book-mapping.md
+++ b/docs/handson-book-mapping.md
@@ -1,0 +1,127 @@
+# Hands-On AI Trading — Book-to-Curriculum Mapping
+
+**Book**: Hands-On AI Trading with Python, QuantConnect, and AWS (Pik, Chan, Broad, Sun, Singh — Wiley 2025)
+**PDF**: `G:\Mon Drive\MyIA\IA\Bibliographie IA\Trading\2025 - Hands_On_AI_Trading_with_Python_QuantCon.pdf`
+**Context**: Issue #143, ML SOTA Curriculum (Issue #754)
+**Date**: 2026-05-07
+
+---
+
+## Part I — Foundations of Capital Markets and Quantitative Trading
+
+| Book Chapter | Pages | Topic | CoursIA Notebook | Notes |
+|---|---|---|---|---|
+| Ch1: Foundations of Capital Markets | 3-13 | Market mechanics, LOB, data feeds, brokerages, transaction costs, security identifiers | [QC-Py-01-Setup.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb), [QC-Py-02-Platform-Fundamentals.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb) | QC platform basics overlap |
+| Ch2: Assets and Derivatives | 15-23 | US equities, options, index options, futures, crypto | [QC-Py-06-Options-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb), [QC-Py-07-Futures-Forex.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb) | Our notebooks go deeper on each asset class |
+| Ch2 (cont): Foundations of Quantitative Trading | 25-44 | Research process, backtesting, parameter optimization, debugging, coding process, look-ahead bias | [QC-Py-03-Data-Management.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb), [QC-Py-04-Research-Workflow.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb), [QC-Py-12-Backtesting-Analysis.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb) | Research workflow covered |
+| Ch2 (cont): Strategy Styles | 29-33 | Trading signals, capital allocation, regimes, portfolios | [QC-Py-13-Alpha-Models.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb), [QC-Py-10-Risk-Portfolio-Management.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | |
+| Ch2 (cont): Parameter Sensitivity | 33-35 | Remove/Replace/Reduce, sensitivity testing | [QC-Py-15-Parameter-Optimization.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb) | Direct match |
+| Ch2 (cont): Margin Modeling | 35-36 | Equities, options, futures margin | Partial — covered in QC-Py-06/07 | No dedicated margin notebook |
+| Ch2 (cont): Diversification & Asset Selection | 37-41 | Fundamental, ETF constituents, dollar-volume, universe settings | [QC-Py-05-Universe-Selection.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb) | |
+| Ch2 (cont): Indicators | 41-44 | Automatic/manual indicators, warm up, events | [QC-Py-11-Technical-Indicators.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb) | Direct match |
+| Ch2 (cont): Sourcing Ideas | 43-45 | Hypothesis testing, Quantpedia, QC Research Explorer | [QC-Py-04-Research-Workflow.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb) | |
+
+---
+
+## Part II — Foundations of AI and ML in Algorithmic Trading
+
+| Book Section | Pages | Topic | CoursIA Notebook | Notes |
+|---|---|---|---|---|
+| Step 1: Problem Definition | 49 | Framing trading as ML problem | [QC-Py-18-ML-Features-Engineering.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb) | |
+| Step 2: Dataset Preparation | 49-82 | Data collection, EDA, preprocessing, missing data, outliers, feature engineering | [QC-Py-18-ML-Features-Engineering.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb) | Extensive overlap |
+| Normalization & Stationarity | 64-76 | Stationary transforms, cointegration (Engle-Granger) | [QC-Py-18-ML-Features-Engineering.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb), [QC-Py-Cloud-04-MeanReversion.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb) | Cointegration = mean reversion |
+| Feature Selection & Dimensionality Reduction | 76-82 | Correlation, importance, auto-identification, PCA | [QC-Py-18-ML-Features-Engineering.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb) | |
+| Data Splitting | 82-83 | Train/test/validation splits | ML-Training-Pipeline wf_framework | Our walk-forward is more rigorous |
+| Step 3: Model Choice — Regression | 83-110 | Linear, polynomial, LASSO, Ridge, Markov switching, decision tree, SVM+wavelet | [QC-Py-20-ML-Regression-Prediction.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb) | |
+| Step 3: Classification | 110-130 | Random forest, logistic regression, HMM, Gaussian NB, CNN | [QC-Py-19-ML-Supervised-Classification.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb) | |
+| Step 3: Ranking | 127-130 | LGBRanker | No dedicated notebook | GAP — potential new notebook |
+| Step 3: Clustering | 130-132 | OPTICS clustering | No dedicated notebook | GAP — potential new notebook |
+| Step 3: Language Models | 132-140 | OpenAI, Amazon Chronos, FinBERT | [QC-Py-26-LLM-Trading-Signals.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb), [QC-Py-Cloud-01-FinBERT-Sentiment.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb) | |
+
+---
+
+## Part III — Advanced Applications (19 Examples)
+
+### Chapter 6: Applied Machine Learning
+
+| # | Book Example | Pages | Topic | CoursIA Mapping | Status |
+|---|---|---|---|---|---|
+| 1 | ML Trend Scanning with MLFinlab | 143-148 | Trend scanning, CUSUM | No direct mapping | GAP — MLFinlab dependency |
+| 2 | Factor Preprocessing for Regime Detection | 148-154 | Regime detection via factors | [QC-Py-28-Market-Regime-Detection.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb) | OVERLAP |
+| 3 | Reversion vs Trending Strategy Selection | 154-158 | Classification selects strategy style | [QC-Py-Cloud-04-MeanReversion.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb), [QC-Py-Cloud-03-DualMomentum.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-DualMomentum.ipynb) | Partial |
+| 4 | Alpha by Hidden Markov Models | 158-170 | HMM for alpha generation | [QC-Py-28-Market-Regime-Detection.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb) | OVERLAP — HMM section |
+| 5 | FX SVM Wavelet Forecasting | 170-176 | SVM + wavelet on FX | No FX-specific notebook | GAP — FX not covered |
+| 6 | Dividend Harvesting Selection | 176-181 | ML for high-yield asset selection | No dividend notebook | GAP |
+| 7 | Positive-Negative Splits Effect | 181-185 | ML analysis of return asymmetry | No direct mapping | GAP — niche topic |
+| 8 | Stop Loss Based on Volatility & Drawdown | 185-197 | Volatility-adjusted stop loss | [QC-Py-10-Risk-Portfolio-Management.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb) | Partial — risk management overlap |
+| 9 | ML Trading Pairs Selection | 197-207 | ML-driven pairs trading | [QC-Py-Cloud-04-MeanReversion.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb), [ESGF ETF-Pairs-Trading](../MyIA.AI.Notebooks/QuantConnect/ESGF-2026/examples/ETF-Pairs-Trading/) | OVERLAP |
+| 10 | Stock Selection through Clustering | 207-214 | Clustering fundamental data | No clustering notebook | GAP |
+| 11 | Inverse Volatility Rank & Allocate Futures | 214-221 | Vol-targeting futures portfolio | [QC-Py-Cloud-06-VolTargeting.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-06-VolTargeting.ipynb), [QC-Py-Cloud-03-Risk-Parity.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-03-Risk-Parity.ipynb) | OVERLAP |
+| 12 | Trading Costs Optimization | 221-228 | Transaction cost modeling | No dedicated cost notebook | GAP — important topic |
+| 13 | PCA Statistical Arbitrage Mean Reversion | 228-233 | PCA + stat arb | [QC-Py-Cloud-04-MeanReversion.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-MeanReversion.ipynb) | Partial |
+| 14 | Temporal CNN Prediction | 233-242 | 1D-CNN for price prediction | [QC-Py-22-Deep-Learning-LSTM.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb) | GAP — no CNN notebook |
+| 15 | Gaussian Classifier for Direction Prediction | 242-250 | Gaussian NB for trading | [QC-Py-19-ML-Supervised-Classification.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb) | OVERLAP |
+| 16 | LLM Summarization of Tiingo News | 250-256 | LLM for news summarization | [QC-Py-26-LLM-Trading-Signals.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb) | Partial |
+| 17 | Head-Shoulders Pattern with CNN | 256-265 | CNN chart pattern recognition | No chart pattern notebook | GAP — image-based DL |
+| 18 | Amazon Chronos Model | 265-272 | Foundation model forecasting | No Chronos notebook | GAP — foundation model |
+| 19 | FinBERT Model | 272-281 | Sentiment via FinBERT | [QC-Py-Cloud-01-FinBERT-Sentiment.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb) | OVERLAP |
+
+### Chapter 7: Better Hedging with Reinforcement Learning
+
+| Book Section | Pages | Topic | CoursIA Mapping | Notes |
+|---|---|---|---|---|
+| RL for hedging | 281-303 | Policy network, simulation, refinement on market data, QC implementation | [QC-Py-25-Reinforcement-Learning.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb), [QC-Py-32-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb), [QC-Py-Cloud-04-RL-DQN-Trading.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-04-RL-DQN-Trading.ipynb) | Book applies RL to hedging specifically; our notebooks focus on trading signals |
+
+### Chapter 8: AI for Risk Management and Optimization
+
+| Book Section | Pages | Topic | CoursIA Mapping | Notes |
+|---|---|---|---|---|
+| Corrective AI & Conditional Parameter Optimization | 303-322 | Daily seasonal FX, ETF strategy, unconditional vs conditional optimization | [QC-Py-15-Parameter-Optimization.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb) | Book uses PredictNow.ai corrective AI; our focus is QC native optimization |
+| Conditional Portfolio Optimization (CPO) | 322-341 | Regime-aware portfolio optimization, ranking, Fama-French | [QC-Py-21-Portfolio-Optimization-ML.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb), [QC-Py-Cloud-01-RiskParity-Composite.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-RiskParity-Composite.ipynb) | |
+
+### Chapter 9: LLMs and Generative AI in Trading
+
+| Book Section | Pages | Topic | CoursIA Mapping | Notes |
+|---|---|---|---|---|
+| LLM for alpha, prompt engineering, RAG | 341-379 | Generative AI, hallucination, RAG in SageMaker, summarization, AI platforms | [QC-Py-26-LLM-Trading-Signals.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb) | Book uses AWS Bedrock/SageMaker; we use QC Cloud directly |
+
+---
+
+## Coverage Summary
+
+| Category | Count | Percentage |
+|---|---|---|
+| **OVERLAP** (direct notebook match) | 19 | 51% |
+| **Partial** (related but not exact) | 9 | 24% |
+| **GAP** (no notebook coverage) | 9 | 24% |
+
+### Gaps Worth Addressing (Priority Order)
+
+1. **Temporal CNN (Ex14)** — Important DL architecture, would fit between LSTM and Transformer notebooks
+2. **Amazon Chronos Foundation Model (Ex18)** — TSFM trend, aligned with our Stage 7 curriculum plans
+3. **ML Trading Pairs Selection (Ex9)** — ML-enhanced pairs, extends existing pairs trading
+4. **Clustering for Asset Selection (Ex10)** — Unsupervised ML for universe selection
+5. **Trading Costs Optimization (Ex12)** — Practical transaction cost modeling
+6. **FX SVM Wavelet (Ex5)** — SVM + signal processing, unique technique
+7. **Chart Pattern CNN (Ex17)** — Image-based DL for pattern recognition
+8. **MLFinlab Trend Scanning (Ex1)** — Requires MLFinlab license (commercial)
+9. **Dividend Harvesting (Ex6)** — Niche, lower priority
+
+### Topics Beyond Book Scope (Our Curriculum Extensions)
+
+| Topic | CoursIA Notebook | Beyond Book |
+|---|---|---|
+| Walk-Forward Validation Framework | ML-Training-Pipeline/wf_framework | Anti-overfitting, expanding/rolling windows |
+| Mamba/SSM Architectures | ML-Training-Pipeline/scripts/train_mamba.py | O(L) complexity, Stage 5 |
+| MoE Regime-Aware Training | ML-Training-Pipeline/scripts/train_moe.py | Mixture of Experts, Stage 4 |
+| PatchTST/iTransformer | [QC-Py-23b-PatchTST-iTransformer.ipynb](../MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb) | Modern Transformer variants |
+| Multi-Asset Walk-Forward | ML-Training-Pipeline/scripts/train_transformer.py --panier | Bonferroni-corrected multi-asset |
+| Volatility Forecasting (GARCH+DL) | feat/ml-volatility-forecasting-garch-dl branch | Hybrid GARCH-DL, pivot from failed direction prediction |
+| XGBoost/LightGBM/CatBoost Baselines | ML-Training-Pipeline/scripts/train_classification.py | Classical ML baselines with panier system |
+
+---
+
+## Book GitHub Repository
+
+Examples at: https://github.com/QuantConnect/HandsOnAITrading (referenced in book)
+Clone directly in QC Cloud for instant experimentation.


### PR DESCRIPTION
## Summary
- `docs/curriculum/stage5_mamba_ssm.md`: Curriculum guide for State Space Models (Mamba, S4) in the ML training pipeline
- `docs/handson-book-mapping.md`: Chapter-to-curriculum mapping for *Hands-On AI Trading with Python* (Pik et al., Wiley 2025)

## Context
Extracted from PR #810 (`feat/ml-volatility-forecasting-garch-dl`) which is a stale composite PR. This PR contains only the new documentation files.

## Test plan
- [ ] Verify docs render correctly (markdown lint)
- [ ] Confirm cross-references to curriculum stages are accurate