### PR TITLE
Fix: relabel guided examples in SW-2-CSharp (anti-leak)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -1663,7 +1663,7 @@
     }
    ],
    "source": [
-    "// EXERCICE 1 : Modeliser un reseau social en RDF\n",
+    "// Exemple guide 1 : Modeliser un reseau social en RDF\n",
     "IGraph social = new Graph();\n",
     "\n",
     "// Declaration des prefixes\n",
@@ -1820,7 +1820,7 @@
     }
    ],
    "source": [
-    "// EXERCICE 2 : Comparer les tailles de serialisation\n",
+    "// Exemple guide 2 : Comparer les tailles de serialisation\n",
     "\n",
     "// Fonction utilitaire pour serialiser et mesurer\n",
     "string SerializeGraph(IGraph graph, IRdfWriter writer)\n",


### PR DESCRIPTION
## Summary
Cells 42/45 of SW-2-CSharp-RDFBasics are demonstrative worked examples (markdown headers "## 5/6. Exemple guide" + interpretation cells "Interpretation de l'Exemple guide"). Their code comments mislabeled them `// EXERCICE 1/2`, making complete worked solutions look like leaked exercise answers.

## Change
- 2-line comment relabel: `// EXERCICE 1/2` -> `// Exemple guide 1/2`
- No code logic touched (outputs unchanged, exec_count preserved)
- Genuine exercise (cell 48) was already a proper stub (`// Exercice : votre code ici`) — untouched

## Verification
- `git diff --stat`: 2 insertions(+), 2 deletions(-)
- JSON validates
- Anti-regression: demonstrative content preserved, NOT stripped