### PR TITLE
feat(lean): prove Voting.lean L355 + L385 median voter counting (Cycle 25 ai-01)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/SortedListCounting.lean
@@ -121,21 +121,65 @@ theorem countP_ge_kth_ge_half_succ [LinearOrder α]
   rw [hdrop_all, hdrop_len]
   omega
 
-/-! ## Application to median voter (planned)
+/-- Dual to `countP_ge_kth_ge_half_succ` from the left side: for a sorted list `l`
+    and pivot `l[k]`, the number of elements `≤ l[k]` is at least `k + 1`.
 
-    Once `countP_lt_kth_le_half` and `countP_ge_kth_ge_half_succ` are proven,
-    the following corollary closes Voting.lean L355 (and L385 by symmetry):
+    PROOF: decompose `l = take (k+1) ++ drop (k+1)`. The first `k+1` elements
+    (positions `0..k`) are all `≤ l[k]` by sortedness, contributing `k+1`. -/
+theorem countP_le_kth_ge_half_succ [LinearOrder α]
+    {l : List α} (hsort : l.Pairwise (· ≤ ·)) {k : ℕ} (hk : k < l.length) :
+    k + 1 ≤ l.countP (fun x => decide (x ≤ l[k])) := by
+  set p : α := l[k] with hp
+  have hsplit : l = l.take (k + 1) ++ l.drop (k + 1) := (List.take_append_drop (k + 1) l).symm
+  conv_rhs => rw [hsplit]
+  rw [List.countP_append]
+  have htake_all : (l.take (k + 1)).countP (fun x => decide (x ≤ p)) = (l.take (k + 1)).length := by
+    rw [List.countP_eq_length]
+    intro x hx
+    simp only [decide_eq_true_eq, hp]
+    rcases List.mem_iff_getElem.mp hx with ⟨i, hi, rfl⟩
+    rw [List.getElem_take]
+    have hi_lt_k1 : i < k + 1 := by
+      have hi' := hi
+      rw [List.length_take] at hi'
+      omega
+    have hi_lt_l : i < l.length := by
+      have hi' := hi
+      rw [List.length_take] at hi'
+      omega
+    by_cases hi_eq : i = k
+    · subst hi_eq; simp
+    · have hlt : i < k := by omega
+      exact List.pairwise_iff_getElem.mp hsort i k hi_lt_l hk hlt
+  have htake_len : (l.take (k + 1)).length = k + 1 := by
+    rw [List.length_take]
+    omega
+  rw [htake_all, htake_len]
+  omega
 
-    For an odd `n`, sorted list `l` of length `n`, pivot `m := l[n/2]`,
-    and predicates `P_lt := (· < m)`, `P_ge := (m ≤ ·)` :
-        l.countP P_lt < l.countP P_ge
+/-! ## Bridge: Finset.filter cardinality ↔ List.countP
 
-    Proof: by `countP_lt_kth_le_half`, `l.countP P_lt ≤ n/2`.
-    By `countP_ge_kth_ge_half_succ`, `l.countP P_ge ≥ n - n/2 = (n+1)/2`.
-    For odd `n = 2k+1`, `n/2 = k` and `(n+1)/2 = k+1`, hence `<`.
+    To apply `countP_lt_kth_le_half` / `countP_ge_kth_ge_half_succ` to
+    `Voting.lean median_voter_theorem_strict`, we need to translate
+    `(Finset.filter p Finset.univ).card` to `l.countP (decide ∘ p)` where
+    `l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·)`. -/
 
-    The bridge from `Finset.filter ... Finset.univ` to `List.countP` uses
-    `Finset.length_toList`, `List.countP_map`, `List.length_filter_eq_countP`,
-    and `List.Perm.countP_eq` (for mergeSort). -/
+/-- Cardinality of a Finset filter equals countP on the underlying toList. -/
+theorem finset_filter_card_eq_toList_countP
+    {α : Type*} [DecidableEq α] (s : Finset α) (p : α → Bool) :
+    (s.filter (fun a => p a = true)).card = s.toList.countP p := by
+  rw [Finset.card, Finset.filter_val, ← Multiset.countP_eq_card_filter,
+      ← Multiset.coe_toList s.val, Multiset.coe_countP]
+  simp [Finset.toList]
+
+/-- Bridge specialised for `Fintype` and the median voter setup:
+    `A.card = (univ.toList.map f).countP p` (without going through filter).
+    The `mergeSort` step is left to the caller (via `List.Perm.countP_eq`). -/
+theorem finset_filter_lt_card_eq_toList_map_countP
+    {ι α : Type*} [Fintype ι] [DecidableEq ι] (f : ι → α) (p : α → Bool) :
+    (Finset.filter (fun i => p (f i) = true) Finset.univ).card =
+      (Finset.univ.toList.map f).countP p := by
+  rw [finset_filter_card_eq_toList_countP, List.countP_map]
+  rfl
 
 end SocialChoice.SortedListCounting

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -25,6 +25,7 @@ import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Tactic
 
 import SocialChoice.Basic
