### PR TITLE
feat(lean): SortedListCounting helper lemma scaffold (Cycle 25 ai-01 backup)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
@@ -28,3 +28,4 @@ import SocialChoice.Framework
 import SocialChoice.Arrow
 import SocialChoice.Sen
 import SocialChoice.Voting
+import SocialChoice.SortedListCounting

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
@@ -1,0 +1,98 @@
+/-
+  Sorted List Counting Lemmas
+  ===========================
+
+  Helper lemma stubs for counting elements in sorted lists relative to a pivot
+  (typically the median element at position `length / 2`).
+
+  These lemmas factor out the structural counting argument required by
+  `Voting.lean median_voter_theorem_strict` (sorries at L355 and L385).
+
+  PROOF STRATEGY (factored from Voting.lean L338-L354):
+  1. Let `l` be a sorted list with pivot at position `k = l.length / 2`.
+  2. Decompose `l = take k ++ drop k`.
+  3. By sortedness, all elements in `drop k` are ≥ `l[k]`.
+  4. Therefore `l.countP (· < l[k]) ≤ (take k).length = k`.
+  5. Symmetrically, `l.countP (l[k] ≤ ·) ≥ (drop k).length = l.length - k`.
+
+  Once these helpers are proven, Voting.lean L355 and L385 reduce to a
+  bridging argument:
+    A := Finset.filter (peaks i < median) Finset.univ
+    A.card = (univ.toList.filter (peaks · < median)).length
+           = (univ.toList.map peaks).countP (· < median)
+           = (sortedPeaksList.countP (· < median))   [by Perm.countP_eq]
+           ≤ k                                        [by countP_lt_kth_le_half]
+
+  KEY MATHLIB LEMMAS (target API):
+  - `List.Pairwise (· ≤ ·)` (sortedness primitive in current Mathlib)
+  - `List.sorted_mergeSort` / `List.mergeSort_perm`
+  - `List.Perm.countP_eq`, `List.countP_append`, `List.countP_eq_zero`
+  - `List.length_take`, `List.length_drop`, `List.take_append_drop`
+
+  STATUS: stub file with lemma signatures (sorries).
+  Cycle 25 Wave 3 ai-01 backup for po-2026 Track 2.
+  Reference: dispatched in msg-20260511T233949-r0i1xs (2026-05-11).
+-/
+
+import Mathlib.Data.List.Sort
+import Mathlib.Data.List.Count
+import Mathlib.Tactic
+
+namespace SocialChoice.SortedListCounting
+
+variable {α : Type*}
+
+/-! ## Counting elements relative to a sorted-list pivot -/
+
+/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
+    elements strictly less than `l[k]` is at most `k`.
+
+    PROOF SKETCH (TODO po-2026 Track 2):
+    - Decompose `l = l.take k ++ l.drop k` via `List.take_append_drop`.
+    - `(l.take k).length = k` by `List.length_take` (using `hk : k < l.length`).
+    - `(l.drop k).head = l[k]` by indexing.
+    - By `Pairwise.drop` and head-of-drop reasoning, all elements of `l.drop k`
+      are `≥ l[k]`.
+    - Hence `(l.drop k).countP (· < l[k]) = 0` by `List.countP_eq_zero`.
+    - Combining via `List.countP_append` and `List.countP_le_length`:
+        `l.countP (· < l[k]) = (l.take k).countP (· < l[k]) + 0 ≤ k`. -/
+theorem countP_lt_kth_le_half [LinearOrder α]
+    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
+    l.countP (fun x => decide (x < l[k])) ≤ k := by
+  sorry
+
+/-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
+    elements `≥ l[k]` is at least `l.length - k`.
+
+    Dual of `countP_lt_kth_le_half`, giving a lower bound on the
+    "right side" of the pivot.
+
+    PROOF SKETCH (TODO po-2026 Track 2):
+    - Decompose `l = l.take k ++ l.drop k`.
+    - `(l.drop k).length = l.length - k` by `List.length_drop`.
+    - All elements of `l.drop k` are `≥ l[k]` (head + sortedness).
+    - So `(l.drop k).countP (l[k] ≤ ·) = (l.drop k).length`.
+    - Adding `(l.take k).countP (l[k] ≤ ·) ≥ 0` gives the bound. -/
+theorem countP_ge_kth_ge_half_succ [LinearOrder α]
+    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
+    l.length - k ≤ l.countP (fun x => decide (l[k] ≤ x)) := by
+  sorry
+
+/-! ## Application to median voter (planned)
+
+    Once `countP_lt_kth_le_half` and `countP_ge_kth_ge_half_succ` are proven,
+    the following corollary closes Voting.lean L355 (and L385 by symmetry):
+
+    For an odd `n`, sorted list `l` of length `n`, pivot `m := l[n/2]`,
+    and predicates `P_lt := (· < m)`, `P_ge := (m ≤ ·)` :
+        l.countP P_lt < l.countP P_ge
+
+    Proof: by `countP_lt_kth_le_half`, `l.countP P_lt ≤ n/2`.
+    By `countP_ge_kth_ge_half_succ`, `l.countP P_ge ≥ n - n/2 = (n+1)/2`.
+    For odd `n = 2k+1`, `n/2 = k` and `(n+1)/2 = k+1`, hence `<`.
+
+    The bridge from `Finset.filter ... Finset.univ` to `List.countP` uses
+    `Finset.length_toList`, `List.countP_map`, `List.length_filter_eq_countP`,
+    and `List.Perm.countP_eq` (for mergeSort). -/
+
+end SocialChoice.SortedListCounting


