### PR TITLE
feat(ml): add generic sweep checkpoint-resume utility (#1053)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_checkpoint.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_checkpoint.py
@@ -1,0 +1,217 @@
+"""
+Generic sweep checkpoint-resume utility for ML training loops.
+
+Tracks completed (seed, symbol, param_combo) combinations in a JSON state file.
+On restart, automatically skips already-completed combos.
+
+Usage in training scripts:
+    from sweep_checkpoint import SweepCheckpoint
+
+    sweep = SweepCheckpoint("checkpoints/lstm_sweep", seeds=[0,1,7,42], symbols=["SPY","ETH"])
+
+    for combo in sweep.remaining():
+        result = train_single(**combo)
+        sweep.mark_done(combo, result["metrics"])
+
+    sweep.finalize()
+
+Cross-platform: works on Linux and Windows. No GPU dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Any, Generator
+
+
+class SweepCheckpoint:
+    """Portable checkpoint-resume for parameter sweep loops.
+
+    State is stored in ``<output_dir>/sweep_state.json`` with:
+    - ``completed``: list of combo dicts with their results
+    - ``pending``: list of combo dicts not yet run
+    - ``meta``: sweep metadata (start time, platform, etc.)
+
+    Parameters
+    ----------
+    output_dir : str or Path
+        Directory for the state file. Created if needed.
+    seeds : list[int] or None
+        Seeds to sweep. Combined with symbols/params.
+    symbols : list[str] or None
+        Symbols to sweep.
+    extra_param_grid : dict or None
+        Additional parameter grid. Keys are param names, values are lists.
+        Example: ``{"hidden_size": [64, 128], "num_layers": [1, 2]}``
+    resume : bool
+        If True, load existing state and skip completed combos.
+        If False, start fresh (overwrite existing state).
+    """
+
+    def __init__(
+        self,
+        output_dir: str | Path,
+        seeds: list[int] | None = None,
+        symbols: list[str] | None = None,
+        extra_param_grid: dict[str, list] | None = None,
+        resume: bool = True,
+    ) -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.state_path = self.output_dir / "sweep_state.json"
+
+        self.seeds = seeds or [0]
+        self.symbols = symbols or ["default"]
+        self.extra_param_grid = extra_param_grid or {}
+
+        self._completed: list[dict] = []
+        self._pending: list[dict] = []
+        self._start_time = time.time()
+        self._interrupted = False
+
+        if resume and self.state_path.exists():
+            self._load_state()
+        else:
+            self._build_combos()
+
+        # Register graceful shutdown on SIGINT/SIGTERM
+        if platform.system() != "Windows":
+            signal.signal(signal.SIGTERM, self._handle_signal)
+        signal.signal(signal.SIGINT, self._handle_signal)
+
+    def _build_combos(self) -> None:
+        """Generate all parameter combinations."""
+        combos = []
+        for seed in self.seeds:
+            for symbol in self.symbols:
+                base = {"seed": seed, "symbol": symbol}
+                if not self.extra_param_grid:
+                    combos.append(base)
+                else:
+                    keys = list(self.extra_param_grid.keys())
+                    values = [self.extra_param_grid[k] for k in keys]
+                    from itertools import product
+                    for vals in product(*values):
+                        combo = {**base}
+                        for k, v in zip(keys, vals):
+                            combo[k] = v
+                        combos.append(combo)
+
+        self._pending = combos
+        self._completed = []
+        self._save_state()
+
+    def _combo_key(self, combo: dict) -> str:
+        """Stable string key for a combo dict."""
+        return json.dumps(combo, sort_keys=True)
+
+    def _load_state(self) -> None:
+        """Load existing state from disk."""
+        with open(self.state_path, "r", encoding="utf-8") as f:
+            state = json.load(f)
+        self._completed = state.get("completed", [])
+        self._pending = state.get("pending", [])
+
+        done_keys = {self._combo_key(c) for c in self._completed}
+        self._pending = [c for c in self._pending if self._combo_key(c) not in done_keys]
+
+        print(f"SweepCheckpoint: resumed {len(self._completed)} done, "
+              f"{len(self._pending)} remaining")
+
+    def _save_state(self) -> None:
+        """Persist current state to disk."""
+        state = {
+            "meta": {
+                "platform": platform.system(),
+                "python": platform.python_version(),
+                "updated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "elapsed_s": round(time.time() - self._start_time, 1),
+            },
+            "completed": self._completed,
+            "pending": self._pending,
+        }
+        tmp_path = self.state_path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2, default=str)
+        tmp_path.replace(self.state_path)
+
+    def _handle_signal(self, signum: int, frame: Any) -> None:
+        """Save state on interrupt, then exit."""
+        self._interrupted = True
+        print(f"\nSweepCheckpoint: signal {signum} received, saving state...")
+        self._save_state()
+        print(f"  {len(self._completed)} completed, {len(self._pending)} remaining")
+        sys.exit(130)
+
+    def remaining(self) -> Generator[dict, None, None]:
+        """Yield pending combos.
+
+        Yields combo dicts. Call ``mark_done()`` after each successful run.
+        If the sweep was previously interrupted, skips completed combos.
+        """
+        while self._pending:
+            combo = self._pending.pop(0)
+            self._save_state()
+            yield combo
+
+    def mark_done(self, combo: dict, metrics: dict | None = None) -> None:
+        """Mark a combo as completed with optional metrics.
+
+        Parameters
+        ----------
+        combo : dict
+            The parameter combination that was run.
+        metrics : dict or None
+            Result metrics to store alongside the combo.
+        """
+        entry = {**combo}
+        if metrics:
+            entry["metrics"] = metrics
+        entry["completed_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        self._completed.append(entry)
+        self._save_state()
+
+        done = len(self._completed)
+        total = done + len(self._pending)
+        pct = done / total * 100 if total else 100
+        print(f"  Sweep progress: {done}/{total} ({pct:.0f}%)")
+
+    def finalize(self) -> dict:
+        """Write final summary and return aggregated results.
+
+        Returns dict with completed count, total, elapsed time, and results.
+        """
+        elapsed = time.time() - self._start_time
+        total = len(self._completed) + len(self._pending)
+        summary = {
+            "total_combos": total,
+            "completed": len(self._completed),
+            "remaining": len(self._pending),
+            "elapsed_s": round(elapsed, 1),
+            "completed_combos": self._completed,
+        }
+
+        summary_path = self.output_dir / "sweep_summary.json"
+        with open(summary_path, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2, default=str)
+
+        print(f"\nSweep complete: {len(self._completed)}/{total} combos "
+              f"in {elapsed:.0f}s")
+        return summary
+
+    @property
+    def progress(self) -> tuple[int, int]:
+        """Return (completed, total) counts."""
+        total = len(self._completed) + len(self._pending)
+        return len(self._completed), total
+
+    @property
+    def results(self) -> list[dict]:
+        """Return all completed combo results."""
+        return list(self._completed)

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_sweep_checkpoint.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_sweep_checkpoint.py
@@ -1,0 +1,130 @@
+"""Tests for sweep_checkpoint.py — generic sweep checkpoint-resume utility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sweep_checkpoint import SweepCheckpoint
+
+
+@pytest.fixture
+def sweep_dir(tmp_path):
+    return tmp_path / "sweep_test"
+
+
+class TestSweepCheckpointInit:
+    def test_creates_output_dir(self, sweep_dir):
+        SweepCheckpoint(sweep_dir, resume=False)
+        assert sweep_dir.exists()
+
+    def test_generates_seed_symbol_combos(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY", "ETH"], resume=False)
+        done, total = sc.progress
+        assert total == 4  # 2 seeds x 2 symbols
+        assert done == 0
+
+    def test_generates_extra_param_grid(self, sweep_dir):
+        sc = SweepCheckpoint(
+            sweep_dir, seeds=[42], symbols=["SPY"],
+            extra_param_grid={"hidden_size": [64, 128], "layers": [1, 2]},
+            resume=False,
+        )
+        done, total = sc.progress
+        assert total == 4  # 1 seed x 1 symbol x 2 hidden x 2 layers
+
+    def test_generates_only_seeds_when_no_symbols(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 7, 42], resume=False)
+        done, total = sc.progress
+        assert total == 3
+
+
+class TestSweepCheckpointIteration:
+    def test_yields_all_combos(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        combos = list(sc.remaining())
+        assert len(combos) == 2
+        assert all("seed" in c and "symbol" in c for c in combos)
+
+    def test_mark_done_reduces_pending(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        for combo in sc.remaining():
+            sc.mark_done(combo, {"mse": 0.01})
+        done, total = sc.progress
+        assert done == 2
+        assert total == 2
+
+    def test_state_file_updated_after_mark_done(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0], symbols=["SPY"], resume=False)
+        for combo in sc.remaining():
+            sc.mark_done(combo, {"sharpe": 1.5})
+            break
+        state = json.loads((sweep_dir / "sweep_state.json").read_text(encoding="utf-8"))
+        assert len(state["completed"]) == 1
+        assert state["completed"][0]["metrics"]["sharpe"] == 1.5
+
+
+class TestSweepCheckpointResume:
+    def test_resume_skips_completed(self, sweep_dir):
+        sc1 = SweepCheckpoint(sweep_dir, seeds=[0, 1, 42], symbols=["SPY"], resume=False)
+        count = 0
+        for combo in sc1.remaining():
+            sc1.mark_done(combo, {"dir_acc": 0.55})
+            count += 1
+            if count >= 2:
+                break
+
+        done1, _ = sc1.progress
+        assert done1 == 2
+
+        sc2 = SweepCheckpoint(sweep_dir, seeds=[0, 1, 42], symbols=["SPY"], resume=True)
+        done2, total = sc2.progress
+        assert done2 == 2
+        assert total == 3
+
+        remaining = list(sc2.remaining())
+        assert len(remaining) == 1
+
+    def test_fresh_start_ignores_existing(self, sweep_dir):
+        sc1 = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        for combo in sc1.remaining():
+            sc1.mark_done(combo, {"mse": 0.01})
+
+        sc2 = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        done, total = sc2.progress
+        assert done == 0
+        assert total == 2
+
+
+class TestSweepCheckpointFinalize:
+    def test_finalize_creates_summary(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        for combo in sc.remaining():
+            sc.mark_done(combo, {"mse": 0.01})
+        summary = sc.finalize()
+
+        assert summary["completed"] == 2
+        assert summary["total_combos"] == 2
+        assert summary["remaining"] == 0
+        assert "elapsed_s" in summary
+        assert (sweep_dir / "sweep_summary.json").exists()
+
+    def test_partial_finalize(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1, 42], symbols=["SPY"], resume=False)
+        for combo in sc.remaining():
+            sc.mark_done(combo, {"mse": 0.01})
+            break
+        summary = sc.finalize()
+        assert summary["completed"] == 1
+        assert summary["remaining"] == 2
+
+
+class TestSweepCheckpointResults:
+    def test_results_returns_completed(self, sweep_dir):
+        sc = SweepCheckpoint(sweep_dir, seeds=[0, 1], symbols=["SPY"], resume=False)
+        for combo in sc.remaining():
+            sc.mark_done(combo, {"dir_acc": 0.6})
+        assert len(sc.results) == 2
+        assert sc.results[0]["metrics"]["dir_acc"] == 0.6


### PR DESCRIPTION
## Summary
Clean cherry-pick of commit 8d58d26f from PR #1148 (DIRTY mega-composite from stale branch base).

Adds `sweep_checkpoint.py` — generic parameter sweep checkpoint-resume utility for ML training loops.
- Tracks completed (seed, symbol, param_combo) in JSON state file
- Resume: auto-skips completed combos on restart
- Signal-safe (SIGINT/SIGTERM), cross-platform (Linux/Windows)
- 12/12 unit tests passing

## Files (2)
- `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_checkpoint.py` (+217)
- `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests/test_sweep_checkpoint.py` (+130)

## Background
PR #1148 was opened with same content but the branch was based on a stale revision, accumulating 100+ unrelated changed files (25520+/32224-). Cherry-pick of clean commit 8d58d26f via fresh branch from main. PR #1148 will be closed as superseded.

Closes #1053
Supersedes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>