### PR TITLE
fix(docker): hardening Phase 2 — non-root users + resource limits for top-5 services

### DIFF
--- a/docker-configurations/services/comfyui-qwen/docker-compose.yml
+++ b/docker-configurations/services/comfyui-qwen/docker-compose.yml
@@ -3,9 +3,13 @@ services:
     image: python:3.11
     container_name: comfyui-qwen
     hostname: comfyui-qwen
+    user: "1000:1000"
     
     deploy:
       resources:
+        limits:
+          cpus: '4'
+          memory: 12G
         reservations:
           devices:
             - driver: nvidia

--- a/docker-configurations/services/funasr-api/Dockerfile
+++ b/docker-configurations/services/funasr-api/Dockerfile
@@ -51,8 +51,15 @@ RUN chmod +x /app/start.sh /app/patch-funasr.sh
 # Apply runtime patches for FunASR Nano compatibility
 RUN /app/patch-funasr.sh
 
-# Create directories
-RUN mkdir -p /app/models /app/uploads
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser
+
+# Create directories with proper ownership
+RUN mkdir -p /app/models /app/uploads && \
+    chown -R appuser:appuser /app
+
+USER appuser
 
 # Expose port
 EXPOSE 8194

--- a/docker-configurations/services/funasr-api/docker-compose.yml
+++ b/docker-configurations/services/funasr-api/docker-compose.yml
@@ -15,6 +15,9 @@ services:
 
     deploy:
       resources:
+        limits:
+          cpus: '2'
+          memory: 4G
         reservations:
           devices:
             - driver: nvidia
@@ -34,7 +37,7 @@ services:
         read_only: true
       - type: volume
         source: funasr-cache
-        target: /root/.cache
+        target: /home/appuser/.cache
 
     environment:
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-1}
@@ -56,6 +59,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 120s
+
+    read_only: true
+    tmpfs:
+      - /tmp:size=100M
 
     restart: unless-stopped
 

--- a/docker-configurations/services/sd-forge-main/docker-compose.yml
+++ b/docker-configurations/services/sd-forge-main/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   sd-forge-main:
     build: .
@@ -8,6 +6,7 @@ services:
     hostname: sd-forge-main
     ports:
       - "127.0.0.1:7860:7860"
+    user: "1000:1000"
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - WEB_USER=${FORGE_USER:-admin}
@@ -18,11 +17,20 @@ services:
       - ../../shared/outputs:/opt/storage/stable_diffusion/outputs
     deploy:
       resources:
+        limits:
+          cpus: '2'
+          memory: 6G
         reservations:
           devices:
             - driver: nvidia
               device_ids: ['1']
               capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:7860/ | grep -qE '200|401|403'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
     restart: unless-stopped
     stdin_open: true
     tty: true

--- a/docker-configurations/services/vllm-zimage/docker-compose.yml
+++ b/docker-configurations/services/vllm-zimage/docker-compose.yml
@@ -2,11 +2,12 @@ services:
   vllm-zimage:
     image: vllm/vllm-omni:v0.12.0rc1
     container_name: vllm-zimage
+    user: "1000:1000"
     ipc: host
     ports:
       - "127.0.0.1:${VLLM_ZIMAGE_PORT:-8001}:8000"
     volumes:
-      - ../../shared/cache/huggingface:/root/.cache/huggingface
+      - ../../shared/cache/huggingface:/home/vllm/.cache/huggingface
       - ../../shared/models:/models:ro
     environment:
       - HF_TOKEN=${HF_TOKEN}
@@ -39,6 +40,9 @@ services:
       - "${VLLM_API_KEY:-}"
     deploy:
       resources:
+        limits:
+          cpus: '4'
+          memory: 8G
         reservations:
           devices:
             - driver: nvidia

--- a/docker-configurations/services/whisper-api/Dockerfile
+++ b/docker-configurations/services/whisper-api/Dockerfile
@@ -28,8 +28,15 @@ COPY app.py /app/
 COPY start.sh /app/
 RUN chmod +x /app/start.sh
 
-# Create directories
-RUN mkdir -p /app/models /app/uploads /app/outputs
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser
+
+# Create directories with proper ownership
+RUN mkdir -p /app/models /app/uploads /app/outputs && \
+    chown -R appuser:appuser /app
+
+USER appuser
 
 # Expose port
 EXPOSE 8190

--- a/docker-configurations/services/whisper-api/docker-compose.yml
+++ b/docker-configurations/services/whisper-api/docker-compose.yml
@@ -15,6 +15,9 @@ services:
 
     deploy:
       resources:
+        limits:
+          cpus: '2'
+          memory: 4G
         reservations:
           devices:
             - driver: nvidia
@@ -34,7 +37,7 @@ services:
         read_only: true
       - type: volume
         source: whisper-cache
-        target: /root/.cache
+        target: /home/appuser/.cache
 
     environment:
       - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
@@ -55,6 +58,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 120s
+
+    read_only: true
+    tmpfs:
+      - /tmp:size=100M
 
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary
- Add non-root users (UID 1000) to all 5 priority GenAI services
- Add CPU and memory resource limits to prevent host OOM
- Add read-only filesystem to whisper-api and funasr-api
- Add missing healthcheck to sd-forge-main
- Fix cache volume paths for non-root user home directories

Phase 1 (localhost-only binding) was #808. This is Phase 2.

## Services hardened

| Service | Non-root | CPU limit | RAM limit | read_only | Healthcheck |
|---------|----------|-----------|-----------|-----------|-------------|
| vllm-zimage | user 1000:1000 | 4 | 8G | no | existing |
| comfyui-qwen | user 1000:1000 | 4 | 12G | no | existing |
| whisper-api | appuser (Dockerfile) | 2 | 4G | yes | existing |
| funasr-api | appuser (Dockerfile) | 2 | 4G | yes | existing |
| sd-forge-main | user 1000:1000 | 2 | 6G | no | **added** |

## Breaking changes

- **whisper-api, funasr-api**: Dockerfiles modified — need `docker compose build` to rebuild images with the new appuser
- **vllm-zimage**: Cache path changed from `/root/.cache/huggingface` to `/home/vllm/.cache/huggingface` — existing cache volume data is preserved (Docker volume mount target only)
- **comfyui-qwen**: Runs as UID 1000 — host workspace directory must be writable by UID 1000

## Test plan
- [ ] `docker compose config` validates on all 5 services
- [ ] Rebuild whisper-api and funasr-api images (`docker compose build`)
- [ ] Verify containers start as non-root (`docker exec <container> id`)
- [ ] Verify GPU access still works (`docker exec <container> nvidia-smi`)
- [ ] Verify healthchecks pass after restart
- [ ] Verify resource limits enforced (`docker stats --no-stream`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)