### PR TITLE
feat(grading): EPITA SCIA 2026 PrCon grading config (#927 Phase 3)

### DIFF
--- a/GradeBookApp/configs/epf_2026_prcon.py
+++ b/GradeBookApp/configs/epf_2026_prcon.py
@@ -1,0 +1,92 @@
+"""
+Configuration EPITA SCIA 2026 - Programmation par Contraintes (PrCon)
+====================================================================
+
+Wrapper de configuration pour la notation collegiale du projet PrCon
+(soutenances 18 + 22 mai 2026, EPIC #927 Phase 3).
+
+Modele identique aux configs EPF (notation 50% prof / 50% etudiants,
+redressement statistique, bonus/malus selon la taille du groupe).
+
+PREREQUIS D'EXECUTION (deux exports manuels obligatoires)
+---------------------------------------------------------
+Le pipeline lit des CSV **separes par des virgules** (gradebook.load_*
+utilise pandas read_csv avec delimiter=','). Or les sources actuelles ne
+sont pas dans ce format. Avant de lancer ce script, exporter en CSV
+virgule (l'export par defaut de Google Sheets/Forms est deja en virgule) :
+
+1. EVALUATIONS (le blocage principal) :
+   "Epita - 2026 - PrCon - Evaluations (reponses)" est aujourd'hui un
+   pointeur .gsheet (188 octets), PAS un CSV. L'exporter en CSV virgule
+   sous le nom 'evaluations_path' ci-dessous.
+
+2. INSCRIPTIONS :
+   La source la plus recente est 'SCIA-2026-Inscription-PrCon.xlsx'
+   (22 mai). Le CSV existant 'SCIA-2026-Inscription-PrCon-2.csv' (18 mai)
+   est separe par des POINTS-VIRGULES et ne se chargera pas tel quel.
+   Re-exporter l'inscription a jour en CSV virgule sous 'inscriptions_path'.
+
+Tant que ces deux fichiers ne sont pas presents, run_pipeline() s'arrete
+proprement avec un message "Fichier introuvable" (pas de crash).
+
+NOTES DE NOTATION (verifiees 2026-05-23)
+----------------------------------------
+- Taille de groupe observee dans l'inscription : 1 a 4 (max = 4, 31 sujets
+  distincts). Le bareme par defaut de gradebook.py
+  {1:+3, 2:+1, 3:0, 4:-1} couvre donc exactement tous les groupes reels ;
+  aucun override n'est necessaire. (Si un groupe de 5/6 apparaissait apres
+  re-export, le defaut donnerait -2 ; le bareme PrCon voudrait -2 quint /
+  -3 sext : il faudrait alors etendre group_size_adjustments dans
+  gradebook.py.)
+- L'inscription liste 31 sujets ; le brief de handoff mentionnait ~34
+  groupes. Reconcilier (groupes non inscrits, ou sujets du formulaire
+  d'eval absents de l'inscription) avant transmission des notes.
+- Chaque groupe DOIT avoir une ligne d'evaluation prof (email ci-dessous)
+  sinon la note collegiale du groupe est incomplete. Verifier la
+  couverture prof avant export final.
+- Caveats par groupe (plagiat, projet non note, etc.) : voir le document
+  de revue 'EPITA-2026-PrCon-Review.md' (meme dossier G-drive). A integrer
+  manuellement, ce n'est pas du ressort de ce wrapper.
+"""
+
+from pathlib import Path
+
+# Dossier G-drive de la promo SCIA 2026 PrCon
+_GDRIVE = r"G:\Mon Drive\MyIA\Formation\Epita\2026"
+
+# Configuration specifique EPITA SCIA 2026 PrCon
+CONFIG = {
+    'nom_classe': 'EPITA SCIA 2026 - Programmation par Contraintes',
+
+    # Chemins des fichiers (a produire par export CSV virgule, cf docstring)
+    'inscriptions_path': rf"{_GDRIVE}\SCIA-2026-Inscription-PrCon-export.csv",
+    'evaluations_path': rf"{_GDRIVE}\Epita - 2026 - PrCon - Evaluations (reponses).csv",
+    'output_path': rf"{_GDRIVE}\Notes_Finales_PrCon_2026.xlsx",
+
+    # Mapping des colonnes du CSV d'inscription
+    # (verifie sur l'en-tete reel : F;Prenom;Nom;Mail;ID;Ordre de passage;Sujet...)
+    'column_mapping': {
+        "Prenom": "prenom",
+        "Nom": "nom",
+        "Sujet Projet de Programmation par Contrainte": "sujet_projet_1"
+    },
+
+    # Parametres de redressement statistique
+    'target_mean': 14.5,
+    'target_std': 2.0,
+
+    # Parametres de ponderation
+    'teacher_weight': 1.0,  # 50%/50% prof/etudiants
+    'professor_email': 'jsboige@gmail.com',
+
+    # Groupes blacklistes (doublons connus). Aucun pour PrCon a ce jour.
+    'blacklisted_groups': []
+}
+
+
+if __name__ == '__main__':
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from gradebook import run_pipeline
+    run_pipeline(CONFIG)


### PR DESCRIPTION
## Summary

Ajoute `GradeBookApp/configs/epf_2026_prcon.py` — wrapper `run_pipeline()` pour la notation collegiale du projet **Programmation par Contraintes** (soutenances 18 + 22 mai 2026, EPIC #927 Phase 3, transmission < 72h).

Meme modele que les configs EPF existantes (50% prof / 50% etudiants, redressement statistique, bonus/malus taille groupe).

## Verifie

- **column_mapping** valide sur l'en-tete reel de l'inscription : `F;Prenom;Nom;Mail;ID;Ordre de passage;Sujet Projet de Programmation par Contrainte` -> `{Prenom, Nom, Sujet...}`.
- **Bareme taille groupe** : distribution reelle = 1 a 4 (max 4, 31 sujets). Le defaut `gradebook.py` `{1:+3, 2:+1, 3:0, 4:-1}` couvre exactement tous les groupes -> **aucun override de code necessaire** (sext=-3 moot).
- `target_mean=14.5`, `target_std=2.0`, `teacher_weight=1.0`, `professor_email=jsboige@gmail.com`.
- Import OK (10 cles), pas de modif de `gradebook.py`, additif (1 fichier).

## Prerequis d'execution (documentes dans le docstring)

Le pipeline lit des CSV **virgule**. Avant de lancer :
1. **Evaluations** (blocage principal) : `Epita - 2026 - PrCon - Evaluations (reponses)` est un pointeur `.gsheet` (188 o), pas un CSV -> exporter en CSV virgule.
2. **Inscription** : `SCIA-2026-Inscription-PrCon-2.csv` (18 mai) est en **point-virgule** ; source la plus a jour = `.xlsx` (22 mai) -> re-exporter en CSV virgule.

Tant que les fichiers manquent, `run_pipeline()` s'arrete proprement (guard `gradebook.py:689-695`, retourne None, pas de crash).

## A reconcilier hors PR

- 31 sujets inscrits vs ~34 groupes attendus (handoff) -> verifier couverture.
- Chaque groupe doit avoir une ligne d'eval prof.
- Caveats par groupe : voir `EPITA-2026-PrCon-Review.md` (G-drive).
- Env de run : deps `gradebook.py` = pandas, numpy, unidecode, openpyxl, rapidfuzz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)