### PR TITLE
feat(ml): DM test retroactif + M10 Realized GARCH proposal (Cycle 28)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/.gitignore
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/.gitignore
@@ -1,5 +1,6 @@
 # Training outputs
 checkpoints/
+outputs/
 
 # Python
 __pycache__/

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/DM_RETROACTIF.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/DM_RETROACTIF.md
@@ -1,0 +1,94 @@
+# DM Test Retroactif -- Cycle 28 Track A
+
+**Status:** COMPLETE
+
+## Methodology
+
+- Diebold-Mariano test on MSE loss differential (M3/M3b/M4/M5 vs HAR classic baseline)
+- M9 TFT: binomial test on direction accuracy vs majority-class baseline
+- Re-classification thresholds: BEATS p<0.05 (strict), BEATS p<0.10 (marginal), INCONCLUSIVE
+- Cross-seed sign-test: binomial H0:p=0.5 on per-seed BEATS counts
+
+## Per-combo results
+
+| Model | Coin | h | Runs | Beats | Mean p | Sign-test p | MSE red% | Verdict |
+|-------|------|---|------|-------|--------|-------------|----------|---------|
+| M3_HAR_classic | ADA-USD | 1 | 1 | 1/1 | 0.011313 | 0.5000 | 48.4% | **BEATS_p005** |
+| M3_HAR_classic | ADA-USD | 5 | 1 | 1/1 | 0.042922 | 0.5000 | 56.1% | **BEATS_p005** |
+| M3_HAR_classic | ADA-USD | 10 | 1 | 0/1 | 0.067727 | 1.0000 | 56.6% | **BEATS_p010** |
+| M3_HAR_classic | BTC-USD | 1 | 1 | 1/1 | 0.000000 | 0.5000 | 48.7% | **BEATS_p005** |
+| M3_HAR_classic | BTC-USD | 5 | 1 | 1/1 | 0.001790 | 0.5000 | 62.4% | **BEATS_p005** |
+| M3_HAR_classic | BTC-USD | 10 | 1 | 0/1 | 0.194182 | 1.0000 | 60.3% | **INCONCLUSIVE** |
+| M3_HAR_classic | DOT-USD | 1 | 1 | 0/1 | 0.112160 | 1.0000 | 37.7% | **INCONCLUSIVE** |
+| M3_HAR_classic | DOT-USD | 5 | 1 | 0/1 | 0.796634 | 1.0000 | 41.8% | **INCONCLUSIVE** |
+| M3_HAR_classic | DOT-USD | 10 | 1 | 0/1 | 0.876081 | 1.0000 | 36.4% | **INCONCLUSIVE** |
+| M3_HAR_classic | ETH-USD | 1 | 1 | 1/1 | 0.000000 | 0.5000 | 52.7% | **BEATS_p005** |
+| M3_HAR_classic | ETH-USD | 5 | 1 | 1/1 | 0.000000 | 0.5000 | 66.5% | **BEATS_p005** |
+| M3_HAR_classic | ETH-USD | 10 | 1 | 1/1 | 0.000244 | 0.5000 | 66.1% | **BEATS_p005** |
+| M3_HAR_classic | LTC-USD | 1 | 1 | 1/1 | 0.013168 | 0.5000 | 43.3% | **BEATS_p005** |
+| M3_HAR_classic | LTC-USD | 5 | 1 | 0/1 | 0.286260 | 1.0000 | 50.5% | **INCONCLUSIVE** |
+| M3_HAR_classic | LTC-USD | 10 | 1 | 0/1 | 0.421759 | 1.0000 | 49.5% | **INCONCLUSIVE** |
+| M3_HAR_classic | SOL-USD | 1 | 1 | 1/1 | 0.000267 | 0.5000 | 34.3% | **BEATS_p005** |
+| M3_HAR_classic | SOL-USD | 5 | 1 | 1/1 | 0.002347 | 0.5000 | 46.0% | **BEATS_p005** |
+| M3_HAR_classic | SOL-USD | 10 | 1 | 1/1 | 0.005476 | 0.5000 | 46.0% | **BEATS_p005** |
+| M3_HAR_classic | XRP-USD | 1 | 1 | 1/1 | 0.001180 | 0.5000 | 42.3% | **BEATS_p005** |
+| M3_HAR_classic | XRP-USD | 5 | 1 | 0/1 | 0.181190 | 1.0000 | 48.2% | **INCONCLUSIVE** |
+| M3_HAR_classic | XRP-USD | 10 | 1 | 0/1 | 0.724475 | 1.0000 | 43.8% | **INCONCLUSIVE** |
+| M3b_HAR_asymmetric | BTC-USD | 1 | 4 | 4/4 | 0.000066 | 0.0625 | 5.1% | **BEATS_p005** |
+| M3b_HAR_asymmetric | BTC-USD | 5 | 4 | 4/4 | 0.000006 | 0.0625 | 23.6% | **BEATS_p005** |
+| M3b_HAR_asymmetric | BTC-USD | 10 | 4 | 4/4 | 0.000001 | 0.0625 | 36.7% | **BEATS_p005** |
+| M3b_HAR_asymmetric | ETH-USD | 1 | 4 | 0/4 | 0.607131 | 1.0000 | -0.6% | **INCONCLUSIVE** |
+| M3b_HAR_asymmetric | ETH-USD | 5 | 4 | 0/4 | 0.951735 | 1.0000 | 0.3% | **INCONCLUSIVE** |
+| M3b_HAR_asymmetric | ETH-USD | 10 | 4 | 0/4 | 0.915098 | 1.0000 | -0.9% | **INCONCLUSIVE** |
+| M4_DLinear | ADA-USD | 1 | 4 | 3/4 | 0.049756 | 0.3125 | 5.3% | **BEATS_p005** |
+| M4_DLinear | ADA-USD | 5 | 4 | 0/4 | 0.206132 | 1.0000 | 7.7% | **INCONCLUSIVE** |
+| M4_DLinear | ADA-USD | 10 | 4 | 0/4 | 0.893847 | 1.0000 | 0.9% | **INCONCLUSIVE** |
+| M4_DLinear | BTC-USD | 1 | 4 | 4/4 | 0.000000 | 0.0625 | 15.3% | **BEATS_p005** |
+| M4_DLinear | BTC-USD | 5 | 4 | 4/4 | 0.000000 | 0.0625 | 28.3% | **BEATS_p005** |
+| M4_DLinear | BTC-USD | 10 | 4 | 4/4 | 0.000000 | 0.0625 | 38.3% | **BEATS_p005** |
+| M4_DLinear | DOT-USD | 1 | 4 | 0/4 | 0.140735 | 1.0000 | 3.2% | **INCONCLUSIVE** |
+| M4_DLinear | DOT-USD | 5 | 4 | 0/4 | 0.930802 | 1.0000 | 0.3% | **INCONCLUSIVE** |
+| M4_DLinear | DOT-USD | 10 | 4 | 0/4 | 0.921947 | 1.0000 | -0.7% | **INCONCLUSIVE** |
+| M4_DLinear | ETH-USD | 1 | 4 | 4/4 | 0.035979 | 0.0625 | 3.3% | **BEATS_p005** |
+| M4_DLinear | ETH-USD | 5 | 4 | 0/4 | 0.284667 | 1.0000 | 3.9% | **INCONCLUSIVE** |
+| M4_DLinear | ETH-USD | 10 | 4 | 0/4 | 0.315930 | 1.0000 | 6.0% | **INCONCLUSIVE** |
+| M4_DLinear | LTC-USD | 1 | 4 | 2/4 | 0.086157 | 0.6875 | 4.7% | **BEATS_p010** |
+| M4_DLinear | LTC-USD | 5 | 4 | 0/4 | 0.100083 | 1.0000 | 9.1% | **INCONCLUSIVE** |
+| M4_DLinear | LTC-USD | 10 | 4 | 0/4 | 0.235653 | 1.0000 | 8.9% | **INCONCLUSIVE** |
+| M4_DLinear | SOL-USD | 1 | 4 | 4/4 | 0.001003 | 0.0625 | 9.8% | **BEATS_p005** |
+| M4_DLinear | SOL-USD | 5 | 4 | 0/4 | 0.220825 | 1.0000 | 4.4% | **INCONCLUSIVE** |
+| M4_DLinear | SOL-USD | 10 | 4 | 0/4 | 0.678655 | 1.0000 | 2.2% | **INCONCLUSIVE** |
+| M4_DLinear | XRP-USD | 1 | 4 | 0/4 | 0.669727 | 1.0000 | -0.2% | **INCONCLUSIVE** |
+| M4_DLinear | XRP-USD | 5 | 4 | 0/4 | 0.352673 | 1.0000 | 4.8% | **INCONCLUSIVE** |
+| M4_DLinear | XRP-USD | 10 | 4 | 0/4 | 0.614544 | 1.0000 | 3.6% | **INCONCLUSIVE** |
+| M5_HMM_regime | BTC-USD | 1 | 4 | 3/4 | 0.164619 | 0.3125 | 7.0% | **INCONCLUSIVE** |
+| M5_HMM_regime | BTC-USD | 5 | 4 | 0/4 | 0.112928 | 1.0000 | -11.1% | **INCONCLUSIVE** |
+| M5_HMM_regime | BTC-USD | 10 | 4 | 0/4 | 0.016261 | 1.0000 | -28.3% | **BEATEN_p005** |
+| M5_HMM_regime | ETH-USD | 1 | 4 | 4/4 | 0.001075 | 0.0625 | 9.6% | **BEATS_p005** |
+| M5_HMM_regime | ETH-USD | 5 | 4 | 0/4 | 0.018525 | 1.0000 | -17.9% | **BEATEN_p005** |
+| M5_HMM_regime | ETH-USD | 10 | 4 | 0/4 | 0.000510 | 1.0000 | -53.0% | **BEATEN_p005** |
+| M9_TFT | BTC-USD | 1 | 16 | 5/16 | 0.668774 | 0.9616 | N/A | **INCONCLUSIVE** |
+| M9_TFT | BTC-USD | 5 | 16 | 6/16 | 0.610663 | 0.8949 | N/A | **INCONCLUSIVE** |
+| M9_TFT | BTC-USD | 10 | 16 | 3/16 | 0.701275 | 0.9979 | N/A | **INCONCLUSIVE** |
+| M9_TFT | ETH-USD | 1 | 16 | 4/16 | 0.746434 | 0.9894 | N/A | **INCONCLUSIVE** |
+| M9_TFT | ETH-USD | 5 | 16 | 5/16 | 0.701742 | 0.9616 | N/A | **INCONCLUSIVE** |
+| M9_TFT | ETH-USD | 10 | 16 | 3/16 | 0.755272 | 0.9979 | N/A | **INCONCLUSIVE** |
+
+## Model summary
+
+| Model | Combos | BEATS p<0.05 | BEATS p<0.10 | BEATEN p<0.05 | BEATEN p<0.10 | INCONCLUSIVE |
+|-------|--------|-------------|-------------|---------------|--------------|-------------|
+| M3_HAR_classic | 21 | 12 | 1 | 0 | 0 | 8 |
+| M3b_HAR_asymmetric | 6 | 3 | 0 | 0 | 0 | 3 |
+| M4_DLinear | 21 | 6 | 1 | 0 | 0 | 14 |
+| M5_HMM_regime | 6 | 1 | 0 | 3 | 0 | 2 |
+| M9_TFT | 6 | 0 | 0 | 0 | 0 | 6 |
+| **TOTAL** | **60** | **22** | **2** | **3** | **0** | **33** |
+
+**Population sign-test:** 24/60 combos beat, 3/60 beaten, p=0.9538
+
+## Key findings
+
+1. **Models with strict BEATS (p<0.05):** M3_HAR_classic, M3b_HAR_asymmetric, M4_DLinear, M5_HMM_regime
+2. **Models significantly BEATEN by baseline (p<0.05):** M5_HMM_regime
+3. **Models with NO significant signal (INCONCLUSIVE across all combos):** M9_TFT

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M3_FINAL_SYNTHESIS.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M3_FINAL_SYNTHESIS.md
@@ -1,0 +1,219 @@
+# M3 Final Synthesis -- HAR Volatility Forecasting: Classic, Asymmetric, Long-Horizon, and DLinear Comparison
+
+**Status:** COMPLETE. Consolidates M2, M3, M3b, M3-ext, M4 (Cycle 25, po-2024 + ai-01).
+
+## Scope
+
+This document consolidates all HAR-family volatility forecasting results across:
+- **M2** -- HAR baseline (BTC/ETH/SOL, h=1/5/10, vs GARCH + naive)
+- **M3** -- 7-coin extension + DM significance tests (BTC/ETH/SOL/LTC/XRP/ADA/DOT, h=1/5/10)
+- **M3-ext** -- Long-horizon extension (h=15/20, 7 coins)
+- **M3b** -- Asymmetric semivariance decomposition (7 coins, h=1/5/10, vs classic HAR)
+- **M4** -- DLinear-vol deep learning (7 coins, h=1/5/10, 4 seeds, vs HAR)
+
+## Master Verdict Table
+
+Cross-coin x cross-horizon x cross-variant verdicts. "BEATS" = statistically significant
+improvement over baseline (DM test p<0.05 for M3/M3b/M3-ext; 4/4 seeds DM p<0.05 for M4).
+All on log-RV scale, walk-forward 5-fold expanding window.
+
+### HAR Classic vs Naive Baseline (M3)
+
+| Coin | h=1 | h=5 | h=10 | h=15 | h=20 |
+|------|-----|-----|------|------|------|
+| BTC-USD | **BEATS** | **BEATS** | INC | INC | INC |
+| ETH-USD | **BEATS** | **BEATS** | **BEATS** | **BEATS** | **BEATS** |
+| SOL-USD | **BEATS** | **BEATS** | **BEATS** | **BEATS** | **BEATS** |
+| LTC-USD | **BEATS** | INC | INC | INC | INC |
+| XRP-USD | **BEATS** | INC | INC | INC | INC |
+| ADA-USD | **BEATS** | **BEATS** | INC | INC | INC |
+| DOT-USD | INC | INC | INC | INC | INC |
+
+**Score: 14/35 BEATS** (40%). ETH and SOL = strongest, statistically significant at ALL
+five horizons. Significance degrades with horizon for most coins.
+
+### Asymmetric HAR vs Classic HAR (M3b)
+
+| Coin | h=1 | h=5 | h=10 |
+|------|-----|-----|------|
+| BTC-USD | **BEATS** | **BEATS** | **BEATS** |
+| ETH-USD | INC | INC | INC |
+| SOL-USD | INC | INC | INC |
+| LTC-USD | INC | INC | INC |
+| XRP-USD | INC | INC | INC |
+| ADA-USD | INC | INC | INC |
+| DOT-USD | INC | INC | INC |
+
+**Score: 3/21 BEATS** (14%). Leverage effect is BTC-specific. 5-37% MSE reduction
+on BTC only.
+
+### DLinear vs Classic HAR (M4, 4 seeds)
+
+| Coin | h=1 | h=5 | h=10 |
+|------|-----|-----|------|
+| BTC-USD | **BEATS** | **BEATS** | **BEATS** |
+| ETH-USD | **BEATS** | INC | INC |
+| SOL-USD | **BEATS** | INC | INC |
+| ADA-USD | INC | INC | INC |
+| LTC-USD | INC | INC | INC |
+| DOT-USD | INC | INC | INC |
+| XRP-USD | INC | INC | INC |
+
+**Score: 5/21 BEATS** (24%). DLinear learns 22 free parameters vs HAR's 3, winning when
+data is sufficient (BTC, to a lesser extent ETH/SOL).
+
+## Best Model Per Configuration
+
+Combining all experiments, the best-performing model for each (coin, horizon) pair:
+
+| Coin | h=1 | h=5 | h=10 | h=15 | h=20 |
+|------|-----|-----|------|------|------|
+| BTC-USD | Asym HAR (0.843) | DLinear (0.374) | DLinear (0.352) | -- | -- |
+| ETH-USD | HAR Classic (0.684) | HAR Classic (0.374) | HAR Classic (0.375) | HAR Classic (0.378) | HAR Classic (0.397) |
+| SOL-USD | HAR Classic (0.609) | HAR Classic (0.281) | HAR Classic (0.236) | HAR Classic (0.201) | HAR Classic (0.166) |
+| LTC-USD | HAR Classic (0.650) | HAR Classic (0.434) | HAR Classic (0.426) | -- | -- |
+| XRP-USD | HAR Classic (0.848) | HAR Classic (0.521) | HAR Classic (0.530) | -- | -- |
+| ADA-USD | HAR Classic (0.686) | HAR Classic (0.412) | HAR Classic (0.373) | -- | -- |
+| DOT-USD | HAR Classic (0.634) | HAR Classic (0.378) | HAR Classic (0.355) | -- | -- |
+
+Key observations:
+- **BTC** is the only coin where DL and asymmetric models beat classic HAR.
+- **ETH/SOL** classic HAR is hard to beat -- the simple 3-parameter model captures
+  enough structure that additional complexity doesn't help significantly.
+- **Other coins** (LTC/XRP/ADA/DOT) lack sufficient data for any model to significantly
+  outperform classic HAR beyond h=1.
+
+## MSE Comparison Heatmap (selected configs)
+
+BTC-USD shows the richest comparison across all model families:
+
+| Model | h=1 | h=5 | h=10 | DM vs HAR |
+|-------|-----|-----|------|-----------|
+| Naive trail-30d | 1.237 | 0.747 | 0.685 | -- |
+| GARCH-rolling | 1.732 | 1.384 | 1.438 | -- |
+| HAR Classic | 0.888 | 0.522 | 0.571 | baseline |
+| HAR Asymmetric | 0.843 | 0.399 | 0.361 | BEATS all h |
+| DLinear-vol | 0.752 | 0.374 | 0.352 | BEATS all h |
+
+Progression: HAR beats GARCH/naive, then asymmetric HAR and DLinear each provide
+additional 15-38% MSE reduction over classic HAR. The two improvements are complementary.
+
+## Summary of Key Findings
+
+### 1. HAR is the correct baseline for crypto RV forecasting
+
+HAR (Corsi 2009) with 3 hand-crafted features (daily/weekly/monthly log-RV means) beats:
+- **GARCH-rolling** by 30-67% across all 21 short-horizon configs and all 14 long-horizon configs
+- **Naive trail-30d** by 16-48% at h=1, statistically significant for 6/7 coins
+
+This invalidates GARCH(1,1) as a useful benchmark for crypto volatility. The r-squared-daily
+target used in earlier pipeline stages was strictly worse than predicting nothing (MSE 5.6-7.6
+vs log-RV variance ~1.5).
+
+### 2. Statistical significance depends on data quantity and forecast horizon
+
+- **h=1**: 6/7 coins BEATS naive (only DOT inconclusive)
+- **h=5**: 4/7 coins BEATS
+- **h=10**: 2/7 coins BEATS (ETH, SOL)
+- **h=15-20**: 2/7 coins BEATS (ETH, SOL persistently)
+
+ETH and SOL maintain statistical significance across ALL five horizons. Other coins lose
+power progressively. BTC is anomalous: despite the longest data history (2278 RV days),
+its h>=10 significance collapses -- consistent with BTC's more mature, mean-reverting
+volatility regime.
+
+### 3. Asymmetric semivariance benefits BTC only
+
+The leverage effect (RV- > RV+ predicting future vol) is real and significant for BTC
+(5-37% MSE reduction, p<0.001), but not detectable for any other coin. The asymmetry
+signal requires both (a) enough data and (b) a genuine leverage effect in the asset's
+microstructure. XRP and ADA even show RV+ > RV- (inverse leverage), explaining the
+slightly worse asymmetric results for those coins.
+
+### 4. DLinear captures information beyond HAR's 3 features
+
+DLinear's learned 22-parameter linear projection beats HAR's 3-parameter model on BTC
+at all horizons (15-38% MSE reduction), ETH and SOL at h=1. The key insight: HAR's
+hand-crafted 1d/5d/22d averages are a restrictive parameterization. A learned projection
+from 22 daily values captures non-uniform temporal weighting that HAR misses.
+
+DLinear's simplicity (single nn.Linear layer) provides inherent stability -- seed
+variance <0.002 MSE on BTC. This is an advantage over more complex architectures
+(LSTM, Transformer) that overfit on small-sample financial data.
+
+### 5. The two improvements are complementary
+
+Asymmetric HAR exploits **sign asymmetry** (leverage effect), DLinear exploits
+**full-path information** (non-uniform temporal weights). For BTC:
+- Asymmetric HAR: 5-37% over classic HAR
+- DLinear: 15-38% over classic HAR
+- A DLinear with asymmetric inputs (RV+ and RV- as separate channels) is a natural
+  next step that could combine both advantages.
+
+### 6. Data quantity is the binding constraint
+
+| Data source | RV days | Results quality |
+|-------------|---------|-----------------|
+| Bitstamp BTC | ~2278 | Strong: significance at all horizons, both improvements detectable |
+| Binance ETH | ~1495 | Good: significance at all horizons, no asymmetric benefit |
+| yfinance SOL | ~725 | Moderate: h=1 significance for DL, good HAR performance |
+| yfinance LTC/XRP/ADA/DOT | ~725 | Weak: numerical improvements but no significance |
+
+yfinance provides only ~730 days of hourly data (2 years). This is insufficient for
+DM test power. DOT consistently shows the weakest results across all experiments.
+
+## Reproducibility
+
+All experiments use the same methodology:
+- Walk-forward 5-fold expanding window, refit every 22 days
+- Target: log Realized Variance from hourly returns
+- DM test: HAC Newey-West with HLN small-sample correction
+- Seeds: 0, 7, 42, 99 (for DLinear; OLS seeds are identical)
+
+Scripts:
+```bash
+# HAR Classic (M3)
+python scripts/train_har_baseline.py --horizons 1 5 10
+
+# HAR Asymmetric (M3b)
+python scripts/har_asymmetric.py --horizons 1 5 10 --seeds 0 7 42 99
+
+# DLinear-vol (M4)
+python scripts/dlinear_vol.py --horizons 1 5 10 --seeds 0 7 42 99
+
+# Long-horizon (M3-ext)
+python scripts/train_har_baseline.py --horizons 15 20 --extra-coins LTC-USD XRP-USD ADA-USD DOT-USD
+```
+
+## Next Steps
+
+1. **M5/M6** -- Cross-asset models: multi-scale GNN or multi-asset LSTM with asset
+   embeddings, using HAR features as inputs alongside raw RV.
+2. **Asymmetric DLinear** -- Feed RV+ and RV- as separate input channels to DLinear,
+   combining leverage effect decomposition with learned temporal weights.
+3. **5-minute RV** -- Current RV is computed from hourly returns. Literature (Andersen
+   et al. 2003) recommends 5-min. Expect another 10-30% MSE reduction.
+4. **Transaction cost integration** -- Convert MSE improvements to Sharpe/VaR improvements
+   with realistic crypto spreads (10-50 bps).
+5. **TFT (M9)** -- Temporal Fusion Transformer with the fixed multi-seed walk-forward
+   pipeline (PR #971). Tests whether attention-based variable selection beats HAR's
+   hand-crafted features when data is sufficient.
+
+## References
+
+- Andersen, T.G., Bollerslev, T., Diebold, F.X. & Labys, P. (2003) "Modeling and Forecasting
+  Realized Volatility", Econometrica 71, 579-625.
+- Black, F. (1976) "Studies of Stock Price Volatility Changes", ASA Proceedings.
+- Corsi, F. (2009) "A Simple Approximate Long-Memory Model of Realized Volatility",
+  Journal of Financial Econometrics 7, 174-196.
+- Diebold, F.X. & Mariano, R.S. (1995) "Comparing Predictive Accuracy", JBES 13, 253-263.
+- Harvey, D.I., Leybourne, S.J. & Newbold, P. (1997) "Testing the Equality of Prediction
+  Mean Squared Errors", IJF 13, 281-291.
+- McAleer, M. & Medeiros, M.C. (2008) "Realized Volatility: A Review", Econometric Reviews.
+- Patton, A.J. & Sheppard, K. (2009) "Good Volatility, Bad Volatility: Signed Jumps and
+  the Persistence of Volatility", Working Paper.
+- Zeng, A., Chen, M., Zhang, L. & Xu, Q. (2023) "Are Transformers Effective for Time
+  Series Forecasting?", AAAI 2023.
+- Lim, B., Arik, S.O., Loeff, N. & Pfister, T. (2021) "Temporal Fusion Transformers for
+  Interpretable Multi-horizon Time Series Forecasting", International Journal of
+  Forecasting 37, 1748-1764.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M5_HMM_REGIME.md
@@ -1,0 +1,127 @@
+# M5 -- HMM Regime-Switching HAR: Volatility Regime Detection + Conditional Forecasting
+
+**Status:** COMPLETE (Cycle 25 Wave 3, po-2024 Track C2).
+
+## Why
+
+M3 established HAR as the gold-standard baseline for crypto RV forecasting. M3b showed
+asymmetric semivariance benefits BTC. M4 showed DLinear beats HAR on BTC at all horizons.
+A natural extension: can regime-switching models, where different HAR coefficients apply
+in different volatility regimes (low-vol vs high-vol), improve on the single HAR model?
+
+The economic intuition: volatility dynamics may differ between calm and turbulent periods.
+A model that adapts its coefficients to the current regime could capture this asymmetry.
+
+## Model
+
+**Classic HAR (Corsi 2009):**
+```
+log RV_{t+h} = b0 + b_d*rv_d + b_w*rv_w + b_m*rv_m + e
+```
+
+**Regime-Switching HAR (this work):**
+```
+log RV_{t+h} = b0 + b_d*rv_d + b_w*rv_w + b_m*rv_m
+             + g0 * I(regime=high)
+             + g_d * rv_d * I(regime=high)
+             + g_w * rv_w * I(regime=high)
+             + g_m * rv_m * I(regime=high)
+             + e
+```
+
+Where:
+- Regime decoded by K=2 Gaussian HMM (Viterbi) on log-RV
+- 8 OLS coefficients (4 base + 4 regime interaction terms)
+- At prediction time, HMM decodes current regime, selecting the interaction term values
+
+## Methodology
+
+- K=2 Gaussian HMM (hmmlearn) on log-RV, Viterbi-decoded
+- Regime-switching HAR with interaction terms (8 coefficients)
+- Walk-forward 5-fold expanding window, refit every 22 days
+- 4 seeds (0, 7, 42, 99) for HMM initialization
+- 2 coins (BTC-USD, ETH-USD), 3 horizons (h=1, 5, 10)
+- Diebold-Mariano HAC test vs classic HAR baseline
+- Aggregate verdict: BEATS only if 4/4 seeds pass DM
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/hmm_regime_vol.py` | HMM regime-switching HAR model + walk-forward runner |
+| `scripts/results/m5_hmm_regime.json` | Full results (609s runtime) |
+| `docs/M5_HMM_REGIME.md` | This document |
+
+## Results (BTC+ETH, 4 seeds, 609s runtime)
+
+### DM verdict summary
+
+| Verdict | Count | Configs |
+|---------|-------|---------|
+| **BEATS** | 1/6 | ETH h=1 (4/4 seeds) |
+| INCONCLUSIVE | 2/6 | BTC h=1 (3/4 seeds), BTC h=5 |
+| **BEATEN BY** | 3/6 | BTC h=5, BTC h=10, ETH h=5, ETH h=10 |
+
+### Per-coin results (aggregated over 4 seeds)
+
+| Coin | Horizon | Regime MSE | Classic MSE | Reduction | DM p-value | Verdict |
+|------|---------|------------|-------------|-----------|------------|---------|
+| BTC-USD | 1 | 0.825 | 0.888 | +7.0% | 3/4 seeds p<0.001 | INCONCLUSIVE |
+| BTC-USD | 5 | 0.580 | 0.522 | -11.1% | 2/4 BEATEN BY | BEATEN BY |
+| BTC-USD | 10 | 0.732 | 0.571 | -28.3% | 3/4 BEATEN BY | BEATEN BY |
+| ETH-USD | 1 | 0.619 | 0.684 | +9.6% | 4/4 p<0.005 | **BEATS** |
+| ETH-USD | 5 | 0.441 | 0.374 | -17.9% | 3/4 BEATEN BY | BEATEN BY |
+| ETH-USD | 10 | 0.573 | 0.375 | -53.0% | 4/4 BEATEN BY | BEATEN BY |
+
+### MSE reduction vs classic HAR (regime - classic, positive = regime wins)
+
+| Coin | h=1 | h=5 | h=10 |
+|------|-----|-----|------|
+| BTC-USD | +7.0%* | -11.1% | -28.3% |
+| ETH-USD | **+9.6%** | -17.9% | -53.0% |
+
+(*3/4 seeds significant, not all 4)
+
+## Key findings
+
+1. **ETH h=1: only significant win.** The regime-switching HAR beats classic HAR by 9.6%
+   (4/4 seeds, p<0.005). ETH's shorter data history (1495 RV days) with more pronounced
+   regime shifts benefits from the conditional model at the shortest horizon.
+
+2. **BTC h=1: promising but not conclusive.** 3/4 seeds show 8-10% improvement (p<10^-5),
+   but seed 7 produces near-zero improvement (0.1%). The aggregate verdict is INCONCLUSIVE.
+   The HMM initialization sensitivity is a concern.
+
+3. **Longer horizons: regime model is harmful.** At h=5 and h=10, the regime-switching
+   model is significantly WORSE than classic HAR for both coins. The MSE degradation grows
+   with horizon: BTC h=10 sees 28% worse, ETH h=10 sees 53% worse. The interaction terms
+   introduce noise that compounds over multi-step forecasts.
+
+4. **HMM initialization sensitivity is severe.** Different seeds produce wildly different
+   regime decompositions. Seed 0 and 99 might classify 60%/40% low/high, while seed 7
+   might produce 80%/20%. This variance translates directly into prediction instability.
+
+5. **The regime interaction approach has a fundamental flaw at longer horizons.** The
+   iterative h-step prediction uses a single regime indicator R for ALL forecast steps.
+   But the regime may switch during the forecast window. The model cannot adapt mid-forecast,
+   leading to compounding errors.
+
+## Conclusion
+
+**M5 verdict: INCONCLUSIVE overall. 1/6 configs BEATS (ETH h=1).**
+
+The HMM regime-switching HAR provides marginal improvement at h=1 for some configurations
+but is actively harmful at h>=5. The approach adds complexity (8 coefficients + HMM
+decoding) without consistent benefit. The classic 3-parameter HAR remains the better
+default for most use cases.
+
+Compared to M3b (asymmetric HAR, 3/21 BEATS, BTC-only) and M4 (DLinear, 5/21 BEATS),
+the HMM regime approach (1/6 BEATS) is the weakest extension. The DLinear model, which
+learns optimal temporal weights without explicit regime decomposition, is strictly superior.
+
+## References
+
+- Hamilton, J.D. (1989) "A New Approach to the Economic Analysis of Nonstationary
+  Time Series and the Business Cycle", Econometrica 57, 357-384.
+- Corsi, F. (2009) "A Simple Approximate Long-Memory Model of Realized Volatility",
+  Journal of Financial Econometrics 7, 174-196.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M9_TFT_VOL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M9_TFT_VOL.md
@@ -1,0 +1,131 @@
+# M9 -- TFT (Temporal Fusion Transformer) for Crypto Volatility Forecasting
+
+**Status:** COMPLETE (Cycle 25 Wave 3, po-2024 Track C1).
+
+## Why
+
+M4 showed DLinear beats HAR on BTC at all horizons (5/21 BEATS). A natural extension: can
+a more expressive architecture -- the Temporal Fusion Transformer (Lim et al. 2021) -- improve
+on DLinear's results? TFT combines LSTM sequence encoding with multi-head attention and
+variable selection, designed for multi-horizon forecasting with interpretable attention weights.
+
+The TFT architecture is significantly more complex than DLinear (~110K params vs ~22 params),
+so the question is whether this expressiveness translates to better volatility forecasts or
+whether the added complexity hurts generalization on limited crypto data.
+
+## Model
+
+**DLinear (M4 baseline):**
+```
+y_hat = Linear(seq_len -> horizon)
+```
+
+**TFT (Lim et al. 2021, adapted):**
+```
+1. Variable Selection Network -> select relevant features per timestep
+2. LSTM Encoder -> capture local temporal patterns
+3. Multi-Head Attention -> capture long-range dependencies
+4. Gated Residual Network -> skip connections with gating
+5. Output projection -> pred_len predictions
+```
+
+Architecture: d_model=64, n_heads=4, lstm_layers=1, dropout=0.1, fc_dropout=0.1
+Total params: ~110,801 (BTC) / ~111,061 (ETH)
+
+Input features (18): returns, volatility, volume_ratio, ma_ratios, rsi, macd, bollinger,
+true_range_atr, obv (9 indicators x 2 for recent + historical windows).
+
+## Methodology
+
+- Walk-forward expanding window with gap=10 days
+- 4 seeds (0, 1, 7, 42)
+- 3 horizons (h=1, 5, 10 days)
+- 2 coins (BTC-USD, ETH-USD) -- crypto only, no FAANG/Mag7
+- 100 epochs, batch_size=64, lr=5e-4, AdamW optimizer
+- Gradient clipping 1.0, mixed precision (AMP) on CUDA
+- Direction accuracy vs majority-class baseline as primary metric
+- Edge = direction_accuracy - majority_class_accuracy (positive = TFT wins)
+- Verdict: BEATS if Edge > 0 and significant across seeds; INCONCLUSIVE otherwise
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/train_tft.py` | TFT model + walk-forward training pipeline |
+| `scripts/results/m9_tft_*.json` | Results per config |
+| `outputs/tft_m9_*/results.json` | Detailed per-run results |
+| `docs/M9_TFT_VOL.md` | This document |
+
+## Results
+
+### BTC-USD
+
+| Horizon | Seeds | Folds | DirAcc | Edge | MSE | Verdict |
+|---------|-------|-------|--------|------|-----|---------|
+| h=1 | 4 | 4 | 0.4963 | -0.0304 | 0.018462 | INCONCLUSIVE |
+| h=5 | 4 | 4 | 0.5017 | -0.0250 | 0.016952 | INCONCLUSIVE |
+| h=10 | 4 | 4 | 0.4995 | -0.0279 | 0.019945 | INCONCLUSIVE |
+
+### ETH-USD
+
+| Horizon | Seeds | Folds | DirAcc | Edge | MSE | Verdict |
+|---------|-------|-------|--------|------|-----|---------|
+| h=1 | 4 | 4 | 0.4993 | -0.0284 | 0.003269 | INCONCLUSIVE |
+| h=5 | 4 | 4 | 0.5019 | -0.0248 | 0.004326 | INCONCLUSIVE |
+| h=10 | 4 | 4 | 0.4969 | -0.0299 | 0.004452 | INCONCLUSIVE |
+
+### Aggregate summary (6/6 configs)
+
+| Metric | Mean across configs | Range |
+|--------|---------------------|-------|
+| DirAcc | 0.4993 | 0.4963-0.5019 |
+| Edge | -0.0277 | -0.0304 to -0.0248 |
+| MSE | 0.011234 | 0.003269-0.019945 |
+
+**Overall verdict: 0/6 BEATS (INCONCLUSIVE across all 6 configs)**
+
+### Comparison with baselines
+
+| Model | Params | BEATS count | Best edge |
+|-------|--------|-------------|-----------|
+| M3b HAR asymmetric | 3-5 | 3/21 | +0.05 (BTC h=1) |
+| M4 DLinear | ~22 | 5/21 | -15% MSE (BTC h=1) |
+| M5 HMM regime | 8+HMM | 1/6 | +9.6% MSE (ETH h=1) |
+| **M9 TFT** | **~110K** | **0/6** | **-0.025 edge** |
+
+## Key findings
+
+1. **TFT fails to beat majority-class baseline.** Across all 6 configs (BTC h=1/5/10,
+   ETH h=1/5/10), the aggregate edge is consistently negative (-0.025 to -0.030). The 110K
+   param TFT model cannot reliably predict volatility direction better than always predicting
+   the majority class. Mean edge = -0.0277, mean DirAcc = 0.4993 (< 50%).
+
+2. **Fold 1 (smallest training set) is catastrophic.** With only ~700 training samples, TFT
+   overfits dramatically: edges range from -0.12 to -0.16. Later folds (3-4) with ~2800
+   samples sometimes achieve positive edge (+0.02 to +0.05), but not enough to compensate.
+
+3. **More data helps but not enough.** The trend from Fold 1 to Fold 4 is consistently
+   improving (e.g., BTC h=1 seed 0: -0.16 -> -0.04 -> -0.02 -> +0.03). However, even
+   with the maximum training window, TFT averages only ~50% direction accuracy.
+
+4. **TFT is strictly worse than DLinear.** DLinear (~22 params) achieved 5/21 BEATS with
+   15-38% MSE reduction vs HAR. TFT (~110K params, 5000x more parameters) achieves 0/6
+   BEATS and cannot even beat the majority-class baseline. This confirms the finding from
+   Zeng et al. (2023): transformers struggle on simple time series forecasting tasks.
+
+5. **No meaningful difference between horizons.** h=1, h=5, and h=10 all produce similar
+   negative edges (~-0.028). Unlike DLinear which improved with longer horizons, TFT shows
+   no horizon-dependent pattern.
+
+6. **Seed stability is moderate.** Standard deviation of edge across seeds is ~0.06, with
+   consistent negative mean. The verdict (INCONCLUSIVE) is stable across all seed choices.
+
+## References
+
+- Lim, B., Arik, S.O., Loeff, N. & Pfister, T. (2021) "Temporal Fusion Transformers for
+  Interpretable Multi-horizon Time Series Forecasting", International Journal of Forecasting
+  37(4), 1748-1764.
+- Zeng, A., Chen, M., Zhang, L. & Xu, Q. (2023) "Are Transformers Effective for Time Series
+  Forecasting?", AAAI 2023.
+- Corsi, F. (2009) "A Simple Approximate Long-Memory Model of Realized Volatility",
+  Journal of Financial Econometrics 7, 174-196.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M_NEXT_VOL_PROPOSAL.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/M_NEXT_VOL_PROPOSAL.md
@@ -1,0 +1,74 @@
+# M10 Proposal -- Realized GARCH for Crypto Volatility Forecasting
+
+**Status:** PROPOSED (Cycle 28 Track B)
+
+## Recommendation
+
+**Realized GARCH (Hansen, Huang, Shek 2012)** as M10, with Markov-Switching GARCH as fallback M11.
+
+## Why Realized GARCH
+
+The DM retroactif (Cycle 28 Track A) re-classified 60 combos with direction-aware testing:
+
+| Model | BEATS p<0.05 | Params | Key issue |
+|-------|-------------|--------|-----------|
+| M3 HAR classic | 12/21 | 4 | Strong baseline, but no GARCH dynamics |
+| M3b HAR asymmetric | 3/6 | 5 | Leverage effect BTC-specific only |
+| M4 DLinear | 6/21 | ~22 | Data-hungry, inconsistent cross-coin |
+| M5 HMM regime | 1/6 | 8+HMM | Two-step estimation causes BEATEN paradox at h>=5 |
+| M9 TFT | 0/6 | ~110K | Catastrophic overfit, no signal |
+
+The pattern is clear: **models that incorporate realized measures beat those that don't, but only when the parameter count stays low.** HAR classic (4 params, uses RV directly) is the strongest. TFT (110K params) fails completely. The sweet spot is 5-15 parameters using daily RV.
+
+Realized GARCH sits in this sweet spot. It extends GARCH(1,1) with a measurement equation linking latent conditional variance to observed RV:
+
+```
+GARCH:     h_t = omega + alpha * eps^2_{t-1} + beta * h_{t-1}
+Measure:   log(RV_t) = xi + phi * log(h_t) + tau(eps_t) + u_t
+Leverage:  tau(eps_t) = gamma_1 * eps_t + gamma_2 * (eps_t^2 - 1)
+```
+
+**7-9 parameters total.** Each has economic interpretation (no black box).
+
+## Why not the alternatives
+
+| Candidate | Rejected because |
+|-----------|-----------------|
+| HEAVY (Shephard 2010) | Same goal as Realized GARCH but harder to implement (bivariate MLE, no library). Same low param count (8-10) but 2x coding effort for marginal expected gain. |
+| GARCH-MIDAS (Engle 2013) | MIDAS component needs macro drivers (CPI, GDP). Crypto volatility has weak macro links. 8-15 params on ~100 monthly obs = unstable. |
+| MS-GARCH (Haas 2004) | Fixes M5's two-step flaw (joint Hamilton filter + GARCH MLE). Good theory but 11 params + complex optimization = 5-8h dev. Ranked as M11 fallback. |
+| GNN cross-asset | 2 assets (BTC+ETH) = trivial 2-node graph. No structure to learn. TFT already showed >100K params = catastrophic on this data. |
+
+## Expected results
+
+Based on Hansen et al. (2012) equities + Charles & Darne (2019) crypto:
+
+- **h=1:** 5-15% MSE reduction vs HAR classic. Realized measure + GARCH dynamics should improve on HAR's linear lag structure.
+- **h=5/10:** Modest or no improvement. GARCH dynamics dominate at longer horizons, converging to unconditional variance (same as HAR).
+- **BTC vs ETH:** BTC should benefit more (more data, stronger GARCH persistence). ETH ~1500 obs may be tight for MLE convergence.
+
+## Implementation plan
+
+- Fork `garch_rolling_baseline.py` (walk-forward refit every 22 days, gap=10)
+- Custom MLE via `scipy.optimize.minimize` (log-likelihood from Hansen 2012 eq. 7-8)
+- Daily RV from `realized_variance.py` as realized measure
+- Walk-forward expanding window, 4 seeds (0,1,7,42), BTC+ETH, h=1/5/10
+- DM test vs HAR classic baseline, direction-aware classification
+- Expected dev time: 2-3 hours. Runtime: ~10 min per config.
+
+## Benchmarks to beat
+
+| Benchmark | BTC h=1 | BTC h=5 | BTC h=10 | ETH h=1 | ETH h=5 | ETH h=10 |
+|-----------|---------|---------|----------|---------|---------|----------|
+| M3 HAR classic | BEATS_p005 | BEATS_p005 | INCONCLUSIVE | BEATS_p005 | BEATS_p005 | BEATS_p005 |
+| M3b HAR asym | BEATS_p005 | BEATS_p005 | BEATS_p005 | INCONCLUSIVE | INCONCLUSIVE | INCONCLUSIVE |
+| M4 DLinear | BEATS_p005 | BEATS_p005 | BEATS_p005 | BEATS_p005 | INCONCLUSIVE | INCONCLUSIVE |
+
+Realized GARCH must achieve BEATS_p005 on at least BTC h=1 (where HAR classic already beats GARCH) to be viable. If it fails, MS-GARCH (M11) is the fallback.
+
+## References
+
+- Hansen, P.R., Huang, Z. & Shek, H.H. (2012) "Realized GARCH: A Joint Model for Returns and Realized Measures of Volatility", Journal of Applied Econometrics 27(6), 877-906.
+- Charles, A. & Darne, O. (2019) "Volatility Estimators in Crypto Markets", Economics Bulletin 39(1), 144-152.
+- Shephard, N. & Sheppard, K. (2010) "Realising the Future: Forecasting with High-Frequency-Based Volatility (HEAVY) Models", Journal of Applied Econometrics 25(2), 197-231.
+- Haas, M., Mittnik, S. & Paolella, M.S. (2004) "A New Approach to Markov-Switching GARCH Models", Journal of Financial Econometrics 2(4), 493-530.

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test_retroactif.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test_retroactif.py
@@ -1,0 +1,453 @@
+"""
+DM Test Retroactif -- Cycle 28 Track A
+Re-classify all raw BEATS claims across M3/M3b/M4/M5/M9 using strict p-value thresholds.
+
+Methodology:
+- Per-combo: DM p-value < 0.05 => BEATS_p005, < 0.10 => BEATS_p010, else INCONCLUSIVE
+- Cross-seed sign-test: binomial test on N_beats/N_seeds
+- Aggregation by model and overall
+
+Usage:
+    python scripts/dm_test_retroactif.py
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from collections import defaultdict
+from scipy import stats
+
+BASE = Path(__file__).resolve().parent
+RESULTS = BASE / "results"
+OUTPUTS = BASE.parent / "outputs"
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def extract_m3_classic():
+    """M3 HAR classic vs GARCH/naive baselines."""
+    data = load_json(RESULTS / "m3_har_extended.json")
+    rows = []
+    for r in data["rows"]:
+        rows.append({
+            "model": "M3_HAR_classic",
+            "coin": r["coin"],
+            "horizon": r["horizon"],
+            "seed": "pooled",
+            "dm_stat": r["dm_stat"],
+            "dm_pvalue": r["dm_pvalue"],
+            "mse_model": r["har_mse_logrv"],
+            "mse_baseline": r.get("garch_rolling_mse_logrv", r.get("naive_30d_mse_logrv")),
+            "n_predictions": r["n_predictions"],
+            "baseline_type": "GARCH_rolling",
+        })
+    return rows
+
+
+def extract_m3b_asymmetric():
+    """M3b HAR asymmetric vs HAR classic."""
+    data = load_json(RESULTS / "m3_har_asymmetric.json")
+    rows = []
+    for r in data["rows"]:
+        if r.get("seed") == "aggregate":
+            continue
+        rows.append({
+            "model": "M3b_HAR_asymmetric",
+            "coin": r["coin"],
+            "horizon": r["horizon"],
+            "seed": r["seed"],
+            "dm_stat": r["dm_stat"],
+            "dm_pvalue": r["dm_pvalue"],
+            "mse_model": r["asym_mse_logrv"],
+            "mse_baseline": r["classic_mse_logrv"],
+            "n_predictions": r["n_predictions"],
+            "baseline_type": "HAR_classic",
+        })
+    return rows
+
+
+def extract_m4_dlinear():
+    """M4 DLinear vs HAR classic."""
+    data = load_json(RESULTS / "m4_dlinear_vol_full.json")
+    rows = []
+    for r in data["rows"]:
+        rows.append({
+            "model": "M4_DLinear",
+            "coin": r["coin"],
+            "horizon": r["horizon"],
+            "seed": r["seed"],
+            "dm_stat": r["dm_stat"],
+            "dm_pvalue": r["dm_pvalue"],
+            "mse_model": r["dlinear_mse_logrv"],
+            "mse_baseline": r["har_mse_logrv"],
+            "n_predictions": r["n_predictions"],
+            "baseline_type": "HAR_classic",
+        })
+    return rows
+
+
+def extract_m5_hmm():
+    """M5 HMM regime-switching vs HAR classic."""
+    data = load_json(RESULTS / "m5_hmm_regime.json")
+    rows = []
+    for r in data["results"]:
+        if r.get("seed") == "aggregate":
+            continue
+        rows.append({
+            "model": "M5_HMM_regime",
+            "coin": r["coin"],
+            "horizon": r["horizon"],
+            "seed": r["seed"],
+            "dm_stat": r["dm_statistic"],
+            "dm_pvalue": r["dm_p_value"],
+            "mse_model": r["regime_mse"],
+            "mse_baseline": r["classic_mse"],
+            "n_predictions": r["n_preds"],
+            "baseline_type": "HAR_classic",
+        })
+    return rows
+
+
+def extract_m9_tft():
+    """M9 TFT vs majority-class baseline (direction accuracy edge)."""
+    tft_dirs = sorted(OUTPUTS.glob("tft_m9_*/results.json"))
+    rows = []
+    for d in tft_dirs:
+        data = load_json(d)
+        config_name = d.parent.name  # e.g. tft_m9_btc_h1
+        # Skip non-standard dirs (e.g. tft_m9_test)
+        if config_name == "tft_m9_test" or "tft_m9_run" in config_name:
+            continue
+        # Extract coin and horizon from hyperparams if available
+        hp = data.get("hyperparams", {})
+        symbols = hp.get("symbols", [])
+        coin = symbols[0] if symbols else "BTC-USD"
+        horizon = hp.get("pred_len", 1)
+
+        for run in data["per_run"]:
+            edge = run["edge_over_majority"]
+            n_test = run["n_test"]
+            majority_acc = run["majority_class_baseline"]["majority_class_accuracy"]
+
+            # For direction accuracy, we compute a binomial test
+            # H0: p = majority_acc (model is random)
+            # H1: p > majority_acc (model beats baseline)
+            dir_acc = run["direction_accuracy_step1"]
+            n_correct = int(dir_acc * n_test)
+            binom_pvalue = stats.binomtest(n_correct, n_test, majority_acc, alternative="greater").pvalue
+
+            rows.append({
+                "model": "M9_TFT",
+                "coin": coin,
+                "horizon": horizon,
+                "seed": run["seed"],
+                "fold": run["fold_idx"],
+                "dm_stat": edge,
+                "dm_pvalue": binom_pvalue,
+                "mse_model": run["mse"],
+                "mse_baseline": None,
+                "n_predictions": n_test,
+                "baseline_type": "majority_class",
+                "edge": edge,
+                "dir_acc": dir_acc,
+            })
+    return rows
+
+
+def classify_combo(rows_for_combo):
+    """Classify a single (model, coin, horizon) combo across seeds/folds."""
+    # Separate rows by direction: model beats baseline vs baseline beats model
+    beats_pvalues = []
+    beaten_pvalues = []
+    for r in rows_for_combo:
+        if r["dm_pvalue"] is None:
+            continue
+        model = r["model"]
+        dm_stat = r["dm_stat"]
+        # For MSE-based tests: dm_stat < 0 means model has lower MSE (beats)
+        # For M9: edge > 0 means model beats majority
+        if model == "M9_TFT":
+            is_beat = r.get("edge", 0) > 0
+        else:
+            is_beat = dm_stat < 0
+
+        if is_beat:
+            beats_pvalues.append(r["dm_pvalue"])
+        else:
+            beaten_pvalues.append(r["dm_pvalue"])
+
+    all_pvalues = [r["dm_pvalue"] for r in rows_for_combo if r["dm_pvalue"] is not None]
+    if not all_pvalues:
+        return "INCONCLUSIVE", None, len(rows_for_combo)
+
+    mean_p = sum(all_pvalues) / len(all_pvalues)
+
+    # Check if model predominantly BEATEN by baseline
+    n_beaten = len(beaten_pvalues)
+    n_beats = len(beats_pvalues)
+    n_total = n_beats + n_beaten
+
+    # If more seeds show BEATEN than BEATS, classify as BEATEN
+    if n_beaten > n_beats:
+        beaten_mean_p = sum(beaten_pvalues) / len(beaten_pvalues) if beaten_pvalues else 1.0
+        if beaten_mean_p < 0.05:
+            return "BEATEN_p005", mean_p, len(rows_for_combo)
+        elif beaten_mean_p < 0.10:
+            return "BEATEN_p010", mean_p, len(rows_for_combo)
+        else:
+            return "INCONCLUSIVE", mean_p, len(rows_for_combo)
+
+    # Model predominantly beats baseline
+    beats_mean_p = sum(beats_pvalues) / len(beats_pvalues) if beats_pvalues else 1.0
+    if beats_mean_p < 0.05:
+        verdict = "BEATS_p005"
+    elif beats_mean_p < 0.10:
+        verdict = "BEATS_p010"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    return verdict, mean_p, len(rows_for_combo)
+
+
+def sign_test_across_seeds(rows_for_combo):
+    """Binomial sign-test: count how many seeds beat baseline."""
+    # For DM-style tests: negative dm_stat => model beats baseline
+    # For M9: positive edge => model beats baseline
+    n_beats = 0
+    n_total = 0
+    for r in rows_for_combo:
+        model = r["model"]
+        dm_stat = r["dm_stat"]
+        if model == "M9_TFT":
+            beats = r.get("edge", 0) > 0
+        else:
+            beats = dm_stat < 0 and r["dm_pvalue"] < 0.05
+        if beats:
+            n_beats += 1
+        n_total += 1
+
+    if n_total == 0:
+        return None, n_beats, n_total
+
+    # Binomial test: H0: p=0.5 (random), H1: p>0.5 (model wins more than chance)
+    binom_p = stats.binomtest(n_beats, n_total, 0.5, alternative="greater").pvalue
+    return binom_p, n_beats, n_total
+
+
+def main():
+    print("=" * 80)
+    print("DM TEST RETROACTIF -- Cycle 28 Track A")
+    print("Re-classification: BEATS p<0.05 / BEATS p<0.10 / INCONCLUSIVE")
+    print("=" * 80)
+
+    all_rows = []
+    all_rows.extend(extract_m3_classic())
+    all_rows.extend(extract_m3b_asymmetric())
+    all_rows.extend(extract_m4_dlinear())
+    all_rows.extend(extract_m5_hmm())
+    all_rows.extend(extract_m9_tft())
+
+    print(f"\nTotal raw rows loaded: {len(all_rows)}")
+
+    # Group by (model, coin, horizon)
+    combos = defaultdict(list)
+    for r in all_rows:
+        key = (r["model"], r["coin"], r["horizon"])
+        combos[key].append(r)
+
+    print(f"Unique combos: {len(combos)}")
+
+    # Re-classify each combo
+    results = []
+    model_summary = defaultdict(lambda: {
+        "p005": 0, "p010": 0, "beaten_p005": 0, "beaten_p010": 0, "inconclusive": 0, "total": 0
+    })
+
+    for (model, coin, horizon), rows in sorted(combos.items()):
+        verdict, mean_p, n_runs = classify_combo(rows)
+        sign_p, n_beats, n_seeds = sign_test_across_seeds(rows)
+
+        mse_model = [r["mse_model"] for r in rows if r["mse_model"] is not None]
+        mse_baseline = [r["mse_baseline"] for r in rows if r["mse_baseline"] is not None]
+        mean_mse_model = sum(mse_model) / len(mse_model) if mse_model else None
+        mean_mse_baseline = sum(mse_baseline) / len(mse_baseline) if mse_baseline else None
+        mse_reduction_pct = (
+            (1 - mean_mse_model / mean_mse_baseline) * 100
+            if mean_mse_model and mean_mse_baseline and mean_mse_baseline > 0
+            else None
+        )
+
+        result = {
+            "model": model,
+            "coin": coin,
+            "horizon": horizon,
+            "n_runs": n_runs,
+            "n_beats_seeds": n_beats,
+            "n_total_seeds": n_seeds,
+            "mean_dm_pvalue": round(mean_p, 6) if mean_p is not None else None,
+            "sign_test_pvalue": round(sign_p, 6) if sign_p is not None else None,
+            "mean_mse_model": round(mean_mse_model, 6) if mean_mse_model else None,
+            "mean_mse_baseline": round(mean_mse_baseline, 6) if mean_mse_baseline else None,
+            "mse_reduction_pct": round(mse_reduction_pct, 2) if mse_reduction_pct is not None else None,
+            "verdict_strict": verdict,
+        }
+        results.append(result)
+
+        model_summary[model]["total"] += 1
+        if verdict == "BEATS_p005":
+            model_summary[model]["p005"] += 1
+        elif verdict == "BEATS_p010":
+            model_summary[model]["p010"] += 1
+        elif verdict == "BEATEN_p005":
+            model_summary[model]["beaten_p005"] += 1
+        elif verdict == "BEATEN_p010":
+            model_summary[model]["beaten_p010"] += 1
+        else:
+            model_summary[model]["inconclusive"] += 1
+
+    # Print per-combo table
+    print(f"\n{'Model':<20} {'Coin':<8} {'h':<4} {'Runs':<5} {'Beats':<7} {'Mean p':<12} {'Sign p':<12} {'MSE red%':<10} {'Verdict'}")
+    print("-" * 110)
+    for r in results:
+        sign_p_str = f"{r['sign_test_pvalue']:.4f}" if r["sign_test_pvalue"] is not None else "N/A"
+        mean_p_str = f"{r['mean_dm_pvalue']:.6f}" if r["mean_dm_pvalue"] is not None else "N/A"
+        mse_str = f"{r['mse_reduction_pct']:.1f}" if r["mse_reduction_pct"] is not None else "N/A"
+        print(f"{r['model']:<20} {r['coin']:<8} {r['horizon']:<4} {r['n_runs']:<5} "
+              f"{r['n_beats_seeds']}/{r['n_total_seeds']:<5} {mean_p_str:<12} {sign_p_str:<12} "
+              f"{mse_str:<10} {r['verdict_strict']}")
+
+    # Print model summary
+    print("\n" + "=" * 80)
+    print("MODEL SUMMARY")
+    print("=" * 80)
+    total_p005 = 0
+    total_p010 = 0
+    total_beaten_p005 = 0
+    total_beaten_p010 = 0
+    total_inc = 0
+    total_all = 0
+    for model in ["M3_HAR_classic", "M3b_HAR_asymmetric", "M4_DLinear", "M5_HMM_regime", "M9_TFT"]:
+        s = model_summary.get(model, {"p005": 0, "p010": 0, "beaten_p005": 0, "beaten_p010": 0, "inconclusive": 0, "total": 0})
+        total_p005 += s["p005"]
+        total_p010 += s["p010"]
+        total_beaten_p005 += s["beaten_p005"]
+        total_beaten_p010 += s["beaten_p010"]
+        total_inc += s["inconclusive"]
+        total_all += s["total"]
+        print(f"  {model:<22} {s['total']} combos: "
+              f"BEATS p<0.05: {s['p005']}, BEATS p<0.10: {s['p010']}, "
+              f"BEATEN p<0.05: {s['beaten_p005']}, BEATEN p<0.10: {s['beaten_p010']}, "
+              f"INCONCLUSIVE: {s['inconclusive']}")
+
+    print(f"\n  {'TOTAL':<22} {total_all} combos: "
+          f"BEATS p<0.05: {total_p005}, BEATS p<0.10: {total_p010}, "
+          f"BEATEN p<0.05: {total_beaten_p005}, BEATEN p<0.10: {total_beaten_p010}, "
+          f"INCONCLUSIVE: {total_inc}")
+
+    # Edge population sign-test (across ALL combos)
+    n_beats_total = sum(1 for r in results if r["verdict_strict"] in ("BEATS_p005", "BEATS_p010"))
+    n_beaten_total = sum(1 for r in results if r["verdict_strict"] in ("BEATEN_p005", "BEATEN_p010"))
+    n_total_combos = len(results)
+    pop_sign_p = stats.binomtest(n_beats_total, n_total_combos, 0.5, alternative="greater").pvalue
+    print(f"\n  Population sign-test: {n_beats_total}/{n_total_combos} combos beat, p={pop_sign_p:.4f}")
+
+    # Save JSON output
+    output_path = RESULTS.parent / "results" / "dm_retroactif" / "dm_retroactif_results.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output = {
+        "experiment": "DM_RETROACTIF_Cycle28_TrackA",
+        "methodology": "Diebold-Mariano MSE-diff for M3/M3b/M4/M5, binomial dir-acc for M9. "
+                       "Re-classification: BEATS p<0.05, BEATS p<0.10, INCONCLUSIVE. "
+                       "Sign-test = binomial across seeds per combo.",
+        "per_combo": results,
+        "model_summary": {k: v for k, v in model_summary.items()},
+        "population_sign_test": {
+            "n_beats": n_beats_total,
+            "n_total": n_total_combos,
+            "p_value": round(pop_sign_p, 6),
+        },
+    }
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2, default=str)
+    print(f"\nResults saved to: {output_path}")
+
+    # Generate markdown table for docs
+    md_path = RESULTS.parent.parent / "docs" / "DM_RETROACTIF.md"
+    md_lines = [
+        "# DM Test Retroactif -- Cycle 28 Track A",
+        "",
+        "**Status:** COMPLETE",
+        "",
+        "## Methodology",
+        "",
+        "- Diebold-Mariano test on MSE loss differential (M3/M3b/M4/M5 vs HAR classic baseline)",
+        "- M9 TFT: binomial test on direction accuracy vs majority-class baseline",
+        "- Re-classification thresholds: BEATS p<0.05 (strict), BEATS p<0.10 (marginal), INCONCLUSIVE",
+        "- Cross-seed sign-test: binomial H0:p=0.5 on per-seed BEATS counts",
+        "",
+        "## Per-combo results",
+        "",
+        "| Model | Coin | h | Runs | Beats | Mean p | Sign-test p | MSE red% | Verdict |",
+        "|-------|------|---|------|-------|--------|-------------|----------|---------|",
+    ]
+    for r in results:
+        sign_p_str = f"{r['sign_test_pvalue']:.4f}" if r["sign_test_pvalue"] is not None else "N/A"
+        mean_p_str = f"{r['mean_dm_pvalue']:.6f}" if r["mean_dm_pvalue"] is not None else "N/A"
+        mse_str = f"{r['mse_reduction_pct']:.1f}%" if r["mse_reduction_pct"] is not None else "N/A"
+        md_lines.append(
+            f"| {r['model']} | {r['coin']} | {r['horizon']} | {r['n_runs']} | "
+            f"{r['n_beats_seeds']}/{r['n_total_seeds']} | {mean_p_str} | {sign_p_str} | "
+            f"{mse_str} | **{r['verdict_strict']}** |"
+        )
+
+    md_lines.extend([
+        "",
+        "## Model summary",
+        "",
+        "| Model | Combos | BEATS p<0.05 | BEATS p<0.10 | BEATEN p<0.05 | BEATEN p<0.10 | INCONCLUSIVE |",
+        "|-------|--------|-------------|-------------|---------------|--------------|-------------|",
+    ])
+    for model in ["M3_HAR_classic", "M3b_HAR_asymmetric", "M4_DLinear", "M5_HMM_regime", "M9_TFT"]:
+        s = model_summary.get(model, {"p005": 0, "p010": 0, "beaten_p005": 0, "beaten_p010": 0, "inconclusive": 0, "total": 0})
+        md_lines.append(f"| {model} | {s['total']} | {s['p005']} | {s['p010']} | {s['beaten_p005']} | {s['beaten_p010']} | {s['inconclusive']} |")
+
+    md_lines.extend([
+        f"| **TOTAL** | **{total_all}** | **{total_p005}** | **{total_p010}** | **{total_beaten_p005}** | **{total_beaten_p010}** | **{total_inc}** |",
+        "",
+        f"**Population sign-test:** {n_beats_total}/{n_total_combos} combos beat, "
+        f"{n_beaten_total}/{n_total_combos} beaten, p={pop_sign_p:.4f}",
+        "",
+        "## Key findings",
+        "",
+    ])
+
+    # Auto-generate key findings
+    finding_num = 1
+    if total_p005 > 0:
+        best_models = [m for m, s in model_summary.items() if s["p005"] > 0]
+        md_lines.append(f"{finding_num}. **Models with strict BEATS (p<0.05):** {', '.join(best_models)}")
+        finding_num += 1
+    if total_beaten_p005 > 0:
+        beaten_models = [m for m, s in model_summary.items() if s["beaten_p005"] > 0]
+        md_lines.append(f"{finding_num}. **Models significantly BEATEN by baseline (p<0.05):** {', '.join(beaten_models)}")
+        finding_num += 1
+    if total_p010 > 0:
+        marginal = [m for m, s in model_summary.items() if s["p010"] > 0 and s["p005"] == 0]
+        if marginal:
+            md_lines.append(f"{finding_num}. **Models with marginal BEATS (p<0.10 only):** {', '.join(marginal)}")
+            finding_num += 1
+    no_signal = [m for m, s in model_summary.items() if s["p005"] == 0 and s["p010"] == 0 and s["beaten_p005"] == 0 and s["beaten_p010"] == 0]
+    if no_signal:
+        md_lines.append(f"{finding_num}. **Models with NO significant signal (INCONCLUSIVE across all combos):** {', '.join(no_signal)}")
+
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(md_lines))
+    print(f"Markdown saved to: {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/hmm_regime_vol.py
@@ -1,0 +1,402 @@
+"""M5 -- HMM Regime-Switching HAR: Volatility Regime Detection + Conditional Forecasting.
+
+Fits a K-state Gaussian HMM on log-RV to identify volatility regimes, then
+uses regime-switching HAR: separate HAR coefficients per regime, with the
+current decoded regime selecting which model to use for prediction.
+
+Approach v2 (regime-switching):
+- K=2 Gaussian HMM on log-RV (low-vol vs high-vol regime)
+- Viterbi-decode the most likely regime at each time step
+- Fit separate HAR models for low-vol and high-vol regime days
+- At prediction time, use current decoded regime to select the HAR model
+- Walk-forward 5-fold expanding window, 4 seeds for HMM init
+- DM test vs classic (single) HAR
+
+Coins: BTC-USD (Bitstamp, ~2278 RV days) and ETH-USD (Binance, ~1495 RV days).
+Horizons: h=1, 5, 10 days. Seeds: 0, 7, 42, 99.
+
+References:
+- Hamilton (1989) "A New Approach to the Economic Analysis of Nonstationary
+  Time Series and the Business Cycle", Econometrica 57, 357-384.
+- Corsi (2009) "A Simple Approximate Long-Memory Model of Realized Volatility",
+  Journal of Financial Econometrics 7, 174-196.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from dm_test import dm_verdict
+from har_model import HARModel, _make_split_indices
+from intraday_loader import load_binance_eth, load_bitstamp_btc
+from realized_variance import daily_realized_variance, har_lag_features, realized_variance_to_log
+
+try:
+    from hmmlearn.hmm import GaussianHMM
+except ImportError:
+    sys.exit("hmmlearn not found. Install with: pip install hmmlearn")
+
+
+SEEDS = [0, 7, 42, 99]
+HORIZONS = [1, 5, 10]
+N_SPLITS = 5
+REFIT_EVERY = 22
+N_HMM_STATES = 2
+RESULTS_DIR = SCRIPTS_DIR / "results"
+
+
+def fit_hmm_regimes(log_rv_train: np.ndarray, seed: int) -> "GaussianHMM":
+    """Fit K-state GaussianHMM on log-RV. State 0 = low vol, state 1 = high vol."""
+    model = GaussianHMM(
+        n_components=N_HMM_STATES,
+        covariance_type="full",
+        n_iter=200,
+        tol=1e-4,
+        random_state=seed,
+    )
+    X = log_rv_train.reshape(-1, 1)
+    model.fit(X)
+    if model.means_[0, 0] > model.means_[1, 0]:
+        model.means_ = model.means_[::-1]
+        model.covars_ = model.covars_[::-1]
+        trans = model.transmat_.copy()
+        model.transmat_[0] = trans[1]
+        model.transmat_[1] = trans[0]
+        model.startprob_ = model.startprob_[::-1]
+    return model
+
+
+def decode_viterbi(model: "GaussianHMM", log_rv: np.ndarray) -> np.ndarray:
+    """Viterbi-decode most likely state sequence. Returns 0=low, 1=high."""
+    X = log_rv.reshape(-1, 1)
+    return model.predict(X)
+
+
+class RegimeSwitchingHAR:
+    """HAR with regime dummy and regime x RV interaction terms.
+
+    log RV_{t+h} = b0 + b_d*rv_d + b_w*rv_w + b_m*rv_m
+                 + g0 * I(regime=high)
+                 + g_d * rv_d * I(regime=high)
+                 + g_w * rv_w * I(regime=high)
+                 + g_m * rv_m * I(regime=high)
+                 + e
+
+    This allows different intercepts and slopes in each regime while
+    keeping the temporal structure intact.
+    """
+
+    def __init__(self) -> None:
+        self.coef_: np.ndarray | None = None
+
+    def fit(self, rv_train: pd.Series, regime_labels: np.ndarray) -> "RegimeSwitchingHAR":
+        feats = har_lag_features(rv_train).apply(realized_variance_to_log)
+        target = realized_variance_to_log(rv_train).rename("y")
+        # regime_labels is aligned to rv_train index
+        high_regime = pd.Series(regime_labels == 1, index=rv_train.index, dtype=float)
+        df = pd.concat([feats, high_regime.rename("R"), target], axis=1).dropna()
+        if len(df) < 30:
+            raise ValueError(f"RegimeSwitchingHAR needs >=30 obs, got {len(df)}")
+
+        rv_d = df["rv_d"].values
+        rv_w = df["rv_w"].values
+        rv_m = df["rv_m"].values
+        R = df["R"].values
+
+        # Features: [1, rv_d, rv_w, rv_m, R, rv_d*R, rv_w*R, rv_m*R]
+        X = np.column_stack([
+            np.ones(len(df)),
+            rv_d, rv_w, rv_m,
+            R,
+            rv_d * R, rv_w * R, rv_m * R,
+        ])
+        y = df["y"].values
+        coef, *_ = np.linalg.lstsq(X, y, rcond=None)
+        self.coef_ = coef
+        return self
+
+    def predict_h_step(
+        self, rv_history: pd.Series, horizon: int, regime_high: bool,
+    ) -> float:
+        if self.coef_ is None:
+            raise RuntimeError("predict before fit")
+        R = 1.0 if regime_high else 0.0
+        history = list(rv_history.astype(float).values)
+        forecasts: list[float] = []
+        for _ in range(horizon):
+            tail = pd.Series(history[-22:])
+            log_rv = np.log(tail.clip(lower=1e-12))
+            rv_d = float(log_rv.iloc[-1])
+            rv_w = float(log_rv.iloc[-5:].mean())
+            rv_m = float(log_rv.iloc[-22:].mean())
+            x = np.array([1.0, rv_d, rv_w, rv_m, R, rv_d * R, rv_w * R, rv_m * R])
+            log_pred = float(x @ self.coef_)
+            forecasts.append(log_pred)
+            history.append(float(np.exp(log_pred)))
+        return float(np.mean(forecasts))
+
+
+def walk_forward_regime_switching(
+    rv: pd.Series,
+    horizon: int,
+    seed: int,
+    n_splits: int = N_SPLITS,
+    refit_every: int = REFIT_EVERY,
+) -> dict:
+    """Walk-forward evaluation of regime-switching HAR vs classic HAR.
+
+    At each prediction step:
+    1. Decode the most likely regime from the HMM
+    2. Use the regime-specific HAR model to predict
+    3. Compare against a single classic HAR model
+    """
+    rv = rv.dropna().astype(float)
+    n = len(rv)
+    if n < 200:
+        raise ValueError(f"need >=200 daily obs, got {n}")
+
+    log_rv = np.log(rv.clip(lower=1e-12))
+    log_rv_arr = log_rv.values
+    splits = _make_split_indices(n, n_splits)
+
+    regime_preds: list[float] = []
+    classic_preds: list[float] = []
+    truths: list[float] = []
+    pred_dates: list[pd.Timestamp] = []
+
+    for fold_idx, (train_end, test_start, test_end) in enumerate(splits):
+        if train_end < 60:
+            continue
+
+        # Fit HMM on training data
+        hmm_model = fit_hmm_regimes(log_rv_arr[:train_end], seed=seed)
+
+        # Decode regimes for training data
+        train_labels = decode_viterbi(hmm_model, log_rv_arr[:train_end])
+
+        # Fit regime-switching HAR (interaction terms)
+        regime_model = RegimeSwitchingHAR().fit(rv.iloc[:train_end], train_labels)
+
+        # Classic HAR
+        classic_model = HARModel().fit(rv.iloc[:train_end])
+
+        # Decode regimes for the test window in advance (Viterbi on train+test)
+        # This is O(T) and done once per fold — much more efficient than per-step
+        test_labels = decode_viterbi(
+            hmm_model, log_rv_arr[:test_end],
+        )[test_start:test_end - horizon]
+
+        # Walk forward
+        history = list(rv.iloc[:test_start].values)
+        last_refit_idx = test_start
+
+        for step_j, i in enumerate(range(test_start, test_end - horizon)):
+            target_window = log_rv_arr[i:i + horizon].mean()
+            tail = pd.Series(history[-(22 + horizon):])
+
+            # Use the pre-decoded regime label for this test point
+            current_regime = int(test_labels[step_j])
+
+            # Regime-switching prediction: use interaction-term HAR
+            regime_pred = regime_model.predict_h_step(tail, horizon, regime_high=(current_regime == 1))
+            classic_pred = classic_model.predict_h_step(tail, horizon=horizon)
+
+            regime_preds.append(regime_pred)
+            classic_preds.append(classic_pred)
+            truths.append(float(target_window))
+            pred_dates.append(rv.index[i])
+
+            history.append(float(rv.iloc[i]))
+
+            # Periodic refit
+            if (i - test_start) % refit_every == 0 and i > test_start:
+                hmm_model = fit_hmm_regimes(log_rv_arr[:i], seed=seed)
+                expanded_labels = decode_viterbi(hmm_model, log_rv_arr[:i])
+
+                regime_model = RegimeSwitchingHAR().fit(rv.iloc[:i], expanded_labels)
+                classic_model = HARModel().fit(rv.iloc[:i])
+
+                # Re-decode remaining test labels from this point forward
+                remaining_labels = decode_viterbi(
+                    hmm_model, log_rv_arr[:test_end],
+                )[(i + 1):test_end - horizon]
+                # Patch test_labels from current position onward
+                test_labels_list = list(test_labels)
+                for k, lbl in enumerate(remaining_labels):
+                    if step_j + 1 + k < len(test_labels_list):
+                        test_labels_list[step_j + 1 + k] = int(lbl)
+                test_labels = np.array(test_labels_list)
+                last_refit_idx = i
+
+    regime_preds = np.asarray(regime_preds)
+    classic_preds = np.asarray(classic_preds)
+    truths_arr = np.asarray(truths)
+
+    regime_mse = float(np.mean((regime_preds - truths_arr) ** 2)) if len(truths_arr) else float("nan")
+    classic_mse = float(np.mean((classic_preds - truths_arr) ** 2)) if len(truths_arr) else float("nan")
+
+    regime_errors = regime_preds - truths_arr
+    classic_errors = classic_preds - truths_arr
+    dm = dm_verdict(regime_errors, classic_errors, horizon=horizon)
+
+    return {
+        "seed": seed,
+        "horizon": horizon,
+        "n_preds": len(truths_arr),
+        "regime_mse": regime_mse,
+        "classic_mse": classic_mse,
+        "mse_reduction_pct": (
+            (classic_mse - regime_mse) / classic_mse * 100
+            if classic_mse > 0 else 0.0
+        ),
+        "dm_statistic": dm["dm_statistic"],
+        "dm_p_value": dm["p_value"],
+        "dm_verdict": dm["verdict"],
+    }
+
+
+def load_panel() -> dict[str, pd.Series]:
+    """Load BTC and ETH daily RV series."""
+    panels: dict[str, pd.Series] = {}
+    try:
+        btc = load_bitstamp_btc()
+        ret_btc = np.log(btc.df["close"]).diff().dropna()
+        rv_btc = daily_realized_variance(ret_btc)
+        panels["BTC-USD"] = rv_btc
+        print(f"BTC-USD: {len(rv_btc)} RV days ({rv_btc.index[0].date()} to {rv_btc.index[-1].date()})")
+    except FileNotFoundError as e:
+        print(f"BTC data not found: {e}")
+
+    try:
+        eth = load_binance_eth()
+        ret_eth = np.log(eth.df["close"]).diff().dropna()
+        rv_eth = daily_realized_variance(ret_eth)
+        panels["ETH-USD"] = rv_eth
+        print(f"ETH-USD: {len(rv_eth)} RV days ({rv_eth.index[0].date()} to {rv_eth.index[-1].date()})")
+    except FileNotFoundError as e:
+        print(f"ETH data not found: {e}")
+
+    return panels
+
+
+def main() -> None:
+    print("=" * 70)
+    print("M5 -- HMM Regime-Switching HAR vs Classic HAR")
+    print(f"Seeds: {SEEDS}, Horizons: {HORIZONS}, HMM states: {N_HMM_STATES}")
+    print(f"Approach: regime-switching (separate HAR per decoded regime)")
+    print("=" * 70)
+
+    panels = load_panel()
+    if not panels:
+        sys.exit("No data loaded, aborting.")
+
+    t0 = time.time()
+    all_results: list[dict] = []
+
+    for coin, rv in panels.items():
+        print(f"\n{'=' * 50}")
+        print(f"  {coin}  ({len(rv)} RV days)")
+        print(f"{'=' * 50}")
+
+        # Quick HMM regime analysis on full data
+        log_rv_full = np.log(rv.clip(lower=1e-12)).values
+        hmm_full = fit_hmm_regimes(log_rv_full, seed=0)
+        labels_full = decode_viterbi(hmm_full, log_rv_full)
+        n_low = (labels_full == 0).sum()
+        n_high = (labels_full == 1).sum()
+        print(f"  HMM regime split (full data): low-vol={n_low} ({n_low/len(labels_full)*100:.0f}%), "
+              f"high-vol={n_high} ({n_high/len(labels_full)*100:.0f}%)")
+        print(f"  Low-vol mean log-RV: {log_rv_full[labels_full==0].mean():.4f}")
+        print(f"  High-vol mean log-RV: {log_rv_full[labels_full==1].mean():.4f}")
+
+        for horizon in HORIZONS:
+            print(f"\n  h={horizon}:")
+            seed_results = []
+            for seed in SEEDS:
+                t1 = time.time()
+                res = walk_forward_regime_switching(rv, horizon, seed)
+                elapsed = time.time() - t1
+                tag = "**" if "BEATS" in res["dm_verdict"] and "BEATEN" not in res["dm_verdict"] else "  "
+                print(
+                    f"    seed={seed:2d}: regime_mse={res['regime_mse']:.4f} "
+                    f"classic_mse={res['classic_mse']:.4f} "
+                    f"reduction={res['mse_reduction_pct']:+.1f}% "
+                    f"DM p={res['dm_p_value']:.4f} {tag}{res['dm_verdict']}{tag} "
+                    f"({elapsed:.1f}s)"
+                )
+                res["coin"] = coin
+                all_results.append(res)
+                seed_results.append(res)
+
+            n_beats = sum(1 for r in seed_results if "BEATS" in r["dm_verdict"] and "BEATEN" not in r["dm_verdict"])
+            mean_reduction = np.mean([r["mse_reduction_pct"] for r in seed_results])
+            mean_regime_mse = np.mean([r["regime_mse"] for r in seed_results])
+            mean_classic_mse = np.mean([r["classic_mse"] for r in seed_results])
+            agg_verdict = "BEATS" if n_beats == len(SEEDS) else "INCONCLUSIVE"
+            print(
+                f"    >> AGGREGATE: {n_beats}/{len(SEEDS)} seeds beat classic, "
+                f"mean reduction={mean_reduction:+.1f}%, "
+                f"verdict={agg_verdict}"
+            )
+            all_results.append({
+                "coin": coin, "horizon": horizon, "seed": "aggregate",
+                "n_beats_seeds": f"{n_beats}/{len(SEEDS)}",
+                "mean_regime_mse": float(mean_regime_mse),
+                "mean_classic_mse": float(mean_classic_mse),
+                "mean_reduction_pct": float(mean_reduction),
+                "aggregate_verdict": agg_verdict,
+            })
+
+    elapsed_total = time.time() - t0
+    print(f"\n{'=' * 70}")
+    print(f"Done in {elapsed_total:.0f}s ({elapsed_total / 60:.1f} min)")
+    print(f"{'=' * 70}")
+
+    RESULTS_DIR.mkdir(exist_ok=True)
+    out_path = RESULTS_DIR / "m5_hmm_regime.json"
+    with open(out_path, "w") as f:
+        json.dump({
+            "experiment": "M5_HMM_REGIME_SWITCHING_HAR",
+            "approach": "regime-switching: separate HAR per Viterbi-decoded regime",
+            "n_hmm_states": N_HMM_STATES,
+            "seeds": SEEDS,
+            "horizons": HORIZONS,
+            "n_splits": N_SPLITS,
+            "refit_every": REFIT_EVERY,
+            "elapsed_seconds": elapsed_total,
+            "results": all_results,
+        }, f, indent=2, default=str)
+    print(f"Results saved to {out_path}")
+
+    print("\n## M5 HMM Regime-Switching HAR Summary")
+    print("| Coin | h=1 | h=5 | h=10 |")
+    print("|------|-----|-----|------|")
+    for coin in panels:
+        row = f"| {coin} |"
+        for h in HORIZONS:
+            agg = next(
+                (r for r in all_results
+                 if r["coin"] == coin and r["horizon"] == h
+                 and r.get("seed") == "aggregate"),
+                None,
+            )
+            if agg:
+                v = agg["aggregate_verdict"]
+                red = agg["mean_reduction_pct"]
+                row += f" {v} ({red:+.1f}%) |"
+            else:
+                row += " -- |"
+        print(row)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Track A — DM test retroactif**: Direction-aware Diebold-Mariano re-classification of 60 combos across M3/M3b/M4/M5/M9 with strict p-value thresholds (p<0.05 BEATS_p005, p<0.10 BEATS_p010, INCONCLUSIVE). Includes cross-seed binomial sign-test and BEATEN detection for positive dm_stat.
- **Track B — M10 proposal**: Recommends Realized GARCH (Hansen 2012) as M10 with 7-9 params, custom MLE using daily RV. MS-GARCH as M11 fallback.

## Key findings (Track A)

| Model | BEATS p<0.05 | BEATEN p<0.05 | INCONCLUSIVE |
|-------|-------------|---------------|-------------|
| M3 HAR classic | 12/21 | 0/21 | 8/21 |
| M3b HAR asymmetric | 3/6 | 0/6 | 3/6 |
| M4 DLinear | 6/21 | 0/21 | 14/21 |
| M5 HMM regime | 1/6 | **3/6** | 2/6 |
| M9 TFT | 0/6 | 0/6 | 6/6 |

- **Population sign-test p=0.9538** — models do NOT significantly beat baselines across all 60 combos
- **M5 HMM paradox**: 3/6 combos BEATEN at h>=5 due to two-step Viterbi+OLS estimation
- **M3b BTC 3/21 raw → ALL 3 survive p<0.05** (BTC h=1/5/10)

## Files changed

| File | Role |
|------|------|
| `scripts/dm_test_retroactif.py` | DM test script (direction-aware classification, sign-test) |
| `docs/DM_RETROACTIF.md` | Full results documentation |
| `docs/M_NEXT_VOL_PROPOSAL.md` | M10 Realized GARCH proposal (1 page) |

## Test plan

- [x] Script runs end-to-end: `python scripts/dm_test_retroactif.py`
- [x] Direction-aware: M5 BEATEN combos correctly classified (dm_stat > 0 + p<0.05)
- [x] Output verified: 60 combos = 21+6+21+6+6, no duplicates
- [x] Proposal references correct benchmarks from Track A results

🤖 Generated with [Claude Code](https://claude.com/claude-code)