### PR TITLE
fix(catalog): repair RESEARCH classification in --all mode

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -36,6 +36,7 @@ NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
 
 EXCLUDE_ALWAYS = {".ipynb_checkpoints", "obj", "bin", "__pycache__", ".git"}
 EXCLUDE_PEDAGOGICAL = {"research", "archive", "_output", "output", "ESGF", "examples"}
+RESEARCH_DIR_KEYWORDS = {"research", "archive", "examples", "ESGF"}
 
 SERIES_ORDER = [
     "GenAI", "Search", "ML", "SymbolicAI", "QuantConnect",
@@ -176,6 +177,12 @@ def check_errors(outputs: list) -> list[str]:
     return errors
 
 
+def _is_research_path(nb_path: Path) -> bool:
+    """Check if notebook is in a research/archive/examples/ESGF directory."""
+    parts = nb_path.relative_to(NOTEBOOKS_DIR).parts
+    return any(part in RESEARCH_DIR_KEYWORDS for part in parts)
+
+
 def determine_status(
     nb_path: Path,
     notebook: dict,
@@ -190,10 +197,8 @@ def determine_status(
     RESEARCH  — in research/archive/examples path
     BROKEN    — errors in outputs
     """
-    rel_path = str(nb_path.relative_to(NOTEBOOKS_DIR))
-
-    # Research/archive path → RESEARCH
-    if not pedagogical:
+    # Research/archive path → RESEARCH (regardless of pedagogical flag)
+    if _is_research_path(nb_path):
         return "RESEARCH"
 
     # Check for errors in outputs
@@ -474,7 +479,6 @@ def scan_all_notebooks(
                 for exc in EXCLUDE_PEDAGOGICAL
             ):
                 continue
-
             entry = analyze_notebook(nb_path, pedagogical, git_meta=git_meta)
             if entry:
                 entries.append(entry)


### PR DESCRIPTION
## Summary
- Fix `generate_catalog.py --all` bug where ALL 1168 notebooks were classified as RESEARCH (should be ~14)
- Root cause: `determine_status()` used `pedagogical=False` as proxy for RESEARCH instead of checking actual path
- Introduce `_is_research_path()` that checks path segments against `RESEARCH_DIR_KEYWORDS`
- Default catalog unchanged: 467 notebooks, RESEARCH:0 (excluded by path filter, by design)
- `--all` catalog now correct: 1168 notebooks, RESEARCH:14 (properly classified)

## #623 Phase 1 Proof (ai-01 demand)

### Proof 1: RESEARCH classification
- `--all` mode: **14 notebooks** classified RESEARCH in research/archive/examples/ESGF directories
- Default mode: RESEARCH:0 by design (research notebooks excluded from pedagogical catalog)
- 14 RESEARCH notebooks: 3 GenAI examples, 6 QuantConnect research, 4 ESGF examples, 1 SymbolicAI archive

### Proof 2: CATALOG-STATUS markers in READMEs
- **SymbolicAI/README.md** (line 3): `<!-- CATALOG-STATUS series: SymbolicAI pedagogical_count: 89 maturity: BETA=67, ALPHA=12, PRODUCTION=7, DRAFT=3 -->`
- **Search/README.md** (line 3): `<!-- CATALOG-STATUS series: Search pedagogical_count: 45 maturity: BETA=16, PRODUCTION=15, DRAFT=8, ALPHA=6 -->`
- **Sudoku/README.md** (line 3): `<!-- CATALOG-STATUS series: Sudoku pedagogical_count: 32 maturity: BETA=16, ALPHA=11, PRODUCTION=5 -->`

### Proof 3: Maturity heuristic calibration (3 examples)
| Notebook | Computed | Expected | Match |
|----------|----------|----------|-------|
| Search/App-15-SportsScheduling (outs=11/14, kernel ok, intro+conclusion) | PRODUCTION | PRODUCTION | Yes |
| SymbolicAI/Planners-0-Setup (outs=12/12, kernel Python 3) | PRODUCTION | PRODUCTION | Yes |
| Sudoku-10-ORTools-Python (outs=8/8, kernel ok) | PRODUCTION | PRODUCTION | Yes |

## Test plan
- [x] `python generate_catalog.py --check` → 467 notebooks, RESEARCH:0
- [x] `python generate_catalog.py --check --all` → 1168 notebooks, RESEARCH:14
- [x] 3 CATALOG-STATUS markers verified in SymbolicAI/Search/Sudoku READMEs
- [x] 3 maturity heuristic examples match expected classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)