### PR TITLE
feat(epita-iasy): SW-4b/SW-7b exercices resolus -> exemples guides + nouveaux exercices

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
@@ -5,10 +5,10 @@
    "id": "header-navigation",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T14:24:58.242687+00:00",
+     "duration": 0.00318,
+     "end_time": "2026-05-20T14:33:40.905037+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:58.239688+00:00",
+     "start_time": "2026-05-20T14:33:40.901857+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "section-1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:24:58.249688+00:00",
+     "duration": 0.003003,
+     "end_time": "2026-05-20T14:33:40.912145+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:58.246688+00:00",
+     "start_time": "2026-05-20T14:33:40.909142+00:00",
      "status": "completed"
     },
     "tags": []
@@ -66,16 +66,16 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:58.256688Z",
-     "iopub.status.busy": "2026-05-20T14:24:58.256688Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.505858Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.505858Z"
+     "iopub.execute_input": "2026-05-20T14:33:40.919596Z",
+     "iopub.status.busy": "2026-05-20T14:33:40.919596Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.033736Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.032738Z"
     },
     "papermill": {
-     "duration": 1.254172,
-     "end_time": "2026-05-20T14:24:59.506860+00:00",
+     "duration": 1.118141,
+     "end_time": "2026-05-20T14:33:42.033736+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:58.252688+00:00",
+     "start_time": "2026-05-20T14:33:40.915595+00:00",
      "status": "completed"
     },
     "tags": []
@@ -86,15 +86,6 @@
      "output_type": "stream",
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 23.0.1 -> 26.1.1\n",
-      "[notice] To update, run: C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -107,10 +98,10 @@
    "id": "v2fyj3kyd1h",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-05-20T14:24:59.513859+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:42.040735+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.509858+00:00",
+     "start_time": "2026-05-20T14:33:42.037735+00:00",
      "status": "completed"
     },
     "tags": []
@@ -125,16 +116,16 @@
    "id": "imports-and-load",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.520860Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.520860Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.601208Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.600208Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.050759Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.050241Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.126027Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.125026Z"
     },
     "papermill": {
-     "duration": 0.085347,
-     "end_time": "2026-05-20T14:24:59.602207+00:00",
+     "duration": 0.081291,
+     "end_time": "2026-05-20T14:33:42.126027+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.516860+00:00",
+     "start_time": "2026-05-20T14:33:42.044736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -176,9 +167,9 @@
    "metadata": {
     "papermill": {
      "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.609208+00:00",
+     "end_time": "2026-05-20T14:33:42.133026+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.606208+00:00",
+     "start_time": "2026-05-20T14:33:42.130026+00:00",
      "status": "completed"
     },
     "tags": []
@@ -198,10 +189,10 @@
    "id": "section-2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.615207+00:00",
+     "duration": 0.003001,
+     "end_time": "2026-05-20T14:33:42.140027+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.612207+00:00",
+     "start_time": "2026-05-20T14:33:42.137026+00:00",
      "status": "completed"
     },
     "tags": []
@@ -220,16 +211,16 @@
    "id": "sparql-select",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.622715Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.622715Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.709824Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.709824Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.149026Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.148027Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.281630Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.280628Z"
     },
     "papermill": {
-     "duration": 0.092108,
-     "end_time": "2026-05-20T14:24:59.710823+00:00",
+     "duration": 0.138603,
+     "end_time": "2026-05-20T14:33:42.281630+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.618715+00:00",
+     "start_time": "2026-05-20T14:33:42.143027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -276,10 +267,10 @@
    "id": "sparql-select-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T14:24:59.717821+00:00",
+     "duration": 0.005999,
+     "end_time": "2026-05-20T14:33:42.293147+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.714822+00:00",
+     "start_time": "2026-05-20T14:33:42.287148+00:00",
      "status": "completed"
     },
     "tags": []
@@ -310,10 +301,10 @@
    "id": "section-3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003021,
-     "end_time": "2026-05-20T14:24:59.723844+00:00",
+     "duration": 0.004694,
+     "end_time": "2026-05-20T14:33:42.301471+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.720823+00:00",
+     "start_time": "2026-05-20T14:33:42.296777+00:00",
      "status": "completed"
     },
     "tags": []
@@ -332,16 +323,16 @@
    "id": "sparql-filter",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.731123Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.731123Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.741191Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.741191Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.308816Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.308816Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.327850Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.326850Z"
     },
     "papermill": {
-     "duration": 0.015192,
-     "end_time": "2026-05-20T14:24:59.742192+00:00",
+     "duration": 0.023723,
+     "end_time": "2026-05-20T14:33:42.328851+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.727000+00:00",
+     "start_time": "2026-05-20T14:33:42.305128+00:00",
      "status": "completed"
     },
     "tags": []
@@ -383,10 +374,10 @@
    "id": "filter-explanation",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.748196+00:00",
+     "duration": 0.00363,
+     "end_time": "2026-05-20T14:33:42.336288+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.745196+00:00",
+     "start_time": "2026-05-20T14:33:42.332658+00:00",
      "status": "completed"
     },
     "tags": []
@@ -412,10 +403,10 @@
    "id": "section-4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003139,
-     "end_time": "2026-05-20T14:24:59.754335+00:00",
+     "duration": 0.003526,
+     "end_time": "2026-05-20T14:33:42.343423+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.751196+00:00",
+     "start_time": "2026-05-20T14:33:42.339897+00:00",
      "status": "completed"
     },
     "tags": []
@@ -434,16 +425,16 @@
    "id": "sparql-optional",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.763119Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.763119Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.771905Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.771905Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.351423Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.351423Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.375422Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.374423Z"
     },
     "papermill": {
-     "duration": 0.014064,
-     "end_time": "2026-05-20T14:24:59.772907+00:00",
+     "duration": 0.028999,
+     "end_time": "2026-05-20T14:33:42.375422+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.758843+00:00",
+     "start_time": "2026-05-20T14:33:42.346423+00:00",
      "status": "completed"
     },
     "tags": []
@@ -492,10 +483,10 @@
    "id": "optional-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T14:24:59.779904+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:42.383427+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.776905+00:00",
+     "start_time": "2026-05-20T14:33:42.379426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -519,10 +510,10 @@
    "id": "section-5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003427,
-     "end_time": "2026-05-20T14:24:59.786331+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:42.390426+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.782904+00:00",
+     "start_time": "2026-05-20T14:33:42.387426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -541,16 +532,16 @@
    "id": "sparql-union",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.793841Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.793841Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.801842Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.801842Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.398934Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.398934Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.421637Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.421637Z"
     },
     "papermill": {
-     "duration": 0.012999,
-     "end_time": "2026-05-20T14:24:59.802843+00:00",
+     "duration": 0.027704,
+     "end_time": "2026-05-20T14:33:42.422637+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.789844+00:00",
+     "start_time": "2026-05-20T14:33:42.394933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -599,10 +590,10 @@
    "id": "union-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.808841+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T14:33:42.430636+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.805841+00:00",
+     "start_time": "2026-05-20T14:33:42.426637+00:00",
      "status": "completed"
     },
     "tags": []
