### PR TITLE
fix(genai): anti-hallucination params for Whisper STT FR transcription

### DIFF
--- a/docker-configurations/services/whisper-api/app.py
+++ b/docker-configurations/services/whisper-api/app.py
@@ -241,12 +241,16 @@ async def transcribe_audio(
         segments_generator, info = whisper_model.transcribe(
             tmp_path,
             language=language,
-            initial_prompt=prompt,
+            initial_prompt=prompt if prompt else "Voici une transcription en francais.",
             temperature=temperature,
             word_timestamps=word_timestamps,
             beam_size=5,
             vad_filter=True,
-            vad_parameters=dict(min_silence_duration_ms=500)
+            vad_parameters=dict(min_silence_duration_ms=500),
+            condition_on_previous_text=False,
+            no_speech_threshold=0.6,
+            compression_ratio_threshold=2.4,
+            log_prob_threshold=-1.0,
         )
 
         # Collect segments


### PR DESCRIPTION
## Summary
- Fix French transcription hallucinations in Whisper STT API (`large-v3-turbo` model)
- Add 4 anti-hallucination parameters: `condition_on_previous_text=False`, `no_speech_threshold=0.6`, `compression_ratio_threshold=2.4`, `log_prob_threshold=-1.0`
- Set French-specific default `initial_prompt` when none provided

## Problem
Whisper STT produced French hallucinations ("l'anocle" instead of "NanoClaw") due to `condition_on_previous_text` cascading errors and insufficient quality filtering on `large-v3-turbo`.

## Changes
**`docker-configurations/services/whisper-api/app.py`** (1 file, +6/-2 lines)
- `condition_on_previous_text=False` — prevents cascading error propagation between segments
- `no_speech_threshold=0.6` — skip silence/noise segments
- `compression_ratio_threshold=2.4` — filter repetitive/garbage output
- `log_prob_threshold=-1.0` — filter low-confidence segments
- Default `initial_prompt="Voici une transcription en francais."` when no prompt provided

## Test Results (curl E2E)
- Kokoro TTS-generated FR audio → Whisper transcription
- **Before**: "l'anocle" (hallucination), cascading errors in subsequent segments
- **After**: "NanoClaw" correctly transcribed, no cascading hallucinations
- Remaining minor errors ("2E's" for "tu es") are TTS accent artifacts, not Whisper hallucination

## Design Decision
- **Kept `large-v3-turbo`** (not switched to `large-v3`): the anti-hallucination params are the real fix. `large-v3` switch caused `PermissionError` on HuggingFace cache dir and would double model size in GPU memory.
- Container healthy, model loaded on CUDA (GPU0 RTX 3080Ti 16GB)

## Test plan
- [x] curl test with Kokoro TTS FR audio (NanoClaw transcription correct)
- [ ] NanoClaw E2E validation (T22.8, pending)
- [ ] Monitor production for residual hallucination rate

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>