### PR TITLE
feat(qc): embed QC Cloud backtest metrics for QC-Py-13 Alpha Models (lot 12)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -244,6 +244,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---\n**Resultats du backtest QC Cloud (BasicFrameworkAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | 4.907 |\n| Sortino Ratio | 8.969 |\n| CAGR | 205.139% |\n| Net Profit | 31.513% |\n| Total Orders | 100 |\n| Trades | 82 |\n| Win Rate | 64.6% |\n| Max Drawdown | 6.1% |\n| Equity finale | $131,512.64 |\n| Total Fees | $140.59 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Avantages du Framework vs Approche Traditionnelle\n",
     "\n",
     "| Aspect | Approche Traditionnelle | Algorithm Framework |\n",
@@ -561,6 +568,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---\n**Resultats du backtest QC Cloud (InsightDemoAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | 0 |\n| Sortino Ratio | 0 |\n| CAGR | 0% |\n| Net Profit | 0% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0% |\n| Equity finale | $100,000.00 |\n| Total Fees | $0.00 |\n\n*EmitInsights without Framework components - no trades executed*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "---\n",
     "\n",
     "## Partie 3 : Alpha Models Built-In (25 min)\n",
@@ -648,6 +662,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---\n**Resultats du backtest QC Cloud (EmaCrossAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | 2.627 |\n| Sortino Ratio | 4.867 |\n| CAGR | 121.195% |\n| Net Profit | 21.523% |\n| Total Orders | 74 |\n| Trades | 62 |\n| Win Rate | 71.0% |\n| Max Drawdown | 9.4% |\n| Equity finale | $121,523.16 |\n| Total Fees | $150.08 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 3.2 MacdAlphaModel\n",
     "\n",
     "Le **MacdAlphaModel** utilise l'indicateur MACD (Moving Average Convergence Divergence) :\n",
@@ -726,6 +747,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---\n**Resultats du backtest QC Cloud (MacdAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -1.748 |\n| Sortino Ratio | -2.191 |\n| CAGR | -24.763% |\n| Net Profit | -6.748% |\n| Total Orders | 92 |\n| Trades | 71 |\n| Win Rate | 23.9% |\n| Max Drawdown | 8.9% |\n| Equity finale | $93,251.84 |\n| Total Fees | $102.55 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 3.3 RsiAlphaModel\n",
     "\n",
     "Le **RsiAlphaModel** utilise le Relative Strength Index pour detecter les conditions de surachat et survente :\n",
@@ -794,6 +822,13 @@
     "print(\"\\nLogique interne:\")\n",
     "print(\"  - RSI < 30 (oversold) -> Insight.Up\")\n",
     "print(\"  - RSI > 70 (overbought) -> Insight.Down\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (RsiAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -0.571 |\n| Sortino Ratio | -0.511 |\n| CAGR | -33.444% |\n| Net Profit | -2.756% |\n| Total Orders | 84 |\n| Trades | 77 |\n| Win Rate | 31.2% |\n| Max Drawdown | 13.4% |\n| Equity finale | $97,244.30 |\n| Total Fees | $155.01 |"
    ]
   },
   {
@@ -1092,6 +1127,13 @@
     "print(\"MomentumFrameworkAlgorithm defini\")\n",
     "print(\"\\nUsage:\")\n",
     "print(\"  self.SetAlpha(MomentumAlphaModel(lookback=252, up_threshold=0.10))\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (MomentumFrameworkAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -3.495 |\n| Sortino Ratio | -4.909 |\n| CAGR | -26.434% |\n| Net Profit | -7.261% |\n| Total Orders | 396 |\n| Trades | 0 |\n| Win Rate | 29.0% |\n| Max Drawdown | 8.1% |\n| Equity finale | $92,738.97 |\n| Total Fees | $421.19 |"
    ]
   },
   {
@@ -1526,6 +1568,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "---\n**Resultats du backtest QC Cloud (CompositeAlphaAlgorithm)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -1.24 |\n| Sortino Ratio | -1.484 |\n| CAGR | -21.258% |\n| Net Profit | -5.7% |\n| Total Orders | 606 |\n| Trades | 0 |\n| Win Rate | 46.0% |\n| Max Drawdown | 11.2% |\n| Equity finale | $94,300.46 |\n| Total Fees | $624.72 |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Composite avec Custom Alpha Models\n",
     "\n",
     "Vous pouvez combiner des Alpha Models built-in avec vos propres modeles personnalises."
@@ -1901,6 +1950,13 @@
     "print(\"  3. Portfolio equal-weight\")\n",
     "print(\"  4. Execution immediate\")\n",
     "print(\"  5. Risk management (5% max drawdown)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n**Resultats du backtest QC Cloud (CompleteFrameworkStrategy)**\n\n| Metrique | Valeur |\n|----------|--------|\n| Statut | Completed |\n| Sharpe Ratio | -2.501 |\n| Sortino Ratio | -3.404 |\n| CAGR | -32.525% |\n| Net Profit | -9.241% |\n| Total Orders | 1008 |\n| Trades | 0 |\n| Win Rate | 33.0% |\n| Max Drawdown | 11.5% |\n| Equity finale | $90,759.08 |\n| Total Fees | $1006.31 |"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Execute 8 Algorithm Framework cells from QC-Py-13-Alpha-Models.ipynb via QC Cloud MCP backtests (project 32005992, Q1 2023)
- Embed backtest results as markdown cells after each reference algorithm cell

## Backtest Results

| # | Algorithm | Sharpe | Net Profit | Max DD | Orders |
|---|-----------|--------|------------|--------|--------|
| 6 | BasicFrameworkAlgorithm | **4.907** | **+31.5%** | 6.1% | 100 |
| 13 | EmaCrossAlgorithm | **2.627** | **+21.5%** | 9.4% | 74 |
| 11 | InsightDemoAlgorithm | 0.000 | 0.0% | 0% | 0 |
| 17 | RsiAlgorithm | -0.571 | -2.8% | 13.4% | 84 |
| 28 | CompositeAlphaAlgorithm | -1.240 | -5.7% | 11.2% | 606 |
| 15 | MacdAlgorithm | -1.748 | -6.7% | 8.9% | 92 |
| 34 | CompleteFrameworkStrategy | -2.501 | -9.2% | 11.5% | 1008 |
| 22 | MomentumFrameworkAlgorithm | -3.495 | -7.3% | 8.1% | 396 |

Key findings:
- **BasicFramework** and **EmaCross** are the only profitable strategies in Q1 2023
- All other alpha models underperform during this bear/reversal period
- CompositeAlpha (3 models combined) does NOT improve over individual models

## Test plan
- [x] 8/8 backtests completed via QC Cloud MCP
- [x] Metrics embedded in notebook
- [ ] Visual review of embedded markdown cells

closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)