### PR TITLE
fix(sudoku): dynamic CWD + relative DLL paths + C.1 stub

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:38.610335Z",
@@ -73,161 +73,8 @@
      "shell.execute_reply": "2026-04-21T00:17:40.917342Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '28252.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "ename": "Error",
-     "evalue": "System.IO.DirectoryNotFoundException: Could not find a part of the path 'd:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku'.\r\n   at System.Environment.set_CurrentDirectoryCore(String value)\r\n   at Submission#2.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.DirectoryNotFoundException: Could not find a part of the path 'd:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku'.\r\n   at System.Environment.set_CurrentDirectoryCore(String value)\r\n   at Submission#2.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-      "   at System.Environment.set_CurrentDirectoryCore(String value)",
-      "   at Submission#2.<<Initialize>>d__0.MoveNext()",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
-     ]
-    }
-   ],
-   "source": [
-    "// Configuration du repertoire de travail\n",
-    "// IMPORTANT: Doit etre avant toute utilisation de fichiers relatifs\n",
-    "using System;\n",
-    "using System.IO;\n",
-    "using System.Net.Http;\n",
-    "\n",
-    "System.IO.Directory.SetCurrentDirectory(@\"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku\");\n",
-    "\n",
-    "const string ChocoVersion = \"4.10.17\";\n",
-    "const string ChocoJar = $\"choco-solver-{ChocoVersion}-jar-with-dependencies.jar\";\n",
-    "const string ChocoUrl = $\"https://repo1.maven.org/maven2/org/choco-solver/choco-solver/{ChocoVersion}/{ChocoJar}\";\n",
-    "\n",
-    "if (!File.Exists(ChocoJar))\n",
-    "{\n",
-    "    Console.WriteLine($\"Telechargement de {ChocoJar} depuis Maven...\");\n",
-    "    using var client = new HttpClient();\n",
-    "    var data = client.GetByteArrayAsync(ChocoUrl).Result;\n",
-    "    File.WriteAllBytes(ChocoJar, data);\n",
-    "    Console.WriteLine($\"Telecharge: {ChocoJar} ({data.Length} bytes)\");\n",
-    "}\n",
-    "else\n",
-    "{\n",
-    "    Console.WriteLine($\"Choco-solver JAR deja present: {ChocoJar}\");\n",
-    "}"
-   ]
+   "outputs": [],
+   "source": "// Configuration du repertoire de travail\n// IMPORTANT: Doit etre avant toute utilisation de fichiers relatifs\nusing System;\nusing System.IO;\nusing System.Net.Http;\n\n// Resoudre le chemin du repertoire Sudoku relativement a l'emplacement du notebook\n// .NET Interactive resout les chemins depuis son CWD, pas depuis le notebook\nvar sudokuDir = Path.Combine(Environment.CurrentDirectory, \"MyIA.AI.Notebooks\", \"Sudoku\");\nif (!Directory.Exists(sudokuDir))\n{\n    // Fallback: chercher relativement au repertoire parent\n    var parentDir = new DirectoryInfo(Environment.CurrentDirectory);\n    while (parentDir != null && !Directory.Exists(Path.Combine(parentDir.FullName, \"MyIA.AI.Notebooks\", \"Sudoku\")))\n    {\n        parentDir = parentDir.Parent;\n    }\n    if (parentDir != null)\n    {\n        sudokuDir = Path.Combine(parentDir.FullName, \"MyIA.AI.Notebooks\", \"Sudoku\");\n    }\n}\nDirectory.SetCurrentDirectory(sudokuDir);\n\nconst string ChocoVersion = \"4.10.17\";\nconst string ChocoJar = $\"choco-solver-{ChocoVersion}-jar-with-dependencies.jar\";\nconst string ChocoUrl = $\"https://repo1.maven.org/maven2/org/choco-solver/choco-solver/{ChocoVersion}/{ChocoJar}\";\n\nif (!File.Exists(ChocoJar))\n{\n    Console.WriteLine($\"Telechargement de {ChocoJar} depuis Maven...\");\n    using var client = new HttpClient();\n    var data = client.GetByteArrayAsync(ChocoUrl).Result;\n    File.WriteAllBytes(ChocoJar, data);\n    Console.WriteLine($\"Telecharge: {ChocoJar} ({data.Length} bytes)\");\n}\nelse\n{\n    Console.WriteLine($\"Choco-solver JAR deja present: {ChocoJar}\");\n}"
   },
   {
    "cell_type": "markdown",
@@ -238,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -253,49 +100,8 @@
      "languageId": "polyglot-notebook"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(4,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Runtime.dll' introuvable\r\n",
-      "\r\n",
-      "(5,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Java.dll' introuvable\r\n",
-      "\r\n",
-      "(6,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.CoreLib.dll' introuvable\r\n",
-      "\r\n",
-      "(9,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/org.chocosolver.solver.dll' introuvable\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
-   "source": [
-    "// IMPORTANT: Les directives #r doivent etre en PREMIER, avant tout autre code\n",
-    "\n",
-    "// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Runtime.dll\"\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Java.dll\"\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.CoreLib.dll\"\n",
-    "\n",
-    "// Charger la DLL Choco-solver pré-compilée\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/org.chocosolver.solver.dll\"\n",
-    "\n",
-    "// Maintenant le code C# normal peut commencer\n",
-    "using System;\n",
-    "using System.IO;\n",
-    "\n",
-    "// Définir le répertoire de travail\n",
-    "System.IO.Directory.SetCurrentDirectory(@\"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku\");\n",
-    "\n",
-    "Console.WriteLine(\"Packages IKVM et Choco-solver charges.\");\n"
-   ]
+   "outputs": [],
+   "source": "// IMPORTANT: Les directives #r doivent etre en PREMIER, avant tout autre code\n\n// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n// Les DLLs sont dans le repertoire Sudoku (CWD positionne par la cellule precedente)\n#r \"IKVM.Runtime.dll\"\n#r \"IKVM.Java.dll\"\n#r \"IKVM.CoreLib.dll\"\n\n// Charger la DLL Choco-solver pré-compilée\n#r \"org.chocosolver.solver.dll\"\n\nConsole.WriteLine(\"Packages IKVM et Choco-solver charges.\");"
   },
   {
    "cell_type": "markdown",
@@ -306,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:40.985963Z",
@@ -315,31 +121,7 @@
      "shell.execute_reply": "2026-04-21T00:17:41.019681Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Imports Choco via IKVM (espaces de noms Java mappes vers .NET)\n",
     "// NOTE: Ce code ne s'executera pas car le JAR ne peut pas etre charge\n",
@@ -367,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:41.021615Z",
@@ -376,48 +158,7 @@
      "shell.execute_reply": "2026-04-21T00:17:41.081272Z"
     }
    },
-   "outputs": [
-    {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Importer les classes de base depuis le notebook d'environnement\n",
     "#!import Sudoku-0-Environment-Csharp.ipynb\n"
@@ -434,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -449,39 +190,7 @@
      "languageId": "polyglot-notebook"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,34): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(65,32): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(65,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(70,31): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(70,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,36): error CS0246: Le nom de type ou d'espace de noms 'Constraint' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "public class ChocoSimpleSolver : ISudokuSolver\n",
     "{\n",
@@ -578,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -593,85 +302,7 @@
      "languageId": "polyglot-notebook"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,44): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,15): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,37): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,20): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(34,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,54): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,67): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,23): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(130,45): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(130,58): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,37): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,50): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,20): error CS0246: Le nom de type ou d'espace de noms 'Solver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,67): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,23): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(176,39): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(176,22): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(190,32): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(190,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(200,31): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(200,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,62): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(107,29): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(111,34): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(153,13): error CS0103: Le nom 'org' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(154,21): error CS0246: Le nom de type ou d'espace de noms 'FirstFail' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(155,21): error CS0246: Le nom de type ou d'espace de noms 'IntDomainMin' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(178,24): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(192,26): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(202,25): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "public class ChocoSolverVariableSelector : ISudokuSolver\n",
     "{\n",
@@ -901,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -916,23 +547,7 @@
      "languageId": "polyglot-notebook"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,22): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Grille de test\n",
     "var testPuzzle = new SudokuGrid();\n",
@@ -961,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -976,25 +591,7 @@
      "languageId": "polyglot-notebook"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,18): error CS0246: Le nom de type ou d'espace de noms 'ChocoSolverVariableSelector' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,29): error CS0103: Le nom 'testPuzzle' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Test avec le solveur optimise\n",
     "var solver = new ChocoSolverVariableSelector();\n",
@@ -1055,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:41.859680Z",
@@ -1064,68 +661,8 @@
      "shell.execute_reply": "2026-04-21T00:17:41.907362Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(15,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
-   "source": [
-    "// EXERCICE : Probleme des N-Reines avec Choco-solver\n",
-    "// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines\n",
-    "\n",
-    "public class NQueensChocoSolver\n",
-    "{\n",
-    "    public int N { get; set; }\n",
-    "    \n",
-    "    public NQueensChocoSolver(int n)\n",
-    "    {\n",
-    "        N = n;\n",
-    "    }\n",
-    "    \n",
-    "    public int CountSolutions()\n",
-    "    {\n",
-    "        var model = new Model($\"N-Queens N={N}\");\n",
-    "        \n",
-    "        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)\n",
-    "        // var queens = model.intVarArray(\"queens\", N, 0, N - 1);\n",
-    "        \n",
-    "        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes\n",
-    "        // model.allDifferent(queens).post();\n",
-    "        \n",
-    "        // TODO: Contraintes de diagonales\n",
-    "        // Pour chaque paire (i, j) avec i < j :\n",
-    "        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", i - j).post();  // diagonale principale\n",
-    "        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", j - i).post();  // diagonale secondaire\n",
-    "        \n",
-    "        // TODO: Compter les solutions avec solver.findAllSolutions()\n",
-    "        // var solver = model.getSolver();\n",
-    "        // solver.findAllSolutions();\n",
-    "        // return (int)solver.getSolutionCount();\n",
-    "        \n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// Test\n",
-    "int N = 8;\n",
-    "var nQueens = new NQueensChocoSolver(N);\n",
-    "// int count = nQueens.CountSolutions();\n",
-    "// Console.WriteLine($\"Nombre de solutions pour {N}-Reines : {count}\");\n",
-    "// Console.WriteLine($\"Attendu : 92\");\n",
-    "Console.WriteLine($\"TODO: Implementez NQueensChocoSolver.CountSolutions() pour le probleme des {N}-Reines\");"
-   ]
+   "outputs": [],
+   "source": "// EXERCICE : Probleme des N-Reines avec Choco-solver\n// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines\n\npublic class NQueensChocoSolver\n{\n    public int N { get; set; }\n    \n    public NQueensChocoSolver(int n)\n    {\n        N = n;\n    }\n    \n    public int CountSolutions()\n    {\n        var model = new Model($\"N-Queens N={N}\");\n        \n        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)\n        // var queens = model.intVarArray(\"queens\", N, 0, N - 1);\n        \n        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes\n        // model.allDifferent(queens).post();\n        \n        // TODO: Contraintes de diagonales\n        // Pour chaque paire (i, j) avec i < j :\n        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", i - j).post();  // diagonale principale\n        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", j - i).post();  // diagonale secondaire\n        \n        // TODO: Compter les solutions avec solver.findAllSolutions()\n        // var solver = model.getSolver();\n        // solver.findAllSolutions();\n        // return (int)solver.getSolutionCount();\n        \n        return -1;  // TODO etudiant : remplacer par le comptage des solutions\n    }\n}\n\n// Test\nint N = 8;\nvar nQueens = new NQueensChocoSolver(N);\n// int count = nQueens.CountSolutions();\n// Console.WriteLine($\"Nombre de solutions pour {N}-Reines : {count}\");\n// Console.WriteLine($\"Attendu : 92\");\nConsole.WriteLine($\"TODO: Implementez NQueensChocoSolver.CountSolutions() pour le probleme des {N}-Reines\");"
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8cbc3c67",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Sudoku-12 : Resolution avec Z3 SMT Solver (C#)\n",
     "\n",
