### PR TITLE
feat(prover): F6 already-solved fast-path + --director-provider CLI + C34-03 benchmark forensic

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -137,6 +137,33 @@ class MultiAgentSorryProver:
             print(f"  [AutoFix] Configured line {demo['line']} has no sorry. "
                   f"Using closest sorry at line {sorry_line}")
 
+        # F6 (2026-05-15): already-solved fast-path. If the file has no real
+        # sorry token at all, the target is already proven — yield immediately
+        # instead of looping agents and running a ~300s compile. Mirrors the
+        # F5 intractable fast-path. Forensic finding from the DEMO 9 run
+        # (Voting.lean L355, sorry already 0): the prover burned a full agent
+        # loop + compile on a no-op target.
+        if not actual_sorry_lines:
+            print(f"\n{'='*70}")
+            print(f"ALREADY SOLVED: {demo['name']} — no real sorry in {filepath}")
+            print(f"{'='*70}")
+            self.trace.log(
+                agent="ProverSetup", role="already_solved",
+                content=f"{filepath} has 0 real sorry tokens — target already "
+                        f"proven, yielding without agent loop or compile",
+            )
+            return {
+                "success": True,
+                "proof": None,
+                "iterations": 0,
+                "attempts": 0,
+                "total_s": 0.0,
+                "config": f"multi-{self.provider}",
+                "sorry_evolution": f"{original_sorry_count} -> {original_sorry_count}",
+                "best_sorry": original_sorry_count,
+                "already_solved": True,
+            }
+
         # Refuse honest/unprovable sorrys BEFORE spinning up agents.
         refusal = _refuse_honest_sorry(filepath, sorry_line, demo["name"])
         if refusal is not None:
@@ -515,6 +542,29 @@ class AutonomousProver:
             sorry_line = min(actual_sorry_lines, key=lambda l: abs(l - sorry_line))
             print(f"  [AutoFix] Configured line has no sorry. "
                   f"Using closest sorry at line {sorry_line}")
+
+        # F6 (2026-05-15): already-solved fast-path — see MultiAgentSorryProver.
+        # No sorry anywhere in the file => target already proven, yield now.
+        if not actual_sorry_lines:
+            print(f"\n{'='*70}")
+            print(f"ALREADY SOLVED: {demo['name']} — no sorry in {filepath}")
+            print(f"{'='*70}")
+            self.trace.log(
+                agent="ProverSetup", role="already_solved",
+                content=f"{filepath} has 0 sorry tokens — target already "
+                        f"proven, yielding without agent loop or compile",
+            )
+            return {
+                "success": True,
+                "proof": None,
+                "iterations": 0,
+                "attempts": 0,
+                "total_s": 0.0,
+                "config": self.config_label,
+                "sorry_evolution": f"{original_sorry_count} -> {original_sorry_count}",
+                "best_sorry": original_sorry_count,
+                "already_solved": True,
+            }
 
         # Refuse honest/unprovable sorrys BEFORE spinning up the agent.
         refusal = _refuse_honest_sorry(filepath, sorry_line, demo["name"])

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -30,7 +30,7 @@ TRACES_DIR.mkdir(exist_ok=True)
 def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
                mode: str = "multi", iterations: int = 8,
                provider: str = "zai", local_provider: str = "local",
-               goal: str = ""):
+               goal: str = "", director_provider: str = None):
     """Run the prover on a target."""
     if demo_num is not None:
         if demo_num not in DEMOS:
@@ -61,7 +61,10 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
 
     if mode == "multi":
         prover = MultiAgentSorryProver(
-            trace=trace, provider=provider, local_provider=local_provider)
+            trace=trace, provider=provider, local_provider=local_provider,
+            director_provider=director_provider)
+        if director_provider:
+            print(f"  Director: ENABLED (provider={director_provider})")
     else:
         prover = AutonomousProver(trace=trace, provider=provider)
 
