### PR TITLE
feat(lean): Cycle 28 — strategy-proofness + Bondareva-Shapley hardness

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/BONDAREVA_SHAPLEY_HARDNESS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/BONDAREVA_SHAPLEY_HARDNESS.md
@@ -1,0 +1,120 @@
+# Bondareva-Shapley Backward: Hardness Investigation
+
+**Agent:** po-2025 | **Date:** 2026-05-12 | **Cycle:** 28 Track A
+
+## Verdict: PARTIALLY_PROUVABLE (reclassified from HONEST_UNPROVABLE)
+
+The `bondareva_shapley_backward` sorry at `Basic.lean:234` was classified as
+HONEST_UNPROVABLE because "LP duality / Farkas' lemma is missing in Mathlib."
+This assessment is **partially outdated**: Farkas' lemma IS available since 2025
+(Dillies/Yang). LP strong duality remains absent but is NOT required for the proof.
+
+## What changed in Mathlib
+
+The comment in `Basic.lean:221-224` claims Mathlib lacks:
+
+| Claimed missing | Actual status (Mathlib v4.28-rc1) |
+|-----------------|----------------------------------|
+| LP duality theorem | Still absent (TODO in Cone.Basic) |
+| Farkas' lemma usable on `Finset N -> R` | **Available** as `ProperCone.hyperplane_separation` |
+| `Polyhedral.cone_of_nonempty` | Still absent |
+
+**Key module:** `Mathlib.Analysis.Convex.Cone.Dual` (Copyright 2025 Yaël Dillies, Andrew Yang)
+
+Provides:
+- `ProperCone.dual` — dual cone with respect to a continuous perfect pairing
+- `ProperCone.hyperplane_separation` — Farkas' lemma (separate compact convex from proper cone)
+- `ProperCone.hyperplane_separation_point` — Point version of Farkas' lemma
+- `ProperCone.dual_dual_flip` — Double dual of proper cone = itself
+
+## Proof strategy (Farkas-based, no LP duality needed)
+
+The classical proof does NOT require LP strong duality. It only needs Farkas' lemma
+(theorem of alternatives):
+
+### Step 1: Formulate as feasibility
+
+Find `x : N -> R` satisfying:
+- `sum_{i in S} x i >= v(S)` for all nonempty `S : Finset N`
+- `sum_i x i <= v(N)`
+
+### Step 2: Apply Farkas' alternative theorem
+
+This system is feasible iff the alternative is infeasible:
+
+> For all `lambda_S >= 0` and `mu >= 0`:
+> if `sum_S lambda_S * 1_{i in S} = mu` for all `i`, then `sum_S lambda_S * v(S) <= mu * v(N)`
+
+### Step 3: Connect to balanced condition
+
+Setting `w_S = lambda_S / mu` (when `mu > 0`), the alternative becomes:
+> For all balanced weights `w`: `sum_S w_S * v(S) <= v(N)`
+
+This is EXACTLY the balanced condition of the game.
+
+### Step 4: Extract core membership
+
+From feasibility: `sum_i x i <= v(N)` and `sum_{i in N} x i >= v(N)`, so `sum_i x i = v(N)`.
+Combined with coalition constraints, `x` is in the Core.
+
+## Infrastructure gap: theorem of alternatives
+
+`ProperCone.hyperplane_separation` gives Farkas in **separation form**:
+```
+C : ProperCone R E, K compact convex, Disjoint K C =>
+  exists f : StrongDual R E, (forall x in C, 0 <= f x) /\ forall x in K, f x < 0
+```
+
+The proof needs Farkas in **alternatives form**:
+```
+Either {x | Ax >= b} has a solution, or {y >= 0 | A^T y = 0, y . b > 0} has a solution
+```
+
+Deriving alternatives from separation requires:
+1. Encode `{Ax >= b}` as the preimage of a proper cone under a linear map
+2. Show this preimage (or the associated cone) is proper (closed, pointed, convex)
+3. Apply `hyperplane_separation` to get the separating functional
+4. Translate back to the alternatives formulation
+
+**In finite dimensions** (`Fin n -> R`), all linear maps are continuous, all
+finite-dimensional subspaces are closed, so the "proper cone" conditions are
+automatic. Mathlib provides `LinearMap.continuous_of_finiteDimensional` and
+`Submodule.closed_of_finiteDimensional`.
+
+## Estimated work
+
+| Component | Lines | Difficulty | Mathlib support |
+|-----------|-------|------------|----------------|
+| Theorem of alternatives from separation | ~60-80 | HARD | hyperplane_separation + fd continuity |
+| Coalition constraint system as proper cone | ~30-50 | MEDIUM | ProperCone, finite-dimensional |
+| Balanced ↔ alternative equivalence | ~20-30 | MEDIUM | Finset algebra, balanced def |
+| Extract core membership | ~10-20 | EASY | Core definition, sum manipulation |
+| **Total** | **~150-200** | **MEDIUM-HARD** | |
+
+## Recommendations
+
+1. **Reclassify** `bondareva_shapley_backward` from HONEST_UNPROVABLE to
+   **WIP_HARD** (feasible, ~150-200 lines of preparatory lemmas)
+2. **Do NOT attempt now** — 150-200 lines of convex analysis infrastructure
+   is a multi-day effort, better suited for a focused sprint
+3. **Update FORMAL_STATUS.md** — change BLOCKED to WIP_HARD with the
+   Farkas-based strategy outlined here
+4. **Prerequisite:** verify `Fin N -> R` can be given `LocallyConvexSpace R`
+   and `IsContPerfPair` instances (likely yes via `Pi.topologicalSpace`)
+
+## Alternative: reduced game approach
+
+An inductive proof on `|N|` via reduced games avoids Farkas entirely but requires:
+- Defining the Davis-Maschler reduced game
+- Proving the reduced game inherits balancedness
+- More game-theory-specific infrastructure
+
+This is likely MORE work than the Farkas approach since Mathlib's convex
+analysis is already well-developed.
+
+## References
+
+- Dillies, Y., Yang, A. (2025). `Mathlib.Analysis.Convex.Cone.Dual`
+- Bondareva, O.N. (1963). "Some Applications of Linear Programming Methods
+  to the Theory of Cooperative Games"
+- Shapley, L.S. (1967). "On Balanced Sets and Cores"

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -7,7 +7,7 @@
 | Lean toolchain | `leanprover/lean4:v4.28.0-rc1` |
 | Mathlib | pinned via lake-manifest.json |
 | Total sorry | **3** (2 Basic + 1 Shapley) |
