### PR TITLE
feat(misc): modernize 10 CaseStudies/ML/RL notebooks — nav headers (#999)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../README.md)\n",
     "# CC1 - IA Exploratoire et Symbolique\n",
     "## Système de Diagnostic Médical Multi-Contraintes pour le Diabète de Type 2\n",
     "\n",
@@ -2292,7 +2293,10 @@
     "✅ **Optimisation** : Algorithmes génétiques\n",
     "✅ **Application Biomédicale** : Diagnostic du diabète de type 2\n",
     "\n",
-    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents."
+    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../README.md)\n",
     "# CC1 - IA Exploratoire et Symbolique\n",
     "## Système de Diagnostic Médical Multi-Contraintes pour le Diabète de Type 2\n",
     "\n",
@@ -1199,7 +1200,10 @@
     "✅ **Optimisation** : Algorithmes génétiques\n",
     "✅ **Application Biomédicale** : Diagnostic du diabète de type 2\n",
     "\n",
-    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents."
+    "Les compétences développées sont directement transférables à d'autres domaines nécessitant des systèmes de décision intelligents.",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "**Navigation** : [Index](../../README.md)\n",
     "# CC2 : OncoPlan - Corrigé Type\n",
     "\n",
     "**Cours :** IA101 - Intelligence Artificielle (EPF 2026)\n",
@@ -456,7 +457,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Partie 3 : Bonus Smart Contract"
+    "## Partie 3 : Bonus Smart Contract",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../README.md)\n",
     "# CC2 : OncoPlan - Squelette\n",
     "\n",
     "**Cours :** IA101 - Intelligence Artificielle (EPF 2026)\n",
@@ -623,7 +624,10 @@
    "source": [
     "## Partie 3 : Bonus Smart Contract\n",
     "\n",
-    "**Objectif :** Garantir l'intégrité du plan de traitement."
+    "**Objectif :** Garantir l'intégrité du plan de traitement.",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index CaseStudies](../../README.md)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../../../README.md) | [<< Lab4](../Lab4-DataWrangling/Lab4-DataWrangling.ipynb) | [Lab6 >>](../Lab6-First-Agent/Lab6-First-Agent.ipynb)\n",
     "# Lab 5 - De la Visualisation au Machine Learning"
    ]
   },
@@ -672,7 +673,10 @@
    "source": [
     "## Exemple guidé\n",
     "\n",
-    "À vous de pratiquer la visualisation et la classification binaire !"
+    "À vous de pratiquer la visualisation et la classification binaire !",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index ML](../../../../README.md)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML_executed.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab5-Viz-ML/Lab5-Viz-ML_executed.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../../../README.md) | [<< Lab4](../Lab4-DataWrangling/Lab4-DataWrangling.ipynb) | [Lab6 >>](../Lab6-First-Agent/Lab6-First-Agent.ipynb)\n",
     "# Lab 5 - De la Visualisation au Machine Learning"
    ]
   },
@@ -640,7 +641,10 @@
    "source": [
     "## Exemple guidé\n",
     "\n",
-    "À vous de pratiquer la visualisation et la classification binaire !"
+    "À vous de pratiquer la visualisation et la classification binaire !",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index ML](../../../../README.md)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](../../../../README.md) | [<< Lab5](../Lab5-Viz-ML/Lab5-Viz-ML.ipynb) | [Lab7 >>](../../../Day4/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb)\n",
     "# Lab 6 - Anatomie de votre premier Agent d'IA"
    ]
   },
@@ -447,7 +448,10 @@
    "source": [
     "## Exemple guidé\n",
     "\n",
-    "À vous d'étendre l'agent en lui ajoutant un nouvel outil mathématique !"
+    "À vous d'étendre l'agent en lui ajoutant un nouvel outil mathématique !",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index ML](../../../../README.md)\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/RL/stable_baseline_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/stable_baseline_1_intro_cartpole.ipynb
@@ -15,6 +15,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](README.md) | [RL MDP/Q-Learning >>](rl_4_mdp_dp_qlearning.ipynb)\n",
     "# Tutoriel Stable Baselines3 - Premiers pas\n",
     "\n",
     "\n",
