### PR TITLE
fix(sudoku): resolve C.1 violations and missing API in Sudoku-12

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -61,128 +61,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
-       "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:6819:463d:62b5:6b06:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%19:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::3256:b4d8:946e:168d%23:2048/\",\"http://172.20.16.1:2048/\",\"http://fe80::c2e2:244b:a059:da51%44:2048/\",\"http://172.21.192.1:2048/\"])\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '9460.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.Z3</span></li></ul></div><div></div></div>"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Z3, 4.12.2</span></li></ul></div></div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -217,43 +102,59 @@
    },
    "outputs": [
     {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: Could not find file 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'.\r\nFile name: 'C:\\dev\\CoursIA\\Sudoku-0-Environment-Csharp.ipynb'\r\n   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)\r\n   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)\r\n   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)\r\n   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41\r\n   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114\r\n   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371\r\n   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41",
-      "   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)",
-      "   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.AsyncWindowsFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)",
-      "   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean useAsync)",
-      "   at Microsoft.DotNet.Interactive.Utility.IOExtensions.ReadAllTextInternalAsync(String filePath, Encoding encoding, CancellationToken cancellationToken) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Utility\\IOExtensions.cs:line 41",
-      "   at Microsoft.DotNet.Interactive.Documents.InteractiveDocument.LoadAsync(FileInfo file, KernelInfoCollection kernelInfos) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive.Documents\\InteractiveDocument.cs:line 139",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.LoadAndRunInteractiveDocument(Kernel kernel, FileInfo file, KernelCommand parentCommand) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 114",
-      "   at Microsoft.DotNet.Interactive.KernelExtensions.<>c__DisplayClass4_0`1.<<UseImportMagicCommand>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelExtensions.cs:line 103",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.Kernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\Kernel.cs:line 371",
-      "   at Microsoft.DotNet.Interactive.CompositeKernel.HandleAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\CompositeKernel.cs:line 216",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<BuildPipeline>b__6_0(KernelCommand command, KernelInvocationContext context, KernelPipelineContinuation _) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 60",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass6_0.<<UseTelemetrySender>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 462",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensionLoader.<>c__DisplayClass0_0.<<UseNuGetExtensions>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensionLoader.cs:line 25",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_1.<<BuildPipeline>b__3>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 75",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.App.KernelExtensions.<>c__DisplayClass5_0.<<UseSecretManager>b__0>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\dotnet-interactive\\KernelExtensions.cs:line 388",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.<>c__DisplayClass6_0.<<BuildPipeline>g__Combine|2>d.MoveNext() in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 73",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.DotNet.Interactive.KernelCommandPipeline.SendAsync(KernelCommand command, KernelInvocationContext context) in D:\\a\\_work\\1\\s\\src\\Microsoft.DotNet.Interactive\\KernelCommandPipeline.cs:line 41"
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET</span></li></ul></div><div></div></div>"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
      ]
     }
    ],
@@ -287,33 +188,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,34): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(88,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(102,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(102,12): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(104,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(104,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "// Importer les bibliothèques nécessaires\n",
     "using System.Diagnostics;\n",
@@ -473,29 +348,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,47): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(118,42): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(133,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(133,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -659,43 +512,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(3,40): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(7,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(14,24): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(15,26): error CS0103: Le nom 'GetPuzzleConstraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(16,20): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,66): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -762,45 +579,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(4,46): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(13,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(22,32): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(23,31): error CS0103: Le nom 'GetConstExpr' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,41): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(39,70): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "\n",
@@ -884,55 +663,7 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,34): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,29): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(16,50): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,9): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(12,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(24,36): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(25,35): error CS0103: Le nom 'GetConstExpr' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(27,41): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(28,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(30,38): error CS0103: Le nom 'GetPuzzleConstraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(33,25): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(34,21): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(35,21): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(35,31): error CS0103: Le nom 'GenericContraints' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(50,74): error CS0103: Le nom 'CellVariables' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
-    }
-   ],
+   "outputs": [],
    "source": [
     "using Microsoft.Z3;\n",
     "using System;\n",
@@ -1030,31 +761,13 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(1,38): error CS0246: Le nom de type ou d'espace de noms 'ISudokuSolver' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(3,34): error CS0246: Le nom de type ou d'espace de noms 'Z3IntSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,41): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,47): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSubstitution' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(6,41): error CS0246: Le nom de type ou d'espace de noms 'Z3BitSub_Tactic' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(9,15): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(10,1): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
-     ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Running tests..."
+      ]
+     }
     }
    ],
    "source": [
@@ -1146,25 +859,11 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(4,32): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverBase' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,38): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(8,21): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(10,22): error CS0103: Le nom 'ctx' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "TODO : Implementez SudokuXZ3Solver avec les contraintes de diagonale\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
    "source": [
@@ -1199,7 +898,7 @@
     "        // solver.Assert(GetPuzzleConstraints(grid));\n",
     "        // if (solver.Check() == Status.SATISFIABLE) { ... extraire la solution ... }\n",
     "\n",
-    "        throw new NotImplementedException(\"A vous d'implementer le Sudoku X avec Z3 !\");\n",
+    "        return grid;\n",
     "    }\n",
     "}\n",
     "\n",
@@ -1239,31 +938,11 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(42,19): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(42,43): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(4,20): error CS0246: Le nom de type ou d'espace de noms 'Context' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,20): error CS0246: Le nom de type ou d'espace de noms 'IntExpr' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(4,34): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,48): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "TODO : Implementez Z3SudokuUnicityChecker.HasUniqueSolution()\r\n"
      ]
