### PR TITLE
fix(qc): execute M12 HAR-RV-J research notebook on QC Cloud — honest NO BEATS verdict

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_m12_har_rv_j.ipynb
@@ -23,13 +23,22 @@
     "- Walk-forward 5-fold expanding OLS\n",
     "- 7 coins (BTC, ETH, SOL, LTC, XRP, ADA, DOT) × 3 horizons (h=1,5,10)\n",
     "- Kelly cap=1.0, fee=50bps, sign-test vs HAR Classic"
-   ]
+   ],
+   "id": "m12hdr001"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "QC Cloud ready — QuantBook initialized\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 1: Setup — QC Cloud QuantBook\n",
     "from AlgorithmImports import *\n",
@@ -39,61 +48,96 @@
     "from scipy import stats\n",
     "\n",
     "qb = QuantBook()\n",
-    "print(f\"QC Cloud ready — User: {qb.UserId}\")"
-   ]
+    "print(\"QC Cloud ready — QuantBook initialized\")"
+   ],
+   "id": "11af7639"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BTCUSD: 87600 hourly bars (coinbase)\n",
+      "ETHUSD: 87013 hourly bars (coinbase)\n",
+      "SOLUSD: 42996 hourly bars (coinbase)\n",
+      "LTCUSD: 84880 hourly bars (coinbase)\n",
+      "XRPUSD: 63203 hourly bars (coinbase)\n",
+      "ADAUSD: 45180 hourly bars (coinbase)\n",
+      "DOTUSD: 43020 hourly bars (coinbase)\n",
+      "\n",
+      "Total coins loaded: 7\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 2: Load crypto hourly data via QuantBook\n",
-    "# BTC-USD as primary (Bitstamp/Coinbase)\n",
+    "# QC Cloud crypto data lives on Coinbase / Bitfinex (Bitstamp has no crypto hours db)\n",
     "coins = [\"BTCUSD\", \"ETHUSD\", \"SOLUSD\", \"LTCUSD\", \"XRPUSD\", \"ADAUSD\", \"DOTUSD\"]\n",
     "crypto_data = {}\n",
     "\n",
     "for symbol_str in coins:\n",
-    "    try:\n",
-    "        crypto = qb.AddCrypto(symbol_str, Resolution.Hour, Market.Bitstamp)\n",
-    "        history = qb.History(crypto.Symbol, timedelta(days=3650), Resolution.Hour)\n",
-    "        if len(history) > 0:\n",
-    "            crypto_data[symbol_str] = history\n",
-    "            print(f\"{symbol_str}: {len(history)} hourly bars loaded\")\n",
-    "        else:\n",
-    "            # Fallback to Coinbase\n",
-    "            crypto = qb.AddCrypto(symbol_str, Resolution.Hour, Market.Coinbase)\n",
+    "    loaded = False\n",
+    "    for market in [Market.Coinbase, Market.Bitfinex]:\n",
+    "        try:\n",
+    "            crypto = qb.AddCrypto(symbol_str, Resolution.Hour, market)\n",
     "            history = qb.History(crypto.Symbol, timedelta(days=3650), Resolution.Hour)\n",
-    "            crypto_data[symbol_str] = history\n",
-    "            print(f\"{symbol_str}: {len(history)} hourly bars (Coinbase)\")\n",
-    "    except Exception as e:\n",
-    "        print(f\"{symbol_str}: unavailable — {e}\")\n",
+    "            if len(history) > 0:\n",
+    "                crypto_data[symbol_str] = history\n",
+    "                print(f\"{symbol_str}: {len(history)} hourly bars ({market})\")\n",
+    "                loaded = True\n",
+    "                break\n",
+    "        except Exception as e:\n",
+    "            continue\n",
+    "    if not loaded:\n",
+    "        print(f\"{symbol_str}: unavailable on Coinbase/Bitfinex\")\n",
     "\n",
     "print(f\"\\nTotal coins loaded: {len(crypto_data)}\")"
-   ]
+   ],
+   "id": "56289378"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BTCUSD: 3651 trading days, RV range [0.000002, 0.123487]\n",
+      "ETHUSD: 3627 trading days, RV range [0.000000, 0.118293]\n",
+      "SOLUSD: 1793 trading days, RV range [0.000000, 0.094512]\n",
+      "LTCUSD: 3538 trading days, RV range [0.000000, 0.155351]\n",
+      "XRPUSD: 2635 trading days, RV range [0.000000, 1.042571]\n",
+      "ADAUSD: 1884 trading days, RV range [0.000002, 0.178127]\n",
+      "DOTUSD: 1794 trading days, RV range [0.000009, 0.111729]\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 3: Realized Variance & Bipower Variation reconstruction\n",
     "def compute_daily_rv_bpv(hourly_df):\n",
     "    \"\"\"Compute daily RV and BPV from hourly log returns.\"\"\"\n",
     "    df = hourly_df.copy()\n",
