### PR TITLE
fix(ci): correct grep -c count in Detect notebook changes job

### DIFF
--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -55,7 +55,10 @@ jobs:
             | grep -v '/archive/' | grep -v '/_output/' | grep -v '/research/' \
             || true)
 
-          COUNT=$(echo "$NOTEBOOKS" | grep -c '\.ipynb$' || echo "0")
+          # grep -c prints "0" AND exits 1 on no-match; "|| echo 0" would
+          # then append a second "0", producing an invalid $GITHUB_OUTPUT
+          # line. "|| true" keeps grep's own "0" and just swallows the exit.
+          COUNT=$(echo "$NOTEBOOKS" | grep -c '\.ipynb$' || true)
           echo "notebooks<<EOF" >> "$GITHUB_OUTPUT"
           echo "$NOTEBOOKS" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `Detect notebook changes` job in `notebook-execution-required.yml` fails on **any PR whose only changed notebooks are excluded paths** (`research/`, `archive/`, `_output/`, `.ipynb_checkpoints/`).

### Root cause

[notebook-execution-required.yml:58](https://github.com/jsboige/CoursIA/blob/main/.github/workflows/notebook-execution-required.yml#L58):
```bash
COUNT=$(echo "$NOTEBOOKS" | grep -c '\.ipynb$' || echo "0")
```
`grep -c` prints `0` to stdout **and** exits 1 on no-match. The `|| echo "0"` then appends a *second* `0`, so `COUNT="0\n0"`. The next line `echo "has_notebooks=$COUNT" >> "$GITHUB_OUTPUT"` writes a two-line value, which Actions rejects:
```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '0'
```
The job fails, and `validate-static` / `execute-python` get SKIPPED via failure instead of a clean `has_notebooks > 0` gate.

### Observed

PR #1106 (M12 QC Cloud research notebook — `research/` only) hit this. Would recur on every research-only / archive-only notebook PR.

### Fix

Replace `|| echo "0"` with `|| true`: `grep -c` already emits its own `0`, and `|| true` just swallows the non-zero exit.

## Test plan

Verified locally:
- empty `$NOTEBOOKS` -> `COUNT=0` (single clean value)
- two notebooks -> `COUNT=2`

After merge, the `has_notebooks > 0` gate works as designed: research-only PRs get a clean SKIP of the downstream jobs instead of a failed detect job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)