@@ -44,7 +54,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "ee60521d",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -55,143 +66,36 @@
      "iopub.status.idle": "2026-04-21T00:17:49.790628Z",
      "shell.execute_reply": "2026-04-21T00:17:49.778729Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '9460.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
-    {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "#r \"nuget: Microsoft.Z3\""
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "57199dd6",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Importation des Classes de Base\n",
     "\n",
@@ -200,7 +104,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "9b2048ea",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -211,59 +116,36 @@
      "iopub.status.idle": "2026-04-21T00:17:49.856369Z",
      "shell.execute_reply": "2026-04-21T00:17:49.851638Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
-   "outputs": [
-    {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#!import Sudoku-0-Environment-Csharp.ipynb"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b00fc3a9",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3. Implémentation de base avec des entiers\n",
     "\n",
@@ -272,7 +154,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
+   "id": "ef63f48d",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -283,37 +166,19 @@
      "iopub.status.idle": "2026-04-21T00:17:50.968946Z",
      "shell.execute_reply": "2026-04-21T00:17:50.968290Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,34): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(88,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(102,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(102,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(104,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(104,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Importer les bibliothèques nécessaires\n",
     "using System.Diagnostics;\n",
@@ -447,7 +312,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6e4ce13b",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7. Utilisation de vecteurs de bits\n",
     "\n",
@@ -458,7 +333,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
+   "id": "6675583d",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -469,33 +345,19 @@
      "iopub.status.idle": "2026-04-21T00:17:51.066975Z",
      "shell.execute_reply": "2026-04-21T00:17:51.066116Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,47): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(118,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(133,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(133,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -635,7 +497,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "060db2d6",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4. Implémentation simple avec vecteurs de bits\n",
     "\n",
@@ -644,7 +516,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "id": "06b7e450",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -655,47 +528,19 @@
      "iopub.status.idle": "2026-04-21T00:17:51.161330Z",
      "shell.execute_reply": "2026-04-21T00:17:51.161006Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,40): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,24): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(15,26): error CS0103: Le nom 'GetPuzzleConstraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(16,20): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,66): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -738,7 +583,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "05931c31",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 5. Utilisation de l'API de substitution avec vecteurs de bits\n",
     "\n",
@@ -747,7 +602,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "id": "b0966c5a",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -758,49 +614,19 @@
      "iopub.status.idle": "2026-04-21T00:17:51.276484Z",
      "shell.execute_reply": "2026-04-21T00:17:51.275874Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(4,46): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(22,32): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(23,31): error CS0103: Le nom 'GetConstExpr' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,41): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(39,70): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -860,7 +686,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b536a57e",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6. Utilisation de l'API de tactiques avec vecteurs de bits\n",
     "\n",
@@ -869,7 +705,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
+   "id": "9dbb9b08",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -880,59 +717,19 @@
      "iopub.status.idle": "2026-04-21T00:17:51.461345Z",
      "shell.execute_reply": "2026-04-21T00:17:51.461126Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,34): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(24,36): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(25,35): error CS0103: Le nom 'GetConstExpr' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,41): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(30,38): error CS0103: Le nom 'GetPuzzleConstraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(33,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(34,21): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(35,21): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(35,31): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(50,74): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "using System;\n",
@@ -1004,7 +801,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4793be52",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7. Comparaison des solveurs\n",
     "\n",
@@ -1013,7 +820,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
+   "id": "4121d11a",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1024,39 +832,19 @@
      "iopub.status.idle": "2026-04-21T00:17:51.561519Z",
      "shell.execute_reply": "2026-04-21T00:17:51.560792Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,38): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,34): error CS0246: Le nom de type ou d'espace de noms 'Z3IntSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,41): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,47): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSubstitution' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,41): error CS0246: Le nom de type ou d'espace de noms 'Z3BitSub_Tactic' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,15): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,1): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "var solvers = new List<(string Name, ISudokuSolver Solver)>\n",
     "{\n",
@@ -1073,7 +861,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c9195b66",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation des resultats\n",
     "\n",
@@ -1101,7 +899,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c5e78be8",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Conclusion\n",
     "\n",
@@ -1114,7 +922,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "bdb5f401",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -1135,38 +953,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
+   "id": "d0df3ce8",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:51.563265Z",
      "iopub.status.busy": "2026-04-21T00:17:51.562982Z",
      "iopub.status.idle": "2026-04-21T00:17:51.616202Z",
      "shell.execute_reply": "2026-04-21T00:17:51.615556Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(4,32): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,22): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Exercice 1 : Sudoku X avec contraintes de diagonale (Z3 BitVector)\n",
     "using Microsoft.Z3;\n",
@@ -1208,7 +1013,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c5337771",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Verifier l'unicite d'une solution avec Z3\n",
     "\n",
@@ -1228,44 +1043,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "id": "68dcaec2",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:51.618285Z",
      "iopub.status.busy": "2026-04-21T00:17:51.617925Z",
      "iopub.status.idle": "2026-04-21T00:17:51.759907Z",
      "shell.execute_reply": "2026-04-21T00:17:51.758927Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(42,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(42,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,20): error CS0246: Le nom de type ou d'espace de noms 'Context' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,20): error CS0246: Le nom de type ou d'espace de noms 'IntExpr' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,34): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,48): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Exercice 2 : Verification d'unicite des solutions avec Z3\n",
     "public class Z3SudokuUnicityChecker\n",
@@ -1316,7 +1112,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "50d4bd4e",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 : Comparer les tactiques Z3\n",
     "\n",
@@ -1336,40 +1142,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
+   "id": "75b3cced",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:51.761910Z",
      "iopub.status.busy": "2026-04-21T00:17:51.761589Z",
      "iopub.status.idle": "2026-04-21T00:17:51.827811Z",
      "shell.execute_reply": "2026-04-21T00:17:51.826997Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(5,20): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,44): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(6,17): error CS0103: Le nom 'Z3BitVectorSolverBase' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(7,21): error CS0103: Le nom 'Z3BitVectorSolverBase' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(8,30): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Exercice 3 : Comparaison des tactiques Z3\n",
     "using Microsoft.Z3;\n",
@@ -1407,7 +1198,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "11c7ed94",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Verification de proprietes avec Z3\n",
     "\n",
@@ -1434,40 +1235,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "2abd8346",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:51.830006Z",
      "iopub.status.busy": "2026-04-21T00:17:51.829542Z",
      "iopub.status.idle": "2026-04-21T00:17:51.882657Z",
      "shell.execute_reply": "2026-04-21T00:17:51.882296Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(38,18): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,20): error CS0246: Le nom de type ou d'espace de noms 'Context' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(25,27): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,34): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// EXERCICE : Verification de proprietes avec Z3\n",
     "\n",
@@ -1518,7 +1304,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f5aa4d0f",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1543,6 +1339,18 @@
    "pygments_lexer": "csharp",
    "version": "13.0"
   },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.131957,
+   "end_time": "2026-05-08T22:50:57.170498+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Sudoku-12-Z3-Csharp.ipynb",
+   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-12-Z3-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-08T22:50:54.038541+00:00",
+   "version": "2.7.0"
+  },
   "polyglot_notebook": {
    "kernelInfo": {
     "defaultKernelName": "csharp",
@@ -1557,5 +1365,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "beab991d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003535,
+     "end_time": "2026-05-08T22:50:55.911012+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:50:55.907477+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<< [Sudoku-5-DancingLinks](Sudoku-5-DancingLinks.ipynb) | [Index](README.md) | [Sudoku-7-Norvig](Sudoku-7-Norvig.ipynb) >>\n",
     "\n",
@@ -49,19 +59,28 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "4b70f2f2",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:17:55.349766Z",
-     "iopub.status.busy": "2026-04-21T00:17:55.342121Z",
-     "iopub.status.idle": "2026-04-21T00:18:02.190974Z",
-     "shell.execute_reply": "2026-04-21T00:18:02.182449Z"
+     "iopub.execute_input": "2026-05-08T22:50:55.926042Z",
+     "iopub.status.busy": "2026-05-08T22:50:55.921072Z",
+     "iopub.status.idle": "2026-05-08T22:50:59.262989Z",
+     "shell.execute_reply": "2026-05-08T22:50:59.259709Z"
+    },
+    "papermill": {
+     "duration": 3.3489,
+     "end_time": "2026-05-08T22:50:59.263074+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:50:55.914174+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -69,7 +88,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-20576.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -114,12 +133,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.96.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '16972.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '20576.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -196,7 +215,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "746a27d2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003919,
+     "end_time": "2026-05-08T22:50:59.270638+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:50:59.266719+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3. Importation des Classes de Base\n",
     "\n",
@@ -206,59 +235,203 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "7296ddbb",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:02.193048Z",
-     "iopub.status.busy": "2026-04-21T00:18:02.192707Z",
-     "iopub.status.idle": "2026-04-21T00:18:02.236835Z",
-     "shell.execute_reply": "2026-04-21T00:18:02.235749Z"
+     "iopub.execute_input": "2026-05-08T22:50:59.282273Z",
+     "iopub.status.busy": "2026-05-08T22:50:59.282129Z",
+     "iopub.status.idle": "2026-05-08T22:51:00.627020Z",
+     "shell.execute_reply": "2026-05-08T22:51:00.626843Z"
+    },
+    "papermill": {
+     "duration": 1.353407,
+     "end_time": "2026-05-08T22:51:00.627091+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:50:59.273684+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "data": {
+      "text/markdown": [
+       "# Sudoku-0 : Environnement et Classes de Base (C#)\n",
+       "\n",
+       "**Navigation** : [Index](README.md) | [Sudoku-1 Backtracking C# >>](Sudoku-1-Backtracking-Csharp.ipynb)\n",
+       "\n",
+       "## Objectifs d'apprentissage\n",
+       "\n",
+       "A la fin de ce notebook, vous saurez :\n",
+       "1. Comprendre la structure de donnees `SudokuGrid` et ses methodes principales\n",
+       "2. Utiliser `ISudokuSolver` pour implementer un solveur de Sudoku\n",
+       "3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n",
+       "4. Comparer les performances de plusieurs solveurs sur differentes difficultes\n",
+       "\n",
+       "**Prerequis** : Notions de base en C# (.NET Interactive)  \n",
+       "**Duree estimee** : ~15 min"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuGrid\n",
+       "\n",
+       "Nous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Structure de donnees pour la grille Sudoku\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les operations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n",
+       "| `AllNeighbours` | 27 x 9 positions | Pre-calcul des voisins ligne/colonne/bloc |\n",
+       "| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n",
+       "| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n",
+       "| `NbErrors()` | int | Nombre de conflits + modifications erronees |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Pre-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calcules une seule fois a l'initialisation, evitant les recalculs couteux\n",
+       "2. **Conversion flexible** : Methodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour differents formats de fichiers)\n",
+       "3. **Validation robuste** : `NbErrors` compte a la fois les doublons (ligne/colonne/bloc) et les modifications de indices pre-remplis\n",
+       "4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n",
+       "\n",
+       "> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pre-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de l'interface ISudokuSolver\n",
+       "\n",
+       "Nous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Interface de strategie\n",
+       "\n",
+       "**Sortie obtenue** : L'interface `ISudokuSolver` definit le contrat que tous les solveurs doivent respecter.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Solve(SudokuGrid)` | SudokuGrid | Methode unique de resolution |\n",
+       "| Pattern | Strategie | Permuter les algorithmes sans modifier le code client |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Simplicite** : Une seule methode `Solve` prenant une grille et retournant une grille resolue\n",
+       "2. **Flexibilite** : N'importe quel algorithme (backtracking, CSP, metaheuristique) peut implementer cette interface\n",
+       "3. **Composabilite** : Les solveurs peuvent etre passes en parametre, stockes dans des listes, testes unitairement\n",
+       "4. **Extensibilite** : Ajouter un nouveau solver ne necessite que d'implementer l'interface\n",
+       "\n",
+       "> **Note technique** : Ce design pattern permet a `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le meme code de test."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuHelper\n",
+       "\n",
+       "Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n",
+       "\n",
+       "- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n",
+       "- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n",
+       "- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n",
+       "- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Infrastructure de test et benchmark\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complete pour tester et comparer les solveurs de Sudoku.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulte (Easy/Medium/Hard) |\n",
+       "| `TestSolvers()` | Performance multi-solveurs | Execution parallele avec timeout |\n",
+       "| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de resolution |\n",
+       "| `SolveSudoku()` | Test unitaire | Resolution individuelle avec affichage |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Chargement intelligent** : Recherche recursive du dossier `Puzzles` dans l'arborescence\n",
+       "2. **Robustesse** : Gestion des timeouts (3000ms par defaut) et exceptions\n",
+       "3. **Mesures** : Temps d'execution total + nombre de grilles resolues\n",
+       "4. **Disqualification** : Un solver echouant sur une grille est disqualifie pour la difficulte\n",
+       "\n",
+       "> **Note technique** : La methode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe increment du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Exercice : Validation d'une grille Sudoku\n",
+       "\n",
+       "### Enonce\n",
+       "\n",
+       "Implementez une methode `IsValidSolution` qui verifie qu'une grille est une solution valide de Sudoku, c'est-a-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 a 9.\n",
+       "\n",
+       "Utilisez cette methode pour valider les resultats de `SudokuHelper.SolveSudoku`.\n",
+       "\n",
+       "### Indices\n",
+       "\n",
+       "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
+       "- Pour chaque unite, verifiez que les 9 chiffres sont tous presents sans doublon\n",
+       "- `SudokuGrid.AllNeighbours` contient deja les indices des unites"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
      ]
     }
    ],
@@ -268,7 +441,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "461f5bc1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003455,
+     "end_time": "2026-05-08T22:51:00.634666+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:00.631211+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4. Implémentation du Solver Naïf\n",
     "\n",
@@ -282,47 +465,30 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "a0f777e1",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:02.239170Z",
-     "iopub.status.busy": "2026-04-21T00:18:02.238863Z",
-     "iopub.status.idle": "2026-04-21T00:18:03.066234Z",
-     "shell.execute_reply": "2026-04-21T00:18:03.065319Z"
+     "iopub.execute_input": "2026-05-08T22:51:00.643878Z",
+     "iopub.status.busy": "2026-05-08T22:51:00.643518Z",
+     "iopub.status.idle": "2026-05-08T22:51:00.732764Z",
+     "shell.execute_reply": "2026-05-08T22:51:00.732548Z"
+    },
+    "papermill": {
+     "duration": 0.094699,
+     "end_time": "2026-05-08T22:51:00.732854+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:00.638155+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(10,41): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(27,37): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,25): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(48,48): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Importation des bibliothèques nécessaires\n",
     "using System.Linq;\n",
@@ -408,7 +574,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "87221f32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00498,
+     "end_time": "2026-05-08T22:51:00.743138+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:00.738158+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "#### Test du solver naïf sur 2 sudokus simples"
    ]
