### PR TITLE
fix(Sudoku): remove solution leaks in Sudoku-1/3/7 (#362)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -6,10 +6,10 @@
    "metadata": {
     "id": "884e2b68",
     "papermill": {
-     "duration": 0.005089,
-     "end_time": "2026-04-25T14:45:38.095270",
+     "duration": 0.022417,
+     "end_time": "2026-05-14T07:29:04.090966+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.090181",
+     "start_time": "2026-05-14T07:29:04.068549+00:00",
      "status": "completed"
     },
     "tags": []
@@ -42,17 +42,17 @@
    "id": "de7f84be",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.104585Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.104248Z",
-     "iopub.status.idle": "2026-04-25T14:45:38.193517Z",
-     "shell.execute_reply": "2026-04-25T14:45:38.192741Z"
+     "iopub.execute_input": "2026-05-14T07:29:04.132638Z",
+     "iopub.status.busy": "2026-05-14T07:29:04.132202Z",
+     "iopub.status.idle": "2026-05-14T07:29:06.000098Z",
+     "shell.execute_reply": "2026-05-14T07:29:05.996391Z"
     },
     "id": "de7f84be",
     "papermill": {
-     "duration": 0.095961,
-     "end_time": "2026-04-25T14:45:38.195109",
+     "duration": 1.890368,
+     "end_time": "2026-05-14T07:29:06.003852+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.099148",
+     "start_time": "2026-05-14T07:29:04.113484+00:00",
      "status": "completed"
     },
     "tags": []
@@ -71,10 +71,10 @@
    "metadata": {
     "id": "t411Tak83P6I",
     "papermill": {
-     "duration": 0.006271,
-     "end_time": "2026-04-25T14:45:38.206774",
+     "duration": 0.010131,
+     "end_time": "2026-05-14T07:29:06.029424+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.200503",
+     "start_time": "2026-05-14T07:29:06.019293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -92,18 +92,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.219346Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.218735Z",
-     "iopub.status.idle": "2026-04-25T14:45:38.227999Z",
-     "shell.execute_reply": "2026-04-25T14:45:38.227467Z"
+     "iopub.execute_input": "2026-05-14T07:29:06.053616Z",
+     "iopub.status.busy": "2026-05-14T07:29:06.052826Z",
+     "iopub.status.idle": "2026-05-14T07:29:06.067828Z",
+     "shell.execute_reply": "2026-05-14T07:29:06.065796Z"
     },
     "id": "b6lzcu0r26e",
     "outputId": "6f83c74b-c9fb-4f82-9447-3b5ce28ac6e6",
     "papermill": {
-     "duration": 0.017076,
-     "end_time": "2026-04-25T14:45:38.229208",
+     "duration": 0.028754,
+     "end_time": "2026-05-14T07:29:06.069767+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.212132",
+     "start_time": "2026-05-14T07:29:06.041013+00:00",
      "status": "completed"
     },
     "tags": []
@@ -113,7 +113,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
+      "Dossier Puzzles: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
       "Fichiers disponibles: ['Sudoku_Easy51.txt', 'Sudoku_hardest.txt', 'Sudoku_top95.txt']\n"
      ]
     }
@@ -144,10 +144,10 @@
    "metadata": {
     "id": "6c6a8105",
     "papermill": {
-     "duration": 0.003106,
-     "end_time": "2026-04-25T14:45:38.244356",
+     "duration": 0.007493,
+     "end_time": "2026-05-14T07:29:06.084192+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.241250",
+     "start_time": "2026-05-14T07:29:06.076699+00:00",
      "status": "completed"
     },
     "tags": []
@@ -189,18 +189,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.253338Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.252932Z",
-     "iopub.status.idle": "2026-04-25T14:45:38.263632Z",
-     "shell.execute_reply": "2026-04-25T14:45:38.262972Z"
+     "iopub.execute_input": "2026-05-14T07:29:06.109898Z",
+     "iopub.status.busy": "2026-05-14T07:29:06.109381Z",
+     "iopub.status.idle": "2026-05-14T07:29:06.128480Z",
+     "shell.execute_reply": "2026-05-14T07:29:06.127218Z"
     },
     "id": "c2876acc",
     "outputId": "7e9774b6-1bb4-4f65-de55-03bf187bc7af",
     "papermill": {
-     "duration": 0.016772,
-     "end_time": "2026-04-25T14:45:38.264765",
+     "duration": 0.036432,
+     "end_time": "2026-05-14T07:29:06.129600+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.247993",
+     "start_time": "2026-05-14T07:29:06.093168+00:00",
      "status": "completed"
     },
     "tags": []
@@ -330,10 +330,10 @@
    "metadata": {
     "id": "bc8d94e8",
     "papermill": {
-     "duration": 0.00371,
-     "end_time": "2026-04-25T14:45:38.271951",
+     "duration": 0.004927,
+     "end_time": "2026-05-14T07:29:06.138913+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.268241",
+     "start_time": "2026-05-14T07:29:06.133986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -379,18 +379,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.280589Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.280012Z",
-     "iopub.status.idle": "2026-04-25T14:45:38.287471Z",
-     "shell.execute_reply": "2026-04-25T14:45:38.286802Z"
+     "iopub.execute_input": "2026-05-14T07:29:06.153376Z",
+     "iopub.status.busy": "2026-05-14T07:29:06.152934Z",
+     "iopub.status.idle": "2026-05-14T07:29:06.166937Z",
+     "shell.execute_reply": "2026-05-14T07:29:06.165644Z"
     },
     "id": "74da6893",
     "outputId": "29ba57ef-ed81-4d85-d364-05574db899e1",
     "papermill": {
-     "duration": 0.013185,
-     "end_time": "2026-04-25T14:45:38.288608",
+     "duration": 0.023541,
+     "end_time": "2026-05-14T07:29:06.168560+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.275423",
+     "start_time": "2026-05-14T07:29:06.145019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -415,7 +415,7 @@
       "\n",
       "Résolu: True\n",
       "Appels récursifs: 49\n",
-      "Temps: 0.31 ms\n",
+      "Temps: 0.45 ms\n",
       "\n",
       "Solution:\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
@@ -501,10 +501,10 @@
    "metadata": {
     "id": "gvgjjn1vllp",
     "papermill": {
-     "duration": 0.004046,
-     "end_time": "2026-04-25T14:45:38.297052",
+     "duration": 0.007051,
+     "end_time": "2026-05-14T07:29:06.185950+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.293006",
+     "start_time": "2026-05-14T07:29:06.178899+00:00",
      "status": "completed"
     },
     "tags": []
@@ -534,10 +534,10 @@
    "metadata": {
     "id": "939ee8ed",
     "papermill": {
-     "duration": 0.003857,
-     "end_time": "2026-04-25T14:45:38.304735",
+     "duration": 0.005038,
+     "end_time": "2026-05-14T07:29:06.197342+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.300878",
+     "start_time": "2026-05-14T07:29:06.192304+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,18 +572,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.314206Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.313782Z",
-     "iopub.status.idle": "2026-04-25T14:45:38.338038Z",
-     "shell.execute_reply": "2026-04-25T14:45:38.337313Z"
+     "iopub.execute_input": "2026-05-14T07:29:06.207907Z",
+     "iopub.status.busy": "2026-05-14T07:29:06.207630Z",
+     "iopub.status.idle": "2026-05-14T07:29:06.243155Z",
+     "shell.execute_reply": "2026-05-14T07:29:06.241813Z"
     },
     "id": "362d7226",
     "outputId": "83cdc465-0fac-48c4-ca35-f79d6fff09e5",
     "papermill": {
-     "duration": 0.03122,
-     "end_time": "2026-04-25T14:45:38.339697",
+     "duration": 0.042975,
+     "end_time": "2026-05-14T07:29:06.244511+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.308477",
+     "start_time": "2026-05-14T07:29:06.201536+00:00",
      "status": "completed"
     },
     "tags": []
@@ -634,10 +634,10 @@
    "metadata": {
     "id": "adb22aed",
     "papermill": {
-     "duration": 0.003423,
-     "end_time": "2026-04-25T14:45:38.347068",
+     "duration": 0.009363,
+     "end_time": "2026-05-14T07:29:06.262075+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.343645",
+     "start_time": "2026-05-14T07:29:06.252712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -672,10 +672,10 @@
    "metadata": {
     "id": "c8b16827",
     "papermill": {
-     "duration": 0.003729,
-     "end_time": "2026-04-25T14:45:38.354202",
+     "duration": 0.009997,
+     "end_time": "2026-05-14T07:29:06.279871+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.350473",
+     "start_time": "2026-05-14T07:29:06.269874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -708,18 +708,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:38.364560Z",
-     "iopub.status.busy": "2026-04-25T14:45:38.364054Z",
-     "iopub.status.idle": "2026-04-25T14:45:46.597322Z",
-     "shell.execute_reply": "2026-04-25T14:45:46.595967Z"
+     "iopub.execute_input": "2026-05-14T07:29:06.294187Z",
+     "iopub.status.busy": "2026-05-14T07:29:06.293802Z",
+     "iopub.status.idle": "2026-05-14T07:29:18.467255Z",
+     "shell.execute_reply": "2026-05-14T07:29:18.465469Z"
     },
     "id": "d6bd419d",
     "outputId": "01628dec-cde3-4c10-99b3-5b7c0e7d1f81",
     "papermill": {
-     "duration": 8.241021,
-     "end_time": "2026-04-25T14:45:46.599319",
+     "duration": 12.183067,
+     "end_time": "2026-05-14T07:29:18.469072+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:38.358298",
+     "start_time": "2026-05-14T07:29:06.286005+00:00",
      "status": "completed"
     },
     "tags": []
@@ -731,17 +731,17 @@
      "text": [
       "\n",
       "=== Benchmark: Puzzles Faciles (10 puzzles) ===\n",
-      "  Puzzle 1: OK, 36 vides, 49 appels, 0.25 ms\n",
-      "  Puzzle 2: OK, 49 vides, 201 appels, 1.05 ms\n",
-      "  Puzzle 3: OK, 51 vides, 295 appels, 1.44 ms\n"
+      "  Puzzle 1: OK, 36 vides, 49 appels, 0.73 ms\n",
+      "  Puzzle 2: OK, 49 vides, 201 appels, 1.37 ms\n",
+      "  Puzzle 3: OK, 51 vides, 295 appels, 2.27 ms\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 4: OK, 53 vides, 19023 appels, 106.86 ms\n",
-      "  Puzzle 5: OK, 51 vides, 1683 appels, 9.50 ms\n"
+      "  Puzzle 4: OK, 53 vides, 19023 appels, 169.04 ms\n",
+      "  Puzzle 5: OK, 51 vides, 1683 appels, 12.20 ms\n"
      ]
     },
     {
@@ -751,8 +751,8 @@
       "\n",
       "Résumé:\n",
       "  Résolus: 10/10\n",
-      "  Temps total: 1491.49 ms\n",
-      "  Temps moyen: 149.15 ms\n",
+      "  Temps total: 2245.68 ms\n",
+      "  Temps moyen: 224.57 ms\n",
       "  Appels totaux: 247760\n",
       "  Appels moyens: 24776\n",
       "\n",
@@ -763,29 +763,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK, 59 vides, 335638 appels, 2163.21 ms\n",
-      "  Puzzle 2: OK, 58 vides, 10008 appels, 55.66 ms\n"
+      "  Puzzle 1: OK, 59 vides, 335638 appels, 2787.00 ms\n",
+      "  Puzzle 2: OK, 58 vides, 10008 appels, 151.53 ms\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 3: OK, 55 vides, 228215 appels, 1297.08 ms\n"
+      "  Puzzle 3: OK, 55 vides, 228215 appels, 2420.16 ms\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 4: OK, 57 vides, 75446 appels, 452.50 ms\n"
+      "  Puzzle 4: OK, 57 vides, 75446 appels, 690.67 ms\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 5: OK, 59 vides, 207075 appels, 1479.09 ms\n"
+      "  Puzzle 5: OK, 59 vides, 207075 appels, 1987.61 ms\n"
      ]
     },
     {
@@ -795,8 +795,8 @@
       "\n",
       "Résumé:\n",
       "  Résolus: 11/11\n",
-      "  Temps total: 6730.64 ms\n",
-      "  Temps moyen: 611.88 ms\n",
+      "  Temps total: 9915.21 ms\n",
+      "  Temps moyen: 901.38 ms\n",
       "  Appels totaux: 1050007\n",
       "  Appels moyens: 95455\n"
      ]
@@ -847,10 +847,10 @@
    "metadata": {
     "id": "e1xke5h5g5i",
     "papermill": {
-     "duration": 0.004637,
-     "end_time": "2026-04-25T14:45:46.609185",
+     "duration": 0.004638,
+     "end_time": "2026-05-14T07:29:18.478772+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:46.604548",
+     "start_time": "2026-05-14T07:29:18.474134+00:00",
      "status": "completed"
     },
     "tags": []
@@ -881,10 +881,10 @@
    "metadata": {
     "id": "df19e441",
     "papermill": {
-     "duration": 0.005786,
-     "end_time": "2026-04-25T14:45:46.619326",
+     "duration": 0.005258,
+     "end_time": "2026-05-14T07:29:18.489729+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:46.613540",
+     "start_time": "2026-05-14T07:29:18.484471+00:00",
      "status": "completed"
     },
     "tags": []
@@ -938,18 +938,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:46.629129Z",
-     "iopub.status.busy": "2026-04-25T14:45:46.628614Z",
-     "iopub.status.idle": "2026-04-25T14:45:52.473243Z",
-     "shell.execute_reply": "2026-04-25T14:45:52.472371Z"
+     "iopub.execute_input": "2026-05-14T07:29:18.502785Z",
+     "iopub.status.busy": "2026-05-14T07:29:18.502538Z",
+     "iopub.status.idle": "2026-05-14T07:29:31.301253Z",
+     "shell.execute_reply": "2026-05-14T07:29:31.298406Z"
     },
     "id": "e6c30e55",
     "outputId": "c613c98d-bf67-4acb-f6cf-c32be1d9ceb0",
     "papermill": {
-     "duration": 5.851151,
-     "end_time": "2026-04-25T14:45:52.474424",
+     "duration": 12.809089,
+     "end_time": "2026-05-14T07:29:31.303091+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:46.623273",
+     "start_time": "2026-05-14T07:29:18.494002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -968,13 +968,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Simple: 335638 appels, 2185.69 ms\n",
-      "  MRV:    4037 appels, 325.57 ms\n",
+      "  Simple: 335638 appels, 6026.22 ms\n",
+      "  MRV:    4037 appels, 580.37 ms\n",
       "  Speedup: 83.1x\n",
       "\n",
-      "Puzzle difficile 2:\n",
-      "  Simple: 10008 appels, 53.54 ms\n",
-      "  MRV:    543 appels, 47.83 ms\n",
+      "Puzzle difficile 2:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Simple: 10008 appels, 288.45 ms\n",
+      "  MRV:    543 appels, 177.91 ms\n",
       "  Speedup: 18.4x\n",
       "\n",
       "Puzzle difficile 3:\n"
@@ -984,8 +990,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Simple: 228215 appels, 1291.77 ms\n",
-      "  MRV:    171 appels, 11.48 ms\n",
+      "  Simple: 228215 appels, 1797.50 ms\n",
+      "  MRV:    171 appels, 14.12 ms\n",
       "  Speedup: 1334.6x\n",
       "\n",
       "Puzzle difficile 4:\n"
@@ -995,8 +1001,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Simple: 75446 appels, 485.99 ms\n",
-      "  MRV:    1079 appels, 85.67 ms\n",
+      "  Simple: 75446 appels, 951.24 ms\n",
+      "  MRV:    1079 appels, 254.82 ms\n",
       "  Speedup: 69.9x\n",
       "\n",
       "Puzzle difficile 5:\n"
@@ -1006,8 +1012,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Simple: 207075 appels, 1338.72 ms\n",
-      "  MRV:    79 appels, 5.43 ms\n",
+      "  Simple: 207075 appels, 2675.39 ms\n",
+      "  MRV:    79 appels, 11.62 ms\n",
       "  Speedup: 2621.2x\n"
      ]
     }
@@ -1114,10 +1120,10 @@
    "metadata": {
     "id": "y355a2qsplr",
     "papermill": {
-     "duration": 0.004228,
-     "end_time": "2026-04-25T14:45:52.483343",
+     "duration": 0.009975,
+     "end_time": "2026-05-14T07:29:31.324116+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:52.479115",
+     "start_time": "2026-05-14T07:29:31.314141+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1160,10 @@
    "metadata": {
     "id": "4072c0bd",
     "papermill": {
-     "duration": 0.00419,
-     "end_time": "2026-04-25T14:45:52.491654",
+     "duration": 0.018214,
+     "end_time": "2026-05-14T07:29:31.354920+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:52.487464",
+     "start_time": "2026-05-14T07:29:31.336706+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,18 +1193,18 @@
      "height": 1000
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:52.510962Z",
-     "iopub.status.busy": "2026-04-25T14:45:52.510385Z",
-     "iopub.status.idle": "2026-04-25T14:45:53.972888Z",
-     "shell.execute_reply": "2026-04-25T14:45:53.971914Z"
+     "iopub.execute_input": "2026-05-14T07:29:31.416706Z",
+     "iopub.status.busy": "2026-05-14T07:29:31.415729Z",
+     "iopub.status.idle": "2026-05-14T07:29:35.356063Z",
+     "shell.execute_reply": "2026-05-14T07:29:35.354969Z"
     },
     "id": "7c13432e",
     "outputId": "0fff40bc-b35b-4aa0-ef8e-98e59074b18c",
     "papermill": {
-     "duration": 1.478593,
-     "end_time": "2026-04-25T14:45:53.974249",
+     "duration": 3.980792,
+     "end_time": "2026-05-14T07:29:35.356794+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:52.495656",
+     "start_time": "2026-05-14T07:29:31.376002+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1206,7 +1212,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAJOCAYAAACkx02ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAASB1JREFUeJzt3QmUTOe6//GnabTZMg9ljikHy3VoScxjEpw2XTFcYj5C5C4cich1TSuEE3EkJBzEHCzE0DkXRyNi1iHWvcYgx9hIci1DDG3q/q/nPf/u1VrLJZpd9ezvZ61aVamq8G61a9dvv+/zvjssMTExUQAAAAzI4HUDAAAA0gvBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQbAIytVqpS7BbPNmzdLWFiYjBo16pH/n5MnT7r/p3v37k/0dzdo0MD9OQC8Q7ABPJL0Y5ryljlzZilevLh07txZ/ud//kf8+O/xyiuv+DaUAXhy4enwZwB4AmXLlpUuXbq4x9euXZNdu3bJ4sWLZcWKFbJx40apXbu2100MKZGRkXL48GHJnz//I/8/xYoVc/9P7ty5n2rbADx9BBvAY88999wDwybDhw+XsWPHyn/8x3+4oRU8umzZsknFihUf6//JlCnTY/8/AIITQ1FAEHrrrbfc/bfffvtINSD6mtZ3JJk7d+4Dw1ypbyn/31+76Z/1f0lMTJTZs2e73qVcuXK5cFGjRg333JPSbdZ2nDhxQj755BMXQLJkySIlS5aU0aNHS0JCwq/W2CT92506dcrdUm5b6vek/vfdu3evDBgwQCpXrux6c7JmzSpVqlSR8ePHy507d5542wCkP3psgCD2WwtRq1WrJiNHjnzg+fPnz8uMGTPcD3SStN6npk2bJj/99JMLKf9XqPm3f/s3N3xWrlw5Vx+ktUIxMTHSq1cvOXTokEycOFGe1Ntvvy3ffPONtGzZUl5++WVZtWqVCya3b992vVsPkydPHreNkydPdv89cODA5NdShsG0zJw5U7766iupV6+eNG/eXG7cuOGC07Bhw1zo/PLLL594uwCks0QAnjhx4kSifgVffvnlB14bMWKEe61hw4b3vbdbt25p/ln6Wv369X/177t+/Xri73//+8SwsLDE5cuX/+p7x48f7/7MVq1aJd67dy/5+ZIlS7pbSjNmzHDv7dGjR+Lt27eTn79161biH/7wB/fanj17fvXv+7V/D91mfb506dKJ586dS37+559/TsyTJ09izpw53d+V5Ouvv3bvHzly5H1/TlptT/13p/73PXXqVOLdu3fvey4hISGxZ8+e7v3btm277zX9DDisAt5iKArw2PHjx13Pg960V0J7B8aMGSMRERG/2hPxOHS4RguUdWhl3Lhx0q5du4e+V4uWtUeievXq8sUXX0iGDL9+mJg6dapkz55dPv30U1erkkR7bZLar705T+o///M/pUiRIsn/rcXBrVq1kl9++UW+//57eRpKlCghGTNmfKAX7c0333SPN2zY8FT+XgC/HUNRgMd++OEHVyuiNBgUKlTIDee8++67rp4jPQwdOlRWrlzpakj0z32YPXv2SNeuXaVo0aJuCEYDy6/RoZn9+/e790+YMOGB15PqUI4cOfLE2/D73//+gecCgYC7v3z5sjwNOsylwW3JkiVuG3TW2j87yP7p3LlzT+XvBfDbEWwAj2m9yLp1657anz9r1ixX46L1JFpf8zBnzpyRP/zhD65HQkONhpX/y6VLl9wPfVxcXHI4S8v169flSWlRcmrh4f88hN27d0+ehn/91391/xbly5eXDh06SMGCBV341CD18ccfy61bt57K3wvgtyPYACEgaTjo7t27D7x25cqVh/5/ug5Ov3793A+zFrqmHCpKSYdztChXi4W1Z+df/uVfHitsaG+K9vZYosXBGmo0eP7Xf/3XfUNSutaQBhsAwYcaGyAE6MwepT0jqe3bty/N/0cXnNMeBw0ff/vb3yRv3rxpvk97Ozp27OhWOv7www8lKirqkduVM2dOqVSpkvu7ntZwUHrRYPI4PTs6RKhatGjxQJ3N1q1b0719ANIHwQYIARpOKlSoINu2bXPFxil7WrTQN7Wff/7Z9cBoDYwWA+s07IfR6c9r1qyRP/7xjzJ48ODHbtu///u/u7+nT58+aQ456fozuk6M1zTY/e///q/Ex8c/0vt1nRyl/+YpHTx4UD744IOn0kYAT46hKCBE/OlPf3Lh48UXX5T27du7mU5r166VmjVrPvBeXbflH//4h1sk7+uvv3a31HQWVmxsrCuO1XVtChQokOaFI1u3bu3WxXmYvn37uqGZefPmyfbt26VJkyauPufHH390Bbe7d++WRYsWeX6dpkaNGrnhsldffVXq1q3rZm3pDDS9PezSDHpbunSpW//nhRdekNOnT0t0dLTrxVm+fPkz3wYA/zeCDRAitEdEZxnpQnNaEKxTn3WWk15+QX+kU9IeFKU/5A+rfdEQk/S+mzdvPnRquQaSXws2SasT6wJ2uqCdDnvp7CEttNWeIi1c1rDjNZ0ursXO2j4dStJhKQ2ADws2Ovyk79VZZFrcrTU3Sduj4YhgAwSnMF3MxutGAAAApAdqbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAAD4b4E+XYQLAADAK4+y9F74415hWFc79YuLFy9Kvnz5xC/8tr26TL5eloD92j4/bTP7tX/4bZvPnz//SO97rGCjX5KzZ8+KX+hVjvW6MH7ht+0NBALuatns1/b5aZvZr/3Db9scCAQe6X3U2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwI+iCTUJCgkydOlWqV68u2bJlk1y5ckm9evUkOjra66YhncTFxcnkyZOlWbNmUqJECcmcObMULlxY2rVrJ7t37/a6ecBvVqpUKQkLC0vz1qBBA/GLCRMmJG/3rl27vG4OnlB8fLwMHjzY/RYXLVpUIiIi3DG7du3aMmfOHLlz544Ek3AJIomJifLaa6/Jl19+KWXLlpVevXrJrVu3ZPXq1dKqVSuZMmWKDBgwwOtm4gnp56gHPv2MNdwUKFBAjh07JqtWrXK3RYsWSYcOHbxuJvCb5M6dWwYOHJhm6PGDAwcOyMiRIyV79uxy/fp1r5uDdHDt2jWZNm2aREZGSosWLdwx+9KlS7J27Vrp2bOnLFmyxD3OkCE4+kqCKthooNGbpsCYmBjJmjWre37cuHFSo0YNGTJkiLRs2dI3Bwir9MuxefNmqV+//n3Pb926VRo3biz9+vWT1q1bS5YsWTxrI/Bb5cmTR0aNGiV+pGfu3bp1k2rVqkm5cuVk4cKFXjcJ6SBv3rxy5coV17ue0t27d6Vp06ayfv16F2w09ASD4IhX/5/2zKj33nsvOdSo/Pnzy6BBg1zvjXZ7IbS1bdv2gVCj6tatKw0bNnRnAvv37/ekbQB+u7Fjx8rBgwdl9uzZkjFjRq+bg3SiPTGpQ40KDw+XNm3auMfHjx+XYBFUPTYXLlxw96VLl37gtaTnNm3aJKNHj37mbcOzkSlTpuQvDBCK9ARs7ty5cu7cOVcjWLNmTalVq5ZY991337lgM2bMGHn++ee9bg6eUU3sunXr3OPKlStLsAiqXw/tmVEnTpyQSpUq3feaPqeOHj3qSdvw9J0+fVo2bNggRYoUkSpVqnjdHOA3n6D16NHjvuc03CxevNjVlVkNc6+//robgnrnnXe8bg6ektu3b7vSEK2HvXjxomzcuFGOHDni9nctIwgWQRVsXn31VVeENH78eGnUqJGrvFb6D6izaNTly5c9biWe1th8165d3QFSC4vpxkYo0gO8Dqnq2WuOHDncidikSZNkwYIF7sCvQ6w5c+YUa0aMGOEmAOzdu5fvrvFgMzrFiInOetPa1w8++ECCSVAFm86dO7su3K+//tqdsb/yyivuB09nyhQqVMi9J1iqrpG+3Zndu3eXLVu2SJ8+fVzAAUKRzgZKSXsw5s+f7x5ruJk5c6abNmvJzp07ZeLEia5gOpiGI5D+NKxrb40es3Wo9auvvnI1sboPrFmzxg29BoOgSglaV6GV1foF0QAzY8YMWbFihZvqvXz5cveeggULet1MpCP9guh0QZ3i3aVLF5k+fbrXTQLSXd++fd399u3bxRKdFaOzoKpWrSrvvvuu183BM5IhQwYJBAJuBqv+Tut+rfVVwSKoemyUTvHVs57UZz46PVjptG/YCTXada9ntJ06dXK9dfTIwaKk+kFr67ro+iY6BKXSmjWjXnzxRXe/cuVKt4wDbGnWrNl9v9HBIOiCzcN88cUX7r5jx45eNwXpHGp0MT7tpmdsHlYlrahtbQ0uPRHVhVTTokPLGnqioqLcgm7Wth3/pENSKWe0BoOgCzZXr159YJxOh6F0XQSdWaBroMDG8JOGmvbt27tFvAg1CHU6O0QvEaKXgkn9/NChQ5PrCC3R9cZmzZqV5mtaN6fBZtiwYfLCCy8887Yh/Rw6dMgF09T79o0bN5Jrxpo3by7BIuiCja73ULx4cTfdW2dFxcbGui6uMmXKyLJly/gBNEDXuZg3b54rRCtfvry8//77D7xHu6y18BIIFTqjU2dA6fV0SpYs6S4poLOitKhSJ0HoD7y+BoSapUuXun27Tp06LuBo54Ne809rYnXWss4E1EV0g0XQBRsdltCCYb1wmh4MdGG+4cOHy9tvvx00Fdd4MidPnkwen39YwZl+eQg2CCW6avbhw4dl37597vIgejartTV6Jtu/f//kWgQg1LRs2dINOe3YscPNgNJjt14TTYvGtTxEe+CDaVHV4GnJ/6czovx6nRW/0CJhvQGW6GVC0rpUiF/xPbejRo0aITVxhykoAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAM8ISExMTH+mNYWESEREhTZs2Fb+IjY2VyMhI8Qu/bW9MTIzEx8ezX/uAn7aZ/do//LbNMTExcvPmzfQNNsWKFZOzZ8+KX0RFRUl0dLT4hd+2NxAISFxcHPu1D/hpm9mv/cNv2xwIBB5pn2YoCgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGBG0AWbhQsXSt++faVGjRqSJUsWCQsLk7lz53rdLABPYOXKldK0aVPJly+fRERESOnSpaVTp05y5swZsSI+Pl4GDx4s9erVk6JFi7rtLFy4sNSuXVvmzJkjd+7c8bqJSAdxcXEyefJkadasmZQoUUIyZ87sPud27drJ7t27xapSpUq53+O0bg0aNJBgEi5BZvjw4XLq1CnJnz+/FClSxD0GEJoSExPljTfekBkzZkjZsmWlY8eOkjNnTjl37px888037vtdvHhxseDatWsybdo0iYyMlBYtWkiBAgXk0qVLsnbtWunZs6csWbLEPc6QIejOJ/EYpkyZIhMmTHD7s4Yb/ZyPHTsmq1atcrdFixZJhw4dxKLcuXPLwIED0ww9wSTogs2sWbOkXLlyUrJkSRk/frwMGzbM6yYB+I0++eQTF2r69+/vHmfMmPG+1+/evStW5M2bV65cueLO4FNvo/ZWrV+/3gUbDT0IXRpcN2/eLPXr17/v+a1bt0rjxo2lX79+0rp1azfiYE2ePHlk1KhREuyC7tShSZMmLtQACG03b96U0aNHS5kyZeTjjz9+INSo8PCgO7f6zbQnJnWoSdrGNm3auMfHjx/3oGVIT23btn0g1Ki6detKw4YNXS/d/v37PWkb/snOUQVAUNEeCj3I9+jRQ+7duyfR0dFy9OhRd9anJzDPPfec+EFCQoKsW7fOPa5cubLXzcFTlClTJnOBPaVbt265mlcdSs6VK5fUrFlTatWqJcHG5r8+AM/t3bvX3WtPTdWqVV2oSdm7MWjQIJk4caJYc/v2bRk3bpyrL7p48aJs3LhRjhw54gKeDlXAptOnT8uGDRtcbWiVKlXEogsXLrj9OCUNN4sXL3Y1R8Ei6IaiANjw008/uftJkya5osPY2Fj55ZdfZMuWLVK+fHn56KOPXLGtxWCjQ3BjxoyRTz/9VL7//nsZMmSIqzWCTTrjrWvXrq5HQwuL0xp2DXU9evRwIf3HH3+U69evy759+9w2f/vtty6w63c7WBBsADy1IRildSc6W0TP7HLkyOFqEZYtW+Z6bTTcWKPbqL01Ovym09k13OikCJ0Se/XqVa+bh6ewn3fv3t0F9j59+rgfe4tGjhwpjRo1koIFC0q2bNmkWrVqMn/+fLe9Ortx5syZEiwINgCeCu2lUbomla7rkpLWmmhR8Q8//CCXL18WizS4BQIBN0tGe2u2b98uY8eO9bpZSOdQo1P5dYp3ly5dZPr06eI3ffv2dfe6fwcLgg2Ap6JChQruXouF05L0vM6esk7XO1E6TRh2Qo0Oz8ybN88tNqlFtX5coyh//vzuXoengoX/PgUAz4ROfVWHDx9OsyZBpz5nz57dLXBmnc4iSTlrBjZCjQ7F6GJ8CxYsMFlX8yiSVlsOpkX6CDYAnoqklVk1wGiNSUq6+KYOQen6Llamxh46dEhu3LjxwPP6nF5qQTVv3tyDluFpDD9pqGnfvr27DJD1UHPkyJE09219fujQoe5x586dJVgE3RFFD4Dbtm1zj5MWOdLnkrpw69SpI7179/a0jQAezWeffSYvvfSSK6rUAuKKFSu62RSbNm1yC3F++OGHYsXSpUvdDDA9RunZq67zodcV0tWGddq3Fk3rFHeENp3tpsNPWiSus/vef//9B96jKw9rca0VS5Yscfu2XgdNv7fa06rLN6xZs8b1vuoVAvS1YBF0wUZDje40KWlRUsrCJIINEDq9Nnv27JERI0a4Rep00T69YOCbb77pntMZFla0bNnSDTnt2LFDdu7c6a4dpQXUuoaPXiNLz/Kt9E752cmTJ929fr4PKwbXYGsp2DRs2NANKetJiV46QntvtLZGeyD1cilJNWTBIui+ZVqAxdW8ATv0Ipd6dWvrdPaX3mCbH3+j6tevn+ZlJIIVNTYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzwhITExMf6Y1hYRIRESFNmzYVv4iNjZXIyEjxC79tb0xMjMTHx7Nf+4Cftpn92j/8ts0xMTFy8+bN9A02xYoVk7Nnz4pfREVFSXR0tPiF37Y3EAhIXFwc+7UP+Gmb2a/9w2/bHAgEHmmfZigKAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZQBptSpUpJWFhYmrcGDRp43Tykg8TERFmxYoU0bNhQihQpItmyZZMKFSpI37595R//+If4wYQJE5L36127dnndHKSDuXPnPvTYlXRr3Lix181EOlm5cqU0bdpU8uXLJxEREVK6dGnp1KmTnDlzxuum+Vq4BKncuXPLwIED0ww9CH1DhgyRSZMmuVDTunVryZUrl/z3f/+3zJw5UxYvXiw7duyQypUri1UHDhyQkSNHSvbs2eX69eteNwfppFq1au5zTcvy5cvl4MGD8vLLLz/zdiH9T8zeeOMNmTFjhpQtW1Y6duwoOXPmlHPnzsk333wjp06dkuLFi3vdTN8K2mCTJ08eGTVqlNfNwFNw4cIFmTx5spQsWdKFGQ2xSf7yl7/I4MGDXeiZPXu2WHTnzh3p1q2b+xEsV66cLFy40OsmIZ3oZ6q31G7fvi1Tp06V8PBw99kjtH3yyScu1PTv3989zpgx432v371717O2IUiHomDbyZMnJSEhQWrXrn1fqFEtW7Z09z///LNYNXbsWHfmrsEt9QERNq1atUouXrzo9u9ChQp53Rw8gZs3b8ro0aOlTJky8vHHH6f5HdYAC+8E7b/+rVu33Hi1du3pMEXNmjWlVq1aXjcL6UB7KTJnzizbt2+Xq1evus83yd/+9jd3b7UO4bvvvnPBZsyYMfL888973Rw8I7NmzXL3vXv39ropeELr16+XS5cuSY8ePeTevXsSHR0tR48edaMMTZo0keeee87rJvpeeDAPV+iOk5KGG62/0DFNhC4ttBs/frz86U9/kooVK0qrVq2Sa2w2bdrkuncHDBgg1mhYf/31191QxTvvvON1c/CMaL3Fxo0bJRAIyCuvvOJ1c/CE9u7d6+61p6Zq1aou1CTJkCGDDBo0SCZOnOhhCxGUQ1EaaPRA8OOPP7rCyn379knXrl3l22+/dWfyv/zyi9dNxBPSL/+SJUvk2rVrMn36dPnzn/8sf//7312vXOfOnU125Y4YMUKOHTsmc+bMYQjKR/Tz1qHX7t2787kb8NNPP7l7rQPUofTY2Fj3m7RlyxYpX768fPTRRzJt2jSvm+lrQRlsdFZBo0aNpGDBgm4asJ7hzp8/34UbPfvRmTMIbToU06VLF3nvvffc1Eg9MGzdulXi4+PdlH7t3rVk586d7ixu+PDhpmd74X4aaDTY6DTvnj17et0cpNNnqnQ4XWundCQhR44cUrduXVm2bJnrtdFwA+8EZbB5GF3jRGltBkLXhg0bXHjV4aZ3333XddHrgaFOnTry1VdfSaZMmdwwlRU6Q0Jnwmi3tW4v/LWvnz592p2o6RonCH1JEx5q1KghRYsWve81PWnRouIffvhBLl++7FELEVL9/fnz53f3rPsR2tauXevudXG+1AoXLuzqbnT4UYepNPCEOt0OHYJKOstLy4svvpi84Jeu6wMbKBq2RxcSVVosnJak53X21MPeg6crpILN7t273T2L9IU2XdPj16Z06/Panas9NxZkyZJFevXqleZrOi6voScqKkoKFCjAvm2ITu9evXq15M2bV9q0aeN1c5BOkk7IDh8+nOYaVcePH3cLb+r3Gd4IumBz5MgRKVGihKutSf380KFD3WMtLkXo0vVrdLEyLb5r167dfWvZaCHx2bNn3Xs0EFiQNWvW5DP31LSgVIPNsGHD5IUXXnjmbcPTs2DBAhfitZbMyr4McbNymzVr5qZ96/c6ZW+czvbUISj9zC1OgAgVQfcvrzNl9AevXr16bmVaTb46nW7NmjUuDesPgL6G0NW+fXs3ayBpFoH2VmiXra7xotO9NQjoPgCEss8//9zdMwxlz2effSYvvfSS9OnTxxUQJw2f6/FLf7c+/PBDr5voa+HB2M2nXXy6k+gsmRs3brjamubNm7v1TTQpI7TplFc929HLJyxdulQWLVrkzmx1RdakmVKVKlXyupnAb6ZTgPV6YJGRkVKlShWvm4On0GuzZ88et4TDunXr3PFM6wPffPNN95zO6IV3gi7Y1K9f391gm3bN6wwhv88S0tW19QZbNNDohRJhl17kUqfyI/iE1HRvAACAX0OwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBlhiYmJiY/0xrAwyZAhgxQpUkT84uLFi5IvXz7xC79t7/nz5yUhIYH92gf8tM3s1/7ht20+f/683Lt3L32DDQAAgFceJbKEP84fyBmAbX7bXs5s/cNP28x+7R9+2+bz588/0vseK9jol+Ts2bPiF1FRURIdHS1+4bftDQQCEhcXx37tA37aZvZr//DbNgcCgUd6H8XDAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYOOxuLg4mTx5sjRr1kxKlCghmTNnlsKFC0u7du1k9+7dYt3KlSuladOmki9fPomIiJDSpUtLp06d5MyZM2JJfHy8DB48WOrVqydFixZ126qfc+3atWXOnDly584dr5uIdJCQkCBTp06V6tWrS7Zs2SRXrlzuM4+Ojva6acBvtnDhQunbt6/UqFFDsmTJImFhYTJ37lwJVuFeN8DvpkyZIhMmTJCyZcu6cFOgQAE5duyYrFq1yt0WLVokHTp0EGsSExPljTfekBkzZrht79ixo+TMmVPOnTsn33zzjZw6dUqKFy8uVly7dk2mTZsmkZGR0qJFC/c5X7p0SdauXSs9e/aUJUuWuMcZMnCuEcr79GuvvSZffvml26d79eolt27dktWrV0urVq3cd33AgAFeNxN4bMOHD3fH5Pz580uRIkXc42BGsPGY/tBt3rxZ6tevf9/zW7dulcaNG0u/fv2kdevWLiVb8sknn7hQ079/f/c4Y8aM971+9+5dsSRv3rxy5coV1yOXeju1x2r9+vUu2GjoQWjSQKM37YWLiYmRrFmzuufHjRvnznSHDBkiLVu2lFKlSnndVOCxzJo1S8qVKyclS5aU8ePHy7BhwySYcXrosbZt2z4QalTdunWlYcOG7qx+//79YsnNmzdl9OjRUqZMGfn4448fCDUqPNxW5taemNShJmk727Rp4x4fP37cg5YhvWjPjHrvvfeSQ43Ss9xBgwa53hsddgRCTZMmTVyoCRUEmyCWKVMmkz/y2juhgU17ou7duycrVqxwZwHTp0/33Y+71mSsW7fOPa5cubLXzcETuHDhgrvXOrHUkp7btGnTM28X4De2fjENOX36tGzYsMGNZ1apUkUs2bt3r7vXnpqqVavK0aNH7+vZ0LPbiRMnikW3b992QxNaj3Hx4kXZuHGjHDlyRHr06OGGHhG6tGdGnThxQipVqnTfa/qcSrmvA3g66LEJQjpDpmvXrq7rWguL0xqqCWU//fSTu580aZLkzp1bYmNj5ZdffpEtW7ZI+fLl5aOPPnKFtlaDjQ7DjRkzRj799FP5/vvvXe2F1hshtL366qvuXnsfdRZcEg2wOvNRXb582bP2AX5BsAnCoYnu3bu7H/k+ffq4gGNxG5XWnOjMr5o1a0qOHDlcXdGyZctcr42GG4t0O7W3RofgdEq7hhstzGvQoIFcvXrV6+bhCXTu3NnVxWnhv/ayvvXWW27m3+9+9zs37Vsx6w14+viWBdkPvk791SneXbp0cTUnFmkvjdKZIrqmS0paZ6JFxT/88IPps1v9gQsEAm7Wm/bWbN++XcaOHet1s/AEtBZOZ7aNGjXKfb76uWr9mE71Xr58uXtPwYIFvW4mYB7BJohCjdZZzJs3zy1Qp4sfWT27q1ChgrvPkydPmq8nPa+zp/xA1y9SOu0foU2XZRg5cqQbYtShZB12/etf/+oW4kwK8wCeLpu/nCEaaubPn+8W41uwYIG5upqUtLteHT58OM36Ip0ZlT17dreInR/oooQpZ8HBni+++MLd60KUAJ4ugk2QDD9pqGnfvr1butpyqFFJqyxrgNH6kpS08FKHoHRtF0vT3A8dOiQ3btx44Hl9Ti+1oJo3b+5By5Ce0qqT0mGo2bNnu1oyXbcKwNNl55cjROnsGB1+0qJSnRH0/vvvP/AeXe+lWrVqYslnn30mL730kiuQ1gLiihUryr59+9w6H7oQ1IcffiiWLF261M0Cq1Onjlt5VotJdXhCazJ01owWTus0d4S2WrVquUuB6HRvvR6YzvjTIUatG9PCeOsnLbBp1qxZsm3bNvc4acFYfS5p+FyPa71795ZgQbDx2MmTJ5OvJfSw4lH9IbQWbLTXZs+ePTJixAi3QJ0u2qcXhXzzzTfdc9aKLHUpfR1y2rFjh+zcudN93lpErev46PCE9tpZ6qHyKx1K1oLhXbt2uWFVXZhPr7Pz9ttvJ8+MAkLNtm3b3Al4SjrhQW9JCDZIpkXCwXyV1KdJz2z9ssS8Fo1SOGqfzojSG2DJ3BD7naLGBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZYYmJi4iO9MSxMIiIipGnTpuIXsbGxEhkZKX7ht+2NiYmR+Ph49msf8NM2s1/7h9+2OSYmRm7evJm+waZYsWJy9uxZ8YuoqCiJjo4Wv/Db9gYCAYmLi2O/9gE/bTP7tX/4bZsDgcAj7dMMRQEAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgEgVKlSklYWFiatwYNGog1c+fOfej2Jt0aN27sdTPxhBYuXCh9+/aVGjVqSJYsWdznqp897IiLi5PJkydLs2bNpESJEpI5c2YpXLiwtGvXTnbv3i1WJSQkyNSpU6V69eqSLVs2yZUrl9SrV0+io6O9bhpEJNzrBuCfcufOLQMHDkwz9FhTrVo1GTlyZJqvLV++XA4ePCgvv/zyM28X0tfw4cPl1KlTkj9/filSpIh7DFumTJkiEyZMkLJly7pwU6BAATl27JisWrXK3RYtWiQdOnQQSxITE+W1116TL7/80m13r1695NatW7J69Wpp1aqV+zcZMGCA1830NYJNkMiTJ4+MGjVK/ECDjd5Su337tjsLCg8Pl27dunnSNqSfWbNmSbly5aRkyZIyfvx4GTZsmNdNQjqLjIyUzZs3S/369e97fuvWra7XtV+/ftK6dWvXY2eFBhq91a5dW2JiYiRr1qzu+XHjxrneySFDhkjLli1NnpSGCoaiEDT0DO/ixYvuoFCoUCGvm4Mn1KRJExdqYFfbtm0fCDWqbt260rBhQ7l06ZLs379fLNGeGfXee+8lhxqlPZODBg1yvTdz5szxsIWgxyZI6JdB6w/OnTvnxmtr1qwptWrVEr+d4avevXt73RQATyhTpkzuXntgLblw4YK7L1269AOvJT23adMmGT169DNvG/7J1h4X4l+WHj163PechpvFixe7cVzrtP5i48aNEggE5JVXXvG6OQCewOnTp2XDhg2utqpKlSpiifbMqBMnTkilSpXue02fU0ePHvWkbfgnhqKCgAYa/VH/8ccf5fr167Jv3z7p2rWrfPvtt26c+pdffhHrtOtWZxp0795dMmbM6HVzAPxGd+7ccccv7YXWwmJr3+dXX33V3WvdWHx8fPLzOoyuM8TU5cuXPWsf6LEJCqlnCGlh7fz5893jBQsWyMyZM2Xw4MFilQYaDTY6Hbhnz55eNwfAb5R0crJlyxbp06ePCzjWdO7c2ZUNfP311643SnuYNcxpjWBSbWCGDPQZeIl//SCma4Co7du3i2XaZa1d140aNUpz3BpAaIQaPTHRKd5dunSR6dOni0VaM7R27Vo3i1UDzIwZM2TFihVuqrcuV6EKFizodTN9jR6bEBjL1eEpyygaBkI/1OiQuvY0d+rUyfVoWO610Onr2tOeurddp74rnfYN79jd8wxIWrnT8noIOi6t0yfz5s0rbdq08bo5AJ4g1OhifDp8bq2u5lF98cUX7r5jx45eN8XXCDYeO3LkiNy4cSPN54cOHZo8pmuVHgR1YT7tura0iBfgp+EnDTXt27d3l9HwQ6i5evXqA8/pMNTs2bPdbFZd3wfeYSjKY0uWLJFJkya564zoYmbZs2d3UwXXrFnjCtJ0tVZ9zarPP//c3TMMZXOIcdu2be5x0iJt+lxSd32dOnX43EPcmDFjZN68eZIjRw4pX768vP/++w+8R1ceTmul8VCma4wVL17cTfeOiIiQ2NhYt1+XKVNGli1b5otwF8wINh7T1TkPHz7spnjrMuTae6O1Nc2bN5f+/fu7669YpQeDAwcOuGXZra11AXGhRn/0UtJC+JTF8ASb0Hby5El3f+3aNRk7dmya79GhdGvBRofctGB4165d7gRUJz3otdHefvttt8AqvEWw8ZguR57WkuR+oIFGLygHm7SAlKt52+bXz1hnRPnl2n6hiBobAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGWGJiYmJj/TGsDCJiIiQpk2bil/ExsZKZGSk+IXftjcmJkbi4+PZr33AT9vMfu0fftvmmJgYuXnzZvoGm2LFisnZs2fFL6KioiQ6Olr8wm/bGwgEJC4ujv3aB/y0zezX/uG3bQ4EAo+0TzMUBQAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYBMEEhISZOrUqVK9enXJli2b5MqVS+rVqyfR0dFeNw1PwcqVK6Vp06aSL18+iYiIkNKlS0unTp3kzJkzYsncuXMlLCzsV2+NGzf2upl4QqVKlXro59ugQQOxJj4+XgYPHuyO0UWLFnXf4cKFC0vt2rVlzpw5cufOHa+b6HvhXjfA7xITE+W1116TL7/8UsqWLSu9evWSW7duyerVq6VVq1YyZcoUGTBggNfNRDp91m+88YbMmDHDfdYdO3aUnDlzyrlz5+Sbb76RU6dOSfHixcWKatWqyciRI9N8bfny5XLw4EF5+eWXn3m7kP5y584tAwcOTDP0WHPt2jWZNm2aREZGSosWLaRAgQJy6dIlWbt2rfTs2VOWLFniHmfIQL+BVwg2HtNAozdN+zExMZI1a1b3/Lhx46RGjRoyZMgQadmypckDhN988sknLtT079/fPc6YMeN9r9+9e1cs0WCjt9Ru377teijDw8OlW7dunrQN6StPnjwyatQoX/yz5s2bV65cuSKZM2d+4PurPbHr1693wUZDD7xBpPSY9syo9957LznUqPz588ugQYNc7412byK03bx5U0aPHi1lypSRjz/++IFQo/SH3g9WrVolFy9edIG9UKFCXjcHeCzaE5M61CR9f9u0aeMeHz9+3IOWIYk/jqRB7MKFC+5e6yxSS3pu06ZN7kcRoUvP4rS7ukePHnLv3j1XP3X06FF3ptukSRN57rnnxC9mzZrl7nv37u11U5BO9ARMa6p0WFVrBGvWrCm1atUSv9VKrlu3zj2uXLmy183xNYKNx7RnRp04cUIqVap032v6nNIfQIS2vXv3unvtqalatep9n6meAWrv3MSJE8U6rSPauHGjBAIBeeWVV7xuDtLxBE1De0oabhYvXuzqySzSIVUtGdDaOe2B1P36yJEj7t+BonhvMRTlsVdffdXdjx8/3lXbJ9EvyuTJk93jy5cve9Y+pI+ffvrJ3U+aNMkVWsbGxsovv/wiW7ZskfLly8tHH33kChKt02FVPbPt3r17msNxCD36Q64/6j/++KNcv35d9u3bJ127dpVvv/3W/cDrfm412GhP+pgxY+TTTz+V77//3tVEah0dvEWw8Vjnzp2lYcOGsnXrVqlSpYq89dZbbubM7373O9elq6iuD336Y650bF5rTPRsNkeOHFK3bl1ZtmyZ+4w13Fj/N9Bgo9OAdfYIbNCZb40aNZKCBQu65Sq0YHz+/Pku3GgP3cyZM8Ui/f5qb40OLetSDRpudJhVp7hfvXrV6+b5Gr+YHtOCM62g1xkF+uOmaX/FihVuqrdOiVV6wEBo014apTPddO2LlHQ8XouKf/jhB9O9cxs2bJDTp0+7H8G0aspgS9++fd399u3bxTI9buvQar9+/dzxW7d37NixXjfL1wg2QSBLlizurEe7MrUIT4ct/vrXv0pcXFzyjyFCW4UKFdy9FgunJel5nT1lFUXD/qwf1OEpv2jWrJm737x5s9dN8TWCTRD74osv3L0u5IbQpsON6vDhww+8piuV6vTQ7Nmzu8W+LNKaMV3aQNcASZoSC9t2797t7v20BpfOClOZMmXyuim+RrAJAmmNx+ow1OzZs10tRtu2bT1pF9KPzgzRszkNMEk9F0m0cFyHoPQH3+paNgsWLHDFll26dHE9lLBBZwHduHEjzeeHDh2aXEdoyaFDh9LcZn1OL7Wgmjdv7kHLkMTmUTTE6HoPupS+TvfW647ojBntytS6Cy0sZfaIDZ999pm89NJL0qdPH1dAXLFiRTeDRNcpKlmypHz44Ydi1eeff+7uGYayRS8foDP99LpJug9rr6MuZbBmzRrXEzls2DD3miVLly5121ynTh3XG6WTPLRsQGsltWdSJwTo8g3wDsEmCHTo0MEVDO/atcsdDLSwcvjw4fL2228nz4yCjV6bPXv2yIgRI9xCXrpon148780333TPWS0S16B+4MABd20dnfkHW0OsOryqAV1ndmqvhdbWaI+FXjokqebEEl0xW4ecduzYITt37nTXjtLJAbo+lZYN6Iw/qz2voYJ//SCgM6L8cp0Vv9OeOb9dIkMDjU6LhT3169d3Nz/RyRxM6Ahu1NgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwIywxMTHxkd4YFiYZMmSQIkWKiF9cvHhR8uXLJ37ht+09f/68JCQksF/7gJ+2mf3aP/y2zefPn5d79+6lb7ABAADwyqNElvDH+QM5A7DNb9vLma1/+Gmb2a/9w2/bfP78+Ud632MFG/2SnD17VvwiKipKoqOjxS/8tr2BQEDi4uLYr33AT9vMfu0fftvmQCDwSO+jeBgAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGUEXbOLi4mTy5MnSrFkzKVGihGTOnFkKFy4s7dq1k927d4tfTJgwQcLCwtxt165dXjcH6aBUqVLJn2nqW4MGDcSa+Ph4GTx4sNSrV0+KFi0qERER7rtcu3ZtmTNnjty5c8frJiIdrVy5Upo2bSr58uVzn3Xp0qWlU6dOcubMGa+bBp8JlyAzZcoU96NetmxZF24KFCggx44dk1WrVrnbokWLpEOHDmLZgQMHZOTIkZI9e3a5fv26181BOsqdO7cMHDgwzdBjzbVr12TatGkSGRkpLVq0cN/lS5cuydq1a6Vnz56yZMkS9zhDhqA7v8JjSExMlDfeeENmzJjhjtsdO3aUnDlzyrlz5+Sbb76RU6dOSfHixb1uJnwk6IKNHgQ3b94s9evXv+/5rVu3SuPGjaVfv37SunVryZIli1ikZ7HdunWTatWqSbly5WThwoVeNwnpKE+ePDJq1Cjxg7x588qVK1dcr2tKd+/edWf269evd8FGQw9C1yeffOJCTf/+/d3jjBkzPvB5A89S0J0qtW3b9oFQo+rWrSsNGzZ0Z3z79+8Xq8aOHSsHDx6U2bNnP3CAAEKJ9sSkDjUqPDxc2rRp4x4fP37cg5Yhvdy8eVNGjx4tZcqUkY8//jjNY5Z+3sCzFFJ7XKZMmUx/Ub777jsXbMaMGSPPP/+8183BU3Dr1i2ZO3eu66bPlSuX1KxZU2rVqiV+kpCQIOvWrXOPK1eu7HVz8AS0101PNnv06CH37t2T6OhoOXr0qOuZbNKkiTz33HNeNxE+FDIJ4fTp07JhwwYpUqSIVKlSRSz+4L3++utuCOqdd97xujl4Si5cuOB+BFLScLN48WJXn2DR7du3Zdy4ca4W4+LFi7Jx40Y5cuSI+3fQ4WWErr1797p77ampWrWqCzUpe+wGDRokEydO9LCF8KPwUKk76dq1q/vx18Jii0M0I0aMcEXSeqCwuH0Q90OuQ6raS5EjRw73IzBp0iRZsGCB+4HXIVYturQYbHS4IonOAhsyZIh88MEHnrYLT+6nn35y97ofV69eXWJjY6VSpUqyb98++eMf/ygfffSRC+xaGwn4tsYmrW7r7t27y5YtW6RPnz4u4Fizc+dOd1YzfPhwuuYN05lujRo1koIFC0q2bNlc79z8+fPdPq0zR2bOnCkWaYjT3hodqtCpv59++qnMmjXLTXG/evWq183DEx6fldZS6axV7X3Uz1sD/LJly1yvjYYb4FnKEOxfGp0WqlO8u3TpItOnTxdrdMaAzoLSbtx3333X6+bAA3379nX327dvF8v0Ry4QCLizd51Fo9urNWUI7eULVI0aNdxaRSnpSZoWFf/www9y+fJlj1oIPwoP5lCjXfd6RquLPGnBpcX1LnStDx2CUmnNIFEvvvhi8gJYOtUdtuTPn9/d+2nNIl2jSunSDghdFSpUcPdaLJyWpOd19tTD3gP4ItikDDW6GJ/WIFitO9H1eHr16pXmazr8pqEnKirKLW5mcRE3SPKK2n76fHVWWMqZjghNugSHOnz4cJq1kTqdXxca1eMX4NtgkzT8pKGmffv2boE6q6FGZc2a1dUbpEVrizTYDBs2TF544YVn3jakH50FpJcI0dqa1M8PHTrUPe7cubNYcujQIRfWUm/zjRs33KUWVPPmzT1qHdJD0grxOu1bj2O9e/dOfm38+PFuCErLCKwu0YHgFHR7m67hMm/ePFeAVr58eXn//fcfeI8Ox2jhJRAq9PIBOnNEr5tUsmRJdxars6LWrFnjzmw1vOprlixdutRtc506dVzA0XV79FpwutqwTvvWAlOdDozQ9tlnn8lLL73kJndoAXHFihXdrKhNmza5ff3DDz/0uonwmaALNidPnkyuPXlYYaEeJAk2CLUue+2u1wO+Xh5Eey20tkZ7LHQp+qSaE0tatmzphpx27NjhZv7pd1qLTbVQXq8npD2znMnb6LXZs2ePW7JCF17U3hu92Ombb77pntNZgMCzFHRHFS0S1hv4t7BELxOS1qVCLNOZMnqDfXqRS71iOxAM7E0zAgAAvkWwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZYYmJi4iO9MSxMIiIipGnTpuIXsbGxEhkZKX7ht+2NiYmR+Ph49msf8NM2s1/7h9+2OSYmRm7evJm+waZYsWJy9uxZ8YuoqCiJjo4Wv/Db9gYCAYmLi2O/9gE/bTP7tX/4bZsDgcAj7dMMRQEAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwI+iCzdy5cyUsLOxXb40bN/a6mXhCpUqVeujn26BBA7EmLi5OJk+eLM2aNZMSJUpI5syZpXDhwtKuXTvZvXu3180DfpP4+HgZPHiw1KtXT4oWLSoRERFuv65du7bMmTNH7ty543UT8ZRMmDAh+Zi9a9cuCSbhEmSqVasmI0eOTPO15cuXy8GDB+Xll19+5u1C+sudO7cMHDgwzdBjzZQpU9yBoGzZsi7cFChQQI4dOyarVq1yt0WLFkmHDh28bibwWK5duybTpk2TyMhIadGihduvL126JGvXrpWePXvKkiVL3OMMGYLuHBpP4MCBA+53Onv27HL9+nUJNkEZbPSW2u3bt2Xq1KkSHh4u3bp186RtSF958uSRUaNGiR/ogX/z5s1Sv379+57funWr64Hs16+ftG7dWrJkyeJZG4HHlTdvXrly5YrrgUzp7t270rRpU1m/fr0LNhp6YMOdO3fcb7D+TpcrV04WLlwowSZkYrSe1V68eFFatmwphQoV8ro5wGNp27btA6FG1a1bVxo2bOjOcvfv3+9J24DfSntiUocapSegbdq0cY+PHz/uQcvwtIwdO9aNnMyePVsyZswowSjoemweZtasWe6+d+/eXjcF6eTWrVuupurcuXOSK1cuqVmzptSqVUv8JlOmTMk/BoAFCQkJsm7dOve4cuXKXjcH6eS7775zwWbMmDHy/PPPS7AKiSPpqVOnZOPGjRIIBOSVV17xujlIJxcuXJAePXrc95yGm8WLF7taFD84ffq0bNiwQYoUKSJVqlTxujnAb6KlAuPGjZPExETXs67H6yNHjrjvN5M97JyIvv76624I6p133pFgFhLBRqvr9Qyge/fuQdv1hcejBzwdhtGzuRw5csjRo0dl0qRJsmDBAncg1GGZnDlzivWx6q5du7oDhhYWs28jlIPN6NGjk/9bZ8oMGTJEPvjgA0/bhfQzYsQIN+Fh7969QX+sCvoaGw00Gmz0i6JV9rBBK+obNWokBQsWlGzZsrmzgPnz57sfeu2hmzlzpliWFNS3bNkiffr0cdsNhCo9OdHemnv37smZM2fk008/deUDunTD1atXvW4entDOnTtl4sSJMnz48JAYWgz6YKPd9Npdrz+CpUuX9ro5eMr69u3r7rdv3y6WQ42GdJ3i3aVLF5k+fbrXTQLSrZhYSwZ0lt+MGTPc91hrMhC67t6962ZBVa1aVd59910JBUE/FEXRsL/kz5/f3Qfj2gjpFWp0GE57pzp16uSKp1njAxbpek1KlzlAaK9VdOzYMfc4rRlw6sUXX3T3K1eudMtWeC2og40Woa1evdqtlZA0dRC2Ja3Ca3GRvpShRhfj03qiYB+rBn4rne2YctYfQlOWLFmkV69eab6mQ+kaeqKiotzijMFy3A7qYKMHfi1K0+56Fi6zQ2dL6GUFtLYm9fNDhw51jzt37iwWh5801LRv394takWoQag7dOiQ+zFL/V2+ceOGu9SCat68uUetQ3rImjVr8shJalonqMFm2LBh8sILL0iwCOpg8/nnn7t7hqFs0WXWdQaUXl+mZMmSbllunRW1Zs0aN1NIvyT6miW67sO8efNckWX58uXl/ffff+A92oWb1qrbQLBaunSp+y7XqVPHBRxdj0qvi6arDWuPu858HDRokNfNhM8EbbCJjY1116PQpehZ38MWXWn38OHDsm/fPndJAT2709oaPbPr379/8ti8JSdPnkwer35YMaX+MBBsEEp0JXgdctqxY4ebOaP7t14DTgtNO3bs6HopWXgSz1rQ7nEaaHT6IOzRSwukdXkBy7RIWG+AJTVq1HA3+NPcID2uMR0DAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgRlhiYmLiI70xLEwiIiKkadOm4hexsbESGRkpfuG37Y2JiZH4+Hj2ax/w0zazX/uH37Y5JiZGbt68mb7BplixYnL27Fnxi6ioKImOjha/8Nv2BgIBiYuLY7/2AT9tM/u1f/htmwOBwCPt0wxFAQAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2ASBxMREWbFihTRs2FCKFCki2bJlkwoVKkjfvn3lH//4h9fNA9LNhAkTJCwszN127dol1ixcuNB9b2vUqCFZsmRx2zl37lyxLCEhQaZOnSrVq1d3x65cuXJJvXr1JDo6WqwqVapU8n6c+tagQQOvm+d74V43ACJDhgyRSZMmuVDTunVrd2D47//+b5k5c6YsXrxYduzYIZUrV/a6mcATOXDggIwcOVKyZ88u169fF4uGDx8up06dkvz587vvsz62flL22muvyZdffilly5aVXr16ya1bt2T16tXSqlUrmTJligwYMEAsyp07twwcODDN0ANvEWw8duHCBZk8ebKULFnShRn9siT5y1/+IoMHD3ahZ/bs2Z62E3gSd+7ckW7dukm1atWkXLlyrmfDolmzZrnt0+/z+PHjZdiwYWKZBhq91a5dW2JiYiRr1qzu+XHjxrleKz1pa9mypckf+zx58sioUaO8bgbSwFCUx06ePOm6cvXAkDLUKD0gqJ9//tmj1gHpY+zYsXLw4EEX0DNmzChWNWnSxIUav9CeGfXee+8lhxqlPVaDBg1yvTdz5szxsIXwI4KNx/TsLnPmzLJ9+3a5evXqfa/97W9/c/eNGzf2qHXAk/vuu+9csNFhqOeff97r5iCde5xV6dKlH3gt6blNmzaJRRratH5Ke6e0xmj37t1eNwn/H0NRHsuXL5/rsv7Tn/4kFStWdOPSSTU2ekDo37+/2TFq2KcH/9dff90NQb3zzjteNwfpTHtm1IkTJ6RSpUr3vabPqaNHj4rVUNejR4/7nqtZs6ari9R6I3iHHpsgoF22S5YskWvXrsn06dPlz3/+s/z973+XWrVqSefOnSU8nPyJ0DRixAg5duyYG46wPATlV6+++qq715Oz+Pj45OcvXrzoagfV5cuXxRoNNBs3bpQff/zRFcLv27dPunbtKt9++63rYf/ll1+8bqKvEWyCwJgxY6RLly5unPrMmTPuS7F161Z3oNCpg5anTcKunTt3ysSJE91MIWb12aQnXrpMhR6vqlSpIm+99Za88cYb8rvf/c71PKsMGez9zOiwaqNGjaRgwYJuirv2SM6fP9+FG50JpzNa4R17e1yI2bBhg/uS6HDTu+++K4FAQHLkyCF16tSRr776SjJlyuSGqYBQcvfuXTcLqmrVqm6/hk3am7x27Vo3O0gDzIwZM9yaXDqkvnz5cvce/fH3C13DSGnNJLzDGIfH9KCg9KwntcKFC7u6G+3m1GEqDTxAKND9VYeglBbHp+XFF1909ytXrnTrNyE06UKEenKmt5Q2b97s7nXat99qjqyu0xQqCDYeu3379q9O6dbn9UxIe26AUPqx08Xa0rJlyxYXeqKioqRAgQIm1ziByBdffOHuO3bsKH6RNDOKfdpbBBuP6fo1OlVQF+Fr167dfWvZaCHx2bNn3Xv0hwIIFbqmiS5Wl5bu3bu7YKOL173wwgvPvG1IX7pMRVI9TRIdhtI1i3SWUNu2bcWSI0eOSIkSJVxtTernhw4dmlx7BO8QbDzWvn17mTZtmjuLLV++vDuL1RUtde0Pne6tPxAaegAEPw1z27Ztc4/379+f/FzSsIzWzvXu3Vss0dmbxYsXd9O9IyIiJDY21m1vmTJlZNmyZeZmw+kMVj0m6/WwdDFGvUSITmlfs2aNW2FbA7u+Bu8QbDymX/r169e7yycsXbpUFi1a5IanChUqlDxTKvX6EACCk4aaefPm3fecFpKmLCa1Fmw6dOjgCob1oqb6w64L8+lMuLfffvuBnhwLtB7y8OHDrvZRZ4PduHHD1dY0b97crTvWrFkzr5voewSbIKDDTDpzhNkj8ANdrdXqFa8tb9vD6IwoP10zqX79+u6G4MV0bwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGaEJSYmJj7SG8PCJEOGDFKkSBHxi4sXL0q+fPnEL/y2vefPn5eEhAT2ax/w0zazX/uH37b5/Pnzcu/evf/zfeGP+gc+Yv4BAADwDENRAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAQKz4fyG3gX5t+wnPAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAJOCAYAAACkx02ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASB1JREFUeJzt3QmUTOe6//GnabTZMg9ljikHy3VoScxjEpw2XTFcYj5C5C4cich1TSuEE3EkJBzEHCzE0DkXRyNi1iHWvcYgx9hIci1DDG3q/q/nPf/u1VrLJZpd9ezvZ61aVamq8G61a9dvv+/zvjssMTExUQAAAAzI4HUDAAAA0gvBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQbAIytVqpS7BbPNmzdLWFiYjBo16pH/n5MnT7r/p3v37k/0dzdo0MD9OQC8Q7ABPJL0Y5ryljlzZilevLh07txZ/ud//kf8+O/xyiuv+DaUAXhy4enwZwB4AmXLlpUuXbq4x9euXZNdu3bJ4sWLZcWKFbJx40apXbu2100MKZGRkXL48GHJnz//I/8/xYoVc/9P7ty5n2rbADx9BBvAY88999wDwybDhw+XsWPHyn/8x3+4oRU8umzZsknFihUf6//JlCnTY/8/AIITQ1FAEHrrrbfc/bfffvtINSD6mtZ3JJk7d+4Dw1ypbyn/31+76Z/1f0lMTJTZs2e73qVcuXK5cFGjRg333JPSbdZ2nDhxQj755BMXQLJkySIlS5aU0aNHS0JCwq/W2CT92506dcrdUm5b6vek/vfdu3evDBgwQCpXrux6c7JmzSpVqlSR8ePHy507d5542wCkP3psgCD2WwtRq1WrJiNHjnzg+fPnz8uMGTPcD3SStN6npk2bJj/99JMLKf9XqPm3f/s3N3xWrlw5Vx+ktUIxMTHSq1cvOXTokEycOFGe1Ntvvy3ffPONtGzZUl5++WVZtWqVCya3b992vVsPkydPHreNkydPdv89cODA5NdShsG0zJw5U7766iupV6+eNG/eXG7cuOGC07Bhw1zo/PLLL594uwCks0QAnjhx4kSifgVffvnlB14bMWKEe61hw4b3vbdbt25p/ln6Wv369X/177t+/Xri73//+8SwsLDE5cuX/+p7x48f7/7MVq1aJd67dy/5+ZIlS7pbSjNmzHDv7dGjR+Lt27eTn79161biH/7wB/fanj17fvXv+7V/D91mfb506dKJ586dS37+559/TsyTJ09izpw53d+V5Ouvv3bvHzly5H1/TlptT/13p/73PXXqVOLdu3fvey4hISGxZ8+e7v3btm277zX9DDisAt5iKArw2PHjx13Pg960V0J7B8aMGSMRERG/2hPxOHS4RguUdWhl3Lhx0q5du4e+V4uWtUeievXq8sUXX0iGDL9+mJg6dapkz55dPv30U1erkkR7bZLar705T+o///M/pUiRIsn/rcXBrVq1kl9++UW+//57eRpKlCghGTNmfKAX7c0333SPN2zY8FT+XgC/HUNRgMd++OEHVyuiNBgUKlTIDee8++67rp4jPQwdOlRWrlzpakj0z32YPXv2SNeuXaVo0aJuCEYDy6/RoZn9+/e790+YMOGB15PqUI4cOfLE2/D73//+gecCgYC7v3z5sjwNOsylwW3JkiVuG3TW2j87yP7p3LlzT+XvBfDbEWwAj2m9yLp1657anz9r1ixX46L1JFpf8zBnzpyRP/zhD65HQkONhpX/y6VLl9wPfVxcXHI4S8v169flSWlRcmrh4f88hN27d0+ehn/91391/xbly5eXDh06SMGCBV341CD18ccfy61bt57K3wvgtyPYACEgaTjo7t27D7x25cqVh/5/ug5Ov3793A+zFrqmHCpKSYdztChXi4W1Z+df/uVfHitsaG+K9vZYosXBGmo0eP7Xf/3XfUNSutaQBhsAwYcaGyAE6MwepT0jqe3bty/N/0cXnNMeBw0ff/vb3yRv3rxpvk97Ozp27OhWOv7www8lKirqkduVM2dOqVSpkvu7ntZwUHrRYPI4PTs6RKhatGjxQJ3N1q1b0719ANIHwQYIARpOKlSoINu2bXPFxil7WrTQN7Wff/7Z9cBoDYwWA+s07IfR6c9r1qyRP/7xjzJ48ODHbtu///u/u7+nT58+aQ456fozuk6M1zTY/e///q/Ex8c/0vt1nRyl/+YpHTx4UD744IOn0kYAT46hKCBE/OlPf3Lh48UXX5T27du7mU5r166VmjVrPvBeXbflH//4h1sk7+uvv3a31HQWVmxsrCuO1XVtChQokOaFI1u3bu3WxXmYvn37uqGZefPmyfbt26VJkyauPufHH390Bbe7d++WRYsWeX6dpkaNGrnhsldffVXq1q3rZm3pDDS9PezSDHpbunSpW//nhRdekNOnT0t0dLTrxVm+fPkz3wYA/zeCDRAitEdEZxnpQnNaEKxTn3WWk15+QX+kU9IeFKU/5A+rfdEQk/S+mzdvPnRquQaSXws2SasT6wJ2uqCdDnvp7CEttNWeIi1c1rDjNZ0ursXO2j4dStJhKQ2ADws2Ovyk79VZZFrcrTU3Sduj4YhgAwSnMF3MxutGAAAApAdqbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAAD4b4E+XYQLAADAK4+y9F74415hWFc79YuLFy9Kvnz5xC/8tr26TL5eloD92j4/bTP7tX/4bZvPnz//SO97rGCjX5KzZ8+KX+hVjvW6MH7ht+0NBALuatns1/b5aZvZr/3Db9scCAQe6X3U2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwI+iCTUJCgkydOlWqV68u2bJlk1y5ckm9evUkOjra66YhncTFxcnkyZOlWbNmUqJECcmcObMULlxY2rVrJ7t37/a6ecBvVqpUKQkLC0vz1qBBA/GLCRMmJG/3rl27vG4OnlB8fLwMHjzY/RYXLVpUIiIi3DG7du3aMmfOHLlz544Ek3AJIomJifLaa6/Jl19+KWXLlpVevXrJrVu3ZPXq1dKqVSuZMmWKDBgwwOtm4gnp56gHPv2MNdwUKFBAjh07JqtWrXK3RYsWSYcOHbxuJvCb5M6dWwYOHJhm6PGDAwcOyMiRIyV79uxy/fp1r5uDdHDt2jWZNm2aREZGSosWLdwx+9KlS7J27Vrp2bOnLFmyxD3OkCE4+kqCKthooNGbpsCYmBjJmjWre37cuHFSo0YNGTJkiLRs2dI3Bwir9MuxefNmqV+//n3Pb926VRo3biz9+vWT1q1bS5YsWTxrI/Bb5cmTR0aNGiV+pGfu3bp1k2rVqkm5cuVk4cKFXjcJ6SBv3rxy5coV17ue0t27d6Vp06ayfv16F2w09ASD4IhX/5/2zKj33nsvOdSo/Pnzy6BBg1zvjXZ7IbS1bdv2gVCj6tatKw0bNnRnAvv37/ekbQB+u7Fjx8rBgwdl9uzZkjFjRq+bg3SiPTGpQ40KDw+XNm3auMfHjx+XYBFUPTYXLlxw96VLl37gtaTnNm3aJKNHj37mbcOzkSlTpuQvDBCK9ARs7ty5cu7cOVcjWLNmTalVq5ZY991337lgM2bMGHn++ee9bg6eUU3sunXr3OPKlStLsAiqXw/tmVEnTpyQSpUq3feaPqeOHj3qSdvw9J0+fVo2bNggRYoUkSpVqnjdHOA3n6D16NHjvuc03CxevNjVlVkNc6+//robgnrnnXe8bg6ektu3b7vSEK2HvXjxomzcuFGOHDni9nctIwgWQRVsXn31VVeENH78eGnUqJGrvFb6D6izaNTly5c9biWe1th8165d3QFSC4vpxkYo0gO8Dqnq2WuOHDncidikSZNkwYIF7sCvQ6w5c+YUa0aMGOEmAOzdu5fvrvFgMzrFiInOetPa1w8++ECCSVAFm86dO7su3K+//tqdsb/yyivuB09nyhQqVMi9J1iqrpG+3Zndu3eXLVu2SJ8+fVzAAUKRzgZKSXsw5s+f7x5ruJk5c6abNmvJzp07ZeLEia5gOpiGI5D+NKxrb40es3Wo9auvvnI1sboPrFmzxg29BoOgSglaV6GV1foF0QAzY8YMWbFihZvqvXz5cveeggULet1MpCP9guh0QZ3i3aVLF5k+fbrXTQLSXd++fd399u3bxRKdFaOzoKpWrSrvvvuu183BM5IhQwYJBAJuBqv+Tut+rfVVwSKoemyUTvHVs57UZz46PVjptG/YCTXada9ntJ06dXK9dfTIwaKk+kFr67ro+iY6BKXSmjWjXnzxRXe/cuVKt4wDbGnWrNl9v9HBIOiCzcN88cUX7r5jx45eNwXpHGp0MT7tpmdsHlYlrahtbQ0uPRHVhVTTokPLGnqioqLcgm7Wth3/pENSKWe0BoOgCzZXr159YJxOh6F0XQSdWaBroMDG8JOGmvbt27tFvAg1CHU6O0QvEaKXgkn9/NChQ5PrCC3R9cZmzZqV5mtaN6fBZtiwYfLCCy8887Yh/Rw6dMgF09T79o0bN5Jrxpo3by7BIuiCja73ULx4cTfdW2dFxcbGui6uMmXKyLJly/gBNEDXuZg3b54rRCtfvry8//77D7xHu6y18BIIFTqjU2dA6fV0SpYs6S4poLOitKhSJ0HoD7y+BoSapUuXun27Tp06LuBo54Ne809rYnXWss4E1EV0g0XQBRsdltCCYb1wmh4MdGG+4cOHy9tvvx00Fdd4MidPnkwen39YwZl+eQg2CCW6avbhw4dl37597vIgejartTV6Jtu/f//kWgQg1LRs2dINOe3YscPNgNJjt14TTYvGtTxEe+CDaVHV4GnJ/6czovx6nRW/0CJhvQGW6GVC0rpUiF/xPbejRo0aITVxhykoAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAM8ISExMTH+mNYWESEREhTZs2Fb+IjY2VyMhI8Qu/bW9MTIzEx8ezX/uAn7aZ/do//LbNMTExcvPmzfQNNsWKFZOzZ8+KX0RFRUl0dLT4hd+2NxAISFxcHPu1D/hpm9mv/cNv2xwIBB5pn2YoCgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGBG0AWbhQsXSt++faVGjRqSJUsWCQsLk7lz53rdLABPYOXKldK0aVPJly+fRERESOnSpaVTp05y5swZsSI+Pl4GDx4s9erVk6JFi7rtLFy4sNSuXVvmzJkjd+7c8bqJSAdxcXEyefJkadasmZQoUUIyZ87sPud27drJ7t27xapSpUq53+O0bg0aNJBgEi5BZvjw4XLq1CnJnz+/FClSxD0GEJoSExPljTfekBkzZkjZsmWlY8eOkjNnTjl37px888037vtdvHhxseDatWsybdo0iYyMlBYtWkiBAgXk0qVLsnbtWunZs6csWbLEPc6QIejOJ/EYpkyZIhMmTHD7s4Yb/ZyPHTsmq1atcrdFixZJhw4dxKLcuXPLwIED0ww9wSTogs2sWbOkXLlyUrJkSRk/frwMGzbM6yYB+I0++eQTF2r69+/vHmfMmPG+1+/evStW5M2bV65cueLO4FNvo/ZWrV+/3gUbDT0IXRpcN2/eLPXr17/v+a1bt0rjxo2lX79+0rp1azfiYE2ePHlk1KhREuyC7tShSZMmLtQACG03b96U0aNHS5kyZeTjjz9+INSo8PCgO7f6zbQnJnWoSdrGNm3auMfHjx/3oGVIT23btn0g1Ki6detKw4YNXS/d/v37PWkb/snOUQVAUNEeCj3I9+jRQ+7duyfR0dFy9OhRd9anJzDPPfec+EFCQoKsW7fOPa5cubLXzcFTlClTJnOBPaVbt265mlcdSs6VK5fUrFlTatWqJcHG5r8+AM/t3bvX3WtPTdWqVV2oSdm7MWjQIJk4caJYc/v2bRk3bpyrL7p48aJs3LhRjhw54gKeDlXAptOnT8uGDRtcbWiVKlXEogsXLrj9OCUNN4sXL3Y1R8Ei6IaiANjw008/uftJkya5osPY2Fj55ZdfZMuWLVK+fHn56KOPXLGtxWCjQ3BjxoyRTz/9VL7//nsZMmSIqzWCTTrjrWvXrq5HQwuL0xp2DXU9evRwIf3HH3+U69evy759+9w2f/vtty6w63c7WBBsADy1IRildSc6W0TP7HLkyOFqEZYtW+Z6bTTcWKPbqL01Ovym09k13OikCJ0Se/XqVa+bh6ewn3fv3t0F9j59+rgfe4tGjhwpjRo1koIFC0q2bNmkWrVqMn/+fLe9Ortx5syZEiwINgCeCu2lUbomla7rkpLWmmhR8Q8//CCXL18WizS4BQIBN0tGe2u2b98uY8eO9bpZSOdQo1P5dYp3ly5dZPr06eI3ffv2dfe6fwcLgg2Ap6JChQruXouF05L0vM6esk7XO1E6TRh2Qo0Oz8ybN88tNqlFtX5coyh//vzuXoengoX/PgUAz4ROfVWHDx9OsyZBpz5nz57dLXBmnc4iSTlrBjZCjQ7F6GJ8CxYsMFlX8yiSVlsOpkX6CDYAnoqklVk1wGiNSUq6+KYOQen6Llamxh46dEhu3LjxwPP6nF5qQTVv3tyDluFpDD9pqGnfvr27DJD1UHPkyJE09219fujQoe5x586dJVgE3RFFD4Dbtm1zj5MWOdLnkrpw69SpI7179/a0jQAezWeffSYvvfSSK6rUAuKKFSu62RSbNm1yC3F++OGHYsXSpUvdDDA9RunZq67zodcV0tWGddq3Fk3rFHeENp3tpsNPWiSus/vef//9B96jKw9rca0VS5Yscfu2XgdNv7fa06rLN6xZs8b1vuoVAvS1YBF0wUZDje40KWlRUsrCJIINEDq9Nnv27JERI0a4Rep00T69YOCbb77pntMZFla0bNnSDTnt2LFDdu7c6a4dpQXUuoaPXiNLz/Kt9E752cmTJ929fr4PKwbXYGsp2DRs2NANKetJiV46QntvtLZGeyD1cilJNWTBIui+ZVqAxdW8ATv0Ipd6dWvrdPaX3mCbH3+j6tevn+ZlJIIVNTYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzwhITExMf6Y1hYRIRESFNmzYVv4iNjZXIyEjxC79tb0xMjMTHx7Nf+4Cftpn92j/8ts0xMTFy8+bN9A02xYoVk7Nnz4pfREVFSXR0tPiF37Y3EAhIXFwc+7UP+Gmb2a/9w2/bHAgEHmmfZigKAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZQBptSpUpJWFhYmrcGDRp43Tykg8TERFmxYoU0bNhQihQpItmyZZMKFSpI37595R//+If4wYQJE5L36127dnndHKSDuXPnPvTYlXRr3Lix181EOlm5cqU0bdpU8uXLJxEREVK6dGnp1KmTnDlzxuum+Vq4BKncuXPLwIED0ww9CH1DhgyRSZMmuVDTunVryZUrl/z3f/+3zJw5UxYvXiw7duyQypUri1UHDhyQkSNHSvbs2eX69eteNwfppFq1au5zTcvy5cvl4MGD8vLLLz/zdiH9T8zeeOMNmTFjhpQtW1Y6duwoOXPmlHPnzsk333wjp06dkuLFi3vdTN8K2mCTJ08eGTVqlNfNwFNw4cIFmTx5spQsWdKFGQ2xSf7yl7/I4MGDXeiZPXu2WHTnzh3p1q2b+xEsV66cLFy40OsmIZ3oZ6q31G7fvi1Tp06V8PBw99kjtH3yyScu1PTv3989zpgx432v371717O2IUiHomDbyZMnJSEhQWrXrn1fqFEtW7Z09z///LNYNXbsWHfmrsEt9QERNq1atUouXrzo9u9ChQp53Rw8gZs3b8ro0aOlTJky8vHHH6f5HdYAC+8E7b/+rVu33Hi1du3pMEXNmjWlVq1aXjcL6UB7KTJnzizbt2+Xq1evus83yd/+9jd3b7UO4bvvvnPBZsyYMfL888973Rw8I7NmzXL3vXv39ropeELr16+XS5cuSY8ePeTevXsSHR0tR48edaMMTZo0keeee87rJvpeeDAPV+iOk5KGG62/0DFNhC4ttBs/frz86U9/kooVK0qrVq2Sa2w2bdrkuncHDBgg1mhYf/31191QxTvvvON1c/CMaL3Fxo0bJRAIyCuvvOJ1c/CE9u7d6+61p6Zq1aou1CTJkCGDDBo0SCZOnOhhCxGUQ1EaaPRA8OOPP7rCyn379knXrl3l22+/dWfyv/zyi9dNxBPSL/+SJUvk2rVrMn36dPnzn/8sf//7312vXOfOnU125Y4YMUKOHTsmc+bMYQjKR/Tz1qHX7t2787kb8NNPP7l7rQPUofTY2Fj3m7RlyxYpX768fPTRRzJt2jSvm+lrQRlsdFZBo0aNpGDBgm4asJ7hzp8/34UbPfvRmTMIbToU06VLF3nvvffc1Eg9MGzdulXi4+PdlH7t3rVk586d7ixu+PDhpmd74X4aaDTY6DTvnj17et0cpNNnqnQ4XWundCQhR44cUrduXVm2bJnrtdFwA+8EZbB5GF3jRGltBkLXhg0bXHjV4aZ3333XddHrgaFOnTry1VdfSaZMmdwwlRU6Q0Jnwmi3tW4v/LWvnz592p2o6RonCH1JEx5q1KghRYsWve81PWnRouIffvhBLl++7FELEVL9/fnz53f3rPsR2tauXevudXG+1AoXLuzqbnT4UYepNPCEOt0OHYJKOstLy4svvpi84Jeu6wMbKBq2RxcSVVosnJak53X21MPeg6crpILN7t273T2L9IU2XdPj16Z06/Panas9NxZkyZJFevXqleZrOi6voScqKkoKFCjAvm2ITu9evXq15M2bV9q0aeN1c5BOkk7IDh8+nOYaVcePH3cLb+r3Gd4IumBz5MgRKVGihKutSf380KFD3WMtLkXo0vVrdLEyLb5r167dfWvZaCHx2bNn3Xs0EFiQNWvW5DP31LSgVIPNsGHD5IUXXnjmbcPTs2DBAhfitZbMyr4McbNymzVr5qZ96/c6ZW+czvbUISj9zC1OgAgVQfcvrzNl9AevXr16bmVaTb46nW7NmjUuDesPgL6G0NW+fXs3ayBpFoH2VmiXra7xotO9NQjoPgCEss8//9zdMwxlz2effSYvvfSS9OnTxxUQJw2f6/FLf7c+/PBDr5voa+HB2M2nXXy6k+gsmRs3brjamubNm7v1TTQpI7TplFc929HLJyxdulQWLVrkzmx1RdakmVKVKlXyupnAb6ZTgPV6YJGRkVKlShWvm4On0GuzZ88et4TDunXr3PFM6wPffPNN95zO6IV3gi7Y1K9f391gm3bN6wwhv88S0tW19QZbNNDohRJhl17kUqfyI/iE1HRvAACAX0OwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBlhiYmJiY/0xrAwyZAhgxQpUkT84uLFi5IvXz7xC79t7/nz5yUhIYH92gf8tM3s1/7ht20+f/683Lt3L32DDQAAgFceJbKEP84fyBmAbX7bXs5s/cNP28x+7R9+2+bz588/0vseK9jol+Ts2bPiF1FRURIdHS1+4bftDQQCEhcXx37tA37aZvZr//DbNgcCgUd6H8XDAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYOOxuLg4mTx5sjRr1kxKlCghmTNnlsKFC0u7du1k9+7dYt3KlSuladOmki9fPomIiJDSpUtLp06d5MyZM2JJfHy8DB48WOrVqydFixZ126qfc+3atWXOnDly584dr5uIdJCQkCBTp06V6tWrS7Zs2SRXrlzuM4+Ojva6acBvtnDhQunbt6/UqFFDsmTJImFhYTJ37lwJVuFeN8DvpkyZIhMmTJCyZcu6cFOgQAE5duyYrFq1yt0WLVokHTp0EGsSExPljTfekBkzZrht79ixo+TMmVPOnTsn33zzjZw6dUqKFy8uVly7dk2mTZsmkZGR0qJFC/c5X7p0SdauXSs9e/aUJUuWuMcZMnCuEcr79GuvvSZffvml26d79eolt27dktWrV0urVq3cd33AgAFeNxN4bMOHD3fH5Pz580uRIkXc42BGsPGY/tBt3rxZ6tevf9/zW7dulcaNG0u/fv2kdevWLiVb8sknn7hQ079/f/c4Y8aM971+9+5dsSRv3rxy5coV1yOXeju1x2r9+vUu2GjoQWjSQKM37YWLiYmRrFmzuufHjRvnznSHDBkiLVu2lFKlSnndVOCxzJo1S8qVKyclS5aU8ePHy7BhwySYcXrosbZt2z4QalTdunWlYcOG7qx+//79YsnNmzdl9OjRUqZMGfn4448fCDUqPNxW5taemNShJmk727Rp4x4fP37cg5YhvWjPjHrvvfeSQ43Ss9xBgwa53hsddgRCTZMmTVyoCRUEmyCWKVMmkz/y2juhgU17ou7duycrVqxwZwHTp0/33Y+71mSsW7fOPa5cubLXzcETuHDhgrvXOrHUkp7btGnTM28X4De2fjENOX36tGzYsMGNZ1apUkUs2bt3r7vXnpqqVavK0aNH7+vZ0LPbiRMnikW3b992QxNaj3Hx4kXZuHGjHDlyRHr06OGGHhG6tGdGnThxQipVqnTfa/qcSrmvA3g66LEJQjpDpmvXrq7rWguL0xqqCWU//fSTu580aZLkzp1bYmNj5ZdffpEtW7ZI+fLl5aOPPnKFtlaDjQ7DjRkzRj799FP5/vvvXe2F1hshtL366qvuXnsfdRZcEg2wOvNRXb582bP2AX5BsAnCoYnu3bu7H/k+ffq4gGNxG5XWnOjMr5o1a0qOHDlcXdGyZctcr42GG4t0O7W3RofgdEq7hhstzGvQoIFcvXrV6+bhCXTu3NnVxWnhv/ayvvXWW27m3+9+9zs37Vsx6w14+viWBdkPvk791SneXbp0cTUnFmkvjdKZIrqmS0paZ6JFxT/88IPps1v9gQsEAm7Wm/bWbN++XcaOHet1s/AEtBZOZ7aNGjXKfb76uWr9mE71Xr58uXtPwYIFvW4mYB7BJohCjdZZzJs3zy1Qp4sfWT27q1ChgrvPkydPmq8nPa+zp/xA1y9SOu0foU2XZRg5cqQbYtShZB12/etf/+oW4kwK8wCeLpu/nCEaaubPn+8W41uwYIG5upqUtLteHT58OM36Ip0ZlT17dreInR/oooQpZ8HBni+++MLd60KUAJ4ugk2QDD9pqGnfvr1butpyqFFJqyxrgNH6kpS08FKHoHRtF0vT3A8dOiQ3btx44Hl9Ti+1oJo3b+5By5Ce0qqT0mGo2bNnu1oyXbcKwNNl55cjROnsGB1+0qJSnRH0/vvvP/AeXe+lWrVqYslnn30mL730kiuQ1gLiihUryr59+9w6H7oQ1IcffiiWLF261M0Cq1Onjlt5VotJdXhCazJ01owWTus0d4S2WrVquUuB6HRvvR6YzvjTIUatG9PCeOsnLbBp1qxZsm3bNvc4acFYfS5p+FyPa71795ZgQbDx2MmTJ5OvJfSw4lH9IbQWbLTXZs+ePTJixAi3QJ0u2qcXhXzzzTfdc9aKLHUpfR1y2rFjh+zcudN93lpErev46PCE9tpZ6qHyKx1K1oLhXbt2uWFVXZhPr7Pz9ttvJ8+MAkLNtm3b3Al4SjrhQW9JCDZIpkXCwXyV1KdJz2z9ssS8Fo1SOGqfzojSG2DJ3BD7naLGBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZYYmJi4iO9MSxMIiIipGnTpuIXsbGxEhkZKX7ht+2NiYmR+Ph49msf8NM2s1/7h9+2OSYmRm7evJm+waZYsWJy9uxZ8YuoqCiJjo4Wv/Db9gYCAYmLi2O/9gE/bTP7tX/4bZsDgcAj7dMMRQEAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgEgVKlSklYWFiatwYNGog1c+fOfej2Jt0aN27sdTPxhBYuXCh9+/aVGjVqSJYsWdznqp897IiLi5PJkydLs2bNpESJEpI5c2YpXLiwtGvXTnbv3i1WJSQkyNSpU6V69eqSLVs2yZUrl9SrV0+io6O9bhpEJNzrBuCfcufOLQMHDkwz9FhTrVo1GTlyZJqvLV++XA4ePCgvv/zyM28X0tfw4cPl1KlTkj9/filSpIh7DFumTJkiEyZMkLJly7pwU6BAATl27JisWrXK3RYtWiQdOnQQSxITE+W1116TL7/80m13r1695NatW7J69Wpp1aqV+zcZMGCA1830NYJNkMiTJ4+MGjVK/ECDjd5Su337tjsLCg8Pl27dunnSNqSfWbNmSbly5aRkyZIyfvx4GTZsmNdNQjqLjIyUzZs3S/369e97fuvWra7XtV+/ftK6dWvXY2eFBhq91a5dW2JiYiRr1qzu+XHjxrneySFDhkjLli1NnpSGCoaiEDT0DO/ixYvuoFCoUCGvm4Mn1KRJExdqYFfbtm0fCDWqbt260rBhQ7l06ZLs379fLNGeGfXee+8lhxqlPZODBg1yvTdz5szxsIWgxyZI6JdB6w/OnTvnxmtr1qwptWrVEr+d4avevXt73RQATyhTpkzuXntgLblw4YK7L1269AOvJT23adMmGT169DNvG/7J1h4X4l+WHj163PechpvFixe7cVzrtP5i48aNEggE5JVXXvG6OQCewOnTp2XDhg2utqpKlSpiifbMqBMnTkilSpXue02fU0ePHvWkbfgnhqKCgAYa/VH/8ccf5fr167Jv3z7p2rWrfPvtt26c+pdffhHrtOtWZxp0795dMmbM6HVzAPxGd+7ccccv7YXWwmJr3+dXX33V3WvdWHx8fPLzOoyuM8TU5cuXPWsf6LEJCqlnCGlh7fz5893jBQsWyMyZM2Xw4MFilQYaDTY6Hbhnz55eNwfAb5R0crJlyxbp06ePCzjWdO7c2ZUNfP311643SnuYNcxpjWBSbWCGDPQZeIl//SCma4Co7du3i2XaZa1d140aNUpz3BpAaIQaPTHRKd5dunSR6dOni0VaM7R27Vo3i1UDzIwZM2TFihVuqrcuV6EKFizodTN9jR6bEBjL1eEpyygaBkI/1OiQuvY0d+rUyfVoWO610Onr2tOeurddp74rnfYN79jd8wxIWrnT8noIOi6t0yfz5s0rbdq08bo5AJ4g1OhifDp8bq2u5lF98cUX7r5jx45eN8XXCDYeO3LkiNy4cSPN54cOHZo8pmuVHgR1YT7tura0iBfgp+EnDTXt27d3l9HwQ6i5evXqA8/pMNTs2bPdbFZd3wfeYSjKY0uWLJFJkya564zoYmbZs2d3UwXXrFnjCtJ0tVZ9zarPP//c3TMMZXOIcdu2be5x0iJt+lxSd32dOnX43EPcmDFjZN68eZIjRw4pX768vP/++w+8R1ceTmul8VCma4wVL17cTfeOiIiQ2NhYt1+XKVNGli1b5otwF8wINh7T1TkPHz7spnjrMuTae6O1Nc2bN5f+/fu7669YpQeDAwcOuGXZra11AXGhRn/0UtJC+JTF8ASb0Hby5El3f+3aNRk7dmya79GhdGvBRofctGB4165d7gRUJz3otdHefvttt8AqvEWw8ZguR57WkuR+oIFGLygHm7SAlKt52+bXz1hnRPnl2n6hiBobAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGWGJiYmJj/TGsDCJiIiQpk2bil/ExsZKZGSk+IXftjcmJkbi4+PZr33AT9vMfu0fftvmmJgYuXnzZvoGm2LFisnZs2fFL6KioiQ6Olr8wm/bGwgEJC4ujv3aB/y0zezX/uG3bQ4EAo+0TzMUBQAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYBMEEhISZOrUqVK9enXJli2b5MqVS+rVqyfR0dFeNw1PwcqVK6Vp06aSL18+iYiIkNKlS0unTp3kzJkzYsncuXMlLCzsV2+NGzf2upl4QqVKlXro59ugQQOxJj4+XgYPHuyO0UWLFnXf4cKFC0vt2rVlzpw5cufOHa+b6HvhXjfA7xITE+W1116TL7/8UsqWLSu9evWSW7duyerVq6VVq1YyZcoUGTBggNfNRDp91m+88YbMmDHDfdYdO3aUnDlzyrlz5+Sbb76RU6dOSfHixcWKatWqyciRI9N8bfny5XLw4EF5+eWXn3m7kP5y584tAwcOTDP0WHPt2jWZNm2aREZGSosWLaRAgQJy6dIlWbt2rfTs2VOWLFniHmfIQL+BVwg2HtNAozdN+zExMZI1a1b3/Lhx46RGjRoyZMgQadmypckDhN988sknLtT079/fPc6YMeN9r9+9e1cs0WCjt9Ru377teijDw8OlW7dunrQN6StPnjwyatQoX/yz5s2bV65cuSKZM2d+4PurPbHr1693wUZDD7xBpPSY9syo9957LznUqPz588ugQYNc7412byK03bx5U0aPHi1lypSRjz/++IFQo/SH3g9WrVolFy9edIG9UKFCXjcHeCzaE5M61CR9f9u0aeMeHz9+3IOWIYk/jqRB7MKFC+5e6yxSS3pu06ZN7kcRoUvP4rS7ukePHnLv3j1XP3X06FF3ptukSRN57rnnxC9mzZrl7nv37u11U5BO9ARMa6p0WFVrBGvWrCm1atUSv9VKrlu3zj2uXLmy183xNYKNx7RnRp04cUIqVap032v6nNIfQIS2vXv3unvtqalatep9n6meAWrv3MSJE8U6rSPauHGjBAIBeeWVV7xuDtLxBE1De0oabhYvXuzqySzSIVUtGdDaOe2B1P36yJEj7t+BonhvMRTlsVdffdXdjx8/3lXbJ9EvyuTJk93jy5cve9Y+pI+ffvrJ3U+aNMkVWsbGxsovv/wiW7ZskfLly8tHH33kChKt02FVPbPt3r17msNxCD36Q64/6j/++KNcv35d9u3bJ127dpVvv/3W/cDrfm412GhP+pgxY+TTTz+V77//3tVEah0dvEWw8Vjnzp2lYcOGsnXrVqlSpYq89dZbbubM7373O9elq6iuD336Y650bF5rTPRsNkeOHFK3bl1ZtmyZ+4w13Fj/N9Bgo9OAdfYIbNCZb40aNZKCBQu65Sq0YHz+/Pku3GgP3cyZM8Ui/f5qb40OLetSDRpudJhVp7hfvXrV6+b5Gr+YHtOCM62g1xkF+uOmaX/FihVuqrdOiVV6wEBo014apTPddO2LlHQ8XouKf/jhB9O9cxs2bJDTp0+7H8G0aspgS9++fd399u3bxTI9buvQar9+/dzxW7d37NixXjfL1wg2QSBLlizurEe7MrUIT4ct/vrXv0pcXFzyjyFCW4UKFdy9FgunJel5nT1lFUXD/qwf1OEpv2jWrJm737x5s9dN8TWCTRD74osv3L0u5IbQpsON6vDhww+8piuV6vTQ7Nmzu8W+LNKaMV3aQNcASZoSC9t2797t7v20BpfOClOZMmXyuim+RrAJAmmNx+ow1OzZs10tRtu2bT1pF9KPzgzRszkNMEk9F0m0cFyHoPQH3+paNgsWLHDFll26dHE9lLBBZwHduHEjzeeHDh2aXEdoyaFDh9LcZn1OL7Wgmjdv7kHLkMTmUTTE6HoPupS+TvfW647ojBntytS6Cy0sZfaIDZ999pm89NJL0qdPH1dAXLFiRTeDRNcpKlmypHz44Ydi1eeff+7uGYayRS8foDP99LpJug9rr6MuZbBmzRrXEzls2DD3miVLly5121ynTh3XG6WTPLRsQGsltWdSJwTo8g3wDsEmCHTo0MEVDO/atcsdDLSwcvjw4fL2228nz4yCjV6bPXv2yIgRI9xCXrpon148780333TPWS0S16B+4MABd20dnfkHW0OsOryqAV1ndmqvhdbWaI+FXjokqebEEl0xW4ecduzYITt37nTXjtLJAbo+lZYN6Iw/qz2voYJ//SCgM6L8cp0Vv9OeOb9dIkMDjU6LhT3169d3Nz/RyRxM6Ahu1NgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwIywxMTHxkd4YFiYZMmSQIkWKiF9cvHhR8uXLJ37ht+09f/68JCQksF/7gJ+2mf3aP/y2zefPn5d79+6lb7ABAADwyqNElvDH+QM5A7DNb9vLma1/+Gmb2a/9w2/bfP78+Ud632MFG/2SnD17VvwiKipKoqOjxS/8tr2BQEDi4uLYr33AT9vMfu0fftvmQCDwSO+jeBgAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGUEXbOLi4mTy5MnSrFkzKVGihGTOnFkKFy4s7dq1k927d4tfTJgwQcLCwtxt165dXjcH6aBUqVLJn2nqW4MGDcSa+Ph4GTx4sNSrV0+KFi0qERER7rtcu3ZtmTNnjty5c8frJiIdrVy5Upo2bSr58uVzn3Xp0qWlU6dOcubMGa+bBp8JlyAzZcoU96NetmxZF24KFCggx44dk1WrVrnbokWLpEOHDmLZgQMHZOTIkZI9e3a5fv26181BOsqdO7cMHDgwzdBjzbVr12TatGkSGRkpLVq0cN/lS5cuydq1a6Vnz56yZMkS9zhDhqA7v8JjSExMlDfeeENmzJjhjtsdO3aUnDlzyrlz5+Sbb76RU6dOSfHixb1uJnwk6IKNHgQ3b94s9evXv+/5rVu3SuPGjaVfv37SunVryZIli1ikZ7HdunWTatWqSbly5WThwoVeNwnpKE+ePDJq1Cjxg7x588qVK1dcr2tKd+/edWf269evd8FGQw9C1yeffOJCTf/+/d3jjBkzPvB5A89S0J0qtW3b9oFQo+rWrSsNGzZ0Z3z79+8Xq8aOHSsHDx6U2bNnP3CAAEKJ9sSkDjUqPDxc2rRp4x4fP37cg5Yhvdy8eVNGjx4tZcqUkY8//jjNY5Z+3sCzFFJ7XKZMmUx/Ub777jsXbMaMGSPPP/+8183BU3Dr1i2ZO3eu66bPlSuX1KxZU2rVqiV+kpCQIOvWrXOPK1eu7HVz8AS0101PNnv06CH37t2T6OhoOXr0qOuZbNKkiTz33HNeNxE+FDIJ4fTp07JhwwYpUqSIVKlSRSz+4L3++utuCOqdd97xujl4Si5cuOB+BFLScLN48WJXn2DR7du3Zdy4ca4W4+LFi7Jx40Y5cuSI+3fQ4WWErr1797p77ampWrWqCzUpe+wGDRokEydO9LCF8KPwUKk76dq1q/vx18Jii0M0I0aMcEXSeqCwuH0Q90OuQ6raS5EjRw73IzBp0iRZsGCB+4HXIVYturQYbHS4IonOAhsyZIh88MEHnrYLT+6nn35y97ofV69eXWJjY6VSpUqyb98++eMf/ygfffSRC+xaGwn4tsYmrW7r7t27y5YtW6RPnz4u4Fizc+dOd1YzfPhwuuYN05lujRo1koIFC0q2bNlc79z8+fPdPq0zR2bOnCkWaYjT3hodqtCpv59++qnMmjXLTXG/evWq183DEx6fldZS6axV7X3Uz1sD/LJly1yvjYYb4FnKEOxfGp0WqlO8u3TpItOnTxdrdMaAzoLSbtx3333X6+bAA3379nX327dvF8v0Ry4QCLizd51Fo9urNWUI7eULVI0aNdxaRSnpSZoWFf/www9y+fJlj1oIPwoP5lCjXfd6RquLPGnBpcX1LnStDx2CUmnNIFEvvvhi8gJYOtUdtuTPn9/d+2nNIl2jSunSDghdFSpUcPdaLJyWpOd19tTD3gP4ItikDDW6GJ/WIFitO9H1eHr16pXmazr8pqEnKirKLW5mcRE3SPKK2n76fHVWWMqZjghNugSHOnz4cJq1kTqdXxca1eMX4NtgkzT8pKGmffv2boE6q6FGZc2a1dUbpEVrizTYDBs2TF544YVn3jakH50FpJcI0dqa1M8PHTrUPe7cubNYcujQIRfWUm/zjRs33KUWVPPmzT1qHdJD0grxOu1bj2O9e/dOfm38+PFuCErLCKwu0YHgFHR7m67hMm/ePFeAVr58eXn//fcfeI8Ox2jhJRAq9PIBOnNEr5tUsmRJdxars6LWrFnjzmw1vOprlixdutRtc506dVzA0XV79FpwutqwTvvWAlOdDozQ9tlnn8lLL73kJndoAXHFihXdrKhNmza5ff3DDz/0uonwmaALNidPnkyuPXlYYaEeJAk2CLUue+2u1wO+Xh5Eey20tkZ7LHQp+qSaE0tatmzphpx27NjhZv7pd1qLTbVQXq8npD2znMnb6LXZs2ePW7JCF17U3hu92Ombb77pntNZgMCzFHRHFS0S1hv4t7BELxOS1qVCLNOZMnqDfXqRS71iOxAM7E0zAgAAvkWwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYEZYYmJi4iO9MSxMIiIipGnTpuIXsbGxEhkZKX7ht+2NiYmR+Ph49msf8NM2s1/7h9+2OSYmRm7evJm+waZYsWJy9uxZ8YuoqCiJjo4Wv/Db9gYCAYmLi2O/9gE/bTP7tX/4bZsDgcAj7dMMRQEAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwI+iCzdy5cyUsLOxXb40bN/a6mXhCpUqVeujn26BBA7EmLi5OJk+eLM2aNZMSJUpI5syZpXDhwtKuXTvZvXu3180DfpP4+HgZPHiw1KtXT4oWLSoRERFuv65du7bMmTNH7ty543UT8ZRMmDAh+Zi9a9cuCSbhEmSqVasmI0eOTPO15cuXy8GDB+Xll19+5u1C+sudO7cMHDgwzdBjzZQpU9yBoGzZsi7cFChQQI4dOyarVq1yt0WLFkmHDh28bibwWK5duybTpk2TyMhIadGihduvL126JGvXrpWePXvKkiVL3OMMGYLuHBpP4MCBA+53Onv27HL9+nUJNkEZbPSW2u3bt2Xq1KkSHh4u3bp186RtSF958uSRUaNGiR/ogX/z5s1Sv379+57funWr64Hs16+ftG7dWrJkyeJZG4HHlTdvXrly5YrrgUzp7t270rRpU1m/fr0LNhp6YMOdO3fcb7D+TpcrV04WLlwowSZkYrSe1V68eFFatmwphQoV8ro5wGNp27btA6FG1a1bVxo2bOjOcvfv3+9J24DfSntiUocapSegbdq0cY+PHz/uQcvwtIwdO9aNnMyePVsyZswowSjoemweZtasWe6+d+/eXjcF6eTWrVuupurcuXOSK1cuqVmzptSqVUv8JlOmTMk/BoAFCQkJsm7dOve4cuXKXjcH6eS7775zwWbMmDHy/PPPS7AKiSPpqVOnZOPGjRIIBOSVV17xujlIJxcuXJAePXrc95yGm8WLF7taFD84ffq0bNiwQYoUKSJVqlTxujnAb6KlAuPGjZPExETXs67H6yNHjrjvN5M97JyIvv76624I6p133pFgFhLBRqvr9Qyge/fuQdv1hcejBzwdhtGzuRw5csjRo0dl0qRJsmDBAncg1GGZnDlzivWx6q5du7oDhhYWs28jlIPN6NGjk/9bZ8oMGTJEPvjgA0/bhfQzYsQIN+Fh7969QX+sCvoaGw00Gmz0i6JV9rBBK+obNWokBQsWlGzZsrmzgPnz57sfeu2hmzlzpliWFNS3bNkiffr0cdsNhCo9OdHemnv37smZM2fk008/deUDunTD1atXvW4entDOnTtl4sSJMnz48JAYWgz6YKPd9Npdrz+CpUuX9ro5eMr69u3r7rdv3y6WQ42GdJ3i3aVLF5k+fbrXTQLSrZhYSwZ0lt+MGTPc91hrMhC67t6962ZBVa1aVd59910JBUE/FEXRsL/kz5/f3Qfj2gjpFWp0GE57pzp16uSKp1njAxbpek1KlzlAaK9VdOzYMfc4rRlw6sUXX3T3K1eudMtWeC2og40Woa1evdqtlZA0dRC2Ja3Ca3GRvpShRhfj03qiYB+rBn4rne2YctYfQlOWLFmkV69eab6mQ+kaeqKiotzijMFy3A7qYKMHfi1K0+56Fi6zQ2dL6GUFtLYm9fNDhw51jzt37iwWh5801LRv394takWoQag7dOiQ+zFL/V2+ceOGu9SCat68uUetQ3rImjVr8shJalonqMFm2LBh8sILL0iwCOpg8/nnn7t7hqFs0WXWdQaUXl+mZMmSbllunRW1Zs0aN1NIvyT6miW67sO8efNckWX58uXl/ffff+A92oWb1qrbQLBaunSp+y7XqVPHBRxdj0qvi6arDWuPu858HDRokNfNhM8EbbCJjY1116PQpehZ38MWXWn38OHDsm/fPndJAT2709oaPbPr379/8ti8JSdPnkwer35YMaX+MBBsEEp0JXgdctqxY4ebOaP7t14DTgtNO3bs6HopWXgSz1rQ7nEaaHT6IOzRSwukdXkBy7RIWG+AJTVq1HA3+NPcID2uMR0DAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgRlhiYmLiI70xLEwiIiKkadOm4hexsbESGRkpfuG37Y2JiZH4+Hj2ax/w0zazX/uH37Y5JiZGbt68mb7BplixYnL27Fnxi6ioKImOjha/8Nv2BgIBiYuLY7/2AT9tM/u1f/htmwOBwCPt0wxFAQAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAwAyCDQAAMINgAwAAzCDYAAAAMwg2AADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2ASBxMREWbFihTRs2FCKFCki2bJlkwoVKkjfvn3lH//4h9fNA9LNhAkTJCwszN127dol1ixcuNB9b2vUqCFZsmRx2zl37lyxLCEhQaZOnSrVq1d3x65cuXJJvXr1JDo6WqwqVapU8n6c+tagQQOvm+d74V43ACJDhgyRSZMmuVDTunVrd2D47//+b5k5c6YsXrxYduzYIZUrV/a6mcATOXDggIwcOVKyZ88u169fF4uGDx8up06dkvz587vvsz62flL22muvyZdffilly5aVXr16ya1bt2T16tXSqlUrmTJligwYMEAsyp07twwcODDN0ANvEWw8duHCBZk8ebKULFnShRn9siT5y1/+IoMHD3ahZ/bs2Z62E3gSd+7ckW7dukm1atWkXLlyrmfDolmzZrnt0+/z+PHjZdiwYWKZBhq91a5dW2JiYiRr1qzu+XHjxrleKz1pa9mypckf+zx58sioUaO8bgbSwFCUx06ePOm6cvXAkDLUKD0gqJ9//tmj1gHpY+zYsXLw4EEX0DNmzChWNWnSxIUav9CeGfXee+8lhxqlPVaDBg1yvTdz5szxsIXwI4KNx/TsLnPmzLJ9+3a5evXqfa/97W9/c/eNGzf2qHXAk/vuu+9csNFhqOeff97r5iCde5xV6dKlH3gt6blNmzaJRRratH5Ke6e0xmj37t1eNwn/H0NRHsuXL5/rsv7Tn/4kFStWdOPSSTU2ekDo37+/2TFq2KcH/9dff90NQb3zzjteNwfpTHtm1IkTJ6RSpUr3vabPqaNHj4rVUNejR4/7nqtZs6ari9R6I3iHHpsgoF22S5YskWvXrsn06dPlz3/+s/z973+XWrVqSefOnSU8nPyJ0DRixAg5duyYG46wPATlV6+++qq715Oz+Pj45OcvXrzoagfV5cuXxRoNNBs3bpQff/zRFcLv27dPunbtKt9++63rYf/ll1+8bqKvEWyCwJgxY6RLly5unPrMmTPuS7F161Z3oNCpg5anTcKunTt3ysSJE91MIWb12aQnXrpMhR6vqlSpIm+99Za88cYb8rvf/c71PKsMGez9zOiwaqNGjaRgwYJuirv2SM6fP9+FG50JpzNa4R17e1yI2bBhg/uS6HDTu+++K4FAQHLkyCF16tSRr776SjJlyuSGqYBQcvfuXTcLqmrVqm6/hk3am7x27Vo3O0gDzIwZM9yaXDqkvnz5cvce/fH3C13DSGnNJLzDGIfH9KCg9KwntcKFC7u6G+3m1GEqDTxAKND9VYeglBbHp+XFF1909ytXrnTrNyE06UKEenKmt5Q2b97s7nXat99qjqyu0xQqCDYeu3379q9O6dbn9UxIe26AUPqx08Xa0rJlyxYXeqKioqRAgQIm1ziByBdffOHuO3bsKH6RNDOKfdpbBBuP6fo1OlVQF+Fr167dfWvZaCHx2bNn3Xv0hwIIFbqmiS5Wl5bu3bu7YKOL173wwgvPvG1IX7pMRVI9TRIdhtI1i3SWUNu2bcWSI0eOSIkSJVxtTernhw4dmlx7BO8QbDzWvn17mTZtmjuLLV++vDuL1RUtde0Pne6tPxAaegAEPw1z27Ztc4/379+f/FzSsIzWzvXu3Vss0dmbxYsXd9O9IyIiJDY21m1vmTJlZNmyZeZmw+kMVj0m6/WwdDFGvUSITmlfs2aNW2FbA7u+Bu8QbDymX/r169e7yycsXbpUFi1a5IanChUqlDxTKvX6EACCk4aaefPm3fecFpKmLCa1Fmw6dOjgCob1oqb6w64L8+lMuLfffvuBnhwLtB7y8OHDrvZRZ4PduHHD1dY0b97crTvWrFkzr5voewSbIKDDTDpzhNkj8ANdrdXqFa8tb9vD6IwoP10zqX79+u6G4MV0bwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGYQbAAAgBkEGwAAYAbBBgAAmEGwAQAAZhBsAACAGQQbAABgBsEGAACYQbABAABmEGwAAIAZBBsAAGAGwQYAAJhBsAEAAGaEJSYmJj7SG8PCJEOGDFKkSBHxi4sXL0q+fPnEL/y2vefPn5eEhAT2ax/w0zazX/uH37b5/Pnzcu/evf/zfeGP+gc+Yv4BAADwDENRAADADIINAAAwg2ADAADMINgAAAAzCDYAAMAMgg0AADCDYAMAAMwg2AAAADMINgAAQKz4fyG3gX5t+wnPAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x600 with 1 Axes>"
       ]
@@ -1216,7 +1222,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjUAAAJOCAYAAABP8PaaAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdBZJREFUeJzt3Ql4FOW6J/B/IBA2QQ0gmEBYlEWFYRgWNewCKiIgXGR5grLKot4rigsOA8KowBEjDigOIrvAlR0Z8bBdDLLIFRmvIBxQ2ZEjl4GDCFkINc//KxtD0mBQCJ23/r/n6dN9qlvS1fVV1Vvf975fRXme50FEREQknytwvb+AiIiIyNWgoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRETy1D//8z+jUKFC+OSTT673VxFjFNTIH9KsWTNERUVd078xffp09zf4HEmOHDmC4sWL4/XXX79oOb8rf5fceuWVV9x/s27dumvwLYMjUttJXmM74u/AdhXJ/vVf/xUTJ07E5MmT0aZNmzz7u40bN0bDhg3z7O/J9aGgxqhffvnFnXTr1q2LEiVKICYmBvHx8W7HHjp0KL7//vvr/RWxb98+dxDu2bMn8pP//t//O4oVK+auNkWCjvsv92Puz79n165d6Nu3L0aNGoVevXohLzHY27JlC+bNm5enf1fyVnQe/z3JAz///DMaNWqE//iP/8Btt92GpKQkxMbG4j//8z/dTj1mzBhUrVrVPSLZI488grvvvhvly5dHpNizZw9mzpzpAhsGiyKRokGDBti5cydKly6NSPX111/jjTfewIABA/L8b993333uIm/EiBHo0qXLNe9plutDQY1B48ePdwENr4jYxZt95927dy/S0tIQ6UqVKuUekYS/5/nz59GjR4/r/VVELsLewxo1aiCSMZi4nniB9+yzz2Lt2rUuyBF7NPxk0KZNm9zzk08+GfZqpHLlymEPftu3b8ejjz6KsmXLuuEqfu6ZZ57B8ePH/3SOSPa8Bz7z36cZM2a490KP0H9/uVyJDRs24KGHHsLNN9+MIkWKuPXhFdiZM2dyfDaU6/L3v/8djz/+uLuSLVq0qOsFupJ8FgYz/K516tTB7bfffsnPHTp0CN26dXN/hyeaxMRErF69GleCQWnXrl1dL1XhwoWRkJCAp59+Ose2uFweRaQM77G38IYbbgi7bahdu3bue+7evdv9/3/84x8YO3YsmjZtiltvvdWtP58fe+yxKx42ZQDP4L5ixYquTfP35O+xf//+K/qtwuVLhfLKUlNTMWzYMNfzyeTX0LbgegwfPhx33HGH69UrWbKk+y3YBrP//XDS09MxYcIE3H///ahQoYL7/tw3O3bsiG3btuX4/OXawpXs25fLDatUqZJ7ZP3/3CeI/2ZoH87+3+d2O/yRz3/11Vf4p3/6pwufLVOmDOrXr4/XXnstx2c7d+7snoOef2WZemoM4lAT8STBE3BufP755+7gyQMpDxA8WDE4evvtt7F8+XJs3rz5qnZr83v9y7/8i/v3/8t/+S/o0KHDhfeyHjTDmT9/vgsaeADjlR8P1CtXrnTj9H/961/dwZ2BTlYnT550Q3Ls+WEvy08//eQSFrnOW7duxV133fW73/mbb77BsWPH0KlTp0t+5sSJEy6I4YGVB2V+nn/ngQcewIIFCy5az0tZtmyZOwEVKFAA7du3dye0b7/91iVXcv2++OIL3HTTTcgveHU8cuRILFmyBN27d7/oPQ6Jfvrppy6Bs1q1am4Zh1AYDDRv3twNQTIpm7kYc+bMwf/5P//HncQY5P0e/k7cvswva9u2rQtEGbx8+OGHWLFihWvfVapU+dPrx/bAYRVu4xtvvNGd3D3Pc3+b34Htge9xe/KkzO3LNvh76/D//t//c4EH8+CYUMtt/sMPP7j/nt8/JSXFnbyv577N78cAgevP/Znrn30fvtLtcCWf/7//9//i3nvvRcGCBd2+wt+U+zr3F/aqcpg4K+YVcn9as2bNH1pfyQc8MWfp0qUeN+0NN9zgPffcc95f//pX7z//8z8v+fnMzEyvatWq7r/59NNPL3rv+eefd8t79+590fKmTZu65VmNGDHCLfu3f/u3HH9j2rRp7j0+h+zdu9cte/zxx8N+r3D/zT/+8Q+vVKlSXkxMjPf1119ftA5dunRxnx81atRF/w6X8TFo0CD3uZApU6a45f379/dy45133nGff//998O+H/o73bt3986fP39hOb9n4cKFvTJlynhnzpy57O/F7VSyZEkvLi7O27dv30X//ty5c93nn3rqqQvL+N9yGf+t7H7v9w33ef47V/LIjT179rjv8eCDD+Z4b8KECe69iRMnXlh28uRJ7/jx4zk+u3btWq9AgQJe3759f7edpKene5UqVXL7wFdffXXR59evX+8VLFjQa9u2ba5/K77HNh9uH6hTp06O7/sf//Ef7r0OHTrk+LdSU1O9n3/+Oezfyf65Q4cO5Vi+fft2r0SJEl7Lli0vWh6uLfyRfTvcuoYkJCS4R1b8zfjf8DfM7kq3w5V+/tlnn3V/e8mSJTn+9qWOeY888oj7b3744Yew70v+pqDGqDfffNMd+EInWj54cHvyySe93bt3X/TZlJSUS550ePC9+eabvSJFinhpaWnXPaiZOXOmWzZw4MAcn9+/f78XHR3tValS5aLl/Hzx4sVznEgyMjLc5+vWrevlxtChQ92/tWzZsrDv8z0edLMHI9SnTx/3/oIFCy77eyUnJ7tlXM9w+F1Lly59TYKa0L91JY/cuueee9xv/fe///2i5Q0aNPAKFSrkHTt2LFf/Tq1atdxJ7/fayaJFi8IGuCEdO3Z0ARKD5D8b1PAiIrtQUNOtWzfvWnj44YddoMwg4HJt4Y/s21czqLnS7XClnw8FNbxwy60BAwa4/4a/jdij4SejmAzXr18/17W/ceNGfPnll65b95133sEHH3zghkSYy0Ch8flw4+jMBahXr54b3vnb3/6GWrVq4Xq63HflmDq7pTnsxgow5nGEcGgje7VSdHQ0brnlFtddnRuh/INQF3s4/A7hhhU4hMDfnd//csNXHAogbqtw+SPM3+CQDR9Xu8qFv6l/Trv6ONzCYYO5c+e6YYpQJRmr8R5++OEc68IhRCa883fgup47d+7Ce8yx+T2h35FtNlyOydGjR12OFNsK2/efrTrKrmbNmqhdu7ZbX+ZYcdiRvy+HXTkMlVscXvnLX/7ihpD4nTMyMi56n7/N5aoDr/e+faXb4Uo/z2FathMOU3IoulWrVmjSpAni4uIu+Z2Yhxf67cQeBTWG8aTOxLhQchwTF19++WW8++676NOnDw4fPuxOEKdOnXLv8wQfTuigGfrc9ZSb78oDHj+XNahhkmY4DGwyMzNz9beZXBwKLC7lUt8rtJzb4PfyKIjB5+Uw3yCSS3ez4wmH+RezZ8++ENTMmjXLPWevJGPOFD/Pky5zK5ifwYTrUNJ4bpJsQ78j8zB+73f8s8Jtc7YrVtjwxLxw4UI899xzbjlzrZ566imX68E8kMvhxUiLFi3c69atW7vcEv4m/B2Yn8Q8lt+rYrze+/aVbocr/TxzsRgAc04u5lxNmzbNLWeuEZPNmZeV3dmzZ90z25TYo6AmQJgky2RTJlvyxMDE1//23/7bhRM+q4PC4dXR5QKDkNAVaNar6pDfO5nn1tX6rn8ET0hZD7zhXOp7hZb/Xol66Htz2+Qmeflq/uZMxrzSqpDczl7Lq2Mmu/JkzKvw6tWruwCHvwd7arL/m0z0ZgJ39iqz3E6cFvodP/74Y5dsei1/x0vNd8KEfVYv/a//9b9cojODHP5/VumxSoqTYF4Oq3cYtKxfv94luWfFHg0GNddif+H6hPsdQr/FlUyzcKXb4Uo/H+oFZQIxgxX27PG/5YUbqyNZ9ZU9GTy0/4b2Z7FFQU3A8IDFapKs/ut//a/umVc8L7zwQo4rIg5dsZeCJ6LLCVXksAcou3AlqKEr1dz2lGT/rux6zurgwYNuyIYHsay9NFdLqHueJ+VLOXDggAsYsw9B8cSU9ftfCq88Fy1a5IZqchPUXOlv/ntBDauUrsSVTMnPHhkGNQxmWA3Esl32GGavVOM2vPPOO3MEND/++KOr/smN0HT4/B1zc3IMDSlejd8x3D7H4Sg+OOTLIUpWMP1eUMPfgcFg9oCGpfGsAMuNP7Jvs02F+x3YPjhUmz2oudx+fKXb4Uo/nxXXg8NsfHB7soJu1apV6N+//0Wf4/7LoDLS5/SRP0bz1Bj0v//3/8a///u/h32PJxWWzHKnD500WXLKOTZ4tZN9PpVXX33V5ZKwhPr3chlC5aWccZfj3iE8QIXrTubBkwd8BiO5xbJNHlTZzbxjx44Ly5kL8uKLL7orzGs1LwuvCHlFz6vBS+GBnUN8WXNTOOcMh1p4Zfh797rh1PEMyDg8kXX9sp7QQnkHxJMRP8+TZNYeJF6Zc9v9kZyaK3lcCV45c5uzLbCNULhJDBkQfvfddxf1LnDIb+DAgTlySi7XThg8JCcnu9Ln7PjvME8law8Bf0su498OYW7W7wUf4TAACHfbgNA6ZQ/kwuHvwCkCsrYDtq8hQ4a4qQJy44/s29yP+d0/++yzC8tYDs48vcvlqITbj690O1zp53lsCTccfKnfmevBIJX5OBp+skk9NQbxAMZpyDnRFw9qnLiMV2XcmdljwBMzu2c5zwvx/3PYgfkLPOkyB4cHVB4weIXHgyJvrfB7OJkd/x672e+55x6XsMdei6VLl7ohhsWLF1/0eeYH8ADKgxdPbrwy53e53BwePPm8//777kDMqzrmXjBY4AGbwxVM2nz++edxLfCEzAnheFDlgTTciYnJoXyf69WyZcsL89Qw2OK8GaG8nEvhujC5lNuA8/ewR4NXlByGCJ1oOC8HE8CJJyNOyhe6zxdPCjwRswue3zUS7vEVwvbG3jUG3QxKuY3ZRrLj+vDBXgbOq8LfjlfcDKL4m+Rm2IV/i/MCPfjgg+53YG4Ke9oYRLNNcj/g8BCHhUKY9/LEE0+4tsvfn4E596XczAUTLsGXk+SxPXLyvXLlyrneD15UsI0PHjz4d/8N/gZM4mVPDX83tjfuj/x3GIDmZuLIP7JvM3jh3+XnuZ/x5M/fnxdC4ZKS+duOGzfO/XZMgmdPMP8G9+Mr3Q5X+nnmzfzbv/2ba0ecH4i/EXuxOA8Ne2yZQJwV/3vuS7mZL0ryqetdfiVX365du7y//OUvXqtWrbzKlSu7kk0+WNLN8ssvv/wy7H/HMtR/+qd/ciXDLLNl6ea//Mu/hC23DVfSHZob4rHHHnOlokWLFvXuvvtuV24ZruyW/va3v3lt2rTxbrzxRi8qKuqiEudL/TfEckyWqfK/Y2lrtWrVvP/xP/6Hd/r06RyfvdIS1cv513/9V/fv8flSf+fgwYNuzpxQuSzLmVeuXJnj85crgec2ZBk4vxvX76abbnLlzP/8z//sbdmy5aLPci6SV155xatQocKF3+Ltt99283BcSUl3Xvj8888vlIOzRD4czvHz3nvveXfeeaf7/cqVK+d+i59++ilsu7tcO+E8L2zDt99+u5vbiHMA1axZ0811s2bNmrBzEfGzbP8VK1b0hg8f7sqmL1fSHQ7bwEsvveTaf9myZd124b/HkuRNmzbl+vfiFAAs4y9WrJjbLx999FHv+++/D1tGfbny/ivZt2n+/PmuvfF78/d/+umnXQn4pfYXHm9Cv1u43+pKt0NuP8+5d3i8qV69upvbhtNY3HHHHd7LL78cdt169uzp1oltSWyK4v9c78BKJL9g9zeHKXiFy6tXkUjB3jv2cLDX7o8MmVnHoTz2ILH3b+rUqdf768g1opwakSvABMPRo0e74S6W3IpEilAuEG8FIDkxT4c5Sf/zf/7P6/1V5BpSTo3IFWIeD6uccnujT5FriRMYMm+LuTPMf2H+jIRPaGaC+uUm5pP8T8NPIiL5GGfU5V3CWc3IhN3sJeAiQaKgRkRERExQTo2IiIiYoKBGRERETFBQIyIiIsGqfrrUTdtERERErrXcpABfUUk3p9wON022VSzZ5ZTcQRG09eUNEjkVvtq1bUFb3yC266Bt46C269y4oqCGO8ihQ4cQFLyjLm8UGBRBW19OUsb76Khd2xa09Q1iuw7aNg7iOsfnclJJ5dSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYkLEBTXnz5/HxIkTUbduXRQrVgwlS5ZEkyZNsGzZMli3eDHQqhUQGwsUKQJUrgx06wYcPAhTDh8+jPHjx6N169aoWLEiChcujHLlyqFTp0744osvYNHs2UD//kC9ekBMDBAVBUyfDtM8D1i0CGjeHChfHihWDKhe3f8dfvgBJlWqVAlRUVFhH82aNUMQjB079sI6b968GZZwn+W+e7nHfffBlNTUVDz77LPuPHzrrbeiSJEi7nidmJiIadOmISMjA5EkGhHE8zw8+uijWLhwIapWrYo+ffogLS0NS5cuRfv27TFhwgQ89dRTsHjwHzAAmDwZqFoV6NoVuOEG4MgR4LPPgP37gQoVYAa3Iw983MYMbMqUKYM9e/ZgyZIl7jFnzhx06dIFlgwb5m/H0qX9EzxfWzdkCJCc7K9vhw5AyZLA118D778PzJ0LbNwI3HUXzClVqhSeeeaZsAGPddu3b8eIESNQvHhx/PLLL7CmTh1gxIjw7y1YAOzYAdx/f15/q2vr9OnTmDRpEho0aICHHnrIHa9PnDiBFStWoHfv3pg3b557XaBAhPSReLnEj8bFxXnX0vz5893fSUxM9M6cOXNh+bFjx7yEhAQvJibG27t3r5dXHn744Tz5O+PH8/f1vEGDPO/cuZzvZ2TYWt+FCxd669aty7E8JSXFK1SokHfTTTd5qamp1/x7sD3nRbumVas8b98+//Xo0f72njbNuy7yYjv/+KPnFSjgeQkJnnfy5MXvJSf769+rl2eqXROPU3xcT3nZrrNKT0/36tat6zVs2NBLSkpy32HTpk3mtnE4aWmeFxvredHRnnf0qGdqnTMzM700rmA2GRkZXrNmzdx2Xr58+TX/HrltzxESWvnYI0Mvv/wyihYtemF56dKlMXjwYNdrw+4uS86eBUaOBKpUAd5+GyhYMOdnoiOqP+3P69ixI5o2bZpjeePGjdG8eXN3FfDNN9/AkpYtgYQEBMa+fRxKBhIT2XNx8Xtt2/rPx45dl68m18hrr72GHTt2YOrUqSgY7kBm2JIlwPHjftu+5RaYUqBAAZcikF10dDQeeeQR9/q7775DpIio0+XRo0fdc2Umk2QTWrZ27VqMZBRgxMqVwIkTQK9eQGYmwNSh3buBG2/0T4S33YZAKVSo0IUdRvKv228HeBzcsAE4dcofegpZvtx/tpZ7EMKLr+nTp+PIkSMuJ7B+/fpo2LAhLPvqq69cUDNq1CjccccdCJopU/znvn0RGOfPn8enn37qXt8VQePIEXXmYI8M7d27FzVr1rzoPS6j3TzjG7J1q//MC5vatf2AJoRDlIMHA+PGIRAOHDiA1atXo3z58qhVq9b1/jryJzDZfcwY4LnngBo1gPbtf8upWbsWGDQIMJged+HirBevUrJgYDN37lyXR2YxiHvsscdQp04dvPDCCwga5setWQPExwMPPACz0tPT8frrr7vc1+PHj2PNmjXYtWuXa+v3RdAVSkQFNQ8++KBLOhozZgxatGjhsqyJPyCrZejkyZOw5Kef/GcmVNatC2zZAjCe27YNeOIJ4M03/eThgQNhGjPoe/To4Q6QTCIOWve1RQzI4+L8q9f33vtteaNGQPfu9oZViQd4DqPyyrVEiRLuIiw5ORmzZs1yB34Oq97AKgBDhg8f7hL9t27dGsj9lhkRHGrt2TN8+oCloGZkllESVrcNGTIEo0ePRiSJqJya7t27u5yK9evXuyv1p59+GgMGDMCdd97punEpYjKsrxLuDMSueo7L1q8PlCjB/BJg/ny/t4aBjfVuzJ49eyIlJQX9+vVzwY3kf6NGAUlJzJHzpyX4+Wdg/XqWiAKsbrY4SwMrf3hBVrZsWTclBXsvZs6c6dr0/v378T5LvwzZtGkTxo0bh2HDhkXUEEReHr8Z1LCUu3dvmFaiRAnXS5OZmYmDBw/inXfewZQpU9xUBac4xhwhIipCYB4FS8NeeeUVF7xMnjwZixYtcuXcC1gvB7iDhSWhJErOX3LrrRe/x2MEE4i//549VDAb0LAskGXcSUlJeC/rJb3kW6tX+6WvHGJ66SW/a57BOntpPv6YuVP+0FRQ9OfkPGCO0QZYce7cOTz++OOoXbs2XuJGDmg7P3AAaNHCn1csCAoUKID4+HgMHDjQnaPZpplPFSkirgM4JibGXe3wkdW6devccz2e/Q3hZGTExOBwQstZJXWpz+TngIbd9byS7datm0uutNYTF1QrVvjPnHgvu3Ll/DwbDrGePu0HO9aF8gUtzd3C+Us47EThqmPonnvucc+LFy9GB05WZEwQE4Sz4jxjWc/PkSDigppL+fDDD91zV85MZ0jooL9zZ873OFEjK+WKFwfKlIHZgIYT7THnIIjj8Valp1++bJvLGb/+WuxmXmimbEsT8PEClBOkhsOhZAY87dq1c5O1WVrvEJZwcxaSm28Gfq1sDpwjnCE2S9VqJIi4oIZjc6H8mRAOPXHuA1YQcI4TS5gEzGCXpd2M+rNG/Kwe4bAT8xIsJVWGhpwY0HTu3BmzZ89WQGMM56eZONFPgO/U6eK5ajjCeOiQ/xneMsIKVoLwth/Mpcm+/MUXX7yQN2gF5xJjTkU4zJFjUDN06FDcfffdsGjWLD945/HZUjvO7ttvv3VBafZ2febMGXf7BGrTpg0iRcSdKjmfQ4UKFVxJN6uftmzZ4rq2qlSpgvnz55s8+b37LnDvvUC/fn6ycKhrnqWvnLDtjTdgCueymDFjhks8q1atGl599dUcn2FXNZMsreCx//PP/deheQW5LNRry1wTS13YnTsDkybxih2oVg1o184fPv3qK79dc25NBjyWsHKTlU68R05CQoK7VQCrnz755BNX3ccTPN8TGz74wH+2tN+G89FHH7l23ahRIxfcsNOB9+9j/isrk1ntx8lxI0XEBTUcimByMG+ExgMBJ91jZv3zzz+fowfHUm/Nl1+yNBLgXEbstWHewZNP+suM5UZjH6eb/XVM/lIJZtx5LAU1DGhmzLh4GXNGs+aNWjo48tqD7fitt3hQBObM8a9qOdtqqCIq21RU+R4rN3fu3Ilt27a5Ck5eyTKXhlexgwYNupB/IPkfp97Yvh1o0ACwPqVW27Zt3TDTxo0bXbUbj9u8vxkTxJkOwl73SJosNYr3SsjVB6OiEBcXh0PsNw4IjgcH4e7gQV1fZvDzikPt2ragrW8Q23XQtnFQ2/WhXLRnlZqIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFClSBK1atUJQbNmyBQ0aNEBQBG19V61ahdTUVLVr44K2vkFs10HbxkFt12fPnr26QU1cXBwOHTqEoGjXrh2WLVuGoAja+sbHx+Pw4cNq18YFbX2D2K6Dto2D2q4P5aI9a/hJRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJERfUzJ49G/3790e9evUQExODqKgoTJ8+HVZx1aKiLv+47z6YN3bsb+u7eTPMOX8emDgRqFsXKFYMKFkSaNIEWLYM5i1evBitWrVCbGwsihQpgsqVK6Nbt244ePAgLElNTcWzzz6LJk2a4NZbb3XrWq5cOSQmJmLatGnIyMiANZ4HLFoENG8OlC/vt+3q1YH+/YEffoA5hw8fxvjx49G6dWtUrFgRhQsXdtu4U6dO+OKLL2BVpUqV3Lk43KNZs2aIJNGIMMOGDcP+/ftRunRplC9f3r22rE4dYMSI8O8tWADs2AHcfz9M277d/w2KFwd++QUmD/yPPgosXAhUrQr06QOkpQFLlwLt2wMTJgBPPQVzPM/DgAEDMHnyZFStWhVdu3bFDTfcgCNHjuCzzz5z+3aFChVgxenTpzFp0iQ0aNAADz30EMqUKYMTJ05gxYoV6N27N+bNm+deFygQcdeSf9iQIUBysh/QdOjgB+tffw28/z4wdy6wcSNw110wY8KECRg7dqxrzwxsuI337NmDJUuWuMecOXPQpUsXWFSqVCk888wzYQOeiOLlEj8aFxfnXWurVq3y9u3b516PHj3a/d1p06Z518PDDz/sXS9paZ4XG+t50dGed/So3fVNT/e8unU9r2FDz0tKYjvzvE2b8uZvsz3nRbueP99fr8REzztz5rflx455XkKC58XEeN7evV6eyavtPH78ePf7Dho0yDt37lyO9zMyMkytb2ZmppfGHTfMejZr1sz9FsuXLzfTrn/80fMKFPDb8MmTF7+XnOy3+V69PFPbeOHChd66detyLE9JSfEKFSrk3XTTTV5qaqq543VCQoJ7XE+5bc8Rd8nQsmVLJCQkIOiWLAGOHwfatgVuuQVmvfaa3xs1dSpQsCBMYo8MvfwyULTob8tLlwYGD/Z7baZNgylnz57FyJEjUaVKFbz99tsoGGbjRkdHXEfxn8IeGA5HhFvPRx55xL3+7rvvYMW+ff6wamIir+Ivfo/HLTp2DKZ07NgRTZs2zbG8cePGaN68ueuZ++abb67LdxOfraOKIVOm+M99+8Ksr77yg5pRo4A77oBZR4/6z5Ur53wvtGztWmDkSJixcuVKd4Dv1asXMjMzsWzZMuzevRs33niju3C57bbbEBTnz5/Hp59+6l7fZWgs5vbbAcZwGzYAp075Q08hy5f7z0HIBwwpVKiQyWA9JC0tzeW3cvi4ZMmSqF+/Pho2bIhIY/PXz+eYRrRmDRAfDzzwAExi78Rjj/k5RS+8ANPYI0N79wI1a178HpfR7t0wZevWre6ZPTS1a9d2AU3WHo3Bgwdj3LhxsCg9PR2vv/66yyk6fvw41qxZg127drkA7z5DZ/nYWGDMGOC554AaNfz8sFBODYP0QYNs5oqFc+DAAaxevdrlgdaqVQsWHT161LXhrBjYzJ071+UYRQoFNRGIQxHs1u3Z0+6QzPDhwJ49PPnZXceQBx8E5s3zTwAtWgBFivjLObw4frz/+uRJmPLTTz+55+TkZNStWxdbtmxBzZo1sW3bNjzxxBN488033YFw4MCBsBjUcOgthBUiQ4YMwejRo2ENh0/j4vwe5ffe+215o0ZA9+7stYB5rGrr0aOH68lgEnG4odb8rlevXm6IjT2NJUqUcBcp3LdnzZrlAnUOubEIIBJEXE5N0DGYYVDD0ubevWHSpk0AL9KHDbNVGXEpPLiz5HX9eoAXcU8/DQwYANx5529d9oYKYi4MuRBzTFgVwis6Hgx5YJw/f77rrWFgYxHXk700HHZj2fo777yDKVOmuNLXUxynMYRDx0lJfr4YK/R//tlv56mpACt9rU9ZwHbes2dPpKSkoF+/fi64sWjEiBFo0aIFypYti2LFiqFOnTqYOXOmW19WMb7PcrcIYexQmv+tXs2uTP+KPlwORn537hzw+ONA7drASy8hEHi1umIF8MorfvAyebI/twe761m2T2XLwlz5J3G+Kc7ZkhWv9phA/P333+OktS6qLBi4xcfHu94olrVv2LABrzGJzNCxilMxcIiJ+zKHy0uU8HtpPv6YOSb+0JTlgIal+izjTkpKwntZu6oCoj8nJALzqjYgUgSgczB/sZ4gfPq0P+xEYQpFnHvu8Z8XL/bnvrAgJsY/AWSfk2jdOv+5Xj2YUp0zsAEuMTic0HJWSV3qM5ZwThNaF9rgBjBQJ/ZCZleunJ9ns22bv88z2LEW0HBIhr0VnEiSCbSW5h/KLc4nR79E0ARjCmoiCHMsWP57883ArxWg5vDkzsnnwklJ8QOedu2AMmU4qRPM+/BD/7lrV5jC8lbauXNn2BwEljYXL17cTV4WBKwYyVohY0F6+uXLtrmc53lDq5wjoOFEe8wrsZhHkxuhWZQjaQK+4IWWEWzWLP9AwTFqnvwt4jwt7I0K97j3Xv8zQ4f6/5+VUVaES6Xg0BPn56lfn/NfwJTQjKsMXphPktWYMWPcsBPnbrFU/vrtt9/izJkzOZZzGW+fQG3atIEVnJ+GOKPwP/5x8XsciTl0yO91tXQsCw05MaDp3Lmzu62P9YBm165dYds1l7/44ovudXcmDkaIiDui8AD4+eefu9ehSYy4LNRt26hRI/Q1OjbzwQf+s9HVCzRO58A7ArCkm9VPW7b4Q09VqgDz59usAHv33Xdx7733ugRKJgvXqFHDVT+tXbvWTbD5xhtvwJKPPvrIVYTwGMUrV87lwXsF8dYILO1mkjRL2a3o3BmYNMnvYa1Wze9h5Ugi559iSTcvYBjwWDJq1CjMmDHDJYNXq1YNr776ao7PdOjQwSXSWjFv3jzXrnlPM+637GFl9dMnn3ziel2HDh3q3osUERfUMKBho8mKSUhZE5EsBjU8yfEeSA0a+BUyYgtvB8PkYN6sk/c1ZBI4q7+ef/7iScus9dZ8+eWXGD58uJt8jhPy8eZ/Tz75pFvGSgpL2rZt64aZNm7ciE2bNrl7QTFhmvP08L5XvMK31DPFQHzlSuCttxjQAXPm+D3NnAE9VBGVfV6m/G4fp1H+9T5fl0r6ZkBrKahp3ry5G0bmBcn69etdrw1zadjrOGjQoAv5YpEi4vYwJlxZviv3pTCYcXfYCjBudqubnpVPfAQNb1jJO1QHASu9+AgSDi2x8ikolYxBPD81bdo07K0hIpVyakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAlRnud5ufpgVBSKFCmCVq1aISi2bNmCBg0aICiCtr6rVq1Camqq2rVxQVvfILbroG3joLbrs2fPXt2gJi4uDocOHUJQtGvXDsuWLUNQBG194+PjcfjwYbVr44K2vkFs10HbxkFt14dy0Z41/CQiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICREZ1FSqVAlRUVFhH82aNYMlqanAs88CTZoAt94KFCkClCsHJCYC06YBGRkwyfM8LFq0CM2bN0f58uVRrFgxVK9eHf3798cPP/yAIBg7duyFdr1582ZYcvgwMH480Lo1ULEiULiw3647dQK++AImTZ8+/ZLHrdDjvvvugyWzZwP9+wP16gExMUBUFH8HBMLixYvRqlUrxMbGokiRIqhcuTK6deuGgwcPwpLz54GJE4G6dYFixYCSJf3z1bJliEjRiFClSpXCM888EzbgseT0aWDSJKBBA+Chh4AyZYATJ4AVK4DevYF58/zXBSIy/PzjhgwZguTkZBfQdOjQASVLlsTXX3+N999/H3PnzsXGjRtx1113wart27djxIgRKF68OH755RdYM2ECgzagalU/sGG73rMHWLLEf8yZA3TpAlPq1Knjtmk4CxYswI4dO3D//ffDkmHDgP37gdKlgfLl/dfW8YJswIABmDx5MqpWrYquXbvihhtuwJEjR/DZZ59h//79qFChAizwPODRR4GFC/19uU8fIC0NWLoUaN/e38+fegqRxcslfjQuLs7LCwkJCe5xvT388MPX/G9kZnpeWlrO5RkZntesGX93z1u+3DOzvvTjjz96BQoUcNv45MmTF72XnJzs2lqvXr2u+fdge87Ldh2Snp7u1a1b12vYsKGXlJTkvsOmTZvy7O/nxXZeuNDz1q3LuTwlxfMKFfK8m27yvNRUz1S7vpS0tDQvNjbWi46O9o4ePWqqXa9a5Xn79vmvR4/2j1fTpnl5Li+38fjx493vO2jQIO/cuXM53s/gwdvIOs+f72/TxETPO3Pmt+XHjvE87XkxMZ63d6+XJ3Lbno1d/+c/7IFh13x20dHAI4/4r7/7Dqbs27cP58+fR2JiouuRy6pt27bu+dixY7Dqtddec1ftU6dORcGCBWFRx45A06Y5lzduDDRv7vdGfvMNAmHJkiU4fvy4a9u33HILLGnZEkhIQGCcPXsWI0eORJUqVfD222+H3X+jefA2YulS//nll4GiRX9bzp65wYP9XhumSUSSiP3109LS3Bg1u/Q4NFG/fn00bNgQQcFxzE8/9V9bG4W5/fbbUbhwYWzYsAGnTp1y2zdk+fLl7tla7kHIV1995YKaUaNG4Y477kAQFSrkPxs69l/WlClT3HPfvn2v91eRP2nlypU4ceIEevXqhczMTCxbtgy7d+/GjTfeiJYtW+K2226DJUeP+s+VK+d8L7Rs7Vpg5EhEjIg9rBw9etQ1nKwY2DDfguOY1qSnA6+/7o9hHj8OrFkD7NoF8Cewdn5nYt2YMWPw3HPPoUaNGmjfvv2FnJq1a9di0KBBeCriBmqvTqD+2GOPudyLF154AUF04ACwerWff1GrFsxjfsWaNWsQHx+PBx544Hp/HfmTtm7d6p7ZQ1O7dm0X0IQUKFAAgwcPxrhx42BF6dL+8969QM2aF7/HZZTlJ4gIERnUMJhp3LixSxQtUaKEazhMKp01a5a7gv/mm29cYpa1oCZrtMsqgiFDgNGjYRJ3/ri4OHf1+t57711Y3qhRI3Tv3t1UF27I8OHDsWfPHndgtDrsdDms5OvRw++yZhJxEH6CadOmuaHWnj17BnKbW/PTTz+5Z56P6tatiy1btqBmzZrYtm0bnnjiCbz55pvuonvgwIGw4MEH/WKVMWOAFi386lzihTerG+nkSUSUiMypYQVBixYtULZsWVfqyyvbmTNnokePHu7KhxUy1pQo4ffSZGYCrAh85x12WwOsYD91CuZw+CUpKQkvv/yyK4H8+eefsX79eqSmprqyfXbrWrJp0yZ3BTds2DDTVV2XG07t2RNISQH69fODG+sYzDCoYSl3b5YyioltShw+Z64URw944c2L8Pnz57veGgY2VnTv7ufArV/v96w+/TQwYABw551+aTdFWmVuhH2dy+McJsRcDKvYQOLjAQb6kydzXZlYClNWr17tAlcOMb300kuua54HBvbSfPzxxyhUqJAbmrLi3LlzePzxx113Ndc3aHge4DmdZdxJSUCWjjnT2M4PHDjgLtA4h4nkf6HChnr16uFWTiyWBS9WmED8/fff42SkdV/8Qeww55Qir7zin5t4Tlq0yC/nXrDA/0zZsogo+aqPv/SvA3wW5/UIh/N70Lp1MGUF9xLwCqB5jvfKlSvn8mzYnXv69GkX7OR3XA8OO4Wu8MK55557LkzoxXl7LAU0zAubORPo1s2fmC3SruyuFSUI28MJQomJweGElrNK6lKfyW9iYjh64j+yCp2XOPFiJMlXQc0Xv05Fam0Cvks5cuTiahEr0plAdJmybS5nNy57bCyIiYlBH85aFUZKSooLeNq1a4cyZcqYattZAxpOtDdrVjDyaIgl3EuXLsXNN9+MR0JzM0i+F7oQ27lzZ473MjIy8N1337kJNbkvW/fhh/5z166IKBEX1OzatQsVK1Z0uTTZl7/44ovuNRNJrfj2WwZp/vTTWZ05498+gdq0gSmcn2bixIku2a5Tp04XzVXDpOFDhw65zzAYsKBo0aIXrtqzYwIpg5qhQ4fi7rvvhrUhJwY0nTv70+kHJaAhFjUweGfemJV2LJxVtypat27tSru5T2fthWNFJ4eduM0tFTqcOvVb/kwIh56mTmVFsj8nVSSJuF9+3rx57mTXpEkTJCQkuKiX1U+ffPKJi4R58Od7Vnz0ETPpWfXjBzdsPLxvDkdomGHOyco4yZElnTt3xqRJk1wvRbVq1VwvBbtqOYcLS7oZBLANSP41ahQwY4afAF+tGvDqqzk/w1G2OnVg0gcffBCIoSfG6p9/7r8OTabIZaGhCR7XrP0E7777Lu69917069fPJQuHhst57OI564033oAlDRsCvOsDS7pZ/bRli799q1QB5s+PvIuV6Ejs3mPXHhsJq2HOnDnjcmnatGnj5i9hlGwJJ9DlMNPGjayQ8e8FxY6L2rX9bj1e7RoK+h2WtvJK56233sJHH32EOXPmuKtazrYaqohimaTkX/v2+c9sz5dKdGcQbzGoYZkv7+3VoEED1DI+GQ8DGgavWbG4IWsth7Wghr01X375pZui4dNPP3XHMuYCPvnkk24Zq3Yt6dLFTw7mPXc5LQNz3nnPr+efz9mDEwki7nTZtGlT9wgKJllFWqJVXmCXPCuBglgNlBVnzebDGq6SwdXKFQYz/u3y7AvqduYNK1muHwSvvOI/8ouA1CGIiIiIdQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiZEeZ7n5eqDUVEoUKAAypcvj6A4fvw4YmNjERRBW98ff/wR58+fV7s2LmjrG8R2HbRtHNR2nZmZeXWDGhEREZHrITfhSvSV/INBivyDGAkHbX2DeEUbxO0ctPUNYrsO2jYOarvOjSsKariDHDp0CEHRrl07LFu2DEERtPWNj4/H4cOH1a6NC9r6BrFdB20bB7Vd54YShUVERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExISKDGs8DFi0CmjcHypcHihUDqlcH+vcHfvgBphw+fBjjx49H69atUbFiRRQuXBjlypVDp06d8MUXX8C6xYsXo1WrVoiNjUWRIkVQuXJldOvWDQcPHoQlqampePbZZ9GkSRPceuutbl25nRMTEzFt2jRkZGTAmkqVgKio8I9mzWDS+fPnMXHiRNStWxfFihVDyZIl3TZftmwZLJo+/dLbOPS47z6YNnbsb+u6eTPMmT17Nvr374969eohJiYGUVFRmM4NH6GiEYGGDAGSk/2ApkMHoGRJ4OuvgfffB+bOBTZuBO66CyZMmDABY8eORdWqVV1gU6ZMGezZswdLlixxjzlz5qBLly6wxvM8DBgwAJMnT3br3rVrV9xwww04cuQIPvvsM+zfvx8VKlSAFadPn8akSZPQoEEDPPTQQ247nzhxAitWrEDv3r0xb94897pAgYi8zvjDSpUCnnkmfMBjsU0/+uijWLhwoWvTffr0QVpaGpYuXYr27du7ff2pp56CJXXqACNGhH9vwQJgxw7g/vth1vbt/voXLw788gtMGjZsmDsely5dGuXLl3evI5qXS/xoXFycd639+KPnFSjgeQkJnnfy5MXvJSfze3her15ennj44Yev+d9YuHCht27duhzLU1JSvEKFCnk33XSTl5qa6llZ35Dx48e7NjVo0CDv3LlzOd7PyMi45t+B7Tmv2nVmZqaXlpYWdj2bNWvmvsfy5cs9S9uZ+zAf11tere/8+fPddkxMTPTOnDlzYfmxY8e8hIQELyYmxtu7d6+pdn0pbOqxsZ4XHe15R4/aOnaFpKd7Xt26ntewoeclJfnnpk2b8u7v59U6r1q1ytu3b597PXr0aNe2pk2b5uW13LbniLss3LePXbhAYqJ/lZdV27b+87FjMKNjx45o2rRpjuWNGzdG8+bN3dX8N998A0vOnj2LkSNHokqVKnj77bdRsGDBHJ+Jjo7ITsQ/jD0wHFoMt56PPPKIe/3dd99dh28mVwt7ZOjll19G0aJFLyznFe7gwYNdrw2HGoNgyRLg+HH/mH3LLTDptdf8nqipU4EwhzAzWrZsiYSEBOQXEXfmuP12gMf+DRuAU6f8oaeQ5cv9Z+tjtCGFChUyeYJfuXKlC9Z69eqFzMxMl2+we/du3HjjjW4Huu222xAUzMH49NNP3eu7rIypZpGW5uddHDni78v16wMNG8Kko0ePumfmhWUXWrZ27VoX0Fs3ZYr/3LcvTPrqKz+oGTUKuOOO6/1tJKuIO1vGxgJjxgDPPQfUqAG0b/9bTs3atcCgQYCxYemwDhw4gNWrV7sxzFq1asGSrVu3umf20NSuXdsFNFl7NHhVO27cOFiUnp6O119/3eVfHD9+HGvWrMGuXbtcgHefwWid5/levS5exsCGuXFVq8IU9sjQ3r17UbNmzYve4zLK2tatYsrFmjVAfDzwwAMwGag/9pifT/TCC9f720jEBzU0eDAQF+dH+e+999vyRo2A7t3ZcwHTWAnTo0cP113NJOJwwzP52U8//eSek5OTXZXIli1b3Elg27ZteOKJJ/Dmm2+6RMuBAwfCYlCT9UqdlQRDhgzB6NGjYQ2DmcaN/aT+EiV4QvcLAGbN8ntbOap6ww0w48EHH3QJ32PGjEGLFi1chRsxeGWFI508eRLWcYSNKQQ9e9oclhk+HNizhxdnNtcvv4u4nBpil15SEsemAVb2/vwzsH49y2L9UlCj1ZEXhiN69uyJlJQU9OvXzwU3FteRmGPCCq/69eujRIkSLo9o/vz5rreGgY1FXE/20nDYjWXr77zzDqZMmYJmzZrhFMdbDWFVSIsWQNmy/rQMvLKdORNgk+bVPKsZLenevbvLg1u/fr3rXX366addhd+dd97pSrvJWnVbdty1GdSwvLl3b5izaRPATuRhw+xU4FoTcXvY6tX+wZBDTC+95Hdh8iqPvTQff8w8E39oyiKe7FneyzLupKQkvJe1m8qQUr9mgHPeA87ZkhXzSphA/P3335u+quXJLT4+3vVGsax9w4YNeI2D9AHA+aaIeXOWMPeNZfmvvPKK277crosWLXLl3AtY3wwGeGVhGY/fBw74wWyY1KJ87dw54PHHgdq1/XOTRKaIG8hZscJ/5sR72ZUr5+fZbNvGeT/8YMdSQMO8ipkzZ7rJ5zi5kdWruuqcSRFwicHhhJazSupSn7GE8xPRunXrEAS/pp6YnNeDk5ONGDHCPbIKbVsG8pZZThDmOYfDThSmkNG55x7/efFif441yXsRF9Skp1++bJvLea7/tTDIXEDDifZmzZplLo8mK3bR086dO8PmE7G0uXjx4m6CuiDghINZq92sC02UbXECvkv58MMP3TMnmbSKJdysar/5ZuDXWQpMiYkB+vQJ/15Kih/wtGsH8LAVpLYdaSIuqOH8NBMn+gmFnTpdPFcNR2MOHfI/wwZmaciJAU3nzp3dlNSWAxoKzZ7M0m7mk/TNclnHJEsOO3H4zVIp+7fffotKlSq5qfOzOnPmjLt9ArVp0wZW7NoFVKzo59JkX/7ii/5rJv1bw7yoUP5MCIeepk6d6nLHOC+VVUwA50Up8yGtHJ+z4tRDoZ6o7JgUzaBm6FDg7rvz+ptJVhF31ujcGZg0yY98q1XzI1+OQHBeAJZ0s2Ex4LFi1KhRmDFjhksgrVatGl599dUcn+nQoQPqMMvSkHfffRf33nuvS4ZmsnCNGjVc9RPn8eBET2+88QYs+eijj1y1V6NGjVxwwxMf7/vFHAxWxzBJmqXsVsyb5++nTZoAnLeL08iz+umTT9gb5x/8+Z41DRs2dLf3YDUfq59Y2cehJ+aJMQne8gXLBx/YHXoKsilTpuDzzz93r0MTwXJZaEiVx7SsF6bXW8QFNdznV64E3nqLJwJgzhw/+ueslKGKqGxTQORr+ziF8q/3BrpUoihPgtaCGvbWfPnllxg+fLibfI69NrzB45NPPumWWUuobNu2rRtm2rhxIzZt2uS2NxOmOU8PhyTYW2epZ4ojjBxdZP4bKxfPnPFzadgZxbmmfk0jMofDx0wO3rx5sxtK5aR7vHfO888/n6MHx5ItW/z7IDVoABibVivwPv/8c3fhnRULG/gIiaSgJor3SsjVB6OiEBcXh0Mc/wmIdu3amb27bjhBW19WH7G3RO3atqCtbxDbddC2cVDb9aFctGeb5TUiIiISOApqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFClSBK1atUJQbNmyBQ0aNEBQBG19V61ahdTUVLVr44K2vkFs10HbxkFt12fPnr26QU1cXBwOHTqEoGjXrh2WLVuGoAja+sbHx+Pw4cNq18YFbX2D2K6Dto2D2q4P5aI9a/hJRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJERfUpKYCzz4LNGkC3HorUKQIUK4ckJgITJsGZGTAnEqVKiEqKirso1mzZrBm+vTpl1zf0OO+++6DJZ4HLFoENG8OlC8PFCsGVK8O9O8P/PADTJo9ezb69++PevXqISYmxm1XbvsgGTsWiIryH5s3w5TDhw9j/PjxaN26NSpWrIjChQujXLly6NSpE7744gtYdf78eUycOBF169ZFsWLFULJkSTRp0gTLli2DdYsXA61aAbGx/rm5cmWgWzfg4EFEjGhEmNOngUmTgAYNgIceAsqUAU6cAFasAHr3BubN818XiLhw7M8pVaoUnnnmmbABjzV16tTBiBEjwr63YMEC7NixA/fffz8sGTIESE72A5oOHYCSJYGvvwbefx+YOxfYuBG46y6YMmzYMOzfvx+lS5dG+fLl3esg2b4dYDMvXhz45ReYM2HCBIwdOxZVq1Z1gU2ZMmWwZ88eLFmyxD3mzJmDLl26wBLP8/Doo49i4cKFbr379OmDtLQ0LF26FO3bt3e/yVNPPQVrPA8YMACYPBmoWhXo2hW44QbgyBHgs88A7toVKiAyeLnEj8bFxXnXWmam56Wl5VyekeF5zZrxe3je8uVennj44Yfz5O8kJCS4x/WWV+t7KWlpaV5sbKwXHR3tHT169Jr/PbbnvGjXP/7oeQUKcDt73smTF7+XnOy36V69PHPbedWqVd6+ffvc69GjR7vfetq0aV4Q2nV6uufVret5DRt6XlKSv403bcqbv51X7XrhwoXeunXrcixPSUnxChUq5N10001eamqqZ2kbz58/3/22iYmJ3pkzZy4sP3bsmDuGx8TEeHv37jXXrseP99vwoEGed+5c+PPztZbb9hxx/R3sgSlcOOfy6GjgkUf81999l+dfS/IAr+6OHz+Otm3b4pZbboEV+/axy9ofQi1V6uL32rb1n48dgzktW7ZEQkICgui114AdO4CpU4GCBWFSx44d0bRp0xzLGzdujObNm+PEiRP45ptvYAl7ZOjll19G0aJFLyxnb+TgwYNdr8005kkYcvYsMHIkUKUK8Pbb4dszz8+RIoK+yuXxpPDpp/5ra930xJ2B+QZHjhxxY7T169dHw4YNESRTpkxxz3379oUlt9/uB+obNgCnTvlDTyHLl/vPxlKIAu2rr/ygZtQo4I47EEiFChVyz9GRdLa7Co4ePeqeKzOZJJvQsrVr12IkowAjVq70U0B69QIyMwGmDu3eDdx4Iy9cgNtuQ0SJ2BaXng68/ro/lnf8OLBmDbBrl//DWjwBcGfpxZXLgoHN3Llz3ditdcy3WLNmDeLj4/HAAw/AEibVjRkDPPccUKMG0L79bzk1a9cCgwYBBofhAyktDXjsMeaNAS+8gEA6cOAAVq9e7fKoatWqBUvYI0N79+5FzZo1L3qPy2g3z/iGbN3qP7OHpnZtP6DJOrIyeDAwbhwiRsQNP2UNahjs8mrnnXeAv/3NT7ZkopI1DGZ4Qv/73/+OX375Bdu2bUOPHj3w7//+764K6Oeff4Z17LJlVUHPnj1R0GB/PXd8JrkzEf6994C//AX4618BdsZ17x5Z3bfyxw0fDuzZ41dqGmzGvysjI8Mdu9jzzCRia/vygw8+6J7HjBmDVJbq/orD5qwEo5MnT8KSn37yn1nowOHzLVsAnpJSUoBq1YA33/SLeyJFxAY1JUr4vTTs7mK5GAMbjk6wwpld+JawEqhFixYoW7asKxFkddDMmTPdwYE9GO+zRMYwBjMMaljy25slbgYxOE9K4li83555UFi/3p/CgG06ANWg5m3a5F+xDhtmc4j894QuSlJSUtCvXz93/LKme/fuLl9o/fr1rhfq6aefxoABA3DnnXe6tAEqYKw09/x5/5lD6EuWcATBPz83bgzMn+/31jCwiRQR/+vzB4uPBwYO9HtpmJfA8eog4BwftIErbRi7qtllzcAu3Fh1frd6tV/ayyGml17y2zMPCo0aAR9/zPwDf2hK8q9z54DHH/e757mNgxjQ8IKEZdxJSUl4j92RBjFHaMWKFXjllVdc8DJ58mQsWrTIlXNzOgrixaklpX4tbqhXz587LisG70wg/v579lAhIuSrTu/Wrf3ndesQCKHxWw5JWWY1QTiE8yoRJ97LjhNLMs9m2zZ/aIrBjuQ/3HYcdqJw1Zt0zz2/TWDGuYosBTQcQmfvcrdu3VzBg7Xeiqw4kSR717PPtbXu1xMTJ5u0pHp1/5mJweGElrNK6lKfyUv5KqjhRD/0a2K9eaFZOS1OwJd1LJplkjfffDMeCdXsG8P8sMuVbXM5zwFBadcWxcQAffqEf4+5Bwx42rXzJxO1tDtnDWg40d6sWbPM5dHk1ocffuieu3JmOkOa/3oxtnNnzvc4wz+nWOEEk2zbkSDigppvv/V3ek4jn9WZM/7tE6hNG5ixa9cuN8U4c2myL3/xxRcvjONaxYNgenq667LmFZBFnJ9m4kQ/0a5Tp4vnqmEv/aFD/meMrn4gcMqSXzscc+jZ0w9qhg4F7r4b5oacGNB07tzZ3RYjCAHNqVOnLuTPhHDoaerUqa5ilfP3WFK1qj9KwtJutvGsHeqs6uSwE/MFI6XYIUK+xm8++sg/+DPfgMEN287hw34XPku7mZzEShIr5s2bh+TkZHfvEE5UVrx4cVcS+Mknn7hKgqFDh7r3rPrggw9MDz1R585+dUCoWoBX7Oym5XwmLOnmCZFt3uKw4ueff+5ehyZh47JQN32jRo1Mb3frRo0ahRkzZqBEiRKoVq0aXn311Ryf6dChgyt8sITzh1WoUMGVdBcpUgRbtmxxbbpKlSqYP3++ycDu3XeBe+8F+vXzk4VDQ+Y8fnF+zTfeQMSIuKCGM6xymIn3wmE1AceqeWXLBDz26rE4JlIiwquBmfQ7d+50ZdzMqD9z5ozLpWnTpg0GDRrk7qliFQ8G27dvR4MGDczNZ5EVj3G8ynnrLT9onzPHH5LipMmhiqhsU16YwICGJ72smPSeNfFdQU3+tY9TZbt8otN47RLVGxw6txbUcJiNycGbN292F54sbuB9zp5//vkcPTiWemu+/NKfsoCT4PJ4xnzAJ5/0l0VSbnTEhQfMsTKWZ3VZnGY83FTjQcBgxr+tmH0cWmJVTJAqY5gwGrS7cofDn8DizxDU7cvKJz6CpkIFf/6lSGc3RV1EREQCRUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExIQoz/O8XH0wKgpFihRBq1atEBRbtmxBgwYNEBRBW99Vq1YhNTVV7dq4oK1vENt10LZxUNv12bNnr25QExcXh0OHDiEo2rVrh2XLliEogra+8fHxOHz4sNq1cUFb3yC266Bt46C260O5aM8afhIRERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYkK+CGrGjgWiovzH5s0w5/z585g4cSLq1q2LYsWKoWTJkmjSpAmWLVsGq2bPBvr3B+rVA2Ji/G07fTrMW7x4MVq1aoXY2FgUKVIElStXRrdu3XDw4EFYMn36dERFRV32cd9998GSw4eB8eOB1q2BihWBwoWBcuWATp2AL76ASZUqVbrk9m3WrBmsSU1NxbPPPuuOz7feeqvbh8uVK4fExERMmzYNGRkZsMjzgEWLgObNgfLlgWLFgOrV/WP4Dz8gokQjwm3fDowYARQvDvzyC8zxPA+PPvooFi5ciKpVq6JPnz5IS0vD0qVL0b59e0yYMAFPPfUUrBk2DNi/Hyhd2t9J+NoybucBAwZg8uTJbjt37doVN9xwA44cOYLPPvsM+/fvR4UKFWBFnTp1MII7bhgLFizAjh07cP/998OSCRP8C7CqVf3ApkwZYM8eYMkS/zFnDtClC8wpVaoUnnnmmbABjzWnT5/GpEmT0KBBAzz00EMoU6YMTpw4gRUrVqB3796YN2+ee12gQL7oL8i1IUOA5GT/WN2hA1CyJPD118D77wNz5wIbNwJ33YXI4OUSPxoXF+flpfR0z6tb1/MaNvS8pCR+B8/btCnv/v7DDz98zf/G/Pnz3W+bmJjonTlz5sLyY8eOeQkJCV5MTIy3d+9ez8r6hqxa5Xn79vmvR4/2t+20aV6eYnvOq3Y9fvx497cGDRrknTt3Lsf7GRkZXl7Jy+2cXVpamhcbG+tFR0d7R48eNbW+Cxd63rp1OZenpHheoUKed9NNnpeaaqtd8xjFx/WWV9s4MzPTteFw+2+zZs3c7758+XJT6/zjj55XoAC3teedPHnxe8nJ/rG7V69r/z1y254jOpx87TVgxw5g6lSgYEGYxB4Zevnll1G0aNELy0uXLo3Bgwe7Xht2a1rTsiWQkIBAOHv2LEaOHIkqVarg7bffRsEwjTk6OuI7Ta+KJUuW4Pjx42jbti1uueUWWNKxI9C0ac7ljRv73fYnTgDffHM9vplcLeyBKcxxxTD77yOPPOJef/fdd7Bk3z6mSACJieyVu/i9tm3952PHEDEi9kj61Vd+UDNqFHDHHTDr6NGj7pm5FdmFlq1du9adFCV/Wrlypeui7tWrFzIzM12u1O7du3HjjTeiZcuWuO222xAUU6ZMcc99+/ZFkBQq5D9bjF154cUcKg6lMh+wfv36aNiwIYKEeZGffvqpe31XxIzDXB233+7nh23YAJw65Q89hSxf7j9HUnpcRO5iaWnAY49xXB544QWYxh4Z2rt3L2rWrHnRe1xGPAFK/rV161b3zB6a2rVrX7Q9eeXHHrlx48bBOuYNrVmzBvHx8XjggQcQFAcOAKtX+/kItWrB5IUZA/asGNjMnTvX5Y9ZlJ6ejtdff93lyrHnke16165d7newlgAfGwuMGQM89xxQowbQvv1vOTVr1wKDBgGRlPYZkcNPw4f7CXYcdbE67BTy4IMPuucxY8a4zPoQ7ijjWUoB4OTJk9ft+8mf99NPP7nn5ORkl1S5ZcsW/Pzzz0hJSUG1atXw5ptvuuRD6ziMyivanj17hh2Cs4jFMD16+BdqTCK2tto8ifOE/ve//x2//PILtm3bhh49euDf//3f3cmd7dxqUMPe81GjRuGdd97B3/72NwwZMsQVAlg0eDAwbx4TpYH33gP+8hfgr38F2CHXvXtk9UBGXFCzaRPAi1ZWxxjrxQure/fuaN68OdavX49atWrh6aefdlUyd955p+vKJWuZ9EHDEzlxLJ45JbyKLVGiBBo3boz58+e77cvAxvpvwKCGpb6sEgkCbvaePYGUFKBfPz+4sYYVbi1atEDZsmXddBSseps5c6YLbNgz9z7LYwzi/steGg4nczoGBjYcWmUZ+ymO0RgzahSQlMTcT4CzTzBWXb+eJe4AK/cjafaRiDpbnjsHPP44ULs28NJLCAQmmLEE8JVXXnEnN0b6ixYtcuXcLH0lHjAk/2LvDNWrV8/NbZEVx9+ZQPz999+b7pFbvXo1Dhw44E6A4fLHLAY0jN1Yxs2TAa9ug6Q/JzAB8zA2wDIeszmcOnDgQHfs5vq+xmRQQ1av9qdV4RATz8vx8QzqgEaNgI8/9vPFODQVKSKo08jv2uKwE4VJMHfuucd/XrzYr5e3ICYmxl3xZJ/XY926dRdOhpJ/VecsVYBLDA4ntJxVUpf6TH4XpARhBjRMMZk5E+jWzZ9UMmidraFcQQ5JBUVrTk6U5bhtxYoV/jMr+LLj5JLMs9m2zT9/M9i53iIqqOHMsn36hH+PXbgMeNq18ye1MjivUw4ffvihe+ZEbZJ/cXiRdu7cmeM9zkDKEtDixYu7ibwsYn4Ypy64+eabL5S9BiGg4UR7s2bZy6PJjS9+nULZ4gR8l8LqLyoUKnUzIj398mXbXM6gPVJWO6KuHzhNCy/owj3uvdf/zNCh/v9nZZQV4cZgOfQ0depUl3/RkRNgSL7FChBexTF4CfVYhDBBnMNOPNlbnatm1qxZLrEyKSnJ9UpaH3JiQNO5s38rEMsBDat9zpw5E3b5iy++eCFn0JJvv/027DpzGW+fQG3atIEliYn+M2cU/sc/Ln6Pw6qHDvkjKJGya9s8iuYznNOBU+SzpJv3EmF1DLswmWvBRFKLlSI8t3/+uf86NCEZl4V6bjlea2mk4t1338W9996Lfv36uWThGjVquEoRzkGUkJCAN954A1Z98MEHgRh6YjLljBl+F3y1asCrr+b8DIfMrVyQ8ZYArOjjfZDYhtnbyOkKPvnkE9cDOXToUPeeJR999JFb50aNGrleKBZzHD582OVFskeSyf+cosGSzp0BFmdytITtmqMlHCXnXHIs6WZnBAOeSKGgJgJ06dLFJQdv3rzZHQyYSDls2DA8//zzFyqgrGFAwxNAVswpzJpXaOkcyN6aL7/8EsOHD3eTdHFCPt4I78knn3TLrCaDM0Dfvn27u1cOq/ss48yrxNyCS+WKcjTGSlDDYVUOqTI4Z/UmeyuYS8OeikGDBl3IMbGEM2FzmGnjxo3YtGmTuxcUCwE4/xTTBFjZZ63HtWBBTiAKvPUWgzo/+Z1DUpwQPFQRlW2Ktesq3/z6TLazehdnVj7xESSWt+elsDfO4i0vLofBjH/rOPuC1qabNm3qHkHCoo0gFm7ExPiVT/mhKjmicmpERERE/igFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFChQAOXLl0dQHD9+HLGxsQiKoK3vjz/+iPPnz6tdGxe09Q1iuw7aNg5qu87MzLy6QY2IiIjI9ZCbcCX6Sv7BIEX+QYyEg7a+QbyiDeJ2Dtr6BrFdB20bB7Vd58YVBTXcQQ4dOoSgaNeuHZYtW4agCNr6xsfH4/Dhw2rXxgVtfYPYroO2jYParnNDicIiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImBBxQc3hw4cxfvx4tG7dGhUrVkThwoVRrlw5dOrUCV988QWCYuzYsYiKinKPzZs3w5rz54GJE4G6dYFixYCSJYEmTYBly2BSpUqVLmzP7I9mzZrBmtTUVDz77LNo0qQJbr31VhQpUsTtx4mJiZg2bRoyMjJgkecBixYBzZsD5cv7bbt6daB/f+CHH2DW4sWL0apVK8TGxrptXblyZXTr1g0HDx6ENbNn+9uzXj0gJgaIigKmT4dZ06f763i5x333IWJEI8JMmDDBndCrVq3qApsyZcpgz549WLJkiXvMmTMHXbp0gWXbt2/HiBEjULx4cfzyyy+weOB/9FFg4UKgalWgTx8gLQ1YuhRo355tAHjqKZhTqlQpPPPMM2EDHmtOnz6NSZMmoUGDBnjooYfcfnzixAmsWLECvXv3xrx589zrAgUi7rrqTxkyBEhO9gOaDh38YP3rr4H33wfmzgU2bgTuugtmeJ6HAQMGYPLkye6Y3bVrV9xwww04cuQIPvvsM+zfvx8VKlSAJcOGAfv3A6VL+9uZry2rUwcYMSL8ewsWADt2APffj8jh5RI/GhcX511rCxcu9NatW5djeUpKileoUCHvpptu8lJTU7288PDDD3t5LT093atbt67XsGFDLykpyf3umzZtMrW+8+ezPXleYqLnnTnz2/JjxzwvIcHzYmI8b+/ea/892J7zql0nJCS4RyTIi+2cmZnppaWl5ViekZHhNWvWzP3uy5cv9yy16x9/9LwCBfw2fPLkxe8lJ/ttvlcvW+16/Pjx7m8NGjTIO3fuXNjtbe1YvWqV5+3b578ePdrfrtOmeXnuepyfsuLuHRvredHRnnf0qHfN5bY9R9xlUseOHdG0adMcyxs3bozmzZu7q71vvvkGVr322mvYsWMHpk6dioIFC8Ii9sjQyy8DRYv+tpxXPoMH+70206Zdt68nVwF7YDh0nF10dDQeeeQR9/q7776DJfv2+cOqiYnslbv4vbZt/edjx2DG2bNnMXLkSFSpUgVvv/122OMVt7c1LVsCCQnX+1tcf0uWAMeP+237llsQMfJViytUqJDZHYW++uorF9SMGjUKd9xxB6w6etR/rlw553uhZWvXAiNHwpS0tDRMnz7ddc2XLFkS9evXR8OGDREk58+fx6effupe32VpHAbA7bcDjOM2bABOnfKHnkKWL/efIyn34M9auXKlu8js1asXMjMzsWzZMuzevRs33ngjWrZsidtuu+16f0W5hqZM8Z/79kVEyTfRwYEDB7B69WqUL18etWrVgjU84T322GOoU6cOXnjhBVjGHhnauxeoWfPi97iMdu+GOUePHnUngKwY2MydO9flI1iUnp6O119/3eVeHD9+HGvWrMGuXbvc73CfpTM8gNhYYMwY4LnngBo1/PywUE4Ng/RBg2zlim3dutU9s4emdu3aLqDJ2lM3ePBgjBs37jp+Q7lWmEe0Zg0QHw888AAiSr4Ialgp0aNHD3fiZxKxxWGZ4cOHu4RoHigsrl9WDz4IzJvnnwBatACKFPGXsytz/Hj/9cmTMIUncQ6hsneiRIkS7gSQnJyMWbNmuZM7h1SZYGkxqOEQRQirvYYMGYLRo0fDIg6fxsX5V6/vvffb8kaNgO7d2csMM3766Sf3zHZct25dbNmyBTVr1sS2bdvwxBNP4M0333TB+sCBA6/3V5WrjOkBHGrt2ZNBLSJKxOXUhOuu7tmzJ1JSUtCvXz8X3FizadMmd0UzbNgwc13y4fDgzpLX9esBdro9/TQwYABw552/ddkbK4px1WwtWrRA2bJlUaxYMdcjN3PmTNeeWSHyPstjDGIAx14aDk+wvPedd97BlClTXBn7KY7RGDNqFJCU5OeLsZr555/9dp6aCrBy39KUBTw2E3OnWJnKXkdubwbv8+fPd701DGzElvPn/aCGpdy9eyPiFIj0nYblnyzjTkpKwntZL32MOHfuHB5//HHXffvSSy8hCHi1umIF8MorfvAyebI/twe761kiSGXLIhD6c8ILMA9jAyzjCS4+Pt5dtbP8l+vL/DFLVq/2S185xMRdmV3zJUr4vTQff8ycQH9oytIUBVSvXj03F1FWvDhjAvH333+Pk9a6XQNu9Wqmg/i97OHyIq+36EgOaNhlz6tZTuLEBEtrc1qE5vPgsBOFqxahe+6558IEVx04+YUBnLSKJ4Ds8x+sW+c/c2KrICj9a4KRxfmILoXzT9G60MY2goE6sRcyu3Ll/Dybbdu4z/vBTn5XnbMKAi4xOJzQclZJXeozkv9MidAE4YgOarIGNJxoj3kHVvNMYmJi0Iezz4XBITcGPO3atXOTl1mcpC27Dz/0n7t2RSCEZskOwrYNYfVX1mpGK9LTL1+2zeW8LrOy2pxig3bu3Bk2D5Il+5xAlMcuseH4cX9KjptvBn6dmSHiREfqkBMDms6dO2P27NlmAxoqWrSoyzEIh7lEDGqGDh2Ku+++G5ZkL3klDj1NncqKIM5XBDNY7cNbfjCXJvvyF1980b3uzkQjQ7799lsXqGVf5zNnzrjbJ1CbNm1gCeen4a0/OKNwp04Xz1XDkfNDh/zPsJfSgtCs7yzt5jGsb5ZL9zFjxrhhJ6YNWJ2CI4hmzfKDd+aNRWo7jrjWxjlaZsyY4RLOqlWrhldffTXHZzgEw0RLyb84PQtnT2dJN6uftmzxh56qVAHmz4+8jPo/g7cEYIUI74OUkJDgrl5Z/fTJJ5+4K1oGrXzPko8++sitc6NGjVxww3l5eF833hqBpd1MJmXJryWdOwOTJrGHFahWDWjXjkMwnH/KL+nmRJMMeCx59913ce+997oiDiYL16hRw1U/rV271rX1N954A9bwGvTzz/3XoXlguSw0msocqkgdmvmzPvjAf47k9Yu4oGYfp+X8NdfkUomEPEgqqMnfePsuJgfzXp28tyETznhPleefz9mDY6Gbnl30PNivX7/e9VYwl4Y9FYMGDbqQY2JJ27Zt3TDTxo0bXXUf92cmljIhnvcHYm+stSt4BuIrVwJvvcWgDpgzx7+q5WyroYqo7PMyWeit+fLLL92UFJxUkb02vHHpk08+6Zax2s8aBjQzZly8jHn+WXP9I/mk/0fxwnP7dqBBA79qNVJF3FGFCcF8iO3fgpVPfAQBb/sR7tYflrEiho+gYZc8K58CUsjo8IaVvPN6UPCQbPSwfFkMZtxdICOcvXIiERERCSQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICVGe53m5+mBUFIoUKYJWrVohKLZs2YIGDRogKIK2vqtWrUJqaqratXFBW98gtuugbeOgtuuzZ89e3aAmLi4Ohw4dQlC0a9cOy5YtQ1AEbX3j4+Nx+PBhtWvjgra+QWzXQdvGQW3Xh3LRnjX8JCIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEhIgLaqZPn46oqKjLPu677z5YMns20L8/UK8eEBMDREXxd4BplSpVuuT2bdasGSw5fPgwxo8fj9atW6NixYooXLgwypUrh06dOuGLL76AVefPAxMnAnXrAsWKASVLAk2aAMuWwbzFi4FWrYDYWKBIEaByZaBbN+DgQZiRmpqKZ599Fk2aNMGtt96KIkWKuHadmJiIadOmISMjAxZ5HrBoEdC8OVC+vN+2q1f3j+E//IBAGDt27IXj9ebNmxFJohFh6tSpgxEjRoR9b8GCBdixYwfuv/9+WDJsGLB/P1C6tL+T8HUQlCpVCs8880zYgMeSCRMmuINA1apVXWBTpkwZ7NmzB0uWLHGPOXPmoEuXLrB24H/0UWDhQqBqVaBPHyAtDVi6FGjfnr8J8NRTMIfrPWAAMHmyv95duwI33AAcOQJ89pm/b1eoABNOnz6NSZMmoUGDBnjooYdcuz5x4gRWrFiB3r17Y968ee51gQIRd+38pwwZAiQn+8fqDh38YP3rr4H33wfmzgU2bgTuugtmbd++3Z2jixcvjl9++QURx8slfjQuLs67XtLS0rzY2FgvOjraO3r0aJ78zYcffjhP/s6qVZ63b5//evRo/taeN22al+fyan0pISHBPa4ntue8aNcLFy701q1bl2N5SkqKV6hQIe+mm27yUlNTPUvbef58vx0nJnremTO/LT92jNve82JiPG/vXs9cux4/3l/vQYM879y5nO9nZNhp15mZme64nF1GRobXrFkz9x2WL1/uWdrGP/7oeQUK+G345MmL30tO9rd9r1722nVIenq6V7duXa9hw4ZeUlKS28abNm3y8kJu23O+CaF5RXv8+HG0bdsWt9xyCyxp2RJISLje30KulY4dO6Jp06Y5ljdu3BjNmzd3V7fffPMNLGGPDL38MlC06G/L2Rs5eLDfazNtGkw5exYYORKoUgV4+22gYMGcn4mOuL7xP449MBxKzS46OhqPPPKIe/3dd9/Bkn37/GHVxET2NF/8Xtu2/vOxYzDrtddec6MlU6dORcFwDTwC5JtdbMqUKe65b9++1/uryFWSlpbmcqiOHDmCkiVLon79+mjYsCGCpFChQhdOBJYcPeo/M5cku9CytWv9IMCKlSuBEyeAXr2AzEw/d2j3buDGG/0Ll9tuQyCcP38en376qXt9l7FxmNtvBxjHbdgAnDrlDz2FLF/uPxtL+bzgq6++ckHNqFGjcMcddyBS5Ysj6f79+7FmzRrEx8fjgQceuN5fR66So0ePohfPAFkwsJk7d67LP7HuwIEDWL16NcqXL49atWrBEvbI0N69QM2aF7/HZcQTviVbt/rPvICtXfvi9WNaCXuoxo2DOenp6Xj99deZyuB603ms3rVrl9u3rRV1MPF7zBjgueeAGjX8/LBQTg2D9EGDbOaKpaWl4bHHHnM5ry+88AIiWb4IaphJz+i/Z8+eEdvlJVeGBzwOv/BKrkSJEti9ezeSk5Mxa9YsdyDkcMwNzLA0ipUhPXr0cAcLJhFba9cPPgjMm+efAFq08CuA6PhxYPx4//XJkzDlp5/8ZyaRsuJryxY/oNu2DXjiCeDNN/3k4YEDYS6oGZmly40VMUOGDMHo0aNhEYPTuDiOGgDvvffb8kaNgO7dbQ0xhgwfPtwVN2zdujXij1URn1PDYIZBDXcUZtSLDcyeb9GiBcqWLYtixYq5K4CZM2e6Ez175t5nKYFRoQA9JSUF/fr1c+tsDQ/uLHldvx5gJ9TTT/tVQXfe+VuXvbGiGJdrQRyeWLKEvY5AiRLMnQLmz/fXl4GNNbwoYS9NZmYmDh48iHfeecelC3BqhlMcozFm1CggKcnPF2OJ/s8/++08NRXgbBTWpizYtGkTxo0bh2HDhuWL4cSIP6ywe57d9DwBVg43QC+m9OdkD+CY9QZYDWgYnLOMOykpCe9lvdQzhFerK1YAr7zin8xZ4sy5Pdhdv2CB/5myZWFKKHGU803deuvF7/FcwATi77+310OVNXGYKQIDBw7E5MmT3T7MHAxLVq/mBZk/xPTSS0B8vB+4spfm44+ZI+cPTVlx7tw5PP7446hduzZe4grnAxHfUaYE4WAp/WsyRkTOf3AVAhoOu7FHqlu3bi5J2tocHllxIkmeALJPO7Vu3W8nf0s4ARsxMTic0HJWSV3qM1ZwPiZaF9rYRjBQJ/ZCZleunJ9nw+HG06f9YMfCXER79uxxr8NVutE999zjnhcvXowOnLjnOovooIZJZ0uXLsXNN998oURQbAvNsGttAr6sAQ0n2mPuUKSPTV8rH37oP3NiOktCJ7qdO3O+x8l1Wd1cvDhQpgzMY0Vj1uo+K9LTL1+2zeW8TrGy2jExMejDmTPD4PA5A5527dq5iRcj5Zgd0UEND/xMQmM3PX9csYGVEbxdAHNpsi9/8cUX3evuTMowNuTEgKZz586YPXt2IAKa7CWvxKGnqVP9fJOOHWEKk4DZQcHSbnYwZ+1cZsI0h52Yi2ElkfTbb791J7Ls+/GZM2fc7ROoTZs2sITz0/DWH0wG79Tp4rlqOJJ86JD/GSunq6JFi14YLcmOeYEMaoYOHYq7774bkSKid68PPvggEENPbDOff+6/Ds3BxmWhnluO11r6CTh9OiudeM+YhIQEN902q58++eQTVxXEnYTvWcF5HWbMmOESKqtVq4ZXX301x2fYbctkaUs45RBvCcAKIFY/sRqIbZq5JUyctRjXvfsucO+9QL9+frJwaDiC5b6cYPONN2DGRx995PbjRo0aueCGc03xPme8NQJ72VndOJilQoZ07gxMmsReCqBaNaBdO38o8auv/G3MiSYZ8Mj1E7FBzZYtW9w9JnhfEWtzeGTHgGbGjIuXMU82a66spaCGs+ju3LkT27Ztw/r1692VHXNpeFU3aNCgC+PxVuzjNKS/jk9fKnGSJwVrQQ1vZ8XkYN7vjsMvzPPnfc6efz5nD46l3povv2QJLMD559hrw1yLJ5/0l1lKjubs7hxm2rhxo6uQYfvm/dyYVNq1a1fXO2ltUkkG4tymb73FoA6YM8cfkuIk96GKqOzzMkneitgWx2DGv+WUfbwjt/W7cmfFWwaEu22AVUwI5iNoWPnER9Cwd8raLSDCqVevnnsEDYeWWAiUT4qBAndcs1t6ISIiIoGioEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJiQpTneV6uPhgVhSJFiqBVq1YIii1btqBBgwYIiqCt76pVq5Camqp2bVzQ1jeI7Tpo2zio7frs2bNXN6iJi4vDoUOHEBTt2rXDsmXLEBRBW9/4+HgcPnxY7dq4oK1vENt10LZxUNv1oVy0Zw0/iYiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExIaKDmsWLgVatgNhYoEgRoHJloFs34OBBmOJ5HhYtWoTmzZujfPnyKFasGKpXr47+/fvjhx9+gDWpqcCzzwJNmgC33upv23LlgMREYNo0ICMD5kyfDkRFXf5x330wb+zYsYiKinKPzZs3w5LZs2e7fbZevXqIiYlx6zidG96w8+fPY+LEiahbt647bpUsWRJNmjTBsmXLYFWlSpUutOHsj2bNmsGaw4eB8eOB1q2BihWBwoX943WnTsAXXyDiRCMCeR4wYAAweTJQtSrQtStwww3AkSPAZ58B+/cDFSrAjCFDhiA5OdkFNB06dHAHhq+//hrvv/8+5s6di40bN+Kuu+6CFadPA5MmAQ0aAA89BJQpA5w4AaxYAfTuDcyb578uENEh95WpUwcYMSL8ewsWADt2APffD9O2b9+OESNGoHjx4vjll19gzbBhw7B//36ULl3a7ct8bRkvxh599FEsXLgQVatWRZ8+fZCWloalS5eiffv2mDBhAp566ilYVKpUKTzzzDNhAx5rJkzgxYh/LmZgw+P1nj3AkiX+Y84coEsXRA4vl/jRuLg4Ly+MH8+/53mDBnneuXM538/IyJOv4T388MPX/G/8+OOPXoECBbyEhATv5MmTF72XnJzsfvdevXp5VtaXMjM9Ly0t/HZt1szf9suXX/vvwfacl+06HP4OsbGeFx3teUePeqa2c1bp6ele3bp1vYYNG3pJSUnud9+0aZOp9V21apW3b98+93r06NFuHadNm+bltbxq1/Pnz3d/JzEx0Ttz5syF5ceOHXPHs5iYGG/v3r2etTbNdePjesurdV640PPWrcu5PCXF8woV8rybbvK81NRr/z1y254j7lr47Flg5EigShXg7beBggVzfiY6IvuX/ph9+/a5LtzExEQX/WfVtm1b93zs2DFYwh4YdmGG266PPOK//u47BAKvdI4f57YGbrkFZr322mvYsWMHpk6dioLhdmoDWrZsiYSEBAQFe2To5ZdfRtGiRS8sZ0/V4MGDXa/NNI4nS77WsSPQtGnO5Y0bA82b+73s33yDiBFx4cHKlf6P1KsXkJkJcGh2927gxht50ABuuw2m3H777ShcuDA2bNiAU6dOuaGnkOXLl7vn+4KQbOHG54FPP/VfGxptu6wpU/znvn1h1ldffeWCmlGjRuGOO+643l9HrpKjR4+658pMdswmtGzt2rUYyatUYxiwMV/qyJEj7phdv359NGzYEEFTqFDkdTRE0Ffxbd3qP/NirnZtP6DJeoU/eDAwbhzMiI2NxZgxY/Dcc8+hRo0abiw6lFPDA8KgQYPMjkunpwOvv+7nULG3Ys0aYNcuP6ANQhzHlAuuc3w88MADMIkH/8ceewx16tTBCy+8cL2/jlxF7JGhvXv3ombNmhe9x2W0O+sB3FhA14sHqiwY2DAHkvlFQXDgALB6NVC+PFCrFiJGxAU1P/3kPycnA3XrAlu2ANxftm0DnngCePNNP2Fp4ECYwa7auLg49O3bF++9996F5Y0aNUL37t0RHUlh8FUOarJexLECaMgQYPRoBAJ75tk71bNn+GFWC4YPH449e/Zg69atZoedgurBBx/EvHnz3EVZixYtUIRljOAFynGMZ7kMgJMnT8IaBjONGzd2xRslSpRwgRsLPWbNmuV61b/55hvcwMoWwzIygB49eNHiJxFH0q4dcTk1PMgTcy6Yb1C/PlCihD9+N3++31vDwMYSdssnJSW5semDBw/i559/xvr165GamupKBK2WR3K7speGw4ws03/nHX84hlWRp07BNLZzBjUM5FjxZdGmTZswbtw4VxVkqXpPfLzg4jQUPFbVqlULTz/9NAYMGIA777zzwjB6AUsljL9iBR+DuLJly7oydvZCzpw5Ez169HAVb6xatez8rxdiKSlAv35+cBNJIq7FhXJl69Xz5zDJisdFJhB//z2vAGDC6tWr3U7CIaaXXnoJ8fHxLvpnL83HH3+MQoUKuaEpy3jc4xAMe99Yxr9hAxNLYRq7bdl926KFP/+SNefOncPjjz+O2rVru3Yt9rAHecWKFXjllVdc8DJ58mQ33xaH0BdwngLAnfiDgnMUEfMjLQc0vXv7ZdxJSUCWgYWIEXHjGtWr+89MDA4ntJxVUpf6TH7CgwLxiie7cuXKuTybbdu24fTp0y7YsY7zINC6dTDNeoIw2yuHnYiJ8OHcc8897nnx4sVufibJfzjJIC/K+Mhq3a87MCciDFqOkcU5mEIBDdOIZs70J8HlvJKR2BEXcUFN6Ny+c2f4cTyW+hYv7k8AZEE6E0suU7bN5bwKYo9NEHCCRbK8ukyKZjXszTf/VsJu8WTHydjCSUlJcQFPu3btUKZMGZMTlgXdhx9+6J67cubUgPji1+l1Lbbn81kCGk60N2tWZOXRRHRQE5q1kKXdvJrNeiU7Zow/7MRuLyu5s5yfhtOMM9GsU6dOF81Vw6ThQ4cOuc/wJGHFt99yxweKFbt4+Zkz/u0TqE0bmMUDAmNZtmNDm/UinLdkSqg7KpuePXu6oGbo0KG4++678/y7ydWTfRoK4tAT5yNiNVBHTnJiyK5du1CxYkWXS5N9+Ysvvngh18jikNPMmUDnzrwdSOQGNBSRocG77wL33usnITFZuEYNv/pp7VqAc1u98QbM6Ny5MyZNmuSuXqtVq+auXm+88UY3twdLunlyYMBjyUcf+dVtjRr5wQ2Piby/CEfi2IvBpHCW7lv1wQe2h56CikHc559/7l6zAia0LDQUwzw5VjhawrlZKlSo4Eq6Wf20ZcsWt75VqlTB/PnzzVW8sdqLx2Pe34oTLfKWH6x++uSTT5CRkeECdb5nyahRwIwZfmFHtWrAq6/m/AxHj3krmEgQkUENe2u+/JLloP5kbOy14Q20nnzSX2Yp94w7/cqVK/HWW2/ho48+wpw5c9yQ1C233HKhIir7HBD5HWfP5TDTxo2skPHvBcUOKs5LxN5qXhVY6YnLjlMUbN/u3/cqkuZ2kD+PAc0MHv2zYNJo1sRRa0FNly5dXHIwb07Kkzon3WO12/PPP5+jB8cC5j7u3LnT5Tmy6uvMmTMul6ZNmzZuTrHWoaRAQ/bt8595nL5UAQcvTiMlqInivRJy9cGoKDeXCodDgoK9JlbLqcMJ2vqy0uzw4cNq18YFbX2D2K6Dto2D2q4P5aI9R2DusoiIiMiVU1AjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMSHK8zwvVx+MikKBAgVQvnx5BMXx48cRGxuLoAja+v744484f/682rVxQVvfILbroG3joLbrzMzM3/1cdG7/wVzGPiIiIiLXhYafRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERAQW/H/DTTVKfarwcwAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjUAAAJOCAYAAABP8PaaAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAdBZJREFUeJzt3Ql4FOW6J/B/IBA2QQ0gmEBYlEWFYRgWNewCKiIgXGR5grLKot4rigsOA8KowBEjDigOIrvAlR0Z8bBdDLLIFRmvIBxQ2ZEjl4GDCFkINc//KxtD0mBQCJ23/r/n6dN9qlvS1fVV1Vvf975fRXme50FEREQknytwvb+AiIiIyNWgoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRETy1D//8z+jUKFC+OSTT673VxFjFNTIH9KsWTNERUVd078xffp09zf4HEmOHDmC4sWL4/XXX79oOb8rf5fceuWVV9x/s27dumvwLYMjUttJXmM74u/AdhXJ/vVf/xUTJ07E5MmT0aZNmzz7u40bN0bDhg3z7O/J9aGgxqhffvnFnXTr1q2LEiVKICYmBvHx8W7HHjp0KL7//vvr/RWxb98+dxDu2bMn8pP//t//O4oVK+auNkWCjvsv92Puz79n165d6Nu3L0aNGoVevXohLzHY27JlC+bNm5enf1fyVnQe/z3JAz///DMaNWqE//iP/8Btt92GpKQkxMbG4j//8z/dTj1mzBhUrVrVPSLZI488grvvvhvly5dHpNizZw9mzpzpAhsGiyKRokGDBti5cydKly6NSPX111/jjTfewIABA/L8b993333uIm/EiBHo0qXLNe9plutDQY1B48ePdwENr4jYxZt95927dy/S0tIQ6UqVKuUekYS/5/nz59GjR4/r/VVELsLewxo1aiCSMZi4nniB9+yzz2Lt2rUuyBF7NPxk0KZNm9zzk08+GfZqpHLlymEPftu3b8ejjz6KsmXLuuEqfu6ZZ57B8ePH/3SOSPa8Bz7z36cZM2a490KP0H9/uVyJDRs24KGHHsLNN9+MIkWKuPXhFdiZM2dyfDaU6/L3v/8djz/+uLuSLVq0qOsFupJ8FgYz/K516tTB7bfffsnPHTp0CN26dXN/hyeaxMRErF69GleCQWnXrl1dL1XhwoWRkJCAp59+Ose2uFweRaQM77G38IYbbgi7bahdu3bue+7evdv9/3/84x8YO3YsmjZtiltvvdWtP58fe+yxKx42ZQDP4L5ixYquTfP35O+xf//+K/qtwuVLhfLKUlNTMWzYMNfzyeTX0LbgegwfPhx33HGH69UrWbKk+y3YBrP//XDS09MxYcIE3H///ahQoYL7/tw3O3bsiG3btuX4/OXawpXs25fLDatUqZJ7ZP3/3CeI/2ZoH87+3+d2O/yRz3/11Vf4p3/6pwufLVOmDOrXr4/XXnstx2c7d+7snoOef2WZemoM4lAT8STBE3BufP755+7gyQMpDxA8WDE4evvtt7F8+XJs3rz5qnZr83v9y7/8i/v3/8t/+S/o0KHDhfeyHjTDmT9/vgsaeADjlR8P1CtXrnTj9H/961/dwZ2BTlYnT550Q3Ls+WEvy08//eQSFrnOW7duxV133fW73/mbb77BsWPH0KlTp0t+5sSJEy6I4YGVB2V+nn/ngQcewIIFCy5az0tZtmyZOwEVKFAA7du3dye0b7/91iVXcv2++OIL3HTTTcgveHU8cuRILFmyBN27d7/oPQ6Jfvrppy6Bs1q1am4Zh1AYDDRv3twNQTIpm7kYc+bMwf/5P//HncQY5P0e/k7cvswva9u2rQtEGbx8+OGHWLFihWvfVapU+dPrx/bAYRVu4xtvvNGd3D3Pc3+b34Htge9xe/KkzO3LNvh76/D//t//c4EH8+CYUMtt/sMPP7j/nt8/JSXFnbyv577N78cAgevP/Znrn30fvtLtcCWf/7//9//i3nvvRcGCBd2+wt+U+zr3F/aqcpg4K+YVcn9as2bNH1pfyQc8MWfp0qUeN+0NN9zgPffcc95f//pX7z//8z8v+fnMzEyvatWq7r/59NNPL3rv+eefd8t79+590fKmTZu65VmNGDHCLfu3f/u3HH9j2rRp7j0+h+zdu9cte/zxx8N+r3D/zT/+8Q+vVKlSXkxMjPf1119ftA5dunRxnx81atRF/w6X8TFo0CD3uZApU6a45f379/dy45133nGff//998O+H/o73bt3986fP39hOb9n4cKFvTJlynhnzpy57O/F7VSyZEkvLi7O27dv30X//ty5c93nn3rqqQvL+N9yGf+t7H7v9w33ef47V/LIjT179rjv8eCDD+Z4b8KECe69iRMnXlh28uRJ7/jx4zk+u3btWq9AgQJe3759f7edpKene5UqVXL7wFdffXXR59evX+8VLFjQa9u2ba5/K77HNh9uH6hTp06O7/sf//Ef7r0OHTrk+LdSU1O9n3/+Oezfyf65Q4cO5Vi+fft2r0SJEl7Lli0vWh6uLfyRfTvcuoYkJCS4R1b8zfjf8DfM7kq3w5V+/tlnn3V/e8mSJTn+9qWOeY888oj7b3744Yew70v+pqDGqDfffNMd+EInWj54cHvyySe93bt3X/TZlJSUS550ePC9+eabvSJFinhpaWnXPaiZOXOmWzZw4MAcn9+/f78XHR3tValS5aLl/Hzx4sVznEgyMjLc5+vWrevlxtChQ92/tWzZsrDv8z0edLMHI9SnTx/3/oIFCy77eyUnJ7tlXM9w+F1Lly59TYKa0L91JY/cuueee9xv/fe///2i5Q0aNPAKFSrkHTt2LFf/Tq1atdxJ7/fayaJFi8IGuCEdO3Z0ARKD5D8b1PAiIrtQUNOtWzfvWnj44YddoMwg4HJt4Y/s21czqLnS7XClnw8FNbxwy60BAwa4/4a/jdij4SejmAzXr18/17W/ceNGfPnll65b95133sEHH3zghkSYy0Ch8flw4+jMBahXr54b3vnb3/6GWrVq4Xq63HflmDq7pTnsxgow5nGEcGgje7VSdHQ0brnlFtddnRuh/INQF3s4/A7hhhU4hMDfnd//csNXHAogbqtw+SPM3+CQDR9Xu8qFv6l/Trv6ONzCYYO5c+e6YYpQJRmr8R5++OEc68IhRCa883fgup47d+7Ce8yx+T2h35FtNlyOydGjR12OFNsK2/efrTrKrmbNmqhdu7ZbX+ZYcdiRvy+HXTkMlVscXvnLX/7ihpD4nTMyMi56n7/N5aoDr/e+faXb4Uo/z2FathMOU3IoulWrVmjSpAni4uIu+Z2Yhxf67cQeBTWG8aTOxLhQchwTF19++WW8++676NOnDw4fPuxOEKdOnXLv8wQfTuigGfrc9ZSb78oDHj+XNahhkmY4DGwyMzNz9beZXBwKLC7lUt8rtJzb4PfyKIjB5+Uw3yCSS3ez4wmH+RezZ8++ENTMmjXLPWevJGPOFD/Pky5zK5ifwYTrUNJ4bpJsQ78j8zB+73f8s8Jtc7YrVtjwxLxw4UI899xzbjlzrZ566imX68E8kMvhxUiLFi3c69atW7vcEv4m/B2Yn8Q8lt+rYrze+/aVbocr/TxzsRgAc04u5lxNmzbNLWeuEZPNmZeV3dmzZ90z25TYo6AmQJgky2RTJlvyxMDE1//23/7bhRM+q4PC4dXR5QKDkNAVaNar6pDfO5nn1tX6rn8ET0hZD7zhXOp7hZb/Xol66Htz2+Qmeflq/uZMxrzSqpDczl7Lq2Mmu/JkzKvw6tWruwCHvwd7arL/m0z0ZgJ39iqz3E6cFvodP/74Y5dsei1/x0vNd8KEfVYv/a//9b9cojODHP5/VumxSoqTYF4Oq3cYtKxfv94luWfFHg0GNddif+H6hPsdQr/FlUyzcKXb4Uo/H+oFZQIxgxX27PG/5YUbqyNZ9ZU9GTy0/4b2Z7FFQU3A8IDFapKs/ut//a/umVc8L7zwQo4rIg5dsZeCJ6LLCVXksAcou3AlqKEr1dz2lGT/rux6zurgwYNuyIYHsay9NFdLqHueJ+VLOXDggAsYsw9B8cSU9ftfCq88Fy1a5IZqchPUXOlv/ntBDauUrsSVTMnPHhkGNQxmWA3Esl32GGavVOM2vPPOO3MEND/++KOr/smN0HT4/B1zc3IMDSlejd8x3D7H4Sg+OOTLIUpWMP1eUMPfgcFg9oCGpfGsAMuNP7Jvs02F+x3YPjhUmz2oudx+fKXb4Uo/nxXXg8NsfHB7soJu1apV6N+//0Wf4/7LoDLS5/SRP0bz1Bj0v//3/8a///u/h32PJxWWzHKnD500WXLKOTZ4tZN9PpVXX33V5ZKwhPr3chlC5aWccZfj3iE8QIXrTubBkwd8BiO5xbJNHlTZzbxjx44Ly5kL8uKLL7orzGs1LwuvCHlFz6vBS+GBnUN8WXNTOOcMh1p4Zfh797rh1PEMyDg8kXX9sp7QQnkHxJMRP8+TZNYeJF6Zc9v9kZyaK3lcCV45c5uzLbCNULhJDBkQfvfddxf1LnDIb+DAgTlySi7XThg8JCcnu9Ln7PjvME8law8Bf0su498OYW7W7wUf4TAACHfbgNA6ZQ/kwuHvwCkCsrYDtq8hQ4a4qQJy44/s29yP+d0/++yzC8tYDs48vcvlqITbj690O1zp53lsCTccfKnfmevBIJX5OBp+skk9NQbxAMZpyDnRFw9qnLiMV2XcmdljwBMzu2c5zwvx/3PYgfkLPOkyB4cHVB4weIXHgyJvrfB7OJkd/x672e+55x6XsMdei6VLl7ohhsWLF1/0eeYH8ADKgxdPbrwy53e53BwePPm8//777kDMqzrmXjBY4AGbwxVM2nz++edxLfCEzAnheFDlgTTciYnJoXyf69WyZcsL89Qw2OK8GaG8nEvhujC5lNuA8/ewR4NXlByGCJ1oOC8HE8CJJyNOyhe6zxdPCjwRswue3zUS7vEVwvbG3jUG3QxKuY3ZRrLj+vDBXgbOq8LfjlfcDKL4m+Rm2IV/i/MCPfjgg+53YG4Ke9oYRLNNcj/g8BCHhUKY9/LEE0+4tsvfn4E596XczAUTLsGXk+SxPXLyvXLlyrneD15UsI0PHjz4d/8N/gZM4mVPDX83tjfuj/x3GIDmZuLIP7JvM3jh3+XnuZ/x5M/fnxdC4ZKS+duOGzfO/XZMgmdPMP8G9+Mr3Q5X+nnmzfzbv/2ba0ecH4i/EXuxOA8Ne2yZQJwV/3vuS7mZL0ryqetdfiVX365du7y//OUvXqtWrbzKlSu7kk0+WNLN8ssvv/wy7H/HMtR/+qd/ciXDLLNl6ea//Mu/hC23DVfSHZob4rHHHnOlokWLFvXuvvtuV24ZruyW/va3v3lt2rTxbrzxRi8qKuqiEudL/TfEckyWqfK/Y2lrtWrVvP/xP/6Hd/r06RyfvdIS1cv513/9V/fv8flSf+fgwYNuzpxQuSzLmVeuXJnj85crgec2ZBk4vxvX76abbnLlzP/8z//sbdmy5aLPci6SV155xatQocKF3+Ltt99283BcSUl3Xvj8888vlIOzRD4czvHz3nvveXfeeaf7/cqVK+d+i59++ilsu7tcO+E8L2zDt99+u5vbiHMA1axZ0811s2bNmrBzEfGzbP8VK1b0hg8f7sqmL1fSHQ7bwEsvveTaf9myZd124b/HkuRNmzbl+vfiFAAs4y9WrJjbLx999FHv+++/D1tGfbny/ivZt2n+/PmuvfF78/d/+umnXQn4pfYXHm9Cv1u43+pKt0NuP8+5d3i8qV69upvbhtNY3HHHHd7LL78cdt169uzp1oltSWyK4v9c78BKJL9g9zeHKXiFy6tXkUjB3jv2cLDX7o8MmVnHoTz2ILH3b+rUqdf768g1opwakSvABMPRo0e74S6W3IpEilAuEG8FIDkxT4c5Sf/zf/7P6/1V5BpSTo3IFWIeD6uccnujT5FriRMYMm+LuTPMf2H+jIRPaGaC+uUm5pP8T8NPIiL5GGfU5V3CWc3IhN3sJeAiQaKgRkRERExQTo2IiIiYoKBGRERETFBQIyIiIsGqfrrUTdtERERErrXcpABfUUk3p9wON022VSzZ5ZTcQRG09eUNEjkVvtq1bUFb3yC266Bt46C269y4oqCGO8ihQ4cQFLyjLm8UGBRBW19OUsb76Khd2xa09Q1iuw7aNg7iOsfnclJJ5dSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYkLEBTXnz5/HxIkTUbduXRQrVgwlS5ZEkyZNsGzZMli3eDHQqhUQGwsUKQJUrgx06wYcPAhTDh8+jPHjx6N169aoWLEiChcujHLlyqFTp0744osvYNHs2UD//kC9ekBMDBAVBUyfDtM8D1i0CGjeHChfHihWDKhe3f8dfvgBJlWqVAlRUVFhH82aNUMQjB079sI6b968GZZwn+W+e7nHfffBlNTUVDz77LPuPHzrrbeiSJEi7nidmJiIadOmISMjA5EkGhHE8zw8+uijWLhwIapWrYo+ffogLS0NS5cuRfv27TFhwgQ89dRTsHjwHzAAmDwZqFoV6NoVuOEG4MgR4LPPgP37gQoVYAa3Iw983MYMbMqUKYM9e/ZgyZIl7jFnzhx06dIFlgwb5m/H0qX9EzxfWzdkCJCc7K9vhw5AyZLA118D778PzJ0LbNwI3HUXzClVqhSeeeaZsAGPddu3b8eIESNQvHhx/PLLL7CmTh1gxIjw7y1YAOzYAdx/f15/q2vr9OnTmDRpEho0aICHHnrIHa9PnDiBFStWoHfv3pg3b557XaBAhPSReLnEj8bFxXnX0vz5893fSUxM9M6cOXNh+bFjx7yEhAQvJibG27t3r5dXHn744Tz5O+PH8/f1vEGDPO/cuZzvZ2TYWt+FCxd669aty7E8JSXFK1SokHfTTTd5qamp1/x7sD3nRbumVas8b98+//Xo0f72njbNuy7yYjv/+KPnFSjgeQkJnnfy5MXvJSf769+rl2eqXROPU3xcT3nZrrNKT0/36tat6zVs2NBLSkpy32HTpk3mtnE4aWmeFxvredHRnnf0qGdqnTMzM700rmA2GRkZXrNmzdx2Xr58+TX/HrltzxESWvnYI0Mvv/wyihYtemF56dKlMXjwYNdrw+4uS86eBUaOBKpUAd5+GyhYMOdnoiOqP+3P69ixI5o2bZpjeePGjdG8eXN3FfDNN9/AkpYtgYQEBMa+fRxKBhIT2XNx8Xtt2/rPx45dl68m18hrr72GHTt2YOrUqSgY7kBm2JIlwPHjftu+5RaYUqBAAZcikF10dDQeeeQR9/q7775DpIio0+XRo0fdc2Umk2QTWrZ27VqMZBRgxMqVwIkTQK9eQGYmwNSh3buBG2/0T4S33YZAKVSo0IUdRvKv228HeBzcsAE4dcofegpZvtx/tpZ7EMKLr+nTp+PIkSMuJ7B+/fpo2LAhLPvqq69cUDNq1CjccccdCJopU/znvn0RGOfPn8enn37qXt8VQePIEXXmYI8M7d27FzVr1rzoPS6j3TzjG7J1q//MC5vatf2AJoRDlIMHA+PGIRAOHDiA1atXo3z58qhVq9b1/jryJzDZfcwY4LnngBo1gPbtf8upWbsWGDQIMJged+HirBevUrJgYDN37lyXR2YxiHvsscdQp04dvPDCCwga5setWQPExwMPPACz0tPT8frrr7vc1+PHj2PNmjXYtWuXa+v3RdAVSkQFNQ8++KBLOhozZgxatGjhsqyJPyCrZejkyZOw5Kef/GcmVNatC2zZAjCe27YNeOIJ4M03/eThgQNhGjPoe/To4Q6QTCIOWve1RQzI4+L8q9f33vtteaNGQPfu9oZViQd4DqPyyrVEiRLuIiw5ORmzZs1yB34Oq97AKgBDhg8f7hL9t27dGsj9lhkRHGrt2TN8+oCloGZkllESVrcNGTIEo0ePRiSJqJya7t27u5yK9evXuyv1p59+GgMGDMCdd97punEpYjKsrxLuDMSueo7L1q8PlCjB/BJg/ny/t4aBjfVuzJ49eyIlJQX9+vVzwY3kf6NGAUlJzJHzpyX4+Wdg/XqWiAKsbrY4SwMrf3hBVrZsWTclBXsvZs6c6dr0/v378T5LvwzZtGkTxo0bh2HDhkXUEEReHr8Z1LCUu3dvmFaiRAnXS5OZmYmDBw/inXfewZQpU9xUBac4xhwhIipCYB4FS8NeeeUVF7xMnjwZixYtcuXcC1gvB7iDhSWhJErOX3LrrRe/x2MEE4i//549VDAb0LAskGXcSUlJeC/rJb3kW6tX+6WvHGJ66SW/a57BOntpPv6YuVP+0FRQ9OfkPGCO0QZYce7cOTz++OOoXbs2XuJGDmg7P3AAaNHCn1csCAoUKID4+HgMHDjQnaPZpplPFSkirgM4JibGXe3wkdW6devccz2e/Q3hZGTExOBwQstZJXWpz+TngIbd9byS7datm0uutNYTF1QrVvjPnHgvu3Ll/DwbDrGePu0HO9aF8gUtzd3C+Us47EThqmPonnvucc+LFy9GB05WZEwQE4Sz4jxjWc/PkSDigppL+fDDD91zV85MZ0jooL9zZ873OFEjK+WKFwfKlIHZgIYT7THnIIjj8Valp1++bJvLGb/+WuxmXmimbEsT8PEClBOkhsOhZAY87dq1c5O1WVrvEJZwcxaSm28Gfq1sDpwjnCE2S9VqJIi4oIZjc6H8mRAOPXHuA1YQcI4TS5gEzGCXpd2M+rNG/Kwe4bAT8xIsJVWGhpwY0HTu3BmzZ89WQGMM56eZONFPgO/U6eK5ajjCeOiQ/xneMsIKVoLwth/Mpcm+/MUXX7yQN2gF5xJjTkU4zJFjUDN06FDcfffdsGjWLD945/HZUjvO7ttvv3VBafZ2febMGXf7BGrTpg0iRcSdKjmfQ4UKFVxJN6uftmzZ4rq2qlSpgvnz55s8+b37LnDvvUC/fn6ycKhrnqWvnLDtjTdgCueymDFjhks8q1atGl599dUcn2FXNZMsreCx//PP/deheQW5LNRry1wTS13YnTsDkybxih2oVg1o184fPv3qK79dc25NBjyWsHKTlU68R05CQoK7VQCrnz755BNX3ccTPN8TGz74wH+2tN+G89FHH7l23ahRIxfcsNOB9+9j/isrk1ntx8lxI0XEBTUcimByMG+ExgMBJ91jZv3zzz+fowfHUm/Nl1+yNBLgXEbstWHewZNP+suM5UZjH6eb/XVM/lIJZtx5LAU1DGhmzLh4GXNGs+aNWjo48tqD7fitt3hQBObM8a9qOdtqqCIq21RU+R4rN3fu3Ilt27a5Ck5eyTKXhlexgwYNupB/IPkfp97Yvh1o0ACwPqVW27Zt3TDTxo0bXbUbj9u8vxkTxJkOwl73SJosNYr3SsjVB6OiEBcXh0PsNw4IjgcH4e7gQV1fZvDzikPt2ragrW8Q23XQtnFQ2/WhXLRnlZqIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFClSBK1atUJQbNmyBQ0aNEBQBG19V61ahdTUVLVr44K2vkFs10HbxkFt12fPnr26QU1cXBwOHTqEoGjXrh2WLVuGoAja+sbHx+Pw4cNq18YFbX2D2K6Dto2D2q4P5aI9a/hJRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJERfUzJ49G/3790e9evUQExODqKgoTJ8+HVZx1aKiLv+47z6YN3bsb+u7eTPMOX8emDgRqFsXKFYMKFkSaNIEWLYM5i1evBitWrVCbGwsihQpgsqVK6Nbt244ePAgLElNTcWzzz6LJk2a4NZbb3XrWq5cOSQmJmLatGnIyMiANZ4HLFoENG8OlC/vt+3q1YH+/YEffoA5hw8fxvjx49G6dWtUrFgRhQsXdtu4U6dO+OKLL2BVpUqV3Lk43KNZs2aIJNGIMMOGDcP+/ftRunRplC9f3r22rE4dYMSI8O8tWADs2AHcfz9M277d/w2KFwd++QUmD/yPPgosXAhUrQr06QOkpQFLlwLt2wMTJgBPPQVzPM/DgAEDMHnyZFStWhVdu3bFDTfcgCNHjuCzzz5z+3aFChVgxenTpzFp0iQ0aNAADz30EMqUKYMTJ05gxYoV6N27N+bNm+deFygQcdeSf9iQIUBysh/QdOjgB+tffw28/z4wdy6wcSNw110wY8KECRg7dqxrzwxsuI337NmDJUuWuMecOXPQpUsXWFSqVCk888wzYQOeiOLlEj8aFxfnXWurVq3y9u3b516PHj3a/d1p06Z518PDDz/sXS9paZ4XG+t50dGed/So3fVNT/e8unU9r2FDz0tKYjvzvE2b8uZvsz3nRbueP99fr8REzztz5rflx455XkKC58XEeN7evV6eyavtPH78ePf7Dho0yDt37lyO9zMyMkytb2ZmppfGHTfMejZr1sz9FsuXLzfTrn/80fMKFPDb8MmTF7+XnOy3+V69PFPbeOHChd66detyLE9JSfEKFSrk3XTTTV5qaqq543VCQoJ7XE+5bc8Rd8nQsmVLJCQkIOiWLAGOHwfatgVuuQVmvfaa3xs1dSpQsCBMYo8MvfwyULTob8tLlwYGD/Z7baZNgylnz57FyJEjUaVKFbz99tsoGGbjRkdHXEfxn8IeGA5HhFvPRx55xL3+7rvvYMW+ff6wamIir+Ivfo/HLTp2DKZ07NgRTZs2zbG8cePGaN68ueuZ++abb67LdxOfraOKIVOm+M99+8Ksr77yg5pRo4A77oBZR4/6z5Ur53wvtGztWmDkSJixcuVKd4Dv1asXMjMzsWzZMuzevRs33niju3C57bbbEBTnz5/Hp59+6l7fZWgs5vbbAcZwGzYAp075Q08hy5f7z0HIBwwpVKiQyWA9JC0tzeW3cvi4ZMmSqF+/Pho2bIhIY/PXz+eYRrRmDRAfDzzwAExi78Rjj/k5RS+8ANPYI0N79wI1a178HpfR7t0wZevWre6ZPTS1a9d2AU3WHo3Bgwdj3LhxsCg9PR2vv/66yyk6fvw41qxZg127drkA7z5DZ/nYWGDMGOC554AaNfz8sFBODYP0QYNs5oqFc+DAAaxevdrlgdaqVQsWHT161LXhrBjYzJ071+UYRQoFNRGIQxHs1u3Z0+6QzPDhwJ49PPnZXceQBx8E5s3zTwAtWgBFivjLObw4frz/+uRJmPLTTz+55+TkZNStWxdbtmxBzZo1sW3bNjzxxBN488033YFw4MCBsBjUcOgthBUiQ4YMwejRo2ENh0/j4vwe5ffe+215o0ZA9+7stYB5rGrr0aOH68lgEnG4odb8rlevXm6IjT2NJUqUcBcp3LdnzZrlAnUOubEIIBJEXE5N0DGYYVDD0ubevWHSpk0AL9KHDbNVGXEpPLiz5HX9eoAXcU8/DQwYANx5529d9oYKYi4MuRBzTFgVwis6Hgx5YJw/f77rrWFgYxHXk700HHZj2fo777yDKVOmuNLXUxynMYRDx0lJfr4YK/R//tlv56mpACt9rU9ZwHbes2dPpKSkoF+/fi64sWjEiBFo0aIFypYti2LFiqFOnTqYOXOmW19WMb7PcrcIYexQmv+tXs2uTP+KPlwORn537hzw+ONA7drASy8hEHi1umIF8MorfvAyebI/twe761m2T2XLwlz5J3G+Kc7ZkhWv9phA/P333+OktS6qLBi4xcfHu94olrVv2LABrzGJzNCxilMxcIiJ+zKHy0uU8HtpPv6YOSb+0JTlgIal+izjTkpKwntZu6oCoj8nJALzqjYgUgSgczB/sZ4gfPq0P+xEYQpFnHvu8Z8XL/bnvrAgJsY/AWSfk2jdOv+5Xj2YUp0zsAEuMTic0HJWSV3qM5ZwThNaF9rgBjBQJ/ZCZleunJ9ns22bv88z2LEW0HBIhr0VnEiSCbSW5h/KLc4nR79E0ARjCmoiCHMsWP57883ArxWg5vDkzsnnwklJ8QOedu2AMmU4qRPM+/BD/7lrV5jC8lbauXNn2BwEljYXL17cTV4WBKwYyVohY0F6+uXLtrmc53lDq5wjoOFEe8wrsZhHkxuhWZQjaQK+4IWWEWzWLP9AwTFqnvwt4jwt7I0K97j3Xv8zQ4f6/5+VUVaES6Xg0BPn56lfn/NfwJTQjKsMXphPktWYMWPcsBPnbrFU/vrtt9/izJkzOZZzGW+fQG3atIEVnJ+GOKPwP/5x8XsciTl0yO91tXQsCw05MaDp3Lmzu62P9YBm165dYds1l7/44ovudXcmDkaIiDui8AD4+eefu9ehSYy4LNRt26hRI/Q1OjbzwQf+s9HVCzRO58A7ArCkm9VPW7b4Q09VqgDz59usAHv33Xdx7733ugRKJgvXqFHDVT+tXbvWTbD5xhtvwJKPPvrIVYTwGMUrV87lwXsF8dYILO1mkjRL2a3o3BmYNMnvYa1Wze9h5Ugi559iSTcvYBjwWDJq1CjMmDHDJYNXq1YNr776ao7PdOjQwSXSWjFv3jzXrnlPM+637GFl9dMnn3ziel2HDh3q3osUERfUMKBho8mKSUhZE5EsBjU8yfEeSA0a+BUyYgtvB8PkYN6sk/c1ZBI4q7+ef/7iScus9dZ8+eWXGD58uJt8jhPy8eZ/Tz75pFvGSgpL2rZt64aZNm7ciE2bNrl7QTFhmvP08L5XvMK31DPFQHzlSuCttxjQAXPm+D3NnAE9VBGVfV6m/G4fp1H+9T5fl0r6ZkBrKahp3ry5G0bmBcn69etdrw1zadjrOGjQoAv5YpEi4vYwJlxZviv3pTCYcXfYCjBudqubnpVPfAQNb1jJO1QHASu9+AgSDi2x8ikolYxBPD81bdo07K0hIpVyakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAlRnud5ufpgVBSKFCmCVq1aISi2bNmCBg0aICiCtr6rVq1Camqq2rVxQVvfILbroG3joLbrs2fPXt2gJi4uDocOHUJQtGvXDsuWLUNQBG194+PjcfjwYbVr44K2vkFs10HbxkFt14dy0Z41/CQiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICREZ1FSqVAlRUVFhH82aNYMlqanAs88CTZoAt94KFCkClCsHJCYC06YBGRkwyfM8LFq0CM2bN0f58uVRrFgxVK9eHf3798cPP/yAIBg7duyFdr1582ZYcvgwMH480Lo1ULEiULiw3647dQK++AImTZ8+/ZLHrdDjvvvugyWzZwP9+wP16gExMUBUFH8HBMLixYvRqlUrxMbGokiRIqhcuTK6deuGgwcPwpLz54GJE4G6dYFixYCSJf3z1bJliEjRiFClSpXCM888EzbgseT0aWDSJKBBA+Chh4AyZYATJ4AVK4DevYF58/zXBSIy/PzjhgwZguTkZBfQdOjQASVLlsTXX3+N999/H3PnzsXGjRtx1113wart27djxIgRKF68OH755RdYM2ECgzagalU/sGG73rMHWLLEf8yZA3TpAlPq1Knjtmk4CxYswI4dO3D//ffDkmHDgP37gdKlgfLl/dfW8YJswIABmDx5MqpWrYquXbvihhtuwJEjR/DZZ59h//79qFChAizwPODRR4GFC/19uU8fIC0NWLoUaN/e38+fegqRxcslfjQuLs7LCwkJCe5xvT388MPX/G9kZnpeWlrO5RkZntesGX93z1u+3DOzvvTjjz96BQoUcNv45MmTF72XnJzs2lqvXr2u+fdge87Ldh2Snp7u1a1b12vYsKGXlJTkvsOmTZvy7O/nxXZeuNDz1q3LuTwlxfMKFfK8m27yvNRUz1S7vpS0tDQvNjbWi46O9o4ePWqqXa9a5Xn79vmvR4/2j1fTpnl5Li+38fjx493vO2jQIO/cuXM53s/gwdvIOs+f72/TxETPO3Pmt+XHjvE87XkxMZ63d6+XJ3Lbno1d/+c/7IFh13x20dHAI4/4r7/7Dqbs27cP58+fR2JiouuRy6pt27bu+dixY7Dqtddec1ftU6dORcGCBWFRx45A06Y5lzduDDRv7vdGfvMNAmHJkiU4fvy4a9u33HILLGnZEkhIQGCcPXsWI0eORJUqVfD222+H3X+jefA2YulS//nll4GiRX9bzp65wYP9XhumSUSSiP3109LS3Bg1u/Q4NFG/fn00bNgQQcFxzE8/9V9bG4W5/fbbUbhwYWzYsAGnTp1y2zdk+fLl7tla7kHIV1995YKaUaNG4Y477kAQFSrkPxs69l/WlClT3HPfvn2v91eRP2nlypU4ceIEevXqhczMTCxbtgy7d+/GjTfeiJYtW+K2226DJUeP+s+VK+d8L7Rs7Vpg5EhEjIg9rBw9etQ1nKwY2DDfguOY1qSnA6+/7o9hHj8OrFkD7NoF8Cewdn5nYt2YMWPw3HPPoUaNGmjfvv2FnJq1a9di0KBBeCriBmqvTqD+2GOPudyLF154AUF04ACwerWff1GrFsxjfsWaNWsQHx+PBx544Hp/HfmTtm7d6p7ZQ1O7dm0X0IQUKFAAgwcPxrhx42BF6dL+8969QM2aF7/HZZTlJ4gIERnUMJhp3LixSxQtUaKEazhMKp01a5a7gv/mm29cYpa1oCZrtMsqgiFDgNGjYRJ3/ri4OHf1+t57711Y3qhRI3Tv3t1UF27I8OHDsWfPHndgtDrsdDms5OvRw++yZhJxEH6CadOmuaHWnj17BnKbW/PTTz+5Z56P6tatiy1btqBmzZrYtm0bnnjiCbz55pvuonvgwIGw4MEH/WKVMWOAFi386lzihTerG+nkSUSUiMypYQVBixYtULZsWVfqyyvbmTNnokePHu7KhxUy1pQo4ffSZGYCrAh85x12WwOsYD91CuZw+CUpKQkvv/yyK4H8+eefsX79eqSmprqyfXbrWrJp0yZ3BTds2DDTVV2XG07t2RNISQH69fODG+sYzDCoYSl3b5YyioltShw+Z64URw944c2L8Pnz57veGgY2VnTv7ufArV/v96w+/TQwYABw551+aTdFWmVuhH2dy+McJsRcDKvYQOLjAQb6kydzXZlYClNWr17tAlcOMb300kuua54HBvbSfPzxxyhUqJAbmrLi3LlzePzxx113Ndc3aHge4DmdZdxJSUCWjjnT2M4PHDjgLtA4h4nkf6HChnr16uFWTiyWBS9WmED8/fff42SkdV/8Qeww55Qir7zin5t4Tlq0yC/nXrDA/0zZsogo+aqPv/SvA3wW5/UIh/N70Lp1MGUF9xLwCqB5jvfKlSvn8mzYnXv69GkX7OR3XA8OO4Wu8MK55557LkzoxXl7LAU0zAubORPo1s2fmC3SruyuFSUI28MJQomJweGElrNK6lKfyW9iYjh64j+yCp2XOPFiJMlXQc0Xv05Fam0Cvks5cuTiahEr0plAdJmybS5nNy57bCyIiYlBH85aFUZKSooLeNq1a4cyZcqYattZAxpOtDdrVjDyaIgl3EuXLsXNN9+MR0JzM0i+F7oQ27lzZ473MjIy8N1337kJNbkvW/fhh/5z166IKBEX1OzatQsVK1Z0uTTZl7/44ovuNRNJrfj2WwZp/vTTWZ05498+gdq0gSmcn2bixIku2a5Tp04XzVXDpOFDhw65zzAYsKBo0aIXrtqzYwIpg5qhQ4fi7rvvhrUhJwY0nTv70+kHJaAhFjUweGfemJV2LJxVtypat27tSru5T2fthWNFJ4eduM0tFTqcOvVb/kwIh56mTmVFsj8nVSSJuF9+3rx57mTXpEkTJCQkuKiX1U+ffPKJi4R58Od7Vnz0ETPpWfXjBzdsPLxvDkdomGHOyco4yZElnTt3xqRJk1wvRbVq1VwvBbtqOYcLS7oZBLANSP41ahQwY4afAF+tGvDqqzk/w1G2OnVg0gcffBCIoSfG6p9/7r8OTabIZaGhCR7XrP0E7777Lu69917069fPJQuHhst57OI564033oAlDRsCvOsDS7pZ/bRli799q1QB5s+PvIuV6Ejs3mPXHhsJq2HOnDnjcmnatGnj5i9hlGwJJ9DlMNPGjayQ8e8FxY6L2rX9bj1e7RoK+h2WtvJK56233sJHH32EOXPmuKtazrYaqohimaTkX/v2+c9sz5dKdGcQbzGoYZkv7+3VoEED1DI+GQ8DGgavWbG4IWsth7Wghr01X375pZui4dNPP3XHMuYCPvnkk24Zq3Yt6dLFTw7mPXc5LQNz3nnPr+efz9mDEwki7nTZtGlT9wgKJllFWqJVXmCXPCuBglgNlBVnzebDGq6SwdXKFQYz/u3y7AvqduYNK1muHwSvvOI/8ouA1CGIiIiIdQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiZEeZ7n5eqDUVEoUKAAypcvj6A4fvw4YmNjERRBW98ff/wR58+fV7s2LmjrG8R2HbRtHNR2nZmZeXWDGhEREZHrITfhSvSV/INBivyDGAkHbX2DeEUbxO0ctPUNYrsO2jYOarvOjSsKariDHDp0CEHRrl07LFu2DEERtPWNj4/H4cOH1a6NC9r6BrFdB20bB7Vd54YShUVERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExISKDGs8DFi0CmjcHypcHihUDqlcH+vcHfvgBphw+fBjjx49H69atUbFiRRQuXBjlypVDp06d8MUXX8C6xYsXo1WrVoiNjUWRIkVQuXJldOvWDQcPHoQlqampePbZZ9GkSRPceuutbl25nRMTEzFt2jRkZGTAmkqVgKio8I9mzWDS+fPnMXHiRNStWxfFihVDyZIl3TZftmwZLJo+/dLbOPS47z6YNnbsb+u6eTPMmT17Nvr374969eohJiYGUVFRmM4NH6GiEYGGDAGSk/2ApkMHoGRJ4OuvgfffB+bOBTZuBO66CyZMmDABY8eORdWqVV1gU6ZMGezZswdLlixxjzlz5qBLly6wxvM8DBgwAJMnT3br3rVrV9xwww04cuQIPvvsM+zfvx8VKlSAFadPn8akSZPQoEEDPPTQQ247nzhxAitWrEDv3r0xb94897pAgYi8zvjDSpUCnnkmfMBjsU0/+uijWLhwoWvTffr0QVpaGpYuXYr27du7ff2pp56CJXXqACNGhH9vwQJgxw7g/vth1vbt/voXLw788gtMGjZsmDsely5dGuXLl3evI5qXS/xoXFycd639+KPnFSjgeQkJnnfy5MXvJSfze3her15ennj44Yev+d9YuHCht27duhzLU1JSvEKFCnk33XSTl5qa6llZ35Dx48e7NjVo0CDv3LlzOd7PyMi45t+B7Tmv2nVmZqaXlpYWdj2bNWvmvsfy5cs9S9uZ+zAf11tere/8+fPddkxMTPTOnDlzYfmxY8e8hIQELyYmxtu7d6+pdn0pbOqxsZ4XHe15R4/aOnaFpKd7Xt26ntewoeclJfnnpk2b8u7v59U6r1q1ytu3b597PXr0aNe2pk2b5uW13LbniLss3LePXbhAYqJ/lZdV27b+87FjMKNjx45o2rRpjuWNGzdG8+bN3dX8N998A0vOnj2LkSNHokqVKnj77bdRsGDBHJ+Jjo7ITsQ/jD0wHFoMt56PPPKIe/3dd99dh28mVwt7ZOjll19G0aJFLyznFe7gwYNdrw2HGoNgyRLg+HH/mH3LLTDptdf8nqipU4EwhzAzWrZsiYSEBOQXEXfmuP12gMf+DRuAU6f8oaeQ5cv9Z+tjtCGFChUyeYJfuXKlC9Z69eqFzMxMl2+we/du3HjjjW4Huu222xAUzMH49NNP3eu7rIypZpGW5uddHDni78v16wMNG8Kko0ePumfmhWUXWrZ27VoX0Fs3ZYr/3LcvTPrqKz+oGTUKuOOO6/1tJKuIO1vGxgJjxgDPPQfUqAG0b/9bTs3atcCgQYCxYemwDhw4gNWrV7sxzFq1asGSrVu3umf20NSuXdsFNFl7NHhVO27cOFiUnp6O119/3eVfHD9+HGvWrMGuXbtcgHefwWid5/levS5exsCGuXFVq8IU9sjQ3r17UbNmzYve4zLK2tatYsrFmjVAfDzwwAMwGag/9pifT/TCC9f720jEBzU0eDAQF+dH+e+999vyRo2A7t3ZcwHTWAnTo0cP113NJOJwwzP52U8//eSek5OTXZXIli1b3Elg27ZteOKJJ/Dmm2+6RMuBAwfCYlCT9UqdlQRDhgzB6NGjYQ2DmcaN/aT+EiV4QvcLAGbN8ntbOap6ww0w48EHH3QJ32PGjEGLFi1chRsxeGWFI508eRLWcYSNKQQ9e9oclhk+HNizhxdnNtcvv4u4nBpil15SEsemAVb2/vwzsH49y2L9UlCj1ZEXhiN69uyJlJQU9OvXzwU3FteRmGPCCq/69eujRIkSLo9o/vz5rreGgY1FXE/20nDYjWXr77zzDqZMmYJmzZrhFMdbDWFVSIsWQNmy/rQMvLKdORNgk+bVPKsZLenevbvLg1u/fr3rXX366addhd+dd97pSrvJWnVbdty1GdSwvLl3b5izaRPATuRhw+xU4FoTcXvY6tX+wZBDTC+95Hdh8iqPvTQff8w8E39oyiKe7FneyzLupKQkvJe1m8qQUr9mgHPeA87ZkhXzSphA/P3335u+quXJLT4+3vVGsax9w4YNeI2D9AHA+aaIeXOWMPeNZfmvvPKK277crosWLXLl3AtY3wwGeGVhGY/fBw74wWyY1KJ87dw54PHHgdq1/XOTRKaIG8hZscJ/5sR72ZUr5+fZbNvGeT/8YMdSQMO8ipkzZ7rJ5zi5kdWruuqcSRFwicHhhJazSupSn7GE8xPRunXrEAS/pp6YnNeDk5ONGDHCPbIKbVsG8pZZThDmOYfDThSmkNG55x7/efFif441yXsRF9Skp1++bJvLea7/tTDIXEDDifZmzZplLo8mK3bR086dO8PmE7G0uXjx4m6CuiDghINZq92sC02UbXECvkv58MMP3TMnmbSKJdysar/5ZuDXWQpMiYkB+vQJ/15Kih/wtGsH8LAVpLYdaSIuqOH8NBMn+gmFnTpdPFcNR2MOHfI/wwZmaciJAU3nzp3dlNSWAxoKzZ7M0m7mk/TNclnHJEsOO3H4zVIp+7fffotKlSq5qfOzOnPmjLt9ArVp0wZW7NoFVKzo59JkX/7ii/5rJv1bw7yoUP5MCIeepk6d6nLHOC+VVUwA50Up8yGtHJ+z4tRDoZ6o7JgUzaBm6FDg7rvz+ptJVhF31ujcGZg0yY98q1XzI1+OQHBeAJZ0s2Ex4LFi1KhRmDFjhksgrVatGl599dUcn+nQoQPqMMvSkHfffRf33nuvS4ZmsnCNGjVc9RPn8eBET2+88QYs+eijj1y1V6NGjVxwwxMf7/vFHAxWxzBJmqXsVsyb5++nTZoAnLeL08iz+umTT9gb5x/8+Z41DRs2dLf3YDUfq59Y2cehJ+aJMQne8gXLBx/YHXoKsilTpuDzzz93r0MTwXJZaEiVx7SsF6bXW8QFNdznV64E3nqLJwJgzhw/+ueslKGKqGxTQORr+ziF8q/3BrpUoihPgtaCGvbWfPnllxg+fLibfI69NrzB45NPPumWWUuobNu2rRtm2rhxIzZt2uS2NxOmOU8PhyTYW2epZ4ojjBxdZP4bKxfPnPFzadgZxbmmfk0jMofDx0wO3rx5sxtK5aR7vHfO888/n6MHx5ItW/z7IDVoABibVivwPv/8c3fhnRULG/gIiaSgJor3SsjVB6OiEBcXh0Mc/wmIdu3amb27bjhBW19WH7G3RO3atqCtbxDbddC2cVDb9aFctGeb5TUiIiISOApqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFClSBK1atUJQbNmyBQ0aNEBQBG19V61ahdTUVLVr44K2vkFs10HbxkFt12fPnr26QU1cXBwOHTqEoGjXrh2WLVuGoAja+sbHx+Pw4cNq18YFbX2D2K6Dto2D2q4P5aI9a/hJRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJERfUpKYCzz4LNGkC3HorUKQIUK4ckJgITJsGZGTAnEqVKiEqKirso1mzZrBm+vTpl1zf0OO+++6DJZ4HLFoENG8OlC8PFCsGVK8O9O8P/PADTJo9ezb69++PevXqISYmxm1XbvsgGTsWiIryH5s3w5TDhw9j/PjxaN26NSpWrIjChQujXLly6NSpE7744gtYdf78eUycOBF169ZFsWLFULJkSTRp0gTLli2DdYsXA61aAbGx/rm5cmWgWzfg4EFEjGhEmNOngUmTgAYNgIceAsqUAU6cAFasAHr3BubN818XiLhw7M8pVaoUnnnmmbABjzV16tTBiBEjwr63YMEC7NixA/fffz8sGTIESE72A5oOHYCSJYGvvwbefx+YOxfYuBG46y6YMmzYMOzfvx+lS5dG+fLl3esg2b4dYDMvXhz45ReYM2HCBIwdOxZVq1Z1gU2ZMmWwZ88eLFmyxD3mzJmDLl26wBLP8/Doo49i4cKFbr379OmDtLQ0LF26FO3bt3e/yVNPPQVrPA8YMACYPBmoWhXo2hW44QbgyBHgs88A7toVKiAyeLnEj8bFxXnXWmam56Wl5VyekeF5zZrxe3je8uVennj44Yfz5O8kJCS4x/WWV+t7KWlpaV5sbKwXHR3tHT169Jr/PbbnvGjXP/7oeQUKcDt73smTF7+XnOy36V69PHPbedWqVd6+ffvc69GjR7vfetq0aV4Q2nV6uufVret5DRt6XlKSv403bcqbv51X7XrhwoXeunXrcixPSUnxChUq5N10001eamqqZ2kbz58/3/22iYmJ3pkzZy4sP3bsmDuGx8TEeHv37jXXrseP99vwoEGed+5c+PPztZbb9hxx/R3sgSlcOOfy6GjgkUf81999l+dfS/IAr+6OHz+Otm3b4pZbboEV+/axy9ofQi1V6uL32rb1n48dgzktW7ZEQkICgui114AdO4CpU4GCBWFSx44d0bRp0xzLGzdujObNm+PEiRP45ptvYAl7ZOjll19G0aJFLyxnb+TgwYNdr8005kkYcvYsMHIkUKUK8Pbb4dszz8+RIoK+yuXxpPDpp/5ra930xJ2B+QZHjhxxY7T169dHw4YNESRTpkxxz3379oUlt9/uB+obNgCnTvlDTyHLl/vPxlKIAu2rr/ygZtQo4I47EEiFChVyz9GRdLa7Co4ePeqeKzOZJJvQsrVr12IkowAjVq70U0B69QIyMwGmDu3eDdx4Iy9cgNtuQ0SJ2BaXng68/ro/lnf8OLBmDbBrl//DWjwBcGfpxZXLgoHN3Llz3ditdcy3WLNmDeLj4/HAAw/AEibVjRkDPPccUKMG0L79bzk1a9cCgwYBBofhAyktDXjsMeaNAS+8gEA6cOAAVq9e7fKoatWqBUvYI0N79+5FzZo1L3qPy2g3z/iGbN3qP7OHpnZtP6DJOrIyeDAwbhwiRsQNP2UNahjs8mrnnXeAv/3NT7ZkopI1DGZ4Qv/73/+OX375Bdu2bUOPHj3w7//+764K6Oeff4Z17LJlVUHPnj1R0GB/PXd8JrkzEf6994C//AX4618BdsZ17x5Z3bfyxw0fDuzZ41dqGmzGvysjI8Mdu9jzzCRia/vygw8+6J7HjBmDVJbq/orD5qwEo5MnT8KSn37yn1nowOHzLVsAnpJSUoBq1YA33/SLeyJFxAY1JUr4vTTs7mK5GAMbjk6wwpld+JawEqhFixYoW7asKxFkddDMmTPdwYE9GO+zRMYwBjMMaljy25slbgYxOE9K4li83555UFi/3p/CgG06ANWg5m3a5F+xDhtmc4j894QuSlJSUtCvXz93/LKme/fuLl9o/fr1rhfq6aefxoABA3DnnXe6tAEqYKw09/x5/5lD6EuWcATBPz83bgzMn+/31jCwiRQR/+vzB4uPBwYO9HtpmJfA8eog4BwftIErbRi7qtllzcAu3Fh1frd6tV/ayyGml17y2zMPCo0aAR9/zPwDf2hK8q9z54DHH/e757mNgxjQ8IKEZdxJSUl4j92RBjFHaMWKFXjllVdc8DJ58mQsWrTIlXNzOgrixaklpX4tbqhXz587LisG70wg/v579lAhIuSrTu/Wrf3ndesQCKHxWw5JWWY1QTiE8yoRJ97LjhNLMs9m2zZ/aIrBjuQ/3HYcdqJw1Zt0zz2/TWDGuYosBTQcQmfvcrdu3VzBg7Xeiqw4kSR717PPtbXu1xMTJ5u0pHp1/5mJweGElrNK6lKfyUv5KqjhRD/0a2K9eaFZOS1OwJd1LJplkjfffDMeCdXsG8P8sMuVbXM5zwFBadcWxcQAffqEf4+5Bwx42rXzJxO1tDtnDWg40d6sWbPM5dHk1ocffuieu3JmOkOa/3oxtnNnzvc4wz+nWOEEk2zbkSDigppvv/V3ek4jn9WZM/7tE6hNG5ixa9cuN8U4c2myL3/xxRcvjONaxYNgenq667LmFZBFnJ9m4kQ/0a5Tp4vnqmEv/aFD/meMrn4gcMqSXzscc+jZ0w9qhg4F7r4b5oacGNB07tzZ3RYjCAHNqVOnLuTPhHDoaerUqa5ilfP3WFK1qj9KwtJutvGsHeqs6uSwE/MFI6XYIUK+xm8++sg/+DPfgMEN287hw34XPku7mZzEShIr5s2bh+TkZHfvEE5UVrx4cVcS+Mknn7hKgqFDh7r3rPrggw9MDz1R585+dUCoWoBX7Oym5XwmLOnmCZFt3uKw4ueff+5ehyZh47JQN32jRo1Mb3frRo0ahRkzZqBEiRKoVq0aXn311Ryf6dChgyt8sITzh1WoUMGVdBcpUgRbtmxxbbpKlSqYP3++ycDu3XeBe+8F+vXzk4VDQ+Y8fnF+zTfeQMSIuKCGM6xymIn3wmE1AceqeWXLBDz26rE4JlIiwquBmfQ7d+50ZdzMqD9z5ozLpWnTpg0GDRrk7qliFQ8G27dvR4MGDczNZ5EVj3G8ynnrLT9onzPHH5LipMmhiqhsU16YwICGJ72smPSeNfFdQU3+tY9TZbt8otN47RLVGxw6txbUcJiNycGbN292F54sbuB9zp5//vkcPTiWemu+/NKfsoCT4PJ4xnzAJ5/0l0VSbnTEhQfMsTKWZ3VZnGY83FTjQcBgxr+tmH0cWmJVTJAqY5gwGrS7cofDn8DizxDU7cvKJz6CpkIFf/6lSGc3RV1EREQCRUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExIQoz/O8XH0wKgpFihRBq1atEBRbtmxBgwYNEBRBW99Vq1YhNTVV7dq4oK1vENt10LZxUNv12bNnr25QExcXh0OHDiEo2rVrh2XLliEogra+8fHxOHz4sNq1cUFb3yC266Bt46C260O5aM8afhIRERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYkK+CGrGjgWiovzH5s0w5/z585g4cSLq1q2LYsWKoWTJkmjSpAmWLVsGq2bPBvr3B+rVA2Ji/G07fTrMW7x4MVq1aoXY2FgUKVIElStXRrdu3XDw4EFYMn36dERFRV32cd9998GSw4eB8eOB1q2BihWBwoWBcuWATp2AL76ASZUqVbrk9m3WrBmsSU1NxbPPPuuOz7feeqvbh8uVK4fExERMmzYNGRkZsMjzgEWLgObNgfLlgWLFgOrV/WP4Dz8gokQjwm3fDowYARQvDvzyC8zxPA+PPvooFi5ciKpVq6JPnz5IS0vD0qVL0b59e0yYMAFPPfUUrBk2DNi/Hyhd2t9J+NoybucBAwZg8uTJbjt37doVN9xwA44cOYLPPvsM+/fvR4UKFWBFnTp1MII7bhgLFizAjh07cP/998OSCRP8C7CqVf3ApkwZYM8eYMkS/zFnDtClC8wpVaoUnnnmmbABjzWnT5/GpEmT0KBBAzz00EMoU6YMTpw4gRUrVqB3796YN2+ee12gQL7oL8i1IUOA5GT/WN2hA1CyJPD118D77wNz5wIbNwJ33YXI4OUSPxoXF+flpfR0z6tb1/MaNvS8pCR+B8/btCnv/v7DDz98zf/G/Pnz3W+bmJjonTlz5sLyY8eOeQkJCV5MTIy3d+9ez8r6hqxa5Xn79vmvR4/2t+20aV6eYnvOq3Y9fvx497cGDRrknTt3Lsf7GRkZXl7Jy+2cXVpamhcbG+tFR0d7R48eNbW+Cxd63rp1OZenpHheoUKed9NNnpeaaqtd8xjFx/WWV9s4MzPTteFw+2+zZs3c7758+XJT6/zjj55XoAC3teedPHnxe8nJ/rG7V69r/z1y254jOpx87TVgxw5g6lSgYEGYxB4Zevnll1G0aNELy0uXLo3Bgwe7Xht2a1rTsiWQkIBAOHv2LEaOHIkqVarg7bffRsEwjTk6OuI7Ta+KJUuW4Pjx42jbti1uueUWWNKxI9C0ac7ljRv73fYnTgDffHM9vplcLeyBKcxxxTD77yOPPOJef/fdd7Bk3z6mSACJieyVu/i9tm3952PHEDEi9kj61Vd+UDNqFHDHHTDr6NGj7pm5FdmFlq1du9adFCV/Wrlypeui7tWrFzIzM12u1O7du3HjjTeiZcuWuO222xAUU6ZMcc99+/ZFkBQq5D9bjF154cUcKg6lMh+wfv36aNiwIYKEeZGffvqpe31XxIzDXB233+7nh23YAJw65Q89hSxf7j9HUnpcRO5iaWnAY49xXB544QWYxh4Z2rt3L2rWrHnRe1xGPAFK/rV161b3zB6a2rVrX7Q9eeXHHrlx48bBOuYNrVmzBvHx8XjggQcQFAcOAKtX+/kItWrB5IUZA/asGNjMnTvX5Y9ZlJ6ejtdff93lyrHnke16165d7newlgAfGwuMGQM89xxQowbQvv1vOTVr1wKDBgGRlPYZkcNPw4f7CXYcdbE67BTy4IMPuucxY8a4zPoQ7ijjWUoB4OTJk9ft+8mf99NPP7nn5ORkl1S5ZcsW/Pzzz0hJSUG1atXw5ptvuuRD6ziMyivanj17hh2Cs4jFMD16+BdqTCK2tto8ifOE/ve//x2//PILtm3bhh49euDf//3f3cmd7dxqUMPe81GjRuGdd97B3/72NwwZMsQVAlg0eDAwbx4TpYH33gP+8hfgr38F2CHXvXtk9UBGXFCzaRPAi1ZWxxjrxQure/fuaN68OdavX49atWrh6aefdlUyd955p+vKJWuZ9EHDEzlxLJ45JbyKLVGiBBo3boz58+e77cvAxvpvwKCGpb6sEgkCbvaePYGUFKBfPz+4sYYVbi1atEDZsmXddBSseps5c6YLbNgz9z7LYwzi/steGg4nczoGBjYcWmUZ+ymO0RgzahSQlMTcT4CzTzBWXb+eJe4AK/cjafaRiDpbnjsHPP44ULs28NJLCAQmmLEE8JVXXnEnN0b6ixYtcuXcLH0lHjAk/2LvDNWrV8/NbZEVx9+ZQPz999+b7pFbvXo1Dhw44E6A4fLHLAY0jN1Yxs2TAa9ug6Q/JzAB8zA2wDIeszmcOnDgQHfs5vq+xmRQQ1av9qdV4RATz8vx8QzqgEaNgI8/9vPFODQVKSKo08jv2uKwE4VJMHfuucd/XrzYr5e3ICYmxl3xZJ/XY926dRdOhpJ/VecsVYBLDA4ntJxVUpf6TH4XpARhBjRMMZk5E+jWzZ9UMmidraFcQQ5JBUVrTk6U5bhtxYoV/jMr+LLj5JLMs9m2zT9/M9i53iIqqOHMsn36hH+PXbgMeNq18ye1MjivUw4ffvihe+ZEbZJ/cXiRdu7cmeM9zkDKEtDixYu7ibwsYn4Ypy64+eabL5S9BiGg4UR7s2bZy6PJjS9+nULZ4gR8l8LqLyoUKnUzIj398mXbXM6gPVJWO6KuHzhNCy/owj3uvdf/zNCh/v9nZZQV4cZgOfQ0depUl3/RkRNgSL7FChBexTF4CfVYhDBBnMNOPNlbnatm1qxZLrEyKSnJ9UpaH3JiQNO5s38rEMsBDat9zpw5E3b5iy++eCFn0JJvv/027DpzGW+fQG3atIEliYn+M2cU/sc/Ln6Pw6qHDvkjKJGya9s8iuYznNOBU+SzpJv3EmF1DLswmWvBRFKLlSI8t3/+uf86NCEZl4V6bjlea2mk4t1338W9996Lfv36uWThGjVquEoRzkGUkJCAN954A1Z98MEHgRh6YjLljBl+F3y1asCrr+b8DIfMrVyQ8ZYArOjjfZDYhtnbyOkKPvnkE9cDOXToUPeeJR999JFb50aNGrleKBZzHD582OVFskeSyf+cosGSzp0BFmdytITtmqMlHCXnXHIs6WZnBAOeSKGgJgJ06dLFJQdv3rzZHQyYSDls2DA8//zzFyqgrGFAwxNAVswpzJpXaOkcyN6aL7/8EsOHD3eTdHFCPt4I78knn3TLrCaDM0Dfvn27u1cOq/ss48yrxNyCS+WKcjTGSlDDYVUOqTI4Z/UmeyuYS8OeikGDBl3IMbGEM2FzmGnjxo3YtGmTuxcUCwE4/xTTBFjZZ63HtWBBTiAKvPUWgzo/+Z1DUpwQPFQRlW2Ktesq3/z6TLazehdnVj7xESSWt+elsDfO4i0vLofBjH/rOPuC1qabNm3qHkHCoo0gFm7ExPiVT/mhKjmicmpERERE/igFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETojzP83L1wagoFChQAOXLl0dQHD9+HLGxsQiKoK3vjz/+iPPnz6tdGxe09Q1iuw7aNg5qu87MzLy6QY2IiIjI9ZCbcCX6Sv7BIEX+QYyEg7a+QbyiDeJ2Dtr6BrFdB20bB7Vd58YVBTXcQQ4dOoSgaNeuHZYtW4agCNr6xsfH4/Dhw2rXxgVtfYPYroO2jYParnNDicIiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImBBxQc3hw4cxfvx4tG7dGhUrVkThwoVRrlw5dOrUCV988QWCYuzYsYiKinKPzZs3w5rz54GJE4G6dYFixYCSJYEmTYBly2BSpUqVLmzP7I9mzZrBmtTUVDz77LNo0qQJbr31VhQpUsTtx4mJiZg2bRoyMjJgkecBixYBzZsD5cv7bbt6daB/f+CHH2DW4sWL0apVK8TGxrptXblyZXTr1g0HDx6ENbNn+9uzXj0gJgaIigKmT4dZ06f763i5x333IWJEI8JMmDDBndCrVq3qApsyZcpgz549WLJkiXvMmTMHXbp0gWXbt2/HiBEjULx4cfzyyy+weOB/9FFg4UKgalWgTx8gLQ1YuhRo355tAHjqKZhTqlQpPPPMM2EDHmtOnz6NSZMmoUGDBnjooYfcfnzixAmsWLECvXv3xrx589zrAgUi7rrqTxkyBEhO9gOaDh38YP3rr4H33wfmzgU2bgTuugtmeJ6HAQMGYPLkye6Y3bVrV9xwww04cuQIPvvsM+zfvx8VKlSAJcOGAfv3A6VL+9uZry2rUwcYMSL8ewsWADt2APffj8jh5RI/GhcX511rCxcu9NatW5djeUpKileoUCHvpptu8lJTU7288PDDD3t5LT093atbt67XsGFDLykpyf3umzZtMrW+8+ezPXleYqLnnTnz2/JjxzwvIcHzYmI8b+/ea/892J7zql0nJCS4RyTIi+2cmZnppaWl5ViekZHhNWvWzP3uy5cv9yy16x9/9LwCBfw2fPLkxe8lJ/ttvlcvW+16/Pjx7m8NGjTIO3fuXNjtbe1YvWqV5+3b578ePdrfrtOmeXnuepyfsuLuHRvredHRnnf0qHfN5bY9R9xlUseOHdG0adMcyxs3bozmzZu7q71vvvkGVr322mvYsWMHpk6dioIFC8Ii9sjQyy8DRYv+tpxXPoMH+70206Zdt68nVwF7YDh0nF10dDQeeeQR9/q7776DJfv2+cOqiYnslbv4vbZt/edjx2DG2bNnMXLkSFSpUgVvv/122OMVt7c1LVsCCQnX+1tcf0uWAMeP+237llsQMfJViytUqJDZHYW++uorF9SMGjUKd9xxB6w6etR/rlw553uhZWvXAiNHwpS0tDRMnz7ddc2XLFkS9evXR8OGDREk58+fx6effupe32VpHAbA7bcDjOM2bABOnfKHnkKWL/efIyn34M9auXKlu8js1asXMjMzsWzZMuzevRs33ngjWrZsidtuu+16f0W5hqZM8Z/79kVEyTfRwYEDB7B69WqUL18etWrVgjU84T322GOoU6cOXnjhBVjGHhnauxeoWfPi97iMdu+GOUePHnUngKwY2MydO9flI1iUnp6O119/3eVeHD9+HGvWrMGuXbvc73CfpTM8gNhYYMwY4LnngBo1/PywUE4Ng/RBg2zlim3dutU9s4emdu3aLqDJ2lM3ePBgjBs37jp+Q7lWmEe0Zg0QHw888AAiSr4Ialgp0aNHD3fiZxKxxWGZ4cOHu4RoHigsrl9WDz4IzJvnnwBatACKFPGXsytz/Hj/9cmTMIUncQ6hsneiRIkS7gSQnJyMWbNmuZM7h1SZYGkxqOEQRQirvYYMGYLRo0fDIg6fxsX5V6/vvffb8kaNgO7d2csMM3766Sf3zHZct25dbNmyBTVr1sS2bdvwxBNP4M0333TB+sCBA6/3V5WrjOkBHGrt2ZNBLSJKxOXUhOuu7tmzJ1JSUtCvXz8X3FizadMmd0UzbNgwc13y4fDgzpLX9esBdro9/TQwYABw552/ddkbK4px1WwtWrRA2bJlUaxYMdcjN3PmTNeeWSHyPstjDGIAx14aDk+wvPedd97BlClTXBn7KY7RGDNqFJCU5OeLsZr555/9dp6aCrBy39KUBTw2E3OnWJnKXkdubwbv8+fPd701DGzElvPn/aCGpdy9eyPiFIj0nYblnyzjTkpKwntZL32MOHfuHB5//HHXffvSSy8hCHi1umIF8MorfvAyebI/twe761kiSGXLIhD6c8ILMA9jAyzjCS4+Pt5dtbP8l+vL/DFLVq/2S185xMRdmV3zJUr4vTQff8ycQH9oytIUBVSvXj03F1FWvDhjAvH333+Pk9a6XQNu9Wqmg/i97OHyIq+36EgOaNhlz6tZTuLEBEtrc1qE5vPgsBOFqxahe+6558IEVx04+YUBnLSKJ4Ds8x+sW+c/c2KrICj9a4KRxfmILoXzT9G60MY2goE6sRcyu3Ll/Dybbdu4z/vBTn5XnbMKAi4xOJzQclZJXeozkv9MidAE4YgOarIGNJxoj3kHVvNMYmJi0Iezz4XBITcGPO3atXOTl1mcpC27Dz/0n7t2RSCEZskOwrYNYfVX1mpGK9LTL1+2zeW8LrOy2pxig3bu3Bk2D5Il+5xAlMcuseH4cX9KjptvBn6dmSHiREfqkBMDms6dO2P27NlmAxoqWrSoyzEIh7lEDGqGDh2Ku+++G5ZkL3klDj1NncqKIM5XBDNY7cNbfjCXJvvyF1980b3uzkQjQ7799lsXqGVf5zNnzrjbJ1CbNm1gCeen4a0/OKNwp04Xz1XDkfNDh/zPsJfSgtCs7yzt5jGsb5ZL9zFjxrhhJ6YNWJ2CI4hmzfKDd+aNRWo7jrjWxjlaZsyY4RLOqlWrhldffTXHZzgEw0RLyb84PQtnT2dJN6uftmzxh56qVAHmz4+8jPo/g7cEYIUI74OUkJDgrl5Z/fTJJ5+4K1oGrXzPko8++sitc6NGjVxww3l5eF833hqBpd1MJmXJryWdOwOTJrGHFahWDWjXjkMwnH/KL+nmRJMMeCx59913ce+997oiDiYL16hRw1U/rV271rX1N954A9bwGvTzz/3XoXlguSw0msocqkgdmvmzPvjAf47k9Yu4oGYfp+X8NdfkUomEPEgqqMnfePsuJgfzXp28tyETznhPleefz9mDY6Gbnl30PNivX7/e9VYwl4Y9FYMGDbqQY2JJ27Zt3TDTxo0bXXUf92cmljIhnvcHYm+stSt4BuIrVwJvvcWgDpgzx7+q5WyroYqo7PMyWeit+fLLL92UFJxUkb02vHHpk08+6Zax2s8aBjQzZly8jHn+WXP9I/mk/0fxwnP7dqBBA79qNVJF3FGFCcF8iO3fgpVPfAQBb/sR7tYflrEiho+gYZc8K58CUsjo8IaVvPN6UPCQbPSwfFkMZtxdICOcvXIiERERCSQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICVGe53m5+mBUFIoUKYJWrVohKLZs2YIGDRogKIK2vqtWrUJqaqratXFBW98gtuugbeOgtuuzZ89e3aAmLi4Ohw4dQlC0a9cOy5YtQ1AEbX3j4+Nx+PBhtWvjgra+QWzXQdvGQW3Xh3LRnjX8JCIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEhIgLaqZPn46oqKjLPu677z5YMns20L8/UK8eEBMDREXxd4BplSpVuuT2bdasGSw5fPgwxo8fj9atW6NixYooXLgwypUrh06dOuGLL76AVefPAxMnAnXrAsWKASVLAk2aAMuWwbzFi4FWrYDYWKBIEaByZaBbN+DgQZiRmpqKZ599Fk2aNMGtt96KIkWKuHadmJiIadOmISMjAxZ5HrBoEdC8OVC+vN+2q1f3j+E//IBAGDt27IXj9ebNmxFJohFh6tSpgxEjRoR9b8GCBdixYwfuv/9+WDJsGLB/P1C6tL+T8HUQlCpVCs8880zYgMeSCRMmuINA1apVXWBTpkwZ7NmzB0uWLHGPOXPmoEuXLrB24H/0UWDhQqBqVaBPHyAtDVi6FGjfnr8J8NRTMIfrPWAAMHmyv95duwI33AAcOQJ89pm/b1eoABNOnz6NSZMmoUGDBnjooYdcuz5x4gRWrFiB3r17Y968ee51gQIRd+38pwwZAiQn+8fqDh38YP3rr4H33wfmzgU2bgTuugtmbd++3Z2jixcvjl9++QURx8slfjQuLs67XtLS0rzY2FgvOjraO3r0aJ78zYcffjhP/s6qVZ63b5//evRo/taeN22al+fyan0pISHBPa4ntue8aNcLFy701q1bl2N5SkqKV6hQIe+mm27yUlNTPUvbef58vx0nJnremTO/LT92jNve82JiPG/vXs9cux4/3l/vQYM879y5nO9nZNhp15mZme64nF1GRobXrFkz9x2WL1/uWdrGP/7oeQUK+G345MmL30tO9rd9r1722nVIenq6V7duXa9hw4ZeUlKS28abNm3y8kJu23O+CaF5RXv8+HG0bdsWt9xyCyxp2RJISLje30KulY4dO6Jp06Y5ljdu3BjNmzd3V7fffPMNLGGPDL38MlC06G/L2Rs5eLDfazNtGkw5exYYORKoUgV4+22gYMGcn4mOuL7xP449MBxKzS46OhqPPPKIe/3dd9/Bkn37/GHVxET2NF/8Xtu2/vOxYzDrtddec6MlU6dORcFwDTwC5JtdbMqUKe65b9++1/uryFWSlpbmcqiOHDmCkiVLon79+mjYsCGCpFChQhdOBJYcPeo/M5cku9CytWv9IMCKlSuBEyeAXr2AzEw/d2j3buDGG/0Ll9tuQyCcP38en376qXt9l7FxmNtvBxjHbdgAnDrlDz2FLF/uPxtL+bzgq6++ckHNqFGjcMcddyBS5Ysj6f79+7FmzRrEx8fjgQceuN5fR66So0ePohfPAFkwsJk7d67LP7HuwIEDWL16NcqXL49atWrBEvbI0N69QM2aF7/HZcQTviVbt/rPvICtXfvi9WNaCXuoxo2DOenp6Xj99deZyuB603ms3rVrl9u3rRV1MPF7zBjgueeAGjX8/LBQTg2D9EGDbOaKpaWl4bHHHnM5ry+88AIiWb4IaphJz+i/Z8+eEdvlJVeGBzwOv/BKrkSJEti9ezeSk5Mxa9YsdyDkcMwNzLA0ipUhPXr0cAcLJhFba9cPPgjMm+efAFq08CuA6PhxYPx4//XJkzDlp5/8ZyaRsuJryxY/oNu2DXjiCeDNN/3k4YEDYS6oGZmly40VMUOGDMHo0aNhEYPTuDiOGgDvvffb8kaNgO7dbQ0xhgwfPtwVN2zdujXij1URn1PDYIZBDXcUZtSLDcyeb9GiBcqWLYtixYq5K4CZM2e6Ez175t5nKYFRoQA9JSUF/fr1c+tsDQ/uLHldvx5gJ9TTT/tVQXfe+VuXvbGiGJdrQRyeWLKEvY5AiRLMnQLmz/fXl4GNNbwoYS9NZmYmDh48iHfeecelC3BqhlMcozFm1CggKcnPF2OJ/s8/++08NRXgbBTWpizYtGkTxo0bh2HDhuWL4cSIP6ywe57d9DwBVg43QC+m9OdkD+CY9QZYDWgYnLOMOykpCe9lvdQzhFerK1YAr7zin8xZ4sy5Pdhdv2CB/5myZWFKKHGU803deuvF7/FcwATi77+310OVNXGYKQIDBw7E5MmT3T7MHAxLVq/mBZk/xPTSS0B8vB+4spfm44+ZI+cPTVlx7tw5PP7446hduzZe4grnAxHfUaYE4WAp/WsyRkTOf3AVAhoOu7FHqlu3bi5J2tocHllxIkmeALJPO7Vu3W8nf0s4ARsxMTic0HJWSV3qM1ZwPiZaF9rYRjBQJ/ZCZleunJ9nw+HG06f9YMfCXER79uxxr8NVutE999zjnhcvXowOnLjnOovooIZJZ0uXLsXNN998oURQbAvNsGttAr6sAQ0n2mPuUKSPTV8rH37oP3NiOktCJ7qdO3O+x8l1Wd1cvDhQpgzMY0Vj1uo+K9LTL1+2zeW8TrGy2jExMejDmTPD4PA5A5527dq5iRcj5Zgd0UEND/xMQmM3PX9csYGVEbxdAHNpsi9/8cUX3evuTMowNuTEgKZz586YPXt2IAKa7CWvxKGnqVP9fJOOHWEKk4DZQcHSbnYwZ+1cZsI0h52Yi2ElkfTbb791J7Ls+/GZM2fc7ROoTZs2sITz0/DWH0wG79Tp4rlqOJJ86JD/GSunq6JFi14YLcmOeYEMaoYOHYq7774bkSKid68PPvggEENPbDOff+6/Ds3BxmWhnluO11r6CTh9OiudeM+YhIQEN902q58++eQTVxXEnYTvWcF5HWbMmOESKqtVq4ZXX301x2fYbctkaUs45RBvCcAKIFY/sRqIbZq5JUyctRjXvfsucO+9QL9+frJwaDiC5b6cYPONN2DGRx995PbjRo0aueCGc03xPme8NQJ72VndOJilQoZ07gxMmsReCqBaNaBdO38o8auv/G3MiSYZ8Mj1E7FBzZYtW9w9JnhfEWtzeGTHgGbGjIuXMU82a66spaCGs+ju3LkT27Ztw/r1692VHXNpeFU3aNCgC+PxVuzjNKS/jk9fKnGSJwVrQQ1vZ8XkYN7vjsMvzPPnfc6efz5nD46l3povv2QJLMD559hrw1yLJ5/0l1lKjubs7hxm2rhxo6uQYfvm/dyYVNq1a1fXO2ltUkkG4tymb73FoA6YM8cfkuIk96GKqOzzMkneitgWx2DGv+WUfbwjt/W7cmfFWwaEu22AVUwI5iNoWPnER9Cwd8raLSDCqVevnnsEDYeWWAiUT4qBAndcs1t6ISIiIoGioEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJiQpTneV6uPhgVhSJFiqBVq1YIii1btqBBgwYIiqCt76pVq5Camqp2bVzQ1jeI7Tpo2zio7frs2bNXN6iJi4vDoUOHEBTt2rXDsmXLEBRBW9/4+HgcPnxY7dq4oK1vENt10LZxUNv1oVy0Zw0/iYiIiAkKakRERMQEBTUiIiJigoIaERERMUFBjYiIiJigoEZERERMUFAjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExIaKDmsWLgVatgNhYoEgRoHJloFs34OBBmOJ5HhYtWoTmzZujfPnyKFasGKpXr47+/fvjhx9+gDWpqcCzzwJNmgC33upv23LlgMREYNo0ICMD5kyfDkRFXf5x330wb+zYsYiKinKPzZs3w5LZs2e7fbZevXqIiYlx6zidG96w8+fPY+LEiahbt647bpUsWRJNmjTBsmXLYFWlSpUutOHsj2bNmsGaw4eB8eOB1q2BihWBwoX943WnTsAXXyDiRCMCeR4wYAAweTJQtSrQtStwww3AkSPAZ58B+/cDFSrAjCFDhiA5OdkFNB06dHAHhq+//hrvv/8+5s6di40bN+Kuu+6CFadPA5MmAQ0aAA89BJQpA5w4AaxYAfTuDcyb578uENEh95WpUwcYMSL8ewsWADt2APffD9O2b9+OESNGoHjx4vjll19gzbBhw7B//36ULl3a7ct8bRkvxh599FEsXLgQVatWRZ8+fZCWloalS5eiffv2mDBhAp566ilYVKpUKTzzzDNhAx5rJkzgxYh/LmZgw+P1nj3AkiX+Y84coEsXRA4vl/jRuLg4Ly+MH8+/53mDBnneuXM538/IyJOv4T388MPX/G/8+OOPXoECBbyEhATv5MmTF72XnJzsfvdevXp5VtaXMjM9Ly0t/HZt1szf9suXX/vvwfacl+06HP4OsbGeFx3teUePeqa2c1bp6ele3bp1vYYNG3pJSUnud9+0aZOp9V21apW3b98+93r06NFuHadNm+bltbxq1/Pnz3d/JzEx0Ttz5syF5ceOHXPHs5iYGG/v3r2etTbNdePjesurdV640PPWrcu5PCXF8woV8rybbvK81NRr/z1y254j7lr47Flg5EigShXg7beBggVzfiY6IvuX/ph9+/a5LtzExEQX/WfVtm1b93zs2DFYwh4YdmGG266PPOK//u47BAKvdI4f57YGbrkFZr322mvYsWMHpk6dioLhdmoDWrZsiYSEBAQFe2To5ZdfRtGiRS8sZ0/V4MGDXa/NNI4nS77WsSPQtGnO5Y0bA82b+73s33yDiBFx4cHKlf6P1KsXkJkJcGh2927gxht50ABuuw2m3H777ShcuDA2bNiAU6dOuaGnkOXLl7vn+4KQbOHG54FPP/VfGxptu6wpU/znvn1h1ldffeWCmlGjRuGOO+643l9HrpKjR4+658pMdswmtGzt2rUYyatUYxiwMV/qyJEj7phdv359NGzYEEFTqFDkdTRE0Ffxbd3qP/NirnZtP6DJeoU/eDAwbhzMiI2NxZgxY/Dcc8+hRo0abiw6lFPDA8KgQYPMjkunpwOvv+7nULG3Ys0aYNcuP6ANQhzHlAuuc3w88MADMIkH/8ceewx16tTBCy+8cL2/jlxF7JGhvXv3ombNmhe9x2W0O+sB3FhA14sHqiwY2DAHkvlFQXDgALB6NVC+PFCrFiJGxAU1P/3kPycnA3XrAlu2ANxftm0DnngCePNNP2Fp4ECYwa7auLg49O3bF++9996F5Y0aNUL37t0RHUlh8FUOarJexLECaMgQYPRoBAJ75tk71bNn+GFWC4YPH449e/Zg69atZoedgurBBx/EvHnz3EVZixYtUIRljOAFynGMZ7kMgJMnT8IaBjONGzd2xRslSpRwgRsLPWbNmuV61b/55hvcwMoWwzIygB49eNHiJxFH0q4dcTk1PMgTcy6Yb1C/PlCihD9+N3++31vDwMYSdssnJSW5semDBw/i559/xvr165GamupKBK2WR3K7speGw4ws03/nHX84hlWRp07BNLZzBjUM5FjxZdGmTZswbtw4VxVkqXpPfLzg4jQUPFbVqlULTz/9NAYMGIA777zzwjB6AUsljL9iBR+DuLJly7oydvZCzpw5Ez169HAVb6xatez8rxdiKSlAv35+cBNJIq7FhXJl69Xz5zDJisdFJhB//z2vAGDC6tWr3U7CIaaXXnoJ8fHxLvpnL83HH3+MQoUKuaEpy3jc4xAMe99Yxr9hAxNLYRq7bdl926KFP/+SNefOncPjjz+O2rVru3Yt9rAHecWKFXjllVdc8DJ58mQ33xaH0BdwngLAnfiDgnMUEfMjLQc0vXv7ZdxJSUCWgYWIEXHjGtWr+89MDA4ntJxVUpf6TH7CgwLxiie7cuXKuTybbdu24fTp0y7YsY7zINC6dTDNeoIw2yuHnYiJ8OHcc8897nnx4sVufibJfzjJIC/K+Mhq3a87MCciDFqOkcU5mEIBDdOIZs70J8HlvJKR2BEXcUFN6Ny+c2f4cTyW+hYv7k8AZEE6E0suU7bN5bwKYo9NEHCCRbK8ukyKZjXszTf/VsJu8WTHydjCSUlJcQFPu3btUKZMGZMTlgXdhx9+6J67cubUgPji1+l1Lbbn81kCGk60N2tWZOXRRHRQE5q1kKXdvJrNeiU7Zow/7MRuLyu5s5yfhtOMM9GsU6dOF81Vw6ThQ4cOuc/wJGHFt99yxweKFbt4+Zkz/u0TqE0bmMUDAmNZtmNDm/UinLdkSqg7KpuePXu6oGbo0KG4++678/y7ydWTfRoK4tAT5yNiNVBHTnJiyK5du1CxYkWXS5N9+Ysvvngh18jikNPMmUDnzrwdSOQGNBSRocG77wL33usnITFZuEYNv/pp7VqAc1u98QbM6Ny5MyZNmuSuXqtVq+auXm+88UY3twdLunlyYMBjyUcf+dVtjRr5wQ2Piby/CEfi2IvBpHCW7lv1wQe2h56CikHc559/7l6zAia0LDQUwzw5VjhawrlZKlSo4Eq6Wf20ZcsWt75VqlTB/PnzzVW8sdqLx2Pe34oTLfKWH6x++uSTT5CRkeECdb5nyahRwIwZfmFHtWrAq6/m/AxHj3krmEgQkUENe2u+/JLloP5kbOy14Q20nnzSX2Yp94w7/cqVK/HWW2/ho48+wpw5c9yQ1C233HKhIir7HBD5HWfP5TDTxo2skPHvBcUOKs5LxN5qXhVY6YnLjlMUbN/u3/cqkuZ2kD+PAc0MHv2zYNJo1sRRa0FNly5dXHIwb07Kkzon3WO12/PPP5+jB8cC5j7u3LnT5Tmy6uvMmTMul6ZNmzZuTrHWoaRAQ/bt8595nL5UAQcvTiMlqInivRJy9cGoKDeXCodDgoK9JlbLqcMJ2vqy0uzw4cNq18YFbX2D2K6Dto2D2q4P5aI9R2DusoiIiMiVU1AjIiIiJiioERERERMU1IiIiIgJCmpERETEBAU1IiIiYoKCGhERETFBQY2IiIiYoKBGRERETFBQIyIiIiYoqBERERETFNSIiIiICQpqRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERMQEBTUiIiJigoIaERERMSHK8zwvVx+MikKBAgVQvnx5BMXx48cRGxuLoAja+v744484f/682rVxQVvfILbroG3joLbrzMzM3/1cdG7/wVzGPiIiIiLXhYafRERExAQFNSIiImKCghoRERExQUGNiIiImKCgRkRERExQUCMiIiImKKgRERERExTUiIiIiAkKakRERAQW/H/DTTVKfarwcwAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 600x600 with 1 Axes>"
       ]
@@ -1284,10 +1290,10 @@
    "metadata": {
     "id": "26ceb5e6",
     "papermill": {
-     "duration": 0.005098,
-     "end_time": "2026-04-25T14:45:53.985061",
+     "duration": 0.005852,
+     "end_time": "2026-05-14T07:29:35.369898+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:53.979963",
+     "start_time": "2026-05-14T07:29:35.364046+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1322,10 +1328,10 @@
    "metadata": {
     "id": "10e891bf",
     "papermill": {
-     "duration": 0.004846,
-     "end_time": "2026-04-25T14:45:53.994978",
+     "duration": 0.008088,
+     "end_time": "2026-05-14T07:29:35.384186+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:53.990132",
+     "start_time": "2026-05-14T07:29:35.376098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1353,10 +1359,10 @@
    "metadata": {
     "id": "r0g3bnhfwk7",
     "papermill": {
-     "duration": 0.004717,
-     "end_time": "2026-04-25T14:45:54.004321",
+     "duration": 0.006835,
+     "end_time": "2026-05-14T07:29:35.397210+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:53.999604",
+     "start_time": "2026-05-14T07:29:35.390375+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1384,35 +1390,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "id": "lni75htlvgp",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:54.016327Z",
-     "iopub.status.busy": "2026-04-25T14:45:54.015800Z",
-     "iopub.status.idle": "2026-04-25T14:45:54.029422Z",
-     "shell.execute_reply": "2026-04-25T14:45:54.028370Z"
+     "iopub.execute_input": "2026-05-14T07:29:35.410707Z",
+     "iopub.status.busy": "2026-05-14T07:29:35.410394Z",
+     "iopub.status.idle": "2026-05-14T07:29:35.419933Z",
+     "shell.execute_reply": "2026-05-14T07:29:35.418689Z"
     },
     "id": "lni75htlvgp",
     "outputId": "4c453b95-68c7-4863-ae78-5e0018d226c3",
     "papermill": {
-     "duration": 0.021233,
-     "end_time": "2026-04-25T14:45:54.030506",
+     "duration": 0.017637,
+     "end_time": "2026-05-14T07:29:35.420861+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:54.009273",
+     "start_time": "2026-05-14T07:29:35.403224+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Nombre de solutions: 1\n"
+      "Nombre de solutions: 0\n"
      ]
     }
    ],
@@ -1453,7 +1459,7 @@
     "                    best = (r, c, possible)\n",
     "                    best_count = len(possible)\n",
     "                    if best_count == 0:\n",
-    "                        return best  # Échec immédiat\n",
+    "                        return best  # Echec immediat\n",
     "\n",
     "    return best\n",
     "\n",
@@ -1467,32 +1473,16 @@
     "    Returns:\n",
     "        Nombre de solutions trouvees (plafonne a max_solutions)\n",
     "    \"\"\"\n",
-    "    # Etape 1 : Copier la grille pour ne pas modifier l'original\n",
-    "    my_grid = grid.clone()\n",
+    "    # TODO etudiant : adaptez le backtracking pour compter toutes les solutions\n",
+    "    # au lieu de s'arreter a la premiere.\n",
+    "    # Indications :\n",
+    "    #   1. Copiez la grille avec grid.clone()\n",
+    "    #   2. Ecrivez une fonction recursive qui explore toutes les branches\n",
+    "    #   3. Quand la grille est complete, retournez 1 (une solution trouvee)\n",
+    "    #   4. Si nb_solutions >= max_solutions, arretez prematurely\n",
+    "    #   5. Apres chaque essai, remettez la case a 0 (backtrack)\n",
+    "    return 0  # TODO etudiant : remplacer par l'implementation\n",
     "\n",
-    "    # Etape 2 : Adapter le backtracking pour compter toutes les solutions\n",
-    "    def count_solutions_rec(grid: SudokuGrid) -> int:\n",
-    "        result = find_mrv_empty(grid)\n",
-    "        if result is None:\n",
-    "            return 1  # Grille complète\n",
-    "\n",
-    "        row, col, possible = result\n",
-    "\n",
-    "        if len(possible) == 0:\n",
-    "            return 0  # Impasse\n",
-    "\n",
-    "        nb_sol = 0\n",
-    "        for num in possible:\n",
-    "            grid.cells[row][col] = num\n",
-    "            nb_sol += count_solutions_rec(grid)\n",
-    "            # Etape 3 : Arreter apres max_solutions trouvees\n",
-    "            if nb_sol >= max_solutions:\n",
-    "                return max_solutions\n",
-    "            grid.cells[row][col] = 0\n",
-    "\n",
-    "        return nb_sol\n",
-    "\n",
-    "    return count_solutions_rec(my_grid)\n",
     "\n",
     "# Test : un bon puzzle devrait avoir exactement 1 solution\n",
     "grid_to_count = SudokuGrid.from_string(easy_puzzles[0])\n",
@@ -1502,35 +1492,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "Gb46apf58toW",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:54.041555Z",
-     "iopub.status.busy": "2026-04-25T14:45:54.041156Z",
-     "iopub.status.idle": "2026-04-25T14:45:54.054941Z",
-     "shell.execute_reply": "2026-04-25T14:45:54.053446Z"
+     "iopub.execute_input": "2026-05-14T07:29:35.438767Z",
+     "iopub.status.busy": "2026-05-14T07:29:35.438478Z",
+     "iopub.status.idle": "2026-05-14T07:29:35.443947Z",
+     "shell.execute_reply": "2026-05-14T07:29:35.442565Z"
     },
     "id": "Gb46apf58toW",
     "outputId": "40609cc5-1410-4ba0-e573-ce7c1e97dc78",
     "papermill": {
-     "duration": 0.021739,
-     "end_time": "2026-04-25T14:45:54.056821",
+     "duration": 0.015641,
+     "end_time": "2026-05-14T07:29:35.444840+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:54.035082",
+     "start_time": "2026-05-14T07:29:35.429199+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
-      "Nombre de solutions: 2\n"
+      "Nombre de solutions: 0\n"
      ]
     }
    ],
@@ -1558,10 +1548,10 @@
    "id": "65a70ce6",
    "metadata": {
     "papermill": {
-     "duration": 0.005512,
-     "end_time": "2026-04-25T14:45:54.069775",
+     "duration": 0.005815,
+     "end_time": "2026-05-14T07:29:35.457551+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:54.064263",
+     "start_time": "2026-05-14T07:29:35.451736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1590,16 +1580,16 @@
    "id": "767b48fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:45:54.086820Z",
-     "iopub.status.busy": "2026-04-25T14:45:54.086006Z",
-     "iopub.status.idle": "2026-04-25T14:45:54.093444Z",
-     "shell.execute_reply": "2026-04-25T14:45:54.092440Z"
+     "iopub.execute_input": "2026-05-14T07:29:35.469886Z",
+     "iopub.status.busy": "2026-05-14T07:29:35.469656Z",
+     "iopub.status.idle": "2026-05-14T07:29:35.475195Z",
+     "shell.execute_reply": "2026-05-14T07:29:35.474342Z"
     },
     "papermill": {
-     "duration": 0.017617,
-     "end_time": "2026-04-25T14:45:54.095215",
+     "duration": 0.01303,
+     "end_time": "2026-05-14T07:29:35.475955+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:45:54.077598",
+     "start_time": "2026-05-14T07:29:35.462925+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1665,18 +1655,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 18.328818,
-   "end_time": "2026-04-25T14:45:54.443612",
+   "duration": 33.736898,
+   "end_time": "2026-05-14T07:29:35.933998+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-1-Backtracking-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T14:45:36.114794",
+   "start_time": "2026-05-14T07:29:02.197100+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.004197,
-     "end_time": "2026-04-25T14:59:04.688061",
+     "duration": 0.020103,
+     "end_time": "2026-05-14T07:40:11.420365+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:04.683864",
+     "start_time": "2026-05-14T07:40:11.400262+00:00",
      "status": "completed"
     },
     "tags": []
@@ -64,16 +64,16 @@
      "start_time": "2026-04-20T09:34:18.321108131Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:04.696778Z",
-     "iopub.status.busy": "2026-04-25T14:59:04.696280Z",
-     "iopub.status.idle": "2026-04-25T14:59:05.369493Z",
-     "shell.execute_reply": "2026-04-25T14:59:05.368683Z"
+     "iopub.execute_input": "2026-05-14T07:40:11.438346Z",
+     "iopub.status.busy": "2026-05-14T07:40:11.438023Z",
+     "iopub.status.idle": "2026-05-14T07:40:12.123546Z",
+     "shell.execute_reply": "2026-05-14T07:40:12.122629Z"
     },
     "papermill": {
-     "duration": 0.678747,
-     "end_time": "2026-04-25T14:59:05.370701",
+     "duration": 0.693658,
+     "end_time": "2026-05-14T07:40:12.124708+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:04.691954",
+     "start_time": "2026-05-14T07:40:11.431050+00:00",
      "status": "completed"
     },
     "tags": []
@@ -83,7 +83,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PyGAD version: 3.5.0\n"
+      "PyGAD version: 3.6.0\n"
      ]
     }
    ],
@@ -107,10 +107,10 @@
    "id": "3cd6ebc1e3966ffe",
    "metadata": {
     "papermill": {
-     "duration": 0.003727,
-     "end_time": "2026-04-25T14:59:05.378138",
+     "duration": 0.01848,
+     "end_time": "2026-05-14T07:40:12.153892+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.374411",
+     "start_time": "2026-05-14T07:40:12.135412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -129,16 +129,16 @@
      "start_time": "2026-04-20T09:34:18.417775845Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:05.386554Z",
-     "iopub.status.busy": "2026-04-25T14:59:05.386033Z",
-     "iopub.status.idle": "2026-04-25T14:59:05.391433Z",
-     "shell.execute_reply": "2026-04-25T14:59:05.390671Z"
+     "iopub.execute_input": "2026-05-14T07:40:12.173131Z",
+     "iopub.status.busy": "2026-05-14T07:40:12.172839Z",
+     "iopub.status.idle": "2026-05-14T07:40:12.178520Z",
+     "shell.execute_reply": "2026-05-14T07:40:12.177700Z"
     },
     "papermill": {
-     "duration": 0.010992,
-     "end_time": "2026-04-25T14:59:05.392607",
+     "duration": 0.019878,
+     "end_time": "2026-05-14T07:40:12.181172+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.381615",
+     "start_time": "2026-05-14T07:40:12.161294+00:00",
      "status": "completed"
     },
     "tags": []
@@ -174,10 +174,10 @@
    "id": "cell-2",
    "metadata": {
     "papermill": {
-     "duration": 0.003736,
-     "end_time": "2026-04-25T14:59:05.399880",
+     "duration": 0.009157,
+     "end_time": "2026-05-14T07:40:12.198467+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.396144",
+     "start_time": "2026-05-14T07:40:12.189310+00:00",
      "status": "completed"
     },
     "tags": []
@@ -196,16 +196,16 @@
      "start_time": "2026-04-20T09:34:18.565835782Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:05.408320Z",
-     "iopub.status.busy": "2026-04-25T14:59:05.407844Z",
-     "iopub.status.idle": "2026-04-25T14:59:05.421293Z",
-     "shell.execute_reply": "2026-04-25T14:59:05.420353Z"
+     "iopub.execute_input": "2026-05-14T07:40:12.217650Z",
+     "iopub.status.busy": "2026-05-14T07:40:12.217451Z",
+     "iopub.status.idle": "2026-05-14T07:40:12.228374Z",
+     "shell.execute_reply": "2026-05-14T07:40:12.227744Z"
     },
     "papermill": {
-     "duration": 0.019283,
-     "end_time": "2026-04-25T14:59:05.422592",
+     "duration": 0.022836,
+     "end_time": "2026-05-14T07:40:12.230459+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.403309",
+     "start_time": "2026-05-14T07:40:12.207623+00:00",
      "status": "completed"
     },
     "tags": []
@@ -332,10 +332,10 @@
    "id": "5dab677e",
    "metadata": {
     "papermill": {
-     "duration": 0.003625,
-     "end_time": "2026-04-25T14:59:05.439686",
+     "duration": 0.007415,
+     "end_time": "2026-05-14T07:40:12.246467+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.436061",
+     "start_time": "2026-05-14T07:40:12.239052+00:00",
      "status": "completed"
     },
     "tags": []
@@ -371,10 +371,10 @@
    "id": "cell-4",
    "metadata": {
     "papermill": {
-     "duration": 0.003893,
-     "end_time": "2026-04-25T14:59:05.447545",
+     "duration": 0.007186,
+     "end_time": "2026-05-14T07:40:12.262371+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.443652",
+     "start_time": "2026-05-14T07:40:12.255185+00:00",
      "status": "completed"
     },
     "tags": []
@@ -396,16 +396,16 @@
      "start_time": "2026-04-20T09:34:18.602903996Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:05.456824Z",
-     "iopub.status.busy": "2026-04-25T14:59:05.456372Z",
-     "iopub.status.idle": "2026-04-25T14:59:14.962852Z",
-     "shell.execute_reply": "2026-04-25T14:59:14.961495Z"
+     "iopub.execute_input": "2026-05-14T07:40:12.287008Z",
+     "iopub.status.busy": "2026-05-14T07:40:12.286652Z",
+     "iopub.status.idle": "2026-05-14T07:40:42.866540Z",
+     "shell.execute_reply": "2026-05-14T07:40:42.864923Z"
     },
     "papermill": {
-     "duration": 9.512985,
-     "end_time": "2026-04-25T14:59:14.964458",
+     "duration": 30.598657,
+     "end_time": "2026-05-14T07:40:42.873864+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:05.451473",
+     "start_time": "2026-05-14T07:40:12.275207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -436,22 +436,22 @@
      "text": [
       "\n",
       "Resolu: False\n",
-      "Erreurs finales: 19\n",
-      "Temps: 9.49s\n",
+      "Erreurs finales: 23\n",
+      "Temps: 30.56s\n",
       "Generations: 200\n",
       "\n",
       "Resultat:\n",
-      "9 6 2 | 1 9 5 | 4 7 3 \n",
-      "1 4 4 | 7 6 3 | 8 2 5 \n",
-      "5 3 8 | 4 2 7 | 1 6 9 \n",
+      "9 6 2 | 9 2 5 | 4 4 3 \n",
+      "1 1 9 | 7 6 3 | 8 2 5 \n",
+      "5 3 8 | 4 8 7 | 1 6 9 \n",
       "---------------------\n",
-      "8 2 6 | 3 5 9 | 7 4 1 \n",
-      "3 5 7 | 8 1 8 | 2 9 8 \n",
-      "4 9 1 | 6 7 2 | 5 3 6 \n",
+      "4 2 6 | 3 5 9 | 8 4 1 \n",
+      "3 5 7 | 1 1 4 | 2 9 6 \n",
+      "8 9 4 | 6 7 2 | 5 3 7 \n",
       "---------------------\n",
-      "2 4 9 | 5 3 7 | 6 1 4 \n",
-      "7 1 5 | 2 8 9 | 3 8 4 \n",
-      "6 8 7 | 6 4 1 | 9 5 2 \n"
+      "2 4 3 | 5 3 8 | 6 7 8 \n",
+      "7 8 5 | 2 9 6 | 3 1 4 \n",
+      "6 8 3 | 7 4 1 | 9 5 2 \n"
      ]
     }
    ],
@@ -547,10 +547,10 @@
    "id": "p6g1yllwce",
    "metadata": {
     "papermill": {
-     "duration": 0.004523,
-     "end_time": "2026-04-25T14:59:14.973635",
+     "duration": 0.007879,
+     "end_time": "2026-05-14T07:40:42.892878+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:14.969112",
+     "start_time": "2026-05-14T07:40:42.884999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -580,10 +580,10 @@
    "id": "cell-6",
    "metadata": {
     "papermill": {
-     "duration": 0.004758,
-     "end_time": "2026-04-25T14:59:14.983032",
+     "duration": 0.00947,
+     "end_time": "2026-05-14T07:40:42.913752+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:14.978274",
+     "start_time": "2026-05-14T07:40:42.904282+00:00",
      "status": "completed"
     },
     "tags": []
@@ -605,16 +605,16 @@
      "start_time": "2026-04-20T09:34:22.821227230Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:14.993157Z",
-     "iopub.status.busy": "2026-04-25T14:59:14.992746Z",
-     "iopub.status.idle": "2026-04-25T14:59:17.086366Z",
-     "shell.execute_reply": "2026-04-25T14:59:17.085306Z"
+     "iopub.execute_input": "2026-05-14T07:40:42.931907Z",
+     "iopub.status.busy": "2026-05-14T07:40:42.931337Z",
+     "iopub.status.idle": "2026-05-14T07:40:45.884984Z",
+     "shell.execute_reply": "2026-05-14T07:40:45.883454Z"
     },
     "papermill": {
-     "duration": 2.100221,
-     "end_time": "2026-04-25T14:59:17.087601",
+     "duration": 2.965325,
+     "end_time": "2026-05-14T07:40:45.886413+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:14.987380",
+     "start_time": "2026-05-14T07:40:42.921088+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,8 +657,8 @@
       "\n",
       "Resolu: True\n",
       "Erreurs finales: 0\n",
-      "Temps: 2.08s\n",
-      "Generations: 38\n",
+      "Temps: 2.92s\n",
+      "Generations: 22\n",
       "\n",
       "Resultat:\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
@@ -818,10 +818,10 @@
    "id": "t0p26rqwsh",
    "metadata": {
     "papermill": {
-     "duration": 0.004148,
-     "end_time": "2026-04-25T14:59:17.095987",
+     "duration": 0.006205,
+     "end_time": "2026-05-14T07:40:45.899808+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:17.091839",
+     "start_time": "2026-05-14T07:40:45.893603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -858,10 +858,10 @@
    "id": "cell-8",
    "metadata": {
     "papermill": {
-     "duration": 0.003928,
-     "end_time": "2026-04-25T14:59:17.104040",
+     "duration": 0.006263,
+     "end_time": "2026-05-14T07:40:45.913005+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:17.100112",
+     "start_time": "2026-05-14T07:40:45.906742+00:00",
      "status": "completed"
     },
     "tags": []
@@ -880,16 +880,16 @@
      "start_time": "2026-04-20T09:34:24.126565272Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:17.113699Z",
-     "iopub.status.busy": "2026-04-25T14:59:17.113206Z",
-     "iopub.status.idle": "2026-04-25T14:59:40.179417Z",
-     "shell.execute_reply": "2026-04-25T14:59:40.178215Z"
+     "iopub.execute_input": "2026-05-14T07:40:45.929756Z",
+     "iopub.status.busy": "2026-05-14T07:40:45.929407Z",
+     "iopub.status.idle": "2026-05-14T07:41:51.634536Z",
+     "shell.execute_reply": "2026-05-14T07:41:51.633033Z"
     },
     "papermill": {
-     "duration": 23.072622,
-     "end_time": "2026-04-25T14:59:40.180750",
+     "duration": 65.715969,
+     "end_time": "2026-05-14T07:41:51.635713+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:17.108128",
+     "start_time": "2026-05-14T07:40:45.919744+00:00",
      "status": "completed"
     },
     "tags": []
@@ -908,7 +908,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Resolu: False, Erreurs: 16, Temps: 21.11s\n",
+      "Resolu: False, Erreurs: 20, Temps: 59.77s\n",
       "\n",
       "--- Approche Permutations ---\n",
       "Ligne 0: 24 permutations valides\n",
@@ -926,12 +926,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Resolu: True, Erreurs: 0, Temps: 1.71s\n"
+      "Resolu: True, Erreurs: 0, Temps: 5.24s\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaWJJREFUeJzt3Qd8VFX2wPEzoQQSkgAhNClSBFSaoIsUAQFBQATBjisiggVdBSt2bGBZsaPrumAHRVCxoIIUQVBAEdEVBUVEgSBIQoDQ8v6fc2cn/0wySSaZ8t7M+30/nzFkZvLm3jsT38l5957rsSzLEgAAAAAAACCKEqL5YgAAAAAAAIAiKQUAAAAAAICoIykFAAAAAACAqCMpBQAAAAAAgKgjKQUAAAAAAICoIykFAAAAAACAqCMpBQAAAAAAgKgjKQUAAAAAAICoIykFAAAAAACAqCMpBcSYSy65RI4++mi/+zwej9x9993lOp4eS48Zbb/99ptUqVJFli1b5nf/yy+/LK1atZJKlSpJ9erVzX09e/Y0t0jS8dNxhLOcfPLJctNNN9ndDAAAwm7Tpk0m9pg+fbo4VU5OjtSuXVteffVVv/vnzZsn7du3N7Gc9mH37t0BY9Rw07HS19OxQ2Tpe1ytWjXZsWOH3U1BnCMpBUTYxo0b5fLLL5emTZuaE3dqaqp07dpVHn/8cdm/f7+41T333COdOnUyY+Hzww8/mICmWbNm8vzzz8u//vUviRUff/yxjBo1Slq3bi0VKlQoNSjTz8WFF15oAr2qVavKMcccI7fddlvU2hsrbr75Znn66adl27ZtdjcFABBkwsB307inRYsWcvXVV8v27dslFn3//ffmwlUoSZDXXntNHnvsMYlFGq+mpKTI+eefn3/fzp075dxzzzXxi56j9YJicnKyxIr//ve/cvrpp5uES82aNeXvf/87iZcAdIyaN28ukyZNsrspiHMV7W4AEM/ef/99OeeccyQxMVEuvvhik7A4ePCgLF26VG688Ub57rvvYirxEi564n/xxRfNraBFixZJXl6eCYD0JFgw4eN0GnDOnDlTOnToIPXr1y/xuWvWrDEzv4466ii5/vrrJT09XTZv3mxmj8Hf4MGDTSL3mWeeMYlMAIDz6f+vmzRpIrm5uSbmmTp1qnzwwQeybt06SUpKklhLSk2cONGct8s7C0hjBO37dddd53d/48aNzQVKnR3uRIcOHTIx2bhx48wFN5+VK1fKnj175N5775U+ffrk368XFDWOc7ItW7ZI9+7dJS0tTR544AEzE+yRRx6Rb7/9Vr788kupXLmy3U10FL2wfsMNN5jfAU1OApFAUgqIkF9++cVcVdKA49NPP5V69erlPzZ27FjZsGGDSVq50SuvvCIVK1aUQYMG+d2fmZlpvvqW7fnEQoCggY0GYxpYnnHGGSb4DESDNb0ip0sUFy5caK4yRsvevXuLvZK5b9++qP2hUFI7CktISJCzzz5bXnrpJRMQscQSAJyvf//+cuKJJ5p/X3bZZebiy6OPPirvvPOOXHDBBSEdO5rnq0jzzSZzqvfee89cSNRZUcHEa05NrhWO1zQOWb16tTRq1Mjc97e//U1OO+00M9NvzJgxEXldy7JMkjZQ3Kf3a6yrMU+kaRyqF8iD/dwNGzZMrrnmGnnzzTfl0ksvjXj74E4s3wMi5KGHHjJXX1544QW/hJSPzgS69tpriyRrOnbsaE5YOp1Yk1rlmT1T3Jr+YOsmaV0AvZrXsGFDM8tL2/rggw8Wufo1Y8YM0169cqKzWdq0aWOuqJXm7bffNkv3dNq0j7b3rrvuMv/OyMjwq5NVuKaUzqjSx9944w25//77pUGDBubk2rt3b5PsK+izzz4zs9U08NC+aJ/0il8wSyf//PNPs6RQA+DS6OyoYIIxnfWlCSvtq77PeuwjR45IWWibNFGjnxHttwb+7777bsAlFIsXL5arrrrKLBPUcVI6ljprTwMyvVqowf2tt95qHjtw4IBpm77nvvHSmk56fzA1MArXN/N95vRKsy5XrFGjhnTr1s08pkvyRo4cadqlr6W/JzozqvASCQ0Uf/31VzPDDAAQe3r16pV/wa4sMU9x5yvfeUhnuOjyMS2RoI/17dvXHEMTADqLR88venw9t+zatSuoepwFa23qeU5jCHXqqafmL0vUOERpkm3gwIEmBtDzmJYf0NcteF7XPuhFSD2P+X7eF6MVdz7Vi5mnnHKKuYCjiR9tvy45K8h3ftW4R9urz9PZP3peLRy3fPLJJ+bcq8/R2Ktly5b55/3S4jVtq/arYH9GjBhh/n3SSSeZNvjGq3D8WfB90pUBehwdJ/05nW1V0Nq1a83P+8pd1K1b1yRBdKlgabKyskxspF9L89Zbb5mLh76ElNLZXrrMVOPK0mgsrEsxjz/+eNPOOnXqmNlEf/31l9/zdBz0dT766CMTp+nn8LnnnsuPYTWGvv32282sef3sZmdnm5/74osvzLI5fS/1/h49ehSpv1qWOF+/1+WzWhNM26zjr7Wigo3jNX5s27at+awDkcJMKSBC5s6da06sXbp0Cer5mly54447zNUovaqoV6aefPJJE4R9/fXXRa5GRYoGMnoC/P33381JVk/an3/+uUyYMEG2bt2aXxNBAxy92qmJIE1YKQ2Y9MRZONlWeCq4BiJXXnml3/16XJ0NM2fOHDPNX4MmPQmWZPLkyeaqkk4r1kBEE4HDhw83J3QfvbKjfdLX0yu1OjVbx1Wnb+tjJXnqqafM7Byd0RSuQuvz5883XzUo0CBFA229OnbWWWeZJWoamJdEl3xqHS4NYm655RYTsGoQNWTIEBNo6XEK0oSUJvnuvPNOc2XQR4M8vZKtfwRcdNFFJqjSQOvMM880Sy30SuGxxx5rprNPmTJFfvzxRxOclpcG9Vo3S69Q6h8Lvqtv2h+9AqfBlV551c+VLmUsGGxpwKT0s3XCCSeUuw0AAHtoHUWl5+GyxjyBzlc++oe2zvrQ84gmnTQO0GNqEkz/+Ne6hJq00WNrrPCf//ynTO3W9vzjH/+QJ554wiRx9LyofF81maTxyvjx481XTSbp+VYTDA8//LB5jtaL1BhF4w49n6qCF+UCxQnaX40hNcmgF9G0/Xru/+qrr4okI7S/ulRS6/7o4//+979NIsEXm+l5VpMjGlPpskqNP3RMCic6AtH4T8sSFKT90aSWJpl8yzQLJq2KW76oy/00rtQkib5PQ4cOlZ9//jn/gp6e//V7TappQspX4kK/rlixosSLqho76s9NmzatxM17NLbVWMM3i68gnS2lS0xLo33Q911fTz8bmmjVeFE/tzqmBS9Qrl+/3sTK+jOjR4824+ajyUuN//RzqRf+9N/6+dH3XuMevUCoMa72ST/PepFV21geelyNFTU5VatWLfMZKkscr+0JJQYESmUBCLusrCz9q9saPHhwUM/ftGmTVaFCBev+++/3u//bb7+1Klas6Hf/iBEjrMaNG/s9T1/rrrvuKvE5Sp9T+Nden6fP97n33nut5ORk68cff/R73i233GLauHnzZvP9tddea6WmplqHDx+2ymLDhg2mDU8++WSx7duxY4ff/T169DA3n4ULF5rnHXvssdaBAwfy73/88cfN/TpuPvv27SvyOpMmTbI8Ho/166+/FnntQO3R1yuLgQMHBhx/deaZZ5pjpqenW8OHD7dmzZpl3XHHHeZ97tKli5WXl1fisXv37m21adPGys3Nzb9Pf0Z/9phjjsm/b9q0aeZ1unXrVuQ90rHUx5599lm/+19++WUrISHB+uyzz/zu1+fp85ctW2a+/+WXX8z3+hqFFf4s+sbwggsu8HveX3/9Ze5/+OGHrWBUrlzZuvLKK4N6LgDAHr5zz/z58825/LfffrNmzJhhznlVq1a1tmzZUqaYp7jzle88lJGRYe3evTv//gkTJpj727VrZx06dCj/fj0H6Xmk4Lmz8PmquLjozTffLDYWCBRjXH755VZSUpLfaxUXFwQ6n7Zv396qXbu2tXPnzvz7vvnmG3N+vvjii4ucXy+99FK/Y5511llmvH2mTJkSMLYqjY6fxkrXX399se/zypUr/e4vHH/6+qft2bVrV/7977zzjrl/7ty5JY7l66+/bp63ZMmSIq+txy58X6C4pCBtrz7vpZdeKvLYjTfeaB4r+L4VpvGRPufVV1/1u3/evHlF7tdx0Pv0sYJ8MWzTpk39+qyxnMZx/fr184sF9TlNmjSxTjvttHLF+fq9fna+++47v/vLEsc/8MAD5jjbt28v9blAebB8D4gA3xTcYAsCzp4928xS0atdumTMd9MrRTq7RGfqRIvOHtIp47rMqmBbdGqzTkdfsmSJeZ5exdSZN3qlpSx807D1+KHSq1QF601pu5VeafMpuHZf26t90dlrep7Wq1ol0SuU+rxwzZJSuqRT6dR1Xbqgs4X0SqNeMdMrkgsWLCj2Z/UqsF7t0s+JXnH0vTc6pv369ZOffvrJXAUsSK/MFSxO6qNXSnX8Cr/3evVX610VfO99yy5C+RxeccUVft/r+6LvnV7JLjzlPRDf5xEA4HwaM+gsXV0CrjOcdGaQzmbRWb5ljXkCna8KzsLVZU4+WhpA6YwqrV1Z8H6dUVX4HBmqgjGG77yssYjO0NblZGWlM9J1qbrO9ik4c1pnOelS9kAzeQqfX/X1NS7wxaK+WWe6/KosRcg15tAYKBzx2nnnned3nNLiNa2xpGN58sknm+91BlhJdLy0rSXNklK+0g36mSrMV2OppPIOGifp503fi4KfXZ1JpJ/xwp9dnUWm8VkgugSyYJ/1fdc4Tksd6PvnO7bGrjqbSePv8haR1xUQxx13nN99ZYnjfe8dcRgiheV7QAToumxfgBIMPQnpyVSDsUCiWThS26Lr+jWYDMRX3FKXhelUYJ1mrEGm1nHQAFPXwQfDt4QrFAXrARQ8aRZMcuhSMJ1KrzWXCic/gqk9EG6+AKRwoVcNQnSJpCamCu5kU5BOt9dx0yUPeivu/dH3o2BAFIg+p3ABeX3vdep2ae99eRRuhwaEOl1cdx/UpRgaeOryAt2lUv8wKUz7TZFzAIgNWudJa/RoYkj/H6/LlnxFnMsa8wQ6XxUXB/gSVJoMC3R/MBdBykKXlmldIL1g5EsChRJjaN0pVXCZl49eNNL6RIU3CykpFtJ4VBNCuqRPl0nqsn9NcOjSOa1NGUxh7WjFa5oE05IJWueocLwRrnjNF4MVrJNZMBFW8DmB6GdX26LLIwMp3O7iYrBAj+mxla9eVyD62uVJEgZqR1nieN9ngDgMkUJSCogADQK06GVxO7AVplc+9H/0H374YcBZLSXVHgikuJNGMAW1tS16BUiLWweiQabSE7Je1dEASdutN133rkmFF198sdjj++pJhCMwDDRWBU+e2l/tiwY6WldCZwBpIKdXSvVqmh3bFuvnQhWsiaF8AU5J4+Jrr9YfKO7KmxYoL6i44CrQ/Xp8LXKpOyQF4gvyy/P5CvR6Wkxfd2DUOgX6OdJEm9bE0OC+cO0oLb6vdRAAAM6ntW8C1e0pT8xTUpKguDigtPigJMFuPqLnJZ2BojGfznjWuko620Zn9WjMEa0Yo7S+6vjpLBudxaMF17XI9cyZM80saN18pbif15la+j5FI15TmhDRC3M33nijtG/f3nwOdAw1SRKusfRtPKQz0grT+7TPgWZR+Wg7NF7TWmaBFL6oV9Jnt/Bjvj5qLTLtfyC+342yxmGB2lGWON73GSAOQ6SQlAIiRGd9aIHG5cuXS+fOnUt8rgYyemLWKxm+pE8o9CqKBkvFXYErrS26xKy42ToF6ZVLTSroTU+metVFdxbR5ELh5EjBq2V6ciy4A0+kaJFuLdCtJ1c9yfqUdclhOOkU7+eff77IEoI//vjDfC1ulpLSoqe+q8jBvD9lpe/9N998Y66ilnQ1zHeVrvBnLJjPV6DX1NlSetOrhBqI/fOf/zRLG310rHTZha+wLAAgdoU75glnrKTnmsIJi+LOh7r8XJdZ6XJELYjuEyi+CXaGSePGjfMLZBemywE1KVBwllSwdEaUntv1pheedNMRLViuiari4gmd5abvVTTiNU16aPkCnSmls9sLzx4KF50RpHHWqlWrijymG+EUlwzy0fHQQvRadL6khFN5+IrFa5KztBgvlDi/PHG8fgb0s1dSjAqEgppSQIToTCMNHHS69Pbt2wPuROPbdlWnUetVJD0ZF76Kp98Hsx1u4RObTvHVZXg+GmRpPYfS6JUqTaTplZPC9AR4+PBh8+/CbdKAx7dbXqBp0T6aUNGrp4ECgnDzXZkrOKb678Lb3RZH185rEFh4a+VQ6LbOehVOr0YVvPKnU+uVzuwqjl7V0vpWGjAEusqnuxeFQt97TQBp0qwwrbHg271PAyYNTnz1xXx098Bg6Zj6psoX/NxqHbbCnx/doVAFu5MlAMC5wh3zlJeecwqfx/RiYuHZJr4kUOEkQKAYQ5Nagc6FeoxglqDpTB5NjOjFtIKvpzPvdVbTgAEDpKx0tnhhvuRLSfGa0ouqdsVryrfjc2l0bDVeC2aMtZbne++9J7/99lv+fZoQ04uYWqOstDhJPx9aB7QwjY8DJYrKctFSP5OPPPJIfv3R4mK8UOJ8n7LE8RqHlXaBHQgFM6WACNEThm6Bq2v5dYaHztRp3bq1CVh0erIWS/QVZNTn3nfffaam0KZNm2TIkCHmj3O9MqEnmDFjxpglW8HSoqI6dfyss84y29VqAmDq1KnmimRpxSJ12rTWX9KZXto+PUlqMkJnHc2aNcu0TxMSmmzTQEenfzdo0MBcndEtizXQKW1GiyZm9Aqd1l/w1d+KBF2up2OrY6fJFn2tt956K+ip6LrFrwbNeiWxtGLnGhjouPlqP2mwoO+pateunbkKpbRekvZdrwTqlHR9r3V2kiaCtM6UFkAvrU5Ht27dzDI7LWKus6c06amJRN1uWo9VXn//+99NfQEtmqp91iuBGnxpoKf3a6LStxxD3//Jkyebr3qfBvYa0AVLn6tXbDXA0+KbekVWP+vaF/38FqQz23SGXeElfQCA2BPumKe89Pyl5ztNUugFIT1/6nmu8BIljWs0aaJ1EPXcrheWNPbRCyU6Y0VrAGmspbOhXn755YBLBDWW0iVz48ePN+d5XYbliwsK0+VbWudHkwCjRo0yF4U0vtK6WLoBS1np0kI9Rw8cONDMxNK6R5o409hN44nS4jXtk56zIzmrTeMznW320EMPyaFDh8yMJk3CBTtLSz83WgxfL/iVVuz81ltvNTH4qaeeKtdee61JAOmYa1xVXEF9H12uefnll5tSA7r0Tesw6cVWndGlx9SLnlqrqzw0KaQXKPW9P/74401bdBw0ftWYTMdo7ty5Icf5PsHG8fp50Rh37Nix5eoXEJRy7dkHIGg//vijNXr0aOvoo4822xGnpKRYXbt2tZ588ski286+9dZbVrdu3azk5GRza9WqlTV27Fhr/fr1JW4DG2hb448//thq3bq1ec2WLVtar7zySsCtYgtvfaz27NljtlVu3ry5+flatWpZXbp0sR555BHr4MGD5jmzZs2y+vbta7Yt1uc0atTIbIO8devWUsdEt5TVbZ9ffvllv/t97Su8bbFuCa23wtvp6jbNpW2t/P3331t9+vSxqlWrZvqh74VurVz4eYHGxndfoG2gC/NtRxzoVnh8datfff9btGhhVapUyWrYsKF1++23549taTZu3Gi2ha5bt675+aOOOso644wzzHtS2nbNSsfy+OOPD3hsbcODDz5oHk9MTLRq1KhhdezY0Zo4caKVlZXlt0XxqFGjrLS0NPOZPvfcc63MzMwin8Xi3tM///zTfLb1M66fdT1Op06drDfeeMPveUeOHLHq1atnxgcA4GwlnXsKCybmKe585TvfP/zww373FxcfBGqXnl9uvvlmExskJSVZ/fr1szZs2BAwLnr++eetpk2bWhUqVPCLC5YtW2adfPLJVtWqVa369etbN910k/XRRx8ViR1ycnKsCy+80Kpevbp5zBfHBYpb1Pz5802sqMdNTU21Bg0aZOKZgoo7v/r6qsdWCxYssAYPHmzap/Gafr3gggtMfFqaAwcOmPG59957Sx3PQDFqce+TKhwvbNmyxTrrrLPMGGlMcM4551h//PFHkecV7l/B+wqPY3HWrVtnYlh93/X1hg8fbm3bts0K1r/+9S8TG+n7ozFQmzZtzHuv7fXRcRg4cGCRny3uM+rz9ddfW0OHDrXS09NNHKbH0RhL38fyxPn6vf5eFRZsHD916lQzTtnZ2UGPD1BWHv1PcOkrAAgfvfqnV94+++wzu5sCB9Mi6LozoS539RUoBQAA0aFL1XQGks4GKq5gOeKXzlLX1QJTpkyxuymIYySlANhi8+bNZpqxruPXZWJAILp84ZRTTjFT+gEAQHTp8jYtFaBJieHDh9vdHESR7tSoyxF//vnn/F2igUggKQUAAAAAAICoY/c9AAAAAAAARB1JKQAAAAAAAEQdSSkAAAAAAABEHUkpAAAAAAAARF1FiXN5eXnyxx9/SEpKing8HrubAwAAYozuCbNnzx6pX7++JCS443oe8RMAAIhG/BT3SSkNqBo2bGh3MwAAQIz77bffpEGDBuIGxE8AACAa8VPcJ6X0Cp9vIFJTUyNyJXHHjh2SkZHhmqun4cYYhobxCx1jGDrGMDSMn7PHMDs72yRofDGFG0Q6fnL7556+u7Pvbu+/m/vu9v67ue9u7n92kPFT3CelfFPONaCKVFIqNzfXHNtNH7BwYgxDw/iFjjEMHWMYGsYvNsbQTcvYIh0/uf1zT9/d2Xe399/NfXd7/93cd+X2/ntKiZ/cNyIAAAAAAACwHUkpAAAAAAAARB1JKQAAAAAAAEQdSSkAAAAAAABEHUkpAAAAAAAARB1JKQAAAAAAAEQdSSkAAAAAAABEHUkpAAAAAAAARB1JKQAAAAAAAEQdSSkAAAAAAABEXcXov2ScefVVqbZypXiSk0U8HpFjjxX5+9/tbhUAAIBjbdsm8vjjHtm7t5okJ3tMCBWM1q1FLrww0q0DAADRQlIqRJ7ly6XKBx+IVKggkpUlsm8fSSkAAIASZGeLvPGGyJEjVUwIFYy9e0V27RIZMkQkKSnSLQQAANFAUipE1lNPyZ+ZmVK7dm3xvPKKyIgRIgcOiCQm2t00AAAAR2rRQuSnnyzJzPzTxFAJCaVPlVq3TqRNG5HPPxfp0ycqzQQAABFGTalwql7d+1VnTAEAACBsjj9eJCNDZNEiu1sCAADChaRUOKWleb/u3m13SwAAAOKK1p3q2VNk4UK7WwIAAMKFpFQkZkqRlAIAAAg7TUp9+aW3vhQAAIh9JKXCiaQUAABAxJx6qsjhwyLLltndEgAAEA4kpcKJpBQAAEDEtGolUqcOS/gAAIgXJKXCKSXFW/CApBQAAEDE6kpR7BwAgPhAUiqcEhK8xc5JSgEAAERsCd/KlSJ79tjdEgAAECqSUpFYwkdSCgAAICJ0ptSRI9SVAgAgHpCUikRSKivL7lYAAADEpRYtROrVo64UAADxgKRUuDFTCgAAIOJ1pUhKAQAQ+0hKhRtJKQAAgIjXlVq9WiQ72+6WAACAUJCUCjeSUgAAABFPSuXliXz2md0tAQAAoSApFW4kpQAAACKqWTORo44SWbTI7pYAAIBQkJQKN5JSAAAAEa8rpbOlqCsFAEBsIykVbiSlAAAAIk6LnX/9NWEXAACxjKRUJJJS+/aJHDxod0sAAADiFnWlAACIfSSlwi0tzfs1K8vulgAAAMStJk1EGjViCR8AALGMpFQkZkopklIAAAARrSulS/godg4AQOwiKRWppBQFDgAAACK+hG/NGpFdu+xuCQAAKA+SUuFGUgoAAETQpEmT5KSTTpKUlBSpXbu2DBkyRNavX+/3nNzcXBk7dqykp6dLtWrVZNiwYbJ9+3aJNzpTyrJEliyxuyUAACCmk1KTJ08Wj8cj1113Xf59PXv2NPcVvF1xxRXiaCSlAABABC1evNgknFasWCGffPKJHDp0SPr27St79+7Nf864ceNk7ty58uabb5rn//HHHzJ06FCJN0cf7b2xhA8AgNhUURxg5cqV8txzz0nbtm2LPDZ69Gi555578r9PSkoSR0tN9RY5ICkFAAAiYN68eX7fT58+3cyYWr16tXTv3l2ysrLkhRdekNdee0169eplnjNt2jQ59thjTSLr5JNPlnhbwkexcwAAYpPtSamcnBwZPny4PP/883LfffcVeVyTUHXr1pWYkZDgTUyRlAIAAFGgSShVs2ZN81WTUzp7qk+fPvnPadWqlTRq1EiWL18eMCl14MABc/PJzs42X/Py8swtEvS4lmWFfPzu3TXpliA7duRJerrEhHD1PRa5ue9u77+b++72/ru5727uf16Q/bU9KaXTzwcOHGgCp0BJqVdffVVeeeUVk5gaNGiQ3HHHHSXOlop2UBXoA+bRJXwzZ4r8+adYEyeKVKoU9teNJ279JQ0Xxi90jGHoGMPQMH7OHkMnvy/aNi190LVrV2ndurW5b9u2bVK5cmWp7isp8D916tQxjxVXp2qixiyF7Nixw9SnilTbNaGm71uCXtQrp9at9Wdry7vvZsnAgf8fAzpZuPoei9zcd7f33819d3v/3dx3N/d/z549zk9KzZgxQ7766iuzfC+QCy+8UBo3biz169eXtWvXys0332wKec6ePbvYY0Y7qAr0Aat2xhlSZd48qfjgg7Kzb185fNxxYX/deOLWX9JwYfxCxxiGjjEMDePn7DEMNqiy6+LeunXrZOnSpSEdZ8KECTJ+/Hi/i3oNGzaUjIwMSdUZ4BF6z7ReqL5GKO9Z7doiTZtasmZNdRk50pJYEK6+xyI3993t/Xdz393efzf33c39r1KlirOTUr/99ptce+21pkBncY0dM2ZM/r/btGkj9erVk969e8vGjRulWbNmjgiqAn7AnnjCuz9xx45Ss1o1b7SEYrn1lzRcGL/QMYahYwxDw/g5ewyDDaqi7eqrr5b33ntPlixZIg0aNMi/X2eXHzx4UHbv3u03W0p33yuuJEJiYqK5FaZjGcnPpL5n4XgNrSulxc4TEjwSK8LV91jk5r67vf9u7rvb++/mvru1/wlB9tW2pJTWO8jMzJQOHTrk33fkyBETWD311FNmCV6FChX8fqZTp07m64YNG4pNStkRVAX8gFWt6n3dQ4e8daZQIjf+koYT4xc6xjB0jGFoGD/njqHT3hOdDXbNNdfInDlzZNGiRdKkSRO/xzt27CiVKlWSBQsWyLBhw8x9OtN88+bN0rlzZ4lHmpR64QWdGS+SkWF3awAAQLBsS0rpjKdvv/3W776RI0eaQpy6TK9wQkqt0dlHImbGlOP5EmMF6lsBAACEY8me7qz3zjvvSEpKSn6dqLS0NKlatar5OmrUKDNzXIuf60xxTWJpQiredt7z6dnT+3XxYpGzz7a7NQAAwPFJKQ2ifAU5fZKTkyU9Pd3cr0v0NOAaMGCAuU9rSo0bN85sddy2bVtxvMqVvV9JSgEAgDCaOnWq+drTl4n5n2nTpskll1xi/j1lyhQzw0tnSuns8379+skzzzwj8eqoo0SOOUZk4UKSUgAAxBLbd98rju4aM3/+fHnsscdk7969pi6UBla33367xARmSgEAgAgt3wumDtbTTz9tbm6hOTqtKwUAAGKHo5JSWhfBR5NQi3UOdqwiKQUAABDVulLPP68F3UXq1LG7NQAAIBjOqtwZT3xJqYMH7W4JAABA3POtZmS2FAAAsYOkVKRQUwoAACBqdB+cli1JSgEAEEtISkWKxyNSqRJJKQAAgCgu4dNi5wAAIDaQlIr0Ej6SUgAAAFFbwrd+vcjWrXa3BAAABIOkVCSRlAIAAIga6koBABBbSEpFOilFoXMAAICo0F33jjuOJXwAAMQKklKRxEwpAACAqM+WYqYUAACxgaRUJJGUAgAAiHqx859+Evn9d7tbAgAASkNSKpIqVyYpBQAAEEU9eni/MlsKAADnIykVScyUAgAAiKqMDJHWrakrBQBALCApFUkkpQAAAGxZwkdSCgAA5yMpFUnsvgcAAGBLsfOffxbZvNnulgAAgJKQlIokZkoBAABEHXWlAACIDSSlIomkFAAAQNSlp4u0bUtSCgAApyMpFUnsvgcAAGAL6koBAOB8JKUiiZlSAAAAtiWlNm3y3gAAgDORlIokCp0DAADYont3EY+HJXwAADgZSalIYqYUAACALWrUEDnhBJGPPrK7JQAAoDgkpSKJpBQAAIBtzjpL5L33RPbvt7slAAAgEJJSkURSCgAAwDbnniuSkyMyb57dLQEAAIGQlIokdt8DAACwTYsWIu3bi7zxht0tAQAAgZCUiiRmSgEAANg+W2ruXJF9++xuCQAAKIykVCSx+x4AAICtzjlHZO9ekQ8+sLslAACgMJJSkcRMKQAAAFs1by7SoQNL+AAAcCKSUpFOSh06JJKXZ3dLAAAAXL2ET3fh0xlTAADAOUhKRToppVjCBwAAYOsSvv37Rd5/3+6WAACAgkhKRXr3PcUSPgAAANs0bSpy4oks4QMAwGlISkUSM6UAAAAcs4RPZ0rl5NjdEgAA4ENSKhpJKWZKAQAA2L6ELzfXW1sKAAA4A0mpSCIpBQAA4AhHHy3SqZPIzJl2twQAAPiQlIokklIAAACOWsL34Yci2dl2twQAACiSUpFEUgoAAMAxzj7bG5bNnWt3SwAAgKOSUpMnTxaPxyPXXXdd/n25ubkyduxYSU9Pl2rVqsmwYcNk+/btEjPYfQ8AAMAxGjUS6dyZXfgAAHAKRySlVq5cKc8995y0bdvW7/5x48bJ3Llz5c0335TFixfLH3/8IUOHDpWYwe57AAAAjlvCN2+eSFaW3S0BAAC2J6VycnJk+PDh8vzzz0uNGjXy78/KypIXXnhBHn30UenVq5d07NhRpk2bJp9//rmsWLFCYgLL9wAAABy3hE+vF777rt0tAQAAFe1ugC7PGzhwoPTp00fuu+++/PtXr14thw4dMvf7tGrVSho1aiTLly+Xk08+OeDxDhw4YG4+2f+rZJmXl2du4abHtCwr8LErVTJZv7z9+/WJYX/teFHiGKJUjF/oGMPQMYahYfycPYa8L/GlQQORrl29S/j+/ne7WwMAgLvZmpSaMWOGfPXVV2b5XmHbtm2TypUrS/Xq1f3ur1OnjnmsOJMmTZKJEycWuX/Hjh2mRlUkAlWd1aWBcEKC/8QzT3a21NFZX5mZciAzM+yvHS9KGkOUjvELHWMYOsYwNIyfs8dwz549YT0enLGE74YbRP76S6TARH0AAOCWpNRvv/0m1157rXzyySdSpUqVsB13woQJMn78eL+ZUg0bNpSMjAxJTU2VSATBWqBdj18kCK5WzXxJ0/7Vrh32144XJY4hSsX4hY4xDB1jGBrGz9ljGM44Bc4wbJiI7q3zzjsil1xid2sAAHAv25JSujwvMzNTOnTokH/fkSNHZMmSJfLUU0/JRx99JAcPHpTdu3f7zZbS3ffq1q1b7HETExPNrTANUCMV6GsQHPD4/wtiEw4f1gZE5LXjRbFjiKAwfqFjDEPHGIaG8XPuGPKexJ+jjhLp1s27hI+kFAAA9rEtyurdu7d8++23smbNmvzbiSeeaIqe+/5dqVIlWbBgQf7PrF+/XjZv3iyddS/fWFCxojcZRaFzAAAARznvPJFPPhHZtcvulgAA4F62zZRKSUmR1q1b+92XnJws6enp+fePGjXKLMWrWbOmWXp3zTXXmIRUcUXOHUlnbZGUAgAAcNwSvmuuEXn7bZFLL7W7NQAAuJOj56NPmTJFzjjjDBk2bJh0797dLNubPXu2xBSSUgAAAI6j1SB69PAu4QMAAC7cfa+wRYsWFSks+vTTT5tbzCIpBQAA4Nhd+HS21M6dIunpdrcGAAD3cfRMqbigSamDB+1uBQAAAAoZOlTEskTmzLG7JQAAuBNJqUirXJmZUgAAAA5Up45Iz54iM2fa3RIAANyJpFSksXwPAADA0Uv4Pv1UZMcOu1sCAID7kJSKNJJSAAAAjl7Cp2JtLx0AAOIBSalIIykFAADgWBkZIr16sQsfAAB2ICkVaSSlAAAAHL+ETzeB3r7d7pYAAOAuJKUijd33AAAAHL+Ez+NhCR8AANFGUirS2H0PAADA0dLTRfr0YQkfAADRRlIq0li+BwAAwmzJkiUyaNAgqV+/vng8Hnn77bf9Hr/kkkvM/QVvp59+um3tjZUlfIsXi2zbZndLAABwD5JS0UhK7dvnvQEAAITB3r17pV27dvL0008X+xxNQm3dujX/9vrrr0e1jbFmyBCRChVEZs2yuyUAALhHRbsbEPdSUkSWLhVJThZ5912RQYPsbhEAAIhx/fv3N7eSJCYmSt26daPWplhXs6bIaad5l/BdfbXdrQEAwB1ISkXaXXeJnHqqyMiRIj/+aHdrAACASyxatEhq164tNWrUkF69esl9990n6Vo8KYADBw6Ym092drb5mpeXZ26RoMe1LCtixy+Ps88Wuewyj/z2myVHHRW513Fi36PFzX13e//d3He399/NfXdz//OC7C9JqUjTK5RapOCGG0R277a7NQAAwAV06d7QoUOlSZMmsnHjRrn11lvNzKrly5dLBV2jVsikSZNk4sSJRe7fsWOH5ObmRixYzcrKMoF6QoIzKkp06aL1t2rLG2/skeHD90fsdZzY92hxc9/d3n83993t/Xdz393c/z179gT1PJJS0VK9OkkpAAAQFeeff37+v9u0aSNt27aVZs2amdlTvXv3LvL8CRMmyPjx4/1mSjVs2FAyMjIkNTU1YkG6FmDX13BKkF67tkiHDiJffZUq48alROx1nNj3aHFz393efzf33e39d3Pf3dz/KlWqBPU8klLRQlIKAADYpGnTplKrVi3ZsGFDwKSU1p/SW2EaPEcygNYgPdKvUVY9e4q89pq3bR6PuKrv0eLmvru9/27uu9v77+a+u7X/CUH21T0j4oSkVFaW3a0AAAAutGXLFtm5c6fUq1fP7qY4npYC/eMPkZ9+srslAADEP5JS0cJMKQAAECY5OTmyZs0ac1O//PKL+ffmzZvNYzfeeKOsWLFCNm3aJAsWLJDBgwdL8+bNpV+/fnY33fG6dRPRsluLFtndEgAA4h9JqWghKQUAAMJk1apVcsIJJ5ib0npQ+u8777zTFDJfu3atnHnmmdKiRQsZNWqUdOzYUT777LOAS/TgT0todewosnCh3S0BACD+UVMqWkhKAQCAMOnZs6fZxac4H330UVTbE49L+F58UUSHOJJ1pQAAcDtmSkULSSkAAICYoMXOt20TWb/e7pYAABDfSEpFS1qayJ49IocP290SAAAAlIC6UgAARAdJqWjOlFLZ2Xa3BAAAACWoVk3kpJOoKwUAQKSRlIp2UoolfAAAADFRV0pnSpVQugsAAISIpFS0kJQCAACIqbpSmZki//2v3S0BACB+kZSKFpJSAAAAMaNrV5FKlVjCBwBAJJGUihaSUgAAADEjOVnkb3+j2DkAAJFEUiqau++prCy7WwIAAIAgl/BpUiovz+6WAAAQn0hKRUvFit6tXJgpBQAAEDPFzv/8U+S77+xuCQAA8YmkVLSX8JGUAgAAiAmdO3vrSrGEDwCAyCApFU0kpQAAAGJGUpLIySdT7BwAgEghKRVNJKUAAABibgnf4sXUlQIAIBJISkUTSSkAAICYK3a+a5fIt9/a3RIAAOKPrUmpqVOnStu2bSU1NdXcOnfuLB9++GH+4z179hSPx+N3u+KKKyRmkZQCAACIubpSiYnUlQIAIO6SUg0aNJDJkyfL6tWrZdWqVdKrVy8ZPHiwfFdgi5PRo0fL1q1b828PPfSQxCySUgAAADGlShXqSgEAECkVxUaDBg3y+/7+++83s6dWrFghxx9/vLkvKSlJ6tatK3GBpBQAAEBM1pV67DGRI0dEKlSwuzUAAMQPx9SUOnLkiMyYMUP27t1rlvH5vPrqq1KrVi1p3bq1TJgwQfbt2ycxKy2NpBQAAEAMJqU0hFu71u6WAAAQX2ydKaW+/fZbk4TKzc2VatWqyZw5c+S4444zj1144YXSuHFjqV+/vqxdu1ZuvvlmWb9+vcyePbvY4x04cMDcfLKzs83XvLw8cws3PaZlWcEdu3p1ScjOlrz9+73FCVD2MUQRjF/oGMPQMYahYfycPYa8L+jUybuMT5fwnXCC3a0BACB+2J6UatmypaxZs0aysrJk1qxZMmLECFm8eLFJTI0ZMyb/eW3atJF69epJ7969ZePGjdKsWbOAx5s0aZJMnDixyP07duwwia9IBKradg2EExJKnnhWqW5dSReRXcuWyeHWrcPellhVljFEUYxf6BjD0DGGoWH8nD2Ge/bsCevxEHv0WmKXLt5i5+PH290aAADih+1JqcqVK0vz5s3Nvzt27CgrV66Uxx9/XJ577rkiz+2kl6lEZMOGDcUmpXSJ3/gC0YLOlGrYsKFkZGSYHf4iEQTrroB6/FKD4O7dxfJ4pObmzSK9eoW9LbGqTGOIIhi/0DGGoWMMQ8P4OXsMq+gUGbhez54i//wndaUAAIirpFSgoLLg8ruCdEaV0hlTxUlMTDS3wjRAjVSgr0FwUMfXpFjz5uLRggT80VG+MURAjF/oGMPQMYahYfycO4a8J/DVlbrzTpGvvxY58US7WwMAQHyoGK4i5VobSus/1ahRI+if01lN/fv3l0aNGpmp8a+99posWrRIPvroI7NET78fMGCApKenm5pS48aNk+7du0vbtm0lZrVvr9k1u1sBAAAcoLwxFKLvpJNEqlb1LuEjKQUAQHiU69LfddddJy+88EJ+MNWjRw/p0KGDWSanSaVgZWZmysUXX2zqSmmtKF26pwmp0047zSzrmz9/vvTt21datWol119/vQwbNkzmzp0rMU2TUt98I2JZdrcEAABEWbhiKESfTsTv2tVb7BwAANg4U0oLkl900UXm35ok+uWXX+SHH36Ql19+WW677TZZtmxZUMfxBWWBaHCmBc/jjialdE9hrSvVuLHdrQEAAFEUrhgK9i3hmzxZ5PBhkYqOK4IBAIBLZkr9+eefUrduXfPvDz74QM455xxp0aKFXHrppWYKOkpJSimW8AEA4DrEULFf7Fw3Y/zqK7tbAgCAi5NSderUke+//95MO583b55Zbqf27dsnFdiOpGRapL1WLZF//UvkySdFDh60u0UAACBKiKFiv65UUpK3rhQAALApKTVy5Eg599xzpXXr1manmz59+pj7v/jiC1P/CSXweETOPltk+XKRf/xD5JNP7G4RAACIEmKo2Fapkki3btSVAgAgXMq1Gv7uu++WNm3ayObNm82080St/ChirvDdcsstYWtc3Jo6VeSZZ0TS073L+AYOtLtFAAAgCoih4qOu1H33iRw65E1SAQCAKCalDh06JKeffro8++yzZje8gkaMGBFCU1w4Y6pdO2pLAQDgEsRQ8ZOUmjBBZPVqkZNPtrs1AAC4bPlepUqVZO3atZFpjRuLnpOUAgDAFYih4kOHDiLVqrGEDwAA22pK6VbGL7zwQlgaIG5PSm3Y4N3GBQAAxD1iqNinS/ZOOYVi5wAA2FZT6vDhw/Kf//xH5s+fLx07dpTk5GS/xx999NGwNC7u6fI9pVtAd+lid2sAAECEEUPFh549RSZO9G6iXLmy3a0BAMBlSal169ZJB527LCI//vij32O6kwyCdNxx3sttuoSPpBQAAHGPGCp+6krdfLPIypUiXbva3RoAAFyWlFrIIvrw0Etrxx5LXSkAAFyCGCo+nHCCSEqKdwkfSSkAAKKclEKY60q9/rrIl18W/xy9ovqf/0SzVQAAAChGxYoi3bt7i53fdpvdrQEAwGVJqVNPPbXEKeaffvppKG1yl3HjRNLSRCwr8OMbN4pMny7y+OPeS3IAACBmEUPF1xK+O+4QOXBAJDHR7tYAAOCipFR7nd1TwKFDh2TNmjWmTsKIESPC1TZ30LF84oniH9elfR9+SDF0AADiADFUfBU737/fO9ldd+MDAABRSkpNmTIl4P1333235OTklOeQKA7F0AEAiBvEUPFD84s62V3rSpGUAgCgfBIkjC666CKzzTHCXAxdE1MUQwcAIG4RQ8WeChX+v64UAABwQFJq+fLlUqVKlXAeEqpdO5FvvrG7FQAAIEKIoWK3rtTnn4vk5trdEgAAXLR8b+jQoX7fW5YlW7dulVWrVskdWvER4Z8f/sYbIocPe7d7AQAAMYkYKv6SUlro/IsvRHr0sLs1AADEnnJlONJ0AX0BCQkJ0rJlS7nnnnukb9++4WobCial9BLcTz+JHHus3a0BAADlRAwVX9q2FalRw7uEj6QUAABRSkpNmzatPD+GUJbvKd2FLy+v6OMZGSK1a0e9WQAAoGyIoeJLQoI3GfXRRyLnnBP8z2k4t2tXRdmxw3uMWKbtb9ky9vsBALBHudeC7d69W2bNmiUbN26UG2+8UWrWrClfffWV1KlTR4466qjwttLtatYUadZM5PrrvbfCqlfXyEbE47GjdQAAoAyIoeLLaaeJjB0r0rp1WX5KMzi1JF6ccYbIrFkiiYl2twQA4Iqk1Nq1a6V3795SvXp12bRpk4wePdoEVLNnz5bNmzfLSy+9FP6Wut2SJSK//lr0/k8+EbnrLpF9+0SSk+1oGQAACBIxVPwZM0bkpJO8pT+DlZeXJ3/99ZfUqFHDLOGMZRs3ilx2mdZLE3nrLRHq9QMAIp6UGj9+vIwcOVIeeughSUlJyb9/wIABcuGFF5bnkChN/freW2F//eX9uns3SSkAAByOGCr+6B40mpQqC12+l5l5yFRfiPGclHTu7K0iMXiwNzE1ezaJKQBA8Mp1Gly5cqVcfvnlRe7XKefbtm0rzyFRXrp0T2Vl2d0SAABQCmIoxCOt0T93rrfg+5AhIvv3290iAEBcJ6USExMlOzu7yP0//vijZGjRbUQ/KaUzpQAAgKMRQyFe9ekj8v773ooTOmuKxBQAIGJJqTPPPNNsXXzo0CHzvcfjMXUQbr75Zhk2bFh5DonyIikFAEDMIIZCPOvVS+SDD0SWLdPPurfkKQAAYU9K/fOf/5ScnBypXbu27N+/X3r06CHNmzc3tRHuv//+8hwS5UVSCgCAmEEMhXjXs6c3MbV8ucigQSJ799rdIgBA3BU6T0tLk08++USWLVsm33zzjQmuOnToIH103i6iq2pVb4VNklIAADgeMRTcoEcPkQ8/FOnfX+SMM0Tee4/9eAAAYUpK6XTzqlWrypo1a6Rr167mBht5PN7ZUiSlAABwNGIouMkpp4jMm+dNTA0Y4K03Va2a3a0CAMT88r1KlSpJo0aN5MiRI5FpEcqOpBQAAI4XzhhqyZIlMmjQIKlfv76pS/X222/7PW5Zltx5551Sr149kwjTmVg//fRTyK8LlEW3biIffSTy9dfe5NSePXa3CAAQFzWlbrvtNrn11ltl165d4W8Ryo6kFAAAMSFcMdTevXulXbt28vTTTwd8/KGHHpInnnhCnn32Wfniiy8kOTlZ+vXrJ7m5uSG9LlBWXbqIfPyxyNq1JKYAAGGqKfXUU0/Jhg0bzNW5xo0bm0CnoK+++qo8h0V5kZQCACAmhCuG6t+/v7kForOkHnvsMbn99ttl8ODB5r6XXnpJ6tSpY2ZUnX/++WHoCRC8k0/2Jqb69tXPrkdefNEjtWvb3SoAQMwmpYYMGRL+liC0pFRWlt2tAAAADoihfvnlF9m2bZtf8XQtsN6pUydZvnx5wKTUgQMHzM0nOzvbfM3LyzO3SNDjagItUsd3Mjf2/aSTvImpfv08MmRITbO0z+OxIlp2deRIS048URzFje+9j5v77vb+u7nvbu5/XpD9LXNS6vDhw6Z2waWXXioNGjSQUEydOtXcNm3aZL4//vjjTf0D35U/nWJ+/fXXy4wZM0ygpNPOn3nmGXOlD4WSUps3290KAAAQpRiqJJqQUoXjJf3e91hhkyZNkokTJxa5f8eOHRFb8qfBalZWlgnUExLKVVEiZrm1740bi7z+egW5445kWb5cE1KeiL3Wli0V5McfD8mrr/4lTuLW997tfXd7/93cdzf3f0+Q67XLnJSqWLGiPPzww3LxxRdLqDQgmzx5shxzzDHmDXrxxRfNNPOvv/7aJKjGjRsn77//vrz55pvmCt/VV18tQ4cONdsoowCW7wEA4HjhjKHCbcKECTJ+/Hi/mVINGzaUjIwMSU1NjViQrkk6fQ03Belu7/tpp+VJ+/Y7It73Z54RGTeuslSsWFtq1hTHcPN77+a+u73/bu67m/tfpUqVyC3f69WrlyxevFiOPvpoCYXuGlPQ/fffb2ZOrVixwiSsXnjhBXnttdfM66lp06bJscceax4/WRenw4ukFAAAMSFcMVRJ6tata75u377d7L7no9+3b98+4M8kJiaaW2EaPEcygNYgPdKv4VT0PbJ9P/tskX/8Q+Tdd3V2YsReplx4793Zd7f33819d2v/E4Lsa7mSUrq87pZbbpFvv/1WOnbsWKRI55lnnlnmY+r2yDojSneT6dy5s6xevVoOHTrkVw+hVatWZitlrYdAUipAUsqyvAvoAQCAI0UihiqsSZMmJjG1YMGC/CSUznzSXfiuvPLKkI8PxALNzfboIfLGG+K4pBQAIMSk1FVXXWW+PvroowEzgJpgCpYGZZqE0noF1apVkzlz5shxxx0na9askcqVK0t1TbgEWQ/BjkKdjihalpoqCQcPSt6+fSJVq0qsccQYxjDGL3SMYegYw9Awfs4ew3AeM1wxVE5OjtnFr2Bxc42datasaS7gXXfddXLfffeZEgmapLrjjjvMjn9sVgM3OfdckWuuEdm5UyQ93e7WAADClpQKZ3DWsmVLE0Rp4a9Zs2bJiBEjzLT28op2oU4nFC1L9Hikhoj8uWGD5MVgEXgnjGEsY/xCxxiGjjEMDePn7DEMtlBnNGOoVatWyamnnpr/va8elMZR06dPl5tuusnMPh8zZozs3r1bunXrJvPmzQu6vgMQD4YOFbn6apE5c0Quu8zu1gAAQk5KDRgwQF5//XVTdFxpkfIrrrgifzbTzp075ZRTTpHvv/8+6GPqbKjmzZubf+s09pUrV8rjjz8u5513nhw8eNAEUgVnS2k9BF+tBCcU6nRE0TLdykREalWsKFK7tsQaR4xhDGP8QscYho4xDA3j5+wxDEciJ9wxVM+ePU0Crjg6Fvfcc4+5AW6l12p79vQu4SMpBQBxkJT66KOP/JbGPfDAA3LuuefmB1S61fH69etDDir1NTRBValSJVMPYdiwYeYxPfbmzZvNcr/i2FGo0/aiZf/bUiRBlyrG6B8zto9hjGP8QscYho4xDA3j59wxDMfxohFDAQi8hG/sWF01IZKRYXdrAAAhJaUKX5Er6QpdMHRWkxb81NoHOjVed9pbtGiRCdz0SuKoUaPMrCetj6CznK655hqTkKLIeSH/u+oqWVl2twQAAEQhhgIQ/BI+TUrNni1y+eV2twYAEJaaUuGSmZkpF198sWzdutUkodq2bWsSUqeddpp5fMqUKebqpM6U0quL/fr1k2eeecbOJjuTb3mj7sAHAAAAwNDZUb16eZfwkZQCgBhPSum0eL0Vvq+8XnjhhVJrODz99NPmhhLodtIVKpCUAgDAocIdQwEo2xI+TUht3+6tMwUAiOHle5dcckl+zSbdzU6LdCZrUkTEr1YCokiDWp0tRVIKAABHIoYC7HPWWSJXXOFdwnfllXa3BgBQ7qSUbjNc0EUXXVTkObocDzYgKQUAgGMRQwH2SU8X6dPHu4SPpBQAxHBSatq0aZFrCUJTo4bIrl12twIAAARADAXYv4TvsstEtm0TqVvX7tYAAHzYdzpe6AL5zEy7WwEAAAA4zpAh3hKsb71ld0sAAAWRlIoXeslHL/0AAAAA8FOzpohu8D1zpt0tAQAURFIqnmZKkZQCAAAAil3Ct3SpyO+/290SAIAPSal4myllWXa3BAAAAHDkEr6KFVnCBwBOQlIqnpJSup10VpbdLQEAAAAcuVl1v37eXfgAAM5AUipe+LYRYQkfAAAAUOwSvmXLRLZssbslAABFUipekJQCAAAASnTmmSKVK4vMmmV3SwAAiqRUvCApBQAAAJQoLU3k9NNZwgcATkFSKl5UqyaSlERSCgAAAChlCd/y5SKbN9vdEgAASal44fH8/w58AAAAAAIaNEgkMZElfADgBCSl4kmdOiLbt9vdCgAAAMCxUlNF+vcXmTnT7pYAAEhKxRNmSgEAAAClOu88kS+/FNm0ye6WAIC7kZSKJySlAAAAgFKdcYZIlSoib75pd0sAwN1ISsUTklIAAABAUHsEDRzILnwAYDeSUvGWlMrMFDlyxO6WAAAAAI7fhW/VKpGff7a7JQDgXiSl4i0plZcn8uefdrcEAAAAcDSdKVW1Kkv4AMBOFW19dYRXvXrery1aiFSoEL7jpqR4K0Hq7n4AAABAHEhO9taW0iV8N99sd2sAwJ1ISsWTDh1EnnlGZM+e8B1z1y6RBx8U+e9/SUoBAAAg7pbwnXOOyIYNIs2b290aAHAfklLxRGdHXXlleI+Zne1NSlFAHQAAAHFmwADvjCmdLXXrrXa3BgDch5pSKH3pni62377d7pYAAAAAYZWUJDJoELvwAYBdSEqhZB6Pt4A6M6UAAAAQp0v4vvlGZP16u1sCAO5DUgqlIykFAACAOHX66SLVqrELHwDYgaQUSkdSCgAAAHFKK1WceSZL+ADADhQ6R3BJqeXL7W4FAAAAELElfK+95t2BT6tXRI5HjhypJRUqRPRFyuWSS0Ruu83uVgBwG5JSKB0zpQAAABDnu/Ddd5934+lIsiyRfftyJSkpOcLJr7LR68/PPuvdgdBJ7QIQ/0hKoXR16ohkZoocOSJSoYLdrQEAAADCqlKl6MwSysuzJDMzR2rXTpKEBOdkf95/X+SMM0Q2bvTOFgOAaKGmFIKbKZWXJ7Jzp90tAQAAABBm3bqJJCSILFpkd0sAuA1JKQSXlFIs4QMAAADiTlqaSMeOIgsX2t0SAG5DUgqlIykFAAAAxLWePb1JKa17BQDRQlIKwdWUUiSlAAAAgLh06qkiW7eK/PST3S0B4Ca2JqUmTZokJ510kqSkpEjt2rVlyJAhsn79er/n9OzZUzwej9/tiiuusK3NrlSlikj16iSlAAAAgDiuK6V7GrGED4BrklKLFy+WsWPHyooVK+STTz6RQ4cOSd++fWXv3r1+zxs9erRs3bo1//bQQw/Z1mZXL+EjKQUAAADEpZQUkRNPpNg5gOiqKDaaN2+e3/fTp083M6ZWr14t3bt3z78/KSlJ6vrqGsEeJKUAAACAuF/CN22at66Ux2N3awC4ga1JqcKysrLM15o1a/rd/+qrr8orr7xiElODBg2SO+64wySqAjlw4IC5+WRnZ5uveXl55hZuekzLsiJybCfxaF2pbdvEYgwdh/ELHWMYOsYwNIyfs8eQ9wWAm4qdT54s8sMPIscea3drALiBY5JSGvBdd9110rVrV2ndunX+/RdeeKE0btxY6tevL2vXrpWbb77Z1J2aPXt2sXWqJk6cWOT+HTt2SG5ubkTarck0DYQTEuK3bny1jAyp+tlnsiMzM+zHdssYRgrjFzrGMHSMYWgYP2eP4Z49e8J6PABwqq5dRSpW9C7hIykFwFVJKa0ttW7dOlm6dKnf/WPGjMn/d5s2baRevXrSu3dv2bhxozRr1qzIcSZMmCDjx4/3mynVsGFDycjIkNTU1IgEwVp8XY8f139IdO4sCU89JbW1+mF6elgP7ZoxjBDGL3SMYegYw9Awfs4ewyq64QcAuEC1aiJ/+5u32PmVV9rdGgBu4Iik1NVXXy3vvfeeLFmyRBo0aFDiczt16mS+btiwIWBSKjEx0dwK0wA1UoG+BsGRPL4jdOhgviR8+61Ir15hP7wrxjCCGL/QMYahYwxDw/g5dwx5TwC4bQnf889TVwpAdNgaZekUe01IzZkzRz799FNp0qRJqT+zZs0a81VnTCGKjjlGpGpVfQPsbgkAAACACBY737FD5Pvv7W4JADeoaPeSvddee03eeecdSUlJkW3/290tLS1Nqlatapbo6eMDBgyQ9PR0U1Nq3LhxZme+tm3b2tl099FlezrmJKUAAACAuNWli0ilSt4lfMcfb3drAMQ7W2dKTZ061RQl7dmzp5n55LvNnDnTPF65cmWZP3++9O3bV1q1aiXXX3+9DBs2TObOnWtns92rXTuRb76xuxUAAAAAIkQ3OdeKKVrsHADieqaULt8riRYoX7x4cdTag1K0by/yn/+IHDigxbvsbg0AAACACNWVmjpVN5HQunp2twZAPON/MShbUurwYRaYAwAAAHFeV2rnTpHvvrO7JQDiHUkpBK9NG+9XlvABAAAAcatzZy2l4q0rBQCRRFIKwatWTSQjQ+T33+1uCQAAAIAI0U23Tz6ZpBSAyCMphbKpW1fkf7skAgAAZ7r77rvF4/H43XTTGAAoyxI+Le+rdaUAIFJISqFsSEoBABATjj/+eNm6dWv+benSpXY3CUCMFTv/6y+RtWvtbgmAeGbr7nuI0aTUL7/Y3QoAAFCKihUrSl09bwNAOejyPd1we9Ei735HABAJzJRC2TBTCgCAmPDTTz9J/fr1pWnTpjJ8+HDZvHmz3U0CEEOqVBHp0oW6UgAii5lSKJs6dUS2b7e7FQAAoASdOnWS6dOnS8uWLc3SvYkTJ8opp5wi69atk5SUlCLPP3DggLn5ZGdnm695eXnmFgl6XMuyInZ8J6Pv7ux7LPa/Rw+RKVM8cuiQJRUquKvv4ebm/ru5727uf16Q/SUphbLPlNqzR2TvXpHkZLtbAwAAAujfv3/+v9u2bWuSVI0bN5Y33nhDRo0aVeT5kyZNMomrwnbs2CG5ubkRC1azsrJMoJ6Q4K7J+/TdnX2Pxf63a1dJsrLSZeHCndK27WFX9T3c3Nx/N/fdzf3fo3mDIJCUQtn4alPobKmmTe1uDQAACEL16tWlRYsWsmHDhoCPT5gwQcaPH+83U6phw4aSkZEhqampEQvSdVdAfQ03BemKvruz77HY/379dBmfJWvX1pQ+fdzV93Bzc//d3Hc397+KrgEOAkkplC8ppXWlSEoBABATcnJyZOPGjfL3v/894OOJiYnmVpgGz5EMoDVIj/RrOBV9d2ffY63/VauKdO0qsnixR264wV19jwQ399/NfXdr/xOC7Kt7RgThT0oBAABHuuGGG2Tx4sWyadMm+fzzz+Wss86SChUqyAUXXGB30wDEmFNPFVmyRORwaKv3ACAgklIomxo1RCpVIikFAICDbdmyxSSgtND5ueeeK+np6bJixQqzdAAAyqJnT13SK/L113a3BEA8Yvkeykan4OkOfCSlAABwrBkzZtjdBABx4qSTRJKSRBYt8v4bAMKJmVIoO5JSAAAAgCtUruytK7Vwod0tARCPSEqhfHWldPc9AAAAAK6oK/XZZ9SVAhB+JKVQvqQUM6UAAAAA1ySlcnJEVq+2uyUA4g1JKZQdSSkAAADANTp2FElOZgkfgPCj0DnKl5T6/XeRwYPDcjiPZUn1gwfFowvWPR5xLG3fI4+ING5sd0sAAACAqNHNt085xVvs/JZb7G4NgHjCTCmUXb9+3oSUZbnr9s47InPn2j36AAAAQNT17CmydKnIoUN2twRAPGGmFMrumGNE3norbIez8vJkd2am1K5dWzwJCc6et7xmjd2tAAAAAGypK6WzpFatEunc2e7WAIgXDs4AAA7Tvj1JKQAAALhShw4iKSnUlQIQXiSlgGC1ayeybh1zlgEAAOA6FSt660qRlAIQTiSlgLLMlDpwQGT9ertbAgAAANiyhG/ZMpGDB+1uCYB4QVIKKMtMKfXNN3a3BAAAALCl2Pn+/SJffml3SwDEC5JSQLDS0kSaNKGuFAAAAFzphBO8IfGiRXa3BEC8YPc9oKyzpVavFsnJifxrJSWJOHk3QgAAALhKhQoi3bt760rdfrvdrQEQD0hKAWXdduTOO71bj0TaOeeIvPFG5F8HAAAAKMMSvttu85ZaTUy0uzUAYh1JKaAsrr1WpGVLkby8yL7Ou++KzJ8vYlkiHk9kXwsAAAAoQ7Hz3FyRL77wzpoCgFCQlALKIjVV5NxzI/86VauKvP66yNatIvXrR/71AAAAgCC0bStSvbp3CR9JKQChomAN4OSd/iiqDgAAAIfVlerRg2LnAMKDpBTgRI0be7c2ISkFAAAABy7hW77cu4wPAGJ2+d6kSZNk9uzZ8sMPP0jVqlWlS5cu8uCDD0pLrdnzP7m5uXL99dfLjBkz5MCBA9KvXz955plnpE6dOnY2HYgsrSPVvr3IN9/Y3RIAAACgSLFzLXR++eUitWsH9zOW5ZF9+1IkKcnjypKpbu6/m/sezf63aydy0UUSc2xNSi1evFjGjh0rJ510khw+fFhuvfVW6du3r3z//feSnJxsnjNu3Dh5//335c0335S0tDS5+uqrZejQobJs2TI7mw5EnialPvzQ7lYAAAAAftq0EenXT2TFirL93JEjiWb5n1u5uf9u7ns0+p+TI/L44yIDB4rUqCExxdak1Lx58/y+nz59utSuXVtWr14t3bt3l6ysLHnhhRfktddek169epnnTJs2TY499lhZsWKFnHzyyTa1HIgCTXU/8YT3/zDVqtndGgAAAMBISNC/5cr2M3l5lmRm/mn+3ktIcN90GTf33819j1b/f/9dpGFDkXfeEbnkEokpjtp9T5NQqmbNmuarJqcOHTokffr0yX9Oq1atpFGjRrJ8+fKASSld4qc3n+zsbPM1Ly/P3MJNj2lZVkSO7RaMYTHatpUEyxJr8mSxGjTw3qeXpLTeVAGMX+gYw9AxhqFh/Jw9hrwvAADAyY46SqRbN5E33iApFVLAd91110nXrl2ldevW5r5t27ZJ5cqVpbruOVqA1pPSx4qrUzVx4sQi9+/YscPUp4pEuzWZpoFwgl4yQJkxhsWoVUsyjjpKEh54QDSf7rEs2X/22ZL15JN+T2P8QscYho4xDA3j5+wx3LNnT1iPBwAAEG7nnqvlj0R27dKJPhIzHJOU0tpS69atk6VLl4Z0nAkTJsj48eP9Zko1bNhQMjIyJDU1VSIRBHs8HnN8/pAoH8awBJs3i+X791VXSZXPP5fEQtUkGb/QMYahYwxDw/g5ewyrVKkS1uMBAACE27BhIv/4h8jbb4tceqnEDEckpbR4+XvvvSdLliyRBr5lSiJSt25dOXjwoOzevdtvttT27dvNY4EkJiaaW2EaoEYq0NcgOJLHdwPGMMjC5y+8IJ6DB/UvJL+HGL/QMYahYwxDw/g5dwx5TwAAgNPVqyfSvbt3CV8sJaVsjbJ0ir0mpObMmSOffvqpNGnSxO/xjh07SqVKlWTBggX5961fv142b94snTt3tqHFgM1JqcOHRb7/3u6WAAAAAAAcuIRv/nyRnTslZiTYvWTvlVdeMbvrpaSkmDpRetu/f795PC0tTUaNGmWW4y1cuNAUPh85cqRJSLHzHly5967HI7Jmjd0tAQAAAAA4cAmfZYnMmSMxw9ak1NSpU01R0p49e0q9evXybzNnzsx/zpQpU+SMM86QYcOGSffu3c2yvdmzZ9vZbMAeyckiLVqIfPON3S0BAAAAADhMnToiPXuKFEipOF5Fu5fvBVNc9OmnnzY3wPV0CR8zpQAAAAAAxSzhu+oqkR07RDIyxPGo3AnEknbtvEmpIBK6AAAAAAB3GTrU+zVWFpg5Yvc9AGWYKZWdLXLKKSIVvb++HhGpefCgeCpXFle74QaRM86wuxUAAAAAYJuMDJFevby78F1+uTgeSSkglvToIXLFFSI5Of9/n2XJkdxcqVSlircQuhvNmyfyzjskpQAAAAC43rnnev9s3L7dW2fKyUhKAbEkKUl3CPC7y8rLk6zMTEmsXVs8CS5dkdu3r8ju3Xa3AgAAAABsd9ZZIlde6V3Cp1+dzKV/wQKIK9Wrk5QCAAAAABGpVUukd2/vEj6nIykFIPaRlAIAAAAAvyV8ixeLbNsmjkZSCkDsIykFAAAAAH5L+CpUEHnrLXE0klIAYh9JKQAAAADIV7OmyGmnOX8JH0kpAPGRlMrKMjsRAgAAAADELOH77DORP/4QxyIpBSA+klKHDons3293SwAAAADAEQYPFqlYUWTWLHEsklIA4iMppVjCBwAAAABGjRoiffs6ewkfSSkAsY+kFAAAAAAEXMK3bJnIli3iSCSlAMQ+klIAAAAAEHAJX+XKzl3CR1IKQOwjKQUAAAAARaSliZx+unOX8JGUAhAf/6dVJKUAAAAAoMgSvuXLRTZvFschKQUg9iUlebeVICkFAAAAAH4GDRJJTHTmEj6SUgBin8fjXcJHUgoAAAAA/KSmivTv78wlfCSlAMQHTUplZdndCgAAAABw5BK+L74Q2bRJHIWkFID4wEwpAAAAAAjojDNEqlQRefNNcRSSUgDiA0kpAAAAAAgoJUVkwADnLeEjKQUgPpCUAgAAAIASl/CtWiXy88/iGCSlAMQHklIAAAAAUOISvqpVnbWEj6QUgPhAUgoAAAAAipWc7E1MOWkJH0kpAPGBpBQAFPH000/L0UcfLVWqVJFOnTrJl19+aXeTAACAzUv4vvpKZMMGcQSSUgDiKyllWXa3BAAcYebMmTJ+/Hi566675KuvvpJ27dpJv379JDMz0+6mAQAAmwwYIJKU5JwlfCSlAMRPUurgQZHcXLtbAgCO8Oijj8ro0aNl5MiRctxxx8mzzz4rSUlJ8p///MfupgEAAJskJYkMGuScJXwkpQDET1JKsYQPAOTgwYOyevVq6dOnT/59CQkJ5vvly5fb2jYAAGD/Er41a0R+/NHulohUtLsBABDWpFTv3iKJiWX6UY+IpB8+LJ6K/C+xvBjD0DB+YTB/vt0tcJQ///xTjhw5InXq1PG7X7//4Ycfijz/wIED5uaTnZ1tvubl5ZlbJOhxLcuK2PGdjL67s+9u77+b++72/ru5707tf79+ItWqeWTmTEtuuy0yrxFsf4l+AcSHjh1FbrpJJCen7D9rWXJw/36pqPujejQ9gDJjDEPD+IWuUiWRQ4fsbkXMmjRpkkycOLHI/Tt27JDcCC2L1mA1KyvLBOo6i8tN6Ls7++72/ru5727vv5v77uT+X3NNstSrd1gyM///olQ47dmzJ6jnkZQCEB+qVBF58MFy/aiVlyd7MjOlau3a4nHQiSKWMIahYfzCQK/G7dtndysco1atWlKhQgXZvn273/36fd26dYs8f8KECaYoesGZUg0bNpSMjAxJTU2NWJDu8XjMazgpSI8G+u7Ovru9/27uu9v77+a+O7n/990X2ePrzr/BICkFAAAQZypXriwdO3aUBQsWyJAhQ/KDYv3+6quvLvL8xMREcytMg+dIBtAapEf6NZyKvruz727vv5v77vb+u7nvbu1/QpB9JSkFAAAQh3Tm04gRI+TEE0+Uv/3tb/LYY4/J3r17zW58AAAATmBrmm7JkiUyaNAgqV+/vskcvv32236PX3LJJeb+grfTTz/dtvYCAADEivPOO08eeeQRufPOO6V9+/ayZs0amTdvXpHi5wAAAHaxdaaUXq1r166dXHrppTJ06NCAz9Ek1LRp0/K/DzS1HAAAAEXpUr1Ay/UAAADE7Ump/v37m1tJNAkVqCAnAAAAAAAAYpfjq2wtWrRIateuLS1btpQrr7xSdu7caXeTAAAAAAAAECJHFzrXpXu6rK9JkyayceNGufXWW83MquXLl5ttjgM5cOCAuRXc0ti344zewk2PaVlWRI7tFoxhaBi/0DGGoWMMQ8P4OXsMeV8AAABcmJQ6//zz8//dpk0badu2rTRr1szMnurdu3fAn5k0aZJMnDixyP07duyQ3NzciASqWVlZJhB20/aO4cQYhobxCx1jGDrGMDSMn7PHcM+ePWE9HgAAAGIgKVVY06ZNpVatWrJhw4Zik1ITJkwwWyAXnCnVsGFDycjIkNTU1IgEwboroB6fPyTKhzEMDeMXOsYwdIxhaBg/Z49hlSpVwno8AAAAxGBSasuWLaamVL169UosjB5ohz4NUCMV6GsQHMnjuwFjGBrGL3SMYegYw9Awfs4dQ94TAACAOExK5eTkmFlPPr/88ousWbNGatasaW66DG/YsGFm9z2tKXXTTTdJ8+bNpV+/fnY2GwAAAAAAALGclFq1apWceuqp+d/7lt2NGDFCpk6dKmvXrpUXX3xRdu/eLfXr15e+ffvKvffeG3AmVHG0tkTBgueRWC6gtSZ0aj9XUsuHMQwN4xc6xjB0jGFoGD9nj6EvhvDFFG4Q6fjJ7Z97+u7Ovru9/27uu9v77+a+u7n/2UHGTx4rziMsXfKnNaUAAABC8dtvv0mDBg3EDYifAABANOKnuE9KaVbyjz/+kJSUFFNrItx8hdR1oCNRSN0NGMPQMH6hYwxDxxiGhvFz9hhqqKRXOHXWtluucEY6fnL7556+u7Pvbu+/m/vu9v67ue9u7r8VZPwUU4XOy0M7H42rmvrhctMHLBIYw9AwfqFjDEPHGIaG8XPuGKalpYmbRCt+cvvnnr67s+9u77+b++72/ru5727tf1oQ8ZM7LvcBAAAAAADAUUhKAQAAAAAAIOpISoVIdwK86667yrQjIPwxhqFh/ELHGIaOMQwN4xc6xjD2uPk9o+/u7Lvb++/mvru9/27uu3J7/0sT94XOAQAAAAAA4DzMlAIAAAAAAEDUkZQCAAAAAABA1JGUAgAAAAAAQNSRlArR008/LUcffbRUqVJFOnXqJF9++aXdTXKku+++Wzwej9+tVatW+Y/n5ubK2LFjJT09XapVqybDhg2T7du3i5stWbJEBg0aJPXr1zfj9fbbb/s9ruXg7rzzTqlXr55UrVpV+vTpIz/99JPfc3bt2iXDhw+X1NRUqV69uowaNUpycnLEDUobv0suuaTIZ/L000/3e46bx09NmjRJTjrpJElJSZHatWvLkCFDZP369X7PCeZ3d/PmzTJw4EBJSkoyx7nxxhvl8OHDEu+CGb+ePXsW+RxeccUVfs9x6/ipqVOnStu2bc3voN46d+4sH374Yf7jfP5il1vjp9LioXgSjjjG7XGI2+MHN5/73Xzejte+x/P7HiqSUiGYOXOmjB8/3lTS/+qrr6Rdu3bSr18/yczMtLtpjnT88cfL1q1b829Lly7Nf2zcuHEyd+5cefPNN2Xx4sXyxx9/yNChQ8XN9u7daz5TGrgH8tBDD8kTTzwhzz77rHzxxReSnJxsPn/6P3sfTah899138sknn8h7771nAqQxY8aIG5Q2fkqDv4Kfyddff93vcTePn9LfRQ0cVqxYYcbg0KFD0rdvXzO2wf7uHjlyxCQEDh48KJ9//rm8+OKLMn36dPOHSLwLZvzU6NGj/T6H+rvt4+bxUw0aNJDJkyfL6tWrZdWqVdKrVy8ZPHiw+b1UfP5ik9vjp5LioXgSjjjG7XGIm+MHN5/73Xzejue+x/P7HjLdfQ/l87e//c0aO3Zs/vdHjhyx6tevb02aNMnWdjnRXXfdZbVr1y7gY7t377YqVapkvfnmm/n3/fe//9VdIa3ly5dHsZXOpWMxZ86c/O/z8vKsunXrWg8//LDfOCYmJlqvv/66+f777783P7dy5cr853z44YeWx+Oxfv/9d8vN46dGjBhhDR48uNifYfyKyszMNGOyePHioH93P/jgAyshIcHatm1b/nOmTp1qpaamWgcOHLDcPH6qR48e1rXXXlvszzB+RdWoUcP697//zecvhrk5fiopHopn5Ylj3B6HuD1+cPO5383n7Xjtuxvf97JgplQ56VVXzYLqVGOfhIQE8/3y5cttbZtT6ZRsncLctGlTMwNFl1QoHUe9ilBwLHUqe6NGjRjLYvzyyy+ybds2vzFLS0szSyB8Y6ZfdcnZiSeemP8cfb5+TvWKJEQWLVpkpla3bNlSrrzyStm5c2f+Y4xfUVlZWeZrzZo1g/7d1a9t2rSROnXq5D9Hr4RnZ2f7XTly4/j5vPrqq1KrVi1p3bq1TJgwQfbt25f/GOMnfrOeZsyYYa4265R4Pn+xifip+HjITYKJY9weh7g9fnDzud/N5+147bub3vfyqFiun4L8+eef5sNWMNBV+v0PP/xgW7ucSoMMXTKhJ12dqjhx4kQ55ZRTZN26dSYoqVy5skkAFB5LfQxF+cYl0OfP95h+1UCnoIoVK5qTIuPqnTKv04WbNGkiGzdulFtvvVX69+9vTooVKlRg/ArJy8uT6667Trp27WpOpCqY3139Guhz6nvMzeOnLrzwQmncuLH5A3Xt2rVy8803m9oTs2fPNo8zfiLffvutCeh0SY/Wn5gzZ44cd9xxsmbNGj5/Mcjt8VNJ8ZDWoHGLYOIYt8chbo8f3Hzud/N5O1777ob3PRQkpRAVepL10QJwGpTpL+Ubb7xhilsC0Xb++efn/1tnUujnslmzZuaqZe/evW1tmxNpfQT9oylea5/YNX4Fa5Tp51AL/urnT/9A0c8jxPzxroGsXm2eNWuWjBgxwtShAOItHtLNNOAebolD3Bw/uPXc7+bzdnF918RUvL/voWD5XjnptDu9ilF4twD9vm7dura1K1ZohrxFixayYcMGM146nX/37t1+z2Esi+cbl5I+f/q1cNFY3XFKd5RjXIvSZRT6e62fScX4/b+rr77aFHpfuHChKeLoE8zvrn4N9Dn1Pebm8QtE/0BVBT+Hbh8/varavHlz6dixo9nVSAsHP/7443z+YhTxU/HxkJsEE8e4PQ5xe/zg5nO/m8/b8dp3N7zvoSApFcIHTj9sCxYs8Juiqd8XXDeKwHJyckxWWDPEOo6VKlXyG0udyqg1FhjLwHSqt/7Pu+CYaY0UrXXkGzP9qv/T1/XbPp9++qn5nPr+J4j/t2XLFlPLQT+TivHzbtetQZVOPda+6+euoGB+d/WrTmUumODT3Wh0q1zfdGa3jl8genVNFfwcunX8iqO/gwcOHODzF6OIn4qPh9wkmDjG7XGI2+MHN5/73Xzejte+u/F9L5MylUWHnxkzZphdQqZPn2526hozZoxVvXp1v11+4HX99ddbixYtsn755Rdr2bJlVp8+faxatWqZHSnUFVdcYTVq1Mj69NNPrVWrVlmdO3c2Nzfbs2eP9fXXX5ub/qo++uij5t+//vqreXzy5Mnm8/bOO+9Ya9euNTu4NGnSxNq/f3/+MU4//XTrhBNOsL744gtr6dKl1jHHHGNdcMEFltvHTx+74YYbzE4f+pmcP3++1aFDBzM+ubm5+cdw8/ipK6+80kpLSzO/u1u3bs2/7du3L/85pf3uHj582GrdurXVt29fa82aNda8efOsjIwMa8KECZbbx2/Dhg3WPffcY8ZNP4f6u9y0aVOre/fu+cdw8/ipW265xexYpOOj/5/T73UHzI8//tg8zucvNrk5fiotHoon4Yhj3B6HuDl+cPO5383n7Xjte7y/76EiKRWiJ5980vxiVa5c2WxxvGLFCrub5EjnnXeeVa9ePTNORx11lPlefzl9NAC56qqrzLaZSUlJ1llnnWX+B+5mCxcuNEFM4ZtuIezbTvmOO+6w6tSpY4L73r17W+vXr/c7xs6dO00SpVq1amYL9JEjR5pAyO3jp4GB/pGqf5zq1rSNGze2Ro8eXeQPIjePnwo0fnqbNm1amX53N23aZPXv39+qWrWq+eNL/yg7dOiQ5fbx27x5swlGatasaX6Hmzdvbt14441WVlaW33HcOn7q0ksvNb+feu7Q31f9/5wvsFV8/mKXW+On0uKheBKOOMbtcYjb4wc3n/vdfN6Ox77H+/seKo/+p2xzqwAAAAAAAIDQUFMKAAAAAAAAUUdSCgAAAAAAAFFHUgoAAAAAAABRR1IKAAAAAAAAUUdSCgAAAAAAAFFHUgoAAAAAAABRR1IKAAAAAAAAUUdSCgAAAAAAAFFHUgoAwmT69OlSvXp1u5sBAAAQU4ihAPciKQUg6rZt2ybXXnutNG/eXKpUqSJ16tSRrl27ytSpU2Xfvn0SC44++mh57LHH/O4777zz5Mcff7StTQAAIL4RQwGINxXtbgAAd/n5559N8KRXwx544AFp06aNJCYmyrfffiv/+te/5KijjpIzzzzTlrZZliVHjhyRihXL97/GqlWrmhsAAEC4EUMBiEfMlAIQVVdddZUJWFatWiXnnnuuHHvssdK0aVMZPHiwvP/++zJo0CDzvN27d8tll10mGRkZkpqaKr169ZJvvvkm/zh33323tG/fXl5++WVzxS0tLU3OP/982bNnT/5z8vLyZNKkSdKkSRMT6LRr105mzZqV//iiRYvE4/HIhx9+KB07djSB3dKlS2Xjxo2mPXr1sVq1anLSSSfJ/Pnz83+uZ8+e8uuvv8q4cePMz+utuKnneuWyWbNmUrlyZWnZsqVpb0H6s//+97/lrLPOkqSkJDnmmGPk3XffjcDIAwCAWEYMRQwFxCOSUgCiZufOnfLxxx/L2LFjJTk5OeBzfMHJOeecI5mZmSbYWb16tXTo0EF69+4tu3btyn+uBj5vv/22vPfee+a2ePFimTx5cv7jGky99NJL8uyzz8p3331nAqCLLrrIPK+gW265xfzcf//7X2nbtq3k5OTIgAEDZMGCBfL111/L6aefbgK9zZs3m+fPnj1bGjRoIPfcc49s3brV3AKZM2eOmWJ//fXXy7p16+Tyyy+XkSNHysKFC/2eN3HiRBNcrl271rzu8OHD/foJAADcjRiKGAqIWxYARMmKFSss/d/O7Nmz/e5PT0+3kpOTze2mm26yPvvsMys1NdXKzc31e16zZs2s5557zvz7rrvuspKSkqzs7Oz8x2+88UarU6dO5t/6s/r4559/7neMUaNGWRdccIH598KFC0173n777VLbfvzxx1tPPvlk/veNGze2pkyZ4vecadOmWWlpafnfd+nSxRo9erTfc8455xxrwIAB+d/r699+++353+fk5Jj7Pvzww1LbBAAA3IEYihgKiFfUlAJguy+//NJME9erWwcOHDBTzPVKW3p6ut/z9u/fb67s+eiU85SUlPzv69WrZ64Mqg0bNpiCn6eddprfMQ4ePCgnnHCC330nnnii3/f62jq1XafC6xW8w4cPm9f2XeULll41HDNmjN99Wgvi8ccf97tPryz66NVPnWrv6wcAAEBxiKGIoYBYR1IKQNToTjE6tXz9+vV+92s9BOUrcKkBjQZHWq+gsIL1BipVquT3mB5bAzPfMZQGRVr4syCte1BQ4WnwN9xwg3zyySfyyCOPmDZru84++2wTjEVCSf0AAAAghgqMGAqIfSSlAESNXrXTq25PPfWUXHPNNcXWRNDaB7rlsRbz1Ct55XHccceZwEmvzPXo0aNMP7ts2TK55JJLTOFMX3C2adMmv+do0U3dZaYkWoBUjzVixAi/Y2vbAAAAgkUMRQwFxCuSUgCi6plnnjHTr3W6t07v1mnXCQkJsnLlSvnhhx/MDi59+vSRzp07y5AhQ+Shhx6SFi1ayB9//GGu2GmQU3iqeCA6JV2v1mlhTr1i1q1bN8nKyjIBjU7tLhjkFKa7t2ghTi3MqVfc7rjjjiJX3TTQW7JkidmtRgO3WrVqFTnOjTfeaIpv6lR37dPcuXPNcQvuQgMAABAMYihiKCAekZQCEFW6ta/uxvLAAw/IhAkTZMuWLSYg0StfGgDpdscaxHzwwQdy2223mZ1WduzYIXXr1pXu3bubLYaDde+995rtkHUHmZ9//tlMW9criLfeemuJP/foo4/KpZdeKl26dDGB0s033yzZ2dl+z9FdY3QnGO2P1nDw1tv0pwGh1j7QKey6g4xuqzxt2jSzHTIAAEBZEEMRQwHxyKPVzu1uBAAAAAAAANwlwe4GAAAAAAAAwH1ISgEAAAAAACDqSEoBAAAAAAAg6khKAQAAAAAAIOpISgEAAAAAACDqSEoBAAAAAAAg6khKAQAAAAAAIOpISgEAAAAAACDqSEoBAAAAAAAg6khKAQAAAAAAIOpISgEAAAAAACDqSEoBAAAAAABAou3/AG3x9EDh7T9eAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAeBVJREFUeJzt3Qd8FNX2wPGzARJaAtJ7s9CLoCJNEBBEHkpREQtIfSr6p1gQG6I+wYoFBJ4i2BAEAQUVBRQQBaXIAywICIISICAQaiiZ/+fcuDGbbMImW2Zn9/f9fMaws5vJ3Tsb5+TMufe6LMuyBAAAAAAAAAihmFD+MAAAAAAAAECRlAIAAAAAAEDIkZQCAAAAAABAyJGUAgAAAAAAQMiRlAIAAAAAAEDIkZQCAAAAAABAyJGUAgAAAAAAQMiRlAIAAAAAAEDIkZQCAAAAAABAyJGUAhzg9ttvl2rVqnnsc7lc8vjjj+fpeHosPWao7dq1SwoWLCjffPONx/533nlHatWqJQUKFJDixYubfW3atDFbMGn/aT8ivFx++eXywAMP2N0MAABCaseOHSYumTZtmoSro0ePSpkyZeS9997z2L9w4UJp1KiRifP0PRw6dMhr/Bpo2lf687TvEFx6josWLSpJSUl2NwURhqQUEATbtm2Tf//731KjRg1zcU5ISJAWLVrIyy+/LCdOnJBo9cQTT0jTpk1NX7j98ssvJmg5//zz5fXXX5f//ve/4gTHjx+XCRMmSIcOHaR8+fISHx8vF198sUycOFHOnj2b5fWpqany7LPPSvXq1c1nokGDBvL+++/b0vZwN2LECNO3e/bssbspAIAAJAzcm17/LrroIrn77rtl79694kQ//fSTuanlTxJk+vTp8tJLL4kTaSyrMc9NN92Uvu/AgQNy4403SqFChcz1W282FilSRJzi559/lquvvtokXEqUKCG33XYbiRcvtI8uuOACGTNmjN1NQYTJb3cDgEjzySefyA033CBxcXHSu3dvqVevnpw6dUpWrFgh999/v/z444+OSbwEkl7c33rrLbNltHTpUpOw0SBHL3RuX3zxhYSz3377Te655x5p166dDB8+3CQeP//8c7nrrrtk1apVWd7nww8/LGPHjpWBAwfKpZdeKh999JHcfPPNJkjPGNhB5LrrrjP9+dprr5lEJgDA2fT/5XpT5uTJkyYe0hs4n376qWzatEkKFy4sTktKjR492lRz57UKSJNS+t6HDh3qsb9q1arm5qVWjoej06dPm3ht2LBhki9fvvT9q1evliNHjsiTTz4p7du3T9+vNxs1xgtnf/zxh1xxxRVSrFgxefrpp00l2PPPPy8bN26U77//XmJjY+1uYljRm+733Xef+R3Q5CQQCCSlgADavn27STBoUPHll1+aChq3wYMHy9atW03SKhq9++67kj9/funSpYvH/n379pmv7mF7buEeBJQrV84ELHXr1vW4UPfr10+mTp0qjz76aHqS7c8//5QXXnjBfAbGjx9v9g0YMEBat25tEpWaxMwY3AXSsWPHsr1bqdVeofpjIKd2ZBYTEyPXX3+9vP322yboYYglADhbp06d5JJLLkm//pUsWVJefPFFc4OmV69efh07lNeyYHNXk4WrBQsWmJuMWhXlSywXrsm1jDQRpTHK2rVrpUqVKmbfZZddJldddZWp9Bs0aFBQfq5lWSZJq9Vlmel+jYM1Hgo2TRrqzXNfP3c9evQwN2VnzZplYl4gEBi+BwSQDs/SOyxTpkzxSEi5aZJiyJAhWZI1TZo0MRclLRnWpJbOvZRb2Y3b93XeJB37r3fsKleubKq8tK3PPPNMljtcM2bMMO3VuyNazVK/fn1z1+xc5s2bZ4buaWm0m7Z31KhR5t+lS5f2mCcr85xSWlGlz3/wwQfyn//8RypVqmQuoFqppMm+jL7++muT6NHgQt+Lvie9q+fL0Mn9+/ebIYUa5OakVKlSHgkpt27duqWXgrtp0K13F7WKyk3fy5133mnu0K1cufKc7dI2aaJGPyP6vjW4//jjj70Ok1i2bJn5WTrng/aT0r7Uqj0NuvSOoAbwDz30kHkuJSXFnAc95+7+0jmddL8v81xknt/M/ZnTu8laDXbeeedJy5YtzXM6JK9v376mXfqz9PdEK6MyD4PQYPD333+X9evXn7NvAADO0rZt2/SbebmJh7K7lrmvUVrhosPHdPoEfU6H2OsxNAGgVTx67dHj63Xnr7/+8mmuzozzcOo1UOMLdeWVV6YPS9QYxX2979y5s1SoUMFc43RqAv25GYf163vQG5R6jXN/vzt+y+5aqzc6W7VqZW7uaOJH258xzsh47dWYSNurr9PqH73mZo5pFi1aZK7L+hqNy2rWrJkeE5wrltO26vvK+H769Olj/q2V4NoGd39ljk0znicdNaDH0X7S79Nqq4w2bNhgvt89FYbeDNQkiA4VPJfDhw+buEm/nsuHH34o//rXv9ITUkqrvXSYqcac56Jxsg7F1JhQ21m2bFlzk/LgwYMer9N+0J+jVfUaw+nncPLkyenxrcbXjzzyiFSsWNF8dpOTk833fffdd2bYnJ5L3a83NDPPzZqbvwH0sQ6f1TnBtM3a/zpXlK8xvsaWOgWFftaBQKFSCgig+fPnm4tn8+bNfXq9Jle0okbvOOmdQ7379Oqrr5pA64cffshyxylYNFjRi5xW9OiFVC/M3377rYwcOVISExPT5z3QIEbvaGoiSBNWSoMivThmTrZlpAkZDTY0CZORHlerYebOnWtK+TUw0gtdTnQInN450tJhDTY0EXjLLbeYi7ab3r3R96Q/T+/Gavm19qsmgPS5nGglk1bnfPXVV3maaN09D5Imrdz0XGogWbt2bY/X6p049/PupI03OuRT5+HSQOXBBx80x9JAqWvXriaYcifC3DQhpUm+xx57zNz9c9NATu9Wa6B/6623msBJg6lrr73WDKfQu4HaRq0AGzdunPz6668mAM0rDdwvvPBCcxdS/yBw32HT96N32TSA0rur+rnauXOnR0ClQZHSz5bO1QUAiKy5N5Veo3MbD3m7lrnpH9pa9aHXGE06aYygx9QkmP7xr3MWatJGj61xxJtvvpmrdmt7/u///k9eeeUVk8RxX9fdXzWZpLGMDuvXr5pM0muxJhiee+659OH8Gr9oTKLXWpXxhl1mixcvNu9X40tNMugNNm2/xgXr1q3LkozQ96tDJXXeH33+jTfeMIkEd9ym12BNjmi8pcMqNSmhfZI50eGNxoaNGzf22KfvR5NammRyD9PMmLTKbviiDvfTmFOTJHqeunfvbqZGcFdXaWygjzWppgkp9/QX+lWnScjphqvGlfp9Wrme08I+GvdqHOKu4ssco+kQ03PR96DnXX+efjY00aqxpH5utU8zVott3rzZxNH6PTqdg/abmyYvtTpKP5d6U1D/rZ8fPfcaE+nNQ41/9T3p51lvwLrjyNzS42ocqckpjVf1M5SbGF/b4098CGRhAQiIw4cP61/d1nXXXefT63fs2GHly5fP+s9//uOxf+PGjVb+/Pk99vfp08eqWrWqx+v0Z40aNSrH1yh9TeZfdX2dvt7tySeftIoUKWL9+uuvHq978MEHTRt37txpHg8ZMsRKSEiwzpw5Y+XG1q1bTRteffXVbNuXlJTksb9169Zmc/vqq6/M62rXrm2lpKSk73/55ZfNfu03t+PHj2f5OWPGjLFcLpf1+++/Z/nZ3tqjPy+3tF116tSxqlevbp0+fTp9f+fOna0aNWpkef2xY8fMz9J+zkm7du2s+vXrWydPnkzfl5qaajVv3ty68MIL0/dNnTrVHK9ly5ZZzpH2pT43adIkj/3vvPOOFRMTY3399dce+/V1+vpvvvnGPN6+fbt5rD8js8yfRXcf9urVy+N1Bw8eNPufe+45yxexsbHWnXfe6dNrAQDhx31dWrx4sbnO79q1y5oxY4ZVsmRJq1ChQtYff/yRq3gou2uZ+xpVunRp69ChQ+n7R44cafY3bNjQ47qs1ye9xmS8rma+lmUXM82aNSvbOMFb/PHvf//bKly4sMfP0rjAW8zm7VrbqFEjq0yZMtaBAwfS9/3vf/8z1+7evXtnufb269fP45jdunUz/e02btw4r3HXuWj/aRx17733ZnueV69e7bE/c2zqfn/anr/++it9/0cffWT2z58/P8e+fP/9983rli9fnuVn67Ez7/MWs2Sk7dXXvf3221meu//++81zGc9bZho76Wvee+89j/0LFy7Msl/7Qffpcxm541uNEzO+Z43zNMbr2LGj+XfGftE486qrrsrT3wD6WD87P/74o8f+3MT4Tz/9tDnO3r17z/lawBcM3wMCxF1m6+ukf3PmzDFVKnpHS4eMuTe9G6TVJVqpEypaPaRl4TrMKmNbtHxZS86XL19uXqd3KrXyRu+m5Ia71FqP7y+9E5Vxviltt9K7aW4Zx+dre/W9aPWaXov1zlVO9C6kvi4vVVJ6x0mHrOkdMp0/y03vauqdyMzc4/dzGlaod3r1jpZ+TvSuovvcaJ927NhRtmzZYu70ZaR337zNUaVt0P7LfO71Dm+tWrU8zr17aIU/n8M77rjD47GeFz13erc6c1m7N+7PIwDA2TSe0ApeHR6uFU5aGaTVLFoBnNt4yNu1LGOFrg5zctNpA5RWVGW8Lut+rajKfP30V8b4w33N1jhFq7d1OFluabW6DmPXah8d0uimVU46zN1bJU/ma6/+fI0Z3HGqu+pMh1/lZhJyjUc0PgpELNezZ0+P45wrltM5lrQvL7/8cvNYK8Byov2lbc2pSipj/JXXGE1jKP286bnI+NnVSiL9jGf+7GoVmcZu3ugQyIzvWc+7xng6DYKeP/exNa7VaiaNzfM6ibyOjqhTp47HvtzE+O5zR4yGQGH4HhAgOvbaHYT4Qi80esHUgMubUE4OqW3RsfsaMHrjnsBSh4Vpua+WEmsgqXM1aBCpY9194R7C5Y+MY/4zXhgzJjl0KJiWy+ucS5mTH77ML5AXWpavq8xo+fU111zj8ZwGGRnnZ8oYZLmfz46W1Gu/6bAG3bI7P3o+MgY93uhrMk8gr+dey7PPde7zInM7NOjTkvB7773XDLfQ4FKHEOgqlfrHR2b6vpnkHACcT+d50jl6NDGk///XYUvuSZxzGw95u5ZlFyO4E1SaDPO235cbJLmhQ8t0XiC9meROAvkTf+i8UyrjMC83vaGk8xNlXkgkpzhJY1VNCOmQPh0mqVMCaIJDh87pvJW+TKwdqlhOk2A6nYLOc5Q5FglULOeOv/Iao+lnV9uiwyO9ydzu7OIzb8/psZV7vi5v9GfnJUnorR25ifHdnwFiNAQKSSkgQPRCrxNb6hK/vtC7G/o/888++8xrVUtO8wt4k92FIePkmjm1Re/y6OTW3mggqfSiq3duNAjSduumY9s1qfDWW29le3z3nBGBCP6yW6XOfYHU96vvRYMZnTtCK4A0WNO7oXrHLBhLE+tcAvqz9O6kBqOZ6WTeercsc5JF74Aq/dxkx91enWMgu7tr7lX+3LILoLzt1+PrRJa6CpI37kA+L58vbz9PJ9PXFRh1LgL9HGmiTee90AA+89xROvl+xrm5AADOpHPfeJu3Jy/xUE5JguxihHPFDjnxJY5yX7O0AkXjQZ1bSedV0mobrerRGCEY8Ude3qv2n1bZaFyiE67rJNczZ840FdJffPFFtt+vlVp6nkIRyylNiOgcVrpKcaNGjcznQPtQkySB6kv3okTueCwj3afv2VsVlZu2Q2NjncvMm8w3/HL67GZ+zv0e9aanvn9v3L8buY3RvLUjNzG++zNAjIZAISkFBJBWfegkjLqaWrNmzXJ8rQYrevHVuxXupI8/9E6JBkTZ3WU7V1t01UAtrz8XvTupSQXd9IKpd1Z09RBNLmROjmS8I6YXwIyr7ASLTtKtE3TrBVQvpG65HXLoKy1/17uNepdR7wR7o8GE3pXUiqSM5dLuydmzCzaUTmzqvlPsy/nJLT33//vf/8yd0pzueLnvxGX+jPny+fL2M7VaSje9E6jv/4UXXjArL7lpElGHVmSeHB4AEFkCHQ8FMo7S61DmhEV210odmq7DrHQ4ok6I7uYt9vG1wqRq1arpE2RnpsMBNSmQsUrKV1oRpdd93fSmlC5IohOWa6Iqu1hDq9z0XIUiltOkx5IlS0yllFa+Z64eChStCNLE0Zo1a7I8p4vk5BSfKe0PnYheJ53PKeGUF+7J4jXJea74z5+/AfIS4+tnQD972VXZA7nFnFJAAGmlkQYHmqTYu3ev19Vm3EurahJD7xTpBTfznTp97MuSt5kvXlrGq8Pw3DSQ0jkbzkXvRmkiTe+OZKYXuTNnzph/Z26TBjXu1fK8lT67aUJF75B6u+gHmvvuW8Y+1X9nXtI2Ozo+XgO9zMsne6N3GnVuDA0+9S5ZdmXvunSz9sFrr73m0aZJkyaZgCin1Rr1zpXOb6VBgbc7ebpCkT/03GsCSIceZqbzKLhX79OgSAMQ9/xibhnf07lon7rL4TN+bnUetsyfH13uW/m6kiUAwJkCHQ/llV6PMl/j9EZj5moTdxIocxLAW/yhSS1v10k9hi9D0LSSRxMjeqMt48/Tqnytaso8XYAvtJI8M3fyJadYTukNV7tiOeVeDfpctG81lvOlj3VV4AULFsiuXbvS92lCTG9w6hxl54qh9POhUzdkprGzt0SRr3ReKv1MPv/88+bGcU7xnz9/A7jlJsbXGO1cN9+B3KBSCgggvSjoMrc6Xl8rPLRSp169eiYo0RJknRDRPemivvapp56SkSNHyo4dO6Rr167mj3O9+6AXkUGDBpkhW77S5IiWh3fr1s0sSasJgIkTJ5q7jueaEFJLo3X+Ja300vbphVCTEVp1NHv2bNM+TUhosk2DGS3xrlSpkrkDo8sSazBzrooWTczoXTidY8E9/1Yw6HA97VvtO0226M/68MMPfS4310nKNTDWu4U5TXau7/3aa681dzt1HgY9txnphdx9Mde+0mFrWoJ9+vRpufTSS83wNV3OV5NZ2ZWxu2kFVsuWLc0wO53EXKunNOmpiURdUlornfLqtttuM3MI6NBDfc96t08DLA3mdL8mKt1DLvT8jx071nzVfRq8a9DmK32t3pXVIE4rxvSuq37W9b3o5zcjrWzTCrvMQ/oAAJEl0PFQXum1Ta+FmqTQaQD02qrXwMxDlDTm0eu2zpGoiQAd3qVxkd5E0YoVnQNI4zCND9555x2vQwQ1ztIhc8OHDzcxgQ7D0uoUbzR20Hl+NAnQv39/c8NIYy+dF0sXZ8ktHVqo1+/OnTubSiyd90gTZxqraKxxrlhO35Nez4NZ1aaxm97we/bZZ03cpDfwNAnna5WWfm50Mnwdfnauyc4feughE8NdeeWVMmTIEJMA0j7XmCu7CfXddLjmv//9bzMNgQ5903mY9CakVnTpMfWGqMaIeaFJIa2y13Nft25d0xbtB41tNV7TPpo/f77ffwO4+Rrj6+dFk1+DBw/O0/sCvPJpjT4AufLrr79aAwcOtKpVq2aWHI6Pj7datGhhvfrqq1mWlv3www+tli1bWkWKFDFbrVq1rMGDB1ubN2/OcalXb0sXf/HFF1a9evXMz6xZs6b17rvvel0ONvPyxurIkSNm6eQLLrjAfH+pUqWs5s2bW88//7x16tQp85rZs2dbHTp0MEsT62uqVKliljpOTEw8Z5/osrG6tPM777zjsd/dvsxLE+uyz7plXjJXl2I+1/LJP/30k9W+fXuraNGi5n3oudDlkzO/zlvfuPd5W+o5I3d7stsyn5uzZ8+aJXS177Xv6tata86Pr7Zt22aWfi5XrpxVoEABq2LFita//vUvc07OtSSz0r7Un+mNnt9nnnnGPB8XF2edd955VpMmTazRo0dbhw8f9liGuH///laxYsXMZ/rGG2+09u3bl+X9ZndO9+/fbz7b+hnXz7oep2nTptYHH3yQpa/Kly9vPfLIIz73DwAg/OR0XcrMl3gou2uZOxZ47rnnPPZnFzt4a5dee0aMGGHihsKFC1sdO3a0tm7d6jVmev31160aNWpY+fLl84gZvvnmG+vyyy+3ChUqZFWoUMF64IEHrM8//zxLXHH06FHr5ptvtooXL26ec8d43mIatXjxYhNH6nETEhKsLl26mFgno+yuve73qsdWS5Yssa677jrTPo1H9GuvXr1M7HouKSkppn+efPLJc/ant/g1u/OkMscSf/zxh9WtWzfTRxov3HDDDdbu3buzvC7z+8u4L3M/ZmfTpk0mvtXzrj/vlltusfbs2WP56r///a+Jm/T8aHxUv359c+61vW7aD507d87yvdl9Rt1++OEHq3v37lbJkiVNjKbH0fhLz2Ne/gbQx/p7lZmvMf7EiRNNPyUnJ/vcP8C5uPQ/3tNVABBYeodP765phRCQHa0i0yWQdbirexJSAABgPx2qphVIWg10rkpvRB6tYNeRBOPGjbO7KYggJKUAhMzOnTtNKbGO1ddhYoA3OkShVatWpmwfAACEDx3eptMIaFLilltusbs5CCFdqVGHI/72229mzlMgUEhKAQAAAAAAIORYfQ8AAAAAAAAhR1IKAAAAAAAAIUdSCgAAAAAAACFHUgoAAAAAAAAhl18iXGpqquzevVvi4+PF5XLZ3RwAABCGdN2XI0eOSIUKFSQmhnt2OSG2AgAAgYqtIj4ppUFT5cqV7W4GAABwgF27dkmlSpXsbkZYI7YCAACBiq0iPimld/HcHZGQkBCUu4VJSUlSunRp7qzmEn3nH/rPP/Rf3tF3/qH/wrP/kpOTTaLFHTcge8RWyIjz5SycL+fhnDkL5yv3sVXEJ6XcZeUaNAUrcDp58qQ5drR/6HKLvvMP/ecf+i/v6Dv/0H/h3X8MRzs3YitkxPlyFs6X83DOnIXzlfvYil4CAAAAAABAyJGUAgAAAAAAQMiRlAIAAAAAAEDIkZQCAAAAAABAyJGUAgAAAAAAQMiRlAIAAAAAAEDIkZQCAAAAAABAyJGUAgAACENjxoyRSy+9VOLj46VMmTLStWtX2bx5s8drTp48KYMHD5aSJUtK0aJFpUePHrJ3794cj2tZljz22GNSvnx5KVSokLRv3162bNkS5HcDAACQFUkpAACAMLRs2TKTcFq1apUsWrRITp8+LR06dJBjx46lv2bYsGEyf/58mTVrlnn97t27pXv37jke99lnn5VXXnlFJk2aJN99950UKVJEOnbsaBJcAAAAoZQ/pD8NAAAAPlm4cKHH42nTppmKqbVr18oVV1whhw8flilTpsj06dOlbdu25jVTp06V2rVrm0TW5Zdf7rVK6qWXXpJHHnlErrvuOrPv7bfflrJly8q8efPkpptuCtG7AwAAICnln0OHxPXMM5Kvc2eRMmXsbg0AAIhgmoRSJUqUMF81OaXVUzr8zq1WrVpSpUoVWblypdek1Pbt22XPnj0e31OsWDFp2rSp+R5vSamUlBSzuSUnJ5uvqampZgu0xx7Tn1FUChcWcbmsgB23XDlL7rpLJF++gB0Sf38ONNkZjM8CAo/z5TycM2fhfP3D1z4gKeWPM2fENXas5L/wQpHmze1uDQAAiODAbujQodKiRQupV6+e2afJpdjYWClevLjHa7XqSZ/zxr1fX+Pr9+jcVqNHj86yPykpKShD/mbOLCkpKbESExPYgH7XrnyybdsxeeihowE9brTTz6YmTPWPsJgYZgYJd5wv5+GcOQvn6x9HjhwRX5CU8sffQWDM33cMAQAAgkHnltq0aZOsWLEi5D975MiRMnz4cI9KqcqVK0vp0qUlISEh4D/v559TJSlpvzl+IAP6556z5MEHi0qbNoWla9eAHTbq6R9gLpcr4OcLwcH5ch7OmbNwvv5RsGBB8QVJKX/kzy9W0aLi+rucHgAAINDuvvtuWbBggSxfvlwqVaqUvr9cuXJy6tQpOXTokEe1lK6+p895496vr9HV9zJ+T6NGjbx+T1xcnNky02A7WAG3BvSBPv4DD4h8/71I374xosVmF10UsENHvWCcLwQP58t5OGfOwvlK4+v7j+5eCoTixSWGpBQAAAgwLf3XhNTcuXPlyy+/lOrVq3s836RJEylQoIAsWbIkfd/mzZtl586d0qxZM6/H1GNoYirj92jlk67Cl933RAqXSyeCF9FcnC5QeJRRfAAA2I6klL+KFxcXw/cAAEAQhuy9++67ZnW9+Ph4M+eTbidOnEifoLx///5maN1XX31lJj7v27evSS5lnORcJz/XxJb77q3OTfXUU0/Jxx9/LBs3bpTevXtLhQoVpGsUjGnT0YZz5ojs2CEyYIAm/uxuEQAA0Y3he/6iUgoAAATBxIkTzdc2bdp47J86darcfvvt5t/jxo0z5fE9evQwK+R17NhRXnvtNY/Xa/WUe+U+9cADD8ixY8dk0KBBZuhfy5YtZeHChT7P/eB0deqkVUzdeKOIFocNGWJ3iwAAiF4kpfxFpRQAAAjS8L1z0UTShAkTzObrcbRa6oknnjBbtLrhBpF77xW57z6Rxo1FWrWyu0UAAEQnhu/5i0opAAAAxxk7VqRFi7SKqcREu1sDAEB0IikViEopklIAAACOkj+/yMyZujpQWuXU6dN2twgAgOhDUioQlVIM3wMAAHCcsmVFZs8W+f77tKF8AAAgtEhK+cmiUgoAAMCxdLLzceNEXnlFZPp0u1sDAEB0ISkViEqpY8dEzpyxuyUAAADIg7vuErn1VpGBA0U2brS7NQAARA+SUv4qXjztK9VSAAAAjuRyiUyeLHLBBSLdu4scOmR3iwAAiA4kpQKVlDp40O6WAAAAII8KFxaZM0ckKUlk0CC7WwMAQHQgKRWopBS31AAAABzt/PNFHn5Y5OOPRVJT7W4NAACRj6SUv0hKAQAARIzatUVSUkQSE+1uCQAAkY+klL/OOy/tK0kpAAAAx6tePe3r9u12twQAgMhHUspfCQli6eyYJKUAAAAiJin12292twQAgMhHUspfMTFixceTlAIAAIiQCc/LlqVSCgCAUCApFQBWQoK4SEoBAABETLUUSSkAAIKPpFQApOpk5ySlAAAAIkKNGgzfAwAg4pNSjz/+uLhcLo+tVq1a6c+fPHlSBg8eLCVLlpSiRYtKjx49ZO/evRJuUhMSSEoBAABECCqlAACIkkqpunXrSmJiYvq2YsWK9OeGDRsm8+fPl1mzZsmyZctk9+7d0r17dwnH4XskpQAAACKnUurPP0VSUuxuCQAAkS2/7Q3In1/KlSuXZf/hw4dlypQpMn36dGnbtq3ZN3XqVKldu7asWrVKLr/8cgkXqcWKiezcaXczAAAAEKBKKcsS+f13kYsusrs1AABELtuTUlu2bJEKFSpIwYIFpVmzZjJmzBipUqWKrF27Vk6fPi3t27dPf60O7dPnVq5cmW1SKiUlxWxuycnJ5mtqaqrZAs0c9+9KqWAcP5Jpf1mWRb/lEf3nH/ov7+g7/9B/4dl/nA9kTkopHcJHUgoAgAhNSjVt2lSmTZsmNWvWNEP3Ro8eLa1atZJNmzbJnj17JDY2VorrJOIZlC1b1jyXHU1q6XEyS0pKMnNUBZoGsQViY6XQX39J0r59AT9+JNO+04o4/eMiJsb2kaSOQ//5h/7LO/rOP/RfePbfkSNHAnYsOF+lSlrNz2TnAABEdFKqU6dO6f9u0KCBSVJVrVpVPvjgAylUqFCejjly5EgZPny4R6VU5cqVpXTp0pKgFU1BCI6PlywpMSdOSJkyZQJ+/EimfaeT2+u54Q+z3KP//EP/5R195x/6Lzz7Tyu2ATdNSFWpwmTnAABE/PC9jLQq6qKLLpKtW7fKVVddJadOnZJDhw55VEvp6nve5qByi4uLM1tmGrgGK/i3ihQROXpUYlwuEd3gM/3DIpjnJtLRf/6h//KOvvMP/Rd+/ce5gLfJzklKAQAQXGEVgR09elS2bdsm5cuXlyZNmkiBAgVkyZIl6c9v3rxZdu7caeaeCidW0aLi0rkoTpywuykAAAAI0LxSDN8DACCCK6Xuu+8+6dKlixmyt3v3bhk1apTky5dPevXqJcWKFZP+/fuboXglSpQwQ+/uuecek5AKp5X30iul1NGjIoUL290cAAAABCApNXu23a0AACCy2Vop9ccff5gElE50fuONN0rJkiVl1apVZp4INW7cOPnXv/4lPXr0kCuuuMIM25szZ46EG4+kFAAAQAAsX77c3LzTVYp1yOK8efM8ntd93rbnnnsu22M+/vjjWV6vqxvD+/C9gwfNAssAACASK6VmzJhxzklHJ0yYYLZwRlIKAAAE2rFjx6Rhw4bSr18/6d69e5bndeXijD777DNTZa4383JSt25dWbx4cfrj/DqrN7xWSimdV+rii+1uDQAAkYkoJABS3UP2SEoBAIAArlKccaXizDIv/PLRRx/JlVdeKTW0xCcHmoTKadEYpHF3I0kpAACiZKJzp0qvlDpyxO6mAACAKKSrE3/yySemUupctmzZYoYEavLqlltuMYvIIKuSJUWKFmWycwAAgolKqQCtvmdQKQUAAGzw1ltvSXx8vNdhfhk1bdpUpk2bZubz1OF/o0ePllatWsmmTZvM93uTkpJiNrfk5GTzNTU11WyBpse0LCsox86t6tVdJimVmmrZ3ZSwFU7nC+fG+XIezpmzcL7+4WsfkJQKAIvhewAAwEZvvvmmqXrS+ThzknE4YIMGDUySSldB/uCDD7KtshozZoxJXmWWlJQkJ0+elGAEsYcPHzZBfUyMvUX9FSoUl19+ccm+fQdtbUc4C6fzhXPjfDkP58xZOF//OOLjSDKSUoEQGytWbKy4SEoBAIAQ+/rrr2Xz5s0yc+bMXH9v8eLF5aKLLpKtW7dm+5qRI0fK8OHDPSqlKleubFZLTkhIkGAE9LoqoB7f7oC+Vi2XLFwoUqZMGVvbEc7C6Xzh3DhfzsM5cxbO1z/OdaPMjaRUoOgQPpJSAAAgxKZMmSJNmjQxK/Xl1tGjR2Xbtm1y2223ZfuauLg4s2WmwXawAm4N6IN5/NxMdr5jh2mRRPnfFo44X/AN58t5OGfOwvlK4+v7j+5eCnRSionOAQBAgGjCaP369WZT27dvN//OODG5Vi3NmjVLBgwY4PUY7dq1k/Hjx6c/vu+++2TZsmWyY8cO+fbbb6Vbt26SL18+6dWrVwjekfNoUkqn00pMtLslAABEJiqlAoVKKQAAEEBr1qyRK6+8Mv2xewhdnz59zGTlasaMGWbeiuySSloFtX///vTHf/zxh3ntgQMHzNCCli1byqpVq8y/kVX16mlft28XqVjR7tYAABB5SEoFiq5YQ1IKAAAESJs2bUzCKSeDBg0yW3a0IiojTWIh90kpXYGvZUu7WwMAQORh+F6gUCkFAAAQUXSB5bJl0yqlAABA4JGUCpQiRUhKAQAARGC1FEkpAACCg6RUoFApBQAAEJGTnevwPQAAEHgkpQKF1fcAAAAiDpVSAAAED0mpQKFSCgAAICIrpf78UyQlxe6WAAAQeUhKBYjF6nsAAAARWSmliyD+/rvdLQEAIPKQlAoUKqUAAAAiMimlGMIHAEDgkZQK9Op7eisNAAAAEaFSJZH8+ZnsHACAYCApFchKqdRUkRMn7G4JAAAAAkQTUlWqUCkFAEAwkJQKZFJKMYQPAAAg4iY7p1IKAIDAIykVKCSlAAAAInZeKSqlAAAIPJJSgaKr7ymSUgAAABGFpBQAAMFBUipQqJQCAACI2OF7Bw+KHDpkd0sAAIgsJKUChaQUAABAxFZKKaqlAAAILJJSgU5KHTlid0sAAAAQ4EopxWTnAAAEFkmpQKFSCgAAICKVLJkW6lEpBQBAYJGUCpTYWJECBUhKAQAARBiXi8nOAQAIBpJSgV6BLznZ7lYAAAAgCEP4GL4HAEBgkZQKpGrVRLZssbsVAAAACDAqpQAACDySUoHUqJHI+vV2twIAAABBqJTasUMkNdXulgAAEDlISgXSxReLbNokcuqU3S0BAABAgCulUlJEEhPtbgkAAJGDpFSgK6VOnxb5+We7WwIAAIAAJ6UUQ/gAAIjApNTYsWPF5XLJ0KFD0/e1adPG7Mu43XHHHRK2GjZMW57lhx/sbgkAAACCkJRisnMAAAInv4SB1atXy+TJk6VBgwZZnhs4cKA88cQT6Y8LFy4sYb363gUXMK8UAABAhNEQtGxZKqUAAIioSqmjR4/KLbfcIq+//rqcd955WZ7XJFS5cuXSt4SEBAn7IXxUSgEAAD8tX75cunTpIhUqVDDV4vPmzfN4/vbbb89SUX711Vef87gTJkyQatWqScGCBaVp06by/fffB/FdRN5k5ySlAACIoEqpwYMHS+fOnaV9+/by1FNPZXn+vffek3fffdckpDQwe/TRR3OslkpJSTGbW3JysvmamppqtkDTY1qW9c+xGzUS1zPPiHXmjEiM7Tm/sJal75Ar9J9/6L+8o+/8Q/+FZ/+F4/k4duyYNGzYUPr16yfdu3f3+hpNQk2dOjX9cVxcXI7HnDlzpgwfPlwmTZpkElIvvfSSdOzYUTZv3ixlypQJ+HuIxCF8DN8DACBCklIzZsyQdevWmeF73tx8881StWpVc4dww4YNMmLECBM0zZkzJ9tjjhkzRkaPHp1lf1JSkpw8eVICTYPYw4cPmwA5JiZG4ipWlPOSkyVp0yZJLVcu4D8vkmTuO+QO/ecf+i/v6Dv/0H/h2X9HjhyRcNOpUyez5USTUHrjzlcvvviimRqhb9++5rEmpz755BN588035cEHH/S7zdGQlFq+3O5WAAAQOWxLSu3atUuGDBkiixYtMuXj3gwaNCj93/Xr15fy5ctLu3btZNu2bXL++ed7/Z6RI0eaO4AZK6UqV64spUuXDsrQPw2OtVxej2+C49q1zf5SWinFHcfc9R1yhf7zD/2Xd/Sdf+i/8Oy/7GKRcLd06VJT4aRTILRt29ZUnZcsWdLra0+dOiVr1641sZKb9qFWq69cuTJ8q9DDSLVqIn/+6ZITJyw5R1Fa1Ajn84WsOF/OwzlzFs7XP3ztA9uSUhoU7du3Txo3bpy+7+zZs2b+hPHjx5vgJ1++fB7fo2XmauvWrdkmpfSOobfSdQ26ghX8a3CcfvyKFdN+3r59DN/Lbd8h1+g//9B/eUff+Yf+C7/+c+K50KF7OqyvevXq5obdQw89ZCqrNMGUOYZS+/fvN7FWWZ2tOwN9/Msvv4RtFXo4Oe+8WLGsErJu3X45//yzdjcnLITz+UJWnC/n4Zw5C+cr91XotiWltOJp48aNHvu0lLxWrVpmmJ63YGr936vaacVU2HJXR+3ZY3dLAABABLvppps8Ksp1FWO9aafVUxpnBYrtVehhxH0vNTm5JAXxDjhfyIrz5TycM2fhfOW+Ct22pFR8fLzUq1fPY1+RIkVMybnu1zt+06dPl2uuucbs0zmlhg0bJldccYUJusJWgQIipUqJJCba3RIAABBFatSoIaVKlTIV5d6SUvqc3vTbu3evx359nNO8VLZXoYeRKlVE8ucX2bFD22Z3a8JHuJ4veMf5ch7OmbNwvtL4+v7DtpdiY2Nl8eLF0qFDB1M9de+990qPHj1k/vz5Eva0kotKKQAAEEJ//PGHHDhwINuKco2tmjRpIkuWLPG4o6uPmzVrFsKWOpcW8mtiavt2u1sCAEBksHX1vcy03NxNy8KXLVsmjqR3G0lKAQAAPxw9etRUPblt377dTGVQokQJs+k8T3rDTquctML8gQcekAsuuEA6duyY/j1aMdWtWze5++67zWMdhtenTx+55JJL5LLLLpOXXnpJjh07lr4aH86tRg2R336zuxUAAESGsEpKRQxNShGtAAAAP6xZs0auvPLK9MfueZ00qTRx4kQztcFbb70lhw4dkgoVKpjq8ieffNJjqJ0mq3SCc7eePXuaCcofe+wx2bNnjzRq1EgWLlyYZfJzZK96dV2wx+5WAAAQGUhKBSsp9e23drcCAAA4WJs2bczqPdn5/PPPz3mMHTt2ZNmnVVPuyinkrVJq9my7WwEAQGQI2zmlHI05pQAAACK2UurgQZFDh+xuCQAAzkdSKliVUseOiRw5YndLAAAAEOCklGKycwAA/EdSKhjcyypTLQUAABBxw/cU04cCAOA/klLB4F6KmaQUAABARClZUqRoUSqlAAAIBJJSwayUSky0uyUAAAAIIJcrrVqKpBQAAP4jKRUMxYqJ6HLMVEoBAABE5LxSDN8DAMB/JKWCdQtNh/BRKQUAABCRSSkqpQAA8B9JqWAO4Zs5U+S220T277e7NQAAAAgQ9/C91FS7WwIAgLORlAqWgQNFqlUTefddke++s7s1AAAACGCl1KlTFMUDAOAvklLB0q+fyIIFaf8+dMju1gAAACCASSnFED4AAPxDUiqYChUSKVCApBQAAEAEJqWY7BwAAP+QlAr2hOfnnSdy8KDdLQEAAECAFC4sUrYslVIAAPiLpFSwFS9OpRQAAEAETnZOpRQAAP4hKRVsJKUAAAAicggflVIAAPiHpFSwkZQCAACIOCSlAADwH0mpYNM5pUhKAQAARNzwvT//FElJsbslAAA4F0mpUFRKMdE5AABAxFVKWZbI77/b3RIAAJyLpFSwMXwPAAAgIiulFEP4AADIO5JSwUZSCgAAIOJUqiSSPz8r8AEA4A+SUqFKSml9NwAAACJCvnwiVapQKQUAgD/y+/Xd8G2i89RUkaNHReLj7W4NAAAAAjiEb8YMkW3bAnvcAgVEHnpIpEGDwB4XAIBwQ1IqFJVSSic7JykFAAAQMQYOFJk6VeT48cAed/NmkS5dRNauFSlVKrDHBgAgnJCUClVSSofwaY03AAAAIsKNN6ZtgbZrl0jjxiI33yzy2WdpQwUBAIhEzCkVyqQUAACAj5YvXy5dunSRChUqiMvlknnz5qU/d/r0aRkxYoTUr19fihQpYl7Tu3dv2b17d47HfPzxx82xMm61atUKwbtBblSunDYscMkSkVGj7G4NAADBQ1IqFHNKKZJSAAAgF44dOyYNGzaUCRMmZHnu+PHjsm7dOnn00UfN1zlz5sjmzZvl2muvPedx69atK4mJienbihUrgvQO4I927USeflrkP/8R+egju1sDAEBwMHwv2IoVS/tKUgoAAORCp06dzOZNsWLFZNGiRR77xo8fL5dddpns3LlTquQwZUD+/PmlXLlyAW8vAu+BB0S++06kd2+RNWtELrzQ7hYBABBYVEoFW1ycSKFCaROdAwAABMnhw4fNcLzi7qkDsrFlyxYz3K9GjRpyyy23mCQWwpPLJTJtmojmELt31+o5u1sEAEBgUSkVChocUikFAACC5OTJk2aOqV69eklCQkK2r2vatKlMmzZNatasaYbujR49Wlq1aiWbNm2S+GxWCU5JSTGbW3JysvmamppqtkDTY1qWFZRjO1HRoiKzZ4s0a+aSAQNE3n3XMsmqcMH5chbOl/NwzpyF8/UPX/uApFSo5pUiKQUAAIJAJz2/8cYbTRA8ceLEHF+bcThggwYNTJKqatWq8sEHH0j//v29fs+YMWNM8iqzpKQkkwwLRhCrVV/6fmJiKOpXpUuLvPhiQfn3v4tL3bpHZMCA4xIuOF/OwvlyHs6Zs3C+/nHkyBFxVFJq7NixMnLkSBkyZIi89NJLZp8GOvfee6/MmDHD3KHr2LGjvPbaa1K2bFlxFCqlAABAEBNSv//+u3z55Zc5Vkl5o0P9LrroItm6dWu2r9H4bPjw4R6VUpUrV5bSpUvn+uf5GtDrMEQ9frQH9BlpldQvv1gyenS8XHFFUWnZUsIC58tZOF/OwzlzFs7XPwoWLCiOSUqtXr1aJk+ebO7YZTRs2DD55JNPZNasWWZCz7vvvlu6d+8u33zzjTgKSSkAABCkhJTOEfXVV19JyZIlc32Mo0ePyrZt2+S2227L9jVxcXFmy0yD7WAF3BrQB/P4TvXMMyJr14r07OmSdetEypeXsMD5chbOl/NwzpyF85XG1/dvey9pMKSTbL7++utyng5z+5uWvE2ZMkVefPFFadu2rTRp0kSmTp0q3377raxatUocl5RionMAAJDLGGn9+vVmU9u3bzf/1onJNSF1/fXXy5o1a+S9996Ts2fPyp49e8x26tSp9GO0a9fOrMrndt9998myZctkx44dJqbq1q2b5MuXz8xFhfBXoIDIzJka6IvceKMmJu1uEQAA/rG9Umrw4MHSuXNnad++vTz11FPp+9euXWsCLt3vVqtWLbPE8cqVK+Xyyy93zGScLk1KffmlyMMPZ3nOKlxYS8K0tk2iDZPA+Yf+8w/9l3f0nX/ov/Dsv3A8H5pwuvLKK9Mfu4fQ9enTRx5//HH5+OOPzeNGjRp5fJ9WTbVp08b8W6ug9u/fn/7cH3/8YRJQBw4cMEMLWrZsaW726b/hDLoS36xZIq1bi9x/v8jfs14AAOBItialdK6odevWmeF7memdvtjY2CzLGut8UvpcdsJxMs6CDRtK0fnzxfX225m/WfLt3i1/XXSRnGrVSqINk8D5h/7zD/2Xd/Sdf+i/8Ow/XyfjDCVNLOn7zE5Oz7lpRVTm2AvO17y5yLhxIvfcoysqilDoBgBwKtuSUrt27TKTmi9atMjnCbB8EZaTcerMlLplduyYSEKCFNdkWZkyEm2YBM4/9J9/6L+8o+/8Q/+FZ/8FMhYBQmHwYBGd0aJvX5EnnrCzJS7p0qWIjB1rZxsAAE5lW1JKh+ft27dPGjdunL5P50NYvny5mfvg888/N3MiHDp0yKNaau/evVJO65YjYTLO+HizxezdmzY5QBRiEjj/0H/+of/yjr7zD/0Xfv3HuYDTuFwikyfr9Bb2Tl26caPI+PFF5KGH0qZRBQDAEUkpnXhzo17FMujbt6+ZN2rEiBGmuqlAgQKyZMkS6dGjh3l+8+bNZnLPZs2aScTQBFsOwxEBAAAAb4oUEXnkEXvbsHOnJdWru2TGDEvuuMPetgAAnMe2pFR8fLzUq1fPY1+RIkXMcsbu/f379zdD8UqUKGGG3t1zzz0mIZXdJOeOpGv5kpQCAACAA1WqJNK2bYq8+WYcSSkAQK6Fda36uHHj5F//+peplLriiivMsL05c+ZIRNFKqcREu1sBAAAA5MnNN5+Q1atd8r//2d0SAIDT2Lr6XmZLly7NMunohAkTzBaxNCm1aZPdrQAAAADypH37FClb1pIpU1zyyit2twYAEHWVUjpB+fr16+WgnbMsOnn4HpVSAABELOIkRLoCBUT69BF55x2REyfsbg0AIOKTUkOHDpUpU6akB1qtW7c2q+jp5OSZq53gQ6WUBqkpKXa3BAAABABxEqJRv36WHDokEmkzbQAAwjApNXv2bGnYsKH59/z582X79u3yyy+/yLBhw+Thhx8OdBsjPyml9u61uyUAACAAiJMQjS68UKRNG5E33rC7JQCAiE9K7d+/30w6rj799FO54YYb5KKLLpJ+/frJxo0bA93GyB++pxjCBwBARCBOQrQaMEDniBXZssXulgAAIjopVbZsWfnpp59MSfrChQvlqquuMvuPHz8u+fLlC3Qbo6NSas8eu1sCAAACgDgJ0ap7d5HixUXefNPulgAAIjop1bdvX7nxxhulXr164nK5pH379mb/d999J7Vq1Qp0GyNbqVIiMTEkpQAAiBDESYhWhQqJ3HqryLRpIqdP290aAIAT5M/LNz3++ONSv3592blzpylJj4uLM/v17t+DDz4Y6DZGNr1jWrYsw/cAAIgQxEmI9iF848eLfPKJSNeudrcGABBxSanTp0/L1VdfLZMmTZIePXp4PNdH14JF3obwUSkFAIDjESch2ukc/5demjbhOUkpAEDAh+8VKFBANmzYkNtvQ05ISgEAEBGIk4C0aqnPPhP54w+7WwIAiMg5pW699VaZMmVK4FsTzSvw6VIlV16ZdevSReTwYbtbCAAAfESchGh3000iBQumzS0FAEDA55Q6c+aMvPnmm7J48WJp0qSJFClSxOP5F198MS+HjV59+4qcPJl1f3KyyIIFIj/9JNKsmR0tAwAAuUSchGiXkCDSs6eI5mYfeihtTR8AAAKWlNq0aZM0btzY/PvXX3/1eE5XmUEutWyZtmX2++9pSamjR+1oFQAAyAPiJCBtCN/UqSJLlohcdZXdrQEARFRS6quvvgp8S5BV0aJpX0lKAQDgGMRJQFqRf+3aaROek5QCAGSHYtpwRlIKAAAADqRFgQMHisydK7J/v92tAQBEVKXUlVdemWP5+ZdffulPm+AWGyuSPz9JKQAAHIQ4CUhz220iI0aIvPOOyLBhdrcGABAxSalGjRp5PD59+rSsX7/ezKHQp0+fQLUNGtBqtdSRI3a3BAAA+Ig4CUhTqpRIt25pQ/iGDk0LbQEA8DspNW7cOK/7H3/8cTlKVU9gxcdTKQUAgIMQJwGeE5536CCyahWLSQMAgjyn1K233mqWQEYAaaUUASwAAI5HnIRo1K6dSLVqIq+/bndLAAARn5RauXKlFCxYMJCHBEkpAAAiQm7jpOXLl0uXLl2kQoUKZo6qefPmeTxvWZY89thjUr58eSlUqJC0b99etmzZcs7jTpgwQapVq2ba0rRpU/n+++/z9H4AX8TEiPTvLzJzpkhyst2tAQBExPC97t27ZwmKEhMTZc2aNfLoo48Gqm1QJKUAAHCUQMVJx44dk4YNG0q/fv2yHFM9++yz8sorr8hbb70l1atXN8fu2LGj/PTTT9kmv2bOnCnDhw+XSZMmmYTUSy+9ZL5n8+bNUqZMmTy8W+Dcbr9dZNQokRkzRAYNsrs1AADHJ6WKFSvm8TgmJkZq1qwpTzzxhHTQQeMIHCY6BwDAUQIVJ3Xq1Mls3miiSxNKjzzyiFx33XVm39tvvy1ly5Y1FVU33XST1+978cUXZeDAgdK3b1/zWJNTn3zyiRlW+OCDD+biXQK+q1RJP89pE56TlAIA+J2Umjp1al6+DXlNSiUm2t0KAAAQRnHS9u3bZc+ePWbIXsZkmFY/6TBBb0mpU6dOydq1a2XkyJEeCTM9hn4PEOwJz3Ulvk8+SZtjCoGluXBN/gFAVCSl1KFDh2T27Nmybds2uf/++6VEiRKybt06c4euYsWKgW1ltK++58P8EAAAIHwEO07ShJTS42Wkj93PZbZ//345e/as1+/55Zdfsv1ZKSkpZnNL/ntioNTUVLMFmh5TK8GCcWyIbedLK6UqVHDJv/7lClnboonLZcmMGZZcf33Or+P3y3k4Z87C+fqHr32Qp6TUhg0bpF27dlK8eHHZsWOHKQPXYGvOnDmyc+dOUz6OAGFOKQAAHCXS4qQxY8bI6NGjs+xPSkqSkydPBiWIPXz4sAnqtZIL4S0352vBghj58898IWtbNJk8uYj06xcr5codkIsuOpvt6/j9ch7OmbNwvv5xxMdpiPKUlNIJMnUuAp1gM14ref52zTXXyM0335yXQyI7JKUAAHCUUMRJ5cqVM1/37t1rVt9z08eNGjXy+j2lSpWSfPnymddkpI/dx/NGh/vpe8pYKVW5cmUpXbq0JCQkSDACel1tUI8f7QG9E+TmfOlc+g0bhqxpUeWKK0SaNXPJv/9dSlatssxgC2/4/XIezpmzcL7+4euKw3lKSq1evVomT56cZb+Wo2dXMo48IikFAICjhCJO0tX2NJG0ZMmS9CSUJou+++47ufPOO71+T2xsrDRp0sR8T9euXdODZ3189913Z/uz4uLizJaZBtvBCrg1oA/m8RFYnC/7aX54zhyRSy8V6d/fJbNm6Xnx/lrOl/NwzpyF85XG1/efp17SwMQ9n0BGv/76q8kIIgir71mW3S0BAAAhjJOOHj0q69evN5t7cnP9tw4B1IB36NCh8tRTT8nHH38sGzdulN69e0uFChXSE05KhxGOHz8+/bFWPL3++uvy1ltvyc8//2wSWMeOHUtfjQ+Ac9WsKfLWWyIffijywgt2twYAJHiVUtdee61Z1viDDz4wjzUw0gBpxIgR0qNHj7wcEjklpc6e1VlGtf7N7tYAAIAQxUlr1qyRK6+8Mv2xewhdnz59ZNq0afLAAw+YhNKgQYPMxOotW7aUhQsXepTL60TrOsG5W8+ePc1cUI899pip2tIqK/2ezJOfA3AmXeHwwQdFRowQadJEJMP/QgAgLLksnYErl3Tiruuvv94ESzp5ld6V08CmWbNm8umnn0qRIkUkXOidSl0iWdscrHkP9u3bJ2XKlAlOed68eWlXl6QknQxCIknQ+y7C0X/+of/yjr7zD/0Xnv0XyHjBSXFSVMZWCCjOV/g5c0bk6qt10QWRdetEKlX65znOl/NwzpyF85X7eCFPlVJ64EWLFsk333wj//vf/0x5eePGjaV9+/Z5ORzOVSmldF6pCEtKAQAQiYiTANgpf36R999Pq5S6/nqRZct0WLHdrQKAACWlTp8+LYUKFTJzGrRo0cJsCFFSCgAAhDXiJADhQKevmz1bpFUrkWHDRF57ze4WAYB3ua4nK1CggFSpUkXO6jxHfpo4caI0aNDAlHLppmXtn332Wfrzbdq0MfMwZNzuuOMOicqklE52DgAAwlog4yQA8Mdll4m8+qr+zZU2AToAhKM8DXJ8+OGH5aGHHpK//vrLrx9eqVIlGTt2rKxdu9bMu9C2bVu57rrr5Mcff0x/zcCBAyUxMTF9e/bZZyWqUCkFAICjBCpOAgB/DRwo0q+fiN7X/+EHu1sDAAGaU0qXFt66dauZuLNq1apZJuxcpzPq+aBLly4ej//zn/+Y6qlVq1ZJ3bp1zb7ChQtLuXLlJGqRlAIAwFECFScBgL9cLv1/ksj69SK6+Of339vdIgAIQFKqa9euEmha5j5r1iyztLEO43N777335N133zWJKU1iPfrooyZRlZ2UlBSzZZzx3T0Lvm6BpsfUBQyDcWyjSBFTzpaq7yNYP8MmQe+7CEf/+Yf+yzv6zj/0X3j2XyCPF4w4CQDyqlAhkQ8/TJv4/LbbXDJlit0tAgA/klJnzpwxczv169fPDL/z18aNG00S6uTJk1K0aFGZO3eu1KlTxzx38803mzuMeqdxw4YNMmLECNm8ebPMmTMn2+ONGTNGRo8enWV/UlKS+RmBpkGsLnGoAXJQlny0LCmbP78c2bNHTuzbJ5Ek6H0X4eg//9B/eUff+Yf+C8/+OxKguRsDHScBQCBUqyYyfbpIp046xDherr5axAmXoNhYkWuu0fn67G4JgGBxWRrV5VJ8fLxJJlXT/7v56dSpU7Jz504TYM6ePVveeOMNWbZsWXpiKqMvv/xS2rVrZ0rizz//fJ8rpSpXriwHDx40k6kHIzjWhFfp0qWD9seFq2RJsUaOFLnvPokkoei7SEb/+Yf+yzv6zj/0X3j2n8YL5513nolH/I0XAhknhSPtq2LFigWkr7I7x/v27ZMyZcrwO+IAnC9nGTs2VUaOdNZ50onao22tq4z4HXMWzlfu44U8Dd/TCck1cRSIYCs2NlYuuOAC8+8mTZrI6tWr5eWXX5bJkydneW3Tpk3N15ySUnFxcWbLTD8QQUsauVxBPb7OK+XSOaUi8EMd9L6LcPSff+i/vKPv/EP/hV//BfJYgYyTACCQHnhA5IYb9kqJEs64MXLLLSJvvBHdSSkg0uUpKdWpUyd58MEHzV1ATSRlnsDz2muv9SuzmLHSKaP1OkOfiJQvX16ibrJzJjoHAMARghknAYC/ihSxpFgxZ9zvHjRI5Lrr0lYOvPhiu1sDIGySUnfddZf5+uKLL3q9e6mTlvti5MiRJnCrUqWKmcth+vTpsnTpUvn8889l27Zt5vE111wjJUuWNHNKDRs2TK644gpp0KCBRBWSUgAAOEag4iQAiHY6n5TWI+jk7LqKIIDIk9/OFWp0rGXv3r0lMTHRjDXUZJMmpK666irZtWuXLF68WF566SWzIp/OC9WjRw955JFHJOrEx5OUAgDAIVhZEQACI39+kdtvF3ntNZHnnktbSRBAZMlV0aZWLekkVW5jx46VQ4cOpT8+cOCA1wnKszNlyhTZsWOHGa6nCSpNQmlCSmkSSudj0GPqqnlbtmyRZ599NigTaoY9KqUAAAh7gY6TAAAi/fuL6P9aZ8+2uyUAbE9KaRVTxvmenn76afnrr788lkHevHlzYFuItKRUgJaqBgAAwUGcBACBp+tbtW2bNuE5gChPSlmWleNjBInORHjggN2tAAAAOSBOAoDgGDBAZPlykV9/tbslAALNAWsuQOrWFfnlF5FTp+xuCQAAAACEVLduIuedlzbhOYAoTkrpijG6Zd6HINP1T0+fFvn5Z7tbAgAAskGcBADBUbCgyG23iUyblvZnEYAoXX1Py9Bvv/12iYuLM491AvI77rhDihQpYh5nnEcBAdSggUa1Ij/8INKwod2tAQAAXhAnAUBwJzx/5RWR+fNFune3uzUAbElK9enTx+PxrbfemuU1vXv39r9V8BQfL3LBBWlJKV0TFQAAhB3iJAAI7n36yy5Lm/CcpBQQpUmpqVOnBq8lOPcQvvXr7W4FAADIBnESAATXwIEigwaJ7NolUrmy3a0BEAhMdO4UjRqlJaVSU+1uCQAAAACEXM+eIoUL600Au1sCIFBISjmpUio5WWT7drtbAgAAAAC2zGpy001pq/CdPWt3awCEfPgebK6UUh06iBQtmvV5HVg9alTImwUAAAAAoTJgQFpSasmStD+NADgbSSmnKFdO5IUXRHbsyPrcmjVpM/6RlAIAAAAQwZo2FalbV+T110lKAZGApJSTDB/uff/MmWl1rPv3i5QqFepWAQAAG1SrVk1+//33LPvvuusumTBhQpb906ZNk759+3rsi4uLk5MnTwa1nQAQSC5X2oTn998vsm+fSJkydrcIgD+YUypS5ptSP/xgd0sAAECIrF69WhITE9O3RYsWmf033HBDtt+TkJDg8T3ekloAEO5uvTUtOfXOO3a3BIC/SEpFggsuSJtnSlfnAwAAUaF06dJSrly59G3BggVy/vnnS+vWrbP9HpfL5fE9ZcuWDWmbASAQSpZMm1JXZzCxLLtbA8AfDN+LBDExIg0bUikFAECUOnXqlLz77rsyfPhwk3jKztGjR6Vq1aqSmpoqjRs3lqefflrq6uQsOUhJSTGbW7KuBixijqFboOkxLcsKyrEReJwvZ4mk89Wvn84pFSMrVqRKixYSsSLpnEUDztc/fO0DklKRtDrfl1/a3QoAAGCDefPmyaFDh+T222/P9jU1a9aUN998Uxo0aCCHDx+W559/Xpo3by4//vijVKpUKdvvGzNmjIwePTrL/qSkpKDMR6VBrLZPg/oYvfGGsMb5cpZIOl+aT69SpZSMH39aLrzwsESqSDpn0YDz9Y8jR46IL0hKRdK8UhMnihw/LlK4sN2tAQAAITRlyhTp1KmTVKhQIdvXNGvWzGxumpCqXbu2TJ48WZ588slsv2/kyJGmAitjpVTlypXN8EGdoyoYAb1We+nxoz2gdwLOl7NE2vnSCc+ffrqgTJoUJ8WKSUSKtHMW6Thf/yhYsKD4gqRUJCWltDxO72RmF5DGxor07i1SpEioWwcAAIJEJytfvHixzJkzJ1ffV6BAAbn44otl69atOb5OV+jTLTMNtoMVcGtAH8zjI7A4X84SSedLh/CNGqWLkbvkjjskYkXSOYsGnK80vr5/klKRQutXL7xQZPx478/rDIAnToiUKCHSs2eoWwcAAIJk6tSpUqZMGencuXOuvu/s2bOyceNGueaaa4LWNgAIJr0Xr//r0wnPIzkpBUSy6E7dRRK9g/nrryLHjmW/6bC+xES7WwoAAAI4TECTUn369JH8+T3vNfbu3dsMvXN74okn5IsvvpDffvtN1q1bJ7feequpshowYIANLQeAwND/ha1dy5pPgFORlIoWuhJPuXIkpQAAiCA6bG/nzp3ST8ewZKL7EzNc9w8ePCgDBw4080hpdZTODfXtt99KnTp1QtxqAAgcLfYsX17n1rO7JQDyguF70USTUnv22N0KAAAQIB06dDAr/HizdOlSj8fjxo0zGwBEEi0S1YVHX31VVwWViFOokEvuvjtGypSxuyVAcJCUiiZ6C4GkFAAAAIAIMniwyIYNIn/9JRFH39cPP5wnK1eyyDoiE0mpaKuU2rLF7lYAAAAAQMBUrCiyYIFEpDVrLGnVKr/83/+lTegORBrmlIomzCkFAAAAAI7RuLHI2LHJMmWKi6QUIhKVUtE2fG//fpHTp0UKFLC7NQAAAACAc+jZ84T89FOCDB7skoYNRS691O4WAYFDpVS0VUrpZKiROAMgAAAAAESol16ypFEjkeuvT6szACIFSaloS0ophvABAAAAgGPExYnMni1y/LhIr14iZ8/a3SIgMEhKRdvwPcUKfAAAAADgKJUri8yYIfLllyKPPWZ3a4DAICkVTUqXFnG5SEoBAAAAgAO1ayfy9NNp20cf2d0awH8kpaKJTm5eqhRJKQAAAABwqAceEOnWTaR3b5Fff7W7NYCDk1ITJ06UBg0aSEJCgtmaNWsmn332WfrzJ0+elMGDB0vJkiWlaNGi0qNHD9m7d6+dTY6MIXzMKQUAAAAAjqSDX6ZNS5syuHt3kWPH7G4R4NCkVKVKlWTs2LGydu1aWbNmjbRt21auu+46+fHHH83zw4YNk/nz58usWbNk2bJlsnv3bumuv3XIO/0/F5VSAAAAAOBYCQkic+aI7NghMmBA2iLrgBPlt/OHd+nSxePxf/7zH1M9tWrVKpOwmjJlikyfPt0kq9TUqVOldu3a5vnLL7/cplZHQFJq2za7WwEAAAAA8EPduiJvvinSs6eI/nk8ZIjdLQIclpTK6OzZs6Yi6tixY2YYn1ZPnT59Wtq3b5/+mlq1akmVKlVk5cqV2SalUlJSzOaWnJxsvqamppot0PSYlmUF5djB4NKk1Ny5IjfemPXJggXFeuYZkbJlQ9IWp/VduKH//EP/5R195x/6Lzz7j/MBAHAi/bPuu+9E7rtPpHFjkVat7G4R4LCk1MaNG00SSueP0nmj5s6dK3Xq1JH169dLbGysFC9e3OP1ZcuWlT05DD8bM2aMjB49Osv+pKQk8zMCTYPYw4cPmwA5Jib8540v0KqVFP3+e5HMc3NZlsR9/bUcbtlSTl57bUja4rS+Czf0n3/ov7yj7/xD/4Vn/x05ciRgxwIAIJTGjhVZs0akc2eRqlXFEfLnF3nqqbQ2I7rZnpSqWbOmSUBpgDl79mzp06ePmT8qr0aOHCnDhw/3qJSqXLmylC5d2kymHozg2OVymeM74o+La65J2zKzLLGKFJGEEyckoUyZkDTFcX0XZug//9B/eUff+Yf+C8/+K1iwYMCOBQBAqBdZnzVLZNw4kePHxRHWrRPp1UtE6yVq1bK7NYjqpJRWQ11wwQXm302aNJHVq1fLyy+/LD179pRTp07JoUOHPKqldPW9cjoELRtxcXFmy0wD12AF/xocB/P4IVOunLi0giqE7yNi+s4m9J9/6L+8o+/8Q/+FX/9xLgAATqZ1BWPGiGNogfJll6WtHqiJqaJF7W4R7BITjndAdU4oTVAVKFBAlixZkv7c5s2bZefOnWa4H4KgfHlW5gMAAAAABFV8fNrqgbt2ifTvz+qB0czWSikdatepUyczebnO5aAr7S1dulQ+//xzKVasmPTv398MxStRooQZenfPPfeYhBQr7wWJVqAlJtrdCgAAAABAhKtdW2TqVJEbbhBp2lQkwyw8iCK2JqX27dsnvXv3lsTERJOEatCggUlIXXXVVeb5cePGmXL6Hj16mOqpjh07ymuvvWZnkyM/KbVqld2tAAAAAABEgeuvT1s58IEHdDofkdat7W4RoiopNWXKlHNOOjphwgSzIQQYvgcAAAAACCGdC0tXD7zxxrQJ0CtWtLtFiOo5pWBzpdS+fSJnz9rdEgAAAABAFMifX2TmzLRVBDUxdeqU3S1CKJGUgmdSKjVVJCnJ7pYAAAAAAKJo9cDZs0VWrxa59167W4NQIikFz6SUYggfAAAAACCEdD2zl18WGT9e5N137W4NQoWkFDznlFIkpQAACHuPP/64uFwuj61WrVo5fs+sWbPMa3Tezvr168unn34asvYCAHAud9wh0ru3yKBBIhs22N0ahAJJKXjWTKrERLtbAgAAfFC3bl2zirF7W7FiRbav/fbbb6VXr17Sv39/+eGHH6Rr165m27RpU0jbDABAdlwukUmTRGrWFOneXeTQIbtbhGAjKYV/xMWJlChBpRQAAA6RP39+KVeuXPpWqlSpbF/78ssvy9VXXy3333+/1K5dW5588klp3LixjNdxEgAAhIlChUQ+/FDkwAGR225Lm/YYkYukFLIO4SMpBQCAI2zZskUqVKggNWrUkFtuuUV27tyZ7WtXrlwp7du399jXsWNHsx8AgHBSo4bIe++JfPKJyNNP290aBFP+oB4dzpzsnOF7AACEvaZNm8q0adOkZs2aZuje6NGjpVWrVmY4Xnx8fJbX79mzR8qWLeuxTx/r/pykpKSYzS05Odl8TU1NNVug6TEtywrKsRF4nC9n4Xw5TzSfs6uvFnnsMZFHH42RUaMsn2ek+flnSxISxBbRfL4y87UPSEoha1Iqh7usAAAgPHTq1Cn93w0aNDBJqqpVq8oHH3xg5o0KlDFjxpiEV2ZJSUly8uRJCUYQe/jwYRPUx8RQ1B/uOF/Owvlynmg/ZzrhecWKcXLw4Lnf+7FjLnniiQT56KND0rHjPzdTQinaz1dGR44cEV+QlELW4XszZ4pUquTb6ytXFtFJVfPlC3bLAABADooXLy4XXXSRbN261evzOufU3r17PfbpY92fk5EjR8rw4cM9KqUqV64spUuXloQg3IrWgF5XEtTjR3tA7wScL2fhfDkP50zE1/ssliUybZol69YVl9tu862yKtA4X//QlX59QVIKnu68U0RL/vU3+lw2bxZ5/32RgwdFcphYFQAABN/Ro0dl27ZtcpvOCutFs2bNZMmSJTJ06ND0fYsWLTL7cxIXF2e2zDTYDlbArQF9MI+PwOJ8OQvny3k4Z75r107kyy/1GuWyrQ2crzS+vn+SUsg6o5wO3PXF0qVpSSldp5OkFAAAIXXfffdJly5dzJC93bt3y6hRoyRfvnzSq1cv83zv3r2lYsWKZvidGjJkiLRu3VpeeOEF6dy5s8yYMUPWrFkj//3vf21+JwAABC4pNXWqVgLrvIl2twa+iO7UHfxTvHjaV01KAQCAkPrjjz9MAkonOr/xxhulZMmSsmrVKjNkQOlKfDoBulvz5s1l+vTpJgnVsGFDmT17tsybN0/q1atn47sAACBw2rZN+6rVUnAGKqWQdySlAACwjVY65WSpVjRncsMNN5gNAIBInSK5Tp20pNTfhcMIc1RKwf+klM4pBQAAAABAGFRLLVlidyvgK5JSyDtdccflolIKAAAAABA280pt3562IfyRlELe6Wz6xYqRlAIAAAAAhIU2bdL+VKVayhlISsH/IXwkpQAAAAAAYfInapMmJKWcgqQU/P+NZ04pAAAAAEAYDeHTyc4ty+6W4FxISsE/VEoBAAAAAMJssvN9+0R+/NHuluBcSErBPySlAAAAAABhpEULkdhYhvA5AUkp+Oe880hKAQAAAADCRuHCIs2bk5RyApJS8A9zSgEAAAAAwnBeqWXLRM6csbslyAlJKfiH4XsAAAAAgDBMSiUni6xda3dLkBOSUvAPSSkAAAAAQJi55BKRokUZwhfuSErB/6TUyZNpGwAAAAAAYaBAAZHWrUlKhTuSUvB/onNFtRQAAAAAIMyG8H3zjciJE3a3BNkhKQX/K6UUSSkAAAAAQJglpVJSRFautLslyA5JKfiHpBQAAAAAIAzVqydSujRD+MIZSSn4h6QUAAAAACAMxcSIXHklSalwZmtSasyYMXLppZdKfHy8lClTRrp27SqbN2/2eE2bNm3E5XJ5bHfccYdtbUYmJKUAAAAAAGE8hG/1apHDh+1uCcIuKbVs2TIZPHiwrFq1ShYtWiSnT5+WDh06yLFjxzxeN3DgQElMTEzfnn32WdvajEx0jc18+UQOHrS7JQAAAAAAZElKpaaKLF9ud0vgTX6x0cKFCz0eT5s2zVRMrV27Vq644or0/YULF5Zy5crZ0EKck8uVVi1FpRQAAAAAIMzUqCFStWraEL4uXexuDcJ6TqnDf9fTlShRwmP/e++9J6VKlZJ69erJyJEj5fjx4za1EF6RlAIAAAAAhGkdhVZLMa9UeLK1Uiqj1NRUGTp0qLRo0cIkn9xuvvlmqVq1qlSoUEE2bNggI0aMMPNOzZkzx+txUlJSzOaWnJycfnzdgtFuy7KCcmyncGlS6r33RNauzd03Wpacd+qUSGysWPp/inAVEyPWM8+INGwo4YTPnn/ov7yj7/xD/4Vn/3E+AACIXG3birz5psjevSJly9rdGoRlUkrnltq0aZOsWLHCY/+gQYPS/12/fn0pX768tGvXTrZt2ybnn3++18nTR48enWV/UlKSnDx5MuDt1iBWK7w0QI7Rqf2jUME+fSTuyy9z/X3aZzqP2NkCBcwE9uEqbvFiOf7WW3L0wQclnPDZ8w/9l3f0nX/ov/DsvyNHjgTsWAAAIPySUkr/bO3Vy+7WIOySUnfffbcsWLBAli9fLpUqVcrxtU2bNjVft27d6jUppcP7hg8f7lEpVblyZSldurQkJCQEJTjWhIoeP2r/uBg8OG3Lyx8WSUlh33eua66RIlu2SOEyZSSc8NnzD/2Xd/Sdf+i/8Oy/ggULBuxYAAAgvJQvL1KnDkmpcGRrUkrvct5zzz0yd+5cWbp0qVSvXv2c37N+/XrzVSumvImLizNbZhq4Biv41+A4mMePZI7ou8aNRd56S1xh2EZH9F8Yo//yjr7zD/0Xfv3HuQAAILLpvFILFtjdCmQWY/eQvXfffVemT58u8fHxsmfPHrOdOHHCPK9D9J588kmzGt+OHTvk448/lt69e5uV+Ro0aGBn0xFNLr5YZPdukX377G4JAAAeUxZceumlJobS1Yu7du1q5t3Mia50rEm9jBtVYgCAaElKbd+etiF82JqUmjhxopkXok2bNqbyyb3NnDnTPB8bGyuLFy+WDh06SK1ateTee++VHj16yPz58+1sNqIxKaX+rtIDACAcLFu2zNzgW7VqlSxatMjM06gx07Fjx3L8Pp3OIDExMX37/fffQ9ZmAADs0rq1WcOKVfjCjO3D93Kic0FpwAXYqkYNkfh4kR9+EOnQwe7WAABgLFy4MEsVlFZMaYW5VpVnR6ujypUrF4IWAgAQPnTR+CZN0uaVGjDA7tYgrCY6B8KaptMbNkxLSgEAEKa0+lyVKFEix9cdPXpUqlataiaNb9y4sTz99NNSt27dbF+fkpJitoyLyCj9ft0CTY+pNy6DcWwEHufLWThfzsM5C6y2bV0ybZrI2bOWBGMBeM7XP3ztA5JSgK9D+D76SOT99yVspKZKQf3DQFeVdPIEvXq3/sor7W4FADg+8Bs6dKi0aNFC6tWrl+3ratasKW+++aaZm1OTWM8//7w0b95cfvzxx2xXQNa5q0aPHp1lf1JSkpw8eVICzazOe/iwCeqZgD78cb6chfPlPJyzwGrcOFaeeaaEfP31AalV60zAj8/5+seRI0fEFySlAF9o0uTVV0VuvlnChf4vrrhEAL1FsXevSOnSdrcEABxL55batGmTrFixIsfXNWvWzGxumpCqXbu2TJ482Swu483IkSNl+PDhHpVSOsVC6dKlzfxUwQjodYihHj/aA3on4Hw5C+fLeThngdW5s85dbcn69SUkh5Huecb5+oevC6mQlAJ80a2biK4KGUZlmPo/vH379pn5Qxz7P7zffhOpXz9tEvmrrrK7NQDgSHfffbcsWLBAli9fnm21U3YKFCggF198sWzdujXb18TFxZktM732BOv6owF9MI+PwOJ8OQvny3k4Z4FTpIjekBH56iuXDB0anJ/B+Urj6/snKQX4KtyWzNYEWeHCaZtT/4dXp84/k8iTlAKAXNGhAffcc4/MnTtXli5dKtWrV8/1Mc6ePSsbN26Ua665JihtBAAg3LRrJ/LccyJnzojkJyNiO4f+JQsgIjCJPAD4NWTv3XfflenTp0t8fLzs2bPHbCe0svdvvXv3NsPv3J544gn54osv5LfffpN169bJrbfeKr///rsMYBkiAEAUJaV0at61a+1uCRRJKQD2atSIpBQA5MHEiRPNZKpt2rSR8uXLp28zZ85Mf83OnTslMTEx/fHBgwdl4MCBZh4prY7S+aG+/fZbqaOVqwAARIFLL00brLFkid0tgaJYDYD9KxtOmCBy7FjaIG8AgM/D985Fh/VlNG7cOLMBABCtdMhe69Yi772n19LAHluPd/RoESlaNG09J7sWN+/Xz76fn1skpQDYn5TS/3tv2KDLQtndGgAAAAAR7tZbRYYMEXnllUAf2SWpqYUlJsaejNDZsyIHDog0aJBWEeYEJKUA2EuHjOjtCh3CR1IKAAAAQJD17Jm2BVpqqiX79iX9vUK6y5akVLVqIm+8QVIKAHyjy4zXqyfyf/8ncu+9IfuxeokoG7KfFlny3Hd9+4q89lrgGwQAAABA8uVLG7r34osiL7wgZhhhuCMpBcB+r78usnJlyOdiOXrkiBSNjxeXUwZch4k89d2HH4p8802wmwYAAABEtb59RZ58UmTWrLR/hzuSUgDsd8klaVsopabK8X37pGiZMiIxLEQa9L47dEhk/PhgtwwAAACIatWqiVx1VdoQPickpfhLDAAQfOXLiyQliZw5Y3dLAAAAgIg2YIDIt9+K/PSThD2SUgCA0KxNq6ss7ttnd0sAAACAiHbttSKlSqVVS4U7klIAgNBUSqk9e+xuCQAAABDxa0n16SPy9tsiKSkS1khKAQBCUymlSEoBAAAAQde/v8iBAyIffSRhjaQUACD4dFJ0XakvMdHulgAAAAARr3ZtkRYtwn8IH0kpAEDwFSiQNrCdSikAAAAgZBOeL1oksn27hC2SUgCA0A3hIykFAAAAhMQNN4gkJIi8+aaELZJSAIDQJaUYvgcAAACERJEiIjffLDJ1qsiZMxKWSEoBAEK3Ah+VUgAAAEBIh/D9+afI559LWCIpBQAIDYbvAQAAACHVuLFIo0bhO+E5SSkAQGiQlAIAAABCyuVKq5aaPz88Q3GSUgCA0A3fO3ZM5MgRu1sCAAAARI2bb05bDPuttyTskJQCAISuUkqF4y0aAAAAIEKdd17aSnw6hM+yJKzkt7sBAIAoS0p9/bVv1VJaa1yvXtptHQAAAAB5pkP43nlHZNkykTZtJGyQlAIAhEalSmkJpv79ff+ep58WGTkymK0CAAAAIl6rViIXXphWLUVSCgAQfYoWFdmyReTAAd9e/3//J7JqVbBbBQAAAETNhOePPSby6qtpQ/rCAUkpAEDoVK2atvmiRQuRGTOC3SIAAAAgKvTpI/LwwyLvvSdy990SFpjoHAAQnho1Etm50/fKKgAAAADZKltW5NprRV5/PXwmPLc1KTVmzBi59NJLJT4+XsqUKSNdu3aVzZs3e7zm5MmTMnjwYClZsqQULVpUevToIXv37rWtzQCAELn44rSv//uf3S0BwtqECROkWrVqUrBgQWnatKl8//33Ob5+1qxZUqtWLfP6+vXry6effhqytgIAAHsNGCCyYYPImjUSFmxNSi1btswknFatWiWLFi2S06dPS4cOHeTYsWPprxk2bJjMnz/fBFD6+t27d0v37t3tbDYAIBR0JsbChUV++MHulgBha+bMmTJ8+HAZNWqUrFu3Tho2bCgdO3aUffv2eX39t99+K7169ZL+/fvLDz/8YG4I6rZp06aQtx0AAIRehw5p6w/phOcS7UmphQsXyu233y5169Y1QdS0adNk586dsnbtWvP84cOHZcqUKfLiiy9K27ZtpUmTJjJ16lQTUGkiCwAQwfLlE2nQgKQUkAONkQYOHCh9+/aVOnXqyKRJk6Rw4cLy5ptven39yy+/LFdffbXcf//9Urt2bXnyySelcePGMn78+JC3HQAA2BNi9+snMn26yNGjYruwmlNKk1CqRIkS5qsmp7R6qn379umv0XLzKlWqyMqVK21rJwAghEP41q+3uxVAWDp16pSJlTLGSTExMeZxdnGS7s/4eqWVVcRVAABEj379RHSA2qxZdrckjFbfS01NlaFDh0qLFi2kXr16Zt+ePXskNjZWihcv7vHasmXLmue8SUlJMZtbcnJy+vF1C0a7LcsKyrEjHX3nH/rPP/SfQ/quQQNxTZr0z/xSEcBlWVLyzBlx5c8vlq7NC981aSKpkyYF5fPnxP8X7N+/X86ePWviooz08S+//OL1ezR+8vb67OIqRWyFnHC+nIXz5TycM2dxyvmqXFnkqqtcZghfnz7BmfHc1z4Im6SUzi2l8xmsWLHC78nTR48enWV/UlKSmTQ9GB2tFV76wdO7k/Adfecf+s8/9J8z+s7VqpUU1dkYT5+WiGFZknLqlMTFxoqQlMqVs1WqyNF9+4Ly+Tty5EjAjhVpiK2QE86Xs3C+nIdz5ixOOl99+sTK2rWxkph41AzpCzRfY6uwSErdfffdsmDBAlm+fLlU0hm3/lauXDlTmn7o0CGPaildfU+f82bkyJFmws+Md/MqV64spUuXloSEhKB86Fwulzl+uH/owg195x/6zz/0n0P6rkwZEa2UirD+S05KkgQ+e3lSOEifP12JzmlKlSol+fLly7IqcU5xku7PzesVsRVywvlyFs6X83DOnMVJ5+umm9I2kcJBOb6vsZWtSSnNHt5zzz0yd+5cWbp0qVSvXt3jeZ3YvECBArJkyRLp0aOH2bd582YzGXqzZs28HjMuLs5smekHIlgfCv3QBfP4kYy+8w/95x/6L+/oO//Qf+HXf048FzrFgcZKGifpCnruYFgf6w0/bzR+0ud1ygQ3XQE5u7hKEVvhXDhfzsL5ch7OmbNwvtL4+v7z2z1kb/r06fLRRx9JfHx8+nwGxYoVk0KFCpmvumSx3p3Tyc/1bpwmsTRwuvzyy+1sOgAAgO00RurTp49ccsklctlll8lLL70kx44dM6vxqd69e0vFihXNEDw1ZMgQad26tbzwwgvSuXNnmTFjhqxZs0b++9//2vxOAABANLI1KTVx4kTztU2bNh77p06dKrfffrv597hx40yGTSuldJJNXSHmtddes6W9AAAA4aRnz55mbqfHHnvM3Nxr1KiRLFy4MH0yc60uz3insnnz5uaG4COPPCIPPfSQXHjhhTJv3rz0RWYAAABCyfbhe76MQ5wwYYLZAAAA4EmH6mU3XE+nR8jshhtuMBsAAIDdonuQIwAAAAAAAGxBUgoAAAAAAAAhR1IKAAAAAAAAIUdSCgAAAAAAACFHUgoAAAAAAAAhR1IKAAAAAAAAIUdSCgAAAAAAACGXXyKcZVnma3JyclCOn5qaKkeOHJGCBQtKTAw5vtyg7/xD//mH/ss7+s4/9F949p87TnDHDcgesRUy4nw5C+fLeThnzsL5yn1sFfFJKf1AqMqVK9vdFAAAEOY0bihWrJjdzQhrxFYAACBQsZXLivBbgpqp3L17t8THx4vL5QpK9k+Dsl27dklCQkLAjx/J6Dv/0H/+of/yjr7zD/0Xnv2n4ZAGTRUqVIj6O5vnQmyFjDhfzsL5ch7OmbNwvnIfW0V8pZS++UqVKgX95+gHLto/dHlF3/mH/vMP/Zd39J1/6L/w6z8qpHxDbAVvOF/OwvlyHs6Zs3C+fI+tuBUIAAAAAACAkCMpBQAAAAAAgJAjKeWnuLg4GTVqlPmK3KHv/EP/+Yf+yzv6zj/0n3/ov8jHOXYWzpezcL6ch3PmLJyv3Iv4ic4BAAAAAAAQfqiUAgAAAAAAQMiRlAIAAAAAAEDIkZQCAAAAAABAyJGU8sOECROkWrVqUrBgQWnatKl8//33djcpLD3++OPicrk8tlq1aqU/f/LkSRk8eLCULFlSihYtKj169JC9e/dKNFq+fLl06dJFKlSoYPpp3rx5Hs/rFHCPPfaYlC9fXgoVKiTt27eXLVu2eLzmr7/+kltuuUUSEhKkePHi0r9/fzl69KhEg3P13+23357ls3j11Vd7vCZa+2/MmDFy6aWXSnx8vJQpU0a6du0qmzdv9niNL7+rO3fulM6dO0vhwoXNce6//345c+aMRDpf+q9NmzZZPn933HGHx2uitf8mTpwoDRo0ML93ujVr1kw+++yz9Of57EUPYqvIjlHgvOs6nHMdhH3Gjh1r/r84dOjQ9H2cM9+RlMqjmTNnyvDhw83M+uvWrZOGDRtKx44dZd++fXY3LSzVrVtXEhMT07cVK1akPzds2DCZP3++zJo1S5YtWya7d++W7t27SzQ6duyY+SxpUO7Ns88+K6+88opMmjRJvvvuOylSpIj53On/9Nw0ofLjjz/KokWLZMGCBSaIHDRokESDc/Wf0iRUxs/i+++/7/F8tPaf/u7phXPVqlXmvZ8+fVo6dOhg+tTX39WzZ8+apMCpU6fk22+/lbfeekumTZtm/kiJdL70nxo4cKDH509/p92iuf8qVapkArq1a9fKmjVrpG3btnLdddeZ30XFZy86EFtFfowCZ13X4ZzrIOyzevVqmTx5skkqZsQ5ywVdfQ+5d9lll1mDBw9Of3z27FmrQoUK1pgxY2xtVzgaNWqU1bBhQ6/PHTp0yCpQoIA1a9as9H0///yzrghprVy50opm2gdz585Nf5yammqVK1fOeu655zz6Ly4uznr//ffN459++sl83+rVq9Nf89lnn1kul8v6888/rWjuP9WnTx/ruuuuy/Z76L9/7Nu3z/TFsmXLfP5d/fTTT62YmBhrz5496a+ZOHGilZCQYKWkpFjR3H+qdevW1pAhQ7L9HvrP03nnnWe98cYbfPaiCLFVZMcocN51Hc65DsIeR44csS688EJr0aJFHnEe5yx3qJTKA70Tq1lsLUt2i4mJMY9Xrlxpa9vClZZva7l3jRo1TCWKDrNQ2o965yZjX+rQvipVqtCXmWzfvl327Nnj0VfFihUzwxvcfaVfdcjZJZdckv4afb1+PvWuJUSWLl1qythr1qwpd955pxw4cCD9OfrvH4cPHzZfS5Qo4fPvqn6tX7++lC1bNv01epc8OTk5/U5ftPaf23vvvSelSpWSevXqyciRI+X48ePpz9F//1Q9zZgxw9zN1+ELfPaiA7FV5McocN51Hc65DsIeWo2oldoZz43inOVO/ly+HiKyf/9+8z+LjMGv0se//PKLbe0KVxqQ6DAKTQLocJXRo0dLq1atZNOmTSaAiY2NNYmAzH2pz+Ef7v7w9rlzP6dfNeGSUf78+U0AQn+mDd3Tstnq1avLtm3b5KGHHpJOnTqZi0O+fPnov7+lpqaaMfEtWrQwyRPly++qfvX2+XQ/F839p26++WapWrWqSdBv2LBBRowYYeb3mDNnjnk+2vtv48aNJvjWoT4698LcuXOlTp06sn79ej57UYDYKvJjFDjvug7nXAcRepo41KHmOnwvM36/coekFIJO/+h307G2mqTSP8w++OADMxEmECo33XRT+r+1qkI/j+eff76pnmrXrp2tbQu3uz6aNM449xv877+Mc5Pp508nA9bPnSZI9XMY7fTGhQbeejd/9uzZ0qdPHzMHAwDAP1zXnYHroHPs2rVLhgwZYuZr04U54B+G7+WBDr3QqorMs+fr43LlytnWLqfQjPFFF10kW7duNf2lJfuHDh3yeA19mZW7P3L63OnXzBPC6upTuqIc/ZmVDifV32f9LCr6T+Tuu+82E7x/9dVXZtJNN19+V/Wrt8+n+7lo7j9vNEGvMn7+orn/9I7iBRdcIE2aNDGrRumEyi+//DKfvShBbBX5MQqcd12Hc66DCC0dnqd/MzRu3NiMqtBNE4i62IP+WyuiOGe+IymVx/9h6P8slixZ4lEWq4+15BI5O3r0qKkM0CoB7ccCBQp49KUOZ9E5p+hLTzrkTP8nlrGvdL4UnevI3Vf6Vf/np/+jdPvyyy/N59P9BzD+8ccff5g5pfSzGO39p/PWauCqpeL6nvXzlpEvv6v6VUvPMyb29A6SLm2s5efR3H/e6N1QlfHzF639543+3qWkpPDZixLEVpEfo8B513U45zqI0NJKd407NJZzbzonrc6d7P435ywXcjkxOv42Y8YMs6LItGnTzIpdgwYNsooXL+6x8g/S3HvvvdbSpUut7du3W998843Vvn17q1SpUmYVEHXHHXdYVapUsb788ktrzZo1VrNmzcwWrSs4/PDDD2bTX88XX3zR/Pv33383z48dO9Z8zj766CNrw4YNZiW56tWrWydOnEg/xtVXX21dfPHF1nfffWetWLHCrAjRq1cvK9r7T5+77777zIoX+llcvHix1bhxY9M/J0+etKK9/+68806rWLFi5nc1MTExfTt+/Hj6a871u3rmzBmrXr16VocOHaz169dbCxcutEqXLm2NHDnSivb+27p1q/XEE0+YftPPn/4O16hRw7riiivSjxHN/ffggw+aFaG0b/T/bfpYV7384osvzPN89qIDsVXkxyhw1nUdzrkOwn6ZV1nmnPmOpJQfXn31VfNBi42NNcsYr1q1yu4mhaWePXta5cuXN/1UsWJF81j/QHPTYOWuu+4yy54WLlzY6tatm7loRqOvvvrKBHqZtz59+qQvufzoo49aZcuWNYF7u3btrM2bN3sc48CBAyaJUrRoUbMcet++fU0gGe39p0GY/sGqf6jqEq1Vq1a1Bg4cmOWPnWjtP2/9ptvUqVNz9bu6Y8cOq1OnTlahQoVM8lmT0qdPn7aivf927txpElAlSpQwv7sXXHCBdf/991uHDx/2OE609l+/fv3M76ReJ/R3VP/f5g7EFZ+96EFsFdkxCpx3XYdzroMIr6QU58x3Lv1PbiqrAAAAAAAAAH8xpxQAAAAAAABCjqQUAAAAAAAAQo6kFAAAAAAAAEKOpBQAAAAAAABCjqQUAAAAAAAAQo6kFAAAAAAAAEKOpBQAAAAAAABCjqQUAAAAAAAAQo6kFAD4Ydq0aVK8eHG7mwEAABARiK2A6EJSCkBI7NmzR4YMGSIXXHCBFCxYUMqWLSstWrSQiRMnyvHjx8UJqlWrJi+99JLHvp49e8qvv/5qW5sAAEB0IrYCEAny290AAJHvt99+M0GS3vV6+umnpX79+hIXFycbN26U//73v1KxYkW59tprbWmbZVly9uxZyZ8/b/87LFSokNkAAABChdgKQKSgUgpA0N11110mMFmzZo3ceOONUrt2balRo4Zcd9118sknn0iXLl3M6w4dOiQDBgyQ0qVLS0JCgrRt21b+97//pR/n8ccfl0aNGsk777xj7qwVK1ZMbrrpJjly5Ej6a1JTU2XMmDFSvXp1E9A0bNhQZs+enf780qVLxeVyyWeffSZNmjQxAdyKFStk27Ztpj16l7Fo0aJy6aWXyuLFi9O/r02bNvL777/LsGHDzPfrll2Jud6hPP/88yU2NlZq1qxp2puRfu8bb7wh3bp1k8KFC8uFF14oH3/8cRB6HgAARCJiK2IrIFKQlAIQVAcOHJAvvvhCBg8eLEWKFPH6GncQcsMNN8i+fftMULN27Vpp3LixtGvXTv7666/012qAM2/ePFmwYIHZli1bJmPHjk1/XoOmt99+WyZNmiQ//vijCXRuvfVW87qMHnzwQfN9P//8szRo0ECOHj0q11xzjSxZskR++OEHufrqq01At3PnTvP6OXPmSKVKleSJJ56QxMREs3kzd+5cU0p/7733yqZNm+Tf//639O3bV7766iuP140ePdoEkRs2bDA/95ZbbvF4nwAAAN4QWxFbARHFAoAgWrVqlaX/q5kzZ47H/pIlS1pFihQx2wMPPGB9/fXXVkJCgnXy5EmP151//vnW5MmTzb9HjRplFS5c2EpOTk5//v7777eaNm1q/q3fq89/++23Hsfo37+/1atXL/Pvr776yrRn3rx552x73bp1rVdffTX9cdWqVa1x48Z5vGbq1KlWsWLF0h83b97cGjhwoMdrbrjhBuuaa65Jf6w//5FHHkl/fPToUbPvs88+O2ebAABAdCO2IrYCIglzSgGwxffff2/KwfUuVkpKiikl1ztqJUuW9HjdiRMnzB08Ny0tj4+PT39cvnx5cwdQbd261UzsedVVV3kc49SpU3LxxRd77Lvkkks8HuvP1hJ2LXnXO3VnzpwxP9t9N89Xendw0KBBHvt0zoeXX37ZY5/eQXTTu5xaUu9+HwAAALlFbEVsBTgRSSkAQaUrwmgJ+ebNmz3267wHyj2RpQYuGgTpvASZZZxXoECBAh7P6bE1AHMfQ2nwoxN8ZqTzG2SUudz9vvvuk0WLFsnzzz9v2qztuv76603QFQw5vQ8AAIDsEFt5R2wFOBNJKQBBpXfn9O7a+PHj5Z577sl27gOd40CXNtZJO/WOXV7UqVPHBEh6B65169a5+t5vvvlGbr/9djNBpjsI27Fjh8drdHJNXU0mJzrRqB6rT58+HsfWtgEAAPiL2IrYCogkJKUABN1rr71myqy1rFvLuLW8OiYmRlavXi2//PKLWamlffv20qxZM+natas8++yzctFFF8nu3bvNnTkNZjKXhHujped6V04n4NQ7Yy1btpTDhw+bwEVLuDMGM5npKi064aZOwKl31h599NEsd9c0oFu+fLlZlUYDtFKlSmU5zv33328m2dSSdn1P8+fPN8fNuNoMAACAP4itiK2ASEFSCkDQ6RK+uurK008/LSNHjpQ//vjDBB56h0sDHV3WWIOVTz/9VB5++GGzokpSUpKUK1dOrrjiCrOUsK+efPJJs+yxrhTz22+/mfJ0vVP40EMP5fh9L774ovTr10+aN29uAqIRI0ZIcnKyx2t0dRhd8UXfj87VkDavpicN/HSOAy1V15VidPnkqVOnmmWPAQAAAoHYitgKiBQune3c7kYAAAAAAAAgusTY3QAAAAAAAABEH5JSAAAAAAAACDmSUgAAAAAAAAg5klIAAAAAAAAIOZJSAAAAAAAACDmSUgAAAAAAAAg5klIAAAAAAAAIOZJSAAAAAAAACDmSUgAAAAAAAAg5klIAAAAAAAAIOZJSAAAAAAAACDmSUgAAAAAAAJBQ+3+9ibQawIes7QAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1200x400 with 2 Axes>"
       ]
@@ -997,10 +997,10 @@
    "id": "9b146a0d",
    "metadata": {
     "papermill": {
-     "duration": 0.004628,
-     "end_time": "2026-04-25T14:59:40.190063",
+     "duration": 0.008629,
+     "end_time": "2026-05-14T07:41:51.654590+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:40.185435",
+     "start_time": "2026-05-14T07:41:51.645961+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1034,10 +1034,10 @@
    "id": "cell-10",
    "metadata": {
     "papermill": {
-     "duration": 0.004131,
-     "end_time": "2026-04-25T14:59:40.198455",
+     "duration": 0.0076,
+     "end_time": "2026-05-14T07:41:51.670531+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:40.194324",
+     "start_time": "2026-05-14T07:41:51.662931+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1056,16 +1056,16 @@
      "start_time": "2026-04-20T09:34:33.864091482Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:59:40.209359Z",
-     "iopub.status.busy": "2026-04-25T14:59:40.208621Z",
-     "iopub.status.idle": "2026-04-25T15:00:47.468158Z",
-     "shell.execute_reply": "2026-04-25T15:00:47.467446Z"
+     "iopub.execute_input": "2026-05-14T07:41:51.689257Z",
+     "iopub.status.busy": "2026-05-14T07:41:51.688920Z",
+     "iopub.status.idle": "2026-05-14T07:43:52.855674Z",
+     "shell.execute_reply": "2026-05-14T07:43:52.854583Z"
     },
     "papermill": {
-     "duration": 67.269508,
-     "end_time": "2026-04-25T15:00:47.472058",
+     "duration": 121.185325,
+     "end_time": "2026-05-14T07:43:52.864027+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:59:40.202550",
+     "start_time": "2026-05-14T07:41:51.678702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1092,7 +1092,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK, 1.49s, 27 gen\n",
+      "  Puzzle 1: OK, 3.71s, 25 gen\n",
       "Ligne 0: 720 permutations valides\n",
       "Ligne 1: 120 permutations valides\n",
       "Ligne 2: 120 permutations valides\n",
@@ -1108,7 +1108,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 2: 2 err, 32.61s, 500 gen\n"
+      "  Puzzle 2: 8 err, 58.24s, 500 gen\n"
      ]
     },
     {
@@ -1130,20 +1130,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 3: 8 err, 33.15s, 500 gen\n",
+      "  Puzzle 3: 8 err, 59.20s, 500 gen\n",
       "\n",
       "Resume:\n",
       "  Resolus: 1/3\n",
-      "  Temps total: 67.25s\n",
-      "  Temps moyen: 22.42s\n"
+      "  Temps total: 121.15s\n",
+      "  Temps moyen: 40.38s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'solved': True, 'errors': 0, 'time': 1.4853582382202148},\n",
-       " {'solved': False, 'errors': 2, 'time': 32.61489272117615},\n",
-       " {'solved': False, 'errors': 8, 'time': 33.147849321365356}]"
+       "[{'solved': True, 'errors': 0, 'time': 3.7093634605407715},\n",
+       " {'solved': False, 'errors': 8, 'time': 58.24074077606201},\n",
+       " {'solved': False, 'errors': 8, 'time': 59.201672077178955}]"
       ]
      },
      "execution_count": 7,
@@ -1198,10 +1198,10 @@
    "id": "2iay85cksiv",
    "metadata": {
     "papermill": {
-     "duration": 0.00399,
-     "end_time": "2026-04-25T15:00:47.480328",
+     "duration": 0.004869,
+     "end_time": "2026-05-14T07:43:52.875214+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:47.476338",
+     "start_time": "2026-05-14T07:43:52.870345+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1239,10 +1239,10 @@
    "id": "cell-12",
    "metadata": {
     "papermill": {
-     "duration": 0.004685,
-     "end_time": "2026-04-25T15:00:47.489025",
+     "duration": 0.006136,
+     "end_time": "2026-05-14T07:43:52.887487+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:47.484340",
+     "start_time": "2026-05-14T07:43:52.881351+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1279,10 +1279,10 @@
    "id": "cgxbmeh06jj",
    "metadata": {
     "papermill": {
-     "duration": 0.004288,
-     "end_time": "2026-04-25T15:00:47.497566",
+     "duration": 0.00529,
+     "end_time": "2026-05-14T07:43:52.897649+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:47.493278",
+     "start_time": "2026-05-14T07:43:52.892359+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1318,16 +1318,16 @@
      "start_time": "2026-04-20T09:35:04.249735249Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:00:47.518111Z",
-     "iopub.status.busy": "2026-04-25T15:00:47.517785Z",
-     "iopub.status.idle": "2026-04-25T15:00:50.227684Z",
-     "shell.execute_reply": "2026-04-25T15:00:50.227011Z"
+     "iopub.execute_input": "2026-05-14T07:43:52.912572Z",
+     "iopub.status.busy": "2026-05-14T07:43:52.911889Z",
+     "iopub.status.idle": "2026-05-14T07:43:57.897503Z",
+     "shell.execute_reply": "2026-05-14T07:43:57.894876Z"
     },
     "papermill": {
-     "duration": 2.727099,
-     "end_time": "2026-04-25T15:00:50.228987",
+     "duration": 4.997331,
+     "end_time": "2026-05-14T07:43:57.899713+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:47.501888",
+     "start_time": "2026-05-14T07:43:52.902382+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1359,7 +1359,7 @@
      "text": [
       "\n",
       "Resolu: True, Erreurs: 0\n",
-      "Generations: 50\n",
+      "Generations: 33\n",
       "\n",
       "Resultat:\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
@@ -1506,10 +1506,10 @@
    "id": "3e498c55",
    "metadata": {
     "papermill": {
-     "duration": 0.004534,
-     "end_time": "2026-04-25T15:00:50.238185",
+     "duration": 0.007856,
+     "end_time": "2026-05-14T07:43:57.920353+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:50.233651",
+     "start_time": "2026-05-14T07:43:57.912497+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1543,16 +1543,16 @@
    "id": "0b83e933",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:00:50.248702Z",
-     "iopub.status.busy": "2026-04-25T15:00:50.248317Z",
-     "iopub.status.idle": "2026-04-25T15:00:55.858878Z",
-     "shell.execute_reply": "2026-04-25T15:00:55.857899Z"
+     "iopub.execute_input": "2026-05-14T07:43:57.933070Z",
+     "iopub.status.busy": "2026-05-14T07:43:57.932416Z",
+     "iopub.status.idle": "2026-05-14T07:43:57.940310Z",
+     "shell.execute_reply": "2026-05-14T07:43:57.939221Z"
     },
     "papermill": {
-     "duration": 5.617395,
-     "end_time": "2026-04-25T15:00:55.860017",
+     "duration": 0.015598,
+     "end_time": "2026-05-14T07:43:57.941124+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:50.242622",
+     "start_time": "2026-05-14T07:43:57.925526+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1562,35 +1562,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Comparaison SinglePoint vs Uniforme ===\n",
-      "Ligne 0: 24 permutations valides\n",
-      "Ligne 1: 24 permutations valides\n",
-      "Ligne 2: 24 permutations valides\n",
-      "Ligne 3: 24 permutations valides\n",
-      "Ligne 4: 24 permutations valides\n",
-      "Ligne 5: 24 permutations valides\n",
-      "Ligne 6: 24 permutations valides\n",
-      "Ligne 7: 24 permutations valides\n",
-      "Ligne 8: 24 permutations valides\n"
+      "Exercice a completer - implementez uniform_crossover et UniformCrossoverSolver.solve\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SinglePoint  : resolu=True, erreurs=0, temps=3.06s, generations=59\n",
-      "Uniforme     : resolu=True, erreurs=0, temps=2.34s, generations=43\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAHqCAYAAAB/bWzAAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAc7FJREFUeJzt3QeYVOX1x/HfzHYWlr4sSO8KghQLgnREQLDFFo2oiCaWWBILJtYY0ZhYkhgjauCviYklakBApQkWUGkKKB1Eemd3ga1z/897h113YdnGzNx7Z76f5xnn7szszJl57+K5Z957Xp9lWZYAAAAAAAAAAK7gdzoAAAAAAAAAAMCPKNoCAAAAAAAAgItQtAUAAAAAAAAAF6FoCwAAAAAAAAAuQtEWAAAAAAAAAFyEoi0AAAAAAAAAuAhFWwAAAAAAAABwEYq2AAAAAAAAAOAiFG0BAAAAAAAAwEUo2gJwhZYtW+raa68N62t8/PHH8vl89nUsfw4AAADwFi/ksdFq48aN9mc/adKkUrd/8MEHOu2005ScnGzfv3//fsdiBBCdKNoCCKtly5bpJz/5iVq0aGEnNCeddJKGDBmiv/zlL4oGDz/8sJ2kFV1q1KihU045Rb/97W+VmZkZ0Vj+9re/HZNMViQnJ0fPPPOMzjzzTNWuXdseo/bt2+vWW2/V6tWrwxYrAABANFi3bp1uuukmtW7d2s6j0tLS1Lt3bz333HM6fPiw0+F52uuvv65nn3220o83ubjJYcvy9ttvh7TovWfPHl122WVKSUnR888/r9dee02pqakheW4AKBJfvAUAIfb5559rwIABat68ucaOHauMjAz98MMPWrBggZ3I3nbbbcWPXbVqlfx+736P9MILL6hmzZrKzs7WRx99pN///veaPXu2PvvsMztBrKwT+RxM0bZBgwaVnqm7e/dunXfeeVq0aJHOP/98/fSnP7Xfg4nhP//5jyZMmKC8vLxqxQIAABDtpk6dqksvvVRJSUm65ppr1LlzZzt3+vTTT3X33XdrxYoVdj4VCn379rWLwImJiYqlou3y5ct1xx13OBqHmXxiPvuEhITi27766itlZWXpd7/7nQYPHuxofACiF0VbAGFjCpdm9qZJaurUqVPqvp07d5b62SS7XmZmE5uCqfHzn/9cl1xyid555x27QN2rV69KP08kPwdT3F2yZIk988DEW5JJQH/zm9+U+/sHDx6M6RkFZpayOXDy8pcNAACgejZs2KArrrjCLuiZL+obN25cfN8tt9yitWvX2kXd4wkEAnaB18zOrQyTb1T2sQgtMwHj6M++6Fjm6GOcExHruTWAY3GkCSCsp4t16tSpzGQmPT293F6u5jR/kyCZmap33XWXGjZsaCcxF110kXbt2nVM0mvaFDRp0sRuT2Bm93777beV7g/7xRdf2DNOTYHZ/H6/fv3s1z0RAwcOLE7oi5KwX/3qV2rWrJldmO3QoYP++Mc/yrKskHwO5vfMbI65c+cWt2ro379/ue/ZHEiMGTPmmIKtYWI08RUxMZlZuGZMhw8frlq1aumqq66q0nubMWOG+vTpY+8P5rnM4+6///5SjzFtM8w+Y8ahbt266tmzpz3LoiRTaB42bJh9+qF5nkGDBtnF8SILFy603////d//HfO+PvzwQ/u+999/v/i2LVu26Prrr1ejRo3s+M3r/+Mf/yizj5yZgWxaX5g2HybGSLfAAAAA7vCHP/zBPsPqlVdeKVWwLdK2bVvdfvvtx5y6/69//cvONUzOYXqiVia3OV5P2zVr1th5nDmbzRQVmzZtaheSDxw4UOp3//nPf6pHjx72qfz16tWzH2POfivJ5I1mpvA333xj58ImzzHvwXy5b5gc07TTMs9hcriZM2ce856rklO9+eab9gQPE7OJ3bxnU+guGY/JVb///vvi3Nbku6FU9J7NcYM5fjDv2eR4ZmzL62lrfm/06NH29umnn27fVzJ/f+utt4o/bzOp4+qrr7Y/m5LKy62L9hXzPKbtmnkeMwnEtJ0zXnzxRXtszOdmYjHxReL4BkDkMdMWQNiYmQfz58+3T2syCVF1mBYKpnj30EMP2QmJ6Wtlkpg33nij+DHjxo2zk6uRI0dq6NCh+vrrr+1rMxOyImZmhEmSTWJlXsPMYpg4caJddP3kk090xhlnVCtuk4AZ9evXt4uXo0aN0pw5c+wiqVmwwBQPzWlzJoEzPWVP9HMwP5vHmOSvaIasSZiPZ/Lkyfb1z372s0q/p4KCAvtzNYVXU5Q1CWBl35spKJsWDF26dNGjjz5qJ/ImMS+ZPL700kv65S9/ac9aNgc5ZvzMgYNJOk3rhqLnOeecc+yDmnvuucc+Tc0kriZhLTqYMIVe01fOHAwUJdRFzOdlPkfzPowdO3borLPOKk6OTVF8+vTp9nsxBdmjT8czM5DN7Npf//rXys3NjalTFAEAwI+mTJli5xtnn312pX/H5J0mPzE5hynmFX3pXlFuUxYzS9fkMyYfMTmgKdya3Mt8MW0WxDLFOsMURh944AG7/+oNN9xgf+lvviQ37RZMsbjk5Ip9+/bZ+Zop6pq2D6b9l9k2hWaTE5mzyUxO9tRTT9n5min8mmJjdXKqJ554ws67TU5liswmlzdFS5P3GSafNbdv3ry5OJ80eW6omfdsipsXX3yx/RmZIvW9996rU0891T5GKIuJzRSuTesLk9e2atVKbdq0se8zhd3rrrvOLuaOHz/e/lxMWziT8x79eZeVWxcxxyEmXzeztg3zXGZszD5iWqLdfPPNduzmczOFcrNvhfv4BoADLAAIk48++siKi4uzL7169bLuuece68MPP7Ty8vKOeWyLFi2s0aNHF/88ceJEM03TGjx4sBUIBIpvv/POO+3n279/v/3z9u3brfj4eOvCCy8s9XwPP/yw/fsln3POnDn2bebaMM/brl07a+jQoaVe49ChQ1arVq2sIUOGVPgeH3roIfs5V61aZe3atcvasGGD9eKLL1pJSUlWo0aNrIMHD1rvvfee/ZjHHnus1O/+5Cc/sXw+n7V27doT/hyMTp06Wf369bMq46KLLrKfd9++fZV6vInJPP6+++4rdXtl39szzzxjP858RsdzwQUX2O+hPGacExMTrXXr1hXftnXrVqtWrVpW3759i28bN26clZCQYO3du7f4ttzcXKtOnTrW9ddfX3zbmDFjrMaNG1u7d+8u9TpXXHGFVbt2bXtfKLnvtG7duvg2AAAQmw4cOGDnBSZ3qSzzeL/fb61YsaJauc3ReeySJUvsn996663jvubGjRvtfPH3v/99qduXLVtm588lbzc5pHm+119/vfi2lStXFse9YMGC4ttNPm9uN3lqdXOqk08+2c7Nijz33HP27Sa2IiNGjLBz48oyv3/LLbeUeZ/5nEp+fiXf86uvvlp8m4kpIyPDuuSSS4pvM/n90e+3KEf/6quvim8zxzjp6elW586drcOHDxff/v7779uPffDBByvMrYvehzmWMK9bxBxfmNtNbJmZmaVyXnN70WNDcXwDwD1ojwAgbIYMGWLPtDUzMc3sV/NNsPk22Zx2VDTTsyI33nhjqYW8zEyEwsJC+1QpY9asWfa31Obb5pJKLnJ2PEuXLrVPKzMzBswKsGZhLnMxp/ubU7TmzZtnt16oDPNtu5lRYL5pNysIm1OWzCld5hvzadOmKS4uzp5FWpJpKWDyMjML4UQ/h6oqOq2/aHZEZf3iF78o9XNl31vRrIL//e9/x/1MzWPMbArTA7ks5v2aRd4uvPBCe2ZLEXNKohlDs+hH0fu6/PLLlZ+fb/cVLmJ+18w8MfcZJr7//ve/9gxts100/uZi9lMzu2Px4sWlYjAzd80pagAAIHZVN48yp6ib092rk9scrWgmrTnD6dChQ2U+xuRBJu8yM0hL5jlmVm67du3sM6VKMjNZzczakvmtyc9OPvnkUjN+i7bXr19f7ZzKzEYtecaSyW1LPmekmPds2hcUMTGZmajVicO06DK9bs1xSckeuCNGjFDHjh3L7HF8dG5dxByLlGwHUfSZm3YYJfe7o8cilMc3AJxHewQAYWVODTIJozmFyxRu3333XfsUJ3NKlUkqSiauZWnevHmpn82p7YY5HcgoKlqaImlJpl9X0WOPxyQ0xtGn0JdkkkzTQ3bv3r2lbjcFWlOsLGISVXNamzmlzfTmKjpFqihG02/36MTeJMAl38OJfA5VZWI1zKq3lV1AIT4+3n5vJVX2vZlC6csvv2yflnfffffZSaM5Dc3sB0ULeZlT0Ux/NJMom/E899xz7YSzd+/e9v3mdD5zUGIOII5mXs8koOY0PdM/rWvXrnZybNohmNPyDLNtTkUs6jdsns8Ucc2pbcdb2fnoBfNMUR4AAMS2knlUVRydR1Qltynrucx6B08//bTdvsAUPc1ECVOALCromlzXFFFNgbYsJm8tyeR5JScJGOa5zLoFR99WMg+tTk4V6ty2so5+f2W9ZxOLadFVVUV5b1njafJSU4SvKLc+3udT9JlXNBaVPb6p6DgJgDtQtAUQEeZba1PANZf27dvb366b5vqmz1J5ShZGSzp6kavqKPqW2fTlMr1Yj/ftu+lBZRYnKMksMFby22/TF8wUBMMl1J+DSRwNs6BB0cyGipg+tEUF1qoys1PNN/tmRoeZZWAW3jBFVFNANTNMzPszByerVq2ye7GZ+00h3PTsevDBB/XII49U+TVNodj0cTOzC0xR2czuvvLKK+0EueT4m4Ob4yW2pgfv0e8DAADENlO0NV9am3UbqiLUecSf/vQne0ErcyaTyafMmU+m96lZxMwUA02uYwqS5synsnLJo3vEHi/frCgPrU5OFY4c3+Sqhw8fLvO+otnIJWfAhiuOyiovtz7Rsajo+AaAN1C0BRBxZqEoY9u2bSFZ7Mwwi1qVnL1gTgeq6Jv6otmwJvEePHjwcR9nZm3OmDGj1G3mtLKqxGhmkJrZGCVnpK5cubLUezhRR88SKI85fc0k9WY14coWbU/0vZmk1MywNRczK+Txxx+3F3Iwhdyiz9/MajbFVnMxs7PNbFxTeDWLzZnZzabdhCnsHs28nnn+krMPzHOYYq8p/ppF2czphSVP+TPPZ2I2pyaWN/4AAABHM4tCmVmlphVYr169qvUcVc1tymIWzDKX3/72t/r888/tM5T+/ve/67HHHrNzXVPMMzmymTQRLuHKqaqS2xblnWV9lkbR7aHKu4/3+kWvVXRmV8nXD+drV/X4BoA30NMWQNiYYlxZ31KbPqjHO3WoqkwB0MycNKvblvTXv/61wt81K6qaxMas1pqdnX3M/eZUL8OcPmSSnpKXo7+lL8/w4cPtJPbomEybCJOMHm9l2qoyBU9zalplmIMLs1KuaVnw3nvvHXO/KZia1XxD9d6Obi9hFH37b1Y9Liq0Hz0727TPMPuQ6U9rZhaYlglmNsnGjRuLH2dW5X399dftlXeLTlc0zMxdcxBjZvSai+kPZ2ZEFzHPZ/qCmaJuWTNlisYfAADgaPfcc4+de5nWTyYXOdq6dev03HPPlfscVc1tSjJfRpt1HUoyeY8p9BblVubLb/Ma5kvso3Ny8/PRuVd1hSunMp+vOZW/skxeamYZL1q0qNTtJj82LSRM7lmViRfVmZiSnp5uF82LxsAwM52/++47u7dtuFX2+AaANzDTFkDYmMXAzKlIF110kX06vikEmhkApoBmWguYFgknysygvP322+3Tw0wfL1OINL1zTXJk2hWU9w29SWpN0dIUFk2vMBOPWSRty5YtdsHZJMlTpkw54RjNrFbTXsHMKjUJuZm5a05hMwn6HXfcUar/7YkmaaZ4bWZWmJ6wJmk8+lv+kl599VX7QMEk9CZGUwA3ybHphfWf//zHngltEr5QvLdHH33Ubo9gklUzy8D0NTOtD8ype+aAxDCxmETazBAx42qSW1MMNr9TNIvXvDcz69n8jlnkwRTsX3zxRTsxNgvdHc3MtjXtFUyR3fS2PfoUtCeeeMIea7OIw9ixY+0isSkwm8UyzAzisorNAAAAJscxhVWTa5gviq+55hp17ty5ON81bcBM64KKVDW3KTJ79mzdeuutuvTSS+1ZtKaA+9prrxUXUItiNM9vzlgyeZpZ8MzkVKbNl1lnwix0W5kv6SsjHDmVyW3NcYPp3WtarJnT+k3ueTxm3QTzuZsv6c3CwOb4Y+vWrZo0aZKd106cOFHhZHoEP/nkk/YxhVl0zrTlMgV4U7w3xz533nmnwi1SxzcAIsQCgDCZPn26df3111sdO3a0atasaSUmJlpt27a1brvtNmvHjh2lHtuiRQtr9OjRxT9PnDjRTAewvvrqq1KPmzNnjn27uS5SUFBgPfDAA1ZGRoaVkpJiDRw40Pruu++s+vXrWz//+c/L/V1jyZIl1sUXX2w/PikpyY7lsssus2bNmlXhe3zooYfs59y1a1e5j8vKyrLuvPNOq0mTJlZCQoLVrl0766mnnrICgUDIPoft27dbI0aMsGrVqmXf169fvwrjP3TokPXHP/7ROv3004vHyMRmxmjt2rXFjzMxpaamVvu9mc/yggsusB9jXsNcX3nlldbq1auLH/Piiy9affv2LR6HNm3aWHfffbd14MCBUq+3ePFia+jQoXa8NWrUsAYMGGB9/vnnZca2Zs0a+7Mwl08//bTMx5h98ZZbbrGaNWtmx2/2o0GDBlkTJkw45vN+6623KvxMAQBA7DC5zNixY62WLVvaOY7Jw3r37m395S9/sXJycoofZ/IIk2+UpTK5zdG53/r16+082+RLycnJVr169ezfmzlz5jHP/9///tfq06ePncuZi8nNTSyrVq0qfozJGzt16nTM75rc1OSXRyvr/ZxITrVhwwb7dpP7FsnOzrZ++tOfWnXq1LHvM7FUZPPmzdYNN9xgnXTSSVZ8fLz9uZx//vnWggULjnns8d6zyXtLvlZZsR0vRzfeeOMNq1u3bnY+a17/qquusuM6+jWOl1uX9dkWxWBy7JKO93meyPENAPfwmf9EqkAMAJFiToMybQ3M7AIzCxQAAAAAAMAr6GkLwPPKWiX22Wefta/79+/vQEQAAAAAAADVR09bAJ5nel2ZXlVm8QHT6+rTTz/Vv//9b7tHqumPCgAAAAAA4CUUbQF4XpcuXexFG8xiDWYl3aLFyUxrBAAAAAAAAK+hpy0AAAAAAAAAuAg9bQEAAAAAAADARSjaAgAAAAAAAICLRH1P20AgoK1bt6pWrVry+XxOhwMAAIBqMl29srKy1KRJE/n9sTX3gJwWAAAgtnLaqC/amuS2WbNmTocBAACAEPnhhx/UtGlTxRJyWgAAgNjKaaO+aGtmIxR9EGlpaRGbCbFr1y41bNgw5maBuAnj4B6MhXswFu7AOLgHY+GtscjMzLQLl0X5XSwhp4XbsH+gIuwjKA/7B2J5/8isZE4b9UXbotPHTHIbyQQ3JyfHfr1o3Lm8gnFwD8bCPRgLd2Ac3IOx8OZYxGJ7AHJauA37ByrCPoLysH+gPLGyf/gqyGmj950DAAAAAAAAgAdRtAUAAAAAAAAAF6FoCwAAAAAAAAAuQtEWAAAAAAAAAFyEoi0AAAAAAAAAuAhFWwAAAAAAAABwEYq2AAAAAAAAAOAiFG0BAAAAAAAAwEUo2gIAAAAAAACAi1C0BQAAAAAAAAAXoWgLAAAAAAAAAC7iaNF2/PjxOv3001WrVi2lp6frwgsv1KpVq0o9pn///vL5fKUuP//5zx2LGQAAACiJnBYAAABRVbSdO3eubrnlFi1YsEAzZsxQfn6+zj33XB08eLDU48aOHatt27YVX/7whz84FjMAAABQEjktAAAAQi1eDvrggw9K/Txp0iR7dsKiRYvUt2/f4ttr1KihjIwMByIEAAAAykdOCwAAgKjuaXvgwAH7ul69eqVu/9e//qUGDRqoc+fOGjdunA4dOiS3OpBr6e2VBVqf6aqPFgAAABESDTmtbfViJX9VuiANAACAGJhpW1IgENAdd9yh3r1724lskZ/+9Kdq0aKFmjRpom+++Ub33nuv3SPsnXfeKfN5cnNz7UuRzMzM4uc3l3B7aF6uJq8t1BVt4nVG6/C/Ho7PjLdlWREZd5SPsXAPxsIdGAf3YCy8NRZeGKdoyWn13Zfy/+4qpSWnKtDvAqlm7fC/JjyFfz9REfYRlIf9A7G8fwQq+b5cU7Q1fcCWL1+uTz/9tNTtN954Y/H2qaeeqsaNG2vQoEFat26d2rRpU+ZCEI888sgxt+/atUs5OTkKt1714zR5bYpmbfbrlh07FRfHjFsn/wjMTBfzh+73Mw5OYizcg7FwB8bBPRgLb41FVlaW3C5aclrVba76Ga2UsH2Dsie/rEODfxb+14Sn8O8nKsI+gvKwfyCW94+sSua0Pst8Ag679dZb9b///U/z5s1Tq1atyn2sWdChZs2adu+woUOHVmpWQrNmzbRv3z6lpaWFJf5Sr19g6YxXD+tgvvTmqER1b+yaunhM/pGbA5uGDRtG5R+5lzAW7sFYuAPj4B6MhbfGwuR1devWtZP4SOR1sZzTGtbH/1XchPtk1Wko67k5UkJSRF4X3sC/n6gI+wjKw/6BWN4/MiuZ0zpaUTT14ttuu03vvvuuPv744wqTW2Pp0qX2tZmdUJakpCT7cjQzyJEY6JREaVALM9u2UNM3BNTzpOjbubzE5/NFbOxRPsbCPRgLd2Ac3IOx8M5YuHWMojGnNQJ9RqrwzacVt3+nfJ9NkQZeFpHXhXfw7ycqwj6C8rB/IFb3D38l35Pf6dPH/vnPf+r1119XrVq1tH37dvty+PBh+35zutjvfvc7e+XdjRs3avLkybrmmmvsVXi7dOkitxreJs6+nr6+UAHnJzIDAAAgjKI1p1V8og72uzy4/f5LZtqL0xEBAADEDEeLti+88II9Fbh///72LIOiyxtvvGHfn5iYqJkzZ+rcc89Vx44d9atf/UqXXHKJpkyZIjc7p2mcUuMtbT9oackOklsAAIBoFq05rXG410hZNdKkreulhTOcDgcAACBmON4eoTymb9fcuXPlNUnxPp3TuEAf/JCgqWsL1CMjOPMWAAAA0Sdac1rDSk6Vzr1Keu8FafIE6fRzzfmKTocFAAAQ9aKvMYRLDDqpwL6evr6AFgkAAADwLGvoNVJCorR2qbTyK6fDAQAAiAkUbcPk9PRC1UqUdhy0tGg7LRIAAADgUbUbSP1+Etye/KLT0QAAAMQEirZhkhgnDW4ZbIswbV1w1i0AAADgSeePkXx+acnH0qZVTkcDAAAQ9SjahtHw1sGWwdPX0SIBAAAAHpbRUjrzvOD2lAlORwMAABD1KNqGUe+mfrtFws5DlhZuo0UCAAAAPGzk2OD15+9Lu7c6HQ0AAEBUo2gbRolxPp3bKjjblhYJAAAA8LQ2XaROvaTCAmnqP5yOBgAAIKpRtA2zEW2OtEhYX6DCAC0SAAAA4GGjbgpez35Dyt7vdDQAAABRi6JtmJ3dNE61k6RdpkXCdlokAAAAwMO69JFaniLlHpI++qfT0QAAAEQtirYRbJEwdS0tEgAAAOBhPt+PvW0/+D8pL8fpiAAAAKISRdsIoEUCAAAAosZZw6WGTaXMvdLHbzsdDQAAQFSiaBsBvU6KU50kac9hS19uK3Q6HAAAAKD64uKlEWOC2++/ElyYDAAAACFF0TYCEmiRAAAAgGgy4FKpVl1p5ybpiw+cjgYAACDqULSNkBFtg0XbD9cXqoAWCQAAAPCypBRp6DXB7ckTJIv8FgAAIJQo2kbIWU3iVDdZ2pNj6YuttEgAAACAxw39WbB4u3GFtPxzp6MBAACIKhRtI9giYeiRFgnT1tEiAQAAAB5n2iMMuCy4PflFp6MBAACIKhRtI2h4cYuEAlokAAAAwPuGXy/546Rln0nrlzkdDQAAQNSgaBvhFgn1kqW9OdICWiQAAADA69KbSmefH9ye8pLT0QAAAEQNirYRFO/3aWjrIy0S1tIiAQAAAFFg5Njg9YLp0vbvnY4GAAAgKlC0jbARbY60SNhQoPxCWiQAAADA41qcLHXtK1kBaeorTkcDAAAQFSjaRtgZTeJUP8WnfbRIAAAAQLQYdVPw+uO3pQO7nY4GAADA8yjaOtEioVWcvT2VFgkAAACIBqecKbXpIuXnSh+86nQ0AAAAnkfR1gEj2tIiAQAAAFHE5/txtu1H/5RyDjodEQAAgKdRtHXAGY2DLRIO5EpzN9EiAQAAAFHg9CFSRkvp4AFp9ptORwMAAOBpFG0dEOf36cL2wdm2v/88V4fymW0LAAAAj/PHSeffENw2C5IV5DsdEQAAgGdRtHXIbT0S1TjVp+8zLT31RZ7T4QAAAAAnru/FUu0G0p5t0ufvOx0NAACAZ1G0dUhakk9PDEiyt/9vWb4WbGFRMgAAAHhcYpI07Nrg9pQJksUZZQAAANVB0dZB5zSL1xUnB9sk3DsnVwdpkwAAAACvG3KVlFJT+mG1tORjp6MBAADwJIq2Dht3dpKa1PTphyxLT86nTQIAAAA8LjVNGnTFj7NtAQAAUGUUbR1WK/HHNgn/XJGvzzbTJgEAAAAeN/w6KS5B+u5Lac0Sp6MBAADwHIq2LtCnabyu6vRjm4SsPNokAAAAwMPqZUjnXBDcnvyi09EAAAB4DkVbl7ivV5Ka1vJpa7alJ+bnOh0OAAAAcGJGjg1eL5wpbVnndDQAAACeQtHWJVITfPrDkTYJ//62QJ/8QJsEAAAAeNhJbaUegyXLkt5/2eloAAAAPIWirYucdVK8Rp+aYG/f93GuMnNpkwAAAAAPG3Vj8PqT96S9O5yOBgAAwDMo2rrM3WcmqkWaT9uyLT3+OW0SAAAA4GEdekgdekoFedL0SU5HAwAA4BkUbV2mRoJPTw5Ilk/SmysL9PH3tEkAAABAFMy2nfm6dCjL6WgAAAA8gaKtC53RJE7Xdgm2SRg3N1cHaJMAAAAAr+o2QGraTjqcLc143eloAAAAPIGirUv9+oxEtazt046Dlh77jDYJAAAA8Ci/Xxo5Nrg9faKUT24LAABQEYq2LpWS4NNTA4NtEv67qkCzNtImAQAAAB7Ve6RUL0Pavyu4KBkAAADKRdHWxXpkxOmGrsE2Cb+Zm6v9ObRJAAAAgAfFJ0ojrg9uT3lJCgScjggAAMDVKNq63J1nJKpNHZ92HrL0KG0SAAAA4FUDL5dS06RtG6SFM5yOBgAAwNUo2rpccnywTYLfJ723ukAfbaBNAgAAADwopaY05Krg9uQJksVZZAAAAMdD0dYDTmsUp7Gn/dgmYe9hElwAAAB40HnXSgmJ0tql0sqvnI4GAADAtSjaesQdPRPVrq5few5bevhT2iQAAADAg+o0kPr9JLg9+UWnowEAAHAtirYekRTv0x8GJinOJ72/tkDT19EmAQAAAB50/hjJ55eWfCxtWuV0NAAAAK5E0dZDuqbH6efdgm0SHpyXa8+6BQAAADwlo6V05nnB7SkTnI4GAADAlSjaesytPRPVoZ5fe3IsPfQJbRIAAADgQSPHBq8/f1/avdXpaAAAAFyHoq3HJMX59NTAJMX7pWnrCjR1bb7TIQEAAABV06aL1KmXVFggTX3F6WgAAABch6KtB3VuGKdfFLVJ+CRXuw4FnA4JAAAAqJpRNwWvZ78hZe1zOhoAAABXoWjrUbf0SNTJ9f3alyM9MC9XlkV/WwAAAHhIlz5Sy1Ok3MPSR/90OhoAAABXoWjrUYlxPv3xSJuEjzYUasraAqdDAgAAACrP5/uxt+0Hr0p5OU5HBAAA4BoUbT3s5AZxuq1Hor1tFiXbeZA2CQAAAPCQs4ZLDZtKWXulj992OhoAAADXiHc6AJyYn3dL0IwNBVq+O6DfzsvVi+cly2dmLQAAAABuFxcvjRgjTXpE+t/fpf27IvO6STWkwVdKqWmReT0AAIAqomjrcQlxPj01MEmj3j6smRsLtXJPwJ6BCwAAAHjCgEul//5F2rNNeuevkXvd7H3SVfdF7vUAAACqgKJtFOhQP05nnRSnT34o1MLtFG0BAADgIUkp0l1/kxZMlSKxtu6+HdJXH0lffij99N5gb10AAACXoWgbJbo3ChZtl+wo1M86JzgdDgAAAFB5J58evETC4Wxp7MfSjk3S5jVSs/aReV0AAIAqYCGyKNE9IziUi7cXOh0KAAAA4F4pNaXOvYLbC2c6HQ0AAECZKNpGia7pcTIndm3KtLT7UMDpcAAAAAD36jk4eE3RFgAAuBRF2yiRluRTu7rB4Vyyg6ItAAAAcFzdBwWv130t7d3hdDQAAADHoGgbjS0SdtAiAQAAADiueo2kNl2D24tnOR0NAADAMSjaRpFuGXH2NX1tAQAAgArQIgEAALgYRdso0r1RsGi7bFdA+YWW0+EAAAAA7i/aLp8vHc52OhoAAIBSKNpGkVZ1fKqdJOUUSN/toa8tAAAAcFxN20kZLaSCPOnrT5yOBgAAoBSKtlHE7/Op25HZtrRIAAAAAMrh80k9aJEAAADcydGi7fjx43X66aerVq1aSk9P14UXXqhVq1aVekxOTo5uueUW1a9fXzVr1tQll1yiHTtY4fV4uhf1td3BTFsAAIBIIKf1sJ5DgtdLZksF+U5HAwAA4I6i7dy5c+3kdcGCBZoxY4by8/N17rnn6uDBg8WPufPOOzVlyhS99dZb9uO3bt2qiy++2MmwXa1bo+CQLtnBTFsAAIBIIKf1sA7dpVr1pIOZ0sqvnI4GAACgWLwc9MEHH5T6edKkSfbshEWLFqlv3746cOCAXnnlFb3++usaOHCg/ZiJEyfq5JNPtpPis846y6HI3atrepz8PmlLlqUdBwNqlEoHDAAAgHAip/Uwf5zUfYA097/BFgmdz3Y6IgAAAOeLtkczCa1Rr149+9okumamwuDBR3pNSerYsaOaN2+u+fPnl5ng5ubm2pcimZmZ9nUgELAvkWBex7KsiL1eSTXipQ71fPpuj6VF2wp0XmtXDXFEOTkOKI2xcA/Gwh0YB/dgLLw1Fl4ZJ3Jaj+k+SP65/5W1cKasn/0m2OsWFYqZ/QPVxj6C8rB/IJb3j0Al31e8mwK+44471Lt3b3Xu3Nm+bfv27UpMTFSdOnVKPbZRo0b2fcfrKfbII48cc/uuXbvsXmKRei8mWTc7mN8f+ZmuHdOS9N2eBH22IVvda+YpVjk9DvgRY+EejIU7MA7uwVh4ayyysrLkduS03uPLaK/0hET5dm/RnqWfq+Ckdk6H5Amxsn+g+thHUB72D8Ty/pFVyZzWNUVb0wds+fLl+vTTT0/oecaNG6e77rqr1KyEZs2aqWHDhkpLS1Okdi6fz2e/phM719ktC/TuhjytykpWenrpg4NY4vQ44EeMhXswFu7AOLgHY+GtsUhOTpbbkdN61Kl9pMWzVW/DYqlbb6ej8YSY2j9QLewjKA/7B2J5/0iuZE7riqLtrbfeqvfff1/z5s1T06ZNi2/PyMhQXl6e9u/fX2pmgllp19xXlqSkJPtyNDPIkRxos3NF+jWL9GhshjVPy3cHlG/5lBQXu6d4OTkOKI2xcA/Gwh0YB/dgLLwzFm4fI3JaD+s5xC7a+hfNkn5yu9PReEbM7B+oNvYRlIf9A7G6f/gr+Z4cfedmmrNJbt99913Nnj1brVq1KnV/jx49lJCQoFmzZhXftmrVKm3atEm9evVyIGJvaJHmU71kKa9Q+nZXdPb/AAAAcAty2ijQfWCwl+2GFdLurU5HAwAA4OxMW3P6mFlF93//+59q1apV3NOrdu3aSklJsa/HjBljnxpmFnIwp4LddtttdnLLKrvlfxvRrVGcZn1fqMU7CtUtI87pkAAAAKIWOW0UqNNAatdNWr1YMrNth/7M6YgAAECMc3Sm7QsvvGA3Fu7fv78aN25cfHnjjTeKH/PMM8/o/PPP1yWXXKK+ffvap5C98847TobtCUWF2iU7mGkLAAAQTuS0UeL0IcHrhTOdjgQAAMDZmbbmVLLKNOd9/vnn7Qsqr8eRou3i7YVOhwIAABDVyGmjRI8h0r+elL5dIB3MlFIjs+AbAABAWaKvmy9spzb0y6w/tv2gpa3ZzLYFAAAAytWkldSkjVRYIC392OloAABAjKNoG6VqJPh0cv3g8C5hti0AAABQsZ6Dg9e0SAAAAA6jaBsDfW0X09cWAAAAqHzRdulcqSDP6WgAAEAMo2gbxbo3Cg4vfW0BAACASmh7mlS7gXQ4W1rxhdPRAACAGEbRNop1PzLT9tvdAeUWVLxABgAAABDT/H6px8Dg9iJaJAAAAOdQtI1iTWv51CDFp/yAtGwXLRIAAACACvUY8mNfW4uJDwAAwBkUbaOYz+dT94wji5HtoEUCAAAAUKFTz5aSUqS926UNy52OBgAAxCiKtlGue6Ngi4RF9LUFAAAAKpaYLHU558fZtgAAAA6gaBvluh3pa7tkR0AWp3cBAAAAFes5OHhN0RYAADiEom2UO7WhX/F+adchS1uyKNoCAAAAFeo+UPL5pU0rpZ0/OB0NAACIQRRto1xyvE+nNAgOMy0SAAAAgEqoVVfqeHpwm9m2AADAARRtY6ivrWmRAAAAAKAqLRJmOB0JAACIQRRtY0D3jOAwL97BTFsAAACgSkXblQul7P1ORwMAAGIMRdsY0O3ITNvvdgd0KJ++tgAAAECFGjWXmrWXAoXS4jlORwMAAGIMRdsY0KSmT41SfSq0pGW7aJEAAAAAVK1FAn1tAQBAZFG0jQE+n0/dGx1pkcBiZAAAAEDl9BwSvP56npSX63Q0AAAghlC0jRHdMooWI6NoCwAAAFRKq85S3UZS7iFpxedORwMAAGIIRdsY0f1IX1sz09ay6GsLAAAAVMjvl3oMCm7TIgEAAEQQRdsY0amhX4l+aW+O9H0mRVsAAACgSn1tF82SAqwPAQAAIoOibYxIivOpc8PgcC+hry0AAABQOZ3OklJqSvt3Seu+cToaAAAQIyjaxmBf28X0tQUAAAAqJyFJ6to3uE2LBAAAECHxkXohOK+b3dc2X5/+UKg3vs0PWZuvfs3ilJ5K/R8AAABRqucQacE0adFM6cpfOx0NAACIARRtY0iPjGBh1fS0HTc3N2TP27tpnF4bmRKy5wMAAABcpVt/KS5e2rxG2vmDlN7M6YgAAECUo2gbQxql+nX/2Yn6cmto2iMcLpA+21yor3cWyrIs+Xy+kDwvAAAA4CqpaVKrztLapdLKhRRtAQBA2FG0jTE3dE3UDV1D81y5hZY6v3RQ2XnS9oOWGtekaAsAAIAo1aFHsGi7aqHU9yKnowEAAFGORqSotqQ4n1rWDhZq1+wNOB0OAAAAEN6irbFqkdORAACAGEDRFiekXb3gLrR6H0VbAAAARLH2R4q2pq9t9gGnowEAAFGOoi1OSLu6wV2ImbYAAACIanUaSBktg9urFzsdDQAAiHIUbXFC2h+ZaUvRFgAAAFGPFgkAACBCKNoiJO0R1u4LyLIsp8MBAAAAwl+0XU3RFgAAhBdFW5yQlrX9ivdL2fnS1myKtgAAAIhiHXoGr9d+LRXkOR0NAACIYhRtcUIS43xqWdtnb9MiAQAAAFGtSWupVl0pP1fasMLpaAAAQBSjaIuQLUZmWiQAAAAAUcvnk9p3D27T1xYAAIQRRVuErK/taoq2AAAAiHYsRgYAACKAoi1OWPt6cfY17REAAAAQO0XbhRIL8QIAgDChaIuQtkewSFwBAAAQzVqdKsUnSpl7pe0bnY4GAABEKYq2OGFmIbIEv3QwX9qaTdEWAAAAUSwxSWpzanCbFgkAACBMKNrihCXE+dSq9pG+trRIAAAAQLRrT19bAAAQXhRtEdLFyOhrCwAAgKjHYmQAACDMKNoitEXbfRRtAQAAEOXadw9eb10X7G0LAAAQYhRtEdLFyGiPAAAAgKiXVk9q0ia4vXqx09EAAIAoRNEWIdH+yEzbtfsCClgsRgYAAIAoR4sEAAAQRhRtERItavuU6JcOF0hbsijaAgAAIEaKtqsp2gIAgNCjaIuQiPf71KoOLRIAAAAQY0XbdcukvFynowEAAFGGoi1ChsXIAAAAEDMyWgZ72xbkSRuWOR0NAACIMhRtEfK+tmuYaQsAAIBo5/PR1xYAAIQNRVuETLu6FG0BAAAQQzr0DF6vWux0JAAAIMpQtEXI2yOs3R9QwGIxMgAAAMTQYmTkvwAAIIQo2iJkWqT5lBgn5RRIP2SStAIAACDKteokJSRJWfukreudjgYAAEQRirYImTi/T23q0CIBAAAAMSI+UWrbNbhNX1sAABBCFG0RUm2P9LVdvY+iLQAAAGJA+6LFyBY6HQkAAIgiFG0RUu2L+tpStAUAAEAs9bVlpi0AAAghirYIy2JktEcAAABATGjfPXi9faN0YLfT0QAAgChB0RYh1a7ujzNtCwMsRgYAAIAoV7O21LRdcJvZtgAAIEQo2iKkmqf5lBQn5RZKP2RRtAUAAEAMoEUCAAAIMYq2CKk4v09tjsy2pUUCAAAAYkKHnsHr1YudjgQAAEQJirYIW4uE1RRtAQAAEEszbdcvl/JynI4GAABEAYq2CN9iZPso2gIAACAGpDeT6jSUCvOldd84HQ0AAIgCFG0Rcu1pjwAAAIBY4vP92CKBvrYAACAEKNoibDNt1+0PqDDAYmQAAACIpcXIFjodCQAAiAIUbRFyzdJ8So6X8gql7zMp2gIAACCGirZmMbIAZ5wBAIATQ9EWIef3+dS2Di0SAAAAEENanCwlpUgHM6Uta52OBgAAeJyjRdt58+Zp5MiRatKkiXw+n957771S91977bX27SUv5513nmPxovJYjAwAAMQS8looPkFq2zW4TV9bAADg5aLtwYMH1bVrVz3//PPHfYxJZrdt21Z8+fe//x3RGHFiRdvVzLQFAAAxgLwWtvb0tQUAAKERLwcNGzbMvpQnKSlJGRkZEYsJodGuLu0RAABA7CCvRenFyBY7HQkAAPA41/e0/fjjj5Wenq4OHTroF7/4hfbs2eN0SKiE9kdm2m7YH1BBgMXIAAAAyGtjQPvuks8n7dwk7dvpdDQAAMDDHJ1pWxFzCtnFF1+sVq1aad26dbr//vvtGQzz589XXFxcmb+Tm5trX4pkZmba14FAwL5Egnkdy7Ii9npu1DjVUkq8dLhA2rCvUG2OzLyNJMbBPRgL92As3IFxcA/Gwltj4eVxqmpeS07rUcmp8jXrIN+mlQqs/Eo6s/zZ117G/oGKsI+gPOwfiOX9I1DJ9+Xqou0VV1xRvH3qqaeqS5cuatOmjT1LYdCgQWX+zvjx4/XII48cc/uuXbuUk5OjSH34Bw4csHcwv9/1k5nDpkXNFK3cH6eFG/epVn5hxF+fcXAPxsI9GAt3YBzcg7Hw1lhkZWXJq6qa15LTeldas5NVY9NKHV76qbJaHWmXEIXYP1AR9hGUh/0Dsbx/ZFUyp3V10fZorVu3VoMGDbR27drjFm3HjRunu+66q9SshGbNmqlhw4ZKS0uL2M5lVgQ2rxmNO1dlnZKeq5X7C7UzkKb09ISIvz7j4B6MhXswFu7AOLgHY+GtsUhOTla0qCivJaf1sNP6SJ+9qxo/rFRKerqiFfsHKsI+gvKwfyCW94/kSua0nirabt682e791bhx43IXeDCXo5lBjuRAm50r0q/pNu3rmVP9CrV2n3PfjDAO7sFYuAdj4Q6Mg3swFt4Zi2gao4ryWnJaD+t4un3l27hCvrwcKbmGohX7ByrCPoLysH8gVvcPfyXfk6NF2+zsbHt2QZENGzZo6dKlqlevnn0xp4Rdcskl9iq7pvfXPffco7Zt22ro0KFOho1KandkMbI1e6OzBwkAAEAR8loUa9BEqpch7d0urfta6tTL6YgAAIAHOVquXrhwobp162ZfDHMKmNl+8MEH7QUZvvnmG40aNUrt27fXmDFj1KNHD33yySdlzjqA+7Q7svjYhgMB5RdaTocDAAAQNuS1KObzSR2O9LJdtcjpaAAAgEc5OtO2f//+dlPh4/nwww8jGg9Cq0ktn2rES4cKpO8zLbWt63M6JAAAgLAgr0Uppmg7f6q0aqHTkQAAAI+KvsYQcA2/z6e2R1okrKZFAgAAAGJF0Uzb1UukQKHT0QAAAA+iaIuItEigry0AAABiRvOOUnKqdDhb+mGN09EAAAAPomiLsGpftBjZPoq2AAAAiBFx8VK704Lb9LUFAADVQNEWYcVMWwAAAMSk9kWLkdHXFgAAVB1FW4RVuyMzbTccCCiv8PiLcwAAAABRpWPP4DUzbQEAQDVQtEVYNanpU80EqSAgbTzAbFsAAADEiLZdJZ9f2r1F2rPN6WgAAIDHULRFWPl8PrWlRQIAAABiTUpNqcXJwW1m2wIAgCqKr+ovANVpkbB0Z0CTluVr4fbyC7fJ8dKYLglqUIPvEwAAAOBxHXtIG1dIU1+RVi+KXC/ds8+PzGsBAAB3F20LCwu1bNkytWjRQnXr1g3FUyKKdGro11srpUXbA/alItl5ln7XNzkisQEAAJREXouQOuUs6YNXpXXfBC+R8OFrwRm+J7WJzOsBAAD3FG3vuOMOnXrqqRozZoyd2Pbr10+ff/65atSooffff1/9+/cPfaTwrEs7JCivUMrMLX8hsl2HLL3xXYE+WF+oh/pYivf7IhYjAACITeS1CKueg6XrHpb274rM6309T1q/THr/Zemm8ZF5TQAA4J6i7dtvv62rr77a3p4yZYo2bNiglStX6rXXXtNvfvMbffbZZ6GOEx6WkuDTDV0TK3xcfqGlD9cXaM9hS19uLdTZTeneAQAAwou8FmHlj5OG/ixyr3daP+mhy6RP3pMuvUOq1yhyrw0AAEKqWo1Dd+/erYyMDHt72rRpuvTSS9W+fXtdf/319ulkQHUkxPk0tHWwUDt1XYHT4QAAgBhAXouo0qGH1KGnVJAnTZ/kdDQAACDSRdtGjRrp22+/tU8h++CDDzRkyBD79kOHDikuLu5E4kGMG94mWLQ1M24LAuW3UwAAADhR5LWIOqNuCl7PfF06lOV0NAAAIJJF2+uuu06XXXaZOnfuLJ/Pp8GDB9u3f/HFF+rYsWN1YwHU66Q41U2W9uZIC7YWOh0OAACIcuS1iDrd+ktN20mHs6UZrzsdDQAAiGTR9uGHH9Yrr7yiG2+80e7zlZSUZN9uZiPcd9991Y0FsBcfO+9Ii4Rpa2mRAAAAwou8FlHH75dGjg1uT58o5ec6HREAAIhE0TY/P1+DBg1Sly5ddOedd6pp06bF940ePVoXXHBBdeIAjm2RsKHAXpwMAAAgHMhrEbV6j5TqZUj7dwUXJQMAANFftE1ISNA333wTnmgASWc2iVP9ZJ/20SIBAACEEXktolZ8ojTi+uD2lJekADk1AAAx0R7h6quvtk8jA8LVImFo6+DCH9PW0SIBAACED3ktotbAy6XUNGnbBmnhTKejAQAAVRQ8D72KCgoK9I9//EMzZ85Ujx49lJqaWur+p59+ujpPCxQb0TZer39boA/XF+jRcywlxPmcDgkAAEQh8lpErZSa0pCrpPdekCZPkE4/V/KRUwMAENVF2+XLl6t79+729urVq0vdZ1bdBU7UGY3jVD/Fpz2HLc3fUqi+zau1qwIAAJSLvBZR7bxrpamvSGuXSt99KZ1yptMRAQCASqpWJWzOnDnV+TWg0uL8Pg1rHa9/rsjX1HUFFG0BAEBYkNciqtVpIPX7iTTzdWnKBIq2AABEe09bIFItEoyPNhQor9ByOhwAAADAe84fI/n80pKPpU2rnI4GAABUUrWmLw4YMKDc08Vmz55dnacFSumZ4VeDFJ92H7b0+eZC9W/BbFsAABBa5LWIehktpTPPkxZMC862veVPTkcEAADCNdP2tNNOU9euXYsvp5xyivLy8rR48WKdeuqp1XlKoOwWCW2ChVrTIgEAACDUyGsRE0aODV5//r60e6vT0QAAgEqo1tTFZ555pszbH374YWVnZ1fnKYEyjWgTr9eW59stEn5faCkxjgVBAABA6JDXIia06SJ16iWtmB9cmGz0A05HBAAAItnT9uqrr9Y//vGPUD4lYlyPDL/Sa/iUlSd9urnQ6XAAAECMIK9F1Bl1U/B69htS1j6nowEAAJEs2s6fP1/JycmhfErEuJItEqbTIgEAAEQIeS2iTpc+UstTpNzD0kf/dDoaAAAQjvYIF198camfLcvStm3btHDhQj3wAKfaILSGt4nX/y0Ltkh4rNBSEi0SAABAiJDXImaYBfdMb9u/3Cl98Kp0/g1SUorTUQEAgFAWbWvXrl3qZ7/frw4dOujRRx/VueeeW52nBMptkdAo1acdBy19+kOhBrWs1m4LAABwDPJaxJSzhkv/+ZO0a7M097/SuVc7HREAADiOalW/Jk6cWJ1fA6rF7/NpWOt4TVqWr2nrCijaAgCAkCGvRUyJi5dGjJEmPSK9/7I06IrgbQAAIHp62u7fv18vv/yyxo0bp71799q3LV68WFu2bAllfIBtRNtgMjljY4FyCyynwwEAAFGEvBYxZcClUq160s4fpC+mOx0NAAAIZdH2m2++Ubt27fTkk0/qj3/8o53oGu+8846d7AKh1q2RX41TfcrOkz75odDpcAAAQJQgr0XMMX1sz7smuD35JdPI2emIAABAqIq2d911l6677jqtWbOm1Kq6w4cP17x586rzlEDFLRLaBGfbTl1X4HQ4AAAgSpDXIiaZXrameLtxhbTsM6ejAQAAoSrafvXVV7rpppuOuf2kk07S9u3bq/OUQIVGHCnaztxYoBxaJAAAgBAgr0VMqlVXGnBZcHvyi05HAwAAQlW0TUpKUmZm5jG3r169Wg0bNqzOUwIVOq2RX01q+nQwX5pHiwQAABAC5LWIWcOvl/xx0vLPpfXLnI4GAACEomg7atQoPfroo8rPz7d/9vl82rRpk+69915dcskl1XlKoEJmPxt+ZLbtNFokAACAECCvRcxKbyqdfX5we/IEp6MBAABHCVbAquhPf/qTfvKTnyg9PV2HDx9Wv3797NPHevXqpd///vfVeUqgUkzR9uWv8zVrY4FW7ilUvN933McGAgHtzfQpMyEgfwVfTzSs4VPtpOM/FwAAiE7ktYhpI2+UPv2f9MUH0rdfSLXrV/53AwH5cgNSeno4IwQAIGZVq2hbu3ZtzZgxQ5999pm+/vprZWdnq3v37ho8eHDoIwRK6JoebJGwNdvS8DcPV+I3UiXlVPioWonS5J/UUIva1Zp8DgAAPIq8FjGtRUepa1/p63nSoz+t0q+arDndHyfryfelZu3DFiIAALGqykVbc+pYSkqKli5dqt69e9sXIFLMKYu39UzU01/mqSBQ8WJkgYAlfzmzcY2cAikrT7p3To5evyBFfh8zbgEAiAXktYCkK34lbdsgHc6u0q9ZOQfly8+TtXgORVsAANxQtE1ISFDz5s1VWMhCUHDG5Scn2JeKmPYIO3futE939JfTH2FTZkDD3zikL7cF9NryfI0+NTHEEQMAADcirwUkteos/fnjKv+aNXmCfK8/Kd/qxWEJCwCAWFetc8F/85vf6P7779fevXtDHxEQYc3T/LqvV5K9/eSCPG08EHA6JAAAECHktUA1degRvF69SLIqPgMOAABEoKftX//6V61du1ZNmjRRixYtlJpq+ob+aPFivm2Ft/y0U7ymry/Q/C2Funt2jv5zQYriKmirAAAAvI+8FqimVp1kJSTKl7Uv2F6hSWunIwIAIKpUq2h74YUXhj4SwEGmj+2T/ZM07M1DWrQ9oEnL8jWmK20SAACIduS1QDXFJyq/2clKXP+1tGoRRVsAAJwu2hYUFNiLQV1//fVq2rRpqOMBHNM0za/7z07Sb+bm6o9f5GlA83i1rlutDiIAAMADyGuBE5PXusuPRdsBlzodDgAAUaXKFan4+Hg99dRTdpILRJsrTo5Xn6Zxyi2U7pmTo8IA/bkAAIhW5LXAiclv1eXHvrYAACCkqjWNcODAgZo7d25oIwFcwMy2eWJAkmomSot3BPSPb/KdDgkAAIQReS1QfXktOwc3tq6XMvc4HQ4AAFGlWj1thw0bpvvuu0/Lli1Tjx49jlmwYdSoUaGKD4i4JjX9+u3ZSbrv41z96cs8DWgRr7a0SQAAICqR1wLVZ6WmyWraTr7Na6TVi6WeQ5wOCQCA2C7a3nzzzfb1008/XeZMxcLCwhOPDHDQpR3jNX19geZuKtTds3P01kUpivf7nA4LAACEGHktcILad5dM0db0taVoCwBAyFRr+mAgEDjuhcQW0cAcpI3vl6RaidLXOwN6aSltEgAAiEbktcCJsdr3CG6sXOh0KAAAxG7Rdvjw4Tpw4EDxz0888YT2799f/POePXt0yimnhDZCwCEZNf16sHeSvf3cV3lavZcDNwAAogV5LRAiHY4UbTeskPJynY4GAIDYLNp++OGHys398X/Ejz/+uPbu3Vv8s1l5d9WqVaGNEHDQxR3iNbBFnPIC0q9n5yq/0HI6JAAAEALktUCIpDeT6jSUCvKk9cucjgYAgNgs2lqWVe7PQDS2Sfh9vyTVTpKW7wpoAm0SAACICuS1QIj4fFJRi4RVtEgAAMDRnrZALGmU6tdDfYJtEv6yKE+ZuRzUAQAAAMe0SDCLkQEAgMgXbc2sQ3M5+jYg2l3QLl5t6/qUVyjN2ljgdDgAAOAEkdcCIdSxZ/B69WKzup/T0QAAEBXiq/Jgc9rYtddeq6Sk4KzDnJwc/fznP1dqaqr9c8m+YEA0MQdxw9vE688L8zVtXYEu6pDgdEgAAOAEkNcCIdTiZCkpRcreL21dJzVt53REAADEVtF29OjRpX6++uqrj3nMNddcc+JRAS5UVLT95IdCu0VCWhKzcQAA8CryWiCE4hOkNl2kb78ItkigaAsAQGSLthMnTjzxVwQ8qn29OLWv69fqfQHN3Figi5ltCwCAZ5HXAiHWoeePRdtBVzgdDQAAnsdCZEAVDG8b/J5j6jr62gIAAADHLka20OlIAACIChRtgSq2SDA+/aFQB3Itp8MBAAAA3KF9d7MQhLRjk7R/t9PRAADgeRRtgSpoW9ev9vX8yg9IMzYw2xYAAACw1aglNesQ3F69yOloAADwPIq2QBWNODLblhYJAAAAQFktEijaAgBwoijaAtVskfDZ5kLtz6FFAgAAAFCqaLuSvrYAAJwoirZAFbWp61fH+n4VBKSPaJEAAAAABHXoGbzeuELKPex0NAAAeJqjRdt58+Zp5MiRatKkiXw+n957771S91uWpQcffFCNGzdWSkqKBg8erDVr1jgWL3B0i4TptEgAAADktUBQgyZSvQypsEBa943T0QAA4GmOFm0PHjyorl276vnnny/z/j/84Q/685//rL///e/64osvlJqaqqFDhyonJyfisQIlDStqkbClUPtokQAAQMwjrwUk+XxS++7B7VW0SAAA4EQEK08OGTZsmH0pi5mN8Oyzz+q3v/2tLrjgAvu2V199VY0aNbJnLlxxxRURjhb4Ues6fp3SwK9vdwfsFgmXn5zgdEgAAMBB5LXAER17SgumsRgZAABeLtqWZ8OGDdq+fbt96liR2rVr68wzz9T8+fOPm9zm5ubalyKZmZn2dSAQsC+RYF7HJOeRej04Mw7DWsfZRdupa/N1aYe4sLxGtOBvwj0YC3dgHNyDsfDWWHh1nKqT15LTwu2Ou3+0626fzmmtXiyroEDys4xKrOLfEJSH/QOxvH8EKvm+XFu0NYmtYWYglGR+LrqvLOPHj9cjjzxyzO27du2K2Oln5sM/cOCAvYP5SVIcE+5xOLO2T1Kq5m8p1OofdqpOUshfImrwN+EejIU7MA7uwVh4ayyysrLkRdXJa8lp4XbH3T+S6yo9MUX+Q1na880XKmjSxskw4SD+DUF52D8Qy/tHViVzWtcWbatr3Lhxuuuuu0rNSmjWrJkaNmyotLS0iO1cZgEK85rRuHN5RbjHIT1d6tTgsFbslhZn19MVzaLuzylk+JtwD8bCHRgH92AsvDUWycnJihXktHC78vYPX7tu0orPVW/3Bum0Xo7FCGfxbwjKw/6BWN4/kiuZ07q2ypSRkWFf79ixw15lt4j5+bTTTjvu7yUlJdmXo5lBjuRAm50r0q+JyI/D8DYJWrE7T9PXF+qnnRLD8hrRgr8J92As3IFxcA/Gwjtj4dUxqk5eS04LLzju/mH62q74XP7VS6Rzr3YqPLgA/4agPOwfiNX9w1/J9+Tad96qVSs7wZ01a1apGQZmtd1evfi2Fu4wvE3wew/TImHPYcvpcAAAgAuR1yLmdOgRvF610OlIAADwLEdn2mZnZ2vt2rWlFmlYunSp6tWrp+bNm+uOO+7QY489pnbt2tnJ7gMPPKAmTZrowgsvdDJsoFiL2n51bujX8l0Bfbi+QD/tlOB0SAAAwAHktUAJ7U6TfH5p12Zp7w6pXul+zgAAwOVF24ULF2rAgAHFPxf17Ro9erQmTZqke+65RwcPHtSNN96o/fv3q0+fPvrggw9iqp8Z3G9Em3gt35Wnqeso2gIAEKvIa4ESUmpKLU6WNq6QVi+SzhrudEQAAHiOo0Xb/v372yvBlde/4tFHH7UvgJtbJDy5IE9fbC3U7kMBNajh2q4jAAAgTMhrgaN06B4s2q6iaAsAQHVQXQJOULM0v7qk+xWwpA83FDodDgAAAOA8+toCAHBCKNoCIWqRYExbW+B0KAAAAIDzOvQMXm/8Tso56HQ0AAB4DkVbIEQtEowvthVq16GA0+EAAAAAzqrfWGrQRAoUSmu/djoaAAA8h6ItEAIn1fLrtCMtEj5YT4sEAAAAQO2LWiQscjoSAAA8h6ItECLD2x5pkbAu3+lQAAAAAOd1PNIigaItAABVRtEWCJFhrYNF2y+3BrTzIC0SAAAAEOOKFiNbsyTYJgEAAFRasMoEICQtEro18mvJjoAmry3QlackhOR5431SkvkPAAAA4CXN2kspNaXD2dKmVVLLU5yOCAAAz6BoC4R4QbIlO/L0+OfBSyiYcu24Xom64bTEkDwfAAAAEBH+OKl9N+nrT4ItEijaAgBQabRHAEJoVLt4NUoN7axYS9JTX+Tpu92cUgYAAACPYTEyAACqhZm2QAg1rOHXp1fXUF4I66t3zsrRRxsKdfecXL1zcYoS42iVAAAAAI/1tV210OlIAADwFGbaAiEW5/cpJSF0l9/1TVLdZOnb3QH9bXFoWi4AAAAAEdH2tGCbhD3bpN1bnY4GAADPoGgLeGD27iPnJNnbf1ucr+W7aJMAAAAAj0iu8WMv29W0SAAAoLIo2gIeMKJNvIa1jlNBQLp7dq7yCk2nWwAAAMBDLRJWUrQFAKCyKNoCHuDz+fRo32TVT/Zp1d6A/rqINgkAAADwWNGWmbYAAFQaRVvAI+qnmMJtsE3CC4vz9c1O2iQAAADAA9ofKdp+v1I6nO10NAAAeAJFW8BDhrWJ1/lt42W6I5g2Cbm0SQAAAIDb1WskpTeTrIC0ZqnT0QAA4AkUbQGPebhPkj3rds2+gJ77ijYJAAAA8NBs21ULnY4EAABPoGgLeEy9FJ8eO9ImYcLSfC3dQZsEAAAAuFzHoqItfW0BAKgMiraABw1tHa8L2sUrYLdJyFFuAW0SAAAA4IHFyEx7hMICp6MBAMD1KNoCHvVQnyQ1rOHTuv2WnqFNAgAAANzspHZSapqUe0j6/junowEAwPUo2gIeVSfZp8f7BdskvLQ0X4u20yYBAAAALuX3S+27B7dpkQAAQIXiK34IALca1DJeF7eP1zurC+w2CXedkRjxGNrV9atD/biIvy4AAAA8uBjZko+lLz+Sajeo2u8mpUhd+kgJwUkLAABEO4q2gMc90CdJn20p1MYDln45Izfir58cL829qoYa1mDiPgAAAMrRsWfw+rsvgpequuSX0qW3hzwsAADciKIt4HG1k3z6y5Bk/XVRnvIj3CFh9d6A9uRY+nB9oa7uTNEWAAAAFSxGdu7PpC1rqvZ7h7KkDSukBdMo2gIAYgZFWyAK9Gwcp0nnp0T8dV9amqfx8/M0bV2Bru6cEPHXBwAAgIf446TrH67675mi7djTpS1rpa0bpCatwhEdAACuwtQ4ANU2vE3we58vthZq16GA0+EAAAAgGtWoJZ1yZnB70QynowEAICIo2gKotpNq+dU13S9L0vT1BU6HAwAAgGjVc3DweuFMpyMBACAiKNoCOCEjjsy2nb6Ooi0AAADCpMeg4PXqxdKB3U5HAwBA2FG0BXBChh0p2n65NaCdB2mRAAAAgDBo0ERq1UmyLGnxHKejAQAg7CjaAjjhFgndGgVbJHxAiwQAAACES88hwWtaJAAAYgBFWwAhW5BsKi0SAAAAEO6+tss+lXIPOx0NAABhRdEWQMhaJCzcFtD2bFokAAAAIAyad5QaNpXycoKFWwAAohhFWwAnrElNv3pk0CIBAAAAYeTz/TjblhYJAIAoR9EWQEjQIgEAAABhV1S0XTRbChQ6HQ0AAGFD0RZASAxrHSzaLtoe0DZaJAAAACAcOp4updaWsvZKqxY7HQ0AAGFD0RZASGTU9KtnRvCflOnMtgUAAEA4xMVL3QYEtxfOcDoaAADChqItgJAZ0TY423Y6fW0BAAAQ9hYJMyXLrKoAAED0oWgLIGTOax0v35EWCVtpkQAAAIBw6HqOFJ8obf9e2rLW6WgAAAgLirYAQqZRql+nN6ZFAgAAAMIopabUuVdwe+FMp6MBACAsKNoCCKnhbYItEqZRtAUAAEC4WyRQtAUARCmKtgDC0iJhyY6AtmTRIgEAAABh0H1Q8HrtUmnfTqejAQAg5CjaAgip9FS/zmhCiwQAAACEUb1GUpuuwe1Fs5yOBgCAkKNoCyDkhrdJsK+nUrQFAABAuJw+JHi9cIbTkQAAEHIUbQGE3Hmt4+T3SV/vDGhzJi0SAAAAEMa+tsvnS4eznY4GAICQomgLIOQa1vDrzMZx9jYLkgEAACAsTmorZbSQCvKkrz9xOhoAAEKKoi2AsBjeNt6+nraeoi0AAADCwOeTehyZbbtwptPRAAAQUhRtAYTF0FbBFgnf7AzoB1okAAAAIBx6Hulru2SOVJDvdDQAAIQMRVsAYdGghl9nNQm2SJi+vtDpcAAAABCNOnSXatWTDh6QVi10OhoAAEKGoi2AsBlR1CJhHUVbAAAAhIE/Tuo+ILhNiwQAQBShaAsgbM5tFa84n7R8d0Cbs31OhwMAAIBo1LNEX1vLcjoaAABCgqItgLCpn+JTr5OCLRJmbwnOugUAAABC6tQ+UkKStGuztGmV09EAABASFG0BhNWINsFi7SyKtgAAAAiH5BpSlz7B7YUznI4GAICQoGgLIKzObR1skbDmQJw2Hgg4HQ4AAACiUY+iFgkUbQEA0YGiLYCwqptsWiQE/6lhQTIAAACERfeBks8nbVgh7d7qdDQAAJwwirYAwm74kRYJ09cXOB0KAAAAolGdBlL77sHtRbOcjgYAgBNG0RZA2A1pGac4n6Xv9lhav58WCQAAAAiDnkUtEmY6HQkAACeMoi2AiLRIOD092Bph+jpm2wIAACAMegwJXn/7hXQoy+loAAA4IRRtAUTEwJOCxdqpFG0BAAAQDk1aSU3aSIX50tKPnY4GAIATQtEWQET0bVygBL+0ck9A6/bRIgEAAABhQIsEAECUoGgLICLSEqXeTYP/5Exjti0AAADCWbRd8rFUkOd0NAAAVBtFWwARM7x1vH1NiwQAAACERdvTpNoNpMPZ0oovnI4GAIBqo2gLIGIGt4yzWySs3hvQmr20SAAAAECI+f1Sj4HB7UW0SAAAeJeri7YPP/ywfD5fqUvHjh2dDgtANaUl+dSnWZy9TYsEAEAsIa8FIqjHkB/72lqW09EAAFAtwXOVXaxTp06aOfPHb0jj410fMoByjGgTrznfF9pF29tPT3Q6HAAAIoa8FoiQU8+WklKkvdulDcul1qc6HREAAFXm+kzRJLMZGRlOhwEgRAa3jFeiP1dr9gW0em+h2tcLzrwFACDakdcCEZKYLHU5R/rqo+BsW4q2AAAPcnV7BGPNmjVq0qSJWrdurauuukqbNm1yOiQAJ9gi4ZwjLRKmrqVFAgAgdpDXAhF0eokWCQAAeJCrZ9qeeeaZmjRpkjp06KBt27bpkUce0TnnnKPly5erVq1aZf5Obm6ufSmSmZlpXwcCAfsSCeZ1LMuK2OuhbIyDe8diWOs4zTrSIuGXPeLtvn6IDP4u3IFxcA/Gwltj4eVxqmpeS04Lt3P9/tG1n3z+OPk2rVRg0WypW3+nI4o5rt9H4Cj2D8Ty/hGo5PtyddF22LBhxdtdunSxk90WLVrozTff1JgxY8r8nfHjx9tJ8NF27dqlnJwcRerDP3DggL2D+c3qpXAE4+DeseiaKiX6U7Vuv7Rg3R61SYvOf4jdiL8Ld2Ac3IOx8NZYZGVlyauqmteS08LtvLB/pJ0xXDUWTJHv2Vu19xfPKr91F6dDiile2EfgHPYPxPL+kVXJnNbVRduj1alTR+3bt9fatWuP+5hx48bprrvuKjUroVmzZmrYsKHS0tIitnOZmYPmNaNx5/IKxsHdY9G3ea5mbizUF/vS1KstC5JFCn8X7sA4uAdj4a2xSE5OVrSoKK8lp4XbeWL/uPlJWYcz5ft6ruq9fK+sB/8lNe/odFQxwxP7CBzD/oFY3j+SK5nTeqpom52drXXr1ulnP/vZcR+TlJRkX45mBjmSA212rki/Jo7FOLh3LEa0ibeLttPWF+rOM3y0SIgg/i7cgXFwD8bCO2MRTWNUUV5LTgsvcP3+kZgk3fW89Pho+VYtkm/8ddIjb0gZLZ2OLGa4fh+Bo9g/EKv7h7+S78nV7/zXv/615s6dq40bN+rzzz/XRRddpLi4OF155ZVOhwbgBA1qGa/EOGn9fksr99IeAQAQ3chrAYckpUj3vBycYXtgt/T70dLeHU5HBQCAt4u2mzdvthNZs2DDZZddpvr162vBggX29GgA3lYz0af+zePs7WlrC5wOBwCAsCKvBRyUmibdP0lq1Fzatdmeeavs/U5HBQCAd9sj/Oc//3E6BABhNLxNvD7aUKip6wp01xmJtEgAAEQt8lrAYXUaSr95VXroMmnzGunJG4I/J9dwOjIAALw30xZAdBvYIl5JcdLGA5a+20OLBAAAAIRRerPgjNvU2tKaJdLTN0v5uU5HBQBAmSjaAnBFi4SptEgAAABAuDXrIN33ipRUQ/rmE+n5X0uBQqejAgDgGBRtAThqRNtgl5Zp6wpkWZbT4QAAACDatesm/eoFKS5BWjBNevkBiTwUAOAyFG0BOGpAi3glx0vfZ1pasZsWCQAAAIiALn2k256RfH5p9hvSf/7odEQAAJRC0RaAo1ITfBpwpEWCmW0LAAAARMRZw6Qbfhfc/t/fpSkvOR0RAADFKNoCcNyItgn2NS0SAAAAEFGDrpCuvCe4/a8npDlvOR0RAAA2irYAHGcWIzMtEjZlWlpOiwQAAABE0gU3SSPHBrcn3C99+aHTEQEAoOAKQADgoBoJPg1sEW/PtH1ifp66NeL7pHAxM5kPHkxU6sY8+Xy+iL1ueqpPV52SoDh/5F4TAACg0n56r5R9QJrzpvTnO6ShP5MSEp2OytN8llTz0EH5aqRKVUkB05tLAy6VIpirAoAbUbQF4Aoj2gSLtvO3FNoXhJM5AIl8/+CcfOnGbhz8AAAAFzIFwrGPSQczpS8/kKa+4nREnmdKrjWr+8u160s9BoU2IADwGIq2AFxhaOs43d8rUVuz6WkbVpalQ4cPqUZKjYjNXthz2NKUtQV6+qs8DWwZr7Z1mUkNAABcyB8n3fa0NKOntGuz09FExRlehw4dUo0aNSp/htemVdKK+dLkFynaAoh5FG0BuILf59MNpzELM9wCgYB27tyv9PQ68vv9EUvYM/Mszd1UqLtn5+iti1IUT5sEAADgRglJ0vDrnI4iKliBgLJ27lRKerp8lc079+2UbusnrVokrVoodegZ7jABwLWY7gQACCszs+LxfkmqlSh9vTOgl5bmOx0SAAAA3KhuutT3wuD25JecjgYAHEXRFgAQdo1r+vVg7yR7+7mv8rRqD32LAQAAUIbzxwbbeC2aKW1e43Q0AOAYirYAgIi4uEO8BraIU15AuntOrvIL6V8MAACAozRpLfUcEtyewmxbALGLoi0AIGJtEn7fL0m1k6TluwKaQJsEAAAAlGXUTcHrTydLe7Y5HQ0AOIKiLQAgYhql+vVQn2CbhD8vzNN3tEkAAADA0dqdJp18plSYL02b6HQ0AOAIirYAgIi6oF28hrSMU75pkzCbNgkAAAAow6ixwetZ/5GyDzgdDQBEHEVbAEDE2yQ81i9JdZKkb3cH9LfFtEkAAADAUU7rLzVrL+UclGa+7nQ0ABBxFG0BABHXsIZfj5wTbJPw/OI8rdhFmwQAAACU4PNJI28Mbk+fJOXlOh0RAEQURVsAgCPObxuv81rHqcC0SZiTqzzaJAAAAKCks8+XGjSRDuyW5v3X6WgAIKIo2gIAHGuT8Og5SaqXLK3cE9Dzi/KcDgkAAABuEp8gDb8+uP3+y1KAs7MAxA6KtgAAxzSo4dejfZPtbdPbdhltEgAAAFDSwMuk1NrS9u+lLz9yOhoAiJj4yL0UAADHGt4mXiPaxGvqugKNnnJYGTVj4PtEy1JBQYri4w8H+7V5VJxPuqlbgs5vm+B0KAAAIFolp0pDfya981dpygTpzPM8nT8BQGVRtAUAOM4sSvbltkLtOmRpf25AsSHOVG+PXLzr3jm56pIep+ZpMVBsBwAAzjjvGmnKS9K6b6RvF0idejkdEQCEHUVbAIDj6qX49P6lKVq1NzYKtlbA0v79+1WnTh35/N6dKfLXhXn6cltA987J0b9GpcjPrBcAABAOafWlAZdKH/1TmvwiRVsAMYGiLQDAFRrW8NuXWBAIBLQzsVDp6XHy+737nluk+TXsjUP6YmtAry3P1+hTE50OCQAARKsRY6QZr0tffyJ9/53U4mSnIwKAsPLukSIAAHBUszS/7uuVZG8/uSBPGw/ExkxpAADggEbNpbOGBbcnT3A6GgAIO4q2AACg2n7aKV5nnxSnnALp7tk5Kgx4u0cvAABwsVE3Ba/nT5V2bnY6GgAIK4q2AACg2kwf2ycHJCk1QVq0PaBJy/KdDgkAAESrVp2kU/tIgUJp2itORwMAYUXRFgAAnJCTavl1/9nBNgl//CJP6/fRJgEAAITJqBuD17PflDL3Oh0NAIQNRVsAAHDCrjg5Xn2axim3ULpnDm0SAABAmHQ+OzjjNi9H+vA1p6MBgLChaAsAAE6Yz+fTEwOSVDNRWrwjoH98Q5sEAAAQBj7fj71tP3pNyjnkdEQAEBYUbQEAQEg0qenXb4+0SfjTl3laS5sEAAAQDmcMldKbS1n7pI/fcjoaAAgLirYAACBkLu0Yr37N45RXKN09O0cFtEkAAAChFhcvnX9DcPv9V6QCzvABEH0o2gIAgJC2SRjfL0m1EqWvdwb00lIOogAAQBj0v0RKqyft3iItmO50NAAQchRtAQBASGXU9OvB3sE2Cc99ladVewqdDgkAAESbxGTpvNHB7SkTJIuzewBEl3inAwAAANHn4g7xmr6+QLO/L9Tdc3L1wtBk+X1ynUAgoD2HfSrMDsjPV9nF6iX7lBTvwgEDAKCkc6+W/vei9P130oJpUvvuTkeEygoE5N+/R4orFEkYQrZ/+PxS3fTggoVRgKItAAAIS5uE3/dL0nlvHNLyXQGd8083r+ycKinH6SBcJb2GTx9dUUNpSdGR8AIAolTNOtLAy6XpE6Xnful0NKgCU4ZLdzoIROf+0XuUdNszigYUbQEAQFg0SvVrfP9k3TMnR3kFciWr+L8+UZ4Myg9IOw9ZmrGhQJd0THA6HAAAyjdyrLR4lrRnu9ORoAosk38FUzCyMIRu/yjIkz6bLF34C6lZe3kdRVsAABA257WO13mta8qtTHuEnTt3Kj09XX5OzbP9eWGenv0qT1PXUbQFAHhAvUbSc3OcjgJVZJXIwXzkYAjV/vH0LdKXH0hTXpJufkpex18GAAAAig1vE/xO/9PNhTqQy6IuAAAA8IhRNwavzWzb3VvldRRtAQAAUKxtXb861POrICB9tMGlfS0AAACAo7XtKp1yplRYIE2fJK+jaAsAAIAyZ9tOW0vRFgAAAB4y6qbg9az/SNkH5GUUbQEAAFBm0fazLYXan0OLBAAAAHhE175S845SzkFpxj/lZRRtAQAAUEqbun51rE+LBAAAAHiMz/djb9sP/k/Ky5FXUbQFAADAMUYUtUhYR9EWAAAAHnLWcKlBE+nAHmnuO/IqirYAAAA4xrCiFgmbC7WPFgkAAADwivgEacSY4Pb7L0mBQnkRRVsAAAAco3Udv05p4FehJX20ntm2AAAA8JABl0k160g7NklffigvomgLAACAchckm0qLBAAAAHhJcg1p6M+C25NflCzvnTlG0RYAAADlFm3nbynUnsPeS3QBAAAQw4ZeIyUmS+uXSyvmy2so2gIAAKBMLWv71bmoRcIGZtsCAADAQ9LqSQMuDW5PniCvoWgLAACAChckm7qWoi0AAAA8ZsQYyR8nffOJtGGFvISiLQAAACpskbBga6F2Hwo4HQ4AAABQeenNpLOGB7envCQvoWgLAACA42phWiQ09Ctgt0godDocAAAAoGpGjg1ez58q7fxBXkHRFgAAAOUaUdQiYR0tEgAAAOAxrTpJXc6RrIA09RV5BUVbAAAAVKpFwhdbC7WLFgkAAADwmlE3Bq/nvCVl7pEXULQFAABAuZql+dUlPdgi4cP1tEgAAACAx3TqJbXuLOXlSB++Ji+gaAsAAIBKt0iYRosEAAAAeI3PJ426KbhtirY5h+R2FG0BAABQIVokAAAAwNPOGCo1ai5l75fmvCm3o2gLAACACp1Uy6/T0v2yJE1fz2xbAAAAeIw/Tjp/bHDbLEhWkC83o2gLAACAShne9kiLhLUUbQEAAOBB/S6WateXdm+VFkyTm1G0BQAAQKUMax0s2n61LaCdB2mRAAAAAI9JTJbOGx3cnjxBssx5ZO5E0RYAAACVbpHQrVGwRcIHtEgAAACAFw25WkpOlTatlL6eJ7fyRNH2+eefV8uWLZWcnKwzzzxTX375pdMhAQAAxPSCZFPXUbStDvJaAAAAh9WsLQ26Irg9+UW5leuLtm+88YbuuusuPfTQQ1q8eLG6du2qoUOHaufOnU6HBgAAEHOGHSnaLtwW0PZsWiRUBXktAACASwy7VoqLl779Qlr7tdzI9UXbp59+WmPHjtV1112nU045RX//+99Vo0YN/eMf/3A6NAAAgJjTpKZfPTJokVAd5LUAAAAu0aCJ1HvUj71tXSg4VcKl8vLytGjRIo0bN674Nr/fr8GDB2v+/Pll/k5ubq59KZKZmWlfBwIB+xIJ5nUsy4rY66FsjIN7MBbuwVi4A+PgHoxF9QxrHadF2wN2i4RrOsdHbCy8PE5VzWvJaeF27B+oCPsIysP+AVfsH+ffIP+8d2R99aGsLeukxq0UCZV9X64u2u7evVuFhYVq1KhRqdvNzytXrizzd8aPH69HHnnkmNt37dqlnJwcRerDP3DggL2DmWQczmAc3IOxcA/Gwh0YB/dgLKrn9DSfpFS7cLv8+11KT7EiMhZZWVnyqqrmteS0cDv2D1SEfQTlYf+AK/aPxNqq06m3kld8pkPvTVDWJXcqEiqb07q6aFsdZvaC6RVWclZCs2bN1LBhQ6WlpUVs5/L5fPZr8o+PcxgH92As3IOxcAfGwT0Yi+pJl3Tvmfnq3NCvkxunKM5virjhHwuzeFesIKeF27F/oCLsIygP+wdcs39cfqcCawcopf+lSkmuoUiobE7r6qJtgwYNFBcXpx07dpS63fyckZFR5u8kJSXZl6OZQY7kPwRm54r0a+JYjIN7MBbuwVi4A+PgHoxF9dzU/dh8K9xj4eUxqmpeS04LL2D/QEXYR1Ae9g+4Yv9o3y14iaDKvidX/2UkJiaqR48emjVrVqlqu/m5V69ejsYGAAAAVBZ5LQAAAKrC1TNtDXNa2OjRo9WzZ0+dccYZevbZZ3Xw4EF71V0AAADAK8hrAQAAEDVF28svv9xecOHBBx/U9u3bddppp+mDDz44ZhEHAAAAwM3IawEAABA1RVvj1ltvtS8AAACAl5HXAgAAwPM9bQEAAAAAAAAg1lC0BQAAAAAAAAAXoWgLAAAAAAAAAC5C0RYAAAAAAAAAXISiLQAAAAAAAAC4CEVbAAAAAAAAAHARirYAAAAAAAAA4CIUbQEAAAAAAADARSjaAgAAAAAAAICLULQFAAAAAAAAABehaAsAAAAAAAAALhKvKGdZln2dmZkZsdcMBALKyspScnKy/H7q4k5hHNyDsXAPxsIdGAf3YCy8NRZF+VxRfhdLyGnhNuwfqAj7CMrD/oFY3j8yK5nTRn3R1gyy0axZM6dDAQAAQIjyu9q1ayuWkNMCAADEVk7rs6J8qoKpzm/dulW1atWSz+eLWMXcJNQ//PCD0tLSIvKaOBbj4B6MhXswFu7AOLgHY+GtsTBpq0lumzRpEpWzLspDTgu3Yf9ARdhHUB72D8Ty/mFVMqeN+pm25s03bdrUkdc2O1Y07lxewzi4B2PhHoyFOzAO7sFYeGcsYm2GbRFyWrgV+wcqwj6C8rB/IFb3j9qVyGlja4oCAAAAAAAAALgcRVsAAAAAAAAAcBGKtmGQlJSkhx56yL6GcxgH92As3IOxcAfGwT0YC/dgLNyHMUF52D9QEfYRlIf9A+Vh/4iRhcgAAAAAAAAAwEuYaQsAAAAAAAAALkLRFgAAAAAAAABchKItAAAAAAAAALgIRdsQe/7559WyZUslJyfrzDPP1Jdfful0SFFv3rx5GjlypJo0aSKfz6f33nuv1P2mbfODDz6oxo0bKyUlRYMHD9aaNWscizdajR8/Xqeffrpq1aql9PR0XXjhhVq1alWpx+Tk5OiWW25R/fr1VbNmTV1yySXasWOHYzFHqxdeeEFdunRRWlqafenVq5emT59efD/j4IwnnnjC/jfqjjvuKL6NsYiMhx9+2P7sS146duxYfD/jEFlbtmzR1VdfbX/e5v/Lp556qhYuXFh8P//fdgdyWhQh10Z5OAZAeTguQVVwvHQsirYh9MYbb+iuu+6yV7hbvHixunbtqqFDh2rnzp1OhxbVDh48aH/W5uCiLH/4wx/05z//WX//+9/1xRdfKDU11R4X88eP0Jk7d679j+mCBQs0Y8YM5efn69xzz7XHp8idd96pKVOm6K233rIfv3XrVl188cWOxh2NmjZtav8Pb9GiRXYhZODAgbrgggu0YsUK+37GIfK++uorvfjii3bSWhJjETmdOnXStm3bii+ffvpp8X2MQ+Ts27dPvXv3VkJCgn3Q9u233+pPf/qT6tatW/wY/r/tPHJalESujfJwDIDycFyCyuJ46TgshMwZZ5xh3XLLLcU/FxYWWk2aNLHGjx/vaFyxxOzS7777bvHPgUDAysjIsJ566qni2/bv328lJSVZ//73vx2KMjbs3LnTHo+5c+cWf+4JCQnWW2+9VfyY7777zn7M/PnzHYw0NtStW9d6+eWXGQcHZGVlWe3atbNmzJhh9evXz7r99tvt2xmLyHnooYesrl27lnkf4xBZ9957r9WnT5/j3s//t92BnBbHQ66NinAMgIpwXIKjcbx0fMy0DZG8vDz72yNzOlARv99v/zx//nxHY4tlGzZs0Pbt20uNS+3ate3T/BiX8Dpw4IB9Xa9ePfva/H2Yb95LjoU5Pbl58+aMRRgVFhbqP//5jz3bwZyOxDhEnpl9MmLEiFKfucFYRJY5Vdec2tu6dWtdddVV2rRpk3074xBZkydPVs+ePXXppZfap9F269ZNL730UvH9/H/beeS0qAr+ZnE0jgFwPByX4Hg4Xjq++HLuQxXs3r3b/keoUaNGpW43P69cudKxuGKdSSKNssal6D6EXiAQsPvQmFNgO3fubN9mPu/ExETVqVOn1GMZi/BYtmyZnQyZUxNN7593331Xp5xyipYuXco4RJBJTM2pxeZ0n6PxNxE5pngwadIkdejQwW6N8Mgjj+icc87R8uXLGYcIW79+vd3fzpx6f//999t/G7/85S/tMRg9ejT/33YBclpUBX+zKIljAJSF4xKUh+Ol8lG0BRCWb8pMMaRkz0hElilOmUTIzHZ4++237WKI6QGEyPnhhx90++232/3dzEI+cM6wYcOKt02fLFPEbdGihd5880170RxE9oDezLR9/PHH7Z/NTFvz/wvTC9P8OwUA8C6OAVAWjktwPBwvVYz2CCHSoEEDxcXFHbOKnfk5IyPDsbhiXdFnz7hEzq233qr3339fc+bMsRvPFzGftznlcv/+/aUez1iEh/lGsm3bturRo4e9qq9ZQOS5555jHCLInM5jFu3p3r274uPj7YtJUM1iLWbbfEPMWDjDfFvfvn17rV27lr+JCDOry5vZNSWdfPLJxe0q+P+288hpURX8zaIIxwA4Ho5LcDwcL1WMom0I/yEy/wjNmjWr1GwS87M5FQDOaNWqlf3HXHJcMjMz7ZVtGZfQMmtTmGTNnO4ye/Zs+7Mvyfx9mNXCS47FqlWr7AN1xiL8zL9Hubm5jEMEDRo0yD4dzMwsKLqYGYamn2rRNmPhjOzsbK1bt84uIPI3EVnmlFnz+Za0evVqe+azwf+3nUdOi6rgbxYcA6CqOC5BEY6XKkZ7hBAy/dnMVH+zY51xxhl69tln7Sbb1113ndOhRf3Bt5ktVXJBBPMHbprfmwbVpq/SY489pnbt2tlJxAMPPGAvRnPhhRc6Gnc0ng71+uuv63//+59q1apV3GPGLEZhTj8212PGjLH/TszYpKWl6bbbbrP/sT3rrLOcDj+qjBs3zj4d3Oz/WVlZ9rh8/PHH+vDDDxmHCDJ/B0X93Iqkpqaqfv36xbczFpHx61//WiNHjrQLg1u3btVDDz1kzyS88sor+ZuIsDvvvFNnn3223R7hsssu05dffqkJEybYF8Pn8/H/bRcgp0VJ5NooD8cAKA/HJSgPx0uVYCGk/vKXv1jNmze3EhMTrTPOOMNasGCB0yFFvTlz5lhmVz76Mnr0aPv+QCBgPfDAA1ajRo2spKQka9CgQdaqVaucDjvqlDUG5jJx4sTixxw+fNi6+eabrbp161o1atSwLrroImvbtm2Oxh2Nrr/+eqtFixb2v0MNGza09/mPPvqo+H7GwTn9+vWzbr/99uKfGYvIuPzyy63GjRvbfxMnnXSS/fPatWuL72ccImvKlClW586d7f8nd+zY0ZowYUKp+/n/tjuQ06IIuTbKwzEAysNxCaqK46XSfOY/lSnuAgAAAAAAAADCj562AAAAAAAAAOAiFG0BAAAAAAAAwEUo2gIAAAAAAACAi1C0BQAAAAAAAAAXoWgLAAAAAAAAAC5C0RYAAAAAAAAAXISiLQAAAAAAAAC4CEVbAAAAAAAAAHARirYAgFImTZqkOnXqOB0GAAAAUG3ktAC8jqItAFTT9u3bdfvtt6tt27ZKTk5Wo0aN1Lt3b73wwgs6dOiQvKBly5Z69tlnS912+eWXa/Xq1Y7FBAAAgMghpwUAd4p3OgAA8KL169fbyaz59v7xxx/XqaeeqqSkJC1btkwTJkzQSSedpFGjRjkSm2VZKiwsVHx89f6JT0lJsS8AAACIbuS0AOBezLQFgGq4+eab7QRy4cKFuuyyy3TyySerdevWuuCCCzR16lSNHDnSftz+/ft1ww03qGHDhkpLS9PAgQP19ddfFz/Pww8/rNNOO02vvfaaPUOgdu3auuKKK5SVlVX8mEAgoPHjx6tVq1Z24tm1a1e9/fbbxfd//PHH8vl8mj59unr06GEn2p9++qnWrVtnx2NmS9SsWVOnn366Zs6cWfx7/fv31/fff68777zT/n1zOd6pZGamRZs2bZSYmKgOHTrY8ZZkfvfll1/WRRddpBo1aqhdu3aaPHlyGD55AAAAhAo5LTktAPeiaAsAVbRnzx599NFHuuWWW5SamlrmY4qSxUsvvVQ7d+60k89Fixape/fuGjRokPbu3Vv8WJOIvvfee3r//ffty9y5c/XEE08U32+S21dffVV///vftWLFCjshvfrqq+3HlXTffffZv/fdd9+pS5cuys7O1vDhwzVr1iwtWbJE5513np14b9q0yX78O++8o6ZNm+rRRx/Vtm3b7EtZ3n33XfuUuV/96ldavny5brrpJl133XWaM2dOqcc98sgjdrL/zTff2K971VVXlXqfAAAAcA9yWnJaAC5nAQCqZMGCBZb55/Odd94pdXv9+vWt1NRU+3LPPfdYn3zyiZWWlmbl5OSUelybNm2sF1980d5+6KGHrBo1aliZmZnF9999993WmWeeaW+b3zX3f/7556WeY8yYMdaVV15pb8+ZM8eO57333qsw9k6dOll/+ctfin9u0aKF9cwzz5R6zMSJE63atWsX/3z22WdbY8eOLfWYSy+91Bo+fHjxz+b1f/vb3xb/nJ2dbd82ffr0CmMCAABA5JHTktMCcDd62gJAiHz55Zf2aV/m2/jc3Fz7lDEzM6B+/fqlHnf48GF7JkIRcwpZrVq1in9u3LixPZPBWLt2rb0AxJAhQ0o9R15enrp161bqtp49e5b62by2OVXNnNpmZhwUFBTYr100K6GyzCyHG2+8sdRtpvfZc889V+o2MxOiiJmtYU6dK3ofAAAA8AZyWnJaAO5A0RYAqsisrGtOFVu1alWp203/L6NowQOTYJpk1fTnOlrJ/loJCQml7jPPbRLloucwTJJqFoIoyfT5Kuno09p+/etfa8aMGfrjH/9ox2zi+slPfmInx+FQ3vsAAACAu5DTlo2cFoBbULQFgCoyswzMLIG//vWvuu22247bA8z0+tq+fbu9uIOZeVAdp5xyip3ImpkE/fr1q9LvfvbZZ7r22mvthRSKkuWNGzeWeoxZhMGsylsesyCFea7Ro0eXem4TGwAAALyJnJacFoC7UbQFgGr429/+Zp9OZU7fMqdrmdOo/H6/vvrqK61cudJe8Xbw4MHq1auXLrzwQv3hD39Q+/bttXXrVnuGgUk6jz71qyzmFDMzu8As1GC+4e/Tp48OHDhgJ5jmVK2SSefRzGq3ZmEGs1CDmSHwwAMPHDNLwCTe8+bNs1f3NYl0gwYNjnmeu+++216MwZy6Zt7TlClT7OctuWovAAAAvIeclpwWgHtRtAWAamjTpo29eu3jjz+ucePGafPmzXaCaL6pNwnpzTffbCeV06ZN029+8xt7Zdpdu3YpIyNDffv2VaNGjSr9Wr/73e/UsGFDe8Xd9evX26ehmRkP999/f7m/9/TTT+v666/X2WefbSeu9957rzIzM0s9xqyya1bONe/H9CwLrr9QmknQTa8vc0qaWXG3VatWmjhxovr371+FTwwAAABuQ05LTgvAvXxmNTKngwAAAAAAAAAABPmPXAMAAAAAAAAAXICiLQAAAAAAAAC4CEVbAAAAAAAAAHARirYAAAAAAAAA4CIUbQEAAAAAAADARSjaAgAAAAAAAICLULQFAAAAAAAAABehaAsAAAAAAAAALkLRFgAAAAAAAABchKItAAAAAAAAALgIRVsAAAAAAAAAcBGKtgAAAAAAAAAg9/h/vwEX7aSBsZ4AAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 1400x500 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -1601,21 +1574,22 @@
     "\n",
     "    Chaque gene de l'enfant est pris aleatoirement\n",
     "    du parent 1 ou du parent 2 (probabilite p=0.5).\n",
+    "\n",
+    "    Args:\n",
+    "        parents: Tableau numpy des parents selectionnes (shape: n_parents x n_genes)\n",
+    "        offspring_size: Tuple (n_offspring, n_genes)\n",
+    "        ga_instance: Instance PyGAD courante\n",
+    "\n",
+    "    Returns:\n",
+    "        Tableau numpy des enfants (shape: offspring_size)\n",
     "    \"\"\"\n",
-    "    offspring = []\n",
-    "    for _ in range(offspring_size[0]):\n",
-    "        parent1_idx = np.random.randint(0, parents.shape[0])\n",
-    "        parent2_idx = np.random.randint(0, parents.shape[0])\n",
-    "        parent1 = parents[parent1_idx]\n",
-    "        parent2 = parents[parent2_idx]\n",
-    "\n",
-    "        # Pour chaque gene, choisir aleatoirement parent1 ou parent2\n",
-    "        num_genes = parent1.shape[0]\n",
-    "        mask = np.random.randint(0, 2, size=num_genes)  # 0 ou 1 pour chaque gene\n",
-    "        child = np.where(mask == 0, parent1, parent2)\n",
-    "        offspring.append(child)\n",
-    "\n",
-    "    return np.array(offspring)\n",
+    "    # TODO etudiant : implementez le croisement uniforme\n",
+    "    # Indications :\n",
+    "    #   1. Pour chaque enfant, choisir 2 parents aleatoirement\n",
+    "    #   2. Pour chaque gene, choisir aleatoirement parent1 ou parent2\n",
+    "    #   3. Utilisez np.random.randint(0, 2, size=num_genes) pour le masque\n",
+    "    #   4. Utilisez np.where(mask == 0, parent1, parent2) pour construire l'enfant\n",
+    "    pass\n",
     "\n",
     "\n",
     "class UniformCrossoverSolver(PermutationGeneticSolver):\n",
@@ -1627,87 +1601,26 @@
     "    \"\"\"\n",
     "\n",
     "    def solve(self, puzzle: SudokuGrid) -> Tuple[SudokuGrid, bool]:\n",
-    "        self.puzzle = puzzle\n",
-    "        self.best_fitness_history = []\n",
+    "        \"\"\"Resout le Sudoku avec croisement uniforme.\n",
     "\n",
-    "        self.valid_perms = self._compute_valid_permutations(puzzle)\n",
+    "        TODO etudiant : reprenez la methode solve() de PermutationGeneticSolver\n",
+    "        et remplacez uniquement crossover_type=\"single_point\" par\n",
+    "        crossover_type=uniform_crossover (votre fonction definie ci-dessus).\n",
     "\n",
-    "        for i, perms in enumerate(self.valid_perms):\n",
-    "            if len(perms) == 0:\n",
-    "                print(f\"Erreur: Ligne {i} n'a aucune permutation valide!\")\n",
-    "                return puzzle.clone(), False\n",
-    "\n",
-    "        def fitness_func(ga_instance, solution, solution_idx):\n",
-    "            grid = self._solution_to_grid(solution)\n",
-    "            errors = self._count_column_block_errors(grid)\n",
-    "            return -errors\n",
-    "\n",
-    "        def on_generation(ga_instance):\n",
-    "            best = ga_instance.best_solution()[1]\n",
-    "            self.best_fitness_history.append(-best)\n",
-    "\n",
-    "        gene_space = [list(range(len(perms))) for perms in self.valid_perms]\n",
-    "\n",
-    "        ga = pygad.GA(\n",
-    "            num_generations=self.num_generations,\n",
-    "            num_parents_mating=self.population_size // 4,\n",
-    "            fitness_func=fitness_func,\n",
-    "            sol_per_pop=self.population_size,\n",
-    "            num_genes=9,\n",
-    "            gene_type=int,\n",
-    "            gene_space=gene_space,\n",
-    "            parent_selection_type=\"tournament\",\n",
-    "            crossover_type=uniform_crossover,  # operateur personnalise\n",
-    "            mutation_type=\"random\",\n",
-    "            mutation_percent_genes=20,\n",
-    "            on_generation=on_generation,\n",
-    "            stop_criteria=\"reach_0\",\n",
-    "            suppress_warnings=True,\n",
-    "        )\n",
-    "\n",
-    "        ga.run()\n",
-    "\n",
-    "        solution, fitness, _ = ga.best_solution()\n",
-    "        result_grid = self._solution_to_grid(solution)\n",
-    "\n",
-    "        return result_grid, result_grid.is_solved()\n",
+    "        Le reste de la configuration PyGAD est identique.\n",
+    "        \"\"\"\n",
+    "        # TODO etudiant : reprenez le code de PermutationGeneticSolver.solve()\n",
+    "        # et remplacez crossover_type par votre operateur uniform_crossover\n",
+    "        return puzzle.clone(), False\n",
     "\n",
     "\n",
     "# Benchmark et comparaison des courbes de convergence\n",
-    "test_grid = SudokuGrid.from_string(easy_puzzles[0])\n",
-    "\n",
-    "print(\"=== Comparaison SinglePoint vs Uniforme ===\")\n",
-    "\n",
-    "solver_sp = PermutationGeneticSolver(num_generations=300, population_size=200)\n",
-    "start = time.time()\n",
-    "result_sp, solved_sp = solver_sp.solve(test_grid)\n",
-    "time_sp = time.time() - start\n",
-    "\n",
-    "solver_uc = UniformCrossoverSolver(num_generations=300, population_size=200)\n",
-    "start = time.time()\n",
-    "result_uc, solved_uc = solver_uc.solve(test_grid)\n",
-    "time_uc = time.time() - start\n",
-    "\n",
-    "print(f\"SinglePoint  : resolu={solved_sp}, erreurs={result_sp.count_errors()}, temps={time_sp:.2f}s, generations={len(solver_sp.best_fitness_history)}\")\n",
-    "print(f\"Uniforme     : resolu={solved_uc}, erreurs={result_uc.count_errors()}, temps={time_uc:.2f}s, generations={len(solver_uc.best_fitness_history)}\")\n",
-    "\n",
-    "# Courbes de convergence cote a cote\n",
-    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 5))\n",
-    "\n",
-    "ax1.plot(solver_sp.best_fitness_history, color='#2196F3', linewidth=1.5)\n",
-    "ax1.set_title(\"Single-Point Crossover\")\n",
-    "ax1.set_xlabel(\"Generation\")\n",
-    "ax1.set_ylabel(\"Erreurs\")\n",
-    "ax1.grid(True, alpha=0.3)\n",
-    "\n",
-    "ax2.plot(solver_uc.best_fitness_history, color='#FF5722', linewidth=1.5)\n",
-    "ax2.set_title(\"Croisement Uniforme\")\n",
-    "ax2.set_xlabel(\"Generation\")\n",
-    "ax2.set_ylabel(\"Erreurs\")\n",
-    "ax2.grid(True, alpha=0.3)\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.show()\n"
+    "# Testez votre solveur ici :\n",
+    "# test_grid = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "# solver_uc = UniformCrossoverSolver(num_generations=300, population_size=200)\n",
+    "# result_uc, solved_uc = solver_uc.solve(test_grid)\n",
+    "# print(f\"Uniforme : resolu={solved_uc}, erreurs={result_uc.count_errors()}\")\n",
+    "print(\"Exercice a completer - implementez uniform_crossover et UniformCrossoverSolver.solve\")\n"
    ]
   },
   {
@@ -1715,10 +1628,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.004763,
-     "end_time": "2026-04-25T15:00:55.870059",
+     "duration": 0.006383,
+     "end_time": "2026-05-14T07:43:57.953170+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:00:55.865296",
+     "start_time": "2026-05-14T07:43:57.946787+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1751,18 +1664,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 114.114381,
-   "end_time": "2026-04-25T15:00:56.228251",
+   "duration": 228.556072,
+   "end_time": "2026-05-14T07:43:58.103191+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-3-Genetic-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T14:59:02.113870",
+   "start_time": "2026-05-14T07:40:09.547119+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "67435a9a",
    "metadata": {
     "papermill": {
-     "duration": 0.00269,
-     "end_time": "2026-05-13T08:02:06.105293",
+     "duration": 0.021778,
+     "end_time": "2026-05-14T07:32:39.635495+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.102603",
+     "start_time": "2026-05-14T07:32:39.613717+00:00",
      "status": "completed"
     },
     "tags": []
@@ -28,10 +28,10 @@
    "id": "3ff35849",
    "metadata": {
     "papermill": {
-     "duration": 0.002497,
-     "end_time": "2026-05-13T08:02:06.109789",
+     "duration": 0.008811,
+     "end_time": "2026-05-14T07:32:39.661893+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.107292",
+     "start_time": "2026-05-14T07:32:39.653082+00:00",
      "status": "completed"
     },
     "tags": []
@@ -64,10 +64,10 @@
    "id": "e1bbeb9d",
    "metadata": {
     "papermill": {
-     "duration": 0.002001,
-     "end_time": "2026-05-13T08:02:06.114790",
+     "duration": 0.007836,
+     "end_time": "2026-05-14T07:32:39.675395+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.112789",
+     "start_time": "2026-05-14T07:32:39.667559+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,16 +82,16 @@
    "id": "cell-1-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.120789Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.120789Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.128937Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.127929Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.682026Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.681852Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.690272Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.689452Z"
     },
     "papermill": {
-     "duration": 0.012147,
-     "end_time": "2026-05-13T08:02:06.128937",
+     "duration": 0.012817,
+     "end_time": "2026-05-14T07:32:39.690947+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.116790",
+     "start_time": "2026-05-14T07:32:39.678130+00:00",
      "status": "completed"
     },
     "tags": []
@@ -118,10 +118,10 @@
    "id": "59f3d83a",
    "metadata": {
     "papermill": {
-     "duration": 0.001908,
-     "end_time": "2026-05-13T08:02:06.133909",
+     "duration": 0.004862,
+     "end_time": "2026-05-14T07:32:39.698274+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.132001",
+     "start_time": "2026-05-14T07:32:39.693412+00:00",
      "status": "completed"
     },
     "tags": []
@@ -148,10 +148,10 @@
    "id": "ca285f16",
    "metadata": {
     "papermill": {
-     "duration": 0.002994,
-     "end_time": "2026-05-13T08:02:06.139936",
+     "duration": 0.00563,
+     "end_time": "2026-05-14T07:32:39.714089+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.136942",
+     "start_time": "2026-05-14T07:32:39.708459+00:00",
      "status": "completed"
     },
     "tags": []
@@ -168,16 +168,16 @@
    "id": "cell-2-constants",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.196282Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.196282Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.202100Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.201597Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.742363Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.741475Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.755018Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.753229Z"
     },
     "papermill": {
-     "duration": 0.060165,
-     "end_time": "2026-05-13T08:02:06.202100",
+     "duration": 0.031415,
+     "end_time": "2026-05-14T07:32:39.756085+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.141935",
+     "start_time": "2026-05-14T07:32:39.724670+00:00",
      "status": "completed"
     },
     "tags": []
@@ -226,10 +226,10 @@
    "id": "c6283f68",
    "metadata": {
     "papermill": {
-     "duration": 0.002802,
-     "end_time": "2026-05-13T08:02:06.207921",
+     "duration": 0.004574,
+     "end_time": "2026-05-14T07:32:39.765082+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.205119",
+     "start_time": "2026-05-14T07:32:39.760508+00:00",
      "status": "completed"
     },
     "tags": []
@@ -260,16 +260,16 @@
    "id": "cell-3-assign-eliminate",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.213920Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.212922Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.217878Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.217878Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.775571Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.775378Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.783358Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.781922Z"
     },
     "papermill": {
-     "duration": 0.008962,
-     "end_time": "2026-05-13T08:02:06.218882",
+     "duration": 0.014814,
+     "end_time": "2026-05-14T07:32:39.785417+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.209920",
+     "start_time": "2026-05-14T07:32:39.770603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -318,10 +318,10 @@
    "id": "021ed51f",
    "metadata": {
     "papermill": {
-     "duration": 0.002513,
-     "end_time": "2026-05-13T08:02:06.223395",
+     "duration": 0.002966,
+     "end_time": "2026-05-14T07:32:39.791747+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.220882",
+     "start_time": "2026-05-14T07:32:39.788781+00:00",
      "status": "completed"
     },
     "tags": []
@@ -342,16 +342,16 @@
    "id": "cell-4-parse",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.228904Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.228904Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.232924Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.232924Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.805618Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.805247Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.813323Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.811886Z"
     },
     "papermill": {
-     "duration": 0.008534,
-     "end_time": "2026-05-13T08:02:06.233929",
+     "duration": 0.018773,
+     "end_time": "2026-05-14T07:32:39.814449+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.225395",
+     "start_time": "2026-05-14T07:32:39.795676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -390,10 +390,10 @@
    "id": "848caf7d",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-05-13T08:02:06.237928",
+     "duration": 0.00659,
+     "end_time": "2026-05-14T07:32:39.825609+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.235929",
+     "start_time": "2026-05-14T07:32:39.819019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -421,16 +421,16 @@
    "id": "cell-5-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.243870Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.243870Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.248664Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.248157Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.835749Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.835166Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.842393Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.841465Z"
     },
     "papermill": {
-     "duration": 0.007302,
-     "end_time": "2026-05-13T08:02:06.248664",
+     "duration": 0.013925,
+     "end_time": "2026-05-14T07:32:39.843147+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.241362",
+     "start_time": "2026-05-14T07:32:39.829222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -464,10 +464,10 @@
    "id": "f5e7edea",
    "metadata": {
     "papermill": {
-     "duration": 0.001998,
-     "end_time": "2026-05-13T08:02:06.253674",
+     "duration": 0.01074,
+     "end_time": "2026-05-14T07:32:39.857728+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.251676",
+     "start_time": "2026-05-14T07:32:39.846988+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,16 +484,16 @@
    "id": "cell-6-display",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.260380Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.259385Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.263951Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.263431Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.873836Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.873485Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.879340Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.878447Z"
     },
     "papermill": {
-     "duration": 0.00809,
-     "end_time": "2026-05-13T08:02:06.264960",
+     "duration": 0.016028,
+     "end_time": "2026-05-14T07:32:39.880198+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.256870",
+     "start_time": "2026-05-14T07:32:39.864170+00:00",
      "status": "completed"
     },
     "tags": []
@@ -518,10 +518,10 @@
    "id": "test-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003026,
-     "end_time": "2026-05-13T08:02:06.269984",
+     "duration": 0.003959,
+     "end_time": "2026-05-14T07:32:39.889943+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.266958",
+     "start_time": "2026-05-14T07:32:39.885984+00:00",
      "status": "completed"
     },
     "tags": []
@@ -538,16 +538,16 @@
    "id": "cell-7-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.275758Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.275758Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.283193Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.283193Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.895973Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.895806Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.903897Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.903146Z"
     },
     "papermill": {
-     "duration": 0.012397,
-     "end_time": "2026-05-13T08:02:06.284388",
+     "duration": 0.011979,
+     "end_time": "2026-05-14T07:32:39.904535+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.271991",
+     "start_time": "2026-05-14T07:32:39.892556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,7 +572,7 @@
       "\n",
       "Resolution...\n",
       "\n",
-      "Resolu en 2.01 ms\n",
+      "Resolu en 1.61 ms\n",
       "4 8 3 |9 2 1 |6 5 7 \n",
       "9 6 7 |3 4 5 |8 2 1 \n",
       "2 5 1 |8 7 6 |4 9 3 \n",
@@ -609,10 +609,10 @@
    "id": "f50e4660",
    "metadata": {
     "papermill": {
-     "duration": 0.00271,
-     "end_time": "2026-05-13T08:02:06.289102",
+     "duration": 0.002243,
+     "end_time": "2026-05-14T07:32:39.908712+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.286392",
+     "start_time": "2026-05-14T07:32:39.906469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -629,16 +629,16 @@
    "id": "cell-8-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.295299Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.295299Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.365589Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.365589Z"
+     "iopub.execute_input": "2026-05-14T07:32:39.919046Z",
+     "iopub.status.busy": "2026-05-14T07:32:39.918786Z",
+     "iopub.status.idle": "2026-05-14T07:32:39.993357Z",
+     "shell.execute_reply": "2026-05-14T07:32:39.992759Z"
     },
     "papermill": {
-     "duration": 0.074597,
-     "end_time": "2026-05-13T08:02:06.366705",
+     "duration": 0.082156,
+     "end_time": "2026-05-14T07:32:39.994080+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.292108",
+     "start_time": "2026-05-14T07:32:39.911924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -649,21 +649,21 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Benchmark: Puzzles Faciles (20 puzzles)\n",
-      "  Resolus: 20/20\n",
-      "  Temps total: 36.61 ms\n",
-      "  Temps moyen: 1.83 ms/puzzle\n",
-      "\n",
-      "Benchmark: Puzzles Difficiles (11 puzzles)\n"
+      "Benchmark: Puzzles Faciles (20 puzzles)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  Resolus: 20/20\n",
+      "  Temps total: 35.68 ms\n",
+      "  Temps moyen: 1.78 ms/puzzle\n",
+      "\n",
+      "Benchmark: Puzzles Difficiles (11 puzzles)\n",
       "  Resolus: 11/11\n",
-      "  Temps total: 26.09 ms\n",
-      "  Temps moyen: 2.37 ms/puzzle\n"
+      "  Temps total: 29.81 ms\n",
+      "  Temps moyen: 2.71 ms/puzzle\n"
      ]
     }
    ],
@@ -708,10 +708,10 @@
    "id": "162evydrpdu",
    "metadata": {
     "papermill": {
-     "duration": 0.003508,
-     "end_time": "2026-05-13T08:02:06.372212",
+     "duration": 0.002928,
+     "end_time": "2026-05-14T07:32:39.999347+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.368704",
+     "start_time": "2026-05-14T07:32:39.996419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -739,10 +739,10 @@
    "id": "gy8q93llr0t",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-13T08:02:06.377218",
+     "duration": 0.002791,
+     "end_time": "2026-05-14T07:32:40.005408+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.374218",
+     "start_time": "2026-05-14T07:32:40.002617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -777,16 +777,16 @@
    "id": "sw7jd6fdkc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.382724Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.382724Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.391609Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.391609Z"
+     "iopub.execute_input": "2026-05-14T07:32:40.010711Z",
+     "iopub.status.busy": "2026-05-14T07:32:40.010497Z",
+     "iopub.status.idle": "2026-05-14T07:32:40.018193Z",
+     "shell.execute_reply": "2026-05-14T07:32:40.017437Z"
     },
     "papermill": {
-     "duration": 0.013398,
-     "end_time": "2026-05-13T08:02:06.392616",
+     "duration": 0.011102,
+     "end_time": "2026-05-14T07:32:40.018863+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.379218",
+     "start_time": "2026-05-14T07:32:40.007761+00:00",
      "status": "completed"
     },
     "tags": []
@@ -797,18 +797,10 @@
      "output_type": "stream",
      "text": [
       "Puzzle 4x4:\n",
-      " 1  23| 23 4 \n",
-      " 23 4 | 1  23\n",
-      "------+------\n",
-      " 23 1 | 4  23\n",
-      " 4  23| 23 1 \n",
+      "Exercice a completer\n",
       "\n",
       "Solution 4x4:\n",
-      "1 2 |3 4 \n",
-      "3 4 |1 2 \n",
-      "----+----\n",
-      "2 1 |4 3 \n",
-      "4 3 |2 1 \n"
+      "Exercice a completer\n"
      ]
     }
    ],
@@ -878,17 +870,23 @@
     "    return search4(parse_grid4(grid))\n",
     "\n",
     "def display_4x4(values):\n",
-    "    if not values:\n",
-    "        return \"Pas de solution\"\n",
-    "    width = 1 + max(len(values[s]) for s in squares4)\n",
-    "    line = '+'.join(['-' * (width * 2)] * 2)\n",
-    "    result = []\n",
-    "    for r in rows4:\n",
-    "        result.append(''.join(values[r + c].center(width) + ('|' if c == '2' else '')\n",
-    "                              for c in cols4))\n",
-    "        if r == 'B':\n",
-    "            result.append(line)\n",
-    "    return '\\n'.join(result)\n",
+    "    \"\"\"Affiche une grille de Sudoku 4x4.\n",
+    "\n",
+    "    Args:\n",
+    "        values: dictionnaire {square: candidats} ou None\n",
+    "\n",
+    "    Returns:\n",
+    "        Representation texte de la grille 4x4 avec separateurs\n",
+    "        de blocs 2x2.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez l'affichage 4x4\n",
+    "    # Indications :\n",
+    "    #   1. Si values est None, retourner \"Pas de solution\"\n",
+    "    #   2. Calculer la largeur max d'une cellule\n",
+    "    #   3. Construire les lignes avec '|' entre les colonnes 2 et 3\n",
+    "    #   4. Ajouter une ligne de separation apres la ligne 'B'\n",
+    "    #   5. Retourner le resultat join par '\\n'\n",
+    "    return \"Exercice a completer\"\n",
     "\n",
     "\n",
     "test_4x4 = \"1004041001404001\"\n",
@@ -904,10 +902,10 @@
    "id": "31556af2",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-13T08:02:06.397718",
+     "duration": 0.002087,
+     "end_time": "2026-05-14T07:32:40.023107+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.394718",
+     "start_time": "2026-05-14T07:32:40.021020+00:00",
      "status": "completed"
     },
     "tags": []
@@ -941,16 +939,16 @@
    "id": "f183e45e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.404152Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.404152Z",
-     "iopub.status.idle": "2026-05-13T08:02:06.408488Z",
-     "shell.execute_reply": "2026-05-13T08:02:06.408488Z"
+     "iopub.execute_input": "2026-05-14T07:32:40.028255Z",
+     "iopub.status.busy": "2026-05-14T07:32:40.028111Z",
+     "iopub.status.idle": "2026-05-14T07:32:40.032687Z",
+     "shell.execute_reply": "2026-05-14T07:32:40.031975Z"
     },
     "papermill": {
-     "duration": 0.009776,
-     "end_time": "2026-05-13T08:02:06.409494",
+     "duration": 0.007809,
+     "end_time": "2026-05-14T07:32:40.033281+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.399718",
+     "start_time": "2026-05-14T07:32:40.025472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1005,10 +1003,10 @@
    "id": "b00eeb33",
    "metadata": {
     "papermill": {
-     "duration": 0.002658,
-     "end_time": "2026-05-13T08:02:06.414153",
+     "duration": 0.002244,
+     "end_time": "2026-05-14T07:32:40.037935+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.411495",
+     "start_time": "2026-05-14T07:32:40.035691+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1057,18 +1055,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.541115,
-   "end_time": "2026-05-13T08:02:06.542951",
+   "duration": 1.944464,
+   "end_time": "2026-05-14T07:32:40.168117+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku7.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-13T08:02:05.001836",
+   "start_time": "2026-05-14T07:32:38.223653+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary
- Remove solution leaks in 3 Sudoku notebooks: Sudoku-1-Backtracking, Sudoku-3-Genetic, Sudoku-7-Norvig
- Fix exercise stubs to use `pass` / `return None  # TODO etudiant` patterns (rule C.1)
- Re-execute all 3 notebooks via Papermill (SUCCESS)

## Test plan
- [x] Papermill execution: Sudoku-1 SUCCESS (34.3s), Sudoku-3 SUCCESS (229.5s), Sudoku-7 SUCCESS (2.6s)
- [x] No `raise NotImplementedError` in any cell
- [x] All code cells have `execution_count != null`

Refs #362