### PR TITLE
fix(prover): ContextVar-safe agent timeout (po-2026 Voting:338 BG unblock)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -89,12 +89,15 @@ import SocialChoice.Definitions
 # this dynamically; this registry is the static fallback.
 HONEST_SORRIES = {
     str(VOTING_FILE) if VOTING_FILE else "": {
-        261: (
+        # Line of the actual `sorry` keyword; FIXME marker is in comment block
+        # immediately above (L253-261). Realigned 2026-05-12 (ai-01 iter 2)
+        # after PR #952 shifted line numbers when L338+L361 were proven.
+        262: (
             "median_voter_theorem WEAK version is UNPROVABLE with single_peaked "
             "(weak preference). Counter-example: σ={1,2,3}, 3 voters, peaks "
             "[1,2,3], median=2. If voter 3 is indifferent between 1 and 2, "
             "margin(2,1) = 0, not > 0. Use median_voter_theorem_strict instead "
-            "(L270 with hstrict_left/hstrict_right hypotheses)."
+            "(L271 with hstrict_left/hstrict_right hypotheses)."
         ),
     },
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -637,8 +637,38 @@ class AutonomousProver:
                 for retry in range(max_retries + 1):
                     try:
                         if agent_timeout_s > 0:
-                            response = await asyncio.wait_for(
-                                agent.run(full_context), timeout=agent_timeout_s)
+                            # ContextVar-safe timeout: do NOT use `asyncio.wait_for`
+                            # because the framework's AgentTelemetryLayer sets a
+                            # ContextVar Token inside `agent.run`. `wait_for`
+                            # spawns a child task with a child Context, and on
+                            # timeout the Token.reset propagates through the
+                            # outer Context, raising
+                            # `ValueError: <Token> was created in a different
+                            # Context` (verified via OTel trace
+                            # multi_SMOKE_ZERO_ADD_local_*.spans.jsonl,
+                            # 2026-05-11, cf. workflow.py L116 NOTE).
+                            #
+                            # Fix: spawn the task explicitly and use
+                            # `asyncio.wait` (which never auto-cancels) + manual
+                            # cancel + `await task` so the Token reset runs
+                            # inside the task's own Context.
+                            agent_task = asyncio.create_task(
+                                agent.run(full_context))
+                            done, _pending = await asyncio.wait(
+                                {agent_task}, timeout=agent_timeout_s)
+                            if agent_task in done:
+                                response = agent_task.result()
+                            else:
+                                agent_task.cancel()
+                                try:
+                                    await agent_task
+                                except (asyncio.CancelledError, Exception):
+                                    # Cancellation/teardown errors are
+                                    # expected — Token reset happens inside
+                                    # the task's own Context.
+                                    pass
+                                raise asyncio.TimeoutError(
+                                    f"agent.run exceeded {agent_timeout_s}s")
                         else:
                             response = await agent.run(full_context)
                         break  # Success — exit retry loop


### PR DESCRIPTION
## Summary

ai-01 BG iter 2 (Cycle 27). Fixes the ContextVar leak that broke
po-2026's Cycle 24 BG Voting:338 runs (0 sorry eliminated, ContextVar
errors in OTel trace).

### Track A — ContextVar fix (MAIN)

`provers.py` L639-641 wrapped `agent.run(...)` in `asyncio.wait_for(...,
timeout=agent_timeout_s)`. The framework's `AgentTelemetryLayer` sets a
`ContextVar` Token inside `agent.run`; `wait_for` spawns a child Task with
a **child Context**, so on timeout the Token reset runs in the outer
Context and raises `ValueError: <Token> was created in a different Context`.
This silently corrupted every LLM call.

`workflow.py` L116-123 already documented this gotcha for the multi-agent
path; `AutonomousProver` was the last remaining caller still using the
broken pattern.

**Fix**: replace with `asyncio.create_task` + `asyncio.wait` (no
auto-cancel) + manual `task.cancel()` + `await task`. The Token reset
now runs inside the task's own Context where it was created. Behaviour
on timeout is unchanged (raises `asyncio.TimeoutError`, caught by the
existing handler at L645-648).

### Track A bis — HONEST_SORRIES registry realignment

`config.py` mapped `Voting.lean:261` but the actual `sorry` is at L262
(off-by-one after PR #952 shifted line numbers when L338+L361 were
proven). Realigned to L262 + updated cross-reference (L270 -> L271 for
`median_voter_theorem_strict`). Dynamic `is_honest_sorry()` already
catches the FIXME marker; this just keeps the static fallback consistent.

### Track B — Voting.lean L338 (target stale)

Mission named "Voting.lean L338" but **L338 sorry has been resolved by
PR #952** (Cycle 25, commit 6b3c5db9). Current `grep -c sorry
Voting.lean = 1`, the lone remaining sorry at L262 is the documented
HONEST unprovable case (weak `single_peaked` admits indifference,
counter-example {1,2,3} with voter 3 indifferent — `margin(2,1) = 0`).
The provable strict variant `median_voter_theorem_strict` at L271
is already 0-sorry. No Lean proof work to do.

## Validation

| Check | Result |
|-------|--------|
| `grep -c sorry SocialChoice/Voting.lean` (before) | 1 |
| `grep -c sorry SocialChoice/Voting.lean` (after) | 1 |
| `lake build SocialChoice.Voting` | SUCCESS (3287 jobs) |
| `lake build` (full) | SUCCESS (3292 jobs) |
| `python -m py_compile provers.py` | OK |
| `python -m py_compile config.py` | OK |
| asyncio micro-test (new pattern timeout) | `asyncio.TimeoutError` raised cleanly, no `ValueError` leak |

### Lake build trailer
```
warning: SocialChoice/Voting.lean:627:0: automatically included section variable(s) unused in theorem `SocialChoice.banks_set_subset`:
  [DecidableEq σ]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableEq σ] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
Build completed successfully (3292 jobs).
```

## Test plan

- [x] Lake build SUCCESS confirmed (3292 jobs, warnings only)
- [x] Python syntax check on both files
- [x] asyncio micro-test confirms the new pattern handles timeout cleanly
- [ ] po-2026 retries Voting:338 BG with the new prover — expected to no longer hit ContextVar errors (next iteration)

## Scope discipline

- DID NOT touch `stable_marriage_lean` (po-2026 territory)
- DID NOT touch `_SmokeTest.lean` (ai-01 iter 1 / PR #970 territory)
- DID NOT inject `sorry` anywhere (anti-regression rule)
- L262 honest sorry left in place per FIXME documentation
- Only 2 files touched (provers.py +34/-2, config.py +5/-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)