### PR TITLE
fix(sudoku): resolve C.1 violations and type conflicts in Sudoku-8

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -56,158 +56,59 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '24416.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
+     "output_type": "display_data",
      "metadata": {},
-     "output_type": "display_data"
+     "data": {}
     },
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET</span></li></ul></div><div></div></div>"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
      ]
     }
    ],
@@ -287,31 +188,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(11,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(17,26): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(46,38): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(46,23): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'nRow'.\r\n",
-      "\r\n",
-      "(46,29): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'nCol'.\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Grille de candidats pour le solveur humain.\n",
@@ -476,23 +353,71 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,16): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,40): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,22): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Puzzle initial :\n",
+       "-------------------------------\n",
+       "| 9     2 |       5 | 4     3 | \n",
+       "| 1       |    6  3 |    2  5 | \n",
+       "| 5     8 | 4     7 |    6    | \n",
+       "-------------------------------\n",
+       "|    2  6 | 3     9 |       1 | \n",
+       "|    5  7 |    1    | 2  9    | \n",
+       "|    9    | 6  7    | 5  3    | \n",
+       "-------------------------------\n",
+       "| 2  4    | 5  3    | 6       | \n",
+       "| 7     5 | 2       | 3     4 | \n",
+       "|    8    |    4  1 | 9  5    | \n",
+       "-------------------------------"
+      ]
+     }
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 36, Candidats totaux: 66, Moyenne: 1,8 candidats/cellule"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Cellule (0,1) : candidats = {6, 7}"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Cellule (1,1) : candidats = {7}"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Cellule (1,2) : candidats = {4}"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Cellule (2,1) : candidats = {3}"
+      ]
+     }
     }
    ],
    "source": [
@@ -581,35 +506,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(11,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(41,42): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(46,30): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(59,26): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'row'.\r\n",
-      "\r\n",
-      "(59,31): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'col'.\r\n",
-      "\r\n",
-      "(59,36): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée '_'.\r\n",
-      "\r\n",
-      "(59,36): error CS8183: Impossible de déduire le type d'une variable implicitement typée abandonnée.\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Contient les techniques de resolution humaines.\n",
@@ -713,29 +610,62 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,30): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,54): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,19): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,14): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(17,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(25,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Puzzle facile initial : 36 cellules vides"
+      ]
+     }
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 36, Candidats totaux: 66, Moyenne: 1,8 candidats/cellule"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Tour 1 - Naked Singles : 36 placements"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "Resultat : RESOLU apres 36 placements en 1 tours"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "-------------------------------\n",
+       "| 9  6  2 | 1  8  5 | 4  7  3 | \n",
+       "| 1  7  4 | 9  6  3 | 8  2  5 | \n",
+       "| 5  3  8 | 4  2  7 | 1  6  9 | \n",
+       "-------------------------------\n",
+       "| 8  2  6 | 3  5  9 | 7  4  1 | \n",
+       "| 3  5  7 | 8  1  4 | 2  9  6 | \n",
+       "| 4  9  1 | 6  7  2 | 5  3  8 | \n",
+       "-------------------------------\n",
+       "| 2  4  9 | 5  3  8 | 6  1  7 | \n",
+       "| 7  1  5 | 2  9  6 | 3  8  4 | \n",
+       "| 6  8  3 | 7  4  1 | 9  5  2 | \n",
+       "-------------------------------"
+      ]
+     }
     }
    ],
    "source": [
@@ -815,29 +745,40 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,32): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,56): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(2,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,20): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(13,14): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Puzzle moyen initial : 59 cellules vides"
+      ]
+     }
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Resultat avec techniques de base uniquement : BLOQUE"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Placements effectues : 11, Cellules restantes : 48"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Cellules non resolues: 48, Candidats totaux: 169, Moyenne: 3,5 candidats/cellule"
+      ]
+     }
     }
    ],
    "source": [
@@ -921,29 +862,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,39): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(54,53): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(114,53): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,30): error CS0103: Le nom 'SudokuGrid' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Ajout des techniques intermediaires a la classe HumanTechniques\n",
     "public static class HumanTechniquesIntermediate\n",
