### PR TITLE
feat(qc): embed QC Cloud backtest metrics into QC-Py-06 Options Trading

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -244,6 +244,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (BasicOptionsSetup)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*Options setup exploration, Q1 2023*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : BasicOptionsSetup (2023, $100k) — 0 ordres, Net Profit 0%. Demo de configuration de base (AddOption, SetFilter, OptionChains). Pas de logique de trading.",
    "metadata": {}
   },
@@ -382,6 +389,13 @@
     "            self.Log(f\"  IV: {atm_put.ImpliedVolatility:.2%} | OI: {atm_put.OpenInterest}\")\n",
     "        \n",
     "        self.logged = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (OptionChainNavigation)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*Option chain navigation exploration, Q1 2023*"
    ]
   },
   {
@@ -632,6 +646,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (GreeksAnalysis)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*Greeks analysis exploration, Q1 2023*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : GreeksAnalysis (2023 Q1, $100k) — 0 ordres, Net Profit 0%. Demo d'analyse des Greeks (Delta, Gamma, Theta, Vega, Rho). Affiche les Greeks du call ATM une seule fois, pas de trading.",
    "metadata": {}
   },
@@ -818,6 +839,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (CoveredCallStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 7 |\n| Sharpe Ratio | 0.061 |\n| CAGR | 7.011% |\n| Max Drawdown | 6.100% |\n| Net Profit | +1.684% |\n| Equity finale | $50,842.00 |\n\n*Covered Call SPY delta 0.30, Q1 2023*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : CoveredCallStrategy (2023, $50k) — 26 ordres, Net Profit +12.9%, Sharpe 0.608, CAGR 13.0%, MaxDD 6.1%, Win Rate 57%. Performance solide : premium regulier + appreciation du sous-jacent SPY en 2023. MaxDD maitrise (6.1%). Strategie de revenu confirmee.",
    "metadata": {}
   },
@@ -956,6 +984,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (ProtectivePutStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 7 |\n| Sharpe Ratio | 1.948 |\n| CAGR | 23.093% |\n| Max Drawdown | 2.200% |\n| Net Profit | +5.254% |\n| Equity finale | $63,152.50 |\n\n*Protective Put ATM, Q1 2023*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : ProtectivePutStrategy (2023 H1, $60k) — 13 ordres, Net Profit +8.1%, Sharpe 1.362, CAGR 17.0%, MaxDD 2.2%, Win Rate 33%. Excelle protection : MaxDD tres faible (2.2%) grace au put de couverture. Sharpe eleve car volatilite reduite. Le cout du put limite le gain mais protege efficacement.",
    "metadata": {}
   },
@@ -1085,6 +1120,13 @@
     "        self.MarketOrder(short_call.Symbol, -1) # Vendre 1 call\n",
     "        \n",
     "        self.spread_opened = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (BullCallSpreadStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 4 |\n| Sharpe Ratio | -1.848 |\n| CAGR | 1.510% |\n| Max Drawdown | 0.700% |\n| Net Profit | +0.370% |\n| Equity finale | $10,037.00 |\n\n*Bull Call Spread ATM/OTM, Q1 2023*"
    ]
   },
   {
@@ -1263,6 +1305,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (IronCondorStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $20,000.00 |\n\n*Iron Condor exploration, Q1 2023 (no matching contracts)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "> **Resultats backtest QC Cloud** : IronCondorStrategy (2023 H1, $20k) — 0 ordres, Net Profit 0%. L'Iron Condor n'a pas execute de trades. Possible cause : filtre de liquidite trop strict ou aucun contrat avec les strikes/expiration cibles dans la range -10/+10 strikes.",
    "metadata": {}
   },
@@ -1356,6 +1405,13 @@
     "            self.Debug(f\"Order filled: {orderEvent.Symbol}, \" +\n",
     "                       f\"Qty: {orderEvent.FillQuantity}, \" +\n",
     "                       f\"Price: ${orderEvent.FillPrice:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (AssignmentHandling)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 0 |\n| Sharpe Ratio | 0 |\n| CAGR | 0% |\n| Max Drawdown | 0% |\n| Net Profit | 0% |\n| Equity finale | $100,000.00 |\n\n*Assignment event handler demo, Q1 2023*"
    ]
   },
   {
@@ -1604,6 +1660,13 @@
     "        if self.trades_count > 0:\n",
     "            self.Log(f\"  Average Premium/Trade: ${self.total_premium/self.trades_count:.2f}\")\n",
     "        self.Log(f\"{'='*60}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (CoveredCallWithRoll)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Dates negociables | 62 |\n| Ordres executes | 6 |\n| Sharpe Ratio | 0.493 |\n| CAGR | 11.372% |\n| Max Drawdown | 4.200% |\n| Net Profit | +2.690% |\n| Equity finale | $56,479.50 |\n\n*Covered Call with auto-roll delta 0.30, Q1 2023*"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Lot 8 of Voie 2 QC Cloud execution (#969): 8 backtests via MCP qc-mcp for QC-Py-06-Options-Trading notebook
- Embed backtest result markdown cells (Sharpe, CAGR, MaxDD, Net Profit, End Equity) after each REF QC algorithm cell
- Project ID 32005992, org `d600793ee4caecb03441a09fc2d00f7f` (research tier)

## Backtest Results

| Strategy | Orders | Sharpe | CAGR | MaxDD | Net Profit | End Equity |
|----------|--------|--------|------|-------|------------|------------|
| BasicOptionsSetup | 0 | 0 | 0% | 0% | 0% | $100,000 |
| OptionChainNavigation | 0 | 0 | 0% | 0% | 0% | $100,000 |
| GreeksAnalysis | 0 | 0 | 0% | 0% | 0% | $100,000 |
| CoveredCallStrategy | 7 | 0.061 | 7.011% | 6.100% | +1.684% | $50,842 |
| ProtectivePutStrategy | 7 | 1.948 | 23.093% | 2.200% | +5.254% | $63,152 |
| BullCallSpreadStrategy | 4 | -1.848 | 1.510% | 0.700% | +0.370% | $10,037 |
| IronCondorStrategy | 0 | 0 | 0% | 0% | 0% | $20,000 |
| AssignmentHandling | 0 | 0 | 0% | 0% | 0% | $100,000 |
| CoveredCallWithRoll | 6 | 0.493 | 11.372% | 4.200% | +2.690% | $56,479 |

## Test plan
- [x] All 8 backtests completed via MCP qc-mcp (compile + backtest + read results)
- [x] Metrics embedded as markdown cells in correct positions
- [x] Notebook structure preserved (no source code changes)
- [ ] Review notebook visually for correct placement

Closes #969 (partial — QC-Py-06 done, remaining notebooks in subsequent lots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)