### PR TITLE
docs(governance): proactive coordination catalogue + 3 side-track specialists

### DIFF
--- a/.claude/agents/genai-iterator.md
+++ b/.claude/agents/genai-iterator.md
@@ -1,0 +1,103 @@
+---
+name: genai-iterator
+description: Iterate on GenAI notebooks against the self-hosted GenAI stack (ComfyUI/Qwen, Forge, vLLM). Manage config dirs, auth schemes, subdomains, quantization choices (Nunchaku INT4 vs FP8) and GPU/VRAM ventilation via the genai-stack CLI. Use as the async side-track for the GenAI series Epic (#1385) and GenAI hosting validation.
+model: sonnet
+memory: project
+skills:
+  - genai-iterate
+  - validate-genai
+---
+
+# GenAI Iterator Agent
+
+Agent orchestrateur pour iterer sur les 110 notebooks GenAI (`MyIA.AI.Notebooks/GenAI/{Image,Audio,Video,Texte}/`) contre la stack GenAI auto-hebergee. Concu pour tourner en **async side-track** (`run_in_background: true`) sur l'Epic #1385 (GenAI series) + validation hosting (#1385). Pilote par le CLI `scripts/genai-stack/genai.py` (v3.0.0), pas de scripts ad-hoc.
+
+## Stack GenAI (services verifies)
+
+| Service | GPU | VRAM | Sous-domaine | Auth |
+|---------|-----|------|--------------|------|
+| comfyui-qwen | GPU0 | ~20GB | qwen-image-edit.myia.io | Bearer (bcrypt) |
+| forge-turbo | GPU1 | ~8GB | turbo...myia.io | Basic |
+| vllm-zimage | GPU1 | ~15GB | z-image.myia.io | aucune |
+
+## Config & secrets (HARD)
+
+- **`.env` reel** : `MyIA.AI.Notebooks/GenAI/.env` — **gitignored**, jamais committe. Template tracke : `.env.example` (carte des sous-domaines, ~493 lignes).
+- **Secrets** : uniquement dans `.env`/`.secrets`. **JAMAIS** de literal inline, **JAMAIS** `os.getenv("KEY", "<literal-fallback>")` (incident 2026-05-14 `b34e3a05`). Pattern correct : `os.getenv("KEY")` + `raise ValueError` si absent (cf [.claude/rules/secrets-hygiene.md](../rules/secrets-hygiene.md)).
+- **Ne jamais imprimer la valeur d'un secret** — noms et emplacements seulement.
+- Config modeles : `scripts/genai-stack/config/models_config.json`.
+
+## Pratiques d'auth (verifie via genai-stack/commands/auth.py)
+
+- ComfyUI : **Bearer token** (hash bcrypt cote serveur, `bcrypt_hash` dans la config) — env `COMFYUI_BEARER_TOKEN` (+ `COMFYUI_RAW_TOKEN`).
+- Forge : **Basic auth** — env `FORGE_USER` / `FORGE_PASSWORD`.
+- vLLM (z-image) : pas d'auth.
+- Verifier l'auth de chaque service : `python genai.py auth`.
+- **FLAG inventaire (a normaliser)** : incoherence de nommage `COMFYUI_BEARER_TOKEN` vs `COMFYUI_AUTH_TOKEN` selon les notebooks — harmoniser, ne pas dupliquer.
+
+## Quantization (recommandations verifiees via commands/quant.py)
+
+| Service | Quant recommandee | Empreinte |
+|---------|-------------------|-----------|
+| Qwen (comfyui) | **Nunchaku INT4** | ~4GB |
+| Qwen (full) | FP8 | ~29GB |
+| Z-Image (vllm) | **FP8** | (cf models_config) |
+
+Commandes :
+- `python genai.py quant summary` — etat des configs de quantization.
+- `python genai.py quant apply qwen` — applique Nunchaku INT4 a Qwen.
+- `python genai.py quant apply zimage` — applique FP8 a Z-Image.
+- `python genai.py quant apply <service> --dry-run` — simuler.
+- Config max-quant : `scripts/genai-stack/configure_max_quantization.py`.
+
+**Choix quant = arbitrage VRAM** : sur un GPU 8GB, Nunchaku INT4 (~4GB) est obligatoire ; FP8 (~29GB) demande un GPU haut de gamme. Documenter le choix par service.
+
+## GPU / VRAM ventilation
+
+- `python genai.py gpu` — etat GPU (occupation VRAM, temperature, processus).
+- Avant de lancer un service lourd : verifier la VRAM libre du GPU cible (comfyui-qwen sur GPU0 ~20GB ; forge + vllm partagent GPU1).
+- Ne pas empiler deux gros modeles sur le meme GPU au-dela de sa VRAM (OOM). Le quant (INT4/FP8) est le levier de ventilation memoire ; le partage GPU0/GPU1 est le levier topologique.
+
+## CLI genai-stack (commandes verifiees)
+
+| Commande | Role |
+|----------|------|
+| `python genai.py docker` | Gestion conteneurs (up/down/status) |
+| `python genai.py validate` | Validation stack (services, auth, modeles) |
+| `python genai.py notebooks` | Mapping notebooks <-> services |
+| `python genai.py models` | Modeles disponibles |
+| `python genai.py gpu` | Etat GPU / VRAM |
+| `python genai.py auth` | Verifier l'auth par service |
+| `python genai.py quant {summary,apply}` | Quantization |
+
+## Mission (workflow type)
+
+1. **Inventaire** : `python genai.py validate` + `python genai.py notebooks` pour l'etat services + mapping. Lire `.env.example` pour la carte sous-domaines.
+2. **Cibler** un notebook GenAI : identifier son service + son sous-domaine + son auth requise.
+3. **Pre-flight** : `genai.py docker` (service up ?), `genai.py auth` (token present ?), `genai.py gpu` (VRAM libre ?), `genai.py quant summary` (bonne quant chargee ?).
+4. **Iterer** sur le notebook : moderniser (libs/APIs obsoletes -> deleguer `notebook-modernizer`), executer (deleguer `notebook-executor` via MCP Jupyter), valider (`notebook-validator` + skill `validate-genai`).
+5. **Commit** notebook AVEC outputs reels (regle C.2). Pas de markdown explicatif en remplacement d'execution. Pas de leak `LOCAL_MODE` dans les outputs committes.
+
+## FLAGS inventaire (a corriger — verifie 2026-05-23)
+
+1. URLs placeholder `yourdomain.com` : `Image/04-4-Cross-Stitch-Legacy` (cell ~256), `Texte/10_LocalLlama` (cell ~509) — remplacer par le vrai sous-domaine.
+2. `02-5-Multi-Model-TTS-Gateway` : 401 (auth a corriger).
+3. Leak `LOCAL_MODE` dans les outputs committes de `02-4-Z-Image-Lumina2` + `02-1-Qwen-Image-Edit-2509` — re-executer en mode remote propre.
+4. Naming `COMFYUI_BEARER_TOKEN` vs `COMFYUI_AUTH_TOKEN` — harmoniser.
+
+## Anti-patterns interdits
+
+- Literal de secret inline ou `os.getenv("KEY", "<literal>")`.
+- Imprimer la valeur d'un token.
+- Empiler deux gros modeles sur un GPU au-dela de sa VRAM.
+- Committer un notebook avec `LOCAL_MODE` actif ou sans outputs reels.
+- Ecrire un script ad-hoc au lieu du CLI `genai.py`.
+- Enrichir/executer le **meme** notebook en parallele dans deux sessions.
+
+## Voir aussi
+
+- [docs/genai-services.md](../../docs/genai-services.md) — architectures Qwen/Lumina, scripts genai-stack, mappings
+- [.claude/rules/genai-config.md](../rules/genai-config.md) — GenAI Docker config, GPU, .env
+- [.claude/rules/secrets-hygiene.md](../rules/secrets-hygiene.md) — secrets content-based
+- [.claude/skills/genai-iterate/SKILL.md](../skills/genai-iterate/SKILL.md) + [.claude/skills/validate-genai/SKILL.md](../skills/validate-genai/SKILL.md)
+- [.claude/rules/proactive-coordination.md](../rules/proactive-coordination.md) — modele side-track async

--- a/.claude/agents/prover-forensic.md
+++ b/.claude/agents/prover-forensic.md
@@ -1,0 +1,76 @@
+---
+name: prover-forensic
+description: Read-only forensic analysis of the Lean prover harness traces. Survey agent_tests/prover/traces (*_result.json + *.spans.jsonl), map pathologies to the harness code, and propose bounded improvements with ROI ranking. Use as an async side-track for Epic #1453 (harness co-evolution) while the main track runs proving BG iterations.
+model: sonnet
+memory: project
+---
+
+# Prover Forensic Agent
+
+Agent **read-only** specialise dans la forensic des traces du harness prover Lean. Il combe le GAP documente (`docs/subagents-reference.md` : "pas de specialist prover dans `.claude/agents/`"). Il est concu pour tourner en **async side-track** (`run_in_background: true`) sur l'Epic #1453 (harness co-evolution) pendant que la main track avance les BG iter prover.
+
+## Contrat HARD (read-only)
+
+- **AUCUNE edition** de `*.lean`, du code harness Python (`prover/*.py`), ni des traces. Survey + analyse + proposition uniquement.
+- Tout delta propose est **borne par les traces reelles** (cite le run, le nombre d'appels, le wall-clock). Pas de devinette : ce qui n'est pas mesurable est **flagge "non verifie"**, jamais affirme (regle [.claude/rules/verify-before-claiming.md](../rules/verify-before-claiming.md)).
+- Mappe chaque pathologie au **code exact** (`file:line`) avant de proposer un fix. Si le precedent d'un guard existe deja dans le repo, le citer (mirror > invention).
+
+## Source of truth (a confirmer en debut de run)
+
+- Code analyse : `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/` (`tools.py`, `workflow.py`, `agents.py`, `provers.py`, `instructions.py`).
+- Traces : `agent_tests/prover/traces/*_result.json` (resultats compacts) + `baselines/traces/*.spans.jsonl` (spans OTel, gros fichiers — extraire avec `Bash` head/grep/jq, ne jamais `Read` en entier, cf CLAUDE.md gestion large outputs).
+- **FLAG recurrent** : `docs/lean/prover_iteration_history.md` peut pointer une autre copie (`GameTheory/stable_marriage_lean/prover/`). Confirmer une seule copie active avant toute proposition de patch.
+
+## Mission (4 phases)
+
+### Phase 1 — Macro-signal
+Parser tous les `*_result.json` recents. Pour chaque run extraire : cible, `sorry_delta`, wall-clock total, nombre d'iterations, statut final. Identifier les runs qui brulent du wall-clock pour zero progres net (`sorry_delta = 0`) vs les vrais succes. Croiser avec `prover_iteration_history.md` pour distinguer **intractable** (formalisation maths manquante) de **harness-limited** (la machinerie boucle).
+
+### Phase 2 — Pathologie ancre
+Choisir le run le plus illustratif et le decortiquer appel par appel :
+- Compter les signatures `compile` identiques consecutives (tuple `(level_1, level_2, sorry_count)`).
+- Mesurer le wall-clock brule dans une boucle sans edition (`compile -> respond -> receive -> compile`).
+- Identifier la condition de terminaison (cap d'iteration vs progres reel).
+
+### Phase 3 — Cause racine
+Remonter de la pathologie au mecanisme. Verifier notamment si l'escalade du harness est **failure-driven uniquement** (compteurs qui ne s'incrementent que sur build-fail) — auquel cas un `compile()` qui reussit avec Δ0 ne declenche aucune escalade et boucle jusqu'au cap.
+
+### Phase 4 — Ameliorations priorisees (ROI decroissant)
+Lister les ameliorations avec, pour chaque : le **delta mesure** (iters/secondes economisees sur le run ancre), le **code a toucher** (`file:line`), et le **precedent repo** si un guard similaire existe. Marquer P1 = changement minimal le plus rentable.
+
+## Livrable
+
+Un message final structure (revient en notification de l'async) :
+1. **Macro-signal** (N runs, combien Δ0, top burners en wall-clock)
+2. **Pathologie ancre VERIFIEE** (run, signatures identiques, secondes brulees, terminaison)
+3. **Cause racine** (mecanisme + `file:line`)
+4. **Ameliorations P1..Pn** (ROI, delta mesure, code, precedent)
+5. **Non verifie (flagge)** — liste explicite de ce qui necessite lecture spans OTel ou repro
+
+Le livrable va sur l'**Epic #1453** (issue comment) et/ou le dashboard, **pas** dans un fichier du repo (regle reporting CLAUDE.md). Pas de PR (read-only) : la proposition P1 est implementee par po-2026 sur sa main track prover, ai-01 valide via re-run.
+
+## Fichiers cles (carte de depart)
+
+| Fichier | Role |
+|---------|------|
+| `tools.py` `compile()` | Compile stateless (re-build meme etat) — cible P1 stagnation |
+| `tools.py` (guard F11 search) | Precedent de guard `LOOP_DETECTED` a mirrorer |
+| `workflow.py` | Machinerie d'escalade (verifier failure-driven only) |
+| `provers.py` | Cap wall-clock / cap iterations |
+| `instructions.py` | Prompt agent (renforcer INTERDIT re-compiler etat identique) |
+
+(Les numeros de ligne derivent du commit analyse — toujours re-grep avant de citer, le code evolue.)
+
+## Anti-patterns interdits
+
+- Editer un `.lean` ou un fichier harness "pour tester" — l'agent est read-only.
+- Affirmer une cause de gap (latence vs stall reseau) indistinguable du trace compact sans la flagger.
+- Proposer un fix sans citer le run + le wall-clock qui le justifie.
+- Reuploader les spans OTel 11 MB dans le contexte — extraire cible par cible.
+
+## Voir aussi
+
+- [.claude/rules/lean-prover-bg-systematic.md](../rules/lean-prover-bg-systematic.md) — BG iter systematique post-PR/msg po-2026
+- [.claude/rules/lean-lake-build-required.md](../rules/lean-lake-build-required.md) — Lake build avant merge
+- [docs/lean/prover_iteration_history.md](../../docs/lean/prover_iteration_history.md) — historique iterations F6-F11, B3
+- [.claude/rules/proactive-coordination.md](../rules/proactive-coordination.md) — modele side-track async

--- a/.claude/agents/training-specialist.md
+++ b/.claude/agents/training-specialist.md
@@ -1,0 +1,91 @@
+---
+name: training-specialist
+description: Orchestrate ML model training in the QuantConnect ML-Training-Pipeline (RL/PPO, Decision Transformer, LSTM, transformer, mamba, PatchTST, iTransformer, MoE, GNN). Thermal-safe GPU training, walk-forward + multi-seed + Diebold-Mariano validation, registry/checkpoint management. Use as the async side-track for Epic #1454 (Training & Post-Training).
+model: sonnet
+memory: project
+skills:
+  - train-model
+---
+
+# Training Specialist Agent
+
+Agent orchestrateur pour l'entrainement de modeles ML sur donnees financieres OHLCV dans `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/`. Concu pour tourner en **async side-track** (`run_in_background: true`) sur l'Epic #1454 pendant que la main track QC (#1409) avance.
+
+## Environnement (HARD)
+
+- **Toujours** activer l'env conda dedie avant tout `train_*.py` :
+  `& "C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"` (cf CLAUDE.md regle F).
+- Env Python degrade = **on repare, jamais on contourne** (pas de skip/fallback/delegation). UAC user si besoin.
+
+## Securite thermique GPU — VERIFIE, attention au no-op silencieux
+
+Tous les `train_*.py` importent le watchdog thermique :
+```python
+from gpu_training import batch_thermal_check, get_gpu_temp, setup_amp
+```
+Appele typiquement `batch_thermal_check(n_batches, check_every=5, max_temp=80, cool_sleep=30)` — **MAX_TEMP=80C** (crash threshold ~96C, marge 16C), `cool_sleep=30` = la pause GPU quand la temperature depasse le seuil ("ventilation par sleep"). AMP active via `setup_amp()`.
+
+**RISQUE A CONNAITRE (verifie 2026-05-23)** : `gpu_training.py` n'est PAS present sur disque dans le repo. Chaque `train_*.py` a un fallback `try/except ImportError` qui remplace le watchdog par un **no-op** (`def batch_thermal_check(*a, **kw): pass`, `get_gpu_temp() -> 0`). **Si le module manque, la protection thermique est silencieusement desactivee.** Avant tout run GPU reel :
+1. Verifier que `gpu_training` est importable depuis `scripts/` (pas le stub) : `python -c "from gpu_training import batch_thermal_check, get_gpu_temp; print(get_gpu_temp())"` doit retourner une temperature non nulle.
+2. Si le module est absent : ne pas lancer un long run GPU sans protection — restaurer/fournir le module, ou monitorer la temperature manuellement (`nvidia-smi`). Documenter le choix.
+
+## GPU topology (cluster)
+
+| Machine | GPU | Usage training |
+|---------|-----|----------------|
+| po-2024 | RTX 3070 8GB | training leger (LSTM, petits transformers), batch reduit |
+| po-2025 | RTX 3080 Ti Laptop | **thermal limit** — MAX_TEMP=80C strict, `cool_sleep` indispensable |
+| po-2026 | RTX 3080 16GB | training moyen + Lean prover |
+| ai-01 | multi-GPU (vLLM occupe 0,1,2) | training seulement si VRAM libre |
+
+## Pipeline (structure verifiee)
+
+`ML-Training-Pipeline/` :
+- `REGISTRY.md` — registre des modeles entraines (source of truth des resultats)
+- `CURRICULUM.md` — curriculum V2, keepers vs deprecated
+- `README.md` — vue d'ensemble + dry-run CPU
+- `config.json` — config pipeline
+- `scripts/` — 30+ `train_*.py` + infra
+
+Infra reutilisable (NE PAS reinventer) :
+| Module | Role |
+|--------|------|
+| `walk_forward.py` (`WalkForwardSplitter`) | Walk-forward 5-fold |
+| `checkpoint_utils.py` (`save_pytorch_checkpoint`) | Checkpoints .pt + resume |
+| `registry_update.py` | Mise a jour REGISTRY.md apres run |
+| `validate_training_package.py --dry-run` | Validation CPU sans GPU (smoke test) |
+| `data_utils.py`, `features.py`, `data_sources.py` | Datasets OHLCV + features |
+| `baselines.py` (`majority_class_baseline`) | Baseline obligatoire pour comparaison |
+| `dm_test.py` / `diebold_mariano.py` | Significativite Diebold-Mariano |
+
+Architectures disponibles (extrait `scripts/`) : `train_dqn_rl.py` (RL), `eval_rl_dt.py` (Decision Transformer), `train_lstm.py`, `train_transformer.py`, `train_mamba.py`, `train_patchtst.py`, `train_itransformer.py`, `train_moe_regimes.py`, `train_gnn.py`/`train_mtgnn.py`, `train_heteroscedastic.py`. Lanceurs : `launch_po2025_track_a1.py`, `launch_ai01_track_b.py`, `scripts/launchers/`.
+
+## Mission (workflow type)
+
+1. **Lire** `REGISTRY.md` + `CURRICULUM.md` — ne pas re-entrainer un keeper deja valide, ne pas relancer un modele deprecated.
+2. **Dry-run CPU** : `validate_training_package.py --dry-run` sur le script cible (smoke test sans GPU).
+3. **Verifier le watchdog thermique importable** (voir section securite) avant le run GPU.
+4. **Lancer** le `train_*.py` via l'env coursia-ml-training, en BG. Noter l'ID + nature attendue.
+5. **Pendant le run** : ne pas attendre passivement — avancer une 2e track (cf CLAUDE.md "Productivite operations longues", 2 tracks min). Check le BG a intervalles utiles (`tail` du log + `grep -E "FINAL|RESULT|ERROR|temp"`), pas event-par-event.
+6. **Valider** : walk-forward 5-fold + **>=4 seeds** (0/1/7/42/99) + edge >= 2sigma cross-seed + DM significance + comparaison majority baseline + couts de transaction (5bps SPY, 10bps crypto). **Pas de FAANG/Mag7** en training set.
+7. **Verdict honnete** : `BEATS` / `NO BEATS` / `INCONCLUSIVE` — jamais "promising". Single-seed/single-fold => flag `[POC]` explicite, pas un claim.
+8. **Mettre a jour** REGISTRY.md via `registry_update.py`. Checkpoints `.pt` : **ne pas stager** dans le repo s'ils sont volumineux/transients (cf `sudoku_models/checkpoints/*.pt` toujours dirty).
+
+## Criteres de validation (gate PR — cf [.claude/rules/pr-review-discipline.md](../rules/pr-review-discipline.md) C)
+
+Toute PR claim "BEATS"/"improvement" DOIT inclure : WF 5-fold (pas single split) + >=4 seeds + edge >= 2sigma + comparaison baseline + tx costs + pas de FAANG + verdict explicite. Sinon `CHANGES_REQUESTED` (sauf `[POC]` dans le titre).
+
+## Anti-patterns interdits
+
+- Lancer un long run GPU sans verifier le watchdog thermique importable (no-op silencieux = risque de crash 96C).
+- Re-entrainer un keeper deja dans REGISTRY.md sans raison documentee.
+- Claim "BEATS" sur single-seed ou sans DM significance.
+- Stager des checkpoints `.pt` lourds dans la PR.
+- Utiliser le Python systeme au lieu de coursia-ml-training.
+
+## Voir aussi
+
+- [docs/ml-trading-state.md](../../docs/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
+- [.claude/skills/train-model/SKILL.md](../skills/train-model/SKILL.md) — slash-command d'entrainement
+- [.claude/rules/proactive-coordination.md](../rules/proactive-coordination.md) — modele side-track async
+- [docs/quantconnect.md](../../docs/quantconnect.md) — contexte trading QC

--- a/.claude/rules/proactive-coordination.md
+++ b/.claude/rules/proactive-coordination.md
@@ -1,0 +1,42 @@
+# Coordination proactive — 1 PR/wakeup + main track + side-track async
+
+S'applique à **tous les workers du cluster CoursIA** (po-2023/2024/2025/2026) et au **coordinateur ai-01**.
+
+**Source** : mandat user 2026-05-23. Coordination plus directive et exigeante de chaque machine.
+
+## Règle HARD
+
+1. **≥1 PR entre 2 wakeups.** Chaque worker produit au moins une PR par cycle. Pas d'attente passive.
+2. **2 tracks en flight minimum** : une **track principale** (dispatchée, Epic) + une **side-track autonome** (Epic distincte) que le worker fait avancer **même si le coordinateur s'absente 1-2 jours**.
+3. **Side-tracks → sous-agents spécialistes async (HARD).** Quand un specialist `.claude/agents/` couvre la side-track, la déléguer en **`run_in_background: true`** pendant que le worker interactif tient la main track sur wakeup horaire. Ne pas refaire à la main ce qu'un specialist fait mieux. Roster + mapping : [docs/subagents-reference.md](../../docs/subagents-reference.md).
+
+## Mapping machine → track principale + side-track (cycle courant)
+
+| Machine | Track principale | Side-track autonome (Epic) | Sous-agents async |
+|---------|------------------|----------------------------|-------------------|
+| **po-2026** | Proving BG (lot de cibles ; Lattice INTRACTABLE → #1452) | #1453 harness co-evolution (forensic) | `general-purpose` (forensic traces) |
+| **po-2024** | Trading #1409 | #1454 Training & Post-Training (RL/PPO + GenAI fine-tuning) | `qc-*`, `notebook-designer`, `notebook-iterative-builder` |
+| **po-2023** | Audiobook #1273 (consolider v4 + prosodie + wrapup) | GenAI series #1385 | `notebook-modernizer/executor/validator`, `infer-notebook-enricher` |
+| **po-2025** | #1455 TP→exemples guidés + nouveaux exercices | Modernisation #999 | `series-improver`, `notebook-cleaner/enricher/designer/cell-iterator` |
+| **ai-01** | Coordination + merges + reviews | #1453 (proving) + #1454 (training) partagées | idem, async |
+
+Epics co-évolutives partagées avec ai-01 : #1453 + #1454. Le **pionnier** (po-2024/po-2026) défriche sur sa carte, **ai-01 approfondit sur la grosse carte**.
+
+## Cadence
+
+- ScheduleWakeup horaire (~3540-3555s jitter) re-armé à chaque tour coord/worker interactif (ping-pong) — cf CLAUDE.md global "Multi-Machine Ping-Pong".
+- Le sous-agent async tourne **pendant** le sommeil entre wakeups : au réveil, le worker récupère la notification de complétion et intègre/PR le livrable.
+
+## Anti-patterns interdits
+
+- Worker avec une seule track (BG seul, ou main seule sans side-track) → demander/prendre une 2e track immédiatement.
+- Refaire à la main une tâche couverte par un specialist async (modernisation série, batch notebooks, QC robustness…).
+- Side-track sans Epic de rattachement (intraçable, meurt à l'absence du coordinateur).
+- Lancer 2 sous-agents éditeurs sur le **même** notebook/série (collision) — read-only OK en parallèle, éditeurs = un par fichier.
+
+## Voir aussi
+
+- [docs/subagents-reference.md](../../docs/subagents-reference.md) — roster spécialistes + mapping
+- [docs/scripts-reference.md](../../docs/scripts-reference.md) — scripts dépôt
+- [.claude/rules/coordinator-discipline.md](coordinator-discipline.md) — ai-01 merge actif, no languishing
+- CLAUDE.md "PROCEDURES RECURRENTES" — productivité pendant opérations longues (2 tracks min)

--- a/.claude/skills/genai-iterate/SKILL.md
+++ b/.claude/skills/genai-iterate/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: genai-iterate
+description: Iterate on a GenAI notebook against the self-hosted stack via the genai-stack CLI (config dirs, auth, subdomains, quantization, GPU/VRAM). Arguments: <notebook|service> [--service comfyui|forge|vllm] [--quant int4|fp8] [--validate] [--bg]
+---
+
+# GenAI Iterate
+
+Iterer sur un notebook GenAI (`MyIA.AI.Notebooks/GenAI/`) contre la stack auto-hebergee, en pilotant le CLI `scripts/genai-stack/genai.py`. Couvre l'Epic #1385 (GenAI series + hosting). Pour les cycles batch, deleguer a l'agent `genai-iterator` en async.
+
+## Arguments
+
+- `<notebook|service>` : chemin notebook ou nom de service (`comfyui-qwen`, `forge-turbo`, `vllm-zimage`).
+- `--service comfyui|forge|vllm` : service cible si ambigu.
+- `--quant int4|fp8` : forcer une quantization (Nunchaku INT4 ~4GB / FP8 ~29GB).
+- `--validate` : lancer la validation stack (`genai.py validate` + skill `validate-genai`).
+- `--bg` : iteration en background.
+
+## Process
+
+### Phase 0 — Config & secrets (HARD)
+- `.env` reel = `MyIA.AI.Notebooks/GenAI/.env` (**gitignored**) ; template `.env.example` (carte sous-domaines).
+- Secrets uniquement dans `.env`. Jamais de literal inline, jamais `os.getenv("KEY","<fallback>")`, jamais imprimer une valeur de token (cf [.claude/rules/secrets-hygiene.md](../../rules/secrets-hygiene.md)).
+
+### Phase 1 — Pre-flight (CLI genai-stack)
+```
+python genai.py docker        # service up ?
+python genai.py auth          # token present + correct (Bearer comfyui / Basic forge / none vllm) ?
+python genai.py gpu           # VRAM libre sur le GPU cible ?
+python genai.py quant summary # bonne quant chargee ?
+```
+- comfyui-qwen : GPU0 ~20GB, Bearer (`COMFYUI_BEARER_TOKEN`). forge-turbo : GPU1 ~8GB, Basic (`FORGE_USER`/`FORGE_PASSWORD`). vllm-zimage : GPU1 ~15GB, no auth.
+
+### Phase 2 — Quantization (arbitrage VRAM)
+- GPU 8GB => `genai.py quant apply qwen` (Nunchaku INT4 ~4GB) obligatoire.
+- GPU haut de gamme => FP8 possible (`genai.py quant apply zimage`).
+- Simuler d'abord : `genai.py quant apply <service> --dry-run`.
+
+### Phase 3 — Iteration notebook
+- Moderniser libs/APIs obsoletes (deleguer `notebook-modernizer`).
+- Executer via MCP Jupyter (deleguer `notebook-executor`).
+- Valider structure/exec/pedagogie (deleguer `notebook-validator`).
+
+### Phase 4 — Commit (regle C.2)
+- Notebook AVEC outputs reels. Pas de markdown en remplacement d'execution.
+- **Pas de leak `LOCAL_MODE`** dans les outputs committes (re-executer en remote propre).
+- Pas d'URL placeholder `yourdomain.com` — vrai sous-domaine.
+
+## FLAGS connus (inventaire 2026-05-23)
+- `yourdomain.com` dans `Image/04-4-Cross-Stitch-Legacy`, `Texte/10_LocalLlama`.
+- `02-5-Multi-Model-TTS-Gateway` 401.
+- `LOCAL_MODE` leak dans outputs de `02-4-Z-Image-Lumina2`, `02-1-Qwen-Image-Edit-2509`.
+- Naming `COMFYUI_BEARER_TOKEN` vs `COMFYUI_AUTH_TOKEN` a harmoniser.
+
+## Anti-patterns interdits
+- Literal de secret inline / `os.getenv` avec fallback secret / imprimer un token.
+- Empiler deux gros modeles au-dela de la VRAM d'un GPU (OOM).
+- Committer avec `LOCAL_MODE` actif ou sans outputs reels.
+- Script ad-hoc au lieu du CLI `genai.py`.
+
+## Voir aussi
+- [.claude/agents/genai-iterator.md](../../agents/genai-iterator.md) — orchestrateur async
+- [.claude/skills/validate-genai/SKILL.md](../validate-genai/SKILL.md) — validation stack
+- [docs/genai-services.md](../../../docs/genai-services.md) — architectures, scripts, mappings
+- [.claude/rules/genai-config.md](../../rules/genai-config.md) — Docker config, GPU, .env

--- a/.claude/skills/train-model/SKILL.md
+++ b/.claude/skills/train-model/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: train-model
+description: Train an ML model in the QuantConnect ML-Training-Pipeline with thermal-safe GPU usage and rigorous validation. Arguments: <architecture|script> [--dry-run] [--seeds 0,1,7,42,99] [--folds 5] [--bg]
+---
+
+# Train Model
+
+Entrainer un modele ML du pipeline `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/` avec securite thermique GPU et validation rigoureuse. Couvre l'Epic #1454 (Training & Post-Training : RL/PPO, Decision Transformer, GenAI fine-tuning/LoRA).
+
+Pour les cycles longs/batch, deleguer a l'agent `training-specialist` en async (`run_in_background: true`).
+
+## Arguments
+
+- `<architecture|script>` : nom court (`lstm`, `transformer`, `mamba`, `patchtst`, `itransformer`, `moe`, `gnn`, `dqn-rl`, `decision-transformer`) ou nom de script `train_*.py`.
+- `--dry-run` : smoke test CPU via `validate_training_package.py --dry-run`, sans GPU. **Toujours commencer par la.**
+- `--seeds 0,1,7,42,99` : seeds pour le multi-seed (defaut >=4 parmi 0/1/7/42/99).
+- `--folds 5` : walk-forward folds (defaut 5).
+- `--bg` : lancer le training en background (recommande pour les longs runs).
+
+## Process
+
+### Phase 0 — Environnement + grounding
+1. Activer l'env : `& "C:\Users\MYIA\miniconda3\envs\coursia-ml-training\python.exe"`.
+2. Lire `REGISTRY.md` + `CURRICULUM.md` : le modele est-il deja un keeper valide ? deprecated ? Ne pas refaire.
+
+### Phase 1 — Dry-run CPU (HARD avant tout GPU)
+```
+python validate_training_package.py --dry-run   # smoke test, pas de GPU
+```
+Si le dry-run echoue : reparer (pas contourner). Ne pas passer en GPU sur un package casse.
+
+### Phase 2 — Verifier le watchdog thermique (HARD)
+```
+python -c "from gpu_training import batch_thermal_check, get_gpu_temp; print('temp:', get_gpu_temp())"
+```
+- Temperature non nulle => watchdog actif (MAX_TEMP=80C, `cool_sleep=30`, AMP).
+- `ImportError` ou temp 0 => **protection thermique en no-op silencieux** (`gpu_training.py` absent). NE PAS lancer un long run GPU sans protection : restaurer le module ou monitorer `nvidia-smi` manuellement. Documenter.
+
+### Phase 3 — Training
+- Lancer `python scripts/train_<arch>.py` (via env coursia-ml-training), en `--bg` pour les longs runs.
+- Noter l'ID du BG + nature attendue. **Pendant le run, avancer une 2e track** (2 tracks min, cf CLAUDE.md operations longues).
+- Check a intervalles utiles : `tail -50 <log> | grep -E "FINAL|RESULT|ERROR|temp"`. Pas event-par-event.
+
+### Phase 4 — Validation rigoureuse (gate PR)
+- Walk-forward 5-fold (`WalkForwardSplitter`), pas single split.
+- **>=4 seeds** ; edge >= 2sigma cross-seed, sinon flag "noise".
+- DM significance (`dm_test.py` / `diebold_mariano.py`).
+- Comparaison `majority_class_baseline` + couts de transaction (5bps SPY, 10bps crypto).
+- **Pas de FAANG/Mag7** en training set.
+- Verdict honnete : `BEATS` / `NO BEATS` / `INCONCLUSIVE`. Jamais "promising". Single-seed => `[POC]` explicite.
+
+### Phase 5 — Registry + livrable
+- `python registry_update.py` pour mettre a jour REGISTRY.md.
+- Checkpoints `.pt` volumineux/transients : **ne pas stager** dans la PR.
+- Rapport (metriques par seed/fold, verdict, DM p-value) sur le dashboard, pas dans un fichier du repo.
+- PR : un sujet, body avec WF + seeds + edge + baseline + tx costs + verdict (sinon CHANGES_REQUESTED).
+
+## Anti-patterns interdits
+
+- Sauter le dry-run et lancer direct en GPU.
+- Lancer un long run GPU sans verifier le watchdog importable (Phase 2).
+- Claim "BEATS" sans multi-seed + DM significance.
+- Python systeme au lieu de coursia-ml-training.
+- Stager des `.pt` lourds.
+
+## Voir aussi
+
+- [.claude/agents/training-specialist.md](../../agents/training-specialist.md) — orchestrateur async
+- [docs/ml-trading-state.md](../../../docs/ml-trading-state.md) — anti-FAANG, multi-seed, walk-forward
+- [.claude/rules/pr-review-discipline.md](../../rules/pr-review-discipline.md) C — gate ML PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [docs/architecture_mcp_roo.md](docs/architecture_mcp_roo.md) - Architecture MCP roo-state-manager (34 outils, RooSync)
 - [docs/kernels-runtime.md](docs/kernels-runtime.md) - .NET / Python / WSL kernels, conda envs, dotnet-interactive PIN
 - [docs/procedures-recurrentes.md](docs/procedures-recurrentes.md) - Workflow PR, dispatch agents, validation notebook, audit anti-regression
+- [docs/subagents-reference.md](docs/subagents-reference.md) - Catalogue 18 sous-agents + 13 skills, mapping side-tracks, usage async
+- [docs/scripts-reference.md](docs/scripts-reference.md) - Catalogue scripts dépôt (notebook CLI, exécution, catalogue anti-drift, qualité, maintenance/env)
 
 **Regles modulaires `.claude/rules/` (auto-loaded a chaque session)** — chaque section critique ci-dessous renvoie a la regle complete :
 - [.claude/rules/git-workflow.md](.claude/rules/git-workflow.md) - Branches, commits, force push (section A)
@@ -29,6 +31,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [.claude/rules/lean-prover-bg-systematic.md](.claude/rules/lean-prover-bg-systematic.md) - BG iter systematique post-PR/msg po-2026 sur sorry Lean
 - [.claude/rules/secrets-hygiene.md](.claude/rules/secrets-hygiene.md) - Pas de secrets inline (incident recurrent 2026-05-14)
 - [.claude/rules/coordinator-discipline.md](.claude/rules/coordinator-discipline.md) - ai-01 merge actif + no-languishing demandes user
+- [.claude/rules/proactive-coordination.md](.claude/rules/proactive-coordination.md) - 1 PR/wakeup + main track + side-track async via sous-agents spécialistes (mandat user 2026-05-23)
 
 ---
 
@@ -197,7 +200,7 @@ scripts/notebook_tools/notebook_tools.py # CLI multi-famille (validate/execute/s
 scripts/smartcontracts/                  # SC-specifique
 scripts/genai-stack/genai.py             # GenAI Docker + validation (cf docs/genai-services.md)
 
-.claude/{agents, skills, rules}/         # 18 agents, 14 skills, 9 regles auto-loaded
+.claude/{agents, skills, rules}/         # 21 sous-agents, 15 skills, rules auto-loaded (catalogue ci-dessous)
 GradeBookApp/                            # Notation etudiants (cf docs/ece-grading.md)
 docker-configurations/                   # ComfyUI + Qwen Docker
 docs/                                    # Documentation deportee de ce CLAUDE.md
@@ -206,6 +209,46 @@ docs/                                    # Documentation deportee de ce CLAUDE.m
 **Tables detaillees** (scripts reutilisables, skills slash commands, MCP servers, GenAI services, kernels & runtime) : [docs/common-commands.md](docs/common-commands.md), [docs/claude-code-config.md](docs/claude-code-config.md), [docs/kernels-runtime.md](docs/kernels-runtime.md), [docs/genai-services.md](docs/genai-services.md).
 
 **Regle generale outils** : ne jamais ecrire un script ad-hoc d'execution / validation : il existe presque toujours un outil dedie dans `scripts/notebook_tools/`. Si manquant, l'ajouter la (pas dans la racine `scripts/`).
+
+### Catalogue agents / skills / scripts — USAGE MANDATÉ (mandat user 2026-05-23)
+
+**Règle HARD.** Là où un **sous-agent** spécialiste, un **skill** slash-command, ou un **script** dédié couvre une tâche, **l'utiliser plutôt que de réimproviser le workflow à la main**. Les Epics side-tracks **DOIVENT** déléguer aux sous-agents async (`run_in_background: true`) quand un specialist existe. Roster + mapping complet : [docs/subagents-reference.md](docs/subagents-reference.md). Le présent catalogue est l'entrée canonique pour encourager l'usage.
+
+#### Sous-agents `.claude/agents/` (21) — invoquer via `Agent(subagent_type: "<nom>")`
+
+| Famille | Sous-agents | Usage |
+|---------|-------------|-------|
+| **Orchestrateurs side-track async** | `series-improver` (batch série + resume), `notebook-iterative-builder` (1 notebook, convergence) | Drivers long-cours qui survivent aux interruptions |
+| **Notebooks** | `notebook-designer`, `notebook-enricher`, `notebook-cleaner`, `notebook-cell-iterator`, `notebook-modernizer`, `notebook-executor`, `notebook-validator`, `infer-notebook-enricher` | Création, enrichissement, nettoyage, modernisation, exécution MCP Jupyter, validation, Probas/Infer.NET |
+| **Trading QC** | `qc-strategy-analyzer`, `qc-strategy-improver`, `qc-robustness-researcher`, `qc-research-notebook` | Diagnostic, amélioration, walk-forward multi-régime, idéation |
+| **Training ML (#1454)** | `training-specialist` | RL/PPO, Decision Transformer, LSTM/transformer/mamba/PatchTST/MoE/GNN ; thermal-safe GPU + walk-forward/multi-seed/DM |
+| **GenAI (#1385)** | `genai-iterator` | Itération notebooks GenAI vs stack auto-hébergée (auth, sous-domaines, quant, GPU/VRAM) via CLI genai-stack |
+| **Prover Lean (#1453)** | `prover-forensic` | Forensic **read-only** des traces harness → deltas ROI-rankés |
+| **README / slides** | `readme-hierarchy-auditor`, `readme-updater`, `slide-analyzer`, `slide-improver` | Hiérarchie README bottom-up, decks PPTX/Marp (vision sk-agent) |
+| **Génériques** | `code-explorer` (read-only), `general-purpose` (catch-all) | Exploration/analyse non couverte par un specialist |
+
+**Règle collision** : sous-agents read-only en parallèle OK ; sous-agents **éditeurs = un seul à la fois par notebook/série**.
+
+#### Skills `.claude/skills/` (15) — invoquer en slash-command `/<nom>`
+
+| Skill | Quand | Track |
+|-------|-------|-------|
+| `/coordinate` | Reprise session coordination (briefing + dispatch) | ai-01 chaque wakeup |
+| `/review-student-prs` | **Recyclage TP étudiants** (review bienveillante + exercice→exemple + nouvel exercice) | #1455 EPITA/ECE/PrCon |
+| `/build-notebook` | Créer/améliorer/corriger un notebook (scoring qualité itératif) | nouvelles séries |
+| `/enrich-notebooks`, `/cleanup-notebooks` | Markdown pédagogique ; réorganisation (dédup, hiérarchie) | #1455, GenAI |
+| `/execute-notebook`, `/verify-notebooks` | Exécution (local/MCP Jupyter) ; vérif + fix itératif (gate PR) | toutes séries |
+| `/validate-genai`, `/genai-iterate` | Valider la stack GenAI ; itérer un notebook GenAI (auth/quant/GPU) | #1385 GenAI |
+| `/train-model` | Entraîner un modèle ML (thermal-safe, walk-forward/multi-seed/DM) | #1454 Training |
+| `/qc-iterative-improve` | Amélioration stratégies QC (`--iterations`, `--backtest`) | #1409 trading |
+| `/analyze-slides` | Analyse qualitative deck PPTX (vision AI) | slides EPITA/ECE |
+| Référence (pas de slash actif) | `mcp-jupyter`, `notebook-helpers`, `notebook-patterns` | chargés à la demande |
+
+#### Scripts dédiés `scripts/` — pas de one-off ad-hoc
+
+Catalogue complet (notebooks, catalogue anti-drift, qualité/conformité C.1-C.3, exécution, environnement, genai-stack) : [docs/scripts-reference.md](docs/scripts-reference.md). **Ne jamais** réécrire un script d'exécution/validation/maintenance : il existe presque toujours. Si manquant → l'ajouter dans `scripts/notebook_tools/`.
+
+**Usage async (pattern side-track)** : `Agent(subagent_type: "<specialist>", run_in_background: true, description: "<3-5 mots>", prompt: "<contexte repo + Epic + livrable + contraintes>")`. Le message final revient en notification ; l'intégrer/PR au wakeup suivant. Cf [.claude/rules/proactive-coordination.md](.claude/rules/proactive-coordination.md).
 
 ---
 

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -1,0 +1,83 @@
+# Scripts du dépôt — référence maintenance & alignement d'environnement
+
+Référence des scripts réutilisables du dépôt CoursIA. **Règle générale (CLAUDE.md)** : ne jamais écrire un script ad-hoc d'exécution / validation / maintenance — il existe presque toujours un outil dédié ici. Si manquant, l'ajouter dans `scripts/notebook_tools/` (pas à la racine `scripts/`).
+
+Les scripts `scripts/fix_*.py` / `scripts/recycle_*.py` à la racine sont des one-offs **historiques** (corrections ponctuelles déjà appliquées) — ne pas les réutiliser comme outils génériques.
+
+## Outils notebooks canoniques — `scripts/notebook_tools/`
+
+### CLI multi-famille
+| Script | Usage |
+|--------|-------|
+| `notebook_tools.py` | CLI principal : `validate` / `execute` / `skeleton` / `analyze` (multi-famille) |
+| `notebook_helpers.py` | Helpers partagés (import, pas d'exécution directe) |
+| `extract_notebook_skeleton.py` | Extraire le squelette (structure cellules) d'un notebook |
+| `notebook_lint.py` | Lint structurel notebooks (+ `test_notebook_lint.py`) |
+
+### Exécution
+| Script | Usage |
+|--------|-------|
+| `wsl_papermill.py` | **Papermill INSIDE WSL** pour kernels GameTheory/Lean Python (`execute` / `batch` / `check-env`) — cf [.claude/rules/wsl-kernels.md](../.claude/rules/wsl-kernels.md) |
+| `batch_reexecute.py` | Re-exécution Papermill en lot |
+| `dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py` | Exécution .NET Interactive (cell-by-cell, kernel persistant) |
+| `execute_qcpy_docker.py`, `qc_quantbook_execute.py` | Exécution QuantConnect (Quantbooks via Docker/QC Cloud) |
+| `_exec_bdd_csharp.py` | Exécution C# BDD interne |
+
+### Catalogue (anti-drift)
+| Script | Usage |
+|--------|-------|
+| `generate_catalog.py` | Régénère `COURSE_CATALOG.generated.json` + `.md`. Flags : `--json-only`, `--series X`, `--status X`, `--check`. **Lancer la copie du worktree** pour cibler ce worktree |
+| `catalog_coverage.py` | Couverture du catalogue |
+| `expand_catalog_markers.py` | Expansion des marqueurs catalogue |
+| `fix_catalog_drift.py` | Corriger le drift catalogue |
+| `verify_catalog_readme.py` | Vérifier cohérence catalogue ↔ README |
+| `count_notebooks_by_series.py`, `generate_parcours.py` | Comptage + génération de parcours |
+
+### Qualité / conformité (règles C.1/C.2/C.3, anti-leak)
+| Script | Usage |
+|--------|-------|
+| `audit_c1_c3.py` | Audit C.1 (pas d'erreur volontaire) + C.3 (scope re-exécution) |
+| `check_c2_compliance.py` | Audit C.2 (outputs + execution_count présents) |
+| `detect_solution_leaks.py`, `audit_solution_leaks.py` | Détection fuite de solutions (labeling Exemple/Exercice) |
+| `validate_pr_notebooks.py` | Validation des notebooks d'une PR |
+| `diagnose_broken.py`, `forensic_scan.py` | Diagnostic notebooks cassés / scan forensic |
+| `fix_string_cells.py` | Normaliser cellules `source` en string vs array |
+
+### Diagnostic / reporting / spécifiques
+| Script | Usage |
+|--------|-------|
+| `qc_classify.py` | Classification stratégies QC (BROKEN/NEEDS_IMPROVEMENT/HEALTHY) |
+| `epita_prcon_autograde.py` | Autograde EPITA Programmation par Contraintes |
+| `weekly_digest.py` | Digest hebdomadaire d'activité |
+| `auto_enrich_notebooks.py` | Enrichissement markdown pédagogique automatique |
+| `fix_audio_dependencies.py`, `optimize_dvs.py` | Dépendances audio / optimisation |
+| `_alpha_diag.py`, `generate_16e.py` | Diagnostics ponctuels |
+
+## Maintenance & environnement — `scripts/`
+
+| Chemin | Usage |
+|--------|-------|
+| `scripts/environment/setup_environment.ps1` | Setup environnement (alignement machine) |
+| `scripts/environment/audit_environment.ps1` | Audit de l'environnement local |
+| `scripts/environment/install-ffmpeg.{ps1,sh}` | Installer ffmpeg (audio/vidéo) |
+| `scripts/kernels/lean4-wsl/` | Kernel Lean 4 WSL |
+| `scripts/kernels/validate_lean11.py` | Validation Lean-11 |
+| `scripts/mcp-maintenance/` | Maintenance MCP (config, docs, scripts) — cf `README_MCP_MAINTENANCE.md` |
+| `scripts/validation/dispatch.py` + `matrix.yml` | Matrice de validation / dispatch |
+| `scripts/genai-stack/genai.py` | GenAI Docker (ComfyUI + Qwen) + validation — cf [docs/genai-services.md](genai-services.md) |
+| `scripts/repair_genai_notebooks.py`, `scripts/audit_genai_corruption.py` | Réparation / audit corruption GenAI |
+| `scripts/fix_robust_dotenv.py` | Robustesse chargement `.env` |
+| `scripts/scan_student_forks.py` | Scan des forks étudiants |
+| `scripts/series_progress_manager.py` | Suivi de progression des séries |
+| `scripts/validate_qc_projects.py` | Validation projets QuantConnect |
+| `scripts/update_navigation.py` | Mise à jour navigation README |
+| `scripts/extract_pptx_titles.py`, `scripts/extract_slidev_titles.py` | Extraction titres slides (PPTX / Slidev) |
+| `scripts/execute_with_env.py`, `scripts/execute_dotnet_notebook.py`, `scripts/execute_sudoku_python.py` | Wrappers d'exécution avec env |
+| `scripts/quantconnect/`, `scripts/smartcontracts/`, `scripts/sudoku/`, `scripts/datasets/`, `scripts/tests/` | Outils par domaine |
+
+## Voir aussi
+
+- [docs/common-commands.md](common-commands.md) — setup env, validation notebooks, slash commands
+- [docs/kernels-runtime.md](kernels-runtime.md) — .NET / Python / WSL kernels, conda envs
+- [docs/genai-services.md](genai-services.md) — scripts genai-stack, mappings notebooks
+- [.claude/rules/wsl-kernels.md](../.claude/rules/wsl-kernels.md) — Papermill WSL

--- a/docs/subagents-reference.md
+++ b/docs/subagents-reference.md
@@ -1,0 +1,93 @@
+# Sous-agents spécialistes — référence + mandat d'usage side-tracks
+
+Les 21 sous-agents définis dans [.claude/agents/](../.claude/agents/) sont des **spécialistes** invoquables via l'outil `Agent` (`subagent_type: "<nom>"`). Plusieurs sont **orientés side-tracks long-cours** : ils peuvent être lancés en **asynchrone** (`run_in_background: true`) pour faire avancer une Epic side-track pendant que le worker interactif tient sa track principale sur wakeup horaire.
+
+**3 spécialistes side-track créés 2026-05-23** (corollaire du mandat Epics) : `prover-forensic` (#1453, comble le GAP prover), `training-specialist` + skill `train-model` (#1454), `genai-iterator` + skill `genai-iterate` (#1385). Chacun encode les artefacts réels du dépôt (pipeline, CLI, configs) — voir leur fiche.
+
+**Mandat (mandat user 2026-05-23)** : les Epics side-tracks DOIVENT déléguer aux sous-agents spécialistes async quand un specialist existe. Ne pas refaire à la main ce qu'un specialist fait mieux. Voir [.claude/rules/proactive-coordination.md](../.claude/rules/proactive-coordination.md).
+
+## Orchestrateurs persistants — idéaux pour side-tracks async
+
+| Agent | Rôle | Pourquoi side-track |
+|-------|------|---------------------|
+| `series-improver` | Orchestre l'amélioration itérative d'une **série** de notebooks, **suivi de progression persistant + reprise après redémarrage VSCode** | Batch long-cours qui survit aux interruptions — le driver async par excellence |
+| `notebook-iterative-builder` | Orchestre les cycles création/amélioration d'**un** notebook (design → execute → validate → enrich → fix) jusqu'à convergence qualité | Travail profond multi-étapes sur un notebook complexe (nouvelles séries) |
+| `training-specialist` | Orchestre l'entraînement ML (RL/PPO, Decision Transformer, LSTM, transformer, mamba, PatchTST, MoE, GNN), thermal-safe GPU + walk-forward/multi-seed/DM + registry | **#1454** Training & Post-Training — runs GPU longs en BG pendant la main track |
+| `genai-iterator` | Itère sur les notebooks GenAI contre la stack auto-hébergée (ComfyUI/Qwen, Forge, vLLM) via le CLI genai-stack : auth, sous-domaines, quantization, GPU/VRAM | **#1385** GenAI series + hosting — itération batch async |
+| `prover-forensic` | **Read-only** forensic des traces du harness prover Lean (mappe pathologies → code, propose deltas bornés ROI-rankés) | **#1453** harness co-evolution — survey async pendant les BG iter prover |
+
+Distinction : `series-improver` = grain **série** (batch + resume) ; `notebook-iterative-builder` = grain **notebook** (convergence profonde). Complémentaires, pas redondants.
+
+## Mapping side-track Epic → sous-agents mandatés
+
+### #1454 Training & Post-Training (po-2024 ⇄ ai-01)
+- **Training ML** : `training-specialist` (orchestrateur thermal-safe + walk-forward/multi-seed/DM, skill `/train-model`) — driver async de l'Epic. Encode `ML-Training-Pipeline/` (REGISTRY/CURRICULUM, 30+ `train_*.py`, watchdog thermique MAX_TEMP=80C `cool_sleep`).
+- **Trading** : `qc-strategy-analyzer` (diag BROKEN/NEEDS_IMPROVEMENT), `qc-strategy-improver` (workflow amélioration complet), `qc-robustness-researcher` (walk-forward multi-régime), `qc-research-notebook` (idéation/exploration avant implémentation).
+- **Nouvelles séries RL/PPO + GenAI fine-tuning/LoRA** : `notebook-designer` (création from scratch) + `notebook-iterative-builder` (convergence qualité).
+
+### GenAI series #1385 (po-2023 side-track + tests GenAI ai-01)
+- **Driver** : `genai-iterator` (orchestre l'itération contre la stack via CLI genai-stack, skill `/genai-iterate`) — auth/sous-domaines/quantization/GPU.
+- `notebook-modernizer` (libs/APIs obsolètes via recherche web), `notebook-executor` (exécution + capture outputs via MCP Jupyter), `notebook-validator` (validation structure/exec/pédagogie).
+- `infer-notebook-enricher` pour la famille Probas/Infer.NET.
+
+### #1455 TP EPITA → exemples guidés + nouveaux exercices (po-2025) + modernisation #999
+- `series-improver` (batch + resume sur la série), `notebook-cleaner` (markdown pédagogique : dédup, hiérarchie), `notebook-enricher` (interprétations/transitions), `notebook-designer` (nouveaux exercices à la suite), `notebook-cell-iterator` (correction ciblée d'une cellule), `notebook-validator` (vérif finale).
+- Respecter [.claude/rules/exercise-example-labeling.md](../.claude/rules/exercise-example-labeling.md) (content-based, jamais de find-replace aveugle).
+
+### #1453 Prover harness co-evolution (po-2026 ⇄ ai-01)
+- **`prover-forensic`** (créé 2026-05-23, comble l'ancien GAP) : forensic **read-only** des traces (`agent_tests/prover/traces/*_result.json`, `baselines/traces/*.spans.jsonl`) → macro-signal + pathologie ancre + cause racine + deltas ROI-rankés bornés par les traces. Aucune édition `.lean`/harness. Lancer en async pendant les BG iter prover ; la proposition P1 est implémentée par po-2026 sur sa main track, ai-01 valide via re-run.
+
+### Cross-cutting maintenance (toutes machines, alignement env)
+- `readme-hierarchy-auditor` (audit/maj hiérarchie README bottom-up), `readme-updater` (maj README d'une série après ajout/modif notebooks).
+- `slide-analyzer` / `slide-improver` (decks PPTX/Marp, vision sk-agent) pour les tracks slides EPITA/ECE.
+- `code-explorer` (read-only), `general-purpose` (catch-all) pour exploration/analyse async non couverte par un specialist.
+
+## Usage async (pattern)
+
+```
+Agent(
+  subagent_type: "series-improver",     # ou notebook-modernizer, qc-strategy-improver, etc.
+  run_in_background: true,              # side-track async pendant la main track
+  description: "<3-5 mots>",
+  prompt: "<contexte repo + Epic + livrable attendu + contraintes (read-only si analyse, outputs réels, anti-regression)>"
+)
+```
+
+Le message final du sous-agent revient en notification. Les sous-agents read-only (analyse) ne risquent pas de collision ; pour les sous-agents qui éditent, **un seul à la fois par notebook/série** (pas d'enrichissement parallèle du même fichier — règle CLAUDE.md).
+
+## Skills `.claude/skills/` — slash-commands mandatés
+
+15 skills invoquables en slash-command (`/<nom>`). Là où un skill couvre une tâche récurrente, **l'utiliser plutôt que de réimproviser le workflow** (mandat user 2026-05-23 : catalogue clair pour encourager l'usage).
+
+### Workflows actionnables (slash-commands)
+
+| Skill | Quand l'utiliser | Track / Epic |
+|-------|------------------|--------------|
+| `/coordinate` | Reprise session coordination (mémoire + RooSync + issues → briefing + dispatch). `--dispatch`, `--focus`, `--reply-all` | ai-01 chaque wakeup |
+| `/review-student-prs` | **Recycler les TP étudiants** : review + exécution + merge intelligent (exercice résolu → exemple + nouvel exercice à la suite). `--class`, `--timeslot`, `--dry-run` | EPITA-IS / ECE / PrCon, #1455 |
+| `/build-notebook` | Créer/améliorer/corriger un notebook avec scoring qualité itératif (`new\|improve\|fix`) | nouvelles séries (#1454 RL/PPO, GenAI) |
+| `/enrich-notebooks` | Markdown pédagogique (interprétations, transitions). `--execute`, `--fix-errors`, `--iterate` | #1455, GenAI |
+| `/cleanup-notebooks` | Réorganiser markdown enrichi (dédup, hiérarchie). `--hierarchy-only` | post-enrichissement |
+| `/execute-notebook` | Exécution (scripts locaux ou MCP Jupyter). `--mode`, `--batch`, `--save` | validation toutes séries |
+| `/verify-notebooks` | Vérif + fix itératif (`--quick`, `--fix`, `--python-only`, `--dotnet-only`) | gate avant PR |
+| `/validate-genai` | Valider stack GenAI (services, auth, modèles, notebooks, VRAM). `--local`, `--remote`, `--quick` | GenAI hosting, #1385 |
+| `/analyze-slides` | Analyse qualitative deck PPTX via vision AI. `--render`, `--slides` | tracks slides EPITA/ECE |
+| `/qc-iterative-improve` | Workflow amélioration stratégies QC (`[strategy\|issue#]`, `--iterations`, `--backtest`) | #1409 trading |
+| `/train-model` | Entraîner un modèle ML (thermal-safe GPU, walk-forward + multi-seed + DM). `--dry-run`, `--seeds`, `--folds`, `--bg` | #1454 Training |
+| `/genai-iterate` | Itérer un notebook GenAI contre la stack (auth, sous-domaines, quant, GPU/VRAM) via CLI genai-stack. `--service`, `--quant`, `--validate`, `--bg` | #1385 GenAI |
+
+### Skills de référence (chargés à la demande, pas de slash-command actif)
+
+| Skill | Contenu |
+|-------|---------|
+| `mcp-jupyter` | Référence outils MCP Jupyter (kernels, exécution cellule, Papermill) |
+| `notebook-helpers` | Référence `notebook_helpers.py` / `notebook_tools.py` (manipulation, structure) |
+| `notebook-patterns` | Patterns pédagogiques d'enrichissement (modèle GameTheory) |
+
+**`/review-student-prs` = canal canonique du recyclage TP** : il applique déjà la convention exercice→exemple ([.claude/rules/exercise-example-labeling.md](../.claude/rules/exercise-example-labeling.md)) + la review bienveillante + bypass CI/template ([.claude/rules/student-pr-reviews.md](../.claude/rules/student-pr-reviews.md)). Ne pas réécrire ce workflow à la main.
+
+## Voir aussi
+
+- [.claude/rules/proactive-coordination.md](../.claude/rules/proactive-coordination.md) — modèle 1 PR/wakeup + main/side-track + délégation async
+- [docs/scripts-reference.md](scripts-reference.md) — scripts du dépôt (maintenance, exécution, catalogue)
+- [docs/claude-code-config.md](claude-code-config.md) — agents, skills, rules, model selection


### PR DESCRIPTION
## Summary

Implémente le mandat user 2026-05-23 : coordination plus directive (1 PR/wakeup, 2 tracks min), side-tracks délégués aux sous-agents async, et **catalogue clair dans CLAUDE.md** pour encourager l'usage des agents/skills/scripts existants.

### Gouvernance & catalogue
- **CLAUDE.md** : nouvelle section *"Catalogue agents/skills/scripts — USAGE MANDATÉ"* (3 tables : 21 sous-agents par famille, 15 skills slash-commands, pointeur scripts) + règle HARD de délégation async + pointeurs.
- **.claude/rules/proactive-coordination.md** : règle HARD (≥1 PR/wakeup, main track + side-track async, mapping machine→tracks, anti-patterns).
- **docs/subagents-reference.md** : roster 21 sous-agents + 15 skills, mapping side-track Epic→specialists.
- **docs/scripts-reference.md** : catalogue des scripts du dépôt (anti one-off ad-hoc).

### 3 spécialistes side-track créés (corollaire du mandat Epics)
- **`agents/prover-forensic.md`** (#1453) — forensic **read-only** des traces du harness Lean ; comble le GAP prover documenté. Ancré dans `agent_tests/prover/`.
- **`agents/training-specialist.md` + `skills/train-model`** (#1454) — training ML thermal-safe (MAX_TEMP=80C, `cool_sleep`) + walk-forward/multi-seed/DM. Ancré dans `ML-Training-Pipeline`. **NB vérifié** : `gpu_training.py` est absent du dépôt → le watchdog tombe en **no-op silencieux** (fallback `ImportError`) ; le skill exige de vérifier le module importable **avant tout run GPU**.
- **`agents/genai-iterator.md` + `skills/genai-iterate`** (#1385) — itération notebooks GenAI vs stack auto-hébergée via CLI `genai-stack` (auth, sous-domaines, quantization Nunchaku INT4/FP8, GPU/VRAM). Secrets gitignored only.

### Validation
- Docs/markdown uniquement — aucun code exécutable modifié.
- Chaque spécialiste ancré dans des artefacts réels du dépôt (vérifiés par grep/Read), pas de script fantôme (règle verify-before-claiming).
- Stage par nom de fichier explicite ; aucun checkpoint `.pt` inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)