### PR TITLE
feat(symbolicai): terminal exercises for notebooks missed by parallel branches (OR-tools, Planners-2, Tweety-1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
@@ -1129,6 +1129,47 @@
     "    Console.WriteLine($\"{nutrients[i].Name}: {nutrientsResult[i]:N2} (min {nutrients[i].Value})\");\n",
     "}"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice : etendre le modele du regime de Stigler\n",
+    "\n",
+    "Le modele resolu ci-dessus minimise le cout annuel sans plafonner la quantite d'un aliment. En pratique, on ne peut pas raisonnablement consommer une quantite illimitee d'un seul produit.\n",
+    "\n",
+    "**Objectif :** ajoutez une borne superieure sur chaque variable d'aliment (par exemple 20 unites maximum), puis re-resolvez le probleme et comparez le cout optimal obtenu avec celui du modele initial.\n",
+    "\n",
+    "Completez la cellule ci-dessous : decommentez les etapes suggerees et implementez-les."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exercice a completer\r\n"
+    }
+   ],
+   "source": [
+    "// Exercice : limiter la quantite de chaque aliment et re-resoudre\n",
+    "// Etapes suggerees (decommentez et completez) :\n",
+    "//   // 1. Reconstruire un solveur et des variables avec une borne superieure (ex: 20)\n",
+    "//   var solver2 = Solver.CreateSolver(\"GLOP\");\n",
+    "//   var foods2 = new List<Variable>();\n",
+    "//   for (int i = 0; i < data.Length; ++i)\n",
+    "//       foods2.Add(solver2.MakeNumVar(0.0, 20.0, data[i].Name)); // borne sup = 20\n",
+    "//   // 2. Re-creer les contraintes nutritionnelles (cf cellule precedente)\n",
+    "//   // 3. Re-definir l'objectif (minimiser le cout) puis appeler solver2.Solve()\n",
+    "//   // 4. Comparer solver2.Objective().Value() au cout du modele initial\n",
+    "\n",
+    "Console.WriteLine(\"Exercice a completer\");"
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -5,10 +5,10 @@
    "id": "1e73cc76",
    "metadata": {
     "papermill": {
-     "duration": 0.006022,
-     "end_time": "2026-05-19T19:05:08.261530+00:00",
+     "duration": 0.007092,
+     "end_time": "2026-05-20T05:23:32.311305",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.255508+00:00",
+     "start_time": "2026-05-20T05:23:32.304213",
      "status": "completed"
     },
     "tags": []
@@ -40,10 +40,10 @@
    "id": "c4e8063c",
    "metadata": {
     "papermill": {
-     "duration": 0.004833,
-     "end_time": "2026-05-19T19:05:08.271951+00:00",
+     "duration": 0.004569,
+     "end_time": "2026-05-20T05:23:32.320873",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.267118+00:00",
+     "start_time": "2026-05-20T05:23:32.316304",
      "status": "completed"
     },
     "tags": []
@@ -77,10 +77,10 @@
    "id": "61da6810",
    "metadata": {
     "papermill": {
-     "duration": 0.005162,
-     "end_time": "2026-05-19T19:05:08.282276+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T05:23:32.328874",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.277114+00:00",
+     "start_time": "2026-05-20T05:23:32.324873",
      "status": "completed"
     },
     "tags": []
@@ -129,10 +129,10 @@
    "id": "9d73442c",
    "metadata": {
     "papermill": {
-     "duration": 0.005691,
-     "end_time": "2026-05-19T19:05:08.293445+00:00",
+     "duration": 0.004508,
+     "end_time": "2026-05-20T05:23:32.337382",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.287754+00:00",
+     "start_time": "2026-05-20T05:23:32.332874",
      "status": "completed"
     },
     "tags": []
@@ -165,10 +165,10 @@
    "id": "c3f7db7c",
    "metadata": {
     "papermill": {
-     "duration": 0.006116,
-     "end_time": "2026-05-19T19:05:08.305534+00:00",
+     "duration": 0.003904,
+     "end_time": "2026-05-20T05:23:32.345287",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.299418+00:00",
+     "start_time": "2026-05-20T05:23:32.341383",
      "status": "completed"
     },
     "tags": []
@@ -199,10 +199,10 @@
    "id": "16fb8924",
    "metadata": {
     "papermill": {
-     "duration": 0.005515,
-     "end_time": "2026-05-19T19:05:08.316494+00:00",
+     "duration": 0.006008,
+     "end_time": "2026-05-20T05:23:32.355800",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.310979+00:00",
+     "start_time": "2026-05-20T05:23:32.349792",
      "status": "completed"
     },
     "tags": []
@@ -228,10 +228,10 @@
    "id": "f1a412c5",
    "metadata": {
     "papermill": {
-     "duration": 0.007935,
-     "end_time": "2026-05-19T19:05:08.332485+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T05:23:32.364799",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.324550+00:00",
+     "start_time": "2026-05-20T05:23:32.360799",
      "status": "completed"
     },
     "tags": []
@@ -261,10 +261,10 @@
    "id": "85660f8a",
    "metadata": {
     "papermill": {
-     "duration": 0.006936,
-     "end_time": "2026-05-19T19:05:08.346439+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T05:23:32.372305",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.339503+00:00",
+     "start_time": "2026-05-20T05:23:32.368306",
      "status": "completed"
     },
     "tags": []
@@ -296,10 +296,10 @@
    "id": "ab0044f0",
    "metadata": {
     "papermill": {
-     "duration": 0.005805,
-     "end_time": "2026-05-19T19:05:08.359242+00:00",
+     "duration": 0.004367,
+     "end_time": "2026-05-20T05:23:32.380674",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.353437+00:00",
+     "start_time": "2026-05-20T05:23:32.376307",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +318,16 @@
    "id": "05021c5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:08.372411Z",
-     "iopub.status.busy": "2026-05-19T19:05:08.372036Z",
-     "iopub.status.idle": "2026-05-19T19:05:08.379427Z",
-     "shell.execute_reply": "2026-05-19T19:05:08.378738Z"
+     "iopub.execute_input": "2026-05-20T05:23:32.391342Z",
+     "iopub.status.busy": "2026-05-20T05:23:32.391342Z",
+     "iopub.status.idle": "2026-05-20T05:23:32.413981Z",
+     "shell.execute_reply": "2026-05-20T05:23:32.413425Z"
     },
     "papermill": {
-     "duration": 0.015237,
-     "end_time": "2026-05-19T19:05:08.380218+00:00",
+     "duration": 0.028675,
+     "end_time": "2026-05-20T05:23:32.414985",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.364981+00:00",
+     "start_time": "2026-05-20T05:23:32.386310",
      "status": "completed"
     },
     "tags": []
@@ -408,10 +408,10 @@
    "id": "e955d826",
    "metadata": {
     "papermill": {
-     "duration": 0.005287,
-     "end_time": "2026-05-19T19:05:08.391129+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T05:23:32.422984",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.385842+00:00",
+     "start_time": "2026-05-20T05:23:32.418985",
      "status": "completed"
     },
     "tags": []
@@ -448,10 +448,10 @@
    "id": "43748612",
    "metadata": {
     "papermill": {
-     "duration": 0.006289,
-     "end_time": "2026-05-19T19:05:08.403639+00:00",
+     "duration": 0.004653,
+     "end_time": "2026-05-20T05:23:32.431638",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.397350+00:00",
+     "start_time": "2026-05-20T05:23:32.426985",
      "status": "completed"
     },
     "tags": []
@@ -475,10 +475,10 @@
    "id": "5bd3f42f",
    "metadata": {
     "papermill": {
-     "duration": 0.006391,
-     "end_time": "2026-05-19T19:05:08.416714+00:00",
+     "duration": 0.005002,
+     "end_time": "2026-05-20T05:23:32.440640",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.410323+00:00",
+     "start_time": "2026-05-20T05:23:32.435638",
      "status": "completed"
     },
     "tags": []
@@ -496,10 +496,10 @@
    "id": "0903d59e",
    "metadata": {
     "papermill": {
-     "duration": 0.006849,
-     "end_time": "2026-05-19T19:05:08.430336+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T05:23:32.448147",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.423487+00:00",
+     "start_time": "2026-05-20T05:23:32.444148",
      "status": "completed"
     },
     "tags": []
@@ -529,10 +529,10 @@
    "id": "8c7c0b5b",
    "metadata": {
     "papermill": {
-     "duration": 0.006149,
-     "end_time": "2026-05-19T19:05:08.443246+00:00",
+     "duration": 0.003509,
+     "end_time": "2026-05-20T05:23:32.456160",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.437097+00:00",
+     "start_time": "2026-05-20T05:23:32.452651",
      "status": "completed"
     },
     "tags": []
@@ -561,10 +561,10 @@
    "id": "107f350f",
    "metadata": {
     "papermill": {
-     "duration": 0.006464,
-     "end_time": "2026-05-19T19:05:08.456924+00:00",
+     "duration": 0.006509,
+     "end_time": "2026-05-20T05:23:32.465669",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.450460+00:00",
+     "start_time": "2026-05-20T05:23:32.459160",
      "status": "completed"
     },
     "tags": []
@@ -596,10 +596,10 @@
    "id": "d3736c14",
    "metadata": {
     "papermill": {
-     "duration": 0.009413,
-     "end_time": "2026-05-19T19:05:08.475521+00:00",
+     "duration": 0.006013,
+     "end_time": "2026-05-20T05:23:32.480203",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.466108+00:00",
+     "start_time": "2026-05-20T05:23:32.474190",
      "status": "completed"
     },
     "tags": []
@@ -624,10 +624,10 @@
    "id": "7af03fc1",
    "metadata": {
     "papermill": {
-     "duration": 0.006809,
-     "end_time": "2026-05-19T19:05:08.491677+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T05:23:32.488132",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.484868+00:00",
+     "start_time": "2026-05-20T05:23:32.484132",
      "status": "completed"
     },
     "tags": []
@@ -644,16 +644,16 @@
    "id": "19ac429a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:08.507352Z",
-     "iopub.status.busy": "2026-05-19T19:05:08.507073Z",
-     "iopub.status.idle": "2026-05-19T19:05:08.512194Z",
-     "shell.execute_reply": "2026-05-19T19:05:08.511433Z"
+     "iopub.execute_input": "2026-05-20T05:23:32.498682Z",
+     "iopub.status.busy": "2026-05-20T05:23:32.498682Z",
+     "iopub.status.idle": "2026-05-20T05:23:32.507429Z",
+     "shell.execute_reply": "2026-05-20T05:23:32.506681Z"
     },
     "papermill": {
-     "duration": 0.013923,
-     "end_time": "2026-05-19T19:05:08.513021+00:00",
+     "duration": 0.015783,
+     "end_time": "2026-05-20T05:23:32.508939",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.499098+00:00",
+     "start_time": "2026-05-20T05:23:32.493156",
      "status": "completed"
     },
     "tags": []
@@ -728,10 +728,10 @@
    "id": "3c675d90",
    "metadata": {
     "papermill": {
-     "duration": 0.006412,
-     "end_time": "2026-05-19T19:05:08.526575+00:00",
+     "duration": 0.004567,
+     "end_time": "2026-05-20T05:23:32.519018",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.520163+00:00",
+     "start_time": "2026-05-20T05:23:32.514451",
      "status": "completed"
     },
     "tags": []
@@ -765,10 +765,10 @@
    "id": "4ce8d8af",
    "metadata": {
     "papermill": {
-     "duration": 0.006927,
-     "end_time": "2026-05-19T19:05:08.540071+00:00",
+     "duration": 0.004612,
+     "end_time": "2026-05-20T05:23:32.528939",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.533144+00:00",
+     "start_time": "2026-05-20T05:23:32.524327",
      "status": "completed"
     },
     "tags": []
@@ -797,10 +797,10 @@
    "id": "0c539d91",
    "metadata": {
     "papermill": {
-     "duration": 0.007881,
-     "end_time": "2026-05-19T19:05:08.556572+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T05:23:32.536448",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.548691+00:00",
+     "start_time": "2026-05-20T05:23:32.532447",
      "status": "completed"
     },
     "tags": []
@@ -819,16 +819,16 @@
    "id": "3b60f6eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:08.574653Z",
-     "iopub.status.busy": "2026-05-19T19:05:08.574300Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.182783Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.181676Z"
+     "iopub.execute_input": "2026-05-20T05:23:32.548042Z",
+     "iopub.status.busy": "2026-05-20T05:23:32.547540Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.311203Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.310124Z"
     },
     "papermill": {
-     "duration": 1.617917,
-     "end_time": "2026-05-19T19:05:10.183634+00:00",
+     "duration": 0.770266,
+     "end_time": "2026-05-20T05:23:33.311717",
      "exception": false,
-     "start_time": "2026-05-19T19:05:08.565717+00:00",
+     "start_time": "2026-05-20T05:23:32.541451",
      "status": "completed"
     },
     "tags": []
@@ -860,10 +860,10 @@
    "id": "049b8db3",
    "metadata": {
     "papermill": {
-     "duration": 0.005723,
-     "end_time": "2026-05-19T19:05:10.196722+00:00",
+     "duration": 0.006216,
+     "end_time": "2026-05-20T05:23:33.323212",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.190999+00:00",
+     "start_time": "2026-05-20T05:23:33.316996",
      "status": "completed"
     },
     "tags": []
@@ -890,10 +890,10 @@
    "id": "fda5f898",
    "metadata": {
     "papermill": {
-     "duration": 0.006789,
-     "end_time": "2026-05-19T19:05:10.209518+00:00",
+     "duration": 0.00467,
+     "end_time": "2026-05-20T05:23:33.332906",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.202729+00:00",
+     "start_time": "2026-05-20T05:23:33.328236",
      "status": "completed"
     },
     "tags": []
@@ -908,16 +908,16 @@
    "id": "99117f74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.224286Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.223736Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.661375Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.660753Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.342832Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.342306Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.729602Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.729043Z"
     },
     "papermill": {
-     "duration": 0.446356,
-     "end_time": "2026-05-19T19:05:10.661981+00:00",
+     "duration": 0.39356,
+     "end_time": "2026-05-20T05:23:33.730607",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.215625+00:00",
+     "start_time": "2026-05-20T05:23:33.337047",
      "status": "completed"
     },
     "tags": []
@@ -958,10 +958,10 @@
    "id": "c209a094",
    "metadata": {
     "papermill": {
-     "duration": 0.006442,
-     "end_time": "2026-05-19T19:05:10.673340+00:00",
+     "duration": 0.004146,
+     "end_time": "2026-05-20T05:23:33.739385",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.666898+00:00",
+     "start_time": "2026-05-20T05:23:33.735239",
      "status": "completed"
     },
     "tags": []
@@ -992,10 +992,10 @@
    "id": "41e9a61f",
    "metadata": {
     "papermill": {
-     "duration": 0.004032,
-     "end_time": "2026-05-19T19:05:10.681848+00:00",
+     "duration": 0.004654,
+     "end_time": "2026-05-20T05:23:33.748199",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.677816+00:00",
+     "start_time": "2026-05-20T05:23:33.743545",
      "status": "completed"
     },
     "tags": []
@@ -1010,16 +1010,16 @@
    "id": "1425c0ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.691707Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.691403Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.699222Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.698377Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.757202Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.757202Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.776067Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.775505Z"
     },
     "papermill": {
-     "duration": 0.0139,
-     "end_time": "2026-05-19T19:05:10.699861+00:00",
+     "duration": 0.024908,
+     "end_time": "2026-05-20T05:23:33.777110",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.685961+00:00",
+     "start_time": "2026-05-20T05:23:33.752202",
      "status": "completed"
     },
     "tags": []
@@ -1084,10 +1084,10 @@
    "id": "ba53494b",
    "metadata": {
     "papermill": {
-     "duration": 0.004082,
-     "end_time": "2026-05-19T19:05:10.708112+00:00",
+     "duration": 0.004142,
+     "end_time": "2026-05-20T05:23:33.785441",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.704030+00:00",
+     "start_time": "2026-05-20T05:23:33.781299",
      "status": "completed"
     },
     "tags": []
@@ -1121,10 +1121,10 @@
    "id": "b8d6dfa0",
    "metadata": {
     "papermill": {
-     "duration": 0.004257,
-     "end_time": "2026-05-19T19:05:10.717087+00:00",
+     "duration": 0.004254,
+     "end_time": "2026-05-20T05:23:33.793838",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.712830+00:00",
+     "start_time": "2026-05-20T05:23:33.789584",
      "status": "completed"
     },
     "tags": []
@@ -1139,16 +1139,16 @@
    "id": "1c986e82",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.727315Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.727072Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.732392Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.731563Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.802478Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.802478Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.823273Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.821679Z"
     },
     "papermill": {
-     "duration": 0.011297,
-     "end_time": "2026-05-19T19:05:10.733095+00:00",
+     "duration": 0.026366,
+     "end_time": "2026-05-20T05:23:33.824273",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.721798+00:00",
+     "start_time": "2026-05-20T05:23:33.797907",
      "status": "completed"
     },
     "tags": []
@@ -1206,10 +1206,10 @@
    "id": "a70ab68f",
    "metadata": {
     "papermill": {
-     "duration": 0.004457,
-     "end_time": "2026-05-19T19:05:10.742504+00:00",
+     "duration": 0.004665,
+     "end_time": "2026-05-20T05:23:33.832937",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.738047+00:00",
+     "start_time": "2026-05-20T05:23:33.828272",
      "status": "completed"
     },
     "tags": []
@@ -1245,10 +1245,10 @@
    "id": "7fae2bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.005055,
-     "end_time": "2026-05-19T19:05:10.752176+00:00",
+     "duration": 0.004711,
+     "end_time": "2026-05-20T05:23:33.841792",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.747121+00:00",
+     "start_time": "2026-05-20T05:23:33.837081",
      "status": "completed"
     },
     "tags": []
@@ -1263,16 +1263,16 @@
    "id": "bfb011ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.765083Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.764735Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.770854Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.770053Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.853529Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.852530Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.869181Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.868060Z"
     },
     "papermill": {
-     "duration": 0.013406,
-     "end_time": "2026-05-19T19:05:10.771669+00:00",
+     "duration": 0.024291,
+     "end_time": "2026-05-20T05:23:33.870239",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.758263+00:00",
+     "start_time": "2026-05-20T05:23:33.845948",
      "status": "completed"
     },
     "tags": []
@@ -1282,16 +1282,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Erreur: \n",
+      "\u001b[96m\u001b[1mNOTE: To disable printing of planning engine credits, add this line to your code: `up.shortcuts.get_environment().credits_stream = None`\n",
+      "\u001b[0m\u001b[96m  *** Credits ***\n",
+      "\u001b[0m\u001b[96m  * In operation mode `OneshotPlanner` at line 563 of `C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\unified_planning\\shortcuts.py`, \u001b[0m\u001b[96myou are using the following planning engine:\n",
+      "\u001b[0m\u001b[96m  * Engine name: pyperplan\n",
+      "  * Developers:  Albert-Ludwigs-Universität Freiburg (Yusra Alkhazraji, Matthias Frorath, Markus Grützner, Malte Helmert, Thomas Liebetraut, Robert Mattmüller, Manuela Ortlieb, Jendrik Seipp, Tobias Springenberg, Philip Stahl, Jan Wülfing)\n",
+      "\u001b[0m\u001b[96m  * Description: \u001b[0m\u001b[96mPyperplan is a lightweight STRIPS planner written in Python.\u001b[0m\u001b[96m\n",
+      "\u001b[0m\u001b[96m\n",
+      "\u001b[0mPlanificateur: Pyperplan\n",
+      "Resolution en cours...\n",
       "\n",
-      "Solution attendue (manuelle):\n",
+      "Solution trouvee !\n",
+      "==================================================\n",
       "  1. load(box1, truck1, depot)\n",
       "  2. drive(truck1, depot, store)\n",
       "  3. unload(box1, truck1, store)\n",
       "  4. drive(truck1, store, depot)\n",
       "  5. load(box2, truck1, depot)\n",
       "  6. drive(truck1, depot, warehouse)\n",
-      "  7. unload(box2, truck1, warehouse)\n"
+      "  7. unload(box2, truck1, warehouse)\n",
+      "==================================================\n",
+      "Longueur du plan: 7 actions\n"
      ]
     }
    ],
@@ -1334,10 +1345,10 @@
    "id": "5e74a1eb",
    "metadata": {
     "papermill": {
-     "duration": 0.005271,
-     "end_time": "2026-05-19T19:05:10.782100+00:00",
+     "duration": 0.004183,
+     "end_time": "2026-05-20T05:23:33.878586",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.776829+00:00",
+     "start_time": "2026-05-20T05:23:33.874403",
      "status": "completed"
     },
     "tags": []
@@ -1366,10 +1377,10 @@
    "id": "211821ab",
    "metadata": {
     "papermill": {
-     "duration": 0.004929,
-     "end_time": "2026-05-19T19:05:10.793134+00:00",
+     "duration": 0.005834,
+     "end_time": "2026-05-20T05:23:33.890429",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.788205+00:00",
+     "start_time": "2026-05-20T05:23:33.884595",
      "status": "completed"
     },
     "tags": []
@@ -1387,10 +1398,10 @@
    "id": "48c1ac50",
    "metadata": {
     "papermill": {
-     "duration": 0.004301,
-     "end_time": "2026-05-19T19:05:10.802031+00:00",
+     "duration": 0.005297,
+     "end_time": "2026-05-20T05:23:33.900468",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.797730+00:00",
+     "start_time": "2026-05-20T05:23:33.895171",
      "status": "completed"
     },
     "tags": []
@@ -1416,10 +1427,10 @@
    "id": "133f8392",
    "metadata": {
     "papermill": {
-     "duration": 0.004402,
-     "end_time": "2026-05-19T19:05:10.810579+00:00",
+     "duration": 0.004317,
+     "end_time": "2026-05-20T05:23:33.910003",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.806177+00:00",
+     "start_time": "2026-05-20T05:23:33.905686",
      "status": "completed"
     },
     "tags": []
@@ -1452,10 +1463,10 @@
    "id": "1591814d",
    "metadata": {
     "papermill": {
-     "duration": 0.004943,
-     "end_time": "2026-05-19T19:05:10.820234+00:00",
+     "duration": 0.005003,
+     "end_time": "2026-05-20T05:23:33.919879",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.815291+00:00",
+     "start_time": "2026-05-20T05:23:33.914876",
      "status": "completed"
     },
     "tags": []
@@ -1478,10 +1489,10 @@
    "id": "c8183f7b",
    "metadata": {
     "papermill": {
-     "duration": 0.005007,
-     "end_time": "2026-05-19T19:05:10.830898+00:00",
+     "duration": 0.004743,
+     "end_time": "2026-05-20T05:23:33.929448",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.825891+00:00",
+     "start_time": "2026-05-20T05:23:33.924705",
      "status": "completed"
     },
     "tags": []
@@ -1505,10 +1516,10 @@
    "id": "9e82c6fd",
    "metadata": {
     "papermill": {
-     "duration": 0.005039,
-     "end_time": "2026-05-19T19:05:10.841609+00:00",
+     "duration": 0.004262,
+     "end_time": "2026-05-20T05:23:33.938935",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.836570+00:00",
+     "start_time": "2026-05-20T05:23:33.934673",
      "status": "completed"
     },
     "tags": []
@@ -1527,16 +1538,16 @@
    "id": "7a4db137",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.852112Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.851853Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.855467Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.854786Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.948927Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.948927Z",
+     "iopub.status.idle": "2026-05-20T05:23:33.960052Z",
+     "shell.execute_reply": "2026-05-20T05:23:33.959433Z"
     },
     "papermill": {
-     "duration": 0.009547,
-     "end_time": "2026-05-19T19:05:10.856096+00:00",
+     "duration": 0.017465,
+     "end_time": "2026-05-20T05:23:33.961096",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.846549+00:00",
+     "start_time": "2026-05-20T05:23:33.943631",
      "status": "completed"
     },
     "tags": []
@@ -1617,10 +1628,10 @@
    "id": "22d8bf02",
    "metadata": {
     "papermill": {
-     "duration": 0.005065,
-     "end_time": "2026-05-19T19:05:10.865323+00:00",
+     "duration": 0.005003,
+     "end_time": "2026-05-20T05:23:33.970154",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.860258+00:00",
+     "start_time": "2026-05-20T05:23:33.965151",
      "status": "completed"
     },
     "tags": []
@@ -1654,10 +1665,10 @@
    "id": "opks33hg4ue",
    "metadata": {
     "papermill": {
-     "duration": 0.004126,
-     "end_time": "2026-05-19T19:05:10.873603+00:00",
+     "duration": 0.004004,
+     "end_time": "2026-05-20T05:23:33.978157",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.869477+00:00",
+     "start_time": "2026-05-20T05:23:33.974153",
      "status": "completed"
     },
     "tags": []
@@ -1672,16 +1683,16 @@
    "id": "2873108b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-19T19:05:10.884832Z",
-     "iopub.status.busy": "2026-05-19T19:05:10.884512Z",
-     "iopub.status.idle": "2026-05-19T19:05:10.889139Z",
-     "shell.execute_reply": "2026-05-19T19:05:10.888206Z"
+     "iopub.execute_input": "2026-05-20T05:23:33.988202Z",
+     "iopub.status.busy": "2026-05-20T05:23:33.988202Z",
+     "iopub.status.idle": "2026-05-20T05:23:34.006934Z",
+     "shell.execute_reply": "2026-05-20T05:23:34.005351Z"
     },
     "papermill": {
-     "duration": 0.011676,
-     "end_time": "2026-05-19T19:05:10.889877+00:00",
+     "duration": 0.025419,
+     "end_time": "2026-05-20T05:23:34.008538",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.878201+00:00",
+     "start_time": "2026-05-20T05:23:33.983119",
      "status": "completed"
     },
     "tags": []
@@ -1750,10 +1761,10 @@
    "id": "054a298d",
    "metadata": {
     "papermill": {
-     "duration": 0.004356,
-     "end_time": "2026-05-19T19:05:10.899361+00:00",
+     "duration": 0.004189,
+     "end_time": "2026-05-20T05:23:34.017262",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.895005+00:00",
+     "start_time": "2026-05-20T05:23:34.013073",
      "status": "completed"
     },
     "tags": []
@@ -1789,10 +1800,10 @@
    "id": "aa5c31a3",
    "metadata": {
     "papermill": {
-     "duration": 0.00405,
-     "end_time": "2026-05-19T19:05:10.907607+00:00",
+     "duration": 0.006307,
+     "end_time": "2026-05-20T05:23:34.028167",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.903557+00:00",
+     "start_time": "2026-05-20T05:23:34.021860",
      "status": "completed"
     },
     "tags": []
@@ -1822,10 +1833,10 @@
    "id": "85acd2ba",
    "metadata": {
     "papermill": {
-     "duration": 0.004033,
-     "end_time": "2026-05-19T19:05:10.915863+00:00",
+     "duration": 0.004162,
+     "end_time": "2026-05-20T05:23:34.036683",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.911830+00:00",
+     "start_time": "2026-05-20T05:23:34.032521",
      "status": "completed"
     },
     "tags": []
@@ -1838,13 +1849,103 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0371e8a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004155,
+     "end_time": "2026-05-20T05:23:34.045090",
+     "exception": false,
+     "start_time": "2026-05-20T05:23:34.040935",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 9.1 - Etendre le probleme Gripper\n",
+    "\n",
+    "Le probleme Gripper de la section 8 transporte **2 balles** entre **2 pieces**. A vous de jouer : ecrivez le **probleme PDDL** (le domaine `gripper-strips` reste inchange) pour la variante suivante :\n",
+    "\n",
+    "- **3 pieces** : `rooma`, `roomb`, `roomc`\n",
+    "- **3 balles** : `ball1`, `ball2`, `ball3`, toutes initialement dans `rooma`\n",
+    "- **Robot** : demarre dans `rooma`, ses deux pinces `left` et `right` sont libres\n",
+    "- **But** : `ball1` et `ball2` dans `roomc`, `ball3` dans `roomb`\n",
+    "\n",
+    "Completez le squelette de la cellule suivante en reutilisant la structure de `GRIPPER_PROBLEM` (sections `:objects`, `:init`, `:goal`).\n",
+    "\n",
+    "> **Indice** : le robot ne possede que 2 pinces mais doit livrer dans 2 pieces differentes. Une partie du transport necessitera donc un aller-retour. Reportez-vous a l'encadre methodologique ci-dessous pour la demarche."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "92639339",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T05:23:34.056298Z",
+     "iopub.status.busy": "2026-05-20T05:23:34.056298Z",
+     "iopub.status.idle": "2026-05-20T05:23:34.067975Z",
+     "shell.execute_reply": "2026-05-20T05:23:34.066977Z"
+    },
+    "papermill": {
+     "duration": 0.01936,
+     "end_time": "2026-05-20T05:23:34.068975",
+     "exception": false,
+     "start_time": "2026-05-20T05:23:34.049615",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 9.1 : Probleme Gripper a 3 pieces / 3 balles\n",
+    "# Le domaine gripper-strips (defini plus haut) reste INCHANGE : seul le\n",
+    "# probleme change. Completez la chaine PDDL ci-dessous en vous inspirant\n",
+    "# de GRIPPER_PROBLEM (section 8).\n",
+    "\n",
+    "GRIPPER_PROBLEM_3 = \"\"\"\n",
+    "(define (problem strips-gripper3)\n",
+    "  (:domain gripper-strips)\n",
+    "  (:objects\n",
+    "    ;; TODO etudiant : rooma roomb roomc - room\n",
+    "    ;; TODO etudiant : ball1 ball2 ball3 - ball\n",
+    "    ;; TODO etudiant : left right - gripper\n",
+    "  )\n",
+    "  (:init\n",
+    "    ;; TODO etudiant : (at-robby rooma)\n",
+    "    ;; TODO etudiant : (free left) (free right)\n",
+    "    ;; TODO etudiant : les 3 balles initialement dans rooma\n",
+    "  )\n",
+    "  (:goal (and\n",
+    "    ;; TODO etudiant : ball1 et ball2 dans roomc, ball3 dans roomb\n",
+    "  ))\n",
+    ")\n",
+    "\"\"\"\n",
+    "\n",
+    "# Une fois GRIPPER_PROBLEM_3 complete, vous pourrez le resoudre avec un\n",
+    "# planificateur (unified-planning + OneshotPlanner) comme en section 6.4.\n",
+    "# Question subsidiaire : avec seulement 2 pinces, combien d'actions au\n",
+    "# minimum pour ce but reparti sur 2 pieces destination ?\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0332270c",
    "metadata": {
     "papermill": {
-     "duration": 0.004027,
-     "end_time": "2026-05-19T19:05:10.924043+00:00",
+     "duration": 0.00443,
+     "end_time": "2026-05-20T05:23:34.077409",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.920016+00:00",
+     "start_time": "2026-05-20T05:23:34.072979",
      "status": "completed"
     },
     "tags": []
@@ -1879,10 +1980,10 @@
    "id": "117f0a06",
    "metadata": {
     "papermill": {
-     "duration": 0.003927,
-     "end_time": "2026-05-19T19:05:10.933249+00:00",
+     "duration": 0.005804,
+     "end_time": "2026-05-20T05:23:34.087503",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.929322+00:00",
+     "start_time": "2026-05-20T05:23:34.081699",
      "status": "completed"
     },
     "tags": []
@@ -1927,10 +2028,10 @@
    "id": "7dbd503c",
    "metadata": {
     "papermill": {
-     "duration": 0.004034,
-     "end_time": "2026-05-19T19:05:10.941699+00:00",
+     "duration": 0.004283,
+     "end_time": "2026-05-20T05:23:34.098005",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.937665+00:00",
+     "start_time": "2026-05-20T05:23:34.093722",
      "status": "completed"
     },
     "tags": []
@@ -1978,10 +2079,10 @@
    "id": "9b9f3486",
    "metadata": {
     "papermill": {
-     "duration": 0.004063,
-     "end_time": "2026-05-19T19:05:10.950333+00:00",
+     "duration": 0.004113,
+     "end_time": "2026-05-20T05:23:34.106821",
      "exception": false,
-     "start_time": "2026-05-19T19:05:10.946270+00:00",
+     "start_time": "2026-05-20T05:23:34.102708",
      "status": "completed"
     },
     "tags": []
@@ -2018,18 +2119,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.10.11"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.024014,
-   "end_time": "2026-05-19T19:05:11.310491+00:00",
+   "duration": 3.835335,
+   "end_time": "2026-05-20T05:23:34.456610",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Planners\\01-Foundation\\Planners-2-PDDL-Basics.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Planners\\01-Foundation\\Planners-2-PDDL-Basics.ipynb",
+   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-2-PDDL-Basics.ipynb",
+   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\01-Foundation\\Planners-2-PDDL-Basics_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-19T19:05:06.286477+00:00",
+   "start_time": "2026-05-20T05:23:30.621275",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-1-Setup.ipynb
@@ -2138,6 +2138,63 @@
   },
   {
    "cell_type": "markdown",
+   "id": "451bd551",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercice : Validez votre installation Tweety\n",
+    "\n",
+    "Avant de passer aux notebooks suivants, verifiez votre maitrise de l'environnement TweetyProject configure dans ce notebook.\n",
+    "\n",
+    "### Exercice - Diagnostic de l'environnement\n",
+    "\n",
+    "Ecrivez une cellule de diagnostic qui :\n",
+    "\n",
+    "1. Importe `jpype` et affiche sa version\n",
+    "2. Verifie que la JVM est demarree (`jpype.isJVMStarted()`)\n",
+    "3. Importe une classe Tweety simple (par exemple `PlBeliefSet` du package `org.tweetyproject.logics.pl.syntax`) et l'instancie\n",
+    "\n",
+    "Completez le squelette ci-dessous.\n",
+    "\n",
+    "> **Indice** : reprenez les imports de la section 1.6.5 (Verification des Imports). Si la JVM n'est pas demarree, re-executez d'abord la cellule 1.6.4 (Demarrage de la JVM)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ed0600a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice de validation - Diagnostic de l'environnement Tweety\n",
+    "# Completez les TODO ci-dessous puis decommentez les lignes.\n",
+    "\n",
+    "# TODO etudiant : importer jpype et afficher sa version\n",
+    "# import jpype\n",
+    "# print(f\"jpype version : {jpype.__version__}\")\n",
+    "\n",
+    "# TODO etudiant : verifier que la JVM est demarree\n",
+    "# print(f\"JVM demarree : {jpype.isJVMStarted()}\")\n",
+    "\n",
+    "# TODO etudiant : importer une classe Tweety et l'instancier\n",
+    "# from org.tweetyproject.logics.pl.syntax import PlBeliefSet\n",
+    "# belief_set = PlBeliefSet()\n",
+    "# print(f\"PlBeliefSet cree : {belief_set}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2b6db053",
    "metadata": {
     "papermill": {

--- a/scripts/notebook_tools/exec_single_cell.py
+++ b/scripts/notebook_tools/exec_single_cell.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Execute a SINGLE notebook cell on a named Jupyter kernel and write its
+execution_count + outputs back, leaving every other cell byte-identical.
+
+Use case (rule C.2/C.3/H.3 compliant): a notebook has heavy or unavailable
+dependencies in most cells (jpype/JVM, GPU, network downloads) but you added a
+single self-contained cell (e.g. a terminal exercise stub) that must carry real
+execution_count + outputs. Re-running the whole notebook would either fail on
+the heavy cells or churn the already-valid outputs of the unchanged cells. This
+tool runs only the target cell on a fresh kernel and persists just that cell.
+
+It reads/writes with the raw ``json`` module (NOT nbformat) so the on-disk key
+order of every other cell is preserved exactly: only the target cell's
+``execution_count`` and ``outputs`` are mutated. This avoids the whole-file
+key-order churn nbformat.write() introduces on notebooks that were saved by
+VS Code / dotnet-interactive (non nbformat-canonical key order).
+
+For .NET (.net-csharp) kernels, the dotnet-interactive HTTP-port bootstrap
+``<div>`` that a fresh kernel injects on the first executed cell (a
+session-specific port, e.g. 44528) is filtered out: it is session noise, not a
+real cell output.
+
+Usage:
+  python exec_single_cell.py <notebook.ipynb> --cell-id <id>  [--kernel python3] [--timeout 120]
+  python exec_single_cell.py <notebook.ipynb> --index   <n>   [--kernel python3] [--timeout 120]
+
+Exit code: 0 if the cell executed without an error output, 1 otherwise.
+"""
+import argparse
+import json
+import queue
+import sys
+
+from jupyter_client.manager import start_new_kernel
+
+
+def _source(cell) -> str:
+    src = cell["source"]
+    return "".join(src) if isinstance(src, list) else src
+
+
+def _is_dotnet_bootstrap(output) -> bool:
+    """Detect the dotnet-interactive HTTP-port bootstrap div (session noise)."""
+    if output.get("output_type") not in ("display_data", "execute_result"):
+        return False
+    data = output.get("data", {})
+    html = data.get("text/html", "")
+    if isinstance(html, list):
+        html = "".join(html)
+    return "dotnet-interactive-this-cell" in html or "HttpPort" in html
+
+
+def collect_outputs(kc, msg_id, timeout):
+    """Drain iopub for the given execution, returning nbformat-shaped dicts."""
+    outputs = []
+    exec_count = None
+    while True:
+        try:
+            msg = kc.get_iopub_msg(timeout=timeout)
+        except queue.Empty:
+            break
+        if msg["parent_header"].get("msg_id") != msg_id:
+            continue
+        mt = msg["msg_type"]
+        content = msg["content"]
+        if mt == "status":
+            if content["execution_state"] == "idle":
+                break
+        elif mt == "execute_input":
+            exec_count = content.get("execution_count", exec_count)
+        elif mt == "stream":
+            outputs.append({
+                "output_type": "stream",
+                "name": content["name"],
+                "text": content["text"],
+            })
+        elif mt == "execute_result":
+            exec_count = content.get("execution_count", exec_count)
+            outputs.append({
+                "output_type": "execute_result",
+                "execution_count": exec_count,
+                "data": content["data"],
+                "metadata": content.get("metadata", {}),
+            })
+        elif mt == "display_data":
+            outputs.append({
+                "output_type": "display_data",
+                "data": content["data"],
+                "metadata": content.get("metadata", {}),
+            })
+        elif mt == "error":
+            outputs.append({
+                "output_type": "error",
+                "ename": content["ename"],
+                "evalue": content["evalue"],
+                "traceback": content["traceback"],
+            })
+    outputs = [o for o in outputs if not _is_dotnet_bootstrap(o)]
+    return outputs, exec_count
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("notebook")
+    ap.add_argument("--cell-id", help="id of the code cell to execute")
+    ap.add_argument("--index", type=int, help="absolute cell index to execute")
+    ap.add_argument("--kernel", default="python3", help="registered kernel name")
+    ap.add_argument("--timeout", type=int, default=120)
+    ap.add_argument("--set-ec", type=int, default=None,
+                    help="override the written execution_count with this value. "
+                         "Useful when running one cell on a fresh kernel (kernel "
+                         "reports ec=1) but the cell's sequential position in the "
+                         "notebook is N: the output is identical, only the display "
+                         "counter is set to its real position.")
+    args = ap.parse_args()
+
+    if not args.cell_id and args.index is None:
+        ap.error("provide --cell-id or --index")
+
+    with open(args.notebook, encoding="utf-8") as f:
+        nb = json.load(f)
+
+    target = None
+    for i, c in enumerate(nb["cells"]):
+        if c.get("cell_type") != "code":
+            continue
+        if args.cell_id and c.get("id") == args.cell_id:
+            target = c
+            break
+        if args.index is not None and i == args.index:
+            target = c
+            break
+    if target is None:
+        print(f"ERROR: code cell not found (cell-id={args.cell_id} index={args.index})")
+        sys.exit(2)
+
+    km, kc = start_new_kernel(kernel_name=args.kernel)
+    status = "unknown"
+    try:
+        msg_id = kc.execute(_source(target))
+        outputs, exec_count = collect_outputs(kc, msg_id, args.timeout)
+        try:
+            reply = kc.get_shell_msg(timeout=args.timeout)
+            if reply["parent_header"].get("msg_id") == msg_id:
+                status = reply["content"].get("status", status)
+                ec = reply["content"].get("execution_count")
+                if ec is not None:
+                    exec_count = ec
+        except queue.Empty:
+            pass
+    finally:
+        kc.stop_channels()
+        km.shutdown_kernel(now=True)
+
+    written_ec = args.set_ec if args.set_ec is not None else exec_count
+    target["execution_count"] = written_ec
+    # execute_result outputs carry their own execution_count: keep it aligned.
+    for o in outputs:
+        if o.get("output_type") == "execute_result":
+            o["execution_count"] = written_ec
+    target["outputs"] = outputs
+
+    with open(args.notebook, "w", encoding="utf-8") as f:
+        json.dump(nb, f, ensure_ascii=False, indent=1)
+        f.write("\n")
+
+    has_err = any(o.get("output_type") == "error" for o in outputs)
+    print(f"Executed cell kernel_ec={exec_count} written_ec={written_ec} "
+          f"status={status} outputs={len(outputs)} error={has_err}")
+    for o in outputs:
+        if o.get("output_type") == "stream":
+            print("  STREAM:", "".join(o["text"]).strip()[:200])
+        elif o.get("output_type") == "error":
+            print("  ERROR:", o["ename"], o["evalue"])
+    sys.exit(1 if has_err else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Gap-fill for the SymbolicAI end-exercise initiative. These 3 notebooks are **not** covered by the parallel agent branches (`feature/symbolicai-planners-exercices-end`, `feature/tweety-end-exercises`, `feature/semanticweb-py-end-exercises`) — verified by cross-branch `git diff --name-only`. Each gets one unsolved terminal exercise with a C.1-conformant stub, re-executed with real outputs (C.2/H.3).

| Notebook | Kernel | Exercise | Exec | Method |
|----------|--------|----------|------|--------|
| OR-tools-Stiegler | .net-csharp | borne superieure par aliment (re-solve + compare) | 10/10, 0 err | surgical single-cell |
| Planners-2-PDDL-Basics | python3 / unified-planning | Gripper 3 pieces / 3 balles | 10/10, 0 err | full re-exec (papermill) |
| Tweety-1-Setup | python3 / jpype | diagnostic env Tweety (jpype/JVM/PlBeliefSet) | 15/15, 0 err | surgical single-cell |

All stubs use `print("Exercice a completer")` / commented scaffold — **no** `raise NotImplementedError` / `assert False` / `1/0` (C.1). No source-cell or `# Solution` deletions (anti-regression verified: 0 source deletions on each).

## Tooling

Adds `scripts/notebook_tools/exec_single_cell.py`: a raw-json single-cell executor that
- preserves on-disk JSON key order (avoids the nbformat whole-file key-order churn on VS-Code/dotnet-interactive .NET notebooks),
- filters the dotnet-interactive HTTP-port bootstrap `<div>` (session noise),
- supports `--set-ec N` to align a fresh-kernel `ec=1` to the cell's sequential position.

Used for the OR-tools and Tweety-1 surgical executions (notebooks whose other cells need heavy deps — OR-Tools nuget / jpype JVM).

## Notes

- Planners-2 has a larger diff because it was fully re-executed (papermill timestamps churn); the only **source** change is the 2 exercise cells.
- Lean-11-TorchLean was intentionally **excluded**: its `import TorchLean.Core/...` references a Lean project absent from the repo, so its 10 `#eval`/`#check` cells cannot execute — tracked separately for the Lean specialist.

## Test plan
- [x] Each notebook: `execution_count != null` + outputs present on all code cells, 0 `output_type: error`
- [x] C.1 grep: no forbidden error patterns
- [x] Anti-regression: 0 source-cell / Solution deletions
- [x] Cross-branch overlap check: 3 notebooks confirmed unique