### PR TITLE
feat(lean): prover DirectorAgent architecture (Track C)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -11,6 +11,7 @@ from .instructions import (
     TACTIC_AGENT_INSTRUCTIONS,
     CRITIC_AGENT_INSTRUCTIONS,
     COORDINATOR_AGENT_INSTRUCTIONS,
+    DIRECTOR_AGENT_INSTRUCTIONS,
 )
 from .tools import SearchTools, TacticTools, CriticTools, CoordinatorTools
 
@@ -109,4 +110,26 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
         ],
         name="CoordinatorAgent",
         default_options=_reasoning_options(),
+    )
+
+
+DIRECTOR_MAX_TOKENS = 512
+
+
+def create_director_agent(provider: str = "openrouter") -> Agent:
+    """DirectorAgent: external LLM providing strategic tactic guidance.
+
+    Uses a more powerful model (GPT-5.5 via OpenRouter) to suggest
+    proof approaches when local agents fail. No tools — pure text output
+    with structured tactic suggestions.
+
+    Budget: max 500 tokens, max 3 calls per iteration.
+    """
+    client = create_client(provider, model_key="reasoning")
+    return Agent(
+        client=client,
+        instructions=DIRECTOR_AGENT_INSTRUCTIONS,
+        tools=[],
+        name="DirectorAgent",
+        default_options=ChatOptions(max_tokens=DIRECTOR_MAX_TOKENS),
     )

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -121,6 +121,15 @@ OUTILS:
    prouveur passera a un autre sorry au prochain run. PREFERE ABANDON EXPLICITE
    plutot que de bruler les iterations sur un mur connu.
 
+DIRECTEUR EXTERNE (optionnel):
+- Si un directeur externe (modele plus puissant) est disponible et que tes
+  agents locaux sont en echec persistant (2+ plans tentes, F1 escalation recue),
+  tu peux demander un conseil tactique en appelant designate_next_agent("director").
+- Le directeur recevra le but, les hypotheses et les tentatives echouees, puis
+  suggera une approche tactique. Le TacticAgent local appliquera la suggestion.
+- Budget limite a 3 appels directeur par session — utilise-le uniquement quand
+  la strategie locale est epuisee, pas en premiere intention.
+
 REGLE D'OR (set_attack_plan):
 - TOUJOURS au moins 2 etapes, formulees en NATUREL ("isoler la conjonction",
   "borner A.card par n/2 via tri", "combiner avec hcomp puis omega")
@@ -133,6 +142,7 @@ QUAND REVENIR (apres TacticAgent / Critic):
 - 3+ echecs consecutifs sur le meme sous-but → reformule la strategie
 - Decomposition introduit un nouveau sorry → ajoute une etape pour ce sous-but
 - Plan inadapte (TacticAgent calle) → set_attack_plan a nouveau (remplace)
