### PR TITLE
feat(ml): Stage 1 feature engineering — HMM regime + cross-asset features

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/regime_detector.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/regime_detector.py
@@ -580,7 +580,7 @@ def compute_regime_transition_features(
         if len(window) < 2:
             transitions.append(0)
         else:
-            switches = (window.diff().abs() > 0).sum()
+            switches = (window != window.shift()).sum()
             transitions.append(switches)
     features["transition_count"] = transitions
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/run_stage1_feature_eng.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/run_stage1_feature_eng.py
@@ -1,0 +1,478 @@
+"""
+Stage 1 Feature Engineering: Enhanced indicators + HMM regime features on crypto panier.
+
+Adds HMM regime features (regime labels, transition features, cross-asset regime)
+on top of the default feature set (RSI, MACD, BB, etc.) from features.py.
+
+Walk-forward 5-fold x 4 seeds with 10bps transaction costs.
+Produces BEATS/NO BEATS/INCONCLUSIVE verdict per coin, compared to Stage 0 RF baseline.
+
+Usage:
+    python run_stage1_feature_eng.py
+    python run_stage1_feature_eng.py --dry-run
+    python run_stage1_feature_eng.py --seeds 0,1,7,42 --n-splits 5
+    python run_stage1_feature_eng.py --symbols BTC-USD ETH-USD
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+from sklearn.preprocessing import StandardScaler
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+CHECKPOINTS_DIR = SCRIPT_DIR.parent / "checkpoints"
+DATA_DIR = SCRIPT_DIR.parent.parent / "datasets" / "yfinance" / "crypto_panier"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from features import FeatureEngineer
+from graph_builder import CRYPTO_PANIER_SYMBOLS, load_crypto_panier
+from regime_detector import (
+    detect_regimes_hmm,
+    detect_regimes_multivariate,
+    compute_regime_transition_features,
+)
+from transaction_costs import TransactionCostModel
+from walk_forward import WalkForwardSplitter
+
+BASELINE_SEEDS = [0, 1, 7, 42]
+BASELINE_N_SPLITS = 5
+BASELINE_GAP = 5
+DEFAULT_BASELINE_PATH = (
+    CHECKPOINTS_DIR / "crypto_baselines" / "stage0_crypto_panier_results.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Feature augmentation
+# ---------------------------------------------------------------------------
+
+BASE_INDICATORS = [
+    "returns", "volatility", "volume_ratio", "ma_ratios",
+    "rsi", "macd", "bollinger", "true_range_atr", "obv",
+]
+
+
+def compute_hmm_features_single(coin_prices: pd.Series, n_states: int = 3) -> pd.DataFrame:
+    """Compute HMM regime features for a single coin.
+
+    Features: regime label (one-hot), regime duration proxy.
+    """
+    result = detect_regimes_hmm(coin_prices, n_states=n_states)
+    features = pd.DataFrame(index=coin_prices.index)
+
+    # One-hot regime labels
+    for i, name in enumerate(result.regime_names):
+        features[f"hmm_regime_{name}"] = (result.labels == i).astype(float)
+
+    return features
+
+
+def compute_cross_asset_regime_features(
+    closes: pd.DataFrame, n_states: int = 3, lookback: int = 20,
+) -> pd.DataFrame:
+    """Compute cross-asset regime features using multivariate HMM."""
+    prices_dict = {col: closes[col] for col in closes.columns}
+    mv_result = detect_regimes_multivariate(
+        prices_dict, method="hmm", n_states=n_states,
+    )
+    return compute_regime_transition_features(mv_result, lookback=lookback)
+
+
+def build_enhanced_features(
+    coin_df: pd.DataFrame,
+    coin_prices: pd.Series,
+    closes_all: pd.DataFrame,
+    lookback: int = 20,
+    add_target: bool = True,
+) -> pd.DataFrame:
+    """Build Stage 1 features = base indicators + HMM regime + cross-asset regime."""
+    # Base features from FeatureEngineer
+    engineer = FeatureEngineer(lookback=lookback, indicators=BASE_INDICATORS)
+    base = engineer.transform(coin_df, add_target=False)
+
+    # Single-coin HMM regime features
+    hmm_feat = compute_hmm_features_single(coin_prices)
+    hmm_feat = hmm_feat.loc[base.index.intersection(hmm_feat.index)]
+
+    # Cross-asset regime features
+    cross_feat = compute_cross_asset_regime_features(closes_all)
+    cross_feat = cross_feat.loc[base.index.intersection(cross_feat.index)]
+
+    # Align all to common index
+    common_idx = base.index.intersection(hmm_feat.index).intersection(cross_feat.index)
+    features = pd.concat([
+        base.loc[common_idx],
+        hmm_feat.loc[common_idx],
+        cross_feat.loc[common_idx],
+    ], axis=1)
+
+    if add_target:
+        features["target"] = coin_df["Close"].pct_change().shift(-1).loc[common_idx]
+
+    features = features.dropna()
+    return features
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward training with transaction costs
+# ---------------------------------------------------------------------------
+
+def train_walk_forward_with_costs(
+    features: pd.DataFrame,
+    seed: int = 0,
+    n_splits: int = 5,
+    gap: int = 5,
+    cost_bps: float = 10.0,
+    n_estimators: int = 200,
+    max_depth: int = 8,
+) -> dict:
+    """Walk-forward RF training with transaction costs deducted from Sharpe."""
+    np.random.seed(seed)
+
+    X = features.drop(columns=["target"]).values
+    y = features["target"].values
+
+    # Binary direction target
+    y_binary = (y > 0.001).astype(int)
+
+    splitter = WalkForwardSplitter(n_splits=n_splits, gap=gap)
+
+    fold_results = []
+    oos_preds = np.full(len(y_binary), -1, dtype=int)
+    oos_returns = np.full(len(y), np.nan, dtype=float)
+
+    for fold_idx, (train_idx, test_idx) in enumerate(splitter.split(X)):
+        if len(test_idx) == 0:
+            continue
+
+        # Internal train/val split (85/15)
+        val_cutoff = int(len(train_idx) * 0.85)
+        tr_idx = train_idx[:val_cutoff]
+        val_idx = train_idx[val_cutoff:]
+
+        scaler = StandardScaler()
+        X_tr = scaler.fit_transform(X[tr_idx])
+        X_val = scaler.transform(X[val_idx])
+        X_te = scaler.transform(X[test_idx])
+
+        model = RandomForestClassifier(
+            n_estimators=n_estimators, max_depth=max_depth,
+            random_state=seed, n_jobs=-1,
+        )
+        model.fit(X_tr, y_binary[tr_idx])
+
+        fold_preds = model.predict(X_te)
+        fold_acc = accuracy_score(y_binary[test_idx], fold_preds)
+        val_preds = model.predict(X_val)
+        val_acc = accuracy_score(y_binary[val_idx], val_preds)
+
+        oos_preds[test_idx] = fold_preds
+        # Strategy returns: long if predicted up, short if predicted down
+        strategy_returns = np.where(fold_preds == 1, y[test_idx], -y[test_idx])
+        oos_returns[test_idx] = strategy_returns
+
+        fold_results.append({
+            "fold": fold_idx,
+            "val_accuracy": round(val_acc, 4),
+            "oos_accuracy": round(fold_acc, 4),
+            "train_size": len(tr_idx),
+            "test_size": len(test_idx),
+        })
+
+    # Aggregate OOS
+    valid_mask = oos_preds >= 0
+    oos_predictions = oos_preds[valid_mask]
+    oos_targets = y_binary[valid_mask]
+    oos_rets = oos_returns[valid_mask]
+
+    if len(oos_predictions) == 0:
+        return {"seed": seed, "status": "no_oos_data"}
+
+    oos_diracc = float(np.mean(oos_predictions == oos_targets))
+
+    # Majority baseline
+    majority_freq = float(np.mean(oos_targets == 1))
+    majority_acc = max(majority_freq, 1.0 - majority_freq)
+
+    # Sharpe computation
+    gross_sharpe = _sharpe(oos_rets)
+    cost_model = TransactionCostModel(commission_bps=cost_bps / 2)
+    # Compute trade indicator: position change when prediction flips
+    oos_positions = np.where(oos_predictions == 1, 1.0, -1.0)
+    trade_indicators = np.abs(np.diff(oos_positions, prepend=oos_positions[0]))
+    net_returns = cost_model.apply_to_returns(oos_rets, trades=trade_indicators)
+    net_sharpe = _sharpe(net_returns)
+
+    edge = oos_diracc - majority_acc
+
+    return {
+        "seed": seed,
+        "oos_diracc": round(oos_diracc, 4),
+        "majority_acc": round(majority_acc, 4),
+        "edge_vs_majority": round(edge, 4),
+        "gross_sharpe": round(gross_sharpe, 4),
+        "net_sharpe": round(net_sharpe, 4),
+        "n_oos": int(valid_mask.sum()),
+        "n_folds": len(fold_results),
+        "fold_details": fold_results,
+    }
+
+
+def _sharpe(returns: np.ndarray, annualize: bool = True) -> float:
+    """Annualized Sharpe ratio from daily returns."""
+    if len(returns) < 10:
+        return 0.0
+    mean_r = np.mean(returns)
+    std_r = np.std(returns, ddof=1)
+    if std_r < 1e-10:
+        return 0.0
+    sr = mean_r / std_r
+    if annualize:
+        sr *= np.sqrt(252)
+    return float(sr)
+
+
+# ---------------------------------------------------------------------------
+# Verdict computation
+# ---------------------------------------------------------------------------
+
+def compute_verdict(seed_results: list[dict]) -> dict:
+    """Compute BEATS/NO BEATS/INCONCLUSIVE verdict from multi-seed results.
+
+    BEATS:      t_stat > 2.0 AND mean_edge > 0
+    NO BEATS:   mean_edge < 0
+    INCONCLUSIVE: otherwise
+    """
+    edges = [r["edge_vs_majority"] for r in seed_results]
+    mean_edge = float(np.mean(edges))
+    std_edge = float(np.std(edges, ddof=1)) if len(edges) > 1 else 0.0
+    t_stat = mean_edge / std_edge if std_edge > 1e-10 else 0.0
+
+    net_sharpes = [r["net_sharpe"] for r in seed_results]
+    gross_sharpes = [r["gross_sharpe"] for r in seed_results]
+    diraccs = [r["oos_diracc"] for r in seed_results]
+
+    if mean_edge > 0 and t_stat > 2.0:
+        verdict = "BEATS"
+    elif mean_edge < 0:
+        verdict = "NO BEATS"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    return {
+        "verdict": verdict,
+        "mean_edge_vs_majority": round(mean_edge, 4),
+        "std_edge": round(std_edge, 4),
+        "t_stat": round(t_stat, 4),
+        "mean_net_sharpe": round(float(np.mean(net_sharpes)), 4),
+        "mean_gross_sharpe": round(float(np.mean(gross_sharpes)), 4),
+        "mean_diracc": round(float(np.mean(diraccs)), 4),
+        "seeds": seed_results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Baseline comparison
+# ---------------------------------------------------------------------------
+
+def load_baseline_results(path: Path | None = None) -> dict:
+    """Load Stage 0 baseline results for comparison."""
+    path = path or DEFAULT_BASELINE_PATH
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    baseline = {}
+    for item in data:
+        coin = item["coin"]
+        rf = item.get("rf_walk_forward", {})
+        baseline[coin] = {
+            "verdict": rf.get("verdict", "UNKNOWN"),
+            "mean_edge": rf.get("mean_edge_vs_majority", 0),
+            "t_stat": rf.get("t_stat", 0),
+            "mean_net_sharpe": rf.get("mean_net_sharpe", 0),
+            "n_features": rf.get("n_features", 19),
+            "n_folds": rf.get("seeds", [{}])[0].get("n_folds", 4) if rf.get("seeds") else 4,
+        }
+    return baseline
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def load_coin_data(symbol: str) -> pd.DataFrame:
+    """Load OHLCV data for a single crypto coin."""
+    matches = list(DATA_DIR.glob(f"{symbol}_*.csv"))
+    if not matches:
+        raise FileNotFoundError(f"No data file found for {symbol} in {DATA_DIR}")
+    df = pd.read_csv(matches[0], index_col=0, parse_dates=True)
+    # Ensure standard column names
+    df.columns = [c.strip().capitalize() for c in df.columns]
+    return df
+
+
+def run_single_coin(
+    symbol: str,
+    closes_all: pd.DataFrame,
+    seeds: list[int],
+    n_splits: int,
+    gap: int,
+    cost_bps: float,
+    lookback: int,
+    dry_run: bool = False,
+) -> dict:
+    """Run Stage 1 experiment for a single coin."""
+    print(f"\n{'='*60}")
+    print(f"  {symbol}")
+    print(f"{'='*60}")
+
+    coin_df = load_coin_data(symbol)
+    coin_prices = coin_df["Close"]
+
+    if dry_run:
+        coin_df = coin_df.iloc[-500:]
+        coin_prices = coin_prices.iloc[-500:]
+
+    print(f"  Data: {len(coin_df)} rows ({coin_df.index.min().date()} -> {coin_df.index.max().date()})")
+
+    # Build features
+    t0 = time.time()
+    features = build_enhanced_features(coin_df, coin_prices, closes_all, lookback=lookback)
+    n_features = len(features.columns) - 1  # minus target
+    print(f"  Features: {n_features} columns, {len(features)} rows ({time.time()-t0:.1f}s)")
+
+    # Multi-seed walk-forward
+    seed_results = []
+    for seed in seeds:
+        t0 = time.time()
+        result = train_walk_forward_with_costs(
+            features, seed=seed, n_splits=n_splits, gap=gap,
+            cost_bps=cost_bps,
+        )
+        elapsed = time.time() - t0
+        if result.get("status") == "no_oos_data":
+            print(f"    seed={seed}: NO OOS DATA")
+            continue
+        seed_results.append(result)
+        print(
+            f"    seed={seed}: DirAcc={result['oos_diracc']:.4f}  "
+            f"edge={result['edge_vs_majority']:+.4f}  "
+            f"net_sharpe={result['net_sharpe']:.4f}  "
+            f"({elapsed:.1f}s)"
+        )
+
+    if not seed_results:
+        return {"coin": symbol, "verdict": "ERROR", "error": "no valid seeds"}
+
+    verdict_data = compute_verdict(seed_results)
+    verdict_data["coin"] = symbol
+    verdict_data["n_features"] = n_features
+    verdict_data["n_seeds"] = len(seed_results)
+    verdict_data["cost_bps"] = cost_bps
+    verdict_data["n_splits"] = n_splits
+
+    print(f"  VERDICT: {verdict_data['verdict']}")
+    print(f"    mean_edge={verdict_data['mean_edge_vs_majority']:+.4f}  "
+          f"t={verdict_data['t_stat']:.4f}  "
+          f"net_sharpe={verdict_data['mean_net_sharpe']:.4f}")
+
+    return verdict_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stage 1: Enhanced features + HMM regime")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--symbols", nargs="+", default=None)
+    parser.add_argument("--seeds", type=str, default=None, help="Comma-separated seeds")
+    parser.add_argument("--n-splits", type=int, default=BASELINE_N_SPLITS)
+    parser.add_argument("--gap", type=int, default=BASELINE_GAP)
+    parser.add_argument("--cost-bps", type=float, default=10.0)
+    parser.add_argument("--lookback", type=int, default=20)
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument("--baseline-path", default=None)
+    args = parser.parse_args()
+
+    symbols = args.symbols or CRYPTO_PANIER_SYMBOLS
+    seeds = [int(s) for s in args.seeds.split(",")] if args.seeds else BASELINE_SEEDS
+
+    print("Stage 1: Enhanced Features + HMM Regime")
+    print(f"  Coins: {len(symbols)}, Seeds: {seeds}")
+    print(f"  Walk-forward: {args.n_splits} folds, gap={args.gap}")
+    print(f"  Costs: {args.cost_bps} bps")
+
+    # Load all closes for cross-asset features
+    if args.dry_run:
+        closes_all = load_crypto_panier()
+        closes_all = closes_all.iloc[-500:]
+    else:
+        closes_all = load_crypto_panier()
+
+    print(f"  Cross-asset data: {len(closes_all)} days, {len(closes_all.columns)} coins")
+
+    # Load baseline for comparison
+    baseline_path = Path(args.baseline_path) if args.baseline_path else DEFAULT_BASELINE_PATH
+    baseline = load_baseline_results(baseline_path)
+
+    # Run experiments
+    all_results = []
+    for symbol in symbols:
+        result = run_single_coin(
+            symbol, closes_all, seeds,
+            n_splits=args.n_splits, gap=args.gap,
+            cost_bps=args.cost_bps, lookback=args.lookback,
+            dry_run=args.dry_run,
+        )
+        all_results.append(result)
+
+    # Print comparison table
+    print(f"\n{'='*80}")
+    print("STAGE 1 vs STAGE 0 COMPARISON")
+    print(f"{'='*80}")
+    print(f"{'Coin':10s} {'S1 Verdict':12s} {'S1 Edge':>8s} {'S1 t':>6s} {'S1 NetSR':>8s} "
+          f"{'S0 Verdict':12s} {'S0 Edge':>8s} {'Delta':>7s}")
+    print("-" * 80)
+
+    for r in all_results:
+        coin = r["coin"]
+        s0 = baseline.get(coin, {})
+        s1_edge = r.get("mean_edge_vs_majority", 0)
+        s0_edge = s0.get("mean_edge", 0)
+        delta = s1_edge - s0_edge
+        print(
+            f"{coin:10s} {r.get('verdict','?'):12s} {s1_edge:+8.4f} "
+            f"{r.get('t_stat',0):6.3f} {r.get('mean_net_sharpe',0):8.4f} "
+            f"{s0.get('verdict','N/A'):12s} {s0_edge:+8.4f} {delta:+7.4f}"
+        )
+
+    # Save results
+    output_dir = Path(args.output_dir) if args.output_dir else CHECKPOINTS_DIR / "stage1_feature_eng"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = output_dir / f"stage1_results_{ts}.json"
+    out_file.write_text(json.dumps(all_results, indent=2, default=str), encoding="utf-8")
+    print(f"\nResults saved: {out_file}")
+
+    # Also save latest as stable name
+    latest = output_dir / "stage1_latest.json"
+    latest.write_text(json.dumps(all_results, indent=2, default=str), encoding="utf-8")
+
+    # Summary verdicts
+    verdicts = [r.get("verdict", "ERROR") for r in all_results]
+    print(f"\nSummary: BEATS={verdicts.count('BEATS')}  "
+          f"NO BEATS={verdicts.count('NO BEATS')}  "
+          f"INCONCLUSIVE={verdicts.count('INCONCLUSIVE')}  "
+          f"ERROR={verdicts.count('ERROR')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_volatility_garch_dl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_volatility_garch_dl.py
@@ -51,7 +51,8 @@ from walk_forward import WalkForwardSplitter
 RESULTS_DIR = SCRIPT_DIR.parent / "results" / "volatility_garch_dl"
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-ASSETS = ["SPY", "BTC-USD", "GLD", "EFA", "EEM"]
+EQUITY_ASSETS = ["SPY", "BTC-USD", "GLD", "EFA", "EEM"]
+CRYPTO_PANIER = ["BTC-USD", "ETH-USD", "SOL-USD", "ADA-USD", "AVAX-USD"]
 HORIZONS = [1, 5, 20]
 DEFAULT_SEEDS = [0, 1, 7, 42, 123]
 DATA_START = "2010-01-01"
@@ -743,7 +744,9 @@ def parse_args():
     parser.add_argument("--horizon", type=int, default=5, help="Prediction horizon (days)")
     parser.add_argument("--seeds", type=int, nargs="+", default=DEFAULT_SEEDS, help="Random seeds")
     parser.add_argument("--model", type=str, default="lstm", choices=MODEL_TYPES, help="DL model type")
-    parser.add_argument("--all-assets", action="store_true", help="Run all assets")
+    parser.add_argument("--all-assets", action="store_true", help="Run all equity assets")
+    parser.add_argument("--crypto-panier", action="store_true",
+                        help="Run crypto panier (BTC, ETH, SOL, ADA, AVAX)")
     parser.add_argument("--all-horizons", action="store_true", help="Run all horizons")
     parser.add_argument("--n-splits", type=int, default=5, help="Walk-forward folds")
     parser.add_argument("--lookback", type=int, default=60, help="Sequence lookback")
@@ -766,7 +769,13 @@ def main():
     print(f"Model: {args.model}")
     print(f"Results dir: {RESULTS_DIR}")
 
-    assets = ASSETS if args.all_assets else [args.asset]
+    if args.crypto_panier:
+        assets = CRYPTO_PANIER
+        print(f"Mode: CRYPTO PANIER ({len(assets)} assets)")
+    elif args.all_assets:
+        assets = EQUITY_ASSETS
+    else:
+        assets = [args.asset]
     horizons = HORIZONS if args.all_horizons else [args.horizon]
 
     all_summaries = []

--- a/docs/qc-broken-strategies-audit.md
+++ b/docs/qc-broken-strategies-audit.md
@@ -1,0 +1,186 @@
+# QC Broken Strategies Audit — Root Cause Analysis
+
+**Date**: 2026-05-08
+**Author**: myia-po-2024 (Cycle 10, Track 2)
+**Scope**: 5 BROKEN strategies identified from the QC Cloud catalog (118 projects)
+**Methodology**: Read full source code + backtest history for each strategy, identify structural root cause.
+
+---
+
+## Summary Table
+
+| # | Strategy | Project ID | Best Sharpe | Root Cause | Fix Difficulty |
+|---|----------|-----------|-------------|------------|----------------|
+| 1 | PairsTrading | 28693651 | -1.152 | Cointegration breakdown in ETF pairs | Hard — need fundamentally different pair selection |
+| 2 | ESGF-RL-DQN-Trading | 29687000 | -0.341 | Linear Q-function too simple, undertrained | Hard — need deep Q-network or different RL algorithm |
+| 3 | TrendFilteredMeanReversion | 28817422 | -0.129 | ~85% cash drag in bull market | Medium — need always-invested overlay or regime switch |
+| 4 | ETF-Pairs-Researcher | 28433746 | -0.002 | Same cointegration flaw, 8 iterations confirm dead end | Hard — same as #1 |
+| 5 | HandsOn-Ex19-FinBERT-Sentiment | 29936073 | 0.000 (zero trades) | FinBERT/transformers unavailable in QC Cloud | Unfixable — platform limitation |
+
+---
+
+## Strategy 1: PairsTrading (28693651)
+
+### Current State
+- **Sharpe**: -1.152 | **CAGR**: -0.568% | **MaxDD**: 12.4% | **Net Profit**: -3.54%
+- **Pairs**: GLD/SLV, TLT/IEF, EWA/EWC (same as ETF-Pairs-Researcher)
+- **Method**: OLS hedge ratio (252-day), z-score entry/exit (2.5/0.5/4.5), lookback 120
+
+### Root Cause: Structural Cointegration Breakdown
+
+ETF pairs do not maintain stable cointegration over multi-year periods. The OLS hedge ratio (slope from linregress of price_A on price_B over 252 days) is a rolling estimate that lags structural shifts. When cointegration breaks:
+
+1. The spread drifts (non-stationary), generating false z-score signals
+2. Positions opened on "mean reversion" converge to the wrong mean
+3. The stop-zscore (4.5) is too wide — by the time it triggers, significant losses have accumulated
+
+**Key evidence**: The same 3 pairs were tried across 2 separate projects (this one + ETF-Pairs-Researcher) with 11+ combined iterations, parameter sweeps, and framework changes. None achieved sustained positive Sharpe.
+
+### Recommended Fix
+- Replace OLS with Kalman filter for dynamic hedge ratio estimation
+- Use Engle-Granger/Johansen cointegration test as real-time filter (only trade pairs with t_stat < -3.0)
+- Consider intraday data (hourly) for faster mean reversion
+- Alternative: switch to statistical arbitrage across sectors (many pairs, small allocation each)
+
+---
+
+## Strategy 2: ESGF-RL-DQN-Trading (29687000)
+
+### Current State
+- **Sharpe**: -0.341 | **CAGR**: N/A | **Net Profit**: negative
+- **Method**: Linear Q-learning (numpy-only, no neural network despite the name)
+- **State**: 8-dim (ROC 1/5/20, std_20, position, trend, RSI_norm, BB_position, bias)
+- **Actions**: HOLD/BUY/SELL with confidence threshold 0.3
+
+### Root Cause: Function Approximation Too Simple + Undertrained
+
+Three compounding problems:
+
+1. **Linear Q-function**: A linear model with 8 features + bias cannot capture the non-linear interactions between momentum, volatility, and regime. The Q(s,a) = w^T * phi(s,a) formulation assumes additive contributions of each state dimension. In reality, "high RSI + uptrend" and "high RSI + downtrend" should produce very different Q-values, but a linear model gives the same RSI coefficient regardless of trend.
+
+2. **Undertrained**: Replay buffer of 3000, batch size 32, but the algorithm starts trading from day 1 with no pre-training period. The Q-function is essentially random for the first ~100 episodes (3000/32 batches). By the time it starts learning meaningful patterns, it has accumulated significant losses.
+
+3. **Confidence threshold insufficient**: The 0.3 threshold was added to reduce trade frequency, but a linear model's "confidence" is just the magnitude of w^T * phi — which can be large simply because the features have large magnitudes, not because the model is confident.
+
+### Recommended Fix
+- Replace linear Q with a proper DQN (2-layer MLP, 64-128 hidden units)
+- Pre-fill replay buffer with 10000 random steps before training begins
+- Use target network soft update (tau=0.005) instead of hard update
+- Add reward shaping: penalize drawdown, reward Sharpe-like risk-adjusted returns
+- Alternative: switch to PPO or A2C for more stable policy gradient training
+
+---
+
+## Strategy 3: TrendFilteredMeanReversion (28817422)
+
+### Current State
+- **Sharpe**: -0.129 | **CAGR**: 3.4% | **MaxDD**: 17.5%
+- **Method**: RSI(2) < 10 in bull regime (SPY > SMA200), exit on close > SMA5 or RSI(2) > 70 or 5-day stop
+- **Universe**: SPY only
+
+### Root Cause: Cash Drag in Bull Market
+
+The strategy's own code comments document this clearly: ~85% of trading days have RSI(2) > 10 for SPY during the 2015-2026 bull market. The strategy is in cash for the vast majority of the backtest period.
+
+**Key evidence from iteration history**:
+- v1.0 (single-asset SPY): Sharpe -0.016, the best variant
+- v4 (multi-asset 6 ETFs): Sharpe -0.129, worse because more assets = more cash drag
+
+The structural ceiling: RSI(2) < 10 is an extremely rare event for broad market ETFs in a sustained uptrend. The strategy works in theory (when it trades, it profits), but the signal frequency is too low to overcome the opportunity cost of not being invested.
+
+### Recommended Fix
+- **Always-invested overlay**: Stay long SPY by default, use RSI(2) signals for sizing (e.g., 1.5x long when oversold, 0.5x when overbought)
+- **Widen universe**: Apply RSI(2) signals to individual sector ETFs (11 GICS sectors) where oversold events are more frequent
+- **Lower RSI threshold**: RSI(2) < 20 instead of < 10 captures more signals
+- **Add short side**: Short SPY when RSI(2) > 90 in bear regime (SPY < SMA200) for mean reversion in both directions
+
+---
+
+## Strategy 4: ETF-Pairs-Researcher (28433746)
+
+### Current State
+- **Sharpe**: -0.002 (v4 best), -0.368 (v3), -1.165 (v4 sector) | **8 backtests**, none positive
+- **Pairs**: Same 3 pairs as PairsTrading (GLD/SLV, TLT/IEF, EWA/EWC)
+- **Method**: OLS hedge + z-score with wider thresholds (entry 3.0, exit 0.5, stop 5.0)
+
+### Root Cause: Same Cointegration Flaw as Strategy 1
+
+This project confirms the dead-end nature of ETF pairs trading with OLS:
+
+| Iteration | Approach | Sharpe | Trades | Key Change |
+|-----------|----------|--------|--------|------------|
+| v1 | PearsonCorrelationPairsTradingAlphaModel | Runtime Error | 0 | Framework-based, failed |
+| v2 (all modules) | Alpha+Portfolio+Risk framework | -0.706 | 3409 | Too many trades, whipsaws |
+| v2b | Fixed universe | 0.000 | 0 | Zero trades (threshold too tight) |
+| v3 | Single-file + sector ETFs | -0.368 | 656 | Sector pairs worse than commodity |
+| v4 sector | Daily, lookback=120 | -1.165 | 915 | Worst variant |
+| v4 commodity | Wider thresholds (3.0) | -0.002 | 152 | Fewest trades, nearly flat |
+
+**Key insight**: Across all iterations, no parameter combination or framework choice produced positive Sharpe. The only way to reduce losses was to trade less (wider thresholds = fewer signals = less damage), but this also eliminates any chance of profit.
+
+### Recommended Fix
+- Same as Strategy 1 — the pairs trading approach on broad ETFs is fundamentally flawed
+- If pursuing: requires Kalman filter + real-time cointegration testing + intraday data
+- **More practical alternative**: Abandon pairs trading on broad ETFs, focus on sector rotation or factor momentum instead
+
+---
+
+## Strategy 5: HandsOn-Ex19-FinBERT-Sentiment (29936073)
+
+### Current State
+- **Original (v1)**: Sharpe 0.000, zero trades, zero everything — completely non-functional
+- **v2 "fix"**: Sharpe 0.584, CAGR 22%, MaxDD 43% — but this is a price-momentum proxy, NOT FinBERT
+
+### Root Cause: Platform Limitation — transformers Unavailable in QC Cloud
+
+The strategy attempts to load FinBERT (`ProsusAI/finbert` via HuggingFace transformers + torch) for news sentiment analysis. In QC Cloud's Python environment:
+
+1. `transformers` library is not pre-installed
+2. `torch` (PyTorch) is not available
+3. The `_load_model()` method catches the ImportError and falls back to keyword-based sentiment
+4. The keyword fallback produces near-zero sentiment scores (news articles don't contain enough matching words), resulting in zero trades
+
+**The v2 "fix" is deceptive**: it replaces FinBERT with a `_price_sentiment_proxy()` that computes 10-day momentum z-score. This works (Sharpe 0.584) but completely defeats the pedagogical purpose of the HandsOn exercise (learning to use NLP models for trading signals). The exercise should demonstrate sentiment analysis, not momentum trading.
+
+### Recommended Fix
+- **Pedagogically correct**: This exercise should use a pre-computed sentiment dataset or a lighter-weight model that CAN run in QC Cloud
+- **Alternative 1**: Use QC's built-in `TiingoNews` sentiment scores directly (the `TiingoNews` data already provides sentiment, no model needed)
+- **Alternative 2**: Use the `Quandl` sentiment indicator or similar pre-computed sentiment data
+- **Alternative 3**: Keep the keyword-based approach but with much larger dictionaries and TF-IDF weighting
+- **DO NOT**: Use the price-momentum proxy — it teaches the wrong lesson
+
+---
+
+## Cross-Strategy Patterns
+
+### Pattern 1: Same Flaw, Two Projects
+PairsTrading (28693651) and ETF-Pairs-Researcher (28433746) implement the same strategy with different parameter tunings. Both fail identically. **Lesson**: Parameter optimization cannot fix a structurally flawed approach.
+
+### Pattern 2: Framework Overhead
+ETF-Pairs-Researcher spent 4 iterations on framework architecture (Alpha Model, Portfolio Construction, Risk Management) before the author gave up and went single-file. The framework complexity (5 files: main.py, alpha.py, portfolio.py, risk.py, universe.py) added zero value. **Lesson**: Start simple, validate the core signal before adding framework sophistication.
+
+### Pattern 3: "Fix by Replacement"
+Two strategies were "fixed" by replacing their core signal:
+- FinBERT → price-momentum proxy (works but wrong lesson)
+- DQN name → linear Q-learning (doesn't work, mislabeled)
+
+**Lesson**: If the core technology doesn't work on the platform, document the limitation rather than silently replacing it.
+
+### Pattern 4: Cash Drag as Silent Killer
+TrendFilteredMeanReversion has positive expectancy per-trade but negative Sharpe because of cash drag. The strategy "works" in isolation but fails relative to a simple buy-and-hold benchmark. **Lesson**: Always compare to an always-invested baseline; partial allocation strategies must account for the opportunity cost of being in cash.
+
+---
+
+## Actionable Recommendations
+
+| Priority | Action | Impact |
+|----------|--------|--------|
+| High | Merge PairsTrading + ETF-Pairs-Researcher into one project (same strategy, 2 repos) | Reduce clutter |
+| High | Fix Ex19 to use TiingoNews built-in sentiment instead of FinBERT | Restore pedagogical value |
+| Medium | Add DQN layer to ESGF-RL-DQN (replace linear with 2-layer MLP) | Test if deep RL helps |
+| Medium | Refactor TrendFilteredMeanReversion to always-invested overlay | Eliminate cash drag |
+| Low | Archive ETF-Pairs-Researcher v1-v4 iterations (keep v4 as reference) | Cleanup |
+
+---
+
+*End of analysis. No code changes produced — document only, per Cycle 10 Track 2 directive.*


### PR DESCRIPTION
## Summary

- Add `run_stage1_feature_eng.py` — Stage 1 ML experiment: enhanced features on 10-coin crypto panier
- 28 features: 19 base indicators (RSI, MACD, BB, etc.) + 3 single-coin HMM regime (one-hot) + 6 cross-asset multivariate HMM regime features
- Walk-forward 5-fold x 4 seeds (0/1/7/42) with 10bps transaction costs
- Fix `regime_detector.py` bug: string regime labels can't be `diff()`ed — use `!= shift()` instead

## Results (Stage 1 vs Stage 0 baseline)

| Coin | S1 Verdict | S1 Edge | S1 t-stat | S1 Net Sharpe | S0 Verdict | S0 Edge | Delta |
|------|-----------|---------|-----------|---------------|-----------|---------|-------|
| LTC-USD | BEATS | +0.021 | 2.325 | 0.10 | BEATS | +0.013 | +0.008 |
| XRP-USD | BEATS | +0.028 | 2.061 | 0.05 | BEATS | +0.020 | +0.008 |
| LINK-USD | **BEATS** | +0.015 | 2.244 | 0.42 | NO BEATS | -0.026 | **+0.041** |
| MATIC-USD | BEATS | +0.032 | 9.744 | 0.64 | BEATS | +0.020 | +0.012 |
| ETH-USD | INCONCLUSIVE | +0.000 | 0.026 | -0.35 | BEATS | +0.026 | -0.025 |
| SOL-USD | INCONCLUSIVE | +0.011 | 1.671 | -0.84 | NO BEATS | -0.001 | +0.012 |
| BTC-USD | NO BEATS | -0.020 | -1.602 | -0.59 | INCONCLUSIVE | +0.000 | -0.021 |
| ADA-USD | NO BEATS | -0.011 | -2.356 | -0.12 | BEATS | +0.016 | -0.027 |
| AVAX-USD | NO BEATS | -0.023 | -2.985 | -0.19 | INCONCLUSIVE | +0.002 | -0.026 |
| DOT-USD | NO BEATS | -0.017 | -0.901 | -0.10 | INCONCLUSIVE | +0.004 | -0.020 |

**AGGREGATE**: BEATS=4, NO BEATS=4, INCONCLUSIVE=2

### Key findings

1. **LINK-USD flipped NO BEATS → BEATS** — HMM regime features add +0.041 edge (largest improvement)
2. **MATIC-USD strongest**: t=9.744 (highly significant), net Sharpe 0.64, edge +0.032
3. **LTC/XRP/MATIC**: HMM features consistently improved edge by +0.008-0.012
4. **BTC/ADA/AVAX regressed**: HMM features hurt on already-efficient or noisy coins
5. **Mean net Sharpe across BEATS coins**: +0.30 (positive after transaction costs)

### Feature engineering methodology

- **Base features (19)**: returns, volatility, volume_ratio, ma_ratios, rsi, macd, bollinger, true_range_atr, obv (from `FeatureEngineer`)
- **Single-coin HMM regime (3)**: GaussianHMM 3-state (bull/neutral/bear), one-hot encoded per coin
- **Cross-asset regime (6)**: Multivariate HMM on all 10 coins → bull_fraction, bear_fraction, neutral_fraction, regime_stability, regime_entropy, transition_count

## Test plan

- [x] Dry-run passes with 500 rows (pipeline validation)
- [x] Full run on 10 coins completes without error (1645 OOS rows each)
- [x] Walk-forward 5-fold x 4 seeds produces consistent verdicts
- [x] Transaction costs applied correctly (net Sharpe < gross Sharpe)
- [x] Results JSON saved to `checkpoints/stage1_feature_eng/`
- [x] regime_detector.py bug fix: string diff → `!= shift()` for transition counting

Contributes to #776 (Stage 3a crypto panier — Stage 1 feature engineering component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>