### PR TITLE
fix(ml): OBV non-stationarity + regime eval data leakage (audit #705)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -88,7 +88,7 @@ features = engineer.transform(df, cache_path="cache/spy.parquet")
 | macd, macd_signal | MACD indicator |
 | bb_width | Bollinger Band width |
 | true_range, atr_14 | True Range and ATR (requires OHLC) |
-| obv, obv_norm | On-Balance Volume (raw and normalized) |
+| obv | On-Balance Volume (rolling-std normalized) |
 
 ## Checkpoints
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_existing_checkpoints.py
@@ -267,11 +267,16 @@ def evaluate_checkpoint(
     prices_oos = close_prices[oos_indices]
 
     if len(X_oos) > 0:
-        # Normalize OOS data using global stats for regime evaluation
-        global_mean = X.mean(axis=(0, 1), keepdims=True)
-        global_std = X.std(axis=(0, 1), keepdims=True)
-        global_std = np.where(global_std < 1e-8, 1.0, global_std)
-        X_oos_norm = (X_oos - global_mean) / global_std
+        # Normalize OOS data using train-only stats (prevent data leakage)
+        train_mask = ~oos_indices
+        if train_mask.any():
+            train_mean = X[train_mask].mean(axis=(0, 1), keepdims=True)
+            train_std = X[train_mask].std(axis=(0, 1), keepdims=True)
+        else:
+            train_mean = X.mean(axis=(0, 1), keepdims=True)
+            train_std = X.std(axis=(0, 1), keepdims=True)
+        train_std = np.where(train_std < 1e-8, 1.0, train_std)
+        X_oos_norm = (X_oos - train_mean) / train_std
 
         regime_results = eval_per_regime(
             model=_wrap_model(model, model_type),

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/features.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/features.py
@@ -114,14 +114,17 @@ def compute_true_range_atr(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
     return feat
 
 
-def compute_obv(df: pd.DataFrame) -> pd.DataFrame:
-    """On-Balance Volume."""
+def compute_obv(df: pd.DataFrame, window: int = 20) -> pd.DataFrame:
+    """On-Balance Volume (rolling-std normalized).
+
+    Raw OBV cumsum is non-stationary and leaks temporal position.
+    We keep only the rolling-std normalized variant.
+    """
     feat = pd.DataFrame(index=df.index)
     direction = np.sign(df["Close"].diff())
     direction.iloc[0] = 0
-    feat["obv"] = (direction * df["Volume"]).cumsum()
-    # Normalized OBV
-    feat["obv_norm"] = feat["obv"] / feat["obv"].rolling(20).std().replace(0, 1e-10)
+    raw_obv = (direction * df["Volume"]).cumsum()
+    feat["obv"] = raw_obv / raw_obv.rolling(window).std().replace(0, 1e-10)
     return feat
 
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_features.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_features.py
@@ -139,7 +139,7 @@ class TestComputeOBV:
     def test_columns(self, ohlcv):
         feat = compute_obv(ohlcv)
         assert "obv" in feat.columns
-        assert "obv_norm" in feat.columns
+        assert "obv_norm" not in feat.columns
 
 
 class TestComputeRegime:


### PR DESCRIPTION
## Summary
- **Finding #9**: `compute_obv()` now returns only the rolling-std normalized OBV (dropped raw non-stationary cumsum that leaked temporal position)
- **Finding #14**: `eval_existing_checkpoints.py` regime eval now uses train-only normalization stats instead of global stats (prevents OOS data leakage)
- Updated README and test assertions to match the new `obv` column naming

## Test plan
- [x] `pytest scripts/tests/test_features.py::TestComputeOBV` — passes
- [x] Full `test_features.py` suite — 44/45 pass (1 unrelated `test_cache_roundtrip` fails due to missing `pyarrow` in system Python)
- [x] `obv_norm` column no longer exists in any source or test
- [ ] Walk-forward eval dry-run with synthetic data (if `eval_existing_checkpoints.py --dry-run` available)

Closes remaining findings from #705 pipeline audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)