### PR TITLE
fix(slides/03-logique): fix cover bold + Plan du cours bullet list

### DIFF
--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -16,7 +16,7 @@ layout: cover
 
 <div class="grid grid-cols-1 gap-2 text-xl mt-8">
 
-- **Logique propositionnelle**
+- Logique propositionnelle
 - Logique du premier ordre
 - Planification
 - Representation des connaissances
@@ -29,13 +29,13 @@ layout: section
 
 # Plan du cours
 
-I. Introduction
-II. Resolution de problemes
-**III. Bases de connaissances et logique**
-IV. Raisonnement probabiliste
-V. Apprentissage
-VI. Traitement du langage naturel
-VII. TP final projets trimestriels
+- I. Introduction
+- II. Resolution de problemes
+- **III. Bases de connaissances et logique**
+- IV. Raisonnement probabiliste
+- V. Apprentissage
+- VI. Traitement du langage naturel
+- VII. TP final projets trimestriels
 
 ---
 layout: default


### PR DESCRIPTION
## Summary

Visual bug fixes identified by visual analysis of the rendered deck:

- **Cover slide**: `- **Logique propositionnelle**` — bold caused first bullet to render oversized and dominant (blue, large font) over the other bullets. Removed `**`.
- **Plan du cours slide**: 7 plan items lacked `- ` prefix, causing Markdown to concatenate them as a prose paragraph instead of a bullet list. Added `- ` to all 7 items; `**III.**` kept bold as the current chapter highlight.

## Test plan

- [ ] Reload Slidev at http://localhost:3030/ (slide 1: cover bullets equal weight; slide 2: plan items as list)
- [ ] Verify no overflow on either slide
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)