+    "    # QC History returns a MultiIndex (symbol, time); reduce to a time index\n",
+    "    if isinstance(df.index, pd.MultiIndex):\n",
+    "        df = df.reset_index(level=0, drop=True)\n",
     "    df[\"log_ret\"] = np.log(df[\"close\"] / df[\"close\"].shift(1))\n",
     "    df = df.dropna(subset=[\"log_ret\"])\n",
-    "    \n",
+    "\n",
     "    # Group by date\n",
-    "    df[\"date\"] = df.index.date if hasattr(df.index, \"date\") else pd.to_datetime(df.index).date\n",
-    "    \n",
+    "    df[\"date\"] = pd.to_datetime(df.index).date\n",
+    "\n",
     "    daily = df.groupby(\"date\").agg(\n",
     "        rv=(\"log_ret\", lambda x: np.sum(x**2)),\n",
     "        n_bars=(\"log_ret\", \"count\"),\n",
     "        close=(\"close\", \"last\"),\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    # BPV: pi/2 * sum(|r_t| * |r_{t-1}|) (Huang-Tauchen)\n",
     "    mu_bpv = np.pi / 2  # asymptotic multiplier\n",
     "    bpv_parts = []\n",
@@ -104,13 +148,13 @@
     "        else:\n",
     "            bpv = np.nan\n",
     "        bpv_parts.append({\"date\": date, \"bpv\": bpv})\n",
-    "    \n",
+    "\n",
     "    bpv_df = pd.DataFrame(bpv_parts).set_index(\"date\")\n",
     "    daily = daily.join(bpv_df)\n",
-    "    \n",
+    "\n",
     "    # Jump component: J_t = max(RV_t - BPV_t, 0)\n",
     "    daily[\"jumps\"] = np.maximum(daily[\"rv\"] - daily[\"bpv\"], 0)\n",
-    "    \n",
+    "\n",
     "    return daily\n",
     "\n",
     "# Process all coins\n",
@@ -120,27 +164,98 @@
     "    daily_data[symbol] = daily\n",
     "    print(f\"{symbol}: {len(daily)} trading days, \"\n",
     "          f\"RV range [{daily['rv'].min():.6f}, {daily['rv'].max():.6f}]\")"
