### PR TITLE
feat(lean): prove bondareva 4/5 sub-goals (sorry 5→1, 80% reduction)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -234,12 +234,12 @@ theorem bondareva_shapley_backward :
     -- PROVER TARGET: Show intersection of half-spaces is convex
     -- Each constraint S is a half-space { x | ∑_{i∈S} xᵢ ≥ v(S) } which is convex.
     -- Intersection of convex sets is convex.
-    sorry
+    unfold P; rw [← Set.iInter_setOf]; exact _root_.convex_iInter fun S => _root_.convex_halfspace_le (G.v S) (fun x => ∑ i ∈ S, x i)
   -- Step 3: Show P is closed (intersection of closed half-spaces)
   have hP_closed : IsClosed P := by
     -- PROVER TARGET: Intersection of closed sets is closed
     -- Each half-space { x | ∑_{i∈S} xᵢ ≥ v(S) } is closed (continuous preimage of Ici).
-    sorry
+    unfold P; rw [← Set.iInter_setOf]; exact isClosed_iInter (fun S => IsClosed.preimage (continuous_finsetSum S fun i _ ↦ continuous_apply i) isClosed_Ici)
   -- Step 4: Show P is nonempty (take x = λ i. M where M = max_S v(S), then ∑_{i∈S} M ≥ v(S))
   have hP_nonempty : P.Nonempty := by
     -- PROVER TARGET: Construct a large enough constant allocation


### PR DESCRIPTION
## Summary
- Prove 4 of 5 sub-goals in `bondareva_shapley_backward` (Basic.lean)
- **hP_conv** (`Convex ℝ P`): convex_iInter + Convex.preimage (1-liner)
- **hP_closed** (`IsClosed P`): isClosed_iInter + IsClosed.preimage (1-liner)
- **hP_nonempty** (`P.Nonempty`): constructive `x = fun _ => |M|`, calc + gcongr (14 lines)
- **hK_empty** (`K = ∅`): contradiction via grand coalition constraint + linarith (6 lines)
- Sorry count: **5 → 1** (80% reduction)

## Proof 1: sorry count before/after
```
Before: grep -c sorry Basic.lean → 5
After:  grep -c sorry Basic.lean → 1
```

## Proof 2: Lake build SUCCESS
```
Build completed successfully (3324 jobs).
```

## Proof 3: Proof integrity
All 4 proofs use standard Mathlib lemmas. No `axiom` or `sorry` in the new proof terms.

## Remaining target (1 sorry)
- L308: `hCore` (`G.Core.Nonempty`) — extraction argument requiring Core membership proof
- Autonomous prover attempted 10 iterations (~5h), many 1-error near-misses, but could not close

## Prover stats
| Target | Mode | Time | Result |
|--------|------|------|--------|
| hP_conv | multi | ~2h (silent) | SUCCESS |
| hP_closed | multi | ~2h (silent) | SUCCESS |
| hP_nonempty | autonomous | 4158s | SUCCESS |
| hK_empty | autonomous | 2287s | SUCCESS |
| hCore | autonomous | ~5h+ | FAILED (10 iters) |

## Test plan
- [x] `lake build CooperativeGames.Basic` SUCCESS
- [x] `grep -c sorry` 5→1 confirmed
- [x] No axiom leakage in new proofs
- [ ] hCore will require manual proof or stronger LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)