### PR TITLE
fix(genai): migrate hardcoded URLs to os.getenv() pattern

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-header",
    "metadata": {
     "papermill": {
-     "duration": 0.002904,
-     "end_time": "2026-05-12T08:59:10.090110",
+     "duration": 0.003465,
+     "end_time": "2026-05-12T11:14:44.386945",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.087206",
+     "start_time": "2026-05-12T11:14:44.383480",
      "status": "completed"
     },
     "tags": []
@@ -45,22 +45,24 @@
    "id": "cell-params",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.096086Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.095825Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.100347Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.099665Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.394199Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.393685Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.399259Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.398730Z"
     },
     "papermill": {
-     "duration": 0.008663,
-     "end_time": "2026-05-12T08:59:10.101369",
+     "duration": 0.010469,
+     "end_time": "2026-05-12T11:14:44.400824",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.092706",
+     "start_time": "2026-05-12T11:14:44.390355",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "# Parametres Papermill - JAMAIS modifier ce commentaire\n",
     "\n",
     "# Configuration notebook\n",
@@ -69,7 +71,7 @@
     "debug_level = \"INFO\"\n",
     "\n",
     "# Parametres TTS\n",
-    "gateway_url = \"https://tts-api.myia.io\"  # URL du gateway multi-modele\n",
+    "gateway_url = os.getenv(\"TTS_API_URL\", \"https://tts-api.myia.io\")  # URL du gateway multi-modele\n",
     "default_voice = \"alloy\"              # Voix par defaut (OpenAI-compatible)\n",
     "compare_all_models = True           # Comparer les 3 modeles\n",
     "benchmark_latency = True            # Benchmarks de latence\n",
@@ -82,16 +84,16 @@
    "id": "cell-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.107938Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.107513Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.291919Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.291241Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.408854Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.408370Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.617693Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.617033Z"
     },
     "papermill": {
-     "duration": 0.188748,
-     "end_time": "2026-05-12T08:59:10.292985",
+     "duration": 0.215425,
+     "end_time": "2026-05-12T11:14:44.619399",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.104237",
+     "start_time": "2026-05-12T11:14:44.403974",
      "status": "completed"
     },
     "tags": []
@@ -103,7 +105,7 @@
      "text": [
       "Helpers audio importes\n",
       "Multi-Model TTS Gateway - Synthese Vocale\n",
-      "Date : 2026-05-12 10:59:10\n",
+      "Date : 2026-05-12 13:14:44\n",
       "Gateway : https://tts-api.myia.io\n",
       "Sortie : D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\outputs\\audio\\multi-tts\n"
      ]
@@ -158,10 +160,10 @@
    "id": "qyxtlovci1n",
    "metadata": {
     "papermill": {
-     "duration": 0.002445,
-     "end_time": "2026-05-12T08:59:10.298053",
+     "duration": 0.006904,
+     "end_time": "2026-05-12T11:14:44.632145",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.295608",
+     "start_time": "2026-05-12T11:14:44.625241",
      "status": "completed"
     },
     "tags": []
@@ -176,16 +178,16 @@
    "id": "cell-env",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.304192Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.303667Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.318676Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.317941Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.644143Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.643755Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.659108Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.658295Z"
     },
     "papermill": {
-     "duration": 0.019162,
-     "end_time": "2026-05-12T08:59:10.319658",
+     "duration": 0.023082,
+     "end_time": "2026-05-12T11:14:44.660327",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.300496",
+     "start_time": "2026-05-12T11:14:44.637245",
      "status": "completed"
     },
     "tags": []
@@ -234,10 +236,10 @@
    "id": "cell-section1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002545,
-     "end_time": "2026-05-12T08:59:10.324582",
+     "duration": 0.002772,
+     "end_time": "2026-05-12T11:14:44.666111",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.322037",
+     "start_time": "2026-05-12T11:14:44.663339",
      "status": "completed"
     },
     "tags": []
@@ -274,8 +276,33 @@
   {
    "cell_type": "markdown",
    "id": "b160458c",
-   "source": "### Verification de l'etat du gateway\n\nAvant de tester la generation TTS, il est essentiel de verifier que le gateway multi-modele est operationnel et que tous les modeles sont correctement enregistres.\n\n**Procedure de verification** :\n1. **Health check** : Interroger l'endpoint `/health` pour confirmer que le gateway tourne\n2. **Liste des modeles** : Recuperer la liste des modeles enregistres via `/v1/models`\n3. **Liste des voix** : Verifier les voix disponibles pour chaque modele via `/v1/voices`\n\n**Endpoints testes** :\n- `GET {gateway_url}/health` : Status du gateway\n- `GET {gateway_url}/v1/models` : Modeles disponibles avec leurs paths\n- `GET {gateway_url}/v1/voices` : Voix enregistrees et compatibilites\n\nCette verification permet de s'assurer que l'infrastructure est prete avant de lancer les tests de generation, ce qui evite de perdre du temps a debugger des erreurs reseau ou de configuration.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003196,
+     "end_time": "2026-05-12T11:14:44.673002",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.669806",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Verification de l'etat du gateway\n",
+    "\n",
+    "Avant de tester la generation TTS, il est essentiel de verifier que le gateway multi-modele est operationnel et que tous les modeles sont correctement enregistres.\n",
+    "\n",
+    "**Procedure de verification** :\n",
+    "1. **Health check** : Interroger l'endpoint `/health` pour confirmer que le gateway tourne\n",
+    "2. **Liste des modeles** : Recuperer la liste des modeles enregistres via `/v1/models`\n",
+    "3. **Liste des voix** : Verifier les voix disponibles pour chaque modele via `/v1/voices`\n",
+    "\n",
+    "**Endpoints testes** :\n",
+    "- `GET {gateway_url}/health` : Status du gateway\n",
+    "- `GET {gateway_url}/v1/models` : Modeles disponibles avec leurs paths\n",
+    "- `GET {gateway_url}/v1/voices` : Voix enregistrees et compatibilites\n",
+    "\n",
+    "Cette verification permet de s'assurer que l'infrastructure est prete avant de lancer les tests de generation, ce qui evite de perdre du temps a debugger des erreurs reseau ou de configuration."
+   ]
   },
   {
    "cell_type": "code",
@@ -283,16 +310,16 @@
    "id": "cell-health",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.330566Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.330201Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.364514Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.363639Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.681541Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.681169Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.697854Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.696982Z"
     },
     "papermill": {
-     "duration": 0.038643,
-     "end_time": "2026-05-12T08:59:10.365703",
+     "duration": 0.022159,
+     "end_time": "2026-05-12T11:14:44.698855",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.327060",
+     "start_time": "2026-05-12T11:14:44.676696",
      "status": "completed"
     },
     "tags": []
@@ -350,18 +377,58 @@
   {
    "cell_type": "markdown",
    "id": "1b5a6b9f",
-   "source": "### Interpretation du health check\n\n**Resultat observe** : Le gateway repond avec un status \"healthy\", mais une erreur survient lors de la tentative d'affichage de la liste des modeles (`'models'` key error).\n\n### Analyse de la reponse\n\n| Endpoint | Status | Observation |\n|----------|--------|-------------|\n| `/health` | OK (200) | Gateway accessible, status \"healthy\" |\n| `/v1/models` | Erreur | Cle 'models' manquante dans la reponse JSON |\n| `/v1/voices` | Non teste | Bloque par l'erreur precedente |\n\n### Diagnostic\n\nL'erreur indique que la structure de la reponse du `/health` endpoint ne correspond pas a ce que le code attend. Le code s'attend à un dictionnaire avec une cle `'models'` contenant une liste, mais la reponse actuelle a une structure differente.\n\n**Causes possibles** :\n1. **Version differente du gateway** : L'API a peut-etre change et la reponse `/health` ne contient plus la liste des modeles\n2. **Endpoint deplace** : La liste des modeles est peut-ormais sur un endpoint different (ex: `/models` sans `/v1`)\n3. **Format de reponse modifie** : La structure JSON a change (ex: `data.models` au lieu de `models`)\n\n### Comportement attendu\n\nSi le health check fonctionnait correctement, nous verrions :\n- Status : `healthy`\n- Modeles disponibles : `kokoro, tada, qwen`\n- Liste detaillee des modeles avec leurs paths et descriptions\n- Liste des voix disponibles pour chaque modele\n\n> **Note technique** : Malgre cette erreur, le gateway est accessible (status 200), ce qui indique que le service tourne. L'erreur 401 subsequente lors de la generation TTS confirme que le probleme est l'authentification, pas la disponibilite du service.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002872,
+     "end_time": "2026-05-12T11:14:44.705339",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.702467",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation du health check\n",
+    "\n",
+    "**Resultat observe** : Le gateway repond avec un status \"healthy\", mais une erreur survient lors de la tentative d'affichage de la liste des modeles (`'models'` key error).\n",
+    "\n",
+    "### Analyse de la reponse\n",
+    "\n",
+    "| Endpoint | Status | Observation |\n",
+    "|----------|--------|-------------|\n",
+    "| `/health` | OK (200) | Gateway accessible, status \"healthy\" |\n",
+    "| `/v1/models` | Erreur | Cle 'models' manquante dans la reponse JSON |\n",
+    "| `/v1/voices` | Non teste | Bloque par l'erreur precedente |\n",
+    "\n",
+    "### Diagnostic\n",
+    "\n",
+    "L'erreur indique que la structure de la reponse du `/health` endpoint ne correspond pas a ce que le code attend. Le code s'attend à un dictionnaire avec une cle `'models'` contenant une liste, mais la reponse actuelle a une structure differente.\n",
+    "\n",
+    "**Causes possibles** :\n",
+    "1. **Version differente du gateway** : L'API a peut-etre change et la reponse `/health` ne contient plus la liste des modeles\n",
+    "2. **Endpoint deplace** : La liste des modeles est peut-ormais sur un endpoint different (ex: `/models` sans `/v1`)\n",
+    "3. **Format de reponse modifie** : La structure JSON a change (ex: `data.models` au lieu de `models`)\n",
+    "\n",
+    "### Comportement attendu\n",
+    "\n",
+    "Si le health check fonctionnait correctement, nous verrions :\n",
+    "- Status : `healthy`\n",
+    "- Modeles disponibles : `kokoro, tada, qwen`\n",
+    "- Liste detaillee des modeles avec leurs paths et descriptions\n",
+    "- Liste des voix disponibles pour chaque modele\n",
+    "\n",
+    "> **Note technique** : Malgre cette erreur, le gateway est accessible (status 200), ce qui indique que le service tourne. L'erreur 401 subsequente lors de la generation TTS confirme que le probleme est l'authentification, pas la disponibilite du service."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-section2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002389,
-     "end_time": "2026-05-12T08:59:10.370791",
+     "duration": 0.002697,
+     "end_time": "2026-05-12T11:14:44.710881",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.368402",
+     "start_time": "2026-05-12T11:14:44.708184",
      "status": "completed"
     },
     "tags": []
