### PR TITLE
fix(notebook_tools): propagate kernel errors in cell-by-cell exec (#1312)

### DIFF
--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -1213,6 +1213,14 @@ class NotebookExecutor:
             result = self._base_executor.execute_notebook_cell_by_cell(
                 str(self.path), timeout_per_cell=timeout
             )
+            msg = (
+                f"Executed {result.executed_cells} cells: "
+                f"{result.executed_cells - result.failed_cells} OK, "
+                f"{result.failed_cells} errors"
+            )
+            if result.errors:
+                msg += f" | Details: {'; '.join(result.errors[:3])}"
+
             return NotebookExecutionResult(
                 path=str(self.path),
                 success=result.success,
@@ -1222,7 +1230,7 @@ class NotebookExecutor:
                 success_cells=result.executed_cells - result.failed_cells,
                 error_cells=result.failed_cells,
                 execution_time=result.duration,
-                message=f"Executed {result.executed_cells} cells: {result.executed_cells - result.failed_cells} OK, {result.failed_cells} errors"
+                message=msg,
             )
 
         # Fallback: minimal implementation


### PR DESCRIPTION
## Summary
- Fix Bug B from #1312: `execute_cell_by_cell()` in `notebook_tools.py` now includes `result.errors` details in the returned message when kernel startup fails
- Previously showed misleading "Executed 0 cells: 0 OK, 0 errors" when kernel couldn't start

## Test plan
- [ ] Run `python scripts/notebook_tools/notebook_tools.py execute <dotnet_notebook>` on a machine without .NET kernel — should now show actual error (e.g. "Failed to start .net-csharp kernel: ...")
- [ ] Run same with Python kernel (should work as before, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)