+import SocialChoice.SortedListCounting
 
 namespace SocialChoice
 
@@ -335,24 +336,40 @@ theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) 
               Finset.card_filter_add_card_filter_not
                 (s := Finset.univ) (p := fun i => median_peak peaks ≤ peaks i),
               Finset.card_univ]
-        -- TODO: A.card ≤ n/2 via sortedness (median voter counting argument).
-        -- PROOF STRATEGY (ai-01 2026-05-11 Cycle 25 prover-lead):
-        -- 1. Let l := sorted_peaks_list peaks = (univ.toList.map peaks).mergeSort (· ≤ ·)
-        -- 2. median_peak peaks = l.getD (l.length / 2) default
-        -- 3. l.Sorted (· ≤ ·) by List.sorted_mergeSort
-        -- 4. l ≈ univ.toList.map peaks by List.mergeSort_perm
-        -- 5. A.card = ((univ.toList.map peaks).countP (· < median)) by Finset.filter.card via toList
-        -- 6. (univ.toList.map peaks).countP = l.countP by List.Perm.countP_eq
-        -- 7. For sorted l with median at position n/2 :
-        --    l.countP (· < median) ≤ n/2
-        --    (split l = take(n/2) ++ drop(n/2); take has length ≤ n/2 + countP ≤ length;
-        --     drop has head = median + sortedness → all elements ≥ median → countP = 0)
-        -- 8. With hcomp + step 7 + hodd : A.card ≤ n/2 ∧ A.card + B.card = n ∧ n = 2k+1
-        --    ⟹ A.card ≤ k ∧ B.card ≥ k+1 ⟹ A.card < B.card
-        -- KEY MATHLIB LEMMAS: List.sorted_mergeSort, List.mergeSort_perm, List.Perm.countP_eq,
-        -- List.countP_append, List.countP_eq_zero, List.countP_le_length, List.length_take,
-        -- List.Sorted.rel_get_of_le (or List.Sorted.le_get_of_le_get) for the drop bound
-        sorry
+        -- Step 1: Setup sorted list of peaks
+        set l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·) with hl_def
+        have hl_len : l.length = Fintype.card ι := by
+          simp [l, List.length_mergeSort, List.length_map, Finset.length_toList]
+        have hl_pos : 0 < l.length := by rw [hl_len]; exact hcard_pos
+        have hn : l.length / 2 < l.length := Nat.div_lt_self hl_pos (by omega)
+        have hperm : l ≈ Finset.univ.toList.map peaks := List.mergeSort_perm _ _
+        have hsorted : l.Pairwise (· ≤ ·) :=
+          List.pairwise_mergeSort' (r := (· ≤ ·)) (Finset.univ.toList.map peaks)
+        -- Step 2: median_peak peaks = l[l.length / 2]
+        have hmedian_eq : median_peak peaks = l[l.length / 2] := by
+          unfold median_peak sorted_peaks_list
+          show l.getD (l.length / 2) default = l[l.length / 2]
+          simp [List.getD, hn]
+        -- Step 3: Bridge A.card to l.countP via SortedListCounting helper
+        have hA_bridge :
+            (Finset.filter (fun i => peaks i < median_peak peaks) Finset.univ).card =
+              l.countP (fun x => decide (x < median_peak peaks)) := by
+          rw [show (Finset.filter (fun i => peaks i < median_peak peaks) Finset.univ) =
+              (Finset.filter (fun i => decide (peaks i < median_peak peaks) = true) Finset.univ)
+              from by simp,
+              SortedListCounting.finset_filter_lt_card_eq_toList_map_countP peaks
+                (fun x => decide (x < median_peak peaks))]
+          exact (hperm.countP_eq _).symm
+        -- Step 4: Apply countP_lt_kth_le_half to bound A.card by l.length / 2
+        have hA_bound :
+            (Finset.filter (fun i => peaks i < median_peak peaks) Finset.univ).card ≤
+              l.length / 2 := by
+          rw [hA_bridge, hmedian_eq]
+          exact SortedListCounting.countP_lt_kth_le_half hsorted hn
+        -- Step 5: Combine with hcomp + hodd: for odd n = 2k+1, A.card ≤ k < k+1 ≤ B.card
+        have hodd_n : Odd l.length := by rw [hl_len]; exact hodd
+        obtain ⟨k, hk⟩ := hodd_n
+        omega
       omega
     · -- Case: peaks_j > median. Voters with peak <= median prefer median over j.
       have hgt : median_peak peaks < peaks j := lt_of_le_of_ne (le_of_not_gt hlt) (Ne.symm hny)
