### PR TITLE
docs(ml-pipeline): add Curriculum V2 KEEPERS summary to ML-Training-Pipeline README

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/README.md
@@ -2,6 +2,23 @@
 
 Complete training pipeline for ML models on financial OHLCV data. Designed for GPU training with CPU dry-run validation. All GPU scripts use thermal-safe training via `shared/gpu_training.py` (MAX_TEMP=80C, AMP, batch_thermal_check).
 
+## Curriculum V2 — Validated Keepers (2026-05-16, gate FERMEE)
+
+After 8 stages tested (S1–S8) on anti-FAANG/Mag7 universe (SPY, TLT, XLF, XLK, XLE, XLV, XLY, XLI, XLB, XLU, XLP), **4 KEEPERS** confirmed under strict OOS 2027 holdout, walk-forward 5-fold expanding, 4-seed block bootstrap (22-day blocks), tx costs 10bps rebalance + 50bps stress :
+
+| Stage | Strategy | Δ-Sharpe | Stat. Significance | MaxDD | Script |
+|-------|----------|----------|--------------------|-------|--------|
+| S1 vol | **M12 HAR-RV-J** (jump-augmented HAR) | n/a | p=0.0015 (56/84 sign-test) | n/a | `m12_har_rv_j.py` |
+| S1 vol | **M15 LSTM h=32** (log-RV LSTM) | n/a | p=0.0107 (53/84 sign-test) | n/a | `m15_lstm_rv.py` |
+| S3 regime | **HMM Regime** (2-state, daily) | **+0.669** | 4/4 seeds positive | -39.1% | `s3_hmm_regime.py` |
+| S4 v2 | **Inverse-vol Ridge + HMM** | **+0.325** | 4/4 seeds positive | -17.7% | `s4_inverse_vol_ridge_v2.py` |
+
+S1 long-horizon sweep also produced **8 BEATS multi-coin sur 16** (XRP h=66 13.5σ, ETH h=132 5.0σ, BTC h=22/66 BEATS). Reco portfolio : **S3 + S4 v2 monthly rebalance, Sharpe ~1.12**.
+
+**Rejected stages** (NO BEATS) : S2 vol-ensembles (DM, MLP, GSP), S5 stop-loss overlays, S6 LO-only sectors, S7 composites, S8 long-horizon classifiers (dir_acc ≠ edge).
+
+> Detail complet : [`docs/Curriculum_V2_Meta_Analysis.md`](docs/Curriculum_V2_Meta_Analysis.md) — méthodologie, ablations, leçons. Pivot V2 documenté dans [`CURRICULUM.md`](CURRICULUM.md). 3 projets QC Cloud ESGF déployés à partir de ces KEEPERS — cf [`../ESGF-2026/README.md`](../ESGF-2026/README.md).
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

Adds a synthetic *Curriculum V2 — Validated Keepers* block at the top of `ML-Training-Pipeline/README.md`, summarizing the **4 strategies hardened** through the S1–S8 gate closure (2026-05-16).

The detail (methodology, ablations, lessons) already lives in [`docs/Curriculum_V2_Meta_Analysis.md`](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/docs/Curriculum_V2_Meta_Analysis.md) — this PR makes the README **point** to it instead of leaving the top-level reader unaware.

## What's added

A 1-table summary of the 4 KEEPERS with their underlying script :

| Stage | Strategy | Δ-Sharpe | Significance | Script |
|---|---|---|---|---|
| S1 vol | M12 HAR-RV-J | n/a | p=0.0015 | `m12_har_rv_j.py` |
| S1 vol | M15 LSTM h=32 | n/a | p=0.0107 | `m15_lstm_rv.py` |
| S3 regime | HMM Daily 2-state | **+0.669** | 4/4 seeds | `s3_hmm_regime.py` |
| S4 v2 | Inverse-vol Ridge + HMM | **+0.325** | 4/4 seeds | `s4_inverse_vol_ridge_v2.py` |

Plus a S1 long-horizon callout (8 BEATS multi-coin sur 16) and the **NO BEATS rejected stages list** (S2/S5/S6/S7/S8) — important for future students/agents to avoid re-running these experiments.

Cross-links inserted to :
- [`CURRICULUM.md`](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/CURRICULUM.md) (already updated with V2 box header)
- [`../ESGF-2026/README.md`](https://github.com/jsboige/CoursIA/blob/docs/esgf-readme-keepers-2026-05-17/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/README.md) (updated in companion PR #1228)

## Why now

User directive 2026-05-17 (4-part) : *\"Est-ce que nos contenus et readme trading sont à jour ?\"*

The README has been tracking M12/M15 verdicts (line 169-172) but was silent on the S3/S4 regime+ML KEEPERS confirmed in cycle 60+62 hardening. Pre-V2 stages (Stage 0/1/2/3/4) are still documented for historical context — V2 is added on top.

## Test plan

- [x] Diff = 1 fichier (README.md), +17 lignes, 0 suppression
- [x] Aucun code/notebook/script touché
- [x] Tous les scripts cités (`m12_har_rv_j.py`, `m15_lstm_rv.py`, `s3_hmm_regime.py`, `s4_inverse_vol_ridge_v2.py`) existent dans `ML-Training-Pipeline/scripts/` (vérifiés via `ls`)
- [x] Tous les verdicts cités (M12 p=0.0015, M15 p=0.0107, S3 +0.669, S4 v2 +0.325) référencent la mémoire ML 2026 + `docs/Curriculum_V2_Meta_Analysis.md`

## Lien complémentaire

PR #1228 (ESGF-2026 README) — même cycle de documentation, à merger ensemble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)