### PR TITLE
fix(security): raise on missing API keys + scrub leaked key from docs

### DIFF
--- a/docs/genai-services-inventory-2026-05.md
+++ b/docs/genai-services-inventory-2026-05.md
@@ -253,7 +253,7 @@
 |---------|-----------|-----------|--------|
 | ComfyUI Qwen | Bearer Token | `$2b$12$aR9XPUlx7SVbigaNrXoOAOahPXAmqmiPxImJ8DkD2K3Kfme7KKLA.` | login/PASSWORD file in container |
 | ComfyUI Video | Bearer Token | `$2b$12$I2IOvM7xVaAfaaRgQ7MfreDXU9sImLT7Fr8VpaaAFwk3TKlphQF9u` | login/PASSWORD file in container |
-| Whisper/TTS/Audio APIs | API Key | `BwCaesdZuitLAfs6Nr1KX_CVNhX12XavyZThvpT2RD4c1smVrQ00xfZY2PP2pYgK` | Shared across audio stack |
+| Whisper/TTS/Audio APIs | API Key | `[ROTATED 2026-05-14 - see .env]` | Shared across audio stack |
 | SD Forge Main | HTTP Basic | `admin:changeme` | Gradio auth |
 | SD Forge Turbo | HTTP Basic | `forge:QWvghoUTemZa9M9` | Gradio auth |
 | SDNext | Session Cookie | (not tested) | Gradio session |

--- a/scripts/whisper_int8_comparison.py
+++ b/scripts/whisper_int8_comparison.py
@@ -28,8 +28,18 @@ if _env_path.exists():
     from dotenv import load_dotenv
     load_dotenv(_env_path)
 
-TTS_API_KEY = os.getenv("TTS_API_KEY", "")
-STT_API_KEY = os.getenv("WHISPER_API_KEY", "")
+_missing = []
+TTS_API_KEY = os.getenv("TTS_API_KEY")
+STT_API_KEY = os.getenv("WHISPER_API_KEY")
+if not TTS_API_KEY:
+    _missing.append("TTS_API_KEY")
+if not STT_API_KEY:
+    _missing.append("WHISPER_API_KEY")
+if _missing:
+    raise EnvironmentError(
+        f"Missing required env var(s): {', '.join(_missing)}. "
+        f"Source .env: {_env_path} (exists={_env_path.exists()})"
+    )
 
 
 def generate_audio(text: str, output_path: str) -> bool:


### PR DESCRIPTION
## Summary
- `whisper_int8_comparison.py` now raises `EnvironmentError` if `TTS_API_KEY` or `WHISPER_API_KEY` are not set, instead of silently defaulting to empty strings (ai-01 directive for security incident #1076)
- Replaces compromised API key in `genai-services-inventory-2026-05.md` with rotation notice

## Context
Follow-up to PR #1075 (merged). Part of security incident remediation — ai-01 required explicit failure when API keys are absent rather than silent empty-string fallback.

## Test plan
- [x] `grep -rn "BwCaesdZuit" .` returns 0 results (key fully scrubbed)
- [x] Script raises `EnvironmentError` when keys missing (verified locally)
- [x] Docker containers recreated with new key, old key rejected (401)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>