### PR TITLE
fix(sudoku): path-dependency + C.1 stub fix in Sudoku-11

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:38.610335Z",
@@ -75,159 +75,21 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '28252.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Choco-solver JAR deja present: choco-solver-4.10.17-jar-with-dependencies.jar\r\n"
+     ]
     },
     {
-     "ename": "Error",
-     "evalue": "System.IO.DirectoryNotFoundException: Could not find a part of the path 'd:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku'.\r\n   at System.Environment.set_CurrentDirectoryCore(String value)\r\n   at Submission#2.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.DirectoryNotFoundException: Could not find a part of the path 'd:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku'.\r\n   at System.Environment.set_CurrentDirectoryCore(String value)\r\n   at Submission#2.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-      "   at System.Environment.set_CurrentDirectoryCore(String value)",
-      "   at Submission#2.<<Initialize>>d__0.MoveNext()",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Repertoire de travail: d:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\r\n"
      ]
     }
    ],
-   "source": [
-    "// Configuration du repertoire de travail\n",
-    "// IMPORTANT: Doit etre avant toute utilisation de fichiers relatifs\n",
-    "using System;\n",
-    "using System.IO;\n",
-    "using System.Net.Http;\n",
-    "\n",
-    "System.IO.Directory.SetCurrentDirectory(@\"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku\");\n",
-    "\n",
-    "const string ChocoVersion = \"4.10.17\";\n",
-    "const string ChocoJar = $\"choco-solver-{ChocoVersion}-jar-with-dependencies.jar\";\n",
-    "const string ChocoUrl = $\"https://repo1.maven.org/maven2/org/choco-solver/choco-solver/{ChocoVersion}/{ChocoJar}\";\n",
-    "\n",
-    "if (!File.Exists(ChocoJar))\n",
-    "{\n",
-    "    Console.WriteLine($\"Telechargement de {ChocoJar} depuis Maven...\");\n",
-    "    using var client = new HttpClient();\n",
-    "    var data = client.GetByteArrayAsync(ChocoUrl).Result;\n",
-    "    File.WriteAllBytes(ChocoJar, data);\n",
-    "    Console.WriteLine($\"Telecharge: {ChocoJar} ({data.Length} bytes)\");\n",
-    "}\n",
-    "else\n",
-    "{\n",
-    "    Console.WriteLine($\"Choco-solver JAR deja present: {ChocoJar}\");\n",
-    "}"
-   ]
+   "source": "// Configuration du repertoire de travail\n// Recherche le repertoire Sudoku depuis le repertoire courant\nusing System;\nusing System.IO;\nusing System.Net.Http;\n\nstring FindSudokuDir()\n{\n    var dir = new DirectoryInfo(Directory.GetCurrentDirectory());\n    while (dir != null)\n    {\n        // Check if we're in the Sudoku directory\n        if (File.Exists(Path.Combine(dir.FullName, \"Sudoku-0-Environment-Csharp.ipynb\")))\n            return dir.FullName;\n        // Check if Sudoku is a subdirectory\n        var candidate = Path.Combine(dir.FullName, \"MyIA.AI.Notebooks\", \"Sudoku\");\n        if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, \"Sudoku-0-Environment-Csharp.ipynb\")))\n            return candidate;\n        dir = dir.Parent;\n    }\n    return Directory.GetCurrentDirectory();\n}\n\nvar sudokuDir = FindSudokuDir();\nDirectory.SetCurrentDirectory(sudokuDir);\n\nconst string ChocoVersion = \"4.10.17\";\nconst string ChocoJar = $\"choco-solver-{ChocoVersion}-jar-with-dependencies.jar\";\nconst string ChocoUrl = $\"https://repo1.maven.org/maven2/org/choco-solver/choco-solver/{ChocoVersion}/{ChocoJar}\";\n\nif (!File.Exists(ChocoJar))\n{\n    Console.WriteLine($\"Telechargement de {ChocoJar} depuis Maven...\");\n    using var client = new HttpClient();\n    var data = client.GetByteArrayAsync(ChocoUrl).Result;\n    File.WriteAllBytes(ChocoJar, data);\n    Console.WriteLine($\"Telecharge: {ChocoJar} ({data.Length} bytes)\");\n}\nelse\n{\n    Console.WriteLine($\"Choco-solver JAR deja present: {ChocoJar}\");\n}\n\nConsole.WriteLine($\"Repertoire de travail: {sudokuDir}\");"
   },
   {
    "cell_type": "markdown",
@@ -238,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
@@ -255,47 +117,14 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(4,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Runtime.dll' introuvable\r\n",
-      "\r\n",
-      "(5,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Java.dll' introuvable\r\n",
-      "\r\n",
-      "(6,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.CoreLib.dll' introuvable\r\n",
-      "\r\n",
-      "(9,1): error CS0006: Fichier de métadonnées 'd:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/org.chocosolver.solver.dll' introuvable\r\n",
-      "\r\n"
+      "Packages IKVM et Choco-solver charges.\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
-   "source": [
-    "// IMPORTANT: Les directives #r doivent etre en PREMIER, avant tout autre code\n",
-    "\n",
-    "// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Runtime.dll\"\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.Java.dll\"\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/IKVM.CoreLib.dll\"\n",
-    "\n",
-    "// Charger la DLL Choco-solver pré-compilée\n",
-    "#r \"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku/org.chocosolver.solver.dll\"\n",
-    "\n",
-    "// Maintenant le code C# normal peut commencer\n",
-    "using System;\n",
-    "using System.IO;\n",
-    "\n",
-    "// Définir le répertoire de travail\n",
-    "System.IO.Directory.SetCurrentDirectory(@\"d:/Dev/CoursIA/MyIA.AI.Notebooks/Sudoku\");\n",
-    "\n",
-    "Console.WriteLine(\"Packages IKVM et Choco-solver charges.\");\n"
-   ]
+   "source": "// IMPORTANT: Les directives #r doivent etre en PREMIER, avant tout autre code\n\n// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n// Les DLLs doivent etre dans le meme repertoire que le notebook\n#r \"IKVM.Runtime.dll\"\n#r \"IKVM.Java.dll\"\n#r \"IKVM.CoreLib.dll\"\n\n// Charger la DLL Choco-solver pré-compilée\n#r \"org.chocosolver.solver.dll\"\n\n// Maintenant le code C# normal peut commencer\nusing System;\nusing System.IO;\n\nConsole.WriteLine(\"Packages IKVM et Choco-solver charges.\");"
   },
   {
    "cell_type": "markdown",
@@ -317,27 +146,11 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(3,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,7): error CS0246: Le nom de type ou d'espace de noms 'org' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "Choco-solver via IKVM 7.2.4630.5 - Pret pour resolution Sudoku\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
    "source": [
@@ -378,43 +191,59 @@
    },
    "outputs": [
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET</span></li></ul></div><div></div></div>"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
      ]
     }
    ],
