### PR TITLE
Exo: tweety-7b-ranking (groupe IliasKalalou-KaelanGrall)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -36,7 +36,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
+   "id": "5f5615e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting JPype1\n",
+      "  Downloading jpype1-1.7.1-1-cp312-cp312-macosx_11_0_universal2.whl.metadata (4.3 kB)\n",
+      "Requirement already satisfied: packaging in /opt/anaconda3/lib/python3.12/site-packages (from JPype1) (25.0)\n",
+      "Downloading jpype1-1.7.1-1-cp312-cp312-macosx_11_0_universal2.whl (569 kB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m569.7/569.7 kB\u001b[0m \u001b[31m16.4 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: JPype1\n",
+      "Successfully installed JPype1-1.7.1\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.3\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.1.1\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n",
+      "/opt/anaconda3/bin/python\n",
+      "3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:54:21) [Clang 16.0.6 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install JPype1\n",
+    "import sys\n",
+    "print(sys.executable)\n",
+    "print(sys.version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "4464a752",
    "metadata": {
     "execution": {
@@ -60,22 +93,13 @@
      "output_type": "stream",
      "text": [
       "--- Verification JVM Tweety + Outils ---\n",
-      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "JVM demarree avec 42 JARs.\n",
+      "JVM demarree avec 34 JARs.\n",
       "\n",
       "--- Outils disponibles ---\n",
-      "  CLINGO: clingo\n",
-      "  EPROVER: eprover.exe\n",
       "  SAT_SOLVER_PYTHON: sat_solver.py\n",
       "  MARCO: marco.py\n",
       "\n",
-      "JVM prete. Outils: 4/5\n"
+      "JVM prete. Outils: 2/5\n"
      ]
     }
    ],
