### PR TITLE
fix(validation): exclude _output.ipynb duplicates + accurate total count

### DIFF
--- a/scripts/validation/dispatch.py
+++ b/scripts/validation/dispatch.py
@@ -73,7 +73,7 @@ def validate_family(
 
     results = {
         "name": family_name,
-        "total": len(notebooks),
+        "total": 0,
         "pass": 0,
         "warn": 0,
         "fail": 0,
@@ -84,9 +84,13 @@ def validate_family(
     }
 
     for nb_path in notebooks:
+        name = nb_path.name
         if ".ipynb_checkpoints" in str(nb_path):
             continue
+        if name.endswith("_output.ipynb"):
+            continue
 
+        results["total"] += 1
         validator = NotebookValidator(nb_path)
         struct = validator.validate_structure()
 
@@ -238,7 +242,7 @@ def execute_family(
 
     results = {
         "name": family_name,
-        "total": len(notebooks),
+        "total": 0,
         "executed": 0,
         "success": 0,
         "fail": 0,
@@ -248,9 +252,13 @@ def execute_family(
     }
 
     for nb_path in notebooks:
+        name = nb_path.name
         if ".ipynb_checkpoints" in str(nb_path):
             continue
+        if name.endswith("_output.ipynb"):
+            continue
 
+        results["total"] += 1
         try:
             executor = NotebookExecutor(nb_path)
             cell_by_cell = strategy in ("cell-by-cell", "mixed")


### PR DESCRIPTION
## Summary
- Exclude catalog-generated `_output.ipynb` files from validation scanning (both `validate_family()` and `execute_family()`)
- Fix `total` count to reflect only processed notebooks instead of all discovered files
- 555 notebooks validated accurately (was 788 with 233 duplicates), 35 BROKEN (was 70 with 35 false positives)

## Validation results (full scan, 11 families)

| Family | Total | PASS | WARN | FAIL | PROD | BETA | ALPHA | DRAFT |
|--------|-------|------|------|------|------|------|-------|-------|
| Search | 45 | 13 | 32 | 0 | 7 | 11 | 27 | 0 |
| Sudoku | 32 | 25 | 7 | 0 | 22 | 2 | 8 | 0 |
| SymbolicAI | 92 | 73 | 18 | 1 | 51 | 2 | 38 | 1 |
| GenAI | 110 | 105 | 5 | 0 | 26 | 0 | 82 | 2 |
| ML | 30 | 30 | 0 | 0 | 11 | 0 | 19 | 0 |
| QuantConnect | 175 | 114 | 27 | 34 | 94 | 5 | 56 | 20 |
| Probas | 32 | 10 | 22 | 0 | 11 | 5 | 16 | 0 |
| GameTheory | 28 | 10 | 18 | 0 | 7 | 3 | 18 | 0 |
| IIT | 1 | 1 | 0 | 0 | 0 | 0 | 1 | 0 |
| CaseStudies | 4 | 4 | 0 | 0 | 2 | 0 | 2 | 0 |
| RL | 6 | 4 | 2 | 0 | 2 | 0 | 4 | 0 |
| **TOTAL** | **555** | **389** | **131** | **35** | **233** | **28** | **271** | **23** |

**Release-level** (PROD + BETA): 261/555 (47%)
**Pass rate**: 70.1%
**BROKEN**: 35 (34 QuantConnect cloud-only + 1 SymbolicAI archive)

## Test plan
- [x] `python scripts/validation/dispatch.py --all --quick` — 555 notebooks, 0s
- [x] `python scripts/validation/dispatch.py --all` — 555 notebooks, full content validation
- [x] `python scripts/validation/dispatch.py --all --save` — JSON results saved

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)