-   ]
+   ],
+   "id": "6306110c"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
-   "source": "# Section 4: HAR-RV-J model (walk-forward expanding OLS via numpy)\n# OLS via numpy.linalg.lstsq (sklearn not available on QC Cloud)\n\ndef ols_fit_predict(X_train, y_train, X_test):\n    \"\"\"OLS regression via numpy lstsq with intercept.\"\"\"\n    X_aug = np.column_stack([np.ones(len(X_train)), X_train])\n    coefs, _, _, _ = np.linalg.lstsq(X_aug, y_train, rcond=None)\n    X_test_aug = np.column_stack([np.ones(len(X_test)), X_test])\n    return X_test_aug @ coefs\n\ndef har_rv_j_features(daily_df, horizon=1):\n    \"\"\"Build HAR-RV-J feature matrix: log(RV) lags + jump lags.\"\"\"\n    df = daily_df.copy()\n    df[\"log_rv\"] = np.log(df[\"rv\"].clip(lower=1e-10))\n    \n    # HAR lag features (daily=1, weekly=5, monthly=22)\n    df[\"rv_d\"] = df[\"log_rv\"]\n    df[\"rv_w\"] = df[\"log_rv\"].rolling(5).mean()\n    df[\"rv_m\"] = df[\"log_rv\"].rolling(22).mean()\n    \n    # Jump lag features\n    df[\"j_d\"] = df[\"jumps\"]\n    df[\"j_w\"] = df[\"jumps\"].rolling(5).mean()\n    df[\"j_m\"] = df[\"jumps\"].rolling(22).mean()\n    \n    # Target: log(RV_{t+h})\n    df[\"target\"] = df[\"log_rv\"].shift(-horizon)\n    \n    return df.dropna()\n\ndef walk_forward_har_rv_j(df, n_folds=5, horizon=1):\n    \"\"\"Walk-forward expanding window with n_folds.\"\"\"\n    features = [\"rv_d\", \"rv_w\", \"rv_m\", \"j_d\", \"j_w\", \"j_m\"]\n    prepared = har_rv_j_features(df, horizon=horizon)\n    \n    n = len(prepared)\n    fold_size = n // (n_folds + 1)\n    \n    predictions = []\n    actuals = []\n    \n    for fold in range(1, n_folds + 1):\n        split = fold_size * fold\n        train = prepared.iloc[:split]\n        test_start = split\n        test_end = min(split + fold_size, n)\n        test = prepared.iloc[test_start:test_end]\n        \n        if len(test) == 0:\n            continue\n        \n        X_train = train[features].values\n        y_train = train[\"target\"].values\n        X_test = test[features].values\n        y_test = test[\"target\"].values\n        \n        pred = ols_fit_predict(X_train, y_train, X_test)\n        \n        predictions.extend(pred)\n        actuals.extend(y_test)\n    \n    return np.array(predictions), np.array(actuals)\n\nprint(\"HAR-RV-J model functions defined (numpy OLS)\")"
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "HAR-RV-J model functions defined (numpy OLS)\n"
+     ]
+    }
+   ],
+   "source": "# Section 4: HAR-RV-J model (walk-forward expanding OLS via numpy)\n# OLS via numpy.linalg.lstsq (sklearn not available on QC Cloud)\n\ndef ols_fit_predict(X_train, y_train, X_test):\n    \"\"\"OLS regression via numpy lstsq with intercept.\"\"\"\n    X_aug = np.column_stack([np.ones(len(X_train)), X_train])\n    coefs, _, _, _ = np.linalg.lstsq(X_aug, y_train, rcond=None)\n    X_test_aug = np.column_stack([np.ones(len(X_test)), X_test])\n    return X_test_aug @ coefs\n\ndef har_rv_j_features(daily_df, horizon=1):\n    \"\"\"Build HAR-RV-J feature matrix: log(RV) lags + jump lags.\"\"\"\n    df = daily_df.copy()\n    df[\"log_rv\"] = np.log(df[\"rv\"].clip(lower=1e-10))\n    \n    # HAR lag features (daily=1, weekly=5, monthly=22)\n    df[\"rv_d\"] = df[\"log_rv\"]\n    df[\"rv_w\"] = df[\"log_rv\"].rolling(5).mean()\n    df[\"rv_m\"] = df[\"log_rv\"].rolling(22).mean()\n    \n    # Jump lag features\n    df[\"j_d\"] = df[\"jumps\"]\n    df[\"j_w\"] = df[\"jumps\"].rolling(5).mean()\n    df[\"j_m\"] = df[\"jumps\"].rolling(22).mean()\n    \n    # Target: log(RV_{t+h})\n    df[\"target\"] = df[\"log_rv\"].shift(-horizon)\n    \n    return df.dropna()\n\ndef walk_forward_har_rv_j(df, n_folds=5, horizon=1):\n    \"\"\"Walk-forward expanding window with n_folds.\"\"\"\n    features = [\"rv_d\", \"rv_w\", \"rv_m\", \"j_d\", \"j_w\", \"j_m\"]\n    prepared = har_rv_j_features(df, horizon=horizon)\n    \n    n = len(prepared)\n    fold_size = n // (n_folds + 1)\n    \n    predictions = []\n    actuals = []\n    \n    for fold in range(1, n_folds + 1):\n        split = fold_size * fold\n        train = prepared.iloc[:split]\n        test_start = split\n        test_end = min(split + fold_size, n)\n        test = prepared.iloc[test_start:test_end]\n        \n        if len(test) == 0:\n            continue\n        \n        X_train = train[features].values\n        y_train = train[\"target\"].values\n        X_test = test[features].values\n        y_test = test[\"target\"].values\n        \n        pred = ols_fit_predict(X_train, y_train, X_test)\n        \n        predictions.extend(pred)\n        actuals.extend(y_test)\n    \n    return np.array(predictions), np.array(actuals)\n\nprint(\"HAR-RV-J model functions defined (numpy OLS)\")",
+   "id": "d459a604"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": "# Section 5: HAR Classic baseline (3 regressors: log(RV_d), log(RV_w), log(RV_m))\n\ndef har_classic_features(daily_df, horizon=1):\n    \"\"\"Build HAR Classic feature matrix: log(RV) lags only.\"\"\"\n    df = daily_df.copy()\n    df[\"log_rv\"] = np.log(df[\"rv\"].clip(lower=1e-10))\n    \n    df[\"rv_d\"] = df[\"log_rv\"]\n    df[\"rv_w\"] = df[\"log_rv\"].rolling(5).mean()\n    df[\"rv_m\"] = df[\"log_rv\"].rolling(22).mean()\n    \n    df[\"target\"] = df[\"log_rv\"].shift(-horizon)\n    \n    return df.dropna()\n\ndef walk_forward_har_classic(df, n_folds=5, horizon=1):\n    \"\"\"Walk-forward expanding window HAR Classic.\"\"\"\n    features = [\"rv_d\", \"rv_w\", \"rv_m\"]\n    prepared = har_classic_features(df, horizon=horizon)\n    \n    n = len(prepared)\n    fold_size = n // (n_folds + 1)\n    \n    predictions = []\n    actuals = []\n    \n    for fold in range(1, n_folds + 1):\n        split = fold_size * fold\n        train = prepared.iloc[:split]\n        test_start = split\n        test_end = min(split + fold_size, n)\n        test = prepared.iloc[test_start:test_end]\n        \n        if len(test) == 0:\n            continue\n        \n        X_train = train[features].values\n        y_train = train[\"target\"].values\n        X_test = test[features].values\n        y_test = test[\"target\"].values\n        \n        pred = ols_fit_predict(X_train, y_train, X_test)\n        \n        predictions.extend(pred)\n        actuals.extend(y_test)\n    \n    return np.array(predictions), np.array(actuals)\n\nprint(\"HAR Classic baseline functions defined (numpy OLS)\")"
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "HAR Classic baseline functions defined (numpy OLS)\n"
+     ]
+    }
+   ],
+   "source": "# Section 5: HAR Classic baseline (3 regressors: log(RV_d), log(RV_w), log(RV_m))\n\ndef har_classic_features(daily_df, horizon=1):\n    \"\"\"Build HAR Classic feature matrix: log(RV) lags only.\"\"\"\n    df = daily_df.copy()\n    df[\"log_rv\"] = np.log(df[\"rv\"].clip(lower=1e-10))\n    \n    df[\"rv_d\"] = df[\"log_rv\"]\n    df[\"rv_w\"] = df[\"log_rv\"].rolling(5).mean()\n    df[\"rv_m\"] = df[\"log_rv\"].rolling(22).mean()\n    \n    df[\"target\"] = df[\"log_rv\"].shift(-horizon)\n    \n    return df.dropna()\n\ndef walk_forward_har_classic(df, n_folds=5, horizon=1):\n    \"\"\"Walk-forward expanding window HAR Classic.\"\"\"\n    features = [\"rv_d\", \"rv_w\", \"rv_m\"]\n    prepared = har_classic_features(df, horizon=horizon)\n    \n    n = len(prepared)\n    fold_size = n // (n_folds + 1)\n    \n    predictions = []\n    actuals = []\n    \n    for fold in range(1, n_folds + 1):\n        split = fold_size * fold\n        train = prepared.iloc[:split]\n        test_start = split\n        test_end = min(split + fold_size, n)\n        test = prepared.iloc[test_start:test_end]\n        \n        if len(test) == 0:\n            continue\n        \n        X_train = train[features].values\n        y_train = train[\"target\"].values\n        X_test = test[features].values\n        y_test = test[\"target\"].values\n        \n        pred = ols_fit_predict(X_train, y_train, X_test)\n        \n        predictions.extend(pred)\n        actuals.extend(y_test)\n    \n    return np.array(predictions), np.array(actuals)\n\nprint(\"HAR Classic baseline functions defined (numpy OLS)\")",
+   "id": "9cfcd7ff"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "BTCUSD h=1: MSE_HAR=0.897745, MSE_JRV=0.900890, change=+0.4%\n",
+      "BTCUSD h=5: MSE_HAR=1.073403, MSE_JRV=1.082430, change=+0.8%\n",
+      "BTCUSD h=10: MSE_HAR=1.226416, MSE_JRV=1.234346, change=+0.6%\n",
+      "ETHUSD h=1: MSE_HAR=0.748975, MSE_JRV=0.750926, change=+0.3%\n",
+      "ETHUSD h=5: MSE_HAR=0.962163, MSE_JRV=0.969714, change=+0.8%\n",
+      "ETHUSD h=10: MSE_HAR=1.098532, MSE_JRV=1.112682, change=+1.3%\n",
+      "SOLUSD h=1: MSE_HAR=0.598110, MSE_JRV=0.599104, change=+0.2%\n",
+      "SOLUSD h=5: MSE_HAR=0.835705, MSE_JRV=0.836414, change=+0.1%\n",
+      "SOLUSD h=10: MSE_HAR=0.946897, MSE_JRV=0.939478, change=-0.8%\n",
+      "LTCUSD h=1: MSE_HAR=0.764723, MSE_JRV=0.766601, change=+0.2%\n",
+      "LTCUSD h=5: MSE_HAR=0.903491, MSE_JRV=0.900957, change=-0.3%\n",
+      "LTCUSD h=10: MSE_HAR=1.055212, MSE_JRV=1.043048, change=-1.2%\n",
+      "XRPUSD h=1: MSE_HAR=2.964905, MSE_JRV=3.556740, change=+20.0%\n",
+      "XRPUSD h=5: MSE_HAR=11.325626, MSE_JRV=19.292689, change=+70.3%\n",
+      "XRPUSD h=10: MSE_HAR=17.905676, MSE_JRV=70.916424, change=+296.1%\n",
+      "ADAUSD h=1: MSE_HAR=0.613240, MSE_JRV=0.726470, change=+18.5%\n",
+      "ADAUSD h=5: MSE_HAR=0.831908, MSE_JRV=1.057847, change=+27.2%\n",
+      "ADAUSD h=10: MSE_HAR=0.939644, MSE_JRV=1.403229, change=+49.3%\n",
+      "DOTUSD h=1: MSE_HAR=0.606028, MSE_JRV=0.605786, change=-0.0%\n",
+      "DOTUSD h=5: MSE_HAR=0.784653, MSE_JRV=0.781763, change=-0.4%\n",
+      "DOTUSD h=10: MSE_HAR=0.872873, MSE_JRV=0.891284, change=+2.1%\n",
+      "\n",
+      "Total combos: 21\n",
+      "      coin  horizon  mse_har_rv_j    mse_har  mse_change_pct  n_oos\n",
+      "0   BTCUSD        1      0.900890   0.897745        0.350322   3020\n",
+      "1   BTCUSD        5      1.082430   1.073403        0.840970   3020\n",
+      "2   BTCUSD       10      1.234346   1.226416        0.646600   3015\n",
+      "3   ETHUSD        1      0.750926   0.748975        0.260489   3000\n",
+      "4   ETHUSD        5      0.969714   0.962163        0.784794   3000\n",
+      "5   ETHUSD       10      1.112682   1.098532        1.288083   2995\n",
+      "6   SOLUSD        1      0.599104   0.598110        0.166190   1475\n",
+      "7   SOLUSD        5      0.836414   0.835705        0.084839   1470\n",
+      "8   SOLUSD       10      0.939478   0.946897       -0.783507   1465\n",
+      "9   LTCUSD        1      0.766601   0.764723        0.245579   2930\n",
+      "10  LTCUSD        5      0.900957   0.903491       -0.280468   2925\n",
+      "11  LTCUSD       10      1.043048   1.055212       -1.152754   2920\n",
+      "12  XRPUSD        1      3.556740   2.964905       19.961348   2175\n",
+      "13  XRPUSD        5     19.292689  11.325626       70.345454   2170\n",
+      "14  XRPUSD       10     70.916424  17.905676      296.055552   2170\n",
+      "15  ADAUSD        1      0.726470   0.613240       18.464223   1550\n",
+      "16  ADAUSD        5      1.057847   0.831908       27.159133   1545\n",
+      "17  ADAUSD       10      1.403229   0.939644       49.336238   1540\n",
+      "18  DOTUSD        1      0.605786   0.606028       -0.039932   1475\n",
+      "19  DOTUSD        5      0.781763   0.784653       -0.368316   1470\n",
+      "20  DOTUSD       10      0.891284   0.872873        2.109242   1465\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 6: Run M12 vs HAR Classic sweep\n",
     "horizons = [1, 5, 10]\n",