@@ -375,8 +442,38 @@
   {
    "cell_type": "markdown",
    "id": "6418f802",
-   "source": "### Approche de comparaison\n\nLe code suivant va implementer une batterie de tests pour evaluer les trois modeles TTS sur plusieurs criteres de performance.\n\n**Methodologie de test** :\n1. **Texte de test** : Un meme texte (ou une version courte pour Qwen3) est envoye aux trois modeles\n2. **Mesures collectees** : Temps de generation, duree audio, taille du fichier, ratio real-time\n3. **Routage par path** : Chaque modele est contacte sur son endpoint specifique (pas de parametre `model`)\n4. **Gestion d'erreur** : Timeout specifique par modele (180s pour Qwen3, 60s pour les autres)\n\n**Parametres de configuration** :\n- `sample_text` : Texte de 34 mots pour Kokoro et TADA\n- `sample_text_short` : Texte de 10 mots pour Qwen3 (plus lent)\n- `default_voice` : Voix \"alloy\" (compatible OpenAI)\n- `timeout` : Adapté à la vitesse de chaque modele\n\n**Resultats attendus** (si authentification OK) :\n- Tableau comparatif avec metriques de performance\n- Fichiers audio sauvegardes dans `outputs/audio/multi-tts/`\n- Lecteurs audio embeddes pour ecoute directe",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.002646,
+     "end_time": "2026-05-12T11:14:44.716504",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.713858",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Approche de comparaison\n",
+    "\n",
+    "Le code suivant va implementer une batterie de tests pour evaluer les trois modeles TTS sur plusieurs criteres de performance.\n",
+    "\n",
+    "**Methodologie de test** :\n",
+    "1. **Texte de test** : Un meme texte (ou une version courte pour Qwen3) est envoye aux trois modeles\n",
+    "2. **Mesures collectees** : Temps de generation, duree audio, taille du fichier, ratio real-time\n",
+    "3. **Routage par path** : Chaque modele est contacte sur son endpoint specifique (pas de parametre `model`)\n",
+    "4. **Gestion d'erreur** : Timeout specifique par modele (180s pour Qwen3, 60s pour les autres)\n",
+    "\n",
+    "**Parametres de configuration** :\n",
+    "- `sample_text` : Texte de 34 mots pour Kokoro et TADA\n",
+    "- `sample_text_short` : Texte de 10 mots pour Qwen3 (plus lent)\n",
+    "- `default_voice` : Voix \"alloy\" (compatible OpenAI)\n",
+    "- `timeout` : Adapté à la vitesse de chaque modele\n",
+    "\n",
+    "**Resultats attendus** (si authentification OK) :\n",
+    "- Tableau comparatif avec metriques de performance\n",
+    "- Fichiers audio sauvegardes dans `outputs/audio/multi-tts/`\n",
+    "- Lecteurs audio embeddes pour ecoute directe"
+   ]
   },
   {
    "cell_type": "code",
@@ -384,16 +481,16 @@
    "id": "cell-compare",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.378148Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.377725Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.415351Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.414800Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.724610Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.724136Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.765291Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.763807Z"
     },
     "papermill": {
-     "duration": 0.042956,
-     "end_time": "2026-05-12T08:59:10.416955",
+     "duration": 0.048608,
+     "end_time": "2026-05-12T11:14:44.768255",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.373999",
+     "start_time": "2026-05-12T11:14:44.719647",
      "status": "completed"
     },
     "tags": []
@@ -541,18 +638,55 @@
   {
    "cell_type": "markdown",
    "id": "ba6c4ead",
-   "source": "### Analyse des resultats de generation\n\n**Observation** : Les trois requetes TTS ont echoue avec le code d'erreur HTTP 401, indiquant un probleme d'authentification.\n\n### Details de l'erreur\n\n| Modele | Status | Message d'erreur | Cause racine |\n|--------|--------|------------------|--------------|\n| Kokoro | 401 | Missing or invalid Authorization header | API key manquante |\n| TADA 3B ML | 401 | Missing or invalid Authorization header | API key manquante |\n| Qwen3 TTS | 401 | Missing or invalid Authorization header | API key manquante |\n\n### Analyse technique\n\nLe code de comparaison effectue les operations suivantes pour chaque modele :\n\n1. **Requete POST** vers l'endpoint du modele avec le texte et la voix\n2. **Verification du content-type** pour s'assurer que la reponse est de l'audio (pas JSON)\n3. **Mesure du temps de generation** pour calculer le ratio real-time\n4. **Sauvegarde de l'audio** dans le repertoire `outputs/audio/multi-tts/`\n\nLe code contient egalement une gestion d'erreur robuste :\n- `requests.exceptions.Timeout` : capture les depassements de delai (surtout pour Qwen3)\n- `status_code != 200` : capture les erreurs HTTP (401, 500, etc.)\n- Verification `content-type` : evite d'essayer de lire du JSON comme de l'audio\n\n> **Note pedagogique** : Meme en cas d'erreur, la structure du code permet de continuer avec les modeles suivants. C'est un pattern important pour les applications de production : un modele en panne ne doit pas faire echouer tout le systeme.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.008727,
+     "end_time": "2026-05-12T11:14:44.785168",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.776441",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Analyse des resultats de generation\n",
+    "\n",
+    "**Observation** : Les trois requetes TTS ont echoue avec le code d'erreur HTTP 401, indiquant un probleme d'authentification.\n",
+    "\n",
+    "### Details de l'erreur\n",
+    "\n",
+    "| Modele | Status | Message d'erreur | Cause racine |\n",
+    "|--------|--------|------------------|--------------|\n",
+    "| Kokoro | 401 | Missing or invalid Authorization header | API key manquante |\n",
+    "| TADA 3B ML | 401 | Missing or invalid Authorization header | API key manquante |\n",
+    "| Qwen3 TTS | 401 | Missing or invalid Authorization header | API key manquante |\n",
+    "\n",
+    "### Analyse technique\n",
+    "\n",
+    "Le code de comparaison effectue les operations suivantes pour chaque modele :\n",
+    "\n",
+    "1. **Requete POST** vers l'endpoint du modele avec le texte et la voix\n",
+    "2. **Verification du content-type** pour s'assurer que la reponse est de l'audio (pas JSON)\n",
+    "3. **Mesure du temps de generation** pour calculer le ratio real-time\n",
+    "4. **Sauvegarde de l'audio** dans le repertoire `outputs/audio/multi-tts/`\n",
+    "\n",
+    "Le code contient egalement une gestion d'erreur robuste :\n",
+    "- `requests.exceptions.Timeout` : capture les depassements de delai (surtout pour Qwen3)\n",
+    "- `status_code != 200` : capture les erreurs HTTP (401, 500, etc.)\n",
+    "- Verification `content-type` : evite d'essayer de lire du JSON comme de l'audio\n",
+    "\n",
+    "> **Note pedagogique** : Meme en cas d'erreur, la structure du code permet de continuer avec les modeles suivants. C'est un pattern important pour les applications de production : un modele en panne ne doit pas faire echouer tout le systeme."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "0ggty4n19lj6",
    "metadata": {
     "papermill": {
-     "duration": 0.004533,
-     "end_time": "2026-05-12T08:59:10.425252",
+     "duration": 0.007441,
+     "end_time": "2026-05-12T11:14:44.799908",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.420719",
+     "start_time": "2026-05-12T11:14:44.792467",
      "status": "completed"
     },
     "tags": []
@@ -567,16 +701,16 @@
    "id": "cell-comparison-table",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.434853Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.434372Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.439909Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.439083Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.817925Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.817531Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.825093Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.823397Z"
     },
     "papermill": {
-     "duration": 0.012893,
-     "end_time": "2026-05-12T08:59:10.441495",
+     "duration": 0.020516,
+     "end_time": "2026-05-12T11:14:44.827203",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.428602",
+     "start_time": "2026-05-12T11:14:44.806687",
      "status": "completed"
     },
     "tags": []
@@ -613,18 +747,51 @@
   {
    "cell_type": "markdown",
    "id": "8702abcc",
-   "source": "### Interpretation de la comparaison\n\n**Resultat observe** : Les trois modeles TTS ont retourne une erreur 401 (Unauthorized) avec le message \"Missing or invalid Authorization header\". Cela indique que le gateway requiert une authentification par API key.\n\n### Diagnostic de l'erreur\n\n| Cause | Explication | Solution |\n|-------|-------------|----------|\n| **Header manquant** | La requete POST ne contient pas le header `Authorization` | Ajouter `headers={\"Authorization\": \"Bearer <API_KEY>\"}` |\n| **API key non configuree** | La variable d'environnement `TTS_API_KEY` n'est pas definie | Configurer la clé dans le fichier `.env` |\n| **Service distant** | Le gateway distant `tts-api.myia.io` requiert une authentification | Utiliser le service local ou obtenir une clé valide |\n\n### Comportement attendu avec authentification\n\nSi l'authentification etait correcte, le tableau afficherait :\n\n| Modele | Duree (s) | Temps (s) | Ratio | Interpretation |\n|--------|-----------|-----------|-------|----------------|\n| Kokoro | ~8-10 | ~1 | 8-10x | Tres rapide, ideal pour prototypage |\n| TADA 3B ML | ~8-10 | ~2 | 4-5x | Compromis qualite/vitesse |\n| Qwen3 TTS | ~4-5 | ~4-5 | ~1x | Plus lent mais meilleure qualite |\n\n> **Note technique** : Pour tester localement sans authentification, verifiez que le gateway tourne sur `http://localhost:8191` et qu'il est configure en mode \"no-auth\". Sinon, ajoutez la variable `TTS_API_KEY` dans le fichier `.env` du dossier GenAI.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.006637,
+     "end_time": "2026-05-12T11:14:44.840195",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.833558",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation de la comparaison\n",
+    "\n",
+    "**Resultat observe** : Les trois modeles TTS ont retourne une erreur 401 (Unauthorized) avec le message \"Missing or invalid Authorization header\". Cela indique que le gateway requiert une authentification par API key.\n",
+    "\n",
+    "### Diagnostic de l'erreur\n",
+    "\n",
+    "| Cause | Explication | Solution |\n",
+    "|-------|-------------|----------|\n",
+    "| **Header manquant** | La requete POST ne contient pas le header `Authorization` | Ajouter `headers={\"Authorization\": \"Bearer <API_KEY>\"}` |\n",
+    "| **API key non configuree** | La variable d'environnement `TTS_API_KEY` n'est pas definie | Configurer la clé dans le fichier `.env` |\n",
+    "| **Service distant** | Le gateway distant `tts-api.myia.io` requiert une authentification | Utiliser le service local ou obtenir une clé valide |\n",
+    "\n",
+    "### Comportement attendu avec authentification\n",
+    "\n",
+    "Si l'authentification etait correcte, le tableau afficherait :\n",
+    "\n",
+    "| Modele | Duree (s) | Temps (s) | Ratio | Interpretation |\n",
+    "|--------|-----------|-----------|-------|----------------|\n",
+    "| Kokoro | ~8-10 | ~1 | 8-10x | Tres rapide, ideal pour prototypage |\n",
+    "| TADA 3B ML | ~8-10 | ~2 | 4-5x | Compromis qualite/vitesse |\n",
+    "| Qwen3 TTS | ~4-5 | ~4-5 | ~1x | Plus lent mais meilleure qualite |\n",
+    "\n",
+    "> **Note technique** : Pour tester localement sans authentification, verifiez que le gateway tourne sur `http://localhost:8191` et qu'il est configure en mode \"no-auth\". Sinon, ajoutez la variable `TTS_API_KEY` dans le fichier `.env` du dossier GenAI."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ex1-tts-params-md",
    "metadata": {
     "papermill": {
-     "duration": 0.003456,
-     "end_time": "2026-05-12T08:59:10.449463",
+     "duration": 0.007455,
+     "end_time": "2026-05-12T11:14:44.854172",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.446007",
+     "start_time": "2026-05-12T11:14:44.846717",
      "status": "completed"
     },
     "tags": []
@@ -647,16 +814,16 @@
    "id": "ex1-tts-params-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.458226Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.457868Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.462561Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.461900Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.870813Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.870215Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.876842Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.875786Z"
     },
     "papermill": {
-     "duration": 0.011201,
-     "end_time": "2026-05-12T08:59:10.464207",
+     "duration": 0.017831,
+     "end_time": "2026-05-12T11:14:44.879078",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.453006",
+     "start_time": "2026-05-12T11:14:44.861247",
      "status": "completed"
     },
     "tags": []
@@ -687,10 +854,10 @@
    "id": "cell-section3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004868,
-     "end_time": "2026-05-12T08:59:10.474751",
+     "duration": 0.006039,
+     "end_time": "2026-05-12T11:14:44.891579",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.469883",
+     "start_time": "2026-05-12T11:14:44.885540",
      "status": "completed"
     },
     "tags": []
@@ -725,18 +892,36 @@
   {
    "cell_type": "markdown",
    "id": "3d536d09",
-   "source": "### Transition vers l'integration\n\nMaintenant que nous avons compare les 3 modeles et compris leurs forces/faiblesses, passons a l'integration pratique. La section suivante montre comment encapsuler la logique de routing dans un client Python reutilisable, puis comment automatiser la selection du modele avec un routeur intelligent.\n\n**Points abordes** :\n- Client Python multi-modele avec gestion d'erreurs\n- Architecture orientee objet pour faciliter l'integration\n- Routeur intelligent qui selectionne le meilleur modele automatiquement",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.007068,
+     "end_time": "2026-05-12T11:14:44.905268",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.898200",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Transition vers l'integration\n",
+    "\n",
+    "Maintenant que nous avons compare les 3 modeles et compris leurs forces/faiblesses, passons a l'integration pratique. La section suivante montre comment encapsuler la logique de routing dans un client Python reutilisable, puis comment automatiser la selection du modele avec un routeur intelligent.\n",
+    "\n",
+    "**Points abordes** :\n",
+    "- Client Python multi-modele avec gestion d'erreurs\n",
+    "- Architecture orientee objet pour faciliter l'integration\n",
+    "- Routeur intelligent qui selectionne le meilleur modele automatiquement"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-section4-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004323,
-     "end_time": "2026-05-12T08:59:10.483863",
+     "duration": 0.006507,
+     "end_time": "2026-05-12T11:14:44.918265",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.479540",
+     "start_time": "2026-05-12T11:14:44.911758",
      "status": "completed"
     },
     "tags": []
@@ -787,16 +972,16 @@
    "id": "cell-stats",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.494923Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.494396Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.501516Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.500814Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.933101Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.932770Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.939190Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.938154Z"
     },
     "papermill": {
-     "duration": 0.014431,
-     "end_time": "2026-05-12T08:59:10.502968",
+     "duration": 0.016169,
+     "end_time": "2026-05-12T11:14:44.941154",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.488537",
+     "start_time": "2026-05-12T11:14:44.924985",
      "status": "completed"
     },
     "tags": []