@@ -620,10 +611,10 @@
    "id": "section-6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.004004,
-     "end_time": "2026-05-20T14:24:59.815845+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:42.437636+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.811841+00:00",
+     "start_time": "2026-05-20T14:33:42.433636+00:00",
      "status": "completed"
     },
     "tags": []
@@ -642,16 +633,16 @@
    "id": "sparql-class-hierarchy",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.823846Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.822847Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.834011Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.833360Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.445637Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.445637Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.467207Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.466654Z"
     },
     "papermill": {
-     "duration": 0.016171,
-     "end_time": "2026-05-20T14:24:59.835017+00:00",
+     "duration": 0.027608,
+     "end_time": "2026-05-20T14:33:42.468244+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.818846+00:00",
+     "start_time": "2026-05-20T14:33:42.440636+00:00",
      "status": "completed"
     },
     "tags": []
@@ -661,7 +652,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Hierarchie de classes ===\n",
+      "=== Hierarchie de classes ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Classe          Parent         \n",
       "------------------------------\n",
       "Animal          (racine)       \n",
@@ -705,9 +703,9 @@
    "metadata": {
     "papermill": {
      "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.841017+00:00",
+     "end_time": "2026-05-20T14:33:42.475250+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.838017+00:00",
+     "start_time": "2026-05-20T14:33:42.472250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -729,10 +727,10 @@
    "id": "section-7-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002998,
-     "end_time": "2026-05-20T14:24:59.848015+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:42.483250+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.845017+00:00",
+     "start_time": "2026-05-20T14:33:42.479250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -751,16 +749,16 @@
    "id": "sparql-pagination",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.856019Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.855018Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.865123Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.864318Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.491757Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.491757Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.514421Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.513420Z"
     },
     "papermill": {
-     "duration": 0.014626,
-     "end_time": "2026-05-20T14:24:59.865645+00:00",
+     "duration": 0.027665,
+     "end_time": "2026-05-20T14:33:42.514421+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.851019+00:00",
+     "start_time": "2026-05-20T14:33:42.486756+00:00",
      "status": "completed"
     },
     "tags": []
@@ -821,10 +819,10 @@
    "id": "pagination-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.00468,
-     "end_time": "2026-05-20T14:24:59.876081+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:42.522420+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.871401+00:00",
+     "start_time": "2026-05-20T14:33:42.518419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -843,10 +841,10 @@
    "id": "section-8-title",
    "metadata": {
     "papermill": {
-     "duration": 0.004672,
-     "end_time": "2026-05-20T14:24:59.886125+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:42.529420+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.881453+00:00",
+     "start_time": "2026-05-20T14:33:42.525419+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,10 +862,10 @@
    "id": "comparison-table",
    "metadata": {
     "papermill": {
-     "duration": 0.004167,
-     "end_time": "2026-05-20T14:24:59.893415+00:00",
+     "duration": 0.002999,
+     "end_time": "2026-05-20T14:33:42.536420+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.889248+00:00",
+     "start_time": "2026-05-20T14:33:42.533421+00:00",
      "status": "completed"
     },
     "tags": []
@@ -906,10 +904,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.004676,
-     "end_time": "2026-05-20T14:24:59.902289+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:42.543421+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.897613+00:00",
+     "start_time": "2026-05-20T14:33:42.539421+00:00",
      "status": "completed"
     },
     "tags": []
@@ -917,9 +915,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercices\n",
+    "## Exemples guides (issus de contributions etudiantes)\n",
     "\n",
-    "Mettez en pratique les concepts SPARQL appris."
+    "Les exercices ci-dessous ont ete resolus et valides a partir de contributions etudiantes ; ils sont conserves comme **exemples guides** de mise en pratique des concepts SPARQL. De **nouveaux exercices** a completer sont proposes a la fin du notebook."
    ]
   },
   {
@@ -927,20 +925,20 @@
    "id": "exercise-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00421,
-     "end_time": "2026-05-20T14:24:59.912253+00:00",
+     "duration": 0.002999,
+     "end_time": "2026-05-20T14:33:42.550420+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.908043+00:00",
+     "start_time": "2026-05-20T14:33:42.547421+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Trouver les mammiferes\n",
+    "### Exemple guide 1 : Trouver les mammiferes\n",
     "\n",
-    "Ecrivez une requete SPARQL qui retourne tous les animaux qui sont des mammiferes (instances de `ex:Mammal` ou de ses sous-classes `ex:Dog`, `ex:Cat`), avec leur nom et leur age.\n",
+    "Cette requete retourne tous les animaux qui sont des mammiferes (instances de `ex:Mammal` ou de ses sous-classes `ex:Dog`, `ex:Cat`), avec leur nom et leur age.\n",
     "\n",
-    "**Indice** : Utilisez `rdfs:subClassOf` pour remonter la hierarchie, ou listez les classes directement avec `UNION`."
+    "**Approche** : `rdfs:subClassOf*` (chemin de propriete transitif) remonte automatiquement la hierarchie des classes, sans avoir a enumerer chaque sous-classe."
    ]
   },
   {
@@ -949,16 +947,16 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.920074Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.919548Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.941804Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.941088Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.559421Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.558422Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.578424Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.577420Z"
     },
     "papermill": {
-     "duration": 0.027041,
-     "end_time": "2026-05-20T14:24:59.942420+00:00",
+     "duration": 0.024004,
+     "end_time": "2026-05-20T14:33:42.578424+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.915379+00:00",
+     "start_time": "2026-05-20T14:33:42.554420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -975,7 +973,7 @@
     }
    ],
    "source": [
-    "# Exercice 1 : Trouver tous les mammiferes dans animals.ttl\n",
+    "# Exemple guide 1 : trouver tous les mammiferes dans animals.ttl\n",
     "\n",
     "query_mammals = \"\"\"\n",
     "PREFIX ex: <http://example.org/animals#>\n",
@@ -983,8 +981,7 @@
     "\n",
     "SELECT ?name ?age ?type_label\n",
     "WHERE {\n",
-    "    # TODO: Completez la requete\n",
-    "    # Trouvez les animaux dont le type est une sous-classe de ex:Mammal\n",
+    "    # Type de l'animal = sous-classe (transitive) de ex:Mammal via rdfs:subClassOf*\n",
     "    ?animal a ?type .\n",
     "    ?type rdfs:subClassOf* ex:Mammal .\n",
     "    ?type rdfs:label ?type_label .\n",
@@ -1003,20 +1000,20 @@
    "id": "exercise-2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003863,
-     "end_time": "2026-05-20T14:24:59.949991+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:42.586424+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.946128+00:00",
+     "start_time": "2026-05-20T14:33:42.582424+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Animaux sans age defini\n",
+    "### Exemple guide 2 : Animaux sans age defini\n",
     "\n",
-    "Ecrivez une requete qui trouve tous les animaux qui n'ont PAS de propriete `ex:age` definie.\n",
+    "Cette requete trouve tous les animaux qui n'ont PAS de propriete `ex:age` definie.\n",
     "\n",
-    "**Indice** : Utilisez `FILTER (!BOUND(?age))` ou le negatif pattern `MINUS`."
+    "**Approche** : `FILTER NOT EXISTS { ... }` elimine les solutions pour lesquelles le motif existe. Le code gere aussi le cas ou tous les animaux ont un age (resultat vide) avec un message explicite."
    ]
   },
   {
@@ -1025,16 +1022,16 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.958222Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.958222Z",
-     "iopub.status.idle": "2026-05-20T14:24:59.973019Z",
-     "shell.execute_reply": "2026-05-20T14:24:59.972230Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.594930Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.594930Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.609932Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.608930Z"
     },
     "papermill": {
-     "duration": 0.018857,
-     "end_time": "2026-05-20T14:24:59.973019+00:00",
+     "duration": 0.019509,
+     "end_time": "2026-05-20T14:33:42.609932+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.954162+00:00",
+     "start_time": "2026-05-20T14:33:42.590423+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1049,15 +1046,14 @@
     }
    ],
    "source": [
-    "# Exercice 2 : Animaux sans age defini\n",
+    "# Exemple guide 2 : animaux sans age defini\n",
     "\n",
     "query_no_age = \"\"\"\n",
     "PREFIX ex: <http://example.org/animals#>\n",
     "\n",
     "SELECT ?name\n",
     "WHERE {\n",
-    "    # TODO: Completez la requete\n",
-    "    # Trouvez les animaux sans age\n",
+    "    # On garde les animaux pour lesquels aucun triplet ex:age n'existe\n",
     "    ?animal ex:name ?name .\n",
     "    FILTER NOT EXISTS { ?animal ex:age ?age . }\n",
     "}\n",
@@ -1076,10 +1072,10 @@
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:24:59.980028+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T14:33:42.617930+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.977028+00:00",
+     "start_time": "2026-05-20T14:33:42.613931+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1118,10 +1114,10 @@
    "id": "e797dcac",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-05-20T14:24:59.987030+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T14:33:42.625931+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.983029+00:00",
+     "start_time": "2026-05-20T14:33:42.621932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1129,18 +1125,13 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice de synthese : Requetes SPARQL avancees\n",
+    "## Exemple guide de synthese : Requetes SPARQL avancees\n",
     "\n",
-    "Ecrivez des requetes SPARQL plus complexes sur le graphe `animals.ttl` ou sur un graphe de votre creation.\n",
+    "Combinaison de plusieurs fonctionnalites SPARQL sur le graphe `animals.ttl`.\n",
     "\n",
-    "### Partie A : CONSTRUCT\n",
-    "Ecrire une requete `CONSTRUCT` qui genere un nouveau graphe RDF listant uniquement les noms et especes des mammiferes.\n",
+    "**Partie A - CONSTRUCT** : genere un nouveau graphe RDF ne contenant que les mammiferes.\n",
     "\n",
-    "### Partie B : Aggregations\n",
-    "Ecrire une requete avec `GROUP BY` et `COUNT` pour compter le nombre d'animaux par type (`ex:type`).\n",
-    "\n",
-    "### Partie C (bonus) : Graphe personnel\n",
-    "Creer votre propre graphe RDF (domaine libre) et ecrire au moins 2 requetes SELECT + 1 requete CONSTRUCT dessus."
+    "**Partie B - Agregation** : `GROUP BY` + `COUNT` pour compter le nombre d'animaux par type."
    ]
   },
   {
@@ -1149,16 +1140,16 @@
    "id": "b3aa731c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:24:59.995534Z",
-     "iopub.status.busy": "2026-05-20T14:24:59.995534Z",
-     "iopub.status.idle": "2026-05-20T14:25:00.020085Z",
-     "shell.execute_reply": "2026-05-20T14:25:00.019083Z"
+     "iopub.execute_input": "2026-05-20T14:33:42.634930Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.633931Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.656931Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.655931Z"
     },
     "papermill": {
-     "duration": 0.029549,
-     "end_time": "2026-05-20T14:25:00.020085+00:00",
+     "duration": 0.027999,
+     "end_time": "2026-05-20T14:33:42.657931+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:24:59.990536+00:00",
+     "start_time": "2026-05-20T14:33:42.629932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1168,13 +1159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Partie A : CONSTRUCT (mammiferes uniquement) ===\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "=== Partie A : CONSTRUCT (mammiferes uniquement) ===\n",
       "@prefix ns1: <http://example.org/animals#> .\n",
       "\n",
       "ns1:buddy a ns1:Dog ;\n",
@@ -1195,7 +1180,7 @@
     }
    ],
    "source": [
-    "# TODO etudiant : requetes SPARQL avancees\n",
+    "# Exemple guide de synthese : requetes SPARQL avancees (CONSTRUCT + agregation)\n",
     "from rdflib import Graph\n",
     "\n",
     "# Charger le graphe data/animals.ttl\n",
@@ -1240,6 +1225,143 @@
     "for row in g_animals.query(group_query):\n",
     "    print(f\"  {row.type_label} : {row.nb}\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc7cbffb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003999,
+     "end_time": "2026-05-20T14:33:42.665931+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:42.661932+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout meme si les exercices ne sont pas encore completes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91348198",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-05-20T14:33:42.673935+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:42.669931+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Requete ASK\n",
+    "\n",
+    "Ecrivez une requete SPARQL `ASK` qui renvoie `True` s'il existe au moins un animal de plus de 4 ans dans `animals.ttl`, `False` sinon.\n",
+    "\n",
+    "**Indice** : remplacez `SELECT` par `ASK`, et utilisez `FILTER(?age > 4)`. Le resultat booleen se lit via `bool(g.query(votre_requete).askAnswer)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "94d90ffa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T14:33:42.682936Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.681935Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.688030Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.687444Z"
+    },
+    "papermill": {
+     "duration": 0.011102,
+     "end_time": "2026-05-20T14:33:42.689036+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:42.677934+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : requete ASK - existe-t-il un animal de plus de 4 ans ?\n",
+    "# TODO etudiant : ecrire une requete ASK avec FILTER(?age > 4)\n",
+    "# Indice : le resultat booleen se lit via bool(g.query(votre_requete).askAnswer)\n",
+    "\n",
+    "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8c64bf7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:42.698034+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:42.694033+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Description textuelle avec BIND et CONCAT\n",
+    "\n",
+    "Pour chaque animal, produisez une chaine de caracteres du type `\"Rex fait Woof\"` en combinant son nom (`ex:name`) et son cri (`ex:sound`).\n",
+    "\n",
+    "**Indice** : utilisez `BIND(CONCAT(?name, \" fait \", ?sound) AS ?description)` dans le `WHERE`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "db8263f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T14:33:42.709036Z",
+     "iopub.status.busy": "2026-05-20T14:33:42.708035Z",
+     "iopub.status.idle": "2026-05-20T14:33:42.720040Z",
+     "shell.execute_reply": "2026-05-20T14:33:42.719035Z"
+    },
+    "papermill": {
+     "duration": 0.019002,
+     "end_time": "2026-05-20T14:33:42.721035+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:42.702033+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : description textuelle avec BIND / CONCAT\n",
+    "# TODO etudiant : produire ?description = CONCAT(?name, \" fait \", ?sound)\n",
+    "# Indice : ?animal ex:name ?name ; ex:sound ?sound . puis BIND(...)\n",
+    "\n",
+    "print(\"Exercice a completer\")\n"
+   ]
   }
  ],
  "metadata": {
@@ -1258,18 +1380,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.276785,
-   "end_time": "2026-05-20T14:25:00.270172+00:00",
+   "duration": 3.147613,
+   "end_time": "2026-05-20T14:33:42.954884+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "SW-4b-Python-SPARQL.ipynb",
    "output_path": "SW-4b-Python-SPARQL.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T14:24:56.993387+00:00",
+   "start_time": "2026-05-20T14:33:39.807271+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -5,10 +5,10 @@
    "id": "header-navigation",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-05-20T14:22:46.870015+00:00",
+     "duration": 0.004655,
+     "end_time": "2026-05-20T14:33:45.552735+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:46.866016+00:00",
+     "start_time": "2026-05-20T14:33:45.548080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "section-1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-05-20T14:22:46.877119+00:00",
+     "duration": 0.00311,
+     "end_time": "2026-05-20T14:33:45.559984+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:46.873120+00:00",
+     "start_time": "2026-05-20T14:33:45.556874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +67,16 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:46.885746Z",
-     "iopub.status.busy": "2026-05-20T14:22:46.885746Z",
-     "iopub.status.idle": "2026-05-20T14:22:48.204997Z",
-     "shell.execute_reply": "2026-05-20T14:22:48.203996Z"
+     "iopub.execute_input": "2026-05-20T14:33:45.569951Z",
+     "iopub.status.busy": "2026-05-20T14:33:45.569951Z",
+     "iopub.status.idle": "2026-05-20T14:33:46.639523Z",
+     "shell.execute_reply": "2026-05-20T14:33:46.639523Z"
     },
     "papermill": {
-     "duration": 1.324876,
-     "end_time": "2026-05-20T14:22:48.204997+00:00",
+     "duration": 1.076831,
+     "end_time": "2026-05-20T14:33:46.640526+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:46.880121+00:00",
+     "start_time": "2026-05-20T14:33:45.563695+00:00",
      "status": "completed"
     },
     "tags": []
