### PR TITLE
docs(lean): mark LINEARITY_REFACTOR_SPEC.md OBSOLETE post #1024

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/docs/LINEARITY_REFACTOR_SPEC.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/docs/LINEARITY_REFACTOR_SPEC.md
@@ -1,5 +1,9 @@
 # Linearity Axiom Refactor — Spec for prover BG multi-agent
 
+> **STATUS 2026-05-13 23:18 Paris (post PR #1024 merge `cf31ea49`)** : **OBSOLETE / SUPERSEDED**. `shapley_uniqueness` was proved on `feat/lean-mobius-shapley` (po-2026, commit `1eb5a4a0`) WITHOUT the Linearity refactor — `game_eq_mobius_sum` via `dif_pos + simp` on dependent if-then-else + `finsetSumGames` distribution proved sufficient with the existing binary `Additivity` axiom. Shapley.lean sorry count: 1 → 0. Lake build SUCCESS verified locally ai-01 (v5 full cache nuke + rebuild, 3319 jobs, EXIT=0, `Built CooperativeGames.Shapley (140s)`).
+>
+> The Linearity refactor remains **a valid optional cleanup** (matches Shapley 1953 / Roth 1988 axiomatic form more closely), but is no longer required for `shapley_uniqueness` provability. Keep as future-work spec if axiomatic foundations cleanup becomes a priority.
+
 **Date** : 2026-05-13
 **Author** : ai-01 (research side-track A, post user A.1 decision)
 **Target** : `cooperative_games_lean/CooperativeGames/Shapley.lean`


### PR DESCRIPTION
## Summary
- Add OBSOLETE/SUPERSEDED status header to LINEARITY_REFACTOR_SPEC.md
- shapley_uniqueness was proved on PR #1024 (commit 1eb5a4a0, merged as cf31ea49) WITHOUT requiring the Linearity refactor
- The Möbius decomposition path (`game_eq_mobius_sum` via `dif_pos + simp` + `finsetSumGames` distribution) worked with the existing binary Additivity axiom
- Spec retained as optional future-work for axiomatic cleanup (Shapley 1953 / Roth 1988 form), not blocker

## Verification — Lake build SUCCESS local ai-01
Method: full cache nuke + rebuild to bypass Lake's incremental replay
- Cache nuke: `rm -rf .lake/build/lib/lean/CooperativeGames* .lake/build/ir/CooperativeGames*`
- v5 build: `Built CooperativeGames.Basic (170s)` + `Built CooperativeGames.Shapley (140s)` + `Built CooperativeGames (170s)`
- `Build completed successfully (3319 jobs)`, EXIT=0
- Sorry warnings: ONLY `Basic.lean:222:8 declaration uses sorry` (= pre-existing `bondareva_shapley_backward apply?` WIP_HARD, NOT introduced by #1024)
- Shapley.lean: 0 sorry warnings, 0 `sorry` literal occurrences

## Test plan
- [x] grep -c sorry on Shapley.lean@cf31ea49 = 0
- [x] Lake build local SUCCESS (v5 force rebuild)
- [x] Spec file edit is text-only (no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)