### PR TITLE
docs(search): correct total notebook count 40 -> 45 (#623)

### DIFF
--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -30,11 +30,12 @@ Les 20 notebooks d'applications illustrent chaque concept sur des cas réels : p
 ## Vue d'ensemble
 
 | Partie | Notebooks | Duree |
-|--------|-----------|-------|
+| -------- | --------- | ----- |
 | Partie 1: Search Fondamental | 11 | ~12h30 |
 | Partie 2: Programmation par Contraintes | 9 | ~9h |
 | Applications | 20 | ~13h20 |
-| **Total** | **40** | **~34h50** |
+| Heritage (racine) | 5 | ~3h |
+| **Total** | **45** | **~38h** |
 
 | Statistique | Valeur |
 |-------------|--------|


### PR DESCRIPTION
## Summary
Consolidation README Search (track #623).
- Ajout ligne Heritage (5 notebooks legacy racine), total 40 -> 45 (aligne catalog)

Scope: prose README uniquement (commit po-2025, 1 fichier). Blocs CATALOG-STATUS non touches.

Co-authored-by: myia-po-2025
Closes part of #623