### PR TITLE
fix(env): pin fsspec<=2026.2.0 to prevent datasets 4.8.5 conflict (#1338)

### DIFF
--- a/docker-configurations/services/orchestrator/requirements.txt
+++ b/docker-configurations/services/orchestrator/requirements.txt
@@ -8,6 +8,7 @@ requests>=2.31.0
 python-dotenv>=1.0.0
 openai>=1.3.0
 huggingface-hub>=0.20.0
+fsspec>=2023.1.0,<=2026.2.0
 
 # HTTP server
 

--- a/scripts/genai-stack/requirements.txt
+++ b/scripts/genai-stack/requirements.txt
@@ -3,4 +3,5 @@ requests>=2.28.0
 bcrypt>=4.0.0
 python-dotenv>=1.0.0
 huggingface_hub>=0.20.0
+fsspec>=2023.1.0,<=2026.2.0
 papermill>=2.4.0


### PR DESCRIPTION
## Summary
- Pin `fsspec>=2023.1.0,<=2026.2.0` in `scripts/genai-stack/requirements.txt` and `docker-configurations/services/orchestrator/requirements.txt`
- Prevents `datasets 4.8.5` (requires `fsspec<=2026.2.0`) from conflicting with `fsspec 2026.3.0` pulled by `huggingface_hub`/`torch`

## Test plan
- [ ] `pip install -r scripts/genai-stack/requirements.txt` resolves without conflict warning
- [ ] `import datasets` works without import errors

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)