### PR TITLE
feat(lean): prove SortedListCounting helper lemmas (Cycle 25 ai-01)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
@@ -57,9 +57,32 @@ variable {α : Type*}
     - Combining via `List.countP_append` and `List.countP_le_length`:
         `l.countP (· < l[k]) = (l.take k).countP (· < l[k]) + 0 ≤ k`. -/
 theorem countP_lt_kth_le_half [LinearOrder α]
-    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
     l.countP (fun x => decide (x < l[k])) ≤ k := by
-  sorry
+  set p : α := l[k] with hp
+  have hsplit : l = l.take k ++ l.drop k := (List.take_append_drop k l).symm
+  conv_lhs => rw [hsplit]
+  rw [List.countP_append]
+  have h1 : (l.take k).countP (fun x => decide (x < p)) ≤ k := by
+    calc (l.take k).countP (fun x => decide (x < p))
+        ≤ (l.take k).length := List.countP_le_length
+      _ = min k l.length := List.length_take
+      _ ≤ k := min_le_left _ _
+  have h2 : (l.drop k).countP (fun x => decide (x < p)) = 0 := by
+    apply List.countP_eq_zero.mpr
+    intro x hx
+    simp only [decide_eq_true_eq, not_lt, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_drop]
+    have hki_lt : k + i < l.length := by
+      have hi' := hi
+      rw [List.length_drop] at hi'
+      omega
+    by_cases hi0 : i = 0
+    · subst hi0; simp
+    · have hlt : k < k + i := by omega
+      exact List.pairwise_iff_getElem.mp hsort k (k + i) hk hki_lt hlt
+  omega
 
 /-- For a list `l` sorted with `(· ≤ ·)` and pivot `l[k]`, the number of
     elements `≥ l[k]` is at least `l.length - k`.
@@ -74,9 +97,29 @@ theorem countP_lt_kth_le_half [LinearOrder α]
     - So `(l.drop k).countP (l[k] ≤ ·) = (l.drop k).length`.
     - Adding `(l.take k).countP (l[k] ≤ ·) ≥ 0` gives the bound. -/
 theorem countP_ge_kth_ge_half_succ [LinearOrder α]
-    {l : List α} (_hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (_hk : k < l.length) :
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
     l.length - k ≤ l.countP (fun x => decide (l[k] ≤ x)) := by
-  sorry
+  set p : α := l[k] with hp
+  have hsplit : l = l.take k ++ l.drop k := (List.take_append_drop k l).symm
+  conv_rhs => rw [hsplit]
+  rw [List.countP_append]
+  have hdrop_all : (l.drop k).countP (fun x => decide (p ≤ x)) = (l.drop k).length := by
+    rw [List.countP_eq_length]
+    intro x hx
+    simp only [decide_eq_true_eq, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_drop]
+    have hki_lt : k + i < l.length := by
+      have hi' := hi
+      rw [List.length_drop] at hi'
+      omega
+    by_cases hi0 : i = 0
+    · subst hi0; simp
+    · have hlt : k < k + i := by omega
+      exact List.pairwise_iff_getElem.mp hsort k (k + i) hk hki_lt hlt
+  have hdrop_len : (l.drop k).length = l.length - k := List.length_drop
+  rw [hdrop_all, hdrop_len]
+  omega
 
 /-! ## Application to median voter (planned)
 


### PR DESCRIPTION
## Summary

Both helper lemmas in `SocialChoice/SortedListCounting.lean` are now **proven** (no more `sorry`):

- `countP_lt_kth_le_half`: For a sorted list `l` and pivot `l[k]`, the number of elements strictly less than the pivot is at most `k`.
- `countP_ge_kth_ge_half_succ`: For a sorted list `l` and pivot `l[k]`, the number of elements `≥` pivot is at least `l.length - k`.

These are the exact lemmas dispatched to po-2026 (Wave 3 Track 2) but still pending after ~6h cluster overnight. ai-01 picked them up to keep the prover unblocked.

## Proof strategy (matches the file's PROOF SKETCH comments)

1. Decompose `l = l.take k ++ l.drop k` via `List.take_append_drop`
2. `List.pairwise_iff_getElem.mp hsort k (k+i) ... (k < k+i)` — extracts `l[k] ≤ l[k+i]` from the `Pairwise (· ≤ ·)` hypothesis (use `i = 0` branch separately as `l[k+0] = l[k]` and reflexivity)
3. On `l.take k`: bound count by length via `List.countP_le_length`, length is `min k l.length ≤ k`
4. On `l.drop k`: count of `(· < l[k])` is `0` by `List.countP_eq_zero` (all elements ≥ pivot); count of `(l[k] ≤ ·)` equals length `l.length - k` by `List.countP_eq_length`
5. Combine via `List.countP_append` + `omega`

## Sorry count delta

| File | Before | After |
|------|--------|-------|
| `SortedListCounting.lean` | 2 (scaffolding) | **0** |
| `Voting.lean` | 4 | 4 (untouched) |
| `Arrow.lean` / `Sen.lean` / `Framework.lean` / `Basic.lean` | 0 | 0 (certified) |
| **Project total** | **6** | **4 (-33%)** |

## Build proof

```
$ lake build
✔ [3291/3292] Built SocialChoice (7.2s)
Build completed successfully (3292 jobs).
```

`SocialChoice.SortedListCounting` builds independently in 7.7s with **no `sorry` warnings**.

## CLAUDE.md compliance

- **G.2 (honest verdict)**: 2 sorries genuinely eliminated, project sorry count -2 verified by `grep -c sorry`. No `sorry` introduced anywhere.
- **G.4 (split)**: 1 file, 47 insertions / 4 deletions — focused single-purpose PR.
- **anti-regression D**: only adds proofs; no existing code/proof deleted.

## Bénéfice immédiat for Voting.lean L355 / L385

Once a future PR plumbs the bridge `Finset.filter ... Finset.univ → List.countP` (already documented in the file's docstring `## Application to median voter`), `Voting.lean` L355 (LT case) and L385 (GT case) reduce to these two helpers. po-2026 Track 1 (prover retry on L355) and `median_voter_theorem_strict` are now structurally unblocked.

## Test plan

- [x] `lake build` SUCCESS, 3292 jobs
- [x] `grep -c sorry` SortedListCounting.lean = 0
- [x] CI green on push (Lake build + Proof integrity + Staleness)
- [ ] Bot review (clusterManager-Myia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)