### PR TITLE
fix(prover): filter control signals from tactic bridge

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -291,6 +291,10 @@ class AgentExecutor(Executor):
                 and len(self._state.tactic_history) > history_len_before):
             latest = self._state.tactic_history[-1]
             tactic_text = getattr(latest, "tactic", None)
+            # Filter control signals that are NOT valid Lean tactics
+            _CONTROL_SIGNALS = {"LEAVERN", "ABORT", "SKIP", "GIVE_UP"}
+            if tactic_text and tactic_text.strip().upper() in _CONTROL_SIGNALS:
+                tactic_text = None
             if tactic_text:
                 msg.tactic = tactic_text
                 msg.is_decomposition = bool(getattr(latest, "is_decomposition", False))


### PR DESCRIPTION
## Summary
- Filter control signals (`LEAVERN`, `ABORT`, `SKIP`, `GIVE_UP`) in the tactic_bridge before propagating to `msg.tactic`
- Prevents the SearchAgent's "abandon" keyword from being inserted as Lean code by VerifyExecutor

## Context
The SearchAgent prompt instructs it to say "LEAVERN" when a goal is out of reach. When this text leaked through `workflow.py`'s tactic_bridge into `msg.tactic`, VerifyExecutor attempted to insert it as Lean tactic code, causing build failures and wasted iterations. Forensic analysis of L145/L147 traces identified this as one of 5 prover failure modes.

## Test plan
- [ ] Run DEMO 35 (Nash.lean) — should work identically (no regression)
- [ ] Run DEMO 16 (Lattice L145) — LEAVERN no longer appears as proposed tactic
- [ ] `grep -c sorry` unchanged on any file after dry run