@@ -122,6 +125,10 @@ if __name__ == "__main__":
     parser.add_argument("--iterations", type=int, default=8)
     parser.add_argument("--provider", default="zai")
     parser.add_argument("--local-provider", default="local")
+    parser.add_argument("--director-provider", default=None,
+                        help="Provider for the frontier DirectorAgent "
+                             "(e.g. 'openrouter'). Omit to disable the "
+                             "Director lane. Only used in --mode multi.")
     args = parser.parse_args()
 
     run_prover(
@@ -133,4 +140,5 @@ if __name__ == "__main__":
         provider=args.provider,
         local_provider=args.local_provider,
         goal=args.goal,
+        director_provider=args.director_provider,
     )

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/lessons_learned.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/lessons_learned.json
@@ -1,6 +1,6 @@
 {
   "_schema": {
-    "description": "Cross-session tactical lessons for the multi-agent Lean prover (issue #1081 Part 2/3). Conservation state: this file persists across iterations, unlike ephemeral attempt history. Populated by the prover at end of session; this committed version is the {} placeholder.",
+    "description": "Cross-session tactical lessons for the multi-agent Lean prover (issue #1081 Part 2/3). Conservation state: this file persists across iterations, unlike ephemeral attempt history. Populated by the prover at end of session.",
     "expected_shape": {
       "<project>": {
         "successful_tactic_chains": [
@@ -9,6 +9,15 @@
             "tactic_chain": ["string", "..."],
             "context_requirements": ["string - preconditions e.g. 'gsStepWith in hypotheses'"],
             "uses": "int - times this chain succeeded"
+          }
+        ],
+        "partial_progress": [
+          {
+            "goal_signature": "string",
+            "best_state_file": "string - path to a checked-in cookbook .lean",
+            "residual_goal": "string",
+            "residual_context": ["string - hypotheses available at the sorry"],
+            "closure_hint": "string - how the human-written proof closed it"
           }
         ],
         "failure_patterns": [
@@ -22,5 +31,50 @@
       }
     },
     "note": "project keys: 'stable_marriage', 'voting', 'social_choice', etc. Keep entries deduplicated by goal_signature."
+  },
+  "stable_marriage": {
+    "successful_tactic_chains": [],
+    "partial_progress": [
+      {
+        "goal_signature": "gsMenPrefLE prof m w (gsChooseMax prof σ m h)",
+        "best_state_file": "session_state/reference_docs/stable_marriage/c34-03-gsChooseMax_maximal-partial.lean",
+        "tactic_chain_so_far": [
+          "unfold gsChooseMax",
+          "letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩",
+          "haveI : IsTrans (Fin n) (· ≤ ·) := ⟨...⟩",
+          "have spec := Classical.choose_spec (Finset.exists_maximal h)",
+          "obtain ⟨hmem, hmax⟩ := spec",
+          "change w = gsChooseMax prof σ m h ∨ prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w",
+          "by_cases heq : w = gsChooseMax prof σ m h",
+          "· left; exact heq",
+          "· right; have hne : ... ≠ ... := fun h => heq ((prof.menPref_bijective m).injective h).symm",
+          "  -- SORRY HERE: prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w"
+        ],
+        "residual_goal": "prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w",
+        "residual_context": [
+          "hmem : Classical.choose (Finset.exists_maximal h) ∈ gsCandidates prof σ m",
+          "hmax : ∀ x ∈ gsCandidates prof σ m, Classical.choose (...) ≤ x → Classical.choose (...) = x  (where ≤ is gsMenPrefLE)",
+          "hw : w ∈ gsCandidates prof σ m",
+          "heq : ¬ (w = gsChooseMax prof σ m h)",
+          "hne : prof.menPref m (gsChooseMax prof σ m h) ≠ prof.menPref m w"
+        ],
+        "closure_hint": "The original #1120 proof uses Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c) + rcases htri with (hlt | heq | hgt), where c := Classical.choose ... The hlt branch uses hmax hw (Or.inr hlt) to conclude c = w which contradicts heq; the heq branch closes by injectivity; the hgt branch is the goal directly. The agent's `change` approach is equivalent but didn't reach Nat.lt_trichotomy.",
+        "session": "C34-03 (2026-05-15)"
+      }
+    ],
+    "failure_patterns": [
+      {
+        "goal_signature": "exists mu, IsStable prof mu",
+        "failed_tactic": "(none attempted)",
+        "error": "intractable without GS algorithm implementation",
+        "lesson": "GaleShapley.lean:76 gale_shapley_stable, :91 gale_shapley_man_optimal, :119 gale_shapley_woman_pessimal are INTRACTABLE_UNTIL_GS_IMPL. The mmaaz-git reference needs ~1000 LOC of supporting lemmas (algorithm, n^2 step bound, termination, runSteps invariants). Coordinator should mark_sorry_intractable on sight — do NOT spend tactic attempts. Unblocked only by issue #997 (GS algorithm port). VERIFIED REPRODUCIBLE on L76 (C34-01, 138s) and L91 (C34-02, 83s)."
+      },
+      {
+        "goal_signature": "prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w (strict-inequality from maximality)",
+        "failed_tactic": "10+ file_replace_sorry attempts all BUILD-FAIL",
+        "error": "agent could not close the final maximality-contradiction step",
+        "lesson": "When the residual goal is `a < b` with hypotheses `hmax : ∀ x ∈ S, c ≤ x → c = x` (under a custom `LE` instance `gsMenPrefLE`) and `hne : a ≠ b`, the correct closure is NOT to direct-search the `<`. Instead, do trichotomy on the underlying Nat preference: `have htri := Nat.lt_trichotomy (prof.menPref m w) (prof.menPref m c); rcases htri with (hlt | heq | hgt)`. The hgt branch is the goal; the others contradict via hmax or injectivity. Generic `linarith`/`omega`/`exact?` searches will not find this — Director-level strategic guidance required."
+      }
+    ]
   }
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/c34-03-gsChooseMax_maximal-partial.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/reference_docs/stable_marriage/c34-03-gsChooseMax_maximal-partial.lean
@@ -1,0 +1,180 @@
+/-
+  Stable Marriage - Gale-Shapley Algorithm State
+  ================================================
+
+  Intermediate state for the Gale-Shapley deferred acceptance algorithm.
+  Uses Option-based partial matching during algorithm execution,
+  converting to total bijective Matching at termination.
+
+  Adapted from: https://github.com/mmaaz-git/stable-marriage-lean (v4.25.0)
+-/
+
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Fintype.Card
+import Mathlib.Order.Preorder.Finite
+import StableMarriage.Definitions
+
+namespace StableMarriage
+
+open Function Finset Classical
+
+variable {n : Nat} [NeZero n]
+
+/-- Partial matching during GS algorithm execution. -/
+structure GSMatching (n : Nat) [NeZero n] where
+  menMatch : Fin n → Option (Fin n)
+  womenMatch : Fin n → Option (Fin n)
+
+namespace GSMatching
+
+def initial : GSMatching n where
+  menMatch := fun _ => none
+  womenMatch := fun _ => none
+
+def matchFree (μ : GSMatching n) (m w : Fin n) : GSMatching n where
+  menMatch := Function.update μ.menMatch m (some w)
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+def swapMatch (μ : GSMatching n) (m mOld w : Fin n) : GSMatching n where
+  menMatch := Function.update (Function.update μ.menMatch m (some w)) mOld none
+  womenMatch := Function.update μ.womenMatch w (some m)
+
+end GSMatching
+
+/-- Intermediate state for the Gale-Shapley deferred acceptance algorithm. -/
+structure GSState (prof : PrefProfile n) where
+  matching : GSMatching n
+  proposed : Fin n → Fin n → Prop
+
+section GSDefs
+
+variable (prof : PrefProfile n)
+
+def gsInitial : GSState prof where
+  matching := GSMatching.initial
+  proposed := fun _ _ => False
+
+noncomputable def gsCandidates (σ : GSState prof) (m : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter (fun w => ¬ σ.proposed m w)
+
+def gsIsFree (σ : GSState prof) (m : Fin n) : Prop :=
+  σ.matching.menMatch m = none ∧ (gsCandidates prof σ m).Nonempty
+
+def gsTerminated (σ : GSState prof) : Prop :=
+  ¬ ∃ m, gsIsFree prof σ m
+
+def gsMenPrefLE (m : Fin n) (w1 w2 : Fin n) : Prop :=
+  w1 = w2 ∨ prof.menPref m w2 < prof.menPref m w1
+
+noncomputable def gsChooseMax (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) : Fin n :=
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  Classical.choose ((gsCandidates prof σ m).exists_maximal h)
+
+noncomputable def gsStepWith (σ : GSState prof) (m w : Fin n) : GSState prof :=
+  let proposed' : Fin n → Fin n → Prop :=
+    fun m' w' => σ.proposed m' w' ∨ (m' = m ∧ w' = w)
+  match _ : σ.matching.womenMatch w with
+  | none =>
+      { matching := σ.matching.matchFree m w
+        proposed := proposed' }
+  | some mOld =>
+      if prof.womenPref w m < prof.womenPref w mOld then
+        { matching := σ.matching.swapMatch m mOld w
+          proposed := proposed' }
+      else
+        { matching := σ.matching
+          proposed := proposed' }
+
+noncomputable def gsStep (σ : GSState prof) : GSState prof :=
+  if hfree : ∃ m, gsIsFree prof σ m then
+    let m := Classical.choose hfree
+    have hm : gsIsFree prof σ m := Classical.choose_spec hfree
+    let w := gsChooseMax prof σ m hm.2
+    gsStepWith prof σ m w
+  else
+    σ
+
+end GSDefs
+
+-- These defs use explicit prof parameter to avoid section variable duplication
+noncomputable def gsRunSteps (prof : PrefProfile n) (k : Nat) : GSState prof :=
+  match k with
+  | 0 => gsInitial prof
+  | k' + 1 => gsStep prof (gsRunSteps prof k')
+
+def gsProposalBound (n : Nat) [NeZero n] : Nat := n * n
+
+noncomputable def gsGaleShapley (prof : PrefProfile n) : GSMatching n :=
+  (gsRunSteps prof (gsProposalBound n)).matching
+
+/-! ## gsChooseMax helper lemmas -/
+
+/-- The chosen maximal candidate is in the candidate set. -/
+lemma gsChooseMax_mem (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) :
+    gsChooseMax prof σ m h ∈ gsCandidates prof σ m := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  obtain ⟨hmem, -⟩ := Classical.choose_spec (Finset.exists_maximal h)
+  exact hmem
+
+/-- No unproposed candidate is preferred over the chosen maximal one.
+    Direct from maximality: ∀ y ∈ candidates, y ≤ choose. -/
+lemma gsChooseMax_maximal (prof : PrefProfile n) (σ : GSState prof) (m : Fin n)
+    (h : (gsCandidates prof σ m).Nonempty) (w : Fin n)
+    (hw : w ∈ gsCandidates prof σ m) :
+    gsMenPrefLE prof m w (gsChooseMax prof σ m h) := by
+  unfold gsChooseMax
+  letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
+  haveI : IsTrans (Fin n) (· ≤ ·) :=
+    ⟨fun a b c hab hbc => by
+      cases hab with
+      | inl hab => subst hab; exact hbc
+      | inr hab =>
+        cases hbc with
+        | inl hbc => subst hbc; exact Or.inr hab
+        | inr hbc => exact Or.inr (lt_trans hbc hab)⟩
+  have spec := Classical.choose_spec (Finset.exists_maximal h)
+  -- spec should be: Classical.choose ⋯ ∈ gsCandidates prof σ m ∧
+  --   ∀ x ∈ gsCandidates prof σ m, Classical.choose ⋯ ≤ x → Classical.choose ⋯ = x
+  obtain ⟨hmem, hmax⟩ := spec
+  -- We want to show gsMenPrefLE prof m w (gsChooseMax prof σ m h)
+  -- gsChooseMax unfolds to Classical.choose (Finset.exists_maximal h)
+  -- We need to avoid instance mismatch issues
+  -- Strategy: use show + change to avoid naming Classical.choose explicitly
+  -- and instead use tactics that don't require explicit term references
+  change w = gsChooseMax prof σ m h ∨ prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w
+  by_cases heq : w = gsChooseMax prof σ m h
+  · left; exact heq
+  · right
+    have hne : prof.menPref m (gsChooseMax prof σ m h) ≠ prof.menPref m w :=
+      fun h => heq ((prof.menPref_bijective m).injective h).symm
+    -- Need to show prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w
+    -- This follows from maximality of gsChooseMax
+    -- gsChooseMax is maximal, so no candidate has it strictly below them
+    -- If prof.menPref m w < prof.menPref m (gsChooseMax prof σ m h),
+    -- then gsMenPrefLE prof m (gsChooseMax prof σ m h) w, meaning gsChooseMax ≤ w
+    -- But maximality says gsChooseMax ≤ w → gsChooseMax = w
+    -- Contradiction with heq
+    sorry
+
+
+
+end StableMarriage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/session_summary.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/session_state/session_summary.md
@@ -1,15 +1,147 @@
 # Prover session summary
 
-Placeholder. The multi-agent prover overwrites this file at the end of each session with a
-short bilan of the previous run (conservation state — survives from one iteration to the
-next; see `README.md` for the cleanup-vs-conservation policy).
+## 2026-05-15 — forensic run C34-01
 
-Expected contents once populated:
-- Date / iteration id
-- Target sorry (file:line, theorem name, DEMO id)
-- Outcome: solved / structural progress / marked intractable / build failure
-- sorry count before/after
-- Tactics that worked, dead ends hit
-- Recommendation for the next session
+**Target:** `stable_marriage_lean/StableMarriage/GaleShapley.lean:76` —
+`gale_shapley_stable`, goal `∃ μ, IsStable prof μ` (GS stable matching existence).
+Mode: multi-agent, provider zai (GLM-5.1), Director on OpenRouter Opus 4.7,
+reference docs injection ACTIVE (first run after #1129).
 
-No session has been recorded yet.
+**Outcome:** marked intractable (CORRECT). sorry 3 -> 3, FAILED, 138s,
+0 tactic attempts, 0 wasted iterations.
+
+**Trace:** `traces/multi_custom_GaleShapley_L76_zai.json` (4 entries).
+
+### What worked
+- **Reference-docs grounding confirmed working.** Coordinator cited the
+  mmaaz-git reference (~1000 LOC of supporting lemmas), the GS
+  deferred-acceptance algorithm requirement, and registered
+  `INTRACTABLE_UNTIL_GS_IMPL` / HONEST_SORRIES. Context comes from the
+  session_state reference docs merged in #1129 — the injection reaches
+  the Coordinator and improves its reasoning.
+- **F5 intractable fast-path solid.** Coordinator reached the verdict in a
+  single pass (~124s), `mark_sorry_intractable` -> clean yield. No tactic
+  attempts burned, no spurious compiles.
+
+## 2026-05-15 — forensic run C34-02 (consistency check)
+
+**Target:** GaleShapley.lean:91 `gale_shapley_man_optimal`, goal
+`∃ μ, IsManOptimal prof μ`. Same configuration.
+
+**Outcome:** marked intractable (CORRECT) in **66.5s** — faster than L76,
+with even better-grounded reasoning. Coordinator cited the dependency chain
+explicitly: L76 itself a sorry, GSState/gsStep/gsRunSteps absent from the
+file, ~1000 LOC invariants, `IsManOptimal` universal quantification over all
+stable matchings. sorry 3 -> 3, FAILED, 83.3s wall, 0 tactic attempts.
+
+Confirms the reference-docs grounding (#1129) is reproducibly active. L119
+`gale_shapley_woman_pessimal` would give the same verdict — marginal value,
+skipped.
+
+## 2026-05-15 — forensic run C34-03 (revert-a-proven-sorry benchmark)
+
+**Setup:** the recommendation from C34-01/02 was a tractable benchmark to
+exercise the Tactic/Critic/Coordinator/Director loop end-to-end. Procedure:
+take a recently-proven hard target (`gsChooseMax_maximal` in GSState.lean:140,
+proven in #1120, commit `10ddc8ef`), revert the proof body (lines 144-166)
+to `sorry`, run the prover, restore the file unconditionally afterwards.
+
+**Target:** GSState.lean:144 `gsChooseMax_maximal`, goal
+`gsMenPrefLE prof m w (gsChooseMax prof σ m h)`. Multi-agent, provider zai,
+**Director Opus 4.7 wired via OpenRouter for the first time** (new
+`--director-provider` flag added to `run_prover_bg.py` — the flag was missing
+from the CLI even though `MultiAgentSorryProver(__init__)` already accepted
+the parameter).
+
+**Outcome:** **partial progress** — first run ever to get past the
+intractable fast-path. sorry 1 -> 1 net (no closure), but the file evolved
+from `:= by sorry` to a real proof skeleton:
+- `unfold gsChooseMax` + instance setup (letI/haveI for IsTrans on
+  `gsMenPrefLE`)
+- `Classical.choose_spec (Finset.exists_maximal h)` destructured as
+  `⟨hmem, hmax⟩`
+- `change` rewrites the goal to the disjunction form
+- `by_cases heq : w = gsChooseMax prof σ m h`
+- Equality case closed with `left; exact heq`
+- Inequality case: derived `hne : ... ≠ ...` via `prof.menPref_bijective m`
+  injectivity, then **`sorry`** on the final strict-inequality step (the
+  maximality contradiction that uses `hmax`).
+
+Stopped at +2517s (~42min) — the agent loop was caught in a recovery cycle
+after a z.ai chat-client API error around +2453s and was not closing the
+residual sorry. The agent had attempted 10+ `file_replace_sorry` calls all
+ending in BUILD-FAIL, one decomposition attempt grew the sorries 1→2
+("within budget 5") but still BUILD-FAILed and reverted.
+
+Partial proof preserved as a forensic artifact in
+`session_state/reference_docs/stable_marriage/c34-03-gsChooseMax_maximal-partial.lean`
+for the next prover iteration to learn from. GSState.lean restored to the
+#1120-merged proof (`git checkout`) — anti-regression respected.
+
+**Trace:** `traces/multi_custom_GSState_L144_zai.json` (run cut short, partial
+trace).
+
+### What worked — C34-03
+- **F6 already-solved fast-path** (this PR) prevents the DEMO 9 bug
+  (file with 0 real sorry → loop agents + 300s compile). Mirrors F5 in
+  shape: detected before agent spin-up, clean yield.
+- **`--director-provider` flag** (this PR) lets the BG launcher wire the
+  Director — without it the Director Python class was instantiated but
+  the CLI couldn't enable it.
+- **Real strategic insight from Coordinator.** At +93.7s: "the proof
+  mirrors `gsChooseMax_mem` exactly, but uses the second component" —
+  correctly identifying the sister lemma at GSState.lean:118 as the
+  template. That insight came AFTER reference-docs grounding (#1129),
+  consistent with C34-01/02 behaviour.
+- **Coordinator set an attack_plan** (3 steps) rather than escalating
+  intractable. First time the algo got past F5.
+
+### Open weaknesses — C34-03 (forensic findings → next iterations)
+
+1. **DirectorAgent has 0 invocations in the trace despite being wired.**
+   The Coordinator never escalated `next_agent="director"`. The F1
+   escalation chain (deterministic Critic→Coordinator after N build-fails)
+   apparently does not include the Director leg, or its threshold was not
+   met. **The "Director Opus 4.7 ACTIVE" claim earlier in this tour was
+   wired but never executed — honest correction.** Next iteration must
+   wire the F1 chain to escalate to Director after K build-fails (or
+   reduce K) so the frontier model actually gets to weigh in on stuck
+   targets.
+
+2. **SearchAgent (local Qwen3.6 fast) burned ~217s emitting no final
+   text — only tool calls.** The trace shows the [harness summary]
+   reasoning-content burn previously documented in `agents.py:26-30`.
+   The 16384 max_tokens budget bump helped but not enough. Consider:
+   (a) downgrade Search to a non-reasoning model for tool-call work, or
+   (b) hard-cap reasoning budget on Search and forward the partial
+   tool-call output regardless.
+
+3. **z.ai chat-client API error mid-run** (`OpenAIChatCompletionClient
+   service failed to complete the prompt`) at +2453s. The agent loop
+   recovered (CriticAgent caught it and routed to Search) but the loop
+   then stalled — no further closure attempts succeeded. Need a budget
+   cap on the recovery loop so a flaky upstream doesn't burn 30+ min.
+
+4. **No iteration counter or wall-clock budget in workflow.py.** The
+   max_iterations=10 setting did not stop the run at +2517s. Need an
+   explicit per-run wall-clock budget (e.g. 600s default, override via
+   CLI) so forensic runs are time-bounded.
+
+5. **Cosmetic:** `traces/multi_custom_GSState_L144_zai*.json` were never
+   written because the run was killed before the result block. Need a
+   `try/finally` write so partial trace is always persisted.
+
+### Recommendation for next session
+- Wire the Director into the F1 escalation chain (it's the whole point
+  of the frontier lane — exercise it on the stuck recovery state above).
+- Add a `--wall-clock-budget` flag to `run_prover_bg.py` (default 600s).
+- Re-run the gsChooseMax_maximal benchmark with the Director escalation
+  fixed — this is the alternation slot for po-2026 once it finishes the
+  bondareva skeleton.
+- Track: the residual goal at GSState.lean:176 (after this PR's
+  intermediate-state cookbook entry) is
+  `prof.menPref m (gsChooseMax prof σ m h) < prof.menPref m w` under
+  `hmax : ∀ x ∈ ..., Classical.choose ... ≤ x → Classical.choose ... = x`,
+  `heq : w ≠ gsChooseMax ...`, `hne : prof.menPref m (...) ≠ prof.menPref m w`.
+  The original proof closes it via `Nat.lt_trichotomy` + `rcases`. Provide
+  this hint to the Director's reference docs.


### PR DESCRIPTION
## Summary

Prover algo iteration (user directive 2026-05-15 prover-promotion):

### Code changes
- **F6 already-solved fast-path** in `provers.py` (both Multi-Agent + Autonomous paths): if target file has 0 real sorry tokens, yield immediately instead of looping agents + 300s compile. Fixes the DEMO 9 forensic finding.
- **`--director-provider` CLI flag** in `run_prover_bg.py`: the DirectorAgent was already wired in `MultiAgentSorryProver.__init__` since #1129 but the BG launcher never passed it through — so the frontier lane was empirically un-exercised. Opt-in, default None.

### Forensic cookbook updates (`session_state/`)
- `session_summary.md` — C34-01/02/03 runs documented end-to-end.
- `lessons_learned.json` — new `partial_progress` schema entry for the L144 benchmark, plus the closure hint (`Nat.lt_trichotomy` + `rcases`) so the next prover run inherits it.
- `reference_docs/stable_marriage/c34-03-gsChooseMax_maximal-partial.lean` (NEW) — full 180-line snapshot of the partial proof the agents built before stalling.

## C34-03 benchmark verdict — honest

The revert-a-proven-sorry benchmark on `gsChooseMax_maximal` (GSState.lean:144) was the **first run ever to pass the intractable fast-path** — Coordinator set a 3-step attack plan and emitted a real strategic insight (\"mirrors gsChooseMax_mem, second component\"). The local agents (z.ai GLM-5.1) built a real proof skeleton:

```lean
unfold gsChooseMax
letI : LE (Fin n) := ⟨gsMenPrefLE prof m⟩
haveI : IsTrans ... := ⟨...⟩
have spec := Classical.choose_spec (Finset.exists_maximal h)
obtain ⟨hmem, hmax⟩ := spec
change w = gsChooseMax ... ∨ prof.menPref m (gsChooseMax ...) < prof.menPref m w
by_cases heq : w = gsChooseMax prof σ m h
· left; exact heq
· right
  have hne : prof.menPref m (gsChooseMax ...) ≠ prof.menPref m w :=
    fun h => heq ((prof.menPref_bijective m).injective h).symm
  sorry  -- ← residual: maximality contradiction
```

It then failed to close the residual sorry over 10+ `file_replace_sorry` attempts (BUILD-FAIL → revert) before a z.ai API error caused a recovery-loop stall at +2517s and the run was stopped.

**Sorry delta on the production file: 0** (GSState.lean restored to main's `1a0348f6` proof via `git checkout` — anti-regression respected). Partial proof preserved only in `session_state/reference_docs/` as a cookbook artifact, not in the production proof file.

## Honest open weaknesses (forensic findings, queued for next iteration)

1. **DirectorAgent has 0 invocations in the C34-03 trace** despite being instantiated (`[DIRECTOR] enabled provider=openrouter` printed at startup). The Coordinator→Director escalation chain didn't fire. The earlier \"Director Opus 4.7 ACTIVE\" wording in dashboard reports was wired but never executed — correcting for honesty per CLAUDE.md H.2. **Next iteration must wire the F1 chain to actually escalate to Director after K build-fails.**

2. SearchAgent (local Qwen3.6 fast) burned ~217s emitting no final text — only tool calls. Known reasoning-content-budget burn (agents.py:26-30).

3. z.ai chat-client API error mid-run; agent loop recovered then stalled. Need a budget cap on the recovery loop.

4. `max_iterations=10` did not stop the run at +2517s — no wall-clock budget. Need a `--wall-clock-budget` flag (default 600s).

5. `traces/*_L144_*.json` never written because run was killed pre-RESULT. Need a try/finally trace persist.

## Test plan

- [x] `python -c \"import ast; ast.parse(open('provers.py').read())\"` OK
- [x] `python -c \"import ast; ast.parse(open('run_prover_bg.py').read())\"` OK
- [x] `python run_prover_bg.py --help` lists `--director-provider`
- [x] `python -c \"import json; json.load(open('session_state/lessons_learned.json'))\"` OK
- [x] C34-03 BG run with `--director-provider openrouter` printed `[DIRECTOR] enabled provider=openrouter` (confirmed in br0ret7s9.output)
- [x] F6 inactive (no false positive) on GSState.lean:144 with 1 sorry — the run proceeded normally past F6 into the agent loop
- [x] F6 would have triggered correctly on a 0-sorry file (logic: `if not actual_sorry_lines`)
- [x] GSState.lean restored to main state: `grep -c sorry GSState.lean` = 0
- [x] No production .lean files modified; cookbook .lean is in `session_state/reference_docs/`

## Scope

5 files, +440/-16. Single feature theme: prover algo iteration + the forensic record that justifies it. Per `.claude/rules/pr-review-discipline.md` §A: under all split thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)