+- 2+ plans tentes sans progres → envisage designate_next_agent("director")
 
 Exemple de bon plan (methodologique, pas de tactique):
   set_attack_plan(
@@ -148,6 +158,26 @@ INTERDIT:
 - set_attack_plan() sans argument ni avec liste vide → plan inutilisable
 - mettre des tactiques Lean (omega, simp, exact ...) dans les steps
 - repeter le meme plan apres echec sans modification"""
+
+DIRECTOR_AGENT_INSTRUCTIONS = """Expert Lean 4. Tu reçois le but courant, les hypotheses, et les tentatives echouees.
+Propose UNIQUEMENT la prochaine sequence tactique (3-5 lignes max). Pas d'explication longue.
+
+FORMAT DE SORTIE (obligatoire):
+```
+APPROACH: <1 phrase decrivant la strategie>
+TACTICS:
+<tactique 1>
+<tactique 2>
+...
+```
+
+REGLES:
+- Max 500 tokens de sortie
+- Pas de sorry dans tes suggestions
+- Si le but semble hors de portee, dis LEAVERN (abandon)
+- Adapte tes suggestions aux ERREURS PASSEES (ne repete pas ce qui a echoue)
+- Tu peux suggérer des `have` intermediaires pour decomposer
+- Priorise les tactiques Mathlib disponibles sur les raisonnements from-scratch"""
 
 AUTONOMOUS_PROVER_INSTRUCTIONS = """Prouveur autonome. Edite directement le fichier .lean.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -24,6 +24,7 @@ from .agents import (
     create_tactic_agent,
     create_critic_agent,
     create_coordinator_agent,
+    create_director_agent,
 )
 from .workflow import ProofWorkflowBuilder, ProofMessage
 from .instructions import AUTONOMOUS_PROVER_INSTRUCTIONS
@@ -91,10 +92,12 @@ class MultiAgentSorryProver:
     """
 
     def __init__(self, trace: TraceLogger, provider: str = "zai",
-                 local_provider: str = "local"):
+                 local_provider: str = "local",
+                 director_provider: Optional[str] = None):
         self.trace = trace
         self.provider = provider
         self.local_provider = local_provider
+        self.director_provider = director_provider
 
     async def prove_sorry(self, demo: dict, max_iterations: int = 10,
                           workflow_timeout_s: Optional[int] = None) -> dict:
@@ -188,10 +191,21 @@ class MultiAgentSorryProver:
         critic_agent = create_critic_agent(critic_tools, provider=self.provider)
         coordinator_agent = create_coordinator_agent(coordinator_tools, provider=self.provider)
 
+        # Create optional DirectorAgent (external LLM for strategic guidance)
+        director_agent = None
+        if self.director_provider:
+            try:
+                director_agent = create_director_agent(provider=self.director_provider)
+                print(f"  [DIRECTOR] enabled provider={self.director_provider}")
+            except Exception as e:
+                print(f"  [DIRECTOR] FAILED to create: {e}")
+                director_agent = None
+
         # Build workflow graph (kb shared with SearchTools)
         workflow_builder = ProofWorkflowBuilder(
             search_agent, tactic_agent, critic_agent, coordinator_agent,
             sorry_ctx, demo.get("imports", ""), self.trace, state=state, kb=kb,
+            director_agent=director_agent,
         )
         workflow = workflow_builder.build()
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -64,6 +64,9 @@ class ProofMessage:
     # AgentExecutor yields immediately when this is true.
     intractable: bool = False
     intractable_reason: Optional[str] = None
+    # Director (Track C): counts how many times the DirectorAgent has been
+    # consulted this session. Capped at 3 to avoid budget burn.
+    director_calls: int = 0
 
 
 class AgentExecutor(Executor):
@@ -180,6 +183,15 @@ class AgentExecutor(Executor):
         if self._agent.name == "CoordinatorAgent" and self._state and not msg.plan:
             if self._state.plan:
                 msg.plan = list(self._state.plan)
+
+        # Director call tracking
+        if self._agent.name == "DirectorAgent":
+            msg.director_calls += 1
+            if self._trace:
+                self._trace.log(
+                    agent="DirectorAgent", role="director_call",
+                    content=f"director call {msg.director_calls}/3",
+                )
 
         # F5: Coordinator can mark the current sorry intractable. End the
         # session cleanly so we don't waste iterations on a known-dead goal.
@@ -395,18 +407,33 @@ class VerifyExecutor(Executor):
 
 
 class ProofWorkflowBuilder:
-    """Builds the multi-agent proof workflow graph."""
+    """Builds the multi-agent proof workflow graph.
+
+    Optional DirectorAgent: external LLM (e.g. GPT-5.5 via OpenRouter) that
+    provides strategic tactic suggestions when local agents stall. Inserted
+    into the graph after F1 Coordinator escalation, so the flow becomes:
+        Coordinator (stalled) -> Director -> Tactic (retry with guidance)
+    The director has no tools — pure text output with APPROACH + TACTICS.
+    Budget: max 3 calls per session, tracked via ``msg.director_calls``.
+    """
 
     def __init__(self, search_agent: Agent, tactic_agent: Agent,
                  critic_agent: Agent, coordinator_agent: Agent,
                  sorry_context: SorryContext, imports: str,
                  trace: TraceLogger = None, state: "ProofState" = None,
-                 kb: Optional[ProofKnowledgeBase] = None):
+                 kb: Optional[ProofKnowledgeBase] = None,
+                 director_agent: Optional[Agent] = None):
         self._search = AgentExecutor(search_agent, trace=trace, state=state)
         self._tactic = AgentExecutor(tactic_agent, trace=trace, state=state)
         self._critic = AgentExecutor(critic_agent, trace=trace, state=state)
         self._coordinator = AgentExecutor(coordinator_agent, trace=trace, state=state)
         self._verify = VerifyExecutor(sorry_context, imports, trace, kb=kb)
+        self._director: Optional[AgentExecutor] = (
+            AgentExecutor(director_agent, trace=trace, state=state,
+                          timeout_s=120)
+            if director_agent else None
+        )
+        self._director_max_calls = 3
 
     def build(self):
         # B.3: CoordinatorAgent runs FIRST to set attack plan, then routes to
@@ -421,6 +448,10 @@ class ProofWorkflowBuilder:
         # Forward chain: search -> tactic -> verify
         builder.add_edge(self._search, self._tactic)
         builder.add_edge(self._tactic, self._verify)
+
+        # Director -> tactic (director suggests tactics, TacticAgent applies)
+        if self._director:
+            builder.add_edge(self._director, self._tactic)
 
         # Verify routes via switch-case so the "tactic" backedge and the
         # default critic path don't collide as duplicate edges either. F1
@@ -459,16 +490,39 @@ class ProofWorkflowBuilder:
             ],
         )
 
-        # Coordinator routing (requires exactly one Default)
-        builder.add_switch_case_edge_group(
-            source=self._coordinator,
-            cases=[
-                Case(
-                    condition=lambda msg: msg.next_agent == "tactic",
-                    target=self._tactic,
-                ),
-                Default(target=self._search),
-            ],
-        )
+        # Coordinator routing — with optional Director escalation.
+        # When the Coordinator determines local agents are stalled it can
+        # request director guidance by setting next_agent="director".
+        # The guard caps director calls to avoid budget burn; if the cap
+        # is hit the coordinator falls through to search (normal path).
+        if self._director:
+            builder.add_switch_case_edge_group(
+                source=self._coordinator,
+                cases=[
+                    Case(
+                        condition=lambda msg: (
+                            msg.next_agent == "director"
+                            and msg.director_calls < self._director_max_calls
+                        ),
+                        target=self._director,
+                    ),
+                    Case(
+                        condition=lambda msg: msg.next_agent == "tactic",
+                        target=self._tactic,
+                    ),
+                    Default(target=self._search),
+                ],
+            )
+        else:
+            builder.add_switch_case_edge_group(
+                source=self._coordinator,
+                cases=[
+                    Case(
+                        condition=lambda msg: msg.next_agent == "tactic",
+                        target=self._tactic,
+                    ),
+                    Default(target=self._search),
+                ],
+            )
 
         return builder.build()

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -63,6 +63,7 @@ async def main(args: argparse.Namespace) -> int:
     _bg(f"DIFF  {demo.get('difficulty')}")
     _bg(
         f"PROVIDER reasoning={args.provider} fast={args.local_provider} "
+        f"director={args.director_provider or 'none'} "
         f"max_iter={args.max_iter} workflow_timeout={args.workflow_timeout}s"
     )
 
@@ -78,6 +79,7 @@ async def main(args: argparse.Namespace) -> int:
         trace=tr,
         provider=args.provider,
         local_provider=args.local_provider,
+        director_provider=args.director_provider,
     )
 
     t0 = time.time()
@@ -129,6 +131,9 @@ def parse_args() -> argparse.Namespace:
                    help="max workflow iterations")
     p.add_argument("--workflow-timeout", type=int, default=1800,
                    help="wall-clock cap (seconds)")
+    p.add_argument("--director-provider", default=None,
+                   help="external LLM provider for strategic tactic guidance "
+                        "(e.g. openrouter for GPT-5.5)")
     return p.parse_args()
 
 


### PR DESCRIPTION
## Summary
- Add **DirectorAgent** to the multi-agent Lean prover: an external LLM (GPT-5.5 via OpenRouter) that provides strategic tactic guidance when local agents (GLM-5.1, Qwen3.6) stall
- Director is invoked by the **Coordinator** after F1 escalation (3 consecutive BUILD-FAIL), before retrying the TacticAgent with external guidance
- Budget-capped: max 3 director calls per session, 500 tokens/call, 120s timeout per call

## Architecture
```
Coordinator (stalled) → Director → TacticAgent (retry with guidance)
```
The Director has **no tools** — pure text output with structured `APPROACH:` + `TACTICS:` format. The TacticAgent reads the director's suggestion and applies it using its own Lean compilation tools.

## Files changed
- `prover/instructions.py` — `DIRECTOR_AGENT_INSTRUCTIONS` + Coordinator "director" routing docs
- `prover/agents.py` — `create_director_agent()` factory (512 max tokens, no tools)
- `prover/workflow.py` — `ProofWorkflowBuilder` accepts `director_agent`, integrates into switch-case graph, `ProofMessage.director_calls` tracking
- `prover/provers.py` — `director_provider` param, creates + passes director agent to workflow
- `run_prover_bg.py` — `--director-provider` CLI argument

## Usage
```bash
python run_prover_bg.py 15 --director-provider openrouter
```

## Test plan
- [ ] Smoke test DEMO 15 (zero sorry) with `--director-provider openrouter` — verify DirectorAgent is created and graph builds
- [ ] Verify without `--director-provider` — fallback to standard multi-agent workflow (no director)
- [ ] Check `director_calls` cap at 3 — Coordinator should fall through to search after 3 director calls

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>