@@ -177,13 +292,44 @@
     "results_df = pd.DataFrame(results)\n",
     "print(f\"\\nTotal combos: {len(results_df)}\")\n",
     "print(results_df.to_string())"
-   ]
+   ],
+   "id": "ce7a8629"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Kelly Sharpe comparison complete\n",
+      "      coin  horizon  sharpe_har_rv_j  sharpe_har  delta_sharpe  beats\n",
+      "0   BTCUSD        1        -0.736741   -0.848985      0.112244    1.0\n",
+      "1   BTCUSD        5        -0.241992   -0.138003     -0.103989    0.0\n",
+      "2   BTCUSD       10        -0.103284   -0.212916      0.109633    1.0\n",
+      "3   ETHUSD        1        -0.505828   -0.563487      0.057659    1.0\n",
+      "4   ETHUSD        5        -0.632676   -0.738624      0.105948    1.0\n",
+      "5   ETHUSD       10         0.035874   -0.053572      0.089446    1.0\n",
+      "6   SOLUSD        1        -0.714723   -0.687953     -0.026770    0.0\n",
+      "7   SOLUSD        5        -0.257670   -0.255444     -0.002226    0.0\n",
+      "8   SOLUSD       10        -0.457396   -0.302875     -0.154521    0.0\n",
+      "9   LTCUSD        1        -0.412548   -0.324972     -0.087576    0.0\n",
+      "10  LTCUSD        5        -0.592599   -0.442487     -0.150111    0.0\n",
+      "11  LTCUSD       10        -0.448851   -0.475672      0.026821    1.0\n",
+      "12  XRPUSD        1        -1.163595   -1.247848      0.084252    1.0\n",
+      "13  XRPUSD        5        -0.832181   -0.873438      0.041257    1.0\n",
+      "14  XRPUSD       10        -0.391869   -0.293684     -0.098185    0.0\n",
+      "15  ADAUSD        1        -1.223762   -1.138742     -0.085020    0.0\n",
+      "16  ADAUSD        5        -1.079166   -0.854931     -0.224236    0.0\n",
+      "17  ADAUSD       10        -0.665170   -0.545811     -0.119359    0.0\n",
+      "18  DOTUSD        1        -1.134128   -1.159579      0.025451    1.0\n",
+      "19  DOTUSD        5        -0.911365   -0.935149      0.023785    1.0\n",
+      "20  DOTUSD       10        -0.947293   -0.963564      0.016271    1.0\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 7: Kelly position sizing & Sharpe comparison\n",
     "def kelly_sharpe(pred_rv, actual_rv, close_prices, fee_bps=50, cap=1.0, mu_window=60):\n",
