### PR TITLE
ci(h7): notebook-execution-required workflow (H.7 P3)

### DIFF
--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -1,0 +1,187 @@
+name: Notebook Execution Required
+
+# H.7 P3 — Block merge if notebooks lack execution evidence.
+# Validates that every modified .ipynb in a PR has:
+#   1. execution_count != null on all code cells (H.3)
+#   2. Zero cells with output_type: error (H.1)
+#   3. No banned patterns: raise NotImplementedError, assert False, 1/0 (C.1)
+#
+# Non-Python kernels (.NET, Lean, WSL) are checked for C.1 and error outputs
+# but execution_count is advisory only (cannot Papermill-execute in CI yet).
+# Full Papermill execution for Python notebooks is a separate job (Phase 2).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.ipynb'
+  workflow_dispatch:
+    inputs:
+      notebook_paths:
+        description: 'Space-separated notebook paths to validate'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    name: Detect notebook changes
+    runs-on: ubuntu-latest
+    outputs:
+      notebooks: ${{ steps.detect.outputs.notebooks }}
+      has_notebooks: ${{ steps.detect.outputs.has_notebooks }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed notebooks
+        id: detect
+        run: |
+          if [ -n "${{ github.event.inputs.notebook_paths }}" ]; then
+            # Manual dispatch with specific paths
+            NOTEBOOKS="${{ github.event.inputs.notebook_paths }}"
+          else
+            # PR: diff against base
+            NOTEBOOKS=$(git diff --name-only --diff-filter=ACM \
+              origin/${{ github.base_ref }} HEAD -- '*.ipynb' || true)
+          fi
+
+          # Filter out checkpoints, archives, _output
+          NOTEBOOKS=$(echo "$NOTEBOOKS" | grep -v '/.ipynb_checkpoints/' \
+            | grep -v '/archive/' | grep -v '/_output/' | grep -v '/research/' \
+            || true)
+
+          COUNT=$(echo "$NOTEBOOKS" | grep -c '\.ipynb$' || echo "0")
+          echo "notebooks=$NOTEBOOKS" >> "$GITHUB_OUTPUT"
+          echo "has_notebooks=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Detected $COUNT notebook(s) changed"
+
+  validate-static:
+    name: Static validation (H.1/H.3/C.1)
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_notebooks > 0
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install nbformat
+
+      - name: Validate notebooks
+        run: |
+          python scripts/notebook_tools/validate_pr_notebooks.py \
+            origin/${{ github.base_ref }} --json > /tmp/validation_results.json
+          cat /tmp/validation_results.json
+
+          PASSED=$(python -c "import json; print(json.load(open('/tmp/validation_results.json'))['passed'])")
+          if [ "$PASSED" != "True" ]; then
+            echo ""
+            echo "::error::Notebook validation failed. See results above."
+            echo "Fix: re-execute notebooks locally and commit with outputs."
+            echo "  python scripts/notebook_tools/notebook_tools.py execute <path>"
+            exit 1
+          fi
+          echo "All notebooks passed static validation."
+
+      - name: Post validation summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            try {
+              const results = JSON.parse(fs.readFileSync('/tmp/validation_results.json', 'utf8'));
+              const total = results.total_notebooks;
+              const cells = results.total_code_cells;
+              const failed = results.failed_count;
+              const status = results.passed ? 'PASS' : 'FAIL';
+
+              let body = `## Notebook PR Validation: ${status}\n\n`;
+              body += `- **Notebooks checked**: ${total}\n`;
+              body += `- **Code cells validated**: ${cells}\n`;
+              body += `- **Result**: ${failed > 0 ? failed + ' notebook(s) with violations' : 'All passed'}\n\n`;
+              body += `Checks: H.1 (no errors), H.3 (execution_count), C.1 (no banned patterns)\n`;
+              body += `Non-Python kernels (.NET/Lean): C.1 + errors only (execution_count advisory)\n\n`;
+
+              if (!results.passed) {
+                body += `### Violations\n\n`;
+                for (const nb of results.notebooks) {
+                  if (!nb.passed) {
+                    body += `**${nb.path}** (${nb.total_code} cells, ${nb.kernel})\n`;
+                    for (const err of nb.errors) {
+                      body += `- ${err}\n`;
+                    }
+                    body += `\n`;
+                  }
+                }
+                body += `\n### How to fix\n\n`;
+                body += `\`\`\`bash\n`;
+                body += `# Re-execute the notebook\n`;
+                body += `python scripts/notebook_tools/notebook_tools.py execute <path>\n`;
+                body += `\`\`\`\n`;
+              }
+
+              // Find existing comment or create new
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+              const botComment = comments.find(c =>
+                c.user.type === 'Bot' && c.body.includes('Notebook PR Validation:')
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: body,
+                });
+              }
+            } catch (e) {
+              console.log('Could not post validation summary:', e.message);
+            }
+
+  # Phase 2 (future): Papermill execution for Python notebooks
+  # Requires Docker compose with Python + .NET + Lean + WSL
+  # This is a placeholder — full implementation deferred to P4 (H.7)
+  execute-python:
+    name: Papermill execution (Python only)
+    runs-on: ubuntu-latest
+    needs: validate-static
+    if: false  # Disabled until Docker runner is ready
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Papermill
+        run: pip install papermill ipykernel
+
+      - name: Execute Python notebooks
+        run: |
+          echo "Phase 2: Papermill execution not yet implemented"
+          echo "Will use: python scripts/notebook_tools/notebook_tools.py execute"

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Validate notebooks changed in a PR for execution compliance (H.1 / H.3).
+
+Checks that every modified .ipynb in a PR has:
+1. All code cells with execution_count != null
+2. Zero cells with output_type: error
+3. No raise NotImplementedError / assert False / 1/0 (C.1)
+
+Designed for use in GitHub Actions as a merge gate.
+Also usable locally: python validate_pr_notebooks.py <base-branch> [paths...]
+
+Exit codes:
+    0 - All modified notebooks pass
+    1 - One or more notebooks fail validation
+    2 - Setup / runtime error
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Patterns banned by rule C.1
+C1_BANNED = ["raise NotImplementedError", "assert False", "1/0"]
+
+# Kernels that cannot be executed via Papermill in CI (skip execution check,
+# but still check C.1 and structural validity)
+SKIP_EXEC_KERNELS = {
+    ".net-csharp", ".net-fsharp", ".net-powershell",
+    "lean4", "lean4-wsl", "lean",
+}
+
+
+def get_changed_notebooks(base: str, paths: list[str] | None = None) -> list[Path]:
+    """Get list of .ipynb files changed relative to base branch."""
+    if paths:
+        return [Path(p) for p in paths if p.endswith(".ipynb") and Path(p).exists()]
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACM", base],
+            capture_output=True, text=True, check=True,
+            cwd=str(REPO_ROOT),
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: git diff failed: {e.stderr}", file=sys.stderr)
+        return []
+
+    notebooks = []
+    for line in result.stdout.strip().splitlines():
+        if line.endswith(".ipynb") and (REPO_ROOT / line).exists():
+            notebooks.append(REPO_ROOT / line)
+    return notebooks
+
+
+def get_kernel_name(nb_path: Path) -> str:
+    """Extract kernel name from notebook metadata."""
+    try:
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+        return (
+            data.get("metadata", {})
+            .get("kernelspec", {})
+            .get("name", "python3")
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "unknown"
+
+
+def validate_notebook(nb_path: Path) -> dict:
+    """Validate a single notebook for H.1/H.3 compliance.
+
+    Returns dict with: path, kernel, total_code, passed, errors (list).
+    """
+    try:
+        rel_path = str(nb_path.relative_to(REPO_ROOT))
+    except ValueError:
+        rel_path = str(nb_path)
+    result = {
+        "path": rel_path,
+        "kernel": get_kernel_name(nb_path),
+        "total_code": 0,
+        "passed": True,
+        "errors": [],
+    }
+
+    try:
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        result["passed"] = False
+        result["errors"].append(f"Cannot parse JSON: {e}")
+        return result
+
+    kernel = result["kernel"]
+    skip_exec = any(k in kernel for k in SKIP_EXEC_KERNELS)
+
+    for i, cell in enumerate(data.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+
+        source = "".join(cell.get("source", []))
+        if not source.strip():
+            continue
+
+        # Skip comment-only cells
+        lines = [l.strip() for l in source.split("\n") if l.strip()]
+        if all(l.startswith("#") for l in lines):
+            continue
+
+        result["total_code"] += 1
+
+        # C.1 check: banned patterns
+        for pattern in C1_BANNED:
+            if pattern in source:
+                result["passed"] = False
+                result["errors"].append(
+                    f"cell {i}: C.1 violation — '{pattern}' found"
+                )
+
+        # H.3 check: execution_count must not be null (skip for non-Papermill kernels)
+        if not skip_exec:
+            exec_count = cell.get("execution_count")
+            if exec_count is None:
+                result["passed"] = False
+                result["errors"].append(
+                    f"cell {i}: execution_count is null (H.3 violation)"
+                )
+
+        # H.1 check: no error outputs
+        for output in cell.get("outputs", []):
+            if output.get("output_type") == "error":
+                ename = output.get("ename", "Unknown")
+                result["passed"] = False
+                result["errors"].append(
+                    f"cell {i}: has error output — {ename}"
+                )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate notebooks changed in a PR (H.1/H.3/C.1)"
+    )
+    parser.add_argument(
+        "base", nargs="?", default="origin/main",
+        help="Base branch to diff against (default: origin/main)",
+    )
+    parser.add_argument(
+        "paths", nargs="*",
+        help="Specific paths to check (skips git diff)",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Output results as JSON",
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Also check execution_count for non-Python kernels",
+    )
+    args = parser.parse_args()
+
+    notebooks = get_changed_notebooks(args.base, args.paths)
+    if not notebooks:
+        if args.json:
+            print(json.dumps({"notebooks": [], "passed": True}))
+        else:
+            print("No notebooks changed in this PR.")
+        return 0
+
+    results = [validate_notebook(nb) for nb in notebooks]
+    failed = [r for r in results if not r["passed"]]
+    total_cells = sum(r["total_code"] for r in results)
+
+    if args.json:
+        print(json.dumps({
+            "notebooks": results,
+            "total_notebooks": len(results),
+            "total_code_cells": total_cells,
+            "passed": len(failed) == 0,
+            "failed_count": len(failed),
+        }, indent=2, ensure_ascii=False))
+        return 1 if failed else 0
+
+    # Human-readable report
+    print(f"Notebook PR Validation: {len(results) - len(failed)}/{len(results)} passed")
+    print(f"Total code cells checked: {total_cells}")
+    print()
+
+    for r in results:
+        status = "PASS" if r["passed"] else "FAIL"
+        kernel_tag = f" [{r['kernel']}]" if r["kernel"] != "python3" else ""
+        print(f"  {status} {r['path']} ({r['total_code']} cells){kernel_tag}")
+        for err in r["errors"]:
+            print(f"       {err}")
+
+    if failed:
+        print(f"\nFAILED: {len(failed)} notebook(s) with violations")
+        print("Fix: re-execute notebooks and commit with outputs, or fix C.1 violations")
+        return 1
+
+    print("\nAll notebooks passed validation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

H.7 P3 deliverable: GitHub Actions workflow that gates PRs touching `*.ipynb`.

- **Static validation (H.1/H.3/C.1)**: checks `execution_count != null`, zero error outputs, no banned patterns (`raise NotImplementedError`, `assert False`, `1/0`)
- **Kernel-aware**: skips `execution_count` check for non-Papermill kernels (.NET, Lean, WSL) — validates C.1 + error outputs only
- **PR comment**: posts structured validation summary with violation details and fix instructions
- **Phase 2 placeholder**: Papermill execution job for Python notebooks (disabled until Docker runner ready)

### Files

| File | Purpose |
|------|---------|
| `.github/workflows/notebook-execution-required.yml` | GitHub Actions workflow (3 jobs: detect-changes, validate-static, execute-python) |
| `scripts/notebook_tools/validate_pr_notebooks.py` | Validation script for local testing |

### Testing

- `validate_pr_notebooks.py` tested locally on 3 notebook types:
  - Python (GenAI Image): PASS (9 cells, all executed)
  - .NET (Sudoku C#): PASS (4 cells, execution_count skipped correctly)
  - QC research: FAIL (24 cells, 9 H.3 violations detected — correct behavior)
- YAML syntax validated via `pyyaml.safe_load`

### Design decisions

1. **Static-only for now**: Full Papermill execution requires Docker compose with .NET + Lean + WSL — deferred to P4
2. **Kernel-aware skipping**: .NET/Lean/WSL kernels cannot be Papermill-executed; C.1 and error checks still apply
3. **PR comment**: Replaces stale bot comments (finds existing by marker) instead of creating duplicates

## Test plan

- [ ] Merge a test PR touching a single Python notebook with valid outputs — workflow should PASS
- [ ] Merge a test PR touching a notebook with `execution_count: null` — workflow should FAIL and post violations
- [ ] Merge a test PR touching a .NET notebook — workflow should PASS (execution_count advisory only)
- [ ] Verify PR comment is posted with structured violation details

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>