@@ -87,15 +87,6 @@
      "output_type": "stream",
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "[notice] A new release of pip is available: 23.0.1 -> 26.1.1\n",
-      "[notice] To update, run: C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -108,10 +99,10 @@
    "id": "zyf8e47gkb",
    "metadata": {
     "papermill": {
-     "duration": 0.00301,
-     "end_time": "2026-05-20T14:22:48.212028+00:00",
+     "duration": 0.003005,
+     "end_time": "2026-05-20T14:33:46.647531+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.209018+00:00",
+     "start_time": "2026-05-20T14:33:46.644526+00:00",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +117,16 @@
    "id": "imports-owlready2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:48.219020Z",
-     "iopub.status.busy": "2026-05-20T14:22:48.219020Z",
-     "iopub.status.idle": "2026-05-20T14:22:48.252119Z",
-     "shell.execute_reply": "2026-05-20T14:22:48.251019Z"
+     "iopub.execute_input": "2026-05-20T14:33:46.654527Z",
+     "iopub.status.busy": "2026-05-20T14:33:46.653526Z",
+     "iopub.status.idle": "2026-05-20T14:33:46.687088Z",
+     "shell.execute_reply": "2026-05-20T14:33:46.687088Z"
     },
     "papermill": {
-     "duration": 0.037742,
-     "end_time": "2026-05-20T14:22:48.252760+00:00",
+     "duration": 0.037557,
+     "end_time": "2026-05-20T14:33:46.688082+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.215018+00:00",
+     "start_time": "2026-05-20T14:33:46.650525+00:00",
      "status": "completed"
     },
     "tags": []
@@ -164,10 +155,10 @@
    "id": "section-2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003186,
-     "end_time": "2026-05-20T14:22:48.259441+00:00",
+     "duration": 0.003002,
+     "end_time": "2026-05-20T14:33:46.694585+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.256255+00:00",
+     "start_time": "2026-05-20T14:33:46.691583+00:00",
      "status": "completed"
     },
     "tags": []
