### PR TITLE
docs(lean): proof strategy for Voting.lean L338+L361 counting sorries (Cycle 25 prover-lead)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -335,7 +335,24 @@ theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) 
               Finset.card_filter_add_card_filter_not
                 (s := Finset.univ) (p := fun i => median_peak peaks ≤ peaks i),
               Finset.card_univ]
-        sorry -- TODO: A.card ≤ n/2 via sortedness
+        -- TODO: A.card ≤ n/2 via sortedness (median voter counting argument).
+        -- PROOF STRATEGY (ai-01 2026-05-11 Cycle 25 prover-lead):
+        -- 1. Let l := sorted_peaks_list peaks = (univ.toList.map peaks).mergeSort (· ≤ ·)
+        -- 2. median_peak peaks = l.getD (l.length / 2) default
+        -- 3. l.Sorted (· ≤ ·) by List.sorted_mergeSort
+        -- 4. l ≈ univ.toList.map peaks by List.mergeSort_perm
+        -- 5. A.card = ((univ.toList.map peaks).countP (· < median)) by Finset.filter.card via toList
+        -- 6. (univ.toList.map peaks).countP = l.countP by List.Perm.countP_eq
+        -- 7. For sorted l with median at position n/2 :
+        --    l.countP (· < median) ≤ n/2
+        --    (split l = take(n/2) ++ drop(n/2); take has length ≤ n/2 + countP ≤ length;
+        --     drop has head = median + sortedness → all elements ≥ median → countP = 0)
+        -- 8. With hcomp + step 7 + hodd : A.card ≤ n/2 ∧ A.card + B.card = n ∧ n = 2k+1
+        --    ⟹ A.card ≤ k ∧ B.card ≥ k+1 ⟹ A.card < B.card
+        -- KEY MATHLIB LEMMAS: List.sorted_mergeSort, List.mergeSort_perm, List.Perm.countP_eq,
+        -- List.countP_append, List.countP_eq_zero, List.countP_le_length, List.length_take,
+        -- List.Sorted.rel_get_of_le (or List.Sorted.le_get_of_le_get) for the drop bound
+        sorry
       omega
     · -- Case: peaks_j > median. Voters with peak <= median prefer median over j.
       have hgt : median_peak peaks < peaks j := lt_of_le_of_ne (le_of_not_gt hlt) (Ne.symm hny)
@@ -358,7 +375,14 @@ theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) 
         exact (hlt_peaks i hle).2 hi.1
       have hcount : (Finset.filter (fun i => median_peak peaks < peaks i) Finset.univ).card <
           (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ).card := by
-        sorry -- same counting argument (symmetric)
+        -- Symmetric counting argument to L338 (median voter, > case).
+        -- Same strategy: sortedness implies countP (· > median) ≤ (n-1)/2.
+        -- See L338 PROOF STRATEGY comment for the full plan.
+        -- Once a `sorted_peaks_count_lt_median_le_half` helper lemma is proven,
+        -- the dual `sorted_peaks_count_gt_median_le_half` follows by symmetry
+        -- (apply the same lemma to `peaks` with the opposite order, or
+        -- via `mergeSort` of `(· ≥ ·)` and `getD (n/2)`).
+        sorry
       omega
 
 end SinglePeaked


### PR DESCRIPTION
## Summary

Cycle 25 prover-lead by ai-01: document a concrete 8-step proof plan + key Mathlib lemmas at the two counting sorries `Voting.lean L338` (LT case) and `L361` (GT case symmetric) of `median_voter_theorem_strict`.

These sorries resisted Cycle 24 prover BG attempts (multiple failed iterations) because `omega` cannot bridge the sortedness gap from the median-voter counting argument. This PR turns "the prover doesn't know what approach to try" into "the prover/agent has a documented Mathlib-lemma path to follow".

**Zero proof eliminated. 100% documentation.** The goal is to reduce future attempts from cold-start to KB-warm-start (rule F4) with a concrete plan.

## Proof strategy documented at L338

