### PR TITLE
feat(qc): add navigation headers to QC-Py-22 to QC-Py-27 (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-21-Portfolio-Optimization-ML <<](./QC-Py-21-Portfolio-Optimization-ML.ipynb) | [Suivant : QC-Py-23-Attention-Transformers >>](./QC-Py-23-Attention-Transformers.ipynb)\n",
+    "\n",
     "# QC-Py-22 - Modern Time Series Deep Learning (SOTA 2024-2026)\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-22-Deep-Learning-LSTM <<](./QC-Py-22-Deep-Learning-LSTM.ipynb) | [Suivant : QC-Py-23b-PatchTST-iTransformer >>](./QC-Py-23b-PatchTST-iTransformer.ipynb)\n",
+    "\n",
     "# QC-Py-23 - State Space Models (Mamba) pour Trading\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23b-PatchTST-iTransformer.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-23-Attention-Transformers <<](./QC-Py-23-Attention-Transformers.ipynb) | [Suivant : QC-Py-24-Autoencoders-Anomaly >>](./QC-Py-24-Autoencoders-Anomaly.ipynb)\n",
+    "\n",
     "# QC-Py-23b - PatchTST et iTransformer pour Prevision Financiere\n",
     "> **[REFERENCE Pedagogique]** Ce notebook illustre les architectures PatchTST (Nie et al., ICLR 2023) et iTransformer (Liu et al., ICLR 2024) pour la prevision de series temporelles financieres.\n",
     ">\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-23b-PatchTST-iTransformer <<](./QC-Py-23b-PatchTST-iTransformer.ipynb) | [Suivant : QC-Py-25-Reinforcement-Learning >>](./QC-Py-25-Reinforcement-Learning.ipynb)\n",
+    "\n",
     "# QC-Py-24 - Modèles Génératifs pour Anomaly Detection et Régimes\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
@@ -14,6 +14,8 @@
     "tags": []
    },
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-24-Autoencoders-Anomaly <<](./QC-Py-24-Autoencoders-Anomaly.ipynb) | [Suivant : QC-Py-26-LLM-Trading-Signals >>](./QC-Py-26-LLM-Trading-Signals.ipynb)\n",
+    "\n",
     "# QC-Py-25 - Reinforcement Learning pour le Trading\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-25-Reinforcement-Learning <<](./QC-Py-25-Reinforcement-Learning.ipynb) | [Suivant : QC-Py-27-Production-Deployment >>](./QC-Py-27-Production-Deployment.ipynb)\n",
+    "\n",
     "# QC-Py-26 - LLM Trading Signals\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-26-LLM-Trading-Signals <<](./QC-Py-26-LLM-Trading-Signals.ipynb)\n",
+    "\n",
     "# QC-Py-27 - Production Deployment\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",


### PR DESCRIPTION
## Summary
- Add navigation headers to QC-Py-22 through QC-Py-27 (7 notebooks)
- Headers follow the standard pattern: `[<< Sommaire QC](../README.md) | [Precedent <<] | [Suivant >>]`

## Scope
- `MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-*.ipynb` through `QC-Py-27-*.ipynb`
- 7 files, 19 insertions, 0 deletions (markdown-only, no code changes)

## Test plan
- [x] Verified headers present in all 7 notebooks
- [x] No code cells modified (markdown prepend only)
- [x] Previous nav headers not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>