### PR TITLE
fix(pedagogy): add interpretation markdown to ML-1, Lab12, Lab17

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -764,6 +764,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fe5f6ba1",
+   "source": "### Interpretation : Premier test du pipeline\n\n**Resultat obtenu** : Le pipeline echoue sur cette question — le code genere par le LLM tente d'ouvrir `sales.csv` directement au lieu d'utiliser le chemin absolu du fichier temporaire.\n\n**Analyse de l'echec** :\n\n| Etape | Statut | Detail |\n|-------|--------|--------|\n| FileAnalyzer | OK | Fichier detecte, 150 lignes, 5 colonnes |\n| Planner | OK | 3 etapes planifiees |\n| Coder | OK | Code genere |\n| Executor | ERREUR | `No such file or directory: 'sales.csv'` |\n\n**Cause** : Le LLM ne connait pas le chemin absolu du fichier temporaire. Le contexte transmis au Coder contient le nom du fichier mais pas le chemin complet. C'est une limitation courante des systemes LLM-based — le contexte fourni au prompt doit inclure toutes les informations necessaires.\n\n**Amelioration** : Transmettre le chemin complet dans le contexte du Coder, pas seulement le nom du fichier.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-19",
    "metadata": {
     "papermill": {
@@ -855,6 +861,12 @@
     "print(\"=\"*50)\n",
     "print(result2.get('output', result2.get('error', 'Pas de resultat'))[:400])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da57074f",
+   "source": "### Interpretation : Analyse temporelle avec erreur de colonne\n\n**Resultat obtenu** : La seconde question produit un resultat partiel — le LLM genere du code avec une erreur de nom de colonne (`revenue` vs `revenu`), puis une deuxieme tentative retourne un apercu des donnees.\n\n**Points cles** :\n\n1. **Erreur de schema** : Le LLM genere `revenue` au lieu de `revenue` — une confusion frequente entre singulier/pluriel ou FR/EN dans les noms de colonnes\n2. **Resultat partiel** : Malgre l'erreur, le pipeline retourne un apercu des donnees transformees (extraction annee/mois)\n3. **Limitation de max_iterations=1** : Avec une seule iteration, le pipeline ne peut pas corriger automatiquement l'erreur. Avec `max_iterations=2` ou plus, le Verifier aurait detecte l'erreur et relance une iteration avec le contexte corrige\n4. **Robustesse du pipeline** : La boucle iterative est precisement concue pour gerer ce type d'erreur — le contexte s'enrichit a chaque tentative",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/AgenticDataScience/Day7-Production/Lab17-Final-Project.ipynb
@@ -762,6 +762,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "58ed476a",
+   "source": "### Interpretation : Execution du pipeline complet\n\n**Resultat obtenu** : Le pipeline DS-STAR s'execute sur le dataset de ventes mais produit un resultat partiel — le Planner genere 0 etape et le Verifier classe le resultat comme `needs_refinement`.\n\n**Analyse des etapes** :\n\n| Composant | Resultat | Observation |\n|-----------|----------|-------------|\n| FileAnalyzer | OK | Fichier detecte : 200 lignes |\n| Planner | 0 etapes | Le LLM n'a pas decompose la question correctement |\n| Coder | Code genere | Malgre 0 etapes formelles, du code est produit |\n| Executor | OK | Le code s'execute sans erreur |\n| Verifier | needs_refinement | Le resultat ne repond pas completement a la question |\n\n**Cause probable** : Le prompt du Planner demande un format strict (REASONING + STEPS numerotes). Si le LLM ne respecte pas exactement ce format, le parseur par expression reguliere echoue a extraire les etapes. C'est une limitation courante des approches de parsing structure basees sur des regex.\n\n**Point pedagogique** : Avec `max_iterations=1`, le pipeline ne peut pas retenter. En augmentant a `max_iterations=2` ou 3, le contexte enrichi apres la premiere iteration permettrait au Planner de mieux repondre.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-19",
    "metadata": {
     "papermill": {
@@ -838,6 +844,12 @@
     "print(chr(10) + \"=\"*50 + chr(10) + \"RAPPORT\" + chr(10) + \"=\"*50)\n",
     "print(result[\"report\"][:800])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68099cdf",
+   "source": "### Interpretation : Rapport genere par le LLM\n\n**Resultat obtenu** : Le pipeline produit un rapport Markdown structure avec context, methodologie, analyse par region et observations — malgre l'echec partiel de l'etape de verification.\n\n**Analyse du rapport** :\n\n| Section | Contenu | Qualite |\n|---------|---------|---------|\n| Contexte | Description du dataset | Correct (200 lignes, fichier identifie) |\n| Methodologie | Etapes d'analyse | Standard mais generique |\n| Tableau de resultats | Ventes par region | **Donnees fictives** — le LLM invente les chiffres |\n| Observations | Interpretations | Coherentes avec les donnees fictives |\n\n**Point critique** : Les montants du tableau (123 456 euros, etc.) sont generes par le LLM et ne correspondent PAS aux donnees reelles du dataset. Le rapport inclut d'ailleurs une note \"Les montants sont des exemples, a remplacer par les resultats reels\". C'est un phenomene classique d'hallucination du LLM quand il n'a pas acces aux resultats d'execution.\n\n**Amelioration** : Injecter les resultats reels de l'Executor dans le prompt du ReportGenerator pour eviter l'hallucination des chiffres.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
@@ -722,6 +722,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "de81f76f",
+   "source": "### Interpretation : Evaluation du modele de regression\n\n**Resultat obtenu** : Le coefficient de determination R² = 0,97 indique que le modele explique 97 % de la variance des donnees de test.\n\n| Metrique | Valeur | Signification |\n|----------|--------|---------------|\n| R² | 0,97 | Ajustement excellent, proche de la perfection |\n| Donnees d'entrainement | 4 exemples | Dataset minimal pour une demonstration |\n| Donnees de test | 15 exemples | Couvrent la plage 1,1 a 8,0 en taille |\n\n**Points cles** :\n\n1. **R² proche de 1** : La relation taille-prix est fortement lineaire dans ce jeu de donnees synthetiques\n2. **Biais potentiel** : Les donnees d'entrainement et de test se chevauchent partiellement, ce qui peut surerestimer la qualite du modele\n3. **Generalisation** : Un R² eleve sur un petit dataset ne garantit pas la performance sur des donnees reelles plus complexes",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "9afc7aa7",
    "metadata": {
     "papermill": {
@@ -1117,6 +1123,12 @@
     "var predNormal = predictionEngine.Predict(testNormal);\n",
     "Console.WriteLine($\"Test 2 (Montant={testNormal.Montant}, Heure={testNormal.Heure}h) -> Suspecte ? {predNormal.Prediction} (Probabilite : {predNormal.Probability:P2})\");\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cfd39af",
+   "source": "### Interpretation : Evaluation du modele de classification\n\n**Resultats obtenus** : Le modele de classification binaire atteint une precision parfaite sur les donnees de test.\n\n| Metrique | Valeur | Signification |\n|----------|--------|---------------|\n| Accuracy | 100 % | Toutes les transactions sont correctement classees |\n| AUC | 100 % | Separation parfaite entre transactions normales et suspectes |\n| Probabilite suspecte | 99,99 % | Forte confiance pour Montant=3500, Heure=3h |\n| Probabilite normale | 0,03 % | Forte confiance pour Montant=150, Heure=10h |\n\n**Points cles** :\n\n1. **Separation nette** : Les transactions suspectes (montant eleve + heures nocturnes) sont clairement distinctes des normales dans ce jeu de donnees\n2. **Surapprentissage probable** : Performance parfaite sur les donnees d'entrainement — un jeu de test independant serait necessaire pour evaluer la generalisation\n3. **Features discriminantes** : Le montant et l'heure suffisent a separer les deux classes dans cet exemple simplifie\n4. **Limites** : En conditions reelles, les motifs de fraude sont plus subtils et les donnees sont souvent fortement desequilibrees",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
@@ -314,6 +314,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a904fd5c",
+   "source": "#### Interpretation : Comparaison des formats de sortie\n\n**NTriples** : format verbeux — chaque triplet occupe une ligne complete avec les URIs en entier. 4 triplets = 4 lignes. Pas de prefixe, pas de compression.\n\n**Turtle compresse** : format compact — les prefixes sont definis une fois (`@prefix`), les noeuds blancs sont regroupes avec `;` (meme sujet) et les proprietes sont imbriquees avec `[...]`. Le meme graphe tient en 3 lignes au lieu de 4.\n\nLe ratio de compression est ici d'environ 2:1 (NTriples ~400 caracteres vs Turtle ~300 caracteres). Sur des graphes plus grands avec beaucoup de prefixes, le gain peut atteindre 5:1 ou plus.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Serialisation du graphe en RDF/XML via deux methodes equivalentes : helper statique et StringWriter explicite."
@@ -715,6 +721,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f3c4ce9b",
+   "source": "#### Interpretation : Resultats de la selection\n\n**Selection par predicat** `rdf:type` : 14 triplets trouves — 6 declarations de classes (Animal, Mammal, Bird, Dog, Cat, Parrot), 4 declarations de proprietes (name, age, sound, canFly) et 4 instances (rex/Dog, minou/Cat, coco/Parrot, buddy/Dog).\n\n**Selection par sujet** `ex:rex` : 4 proprietes — type (Dog), name (Rex), age (5), sound (Woof). Rex est un chien de 5 ans qui fait \"Woof\".\n\nCes resultats illustrent que `GetTriplesWithPredicate` retourne tous les usages d'un predicat (types, instances), tandis que `GetTriplesWithSubject` decrit un noeud complet.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Combinaison de selections par predicat et par objet avec des expressions LINQ pour filtrer les animaux."
@@ -925,6 +937,12 @@
     "g.RetractList(newRoot);\n",
     "Console.WriteLine($\"RetractList   : {avant} -> {g.Triples.Count} triplets\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf47d2cb",
+   "source": "#### Interpretation : Creation et suppression de liste\n\n**Resultat obtenu** : `AssertList` cree une liste `[true, false]` en generant des noeuds blancs et triplets associes. `RetractList` supprime tous les triplets de la liste.\n\n| Operation | Triplets avant | Triplets apres | Delta |\n|-----------|----------------|----------------|-------|\n| AssertList | 9 (liste initiale 1,2,3) | 11 (+2 elements = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |\n| RetractList | 11 | 7 | -4 |\n\nChaque element de liste coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier qui pointe vers `rdf:nil`.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
@@ -312,9 +312,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Construction d'une requete FILTER avec expression reguliere pour filtrer les resultats par pattern textuel."
-   ]
+   "source": "### Interpretation : FILTER numerique\n\nLa requete generee utilise `FILTER(?age > 24)` : le QueryBuilder traduit l'expression C# `b.Variable(age) > 24` en syntaxe SPARQL equivalente. La variable `?age` est a la fois un pattern de triplet (objet de `info:age`) et une variable de filtrage.\n\n**Remarque** : le predicat `info:age` dans le chemin URI `http://somewhere/peopleInfo#age` montre que les proprietes RDF peuvent representer n'importe quelle relation — ici, l'age d'une personne est un litteral numerique, ce qui permet les comparaisons dans FILTER.\n\nLes filtres SPARQL supportent aussi les expressions regulieres, comme illustre dans la cellule suivante."
   },
   {
    "cell_type": "code",
@@ -599,9 +597,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Utilisation d'une chaine SPARQL brute avec SparqlQueryParser pour construire une requete avec LIMIT et OFFSET."
-   ]
+   "source": "### Interpretation : ORDER BY\n\nLa requete generee par le QueryBuilder produit `ORDER BY ASC(?name)` : le tri est ascendant par defaut avec `.OrderBy(var)`. Pour un tri descendant, il faudrait utiliser `.OrderByDescending(var)`.\n\n**Comparaison des approches** :\n\n| Approche | Code | Avantage |\n|----------|------|----------|\n| QueryBuilder | `.OrderBy(\"name\")` | Type safety, IntelliSense |\n| Chaine brute | `ORDER BY DESC(?age)` | Syntaxe directe, LIMIT/OFFSET |\n\nLe QueryBuilder ne supporte pas encore nativement LIMIT et OFFSET — il faut utiliser une chaine SPARQL brute avec `SparqlQueryParser` pour ces clauses, comme illustre ci-dessous."
   },
   {
    "cell_type": "code",
@@ -777,9 +773,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Chargement d'un graphe de test en memoire et execution d'une requete SELECT avec FILTER sur ce graphe."
-   ]
+   "source": "### Interpretation : Requete complexe QueryBuilder\n\nLa requete combine 4 clauses SPARQL en un seul appel fluide :\n\n| Clause | Methode | Effet sur les resultats |\n|--------|---------|------------------------|\n| `WHERE` (2 patterns) | `.Where(tp => ...)` | Conjonction : le nom ET l'age doivent exister |\n| `OPTIONAL` | `.Optional(opt => ...)` | Email retourne si present, sinon variable non liee |\n| `FILTER` | `.Filter(b => b.Variable(age) > 18)` | Exclut les moins de 18 ans |\n| `ORDER BY` | `.OrderBy(name)` | Tri alphabetique sur le nom |\n\n**Ordre de composition** : `Select → Where → Optional → Filter → OrderBy`. Le QueryBuilder garantit la syntaxe SPARQL valide quelle que soit l'ordre des appels, mais l'ordre logique (selection, pattern, filtre, tri) ameliore la lisibilite.\n\nCette requete sera executee sur un graphe local dans la cellule suivante pour observer les resultats concrets."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Add interpretation markdown cells to 5 notebooks identified as NEEDS_WORK in T5 ALPHA inventory
- **ML-1-Introduction**: 2 cells — regression R2=0.97 interpretation + classification 100% accuracy interpretation
- **Lab12-DS-Star-Workshop**: 2 cells — pipeline test 1 error analysis (file-not-found) + pipeline test 2 partial results (column mismatch)
- **Lab17-Final-Project**: 2 cells — pipeline execution analysis (0 planner steps) + LLM report hallucination analysis
- **SW-3-CSharp-GraphOperations**: 3 cells — triplet counting (9->11->7), rdf:type breakdown, NTriples vs Turtle compression ratio
- **SW-4-CSharp-SPARQL**: 3 cells — FILTER numeric interpretation, ORDER BY vs raw string comparison, complex QueryBuilder composition

## Test plan
- [x] Markdown-only changes, no code cell modifications
- [x] Existing execution_count and outputs preserved
- [x] 0 null-exec code cells verified on all notebooks
- [x] 57 insertions, 9 deletions — enrichment only (3 thin cells replaced)
- [x] No C.1 violations (no `raise NotImplementedError` introduced)
- [x] French language, no emojis, professional markdown tables