### PR TITLE
fix(docker): bind GenAI service ports to localhost (#808)

### DIFF
--- a/docker-configurations/services/comfyui-qwen/docker-compose.yml
+++ b/docker-configurations/services/comfyui-qwen/docker-compose.yml
@@ -13,7 +13,7 @@ services:
               capabilities: [gpu]
     
     ports:
-      - "${COMFYUI_PORT:-8188}:8188"
+      - "127.0.0.1:${COMFYUI_PORT:-8188}:8188"
     
     volumes:
       - type: bind

--- a/docker-configurations/services/comfyui-video/docker-compose.yml
+++ b/docker-configurations/services/comfyui-video/docker-compose.yml
@@ -25,7 +25,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${COMFYUI_VIDEO_PORT:-8189}:8188"
+      - "127.0.0.1:${COMFYUI_VIDEO_PORT:-8189}:8188"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/demucs-api/docker-compose.yml
+++ b/docker-configurations/services/demucs-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${DEMUCS_API_PORT:-8193}:8193"
+      - "127.0.0.1:${DEMUCS_API_PORT:-8193}:8193"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/forge-turbo/docker-compose.yml
+++ b/docker-configurations/services/forge-turbo/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     container_name: forge-turbo
     hostname: forge-turbo
     ports:
-      - "${FORGE_PORT:-17861}:17860"
-      - "1111:1111"
+      - "127.0.0.1:${FORGE_PORT:-17861}:17860"
+      - "127.0.0.1:1111:1111"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}

--- a/docker-configurations/services/funasr-api/docker-compose.yml
+++ b/docker-configurations/services/funasr-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${FUNASR_API_PORT:-8194}:8194"
+      - "127.0.0.1:${FUNASR_API_PORT:-8194}:8194"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/musicgen-api/docker-compose.yml
+++ b/docker-configurations/services/musicgen-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${MUSICGEN_API_PORT:-8192}:8192"
+      - "127.0.0.1:${MUSICGEN_API_PORT:-8192}:8192"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/orchestrator/docker-compose.yml
+++ b/docker-configurations/services/orchestrator/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     hostname: orchestrator
     
     ports:
-      - "${ORCHESTRATOR_PORT:-8090}:8090"
+      - "127.0.0.1:${ORCHESTRATOR_PORT:-8090}:8090"
     
     volumes:
       - type: bind
@@ -87,7 +87,7 @@ services:
               capabilities: [gpu]
     
     ports:
-      - "${FLUX_PORT:-8189}:8188"
+      - "127.0.0.1:${FLUX_PORT:-8189}:8188"
     
     volumes:
       - type: bind
@@ -160,7 +160,7 @@ services:
               capabilities: [gpu]
     
     ports:
-      - "${SD35_PORT:-8190}:8000"
+      - "127.0.0.1:${SD35_PORT:-8190}:8000"
     
     volumes:
       - type: bind
@@ -233,7 +233,7 @@ services:
               capabilities: [gpu]
     
     ports:
-      - "${COMFYUI_WORKFLOWS_PORT:-8191}:8188"
+      - "127.0.0.1:${COMFYUI_WORKFLOWS_PORT:-8191}:8188"
     
     volumes:
       - type: bind

--- a/docker-configurations/services/qwen-asr-api/docker-compose.yml
+++ b/docker-configurations/services/qwen-asr-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${QWEN_ASR_PORT:-8195}:8195"
+      - "127.0.0.1:${QWEN_ASR_PORT:-8195}:8195"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/sd-forge-main/docker-compose.yml
+++ b/docker-configurations/services/sd-forge-main/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: sd-forge-main
     hostname: sd-forge-main
     ports:
-      - "7860:7860"
+      - "127.0.0.1:7860:7860"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}

--- a/docker-configurations/services/sd-forge/docker-compose.yml
+++ b/docker-configurations/services/sd-forge/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/myia-org/sd-forge:latest
     container_name: sd-forge
     ports:
