### PR TITLE
docs(audio): Epic #1028 delivery date + post-mortem link

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -4,7 +4,7 @@
 
 Le traitement audio est souvent le parent pauvre de l'IA generative, eclipsé par les images et le texte. Pourtant, la voix et la musique sont les modalites les plus naturelles de l'interaction humaine. Cette serie couvre l'ensemble de la chaine audio IA : reconnaissance vocale, synthese, clonage, generation musicale, et orchestration de pipelines.
 
-28 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028).
+28 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028, livre 18/05/2026, 8 PRs, post-mortem [ici](../../docs/epic-1028-audiobook-postmortem.md)).
 
 ## Fil rouge : construire un podcast automatise
 


### PR DESCRIPTION
## Summary
- Add Epic #1028 delivery date (18/05/2026) and post-mortem doc link to Audio README intro

## Context
Track A dispatch C72: verify audiobook final committed + update README with delivery note.
- `boule_de_suif_finalized.mp3` (2.0 MB) confirmed in `audiobook_final/` (merged via #1254)
- Issue #1028 already CLOSED
- Catalog drift check: all markers up-to-date (473 entries, 0 drift)

## Test plan
- [ ] Verify README link to post-mortem resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)