### PR TITLE
fix(lean): repair Voting.lean baseline build (indent + add Voting to CI)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -239,11 +239,11 @@ theorem median_voter_theorem (prof : ι → PrefOrder σ) (peaks : ι → σ)
   unfold median_peak sorted_peaks_list
   set l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·)
   have hl : l.length = Fintype.card ι := by
-  simp [l, List.length_mergeSort, List.length_map, Finset.length_toList]
+    simp [l, List.length_mergeSort, List.length_map, Finset.length_toList]
   have hn : l.length / 2 < l.length := by omega
   have hperm : l ≈ Finset.univ.toList.map peaks := List.mergeSort_perm _ _
   have hin : l.getD (l.length / 2) default ∈ l := by
-  simp [List.getD, List.getElem?_eq_getElem, hn]
+    simp [List.getD, List.getElem?_eq_getElem, hn]
   rw [List.Perm.mem_iff hperm] at hin
   simp only [List.mem_map, Finset.mem_toList] at hin
   obtain ⟨i, _, heq⟩ := hin


### PR DESCRIPTION
## Summary
- Fix 2 indentation bugs in `median_voter_theorem` (L242 + L246) introduced in `592147a4` and propagated through every Voting.lean change since
- `lake build SocialChoice.Voting` now SUCCESS on Windows native (3286 jobs)
- sorry count = 2 baseline preserved (L251 median completion, L445 maximal chain)

## Root cause
CI workflow `lean-social-choice.yml` only checks `Arrow / Sen / Framework / Basic` for sorry — **Voting.lean has never been built by CI**. The bug survived multiple PRs (notably the broken #866 + the corrective #885) because no one ran `lake build SocialChoice.Voting` locally.

## Verification
```
$ lake build SocialChoice.Voting
warning: SocialChoice/Voting.lean:281:0: ... (unused section vars, harmless)
warning: SocialChoice/Voting.lean:439:8: declaration uses `sorry`
Build completed successfully (3286 jobs).

$ grep -c sorry SocialChoice/Voting.lean
2
$ grep -n sorry SocialChoice/Voting.lean
251:  · sorry -- TODO: median beats all others in single-peaked profile
445:  sorry -- TODO: maximal chain existence (finiteness + Zorn-like argument)
```

Toolchain: Lake 5.0.0-src+f72c35b, Lean 4.29.1, Mathlib at rev `5e932f97` (cache via `lake exe cache get`).

## Follow-up (separate PRs)
- Add `SocialChoice.Voting` to the CI Lake build matrix so this can never happen again
- po-2026 already dispatched on T21.2 (median_voter_theorem_strict) + T21.3 (rebase #882) — both now have a green baseline to rebase against

🤖 Authored with the Section H.4 discipline applied.