### PR TITLE
feat(gt): modernize 2 GameTheory notebooks — nav headers (#999)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Navigation** : [Notebooks](../) | \n",
+    "> **Serie** : GameTheory-1-Setup\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "90911ae5",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
@@ -2,6 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Navigation** : [Notebooks](../) | \n",
+    "> **Serie** : SocialChoice 01 - Theoreme d'Arrow : Preuve Formelle et Simulation\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a0f1b2c3",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary
- Add navigation headers to GameTheory-1-Setup and Arrow-Impossibility-Theorem
- Markdown-only changes, outputs preserved

Part of #999 modernization side-track.