### PR TITLE
docs(slides): Slidev frontmatter invariant (Issue #1238 follow-up)

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -141,3 +141,46 @@ Regles de base pour les images et le layout :
 - **Slides "Questions?"** conservees comme pauses respiratoires entre sections
 - **PPTX-reference en `.gitignore` ou committe** selon le deck : les renders PNG servent a l'audit visuel
 - **Cross-references notebooks** : chaque deck termine ses sections par un lien vers le notebook Jupyter correspondant
+
+## Invariants Slidev (regression-prone)
+
+Bugs silencieux observes sur le parser Slidev — a respecter strictement pour eviter les regressions.
+
+### Frontmatter par slide : **pas de ligne vide** entre `---` et la cle `layout:`
+
+**Probleme** : une ligne vide entre le separateur `---` et `layout: <name>` casse le parser YAML. Slidev rend alors `layout: section` comme texte litteral dans le body et la slide apparait vide / cassee.
+
+**Forme correcte** :
+
+```markdown
+---
+layout: section
+---
+
+# Plan du cours
+
+...
+```
+
+**Forme cassee** (a ne JAMAIS faire) :
+
+```markdown
+---
+
+layout: section
+---
+```
+
+**Detection** : `grep -nP "^---$\s*\n\s*\nlayout:" slides/<deck>/slides.md` (multiline mode).
+
+**Incident** : 2026-05-17 deck `03-logique` slide 2 (TOC) avait cette regression — corrigee dans PR #1239 (cours EPITA TODAY).
+
+### Layout `image-overlay` (HARD, issue #221)
+
+Images pleine-largeur : layout `image-overlay` avec texte par-dessus, **JAMAIS** en colonne droite (`two-cols` avec image a droite). Convention confirmee 5+ fois.
+
+### Verification visuelle obligatoire avant merge
+
+- Lancer `npx slidev slides.md --port 30XX` localement
+- Capture Playwright `?clicks=99` sur les slides modifiees (post-animations)
+- Audit `<deck>/analysis/visual-audit-deck<NN>.md` mis a jour si regression detectee


### PR DESCRIPTION
## Summary

Codify the Slidev frontmatter invariant discovered when fixing slide 2 of deck `03-logique` for the EPITA SymbolicAI course (2026-05-18). A blank line between `---` slide separator and `layout: <name>` key silently breaks the parser — `layout: section` renders as raw text and the slide appears empty.

This was fixed reactively in PR #1239 ; this PR documents the rule so future deck creation / editing avoids the regression.

## Scope

- `slides/README.md` only (+43 lines, no code changes)
- Added "Invariants Slidev (regression-prone)" section under "Decisions de conception"
- Consolidates 2 invariants:
  1. **NEW** : no blank line between `---` and `layout:` (HARD, regression source 2026-05-17)
  2. **EXISTING** : layout `image-overlay` for full-width images, never right-column (issue #221, confirmed 5+ times)
- Detection grep pattern documented + visual verification protocol

## Why now / why this PR

- ai-01 C69 dispatch listed this as my Track 4 (post-cours doc PR)
- Issue #1238 explicitly recommends this documentation
- Single-purpose PR (docs only, <50 lines but tightly scoped to ONE invariant rule + consolidation with #221), aligns with discipline G.5

## Verification

- `git diff --stat` : `1 file changed, 43 insertions(+)`
- Markdown lint warnings (line length >80) are consistent with existing README style — not fixed to avoid drive-by changes
- No notebook execution / build required (docs-only)

## Linked

- Issue #1238 (post-cours follow-up: 23 image regressions + Slidev invariant)
- PR #1239 (reactive fix — slides 1+2 deck 03-logique, MERGED 23:08Z 2026-05-17)
- PR #1253 (TP enrichment deck 03-logique, APPROVED + MERGEABLE — awaits ai-01 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)