@@ -808,7 +993,7 @@
      "text": [
       "STATISTIQUES DE SESSION\n",
       "==================================================\n",
-      "Date : 2026-05-12 10:59:10\n",
+      "Date : 2026-05-12 13:14:44\n",
       "Gateway : http://localhost:8191\n",
       "Modeles testes : 0\n",
       "Fichiers sauvegardes : 1 (0.2 MB)\n",
@@ -819,7 +1004,7 @@
       "3. Explorer le voice cloning avec XTTS (02-2)\n",
       "4. Comparer tous les modeles TTS et STT (03-1)\n",
       "\n",
-      "Notebook Multi-Model TTS termine - 10:59:10\n"
+      "Notebook Multi-Model TTS termine - 13:14:44\n"
      ]
     }
    ],
@@ -849,18 +1034,59 @@
   {
    "cell_type": "markdown",
    "id": "645f1cf1",
-   "source": "## Conclusion du Notebook\n\nCe notebook a presente l'architecture multi-modele TTS avec un gateway centralise qui permet de router les requetes vers le modele le plus adapte au cas d'usage.\n\n### Points cles retenus\n\n| Concept | Description |\n|---------|-------------|\n| **Path-based routing** | Chaque modele a son propre endpoint (`/v1/audio/speech`, `/tada/v1/audio/speech`, `/qwen/v1/audio/speech`) |\n| **Backward compatibility** | L'endpoint par defaut utilise Kokoro pour compatibilite OpenAI TTS |\n| **Modele selection** | Le choix depend de : vitesse requise, qualite audio, contraintes resources, besoin de clonage vocal |\n| **Integration simple** | Client Python avec methode `generate(text, model, voice)` |\n\n### Tableau decisionnel\n\n| Scenario | Modele | Rationale |\n|----------|--------|-----------|\n| Prototypage rapide | Kokoro | Generation instantanee, faible latence |\n| Production standard | TADA 3B ML | Equilibre qualite/vitesse |\n| Haute qualite | Qwen3 TTS | Meilleure naturalite, support voix custom |\n| Gros volume | Kokoro | Pas de cout per-token, leger |\n| Applications mobiles | Kokoro | Compatible CPU, faible footprint |\n\n### Prochaines etapes\n\n1. **Integration API** : Construire un endpoint FastAPI qui expose le gateway TTS (notebook 03-1)\n2. **Pipeline vocal complet** : Combiner STT (Whisper/Qwen ASR) + TTS pour une application de dialogue (notebook 03-2)\n3. **Voice cloning** : Explorer XTTS pour creer des voix personnalisees (notebook 02-2)\n4. **Optimisation** : Implementer le cache audio pour reduire la latence sur les textes repetitifs\n\n> **Note technique** : L'authentification par API key (header `Authorization`) est necessaire pour les appels au gateway. Configurez la variable d'environnement `TTS_API_KEY` ou passez le header explicitement dans les requetes.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005848,
+     "end_time": "2026-05-12T11:14:44.953228",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.947380",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion du Notebook\n",
+    "\n",
+    "Ce notebook a presente l'architecture multi-modele TTS avec un gateway centralise qui permet de router les requetes vers le modele le plus adapte au cas d'usage.\n",
+    "\n",
+    "### Points cles retenus\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| **Path-based routing** | Chaque modele a son propre endpoint (`/v1/audio/speech`, `/tada/v1/audio/speech`, `/qwen/v1/audio/speech`) |\n",
+    "| **Backward compatibility** | L'endpoint par defaut utilise Kokoro pour compatibilite OpenAI TTS |\n",
+    "| **Modele selection** | Le choix depend de : vitesse requise, qualite audio, contraintes resources, besoin de clonage vocal |\n",
+    "| **Integration simple** | Client Python avec methode `generate(text, model, voice)` |\n",
+    "\n",
+    "### Tableau decisionnel\n",
+    "\n",
+    "| Scenario | Modele | Rationale |\n",
+    "|----------|--------|-----------|\n",
+    "| Prototypage rapide | Kokoro | Generation instantanee, faible latence |\n",
+    "| Production standard | TADA 3B ML | Equilibre qualite/vitesse |\n",
+    "| Haute qualite | Qwen3 TTS | Meilleure naturalite, support voix custom |\n",
+    "| Gros volume | Kokoro | Pas de cout per-token, leger |\n",
+    "| Applications mobiles | Kokoro | Compatible CPU, faible footprint |\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "1. **Integration API** : Construire un endpoint FastAPI qui expose le gateway TTS (notebook 03-1)\n",
+    "2. **Pipeline vocal complet** : Combiner STT (Whisper/Qwen ASR) + TTS pour une application de dialogue (notebook 03-2)\n",
+    "3. **Voice cloning** : Explorer XTTS pour creer des voix personnalisees (notebook 02-2)\n",
+    "4. **Optimisation** : Implementer le cache audio pour reduire la latence sur les textes repetitifs\n",
+    "\n",
+    "> **Note technique** : L'authentification par API key (header `Authorization`) est necessaire pour les appels au gateway. Configurez la variable d'environnement `TTS_API_KEY` ou passez le header explicitement dans les requetes."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ex2-tts-router-md",
    "metadata": {
     "papermill": {
-     "duration": 0.005652,
-     "end_time": "2026-05-12T08:59:10.513576",
+     "duration": 0.006172,
+     "end_time": "2026-05-12T11:14:44.965677",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.507924",
+     "start_time": "2026-05-12T11:14:44.959505",
      "status": "completed"
     },
     "tags": []
@@ -884,16 +1110,16 @@
    "id": "ex2-tts-router-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T08:59:10.526671Z",
-     "iopub.status.busy": "2026-05-12T08:59:10.526153Z",
-     "iopub.status.idle": "2026-05-12T08:59:10.530340Z",
-     "shell.execute_reply": "2026-05-12T08:59:10.529473Z"
+     "iopub.execute_input": "2026-05-12T11:14:44.979068Z",
+     "iopub.status.busy": "2026-05-12T11:14:44.978472Z",
+     "iopub.status.idle": "2026-05-12T11:14:44.983183Z",
+     "shell.execute_reply": "2026-05-12T11:14:44.982407Z"
     },
     "papermill": {
-     "duration": 0.012269,
-     "end_time": "2026-05-12T08:59:10.531900",
+     "duration": 0.013591,
+     "end_time": "2026-05-12T11:14:44.985036",
      "exception": false,
-     "start_time": "2026-05-12T08:59:10.519631",
+     "start_time": "2026-05-12T11:14:44.971445",
      "status": "completed"
     },
     "tags": []
@@ -924,8 +1150,58 @@
   {
    "cell_type": "markdown",
    "id": "7da74018",
-   "source": "### Pistes de solution pour le routeur intelligent\n\nPour implementer le routeur TTS intelligent, voici les etapes cles :\n\n**1. Verification de disponibilite**\n```python\ndef check_model_health(model_url):\n    try:\n        response = requests.get(f\"{model_url}/health\", timeout=5)\n        return response.status_code == 200\n    except:\n        return False\n```\n\n**2. Estimation du temps de generation**\n- Kokoro : ~0.1s par mot (ratio real-time ~10x)\n- TADA 3B ML : ~0.2s par mot (ratio real-time ~5x)\n- Qwen3 TTS : ~1s par mot (ratio real-time ~1x)\n\n**3. Logique de selection**\n```python\nword_count = len(text.split())\nhas_voice_clone = voice_clone is not None\nurgent = max_wait_seconds < (word_count * 0.5)  # Seuil arbitraire\n\nif has_voice_clone:\n    return \"qwen\"  # Seul Qwen supporte le voice cloning\nelif urgent or word_count < 50:\n    return \"kokoro\"  # Plus rapide\nelif word_count > 200:\n    return \"qwen\"  # Meilleure qualite pour texte long\nelse:\n    return \"tada\"  # Compromis\n```\n\n**4. Fallback**\n- Si le modele choisi echoue (timeout, erreur), retenter avec Kokoro\n- Kokoro est le plus stable et le plus rapide, donc bon fallback\n\n> **Note technique** : Ajoutez un systeme de cache pour les textes repetitifs. Utilisez un hash du texte comme cle de cache pour eviter de regenerer le meme audio.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004852,
+     "end_time": "2026-05-12T11:14:44.995920",
+     "exception": false,
+     "start_time": "2026-05-12T11:14:44.991068",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Pistes de solution pour le routeur intelligent\n",
+    "\n",
+    "Pour implementer le routeur TTS intelligent, voici les etapes cles :\n",
+    "\n",
+    "**1. Verification de disponibilite**\n",
+    "```python\n",
+    "def check_model_health(model_url):\n",
+    "    try:\n",
+    "        response = requests.get(f\"{model_url}/health\", timeout=5)\n",
+    "        return response.status_code == 200\n",
+    "    except:\n",
+    "        return False\n",
+    "```\n",
+    "\n",
+    "**2. Estimation du temps de generation**\n",
+    "- Kokoro : ~0.1s par mot (ratio real-time ~10x)\n",
+    "- TADA 3B ML : ~0.2s par mot (ratio real-time ~5x)\n",
+    "- Qwen3 TTS : ~1s par mot (ratio real-time ~1x)\n",
+    "\n",
+    "**3. Logique de selection**\n",
+    "```python\n",
+    "word_count = len(text.split())\n",
+    "has_voice_clone = voice_clone is not None\n",
+    "urgent = max_wait_seconds < (word_count * 0.5)  # Seuil arbitraire\n",
+    "\n",
+    "if has_voice_clone:\n",
+    "    return \"qwen\"  # Seul Qwen supporte le voice cloning\n",
+    "elif urgent or word_count < 50:\n",
+    "    return \"kokoro\"  # Plus rapide\n",
+    "elif word_count > 200:\n",
+    "    return \"qwen\"  # Meilleure qualite pour texte long\n",
+    "else:\n",
+    "    return \"tada\"  # Compromis\n",
+    "```\n",
+    "\n",
+    "**4. Fallback**\n",
+    "- Si le modele choisi echoue (timeout, erreur), retenter avec Kokoro\n",
+    "- Kokoro est le plus stable et le plus rapide, donc bon fallback\n",
+    "\n",
+    "> **Note technique** : Ajoutez un systeme de cache pour les textes repetitifs. Utilisez un hash du texte comme cle de cache pour eviter de regenerer le meme audio."
+   ]
   }
  ],
  "metadata": {
@@ -948,14 +1224,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.63816,
-   "end_time": "2026-05-12T08:59:10.782273",
+   "duration": 2.766632,
+   "end_time": "2026-05-12T11:14:45.247186",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\02-Advanced\\02-5-Multi-Model-TTS-Gateway.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\02-Advanced\\02-5-Multi-Model-TTS-Gateway_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-12T08:59:08.144113",
+   "start_time": "2026-05-12T11:14:42.480554",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -6,16 +6,16 @@
    "id": "b48102c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:30.046566Z",
-     "iopub.status.busy": "2026-05-12T10:00:30.046118Z",
-     "iopub.status.idle": "2026-05-12T10:00:30.051158Z",
-     "shell.execute_reply": "2026-05-12T10:00:30.050105Z"
+     "iopub.execute_input": "2026-05-12T11:15:02.962838Z",
+     "iopub.status.busy": "2026-05-12T11:15:02.962337Z",
+     "iopub.status.idle": "2026-05-12T11:15:02.967346Z",
+     "shell.execute_reply": "2026-05-12T11:15:02.966534Z"
     },
     "papermill": {
-     "duration": 0.01237,
-     "end_time": "2026-05-12T10:00:30.052538",
+     "duration": 0.011696,
+     "end_time": "2026-05-12T11:15:02.968706",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.040168",
+     "start_time": "2026-05-12T11:15:02.957010",
      "status": "completed"
     },
     "tags": [
@@ -33,10 +33,10 @@
    "id": "79be9a9e",
    "metadata": {
     "papermill": {
-     "duration": 0.004085,
-     "end_time": "2026-05-12T10:00:30.062002",
+     "duration": 0.00355,
+     "end_time": "2026-05-12T11:15:02.976268",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.057917",
+     "start_time": "2026-05-12T11:15:02.972718",
      "status": "completed"
     },
     "tags": []
@@ -94,10 +94,10 @@
    "id": "ikycba75qmf",
    "metadata": {
     "papermill": {
-     "duration": 0.003648,
-     "end_time": "2026-05-12T10:00:30.069949",
+     "duration": 0.005241,
+     "end_time": "2026-05-12T11:15:02.985679",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.066301",
+     "start_time": "2026-05-12T11:15:02.980438",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "244bd967",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:30.081220Z",
-     "iopub.status.busy": "2026-05-12T10:00:30.080361Z",
-     "iopub.status.idle": "2026-05-12T10:00:30.926124Z",
-     "shell.execute_reply": "2026-05-12T10:00:30.924660Z"
+     "iopub.execute_input": "2026-05-12T11:15:02.995402Z",
+     "iopub.status.busy": "2026-05-12T11:15:02.995113Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.666656Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.665536Z"
     },
     "papermill": {
-     "duration": 0.852897,
-     "end_time": "2026-05-12T10:00:30.927940",
+     "duration": 0.679091,
+     "end_time": "2026-05-12T11:15:03.668423",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.075043",
+     "start_time": "2026-05-12T11:15:02.989332",
      "status": "completed"
     },
     "tags": []
@@ -217,7 +217,7 @@
     "if LOCAL_MODE:\n",
     "    API_BASE_URL = \"http://127.0.0.1:8188\"\n",
     "else:\n",
-    "    API_BASE_URL = \"https://qwen-image-edit.myia.io\"\n",
+    "    API_BASE_URL = os.getenv(\"QWEN_IMAGE_EDIT_URL\", \"https://qwen-image-edit.myia.io\")\n",
     "\n",
     "CLIENT_ID = str(uuid.uuid4())  # ID unique pour tracking\n",
     "\n",
@@ -244,10 +244,10 @@
    "id": "5743a6a4",
    "metadata": {
     "papermill": {
-     "duration": 0.004515,
-     "end_time": "2026-05-12T10:00:30.937401",
+     "duration": 0.006003,
+     "end_time": "2026-05-12T11:15:03.681301",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.932886",
+     "start_time": "2026-05-12T11:15:03.675298",
      "status": "completed"
     },
     "tags": []
@@ -341,10 +341,10 @@
    "id": "851cb759",
    "metadata": {
     "papermill": {
-     "duration": 0.005026,
-     "end_time": "2026-05-12T10:00:30.948481",
+     "duration": 0.006137,
+     "end_time": "2026-05-12T11:15:03.693847",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.943455",
+     "start_time": "2026-05-12T11:15:03.687710",
      "status": "completed"
     },
     "tags": []
@@ -447,16 +447,16 @@
    "id": "85a8ef79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:30.958684Z",
-     "iopub.status.busy": "2026-05-12T10:00:30.958141Z",
-     "iopub.status.idle": "2026-05-12T10:00:30.972794Z",
-     "shell.execute_reply": "2026-05-12T10:00:30.971443Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.704795Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.704364Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.716651Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.715793Z"
     },
     "papermill": {
-     "duration": 0.021325,
-     "end_time": "2026-05-12T10:00:30.974054",
+     "duration": 0.019746,
+     "end_time": "2026-05-12T11:15:03.718358",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.952729",
+     "start_time": "2026-05-12T11:15:03.698612",
      "status": "completed"
     },
     "tags": []
@@ -622,10 +622,10 @@
    "id": "de517444",
    "metadata": {
     "papermill": {
-     "duration": 0.003968,
-     "end_time": "2026-05-12T10:00:30.981939",
+     "duration": 0.003964,
+     "end_time": "2026-05-12T11:15:03.726078",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.977971",
+     "start_time": "2026-05-12T11:15:03.722114",
      "status": "completed"
     },
     "tags": []
@@ -674,16 +674,16 @@
    "id": "f26afacc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:30.991500Z",
-     "iopub.status.busy": "2026-05-12T10:00:30.990918Z",
-     "iopub.status.idle": "2026-05-12T10:00:30.998910Z",
-     "shell.execute_reply": "2026-05-12T10:00:30.997875Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.736974Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.736560Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.743723Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.743048Z"
     },
     "papermill": {
-     "duration": 0.01444,
-     "end_time": "2026-05-12T10:00:31.000293",
+     "duration": 0.014571,
+     "end_time": "2026-05-12T11:15:03.745741",
      "exception": false,
-     "start_time": "2026-05-12T10:00:30.985853",
+     "start_time": "2026-05-12T11:15:03.731170",
      "status": "completed"
     },
     "tags": []
@@ -788,16 +788,16 @@
    "id": "a20b3bf0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.010419Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.009880Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.664194Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.663537Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.756041Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.755426Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.086659Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.085943Z"
     },
     "papermill": {
-     "duration": 0.660832,
-     "end_time": "2026-05-12T10:00:31.665358",
+     "duration": 0.337219,
+     "end_time": "2026-05-12T11:15:04.087804",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.004526",
+     "start_time": "2026-05-12T11:15:03.750585",
      "status": "completed"
     },
     "tags": []
@@ -847,10 +847,10 @@
    "id": "58j7qubak5c",
    "metadata": {
     "papermill": {
-     "duration": 0.0043,
-     "end_time": "2026-05-12T10:00:31.673948",
+     "duration": 0.005975,
+     "end_time": "2026-05-12T11:15:04.098103",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.669648",
+     "start_time": "2026-05-12T11:15:04.092128",
      "status": "completed"
     },
     "tags": []
@@ -865,16 +865,16 @@
    "id": "62d6a7ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.684184Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.683797Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.698049Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.697120Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.108118Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.107787Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.120260Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.119308Z"
     },
     "papermill": {
-     "duration": 0.021482,
-     "end_time": "2026-05-12T10:00:31.699718",
+     "duration": 0.019453,
+     "end_time": "2026-05-12T11:15:04.121743",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.678236",
+     "start_time": "2026-05-12T11:15:04.102290",
      "status": "completed"
     },
     "tags": []
@@ -1143,10 +1143,10 @@
    "id": "e75258e1",
    "metadata": {
     "papermill": {
-     "duration": 0.004217,
-     "end_time": "2026-05-12T10:00:31.709433",
+     "duration": 0.006123,
+     "end_time": "2026-05-12T11:15:04.134887",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.705216",
+     "start_time": "2026-05-12T11:15:04.128764",
      "status": "completed"
     },
     "tags": []
@@ -1196,16 +1196,16 @@
    "id": "ba896395",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.719825Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.719506Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.746925Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.746364Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.150172Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.149628Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.173711Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.172633Z"
     },
     "papermill": {
-     "duration": 0.034007,
-     "end_time": "2026-05-12T10:00:31.748054",
+     "duration": 0.034024,
+     "end_time": "2026-05-12T11:15:04.175360",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.714047",
+     "start_time": "2026-05-12T11:15:04.141336",
      "status": "completed"
     },
     "tags": []
@@ -1275,10 +1275,10 @@
    "id": "64a6a3da",
    "metadata": {
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-05-12T10:00:31.757279",
+     "duration": 0.006808,
+     "end_time": "2026-05-12T11:15:04.188201",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.752771",
+     "start_time": "2026-05-12T11:15:04.181393",
      "status": "completed"
     },
     "tags": []
@@ -1321,16 +1321,16 @@
    "id": "a747201c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.767317Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.766856Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.782152Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.781196Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.203273Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.202671Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.218697Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.217803Z"
     },
     "papermill": {
-     "duration": 0.022024,
-     "end_time": "2026-05-12T10:00:31.783501",
+     "duration": 0.025557,
+     "end_time": "2026-05-12T11:15:04.220303",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.761477",
+     "start_time": "2026-05-12T11:15:04.194746",
      "status": "completed"
     },
     "tags": []
@@ -1485,10 +1485,10 @@
    "id": "7e1176e6",
    "metadata": {
     "papermill": {
-     "duration": 0.003933,
-     "end_time": "2026-05-12T10:00:31.794228",
+     "duration": 0.005864,
+     "end_time": "2026-05-12T11:15:04.236027",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.790295",
+     "start_time": "2026-05-12T11:15:04.230163",
      "status": "completed"
     },
     "tags": []
@@ -1527,16 +1527,16 @@
    "id": "84553629",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.803837Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.803317Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.808804Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.807984Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.250455Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.249989Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.254749Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.253936Z"
     },
     "papermill": {
-     "duration": 0.011629,
-     "end_time": "2026-05-12T10:00:31.809868",
+     "duration": 0.013815,
+     "end_time": "2026-05-12T11:15:04.256195",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.798239",
+     "start_time": "2026-05-12T11:15:04.242380",
      "status": "completed"
     },
     "tags": []
@@ -1569,10 +1569,10 @@
    "id": "fgpme48zvz4",
    "metadata": {
     "papermill": {
-     "duration": 0.005208,
-     "end_time": "2026-05-12T10:00:31.819280",
+     "duration": 0.006022,
+     "end_time": "2026-05-12T11:15:04.268284",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.814072",
+     "start_time": "2026-05-12T11:15:04.262262",
      "status": "completed"
     },
     "tags": []
@@ -1587,16 +1587,16 @@
    "id": "dacdbf51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.829360Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.829052Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.842298Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.841355Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.284561Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.284061Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.297385Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.296219Z"
     },
     "papermill": {
-     "duration": 0.0203,
-     "end_time": "2026-05-12T10:00:31.844046",
+     "duration": 0.024168,
+     "end_time": "2026-05-12T11:15:04.299132",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.823746",
+     "start_time": "2026-05-12T11:15:04.274964",
      "status": "completed"
     },
     "tags": []
@@ -1780,10 +1780,10 @@
    "id": "a6db2fc7",
    "metadata": {
     "papermill": {
-     "duration": 0.004031,
-     "end_time": "2026-05-12T10:00:31.854260",
+     "duration": 0.00657,
+     "end_time": "2026-05-12T11:15:04.312614",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.850229",
+     "start_time": "2026-05-12T11:15:04.306044",
      "status": "completed"
     },
     "tags": []
@@ -1851,16 +1851,16 @@
    "id": "a7af4b97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T10:00:31.864493Z",
-     "iopub.status.busy": "2026-05-12T10:00:31.864181Z",
-     "iopub.status.idle": "2026-05-12T10:00:31.872922Z",
-     "shell.execute_reply": "2026-05-12T10:00:31.872126Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.327053Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.326741Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.335628Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.334646Z"
     },
     "papermill": {
-     "duration": 0.015946,
-     "end_time": "2026-05-12T10:00:31.874560",
+     "duration": 0.017995,
+     "end_time": "2026-05-12T11:15:04.337148",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.858614",
+     "start_time": "2026-05-12T11:15:04.319153",
      "status": "completed"
     },
     "tags": []
@@ -2042,10 +2042,10 @@
    "id": "0a694ae8",
    "metadata": {
     "papermill": {
-     "duration": 0.00484,
-     "end_time": "2026-05-12T10:00:31.884915",
+     "duration": 0.006352,
+     "end_time": "2026-05-12T11:15:04.351753",
      "exception": false,
-     "start_time": "2026-05-12T10:00:31.880075",
+     "start_time": "2026-05-12T11:15:04.345401",
      "status": "completed"
     },
     "tags": []
@@ -2141,8 +2141,8 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.886953,
-   "end_time": "2026-05-12T10:00:32.246767",
+   "duration": 3.853431,
+   "end_time": "2026-05-12T11:15:04.704589",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Image\\01-Foundation\\01-5-Qwen-Image-Edit.ipynb",
@@ -2150,7 +2150,7 @@
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-05-12T10:00:27.359814",
+   "start_time": "2026-05-12T11:15:00.851158",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.006064,
-     "end_time": "2026-05-12T09:55:51.058531",
+     "duration": 0.00419,
+     "end_time": "2026-05-12T11:15:02.980409",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.052467",
+     "start_time": "2026-05-12T11:15:02.976219",
      "status": "completed"
     },
     "tags": []
@@ -23,16 +23,16 @@
    "id": "cell-1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.071440Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.071160Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.078551Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.077640Z"
+     "iopub.execute_input": "2026-05-12T11:15:02.993360Z",
+     "iopub.status.busy": "2026-05-12T11:15:02.993052Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.000079Z",
+     "shell.execute_reply": "2026-05-12T11:15:02.998986Z"
     },
     "papermill": {
-     "duration": 0.015537,
-     "end_time": "2026-05-12T09:55:51.080285",
+     "duration": 0.016223,
+     "end_time": "2026-05-12T11:15:03.001851",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.064748",
+     "start_time": "2026-05-12T11:15:02.985628",
      "status": "completed"
     },
     "tags": [
@@ -55,7 +55,7 @@
     "use_api = True\n",
     "\n",
     "# Parametres API ComfyUI (si use_api=True)\n",
-    "comfyui_url = \"https://comfyui-video.myia.io\"  # ComfyUI-Video service\n",
+    "comfyui_url = os.getenv(\"COMFYUI_VIDEO_URL\", \"https://comfyui-video.myia.io\")  # ComfyUI-Video service\n",
     "comfyui_token = os.getenv(\"COMFYUI_VIDEO_TOKEN\")  # Token Bearer (charge depuis .env)\n",
     "\n",
     "# Parametres modele HunyuanVideo (si use_api=False)\n",
@@ -83,16 +83,16 @@
    "id": "f9f350f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.091487Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.090923Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.096859Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.095268Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.014522Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.014213Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.017896Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.017174Z"
     },
     "papermill": {
-     "duration": 0.014469,
-     "end_time": "2026-05-12T09:55:51.098823",
+     "duration": 0.012413,
+     "end_time": "2026-05-12T11:15:03.019372",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.084354",
+     "start_time": "2026-05-12T11:15:03.006959",
      "status": "completed"
     },
     "tags": [
@@ -110,10 +110,10 @@
    "id": "lo8o3p2kbq",
    "metadata": {
     "papermill": {
-     "duration": 0.005795,
-     "end_time": "2026-05-12T09:55:51.110572",
+     "duration": 0.006702,
+     "end_time": "2026-05-12T11:15:03.032145",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.104777",
+     "start_time": "2026-05-12T11:15:03.025443",
      "status": "completed"
     },
     "tags": []
@@ -128,16 +128,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.122094Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.121608Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.131902Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.130324Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.047326Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.046876Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.055044Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.054154Z"
     },
     "papermill": {
-     "duration": 0.017861,
-     "end_time": "2026-05-12T09:55:51.133792",
+     "duration": 0.017259,
+     "end_time": "2026-05-12T11:15:03.057125",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.115931",
+     "start_time": "2026-05-12T11:15:03.039866",
      "status": "completed"
     },
     "tags": []
@@ -165,10 +165,10 @@
    "id": "f9kpp71jplr",
    "metadata": {
     "papermill": {
-     "duration": 0.007178,
-     "end_time": "2026-05-12T09:55:51.147829",
+     "duration": 0.006629,
+     "end_time": "2026-05-12T11:15:03.070560",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.140651",
+     "start_time": "2026-05-12T11:15:03.063931",
      "status": "completed"
     },
     "tags": []
@@ -183,16 +183,16 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.159754Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.159218Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.192946Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.191148Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.084579Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.083950Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.108557Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.107319Z"
     },
     "papermill": {
-     "duration": 0.04098,
-     "end_time": "2026-05-12T09:55:51.194777",
+     "duration": 0.035201,
+     "end_time": "2026-05-12T11:15:03.110701",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.153797",
+     "start_time": "2026-05-12T11:15:03.075500",
      "status": "completed"
     },
     "tags": []
@@ -382,10 +382,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.004007,
-     "end_time": "2026-05-12T09:55:51.203150",
+     "duration": 0.006014,
+     "end_time": "2026-05-12T11:15:03.123220",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.199143",
+     "start_time": "2026-05-12T11:15:03.117206",
      "status": "completed"
     },
     "tags": []
@@ -400,16 +400,16 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.212743Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.212369Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.222283Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.221054Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.138668Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.138136Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.147311Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.146448Z"
     },
     "papermill": {
-     "duration": 0.016698,
-     "end_time": "2026-05-12T09:55:51.223978",
+     "duration": 0.018886,
+     "end_time": "2026-05-12T11:15:03.148918",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.207280",
+     "start_time": "2026-05-12T11:15:03.130032",
      "status": "completed"
     },
     "tags": []