-| Honest unprovable (in Mathlib) | **1** (Basic.lean:234) |
+| Honest unprovable (in Mathlib) | **0** (Basic.lean:234 reclassified to WIP_HARD, see BONDAREVA_SHAPLEY_HARDNESS.md) |
 | Total lines | ~440 |
 | Total theorems | 11 |
 | Total definitions | 29 |
@@ -29,8 +29,11 @@ Key definitions: `Coalition`, `TUGame`, `Superadditive`, `Convex`, `marginalCont
 `unanimityGame`, `majorityGame`, `Allocation`, `Core`, `CoreEmpty`, `Balanced`.
 
 sorry locations (post-2026-05-12 BG iter 3 annotations):
-- Line 234: `bondareva_shapley_backward` — HONEST_UNPROVABLE in current Mathlib
-  (LP duality / Farkas' lemma missing). Registered in `prover/config.py` HONEST_SORRIES.
+- Line 234: `bondareva_shapley_backward` — **WIP_HARD** (reclassified from HONEST_UNPROVABLE).
+  Farkas' lemma IS available (ProperCone.hyperplane_separation, Dillies/Yang 2025).
+  LP strong duality NOT needed — proof uses theorem of alternatives from Farkas.
+  See `BONDAREVA_SHAPLEY_HARDNESS.md` for strategy (~150-200 lines infrastructure).
+
 - Line 262: `convex_core_nonempty` — WIP_HARD (~1-2 weeks Mathlib infrastructure).
 
 ### CooperativeGames/Shapley.lean — SHAPLEY VALUE
@@ -78,7 +81,7 @@ sorry locations:
 
 | Theorem | File | Line | Category | sorry | Statement |
 |---------|------|------|----------|-------|-----------|
-| `bondareva_shapley_backward` | Basic.lean | 234 | HONEST_UNPROVABLE | 1 | Balanced implies Core nonempty (needs LP duality) |
+| `bondareva_shapley_backward` | Basic.lean | 234 | WIP_HARD | 1 | Balanced implies Core nonempty (Farkas-based strategy in BONDAREVA_SHAPLEY_HARDNESS.md) |
 | `convex_core_nonempty` | Basic.lean | 262 | WIP_HARD | 1 | Convex games have nonempty Core |
 | `shapley_uniqueness` | Shapley.lean | 566 | WIP_HARD | 1 | Shapley value is unique solution satisfying axioms |
 
@@ -89,7 +92,7 @@ sorry locations:
 | Basic.lean | PARTIAL (2 sorry — 1 HONEST + 1 WIP) |
 | Shapley.lean | PARTIAL (1 sorry — WIP, Shapley uniqueness via Mobius) |
 
-**Project certification: PARTIAL** — 3 sorry remaining, of which 1 is documented HONEST_UNPROVABLE.
+**Project certification: PARTIAL** — 3 sorry remaining, all WIP_HARD (0 HONEST_UNPROVABLE after reclassification).
 
 ## Remaining Work
 
@@ -97,7 +100,7 @@ sorry locations:
 |----------|------|-------|----------|
 | HIGH | Complete `shapley_uniqueness` proof | 1 | WIP_HARD (DEMO 6/8) |
 | MEDIUM | Complete `convex_core_nonempty` proof | 1 | WIP_HARD (Route A: marginal vectors) |
-| BLOCKED | `bondareva_shapley_backward` | 1 | Awaits Mathlib LP duality / Farkas |
+| MEDIUM | `bondareva_shapley_backward` | 1 | WIP_HARD (Farkas available, ~150-200 lines prep) |
 | LOW | Upgrade toolchain to v4.29.1 | 0 | (follow social_choice_lean) |
 
 ## References
@@ -117,3 +120,4 @@ sorry locations:
 | 2026-04-30 | `shapley_unanimity` 2->1 sorry | PR #791 |
 | 2026-05-01 | `bondareva_shapley_forward` proved | PR #802 |
 | 2026-05-12 | BG iter 3: HONEST_UNPROVABLE annotation Basic.lean L234 (LP duality missing); FORMAL_STATUS realigned (7->3 sorry: stale doc) | (this PR) |
+| 2026-05-12 | Reclassified bondareva_shapley_backward: HONEST_UNPROVABLE -> WIP_HARD (Farkas available in Mathlib 2025); added BONDAREVA_SHAPLEY_HARDNESS.md | Cycle 28 Track A |

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/SocialChoice/Voting.lean
@@ -464,6 +464,40 @@ theorem median_voter_theorem (prof : ι → PrefOrder σ) (peaks : ι → σ)
     (fun i a b hpa hab => (hsp i).2.2 a b hpa hab)
     hodd
 
+/-! ## Strategy-Proofness under Single-Peaked Preferences -/
+
+/-- A voting rule f is strategy-proof on a set S if no voter can change the
+    outcome to one they strictly prefer by misreporting their preferences.
+    Here stated without Function.update to avoid DecidableEq ι:
+    for any truthful profile prof and deviating profile prof' that agrees
+    with prof everywhere except possibly at i, the deviant outcome is not
+    strictly preferred (under the true preferences) to the truthful outcome. -/
+def strategy_proof_scc (f : SCC ι σ) (S : Finset σ) : Prop :=
+  ∀ prof prof' i,
+    (∀ j, j ≠ i → prof' j = prof j) →
+    ¬ ∃ x y, x ∈ f prof' S ∧ y ∈ f prof S ∧ P (prof i).rel x y
+
+/-- Under strictly single-peaked preferences, no voter can strictly prefer
+    the median peak to their own peak. This is the core insight behind
+    strategy-proofness of the median rule: the peak is the unique top
+    element of the preference ordering, so nothing (including the median)
+    can be strictly preferred to it.
+
+    This lemma does NOT require an odd number of voters — it is purely
+    about the preference structure. -/
+theorem peak_not_strictly_preferred_to_median [Inhabited σ]
+    (prof : ι → PrefOrder σ)
+    (peaks : ι → σ)
+    (hsp : strictly_single_peaked_profile prof peaks)
+    (i : ι)
+    (hne : peaks i ≠ median_peak peaks) :
+    ¬ P (prof i).rel (median_peak peaks) (peaks i) := by
+  intro h
+  -- is_peak gives: ∀ x ≠ p, P R p x (peak strictly preferred to everything else)
+  -- So P (prof i).rel (peaks i) (median_peak peaks) with component .2 = ¬ R (median_peak) (peaks_i)
+  -- But h.1 gives R (median_peak) (peaks_i), contradiction.
+  exact (hsp i).1.1 (median_peak peaks) hne.symm |>.2 h.1
+
 end SinglePeaked
 
 section SplitCycle


### PR DESCRIPTION
## Summary

- **Track A**: Reclassify `bondareva_shapley_backward` from HONEST_UNPROVABLE to WIP_HARD. Farkas' lemma IS available in Mathlib (Dillies/Yang 2025, `ProperCone.hyperplane_separation`). LP strong duality NOT needed — proof uses theorem of alternatives. Added `BONDAREVA_SHAPLEY_HARDNESS.md` with detailed proof strategy (~150-200 lines infrastructure estimated).
- **Track B**: Add `strategy_proof_scc` definition and `peak_not_strictly_preferred_to_median` theorem to `Voting.lean` (SinglePeaked section). The theorem proves that under strictly single-peaked preferences, no voter can strictly prefer the median peak to their own peak — the core insight behind median rule strategy-proofness.

## Verification

- `lake build SocialChoice.Voting`: **SUCCESS** (0 errors)
- `grep -c sorry` across all social_choice_lean files: **0** (no new sorry)
- FORMAL_STATUS.md updated: 0 HONEST_UNPROVABLE (was 1), reclassified to WIP_HARD

## Files changed

| File | Change |
|------|--------|
| `cooperative_games_lean/BONDAREVA_SHAPLEY_HARDNESS.md` | New — hardness investigation memo with Farkas-based proof strategy |
| `cooperative_games_lean/FORMAL_STATUS.md` | Updated — reclassified bondareva_shapley_backward to WIP_HARD |
| `social_choice_lean/SocialChoice/Voting.lean` | +34 lines — `strategy_proof_scc` def + proved `peak_not_strictly_preferred_to_median` |

## Note

The proof was written manually (not via prover multi-agent). The theorem is immediate from the `is_peak` definition — the peak is the unique top element, so `¬ P R (median_peak) (peaks_i)` follows from `P R (peaks_i) (median_peak)` (asymmetry of strict preference).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>