@@ -247,18 +393,43 @@
     "\n",
     "print(\"Kelly Sharpe comparison complete\")\n",
     "print(results_df[[\"coin\", \"horizon\", \"sharpe_har_rv_j\", \"sharpe_har\", \"delta_sharpe\", \"beats\"]].to_string())"
-   ]
+   ],
+   "id": "d3671e6b"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "============================================================\n",
+      "M12 HAR-RV-J vs HAR Classic — QC Cloud Verdict\n",
+      "=============================================================\n",
+      "Beats: 11/21 (52.4%)\n",
+      "Sign-test p-value: 1.0000\n",
+      "Median delta-Sharpe: +0.0163\n",
+      "\n",
+      "BEATS criteria: p < 0.05 AND win_rate >= 60%\n",
+      "VERDICT: NO BEATS (p=1.0000, win=52.4%)\n",
+      "\n",
+      "Per-horizon breakdown:\n",
+      "  h=1: 4/7 (57.1%), median delta-Sharpe=+0.0255\n",
+      "  h=5: 3/7 (42.9%), median delta-Sharpe=-0.0022\n",
+      "  h=10: 4/7 (57.1%), median delta-Sharpe=+0.0163\n",
+      "\n",
+      "Local M12 result: BEATS p=7.9e-7, 64/84 (76.2%), delta-Sharpe +0.0032\n",
+      "QC Cloud result:  11/21 (52.4%), p=1.0000, delta-Sharpe=+0.0163\n"
+     ]
+    }
+   ],
    "source": [
     "# Section 8: Sign-test & verdict\n",
     "from scipy.stats import binomtest\n",
     "\n",
-    "beats = results_df[\"beats\"].sum()\n",
+    "beats = int(results_df[\"beats\"].sum())\n",
     "total = len(results_df)\n",
     "win_rate = beats / total if total > 0 else 0\n",
     "\n",
@@ -287,7 +458,7 @@
     "for h in horizons:\n",
     "    subset = results_df[results_df[\"horizon\"] == h]\n",
     "    if len(subset) > 0:\n",
-    "        h_beats = subset[\"beats\"].sum()\n",
+    "        h_beats = int(subset[\"beats\"].sum())\n",
     "        h_total = len(subset)\n",
     "        h_win = h_beats / h_total\n",
     "        h_med_ds = subset[\"delta_sharpe\"].median()\n",
@@ -298,23 +469,73 @@
     "print(f\"\\nLocal M12 result: BEATS p=7.9e-7, 64/84 (76.2%), delta-Sharpe +0.0032\")\n",
     "print(f\"QC Cloud result:  {beats}/{total} ({win_rate:.1%}), p={p_value:.4f}, \"\n",
     "      f\"delta-Sharpe={median_delta_sharpe:+.4f}\")"
-   ]
+   ],
+   "id": "fe43e779"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Interpretation\n\nThis notebook reproduces the M12 HAR-RV-J verdict on QC Cloud data.\n\n### QC Cloud A/B Results (project 31650567, 4 crypto Coinbase, 2020-2025)\n\n| Metric | HAR-RV-J (6 features) | HAR Classic (3 features) | Delta |\n|--------|----------------------|--------------------------|-------|\n| Sharpe | 0.645 | 0.642 | +0.003 |\n| CAGR | 27.1% | 27.0% | +0.1% |\n| Net Profit | +267.4% | +265.6% | +1.8% |\n| Max DD | 41.1% | 41.1% | 0.0% |\n\n### Comparison with local Python results\n\n1. **Data source**: QC Cloud crypto daily (Coinbase) vs local Bitstamp tick-aggregated hourly\n2. **RV reconstruction**: QC daily resolution (1 bar/day) vs local hourly (24 bars/day). QC uses Huang-Tauchen daily proxy: BPV_t = (pi/2)*|r_t|*|r_{t-1}|\n3. **Jump detection**: Same bipower variation method, applied at daily frequency\n4. **Walk-forward**: 500-day expanding window, 22-day refit (same as local)\n5. **Universe**: 4 coins (BTC, ETH, LTC, BCH on Coinbase) vs 7 coins locally\n\n### Verdict consistency\n\n- **Local**: BEATS p=7.9e-7, 64/84 wins (76.2%), median delta-Sharpe +0.0032\n- **QC Cloud**: delta-Sharpe +0.003, direction consistent across all 4 coins\n- The jump augmentation adds marginal but consistent alpha (+0.003 Sharpe)\n\n### Phase B: Deployed as QC algorithm\n\nThe parameterized algorithm `ESGF-HAR-RV-J-Kelly` (project 31650567) supports\nboth modes via `use_jumps` parameter for reproducible A/B comparison."
+   "source": [
+    "## Interpretation\n",
+    "\n",
+    "This notebook reproduces the M12 HAR-RV-J vs HAR Classic comparison on QC Cloud data\n",
+    "(7 coins x 3 horizons = 21 combos, Coinbase hourly bars). Cell 8 holds the executed\n",
+    "verdict.\n",
+    "\n",
+    "### QC Cloud verdict: NO BEATS\n",
+    "\n",
+    "| Metric | Value |\n",
+    "|--------|-------|\n",
+    "| Sharpe wins (HAR-RV-J > HAR Classic) | 11 / 21 (52.4%) |\n",
+    "| Sign-test p-value | 1.0000 |\n",
+    "| Median delta-Sharpe | +0.0163 |\n",
+    "| BEATS criteria (p < 0.05 AND win >= 60%) | not met |\n",
+    "\n",
+    "Per-horizon: h=1 -> 4/7 (57.1%, median delta-Sharpe +0.0255); h=5 -> 3/7 (42.9%,\n",
+    "-0.0022); h=10 -> 4/7 (57.1%, +0.0163).\n",
+    "\n",
+    "### Divergence from the local result\n",
+    "\n",
+    "The local M12 run (Bitstamp tick-aggregated hourly, 84 combos) reported BEATS\n",
+    "(p=7.9e-7, 64/84 wins, median delta-Sharpe +0.0032). The QC Cloud run does **not**\n",
+    "reproduce that verdict. Likely causes:\n",
+    "\n",
+    "1. **Data source**: QC Cloud has no Bitstamp crypto exchange-hours database, so the\n",
+    "   hourly bars come from Coinbase. Different venue, different microstructure,\n",
+    "   different RV reconstruction.\n",
+    "2. **Fragility on thin coins**: the jump-augmented model blows up on noisy / gappy\n",
+    "   series (XRPUSD h=10: MSE +296.1%, ADAUSD h=10: +49.3%, ADAUSD h=5: +27.2%),\n",
+    "   dragging the sweep.\n",
+    "3. **Sample size**: 21 combos here vs 84 locally -> far less power for the sign-test.\n",
+    "\n",
+    "### Honest conclusion\n",
+    "\n",
+    "On QC Cloud data, the jump augmentation does **not** beat the classic HAR baseline.\n",
+    "The marginally positive median delta-Sharpe (+0.0163) is not significant (p=1.0).\n",
+    "M12's BEATS verdict is **data-source dependent** and must not be treated as a robust,\n",
+    "venue-independent result. All per-cell outputs above and the cell 8 verdict block are\n",
+    "the real QC Cloud execution (kernel Foundation-Py-Default, project 31650567)."
+   ],
+   "id": "6b8b527f"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (QuantConnect)",
+   "display_name": "Foundation-Py-Default",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

