### PR TITLE
feat(ml-training): M15 checkpoint-resume pattern

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
@@ -498,7 +498,20 @@ def main() -> None:
     results_dir.mkdir(parents=True, exist_ok=True)
     t0 = time.time()
 
+    checkpoint_path = results_dir / "checkpoint.jsonl"
     combos: list[dict] = []
+    completed_keys: set[tuple] = set()
+    if checkpoint_path.exists():
+        with open(checkpoint_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                combos.append(row)
+                completed_keys.add((row["coin"], row["horizon"], row["seed"]))
+        print(f"[CHECKPOINT] resumed {len(combos)} combos from {checkpoint_path.name}", flush=True)
+
     total = len(COINS) * len(HORIZONS) * len(SEEDS)
     done = 0
 
@@ -514,10 +527,16 @@ def main() -> None:
         for h in HORIZONS:
             for seed in SEEDS:
                 done += 1
+                key = (coin, h, seed)
+                if key in completed_keys:
+                    print(f"\n[{done}/{total}] {coin} h={h} seed={seed} -- SKIP (checkpoint)", flush=True)
+                    continue
                 print(f"\n[{done}/{total}] {coin} h={h} seed={seed}", flush=True)
                 row = evaluate_one_combo(coin, h, seed, hidden_size=hidden_size)
                 if row is not None:
                     combos.append(row)
+                    with open(checkpoint_path, "a") as f:
+                        f.write(json.dumps(row, default=str) + "\n")
                 else:
                     print(f"  SKIPPED (insufficient data)", flush=True)
 


### PR DESCRIPTION
## Summary

Adds checkpoint-resume mechanism to `m15_lstm_rv.py` — a reference implementation for issue #1053 (portage across ~25 ML sweeps).

## Pattern

1. **Startup**: read `results/m15_lstm_rv_h{N}/checkpoint.jsonl` if exists, build `completed_keys: set[tuple[str, int, int]]` from `(coin, horizon, seed)`
2. **Loop**: check `(coin, h, seed) in completed_keys` before training; print `SKIP (checkpoint)` if hit
3. **Per-combo**: append `{coin, h, seed, ...metrics}` to checkpoint.jsonl immediately after `evaluate_one_combo` success

## Test plan

- [x] Syntax validated via `ast.parse`
- [x] Resume tested in production: iter 6 BG killed by VSCode restart → restart with same args resumed 8/84 combos cleanly without redo
- [x] Currently running 9/84 (BTC-USD h=10 seed=0) post-resume — verified in `results/m15_lstm_rv_h128_resume2.log`

## Next steps

- Issue #1053 tracks portage of this pattern to M11-M14, SOTA family (TFT/Mamba/iTransformer/PatchTST/Transformer), train_moe.py, train_volatility_*, train_dqn_rl.py, etc.
- Bonus suggested in #1053: extract `scripts/notebook_helpers.py:CheckpointHelper` reusable across sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)