-      - "7860:7860"
+      - "127.0.0.1:7860:7860"
     environment:
       - COMMANDLINE_ARGS=--listen --xformers --enable-insecure-extension-access --api
       - API_KEY=${SD_FORGE_API_KEY}

--- a/docker-configurations/services/sdnext/docker-compose.yml
+++ b/docker-configurations/services/sdnext/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: sdnext
     hostname: sdnext
     ports:
-      - "7861:7860"
+      - "127.0.0.1:7861:7860"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}

--- a/docker-configurations/services/tts-api/docker-compose.yml
+++ b/docker-configurations/services/tts-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${TTS_API_PORT:-8191}:8191"
+      - "127.0.0.1:${TTS_API_PORT:-8191}:8191"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/tts-multi/docker-compose.yml
+++ b/docker-configurations/services/tts-multi/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     hostname: tts-gateway
 
     ports:
-      - "${TTS_GATEWAY_PORT:-8196}:8000"
+      - "127.0.0.1:${TTS_GATEWAY_PORT:-8196}:8000"
 
     environment:
       - PYTHONUNBUFFERED=1

--- a/docker-configurations/services/vllm-zimage/docker-compose.yml
+++ b/docker-configurations/services/vllm-zimage/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: vllm-zimage
     ipc: host
     ports:
-      - "${VLLM_ZIMAGE_PORT:-8001}:8000"
+      - "127.0.0.1:${VLLM_ZIMAGE_PORT:-8001}:8000"
     volumes:
       - ../../shared/cache/huggingface:/root/.cache/huggingface
       - ../../shared/models:/models:ro

--- a/docker-configurations/services/whisper-api/docker-compose.yml
+++ b/docker-configurations/services/whisper-api/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${WHISPER_API_PORT:-8190}:8190"
+      - "127.0.0.1:${WHISPER_API_PORT:-8190}:8190"
 
     volumes:
       - type: bind

--- a/docker-configurations/services/whisper-webui/docker-compose.yml
+++ b/docker-configurations/services/whisper-webui/docker-compose.yml
@@ -22,7 +22,7 @@ services:
               capabilities: [gpu]
 
     ports:
-      - "${WHISPER_PORT:-36540}:7860"
+      - "127.0.0.1:${WHISPER_PORT:-36540}:7860"
 
     volumes:
       - type: bind


### PR DESCRIPTION
## Summary
- Bind all 16 GenAI Docker service ports to `127.0.0.1` instead of `0.0.0.0`
- Prevents direct LAN access that bypasses IIS reverse proxy authentication on `*.myia.io`
- 19 port bindings hardened across 16 compose files

## Services affected

| Category | Services | Ports |
|----------|----------|-------|
| Image | comfyui-qwen, comfyui-video, vllm-zimage, sd-forge-main, sd-forge, sdnext, forge-turbo | 8188, 8189, 8001, 7860×2, 7861, 17861+1111 |
| Audio | whisper-api, tts-api, musicgen-api, demucs-api, funasr-api, qwen-asr-api, tts-multi gateway, whisper-webui | 8190–8196, 36540 |
| Orchestrator | main, flux-1-dev, sd35, comfyui-workflows | 8090, 8189, 8190, 8191 |

Internal services using `expose` (not `ports`) left unchanged: tts-kokoro, tts-tada, tts-qwen workers.

## Security rationale

All services are behind IIS reverse proxy on `*.myia.io` domains with SSL and auth. Binding to `127.0.0.1` ensures all external traffic goes through IIS, preventing LAN bypass of authentication.

## Test plan
- [ ] `docker compose config` validates on each modified compose file
- [ ] Services remain accessible via `*.myia.io` (IIS routes to localhost)
- [ ] Direct LAN access on port (e.g., `curl http://82.66.89.184:8188`) returns connection refused

Addresses finding F3 from security audit (#808 / PR #844).

🤖 Generated with [Claude Code](https://claude.com/claude-code)