```
1. Let l := sorted_peaks_list peaks = (univ.toList.map peaks).mergeSort (· ≤ ·)
2. median_peak peaks = l.getD (l.length / 2) default
3. l.Sorted (· ≤ ·) by List.sorted_mergeSort
4. l ≈ univ.toList.map peaks by List.mergeSort_perm
5. A.card = ((univ.toList.map peaks).countP (· < median)) by Finset.filter.card via toList
6. (univ.toList.map peaks).countP = l.countP by List.Perm.countP_eq
7. For sorted l with median at position n/2 :
   l.countP (· < median) ≤ n/2
   (split l = take(n/2) ++ drop(n/2);
    take has length ≤ n/2 + countP ≤ length;
    drop has head = median + sortedness → all elements ≥ median → countP = 0)
8. With hcomp + step 7 + hodd : A.card ≤ n/2 ∧ A.card + B.card = n ∧ n = 2k+1
   ⟹ A.card ≤ k ∧ B.card ≥ k+1 ⟹ A.card < B.card
```

L361 = symmetric (mergeSort `(· ≥ ·)`).

## Test plan / Evidence (rule B + G.2)

### sorry count (anti-regression D)
- **BEFORE**: 3 actual sorries in `Voting.lean` (L261 honest + L338 + L361)
- **AFTER**: 3 actual sorries (unchanged — pure comment additions at the existing sorry locations)

```bash
grep -nE '^[[:space:]]*sorry$' MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
```

### Lake build SUCCESS (rule B + G.2)

```
lake -R build (in social_choice_lean/)
...
✔ [3290/3291] Built SocialChoice (7.5s)
Build completed successfully (3291 jobs).
```

Exit code: 0. Only pre-existing `linter.unusedSectionVars` warnings on `banks_set_subset` (separate section, unaffected).

### Diff stat
- 1 file changed (`Voting.lean`), +26 insertions / -2 deletions
- All additions are line comments (`-- ...`) immediately preceding existing `sorry` keywords
- No structural changes (theorem signature, context, proof body — untouched)

## Companion KB enrichment (local ai-01)

The prover KB at `prover/proof_knowledge.json` (gitignored runtime artifact) on ai-01 has been seeded with 7 sorted-list lemma patterns + a full L338/L361 scaffold entry for local F4 KB warm-start retrieval. Other agents (e.g., po-2026 retry) can replicate these patterns by adding the same entries to their local `proof_knowledge.json`:

- `List.countP split via take/drop` → `← List.take_append_drop k l, List.countP_append`
- `List.countP on sorted list (drop part)` → `List.countP_eq_zero` + `List.Sorted.rel_get_of_le`
- `List.countP bounded by length` → `List.countP_le_length`
- `List.mergeSort yields Sorted permutation` → `List.sorted_mergeSort + List.mergeSort_perm`
- `Finset.filter.card via toList countP` → `Finset.toList_filter, List.length_toList`
- `List.Perm.countP_eq for sorting bridge` → `List.Perm.countP_eq _ hperm`
- `Odd n yields strict midpoint split` → `Nat.odd_iff` + omega manipulations

These are documented in the strategy comments themselves (so even without KB seeding, an agent reading `Voting.lean` has the full lemma list).

## Why this approach (instead of full proof)

User asked ai-01 to "take prover lead and advance proofs a little" without monopolizing the cycle. Documenting the strategy + Mathlib lemmas gives the next attempt (po-2026 retry, future ai-01 BG, or human follow-up) a 50-100 line formalization target instead of a "discover the approach" task. This is a multiplier on next-attempt success rate.

The full formalization is ~50-100 lines of Lean (split + sortedness + countP bookkeeping). Out of scope for this single commit; in scope for next cycle's prover BG with KB warm-start fully wired.

## Cycle 25 context

ai-01 prover-lead track. po-2026 dispatched (msg-20260511T204536-2yvyim) to QC Cloud #934 + QC strategy enhancement (NOT prover this cycle). po-2024 (HAR-RV multi-coin + DM test) and po-2025 (LSTM-Crypto fix + GaussianNB) running parallel ML/data tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)