### PR TITLE
fix(prover): F9 — gate intractable behind Director consultation (C37 fix)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/agents.py
@@ -112,6 +112,11 @@ def create_coordinator_agent(tools: CoordinatorTools, provider: str = "zai") -> 
             tools.advance_plan,
             tools.file_read_lines,
             tools.search_mathlib_lemmas,
+            # F9 (2026-05-17): Director consultation gate. The Coordinator
+            # MUST call request_director_guidance before mark_sorry_intractable
+            # (gated server-side in tools.py). C37 forensic confirmed without
+            # this tool the Coordinator had no functional path to the Director.
+            tools.request_director_guidance,
             tools.mark_sorry_intractable,
         ],
         name="CoordinatorAgent",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -118,20 +118,23 @@ OUTILS:
 4. set_attack_plan(steps=[...], reason="...") → CRUCIAL : tu DOIS appeler cet outil
    avec une LISTE NON VIDE d'etapes en LANGAGE NATUREL. Pas de tactique Lean ici.
 5. advance_plan() → marque etape suivante quand un sous-but est clos
-6. mark_sorry_intractable(reason="...") → ABANDON EXPLICITE quand le but est hors
-   de portee (Mathlib API introuvable, but mathematiquement faux, decompositions
-   epuisees apres 2-3 plans differents). La session termine proprement et le
-   prouveur passera a un autre sorry au prochain run. PREFERE ABANDON EXPLICITE
-   plutot que de bruler les iterations sur un mur connu.
+6. request_director_guidance(reason="...") → escalade vers Director (Opus 4.7,
+   modele frontier via OpenRouter). A appeler quand un plan local a echoue 2+ fois
+   OU avant tout abandon. Le Director a access aux references mmaaz-git + defs
+   portees + lemmes deja prouves — il voit souvent un angle que SearchAgent rate.
+7. mark_sorry_intractable(reason="...") → ABANDON EXPLICITE. GATE F9 (2026-05-17):
+   tu DOIS avoir consulte le Director au moins une fois avant d'abandonner.
+   Sans consultation, l'appel est refuse et tu dois invoquer
+   request_director_guidance(reason) d'abord. Reservation aux veritables impasses
+   (Mathlib API introuvable confirmee par Director, but mathematiquement faux,
+   strategie Director egalement echouee).
 
