### PR TITLE
feat(ml-training): instrument m12/m15 for Curriculum V2 S1 (Epic #1167)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m12_har_rv_j.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m12_har_rv_j.py
@@ -276,10 +276,19 @@ def evaluate_one_combo(
     coin: str,
     horizon: int,
     seed: int,
+    oos_strict_year: int | None = None,
 ) -> dict | None:
-    """Run HAR-RV-J vs HAR Classic for one (coin, horizon, seed) combo."""
+    """Run HAR-RV-J vs HAR Classic for one (coin, horizon, seed) combo.
+
+    If oos_strict_year is provided, all data on/after Jan 1st of that year is
+    excluded from training and walk-forward evaluation (held out for separate
+    OOS verdict computed externally).
+    """
     np.random.seed(seed)
     hourly_rets = _load_one_coin(coin)
+    if oos_strict_year is not None:
+        cutoff = pd.Timestamp(f"{oos_strict_year}-01-01", tz=hourly_rets.index.tz)
+        hourly_rets = hourly_rets[hourly_rets.index < cutoff]
     if len(hourly_rets) < 1000:
         return None
 
@@ -376,32 +385,83 @@ def evaluate_one_combo(
     }
 
 
+def _csv_list(value: str) -> list[str]:
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _csv_int_list(value: str) -> list[int]:
+    return [int(s.strip()) for s in value.split(",") if s.strip()]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="M12 HAR-RV-J sweep")
     parser.add_argument("--dry-run", action="store_true", help="Run BTC h=1 seed=0 only")
+    parser.add_argument(
+        "--seeds",
+        type=_csv_int_list,
+        default=None,
+        help="Comma-separated seeds override (default: 0,1,7,42)",
+    )
+    parser.add_argument(
+        "--coins",
+        type=_csv_list,
+        default=None,
+        help="Comma-separated coins override (default: BTC/ETH/SOL/LTC/XRP/ADA/DOT)",
+    )
+    parser.add_argument(
+        "--horizons",
+        type=_csv_int_list,
+        default=None,
+        help="Comma-separated horizons override (default: 1,5,10)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Override results directory (default: results/m12_har_rv_j/)",
+    )
+    parser.add_argument(
+        "--oos-strict",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help=(
+            "Hold out all data >= Jan 1st of YEAR from training/walk-forward "
+            "(for separate OOS verdict). Example: --oos-strict 2027"
+        ),
+    )
     args = parser.parse_args()
 
-    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    coins = args.coins if args.coins is not None else COINS
+    horizons = args.horizons if args.horizons is not None else HORIZONS
+    seeds = args.seeds if args.seeds is not None else SEEDS
+    results_dir = args.output if args.output is not None else RESULTS_DIR
+    oos_strict_year = args.oos_strict
+
+    results_dir.mkdir(parents=True, exist_ok=True)
     t0 = time.time()
 
     combos: list[dict] = []
-    total = len(COINS) * len(HORIZONS) * len(SEEDS)
+    total = len(coins) * len(horizons) * len(seeds)
     done = 0
 
     if args.dry_run:
         print("[DRY RUN] BTC-USD h=1 seed=0 only")
-        row = evaluate_one_combo("BTC-USD", 1, 0)
+        row = evaluate_one_combo("BTC-USD", 1, 0, oos_strict_year=oos_strict_year)
         if row:
             combos.append(row)
             print(json.dumps(row, indent=2))
         return
 
-    for coin in COINS:
-        for h in HORIZONS:
-            for seed in SEEDS:
+    if oos_strict_year is not None:
+        print(f"[OOS-STRICT] Holding out data >= {oos_strict_year}-01-01")
+
+    for coin in coins:
+        for h in horizons:
+            for seed in seeds:
                 done += 1
                 print(f"\n[{done}/{total}] {coin} h={h} seed={seed}", flush=True)
-                row = evaluate_one_combo(coin, h, seed)
+                row = evaluate_one_combo(coin, h, seed, oos_strict_year=oos_strict_year)
                 if row is not None:
                     combos.append(row)
                 else:
@@ -429,7 +489,7 @@ def main() -> None:
     print(f"  p-value = {p_sign:.4f}")
     print(f"  median delta-Sharpe = {median_delta:+.4f}")
     print(f"\nPer-coin median delta-Sharpe:")
-    for c in COINS:
+    for c in coins:
         if c in per_coin:
             med = float(np.median(per_coin[c]["deltas"]))
             med_mse = float(np.median(per_coin[c]["mses"]))
