### PR TITLE
feat(qc): Lot 7 — QC-Py-05 Universe Selection backtest metrics (11 cells)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -196,6 +196,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `FAANGManualUniverse`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.84 | 27.526% | 50.700% | +1039.578% | 5 | $1,139,577.97 |\n\n*FAANG buy-and-hold, 2015-2024*\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : FAANGManualUniverse (2015-2024, $100k) — 9 ordres, Net Profit +38.7%, Sharpe 0.387, CAGR 8.8%, MaxDD 33.6%. Equal-weight FAANG sans rebalancement.",
    "metadata": {}
   },
@@ -258,6 +265,13 @@
     "        self.all_symbols = list(self.stocks.values()) + list(self.etfs.values())\n",
     "        \n",
     "        self.Log(f\"Multi-asset universe: {len(self.stocks)} stocks, {len(self.etfs)} ETFs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `MultiAssetManualUniverse`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Multi-asset exploration, no trading*\n---"
    ]
   },
   {
@@ -383,6 +397,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `CoarseUniverseAlgorithm`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Coarse selection only, 2020-2024*\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : CoarseUniverseAlgorithm (2015-2024, $100k) — 0 ordres, Net Profit 0%. Demo Coarse Selection (Top 100 par volume). La selection s'execute mais OnData est vide — pas de trading.",
    "metadata": {}
   },
@@ -492,6 +513,13 @@
     "        sorted_stocks = sorted(filtered, key=lambda x: x.DollarVolume, reverse=True)\n",
     "        \n",
     "        return [x.Symbol for x in sorted_stocks[:self.num_stocks]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `MonthlyCoarseUniverse`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Monthly coarse reselection, 2020-2024*\n---"
    ]
   },
   {
@@ -634,6 +662,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `TechValueUniverse`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Coarse+Fine tech/value selection, 2020-2024*\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : TechValueUniverse (2015-2024, $100k) — 0 ordres, Net Profit 0%. Demo Coarse+Fine Selection (Tech sector, P/E < 30). La selection fonctionne mais pas de logique de trading dans OnData.",
    "metadata": {}
   },
@@ -724,6 +759,13 @@
     "        self.Log(f\"Fine: {len(fine)} total -> {len(large_cap)} large -> {len(dividend_payers)} dividend -> {len(value_stocks)} value\")\n",
     "        \n",
     "        return [x.Symbol for x in sorted_by_yield[:self.num_stocks]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `DividendValueUniverse`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*Coarse+Fine dividend/value selection, 2020-2024*\n---"
    ]
   },
   {
@@ -820,6 +862,13 @@
     "        \n",
     "        sorted_stocks = sorted(filtered, key=lambda x: x.DollarVolume, reverse=True)\n",
     "        return [x.Symbol for x in sorted_stocks[:50]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `UniverseSettingsExample`\n\n| Resultat | End Equity |\n|----------|------------|\n| Exploration (0 ordre) | $100,000.00 |\n\n*UniverseSettings demo, 2020-2024*\n---"
    ]
   },
   {
@@ -958,6 +1007,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `DynamicRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.2 | 6.610% | 48.800% | +37.769% | 1292 | $137,768.70 |\n\n*Dynamic rebalancing on universe change, 2020-2024*\n---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : DynamicRebalancingAlgorithm (2015-2024, $100k) — 2461 ordres, Net Profit +179.7%, Sharpe 0.406, CAGR 10.8%, MaxDD 38.7%, Win Rate 72%. Top 20 mensuel, equal-weight via OnSecuritiesChanged.",
    "metadata": {}
   },
@@ -1057,6 +1113,13 @@
     "            if abs(current_weight - target_weight) > self.tolerance:\n",
     "                self.SetHoldings(symbol, target_weight)\n",
     "                self.Debug(f\"Rebalanced {symbol.Value}: {current_weight:.1%} -> {target_weight:.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `SmartRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.207 | 6.393% | 28.500% | +36.371% | 51 | $136,370.80 |\n\n*Tolerance-based rebalancing (5% threshold), 2020-2024*\n---"
    ]
   },
   {
@@ -1184,6 +1247,13 @@
     "            self.Log(f\"Added: {[s.Symbol.Value for s in changes.AddedSecurities]}\")\n",
     "        if len(changes.RemovedSecurities) > 0:\n",
     "            self.Log(f\"Removed: {[s.Symbol.Value for s in changes.RemovedSecurities]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `ScheduledRebalancingAlgorithm`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.252 | 8.253% | 45.400% | +48.725% | 1098 | $148,725.36 |\n\n*Scheduled monthly rebalancing, 2020-2024*\n---"
    ]
   },
   {
@@ -1437,6 +1507,13 @@
     "        total_return = (self.Portfolio.TotalPortfolioValue - self.StartingCash) / self.StartingCash\n",
     "        self.Log(f\"Total Return: {total_return:.1%}\")\n",
     "        self.Log(\"=\"*50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Backtest QC Cloud** : `MomentumUniverseStrategy`\n\n| Sharpe | CAGR | MaxDD | Net Profit | Orders | End Equity |\n|--------|------|-------|------------|--------|------------|\n| 0.208 | 9.008% | 19.000% | +29.561% | 667 | $129,560.80 |\n\n*Momentum coarse+fine, 2022-2024, lookback=126d*\n---"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- 11 REFERENCE QC cells from QC-Py-05-Universe-Selection.ipynb backtested via QC Cloud MCP (project 32005992)
- Embedded markdown result cells after each REF code cell with Sharpe/CAGR/MaxDD/Net Profit/Orders

## Backtest Results

| Cell | Algorithm | Sharpe | CAGR | MaxDD | Net Profit | Orders |
|------|-----------|--------|------|-------|------------|--------|
| 5 | FAANGManualUniverse | 0.84 | 27.5% | 50.7% | +1039.6% | 5 |
| 8 | MultiAssetManualUniverse | - | - | - | 0% | 0 |
| 11 | CoarseUniverseAlgorithm | - | - | - | 0% | 0 |
| 14 | MonthlyCoarseUniverse | - | - | - | 0% | 0 |
| 17 | TechValueUniverse | - | - | - | 0% | 0 |
| 20 | DividendValueUniverse | - | - | - | 0% | 0 |
| 23 | UniverseSettingsExample | - | - | - | 0% | 0 |
| 27 | DynamicRebalancingAlgorithm | 0.20 | 6.6% | 48.8% | +37.8% | 1292 |
| 30 | SmartRebalancingAlgorithm | 0.21 | 6.4% | 28.5% | +36.4% | 51 |
| 33 | ScheduledRebalancingAlgorithm | 0.25 | 8.3% | 45.4% | +48.7% | 1098 |
| 37 | MomentumUniverseStrategy | 0.21 | 9.0% | 19.0% | +29.6% | 667 |

Cells with 0 orders are exploration/demos (universe selection without trading logic).

## Test plan
- [x] All 11 cells compiled and backtested via MCP qc-mcp
- [x] Metrics embedded as markdown cells in notebook
- [ ] Visual review of notebook rendering

Closes part of #969 (Voie 2 QC Cloud execution, Lot 7/34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)