### PR TITLE
fix(ml): resolve ML-7 Recommendation schema mismatch and C# type errors

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -1154,73 +1154,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Entraînement du modèle de recommandation de produits...\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "System.ArgumentOutOfRangeException: Schema mismatch for label column 'Purchased': expected Boolean, got Single (Parameter 'labelCol')\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckLabelCompatible(Column labelCol)\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckInputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.GetOutputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Data.EstimatorChain`1.GetOutputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Data.EstimatorChain`1.Fit(IDataView input)\r\n   at Submission#11.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-     "traceback": [
-      "System.ArgumentOutOfRangeException: Schema mismatch for label column 'Purchased': expected Boolean, got Single (Parameter 'labelCol')\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckLabelCompatible(Column labelCol)\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckInputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.GetOutputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Data.EstimatorChain`1.GetOutputSchema(SchemaShape inputSchema)\r\n   at Microsoft.ML.Data.EstimatorChain`1.Fit(IDataView input)\r\n   at Submission#11.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-      "   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckLabelCompatible(Column labelCol)",
-      "   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.CheckInputSchema(SchemaShape inputSchema)",
-      "   at Microsoft.ML.Trainers.TrainerEstimatorBase`2.GetOutputSchema(SchemaShape inputSchema)",
-      "   at Microsoft.ML.Data.EstimatorChain`1.GetOutputSchema(SchemaShape inputSchema)",
-      "   at Microsoft.ML.Data.EstimatorChain`1.Fit(IDataView input)",
-      "   at Submission#11.<<Initialize>>d__0.MoveNext()",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
-     ]
-    }
-   ],
-   "source": [
-    "using Microsoft.ML;\n",
-    "using Microsoft.ML.Data;\n",
-    "using Microsoft.ML.Trainers;\n",
-    "using System;\n",
-    "using System.Collections.Generic;\n",
-    "using System.Linq;\n",
-    "\n",
-    "// Entraîner le modèle de recommandation de produits\n",
-    "var productData = mlContext.Data.LoadFromEnumerable(positivePurchases);\n",
-    "\n",
-    "// Utiliser SDCA pour la classification binaire (acheté ou non)\n",
-    "var productPipeline = mlContext.Transforms.Concatenate(\"Features\", \"UserId\", \"ProductId\")\n",
-    "    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(\n",
-    "        labelColumnName: \"Purchased\",\n",
-    "        featureColumnName: \"Features\",\n",
-    "        maximumNumberOfIterations: 100));\n",
-    "\n",
-    "Console.WriteLine(\"Entraînement du modèle de recommandation de produits...\");\n",
-    "var productModel = productPipeline.Fit(productData);\n",
-    "Console.WriteLine(\"Modèle entraîné !\");\n",
-    "\n",
-    "// Faire des recommandations pour un utilisateur\n",
-    "var productEngine = mlContext.Model.CreatePredictionEngine<ProductPurchase, ProductRecommendationPrediction>(productModel);\n",
-    "\n",
-    "Console.WriteLine(\"\\n=== Top-5 Recommandations de produits pour l'Utilisateur 1 ===\");\n",
-    "var userRecommendations = new List<(int productId, float score)>();\n",
-    "\n",
-    "for (int productId = 1; productId <= 20; productId++)\n",
-    "{\n",
-    "    var pred = productEngine.Predict(new ProductPurchase { UserId = 1, ProductId = productId });\n",
-    "    userRecommendations.Add((productId, pred.Score));\n",
-    "}\n",
-    "\n",
-    "var top5 = userRecommendations.OrderByDescending(x => x.score).Take(5);\n",
-    "foreach (var (productId, score) in top5)\n",
-    "{\n",
-    "    Console.WriteLine($\"  - Produit {productId} : probabilité d'achat = {score:F3}\");\n",
-    "}\n"
-   ]
+   "outputs": [],
+   "source": "using Microsoft.ML;\nusing Microsoft.ML.Data;\nusing Microsoft.ML.Trainers;\nusing System;\nusing System.Collections.Generic;\nusing System.Linq;\n\n// Utiliser TOUTES les donnees (achats ET non-achats) pour la classification binaire\n// Un classifieur binaire necessite les deux classes (true/false) pour s'entrainer\nvar productData = mlContext.Data.LoadFromEnumerable(purchaseData);\n\n// Convertir le label bool en type Boolean explicite + concatenation des features\nvar productPipeline = mlContext.Transforms.Conversion.ConvertType(\"Purchased\", outputKind: DataKind.Boolean)\n    .Append(mlContext.Transforms.Concatenate(\"Features\", \"UserId\", \"ProductId\"))\n    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(\n        labelColumnName: \"Purchased\",\n        featureColumnName: \"Features\",\n        maximumNumberOfIterations: 100));\n\nConsole.WriteLine(\"Entrainement du modele de recommandation de produits...\");\nvar productModel = productPipeline.Fit(productData);\nConsole.WriteLine(\"Modele entraine !\");\n\n// Faire des recommandations pour un utilisateur\nvar productEngine = mlContext.Model.CreatePredictionEngine<ProductPurchase, ProductRecommendationPrediction>(productModel);\n\nConsole.WriteLine(\"\\n=== Top-5 Recommandations de produits pour l'Utilisateur 1 ===\");\nvar userRecommendations = new List<(int productId, float score)>();\n\nfor (int productId = 1; productId <= 20; productId++)\n{\n    var pred = productEngine.Predict(new ProductPurchase { UserId = 1, ProductId = productId });\n    userRecommendations.Add((productId, pred.Score));\n}\n\nvar top5 = userRecommendations.OrderByDescending(x => x.score).Take(5);\nforeach (var (productId, score) in top5)\n{\n    Console.WriteLine($\"  - Produit {productId} : probabilite d'achat = {score:F3}\");\n}"
   },
   {
    "cell_type": "markdown",
@@ -1269,76 +1206,10 @@
   },
   {
    "cell_type": "code",
-   "source": [
-    "// Exercice : Système de recommandation de livres\n",
-    "\n",
-    "// TODO: Définir la classe BookRating\n",
-    "public class BookRating\n",
-    "{\n",
-    "    // Propriétés: UserId, BookId, Rating (1-5)\n",
-    "}\n",
-    "\n",
-    "// TODO: Définir la classe BookRatingPrediction\n",
-    "public class BookRatingPrediction\n",
-    "{\n",
-    "    // Propriété: Score (note prédite)\n",
-    "}\n",
-    "\n",
-    "// TODO: Créer les données d'entraînement (10 utilisateurs, 8 livres)\n",
-    "// Variez les préférences : certains aiment la SF, d'autres les Romans, etc.\n",
-    "var bookData = new List<BookRating>\n",
-    "{\n",
-    "    // Ajoutez au moins 30 notes\n",
-    "};\n",
-    "\n",
-    "// TODO: Créer le MLContext et charger les données\n",
-    "MLContext bookContext = null;\n",
-    "IDataView bookTrainingData = null;\n",
-    "\n",
-    "// TODO: Construire le pipeline de recommandation\n",
-    "var bookPipeline = null;\n",
-    "\n",
-    "// TODO: Entraîner le modèle\n",
-    "var bookModel = null;\n",
-    "\n",
-    "// TODO: Créer le moteur de prédiction\n",
-    "var bookEngine = null;\n",
-    "\n",
-    "// TODO: Générer les Top-3 recommandations pour l'Utilisateur 1\n",
-    "Console.WriteLine(\"=== Top-3 Recommandations de livres pour l'Utilisateur 1 ===\");\n",
-    "// Pour chaque livre non noté par l'utilisateur, prédire la note\n",
-    "// Trier par note prédite décroissante et afficher le Top 3\n",
-    "\n",
-    "// TODO (bonus): Cold Start - Recommandations pour un nouvel utilisateur (User 11)\n",
-    "Console.WriteLine(\"\\n=== Cold Start - Recommandations pour nouvel utilisateur ===\");\n",
-    "// Utiliser la moyenne globale des livres\n",
-    "var topBooks = null; // Livres les mieux notés globalement"
-   ],
+   "source": "// Exercice : Système de recommandation de livres\n\n// TODO: Définir la classe BookRating\npublic class BookRating\n{\n    // Propriétés: UserId, BookId, Rating (1-5)\n}\n\n// TODO: Définir la classe BookRatingPrediction\npublic class BookRatingPrediction\n{\n    // Propriété: Score (note prédite)\n}\n\n// TODO: Créer les données d'entraînement (10 utilisateurs, 8 livres)\n// Variez les préférences : certains aiment la SF, d'autres les Romans, etc.\nvar bookData = new List<BookRating>\n{\n    // Ajoutez au moins 30 notes\n};\n\n// TODO: Créer le MLContext et charger les données\nMLContext bookContext = null;\nIDataView bookTrainingData = null;\n\n// TODO: Construire le pipeline de recommandation\nIEstimator<ITransformer> bookPipeline = null;\n\n// TODO: Entraîner le modèle\nITransformer bookModel = null;\n\n// TODO: Créer le moteur de prédiction\nPredictionEngine<BookRating, BookRatingPrediction> bookEngine = null;\n\n// TODO: Générer les Top-3 recommandations pour l'Utilisateur 1\nConsole.WriteLine(\"=== Top-3 Recommandations de livres pour l'Utilisateur 1 ===\");\n// Pour chaque livre non noté par l'utilisateur, prédire la note\n// Trier par note prédite décroissante et afficher le Top 3\n\n// TODO (bonus): Cold Start - Recommandations pour un nouvel utilisateur (User 11)\nConsole.WriteLine(\"\\n=== Cold Start - Recommandations pour nouvel utilisateur ===\");\n// Utiliser la moyenne globale des livres\nList<(int bookId, float score)> topBooks = null; // Livres les mieux notés globalement",
    "metadata": {},
    "execution_count": null,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "\r\n",
-      "(27,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n",
-      "(30,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n",
-      "(33,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n",
-      "(43,5): error CS0815: Impossible d'assigner <Null> à une variable implicitement typée\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "output_type": "error",
-     "ename": "Error",
-     "evalue": "compilation error",
-     "traceback": []
-    }
-   ]
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -602,14 +602,14 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Utilisateur 1 - Film 3 : Note prédite = 1,16 (vraie note = 1)\r\n"
+      "Utilisateur 1 - Film 3 : Note prédite = 1,15 (vraie note = 1)\r\n"
      ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Utilisateur 2 - Film 1 : Note prédite = 1,74 (vraie note = 2)\r\n"