@@ -476,13 +536,13 @@ def main() -> None:
         },
     }
 
-    with open(RESULTS_DIR / "results.json", "w") as f:
+    with open(results_dir / "results.json", "w") as f:
         json.dump(results, f, indent=2, default=str)
 
     # CSV
     if combos:
         df = pd.DataFrame(combos)
-        df.to_csv(RESULTS_DIR / "m12_har_rv_j_results.csv", index=False)
+        df.to_csv(results_dir / "m12_har_rv_j_results.csv", index=False)
         print(f"\nSaved: {RESULTS_DIR / 'results.json'}")
         print(f"Saved: {RESULTS_DIR / 'm12_har_rv_j_results.csv'}")
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
@@ -371,14 +371,22 @@ def evaluate_one_combo(
     horizon: int,
     seed: int,
     hidden_size: int = HIDDEN_SIZE,
+    oos_strict_year: int | None = None,
 ) -> dict | None:
-    """Run LSTM vs HAR Classic for one (coin, horizon, seed) combo."""
+    """Run LSTM vs HAR Classic for one (coin, horizon, seed) combo.
+
+    If oos_strict_year is set, data on/after Jan 1st of that year is held out
+    from training/walk-forward (reserved for separate OOS verdict).
+    """
     import torch
 
     torch.manual_seed(seed)
     np.random.seed(seed)
 
     hourly_rets = _load_one_coin(coin)
+    if oos_strict_year is not None:
+        cutoff = pd.Timestamp(f"{oos_strict_year}-01-01", tz=hourly_rets.index.tz)
+        hourly_rets = hourly_rets[hourly_rets.index < cutoff]
     if len(hourly_rets) < 1000:
         return None
 
@@ -476,14 +484,60 @@ def evaluate_one_combo(
     }
 
 
+def _csv_list(value: str) -> list[str]:
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+def _csv_int_list(value: str) -> list[int]:
+    return [int(s.strip()) for s in value.split(",") if s.strip()]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="M15 Log-LSTM RV sweep")
     parser.add_argument("--dry-run", action="store_true", help="Run BTC h=1 seed=0 only")
     parser.add_argument("--hidden-size", type=int, default=HIDDEN_SIZE,
                         help=f"LSTM hidden size (default: {HIDDEN_SIZE})")
+    parser.add_argument(
+        "--seeds",
+        type=_csv_int_list,
+        default=None,
+        help="Comma-separated seeds override (default: 0,1,7,42)",
+    )
+    parser.add_argument(
+        "--coins",
+        type=_csv_list,
+        default=None,
+        help="Comma-separated coins override (default: BTC/ETH/SOL/LTC/XRP/ADA/DOT)",
+    )
+    parser.add_argument(
+        "--horizons",
+        type=_csv_int_list,
+        default=None,
+        help="Comma-separated horizons override (default: 1,5,10)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Override results directory (default: results/m15_lstm_rv_h{hidden_size}/)",
+    )
+    parser.add_argument(
+        "--oos-strict",
+        type=int,
+        default=None,
+        metavar="YEAR",
+        help=(
+            "Hold out all data >= Jan 1st of YEAR from training/walk-forward "
+            "(for separate OOS verdict). Example: --oos-strict 2027"
+        ),
+    )
     args = parser.parse_args()
 
     hidden_size = args.hidden_size
+    coins = args.coins if args.coins is not None else COINS
+    horizons = args.horizons if args.horizons is not None else HORIZONS
+    seeds = args.seeds if args.seeds is not None else SEEDS
+    oos_strict_year = args.oos_strict
 
     import torch
     print(f"PyTorch {torch.__version__}, CUDA: {torch.cuda.is_available()}")
@@ -494,7 +548,11 @@ def main() -> None:
     n_params = count_params(model_demo)
     print(f"LSTM params: {n_params} (hidden={hidden_size}, layers={NUM_LAYERS}, window={WINDOW})")
 
-    results_dir = SCRIPT_DIR / "results" / f"m15_lstm_rv_h{hidden_size}"
+    results_dir = (
+        args.output
+        if args.output is not None
+        else SCRIPT_DIR / "results" / f"m15_lstm_rv_h{hidden_size}"
+    )
     results_dir.mkdir(parents=True, exist_ok=True)
     t0 = time.time()
 
@@ -512,27 +570,32 @@ def main() -> None:
                 completed_keys.add((row["coin"], row["horizon"], row["seed"]))
         print(f"[CHECKPOINT] resumed {len(combos)} combos from {checkpoint_path.name}", flush=True)
 
