### PR TITLE
fix(docker): add non-root USER to 10 remaining service Dockerfiles (Phase 4)

### DIFF
--- a/docker-configurations/services/demucs-api/Dockerfile
+++ b/docker-configurations/services/demucs-api/Dockerfile
@@ -31,6 +31,13 @@ RUN chmod +x /app/start.sh
 # Create directories
 RUN mkdir -p /app/models /app/outputs /app/uploads
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8193
 

--- a/docker-configurations/services/forge-turbo/Dockerfile
+++ b/docker-configurations/services/forge-turbo/Dockerfile
@@ -20,6 +20,11 @@ RUN source /opt/environments/python/forge/bin/activate && \
 # The base image uses user 1000 (often named 'user' or 'webui')
 RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webui-forge
 
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser
+
+USER appuser
+
 # 4. Pre-flight check to ensure imports work
 RUN source /opt/environments/python/forge/bin/activate && \
     python -c "import numpy; import cv2; import skimage; print('Imports successful')"

--- a/docker-configurations/services/musicgen-api/Dockerfile
+++ b/docker-configurations/services/musicgen-api/Dockerfile
@@ -31,6 +31,13 @@ RUN chmod +x /app/start.sh
 # Create directories
 RUN mkdir -p /app/models /app/outputs
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8192
 

--- a/docker-configurations/services/qwen-asr-api/Dockerfile
+++ b/docker-configurations/services/qwen-asr-api/Dockerfile
@@ -45,6 +45,13 @@ RUN chmod +x /app/start.sh
 # Create directories
 RUN mkdir -p /app/models /app/uploads
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8195
 

--- a/docker-configurations/services/sdnext/Dockerfile
+++ b/docker-configurations/services/sdnext/Dockerfile
@@ -16,3 +16,8 @@ RUN chown -R 1000:1000 /opt/environments/python/forge /opt/stable-diffusion-webu
 
 RUN source /opt/environments/python/forge/bin/activate && \
     python -c "import numpy; import cv2; import skimage; print('Imports successful')"
+
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser
+
+USER appuser

--- a/docker-configurations/services/tts-api/Dockerfile
+++ b/docker-configurations/services/tts-api/Dockerfile
@@ -31,6 +31,13 @@ RUN chmod +x /app/start.sh
 # Create directories
 RUN mkdir -p /app/models /app/outputs
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8191
 

--- a/docker-configurations/services/tts-multi/gateway/Dockerfile
+++ b/docker-configurations/services/tts-multi/gateway/Dockerfile
@@ -11,6 +11,13 @@ RUN pip install --no-cache-dir \
 # Copy application
 COPY app.py .
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8000
 

--- a/docker-configurations/services/tts-multi/kokoro/Dockerfile
+++ b/docker-configurations/services/tts-multi/kokoro/Dockerfile
@@ -26,6 +26,13 @@ RUN pip install --no-cache-dir \
 # Copy application
 COPY app.py .
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8000
 

--- a/docker-configurations/services/tts-multi/qwen/Dockerfile
+++ b/docker-configurations/services/tts-multi/qwen/Dockerfile
@@ -10,6 +10,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8000
 

--- a/docker-configurations/services/tts-multi/tada/Dockerfile
+++ b/docker-configurations/services/tts-multi/tada/Dockerfile
@@ -34,6 +34,13 @@ RUN pip install --no-cache-dir \
 # Copy application
 COPY app.py .
 
+# Create non-root user for security
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
 # Expose port
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- Docker hardening Phase 4: add `USER appuser` (uid 1000) to all 10 remaining GenAI service Dockerfiles
- Phase 3 (PR #881) covered 5/16 services, this completes coverage to 16/16
- All services now run as non-root inside containers

### Pattern applied
```dockerfile
RUN groupadd -g 1000 appuser && \
    useradd -u 1000 -g appuser -m -s /bin/bash appuser && \
    chown -R appuser:appuser /app

USER appuser
```

### Services hardened (10)
| Service | Base image | Pattern |
|---------|-----------|---------|
| tts-api | python:3.11-slim | Standard |
| musicgen-api | python:3.11-slim | Standard |
| demucs-api | python:3.11-slim | Standard |
| qwen-asr-api | nvidia/cuda:12.1.0-runtime-ubuntu22.04 | Standard |
| sdnext | ai-dock/sd-forge:latest-cuda | chown already existed, added groupadd+USER |
| forge-turbo | ai-dock/sd-forge:latest-cuda | chown already existed, added groupadd+USER |
| tts-multi/kokoro | python:3.11-slim | Standard |
| tts-multi/tada | python:3.11-slim | Standard |
| tts-multi/gateway | python:3.11-slim | Standard (minimal service) |
| tts-multi/qwen | vllm/vllm-omni:v0.16.0 | Standard |

### Already hardened (Phase 3, PR #881 + prior)
whisper-api, funasr-api, vllm-zimage, comfyui-qwen, sd-forge-main, orchestrator

## Test plan
- [ ] Rebuild each service image and verify `docker exec <container> id` shows `uid=1000(appuser)`
- [ ] Verify healthchecks pass after rebuild (service functional)
- [ ] Verify model download/cache still works (HF cache dir ownership)

🤖 Generated with [Claude Code](https://claude.com/claude-code)