### PR TITLE
feat(qc): embed QC Cloud backtest metrics for QC-Py-17/27/28 (Lot 16)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -1537,6 +1537,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dfb5ea72",
+   "metadata": {},
+   "source": [
+    "> **Resultat du backtest QC Cloud** - `SentimentTradingAlgorithm` (periode 2015-01-01 a 2024-12-31, $100k initial)\n",
+    ">\n",
+    "> | Metrique | Valeur |\n",
+    "> |----------|--------|\n",
+    "> | Statut | COMPLETED |\n",
+    "> | Ordres | 0 |\n",
+    "> | Sharpe | 0 |\n",
+    "> | Net Profit | 0% |\n",
+    "> | End Equity | $100,000 |\n",
+    ">\n",
+    "> **Note** : Skeleton sans source de donnees de sentiment - le Custom Data (`SentimentData`) n'est pas disponible en backtest standard. L'algorithme illustre le pattern d'integration de donnees alternative, mais ne peut pas generer de signaux sans feed de sentiment reel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c910b64e",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -605,6 +605,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "> **Resultat du backtest QC Cloud** - `PaperTradingAlgorithm` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 2 |\n> | Sharpe | -2.16 |\n> | Net Profit | -2.46% |\n> | CAGR | -10.1% |\n> | Max Drawdown | 3.2% |\n> | End Equity | $97,537.51 |\n>\n> **Note** : SMA 10/30 crossover sur SPY, 1 trade (perte) en Q1 2023. Le cross-over simple est trop lent pour une periode courte de 3 mois. La strategie a achete en janvier et vendu a perte en mars, coherent avec le sharpe negatif.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "75a52b96",
    "metadata": {},
    "source": [
@@ -956,6 +961,11 @@
     "print(\"  - Max 20 trades per day\")\n",
     "print(\"  - Auto-liquidation on breach\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "> **Resultat du backtest QC Cloud** - `LiveTradingAlgorithm` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 0 |\n> | Sharpe | 0 |\n> | Net Profit | 0% |\n> | End Equity | $100,000 |\n>\n> **Note** : Risk manager skeleton - aucune logique de trading, reset quotidien uniquement. Le framework de risque (position sizing, daily loss limit, trade limit) est en place mais ne genere pas de signaux.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -374,6 +374,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "> **Resultat du backtest QC Cloud** - `RegimeSwitching` (periode 2023-01-01 a 2023-03-31, $100k initial)\n>\n> | Metrique | Valeur |\n> |----------|--------|\n> | Statut | COMPLETED |\n> | Ordres | 32 |\n> | Trades | 18 |\n> | Sharpe | **1.731** |\n> | Sortino | 2.446 |\n> | Net Profit | **+8.74%** |\n> | CAGR | 40.675% |\n> | Max Drawdown | 6.9% |\n> | Win Rate | 71% |\n> | Alpha | 0.083 |\n> | Beta | 0.781 |\n> | End Equity | $108,741.30 |\n>\n> **Performance solide** : La strategie regime-switching (bull/bear/sideways via SMA50/200, RSI mean-reversion, trailing stop -10%) genere un Sharpe > 1.7 sur Q1 2023 avec un drawdown contenu sous 7%. Le win rate de 71% et le alpha positif confirment l'edge de l'approche adaptive.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",


### PR DESCRIPTION
## Summary
- Embed QC Cloud backtest results for 4 REFERENCE QC cells across 3 notebooks (Lot 16)
- **QC-Py-17** `SentimentTradingAlgorithm`: COMPLETED, 0 trades (no sentiment data source in backtest)
- **QC-Py-27** `PaperTradingAlgorithm`: COMPLETED, 2 orders, Sharpe -2.16, -2.46% (SMA crossover too slow for Q1 2023)
- **QC-Py-27** `LiveTradingAlgorithm`: COMPLETED, 0 trades (risk manager skeleton, no trading logic)
- **QC-Py-28** `RegimeSwitching`: COMPLETED, 32 orders, **Sharpe 1.731**, +8.74%, CAGR 40.7%, MaxDD 6.9%, Win Rate 71%

## Test plan
- [x] 4/4 backtests COMPLETED via QC Cloud MCP (project 32005992, research org)
- [x] Result markdown cells inserted after each REFERENCE QC code cell
- [x] Metrics match lot16_metrics.json
- [x] No source code modified (markdown insertions only)

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)