@@ -186,16 +177,16 @@
    "id": "create-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:48.267147Z",
-     "iopub.status.busy": "2026-05-20T14:22:48.267147Z",
-     "iopub.status.idle": "2026-05-20T14:22:48.282247Z",
-     "shell.execute_reply": "2026-05-20T14:22:48.281651Z"
+     "iopub.execute_input": "2026-05-20T14:33:46.701587Z",
+     "iopub.status.busy": "2026-05-20T14:33:46.701587Z",
+     "iopub.status.idle": "2026-05-20T14:33:46.717933Z",
+     "shell.execute_reply": "2026-05-20T14:33:46.717933Z"
     },
     "papermill": {
-     "duration": 0.02061,
-     "end_time": "2026-05-20T14:22:48.283251+00:00",
+     "duration": 0.020347,
+     "end_time": "2026-05-20T14:33:46.718934+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.262641+00:00",
+     "start_time": "2026-05-20T14:33:46.698587+00:00",
      "status": "completed"
     },
     "tags": []
@@ -268,10 +259,10 @@
    "id": "create-ontology-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-05-20T14:22:48.292251+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:46.724934+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.287251+00:00",
+     "start_time": "2026-05-20T14:33:46.721934+00:00",
      "status": "completed"
     },
     "tags": []
