### PR TITLE
feat(qc): add navigation headers to QC-Py-01 to QC-Py-05 (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -5,6 +5,8 @@
    "id": "1",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Suivant : QC-Py-02-Platform-Fundamentals >>](./QC-Py-02-Platform-Fundamentals.ipynb)\n",
+    "\n",
     "# QC-Py-01 : Configuration et Premier Backtest QuantConnect\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -5,6 +5,8 @@
    "id": "intro-section",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-01-Setup <<](./QC-Py-01-Setup.ipynb) | [Suivant : QC-Py-03-Data-Management >>](./QC-Py-03-Data-Management.ipynb)\n",
+    "\n",
     "# QC-Py-02 : QuantConnect Platform Fundamentals - QCAlgorithm Lifecycle\n",
     "\n",
     "## Introduction\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-03-Data-Management.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-02-Platform-Fundamentals <<](./QC-Py-02-Platform-Fundamentals.ipynb) | [Suivant : QC-Py-04-Research-Workflow >>](./QC-Py-04-Research-Workflow.ipynb)\n",
+    "\n",
     "# QC-Py-03 - Data Management in QuantConnect\n",
     "\n",
     "## History API et Consolidators\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-03-Data-Management <<](./QC-Py-03-Data-Management.ipynb) | [Suivant : QC-Py-05-Universe-Selection >>](./QC-Py-05-Universe-Selection.ipynb)\n",
+    "\n",
     "# QC-Py-04 - Research Workflow with QuantBook\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-04-Research-Workflow <<](./QC-Py-04-Research-Workflow.ipynb) | [Suivant : QC-Py-06-Options-Trading >>](./QC-Py-06-Options-Trading.ipynb)\n",
+    "\n",
     "# QC-Py-05 - Universe Selection dans QuantConnect\n",
     "\n",
     "> **Selection dynamique d'actifs pour des strategies multi-assets**\n",


### PR DESCRIPTION
## Summary
- Add navigation links (prev/next/sommaire QC) to first markdown cell of 5 QuantConnect Python pedagogical notebooks (QC-Py-01 through QC-Py-05)
- Part of modernization side-track #999

## Scope
5 files, markdown-only changes (nav headers added to first cell), 0 code changes, 0 H.3 violations introduced.

## Notebooks modified
| Notebook | Nav added |
|----------|-----------|
| QC-Py-01-Setup | Yes |
| QC-Py-02-Platform-Fundamentals | Yes |
| QC-Py-03-Data-Management | Yes |
| QC-Py-04-Research-Workflow | Yes |
| QC-Py-05-Universe-Selection | Yes |

## Pre-existing issues (NOT introduced by this PR)
- QC-Py-03 and QC-Py-05 have string-format source cells and H.3 violations (null exec_count) — these are QC Cloud notebooks that cannot be executed locally. These issues exist identically on main.

Closes #999 (partial — 5/52 QC pedagogical notebooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>