### PR TITLE
fix(slides/03-logique): wrap slide 18 text to prevent img_014 overlap

### DIFF
--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -394,6 +394,8 @@ layout: default
 <img src="./images/img_014.png" style="position:absolute; top:50px; right:10px; width:380px;" alt="Equivalences logiques et chainage" />
 <img src="./images/img_013.png" style="position:absolute; bottom:20px; right:20px; width:180px;" alt="Clauses Forward Chaining" />
 
+<div style="max-width: 58%;">
+
 ## Forward Chaining (chaine avant)
 
 - Partir des faits connus
@@ -410,6 +412,8 @@ layout: default
 
 - Forward: mieux quand les faits sont peu nombreux et les buts nombreux
 - Backward: mieux quand les buts sont peu nombreux et les faits nombreux
+
+</div>
 
 ---
 layout: default


### PR DESCRIPTION
Slide 18 'Forward et Backward Chaining' : img_014.png (380px wide, top-right) chevauchait la 3e ligne du bullet Forward Chaining. Wrap les 3 sections H2 (Forward / Backward / Comparaison) dans div style='max-width: 58%' (+4 lignes). Pattern slide 142 L1656. Verification visuelle Playwright 1920x1080 OK, 126 slides inchanges. Iter 2 prereprise cours EPITA SCIA dispatch ai-01.