### PR DESCRIPTION
## Summary

New file `SocialChoice/SortedListCounting.lean` (+99 lines, 1 import line in `SocialChoice.lean` root) introducing two helper lemma signatures with proof scaffolds for the median-voter counting argument:

```lean
theorem countP_lt_kth_le_half [LinearOrder α]
    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
    l.countP (fun x => decide (x < l[k])) ≤ k := by sorry

theorem countP_ge_kth_ge_half_succ [LinearOrder α]
    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
    l.length - k ≤ l.countP (fun x => decide (l[k] ≤ x)) := by sorry
```

Both lemmas use `sorry` placeholders with detailed PROOF SKETCH comments documenting the `take/drop` decomposition strategy + key Mathlib lemmas referenced.

## Why

Backup for **po-2026 Wave 3 Track 2** (helper lemma extraction) — po-2026 silent overnight (>3h post-Wave 3 dispatch msg-20260511T233949-r0i1xs). Rather than leaving the file unwritten, ai-01 provides scaffolding so future prover sessions or po-2026 (if they wake up) can refine the stubs into full proofs.

## Sorry count integrity

| File | Before | After | Note |
|------|--------|-------|------|
| **SocialChoice/SortedListCounting.lean** | N/A (new) | 2 | Intentional scaffolding (not regression) |
| **SocialChoice/Voting.lean** | 3 | 3 | Unchanged (L261 honest FIXME + L355 LT + L385 GT) |
| **TOTAL project** | 3 | 5 | +2 NEW intentional sorries in scaffold file |

Per CLAUDE.md sec D Anti-régression : these sorries are NEW in a NEW file, not replacing existing proofs. Intent documented in module docstring + PROOF SKETCH comments. Reference: dispatched in msg-20260511T233949-r0i1xs.

## Test plan

- [x] `lake build SocialChoice.SortedListCounting` SUCCESS (3285 jobs, 7.2s)
- [x] `lake build` (full project) SUCCESS (3292 jobs, 7.6s)
- [x] Module added to `SocialChoice.lean` root import list
- [x] No change to existing files (Voting.lean L355/L385 sorries preserved as documented)
- [x] G.4 OK : 2 files, +99/-0 (Lean infrastructure file with sorries, not docs-only)

## Future work (post-merge)

Once `countP_lt_kth_le_half` and `countP_ge_kth_ge_half_succ` are proven (currently 2 sorries), they reduce Voting.lean L355/L385 to:

```
A := Finset.filter (peaks i < median) Finset.univ
A.card = (univ.toList.map peaks).countP (· < median)   [bridge via Perm.countP_eq]
       ≤ k                                              [by countP_lt_kth_le_half]
```

This unblocks the Voting median voter theorem strict version.

## Disclosure (G.6)

Self-merge by ai-01 (coord). Justification :
- Cluster overnight (po-2026 silent >3h post-dispatch)
- Pure scaffolding work (no claim of progress on Voting.lean sorries)
- Lake build verified SUCCESS
- Clear documentation that this is a backup — po-2026 retains Track 2 dispatch ownership for full proofs

— ai-01 coord, 2026-05-12T~04:55Z (UTC 02:55Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)