### PR TITLE
feat(qc): add navigation headers to QC-Py-28/35/Dataset-Workflow (#999)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-27-Production-Deployment <<](./QC-Py-27-Production-Deployment.ipynb) | [Suivant : QC-Py-30-LSTM-Training >>](./QC-Py-30-LSTM-Training.ipynb)\n",
+    "\n",
     "# QC-Py-28 - Market Regime Detection\n",
     "> **[QC CLOUD]** Ce notebook utilise QuantBook / AlgorithmImports et necessite un environnement QuantConnect Cloud. Les cellules de code ne sont pas executables localement.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md) | [Precedent : QC-Py-34-RL-SAC-A2C-Trading <<](./QC-Py-34-RL-SAC-A2C-Trading.ipynb) | [Suivant : QC-Py-40-PaperTrading-Binance >>](./QC-Py-40-PaperTrading-Binance.ipynb)\n",
+    "\n",
     "# QC-Py-35 - Reinforcement Learning pour la Construction de Portefeuille\n",
     "\n",
     "> **Niveau** : Avance | **Pre-requis** : QC-Py-32, QC-Py-22 | **Temps** : 90 min\n",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[<< Sommaire QC](../README.md)\n",
+    "\n",
     "# Workflow : Téléchargement et gestion des datasets\n",
     "\n",
     "Ce notebook démontre l'utilisation des scripts `scripts/datasets/` pour télécharger,\n",


### PR DESCRIPTION
## Summary
- Add navigation headers to 3 remaining QC notebooks: QC-Py-28, QC-Py-35, QC-Py-Dataset-Workflow
- Completes nav header coverage for all non-pedagogical QC Python notebooks

## Scope
- 3 files, 8 insertions, 2 deletions (markdown-only, no code changes)

## Test plan
- [x] Verified headers present in all 3 notebooks
- [x] No code cells modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>