@@ -537,10 +537,10 @@
    "id": "l563jvpap1",
    "metadata": {
     "papermill": {
-     "duration": 0.004353,
-     "end_time": "2026-05-12T09:55:51.232382",
+     "duration": 0.006648,
+     "end_time": "2026-05-12T11:15:03.161458",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.228029",
+     "start_time": "2026-05-12T11:15:03.154810",
      "status": "completed"
     },
     "tags": []
@@ -555,16 +555,16 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.242089Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.241720Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.250992Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.249803Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.176234Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.175466Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.184156Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.183382Z"
     },
     "papermill": {
-     "duration": 0.015902,
-     "end_time": "2026-05-12T09:55:51.252292",
+     "duration": 0.017031,
+     "end_time": "2026-05-12T11:15:03.185696",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.236390",
+     "start_time": "2026-05-12T11:15:03.168665",
      "status": "completed"
     },
     "tags": []
@@ -648,10 +648,10 @@
    "id": "60wdqtkxjn",
    "metadata": {
     "papermill": {
-     "duration": 0.00387,
-     "end_time": "2026-05-12T09:55:51.260147",
+     "duration": 0.005054,
+     "end_time": "2026-05-12T11:15:03.194842",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.256277",
+     "start_time": "2026-05-12T11:15:03.189788",
      "status": "completed"
     },
     "tags": []
@@ -666,16 +666,16 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.269207Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.268629Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.277224Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.276292Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.204671Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.204336Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.212805Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.211811Z"
     },
     "papermill": {
-     "duration": 0.014555,
-     "end_time": "2026-05-12T09:55:51.278436",
+     "duration": 0.015745,
+     "end_time": "2026-05-12T11:15:03.214408",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.263881",
+     "start_time": "2026-05-12T11:15:03.198663",
      "status": "completed"
     },
     "tags": []
