### PR TITLE
fix(ci): notebook-execution-required multiline GHA output

### DIFF
--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -56,7 +56,9 @@ jobs:
             || true)
 
           COUNT=$(echo "$NOTEBOOKS" | grep -c '\.ipynb$' || echo "0")
-          echo "notebooks=$NOTEBOOKS" >> "$GITHUB_OUTPUT"
+          echo "notebooks<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTEBOOKS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
           echo "has_notebooks=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Detected $COUNT notebook(s) changed"
 


### PR DESCRIPTION
## Summary
- Fix GHA workflow `notebook-execution-required.yml` multiline output parsing
- When multiple notebooks were changed in a PR, the `$NOTEBOOKS` variable containing newlines was written as a single-line `$GITHUB_OUTPUT` value, causing `Invalid format` errors
- Fix: use heredoc delimiter syntax (`<<EOF`) for multiline GitHub Actions output

## Context
PR #1035 (batch 3 barbie-schreck fix) hit this CI failure:
```
Detected 3 notebook(s) changed
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb'
```

The notebooks were valid (43/43 cells, 0 errors) — only the workflow parsing broke.

## Sprint A batch 4 audit results

### Track 1: KernelArguments propagation
- Grep across all GenAI SK notebooks: **no other notebooks use `kernel.invoke(value=...)`**
- Bug is isolated to barbie-schreck only (already fixed in PR #1035)
- All other notebooks correctly use `KernelArguments`

### Track 2: 5-pattern audit (SK + CaseStudies)
| Pattern | Affected notebooks | Status |
|---------|-------------------|--------|
| `kernel.invoke(value=)` | barbie-schreck only | Fixed #1035 |
| `ChatMessageContent`/`AuthorRole` imports | Correct everywhere | OK |
| Empty chat history crash | Only barbie-schreck | Fixed #1035 |
| `msg.name` vs `msg.role` | Contextually correct | OK |
| cwd `.env` resolution | Only Createur mail | Fixed #1035 |

### Track 3: GenAI services health (po-2023)
| Service | Port | Status |
|---------|------|--------|
| Whisper STT | 8190 | UP |
| Kokoro TTS | 8191 | UP |
| MusicGen | 8192 | UP |
| Demucs | 8193 | UP |
| ComfyUI Video | 8189 | UP (401 auth) |
| Qwen Image Edit | 8188 | UP (401 auth) |
| Z-Image/Lumina | 8001 | UP |
| Qwen ASR | 8195 | UP |
| SD Forge Turbo | 17861 | UP |
| SD Forge | 7860 | DOWN (non-critical) |
| SD.Next | 7861 | DOWN (non-critical) |

Reverse proxy: whisper-api.myia.io, z-image.myia.io, stt.myia.io all UP with valid SSL.

## Test plan
- [x] Grep confirmed no other `kernel.invoke(value=)` across GenAI/
- [x] All 11 primary GenAI services health-checked (9 UP, 2 non-critical DOWN)
- [ ] CI workflow should pass on this PR (single notebook → no multiline issue)
- [ ] Next PR with multiple notebooks will validate the heredoc fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)