### PR TITLE
fix(prover): config.py Shapley path + stale DEMOS lines (fixes #919)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -49,8 +49,17 @@ import Mathlib.Tactic
 import CooperativeGames.Basic
 """
 
-SHAPLEY_FILE = Path(LEAN_PROJECT_DIR) / "CooperativeGames" / "Shapley.lean" if LEAN_PROJECT_DIR else None
-BASIC_FILE = Path(LEAN_PROJECT_DIR) / "CooperativeGames" / "Basic.lean" if LEAN_PROJECT_DIR else None
+_COOPERATIVE_GAMES_CANDIDATES = [
+    Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean"),
+    Path(r"D:\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean"),
+    Path(r"d:\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean"),
+]
+COOPERATIVE_GAMES_DIR = next(
+    (p for p in _COOPERATIVE_GAMES_CANDIDATES if p.exists()),
+    Path(LEAN_PROJECT_DIR) if LEAN_PROJECT_DIR else _COOPERATIVE_GAMES_CANDIDATES[0],
+)
+SHAPLEY_FILE = COOPERATIVE_GAMES_DIR / "CooperativeGames" / "Shapley.lean" if COOPERATIVE_GAMES_DIR.exists() else None
+BASIC_FILE = COOPERATIVE_GAMES_DIR / "CooperativeGames" / "Basic.lean" if COOPERATIVE_GAMES_DIR.exists() else None
 
 _SOCIAL_CHOICE_CANDIDATES = [
     Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\GameTheory\social_choice_lean"),
@@ -162,13 +171,13 @@ DEMOS = {
     6: {
         "name": "SHAPLEY_UNIQUENESS",
         "file": str(SHAPLEY_FILE),
-        "line": 513,
+        "line": 566,
         "sorry_type": "full_proof",
         "theorem_name": "shapley_uniqueness",
         "theorem": "shapley_uniqueness",
         "imports": SHAPLEY_IMPORTS,
         "description": (
-            "Replace sorry at line 513 of Shapley.lean. Prove shapley_uniqueness:\n"
+            "Replace sorry at line 566 of Shapley.lean (theorem starts L556). Prove shapley_uniqueness:\n"
             "any solution satisfying all 4 axioms equals Shapley value.\n"
             "Uses Mobius decomposition of games into unanimity games.\n"
             "Depends on: shapley_unanimity, shapley_efficient, shapley_symmetric, shapley_null_player.\n"
@@ -190,46 +199,19 @@ DEMOS = {
         ),
         "context_after": "  · -- Case i ∉ T: i is a null player",
     },
-    7: {
-        "name": "SHAPLEY_EFFICIENT_COEFF",
-        "file": str(SHAPLEY_FILE),
-        "line": 292,
-        "sorry_type": "partial_proof",
-        "theorem_name": "shapley_efficient (T ≠ ∅ case)",
-        "theorem": "shapley_efficient",
-        "imports": SHAPLEY_IMPORTS,
-        "description": (
-            "Replace sorry at line 292 of Shapley.lean. Context: proving efficiency.\n"
-            "We're inside `Finset.sum_eq_single` proving that T ≠ univ has zero coefficient.\n"
-            "Case T ≠ ∅: need to show that coefficient |T|*c(|T|-1) equals c(|T|)*(n-|T|).\n"
-            "We have `hshift := shapleyCoef_shift n (T.card - 1) (by omega)`.\n"
-            "Pre-sorry code:\n"
-            "```\n"
-            "  have hTcard : 1 ≤ T.card := Nat.pos_of_ne_zero hT0\n"
-            "  have hshift := shapleyCoef_shift (Fintype.card N) (T.card - 1) (by omega)\n"
-            "```\n"
-            "Goal: `↑T.card * shapleyCoef (Fintype.card N) (T.card - 1) * G.v T -\n"
-            "  shapleyCoef (Fintype.card N) T.card * (↑(Fintype.card N - T.card) * G.v T) = 0`\n"
-            "Key: rewrite using hshift, then use Nat subtraction properties."
-        ),
-        "difficulty": "hard",
-        "context_before": (
-            "        · -- T ≠ ∅: coefficient shift applies\n"
-            "          have hTcard : 1 ≤ T.card := Nat.pos_of_ne_zero hT0\n"
-            "          have hshift := shapleyCoef_shift (Fintype.card N) (T.card - 1) (by omega)\n"
-        ),
-        "context_after": "      (fun h => (h (Finset.mem_univ _)).elim)",
-    },
+    # DEMO 7 (SHAPLEY_EFFICIENT_COEFF, was line=292) removed: theorem shapley_efficient
+    # is now fully proved on main (Shapley.lean L243-L329). Single remaining sorry in
+    # this file is L566 (shapley_uniqueness), already covered by DEMOS 6 + 8.
     8: {
         "name": "SHAPLEY_UNIQUENESS_ALT",
         "file": str(SHAPLEY_FILE),
-        "line": 513,
+        "line": 566,
         "sorry_type": "full_proof",
         "theorem_name": "shapley_uniqueness (alternative entry)",
         "theorem": "shapley_uniqueness",
         "imports": SHAPLEY_IMPORTS,
         "description": (
-            "Same target as Demo 6 (line 513). Alias for batch/testing.\n"
+            "Same target as Demo 6 (line 566). Alias for batch/testing.\n"
             "Prove shapley_uniqueness: any solution satisfying all 4 axioms equals Shapley value.\n"
             "Uses Mobius decomposition of games into unanimity games.\n"
             "All helper theorems proved."


### PR DESCRIPTION
## Summary

Closes #919. Self-fix by ai-01 since cluster IDLE this hour and bug is well-scoped (single file, 18+/-36 lines).

Two problems in `prover/config.py`:

1. **SHAPLEY_FILE / BASIC_FILE unreachable**: derived from `LEAN_PROJECT_DIR` env var which historically points to `social_choice_lean/`, but Shapley.lean migrated to `cooperative_games_lean/CooperativeGames/`. If env unset → `None`. If set → wrong subdir. DEMOS 6/7/8 silently fail at file open in both cases.

2. **Stale line numbers**: DEMOS 6/8 referenced line=513 but `shapley_uniqueness` sorry is at L566. DEMO 7 (line=292, `shapley_efficient` T≠∅ case) is fully proved on main (L243-L329).

## Changes

- `_COOPERATIVE_GAMES_CANDIDATES` mirror of `_SOCIAL_CHOICE_CANDIDATES` pattern (3 path variants C/D/d). Falls back to `LEAN_PROJECT_DIR` when env set.
- DEMO 6 line=513 → 566
- DEMO 8 line=513 → 566 + description text update
- DEMO 7 removed (replaced with comment explaining why)

## Verification

```
$ python3 (mocked dotenv/agent_framework_openai)
COOPERATIVE_GAMES_DIR: D:\CoursIA\MyIA.AI.Notebooks\GameTheory\cooperative_games_lean
COOPERATIVE_GAMES_DIR exists: True
SHAPLEY_FILE: ...\cooperative_games_lean\CooperativeGames\Shapley.lean
SHAPLEY_FILE exists: True
BASIC_FILE exists: True
DEMO 6 line: 566
DEMO 7 in DEMOS: False
DEMO 8 line: 566
VOTING_FILE exists: True   (regression check — unchanged path)
```

`grep -nc sorry MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean` = 1 (at L566).

`py_compile` clean.

## Anti-régression checklist (CLAUDE.md B)
- [x] Scope: 1 Python file modified, 0 Lean diff (verified `git diff` no .lean touched)
- [x] Sanity test: COOPERATIVE_GAMES_DIR resolves correctly without env var
- [x] Single domain (prover config), single concern (Shapley path bug)
- [x] G.4 OK: 1 file < 15
- [x] No body inflation: small targeted fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)