@@ -299,10 +290,10 @@
    "id": "section-3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-05-20T14:22:48.299250+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:46.730933+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.295250+00:00",
+     "start_time": "2026-05-20T14:33:46.727933+00:00",
      "status": "completed"
     },
     "tags": []
@@ -321,16 +312,16 @@
    "id": "create-individuals",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:48.308551Z",
-     "iopub.status.busy": "2026-05-20T14:22:48.308551Z",
-     "iopub.status.idle": "2026-05-20T14:22:48.313262Z",
-     "shell.execute_reply": "2026-05-20T14:22:48.312704Z"
+     "iopub.execute_input": "2026-05-20T14:33:46.738936Z",
+     "iopub.status.busy": "2026-05-20T14:33:46.738936Z",
+     "iopub.status.idle": "2026-05-20T14:33:46.748703Z",
+     "shell.execute_reply": "2026-05-20T14:33:46.748703Z"
     },
     "papermill": {
-     "duration": 0.011459,
-     "end_time": "2026-05-20T14:22:48.314267+00:00",
+     "duration": 0.01477,
+     "end_time": "2026-05-20T14:33:46.749706+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.302808+00:00",
+     "start_time": "2026-05-20T14:33:46.734936+00:00",
      "status": "completed"
     },
     "tags": []
@@ -382,10 +373,10 @@
    "id": "individuals-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-05-20T14:22:48.321266+00:00",
+     "duration": 0.004002,
+     "end_time": "2026-05-20T14:33:46.756706+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.317265+00:00",
+     "start_time": "2026-05-20T14:33:46.752704+00:00",
      "status": "completed"
     },
     "tags": []
@@ -410,10 +401,10 @@
    "id": "section-4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003997,
-     "end_time": "2026-05-20T14:22:48.329270+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:46.762704+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.325273+00:00",
+     "start_time": "2026-05-20T14:33:46.759704+00:00",
      "status": "completed"
     },
     "tags": []
@@ -432,16 +423,16 @@
    "id": "restrictions",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:48.343270Z",
-     "iopub.status.busy": "2026-05-20T14:22:48.343270Z",
-     "iopub.status.idle": "2026-05-20T14:22:48.360247Z",
-     "shell.execute_reply": "2026-05-20T14:22:48.360247Z"
+     "iopub.execute_input": "2026-05-20T14:33:46.770707Z",
+     "iopub.status.busy": "2026-05-20T14:33:46.769706Z",
+     "iopub.status.idle": "2026-05-20T14:33:46.780590Z",
+     "shell.execute_reply": "2026-05-20T14:33:46.780590Z"
     },
     "papermill": {
-     "duration": 0.024976,
-     "end_time": "2026-05-20T14:22:48.361247+00:00",
+     "duration": 0.015886,
+     "end_time": "2026-05-20T14:33:46.781591+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.336271+00:00",
+     "start_time": "2026-05-20T14:33:46.765705+00:00",
      "status": "completed"
     },
     "tags": []
@@ -502,10 +493,10 @@
    "id": "restrictions-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-05-20T14:22:48.369246+00:00",
+     "duration": 0.003013,
+     "end_time": "2026-05-20T14:33:46.787611+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.365247+00:00",
+     "start_time": "2026-05-20T14:33:46.784598+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,10 +520,10 @@
    "id": "section-5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-05-20T14:22:48.375247+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:46.794603+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.372246+00:00",
+     "start_time": "2026-05-20T14:33:46.791603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -551,16 +542,16 @@
    "id": "reasoning",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:48.383248Z",
-     "iopub.status.busy": "2026-05-20T14:22:48.383248Z",
-     "iopub.status.idle": "2026-05-20T14:22:49.319258Z",
-     "shell.execute_reply": "2026-05-20T14:22:49.319258Z"
+     "iopub.execute_input": "2026-05-20T14:33:46.802110Z",
+     "iopub.status.busy": "2026-05-20T14:33:46.801108Z",
+     "iopub.status.idle": "2026-05-20T14:33:47.715092Z",
+     "shell.execute_reply": "2026-05-20T14:33:47.714092Z"
     },
     "papermill": {
-     "duration": 0.942011,
-     "end_time": "2026-05-20T14:22:49.320259+00:00",
+     "duration": 0.917488,
+     "end_time": "2026-05-20T14:33:47.715092+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:48.378248+00:00",
+     "start_time": "2026-05-20T14:33:46.797604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -570,7 +561,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Avant raisonnement ===\n",
+      "=== Avant raisonnement ==="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Bob types : [company.Person]\n",
       "Alice types : [company.Person]\n",
       "Charlie types : [company.Person]\n",
@@ -582,7 +580,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpudnwld7q\n"
+      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpgv66hz46\n"
      ]
     },
     {
@@ -592,7 +590,7 @@
       "=== Apres raisonnement (HermiT) ===\n",
       "Bob types : [company.Employee]\n",
       "Alice types : [company.Employee]\n",
-      "Charlie types : [company.Manager, company.Employee]\n",
+      "Charlie types : [company.Employee, company.Manager]\n",
       "\n",
       "Deductions :\n",
       "  Bob est Employee (car works_in SOME Department)\n",
@@ -604,9 +602,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.8182399272918701 seconds\n",
+      "* Owlready2 * HermiT took 0.7952301502227783 seconds\n",
       "* Owlready * Reparenting company.Bob: {company.Person} => {company.Employee}\n",
-      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Manager, company.Employee}\n",
+      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Employee, company.Manager}\n",
       "* Owlready * Reparenting company.Alice: {company.Person} => {company.Employee}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
@@ -673,10 +671,10 @@
    "id": "reasoning-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-05-20T14:22:49.327260+00:00",
+     "duration": 0.003008,
+     "end_time": "2026-05-20T14:33:47.722100+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.323258+00:00",
+     "start_time": "2026-05-20T14:33:47.719092+00:00",
      "status": "completed"
     },
     "tags": []
@@ -703,10 +701,10 @@
    "id": "section-6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002,
-     "end_time": "2026-05-20T14:22:49.332262+00:00",
+     "duration": 0.002993,
+     "end_time": "2026-05-20T14:33:47.729093+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.330262+00:00",
+     "start_time": "2026-05-20T14:33:47.726100+00:00",
      "status": "completed"
     },
     "tags": []
@@ -725,16 +723,16 @@
    "id": "load-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:49.340765Z",
