### PR TITLE
fix(prover): enforce strict Critic escalation after 3 TacticAgent fails

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -51,11 +51,16 @@ QUAND UTILISER submit_decomposition:
 - Counting / cardinalite necessitant transfer (Finset → List → countP)
 - Quand 2 essais one-shot ont echoue : DECOMPOSE plutot que d'iterer
 
-CYCLE D'ITERATION (si echec):
+CYCLE D'ITERATION (si echec) — escalade STRICTE:
 - Lire l'erreur compilateur (elle est explicite)
 - Adapter (ajouter named arg, changer un lemme, ajouter un cast)
 - Si 2 adaptations identiques echouent : DECOMPOSER ou demander plus de lemmes
-- Si 3 echecs cumules sur le meme sorry : laisser le Critic / Coordinator reformuler
+- ESCALADE OBLIGATOIRE: apres 3 essais consecutifs en echec sur le MEME sorry
+  (meme ligne), tu DOIS arreter de soumettre des tactiques et appeler
+  designate_next_agent("critic") (ou "coordinator" si plan deja ajuste 2x).
+  Pas d'exception: continuer a marteler = boucle locale = budget brule pour rien.
+- Si decomposition: max 2 decomposition_progress consecutifs sans baisse nette
+  du sorry global. Au-dela, escalade Critic pour re-planifier.
 
 INTERDIT (verifie toujours dans FAILED ATTEMPTS):
 - Repeter une tactique deja en echec (meme texte exact)


### PR DESCRIPTION
## Summary

- Iter 6 BG DEMO 9 cap 10 (2197s) confirmed TacticAgent local-loop pattern (14+ decomposition_progress, BUILD-FAIL 1-3 oscillation, **0 Critic escalation** despite L58 saying "3 echecs -> Critic")
- Soft phrasing "laisser le Critic / Coordinator reformuler" was ignored by local Qwen reasoning
- Patch hardens TACTIC_AGENT_INSTRUCTIONS cycle with **ESCALADE OBLIGATOIRE** + explicit `designate_next_agent("critic")` call + decomposition cap (max 2 consecutive without net sorry reduction)

## Diff

`prover/instructions.py` L54-62: 7 insertions, 2 deletions. No runtime code change, prompt-only.

## Test plan

- [ ] Iter 7 BG on same DEMO 9 cap 10, check whether Critic escalation triggers at 3rd fail boundary
- [ ] Compare sorry trajectory vs iter 6 (which closed structurally at 4->6 without Critic intervention)
- [ ] Goal: at least 1 sorry closed via Critic re-planning OR documented Critic loop (Critic also stuck = different problem to escalate)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>