### PR TITLE
feat(lean): cooperative_games_lean iter 3 - HONEST_UNPROVABLE annotation + WIP categorization

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -213,6 +213,24 @@ theorem bondareva_shapley_forward :
     NOTE: LP duality is not available in Mathlib. -/
 theorem bondareva_shapley_backward :
     G.Balanced → G.Core.Nonempty := by
+  -- FIXME: This sorry is HONEST_UNPROVABLE in the current Mathlib (as of v4.28-rc1
+  -- and v4.29.1). The classical proof of Bondareva-Shapley (Bondareva 1963,
+  -- Shapley 1967) requires LP duality / Farkas' lemma applied to:
+  --   primal:  min ∑ᵢ xᵢ  s.t.  ∑_{i∈S} xᵢ ≥ v(S) for all coalitions S
+  --   dual:    max ∑_S w(S)·v(S)  s.t.  ∑_{S∋i} w(S) = 1, w(S) ≥ 0
+  -- Mathlib does NOT currently expose:
+  --   * a generic LP duality theorem over ℝ (`LinearProgramming.duality` is absent);
+  --   * Farkas' lemma in a form usable on `Finset N → ℝ`;
+  --   * a `Polyhedral.cone_of_nonempty` constructor delivering the certificate.
+  -- The only known workaround is to either:
+  --   (a) port a few hundred lines of LP/Farkas machinery first
+  --       (e.g. `Mathlib.Analysis.Convex.Cone.Dual` + Hahn-Banach finite-dim), or
+  --   (b) reformulate via Shapley value (convex ⇒ Shapley vector ∈ Core, but
+  --       this only covers the convex-implies-balanced direction, not the
+  --       general balanced game case).
+  -- Both options are multi-week efforts and out of scope for the current
+  -- Lean port. Marking HONEST_UNPROVABLE until Mathlib gains LP duality.
+  -- Registered in prover/config.py HONEST_SORRIES (filepath: Basic.lean L216).
   sorry
 
 /-- Bondareva-Shapley: The Core is nonempty iff the game is balanced. -/
@@ -220,9 +238,9 @@ theorem bondareva_shapley :
     G.Core.Nonempty ↔ G.Balanced :=
   ⟨bondareva_shapley_forward G, bondareva_shapley_backward G⟩
 
-/-- For convex games, Shapley value is in the Core.
-    PROOF SKETCH (Shapley 1971):
-    A game is convex iff the Shapley value is in the Core.
+/-- For convex games, the Shapley value is in the Core (Shapley 1971).
+    PROOF SKETCH:
+    A game is convex iff the Shapley value lies in the Core.
     Key step: for convex G and any ordering π, the marginal contribution
     vector m^π = (v(P^π_i ∪ {i}) - v(P^π_i))_i is in the Core.
     The Shapley value is the average of all marginal vectors,
@@ -230,6 +248,17 @@ theorem bondareva_shapley :
     Alternative: prove convex ⇒ balanced, then use Bondareva-Shapley. -/
 theorem convex_core_nonempty (h : G.Convex) :
     G.Core.Nonempty := by
+  -- STATUS: WIP (provable in Mathlib but expensive). Two known routes:
+  -- 1. Direct (Shapley 1971): construct the marginal contribution vector
+  --    m^pi for some ordering pi and show it lies in Core via convexity.
+  --    Needs: ordering enumeration on N, marginal vector definition,
+  --    pointwise inequalities chained over orderings (~150 lines).
+  -- 2. Via Bondareva-Shapley: prove `G.Convex -> G.Balanced` then apply
+  --    `bondareva_shapley_backward`. Blocked because the backward direction
+  --    is itself blocked on missing Mathlib LP duality machinery (see L234).
+  -- Recommended next step: implement Route 1 as a separate `marginalVector`
+  -- definition + `convex_marginal_in_core` lemma, then average via additivity.
+  -- Estimated effort: 1-2 weeks for a competent Mathlib contributor.
   sorry
 
 end TUGame

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -6,8 +6,9 @@
 |------|-------|
 | Lean toolchain | `leanprover/lean4:v4.28.0-rc1` |
 | Mathlib | pinned via lake-manifest.json |
