### PR TITLE
fix(lean+prover): _SmokeTest 1->0 sorry + AutonomousProver revert no-op bugfix

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/_SmokeTest.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/_SmokeTest.lean
@@ -3,6 +3,6 @@ import Mathlib.Data.Nat.Basic
 namespace SmokeTest
 
 theorem zero_add_smoke (n : Nat) : 0 + n = n := by
-  sorry
+  exact Nat.zero_add n
 
 end SmokeTest

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -893,10 +893,14 @@ class AutonomousProver:
                 unsolved = [e for e in errors if "unsolved" in e.get("message", "")]
                 if unsolved:
                     print(f"  FALSE POSITIVE: {len(unsolved)} unsolved goals despite "
-                          f"{final_sorry} sorry. Reverting.", flush=True)
-                    Path(filepath).write_text(
-                        Path(filepath).read_text(encoding="utf-8"), encoding="utf-8")
-                    # Restore original if best state also has unsolved goals
+                          f"{final_sorry} sorry. Reverting to original.", flush=True)
+                    # BUGFIX (2026-05-12 ai-01): previous version did
+                    # `Path(filepath).write_text(Path(filepath).read_text(...), ...)`
+                    # which is a no-op (reads then writes the SAME file content),
+                    # so the broken/unsolved-goal file was committed to disk
+                    # despite the "Reverting" message. Restore from
+                    # `original_file_content` captured at session start.
+                    Path(filepath).write_text(original_file_content, encoding="utf-8")
                     final_sorry = original_sorry_count
                 else:
                     print(f"  Build failed ({verify_result.get('error_count', '?')} errors), "


### PR DESCRIPTION
## Summary

2 orthogonal commits livrés par BG ai-01 sur la chaîne Lean prover (parallel à po-2026 qui itère sur stable_marriage 3 hard sorrys + Voting L262 design).

### Commit 1 — `_SmokeTest.lean` 1 → 0 sorry

`MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/_SmokeTest.lean` L6 contient un sorry trivial (`0 + n = n`) utilisé comme fixture du multi-agent prover. Le prover **a déjà trouvé la preuve `exact Nat.zero_add n` le 11/05** (cf `.prover_history/_SmokeTest_54f39f6f75_L6.json` outcome=success) mais elle n'avait jamais été commitée en retour. Application + verification.

### Commit 2 — `provers.py:893` BUGFIX no-op revert (CRITIQUE)

Le guard FALSE_POSITIVE de `AutonomousProver._run_one_demo` détecte quand le model claims `final_sorry < original_sorry_count` mais `compile()` reporte unsolved goals. Le revert lui-même était **bugué** :

```python
Path(filepath).write_text(
    Path(filepath).read_text(encoding="utf-8"), encoding="utf-8")
```

Read+write du **même** fichier = **no-op**. Le fichier reste corrompu malgré le log "Reverting", et `final_sorry` est silencieusement reset à `original_sorry_count` → caller voit "no progress" alors que le fichier sur disque est bel et bien cassé.

**Fix** : write `original_file_content` (capturé L604 au début de session) au lieu de re-read. Match la logique analogue L882 ("Always restore original if no improvement"). Comment ajouté pour audit futur.

Conséquence probable : plusieurs incidents passés où le prover déclarait "DONE" et le fichier ne compilait plus en silence (cf #946 "build-verified snapshots + mandatory final verify" ajouté Cycle 25 iter 2 — partial mitigation, mais le bug racine restait).

## Test plan

- [x] `_SmokeTest.lean`: `lake build` SUCCESS (3292 jobs) — file builds, sorry count 1 → 0
- [x] `provers.py`: Python-only edit, no breaking change CLI/API. No `lake build` needed (Python file)
- [x] Sorry count global :
  - `_SmokeTest.lean`: 1 → 0 ✅
  - `Voting.lean`: 2 → 2 (untouched, po-2026 territory L262 + L338 préservés)
  - `GaleShapley.lean`: 3 → 3 (untouched, po-2026 territory)
  - Other social_choice_lean / stable_marriage_lean files: unchanged
- [x] No regression : aucun sorry ajouté à des preuves working
- [x] Lake build SUCCESS log captured: `Build completed successfully (3292 jobs)`

## Investigation lead non-traitée (suggérée pour BG suivant)

`workflow.py` L116-123 NOTE interdit `asyncio.wait_for` dans `AgentExecutor.handle` (corruption ContextVar Token). Mais `AutonomousProver._run_session` L639-641 wraps `agent.run` dans `asyncio.wait_for` malgré tout. **Probable même bug** que celui rapporté par po-2026 sur Voting:338 BG runs (0 sorry eliminated, ContextVar bug). À investiguer prochaine itération BG.

## Files of interest

- `MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/_SmokeTest.lean` (modified)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py` (bugfix L893-906)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/.prover_history/Voting_c94c6e6ddb_L338.json` (lead pour next iter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
