### PR TITLE
fix(semanticweb): promote SW-4-CSharp-SPARQL ALPHA->BETA (#999)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
@@ -980,14 +980,16 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [],
-   "source": [
-    "// Exercice 1 : Votre code ici\n",
-    "// string sparql = @\"PREFIX foaf: ...\n",
-    "// SELECT ?name ?age WHERE { ... FILTER(?age > 20) } ORDER BY DESC(?age)\";\n",
-    "// var results = g.ExecuteQuery(sparql) as SparqlResultSet;\n",
-    "// foreach (var r in results) Console.WriteLine(...);"
-   ]
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": "// Exercice 1 : Votre code ici\n// string sparql = @\"PREFIX foaf: ...\n// SELECT ?name ?age WHERE { ... FILTER(?age > 20) } ORDER BY DESC(?age)\";\n// var results = g.ExecuteQuery(sparql) as SparqlResultSet;\n// foreach (var r in results) Console.WriteLine(...);\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
    "cell_type": "markdown",
@@ -1009,15 +1011,16 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [],
-   "source": [
-    "// Exercice 2 : Votre code ici\n",
-    "// var prefixes = new NamespaceMapper(true);\n",
-    "// prefixes.AddNamespace(\"foaf\", ...);\n",
-    "// var qb = QueryBuilder.Select(...).Where(...).Optional(...).OrderBy(...);\n",
-    "// qb.Prefixes = prefixes;\n",
-    "// Console.WriteLine(qb.BuildQuery().ToString());"
-   ]
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": "// Exercice 2 : Votre code ici\n// var prefixes = new NamespaceMapper(true);\n// prefixes.AddNamespace(\"foaf\", ...);\n// var qb = QueryBuilder.Select(...).Where(...).Optional(...).OrderBy(...);\n// qb.Prefixes = prefixes;\n// Console.WriteLine(qb.BuildQuery().ToString());\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
    "cell_type": "markdown",
@@ -1039,17 +1042,16 @@
      "kernelName": "csharp"
     }
    },
-   "outputs": [],
-   "source": [
-    "// Exercice 3 : Votre code ici\n",
-    "// IGraph animals = new Graph();\n",
-    "// new TurtleParser().Load(animals, \"data/animals.ttl\");\n",
-    "// string sparql = @\"PREFIX ex: <http://example.org/animals#>\n",
-    "// SELECT ?name ?age WHERE {\n",
-    "//     ?animal a ex:Dog . ?animal ex:name ?name . ?animal ex:age ?age .\n",
-    "// }\";\n",
-    "// var results = animals.ExecuteQuery(sparql) as SparqlResultSet;"
-   ]
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": "// Exercice 3 : Votre code ici\n// IGraph animals = new Graph();\n// new TurtleParser().Load(animals, \"data/animals.ttl\");\n// string sparql = @\"PREFIX ex: <http://example.org/animals#>\n// SELECT ?name ?age WHERE {\n//     ?animal a ex:Dog . ?animal ex:name ?name . ?animal ex:age ?age .\n// }\";\n// var results = animals.ExecuteQuery(sparql) as SparqlResultSet;\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Promote `SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb` from ALPHA to BETA under #999 campaign
- Add `Console.WriteLine("Exercice a completer")` to 3 exercise cells that had only commented-out code (no executable lines)
- Exercise stubs preserve all original comments/scaffolding per rule C.1

## Test plan
- [x] Cell-by-cell execution (.NET Interactive): 16/16 cells, 0 errors, 4.8s
- [x] No `raise NotImplementedError` in notebook (rule C.1)
- [x] All 16 code cells have `execution_count != null` + outputs (rule C.2)
- [x] Scope strict: only modified this single notebook (rule C.3)

## Sprint H — po-2025 ALPHA promotion

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>