### PR TITLE
feat(prover): B2 SearchAgent gate before intractable (closes #1224)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -118,6 +118,12 @@ class ProofState:
     # whether to force Director invocation at iteration 4.
     _has_director: bool = False
 
+    # B2 (issue #1224): SearchAgent consultation gate. The Coordinator
+    # MUST have had SearchAgent explore reference_docs/ before
+    # mark_sorry_intractable can terminate the session. C37 forensic showed
+    # Coordinator decided intractable in 139.7s with 0 SearchAgent payload.
+    search_agent_consulted: bool = False
+
     # B.8: Checkpoint support — save/restore state between phases
     _checkpoints: Dict[str, dict] = field(default_factory=dict, repr=False)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -1548,7 +1548,7 @@ class CoordinatorTools:
         )
 
     def mark_sorry_intractable(self, reason: str) -> str:
-        """Explicitly abandon the current sorry (F5, gated by F9).
+        """Explicitly abandon the current sorry (F5, gated by F9 + B2).
 
         Call this when the Coordinator has exhausted realistic attack plans
         on a goal — e.g., the lemma requires an obscure Mathlib API the
@@ -1557,11 +1557,13 @@ class CoordinatorTools:
         prover run can target a different sorry instead of burning the
         remaining iteration budget on a dead end.
 
-        F9 (2026-05-17): now gated. Must call request_director_guidance()
-        at least once first AND wait for the Director to actually run
-        (state.director_consulted set to True by AgentExecutor when
-        DirectorAgent yields). Premature calls return an error message and
-        leave the session running.
+        Gates (in order):
+          - F9: Must call request_director_guidance() at least once first
+            AND wait for Director to run (state.director_consulted).
+          - B2 (issue #1224): SearchAgent must have explored reference_docs/
+            before intractable is allowed. C37 forensic showed Coordinator
+            decided intractable in 139.7s with 0 SearchAgent payload — the
+            upstream proof was available but never found.
 
         Args:
             reason: Concise explanation (logged in trace + final report).
@@ -1583,6 +1585,26 @@ class CoordinatorTools:
                 "request_director_guidance(reason=...) now, then try the "
                 "Director's APPROACH+TACTICS. Only if that ALSO fails should "
                 "you call mark_sorry_intractable again."
+            )
+
+        # B2 gate (issue #1224): SearchAgent must have explored reference_docs.
+        if not getattr(self._state, "search_agent_consulted", False):
+            if self._trace:
+                self._trace.log(
+                    agent="CoordinatorAgent", role="intractable_blocked",
+                    content=(f"B2 gate: intractable refused — SearchAgent not "
+                             f"yet consulted. reason={reason[:120]}"),
+                    tool_name="mark_sorry_intractable",
+                )
+            return (
+                "REFUSED (B2 gate). SearchAgent has not yet explored "
+                "reference_docs/ for upstream proofs or Mathlib lemmas "
+                "relevant to this goal. Route to SearchAgent first so it can "
+                "scan for matching theorems — the C37 forensic showed "
+                "Coordinator abandoned in 139.7s while the upstream proof "
+                "was available in reference_docs. Call route_to_search_agent "
+                "or designate next_agent=SearchAgent, wait for it to run, "
+                "then try mark_sorry_intractable again."
             )
 
         self._state.intractable = True

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -367,6 +367,18 @@ class AgentExecutor(Executor):
                         content=f"flagged absent: {absent}",
                     )
 
+        # B2 (issue #1224): Track SearchAgent consultations so the
+        # intractable gate can require at least one SearchAgent pass
+        # before abandoning a sorry.
+        if self._agent.name == "SearchAgent":
+            if self._state:
+                self._state.search_agent_consulted = True
+            if self._trace:
+                self._trace.log(
+                    agent="SearchAgent", role="search_consulted",
+                    content="SearchAgent ran — intractable gate satisfied",
+                )
+
         # F5: Coordinator can mark the current sorry intractable. End the
         # session cleanly so we don't waste iterations on a known-dead goal.
         if (self._state and getattr(self._state, "intractable", False)


### PR DESCRIPTION
## Summary
- Add `search_agent_consulted` flag to `ProofState` — set when SearchAgent runs in `AgentExecutor`
- Add B2 gate in `mark_sorry_intractable`: CoordinatorAgent MUST wait for SearchAgent to explore `reference_docs/` before abandoning a sorry
- Direct fix for C37 forensic finding: Coordinator abandoned in 139.7s with 0 SearchAgent payload while the upstream proof was available in reference_docs

## Files changed (3 files, +46/-6)
- `prover/state.py`: new `search_agent_consulted: bool = False` field
- `prover/workflow.py`: set flag in `AgentExecutor` when SearchAgent runs (after Director tracking block)
- `prover/tools.py`: B2 gate in `mark_sorry_intractable` after existing F9 (Director) gate

## Test plan
- [x] `py_compile` syntax check on all 3 files
- [ ] Run prover in `multi` mode against a known sorry — verify B2 gate fires when SearchAgent has not yet run
- [ ] Verify gate clears after SearchAgent invocation

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)