### PR TITLE
feat(qc): add navigation headers to QC-Py-17 to QC-Py-21 (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-16-Alternative-Data <<](./QC-Py-16-Alternative-Data.ipynb) | [Suivant : QC-Py-18-ML-Features-Engineering >>](./QC-Py-18-ML-Features-Engineering.ipynb)\n",
+    "\n",
     "# QC-Py-17 - Sentiment Analysis pour le Trading\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-17-Sentiment-Analysis <<](./QC-Py-17-Sentiment-Analysis.ipynb) | [Suivant : QC-Py-19-ML-Supervised-Classification >>](./QC-Py-19-ML-Supervised-Classification.ipynb)\n",
+    "\n",
     "# QC-Py-18 - Feature Engineering pour Machine Learning Trading\n",
     "\n",
     "> **Construire des features predictives pour les modeles ML**\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-18-ML-Features-Engineering <<](./QC-Py-18-ML-Features-Engineering.ipynb) | [Suivant : QC-Py-20-ML-Regression-Prediction >>](./QC-Py-20-ML-Regression-Prediction.ipynb)\n",
+    "\n",
     "# QC-Py-19 - Machine Learning Classification pour Direction Prediction\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-19-ML-Supervised-Classification <<](./QC-Py-19-ML-Supervised-Classification.ipynb) | [Suivant : QC-Py-21-Portfolio-Optimization-ML >>](./QC-Py-21-Portfolio-Optimization-ML.ipynb)\n",
+    "\n",
     "# QC-Py-20 - Machine Learning Regression pour Price Prediction\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-20-ML-Regression-Prediction <<](./QC-Py-20-ML-Regression-Prediction.ipynb) | [Suivant : QC-Py-22-Deep-Learning-LSTM >>](./QC-Py-22-Deep-Learning-LSTM.ipynb)\n",
+    "\n",
     "# QC-Py-21 - Portfolio Optimization avec Machine Learning\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",


### PR DESCRIPTION
## Summary
- Add navigation links (prev/next/sommaire QC) to 5 QuantConnect Python notebooks (QC-Py-17 through QC-Py-21)
- Part of modernization side-track #999

## Scope
5 files, markdown-only changes, 0 code changes.

Closes #999 (partial — 20/52 QC pedagogical notebooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>