@@ -416,41 +592,877 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "4d31fa70",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:03.068261Z",
-     "iopub.status.busy": "2026-04-21T00:18:03.067912Z",
-     "iopub.status.idle": "2026-04-21T00:18:03.157662Z",
-     "shell.execute_reply": "2026-04-21T00:18:03.156909Z"
+     "iopub.execute_input": "2026-05-08T22:51:00.758153Z",
+     "iopub.status.busy": "2026-05-08T22:51:00.757879Z",
+     "iopub.status.idle": "2026-05-08T22:51:41.292547Z",
+     "shell.execute_reply": "2026-05-08T22:51:41.292394Z"
+    },
+    "papermill": {
+     "duration": 40.541983,
+     "end_time": "2026-05-08T22:51:41.292613+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:00.750630+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
+     "data": {
+      "text/plain": [
+       "Résolution par le solver NaiveProbabilisticSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n",
-      "(1,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(1,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,23): error CS0246: Le nom de type ou d'espace de noms 'NaiveProbabilisticSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,5): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "Compiling model..."
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterating: \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 50\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
+       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
+       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
+       "-------------------------------\n",
+       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
+       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
+       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
+       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
+       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 14061,798 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver NaiveProbabilisticSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "|       3 |    2    | 6       | \n",
+       "| 9       | 3     5 |       1 | \n",
+       "|       1 | 8     6 | 4       | \n",
+       "-------------------------------\n",
+       "|       8 | 1     2 | 9       | \n",
+       "| 7       |         |       8 | \n",
+       "|       6 | 7     8 | 2       | \n",
+       "-------------------------------\n",
+       "|       2 | 6     9 | 5       | \n",
+       "| 8       | 2     3 |       9 | \n",
+       "|       5 |    1    | 3       | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compiling model..."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterating: \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 50\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 4  8  3 | 9  2  1 | 6  5  7 | \n",
+       "| 9  6  7 | 3  4  5 | 8  2  1 | \n",
+       "| 2  5  1 | 8  7  6 | 4  9  3 | \n",
+       "-------------------------------\n",
+       "| 5  4  8 | 1  3  2 | 9  7  6 | \n",
+       "| 7  2  9 | 5  6  4 | 1  3  8 | \n",
+       "| 1  3  6 | 7  9  8 | 2  4  5 | \n",
+       "-------------------------------\n",
+       "| 3  7  2 | 6  8  9 | 5  1  4 | \n",
+       "| 8  1  4 | 2  5  3 | 7  6  9 | \n",
+       "| 6  9  5 | 4  1  7 | 3  8  2 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 26402,694 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -465,7 +1477,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "aa5f0fde",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005675,
+     "end_time": "2026-05-08T22:51:41.304680+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:41.299005+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation des résultats du solver naïf\n",
     "\n",
@@ -487,7 +1509,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "23344dd8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005447,
+     "end_time": "2026-05-08T22:51:41.315598+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:41.310151+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On constate que le solver naïf a besoin de recompiler un nouveau modèle à chaque nouvelle résolution.\n",
     "Nous pouvons implémenter un solver plus robuste qui ne nécessitera pas de nouvelle compilation, par l'introduction de nouvelles variables aléatoires.\n",
@@ -506,47 +1538,30 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "fddbf436",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:03.213297Z",
-     "iopub.status.busy": "2026-04-21T00:18:03.159123Z",
-     "iopub.status.idle": "2026-04-21T00:18:03.492659Z",
-     "shell.execute_reply": "2026-04-21T00:18:03.492163Z"
+     "iopub.execute_input": "2026-05-08T22:51:41.328184Z",
+     "iopub.status.busy": "2026-05-08T22:51:41.328005Z",
+     "iopub.status.idle": "2026-05-08T22:51:41.375622Z",
+     "shell.execute_reply": "2026-05-08T22:51:41.375487Z"
+    },
+    "papermill": {
+     "duration": 0.054567,
+     "end_time": "2026-05-08T22:51:41.375682+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:41.321115+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(10,42): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(95,37): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,25): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(79,48): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using System.Linq;\n",
     "using Microsoft.ML.Probabilistic.Algorithms;\n",
@@ -711,7 +1726,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "804a48bf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005637,
+     "end_time": "2026-05-08T22:51:41.387260+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:41.381623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6. Test de la Résolution \n",
     "\n",
@@ -723,43 +1748,872 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "67c639b7",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:03.494308Z",
-     "iopub.status.busy": "2026-04-21T00:18:03.493981Z",
-     "iopub.status.idle": "2026-04-21T00:18:03.616993Z",
-     "shell.execute_reply": "2026-04-21T00:18:03.616727Z"
+     "iopub.execute_input": "2026-05-08T22:51:41.399234Z",
+     "iopub.status.busy": "2026-05-08T22:51:41.399076Z",
+     "iopub.status.idle": "2026-05-08T22:54:39.081361Z",
+     "shell.execute_reply": "2026-05-08T22:54:39.081206Z"
+    },
+    "papermill": {
+     "duration": 177.688762,
+     "end_time": "2026-05-08T22:54:39.081439+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:51:41.392677+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
+     "data": {
+      "text/plain": [
+       "Test des sudokus faciles"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver RobustProbabilisticSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n",
-      "(2,38): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,39): error CS0246: Le nom de type ou d'espace de noms 'RobustProbabilisticSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(11,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(21,28): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "Compiling model..."
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterating: \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 50\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
+       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
+       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
+       "-------------------------------\n",
+       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
+       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
+       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
+       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
+       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 177556,7137 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver RobustProbabilisticSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "|       3 |    2    | 6       | \n",
+       "| 9       | 3     5 |       1 | \n",
+       "|       1 | 8     6 | 4       | \n",
+       "-------------------------------\n",
+       "|       8 | 1     2 | 9       | \n",
+       "| 7       |         |       8 | \n",
+       "|       6 | 7     8 | 2       | \n",
+       "-------------------------------\n",
+       "|       2 | 6     9 | 5       | \n",
+       "| 8       | 2     3 |       9 | \n",
+       "|       5 |    1    | 3       | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iterating: \r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 50\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 4  8  3 | 9  2  1 | 6  5  7 | \n",
+       "| 9  6  7 | 3  4  5 | 8  2  1 | \n",
+       "| 2  5  1 | 8  7  6 | 4  9  3 | \n",
+       "-------------------------------\n",
+       "| 5  4  8 | 1  3  2 | 9  7  6 | \n",
+       "| 7  2  9 | 5  6  4 | 1  3  8 | \n",
+       "| 1  3  6 | 7  9  8 | 2  4  5 | \n",
+       "-------------------------------\n",
+       "| 3  7  2 | 6  8  9 | 5  1  4 | \n",
+       "| 8  1  4 | 2  5  3 | 7  6  9 | \n",
+       "| 6  9  5 | 4  1  7 | 3  8  2 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 89,2496 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -792,7 +2646,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "209f5288",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01593,
+     "end_time": "2026-05-08T22:54:39.107946+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.092016+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation des résultats du solver robuste\n",
     "\n",
@@ -814,7 +2678,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5646ae6f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010662,
+     "end_time": "2026-05-08T22:54:39.130126+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.119464+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On constate qu'une fois le modèle compilé, le solver robuste peut effectuer de nouvelles inférences dans un temps très raisonnable.\n",
     "\n",
@@ -824,41 +2698,448 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "907590c9",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:03.618828Z",
-     "iopub.status.busy": "2026-04-21T00:18:03.618577Z",
-     "iopub.status.idle": "2026-04-21T00:18:03.707503Z",
-     "shell.execute_reply": "2026-04-21T00:18:03.706977Z"
+     "iopub.execute_input": "2026-05-08T22:54:39.156322Z",
+     "iopub.status.busy": "2026-05-08T22:54:39.156129Z",
+     "iopub.status.idle": "2026-05-08T22:54:39.259261Z",
+     "shell.execute_reply": "2026-05-08T22:54:39.259118Z"
+    },
+    "papermill": {
+     "duration": 0.116129,
+     "end_time": "2026-05-08T22:54:39.259327+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.143198+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
+     "data": {
+      "text/plain": [
+       "Test des sudokus medium"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver RobustProbabilisticSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 8  5    |       2 | 4       | \n",
+       "| 7  2    |         |       9 | \n",
+       "|       4 |         |         | \n",
+       "-------------------------------\n",
+       "|         | 1     7 |       2 | \n",
+       "| 3     5 |         | 9       | \n",
+       "|    4    |         |         | \n",
+       "-------------------------------\n",
+       "|         |    8    |    7    | \n",
+       "|    1  7 |         |         | \n",
+       "|         |    3  6 |    4    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\r\n",
-      "(4,21): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,45): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,24): error CS0103: Le nom 'solvers' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,28): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "Iterating: \r\n"
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 50\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 8  5  1 | 9  9  2 | 4  3  7 | \n",
+       "| 7  2  6 | 3  4  4 | 8  6  9 | \n",
+       "| 9  6  4 | 5  1  8 | 1  2  7 | \n",
+       "-------------------------------\n",
+       "| 9  8  9 | 1  6  7 | 3  5  2 | \n",
+       "| 3  7  5 | 8  2  4 | 9  1  4 | \n",
+       "| 1  4  2 | 3  9  3 | 7  1  7 | \n",
+       "-------------------------------\n",
+       "| 4  3  3 | 5  8  1 | 2  7  5 | \n",
+       "| 4  1  7 | 2  9  5 | 6  9  3 | \n",
+       "| 5  9  9 | 7  3  6 | 1  4  8 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 37\n",
+       "Temps de résolution: 69,9071 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -879,7 +3160,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "11fa1f44",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010791,
+     "end_time": "2026-05-08T22:54:39.281674+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.270883+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Limites du solver robuste sur les grilles moyennes\n",
     "\n",
@@ -901,7 +3192,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "37e0a64c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01097,
+     "end_time": "2026-05-08T22:54:39.303127+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.292157+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "#### Conclusion sur la Résolution des Sudokus de Difficulté Moyenne\n",
     "\n",
@@ -921,61 +3222,30 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "1d5a0d2a",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:18:03.709427Z",
-     "iopub.status.busy": "2026-04-21T00:18:03.708981Z",
-     "iopub.status.idle": "2026-04-21T00:18:04.011911Z",
-     "shell.execute_reply": "2026-04-21T00:18:04.011226Z"
+     "iopub.execute_input": "2026-05-08T22:54:39.331158Z",
+     "iopub.status.busy": "2026-05-08T22:54:39.330951Z",
+     "iopub.status.idle": "2026-05-08T22:54:39.367579Z",
+     "shell.execute_reply": "2026-05-08T22:54:39.367432Z"
+    },
+    "papermill": {
+     "duration": 0.050342,
+     "end_time": "2026-05-08T22:54:39.367643+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.317301+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,37): error CS0246: Le nom de type ou d'espace de noms 'RobustSudokuModel' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(97,45): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(101,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(101,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(103,25): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(104,15): error CS1061: 'IterativeSudokuModel' ne contient pas de définition pour 'SolveSudoku' et aucune méthode d'extension accessible 'SolveSudoku' acceptant un premier argument de type 'IterativeSudokuModel' n'a été trouvée (une directive using ou une référence d'assembly est-elle manquante ?)\r\n",
-      "\r\n",
-      "(17,33): error CS0103: Le nom 'CellIndices' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(19,82): error CS0103: Le nom 'ProbCells' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,44): error CS0103: Le nom 'CellDomain' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,62): error CS0103: Le nom 'EpsilonProba' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(29,32): error CS0103: Le nom 'FixedValueProba' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(38,13): error CS0103: Le nom 'CellsPrior' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(54,35): error CS0103: Le nom 'CellIndices' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using System;\n",
     "using System.Linq;\n",
@@ -1088,14 +3358,34 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e33ae9ce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012153,
+     "end_time": "2026-05-08T22:54:39.391676+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.379523+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "#### Test sur un Sudoku simple"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8a465c74",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012392,
+     "end_time": "2026-05-08T22:54:39.416385+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.403993+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Performance du solver iteratif sur les grilles faciles\n",
     "\n",
@@ -1118,7 +3408,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
+   "id": "743d71b5",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1129,33 +3420,19 @@
      "iopub.status.idle": "2026-04-21T00:18:04.062056Z",
      "shell.execute_reply": "2026-04-21T00:18:04.061511Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": false,
+     "start_time": "2026-05-08T22:54:39.429355+00:00",
+     "status": "running"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,27): error CS0246: Le nom de type ou d'espace de noms 'IterativeProbabilisticSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(3,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(8,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Tester le solver itératif sur un Sudoku de difficulté facile\n",
     "var iterativeSolver = new IterativeProbabilisticSolver();\n",
@@ -1170,14 +3447,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e14fecea",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "#### Test sur un Sudoku medium"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
+   "id": "680d20f9",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1188,35 +3476,19 @@
      "iopub.status.idle": "2026-04-21T00:18:04.124644Z",
      "shell.execute_reply": "2026-04-21T00:18:04.124440Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,20): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(3,44): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,1): error CS0103: Le nom 'IterativeProbabilisticSolver' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,1): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,40): error CS0103: Le nom 'iterativeSolver' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Tester le solver itératif sur un Sudoku de difficulté medium\n",
     "IterativeProbabilisticSolver.Model.NbIterationCells = 1;\n",
@@ -1226,7 +3498,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "71e65dac",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation des résultats du solver itératif\n",
     "\n",
@@ -1248,7 +3530,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c84f9cf1",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### 7. Utiliser une version précompilée\n",
     "\n",
@@ -1257,7 +3549,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
+   "id": "2eecab7d",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1268,21 +3561,19 @@
      "iopub.status.idle": "2026-04-21T00:18:24.264777Z",
      "shell.execute_reply": "2026-04-21T00:18:24.264407Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.CodeAnalysis, 5.3.0</span></li><li><span>microsoft.codeanalysis.csharp, 2.10.0</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "#r \"nuget: Microsoft.CodeAnalysis\"\n",
     "#r \"nuget: Microsoft.CodeAnalysis.CSharp\""
@@ -1290,7 +3581,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ee1f7821",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Architecture du solver precompile\n",
     "\n",
@@ -1313,14 +3614,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e023582d",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "Import des espaces de noms necessaires pour le modele Infer.NET."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "5b867dc3",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1331,35 +3643,19 @@
      "iopub.status.idle": "2026-04-21T00:18:25.063373Z",
      "shell.execute_reply": "2026-04-21T00:18:25.060908Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(19,45): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(203,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(203,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(131,48): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(210,25): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "using System;\n",
     "using System.IO;\n",
@@ -1609,7 +3905,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "544bd1ed",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "#### Tests\n",
     "\n",
@@ -1618,7 +3924,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
+   "id": "ce8bf59c",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -1629,39 +3936,19 @@
      "iopub.status.idle": "2026-04-21T00:18:25.516426Z",
      "shell.execute_reply": "2026-04-21T00:18:25.515457Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,29): error CS0246: Le nom de type ou d'espace de noms 'PrecompiledRobustSudokuModel' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(3,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(11,20): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(11,44): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(7,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,1): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Tester le solver avec modèle précompilé sur un Sudoku de difficulté facile\n",
     "var precompiledSolver = new PrecompiledRobustSudokuModel();\n",
@@ -1679,7 +3966,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "40e09ec5",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation des résultats\n",
     "\n",
@@ -1701,7 +3998,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "57278420",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1714,7 +4021,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1fe41dd3",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### 8. Exercices\n",
     "\n",
@@ -1737,7 +4054,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
+   "id": "f35bc564",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:18:25.518741Z",
@@ -1745,29 +4063,17 @@
      "iopub.status.idle": "2026-04-21T00:18:25.895576Z",
      "shell.execute_reply": "2026-04-21T00:18:25.888726Z"
     },
-    "language": "polyglot-notebook"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(4,40): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+    "language": "polyglot-notebook",
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// TODO: Implementer une version amelioree du solver iteratif\n",
     "// qui verifie la coherence des valeurs avant de les fixer\n",
@@ -1801,14 +4107,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d4b25852",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "Implementation d'un solveur hybride combinant inference probabiliste et propagation de contraintes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
+   "id": "0549ea4e",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:18:25.897752Z",
@@ -1816,29 +4133,17 @@
      "iopub.status.idle": "2026-04-21T00:18:26.229082Z",
      "shell.execute_reply": "2026-04-21T00:18:26.228147Z"
     },
-    "language": "polyglot-notebook"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(7,42): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+    "language": "polyglot-notebook",
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// TODO: Implementer HybridProbabilisticSolver\n",
     "// Ce solver doit:\n",
@@ -1883,6 +4188,18 @@
    "pygments_lexer": "csharp",
    "version": "13.0"
   },
+  "papermill": {
+   "default_parameters": {},
+   "duration": null,
+   "end_time": null,
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Sudoku-15-Infer-Csharp.ipynb",
+   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-15-Infer-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-08T22:50:54.038769+00:00",
+   "version": "2.7.0"
+  },
   "polyglot_notebook": {
    "kernelInfo": {
     "defaultKernelName": "csharp",
@@ -1897,5 +4214,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -2,8 +2,29 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "18348253",
+   "metadata": {
+    "tags": [
+     "papermill-error-cell-tag"
+    ]
+   },
+   "source": [
+    "<span style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">An Exception was encountered at '<a href=\"#papermill-error-cell\">In [12]</a>'.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5387691e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010378,
+     "end_time": "2026-05-08T22:49:49.397702+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:49.387324+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<< [Sudoku-8-SimulatedAnnealing](Sudoku-8-SimulatedAnnealing.ipynb) | [Index](README.md) | [Sudoku-10-NeuralNetwork](Sudoku-10-NeuralNetwork.ipynb) >>\n",
     "\n",
@@ -29,7 +50,16 @@
   {
    "cell_type": "markdown",
    "id": "fe408d48",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003469,
+     "end_time": "2026-05-08T22:49:49.406333+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:49.402864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Importation de l'environnement\n",
     "\n",
@@ -45,14 +75,22 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:30.054476Z",
-     "iopub.status.busy": "2026-04-21T00:20:30.043648Z",
-     "iopub.status.idle": "2026-04-21T00:20:30.203974Z",
-     "shell.execute_reply": "2026-04-21T00:20:30.194492Z"
+     "iopub.execute_input": "2026-05-08T22:49:49.423981Z",
+     "iopub.status.busy": "2026-05-08T22:49:49.418569Z",
+     "iopub.status.idle": "2026-05-08T22:49:51.655029Z",
+     "shell.execute_reply": "2026-05-08T22:49:51.653142Z"
+    },
+    "papermill": {
+     "duration": 2.245833,
+     "end_time": "2026-05-08T22:49:51.655162+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:49.409329+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -60,7 +98,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-32140.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -105,12 +143,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.19.96.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '24416.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '32140.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -171,43 +209,178 @@
      "output_type": "display_data"
     },
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "data": {
+      "text/markdown": [
+       "# Sudoku-0 : Environnement et Classes de Base (C#)\n",
+       "\n",
+       "**Navigation** : [Index](README.md) | [Sudoku-1 Backtracking C# >>](Sudoku-1-Backtracking-Csharp.ipynb)\n",
+       "\n",
+       "## Objectifs d'apprentissage\n",
+       "\n",
+       "A la fin de ce notebook, vous saurez :\n",
+       "1. Comprendre la structure de donnees `SudokuGrid` et ses methodes principales\n",
+       "2. Utiliser `ISudokuSolver` pour implementer un solveur de Sudoku\n",
+       "3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n",
+       "4. Comparer les performances de plusieurs solveurs sur differentes difficultes\n",
+       "\n",
+       "**Prerequis** : Notions de base en C# (.NET Interactive)  \n",
+       "**Duree estimee** : ~15 min"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuGrid\n",
+       "\n",
+       "Nous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Structure de donnees pour la grille Sudoku\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les operations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n",
+       "| `AllNeighbours` | 27 x 9 positions | Pre-calcul des voisins ligne/colonne/bloc |\n",
+       "| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n",
+       "| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n",
+       "| `NbErrors()` | int | Nombre de conflits + modifications erronees |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Pre-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calcules une seule fois a l'initialisation, evitant les recalculs couteux\n",
+       "2. **Conversion flexible** : Methodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour differents formats de fichiers)\n",
+       "3. **Validation robuste** : `NbErrors` compte a la fois les doublons (ligne/colonne/bloc) et les modifications de indices pre-remplis\n",
+       "4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n",
+       "\n",
+       "> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pre-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de l'interface ISudokuSolver\n",
+       "\n",
+       "Nous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Interface de strategie\n",
+       "\n",
+       "**Sortie obtenue** : L'interface `ISudokuSolver` definit le contrat que tous les solveurs doivent respecter.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Solve(SudokuGrid)` | SudokuGrid | Methode unique de resolution |\n",
+       "| Pattern | Strategie | Permuter les algorithmes sans modifier le code client |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Simplicite** : Une seule methode `Solve` prenant une grille et retournant une grille resolue\n",
+       "2. **Flexibilite** : N'importe quel algorithme (backtracking, CSP, metaheuristique) peut implementer cette interface\n",
+       "3. **Composabilite** : Les solveurs peuvent etre passes en parametre, stockes dans des listes, testes unitairement\n",
+       "4. **Extensibilite** : Ajouter un nouveau solver ne necessite que d'implementer l'interface\n",
+       "\n",
+       "> **Note technique** : Ce design pattern permet a `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le meme code de test."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuHelper\n",
+       "\n",
+       "Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n",
+       "\n",
+       "- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n",
+       "- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n",
+       "- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n",
+       "- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Infrastructure de test et benchmark\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complete pour tester et comparer les solveurs de Sudoku.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulte (Easy/Medium/Hard) |\n",
+       "| `TestSolvers()` | Performance multi-solveurs | Execution parallele avec timeout |\n",
+       "| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de resolution |\n",
+       "| `SolveSudoku()` | Test unitaire | Resolution individuelle avec affichage |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Chargement intelligent** : Recherche recursive du dossier `Puzzles` dans l'arborescence\n",
+       "2. **Robustesse** : Gestion des timeouts (3000ms par defaut) et exceptions\n",
+       "3. **Mesures** : Temps d'execution total + nombre de grilles resolues\n",
+       "4. **Disqualification** : Un solver echouant sur une grille est disqualifie pour la difficulte\n",
+       "\n",
+       "> **Note technique** : La methode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe increment du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Exercice : Validation d'une grille Sudoku\n",
+       "\n",
+       "### Enonce\n",
+       "\n",
+       "Implementez une methode `IsValidSolution` qui verifie qu'une grille est une solution valide de Sudoku, c'est-a-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 a 9.\n",
+       "\n",
+       "Utilisez cette methode pour valider les resultats de `SudokuHelper.SolveSudoku`.\n",
+       "\n",
+       "### Indices\n",
+       "\n",
+       "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
+       "- Pour chaque unite, verifiez que les 9 chiffres sont tous presents sans doublon\n",
+       "- `SudokuGrid.AllNeighbours` contient deja les indices des unites"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
      ]
     }
    ],
@@ -218,7 +391,16 @@
   {
    "cell_type": "markdown",
    "id": "d916d0fd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003778,
+     "end_time": "2026-05-08T22:49:51.665874+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.662096+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Introduction : Comment les humains resolvent les Sudoku (~3 min)\n",
     "\n",
@@ -256,7 +438,16 @@
   {
    "cell_type": "markdown",
    "id": "e0eb174f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003996,
+     "end_time": "2026-05-08T22:49:51.673933+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.669937+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Infrastructure : Grille de candidats\n",
     "\n",
@@ -278,40 +469,24 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:30.205913Z",
-     "iopub.status.busy": "2026-04-21T00:20:30.205681Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.181878Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.181616Z"
+     "iopub.execute_input": "2026-05-08T22:49:51.683750Z",
+     "iopub.status.busy": "2026-05-08T22:49:51.683401Z",
+     "iopub.status.idle": "2026-05-08T22:49:51.747635Z",
+     "shell.execute_reply": "2026-05-08T22:49:51.747500Z"
+    },
+    "papermill": {
+     "duration": 0.069978,
+     "end_time": "2026-05-08T22:49:51.747695+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.677717+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(11,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(17,26): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(46,38): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(46,23): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'nRow'.\r\n",
-      "\r\n",
-      "(46,29): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'nCol'.\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Grille de candidats pour le solveur humain.\n",
@@ -440,7 +615,16 @@
   {
    "cell_type": "markdown",
    "id": "7d21604f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00373,
+     "end_time": "2026-05-08T22:49:51.755511+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.751781+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : CandidateGrid\n",
     "\n",
@@ -465,34 +649,90 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.183836Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.183489Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.346531Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.345698Z"
+     "iopub.execute_input": "2026-05-08T22:49:51.764200Z",
+     "iopub.status.busy": "2026-05-08T22:49:51.764030Z",
+     "iopub.status.idle": "2026-05-08T22:49:51.871250Z",
+     "shell.execute_reply": "2026-05-08T22:49:51.871111Z"
+    },
+    "papermill": {
+     "duration": 0.1121,
+     "end_time": "2026-05-08T22:49:51.871314+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.759214+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,16): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,40): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,22): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+     "data": {
+      "text/plain": [
+       "Puzzle initial :\n",
+       "-------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 36, Candidats totaux: 66, Moyenne: 1,8 candidats/cellule"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Cellule (0,1) : candidats = {6, 7}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Cellule (1,1) : candidats = {7}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Cellule (1,2) : candidats = {4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Cellule (2,1) : candidats = {3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -520,7 +760,16 @@
   {
    "cell_type": "markdown",
    "id": "m8r6kl5kgq",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006746,
+     "end_time": "2026-05-08T22:49:51.882443+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.875697+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Grille de candidats\n",
     "\n",
@@ -540,7 +789,16 @@
   {
    "cell_type": "markdown",
    "id": "79827c2c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007543,
+     "end_time": "2026-05-08T22:49:51.894557+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.887014+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Techniques de base (~5 min)\n",
     "\n",
@@ -572,44 +830,24 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.348565Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.348180Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.445644Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.445078Z"
+     "iopub.execute_input": "2026-05-08T22:49:51.909570Z",
+     "iopub.status.busy": "2026-05-08T22:49:51.909263Z",
+     "iopub.status.idle": "2026-05-08T22:49:51.976645Z",
+     "shell.execute_reply": "2026-05-08T22:49:51.976512Z"
+    },
+    "papermill": {
+     "duration": 0.074991,
+     "end_time": "2026-05-08T22:49:51.976702+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.901711+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(11,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(41,42): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(46,30): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(59,26): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'row'.\r\n",
-      "\r\n",
-      "(59,31): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'col'.\r\n",
-      "\r\n",
-      "(59,36): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée '_'.\r\n",
-      "\r\n",
-      "(59,36): error CS8183: Impossible de déduire le type d'une variable implicitement typée abandonnée.\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Contient les techniques de resolution humaines.\n",
@@ -686,7 +924,16 @@
   {
    "cell_type": "markdown",
    "id": "70c61efc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004766,
+     "end_time": "2026-05-08T22:49:51.985300+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.980534+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Test des techniques de base\n",
     "\n",
@@ -702,40 +949,81 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.447452Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.447182Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.518934Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.518347Z"
+     "iopub.execute_input": "2026-05-08T22:49:51.994604Z",
+     "iopub.status.busy": "2026-05-08T22:49:51.994435Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.039119Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.038994Z"
+    },
+    "papermill": {
+     "duration": 0.049965,
+     "end_time": "2026-05-08T22:49:52.039174+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:51.989209+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,30): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,54): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,19): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,14): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(17,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(25,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "data": {
+      "text/plain": [
+       "Puzzle facile initial : 36 cellules vides"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 36, Candidats totaux: 66, Moyenne: 1,8 candidats/cellule"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  Tour 1 - Naked Singles : 36 placements"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "Resultat : RESOLU apres 36 placements en 1 tours"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "-------------------------------\n",
+       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
+       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
+       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
+       "-------------------------------\n",
+       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
+       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
+       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
+       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
+       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -779,7 +1067,16 @@
   {
    "cell_type": "markdown",
    "id": "fe3b0291",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.014185,
+     "end_time": "2026-05-08T22:49:52.057343+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.043158+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Techniques de base\n",
     "\n",
@@ -804,40 +1101,59 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.520648Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.520346Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.584278Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.583686Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.066607Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.066452Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.123103Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.122975Z"
+    },
+    "papermill": {
+     "duration": 0.061779,
+     "end_time": "2026-05-08T22:49:52.123160+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.061381+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,32): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,56): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,20): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(13,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "data": {
+      "text/plain": [
+       "Puzzle moyen initial : 59 cellules vides"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "data": {
+      "text/plain": [
+       "Resultat avec techniques de base uniquement : BLOQUE"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Placements effectues : 11, Cellules restantes : 48"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 48, Candidats totaux: 169, Moyenne: 3,5 candidats/cellule"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -866,7 +1182,16 @@
   {
    "cell_type": "markdown",
    "id": "956b26a5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004,
+     "end_time": "2026-05-08T22:49:52.131623+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.127623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Limites des techniques de base\n",
     "\n",
@@ -878,7 +1203,16 @@
   {
    "cell_type": "markdown",
    "id": "16cd6fa2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004403,
+     "end_time": "2026-05-08T22:49:52.140345+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.135942+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Techniques intermediaires (~5 min)\n",
     "\n",
@@ -912,38 +1246,24 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.643480Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.585677Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.779063Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.778681Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.149908Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.149719Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.198423Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.198287Z"
+    },
+    "papermill": {
+     "duration": 0.053816,
+     "end_time": "2026-05-08T22:49:52.198479+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.144663+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,39): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(54,53): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(114,53): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,30): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Ajout des techniques intermediaires a la classe HumanTechniques\n",
     "public static class HumanTechniquesIntermediate\n",
@@ -1134,7 +1454,16 @@
   {
    "cell_type": "markdown",
    "id": "29b51c17",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00421,
+     "end_time": "2026-05-08T22:49:52.207136+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.202926+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Techniques intermediaires\n",
     "\n",
@@ -1157,7 +1486,16 @@
   {
    "cell_type": "markdown",
    "id": "c52cf6d9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004216,
+     "end_time": "2026-05-08T22:49:52.215680+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.211464+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Technique avancee : X-Wing (~5 min)\n",
     "\n",
@@ -1188,36 +1526,24 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.781513Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.781014Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.850576Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.849698Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.227220Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.226971Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.265414Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.265229Z"
+    },
+    "papermill": {
+     "duration": 0.045092,
+     "end_time": "2026-05-08T22:49:52.265496+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.220404+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(25,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(69,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "public static class HumanTechniquesAdvanced\n",
     "{\n",
@@ -1336,7 +1662,16 @@
   {
    "cell_type": "markdown",
    "id": "6ec579ad",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006061,
+     "end_time": "2026-05-08T22:49:52.276604+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.270543+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : X-Wing\n",
     "\n",
@@ -1355,7 +1690,16 @@
   {
    "cell_type": "markdown",
    "id": "57010e81",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005243,
+     "end_time": "2026-05-08T22:49:52.286885+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.281642+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Techniques expertes (apercu) (~3 min)\n",
     "\n",
@@ -1387,7 +1731,16 @@
   {
    "cell_type": "markdown",
    "id": "0ea55c22",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004484,
+     "end_time": "2026-05-08T22:49:52.296102+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.291618+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Solveur humain complet (~4 min)\n",
     "\n",
@@ -1410,56 +1763,24 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.852350Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.851990Z",
-     "iopub.status.idle": "2026-04-21T00:20:32.993008Z",
-     "shell.execute_reply": "2026-04-21T00:20:32.992392Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.306147Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.305961Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.364928Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.364790Z"
+    },
+    "papermill": {
+     "duration": 0.064716,
+     "end_time": "2026-05-08T22:49:52.364986+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.300270+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(5,28): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(48,39): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(115,36): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(22,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,22): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(57,22): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(66,22): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(75,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(84,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(93,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(102,22): error CS0103: Le nom 'HumanTechniquesAdvanced' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Solveur de Sudoku imitant le raisonnement humain.\n",
@@ -1620,7 +1941,16 @@
   {
    "cell_type": "markdown",
    "id": "ad4b4ee5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003819,
+     "end_time": "2026-05-08T22:49:52.372814+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.368995+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Architecture du HumanSolver\n",
     "\n",
@@ -1645,7 +1975,16 @@
   {
    "cell_type": "markdown",
    "id": "41b17d83",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004103,
+     "end_time": "2026-05-08T22:49:52.381016+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.376913+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Test du solveur humain complet\n",
     "\n",
@@ -1661,64 +2000,132 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:32.994633Z",
-     "iopub.status.busy": "2026-04-21T00:20:32.994359Z",
-     "iopub.status.idle": "2026-04-21T00:20:33.057894Z",
-     "shell.execute_reply": "2026-04-21T00:20:33.057565Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.392011Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.391859Z",
+     "iopub.status.idle": "2026-05-08T22:49:52.460338Z",
+     "shell.execute_reply": "2026-05-08T22:49:52.460226Z"
+    },
+    "papermill": {
+     "duration": 0.07502,
+     "end_time": "2026-05-08T22:49:52.460390+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.385370+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,23): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,48): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,13): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,26): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,50): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,15): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(20,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(20,48): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(20,13): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,42): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(7,66): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(13,19): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(15,44): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(15,68): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(21,19): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,42): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(23,66): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "data": {
+      "text/plain": [
+       "=== PUZZLE FACILE ==="
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Naked Singles x36\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 1\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== PUZZLE MOYEN ==="
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Hidden Singles x6\r\n",
+       "  Etape 2: Naked Singles x1\r\n",
+       "  Etape 3: Hidden Singles x3\r\n",
+       "  Etape 4: Hidden Singles x1\r\n",
+       "  Etape 5: Naked Pairs (eliminations) x9\r\n",
+       "  Etape 6: Locked Candidates - Pointing (eliminations) x17\r\n",
+       "  Etape 7: Naked Singles x19\r\n",
+       "  Etape 8: Hidden Singles x9\r\n",
+       "  Etape 9: Hidden Singles x6\r\n",
+       "  Etape 10: Naked Singles x14\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 10\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== PUZZLE DIFFICILE ==="
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Hidden Singles x3\r\n",
+       "  Etape 2: Locked Candidates - Pointing (eliminations) x21\r\n",
+       "  Etape 3: Naked Singles x6\r\n",
+       "  Etape 4: Hidden Singles x2\r\n",
+       "  Etape 5: Hidden Singles x2\r\n",
+       "  Etape 6: Naked Pairs (eliminations) x15\r\n",
+       "  Etape 7: Naked Singles x2\r\n",
+       "  Etape 8: Hidden Singles x4\r\n",
+       "  Etape 9: Naked Singles x45\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 9\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1751,7 +2158,16 @@
   {
    "cell_type": "markdown",
    "id": "228d640f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004852,
+     "end_time": "2026-05-08T22:49:52.469629+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.464777+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Resultats du HumanSolver\n",
     "\n",
@@ -1769,7 +2185,16 @@
   {
    "cell_type": "markdown",
    "id": "276475bf",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003944,
+     "end_time": "2026-05-08T22:49:52.477750+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.473806+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Comparaison avec les autres solveurs\n",
     "\n",
@@ -1785,55 +2210,644 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:33.059806Z",
-     "iopub.status.busy": "2026-04-21T00:20:33.059412Z",
-     "iopub.status.idle": "2026-04-21T00:20:33.064068Z",
-     "shell.execute_reply": "2026-04-21T00:20:33.063043Z"
+     "iopub.execute_input": "2026-05-08T22:49:52.487859Z",
+     "iopub.status.busy": "2026-05-08T22:49:52.487707Z",
+     "iopub.status.idle": "2026-05-08T22:49:56.977579Z",
+     "shell.execute_reply": "2026-05-08T22:49:56.977659Z"
+    },
+    "papermill": {
+     "duration": 4.495965,
+     "end_time": "2026-05-08T22:49:56.977717+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:52.481752+00:00",
+     "status": "completed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "data": {
+      "text/markdown": [
+       "# Sudoku-1 : Resolution par Backtracking\n",
+       "\n",
+       "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment.ipynb) | [Index](README.md) | [Sudoku-2 Genetic >>](Sudoku-2-Genetic.ipynb)\n",
+       "\n",
+       "## Objectifs d'apprentissage\n",
+       "\n",
+       "A la fin de ce notebook, vous saurez :\n",
+       "1. **Implementer** un algorithme de backtracking pour resoudre le Sudoku\n",
+       "2. **Comprendre** l'exploration en profondeur et le retour arriere\n",
+       "3. **Analyser** les performances du backtracking selon la difficulte des puzzles\n",
+       "\n",
+       "**Duree estimee** : ~7 min | **Prerequis** : [Sudoku-0 Environment](Sudoku-0-Environment.ipynb) | **Lien** : Voir [Search-6 CSP Fundamentals](../Search/Foundations/Search-6-CSP-Fundamentals.ipynb) pour la theorie du backtracking\n",
+       "\n",
+       "---\n",
+       "\n",
+       "## Introduction Theorique\n",
+       "\n",
+       "L'algorithme de backtracking est une methode de recherche en profondeur utilisee pour resoudre les problemes de satisfaction de contraintes (CSP), comme le Sudoku. L'algorithme explore toutes les configurations possibles pour trouver une solution qui respecte les contraintes :\n",
+       "\n",
+       "- **Exploration en profondeur** : L'algorithme explore chaque possibilite de maniere exhaustive avant de revenir en arriere (backtrack) lorsque aucune solution n'est trouvee dans une branche particuliere.\n",
+       "- **Contraintes** : Dans le cas du Sudoku, les contraintes sont les regles du jeu : chaque chiffre de 1 a 9 doit apparaitre une seule fois par ligne, colonne et sous-grille de 3x3.\n",
+       "\n",
+       "## Implementation de l'Algorithme de Backtracking\n",
+       "\n",
+       "L'algorithme suit ces etapes :\n",
+       "1. Trouver une case vide dans la grille.\n",
+       "2. Tenter de placer un chiffre (1-9) dans la case vide.\n",
+       "3. Verifier si ce chiffre respecte les contraintes.\n",
+       "4. Si oui, passer a la case suivante et repeter le processus.\n",
+       "5. Si non, essayer le chiffre suivant.\n",
+       "6. Si aucun chiffre ne convient, revenir en arriere (backtrack).\n",
+       "\n",
+       "## Importation des Classes de Base\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "# Sudoku-0 : Environnement et Classes de Base (C#)\n",
+       "\n",
+       "**Navigation** : [Index](README.md) | [Sudoku-1 Backtracking C# >>](Sudoku-1-Backtracking-Csharp.ipynb)\n",
+       "\n",
+       "## Objectifs d'apprentissage\n",
+       "\n",
+       "A la fin de ce notebook, vous saurez :\n",
+       "1. Comprendre la structure de donnees `SudokuGrid` et ses methodes principales\n",
+       "2. Utiliser `ISudokuSolver` pour implementer un solveur de Sudoku\n",
+       "3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n",
+       "4. Comparer les performances de plusieurs solveurs sur differentes difficultes\n",
+       "\n",
+       "**Prerequis** : Notions de base en C# (.NET Interactive)  \n",
+       "**Duree estimee** : ~15 min"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuGrid\n",
+       "\n",
+       "Nous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Structure de donnees pour la grille Sudoku\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les operations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n",
+       "| `AllNeighbours` | 27 x 9 positions | Pre-calcul des voisins ligne/colonne/bloc |\n",
+       "| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n",
+       "| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n",
+       "| `NbErrors()` | int | Nombre de conflits + modifications erronees |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Pre-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calcules une seule fois a l'initialisation, evitant les recalculs couteux\n",
+       "2. **Conversion flexible** : Methodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour differents formats de fichiers)\n",
+       "3. **Validation robuste** : `NbErrors` compte a la fois les doublons (ligne/colonne/bloc) et les modifications de indices pre-remplis\n",
+       "4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n",
+       "\n",
+       "> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pre-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de l'interface ISudokuSolver\n",
+       "\n",
+       "Nous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Interface de strategie\n",
+       "\n",
+       "**Sortie obtenue** : L'interface `ISudokuSolver` definit le contrat que tous les solveurs doivent respecter.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `Solve(SudokuGrid)` | SudokuGrid | Methode unique de resolution |\n",
+       "| Pattern | Strategie | Permuter les algorithmes sans modifier le code client |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Simplicite** : Une seule methode `Solve` prenant une grille et retournant une grille resolue\n",
+       "2. **Flexibilite** : N'importe quel algorithme (backtracking, CSP, metaheuristique) peut implementer cette interface\n",
+       "3. **Composabilite** : Les solveurs peuvent etre passes en parametre, stockes dans des listes, testes unitairement\n",
+       "4. **Extensibilite** : Ajouter un nouveau solver ne necessite que d'implementer l'interface\n",
+       "\n",
+       "> **Note technique** : Ce design pattern permet a `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le meme code de test."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Définition de la classe SudokuHelper\n",
+       "\n",
+       "Nous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n",
+       "\n",
+       "- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n",
+       "- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n",
+       "- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n",
+       "- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Infrastructure de test et benchmark\n",
+       "\n",
+       "**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complete pour tester et comparer les solveurs de Sudoku.\n",
+       "\n",
+       "| Aspect | Valeur | Signification |\n",
+       "|--------|--------|---------------|\n",
+       "| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulte (Easy/Medium/Hard) |\n",
+       "| `TestSolvers()` | Performance multi-solveurs | Execution parallele avec timeout |\n",
+       "| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de resolution |\n",
+       "| `SolveSudoku()` | Test unitaire | Resolution individuelle avec affichage |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Chargement intelligent** : Recherche recursive du dossier `Puzzles` dans l'arborescence\n",
+       "2. **Robustesse** : Gestion des timeouts (3000ms par defaut) et exceptions\n",
+       "3. **Mesures** : Temps d'execution total + nombre de grilles resolues\n",
+       "4. **Disqualification** : Un solver echouant sur une grille est disqualifie pour la difficulte\n",
+       "\n",
+       "> **Note technique** : La methode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe increment du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Exercice : Validation d'une grille Sudoku\n",
+       "\n",
+       "### Enonce\n",
+       "\n",
+       "Implementez une methode `IsValidSolution` qui verifie qu'une grille est une solution valide de Sudoku, c'est-a-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 a 9.\n",
+       "\n",
+       "Utilisez cette methode pour valider les resultats de `SudokuHelper.SolveSudoku`.\n",
+       "\n",
+       "### Indices\n",
+       "\n",
+       "- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n",
+       "- Pour chaque unite, verifiez que les 9 chiffres sont tous presents sans doublon\n",
+       "- `SudokuGrid.AllNeighbours` contient deja les indices des unites"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
      ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Affichage des Puzzles de chaque Difficulté\n",
+       "\n",
+       "Nous allons charger et afficher un puzzle de chaque niveau de difficulté : Facile, Moyen et Difficile.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Puzzle Facile:\n",
+       "-------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Puzzle Moyen:\n",
+       "-------------------------------\n",
+       "| 8  5    |       2 | 4       | \n",
+       "| 7  2    |         |       9 | \n",
+       "|       4 |         |         | \n",
+       "-------------------------------\n",
+       "|         | 1     7 |       2 | \n",
+       "| 3     5 |         | 9       | \n",
+       "|    4    |         |         | \n",
+       "-------------------------------\n",
+       "|         |    8    |    7    | \n",
+       "|    1  7 |         |         | \n",
+       "|         |    3  6 |    4    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Puzzle Difficile:\n",
+       "-------------------------------\n",
+       "| 4       |         | 8     5 | \n",
+       "|    3    |         |         | \n",
+       "|         | 7       |         | \n",
+       "-------------------------------\n",
+       "|    2    |         |    6    | \n",
+       "|         |    8    | 4       | \n",
+       "|         |    1    |         | \n",
+       "-------------------------------\n",
+       "|         | 6     3 |    7    | \n",
+       "| 5       | 2       |         | \n",
+       "| 1     4 |         |         | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Structure des Puzzles Sudoku\n",
+       "\n",
+       "**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete charges et affiches. La difference de complexite se voit visuellement par le nombre de cases pre-remplies.\n",
+       "\n",
+       "| Difficulte | Cases vides (estimation) | Observation visuelle |\n",
+       "|------------|------------------------|---------------------|\n",
+       "| Facile | ~30-35 | Plus de 50% des cases sont deja remplies, beaucoup de contraintes visibles |\n",
+       "| Moyen | ~45-50 | Environ 50% de cases vides, structure moins evidente |\n",
+       "| Difficile | ~55-60 | Tres peu de cases pre-remplies (environ 40%), contraintes minimales |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Echantillonnage representatif** : La methode `GetSudokus().FirstOrDefault()` retourne le premier puzzle disponible de chaque niveau, ce qui permet une comparaison consistante.\n",
+       "2. **Correlation difficulte/densite** : Plus le puzzle a de cases vides, plus l'espace de recherche est grand et plus le backtracking devra explorer de combinaisons.\n",
+       "3. **Regles du jeu respectees** : Chaque puzzle respecte les contraintes du Sudoku (uniques chiffres 1-9 par ligne, colonne, bloc 3x3).\n",
+       "4. **Preparation aux tests** : Ces trois puzzles serviront de base pour evaluer les performances du solveur de backtracking.\n",
+       "\n",
+       "> **Note technique** : Les puzzles sont generes algorithmiquement pour garantir qu'ils ont exactement une solution unique. Cette propriete est cruciale pour evaluer la completude de l'algorithme de backtracking.\n",
+       "\n",
+       "**Impact sur la performance** : Le nombre de cases vides determine directement la taille de l'arbre de recherche du backtracking. Avec 60 cases vides, le pire cas theorique est 9^60 possibilites, mais les contraintes reduisent drastiquement ce nombre en pratique."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Code du solver en C#\n",
+       "\n",
+       "Nous allons maintenant implémenter ce solveur en C#.\n",
+       "\n",
+       "### Classe `BacktrackingDotNetSolver`"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Test du Solveur\n",
+       "\n",
+       "Nous allons maintenant tester notre solveur de Sudoku par backtracking en utilisant une grille de Sudoku.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle Sudoku Facile Initial:\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver BacktrackingDotNetSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BacktrackingDotNetSolver: 122 search calls\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
+       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
+       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
+       "-------------------------------\n",
+       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
+       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
+       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
+       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
+       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 0,4082 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle Sudoku Moyen Initial:\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver BacktrackingDotNetSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 8  5    |       2 | 4       | \n",
+       "| 7  2    |         |       9 | \n",
+       "|       4 |         |         | \n",
+       "-------------------------------\n",
+       "|         | 1     7 |       2 | \n",
+       "| 3     5 |         | 9       | \n",
+       "|    4    |         |         | \n",
+       "-------------------------------\n",
+       "|         |    8    |    7    | \n",
+       "|    1  7 |         |         | \n",
+       "|         |    3  6 |    4    | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BacktrackingDotNetSolver: 490304 search calls\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 8  5  9 | 6  1  2 | 4  3  7 | \n",
+       "| 7  2  3 | 8  5  4 | 1  6  9 | \n",
+       "| 1  6  4 | 3  7  9 | 5  2  8 | \n",
+       "-------------------------------\n",
+       "| 9  8  6 | 1  4  7 | 3  5  2 | \n",
+       "| 3  7  5 | 2  6  8 | 9  1  4 | \n",
+       "| 2  4  1 | 5  9  3 | 7  8  6 | \n",
+       "-------------------------------\n",
+       "| 4  3  2 | 9  8  1 | 6  7  5 | \n",
+       "| 6  1  7 | 4  2  5 | 8  9  3 | \n",
+       "| 5  9  8 | 7  3  6 | 2  4  1 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 133,4834 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Puzzle Sudoku Difficile Initial:\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Résolution par le solver BacktrackingDotNetSolver du Sudoku:\n",
+       " -------------------------------\n",
+       "| 4       |         | 8     5 | \n",
+       "|    3    |         |         | \n",
+       "|         | 7       |         | \n",
+       "-------------------------------\n",
+       "|    2    |         |    6    | \n",
+       "|         |    8    | 4       | \n",
+       "|         |    1    |         | \n",
+       "-------------------------------\n",
+       "|         | 6     3 |    7    | \n",
+       "| 5       | 2       |         | \n",
+       "| 1     4 |         |         | \n",
+       "-------------------------------"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BacktrackingDotNetSolver: 12625368 search calls\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sudoku renvoyé:\n",
+       "-------------------------------\n",
+       "| 4  1  7 | 3  6  9 | 8  2  5 | \n",
+       "| 6  3  2 | 1  5  8 | 9  4  7 | \n",
+       "| 9  5  8 | 7  2  4 | 3  1  6 | \n",
+       "-------------------------------\n",
+       "| 8  2  5 | 4  3  7 | 1  6  9 | \n",
+       "| 7  9  1 | 5  8  6 | 4  3  2 | \n",
+       "| 3  4  6 | 9  1  2 | 7  5  8 | \n",
+       "-------------------------------\n",
+       "| 2  8  9 | 6  4  3 | 5  7  1 | \n",
+       "| 5  7  3 | 2  9  1 | 6  8  4 | \n",
+       "| 1  6  4 | 8  7  5 | 2  9  3 | \n",
+       "-------------------------------\n",
+       "Nombre d'erreurs réstantes: 0\n",
+       "Temps de résolution: 3948,1362 ms"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Interpretation : Performance du Backtracking\n",
+       "\n",
+       "**Sortie obtenue** : Trois puzzles de difficulte croissante ont ete resolus avec succes. Le nombre d'appels recursifs et le temps de resolution augmentent exponentiellement avec la difficulte.\n",
+       "\n",
+       "| Difficulte | Appels recursifs | Temps (ms) | Facteur d'augmentation |\n",
+       "|------------|-----------------|------------|------------------------|\n",
+       "| Facile | 122 | 0,49 | 1x (reference) |\n",
+       "| Moyen | 490 304 | 177,79 | 4 019x |\n",
+       "| Difficile | 12 625 368 | 5 762,31 | 103 489x |\n",
+       "\n",
+       "**Points cles** :\n",
+       "1. **Complexite exponentielle** : Le nombre d'appels recursifs explose littéralement entre le puzzle facile (122 appels) et le puzzle difficile (12,6 millions d'appels).\n",
+       "2. **Efficacite sur les puzzles simples** : Le backtracking naive est tres rapide (moins d'une demi-millisecond) pour les puzzles faciles.\n",
+       "3. **Limites sur les puzzles difficiles** : Plus de 5,7 secondes pour un puzzle difficile difficilement acceptable pour une application interactive.\n",
+       "4. **Tous les puzzles resolus** : L'algorithme trouve toujours une solution (completude), mais le cout en temps varie enormement.\n",
+       "\n",
+       "> **Note technique** : Le temps de resolution n'est pas lineaire par rapport au nombre d'appels recursifs. Le puzzle difficile necessite 25 fois plus d'appels que le puzzle moyen, mais prend 32 fois plus de temps. Cela s'explique par le cout de la gestion de la pile d'appels et des operations de validation.\n",
+       "\n",
+       "**Comparaison avec la theorie** : L'analyse des resultats confirme les proprietes theoriques du backtracking :\n",
+       "- **Completude** : Tous les puzzles sont resolus avec 0 erreurs restantes\n",
+       "- **Cout** : Exponentiel dans le pire cas, mais acceptable pour les instances simples\n",
+       "- **Amelioration necessaire** : Les heuristiques (MRV, Forward Checking) sont indispensables pour les puzzles difficiles"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Exercice : Backtracking avec Heuristique MRV (Minimum Remaining Values)\n",
+       "\n",
+       "### Enonce\n",
+       "\n",
+       "L'implementation actuelle de `BacktrackingDotNetSolver` choisit les cellules a remplir dans l'ordre de parcours (de gauche a droite, de haut en bas). Implementez une version amelioree avec l'heuristique **MRV** (Minimum Remaining Values) :\n",
+       "\n",
+       "L'heuristique MRV choisit en priorite la cellule qui a le **moins de valeurs possibles** (le domaine le plus petit). Intuitivement, on commence par les cellules les plus contraintes pour detecter les echecs plus tot et reduire l'espace de recherche.\n",
+       "\n",
+       "Implementez `BacktrackingMRVSolver` :\n",
+       "1. Pour chaque cellule vide, calculez son domaine (valeurs 1-9 compatibles avec les contraintes)\n",
+       "2. Choisissez la cellule avec le plus petit domaine non vide\n",
+       "3. Si un domaine est vide, retournez `false` immediatement (echec precoce)\n",
+       "4. Comparez le nombre d'appels recursifs avec `BacktrackingDotNetSolver`\n",
+       "\n",
+       "### Indice\n",
+       "\n",
+       "Le calcul du domaine consiste a retirer de {1..9} toutes les valeurs deja presentes dans la meme ligne, colonne ou bloc. L'heuristique MRV reduit drastiquement les appels recursifs sur les puzzles difficiles."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TODO: Implementez BacktrackingMRVSolver pour comparer les performances\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Conclusion et Analyse des Performances\n",
+       "\n",
+       "L'algorithme de backtracking est une methode efficace pour resoudre des puzzles de Sudoku simples a moderes. Pour des puzzles plus complexes, il peut devenir lent en raison du grand nombre de combinaisons possibles.\n",
+       "\n",
+       "| Aspect | Observation |\n",
+       "|--------|-------------|\n",
+       "| **Completude** | Oui - trouve toujours une solution si elle existe |\n",
+       "| **Optimalite** | N/A (il n'y a qu'une solution par grille valide) |\n",
+       "| **Complexite** | O(9^81) dans le pire cas, beaucoup mieux en pratique |\n",
+       "| **Forces** | Simple a implementer, garanti de trouver une solution |\n",
+       "| **Faiblesses** | Lent sur les puzzles difficiles sans heuristiques |\n",
+       "\n",
+       "### Pistes d'amelioration\n",
+       "\n",
+       "- **MRV (Minimum Remaining Values)** : choisir la cellule la plus contrainte en premier\n",
+       "- **Forward Checking** : eliminer les valeurs impossibles apres chaque assignation\n",
+       "- **Propagation de contraintes** : voir [Sudoku-7 Norvig](Sudoku-7-Norvig.ipynb) pour une approche plus sophistiquee\n",
+       "\n",
+       "### Prochaines etapes\n",
+       "\n",
+       "Dans les notebooks suivants, nous explorerons des techniques plus avancees :\n",
+       "- [Sudoku-2 Genetic](Sudoku-2-Genetic.ipynb) : approche metaheuristique\n",
+       "- [Sudoku-3 OR-Tools](Sudoku-3-ORTools.ipynb) : programmation par contraintes industrielle\n",
+       "\n",
+       "---\n",
+       "\n",
+       "**Navigation** : [<< Sudoku-0 Environment](Sudoku-0-Environment.ipynb) | [Index](README.md) | [Sudoku-2 Genetic >>](Sudoku-2-Genetic.ipynb)\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1843,9 +2857,30 @@
   {
    "cell_type": "markdown",
    "id": "8bddfbc5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00559,
+     "end_time": "2026-05-08T22:49:56.989101+00:00",
+     "exception": false,
+     "start_time": "2026-05-08T22:49:56.983511+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Configuration des solvers et benchmark comparatif des strategies humaines."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4b81f2d",
+   "metadata": {
+    "tags": [
+     "papermill-error-cell-tag"
+    ]
+   },
+   "source": [
+    "<span id=\"papermill-error-cell\" style=\"color:red; font-family:Helvetica Neue, Helvetica, Arial, sans-serif; font-size:2em;\">Execution using papermill encountered an exception here and stopped:</span>"
    ]
   },
   {
@@ -1857,14 +2892,22 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-21T00:20:33.065904Z",
-     "iopub.status.busy": "2026-04-21T00:20:33.065547Z",
-     "iopub.status.idle": "2026-04-21T00:20:33.141614Z",
-     "shell.execute_reply": "2026-04-21T00:20:33.140929Z"
+     "iopub.execute_input": "2026-05-08T22:49:57.001336Z",
+     "iopub.status.busy": "2026-05-08T22:49:57.001174Z",
+     "iopub.status.idle": "2026-05-08T22:49:57.052328Z",
+     "shell.execute_reply": "2026-05-08T22:49:57.052173Z"
+    },
+    "papermill": {
+     "duration": 0.057794,
+     "end_time": "2026-05-08T22:49:57.052440+00:00",
+     "exception": true,
+     "start_time": "2026-05-08T22:49:56.994646+00:00",
+     "status": "failed"
     },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1872,13 +2915,9 @@
      "output_type": "stream",
      "text": [
       "\r\n",
-      "(1,38): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
+      "(3,5): error CS1950: La méthode Add surchargée 'List<(string Name, ISudokuSolver Solver)>.Add((string Name, ISudokuSolver Solver))' correspondant le mieux à l'initialiseur de collection a des arguments non valides\r\n",
       "\r\n",
-      "(3,25): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,38): error CS0246: Le nom de type ou d'espace de noms 'BacktrackingDotNetSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,15): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
+      "(3,5): error CS1503: Argument 1 : conversion impossible de '(string, HumanSolver)' en '(string Name, ISudokuSolver Solver)'\r\n",
       "\r\n"
      ]
     },
@@ -1909,7 +2948,16 @@
   {
    "cell_type": "markdown",
    "id": "bdd3ec39",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Comparaison de performance\n",
     "\n",
@@ -1926,7 +2974,16 @@
   {
    "cell_type": "markdown",
    "id": "06f82c4b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Analyse statistique par difficulte\n",
     "\n",
@@ -1935,7 +2992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "078aadad",
    "metadata": {
     "dotnet_interactive": {
@@ -1947,45 +3004,19 @@
      "iopub.status.idle": "2026-04-21T00:20:33.264696Z",
      "shell.execute_reply": "2026-04-21T00:20:33.263774Z"
     },
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
     "polyglot_notebook": {
      "kernelName": "csharp"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,24): error CS0246: Le nom de type ou d'espace de noms 'SudokuDifficulty' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(37,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(38,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(39,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,26): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,24): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(20,23): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'technique'.\r\n",
-      "\r\n",
-      "(20,34): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée '_'.\r\n",
-      "\r\n",
-      "(20,34): error CS8183: Impossible de déduire le type d'une variable implicitement typée abandonnée.\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Analyse des techniques utilisees sur un echantillon de puzzles\n",
     "void AnalyzeTechniques(SudokuDifficulty difficulty, int count)\n",
@@ -2031,7 +3062,16 @@
   {
    "cell_type": "markdown",
    "id": "d54e34f1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Distribution des techniques\n",
     "\n",
@@ -2047,7 +3087,16 @@
   {
    "cell_type": "markdown",
    "id": "fa4fca2e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2068,7 +3117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "9858ce63",
    "metadata": {
     "execution": {
@@ -2077,25 +3126,17 @@
      "iopub.status.idle": "2026-04-21T00:20:33.285762Z",
      "shell.execute_reply": "2026-04-21T00:20:33.284988Z"
     },
-    "language": "polyglot-notebook"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+    "language": "polyglot-notebook",
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// Squelette pour le Swordfish\n",
     "public static int ApplySwordfish(CandidateGrid cg)\n",
@@ -2108,7 +3149,16 @@
   {
    "cell_type": "markdown",
    "id": "18wn8202qwk",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -2135,7 +3185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "e8881fdd",
    "metadata": {
     "execution": {
@@ -2144,27 +3194,17 @@
      "iopub.status.idle": "2026-04-21T00:20:33.310068Z",
      "shell.execute_reply": "2026-04-21T00:20:33.309428Z"
     },
-    "language": "polyglot-notebook"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,24): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+    "language": "polyglot-notebook",
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "public interface IHumanTechniqueExpert\n",
     "{\n",
@@ -2176,7 +3216,16 @@
   {
    "cell_type": "markdown",
    "id": "74995405",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Conclusion\n",
     "\n",
@@ -2218,7 +3267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "y893nvxnrmn",
    "metadata": {
     "execution": {
@@ -2226,31 +3275,17 @@
      "iopub.status.busy": "2026-04-21T00:20:33.311589Z",
      "iopub.status.idle": "2026-04-21T00:20:33.343138Z",
      "shell.execute_reply": "2026-04-21T00:20:33.342213Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,42): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,31): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(26,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(38,23): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
     },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": null,
+     "start_time": null,
+     "status": "pending"
+    },
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "// A COMPLETER : Solveur hybride avec techniques expertes\n",
     "\n",
@@ -2320,7 +3355,19 @@
    "mimetype": "text/x-csharp",
    "name": "C#",
    "pygments_lexer": "csharp",
-   "version": "13.0"
+   "version": "12.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 10.334673,
+   "end_time": "2026-05-08T22:49:57.191731+00:00",
+   "environment_variables": {},
+   "exception": true,
+   "input_path": "Sudoku-8-HumanStrategies-Csharp.ipynb",
+   "output_path": "d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-8-HumanStrategies-Csharp.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-08T22:49:46.857058+00:00",
+   "version": "2.7.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {


### PR DESCRIPTION
## Summary
- **Sudoku-11-Choco**: Replace hardcoded absolute paths (`d:/Dev/CoursIA/...`) with dynamic CWD resolution that searches up the directory tree. Replace 4 hardcoded `#r` DLL paths with relative references. Replace `throw NotImplementedException` with compliant stub (`return -1`).
- **Sudoku-8, 12, 15**: Clear stale error outputs caused by .NET Interactive resolving `#!import` relative to CWD instead of notebook directory. Sudoku-8 partially re-executed (11/16 cells OK via Papermill).

## Root Cause
.NET Interactive `#!import` resolves paths relative to **CWD**, not the notebook's directory. When Papermill sets CWD to the repo root, all `#!import "SomeFile.csx"` calls fail with "file not found", producing error outputs in every downstream cell.

## Fixes Applied
| Notebook | Fix | Status |
|----------|-----|--------|
| Sudoku-11-Choco | Dynamic CWD resolution + relative DLL + C.1 stub | Source fixed |
| Sudoku-8-HumanStrategies | Stale error outputs cleared | 11/16 cells re-executed OK |
| Sudoku-12-Z3 | Stale error outputs cleared | Re-exec requires .NET Interactive + NuGet |
| Sudoku-15-Infer | Stale error outputs cleared | Re-exec requires .NET Interactive + NuGet |

## Notes
- Sudoku-12 and 15 need cell-by-cell .NET Interactive execution (Papermill cannot resolve NuGet `#r "nuget: ..."` directives)
- Sudoku-8 cell 11 has a pre-existing compilation bug (`List<(string, ISudokuSolver)>` type mismatch) — separate from this path fix
- Sudoku-13 (SymbolicAutomata) was never executed (0 exec, 0 errors) — separate category, not addressed here

## Test plan
- [x] Sudoku-11 source fixes: dynamic CWD, relative DLL paths, compliant stub
- [x] Sudoku-8 Papermill re-execution: 11/16 cells pass
- [ ] Sudoku-12 re-execution via .NET Interactive (NuGet dependency)
- [ ] Sudoku-15 re-execution via .NET Interactive (Infer.NET dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)