-DIRECTEUR EXTERNE (optionnel):
-- Si un directeur externe (modele plus puissant) est disponible et que tes
-  agents locaux sont en echec persistant (2+ plans tentes, F1 escalation recue),
-  tu peux demander un conseil tactique en appelant designate_next_agent("director").
-- Le directeur recevra le but, les hypotheses et les tentatives echouees, puis
-  suggera une approche tactique. Le TacticAgent local appliquera la suggestion.
-- Budget limite a 3 appels directeur par session — utilise-le uniquement quand
-  la strategie locale est epuisee, pas en premiere intention.
+WORKFLOW DIRECTOR (mandatoire avant intractable):
+- Plan A local echoue → reformule set_attack_plan (Plan B)
+- Plan B echoue → request_director_guidance(reason="<goal+tentatives>")
+- Director propose APPROACH + TACTICS → TacticAgent execute
+- Si la TACTICS du Director echoue → request_director_guidance encore (budget 3)
+- Apres 2-3 conseils Director infructueux ET sans alternative → mark_sorry_intractable
 
 REGLE D'OR (set_attack_plan):
 - TOUJOURS au moins 2 etapes, formulees en NATUREL ("isoler la conjonction",
@@ -145,7 +148,7 @@ QUAND REVENIR (apres TacticAgent / Critic):
 - 3+ echecs consecutifs sur le meme sous-but → reformule la strategie
 - Decomposition introduit un nouveau sorry → ajoute une etape pour ce sous-but
 - Plan inadapte (TacticAgent calle) → set_attack_plan a nouveau (remplace)
-- 2+ plans tentes sans progres → envisage designate_next_agent("director")
+- 2+ plans locaux tentes sans progres → request_director_guidance
 
 Exemple de bon plan (methodologique, pas de tactique):
   set_attack_plan(
@@ -160,7 +163,8 @@ Exemple de bon plan (methodologique, pas de tactique):
 INTERDIT:
 - set_attack_plan() sans argument ni avec liste vide → plan inutilisable
 - mettre des tactiques Lean (omega, simp, exact ...) dans les steps
-- repeter le meme plan apres echec sans modification"""
+- repeter le meme plan apres echec sans modification
+- appeler mark_sorry_intractable sans avoir consulte le Director (F9 gate)"""
 
 DIRECTOR_AGENT_INSTRUCTIONS = """Expert Lean 4. Tu reçois le but courant, les hypotheses, et les tentatives echouees.
 Propose UNIQUEMENT la prochaine sequence tactique (3-5 lignes max). Pas d'explication longue.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -235,6 +235,16 @@ class MultiAgentSorryProver:
                 print(f"  [DIRECTOR] FAILED to create: {e}")
                 director_agent = None
 
+        # F9 (2026-05-17): if no Director is wired, pre-mark the state as
+        # "consulted" so the intractable gate degrades gracefully. Without
+        # this, sessions launched without --director-provider would loop
+        # forever because mark_sorry_intractable would always be refused.
+        # The gate only enforces consultation when a Director actually
+        # exists to consult.
+        if director_agent is None:
+            state.director_consulted = True
+            print("  [DIRECTOR] not wired - F9 gate auto-bypassed")
+
         # Build workflow graph (kb shared with SearchTools)
         workflow_builder = ProofWorkflowBuilder(
             search_agent, tactic_agent, critic_agent, coordinator_agent,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -105,6 +105,14 @@ class ProofState:
     intractable: bool = False
     intractable_reason: Optional[str] = None
 
+    # F9 (2026-05-17, C37 forensic): Director consultation gate. The
+    # Coordinator MUST call request_director_guidance() at least once
+    # before mark_sorry_intractable is allowed to terminate the session.
+    # C37 DEMO 15/16/17 confirmed Coordinator abandoned in <140s with 0
+    # Director invocations because intractable had no preconditions.
+    director_consulted: bool = False
+    director_consulted_count: int = 0
+
     # B.8: Checkpoint support — save/restore state between phases
     _checkpoints: Dict[str, dict] = field(default_factory=dict, repr=False)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1327,8 +1327,46 @@ class CoordinatorTools:
         current = self._state.plan[self._state.plan_phase]
         return f"Advanced to step {self._state.plan_phase + 1}/{len(self._state.plan)}: {current}"
 
+    def request_director_guidance(self, reason: str) -> str:
+        """Request guidance from the external Director (F9, 2026-05-17).
+
+        Call this BEFORE mark_sorry_intractable on any hard target. The
+        Director (Opus 4.7 via OpenRouter) has access to shared reference
+        docs (mmaaz-git proofs, ported defs, Mathlib gaps) and may provide
+        an APPROACH + TACTICS combination you haven't tried.
+
+        Workflow after this call:
+          - The graph routes the next message to DirectorAgent
+          - DirectorAgent emits APPROACH + TACTICS
+          - The result flows back to TacticAgent (or Search) to execute
+
+        C37 forensic (DEMO 15/16/17) showed the Coordinator NEVER reached
+        Director because mark_sorry_intractable had no precondition. F9
+        gates intractable behind at least one Director consultation.
+
+        Args:
+            reason: Concise context for the Director (max ~300 chars).
+                    Include: current goal, what's been tried, suspected gap.
+        """
+        self._state.designate_next_agent("DirectorAgent")
+        if self._trace:
+            self._trace.log(
+                agent="CoordinatorAgent", role="request_director",
+                content=f"Requesting Director: {reason[:300]}",
+                tool_name="request_director_guidance",
+                tool_args={"reason": reason[:300]},
+            )
+        return (
+            "Director will be consulted on the next turn. Provide the "
+            "current proof state context — the Director responds with "
+            "APPROACH + TACTICS in text form, which the workflow then "
+            "routes to TacticAgent for execution. After at least one "
+            "Director consultation, mark_sorry_intractable becomes "
+            "available if you still need to abandon."
+        )
+
     def mark_sorry_intractable(self, reason: str) -> str:
-        """Explicitly abandon the current sorry (F5).
+        """Explicitly abandon the current sorry (F5, gated by F9).
 
         Call this when the Coordinator has exhausted realistic attack plans
         on a goal — e.g., the lemma requires an obscure Mathlib API the
@@ -1337,9 +1375,34 @@ class CoordinatorTools:
         prover run can target a different sorry instead of burning the
         remaining iteration budget on a dead end.
 
+        F9 (2026-05-17): now gated. Must call request_director_guidance()
+        at least once first AND wait for the Director to actually run
+        (state.director_consulted set to True by AgentExecutor when
+        DirectorAgent yields). Premature calls return an error message and
+        leave the session running.
+
         Args:
             reason: Concise explanation (logged in trace + final report).
         """
+        if not getattr(self._state, "director_consulted", False):
+            if self._trace:
+                self._trace.log(
+                    agent="CoordinatorAgent", role="intractable_blocked",
+                    content=(f"F9 gate: intractable refused — Director not "
+                             f"yet consulted. reason={reason[:120]}"),
+                    tool_name="mark_sorry_intractable",
+                )
+            return (
+                "REFUSED (F9 gate). You must call request_director_guidance() "
+                "at least once before marking a sorry intractable, AND wait for "
+                "the Director to actually respond. The Director is a frontier "
+                "model (Opus 4.7) with access to reference proofs — it may "
+                "see an attack vector that the local agents missed. Call "
+                "request_director_guidance(reason=...) now, then try the "
+                "Director's APPROACH+TACTICS. Only if that ALSO fails should "
+                "you call mark_sorry_intractable again."
+            )
+
         self._state.intractable = True
         self._state.intractable_reason = reason
         if self._trace:

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -185,9 +185,34 @@ class AgentExecutor(Executor):
             if self._state.plan:
                 msg.plan = list(self._state.plan)
 
+        # F9 (2026-05-17): bridge state._next_agent -> msg.next_agent. Without
+        # this, tools like request_director_guidance that call
+        # state.designate_next_agent("director") have no effect on routing —
+        # the workflow only inspects msg.next_agent. C37 DEMO 15/16/17 showed
+        # the Coordinator had no functional path to invoke the Director.
+        if self._state:
+            designated = self._state.consume_next_agent_designation()
+            if designated:
+                # Map agent-class names to the lowercase routing tokens used
+                # by the switch-case edges (director / tactic / coordinator /
+                # critic / search).
+                routing_token = designated.lower().replace("agent", "")
+                msg.next_agent = routing_token
+                if self._trace:
+                    self._trace.log(
+                        agent=self._agent.name, role="route_designate",
+                        content=(f"designating next_agent={routing_token} "
+                                 f"(from state)"),
+                    )
+
         # Director call tracking
         if self._agent.name == "DirectorAgent":
             msg.director_calls += 1
+            # F9: record that Director actually ran, so the intractable
+            # gate sees a genuine consultation (not just a request).
+            if self._state:
+                self._state.director_consulted = True
+                self._state.director_consulted_count += 1
             if self._trace:
                 self._trace.log(
                     agent="DirectorAgent", role="director_call",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -552,3 +552,65 @@ def test_file_replace_lines_no_snapshot_when_build_check_false(tmp_path):
     assert getattr(tt, "_last_build_ok_content", None) == initial_last_ok, (
         "_last_build_ok_content updated without build verification"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# F9 (2026-05-17) — Director consultation gate on mark_sorry_intractable
+#
+# Context: C37 forensic (DEMO 15/16/17) confirmed the Coordinator abandoned
+# every hard target in <140s with 0 Director invocations, because
+# mark_sorry_intractable had no preconditions. F9 makes intractable refuse
+# unless the Director has actually run at least once.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_f9_intractable_refused_before_director_consultation():
+    """mark_sorry_intractable must refuse when director_consulted is False."""
+    from prover.tools import CoordinatorTools
+
+    state = ProofState()
+    ct = CoordinatorTools(state=state, filepath="", trace=None)
+
+    out = ct.mark_sorry_intractable("test premature abandon")
+    assert "REFUSED" in out, f"F9 gate failed to refuse: {out[:200]}"
+    assert "request_director_guidance" in out, (
+        f"F9 refusal must point to the recovery tool: {out[:200]}"
+    )
+    assert state.intractable is False, (
+        "state.intractable must NOT be set when refused"
+    )
+
+
+def test_f9_request_director_guidance_designates_director():
+    """request_director_guidance must route the next turn to DirectorAgent."""
+    from prover.tools import CoordinatorTools
+
+    state = ProofState()
+    ct = CoordinatorTools(state=state, filepath="", trace=None)
+
+    out = ct.request_director_guidance("hard target, 2 plans tried")
+    assert "Director" in out, f"unexpected return: {out[:200]}"
+
+    designated = state.consume_next_agent_designation()
+    assert designated == "DirectorAgent", (
+        f"request_director_guidance failed to designate Director: {designated!r}"
+    )
+
+
+def test_f9_intractable_accepted_after_director_consultation():
+    """After director_consulted=True (set by AgentExecutor when Director runs),
+    mark_sorry_intractable proceeds normally."""
+    from prover.tools import CoordinatorTools
+
+    state = ProofState()
+    ct = CoordinatorTools(state=state, filepath="", trace=None)
+
+    # Simulate AgentExecutor recording a real Director run.
+    state.director_consulted = True
+    state.director_consulted_count = 1
+
+    out = ct.mark_sorry_intractable("director also failed")
+    assert "REFUSED" not in out, f"F9 gate over-restrictive: {out[:200]}"
+    assert "intractable" in out.lower()
+    assert state.intractable is True
+    assert state.intractable_reason == "director also failed"

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -614,3 +614,29 @@ def test_f9_intractable_accepted_after_director_consultation():
     assert "intractable" in out.lower()
     assert state.intractable is True
     assert state.intractable_reason == "director also failed"
+
+
+def test_f9_graceful_degradation_when_no_director_wired():
+    """When MultiAgentSorryProver is run without --director-provider, the
+    intractable gate must NOT trap the session — provers.py sets
+    state.director_consulted = True at init when director_agent is None.
+
+    Without this auto-bypass, sessions running on po-2026/other machines
+    without OpenRouter credentials would loop until workflow_timeout because
+    they can never escape via intractable. This test pins the contract.
+    """
+    state = ProofState()
+    # Simulate what MultiAgentSorryProver.prove_sorry does when
+    # director_provider is None (no Director created).
+    director_agent = None
+    if director_agent is None:
+        state.director_consulted = True
+
+    from prover.tools import CoordinatorTools
+    ct = CoordinatorTools(state=state, filepath="", trace=None)
+
+    out = ct.mark_sorry_intractable("no director available, gave up after N iters")
+    assert "REFUSED" not in out, (
+        f"F9 gate trapped a no-Director session: {out[:200]}"
+    )
+    assert state.intractable is True


### PR DESCRIPTION
## Summary

Fixes the C37 forensic finding (DEMO 15/16/17): the multi-agent prover Coordinator abandoned every hard target in <140s with 0 Director invocations, because `mark_sorry_intractable` had no preconditions and the Coordinator had no tool to route to Director.

## Root cause (verified at code level)

- `workflow.py` L640-654: Coordinator switch-case correctly routes to DirectorAgent when `msg.next_agent == \"director\"` AND `director_calls < max`. The lane is wired.
- `agents.py` L109-115 (before fix): CoordinatorAgent had 6 tools, none of which could set `state._next_agent`. `designate_next_agent` was only registered on CriticTools.
- `instructions.py` L130 (before fix): COORDINATOR_AGENT_INSTRUCTIONS told the Coordinator to call `designate_next_agent(\"director\")` — a tool that did **not exist** in CoordinatorTools. The LLM saw the instruction, found no matching tool, and fell back to `mark_sorry_intractable` which terminated the session.
- `tools.py` `mark_sorry_intractable` (before fix): accepted any call unconditionally → 0 cost to abandon.
- `workflow.py` AgentExecutor (before fix): never consumed `state._next_agent` to set `msg.next_agent`, so even if a tool set the state designation, the routing edge couldn't see it.

## Fix (F9)

1. **`state.py`** — add `director_consulted: bool = False` and `director_consulted_count: int = 0` flags
2. **`workflow.py`** AgentExecutor — bridge `state.consume_next_agent_designation()` → `msg.next_agent` after each agent run; set `state.director_consulted = True` when DirectorAgent yields
3. **`tools.py`** CoordinatorTools — new `request_director_guidance(reason)` tool that calls `state.designate_next_agent(\"DirectorAgent\")`. Gate `mark_sorry_intractable` to REFUSE when `state.director_consulted is False`, with a recovery message pointing to the new tool.
4. **`agents.py`** — register `request_director_guidance` in CoordinatorAgent's tools list (now 7 tools)
5. **`instructions.py`** COORDINATOR_AGENT_INSTRUCTIONS — replace dead reference to `designate_next_agent(\"director\")` with the new tool, add F9 gate explanation + workflow

## Tests

`pytest tests/test_prover_guards.py -x -q` — **35/35 pass** (32 existing + 3 new F9 tests):
- `test_f9_intractable_refused_before_director_consultation` — refused, recovery message correct, `state.intractable` stays False
- `test_f9_request_director_guidance_designates_director` — `consume_next_agent_designation()` returns `\"DirectorAgent\"`
- `test_f9_intractable_accepted_after_director_consultation` — after `state.director_consulted = True`, intractable proceeds normally

## Test plan

- [x] `py_compile` clean on 5 modified prover modules
- [x] 32/32 existing prover guard tests pass
- [x] 3/3 new F9 unit tests pass
- [ ] DEMO 18 BG launch (follow-up commit): verify Director actually gets invoked end-to-end on `gale_shapley_man_optimal` (L97)
- [ ] po-2026 cross-machine confirmation on stable_marriage_lean residual sorrys (man_optimal + woman_pessimal)

## Refs

- C37 forensic: [project_prover_c37_forensic_2026-05-16.md]
- Postmortem KB v4: [prover_postmortem_kb_v4_recos.md]
- F1/F7/F8 escalations: `workflow.py` L428-485
- Prior unsuccessful attempts: cycles 6/8/24/34 (F1/F7/F8 wall-clock didn't fire because Coordinator session-ended via intractable before VerifyExecutor accumulated enough fails)