### PR TITLE
fix(symbolicai): relabel 2 standalone exercise leaks (#1205 Phase 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
@@ -775,7 +775,7 @@
     "\n",
     "---\n",
     "\n",
-    "## Exercice : Modélisez un Problème de Planification\n",
+    "## Exemple guide : Modélisez un Problème de Planification\n",
     "\n",
     "Modélisez et résolvez un problème de planification avec Z3.Linq.\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
@@ -584,7 +584,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Exercice : Optimisation de Portefeuille Simplifiee\n",
+    "## Exemple guide : Optimisation de Portefeuille Simplifiee\n",
     "\n",
     "Creez un solveur de programmation lineaire pour un probleme de portefeuille d'investissement.\n",
     "\n",


### PR DESCRIPTION
## Summary
- Relabel 2 standalone SymbolicAI notebooks with solution leaks (instructor demos labeled "Exercice" instead of "Exemple guide")
- Linq2Z3 cell 18: `## Exercice` → `## Exemple guide`
- OR-tools-Stiegler cell 18: `## Exercice` → `## Exemple guide`
- Markdown-only changes, no code/outputs touched

## Verification
```
detect_solution_leaks.py --scan <each> → 0 HIGH, 0 MEDIUM
```

## Related
- Issue #1205 Phase 2 — SymbolicAI series batch fix
- Part of batch: #1212 (Lean), #1213 (Planners), #1214 (SemanticWeb), #1215 (Tweety), #1216 (SmartContracts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)