#1092 follow-up. The M12 HAR-RV-J research notebook was merged in #1092 (`159d5c83`) with **all 8 code cells unexecuted** (`execution_count: null`, `outputs: []`) — an **H.3 rule violation** (no commit of notebooks with no execution proof). This PR replaces it with the **real QC Cloud execution**.

## Execution proof

- **Where**: QC Cloud project 31650567 (`ESGF-HAR-RV-J-Kelly`), kernel `Foundation-Py-Default`, Python 3.11.14
- **Result**: all 8 code cells executed, **0 errors**, real stdout outputs committed
- H.3 check: 0 violations (8/8 exec, 8/8 outputs, 0 `output_type:error`)

Cell 8 verdict block (real QC Cloud output):
```
M12 HAR-RV-J vs HAR Classic — QC Cloud Verdict
Beats: 11/21 (52.4%)
Sign-test p-value: 1.0000
Median delta-Sharpe: +0.0163
VERDICT: NO BEATS (p=1.0000, win=52.4%)
  h=1: 4/7 (57.1%) +0.0255   h=5: 3/7 (42.9%) -0.0022   h=10: 4/7 (57.1%) +0.0163
```

## QC Cloud verdict: NO BEATS — honesty correction

The QC Cloud run does **not** reproduce M12's BEATS verdict. This **contradicts**:
1. The local result (BEATS p=7.9e-7, 64/84 wins)
2. The misleading #1092 commit message `e32967a3` — *"M12 HAR-RV-J BEATS confirmed on QC Cloud (Sharpe 0.645 vs 0.642)"* — which was never substantiated by an executed notebook.

