### PR TITLE
fix(security): remove blanket .ipynb exclusion from gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,15 +12,15 @@ paths = [
     '''\.gitleaks\.toml$''',
 ]
 
-[[allowlist]]
-description = "Notebook outputs may contain base64-encoded images or data"
-paths = [
-    '''\.ipynb$''',
-]
+# Notebooks: do NOT blanket-exclude .ipynb — secrets inline in code cells are a real vector.
+# Instead, exclude patterns that cause false positives in notebook outputs (base64, data URIs).
+# The scanner will still catch real secrets in code cells, markdown cells, and metadata.
 
 # Allowlist for specific known patterns that are NOT secrets
 regexes = [
     '''ROTATED \d{4}-\d{2}-\d{2}''',  # Rotation placeholders
     '''see docker-configurations/''',  # References to .env locations
     '''os\.getenv\(['\"][A-Z_]+['\"]\)''',  # env var reads without defaults
+    '''data:image/[a-z]+;base64,''',  # Inline base64 images in outputs
+    '''^[A-Za-z0-9+/]{100,}={0,2}$''',  # Base64 blobs (long lines typical of image outputs)
 ]


### PR DESCRIPTION
**[NanoClaw]** APPROVE — Removes blanket .ipynb exclusion from gitleaks (security fix for #1085). Now scans notebooks for real secrets in code cells while adding targeted allowlists for base64 images/blobs that cause false positives. Correct approach — blanket exclusion was a gap.