### PR TITLE
docs(audio): update READMEs for Epic #1028 audiobook pipeline

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/README.md
@@ -4,28 +4,53 @@
 
 Ce module presente des cas d'usage concrets et des workflows de production pour l'audio generatif.
 
-**Dans le cadre du fil rouge podcast** : ce niveau met en oeuvre les workflows complets. [04-1](04-1-Educational-Audio-Content.ipynb) automatise la narration de cours (texte vers TTS avec structuration LLM). [04-2](04-2-Transcription-Pipeline.ipynb) gere la transcription batch avec sous-titres SRT pour les episodes longs. [04-3](04-3-Music-Composition-Workflow.ipynb) compose des bandes sonores en plusieurs etapes. [04-4](04-4-Audio-Video-Sync.ipynb) synchronise l'audio genere avec la piste video.
+**Fil rouge podcast** : [04-1](04-1-Educational-Audio-Content.ipynb) automatise la narration de cours. [04-2](04-2-Transcription-Pipeline.ipynb) gere la transcription batch avec sous-titres SRT. [04-3](04-3-Music-Composition-Workflow.ipynb) compose des bandes sonores. [04-4](04-4-Audio-Video-Sync.ipynb) synchronise l'audio avec la video.
 
-## Vue d'overview
+**Fil rouge audiobook (Epic #1028)** : [04-6](04-6-Audiobook-Pipeline.ipynb) a [04-12](04-12-Compilation-Audio_output.ipynb) forment un pipeline agentique 5-pass complet : benchmark des voix, analyse litteraire, casting vocal, annotation prosodique, generation TTS et compilation finale.
+
+## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 5 |
+| Notebooks | 12 |
 | Kernel | Python 3 |
-| Duree estimee | ~4-6h |
+| Duree estimee | ~8-12h |
 | GPU requis | 0-14GB |
 
 ## Notebooks
+
+### Workflows generaux
 
 | # | Notebook | Contenu | Service | VRAM |
 |---|----------|---------|---------|------|
 | 1 | [04-1-Educational-Audio-Content](04-1-Educational-Audio-Content.ipynb) | Narration automatique de cours | Mixed | ~10 GB |
 | 2 | [04-2-Transcription-Pipeline](04-2-Transcription-Pipeline.ipynb) | Batch transcription, sous-titres SRT | Mixed | ~12 GB |
-| 3 | [04-3-Music-Composition-Workflow](04-3-Music-Composition-Workflow.ipynb) | Création musicale multi-étapes | Local GPU | ~14 GB |
+| 3 | [04-3-Music-Composition-Workflow](04-3-Music-Composition-Workflow.ipynb) | Creation musicale multi-etapes | Local GPU | ~14 GB |
 | 4 | [04-4-Audio-Video-Sync](04-4-Audio-Video-Sync.ipynb) | Synchronisation audio-video | Mixed | ~10 GB |
 | 5 | [04-5-LiveCoding-LLM-Music](04-5-LiveCoding-LLM-Music.ipynb) | Strudel.cc + LLM, live coding musical | OpenAI API | 0 |
 
-## Prérequis
+### Pipeline Audiobook Agentique (Epic #1028)
+
+Pipeline complet de 7 notebooks pour generer un audiobook a partir d'un texte litteraire, avec selection de voix, annotation prosodique et compilation finale.
+
+| # | Notebook | Pass | Contenu | Service | VRAM |
+| --- | ---------- | ------ | --------- | --------- | ------ |
+| 6 | [04-6-Audiobook-Pipeline](04-6-Audiobook-Pipeline.ipynb) | P0 | Pipeline audiobook orchestrateur | Mixed | ~10 GB |
+| 7 | [04-7-TTS-Voice-Benchmark](04-7-TTS-Voice-Benchmark.ipynb) | P0 | Benchmark comparatif des modeles TTS | Kokoro + OpenAI | ~2 GB |
+| 8 | [04-8-Lecture-Analytique](04-8-Lecture-Analytique.ipynb) | P1 | Analyse litteraire, segmentation dialogues/narration | OpenAI API | 0 |
+| 9 | [04-9-Voice-Casting](04-9-Voice-Casting.ipynb) | P2 | Attribution de voix par personnage, casting vocal | OpenAI API | 0 |
+| 10 | [04-10-Annotation-Prosodique](04-10-Annotation-Prosodique.ipynb) | P3 | Tags prosodiques FishAudio S2-Pro | OpenAI API | 0 |
+| 11 | [04-11-Generation-TTS](04-11-Generation-TTS_output.ipynb) | P4 | Generation audio Kokoro multi-voix | Kokoro TTS | ~2 GB |
+| 12 | [04-12-Compilation-Audio](04-12-Compilation-Audio_output.ipynb) | P5 | Concatenation FFmpeg + normalisation loudness | FFmpeg | 0 |
+
+**Flux du pipeline audiobook** :
+
+```text
+P0 Benchmark voix → P1 Analyse litteraire → P2 Casting vocal
+    → P3 Annotation prosodique → P4 Generation TTS → P5 Compilation finale
+```
+
+## Prerequis
 
 ### API Keys
 ```bash
@@ -33,56 +58,46 @@ Ce module presente des cas d'usage concrets et des workflows de production pour 
 OPENAI_API_KEY=sk-...
 ```
 
-### Dépendences
+### Dependances
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-audio.txt
 pip install moviepy  # Pour synchronisation A/V
 pip install strudel  # Pour live coding musical
+pip install pydub    # Pour manipulation audio
+# FFmpeg requis pour 04-12 (compilation audio)
 ```
-
-## Cas d'usage
-
-### 04-1 Educational Audio Content
-- **Objectif** : Automatiser la narration de contenus pédagogiques
-- **Technologies** : TTS + GPT-4o + post-processing
-- **Applications** : E-learning, podcasts éducatifs, contenu multilingue
-
-### 04-2 Transcription Pipeline
-- **Objectif** : Traitement batch de fichiers audio
-- **Technologies** : Whisper STT + post-processing SRT
-- **Applications** : Sous-titrage automatique, archives audio, compliance
-
-### 04-3 Music Composition Workflow
-- **Objectif** : Workflow de création musicale assistée
-- **Technologies** : MusicGen + MIDI + post-production
-- **Applications** : Production musicale, sound design, jingles
-
-### 04-4 Audio-Video Sync
-- **Objectif** : Synchroniser l'audio et la vidéo automatiquement
-- **Technologies** : Audio analysis + video processing
-- **Applications** : Dubbing, lip-sync correction, corrections post-production
-
-### 04-5 LiveCoding LLM Music
-- **Objectif** : Composition musicale en temps réel avec LLM
-- **Technologies** : Strudel.cc + OpenAI API
-- **Applications** : Performance live, expérimentation musicale
 
 ## Workflows
 
-### Éducation
-```
-Contenu texte → GPT-4o (structuration) → TTS Narration → Sous-titres → Export
+### Education
+
+```text
+Contenu texte -> GPT-4o (structuration) -> TTS Narration -> Sous-titres -> Export
 ```
 
 ### Production Podcast
-```
-Audio brut → STT → Correction → Enhance → TTS → Podcast final
+
+```text
+Audio brut -> STT -> Correction -> Enhance -> TTS -> Podcast final
 ```
 
 ### Musique
+
+```text
+Texte -> MusicGen -> Edition MIDI -> Post-production -> Export
 ```
-Texte → MusicGen → Édition MIDI → Post-production → Export
+
+### Audiobook Agentique (Epic #1028)
+
+```text
+Texte litteraire -> Benchmark voix (P0)
+    -> Segmentation dialogue/narration (P1)
+    -> Casting vocal par personnage (P2)
+    -> Annotation prosodique [whisper][shout][cold] (P3)
+    -> Generation TTS multi-voix Kokoro (P4)
+    -> FFmpeg concat + loudnorm (P5)
+    -> Audiobook final MP3
 ```
 
 ## Ressources

--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -4,7 +4,7 @@
 
 Le traitement audio est souvent le parent pauvre de l'IA generative, eclipsé par les images et le texte. Pourtant, la voix et la musique sont les modalites les plus naturelles de l'interaction humaine. Cette serie couvre l'ensemble de la chaine audio IA : reconnaissance vocale, synthese, clonage, generation musicale, et orchestration de pipelines.
 
-21 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production.
+28 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028).
 
 ## Fil rouge : construire un podcast automatise
 
@@ -17,7 +17,7 @@ Audio/
 ├── 01-Foundation/     # STT, TTS, bases audio (5 notebooks)
 ├── 02-Advanced/       # Voice cloning, musique, MIDI, chansons, TTS expressif (8 notebooks)
 ├── 03-Orchestration/  # Multi-modeles, temps reel (3 notebooks)
-└── 04-Applications/   # Education, production, sync A/V, live coding (5 notebooks)
+└── 04-Applications/   # Education, production, sync A/V, live coding, audiobook (12 notebooks)
 ```
 
 ## Progression par niveau
@@ -61,7 +61,7 @@ Les composants existent, il faut les assembler. Ce niveau construit les pipeline
 
 ### 04-Applications - Cas d'usage production
 
-Application directe : les notebooks de ce niveau mettent en oeuvre des workflows complets. 04-1 automatise la narration de cours (TTS + LLM), 04-2 traite la transcription batch avec sous-titres SRT, 04-3 compose de la musique en plusieurs etapes, 04-4 synchronise audio et video, et 04-5 explore le live coding musical avec un LLM.
+Application directe : les notebooks de ce niveau mettent en oeuvre des workflows complets. 04-1 a 04-5 couvrent la narration de cours, la transcription batch, la composition musicale, la synchronisation audio-video et le live coding. 04-6 a 04-12 forment un pipeline audiobook agentique complet (Epic #1028) : benchmark des voix, analyse litteraire, casting vocal, annotation prosodique, generation TTS et compilation finale.
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|
@@ -70,6 +70,13 @@ Application directe : les notebooks de ce niveau mettent en oeuvre des workflows
 | [04-3-Music-Composition-Workflow](04-Applications/04-3-Music-Composition-Workflow.ipynb) | Creation musicale multi-etapes | Local GPU | ~14 GB |
 | [04-4-Audio-Video-Sync](04-Applications/04-4-Audio-Video-Sync.ipynb) | Synchronisation audio-video | Mixed | ~10 GB |
 | [04-5-LiveCoding-LLM-Music](04-Applications/04-5-LiveCoding-LLM-Music.ipynb) | Strudel.cc + LLM, live coding musical | OpenAI API | 0 |
+| [04-6-Audiobook-Pipeline](04-Applications/04-6-Audiobook-Pipeline.ipynb) | Pipeline audiobook orchestrateur | Mixed | ~10 GB |
+| [04-7-TTS-Voice-Benchmark](04-Applications/04-7-TTS-Voice-Benchmark.ipynb) | Benchmark comparatif TTS | Kokoro + OpenAI | ~2 GB |
+| [04-8-Lecture-Analytique](04-Applications/04-8-Lecture-Analytique.ipynb) | Analyse litteraire, segmentation | OpenAI API | 0 |
+| [04-9-Voice-Casting](04-Applications/04-9-Voice-Casting.ipynb) | Attribution voix par personnage | OpenAI API | 0 |
+| [04-10-Annotation-Prosodique](04-Applications/04-10-Annotation-Prosodique.ipynb) | Tags prosodiques FishAudio S2-Pro | OpenAI API | 0 |
+| [04-11-Generation-TTS](04-Applications/04-11-Generation-TTS_output.ipynb) | Generation TTS multi-voix Kokoro | Kokoro TTS | ~2 GB |
+| [04-12-Compilation-Audio](04-Applications/04-12-Compilation-Audio_output.ipynb) | FFmpeg concat + normalisation | FFmpeg | 0 |
 
 ## Technologies
 
@@ -77,7 +84,7 @@ Application directe : les notebooks de ce niveau mettent en oeuvre des workflows
 |-------------|-----------|-----------|
 | **OpenAI TTS/STT** | 01-1, 01-2 | `OPENAI_API_KEY` |
 | **Whisper V3 Turbo** | 01-4 | GPU ~10 GB VRAM |
-| **Kokoro TTS** | 01-5 | GPU ~2 GB VRAM |
+| **Kokoro TTS** | 01-5, 04-11 | GPU ~2 GB VRAM |
 | **Chatterbox Turbo** | 02-1 | GPU ~8 GB VRAM |
 | **XTTS v2** | 02-2 | GPU ~6 GB VRAM |
 | **MusicGen (Meta)** | 02-3 | GPU ~10 GB VRAM |
@@ -87,6 +94,7 @@ Application directe : les notebooks de ce niveau mettent en oeuvre des workflows
 | **YuE / SongGeneration 2** | 02-7 | GPU 10-24 GB VRAM |
 | **Fish S2 Pro / Dia TTS** | 02-8 | GPU 6-18 GB VRAM |
 | **OpenAI Realtime API** | 03-3 | `OPENAI_API_KEY` |
+| **FFmpeg** | 04-12 | Installe systeme |
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Update `04-Applications/README.md` from 5 to 12 notebooks (add Epic #1028 audiobook pipeline P0-P5)
- Update parent `Audio/README.md`: notebook count 21->28, tree structure, technologies table
- Add audiobook workflow diagram and pipeline documentation

## Context
Track 3 GenAI enrichment — documentation drift after 7 new audiobook notebooks (04-6 through 04-12) added by Epic #1028.

## Test plan
- [x] Both READMEs render correctly (markdown tables, links, code blocks)
- [x] All notebook links point to existing files
- [x] Statistics consistent between parent and child README

🤖 Generated with [Claude Code](https://claude.com/claude-code)