### PR TITLE
feat(symbolicai/semanticweb): terminal exercises for SW-1 + SW-2 (C# / dotNetRDF)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
@@ -451,6 +451,46 @@
     "\n",
     "**Navigation** : [Index](README.md) | [2-RDFBasics >>](SW-2-RDFBasics.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice : validez votre installation dotNetRDF\n",
+    "\n",
+    "Pour confirmer que votre environnement est correctement configure, creez un petit graphe RDF et affichez le nombre de triplets qu'il contient.\n",
+    "\n",
+    "**Objectif :** creer un graphe avec un seul triplet de votre choix (par exemple `<http://example.org/moi>` `<http://xmlns.com/foaf/0.1/name>` `\"Votre nom\"`), puis afficher `g.Triples.Count`.\n",
+    "\n",
+    "Completez la cellule ci-dessous : decommentez les etapes suggerees et remplacez les valeurs par les votres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice : validez votre installation dotNetRDF\n",
+    "// Etapes suggerees (decommentez et completez) :\n",
+    "//   using VDS.RDF;\n",
+    "//   IGraph g = new Graph();\n",
+    "//   IUriNode moi = g.CreateUriNode(UriFactory.Create(\"http://example.org/moi\"));\n",
+    "//   IUriNode name = g.CreateUriNode(UriFactory.Create(\"http://xmlns.com/foaf/0.1/name\"));\n",
+    "//   ILiteralNode monNom = g.CreateLiteralNode(\"Votre nom\");\n",
+    "//   g.Assert(new Triple(moi, name, monNom));\n",
+    "//   Console.WriteLine($\"Nombre de triplets : {g.Triples.Count}\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer\");"
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -1915,14 +1915,12 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "execution_count": null,
+   "execution_count": 16,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
+     "text": "Exercice a completer\r\n"
     }
    ],
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -604,7 +604,7 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "  DateTime -> 2026-04-21T03:58:44.219738+02:00^^http://www.w3.org/2001/XMLSchema#dateTime\r\n"
+      "  DateTime -> 2026-05-20T07:03:00.376029+02:00^^http://www.w3.org/2001/XMLSchema#dateTime\r\n"
      ]
     },
     {
@@ -1886,6 +1886,57 @@
     "- **Echange machine / streaming** : NTriples\n",
     "- **APIs Web et SEO** : JSON-LD\n",
     "- **Integration XML** : RDF/XML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## 7. Exercice : a vous de jouer\n",
+    "\n",
+    "Vous maitrisez maintenant les triplets, les trois types de noeuds, les namespaces et la serialisation. Mettez tout en pratique sur un cas concret.\n",
+    "\n",
+    "**Enonce** : Construisez un graphe RDF decrivant un livre :\n",
+    "\n",
+    "1. Un noeud **URI** pour le livre (ex : `ex:livre/RDF101`).\n",
+    "2. Un **literal type** (`xsd:integer`) pour l'annee de publication.\n",
+    "3. Un **literal avec tag de langue** (`@fr`) pour le titre.\n",
+    "4. Un **blank node** pour l'auteur, relie au livre via `ex:auteur`, avec un nom (literal simple).\n",
+    "5. Declarez les prefixes `ex` (http://example.org/) et `dc` (http://purl.org/dc/elements/1.1/).\n",
+    "6. Serialisez le graphe en **Turtle** et affichez-le, puis affichez le nombre de triplets (`g.Triples.Count`).\n",
+    "\n",
+    "**Indice** : reutilisez `UriFactory.Create`, `g.CreateLiteralNode(valeur, new Uri(...))` pour le type, `g.CreateLiteralNode(valeur, \"fr\")` pour la langue, `g.CreateBlankNode()`, `g.NamespaceMap.AddNamespace(...)` et `CompressingTurtleWriter`.\n",
+    "\n",
+    "Resultat attendu : un graphe de ~5-6 triplets serialise en Turtle lisible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exercice : votre code ici\n",
+    "// Etapes suggerees :\n",
+    "//   IGraph g = new Graph();\n",
+    "//   g.NamespaceMap.AddNamespace(\"ex\", UriFactory.Create(\"http://example.org/\"));\n",
+    "//   g.NamespaceMap.AddNamespace(\"dc\", UriFactory.Create(\"http://purl.org/dc/elements/1.1/\"));\n",
+    "//   ... creer les noeuds (URI, literals type/langue, blank node) ...\n",
+    "//   ... ajouter les triplets avec g.Assert(...) ...\n",
+    "//   ... serialiser en Turtle avec CompressingTurtleWriter ...\n",
+    "//   Console.WriteLine($\"Nombre de triplets : {g.Triples.Count}\");\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer\");\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Terminal unsolved exercises for the two **C# SemanticWeb** notebooks (the Python `-b-Python` variants are covered by the other SemanticWeb branches). Both re-executed with real outputs (C.2/H.3).

| Notebook | Kernel | Exercise | Exec |
|----------|--------|----------|------|
| SW-1-CSharp-Setup | .net-csharp | validez votre installation dotNetRDF (graphe 1 triplet) | 5/5, 0 err |
| SW-2-CSharp-RDFBasics | .net-csharp | exercice de fin RDF + fix ec=None (cell 48 -> ec 16) | 16/16, 0 err |

Stubs use `Console.WriteLine("Exercice a completer")` / commented scaffold — no `throw`/forbidden errors (C.1). Surgical single-cell execution preserves the existing committed outputs of the heavy dotNetRDF-nuget cells.

## Test plan
- [x] `execution_count != null` + outputs on all code cells, 0 errors
- [x] C.1 grep clean
- [x] No source/Solution deletions