### PR TITLE
feat(lean): prove gsChooseMax_maximal + GS invariant lemmas

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/GSState.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/GSState.lean
@@ -141,6 +141,28 @@ lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
     (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
     (hw : w ∈ gsCandidates prof σ m) :
     gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
-  sorry
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- choose preferred over w: choose ≤ w, so hmax gives w ≤ choose
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- equal preference: injectivity gives w = c
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- w preferred over choose: direct
+    right
+    exact hgt
 
 end StableMarriage


### PR DESCRIPTION
## Summary
- **Prove `gsChooseMax_maximal`**: GSState.lean sorry 1→0. Uses `Nat.lt_trichotomy` on `menPref` values + `Maximal` conditional + `Bijective.injective` + `Fin.ext` for Nat↔Fin equality
- **Includes Lemmas.lean**: 20+ proved GS invariant lemmas (womenBestState, womenUnproposed, menProposedDownward, GSConsistent, etc.)
- Split from #1111 per coordinator request (Lean-only, no prover changes)

## Proof strategy (gsChooseMax_maximal)
1. `obtain ⟨-, hmax⟩` from `Classical.choose_spec (Finset.exists_maximal h)` — hmax is conditional: `∀ y ∈ s, choose ≤ y → y ≤ choose`
2. `Nat.lt_trichotomy` on `prof.menPref m w` vs `prof.menPref m c` → 3 cases
3. Case `<` (choose preferred): `hmax hw (Or.inr hlt)` gives `w ≤ choose`
4. Case `=` (equal prefs): `Fin.ext heq` converts Nat→Fin, then `Bijective.injective` gives `w = c`
5. Case `>` (w preferred): `Or.inr hgt` directly

## Validation
```
grep -c sorry GSState.lean
# 0

lake build SUCCESS (687 jobs, 0 errors)
# Only sorrys are in GaleShapley.lean (3 × INTRACTABLE_UNTIL_GS_IMPL)
```

## Test plan
- [x] `lake build` in WSL — SUCCESS (687 jobs)
- [x] `grep -c sorry GSState.lean` — 0
- [x] Proof integrity: no axioms beyond what Mathlib provides
- [ ] Review proof for simplification opportunities

🤖 Generated with [Claude Code](https://claude.com/claude-code)