### PR TITLE
feat(lean): Lean-2 student solutions -> guided examples + new exercises (#1375)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
@@ -3054,288 +3054,12 @@
    "metadata": {},
    "source": [
     "<a id=\"9-exercices\"></a>\n",
-    "## 9. Exercices\n",
+    "## 9. Exemples guides (exercices resolus)\n",
     "\n",
-    "### Exercice 1 : Definitions de base\n",
-    "Definir une fonction `square` qui calcule le carre d'un nombre naturel."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5b\"><span class=\"kn\">def</span><span class=\"w\"> </span>square<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span><span class=\"w\">  </span><span class=\"c1\">-- Remplacer sorry par l&#39;implementation</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Test</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval square 5  -- Devrait donner 25</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 20</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\\n\\n-- Test\\n-- #eval square 5  -- Devrait donner 25\", \"env\": 19}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 30},\r\n",
-       "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Nat\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 35}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 20}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Votre code ici\n",
-       "def square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\n",
-       "    ──────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "-- Test\n",
-       "-- #eval square 5  -- Devrait donner 25\n",
-       "--% env 20\n",
-       "--% prove 0\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\\n\\n-- Test\\n-- #eval square 5  -- Devrait donner 25\", \"env\": 19}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 30},\r\n",
-       "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Nat\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 35}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 20}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Votre code ici\n",
-    "def square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\n",
+    "> Ces trois exemples reprennent des solutions proposees par les etudiants **Clovis Lefebvre** et **Evariste Balvay** (TP EPITA-IASY). Etudiez-les avant de passer aux exercices de la section 10.\n",
     "\n",
-    "-- Test\n",
-    "-- #eval square 5  -- Devrait donner 25"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Exercice 2 : Fonctions d'ordre superieur\n",
-    "Definir une fonction `applyTwice` qui applique une fonction deux fois a une valeur."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5c\"><span class=\"kn\">def</span><span class=\"w\"> </span>applyTwice<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>a)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Tests</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval applyTwice (fun n : Nat =&gt; n + 1) 0   -- Devrait donner 2</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval applyTwice (fun n : Nat =&gt; n * 2) 3   -- Devrait donner 12</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 21</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\\n\\n-- Tests\\n-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\\n-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\", \"env\": 20}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 54},\r\n",
-       "   \"goal\": \"a✝ b a : Type\\nf : a → a\\nx : a\\n⊢ a\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 59}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 21}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Votre code ici\n",
-       "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
-       "    ──────────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "-- Tests\n",
-       "-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\n",
-       "-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\n",
-       "--% env 21\n",
-       "--% prove 1\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\\n\\n-- Tests\\n-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\\n-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\", \"env\": 20}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 54},\r\n",
-       "   \"goal\": \"a✝ b a : Type\\nf : a → a\\nx : a\\n⊢ a\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 59}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 21}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Votre code ici\n",
-    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
-    "\n",
-    "-- Tests\n",
-    "-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\n",
-    "-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Exercice 3 : Manipulation de paires\n",
-    "Definir une fonction `mapPair` qui applique deux fonctions aux composantes d'une paire."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5d\"><span class=\"kn\">def</span><span class=\"w\"> </span>mapPair<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>d<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>d)<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>d<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Test</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval mapPair (fun n =&gt; n + 1) (fun s =&gt; s ++ &quot;!&quot;) (5, &quot;hello&quot;)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Devrait donner (6, &quot;hello!&quot;)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 22</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := sorry\\n\\n-- Test\\n-- #eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")\\n-- Devrait donner (6, \\\"hello!\\\")\", \"env\": 21}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 78},\r\n",
-       "   \"goal\": \"a✝ b✝ a b c d : Type\\nf : a → c\\ng : b → d\\np : a × b\\n⊢ c × d\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 83}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 22}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Votre code ici\n",
-       "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
-       "    ───────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "-- Test\n",
-       "-- #eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")\n",
-       "-- Devrait donner (6, \"hello!\")\n",
-       "--% env 22\n",
-       "--% prove 2\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := sorry\\n\\n-- Test\\n-- #eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")\\n-- Devrait donner (6, \\\"hello!\\\")\", \"env\": 21}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 78},\r\n",
-       "   \"goal\": \"a✝ b✝ a b c d : Type\\nf : a → c\\ng : b → d\\np : a × b\\n⊢ c × d\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 83}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 22}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Votre code ici\n",
-    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
-    "\n",
-    "-- Test\n",
-    "-- #eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")\n",
-    "-- Devrait donner (6, \"hello!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Exercices a completer\n"
+    "### Exemple guide 1 : Definitions de base\n",
+    "Une fonction `square` qui calcule le carre d'un nombre naturel."
    ]
   },
   {
@@ -3344,20 +3068,84 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "-- Exercice 1 : Carre\n",
-    "-- TODO etudiant : definir square qui retourne n * n\n",
-    "def square (n : Nat) : Nat := sorry\n",
-    "#eval square 5    -- doit retourner 25\n",
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def square (n : Nat) : Nat := n * n\n",
     "\n",
-    "-- Exercice 2 : Application double\n",
-    "-- TODO etudiant : definir applyTwice qui applique f deux fois\n",
-    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
-    "#eval applyTwice (fun n : Nat => n + 1) 0   -- doit retourner 2\n",
+    "#eval square 5  -- 25"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 2 : Fonctions d'ordre superieur\n",
+    "Une fonction `applyTwice` qui applique une fonction deux fois a une valeur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := f (f x)\n",
     "\n",
-    "-- Exercice 3 : Map sur une paire\n",
-    "-- TODO etudiant : definir mapPair qui applique f au premier et g au second\n",
-    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
-    "#eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")  -- doit retourner (6, \"hello!\")"
+    "#eval applyTwice (fun n : Nat => n + 1) 0   -- 2\n",
+    "#eval applyTwice (fun n : Nat => n * 2) 3   -- 12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exemple guide 3 : Manipulation de paires\n",
+    "Une fonction `mapPair` qui applique deux fonctions aux composantes d'une paire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := (f p.1, g p.2)\n",
+    "\n",
+    "#eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")  -- (6, \"hello!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=\"10-exercices\"></a>\n",
+    "## 10. Exercices a completer (a vous de jouer)\n",
+    "\n",
+    "Remplacez chaque `sorry` par votre implementation, puis decommentez la ligne `#eval` pour verifier le resultat attendu indique en commentaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-- Exercice 1 : Parite\n",
+    "-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\n",
+    "def isEven (n : Nat) : Bool := sorry\n",
+    "-- #eval isEven 4    -- doit retourner true\n",
+    "-- #eval isEven 7    -- doit retourner false\n",
+    "\n",
+    "-- Exercice 2 : Inversion d'arguments (ordre superieur)\n",
+    "-- TODO etudiant : definir flip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
+    "def flip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\n",
+    "-- #eval flip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
+    "\n",
+    "-- Exercice 3 : Echange des composantes d'une paire\n",
+    "-- TODO etudiant : definir swap qui echange les deux composantes d'une paire\n",
+    "def swap {a b : Type} (p : a × b) : b × a := sorry\n",
+    "-- #eval swap (1, \"x\")   -- doit retourner (\"x\", 1)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Phase 4 integration of student PR #1375 (**Clovis Lefebvre & Evariste Balvay**, TP EPITA-IASY) on `Lean-2-Dependent-Types.ipynb`.

- **Section 9 "Exercices" -> "Exemples guides"**: the students' `square` / `applyTwice` / `mapPair` solutions are kept as credited worked examples (eval tests uncommented to demonstrate results).
- **Section 10 "Exercices a completer"**: 3 new **distinct** exercises (`isEven` / `flip` / `swap`) added as `:= sorry` stubs, eval lines commented (no runtime error, per C.1 + the notebook's existing stub convention).
- Removes the `### Exercice` + complete-solution **leak** that merging #1375 as-is would have recreated (the de-leak EPIC just closed this exact pattern).

## Validation

- 50 cells / 24 code: 20 unchanged cells retain their valid outputs, **0 error outputs**.
- 4 source-modified cells (42/44/46/48) have **cleared** outputs (ec=None): the local `lean4-wsl` kernel cannot currently resolve the stdlib (`LEAN_PATH`/toolchain not on the REPL search path — flagged as infra), so they were not re-executed coord-side rather than committing stale/broken outputs.
- Leak check: `### Exercice`=0, `### Exemple guide`=3, `:= sorry`=3 (the new stubs). No secrets / path leaks.

Benevolent student-TP merge: closes #1375 with bonus credit to the group. Workflow per `.claude/rules/exercise-example-labeling.md` + `student-pr-reviews.md`.