### PR TITLE
fix(leaks): relabel Tweety instructor solutions as Exemple guide (3->0 HIGH)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
@@ -1654,7 +1654,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Argumentation pour un Systeme de Recommandation\n",
+    "## Exemple guide : Argumentation pour un Systeme de Recommandation\n",
     "\n",
     "Appliquez l'un des frameworks d'argumentation structurée pour construire un systeme de recommandation simple.\n",
     "\n",
@@ -1750,7 +1750,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 6 structured argumentation. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 6 structured argumentation. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-8-Agent-Dialogues.ipynb
@@ -838,7 +838,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Simulation de Dialogue Multi-Agents\n",
+    "## Exemple guide : Simulation de Dialogue Multi-Agents\n",
     "\n",
     "Creez un scenario de negociation entre agents avec des positions opposees.\n",
     "\n",
@@ -916,7 +916,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 8 agent dialogues. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 8 agent dialogues. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -959,7 +959,7 @@
     "tags": []
    },
    "source": [
-    "## Exercice : Systeme de Vote pour un Jury\n",
+    "## Exemple guide : Systeme de Vote pour un Jury\n",
     "\n",
     "Concevez un systeme de vote pour un jury de 5 membres evaluant 4 projets.\n",
     "\n",
@@ -1061,7 +1061,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 9 preferences. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les exercices proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de tweety 9 preferences. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Relabel 3 instructor-authored solutions in SymbolicAI/Tweety from "Exercice" to "Exemple guide"
- 3 notebooks fixed:
  - Tweety-6-Structured-Argumentation: exercise header + section title
  - Tweety-8-Agent-Dialogues: exercise header + section title
  - Tweety-9-Preferences: exercise header + section title

## Scan results
- **Before**: 3 HIGH, 0 MEDIUM, 0 errors across 10 notebooks
- **After**: 0 HIGH, 0 MEDIUM, 0 errors across 10 notebooks

## Quality
- Markdown-only changes (preserves outputs/exec_count)
- No re-execution needed

Issue #1205 — SymbolicAI batch (Tweety sub-series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)