### PR TITLE
docs(probas): add PyMC series + HMM to Probas README (#623)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -9,17 +9,20 @@ maturity: BETA=25, PRODUCTION=6, ALPHA=1
 
 Le monde reel est incertain. Un diagnostic medical n'est jamais sur a 100%, un classement sportif depend de performances intrinsequement variables, et les donnees que nous collectons sont toujours bruitees ou incompletes. La programmation probabiliste offre un cadre rigoureux pour modeliser cette incertitude : plutot que de calculer une seule reponse, on obtient une **distribution de probabilites** qui quantifie notre confiance dans chaque resultat possible.
 
-Cette serie vous apprend a construire des modeles probabilistes decomplexes en quelques lignes de code. Vous decouvrirez comment Infer.NET (Microsoft) permet de definir des variables aleatoires, d'exprimer des observations, et d'obtenir automatiquement les distributions posterieures — sans ecrire d'integrales ni deriver d'equations. Le parcours couvre les fondements mathematiques (distributions, graphs de facteurs), les modeles classiques (reseaux bayesiens, TrueSkill, LDA, HMM), puis la theorie de la decision bayesienne pour prendre des decisions optimales sous incertitude.
+Cette serie couvre trois stack complementaires : **Infer.NET** (Microsoft, C#/.NET Interactive) pour l'inference exacte par message passing, **PyMC** (Python) pour l'echantillonnage MCMC moderne, et des **applications standalone** (RSA, HMM trading). Les 20 notebooks Infer.NET couvrent les fondements mathematiques (distributions, graphs de facteurs), les modeles classiques (reseaux bayesiens, TrueSkill, LDA, HMM), puis la theorie de la decision bayesienne. Les 9 notebooks PyMC reprennent les memes modeles en Python avec l'echantillonnage NUTS, offrant un pont naturel vers l'ecosysteme data science.
 
-**A qui s'adresse cette serie** : etudiants en IA, data scientists, et developpeurs souhaitant aller au-dela des modeles deterministes. Les 20 notebooks Infer.NET utilisent le kernel .NET Interactive (C#), tandis que les 2 notebooks racine (Infer-101, Pyro RSA) sont en Python. Aucun prerequis en probabilites avancees : les concepts sont introduits progressivement.
+**32 notebooks** | **3 stack** | **~30h**
+
+**A qui s'adresse cette serie** : etudiants en IA, data scientists, et developpeurs souhaitant aller au-dela des modeles deterministes. Aucun prerequis en probabilites avancees : les concepts sont introduits progressivement.
 
 ## Vue d'ensemble
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 22 (20 Infer.NET + 2 Python) |
-| Duree totale | ~20h |
+| Notebooks | 32 (20 Infer.NET + 9 PyMC + 3 standalone) |
+| Duree totale | ~30h |
 | Langages | C# (.NET), Python |
+| Kernels | .NET Interactive, Python 3 |
 
 ## Parcours d'apprentissage
 
@@ -35,9 +38,13 @@ Les notebooks 4 a 13 construisent des modeles de complexite croissante, chacun i
 
 La seconde moitie de la serie passe de l'inference a la decision : comment choisir une action quand on ne connait que des probabilites ? Les notebooks 14-16 posent les fondations (axiomes de l'utilite, fonctions d'utilite mono- et multi-attributs). Les notebooks 17-20 appliquent ces concepts aux reseaux de decision, a la valeur de l'information, aux systemes experts robustes, et aux processus decisionnels de Markov (MDPs) — qui relient cette serie a la serie [RL](../RL/).
 
-### Parcours alternatif : Python (Infer-101 + Pyro RSA, ~2h)
+### Parcours alternatif : Python (Infer-101 + Pyro RSA + HMM, ~2h)
 
-Si vous preferez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modeles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application a la linguistique pragmatique avec le framework RSA). Ces deux notebooks ne dependent pas d'Infer.NET.
+Si vous preferez Python au C#, commencez par Infer-101.ipynb (introduction standalone avec modeles Two Coins et Cyclist) puis Pyro_RSA_Hyperbole.ipynb (application a la linguistique pragmatique avec le framework RSA). Le notebook PyMC-HMM-Trading-Alpha.ipynb applique les HMM gaussiens a la generation de signaux de trading.
+
+### Parcours PyMC (9 notebooks, ~6h)
+
+Les notebooks PyMC dans `_python_port/` reprennent les 9 premiers modeles Infer.NET en Python avec PyMC et l'echantillonnage NUTS. Ils constituent un excellent complement pour comparer les approches d'inference (message passing vs MCMC) et rejoindre l'ecosysteme Python data science.
 
 ## Structure
 
@@ -45,6 +52,10 @@ Si vous preferez Python au C#, commencez par Infer-101.ipynb (introduction stand
 Probas/
 ├── Infer-101.ipynb              # Introduction Python/C# (standalone)
 ├── Pyro_RSA_Hyperbole.ipynb     # Pragmatique linguistique (Python)
+├── PyMC-HMM-Trading-Alpha.ipynb # HMM gaussien pour trading (Python)
+├── _python_port/                # Port PyMC des modeles Infer.NET (9 notebooks)
+│   ├── PyMC-1-Setup.ipynb ... PyMC-9-Topic-Models.ipynb
+│   └── README.md
 └── Infer/                       # Serie complete Infer.NET (20 notebooks)
     ├── Infer-1-Setup.ipynb ... Infer-20-Decision-Sequential.ipynb
     ├── README.md                # Documentation detaillee de la serie
@@ -105,7 +116,37 @@ La serie complete est documentee dans [Infer/README.md](Infer/README.md).
 | 13 | Debugging | EP vs VMP, diagnostic erreurs |
 | 14-20 | Decision Theory | Utilite, MAUT, influence diagrams, MDPs |
 
+## Serie PyMC (9 notebooks, Python)
+
+Port Python des memes modeles Infer.NET, utilisant l'echantillonnage MCMC (NUTS) au lieu du message passing. Permet de comparer les deux approches d'inference sur des modeles identiques.
+
+| # | Notebook | Sujet |
+|---|----------|-------|
+| 1 | [PyMC-1-Setup](_python_port/PyMC-1-Setup.ipynb) | Configuration PyMC, modele Beta-Bernoulli |
+| 2 | [PyMC-2-Gaussian-Mixtures](_python_port/PyMC-2-Gaussian-Mixtures.ipynb) | Distributions continues, melanges gaussiens |
+| 3 | [PyMC-3-Factor-Graphs](_python_port/PyMC-3-Factor-Graphs.ipynb) | Graphes de facteurs, inference discrete |
+| 4 | [PyMC-4-Bayesian-Networks](_python_port/PyMC-4-Bayesian-Networks.ipynb) | Reseaux bayesiens, CPTs |
+| 5 | [PyMC-5-Skills-IRT](_python_port/PyMC-5-Skills-IRT.ipynb) | Item Response Theory, modeles de competences |
+| 6 | [PyMC-6-TrueSkill](_python_port/PyMC-6-TrueSkill.ipynb) | Classement, TrueSkill |
+| 7 | [PyMC-7-Classification](_python_port/PyMC-7-Classification.ipynb) | Classification bayesienne |
+| 8 | [PyMC-8-Model-Selection](_python_port/PyMC-8-Model-Selection.ipynb) | Selection de modeles, Bayes Factors |
+| 9 | [PyMC-9-Topic-Models](_python_port/PyMC-9-Topic-Models.ipynb) | LDA, Dirichlet priors |
+
+## Applications standalone (3 notebooks)
+
+| Notebook | Kernel | Contenu | Duree |
+| -------- | ------- | ------- | ----- |
+| [Infer-101](Infer-101.ipynb) | .NET (C#) + Python | Introduction Infer.NET, Two Coins, Cyclist | 1h |
+| [Pyro_RSA_Hyperbole](Pyro_RSA_Hyperbole.ipynb) | Python 3 | Rational Speech Acts, hyperboles | 30 min |
+| [PyMC-HMM-Trading-Alpha](PyMC-HMM-Trading-Alpha.ipynb) | Python 3 | HMM gaussien pour signaux de trading | 45 min |
+
 ## Installation
+
+### Notebooks PyMC (Python)
+
+```bash
+pip install pymc numpy scipy matplotlib arviz
+```
 
 ### Notebooks Infer.NET (C# .NET Interactive)
 
@@ -205,7 +246,9 @@ Voir la licence du repository principal.
 ## Cross-series Bridges
 
 | Serie | Lien | Connection |
-|-------|------|-------------|
+| ------- | ------ | ----------- |
 | [IIT](../IIT/README.md) | PyPhi | L'integration informationnelle (phi) repose sur les memes fondements probabilistes |
 | [SymbolicAI/SemanticWeb](../SymbolicAI/SemanticWeb/README.md) | OWL reasoning | Les ontologies OWL utilisent la logique probabiliste pour le raisonnement incertain |
 | [GameTheory](../GameTheory/README.md) | Bayesian games | Les jeux bayesiens combinent probabilites et theorie des jeux |
+| [QuantConnect](../QuantConnect/README.md) | HMM trading | PyMC-HMM-Trading-Alpha applique les modeles probabilistes aux signaux de trading |
+| [Search](../Search/README.md) | Optimisation bayesienne | La selection de modeles (PyMC-8) utilise les memes techniques que l'optimisation bayesienne |


### PR DESCRIPTION
## Summary
Consolidation prose/structure/navigation du README Probas (track #623, mandat user documentation/consolidation).
- Ajout des 9 notebooks PyMC + HMM trading + 3 apps standalone (manquants dans le sommaire)
- Intro mise a jour (3 stacks), compteur 22 -> 32, table PyMC, learning path, 2 ponts cross-series

Scope: prose README uniquement (commit po-2025, 1 fichier). Blocs CATALOG-STATUS non touches (auto-refresh #1415).

Co-authored-by: myia-po-2025
Closes part of #623