### PR TITLE
docs(teaching): refresh calendar — PrCon done, ESGF grading early June, TP collision protocol

### DIFF
--- a/docs/teaching-context.md
+++ b/docs/teaching-context.md
@@ -8,9 +8,9 @@ Documentation transversale sur l'organisation de l'enseignement annuel : calendr
 |-------|-------|---------------------|
 | EPF | GenAI Bachelor 3A (MSBNS3IN03), classes MIN1/MIN2/MIS | Termine, notes transmises |
 | ECE | IA Finance Ing4 (Gr01/02/03) | Termine, notes rendues debut mai |
-| ESGF | Algo Trading QuantConnect | En cours, soutenance batch 1 |
-| EPITA | Programmation par Contraintes | Soutenances 2 batchs (presentiel + visio) |
-| EPITA | IA Symbolique | 5 cours en cours |
+| ESGF | Algo Trading QuantConnect | En cours, soutenances finales fin mai, **grading debut juin** |
+| EPITA | Programmation par Contraintes | Soutenances 2 batchs **terminees**, suivi TP bonus rempli, notes projet faites |
+| EPITA | IA Symbolique | Cours en cours ; TPs notebooks rendus sur CoursIA = points bonus des projets EPITA-IS |
 
 ## Calendrier general 2026 (printemps)
 
@@ -22,8 +22,8 @@ Les jalons annuels recurrents :
 |---------|---------------|
 | Janvier-Fevrier | Cours EPF GenAI + cours EPITA-PrCon (slides + notebooks) |
 | Mars-Avril | Cours ECE IA Finance Ing4 (Gr01/02/03 successifs) + soutenances P1 |
-| Mai | Soutenances ECE P2, soutenances EPITA-PrCon (batch 1 presentiel + batch 2 visio), debut cours EPITA-IA-Symbolique, soutenance ESGF |
-| Juin | Fin cours EPITA-IA-Symbolique + soutenances projet final |
+| Mai | Soutenances ECE P2, soutenances EPITA-PrCon (batch 1 presentiel + batch 2 visio, terminees), debut cours EPITA-IA-Symbolique, soutenances finales ESGF |
+| Juin | **Grading ESGF (debut juin)**, fin cours EPITA-IA-Symbolique + soutenances projet final |
 | Septembre | Rentree (QC League pour anciens ECE, nouvelle promo EPF) |
 
 ## EPITA - IA Symbolique : scope 2026
@@ -55,6 +55,8 @@ Les jalons annuels recurrents :
 - **Workflow** : PR sur **fork du depot `jsboige/CoursIA`** (pattern PrCon : fork + PR sur notebooks)
 - **Le depot `2026-Epita-Intelligence-Symbolique`** = projets/sujets de soutenance, distinct des TPs notebooks
 - **Bonus** : +0.5 / exercice supplementaire meme serie (cap +1), +1 / exercice autre serie (cap +2), +0.5 redaction 1p markdown explicative (demarche, choix techniques, limites)
+- **Application du bonus** : c'est l'**inscription des groupes dans les fichiers de suivi adequats qui fait foi** (G drive `Notation/`), pas la PR mergee ni le keying gradebook sur la chaine sujet
+- **Collisions de TP** (2 groupes, meme exercice) : merger le **meilleur rendu** ou **cherry-pick entre les meilleurs**, puis **close les autres** avec un message expliquant qu'un seul peut etre merge (meme protocole que les TPs PrCon ; cf SW-10 #1429/#1416 -> #1499)
 - **Soutenance** : 10 min presentation + 5 min Q&A, batch presentiel sur creneau cours + batch visio si depassement
 
 ## Agents cluster par ecole


### PR DESCRIPTION
## Summary

Met a jour le calendrier d'enseignement cross-machine (`docs/teaching-context.md`) suite au point user 2026-05-24. Dates nominatives gardees hors repo (policy ligne 17 : G drive + dashboard).

- **ESGF** : soutenances finales fin mai -> **grading a assurer debut juin** (po-2024 + ai-01).
- **EPITA-PrCon** : soutenances 18 + 22 mai **terminees**, suivi TP bonus deja rempli, notes projet faites.
- **EPITA-IS** : les TPs notebooks rendus sur CoursIA cette semaine = **points bonus des projets EPITA-IS**. L'**inscription des groupes dans les fichiers de suivi fait foi** pour l'application du bonus (pas la PR mergee ni le keying gradebook).
- **Collisions de TP** : protocole formalise = merge le meilleur rendu / cherry-pick entre les meilleurs + close les autres (1 seul mergeable). Deja applique SW-10 #1429/#1416 -> #1499.

## Scope
1 fichier, docs-only, calendrier transversal lu par tous les agents en debut de session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)