-| Total sorry | **7** (3 Basic + 4 Shapley) |
-| Total lines | 398 |
+| Total sorry | **3** (2 Basic + 1 Shapley) |
+| Honest unprovable (in Mathlib) | **1** (Basic.lean:234) |
+| Total lines | ~440 |
 | Total theorems | 11 |
 | Total definitions | 29 |
 
@@ -19,39 +20,42 @@
 
 | Metric | Value |
 |--------|-------|
-| Lines | 167 |
 | Definitions | 12 |
 | Theorems | 4 |
-| sorry | **3** |
+| sorry | **2** |
 | Status | FORMAL-PARTIAL |
 
 Key definitions: `Coalition`, `TUGame`, `Superadditive`, `Convex`, `marginalContribution`,
 `unanimityGame`, `majorityGame`, `Allocation`, `Core`, `CoreEmpty`, `Balanced`.
 
-sorry locations:
-- Line 136: `bondareva_shapski` theorem body (3 sorry)
-- Line 153: `convex_core_nonempty` theorem body (2 sorry, partially proved)
-- Line 165: auxiliary proof
+sorry locations (post-2026-05-12 BG iter 3 annotations):
+- Line 234: `bondareva_shapley_backward` — HONEST_UNPROVABLE in current Mathlib
+  (LP duality / Farkas' lemma missing). Registered in `prover/config.py` HONEST_SORRIES.
+- Line 262: `convex_core_nonempty` — WIP_HARD (~1-2 weeks Mathlib infrastructure).
 
 ### CooperativeGames/Shapley.lean — SHAPLEY VALUE
 
 | Metric | Value |
 |--------|-------|
-| Lines | 231 |
 | Definitions | 17 |
 | Theorems | 7 |
-| sorry | **4** |
+| sorry | **1** |
 | Status | FORMAL-PARTIAL |
 
 Key definitions: `Solution`, `Efficiency`, `Symmetry`, `NullPlayerAxiom`, `Additivity`,
 `shapleyCoef`, `shapleyValue`, `shapleySolution`, `WeightedVotingGame`, `Critical`,
 `BanzhafRaw`, `VetoPlayer`, `Dictator`, `DummyPlayer`.
 
+Previously-proved theorems (sorry resolved):
+- `shapley_null_player` (PR earlier in 2026-04)
+- `shapley_unanimity` (PR #791)
+- `shapley_symmetric` (PR earlier in 2026-04)
+- `shapleyCoef_top` (PR #757)
+- `bondareva_shapley_forward` (PR #802)
+
 sorry locations:
-- Line 117: `shapley_null_player` proof
-- Line 132: `shapley_unanimity` proof
-- Line 160: `shapley_symmetric` proof
-- Line 197: `shapley_uniqueness` proof
+- Line 566: `shapley_uniqueness` — WIP_HARD (Mobius decomposition into unanimity games;
+  DEMO 6/8 in `prover/config.py` target this).
 
 ## Theorem Inventory
 
@@ -59,48 +63,49 @@ sorry locations:
 
 | Theorem | File | Statement |
 |---------|------|-----------|
-| `superadditive_empty_nonneg` | Basic.lean | Superadditive games have v(empty) >= 0 |
+| `superadditive_empty_nonneg` | Basic.lean | v(empty) >= 0 (trivial) |
 | `superadditive_grand_coalition_nonneg_of_nonneg_singletons` | Basic.lean | Grand coalition value nonneg |
+| `bondareva_shapley_forward` | Basic.lean | Core nonempty implies balanced |
 | `shapley_efficient` | Shapley.lean | Shapley value is efficient |
 | `shapley_additive` | Shapley.lean | Shapley value is additive |
+| `shapley_null_player` | Shapley.lean | Shapley value = 0 for null players |
+| `shapley_unanimity` | Shapley.lean | Shapley value on unanimity games |
+| `shapley_symmetric` | Shapley.lean | Shapley value treats symmetric players equally |
+| `shapleyCoef_top` | Shapley.lean | Shapley coefficient for full coalition |
 | `dummy_shapley_zero` | Shapley.lean | Dummy players get zero Shapley value |
 
 ### Partially Proved (contains sorry)
 
-| Theorem | File | sorry | Statement |
-|---------|------|-------|-----------|
-| `bondareva_shapski` | Basic.lean | 3 | Core nonempty iff balanced (Bondareva-Shapley) |
-| `convex_core_nonempty` | Basic.lean | 2 | Convex games have nonempty core |
-| `shapley_null_player` | Shapley.lean | 1 | Shapley value = 0 for null players |
-| `shapley_unanimity` | Shapley.lean | 1 | Shapley value on unanimity games |
-| `shapley_symmetric` | Shapley.lean | 1 | Shapley value treats symmetric players equally |
-| `shapley_uniqueness` | Shapley.lean | 1 | Shapley value is the unique solution satisfying axioms |
+| Theorem | File | Line | Category | sorry | Statement |
+|---------|------|------|----------|-------|-----------|
+| `bondareva_shapley_backward` | Basic.lean | 234 | HONEST_UNPROVABLE | 1 | Balanced implies Core nonempty (needs LP duality) |
+| `convex_core_nonempty` | Basic.lean | 262 | WIP_HARD | 1 | Convex games have nonempty Core |
+| `shapley_uniqueness` | Shapley.lean | 566 | WIP_HARD | 1 | Shapley value is unique solution satisfying axioms |
 
 ## Certification Level
 
 | File | Level |
 |------|-------|
-| Basic.lean | PARTIAL (3 sorry — Bondareva-Shapley theorem) |
-| Shapley.lean | PARTIAL (4 sorry — key Shapley axioms) |
+| Basic.lean | PARTIAL (2 sorry — 1 HONEST + 1 WIP) |
+| Shapley.lean | PARTIAL (1 sorry — WIP, Shapley uniqueness via Mobius) |
 
-**Project certification: PARTIAL** — 7 sorry remaining across 2 files.
+**Project certification: PARTIAL** — 3 sorry remaining, of which 1 is documented HONEST_UNPROVABLE.
 
 ## Remaining Work
 
-| Priority | Task | sorry |
-|----------|------|-------|
-| HIGH | Complete `bondareva_shapski` proof | 3 |
-| HIGH | Complete `shapley_uniqueness` proof | 1 |
-| MEDIUM | Complete `shapley_null_player` proof | 1 |
-| MEDIUM | Complete `shapley_unanimity` proof | 1 |
-| MEDIUM | Complete `shapley_symmetric` proof | 1 |
-| LOW | Upgrade toolchain to v4.29.1 (follow social_choice_lean) | 0 |
+| Priority | Task | sorry | Category |
+|----------|------|-------|----------|
+| HIGH | Complete `shapley_uniqueness` proof | 1 | WIP_HARD (DEMO 6/8) |
+| MEDIUM | Complete `convex_core_nonempty` proof | 1 | WIP_HARD (Route A: marginal vectors) |
+| BLOCKED | `bondareva_shapley_backward` | 1 | Awaits Mathlib LP duality / Farkas |
+| LOW | Upgrade toolchain to v4.29.1 | 0 | (follow social_choice_lean) |
 
 ## References
 
 - Shapley, L.S. (1953). "A Value for N-Person Games"
 - Bondareva, O.N. (1963). "Some Applications of Linear Programming Methods to the Theory of Cooperative Games"
 - Shapley, L.S. (1967). "On Balanced Sets and Cores"
+- Shapley, L.S. (1971). "Cores of Convex Games"
 
 ## History
 
@@ -108,3 +113,7 @@ sorry locations:
 |------|--------|--------|
 | 2026-01-31 | Initial creation with TU games, Shapley value | initial |
 | 2026-04-30 | FORMAL_STATUS.md created | PR-G |
+| 2026-04-30 | `shapleyCoef_top` proved | PR #757 |
+| 2026-04-30 | `shapley_unanimity` 2->1 sorry | PR #791 |
+| 2026-05-01 | `bondareva_shapley_forward` proved | PR #802 |
+| 2026-05-12 | BG iter 3: HONEST_UNPROVABLE annotation Basic.lean L234 (LP duality missing); FORMAL_STATUS realigned (7->3 sorry: stale doc) | (this PR) |

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -100,6 +100,22 @@ HONEST_SORRIES = {
             "(L271 with hstrict_left/hstrict_right hypotheses)."
         ),
     },
+    str(BASIC_FILE) if BASIC_FILE else "": {
+        # bondareva_shapley_backward at Basic.lean L234. Registered 2026-05-12
+        # (ai-01 iter 3 cooperative-games). FIXME marker is in comment block
+        # immediately above (L217-233). Mathlib lacks LP duality / Farkas'
+        # lemma, both of which are required for the classical proof. Marking
+        # as HONEST_UNPROVABLE-in-current-Mathlib until LP machinery lands.
+        234: (
+            "bondareva_shapley_backward (Bondareva 1963, Shapley 1967) requires "
+            "LP duality on Finset N → ℝ (or Farkas' lemma in convex form), "
+            "neither of which is available in Mathlib v4.29.1. The proof needs "
+            "either (a) porting Mathlib.Analysis.Convex.Cone.Dual + finite-dim "
+            "Hahn-Banach, or (b) reformulating via Shapley value which only "
+            "covers the convex special case. Multi-week effort; out of scope. "
+            "DO NOT TOUCH until Mathlib gains LP duality."
+        ),
+    },
 }
 
 


### PR DESCRIPTION
## Summary

ai-01 BG iter 3 — investigation + categorization of the 3 remaining sorrys in `cooperative_games_lean`. No sorry eliminated this iter; one correctly annotated as HONEST_UNPROVABLE-in-current-Mathlib, two confirmed WIP_HARD with documented status. Documentation realigned (FORMAL_STATUS.md was stale, claimed 7 sorry vs actual 3).

## Sorry inventory (3 total, no change in count)

| File | Line (pre) | Line (post) | Theorem | Category | Action |
|------|-----------|-------------|---------|----------|--------|
| `Shapley.lean` | 566 | 566 | `shapley_uniqueness` | WIP_HARD | None — already targeted by DEMO 6/8, recommend prover dispatch in next iter |
| `Basic.lean` | 216 | 234 | `bondareva_shapley_backward` | **HONEST_UNPROVABLE** | FIXME annotation + HONEST_SORRIES registry |
| `Basic.lean` | 233 | 262 | `convex_core_nonempty` | WIP_HARD | STATUS comment block clarifying both proof routes |

### Per-sorry rationale

**`bondareva_shapley_backward` (Basic.lean:234) → HONEST_UNPROVABLE**

Theorem already had a NOTE comment stating *\"LP duality is not available in Mathlib.\"* The classical proof (Bondareva 1963, Shapley 1967) requires LP duality / Farkas' lemma applied to:
- primal: min ∑ᵢ xᵢ s.t. ∑_{i∈S} xᵢ ≥ v(S) for all coalitions S
- dual: max ∑_S w(S)·v(S) s.t. ∑_{S∋i} w(S) = 1, w(S) ≥ 0

Mathlib v4.29.1 does NOT expose:
- generic LP duality theorem over ℝ (`LinearProgramming.duality` is absent)
- Farkas' lemma in a form usable on `Finset N → ℝ`
- a `Polyhedral.cone_of_nonempty` constructor

Multi-week effort to port. Marking HONEST_UNPROVABLE until Mathlib gains LP duality machinery.

**`convex_core_nonempty` (Basic.lean:262) → WIP_HARD**

Provable in Mathlib but requires substantial new infrastructure. Two known routes documented in inline STATUS comment:
- Route A: direct construction of marginal contribution vector m^π and proof it lies in Core via convexity (~150 lines)
- Route B: convex ⇒ balanced + bondareva_shapley_backward (blocked because backward is HONEST_UNPROVABLE)

**`shapley_uniqueness` (Shapley.lean:566) → WIP_HARD**

Mobius decomposition into unanimity games. Already covered by DEMO 6 and DEMO 8 in `prover/config.py`. Recommend next iter dispatch this on a machine with warm Mathlib cache for `cooperative_games_lean` (each Lean project has its own `.lake/packages/mathlib` so cache does not transfer from `social_choice_lean`).

## Detection verification

`is_honest_sorry()` Python helper tested with conda env `coursia-ml-training`:

```
L234 HONEST? True   (FIXME marker detected → prover refuses)
L262 HONEST? False  (no marker → prover may attack)
Shapley L566 HONEST? False  (no marker → prover may attack via DEMO 6/8)
```

Verified static `HONEST_SORRIES[BASIC_FILE][234]` registry entry is correctly populated and would also short-circuit any direct line-targeted attempt.

## Files changed (3 files, +91/-37)

| File | Δ | Notes |
|------|---|-------|
| `MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean` | +35/-1 | Pure `--` line comment additions inside existing `by sorry` blocks. No code semantics changed. |
| `MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md` | +43/-34 | Realigned: was stale (claimed 7 sorry, actual 3); 5 prior PRs eliminated 4 sorrys without status update. |
| `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py` | +16/-0 | Added `BASIC_FILE → 234` HONEST_SORRIES entry. |

## Lake build status (per CLAUDE.md G.2)

Cold-cache lake build of `cooperative_games_lean` (own `.lake/packages/mathlib` separate from `social_choice_lean`'s warm cache) was started before edits and remains in progress at PR open time:
- start: ~14:49 UTC
- progress at PR open: 787/~5000 oleans (~16%) compiling Mathlib from scratch on toolchain v4.28.0-rc1
- estimated completion: ~6h+ (lake build cooperatively yields stdout only at end via `tail -60` filter)

**Why this PR does NOT block on full build SUCCESS**:

1. All Lean source changes are `--` line comments inside existing `by sorry` blocks. Lean grammar guarantees line comments are stripped at lex time and cannot affect parsing of subsequent tokens. Build cannot regress from comment-only additions in `by` blocks.
2. The Python registry change (`config.py`) is independent of Lean compilation.
3. Detection logic verified via direct python invocation (transcript above).

If the reviewer wants explicit lake build SUCCESS confirmation, recommend cherry-picking onto a machine with warm Mathlib cache for `cooperative_games_lean` (currently none in cluster — both `social_choice_lean` and `cooperative_games_lean` need separate Mathlib builds) and running:

```bash
cd MyIA.AI.Notebooks/GameTheory/cooperative_games_lean
lake build  # expect ~30-60min on cold cache, <1min warm
grep -c sorry CooperativeGames/Basic.lean CooperativeGames/Shapley.lean
# Expected: Basic.lean:2, Shapley.lean:1
```

Will follow up with a separate post-merge commit if/when local build completes today.

## Coordination

- Branch: `feat/lean-bg-prover-ai01-cycle27-cooperative-games`
- Cycle: 27 (ai-01 BG iter 3 prover series)
- Prior iters in cycle: #970 (_SmokeTest 1→0 sorry), #972 (ContextVar fix + Voting:338 stale discovery)
- Does NOT touch: `stable_marriage_lean` (po-2026 territory), `social_choice_lean/Voting.lean` L262 (po-2026 HONEST sorry already registered)

## Test plan

- [x] `is_honest_sorry()` detection verified for L234, L262, L566 (Python script run)
- [x] `grep -c sorry` confirmed 3 total sorrys (no injection, no elimination)
- [x] `git diff --stat` ratio: +91/-37 (additions dominated by comments + status doc)
- [ ] `lake build SUCCESS` for cooperative_games_lean — cold-cache build in progress, expected to complete; will append log if done before merge

## Recommendations for next iter

1. Prover BG dispatch on **DEMO 6 (Shapley.lean:566)** — best WIP target. Needs warm Mathlib cache for cooperative_games_lean.
2. `convex_core_nonempty`: separate PR implementing `marginalVector` + `convex_marginal_in_core` lemma (~150 lines new code). Not a single-shot prover target.
3. `bondareva_shapley_backward`: deferred until Mathlib gains LP duality. Track upstream Mathlib PRs on `Mathlib.Analysis.Convex.Cone.Dual` + finite-dim Hahn-Banach.