### PR TITLE
fix(lean): resolve Shapley.lean forward refs + build SUCCESS

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Shapley.lean
@@ -83,6 +83,101 @@ noncomputable def shapleyValue (G : TUGame N) (i : N) : ℝ :=
 noncomputable def shapleySolution : Solution N :=
   fun G i => shapleyValue G i
 
+/-! ## Unanimity Game Characterization (any axiom-satisfying solution) -/
+
+/-- Any efficient symmetric null-player-respecting solution gives 1/|T|
+    for players in T and 0 for players outside T in the unanimity game u_T.
+    Uses the three axioms (efficiency, symmetry, null player) directly. -/
+private theorem phi_unanimity (φ : Solution N)
+    (h_eff : φ.Efficiency)
+    (h_sym : φ.Symmetry)
+    (h_null : φ.NullPlayerAxiom)
+    (T : Finset N) (hT : T.Nonempty) (i : N) :
+    φ (TUGame.unanimityGame T hT) i =
+    if i ∈ T then (1 : ℝ) / T.card else 0 := by
+  classical
+  split_ifs with hiT
+  · -- Case i ∈ T: by symmetry all j∈T get same value, by efficiency sum=1
+    -- Step 1: By symmetry, all j ∈ T have the same value as i
+    have h_eq : ∀ j ∈ T, φ (unanimityGame T hT) j = φ (unanimityGame T hT) i := by
+      intro j hjT
+      by_cases hij : j = i; · subst hij; rfl
+      · apply h_sym
+        intro S hiS hjS
+        simp only [unanimityGame]
+        have hni : ¬(T ⊆ S ∪ {i}) := by
+          intro h
+          have := h hjT
+          simp only [Finset.mem_union, Finset.mem_singleton] at this
+          tauto
+        have hnj : ¬(T ⊆ S ∪ {j}) := by
+          intro h
+          have := h hiT
+          simp only [Finset.mem_union, Finset.mem_singleton] at this
+          tauto
+        rw [if_neg hni, if_neg hnj]
+    -- Step 2: Players outside T are null
+    have h_null_out : ∀ j, j ∉ T → φ (unanimityGame T hT) j = 0 := by
+      intro j hjT'
+      apply h_null
+      intro S hjS
+      simp only [unanimityGame]
+      have hto : T ⊆ S ∪ {j} → T ⊆ S := fun h k hk => by
+        have hk' := h hk
+        simp only [Finset.mem_union, Finset.mem_singleton] at hk'
+        rcases hk' with hk' | hk'
+        · exact hk'
+        · subst hk'; exact absurd hk hjT'
+      split_ifs
+      · rfl
+      · exfalso; exact ‹¬T ⊆ S› (hto ‹T ⊆ S ∪ {j}›)
+      · exfalso; exact ‹¬T ⊆ S ∪ {j}› (fun k hk => Finset.mem_union_left {j} (‹T ⊆ S› hk))
+      · rfl
+    -- Step 3: Efficiency: sum = v(univ) = 1
+    have h_sum_one : ∑ j, φ (unanimityGame T hT) j = 1 := by
+      have := h_eff (unanimityGame T hT)
+      simp only [unanimityGame, if_pos (Finset.subset_univ T)] at this
+      exact this
+    -- Step 4: ∑_{∈T} = 1 (since ∑_{∉T} = 0)
+    have h_sum_T : ∑ j ∈ T, φ (unanimityGame T hT) j = 1 := by
+      have h_out_sum : ∑ j ∈ Finset.filter (fun j => j ∉ T) Finset.univ,
+          φ (unanimityGame T hT) j = 0 :=
+        Finset.sum_eq_zero (fun j hj => by
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hj
+          exact h_null_out j hj)
+      have h_split : ∑ j ∈ T, φ (unanimityGame T hT) j +
+          ∑ j ∈ Finset.filter (fun j => j ∉ T) Finset.univ,
+          φ (unanimityGame T hT) j = ∑ j, φ (unanimityGame T hT) j := by
+        have : Finset.filter (fun j => j ∉ T) Finset.univ = Tᶜ := by
+          ext j; simp
+        rw [this]
+        rw [Finset.sum_add_sum_compl T (fun j => φ (unanimityGame T hT) j)]
+      linarith
+    -- Step 5: All equal in T, so T.card * φ G i = 1
+    have h_card : (T.card : ℝ) * φ (unanimityGame T hT) i = 1 := by
+      have : ∑ _ ∈ T, φ (unanimityGame T hT) i = (T.card : ℝ) * φ (unanimityGame T hT) i := by
+        rw [Finset.sum_const, nsmul_eq_mul]
+      rw [← this]
+      exact (Finset.sum_congr rfl (fun j hj => (h_eq j hj).symm)).trans h_sum_T
+    -- Step 6: Therefore φ G i = 1 / T.card
+    have hT0 : (T.card : ℝ) ≠ 0 := by
+      have hcp : 0 < T.card := Finset.Nonempty.card_pos hT
+      norm_cast
+      omega
+    field_simp
+    linarith
+  · -- Case i ∉ T: i is a null player in unanimityGame T
+    apply h_null
+    intro S hiS
+    simp only [TUGame.unanimityGame]
+    have hto : T ⊆ S ∪ {i} → T ⊆ S := fun h j hj => by
+      obtain hks | hki := Finset.mem_union.mp (h hj)
+      · exact hks
+      · exact absurd (Finset.mem_singleton.mp hki) (fun heq => hiT (heq ▸ hj))
+    split_ifs <;> try rfl
+    · exfalso; exact ‹¬T ⊆ S› (hto ‹T ⊆ S ∪ {i}›)
+    · exfalso; exact ‹¬T ⊆ S ∪ {i}› (fun j hj => Finset.mem_union_left {i} (‹T ⊆ S› hj))
+
 /-! ## Key Properties -/
 
 namespace ShapleyValue