-    },
-    {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
     }
    ],
    "source": [
@@ -1302,7 +981,7 @@
     "        // TODO : 4. Retourner true si aucune deuxieme solution n'existe\n",
     "        // return s.Check() == Status.UNSATISFIABLE;\n",
     "\n",
-    "        throw new NotImplementedException(\"A vous d'implementer HasUniqueSolution !\");\n",
+    "        return false;\n",
     "    }\n",
     "}\n",
     "\n",
@@ -1347,27 +1026,25 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(5,20): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,44): error CS0103: Le nom 'SudokuDifficulty' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(6,17): error CS0103: Le nom 'Z3BitVectorSolverBase' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(7,21): error CS0103: Le nom 'Z3BitVectorSolverBase' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(8,30): error CS0246: Le nom de type ou d'espace de noms 'Z3BitVectorSolverSimple' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n"
+      "Comparaison des tactiques Z3 :\r\n"
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "----------------------------------------\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "TODO : Implementez la comparaison des tactiques Z3\r\n"
+     ]
     }
    ],
    "source": [
@@ -1445,27 +1122,37 @@
    },
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "\r\n",
-      "(38,18): error CS0103: Le nom 'SudokuHelper' n'existe pas dans le contexte actuel\r\n",
-      "\r\n",
-      "(5,20): error CS0246: Le nom de type ou d'espace de noms 'Context' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(11,35): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(25,27): error CS0246: Le nom de type ou d'espace de noms 'SudokuGrid' est introuvable (vous manque-t-il une directive using ou une référence d'assembly ?)\r\n",
-      "\r\n",
-      "(5,34): error CS0103: Le nom 'Z3IntSolverSimple' n'existe pas dans le contexte actuel\r\n",
-      "\r\n"
+      "Test de verification de proprietes Z3\r\n"
      ]
     },
     {
-     "ename": "Error",
-     "evalue": "compilation error",
-     "output_type": "error",
-     "traceback": []
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Puzzle selectionne :\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "-------------------------------\n",
+      "| 4       |         | 8     5 | \n",
+      "|    3    |         |         | \n",
+      "|         | 7       |         | \n",
+      "-------------------------------\n",
+      "|    2    |         |    6    | \n",
+      "|         |    8    | 4       | \n",
+      "|         |    1    |         | \n",
+      "-------------------------------\n",
+      "|         | 6     3 |    7    | \n",
+      "| 5       | 2       |         | \n",
+      "| 1     4 |         |         | \n",
+      "-------------------------------\r\n"
+     ]
     }
    ],
    "source": [
@@ -1486,7 +1173,7 @@
     "        // 2. Trouver la premiere solution S1\n",
     "        // 3. Ajouter la contrainte \"au moins une cellule differe de S1\"\n",
     "        // 4. Verifier si une deuxieme solution existe\n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
+    "        return false;\n",
     "    }\n",
     "\n",
     "    /// <summary>\n",
@@ -1500,13 +1187,13 @@
     "        //   - Creer une copie du puzzle sans la valeur en (i, j)\n",
     "        //   - Verifier que HasUniqueSolution retourne false\n",
     "        // Si toutes les cellules satisfont cette condition -> minimal\n",
-    "        throw new NotImplementedException(\"A vous de jouer !\");\n",
+    "        return false;\n",
     "    }\n",
     "}\n",
     "\n",
     "// Test : verifier les proprietes sur le puzzle facile\n",
     "var checker = new Z3SudokuPropertyChecker();\n",
-    "var easyPuzzle = SudokuHelper.GetHardestPuzzles(1)[0]; // Remplacer par un puzzle facile si disponible\n",
+    "var easyPuzzle = SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First();\n",
     "Console.WriteLine(\"Test de verification de proprietes Z3\");\n",
     "Console.WriteLine(\"Puzzle selectionne :\");\n",
     "Console.WriteLine(easyPuzzle);\n",


### PR DESCRIPTION
## Summary
- Replace 4x `throw new NotImplementedException` with C.1-compliant stubs (`return grid`, `return false`) in exercise cells:
  - `SudokuXZ3Solver.Solve` (cell 8)
  - `Z3SudokuUnicityChecker.HasUniqueSolution` (cell 9)
  - `Z3SudokuPropertyChecker.HasUniqueSolution` + `IsMinimal` (cell 11)
- Fix `SudokuHelper.GetHardestPuzzles(1)` (non-existent API) → `SudokuHelper.GetSudokus(SudokuDifficulty.Hard).First()`
- Re-execute all 12 code cells: **0 errors**, all outputs present

## Test plan
- [x] `exec_dotnet_persist.py Sudoku-12-Z3-Csharp.ipynb` → 12/12 cells OK, 0 errors
- [x] No `throw new NotImplementedException` remaining in notebook source
- [x] Exercise stubs preserve all `// TODO` comments and scaffolding
- [x] No anti-regression: only stub cells and one API call fixed

T12 wave 2 (BROKEN notebook fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)