### PR TITLE
docs(readme): correct Sudoku/GameTheory/QuantConnect counters (#623)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -29,7 +29,7 @@ La Phase 3 couvre les sujets avancés et les applications. Le notebook 13 (CFR) 
 
 ## Structure
 
-**17 notebooks principaux** + **8 side tracks** (b = Lean, c = Python approfondissement) + **4 SocialChoice** (sous-serie dediee) = **29 notebooks**
+**17 notebooks principaux** + **7 side tracks** (4 Lean, 3 Python approfondissement) + **4 SocialChoice** (sous-serie dediee) = **28 notebooks**
 
 ### Partie 1 : Fondations et Jeux statiques (Notebooks 1-6)
 

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -41,7 +41,7 @@ Cette série est une formation complète sur le **trading algorithmique** avec l
 
 ### Contenu
 
-- **46 notebooks Python** (28 cours + 4 training local + 2 paper-trading + 12 Cloud-ready)
+- **51 notebooks Python** (28 cours + 3 training local + 2 paper-trading + 2 dataset + 12 Cloud-ready + 4 RL avance)
 - **18 notebooks sur fondations** avant ML (Universe, Asset Classes, Risk, Framework)
 - **9+ notebooks ML/DL/AI** (Supervised Learning, Deep Learning, Transformers, SSM, RL, LLM, Foundation Models)
 - **Free tier compatible** avec workarounds pour fonctionnalités payantes
@@ -196,7 +196,7 @@ Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders.
 
 ## Projets de Stratégies
 
-Le dossier [`projects/`](projects/) contient **67 stratégies de trading** prêtes à backtester.
+Le dossier [`projects/`](projects/) contient **115 stratégies de trading** prêtes à backtester.
 
 ### Comment utiliser les projets
 

--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -7,7 +7,7 @@ breakdown: =32
 maturity: BETA=23, PRODUCTION=8, ALPHA=1
 -->
 
-Cette serie de **32 notebooks** explore differentes techniques de resolution de Sudoku, des algorithmes classiques aux approches symboliques, probabilistes et neuronales. Les notebooks sont disponibles en **approche miroir C#/Python** pour permettre aux etudiants de choisir leur langage.
+Cette serie de **32 notebooks** (16 C#, 16 Python) explore differentes techniques de resolution de Sudoku, des algorithmes classiques aux approches symboliques, probabilistes et neuronales. Les notebooks sont disponibles en **approche miroir C#/Python** pour permettre aux etudiants de choisir leur langage.
 
 ## Pourquoi etudier le Sudoku en IA ?
 
@@ -48,7 +48,7 @@ Chaque approche reflete une philosophie differente de la resolution de problemes
 
 | Statistique | Valeur |
 |-------------|--------|
-| Notebooks | 33 (16 C#, 17 Python) |
+| Notebooks | 32 (16 C#, 16 Python) |
 | Duree estimee | ~8h |
 | Niveau | Debutant a avance |
 | Langages | C# (.NET Interactive), Python |


### PR DESCRIPTION
## Summary
Consolidation READMEs Sudoku + GameTheory + QuantConnect (track #623).
- Sudoku 33 -> 32 (16+16 mirror), GameTheory 29 -> 28 (7 side tracks), QuantConnect 46 -> 51 Python + strategies

Scope: prose README uniquement (commit po-2025, 3 fichiers). Blocs CATALOG-STATUS non touches.

Co-authored-by: myia-po-2025
Closes part of #623