@@ -451,35 +280,11 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(1,34): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(65,32): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(65,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(70,31): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(70,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,36): error CS0246: Le nom de type ou d'espace de noms 'Constraint' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "ChocoSimpleSolver defini.\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
    "source": [
@@ -595,81 +400,11 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(1,44): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,15): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,37): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,20): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(34,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,54): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,67): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(105,23): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(130,45): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(130,58): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,37): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,50): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(149,20): error CS0246: Le nom de type ou d'espace de noms 'Solver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,67): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(164,23): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(176,39): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(176,22): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(190,32): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(190,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(200,31): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(200,13): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,62): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(107,29): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(111,34): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(153,13): error CS0103: Le nom 'org' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(154,21): error CS0246: Le nom de type ou d'espace de noms 'FirstFail' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(155,21): error CS0246: Le nom de type ou d'espace de noms 'IntDomainMin' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(178,24): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(192,26): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(202,25): error CS0246: Le nom de type ou d'espace de noms 'IntVar' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "ChocoSolverVariableSelector defini avec strategie FirstFail.\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
    "source": [
@@ -918,19 +653,30 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(2,22): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "Puzzle initial:\r\n"
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "-------------------------------\n",
+      "| 9     2 |       5 | 4     3 | \n",
+      "| 1       |    6  3 |    2  5 | \n",
+      "| 5     8 | 4     7 |    6    | \n",
+      "-------------------------------\n",
+      "|    2  6 | 3     9 |       1 | \n",
+      "|    5  7 |    1    | 2  9    | \n",
+      "|    9    | 6  7    | 5  3    | \n",
+      "-------------------------------\n",
+      "| 2  4    | 5  3    | 6       | \n",
+      "| 7     5 | 2       | 3     4 | \n",
+      "|    8    |    4  1 | 9  5    | \n",
+      "-------------------------------\r\n"
+     ]
     }
    ],
    "source": [
@@ -978,21 +724,16 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,18): error CS0246: Le nom de type ou d'espace de noms 'ChocoSolverVariableSelector' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,29): error CS0103: Le nom 'testPuzzle' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
      "output_type": "error",
