### PR TITLE
docs(rules): anti-complaisance harness — CLAUDE.md section G + pr-review-discipline.md

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -1,0 +1,105 @@
+# PR Review Discipline — anti-complaisance
+
+**Contexte** : règle créée 2026-05-08 après constat user que "vous êtes tous trop complaisants, on n'avance pas". Audit cycles 5-7 : 9/10 PRs nuit du 7→8 APPROVED par clusterManager-Myia sans contestation, dont #801 mega-composite 7183 lignes / 41 files, #806 +2 lignes, #807 +46 lignes doc, #791 du 7/05 +3561/-3543 prover refactor caché derrière "shapley sorry 2→1".
+
+Cette rule s'applique à **tous les reviewers**, humains et bots (clusterManager-Myia, jsboige bot, ai-01 coordinateur).
+
+## Critères CHANGES_REQUESTED obligatoires
+
+Un reviewer **DOIT** poster `state: CHANGES_REQUESTED` (pas COMMENTED, pas APPROVED) si **un seul** des points suivants est violé. Posting APPROVED malgré violation = complicité de complaisance.
+
+### A. Composites trop larges (split obligatoire)
+
+| Métrique | Seuil "split required" |
+|----------|------------------------|
+| `additions + deletions` | > 3000 lignes hors notebooks |
+| `changedFiles` | > 15 fichiers (hors `_output.ipynb` et données) |
+| Features distinctes mentionnées dans le `## Summary` | > 4 |
+| Fichiers de domaines différents (ML + Lean + GenAI mélangés) | > 1 domaine |
+
+Si dépassement : refuser le merge, exiger split en PRs cohérentes par feature.
+
+### B. Lean PRs : preuve de progrès vérifiable
+
+Toute PR touchant `*.lean` ou `agent_tests/prover/` **DOIT** inclure dans le body :
+1. `grep -c sorry` avant/après par fichier modifié
+2. Lien vers `Lake build SUCCESS` (CI ou commit local prouvable)
+3. Lien vers `Proof integrity SUCCESS` (axiom check)
+4. Si refactor du prover Python : justifier pourquoi le refactor est nécessaire pour le claim Lean (sinon split en 2 PRs)
+
+Sans ces 4 éléments, **CHANGES_REQUESTED** automatique.
+
+### C. ML PRs : multi-seed obligatoire
+
+Toute PR claim "BEATS" ou "improvement" sur métriques ML/trading **DOIT** inclure :
+1. Walk-forward 5-fold (pas single split)
+2. **≥4 seeds** parmi 0/1/7/42/99 (cf [feedback_multi_seed_required.md])
+3. Edge ≥ 2σ cross-seed sinon flag "noise"
+4. Comparaison à majority baseline + transaction costs (5bps SPY, 10bps crypto)
+5. **Pas de FAANG/Mag7** en training set (cf [dataset_paths.md])
+6. Verdict honnête : "BEATS" / "NO BEATS" / "INCONCLUSIVE" — pas de "promising"
+
+Single-seed ou single-fold = **CHANGES_REQUESTED** sauf si flag explicite `[POC]` dans le titre.
+
+### D. Notebook PRs : preuve d'exécution réelle
+
+Toute PR touchant `*.ipynb` **DOIT** inclure :
+1. Sortie de `papermill` ou kernel exec (pas juste "Papermill SUCCESS" — coller les premières lignes des outputs)
+2. Vérification 0 NotImplementedError (`grep -nE "raise NotImplementedError|assert False|1/0" <nb>`)
+3. Cellules code = `execution_count: <int>` ET `outputs: [...]` cohérents (règle C.2 CLAUDE.md)
+4. Diff ne supprime pas de cellules `# Solution` ou `# Exemple résolu` sans issue référencée (anti-régression)
+
+Pas de validation visuelle (PPTX/Slidev) jamais "OK" sur "j'ai screenshotté". Liens vers screenshots.
+
+### E. Documentation/Admin PRs : groupement obligatoire
+
+PRs dont le contenu = uniquement docs/README/CLAUDE.md/rules :
+- Single PR < 50 lignes : refuser, exiger groupement avec autre PR du même cycle
+- Single PR < 20 lignes : refuser systématiquement (commit direct sur main si trivial)
+- Multiple READMEs touchés sans cohérence cross-series : refuser, exiger un seul focus
+
+Anti-pattern visé : PRs micro qui inflate le compteur "PRs livrées" sans valeur réelle (#806 +2 lignes, #807 +46 lignes doc seul, etc.)
+
+### F. Audit reassessment / "false positive" PRs
+
+Reassessment d'un audit existant **DOIT** documenter :
+1. Critère exact violé par l'audit initial (cite le pattern reconnu)
+2. Méthodologie de vérification (pas "j'ai regardé visuellement")
+3. Au moins 3 cellules-types vérifiées avec preuve (sortie cell ou diff)
+
+Ré-classification "false positive" sans preuve = **CHANGES_REQUESTED**.
+
+### G. QC PRs : backtest obligatoire
+
+Toute PR touchant `MyIA.AI.Notebooks/QuantConnect/projects/` ou strategies cataloguées **DOIT** inclure :
+1. Backtest run (`create_compile` + `create_backtest` via MCP qc-mcp)
+2. Métriques Sharpe/CAGR/MaxDD reportées dans le body
+3. Période OOS distincte de training (pas de same-period leak)
+
+## Anti-pattern : APPROVED en lot batch 5 PRs en 5 minutes
+
+Si un reviewer APPROVE >3 PRs dans une fenêtre <10 minutes : flag automatique. Probable rubber-stamp.
+
+## Mention explicite des bots
+
+@clusterManager-Myia : ces critères s'appliquent à toi en priorité. Tu es la première ligne de défense. Si tu APPROVE une PR violant un des critères ci-dessus, le coordinateur ai-01 contestera explicitement et la PR sera bloquée jusqu'au split / fix.
+
+@jsboige (self-review bot) : self-approval sans valeur GitHub. Reste en COMMENTED + signale les violations dans le body comme tu le fais déjà.
+
+## Workflow ai-01 (coordinateur)
+
+Avant tout merge cascade, ai-01 lit :
+1. `gh pr view <N> --json files,additions,deletions,body,reviews` (pas juste mergeStateStatus)
+2. Vérifie chacun des critères A-G applicables
+3. Si violation : commente sur la PR (`gh pr comment <N>`) avec demande explicite (split, multi-seed, sorry-count, etc.) + ne merge pas
+4. Si conforme : merge avec mention dans le bilan dashboard
+
+Pas de merge en parallèle 5 PRs sans avoir lu les 5 bodies.
+
+## Liens
+
+- [feedback_multi_seed_required.md](../projects/d--CoursIA/memory/feedback_multi_seed_required.md)
+- [feedback_use_bot_reviews_for_dispatch.md](../projects/d--CoursIA/memory/feedback_use_bot_reviews_for_dispatch.md)
+- [feedback_review_state_filter.md](../projects/d--CoursIA/memory/feedback_review_state_filter.md)
+- [anti-regression.md](anti-regression.md)
+- CLAUDE.md section B (Reviews PR 5 points obligatoires)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 
 **Regles modulaires `.claude/rules/` (auto-loaded a chaque session)** — chaque section critique ci-dessous renvoie a la regle complete :
 - [.claude/rules/git-workflow.md](.claude/rules/git-workflow.md) - Branches, commits, force push (section A)
+- [.claude/rules/pr-review-discipline.md](.claude/rules/pr-review-discipline.md) - Critères CHANGES_REQUESTED obligatoires reviewers humains+bots (section B+G)
 - [.claude/rules/anti-regression.md](.claude/rules/anti-regression.md) - Patterns red-flag, audit historique (section D)
 - [.claude/rules/notebook-conventions.md](.claude/rules/notebook-conventions.md) - Manipulation, structure pedagogique, execution kernel (section C)
 - [.claude/rules/code-style.md](.claude/rules/code-style.md) - PEP 8, .NET 9.0, no emojis, langue (section E)
@@ -20,7 +21,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 
 ---
 
-## REGLES CRITIQUES (4 sections)
+## REGLES CRITIQUES (7 sections)
 
 ### A. Coordination & Git
 
@@ -50,7 +51,16 @@ Avant tout merge (y compris ses propres PRs) :
 
 **Si un seul point n'est pas verifie : ne pas merger.**
 
-**Honnetete des rapports** : pas de "DONE"/"fixed"/"validated" sans validation post-fix relancee. Si fix corrige 5/7 cellules : rapporter "5/7, 2 restantes identifiees", pas "DONE". Pas de markdown "RAPPORT"/"AUDIT" comme preuve sans code valide. Incidents 2026-04-08 (slides EPITA) et 2026-04-20 (Sudoku-8 + 27 cellules cassees rapportees DONE).
+**Preuves verifiables, pas mots-cles** :
+- "Papermill SUCCESS" en mot-cle = insuffisant. Coller les premieres lignes des outputs ou un lien CI.
+- "tests passed" sans lien CI = insuffisant. Lien obligatoire.
+- "sorry count -1" sans `lake build SUCCESS` post-modification = invalide. Build log obligatoire.
+- "BEATS" / "improvement" sans 5-fold walk-forward × ≥4 seeds + edge ≥ 2σ documente = invalide.
+- "Migration NOT recommended" / "FALSE POSITIVE" sans 3 cellules-types verifiees avec preuve = invalide.
+
+**Honnetete des rapports** : pas de "DONE"/"fixed"/"validated" sans validation post-fix relancee. Si fix corrige 5/7 cellules : rapporter "5/7, 2 restantes identifiees", pas "DONE". Si N sorrys passent a M < N : rapporter "N→M (X% restant)", pas "DONE Voting". Pas de markdown "RAPPORT"/"AUDIT" comme preuve sans code valide.
+
+**Reviewers (humains et bots)** : critères CHANGES_REQUESTED obligatoires si composite >3000 lignes hors notebooks ou >15 fichiers ou >4 features melangees, si Lean PR sans `grep -c sorry` avant/apres + Lake build SUCCESS, si ML PR sans multi-seed ≥4 + verdict explicite (BEATS/NO BEATS/INCONCLUSIVE), si notebook PR sans output Papermill colle, si docs-only PR <50 lignes (group obligatoire). APPROVED malgre violation = complicite. Cf [.claude/rules/pr-review-discipline.md](.claude/rules/pr-review-discipline.md).
 
 ### C. Notebooks (3 regles user 2026-04-26)
 
@@ -130,6 +140,82 @@ Detail complet : [.claude/rules/code-style.md](.claude/rules/code-style.md) (aut
 | `epita_symbolic_ai` | EPITA SymbolicAI series | `C:\Users\MYIA\.conda\envs\epita_symbolic_ai` |
 
 Pour `train_moe.py`, `train_lstm.py`, `train_mamba.py` etc. : **toujours** activer `coursia-ml-training` (`& "C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"` ou `conda activate coursia-ml-training`). Liste complete via `conda env list`.
+
+### G. Vigilance permanente — anti-complaisance
+
+S'applique a **tous les agents** (executants, coordinateur, reviewers humains et bots). Ces regles sont permanentes : elles ne se relachent ni avec la pression deadline, ni avec la confiance accumulee, ni avec un APPROVED bot.
+
+**G.1 — Verifier les claims contre le code, pas contre les rapports**
+
+Avant de croire qu'un feature manque, qu'une API n'existe pas, qu'un fichier est introuvable, qu'un agent X "n'est pas connecte" : `grep` / `Glob` / `Read` le codebase. Affirmer une absence sans verification = source #1 de faux diagnostics qui se propagent en cascade.
+
+Avant de relayer un diagnostic technique d'un autre agent dans un dispatch ou un bilan : exiger la preuve (ligne de code citee, log d'erreur copie, output compilateur). Pas de propagation par confiance. Si le diagnostic se revele faux apres relais, le coordinateur partage la responsabilite.
+
+**G.2 — Metriques honnetes, pas binaires**
+
+`sorry count = 0` n'a aucune valeur sans `lake build SUCCESS` post-modification. Un theoreme supprime, un identifiant inexistant injecte, une preuve qui ne compile pas = sorry count peut etre 0 ET le port casse. Pour Lean / Coq / Agda, **trois preuves obligatoires** dans le body PR : `grep -c sorry` avant/apres + `lake build` SUCCESS log + Proof integrity check SUCCESS.
+
+Pour ML/trading : `BEATS majority` n'a aucune valeur sur 1 seed × 1 fold. Multi-seed ≥4 + walk-forward 5-fold + edge ≥ 2σ cross-seed + transaction costs documentes ou le verdict est **invalide** (pas "promising", pas "encouraging" — invalide).
+
+Pour notebooks : `Papermill SUCCESS` en mot-cle ne prouve rien. Coller les premieres lignes des outputs reels.
+
+Pour services ops : `200 OK` sur /health ne prouve pas que le service fait son travail. Test E2E reproductible obligatoire (curl + verification du payload retourne).
+
+**G.3 — Pas de "DONE" sur progres marginal**
+
+Si N tracks dispatchees → M < N livrees : rapporter `M/N livrees, (N-M) restantes : <liste>`. Pas de `Cycle X complete` quand Track 1 (le HIGH) n'est pas fait et 7 LOW le sont.
+
+Si sorry count passe de N a N-1 : rapporter `1/N elimine, (N-1) restants`. Pas de "DONE Voting".
+
+Si fix corrige 5/7 cellules : rapporter `5/7, 2 restantes : <liste>`. Pas de "DONE notebook".
+
+Pourcentage explicite ou liste residuelle obligatoires.
+
+**G.4 — Composites trop larges = split obligatoire**
+
+Une PR qui depasse l'un de ces seuils doit etre fractionnee en PRs coherentes par feature avant merge :
+- `additions + deletions` > 3000 lignes hors notebooks
+- `changedFiles` > 15 (hors `_output.ipynb` et donnees)
+- > 4 features distinctes mentionnees dans le `## Summary`
+- > 1 domaine (ML + Lean + GenAI melanges)
+
+Le coordinateur **conteste** (commentaire CHANGES_REQUESTED) au lieu de merger. Le reviewer bot DOIT poster CHANGES_REQUESTED.
+
+**G.5 — Shopping cart interdit**
+
+Un dispatch >5 tracks par agent encourage le shopping (LOW d'abord, HIGH reportes). Cibler **2 deep tracks max par agent** par cycle, avec **criteres de sortie verifiables** (compile log, multi-seed verdict, build SUCCESS, healthcheck E2E). Pas de Track LOW pour combler.
+
+Si un agent finit ses 2 tracks avant la coord finale : il attend, il n'invente pas une 3e mission. Laisser les LOW au cycle suivant.
+
+**G.6 — Coordinateur : audit avant merge cascade**
+
+Avant un batch de merges : lire les bodies, verifier au moins **un claim** de chaque PR contre le diff reel. Pas de "5 PRs APPROVED par bot, je merge en 5 minutes".
+
+Si une PR a 0 review humain ET le bot APPROVE : c'est le **minimum** acceptable, mais le coordinateur reste responsable du contenu. Si le claim est faux, c'est le merge qui est en cause, pas le bot.
+
+Lire le diff > lire le titre. Lire le body > lire le mergeStateStatus. Verifier le claim > faire confiance au rapport.
+
+**G.7 — Stagnation cross-cycle = escalade**
+
+Si un blocage technique persiste sur N cycles consecutifs (ex: rebase qui ne se fait pas, sorry qui ne baisse pas, service qui reste DOWN) : le coordinateur **n'attend pas un cycle de plus**. Il prend l'action lui-meme (rebase, fix, escalade user) ou ferme la PR/issue.
+
+Si un agent rapporte "BLOCKED" sans preuve concrete (compile log, error message, screenshot) : ne pas accepter. Demander la preuve avant de re-dispatcher.
+
+**G.8 — Bots reviewers : pas de rubber-stamp**
+
+Pattern interdit : APPROVE >3 PRs en <10 minutes. Probable rubber-stamp. Le coordinateur conteste systematiquement et bloque les PRs jusqu'a re-review serieuse.
+
+Pattern interdit : APPROVED sur composite >3000 lignes / 15 fichiers. Le bot DOIT detecter et poster CHANGES_REQUESTED.
+
+Pattern interdit : APPROVED sur micro PR docs <20 lignes isolee. Le bot DOIT detecter et exiger groupement.
+
+Cf [.claude/rules/pr-review-discipline.md](.claude/rules/pr-review-discipline.md) pour la grille complete.
+
+**G.9 — Culture du doute**
+
+Avant d'envoyer un rapport ou de merger : se demander explicitement "est-ce que je pourrais avoir tort ?". Si oui, verifier. Une affirmation surprenante (ex: "le multi-agent prover existe deja") merite verification avant relais.
+
+Avant d'accepter une "breakthrough" rapportee par un agent (sorry 5→0, BEATS magique, service restaure en 5min) : reproduire au moins 1 element du resultat. Les vrais succes resistent a la verification ; les faux positifs s'effondrent.
 
 ---
 


### PR DESCRIPTION
## Summary

Renforce la vigilance permanente cross-domaines (Lean, ML, notebooks, QC, docs) pour reviewers humains et bots. Pattern voulu : règles permanentes, pas datées par incident.

**CLAUDE.md** :
- Section B (Reviews PR) reinforcee avec block "Preuves verifiables, pas mots-cles" + criteres reviewers humains+bots
- **Nouvelle section G** (G.1-G.9) "Vigilance permanente — anti-complaisance" :
  - G.1 Verifier claims contre code, pas contre rapports
  - G.2 Metriques honnetes (sorry+lake build, multi-seed, Papermill output)
  - G.3 Pas de "DONE" sur progres marginal
  - G.4 Composites trop larges = split obligatoire
  - G.5 Shopping cart interdit (2 deep tracks max/agent/cycle)
  - G.6 Coordinateur : audit avant merge cascade
  - G.7 Stagnation cross-cycle = escalade
  - G.8 Bots reviewers : pas de rubber-stamp
  - G.9 Culture du doute
- Header "REGLES CRITIQUES" passe de (4 sections) a (7 sections)

**Nouveau** `.claude/rules/pr-review-discipline.md` (105 lignes) :
- Criteres CHANGES_REQUESTED obligatoires par categorie (A composite, B Lean, C ML, D notebook, E docs, F audit reassessment, G QC)
- Mention explicite des bots (clusterManager-Myia, jsboige bot)
- Workflow ai-01 coordinateur avant merge cascade

## Scope

- 2 fichiers : `CLAUDE.md` (+88 lignes), `.claude/rules/pr-review-discipline.md` (+105 lignes nouveau)
- Pas de code touche
- Auto-loaded a chaque session (regle dans `.claude/rules/`)

## Test plan

- [ ] Lecture des 9 sous-sections G.1-G.9 par les agents au prochain dispatch
- [ ] Application des criteres CHANGES_REQUESTED par clusterManager-Myia sur prochaines PRs
- [ ] Verification que coordinateur ai-01 audit les bodies avant merge cascade
- [ ] Pas de regression : section H/Kernels & Runtime preservee

🤖 Generated with [Claude Code](https://claude.com/claude-code)