### PR TITLE
feat(lean-prover): F1 deterministic Critic escalation + F4 KB warm-start + F5 mark_sorry_intractable

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -105,6 +105,7 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
             tools.advance_plan,
             tools.file_read_lines,
             tools.search_mathlib_lemmas,
+            tools.mark_sorry_intractable,
         ],
         name="CoordinatorAgent",
         default_options=_reasoning_options(),

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -115,6 +115,11 @@ OUTILS:
 4. set_attack_plan(steps=[...], reason="...") → CRUCIAL : tu DOIS appeler cet outil
    avec une LISTE NON VIDE d'etapes en LANGAGE NATUREL. Pas de tactique Lean ici.
 5. advance_plan() → marque etape suivante quand un sous-but est clos
+6. mark_sorry_intractable(reason="...") → ABANDON EXPLICITE quand le but est hors
+   de portee (Mathlib API introuvable, but mathematiquement faux, decompositions
+   epuisees apres 2-3 plans differents). La session termine proprement et le
+   prouveur passera a un autre sorry au prochain run. PREFERE ABANDON EXPLICITE
+   plutot que de bruler les iterations sur un mur connu.
 
 REGLE D'OR (set_attack_plan):
 - TOUJOURS au moins 2 etapes, formulees en NATUREL ("isoler la conjonction",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -199,6 +199,33 @@ class MultiAgentSorryProver:
         context_msg = self._build_context_message(demo, ctx_data, goal_state,
                                                    original_sorry_count, sorry_line)
 
+        # F4 (2026-05-11): KB warm-start. Surface up to 5 prior successful
+        # proofs whose goal signature overlaps the current goal so the
+        # CoordinatorAgent can incorporate them into the attack plan instead
+        # of re-deriving familiar shapes from scratch.
+        if goal_state:
+            try:
+                similar = kb.search_similar(goal_state, max_results=5)
+                if similar:
+                    lines = ["\nPREUVES SIMILAIRES (KB warm-start, "
+                             f"{len(similar)} resultats):"]
+                    for hit in similar:
+                        rel = hit.get("relevance", 0.0)
+                        tac = (hit.get("tactic") or "")[:160].replace("\n", " ")
+                        f = hit.get("file", "")
+                        lines.append(f"  - [{rel:.2f}] {f} -> {tac}")
+                    context_msg = context_msg + "\n" + "\n".join(lines)
+                    self.trace.log(
+                        agent="ProverSetup", role="kb_warm_start",
+                        content=f"injected {len(similar)} similar entries "
+                                f"(kb_size={kb.size})",
+                    )
+            except Exception as e:
+                self.trace.log(
+                    agent="ProverSetup", role="kb_warm_start_error",
+                    content=f"warm-start lookup failed: {e}",
+                )
+
         initial_msg = ProofMessage(
             content=context_msg,
             sorry_count=original_sorry_count,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -99,6 +99,12 @@ class ProofState:
     plan: List[str] = field(default_factory=list)
     plan_phase: int = 0  # Current step in the plan
 
+    # F5 (2026-05-11): Coordinator can explicitly abandon a goal so the
+    # session ends cleanly instead of burning max_iterations on an
+    # unprovable sorry. Set via CoordinatorTools.mark_sorry_intractable.
+    intractable: bool = False
+    intractable_reason: Optional[str] = None
+
     # B.8: Checkpoint support — save/restore state between phases
     _checkpoints: Dict[str, dict] = field(default_factory=dict, repr=False)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1285,6 +1285,34 @@ class CoordinatorTools:
         current = self._state.plan[self._state.plan_phase]
         return f"Advanced to step {self._state.plan_phase + 1}/{len(self._state.plan)}: {current}"
 
+    def mark_sorry_intractable(self, reason: str) -> str:
+        """Explicitly abandon the current sorry (F5).
+
+        Call this when the Coordinator has exhausted realistic attack plans
+        on a goal — e.g., the lemma requires an obscure Mathlib API the
+        SearchAgent can't locate, or the goal is mathematically false as
+        stated. Setting intractable ends the session cleanly so the next
+        prover run can target a different sorry instead of burning the
+        remaining iteration budget on a dead end.
+
+        Args:
+            reason: Concise explanation (logged in trace + final report).
+        """
+        self._state.intractable = True
+        self._state.intractable_reason = reason
+        if self._trace:
+            self._trace.log(
+                agent="CoordinatorAgent", role="intractable",
+                content=f"Marked intractable: {reason[:200]}",
+                tool_name="mark_sorry_intractable",
+                tool_args={"reason": reason[:200]},
+            )
+        return (
+            f"Sorry marked intractable. Reason: {reason}. "
+            f"Session will yield_output after this turn — pick a different "
+            f"goal on the next run."
+        )
+
     def file_read_lines(self, start: int, end: int) -> str:
         """Read a specific range of lines from the .lean file (1-based inclusive)."""
         if not self._filepath:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -60,6 +60,10 @@ class ProofMessage:
     next_agent: str = "coordinator"  # B.3: coordinator runs first to set attack plan
     max_iterations: int = 10
     plan: Optional[list] = None  # attack plan from CoordinatorAgent
+    # F5 (2026-05-11): set when Coordinator calls mark_sorry_intractable.
+    # AgentExecutor yields immediately when this is true.
+    intractable: bool = False
+    intractable_reason: Optional[str] = None
 
 
 class AgentExecutor(Executor):
@@ -177,6 +181,24 @@ class AgentExecutor(Executor):
             if self._state.plan:
                 msg.plan = list(self._state.plan)
 
+        # F5: Coordinator can mark the current sorry intractable. End the
+        # session cleanly so we don't waste iterations on a known-dead goal.
+        if (self._state and getattr(self._state, "intractable", False)
+                and not msg.intractable):
+            msg.intractable = True
+            msg.intractable_reason = getattr(
+                self._state, "intractable_reason", None
+            )
+            msg.content = response_text
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name, role="intractable_propagate",
+                    content=(f"yielding session: "
+                             f"{msg.intractable_reason or '(no reason)'}"),
+                )
+            await ctx.yield_output(msg)
+            return
+
         # Agent output becomes the new content
         msg.content = response_text
 
@@ -244,7 +266,7 @@ class VerifyExecutor(Executor):
 
     def __init__(self, sorry_context: SorryContext, imports: str,
                  trace: TraceLogger = None, kb: Optional[ProofKnowledgeBase] = None,
-                 **kwargs):
+                 escalation_threshold: int = 3, **kwargs):
         super().__init__(id="verify_executor", **kwargs)
         self._sorry_ctx = sorry_context
         self._imports = imports