@@ -778,10 +778,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.006848,
-     "end_time": "2026-05-12T09:55:51.289203",
+     "duration": 0.006535,
+     "end_time": "2026-05-12T11:15:03.225660",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.282355",
+     "start_time": "2026-05-12T11:15:03.219125",
      "status": "completed"
     },
     "tags": []
@@ -811,16 +811,16 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.298878Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.298485Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.309431Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.308552Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.237379Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.236621Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.247112Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.246025Z"
     },
     "papermill": {
-     "duration": 0.017696,
-     "end_time": "2026-05-12T09:55:51.310934",
+     "duration": 0.018757,
+     "end_time": "2026-05-12T11:15:03.248488",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.293238",
+     "start_time": "2026-05-12T11:15:03.229731",
      "status": "completed"
     },
     "tags": []
@@ -938,10 +938,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.004099,
-     "end_time": "2026-05-12T09:55:51.319258",
+     "duration": 0.00434,
+     "end_time": "2026-05-12T11:15:03.258201",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.315159",
+     "start_time": "2026-05-12T11:15:03.253861",
      "status": "completed"
     },
     "tags": []
@@ -1025,16 +1025,16 @@
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.329953Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.329645Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.340807Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.339409Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.268087Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.267567Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.277827Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.277005Z"
     },
     "papermill": {
-     "duration": 0.018319,
-     "end_time": "2026-05-12T09:55:51.342161",
+     "duration": 0.016885,
+     "end_time": "2026-05-12T11:15:03.279448",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.323842",
+     "start_time": "2026-05-12T11:15:03.262563",
      "status": "completed"
     },
     "tags": []
@@ -1151,10 +1151,10 @@
    "id": "kzgxpoynp2s",
    "metadata": {
     "papermill": {
-     "duration": 0.003879,
-     "end_time": "2026-05-12T09:55:51.350038",
+     "duration": 0.006617,
+     "end_time": "2026-05-12T11:15:03.292508",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.346159",
+     "start_time": "2026-05-12T11:15:03.285891",
      "status": "completed"
     },
     "tags": []
@@ -1169,16 +1169,16 @@
    "id": "cell-14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.359281Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.358839Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.367643Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.366295Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.306566Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.306270Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.315531Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.314555Z"
     },
     "papermill": {
-     "duration": 0.015775,
-     "end_time": "2026-05-12T09:55:51.369593",
+     "duration": 0.018195,
+     "end_time": "2026-05-12T11:15:03.317108",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.353818",
+     "start_time": "2026-05-12T11:15:03.298913",
      "status": "completed"
     },
     "tags": []
