### PR TITLE
fix(catalog): exclude TODOs in executed cells from maturity heuristic

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -238,11 +238,18 @@ def determine_status(
     return "READY"
 
 
-def count_todos(notebook: dict) -> int:
-    """Count # TODO markers across all code cells."""
+def count_todos(notebook: dict, *, exclude_executed: bool = True) -> int:
+    """Count # TODO markers across code cells.
+
+    When exclude_executed=True (default), TODOs in cells that have been
+    executed with outputs are excluded — they represent resolved exercises,
+    not incomplete work.
+    """
     count = 0
     for cell in notebook.get("cells", []):
         if cell["cell_type"] == "code":
+            if exclude_executed and cell.get("outputs"):
+                continue
             src = "".join(cell.get("source", []))
             count += src.upper().count("# TODO")
     return count


### PR DESCRIPTION
## Summary
- Fix `count_todos()` in `generate_catalog.py` to exclude TODOs in code cells that already have outputs (resolved exercises)
- Prevents notebooks with completed student exercises from being misclassified as DRAFT
- Clean rebase of #1477 — **script-only**, no generated catalog artifacts

## Supersedes
- Closes #1477 (dirty with catalog artifact conflicts)

## Test plan
- [x] Script runs without error (`python generate_catalog.py --all`)
- [x] Expected effect: notebooks with resolved exercises classify higher (DRAFT→ALPHA/BETA)
- [ ] ai-01 regenerates catalog post-merge to apply new heuristic

🤖 Generated with [Claude Code](https://claude.com/claude-code)