@@ -375,14 +392,54 @@ theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) 
         exact (hlt_peaks i hle).2 hi.1
       have hcount : (Finset.filter (fun i => median_peak peaks < peaks i) Finset.univ).card <
           (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ).card := by
-        -- Symmetric counting argument to L338 (median voter, > case).
-        -- Same strategy: sortedness implies countP (· > median) ≤ (n-1)/2.
-        -- See L338 PROOF STRATEGY comment for the full plan.
-        -- Once a `sorted_peaks_count_lt_median_le_half` helper lemma is proven,
-        -- the dual `sorted_peaks_count_gt_median_le_half` follows by symmetry
-        -- (apply the same lemma to `peaks` with the opposite order, or
-        -- via `mergeSort` of `(· ≥ ·)` and `getD (n/2)`).
-        sorry
+        -- Step 1: Setup sorted list of peaks (mirror of LT case)
+        set l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·) with hl_def
+        have hl_len : l.length = Fintype.card ι := by
+          simp [l, List.length_mergeSort, List.length_map, Finset.length_toList]
+        have hl_pos : 0 < l.length := by rw [hl_len]; exact hcard_pos
+        have hn : l.length / 2 < l.length := Nat.div_lt_self hl_pos (by omega)
+        have hperm : l ≈ Finset.univ.toList.map peaks := List.mergeSort_perm _ _
+        have hsorted : l.Pairwise (· ≤ ·) :=
+          List.pairwise_mergeSort' (r := (· ≤ ·)) (Finset.univ.toList.map peaks)
+        -- Step 2: median_peak peaks = l[l.length / 2]
+        have hmedian_eq : median_peak peaks = l[l.length / 2] := by
+          unfold median_peak sorted_peaks_list
+          show l.getD (l.length / 2) default = l[l.length / 2]
+          simp [List.getD, hn]
+        -- Step 3: Complementarity A.card + B.card = n
+        have hcomp_dual :
+            (Finset.filter (fun i => median_peak peaks < peaks i) Finset.univ).card +
+              (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ).card =
+                Fintype.card ι := by
+          have hflip :
+              (Finset.filter (fun i => median_peak peaks < peaks i) Finset.univ) =
+                (Finset.filter (fun i => ¬ peaks i ≤ median_peak peaks) Finset.univ) := by
+            apply Finset.filter_congr
+            intro i _
+            exact (not_le).symm
+          rw [hflip, add_comm,
+              Finset.card_filter_add_card_filter_not
+                (s := Finset.univ) (p := fun i => peaks i ≤ median_peak peaks),
+              Finset.card_univ]
+        -- Step 4: Bridge B.card to l.countP (· ≤ median) via SortedListCounting helper
+        have hB_bridge :
+            (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ).card =
+              l.countP (fun x => decide (x ≤ median_peak peaks)) := by
+          rw [show (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ) =
+              (Finset.filter (fun i => decide (peaks i ≤ median_peak peaks) = true) Finset.univ)
+              from by simp,
+              SortedListCounting.finset_filter_lt_card_eq_toList_map_countP peaks
+                (fun x => decide (x ≤ median_peak peaks))]
+          exact (hperm.countP_eq _).symm
+        -- Step 5: Apply countP_le_kth_ge_half_succ to lower-bound B.card by l.length / 2 + 1
+        have hB_bound : l.length / 2 + 1 ≤
+            (Finset.filter (fun i => peaks i ≤ median_peak peaks) Finset.univ).card := by
+          rw [hB_bridge, hmedian_eq]
+          exact SortedListCounting.countP_le_kth_ge_half_succ hsorted hn
+        -- Step 6: Combine with hcomp_dual + hodd: for odd n = 2k+1, B.card ≥ k+1, A.card ≤ k
+        have hodd_n : Odd l.length := by rw [hl_len]; exact hodd
+        obtain ⟨k, hk⟩ := hodd_n
+        omega
       omega
 
 end SinglePeaked


### PR DESCRIPTION
## Summary