-     "traceback": []
+     "ename": "Error",
+     "evalue": "System.TypeInitializationException: The type initializer for '<Module>' threw an exception.\r\n ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. Le fichier spécifié est introuvable.\r\nFile name: 'System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'\r\n   at ikvm.runtime.Startup.init()\r\n   at .cctor()\r\n   --- End of inner exception stack trace ---\r\n   at Submission#14.ChocoSolverVariableSelector.Solve(SudokuGrid grid)\r\n   at Submission#16.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
+     "traceback": [
+      "System.TypeInitializationException: The type initializer for '<Module>' threw an exception.\r\n ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'. Le fichier spécifié est introuvable.\r\nFile name: 'System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'\r\n   at ikvm.runtime.Startup.init()\r\n   at .cctor()\r\n   --- End of inner exception stack trace ---\r\n   at Submission#14.ChocoSolverVariableSelector.Solve(SudokuGrid grid)\r\n   at Submission#16.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
+      "   at Submission#14.ChocoSolverVariableSelector.Solve(SudokuGrid grid)",
+      "   at Submission#16.<<Initialize>>d__0.MoveNext()",
+      "--- End of stack trace from previous location ---",
+      "   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
+     ]
     }
    ],
    "source": [
@@ -1055,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-04-21T00:17:41.859680Z",
@@ -1066,66 +807,14 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(15,25): error CS0246: Le nom de type ou d'espace de noms 'Model' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "TODO: Implementez NQueensChocoSolver.CountSolutions() pour le probleme des 8-Reines\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
-   "source": [
-    "// EXERCICE : Probleme des N-Reines avec Choco-solver\n",
-    "// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines\n",
-    "\n",
-    "public class NQueensChocoSolver\n",
-    "{\n",
-    "    public int N { get; set; }\n",
-    "    \n",
-    "    public NQueensChocoSolver(int n)\n",
-    "    {\n",
-    "        N = n;\n",
-    "    }\n",
-    "    \n",
-    "    public int CountSolutions()\n",
-    "    {\n",
-    "        var model = new Model($\"N-Queens N={N}\");\n",
-    "        \n",
-    "        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)\n",
-    "        // var queens = model.intVarArray(\"queens\", N, 0, N - 1);\n",
-    "        \n",
-    "        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes\n",
-    "        // model.allDifferent(queens).post();\n",
-    "        \n",
-    "        // TODO: Contraintes de diagonales\n",
-    "        // Pour chaque paire (i, j) avec i < j :\n",
-    "        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", i - j).post();  // diagonale principale\n",
-    "        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", j - i).post();  // diagonale secondaire\n",
-    "        \n",
-    "        // TODO: Compter les solutions avec solver.findAllSolutions()\n",
-    "        // var solver = model.getSolver();\n",
-    "        // solver.findAllSolutions();\n",
-    "        // return (int)solver.getSolutionCount();\n",
-    "        \n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// Test\n",
-    "int N = 8;\n",
-    "var nQueens = new NQueensChocoSolver(N);\n",
-    "// int count = nQueens.CountSolutions();\n",
-    "// Console.WriteLine($\"Nombre de solutions pour {N}-Reines : {count}\");\n",
-    "// Console.WriteLine($\"Attendu : 92\");\n",
-    "Console.WriteLine($\"TODO: Implementez NQueensChocoSolver.CountSolutions() pour le probleme des {N}-Reines\");"
-   ]
+   "source": "// EXERCICE : Probleme des N-Reines avec Choco-solver\n// TODO: Implementez un solveur pour compter les solutions du probleme des N-Reines\n\npublic class NQueensChocoSolver\n{\n    public int N { get; set; }\n    \n    public NQueensChocoSolver(int n)\n    {\n        N = n;\n    }\n    \n    public int CountSolutions()\n    {\n        var model = new Model($\"N-Queens N={N}\");\n        \n        // TODO: Creer les variables queen[i] pour chaque ligne i (domaine 0..N-1)\n        // var queens = model.intVarArray(\"queens\", N, 0, N - 1);\n        \n        // TODO: Contrainte de colonnes : toutes les reines dans des colonnes differentes\n        // model.allDifferent(queens).post();\n        \n        // TODO: Contraintes de diagonales\n        // Pour chaque paire (i, j) avec i < j :\n        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", i - j).post();  // diagonale principale\n        //   model.arithm(queens[i], \"!=\", queens[j], \"+\", b - i).post();  // diagonale secondaire\n        \n        // TODO: Compter les solutions avec solver.findAllSolutions()\n        // var solver = model.getSolver();\n        // solver.findAllSolutions();\n        // return (int)solver.getSolutionCount();\n        \n        return -1;  // TODO étudiant : implementer le comptage des solutions\n    }\n}\n\n// Test\nint N = 8;\nvar nQueens = new NQueensChocoSolver(N);\n// int count = nQueens.CountSolutions();\n// Console.WriteLine($\"Nombre de solutions pour {N}-Reines : {count}\");\n// Console.WriteLine($\"Attendu : 92\");\nConsole.WriteLine($\"TODO: Implementez NQueensChocoSolver.CountSolutions() pour le probleme des {N}-Reines\");"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Replace 6 hardcoded absolute paths (`d:/Dev/CoursIA/...`) with portable alternatives:
  - Cell 2: `FindSudokuDir()` search-up function for working directory
  - Cell 4: Relative `#r` directives for IKVM/Choco DLLs (4 references)
- Fix C.1 violation in cell 19: `throw new NotImplementedException` → `return -1; // TODO étudiant`
- Re-executed via `exec_dotnet_persist.py`: **8/9 cells OK** with outputs persisted to file

## Test plan
- [x] Re-executed cell-by-cell via `exec_dotnet_persist.py` on ai-01
- [x] Cell 2 output: correct directory found via search
- [x] Cell 4 output: "Packages IKVM et Choco-solver charges."
- [x] Cell 19 output: TODO message (C.1 compliant, no exception)
- [x] Cell 16 known IKVM `TypeInitializationException` (System.Text.Json dependency, NOT path-related)
- [x] No `raise NotImplementedError` / `assert False` / `1/0` in notebook (C.1 check passed)

T12: BROKEN notebooks fix wave 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)