### PR TITLE
add our solution (Clovis Lefebvre & Evariste Balvay) for Lean 3

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-3-Propositions-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-3-Propositions-Proofs.ipynb
@@ -2984,7 +2984,13 @@
     "variable (p q r : Prop)\n",
     "\n",
     "-- Votre preuve ici (renomme pour eviter conflit avec la bibliotheque standard)\n",
-    "theorem or_assoc_exercise : (p \\/ q) \\/ r <-> p \\/ (q \\/ r) := sorry"
+    "theorem or_assoc_sol : (p \\/ q) \\/ r <-> p \\/ (q \\/ r) :=\n",
+    "  ⟨fun left_or => left_or.elim\n",
+    "    (fun left_left_or => left_left_or.elim (Or.inl) (fun left_q => Or.inr (Or.inl left_q)))\n",
+    "    (fun left_r => Or.inr (Or.inr left_r)),\n",
+    "   fun right_or => right_or.elim\n",
+    "    (fun right_p => Or.inl (Or.inl right_p))\n",
+    "    (fun right_right_or => right_right_or.elim (fun right_q => Or.inl (Or.inr right_q)) Or.inr)⟩"
    ]
   },
   {
@@ -3071,7 +3077,13 @@
     "variable (p q r : Prop)\n",
     "\n",
     "-- p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r)\n",
-    "theorem and_or_distrib : p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := sorry"
+    "theorem and_or_distrib_sol : p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) :=\n",
+    "  ⟨fun left_and => left_and.right.elim\n",
+    "    (fun left_q => Or.inl ⟨left_and.left, left_q⟩)\n",
+    "    (fun left_r => Or.inr ⟨left_and.left, left_r⟩),\n",
+    "   fun right_or => right_or.elim\n",
+    "    (fun right_left_and => ⟨right_left_and.left, Or.inl right_left_and.right⟩)\n",
+    "    (fun right_right_and => ⟨right_right_and.left, Or.inr right_right_and.right⟩)⟩"
    ]
   },
   {
@@ -3161,7 +3173,9 @@
     "variable (p q : Prop)\n",
     "\n",
     "-- (p -> q) <-> (¬q -> ¬p)\n",
-    "theorem contrapositive : (p -> q) <-> (¬q -> ¬p) := sorry"
+    "theorem contrapositive_sol : (p -> q) <-> (¬q -> ¬p) :=\n",
+    "  ⟨fun h hnq hp => hnq (h hp),\n",
+    "   fun h hp => Or.elim (em q) id (fun hnq => absurd hp (h hnq))⟩"
    ]
   },
   {
@@ -3181,20 +3195,31 @@
     "\n",
     "-- Exercice 1 : Associativite de la disjonction\n",
     "-- TODO etudiant : prouver (p \\/ q) \\/ r <-> p \\/ (q \\/ r)\n",
-    "theorem or_assoc_practice : (p \\/ q) \\/ r <-> p \\/ (q \\/ r) := by\n",
-    "  sorry\n",
+    "theorem or_assoc_sol : (p \\/ q) \\/ r <-> p \\/ (q \\/ r) :=\n",
+    "  ⟨fun left_or => left_or.elim\n",
+    "    (fun left_left_or => left_left_or.elim (Or.inl) (fun left_q => Or.inr (Or.inl left_q)))\n",
+    "    (fun left_r => Or.inr (Or.inr left_r)),\n",
+    "   fun right_or => right_or.elim\n",
+    "    (fun right_p => Or.inl (Or.inl right_p))\n",
+    "    (fun right_right_or => right_right_or.elim (fun right_q => Or.inl (Or.inr right_q)) Or.inr)⟩\n",
     "\n",
     "-- Exercice 2 : Distribution et/disjonction\n",
     "-- TODO etudiant : prouver p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r)\n",
-    "theorem and_or_distrib_practice : p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-    "  sorry\n",
+    "theorem and_or_distrib_sol : p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) :=\n",
+    "  ⟨fun left_and => left_and.right.elim\n",
+    "    (fun left_q => Or.inl ⟨left_and.left, left_q⟩)\n",
+    "    (fun left_r => Or.inr ⟨left_and.left, left_r⟩),\n",
+    "   fun right_or => right_or.elim\n",
+    "    (fun right_left_and => ⟨right_left_and.left, Or.inl right_left_and.right⟩)\n",
+    "    (fun right_right_and => ⟨right_right_and.left, Or.inr right_right_and.right⟩)⟩\n",
     "\n",
     "-- Exercice 3 : Contraposition\n",
     "-- TODO etudiant : prouver (p -> q) <-> (not q -> not p)\n",
     "-- Indice : utiliser open Classical et Or.elim (em q)\n",
     "open Classical in\n",
-    "theorem contrapositive_practice : (p -> q) <-> (not q -> not p) := by\n",
-    "  sorry"
+    "theorem contrapositive_sol : (p -> q) <-> (¬q -> ¬p) :=\n",
+    "  ⟨fun h hnq hp => hnq (h hp),\n",
+    "   fun h hp => Or.elim (em q) id (fun hnq => absurd hp (h hnq))⟩"
    ]
   },
   {


### PR DESCRIPTION
…Lean 3

<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

- add our solution (Clovis Lefebvre & Evariste Balvay) for Lean 3

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
