### PR TITLE
feat(prover): finalize Director — frontier model (Opus 4.7) + reference docs injection (#1081)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -102,7 +102,10 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
     client = create_client(provider, model_key="reasoning")
     return Agent(
         client=client,
-        instructions=COORDINATOR_AGENT_INSTRUCTIONS,
+        # #1081: the Coordinator sets the attack plan — ground it in the
+        # committed reference docs (mmaaz-git strategies, ported defs).
+        instructions=augment_instructions(
+            COORDINATOR_AGENT_INSTRUCTIONS, include_references=True),
         tools=[
             tools.get_proof_state,
             tools.set_attack_plan,
@@ -116,22 +119,34 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
     )
 
 
-DIRECTOR_MAX_TOKENS = 512
+# 512 was too tight: a frontier reasoning model (Opus 4.7 / GPT-5.5) needs
+# room to emit an APPROACH + a concrete TACTICS block, and on extended-thinking
+# routes part of the budget is spent before the visible answer. 2048 lets the
+# Director actually deliver actionable guidance; it is still called at most 3x
+# per session so the cost stays bounded.
+DIRECTOR_MAX_TOKENS = 2048
 
 
 def create_director_agent(provider: str = "openrouter") -> Agent:
-    """DirectorAgent: external LLM providing strategic tactic guidance.
+    """DirectorAgent: external frontier LLM providing strategic guidance.
 
-    Uses a more powerful model (GPT-5.5 via OpenRouter) to suggest
-    proof approaches when local agents fail. No tools — pure text output
-    with structured tactic suggestions.
+    Runs on the strongest model available via OpenRouter (Opus 4.7 /
+    GPT-5.5 high / DeepSeek v4 Pro — see prover/config.py + .env
+    OPENROUTER_CHAT_MODEL_ID). Steers the local z.ai/Qwen agents when they
+    stall: no tools, pure text output with a structured APPROACH + TACTICS
+    block grounded in the reference material embedded in the shared state
+    (mmaaz-git stable-marriage proofs, project definitions, lessons learned).
 
-    Budget: max 500 tokens, max 3 calls per iteration.
+    Budget: max 2048 tokens, max 3 calls per session.
     """
     client = create_client(provider, model_key="reasoning")
     return Agent(
         client=client,
-        instructions=DIRECTOR_AGENT_INSTRUCTIONS,
+        # #1081: the whole point of the frontier Director is grounded guidance
+        # — inject the committed reference docs (mmaaz-git proofs, ported defs,
+        # project tactic patterns) into its instructions.
+        instructions=augment_instructions(
+            DIRECTOR_AGENT_INSTRUCTIONS, include_references=True),
         tools=[],
         name="DirectorAgent",
         default_options=ChatOptions(max_tokens=DIRECTOR_MAX_TOKENS),

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -30,12 +30,19 @@ PROVIDERS = {
         }
     },
     "openrouter": {
+        # OpenRouter is the "powerful provider" lane: the DirectorAgent runs
+        # here on a frontier model to steer the local z.ai/Qwen agents when
+        # they stall. The reasoning default MUST stay a frontier model
+        # (Opus 4.7 / GPT-5.5 / DeepSeek v4 Pro class) — a weak default like
+        # gpt-4o-mini defeats the entire point of the Director escalation.
         "base_url": os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
         "api_key": os.getenv("OPENROUTER_API_KEY", ""),
         "models": {
             "reasoning": os.getenv("OPENROUTER_CHAT_MODEL_ID",
-                                   os.getenv("OPENAI_CHAT_MODEL_ID", "gpt-4o-mini")),
-            "fast": os.getenv("OPENROUTER_FAST_MODEL_ID", "gpt-4o-mini"),
+                                   os.getenv("OPENAI_CHAT_MODEL_ID",
+                                             "anthropic/claude-opus-4.7")),
+            "fast": os.getenv("OPENROUTER_FAST_MODEL_ID",
+                              "anthropic/claude-haiku-4.5"),
         }
     },
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -180,21 +180,110 @@ REGLES:
 - Si le but semble hors de portee, dis LEAVERN (abandon)
 - Adapte tes suggestions aux ERREURS PASSEES (ne repete pas ce qui a echoue)
 - Tu peux suggérer des `have` intermediaires pour decomposer
-- Priorise les tactiques Mathlib disponibles sur les raisonnements from-scratch"""
+- Priorise les tactiques Mathlib disponibles sur les raisonnements from-scratch
+- ANCRE ton APPROACH dans le materiel de reference fourni (REFERENCE DOCS: definitions
+  portees, lemmes deja prouves, strategies mmaaz-git, patterns tactiques du projet) quand
+  il est present — ne raisonne pas a l'aveugle si une strategie de reference existe deja."""
 
-def augment_instructions(base: str, goal: str = "", max_chars: int = 3000) -> str:
-    """Prepend ProofKnowledgeBase context to any agent's instructions."""
+def load_reference_docs(project: str = "stable_marriage", max_chars: int = 6000) -> str:
+    """Load a compact summary of the committed reference docs for `project`.
+
+    Reads `session_state/reference_docs/<project>/` (issue #1081 Part 2) and returns a
+    concatenated, length-capped summary so the prover's agents — especially the
+    DirectorAgent — can ground their guidance in the original mmaaz-git proofs and our
+    ported definitions instead of starting blind each iteration.
+
+    Markdown files (`.md`) are included in full (truncated to a per-file budget); `.lean`
+    snapshot files are summarized to their declaration headers only (NOT dumped whole) to
+    keep the total under `max_chars`. Returns "" if the directory is absent.
+    """
+    import os
+
+    ref_dir = os.path.join(
+        os.path.dirname(__file__), "session_state", "reference_docs", project
+    )
+    if not os.path.isdir(ref_dir):
+        return ""
+
+    # md files carry the distilled strategy/hints; lean files are bulky snapshots.
+    md_files = sorted(f for f in os.listdir(ref_dir) if f.endswith(".md"))
+    lean_files = sorted(f for f in os.listdir(ref_dir) if f.endswith(".lean"))
+    if not md_files and not lean_files:
+        return ""
+
+    parts: list[str] = []
+    # Budget: most of the cap goes to the markdown strategy docs.
+    per_md = max(800, (max_chars - 1200) // max(1, len(md_files)))
+    for name in md_files:
+        try:
+            with open(os.path.join(ref_dir, name), encoding="utf-8") as fh:
+                text = fh.read().strip()
+        except OSError:
+            continue
+        if len(text) > per_md:
+            text = text[:per_md].rstrip() + "\n... [truncated]"
+        parts.append(f"## REFERENCE: {name}\n{text}")
+
+    # For .lean snapshots, list declaration headers only (def/lemma/theorem/structure).
+    for name in lean_files:
+        try:
+            with open(os.path.join(ref_dir, name), encoding="utf-8") as fh:
+                lines = fh.readlines()
+        except OSError:
+            continue
+        decls = [
+            ln.strip()
+            for ln in lines
+            if ln.lstrip().startswith(
+                ("def ", "lemma ", "theorem ", "structure ", "noncomputable def ", "abbrev ")
+            )
+        ]
+        if decls:
+            header = "\n".join(f"  {d}" for d in decls)
+            parts.append(
+                f"## REFERENCE (declarations only): {name}\n"
+                f"  (full snapshot on disk; only signatures listed here)\n{header}"
+            )
+
+    summary = "\n\n".join(parts).strip()
+    if len(summary) > max_chars:
+        summary = summary[:max_chars].rstrip() + "\n... [truncated]"
+    return summary
+
+
+def augment_instructions(
+    base: str,
+    goal: str = "",
+    max_chars: int = 3000,
+    include_references: bool = False,
+    project: str = "stable_marriage",
+) -> str:
+    """Prepend ProofKnowledgeBase context to any agent's instructions.
+
+    If `include_references` is True, also prepend the committed reference docs for
+    `project` (issue #1081 Part 2). Default is False so existing call sites are
+    unaffected.
+    """
     from .knowledge import ProofKnowledgeBase
     kb = ProofKnowledgeBase()
     context = kb.generate_prover_context(goal=goal, max_chars=max_chars)
-    if not context.strip():
+
+    references = load_reference_docs(project) if include_references else ""
+
+    if not context.strip() and not references.strip():
         return base
-    return (
-        f"# PROOF KNOWLEDGE BASE (accumulated from past sessions)\n"
-        f"{context}\n\n"
-        f"---\n\n"
-        f"{base}"
-    )
+
+    blocks: list[str] = []
+    if references.strip():
+        blocks.append(
+            f"# REFERENCE DOCS (committed shared state — issue #1081)\n{references}"
+        )
+    if context.strip():
+        blocks.append(
+            f"# PROOF KNOWLEDGE BASE (accumulated from past sessions)\n{context}"
+        )
+    blocks.append(base)
+    return "\n\n---\n\n".join(blocks)
 
 
 AUTONOMOUS_PROVER_INSTRUCTIONS = """Prouveur autonome. Edite directement le fichier .lean.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/README.md
@@ -1,0 +1,66 @@
+# `session_state/` — portable shared state for the multi-agent Lean prover
+
+Introduced by issue #1081 Part 2 ("reference documents injection"). The multi-agent prover
+(`agent_tests/prover/`) used to start every iteration blind: its agents — including the
+frontier-model `DirectorAgent` — had no access to reference material and rediscovered the
+same proof strategies from scratch each run.
+
+This directory is the **committed, portable shared state** that survives from one iteration
+to the next, so agents can ground their guidance in real reference material.
+
+## Layout
+
+```
+session_state/
+  reference_docs/
+    stable_marriage/
+      mmaaz-git-gs-strategies.md   # proof STRATEGIES extracted from the original
+                                   #   github.com/mmaaz-git/stable-marriage-lean repo
+      gs-definitions.lean          # auto-copied snapshot: Definitions.lean + GSState.lean
+      existing_proofs.lean         # auto-copied snapshot: our ported, PROVEN Lemmas.lean
+      project_hints.md             # domain tactic patterns (issue #1081 Part 1 + cookbook)
+  lessons_learned.json             # cross-session tactical lessons ({} placeholder + schema)
+  session_summary.md               # bilan of the previous prover session (placeholder)
+  README.md                        # this file
+```
+
+## Conservation vs cleanup policy
+
+The whole point of this directory is to separate what must **persist** from what is
+**ephemeral pollution** of a single iteration.
+
+**Conservation (committed, kept across iterations):**
+- `reference_docs/` — reference material. Stable; only changes when the underlying source
+  files change (the `.lean` snapshots are re-copied) or when strategy notes are improved.
+- `lessons_learned.json` — accumulated tactical lessons. Grows across sessions; the prover
+  appends, deduplicating by goal signature. Never auto-deleted.
+- `session_summary.md` — the previous session's bilan. Overwritten (not appended) by each
+  new session, but always kept so the next session can read it.
+
+**Cleanup (NOT stored here, must be wiped between sessions):**
+- Failed tactic attempts of the current iteration, ephemeral proof-state dumps, scratch
+  context. These live in the prover's transient state (`attempt_history.py`, `state.py`,
+  `traces/`), not in `session_state/`. A new session must start from a clean transient
+  state — only `session_state/` carries over.
+
+Rule of thumb: if it is a *reference* (definitions, proven lemmas, strategies) or a
+*distilled lesson*, it belongs here and is conserved. If it is *raw attempt noise* from one
+run, it does not belong here and is cleaned up.
+
+## Regenerating the auto-copied snapshots
+
+`gs-definitions.lean` and `existing_proofs.lean` are verbatim snapshots of
+`MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/` files
+(`Definitions.lean` + `GSState.lean`, and `Lemmas.lean` respectively). They are **not part
+of any Lake build** — they exist only as agent reference. When the source files change,
+re-copy them (and update the header date). Do not edit the snapshots in place; edit the
+real source under `stable_marriage_lean/`.
+
+## How it is wired into the prover
+
+`agent_tests/prover/instructions.py` exposes `load_reference_docs(project)` which reads the
+`reference_docs/<project>/` files and returns a compact (~6000 char) concatenated summary.
+`augment_instructions(..., include_references=True)` optionally prepends it to an agent's
+instructions; the default is `False` so existing call sites are unaffected. The
+`DIRECTOR_AGENT_INSTRUCTIONS` constant tells the Director to ground its APPROACH in this
+reference material.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/lessons_learned.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/lessons_learned.json
@@ -1,0 +1,26 @@
+{
+  "_schema": {
+    "description": "Cross-session tactical lessons for the multi-agent Lean prover (issue #1081 Part 2/3). Conservation state: this file persists across iterations, unlike ephemeral attempt history. Populated by the prover at end of session; this committed version is the {} placeholder.",
+    "expected_shape": {
+      "<project>": {
+        "successful_tactic_chains": [
+          {
+            "goal_signature": "string - normalized goal pattern",
+            "tactic_chain": ["string", "..."],
+            "context_requirements": ["string - preconditions e.g. 'gsStepWith in hypotheses'"],
+            "uses": "int - times this chain succeeded"
+          }
+        ],
+        "failure_patterns": [
+          {
+            "goal_signature": "string",
+            "failed_tactic": "string",
+            "error": "string - e.g. 'simp made no progress'",
+            "lesson": "string - what to do instead"
+          }
+        ]
+      }
+    },
+    "note": "project keys: 'stable_marriage', 'voting', 'social_choice', etc. Keep entries deduplicated by goal_signature."
+  }
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/existing_proofs.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/existing_proofs.lean
@@ -1,0 +1,659 @@
+-- ============================================================
+-- AUTO-COPIED SNAPSHOT -- DO NOT EDIT HERE
+-- Source: MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/Lemmas.lean
+-- Purpose: reference material for the multi-agent Lean prover (issue #1081 Part 2).
+--   These are our ported, PROVEN invariant lemmas. The prover agents use them as
+--   building blocks for the still-intractable GaleShapley.lean theorems.
+--   Regenerate by re-copying the source file when it changes. NOT part of any Lake build.
+-- ============================================================
+
+/-
+  Stable Marriage - Key Lemmas for GS Algorithm Correctness
+  ==========================================================
+
+  Invariants preserved by each GS step:
+  - Matching consistency (each matched pair is mutual)
+  - Proposal monotonicity (proposed set only grows)
+  - Men always proposed downward (to less-preferred women)
+  - Terminating invariants (proposal count bound)
+
+  Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+  Simplified for total bijective preferences (no `acceptable` filter needed).
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Tactic.Common
+import StableMarriage.Definitions
+import StableMarriage.GSState
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-! ## Consistent Partial Matching -/
+
+/-- A partial matching is consistent: each match is mutual.
+    If man m is matched to woman w, then woman w is matched to man m,
+    and vice versa. -/
+def GSConsistent (μ : GSMatching n) : Prop :=
+  ∀ m w, μ.menMatch m = some w ↔ μ.womenMatch w = some m
+
+namespace GSConsistent
+
+variable {μ : GSMatching n}
+
+lemma men_iff_women (h : GSConsistent μ) (m : Fin n) (w : Fin n) :
+    μ.menMatch m = some w ↔ μ.womenMatch w = some m := h m w
+
+lemma women_iff_men (h : GSConsistent μ) (w : Fin n) (m : Fin n) :
+    μ.womenMatch w = some m ↔ μ.menMatch m = some w := (h m w).symm
+
+/-- Initial matching is consistent (all none). -/
+lemma initial : GSConsistent (GSMatching.initial (n := n)) := by
+  intro m w
+  simp [GSMatching.initial]
+
+/-- Matching a free man and free woman preserves consistency. -/
+lemma matchFree (h : GSConsistent μ) (m : Fin n) (w : Fin n)
+    (hm : μ.menMatch m = none) (hw : μ.womenMatch w = none) :
+    GSConsistent (μ.matchFree m w) := by
+  intro m' w'
+  simp only [GSMatching.matchFree, Function.update_apply]
+  split_ifs
+  · simp_all
+  · have : μ.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all [ne_comm]
+  · have : μ.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all [ne_comm]
+  · exact h m' w'
+
+end GSConsistent
+
+/-! ## Proposed Set Tracking -/
+
+/-- The set of proposed pairs as a Finset. -/
+noncomputable def proposedSet (prof : PrefProfile n) (σ : GSState prof) :
+    Finset (Fin n × Fin n) :=
+  Finset.univ.filter (fun mw => σ.proposed mw.1 mw.2)
+
+/-- Number of proposed pairs. -/
+noncomputable def proposedCount (prof : PrefProfile n) (σ : GSState prof) : Nat :=
+  (proposedSet prof σ).card
+
+namespace proposedSet
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma mem_iff (mw : Fin n × Fin n) :
+    mw ∈ proposedSet prof σ ↔ σ.proposed mw.1 mw.2 := by
+  simp [proposedSet]
+
+/-- gsStepWith inserts exactly one new pair into the proposed set. -/
+lemma stepWith_insert (σ : GSState prof) (m w : Fin n) :
+    proposedSet prof (gsStepWith prof σ m w) =
+      insert (m, w) (proposedSet prof σ) := by
+  classical
+  ext ⟨m', w'⟩
+  simp only [mem_iff, mem_insert, Prod.mk.injEq]
+  unfold gsStepWith
+  split
+  · simp; tauto
+  · split <;> simp <;> tauto
+
+end proposedSet
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- Initial state has zero proposals. -/
+lemma initial : proposedCount prof (gsInitial prof) = 0 := by
+  classical
+  simp [proposedCount, proposedSet, gsInitial]
+
+/-- StepWith increases count by one for a new proposal. -/
+lemma stepWith (σ : GSState prof) (m w : Fin n) (hnew : ¬ σ.proposed m w) :
+    proposedCount prof (gsStepWith prof σ m w) = proposedCount prof σ + 1 := by
+  classical
+  have hmem : (m, w) ∉ proposedSet prof σ := by
+    simp [proposedSet]
+    exact hnew
+  simp only [proposedCount, proposedSet.stepWith_insert]
+  exact card_insert_of_notMem hmem
+
+end proposedCount
+
+/-! ## Men Proposed Downward Invariant -/
+
+/-- In the GS algorithm, men propose in order of decreasing preference.
+    After k steps, all proposals by man m were to his top-k candidates.
+    Since preferences are total bijections, every woman is a valid candidate. -/
+def menProposedDownward (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w w', σ.proposed m w → prof.menPref m w' < prof.menPref m w →
+    σ.proposed m w'
+
+/-! ## Women Best Match Invariant -/
+
+/-- Each woman's current match is her best proposal so far. -/
+def womenBestState (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m m', σ.matching.womenMatch w = some m → σ.proposed m' w →
+    prof.womenPref w m ≤ prof.womenPref w m'
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- Initial state trivially satisfies womenBest (no matches). -/
+lemma initial : womenBestState prof (gsInitial prof) := by
+  unfold womenBestState
+  intro w m m' hmatch _
+  unfold gsInitial GSMatching.initial at hmatch
+  simp at hmatch
+
+end womenBestState
+
+/-! ## Men Matched Implies Proposed -/
+
+/-- Every matched man has proposed to his current partner. -/
+def menMatchedProposed (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ m w, σ.matching.menMatch m = some w → σ.proposed m w
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- Initial state trivially satisfies (no matches). -/
+lemma initial : menMatchedProposed prof (gsInitial prof) := by
+  unfold menMatchedProposed
+  intro m w hmatch
+  unfold gsInitial at hmatch
+  unfold GSMatching.initial at hmatch
+  simp at hmatch
+
+end menMatchedProposed
+
+/-! ## Consistency Preservation by GS Steps -/
+
+namespace GSConsistent
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- swapMatch preserves consistency when woman w prefers m over mOld.
+    Pattern follows matchFree proof: split_ifs + have for consistency chains. -/
+lemma swapMatch (h : GSConsistent σ.matching) (m mOld w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (hw : σ.matching.womenMatch w = some mOld)
+    (hmOld : σ.matching.menMatch mOld = some w) :
+    GSConsistent (σ.matching.swapMatch m mOld w) := by
+  have hne : m ≠ mOld := by intro heq; subst heq; simp_all
+  intro m' w'
+  simp only [GSMatching.swapMatch, Function.update_apply]
+  -- outermost if: m' = mOld (from outer update)
+  -- then inner if: m' = m (from inner update)
+  -- RHS if: w' = w
+  split_ifs with h_mOld h_ww h_m h_nw h_nm
+  · -- m' = mOld, w' = w: both sides False by hne
+    simp_all
+  · -- m' = mOld, w' ≠ w: need μ.womenMatch w' ≠ some mOld
+    have : σ.matching.womenMatch w' ≠ some mOld := by
+      intro heq; have := (h mOld w').mpr heq; simp_all
+    simp_all
+  · -- m' ≠ mOld, m' = m, w' = w: both sides True
+    simp_all
+  · -- m' ≠ mOld, m' = m, w' ≠ w: need μ.womenMatch w' ≠ some m
+    have hnw' : w ≠ w' := ne_comm.mp ‹¬w' = w›
+    have : σ.matching.womenMatch w' ≠ some m := by
+      intro heq; have := (h m w').mpr heq; simp_all
+    simp_all
+  · -- m' ≠ mOld, m' ≠ m, w' = w: need μ.menMatch m' ≠ some w
+    have hnm' : m ≠ m' := ne_comm.mp ‹¬m' = m›
+    have : σ.matching.menMatch m' ≠ some w := by
+      intro heq; have := (h m' w).mp heq; simp_all
+    simp_all
+  · -- m' ≠ mOld, m' ≠ m, w' ≠ w: direct consistency
+    exact h m' w'
+
+/-- gsStepWith preserves matching consistency. -/
+lemma stepWith (h : GSConsistent σ.matching) (m w : Fin n)
+    (hm : σ.matching.menMatch m = none)
+    (_hproposed : ¬ σ.proposed m w) :
+    GSConsistent (gsStepWith prof σ m w).matching := by
+  unfold gsStepWith
+  split
+  · -- womenMatch w = none: matchFree case
+    exact matchFree h m w hm ‹_›
+  · -- womenMatch w = some mOld
+    split
+    · -- woman prefers m over mOld: swapMatch case
+      next mOld hwm hwlt =>
+        have hmOld : σ.matching.menMatch mOld = some w := (h mOld w).mpr hwm
+        exact swapMatch prof h m mOld w hm hwm hmOld
+    · -- woman does NOT prefer m: matching unchanged
+      exact h
+
+/-- gsStep preserves matching consistency. -/
+lemma step (h : GSConsistent σ.matching) (hfree : ∃ m, gsIsFree prof σ m) :
+    GSConsistent (gsStep prof σ).matching := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof h m w hm.1 hw
+
+/-- gsRunSteps preserves matching consistency. -/
+lemma runSteps (k : Nat) :
+    GSConsistent (gsRunSteps prof k).matching := by
+  induction k with
+  | zero => exact initial
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end GSConsistent
+
+/-! ## Termination: Proposal Count Bound -/
+
+namespace proposedCount
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- A step for a free man increases the proposal count. -/
+lemma step_of_free (σ : GSState prof) (m : Fin n)
+    (hf : gsIsFree prof σ m) :
+    proposedCount prof (gsStep prof σ) = proposedCount prof σ + 1 := by
+  unfold gsStep
+  rw [dif_pos ⟨m, hf⟩]
+  let m' := Classical.choose ⟨m, hf⟩
+  have hm' : gsIsFree prof σ m' := Classical.choose_spec ⟨m, hf⟩
+  let w := gsChooseMax prof σ m' hm'.2
+  have hw : ¬ σ.proposed m' w := by
+    have := gsChooseMax_mem prof σ m' hm'.2
+    simp [gsCandidates] at this
+    exact this
+  exact stepWith prof σ m' w hw
+
+/-- Proposal count never exceeds n² for any state. -/
+lemma le_bound (σ : GSState prof) :
+    proposedCount prof σ ≤ gsProposalBound n := by
+  classical
+  unfold proposedCount proposedSet gsProposalBound
+  calc (Finset.univ.filter fun mw => σ.proposed mw.1 mw.2).card
+      ≤ (Finset.univ : Finset (Fin n × Fin n)).card :=
+        Finset.card_le_card (Finset.filter_subset _ _)
+    _ = n * n := by
+        simp only [Finset.card_univ, Fintype.card_prod, Fintype.card_fin]
+
+/-- Proposal count at step k never exceeds the bound. -/
+lemma runSteps_le_bound (k : Nat) :
+    proposedCount prof (gsRunSteps prof k) ≤ gsProposalBound n :=
+  le_bound prof _
+
+/-- If a free man exists, one more step keeps count at or below bound. -/
+lemma step_preserves_le_bound {_σ : GSState prof}
+    (_h : proposedCount prof _σ ≤ gsProposalBound n) :
+    proposedCount prof (gsStep prof _σ) ≤ gsProposalBound n :=
+    le_bound prof _
+
+/-- If the algorithm hasn't terminated after k steps, count equals k. -/
+lemma runSteps_eq_of_not_terminated (k : Nat)
+    (hterm : ¬ gsTerminated prof (gsRunSteps prof k)) :
+    proposedCount prof (gsRunSteps prof k) = k := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    have hnk : ¬ gsTerminated prof (gsRunSteps prof k') := by
+      intro hk_term
+      unfold gsTerminated at hk_term hterm
+      simp only [gsRunSteps] at hterm
+      unfold gsStep at hterm
+      rw [dif_neg hk_term] at hterm
+      exact hterm hk_term
+    have ihk := ih hnk
+    have hf : ∃ m, gsIsFree prof (gsRunSteps prof k') m := not_not.mp hnk
+    rw [step_of_free prof (gsRunSteps prof k') (Classical.choose hf)
+        (Classical.choose_spec hf), ihk]
+
+end proposedCount
+
+/-! ## Step Identity When Terminated -/
+
+/-- If the state is terminated, gsStep is identity. -/
+lemma gsStep_eq_of_terminated (prof : PrefProfile n) (σ : GSState prof)
+    (h : gsTerminated prof σ) :
+    gsStep prof σ = σ := by
+  unfold gsStep gsTerminated at *
+  split
+  · contradiction
+  · rfl
+
+/-- If the state is terminated at step k, all subsequent steps are identity. -/
+lemma gsRunSteps_eq_of_terminated (prof : PrefProfile n) (k j : Nat) (hkj : k ≤ j)
+    (h : gsTerminated prof (gsRunSteps prof k)) :
+    gsRunSteps prof j = gsRunSteps prof k := by
+  induction j generalizing k with
+  | zero =>
+    have : k = 0 := Nat.eq_zero_of_le_zero hkj
+    subst this; rfl
+  | succ j' ih =>
+    simp only [gsRunSteps]
+    cases eq_or_lt_of_le hkj with
+    | inl heq => subst heq; rfl
+    | inr hlt =>
+      rw [ih k (Nat.le_of_lt_succ hlt) h]
+      exact gsStep_eq_of_terminated prof _ h
+
+/-! ## Invariant: Men Proposed Downward (step preservation) -/
+
+namespace menProposedDownward
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- gsStep preserves the menProposedDownward invariant. -/
+lemma step (h : menProposedDownward prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menProposedDownward prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  let w₀ := gsChooseMax prof σ m₀ hm₀.2
+  have hw₀ : ¬ σ.proposed m₀ w₀ := by
+    intro h
+    have := gsChooseMax_mem prof σ m₀ hm₀.2
+    simp [gsCandidates] at this
+    exact this h
+  -- Maximality: gsChooseMax is most preferred candidate; no candidate is more preferred
+  have hmax : ∀ w', w' ∈ gsCandidates prof σ m₀ →
+      gsMenPrefLE prof m₀ w₀ w' → w₀ = w' := by
+    intro w' hw'in hle
+    have hmax' := gsChooseMax_maximal prof σ m₀ hm₀.2 w' hw'in
+    cases hle with
+    | inl h => exact h
+    | inr hlt =>
+      cases hmax' with
+      | inl h => exact h.symm
+      | inr hgt => exact absurd hgt (lt_asymm hlt)
+  intro m w w' hprop hlt
+  have goal_from (hab : σ.proposed m w') :
+      (gsStepWith prof σ m₀ w₀).proposed m w' :=
+    (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w')).mp
+      (by rw [proposedSet.stepWith_insert prof σ m₀ w₀]
+          simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff]
+          right; exact hab)
+  have hsrc : σ.proposed m w ∨ (m = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m, w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  rcases hsrc with (hw | ⟨rfl, rfl⟩)
+  · exact goal_from (h m w w' hw hlt)
+  · have hw' : σ.proposed m₀ w' := by
+      by_contra hn
+      have hw'in : w' ∈ gsCandidates prof σ m₀ := by simp [gsCandidates]; exact hn
+      have : w₀ = w' := hmax w' hw'in (Or.inr hlt)
+      subst this; exact lt_irrefl _ hlt
+    exact goal_from hw'
+
+/-- gsRunSteps preserves the menProposedDownward invariant. -/
+lemma runSteps (k : Nat) :
+    menProposedDownward prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    intro m w w' hw hlt
+    unfold gsInitial GSMatching.initial at hw
+    simp at hw
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menProposedDownward
+
+/-! ## Invariant: Men Matched Implies Proposed (step preservation) -/
+
+namespace menMatchedProposed
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- gsStepWith preserves menMatchedProposed. -/
+lemma stepWith (h : menMatchedProposed prof σ) (m w : Fin n) :
+    menMatchedProposed prof (gsStepWith prof σ m w) := by
+  intro m' w' hmatch
+  simp only [gsStepWith] at hmatch ⊢
+  split at *
+  · -- none case: matchFree m w
+    dsimp [GSMatching.matchFree] at hmatch ⊢
+    rw [Function.update_apply] at hmatch
+    split_ifs at hmatch
+    · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+    · left; exact h m' w' hmatch
+  · -- some mOld case
+    rename_i mOld
+    split_ifs at *
+    · -- prefers m: swapMatch m mOld w
+      dsimp [GSMatching.swapMatch] at hmatch ⊢
+      rw [Function.update_apply, Function.update_apply] at hmatch
+      split_ifs at hmatch
+      · injection hmatch with hw; right; exact ⟨‹m' = m›, hw.symm⟩
+      · left; exact h m' w' hmatch
+    · -- doesn't prefer: unchanged
+      dsimp at hmatch ⊢
+      left; exact h m' w' hmatch
+
+/-- gsStep preserves menMatchedProposed. -/
+lemma step (h : menMatchedProposed prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    menMatchedProposed prof (gsStep prof σ) := by
+  unfold gsStep
+  rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  exact stepWith prof h m w
+
+/-- gsRunSteps preserves menMatchedProposed. -/
+lemma runSteps (k : Nat) :
+    menMatchedProposed prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end menMatchedProposed
+
+/-! ## Invariant: Women Proposed Implies Matched -/
+
+/-- If a man has proposed to a woman, she must be matched. -/
+def womenProposedImpliesMatched (prof : PrefProfile n) (σ : GSState prof) : Prop :=
+  ∀ w m, σ.proposed m w → σ.matching.womenMatch w ≠ none
+
+namespace womenProposedImpliesMatched
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+lemma initial : womenProposedImpliesMatched prof (gsInitial prof) := by
+  intro w m hprop; unfold gsInitial at hprop; simp at hprop
+
+lemma stepWith (h : womenProposedImpliesMatched prof σ) (m₀ w₀ : Fin n)
+    (hnew : ¬ σ.proposed m₀ w₀) :
+    womenProposedImpliesMatched prof (gsStepWith prof σ m₀ w₀) := by
+  intro w m' hprop
+  have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+  rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+  simp only [Finset.mem_insert, Prod.mk.injEq] at hmem
+  simp only [gsStepWith]
+  split
+  · dsimp [GSMatching.matchFree]
+    rw [Function.update_apply]
+    by_cases hw : w = w₀
+    · rw [if_pos hw]; simp
+    · rw [if_neg hw]
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · exact absurd rfl hw
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+  · split
+    · next mOld hmold hpref =>
+      dsimp [GSMatching.swapMatch]
+      rw [Function.update_apply]
+      by_cases hw : w = w₀
+      · rw [if_pos hw]; simp
+      · rw [if_neg hw]
+        rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+        · exact absurd rfl hw
+        · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+    · next mOld hmold hpref =>
+      rcases hmem with ⟨⟨rfl, rfl⟩⟩ | hold
+      · simp [hmold]
+      · exact h w m' ((@proposedSet.mem_iff n _ prof σ (m', w)).mp hold)
+
+lemma step (h : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenProposedImpliesMatched prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  let m := Classical.choose hfree
+  have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+  let w := gsChooseMax prof σ m hm.2
+  have hw : ¬ σ.proposed m w := by
+    have := gsChooseMax_mem prof σ m hm.2; simp [gsCandidates] at this; exact this
+  exact stepWith prof h m w hw
+
+lemma runSteps (k : Nat) :
+    womenProposedImpliesMatched prof (gsRunSteps prof k) := by
+  induction k with
+  | zero => simp only [gsRunSteps]; exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenProposedImpliesMatched
+
+/-! ## Invariant: Women Best State (step preservation) -/
+
+/-- If a woman is unmatched and womenProposedImpliesMatched holds,
+    no man has proposed to her yet (contrapositive). -/
+lemma womenUnproposed (prof : PrefProfile n) (σ : GSState prof)
+    (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    ∀ w, σ.matching.womenMatch w = none → ∀ m', ¬σ.proposed m' w := by
+  intro w hw m' hprop
+  exact (hwp w m' hprop) hw
+
+namespace womenBestState
+
+variable (prof : PrefProfile n) {σ : GSState prof}
+
+/-- gsStep preserves womenBestState. -/
+lemma step (h : womenBestState prof σ)
+    (hwp : womenProposedImpliesMatched prof σ)
+    (hfree : ∃ m, gsIsFree prof σ m) :
+    womenBestState prof (gsStep prof σ) := by
+  unfold gsStep; rw [dif_pos hfree]
+  set m₀ := Classical.choose hfree
+  have hm₀ : gsIsFree prof σ m₀ := Classical.choose_spec hfree
+  set w₀ := gsChooseMax prof σ m₀ hm₀.2
+  unfold womenBestState
+  intro w m m' hmatch hprop
+  have hsrc : σ.proposed m' w ∨ (m' = m₀ ∧ w = w₀) := by
+    have hmem := (@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop
+    rw [proposedSet.stepWith_insert prof σ m₀ w₀] at hmem
+    simp only [Finset.mem_insert, Prod.mk.injEq, proposedSet.mem_iff] at hmem
+    cases hmem with | inl h => right; exact h | inr h => left; exact h
+  -- Reduce gsStepWith match and split on discriminant
+  change (gsStepWith prof σ m₀ w₀).matching.womenMatch w = some m at hmatch
+  simp only [gsStepWith] at hmatch
+  split at hmatch
+  · -- none case: matchFree
+    dsimp [GSMatching.matchFree] at hmatch
+    rw [Function.update_apply] at hmatch
+    by_cases hw : w = w₀
+    · rw [if_pos hw] at hmatch
+      injection hmatch with hmi; subst hmi
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exfalso
+        have hn := ‹σ.matching.womenMatch w₀ = none›
+        exact womenUnproposed prof σ h hwp hfree w₀ hn m' (hw ▸ hw')
+      · exact le_rfl
+    · rw [if_neg hw] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · exact h w m m' hmatch hw'
+      · exfalso; exact hw rfl
+  · -- some mOld case
+    next mOld hmold =>
+    by_cases hpref : prof.womenPref w₀ m₀ < prof.womenPref w₀ mOld
+    · rw [if_pos hpref] at hmatch
+      dsimp [GSMatching.swapMatch] at hmatch
+      rw [Function.update_apply] at hmatch
+      by_cases hw : w = w₀
+      · rw [if_pos hw] at hmatch
+        injection hmatch with hmi; subst hmi
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · subst hw
+          have hold := h w₀ mOld m' hmold hw'
+          exact le_trans (le_of_lt hpref) hold
+        · exact le_rfl
+      · rw [if_neg hw] at hmatch
+        rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+        · exact h w m m' hmatch hw'
+        · exfalso; exact hw rfl
+    · rw [if_neg hpref] at hmatch
+      rcases hsrc with (hw' | ⟨rfl, rfl⟩)
+      · by_cases hw : w = w₀
+        · subst hw; exact h w₀ m m' hmatch hw'
+        · exact h w m m' hmatch hw'
+      · rw [hmatch] at hmold
+        injection hmold with heq; subst heq
+        exact by omega
+
+/-- gsRunSteps preserves womenBestState. -/
+lemma runSteps (k : Nat) :
+    womenBestState prof (gsRunSteps prof k) := by
+  induction k with
+  | zero =>
+    simp only [gsRunSteps]
+    exact initial prof
+  | succ k' ih =>
+    simp only [gsRunSteps]
+    by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+    · exact step prof ih (womenProposedImpliesMatched.runSteps prof k') h
+    · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+        unfold gsStep; simp [h]
+      rw [hid]; exact ih
+
+end womenBestState
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/gs-definitions.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/gs-definitions.lean
@@ -1,0 +1,301 @@
+-- ============================================================
+-- AUTO-COPIED SNAPSHOT -- DO NOT EDIT HERE
+-- Source: MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/
+--   Definitions.lean + GSState.lean (concatenated)
+-- Purpose: reference material for the multi-agent Lean prover (issue #1081 Part 2).
+--   The prover agents read this to ground their guidance in the actual ported
+--   definitions instead of starting blind. Regenerate by re-copying the source
+--   files when they change. This file is NOT part of any Lake build.
+-- ============================================================
+
+-- ===== Definitions.lean =====
+
+/-
+  Stable Marriage - Definitions
+  ==============================
+
+  Core types and definitions for the stable marriage problem.
+  We model n men and n women (both as Fin n), each with strict preference
+  rankings over the opposite set.
+
+  A matching is a bijection between men and women.
+  A matching is stable iff no blocking pair exists.
+-/
+
+import Mathlib.Data.Finset.Basic
+
+namespace StableMarriage
+
+open Finset Function
+
+variable {n : Nat} [NeZero n]
+
+/-- A man is identified by Fin n -/
+abbrev Man (n : Nat) := Fin n
+
+/-- A woman is identified by Fin n -/
+abbrev Woman (n : Nat) := Fin n
+
+/--
+A preference ordering for a person over the opposite set.
+Represented as a function mapping each candidate to a rank (lower = preferred).
+Strict preference means the ranking function is injective.
+-/
+structure PrefProfile (n : Nat) [NeZero n] where
+  /-- Men's preferences: each man ranks all women -/
+  menPref : Fin n → Fin n → Fin n
+  /-- Women's preferences: each woman ranks all men -/
+  womenPref : Fin n → Fin n → Fin n
+  /-- Each man's ranking is a permutation (bijective) -/
+  menPref_bijective : ∀ m, Bijective (menPref m)
+  /-- Each woman's ranking is a permutation (bijective) -/
+  womenPref_bijective : ∀ w, Bijective (womenPref w)
+
+namespace PrefProfile
+
+variable {n : Nat} [NeZero n] (prof : PrefProfile n)
+
+/--
+Man `m` prefers woman `w1` over woman `w2` iff w1 has a lower rank.
+Since menPref m is a bijection Fin n → Fin n, lower = more preferred.
+-/
+def manPrefers (m : Fin n) (w1 w2 : Fin n) : Bool :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` prefers man `m1` over man `m2` iff m1 has a lower rank.
+-/
+def womanPrefers (w : Fin n) (m1 m2 : Fin n) : Bool :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+/--
+Man `m` strictly prefers woman `w1` to woman `w2`.
+Prop-valued version for theorem statements.
+-/
+def ManPrefers (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  prof.menPref m w1 < prof.menPref m w2
+
+/--
+Woman `w` strictly prefers man `m1` to man `m2`.
+-/
+def WomanPrefers (w : Fin n) (m1 m2 : Fin n) : Prop :=
+  prof.womenPref w m1 < prof.womenPref w m2
+
+end PrefProfile
+
+/--
+A matching is a bijection from men to women (perfect matching).
+-/
+structure Matching (n : Nat) [NeZero n] where
+  /-- Map each man to his matched woman -/
+  spouse : Fin n → Fin n
+  /-- The matching is bijective (each woman matched to exactly one man) -/
+  bijective : Bijective spouse
+
+namespace Matching
+
+variable {n : Nat} [NeZero n] (μ : Matching n)
+
+/-- Get the inverse: which man is matched to woman w -/
+noncomputable def inverse (w : Fin n) : Fin n :=
+  (Equiv.ofBijective μ.spouse μ.bijective).symm w
+
+end Matching
+
+/--
+A blocking pair for matching μ under preference profile prof:
+a man m and woman w who both prefer each other to their current partners.
+-/
+def IsBlockingPair (prof : PrefProfile n) (μ : Matching n)
+    (m : Fin n) (w : Fin n) : Prop :=
+  prof.ManPrefers m w (μ.spouse m) ∧
+  prof.WomanPrefers w m (μ.inverse w)
+
+/--
+A matching is stable iff no blocking pair exists.
+-/
+def IsStable (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  ∀ m w, ¬ IsBlockingPair prof μ m w
+
+/--
+A matching is man-optimal iff every man gets their best possible partner
+among all stable matchings.
+-/
+def IsManOptimal (prof : PrefProfile n) (μ : Matching n) : Prop :=
+  IsStable prof μ ∧
+  ∀ μ' : Matching n, IsStable prof μ' →
+    ∀ m : Fin n, prof.menPref m (μ.spouse m) ≤ prof.menPref m (μ'.spouse m)
+
+end StableMarriage
+
+
+-- ===== GSState.lean =====
+
+/-
+  Stable Marriage - Gale-Shapley Algorithm State
+  ================================================
+
+  Intermediate state for the Gale-Shapley deferred acceptance algorithm.
+  Uses Option-based partial matching during algorithm execution,
+  converting to total bijective Matching at termination.
+
+  Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-- Partial matching during GS algorithm execution. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- Intermediate state for the Gale-Shapley deferred acceptance algorithm. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- These defs use explicit prof parameter to avoid section variable duplication
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## gsChooseMax helper lemmas -/
+
+/-- The chosen maximal candidate is in the candidate set. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- No unproposed candidate is preferred over the chosen maximal one.
+    Direct from maximality: ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  set c := Classical.choose (Finset.exists_maximal h) with hc
+  obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c)
+  rcases htri with (hlt | heq | hgt)
+  · -- choose preferred over w: choose ≤ w, so hmax gives w ≤ choose
+    have hle : c ≤ w := Or.inr hlt
+    exact hmax hw hle
+  · -- equal preference: injectivity gives w = c
+    left
+    exact (prof.menPref_bijective m).injective (Fin.ext heq)
+  · -- w preferred over choose: direct
+    right
+    exact hgt
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/mmaaz-git-gs-strategies.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/mmaaz-git-gs-strategies.md
@@ -1,0 +1,154 @@
+# Gale-Shapley proof strategies (extracted from mmaaz-git/stable-marriage-lean)
+
+## Source attribution
+
+- Original repository: https://github.com/mmaaz-git/stable-marriage-lean
+- Branch fetched: `main` (5 commits total; specific commit hash not exposed by GitHub raw
+  endpoint at fetch time, 2026-05-15). Lean toolchain noted in our port header as v4.25.0.
+- License: **NOT stated** in the repository (no `LICENSE` file, no license line in
+  `README.md` or source headers as of 2026-05-15). Treat as "all rights reserved by the
+  author" — this document only records the high-level proof STRATEGY (mathematical
+  argument structure and lemma names), not verbatim code. No source code from the original
+  repository is reproduced here.
+- Files consulted via `raw.githubusercontent.com`: `StableMarriageLean/GaleShapley.lean`,
+  `StableMarriageLean/Lemmas.lean`, `StableMarriageLean/Properties.lean`,
+  `StableMarriageLean/README.md`.
+
+## How the original repo is structured (vs our port)
+
+| Original (`StableMarriageLean/`) | Our port (`stable_marriage_lean/StableMarriage/`) |
+|---|---|
+| `Basic.lean` — preferences, matchings, stability, `prefersOpt`, acceptability | `Definitions.lean` — `PrefProfile`, `Matching`, `IsBlockingPair`, `IsStable`, `IsManOptimal` |
+| `GaleShapley.lean` — state machine: `GSState`, `step`, `runSteps`, `galeShapley`, `chooseMaxCandidate` | `GSState.lean` — `GSState`, `GSMatching`, `gsStep`, `gsRunSteps`, `gsGaleShapley`, `gsChooseMax` |
+| `Lemmas.lean` — invariant defs + step/runSteps preservation lemmas | `Lemmas.lean` — same invariants, ported |
+| `Properties.lean` — `galeShapley_stable`, `galeShapley_noBlockingPairs`, termination, IR | `GaleShapley.lean` — `gale_shapley_stable` etc. as **scaffolds with `sorry`** |
+
+Important difference: the original models **incomplete preference lists** (an `acceptable`
+filter, `prefersOpt`, `menAcceptableState` / `womenAcceptableState` invariants and the
+`individuallyRational` theorem). Our port simplifies to **total bijective preferences** —
+so the acceptability machinery is dropped, and any proof step that the original justifies
+via "acceptable" is, for us, either trivial or unnecessary.
+
+## The three intractable sorrys in our codebase
+
+These are the `sorry`s the prover targets (`GaleShapley.lean`, DEMOS 15/16/17):
+
+- L73 `gale_shapley_stable : ∃ μ, IsStable prof μ`
+- L91 `gale_shapley_man_optimal : ∃ μ, IsManOptimal prof μ`
+- L119 `gale_shapley_woman_pessimal` (Knuth 1976 lattice duality)
+
+### 1. `gale_shapley_stable` — stability / no blocking pairs
+
+**This is the one the original repo actually proves**, as `galeShapley_stable` (which bundles
+`galeShapley_consistent`, `galeShapley_individuallyRational`, `galeShapley_noBlockingPairs`).
+For our total-preferences port, consistency + no-blocking-pairs suffice (no IR needed).
+
+**Witness.** Use `gsGaleShapley prof` (our `GSState.lean` L116) — i.e.
+`(gsRunSteps prof (gsProposalBound n)).matching` — as the constructive witness `μ`. It must
+first be turned from a `GSMatching` (Option-valued partial matching) into a total bijective
+`Matching`. The original gets totality from termination: at `terminated`, every man is
+matched. Our port would need a `GSMatching -> Matching` conversion lemma proving the final
+matching is total and bijective; this conversion is currently **missing** from our
+`Lemmas.lean` and is the first real obstacle.
+
+**Key lemmas in the original (names) feeding `galeShapley_noBlockingPairs`:**
+`runSteps_menProposedDownward`, `runSteps_menMatchedProposed`, `runSteps_womenBest`,
+`runSteps_womenUnmatchedReject`, plus `terminated`. Our port already has the analogues:
+`menProposedDownward.runSteps`, `menMatchedProposed.runSteps`, `womenBestState.runSteps`,
+`womenProposedImpliesMatched.runSteps`, `GSConsistent.runSteps` — all PROVEN (see
+`existing_proofs.lean`). We do NOT yet have a `womenUnmatchedReject` analogue, but with total
+preferences `womenProposedImpliesMatched` plays the equivalent role.
+
+**High-level argument (`noBlockingPairs`).** Suppose `(m, w)` is a blocking pair: `m`
+prefers `w` to his partner `μ.spouse m`, and `w` prefers `m` to her partner `μ.inverse w`.
+- Since `m` prefers `w` over his final partner, by `menProposedDownward` (men propose in
+  decreasing preference order, and at termination `m` has exhausted his candidate set) `m`
+  must have proposed to `w` at some step.
+- By `menMatchedProposed` / `womenProposedImpliesMatched`, once `m` proposed to `w`, `w` was
+  matched from that point on and stayed matched (matches only improve for women).
+- By `womenBestState`, `w`'s final partner is at least as preferred (for `w`) as **every**
+  man who ever proposed to her — including `m`. So `w` does NOT prefer `m` to her final
+  partner. Contradiction with the blocking-pair assumption.
+- Case-split on `w`'s match status at termination is the structural skeleton: the original
+  `galeShapley_noBlockingPairs` "case-splits on w's match status".
+
+**Tactic shape to expect.** `intro m w hblock`; `obtain` the two preference facts from
+`IsBlockingPair`; derive `σ.proposed m w` from `menProposedDownward` + termination; then
+`womenBestState` gives `womenPref w (final partner) ≤ womenPref w m`, contradicting the
+strict `WomanPrefers w m (μ.inverse w)`. The hard sub-goal is connecting `μ.inverse w`
+(Definitions-level bijection inverse) to `σ.matching.womenMatch w` (Option-valued GS state)
+— that needs the `GSMatching -> Matching` conversion correctness lemma.
+
+### 2. `gale_shapley_man_optimal` — man-optimality
+
+**NOT proven in the original repo.** `Properties.lean` stops at stability; there is no
+man-optimality theorem in `mmaaz-git/stable-marriage-lean`. So for this sorry there is **no
+reference proof to port** — it has to be done from the mathematical literature
+(Gale-Shapley 1962, Dubins-Freedman / Roth). The strategy below is the standard textbook
+argument, reconstructed; flag it as such to the agents.
+
+**Witness.** Same `gsGaleShapley prof` matching as in (1). `IsManOptimal` = `IsStable ∧
+(∀ μ' stable, ∀ m, menPref m (μ.spouse m) ≤ menPref m (μ'.spouse m))`. The `IsStable`
+conjunct is exactly theorem (1).
+
+**High-level argument (standard "no man is ever rejected by an achievable woman").**
+Define a woman `w` as *achievable* for man `m` if some stable matching pairs them. Claim: in
+GS, no man is ever rejected by an achievable woman. Prove by induction on the proposal
+sequence:
+- Suppose, for contradiction, the first time a man `m` is rejected by an achievable woman
+  `w` (he proposed, she kept/took someone `m'` she prefers). `w` achievable for `m` means
+  some stable `μ'` has `μ'.inverse w = m`.
+- `m'` (the man `w` kept) prefers `w` to whoever he was previously matched to in the GS run;
+  and because this is the *first* rejection-by-achievable-woman, `m'` has not yet been
+  rejected by any woman achievable for him — so in `μ'`, `m'`'s partner `μ'.spouse m'` is
+  someone `m'` likes no more than `w`. Then `(m', w)` blocks `μ'` (m' prefers w to his μ'
+  partner; w prefers m' to m = her μ' partner). Contradicts stability of `μ'`.
+- Therefore no man is rejected by an achievable woman ⇒ each man ends GS with the *best*
+  (lowest `menPref` rank) woman achievable for him ⇒ GS is man-optimal.
+
+**Invariant used (our port):** `menProposedDownward` is the key — it guarantees a man's GS
+partner is his most-preferred among everyone who did NOT reject him, and the argument above
+shows the rejecters are exactly the non-achievable women. There is currently **no Lean
+infrastructure** in our `Lemmas.lean` for the notion "achievable woman" or this induction;
+this sorry is genuinely a multi-day port even with guidance.
+
+### 3. `gale_shapley_woman_pessimal` — woman-pessimality (Knuth 1976 duality)
+
+**NOT proven in the original repo** either. This is the Knuth 1976 lattice-duality result.
+Our theorem statement is already in the convenient pointwise form:
+`IsManOptimal prof μ → IsStable prof μ' → womenPref w (μ'.inverse w) ≤ womenPref w (μ.inverse w)`.
+
+**High-level argument (the clean duality proof, by contradiction).**
+- Assume `w` does strictly better under the man-optimal `μ` than under some stable `μ'`,
+  i.e. `womenPref w (μ.inverse w) < womenPref w (μ'.inverse w)` — `w` strictly prefers her
+  `μ` partner `m := μ.inverse w` to her `μ'` partner.
+- `m` is matched to `w` in `μ`. Consider `m`'s partner in `μ'`, `μ'.spouse m`. By
+  man-optimality of `μ`, `m`'s `μ` partner is his BEST achievable partner, so `m` weakly
+  prefers `μ.spouse m = w` over `μ'.spouse m`. Two sub-cases:
+  - If `m` strictly prefers `w` to `μ'.spouse m`: then `m` prefers `w` to his `μ'` partner,
+    and `w` prefers `m` to her `μ'` partner — `(m, w)` blocks `μ'`. Contradicts stability of
+    `μ'`.
+  - If `m`'s `μ'` partner equals `w` (`μ'.spouse m = w`): then `μ'.inverse w = m = μ.inverse w`,
+    so `w`'s partners coincide and she cannot strictly prefer one — contradicts the
+    assumption.
+- Either way, contradiction. Hence `womenPref w (μ'.inverse w) ≤ womenPref w (μ.inverse w)`.
+
+**Key insight (from our `config.py` DEMO 17):** the `inverse` field swaps the man/woman
+perspective — `μ.inverse w` is the man matched to `w`. The proof never re-runs the
+algorithm; it only uses (a) `IsManOptimal` (the universally-quantified optimality clause)
+and (b) `IsStable prof μ'` (no blocking pair). So unlike (1) and (2), this sorry needs **no
+new GS-state machinery** — it is a pure consequence of the two `Def`s in `Definitions.lean`
+plus careful `Fin n` rank inequality reasoning (trichotomy on the `womenPref`/`menPref`
+Nat values, `lt_irrefl`, transitivity). It is the most tractable of the three for the
+prover and should be attempted first.
+
+## Summary for the Director agent
+
+- `gale_shapley_woman_pessimal` (L119): tractable — pure `Def`-unfolding + blocking-pair
+  contradiction + `Fin` rank trichotomy. **Attack this first.** No reference proof exists;
+  use the duality argument above.
+- `gale_shapley_stable` (L73): the original repo proves it; main missing piece on our side
+  is a `GSMatching -> Matching` totality/bijectivity conversion lemma. All the runSteps
+  invariants it needs are ALREADY PROVEN in our `existing_proofs.lean`.
+- `gale_shapley_man_optimal` (L91): hardest — needs an "achievable woman" notion and an
+  induction on the proposal sequence that does not exist in either codebase. Multi-day port.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/project_hints.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/project_hints.md
@@ -1,0 +1,120 @@
+# Domain tactic patterns — Stable Marriage / Gale-Shapley Lean proofs
+
+Consolidated from issue #1081 Part 1 (5 manually-discovered patterns) and the
+`tactic_cookbook` section of `agent_tests/prover/proof_knowledge.json` (150 patterns,
+seeded from the ~4 manual sessions that proved `womenBestState.step`).
+
+These hints are project-specific. They apply to proofs over `GSState` / `GSMatching` /
+`gsStep` / `gsStepWith` / `gsChooseMax` and the invariant lemmas in `existing_proofs.lean`.
+
+## The 5 core patterns (issue #1081 Part 1)
+
+### 1. `change` to normalize hypotheses
+**When:** a hypothesis contains raw `Classical.choose` / `gsChooseMax` that does not
+syntactically match the local definitions, so `simp` and `split` stay stuck.
+**Do:** `change (normalized_expr) at h` to rewrite the hypothesis into its unfolded form.
+**Example (`womenBestState.step`):**
+`change (gsStepWith prof σ m₀ w₀).matching.womenMatch w = some m at hmatch`
+— after `set m₀`/`set w₀`, `hmatch` still held the raw `gsStep`/`gsChooseMax`; `change`
+normalizes it so the following `simp only [gsStepWith]` + `split` can fire.
+
+### 2. `split at h` for an irreducible `match`
+**When:** `simp only [Def] at h` leaves an irreducible `match` expression in the hypothesis
+and `simp [discriminant_eq]` cannot reduce it.
+**Do:** `split at h` — it creates the `none` / `some` branches directly.
+**Example:** `simp only [gsStepWith] at hmatch; split at hmatch` — `gsStepWith` matches on
+`womenMatch w`; `split` gives the `none` (matchFree) and `some mOld` (swap/reject) cases.
+
+### 3. `rcases` before `subst` (anti-reflexivity)
+**When:** you need both `rcases` and `subst` on a potentially-reflexive equality. An
+`rcases ... with rfl` can unify variables, making a later equality reflexive so `subst`
+fails ("motive is not type correct" / "did not find instance of the pattern").
+**Do:** do the `rcases` with `rfl` patterns first, handle each branch separately.
+**Example:** `rcases hsrc with (hw' | ⟨rfl, rfl⟩)` — the `⟨rfl, rfl⟩` branch unifies
+`m = m₀` and `w = w₀`; the other branch keeps them distinct.
+
+### 4. Explicit `@` for implicit-heavy lemmas
+**When:** a lemma has implicit args (`{n}`, `[NeZero n]`, section variables) that Lean
+cannot infer in the current context.
+**Do:** apply it with `@` and pass the implicits positionally.
+**Example:** `(@proposedSet.mem_iff n _ prof (gsStepWith prof σ m₀ w₀) (m', w)).mpr hprop`
+— `proposedSet.mem_iff` needs `n`, the `NeZero n` instance, `prof`, `σ` before the pair.
+
+### 5. `dsimp` before `rw` on `match` constructs
+**When:** the goal/hypothesis contains a structure update (`GSMatching.matchFree` /
+`swapMatch`) and you want to `rw [Function.update_apply]`, but `rw` fails because the term
+is still wrapped in a `match`/projection.
+**Do:** `dsimp [GSMatching.swapMatch]` (or `matchFree`) first, then `rw [Function.update_apply]`.
+**Example:** `dsimp [GSMatching.swapMatch] at hmatch ⊢; rw [Function.update_apply, Function.update_apply] at hmatch`.
+
+## Additional domain patterns (from proof_knowledge.json tactic_cookbook)
+
+### `Function.update` + `split_ifs`
+Goal/hypothesis from `matchFree`/`swapMatch` contains `Function.update`. Do
+`simp only [GSMatching.matchFree, Function.update_apply]; split_ifs` — `update_apply`
+turns the update into an if-then-else; `split_ifs` produces the branches (4 for a single
+update, 6 for the nested double update in `swapMatch` — name them:
+`split_ifs with h_mOld h_ww h_m h_nw h_nm`). Close each branch with `simp_all`, and the
+default (neither) branch with `exact h m' w'`.
+
+### Consistency chain via the `iff`
+`GSConsistent μ` is `∀ m w, menMatch m = some w ↔ womenMatch w = some m`. Use
+`(h m w).mp` for men→women, `(h m w).mpr` for women→men, `(h m w).symm` for the reversed
+iff. To prove an inequality `womenMatch w' ≠ some m`, assume equality then derive a
+contradiction through the consistency chain (`intro heq; have := (h m w').mpr heq; simp_all`).
+
+### `runSteps` invariant induction (universal skeleton)
+Every `*.runSteps` invariant lemma has the same shape:
+```
+induction k with
+| zero => exact <initial_lemma> prof
+| succ k' ih =>
+  simp only [gsRunSteps]
+  by_cases h : ∃ m, gsIsFree prof (gsRunSteps prof k') m
+  · exact <step_lemma> prof ih h
+  · have hid : gsStep prof (gsRunSteps prof k') = gsRunSteps prof k' := by
+      unfold gsStep; simp [h]
+    rw [hid]; exact ih
+```
+Either a free man exists (apply the `step` lemma) or not (`gsStep` is the identity, proved
+by `unfold gsStep; simp [h]`).
+
+### `Classical.choose` / `choose_spec` for existentials
+`hfree : ∃ m, gsIsFree prof σ m` → `let m := Classical.choose hfree;
+have hm : gsIsFree prof σ m := Classical.choose_spec hfree`. Always introduce the witness
+and its spec together.
+
+### `gsChooseMax` maximality — trichotomy strategy
+To prove `∀ y ∈ candidates, y ≤ choose` for the custom `gsMenPrefLE` preorder:
+`obtain ⟨-, hmax⟩ := Classical.choose_spec (Finset.exists_maximal h)`, then
+`Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m choose)` and `rcases` into 3 cases.
+CRITICAL: `hmax` from `Maximal` is CONDITIONAL — `hmax hw` has type
+`(choose ≤ w → w ≤ choose)`, not `w ≤ choose` directly. The equal-preference case is
+closed by `(prof.menPref_bijective m).injective` turning a `menPref` equality into a
+`Fin` equality.
+
+### Custom `LE` / `IsTrans` instance for `Finset.exists_maximal`
+`Finset.exists_maximal` needs `LE` + `IsTrans`. Build them locally:
+`letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩` then `haveI : IsTrans (Fin n) (· ≤ ·) := ⟨...⟩`
+(transitivity by `cases` on the `Or` of `gsMenPrefLE`, `lt_trans` for the `inr`/`inr` case).
+
+### `injection` for `Option` equality
+After `Function.update` reduction a hypothesis is `some x = some y` (or `none = none`):
+`injection hmatch with hw; subst hw` extracts the underlying equality.
+
+### `by_contra` / `exfalso` for blocking-pair contradictions
+The GS correctness theorems are proved by contradiction: `intro h; by_contra hnot` (or
+`exfalso`), `obtain` the witnesses, then derive `False` by exhibiting a blocking pair or a
+violated invariant. `exfalso` is also useful when the goal is a non-`False` proposition but
+the context already holds a contradiction (`exfalso; exact h hw`).
+
+## Pitfalls to avoid (failed approaches)
+
+- `simp` / `aesop` alone never closes a `gsStepWith` case-analysis goal — the `match` must
+  be `split` first.
+- `omega` only works after every quantity is a pure `Nat`/`Int`; `menPref m w` IS a `Fin n`
+  — convert or use `.val` / `Fin.lt_iff_val_lt_val` before `omega`.
+- Do not `rw` into a `match` construct; `dsimp` the structure update first (pattern 5).
+- Do not `subst` a variable that a prior `rcases ⟨rfl, ...⟩` already unified (pattern 3).
+- Modifying the target theorem or its hypotheses to make a proof go through is forbidden
+  (anti-regression rule) — `mark_sorry_intractable` instead if genuinely stuck.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/session_summary.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/session_summary.md
@@ -1,0 +1,15 @@
+# Prover session summary
+
+Placeholder. The multi-agent prover overwrites this file at the end of each session with a
+short bilan of the previous run (conservation state — survives from one iteration to the
+next; see `README.md` for the cleanup-vs-conservation policy).
+
+Expected contents once populated:
+- Date / iteration id
+- Target sorry (file:line, theorem name, DEMO id)
+- Outcome: solved / structural progress / marked intractable / build failure
+- sorry count before/after
+- Tactics that worked, dead ends hit
+- Recommendation for the next session
+
+No session has been recorded yet.


### PR DESCRIPTION
## Summary

Finalisation de l'algo prouveur (directive user 2026-05-15) en deux volets cohérents, même domaine (prover-only) :

### 1. Reference docs injection — issue #1081 Part 2 (subagent)
État partagé portable committé sous `agent_tests/prover/session_state/` :
- `reference_docs/stable_marriage/mmaaz-git-gs-strategies.md` — stratégies de preuve pour les 3 sorrys GaleShapley intractables, extraites du repo original `mmaaz-git/stable-marriage-lean` (fetch raw.githubusercontent réussi). **Constat important** : le repo original prouve **uniquement la stabilité** (`galeShapley_noBlockingPairs` via les invariants runSteps) ; man-optimality / woman-pessimality y sont **absentes** → stratégies reconstruites depuis la littérature (Gale-Shapley 1962, Knuth 1976) et explicitement flaggées comme telles. Pas de LICENSE dans le repo source → seules les stratégies haut-niveau sont reprises, aucun code verbatim.
- `gs-definitions.lean` / `existing_proofs.lean` — snapshots auto-copiés de nos fichiers portés (Definitions/GSState/Lemmas).
- `project_hints.md` — les 5 patterns tactiques #1081 Part 1 + patterns du cookbook.
- `lessons_learned.json`, `session_summary.md`, `README.md` (politique conservation vs cleanup).
- `instructions.py` : nouvelle fonction `load_reference_docs()`, param opt-in `include_references` sur `augment_instructions()` (défaut False → **backward-compatible**, call sites existants inchangés), ligne d'instruction Director.

### 2. Director frontier-model (commit `1ea58e6f`)
- `config.py` : défaut OpenRouter reasoning durci `gpt-4o-mini` → `anthropic/claude-opus-4.7`. Le DirectorAgent existait déjà (workflow.py L438+) mais tournait sous-modèle.
- `agents.py` : `DIRECTOR_MAX_TOKENS` 512 → 2048 (un modèle frontier a besoin de place pour un bloc APPROACH+TACTICS complet) ; `create_director_agent` et `create_coordinator_agent` enveloppent leurs instructions dans `augment_instructions(..., include_references=True)` → les reference docs **atteignent effectivement** les agents stratégiques.
- `.env` (non versionné) : `OPENROUTER_CHAT_MODEL_ID=anthropic/claude-opus-4.7`.

## Test plan
- [x] `from prover.agents import create_director_agent, create_coordinator_agent` — imports OK
- [x] `PROVIDERS['openrouter']['models']['reasoning']` = `anthropic/claude-opus-4.7`
- [x] `load_reference_docs()` = 6016 chars (capé ~6000), `''` si projet absent
- [x] `augment_instructions(include_references=True)` = 9162 chars ; défaut (False) inchangé → backward-compat
- [x] mmaaz-git fetch réussi (GaleShapley/Lemmas/Properties/README)

## Diff stat
10 fichiers, +1473/-21 — dont ~1200 lignes = snapshots `.lean` + docs de référence (données, pas du code exécutable). Code réel modifié : `instructions.py`, `config.py`, `agents.py`.

Closes #1081 (Part 1 patterns consolidés dans project_hints.md + Part 2 injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)