### PR TITLE
feat(ml): m15 cross-asset LSTM monthly refit + max data

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_cross_asset_lstm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_cross_asset_lstm.py
@@ -58,7 +58,7 @@ KELLY_CAP = 1.0
 MU_WINDOW = 60
 FEE_BPS = 5  # equity standard (not 50bps crypto)
 N_SPLITS = 5
-REFIT_EVERY = 66  # quarterly refit (daily data has more obs than crypto intraday)
+REFIT_EVERY = 22
 RESULTS_DIR = SCRIPT_DIR / "results" / "m15_cross_asset"
 
 # LSTM hyperparams (same as crypto M15)
@@ -78,11 +78,10 @@ def load_daily_asset(ticker: str) -> pd.Series:
     """Load daily log-returns for a traditional asset via yfinance.
 
     Returns a Series of daily log-returns indexed by Date.
-    Limited to last 10 years for computational feasibility.
     """
     import yfinance as yf
 
-    data = yf.download(ticker, period="10y", auto_adjust=True, progress=False)
+    data = yf.download(ticker, period="max", auto_adjust=True, progress=False)
     if data.empty:
         raise ValueError(f"No data for {ticker}")
     close = data["Close"]


### PR DESCRIPTION
## Summary
- `REFIT_EVERY` 66→22 (monthly walk-forward instead of quarterly) for finer regime adaptation
- `yfinance` period `"10y"`→`"max"` to leverage full available history for SPY/TLT/^VIX
- Prep for S9 long-horizon retest (issue #1191)

## Changes
- `m15_cross_asset_lstm.py`: 2 param changes, -3/+2 lines

## Test plan
- [ ] Run on ai-01 with `coursia-ml-training` conda env (PyTorch+CUDA required)
- [ ] Walk-forward 5-fold × 4 seeds, compare Sharpe vs original REFIT_EVERY=66
- [ ] Verify no regression on S1 HAR-RV-J baseline

## Note
Execution requires GPU (RTX 3090). NOT runnable on po-2024 (no CUDA).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>