+      "Utilisateur 2 - Film 1 : Note prédite = 1,69 (vraie note = 2)\r\n"
      ]
     },
     {
@@ -831,21 +831,21 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "RMSE : 2,988\r\n"
+      "RMSE : 2,952\r\n"
      ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "MAE : 2,589\r\n"
+      "MAE : 2,592\r\n"
      ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "R2 : -34,724\r\n"
+      "R2 : -33,869\r\n"
      ]
     },
     {
@@ -1156,7 +1156,65 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Entrainement du modele de recommandation de produits...\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Modele entraine !\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "=== Top-5 Recommandations de produits pour l'Utilisateur 1 ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  - Produit 1 : probabilite d'achat = -0,684\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  - Produit 2 : probabilite d'achat = -0,696\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  - Produit 3 : probabilite d'achat = -0,707\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  - Produit 4 : probabilite d'achat = -0,718\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  - Produit 5 : probabilite d'achat = -0,730\r\n"
+     ]
+    }
+   ],
    "source": "using Microsoft.ML;\nusing Microsoft.ML.Data;\nusing Microsoft.ML.Trainers;\nusing System;\nusing System.Collections.Generic;\nusing System.Linq;\n\n// Utiliser TOUTES les donnees (achats ET non-achats) pour la classification binaire\n// Un classifieur binaire necessite les deux classes (true/false) pour s'entrainer\nvar productData = mlContext.Data.LoadFromEnumerable(purchaseData);\n\n// Convertir le label bool en type Boolean explicite + concatenation des features\nvar productPipeline = mlContext.Transforms.Conversion.ConvertType(\"Purchased\", outputKind: DataKind.Boolean)\n    .Append(mlContext.Transforms.Concatenate(\"Features\", \"UserId\", \"ProductId\"))\n    .Append(mlContext.BinaryClassification.Trainers.SdcaLogisticRegression(\n        labelColumnName: \"Purchased\",\n        featureColumnName: \"Features\",\n        maximumNumberOfIterations: 100));\n\nConsole.WriteLine(\"Entrainement du modele de recommandation de produits...\");\nvar productModel = productPipeline.Fit(productData);\nConsole.WriteLine(\"Modele entraine !\");\n\n// Faire des recommandations pour un utilisateur\nvar productEngine = mlContext.Model.CreatePredictionEngine<ProductPurchase, ProductRecommendationPrediction>(productModel);\n\nConsole.WriteLine(\"\\n=== Top-5 Recommandations de produits pour l'Utilisateur 1 ===\");\nvar userRecommendations = new List<(int productId, float score)>();\n\nfor (int productId = 1; productId <= 20; productId++)\n{\n    var pred = productEngine.Predict(new ProductPurchase { UserId = 1, ProductId = productId });\n    userRecommendations.Add((productId, pred.Score));\n}\n\nvar top5 = userRecommendations.OrderByDescending(x => x.score).Take(5);\nforeach (var (productId, score) in top5)\n{\n    Console.WriteLine($\"  - Produit {productId} : probabilite d'achat = {score:F3}\");\n}"
   },
   {
@@ -1209,7 +1267,23 @@
    "source": "// Exercice : Système de recommandation de livres\n\n// TODO: Définir la classe BookRating\npublic class BookRating\n{\n    // Propriétés: UserId, BookId, Rating (1-5)\n}\n\n// TODO: Définir la classe BookRatingPrediction\npublic class BookRatingPrediction\n{\n    // Propriété: Score (note prédite)\n}\n\n// TODO: Créer les données d'entraînement (10 utilisateurs, 8 livres)\n// Variez les préférences : certains aiment la SF, d'autres les Romans, etc.\nvar bookData = new List<BookRating>\n{\n    // Ajoutez au moins 30 notes\n};\n\n// TODO: Créer le MLContext et charger les données\nMLContext bookContext = null;\nIDataView bookTrainingData = null;\n\n// TODO: Construire le pipeline de recommandation\nIEstimator<ITransformer> bookPipeline = null;\n\n// TODO: Entraîner le modèle\nITransformer bookModel = null;\n\n// TODO: Créer le moteur de prédiction\nPredictionEngine<BookRating, BookRatingPrediction> bookEngine = null;\n\n// TODO: Générer les Top-3 recommandations pour l'Utilisateur 1\nConsole.WriteLine(\"=== Top-3 Recommandations de livres pour l'Utilisateur 1 ===\");\n// Pour chaque livre non noté par l'utilisateur, prédire la note\n// Trier par note prédite décroissante et afficher le Top 3\n\n// TODO (bonus): Cold Start - Recommandations pour un nouvel utilisateur (User 11)\nConsole.WriteLine(\"\\n=== Cold Start - Recommandations pour nouvel utilisateur ===\");\n// Utiliser la moyenne globale des livres\nList<(int bookId, float score)> topBooks = null; // Livres les mieux notés globalement",
    "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "=== Top-3 Recommandations de livres pour l'Utilisateur 1 ===\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "=== Cold Start - Recommandations pour nouvel utilisateur ===\r\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Fix cell 19 schema mismatch: `SdcaLogisticRegression` expected `Boolean` label but got `Single`. Root cause: (1) using `positivePurchases` (only true values) for binary classification, (2) ML.NET maps `bool` to `Single` internally. Fix: use `purchaseData` (all data including negatives) + add `ConvertType("Purchased", outputKind: DataKind.Boolean)` transform before concatenation.
- Fix cell 21 compilation errors: 4x `var x = null` replaced with explicit types (`IEstimator<ITransformer>`, `ITransformer`, `PredictionEngine<BookRating, BookRatingPrediction>`, `List<(int bookId, float score)>`) to resolve CS0815.

## Test plan
- [ ] Re-execute via .NET Interactive cell-by-cell (Papermill cannot handle NuGet dependencies)
- [ ] Verify cell 19 trains successfully with both classes
- [ ] Verify cell 21 compiles without CS0815 errors
- [ ] Verify exercise stubs preserved (TODO comments intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)