@@ -252,6 +274,13 @@ class VerifyExecutor(Executor):
         # B.1 ProofKnowledgeBase: record successful tactics so future sessions
         # can warm-start. Same JSON file that SearchTools reads.
         self._kb = kb or ProofKnowledgeBase()
+        # F1 (2026-05-11): Deterministic Critic escalation. PR #923 attempted
+        # to encode the "after 3 BUILD-FAIL on same line, escalate" rule in the
+        # Critic prompt; iter 5-7 BG runs showed the model still routes back to
+        # TacticAgent on consecutive failures. Encode it here in workflow code
+        # so we don't depend on prompt adherence.
+        self._consecutive_build_fails = 0
+        self._escalation_threshold = escalation_threshold
 
     @handler
     async def handle(self, msg: ProofMessage, ctx: WorkflowContext[ProofMessage]) -> None:
@@ -272,6 +301,7 @@ class VerifyExecutor(Executor):
 
         if result["success"]:
             msg.proof_found = True
+            self._consecutive_build_fails = 0
             if self._trace:
                 self._trace.log(
                     agent="VerifyExecutor", role="verify",
@@ -308,10 +338,40 @@ class VerifyExecutor(Executor):
             msg.sorry_count = new_sorry_count
             msg.error = f"Decomposition: {msg.sorry_count} sorry remaining"
             msg.next_agent = "tactic"
+            # Decomposition is progress (new sub-goals to attack), reset.
+            self._consecutive_build_fails = 0
         else:
             msg.error = result.get("errors", "")[:500]
             msg.error_type = result.get("error_type", "unknown")
-            msg.next_agent = "critic"
+            self._consecutive_build_fails += 1
+            if self._consecutive_build_fails >= self._escalation_threshold:
+                # F1: deterministic escalation to Coordinator. Critic prompt
+                # heuristics aren't reliable enough — when the same sorry_line
+                # has failed N times in a row, the attack plan is wrong, not
+                # the local tactic. Reset by sending control back to the
+                # Coordinator with a clear escalation note.
+                msg.next_agent = "coordinator"
+                escalation_note = (
+                    f"[F1 escalation] {self._consecutive_build_fails} "
+                    f"consecutive BUILD-FAIL on sorry_line "
+                    f"{self._sorry_ctx.sorry_line}. Local tactics aren't "
+                    f"converging — revise the attack plan or mark the goal "
+                    f"intractable. Last error: {msg.error}"
+                )
+                msg.error = escalation_note
+                if self._trace:
+                    self._trace.log(
+                        agent="VerifyExecutor", role="f1_escalation",
+                        content=(f"consecutive_fails="
+                                 f"{self._consecutive_build_fails} >= "
+                                 f"threshold={self._escalation_threshold}, "
+                                 f"forcing route to Coordinator"),
+                    )
+                # Reset so we don't immediately re-escalate on the next fail;
+                # give the Coordinator a fresh window of `threshold` attempts.
+                self._consecutive_build_fails = 0
+            else:
+                msg.next_agent = "critic"
 
         if self._trace:
             self._trace.log(
@@ -363,7 +423,9 @@ class ProofWorkflowBuilder:
         builder.add_edge(self._tactic, self._verify)
 
         # Verify routes via switch-case so the "tactic" backedge and the
-        # default critic path don't collide as duplicate edges either.
+        # default critic path don't collide as duplicate edges either. F1
+        # (2026-05-11) adds the "coordinator" branch so the deterministic
+        # escalation in VerifyExecutor can bypass the Critic entirely.
         builder.add_switch_case_edge_group(
             source=self._verify,
             cases=[
@@ -372,6 +434,10 @@ class ProofWorkflowBuilder:
                         msg.next_agent == "tactic" and not msg.proof_found
                     ),
                     target=self._tactic,
+                ),
+                Case(
+                    condition=lambda msg: msg.next_agent == "coordinator",
+                    target=self._coordinator,
                 ),
                 Default(target=self._critic),
             ],


### PR DESCRIPTION
## Summary
Per user feedback : *le script doit être la principale source de progrès, il doit pouvoir itérer sur les .lean, builder rapidement, explorer Mathlib, laisse discuter un peu les agents de temps à autre comme dans le notebook semantic-kernel*. Three targeted features so the multi-agent prover can run autonomously on po-2026 as a side-track:

**F1 — VerifyExecutor déterministe** ([workflow.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py))
- Counter `_consecutive_build_fails` + threshold (default 3)
- ≥ 3 BUILD-FAIL successive on same `sorry_line` → forces `next_agent = "coordinator"` (bypassing Critic prompt heuristics)
- Reset on success or decomposition (which counts as progress)
- New `coordinator` branch in the Verify switch-case edge group
- Replaces PR #923 prompt-only attempt that iter 5-7 BG runs showed unreliable

**F4 — KB warm-start** ([provers.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py))
- `ProofKnowledgeBase.search_similar(goal, max_results=5)` injected in `context_msg` before initial `ProofMessage`
- Surfaces past successful proofs with overlapping goal signatures
- Coordinator sees familiar shapes at session start instead of re-deriving from scratch

**F5 — `mark_sorry_intractable(reason)`** ([tools.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py) + [state.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py) + [workflow.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py) + [agents.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py) + [instructions.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py))
- New CoordinatorTools tool, wired into `create_coordinator_agent`
- `ProofState.intractable: bool` + `intractable_reason`
- `AgentExecutor` yields output immediately when state.intractable is set after agent.run
- New `ProofMessage.intractable` + `intractable_reason` fields
- Instructions updated : *PREFERE ABANDON EXPLICITE plutot que bruler iterations sur un mur connu*

## Smoke test
Demo `SMOKE_TEST_ZERO_ADD` on `_SmokeTest.lean:6` (`theorem zero_add_smoke (n : Nat) : 0 + n = n`).
- Provider z.ai reasoning + local fast, `max-iter 6`, `workflow-timeout 600s`
- **Result : sorry 1→0 in 182s, tactic `exact Nat.zero_add n`, KB recorded**
- F1/F4/F5 didn't actually fire (trivial proof succeeded on first attempt) but no regression observed

## Diff stats
- 6 files changed, +136 / -3
- All additions, no deletions of existing logic (anti-régression OK)

## Test plan
- [x] Imports clean (`coursia-ml-training` env)
- [x] Smoke test passes end-to-end (sorry 1→0 in 182s)
- [x] `_SmokeTest.lean` restored to its pre-prover state
- [ ] Run on `Voting.lean:385` (`countP_bound` on sorted list, non-trivial — will exercise F1 escalation)
- [ ] po-2026 picks up as side-track once `[SIGNAL] prover-ready` posted

## Next
After larger validation on `Voting.lean:385`, post `[SIGNAL] prover-ready po-2026-go` on workspace dashboard to unblock po-2026 Track 4 side-track on 4 honest sorrys remaining in `Voting.lean` + `Sen.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)