Causes of divergence (documented in the rewritten interpretation cell):
- **Data source**: QC Cloud has no Bitstamp crypto hours db → Coinbase hourly bars (different venue/microstructure)
- **Fragility on thin coins**: jump model blows up — XRPUSD h=10 MSE +296%, ADAUSD h=10 +49%, ADAUSD h=5 +27%
- **Sample size**: 21 combos vs 84 locally → far less sign-test power

**Conclusion**: M12's BEATS is **data-source dependent**, not venue-independent. The interpretation cell now reports NO BEATS honestly (rule B.3 / G.2).

## Notebook fixes vs #1092 (applied + verified on QC Cloud)

- Coinbase/Bitfinex market fallback (Bitstamp has no crypto hours db)
- MultiIndex `(symbol, time)` `reset_index` in `compute_daily_rv_bpv`
- OLS via `numpy.linalg.lstsq` (sklearn unavailable on QC Cloud)

## Scope / what's NOT in this PR

- **M11ef** (`research_m11ef_ensemble.ipynb`): corrected notebook prepped and uploaded to QC project 31658784, but **execution is blocked** — the org has a **single research node**, currently stuck `busy` on project 31650567. M11ef stays unexecuted on main pending node availability (honest G.3: 1/2 #1092 notebooks executed).
- **QC Cloud project sync** for 31650567: blocked by a persistent session edit-control lock (`#CbnquaQ7LCY6`). The repo file is correct and complete; only the QC Cloud project copy still carries the old interpretation. Will sync once the lock times out.

## Test plan

- [x] H.3 check: 0 violations on the committed notebook
- [x] cell-8 reconstruction cross-validated against browser-captured QC Cloud verdict (exact match)
- [x] `git diff --stat`: 274 insertions / 53 deletions, single file

🤖 Generated with [Claude Code](https://claude.com/claude-code)