### PR TITLE
fix(ci): skip GNN tests when torch_geometric not installed

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_model.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_multiscale_gnn_model.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import torch
 
+pytest.importorskip("torch_geometric")  # PyG not installed in CPU CI; tests run on GPU host
+
 from multiscale_gnn_model import MultiScaleGNN, MultiScaleGNNConfig
 
 


### PR DESCRIPTION
## Summary
- Add `pytest.importorskip("torch_geometric")` to `test_multiscale_gnn_model.py`
- PyG is GPU-host only (`coursia-ml-training` conda env on ai-01); CI runner doesn't have it
- Without this skip, pytest collection error → entire ML & Prover Tests workflow reports failure even though 822/822 other tests PASS

## Root cause
PR #840 added the CI workflow. PR #845/#839 then merged. CI now runs on main and tries to collect `test_multiscale_gnn_model.py` which imports `multiscale_gnn_model.py` which has top-level `from torch_geometric.nn import GATConv`. PyG is heavy (CPU build of PyG geometric is slow), so installing it in CI is wasteful — better to skip the GPU-only tests.

## Test plan
- [x] Local: `pytest scripts/tests/test_multiscale_gnn_model.py` PASSES on ai-01 (PyG installed) → tests still run
- [x] CI: importorskip will skip cleanly → no collection error
- [x] All 822 other tests unaffected

## Track
Hotfix CI red on main (post #845 + #840 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)