### PR TITLE
fix(prover): swap TacticAgent GLM-5.1 -> GPT-5.5 via OpenRouter (#1289)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -94,7 +94,8 @@ class MultiAgentSorryProver:
     def __init__(self, trace: TraceLogger, provider: str = "zai",
                  local_provider: str = "local",
                  director_provider: Optional[str] = None,
-                 coordinator_provider: Optional[str] = None):
+                 coordinator_provider: Optional[str] = None,
+                 tactic_provider: Optional[str] = None):
         self.trace = trace
         self.provider = provider
         self.local_provider = local_provider
@@ -104,6 +105,12 @@ class MultiAgentSorryProver:
         # Default to "openrouter" (GPT-5.5 via OPENAI_CHAT_MODEL_ID) which
         # handles Coordinator tasks in <2min vs 12+ min with GLM-5.1.
         self.coordinator_provider = coordinator_provider or "openrouter"
+        # #1289 (TacticAgent): Same root cause — GLM-5.1 (zai) times out at
+        # 1680s on complex Lean tactic generation (Lattice contexts).
+        # BG DEMO 30 forensic showed Coordinator (60s) + Director (8s) fine,
+        # but TacticAgent z.ai hung for 1680s. Default to "openrouter" so
+        # GPT-5.5 handles tactic generation in ~60-120s instead.
+        self.tactic_provider = tactic_provider or "openrouter"
 
     async def prove_sorry(self, demo: dict, max_iterations: int = 10,
                           workflow_timeout_s: Optional[int] = None) -> dict:
@@ -227,7 +234,7 @@ class MultiAgentSorryProver:
         search_agent = create_search_agent(
             search_tools, provider=self.local_provider, goal=goal_state or "")
         tactic_agent = create_tactic_agent(
-            tactic_tools, provider=self.provider, goal=goal_state or "")
+            tactic_tools, provider=self.tactic_provider, goal=goal_state or "")
         critic_agent = create_critic_agent(critic_tools, provider=self.provider)
         coordinator_agent = create_coordinator_agent(coordinator_tools, provider=self.coordinator_provider)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -31,7 +31,8 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
                mode: str = "multi", iterations: int = 8,
                provider: str = "zai", local_provider: str = "local",
                goal: str = "", director_provider: str = None,
-               coordinator_provider: str = None):
+               coordinator_provider: str = None,
+               tactic_provider: str = None):
     """Run the prover on a target."""
     if demo_num is not None:
         if demo_num not in DEMOS:
@@ -57,7 +58,7 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     print(f"Target: {name}")
     print(f"  File: {filepath} (line {line})")
     print(f"  Mode: {mode}, Iterations: {iterations}")
-    print(f"  Provider: {provider}, Local: {local_provider}, Coordinator: {coordinator_provider or 'openrouter (default)'}")
+    print(f"  Provider: {provider}, Local: {local_provider}, Tactic: {tactic_provider or 'openrouter (default)'}, Coordinator: {coordinator_provider or 'openrouter (default)'}")
     print(f"  Initial sorry count: {original_sorry}")
     print()
 
@@ -67,7 +68,8 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         prover = MultiAgentSorryProver(
             trace=trace, provider=provider, local_provider=local_provider,
             director_provider=director_provider,
-            coordinator_provider=coordinator_provider)
+            coordinator_provider=coordinator_provider,
+            tactic_provider=tactic_provider)
         if director_provider:
             print(f"  Director: ENABLED (provider={director_provider})")
     else:
@@ -140,6 +142,11 @@ if __name__ == "__main__":
                              "#1289: GLM-5.1 (zai) times out on complex Lean contexts; "
                              "GPT-5.5 via openrouter is 6x faster. "
                              "Only used in --mode multi.")
+    parser.add_argument("--tactic-provider", default=None,
+                        help="Provider for TacticAgent (default: openrouter). "
+                             "#1289: GLM-5.1 (zai) times out at 1680s on complex "
+                             "Lean tactic generation; GPT-5.5 via openrouter "
+                             "expected ~60-120s. Only used in --mode multi.")
     args = parser.parse_args()
 
     run_prover(
@@ -153,4 +160,5 @@ if __name__ == "__main__":
         goal=args.goal,
         director_provider=args.director_provider,
         coordinator_provider=args.coordinator_provider,
+        tactic_provider=args.tactic_provider,
     )

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/run_prover_bg.py
@@ -63,6 +63,7 @@ async def main(args: argparse.Namespace) -> int:
     _bg(f"DIFF  {demo.get('difficulty')}")
     _bg(
         f"PROVIDER reasoning={args.provider} fast={args.local_provider} "
+        f"tactic={getattr(args, 'tactic_provider', None) or 'openrouter'} "
         f"director={args.director_provider or 'none'} "
         f"max_iter={args.max_iter} workflow_timeout={args.workflow_timeout}s"
     )
@@ -81,6 +82,7 @@ async def main(args: argparse.Namespace) -> int:
         local_provider=args.local_provider,
         director_provider=args.director_provider,
         coordinator_provider=getattr(args, "coordinator_provider", None),
+        tactic_provider=getattr(args, "tactic_provider", None),
     )
 
     t0 = time.time()
@@ -138,6 +140,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--coordinator-provider", default=None,
                    help="Provider for CoordinatorAgent (default: openrouter). "
                         "#1289: GLM-5.1 (zai) times out; GPT-5.5 via openrouter is 6x faster.")
+    p.add_argument("--tactic-provider", default=None,
+                   help="Provider for TacticAgent (default: openrouter). "
+                        "#1289: GLM-5.1 (zai) times out at 1680s on tactic generation; "
+                        "GPT-5.5 via openrouter expected ~60-120s.")
     return p.parse_args()
 
 


### PR DESCRIPTION
## Summary
- Replace GLM-5.1 (z.ai) TacticAgent with GPT-5.5 via OpenRouter (default provider)
- Same root cause as CoordinatorAgent swap (#1394): GLM-5.1 times out at 1680s on complex Lean tactic generation
- 3-file patch: `provers.py` + both `run_prover_bg.py` harnesses

## Changes
| File | Change |
|------|--------|
| `prover/provers.py` | New `tactic_provider` param in `__init__`, passed to `create_tactic_agent` |
| `prover/run_prover_bg.py` | New `--tactic-provider` CLI flag |
| `agent_tests/run_prover_bg.py` | Same flag on legacy harness |

## Validation — BG DEMO 30 (LATTICE_JOIN_BIJECTIVE, L130)

| Agent | Before (GLM-5.1) | After (GPT-5.5 OpenRouter) |
|-------|-------------------|---------------------------|
| Coordinator | 12+ min timeout | ~60s planification + routing |
| Director | not wired | ~8s APPROACH |
| **TacticAgent** | **1680s timeout (28 min)** | **145-215s responses (~3 min)** |

- **TacticAgent speedup: ~11.6x** (1680s → 145s first response)
- TacticAgent correctly identifies `False` goal in `no_cross_match` as intractable (expected — INTRACTABLE_UNTIL_RURAL_HOSPITALS)
- Pipeline flows end-to-end without timeouts

## Post-swap prover architecture

| Agent | Provider | Model |
|-------|----------|-------|
| CoordinatorAgent | openrouter | GPT-5.5 |
| TacticAgent | openrouter | GPT-5.5 |
| DirectorAgent | openrouter | GPT-5.5 |
| SearchAgent | local | Qwen3.6-35b |
| CriticAgent | zai | GLM-5.1 |

## Backward compat
- `--tactic-provider zai` restores old behavior
- Default: `openrouter` (no flag needed)

Closes #1289 (combined with #1394)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>