### PR TITLE
feat(qc): embed Lot 6 backtest metrics into QC-Py-03 (7 cells)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -147,6 +147,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `DataExplorationAlgo`  ",
+    "> **Dates tradeables** : 2516  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : Data exploration only (History, pandas stats)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> **Resultat du Backtest QC Cloud** — DataExplorationAlgo (BT e52e4dbc..., projet 32037)\n>\n> | Sharpe | CAGR | MaxDD | Trades |\n> |--------|------|-------|--------|\n> | - | - | - | 0 (data exploration) |"
    ]
   },
@@ -282,6 +295,19 @@
     "        self.Log(f\"Low: ${latest_bar['low']:.2f}\")\n",
     "        self.Log(f\"Close: ${latest_bar['close']:.2f}\")\n",
     "        self.Log(f\"Volume: {latest_bar['volume']:.0f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `HistorySignaturesDemo`  ",
+    "> **Dates tradeables** : 2516  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : Multi-signature History API demo*"
    ]
   },
   {
@@ -430,6 +456,19 @@
     "        # Retour Adjusted (CORRECT)\n",
     "        return_adjusted = (df_adjusted.loc[after_split, 'close'] / df_adjusted.loc[before_split, 'close']) - 1\n",
     "        self.Log(f\"Retour avec Adjusted: {return_adjusted:.2%} (CORRECT)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `DataNormalizationDemo`  ",
+    "> **Dates tradeables** : 2516  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : Fixed: added DataFrame length checks for Raw/SplitAdjusted modes. v2 backtest.*"
    ]
   },
   {
@@ -684,6 +723,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `ConsolidatorByCountDemo`  ",
+    "> **Dates tradeables** : 61  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : Converted Minute→Daily, 5-bar consolidator. Jan-Mar 2015.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 4.6 Avantages des Consolidators\n",
     "\n",
     "| Avantage | Description |\n",
@@ -929,6 +981,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `PandasAnalysisDemo`  ",
+    "> **Dates tradeables** : 2863  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : SPY pandas analysis (returns, volatility, Sharpe)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 6.3 Analyse avec rolling windows"
    ]
   },
@@ -983,6 +1048,19 @@
     "            self.Log(\"Signal: FORTE TENDANCE BAISSIÈRE (Death Cross)\")\n",
     "        else:\n",
     "            self.Log(\"Signal: TENDANCE MIXTE (Range)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `RollingAnalysisDemo`  ",
+    "> **Dates tradeables** : 2863  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : AAPL rolling SMA 20/50/200 + trend analysis*"
    ]
   },
   {
@@ -1048,6 +1126,19 @@
     "        self.Log(f\"SPY-TLT: {spy_tlt_corr:.2f} (Stocks-Bonds: corrélation négative = bon hedge)\")\n",
     "        self.Log(f\"SPY-GLD: {spy_gld_corr:.2f} (Stocks-Or: corrélation faible = diversification)\")\n",
     "        self.Log(f\"SPY-QQQ: {spy_qqq_corr:.2f} (S&P-Nasdaq: corrélation forte = même secteur)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Resultats du Backtest QC Cloud**",
+    "> ",
+    "> **Algorithme** : `CorrelationAnalysisDemo`  ",
+    "> **Dates tradeables** : 2863  ",
+    "> **Ordres executes** : 0  ",
+    "> **Equity finale** : $100,000.00  ",
+    "> *Note : SPY/TLT/GLD/QQQ correlation matrix*"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Backtested 7 REFERENCE QC cells from QC-Py-03-Data-Management.ipynb via QC Cloud MCP (project 32005992)
- All 7 algorithms completed without errors (data exploration only, 0 orders)
- Embedded backtest metrics as markdown cells after each REF code cell

## Backtest Results

| Cell | Algorithm | Dates | Orders | Note |
|------|-----------|-------|--------|------|
| 5 | DataExplorationAlgo | 2516 | 0 | AAPL History pandas stats |
| 10 | HistorySignaturesDemo | 2516 | 0 | Multi-signature History API |
| 15 | DataNormalizationDemo | 2516 | 0 | Fixed: DataFrame len checks for Raw/SplitAdjusted |
| 24 | ConsolidatorByCountDemo | 61 | 0 | Converted Minute→Daily, 5-bar consolidator |
| 35 | PandasAnalysisDemo | 2863 | 0 | SPY returns/volatility/Sharpe |
| 37 | RollingAnalysisDemo | 2863 | 0 | AAPL SMA 20/50/200 + trend |
| 39 | CorrelationAnalysisDemo | 2863 | 0 | SPY/TLT/GLD/QQQ correlation |

## Test plan
- [x] All 7 backtests completed via QC Cloud MCP (compile + backtest SUCCESS)
- [x] Metrics JSON saved at `temp_qc_cells/lot6_metrics.json`
- [x] Markdown cells embedded bottom-to-top preserving indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)