### PR TITLE
feat(lean): prove gale_shapley_stable — GS stable matching (sorry 3→2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/GaleShapley.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/GaleShapley.lean
@@ -24,6 +24,7 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic.Common
 import StableMarriage.Definitions
+import StableMarriage.Lemmas
 
 namespace StableMarriage
 
@@ -62,18 +63,23 @@ deferred-acceptance algorithm (`mmaaz-git/stable-marriage-lean` provides
 -/
 theorem gale_shapley_stable (prof : PrefProfile n) :
     ∃ μ : Matching n, IsStable prof μ := by
-  -- Attempt 1: aesop -> made no progress (no constructive witness)
-  -- Attempt 2: classical choice on finite set of matchings
-  -- The set of matchings is finite (subtype of Fin n → Fin n).
-  -- The set of stable matchings is decidable. By GS it is nonempty,
-  -- but we cannot prove nonemptiness here without porting GS.
-  -- Attempt 3: special case n=1 — but theorem is parametric in n.
-  classical
-  -- INTRACTABLE_UNTIL_GS_IMPL: existential proof requiring constructive witness
-  -- via Gale-Shapley algorithm. Cannot be solved by LLM tactic search.
-  -- See: mmaaz-git/stable-marriage-lean (Algorithm.lean ~1000 LOC)
-  -- Registered in prover HONEST_SORRIES: GaleShapley.lean L73
-  sorry
+  let σ := gsRunSteps prof (gsProposalBound n)
+  have hterm : gsTerminated prof σ :=
+    gsTerminated_runSteps_bound prof
+  have hcon : GSConsistent σ.matching :=
+    GSConsistent.runSteps prof (gsProposalBound n)
+  have hwp : womenProposedImpliesMatched prof σ :=
+    womenProposedImpliesMatched.runSteps prof (gsProposalBound n)
+  have hdown : menProposedDownward prof σ :=
+    menProposedDownward.runSteps prof (gsProposalBound n)
+  have hmp : menMatchedProposed prof σ :=
+    menMatchedProposed.runSteps prof (gsProposalBound n)
+  have hbest : womenBestState prof σ :=
+    womenBestState.runSteps prof (gsProposalBound n)
+  have hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  exact ⟨gsFinalMatching prof σ hall hcon,
+    fun m w => gsNoBlockingPairs prof hterm hcon hwp hdown hmp hbest m w⟩
 
 /--
 The Gale-Shapley matching is man-optimal: every man gets the best

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/Lemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/stable_marriage_lean/StableMarriage/Lemmas.lean
@@ -732,4 +732,160 @@ lemma gsTerminated_allMenMatched (prof : PrefProfile n) {σ : GSState prof}
       (by simp)
   omega
 
+/-! ## GS Final Matching Conversion -/
+
+/-- Extract spouse from GSMatching using Classical.choose (avoids Option.get type issues). -/
+noncomputable def gsSpouse (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) : Fin n :=
+  Classical.choose (Option.ne_none_iff_exists.mp (hall m))
+
+lemma gsSpouse_spec (μ : GSMatching n)
+    (hall : ∀ m, μ.menMatch m ≠ none) (m : Fin n) :
+    μ.menMatch m = some (gsSpouse μ hall m) :=
+  (Classical.choose_spec (Option.ne_none_iff_exists.mp (hall m))).symm
+
+/-- All women are matched when all men are matched and matching is consistent. -/
+lemma gsAllWomenMatched {μ : GSMatching n}
+    (hall : ∀ m, μ.menMatch m ≠ none)
+    (hcon : GSConsistent μ) (w : Fin n) :
+    μ.womenMatch w ≠ none := by
+  by_contra hnone
+  have hNoMan : ∀ m, μ.menMatch m ≠ some w := by
+    intro m hmw; have := hcon m w |>.mp hmw; rw [hnone] at this; simp at this
+  -- Every man maps to some w' ≠ w, injectively → pigeonhole contradiction
+  have hMap (m : Fin n) : ∃ w', μ.menMatch m = some w' ∧ w' ≠ w := by
+    obtain ⟨w', hw'⟩ := Option.ne_none_iff_exists.mp (hall m)
+    exact ⟨w', hw'.symm, fun heq => hNoMan m (heq ▸ hw'.symm)⟩
+  let f (m : Fin n) : {w' : Fin n // w' ≠ w} :=
+    ⟨Classical.choose (hMap m), (Classical.choose_spec (hMap m)).2⟩
+  have hf : Injective f := by
+    intro m₁ m₂ heq
+    simp only [f, Subtype.mk.injEq] at heq
+    have h₁ := (Classical.choose_spec (hMap m₁)).1
+    have h₂ := (Classical.choose_spec (hMap m₂)).1
+    rw [heq] at h₁
+    -- h₁ : μ.menMatch m₁ = some c  (c = Classical.choose (hMap m₂))
+    -- h₂ : μ.menMatch m₂ = some c
+    have hw₁ := hcon m₁ (Classical.choose (hMap m₂)) |>.mp h₁
+    have hw₂ := hcon m₂ (Classical.choose (hMap m₂)) |>.mp h₂
+    -- hw₁ : μ.womenMatch c = some m₁
+    -- hw₂ : μ.womenMatch c = some m₂
+    exact Option.some.inj (hw₁.symm.trans hw₂)
+  have hle : Fintype.card (Fin n) ≤ Fintype.card {w' : Fin n // w' ≠ w} :=
+    Fintype.card_le_of_injective f hf
+  have hlt : Fintype.card {w' : Fin n // w' ≠ w} < Fintype.card (Fin n) :=
+    @Fintype.card_lt_of_injective_of_notMem _ _ _ _
+      (Subtype.val : {w' : Fin n // w' ≠ w} → Fin n) Subtype.coe_injective w (by simp)
+  omega
+
+/-- Build a total Matching from a terminated GSMatching. -/
+noncomputable def gsFinalMatching (prof : PrefProfile n)
+    (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) : Matching n where
+  spouse := gsSpouse σ.matching hall
+  bijective := by
+    constructor
+    · -- injective: spouse m₁ = spouse m₂ → m₁ = m₂
+      intro m₁ m₂ heq
+      have h₁ := gsSpouse_spec σ.matching hall m₁
+      have h₂ := gsSpouse_spec σ.matching hall m₂
+      rw [heq] at h₁
+      -- h₁ : σ.matching.menMatch m₁ = some (gsSpouse σ.matching hall m₂)
+      -- h₂ : σ.matching.menMatch m₂ = some (gsSpouse σ.matching hall m₂)
+      have hw₁ := hcon m₁ (gsSpouse σ.matching hall m₂) |>.mp h₁
+      have hw₂ := hcon m₂ (gsSpouse σ.matching hall m₂) |>.mp h₂
+      -- hw₁ : σ.matching.womenMatch _ = some m₁
+      -- hw₂ : σ.matching.womenMatch _ = some m₂
+      exact Option.some.inj (hw₁.symm.trans hw₂)
+    · -- surjective: for every w, find m with spouse m = w
+      intro w
+      have hwn := gsAllWomenMatched hall hcon w
+      obtain ⟨m, hm⟩ := Option.ne_none_iff_exists.mp hwn
+      have hmw : σ.matching.menMatch m = some w := (hcon m w).mpr hm.symm
+      exact ⟨m, by
+        have hspec := gsSpouse_spec σ.matching hall m
+        -- hspec : σ.matching.menMatch m = some (gsSpouse σ.matching hall m)
+        rw [hmw] at hspec
+        -- hspec : some w = some (gsSpouse σ.matching hall m)
+        exact Option.some.inj hspec.symm⟩
+
+/-- Key lemma: gsFinalMatching.spouse m extracts the Option value directly. -/
+lemma gsFinalMatching_spouse_get (prof : PrefProfile n) (σ : GSState prof)
+    (hall : ∀ m, σ.matching.menMatch m ≠ none)
+    (hcon : GSConsistent σ.matching) (m : Fin n) :
+    (gsFinalMatching prof σ hall hcon).spouse m =
+      Classical.choose (Option.ne_none_iff_exists.mp (hall m)) := rfl
+
+/-! ## No Blocking Pairs (adapted from upstream Properties.lean L48-120) -/
+
+/-- The GS final state has no blocking pairs.
+
+    Proof structure (adapted from mmaaz-git Properties.lean galeShapley_noBlockingPairs):
+    1. Assume blocking pair (m,w): m prefers w to spouse, w prefers m to inverse
+    2. Show m proposed to w (menProposedDownward + menMatchedProposed)
+    3. w is matched to mW (womenProposedImpliesMatched)
+    4. womenBestState gives: womenPref w mW ≤ womenPref w m
+    5. Blocking condition gives: womenPref w m < womenPref w mW
+    6. Contradiction (≤ and < are incompatible)
+
+    Simplification vs upstream: no "w is unmatched" branch (total preferences).
+-/
+lemma gsNoBlockingPairs (prof : PrefProfile n)
+    (hterm : gsTerminated prof (gsRunSteps prof (gsProposalBound n)))
+    (hcon : GSConsistent (gsRunSteps prof (gsProposalBound n)).matching)
+    (hwp : womenProposedImpliesMatched prof (gsRunSteps prof (gsProposalBound n)))
+    (hdown : menProposedDownward prof (gsRunSteps prof (gsProposalBound n)))
+    (hmatch_prop : menMatchedProposed prof (gsRunSteps prof (gsProposalBound n)))
+    (hbest : womenBestState prof (gsRunSteps prof (gsProposalBound n)))
+    (m w : Fin n) :
+    ¬ IsBlockingPair prof (gsFinalMatching prof (gsRunSteps prof (gsProposalBound n))
+      (fun m => gsTerminated_allMenMatched prof hterm hwp hcon m) hcon) m w := by
+  intro hblock
+  obtain ⟨hmpref, hwpref⟩ := hblock
+  set σ := gsRunSteps prof (gsProposalBound n)
+  set hall : ∀ m, σ.matching.menMatch m ≠ none :=
+    fun m => gsTerminated_allMenMatched prof hterm hwp hcon m
+  set μ := gsFinalMatching prof σ hall hcon
+  -- Step 1: m is matched, extract wMatch
+  have hwMatch' : σ.matching.menMatch m = some (μ.spouse m) :=
+    gsSpouse_spec σ.matching hall m
+  -- Step 2: m proposed to his match (μ.spouse m)
+  have hpropMatch : σ.proposed m (μ.spouse m) :=
+    hmatch_prop m (μ.spouse m) hwMatch'
+  -- Step 3: m proposed to w (downward closure)
+  -- Blocking says menPref m w < menPref m (μ.spouse m), so w is preferred
+  have hpropw : σ.proposed m w :=
+    hdown m (μ.spouse m) w hpropMatch hmpref
+  -- Step 4: w is matched (womenProposedImpliesMatched)
+  have hwomMatch : σ.matching.womenMatch w ≠ none := hwp w m hpropw
+  obtain ⟨mW, hmW⟩ := Option.ne_none_iff_exists.mp hwomMatch
+  have hmW' : σ.matching.womenMatch w = some mW := hmW.symm
+  -- Step 5: womenBestState gives womenPref w mW ≤ womenPref w m
+  have hbest' : prof.womenPref w mW ≤ prof.womenPref w m :=
+    hbest w mW m hmW' hpropw
+  -- Step 6: μ.inverse w = mW
+  -- From consistency: menMatch mW = some w, so spouse mW = w
+  have hmw' : σ.matching.menMatch mW = some w := (hcon mW w).mpr hmW'
+  have hspouse_mW : μ.spouse mW = w := by
+    have h₁ := gsSpouse_spec σ.matching hall mW
+    -- h₁ : menMatch mW = some (gsSpouse ...) and hmw' : menMatch mW = some w
+    exact Option.some.inj (h₁.symm.trans hmw')
+  -- inverse w = mW because spouse mW = w
+  have hwinv : μ.inverse w = mW := by
+    unfold Matching.inverse
+    rw [← hspouse_mW]
+    exact Equiv.ofBijective_symm_apply_apply (gsSpouse σ.matching hall) _ mW
+  rw [hwinv] at hwpref
+  -- hwpref : womenPref w m < womenPref w mW
+  -- hbest' : womenPref w mW ≤ womenPref w m
+  -- Contradiction: hbest' says womenPref w mW ≤ womenPref w m
+  -- but hwpref says womenPref w m < womenPref w mW
+  -- i.e. a ≤ b and b < a is impossible
+  have : (prof.womenPref w mW : Nat) ≤ (prof.womenPref w m : Nat) := by
+    exact mod_cast hbest'
+  have : (prof.womenPref w m : Nat) < (prof.womenPref w mW : Nat) := by
+    exact mod_cast hwpref
+  omega
+
 end StableMarriage


### PR DESCRIPTION
## Summary
- Prove `gale_shapley_stable`: constructive existence of a stable matching via Gale-Shapley algorithm
- Define `gsFinalMatching`: converts partial `GSMatching` (Option-based) to total `Matching` (bijection on `Fin n`)
- Prove `gsNoBlockingPairs`: 6-step contradiction proof using all 5 GS invariants
- Prove `gsAllWomenMatched`: pigeonhole injection proof (n men → n-1 women impossible)
- Sorry count: 3 → 2 in GaleShapley.lean, 0 in Lemmas.lean

## Key proofs

### `gsFinalMatching` (Lemmas.lean ~L785)
Converts `GSMatching` (with `menMatch m ≠ none` for all m) to total `Matching`:
- `spouse := gsSpouse μ hall` (extract via `Classical.choose`)
- Injectivity: if `spouse m₁ = spouse m₂` then consistency gives `womenMatch` equality → `m₁ = m₂`
- Surjectivity: `gsAllWomenMatched` + consistency gives every woman has a preimage

### `gsNoBlockingPairs` (Lemmas.lean ~L834)
For blocking pair (m, w) with `ManPrefers m w (spouse m)` and `WomanPrefers w m (inverse w)`:
1. m is matched to `spouse m` — extract from GSMatching
2. m proposed to `spouse m` — `menMatchedProposed` invariant
3. m proposed to w — `menProposedDownward` (w is preferred over `spouse m`)
4. w is matched to mW — `womenProposedImpliesMatched`
5. `womenBestState` gives `womenPref w mW ≤ womenPref w m`
6. Consistency gives `inverse w = mW`, so blocking says `womenPref w m < womenPref w mW`
7. Contradiction: `mW ≤ m` and `m < mW` via `omega` on Nat coercions

### `gale_shapley_stable` (GaleShapley.lean L64)
Instantiates all 5 invariants for `gsRunSteps prof (gsProposalBound n)` and composes `gsFinalMatching` + `gsNoBlockingPairs`.

## Build verification
- `lake build` SUCCESS (687 jobs)
- `grep -c sorry GaleShapley.lean` = 2 (man_optimal + woman_pessimal, annotated INTRACTABLE_UNTIL_GS_IMPL)
- `grep -c sorry Lemmas.lean` = 0
- `grep -c sorry GSState.lean` = 0

## Remaining sorry (2)
- `gale_shapley_man_optimal`: requires lattice of stable matchings (Knuth 1976)
- `gale_shapley_woman_pessimal`: dual of man-optimality, same machinery needed

## Test plan
- [x] `lake build` passes (687 jobs, 0 errors)
- [x] Sorry count verified: 2 in GaleShapley.lean, 0 elsewhere
- [x] `gale_shapley_stable` produces constructive witness
- [x] `stable_matching_exists` delegates to `gale_shapley_stable` (automatic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)