### PR TITLE
fix: add missing RL training artifact patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -654,6 +654,14 @@ MyIA.AI.Notebooks/QuantConnect/Python/dqn_backtest.png
 MyIA.AI.Notebooks/QuantConnect/Python/dqn_trading_model.json
 MyIA.AI.Notebooks/QuantConnect/Python/dqn_training_curves.png
 
+# RL training artifacts (PPO, SAC, A2C)
+*_backtest.png
+*_training_curves.png
+*_training.png
+*_trading_model.json
+ppo_cartpole.zip
+sac_a2c_*.png
+
 # QC Cloud screenshots and temp research files
 qc*.png
 research_wrapper.ipynb


### PR DESCRIPTION
## Summary
- Generalize `.gitignore` patterns for RL training artifacts (PPO, SAC, A2C)
- Existing patterns only covered `dqn_*` files; new patterns catch all RL training outputs

## Changes
- Added wildcard patterns: `*_backtest.png`, `*_training_curves.png`, `*_training.png`, `*_trading_model.json`
- Added specific patterns: `ppo_cartpole.zip`, `sac_a2c_*.png`
- Keeps existing `dqn_*` patterns for backward compatibility

## Test plan
- [x] `git status` shows 0 untracked files after fix (was 5 PPO/SAC artifacts)