### PR TITLE
fix(prover): build-verified snapshots + mandatory final verify (Cycle 25 iter 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -274,6 +274,9 @@ class MultiAgentSorryProver:
             total_s = time.time() - session_start
             final_sorry = Path(filepath).read_text(encoding="utf-8").count("sorry")
             structural_progress = False
+            # Default value so the success check after finally always has it,
+            # even if an exception is raised mid-block before the verify runs.
+            final_build_ok = False
 
             best_content = getattr(tactic_tools, "best_content", None)
             best_sorry = getattr(tactic_tools, "best_sorry_count",
@@ -303,15 +306,50 @@ class MultiAgentSorryProver:
                     Path(filepath).write_text(original_content, encoding="utf-8")
                     final_sorry = original_sorry_count
 
+            # MANDATORY final build verification on the committed file. This
+            # catches false positives where the snapshot's build_check was
+            # bypassed (build_check=False) or stale-cached. Iter 2 of demo 9
+            # promoted a `show ?a ≦ ?b -- PROBE` snapshot to best because the
+            # agent passed build_check=False; the snapshot guard in tools.py
+            # now prevents that, but this verify is the workflow-level safety
+            # net the user requested ("les verifs via build devraient faire
+            # partie integrante du workflow du prouveur").
+            from .lean_server import LeanVerifier as _LeanVerifierFinal
+            _LeanVerifierFinal.invalidate(filepath)
+            try:
+                final_verify_raw = tactic_tools.compile()
+                final_verify = json.loads(final_verify_raw)
+            except Exception as _e:
+                final_verify = {"overall": False, "level_1": False,
+                                "errors": [{"message": f"final-verify crashed: {_e}"}]}
+
+            final_build_ok = bool(final_verify.get("level_1", False))
+            if not final_build_ok:
+                _errs = final_verify.get("errors", [])[:5]
+                print(
+                    f"  FINAL VERIFY FAILED ({len(_errs)} compile errors). "
+                    f"Reverting to original to avoid leaving the file broken."
+                )
+                Path(filepath).write_text(original_content, encoding="utf-8")
+                final_sorry = original_sorry_count
+                structural_progress = False
+                # Force-clear best snapshot so callers don't claim spurious progress
+                tactic_tools._best_content = None
+                tactic_tools._best_sorry_count = original_sorry_count
+
         # Success now also covers structural progress: file changed but
         # compiles, even if sorry count didn't decrease. Provers.py used to
         # treat that as a failure and restore original, which threw away the
         # decomposition the agent had just done.
+        # IMPORTANT: success ALSO requires final_build_ok — a sorry-count drop
+        # without a real build is the iter 2 false positive we are guarding
+        # against. final_build_ok is set above in the mandatory verify.
         success = (
-            proof_found
-            or final_sorry == 0
-            or final_sorry < original_sorry_count
-            or structural_progress
+            (proof_found
+             or final_sorry == 0
+             or final_sorry < original_sorry_count
+             or structural_progress)
+            and final_build_ok
         )
         self.trace.end_session_span(success, f"{original_sorry_count}->{final_sorry}")
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -802,21 +802,27 @@ class TacticTools:
             Path(self._filepath).write_text(new_file_content, encoding="utf-8")
 
             # Build check: if compilation fails, revert and surface diagnostics.
+            # When build_check=False, we MUST NOT update _last_build_ok_* or
+            # _best_* — those snapshots are the prover's source of truth for
+            # the "best build-passing state" and the autonomous loop commits
+            # them as RESULT_SUCCESS. Updating them on unverified raw sorry
+            # count alone caused a false positive in iter 2 of demo 9 where a
+            # `show ?a ≦ ?b -- PROBE` snapshot (invalid Lean U+2266 token)
+            # was promoted to best_sorry_count=3 because the agent passed
+            # build_check=False.
             if build_check:
                 build_err = self._build_check_or_revert(content, "file_replace_lines")
                 if build_err is not None:
                     build_err["replaced_lines"] = f"{start}-{end}"
                     return json.dumps(build_err, ensure_ascii=False)
 
-            # Track last build-passing snapshot regardless of sorry-count delta.
-            # Decomposition (sorry grows but compiles) is structural progress
-            # that provers.py should commit even if best_sorry_count didn't drop.
-            self._last_build_ok_content = new_file_content
-            self._last_build_ok_sorry_count = sorry_count
+                # Build verified — safe to update snapshots.
+                self._last_build_ok_content = new_file_content
+                self._last_build_ok_sorry_count = sorry_count
 
-            if sorry_count < self._best_sorry_count:
-                self._best_sorry_count = sorry_count
-                self._best_content = new_file_content
+                if sorry_count < self._best_sorry_count:
+                    self._best_sorry_count = sorry_count
+                    self._best_content = new_file_content
 
             return json.dumps({
                 "replaced_lines": f"{start}-{end}",
@@ -824,6 +830,7 @@ class TacticTools:
                 "new_sorry_count": sorry_count,
                 "best_sorry_count": self._best_sorry_count,
                 "build_check": "passed" if build_check else "skipped",
+                "snapshot_updated": build_check,
             }, ensure_ascii=False)
         except Exception as e:
             return json.dumps({"error": str(e)})
@@ -926,19 +933,21 @@ class TacticTools:
             Path(self._filepath).write_text(new_content, encoding="utf-8")
 
             # Build check: if compilation fails, revert and surface diagnostics.
+            # Same invariant as file_replace_lines: snapshots only update when
+            # the build was actually verified. See that method for the full
+            # iter 2 false positive context.
             if build_check:
                 build_err = self._build_check_or_revert(content, "file_replace_sorry")
                 if build_err is not None:
                     build_err["replaced"] = old_line.strip()
                     return json.dumps(build_err, ensure_ascii=False)
 
-            # See file_replace_lines for rationale on _last_build_ok_*.
-            self._last_build_ok_content = new_content
-            self._last_build_ok_sorry_count = sorry_count
+                self._last_build_ok_content = new_content
+                self._last_build_ok_sorry_count = sorry_count
 
-            if sorry_count < self._best_sorry_count:
-                self._best_sorry_count = sorry_count
-                self._best_content = new_content
+                if sorry_count < self._best_sorry_count:
+                    self._best_sorry_count = sorry_count
+                    self._best_content = new_content
 
             return json.dumps({
                 "replaced": old_line.strip(),
@@ -946,6 +955,7 @@ class TacticTools:
                 "new_sorry_count": sorry_count,
                 "best_sorry_count": self._best_sorry_count,
                 "build_check": "passed" if build_check else "skipped",
+                "snapshot_updated": build_check,
             }, ensure_ascii=False)
         except Exception as e:
             return json.dumps({"error": str(e)})

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -453,3 +453,102 @@ def test_file_replace_lines_no_duplicate_when_marker_in_replacement(tmp_path):
     # TODO appears exactly once (no duplicate)
     assert after.count("TODO: prove this") == 1
 
+
+# ──────────────────────────────────────────────────────────────────────────
+# Iter 2 false positive — snapshot must NOT update when build_check=False
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_fake_voting(tmp_path, content_lines):
+    fake = tmp_path / "VotingFake.lean"
+    body = (
+        "import Mathlib.Tactic\n"
+        "namespace TestSpace\n"
+        + "\n".join(f"-- pad {i}" for i in range(80))
+        + "\ntheorem t : True := by\n"
+        + "\n".join(content_lines)
+        + "\n"
+        + "\n".join(f"-- tail {i}" for i in range(80))
+        + "\nend TestSpace\n"
+    )
+    fake.write_text(body, encoding="utf-8")
+    return fake, body
+
+
+def test_file_replace_sorry_no_snapshot_when_build_check_false(tmp_path):
+    """build_check=False MUST NOT update best_sorry_count or best_content.
+
+    Iter 2 of demo 9 (Voting.lean L355) trace: the agent called
+    file_replace_sorry(replacement="show ?a ≦ ?b -- PROBE", build_check=False).
+    The replacement contained an invalid Lean Unicode token (U+2266 instead of
+    U+2264) which fails lake build, but best_sorry_count was promoted to 3
+    (from 4) on raw count alone because build_check was False. The autonomous
+    loop then committed that snapshot as RESULT_SUCCESS sorry 4→3.
+
+    Regression guard: with build_check=False, snapshots stay frozen.
+    """
+    import json
+    fake, body = _make_fake_voting(tmp_path, ["  sorry"])
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=84, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    initial_best = tt.best_sorry_count
+    initial_best_content = tt.best_content
+
+    # Probe with build_check=False — exactly the iter 2 sequence
+    out = json.loads(tt.file_replace_sorry(
+        sorry_line=84,
+        replacement="show ?a ≦ ?b -- PROBE",  # invalid Lean U+2266 token
+        build_check=False,
+    ))
+    assert "error" not in out, out
+    assert out["build_check"] == "skipped"
+    assert out.get("snapshot_updated") is False, (
+        "build_check=False MUST set snapshot_updated=False"
+    )
+    assert tt.best_sorry_count == initial_best, (
+        f"best_sorry_count changed without build verification: "
+        f"{initial_best} -> {tt.best_sorry_count}"
+    )
+    assert tt.best_content == initial_best_content, (
+        "best_content snapshot updated without build verification"
+    )
+
+
+def test_file_replace_lines_no_snapshot_when_build_check_false(tmp_path):
+    """Same invariant for file_replace_lines."""
+    import json
+    fake, body = _make_fake_voting(tmp_path, ["  sorry"])
+
+    state = ProofState(theorem_statement="t")
+    sctx = SorryContext(
+        filepath=str(fake), sorry_line=84, indentation=2,
+        indent_str="  ", full_file=body,
+    )
+    tt = TacticTools(state, str(fake), sctx)
+
+    initial_best = tt.best_sorry_count
+    initial_best_content = tt.best_content
+    initial_last_ok = getattr(tt, "_last_build_ok_content", None)
+
+    out = json.loads(tt.file_replace_lines(
+        start=84, end=84,
+        new_content="  show ?a ≦ ?b -- PROBE",
+        build_check=False,
+    ))
+    assert "error" not in out, out
+    assert out["build_check"] == "skipped"
+    assert out.get("snapshot_updated") is False
+    assert tt.best_sorry_count == initial_best
+    assert tt.best_content == initial_best_content
+    # _last_build_ok_content must also stay frozen — provers.py uses it as
+    # the structural-progress fallback; updating it without a build check
+    # would let an unverified snapshot leak through that path too.
+    assert getattr(tt, "_last_build_ok_content", None) == initial_last_ok, (
+        "_last_build_ok_content updated without build verification"
+    )


### PR DESCRIPTION
## Summary

Stack on PR #941. Fixes the iter 2 false positive in ai-01's prover BG run on demo 9 (Voting.lean L355).

**The bug**: agent calls `file_replace_sorry(replacement="show ?a ≦ ?b -- PROBE", build_check=False)`. Tool returns `best_sorry_count=3` (was 4), `build_check=skipped`. Workflow then commits the snapshot as `RESULT_SUCCESS sorry 4→3`. Independent `lake build`:

```
error: SocialChoice/Voting.lean:355:16: expected token
```

`≦` is U+2266 (NOT U+2264 `≤`) — invalid Lean syntax. The "best build-passing" snapshot was promoted on raw sorry count alone, no build was ever verified.

## Fix (two layers)

### 1. `tools.py` — snapshot integrity guard

Before:
```python
if build_check:
    build_err = self._build_check_or_revert(...)
    if build_err is not None: return ...

self._last_build_ok_content = new_content     # always
self._last_build_ok_sorry_count = sorry_count
if sorry_count < self._best_sorry_count:      # always
    self._best_sorry_count = sorry_count
    self._best_content = new_content
```

After:
```python
if build_check:
    build_err = self._build_check_or_revert(...)
    if build_err is not None: return ...

    # Build verified — safe to update snapshots.
    self._last_build_ok_content = new_content
    ...
```

Probes (`build_check=False`) are still allowed for cheap exploration but no longer leak into snapshots. New `snapshot_updated` field in JSON response so the agent sees whether the probe was committed or not.

### 2. `provers.py` — mandatory final verify

After the `finally:` block restores the chosen snapshot in `MultiAgentSorryProver.prove_sorry`, run an independent lake build (cache invalidated) before declaring success:

```python
_LeanVerifierFinal.invalidate(filepath)
final_verify = json.loads(tactic_tools.compile())
final_build_ok = bool(final_verify.get("level_1", False))

if not final_build_ok:
    print("FINAL VERIFY FAILED. Reverting to original.")
    Path(filepath).write_text(original_content, encoding="utf-8")
    final_sorry = original_sorry_count
    tactic_tools._best_content = None  # force-clear

# success now requires final_build_ok
success = (...) and final_build_ok
```

Addresses user feedback: "Les vérifs via build devraient faire partie intégrante du workflow du prouveur."

## Tests

2 new regression tests in `test_prover_guards.py` replay the exact iter 2 sequence:
- `test_file_replace_sorry_no_snapshot_when_build_check_false`
- `test_file_replace_lines_no_snapshot_when_build_check_false`

Both assert `snapshot_updated == False`, `best_sorry_count` and `best_content` stay frozen, and `_last_build_ok_content` stays frozen too (it's the structural-progress fallback path used by `provers.py`).

```
$ pytest tests/test_prover_guards.py -q
32 passed in 0.85s
```

## Verification

Voting.lean baseline post-revert (after iter 2 leaked the bad snapshot):
```
$ grep -c sorry SocialChoice/Voting.lean
4
$ lake build SocialChoice.Voting
Build completed successfully (3286 jobs).
```

## Test plan

- [x] 32/32 prover guard tests pass (offline, no Lean)
- [x] Voting.lean baseline builds SUCCESS
- [x] Reproduced iter 2 bad snapshot (`≦` U+2266) → verifier returns `success=False` correctly via existing returncode fallback (not the bug)
- [x] Bug isolated: best_sorry_count/best_content updated on raw count when build_check=False (real bug, fixed)
- [ ] Next prover BG run after merge will exercise the full workflow with both layers (CI doesn't have lake)

## Stack

Parent: PR #941 (comment preservation). Merge order: #941 first, then #942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)