-     "iopub.status.busy": "2026-05-20T14:22:49.339756Z",
-     "iopub.status.idle": "2026-05-20T14:22:49.350076Z",
-     "shell.execute_reply": "2026-05-20T14:22:49.350076Z"
+     "iopub.execute_input": "2026-05-20T14:33:47.738536Z",
+     "iopub.status.busy": "2026-05-20T14:33:47.738020Z",
+     "iopub.status.idle": "2026-05-20T14:33:47.760116Z",
+     "shell.execute_reply": "2026-05-20T14:33:47.760116Z"
     },
     "papermill": {
-     "duration": 0.015092,
-     "end_time": "2026-05-20T14:22:49.350851+00:00",
+     "duration": 0.028019,
+     "end_time": "2026-05-20T14:33:47.761115+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.335759+00:00",
+     "start_time": "2026-05-20T14:33:47.733096+00:00",
      "status": "completed"
     },
     "tags": []
@@ -793,10 +791,10 @@
    "id": "section-7-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-05-20T14:22:49.356856+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-05-20T14:33:47.769115+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.353854+00:00",
+     "start_time": "2026-05-20T14:33:47.765116+00:00",
      "status": "completed"
     },
     "tags": []
@@ -815,16 +813,16 @@
    "id": "export-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:49.364935Z",
-     "iopub.status.busy": "2026-05-20T14:22:49.364935Z",
-     "iopub.status.idle": "2026-05-20T14:22:49.397949Z",
-     "shell.execute_reply": "2026-05-20T14:22:49.396955Z"
+     "iopub.execute_input": "2026-05-20T14:33:47.777116Z",
+     "iopub.status.busy": "2026-05-20T14:33:47.777116Z",
+     "iopub.status.idle": "2026-05-20T14:33:47.793120Z",
+     "shell.execute_reply": "2026-05-20T14:33:47.792120Z"
     },
     "papermill": {
-     "duration": 0.037459,
-     "end_time": "2026-05-20T14:22:49.397949+00:00",
+     "duration": 0.021005,
+     "end_time": "2026-05-20T14:33:47.793120+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.360490+00:00",
+     "start_time": "2026-05-20T14:33:47.772115+00:00",
      "status": "completed"
     },
     "tags": []
@@ -887,10 +885,10 @@
    "id": "section-8-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-05-20T14:22:49.404948+00:00",
+     "duration": 0.003998,
+     "end_time": "2026-05-20T14:33:47.801119+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.400949+00:00",
+     "start_time": "2026-05-20T14:33:47.797121+00:00",
      "status": "completed"
     },
     "tags": []
@@ -908,10 +906,10 @@
    "id": "comparison-table",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:22:49.410956+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:47.808134+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.407956+00:00",
+     "start_time": "2026-05-20T14:33:47.804133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -949,10 +947,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003009,
-     "end_time": "2026-05-20T14:22:49.416958+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-20T14:33:47.814870+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.413949+00:00",
+     "start_time": "2026-05-20T14:33:47.811870+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,9 +958,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercices\n",
+    "## Exemples guides (issus de contributions etudiantes)\n",
     "\n",
