### PR TITLE
docs(qc): add README.md for 18 projects missing documentation

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-DualMomentum-NoTLT/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-DualMomentum-NoTLT/README.md
@@ -1,0 +1,40 @@
+# Cloud-DualMomentum-NoTLT
+
+**Asset class:** Equities, Bonds, Commodities (multi-asset ETF rotation)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Dual Momentum strategy (Antonacci 2014) with three controlled variants via the `version` parameter. All variants use a 252-day lookback and monthly rebalance. No TLT allocation, avoiding long-duration Treasury exposure.
+
+- **v1:** Classic absolute + relative momentum on SPY/EFA + BND bond allocation.
+- **v2:** Broadened universe (SPY, QQQ, IEF, GLD, XLP) selecting top 2 by momentum score.
+- **v3:** SPY/QQQ/EFA/GLD top 3 momentum-weighted allocation.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-DualMomentum-NoTLT/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Dual Momentum (3 variants) | Monthly | Lookback 252 days, version 1/2/3 |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Dual Momentum algorithm with 3 strategy variants controlled by `version` parameter |
+
+## References
+
+- Antonacci, G. (2014). *Dual Momentum Investing*. McGraw-Hill.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-MeanReversion-Sectors/README.md
@@ -1,0 +1,35 @@
+# Cloud-MeanReversion-Sectors
+
+**Asset class:** Equities (GICS sector ETFs)
+
+**Cloud project ID:** N/A
+
+## Description
+
+RSI(14) mean reversion strategy on 11 GICS sector ETFs (XLK, XLF, XLE, XLV, XLI, XLY, XLP, XLU, XLB, XLRE, XLC). Three variants with increasing sophistication: v1 uses raw RSI oversold/overbought signals; v2 adds SMA200 regime filtering (only trade in bull markets); v3 incorporates stop-loss rules. Scans daily 30 minutes after market open.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-MeanReversion-Sectors/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| RSI Mean Reversion (3 variants) | Daily scan | RSI period 14, SMA200 regime filter (v2+), stop-loss (v3) |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Mean reversion algorithm with 3 variants (RSI, +regime filter, +stop-loss) on 11 sector ETFs |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-RiskParity-Composite/README.md
@@ -1,0 +1,36 @@
+# Cloud-RiskParity-Composite
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Tactical rotation across six asset classes (SPY, TLT, GLD, EFA, EEM, DBC) using a dual filter: price above SMA200 AND positive 6-month momentum. Assets passing both filters receive equal weight. Rebalances every 30 days. Inspired by AQR's Hurst, Ooi, and Pedersen (2014) approach to trend-following with risk parity allocation.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-RiskParity-Composite/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Dual-filter Risk Parity | 30 days | SMA200 + 6-month momentum, equal weight among passing assets |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Risk parity rotation with SMA200 + momentum dual filter on 6 multi-asset ETFs |
+
+## References
+
+- Hurst, B., Ooi, Y.H., Pedersen, L.H. (2014). *A Century of Evidence on Trend-Following Investing*. AQR.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-SectorRotation-Momentum/README.md
@@ -1,0 +1,35 @@
+# Cloud-SectorRotation-Momentum
+
+**Asset class:** Equities, Bonds, Commodities (ETF rotation)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Momentum-weighted trend following on a 5-ETF universe (QQQ, SPY, EFA, GLD, IWM) with SHY as the defensive cash equivalent. Uses a dual filter (price above SMA200 AND positive 6-month momentum) to select trending assets, then allocates proportionally to their rate-of-change (ROC) momentum scores. Rebalances every 21 trading days.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-SectorRotation-Momentum/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Momentum-weighted trend following | 21 days | SMA200 + 6m momentum dual filter, ROC proportional weighting |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Sector rotation with momentum-weighted allocation and dual trend filter |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Cloud-VolTargeting/README.md
@@ -1,0 +1,35 @@
+# Cloud-VolTargeting
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Volatility targeting strategy with three variants. v1 targets 12% annualized volatility on SPY alone using realized vol scaling. v2 extends to a multi-asset portfolio (SPY, QQQ, IEF, GLD) with equal risk contribution targeting 10% annualized vol. v3 adds a 126-day momentum filter to the multi-asset approach. Monthly rebalance across all variants.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Cloud-VolTargeting/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Vol targeting (3 variants) | Monthly | Vol target 10-12%, momentum filter 126 days (v3), equal risk contribution (v2/v3) |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Volatility targeting algorithm with 3 variants (single-asset, multi-asset ERC, +momentum) |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-GARCH-VolTarget/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-GARCH-VolTarget/README.md
@@ -1,0 +1,38 @@
+# ESGF-GARCH-VolTarget
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 209093652)
+
+## Description
+
+GARCH(1,1) volatility targeting strategy on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Each asset targets 10% annualized volatility with position sizes adjusted by the GARCH forecast. Uses SMA200 for trend direction (long in uptrend, reduce in downtrend). Model is refit every 22 trading days on a 500-day training window. Weekly rebalance on Mondays.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm ESGF-GARCH-VolTarget/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 209093652), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| GARCH(1,1) vol targeting | Weekly (Monday) | Vol target 10%, SMA200 trend, 500-day window, refit every 22 days |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | GARCH(1,1) volatility targeting with SMA200 trend filter on 6 multi-asset ETFs |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with GARCH model analysis and parameter exploration |
+
+## References
+
+- Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-HAR-RV-Kelly/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-HAR-RV-Kelly/README.md
@@ -1,0 +1,39 @@
+# ESGF-HAR-RV-Kelly
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 230839018)
+
+## Description
+
+HAR-RV (Heterogeneous Autoregressive Realized Variance, Corsi 2009) model for forecasting 5-day realized variance on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the Kelly Criterion at 1/4 fraction for position sizing based on the HAR forecast. Includes 5-day momentum direction. Model refit via OLS every 22 days on a 500-day rolling window. Weekly rebalance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm ESGF-HAR-RV-Kelly/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 230839018), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| HAR-RV + Kelly Criterion | Weekly | Kelly fraction 1/4, 5-day forecast, OLS refit every 22 days, 500-day window |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | HAR-RV volatility forecasting with Kelly Criterion sizing on 6 multi-asset ETFs |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with HAR-RV model analysis and Kelly fraction exploration |
+
+## References
+
+- Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
+- Kelly, J.L. (1956). *A New Interpretation of Information Rate*. Bell System Technical Journal.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-VolEnsemble-Conservative/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ESGF-VolEnsemble-Conservative/README.md
@@ -1,0 +1,39 @@
+# ESGF-VolEnsemble-Conservative
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** See `config.json` (local-id: 818573377)
+
+## Description
+
+Conservative ensemble volatility forecasting combining GARCH(1,1) and HAR-RV models on six assets (SPY, EFA, EEM, TLT, GLD, DBC). Uses the maximum of the two volatility forecasts (conservative approach). Targets 8% annualized volatility (half the normal 16% target). Applies SMA200 regime filter with 50% position reduction in bear markets, and SMA50 for trade direction. Weekly rebalance. Most conservative of the three ESGF volatility strategies.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm ESGF-VolEnsemble-Conservative/main.py
+```
+
+### QC Cloud
+Open the cloud project (local-id: 818573377), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Ensemble GARCH+HAR (conservative max) | Weekly | Vol target 8%, SMA200 regime (-50% bear), SMA50 direction, 500-day window |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Conservative ensemble volatility targeting (max of GARCH + HAR) with regime filter |
+| `config.json` | Project configuration (local-id) |
+| `research.ipynb` | Research notebook with ensemble model comparison and conservative parameter analysis |
+
+## References
+
+- Bollerslev, T. (1986). *Generalized Autoregressive Conditional Heteroskedasticity*. Journal of Econometrics.
+- Corsi, F. (2009). *A Simple Approximate Long-Memory Model of Realized Volatility*. Journal of Financial Econometrics.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Ensemble-DLinear-TFT/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Ensemble-DLinear-TFT/README.md
@@ -1,0 +1,41 @@
+# Ensemble-DLinear-TFT
+
+**Asset class:** Crypto (BTC-USD, ETH-USD)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook exploring an ensemble of DLinear and TFT-Lite neural network architectures for predicting crypto direction (BTC-USD, ETH-USD). Conducts a v2 grid search over ensemble weights {0.4, 0.5, 0.6, 0.7} with walk-forward 5-fold validation across 4 seeds. Applies 10bps transaction costs. Verdict: NO BEATS for all configurations (DLinear z=-6.00, TFT-Lite z=-10.69, ensemble z=-9.28).
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| DLinear + TFT-Lite ensemble | N/A (research) | Walk-forward 5-fold x 4 seeds, weight grid {0.4-0.7}, 10bps T-cost |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with DLinear + TFT-Lite ensemble grid search and walk-forward validation |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Zeng, A. et al. (2023). *Are Transformers Effective for Time Series Forecasting?* AAAI.
+- Lim, B. et al. (2021). *Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting*. International Journal of Forecasting.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/GlobalMacro-Regime/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GlobalMacro-Regime/README.md
@@ -1,0 +1,36 @@
+# GlobalMacro-Regime
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Rank-based Risk Parity with Regime Switching (v3 BEST: Sharpe 0.607, CAGR 11.62%, MaxDD 23.6%). Uses SMA200 + 6-month momentum for regime classification. In bull markets, allocates to trending risky assets (SPY, EFA, EEM, TLT, GLD, DBC) with rank-weighted inverse-volatility positioning. In bear markets, shifts to risk parity on defensive assets (BND, TLT, GLD). Monthly rebalance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm GlobalMacro-Regime/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest (default: 2015-01-01 to 2024-12-31).
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Regime-switching Risk Parity (v3) | Monthly | SMA200 + 6m momentum regime, rank-based inverse-vol weighting |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Global macro regime-switching strategy with rank-based risk parity allocation |
+
+## References
+
+- Hurst, B., Ooi, Y.H., Pedersen, L.H. (2014). *A Century of Evidence on Trend-Following Investing*. AQR.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/GraphSAGE-MultiAsset-Ranking/README.md
@@ -1,0 +1,40 @@
+# GraphSAGE-MultiAsset-Ranking
+
+**Asset class:** Equities (large-cap US stocks)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook applying GraphSAGE (Hamilton, Ying, and Leskovec 2017) graph neural network for cross-asset direction prediction on 8 large-cap US stocks (JPM, JNJ, XOM, PG, UNP, V, HD, BA). Constructs a correlation-based graph with threshold 0.5 to capture inter-asset dependencies. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. Verdict: INCONCLUSIVE (insufficient statistical evidence to confirm or reject the approach).
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch Geometric.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| GraphSAGE cross-asset ranking | N/A (research) | Correlation threshold 0.5, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with GraphSAGE model, correlation graph construction, and walk-forward validation |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Hamilton, W., Ying, Z., Leskovec, J. (2017). *Inductive Representation Learning on Large Graphs*. NeurIPS.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Mamba-Crypto-Ranking/README.md
@@ -1,0 +1,40 @@
+# Mamba-Crypto-Ranking
+
+**Asset class:** Crypto (BTC-USD, ETH-USD)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook evaluating Mamba (Selective State Space Model, Gu and Dao 2023) for crypto direction prediction (BTC-USD, ETH-USD). Compares Mamba (d_model=64, d_state=8, 1 layer, 80 epochs) against DLinear and TFT-Lite baselines. Pure PyTorch implementation with walk-forward validation. Verdict: Mamba INCONCLUSIVE (Sharpe 0.000, outputs NaN during training), DLinear NO BEATS, TFT-Lite NO BEATS.
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Mamba SSM | N/A (research) | d_model=64, d_state=8, 1 layer, 80 epochs, walk-forward 5-fold x 4 seeds |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with Mamba model implementation, comparison vs DLinear/TFT-Lite baselines |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Gu, A., Dao, T. (2023). *Mamba: Linear-Time Sequence Modeling with Selective State Spaces*. arXiv.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/README.md
@@ -1,0 +1,49 @@
+# Research-Executor
+
+**Asset class:** Multi-asset (research execution harness)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Framework that executes 8 embedded research notebooks as a QC algorithm within a 2-day backtest window (2024-01-02 to 2024-01-03). Uses a MockQB class to simulate QuantBook environment for notebooks. The embedded research topics include: asset class momentum, commodity term structure, defensive ETF rotation, short harvest, macro factor rotation, Piotroski F-score, puppies of the Dow, and volatility regime ML. Saves executed notebooks to the QC object store.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Research-Executor/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py` and all research notebooks, compile and run a backtest.
+
+### Research Notebook
+```bash
+papermill runner.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Research harness (8 notebooks) | N/A (execution framework) | 2-day window, MockQB simulation, Object Store output |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Research executor algorithm that runs 8 embedded notebooks via MockQB |
+| `runner.ipynb` | Jupyter notebook runner for the research executor |
+| `research_asset_class_momentum.ipynb` | Asset class momentum research notebook |
+| `research_commodity_term_structure.ipynb` | Commodity term structure research notebook |
+| `research_defensive_etf_rotation.ipynb` | Defensive ETF rotation research notebook |
+| `research_short_harvest.ipynb` | Short harvest research notebook |
+| `research_macro_factor_rotation.ipynb` | Macro factor rotation research notebook |
+| `research_piotroski_fscore.ipynb` | Piotroski F-score research notebook |
+| `research_puppies_of_dow.ipynb` | Puppies of the Dow research notebook |
+| `research_volatility_regime_ml.ipynb` | Volatility regime ML research notebook |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Simple-Equity-EMA-Crossing/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Simple-Equity-EMA-Crossing/README.md
@@ -1,0 +1,35 @@
+# Simple-Equity-EMA-Crossing
+
+**Asset class:** Equities (US large-cap tech)
+
+**Cloud project ID:** N/A
+
+## Description
+
+Simple EMA(20)/EMA(50) crossover strategy on five major tech stocks (AAPL, MSFT, GOOGL, AMZN, NVDA). Goes long when the fast EMA crosses above the slow EMA, exits when the fast crosses below. Allocates 20% weight per position (max 5 positions). Uses EUR cash account with Interactive Brokers CASH account type. Checks for crossovers daily at market close.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm Simple-Equity-EMA-Crossing/main.py
+```
+
+### QC Cloud
+Create a new project, upload `main.py`, compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| EMA(20)/EMA(50) crossover | Daily check | Fast EMA 20, slow EMA 50, 20% weight per position |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | EMA crossover algorithm on 5 tech stocks with EUR cash account |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TFT-Crypto-Ranking/README.md
@@ -1,0 +1,40 @@
+# TFT-Crypto-Ranking
+
+**Asset class:** Crypto (BTC-USD, ETH-USD)
+
+**Cloud project ID:** N/A (research-only, no deployable algorithm)
+
+## Description
+
+Research notebook applying the Temporal Fusion Transformer (TFT, Lim et al. 2021) for crypto cross-sectional ranking (BTC vs ETH direction prediction). Uses 26 features (11 BTC-specific + 11 ETH-specific + 4 cross-asset). Architecture includes Variable Selection Network (VSN), Gated Residual Network (GRN), LSTM encoder, and multi-head attention. Walk-forward 5-fold validation across 4 seeds with 10bps transaction costs. DLinear baseline achieved Sharpe 0.742. Verdict: INCONCLUSIVE (z=1.33, insufficient for BEATS threshold).
+
+## How to Run
+
+### Lean CLI
+Not applicable (research-only notebook, no `main.py`).
+
+### QC Cloud
+Not applicable. Run the research notebook locally with Python 3.10+ and PyTorch.
+
+### Local
+```bash
+papermill research.ipynb output.ipynb
+```
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| TFT cross-sectional ranking | N/A (research) | 26 features, VSN+GRN+LSTM+attention, walk-forward 5-fold x 4 seeds, 10bps T-cost |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `research.ipynb` | Research notebook with TFT model for crypto ranking, feature engineering, and walk-forward validation |
+| `_generate_research.py` | Script that generates the research notebook |
+
+## References
+
+- Lim, B. et al. (2021). *Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting*. International Journal of Forecasting.
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/VolTarget-Momentum/README.md
@@ -1,0 +1,36 @@
+# VolTarget-Momentum
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** 30784745
+
+## Description
+
+Rank-based allocation on six risky assets (SPY, EFA, EEM, TLT, GLD, DBC) with BND as a defensive safe harbor. v5 best variant achieved Sharpe 0.65, CAGR 14.72%. Uses SMA200 plus 6-month and 12-month momentum filters for asset selection. Targets 15% annualized volatility using 60-day realized volatility for position sizing, with leverage constrained to 0.3-1.5x. Monthly rebalance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm VolTarget-Momentum/main.py
+```
+
+### QC Cloud
+Open the cloud project (ID: 30784745), compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Rank-based vol targeting + momentum | Monthly | Vol target 15%, 60-day realized vol, leverage 0.3-1.5x, SMA200 + 6m/12m momentum |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Volatility targeting with momentum filters and rank-based allocation on 6 risky + 1 defensive asset |
+| `config.json` | Project configuration (cloud-id, organization-id, language) |
+
+## References
+
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c1-multiasset/README.md
@@ -1,0 +1,40 @@
+# composite-c1-multiasset
+
+**Asset class:** Multi-asset (Equities, Bonds, Commodities)
+
+**Cloud project ID:** N/A
+
+## Description
+
+C4.1 Multi-Asset Rotation Composite (v10) using the Alpha Framework architecture. Trades 5 ETFs (SPY, TLT, GLD, USO, EFA) with 2x leverage. Combines three alpha models: MomentumAlpha (trend-following), MACDAlpha (MACD signal crossover), and RelativeStrengthAlpha (cross-asset relative strength). Portfolio construction via RiskParityPCM (weekly rebalance, 100% max exposure, 40% sector cap). Risk management applies 12% drawdown cap with 4% trailing stop. Execution via VWAP (4 slices, 15-minute window).
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm composite-c1-multiasset/main.py
+```
+
+### QC Cloud
+Create a new project, upload all `.py` files, compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Alpha Framework (3 alphas + RiskParity PCM) | Weekly | Leverage 2x, drawdown cap 12%, trailing stop 4%, VWAP 4-slice execution |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Composite algorithm orchestrating alpha models, PCM, risk management, and execution |
+| `alpha_models.py` | Three alpha models: Momentum, MACD, and Relative Strength |
+| `portfolio_construction.py` | RiskParityPCM with weekly rebalance and sector caps |
+| `risk_management.py` | Drawdown cap (12%) and trailing stop (4%) risk models |
+| `execution.py` | VWAP execution model (4 slices, 15-minute window) |
+
+## References
+
+- [QuantConnect Alpha Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework)
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)

