### PR TITLE
fix(gradebook): match groups by leading code (EPITA PrCon eval labels)

### DIFF
--- a/GradeBookApp/gradebook.py
+++ b/GradeBookApp/gradebook.py
@@ -314,6 +314,18 @@ def palier_group_size_adjustment(group_size):
     return group_size_adjustments.get(group_size, -2.0)
 
 
+def _leading_group_code(normalized):
+    """Extrait le code de groupe en tete (a1, a2b, h1_v2, m2...) s'il existe.
+
+    Les deux sources (inscription et evaluations) prefixent le sujet par un
+    code unique. C'est la cle de jointure fiable : le separateur (tiret vs
+    cadratin) et les noms entre parentheses cote evaluation rendent le fuzzy
+    matching du libelle complet inoperant.
+    """
+    match = re.match(r'^([a-z]+\d+[a-z0-9_]*)\b', normalized)
+    return match.group(1) if match else None
+
+
 def fuzzy_match_group(eval_group_name, student_project_string):
     """
     Correspondance entre nom de groupe évalué et nom de projet inscrit.
@@ -331,6 +343,15 @@ def fuzzy_match_group(eval_group_name, student_project_string):
     student_norm = re.sub(r'\s+', ' ', student_norm)
     eval_norm = eval_norm.replace(' / ', ' - ').replace('/', '-')
     student_norm = student_norm.replace(' / ', ' - ').replace('/', '-')
+
+    # Cas 0 (prioritaire) : code de groupe en tete identique.
+    # Quand les deux libelles portent un code (a1, a2b, h1_v2...), c'est la
+    # cle canonique : codes egaux => meme groupe ; codes differents => groupes
+    # distincts (on n'autorise pas le fuzz a rapprocher deux codes distincts).
+    eval_code = _leading_group_code(eval_norm)
+    student_code = _leading_group_code(student_norm)
+    if eval_code and student_code:
+        return eval_code == student_code
 
     # Cas 1: Correspondance exacte
     if eval_norm == student_norm:


### PR DESCRIPTION
## Contexte

Pipeline de notation EPITA PrCon 2026 (#927). Les libelles d'evaluation (Google Forms) et les sujets d'inscription utilisent des formats divergents qui mettaient le fuzzy matching en echec :

- **Evaluation** : cadratin + noms entre parentheses
  `K1 — Planification Urbaine (Buisseret, Francil, Lefevre-Pontalis)`
- **Inscription** : tiret + pas de noms
  `K1 - Planification urbaine et placement d'infrastructures`

`fuzz.ratio < 90` et aucune sous-chaine commune => **0 groupe apparie** (tous les groupes rejetes "aucun membre inscrit").

## Fix

- `_leading_group_code(normalized)` extrait le code de groupe en tete (`a1`, `a2b`, `h1_v2`, `m2`...).
- Nouveau **Cas 0 prioritaire** dans `fuzzy_match_group` : si les deux libelles portent un code, l'egalite des codes est la cle de jointure canonique (codes egaux => meme groupe ; codes differents => groupes distincts, le fuzz ne peut plus rapprocher deux codes distincts).

## Retro-compatibilite

Additif (+21/-0). Cas 0 ne se declenche que si **les deux** chaines portent un code `[a-z]+\d+` en tete ; sinon comportement strictement inchange (configs EPF preservees). `re` deja importe.

## Validation

Pipeline `epf_2026_prcon.py` execute end-to-end apres le fix : 32 groupes apparies, 71 etudiants, couverture prof complete (34 lignes jsboige@gmail.com). `Notes_Finales_PrCon_2026.xlsx` genere sur GDrive (hors repo).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>