### PR TITLE
feat(qc): add navigation headers to QC-Py-07 to QC-Py-11 (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-06-Options-Trading <<](./QC-Py-06-Options-Trading.ipynb) | [Suivant : QC-Py-08-Multi-Asset-Strategies >>](./QC-Py-08-Multi-Asset-Strategies.ipynb)\n",
+    "\n",
     "# QC-Py-07 : Futures et Forex Trading dans QuantConnect\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-08-Multi-Asset-Strategies.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-07-Futures-Forex <<](./QC-Py-07-Futures-Forex.ipynb) | [Suivant : QC-Py-09-Order-Types >>](./QC-Py-09-Order-Types.ipynb)\n",
+    "\n",
     "# QC-Py-08 - Multi-Asset Portfolio Strategies\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -5,6 +5,8 @@
    "id": "cell-intro",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-08-Multi-Asset-Strategies <<](./QC-Py-08-Multi-Asset-Strategies.ipynb) | [Suivant : QC-Py-10-Risk-Portfolio-Management >>](./QC-Py-10-Risk-Portfolio-Management.ipynb)\n",
+    "\n",
     "# QC-Py-09 : Types d'Ordres et Order Management dans QuantConnect\n",
     "\n",
     "**Duree estimee** : 75 minutes\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-09-Order-Types <<](./QC-Py-09-Order-Types.ipynb) | [Suivant : QC-Py-11-Technical-Indicators >>](./QC-Py-11-Technical-Indicators.ipynb)\n",
+    "\n",
     "# QC-Py-10 - Risk Management et Portfolio Management\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -5,6 +5,8 @@
    "id": "cell-0",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-10-Risk-Portfolio-Management <<](./QC-Py-10-Risk-Portfolio-Management.ipynb) | [Suivant : QC-Py-12-Backtesting-Analysis >>](./QC-Py-12-Backtesting-Analysis.ipynb)\n",
+    "\n",
     "# QC-Py-11 - Indicateurs Techniques dans QuantConnect\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",


### PR DESCRIPTION
## Summary
- Add navigation links (prev/next/sommaire QC) to first markdown cell of 5 QuantConnect Python pedagogical notebooks (QC-Py-07 through QC-Py-11)
- Part of modernization side-track #999

## Scope
5 files, markdown-only changes (nav headers added to first cell), 0 code changes.

## Notebooks modified
| Notebook | Nav added |
|----------|-----------|
| QC-Py-07-Futures-Forex | Yes |
| QC-Py-08-Multi-Asset-Strategies | Yes |
| QC-Py-09-Order-Types | Yes |
| QC-Py-10-Risk-Portfolio-Management | Yes |
| QC-Py-11-Technical-Indicators | Yes |

Closes #999 (partial — 10/52 QC pedagogical notebooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>