--- a/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/composite-c2-equityfactor/README.md
@@ -1,0 +1,41 @@
+# composite-c2-equityfactor
+
+**Asset class:** Equities (US large-cap, fundamental selection)
+
+**Cloud project ID:** N/A
+
+## Description
+
+C4.2 Equity Factor Composite (v12) using the Alpha Framework with fine fundamental universe selection. Two-stage selection: coarse filter (top 200 by dollar volume) then fine filter (top 25 by market cap). Generates signals from four factor alpha models: Value (P/E, P/B ratios), Quality (ROE, debt-to-equity), LowVolatility (realized volatility), and Momentum (price momentum). Portfolio construction via MeanVariancePCM (weekly rebalance, 65% max exposure, 18% sector cap). Risk management via SectorCapRiskModel (max 10% sector weight, max 0.8 beta). Execution via TWAP (6 slices, 10-minute window). Caches fundamental data for performance.
+
+## How to Run
+
+### Lean CLI
+```bash
+lean backtest --algorithm composite-c2-equityfactor/main.py
+```
+
+### QC Cloud
+Create a new project, upload all `.py` files, compile and run a backtest.
+
+## Backtest Metrics
+
+| Method | Rebalance | Key Parameters |
+|--------|-----------|----------------|
+| Alpha Framework (4 factors + MeanVar PCM) | Weekly | Top 25 by market cap, 65% max exposure, sector cap 18%, TWAP 6-slice |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `main.py` | Composite equity factor algorithm orchestrating universe selection, alphas, PCM, risk, and execution |
+| `alpha_models.py` | Four factor models: Value, Quality, LowVolatility, and Momentum |
+| `portfolio_construction.py` | MeanVariancePCM with weekly rebalance, sector caps, and exposure limits |
+| `risk_management.py` | SectorCapRiskModel with max sector weight and beta constraints |
+| `execution.py` | TWAP execution model (6 slices, 10-minute window) |
+
+## References
+
+- [QuantConnect Alpha Framework](https://www.quantconnect.com/docs/v2/writing-algorithms/algorithm-framework)
+- [QuantConnect Fine Fundamental Selection](https://www.quantconnect.com/docs/v2/writing-algorithms/universes/fundamental)
+- [QuantConnect Documentation](https://www.quantconnect.com/docs/)


### PR DESCRIPTION
## Summary
- Adds structured README.md files for 18 QuantConnect strategy projects that previously had no documentation
- Each README includes: asset class, description, cloud project ID, backtest metrics, files list, and references
- Projects covered: Cloud-* (5), ESGF-* (3), Ensemble-*, GlobalMacro-*, GraphSAGE-*, Mamba-*, Research-Executor, Simple-Equity-*, TFT-*, VolTarget-*, composite-c1/c2

## Details
18 files added, 695 lines total. Format consistent with existing READMEs (e.g., Adaptive-Conformal-Risk, EMA-Cross-Alpha).

This completes the README documentation gap for QC projects (ref #557). All 115+ QC projects now have README.md files.

## Test plan
- [x] All 18 README.md files created and follow consistent format
- [x] Spot-checked ESGF-HAR-RV-Kelly and Research-Executor for accuracy
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)