### PR TITLE
feat(lean): Voting.lean strictly_single_peaked variant eliminates last sorry (#973 Option 1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice.lean
@@ -10,8 +10,10 @@
   Voting.lean adds margin-based definitions, Condorcet criteria,
   single-peaked preferences, Split Cycle, and clone-proofness.
 
-  Arrow.lean and Sen.lean: FORMAL-CERTIFIED (0 sorry).
-  Voting.lean: FORMAL-SKETCH (3 sorry in median_voter_theorem).
+  Arrow.lean, Sen.lean, and Voting.lean: FORMAL-CERTIFIED (0 sorry).
+  Voting.lean: median_voter_theorem requires `strictly_single_peaked_profile`
+  (Issue #973 Option 1); the workhorse `median_voter_theorem_strict` takes
+  explicit strict-monotonicity hypotheses.
 
   Reference: Amartya Sen, "Collective Choice and Social Welfare" (1970)
   Reference: John Geanakoplos, "Three Brief Proofs of Arrow's Impossibility Theorem" (2005)

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -201,6 +201,37 @@ theorem single_peaked_peak_best {R : σ → σ → Prop} {p : σ} {S : Finset σ
 def single_peaked_profile (prof : ι → PrefOrder σ) (peaks : ι → σ) : Prop :=
   ∀ i : ι, single_peaked (prof i).rel (peaks i)
 
+/-- R is **strictly** single-peaked with peak p on a linearly ordered set.
+    Strengthens `single_peaked` with strict monotonicity on each side of the peak,
+    eliminating indifference between distinct alternatives on the same side.
+
+    This is the hypothesis needed to obtain a *strict* Condorcet winner via
+    `margin_pos` (positive margin), as opposed to the weak `margin ≥ 0`
+    guarantee from `single_peaked` alone.
+
+    Concretely:
+    - `a < b ≤ p` implies `P R b a` (strictly prefer b to a, left of peak)
+    - `p ≤ a < b` implies `P R a b` (strictly prefer a to b, right of peak) -/
+def strictly_single_peaked (R : σ → σ → Prop) (p : σ) : Prop :=
+  single_peaked R p ∧
+  (∀ a b, a < b → b ≤ p → P R b a) ∧
+  (∀ a b, p ≤ a → a < b → P R a b)
+
+/-- A profile is strictly single-peaked if every voter has strictly single-peaked
+    preferences. This is the standard hypothesis under which the median voter
+    theorem yields a *Condorcet winner* (positive margin) rather than just a
+    weak Condorcet winner (non-negative margin). -/
+def strictly_single_peaked_profile (prof : ι → PrefOrder σ) (peaks : ι → σ) : Prop :=
+  ∀ i : ι, strictly_single_peaked (prof i).rel (peaks i)
+
+set_option linter.unusedSectionVars false in
+/-- A strictly single-peaked profile is in particular single-peaked. -/
+theorem strictly_single_peaked_profile.to_single_peaked
+    {prof : ι → PrefOrder σ} {peaks : ι → σ}
+    (h : strictly_single_peaked_profile prof peaks) :
+    single_peaked_profile prof peaks :=
+  fun i => (h i).1
+
 /-! ## Median Voter Theorem (Black 1948)
 
 For an odd number of voters with single-peaked preferences over a linearly
@@ -224,50 +255,14 @@ noncomputable def median_peak [Inhabited σ] (peaks : ι → σ) : σ :=
   let s := sorted_peaks_list peaks
   s.getD (s.length / 2) default
 
-/-- **Median Voter Theorem (Black 1948)**: For an odd number of voters with
-    single-peaked preferences, the median peak is a Condorcet winner. -/
-theorem median_voter_theorem (prof : ι → PrefOrder σ) (peaks : ι → σ)
-    (hsp : single_peaked_profile prof peaks)
-    (hodd : Odd (Fintype.card ι)) :
-    ∃ m, condorcet_winner prof (Finset.univ.image peaks) m := by
-  classical
-  have hcard_pos : 0 < Fintype.card ι := by
-    have := hodd; rw [Nat.odd_iff] at this; omega
-  have hne : Nonempty ι := Fintype.card_pos_iff.mp hcard_pos
-  haveI : Inhabited σ := Classical.inhabited_of_nonempty (hne.map peaks)
-  use median_peak peaks
-  constructor
-  simp only [Finset.mem_image, Finset.mem_univ, true_and]
-  unfold median_peak sorted_peaks_list
-  set l := (Finset.univ.toList.map peaks).mergeSort (· ≤ ·)
-  have hl : l.length = Fintype.card ι := by
-    simp [l, List.length_mergeSort, List.length_map, Finset.length_toList]
-  have hn : l.length / 2 < l.length := by omega
-  have hperm : l ≈ Finset.univ.toList.map peaks := List.mergeSort_perm _ _
-  have hin : l.getD (l.length / 2) default ∈ l := by
-    simp [List.getD, List.getElem?_eq_getElem, hn]
-  rw [List.Perm.mem_iff hperm] at hin
-  simp only [List.mem_map, Finset.mem_toList] at hin
-  obtain ⟨i, _, heq⟩ := hin
-  exact ⟨i, heq⟩
-  · -- FIXME: This sorry needs a stronger hypothesis to prove.
-    -- single_peaked gives WEAK preference (R b a for a ≤ b ≤ p) but margin_pos
-    -- requires STRICT preference (P R x y = R x y ∧ ¬R y x).
-    -- For a voter with peak p > median and y < median: R_i median y (left-of-peak)
-    -- but ¬R_i y median is NOT derivable — the voter can be indifferent.
-    -- Counter-example: σ = {1,2,3}, 3 voters, peaks [1,2,3], median=2.
-    -- If voter 3 (peak=3) is indifferent between 1 and 2, margin(2,1) = 0, not > 0.
-    -- Fix: either add strictly_single_peaked (no indifference between distinct alts)
-    -- or change conclusion to weak Condorcet winner (margin ≥ 0).
-    sorry
+/-- **Median Voter Theorem — Strict-hypotheses version (Black 1948)**:
+    For an odd number of voters with single-peaked preferences AND explicit
+    strict monotonicity on each side of the peak, the median peak is a
+    Condorcet winner.
 
-/-- **Median Voter Theorem — Strict version (Black 1948)**:
-    For an odd number of voters with strictly single-peaked preferences
-    (strict monotonicity on each side of the peak), the median peak is
-    a Condorcet winner.
-
-    This version requires explicit strict monotonicity hypotheses rather
-    than changing the `single_peaked` definition. -/
+    This is the workhorse lemma; `median_voter_theorem` below packages the
+    strict-monotonicity hypotheses into the `strictly_single_peaked_profile`
+    predicate. Both theorems are equivalent after unfolding. -/
 theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) (peaks : ι → σ)
     (hsp : single_peaked_profile prof peaks)
     (hstrict_left : ∀ i a b, a < b → b ≤ peaks i → P (prof i).rel b a)
@@ -441,6 +436,33 @@ theorem median_voter_theorem_strict [Inhabited σ] (prof : ι → PrefOrder σ) 
         obtain ⟨k, hk⟩ := hodd_n
         omega
       omega
+
+/-- **Median Voter Theorem (Black 1948)**: For an odd number of voters with
+    **strictly** single-peaked preferences, the median peak is a Condorcet winner.
+
+    Note (Issue #973): the hypothesis was strengthened from `single_peaked_profile`
+    to `strictly_single_peaked_profile`. The weaker `single_peaked` allows
+    indifference between distinct alternatives on the same side of the peak,
+    which is incompatible with the *strict* Condorcet winner conclusion via
+    `margin_pos`. Under `strictly_single_peaked_profile`, voters can no longer
+    be indifferent between distinct alternatives on the same side of their peak,
+    yielding positive margins as required. This delegates to
+    `median_voter_theorem_strict` after extracting the strict monotonicity
+    components. -/
+theorem median_voter_theorem (prof : ι → PrefOrder σ) (peaks : ι → σ)
+    (hsp : strictly_single_peaked_profile prof peaks)
+    (hodd : Odd (Fintype.card ι)) :
+    ∃ m, condorcet_winner prof (Finset.univ.image peaks) m := by
+  classical
+  have hcard_pos : 0 < Fintype.card ι := by
+    have := hodd; rw [Nat.odd_iff] at this; omega
+  have hne : Nonempty ι := Fintype.card_pos_iff.mp hcard_pos
+  haveI : Inhabited σ := Classical.inhabited_of_nonempty (hne.map peaks)
+  exact median_voter_theorem_strict prof peaks
+    (strictly_single_peaked_profile.to_single_peaked hsp)
+    (fun i a b hab hbp => (hsp i).2.1 a b hab hbp)
+    (fun i a b hpa hab => (hsp i).2.2 a b hpa hab)
+    hodd
 
 end SinglePeaked
 


### PR DESCRIPTION
## Summary

Closes the last `sorry` in `social_choice_lean` per Issue #973 Option 1 (approved).

- Adds `strictly_single_peaked` (R, p) = `single_peaked R p` AND strict monotonicity on each side of the peak.
- Adds `strictly_single_peaked_profile` and the bridge lemma `to_single_peaked`.
- **Strengthens the signature of `median_voter_theorem`** to require `strictly_single_peaked_profile` instead of `single_peaked_profile`. This is the explicit goal of #973 Option 1; the weaker `single_peaked` allows indifference between distinct alternatives on the same side of the peak, which is incompatible with the *strict* Condorcet winner conclusion (`margin_pos`).
- Reorders `median_voter_theorem` and `median_voter_theorem_strict` so `_strict` (the workhorse) precedes the user-facing theorem. `median_voter_theorem` now delegates to `_strict` by destructuring the strict-single-peaked predicate.
- Keeps `median_voter_theorem_strict` as the explicit-hypothesis entry point (NOT deleted).
- Removes the FIXME comment block and the `sorry` at the former L262.
- Updates `SocialChoice.lean` top-level docstring to reflect 0 sorry across the project.

## CLAUDE.md G.2 evidence

### grep -c sorry per file (before -> after)

| File | Before | After |
|---|---|---|
| Arrow.lean | 0 | 0 |
| Basic.lean | 0 | 0 |
| Framework.lean | 0 | 0 |
| Sen.lean | 0 | 0 |
| SortedListCounting.lean | 0 | 0 |
| **Voting.lean** | **2** (1 real + 1 in FIXME comment text) | **0** |
| _SmokeTest.lean | 0 | 0 |

Real `sorry` count for the project: **1 -> 0**.

`grep -nE "sorry|admit|axiom" Voting.lean` returns no matches after the edit.

### lake build trailer

From `MyIA.AI.Notebooks/GameTheory/social_choice_lean/`:

```
⚠ [3290/3292] Built SocialChoice.Voting (8.5s)
[warnings: pre-existing linter, unused section vars / unused simp args / unused `hsp` in _strict]
✔ [3291/3292] Built SocialChoice (7.0s)
Build completed successfully (3292 jobs).
```

No errors. Only pre-existing linter warnings.

### Anti-regression

- No existing proof, theorem, def, or instance deleted or weakened.
- `git diff --stat`: `+70 / -46` (insertions > deletions, dominated by the new defs + reordering).
- The signature of `median_voter_theorem` is strengthened (requires `strictly_single_peaked_profile`). This is the explicit goal of #973 Option 1.
- No external callers exist (verified via `grep -r median_voter_theorem MyIA.AI.Notebooks/GameTheory/social_choice_lean/`).

## Breaking change

`median_voter_theorem` now requires `strictly_single_peaked_profile prof peaks` instead of `single_peaked_profile prof peaks`. Anyone reusing the theorem must either (a) supply a strictly-single-peaked profile, or (b) call `median_voter_theorem_strict` directly with explicit `hstrict_left` / `hstrict_right` hypotheses. There are no external callers in this repo.

## Test plan

- [x] `grep -c sorry` per file in `SocialChoice/` -> all 0
- [x] `lake build` SUCCESS (3292 jobs)
- [x] No `sorry` / `admit` / `axiom` added anywhere
- [x] No unrelated files touched (`git diff --stat` shows only `SocialChoice.lean` + `SocialChoice/Voting.lean`)
- [x] `median_voter_theorem_strict` preserved as alternative entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)