### PR TITLE
fix(tweety-4): MaxSAT/MUS subprocess uses sys.executable (closes #1322)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
@@ -40,10 +40,10 @@
    "id": "eff88e6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:07.511400Z",
-     "iopub.status.busy": "2026-05-20T06:44:07.511400Z",
-     "iopub.status.idle": "2026-05-20T06:44:07.747318Z",
-     "shell.execute_reply": "2026-05-20T06:44:07.747318Z"
+     "iopub.execute_input": "2026-05-20T08:24:54.026995Z",
+     "iopub.status.busy": "2026-05-20T08:24:54.026995Z",
+     "iopub.status.idle": "2026-05-20T08:24:54.241008Z",
+     "shell.execute_reply": "2026-05-20T08:24:54.240429Z"
     },
     "papermill": {
      "duration": 0.241911,
@@ -313,10 +313,10 @@
    "id": "278b5928",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:07.781319Z",
-     "iopub.status.busy": "2026-05-20T06:44:07.781319Z",
-     "iopub.status.idle": "2026-05-20T06:44:07.811322Z",
-     "shell.execute_reply": "2026-05-20T06:44:07.810319Z"
+     "iopub.execute_input": "2026-05-20T08:24:54.243657Z",
+     "iopub.status.busy": "2026-05-20T08:24:54.243657Z",
+     "iopub.status.idle": "2026-05-20T08:24:54.273332Z",
+     "shell.execute_reply": "2026-05-20T08:24:54.272339Z"
     },
     "papermill": {
      "duration": 0.034003,
@@ -454,10 +454,10 @@
    "id": "dda59866",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:07.827323Z",
-     "iopub.status.busy": "2026-05-20T06:44:07.826323Z",
-     "iopub.status.idle": "2026-05-20T06:44:08.074887Z",
-     "shell.execute_reply": "2026-05-20T06:44:08.074887Z"
+     "iopub.execute_input": "2026-05-20T08:24:54.274332Z",
+     "iopub.status.busy": "2026-05-20T08:24:54.274332Z",
+     "iopub.status.idle": "2026-05-20T08:24:54.505611Z",
+     "shell.execute_reply": "2026-05-20T08:24:54.505611Z"
     },
     "papermill": {
      "duration": 0.253557,
@@ -485,7 +485,7 @@
       "Base initiale: { A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q }\n",
       "  A1:p, A2:q, A2:(p=>r), A3:!q, A3:!r\n",
       "\n",
-      "Nouvelles infos: { !p (A2), s (A3) }\n",
+      "Nouvelles infos: { s (A3), !p (A2) }\n",
       "  A2:!p contredit A1:p (A1 plus credible)\n",
       "  A3:s nouvelle info neutre\n",
       "\n",
@@ -616,10 +616,10 @@
    "id": "1c9fda5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:08.091866Z",
-     "iopub.status.busy": "2026-05-20T06:44:08.091343Z",
-     "iopub.status.idle": "2026-05-20T06:44:20.514946Z",
-     "shell.execute_reply": "2026-05-20T06:44:20.513134Z"
+     "iopub.execute_input": "2026-05-20T08:24:54.508737Z",
+     "iopub.status.busy": "2026-05-20T08:24:54.507612Z",
+     "iopub.status.idle": "2026-05-20T08:25:07.731737Z",
+     "shell.execute_reply": "2026-05-20T08:25:07.731043Z"
     },
     "papermill": {
      "duration": 12.429393,
@@ -637,10 +637,10 @@
      "text": [
       "--- 3.1c Operateurs de revision CrMas ---\n",
       "Revision de: { A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q }\n",
-      "Avec: { !p (A2), s (A3) }\n",
+      "Avec: { s (A3), !p (A2) }\n",
       "\n",
       "1. Operateur Levi (prioritaire):\n",
-      "   Resultat: [A2:!p, A1:p, A3:!r, A2:q, A3:s]\n",
+      "   Resultat: [A3:s, A1:p, A3:!r, A2:q, A2:!p]\n",
       "\n",
       "2. Operateur Simple (credibilite):\n",
       "   Resultat: [A1:p, A2:(p=>r), A3:!q, A3:!r, A2:q]\n",
@@ -652,7 +652,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   Resultat: [A1:p, A3:!r, A2:q, A3:s]\n",
+      "   Resultat: [A3:s, A1:p, A3:!r, A2:q]\n",
       "\n",
       "==> Comparaison des 3 operateurs terminee.\n"
      ]
@@ -837,10 +837,10 @@
    "id": "15d97aa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:20.568536Z",
-     "iopub.status.busy": "2026-05-20T06:44:20.567536Z",
-     "iopub.status.idle": "2026-05-20T06:44:21.434592Z",
-     "shell.execute_reply": "2026-05-20T06:44:21.432587Z"
+     "iopub.execute_input": "2026-05-20T08:25:07.733838Z",
+     "iopub.status.busy": "2026-05-20T08:25:07.733838Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.045914Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.044697Z"
     },
     "papermill": {
      "duration": 0.877059,
@@ -864,31 +864,13 @@
       "   OK: Tous les imports pour Mesures d'Incoherence reussis.\n",
       "\n",
       "--- Mesure Contension ---\n",
-      "KB: { !a&&b, !c||d, a, !b, !d, c, d, c||a, !c||a }\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "KB: { !a&&b, !c||d, a, !b, !d, c, d, c||a, !c||a }\n",
       "Valeur Contension: 3.0\n",
       "\n",
       "--- Mesures Basees sur Distance (Dalal) ---\n",
-      "KB pour Distance: { a&&b&&c, !a&&!b&&!c }\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "KB pour Distance: { a&&b&&c, !a&&!b&&!c }\n",
       "Valeur DSum (Sat): 3.0\n",
-      "Valeur DMax (Sat): 2.0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Valeur DMax (Sat): 2.0\n",
       "Valeur DHit (Sat): 1.0\n",
       "\n",
       "--- Mesures Ma / Mcsc (basees sur MUS) ---\n",
@@ -1138,10 +1120,10 @@
    "id": "5210fa12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:21.504700Z",
-     "iopub.status.busy": "2026-05-20T06:44:21.504185Z",
-     "iopub.status.idle": "2026-05-20T06:44:22.407825Z",
-     "shell.execute_reply": "2026-05-20T06:44:22.406824Z"
+     "iopub.execute_input": "2026-05-20T08:25:08.047610Z",
+     "iopub.status.busy": "2026-05-20T08:25:08.047610Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.578702Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.577706Z"
     },
     "papermill": {
      "duration": 0.913703,
@@ -1211,6 +1193,7 @@
     "        from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n",
     "        from org.tweetyproject.logics.commons.analysis import NaiveMusEnumerator\n",
     "        import subprocess\n",
+    "        import sys\n",
     "        import tempfile\n",
     "        import pathlib\n",
     "\n",
@@ -1292,7 +1275,7 @@
     "                try:\n",
     "                    # Executer marco.py avec --mus-only\n",
     "                    result = subprocess.run(\n",
-    "                        [\"python\", str(marco_script), str(cnf_path), \"--mus-only\"],\n",
+    "                        [sys.executable, str(marco_script), str(cnf_path), \"--mus-only\"],\n",
     "                        capture_output=True,\n",
     "                        text=True,\n",
     "                        timeout=10\n",
@@ -1400,10 +1383,10 @@
    "id": "bdb25959",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:22.448824Z",
-     "iopub.status.busy": "2026-05-20T06:44:22.448824Z",
-     "iopub.status.idle": "2026-05-20T06:44:22.471081Z",
-     "shell.execute_reply": "2026-05-20T06:44:22.470083Z"
+     "iopub.execute_input": "2026-05-20T08:25:08.580701Z",
+     "iopub.status.busy": "2026-05-20T08:25:08.580701Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.592720Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.592720Z"
     },
     "papermill": {
      "duration": 0.031258,
@@ -1510,10 +1493,10 @@
    "id": "5b990eff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:22.516084Z",
-     "iopub.status.busy": "2026-05-20T06:44:22.515084Z",
-     "iopub.status.idle": "2026-05-20T06:44:22.534208Z",
-     "shell.execute_reply": "2026-05-20T06:44:22.533591Z"
+     "iopub.execute_input": "2026-05-20T08:25:08.594713Z",
+     "iopub.status.busy": "2026-05-20T08:25:08.594713Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.608998Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.607926Z"
     },
     "papermill": {
      "duration": 0.029129,
@@ -1597,10 +1580,10 @@
    "id": "1dae6cdf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:22.567213Z",
-     "iopub.status.busy": "2026-05-20T06:44:22.566212Z",
-     "iopub.status.idle": "2026-05-20T06:44:22.690453Z",
-     "shell.execute_reply": "2026-05-20T06:44:22.689368Z"
+     "iopub.execute_input": "2026-05-20T08:25:08.610546Z",
+     "iopub.status.busy": "2026-05-20T08:25:08.610546Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.700836Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.699828Z"
     },
     "papermill": {
      "duration": 0.134283,
@@ -1651,6 +1634,7 @@
     "        print(f\"MaxSAT script: {maxsat_script}\")\n",
     "        \n",
     "        try:\n",
+    "            import sys\n",
     "            import pysat\n",
     "            print(f\"PySAT version: {pysat.__version__}\")\n",
     "            \n",
@@ -1672,7 +1656,7 @@
     "            \n",
     "            # Executer le solveur\n",
     "            result = subprocess.run(\n",
-    "                [\"python\", str(maxsat_script), str(wcnf_path)],\n",
+    "                [sys.executable, str(maxsat_script), str(wcnf_path)],\n",
     "                capture_output=True, text=True, timeout=10\n",
     "            )\n",
     "            \n",
@@ -1689,7 +1673,12 @@
     "                        assignment = [f\"{var_map[abs(l)]}={l>0}\" for l in lits if abs(l) in var_map]\n",
     "                        print(f\"  Assignation: {', '.join(assignment)}\")\n",
     "            else:\n",
-    "                print(f\"Erreur: {result.stderr}\")\n",
+    "                if \"pysat.examples\" in result.stderr or \"No module named 'pysat'\" in result.stderr:\n",
+    "                    print(\"ATTENTION: python-sat (pysat.examples.rc2) introuvable dans ce kernel.\")\n",
+    "                    print(\"Cause: package satellite-science 'pysat' qui masque 'python-sat',\")\n",
+    "                    print(\"ou kernel actif != 'epita_symbolic_ai'. Selectionnez le kernel 'epita_symbolic_ai'.\")\n",
+    "                else:\n",
+    "                    print(f\"Erreur: {result.stderr}\")\n",
     "            \n",
     "            wcnf_path.unlink(missing_ok=True)\n",
     "            \n",
@@ -1804,10 +1793,10 @@
    "id": "n7jccc36dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:22.736845Z",
-     "iopub.status.busy": "2026-05-20T06:44:22.736256Z",
-     "iopub.status.idle": "2026-05-20T06:44:22.752848Z",
-     "shell.execute_reply": "2026-05-20T06:44:22.751848Z"
+     "iopub.execute_input": "2026-05-20T08:25:08.702841Z",
+     "iopub.status.busy": "2026-05-20T08:25:08.702841Z",
+     "iopub.status.idle": "2026-05-20T08:25:08.715993Z",
+     "shell.execute_reply": "2026-05-20T08:25:08.715353Z"
     },
     "papermill": {
      "duration": 0.02559,
@@ -1911,7 +1900,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Problem (#1322 — reproduced LIVE in EPITA-IS class 2026-05-20)

`Tweety-4-Belief-Revision.ipynb` runs the external MaxSAT solver (`ext_tools/maxsat_solver.py`, python-sat RC2) and the MARCO MUS enumerator (`ext_tools/marco.py`, Z3) via `subprocess`. Both cells used the literal `["python", ...]`.

`"python"` resolves through **PATH**, not the kernel. On the user's machine PATH `python` had the satellite-science `pysat` (v3.2.2) shadowing `python-sat` → `ModuleNotFoundError: No module named 'pysat.examples'`. The bug is independent of kernel selection: even with the correct `epita_symbolic_ai` kernel, the subprocess hit the wrong interpreter.

## Fix

- **cell#26 (MaxSAT)** `["python", ...]` → `[sys.executable, ...]` + a clear remediation message when `pysat.examples` is unresolvable (points to the `epita_symbolic_ai` kernel) instead of a raw traceback.
- **cell#18 (MARCO/MUS)** `["python", ...]` → `[sys.executable, ...]` (same latent bug).

`sys.executable` guarantees the subprocess uses the same interpreter as the running kernel.

## Execution proof (re-executed in-place, kernel `epita_symbolic_ai`)

nbconvert --execute --inplace, python-sat 1.9.dev2 + z3 4.16.0. **10 code cells, exec_count complete, 0 errors.**

```
=== cell#26 (MaxSAT) ===
PySAT version: 1.9.dev2
Resultats MaxSAT:
  Status: OPTIMUM FOUND
  Cout optimal: 25
  Assignation: a=False, b=True, c=False, d=True, f=True, g=False

=== cell#18 (MARCO) ===
 - Trouve 5 MUS (NaiveEnumerator)
  Z3 disponible (version 4.16.0)
  Resultats MARCO: U 0 1 / U 0 2 3 / U 4 5 / U 0 4 6
```

## Checklist (notebook PR — rule D)
- [x] Papermill/kernel exec output pasted above (real RC2 + Z3 results)
- [x] 0 NotImplementedError / assert False / 1/0
- [x] All code cells `execution_count` + `outputs` coherent (H.3 PASS)
- [x] No `# Solution` / worked-example cell stripped (only 2 subprocess lines + outputs changed; 31 cells intact)

Closes #1322