@@ -111,37 +206,6 @@ theorem shapley_null_player (G : TUGame N) (i : N)
       So each gets 1/|T|.
       Direct argument: marginalContribution i S = 1 iff T\{i} ⊆ S and i ∉ S.
       Count such S of size s: C(n-|T|-1+1, s-|T|+1) ... leads to 1/|T|. -/
-theorem shapley_unanimity (T : Finset N) (hT : T.Nonempty) (i : N) :
-    shapleyValue (TUGame.unanimityGame T hT) i =
-    if i ∈ T then (1 : ℝ) / T.card else 0 := by
-  classical
-  split_ifs with hiT
-  · -- Case i ∈ T: by symmetry all j∈T get same value, by efficiency sum=1
-    -- Use the axiomatic characterization: symmetry + efficiency + null player
-    have h_sym := ShapleyValue.shapley_symmetric
-    have h_null_ax : Solution.NullPlayerAxiom shapleySolution :=
-      fun G i => ShapleyValue.shapley_null_player G i
-    -- shapleySolution satisfies all three axioms, so phi_unanimity applies
-    have h := phi_unanimity shapleySolution shapley_efficient shapley_symmetric
-      (fun G i => ShapleyValue.shapley_null_player G i) T hT i
-    simp only [shapleySolution] at h
-    exact h
-  · -- Case i ∉ T: i is a null player in unanimityGame T
-    apply ShapleyValue.shapley_null_player
-    intro S hiS
-    simp only [TUGame.unanimityGame]
-    -- T ⊆ S ∪ {i} iff T ⊆ S since i ∉ T
-    have hto : T ⊆ S ∪ {i} → T ⊆ S := fun h j hj => by
-      obtain hj' | hj' := Finset.mem_union.mp (h hj)
-      · exact hj'
-      · exact absurd (Finset.mem_singleton.mp hj') (fun heq => hiT (heq ▸ hj))
-    split_ifs
-    · rfl
-    · exfalso; exact ‹¬T ⊆ S› (hto ‹T ⊆ S ∪ {i}›)
-    · exfalso; exact ‹¬T ⊆ S ∪ {i}› (fun j hj => Finset.mem_union_left {i} (‹T ⊆ S› hj))
-    · rfl
-
-/-! ## Helper lemmas for efficiency proof -/
 
 private theorem shapleyCoef_shift (n s : ℕ) (hs : s + 2 ≤ n) :
     (s + 1 : ℝ) * shapleyCoef n s = (n - s - 1 : ℝ) * shapleyCoef n (s + 1) := by
@@ -163,11 +227,12 @@ private theorem shapleyCoef_top (n : ℕ) (hn : 0 < n) :
   unfold shapleyCoef
   have h1 : n - (n - 1) - 1 = 0 := by omega
   simp only [h1, Nat.factorial_zero, Nat.cast_one, mul_one]
-  have h2 : (n : ℝ) * ↑(Nat.factorial (n - 1)) = ↑(Nat.factorial n) := by
-  have : n = (n - 1) + 1 := by omega
-  rw [this, Nat.factorial_succ, Nat.cast_mul, Nat.cast_one, mul_comm]
-  rw [h2, div_self]
-  exact Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  -- Goal: ↑n * (↑(n-1).factorial / ↑n.factorial) = 1
+  have hfact : (n : ℝ) * ↑(Nat.factorial (n - 1)) = ↑(Nat.factorial n) := by
+    have hsucc : n = (n - 1) + 1 := by omega
+    rw [hsucc, Nat.factorial_succ]
+    simp [Nat.cast_mul]
+  rw [← mul_div_assoc, hfact, div_self (Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n))]
 
 private theorem pos_term_eq (G : TUGame N) :
     (∑ S, shapleyCoef (Fintype.card N) S.card * ∑ i ∈ Finset.univ \ S, G.v (S ∪ {i})) =
