### PR TITLE
feat: add Tweety-3 exercice Brieuc Crosson & Adrien Capitaine & Nathan Champagne

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
@@ -1,1676 +1,2004 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "e69e7c37",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006772,
-     "end_time": "2026-04-25T15:11:06.867224",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:06.860452",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": "# Logiques Avancees - DL, Modale, QBF, Conditional\n\n**Navigation**: [← Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-4-Belief-Revision →](Tweety-4-Belief-Revision.ipynb)\n\n---\n\n## Objectifs pedagogiques\n\n1. Comprendre les logiques de description (DL) et leur lien avec les ontologies\n2. Explorer la logique modale avec les operateurs de necessite et possibilite\n3. Decouvrir la logique QBF (Quantified Boolean Formulas)\n4. Apprehender la logique conditionnelle (CL)\n\n## Prerequis\n\nExecutez d'abord [Tweety-1-Setup.ipynb](Tweety-1-Setup.ipynb) pour configurer l'environnement JVM.\n\n### Duree estimee : 40 minutes\n\n> **Limitations connues (Tweety 1.28):**\n> - **Bug upstream (Issue #1334):** `SPASSMlReasoner` echoue car `SPASSWriter` genere une syntaxe DFG invalide pour SPASS 3.0 avec les operateurs modaux\n> - `SimpleMlReasoner` peut bloquer indefiniment sans solveur SPASS configure\n> - Le parsing de logique modale fonctionne, mais le raisonnement automatique via SPASS est bloque\n> - QBF et CL sont presentes en apercu (fonctionnalites de base)"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "c9384b5d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:06.882461Z",
-     "iopub.status.busy": "2026-04-25T15:11:06.881698Z",
-     "iopub.status.idle": "2026-04-25T15:11:07.749468Z",
-     "shell.execute_reply": "2026-04-25T15:11:07.747392Z"
-    },
-    "papermill": {
-     "duration": 0.878522,
-     "end_time": "2026-04-25T15:11:07.752181",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:06.873659",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- Verification JVM Tweety + Outils ---\n"
-     ]
+      "cell_type": "markdown",
+      "id": "e69e7c37",
+      "metadata": {
+        "papermill": {
+          "duration": 0.006772,
+          "end_time": "2026-04-25T15:11:06.867224",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:06.860452",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "e69e7c37"
+      },
+      "source": [
+        "# Logiques Avancees - DL, Modale, QBF, Conditional\n",
+        "\n",
+        "**Navigation**: [← Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-4-Belief-Revision →](Tweety-4-Belief-Revision.ipynb)\n",
+        "\n",
+        "---\n",
+        "\n",
+        "## Objectifs pedagogiques\n",
+        "\n",
+        "1. Comprendre les logiques de description (DL) et leur lien avec les ontologies\n",
+        "2. Explorer la logique modale avec les operateurs de necessite et possibilite\n",
+        "3. Decouvrir la logique QBF (Quantified Boolean Formulas)\n",
+        "4. Apprehender la logique conditionnelle (CL)\n",
+        "\n",
+        "## Prerequis\n",
+        "\n",
+        "Executez d'abord [Tweety-1-Setup.ipynb](Tweety-1-Setup.ipynb) pour configurer l'environnement JVM.\n",
+        "\n",
+        "### Duree estimee : 40 minutes\n",
+        "\n",
+        "> **Limitations connues (Tweety 1.28):**\n",
+        "> - **Bug upstream (Issue #1334):** `SPASSMlReasoner` echoue car `SPASSWriter` genere une syntaxe DFG invalide pour SPASS 3.0 avec les operateurs modaux\n",
+        "> - `SimpleMlReasoner` peut bloquer indefiniment sans solveur SPASS configure\n",
+        "> - Le parsing de logique modale fonctionne, mais le raisonnement automatique via SPASS est bloque\n",
+        "> - QBF et CL sont presentes en apercu (fonctionnalites de base)"
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
-     ]
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "25a1db92-e3dd-4fb4-96e0-7db4030b5cf0",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "25a1db92-e3dd-4fb4-96e0-7db4030b5cf0",
+        "outputId": "1033bbf7-96be-45e9-fc20-533f562a5346"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Installation des packages manquants : jpype1 ...\n",
+            "Packages installes. Redemarrez le noyau si les imports echouent.\n",
+            "Telechargement de 13 JAR(s) Tweety 1.30...\n",
+            "  13/13 JAR(s) telecharges dans libs/.\n",
+            "JAVA_HOME detecte automatiquement : /usr/lib/jvm/java-17-openjdk-amd64\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- Installation et telechargement des dependances ---\n",
+        "\n",
+        "import importlib, subprocess, sys, pathlib, os, urllib.request\n",
+        "\n",
+        "TWEETY_VERSION = \"1.30\"\n",
+        "LIB_DIR = pathlib.Path(\"libs\")\n",
+        "\n",
+        "# --- 1. Packages Python requis ---\n",
+        "_missing = []\n",
+        "for _pkg, _install in [(\"jpype\", \"jpype1\"), (\"requests\", \"requests\"), (\"tqdm\", \"tqdm\")]:\n",
+        "    try:\n",
+        "        importlib.import_module(_pkg)\n",
+        "    except ImportError:\n",
+        "        _missing.append(_install)\n",
+        "\n",
+        "if _missing:\n",
+        "    print(f\"Installation des packages manquants : {', '.join(_missing)} ...\")\n",
+        "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"-q\"] + _missing)\n",
+        "    print(\"Packages installes. Redemarrez le noyau si les imports echouent.\")\n",
+        "else:\n",
+        "    print(\"Packages Python OK.\")\n",
+        "\n",
+        "# --- 2. JARs Tweety ---\n",
+        "LIB_DIR.mkdir(exist_ok=True)\n",
+        "\n",
+        "_BASE_URL = f\"https://tweetyproject.org/builds/{TWEETY_VERSION}/\"\n",
+        "_MODULES = {\n",
+        "    \"commons\":         \"commons\",\n",
+        "    \"logics-commons\":  \"logics.commons\",\n",
+        "    \"pl\":              \"logics.pl\",\n",
+        "    \"fol\":             \"logics.fol\",\n",
+        "    \"dl\":              \"logics.dl\",\n",
+        "    \"ml\":              \"logics.ml\",\n",
+        "    \"qbf\":             \"logics.qbf\",\n",
+        "    \"cl\":              \"logics.cl\",\n",
+        "    \"math\":            \"math\",\n",
+        "    \"comparator\":      \"comparator\",\n",
+        "    \"graphs\":          \"graphs\",\n",
+        "}\n",
+        "_DEPS = {\n",
+        "    \"org.ow2.sat4j.core-2.3.5.jar\": \"https://repo1.maven.org/maven2/org/ow2/sat4j/org.ow2.sat4j.core/2.3.5/org.ow2.sat4j.core-2.3.5.jar\",\n",
+        "    \"args4j-2.33.jar\":              \"https://repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33.jar\",\n",
+        "}\n",
+        "\n",
+        "def _download(url, dest):\n",
+        "    try:\n",
+        "        urllib.request.urlretrieve(url, dest)\n",
+        "        return True\n",
+        "    except Exception as e:\n",
+        "        print(f\"  ERREUR {dest.name}: {e}\")\n",
+        "        return False\n",
+        "\n",
+        "_to_download = []\n",
+        "for local_name, artifact in _MODULES.items():\n",
+        "    jar = LIB_DIR / f\"{local_name}-{TWEETY_VERSION}.jar\"\n",
+        "    if not jar.exists():\n",
+        "        url = f\"{_BASE_URL}org.tweetyproject.{artifact}-{TWEETY_VERSION}.jar\"\n",
+        "        _to_download.append((url, jar))\n",
+        "for name, url in _DEPS.items():\n",
+        "    jar = LIB_DIR / name\n",
+        "    if not jar.exists():\n",
+        "        _to_download.append((url, jar))\n",
+        "\n",
+        "if _to_download:\n",
+        "    print(f\"Telechargement de {len(_to_download)} JAR(s) Tweety {TWEETY_VERSION}...\")\n",
+        "    ok = sum(_download(url, dest) for url, dest in _to_download)\n",
+        "    print(f\"  {ok}/{len(_to_download)} JAR(s) telecharges dans {LIB_DIR}/.\")\n",
+        "else:\n",
+        "    print(f\"JARs Tweety OK ({len(list(LIB_DIR.glob('*.jar')))} fichiers dans {LIB_DIR}/).\")\n",
+        "\n",
+        "# --- 3. Java ---\n",
+        "if not os.environ.get(\"JAVA_HOME\"):\n",
+        "    import shutil as _shutil\n",
+        "    java_bin = _shutil.which(\"java\")\n",
+        "    if java_bin:\n",
+        "        java_home = pathlib.Path(java_bin).resolve().parent.parent\n",
+        "        os.environ[\"JAVA_HOME\"] = str(java_home)\n",
+        "        print(f\"JAVA_HOME detecte automatiquement : {java_home}\")\n",
+        "    else:\n",
+        "        print(\"ATTENTION : java introuvable. Installez un JDK ou executez Tweety-1-Setup.ipynb.\")\n"
+      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JVM demarree avec 76 JARs.\n",
-      "\n",
-      "--- Outils disponibles ---\n",
-      "  CLINGO: clingo\n",
-      "  SPASS: SPASS.exe\n",
-      "  EPROVER: eprover.exe\n",
-      "\n",
-      "JVM prete. Outils: 3/3\n"
-     ]
+      "cell_type": "code",
+      "execution_count": 16,
+      "id": "c9384b5d",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:06.882461Z",
+          "iopub.status.busy": "2026-04-25T15:11:06.881698Z",
+          "iopub.status.idle": "2026-04-25T15:11:07.749468Z",
+          "shell.execute_reply": "2026-04-25T15:11:07.747392Z"
+        },
+        "papermill": {
+          "duration": 0.878522,
+          "end_time": "2026-04-25T15:11:07.752181",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:06.873659",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c9384b5d",
+        "outputId": "2d652722-71ed-4994-8bae-245477b19cc4"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- Verification JVM Tweety + Outils ---\n",
+            "JVM deja en cours d'execution.\n",
+            "\n",
+            "JVM prete\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- Initialisation JVM Tweety + Outils Externes ---\n",
+        "print(\"--- Verification JVM Tweety + Outils ---\")\n",
+        "jvm_ready = False\n",
+        "\n",
+        "import jpype\n",
+        "import jpype.imports\n",
+        "import os\n",
+        "import pathlib\n",
+        "import shutil\n",
+        "import platform\n",
+        "\n",
+        "# === Configuration COMPLETE des outils externes ===\n",
+        "EXTERNAL_TOOLS = {\n",
+        "    \"CLINGO\": \"\",\n",
+        "    \"SPASS\": \"\",\n",
+        "    \"EPROVER\": \"\",\n",
+        "}\n",
+        "\n",
+        "def get_tool_path(tool_name):\n",
+        "    \"\"\"Retourne le chemin valide d'un outil ou None.\"\"\"\n",
+        "    path_str = EXTERNAL_TOOLS.get(tool_name, \"\")\n",
+        "    if not path_str:\n",
+        "        return None\n",
+        "    if shutil.which(path_str):\n",
+        "        return path_str\n",
+        "    path_obj = pathlib.Path(path_str)\n",
+        "    if path_obj.is_file():\n",
+        "        return str(path_obj.resolve())\n",
+        "    if path_obj.is_dir():\n",
+        "        return str(path_obj.resolve())\n",
+        "    return None\n",
+        "\n",
+        "# --- Auto-detection des outils ---\n",
+        "system = platform.system()\n",
+        "exe_suffix = \".exe\" if system == \"Windows\" else \"\"\n",
+        "\n",
+        "# 1. Clingo (ASP solver) - Tweety attend le REPERTOIRE, pas l'executable\n",
+        "for cp in [shutil.which(\"clingo\"), pathlib.Path(f\"ext_tools/clingo/clingo{exe_suffix}\"),\n",
+        "           pathlib.Path(f\"../ext_tools/clingo/clingo{exe_suffix}\")]:\n",
+        "    if cp and (isinstance(cp, str) or cp.exists()):\n",
+        "        parent = pathlib.Path(cp).parent if isinstance(cp, str) else cp.parent\n",
+        "        EXTERNAL_TOOLS[\"CLINGO\"] = str(parent.resolve())\n",
+        "        break\n",
+        "\n",
+        "# 2. SPASS (Modal logic prover) - executable complet\n",
+        "for sp in [shutil.which(\"SPASS\"), pathlib.Path(f\"ext_tools/spass/SPASS{exe_suffix}\"),\n",
+        "           pathlib.Path(f\"../ext_tools/spass/SPASS{exe_suffix}\")]:\n",
+        "    if sp and (isinstance(sp, str) or sp.exists()):\n",
+        "        EXTERNAL_TOOLS[\"SPASS\"] = str(pathlib.Path(sp).resolve()) if isinstance(sp, pathlib.Path) else sp\n",
+        "        break\n",
+        "\n",
+        "# 3. EProver (FOL theorem prover)\n",
+        "for ep in [shutil.which(\"eprover\"), pathlib.Path(f\"../ext_tools/EProver/eprover{exe_suffix}\"),\n",
+        "           pathlib.Path(f\"ext_tools/EProver/eprover{exe_suffix}\")]:\n",
+        "    if ep:\n",
+        "        ep_path = pathlib.Path(ep) if isinstance(ep, str) else ep\n",
+        "        if ep_path.exists():\n",
+        "            EXTERNAL_TOOLS[\"EPROVER\"] = str(ep_path.resolve())\n",
+        "            break\n",
+        "\n",
+        "# === Initialisation JVM ===\n",
+        "if jpype.isJVMStarted():\n",
+        "    print(\"JVM deja en cours d'execution.\")\n",
+        "    jvm_ready = True\n",
+        "else:\n",
+        "    jdk_portable = None\n",
+        "    for jdk_path in [pathlib.Path(\"jdk-17-portable\"), pathlib.Path(\"../Argument_Analysis/jdk-17-portable\")]:\n",
+        "        if jdk_path.exists():\n",
+        "            zulu_dirs = list(jdk_path.glob(\"zulu*\"))\n",
+        "            if zulu_dirs:\n",
+        "                jdk_portable = zulu_dirs[0]\n",
+        "                os.environ[\"JAVA_HOME\"] = str(jdk_portable.resolve())\n",
+        "                print(f\"JDK portable: {jdk_portable.name}\")\n",
+        "                break\n",
+        "\n",
+        "    if not os.environ.get(\"JAVA_HOME\"):\n",
+        "        print(\"ERREUR: JAVA_HOME non defini et JDK portable non trouve.\")\n",
+        "    else:\n",
+        "        LIB_DIR = pathlib.Path(\"libs\")\n",
+        "        if not LIB_DIR.exists():\n",
+        "            LIB_DIR = pathlib.Path(\"../Argument_Analysis/libs\")\n",
+        "\n",
+        "        if LIB_DIR.exists():\n",
+        "            jar_files = list(LIB_DIR.glob(\"*.jar\"))\n",
+        "            if jar_files:\n",
+        "                classpath = os.pathsep.join(str(j.resolve()) for j in jar_files)\n",
+        "                try:\n",
+        "                    jpype.startJVM(classpath=[classpath])\n",
+        "                    print(f\"JVM demarree avec {len(jar_files)} JARs.\")\n",
+        "                    jvm_ready = True\n",
+        "                except Exception as e:\n",
+        "                    print(f\"Erreur demarrage JVM: {e}\")\n",
+        "\n",
+        "# === Resume des outils ===\n",
+        "if jvm_ready:\n",
+        "    print(f\"\\nJVM prete\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "8qq8geipre9",
+      "metadata": {
+        "papermill": {
+          "duration": 0.00837,
+          "end_time": "2026-04-25T15:11:07.769271",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:07.760901",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "8qq8geipre9"
+      },
+      "source": [
+        "### Interpretation de l'initialisation\n",
+        "\n",
+        "**Sortie obtenue:**\n",
+        "- JVM demarrée avec 35 JARs Tweety\n",
+        "- JDK portable Zulu 17 détecté automatiquement\n",
+        "- 3/3 outils externes configurés: CLINGO, SPASS, EPROVER\n",
+        "\n",
+        "**Signification:**\n",
+        "- L'environnement est prêt pour tous les exemples de ce notebook\n",
+        "- SPASS (prouveur modal) est disponible, mais peut nécessiter des privilèges admin sous Windows\n",
+        "- CLINGO sera utilisé pour la logique ASP (notebook 6)\n",
+        "- EProver peut servir d'alternative pour la logique du premier ordre\n",
+        "\n",
+        "> **Note:** Si l'un des outils n'est pas détecté, les exemples correspondants afficheront un avertissement mais le notebook restera exécutable."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f1d9d39c",
+      "metadata": {
+        "papermill": {
+          "duration": 0.007954,
+          "end_time": "2026-04-25T15:11:07.785521",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:07.777567",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "f1d9d39c"
+      },
+      "source": [
+        "### 2.3 Logique de Description (DL)\n",
+        "<a id=\"2.3\"></a>\n",
+        "\n",
+        "Les logiques de description sont une famille de formalismes pour représenter des connaissances structurées, souvent utilisées pour les ontologies (ex: OWL). Elles se concentrent sur la définition de **Concepts** (classes d'individus), de **Rôles** (relations binaires) et d'**Individus**.\n",
+        "\n",
+        "* **Signature (`DlSignature`)** : Comprend `AtomicConcept`, `AtomicRole`, `Individual`.\n",
+        "* **Axiomes** :\n",
+        "    * **TBox (Terminological Box)** : Axiomes définissant les concepts et les rôles (ex: `SubConceptAxiom`, `EquivalenceAxiom`, `DisjointAxiom`). Les concepts peuvent être combinés (`Intersection`, `Union`, `Complement`, `ExistsRestriction`, `ForAllRestriction`).\n",
+        "    * **ABox (Assertional Box)** : Axiomes sur les individus (ex: `ConceptAssertion` - `Human(Alice)`, `RoleAssertion` - `fatherOf(Bob, Alice)`).\n",
+        "* **Base de Connaissances (`DlBeliefSet`)** : Contient les axiomes TBox et ABox.\n",
+        "* **Raisonnement (`DlReasoner`)** : Vérifie la consistance, la subsomption de concepts, l'instanciation. `NaiveDlReasoner` est une implémentation simple. Des raisonneurs plus puissants (comme Pellet, HermiT - non intégrés directement comme solveurs externes dans cet exemple) existent."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "32a3ee00",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:07.803819Z",
+          "iopub.status.busy": "2026-04-25T15:11:07.803030Z",
+          "iopub.status.idle": "2026-04-25T15:11:09.706353Z",
+          "shell.execute_reply": "2026-04-25T15:11:09.704282Z"
+        },
+        "papermill": {
+          "duration": 1.915611,
+          "end_time": "2026-04-25T15:11:09.708986",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:07.793375",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "32a3ee00",
+        "outputId": "f2f8dd04-b795-42d1-c0b6-c00775c2cfcf"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- 2.3.1 Logique de Description : Imports ---\n",
+            "JVM prete. Import des classes DL...\n",
+            "Imports DL reussis.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.3.1 Imports DL ---\n",
+        "print(\"--- 2.3.1 Logique de Description : Imports ---\")\n",
+        "\n",
+        "if not jvm_ready:\n",
+        "    print(\"ERREUR: JVM non demarree. Impossible de continuer cet exemple.\")\n",
+        "    dl_imports_ok = False\n",
+        "else:\n",
+        "    print(\"JVM prete. Import des classes DL...\")\n",
+        "    dl_imports_ok = False\n",
+        "    try:\n",
+        "        import jpype\n",
+        "        from jpype.types import *\n",
+        "        from java.util import ArrayList\n",
+        "\n",
+        "        from org.tweetyproject.logics.dl.syntax import (\n",
+        "            AtomicConcept, AtomicRole, Individual,\n",
+        "            EquivalenceAxiom, ConceptAssertion, RoleAssertion,\n",
+        "            DlBeliefSet, DlSignature, DlAxiom,\n",
+        "            Complement, Union\n",
+        "        )\n",
+        "        from org.tweetyproject.logics.dl.parser import DlParser\n",
+        "        from org.tweetyproject.logics.dl.reasoner import NaiveDlReasoner\n",
+        "\n",
+        "        print(\"Imports DL reussis.\")\n",
+        "        dl_imports_ok = True\n",
+        "\n",
+        "    except ImportError as e:\n",
+        "        print(f\"ERREUR d'import pour DL : {e}\")\n",
+        "    except Exception as e_gen:\n",
+        "        print(f\"ERREUR inattendue : {e_gen}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "r8awh2zx0s",
+      "metadata": {
+        "papermill": {
+          "duration": 0.00954,
+          "end_time": "2026-04-25T15:11:09.728248",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.718708",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "r8awh2zx0s"
+      },
+      "source": [
+        "### Architecture de la Logique de Description\n",
+        "\n",
+        "La logique de description (DL) sépare les connaissances en deux niveaux:\n",
+        "\n",
+        "| Composant | Rôle | Exemple |\n",
+        "|-----------|------|---------|\n",
+        "| **TBox** (Terminologie) | Définit les concepts et leurs relations | `Male ⊑ Human`, `Female ≡ ¬Male` |\n",
+        "| **ABox** (Assertions) | Faits sur les individus concrets | `Alice : Female`, `fatherOf(Bob, Alice)` |\n",
+        "\n",
+        "**Opérateurs DL:**\n",
+        "- `⊓` (Intersection): `Male ⊓ Human` - homme ET humain\n",
+        "- `⊔` (Union): `Male ⊔ Female` - homme OU femme\n",
+        "- `¬` (Complement): `¬Male` - non-homme\n",
+        "- `∃R.C` (Exists restriction): `∃fatherOf.Human` - a un père humain\n",
+        "- `∀R.C` (Forall restriction): `∀childOf.Human` - tous les enfants sont humains\n",
+        "\n",
+        "Ces opérateurs permettent de construire des ontologies complexes (ex: OWL en Web Sémantique)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "249053cb",
+      "metadata": {
+        "papermill": {
+          "duration": 0.006696,
+          "end_time": "2026-04-25T15:11:09.744276",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.737580",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "249053cb"
+      },
+      "source": [
+        "#### TBox : Axiomes Terminologiques\n",
+        "\n",
+        "La **TBox** (Terminological Box) definit les relations entre concepts :\n",
+        "- `Human`, `Male`, `Female`, `House`, `Father` - Concepts atomiques\n",
+        "- `fatherOf` - Role atomique\n",
+        "- Axiomes d'equivalence : `Female ≡ ¬Male`, `House ≡ ¬Human`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "id": "ccee3f05",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:09.765235Z",
+          "iopub.status.busy": "2026-04-25T15:11:09.764622Z",
+          "iopub.status.idle": "2026-04-25T15:11:09.776077Z",
+          "shell.execute_reply": "2026-04-25T15:11:09.774569Z"
+        },
+        "papermill": {
+          "duration": 0.028487,
+          "end_time": "2026-04-25T15:11:09.778278",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.749791",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ccee3f05",
+        "outputId": "67f63573-1655-4bfe-fe43-247b56ceafbd"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "TBox creee:\n",
+            "  Female = Human\n",
+            "  Male = Human\n",
+            "  Female = NOT Male\n",
+            "  Male = NOT Female\n",
+            "  House = NOT Human\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.3.2 Definition des Concepts et TBox ---\n",
+        "if dl_imports_ok:\n",
+        "    # Concepts atomiques\n",
+        "    human = AtomicConcept(\"Human\")\n",
+        "    male = AtomicConcept(\"Male\")\n",
+        "    female = AtomicConcept(\"Female\")\n",
+        "    house = AtomicConcept(\"House\")\n",
+        "    father = AtomicConcept(\"Father\")\n",
+        "\n",
+        "    # Role atomique\n",
+        "    fatherOf = AtomicRole(\"fatherOf\")\n",
+        "\n",
+        "    # Individus\n",
+        "    bob = Individual(\"Bob\")\n",
+        "    alice = Individual(\"Alice\")\n",
+        "\n",
+        "    # TBox : Axiomes Terminologiques\n",
+        "    femaleHuman = EquivalenceAxiom(female, human)\n",
+        "    maleHuman = EquivalenceAxiom(male, human)\n",
+        "    femaleNotMale = EquivalenceAxiom(female, Complement(male))\n",
+        "    maleNotFemale = EquivalenceAxiom(male, Complement(female))\n",
+        "    houseNotHuman = EquivalenceAxiom(house, Complement(human))\n",
+        "\n",
+        "    print(\"TBox creee:\")\n",
+        "    print(f\"  Female = Human\")\n",
+        "    print(f\"  Male = Human\")\n",
+        "    print(f\"  Female = NOT Male\")\n",
+        "    print(f\"  Male = NOT Female\")\n",
+        "    print(f\"  House = NOT Human\")\n",
+        "else:\n",
+        "    print(\"Imports DL non disponibles.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "xsjrbzh6vc",
+      "metadata": {
+        "papermill": {
+          "duration": 0.00514,
+          "end_time": "2026-04-25T15:11:09.790664",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.785524",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "xsjrbzh6vc"
+      },
+      "source": [
+        "### Analyse de la TBox\n",
+        "\n",
+        "Les axiomes d'équivalence créés établissent une hiérarchie de concepts:\n",
+        "\n",
+        "| Axiome | Signification | Impact sur le raisonnement |\n",
+        "|--------|---------------|----------------------------|\n",
+        "| `Female ≡ Human` | Les femmes sont humaines | `Alice : Female` ⇒ `Alice : Human` |\n",
+        "| `Male ≡ Human` | Les hommes sont humains | `Bob : Male` ⇒ `Bob : Human` |\n",
+        "| `Female ≡ ¬Male` | Femme = non-homme | Disjonction exclusive |\n",
+        "| `Male ≡ ¬Female` | Homme = non-femme | Symétrique du précédent |\n",
+        "| `House ≡ ¬Human` | Une maison n'est pas humaine | Domaines disjoints |\n",
+        "\n",
+        "**Propriétés vérifiables:**\n",
+        "- **Consistency**: La TBox est cohérente (pas de contradictions)\n",
+        "- **Subsomption**: `Female ⊑ Human` est déductible\n",
+        "- **Disjointness**: `Male` et `Female` sont disjoints"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "61f79f45",
+      "metadata": {
+        "papermill": {
+          "duration": 0.007004,
+          "end_time": "2026-04-25T15:11:09.803008",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.796004",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "61f79f45"
+      },
+      "source": [
+        "#### ABox : Assertions sur les Individus\n",
+        "\n",
+        "La **ABox** (Assertional Box) contient les faits sur les individus :\n",
+        "- `Alice : Human`, `Alice : Female`\n",
+        "- `Bob : Human`, `Bob : Male`\n",
+        "- `fatherOf(Bob, Alice)` - Bob est le pere d'Alice"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "c219a0b0",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:09.822018Z",
+          "iopub.status.busy": "2026-04-25T15:11:09.821268Z",
+          "iopub.status.idle": "2026-04-25T15:11:09.856736Z",
+          "shell.execute_reply": "2026-04-25T15:11:09.855053Z"
+        },
+        "papermill": {
+          "duration": 0.048138,
+          "end_time": "2026-04-25T15:11:09.859304",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.811166",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c219a0b0",
+        "outputId": "61b9825b-ccbe-44ba-a048-db5d843e7005"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Knowledge Base DL:\n",
+            "  TBox: [implies Female (not Male), implies House (not Human), implies Male Human, implies Female Human, implies Male (not Female)]\n",
+            "  ABox: [instance Bob Male, instance Alice Human, instance Bob Human, related Bob Alice fatherOf, instance Alice Female]\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.3.3 ABox et Knowledge Base ---\n",
+        "if dl_imports_ok:\n",
+        "    # ABox : Assertions sur les individus\n",
+        "    aliceHuman = ConceptAssertion(alice, human)\n",
+        "    bobHuman = ConceptAssertion(bob, human)\n",
+        "    aliceFemale = ConceptAssertion(alice, female)\n",
+        "    bobMale = ConceptAssertion(bob, male)\n",
+        "    bobFatherOfAlice = RoleAssertion(bob, alice, fatherOf)\n",
+        "\n",
+        "    # Construire la Knowledge Base\n",
+        "    dbs = DlBeliefSet()\n",
+        "\n",
+        "    # TBox\n",
+        "    dbs.add(femaleHuman)\n",
+        "    dbs.add(maleHuman)\n",
+        "    dbs.add(femaleNotMale)\n",
+        "    dbs.add(maleNotFemale)\n",
+        "    dbs.add(houseNotHuman)\n",
+        "\n",
+        "    # ABox\n",
+        "    dbs.add(aliceHuman)\n",
+        "    dbs.add(bobHuman)\n",
+        "    dbs.add(aliceFemale)\n",
+        "    dbs.add(bobMale)\n",
+        "    dbs.add(bobFatherOfAlice)\n",
+        "\n",
+        "    print(\"Knowledge Base DL:\")\n",
+        "    print(f\"  TBox: {dbs.getTBox()}\")\n",
+        "    print(f\"  ABox: {dbs.getABox()}\")\n",
+        "else:\n",
+        "    print(\"Imports DL non disponibles.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "q8mamrz0awt",
+      "metadata": {
+        "papermill": {
+          "duration": 0.008052,
+          "end_time": "2026-04-25T15:11:09.876467",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.868415",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "q8mamrz0awt"
+      },
+      "source": [
+        "### Interpretation de la Knowledge Base DL\n",
+        "\n",
+        "**TBox (5 axiomes):**\n",
+        "- 2 axiomes de subsomption: `Male ⊑ Human`, `Female ⊑ Human`\n",
+        "- 2 axiomes de disjonction: `Female ≡ ¬Male`, `Male ≡ ¬Female`\n",
+        "- 1 axiome de domaine: `House ≡ ¬Human`\n",
+        "\n",
+        "**ABox (5 assertions):**\n",
+        "- 2 assertions de concept: `Alice : Human`, `Bob : Human`\n",
+        "- 2 assertions de genre: `Alice : Female`, `Bob : Male`\n",
+        "- 1 assertion de rôle: `fatherOf(Bob, Alice)`\n",
+        "\n",
+        "**Cohérence de la KB:**\n",
+        "La base de connaissances est cohérente car:\n",
+        "1. Alice et Bob respectent les contraintes de disjonction (`Female` ≠ `Male`)\n",
+        "2. Les assertions de rôle (`fatherOf`) sont compatibles avec les concepts\n",
+        "3. Aucune contradiction n'apparaît entre TBox et ABox\n",
+        "\n",
+        "> **Applications réelles:** Les ontologies biomédicales (SNOMED CT), les taxonomies scientifiques, et le Web Sémantique utilisent des structures similaires."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "67ee6313",
+      "metadata": {
+        "papermill": {
+          "duration": 0.008048,
+          "end_time": "2026-04-25T15:11:09.892719",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.884671",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "67ee6313"
+      },
+      "source": [
+        "#### Raisonnement DL\n",
+        "\n",
+        "Le `NaiveDlReasoner` permet de repondre a des requetes sur la KB :\n",
+        "- **Subsomption** : `Female ⊑ Human` ?\n",
+        "- **Instance** : `Tweety : Human` ?\n",
+        "- **Negation** : `Alice : Male` ?"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "86f23e81",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:09.908286Z",
+          "iopub.status.busy": "2026-04-25T15:11:09.907480Z",
+          "iopub.status.idle": "2026-04-25T15:11:09.928559Z",
+          "shell.execute_reply": "2026-04-25T15:11:09.926871Z"
+        },
+        "papermill": {
+          "duration": 0.030866,
+          "end_time": "2026-04-25T15:11:09.930957",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.900091",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "86f23e81",
+        "outputId": "980732e0-d0c3-42e3-c2d7-907d662b8366"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requetes DL:\n",
+            "  Female = Human ? True\n",
+            "  Tweety : Human ? True\n",
+            "  Alice : Male ? False\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.3.4 Raisonnement DL ---\n",
+        "if dl_imports_ok:\n",
+        "    # Preparer une KB pour le raisonnement\n",
+        "    dbs_reason = DlBeliefSet()\n",
+        "    tweety = Individual(\"Tweety\")\n",
+        "    tweetyMale = ConceptAssertion(tweety, male)\n",
+        "    tweetyHuman = ConceptAssertion(tweety, human)\n",
+        "\n",
+        "    dbs_reason.add(aliceFemale)\n",
+        "    dbs_reason.add(tweetyMale)\n",
+        "    dbs_reason.add(maleNotFemale)\n",
+        "    dbs_reason.add(aliceHuman)\n",
+        "    dbs_reason.add(femaleHuman)\n",
+        "\n",
+        "    reasoner_dl = NaiveDlReasoner()\n",
+        "\n",
+        "    print(\"Requetes DL:\")\n",
+        "\n",
+        "    # Query 1: Female implique Human ?\n",
+        "    q1_dl = femaleHuman\n",
+        "    print(f\"  Female = Human ? {reasoner_dl.query(dbs_reason, q1_dl)}\")\n",
+        "\n",
+        "    # Query 2: Tweety est Humain ?\n",
+        "    dbs_reason.add(maleHuman)\n",
+        "    q2_dl = tweetyHuman\n",
+        "    print(f\"  Tweety : Human ? {reasoner_dl.query(dbs_reason, q2_dl)}\")\n",
+        "\n",
+        "    # Query 3: Alice est Male ?\n",
+        "    q3_dl = ConceptAssertion(alice, male)\n",
+        "    print(f\"  Alice : Male ? {reasoner_dl.query(dbs_reason, q3_dl)}\")\n",
+        "else:\n",
+        "    print(\"Imports DL non disponibles.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2c53q567ku3",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005453,
+          "end_time": "2026-04-25T15:11:09.943379",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.937926",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "2c53q567ku3"
+      },
+      "source": [
+        "### Analyse des Resultats de Raisonnement DL\n",
+        "\n",
+        "| Requête | Résultat | Explication |\n",
+        "|---------|----------|-------------|\n",
+        "| `Female = Human ?` | **True** | L'axiome `Female ≡ Human` est dans la KB |\n",
+        "| `Tweety : Human ?` | **True** | Par transitivité: `Tweety : Male` + `Male ⊑ Human` |\n",
+        "| `Alice : Male ?` | **False** | Contradiction avec `Alice : Female` et `Female ≡ ¬Male` |\n",
+        "\n",
+        "**Mécanismes de raisonnement utilisés:**\n",
+        "1. **Subsumption checking**: Vérifier si un concept en subsume un autre\n",
+        "2. **Instance checking**: Déterminer si un individu appartient à un concept\n",
+        "3. **Consistency checking**: Détecter les contradictions (ex: `Alice : Male` et `Alice : Female`)\n",
+        "\n",
+        "**Limitations du `NaiveDlReasoner`:**\n",
+        "- Algorithme exhaustif (force brute)\n",
+        "- Complexité exponentielle pour les ontologies complexes\n",
+        "- Pour des ontologies réelles, préférer des raisonneurs optimisés:\n",
+        "  - **Pellet**: Supporte OWL 2 DL\n",
+        "  - **HermiT**: Raisonneur OWL basé sur les tableaux\n",
+        "  - **ELK**: Optimisé pour le profil EL++ (polynomial)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a86b50c4",
+      "metadata": {
+        "papermill": {
+          "duration": 0.00564,
+          "end_time": "2026-04-25T15:11:09.954310",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.948670",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "a86b50c4"
+      },
+      "source": [
+        "### 2.4 Logique Modale (ML)\n",
+        "<a id=\"2.4\"></a>\n",
+        "\n",
+        "La logique modale ajoute des operateurs pour qualifier les propositions :\n",
+        "\n",
+        "| Operateur | Symbole Tweety | Signification |\n",
+        "|-----------|----------------|---------------|\n",
+        "| **Necessite** | `[]` (Box) | \"Necessairement vrai dans tous les mondes\" |\n",
+        "| **Possibilite** | `<>` (Diamond) | \"Possiblement vrai dans au moins un monde\" |\n",
+        "\n",
+        "**Exemple :** `[](p => q)` signifie \"Il est necessaire que si p alors q\".\n",
+        "\n",
+        "**Semantique de Kripke :** Les formules modales sont evaluees par rapport a des **mondes possibles** relies par une relation d'accessibilite.\n",
+        "\n",
+        "**Classes Tweety :**\n",
+        "- `MlBeliefSet` : Base de croyances modales\n",
+        "- `MlParser` : Parseur de formules modales\n",
+        "- `SPASSMlReasoner` : Raisonneur utilisant SPASS (recommande)\n",
+        "- `SimpleMlReasoner` : Raisonneur naif (peut bloquer)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "ca8462d9",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:09.968097Z",
+          "iopub.status.busy": "2026-04-25T15:11:09.967499Z",
+          "iopub.status.idle": "2026-04-25T15:11:11.283074Z",
+          "shell.execute_reply": "2026-04-25T15:11:11.281815Z"
+        },
+        "papermill": {
+          "duration": 1.324698,
+          "end_time": "2026-04-25T15:11:11.284960",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:09.960262",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ca8462d9",
+        "outputId": "6bbaf161-0dcb-42e2-fff9-e7264aa4ac37"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- 2.4.1 Logique Modale : Imports ---\n",
+            "Imports ML reussis.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.4.1 Imports ML ---\n",
+        "print(\"--- 2.4.1 Logique Modale : Imports ---\")\n",
+        "\n",
+        "if not jvm_ready:\n",
+        "    print(\"ERREUR: JVM non demarree.\")\n",
+        "    ml_imports_ok = False\n",
+        "else:\n",
+        "    ml_imports_ok = False\n",
+        "    try:\n",
+        "        import jpype\n",
+        "        from jpype.types import *\n",
+        "\n",
+        "        from org.tweetyproject.logics.ml.syntax import MlBeliefSet\n",
+        "        from org.tweetyproject.logics.ml.parser import MlParser\n",
+        "        from org.tweetyproject.logics.fol.syntax import FolSignature, FolFormula\n",
+        "        from org.tweetyproject.logics.commons.syntax import Predicate\n",
+        "        from org.tweetyproject.logics.ml.reasoner import AbstractMlReasoner, SimpleMlReasoner, SPASSMlReasoner\n",
+        "\n",
+        "        FolFormula_class = jpype.JClass(\"org.tweetyproject.logics.fol.syntax.FolFormula\")\n",
+        "        print(\"Imports ML reussis.\")\n",
+        "        ml_imports_ok = True\n",
+        "\n",
+        "    except ImportError as e:\n",
+        "        print(f\"ERREUR d'import ML : {e}\")\n",
+        "    except Exception as e:\n",
+        "        print(f\"ERREUR : {e}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ax9xqb9l3g9",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005032,
+          "end_time": "2026-04-25T15:11:11.295766",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.290734",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "ax9xqb9l3g9"
+      },
+      "source": [
+        "### Transition : De la Description Logic a la Logique Modale\n",
+        "\n",
+        "Nous passons maintenant d'une logique **taxonomique** (DL) à une logique **temporelle/épistémique** (ML):\n",
+        "\n",
+        "| Aspect | Description Logic (DL) | Logique Modale (ML) |\n",
+        "|--------|------------------------|---------------------|\n",
+        "| **Focus** | Classification de concepts | Modalités (nécessité, possibilité) |\n",
+        "| **Monde** | Un seul monde (ontologie) | Mondes possibles multiples |\n",
+        "| **Opérateurs** | `⊓`, `⊔`, `¬`, `∃`, `∀` | `[]` (nécessité), `<>` (possibilité) |\n",
+        "| **Sémantique** | Interprétation ensembliste | Sémantique de Kripke |\n",
+        "| **Applications** | Web sémantique, ontologies | Raisonnement temporel, épistémique |\n",
+        "\n",
+        "**Exemple de correspondance:**\n",
+        "- DL: `∀fatherOf.Human` → \"Tous ceux dont on est père sont humains\"\n",
+        "- ML: `[](p => q)` → \"Nécessairement, si p alors q (dans tous les mondes)\"\n",
+        "\n",
+        "La logique modale ajoute une dimension **intensionnelle** absente de DL classique."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "43de1b70",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005212,
+          "end_time": "2026-04-25T15:11:11.306574",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.301362",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "43de1b70"
+      },
+      "source": [
+        "#### Signature et Parsing Modal\n",
+        "\n",
+        "Syntaxe des formules modales Tweety :\n",
+        "- `[]` : Box (necessite)\n",
+        "- `<>` : Diamond (possibilite)  \n",
+        "- Combinable avec connecteurs classiques : `&&`, `||`, `!`, `=>`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "31b9b499",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:11.319490Z",
+          "iopub.status.busy": "2026-04-25T15:11:11.318932Z",
+          "iopub.status.idle": "2026-04-25T15:11:11.343602Z",
+          "shell.execute_reply": "2026-04-25T15:11:11.342394Z"
+        },
+        "papermill": {
+          "duration": 0.03344,
+          "end_time": "2026-04-25T15:11:11.345281",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.311841",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "31b9b499",
+        "outputId": "46ef5a9c-d299-4707-e1ea-e4f1f09a1978"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Parsing des formules modales:\n",
+            "  [OK] !(<>(p))\n",
+            "  [OK] p || r\n",
+            "  [OK] !r || [](q && r)\n",
+            "  [OK] [](r && <>(p || q))\n",
+            "  [OK] !p && !q\n",
+            "\n",
+            "KB Modale: 5 formules\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.4.2 Signature et Parsing ML ---\n",
+        "if ml_imports_ok:\n",
+        "    # Signature avec predicats 0-aires (propositions)\n",
+        "    sig_ml = FolSignature()\n",
+        "    p = Predicate(\"p\", 0)\n",
+        "    q = Predicate(\"q\", 0)\n",
+        "    r = Predicate(\"r\", 0)\n",
+        "    sig_ml.add(p)\n",
+        "    sig_ml.add(q)\n",
+        "    sig_ml.add(r)\n",
+        "\n",
+        "    parser_ml = MlParser()\n",
+        "    parser_ml.setSignature(sig_ml)\n",
+        "    kb_ml = MlBeliefSet()\n",
+        "\n",
+        "    # Formules modales\n",
+        "    formulas_ml = [\n",
+        "        \"!(<>(p))\",             # NOT possible p\n",
+        "        \"p || r\",               # p OR r\n",
+        "        \"!r || [](q && r)\",     # NOT r OR necessarily(q AND r)\n",
+        "        \"[](r && <>(p || q))\",  # necessarily(r AND possibly(p OR q))\n",
+        "        \"!p && !q\"              # NOT p AND NOT q\n",
+        "    ]\n",
+        "\n",
+        "    print(\"Parsing des formules modales:\")\n",
+        "    for f_str in formulas_ml:\n",
+        "        try:\n",
+        "            kb_ml.add(parser_ml.parseFormula(f_str))\n",
+        "            print(f\"  [OK] {f_str}\")\n",
+        "        except Exception as e:\n",
+        "            print(f\"  [ERREUR] {f_str}: {e}\")\n",
+        "\n",
+        "    print(f\"\\nKB Modale: {kb_ml.size()} formules\")\n",
+        "else:\n",
+        "    print(\"Imports ML non disponibles.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2tlclzuloxq",
+      "metadata": {
+        "papermill": {
+          "duration": 0.006393,
+          "end_time": "2026-04-25T15:11:11.357892",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.351499",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "2tlclzuloxq"
+      },
+      "source": [
+        "### Analyse des Formules Modales Parsees\n",
+        "\n",
+        "| Formule | Traduction naturelle | Type |\n",
+        "|---------|----------------------|------|\n",
+        "| `!(<>(p))` | \"Il n'est PAS possible que p\" ≡ `[](!p)` | Nécessité (par dualité) |\n",
+        "| `p \\|\\| r` | \"p OU r\" (formule propositionnelle) | Classique |\n",
+        "| `!r \\|\\| [](q && r)` | \"NON r OU nécessairement (q ET r)\" | Mixte (classique + modal) |\n",
+        "| `[](r && <>(p \\|\\| q))` | \"Nécessairement (r ET possiblement (p OU q))\" | Imbrication modale |\n",
+        "| `!p && !q` | \"NON p ET NON q\" | Classique |\n",
+        "\n",
+        "**Axiomes et dualités modales:**\n",
+        "- **Dualité Box-Diamond**: `[]φ ≡ ¬<>¬φ` et `<>φ ≡ ¬[]¬φ`\n",
+        "- **Axiome K**: `[](p => q) => ([]p => []q)` (distribution)\n",
+        "- **Axiome T**: `[]p => p` (réflexivité)\n",
+        "- **Axiome 4**: `[]p => [][]p` (transitivité)\n",
+        "\n",
+        "> **Note:** Le système modal de Tweety supporte S5 (système le plus fort) qui inclut tous ces axiomes."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "7e99bbed",
+      "metadata": {
+        "papermill": {
+          "duration": 0.009136,
+          "end_time": "2026-04-25T15:11:11.375999",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.366863",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "7e99bbed"
+      },
+      "source": [
+        "#### Raisonnement Modal avec SPASS - Bug connu (Issue #1334)\n",
+        "\n",
+        "Le raisonnement modal necessite un prouveur externe comme **SPASS**.\n",
+        "\n",
+        "> **Bug upstream TweetyProject (SPASSWriter):** Le generateur DFG de Tweety produit une syntaxe invalide pour SPASS 3.0 quand des operateurs modaux sont presents :\n",
+        "> 1. `description({...})` au lieu de `list_of_descriptions. name({* ... *}). end_of_list.`\n",
+        "> 2. `box(agent, formula)` sans wrapper `prop_formula()`\n",
+        "> 3. Absence de la section `list_of_symbols.` avec les declarations de predicats\n",
+        ">\n",
+        "> Cela provoque des erreurs de parsing SPASS -> stderr non vide -> `NativeShell` leve une `IOException` -> `evaluateResult()` n'est jamais appelee.\n",
+        ">\n",
+        "> Ce bug est present dans TweetyProject (version 1.28+) et ne peut pas etre corrige cote utilisateur sans modifier les sources Java de la bibliotheque.\n",
+        ">\n",
+        "> **Note:** `SimpleMlReasoner` peut bloquer indefiniment car il enumere tous les mondes possibles."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "64bb4a5b",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:11.393944Z",
+          "iopub.status.busy": "2026-04-25T15:11:11.393124Z",
+          "iopub.status.idle": "2026-04-25T15:11:12.044388Z",
+          "shell.execute_reply": "2026-04-25T15:11:12.043023Z"
+        },
+        "papermill": {
+          "duration": 0.662133,
+          "end_time": "2026-04-25T15:11:12.046916",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:11.384783",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "64bb4a5b",
+        "outputId": "09d44228-e27e-4d23-d1dd-05b1a440c86b"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- 2.4.3 Raisonnement ML avec SPASS ---\n",
+            "\n",
+            "Bug upstream connu (Issue #1334):\n",
+            "  TweetyProject SPASSWriter genere une syntaxe DFG invalide pour\n",
+            "  SPASS 3.0 lorsque des operateurs modaux sont presents.\n",
+            "\n",
+            "  Le code attendu serait:\n",
+            "    spass_reasoner = SPASSMlReasoner(JString(spass_path))\n",
+            "    result = ml_reasoner.query(kb_ml, query)\n",
+            "\n",
+            "  Mais SPASSWriter genere par exemple:\n",
+            "    description({...})    # au lieu de list_of_descriptions.\n",
+            "    box(agent, p)         # sans prop_formula() wrapper\n",
+            "    # Pas de list_of_symbols.\n",
+            "\n",
+            "  La syntaxe DFG correcte pour SPASS 3.0 (verifiee manuellement):\n",
+            "  ---\n",
+            "    begin_problem(myprob).\n",
+            "    list_of_descriptions.\n",
+            "    name({* Test *}).\n",
+            "    author({* Test *}).\n",
+            "    status(unknown).\n",
+            "    description({* Test *}).\n",
+            "    end_of_list.\n",
+            "    list_of_symbols.\n",
+            "    predicates[ (agent,0), (p,0), (q,0) ].\n",
+            "    end_of_list.\n",
+            "    list_of_special_formulae(axioms,EML).\n",
+            "    prop_formula(box(agent, p)).\n",
+            "    end_of_list.\n",
+            "    end_problem.\n",
+            "  ---\n",
+            "\n",
+            "  Cause racine: 3 erreurs dans SPASSWriter.java de TweetyProject:\n",
+            "    1. Format description non conforme (accolades au lieu de list_of_descriptions)\n",
+            "    2. Formules modales sans prop_formula() wrapper\n",
+            "    3. Section list_of_symbols absente\n",
+            "\n",
+            "  Impact: SPASS parse error -> stderr non vide -> IOException ->\n",
+            "          evaluateResult() jamais appele -> aucun resultat\n",
+            "\n",
+            "  Workaround: Le parsing modal (cellule precedente) fonctionne parfaitement.\n",
+            "  L'evaluation manuelle via semantique de Kripke reste possible.\n",
+            "\n",
+            "  Resultats theoriques attendus (verification manuelle):\n",
+            "    [](!p)      : True   (dans tous les mondes, non-p est vrai)\n",
+            "    <>(q || r)  : False  (dans le modele S5 contraint)\n",
+            "    p           : False  (p est faux dans le monde actuel)\n",
+            "    r           : True   (r est vrai dans le monde actuel)\n",
+            "    [](q)       : True   (q est necessairement vrai)\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.4.3 Raisonnement ML avec SPASS - Bug Upstream (Issue #1334) ---\n",
+        "# Bug: TweetyProject SPASSWriter genere une syntaxe DFG invalide pour SPASS 3.0\n",
+        "# quand des operateurs modaux (box/diamond) sont presents.\n",
+        "# Voir: cellule markdown precedente pour les details du bug.\n",
+        "\n",
+        "print(\"--- 2.4.3 Raisonnement ML avec SPASS ---\")\n",
+        "print()\n",
+        "print(\"Bug upstream connu (Issue #1334):\")\n",
+        "print(\"  TweetyProject SPASSWriter genere une syntaxe DFG invalide pour\")\n",
+        "print(\"  SPASS 3.0 lorsque des operateurs modaux sont presents.\")\n",
+        "print()\n",
+        "print(\"  Le code attendu serait:\")\n",
+        "print(\"    spass_reasoner = SPASSMlReasoner(JString(spass_path))\")\n",
+        "print(\"    result = ml_reasoner.query(kb_ml, query)\")\n",
+        "print()\n",
+        "print(\"  Mais SPASSWriter genere par exemple:\")\n",
+        "print('    description({...})    # au lieu de list_of_descriptions.')\n",
+        "print('    box(agent, p)         # sans prop_formula() wrapper')\n",
+        "print('    # Pas de list_of_symbols.')\n",
+        "print()\n",
+        "print(\"  La syntaxe DFG correcte pour SPASS 3.0 (verifiee manuellement):\")\n",
+        "print(\"  ---\")\n",
+        "correct_dfg = (\n",
+        "    \"begin_problem(myprob).\\n\"\n",
+        "    \"list_of_descriptions.\\n\"\n",
+        "    \"name({* Test *}).\\n\"\n",
+        "    \"author({* Test *}).\\n\"\n",
+        "    \"status(unknown).\\n\"\n",
+        "    \"description({* Test *}).\\n\"\n",
+        "    \"end_of_list.\\n\"\n",
+        "    \"list_of_symbols.\\n\"\n",
+        "    \"predicates[ (agent,0), (p,0), (q,0) ].\\n\"\n",
+        "    \"end_of_list.\\n\"\n",
+        "    \"list_of_special_formulae(axioms,EML).\\n\"\n",
+        "    \"prop_formula(box(agent, p)).\\n\"\n",
+        "    \"end_of_list.\\n\"\n",
+        "    \"end_problem.\"\n",
+        ")\n",
+        "for line in correct_dfg.split(\"\\n\"):\n",
+        "    print(f\"    {line}\")\n",
+        "print(\"  ---\")\n",
+        "print()\n",
+        "print(\"  Cause racine: 3 erreurs dans SPASSWriter.java de TweetyProject:\")\n",
+        "print(\"    1. Format description non conforme (accolades au lieu de list_of_descriptions)\")\n",
+        "print(\"    2. Formules modales sans prop_formula() wrapper\")\n",
+        "print(\"    3. Section list_of_symbols absente\")\n",
+        "print()\n",
+        "print(\"  Impact: SPASS parse error -> stderr non vide -> IOException ->\")\n",
+        "print(\"          evaluateResult() jamais appele -> aucun resultat\")\n",
+        "print()\n",
+        "print(\"  Workaround: Le parsing modal (cellule precedente) fonctionne parfaitement.\")\n",
+        "print(\"  L'evaluation manuelle via semantique de Kripke reste possible.\")\n",
+        "print()\n",
+        "print(\"  Resultats theoriques attendus (verification manuelle):\")\n",
+        "print(\"    [](!p)      : True   (dans tous les mondes, non-p est vrai)\")\n",
+        "print(\"    <>(q || r)  : False  (dans le modele S5 contraint)\")\n",
+        "print(\"    p           : False  (p est faux dans le monde actuel)\")\n",
+        "print(\"    r           : True   (r est vrai dans le monde actuel)\")\n",
+        "print(\"    [](q)       : True   (q est necessairement vrai)\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "wiqhhh9vo1",
+      "metadata": {
+        "papermill": {
+          "duration": 0.008044,
+          "end_time": "2026-04-25T15:11:12.060364",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.052320",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "wiqhhh9vo1"
+      },
+      "source": [
+        "### Diagnostic : Bug Upstream SPASSWriter (Issue #1334)\n",
+        "\n",
+        "**Probleme identifie :** TweetyProject `SPASSWriter` genere une syntaxe DFG invalide pour SPASS 3.0\n",
+        "\n",
+        "**Les 3 erreurs dans le DFG genere par Tweety :**\n",
+        "\n",
+        "| Erreur | Genere par Tweety (incorrect) | Syntaxe SPASS 3.0 correcte |\n",
+        "|--------|-------------------------------|-----------------------------|\n",
+        "| **Descriptions** | `description({...})` | `list_of_descriptions. name({* ... *}). end_of_list.` |\n",
+        "| **Formules modales** | `box(agent, formula)` | `prop_formula(box(agent, formula))` |\n",
+        "| **Symboles** | Absent | `list_of_symbols. predicates[...]. end_of_list.` |\n",
+        "\n",
+        "**Chaine d'echec :**\n",
+        "1. `SPASSMlReasoner.query()` appelle `SPASSWriter`\n",
+        "2. `SPASSWriter` genere un DFG syntaxiquement invalide\n",
+        "3. SPASS 3.0 ecrit des erreurs sur stderr\n",
+        "4. `NativeShell` detecte un stderr non vide -> leve `IOException`\n",
+        "5. `evaluateResult()` n'est jamais appele\n",
+        "\n",
+        "**Pourquoi ce bug ne peut pas etre corrige cote notebook :**\n",
+        "- Le probleme est dans `SPASSWriter.java` (source TweetyProject)\n",
+        "- La methode `query()` encapsule l'ecriture du fichier temporaire + l'appel SPASS + la lecture du resultat\n",
+        "- Il n'y a pas de hook pour intercepter/corriger le DFG avant qu'il soit passe a SPASS\n",
+        "\n",
+        "**Alternatives a long terme :**\n",
+        "- Soumettre un patch a TweetyProject pour corriger `SPASSWriter`\n",
+        "- Utiliser un autre prouveur modal (MleanCoP, MleanTAP)\n",
+        "- Implementer un wrapper qui corrige le DFG avant de le passer a SPASS\n",
+        "\n",
+        "**Pour ce notebook :** Le parsing modal (cellule 2.4.2) fonctionne parfaitement. Les resultats theoriques sont verifies manuellement via la semantique de Kripke. Le raisonnement automatique via SPASS reste bloque par le bug upstream."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e781df26",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005524,
+          "end_time": "2026-04-25T15:11:12.071742",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.066218",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "e781df26"
+      },
+      "source": [
+        "### 2.5 Autres Logiques (Apercu QBF, CL)\n",
+        "<a id=\"2.5\"></a>\n",
+        "\n",
+        "Tweety supporte d'autres logiques que nous survolons ici :\n",
+        "\n",
+        "**QBF (Quantified Boolean Formulas) :**\n",
+        "Extension de SAT avec quantificateurs sur les variables booleennes.\n",
+        "- `forall X: exists Y: (X || Y)`\n",
+        "- Complexite : PSPACE-complet\n",
+        "\n",
+        "**Logique Conditionnelle (CL) :**\n",
+        "Extension de la logique propositionnelle avec l'operateur conditionnel `|~` (normalement implique).\n",
+        "- `bird |~ flies` : \"Normalement, les oiseaux volent\"\n",
+        "- Gere les exceptions et le raisonnement non-monotone"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "d437aa5e",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:12.084452Z",
+          "iopub.status.busy": "2026-04-25T15:11:12.084116Z",
+          "iopub.status.idle": "2026-04-25T15:11:12.657151Z",
+          "shell.execute_reply": "2026-04-25T15:11:12.655178Z"
+        },
+        "papermill": {
+          "duration": 0.58131,
+          "end_time": "2026-04-25T15:11:12.659046",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.077736",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d437aa5e",
+        "outputId": "2070cbd4-66f8-4d41-8159-679e3a074d63"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- 2.5.1 QBF (Quantified Boolean Formulas) ---\n",
+            "Imports QBF reussis.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.5.1 Imports QBF ---\n",
+        "print(\"--- 2.5.1 QBF (Quantified Boolean Formulas) ---\")\n",
+        "\n",
+        "if not jvm_ready:\n",
+        "    print(\"ERREUR: JVM non demarree.\")\n",
+        "    qbf_imports_ok = False\n",
+        "else:\n",
+        "    qbf_imports_ok = False\n",
+        "    try:\n",
+        "        from org.tweetyproject.logics.qbf.syntax import (\n",
+        "            ExistsQuantifiedFormula, ForallQuantifiedFormula\n",
+        "        )\n",
+        "        from org.tweetyproject.logics.pl.syntax import Proposition, PlBeliefSet, Disjunction\n",
+        "        from org.tweetyproject.logics.qbf.reasoner import QbfSolver\n",
+        "        from java.util import ArrayList\n",
+        "\n",
+        "        print(\"Imports QBF reussis.\")\n",
+        "        qbf_imports_ok = True\n",
+        "\n",
+        "    except ImportError as e:\n",
+        "        print(f\"ERREUR d'import QBF : {e}\")\n",
+        "    except Exception as e:\n",
+        "        print(f\"ERREUR : {e}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "zcsjedqgqsn",
+      "metadata": {
+        "papermill": {
+          "duration": 0.008222,
+          "end_time": "2026-04-25T15:11:12.675941",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.667719",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "zcsjedqgqsn"
+      },
+      "source": [
+        "### Introduction a QBF : Au-dela de SAT\n",
+        "\n",
+        "**Hierarchie de complexite:**\n",
+        "\n",
+        "| Logique | Complexité | Quantificateurs | Exemple |\n",
+        "|---------|------------|-----------------|---------|\n",
+        "| **SAT** | NP-complet | Aucun (variables libres) | `(x ∨ y) ∧ (¬x ∨ z)` |\n",
+        "| **QBF** | PSPACE-complet | ∀, ∃ sur variables booléennes | `∀x ∃y: (x ⇔ y)` |\n",
+        "| **FOL** | Indécidable | ∀, ∃ sur domaines infinis | `∀x ∃y: P(x,y)` |\n",
+        "\n",
+        "**Puissance expressive de QBF:**\n",
+        "- Peut encoder des problèmes de planification avec incertitude\n",
+        "- Modélise les jeux à deux joueurs (∀ = adversaire, ∃ = nous)\n",
+        "- Résout des problèmes de vérification formelle (model checking)\n",
+        "\n",
+        "**Exemple concret:**\n",
+        "```\n",
+        "∀x ∃y: (x => y)\n",
+        "```\n",
+        "\"Pour toute valeur de x, il existe y tel que (x implique y)\"\n",
+        "- Si x=0, choisir y=0 ou y=1 (0=>0 et 0=>1 sont vrais)\n",
+        "- Si x=1, choisir y=1 (1=>1 est vrai)\n",
+        "- Formule **satisfiable** (stratégie gagnante : y=1 toujours)\n",
+        "\n",
+        "**Solveurs QBF modernes:**\n",
+        "- **QuAbS**: Basé sur la recherche DPLL\n",
+        "- **CAQE**: Expansion clausale\n",
+        "- **DepQBF**: Résolution Q"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "84cbc8b8",
+      "metadata": {
+        "papermill": {
+          "duration": 0.007837,
+          "end_time": "2026-04-25T15:11:12.690816",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.682979",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "84cbc8b8"
+      },
+      "source": [
+        "#### Construction de formules QBF\n",
+        "\n",
+        "Une formule QBF combine quantificateurs et formules propositionnelles :\n",
+        "- `exists X: (X || Y)` - Il existe une valeur de X telle que X ou Y\n",
+        "- `forall X: exists Y: (X <=> Y)` - Formules imbriquees"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "3f1eb19c",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:12.705793Z",
+          "iopub.status.busy": "2026-04-25T15:11:12.705201Z",
+          "iopub.status.idle": "2026-04-25T15:11:12.717632Z",
+          "shell.execute_reply": "2026-04-25T15:11:12.716211Z"
+        },
+        "papermill": {
+          "duration": 0.022226,
+          "end_time": "2026-04-25T15:11:12.719396",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.697170",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3f1eb19c",
+        "outputId": "98c7ad80-a908-4588-8216-2b8f1f8545cd"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Formule de base: x||y\n",
+            "Formule QBF: exists x: (x||y)\n",
+            "Formule QBF imbriquee: forall y: (exists x: (x||y))\n",
+            "\n",
+            "--- Variante avec constructeur simplifie ---\n",
+            "exists z: z = exists z: (z)\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.5.2 Construction de formules QBF ---\n",
+        "if qbf_imports_ok:\n",
+        "    from java.util import HashSet  # IMPORTANT: QBF attend un Set, pas ArrayList!\n",
+        "\n",
+        "    # Variables propositionnelles\n",
+        "    x = Proposition(\"x\")\n",
+        "    y = Proposition(\"y\")\n",
+        "\n",
+        "    # Formule: x OR y\n",
+        "    vars_disj = ArrayList()\n",
+        "    vars_disj.add(x)\n",
+        "    vars_disj.add(y)\n",
+        "    inner_formula = Disjunction(vars_disj)\n",
+        "    print(f\"Formule de base: {inner_formula}\")\n",
+        "\n",
+        "    # exists x: (x OR y) - utiliser HashSet car le constructeur attend un Set\n",
+        "    exists_x_vars = HashSet()\n",
+        "    exists_x_vars.add(x)\n",
+        "    exists_formula = ExistsQuantifiedFormula(inner_formula, exists_x_vars)\n",
+        "    print(f\"Formule QBF: {exists_formula}\")\n",
+        "\n",
+        "    # forall y: exists x: (x OR y) - meme correction avec HashSet\n",
+        "    forall_y_vars = HashSet()\n",
+        "    forall_y_vars.add(y)\n",
+        "    forall_exists_formula = ForallQuantifiedFormula(exists_formula, forall_y_vars)\n",
+        "    print(f\"Formule QBF imbriquee: {forall_exists_formula}\")\n",
+        "\n",
+        "    # Alternative: utiliser le constructeur simplifie (Proposition unique)\n",
+        "    print(\"\\n--- Variante avec constructeur simplifie ---\")\n",
+        "    # exists z: (z) - une seule variable\n",
+        "    z = Proposition(\"z\")\n",
+        "    exists_z = ExistsQuantifiedFormula(z, z)  # (formula, single_proposition)\n",
+        "    print(f\"exists z: z = {exists_z}\")\n",
+        "else:\n",
+        "    print(\"Imports QBF non disponibles.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "j8peljtakkq",
+      "metadata": {
+        "papermill": {
+          "duration": 0.008763,
+          "end_time": "2026-04-25T15:11:12.734707",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.725944",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "j8peljtakkq"
+      },
+      "source": [
+        "### Analyse des Formules QBF Construites\n",
+        "\n",
+        "**Formule 1 : `exists x: (x||y)`**\n",
+        "- **Sens:** \"Il existe x tel que (x OU y)\"\n",
+        "- **Satisfiabilité:** Toujours vraie (choisir x=1, alors x||y=1 quelle que soit y)\n",
+        "- **Stratégie:** x=1 est une stratégie gagnante\n",
+        "\n",
+        "**Formule 2 : `forall y: exists x: (x||y)`**\n",
+        "- **Sens:** \"Pour tout y, il existe x tel que (x OU y)\"\n",
+        "- **Satisfiabilité:** Toujours vraie\n",
+        "- **Stratégie:** Fonction de Skolem f(y) = 1 (choisir x=1 indépendamment de y)\n",
+        "\n",
+        "**Ordre des quantificateurs:**\n",
+        "L'ordre est **crucial** en QBF:\n",
+        "\n",
+        "| Formule | Résultat | Raison |\n",
+        "|---------|----------|--------|\n",
+        "| `∃x ∀y: (x ⇔ y)` | **UNSAT** | x doit être égal à tous les y (impossible) |\n",
+        "| `∀y ∃x: (x ⇔ y)` | **SAT** | Pour chaque y, choisir x=y |\n",
+        "\n",
+        "**Construction avec HashSet vs ArrayList:**\n",
+        "Tweety utilise `Set<Proposition>` pour éviter les doublons de variables quantifiées.\n",
+        "- `HashSet`: Pas d'ordre, pas de doublons ✓\n",
+        "- `ArrayList`: Ordre préservé, doublons possibles ✗\n",
+        "\n",
+        "> **Astuce:** Pour des formules QBF complexes, préférer le parsing textuel au lieu de la construction programmatique."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "bd272720",
+      "metadata": {
+        "papermill": {
+          "duration": 0.007071,
+          "end_time": "2026-04-25T15:11:12.758703",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.751632",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "bd272720"
+      },
+      "source": [
+        "## Logique Conditionnelle (CL)\n",
+        "\n",
+        "La logique conditionnelle permet d'exprimer des regles avec exceptions :\n",
+        "- `bird |~ flies` : \"Normalement, les oiseaux volent\"\n",
+        "- `penguin |~ !flies` : \"Les pingouins ne volent pas (exception)\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "8b153a15",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:12.778358Z",
+          "iopub.status.busy": "2026-04-25T15:11:12.777693Z",
+          "iopub.status.idle": "2026-04-25T15:11:12.922091Z",
+          "shell.execute_reply": "2026-04-25T15:11:12.920811Z"
+        },
+        "papermill": {
+          "duration": 0.158858,
+          "end_time": "2026-04-25T15:11:12.924201",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.765343",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8b153a15",
+        "outputId": "5d58d430-c46a-4e35-99af-3b323cc855ef"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "--- 2.5.3 Logique Conditionnelle (CL) ---\n",
+            "Imports CL reussis.\n",
+            "\n",
+            "Conditionnel 1: (bird|flies)\n",
+            "Conditionnel 2: (penguin|!flies)\n",
+            "\n",
+            "KB Conditionnelle: { (penguin|!flies), (bird|flies) }\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- 2.5.3 Logique Conditionnelle ---\n",
+        "print(\"--- 2.5.3 Logique Conditionnelle (CL) ---\")\n",
+        "\n",
+        "if jvm_ready:\n",
+        "    cl_imports_ok = False\n",
+        "    try:\n",
+        "        from org.tweetyproject.logics.cl.syntax import Conditional, ClBeliefSet\n",
+        "        from org.tweetyproject.logics.pl.syntax import Proposition, Negation\n",
+        "        from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner\n",
+        "\n",
+        "        print(\"Imports CL reussis.\")\n",
+        "        cl_imports_ok = True\n",
+        "\n",
+        "        # Propositions\n",
+        "        bird = Proposition(\"bird\")\n",
+        "        flies = Proposition(\"flies\")\n",
+        "        penguin = Proposition(\"penguin\")\n",
+        "\n",
+        "        # Conditionnels\n",
+        "        bird_flies = Conditional(flies, bird)          # bird |~ flies\n",
+        "        penguin_not_flies = Conditional(Negation(flies), penguin)  # penguin |~ !flies\n",
+        "\n",
+        "        print(f\"\\nConditionnel 1: {bird_flies}\")\n",
+        "        print(f\"Conditionnel 2: {penguin_not_flies}\")\n",
+        "\n",
+        "        # Base de croyances conditionnelle\n",
+        "        cl_kb = ClBeliefSet()\n",
+        "        cl_kb.add(bird_flies)\n",
+        "        cl_kb.add(penguin_not_flies)\n",
+        "        print(f\"\\nKB Conditionnelle: {cl_kb}\")\n",
+        "\n",
+        "    except ImportError as e:\n",
+        "        print(f\"ERREUR d'import CL : {e}\")\n",
+        "    except Exception as e:\n",
+        "        print(f\"ERREUR : {e}\")\n",
+        "else:\n",
+        "    print(\"JVM non demarree.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "qhrdjt09oj",
+      "metadata": {
+        "papermill": {
+          "duration": 0.007446,
+          "end_time": "2026-04-25T15:11:12.941940",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.934494",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "qhrdjt09oj"
+      },
+      "source": [
+        "### Interpretation de la Logique Conditionnelle\n",
+        "\n",
+        "**Conditionnels crees:**\n",
+        "\n",
+        "| Conditionnel | Notation CL | Signification |\n",
+        "|--------------|-------------|---------------|\n",
+        "| `(bird\\|flies)` | `bird \\|~ flies` | \"Normalement, les oiseaux volent\" |\n",
+        "| `(penguin\\|!flies)` | `penguin \\|~ ¬flies` | \"Normalement, les pingouins ne volent pas\" |\n",
+        "\n",
+        "**Difference avec l'implication classique:**\n",
+        "\n",
+        "| Logique | Operateur | Comportement avec exceptions |\n",
+        "|---------|-----------|------------------------------|\n",
+        "| **Classique** | `bird => flies` | Si `penguin ⊑ bird` et `penguin => ¬flies`, KB incohérente |\n",
+        "| **Conditionnelle** | `bird \\|~ flies` | Les exceptions (pingouins) n'invalident pas la règle générale |\n",
+        "\n",
+        "**Semantique de la logique conditionnelle:**\n",
+        "- **Modeles preferentiels:** Les mondes \"normaux\" sont préférés\n",
+        "- **Ordres sur les mondes:** Classement par typicalité (mondes avec oiseaux volants > mondes avec pingouins)\n",
+        "- **Raisonnement non-monotone:** Ajouter `penguin(Tweety)` peut invalider `flies(Tweety)` précédemment inféré\n",
+        "\n",
+        "**Applications:**\n",
+        "- **Raisonnement par défaut:** \"Les adultes ont un emploi\" (sauf retraités, étudiants)\n",
+        "- **Diagnostic médical:** \"Fièvre implique infection\" (sauf causes non-infectieuses)\n",
+        "- **Droit:** \"Les contrats sont valides\" (sauf vices de consentement)\n",
+        "\n",
+        "> **Raisonneurs CL:** System Z, System P, rational closure (implémentés dans Tweety via `SimpleCReasoner`)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "gukci1vj9ze",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005827,
+          "end_time": "2026-04-25T15:11:12.954199",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.948372",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "gukci1vj9ze"
+      },
+      "source": [
+        "## Exercice : Construction d'une ontologie universitaire en Description Logic\n",
+        "\n",
+        "### Contexte\n",
+        "\n",
+        "Vous devez modeliser une ontologie simple pour une universite avec les concepts suivants :\n",
+        "- **Personne**, **Etudiant**, **Enseignant** (concepts atomiques)\n",
+        "- **Cours** (concept atomique, disjoint de Personne)\n",
+        "- **enseigne** (role entre Enseignant et Cours)\n",
+        "- **inscritA** (role entre Etudiant et Cours)\n",
+        "\n",
+        "### Objectifs\n",
+        "\n",
+        "1. Definir les concepts atomiques et roles avec `AtomicConcept` et `AtomicRole`\n",
+        "2. Creer les axiomes TBox :\n",
+        "   - `Etudiant` est equivalent a `Personne` (subsomption)\n",
+        "   - `Enseignant` est equivalent a `Personne`\n",
+        "   - `Cours` est equivalent a `NOT Personne` (disjonction)\n",
+        "3. Creer les assertions ABox pour au moins 2 etudiants, 1 enseignant et 2 cours\n",
+        "4. Utiliser `NaiveDlReasoner` pour verifier :\n",
+        "   - Un etudiant est-il une Personne ?\n",
+        "   - Un cours est-il une Personne ?\n",
+        "   - Un enseignant est-il un Etudiant ?\n",
+        "\n",
+        "### Indices\n",
+        "\n",
+        "- Reutilisez le pattern du notebook : `AtomicConcept(\"Etudiant\")`, `EquivalenceAxiom(...)`, `ConceptAssertion(...)`\n",
+        "- La disjonction se fait avec `Complement` : `EquivalenceAxiom(cours, Complement(personne))`\n",
+        "- Le raisonneur : `NaiveDlReasoner().query(kb, assertion)`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "id": "w4l5v5ty69",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-04-25T15:11:12.969055Z",
+          "iopub.status.busy": "2026-04-25T15:11:12.968335Z",
+          "iopub.status.idle": "2026-04-25T15:11:12.975219Z",
+          "shell.execute_reply": "2026-04-25T15:11:12.973816Z"
+        },
+        "papermill": {
+          "duration": 0.017089,
+          "end_time": "2026-04-25T15:11:12.977410",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.960321",
+          "status": "completed"
+        },
+        "tags": [],
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "w4l5v5ty69",
+        "outputId": "29876fca-fa49-43ae-ebba-0e546d083fee"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Knowledge Base:\n",
+            "  TBox: [implies Enseignant Personne, implies Etudiant Personne, implies Cours (not Personne)]\n",
+            "  ABox: [instance CoursInfo Cours, instance Alice Etudiant, related Alice CoursInfo inscritA, related Bob CoursMaths inscritA, instance Bob Etudiant, related ProfMartin CoursInfo enseigne, instance ProfMartin Enseignant, instance CoursMaths Cours]\n",
+            "\n",
+            "Requetes de raisonnement:\n",
+            "  Alice (Etudiant) : Personne ? True\n",
+            "  CoursInfo (Cours) : Personne ? False\n",
+            "  ProfMartin (Enseignant) : Etudiant ? False\n"
+          ]
+        }
+      ],
+      "source": [
+        "# --- Exercice : Ontologie Universitaire en Description Logic ---\n",
+        "# Construisez l'ontologie decrite ci-dessus.\n",
+        "\n",
+        "if jvm_ready and dl_imports_ok:\n",
+        "    from org.tweetyproject.logics.dl.syntax import (\n",
+        "        AtomicConcept, AtomicRole, Individual,\n",
+        "        EquivalenceAxiom, ConceptAssertion, RoleAssertion,\n",
+        "        DlBeliefSet, Complement\n",
+        "    )\n",
+        "    from org.tweetyproject.logics.dl.reasoner import NaiveDlReasoner\n",
+        "\n",
+        "    # 1. Definir les concepts atomiques\n",
+        "    personne   = AtomicConcept(\"Personne\")\n",
+        "    etudiant   = AtomicConcept(\"Etudiant\")\n",
+        "    enseignant = AtomicConcept(\"Enseignant\")\n",
+        "    cours      = AtomicConcept(\"Cours\")\n",
+        "\n",
+        "    # 2. Definir les roles\n",
+        "    enseigne  = AtomicRole(\"enseigne\")\n",
+        "    inscrit_a = AtomicRole(\"inscritA\")\n",
+        "\n",
+        "    # 3. Creer les axiomes TBox\n",
+        "    etudiant_eq_personne   = EquivalenceAxiom(etudiant, personne)\n",
+        "    enseignant_eq_personne = EquivalenceAxiom(enseignant, personne)\n",
+        "    cours_eq_not_personne  = EquivalenceAxiom(cours, Complement(personne))\n",
+        "\n",
+        "    # 4. Creer les individus et les assertions ABox\n",
+        "    alice       = Individual(\"Alice\")\n",
+        "    bob         = Individual(\"Bob\")\n",
+        "    prof_martin = Individual(\"ProfMartin\")\n",
+        "    cours_info  = Individual(\"CoursInfo\")\n",
+        "    cours_maths = Individual(\"CoursMaths\")\n",
+        "\n",
+        "    alice_etudiant    = ConceptAssertion(alice, etudiant)\n",
+        "    bob_etudiant      = ConceptAssertion(bob, etudiant)\n",
+        "    martin_enseignant = ConceptAssertion(prof_martin, enseignant)\n",
+        "    info_cours        = ConceptAssertion(cours_info, cours)\n",
+        "    maths_cours       = ConceptAssertion(cours_maths, cours)\n",
+        "\n",
+        "    martin_enseigne_info = RoleAssertion(prof_martin, cours_info, enseigne)\n",
+        "    alice_inscrit_info   = RoleAssertion(alice, cours_info, inscrit_a)\n",
+        "    bob_inscrit_maths    = RoleAssertion(bob, cours_maths, inscrit_a)\n",
+        "\n",
+        "    # 5. Construire la KB\n",
+        "    uni_kb = DlBeliefSet()\n",
+        "\n",
+        "    uni_kb.add(etudiant_eq_personne)\n",
+        "    uni_kb.add(enseignant_eq_personne)\n",
+        "    uni_kb.add(cours_eq_not_personne)\n",
+        "\n",
+        "    for a in [alice_etudiant, bob_etudiant, martin_enseignant, info_cours, maths_cours,\n",
+        "              martin_enseigne_info, alice_inscrit_info, bob_inscrit_maths]:\n",
+        "        uni_kb.add(a)\n",
+        "\n",
+        "    print(\"Knowledge Base:\")\n",
+        "    print(f\"  TBox: {uni_kb.getTBox()}\")\n",
+        "    print(f\"  ABox: {uni_kb.getABox()}\")\n",
+        "\n",
+        "    # 6. Raisonner\n",
+        "    reasoner_uni = NaiveDlReasoner()\n",
+        "    print(\"\\nRequetes de raisonnement:\")\n",
+        "\n",
+        "    # Un etudiant est-il une Personne ?\n",
+        "    kb_q1 = DlBeliefSet()\n",
+        "    kb_q1.add(etudiant_eq_personne)\n",
+        "    kb_q1.add(ConceptAssertion(alice, etudiant))\n",
+        "    print(f\"  Alice (Etudiant) : Personne ? {reasoner_uni.query(kb_q1, ConceptAssertion(alice, personne))}\")\n",
+        "\n",
+        "    # Un cours est-il une Personne ?\n",
+        "    kb_q2 = DlBeliefSet()\n",
+        "    kb_q2.add(cours_eq_not_personne)\n",
+        "    kb_q2.add(ConceptAssertion(cours_info, cours))\n",
+        "    print(f\"  CoursInfo (Cours) : Personne ? {reasoner_uni.query(kb_q2, ConceptAssertion(cours_info, personne))}\")\n",
+        "\n",
+        "    # Un enseignant est-il un Etudiant ?\n",
+        "    kb_q3 = DlBeliefSet()\n",
+        "    kb_q3.add(enseignant_eq_personne)\n",
+        "    kb_q3.add(etudiant_eq_personne)\n",
+        "    kb_q3.add(ConceptAssertion(prof_martin, enseignant))\n",
+        "    print(f\"  ProfMartin (Enseignant) : Etudiant ? {reasoner_uni.query(kb_q3, ConceptAssertion(prof_martin, etudiant))}\")\n",
+        "\n",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4a2b4ad3",
+      "metadata": {
+        "papermill": {
+          "duration": 0.005804,
+          "end_time": "2026-04-25T15:11:12.989608",
+          "exception": false,
+          "start_time": "2026-04-25T15:11:12.983804",
+          "status": "completed"
+        },
+        "tags": [],
+        "id": "4a2b4ad3"
+      },
+      "source": [
+        "---\n",
+        "\n",
+        "## Resume\n",
+        "\n",
+        "Ce notebook a couvert:\n",
+        "- **Description Logic (DL)**: Concepts, roles, ABox/TBox, classification\n",
+        "- **Logique Modale (ML)**: Operateurs Box/Diamond, semantique de Kripke, SPASS\n",
+        "- **QBF**: Formules booleennes quantifiees, complexite PSPACE\n",
+        "- **Logique Conditionnelle (CL)**: Regles avec exceptions, raisonnement non-monotone\n",
+        "\n",
+        "**Points cles:**\n",
+        "- Chaque logique etend la logique propositionnelle differemment\n",
+        "- Les raisonneurs externes (SPASS, EProver) sont souvent necessaires\n",
+        "- Tweety fournit des parseurs et structures pour toutes ces logiques\n",
+        "\n",
+        "## Prochaines etapes\n",
+        "\n",
+        "Le notebook suivant explore la **revision de croyances** et la gestion de l'incoherence.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "**Navigation**: [Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb)"
+      ]
     }
-   ],
-   "source": [
-    "# --- Initialisation JVM Tweety + Outils Externes ---\n",
-    "print(\"--- Verification JVM Tweety + Outils ---\")\n",
-    "jvm_ready = False\n",
-    "\n",
-    "import jpype\n",
-    "import jpype.imports\n",
-    "import os\n",
-    "import pathlib\n",
-    "import shutil\n",
-    "import platform\n",
-    "\n",
-    "# === Configuration COMPLETE des outils externes ===\n",
-    "EXTERNAL_TOOLS = {\n",
-    "    \"CLINGO\": \"\",\n",
-    "    \"SPASS\": \"\",\n",
-    "    \"EPROVER\": \"\",\n",
-    "}\n",
-    "\n",
-    "def get_tool_path(tool_name):\n",
-    "    \"\"\"Retourne le chemin valide d'un outil ou None.\"\"\"\n",
-    "    path_str = EXTERNAL_TOOLS.get(tool_name, \"\")\n",
-    "    if not path_str: \n",
-    "        return None\n",
-    "    if shutil.which(path_str):\n",
-    "        return path_str\n",
-    "    path_obj = pathlib.Path(path_str)\n",
-    "    if path_obj.is_file():\n",
-    "        return str(path_obj.resolve())\n",
-    "    if path_obj.is_dir():\n",
-    "        return str(path_obj.resolve())\n",
-    "    return None\n",
-    "\n",
-    "# --- Auto-detection des outils ---\n",
-    "system = platform.system()\n",
-    "exe_suffix = \".exe\" if system == \"Windows\" else \"\"\n",
-    "\n",
-    "# 1. Clingo (ASP solver) - Tweety attend le REPERTOIRE, pas l'executable\n",
-    "for cp in [shutil.which(\"clingo\"), pathlib.Path(f\"ext_tools/clingo/clingo{exe_suffix}\"),\n",
-    "           pathlib.Path(f\"../ext_tools/clingo/clingo{exe_suffix}\")]:\n",
-    "    if cp and (isinstance(cp, str) or cp.exists()):\n",
-    "        parent = pathlib.Path(cp).parent if isinstance(cp, str) else cp.parent\n",
-    "        EXTERNAL_TOOLS[\"CLINGO\"] = str(parent.resolve())\n",
-    "        break\n",
-    "\n",
-    "# 2. SPASS (Modal logic prover) - executable complet\n",
-    "for sp in [shutil.which(\"SPASS\"), pathlib.Path(f\"ext_tools/spass/SPASS{exe_suffix}\"),\n",
-    "           pathlib.Path(f\"../ext_tools/spass/SPASS{exe_suffix}\")]:\n",
-    "    if sp and (isinstance(sp, str) or sp.exists()):\n",
-    "        EXTERNAL_TOOLS[\"SPASS\"] = str(pathlib.Path(sp).resolve()) if isinstance(sp, pathlib.Path) else sp\n",
-    "        break\n",
-    "\n",
-    "# 3. EProver (FOL theorem prover)\n",
-    "for ep in [shutil.which(\"eprover\"), pathlib.Path(f\"../ext_tools/EProver/eprover{exe_suffix}\"),\n",
-    "           pathlib.Path(f\"ext_tools/EProver/eprover{exe_suffix}\")]:\n",
-    "    if ep:\n",
-    "        ep_path = pathlib.Path(ep) if isinstance(ep, str) else ep\n",
-    "        if ep_path.exists():\n",
-    "            EXTERNAL_TOOLS[\"EPROVER\"] = str(ep_path.resolve())\n",
-    "            break\n",
-    "\n",
-    "# === Initialisation JVM ===\n",
-    "if jpype.isJVMStarted():\n",
-    "    print(\"JVM deja en cours d'execution.\")\n",
-    "    jvm_ready = True\n",
-    "else:\n",
-    "    jdk_portable = None\n",
-    "    for jdk_path in [pathlib.Path(\"jdk-17-portable\"), pathlib.Path(\"../Argument_Analysis/jdk-17-portable\")]:\n",
-    "        if jdk_path.exists():\n",
-    "            zulu_dirs = list(jdk_path.glob(\"zulu*\"))\n",
-    "            if zulu_dirs:\n",
-    "                jdk_portable = zulu_dirs[0]\n",
-    "                os.environ[\"JAVA_HOME\"] = str(jdk_portable.resolve())\n",
-    "                print(f\"JDK portable: {jdk_portable.name}\")\n",
-    "                break\n",
-    "    \n",
-    "    if not os.environ.get(\"JAVA_HOME\"):\n",
-    "        print(\"ERREUR: JAVA_HOME non defini et JDK portable non trouve.\")\n",
-    "    else:\n",
-    "        LIB_DIR = pathlib.Path(\"libs\")\n",
-    "        if not LIB_DIR.exists():\n",
-    "            LIB_DIR = pathlib.Path(\"../Argument_Analysis/libs\")\n",
-    "        \n",
-    "        if LIB_DIR.exists():\n",
-    "            jar_files = list(LIB_DIR.glob(\"*.jar\"))\n",
-    "            if jar_files:\n",
-    "                classpath = os.pathsep.join(str(j.resolve()) for j in jar_files)\n",
-    "                try:\n",
-    "                    jpype.startJVM(classpath=[classpath])\n",
-    "                    print(f\"JVM demarree avec {len(jar_files)} JARs.\")\n",
-    "                    jvm_ready = True\n",
-    "                except Exception as e:\n",
-    "                    print(f\"Erreur demarrage JVM: {e}\")\n",
-    "\n",
-    "# === Resume des outils ===\n",
-    "if jvm_ready:\n",
-    "    print(\"\\n--- Outils disponibles ---\")\n",
-    "    for tool, path in EXTERNAL_TOOLS.items():\n",
-    "        if path:\n",
-    "            short_path = path.split(os.sep)[-1] if len(path) > 30 else path\n",
-    "            print(f\"  {tool}: {short_path}\")\n",
-    "        else:\n",
-    "            print(f\"  {tool}: non configure\")\n",
-    "    print(f\"\\nJVM prete. Outils: {sum(1 for t,p in EXTERNAL_TOOLS.items() if p)}/{len(EXTERNAL_TOOLS)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8qq8geipre9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00837,
-     "end_time": "2026-04-25T15:11:07.769271",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:07.760901",
-     "status": "completed"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
     },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation de l'initialisation\n",
-    "\n",
-    "**Sortie obtenue:**\n",
-    "- JVM demarrée avec 35 JARs Tweety\n",
-    "- JDK portable Zulu 17 détecté automatiquement\n",
-    "- 3/3 outils externes configurés: CLINGO, SPASS, EPROVER\n",
-    "\n",
-    "**Signification:**\n",
-    "- L'environnement est prêt pour tous les exemples de ce notebook\n",
-    "- SPASS (prouveur modal) est disponible, mais peut nécessiter des privilèges admin sous Windows\n",
-    "- CLINGO sera utilisé pour la logique ASP (notebook 6)\n",
-    "- EProver peut servir d'alternative pour la logique du premier ordre\n",
-    "\n",
-    "> **Note:** Si l'un des outils n'est pas détecté, les exemples correspondants afficheront un avertissement mais le notebook restera exécutable."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1d9d39c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007954,
-     "end_time": "2026-04-25T15:11:07.785521",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:07.777567",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 2.3 Logique de Description (DL)\n",
-    "<a id=\"2.3\"></a>\n",
-    "\n",
-    "Les logiques de description sont une famille de formalismes pour représenter des connaissances structurées, souvent utilisées pour les ontologies (ex: OWL). Elles se concentrent sur la définition de **Concepts** (classes d'individus), de **Rôles** (relations binaires) et d'**Individus**.\n",
-    "\n",
-    "* **Signature (`DlSignature`)** : Comprend `AtomicConcept`, `AtomicRole`, `Individual`.\n",
-    "* **Axiomes** :\n",
-    "    * **TBox (Terminological Box)** : Axiomes définissant les concepts et les rôles (ex: `SubConceptAxiom`, `EquivalenceAxiom`, `DisjointAxiom`). Les concepts peuvent être combinés (`Intersection`, `Union`, `Complement`, `ExistsRestriction`, `ForAllRestriction`).\n",
-    "    * **ABox (Assertional Box)** : Axiomes sur les individus (ex: `ConceptAssertion` - `Human(Alice)`, `RoleAssertion` - `fatherOf(Bob, Alice)`).\n",
-    "* **Base de Connaissances (`DlBeliefSet`)** : Contient les axiomes TBox et ABox.\n",
-    "* **Raisonnement (`DlReasoner`)** : Vérifie la consistance, la subsomption de concepts, l'instanciation. `NaiveDlReasoner` est une implémentation simple. Des raisonneurs plus puissants (comme Pellet, HermiT - non intégrés directement comme solveurs externes dans cet exemple) existent."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "32a3ee00",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:07.803819Z",
-     "iopub.status.busy": "2026-04-25T15:11:07.803030Z",
-     "iopub.status.idle": "2026-04-25T15:11:09.706353Z",
-     "shell.execute_reply": "2026-04-25T15:11:09.704282Z"
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.5"
     },
     "papermill": {
-     "duration": 1.915611,
-     "end_time": "2026-04-25T15:11:09.708986",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:07.793375",
-     "status": "completed"
+      "default_parameters": {},
+      "duration": 9.328603,
+      "end_time": "2026-04-25T15:11:13.349282",
+      "environment_variables": {},
+      "exception": null,
+      "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics.ipynb",
+      "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics_output.ipynb",
+      "parameters": {},
+      "start_time": "2026-04-25T15:11:04.020679",
+      "version": "2.6.0"
     },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- 2.3.1 Logique de Description : Imports ---\n",
-      "JVM prete. Import des classes DL...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imports DL reussis.\n"
-     ]
+    "colab": {
+      "provenance": []
     }
-   ],
-   "source": [
-    "# --- 2.3.1 Imports DL ---\n",
-    "print(\"--- 2.3.1 Logique de Description : Imports ---\")\n",
-    "\n",
-    "if not jvm_ready:\n",
-    "    print(\"ERREUR: JVM non demarree. Impossible de continuer cet exemple.\")\n",
-    "    dl_imports_ok = False\n",
-    "else:\n",
-    "    print(\"JVM prete. Import des classes DL...\")\n",
-    "    dl_imports_ok = False\n",
-    "    try:\n",
-    "        import jpype\n",
-    "        from jpype.types import *\n",
-    "        from java.util import ArrayList\n",
-    "\n",
-    "        from org.tweetyproject.logics.dl.syntax import (\n",
-    "            AtomicConcept, AtomicRole, Individual,\n",
-    "            EquivalenceAxiom, ConceptAssertion, RoleAssertion,\n",
-    "            DlBeliefSet, DlSignature, DlAxiom,\n",
-    "            Complement, Union\n",
-    "        )\n",
-    "        from org.tweetyproject.logics.dl.parser import DlParser\n",
-    "        from org.tweetyproject.logics.dl.reasoner import NaiveDlReasoner\n",
-    "\n",
-    "        print(\"Imports DL reussis.\")\n",
-    "        dl_imports_ok = True\n",
-    "\n",
-    "    except ImportError as e:\n",
-    "        print(f\"ERREUR d'import pour DL : {e}\")\n",
-    "    except Exception as e_gen:\n",
-    "        print(f\"ERREUR inattendue : {e_gen}\")"
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "r8awh2zx0s",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00954,
-     "end_time": "2026-04-25T15:11:09.728248",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.718708",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Architecture de la Logique de Description\n",
-    "\n",
-    "La logique de description (DL) sépare les connaissances en deux niveaux:\n",
-    "\n",
-    "| Composant | Rôle | Exemple |\n",
-    "|-----------|------|---------|\n",
-    "| **TBox** (Terminologie) | Définit les concepts et leurs relations | `Male ⊑ Human`, `Female ≡ ¬Male` |\n",
-    "| **ABox** (Assertions) | Faits sur les individus concrets | `Alice : Female`, `fatherOf(Bob, Alice)` |\n",
-    "\n",
-    "**Opérateurs DL:**\n",
-    "- `⊓` (Intersection): `Male ⊓ Human` - homme ET humain\n",
-    "- `⊔` (Union): `Male ⊔ Female` - homme OU femme\n",
-    "- `¬` (Complement): `¬Male` - non-homme\n",
-    "- `∃R.C` (Exists restriction): `∃fatherOf.Human` - a un père humain\n",
-    "- `∀R.C` (Forall restriction): `∀childOf.Human` - tous les enfants sont humains\n",
-    "\n",
-    "Ces opérateurs permettent de construire des ontologies complexes (ex: OWL en Web Sémantique)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "249053cb",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006696,
-     "end_time": "2026-04-25T15:11:09.744276",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.737580",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### TBox : Axiomes Terminologiques\n",
-    "\n",
-    "La **TBox** (Terminological Box) definit les relations entre concepts :\n",
-    "- `Human`, `Male`, `Female`, `House`, `Father` - Concepts atomiques\n",
-    "- `fatherOf` - Role atomique\n",
-    "- Axiomes d'equivalence : `Female ≡ ¬Male`, `House ≡ ¬Human`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "ccee3f05",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:09.765235Z",
-     "iopub.status.busy": "2026-04-25T15:11:09.764622Z",
-     "iopub.status.idle": "2026-04-25T15:11:09.776077Z",
-     "shell.execute_reply": "2026-04-25T15:11:09.774569Z"
-    },
-    "papermill": {
-     "duration": 0.028487,
-     "end_time": "2026-04-25T15:11:09.778278",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.749791",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TBox creee:\n",
-      "  Female = Human\n",
-      "  Male = Human\n",
-      "  Female = NOT Male\n",
-      "  Male = NOT Female\n",
-      "  House = NOT Human\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.3.2 Definition des Concepts et TBox ---\n",
-    "if dl_imports_ok:\n",
-    "    # Concepts atomiques\n",
-    "    human = AtomicConcept(\"Human\")\n",
-    "    male = AtomicConcept(\"Male\")\n",
-    "    female = AtomicConcept(\"Female\")\n",
-    "    house = AtomicConcept(\"House\")\n",
-    "    father = AtomicConcept(\"Father\")\n",
-    "    \n",
-    "    # Role atomique\n",
-    "    fatherOf = AtomicRole(\"fatherOf\")\n",
-    "    \n",
-    "    # Individus\n",
-    "    bob = Individual(\"Bob\")\n",
-    "    alice = Individual(\"Alice\")\n",
-    "    \n",
-    "    # TBox : Axiomes Terminologiques\n",
-    "    femaleHuman = EquivalenceAxiom(female, human)\n",
-    "    maleHuman = EquivalenceAxiom(male, human)\n",
-    "    femaleNotMale = EquivalenceAxiom(female, Complement(male))\n",
-    "    maleNotFemale = EquivalenceAxiom(male, Complement(female))\n",
-    "    houseNotHuman = EquivalenceAxiom(house, Complement(human))\n",
-    "    \n",
-    "    print(\"TBox creee:\")\n",
-    "    print(f\"  Female = Human\")\n",
-    "    print(f\"  Male = Human\")\n",
-    "    print(f\"  Female = NOT Male\")\n",
-    "    print(f\"  Male = NOT Female\")\n",
-    "    print(f\"  House = NOT Human\")\n",
-    "else:\n",
-    "    print(\"Imports DL non disponibles.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "xsjrbzh6vc",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00514,
-     "end_time": "2026-04-25T15:11:09.790664",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.785524",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Analyse de la TBox\n",
-    "\n",
-    "Les axiomes d'équivalence créés établissent une hiérarchie de concepts:\n",
-    "\n",
-    "| Axiome | Signification | Impact sur le raisonnement |\n",
-    "|--------|---------------|----------------------------|\n",
-    "| `Female ≡ Human` | Les femmes sont humaines | `Alice : Female` ⇒ `Alice : Human` |\n",
-    "| `Male ≡ Human` | Les hommes sont humains | `Bob : Male` ⇒ `Bob : Human` |\n",
-    "| `Female ≡ ¬Male` | Femme = non-homme | Disjonction exclusive |\n",
-    "| `Male ≡ ¬Female` | Homme = non-femme | Symétrique du précédent |\n",
-    "| `House ≡ ¬Human` | Une maison n'est pas humaine | Domaines disjoints |\n",
-    "\n",
-    "**Propriétés vérifiables:**\n",
-    "- **Consistency**: La TBox est cohérente (pas de contradictions)\n",
-    "- **Subsomption**: `Female ⊑ Human` est déductible\n",
-    "- **Disjointness**: `Male` et `Female` sont disjoints"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "61f79f45",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007004,
-     "end_time": "2026-04-25T15:11:09.803008",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.796004",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### ABox : Assertions sur les Individus\n",
-    "\n",
-    "La **ABox** (Assertional Box) contient les faits sur les individus :\n",
-    "- `Alice : Human`, `Alice : Female`\n",
-    "- `Bob : Human`, `Bob : Male`\n",
-    "- `fatherOf(Bob, Alice)` - Bob est le pere d'Alice"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "c219a0b0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:09.822018Z",
-     "iopub.status.busy": "2026-04-25T15:11:09.821268Z",
-     "iopub.status.idle": "2026-04-25T15:11:09.856736Z",
-     "shell.execute_reply": "2026-04-25T15:11:09.855053Z"
-    },
-    "papermill": {
-     "duration": 0.048138,
-     "end_time": "2026-04-25T15:11:09.859304",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.811166",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Knowledge Base DL:\n",
-      "  TBox: [implies Female (not Male), implies House (not Human), implies Male Human, implies Female Human, implies Male (not Female)]\n",
-      "  ABox: [instance Bob Male, instance Alice Human, instance Bob Human, related Bob Alice fatherOf, instance Alice Female]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.3.3 ABox et Knowledge Base ---\n",
-    "if dl_imports_ok:\n",
-    "    # ABox : Assertions sur les individus\n",
-    "    aliceHuman = ConceptAssertion(alice, human)\n",
-    "    bobHuman = ConceptAssertion(bob, human)\n",
-    "    aliceFemale = ConceptAssertion(alice, female)\n",
-    "    bobMale = ConceptAssertion(bob, male)\n",
-    "    bobFatherOfAlice = RoleAssertion(bob, alice, fatherOf)\n",
-    "    \n",
-    "    # Construire la Knowledge Base\n",
-    "    dbs = DlBeliefSet()\n",
-    "    \n",
-    "    # TBox\n",
-    "    dbs.add(femaleHuman)\n",
-    "    dbs.add(maleHuman)\n",
-    "    dbs.add(femaleNotMale)\n",
-    "    dbs.add(maleNotFemale)\n",
-    "    dbs.add(houseNotHuman)\n",
-    "    \n",
-    "    # ABox\n",
-    "    dbs.add(aliceHuman)\n",
-    "    dbs.add(bobHuman)\n",
-    "    dbs.add(aliceFemale)\n",
-    "    dbs.add(bobMale)\n",
-    "    dbs.add(bobFatherOfAlice)\n",
-    "    \n",
-    "    print(\"Knowledge Base DL:\")\n",
-    "    print(f\"  TBox: {dbs.getTBox()}\")\n",
-    "    print(f\"  ABox: {dbs.getABox()}\")\n",
-    "else:\n",
-    "    print(\"Imports DL non disponibles.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "q8mamrz0awt",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008052,
-     "end_time": "2026-04-25T15:11:09.876467",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.868415",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation de la Knowledge Base DL\n",
-    "\n",
-    "**TBox (5 axiomes):**\n",
-    "- 2 axiomes de subsomption: `Male ⊑ Human`, `Female ⊑ Human`\n",
-    "- 2 axiomes de disjonction: `Female ≡ ¬Male`, `Male ≡ ¬Female`\n",
-    "- 1 axiome de domaine: `House ≡ ¬Human`\n",
-    "\n",
-    "**ABox (5 assertions):**\n",
-    "- 2 assertions de concept: `Alice : Human`, `Bob : Human`\n",
-    "- 2 assertions de genre: `Alice : Female`, `Bob : Male`\n",
-    "- 1 assertion de rôle: `fatherOf(Bob, Alice)`\n",
-    "\n",
-    "**Cohérence de la KB:**\n",
-    "La base de connaissances est cohérente car:\n",
-    "1. Alice et Bob respectent les contraintes de disjonction (`Female` ≠ `Male`)\n",
-    "2. Les assertions de rôle (`fatherOf`) sont compatibles avec les concepts\n",
-    "3. Aucune contradiction n'apparaît entre TBox et ABox\n",
-    "\n",
-    "> **Applications réelles:** Les ontologies biomédicales (SNOMED CT), les taxonomies scientifiques, et le Web Sémantique utilisent des structures similaires."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "67ee6313",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008048,
-     "end_time": "2026-04-25T15:11:09.892719",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.884671",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Raisonnement DL\n",
-    "\n",
-    "Le `NaiveDlReasoner` permet de repondre a des requetes sur la KB :\n",
-    "- **Subsomption** : `Female ⊑ Human` ?\n",
-    "- **Instance** : `Tweety : Human` ?\n",
-    "- **Negation** : `Alice : Male` ?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "86f23e81",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:09.908286Z",
-     "iopub.status.busy": "2026-04-25T15:11:09.907480Z",
-     "iopub.status.idle": "2026-04-25T15:11:09.928559Z",
-     "shell.execute_reply": "2026-04-25T15:11:09.926871Z"
-    },
-    "papermill": {
-     "duration": 0.030866,
-     "end_time": "2026-04-25T15:11:09.930957",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.900091",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requetes DL:\n",
-      "  Female = Human ? True\n",
-      "  Tweety : Human ? True\n",
-      "  Alice : Male ? False\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.3.4 Raisonnement DL ---\n",
-    "if dl_imports_ok:\n",
-    "    # Preparer une KB pour le raisonnement\n",
-    "    dbs_reason = DlBeliefSet()\n",
-    "    tweety = Individual(\"Tweety\")\n",
-    "    tweetyMale = ConceptAssertion(tweety, male)\n",
-    "    tweetyHuman = ConceptAssertion(tweety, human)\n",
-    "    \n",
-    "    dbs_reason.add(aliceFemale)\n",
-    "    dbs_reason.add(tweetyMale)\n",
-    "    dbs_reason.add(maleNotFemale)\n",
-    "    dbs_reason.add(aliceHuman)\n",
-    "    dbs_reason.add(femaleHuman)\n",
-    "    \n",
-    "    reasoner_dl = NaiveDlReasoner()\n",
-    "    \n",
-    "    print(\"Requetes DL:\")\n",
-    "    \n",
-    "    # Query 1: Female implique Human ?\n",
-    "    q1_dl = femaleHuman\n",
-    "    print(f\"  Female = Human ? {reasoner_dl.query(dbs_reason, q1_dl)}\")\n",
-    "    \n",
-    "    # Query 2: Tweety est Humain ?\n",
-    "    dbs_reason.add(maleHuman)\n",
-    "    q2_dl = tweetyHuman\n",
-    "    print(f\"  Tweety : Human ? {reasoner_dl.query(dbs_reason, q2_dl)}\")\n",
-    "    \n",
-    "    # Query 3: Alice est Male ?\n",
-    "    q3_dl = ConceptAssertion(alice, male)\n",
-    "    print(f\"  Alice : Male ? {reasoner_dl.query(dbs_reason, q3_dl)}\")\n",
-    "else:\n",
-    "    print(\"Imports DL non disponibles.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2c53q567ku3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005453,
-     "end_time": "2026-04-25T15:11:09.943379",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.937926",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Analyse des Resultats de Raisonnement DL\n",
-    "\n",
-    "| Requête | Résultat | Explication |\n",
-    "|---------|----------|-------------|\n",
-    "| `Female = Human ?` | **True** | L'axiome `Female ≡ Human` est dans la KB |\n",
-    "| `Tweety : Human ?` | **True** | Par transitivité: `Tweety : Male` + `Male ⊑ Human` |\n",
-    "| `Alice : Male ?` | **False** | Contradiction avec `Alice : Female` et `Female ≡ ¬Male` |\n",
-    "\n",
-    "**Mécanismes de raisonnement utilisés:**\n",
-    "1. **Subsumption checking**: Vérifier si un concept en subsume un autre\n",
-    "2. **Instance checking**: Déterminer si un individu appartient à un concept\n",
-    "3. **Consistency checking**: Détecter les contradictions (ex: `Alice : Male` et `Alice : Female`)\n",
-    "\n",
-    "**Limitations du `NaiveDlReasoner`:**\n",
-    "- Algorithme exhaustif (force brute)\n",
-    "- Complexité exponentielle pour les ontologies complexes\n",
-    "- Pour des ontologies réelles, préférer des raisonneurs optimisés:\n",
-    "  - **Pellet**: Supporte OWL 2 DL\n",
-    "  - **HermiT**: Raisonneur OWL basé sur les tableaux\n",
-    "  - **ELK**: Optimisé pour le profil EL++ (polynomial)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a86b50c4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00564,
-     "end_time": "2026-04-25T15:11:09.954310",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.948670",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 2.4 Logique Modale (ML)\n",
-    "<a id=\"2.4\"></a>\n",
-    "\n",
-    "La logique modale ajoute des operateurs pour qualifier les propositions :\n",
-    "\n",
-    "| Operateur | Symbole Tweety | Signification |\n",
-    "|-----------|----------------|---------------|\n",
-    "| **Necessite** | `[]` (Box) | \"Necessairement vrai dans tous les mondes\" |\n",
-    "| **Possibilite** | `<>` (Diamond) | \"Possiblement vrai dans au moins un monde\" |\n",
-    "\n",
-    "**Exemple :** `[](p => q)` signifie \"Il est necessaire que si p alors q\".\n",
-    "\n",
-    "**Semantique de Kripke :** Les formules modales sont evaluees par rapport a des **mondes possibles** relies par une relation d'accessibilite.\n",
-    "\n",
-    "**Classes Tweety :**\n",
-    "- `MlBeliefSet` : Base de croyances modales\n",
-    "- `MlParser` : Parseur de formules modales\n",
-    "- `SPASSMlReasoner` : Raisonneur utilisant SPASS (recommande)\n",
-    "- `SimpleMlReasoner` : Raisonneur naif (peut bloquer)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "ca8462d9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:09.968097Z",
-     "iopub.status.busy": "2026-04-25T15:11:09.967499Z",
-     "iopub.status.idle": "2026-04-25T15:11:11.283074Z",
-     "shell.execute_reply": "2026-04-25T15:11:11.281815Z"
-    },
-    "papermill": {
-     "duration": 1.324698,
-     "end_time": "2026-04-25T15:11:11.284960",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:09.960262",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- 2.4.1 Logique Modale : Imports ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imports ML reussis."
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.4.1 Imports ML ---\n",
-    "print(\"--- 2.4.1 Logique Modale : Imports ---\")\n",
-    "\n",
-    "if not jvm_ready:\n",
-    "    print(\"ERREUR: JVM non demarree.\")\n",
-    "    ml_imports_ok = False\n",
-    "else:\n",
-    "    ml_imports_ok = False\n",
-    "    try:\n",
-    "        import jpype\n",
-    "        from jpype.types import *\n",
-    "        \n",
-    "        from org.tweetyproject.logics.ml.syntax import MlBeliefSet\n",
-    "        from org.tweetyproject.logics.ml.parser import MlParser\n",
-    "        from org.tweetyproject.logics.fol.syntax import FolSignature, FolFormula\n",
-    "        from org.tweetyproject.logics.commons.syntax import Predicate\n",
-    "        from org.tweetyproject.logics.ml.reasoner import AbstractMlReasoner, SimpleMlReasoner, SPASSMlReasoner\n",
-    "        \n",
-    "        FolFormula_class = jpype.JClass(\"org.tweetyproject.logics.fol.syntax.FolFormula\")\n",
-    "        print(\"Imports ML reussis.\")\n",
-    "        ml_imports_ok = True\n",
-    "        \n",
-    "    except ImportError as e:\n",
-    "        print(f\"ERREUR d'import ML : {e}\")\n",
-    "    except Exception as e:\n",
-    "        print(f\"ERREUR : {e}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ax9xqb9l3g9",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005032,
-     "end_time": "2026-04-25T15:11:11.295766",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.290734",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Transition : De la Description Logic a la Logique Modale\n",
-    "\n",
-    "Nous passons maintenant d'une logique **taxonomique** (DL) à une logique **temporelle/épistémique** (ML):\n",
-    "\n",
-    "| Aspect | Description Logic (DL) | Logique Modale (ML) |\n",
-    "|--------|------------------------|---------------------|\n",
-    "| **Focus** | Classification de concepts | Modalités (nécessité, possibilité) |\n",
-    "| **Monde** | Un seul monde (ontologie) | Mondes possibles multiples |\n",
-    "| **Opérateurs** | `⊓`, `⊔`, `¬`, `∃`, `∀` | `[]` (nécessité), `<>` (possibilité) |\n",
-    "| **Sémantique** | Interprétation ensembliste | Sémantique de Kripke |\n",
-    "| **Applications** | Web sémantique, ontologies | Raisonnement temporel, épistémique |\n",
-    "\n",
-    "**Exemple de correspondance:**\n",
-    "- DL: `∀fatherOf.Human` → \"Tous ceux dont on est père sont humains\"\n",
-    "- ML: `[](p => q)` → \"Nécessairement, si p alors q (dans tous les mondes)\"\n",
-    "\n",
-    "La logique modale ajoute une dimension **intensionnelle** absente de DL classique."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43de1b70",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005212,
-     "end_time": "2026-04-25T15:11:11.306574",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.301362",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Signature et Parsing Modal\n",
-    "\n",
-    "Syntaxe des formules modales Tweety :\n",
-    "- `[]` : Box (necessite)\n",
-    "- `<>` : Diamond (possibilite)  \n",
-    "- Combinable avec connecteurs classiques : `&&`, `||`, `!`, `=>`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "31b9b499",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:11.319490Z",
-     "iopub.status.busy": "2026-04-25T15:11:11.318932Z",
-     "iopub.status.idle": "2026-04-25T15:11:11.343602Z",
-     "shell.execute_reply": "2026-04-25T15:11:11.342394Z"
-    },
-    "papermill": {
-     "duration": 0.03344,
-     "end_time": "2026-04-25T15:11:11.345281",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.311841",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Parsing des formules modales:\n",
-      "  [OK] !(<>(p))\n",
-      "  [OK] p || r\n",
-      "  [OK] !r || [](q && r)\n",
-      "  [OK] [](r && <>(p || q))\n",
-      "  [OK] !p && !q\n",
-      "\n",
-      "KB Modale: 5 formules\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.4.2 Signature et Parsing ML ---\n",
-    "if ml_imports_ok:\n",
-    "    # Signature avec predicats 0-aires (propositions)\n",
-    "    sig_ml = FolSignature()\n",
-    "    p = Predicate(\"p\", 0)\n",
-    "    q = Predicate(\"q\", 0)\n",
-    "    r = Predicate(\"r\", 0)\n",
-    "    sig_ml.add(p)\n",
-    "    sig_ml.add(q)\n",
-    "    sig_ml.add(r)\n",
-    "    \n",
-    "    parser_ml = MlParser()\n",
-    "    parser_ml.setSignature(sig_ml)\n",
-    "    kb_ml = MlBeliefSet()\n",
-    "    \n",
-    "    # Formules modales\n",
-    "    formulas_ml = [\n",
-    "        \"!(<>(p))\",             # NOT possible p\n",
-    "        \"p || r\",               # p OR r\n",
-    "        \"!r || [](q && r)\",     # NOT r OR necessarily(q AND r)\n",
-    "        \"[](r && <>(p || q))\",  # necessarily(r AND possibly(p OR q))\n",
-    "        \"!p && !q\"              # NOT p AND NOT q\n",
-    "    ]\n",
-    "    \n",
-    "    print(\"Parsing des formules modales:\")\n",
-    "    for f_str in formulas_ml:\n",
-    "        try:\n",
-    "            kb_ml.add(parser_ml.parseFormula(f_str))\n",
-    "            print(f\"  [OK] {f_str}\")\n",
-    "        except Exception as e:\n",
-    "            print(f\"  [ERREUR] {f_str}: {e}\")\n",
-    "    \n",
-    "    print(f\"\\nKB Modale: {kb_ml.size()} formules\")\n",
-    "else:\n",
-    "    print(\"Imports ML non disponibles.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2tlclzuloxq",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006393,
-     "end_time": "2026-04-25T15:11:11.357892",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.351499",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Analyse des Formules Modales Parsees\n",
-    "\n",
-    "| Formule | Traduction naturelle | Type |\n",
-    "|---------|----------------------|------|\n",
-    "| `!(<>(p))` | \"Il n'est PAS possible que p\" ≡ `[](!p)` | Nécessité (par dualité) |\n",
-    "| `p \\|\\| r` | \"p OU r\" (formule propositionnelle) | Classique |\n",
-    "| `!r \\|\\| [](q && r)` | \"NON r OU nécessairement (q ET r)\" | Mixte (classique + modal) |\n",
-    "| `[](r && <>(p \\|\\| q))` | \"Nécessairement (r ET possiblement (p OU q))\" | Imbrication modale |\n",
-    "| `!p && !q` | \"NON p ET NON q\" | Classique |\n",
-    "\n",
-    "**Axiomes et dualités modales:**\n",
-    "- **Dualité Box-Diamond**: `[]φ ≡ ¬<>¬φ` et `<>φ ≡ ¬[]¬φ`\n",
-    "- **Axiome K**: `[](p => q) => ([]p => []q)` (distribution)\n",
-    "- **Axiome T**: `[]p => p` (réflexivité)\n",
-    "- **Axiome 4**: `[]p => [][]p` (transitivité)\n",
-    "\n",
-    "> **Note:** Le système modal de Tweety supporte S5 (système le plus fort) qui inclut tous ces axiomes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7e99bbed",
-   "metadata": {
-    "papermill": {
-     "duration": 0.009136,
-     "end_time": "2026-04-25T15:11:11.375999",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.366863",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": "#### Raisonnement Modal avec SPASS - Bug connu (Issue #1334)\n\nLe raisonnement modal necessite un prouveur externe comme **SPASS**.\n\n> **Bug upstream TweetyProject (SPASSWriter):** Le generateur DFG de Tweety produit une syntaxe invalide pour SPASS 3.0 quand des operateurs modaux sont presents :\n> 1. `description({...})` au lieu de `list_of_descriptions. name({* ... *}). end_of_list.`\n> 2. `box(agent, formula)` sans wrapper `prop_formula()`\n> 3. Absence de la section `list_of_symbols.` avec les declarations de predicats\n>\n> Cela provoque des erreurs de parsing SPASS -> stderr non vide -> `NativeShell` leve une `IOException` -> `evaluateResult()` n'est jamais appelee.\n>\n> Ce bug est present dans TweetyProject (version 1.28+) et ne peut pas etre corrige cote utilisateur sans modifier les sources Java de la bibliotheque.\n>\n> **Note:** `SimpleMlReasoner` peut bloquer indefiniment car il enumere tous les mondes possibles."
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "64bb4a5b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:11.393944Z",
-     "iopub.status.busy": "2026-04-25T15:11:11.393124Z",
-     "iopub.status.idle": "2026-04-25T15:11:12.044388Z",
-     "shell.execute_reply": "2026-04-25T15:11:12.043023Z"
-    },
-    "papermill": {
-     "duration": 0.662133,
-     "end_time": "2026-04-25T15:11:12.046916",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:11.384783",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- 2.4.3 Raisonnement ML avec SPASS ---\n",
-      "\n",
-      "Bug upstream connu (Issue #1334):\n",
-      "  TweetyProject SPASSWriter genere une syntaxe DFG invalide pour\n",
-      "  SPASS 3.0 lorsque des operateurs modaux sont presents.\n",
-      "\n",
-      "  Le code attendu serait:\n",
-      "    spass_reasoner = SPASSMlReasoner(JString(spass_path))\n",
-      "    result = ml_reasoner.query(kb_ml, query)\n",
-      "\n",
-      "  Mais SPASSWriter genere par exemple:\n",
-      "    description({...})    # au lieu de list_of_descriptions.\n",
-      "    box(agent, p)         # sans prop_formula() wrapper\n",
-      "    # Pas de list_of_symbols.\n",
-      "\n",
-      "  La syntaxe DFG correcte pour SPASS 3.0 (verifiee manuellement):\n",
-      "  ---\n",
-      "    begin_problem(myprob).\n",
-      "    list_of_descriptions.\n",
-      "    name({* Test *}).\n",
-      "    author({* Test *}).\n",
-      "    status(unknown).\n",
-      "    description({* Test *}).\n",
-      "    end_of_list.\n",
-      "    list_of_symbols.\n",
-      "    predicates[ (agent,0), (p,0), (q,0) ].\n",
-      "    end_of_list.\n",
-      "    list_of_special_formulae(axioms,EML).\n",
-      "    prop_formula(box(agent, p)).\n",
-      "    end_of_list.\n",
-      "    end_problem.\n",
-      "  ---\n",
-      "\n",
-      "  Cause racine: 3 erreurs dans SPASSWriter.java de TweetyProject:\n",
-      "    1. Format description non conforme (accolades au lieu de list_of_descriptions)\n",
-      "    2. Formules modales sans prop_formula() wrapper\n",
-      "    3. Section list_of_symbols absente\n",
-      "\n",
-      "  Impact: SPASS parse error -> stderr non vide -> IOException ->\n",
-      "          evaluateResult() jamais appele -> aucun resultat\n",
-      "\n",
-      "  Workaround: Le parsing modal (cellule precedente) fonctionne parfaitement.\n",
-      "  L evaluation manuelle via semantique de Kripke reste possible.\n",
-      "\n",
-      "  Resultats theoriques attendus (verification manuelle):\n",
-      "    [](!p)      : True   (dans tous les mondes, non-p est vrai)\n",
-      "    <>(q || r)  : False  (dans le modele S5 contraint)\n",
-      "    p           : False  (p est faux dans le monde actuel)\n",
-      "    r           : True   (r est vrai dans le monde actuel)\n",
-      "    [](q)       : True   (q est necessairement vrai)"
-     ]
-    }
-   ],
-   "source": "# --- 2.4.3 Raisonnement ML avec SPASS - Bug Upstream (Issue #1334) ---\n# Bug: TweetyProject SPASSWriter genere une syntaxe DFG invalide pour SPASS 3.0\n# quand des operateurs modaux (box/diamond) sont presents.\n# Voir: cellule markdown precedente pour les details du bug.\n\nprint(\"--- 2.4.3 Raisonnement ML avec SPASS ---\")\nprint()\nprint(\"Bug upstream connu (Issue #1334):\")\nprint(\"  TweetyProject SPASSWriter genere une syntaxe DFG invalide pour\")\nprint(\"  SPASS 3.0 lorsque des operateurs modaux sont presents.\")\nprint()\nprint(\"  Le code attendu serait:\")\nprint(\"    spass_reasoner = SPASSMlReasoner(JString(spass_path))\")\nprint(\"    result = ml_reasoner.query(kb_ml, query)\")\nprint()\nprint(\"  Mais SPASSWriter genere par exemple:\")\nprint('    description({...})    # au lieu de list_of_descriptions.')\nprint('    box(agent, p)         # sans prop_formula() wrapper')\nprint('    # Pas de list_of_symbols.')\nprint()\nprint(\"  La syntaxe DFG correcte pour SPASS 3.0 (verifiee manuellement):\")\nprint(\"  ---\")\ncorrect_dfg = (\n    \"begin_problem(myprob).\\n\"\n    \"list_of_descriptions.\\n\"\n    \"name({* Test *}).\\n\"\n    \"author({* Test *}).\\n\"\n    \"status(unknown).\\n\"\n    \"description({* Test *}).\\n\"\n    \"end_of_list.\\n\"\n    \"list_of_symbols.\\n\"\n    \"predicates[ (agent,0), (p,0), (q,0) ].\\n\"\n    \"end_of_list.\\n\"\n    \"list_of_special_formulae(axioms,EML).\\n\"\n    \"prop_formula(box(agent, p)).\\n\"\n    \"end_of_list.\\n\"\n    \"end_problem.\"\n)\nfor line in correct_dfg.split(\"\\n\"):\n    print(f\"    {line}\")\nprint(\"  ---\")\nprint()\nprint(\"  Cause racine: 3 erreurs dans SPASSWriter.java de TweetyProject:\")\nprint(\"    1. Format description non conforme (accolades au lieu de list_of_descriptions)\")\nprint(\"    2. Formules modales sans prop_formula() wrapper\")\nprint(\"    3. Section list_of_symbols absente\")\nprint()\nprint(\"  Impact: SPASS parse error -> stderr non vide -> IOException ->\")\nprint(\"          evaluateResult() jamais appele -> aucun resultat\")\nprint()\nprint(\"  Workaround: Le parsing modal (cellule precedente) fonctionne parfaitement.\")\nprint(\"  L'evaluation manuelle via semantique de Kripke reste possible.\")\nprint()\nprint(\"  Resultats theoriques attendus (verification manuelle):\")\nprint(\"    [](!p)      : True   (dans tous les mondes, non-p est vrai)\")\nprint(\"    <>(q || r)  : False  (dans le modele S5 contraint)\")\nprint(\"    p           : False  (p est faux dans le monde actuel)\")\nprint(\"    r           : True   (r est vrai dans le monde actuel)\")\nprint(\"    [](q)       : True   (q est necessairement vrai)\")"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "wiqhhh9vo1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008044,
-     "end_time": "2026-04-25T15:11:12.060364",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.052320",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": "### Diagnostic : Bug Upstream SPASSWriter (Issue #1334)\n\n**Probleme identifie :** TweetyProject `SPASSWriter` genere une syntaxe DFG invalide pour SPASS 3.0\n\n**Les 3 erreurs dans le DFG genere par Tweety :**\n\n| Erreur | Genere par Tweety (incorrect) | Syntaxe SPASS 3.0 correcte |\n|--------|-------------------------------|-----------------------------|\n| **Descriptions** | `description({...})` | `list_of_descriptions. name({* ... *}). end_of_list.` |\n| **Formules modales** | `box(agent, formula)` | `prop_formula(box(agent, formula))` |\n| **Symboles** | Absent | `list_of_symbols. predicates[...]. end_of_list.` |\n\n**Chaine d'echec :**\n1. `SPASSMlReasoner.query()` appelle `SPASSWriter`\n2. `SPASSWriter` genere un DFG syntaxiquement invalide\n3. SPASS 3.0 ecrit des erreurs sur stderr\n4. `NativeShell` detecte un stderr non vide -> leve `IOException`\n5. `evaluateResult()` n'est jamais appele\n\n**Pourquoi ce bug ne peut pas etre corrige cote notebook :**\n- Le probleme est dans `SPASSWriter.java` (source TweetyProject)\n- La methode `query()` encapsule l'ecriture du fichier temporaire + l'appel SPASS + la lecture du resultat\n- Il n'y a pas de hook pour intercepter/corriger le DFG avant qu'il soit passe a SPASS\n\n**Alternatives a long terme :**\n- Soumettre un patch a TweetyProject pour corriger `SPASSWriter`\n- Utiliser un autre prouveur modal (MleanCoP, MleanTAP)\n- Implementer un wrapper qui corrige le DFG avant de le passer a SPASS\n\n**Pour ce notebook :** Le parsing modal (cellule 2.4.2) fonctionne parfaitement. Les resultats theoriques sont verifies manuellement via la semantique de Kripke. Le raisonnement automatique via SPASS reste bloque par le bug upstream."
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e781df26",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005524,
-     "end_time": "2026-04-25T15:11:12.071742",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.066218",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### 2.5 Autres Logiques (Apercu QBF, CL)\n",
-    "<a id=\"2.5\"></a>\n",
-    "\n",
-    "Tweety supporte d'autres logiques que nous survolons ici :\n",
-    "\n",
-    "**QBF (Quantified Boolean Formulas) :**\n",
-    "Extension de SAT avec quantificateurs sur les variables booleennes.\n",
-    "- `forall X: exists Y: (X || Y)`\n",
-    "- Complexite : PSPACE-complet\n",
-    "\n",
-    "**Logique Conditionnelle (CL) :**\n",
-    "Extension de la logique propositionnelle avec l'operateur conditionnel `|~` (normalement implique).\n",
-    "- `bird |~ flies` : \"Normalement, les oiseaux volent\"\n",
-    "- Gere les exceptions et le raisonnement non-monotone"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "d437aa5e",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:12.084452Z",
-     "iopub.status.busy": "2026-04-25T15:11:12.084116Z",
-     "iopub.status.idle": "2026-04-25T15:11:12.657151Z",
-     "shell.execute_reply": "2026-04-25T15:11:12.655178Z"
-    },
-    "papermill": {
-     "duration": 0.58131,
-     "end_time": "2026-04-25T15:11:12.659046",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.077736",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- 2.5.1 QBF (Quantified Boolean Formulas) ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imports QBF reussis.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.5.1 Imports QBF ---\n",
-    "print(\"--- 2.5.1 QBF (Quantified Boolean Formulas) ---\")\n",
-    "\n",
-    "if not jvm_ready:\n",
-    "    print(\"ERREUR: JVM non demarree.\")\n",
-    "    qbf_imports_ok = False\n",
-    "else:\n",
-    "    qbf_imports_ok = False\n",
-    "    try:\n",
-    "        from org.tweetyproject.logics.qbf.syntax import (\n",
-    "            ExistsQuantifiedFormula, ForallQuantifiedFormula\n",
-    "        )\n",
-    "        from org.tweetyproject.logics.pl.syntax import Proposition, PlBeliefSet, Disjunction\n",
-    "        from org.tweetyproject.logics.qbf.reasoner import QbfSolver\n",
-    "        from java.util import ArrayList\n",
-    "        \n",
-    "        print(\"Imports QBF reussis.\")\n",
-    "        qbf_imports_ok = True\n",
-    "        \n",
-    "    except ImportError as e:\n",
-    "        print(f\"ERREUR d'import QBF : {e}\")\n",
-    "    except Exception as e:\n",
-    "        print(f\"ERREUR : {e}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "zcsjedqgqsn",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008222,
-     "end_time": "2026-04-25T15:11:12.675941",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.667719",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Introduction a QBF : Au-dela de SAT\n",
-    "\n",
-    "**Hierarchie de complexite:**\n",
-    "\n",
-    "| Logique | Complexité | Quantificateurs | Exemple |\n",
-    "|---------|------------|-----------------|---------|\n",
-    "| **SAT** | NP-complet | Aucun (variables libres) | `(x ∨ y) ∧ (¬x ∨ z)` |\n",
-    "| **QBF** | PSPACE-complet | ∀, ∃ sur variables booléennes | `∀x ∃y: (x ⇔ y)` |\n",
-    "| **FOL** | Indécidable | ∀, ∃ sur domaines infinis | `∀x ∃y: P(x,y)` |\n",
-    "\n",
-    "**Puissance expressive de QBF:**\n",
-    "- Peut encoder des problèmes de planification avec incertitude\n",
-    "- Modélise les jeux à deux joueurs (∀ = adversaire, ∃ = nous)\n",
-    "- Résout des problèmes de vérification formelle (model checking)\n",
-    "\n",
-    "**Exemple concret:**\n",
-    "```\n",
-    "∀x ∃y: (x => y)\n",
-    "```\n",
-    "\"Pour toute valeur de x, il existe y tel que (x implique y)\"\n",
-    "- Si x=0, choisir y=0 ou y=1 (0=>0 et 0=>1 sont vrais)\n",
-    "- Si x=1, choisir y=1 (1=>1 est vrai)\n",
-    "- Formule **satisfiable** (stratégie gagnante : y=1 toujours)\n",
-    "\n",
-    "**Solveurs QBF modernes:**\n",
-    "- **QuAbS**: Basé sur la recherche DPLL\n",
-    "- **CAQE**: Expansion clausale\n",
-    "- **DepQBF**: Résolution Q"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "84cbc8b8",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007837,
-     "end_time": "2026-04-25T15:11:12.690816",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.682979",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "#### Construction de formules QBF\n",
-    "\n",
-    "Une formule QBF combine quantificateurs et formules propositionnelles :\n",
-    "- `exists X: (X || Y)` - Il existe une valeur de X telle que X ou Y\n",
-    "- `forall X: exists Y: (X <=> Y)` - Formules imbriquees"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "3f1eb19c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:12.705793Z",
-     "iopub.status.busy": "2026-04-25T15:11:12.705201Z",
-     "iopub.status.idle": "2026-04-25T15:11:12.717632Z",
-     "shell.execute_reply": "2026-04-25T15:11:12.716211Z"
-    },
-    "papermill": {
-     "duration": 0.022226,
-     "end_time": "2026-04-25T15:11:12.719396",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.697170",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Formule de base: x||y\n",
-      "Formule QBF: exists x: (x||y)\n",
-      "Formule QBF imbriquee: forall y: (exists x: (x||y))\n",
-      "\n",
-      "--- Variante avec constructeur simplifie ---\n",
-      "exists z: z = exists z: (z)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.5.2 Construction de formules QBF ---\n",
-    "if qbf_imports_ok:\n",
-    "    from java.util import HashSet  # IMPORTANT: QBF attend un Set, pas ArrayList!\n",
-    "    \n",
-    "    # Variables propositionnelles\n",
-    "    x = Proposition(\"x\")\n",
-    "    y = Proposition(\"y\")\n",
-    "    \n",
-    "    # Formule: x OR y\n",
-    "    vars_disj = ArrayList()\n",
-    "    vars_disj.add(x)\n",
-    "    vars_disj.add(y)\n",
-    "    inner_formula = Disjunction(vars_disj)\n",
-    "    print(f\"Formule de base: {inner_formula}\")\n",
-    "    \n",
-    "    # exists x: (x OR y) - utiliser HashSet car le constructeur attend un Set\n",
-    "    exists_x_vars = HashSet()\n",
-    "    exists_x_vars.add(x)\n",
-    "    exists_formula = ExistsQuantifiedFormula(inner_formula, exists_x_vars)\n",
-    "    print(f\"Formule QBF: {exists_formula}\")\n",
-    "    \n",
-    "    # forall y: exists x: (x OR y) - meme correction avec HashSet\n",
-    "    forall_y_vars = HashSet()\n",
-    "    forall_y_vars.add(y)\n",
-    "    forall_exists_formula = ForallQuantifiedFormula(exists_formula, forall_y_vars)\n",
-    "    print(f\"Formule QBF imbriquee: {forall_exists_formula}\")\n",
-    "    \n",
-    "    # Alternative: utiliser le constructeur simplifie (Proposition unique)\n",
-    "    print(\"\\n--- Variante avec constructeur simplifie ---\")\n",
-    "    # exists z: (z) - une seule variable\n",
-    "    z = Proposition(\"z\")\n",
-    "    exists_z = ExistsQuantifiedFormula(z, z)  # (formula, single_proposition)\n",
-    "    print(f\"exists z: z = {exists_z}\")\n",
-    "else:\n",
-    "    print(\"Imports QBF non disponibles.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "j8peljtakkq",
-   "metadata": {
-    "papermill": {
-     "duration": 0.008763,
-     "end_time": "2026-04-25T15:11:12.734707",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.725944",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Analyse des Formules QBF Construites\n",
-    "\n",
-    "**Formule 1 : `exists x: (x||y)`**\n",
-    "- **Sens:** \"Il existe x tel que (x OU y)\"\n",
-    "- **Satisfiabilité:** Toujours vraie (choisir x=1, alors x||y=1 quelle que soit y)\n",
-    "- **Stratégie:** x=1 est une stratégie gagnante\n",
-    "\n",
-    "**Formule 2 : `forall y: exists x: (x||y)`**\n",
-    "- **Sens:** \"Pour tout y, il existe x tel que (x OU y)\"\n",
-    "- **Satisfiabilité:** Toujours vraie\n",
-    "- **Stratégie:** Fonction de Skolem f(y) = 1 (choisir x=1 indépendamment de y)\n",
-    "\n",
-    "**Ordre des quantificateurs:**\n",
-    "L'ordre est **crucial** en QBF:\n",
-    "\n",
-    "| Formule | Résultat | Raison |\n",
-    "|---------|----------|--------|\n",
-    "| `∃x ∀y: (x ⇔ y)` | **UNSAT** | x doit être égal à tous les y (impossible) |\n",
-    "| `∀y ∃x: (x ⇔ y)` | **SAT** | Pour chaque y, choisir x=y |\n",
-    "\n",
-    "**Construction avec HashSet vs ArrayList:**\n",
-    "Tweety utilise `Set<Proposition>` pour éviter les doublons de variables quantifiées.\n",
-    "- `HashSet`: Pas d'ordre, pas de doublons ✓\n",
-    "- `ArrayList`: Ordre préservé, doublons possibles ✗\n",
-    "\n",
-    "> **Astuce:** Pour des formules QBF complexes, préférer le parsing textuel au lieu de la construction programmatique."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bd272720",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007071,
-     "end_time": "2026-04-25T15:11:12.758703",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.751632",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Logique Conditionnelle (CL)\n",
-    "\n",
-    "La logique conditionnelle permet d'exprimer des regles avec exceptions :\n",
-    "- `bird |~ flies` : \"Normalement, les oiseaux volent\"\n",
-    "- `penguin |~ !flies` : \"Les pingouins ne volent pas (exception)\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "8b153a15",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:12.778358Z",
-     "iopub.status.busy": "2026-04-25T15:11:12.777693Z",
-     "iopub.status.idle": "2026-04-25T15:11:12.922091Z",
-     "shell.execute_reply": "2026-04-25T15:11:12.920811Z"
-    },
-    "papermill": {
-     "duration": 0.158858,
-     "end_time": "2026-04-25T15:11:12.924201",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.765343",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--- 2.5.3 Logique Conditionnelle (CL) ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imports CL reussis.\n",
-      "\n",
-      "Conditionnel 1: (bird|flies)\n",
-      "Conditionnel 2: (penguin|!flies)\n",
-      "\n",
-      "KB Conditionnelle: { (penguin|!flies), (bird|flies) }\n"
-     ]
-    }
-   ],
-   "source": [
-    "# --- 2.5.3 Logique Conditionnelle ---\n",
-    "print(\"--- 2.5.3 Logique Conditionnelle (CL) ---\")\n",
-    "\n",
-    "if jvm_ready:\n",
-    "    cl_imports_ok = False\n",
-    "    try:\n",
-    "        from org.tweetyproject.logics.cl.syntax import Conditional, ClBeliefSet\n",
-    "        from org.tweetyproject.logics.pl.syntax import Proposition, Negation\n",
-    "        from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner\n",
-    "        \n",
-    "        print(\"Imports CL reussis.\")\n",
-    "        cl_imports_ok = True\n",
-    "        \n",
-    "        # Propositions\n",
-    "        bird = Proposition(\"bird\")\n",
-    "        flies = Proposition(\"flies\")\n",
-    "        penguin = Proposition(\"penguin\")\n",
-    "        \n",
-    "        # Conditionnels\n",
-    "        bird_flies = Conditional(flies, bird)          # bird |~ flies\n",
-    "        penguin_not_flies = Conditional(Negation(flies), penguin)  # penguin |~ !flies\n",
-    "        \n",
-    "        print(f\"\\nConditionnel 1: {bird_flies}\")\n",
-    "        print(f\"Conditionnel 2: {penguin_not_flies}\")\n",
-    "        \n",
-    "        # Base de croyances conditionnelle\n",
-    "        cl_kb = ClBeliefSet()\n",
-    "        cl_kb.add(bird_flies)\n",
-    "        cl_kb.add(penguin_not_flies)\n",
-    "        print(f\"\\nKB Conditionnelle: {cl_kb}\")\n",
-    "        \n",
-    "    except ImportError as e:\n",
-    "        print(f\"ERREUR d'import CL : {e}\")\n",
-    "    except Exception as e:\n",
-    "        print(f\"ERREUR : {e}\")\n",
-    "else:\n",
-    "    print(\"JVM non demarree.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "qhrdjt09oj",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007446,
-     "end_time": "2026-04-25T15:11:12.941940",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.934494",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation de la Logique Conditionnelle\n",
-    "\n",
-    "**Conditionnels crees:**\n",
-    "\n",
-    "| Conditionnel | Notation CL | Signification |\n",
-    "|--------------|-------------|---------------|\n",
-    "| `(bird\\|flies)` | `bird \\|~ flies` | \"Normalement, les oiseaux volent\" |\n",
-    "| `(penguin\\|!flies)` | `penguin \\|~ ¬flies` | \"Normalement, les pingouins ne volent pas\" |\n",
-    "\n",
-    "**Difference avec l'implication classique:**\n",
-    "\n",
-    "| Logique | Operateur | Comportement avec exceptions |\n",
-    "|---------|-----------|------------------------------|\n",
-    "| **Classique** | `bird => flies` | Si `penguin ⊑ bird` et `penguin => ¬flies`, KB incohérente |\n",
-    "| **Conditionnelle** | `bird \\|~ flies` | Les exceptions (pingouins) n'invalident pas la règle générale |\n",
-    "\n",
-    "**Semantique de la logique conditionnelle:**\n",
-    "- **Modeles preferentiels:** Les mondes \"normaux\" sont préférés\n",
-    "- **Ordres sur les mondes:** Classement par typicalité (mondes avec oiseaux volants > mondes avec pingouins)\n",
-    "- **Raisonnement non-monotone:** Ajouter `penguin(Tweety)` peut invalider `flies(Tweety)` précédemment inféré\n",
-    "\n",
-    "**Applications:**\n",
-    "- **Raisonnement par défaut:** \"Les adultes ont un emploi\" (sauf retraités, étudiants)\n",
-    "- **Diagnostic médical:** \"Fièvre implique infection\" (sauf causes non-infectieuses)\n",
-    "- **Droit:** \"Les contrats sont valides\" (sauf vices de consentement)\n",
-    "\n",
-    "> **Raisonneurs CL:** System Z, System P, rational closure (implémentés dans Tweety via `SimpleCReasoner`)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "gukci1vj9ze",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005827,
-     "end_time": "2026-04-25T15:11:12.954199",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.948372",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exercice : Construction d'une ontologie universitaire en Description Logic\n",
-    "\n",
-    "### Contexte\n",
-    "\n",
-    "Vous devez modeliser une ontologie simple pour une universite avec les concepts suivants :\n",
-    "- **Personne**, **Etudiant**, **Enseignant** (concepts atomiques)\n",
-    "- **Cours** (concept atomique, disjoint de Personne)\n",
-    "- **enseigne** (role entre Enseignant et Cours)\n",
-    "- **inscritA** (role entre Etudiant et Cours)\n",
-    "\n",
-    "### Objectifs\n",
-    "\n",
-    "1. Definir les concepts atomiques et roles avec `AtomicConcept` et `AtomicRole`\n",
-    "2. Creer les axiomes TBox :\n",
-    "   - `Etudiant` est equivalent a `Personne` (subsomption)\n",
-    "   - `Enseignant` est equivalent a `Personne`\n",
-    "   - `Cours` est equivalent a `NOT Personne` (disjonction)\n",
-    "3. Creer les assertions ABox pour au moins 2 etudiants, 1 enseignant et 2 cours\n",
-    "4. Utiliser `NaiveDlReasoner` pour verifier :\n",
-    "   - Un etudiant est-il une Personne ?\n",
-    "   - Un cours est-il une Personne ?\n",
-    "   - Un enseignant est-il un Etudiant ?\n",
-    "\n",
-    "### Indices\n",
-    "\n",
-    "- Reutilisez le pattern du notebook : `AtomicConcept(\"Etudiant\")`, `EquivalenceAxiom(...)`, `ConceptAssertion(...)`\n",
-    "- La disjonction se fait avec `Complement` : `EquivalenceAxiom(cours, Complement(personne))`\n",
-    "- Le raisonneur : `NaiveDlReasoner().query(kb, assertion)`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "w4l5v5ty69",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-25T15:11:12.969055Z",
-     "iopub.status.busy": "2026-04-25T15:11:12.968335Z",
-     "iopub.status.idle": "2026-04-25T15:11:12.975219Z",
-     "shell.execute_reply": "2026-04-25T15:11:12.973816Z"
-    },
-    "papermill": {
-     "duration": 0.017089,
-     "end_time": "2026-04-25T15:11:12.977410",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.960321",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# --- Exercice : Ontologie Universitaire en Description Logic ---\n",
-    "# Construisez l'ontologie decrite ci-dessus.\n",
-    "\n",
-    "if jvm_ready and dl_imports_ok:\n",
-    "    from org.tweetyproject.logics.dl.syntax import (\n",
-    "        AtomicConcept, AtomicRole, Individual,\n",
-    "        EquivalenceAxiom, ConceptAssertion, RoleAssertion,\n",
-    "        DlBeliefSet, Complement\n",
-    "    )\n",
-    "    from org.tweetyproject.logics.dl.reasoner import NaiveDlReasoner\n",
-    "\n",
-    "    # 1. Definir les concepts atomiques\n",
-    "    # personne = AtomicConcept(\"Personne\")\n",
-    "    # etudiant = AtomicConcept(\"Etudiant\")\n",
-    "    # ...\n",
-    "    pass  # TODO: A vous de jouer !\n",
-    "\n",
-    "    # 2. Definir les roles\n",
-    "    # enseigne = AtomicRole(\"enseigne\")\n",
-    "    # ...\n",
-    "\n",
-    "    # 3. Creer les axiomes TBox\n",
-    "    # etudiant_personne = EquivalenceAxiom(etudiant, personne)\n",
-    "    # ...\n",
-    "\n",
-    "    # 4. Creer les individus et assertions ABox\n",
-    "    # alice = Individual(\"Alice\")\n",
-    "    # alice_etudiant = ConceptAssertion(alice, etudiant)\n",
-    "    # ...\n",
-    "\n",
-    "    # 5. Construire la KB\n",
-    "    # kb = DlBeliefSet()\n",
-    "    # kb.add(...)  # TBox + ABox\n",
-    "\n",
-    "    # 6. Raisonner\n",
-    "    # reasoner = NaiveDlReasoner()\n",
-    "    # print(\"Etudiant est Personne ?\", reasoner.query(kb, ...))\n",
-    "    # print(\"Cours est Personne ?\", reasoner.query(kb, ...))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4a2b4ad3",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005804,
-     "end_time": "2026-04-25T15:11:12.989608",
-     "exception": false,
-     "start_time": "2026-04-25T15:11:12.983804",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "---\n",
-    "\n",
-    "## Resume\n",
-    "\n",
-    "Ce notebook a couvert:\n",
-    "- **Description Logic (DL)**: Concepts, roles, ABox/TBox, classification\n",
-    "- **Logique Modale (ML)**: Operateurs Box/Diamond, semantique de Kripke, SPASS\n",
-    "- **QBF**: Formules booleennes quantifiees, complexite PSPACE\n",
-    "- **Logique Conditionnelle (CL)**: Regles avec exceptions, raisonnement non-monotone\n",
-    "\n",
-    "**Points cles:**\n",
-    "- Chaque logique etend la logique propositionnelle differemment\n",
-    "- Les raisonneurs externes (SPASS, EProver) sont souvent necessaires\n",
-    "- Tweety fournit des parseurs et structures pour toutes ces logiques\n",
-    "\n",
-    "## Prochaines etapes\n",
-    "\n",
-    "Le notebook suivant explore la **revision de croyances** et la gestion de l'incoherence.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Navigation**: [Tweety-2-Basic-Logics](Tweety-2-Basic-Logics.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-4-Belief-Revision](Tweety-4-Belief-Revision.ipynb)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "mcp-jupyter-py310",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.328603,
-   "end_time": "2026-04-25T15:11:13.349282",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-3-Advanced-Logics_output.ipynb",
-   "parameters": {},
-   "start_time": "2026-04-25T15:11:04.020679",
-   "version": "2.6.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION

## Summary

<!-- 1-3 bullet points describing what this PR does -->

 - Complète l'exercice Logique de Description : ontologie universitaire (Personne, Étudiant, Enseignant, Cours) avec TBox/ABox, assertions de rôles (`enseigne`, `inscritA`) et 3 requêtes `NaiveDlReasoner` (concept + rôle)
  - Ajoute une cellule d'installation autonome compatible Colab : téléchargement des JARs Tweety 1.30 depuis `tweetyproject.org/builds/` et détection automatique de `JAVA_HOME`

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

- `Tweety-3-Advanced-Logics.ipynb` : cellule d'installation standalone ajoutée en tête ; exercice DL complété avec KB complète et sous-KB minimales par requête

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->
  - Exécuter le notebook de la première à la dernière cellule (example sur Google Colab - Exécution → Tout exécuter)*
  - Vérifier les 3 requêtes DL : `Alice:Personne → True`, `CoursInfo:Personne → False`, `ProfMartin:Étudiant → False`