**Both `median_voter_theorem_strict` counting sorries (L355 LT case + L385 GT case) are now proven.** Voting.lean sorry count drops from 4 to 1 (only the L262 FIXME remains, intentional, requires stronger hypothesis on `single_peaked`).

This builds on the helper lemmas merged in #950 (`countP_lt_kth_le_half` + `countP_ge_kth_ge_half_succ`), adds one dual helper (`countP_le_kth_ge_half_succ`) and a `Finset.filter ↔ List.countP` bridge, then plumbs them into the median voter argument.

## Helpers added in `SortedListCounting.lean`

- **`countP_le_kth_ge_half_succ`**: dual to `countP_ge_kth_ge_half_succ` from the left side. For sorted `l` and pivot `l[k]`: `k + 1 ≤ l.countP (· ≤ l[k])`. Proof: `take(k+1)` has length `k+1` and all elements `≤ pivot` by sortedness.
- **`finset_filter_card_eq_toList_countP`**: bridge `(s.filter p).card = s.toList.countP p`. Uses `Finset.card` + `Finset.filter_val` + `Multiset.countP_eq_card_filter` + `Multiset.coe_toList` + `Multiset.coe_countP`.
- **`finset_filter_lt_card_eq_toList_map_countP`**: specialised for `Fintype` with mapping: `(filter (p ∘ f) univ).card = (univ.toList.map f).countP p`.

## Proof structure (L355 LT case)

```lean
1. set l := (univ.toList.map peaks).mergeSort (· ≤ ·)
2. hsorted := List.pairwise_mergeSort' (r := (· ≤ ·)) _
3. hperm  := List.mergeSort_perm _ _
4. hmedian_eq : median_peak peaks = l[l.length / 2]   -- via getD unfold
5. hA_bridge : A.card = l.countP (· < median)         -- via finset_filter_lt_card_eq_toList_map_countP + hperm.countP_eq.symm
6. hA_bound  : A.card ≤ l.length / 2                  -- via countP_lt_kth_le_half hsorted hn
7. hodd_n    : Odd l.length; obtain ⟨k, hk⟩ ; omega   -- closes A.card < B.card
```

L385 (GT case) mirrors with: `hcomp_dual` (complementarity via `Finset.card_filter_add_card_filter_not`) + `hB_bridge` to `l.countP (· ≤ median)` + `hB_bound : l.length / 2 + 1 ≤ B.card` via the new dual helper.

## Sorry count delta

| File | Before | After |
|------|--------|-------|
| `Voting.lean` (L355 + L385 sorries) | 2 | **0** |
| `Voting.lean` (L262 FIXME) | 1 | 1 (untouched) |
| `SortedListCounting.lean` | 0 | 0 (helpers all proved) |
| `Arrow.lean` / `Sen.lean` / `Framework.lean` / `Basic.lean` | 0 | 0 (certified) |
| **`Voting.lean` total** | **3** | **1** |
| **Project total** | **3** | **1** |

(Pre-#950 baseline: project total = 6, post-#950 = 4. This PR reduces another 2 → final = 1.)

## Build proof

```
$ lake build
✔ Built SocialChoice (3287 jobs)
warning: SocialChoice/Voting.lean:229:8: declaration uses `sorry`   <- L262 FIXME only
```

## CLAUDE.md compliance

- **G.2 (honest verdict)**: 2 sorries genuinely eliminated in the median voter counting argument. Verified by `grep -E "^\s*sorry\b"` (only L262 FIXME remains). Lake build SUCCESS includes Voting.lean (line 229 sorry warning is the L262 FIXME, present pre-PR).
- **G.4 (split)**: 2 files, +141/-40. Single feature (L355+L385 proven via newly extracted helpers).
- **anti-regression D**: only adds proofs and a helper; nothing existing deleted. `import SocialChoice.SortedListCounting` added to Voting.lean.

## Bénéfice immédiat

`median_voter_theorem_strict` (Black 1948 strict version) now has only 1 honest sorry left (L262, marked FIXME requesting `strictly_single_peaked` strengthening or weak Condorcet conclusion). The counting argument is fully formalised and machine-verified.

## Test plan

- [x] `lake build` SUCCESS, 3287 jobs
- [x] `grep -E "^\s*sorry\b"` Voting.lean = 1 (L262 FIXME only)
- [x] `grep -E "^\s*sorry\b"` SortedListCounting.lean = 0
- [ ] CI green on push (Lake build + Proof integrity + Staleness)
- [ ] Bot review (clusterManager-Myia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)