-    total = len(COINS) * len(HORIZONS) * len(SEEDS)
+    total = len(coins) * len(horizons) * len(seeds)
     done = 0
 
     if args.dry_run:
         print("[DRY RUN] BTC-USD h=1 seed=0 only")
-        row = evaluate_one_combo("BTC-USD", 1, 0, hidden_size=hidden_size)
+        row = evaluate_one_combo("BTC-USD", 1, 0, hidden_size=hidden_size,
+                                 oos_strict_year=oos_strict_year)
         if row:
             combos.append(row)
             print(json.dumps(row, indent=2))
         return
 
-    for coin in COINS:
-        for h in HORIZONS:
-            for seed in SEEDS:
+    if oos_strict_year is not None:
+        print(f"[OOS-STRICT] Holding out data >= {oos_strict_year}-01-01")
+
+    for coin in coins:
+        for h in horizons:
+            for seed in seeds:
                 done += 1
                 key = (coin, h, seed)
                 if key in completed_keys:
                     print(f"\n[{done}/{total}] {coin} h={h} seed={seed} -- SKIP (checkpoint)", flush=True)
                     continue
                 print(f"\n[{done}/{total}] {coin} h={h} seed={seed}", flush=True)
-                row = evaluate_one_combo(coin, h, seed, hidden_size=hidden_size)
+                row = evaluate_one_combo(coin, h, seed, hidden_size=hidden_size,
+                                         oos_strict_year=oos_strict_year)
                 if row is not None:
                     combos.append(row)
                     with open(checkpoint_path, "a") as f:
@@ -572,7 +635,7 @@ def main() -> None:
     print(f"  median delta-Sharpe = {median_delta:+.4f}")
     print(f"  median MSE change = {median_mse:+.1f}%")
     print(f"\nPer-coin:")
-    for c in COINS:
+    for c in coins:
         if c in per_coin:
             med = float(np.median(per_coin[c]["deltas"]))
             med_mse = float(np.median(per_coin[c]["mses"]))


### PR DESCRIPTION
## Summary

Instruments `m12_har_rv_j.py` and `m15_lstm_rv.py` with the flags required by Curriculum V2 S1 Hardening KEEPERS (#1168). Prior to this PR both scripts only supported `--dry-run`, with COINS/HORIZONS/SEEDS hardcoded.

## New flags (both scripts)

| Flag | Effect |
|------|--------|
| `--seeds 0,1,7,42` | Override SEEDS list |
| `--coins BTC-USD,ETH-USD,...` | Override COINS list |
| `--horizons 1,5,10` | Override HORIZONS list |
| `--output PATH` | Override results directory |
| `--oos-strict YEAR` | Hold out data >= Jan 1st of YEAR from training/walk-forward |

## OOS strict semantics

When `--oos-strict 2027` is passed, `hourly_rets` is filtered at load time to exclude data on/after `2027-01-01` (tz-aware cutoff matching the index timezone) **before** computing realized variance, jumps, and features. The held-out period is reserved for a separate OOS verdict run, executed after the sweep on this branch closes with a known training-period verdict.

## Verification

```
python m12_har_rv_j.py --help
# usage shows --seeds, --coins, --horizons, --output, --oos-strict

python m15_lstm_rv.py --help
# usage shows same + existing --hidden-size

python -c "import ast; ast.parse(open('m12_har_rv_j.py').read())"
# SYNTAX OK

python -c "import ast; ast.parse(open('m15_lstm_rv.py').read())"
# SYNTAX OK
```

## Scope discipline

- Only the two scripts modified
- No change to algorithmic logic (HAR-RV-J / LSTM training/eval untouched)
- All existing call paths preserved: `--dry-run` still works, no flags = original defaults
- Module-level COINS/HORIZONS/SEEDS retained as defaults (no removal)

## Why this unblocks S1

S1 gate (Epic #1167 / Issue #1168): `M12 BEATS confirme OOS 2027 + M15h32 BEATS confirme cross-seed 4`. Both require the held-out-year functionality + seed sweeping which did not exist.

## Test plan

- [x] `--help` lists new flags
- [x] `ast.parse` SYNTAX OK on both files
- [ ] (Follow-up after merge) Dry-run `--dry-run --oos-strict 2027` on ai-01 GPU 2 produces a result with reduced data
- [ ] (Follow-up) Full M12 OOS-2027 sweep launched per S1 spec

Refs: #1167 #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)