### PR TITLE
feat(validation): CI workflow + --execute mode (#665)

### DIFF
--- a/.github/workflows/validation-matrix.yml
+++ b/.github/workflows/validation-matrix.yml
@@ -1,0 +1,68 @@
+name: Validation Matrix
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.ipynb'
+      - 'scripts/validation/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.ipynb'
+      - 'scripts/validation/**'
+  workflow_dispatch:
+    inputs:
+      family:
+        description: 'Family to validate (empty = all)'
+        required: false
+        default: ''
+      quick:
+        description: 'Quick mode (structure only)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyyaml nbformat
+
+    - name: Install notebook_tools
+      run: |
+        pip install -r scripts/notebook_tools/requirements.txt 2>/dev/null || true
+        pip install papermill 2>/dev/null || true
+
+    - name: Run validation matrix
+      run: |
+        ARGS=""
+        if [ -n "${{ github.event.inputs.family }}" ]; then
+          ARGS="--family ${{ github.event.inputs.family }}"
+        else
+          ARGS="--all"
+        fi
+        if [ "${{ github.event.inputs.quick }}" = "true" ]; then
+          ARGS="$ARGS --quick"
+        fi
+        python scripts/validation/dispatch.py $ARGS --json --save
+      continue-on-error: true
+
+    - name: Upload validation results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: validation-results
+        path: results/validation_run_*.json
+        retention-days: 30

--- a/scripts/validation/dispatch.py
+++ b/scripts/validation/dispatch.py
@@ -11,6 +11,8 @@ Usage:
     python dispatch.py --all --quick               # Quick scan all
     python dispatch.py --all --json                # JSON output
     python dispatch.py --summary                   # Summary table only
+    python dispatch.py --family Search --execute   # Execute via Papermill
+    python dispatch.py --family Sudoku --execute   # Execute (cell-by-cell for .NET)
 
 Output:
     Per-family pass/fail/warn counts + maturity distribution + BROKEN list.
@@ -32,7 +34,7 @@ NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
 sys.path.insert(0, str(SCRIPTS_DIR / "notebook_tools"))
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from notebook_tools import NotebookValidator, discover_notebooks
+from notebook_tools import NotebookValidator, NotebookExecutor, discover_notebooks
 
 
 def load_matrix() -> dict:
@@ -216,6 +218,69 @@ def build_aggregate(all_results: list[dict]) -> dict:
     }
 
 
+def execute_family(
+    family_name: str,
+    family_config: dict,
+    timeout: int | None = None,
+) -> dict:
+    """Execute notebooks in a family using Papermill or cell-by-cell.
+
+    Delegates to NotebookExecutor which handles kernel detection and
+    per-kernel execution strategies (Papermill for Python, cell-by-cell
+    for .NET Interactive, etc.).
+    """
+    import time
+
+    t0 = time.time()
+    notebooks = get_family_notebooks(family_name, family_config)
+    default_timeout = timeout or family_config.get("timeout", 300)
+    strategy = family_config.get("strategy", "papermill")
+
+    results = {
+        "name": family_name,
+        "total": len(notebooks),
+        "executed": 0,
+        "success": 0,
+        "fail": 0,
+        "skipped": 0,
+        "errors": [],
+        "duration_s": 0.0,
+    }
+
+    for nb_path in notebooks:
+        if ".ipynb_checkpoints" in str(nb_path):
+            continue
+
+        try:
+            executor = NotebookExecutor(nb_path)
+            cell_by_cell = strategy in ("cell-by-cell", "mixed")
+            result = executor.execute_with_papermill(
+                timeout=default_timeout,
+                batch_mode=True,
+            ) if not cell_by_cell else executor.execute_cell_by_cell(
+                timeout=default_timeout,
+            )
+
+            results["executed"] += 1
+            if result.success:
+                results["success"] += 1
+            else:
+                results["fail"] += 1
+                results["errors"].append({
+                    "path": str(nb_path.relative_to(REPO_ROOT)),
+                    "reason": result.message[:200],
+                })
+        except Exception as e:
+            results["fail"] += 1
+            results["errors"].append({
+                "path": str(nb_path.relative_to(REPO_ROOT)),
+                "reason": str(e)[:200],
+            })
+
+    results["duration_s"] = round(time.time() - t0, 1)
+    return results
+
+
 def print_report(all_results: list[dict], json_output: bool = False):
     """Print validation report."""
     if json_output:
@@ -274,6 +339,10 @@ def main():
     parser.add_argument("--family", help="Validate a single family")
     parser.add_argument("--all", action="store_true", help="Validate all families")
     parser.add_argument("--quick", action="store_true", help="Structure check only")
+    parser.add_argument("--execute", action="store_true",
+                        help="Execute notebooks (Papermill/cell-by-cell)")
+    parser.add_argument("--timeout", type=int, default=None,
+                        help="Override timeout in seconds for --execute")
     parser.add_argument("--json", action="store_true", help="JSON output")
     parser.add_argument("--summary", action="store_true", help="Summary table only")
     parser.add_argument(
@@ -299,11 +368,20 @@ def main():
 
     all_results = []
     for name, config in targets.items():
-        print(f"Validating {name}...", end=" ", flush=True)
-        result = validate_family(name, config, quick=args.quick)
-        status = "OK" if result["fail"] == 0 else f"{result['fail']} FAIL"
-        print(f"{result['total']} notebooks, {status} ({result['duration_s']}s)")
-        all_results.append(result)
+        if args.execute:
+            print(f"Executing {name}...", end=" ", flush=True)
+            result = execute_family(name, config, timeout=args.timeout)
+            status = f"{result['success']}/{result['total']} OK"
+            if result["fail"]:
+                status += f" ({result['fail']} FAIL)"
+            print(f"{result['total']} notebooks, {status} ({result['duration_s']}s)")
+            all_results.append(result)
+        else:
+            print(f"Validating {name}...", end=" ", flush=True)
+            result = validate_family(name, config, quick=args.quick)
+            status = "OK" if result["fail"] == 0 else f"{result['fail']} FAIL"
+            print(f"{result['total']} notebooks, {status} ({result['duration_s']}s)")
+            all_results.append(result)
 
     print_report(all_results, json_output=args.json)
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/validation-matrix.yml` — runs `dispatch.py` on push/PR touching notebooks or validation scripts, supports manual trigger with family selection and quick mode
- Add `--execute` flag to `dispatch.py` — delegates to `NotebookExecutor` for Papermill or cell-by-cell execution per family strategy
- Add `--timeout` flag for execution timeout override
- Uploads timestamped JSON results as CI artifact

## Test plan
- [x] `python scripts/validation/dispatch.py --all --quick` — 788 notebooks, 11 families, 88.8% pass rate
- [x] `python scripts/validation/dispatch.py --family Search --quick` — 90 notebooks, 6 FAIL (known)
- [x] `python scripts/validation/dispatch.py --family GenAI --quick` — 184 notebooks, 0 FAIL
- [x] `python scripts/validation/dispatch.py --family QuantConnect --quick` — 177 notebooks, 34 FAIL (known QC cloud-only)
- [ ] CI workflow triggers on next notebook push

Addresses #665 (CI workflow + dispatch.py enhancements for 4 pilot families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)