@@ -1259,10 +1259,10 @@
    "id": "cell-15",
    "metadata": {
     "papermill": {
-     "duration": 0.004104,
-     "end_time": "2026-05-12T09:55:51.378216",
+     "duration": 0.00434,
+     "end_time": "2026-05-12T11:15:03.328675",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.374112",
+     "start_time": "2026-05-12T11:15:03.324335",
      "status": "completed"
     },
     "tags": []
@@ -1294,10 +1294,10 @@
    "id": "azt6dim2ua",
    "metadata": {
     "papermill": {
-     "duration": 0.004144,
-     "end_time": "2026-05-12T09:55:51.386475",
+     "duration": 0.003854,
+     "end_time": "2026-05-12T11:15:03.336626",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.382331",
+     "start_time": "2026-05-12T11:15:03.332772",
      "status": "completed"
     },
     "tags": []
@@ -1332,16 +1332,16 @@
    "id": "sxsaa1xpvbi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.397788Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.397156Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.403790Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.402731Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.351785Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.351255Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.355992Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.354875Z"
     },
     "papermill": {
-     "duration": 0.013782,
-     "end_time": "2026-05-12T09:55:51.405235",
+     "duration": 0.014364,
+     "end_time": "2026-05-12T11:15:03.357847",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.391453",
+     "start_time": "2026-05-12T11:15:03.343483",
      "status": "completed"
     },
     "tags": []
@@ -1376,10 +1376,10 @@
    "id": "atp8jnc141",
    "metadata": {
     "papermill": {
-     "duration": 0.005886,
-     "end_time": "2026-05-12T09:55:51.415781",
+     "duration": 0.004403,
+     "end_time": "2026-05-12T11:15:03.367601",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.409895",
+     "start_time": "2026-05-12T11:15:03.363198",
      "status": "completed"
     },
     "tags": []
@@ -1394,16 +1394,16 @@
    "id": "agk8osyq6xo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.426271Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.425753Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.432662Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.431406Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.379920Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.379292Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.384528Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.383770Z"
     },
     "papermill": {
-     "duration": 0.013995,
-     "end_time": "2026-05-12T09:55:51.434214",
+     "duration": 0.014199,
+     "end_time": "2026-05-12T11:15:03.385876",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.420219",
+     "start_time": "2026-05-12T11:15:03.371677",
      "status": "completed"
     },
     "tags": []
@@ -1440,10 +1440,10 @@
    "id": "zlnyazr08vs",
    "metadata": {
     "papermill": {
-     "duration": 0.005686,
-     "end_time": "2026-05-12T09:55:51.444315",
+     "duration": 0.004271,
+     "end_time": "2026-05-12T11:15:03.394519",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.438629",
+     "start_time": "2026-05-12T11:15:03.390248",
      "status": "completed"
     },
     "tags": []
@@ -1458,16 +1458,16 @@
    "id": "p1ly3tc4lc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.454745Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.454305Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.460015Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.458648Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.404635Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.404114Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.409044Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.408056Z"
     },
     "papermill": {
-     "duration": 0.013411,
-     "end_time": "2026-05-12T09:55:51.462107",
+     "duration": 0.011573,
+     "end_time": "2026-05-12T11:15:03.410455",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.448696",
+     "start_time": "2026-05-12T11:15:03.398882",
      "status": "completed"
     },
     "tags": []
@@ -1495,10 +1495,10 @@
    "id": "lz5hlza5q7",
    "metadata": {
     "papermill": {
-     "duration": 0.003973,
-     "end_time": "2026-05-12T09:55:51.470397",
+     "duration": 0.004561,
+     "end_time": "2026-05-12T11:15:03.421802",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.466424",
+     "start_time": "2026-05-12T11:15:03.417241",
      "status": "completed"
     },
     "tags": []
@@ -1521,16 +1521,16 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.485403Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.484909Z",
-     "iopub.status.idle": "2026-05-12T09:55:54.230354Z",
-     "shell.execute_reply": "2026-05-12T09:55:54.229384Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.434471Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.434057Z",
+     "iopub.status.idle": "2026-05-12T11:15:08.442195Z",
+     "shell.execute_reply": "2026-05-12T11:15:08.440458Z"
     },
     "papermill": {
-     "duration": 2.757245,
-     "end_time": "2026-05-12T09:55:54.232432",
+     "duration": 5.018365,
+     "end_time": "2026-05-12T11:15:08.444599",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.475187",
+     "start_time": "2026-05-12T11:15:03.426234",
      "status": "completed"
     },
     "tags": []
@@ -1543,7 +1543,7 @@
       "\n",
       "--- STATISTIQUES DE SESSION ---\n",
       "========================================\n",
-      "Date : 2026-05-12 11:55:51\n",
+      "Date : 2026-05-12 13:15:03\n",
       "Mode : interactive\n",
       "Modele : tencent/HunyuanVideo\n",
       "Quantification : INT8\n",
@@ -1566,7 +1566,7 @@
       "3. Notebook 02-4 : SVD (animation d'images statiques)\n",
       "4. Module 03 : Comparaison multi-modeles et orchestration de pipelines\n",
       "\n",
-      "Notebook 02-1 HunyuanVideo Generation termine - 11:55:54\n"
+      "Notebook 02-1 HunyuanVideo Generation termine - 13:15:08\n"
      ]
     }
    ],
@@ -1643,8 +1643,8 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.34607,
-   "end_time": "2026-05-12T09:55:54.916132",
+   "duration": 8.359853,
+   "end_time": "2026-05-12T11:15:09.222943",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-1-HunyuanVideo-Generation.ipynb",
@@ -1652,7 +1652,7 @@
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-05-12T09:55:48.570062",
+   "start_time": "2026-05-12T11:15:00.863090",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
@@ -5,10 +5,10 @@
    "id": "b254bf28",
    "metadata": {
     "papermill": {
-     "duration": 0.007391,
-     "end_time": "2026-05-12T09:55:51.090648",
+     "duration": 0.005281,
+     "end_time": "2026-05-12T11:15:02.997277",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.083257",
+     "start_time": "2026-05-12T11:15:02.991996",
      "status": "completed"
     },
     "tags": []
@@ -51,16 +51,16 @@
    "id": "e77ed8a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.104706Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.103959Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.112794Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.111558Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.007583Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.007163Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.015479Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.014575Z"
     },
     "papermill": {
-     "duration": 0.019383,
-     "end_time": "2026-05-12T09:55:51.116502",
+     "duration": 0.014949,
+     "end_time": "2026-05-12T11:15:03.017262",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.097119",
+     "start_time": "2026-05-12T11:15:03.002313",
      "status": "completed"
     },
     "tags": [
@@ -83,7 +83,7 @@
     "use_api = True\n",
     "\n",
     "# Parametres API ComfyUI (si use_api=True)\n",
-    "comfyui_url = \"https://comfyui-video.myia.io\"  # ComfyUI-Video service\n",
+    "comfyui_url = os.getenv(\"COMFYUI_VIDEO_URL\", \"https://comfyui-video.myia.io\")  # ComfyUI-Video service\n",
     "comfyui_token = os.getenv(\"COMFYUI_VIDEO_TOKEN\")  # Token Bearer (charge depuis .env)\n",
     "\n",
     "# Parametres modele Wan (si use_api=False)\n",
@@ -110,16 +110,16 @@
    "id": "86443580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.129439Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.128796Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.134351Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.133449Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.030495Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.029990Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.034511Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.032994Z"
     },
     "papermill": {
-     "duration": 0.013853,
-     "end_time": "2026-05-12T09:55:51.135879",
+     "duration": 0.013975,
+     "end_time": "2026-05-12T11:15:03.036873",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.122026",
+     "start_time": "2026-05-12T11:15:03.022898",
      "status": "completed"
     },
     "tags": [
@@ -137,10 +137,10 @@
    "id": "n5z05qy88ao",
    "metadata": {
     "papermill": {
-     "duration": 0.005648,
-     "end_time": "2026-05-12T09:55:51.145328",
+     "duration": 0.007222,
+     "end_time": "2026-05-12T11:15:03.050089",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.139680",
+     "start_time": "2026-05-12T11:15:03.042867",
      "status": "completed"
     },
     "tags": []
@@ -155,16 +155,16 @@
    "id": "8f09a5ea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.158369Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.157535Z",
-     "iopub.status.idle": "2026-05-12T09:55:51.831533Z",
-     "shell.execute_reply": "2026-05-12T09:55:51.830393Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.062276Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.061635Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.623352Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.622502Z"
     },
     "papermill": {
-     "duration": 0.682001,
-     "end_time": "2026-05-12T09:55:51.832960",
+     "duration": 0.570061,
+     "end_time": "2026-05-12T11:15:03.624984",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.150959",
+     "start_time": "2026-05-12T11:15:03.054923",
      "status": "completed"
     },
     "tags": []
@@ -177,7 +177,7 @@
       "[OK] Helper comfyui_client importé\n",
       "Wan 2.1/2.2 - Generation Video Multilingue\n",
       "Mode d'execution : API ComfyUI\n",
-      "Date : 2026-05-12 11:55:51\n",
+      "Date : 2026-05-12 13:15:03\n",
       "Frames : 16, Steps : 20, CFG : 6.0\n",
       "Resolution : 832x480\n"
      ]
@@ -242,10 +242,10 @@
    "id": "o6xpelwpvjk",
    "metadata": {
     "papermill": {
-     "duration": 0.00372,
-     "end_time": "2026-05-12T09:55:51.840734",
+     "duration": 0.003151,
+     "end_time": "2026-05-12T11:15:03.633087",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.837014",
+     "start_time": "2026-05-12T11:15:03.629936",
      "status": "completed"
     },
     "tags": []
@@ -260,16 +260,16 @@
    "id": "2d24084b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:51.853078Z",
-     "iopub.status.busy": "2026-05-12T09:55:51.852379Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.084620Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.083611Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.644207Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.643816Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.850088Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.849062Z"
     },
     "papermill": {
-     "duration": 0.240461,
-     "end_time": "2026-05-12T09:55:52.085999",
+     "duration": 0.215605,
+     "end_time": "2026-05-12T11:15:03.851866",
      "exception": false,
-     "start_time": "2026-05-12T09:55:51.845538",
+     "start_time": "2026-05-12T11:15:03.636261",
      "status": "completed"
     },
     "tags": []
@@ -457,10 +457,10 @@
    "id": "735a80be",
    "metadata": {
     "papermill": {
-     "duration": 0.004003,
-     "end_time": "2026-05-12T09:55:52.094146",
+     "duration": 0.00626,
+     "end_time": "2026-05-12T11:15:03.864110",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.090143",
+     "start_time": "2026-05-12T11:15:03.857850",
      "status": "completed"
     },
     "tags": []
@@ -507,16 +507,16 @@
    "id": "cb5c8f19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.103674Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.102934Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.113438Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.112753Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.878101Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.877614Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.886762Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.885841Z"
     },
     "papermill": {
-     "duration": 0.017321,
-     "end_time": "2026-05-12T09:55:52.115217",
+     "duration": 0.017728,
+     "end_time": "2026-05-12T11:15:03.888083",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.097896",
+     "start_time": "2026-05-12T11:15:03.870355",
      "status": "completed"
     },
     "tags": []
@@ -640,10 +640,10 @@
    "id": "10930f16",
    "metadata": {
     "papermill": {
-     "duration": 0.004128,
-     "end_time": "2026-05-12T09:55:52.123620",
+     "duration": 0.006409,
+     "end_time": "2026-05-12T11:15:03.898597",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.119492",
+     "start_time": "2026-05-12T11:15:03.892188",
      "status": "completed"
     },
     "tags": []
@@ -661,16 +661,16 @@
    "id": "80d3d0f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.132453Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.132117Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.140375Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.138976Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.910688Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.910225Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.917256Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.916344Z"
     },
     "papermill": {
-     "duration": 0.014382,
-     "end_time": "2026-05-12T09:55:52.141858",
+     "duration": 0.015268,
+     "end_time": "2026-05-12T11:15:03.919079",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.127476",
+     "start_time": "2026-05-12T11:15:03.903811",
      "status": "completed"
     },
     "tags": []
