### PR TITLE
docs(readme): add cross-series bridges to SemanticWeb and CaseStudies (#968)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -53,3 +53,42 @@ pip install -r requirements.txt
 ```
 
 Dependances principales : numpy, pandas, matplotlib, seaborn, z3-solver, pyro-ppl, ortools
+
+## Connections cross-series
+
+Les etudes de cas de cette serie sont des projets interdisciplinaires qui combinent les techniques de plusieurs series du cursus.
+
+### CaseStudies et Search (Recherche et CSP)
+
+Le **Diagnostic Medical** utilise directement les algorithmes de la serie Search :
+
+- **Recherche informee (A-star)** (Search Part 1) : le diagnostic medical est un probleme de recherche dans un espace d'etats (symptomes -> maladies). Les heuristiques A-star guident l'exploration.
+- **CSP et Z3** (Search Part 2) : la validation des diagnostics par contraintes (Z3) est une application directe de la programmation par contraintes. Les solveurs SAT/SMT de Search completent les algorithmes genetiques du CaseStudy.
+
+### CaseStudies et Probas (Inference Probabiliste)
+
+L'**Oncology Planning** utilise Pyro pour la programmation probabiliste :
+
+- **Inference bayesienne** (Probas notebooks 17-20) : le modele de jumeau numerique patient repose sur l'inference bayesienne pour estimer les parametres de reponse au traitement.
+- **Modeles probabilistes** (Probas avec Infer.NET) : les modeles generatifs Pyro sont les memes concepts que les modeles probabilistes de la serie Probas, appliques ici a un domaine medical.
+
+### CaseStudies et Planners (Planification)
+
+L'**Oncology Planning** integre OR-Tools pour la planification CSP :
+
+- **CP-SAT** (Planners-7) : la planification des protocoles de chimiotherapie est un probleme de scheduling sous contraintes (doses, delais, toxicite cumulee). OR-Tools CP-SAT, etudie dans Planners-7, est directement applique ici.
+- **Planification temporelle** (Planners-8) : les contraintes temporelles entre cycles de traitement correspondent aux modeles PDDL 2.1 de Planners-8.
+
+### CaseStudies et SemanticWeb (Web Semantique)
+
+L'**Oncology Planning** utilise une ontologie pour representer les connaissances medicales :
+
+- **Ontologies OWL** (SemanticWeb SW-4/5) : l'ontologie medicale du projet (medicaments, pathologies, interactions) est structuree en OWL/RDF, comme les ontologies etudiees dans la serie SemanticWeb.
+- **Raisonnement ontologique** : les inférences sur les contre-indications medicamenteuses utilisent les memes raisonneurs que la serie SemanticWeb.
+
+### CaseStudies et RL (Apprentissage par Renforcement)
+
+Le **Diagnostic Medical** avec algorithmes genetiques et le **jumeau numerique** patient anticipent les methodes RL :
+
+- **Optimisation par simulation** : le jumeau numerique patient (OncoPlan) est un environnement de simulation similaire aux environnements RL. L'adaptation du protocole pourrait etre formulee comme un probleme RL (etat patient, action traitement, recompense survie).
+- **Exploration vs exploitation** : les algorithmes genetiques du diagnostic medical echangent exploration (mutation) et exploitation (selection), comme en RL.

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -409,6 +409,40 @@ SemanticWeb/
 - [DBpedia](https://dbpedia.org/) - Donnees structurees de Wikipedia
 - [Wikidata](https://www.wikidata.org/) - Base de connaissances libre
 
+## Connections cross-series
+
+### SemanticWeb et Planners (Planification Automatique)
+
+Les graphes de connaissances RDF/OWL (SW-1 a SW-6) fournissent des representations riches du monde que les planificateurs PDDL (Planners-2 a Planners-9) peuvent exploiter :
+
+- **Ontologies OWL (SW-4/5) et domaines PDDL (Planners-6)** : les ontologies definissent les types et relations du domaine ; les fichiers PDDL definissent les actions et contraintes. Les deux formalisent la semantique d'un domaine pour le raisonnement automatique.
+- **SPARQL (SW-3) + planification** : les requetes SPARQL sur un graphe de connaissances peuvent generer les etats initiaux et buts d'un probleme de planification.
+- **GraphRAG (SW-12) + LLM Planning (Planners-10)** : le RAG base sur les graphes de connaissances ameliore la generation de plans par les LLMs en fournissant un contexte structure.
+
+### SemanticWeb et Tweety (Logique et Argumentation)
+
+Les logiques de description (OWL) et les logiques classiques (Tweety) partagent des fondements communs :
+
+- **OWL-DL (SW-4/5) et logique propositionnelle/FOL (Tweety-2/3)** : OWL-DL est une logique de description decidable, fragment de la logique du premier ordre. Les SAT solvers de Tweety completent les raisonneurs OWL (HermiT, Pellet).
+- **SHACL (SW-7) et validation** : les contraintes SHACL sur les graphes RDF sont analogues aux contraintes logiques de Tweety. Les deux approches valident la coherence de bases de connaissances.
+- **Raisonnement monotone (OWL) vs non-monotone (Tweety-6/7)** : les ontologies OWL font du raisonnement monotone (ajout de faits ne retracte rien) ; Tweety explore le raisonnement non-monotone (defeasible, priorite).
+
+### SemanticWeb et Lean (Verification Formelle)
+
+La verification de coherence des ontologies OWL est une forme de verification formelle :
+
+- **OWL consistency checking** : les raisonneurs OWL prouvent la coherence d'une ontologie, similaire aux preuves Lean de correction de programmes.
+- **SHACL shapes** : les shapes SHACL sont des invariants sur les donnees RDF, analogues aux types dependants Lean comme specifications.
+
+### SemanticWeb et SmartContracts
+
+Les smart contracts et le web semantique convergent dans les donnees decentralisees :
+
+- **Graphes de connaissances on-chain** : les NFTs ERC-721 (SC-7) avec metadonnees JSON-LD (SW-8) creent des graphes de connaissances decentraux. Les DID (Decentralized Identifiers) utilisent RDF pour l'identite auto-souveraine.
+- **Oracle data integration** : les oracles blockchain (SC-8 DeFi) peuvent servir de sources RDF pour enrichir les graphes de connaissances en temps reel.
+
+---
+
 ## Licence
 
 Voir la licence du repository principal.


### PR DESCRIPTION
## Summary
- Add 4 cross-series bridge sections to SymbolicAI/SemanticWeb/README.md (Planners, Tweety, Lean, SmartContracts)
- Add 5 cross-series bridge sections to CaseStudies/README.md (Search, Probas, Planners, SemanticWeb, RL)

## Details
Cross-series bridges explain how each series connects to others in the curriculum, helping students navigate interdisciplinary links.

### SemanticWeb bridges (4)
- **Planners**: OWL-DL reasoning ↔ planning domains, GraphRAG ↔ LLM planning
- **Tweety**: Description Logic ↔ FOL, ontological reasoning ↔ argumentation
- **Lean**: SHACL verification ↔ formal proofs, RDF ↔ Lean data structures
- **SmartContracts**: NFT ERC-721 ↔ JSON-LD, DID ↔ blockchain identity

### CaseStudies bridges (5)
- **Search**: Diagnostic Medical uses A* and CSP/Z3 directly from Search series
- **Probas**: Oncology Planning uses Pyro probabilistic programming (bayesian inference)
- **Planners**: Oncology Planning uses OR-Tools CP-SAT for scheduling constraints
- **SemanticWeb**: Oncology Planning uses OWL ontologies for medical knowledge
- **RL**: Digital twin patient as RL-like environment, genetic algorithms exploration/exploitation

## Test plan
- [x] READMEs render correctly (no MD037 lint warnings — avoided A* inside bold markers)
- [x] Bridges reference existing series and accurate notebook content
- [x] Consistent format with existing bridge sections (Tweety, RL, IIT)

Closes #968 (partial — covers SemanticWeb + CaseStudies READMEs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)