### PR TITLE
fix(notebooks): relabel solution sections as corrections in GameTheory Lean notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -2225,56 +2225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "-",
-    "-",
-    "-",
-    "\n",
-    "\n",
-    "#",
-    "#",
-    " ",
-    "8",
-    ".",
-    " ",
-    "S",
-    "o",
-    "l",
-    "u",
-    "t",
-    "i",
-    "o",
-    "n",
-    "s",
-    "\n",
-    "\n",
-    "#",
-    "#",
-    "#",
-    " ",
-    "S",
-    "o",
-    "l",
-    "u",
-    "t",
-    "i",
-    "o",
-    "n",
-    " ",
-    "E",
-    "x",
-    "e",
-    "m",
-    "p",
-    "l",
-    "e",
-    " ",
-    "g",
-    "u",
-    "i",
-    "d",
-    "e",
-    " ",
-    "1"
+    "---\n\n## 8. Corrections — Référence enseignant\n\n### Correction Exemple guide 1"
    ]
   },
   {
@@ -2430,7 +2381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Solution Exemple guide 2"
+    "### Correction Exemple guide 2"
    ]
   },
   {
@@ -2523,15 +2474,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Solution Exemple guide 3\n",
-    "\n",
-    "Pour la preuve que le Core du jeu de majorite a 3 joueurs est vide, voir le notebook Python compagnon (21b) pour l'illustration numerique."
+    "### Correction Exemple guide 3\n\nPour la preuve que le Core du jeu de majorite a 3 joueurs est vide, voir le notebook Python compagnon (21b) pour l'illustration numerique."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "---\n\n## 8. Solutions (suite)\n\n### Resume\n\n#### Concepts formalises\n\n| Concept | Definition Lean |\n|---------|----------------|\n| TU Game | `TUGame N` avec `v : Finset N → R`, `v(∅) = 0` |\n| Superadditivite | `v(S ∪ T) ≥ v(S) + v(T)` pour S, T disjoints |\n| Convexite | Contributions marginales croissantes |\n| Shapley | Contribution marginale moyenne sur permutations |\n| Core | Allocations efficaces et stables |\n| Banzhaf | Nombre de coalitions critiques |\n| Mariage stable | Pas de paire bloquante |\n\n#### Axiomes de Shapley\n\n| Axiome | Signification |\n|--------|---------------|\n| Efficacite | `∑ φ = v(N)` |\n| Symetrie | Joueurs interchangeables = meme paiement |\n| Joueur nul | Contribution nulle = paiement nul |\n| Additivite | `φ(G+H) = φ(G) + φ(H)` |\n\n#### Theoremes cles\n\n1. **Unicite de Shapley** : Les 4 axiomes caracterisent Shapley uniquement\n2. **Bondareva-Shapley** : Core non-vide ⇔ jeu equilibre\n3. **Jeux convexes** : Shapley dans le Core\n4. **Gale-Shapley** : Existence d'un mariage stable, optimal pour les proposants\n\n---\n\n## Conclusion de la Serie GameTheory\n\nCette serie de **21 notebooks** (+3 compagnons Python) a couvert la theorie des jeux de maniere complete :\n\n| Partie | Focus |\n|--------|-------|\n| 1-6 | Fondations : Nash, minimax, evolution |\n| 7-11 | Dynamique : forme extensive, induction, bayesien |\n| 12-16 | Algorithmes : CFR, cooperatif, mecanismes, MARL |\n| 17-21 | Formalisation : Lean 4, preuves, Shapley |\n\nLes **side tracks SocialChoice** (16b-16f reorganises en SC-01 a SC-04) completent cette serie avec les resultats fondamentaux de choix social (Arrow, Sen, methodes de vote) et leurs ports Lean 4.\n\n---\n\n**Navigation** : [← SocialChoice/01-Arrow](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | [Index](GameTheory-1-Setup.ipynb) | [Fin de la serie]"
+   "source": "---\n\n## 8. Corrections — Référence enseignant (suite)\n\n### Resume\n\n#### Concepts formalises\n\n| Concept | Definition Lean |\n|---------|----------------|\n| TU Game | `TUGame N` avec `v : Finset N → R`, `v(∅) = 0` |\n| Superadditivite | `v(S ∪ T) ≥ v(S) + v(T)` pour S, T disjoints |\n| Convexite | Contributions marginales croissantes |\n| Shapley | Contribution marginale moyenne sur permutations |\n| Core | Allocations efficaces et stables |\n| Banzhaf | Nombre de coalitions critiques |\n| Mariage stable | Pas de paire bloquante |\n\n#### Axiomes de Shapley\n\n| Axiome | Signification |\n|--------|---------------|\n| Efficacite | `∑ φ = v(N)` |\n| Symetrie | Joueurs interchangeables = meme paiement |\n| Joueur nul | Contribution nulle = paiement nul |\n| Additivite | `φ(G+H) = φ(G) + φ(H)` |\n\n#### Theoremes cles\n\n1. **Unicite de Shapley** : Les 4 axiomes caracterisent Shapley uniquement\n2. **Bondareva-Shapley** : Core non-vide ⇔ jeu equilibre\n3. **Jeux convexes** : Shapley dans le Core\n4. **Gale-Shapley** : Existence d'un mariage stable, optimal pour les proposants\n\n---\n\n## Conclusion de la Serie GameTheory\n\nCette serie de **21 notebooks** (+3 compagnons Python) a couvert la theorie des jeux de maniere complete :\n\n| Partie | Focus |\n|--------|-------|\n| 1-6 | Fondations : Nash, minimax, evolution |\n| 7-11 | Dynamique : forme extensive, induction, bayesien |\n| 12-16 | Algorithmes : CFR, cooperatif, mecanismes, MARL |\n| 17-21 | Formalisation : Lean 4, preuves, Shapley |\n\nLes **side tracks SocialChoice** (16b-16f reorganises en SC-01 a SC-04) completent cette serie avec les resultats fondamentaux de choix social (Arrow, Sen, methodes de vote) et leurs ports Lean 4.\n\n---\n\n**Navigation** : [← SocialChoice/01-Arrow](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | [Index](GameTheory-1-Setup.ipynb) | [Fin de la serie]"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
@@ -2022,12 +2022,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "<a id=\"7-solutions\"></a>\n",
-    "## 7. Solutions\n",
-    "\n",
-    "### Solution Exemple guide 1 : Chicken"
-   ]
+   "source": "<a id=\"7-corrections\"></a>\n## 7. Corrections — Référence enseignant\n\n### Correction Exemple guide 1 : Chicken"
   },
   {
    "cell_type": "code",
@@ -2325,9 +2320,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Solution Exemple guide 2 : Matching Pennies"
-   ]
+   "source": "### Correction Exemple guide 2 : Matching Pennies"
   },
   {
    "cell_type": "code",
@@ -2600,9 +2593,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Solution Exemple guide 3 : Stag Hunt"
-   ]
+   "source": "### Correction Exemple guide 3 : Stag Hunt"
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -1658,15 +1658,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### Solutions suggérées\n",
-    "\n",
-    "**Exercice 1** : Utilisez la fonction `find_swap_path(CLASSIC_GAMES[\"Chicken\"], CLASSIC_GAMES[\"Matching Pennies\"])` pour découvrir la séquence optimale.\n",
-    "\n",
-    "**Exercice 2** : Notre analyse montre que le nombre de jeux avec exactement 3 équilibres est **0**. Cela n'est pas un accident ! La structure des jeux 2x2 fait qu'on a soit 0, 1, 2, ou 4 équilibres purs, mais jamais 3. Pourquoi ? \n",
-    "\n",
-    "> **Réflexion** : Pensez à la symétrie des meilleures réponses. Si trois cellules sont des équilibres, pourquoi la quatrième ne le serait-elle pas aussi ?\n",
-    "\n",
-    "**Exercice 3** : Le chemin PD → Harmony transforme un dilemme en harmonie parfaite. Utilisez `find_swap_path()` et `show_transformation_chain()` pour visualiser cette transformation."
+    "### Pistes de solution\n\n**Exercice 1** : Utilisez la fonction `find_swap_path()` avec `CLASSIC_GAMES[\"Chicken\"]` et `CLASSIC_GAMES[\"Matching Pennies\"]` pour découvrir la séquence optimale.\n\n**Exercice 2** : Réfléchissez à la structure des meilleures réponses dans un jeu 2x2. Combien de Nash purs peut-on avoir au maximum ?\n\n> **Réflexion** : Pensez à la symétrie des meilleures réponses. Si trois cellules sont des équilibres, pourquoi la quatrième ne le serait-elle pas aussi ?\n\n**Exercice 3** : Utilisez `find_swap_path()` et `show_transformation_chain()` pour visualiser la transformation PD → Harmony."
    ],
    "metadata": {}
   },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
