### PR TITLE
fix(docker): sd-forge-main non-root USER hardening

### DIFF
--- a/docker-configurations/services/sd-forge-main/Dockerfile
+++ b/docker-configurations/services/sd-forge-main/Dockerfile
@@ -12,7 +12,11 @@ RUN source /opt/environments/python/forge/bin/activate && \
     pip uninstall -y numpy opencv-python opencv-python-headless scikit-image Pillow && \
     pip install "numpy<2" opencv-python-headless scikit-image Pillow
 
-RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webui-forge
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webui-forge
 
 RUN source /opt/environments/python/forge/bin/activate && \
     python -c "import numpy; import cv2; import skimage; print('Imports successful')"
+
+USER appuser


### PR DESCRIPTION
## Summary
- Add `groupadd`/`useradd`/`USER appuser` to `sd-forge-main/Dockerfile`
- Docker hardening Phase 3 — was the only mission service missing non-root user directive
- Matches pattern already in `whisper-api` and `funasr-api` Dockerfiles

## Test plan
- [ ] Verify Dockerfile syntax: `docker build --check` or visual review
- [ ] Verify container runs as appuser (uid 1000) after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)