@@ -1197,27 +1116,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(25,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(69,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "public static class HumanTechniquesAdvanced\n",
     "{\n",
@@ -1419,47 +1318,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(5,28): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(48,39): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(115,36): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(22,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,22): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(57,22): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(66,22): error CS0103: Le nom 'HumanTechniques' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(75,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(84,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(93,22): error CS0103: Le nom 'HumanTechniquesIntermediate' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(102,22): error CS0103: Le nom 'HumanTechniquesAdvanced' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "/// <summary>\n",
     "/// Solveur de Sudoku imitant le raisonnement humain.\n",
@@ -1672,53 +1531,113 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,23): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,48): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,13): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,26): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,50): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(12,15): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(20,24): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(20,48): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(20,13): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,42): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(7,66): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(13,19): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(15,44): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(15,68): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(21,19): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(23,42): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(23,66): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "=== PUZZLE FACILE ==="
+      ]
+     }
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Naked Singles x36\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 1\r\n"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== PUZZLE MOYEN ==="
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Hidden Singles x6\r\n",
+       "  Etape 2: Naked Singles x1\r\n",
+       "  Etape 3: Hidden Singles x3\r\n",
+       "  Etape 4: Hidden Singles x1\r\n",
+       "  Etape 5: Naked Pairs (eliminations) x9\r\n",
+       "  Etape 6: Locked Candidates - Pointing (eliminations) x17\r\n",
+       "  Etape 7: Naked Singles x19\r\n",
+       "  Etape 8: Hidden Singles x9\r\n",
+       "  Etape 9: Hidden Singles x6\r\n",
+       "  Etape 10: Naked Singles x14\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 10\r\n"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== PUZZLE DIFFICILE ==="
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Erreurs : 0"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "--- Journal de resolution ---\r\n",
+       "  Etape 1: Hidden Singles x3\r\n",
+       "  Etape 2: Locked Candidates - Pointing (eliminations) x21\r\n",
+       "  Etape 3: Naked Singles x6\r\n",
+       "  Etape 4: Hidden Singles x2\r\n",
+       "  Etape 5: Hidden Singles x2\r\n",
+       "  Etape 6: Naked Pairs (eliminations) x15\r\n",
+       "  Etape 7: Naked Singles x2\r\n",
+       "  Etape 8: Hidden Singles x4\r\n",
+       "  Etape 9: Naked Singles x45\r\n",
+       "  Backtracking necessaire : NON\r\n",
+       "  Total etapes : 9\r\n"
+      ]
+     }
     }
    ],
    "source": [
@@ -1778,7 +1697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "246c3613",
    "metadata": {
     "dotnet_interactive": {
@@ -1794,51 +1713,8 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-1-Backtracking-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
-     ]
-    }
-   ],
-   "source": [
-    "#!import Sudoku-1-Backtracking-Csharp.ipynb"
-   ]
+   "outputs": [],
+   "source": "/// <summary>\n/// Solveur par backtracking pur (pour comparaison avec le HumanSolver).\n/// Defini inline pour eviter les conflits de type lies a l'import de Sudoku-1.\n/// </summary>\npublic class BacktrackingDotNetSolver : ISudokuSolver\n{\n    private int callCount = 0;\n\n    public SudokuGrid Solve(SudokuGrid s)\n    {\n        callCount = 0;\n        Search(s, 0, 0);\n        Console.WriteLine($\"BacktrackingDotNetSolver: {callCount} search calls\");\n        return s;\n    }\n\n    private bool Search(SudokuGrid s, int row, int col)\n    {\n        callCount++;\n        if (row == 9) return true;\n        if (col == 9) return Search(s, row + 1, 0);\n        if (s.Cells[row, col] != 0) return Search(s, row, col + 1);\n\n        for (int num = 1; num <= 9; num++)\n        {\n            if (IsValid(s, row, col, num))\n            {\n                s.Cells[row, col] = num;\n                if (Search(s, row, col + 1)) return true;\n                s.Cells[row, col] = 0;\n            }\n        }\n        return false;\n    }\n\n    private bool IsValid(SudokuGrid s, int row, int col, int val)\n    {\n        for (int i = 0; i < 9; i++)\n            if (s.Cells[row, i] == val || s.Cells[i, col] == val)\n                return false;\n\n        int startRow = 3 * (row / 3), startCol = 3 * (col / 3);\n        for (int i = 0; i < 3; i++)\n            for (int j = 0; j < 3; j++)\n                if (s.Cells[startRow + i, startCol + j] == val)\n                    return false;\n\n        return true;\n    }\n}"
   },
   {
    "cell_type": "markdown",
@@ -1868,25 +1744,217 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Running tests..."
+      ]
+     }
+    },
+    {
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(1,38): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,25): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,38): error CS0246: Le nom de type ou d'espace de noms 'BacktrackingDotNetSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,15): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "BacktrackingDotNetSolver: 122 search calls\r\n"
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 311 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 477 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 25565 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 2544 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 149 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 92214 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 4797 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 137 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 171377 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 490304 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 15387 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 337036 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 114216 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 250684 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 12779 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 14171 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 1474 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 80027 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BacktrackingDotNetSolver: 15893 search calls\r\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "Resultats de performance :"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "HumanSolver | Easy | 6,5 ms | 10/10 | Success"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "HumanSolver | Medium | 52,1 ms | 10/10 | Success"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "HumanSolver | Hard | 5200,9 ms | 4/10 | Disqualified"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "BacktrackingDotNetSolver | Easy | 122,6 ms | 10/10 | Success"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "BacktrackingDotNetSolver | Medium | 479,4 ms | 10/10 | Success"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "BacktrackingDotNetSolver | Hard | 4999,4 ms | 0/10 | Disqualified"
+      ]
+     }
     }
    ],
    "source": [
@@ -1953,37 +2021,223 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,24): error CS0246: Le nom de type ou d'espace de noms 'SudokuDifficulty' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(37,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(38,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(39,19): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,26): error CS0246: Le nom de type ou d'espace de noms 'HumanSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,24): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(20,23): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée 'technique'.\r\n",
-      "\r\n",
-      "(20,34): error CS8130: Impossible de déduire le type de la variable de déconstruction implicitement typée '_'.\r\n",
-      "\r\n",
-      "(20,34): error CS8183: Impossible de déduire le type d'une variable implicitement typée abandonnée.\r\n",
-      "\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== Easy (20 puzzles) ==="
+      ]
+     }
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Singles: 38 utilisations (190% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Hidden Singles: 26 utilisations (130% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Pairs: 3 utilisations (15% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Pointing: 2 utilisations (10% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Claiming: 1 utilisations (5% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  X-Wing: 1 utilisations (5% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Backtracking necessaire : 0/20 puzzles (0%)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== Medium (10 puzzles) ==="
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Hidden Singles: 18 utilisations (180% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Singles: 11 utilisations (110% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Backtracking: 7 utilisations (70% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Pointing: 6 utilisations (60% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Pairs: 4 utilisations (40% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Claiming: 2 utilisations (20% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Backtracking necessaire : 7/10 puzzles (70%)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "\n",
+       "=== Hard (10 puzzles) ==="
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Hidden Singles: 28 utilisations (280% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Singles: 14 utilisations (140% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Pointing: 12 utilisations (120% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Backtracking: 6 utilisations (60% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Naked Pairs: 4 utilisations (40% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Locked Candidates - Claiming: 2 utilisations (20% des puzzles)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "  Backtracking necessaire : 6/10 puzzles (60%)"
+      ]
+     }
     }
    ],
    "source": [
@@ -2068,7 +2322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "9858ce63",
    "metadata": {
     "execution": {
@@ -2079,31 +2333,8 @@
     },
     "language": "polyglot-notebook"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(2,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
-   "source": [
-    "// Squelette pour le Swordfish\n",
-    "public static int ApplySwordfish(CandidateGrid cg)\n",
-    "{\n",
-    "    // TODO: Implementer le Swordfish (generalisation du X-Wing a 3 lignes/colonnes)\n",
-    "    throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "}"
-   ]
+   "outputs": [],
+   "source": "// Squelette pour le Swordfish\npublic static int ApplySwordfish(CandidateGrid cg)\n{\n    // TODO: Implementer le Swordfish (generalisation du X-Wing a 3 lignes/colonnes)\n    return 0;\n}"
   },
   {
    "cell_type": "markdown",
@@ -2146,25 +2377,7 @@
     },
     "language": "polyglot-notebook"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,24): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,34): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "public interface IHumanTechniqueExpert\n",
     "{\n",
@@ -2218,7 +2431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "y893nvxnrmn",
    "metadata": {
     "execution": {
@@ -2230,83 +2443,18 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "\r\n",
-      "(3,42): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
+      "(6,17): warning CS0414: Le champ 'ExpertHumanStrategySolver._swordfishCount' est assigné, mais sa valeur n'est jamais utilisée\r\n",
       "\r\n",
-      "(13,31): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(26,41): error CS0246: Le nom de type ou d'espace de noms 'CandidateGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(38,23): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
+      "(7,17): warning CS0414: Le champ 'ExpertHumanStrategySolver._hiddenPairsBlockCount' est assigné, mais sa valeur n'est jamais utilisée\r\n",
       "\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
-   "source": [
-    "// A COMPLETER : Solveur hybride avec techniques expertes\n",
-    "\n",
-    "public class ExpertHumanStrategySolver : ISudokuSolver\n",
-    "{\n",
-    "    // Compteurs de techniques appliquees\n",
-    "    private int _swordfishCount = 0;\n",
-    "    private int _hiddenPairsBlockCount = 0;\n",
-    "\n",
-    "    /// <summary>\n",
-    "    /// Applique la technique Swordfish : elimine un candidat present dans\n",
-    "    /// exactement 2-3 colonnes de 3 lignes, toujours dans les memes colonnes.\n",
-    "    /// </summary>\n",
-    "    public int ApplySwordfish(CandidateGrid cg)\n",
-    "    {\n",
-    "        // TODO : Implementer le Swordfish\n",
-    "        // Pour chaque candidat (1-9) :\n",
-    "        //   1. Trouver les lignes ou ce candidat apparait dans 2 ou 3 colonnes\n",
-    "        //   2. Chercher 3 telles lignes qui partagent exactement les memes 2-3 colonnes\n",
-    "        //   3. Eliminer le candidat de toutes les autres cellules de ces colonnes\n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "    }\n",
-    "\n",
-    "    /// <summary>\n",
-    "    /// Applique la technique Hidden Pairs dans les blocs 3x3.\n",
-    "    /// </summary>\n",
-    "    public int ApplyHiddenPairsInBlocks(CandidateGrid cg)\n",
-    "    {\n",
-    "        // TODO : Adapter la logique Hidden Pairs pour les 9 blocs 3x3\n",
-    "        // Pour chaque bloc :\n",
-    "        //   1. Trouver deux candidats qui n'apparaissent que dans exactement 2 cellules du bloc\n",
-    "        //   2. Eliminer tous les autres candidats de ces 2 cellules\n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "    }\n",
-    "\n",
-    "    /// <summary>\n",
-    "    /// Resout le Sudoku avec le pipeline complet incluant les techniques expertes.\n",
-    "    /// </summary>\n",
-    "    public bool Solve(SudokuGrid grid)\n",
-    "    {\n",
-    "        // TODO : Integrer les nouvelles techniques dans le pipeline\n",
-    "        // Ordre suggere :\n",
-    "        //   1. NakedSingles -> 2. HiddenSingles -> 3. NakedPairs ->\n",
-    "        //   4. LockedCandidates -> 5. XWing -> 6. Swordfish ->\n",
-    "        //   7. HiddenPairsInBlocks -> 8. Backtracking si necessaire\n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// Test : Comparer les performances du solveur ameliore\n",
-    "// string hardPuzzle = \"800000000003600000070090200060005030004070010030010060020000035000900040000800006\";\n",
-    "// var solver = new ExpertHumanStrategySolver();\n",
-    "// var grid = SudokuGrid.ParseGrid(hardPuzzle);\n",
-    "// bool solved = solver.Solve(grid);\n",
-    "// Console.WriteLine(solved ? \"Resolu sans backtracking !\" : \"Backtracking utilise\");"
-   ]
+   "source": "// A COMPLETER : Solveur hybride avec techniques expertes\n\npublic class ExpertHumanStrategySolver : ISudokuSolver\n{\n    // Compteurs de techniques appliquees\n    private int _swordfishCount = 0;\n    private int _hiddenPairsBlockCount = 0;\n\n    /// <summary>\n    /// Applique la technique Swordfish : elimine un candidat present dans\n    /// exactement 2-3 colonnes de 3 lignes, toujours dans les memes colonnes.\n    /// </summary>\n    public int ApplySwordfish(CandidateGrid cg)\n    {\n        // TODO : Implementer le Swordfish\n        // Pour chaque candidat (1-9) :\n        //   1. Trouver les lignes ou ce candidat apparait dans 2 ou 3 colonnes\n        //   2. Chercher 3 telles lignes qui partagent exactement les memes 2-3 colonnes\n        //   3. Eliminer le candidat de toutes les autres cellules de ces colonnes\n        return 0;\n    }\n\n    /// <summary>\n    /// Applique la technique Hidden Pairs dans les blocs 3x3.\n    /// </summary>\n    public int ApplyHiddenPairsInBlocks(CandidateGrid cg)\n    {\n        // TODO : Adapter la logique Hidden Pairs pour les 9 blocs 3x3\n        // Pour chaque bloc :\n        //   1. Trouver deux candidats qui n'apparaissent que dans exactement 2 cellules du bloc\n        //   2. Eliminer tous les autres candidats de ces 2 cellules\n        return 0;\n    }\n\n    /// <summary>\n    /// Resout le Sudoku avec le pipeline complet incluant les techniques expertes.\n    /// </summary>\n    public SudokuGrid Solve(SudokuGrid s)\n    {\n        // TODO : Integrer les nouvelles techniques dans le pipeline\n        // Ordre suggere :\n        //   1. NakedSingles -> 2. HiddenSingles -> 3. NakedPairs ->\n        //   4. LockedCandidates -> 5. XWing -> 6. Swordfish ->\n        //   7. HiddenPairsInBlocks -> 8. Backtracking si necessaire\n        return s;\n    }\n}\n\n// Test : Comparer les performances du solveur ameliore\n// string hardPuzzle = \"800000000003600000070090200060005030004070010030010060020000035000900040000800006\";\n// var solver = new ExpertHumanStrategySolver();\n// var grid = SudokuGrid.ParseGrid(hardPuzzle);\n// var solved = solver.Solve(grid);\n// Console.WriteLine(solved.IsSolved() ? \"Resolu sans backtracking !\" : \"Backtracking utilise\");"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Replace 4x `throw new NotImplementedException` with C.1-compliant stubs (`return 0`, `return s`) in exercise cells (Swordfish cell 38, ExpertSolver cell 42)
- Fix `ExpertHumanStrategySolver.Solve` return type (`bool` → `SudokuGrid`) to match `ISudokuSolver` interface
- Replace `#!import Sudoku-1-Backtracking-Csharp.ipynb` with inline `BacktrackingDotNetSolver` to resolve double-import type conflicts (`SudokuGrid`/`ISudokuSolver` loaded from both Sudoku-0 and Sudoku-1)
- Re-execute all 16 code cells via `exec_dotnet_persist.py`: **0 errors**, all outputs present

## Test plan
- [x] `exec_dotnet_persist.py Sudoku-8-HumanStrategies-Csharp.ipynb` → 16/16 cells OK, 0 errors
- [x] No `throw new NotImplementedException` or `NotImplementedError` in notebook source
- [x] Exercise stubs preserve all `// TODO` comments and pedagogical scaffolding
- [x] No anti-regression: only stub cells modified, no solution content removed

T12 wave 2 (BROKEN notebook fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)