### PR TITLE
fix(prover): B2 Director-Tactic gap + cumulative re-escalade (#1224)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/__init__.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/__init__.py
@@ -1,7 +1,7 @@
 """Multi-Agent Lean 4 Proof System -- Microsoft Agent Framework."""
 
 from .provers import MultiAgentSorryProver, AutonomousProver
-from .config import PROVIDERS, DEMOS
+from .config import PROVIDERS, DEMOS, PROVED_DEMOS
 from .trace import TraceLogger
 from .state import ProofState, SorryContext
 
@@ -10,6 +10,7 @@ __all__ = [
     "AutonomousProver",
     "PROVIDERS",
     "DEMOS",
+    "PROVED_DEMOS",
     "TraceLogger",
     "ProofState",
     "SorryContext",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -634,30 +634,20 @@ DEMOS = {
     15: {
         "name": "GALESHAPLEY_STABLE",
         "file": str(GALESHAPLEY_FILE),
-        "line": 73,
+        "line": 64,  # was L73, shifted after gsFinalMatching insertion
         "sorry_type": "sorry_replacement",
         "theorem_name": "gale_shapley_stable",
         "theorem": "gale_shapley_stable",
         "imports": GALESHAPLEY_IMPORTS,
         "description": (
-            "Replace sorry at L73 of GaleShapley.lean.\n"
-            "Prove gale_shapley_stable: for any preference profile,\n"
-            "there exists a stable matching.\n"
-            "Strategy: provide gsGaleShapley as constructive witness,\n"
-            "then prove IsStable via no-blocking-pair argument.\n"
-            "Key invariants (already stubbed in Lemmas.lean):\n"
-            "  - GSConsistent.runSteps: final matching is consistent\n"
-            "  - menProposedDownward.runSteps: men proposed in pref order\n"
-            "  - womenBestState.runSteps: women keep best proposal\n"
-            "  - menMatchedProposed.runSteps: matched men proposed\n"
-            "Reference: mmaaz-git/stable-marriage-lean Properties.lean\n"
-            "  galeShapley_noBlockingPairs uses menProposedDownwardState +\n"
-            "  womenBestState + menMatchedProposedState to derive\n"
-            "  contradiction from any blocking pair.\n"
-            "Our type system: total bijections (no `acceptable` filter).\n"
+            "PROVED (PR #1194, 2026-05-16). Do NOT target.\n"
+            "Originally: gale_shapley_stable proved via gsFinalMatching\n"
+            "+ gsAllWomenMatched + gsNoBlockingPairs (6-step contradiction).\n"
             "LEAN_PROJECT must be overridden to stable_marriage_lean."
         ),
         "difficulty": "very_hard",
+        "proved": True,
+        "proved_pr": 1194,
     },
     16: {
         "name": "GALESHAPLEY_MAN_OPTIMAL",
@@ -1100,4 +1090,14 @@ DEMOS = {
             "  sorry  -- TODO: complete trichotomy argument"
         ),
     },
+}
+
+# DEMOS already proved — the prover MUST NOT target these. Lemmas.lean has
+# 0 sorry (all proved 2026-05-15/16), so DEMOS 18-28 are stale. DEMO 15
+# (gale_shapley_stable) was proved in PR #1194. The prover skips any DEMO
+# whose key appears in this set.
+PROVED_DEMOS = {
+    15,  # gale_shapley_stable (PR #1194)
+    # 18-28: all Lemmas.lean entries (GSConsistent, menProposed, womenBest, etc.)
+    18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -19,7 +19,7 @@ sys.stderr.reconfigure(line_buffering=True)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from prover import DEMOS, TraceLogger
+from prover import DEMOS, PROVED_DEMOS, TraceLogger
 from prover.provers import MultiAgentSorryProver, AutonomousProver
 from prover.config import create_client
 
@@ -36,6 +36,9 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         if demo_num not in DEMOS:
             print(f"Demo {demo_num} not found. Available: {sorted(DEMOS.keys())}")
             sys.exit(1)
+        if demo_num in PROVED_DEMOS:
+            print(f"Demo {demo_num} ({DEMOS[demo_num]['name']}) is PROVED — skipping.")
+            sys.exit(0)
         demo = DEMOS[demo_num]
         filepath = demo["file"]
         line = demo.get("line")

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -68,6 +68,11 @@ class ProofMessage:
     # Director (Track C): counts how many times the DirectorAgent has been
     # consulted this session. Capped at 3 to avoid budget burn.
     director_calls: int = 0
+    # B2a (issue #1224): identifiers the Director flagged as absent from
+    # Mathlib / the current project. TacticAgent receives a warning to NOT
+    # try these identifiers. Populated by AgentExecutor after DirectorAgent
+    # runs; consumed when TacticAgent receives the message.
+    absent_identifiers: list = None
 
 
 class AgentExecutor(Executor):
@@ -113,6 +118,27 @@ class AgentExecutor(Executor):
             plan_header += "\n".join(f"  {i+1}. {step}" for i, step in enumerate(msg.plan))
             plan_header += "\n\n---\n"
             content = plan_header + content
+
+        # B2a (issue #1224): Inject absent-identifier warning for TacticAgent.
+        # When the Director flagged identifiers as absent, TacticAgent must
+        # NOT try `exact <absent_id>` — it will always produce "unknown
+        # identifier". This prevents the Director→Tactic gap where the
+        # Director says "X doesn't exist" but TacticAgent still tries X.
+        if (msg.absent_identifiers
+                and self._agent.name == "TacticAgent"):
+            warning = (
+                "WARNING — ABSENT IDENTIFIERS (Director-confirmed). "
+                "Do NOT use these in any tactic; they do not exist in "
+                "Mathlib or the current project:\n"
+            )
+            for ident in msg.absent_identifiers:
+                warning += f"  - {ident}\n"
+            warning += (
+                "If the Director suggested a tactic using any of these, "
+                "you must find an alternative identifier or decompose the "
+                "goal differently.\n\n---\n"
+            )
+            content = warning + content
 
         # NOTE: do NOT wrap `agent.run` in `asyncio.wait_for`. The framework's
         # AgentTelemetryLayer sets/resets a ContextVar Token internally; running
@@ -218,6 +244,36 @@ class AgentExecutor(Executor):
                     agent="DirectorAgent", role="director_call",
                     content=f"director call {msg.director_calls}/3",
                 )
+
+            # B2a (issue #1224): Parse Director output for identifiers the
+            # Director explicitly flags as absent. Pattern examples:
+            #   "identifier X doesn't exist"
+            #   "X is absent from Mathlib"
+            #   "X not found"
+            #   "Mathlib doesn't have X"
+            # Store them so TacticAgent gets a warning to NOT try them.
+            import re as _re
+            _absent_patterns = [
+                r"identifier\s+(\S+)\s+(?:doesn'?t|does not)\s+exist",
+                r"(\S+)\s+is\s+absent\s+from\s+Mathlib",
+                r"(\S+)\s+not\s+found(?:\s+in\s+Mathlib)?",
+                r"Mathlib\s+(?:doesn'?t|does not)\s+have\s+(\S+)",
+                r"no\s+lemma\s+(?:called\s+)?['\"]?(\S+?)['\"]?",
+                r"(\S+)\s+is\s+not\s+in\s+Mathlib",
+            ]
+            absent = []
+            for pat in _absent_patterns:
+                for m in _re.finditer(pat, response_text, _re.IGNORECASE):
+                    ident = m.group(1).strip("`'\".,;:)")
+                    if ident and ident not in absent and len(ident) < 60:
+                        absent.append(ident)
+            if absent:
+                msg.absent_identifiers = absent
+                if self._trace:
+                    self._trace.log(
+                        agent="DirectorAgent", role="absent_identifiers",
+                        content=f"flagged absent: {absent}",
+                    )
 
         # F5: Coordinator can mark the current sorry intractable. End the
         # session cleanly so we don't waste iterations on a known-dead goal.
@@ -330,6 +386,14 @@ class VerifyExecutor(Executor):
         # now hard-coded into F1 routing.
         self._has_director = has_director
         self._director_max_calls = director_max_calls
+        # B2c (issue #1224): cumulative fail counter that NEVER resets on
+        # decomposition. The existing _consecutive_build_fails resets to 0
+        # when TacticAgent submits a decomposition, which means the Director
+        # escalation threshold is never reached in sessions with many
+        # decompositions. This counter keeps climbing and triggers Director
+        # re-escalade after _cumulative_fails_threshold fails regardless.
+        self._cumulative_fails = 0
+        self._cumulative_fails_threshold = 5
         # Re-search trigger: after this many total fails, force a hint to
         # the Critic that fresh lemmas may be needed. The Critic still makes
         # the routing decision, but the hint makes re-search more likely.
@@ -438,6 +502,7 @@ class VerifyExecutor(Executor):
             if not is_probe_error:
                 self._consecutive_build_fails += 1
                 self._total_fails += 1
+                self._cumulative_fails += 1  # B2c: never resets
             elif self._trace:
                 self._trace.log(
                     agent="VerifyExecutor", role="probe_filter",
@@ -471,6 +536,37 @@ class VerifyExecutor(Executor):
                                  f"{self._director_max_calls})"),
                     )
                 self._consecutive_build_fails = 0
+            # B2c (issue #1224): cumulative fail re-escalade. Decompositions
+            # reset _consecutive_build_fails to 0, which means the F1
+            # escalation threshold (default 5) is never reached when the
+            # prover alternates between decompositions and build-fails. This
+            # counter never resets and forces Director re-escalade at a fixed
+            # threshold. This fires ONLY if the other escalation paths haven't
+            # already triggered (wallclock or consecutive).
+            elif (self._cumulative_fails >= self._cumulative_fails_threshold
+                    and self._has_director
+                    and msg.director_calls < self._director_max_calls):
+                msg.next_agent = "director"
+                msg.error = (
+                    f"[B2c cumulative re-escalade -> Director] "
+                    f"{self._cumulative_fails} cumulative BUILD-FAIL "
+                    f"(consecutive was reset to {self._consecutive_build_fails} "
+                    f"by decompositions). Forcing Director invocation. "
+                    f"Last error: {msg.error}"
+                )
+                if self._trace:
+                    self._trace.log(
+                        agent="VerifyExecutor", role="b2c_cumulative_escalation",
+                        content=(f"cumulative_fails={self._cumulative_fails} >= "
+                                 f"threshold={self._cumulative_fails_threshold}, "
+                                 f"consecutive={self._consecutive_build_fails} "
+                                 f"(reset by decomp), forcing Director "
+                                 f"(calls={msg.director_calls}/"
+                                 f"{self._director_max_calls})"),
+                    )
+                self._consecutive_build_fails = 0
+                # Reset cumulative so we don't re-trigger immediately
+                self._cumulative_fails = 0
             elif self._consecutive_build_fails >= self._escalation_threshold:
                 # F1: deterministic escalation. Critic prompt heuristics
                 # aren't reliable enough — when the same sorry_line has


### PR DESCRIPTION
> **G.4 compliance note (2026-05-19)**: PR force-pushed to keep ONLY prover B2 scope (4 files). CI workflow + docs split to separate PR. Slides hunk already merged via #1269.

## Summary

- **B2a**: Director output parsed for absent identifiers (6 regex patterns). TacticAgent receives explicit WARNING to NOT try flagged identifiers — closes the gap where Director says "X doesn't exist" but TacticAgent still tries `exact X`.
- **B2c**: VerifyExecutor cumulative BUILD-FAIL counter (never resets on decomposition) triggers Director re-escalade at threshold >= 5, even when consecutive counter was reset by successful decomposition.
- **Chore**: DEMO 15 marked PROVED (PR #1194). PROVED_DEMOS exclusion set (15, 18-28) added to config.py + __init__.py. run_prover_bg.py skips proved demos.

## Scope: 4 files (single domain — prover Python)

| File | Change |
|------|--------|
| `workflow.py` | B2a absent identifiers + B2c cumulative re-escalade |
| `config.py` | PROVED_DEMOS set + DEMO 15 proved marker |
| `__init__.py` | Export PROVED_DEMOS |
| `run_prover_bg.py` | Skip proved demos |

## Sorry count (PROVER Python files)

These are prover Python files, not Lean — no sorry to count. The sorry counts in Lean targets are unchanged by this PR.

```
grep -c sorry workflow.py → 0 (no sorry in Python)
grep -c sorry config.py   → 0
grep -c sorry run_prover_bg.py → 0
grep -c sorry __init__.py → 0
```

## Diff: F8/F1/F9 logic changes

**F8 (VerifyExecutor BUILD-FAIL path)** — workflow.py:
- Added `absent_identifiers` field to ProofMessage (L71-75)
- Added Director output parsing after DirectorAgent run (L249-275): 6 regex patterns detect "X doesn't exist" / "X is absent from Mathlib" etc.
- Added cumulative fail counter (`_cumulative_fails`) that NEVER resets on decomposition (L389-396)
- Added cumulative re-escalade trigger between wallclock and consecutive threshold checks (L539-569): routes to Director when cumulative >= 5

**F1 (TacticAgent entry)** — workflow.py:
- Before TacticAgent runs, injects WARNING header listing all absent identifiers from Director (L122-141). TacticAgent cannot use flagged identifiers.

**F9 (mark_sorry_intractable)** — NO CHANGE. F9 gate still requires Director consultation first.

## B2b deferred

SearchAgent error handler (retry/fallback provider) requires agent framework changes beyond this patch scope. Deferred to separate PR.

## Test plan

- [x] `python -c "import ast; ast.parse(open('workflow.py').read())"` passes
- [x] `python -c "import ast; ast.parse(open('config.py').read())"` passes
- [x] `python -c "import ast; ast.parse(open('run_prover_bg.py').read())"` passes
- [ ] `python run_prover_bg.py --demo 15` exits with "PROVED — skipping"
- [ ] `python run_prover_bg.py --demo 18` exits with "PROVED — skipping"
- [ ] `python run_prover_bg.py --demo 9 --mode multi --iterations 1` starts without import error