@@ -740,10 +740,10 @@
    "id": "a0045a37",
    "metadata": {
     "papermill": {
-     "duration": 0.004339,
-     "end_time": "2026-05-12T09:55:52.149964",
+     "duration": 0.005998,
+     "end_time": "2026-05-12T11:15:03.931235",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.145625",
+     "start_time": "2026-05-12T11:15:03.925237",
      "status": "completed"
     },
     "tags": []
@@ -774,10 +774,10 @@
    "id": "55fb18ee",
    "metadata": {
     "papermill": {
-     "duration": 0.004029,
-     "end_time": "2026-05-12T09:55:52.158171",
+     "duration": 0.005541,
+     "end_time": "2026-05-12T11:15:03.942844",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.154142",
+     "start_time": "2026-05-12T11:15:03.937303",
      "status": "completed"
     },
     "tags": []
@@ -794,16 +794,16 @@
    "id": "da611d80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.171264Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.170571Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.179920Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.178650Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.956690Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.956096Z",
+     "iopub.status.idle": "2026-05-12T11:15:03.963163Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.962477Z"
     },
     "papermill": {
-     "duration": 0.0199,
-     "end_time": "2026-05-12T09:55:52.182150",
+     "duration": 0.018065,
+     "end_time": "2026-05-12T11:15:03.964289",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.162250",
+     "start_time": "2026-05-12T11:15:03.946224",
      "status": "completed"
     },
     "tags": []
@@ -881,10 +881,10 @@
    "id": "0c4fb1cd",
    "metadata": {
     "papermill": {
-     "duration": 0.005238,
-     "end_time": "2026-05-12T09:55:52.192444",
+     "duration": 0.003517,
+     "end_time": "2026-05-12T11:15:03.973280",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.187206",
+     "start_time": "2026-05-12T11:15:03.969763",
      "status": "completed"
     },
     "tags": []
@@ -911,10 +911,10 @@
    "id": "7f01e810",
    "metadata": {
     "papermill": {
-     "duration": 0.003892,
-     "end_time": "2026-05-12T09:55:52.200420",
+     "duration": 0.005169,
+     "end_time": "2026-05-12T11:15:03.982855",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.196528",
+     "start_time": "2026-05-12T11:15:03.977686",
      "status": "completed"
     },
     "tags": []
@@ -931,16 +931,16 @@
    "id": "cfa445be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.210365Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.209981Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.218800Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.217598Z"
+     "iopub.execute_input": "2026-05-12T11:15:03.994024Z",
+     "iopub.status.busy": "2026-05-12T11:15:03.993593Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.000476Z",
+     "shell.execute_reply": "2026-05-12T11:15:03.999590Z"
     },
     "papermill": {
-     "duration": 0.015676,
-     "end_time": "2026-05-12T09:55:52.220158",
+     "duration": 0.014681,
+     "end_time": "2026-05-12T11:15:04.001763",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.204482",
+     "start_time": "2026-05-12T11:15:03.987082",
      "status": "completed"
     },
     "tags": []
@@ -1012,10 +1012,10 @@
    "id": "f0e0b7a7",
    "metadata": {
     "papermill": {
-     "duration": 0.004066,
-     "end_time": "2026-05-12T09:55:52.232591",
+     "duration": 0.005284,
+     "end_time": "2026-05-12T11:15:04.012082",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.228525",
+     "start_time": "2026-05-12T11:15:04.006798",
      "status": "completed"
     },
     "tags": []
@@ -1060,10 +1060,10 @@
    "id": "iqfm3mqol3",
    "metadata": {
     "papermill": {
-     "duration": 0.00496,
-     "end_time": "2026-05-12T09:55:52.244188",
+     "duration": 0.004314,
+     "end_time": "2026-05-12T11:15:04.022985",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.239228",
+     "start_time": "2026-05-12T11:15:04.018671",
      "status": "completed"
     },
     "tags": []
@@ -1097,10 +1097,10 @@
    "id": "dvsmu6kywm",
    "metadata": {
     "papermill": {
-     "duration": 0.004507,
-     "end_time": "2026-05-12T09:55:52.252922",
+     "duration": 0.003471,
+     "end_time": "2026-05-12T11:15:04.030667",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.248415",
+     "start_time": "2026-05-12T11:15:04.027196",
      "status": "completed"
     },
     "tags": []
@@ -1123,16 +1123,16 @@
    "id": "ecbbpohlb5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.262546Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.262005Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.268693Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.267481Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.041137Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.040620Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.045587Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.044769Z"
     },
     "papermill": {
-     "duration": 0.013508,
-     "end_time": "2026-05-12T09:55:52.270338",
+     "duration": 0.011397,
+     "end_time": "2026-05-12T11:15:04.047220",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.256830",
+     "start_time": "2026-05-12T11:15:04.035823",
      "status": "completed"
     },
     "tags": []
@@ -1173,10 +1173,10 @@
    "id": "ydwmvjegcc",
    "metadata": {
     "papermill": {
-     "duration": 0.003862,
-     "end_time": "2026-05-12T09:55:52.278261",
+     "duration": 0.003988,
+     "end_time": "2026-05-12T11:15:04.055746",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.274399",
+     "start_time": "2026-05-12T11:15:04.051758",
      "status": "completed"
     },
     "tags": []
@@ -1191,16 +1191,16 @@
    "id": "lasl0pmo12b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.287938Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.287433Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.293373Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.292351Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.065553Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.065028Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.069892Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.068974Z"
     },
     "papermill": {
-     "duration": 0.013047,
-     "end_time": "2026-05-12T09:55:52.295271",
+     "duration": 0.010736,
+     "end_time": "2026-05-12T11:15:04.070981",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.282224",
+     "start_time": "2026-05-12T11:15:04.060245",
      "status": "completed"
     },
     "tags": []
@@ -1248,10 +1248,10 @@
    "id": "we9zpvztota",
    "metadata": {
     "papermill": {
-     "duration": 0.004257,
-     "end_time": "2026-05-12T09:55:52.304108",
+     "duration": 0.004514,
+     "end_time": "2026-05-12T11:15:04.079621",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.299851",
+     "start_time": "2026-05-12T11:15:04.075107",
      "status": "completed"
     },
     "tags": []
@@ -1266,16 +1266,16 @@
    "id": "aiuwhy4i85k",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.314377Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.314040Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.320185Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.318653Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.089769Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.089280Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.094799Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.093944Z"
     },
     "papermill": {
-     "duration": 0.013699,
-     "end_time": "2026-05-12T09:55:52.322131",
+     "duration": 0.011752,
+     "end_time": "2026-05-12T11:15:04.095987",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.308432",
+     "start_time": "2026-05-12T11:15:04.084235",
      "status": "completed"
     },
     "tags": []
@@ -1325,10 +1325,10 @@
    "id": "xfpzc9x806",
    "metadata": {
     "papermill": {
-     "duration": 0.003937,
-     "end_time": "2026-05-12T09:55:52.332113",
+     "duration": 0.00639,
+     "end_time": "2026-05-12T11:15:04.106341",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.328176",
+     "start_time": "2026-05-12T11:15:04.099951",
      "status": "completed"
     },
     "tags": []
@@ -1343,16 +1343,16 @@
    "id": "e135f376",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:55:52.341801Z",
-     "iopub.status.busy": "2026-05-12T09:55:52.341292Z",
-     "iopub.status.idle": "2026-05-12T09:55:52.351026Z",
-     "shell.execute_reply": "2026-05-12T09:55:52.349460Z"
+     "iopub.execute_input": "2026-05-12T11:15:04.116784Z",
+     "iopub.status.busy": "2026-05-12T11:15:04.116499Z",
+     "iopub.status.idle": "2026-05-12T11:15:04.122653Z",
+     "shell.execute_reply": "2026-05-12T11:15:04.121863Z"
     },
     "papermill": {
-     "duration": 0.016909,
-     "end_time": "2026-05-12T09:55:52.353089",
+     "duration": 0.012989,
+     "end_time": "2026-05-12T11:15:04.124227",
      "exception": false,
-     "start_time": "2026-05-12T09:55:52.336180",
+     "start_time": "2026-05-12T11:15:04.111238",
      "status": "completed"
     },
     "tags": []
@@ -1365,7 +1365,7 @@
       "\n",
       "--- STATISTIQUES DE SESSION ---\n",
       "==================================================\n",
-      "Date : 2026-05-12 11:55:52\n",
+      "Date : 2026-05-12 13:15:04\n",
       "Mode d'execution : API ComfyUI\n",
       "Modele : wan2.1_t2v_1.3B (ComfyUI)\n",
       "Parametres : 16 frames, 20 steps, CFG=6.0\n",
@@ -1379,7 +1379,7 @@
       "3. Module 03-2 : Orchestration de pipelines text -> image -> video\n",
       "4. Tester Wan 2.2 quand disponible pour les ameliorations de qualite\n",
       "\n",
-      "Notebook 02-3 Wan Video Generation termine - 11:55:52\n"
+      "Notebook 02-3 Wan Video Generation termine - 13:15:04\n"
      ]
     }
    ],
@@ -1433,8 +1433,8 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.129053,
-   "end_time": "2026-05-12T09:55:52.706611",
+   "duration": 3.605911,
+   "end_time": "2026-05-12T11:15:04.483799",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-3-Wan-Video-Generation.ipynb",
@@ -1442,7 +1442,7 @@
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-05-12T09:55:48.577558",
+   "start_time": "2026-05-12T11:15:00.877888",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-header",
    "metadata": {
     "papermill": {
-     "duration": 0.007025,
-     "end_time": "2026-05-12T09:56:49.558911",
+     "duration": 0.003659,
+     "end_time": "2026-05-12T11:14:50.948171",
      "exception": false,
-     "start_time": "2026-05-12T09:56:49.551886",
+     "start_time": "2026-05-12T11:14:50.944512",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "cell-params",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:49.572232Z",
-     "iopub.status.busy": "2026-05-12T09:56:49.571690Z",
-     "iopub.status.idle": "2026-05-12T09:56:49.580625Z",
-     "shell.execute_reply": "2026-05-12T09:56:49.579128Z"
+     "iopub.execute_input": "2026-05-12T11:14:50.956613Z",
+     "iopub.status.busy": "2026-05-12T11:14:50.956285Z",
+     "iopub.status.idle": "2026-05-12T11:14:50.961972Z",
+     "shell.execute_reply": "2026-05-12T11:14:50.961317Z"
     },
     "papermill": {
-     "duration": 0.017608,
-     "end_time": "2026-05-12T09:56:49.582786",
+     "duration": 0.011426,
+     "end_time": "2026-05-12T11:14:50.963153",
      "exception": false,
-     "start_time": "2026-05-12T09:56:49.565178",
+     "start_time": "2026-05-12T11:14:50.951727",
      "status": "completed"
     },
     "tags": [
@@ -65,13 +65,15 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "# Parametres Papermill - JAMAIS modifier ce commentaire\n",
     "# Configuration notebook\n",
     "notebook_mode = \"interactive\"        # \"interactive\" ou \"batch\"\n",
     "skip_widgets = False               # True pour mode batch MCP\n",
     "debug_level = \"INFO\"\n",
     "# Parametres ComfyUI\n",
-    "comfyui_url = \"https://qwen-image-edit.myia.io\"  # URL du serveur ComfyUI\n",
+    "comfyui_url = os.getenv(\"COMFYUI_VIDEO_URL\", \"https://qwen-image-edit.myia.io\")  # URL du serveur ComfyUI\n",
     "workflow_type = \"animatediff\"         # Type de workflow : \"animatediff\"\n",
     "enable_video_helper = True           # Utiliser VideoHelperSuite\n",
     "# Parametres generation\n",
@@ -95,10 +97,10 @@
    "id": "h3ckl1tv0h9",
    "metadata": {
     "papermill": {
-     "duration": 0.005549,
-     "end_time": "2026-05-12T09:56:49.594242",
+     "duration": 0.002961,
+     "end_time": "2026-05-12T11:14:50.969010",
      "exception": false,
-     "start_time": "2026-05-12T09:56:49.588693",
+     "start_time": "2026-05-12T11:14:50.966049",
      "status": "completed"
     },
     "tags": []
@@ -113,16 +115,16 @@
    "id": "cell-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:49.607341Z",
-     "iopub.status.busy": "2026-05-12T09:56:49.606670Z",
-     "iopub.status.idle": "2026-05-12T09:56:50.278679Z",
-     "shell.execute_reply": "2026-05-12T09:56:50.277176Z"
+     "iopub.execute_input": "2026-05-12T11:14:50.976819Z",
+     "iopub.status.busy": "2026-05-12T11:14:50.976203Z",
+     "iopub.status.idle": "2026-05-12T11:14:51.544475Z",
+     "shell.execute_reply": "2026-05-12T11:14:51.543770Z"
     },
     "papermill": {
-     "duration": 0.681203,
-     "end_time": "2026-05-12T09:56:50.280732",
+     "duration": 0.573104,
+     "end_time": "2026-05-12T11:14:51.545414",
      "exception": false,
-     "start_time": "2026-05-12T09:56:49.599529",
+     "start_time": "2026-05-12T11:14:50.972310",
      "status": "completed"
     },
     "tags": []
@@ -135,7 +137,7 @@
       "WARNING: .env non trouve, utilisation variables environnement\n",
       "Helpers GenAI importes\n",
       "ComfyUI - Workflows Video via API\n",
-      "Date : 2026-05-12 11:56:50\n",
+      "Date : 2026-05-12 13:14:51\n",
       "Mode : interactive\n",
       "ComfyUI URL : https://qwen-image-edit.myia.io\n",
       "Workflow : animatediff\n",
@@ -213,10 +215,10 @@
    "id": "p8bll0kz2f",
    "metadata": {
     "papermill": {
-     "duration": 0.005145,
-     "end_time": "2026-05-12T09:56:50.290170",
+     "duration": 0.002698,
+     "end_time": "2026-05-12T11:14:51.551121",
      "exception": false,
-     "start_time": "2026-05-12T09:56:50.285025",
+     "start_time": "2026-05-12T11:14:51.548423",
      "status": "completed"
     },
     "tags": []
@@ -231,16 +233,16 @@
    "id": "cell-env",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:50.299668Z",
-     "iopub.status.busy": "2026-05-12T09:56:50.299012Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.347876Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.345993Z"
+     "iopub.execute_input": "2026-05-12T11:14:51.557999Z",
+     "iopub.status.busy": "2026-05-12T11:14:51.557439Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.053152Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.052596Z"
     },
     "papermill": {
-     "duration": 3.056247,
-     "end_time": "2026-05-12T09:56:53.350202",
+     "duration": 2.50056,
+     "end_time": "2026-05-12T11:14:54.054381",
      "exception": false,
-     "start_time": "2026-05-12T09:56:50.293955",
+     "start_time": "2026-05-12T11:14:51.553821",
      "status": "completed"
     },
     "tags": []
@@ -373,10 +375,10 @@
    "id": "cell-section1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004814,
-     "end_time": "2026-05-12T09:56:53.360298",
+     "duration": 0.003184,
+     "end_time": "2026-05-12T11:14:54.061323",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.355484",
+     "start_time": "2026-05-12T11:14:54.058139",
      "status": "completed"
     },
     "tags": []
@@ -414,16 +416,16 @@
    "id": "cell-workflow-def",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.372554Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.371849Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.388198Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.386830Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.070266Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.069861Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.081032Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.079943Z"
     },
     "papermill": {
-     "duration": 0.02533,
-     "end_time": "2026-05-12T09:56:53.389977",
+     "duration": 0.018037,
+     "end_time": "2026-05-12T11:14:54.082622",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.364647",
+     "start_time": "2026-05-12T11:14:54.064585",
      "status": "completed"
     },
     "tags": []
@@ -617,10 +619,10 @@
    "id": "cell-section2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.005972,
-     "end_time": "2026-05-12T09:56:53.402383",
+     "duration": 0.003211,
+     "end_time": "2026-05-12T11:14:54.089363",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.396411",
+     "start_time": "2026-05-12T11:14:54.086152",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +655,16 @@
    "id": "cell-submit",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.416871Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.415859Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.444165Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.442814Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.097350Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.097062Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.117394Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.116286Z"
     },
     "papermill": {
-     "duration": 0.037903,
-     "end_time": "2026-05-12T09:56:53.446301",
+     "duration": 0.026785,
+     "end_time": "2026-05-12T11:14:54.119492",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.408398",
+     "start_time": "2026-05-12T11:14:54.092707",
      "status": "completed"
     },
     "tags": []
