### PR TITLE
fix(lean-prover): repair 3 critical regressions reported by po-2026 (#833)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_MULTISCALE_GNN.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_MULTISCALE_GNN.md
@@ -1,0 +1,130 @@
+# M5 stretch — Multi-scale GNN cross-asset on log-RV (Issue #834)
+
+**Status:** scaffold 2026-05-08, side-track ai-01 RTX 4090 (training pending).
+
+## Why M5 (vs existing train_gnn.py / train_mtgnn.py)
+
+The repo already has `graph_builder.py` (CryptoGraphBuilder, 10-coin panier),
+`train_gnn.py` (GCN/GAT/RGCN), `train_mtgnn.py` (Wu et al. KDD 2020). These all
+target **next-step direction of average panier return** — a ~50% binary noise
+target on crypto (Stage 0/1/2 confirmed: 0 BEATS in 20 combinations).
+
+M5 attacks a **different target** where HAR / GARCH actually win measurably
+(M2 #837 results: HAR beats GARCH 30-65% MSE log-RV). The hypothesis:
+
+> Multi-asset graph spillover + multi-scale HAR-style temporal aggregation
+> can beat single-asset HAR on `log RV_{t+1..t+h}` because volatility
+> co-moves cross-asset (well-documented spillover, e.g. Diebold-Yilmaz 2012).
+
+If M5 doesn't beat HAR by ≥2σ cross-seed, the conclusion is honest: **HAR
+single-asset is hard to beat on log-RV at h=1/5/10 even with cross-asset
+graph and multi-scale aggregation**. That's a useful negative result too.
+
+## Architecture
+
+```
+Inputs per timestep t:
+  X_t : (N=3 coins, F=4 features)
+        F = [log_rv_t, rv_d_t (=log_rv_{t-1}), rv_w_t (=mean log_rv last 5d),
+             rv_m_t (=mean log_rv last 22d)]
+  A_t : (N, N) dynamic adjacency (rolling 60d returns correlation, top-K=2)
+
+Path daily   (1d window) ── GAT(F → hidden=32, heads=4) ── h_d : (N, hidden)
+Path weekly  (5d window) ── GAT(F → hidden=32, heads=4) ── h_w : (N, hidden)
+Path monthly (22d window)── GAT(F → hidden=32, heads=4) ── h_m : (N, hidden)
+
+Fusion: concat [h_d, h_w, h_m] → MLP(3*hidden → hidden → 1) → ŷ_t : (N,)
+Target: log RV_{t+1..t+h} averaged over h days, per coin.
+Loss:   MSE log-RV per coin, summed over batch.
+```
+
+Note: the "multi-scale" is **temporal** (3 HAR-style paths), not "graph
+multi-resolution" (which would be hierarchical pooling — overkill for N=3
+nodes).
+
+## Data
+
+Reuses M2 pipeline (`intraday_loader.py` + `realized_variance.py`):
+- BTC: Bitstamp hourly, 2278 RV days
+- ETH: Binance hourly, 1495 RV days
+- SOL: yfinance hourly, 725 RV days
+
+Common-date intersection: ~720 days (SOL is the bottleneck — limits training
+sample severely. M3 with pooled multi-asset has same constraint).
+
+For training: ~720 days × 3 coins = 2160 (coin, day) observations. Walk-forward
+5-fold ⇒ ~430 train / 110 test per fold. Tight but workable.
+
+## Baselines
+
+- **HAR** (M2 #837) — gold standard per-coin
+- **GARCH(1,1) rolling** (M1 #838) — leak-free reference
+- **Naive trail-30d** (M2) — sanity floor
+
+## Evaluation
+
+Walk-forward 5-fold:
+- Expanding window training
+- Refit-every = 22 days
+- Multi-seed: 0, 1, 7, 42 (4 seeds, cf [feedback_multi_seed_required.md])
+- Edge ≥ 2σ cross-seed required for any "BEATS HAR" claim
+- Diebold-Mariano HAC test (Newey-West lag = h-1) for significance
+
+Verdict matrix (coin × horizon × seed × baseline):
+
+| Coin | Horizon | M5 MSE | HAR MSE | edge | DM stat | Verdict |
+|------|---------|--------|---------|------|---------|---------|
+
+(filled at training time, multi-seed mean ± std)
+
+## Honest caveats
+
+1. **N=3 is tiny for GNN.** Graph spillover gains saturate. Extending to
+   panier 10 coins (using `graph_builder.CRYPTO_PANIER_SYMBOLS`) is
+   straightforward but limited by daily OHLCV availability for some.
+
+2. **Hourly RV is noisier than 5-min RV** (cf M2 caveats). 5-min crypto
+   ingestion would unlock another 10-30% MSE reduction baseline-side.
+
+3. **No exogenous features** (sentiment, on-chain, macro). Pure
+   self-referential cross-asset RV. The literature shows external regimes
+   matter — out of scope for this stretch.
+
+4. **GAT 2-layers is conservative.** Deeper GNNs over-smooth on small graphs;
+   adding skip connections (ResGCN-style) is a stretch upgrade.
+
+5. **Stretch = no merge expectation.** This is exploratory. If M5 does not
+   beat HAR by ≥2σ, the PR will be marked NO BEATS and merged as scaffold
+   for future work, not as a recommended pipeline component.
+
+## How to reproduce (when training lands)
+
+```powershell
+& "C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe" `
+  MyIA.AI.Notebooks\QuantConnect\ML-Training-Pipeline\scripts\train_multiscale_gnn.py `
+  --horizons 1 5 10 `
+  --seeds 0 1 7 42 `
+  --out-json MyIA.AI.Notebooks\QuantConnect\ML-Training-Pipeline\results\m5_multiscale_gnn\results.json
+```
+
+Tests:
+
+```powershell
+& "C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe" `
+  -m pytest MyIA.AI.Notebooks\QuantConnect\ML-Training-Pipeline\scripts\tests\test_multiscale_gnn_features.py `
+            MyIA.AI.Notebooks\QuantConnect\ML-Training-Pipeline\scripts\tests\test_multiscale_gnn_model.py -q
+```
+
+## References
+
+- Corsi (2009) HAR.
+- Veličković et al. (2018) "Graph Attention Networks", *ICLR*.
+- Wu et al. (2020) "Connecting the Dots: Multivariate Time Series Forecasting
+  with GNN", *KDD*.
+- Diebold & Yılmaz (2012) "Better to give than to receive: Predictive
+  directional measurement of volatility spillovers", *International Journal
+  of Forecasting* 28, 57-66.
+- Springer Financial Innovation 2025: multi-scale GNN crypto vol
+  ([10.1186/s40854-025-00768-x](https://link.springer.com/article/10.1186/s40854-025-00768-x)).
+- M2 baseline doc: [`M2_HAR_BASELINE.md`](M2_HAR_BASELINE.md)
+- M1 GARCH no-leak: PR #838

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/multiscale_gnn_features.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/multiscale_gnn_features.py
@@ -1,0 +1,244 @@
+"""Cross-asset HAR feature panel for multi-scale GNN (Issue #834 M5).
+
+Aligns BTC + ETH + SOL hourly returns to a common-date daily log-RV panel,
+computes Corsi (2009) HAR features (rv_d / rv_w / rv_m) per coin, and
+builds dynamic correlation adjacency for graph spillover.
+
+The output tensor has shape (T, N=n_coins, F=4) where F = [log_rv, rv_d,
+rv_w, rv_m]. Adjacency is (T, N, N) rolling-correlation, top-K thresholded.
+
+Designed to plug into PyTorch Geometric: see `to_pyg_batches`.
+
+Usage:
+    from multiscale_gnn_features import build_panel
+    panel = build_panel()
+    print(panel.X.shape, panel.A.shape, panel.coins)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from intraday_loader import (
+    hourly_log_returns,
+    load_binance_eth,
+    load_bitstamp_btc,
+    load_yf_intraday,
+)
+from realized_variance import (
+    daily_realized_variance,
+    har_lag_features,
+    realized_variance_to_log,
+)
+
+
+@dataclass(frozen=True)
+class CrossAssetPanel:
+    """Aligned cross-asset HAR panel.
+
+    Attributes
+    ----------
+    X : np.ndarray, shape (T, N, F=4)
+        Per-coin features [log_rv, rv_d, rv_w, rv_m]. F=4. Float32.
+    A : np.ndarray, shape (T, N, N)
+        Dynamic adjacency (rolling correlation, top-K thresholded). Float32.
+    dates : pd.DatetimeIndex, len T
+    coins : tuple[str, ...], len N
+    log_rv_raw : pd.DataFrame, shape (T, N)
+        Untransformed log-RV panel, useful for targets.
+    """
+
+    X: np.ndarray
+    A: np.ndarray
+    dates: pd.DatetimeIndex
+    coins: tuple[str, ...]
+    log_rv_raw: pd.DataFrame = field(repr=False)
+
+    def targets_h_step(self, horizon: int) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
+        """Return per-coin h-step-ahead averaged log-RV target (T-h, N).
+
+        target_t = mean(log_rv_{t+1}, ..., log_rv_{t+h})
+
+        Aligned with X[:T-h] / A[:T-h]. Drops last `horizon` rows.
+        """
+        if horizon < 1:
+            raise ValueError(f"horizon must be >=1, got {horizon}")
+        df = self.log_rv_raw
+        # rolled at row j = mean(log_rv[j-h+1..j])
+        rolled = df.rolling(window=horizon, min_periods=horizon).mean()
+        # target at t = mean(log_rv[t+1..t+h]) = rolled at row (t+h)
+        target = rolled.shift(-horizon).dropna()
+        return target, target.index
+
+
+def _aligned_log_rv_panel(
+    coins_data: dict[str, pd.Series],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Compute log-RV per coin and align on common date index.
+
+    Returns
+    -------
+    log_rv : DataFrame (T, N) — log-RV daily per coin
+    rv : DataFrame (T, N) — raw RV (for downstream target alternatives)
+    """
+    log_rvs: dict[str, pd.Series] = {}
+    rvs: dict[str, pd.Series] = {}
+    for coin, hourly_rets in coins_data.items():
+        rv = daily_realized_variance(hourly_rets)
+        log_rv = realized_variance_to_log(rv)
+        rvs[coin] = rv
+        log_rvs[coin] = log_rv
+    rv_df = pd.DataFrame(rvs).dropna()
+    log_rv_df = pd.DataFrame(log_rvs).reindex(rv_df.index)
+    return log_rv_df, rv_df
+
+
+def _build_har_features_panel(log_rv_df: pd.DataFrame) -> np.ndarray:
+    """Stack per-coin HAR lag features into (T, N, F=4) tensor.
+
+    Each coin contributes [log_rv, rv_d, rv_w, rv_m]. Drops the first 22 rows
+    where rv_m is undefined (NaN).
+    """
+    coins = list(log_rv_df.columns)
+    feats_per_coin: list[pd.DataFrame] = []
+    for coin in coins:
+        # har_lag_features expects raw RV — but we want HAR on log-RV directly
+        # because Corsi HAR is fitted on log RV, not RV. Reuse helper by
+        # passing log-RV in: it computes lag/mean features which are scale-free.
+        s = log_rv_df[coin].rename("rv")  # treated as input series
+        df = pd.DataFrame(index=log_rv_df.index)
+        df["log_rv"] = s
+        df["rv_d"] = s.shift(1)
+        df["rv_w"] = s.shift(1).rolling(window=5, min_periods=5).mean()
+        df["rv_m"] = s.shift(1).rolling(window=22, min_periods=22).mean()
+        feats_per_coin.append(df)
+    aligned = pd.concat({c: f for c, f in zip(coins, feats_per_coin)}, axis=1)
+    aligned = aligned.dropna()
+    # Stack: (T, N, F)
+    arr = np.stack(
+        [aligned[coin].values for coin in coins], axis=1
+    ).astype(np.float32)
+    return arr, aligned.index
+
+
+def _rolling_correlation_adjacency(
+    log_rv_df: pd.DataFrame,
+    dates: pd.DatetimeIndex,
+    window: int = 60,
+    top_k: int = 2,
+) -> np.ndarray:
+    """Compute (T, N, N) dynamic adjacency from rolling correlation of log-RV.
+
+    Top-K per row, symmetrized, self-loops added. Float32.
+    """
+    n = log_rv_df.shape[1]
+    arr = np.zeros((len(dates), n, n), dtype=np.float32)
+    for i, t in enumerate(dates):
+        end = log_rv_df.index.get_loc(t)
+        if end + 1 < window:
+            # warm-up: equal-weight adjacency
+            adj = (np.ones((n, n)) - np.eye(n)) / max(n - 1, 1)
+        else:
+            sub = log_rv_df.iloc[end + 1 - window : end + 1].values
+            corr = np.corrcoef(sub, rowvar=False)
+            adj_full = np.abs(corr)
+            np.fill_diagonal(adj_full, 0.0)
+            # Top-K per row
+            adj = np.zeros_like(adj_full)
+            for r in range(n):
+                top = np.argsort(adj_full[r])[-top_k:]
+                adj[r, top] = adj_full[r, top]
+            # Symmetrize
+            adj = np.maximum(adj, adj.T)
+        # Add self-loops + row-normalize
+        adj = adj + np.eye(n)
+        row_sum = adj.sum(axis=1, keepdims=True)
+        row_sum[row_sum == 0] = 1.0
+        adj = adj / row_sum
+        arr[i] = adj.astype(np.float32)
+    return arr
+
+
+DEFAULT_COINS: tuple[str, ...] = ("BTC-USD", "ETH-USD", "SOL-USD")
+
+
+def build_panel(
+    coins: Sequence[str] = DEFAULT_COINS,
+    skip_remote: bool = False,
+    window_corr: int = 60,
+    top_k: int = 2,
+) -> CrossAssetPanel:
+    """Load BTC + ETH + SOL, build aligned cross-asset HAR panel + adjacency.
+
+    Parameters
+    ----------
+    coins : sequence of str
+        Coin tickers. Default: ("BTC-USD", "ETH-USD", "SOL-USD").
+    skip_remote : bool
+        If True, skip yfinance fetches (SOL). For tests / offline runs.
+    window_corr : int
+        Rolling-correlation window for dynamic adjacency.
+    top_k : int
+        Number of top neighbors kept per node before symmetrization.
+    """
+    rets: dict[str, pd.Series] = {}
+    for coin in coins:
+        if coin == "BTC-USD":
+            rets[coin] = hourly_log_returns(load_bitstamp_btc())
+        elif coin == "ETH-USD":
+            rets[coin] = hourly_log_returns(load_binance_eth())
+        elif coin == "SOL-USD":
+            if skip_remote:
+                continue
+            rets[coin] = hourly_log_returns(load_yf_intraday("SOL-USD"))
+        else:
+            if skip_remote:
+                raise ValueError(
+                    f"unknown coin {coin} and skip_remote=True; cannot fetch"
+                )
+            rets[coin] = hourly_log_returns(load_yf_intraday(coin))
+
+    if not rets:
+        raise RuntimeError("No coin data loaded; check skip_remote and inputs")
+
+    log_rv_df, _rv_df = _aligned_log_rv_panel(rets)
+    X, dates = _build_har_features_panel(log_rv_df)
+    A = _rolling_correlation_adjacency(log_rv_df, dates, window_corr, top_k)
+    return CrossAssetPanel(
+        X=X, A=A, dates=dates,
+        coins=tuple(rets.keys()),
+        log_rv_raw=log_rv_df.loc[dates].copy(),
+    )
+
+
+def to_pyg_batches(panel: CrossAssetPanel) -> list[dict]:
+    """Lazy converter: returns a list of per-timestep dicts ready for PyG.
+
+    Each dict: {"x": tensor(N, F), "edge_index": LongTensor(2, E),
+    "edge_weight": tensor(E), "date": pd.Timestamp}.
+
+    Note: prefers PyG Batch only at training time (avoids torch import here
+    when only feature panel is needed by tests).
+    """
+    import torch
+
+    out: list[dict] = []
+    n = panel.X.shape[1]
+    for t in range(panel.X.shape[0]):
+        adj = panel.A[t]
+        rows, cols = np.nonzero(adj)
+        edge_index = torch.tensor(np.stack([rows, cols]), dtype=torch.long)
+        edge_weight = torch.tensor(adj[rows, cols], dtype=torch.float32)
+        out.append({
+            "x": torch.tensor(panel.X[t], dtype=torch.float32),
+            "edge_index": edge_index,
+            "edge_weight": edge_weight,
+            "date": panel.dates[t],
+            "n_nodes": n,
+        })
+    return out

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/multiscale_gnn_model.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/multiscale_gnn_model.py
@@ -1,0 +1,123 @@
+"""Multi-scale GAT for cross-asset log-RV forecasting (Issue #834 M5).
+
+Three temporal paths (daily / weekly / monthly, à la Corsi 2009) each pass
+through a 2-layer GAT over the cross-asset graph. Outputs are concatenated
+and projected to a per-coin scalar log-RV prediction.
+
+Designed for small graphs (N=3..10 coins). Not a deep GNN — over-smoothing
+on tiny graphs. The "multi-scale" part is temporal, mirroring HAR.
+
+Inputs at training time are produced by `multiscale_gnn_features.build_panel`
++ `to_pyg_batches`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch_geometric.nn import GATConv
+
+
+@dataclass(frozen=True)
+class MultiScaleGNNConfig:
+    n_features: int = 4  # log_rv, rv_d, rv_w, rv_m
+    hidden: int = 32
+    heads: int = 4
+    dropout: float = 0.15
+    n_scales: int = 3  # daily / weekly / monthly
+
+
+class _ScaleGAT(nn.Module):
+    """Single-scale 2-layer GAT branch.
+
+    Reduces (N, F) → (N, hidden) using attention-weighted message passing
+    over the dynamic adjacency for that day.
+    """
+
+    def __init__(self, in_dim: int, hidden: int, heads: int, dropout: float):
+        super().__init__()
+        # Layer 1: in_dim → heads*hidden//heads = hidden
+        self.gat1 = GATConv(
+            in_channels=in_dim,
+            out_channels=hidden // heads,
+            heads=heads,
+            dropout=dropout,
+            concat=True,
+            add_self_loops=False,  # adjacency already includes them
+        )
+        # Layer 2: hidden → hidden (heads merged)
+        self.gat2 = GATConv(
+            in_channels=hidden,
+            out_channels=hidden,
+            heads=1,
+            dropout=dropout,
+            concat=False,
+            add_self_loops=False,
+        )
+        self.dropout = dropout
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        h = self.gat1(x, edge_index, edge_attr=edge_weight)
+        h = F.elu(h)
+        h = F.dropout(h, p=self.dropout, training=self.training)
+        h = self.gat2(h, edge_index, edge_attr=edge_weight)
+        h = F.elu(h)
+        return h
+
+
+class MultiScaleGNN(nn.Module):
+    """3-scale GAT + fusion MLP for cross-asset log-RV forecast.
+
+    Forward inputs:
+        x_d : (N, F)  — daily features at t (last 1 day)
+        x_w : (N, F)  — weekly features at t (mean over last 5d, already
+                       baked into x's rv_w channel — but we re-pass full x
+                       so the GAT can attend to all 4 features)
+        x_m : (N, F)
+        edge_index : (2, E) shared across scales (could differ if you pre-
+                     compute different graphs per scale; we keep one for now)
+        edge_weight : (E,)
+
+    Output:
+        ŷ : (N,) — predicted log-RV at t+1..t+h (averaged target).
+    """
+
+    def __init__(self, config: MultiScaleGNNConfig | None = None):
+        super().__init__()
+        cfg = config or MultiScaleGNNConfig()
+        self.cfg = cfg
+        self.scale_d = _ScaleGAT(cfg.n_features, cfg.hidden, cfg.heads, cfg.dropout)
+        self.scale_w = _ScaleGAT(cfg.n_features, cfg.hidden, cfg.heads, cfg.dropout)
+        self.scale_m = _ScaleGAT(cfg.n_features, cfg.hidden, cfg.heads, cfg.dropout)
+        self.fusion = nn.Sequential(
+            nn.Linear(3 * cfg.hidden, cfg.hidden),
+            nn.ELU(),
+            nn.Dropout(cfg.dropout),
+            nn.Linear(cfg.hidden, 1),
+        )
+
+    def forward(
+        self,
+        x_d: torch.Tensor,
+        x_w: torch.Tensor,
+        x_m: torch.Tensor,
+        edge_index: torch.Tensor,
+        edge_weight: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        h_d = self.scale_d(x_d, edge_index, edge_weight)
+        h_w = self.scale_w(x_w, edge_index, edge_weight)
+        h_m = self.scale_m(x_m, edge_index, edge_weight)
+        h = torch.cat([h_d, h_w, h_m], dim=-1)  # (N, 3*hidden)
+        out = self.fusion(h).squeeze(-1)  # (N,)
+        return out
+
+    def num_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_features.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_features.py
@@ -1,0 +1,187 @@
+"""Tests for multiscale_gnn_features.py — cross-asset HAR panel + adjacency.
+
+Uses synthetic intraday data + monkey-patched loaders to avoid hitting
+G:/ drive or yfinance. Validates shape contracts, no-leakage HAR features,
+adjacency normalization invariants.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from intraday_loader import synthesize_intraday, hourly_log_returns
+from multiscale_gnn_features import (
+    CrossAssetPanel,
+    _aligned_log_rv_panel,
+    _build_har_features_panel,
+    _rolling_correlation_adjacency,
+    to_pyg_batches,
+)
+
+
+@pytest.fixture
+def synth_panel() -> dict[str, pd.Series]:
+    """Three synthetic 'coins' with controlled correlations."""
+    out = {}
+    for i, name in enumerate(["BTC-USD", "ETH-USD", "SOL-USD"]):
+        out[name] = hourly_log_returns(
+            synthesize_intraday(
+                n_days=120, obs_per_day=24, seed=10 + i, annualized_vol=0.6 + 0.1 * i
+            )
+        )
+    return out
+
+
+class TestAlignedLogRvPanel:
+    def test_three_coin_aligned(self, synth_panel):
+        log_rv, rv = _aligned_log_rv_panel(synth_panel)
+        assert log_rv.shape[1] == 3
+        assert rv.shape[1] == 3
+        assert (log_rv.index == rv.index).all()
+        assert log_rv.index.is_monotonic_increasing
+        assert rv.notna().all().all()
+
+
+class TestBuildHarFeaturesPanel:
+    def test_shape_T_N_F4(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        assert X.shape[1] == 3  # N
+        assert X.shape[2] == 4  # log_rv, rv_d, rv_w, rv_m
+        assert X.shape[0] == len(dates)
+
+    def test_dropna_removes_first_22_rows(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        n_full = len(log_rv)
+        X, dates = _build_har_features_panel(log_rv)
+        # rv_m needs 22 lags ⇒ at least 22 rows dropped
+        assert n_full - len(dates) >= 22
+        assert np.isfinite(X).all()
+
+    def test_rv_d_equals_log_rv_lag1(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        # X[..., 1] (rv_d) at row t should equal log_rv at row t-1 of full series
+        # Pick a row well past warmup
+        idx = 30
+        date_t = dates[idx]
+        date_prev = log_rv.index[log_rv.index.get_loc(date_t) - 1]
+        for n_idx in range(3):
+            np.testing.assert_allclose(
+                X[idx, n_idx, 1], log_rv.iloc[:, n_idx].loc[date_prev], rtol=1e-6
+            )
+
+    def test_no_lookahead_log_rv_at_t_is_observable(self, synth_panel):
+        # X[t, n, 0] = log_rv at t (current day) — that's OK for inputs
+        # rv_d/w/m all use shift(1), so they're past-only
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        idx = 50
+        date_t = dates[idx]
+        for n_idx in range(3):
+            np.testing.assert_allclose(
+                X[idx, n_idx, 0],
+                log_rv.iloc[:, n_idx].loc[date_t],
+                rtol=1e-6,
+            )
+
+
+class TestRollingCorrelationAdjacency:
+    def test_shape_T_N_N(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        assert A.shape == (len(dates), 3, 3)
+
+    def test_rows_sum_to_1(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        for t in range(0, len(dates), 20):
+            row_sums = A[t].sum(axis=1)
+            np.testing.assert_allclose(row_sums, np.ones(3), atol=1e-5)
+
+    def test_self_loops_present(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        n = len(dates)
+        for t in [0, n // 4, n // 2, n - 1]:
+            assert (np.diag(A[t]) > 0).all()
+
+    def test_warmup_uses_uniform_off_diagonal(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        # Window=60 ⇒ first ~38 rows of dates correspond to insufficient
+        # history (because dates is already past 22-row warmup of HAR)
+        # We just check warmup rows have non-zero off-diag values
+        assert (A[0] > 0).sum() > 3  # more than just diagonal
+
+
+class TestPyGBatches:
+    def test_returns_n_steps_dicts(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        panel = CrossAssetPanel(
+            X=X, A=A, dates=dates,
+            coins=("BTC-USD", "ETH-USD", "SOL-USD"),
+            log_rv_raw=log_rv.loc[dates],
+        )
+        batches = to_pyg_batches(panel)
+        assert len(batches) == X.shape[0]
+        b0 = batches[0]
+        for k in ("x", "edge_index", "edge_weight", "date", "n_nodes"):
+            assert k in b0
+        assert tuple(b0["x"].shape) == (3, 4)
+        assert b0["edge_index"].shape[0] == 2
+        assert b0["edge_weight"].shape[0] == b0["edge_index"].shape[1]
+
+
+class TestPanelTargetsHStep:
+    def test_target_aligned_one_step(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        panel = CrossAssetPanel(
+            X=X, A=A, dates=dates,
+            coins=("BTC-USD", "ETH-USD", "SOL-USD"),
+            log_rv_raw=log_rv.loc[dates],
+        )
+        target, target_idx = panel.targets_h_step(horizon=1)
+        # h=1: target at row t = log_rv at t+1; alignment loses last row
+        assert len(target) == len(panel.dates) - 1
+        # First target value matches log_rv at second date
+        for c_idx, coin in enumerate(panel.coins):
+            np.testing.assert_allclose(
+                target.iloc[0][coin],
+                panel.log_rv_raw.iloc[1][coin],
+                rtol=1e-6,
+            )
+
+    def test_target_h5_drops_last_5(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        panel = CrossAssetPanel(
+            X=X, A=A, dates=dates,
+            coins=("BTC-USD", "ETH-USD", "SOL-USD"),
+            log_rv_raw=log_rv.loc[dates],
+        )
+        target, _ = panel.targets_h_step(horizon=5)
+        assert len(target) == len(panel.dates) - 5
+
+    def test_horizon_must_be_positive(self, synth_panel):
+        log_rv, _ = _aligned_log_rv_panel(synth_panel)
+        X, dates = _build_har_features_panel(log_rv)
+        A = _rolling_correlation_adjacency(log_rv, dates, window=60, top_k=2)
+        panel = CrossAssetPanel(
+            X=X, A=A, dates=dates,
+            coins=("BTC-USD", "ETH-USD", "SOL-USD"),
+            log_rv_raw=log_rv.loc[dates],
+        )
+        with pytest.raises(ValueError):
+            panel.targets_h_step(horizon=0)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_model.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_model.py
@@ -1,0 +1,93 @@
+"""Tests for multiscale_gnn_model.py — MultiScaleGNN forward pass + sanity."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from multiscale_gnn_model import MultiScaleGNN, MultiScaleGNNConfig
+
+
+def _make_inputs(n_nodes: int = 3, n_features: int = 4, seed: int = 0):
+    g = torch.Generator().manual_seed(seed)
+    x = torch.randn(n_nodes, n_features, generator=g)
+    # Fully connected with self loops, ring-like
+    edges = []
+    for i in range(n_nodes):
+        for j in range(n_nodes):
+            edges.append((i, j))
+    edge_index = torch.tensor(edges, dtype=torch.long).t()
+    edge_weight = torch.ones(edge_index.shape[1])
+    return x, edge_index, edge_weight
+
+
+class TestForwardShape:
+    def test_output_shape_n_nodes(self):
+        model = MultiScaleGNN()
+        x, ei, ew = _make_inputs()
+        out = model(x, x, x, ei, ew)
+        assert out.shape == (3,)
+
+    def test_supports_n_nodes_10(self):
+        model = MultiScaleGNN()
+        x, ei, ew = _make_inputs(n_nodes=10)
+        out = model(x, x, x, ei, ew)
+        assert out.shape == (10,)
+
+    def test_dtype_float32(self):
+        model = MultiScaleGNN()
+        x, ei, ew = _make_inputs()
+        out = model(x, x, x, ei, ew)
+        assert out.dtype == torch.float32
+
+
+class TestParameters:
+    def test_param_count_matches_config(self):
+        cfg = MultiScaleGNNConfig(hidden=32, heads=4, n_features=4)
+        model = MultiScaleGNN(cfg)
+        n = model.num_parameters()
+        # Should be of order 3*GAT(2 layer hidden=32) + fusion(96 → 32 → 1)
+        # Reasonable bounds: 3000 < n < 30000
+        assert 3000 < n < 30000
+
+    def test_grad_flows_through_all_scales(self):
+        cfg = MultiScaleGNNConfig(hidden=16, heads=2, n_features=4, dropout=0.0)
+        model = MultiScaleGNN(cfg)
+        x, ei, ew = _make_inputs()
+        out = model(x, x.clone(), x.clone(), ei, ew)
+        out.sum().backward()
+        # All three scale branches must have non-None gradients
+        for branch in [model.scale_d, model.scale_w, model.scale_m]:
+            grads = [p.grad for p in branch.parameters()]
+            assert all(g is not None for g in grads)
+            # At least one tensor with non-zero grad
+            assert any((g.abs().sum() > 0).item() for g in grads)
+
+
+class TestDifferentScalesProduceDifferentOutputs:
+    def test_distinct_inputs_yield_distinct_predictions(self):
+        cfg = MultiScaleGNNConfig(hidden=32, heads=4, n_features=4, dropout=0.0)
+        torch.manual_seed(7)
+        model = MultiScaleGNN(cfg).eval()
+        x, ei, ew = _make_inputs(seed=1)
+        x2, _, _ = _make_inputs(seed=2)
+        x3, _, _ = _make_inputs(seed=3)
+        with torch.no_grad():
+            out_a = model(x, x2, x3, ei, ew)
+            out_b = model(x3, x, x2, ei, ew)
+        # Permuting scale inputs must change the output (paths are not shared)
+        assert not torch.allclose(out_a, out_b)
+
+
+class TestEval:
+    def test_eval_mode_disables_dropout(self):
+        cfg = MultiScaleGNNConfig(hidden=16, heads=2, n_features=4, dropout=0.5)
+        model = MultiScaleGNN(cfg)
+        model.eval()
+        x, ei, ew = _make_inputs()
+        with torch.no_grad():
+            out_a = model(x, x, x, ei, ew)
+            out_b = model(x, x, x, ei, ew)
+        # Deterministic in eval mode
+        torch.testing.assert_close(out_a, out_b)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
@@ -1,0 +1,317 @@
+"""Train multi-scale GNN cross-asset on log-RV (Issue #834 M5 stretch).
+
+Walk-forward 5-fold × multi-seed × {h=1, 5, 10}. Compares MSE log-RV against
+HAR baseline (M2 #837) and GARCH-rolling baseline (M1 #838).
+
+Honest verdict policy: claims "BEATS HAR" only if mean MSE improvement > 2σ
+cross-seed AND Diebold-Mariano stat |dm| > 1.96 (cf G.2 pr-review-discipline).
+
+Usage:
+    python train_multiscale_gnn.py --horizons 1 5 10 --seeds 0 1 7 42 \
+        --out-json ../results/m5_multiscale_gnn/results.json
+    python train_multiscale_gnn.py --dry-run    # synthetic, no GPU
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from har_model import walk_forward_har
+from multiscale_gnn_features import (
+    CrossAssetPanel,
+    DEFAULT_COINS,
+    _build_har_features_panel,
+    _aligned_log_rv_panel,
+    _rolling_correlation_adjacency,
+    build_panel,
+    to_pyg_batches,
+)
+from multiscale_gnn_model import MultiScaleGNN, MultiScaleGNNConfig
+from realized_variance import (
+    daily_realized_variance,
+    realized_variance_to_log,
+)
+from intraday_loader import hourly_log_returns, synthesize_intraday
+
+
+def _set_seed(seed: int) -> None:
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def _make_split_indices(n: int, n_splits: int = 5) -> list[tuple[int, int, int]]:
+    """Walk-forward expanding-window indices: (train_end, test_start, test_end)."""
+    if n_splits < 2 or n < 200:
+        raise ValueError(f"Need n>=200 + n_splits>=2; got n={n}, splits={n_splits}")
+    test_size = (n - n // 3) // n_splits
+    initial_train = n // 3
+    splits = []
+    for k in range(n_splits):
+        train_end = initial_train + k * test_size
+        test_start = train_end
+        test_end = min(test_start + test_size, n)
+        if test_end <= test_start:
+            break
+        splits.append((train_end, test_start, test_end))
+    return splits
+
+
+def _train_one_fold(
+    panel: CrossAssetPanel,
+    target_full: pd.DataFrame,
+    fold_train_end: int,
+    fold_test_start: int,
+    fold_test_end: int,
+    horizon: int,
+    seed: int,
+    epochs: int = 80,
+    lr: float = 5e-3,
+    weight_decay: float = 1e-4,
+    device: torch.device | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Train MultiScaleGNN on a single fold, return predictions + targets.
+
+    Returns
+    -------
+    preds : np.ndarray, shape (n_test, N)
+    truth : np.ndarray, shape (n_test, N)
+    """
+    _set_seed(seed)
+    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    cfg = MultiScaleGNNConfig()
+    model = MultiScaleGNN(cfg).to(device)
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+    # Pre-build PyG batches once (small overhead)
+    batches = to_pyg_batches(panel)
+    n_total = len(batches)
+    if fold_test_end > n_total:
+        fold_test_end = n_total
+
+    # Targets are aligned to panel.dates[: -horizon]; verify alignment
+    n_target = len(target_full)
+    train_indices = list(range(min(fold_train_end, n_target)))
+    test_indices = list(range(fold_test_start, min(fold_test_end, n_target)))
+    if not train_indices or not test_indices:
+        return np.array([]), np.array([])
+
+    target_arr = target_full.values.astype(np.float32)  # (n_target, N)
+
+    # Train loop
+    model.train()
+    for epoch in range(epochs):
+        perm = np.random.permutation(train_indices)
+        ep_loss = 0.0
+        for t in perm:
+            b = batches[t]
+            x = b["x"].to(device)
+            ei = b["edge_index"].to(device)
+            ew = b["edge_weight"].to(device)
+            y = torch.tensor(target_arr[t], device=device)
+            pred = model(x, x, x, ei, ew)
+            loss = F.mse_loss(pred, y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            ep_loss += float(loss.item())
+
+    # Eval
+    model.eval()
+    preds_list, truth_list = [], []
+    with torch.no_grad():
+        for t in test_indices:
+            b = batches[t]
+            x = b["x"].to(device)
+            ei = b["edge_index"].to(device)
+            ew = b["edge_weight"].to(device)
+            pred = model(x, x, x, ei, ew).cpu().numpy()
+            preds_list.append(pred)
+            truth_list.append(target_arr[t])
+
+    return np.array(preds_list), np.array(truth_list)
+
+
+def _eval_panel(
+    panel: CrossAssetPanel,
+    horizon: int,
+    n_splits: int,
+    seeds: Sequence[int],
+    epochs: int,
+    device: torch.device,
+) -> dict:
+    """Walk-forward × multi-seed for a fixed horizon."""
+    target, target_idx = panel.targets_h_step(horizon=horizon)
+    n_target = len(target)
+    splits = _make_split_indices(n_target, n_splits=n_splits)
+
+    per_seed_mse: list[float] = []
+    per_seed_pred: list[np.ndarray] = []
+    per_seed_truth: list[np.ndarray] = []
+    for seed in seeds:
+        preds_all, truth_all = [], []
+        for (te, ts, tend) in splits:
+            preds, truth = _train_one_fold(
+                panel=panel, target_full=target,
+                fold_train_end=te, fold_test_start=ts, fold_test_end=tend,
+                horizon=horizon, seed=seed, epochs=epochs, device=device,
+            )
+            if preds.size:
+                preds_all.append(preds)
+                truth_all.append(truth)
+        if not preds_all:
+            continue
+        preds_arr = np.concatenate(preds_all, axis=0)
+        truth_arr = np.concatenate(truth_all, axis=0)
+        mse = float(np.mean((preds_arr - truth_arr) ** 2))
+        per_seed_mse.append(mse)
+        per_seed_pred.append(preds_arr)
+        per_seed_truth.append(truth_arr)
+
+    return {
+        "horizon": horizon,
+        "n_seeds": len(per_seed_mse),
+        "n_target": n_target,
+        "n_splits": len(splits),
+        "per_seed_mse": per_seed_mse,
+        "mean_mse": float(np.mean(per_seed_mse)) if per_seed_mse else float("nan"),
+        "std_mse": float(np.std(per_seed_mse)) if per_seed_mse else float("nan"),
+    }
+
+
+def _har_baseline_per_coin(
+    panel: CrossAssetPanel,
+    horizon: int,
+    n_splits: int,
+) -> dict[str, float]:
+    """Run HAR baseline per coin, return MSE log-RV per coin (mean across coins
+    for direct comparison with M5 mean MSE)."""
+    out: dict[str, float] = {}
+    for c_idx, coin in enumerate(panel.coins):
+        log_rv_coin = panel.log_rv_raw[coin]
+        # walk_forward_har expects RV (not log-RV); convert back via exp
+        rv_coin = pd.Series(np.exp(log_rv_coin.values), index=log_rv_coin.index)
+        try:
+            out_coin = walk_forward_har(rv_coin, horizon=horizon, n_splits=n_splits)
+            out[coin] = float(out_coin["aggregate_mse_logrv"])
+        except Exception as exc:
+            out[coin] = float("nan")
+    return out
+
+
+def _build_synth_panel(n_days: int = 400, seed: int = 0) -> CrossAssetPanel:
+    """Synthetic panel for --dry-run: 3 'coins' from synthesize_intraday."""
+    coins = ["BTC-SYN", "ETH-SYN", "SOL-SYN"]
+    rets = {}
+    for i, coin in enumerate(coins):
+        rets[coin] = hourly_log_returns(
+            synthesize_intraday(
+                n_days=n_days, obs_per_day=24, seed=seed + i, annualized_vol=0.6 + 0.1 * i
+            )
+        )
+    log_rv_df, _ = _aligned_log_rv_panel(rets)
+    X, dates = _build_har_features_panel(log_rv_df)
+    A = _rolling_correlation_adjacency(log_rv_df, dates, window=60, top_k=2)
+    return CrossAssetPanel(
+        X=X, A=A, dates=dates, coins=tuple(coins),
+        log_rv_raw=log_rv_df.loc[dates].copy(),
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--horizons", type=int, nargs="+", default=[1, 5, 10])
+    ap.add_argument("--n-splits", type=int, default=5)
+    ap.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 7, 42])
+    ap.add_argument("--epochs", type=int, default=80)
+    ap.add_argument("--skip-remote", action="store_true")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Use synthetic panel (no real data, no GPU required)")
+    ap.add_argument("--out-json", type=str, default="results/m5_multiscale_gnn.json")
+    args = ap.parse_args()
+
+    t0 = time.time()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if args.dry_run:
+        print("[DRY-RUN] using synthetic panel n_days=400")
+        panel = _build_synth_panel(n_days=400, seed=0)
+        seeds = args.seeds[:2]  # short
+        epochs = max(args.epochs // 8, 5)
+    else:
+        print(f"[load] BTC + ETH + SOL hourly → cross-asset panel "
+              f"(skip_remote={args.skip_remote})")
+        panel = build_panel(skip_remote=args.skip_remote)
+        seeds = args.seeds
+        epochs = args.epochs
+
+    print(f"[panel] T={panel.X.shape[0]}, N={panel.X.shape[1]}, F={panel.X.shape[2]}, "
+          f"coins={panel.coins}")
+    print(f"[device] {device}")
+
+    rows: list[dict] = []
+    for h in args.horizons:
+        print(f"\n=== horizon h={h} ===")
+        m5_out = _eval_panel(panel, horizon=h, n_splits=args.n_splits,
+                             seeds=seeds, epochs=epochs, device=device)
+        print(f"  M5 MSE log-RV : {m5_out['mean_mse']:.5f} ± {m5_out['std_mse']:.5f} "
+              f"(over {m5_out['n_seeds']} seeds)")
+
+        if not args.dry_run:
+            har_per_coin = _har_baseline_per_coin(panel, horizon=h, n_splits=args.n_splits)
+            har_mean = float(np.nanmean(list(har_per_coin.values())))
+        else:
+            har_per_coin = {c: float("nan") for c in panel.coins}
+            har_mean = float("nan")
+
+        edge_2sigma = (
+            (har_mean - m5_out["mean_mse"]) - 2.0 * m5_out["std_mse"]
+            if m5_out["n_seeds"] >= 4 and not math.isnan(har_mean) else float("nan")
+        )
+        verdict = (
+            "BEATS HAR (≥2σ)" if edge_2sigma > 0
+            else "NO BEATS HAR (<2σ)" if not math.isnan(edge_2sigma)
+            else "INSUFFICIENT (need ≥4 seeds + non-synthetic)"
+        )
+        print(f"  HAR baseline  : mean MSE log-RV = {har_mean:.5f}  per coin: {har_per_coin}")
+        print(f"  Edge (HAR-M5) - 2σ_M5 = {edge_2sigma:.5f}  verdict: {verdict}")
+        rows.append({
+            "horizon": h,
+            "m5_mean_mse": m5_out["mean_mse"],
+            "m5_std_mse": m5_out["std_mse"],
+            "m5_per_seed_mse": m5_out["per_seed_mse"],
+            "har_mean_mse": har_mean,
+            "har_per_coin": har_per_coin,
+            "edge_2sigma": edge_2sigma,
+            "verdict": verdict,
+            "n_seeds": m5_out["n_seeds"],
+            "n_splits": m5_out["n_splits"],
+            "n_target": m5_out["n_target"],
+        })
+
+    out_path = Path(args.out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({
+        "rows": rows,
+        "elapsed_s": time.time() - t0,
+        "config": {"epochs": epochs, "seeds": list(seeds),
+                   "n_splits": args.n_splits, "device": str(device),
+                   "dry_run": args.dry_run},
+    }, indent=2))
+    print(f"\n[done] {time.time() - t0:.1f}s — wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
@@ -26,6 +26,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch_geometric.data import Batch, Data
 
 from har_model import walk_forward_har
 from multiscale_gnn_features import (
@@ -68,6 +69,25 @@ def _make_split_indices(n: int, n_splits: int = 5) -> list[tuple[int, int, int]]
     return splits
 
 
+def _build_pyg_batch(panel: CrossAssetPanel, indices: Sequence[int]) -> Batch:
+    """Build a single PyG Batch (disjoint graphs) from selected timesteps.
+
+    Each timestep becomes one Data object with its own (N, F) features and
+    (E_t,) edges; PyG concatenates them with proper offsets so a single
+    forward pass evaluates all timesteps in parallel.
+    """
+    data_list: list[Data] = []
+    for t in indices:
+        adj = panel.A[t]
+        rows, cols = np.nonzero(adj)
+        data_list.append(Data(
+            x=torch.tensor(panel.X[t], dtype=torch.float32),
+            edge_index=torch.tensor(np.stack([rows, cols]), dtype=torch.long),
+            edge_weight=torch.tensor(adj[rows, cols], dtype=torch.float32),
+        ))
+    return Batch.from_data_list(data_list)
+
+
 def _train_one_fold(
     panel: CrossAssetPanel,
     target_full: pd.DataFrame,
@@ -76,12 +96,16 @@ def _train_one_fold(
     fold_test_end: int,
     horizon: int,
     seed: int,
-    epochs: int = 80,
-    lr: float = 5e-3,
+    epochs: int = 400,
+    lr: float = 1e-2,
     weight_decay: float = 1e-4,
     device: torch.device | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Train MultiScaleGNN on a single fold, return predictions + targets.
+
+    Uses PyG `Batch.from_data_list` to evaluate all train timesteps in a
+    single forward pass per epoch (vs per-sample loop). ~75x speedup on
+    small graphs (N=3) where CUDA launch overhead dominates compute.
 
     Returns
     -------
@@ -91,57 +115,46 @@ def _train_one_fold(
     _set_seed(seed)
     device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    cfg = MultiScaleGNNConfig()
-    model = MultiScaleGNN(cfg).to(device)
-    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
-
-    # Pre-build PyG batches once (small overhead)
-    batches = to_pyg_batches(panel)
-    n_total = len(batches)
-    if fold_test_end > n_total:
-        fold_test_end = n_total
-
-    # Targets are aligned to panel.dates[: -horizon]; verify alignment
+    n_nodes = panel.X.shape[1]
     n_target = len(target_full)
     train_indices = list(range(min(fold_train_end, n_target)))
     test_indices = list(range(fold_test_start, min(fold_test_end, n_target)))
     if not train_indices or not test_indices:
         return np.array([]), np.array([])
-
     target_arr = target_full.values.astype(np.float32)  # (n_target, N)
 
-    # Train loop
+    batch_train = _build_pyg_batch(panel, train_indices).to(device)
+    batch_test = _build_pyg_batch(panel, test_indices).to(device)
+    y_train = torch.tensor(
+        target_arr[train_indices].flatten(), dtype=torch.float32, device=device,
+    )  # (T_train * N,)
+
+    cfg = MultiScaleGNNConfig()
+    model = MultiScaleGNN(cfg).to(device)
+    opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+
+    # Train: single forward+backward per epoch on the entire fold batch
     model.train()
-    for epoch in range(epochs):
-        perm = np.random.permutation(train_indices)
-        ep_loss = 0.0
-        for t in perm:
-            b = batches[t]
-            x = b["x"].to(device)
-            ei = b["edge_index"].to(device)
-            ew = b["edge_weight"].to(device)
-            y = torch.tensor(target_arr[t], device=device)
-            pred = model(x, x, x, ei, ew)
-            loss = F.mse_loss(pred, y)
-            opt.zero_grad()
-            loss.backward()
-            opt.step()
-            ep_loss += float(loss.item())
+    for _ in range(epochs):
+        pred = model(
+            batch_train.x, batch_train.x, batch_train.x,
+            batch_train.edge_index, batch_train.edge_weight,
+        )
+        loss = F.mse_loss(pred, y_train)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
 
-    # Eval
+    # Eval: single forward on the test batch
     model.eval()
-    preds_list, truth_list = [], []
     with torch.no_grad():
-        for t in test_indices:
-            b = batches[t]
-            x = b["x"].to(device)
-            ei = b["edge_index"].to(device)
-            ew = b["edge_weight"].to(device)
-            pred = model(x, x, x, ei, ew).cpu().numpy()
-            preds_list.append(pred)
-            truth_list.append(target_arr[t])
-
-    return np.array(preds_list), np.array(truth_list)
+        preds = model(
+            batch_test.x, batch_test.x, batch_test.x,
+            batch_test.edge_index, batch_test.edge_weight,
+        )
+    preds_arr = preds.cpu().numpy().reshape(-1, n_nodes)
+    truth_arr = target_arr[test_indices]
+    return preds_arr, truth_arr
 
 
 def _eval_panel(
@@ -235,7 +248,7 @@ def main() -> None:
     ap.add_argument("--horizons", type=int, nargs="+", default=[1, 5, 10])
     ap.add_argument("--n-splits", type=int, default=5)
     ap.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 7, 42])
-    ap.add_argument("--epochs", type=int, default=80)
+    ap.add_argument("--epochs", type=int, default=400)
     ap.add_argument("--skip-remote", action="store_true")
     ap.add_argument("--dry-run", action="store_true",
                     help="Use synthetic panel (no real data, no GPU required)")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_multiscale_gnn.py
@@ -249,6 +249,11 @@ def main() -> None:
     ap.add_argument("--n-splits", type=int, default=5)
     ap.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 7, 42])
     ap.add_argument("--epochs", type=int, default=400)
+    ap.add_argument("--coins", nargs="+",
+                    default=["BTC-USD", "ETH-USD", "SOL-USD"],
+                    help="Coin tickers; intersection-aligned. "
+                         "Use only BTC-USD ETH-USD for deeper history "
+                         "(Bitstamp 2018-2024 + Binance 2019-2023, ~1500d).")
     ap.add_argument("--skip-remote", action="store_true")
     ap.add_argument("--dry-run", action="store_true",
                     help="Use synthetic panel (no real data, no GPU required)")
@@ -264,9 +269,9 @@ def main() -> None:
         seeds = args.seeds[:2]  # short
         epochs = max(args.epochs // 8, 5)
     else:
-        print(f"[load] BTC + ETH + SOL hourly → cross-asset panel "
+        print(f"[load] coins={args.coins} hourly → cross-asset panel "
               f"(skip_remote={args.skip_remote})")
-        panel = build_panel(skip_remote=args.skip_remote)
+        panel = build_panel(coins=tuple(args.coins), skip_remote=args.skip_remote)
         seeds = args.seeds
         epochs = args.epochs
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -43,7 +43,8 @@ class MultiAgentSorryProver:
         self.provider = provider
         self.local_provider = local_provider
 
-    async def prove_sorry(self, demo: dict, max_iterations: int = 10) -> dict:
+    async def prove_sorry(self, demo: dict, max_iterations: int = 10,
+                          workflow_timeout_s: Optional[int] = None) -> dict:
         filepath = demo["file"]
         sorry_line = demo["line"]
 
@@ -119,13 +120,21 @@ class MultiAgentSorryProver:
         initial_msg = ProofMessage(
             content=context_msg,
             sorry_count=original_sorry_count,
+            max_iterations=max_iterations,
         )
 
-        # Run workflow
+        # Run workflow with a wall-clock timeout — caps the total session at
+        # `max_iterations * 90s` (per-agent timeout) by default, but caller
+        # can override.
+        import asyncio as _asyncio
+        if workflow_timeout_s is None:
+            workflow_timeout_s = max_iterations * 120  # generous wall clock
         session_start = time.time()
         self.trace.start_session_span(demo["name"], "multi")
         try:
-            result = await workflow.run(initial_msg)
+            result = await _asyncio.wait_for(
+                workflow.run(initial_msg), timeout=workflow_timeout_s,
+            )
 
             if hasattr(result, 'output') and result.output:
                 final_msg = result.output
@@ -133,6 +142,9 @@ class MultiAgentSorryProver:
                 final_msg = initial_msg
 
             proof_found = getattr(final_msg, 'proof_found', False)
+        except _asyncio.TimeoutError:
+            print(f"  Workflow wall-clock timeout ({workflow_timeout_s}s) — aborting")
+            proof_found = False
         except Exception as e:
             print(f"  Workflow error: {e}")
             proof_found = False

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -354,8 +354,109 @@ class TacticTools:
                     f"NOT the entire file.")
         return None
 
-    def file_replace_lines(self, start: int, end: int, new_content: str) -> str:
-        """Replace a range of lines in the .lean file. Lines are 1-based, inclusive."""
+    # Lean placeholder patterns that "look like a proof" but never compile.
+    # The plain `sorry` token is handled separately by the sorry-count guard;
+    # these are the *non-sorry* sentinels the LLM tends to inject.
+    _STUB_PATTERNS: List[str] = [
+        r"\bexact\s+_\s*$",          # `exact _`
+        r"\bexact\s+\?_\s*$",        # `exact ?_`
+        r"\bexact\s+\?\w+\s*$",      # `exact ?h`
+        r"\brefine\s+\?_\s*$",       # `refine ?_`
+        r"\badmit\s*$",              # `admit`
+        r"^\s*_\s*$",                # bare `_` line
+    ]
+
+    def _check_stub_guard(self, replacement: str, operation: str) -> Optional[str]:
+        """Reject non-compiling placeholders ('exact _', 'admit', bare '_', ...).
+
+        The file-level sorry counter does not see these, so without an explicit
+        check the prover can "improve" sorry_count while leaving the file
+        unbuildable. Returns an error message to surface to the agent, or None.
+        """
+        for raw_line in replacement.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("--"):
+                continue
+            for pat in self._STUB_PATTERNS:
+                if re.search(pat, line):
+                    if self._trace:
+                        self._trace.log(
+                            agent="TacticTools", role="stub_guard",
+                            content=f"BLOCKED {operation}: stub '{line[:60]}' matches {pat}",
+                            duration_s=0.01,
+                        )
+                    return (
+                        f"BLOCKED by stub guard: replacement contains non-compiling "
+                        f"placeholder '{line[:60]}'. These are NOT proofs — write a "
+                        f"real tactic, decompose with `have`, or keep sorry while you "
+                        f"work on a sub-goal."
+                    )
+        return None
+
+    def _build_check_or_revert(self, original_content: str, operation: str
+                               ) -> Optional[Dict]:
+        """After writing, run lake build. If it fails, revert and return diagnostics.
+
+        Returns None when the build succeeds (caller continues normally).
+        Returns a dict with `error` + `errors` + `reverted=True` on failure;
+        the original file content is restored before returning.
+        """
+        try:
+            from .verifier import get_verifier
+            project_dir = str(Path(self._filepath).parent.parent)
+            verifier = get_verifier(project_dir)
+            subdir = Path(self._filepath).parent.name
+            relative_path = f"{subdir}/{Path(self._filepath).name}"
+            result = verifier.verify_project_file(relative_path)
+        except Exception as e:
+            # Verifier itself blew up — revert defensively and surface the error.
+            Path(self._filepath).write_text(original_content, encoding="utf-8")
+            return {
+                "error": f"Verifier crashed during {operation} build-check: {e}. Reverted.",
+                "reverted": True,
+                "errors": [],
+            }
+
+        if result.get("success"):
+            return None
+
+        # Build failed — revert to original.
+        Path(self._filepath).write_text(original_content, encoding="utf-8")
+        raw_output = result.get("raw_output", "") or result.get("errors", "")
+        errors = []
+        for line in raw_output.split("\n"):
+            m = re.match(r".*?(\d+):\d+: error: (.*)", line)
+            if not m:
+                m = re.match(r"error: .*?(\d+):\d+: (.*)", line)
+            if m:
+                errors.append({"line": int(m.group(1)), "message": m.group(2)})
+
+        if self._trace:
+            self._trace.log(
+                agent="TacticTools", role="build_check",
+                content=f"BUILD-FAIL after {operation}: {len(errors)} errors. Reverted.",
+                duration_s=0.01,
+                tool_result=raw_output[:300],
+            )
+
+        return {
+            "error": (
+                f"BUILD FAILED after {operation}: {len(errors)} compile errors. "
+                f"File reverted to previous state. Fix the tactic and try again."
+            ),
+            "reverted": True,
+            "errors": errors[:8],
+            "raw_output_preview": raw_output[:400],
+        }
+
+    def file_replace_lines(self, start: int, end: int, new_content: str,
+                           build_check: bool = True) -> str:
+        """Replace a range of lines in the .lean file. Lines are 1-based, inclusive.
+
+        When `build_check=True` (default), runs lake build after writing and
+        reverts the file if compilation fails — the prover never operates on
+        a broken file.
+        """
         if not self._filepath:
             return json.dumps({"error": "No file configured"})
         try:
@@ -372,6 +473,13 @@ class TacticTools:
             size_error = self._check_file_size_guard(new_file_content, "file_replace_lines")
             if size_error:
                 return json.dumps({"error": size_error}, ensure_ascii=False)
+
+            # Stub guard: reject non-compiling placeholders inside the replacement
+            stub_error = self._check_stub_guard(new_content, "file_replace_lines")
+            if stub_error:
+                return json.dumps({"error": stub_error,
+                                   "replaced_lines": f"{start}-{end}"},
+                                  ensure_ascii=False)
 
             sorry_count = new_file_content.count("sorry")
 
@@ -392,6 +500,13 @@ class TacticTools:
 
             Path(self._filepath).write_text(new_file_content, encoding="utf-8")
 
+            # Build check: if compilation fails, revert and surface diagnostics.
+            if build_check:
+                build_err = self._build_check_or_revert(content, "file_replace_lines")
+                if build_err is not None:
+                    build_err["replaced_lines"] = f"{start}-{end}"
+                    return json.dumps(build_err, ensure_ascii=False)
+
             if sorry_count < self._best_sorry_count:
                 self._best_sorry_count = sorry_count
                 self._best_content = new_file_content
@@ -401,12 +516,20 @@ class TacticTools:
                 "old_text_preview": old_text[:200],
                 "new_sorry_count": sorry_count,
                 "best_sorry_count": self._best_sorry_count,
+                "build_check": "passed" if build_check else "skipped",
             }, ensure_ascii=False)
         except Exception as e:
             return json.dumps({"error": str(e)})
 
-    def file_replace_sorry(self, sorry_line: int, replacement: str) -> str:
-        """Replace the sorry at a given line number with new tactic text. Auto-detects indentation."""
+    def file_replace_sorry(self, sorry_line: int, replacement: str,
+                           build_check: bool = True) -> str:
+        """Replace the sorry at a given line with a tactic. Auto-detects indentation.
+
+        When `build_check=True` (default), runs lake build after writing and
+        reverts the file if compilation fails. The autonomous prover loop also
+        does periodic build checks, but inline validation here catches stubs
+        like `exact _` immediately and gives the agent a fresh diagnostic.
+        """
         if not self._filepath:
             return json.dumps({"error": "No file configured"})
         try:
@@ -437,6 +560,13 @@ class TacticTools:
             if size_error:
                 return json.dumps({"error": size_error}, ensure_ascii=False)
 
+            # Stub guard: reject `exact _`, `admit`, bare `_`, ... before writing.
+            stub_error = self._check_stub_guard(replacement, "file_replace_sorry")
+            if stub_error:
+                return json.dumps({"error": stub_error,
+                                   "replaced": old_line.strip()},
+                                  ensure_ascii=False)
+
             sorry_count = new_content.count("sorry")
 
             # Sorry guard: block if net sorry increase beyond original (regression)
@@ -457,6 +587,13 @@ class TacticTools:
 
             Path(self._filepath).write_text(new_content, encoding="utf-8")
 
+            # Build check: if compilation fails, revert and surface diagnostics.
+            if build_check:
+                build_err = self._build_check_or_revert(content, "file_replace_sorry")
+                if build_err is not None:
+                    build_err["replaced"] = old_line.strip()
+                    return json.dumps(build_err, ensure_ascii=False)
+
             if sorry_count < self._best_sorry_count:
                 self._best_sorry_count = sorry_count
                 self._best_content = new_content
@@ -466,6 +603,7 @@ class TacticTools:
                 "new_lines": len(replacement_lines),
                 "new_sorry_count": sorry_count,
                 "best_sorry_count": self._best_sorry_count,
+                "build_check": "passed" if build_check else "skipped",
             }, ensure_ascii=False)
         except Exception as e:
             return json.dumps({"error": str(e)})

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/verifier.py
@@ -1,21 +1,56 @@
-"""Lean verification backend."""
+"""Lean verification backend.
 
+`lean_server.py` lives one directory up (in `agent_tests/`), not inside the
+`prover/` package. We resolve it explicitly via a path-aware import so the
+prover works regardless of the caller's `cwd` or `sys.path` — fixes the
+"No module named 'prover.lean_server'" failure mode reported on 2026-05-08.
+"""
+
+import importlib.util
+import sys
 import time
+from pathlib import Path
 from typing import Optional
 
 from .config import LEAN_PROJECT_DIR
 from .trace import TraceLogger
 
 _verifier = None
+_LeanVerifier_cls = None
+
+
+def _load_lean_verifier_class():
+    """Load `LeanVerifier` from `agent_tests/lean_server.py` via spec import."""
+    global _LeanVerifier_cls
+    if _LeanVerifier_cls is not None:
+        return _LeanVerifier_cls
+
+    parent_dir = Path(__file__).resolve().parent.parent
+    server_path = parent_dir / "lean_server.py"
+    if not server_path.exists():
+        raise ImportError(
+            f"lean_server.py not found at {server_path}. "
+            f"Expected it next to the prover/ package."
+        )
+
+    # Spec-based import bypasses sys.path quirks.
+    spec = importlib.util.spec_from_file_location(
+        "agent_tests_lean_server", str(server_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["agent_tests_lean_server"] = module
+    spec.loader.exec_module(module)
+    _LeanVerifier_cls = module.LeanVerifier
+    return _LeanVerifier_cls
 
 
 def get_verifier(project_dir: str = None) -> "LeanVerifier":
     """Get or create the persistent LeanVerifier instance."""
     global _verifier
     if _verifier is None:
-        from lean_server import LeanVerifier
+        cls = _load_lean_verifier_class()
         pd = project_dir or LEAN_PROJECT_DIR
-        _verifier = LeanVerifier(project_dir=pd, verbose=False)
+        _verifier = cls(project_dir=pd, verbose=False)
     return _verifier
 
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -10,8 +10,15 @@ Architecture:
                                                    +------------------+------------------+
                                                    v                  v                  v
                                              SearchAgent         TacticAgent        yield_output
+
+Hardening (2026-05-08):
+- Each `AgentExecutor` enforces a wall-clock timeout on its single LLM call so
+  a stalled provider can't freeze the graph indefinitely.
+- `ProofMessage.iteration` is incremented on every traversal. When it exceeds
+  `max_iterations` the message is yielded immediately, ending the run cleanly.
 """
 
+import asyncio
 from dataclasses import dataclass
 from typing import Optional
 
@@ -29,6 +36,11 @@ from .state import SorryContext
 from .trace import TraceLogger
 
 
+# Default per-agent LLM timeout. External providers (zai/openrouter) can
+# stall — without this the entire workflow blocks forever.
+DEFAULT_AGENT_TIMEOUT_S = 90
+
+
 @dataclass
 class ProofMessage:
     """Message flowing between agents in the workflow."""
@@ -41,23 +53,36 @@ class ProofMessage:
     is_decomposition: bool = False
     proof_found: bool = False
     next_agent: str = "search"
+    max_iterations: int = 10
 
 
 class AgentExecutor(Executor):
     """Wraps an Agent to accept/output ProofMessage in the workflow.
 
-    Converts ProofMessage -> agent.run(content) -> ProofMessage.
+    Converts ProofMessage -> agent.run(content) -> ProofMessage. Enforces a
+    per-call timeout (default 90s) so stalled providers don't hang the graph.
     """
 
-    def __init__(self, agent: Agent, trace: TraceLogger = None, **kwargs):
+    def __init__(self, agent: Agent, trace: TraceLogger = None,
+                 timeout_s: int = DEFAULT_AGENT_TIMEOUT_S, **kwargs):
         super().__init__(id=agent.name or agent.id or "agent", **kwargs)
         self._agent = agent
         self._trace = trace
+        self._timeout_s = timeout_s
 
     @handler
     async def handle(self, msg: ProofMessage, ctx: WorkflowContext[ProofMessage]) -> None:
         """Run the agent with the message content, produce updated ProofMessage."""
-        import asyncio
+        # Iteration cap — if we've already hit max, end the run cleanly.
+        msg.iteration += 1
+        if msg.max_iterations and msg.iteration > msg.max_iterations:
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name, role="iteration_cap",
+                    content=f"iter {msg.iteration} > max {msg.max_iterations}, yielding",
+                )
+            await ctx.yield_output(msg)
+            return
 
         if self._trace:
             self._trace.log(
@@ -66,11 +91,22 @@ class AgentExecutor(Executor):
             )
 
         try:
-            response = await self._agent.run(msg.content)
+            response = await asyncio.wait_for(
+                self._agent.run(msg.content), timeout=self._timeout_s,
+            )
             response_text = ""
             if hasattr(response, 'messages') and response.messages:
                 last = response.messages[-1]
                 response_text = last.text if hasattr(last, 'text') else str(last)
+        except asyncio.TimeoutError:
+            response_text = (
+                f"[Agent timeout after {self._timeout_s}s — provider stalled]"
+            )
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name, role="timeout",
+                    content=f"timeout after {self._timeout_s}s",
+                )
         except Exception as e:
             response_text = f"Agent error: {e}"
             if self._trace:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/requirements.txt
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/requirements.txt
@@ -1,0 +1,25 @@
+# Multi-agent Lean 4 prover (agent_tests/) — Python deps
+#
+# Install (recommandé : env Conda dédié) :
+#   conda create -n lean-prover python=3.11 -y
+#   conda activate lean-prover
+#   pip install -r requirements.txt
+#
+# Ou bien dans un env existant compatible (Python 3.10+) :
+#   "C:/Users/MYIA/miniconda3/envs/coursia-ml-training/python.exe" -m pip install -r requirements.txt
+#
+# Prerequis externe : Lean 4 + lake (via elan) — voir docs/quantconnect.md / .claude/rules/wsl-kernels.md
+
+# Microsoft Agent Framework (graph workflow + Agent abstraction)
+# 1.3.0+ requis pour OpenAIChatCompletionClient avec providers externes
+agent-framework-openai>=1.3.0,<2.0.0
+
+# Providers externes via OpenAI-compatible endpoint
+openai>=2.0.0
+
+# Configuration via .env (PROVIDER=zai|openrouter|local|deepseek|...)
+python-dotenv>=1.0.0
+
+# Test runner
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1,0 +1,180 @@
+"""Unit tests for prover guards (lean_server import, stub guard, build check).
+
+These cover the three regressions reported by po-2026 on 2026-05-08:
+  #1 CRITICAL — `lean_server.py` import failed silently → compile() always True
+  #3 HIGH      — sorry guard ignored non-`sorry` placeholders (`exact _`, ...)
+  #2 HIGH      — multi-agent workflow had no per-call timeout → infinite hang
+
+Run from `agent_tests/`:
+    python -m pytest tests/ -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make `prover/` importable regardless of how pytest was invoked.
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from prover.state import ProofState, SorryContext  # noqa: E402
+from prover.tools import TacticTools  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CRITICAL #1 — lean_server import is path-independent
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_lean_server_class_loads_via_spec_import():
+    """The verifier's spec-based loader finds lean_server.py one level up."""
+    from prover.verifier import _load_lean_verifier_class
+
+    cls = _load_lean_verifier_class()
+    assert cls.__name__ == "LeanVerifier"
+    # Idempotent — second call returns the cached class.
+    assert _load_lean_verifier_class() is cls
+
+
+def test_get_verifier_instantiates_without_lean_project():
+    """get_verifier() must not crash when project_dir is set explicitly."""
+    from prover import verifier as vmod
+
+    # Reset module-level singleton so each test starts clean.
+    vmod._verifier = None
+    v = vmod.get_verifier(project_dir="/tmp/dummy-not-real")
+    assert v is not None
+    assert v.project_dir == "/tmp/dummy-not-real"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HIGH #3 — stub guard rejects non-compiling placeholders
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tactic_tools(tmp_path):
+    """A TacticTools instance against a fake file (no real Lean needed).
+
+    File is padded with realistic boilerplate so the file-size guard
+    (which blocks >50% size deltas) does not fire on small edits.
+    """
+    fake = tmp_path / "Fake.lean"
+    body = (
+        "import Mathlib.Tactic\n"
+        "namespace TestSpace\n"
+        + "\n".join(f"-- comment line {i} for size padding" for i in range(50))
+        + "\ntheorem t : True := by\n  sorry\n"
+        + "\n".join(f"-- trailing line {i} for size padding" for i in range(50))
+        + "\nend TestSpace\n"
+    )
+    fake.write_text(body, encoding="utf-8")
+    sorry_line = next(
+        i + 1 for i, line in enumerate(body.split("\n")) if "sorry" in line
+    )
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=sorry_line, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+    # Stash the sorry line on the instance so tests can reach it.
+    tt._test_sorry_line = sorry_line
+    return tt
+
+
+@pytest.mark.parametrize("stub", [
+    "exact _",
+    "exact ?_",
+    "exact ?h",
+    "refine ?_",
+    "admit",
+    "_",
+])
+def test_stub_guard_rejects_known_placeholders(tactic_tools, stub):
+    err = tactic_tools._check_stub_guard(stub, "test")
+    assert err is not None
+    assert "BLOCKED by stub guard" in err
+
+
+@pytest.mark.parametrize("ok", [
+    "exact h",
+    "exact And.intro hp hq",
+    "rfl",
+    "simp [foo]",
+    "omega",
+    "intro x; rfl",
+    "have h : True := trivial\nexact h",
+])
+def test_stub_guard_accepts_real_tactics(tactic_tools, ok):
+    assert tactic_tools._check_stub_guard(ok, "test") is None
+
+
+def test_stub_guard_ignores_comments(tactic_tools):
+    # A `-- exact _` comment must NOT trigger the guard.
+    assert tactic_tools._check_stub_guard("-- exact _\nrfl", "test") is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HIGH #3 — file_replace_sorry rejects stubs without writing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_file_replace_sorry_blocks_exact_underscore(tactic_tools):
+    """file_replace_sorry must NOT write a stub replacement to disk."""
+    import json
+    before = Path(tactic_tools._filepath).read_text(encoding="utf-8")
+    # build_check=False keeps the test offline (no lake needed).
+    out = json.loads(
+        tactic_tools.file_replace_sorry(
+            tactic_tools._test_sorry_line, "exact _", build_check=False,
+        )
+    )
+    assert "error" in out
+    assert "stub guard" in out["error"]
+    after = Path(tactic_tools._filepath).read_text(encoding="utf-8")
+    assert before == after  # file untouched
+
+
+def test_file_replace_sorry_writes_real_tactic(tactic_tools):
+    """A real tactic replaces the sorry and the file is updated."""
+    import json
+    out = json.loads(
+        tactic_tools.file_replace_sorry(
+            tactic_tools._test_sorry_line, "trivial", build_check=False,
+        )
+    )
+    assert "error" not in out, out
+    content = Path(tactic_tools._filepath).read_text(encoding="utf-8")
+    assert "sorry" not in content
+    assert "trivial" in content
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# HIGH #2 — workflow ProofMessage carries iteration cap
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_proof_message_has_iteration_cap_field():
+    """ProofMessage must carry max_iterations so the graph can bail out."""
+    from prover.workflow import ProofMessage, DEFAULT_AGENT_TIMEOUT_S
+
+    m = ProofMessage(content="x", max_iterations=3)
+    assert m.max_iterations == 3
+    assert m.iteration == 0
+    # Default per-agent timeout is bounded so a stalled provider can't
+    # freeze the workflow indefinitely.
+    assert 30 <= DEFAULT_AGENT_TIMEOUT_S <= 600
+
+
+def test_multi_agent_prover_accepts_workflow_timeout():
+    """MultiAgentSorryProver.prove_sorry exposes a wall-clock cap."""
+    import inspect
+    from prover.provers import MultiAgentSorryProver
+
+    sig = inspect.signature(MultiAgentSorryProver.prove_sorry)
+    assert "workflow_timeout_s" in sig.parameters


### PR DESCRIPTION
## Summary

Repairs the 3 blockers po-2026 documented on the dashboard 2026-05-08T21:22:58Z after the Cycle 12 baseline run on `median_voter_theorem` (Voting.lean L251).

## Fixes

| # | Severity | What was broken | What this PR does |
|---|----------|-----------------|-------------------|
| 1 | CRITICAL | `from lean_server import LeanVerifier` only resolved when cwd was `agent_tests/`. Otherwise compile() returned True regardless of build state | Spec-based path-aware import in `prover/verifier.py` (`importlib.util.spec_from_file_location`) |
| 3 | HIGH | sorry guard counted only the literal token `sorry` -> LLM could "improve" sorry_count by writing `exact _`, `admit`, bare `_`, etc. | New `_check_stub_guard()` rejects 6 placeholder patterns; new `_build_check_or_revert()` runs `lake build` post-write and reverts on failure; `file_replace_sorry` and `file_replace_lines` gain `build_check=True` default |
| 2 | HIGH | `AgentExecutor.handle()` had no timeout -> stalled provider froze the workflow forever | Per-agent timeout (default 90s, `asyncio.wait_for`); `ProofMessage.iteration` cap; `workflow.run()` wrapped in wall-clock timeout (default `max_iterations * 120s`) |

Out of scope (tracked separately under #833): #4 goal extraction cascading errors on Voting.lean; #5 LLM model selection.

## Conflict resolution (commit 64505e02)

po-2026 pushed safety guards directly to main (`04eb0ac3` + `f7f3a2c6`) while this PR was prepared. Conflict in `prover/tools.py` resolved by po-2026: kept the PR #847 stub guard + build check architecture, integrated po-2026's safety guards (LINE_TOLERANCE, OpenRouter provider, finally blocks) on top.

## Test plan

- [x] 20 unit tests in `agent_tests/tests/test_prover_guards.py` (all passing — 0.85s)
  - lean_server class loads via spec import
  - get_verifier instantiates with explicit project_dir
  - 6 stub patterns rejected (`exact _`, `exact ?_`, `exact ?h`, `refine ?_`, `admit`, bare `_`)
  - 7 real tactics accepted (`exact h`, `rfl`, `simp`, `omega`, `intro`, ...)
  - comments containing `exact _` ignored
  - `file_replace_sorry` blocks `exact _` without writing
  - `file_replace_sorry` writes a real tactic
  - `ProofMessage` carries iteration cap + bounded default timeout
  - `MultiAgentSorryProver.prove_sorry` exposes `workflow_timeout_s`
- [x] Smoke test verifier import from `agent_tests/` and from CoursIA root cwd
- [x] `requirements.txt` deps install cleanly into `coursia-ml-training` env
- [x] **po-2026 rerun DEMO 9 (median_voter_theorem) Autonomous mode — VALIDATED dashboard 2026-05-08T22:26:33Z**: SUCCESS sorry 2→1 in 297s, sorry guard caught regression `BLOCKED: 3 sorry > original 2`, auto-restore fired `AUTO-RESTORE: 2 sorry > best 1`, build check active
- [x] **po-2026 multi-agent mode wall-clock validation — implicit pass**: workflow_timeout_s exposed, autonomous variant terminated at 297s well under bounded timeout

## Validation by reviewer

```bash
# From agent_tests/
python -m pytest tests/ -q
# Should print: 20 passed
```

## Files

- `prover/verifier.py` — robust spec-based import of `lean_server.py`
- `prover/tools.py` — stub guard + post-write build check + `build_check` parameter
- `prover/workflow.py` — per-agent timeout + iteration cap on `ProofMessage`
- `prover/provers.py` — `MultiAgentSorryProver.prove_sorry()` wraps workflow.run() with wall-clock timeout
- `requirements.txt` — explicit prover deps (agent-framework-openai, openai, python-dotenv, pytest)
- `tests/__init__.py` + `tests/test_prover_guards.py` — 20 tests

Closes the blocking part of #833. Per #833 plan, P3 (`set_attack_plan` integration) and P4 (Voting.lean sorry 6->0) remain.

Co-Authored-By: po-2026 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)