@@ -1280,12 +1280,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "<a id=\"7-solutions\"></a>\n",
-    "## 7. Solutions\n",
-    "\n",
-    "### Solution Exemple guide 1"
-   ]
+   "source": "<a id=\"7-corrections\"></a>\n## 7. Corrections — Référence enseignant\n\n### Correction Exemple guide 1"
   },
   {
    "cell_type": "code",
@@ -1451,9 +1446,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Solution Exemple guide 2"
-   ]
+   "source": "### Correction Exemple guide 2"
   },
   {
    "cell_type": "code",
@@ -1617,9 +1610,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Solution Exemple guide 3"
-   ]
+   "source": "### Correction Exemple guide 3"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

- Rename `## 7. Solutions` / `## 8. Solutions` → `## 7. Corrections — Référence enseignant` in GT-2b, GT-4b, GT-15b
- Rename `### Solution Exemple guide N` → `### Correction Exemple guide N` (same files)
- GT-3: replace cell[46] that revealed the exact numerical answer ("le nombre de jeux avec exactement 3 équilibres est **0**") with a Socratic hint, preserving the Réflexion prompt
- All markdown-only changes — no re-execution required (rule C.2 exception)

## Scope

**4 real cases fixed** (9 scanned, 5 false positives):
| Notebook | Cells | Type |
|----------|-------|------|
| GT-2b-Lean-Definitions | [33,35,37] | Solution header rename |
| GT-4b-Lean-NashExistence | [25,27,29] | Solution header rename |
| GT-15b-Lean-CooperativeGames | [31,33,35,36] | Solution header rename |
| GT-3-Topology2x2 | [46] | Numerical answer removed |

**5 false positives** (no change): GT-5, GT-11, GT-12, GT-14, GT-17 — "solution" used as mathematical term in those files.

## Reassessment

Verified each cell by direct JSON read. Classified: CONFIRMED solution leak (headers + GT-3 numerical answer).

## Test plan

- [ ] Markdown-only diff verified — no code cells or outputs touched
- [ ] Notebooks still executable (no `raise NotImplementedError`, no broken stubs)
- [ ] `grep -c sorry` unchanged (no Lean proofs touched)

Partial fix — closes #622 batch 1. Issue remains open for any follow-up.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)