### PR TITLE
feat(lean): prove bondareva hP_nonempty + hK_empty (sorry 3→1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -234,7 +234,17 @@ theorem bondareva_shapley_backward :
     -- PROVER TARGET: Show intersection of half-spaces is convex
     -- Each constraint S is a half-space { x | ∑_{i∈S} xᵢ ≥ v(S) } which is convex.
     -- Intersection of convex sets is convex.
-    unfold P; rw [← Set.iInter_setOf]; exact _root_.convex_iInter fun S => _root_.convex_halfspace_le (G.v S) (fun x => ∑ i ∈ S, x i)
+    intro x hx y hy a b ha hb hab S
+    show ∑ i ∈ S, (a • x + b • y) i ≥ G.v S
+    have h : ∀ i ∈ S, (a • x + b • y) i = a * x i + b * y i := by
+      intro i hi; simp [Pi.smul_apply, Pi.add_apply, smul_eq_mul]
+    calc ∑ i ∈ S, (a • x + b • y) i
+        = ∑ i ∈ S, (a * x i + b * y i) := Finset.sum_congr rfl (fun i hi => h i hi)
+      _ = a * ∑ i ∈ S, x i + b * ∑ i ∈ S, y i := by
+            simp [Finset.sum_add_distrib, Finset.mul_sum, Finset.sum_mul]
+      _ ≥ a * G.v S + b * G.v S := add_le_add (mul_le_mul_of_nonneg_left (hx S) ha) (mul_le_mul_of_nonneg_left (hy S) hb)
+      _ = (a + b) * G.v S := by ring
+      _ = G.v S := by rw [hab]; ring
   -- Step 3: Show P is closed (intersection of closed half-spaces)
   have hP_closed : IsClosed P := by
     -- PROVER TARGET: Intersection of closed sets is closed
@@ -242,10 +252,20 @@ theorem bondareva_shapley_backward :
     unfold P; rw [← Set.iInter_setOf]; exact isClosed_iInter (fun S => IsClosed.preimage (continuous_finsetSum S fun i _ ↦ continuous_apply i) isClosed_Ici)
   -- Step 4: Show P is nonempty (take x = λ i. M where M = max_S v(S), then ∑_{i∈S} M ≥ v(S))
   have hP_nonempty : P.Nonempty := by
-    -- PROVER TARGET: Construct a large enough constant allocation
-    -- Let M = max_S v(S) (exists since Finset N is finite).
-    -- Then x = fun _ => M satisfies ∑_{i∈S} M = S.card * M ≥ M ≥ v(S).
-    sorry
+    let M := Finset.sup' Finset.univ Finset.univ_nonempty G.v
+    use fun _ => |M|
+    intro S
+    by_cases hS : S = ∅
+    · rw [hS]; simp [G.empty_zero]
+    · have hM : G.v S ≤ M := Finset.le_sup' G.v (Finset.mem_univ S)
+      have hScard : (0 : ℕ) < S.card := Finset.card_pos.mpr (Finset.nonempty_of_ne_empty hS)
+      simp only [Finset.sum_const, nsmul_eq_mul]
+      have habsM : M ≤ |M| := le_abs_self M
+      have h1 : (1 : ℝ) ≤ S.card := Nat.one_le_cast.mpr hScard
+      calc G.v S ≤ M := hM
+        _ ≤ |M| := habsM
+        _ = 1 * |M| := (one_mul _).symm
+        _ ≤ (S.card : ℝ) * |M| := by gcongr
   -- Step 5: Show P is bounded below (trivially, 0 as lower bound isn't enough,
   -- but P is bounded since ∑ᵢ xᵢ ≤ v(N) + C for some C, by balanced condition).
   -- In finite dimensions, closed + bounded below + bounded above = compact.

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/CooperativeGames/Basic.lean
@@ -288,7 +288,13 @@ theorem bondareva_shapley_backward :
     -- By contradiction: assume x ∈ P with ∑ᵢ xᵢ < v(N).
     -- The balanced weights w(S) = ∑ᵢ xᵢ - ∑_{i∉S} xᵢ... actually this is the hard part.
     -- Use hyperplane_separation on the cone of balanced weight violations.
-    sorry
+    unfold K
+    rw [Set.eq_empty_iff_forall_notMem]
+    intro x
+    simp only [Set.mem_sep, Set.mem_setOf, not_and]
+    intro hx hlt
+    have := hx Finset.univ
+    linarith
   -- Step 8: Since K = ∅, there exists x ∈ P with ∑ᵢ xᵢ = v(N)
   -- (P is nonempty + closed + no element has sum < v(N) ⟹ some element has sum = v(N))
   have hCore : G.Core.Nonempty := by


### PR DESCRIPTION
## Summary
- Prove 2 additional bondareva_shapley_backward sub-goals (4/5 total)
- **hP_nonempty** (P.Nonempty): constructive proof — allocate x = fun _ => |M| where M = max_S v(S), then S.card * |M| ≥ v(S) via calc chain with gcongr
- **hK_empty** (K = ∅): contradiction — element in P with sum < v(N) contradicts grand coalition constraint from P membership, closed by linarith
- hCore (G.Core.Nonempty) remains as sorry — requires extraction of Core allocation from P \ K

## Proofs (3 criteria)
1. **sorry count**: grep -c sorry = 3 → 1 (main has 3, this PR reduces to 1)
2. **lake build SUCCESS**: 3324 jobs, 0 errors, 1 warning (unused section var DecidableEq)
3. **No axiom leakage**: no `axiom` declarations introduced

## Test plan
- [x] `lake build CooperativeGames.Basic` — SUCCESS
- [x] `grep -c sorry CooperativeGames/Basic.lean` — 1 (was 3)
- [x] Proof integrity — no sorry in hP_nonempty or hK_empty blocks

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>