@@ -877,10 +879,10 @@
    "id": "cell-section3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004965,
-     "end_time": "2026-05-12T09:56:53.455997",
+     "duration": 0.005392,
+     "end_time": "2026-05-12T11:14:54.130921",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.451032",
+     "start_time": "2026-05-12T11:14:54.125529",
      "status": "completed"
     },
     "tags": []
@@ -910,16 +912,16 @@
    "id": "cell-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.469185Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.468751Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.480975Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.479261Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.143966Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.143397Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.150719Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.149745Z"
     },
     "papermill": {
-     "duration": 0.02112,
-     "end_time": "2026-05-12T09:56:53.482875",
+     "duration": 0.015244,
+     "end_time": "2026-05-12T11:14:54.152197",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.461755",
+     "start_time": "2026-05-12T11:14:54.136953",
      "status": "completed"
     },
     "tags": []
@@ -1033,10 +1035,10 @@
    "id": "wr2vd0mz0o",
    "metadata": {
     "papermill": {
-     "duration": 0.007004,
-     "end_time": "2026-05-12T09:56:53.496278",
+     "duration": 0.004531,
+     "end_time": "2026-05-12T11:14:54.162430",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.489274",
+     "start_time": "2026-05-12T11:14:54.157899",
      "status": "completed"
     },
     "tags": []
@@ -1051,16 +1053,16 @@
    "id": "cell-interactive",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.510748Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.510240Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.523212Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.521352Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.175365Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.174803Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.186086Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.184861Z"
     },
     "papermill": {
-     "duration": 0.023229,
-     "end_time": "2026-05-12T09:56:53.525839",
+     "duration": 0.019851,
+     "end_time": "2026-05-12T11:14:54.187907",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.502610",
+     "start_time": "2026-05-12T11:14:54.168056",
      "status": "completed"
     },
     "tags": []
@@ -1150,10 +1152,10 @@
    "id": "73dhieicnau",
    "metadata": {
     "papermill": {
-     "duration": 0.007026,
-     "end_time": "2026-05-12T09:56:53.540594",
+     "duration": 0.003528,
+     "end_time": "2026-05-12T11:14:54.197457",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.533568",
+     "start_time": "2026-05-12T11:14:54.193929",
      "status": "completed"
     },
     "tags": []
@@ -1167,10 +1169,10 @@
    "id": "cell-conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.007323,
-     "end_time": "2026-05-12T09:56:53.553398",
+     "duration": 0.004423,
+     "end_time": "2026-05-12T11:14:54.205726",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.546075",
+     "start_time": "2026-05-12T11:14:54.201303",
      "status": "completed"
     },
     "tags": []
@@ -1213,10 +1215,10 @@
    "id": "2lmilt2pa36",
    "metadata": {
     "papermill": {
-     "duration": 0.008015,
-     "end_time": "2026-05-12T09:56:53.572483",
+     "duration": 0.003297,
+     "end_time": "2026-05-12T11:14:54.216099",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.564468",
+     "start_time": "2026-05-12T11:14:54.212802",
      "status": "completed"
     },
     "tags": []
@@ -1422,16 +1424,16 @@
    "id": "p7w1qzc64a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.589321Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.588428Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.598830Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.596999Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.224415Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.223886Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.231976Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.230986Z"
     },
     "papermill": {
-     "duration": 0.021257,
-     "end_time": "2026-05-12T09:56:53.601482",
+     "duration": 0.014725,
+     "end_time": "2026-05-12T11:14:54.234058",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.580225",
+     "start_time": "2026-05-12T11:14:54.219333",
      "status": "completed"
     },
     "tags": []
@@ -1508,10 +1510,10 @@
    "id": "4qpxhd2ymj5",
    "metadata": {
     "papermill": {
-     "duration": 0.006384,
-     "end_time": "2026-05-12T09:56:53.615349",
+     "duration": 0.006059,
+     "end_time": "2026-05-12T11:14:54.246219",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.608965",
+     "start_time": "2026-05-12T11:14:54.240160",
      "status": "completed"
     },
     "tags": []
@@ -1526,16 +1528,16 @@
    "id": "735ykxgotxb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.630923Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.630024Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.640479Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.638654Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.260288Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.259746Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.267426Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.266541Z"
     },
     "papermill": {
-     "duration": 0.02077,
-     "end_time": "2026-05-12T09:56:53.642640",
+     "duration": 0.016365,
+     "end_time": "2026-05-12T11:14:54.269212",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.621870",
+     "start_time": "2026-05-12T11:14:54.252847",
      "status": "completed"
     },
     "tags": []
@@ -1612,10 +1614,10 @@
    "id": "dz11mxjao7v",
    "metadata": {
     "papermill": {
-     "duration": 0.005479,
-     "end_time": "2026-05-12T09:56:53.654609",
+     "duration": 0.008035,
+     "end_time": "2026-05-12T11:14:54.283393",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.649130",
+     "start_time": "2026-05-12T11:14:54.275358",
      "status": "completed"
     },
     "tags": []
@@ -1630,16 +1632,16 @@
    "id": "tw14kk40jo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.667595Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.666910Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.675976Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.674082Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.296729Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.296063Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.301772Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.301031Z"
     },
     "papermill": {
-     "duration": 0.018072,
-     "end_time": "2026-05-12T09:56:53.677999",
+     "duration": 0.013947,
+     "end_time": "2026-05-12T11:14:54.303439",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.659927",
+     "start_time": "2026-05-12T11:14:54.289492",
      "status": "completed"
     },
     "tags": []
@@ -1691,10 +1693,10 @@
    "id": "van3ww30v5",
    "metadata": {
     "papermill": {
-     "duration": 0.007289,
-     "end_time": "2026-05-12T09:56:53.691359",
+     "duration": 0.004055,
+     "end_time": "2026-05-12T11:14:54.313135",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.684070",
+     "start_time": "2026-05-12T11:14:54.309080",
      "status": "completed"
     },
     "tags": []
@@ -1709,16 +1711,16 @@
    "id": "cell-stats",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T09:56:53.706051Z",
-     "iopub.status.busy": "2026-05-12T09:56:53.705332Z",
-     "iopub.status.idle": "2026-05-12T09:56:53.718124Z",
-     "shell.execute_reply": "2026-05-12T09:56:53.716418Z"
+     "iopub.execute_input": "2026-05-12T11:14:54.320802Z",
+     "iopub.status.busy": "2026-05-12T11:14:54.320547Z",
+     "iopub.status.idle": "2026-05-12T11:14:54.327430Z",
+     "shell.execute_reply": "2026-05-12T11:14:54.326627Z"
     },
     "papermill": {
-     "duration": 0.023112,
-     "end_time": "2026-05-12T09:56:53.720696",
+     "duration": 0.012792,
+     "end_time": "2026-05-12T11:14:54.329064",
      "exception": false,
-     "start_time": "2026-05-12T09:56:53.697584",
+     "start_time": "2026-05-12T11:14:54.316272",
      "status": "completed"
     },
     "tags": []
@@ -1731,7 +1733,7 @@
       "\n",
       "--- STATISTIQUES DE SESSION ---\n",
       "========================================\n",
-      "Date : 2026-05-12 11:56:53\n",
+      "Date : 2026-05-12 13:14:54\n",
       "Mode : interactive\n",
       "ComfyUI URL : https://qwen-image-edit.myia.io\n",
       "ComfyUI disponible : False\n",
@@ -1751,7 +1753,7 @@
       "3. Combiner ComfyUI + diffusers dans un pipeline hybride\n",
       "4. Deployer un serveur ComfyUI pour la generation a la demande\n",
       "\n",
-      "Notebook 03-3 ComfyUI Video Workflows termine - 11:56:53\n"
+      "Notebook 03-3 ComfyUI Video Workflows termine - 13:14:54\n"
      ]
     }
    ],
@@ -1813,14 +1815,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 7.935294,
-   "end_time": "2026-05-12T09:56:54.194645",
+   "duration": 5.624871,
+   "end_time": "2026-05-12T11:14:54.687089",
    "environment_variables": {},
    "exception": null,
    "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Video\\03-Orchestration\\03-3-ComfyUI-Video-Workflows.ipynb",
    "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Video\\03-Orchestration\\03-3-ComfyUI-Video-Workflows_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-12T09:56:46.259351",
+   "start_time": "2026-05-12T11:14:49.062218",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary
- Migrate 5 GenAI notebooks from hardcoded `https://*.myia.io` URLs to `os.getenv("ENV_VAR", "default")` pattern
- Enables deployment flexibility (local/staging/prod) without modifying notebook source code
- Added `import os` where needed in config cells that precede import cells

## Changes
- `02-5-Multi-Model-TTS-Gateway.ipynb`: `gateway_url` → `os.getenv("TTS_API_URL", ...)`
- `01-5-Qwen-Image-Edit.ipynb`: `API_BASE_URL` → `os.getenv("QWEN_IMAGE_EDIT_URL", ...)`
- `02-1-HunyuanVideo-Generation.ipynb`: `comfyui_url` → `os.getenv("COMFYUI_VIDEO_URL", ...)`
- `02-3-Wan-Video-Generation.ipynb`: `comfyui_url` → `os.getenv("COMFYUI_VIDEO_URL", ...)`
- `03-3-ComfyUI-Video-Workflows.ipynb`: `comfyui_url` → `os.getenv("COMFYUI_VIDEO_URL", ...)`

## Test plan
- [x] Papermill 5/5 PASS (re-executed post-migration)
- [x] 0 errors across all GenAI notebooks
- [x] Default behavior unchanged (URLs identical when env vars not set)

Track D2 (ai-01 dispatch 13:02Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)