### PR TITLE
feat(prover): add DEMO 15 SmokeTest for trivial harness validation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -71,6 +71,7 @@ SOCIAL_CHOICE_DIR = next(
     _SOCIAL_CHOICE_CANDIDATES[0],
 )
 VOTING_FILE = SOCIAL_CHOICE_DIR / "SocialChoice" / "Voting.lean" if SOCIAL_CHOICE_DIR.exists() else None
+SMOKE_TEST_FILE = SOCIAL_CHOICE_DIR / "SocialChoice" / "_SmokeTest.lean" if SOCIAL_CHOICE_DIR.exists() else None
 VOTING_IMPORTS = """import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.List.Sort
@@ -551,5 +552,24 @@ DEMOS = {
             "NOTE: may need to unfold clone_independence to see exact goal structure."
         ),
         "difficulty": "very_hard",
+    },
+    15: {
+        "name": "SMOKE_TEST_ZERO_ADD",
+        "file": str(SMOKE_TEST_FILE) if SMOKE_TEST_FILE else "",
+        "line": 6,
+        "sorry_type": "sorry_replacement",
+        "theorem_name": "zero_add_smoke",
+        "theorem": "zero_add_smoke",
+        "imports": "import Mathlib.Data.Nat.Basic\n",
+        "goal": "0 + n = n",
+        "description": (
+            "Smoke test trivial: prove 0 + n = n for Nat.\n"
+            "Single one-line proof. Use one of:\n"
+            "  exact Nat.zero_add n\n"
+            "  omega\n"
+            "  simp\n"
+            "Replace the sorry at L6 of _SmokeTest.lean."
+        ),
+        "difficulty": "trivial",
     },
 }


### PR DESCRIPTION
## Summary

- Add DEMO 15 entry in `prover/config.py` pointing to `_SmokeTest.lean` (sorry trivial `0 + n = n` at L6)
- Add `SMOKE_TEST_FILE` path candidate alongside `VOTING_FILE` in cooperative_games-style derivation
- Validates harness end-to-end on a guaranteed-provable trivial target

## Context

After PR #904 merge (multi-agent prover harness redirect DEMO 9 to L325), iter 4 BG returned `sorry 4 -> 4` on DEMO 9 L325/L338 (very_hard counting + sorting). Unclear whether harness was fundamentally broken or just unable to handle very_hard goals within iter cap 6.

## Validation

Iter 5 BG ran on DEMO 15 (zai/glm-5.1, max_iter=4, timeout=600s):

```
[BG] START demo_id=15 name=SMOKE_TEST_ZERO_ADD
[BG] FILE  D:\CoursIA\MyIA.AI.Notebooks\GameTheory\social_choice_lean\SocialChoice\_SmokeTest.lean
[BG] LINE  6
[BG] DIFF  trivial
[BG] PROVIDER reasoning=zai fast=local max_iter=4 workflow_timeout=600s
[BG] PRE_FILE_SORRY_COUNT 1
...
[+240.1s] TacticAgent -> compile([no args] -> ✔ [112/112] Built SocialChoice._SmokeTest (2.6s)
[+245.2s] TacticAgent [respond]: La preuve est bien terminée et vérifiée
RESULT: SUCCESS  Sorry: 1 -> 0  Total time: 214.7s
[BG] POST_FILE_SORRY_COUNT 0
[BG] DELTA 1
```

Harness validated: `omega` tactic accepted, build SUCCESS, sorry eliminated.

## Test plan

- [x] `_SmokeTest.lean` reverted to keep `sorry` for reproducible reruns
- [x] DEMO 15 runs to SUCCESS sorry 1->0 in ~215s
- [ ] CI green (no notebook touched, only Python config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)