### PR TITLE
feat(epita-iasy): Lean-9 SK Multi-Agents TP - Emile Jouannet (extrait #1374)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-9-SK-Multi-Agents.ipynb
@@ -4855,15 +4855,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 3,
    "id": "35ea88bf",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-20T05:47:00.477089Z",
-     "iopub.status.busy": "2026-05-20T05:47:00.476830Z",
-     "iopub.status.idle": "2026-05-20T05:47:00.482319Z",
-     "shell.execute_reply": "2026-05-20T05:47:00.480735Z"
-    },
     "papermill": {
      "duration": 0.017878,
      "end_time": "2026-05-20T05:47:00.483416+00:00",
@@ -4905,7 +4899,11 @@
     "        async def next(self, agents, history):\n",
     "            # Exercice: si proof_state.failed_tactics > 0, retourner CriticAgent\n",
     "            # Exercice: sinon, deleguer a super().next(agents, history)\n",
-    "            pass  # Exercice: implementez cette methode\n",
+    "            if self.proof_state.failed_tactics > 0 : \n",
+    "                for agent in agents:\n",
+    "                    if agent.name == \"CriticAgent\":\n",
+    "                        return agent\n",
+    "            return await super().next(agents,history)\n",
     "\n",
     "    print(\"Exercice 1: PriorityCriticStrategy - a completer\")\n",
     "except NameError:\n",
@@ -4951,15 +4949,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 2,
    "id": "d69a764e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-20T05:47:00.520352Z",
-     "iopub.status.busy": "2026-05-20T05:47:00.520106Z",
-     "iopub.status.idle": "2026-05-20T05:47:00.525885Z",
-     "shell.execute_reply": "2026-05-20T05:47:00.524310Z"
-    },
     "papermill": {
      "duration": 0.017948,
      "end_time": "2026-05-20T05:47:00.526856+00:00",
@@ -5005,7 +4997,9 @@
     "\n",
     "        def __init__(self, max_iterations: int = 20, max_consecutive_failures: int = 5):\n",
     "            # Exercice: stockez max_iterations et max_consecutive_failures\n",
-    "            pass  # Exercice: initialisez les attributs\n",
+    "            super().__init__()\n",
+    "            self.max_iterations = max_iterations\n",
+    "            self.max_consecutive_failures = max_consecutive_failures\n",
     "\n",
     "        async def should_terminate(self, agents, history):\n",
     "            \"\"\"Determine si la conversation doit s'arreter.\"\"\"\n",
@@ -5014,7 +5008,13 @@
     "            # 2. Si proof_state.iteration >= max_iterations -> arreter\n",
     "            # 3. Si proof_state.failed_tactics >= max_consecutive_failures -> arreter\n",
     "            # Sinon -> continuer (retourner False)\n",
-    "            pass  # Exercice: implementez cette methode\n",
+    "            if self.proof_state.success:\n",
+    "                return True\n",
+    "            if self.proof_state.iteration >= self.max_iterations:\n",
+    "                return True\n",
+    "            if self.proof_state.failed_tactics >= self.max_consecutive_failures:\n",
+    "                return True\n",
+    "            return False\n",
     "\n",
     "    print(\"Exercice 2: Strategie de terminaison intelligente - a completer\")\n",
     "except NameError:\n",
@@ -5107,9 +5107,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (WSL)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3-wsl"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -5121,7 +5121,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
## Summary

Extraction **notebook-only** de #1374 (Emile Jouannet, groupe Symbioose). La PR d'origine bundlait `COURSE_CATALOG.generated.json` (3216 lignes, +1610/-1610) + 2 READMEs : du **drift de regeneration sur base obsolete** qui aurait reverte les entrees catalogue d'autres PRs deja mergees. Ces fichiers sont ecartes coord-side ; seul le notebook de TP est conserve.

## Contenu etudiant (exercices resolus)

Lean-9-SK-Multi-Agents : 3 stubs `pass # Exercice` remplaces par de vraies implementations :
- Strategie de selection d'agent : route vers `CriticAgent` quand `failed_tactics > 0`, sinon delegue a `super().next()`.
- Initialisation de la boucle de preuve : `max_iterations`, `max_consecutive_failures`.
- Conditions de terminaison : succes, iterations max, echecs consecutifs max.

## Validation

- 55 cellules, 22 code, **22 executees, 0 erreur** (mode simulation `SK_AVAILABLE=False` / `has_api_key=False` — la logique de selection/terminaison ecrite par l'etudiant est du Python pur, ne necessite pas de LLM).
- Secrets : tous via `os.getenv(...)` avec `raise ValueError` si manquant, **aucun literal inline** (`sk-...` = detection de placeholder, pas une cle).
- 0 `raise NotImplementedError` / `assert False` / `1/0`.

## Notes

- #1374 sera ferme avec credit bonus a Emile Jouannet (le travail est conserve via cette PR).
- Catalogue/READMEs non touches (regen coord-side ulterieure si besoin).

Co-Authored-By: Emile Jouannet <emile.jouannet@epita.fr>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>