### PR TITLE
feat(qc): add navigation headers to QC-Py-12 to QC-Py-16 (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-11-Technical-Indicators <<](./QC-Py-11-Technical-Indicators.ipynb) | [Suivant : QC-Py-13-Alpha-Models >>](./QC-Py-13-Alpha-Models.ipynb)\n",
+    "\n",
     "# QC-Py-12 - Backtesting et Analyse de Performance\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-12-Backtesting-Analysis <<](./QC-Py-12-Backtesting-Analysis.ipynb) | [Suivant : QC-Py-14-Portfolio-Construction-Execution >>](./QC-Py-14-Portfolio-Construction-Execution.ipynb)\n",
+    "\n",
     "# QC-Py-13 - Alpha Models et Algorithm Framework\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-13-Alpha-Models <<](./QC-Py-13-Alpha-Models.ipynb) | [Suivant : QC-Py-15-Parameter-Optimization >>](./QC-Py-15-Parameter-Optimization.ipynb)\n",
+    "\n",
     "# QC-Py-14 - Portfolio Construction et Execution Models\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-14-Portfolio-Construction-Execution <<](./QC-Py-14-Portfolio-Construction-Execution.ipynb) | [Suivant : QC-Py-16-Alternative-Data >>](./QC-Py-16-Alternative-Data.ipynb)\n",
+    "\n",
     "# QC-Py-15 - Parameter Optimization et Walk-Forward Analysis\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-15-Parameter-Optimization <<](./QC-Py-15-Parameter-Optimization.ipynb) | [Suivant : QC-Py-17-Sentiment-Analysis >>](./QC-Py-17-Sentiment-Analysis.ipynb)\n",
+    "\n",
     "# QC-Py-16 - Alternative Data dans QuantConnect\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",


### PR DESCRIPTION
## Summary
- Add navigation links (prev/next/sommaire QC) to first markdown cell of 5 QuantConnect Python pedagogical notebooks (QC-Py-12 through QC-Py-16)
- Part of modernization side-track #999

## Scope
5 files, markdown-only changes (nav headers added to first cell), 0 code changes.

## Notebooks modified
| Notebook | Nav added |
|----------|-----------|
| QC-Py-12-Backtesting-Analysis | Yes |
| QC-Py-13-Alpha-Models | Yes |
| QC-Py-14-Portfolio-Construction-Execution | Yes |
| QC-Py-15-Parameter-Optimization | Yes |
| QC-Py-16-Alternative-Data | Yes |

Closes #999 (partial — 15/52 QC pedagogical notebooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>