### PR TITLE
chore(gitignore): ignore Playwright session screenshot debris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -646,8 +646,14 @@ videos/
 # regenerable via the audit tooling under slides/_tools
 /deck[0-9][0-9]-*.png
 /review-d[0-9][0-9]-*.png
+/[0-9][0-9]-*-slide-*.png
+/argumentum_*.png
+/argumentum_*.svg
 /.playwright-mcp/
 /calib/
+
+# Slidev pre-fix vs post-fix screenshot pairs (regenerable via Playwright)
+slides/*/analysis/_*.png
 
 # Slidev one-shot PDF exports (regenerable via `npx slidev export`)
 slides/*/export-current.pdf


### PR DESCRIPTION
## Summary

Ajout de 3 patterns gitignore pour les artefacts de screenshot de session :

- \`/[0-9][0-9]-*-slide-*.png\` : matches \`03-logique-slide-01.png\`, \`12-search-slide-15.png\` etc.
- \`/argumentum_*.{png,svg}\` : matches les screenshots de l'exploration Argumentum (initial, after-click, zoom, qrcode)
- \`slides/*/analysis/_*.png\` : matches les paires pre-fix / post-fix Playwright dans les dossiers analysis

## Why

Apres une session slidev/visual-audit (slide-improver agent ou Playwright manuel), une dizaine de screenshots de debug s'accumulent a la racine et dans \`slides/<deck>/analysis/\`. Ces fichiers sont regenerables a la demande et polluent \`git status\` (incident lors de la session preparation cours 2026-05-18).

## Verification

- [x] \`git status\` propre apres ajout des patterns (etait 15 untracked, devient 0)
- [x] Les .png plus anciens (\`auction_*\`, \`cfr_*\`, \`dqn_*\`, etc.) ne sont pas affectes (deja gitignored ailleurs ou intentionnels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)