-    "Mettez en pratique les concepts OWL avec ces deux exercices."
+    "Les exercices ci-dessous ont ete resolus et valides a partir de contributions etudiantes ; ils sont conserves comme **exemples guides** d'utilisation d'OWL et du raisonneur HermiT. De **nouveaux exercices** a completer sont proposes a la fin du notebook."
    ]
   },
   {
@@ -970,23 +968,23 @@
    "id": "exercise-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T14:22:49.422956+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-05-20T14:33:47.822872+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.419957+00:00",
+     "start_time": "2026-05-20T14:33:47.818871+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Famille avec restrictions\n",
+    "### Exemple guide 1 : Famille avec restrictions\n",
     "\n",
-    "Crez une ontologie de famille avec :\n",
+    "Ontologie de famille :\n",
     "- Classes : `Person`, `Parent`, `Child`\n",
     "- Propriete : `has_child` (inverse : `has_parent`)\n",
-    "- Restrictions : `Parent` = Person qui `has_child` SOME Person\n",
+    "- Restrictions : `Parent` = Person qui `has_child` SOME Person ; `Child` = Person qui `has_parent` SOME Person\n",
     "\n",
-    "Crez des individus et verifiez que le raisonneur deduit correctement les types."
+    "**Resultat** : apres `sync_reasoner`, HermiT reclasse Pierre et Marie en `Parent`, et Lucie en `Child`."
    ]
   },
   {
@@ -995,16 +993,16 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:49.431012Z",
-     "iopub.status.busy": "2026-05-20T14:22:49.431012Z",
-     "iopub.status.idle": "2026-05-20T14:22:50.001891Z",
-     "shell.execute_reply": "2026-05-20T14:22:50.001891Z"
+     "iopub.execute_input": "2026-05-20T14:33:47.830872Z",
+     "iopub.status.busy": "2026-05-20T14:33:47.830872Z",
+     "iopub.status.idle": "2026-05-20T14:33:48.429832Z",
+     "shell.execute_reply": "2026-05-20T14:33:48.428831Z"
     },
     "papermill": {
-     "duration": 0.575944,
-     "end_time": "2026-05-20T14:22:50.002893+00:00",
+     "duration": 0.603961,
+     "end_time": "2026-05-20T14:33:48.429832+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:49.426949+00:00",
+     "start_time": "2026-05-20T14:33:47.825871+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1015,7 +1013,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpsy8a3e6g -Y\n"
+      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpe_avyx7d -Y\n"
      ]
     },
     {
@@ -1043,7 +1041,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.549375057220459 seconds\n",
+      "* Owlready2 * HermiT took 0.5754704475402832 seconds\n",
       "* Owlready * Reparenting family2.Lucie: {family2.Person} => {family2.Child}\n",
       "* Owlready * Reparenting family2.Pierre: {family2.Person} => {family2.Parent}\n",
       "* Owlready * Reparenting family2.Marie: {family2.Person} => {family2.Parent}\n",
@@ -1052,8 +1050,8 @@
     }
    ],
    "source": [
-    "# Exercice 1 : Famille avec restrictions\n",
-    "# TODO: Completez l'ontologie\n",
+    "# Exemple guide 1 : famille avec restrictions OWL\n",
+    "# Parent et Child sont definis par equivalent_to ; HermiT reclasse les individus\n",
     "from owlready2 import World\n",
     "\n",
     "world_family = World()\n",
@@ -1108,23 +1106,23 @@
    "id": "exercise-2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-05-20T14:22:50.008893+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:48.437839+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:50.005892+00:00",
+     "start_time": "2026-05-20T14:33:48.433839+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Graphe de connaissances de films\n",
+    "### Exemple guide 2 : Graphe de connaissances de films\n",
     "\n",
-    "Crez une ontologie pour des films :\n",
+    "Ontologie de films :\n",
     "- Classes : `Movie`, `Person` (acteur/realisateur), `Genre`\n",
     "- Proprietes : `has_actor`, `has_director`, `has_genre`\n",
-    "- Restrictions : `ActionMovie` = Movie qui `has_genre` SOME Action\n",
+    "- Restriction : `ActionMovie` = Movie qui `has_genre` SOME Action\n",
     "\n",
-    "Crez un exemple et verifiez le raisonnement."
+    "**Resultat** : apres raisonnement, `DarkKnight` est classe `ActionMovie`."
    ]
   },
   {
@@ -1133,16 +1131,16 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:50.016894Z",
-     "iopub.status.busy": "2026-05-20T14:22:50.016894Z",
-     "iopub.status.idle": "2026-05-20T14:22:50.576527Z",
-     "shell.execute_reply": "2026-05-20T14:22:50.576527Z"
+     "iopub.execute_input": "2026-05-20T14:33:48.446550Z",
+     "iopub.status.busy": "2026-05-20T14:33:48.446550Z",
+     "iopub.status.idle": "2026-05-20T14:33:49.013307Z",
+     "shell.execute_reply": "2026-05-20T14:33:49.012297Z"
     },
     "papermill": {
-     "duration": 0.564638,
-     "end_time": "2026-05-20T14:22:50.577533+00:00",
+     "duration": 0.572764,
+     "end_time": "2026-05-20T14:33:49.014311+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:50.012895+00:00",
+     "start_time": "2026-05-20T14:33:48.441547+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1153,7 +1151,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmp1gfu86sr\n"
+      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpnqa8d5ef\n"
      ]
     },
     {
@@ -1179,15 +1177,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.5506486892700195 seconds\n",
+      "* Owlready2 * HermiT took 0.5442514419555664 seconds\n",
       "* Owlready * Reparenting movies.DarkKnight: {movies.Movie} => {movies.ActionMovie}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : Ontologie de films\n",
-    "# TODO: Completez l'ontologie\n",
+    "# Exemple guide 2 : ontologie de films\n",
+    "# ActionMovie = Movie & has_genre.some(Action) ; HermiT classe DarkKnight\n",
     "world_movies = World()\n",
     "onto_movies = world_movies.get_ontology(\"http://example.org/movies.owl#\")\n",
     "\n",
@@ -1257,10 +1255,10 @@
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.00284,
-     "end_time": "2026-05-20T14:22:50.583859+00:00",
+     "duration": 0.004,
+     "end_time": "2026-05-20T14:33:49.021613+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:50.581019+00:00",
+     "start_time": "2026-05-20T14:33:49.017613+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1298,10 +1296,10 @@
    "id": "3b081608",
    "metadata": {
     "papermill": {
-     "duration": 0.003068,
-     "end_time": "2026-05-20T14:22:50.591249+00:00",
+     "duration": 0.005,
+     "end_time": "2026-05-20T14:33:49.030614+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:50.588181+00:00",
+     "start_time": "2026-05-20T14:33:49.025614+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1309,21 +1307,13 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice de synthese : Ontologie avec raisonnement\n",
+    "## Exemple guide de synthese : Ontologie avec raisonnement\n",
     "\n",
-    "Creez une ontologie OWL pour un domaine de votre choix et utilisez le raisonneur HermiT (ou Pellet) pour deriver de nouvelles connaissances.\n",
+    "Ontologie d'ecosysteme construite avec `owlready2`, raisonnee avec HermiT.\n",
     "\n",
-    "### Contraintes\n",
-    "- Au moins **3 classes** avec hierarchie (`SubClassOf`)\n",
-    "- Au moins **1 restriction** (`some`, `only`, ou `min/max`)\n",
-    "- Au moins **3 instances** dont une dont le type est derive par inference\n",
-    "\n",
-    "### Etapes\n",
-    "1. Definir l'ontologie avec `owlready2`\n",
-    "2. Ajouter des classes, proprietes et instances\n",
-    "3. Lancer le raisonneur avec `sync_reasoner_pellet()` ou `sync_reasoner()`\n",
-    "4. Afficher les types infers des instances\n",
-    "5. (Bonus) Exporter l'ontologie au format OWL/XML"
+    "- 3 classes avec hierarchie : `Animal`, `Mammifere`, `Carnivore`\n",
+    "- 1 restriction : `Carnivore` = Animal qui `has_prey` SOME Animal\n",
+    "- Instances dont le type est derive par inference (Renard, Loup -> Carnivore)"
    ]
   },
   {
@@ -1332,16 +1322,16 @@
    "id": "89008950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:22:50.600165Z",
-     "iopub.status.busy": "2026-05-20T14:22:50.599644Z",
-     "iopub.status.idle": "2026-05-20T14:22:51.156035Z",
-     "shell.execute_reply": "2026-05-20T14:22:51.155368Z"
+     "iopub.execute_input": "2026-05-20T14:33:49.039614Z",
+     "iopub.status.busy": "2026-05-20T14:33:49.039614Z",
+     "iopub.status.idle": "2026-05-20T14:33:49.632669Z",
+     "shell.execute_reply": "2026-05-20T14:33:49.631880Z"
     },
     "papermill": {
-     "duration": 0.561102,
-     "end_time": "2026-05-20T14:22:51.156035+00:00",
+     "duration": 0.598574,
+     "end_time": "2026-05-20T14:33:49.633187+00:00",
      "exception": false,
-     "start_time": "2026-05-20T14:22:50.594933+00:00",
+     "start_time": "2026-05-20T14:33:49.034613+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1352,7 +1342,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpu8xek3db\n"
+      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpnv0waq2w\n"
      ]
     },
     {
@@ -1384,15 +1374,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.5328564643859863 seconds\n",
-      "* Owlready * Reparenting ecosystem.Loup: {ecosystem.Mammifere} => {ecosystem.Mammifere, ecosystem.Carnivore}\n",
-      "* Owlready * Reparenting ecosystem.Renard: {ecosystem.Mammifere} => {ecosystem.Mammifere, ecosystem.Carnivore}\n",
+      "* Owlready2 * HermiT took 0.5675661563873291 seconds\n",
+      "* Owlready * Reparenting ecosystem.Loup: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
+      "* Owlready * Reparenting ecosystem.Renard: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
    "source": [
-    "# TODO etudiant : ontologie avec raisonnement (owlready2)\n",
+    "# Exemple guide de synthese : ontologie d'ecosysteme avec raisonnement\n",
+    "# Carnivore = Animal & has_prey.some(Animal) ; HermiT classe Renard et Loup\n",
     "from owlready2 import get_ontology, Thing, ObjectProperty, sync_reasoner, World\n",
     "\n",
     "# Etape 1 : creer l'ontologie avec get_ontology\n",
@@ -1442,6 +1433,148 @@
     "print()\n",
     "print(\"Ontologie exportee : data/temp_ecosystem.owl\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f1d994",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005001,
+     "end_time": "2026-05-20T14:33:49.641739+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:49.636738+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## Exercices\n",
+    "\n",
+    "A votre tour. Completez les exercices ci-dessous (les solutions ne sont pas fournies). Le notebook doit pouvoir s'executer de bout en bout meme si les exercices ne sont pas encore completes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cd240c4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005002,
+     "end_time": "2026-05-20T14:33:49.649744+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:49.644742+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Vehicules electriques (equivalent_to + raisonnement)\n",
+    "\n",
+    "Construisez une ontologie de vehicules :\n",
+    "- Classes : `Vehicle`, `Battery`, `ElectricVehicle`\n",
+    "- Propriete : `has_battery`\n",
+    "- Restriction : `ElectricVehicle` = Vehicle qui `has_battery` SOME Battery\n",
+    "\n",
+    "Creez un vehicule muni d'une batterie, lancez le raisonneur et verifiez qu'il est classe `ElectricVehicle`.\n",
+    "\n",
+    "**Indice** : sur le modele de l'exemple guide 1, utilisez `equivalent_to = [Vehicle & has_battery.some(Battery)]` puis `sync_reasoner`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "115f4e6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T14:33:49.658249Z",
+     "iopub.status.busy": "2026-05-20T14:33:49.658249Z",
+     "iopub.status.idle": "2026-05-20T14:33:49.663755Z",
+     "shell.execute_reply": "2026-05-20T14:33:49.663755Z"
+    },
+    "papermill": {
+     "duration": 0.012014,
+     "end_time": "2026-05-20T14:33:49.664756+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:49.652742+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : vehicules electriques (equivalent_to + raisonnement)\n",
+    "# TODO etudiant : definir Vehicle, Battery, ElectricVehicle = Vehicle & has_battery.some(Battery)\n",
+    "# Indice : creer un World(), une ontologie, puis sync_reasoner et verifier is_a\n",
+    "\n",
+    "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f322477f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005,
+     "end_time": "2026-05-20T14:33:49.673756+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:49.668756+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Classes disjointes\n",
+    "\n",
+    "Dans une ontologie d'animaux, declarez que `Herbivore` et `Carnivore` sont **disjointes** (`AllDisjoint`). Creez un individu, puis observez le comportement du raisonneur (il ne doit pas inferer qu'un meme individu est a la fois Herbivore et Carnivore).\n",
+    "\n",
+    "**Indice** : utilisez `AllDisjoint([Herbivore, Carnivore])` a l'interieur du bloc `with onto:`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c8c823ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-20T14:33:49.683758Z",
+     "iopub.status.busy": "2026-05-20T14:33:49.682760Z",
+     "iopub.status.idle": "2026-05-20T14:33:49.695761Z",
+     "shell.execute_reply": "2026-05-20T14:33:49.695761Z"
+    },
+    "papermill": {
+     "duration": 0.019508,
+     "end_time": "2026-05-20T14:33:49.697265+00:00",
+     "exception": false,
+     "start_time": "2026-05-20T14:33:49.677757+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : classes disjointes (AllDisjoint)\n",
+    "# TODO etudiant : declarer Herbivore et Carnivore disjointes via AllDisjoint([...])\n",
+    "# Indice : a placer dans le bloc with onto: , puis creer un individu et raisonner\n",
+    "\n",
+    "print(\"Exercice a completer\")\n"
+   ]
   }
  ],
  "metadata": {
@@ -1460,18 +1593,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.454196,
-   "end_time": "2026-05-20T14:22:54.715471+00:00",
+   "duration": 6.018551,
+   "end_time": "2026-05-20T14:33:49.928237+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "SW-7b-Python-OWL.ipynb",
    "output_path": "SW-7b-Python-OWL.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T14:22:45.261275+00:00",
+   "start_time": "2026-05-20T14:33:43.909686+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Phase 4 du workflow de review TP etudiantes (skill `review-student-prs`) sur les notebooks SemanticWeb apres le merge de collision #1376 (qui avait integre les solutions etudiantes mais les laissait sous des titres "Exercice").

- **SW-4b-Python-SPARQL** (34 -> 39 cellules) : les 3 exercices SPARQL resolus deviennent des **exemples guides** (code etudiant preserve, markdown reformule + commentaire pedagogique sur l'approche), puis **2 nouveaux exercices** ajoutes a la suite (requete `ASK` avec `FILTER(?age > 4)` ; description textuelle via `BIND` + `CONCAT`).
- **SW-7b-Python-OWL** (31 -> 36 cellules) : les 3 exercices OWL/HermiT resolus deviennent des **exemples guides**, puis **2 nouveaux exercices** ajoutes (vehicules electriques `equivalent_to` + raisonnement ; classes disjointes `AllDisjoint`).

Conforme a `.claude/rules/exercise-example-labeling.md` (classification par contenu) et C.1 (stubs sans erreur volontaire : `print("Exercice a completer")`, `# TODO`/`# Indice` conserves).

## Validation (papermill, kernel `epita_symbolic_ai`, re-exec end-to-end)

| Notebook | code cells | executed | outputs | errors |
|----------|-----------|----------|---------|--------|
| SW-4b-Python-SPARQL | 13 | 13 | 13 | 0 |
| SW-7b-Python-OWL | 13 | 13 | 13 | 0 |

- Nouveaux stubs d'exercice -> output `Exercice a completer` (aucune `NotImplementedError`/`assert False`/`1/0`).
- Artefacts d'execution owlready2 (`data/temp_company.*`, `data/temp_ecosystem.owl`) exclus du commit (C.3).
- Seule occurrence de chemin dans les outputs = classpath Java HermiT (non sensible, stderr standard du raisonneur).

## Anti-regression

- Code etudiant resolu **preserve tel quel** (devient le corps des exemples guides), aucun `# Solution` strippe.
- Aucun nouvel exercice ne duplique trivialement l'exemple au-dessus (ASK/CONCAT, ElectricVehicle/AllDisjoint = nouveaux concepts du meme domaine).

## Credits

Solutions integrees issues des contributions des groupes Bouteloup/Duthou/Tayant-Serrat et Valhallave (cf #1376, #1362, #1366). Bonus credite aux deux groupes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>