### PR TITLE
fix(tweety-5): correct ArgLearn bug version note (persists in 1.30)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
@@ -1025,7 +1025,7 @@
    "source": [
     "### 4.1.4 Apprentissage de Cadres (Bug Connu)\n",
     "\n",
-    "> ⚠️ **Cette section est documentée mais non exécutable** en raison d'un bug interne Tweety 1.28 (`ClassCastException: Tautology cannot be cast to AssociativePlFormula`).\n",
+    "> ⚠️ **Cette section est documentée mais non exécutable** en raison d'un bug interne de Tweety (constaté en 1.28, toujours présent en 1.30) : `ClassCastException: Tautology cannot be cast to AssociativePlFormula`.\n",
     "\n",
     "**Concept pédagogique** :\n",
     "\n",


### PR DESCRIPTION
## Summary
- Tweety-5 §4.1.4 (apprentissage de cadres Dung) is marked non-executable due to an internal Tweety `ClassCastException` (`Tautology cannot be cast to AssociativePlFormula`).
- The markdown note said the bug was a "Tweety 1.28" issue, but the notebook now runs on **Tweety 1.30** where the bug is **still present**.
- Updated the note to state the bug persists in 1.30, so students on 1.30 don't assume it's a stale-version issue and try to uncomment the code.

## Verification (verify-before-claiming)
Reproduced on env `epita_symbolic_ai` (jpype 1.5.2 + Tweety 1.30 jars):
```
oracle.getLabeling(Semantics.STABLE_SEMANTICS)
-> java.lang.ClassCastException: org.tweetyproject.logics.pl.syntax.Tautology
   cannot be cast to ...AssociativePlFormula
RESULT: ArgLearn STILL BROKEN in 1.30
```

## Scope
- **Markdown-only** change (1 line, cell §4.1.4 warning). Code cell stays commented (bug confirmed) — no anti-régression. No re-execution required (C.2 exception: markdown-only).
- Net diff: 1 insertion, 1 deletion.

Closes #1324