@@ -308,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "id": "4988945f",
    "metadata": {
     "execution": {
@@ -333,13 +357,7 @@
      "text": [
       "\n",
       "--- 5.7 Semantiques Basees sur le Classement (Ranking) ---\n",
-      "JVM prete. Execution des exemples de Ranking Semantics...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "JVM prete. Execution des exemples de Ranking Semantics...\n",
       "Imports pour Ranking Semantics reussis.\n",
       "\n",
       "Definition des AAFs exemples...\n",
@@ -363,13 +381,7 @@
       "* Tuples*:\n",
       "  - AAF Ex5: [j = e = a > g = f > c > h = d = b > i]\n",
       "\n",
-      "* Strategy-Based:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "* Strategy-Based:\n",
       "  - AAF Ex4a: {a=0.167, b=1.0, c=1.0, d=0.25, e=1.0, f=0.25, g=1.0}\n",
       "\n",
       "* SAF-Based (SimpleProduct):\n",
@@ -583,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "3ec0ceec",
    "metadata": {
     "execution": {
@@ -818,7 +830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 20,
    "id": "ihnq7d0yl8",
    "metadata": {
     "execution": {
@@ -836,7 +848,57 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AAF: <{ e1, t1, e2, t2, c1 },[(c1,t2), (e1,t1), (e2,e1)]>\n",
+      "\n",
+      "Categorizer\n",
+      "{e1=0.5, t1=0.667, e2=1.0, t2=0.5, c1=1.0}\n",
+      "\n",
+      "Burden-Based\n",
+      "[c1 = e2 > t1 > t2 = e1]\n",
+      "\n",
+      "Discussion-Based\n",
+      "[c1 = e2 > t1 > t2 = e1]\n",
+      "\n",
+      "Analyse\n",
+      "Categorizer : t1=0.667, t2=0.500. Le traitement A (t1) est mieux classe que B (t2).\n",
+      "Burden-Based : [c1 = e2 > t1 > t2 = e1]. t1 est strictement au-dessus de t2.\n",
+      "Discussion-Based : [c1 = e2 > t1 > t2 = e1]. Meme ordre que Burden-Based.\n",
+      "\n",
+      "Convergence : les 3 semantiques produisent le meme ordre relatif t1 > t2.\n",
+      "Cette convergence s'explique par la structure simple du graphe (chaine d'attaques sans cycle).\n",
+      "Sur des graphes avec cycles ou attaques multiples, Categorizer et Burden peuvent diverger.\n",
+      "\n",
+      "Mecanisme : t1 est reinstaure par e2 (defenseur de t1 via e2 -> e1 -> t1).\n",
+      "En revanche, t2 est attaque par c1 (non attaque, score 1.0) sans aucun defenseur.\n",
+      "Le traitement A est donc mieux supporte que B dans les 3 semantiques.\n",
+      "\n",
+      "Bonus : ajout de e3 attaquant e2\n",
+      "AAF modifie: <{ e1, t1, e2, t2, c1, e3 },[(c1,t2), (e1,t1), (e2,e1), (e3,e2)]>\n",
+      "\n",
+      "Categorizer apres ajout e3:\n",
+      "{e1=0.667, t1=0.6, e2=0.5, t2=0.5, c1=1.0, e3=1.0}\n",
+      "\n",
+      "Burden-Based apres ajout e3:\n",
+      "[e3 = c1 > e1 > t1 > t2 = e2]\n",
+      "\n",
+      "Discussion-Based apres ajout e3:\n",
+      "[e3 = c1 > e1 > t1 > t2 = e2]\n",
+      "\n",
+      "Analyse du bonus\n",
+      "Avant e3 : Categorizer t1=0.667. Apres e3 : t1=0.600. Diminution de 0.067.\n",
+      "Avant e3 : Categorizer t2=0.500. Apres e3 : t2=0.500. Inchange.\n",
+      "e1 passe de 0.500 à 0.667 apres ajout de e3, ce qui confirme numeriquement la defense.\n",
+      "e3 défend e1 en attaquant l'attaquant de e1 (qui est e2).\n",
+      "Chaine : e3 -> e2 -> e1 -> t1. c'est une attaque de second ordre, qui annule partiellement la défense de t1 par e2\n",
+      "t1 reste au-dessus de t2 (0.600 > 0.500) mais l'ecart se reduit de 0.167 a 0.100.\n"
+     ]
+    }
+   ],
    "source": [
     "# --- Exercice : Classement d'un debat medical ---\n",
     "\n",
@@ -855,7 +917,77 @@
     "    # 4. Analyser : quel traitement gagne selon chaque semantique ?\n",
     "    # 5. (Bonus) Ajouter un argument qui attaque une etude et re-calculer\n",
     "\n",
-    "    pass  # TODO etudiant : a vous de jouer !"
+    "    # 1\n",
+    "    theory = DungTheory()\n",
+    "    t1 = Argument(\"t1\")\n",
+    "    t2 = Argument(\"t2\")\n",
+    "    e1 = Argument(\"e1\")\n",
+    "    e2 = Argument(\"e2\")\n",
+    "    c1 = Argument(\"c1\")\n",
+    "\n",
+    "    for arg in [t1, t2, e1, e2, c1]:\n",
+    "        theory.add(arg)\n",
+    "\n",
+    "    # 2\n",
+    "    theory.add(Attack(e1, t1))\n",
+    "    theory.add(Attack(e2, e1))\n",
+    "    theory.add(Attack(c1, t2))\n",
+    "    print(\"AAF:\", theory)\n",
+    "\n",
+    "    # 3\n",
+    "    print(\"\\nCategorizer\")\n",
+    "    r_cat = CategorizerRankingReasoner()\n",
+    "    rank_cat = r_cat.getModel(theory)\n",
+    "    print(RankingTools.roundRanking(rank_cat, 3))\n",
+    "\n",
+    "    print(\"\\nBurden-Based\")\n",
+    "    r_bb = BurdenBasedRankingReasoner()\n",
+    "    rank_bb = r_bb.getModel(theory)\n",
+    "    print(rank_bb)\n",
+    "\n",
+    "    print(\"\\nDiscussion-Based\")\n",
+    "    r_db = DiscussionBasedRankingReasoner()\n",
+    "    rank_db = r_db.getModel(theory)\n",
+    "    print(rank_db)\n",
+    "\n",
+    "    # 4\n",
+    "    print(\"\\nAnalyse\")\n",
+    "    print(\"Categorizer : t1=0.667, t2=0.500. Le traitement A (t1) est mieux classe que B (t2).\")\n",
+    "    print(\"Burden-Based : [c1 = e2 > t1 > t2 = e1]. t1 est strictement au-dessus de t2.\")\n",
+    "    print(\"Discussion-Based : [c1 = e2 > t1 > t2 = e1]. Meme ordre que Burden-Based.\\n\")\n",
+    "    print(\"Convergence : les 3 semantiques produisent le meme ordre relatif t1 > t2.\")\n",
+    "    print(\"Cette convergence s'explique par la structure simple du graphe (chaine d'attaques sans cycle).\")\n",
+    "    print(\"Sur des graphes avec cycles ou attaques multiples, Categorizer et Burden peuvent diverger.\\n\")\n",
+    "    print(\"Mecanisme : t1 est reinstaure par e2 (defenseur de t1 via e2 -> e1 -> t1).\")\n",
+    "    print(\"En revanche, t2 est attaque par c1 (non attaque, score 1.0) sans aucun defenseur.\")\n",
+    "    print(\"Le traitement A est donc mieux supporte que B dans les 3 semantiques.\")\n",
+    "\n",
+    "    # 5\n",
+    "    print(\"\\nBonus : ajout de e3 attaquant e2\")\n",
+    "    e3 = Argument(\"e3\")\n",
+    "    theory.add(e3)\n",
+    "    theory.add(Attack(e3, e2))\n",
+    "    print(\"AAF modifie:\", theory)\n",
+    "\n",
+    "    print(\"\\nCategorizer apres ajout e3:\")\n",
+    "    rank_cat2 = r_cat.getModel(theory)\n",
+    "    print(RankingTools.roundRanking(rank_cat2, 3))\n",
+    "\n",
+    "    print(\"\\nBurden-Based apres ajout e3:\")\n",
+    "    rank_bb2 = r_bb.getModel(theory)\n",
+    "    print(rank_bb2)\n",
+    "\n",
+    "    print(\"\\nDiscussion-Based apres ajout e3:\")\n",
+    "    rank_db2 = r_db.getModel(theory)\n",
+    "    print(rank_db2)\n",
+    "\n",
+    "    print(\"\\nAnalyse du bonus\")\n",
+    "    print(\"Avant e3 : Categorizer t1=0.667. Apres e3 : t1=0.600. Diminution de 0.067.\")\n",
+    "    print(\"Avant e3 : Categorizer t2=0.500. Apres e3 : t2=0.500. Inchange.\")\n",
+    "    print(\"e1 passe de 0.500 à 0.667 apres ajout de e3, ce qui confirme numeriquement la defense.\")\n",
+    "    print(\"e3 défend e1 en attaquant l'attaquant de e1 (qui est e2).\")\n",
+    "    print(\"Chaine : e3 -> e2 -> e1 -> t1. c'est une attaque de second ordre, qui annule partiellement la défense de t1 par e2\")\n",
+    "    print(\"t1 reste au-dessus de t2 (0.600 > 0.500) mais l'ecart se reduit de 0.167 a 0.100.\")\n"
    ]
   },
   {
@@ -918,9 +1050,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mcp-jupyter-py310",
+   "display_name": "Python 3.12 (NLP-Course)",
    "language": "python",
-   "name": "python3"
+   "name": "nlp-course"
   },
   "language_info": {
    "codemirror_mode": {
@@ -932,7 +1064,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.12.2"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->
- Correction de la cellule d'exercice (cellule 13) du notebook Tweety-7b-Ranking-Probabilistic : modelisation d'un debat medical en DungTheory (5 arguments, 3 attaques) et application des semantiques Categorizer, Burden-Based et Discussion-Based.
- Analyse de la convergence des trois semantiques (ordre identique t1 > t2) avec justification structurelle (graphe acyclique en chaine d'attaques) et identification du mecanisme de reinstatement de t1 par e2.
- Bonus : ajout de l'argument e3 attaquant e2, observe comme attaque de second ordre qui annule partiellement la defense de t1 (Categorizer t1 passe de 0.667 a 0.600, e1 remonte de 0.500 a 0.667).
- Groupe : Ilias Kalalou et Kaelan Grall.
-

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
