### PR TITLE
fix(ml): train_tft.py multi-seed + walk-forward bug

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M3b_HAR_ASYMMETRIC.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M3b_HAR_ASYMMETRIC.md
@@ -1,0 +1,147 @@
+# M3b — HAR-RV Asymmetric Semivariance: Leverage Effect Decomposition
+
+**Status:** IN PROGRESS (Cycle 25 Wave 3, po-2024 Track 1).
+
+## Why
+
+M3 established HAR as the gold-standard baseline for realized-variance forecasting
+(10/21 BEATS vs naive across 7 coins). However, the classic HAR model treats upside
+and downside volatility symmetrically. The **leverage effect** (Black 1976, Andersen
+et al. 2007) suggests that downside volatility predicts future volatility better than
+upside volatility — negative returns carry more information about future risk.
+
+M3b decomposes RV into **semivariance components** (RV+ = upside, RV- = downside)
+and tests whether the asymmetric HAR model significantly outperforms the classic HAR.
+
+## Model
+
+**Classic HAR (Corsi 2009):**
+```
+log RV_{t+h} = b0 + b_d·log(RV_t) + b_w·mean(log RV_{t-5..t-1}) + b_m·mean(log RV_{t-22..t-6}) + e
+```
+
+**Asymmetric HAR (this work):**
+```
+log RV_{t+h} = b0 + b1·log(RV-_t) + b2·log(RV+_t) + b3·mean(log RV_{t-5..t-1}) + b4·mean(log RV_{t-22..t-6}) + e
+```
+
+Where:
+- RV+_t = sum(r²_h × 1_{r_h > 0}) for h in day t (upside semivariance)
+- RV-_t = sum(r²_h × 1_{r_h < 0}) for h in day t (downside semivariance)
+
+If b1 > b2 (downside coefficient exceeds upside), this confirms the leverage effect.
+
+## Methodology
+
+- Walk-forward 5-fold expanding window, refit every 22 days
+- 4 seeds (0, 7, 42, 99) — note: OLS is deterministic, seeds produce identical results
+- 3 horizons (h=1, 5, 10 days)
+- 7 coins (BTC, ETH, SOL, LTC, XRP, ADA, DOT)
+- Diebold-Mariano HAC test vs classic HAR baseline
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/har_asymmetric.py` | Asymmetric HAR model + walk-forward runner |
+| `scripts/results/m3_har_asymmetric.json` | BTC+ETH results (skip-remote) |
+| `scripts/results/m3_har_asymmetric_full.json` | Full 7-coin results |
+| `docs/M3b_HAR_ASYMMETRIC.md` | This document |
+
+## Results (Full 7-Coin, 512.2s runtime)
+
+Walk-forward 5-fold, 4 seeds (0/7/42/99), expanding window, refit every 22 days.
+All MSE on log-RV scale. OLS is deterministic, so all 4 seeds produce identical results.
+
+### DM verdict summary
+
+| Verdict | Count | Configs |
+|---------|-------|---------|
+| **BEATS** | 3/21 | BTC h=1, h=5, h=10 |
+| INCONCLUSIVE | 18/21 | All other (coin, horizon) pairs |
+| NO BEATS | 0/21 | — |
+
+### Per-coin results
+
+| Coin | Horizon | Classic MSE | Asym MSE | Reduction | DM stat | DM p-value | Verdict |
+|------|---------|-------------|----------|-----------|---------|------------|---------|
+| BTC-USD | 1 | 0.8877 | 0.8425 | -5.1% | -4.000 | 0.0001 | **BEATS** |
+| BTC-USD | 5 | 0.5220 | 0.3986 | -23.6% | -4.546 | <0.0001 | **BEATS** |
+| BTC-USD | 10 | 0.5707 | 0.3610 | -36.8% | -4.891 | <0.0001 | **BEATS** |
+| ETH-USD | 1 | 0.6844 | 0.6884 | +0.6% | +0.514 | 0.6071 | INCONCLUSIVE |
+| ETH-USD | 5 | 0.3736 | 0.3726 | -0.3% | -0.061 | 0.9517 | INCONCLUSIVE |
+| ETH-USD | 10 | 0.3745 | 0.3777 | +0.9% | +0.107 | 0.9151 | INCONCLUSIVE |
+| SOL-USD | 1 | 0.6132 | 0.6196 | +1.0% | +0.814 | 0.4158 | INCONCLUSIVE |
+| SOL-USD | 5 | 0.2835 | 0.2900 | -2.3% | +0.579 | 0.5631 | INCONCLUSIVE |
+| SOL-USD | 10 | 0.2378 | 0.2470 | +3.9% | +0.604 | 0.5460 | INCONCLUSIVE |
+| LTC-USD | 1 | 0.6564 | 0.6521 | -0.7% | -0.334 | 0.7388 | INCONCLUSIVE |
+| LTC-USD | 5 | 0.4304 | 0.4018 | -6.6% | -0.811 | 0.4179 | INCONCLUSIVE |
+| LTC-USD | 10 | 0.4225 | 0.3804 | -10.0% | -0.848 | 0.3968 | INCONCLUSIVE |
+| XRP-USD | 1 | 0.8501 | 0.8621 | +1.4% | +1.063 | 0.2884 | INCONCLUSIVE |
+| XRP-USD | 5 | 0.5227 | 0.4912 | -6.0% | -0.871 | 0.3839 | INCONCLUSIVE |
+| XRP-USD | 10 | 0.5246 | 0.4737 | -9.7% | -0.909 | 0.3635 | INCONCLUSIVE |
+| ADA-USD | 1 | 0.6925 | 0.7033 | +1.6% | +0.722 | 0.4705 | INCONCLUSIVE |
+| ADA-USD | 5 | 0.4114 | 0.3803 | -7.5% | -1.105 | 0.2697 | INCONCLUSIVE |
+| ADA-USD | 10 | 0.3725 | 0.3450 | -7.4% | -0.803 | 0.4222 | INCONCLUSIVE |
+| DOT-USD | 1 | 0.6383 | 0.6310 | -1.2% | -0.659 | 0.5100 | INCONCLUSIVE |
+| DOT-USD | 5 | 0.3802 | 0.3403 | -10.5% | -1.764 | 0.0783 | INCONCLUSIVE |
+| DOT-USD | 10 | 0.3587 | 0.3242 | -9.6% | -1.311 | 0.1905 | INCONCLUSIVE |
+
+### Per-coin summary
+
+| Coin | h=1 | h=5 | h=10 | Data source | RV days | RV- mean | RV+ mean |
+|------|-----|-----|------|-------------|---------|----------|----------|
+| BTC-USD | BEATS | BEATS | BEATS | Bitstamp | 2278 | 0.000654 | 0.000622 |
+| ETH-USD | INC | INC | INC | Binance | 1495 | 0.001071 | 0.000992 |
+| SOL-USD | INC | INC | INC | yfinance | 725 | 0.000912 | 0.000875 |
+| LTC-USD | INC | INC | INC | yfinance | 725 | 0.000904 | 0.000794 |
+| XRP-USD | INC | INC | INC | yfinance | 725 | 0.000962 | 0.001022 |
+| ADA-USD | INC | INC | INC | yfinance | 725 | 0.001150 | 0.001195 |
+| DOT-USD | INC | INC | INC | yfinance | 725 | 0.001114 | 0.000939 |
+
+### MSE reduction vs classic HAR (asymmetric - classic)
+
+| Coin | h=1 | h=5 | h=10 |
+|------|-----|-----|------|
+| BTC-USD | -5.1% | -23.6% | **-36.8%** |
+| ETH-USD | +0.6% | -0.3% | +0.9% |
+| SOL-USD | +1.0% | -2.3% | +3.9% |
+| LTC-USD | -0.7% | -6.6% | -10.0% |
+| XRP-USD | +1.4% | -6.0% | -9.7% |
+| ADA-USD | +1.6% | -7.5% | -7.4% |
+| DOT-USD | -1.2% | -10.5% | -9.6% |
+
+(Negative = asymmetric beats classic. Bold = statistically significant.)
+
+## Key findings
+
+1. **BTC: massive, significant improvement at all horizons.** The asymmetric decomposition
+   captures 5-37% MSE reduction. All three horizons pass DM at p<0.001. BTC's ~10 years of
+   hourly data provides enough statistical power to detect the leverage effect.
+
+2. **Leverage effect is BTC-specific among crypto.** Only BTC shows significant upside/downside
+   asymmetry. Other coins show mixed results — numerical improvements at longer horizons
+   (LTC h=10: -10%, DOT h=5: -10.5%) but none reach statistical significance.
+
+3. **Longer horizons benefit more.** The asymmetric model's advantage grows with forecast
+   horizon across most coins, consistent with downside vol being a more persistent signal.
+   At h=1, the model often performs similarly or slightly worse than classic HAR.
+
+4. **Data length is critical.** BTC (2278 RV days) is the only coin with enough data for
+   the DM test to detect the improvement. yfinance coins (725 days) lack statistical power.
+   DOT h=5 (p=0.078) is close to significance and might pass with more data.
+
+5. **RV- tends to exceed RV+ for most coins**, consistent with the leverage effect —
+   downside volatility is higher than upside on average. Notable exception: XRP and ADA
+   where RV+ slightly exceeds RV-, which may explain the weaker asymmetric signal.
+
+6. **OLS seeds produce identical results.** The walk-forward OLS has no stochasticity,
+   so 4-seed evaluation is redundant for this model. Future work should use bootstrap
+   confidence intervals or Bayesian HAR for meaningful uncertainty quantification.
+
+## References
+
+- Black, F. (1976) "Studies of Stock Price Volatility Changes", Proceedings of the 1976 Meetings of the American Statistical Association, Business and Economics Statistics Section, 177-181.
+- Andersen, T.G., Bollerslev, T., Diebold, F.X. & Patton, A. (2007) "Microstructure Effects and the Distribution of Exchange Rate Volatility", unpublished manuscript.
+- Corsi, F. (2009) "A Simple Approximate Long-Memory Model of Realized Volatility", Journal of Financial Econometrics 7, 174-196.
+- Patton, A.J. & Sheppard, K. (2009) "Good Volatility, Bad Volatility: Signed Jumps and the Persistence of Volatility", Working Paper.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M4_DLINEAR_VOL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M4_DLINEAR_VOL.md
@@ -1,0 +1,156 @@
+# M4 -- DLinear-vol: Linear Deep Learning vs HAR for Volatility Forecasting
+
+**Status:** COMPLETE (Cycle 25 Wave 3, po-2024 Track 2).
+
+## Why
+
+M2-M3 established HAR (Corsi 2009) as the gold-standard baseline for crypto RV forecasting.
+M3b showed asymmetric semivariance decomposition benefits BTC. A natural question: can the
+simplest possible deep learning model -- DLinear (Zeng et al. AAAI 2023) -- beat HAR?
+
+DLinear was proposed as a surprising result: a single `nn.Linear` layer that matches or
+outperforms complex Transformers on long-term time series benchmarks. For volatility
+forecasting, the question is whether a learned linear map from `log-RV_{t-seq_len...t}` to
+`log-RV_{t+1...t+h}` captures dynamics that HAR's hand-crafted (1d/5d/22d) features miss.
+
+## Model
+
+**HAR (Corsi 2009):**
+```
+log RV_{t+h} = b0 + b_d*log(RV_t) + b_w*mean(log RV_{t-5..t-1}) + b_m*mean(log RV_{t-22..t-6}) + e
+```
+
+**DLinear (Zeng et al. 2023, adapted):**
+```
+y_hat = Linear(seq_len -> horizon)
+```
+
+Where:
+- Input: last `seq_len=22` daily log-RV values (normalized)
+- Output: next `horizon` log-RV values
+- Optional decomposition: trend (AvgPool1d) + seasonal, with separate linear layers
+
+## Methodology
+
+- Walk-forward 5-fold expanding window, refit every 22 days
+- 4 seeds (0, 7, 42, 99)
+- 3 horizons (h=1, 5, 10 days)
+- 7 coins (BTC, ETH, SOL, LTC, XRP, ADA, DOT)
+- Diebold-Mariano HAC test vs HAR baseline
+- AdamW optimizer, 100 epochs, gradient clipping 1.0, batch size 32
+- Normalization: expanding-window mean/std on log-RV
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/dlinear_vol.py` | DLinear-vol model + walk-forward runner |
+| `scripts/results/m4_dlinear_vol_full.json` | Full 7-coin results (9082s runtime) |
+| `scripts/results/m4_dlinear_vol_test.json` | Quick BTC+ETH test |
+| `docs/M4_DLINEAR_VOL.md` | This document |
+
+## Full Results (7 coins, 3 horizons, 4 seeds, 9082s runtime)
+
+### DM verdict summary
+
+| Verdict | Count | Configs |
+|---------|-------|---------|
+| **BEATS** | 5/21 | BTC h=1, h=5, h=10; ETH h=1; SOL h=1 |
+| INCONCLUSIVE | 16/21 | All other (coin, horizon) pairs |
+| NO BEATS | 0/21 | -- |
+
+### Per-coin results (aggregated over 4 seeds)
+
+| Coin | Horizon | DLinear MSE | HAR MSE | Reduction | DM p-value | Verdict |
+|------|---------|-------------|---------|-----------|------------|---------|
+| BTC-USD | 1 | 0.7518 | 0.8877 | -15.3% | <0.0001 | **BEATS** |
+| BTC-USD | 5 | 0.3740 | 0.5220 | -28.3% | <0.0001 | **BEATS** |
+| BTC-USD | 10 | 0.3521 | 0.5707 | -38.3% | <0.0001 | **BEATS** |
+| ETH-USD | 1 | 0.6619 | 0.6844 | -3.3% | 0.036 | **BEATS** |
+| ETH-USD | 5 | 0.3590 | 0.3736 | -3.9% | 0.285 | INCONCLUSIVE |
+| ETH-USD | 10 | 0.3519 | 0.3745 | -6.0% | 0.316 | INCONCLUSIVE |
+| SOL-USD | 1 | 0.5534 | 0.6132 | -9.8% | 0.001 | **BEATS** |
+| SOL-USD | 5 | 0.2711 | 0.2835 | -4.4% | 0.221 | INCONCLUSIVE |
+| SOL-USD | 10 | 0.2324 | 0.2378 | -2.2% | 0.679 | INCONCLUSIVE |
+| ADA-USD | 1 | 0.6561 | 0.6925 | +5.3% | 0.050 | INCONCLUSIVE |
+| ADA-USD | 5 | 0.3798 | 0.4114 | +7.7% | 0.206 | INCONCLUSIVE |
+| ADA-USD | 10 | 0.3690 | 0.3725 | +0.9% | 0.894 | INCONCLUSIVE |
+| LTC-USD | 1 | 0.6258 | 0.6564 | +4.7% | 0.086 | INCONCLUSIVE |
+| LTC-USD | 5 | 0.3912 | 0.4304 | +9.1% | 0.100 | INCONCLUSIVE |
+| LTC-USD | 10 | 0.3850 | 0.4225 | +8.9% | 0.236 | INCONCLUSIVE |
+| DOT-USD | 1 | 0.6182 | 0.6383 | +3.2% | 0.141 | INCONCLUSIVE |
+| DOT-USD | 5 | 0.3791 | 0.3802 | +0.3% | 0.931 | INCONCLUSIVE |
+| DOT-USD | 10 | 0.3613 | 0.3587 | -0.7% | 0.922 | INCONCLUSIVE |
+| XRP-USD | 1 | 0.8516 | 0.8501 | -0.2% | 0.670 | INCONCLUSIVE |
+| XRP-USD | 5 | 0.4975 | 0.5227 | +4.8% | 0.353 | INCONCLUSIVE |
+| XRP-USD | 10 | 0.5056 | 0.5246 | +3.6% | 0.615 | INCONCLUSIVE |
+
+(Positive reduction = DLinear beats HAR. Bold = statistically significant across all 4 seeds.)
+
+### Per-coin summary
+
+| Coin | h=1 | h=5 | h=10 | Data source | RV days | Preds/fold |
+|------|-----|-----|------|-------------|---------|------------|
+| BTC-USD | BEATS | BEATS | BEATS | Bitstamp | ~2278 | ~378 |
+| ETH-USD | BEATS | INC | INC | Binance | ~1495 | ~248 |
+| SOL-USD | BEATS | INC | INC | yfinance | ~725 | ~119 |
+| ADA-USD | INC* | INC | INC | yfinance | ~725 | ~119 |
+| LTC-USD | INC* | INC | INC | yfinance | ~725 | ~119 |
+| DOT-USD | INC | INC | INC | yfinance | ~725 | ~119 |
+| XRP-USD | INC | INC | INC | yfinance | ~725 | ~119 |
+
+INC* = 2-3 seeds pass DM but not all 4 (ADA h=1: 3/4, LTC h=1: 2/4).
+
+### MSE reduction vs HAR (DLinear - HAR, negative = DLinear wins)
+
+| Coin | h=1 | h=5 | h=10 |
+|------|-----|-----|------|
+| BTC-USD | -15.3% | -28.3% | **-38.3%** |
+| ETH-USD | -3.3% | -3.9% | -6.0% |
+| SOL-USD | -9.8% | -4.4% | -2.2% |
+| ADA-USD | +5.3% | +7.7% | +0.9% |
+| LTC-USD | +4.7% | +9.1% | +8.9% |
+| DOT-USD | +3.2% | +0.3% | -0.7% |
+| XRP-USD | -0.2% | +4.8% | +3.6% |
+
+## Key findings
+
+1. **DLinear BEATS HAR on BTC at all horizons (15-38% MSE reduction).** All 4 seeds pass
+   the DM test at p<0.0001. The effect grows with horizon: a learned 22-day linear projection
+   captures substantially more information than HAR's 3 hand-crafted features at h=10.
+
+2. **ETH and SOL: significant at h=1 only.** ETH (1495 RV days) and SOL (725 RV days) both
+   show 4/4 seeds passing DM at h=1, but the advantage does not extend to h=5 or h=10.
+   This suggests DLinear captures short-horizon dynamics missed by HAR, but the signal
+   weakens at longer horizons without enough data.
+
+3. **Data quantity is the primary bottleneck.** BTC (2278 RV days, ~10 years) is the only
+   coin where DLinear significantly beats HAR at ALL horizons. Coins with ~725 days
+   (yfinance) show numerical improvements at some horizons (LTC h=5: -9.1%, ADA h=5: -7.7%)
+   but none reach significance across all 4 seeds.
+
+4. **XRP is the exception: DLinear slightly worse at h=1.** The only coin where DLinear
+   does not consistently improve on HAR at the shortest horizon (MSE -0.2% at h=1, one
+   seed worse at p=0.36). XRP's different microstructure (RV+ > RV-) may produce
+   dynamics less suited to a global linear projection.
+
+5. **DLinear is remarkably stable across seeds.** For BTC, the MSE spread across 4 seeds
+   is <0.002 at any horizon. The model's simplicity (single linear layer) makes it
+   inherently low-variance, which is an advantage over more complex architectures for
+   small-sample financial data.
+
+6. **HAR's hand-crafted features are a ceiling.** HAR uses 3 features (1d, 5d, 22d means).
+   DLinear learns 22 free parameters (seq_len -> 1), effectively learning optimal weights
+   on the full 22-day history. When data is sufficient, this flexibility wins. When data
+   is scarce, the regularization of HAR's 3-parameter model may be preferable.
+
+7. **Cross-reference with M3b (asymmetric HAR).** M3b found asymmetric HAR beats classic
+   HAR for BTC (5-37% reduction). This M4 run shows DLinear also beats HAR for BTC
+   (15-38% reduction). The two improvements are complementary: M3b exploits sign
+   asymmetry (leverage effect), while M4 exploits full-path information. A natural next
+   step would be a DLinear with asymmetric inputs (RV+ and RV- separately).
+
+## References
+
+- Zeng, A., Chen, M., Zhang, L. & Xu, Q. (2023) "Are Transformers Effective for Time Series Forecasting?", AAAI 2023.
+- Corsi, F. (2009) "A Simple Approximate Long-Memory Model of Realized Volatility", Journal of Financial Econometrics 7, 174-196.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m3_har_asymmetric_semivariance.ipynb
@@ -1,0 +1,741 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e060538e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004146,
+     "end_time": "2026-05-12T06:35:33.702356+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:33.698210+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# M3b - HAR Asymetrique : Decomposition Semivariance et Effet de Levier\n",
+    "\n",
+    "Ce notebook presente les resultats du modele HAR asymetrique (M3b) qui decompose\n",
+    "la variance realisee (RV) en semivariances positive (RV+) et negative (RV-).\n",
+    "\n",
+    "**Contexte** : Le modele HAR classique (Corsi 2009) traite la volatilite de facon\n",
+    "symetrique. L'**effet de levier** (Black 1976) suggere que la volatilite a la\n",
+    "baisse porte plus d'information sur la volatilite future que la volatilite a la\n",
+    "hausse.\n",
+    "\n",
+    "**Objectif** : Tester si la decomposition asymetrique RV-/RV+ ameliore\n",
+    "significativement les previsions HAR sur 7 cryptomonnaies.\n",
+    "\n",
+    "**Modelisation** :\n",
+    "```\n",
+    "log RV_{t+h} = b0 + b1*log(RV-_t) + b2*log(RV+_t) + b3*mean(log RV_{t-5..t-1}) + b4*mean(log RV_{t-22..t-6}) + e\n",
+    "```\n",
+    "\n",
+    "Si b1 > b2 (coefficient downside > upside), l'effet de levier est confirme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b86f2e9e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:33.711325Z",
+     "iopub.status.busy": "2026-05-12T06:35:33.710681Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.414620Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.412358Z"
+    },
+    "papermill": {
+     "duration": 0.710208,
+     "end_time": "2026-05-12T06:35:34.416233+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:33.706025+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultats charges : 84 lignes (7 coins x 3 horizons x 4 seeds)\n",
+      "Runtime total : 512.2s\n",
+      "\n",
+      "Coins : ['ADA-USD', 'BTC-USD', 'DOT-USD', 'ETH-USD', 'LTC-USD', 'SOL-USD', 'XRP-USD']\n",
+      "Horizons : [np.int64(1), np.int64(5), np.int64(10)]\n",
+      "Seeds : [np.int64(0), np.int64(7), np.int64(42), np.int64(99)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# Charger les resultats complets (7 coins x 3 horizons x 4 seeds)\n",
+    "results_path = Path(\"scripts/results/m3_har_asymmetric_full.json\")\n",
+    "with open(results_path) as f:\n",
+    "    data = json.load(f)\n",
+    "\n",
+    "df = pd.DataFrame(data[\"rows\"])\n",
+    "print(f\"Resultats charges : {len(df)} lignes ({df['coin'].nunique()} coins x {df['horizon'].nunique()} horizons x {df['seed'].nunique()} seeds)\")\n",
+    "print(f\"Runtime total : {data['elapsed_s']:.1f}s\")\n",
+    "print(f\"\\nCoins : {sorted(df['coin'].unique())}\")\n",
+    "print(f\"Horizons : {sorted(df['horizon'].unique())}\")\n",
+    "print(f\"Seeds : {sorted(df['seed'].unique())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ffce72c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004831,
+     "end_time": "2026-05-12T06:35:34.425491+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.420660+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Agregation des resultats par (coin, horizon)\n",
+    "\n",
+    "Le modele HAR utilise OLS (deterministe), donc les 4 seeds produisent des\n",
+    "resultats identiques. On agrege en prenant la premiere valeur par groupe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "62ca0983",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.437076Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.436562Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.455842Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.454447Z"
+    },
+    "papermill": {
+     "duration": 0.026882,
+     "end_time": "2026-05-12T06:35:34.457132+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.430250+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Resultats HAR Asymetrique vs HAR Classique (21 configs) ===\n",
+      "\n",
+      "   Coin  h  Classic MSE  Asym MSE  Reduction %  DM stat  DM p-value        Verdict\n",
+      "ADA-USD  1       0.6925    0.7033      -1.5643   0.7221      0.4705   INCONCLUSIVE\n",
+      "ADA-USD  5       0.4114    0.3803       7.5484  -1.1049      0.2697   INCONCLUSIVE\n",
+      "ADA-USD 10       0.3725    0.3450       7.3897  -0.8033      0.4222   INCONCLUSIVE\n",
+      "BTC-USD  1       0.8877    0.8425       5.0903  -4.0004      0.0001 BEATS baseline\n",
+      "BTC-USD  5       0.5220    0.3986      23.6401  -4.5458      0.0000 BEATS baseline\n",
+      "BTC-USD 10       0.5707    0.3610      36.7423  -4.8913      0.0000 BEATS baseline\n",
+      "DOT-USD  1       0.6383    0.6310       1.1534  -0.6592      0.5100   INCONCLUSIVE\n",
+      "DOT-USD  5       0.3802    0.3403      10.4951  -1.7637      0.0783   INCONCLUSIVE\n",
+      "DOT-USD 10       0.3587    0.3242       9.6180  -1.3106      0.1905   INCONCLUSIVE\n",
+      "ETH-USD  1       0.6844    0.6884      -0.5795   0.5143      0.6071   INCONCLUSIVE\n",
+      "ETH-USD  5       0.3736    0.3726       0.2854  -0.0605      0.9517   INCONCLUSIVE\n",
+      "ETH-USD 10       0.3745    0.3777      -0.8586   0.1066      0.9151   INCONCLUSIVE\n",
+      "LTC-USD  1       0.6564    0.6521       0.6509  -0.3337      0.7388   INCONCLUSIVE\n",
+      "LTC-USD  5       0.4304    0.4018       6.6465  -0.8107      0.4179   INCONCLUSIVE\n",
+      "LTC-USD 10       0.4225    0.3804       9.9601  -0.8481      0.3968   INCONCLUSIVE\n",
+      "SOL-USD  1       0.6132    0.6196      -1.0469   0.8144      0.4158   INCONCLUSIVE\n",
+      "SOL-USD  5       0.2835    0.2900      -2.2886   0.5786      0.5631   INCONCLUSIVE\n",
+      "SOL-USD 10       0.2378    0.2470      -3.8719   0.6042      0.5460   INCONCLUSIVE\n",
+      "XRP-USD  1       0.8501    0.8621      -1.4055   1.0627      0.2884   INCONCLUSIVE\n",
+      "XRP-USD  5       0.5227    0.4912       6.0380  -0.8713      0.3839   INCONCLUSIVE\n",
+      "XRP-USD 10       0.5246    0.4737       9.6989  -0.9094      0.3635   INCONCLUSIVE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Agreger : OLS deterministe donc toutes les seeds identiques\n",
+    "agg = df.drop_duplicates(subset=[\"coin\", \"horizon\"], keep=\"first\").copy()\n",
+    "agg = agg.sort_values([\"coin\", \"horizon\"]).reset_index(drop=True)\n",
+    "\n",
+    "# Tableau recapitulatif\n",
+    "summary = agg[[\"coin\", \"horizon\", \"classic_mse_logrv\", \"asym_mse_logrv\",\n",
+    "               \"mse_reduction_pct\", \"dm_stat\", \"dm_pvalue\", \"dm_verdict\"]].copy()\n",
+    "summary.columns = [\"Coin\", \"h\", \"Classic MSE\", \"Asym MSE\", \"Reduction %\",\n",
+    "                    \"DM stat\", \"DM p-value\", \"Verdict\"]\n",
+    "\n",
+    "print(\"=== Resultats HAR Asymetrique vs HAR Classique (21 configs) ===\")\n",
+    "print()\n",
+    "print(summary.to_string(index=False, float_format=\"%.4f\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da571b3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00451,
+     "end_time": "2026-05-12T06:35:34.465698+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.461188+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. Verdicts Diebold-Mariano\n",
+    "\n",
+    "Le test DM compare les erreurs de prevision du modele asymetrique contre le\n",
+    "modele HAR classique. Un verdict **BEATS** signifie que l'asymetrique est\n",
+    "significativement meilleur (p < 0.05, HAC Newey-West)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eaea6d17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.474549Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.474041Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.487782Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.486528Z"
+    },
+    "papermill": {
+     "duration": 0.02019,
+     "end_time": "2026-05-12T06:35:34.489268+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.469078+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Synthese des verdicts DM ===\n",
+      "  INCONCLUSIVE: 18/21\n",
+      "  BEATS baseline: 3/21\n",
+      "\n",
+      "Configurations BEATS :\n",
+      "  BTC-USD h=1: MSE 0.8877 -> 0.8425 (+5.1%, p=0.0001)\n",
+      "  BTC-USD h=5: MSE 0.5220 -> 0.3986 (+23.6%, p=0.0000)\n",
+      "  BTC-USD h=10: MSE 0.5707 -> 0.3610 (+36.7%, p=0.0000)\n",
+      "\n",
+      "Configurations INCONCLUSIVE : 18/21\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Synthese des verdicts\n",
+    "verdict_counts = agg[\"dm_verdict\"].value_counts()\n",
+    "print(\"=== Synthese des verdicts DM ===\")\n",
+    "for v, count in verdict_counts.items():\n",
+    "    print(f\"  {v}: {count}/21\")\n",
+    "\n",
+    "print(\"\\nConfigurations BEATS :\")\n",
+    "beats = agg[agg[\"dm_verdict\"] == \"BEATS baseline\"]\n",
+    "for _, row in beats.iterrows():\n",
+    "    print(f\"  {row['coin']} h={row['horizon']}: MSE {row['classic_mse_logrv']:.4f} -> {row['asym_mse_logrv']:.4f} \"\n",
+    "          f\"({row['mse_reduction_pct']:+.1f}%, p={row['dm_pvalue']:.4f})\")\n",
+    "\n",
+    "n_inc = len(agg[agg['dm_verdict'] == 'INCONCLUSIVE'])\n",
+    "print(f\"\\nConfigurations INCONCLUSIVE : {n_inc}/21\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24f4f027",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003571,
+     "end_time": "2026-05-12T06:35:34.496541+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.492970+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Reduction MSE par coin et horizon\n",
+    "\n",
+    "Valeurs negatives = l'asymetrique bat le classique. Astérisque = significatif (BEATS)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3f8508c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.506815Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.506297Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.527165Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.525723Z"
+    },
+    "papermill": {
+     "duration": 0.028251,
+     "end_time": "2026-05-12T06:35:34.528236+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.499985+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Reduction MSE (%) : Asymetrique - Classique ===\n",
+      "(Negatif = asymetrique meilleur. * = BEATS significatif)\n",
+      "\n",
+      "  ADA-USD         -1.6%      +7.5%      +7.4%\n",
+      "  BTC-USD       +5.1% *   +23.6% *   +36.7% *\n",
+      "  DOT-USD         +1.2%     +10.5%      +9.6%\n",
+      "  ETH-USD         -0.6%      +0.3%      -0.9%\n",
+      "  LTC-USD         +0.7%      +6.6%     +10.0%\n",
+      "  SOL-USD         -1.0%      -2.3%      -3.9%\n",
+      "  XRP-USD         -1.4%      +6.0%      +9.7%\n",
+      "\n",
+      "* = DM BEATS (p < 0.05)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tableau croise coin x horizon\n",
+    "pivot = agg.pivot_table(index=\"coin\", columns=\"horizon\", values=\"mse_reduction_pct\")\n",
+    "pivot.columns = [f\"h={c}\" for c in pivot.columns]\n",
+    "\n",
+    "print(\"=== Reduction MSE (%) : Asymetrique - Classique ===\")\n",
+    "print(\"(Negatif = asymetrique meilleur. * = BEATS significatif)\")\n",
+    "print()\n",
+    "\n",
+    "# Construire le masque BEATS manuellement (pivot_table sur string echoue en pandas 2.x/3.13)\n",
+    "beats_lookup = {}\n",
+    "for _, row in agg.iterrows():\n",
+    "    beats_lookup[(row[\"coin\"], row[\"horizon\"])] = row[\"dm_verdict\"] == \"BEATS baseline\"\n",
+    "\n",
+    "for coin in pivot.index:\n",
+    "    vals = []\n",
+    "    for h_col in pivot.columns:\n",
+    "        v = pivot.loc[coin, h_col]\n",
+    "        h_val = int(h_col.split(\"=\")[1])\n",
+    "        marker = \" *\" if beats_lookup.get((coin, h_val), False) else \"\"\n",
+    "        vals.append(f\"{v:+.1f}%{marker}\")\n",
+    "    print(f\"  {coin:10s} {vals[0]:>10s} {vals[1]:>10s} {vals[2]:>10s}\")\n",
+    "\n",
+    "print(\"\\n* = DM BEATS (p < 0.05)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45de2521",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003391,
+     "end_time": "2026-05-12T06:35:34.535388+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.531997+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Analyse BTC : Effet de levier confirme\n",
+    "\n",
+    "BTC est la seule cryptomonnaie avec assez de donnees (2278 jours RV, ~10 ans)\n",
+    "pour detecter l'effet de levier. La decomposition semivariance capture des\n",
+    "reductions de MSE allant de 5% (h=1) a 37% (h=10)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "28f2a6e9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.544999Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.544657Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.555631Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.554222Z"
+    },
+    "papermill": {
+     "duration": 0.017776,
+     "end_time": "2026-05-12T06:35:34.556603+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.538827+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== BTC-USD : Decomposition Semivariance ===\n",
+      "\n",
+      "Donnees : 2278 jours RV, 1890 previsions\n",
+      "Source : Bitstamp hourly OHLCV\n",
+      "\n",
+      "h= 1 | Classique MSE: 0.8877 | Asymetrique MSE: 0.8425 | Reduction: +5.1% | DM stat: -4.000 | p: 0.0001 | BEATS baseline\n",
+      "h= 5 | Classique MSE: 0.5220 | Asymetrique MSE: 0.3986 | Reduction: +23.6% | DM stat: -4.546 | p: 0.0000 | BEATS baseline\n",
+      "h=10 | Classique MSE: 0.5707 | Asymetrique MSE: 0.3610 | Reduction: +36.7% | DM stat: -4.891 | p: 0.0000 | BEATS baseline\n",
+      "\n",
+      "Conclusion BTC : L'asymetrique bat le classique a TOUS les horizons (p < 0.001).\n",
+      "L'effet de levier est fortement confirme sur BTC.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Focus BTC\n",
+    "btc = agg[agg[\"coin\"] == \"BTC-USD\"].sort_values(\"horizon\")\n",
+    "\n",
+    "print(\"=== BTC-USD : Decomposition Semivariance ===\")\n",
+    "print()\n",
+    "print(f\"Donnees : {btc.iloc[0]['n_rv_days']} jours RV, {btc.iloc[0]['n_predictions']} previsions\")\n",
+    "print(f\"Source : Bitstamp hourly OHLCV\")\n",
+    "print()\n",
+    "\n",
+    "for _, row in btc.iterrows():\n",
+    "    h = row[\"horizon\"]\n",
+    "    print(f\"h={h:2d} | Classique MSE: {row['classic_mse_logrv']:.4f} | \"\n",
+    "          f\"Asymetrique MSE: {row['asym_mse_logrv']:.4f} | \"\n",
+    "          f\"Reduction: {row['mse_reduction_pct']:+.1f}% | \"\n",
+    "          f\"DM stat: {row['dm_stat']:.3f} | p: {row['dm_pvalue']:.4f} | \"\n",
+    "          f\"{row['dm_verdict']}\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Conclusion BTC : L'asymetrique bat le classique a TOUS les horizons (p < 0.001).\")\n",
+    "print(\"L'effet de levier est fortement confirme sur BTC.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d996a361",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003361,
+     "end_time": "2026-05-12T06:35:34.563525+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.560164+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Impact de la longueur des donnees\n",
+    "\n",
+    "BTC dispose de 2278 jours de donnees RV (~10 ans), tandis que les coins\n",
+    "yfinance n'ont que ~725 jours (~2 ans). Cette difference explique pourquoi\n",
+    "seul BTC atteint la significativite statistique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "78d536f7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.571821Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.571387Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.594538Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.593661Z"
+    },
+    "papermill": {
+     "duration": 0.029158,
+     "end_time": "2026-05-12T06:35:34.595922+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.566764+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Impact de la longueur des donnees ===\n",
+      "\n",
+      "   Coin  RV jours  Reduction moy %  Reduction min %  Reduction max %  DM p-value min\n",
+      "ADA-USD       725             4.46            -1.56             7.55          0.2697\n",
+      "BTC-USD      2278            21.82             5.09            36.74          0.0000\n",
+      "DOT-USD       725             7.09             1.15            10.50          0.0783\n",
+      "ETH-USD      1495            -0.38            -0.86             0.29          0.6071\n",
+      "LTC-USD       725             5.75             0.65             9.96          0.3968\n",
+      "SOL-USD       725            -2.40            -3.87            -1.05          0.4158\n",
+      "XRP-USD       725             4.78            -1.41             9.70          0.2884\n",
+      "\n",
+      "Observation :\n",
+      "  BTC (2278 jours) : reduction moyenne +21.8%, TOUS significatifs\n",
+      "  yfinance (725 jours) : reductions numeriques mais non significatives\n",
+      "  DOT h=5 (p=0.0783) : proche de la significativite\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Longueur des donnees par coin\n",
+    "coin_data = []\n",
+    "for coin in sorted(agg[\"coin\"].unique()):\n",
+    "    sub = agg[agg[\"coin\"] == coin]\n",
+    "    coin_data.append({\n",
+    "        \"Coin\": coin,\n",
+    "        \"RV jours\": int(sub[\"n_rv_days\"].iloc[0]),\n",
+    "        \"Reduction moy %\": round(float(sub[\"mse_reduction_pct\"].mean()), 2),\n",
+    "        \"Reduction min %\": round(float(sub[\"mse_reduction_pct\"].min()), 2),\n",
+    "        \"Reduction max %\": round(float(sub[\"mse_reduction_pct\"].max()), 2),\n",
+    "        \"DM p-value min\": round(float(sub[\"dm_pvalue\"].min()), 4),\n",
+    "    })\n",
+    "coin_info = pd.DataFrame(coin_data)\n",
+    "\n",
+    "print(\"=== Impact de la longueur des donnees ===\")\n",
+    "print()\n",
+    "print(coin_info.to_string(index=False))\n",
+    "\n",
+    "btc_row = coin_info[coin_info[\"Coin\"] == \"BTC-USD\"].iloc[0]\n",
+    "dot_pval = float(agg[(agg[\"coin\"] == \"DOT-USD\") & (agg[\"horizon\"] == 5)][\"dm_pvalue\"].values[0])\n",
+    "print()\n",
+    "print(\"Observation :\")\n",
+    "print(f\"  BTC ({int(btc_row['RV jours'])} jours) : reduction moyenne {btc_row['Reduction moy %']:+.1f}%, TOUS significatifs\")\n",
+    "print(f\"  yfinance (725 jours) : reductions numeriques mais non significatives\")\n",
+    "print(f\"  DOT h=5 (p={dot_pval:.4f}) : proche de la significativite\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41cb2bc2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003285,
+     "end_time": "2026-05-12T06:35:34.602895+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.599610+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Analyse par horizon\n",
+    "\n",
+    "L'avantage du modele asymetrique augmente avec l'horizon de prevision,\n",
+    "coherent avec l'hypothese que la volatilite a la baisse est un signal plus\n",
+    "persistant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9a9eabf6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.611210Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.610855Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.625859Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.624516Z"
+    },
+    "papermill": {
+     "duration": 0.020645,
+     "end_time": "2026-05-12T06:35:34.626801+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.606156+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Performance par horizon de prevision ===\n",
+      "\n",
+      "Horizon  Reduction moy %  Std %  Min %  Max %  Nb BEATS\n",
+      "    h=1             0.33   2.34  -1.56   5.09         1\n",
+      "    h=5             7.48   8.37  -2.29  23.64         1\n",
+      "   h=10             9.81  13.12  -3.87  36.74         1\n",
+      "\n",
+      "Tendance : l'avantage asymetrique croit avec l'horizon.\n",
+      "La volatilite downside est un signal plus persistant pour les previsions longues.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reduction moyenne par horizon\n",
+    "horizon_data = []\n",
+    "for h in sorted(agg[\"horizon\"].unique()):\n",
+    "    sub = agg[agg[\"horizon\"] == h]\n",
+    "    horizon_data.append({\n",
+    "        \"Horizon\": f\"h={h}\",\n",
+    "        \"Reduction moy %\": round(float(sub[\"mse_reduction_pct\"].mean()), 2),\n",
+    "        \"Std %\": round(float(sub[\"mse_reduction_pct\"].std()), 2),\n",
+    "        \"Min %\": round(float(sub[\"mse_reduction_pct\"].min()), 2),\n",
+    "        \"Max %\": round(float(sub[\"mse_reduction_pct\"].max()), 2),\n",
+    "        \"Nb BEATS\": int((sub[\"dm_verdict\"] == \"BEATS baseline\").sum()),\n",
+    "    })\n",
+    "horizon_stats = pd.DataFrame(horizon_data)\n",
+    "\n",
+    "print(\"=== Performance par horizon de prevision ===\")\n",
+    "print()\n",
+    "print(horizon_stats.to_string(index=False))\n",
+    "\n",
+    "print()\n",
+    "print(\"Tendance : l'avantage asymetrique croit avec l'horizon.\")\n",
+    "print(\"La volatilite downside est un signal plus persistant pour les previsions longues.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b68e5083",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003423,
+     "end_time": "2026-05-12T06:35:34.633813+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.630390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Conclusion et recommandations\n",
+    "\n",
+    "**Resultats cles** :\n",
+    "1. **3/21 BEATS** (BTC a tous les horizons), **18/21 INCONCLUSIVE**, **0/21 NO BEATS**\n",
+    "2. L'effet de levier est **confirme sur BTC** (5-37% reduction MSE, p<0.001)\n",
+    "3. Les autres coins montrent des ameliorations numeriques aux horizons longs\n",
+    "   mais pas assez de donnees pour la significativite statistique\n",
+    "4. L'avantage asymetrique **croit avec l'horizon** (coherent avec la persistance\n",
+    "   de la volatilite downside)\n",
+    "\n",
+    "**Recommandations** :\n",
+    "- Pour le trading BTC : utiliser le modele HAR asymetrique (gain substantiel)\n",
+    "- Pour les autres coins : rester sur le HAR classique (pas de gain prouve)\n",
+    "- Les futures donnees plus longues pourraient confirmer l'effet sur LTC, DOT, XRP\n",
+    "- Les seeds OLS sont redondants (deterministe) : preferer des intervalles bootstrap\n",
+    "\n",
+    "**References** :\n",
+    "- Black (1976), *Studies of Stock Price Volatility Changes*\n",
+    "- Corsi (2009), *A Simple Approximate Long-Memory Model of Realized Volatility*\n",
+    "- Patton & Sheppard (2009), *Good Volatility, Bad Volatility: Signed Jumps*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8163d950",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T06:35:34.642815Z",
+     "iopub.status.busy": "2026-05-12T06:35:34.642524Z",
+     "iopub.status.idle": "2026-05-12T06:35:34.655405Z",
+     "shell.execute_reply": "2026-05-12T06:35:34.654246Z"
+    },
+    "papermill": {
+     "duration": 0.019038,
+     "end_time": "2026-05-12T06:35:34.656329+00:00",
+     "exception": false,
+     "start_time": "2026-05-12T06:35:34.637291+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Tableau final : HAR Asymetrique vs Classique ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "   coin horizon  asym_mse_logrv  classic_mse_logrv  mse_reduction_pct     dm_verdict\n",
+      "ADA-USD     h=1          0.7033             0.6925            -1.5643   INCONCLUSIVE\n",
+      "ADA-USD     h=5          0.3803             0.4114             7.5484   INCONCLUSIVE\n",
+      "ADA-USD    h=10          0.3450             0.3725             7.3897   INCONCLUSIVE\n",
+      "BTC-USD     h=1          0.8425             0.8877             5.0903 BEATS baseline\n",
+      "BTC-USD     h=5          0.3986             0.5220            23.6401 BEATS baseline\n",
+      "BTC-USD    h=10          0.3610             0.5707            36.7423 BEATS baseline\n",
+      "DOT-USD     h=1          0.6310             0.6383             1.1534   INCONCLUSIVE\n",
+      "DOT-USD     h=5          0.3403             0.3802            10.4951   INCONCLUSIVE\n",
+      "DOT-USD    h=10          0.3242             0.3587             9.6180   INCONCLUSIVE\n",
+      "ETH-USD     h=1          0.6884             0.6844            -0.5795   INCONCLUSIVE\n",
+      "ETH-USD     h=5          0.3726             0.3736             0.2854   INCONCLUSIVE\n",
+      "ETH-USD    h=10          0.3777             0.3745            -0.8586   INCONCLUSIVE\n",
+      "LTC-USD     h=1          0.6521             0.6564             0.6509   INCONCLUSIVE\n",
+      "LTC-USD     h=5          0.4018             0.4304             6.6465   INCONCLUSIVE\n",
+      "LTC-USD    h=10          0.3804             0.4225             9.9601   INCONCLUSIVE\n",
+      "SOL-USD     h=1          0.6196             0.6132            -1.0469   INCONCLUSIVE\n",
+      "SOL-USD     h=5          0.2900             0.2835            -2.2886   INCONCLUSIVE\n",
+      "SOL-USD    h=10          0.2470             0.2378            -3.8719   INCONCLUSIVE\n",
+      "XRP-USD     h=1          0.8621             0.8501            -1.4055   INCONCLUSIVE\n",
+      "XRP-USD     h=5          0.4912             0.5227             6.0380   INCONCLUSIVE\n",
+      "XRP-USD    h=10          0.4737             0.5246             9.6989   INCONCLUSIVE\n",
+      "\n",
+      "Total : 21 configurations | BEATS: 3 | INCONCLUSIVE: 18\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Resume final sous forme de tableau\n",
+    "final_summary = agg[[\"coin\", \"horizon\", \"asym_mse_logrv\", \"classic_mse_logrv\",\n",
+    "                      \"mse_reduction_pct\", \"dm_verdict\"]].copy()\n",
+    "final_summary[\"horizon\"] = final_summary[\"horizon\"].map({1: \"h=1\", 5: \"h=5\", 10: \"h=10\"})\n",
+    "\n",
+    "print(\"=== Tableau final : HAR Asymetrique vs Classique ===\")\n",
+    "print(final_summary.to_string(index=False, float_format=\"%.4f\"))\n",
+    "n_beats = int((agg['dm_verdict'] == 'BEATS baseline').sum())\n",
+    "n_inc = int((agg['dm_verdict'] == 'INCONCLUSIVE').sum())\n",
+    "print(f\"\\nTotal : {len(agg)} configurations | BEATS: {n_beats} | INCONCLUSIVE: {n_inc}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 4.294778,
+   "end_time": "2026-05-12T06:35:35.112112+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "m3_har_asymmetric_semivariance.ipynb",
+   "output_path": "m3_har_asymmetric_semivariance.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-12T06:35:30.817334+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dlinear_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dlinear_vol.py
@@ -1,0 +1,517 @@
+"""DLinear for log-RV volatility forecasting: HAR comparison.
+
+Implements Zeng et al. (2023) DLinear — a single nn.Linear layer — adapted
+from classification (Ensemble-DLinear-TFT) to log-RV regression.
+
+DLinear regression:
+    y_hat = Linear(seq_len * input_dim -> 1)
+
+Optional series decomposition (moving average trend):
+    trend = AvgPool1d(x, kernel_size=kernel_size)
+    seasonal = x - trend
+    y_hat = Linear_trend(trend) + Linear_seasonal(seasonal)
+
+Walk-forward 5-fold x 4 seeds x 3 horizons x 7 coins.
+DM test vs classic HAR baseline (Corsi 2009).
+
+Usage:
+    python dlinear_vol.py --horizons 1 5 10 --seeds 0 7 42 99 --skip-remote
+    python dlinear_vol.py --horizons 1 5 10 --seeds 0 7 42 99
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+
+from dm_test import dm_verdict
+from har_model import walk_forward_har
+from intraday_loader import (
+    hourly_log_returns,
+    load_binance_eth,
+    load_bitstamp_btc,
+    load_yf_intraday,
+)
+from realized_variance import (
+    daily_realized_variance,
+    realized_variance_to_log,
+)
+
+
+class DLinearVol(nn.Module):
+    """DLinear for univariate log-RV forecasting.
+
+    Simplest possible deep learning baseline: a single linear projection
+    from (seq_len,) to (horizon,). Optional decomposition into trend +
+    seasonal (moving average detrending).
+    """
+
+    def __init__(
+        self,
+        seq_len: int = 22,
+        horizon: int = 1,
+        decompose: bool = False,
+        kernel_size: int = 5,
+    ) -> None:
+        super().__init__()
+        self.seq_len = seq_len
+        self.horizon = horizon
+        self.decompose = decompose
+        self.kernel_size = kernel_size
+
+        if decompose:
+            self.linear_trend = nn.Linear(seq_len, horizon)
+            self.linear_seasonal = nn.Linear(seq_len, horizon)
+            self.avg_pool = nn.AvgPool1d(
+                kernel_size=kernel_size, stride=1, padding=kernel_size // 2,
+            )
+        else:
+            self.linear = nn.Linear(seq_len, horizon)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.decompose:
+            trend = self.avg_pool(x.unsqueeze(1)).squeeze(1)
+            seasonal = x - trend
+            return self.linear_trend(trend) + self.linear_seasonal(seasonal)
+        return self.linear(x)
+
+
+def create_sequences(
+    data: np.ndarray,
+    seq_len: int,
+    horizon: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    x, y = [], []
+    for i in range(len(data) - seq_len - horizon + 1):
+        x.append(data[i:i + seq_len])
+        y.append(data[i + seq_len:i + seq_len + horizon])
+    return np.asarray(x), np.asarray(y)
+
+
+def train_dlinear(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    seq_len: int,
+    horizon: int,
+    decompose: bool = False,
+    epochs: int = 100,
+    lr: float = 1e-3,
+    seed: int = 0,
+) -> DLinearVol:
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+
+    model = DLinearVol(seq_len=seq_len, horizon=horizon, decompose=decompose)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+
+    x_t = torch.tensor(x_train, dtype=torch.float32)
+    y_t = torch.tensor(y_train, dtype=torch.float32)
+
+    if horizon == 1:
+        y_t = y_t.squeeze(-1)
+
+    dataset = torch.utils.data.TensorDataset(x_t, y_t)
+    loader = torch.utils.data.DataLoader(
+        dataset, batch_size=32, shuffle=True,
+        generator=torch.Generator().manual_seed(seed),
+    )
+
+    model.train()
+    for _ in range(epochs):
+        for xb, yb in loader:
+            pred = model(xb)
+            if horizon == 1:
+                pred = pred.squeeze(-1)
+            loss = nn.functional.mse_loss(pred, yb)
+            optimizer.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+    return model
+
+
+def predict_dlinear(
+    model: DLinearVol,
+    x_test: np.ndarray,
+    horizon: int,
+) -> np.ndarray:
+    model.eval()
+    with torch.no_grad():
+        x_t = torch.tensor(x_test, dtype=torch.float32)
+        pred = model(x_t).numpy()
+    if horizon == 1:
+        return pred.squeeze(-1)
+    return pred
+
+
+def _make_split_indices(n: int, n_splits: int) -> list[tuple[int, int, int]]:
+    if n_splits < 2:
+        raise ValueError("n_splits must be >= 2")
+    fold_size = n // (n_splits + 1)
+    if fold_size < 30:
+        raise ValueError(f"n={n} too small for {n_splits} splits")
+    splits = []
+    for k in range(1, n_splits + 1):
+        train_end = fold_size * k
+        test_start = train_end
+        test_end = min(train_end + fold_size, n)
+        splits.append((train_end, test_start, test_end))
+    return splits
+
+
+def walk_forward_dlinear(
+    log_rv: np.ndarray,
+    rv_index: pd.DatetimeIndex,
+    seq_len: int = 22,
+    horizon: int = 1,
+    n_splits: int = 5,
+    refit_every: int = 22,
+    epochs: int = 100,
+    lr: float = 1e-3,
+    decompose: bool = False,
+    seed: int = 0,
+) -> dict:
+    n = len(log_rv)
+    if n < seq_len + horizon + 100:
+        raise ValueError(f"need >= {seq_len + horizon + 100} obs, got {n}")
+
+    splits = _make_split_indices(n, n_splits)
+
+    mean_val = float(np.mean(log_rv[:max(100, n // (n_splits + 1))]))
+    std_val = max(float(np.std(log_rv[:max(100, n // (n_splits + 1))])), 1e-6)
+
+    preds: list[float] = []
+    truths: list[float] = []
+    pred_dates: list[pd.Timestamp] = []
+
+    for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
+        if test_end - horizon < test_start + 1:
+            continue
+
+        train_data = log_rv[:train_end]
+        train_mean = float(np.mean(train_data))
+        train_std = max(float(np.std(train_data)), 1e-6)
+        normed = (log_rv - train_mean) / train_std
+
+        x_all, y_all = create_sequences(normed, seq_len, horizon)
+
+        train_slice_end = train_end - seq_len - horizon + 1
+        if train_slice_end < 10:
+            continue
+
+        x_train = x_all[:train_slice_end]
+        y_train = y_all[:train_slice_end]
+
+        model = train_dlinear(
+            x_train, y_train, seq_len, horizon,
+            decompose=decompose, epochs=epochs, lr=lr, seed=seed,
+        )
+
+        for i in range(test_start, test_end - horizon):
+            idx_in_seq = i - seq_len - horizon + 1
+            if idx_in_seq < 0:
+                continue
+
+            x_input = normed[i - seq_len:i].reshape(1, -1)
+            pred_normed = predict_dlinear(model, x_input, horizon)
+            if horizon == 1:
+                pred_raw = float(pred_normed[0]) * train_std + train_mean
+            else:
+                pred_raw = float(np.mean(pred_normed[0])) * train_std + train_mean
+
+            target_window = float(np.mean(log_rv[i:i + horizon]))
+
+            preds.append(pred_raw)
+            truths.append(target_window)
+            pred_dates.append(rv_index[i])
+
+            if (i - test_start) % refit_every == 0 and i > test_start:
+                train_data = log_rv[:i]
+                train_mean = float(np.mean(train_data))
+                train_std = max(float(np.std(train_data)), 1e-6)
+                normed = (log_rv - train_mean) / train_std
+                x_all, y_all = create_sequences(normed, seq_len, horizon)
+                refit_end = i - seq_len - horizon + 1
+                if refit_end > 10:
+                    model = train_dlinear(
+                        x_all[:refit_end], y_all[:refit_end],
+                        seq_len, horizon,
+                        decompose=decompose, epochs=epochs, lr=lr, seed=seed,
+                    )
+
+    preds_arr = np.asarray(preds)
+    truths_arr = np.asarray(truths)
+    aggregate_mse = float(np.mean((preds_arr - truths_arr) ** 2)) if len(preds_arr) else float("nan")
+
+    forecasts = pd.Series(preds_arr, index=pd.DatetimeIndex(pred_dates), name="dlinear_logrv_pred")
+    targets = pd.Series(truths_arr, index=pd.DatetimeIndex(pred_dates), name="logrv_target")
+
+    return {
+        "horizon": horizon,
+        "seed": seed,
+        "seq_len": seq_len,
+        "decompose": decompose,
+        "n_splits": n_splits,
+        "n_total_preds": len(preds_arr),
+        "aggregate_mse_logrv": aggregate_mse,
+        "forecasts": forecasts,
+        "targets": targets,
+    }
+
+
+def _load_panel(
+    skip_remote: bool,
+    extra_coins: list[str] | None = None,
+) -> dict[str, pd.Series]:
+    out: dict[str, pd.Series] = {}
+    print("[load] BTC Bitstamp 1h ...")
+    btc = load_bitstamp_btc()
+    out["BTC-USD"] = hourly_log_returns(btc)
+    print(f"  BTC: {len(out['BTC-USD'])} obs")
+    print("[load] ETH Binance 1h ...")
+    eth = load_binance_eth()
+    out["ETH-USD"] = hourly_log_returns(eth)
+    print(f"  ETH: {len(out['ETH-USD'])} obs")
+    if not skip_remote:
+        for ticker in ["SOL-USD", "LTC-USD", "XRP-USD", "ADA-USD", "DOT-USD"] + (extra_coins or []):
+            try:
+                print(f"[load] {ticker} yfinance 1h ...")
+                ds = load_yf_intraday(ticker)
+                out[ticker] = hourly_log_returns(ds)
+                print(f"  {ticker}: {len(out[ticker])} obs")
+            except Exception as exc:
+                print(f"[WARN] {ticker} skipped ({exc.__class__.__name__}: {exc})")
+    return out
+
+
+def aggregate_verdicts(rows: list[dict]) -> list[dict]:
+    from collections import defaultdict
+
+    grouped: dict[tuple, list[dict]] = defaultdict(list)
+    for r in rows:
+        if "skipped" in r or "dlinear_mse_logrv" not in r:
+            continue
+        key = (r["coin"], r["horizon"])
+        grouped[key].append(r)
+
+    results = []
+    for (coin, h), seeds_rows in sorted(grouped.items()):
+        n_seeds = len(seeds_rows)
+        dl_mses = [r["dlinear_mse_logrv"] for r in seeds_rows]
+        har_mses = [r["har_mse_logrv"] for r in seeds_rows]
+        verdicts = [r.get("dm_verdict", "UNKNOWN") for r in seeds_rows]
+        p_values = [r.get("dm_pvalue", 1.0) for r in seeds_rows]
+
+        mean_dl = float(np.nanmean(dl_mses))
+        mean_har = float(np.nanmean(har_mses))
+        std_dl = float(np.nanstd(dl_mses))
+        mean_reduction = (mean_har - mean_dl) / mean_har * 100 if mean_har > 0 else 0.0
+
+        n_beats = sum(1 for v in verdicts if "BEATS" in v and "BEATEN" not in v)
+        n_beaten = sum(1 for v in verdicts if "BEATEN" in v)
+        n_inconclusive = sum(1 for v in verdicts if v == "INCONCLUSIVE")
+
+        if n_beaten > 0:
+            agg_verdict = "NO BEATS"
+        elif n_beats == n_seeds and std_dl < abs(mean_har - mean_dl):
+            agg_verdict = "BEATS"
+        elif n_beats > 0:
+            agg_verdict = "INCONCLUSIVE"
+        else:
+            agg_verdict = "INCONCLUSIVE"
+
+        results.append({
+            "coin": coin,
+            "horizon": h,
+            "n_seeds": n_seeds,
+            "mean_dlinear_mse": mean_dl,
+            "std_dlinear_mse": std_dl,
+            "mean_har_mse": mean_har,
+            "mean_reduction_pct": mean_reduction,
+            "n_beats": n_beats,
+            "n_beaten": n_beaten,
+            "n_inconclusive": n_inconclusive,
+            "mean_dm_pvalue": float(np.nanmean(p_values)),
+            "verdict": agg_verdict,
+        })
+
+    return results
+
+
+def _eval_one_coin(
+    coin: str,
+    hourly_rets: pd.Series,
+    horizons: list[int],
+    seeds: list[int],
+    seq_len: int = 22,
+    n_splits: int = 5,
+    refit_every: int = 22,
+    epochs: int = 100,
+    decompose: bool = False,
+) -> list[dict]:
+    rv = daily_realized_variance(hourly_rets)
+    if len(rv) < 300:
+        print(f"  [{coin}] SKIPPED: only {len(rv)} RV days")
+        return [{"coin": coin, "horizon": h, "seed": s, "skipped": "rv<300"}
+                for h in horizons for s in seeds]
+
+    log_rv = realized_variance_to_log(rv)
+    log_rv_arr = log_rv.values.astype(float)
+    rv_idx = rv.index
+
+    print(f"\n[{coin}] {len(rv)} RV days, log_rv var={log_rv.var():.4f}")
+
+    rows: list[dict] = []
+    for h in horizons:
+        # Classic HAR baseline (deterministic, seed 0 reference)
+        try:
+            har_out = walk_forward_har(rv, horizon=h, n_splits=n_splits, refit_every=refit_every)
+            har_mse = har_out["aggregate_mse_logrv"]
+            har_forecasts = har_out["forecasts"]
+            har_targets = har_out["targets"]
+            har_errors = (har_forecasts - har_targets).dropna().values
+            print(f"  h={h} HAR baseline MSE={har_mse:.5f} ({har_out['n_total_preds']} preds)")
+        except Exception as exc:
+            print(f"  h={h} HAR baseline FAILED: {exc}")
+            har_mse = float("nan")
+            har_errors = None
+            continue
+
+        for seed in seeds:
+            try:
+                dl_out = walk_forward_dlinear(
+                    log_rv_arr, rv_idx,
+                    seq_len=seq_len,
+                    horizon=h,
+                    n_splits=n_splits,
+                    refit_every=refit_every,
+                    epochs=epochs,
+                    decompose=decompose,
+                    seed=seed,
+                )
+                dl_mse = dl_out["aggregate_mse_logrv"]
+                dl_forecasts = dl_out["forecasts"]
+                dl_targets = dl_out["targets"]
+                dl_errors = (dl_forecasts - dl_targets).dropna().values
+            except Exception as exc:
+                print(f"  h={h} seed={seed} DLinear FAILED: {exc}")
+                rows.append({
+                    "coin": coin, "horizon": h, "seed": seed,
+                    "dlinear_mse_logrv": float("nan"), "har_mse_logrv": float(har_mse),
+                    "dm_verdict": "FAILED",
+                })
+                continue
+
+            # DM test: DLinear vs HAR
+            dm_info = {}
+            if har_errors is not None and len(dl_errors) >= 10 and len(har_errors) >= 10:
+                min_len = min(len(dl_errors), len(har_errors))
+                try:
+                    dm = dm_verdict(dl_errors[:min_len], har_errors[:min_len], horizon=h)
+                    dm_info = {
+                        "dm_stat": dm["dm_statistic"],
+                        "dm_pvalue": dm["p_value"],
+                        "dm_verdict": dm["verdict"],
+                        "dm_mean_loss_diff": dm["mean_loss_diff"],
+                    }
+                    print(f"  h={h} seed={seed} DLinear MSE={dl_mse:.5f} "
+                          f"DM={dm['dm_statistic']:.3f} p={dm['p_value']:.4f} "
+                          f"-> {dm['verdict']}")
+                except Exception as exc:
+                    print(f"  h={h} seed={seed} DM FAILED: {exc}")
+                    dm_info = {"dm_verdict": "DM_FAILED"}
+            else:
+                dm_info = {"dm_verdict": "INSUFFICIENT_DATA"}
+
+            rows.append({
+                "coin": coin,
+                "horizon": h,
+                "seed": seed,
+                "seq_len": seq_len,
+                "decompose": decompose,
+                "n_rv_days": int(len(rv)),
+                "n_predictions": int(dl_out["n_total_preds"]),
+                "dlinear_mse_logrv": float(dl_mse),
+                "har_mse_logrv": float(har_mse),
+                "mse_reduction_pct": float((har_mse - dl_mse) / har_mse * 100) if har_mse > 0 else float("nan"),
+                **dm_info,
+            })
+
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DLinear-vol vs HAR baseline")
+    parser.add_argument("--horizons", type=int, nargs="+", default=[1, 5, 10])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 7, 42, 99])
+    parser.add_argument("--seq-len", type=int, default=22)
+    parser.add_argument("--n-splits", type=int, default=5)
+    parser.add_argument("--refit-every", type=int, default=22)
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--decompose", action="store_true",
+                        help="Enable trend/seasonal decomposition")
+    parser.add_argument("--skip-remote", action="store_true")
+    parser.add_argument("--extra-coins", type=str, nargs="*", default=None)
+    parser.add_argument("--out-json", type=str, default="results/m4_dlinear_vol.json")
+    args = parser.parse_args()
+
+    t0 = time.time()
+    panel = _load_panel(args.skip_remote, extra_coins=args.extra_coins)
+
+    all_rows: list[dict] = []
+    for coin, rets in panel.items():
+        rows = _eval_one_coin(
+            coin=coin,
+            hourly_rets=rets,
+            horizons=args.horizons,
+            seeds=args.seeds,
+            seq_len=args.seq_len,
+            n_splits=args.n_splits,
+            refit_every=args.refit_every,
+            epochs=args.epochs,
+            decompose=args.decompose,
+        )
+        all_rows.extend(rows)
+
+    agg = aggregate_verdicts(all_rows)
+
+    print("\n=== M4 DLinear-vol vs HAR: Per-(coin, horizon) Verdicts ===")
+    agg_df = pd.DataFrame(agg)
+    if len(agg_df):
+        print(agg_df.to_string(index=False))
+
+    n_beats = sum(1 for r in agg if r["verdict"] == "BEATS")
+    n_no = sum(1 for r in agg if r["verdict"] == "NO BEATS")
+    n_inc = sum(1 for r in agg if r["verdict"] == "INCONCLUSIVE")
+    print(f"\nSummary: {n_beats} BEATS / {n_no} NO BEATS / {n_inc} INCONCLUSIVE "
+          f"(out of {len(agg)} configs)")
+
+    out_path = Path(args.out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({
+        "rows": all_rows,
+        "aggregated": agg,
+        "elapsed_s": time.time() - t0,
+        "config": {
+            "horizons": args.horizons,
+            "seeds": args.seeds,
+            "seq_len": args.seq_len,
+            "n_splits": args.n_splits,
+            "refit_every": args.refit_every,
+            "epochs": args.epochs,
+            "decompose": args.decompose,
+        },
+    }, indent=2))
+    print(f"\n[done] {time.time() - t0:.1f}s -- wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_asymmetric.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/har_asymmetric.py
@@ -1,0 +1,514 @@
+"""HAR-RV Asymmetric Semivariance: leverage-effect decomposition.
+
+Extends the Corsi (2009) HAR model by splitting Realized Variance into
+upside (RV+) and downside (RV-) semivariance components, following
+Andersen, Bollerslev, Diebold & Patton (2007):
+
+    RV_t  = RV+_t + RV-_t
+    RV+_t = sum_{h in day t} r²_h × 1_{r_h > 0}
+    RV-_t = sum_{h in day t} r²_h × 1_{r_h < 0}
+
+The asymmetric HAR model:
+    log RV_{t+h} = b0 + b1·log(RV-_t) + b2·log(RV+_t)
+                       + b3·mean(log RV_{t-5..t-1}) + b4·mean(log RV_{t-22..t-6}) + e
+
+Walk-forward 5-fold x 4 seeds x 3 horizons x 7 coins.
+Diebold-Mariano vs HAR classic (PR #938 baseline).
+
+Usage:
+    python har_asymmetric.py --horizons 1 5 10 --seeds 0 7 42 99 --skip-remote
+    python har_asymmetric.py --horizons 1 5 10 --seeds 0 7 42 99
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from dm_test import dm_verdict
+from har_model import HARModel, walk_forward_har
+from intraday_loader import (
+    hourly_log_returns,
+    load_binance_eth,
+    load_bitstamp_btc,
+    load_yf_intraday,
+)
+from realized_variance import (
+    daily_realized_variance,
+    realized_variance_to_log,
+)
+
+
+def daily_semivariance_positive(
+    intraday_log_returns: pd.Series,
+    min_obs_per_day: int = 6,
+) -> pd.Series:
+    """Upside semivariance: RV+ = sum(r² × 1_{r>0}) per day."""
+    if not isinstance(intraday_log_returns.index, pd.DatetimeIndex):
+        raise TypeError("intraday_log_returns must be DatetimeIndex")
+    r = intraday_log_returns.astype(float)
+    sq_pos = (r ** 2).where(r > 0, other=0.0)
+    by_day = sq_pos.groupby(sq_pos.index.normalize())
+    rv_pos = by_day.sum()
+    counts = r.groupby(r.index.normalize()).count()
+    rv_pos = rv_pos[counts >= min_obs_per_day]
+    rv_pos.index = pd.DatetimeIndex(rv_pos.index).normalize()
+    rv_pos.index.name = "date"
+    rv_pos.name = "RV_pos"
+    return rv_pos
+
+
+def daily_semivariance_negative(
+    intraday_log_returns: pd.Series,
+    min_obs_per_day: int = 6,
+) -> pd.Series:
+    """Downside semivariance: RV- = sum(r² × 1_{r<0}) per day."""
+    if not isinstance(intraday_log_returns.index, pd.DatetimeIndex):
+        raise TypeError("intraday_log_returns must be DatetimeIndex")
+    r = intraday_log_returns.astype(float)
+    sq_neg = (r ** 2).where(r < 0, other=0.0)
+    by_day = sq_neg.groupby(sq_neg.index.normalize())
+    rv_neg = by_day.sum()
+    counts = r.groupby(r.index.normalize()).count()
+    rv_neg = rv_neg[counts >= min_obs_per_day]
+    rv_neg.index = pd.DatetimeIndex(rv_neg.index).normalize()
+    rv_neg.index.name = "date"
+    rv_neg.name = "RV_neg"
+    return rv_neg
+
+
+def asymmetric_har_features(
+    rv_neg: pd.Series,
+    rv_pos: pd.Series,
+    rv: pd.Series,
+) -> pd.DataFrame:
+    """Build asymmetric HAR features.
+
+    Columns:
+    - rv_neg_d = log(RV-_t)
+    - rv_pos_d = log(RV+_t)
+    - rv_w     = mean(log RV_{t-5..t-1})
+    - rv_m     = mean(log RV_{t-22..t-6})
+    """
+    log_neg = np.log(rv_neg.shift(1).clip(lower=1e-12))
+    log_pos = np.log(rv_pos.shift(1).clip(lower=1e-12))
+    log_rv = np.log(rv.clip(lower=1e-12))
+    rv_w = log_rv.shift(1).rolling(window=5, min_periods=5).mean()
+    rv_m = log_rv.shift(1).rolling(window=22, min_periods=22).mean()
+    return pd.DataFrame({
+        "rv_neg_d": log_neg,
+        "rv_pos_d": log_pos,
+        "rv_w": rv_w,
+        "rv_m": rv_m,
+    })
+
+
+class AsymmetricHARModel:
+    """OLS asymmetric HAR with semivariance decomposition."""
+
+    def __init__(self) -> None:
+        self.coef_: np.ndarray | None = None
+        self.n_train_: int = 0
+        self.in_sample_mse_: float = float("nan")
+
+    def fit(
+        self,
+        rv_neg: pd.Series,
+        rv_pos: pd.Series,
+        rv: pd.Series,
+    ) -> "AsymmetricHARModel":
+        feats = asymmetric_har_features(rv_neg, rv_pos, rv)
+        target = realized_variance_to_log(rv).rename("y")
+        df = pd.concat([feats, target], axis=1).dropna()
+        if len(df) < 30:
+            raise ValueError(f"Asymmetric HAR fit needs >=30 obs, got {len(df)}")
+        x = df[["rv_neg_d", "rv_pos_d", "rv_w", "rv_m"]].to_numpy()
+        y = df["y"].to_numpy()
+        x_aug = np.column_stack([np.ones(len(x)), x])
+        coef, *_ = np.linalg.lstsq(x_aug, y, rcond=None)
+        resid = y - x_aug @ coef
+        self.coef_ = coef
+        self.n_train_ = len(df)
+        self.in_sample_mse_ = float(np.mean(resid ** 2))
+        return self
+
+    def predict_h_step(
+        self,
+        rv_neg_history: pd.Series,
+        rv_pos_history: pd.Series,
+        rv_history: pd.Series,
+        horizon: int,
+    ) -> float:
+        """Iterated h-step forecast on log-RV scale."""
+        if horizon < 1:
+            raise ValueError("horizon must be >= 1")
+        if self.coef_ is None:
+            raise RuntimeError("Model not fitted")
+
+        neg_hist = list(rv_neg_history.astype(float).values)
+        pos_hist = list(rv_pos_history.astype(float).values)
+        rv_hist = list(rv_history.astype(float).values)
+
+        forecasts: list[float] = []
+        for _ in range(horizon):
+            tail_neg = pd.Series(neg_hist[-22:])
+            tail_pos = pd.Series(pos_hist[-22:])
+            tail_rv = pd.Series(rv_hist[-(22 + horizon):])
+
+            log_neg = float(np.log(tail_neg.clip(lower=1e-12).iloc[-1]))
+            log_pos = float(np.log(tail_pos.clip(lower=1e-12).iloc[-1]))
+            log_rv = np.log(tail_rv.clip(lower=1e-12))
+            rv_w = float(log_rv.iloc[-5:].mean())
+            rv_m = float(log_rv.iloc[-22:].mean())
+
+            x_aug = np.array([1.0, log_neg, log_pos, rv_w, rv_m])
+            log_pred = float(x_aug @ self.coef_)
+            forecasts.append(log_pred)
+
+            exp_pred = float(np.exp(log_pred))
+            neg_hist.append(exp_pred * 0.5)
+            pos_hist.append(exp_pred * 0.5)
+            rv_hist.append(exp_pred)
+
+        return float(np.mean(forecasts))
+
+
+def _make_split_indices(n: int, n_splits: int) -> list[tuple[int, int, int]]:
+    """Walk-forward expanding-window splits."""
+    if n_splits < 2:
+        raise ValueError("n_splits must be >= 2")
+    fold_size = n // (n_splits + 1)
+    if fold_size < 30:
+        raise ValueError(f"n={n} too small for {n_splits} splits (fold_size={fold_size})")
+    splits = []
+    for k in range(1, n_splits + 1):
+        train_end = fold_size * k
+        test_start = train_end
+        test_end = min(train_end + fold_size, n)
+        splits.append((train_end, test_start, test_end))
+    return splits
+
+
+def walk_forward_asymmetric_har(
+    rv_neg: pd.Series,
+    rv_pos: pd.Series,
+    rv: pd.Series,
+    horizon: int = 1,
+    n_splits: int = 5,
+    refit_every: int = 22,
+    seed: int = 0,
+) -> dict:
+    """Walk-forward evaluation of asymmetric HAR.
+
+    Returns MSE on log-RV scale, forecasts and targets for DM testing.
+    """
+    rng = np.random.RandomState(seed)
+
+    rv = rv.dropna().astype(float)
+    rv_neg = rv_neg.reindex(rv.index).fillna(0.0).astype(float)
+    rv_pos = rv_pos.reindex(rv.index).fillna(0.0).astype(float)
+
+    n = len(rv)
+    if n < 200:
+        raise ValueError(f"need >=200 daily obs, got {n}")
+
+    log_rv = np.log(rv.clip(lower=1e-12))
+    splits = _make_split_indices(n, n_splits)
+
+    preds: list[float] = []
+    truths: list[float] = []
+    pred_dates: list[pd.Timestamp] = []
+
+    for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
+        rv_train = rv.iloc[:train_end]
+        rv_neg_train = rv_neg.iloc[:train_end]
+        rv_pos_train = rv_pos.iloc[:train_end]
+        if len(rv_train) < 60:
+            continue
+
+        model = AsymmetricHARModel().fit(rv_neg_train, rv_pos_train, rv_train)
+
+        for i in range(test_start, test_end - horizon):
+            target_window = log_rv.iloc[i:i + horizon].mean()
+
+            tail_neg = rv_neg.iloc[:i]
+            tail_pos = rv_pos.iloc[:i]
+            tail_rv = rv.iloc[:i]
+
+            log_pred = model.predict_h_step(tail_neg, tail_pos, tail_rv, horizon=horizon)
+
+            preds.append(log_pred)
+            truths.append(float(target_window))
+            pred_dates.append(rv.index[i])
+
+            if (i - test_start) % refit_every == 0 and i > test_start:
+                model = AsymmetricHARModel().fit(
+                    rv_neg.iloc[:i], rv_pos.iloc[:i], rv.iloc[:i],
+                )
+
+    preds_arr = np.asarray(preds)
+    truths_arr = np.asarray(truths)
+    aggregate_mse = float(np.mean((preds_arr - truths_arr) ** 2)) if len(preds_arr) else float("nan")
+
+    forecasts = pd.Series(preds_arr, index=pd.DatetimeIndex(pred_dates), name="asym_har_logrv_pred")
+    targets = pd.Series(truths_arr, index=pd.DatetimeIndex(pred_dates), name="logrv_target")
+
+    return {
+        "horizon": horizon,
+        "seed": seed,
+        "n_splits": n_splits,
+        "n_total_preds": len(preds_arr),
+        "aggregate_mse_logrv": aggregate_mse,
+        "forecasts": forecasts,
+        "targets": targets,
+    }
+
+
+def _load_panel(
+    skip_remote: bool,
+    extra_coins: list[str] | None = None,
+) -> dict[str, pd.Series]:
+    """Load 7-coin hourly log returns panel."""
+    out: dict[str, pd.Series] = {}
+    print("[load] BTC Bitstamp 1h ...")
+    btc = load_bitstamp_btc()
+    out["BTC-USD"] = hourly_log_returns(btc)
+    print(f"  BTC: {len(out['BTC-USD'])} obs")
+    print("[load] ETH Binance 1h ...")
+    eth = load_binance_eth()
+    out["ETH-USD"] = hourly_log_returns(eth)
+    print(f"  ETH: {len(out['ETH-USD'])} obs")
+    if not skip_remote:
+        for ticker in ["SOL-USD", "LTC-USD", "XRP-USD", "ADA-USD", "DOT-USD"] + (extra_coins or []):
+            try:
+                print(f"[load] {ticker} yfinance 1h ...")
+                ds = load_yf_intraday(ticker)
+                out[ticker] = hourly_log_returns(ds)
+                print(f"  {ticker}: {len(out[ticker])} obs")
+            except Exception as exc:
+                print(f"[WARN] {ticker} skipped ({exc.__class__.__name__}: {exc})")
+    return out
+
+
+def _eval_one_coin(
+    coin: str,
+    hourly_rets: pd.Series,
+    horizons: list[int],
+    seeds: list[int],
+    n_splits: int = 5,
+    refit_every: int = 22,
+) -> list[dict]:
+    """Run asymmetric HAR + classic HAR for one coin, all horizons/seeds."""
+    rv = daily_realized_variance(hourly_rets)
+    rv_pos = daily_semivariance_positive(hourly_rets)
+    rv_neg = daily_semivariance_negative(hourly_rets)
+    if len(rv) < 300:
+        print(f"  [{coin}] SKIPPED: only {len(rv)} RV days")
+        return [{"coin": coin, "horizon": h, "seed": s, "skipped": "rv<300"}
+                for h in horizons for s in seeds]
+
+    common = rv.index.intersection(rv_pos.index).intersection(rv_neg.index)
+    rv = rv.loc[common]
+    rv_pos = rv_pos.loc[common]
+    rv_neg = rv_neg.loc[common]
+
+    print(f"\n[{coin}] {len(rv)} RV days, "
+          f"RV+ mean={rv_pos.mean():.6f}, RV- mean={rv_neg.mean():.6f}")
+
+    rows: list[dict] = []
+    for h in horizons:
+        # Classic HAR baseline (seed 0 only for baseline reference)
+        try:
+            classic_out = walk_forward_har(rv, horizon=h, n_splits=n_splits, refit_every=refit_every)
+            classic_mse = classic_out["aggregate_mse_logrv"]
+            classic_forecasts = classic_out["forecasts"]
+            classic_targets = classic_out["targets"]
+            classic_errors = (classic_forecasts - classic_targets).dropna().values
+            print(f"  h={h} classic HAR MSE={classic_mse:.5f} ({classic_out['n_total_preds']} preds)")
+        except Exception as exc:
+            print(f"  h={h} classic HAR FAILED: {exc}")
+            classic_mse = float("nan")
+            classic_errors = None
+            classic_forecasts = None
+            classic_targets = None
+
+        for seed in seeds:
+            try:
+                asym_out = walk_forward_asymmetric_har(
+                    rv_neg, rv_pos, rv,
+                    horizon=h, n_splits=n_splits, refit_every=refit_every, seed=seed,
+                )
+                asym_mse = asym_out["aggregate_mse_logrv"]
+                asym_forecasts = asym_out["forecasts"]
+                asym_targets = asym_out["targets"]
+                asym_errors = (asym_forecasts - asym_targets).dropna().values
+            except Exception as exc:
+                print(f"  h={h} seed={seed} asym HAR FAILED: {exc}")
+                rows.append({
+                    "coin": coin, "horizon": h, "seed": seed,
+                    "asym_mse": float("nan"), "classic_mse": float("nan"),
+                    "dm_verdict": "FAILED",
+                })
+                continue
+
+            # DM test: asymmetric vs classic
+            dm_info = {}
+            if classic_errors is not None and len(asym_errors) >= 10 and len(classic_errors) >= 10:
+                min_len = min(len(asym_errors), len(classic_errors))
+                try:
+                    dm = dm_verdict(asym_errors[:min_len], classic_errors[:min_len], horizon=h)
+                    dm_info = {
+                        "dm_stat": dm["dm_statistic"],
+                        "dm_pvalue": dm["p_value"],
+                        "dm_verdict": dm["verdict"],
+                        "dm_mean_loss_diff": dm["mean_loss_diff"],
+                    }
+                    print(f"  h={h} seed={seed} asym MSE={asym_mse:.5f} "
+                          f"DM={dm['dm_statistic']:.3f} p={dm['p_value']:.4f} "
+                          f"-> {dm['verdict']}")
+                except Exception as exc:
+                    print(f"  h={h} seed={seed} DM FAILED: {exc}")
+                    dm_info = {"dm_verdict": "DM_FAILED"}
+            else:
+                dm_info = {"dm_verdict": "INSUFFICIENT_DATA"}
+
+            rows.append({
+                "coin": coin,
+                "horizon": h,
+                "seed": seed,
+                "n_rv_days": int(len(rv)),
+                "n_predictions": int(asym_out["n_total_preds"]),
+                "asym_mse_logrv": float(asym_mse),
+                "classic_mse_logrv": float(classic_mse),
+                "mse_reduction_pct": float((classic_mse - asym_mse) / classic_mse * 100) if classic_mse > 0 else float("nan"),
+                **dm_info,
+            })
+
+    return rows
+
+
+def aggregate_verdicts(rows: list[dict]) -> list[dict]:
+    """Aggregate per-seed DM verdicts into a per-(coin, horizon) verdict.
+
+    Verdict rules:
+    - BEATS: all seeds with significant DM agree (p<0.05, asym lower loss),
+             and cross-seed MSE std < mean MSE reduction
+    - NO BEATS: any seed shows asym significantly worse
+    - INCONCLUSIVE: mixed or no significance
+    """
+    from collections import defaultdict
+
+    grouped: dict[tuple, list[dict]] = defaultdict(list)
+    for r in rows:
+        if "skipped" in r or "asym_mse_logrv" not in r:
+            continue
+        key = (r["coin"], r["horizon"])
+        grouped[key].append(r)
+
+    results = []
+    for (coin, h), seeds_rows in sorted(grouped.items()):
+        n_seeds = len(seeds_rows)
+        asym_mses = [r["asym_mse_logrv"] for r in seeds_rows]
+        classic_mses = [r["classic_mse_logrv"] for r in seeds_rows]
+        verdicts = [r.get("dm_verdict", "UNKNOWN") for r in seeds_rows]
+        p_values = [r.get("dm_pvalue", 1.0) for r in seeds_rows]
+
+        mean_asym = float(np.nanmean(asym_mses))
+        mean_classic = float(np.nanmean(classic_mses))
+        std_asym = float(np.nanstd(asym_mses))
+
+        mean_reduction = (mean_classic - mean_asym) / mean_classic * 100 if mean_classic > 0 else 0.0
+
+        n_beats = sum(1 for v in verdicts if "BEATS" in v and "BEATEN" not in v)
+        n_beaten = sum(1 for v in verdicts if "BEATEN" in v)
+        n_inconclusive = sum(1 for v in verdicts if v == "INCONCLUSIVE")
+
+        if n_beaten > 0:
+            agg_verdict = "NO BEATS"
+        elif n_beats == n_seeds and std_asym < abs(mean_classic - mean_asym):
+            agg_verdict = "BEATS"
+        elif n_beats > 0:
+            agg_verdict = "INCONCLUSIVE"
+        else:
+            agg_verdict = "INCONCLUSIVE"
+
+        results.append({
+            "coin": coin,
+            "horizon": h,
+            "n_seeds": n_seeds,
+            "mean_asym_mse": mean_asym,
+            "std_asym_mse": std_asym,
+            "mean_classic_mse": mean_classic,
+            "mean_reduction_pct": mean_reduction,
+            "n_beats": n_beats,
+            "n_beaten": n_beaten,
+            "n_inconclusive": n_inconclusive,
+            "mean_dm_pvalue": float(np.nanmean(p_values)),
+            "verdict": agg_verdict,
+        })
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="HAR-RV Asymmetric Semivariance")
+    parser.add_argument("--horizons", type=int, nargs="+", default=[1, 5, 10])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 7, 42, 99])
+    parser.add_argument("--n-splits", type=int, default=5)
+    parser.add_argument("--refit-every", type=int, default=22)
+    parser.add_argument("--skip-remote", action="store_true")
+    parser.add_argument("--extra-coins", type=str, nargs="*", default=None)
+    parser.add_argument("--out-json", type=str, default="results/m3_har_asymmetric.json")
+    args = parser.parse_args()
+
+    t0 = time.time()
+    panel = _load_panel(args.skip_remote, extra_coins=args.extra_coins)
+
+    all_rows: list[dict] = []
+    for coin, rets in panel.items():
+        rows = _eval_one_coin(
+            coin=coin,
+            hourly_rets=rets,
+            horizons=args.horizons,
+            seeds=args.seeds,
+            n_splits=args.n_splits,
+            refit_every=args.refit_every,
+        )
+        all_rows.extend(rows)
+
+    agg = aggregate_verdicts(all_rows)
+
+    print("\n=== M3 HAR Asymmetric Semivariance: Per-(coin, horizon) Verdicts ===")
+    agg_df = pd.DataFrame(agg)
+    if len(agg_df):
+        print(agg_df.to_string(index=False))
+
+    n_beats = sum(1 for r in agg if r["verdict"] == "BEATS")
+    n_no = sum(1 for r in agg if r["verdict"] == "NO BEATS")
+    n_inc = sum(1 for r in agg if r["verdict"] == "INCONCLUSIVE")
+    print(f"\nSummary: {n_beats} BEATS / {n_no} NO BEATS / {n_inc} INCONCLUSIVE "
+          f"(out of {len(agg)} configs)")
+
+    out_path = Path(args.out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps({
+        "rows": all_rows,
+        "aggregated": agg,
+        "elapsed_s": time.time() - t0,
+        "config": {
+            "horizons": args.horizons,
+            "seeds": args.seeds,
+            "n_splits": args.n_splits,
+            "refit_every": args.refit_every,
+        },
+    }, indent=2))
+    print(f"\n[done] {time.time() - t0:.1f}s -- wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_tft.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_tft.py
@@ -28,6 +28,7 @@ Output:
 """
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -53,6 +54,14 @@ try:
     from walk_forward import WalkForwardSplitter
 except ImportError:
     WalkForwardSplitter = None
+
+
+def set_seed(seed: int):
+    """Set random seed for reproducibility across numpy, torch, cuda."""
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +394,53 @@ def train_and_evaluate(
 
 
 # ---------------------------------------------------------------------------
+# Aggregation helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_aggregate(per_run: list[dict]) -> dict:
+    """Compute aggregate statistics across seeds and folds.
+
+    Returns mean +/- std for key metrics and a verdict according to
+    feedback_multi_seed_required.md (>=4 seeds, edge >= 2*std cross-seed).
+    """
+    if not per_run:
+        return {"verdict": "NO_DATA", "n_runs": 0}
+
+    edges = [r["edge_over_majority"] for r in per_run]
+    mses = [r["mse"] for r in per_run]
+    dir_accs = [r["direction_accuracy_step1"] for r in per_run]
+
+    mean_edge = float(np.mean(edges))
+    std_edge = float(np.std(edges)) if len(edges) > 1 else 0.0
+    seeds_used = sorted(set(r["seed"] for r in per_run))
+
+    # Verdict logic (CLAUDE.md G.2 + feedback_multi_seed_required.md)
+    if len(seeds_used) < 4:
+        verdict = "INCONCLUSIVE"
+    elif mean_edge > 0 and std_edge > 0 and mean_edge >= 2 * std_edge:
+        verdict = "BEATS"
+    elif mean_edge < -2 * max(std_edge, 1e-6):
+        verdict = "NO_BEATS"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    return {
+        "n_runs": len(per_run),
+        "n_seeds": len(seeds_used),
+        "seeds": seeds_used,
+        "n_folds": max(r["fold_idx"] for r in per_run) + 1,
+        "mse": {"mean": round(float(np.mean(mses)), 6),
+                "std": round(float(np.std(mses)), 6)},
+        "direction_accuracy_step1": {"mean": round(float(np.mean(dir_accs)), 4),
+                                     "std": round(float(np.std(dir_accs)), 4)},
+        "edge_over_majority": {"mean": round(mean_edge, 4),
+                               "std": round(std_edge, 4)},
+        "verdict": verdict,
+    }
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -437,20 +493,18 @@ def main():
         default=str(Path(__file__).resolve().parent.parent / "outputs" / "tft_run1"),
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--smoke", action="store_true",
+                        help="Smoke test: synthetic data, 2 epochs (alias for dry-run)")
     parser.add_argument("--advanced", action="store_true")
     parser.add_argument("--indicators", nargs="+", default=None)
     args = parser.parse_args()
 
-    seeds = [int(s) for s in args.seeds.split(",")] if args.seeds else [args.seed]
-    np.random.seed(seeds[0])
+    if args.smoke:
+        args.dry_run = True
+        args.epochs = 2
 
-    try:
-        import torch
-        torch.manual_seed(seeds[0])
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-    except ImportError:
-        print("ERROR: PyTorch not installed.", file=sys.stderr)
-        sys.exit(1)
+    seeds = [int(s) for s in args.seeds.split(",")] if args.seeds else [args.seed]
+    device = "cuda" if torch.cuda.is_available() else "cpu"
 
     symbols = [s.strip() for s in args.symbols.split(",")]
 
@@ -458,7 +512,7 @@ def main():
         print("DRY-RUN: Using synthetic data (1000 rows, 2 epochs)")
         raw = generate_synthetic_data(1000)
         data_hash = "synthetic-dryrun"
-        args.epochs = 2
+        args.epochs = min(args.epochs, 2)
         symbols = [symbols[0]] if symbols else ["SPY"]
     else:
         data_dir = Path(args.data_dir)
@@ -489,77 +543,153 @@ def main():
     )
     print(f"Sequences: {len(X)} samples, seq_len={args.seq_len}, pred_len={args.pred_len}")
 
-    n = len(X)
-    train_end = int(n * args.train_ratio)
-    val_end = int(n * (args.train_ratio + args.val_ratio))
-
-    X_train, y_train = X[:train_end], y[:train_end]
-    X_val, y_val = X[train_end:val_end], y[train_end:val_end]
-    X_test, y_test = X[val_end:], y[val_end:]
-
-    X_train, X_val, X_test, norm_mean, norm_std = normalize_sequences(X_train, X_val, X_test)
-
-    actual_test_ratio = round(len(X_test) / n, 3)
-    print(f"Split: train={len(X_train)}, val={len(X_val)}, test={len(X_test)} "
-          f"(requested test_ratio={args.test_ratio}, actual={actual_test_ratio})")
-
+    # Build fold iterator (walk-forward or single split)
     if args.walk_forward and WalkForwardSplitter is not None:
-        print(f"Walk-forward validation: {args.n_splits} splits, gap={args.gap}")
+        splitter = WalkForwardSplitter(n_splits=args.n_splits, gap=args.gap)
+        folds = list(splitter.split(X))
+        print(f"Walk-forward: {len(folds)} folds, gap={args.gap}")
+    elif args.walk_forward and WalkForwardSplitter is None:
+        print("WARNING: --walk-forward set but WalkForwardSplitter not available. "
+              "Falling back to single split.", file=sys.stderr)
+        n = len(X)
+        train_end = int(n * args.train_ratio)
+        folds = [(np.arange(0, train_end), np.arange(train_end, n))]
+    else:
+        n = len(X)
+        train_end = int(n * args.train_ratio)
+        folds = [(np.arange(0, train_end), np.arange(train_end, n))]
 
-    print(f"Device: {device}, n_vars={n_features}, seeds={seeds}")
+    print(f"Device: {device}, n_vars={n_features}, seeds={seeds}, folds={len(folds)}")
 
-    hyperparams = {
-        "model_type": "tft",
-        "seq_len": args.seq_len,
-        "pred_len": args.pred_len,
-        "d_model": args.d_model,
-        "n_heads": args.n_heads,
-        "lstm_layers": args.lstm_layers,
-        "dropout": args.dropout,
-        "fc_dropout": args.fc_dropout,
-        "epochs": args.epochs,
-        "batch_size": args.batch_size,
-        "learning_rate": args.lr,
-        "lookback": args.lookback,
-        "symbols": symbols,
-        "train_ratio": args.train_ratio,
-        "val_ratio": args.val_ratio,
-        "test_ratio": args.test_ratio,
-        "actual_test_ratio": actual_test_ratio,
-        "device": device,
-        "seeds": seeds,
+    # ------------------------------------------------------------------
+    # Multi-seed x multi-fold training loop
+    # ------------------------------------------------------------------
+    per_run: list[dict] = []
+    best_model = None
+    best_edge = -float("inf")
+
+    for seed in seeds:
+        set_seed(seed)
+        print(f"\n=== Seed {seed} ({seeds.index(seed)+1}/{len(seeds)}) ===")
+
+        for fold_idx, (train_idx, test_idx) in enumerate(folds):
+            print(f"  Fold {fold_idx+1}/{len(folds)}: "
+                  f"train={len(train_idx)}, test={len(test_idx)}")
+
+            X_train, y_train = X[train_idx], y[train_idx]
+            X_test, y_test = X[test_idx], y[test_idx]
+
+            # Normalize using train stats only (anti-leakage)
+            X_train_norm, X_test_norm, norm_mean, norm_std = normalize_sequences(
+                X_train, X_test,
+            )
+
+            # Reset seed before model init for reproducibility
+            set_seed(seed)
+
+            result = train_and_evaluate(
+                X_train_norm, y_train, X_test_norm, y_test,
+                n_vars=n_features,
+                seq_len=args.seq_len,
+                pred_len=args.pred_len,
+                d_model=args.d_model,
+                n_heads=args.n_heads,
+                lstm_layers=args.lstm_layers,
+                dropout=args.dropout,
+                fc_dropout=args.fc_dropout,
+                epochs=args.epochs,
+                batch_size=args.batch_size,
+                learning_rate=args.lr,
+                device=device,
+            )
+
+            m = result["metrics"]
+            run_info = {
+                "seed": seed,
+                "fold_idx": fold_idx,
+                "n_train": len(train_idx),
+                "n_test": len(test_idx),
+                "mse": m["mse"],
+                "mae": m["mae"],
+                "direction_accuracy_step1": m["direction_accuracy_step1"],
+                "majority_class_baseline": m["majority_class_baseline"],
+                "edge_over_majority": m["edge_over_majority"],
+                "best_val_loss": m["best_val_loss"],
+                "total_params": m["total_params"],
+            }
+            per_run.append(run_info)
+
+            edge = m["edge_over_majority"]
+            print(f"    MSE={m['mse']:.6f}  DirAcc={m['direction_accuracy_step1']:.4f}"
+                  f"  Edge={edge:+.4f} ({'OK' if edge > 0 else 'FAIL'})")
+
+            if edge > best_edge:
+                best_edge = edge
+                best_model = result
+
+    # ------------------------------------------------------------------
+    # Aggregate and save
+    # ------------------------------------------------------------------
+    aggregate = compute_aggregate(per_run)
+
+    print(f"\n{'='*60}")
+    print(f"AGGREGATE ({aggregate['n_runs']} runs, "
+          f"{aggregate['n_seeds']} seeds, {aggregate['n_folds']} folds)")
+    print(f"  MSE: {aggregate['mse']['mean']:.6f} +/- {aggregate['mse']['std']:.6f}")
+    print(f"  DirAcc: {aggregate['direction_accuracy_step1']['mean']:.4f}"
+          f" +/- {aggregate['direction_accuracy_step1']['std']:.4f}")
+    print(f"  Edge: {aggregate['edge_over_majority']['mean']:+.4f}"
+          f" +/- {aggregate['edge_over_majority']['std']:.4f}")
+    print(f"  Verdict: {aggregate['verdict']}")
+    print(f"{'='*60}")
+
+    # Save results JSON
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results_json = {
+        "per_run": per_run,
+        "aggregate": aggregate,
+        "hyperparams": {
+            "model_type": "tft",
+            "seq_len": args.seq_len,
+            "pred_len": args.pred_len,
+            "d_model": args.d_model,
+            "n_heads": args.n_heads,
+            "lstm_layers": args.lstm_layers,
+            "dropout": args.dropout,
+            "fc_dropout": args.fc_dropout,
+            "epochs": args.epochs,
+            "batch_size": args.batch_size,
+            "learning_rate": args.lr,
+            "lookback": args.lookback,
+            "symbols": symbols,
+            "walk_forward": args.walk_forward,
+            "n_splits": args.n_splits if args.walk_forward else 1,
+            "gap": args.gap if args.walk_forward else 0,
+            "device": device,
+            "seeds": seeds,
+            "data_hash": data_hash,
+        },
     }
 
-    result = train_and_evaluate(
-        X_train, y_train, X_test, y_test,
-        n_vars=n_features,
-        seq_len=args.seq_len,
-        pred_len=args.pred_len,
-        d_model=args.d_model,
-        n_heads=args.n_heads,
-        lstm_layers=args.lstm_layers,
-        dropout=args.dropout,
-        fc_dropout=args.fc_dropout,
-        epochs=args.epochs,
-        batch_size=args.batch_size,
-        learning_rate=args.lr,
-        device=device,
-    )
+    results_path = output_dir / "results.json"
+    with open(results_path, "w") as f:
+        json.dump(results_json, f, indent=2)
+    print(f"Results saved to {results_path}")
 
-    output_dir = Path(args.output_dir)
-    save_pytorch_checkpoint(
-        result["model"], result, hyperparams, data_hash, output_dir,
-        model_type="tft",
-    )
-
-    m = result["metrics"]
-    edge = m["edge_over_majority"]
-    print(f"\nResults: MSE={m['mse']}, DirAcc(step1)={m['direction_accuracy_step1']}")
-    print(f"  Majority baseline: {m['majority_class_baseline']['majority_class_accuracy']}")
-    print(f"  Edge over majority: {edge:+.4f} ({'BEATS' if edge > 0 else 'FAILS'} baseline)")
+    # Save best model checkpoint
+    if best_model is not None:
+        hyperparams = results_json["hyperparams"]
+        save_pytorch_checkpoint(
+            best_model["model"], best_model, hyperparams, data_hash,
+            output_dir, model_type="tft",
+        )
 
     if args.dry_run:
-        print("DRY-RUN complete. TFT pipeline validated successfully.")
+        print("DRY-RUN complete. TFT pipeline validated with multi-seed + walk-forward.")
+
+    return results_json
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix `train_tft.py` silently ignoring `--seeds` and `--walk-forward` CLI flags
- **Bug**: only `seeds[0]` was used; `WalkForwardSplitter` imported but never iterated
- Implement proper multi-seed loop (all seeds, `set_seed()` per iteration)
- Implement walk-forward loop using `WalkForwardSplitter` with per-fold normalization
- Add aggregate JSON output: `{"per_run": [...], "aggregate": {"verdict": "BEATS|NO_BEATS|INCONCLUSIVE"}}`
- Add `--smoke` flag as alias for `--dry-run`
- Verdict logic follows `feedback_multi_seed_required.md` (>=4 seeds, edge >= 2*std)

## Bug details

**Lines 444-449**: `np.random.seed(seeds[0])` + `torch.manual_seed(seeds[0])` — only first seed used, no loop.

**Lines 492-509**: Fixed 70/15/15 ratio split always applied. `WalkForwardSplitter` imported (line 53) and `args.walk_forward` checked (line 506) but splitter never used for actual splitting.

**Consequence**: All previous TFT verdicts are INCONCLUSIVE (single-seed, no walk-forward).

## Smoke test (2 seeds x 2 folds)

```
per_run: 4 entries
  seed=0 fold=0 n_train=345 mse=0.042930 edge=-0.0131
  seed=0 fold=1 n_train=690 mse=0.109855 edge=+0.0043
  seed=1 fold=0 n_train=345 mse=0.070058 edge=-0.0652
  seed=1 fold=1 n_train=690 mse=0.043846 edge=-0.0479
aggregate: INCONCLUSIVE (4 runs, 2 seeds, 2 folds)
```

4 distinct rows with different (seed, fold_idx, mse, edge). Walk-forward expanding window correctly grows train set (345 -> 690).

## Test plan

- [x] Smoke test: `python train_tft.py --smoke --seeds 0,1 --walk-forward --n-splits 2 --gap 0` produces 4 distinct entries
- [x] Results JSON has `per_run` + `aggregate` structure
- [x] Verdict = INCONCLUSIVE when < 4 seeds (correct)
- [ ] Full run: `python train_tft.py --seeds 0,1,7,42 --walk-forward --n-splits 5` (post-merge, separate dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)