### PR TITLE
fix(ml): repair 19 pre-existing broken tests

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/eval_rl_dt.py
@@ -85,6 +85,11 @@ def load_checkpoint(checkpoint_dir: Path) -> tuple:
 
 
 
+def compute_sharpe(returns: np.ndarray, annualize: bool = True) -> float:
+    """Compute Sharpe ratio from returns array."""
+    return sharpe_from_returns(returns, annualize=annualize)
+
+
 def compute_max_drawdown(cumulative_returns: np.ndarray) -> float:
     """Compute maximum drawdown from cumulative returns."""
     if len(cumulative_returns) < 2:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_build_dataset_v2.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_build_dataset_v2.py
@@ -122,7 +122,7 @@ class TestBuildFeaturesForSymbol:
         features = build_features_for_symbol(
             "SPY", synthetic_panier["SPY"], aux, regime_method="price",
         )
-        valid_regimes = {"uptrend", "downtrend", "volatility", "black_swan"}
+        valid_regimes = {"uptrend", "downtrend", "volatility", "black_swan", "normal"}
         regime_values = set(features["regime_price"].unique())
         assert regime_values.issubset(valid_regimes)
 


### PR DESCRIPTION
## Summary
- Fix `eval_rl_dt.py`: add `compute_sharpe()` alias wrapping `sharpe_from_returns` from baselines — 18 tests were broken because the function didn't exist
- Fix `test_build_dataset_v2.py`: add `"normal"` to valid regime labels — `regime_detector.py` uses `"normal"` as default label but test only expected `uptrend/downtrend/volatility/black_swan`

## Test Results
- **Before**: 736 passed, 7 failed, 5 errors (240 collected)
- **After**: 755 passed, 6 failed, 0 errors
- Remaining 6 failures are dependency-related (`xgboost`, `pyarrow` not installed on this machine) — not code bugs

## Test plan
- [x] `test_eval_rl_dt.py` 18/18 passed (was collection error before)
- [x] `test_build_dataset_v2.py::test_regime_labels_valid` passed (was assertion error before)
- [x] Full suite: 755/761 pass (6 dependency-only failures)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>