@@ -1152,7 +1153,10 @@
     "## Conclusion\n",
     "\n",
     "Dans ce notebook, nous avons vu :\n",
-    "- comment définir et entraîner un modèle RL à l’aide de Stable Baselines3 (en une seule ligne de code) ;)\n"
+    "- comment définir et entraîner un modèle RL à l’aide de Stable Baselines3 (en une seule ligne de code) ;)\n",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index RL](README.md)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/RL/stable_baseline_2_wrappers_sauvegarde_callbacks.ipynb
+++ b/MyIA.AI.Notebooks/RL/stable_baseline_2_wrappers_sauvegarde_callbacks.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](README.md) | [<< SB1 Intro](stable_baseline_1_intro_cartpole.ipynb) | [SB3 Experience Replay >>](stable_baseline_3_experience_replay_dqn.ipynb)\n",
     "# Notebook 2 – Wrappers Gym, Sauvegarde/Chargement, Multiprocessing, Callbacks et Environnements Personnalisés\n",
     "\n",
     "Ce notebook propose un survol des fonctionnalités avancées de la librairie [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3) :\n",
@@ -848,7 +849,10 @@
     "- Les **callbacks**, permettant d’intervenir pendant l’entraînement (sauvegarde automatique du meilleur modèle, monitoring, etc.).\n",
     "- La **création d’un environnement Gym personnalisé**, validé ensuite par la fonction `check_env` et compatible avec tout algorithme Stable-Baselines3.\n",
     "\n",
-    "Vous pouvez maintenant adapter et combiner ces techniques pour vos propres projets d’Apprentissage par Renforcement !"
+    "Vous pouvez maintenant adapter et combiner ces techniques pour vos propres projets d’Apprentissage par Renforcement !",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index RL](README.md)\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/RL/stable_baseline_3_experience_replay_dqn.ipynb
+++ b/MyIA.AI.Notebooks/RL/stable_baseline_3_experience_replay_dqn.ipynb
@@ -14,6 +14,7 @@
     "tags": []
    },
    "source": [
+    "**Navigation** : [Index](README.md) | [<< SB2 Wrappers](stable_baseline_2_wrappers_sauvegarde_callbacks.ipynb) | [DQN/PPO >>](rl_5_dqn_policy_gradient.ipynb)\n",
     "# Notebook 3 – Hindsight Experience Replay (HER) et Sauvegarde Avancée\n",
     "\n",
     "Dans ce troisième notebook, nous allons aborder plusieurs sujets avancés :\n",
@@ -1424,7 +1425,10 @@
     "- la **sauvegarde et le rechargement** de la replay buffer pour reprendre un entraînement ultérieurement,\n",
     "- l’enregistrement vidéo « friendly pour Windows », sans dépendances `apt-get`.\n",
     "\n",
-    "Avec cela, vous disposez d’une base solide pour traiter des tâches plus complexes en Apprentissage par Renforcement, où l’agent doit atteindre des objectifs spécifiques."
+    "Avec cela, vous disposez d’une base solide pour traiter des tâches plus complexes en Apprentissage par Renforcement, où l’agent doit atteindre des objectifs spécifiques.",
+    "\n",
+    "---\n",
+    "**Retour au sommaire** : [Index RL](README.md)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Add navigation headers (prev/next/README) to 10 notebooks across 3 families
- Families: CaseStudies (4), ML (3), RL (3)
- Markdown-only changes, outputs preserved from main

## Verification
- C.1 compliance: verified, no `raise NotImplementedError`
- Output preservation: 0 losses vs main
- Source format: no new string-format cells introduced

Part of #999 modernization side-track.