@@ -432,6 +497,34 @@ theorem shapley_symmetric (G : TUGame N) (i j : N)
       have hsym := h S hS hSj
       rw [hsym]
 
+/-- Shapley value on unanimity games: each player in T gets 1/|T| -/
+theorem shapley_unanimity (T : Finset N) (hT : T.Nonempty) (i : N) :
+    shapleyValue (TUGame.unanimityGame T hT) i =
+    if i ∈ T then (1 : ℝ) / T.card else 0 := by
+  classical
+  split_ifs with hiT
+  · -- Case i ∈ T: by symmetry all j∈T get same value, by efficiency sum=1
+    have h : shapleySolution (TUGame.unanimityGame T hT) i =
+        if i ∈ T then (1 : ℝ) / T.card else 0 :=
+      phi_unanimity (φ := shapleySolution)
+        shapley_efficient shapley_symmetric
+        (fun G i => shapley_null_player G i) T hT i
+    simp only [shapleySolution, if_pos hiT] at h
+    exact h
+  · -- Case i ∉ T: i is a null player in unanimityGame T
+    apply shapley_null_player
+    intro S hiS
+    simp only [TUGame.unanimityGame]
+    have hto : T ⊆ S ∪ {i} → T ⊆ S := fun h j hj => by
+      obtain hj' | hj' := Finset.mem_union.mp (h hj)
+      · exact hj'
+      · exact absurd (Finset.mem_singleton.mp hj') (fun heq => hiT (heq ▸ hj))
+    split_ifs
+    · rfl
+    · exfalso; exact ‹¬T ⊆ S› (hto ‹T ⊆ S ∪ {i}›)
+    · exfalso; exact ‹¬T ⊆ S ∪ {i}› (fun j hj => Finset.mem_union_left {i} (‹T ⊆ S› hj))
+    · rfl
+
 /-- Shapley value satisfies additivity -/
 theorem shapley_additive (G H : TUGame N) (i : N) :
     shapleyValue (Solution.AddGames G H) i =
@@ -453,97 +546,6 @@ end ShapleyValue
     Proof strategy: show any axiom-satisfying solution φ agrees with
     shapleyValue on unanimity games (phi_unanimity + phi_eq_shapley),
     then extend to all games via Mobius decomposition and additivity. -/
-/-- Any efficient symmetric null-player-respecting solution gives 1/|T|
-    for players in T and 0 for players outside T in the unanimity game u_T.
-    Uses the three axioms (efficiency, symmetry, null player) directly. -/
-private theorem phi_unanimity (φ : Solution N)
-    (h_eff : φ.Efficiency)
-    (h_sym : φ.Symmetry)
-    (h_null : φ.NullPlayerAxiom)
-    (T : Finset N) (hT : T.Nonempty) (i : N) :
-    φ (TUGame.unanimityGame T hT) i =
-    if i ∈ T then (1 : ℝ) / T.card else 0 := by
-  classical
-  split_ifs with hiT
-  · -- Case i ∈ T: by symmetry all j∈T get same value, by efficiency sum=1
-    -- Step 1: By symmetry, all j ∈ T have the same value as i
-    have h_eq : ∀ j ∈ T, φ (unanimityGame T hT) j = φ (unanimityGame T hT) i := by
-    intro j hjT
-    by_cases hij : j = i; · subst hij; rfl
-    · apply h_sym
-    intro S hiS hjS
-    simp only [unanimityGame]
-    have hni : ¬(T ⊆ S ∪ {i}) := by
-    intro h
-    have := h hjT
-    simp only [Finset.mem_union, Finset.mem_singleton] at this
-    tauto
-    have hnj : ¬(T ⊆ S ∪ {j}) := by
-    intro h
-    have := h hiT
-    simp only [Finset.mem_union, Finset.mem_singleton] at this
-    tauto
-    rw [if_neg hni, if_neg hnj]
-    -- Step 2: Players outside T are null
-    have h_null_out : ∀ j, j ∉ T → φ (unanimityGame T hT) j = 0 := by
-    intro j hjT'
-    apply h_null
-    intro S hjS
-    simp only [unanimityGame]
-    have hto : T ⊆ S ∪ {j} → T ⊆ S := fun h k hk => by
-    have hk' := h hk
-    simp only [Finset.mem_union, Finset.mem_singleton] at hk'
-    exact hk'.elim id (fun he => absurd (he ▸ hk) (fun h2 => hjT' (h2 ▸ hk)))
-    split_ifs with h1 h2
-    · rfl
-    · exfalso; exact h2 (hto h1)
-    · exfalso; exact h1 (fun k hk => Finset.mem_union_left {j} (h2 hk))
-    · rfl
-    -- Step 3: Efficiency: sum = v(univ) = 1
-    have h_sum_one : ∑ j, φ (unanimityGame T hT) j = 1 := by
-    have := h_eff (unanimityGame T hT)
-    simp only [unanimityGame, if_pos (Finset.subset_univ T)] at this
-    exact this
-    -- Step 4: ∑_{∈T} = 1 (since ∑_{∉T} = 0)
-    have h_sum_T : ∑ j ∈ T, φ (unanimityGame T hT) j = 1 := by
-    have h_out_sum : ∑ j ∈ Finset.filter (fun j => j ∉ T) Finset.univ,
-    φ (unanimityGame T hT) j = 0 :=
-    Finset.sum_eq_zero (fun j hj => by
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hj
-    exact h_null_out j hj.2)
-    have h_split : ∑ j ∈ T, φ (unanimityGame T hT) j +
-    ∑ j ∈ Finset.filter (fun j => j ∉ T) Finset.univ,
-    φ (unanimityGame T hT) j = ∑ j, φ (unanimityGame T hT) j := by
-    have : Finset.filter (fun j => j ∉ T) Finset.univ = Tᶜ := by
-    ext j; simp
-    rw [this]
-    exact (Finset.sum_add_sum_compl T _).symm
-    linarith
-    -- Step 5: All equal in T, so T.card * φ G i = 1
-    have h_card : (T.card : ℝ) * φ (unanimityGame T hT) i = 1 := by
-    have h1 : ∑ j ∈ T, φ (unanimityGame T hT) i = T.card • φ (unanimityGame T hT) i :=
-    Finset.sum_const _
-    have h2 : ∑ j ∈ T, φ (unanimityGame T hT) i = 1 :=
-    (Finset.sum_congr rfl (fun j hj => (h_eq j hj).symm)).trans h_sum_T
-    rw [show T.card • φ (unanimityGame T hT) i = (T.card : ℝ) * φ (unanimityGame T hT) i from
-    Nat.smul_def _ _]
-    linarith
-    -- Step 6: Therefore φ G i = 1 / T.card
-    have hT0 : (T.card : ℝ) ≠ 0 := by
-      simp [Finset.Nonempty.ne_zero hT]
-    field_simp
-    linarith
-  · -- Case i ∉ T: i is a null player in unanimityGame T
-    apply h_null
-    intro S hiS
-    simp only [TUGame.unanimityGame]
-    have hto : T ⊆ S ∪ {i} → T ⊆ S := fun h j hj => by
-      obtain hks | hki := Finset.mem_union.mp (h hj)
-      · exact hks
-      · exact absurd (Finset.mem_singleton.mp hki) (fun heq => hiT (heq ▸ hj))
-    split_ifs <;> try rfl
-    · exfalso; exact ‹¬T ⊆ S› (hto ‹T ⊆ S ∪ {i}›)
-    · exfalso; exact ‹¬T ⊆ S ∪ {i}› (fun j hj => Finset.mem_union_left {i} (‹T ⊆ S› hj))
 
 /-- φ agrees with shapleyValue on unanimity games -/
 private theorem phi_eq_shapley (φ : Solution N)


### PR DESCRIPTION
## Summary
- Move `phi_unanimity` before `ShapleyValue` namespace to eliminate cross-namespace forward reference
- Move `shapley_unanimity` after `shapley_symmetric` to resolve forward refs to `shapley_efficient`/`shapley_symmetric`
- Fix `phi_unanimity` proof tactics (sum_const, nsmul_eq_mul, sum_add_sum_compl, card_pos)
- Fix `shapleyCoef_top` proof (hfact + div_self approach)

## Proof of progress
- `lake build CooperativeGames.Shapley` SUCCESS
- `grep -c sorry Shapley.lean` = 1 (unchanged, `shapley_uniqueness`)
- `grep -c sorry Basic.lean` = 2 (unchanged, out of scope)

## Test plan
- [x] `lake build CooperativeGames.Shapley` passes
- [x] Sorry count unchanged (1 Shapley + 2 Basic)
- [ ] Verify no regression in existing proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)