### PR TITLE
docs(reviews): student TP PR policy — benevolent reviews + bypass CI/template

### DIFF
--- a/.claude/rules/pr-review-discipline.md
+++ b/.claude/rules/pr-review-discipline.md
@@ -2,6 +2,8 @@
 
 S'applique à **tous les reviewers**, humains et bots (clusterManager-Myia, jsboige self-bot, ai-01 coordinateur).
 
+**Exception — PRs de TP étudiantes (mandat user 2026-05-20).** Les critères CHANGES_REQUESTED A-G ci-dessous visent les PRs **internes/contributeurs** (agents cluster `myia-*`, staff). Les PRs soumises par des **étudiants** (forks ou comptes étudiants de `jsboige/CoursIA`) suivent [student-pr-reviews.md](student-pr-reviews.md) : review **bienveillante**, bypass template + CI, **pas de CHANGES_REQUESTED** sur scaffolding (template vide, CI rouge, exec_count manquant). Ne PAS appliquer A-G à un TP étudiant.
+
 **Contexte (incident 2026-05-08), workflow ai-01, anti-patterns détaillés** : [docs/pr-review-context.md](../../docs/pr-review-context.md).
 
 ## Critères CHANGES_REQUESTED obligatoires (HARD)

--- a/.claude/rules/student-pr-reviews.md
+++ b/.claude/rules/student-pr-reviews.md
@@ -61,6 +61,39 @@ Si plusieurs agents commentent un meme PR etudiant (ex: `jsboigeEpita` bot breve
 - Mentionner un critere chiffre ("ce point vaut 3 points") -> fuite de la grille
 - Repondre publiquement a une question etudiant en livrant la grille ("pour la soutenance, regardez bien tel critere")
 
+## PRs de TP etudiantes — review bienveillante + bypass CI/template (mandat user 2026-05-20)
+
+Quand les etudiants soumettent leurs PRs de TP (forks de `jsboige/CoursIA` ou comptes etudiants), le standard de review **change** par rapport aux PRs internes du cluster. Source : mandat user 2026-05-20 (afflux PRs TP EPITA-IS).
+
+**Identifier une PR de TP etudiante** : auteur != agent cluster (`myia-*`) ET != staff (jsboige). Branche ne suit pas la convention `feature/`/`fix/`. Touche des notebooks de TP / exercices.
+
+### 1. Reviews bienveillantes (HARD)
+
+- **Corriger soi-meme les petits defauts** (typo, cellule oubliee, output manquant, petit bug) plutot que renvoyer l'etudiant.
+- **CHANGES_REQUESTED reserve aux VRAIS problemes** : code qui ne tourne pas du tout, TP hors-sujet, fichier essentiel manquant. **Pas de relance** pour : template incomplet, CI rouge, style, `execution_count` manquant, formatage, scaffolding.
+- Format = points forts + signalement **factuel** des manques (cf "Reviews publiques autorisees"). Toujours : **pas de fuite questions soutenance** (regle HARD ci-dessus reste valable).
+
+### 2. Bypass modele de PR + CI (mandat user)
+
+Les etudiants sont freines par le template PR (checklist 5 points) et les checks CI (`notebook-execution-required`, `catalog-drift`). Pour une PR de TP etudiante :
+
+- Le **template peut rester vide / non coche** — ne pas exiger qu'il soit rempli.
+- Les **checks CI peuvent etre rouges** — `notebook-execution-required` (exec_count/outputs/C.1) et `catalog-drift` ciblent la discipline des contributeurs internes, **pas les etudiants**.
+- **Merge** : ai-01 (coordinateur) merge via `gh auth switch -u jsboige` + `gh pr merge <N> --admin --squash` (l'admin override bypasse les required checks rouges), apres une review bienveillante. Ne pas bloquer un TP correct sur un CI rouge de scaffolding.
+
+### 3. Workflow exercices -> exemples (inchange)
+
+Le workflow pedagogique reste : un exercice resolu/soumis **devient un exemple**, et de **nouveaux exercices sont ajoutes a la suite**. Classification par contenu (cf [exercise-example-labeling.md](exercise-example-labeling.md)). Ne jamais stubber une solution etudiante soumise ni purger les exemples existants.
+
+### 4. Cooperation des 2 bots reviewers (HARD)
+
+Sur une PR etudiante, **@clusterManager-Myia** (reviewer principal) et **@jsboige self-bot** doivent coordonner :
+
+- **Une seule review publique breve** par PR (points forts). Pas de double review redondante ni contradictoire (incident 2026-05-17).
+- **clusterManager-Myia** : NE PAS appliquer les criteres CHANGES_REQUESTED A-G de [pr-review-discipline.md](pr-review-discipline.md) aux PRs etudiantes (ils visent les PRs internes/contributeurs). Sur PR etudiante : review bienveillante uniquement.
+- **jsboige self-bot** : reste en COMMENTED, ne duplique pas la review de clusterManager-Myia.
+- En cas de doute sur qui poste : coordination dashboard workspace CoursIA **avant** de commenter.
+
 ## Precedents associes
 
 - **2026-04-20** (`feedback_commits_solutions_discrets`) : les titres de commits/PRs ne doivent PAS mentionner "solutions" / "answer" / "leak". Cette regle etend la prudence aux comments PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->
+
+> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.
+
 ## Summary
 
 <!-- 1-3 bullet points describing what this PR does -->


### PR DESCRIPTION
## Summary

Mandat user 2026-05-20 : afflux imminent de PRs de TP étudiantes (EPITA-IS). Persiste la politique de review pour que les agents ET les 2 bots l'auto-chargent.

- **Reviews bienveillantes** : corriger les petits défauts soi-même, CHANGES_REQUESTED réservé aux vrais problèmes.
- **Bypass template + CI** : étudiants freinés par le template 5-points et les checks `notebook-execution-required` / `catalog-drift` → admin merge, CI rouge ne bloque pas un TP correct.
- **Workflow inchangé** : exercice résolu → devient exemple, nouveaux exercices ajoutés à la suite (content-based labeling).
- **Coopération des 2 bots** : clusterManager-Myia (review principale brève) + jsboige self-bot (COMMENTED, pas de doublon).

## Changes

- `.claude/rules/student-pr-reviews.md` : nouvelle section "PRs de TP étudiantes" (4 sous-règles).
- `.claude/rules/pr-review-discipline.md` : scope clarifier — critères A-G ne s'appliquent pas aux TP étudiants.
- `.github/pull_request_template.md` : note étudiant en tête (remplir Summary seul, CI rouge ne bloque pas).

Docs-only, 39 insertions. Urgent (avant arrivée des PRs étudiantes). Auto-merge coordinateur.