### PR TITLE
feat(lean-prover): set_attack_plan integration into multi-agent workflow (P4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -76,6 +76,8 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
         instructions=COORDINATOR_AGENT_INSTRUCTIONS,
         tools=[
             tools.get_proof_state,
+            tools.set_attack_plan,
+            tools.advance_plan,
             tools.file_read_lines,
             tools.search_mathlib_lemmas,
         ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -109,7 +109,7 @@ class MultiAgentSorryProver:
         # Build workflow graph
         workflow_builder = ProofWorkflowBuilder(
             search_agent, tactic_agent, critic_agent, coordinator_agent,
-            sorry_ctx, demo.get("imports", ""), self.trace,
+            sorry_ctx, demo.get("imports", ""), self.trace, state=state,
         )
         workflow = workflow_builder.build()
 
@@ -121,6 +121,7 @@ class MultiAgentSorryProver:
             content=context_msg,
             sorry_count=original_sorry_count,
             max_iterations=max_iterations,
+            next_agent="coordinator",  # B.3: coordinator sets attack plan first
         )
 
         # Run workflow with a wall-clock timeout — caps the total session at

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -52,8 +52,9 @@ class ProofMessage:
     error_type: Optional[str] = None
     is_decomposition: bool = False
     proof_found: bool = False
-    next_agent: str = "search"
+    next_agent: str = "coordinator"  # B.3: coordinator runs first to set attack plan
     max_iterations: int = 10
+    plan: Optional[list] = None  # attack plan from CoordinatorAgent
 
 
 class AgentExecutor(Executor):
@@ -64,11 +65,13 @@ class AgentExecutor(Executor):
     """
 
     def __init__(self, agent: Agent, trace: TraceLogger = None,
-                 timeout_s: int = DEFAULT_AGENT_TIMEOUT_S, **kwargs):
+                 timeout_s: int = DEFAULT_AGENT_TIMEOUT_S,
+                 state: "ProofState" = None, **kwargs):
         super().__init__(id=agent.name or agent.id or "agent", **kwargs)
         self._agent = agent
         self._trace = trace
         self._timeout_s = timeout_s
+        self._state = state  # B.3: shared state for plan propagation
 
     @handler
     async def handle(self, msg: ProofMessage, ctx: WorkflowContext[ProofMessage]) -> None:
@@ -90,9 +93,17 @@ class AgentExecutor(Executor):
                 content=msg.content[:100],
             )
 
+        # B.3: Inject attack plan context for downstream agents
+        content = msg.content
+        if msg.plan and self._agent.name != "CoordinatorAgent":
+            plan_header = "PLAN D'ATTAQUE (suivre ces etapes):\n"
+            plan_header += "\n".join(f"  {i+1}. {step}" for i, step in enumerate(msg.plan))
+            plan_header += "\n\n---\n"
+            content = plan_header + content
+
         try:
             response = await asyncio.wait_for(
-                self._agent.run(msg.content), timeout=self._timeout_s,
+                self._agent.run(content), timeout=self._timeout_s,
             )
             response_text = ""
             if hasattr(response, 'messages') and response.messages:
@@ -114,6 +125,11 @@ class AgentExecutor(Executor):
                     agent=self._agent.name, role="error",
                     content=str(e)[:200],
                 )
+
+        # B.3: Propagate plan from ProofState into message after Coordinator runs
+        if self._agent.name == "CoordinatorAgent" and self._state and not msg.plan:
+            if self._state.plan:
+                msg.plan = list(self._state.plan)
 
         # Agent output becomes the new content
         msg.content = response_text
@@ -208,15 +224,27 @@ class ProofWorkflowBuilder:
     def __init__(self, search_agent: Agent, tactic_agent: Agent,
                  critic_agent: Agent, coordinator_agent: Agent,
                  sorry_context: SorryContext, imports: str,
-                 trace: TraceLogger = None):
-        self._search = AgentExecutor(search_agent, trace=trace)
-        self._tactic = AgentExecutor(tactic_agent, trace=trace)
-        self._critic = AgentExecutor(critic_agent, trace=trace)
-        self._coordinator = AgentExecutor(coordinator_agent, trace=trace)
+                 trace: TraceLogger = None, state: "ProofState" = None):
+        self._search = AgentExecutor(search_agent, trace=trace, state=state)
+        self._tactic = AgentExecutor(tactic_agent, trace=trace, state=state)
+        self._critic = AgentExecutor(critic_agent, trace=trace, state=state)
+        self._coordinator = AgentExecutor(coordinator_agent, trace=trace, state=state)
         self._verify = VerifyExecutor(sorry_context, imports, trace)
 
     def build(self):
-        builder = WorkflowBuilder(start_executor=self._search)
+        # B.3: CoordinatorAgent runs FIRST to set attack plan, then routes to search
+        builder = WorkflowBuilder(start_executor=self._coordinator)
+
+        # Coordinator -> Search (initial plan or re-plan)
+        builder.add_edge(
+            self._coordinator, self._search,
+            condition=lambda msg: msg.next_agent in ("search", "coordinator"),
+        )
+        # Coordinator -> Tactic (direct tactical guidance)
+        builder.add_edge(
+            self._coordinator, self._tactic,
+            condition=lambda msg: msg.next_agent == "tactic",
+        )
 
         # Forward chain: search -> tactic -> verify
         builder.add_edge(self._search, self._tactic)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -178,3 +178,189 @@ def test_multi_agent_prover_accepts_workflow_timeout():
 
     sig = inspect.signature(MultiAgentSorryProver.prove_sorry)
     assert "workflow_timeout_s" in sig.parameters
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# P4 — set_attack_plan integration (B.3)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_coordinator_agent_has_set_attack_plan_tool():
+    """CoordinatorAgent must expose set_attack_plan and advance_plan tools.
+
+    We verify by checking the CoordinatorTools instance is wired correctly,
+    since the Agent framework stores tools internally (not as _tools).
+    """
+    from prover.tools import CoordinatorTools
+    from prover.agents import create_coordinator_agent
+    from prover.trace import TraceLogger
+
+    state = ProofState(theorem_statement="test")
+    trace = TraceLogger()
+    tools = CoordinatorTools(state, filepath="", trace=trace)
+
+    # Verify the tool methods exist and are callable
+    assert callable(tools.set_attack_plan)
+    assert callable(tools.advance_plan)
+
+    # Verify they work
+    result = tools.set_attack_plan(["step1", "step2"], reason="test")
+    assert state.plan == ["step1", "step2"]
+
+    # Verify the agent was created without error (tools list accepted)
+    agent = create_coordinator_agent(tools, provider="zai")
+    assert agent is not None
+    assert agent.name == "CoordinatorAgent"
+
+
+def test_set_attack_plan_stores_in_proof_state():
+    """set_attack_plan stores steps in ProofState.plan."""
+    from prover.tools import CoordinatorTools
+    from prover.trace import TraceLogger
+
+    state = ProofState(theorem_statement="test")
+    trace = TraceLogger()
+    tools = CoordinatorTools(state, filepath="", trace=trace)
+
+    result = tools.set_attack_plan(
+        steps=["intro x", "exact x"],
+        reason="direct proof"
+    )
+    assert state.plan == ["intro x", "exact x"]
+    assert state.plan_phase == 0
+    assert "2 steps" in result
+
+
+def test_advance_plan_increments_phase():
+    """advance_plan moves to the next step in the plan."""
+    from prover.tools import CoordinatorTools
+    from prover.trace import TraceLogger
+
+    state = ProofState(theorem_statement="test")
+    trace = TraceLogger()
+    tools = CoordinatorTools(state, filepath="", trace=trace)
+
+    tools.set_attack_plan(["step1", "step2", "step3"], reason="test")
+    assert state.plan_phase == 0
+
+    tools.advance_plan()
+    assert state.plan_phase == 1
+
+    tools.advance_plan()
+    assert state.plan_phase == 2
+
+    # Does not go beyond the last step
+    tools.advance_plan()
+    assert state.plan_phase == 2
+
+
+def test_proof_message_has_plan_field():
+    """ProofMessage carries a plan field for B.3 propagation."""
+    from prover.workflow import ProofMessage
+
+    m = ProofMessage(content="x", plan=["step1", "step2"])
+    assert m.plan == ["step1", "step2"]
+    assert m.next_agent == "coordinator"  # default is now coordinator
+
+
+def test_proof_message_default_routes_to_coordinator():
+    """B.3: initial routing is to coordinator (sets attack plan first)."""
+    from prover.workflow import ProofMessage
+
+    m = ProofMessage(content="x")
+    assert m.next_agent == "coordinator"
+
+
+def test_workflow_builder_passes_state_to_executors():
+    """ProofWorkflowBuilder passes state to AgentExecutors for plan propagation."""
+    from unittest.mock import MagicMock
+    from prover.workflow import ProofWorkflowBuilder, ProofMessage
+    from prover.state import SorryContext
+
+    state = ProofState(theorem_statement="test")
+    sorry_ctx = SorryContext(filepath="fake.lean", sorry_line=1, indentation=0)
+
+    mock_agents = [MagicMock(name=f"agent_{i}") for i in range(4)]
+    for a in mock_agents:
+        a.name = f"Agent_{a._mock_name}"
+
+    builder = ProofWorkflowBuilder(
+        *mock_agents, sorry_ctx, "", state=state,
+    )
+    # All executors should have the state reference
+    assert builder._coordinator._state is state
+    assert builder._search._state is state
+    assert builder._tactic._state is state
+    assert builder._critic._state is state
+
+
+def test_plan_injected_into_downstream_context():
+    """B.3: When plan is set, AgentExecutor prepends it for non-coordinator agents."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from prover.workflow import AgentExecutor, ProofMessage
+    from prover.state import ProofState
+
+    state = ProofState(theorem_statement="test")
+    agent = MagicMock()
+    agent.name = "SearchAgent"
+    agent.run = AsyncMock(return_value=MagicMock(
+        messages=[MagicMock(text="found lemma")]
+    ))
+
+    executor = AgentExecutor(agent, state=state)
+    msg = ProofMessage(
+        content="search for lemmas",
+        plan=["step1: intro x", "step2: exact x"],
+    )
+
+    import asyncio
+    # We need a WorkflowContext mock — but we can test the content enrichment
+    # by checking the agent.run call argument
+    async def _test():
+        # Create a minimal mock context
+        ctx = AsyncMock()
+        ctx.yield_output = AsyncMock()
+        ctx.send_message = AsyncMock()
+
+        # Increment is part of handle, so iteration will be 1 after
+        await executor.handle(msg, ctx)
+
+        # Check agent.run was called with plan header prepended
+        call_args = agent.run.call_args[0][0]
+        assert "PLAN D'ATTAQUE" in call_args
+        assert "step1: intro x" in call_args
+        assert "search for lemmas" in call_args
+
+    asyncio.run(_test())
+
+
+def test_plan_not_injected_for_coordinator():
+    """B.3: Plan is NOT prepended when the agent IS CoordinatorAgent."""
+    from unittest.mock import AsyncMock, MagicMock
+    from prover.workflow import AgentExecutor, ProofMessage
+
+    agent = MagicMock()
+    agent.name = "CoordinatorAgent"
+    agent.run = AsyncMock(return_value=MagicMock(
+        messages=[MagicMock(text="coordinated")]
+    ))
+
+    executor = AgentExecutor(agent)
+    msg = ProofMessage(
+        content="analyze goal",
+        plan=["step1"],
+    )
+
+    import asyncio
+
+    async def _test():
+        ctx = AsyncMock()
+        ctx.yield_output = AsyncMock()
+        ctx.send_message = AsyncMock()
+        await executor.handle(msg, ctx)
+
+        call_args = agent.run.call_args[0][0]
+        assert "PLAN D'ATTAQUE" not in call_args
+        assert "analyze goal" in call_args
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary
- **B.3 integration**: CoordinatorAgent now runs FIRST in the multi-agent workflow to create an explicit attack plan before SearchAgent and TacticAgent begin
- **Plan propagation**: Attack plan flows through `ProofMessage.plan` field and is injected into downstream agent context headers
- **8 new tests** covering plan storage, phase increment, routing, context injection, and non-injection for coordinator

## Changes
- `agents.py`: Expose `set_attack_plan` + `advance_plan` on CoordinatorAgent's tool list
- `workflow.py`: CoordinatorAgent is new start node; `ProofMessage` has `plan` field; plan context injected for non-coordinator agents; `AgentExecutor` takes optional `state` for plan propagation
- `provers.py`: Pass `ProofState` to `ProofWorkflowBuilder`; route initial message to coordinator
- `tests/test_prover_guards.py`: 8 new tests (28 total, all passing)

## Test plan
- [x] `python -m pytest tests/test_prover_guards.py` — 28/28 pass
- [x] Existing 20 guard tests unchanged and passing
- [ ] E2E validation with multi-agent prover on Voting.lean (P5)

## Sorry count
- N/A — no Lean files modified (prover infrastructure only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)