### PR TITLE
feat(qc): embed QC Cloud backtest metrics into QC-Py-16 Alternative Data (#969)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -349,6 +349,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> FundamentalsExplorerAlgorithm — Universe only, no OnData trading\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 2.2 Strategie Value Complete\n",
@@ -538,6 +549,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> ValueInvestingStrategy — Universe + OnSecuritiesChanged rebalance (90d window, only 1 cycle in Q1)\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 2.3 Secteurs Morningstar\n",
@@ -568,6 +590,17 @@
    "metadata": {},
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> SectorFilterExample — Universe sector filter only, no trading logic\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -669,6 +702,17 @@
     "print(\"  - Detection d'acquisitions (Item 2.01)\")\n",
     "print(\"  - Earnings surprises (Item 2.02)\")\n",
     "print(\"  - Changements de direction (Item 5.02)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> SEC8KAlgorithm — OnData passes, no SEC data source connected\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
    ]
   },
   {
@@ -1165,6 +1209,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> NewsAPIAlgorithm — OnData passes, no news data source connected\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 4.2 Donnees CSV Locales\n",
@@ -1338,6 +1393,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> CSVDataAlgorithm — OnData passes, no CSV data loaded (last_gdp/last_inflation stay None)\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### 5.2 FRED Data Integration\n",
     "\n",
@@ -1364,6 +1430,17 @@
    "metadata": {},
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> YieldCurveAlgorithm — Rebalance() passes, no FRED data source connected\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1489,6 +1566,17 @@
     "print(\"  - BULLISH: SPY > SMA200 et momentum positif\")\n",
     "print(\"  - BEARISH: SPY < SMA200 et momentum negatif\")\n",
     "print(\"  - NEUTRAL: conditions mixtes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 2.147 |\n| Sortino Ratio | 2.962 |\n| CAGR | 39.1% |\n| Net Profit | 8.45% |\n| Total Orders | 9 |\n| Trades | 4 |\n| Win Rate | 67% |\n| Max Drawdown | 5.5% |\n| End Equity | $108,445.61 |\n| Total Fees | $12.04 |\n| Backtest ID |  |\n\n> MacroTacticalAllocation — REAL TRADING: SMA(200)+ROC(20) regime, monthly rebalance\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
    ]
   },
   {
@@ -1666,6 +1754,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | -1.452 |\n| Sortino Ratio | -1.471 |\n| CAGR | -19.7% |\n| Net Profit | -5.26% |\n| Total Orders | 30 |\n| Trades | 6 |\n| Win Rate | 0% |\n| Max Drawdown | 11.0% |\n| End Equity | $94,737.37 |\n| Total Fees | $30.00 |\n| Backtest ID |  |\n\n> MultiSourceAlternativeDataStrategy — REAL TRADING: Value+Quality+Momentum universe, regime-based allocation\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a1911fcf",
    "metadata": {},
    "source": [
@@ -1817,6 +1916,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | -1.395 |\n| Sortino Ratio | -1.495 |\n| CAGR | -32.6% |\n| Net Profit | -9.28% |\n| Total Orders | 387 |\n| Trades | 157 |\n| Win Rate | 25% |\n| Max Drawdown | 16.9% |\n| End Equity | $90,724.90 |\n| Total Fees | $364.97 |\n| Backtest ID |  |\n\n> EarningsMomentumStrategy — REAL TRADING: MOMP(20) momentum scanner, >5% entry\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 6.2 Post-Earnings Announcement Drift (PEAD)\n",
@@ -1914,6 +2024,17 @@
     "print(\"  SUE = (Actual - Expected) / StdDev\")\n",
     "print(\"  SUE > 1: Positive surprise -> Buy\")\n",
     "print(\"  SUE < -1: Negative surprise -> Short\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "backtest-result"
+    ]
+   },
+   "source": [
+    "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> PEADStrategy — No entry trigger (ProcessEarningsSurprise never called)\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- 11 REFERENCE strategy cells from QC-Py-16 backtested via QC Cloud MCP (project 32005992)
- Results embedded as markdown result cells after each strategy code cell
- Period: Q1 2023, Initial capital: $100,000

## Backtest Results

| Cell | Strategy | Sharpe | CAGR | Net Profit | Trades | Notes |
|------|----------|--------|------|------------|--------|-------|
| 7 | FundamentalsExplorer | 0 | 0% | 0% | 0 | Universe only |
| 9 | ValueInvesting | 0 | 0% | 0% | 0 | Universe + rebalance (90d window) |
| 11 | SectorFilter | 0 | 0% | 0% | 0 | Universe filter only |
| 13 | SEC8K | 0 | 0% | 0% | 0 | No SEC data source |
| 22 | NewsAPI | 0 | 0% | 0% | 0 | No news data source |
| 24 | CSVData | 0 | 0% | 0% | 0 | No CSV data loaded |
| 26 | YieldCurve | 0 | 0% | 0% | 0 | Rebalance passes |
| **28** | **MacroTactical** | **2.147** | **39.1%** | **+8.4%** | **4** | **Best performer** |
| 30 | MultiSourceAltData | -1.452 | -19.7% | -5.3% | 6 | All trades lost |
| 32 | EarningsMomentum | -1.395 | -32.6% | -9.3% | 157 | 25% win rate |
| 34 | PEAD | 0 | 0% | 0% | 0 | No entry trigger |

## Test plan
- [x] All 11 cells compiled and backtested successfully via QC Cloud MCP
- [x] Metrics JSON saved at `temp_qc_cells/lot15_metrics.json`
- [x] Markdown result cells inserted after each REF code cell (bottom-to-top)

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)