### PR TITLE
fix(ml-training): MSE broadcasting bug pred_len=1 in M8 archi (train_{mamba,itransformer,patchtst,tft})

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_itransformer.py
@@ -217,7 +217,7 @@ def train_and_evaluate(
 
             with torch.amp.autocast("cuda", enabled=use_amp):
                 pred = model(X_batch)
-                loss = criterion(pred, y_batch)
+                loss = criterion(pred, y_batch.view_as(pred))
 
             if use_amp:
                 grad_scaler.scale(loss).backward()
@@ -244,7 +244,8 @@ def train_and_evaluate(
             for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
-                    val_loss += criterion(model(X_batch), y_batch).item()
+                    pred = model(X_batch)
+                    val_loss += criterion(pred, y_batch.view_as(pred)).item()
                 val_batches += 1
 
         avg_val = val_loss / max(val_batches, 1)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_mamba.py
@@ -484,7 +484,7 @@ def train_and_evaluate(
 
             with torch.amp.autocast("cuda", enabled=use_amp):
                 pred = model(X_batch)
-                loss = criterion(pred, y_batch)
+                loss = criterion(pred, y_batch.view_as(pred))
 
             if use_amp:
                 grad_scaler.scale(loss).backward()
@@ -511,7 +511,8 @@ def train_and_evaluate(
             for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
-                    val_loss += criterion(model(X_batch), y_batch).item()
+                    pred = model(X_batch)
+                    val_loss += criterion(pred, y_batch.view_as(pred)).item()
                 val_batches += 1
 
         avg_val = val_loss / max(val_batches, 1)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_patchtst.py
@@ -250,7 +250,7 @@ def train_and_evaluate(
 
             with torch.amp.autocast("cuda", enabled=use_amp):
                 pred = model(X_batch)
-                loss = criterion(pred, y_batch)
+                loss = criterion(pred, y_batch.view_as(pred))
 
             if use_amp:
                 grad_scaler.scale(loss).backward()
@@ -277,7 +277,8 @@ def train_and_evaluate(
             for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
-                    val_loss += criterion(model(X_batch), y_batch).item()
+                    pred = model(X_batch)
+                    val_loss += criterion(pred, y_batch.view_as(pred)).item()
                 val_batches += 1
 
         avg_val = val_loss / max(val_batches, 1)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_tft.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_tft.py
@@ -318,7 +318,8 @@ def train_and_evaluate(
             for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device), y_batch.to(device)
                 with torch.amp.autocast("cuda", enabled=use_amp):
-                    val_loss += criterion(model(X_batch), y_batch).item()
+                    pred = model(X_batch)
+                    val_loss += criterion(pred, y_batch.view_as(pred)).item()
                 val_batches += 1
 
         avg_val = val_loss / max(val_batches, 1)


### PR DESCRIPTION
## Summary

Bug detected during walk-forward Mamba launch on GPU 2 (2026-05-11 ai-01):

\`\`\`
UserWarning: Using a target size (torch.Size([64])) that is different to the
input size (torch.Size([64, 1])). This will likely lead to incorrect results
due to broadcasting.
\`\`\`

PyTorch \`MSELoss\` broadcasts \`(B, 1)\` vs \`(B,)\` to \`(B, B)\` matrix → pairwise distances instead of per-sample MSE. Gradient flows in a wrong direction.

Triggers for \`pred_len=1\` across **all 4 M8 architectures**:

| File | Lines (training) | Lines (validation) |
|------|------------------|--------------------|
| train_mamba.py | L487 (FIXED) | L514 (FIXED) |
| train_itransformer.py | L220 (FIXED) | L247 (FIXED) |
| train_patchtst.py | L253 (FIXED) | L280 (FIXED) |
| train_tft.py | L295 (already had guard) | L321 (FIXED) |

## Fix

\`y_batch.view_as(pred)\` to harmonize shapes before \`criterion\` call. Works for any \`pred_len\` (no-op when shapes already match).

## Impact

M8 SOTA sweep verdict (PR #892, **0 BEATS** / 96 runs) is based on training runs that all had this bug for \`pred_len=1\`. The h=5 and h=10 runs may also have the issue if model output is \`[B, pred_len]\` but target loader returns \`[B]\` (TBD).

A walk-forward rerun post-fix is required to validate the verdict robustly (M8 TODO from \`project_m8_verdict_2026-05-10.md\`).

## Test plan

- [x] Mamba walk-forward BTC-USD h=1 relaunched on GPU 2 (BG \`b58fxazq0\`), no warning observed in startup logs (vs initial launch which had the warning).
- [ ] Apple-to-apple comparison with PR #892 results once rerun completes (~5h).
- [ ] If verdict 0 BEATS confirmed post-fix → M8 conclusion robust. If verdict changes → significant finding requiring full sweep redo.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>