### PR TITLE
docs(lean): update FORMAL_STATUS after v4.30 bump + Bondareva proof

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/FORMAL_STATUS.md
@@ -4,15 +4,15 @@
 
 | Item | Value |
 |------|-------|
-| Lean toolchain | `leanprover/lean4:v4.28.0-rc1` |
+| Lean toolchain | `leanprover/lean4:v4.30.0-rc2` |
 | Mathlib | pinned via lake-manifest.json |
-| Total sorry | **3** (2 Basic + 1 Shapley) |
-| Honest unprovable (in Mathlib) | **0** (Basic.lean:234 reclassified to WIP_HARD, see BONDAREVA_SHAPLEY_HARDNESS.md) |
-| Total lines | ~440 |
-| Total theorems | 11 |
+| Total sorry | **1** (0 Basic + 1 Shapley) |
+| Honest unprovable (in Mathlib) | **0** |
+| Total lines | ~990 (Basic 387 + Shapley 603) |
+| Total theorems | 10 |
 | Total definitions | 29 |
 
-**Note**: Toolchain still on v4.28.0-rc1. Upgrade to v4.29.1 recommended (see social_choice_lean for precedent).
+**Note**: Toolchain bumped to v4.30.0-rc2 (PR #1015). Bondareva backward proved (PR #1020).
 
 ## Per-File Status
 
@@ -22,19 +22,15 @@
 |--------|-------|
 | Definitions | 12 |
 | Theorems | 4 |
-| sorry | **2** |
-| Status | FORMAL-PARTIAL |
+| sorry | **0** |
+| Status | FORMAL-COMPLETE |
 
 Key definitions: `Coalition`, `TUGame`, `Superadditive`, `Convex`, `marginalContribution`,
 `unanimityGame`, `majorityGame`, `Allocation`, `Core`, `CoreEmpty`, `Balanced`.
 
-sorry locations (post-2026-05-12 BG iter 3 annotations):
-- Line 234: `bondareva_shapley_backward` — **WIP_HARD** (reclassified from HONEST_UNPROVABLE).
-  Farkas' lemma IS available (ProperCone.hyperplane_separation, Dillies/Yang 2025).
-  LP strong duality NOT needed — proof uses theorem of alternatives from Farkas.
-  See `BONDAREVA_SHAPLEY_HARDNESS.md` for strategy (~150-200 lines infrastructure).
-
-- Line 262: `convex_core_nonempty` — WIP_HARD (~1-2 weeks Mathlib infrastructure).
+Previously-proved theorems (sorry resolved):
+- `bondareva_shapley_backward` (PR #1020, po-2026, 2026-05-13)
+- `convex_core_nonempty` (PR #981, Route A marginal vectors)
 
 ### CooperativeGames/Shapley.lean — SHAPLEY VALUE
 
@@ -57,7 +53,7 @@ Previously-proved theorems (sorry resolved):
 - `bondareva_shapley_forward` (PR #802)
 
 sorry locations:
-- Line 566: `shapley_uniqueness` — WIP_HARD (Mobius decomposition into unanimity games;
+- Line 570: `shapley_uniqueness` — WIP_HARD (Mobius decomposition into unanimity games;
   DEMO 6/8 in `prover/config.py` target this).
 
 ## Theorem Inventory
@@ -69,6 +65,8 @@ sorry locations:
 | `superadditive_empty_nonneg` | Basic.lean | v(empty) >= 0 (trivial) |
 | `superadditive_grand_coalition_nonneg_of_nonneg_singletons` | Basic.lean | Grand coalition value nonneg |
 | `bondareva_shapley_forward` | Basic.lean | Core nonempty implies balanced |
+| `bondareva_shapley_backward` | Basic.lean | Balanced implies Core nonempty (PR #1020) |
+| `convex_core_nonempty` | Basic.lean | Convex games have nonempty Core (PR #981) |
 | `shapley_efficient` | Shapley.lean | Shapley value is efficient |
 | `shapley_additive` | Shapley.lean | Shapley value is additive |
 | `shapley_null_player` | Shapley.lean | Shapley value = 0 for null players |
@@ -81,27 +79,22 @@ sorry locations:
 
 | Theorem | File | Line | Category | sorry | Statement |
 |---------|------|------|----------|-------|-----------|
-| `bondareva_shapley_backward` | Basic.lean | 234 | WIP_HARD | 1 | Balanced implies Core nonempty (Farkas-based strategy in BONDAREVA_SHAPLEY_HARDNESS.md) |
-| `convex_core_nonempty` | Basic.lean | 262 | WIP_HARD | 1 | Convex games have nonempty Core |
-| `shapley_uniqueness` | Shapley.lean | 566 | WIP_HARD | 1 | Shapley value is unique solution satisfying axioms |
+| `shapley_uniqueness` | Shapley.lean | 570 | WIP_HARD | 1 | Shapley value is unique solution satisfying axioms |
 
 ## Certification Level
 
 | File | Level |
 |------|-------|
-| Basic.lean | PARTIAL (2 sorry — 1 HONEST + 1 WIP) |
+| Basic.lean | COMPLETE (0 sorry) |
 | Shapley.lean | PARTIAL (1 sorry — WIP, Shapley uniqueness via Mobius) |
 
-**Project certification: PARTIAL** — 3 sorry remaining, all WIP_HARD (0 HONEST_UNPROVABLE after reclassification).
+**Project certification: PARTIAL** — 1 sorry remaining, WIP_HARD (0 HONEST_UNPROVABLE).
 
 ## Remaining Work
 
 | Priority | Task | sorry | Category |
 |----------|------|-------|----------|
 | HIGH | Complete `shapley_uniqueness` proof | 1 | WIP_HARD (DEMO 6/8) |
-| MEDIUM | Complete `convex_core_nonempty` proof | 1 | WIP_HARD (Route A: marginal vectors) |
-| MEDIUM | `bondareva_shapley_backward` | 1 | WIP_HARD (Farkas available, ~150-200 lines prep) |
-| LOW | Upgrade toolchain to v4.29.1 | 0 | (follow social_choice_lean) |
 
 ## References
 
@@ -119,5 +112,6 @@ sorry locations:
 | 2026-04-30 | `shapleyCoef_top` proved | PR #757 |
 | 2026-04-30 | `shapley_unanimity` 2->1 sorry | PR #791 |
 | 2026-05-01 | `bondareva_shapley_forward` proved | PR #802 |
-| 2026-05-12 | BG iter 3: HONEST_UNPROVABLE annotation Basic.lean L234 (LP duality missing); FORMAL_STATUS realigned (7->3 sorry: stale doc) | (this PR) |
 | 2026-05-12 | Reclassified bondareva_shapley_backward: HONEST_UNPROVABLE -> WIP_HARD (Farkas available in Mathlib 2025); added BONDAREVA_SHAPLEY_HARDNESS.md | Cycle 28 Track A |
+| 2026-05-13 | Toolchain bump to v4.30.0-rc2; `bondareva_shapley_backward` proved (0 sorry Basic.lean); `convex_core_nonempty` proved | PR #1015, #1020, #981 |
+| 2026-05-13 | FORMAL_STATUS realigned: 3->1 sorry, Basic COMPLETE | po-2025 |


### PR DESCRIPTION
## Summary
- Update FORMAL_STATUS.md to reflect post-PR #1015/#1020 reality
- Toolchain: v4.28.0-rc1 → v4.30.0-rc2
- Basic.lean: 2 sorry → 0 sorry (COMPLETE) — `bondareva_shapley_backward` proved by po-2026 (PR #1020), `convex_core_nonempty` proved (PR #981)
- Shapley.lean: 1 sorry (line 570, `shapley_uniqueness`) — unchanged
- Total sorry: 3 → 1

## Verification
- `grep -c sorry Basic.lean` = 0
- `grep -c sorry Shapley.lean` = 1 (line 570)
- Both toolchain files on main already show v4.30.0-rc2 (PR #1015 merged)

## Test plan
- [x] FORMAL_STATUS numbers match actual source code sorry counts
- [x] History section updated with PR references
- [x] No code changes — documentation only

Closes #996 (v4.30 bump task, all Lean work now merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)