### PR TITLE
fix(sl): fix stale nav links + create series README

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/README.md
@@ -1,0 +1,109 @@
+# SymbolicLearning - Apprentissage Symbolique
+
+<!-- CATALOG-STATUS
+series: SymbolicLearning
+pedagogical_count: 2
+breakdown: =2
+maturity: BETA=2
+-->
+
+Comment un agent peut-il apprendre a partir de connaissances existantes plutot que de donnees brutes ? Cette serie explore l'apprentissage symbolique tel que decrit dans le chapitre 19 d'AIMA (Russell & Norvig), depuis l'apprentissage inductif pur (CBH, Version Space) jusqu'aux methodes guidees par la connaissance (EBL, RBL).
+
+Le premier notebook pose les bases : representation d'hypotheses comme conjonctions de contraintes, algorithmes Current-Best-Hypothesis et Candidate Elimination (Version Space), et leurs limites face au bruit et aux concepts disjonctifs. Le second notebook montre comment la connaissance du domaine accelere l'apprentissage : l'apprentissage base sur les explications (EBL) compile les theories en heuristiques operationnelles, et l'apprentissage base sur la pertinence (RBL) identifie les attributs determinant via les determinations.
+
+**A qui s'adresse cette serie** : etudiants en IA, infoirmaticiens interesses par le raisonnement symbolique, et chercheurs en apprentissage automatique souhaitant comprendre les approches non-statistiques. Les notebooks (~2h total) ne necessitent que Python 3.10+ standard library. Une familiarite avec la logique propositionnelle suffit. Ils constituent un complement theorique aux series [Tweety](../Tweety/README.md) (argumentation computationnelle) et [SemanticWeb](../SemanticWeb/README.md) (representation de connaissances).
+
+## Vue d'ensemble
+
+| Statistique | Valeur |
+|-------------|--------|
+| Notebooks | 2 |
+| Kernel | Python 3 |
+| Duree estimee | ~105 min |
+| prerequis | Python 3.10+ (standard library uniquement) |
+
+## Notebooks
+
+| # | Notebook | Contenu | Duree |
+|---|----------|---------|-------|
+| 1 | [SL-1 - Apprentissage Logique](SL-1-LogicalLearning.ipynb) | CBH, Version Space, Candidate Elimination | 50 min |
+| 2 | [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb) | EBL, RBL, determinations | 55 min |
+
+## Contenu detaille
+
+### SL-1-LogicalLearning.ipynb
+
+| Section | Contenu |
+|---------|---------|
+| Domaine restaurant | Attributs, exemples AIMA, hypotheses comme conjonctions |
+| Consistance | Faux positifs/negatifs, verification d'hypotheses |
+| Generalisation/Specialisation | Operations fondamentales, hierarchie de generalite |
+| CBH | Algorithme Current-Best-Hypothesis (AIMA Fig 19.2) |
+| Version Space | Candidate Elimination, G-set et S-set (AIMA Fig 19.3) |
+| Prediction | Strategies unanime, conservateur, majority |
+| Limites | Sensibilite au bruit, incapacite a representer les disjonctions |
+
+### SL-2-KnowledgeBasedLearning.ipynb
+
+| Section | Contenu |
+|---------|---------|
+| Cadre general | Contrainte d'entrainement, EBL vs RBL vs KBIL |
+| EBL - Principe | Exemple de Zog, 4 etapes (expliquer, variabiliser, extraire, simplifier) |
+| EBL - Arithmetique | Simplification d'expressions, arbre de preuve |
+| EBL - Implementation | Classe ArithmeticEBL complete |
+| EBL - Efficacite | Operationalite vs generalite, proliferation de regles |
+| RBL - Determinations | Verification fonctionnelle, reduction d'espace |
+| RBL - MINIMAL-CONSISTENT-DET | Algorithme AIMA 19.4 |
+| RBL - Impact quantitatif | Reduction exponentielle de l'espace des hypotheses |
+
+## Concepts cles
+
+| Concept | Explication | Notebook |
+|---------|-------------|----------|
+| **Hypothese FOL** | Conjonction de contraintes sur les attributs | SL-1 |
+| **Version Space** | Ensemble de toutes les hypotheses consistantes | SL-1 |
+| **CBH** | Maintient une seule hypothese ajustee incrementalement | SL-1 |
+| **EBL** | Extrait une regle generale d'un seul exemple par deduction | SL-2 |
+| **RBL** | Identifie les attributs pertinents via les determinations | SL-2 |
+| **Determination** | Relation fonctionnelle entre attributs | SL-2 |
+| **KBIL** | Apprentissage inductif guide par la connaissance | SL-2 |
+
+## prerequis
+
+### Connaissances requises
+
+- Python de base (fonctions, classes, tuples, dictionnaires)
+- Logique propositionnelle (conjonctions, predicats)
+- Notions d'apprentissage supervisé (classification binaire)
+
+### Environnement Python
+
+Aucune dependance externe. Les notebooks utilisent uniquement la bibliothèque standard Python 3.10+.
+
+## Ressources
+
+### References
+
+- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e/4e ed., Chapitre 19
+- Tom Mitchell, *Machine Learning*, Chapitres 2 (Concept Learning) et 11 (EBL)
+- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference
+
+## Structure des fichiers
+
+```
+SymbolicLearning/
+├── SL-1-LogicalLearning.ipynb         # CBH, Version Space
+├── SL-2-KnowledgeBasedLearning.ipynb   # EBL, RBL
+├── reference/
+│   └── AIMA_Ch19_Knowledge_in_Learning.md  # Notes de reference
+└── README.md                           # Cette documentation
+```
+
+## Cross-series Bridges
+
+| Serie | Lien | Connection |
+|-------|------|-------------|
+| [Tweety](../Tweety/README.md) | Argumentation | Les logiques formelles de Tweety (propositionnelle, FOL) sont le fondement des hypotheses symboliques |
+| [SemanticWeb](../SemanticWeb/README.md) | Representation de connaissances | RDFS/OWL formalisent les determinations et les hierarchies de generalite |
+| [Planners](../Planners/README.md) | Planification | EBL compile les theories en regles operationnelles, similaire aux heuristiques de planification |
+| [Lean](../Lean/README.md) | Preuves formelles | L'arbre de preuve EBL est analogue aux arbres de preuve Lean 4 |

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -13,31 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# SL-1 - Apprentissage Logique : CBH Search et Version Space\n",
-    "\n",
-    "**Navigation** : [Index](../README.md) | [EBL >>](SL-2-ExplanationBasedLearning.ipynb)\n",
-    "\n",
-    "## Objectifs d'apprentissage\n",
-    "\n",
-    "A la fin de ce notebook, vous saurez :\n",
-    "1. Representer des hypotheses comme des formules logiques (conjonctions de predicats)\n",
-    "2. Definir la notion de consistance d'une hypothese (faux positifs / faux negatifs)\n",
-    "3. Implementer l'algorithme **Current-Best-Hypothesis** (CBH) search avec generalisation et specialisation\n",
-    "4. Implementer l'algorithme **Version Space / Candidate Elimination** avec G-set et S-set\n",
-    "5. Comprendre les limites de l'apprentissage par espace de versions (bruit, disjonctions)\n",
-    "\n",
-    "### Prerequis\n",
-    "- Python 3.10+\n",
-    "- Connaissances basiques en logique propositionnelle et predicats\n",
-    "- Notions de generalisation / specialisation en apprentissage\n",
-    "\n",
-    "### Duree estimee : 50 minutes\n",
-    "\n",
-    "### References\n",
-    "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitre 19.1\n",
-    "- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)"
-   ]
+   "source": "# SL-1 - Apprentissage Logique : CBH Search et Version Space\n\n**Navigation** : [Index](./README.md) | [EBL & RBL >>](SL-2-KnowledgeBasedLearning.ipynb)\n\n## Objectifs d'apprentissage\n\nA la fin de ce notebook, vous saurez :\n1. Representer des hypotheses comme des formules logiques (conjonctions de predicats)\n2. Definir la notion de consistance d'une hypothese (faux positifs / faux negatifs)\n3. Implementer l'algorithme **Current-Best-Hypothesis** (CBH) search avec generalisation et specialisation\n4. Implementer l'algorithme **Version Space / Candidate Elimination** avec G-set et S-set\n5. Comprendre les limites de l'apprentissage par espace de versions (bruit, disjonctions)\n\n### Prerequis\n- Python 3.10+\n- Connaissances basiques en logique propositionnelle et predicats\n- Notions de generalisation / specialisation en apprentissage\n\n### Duree estimee : 50 minutes\n\n### References\n- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitre 19.1\n- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)"
   },
   {
    "cell_type": "markdown",
@@ -1722,40 +1698,7 @@
     },
     "tags": []
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## 10. Resume\n",
-    "\n",
-    "### Points cles\n",
-    "\n",
-    "| Concept | Description |\n",
-    "|---------|-------------|\n",
-    "| **Hypothese FOL** | Conjonction de contraintes sur les attributs |\n",
-    "| **Consistance** | Pas de faux positifs ni de faux negatifs |\n",
-    "| **Generalisation** | Remplacer une contrainte par `?` (couvrir plus) |\n",
-    "| **Specialisation** | Remplacer `?` par une valeur (couvrir moins) |\n",
-    "| **CBH** | Maintient une seule hypothese, ajustee incrementalement |\n",
-    "| **Version Space** | Maintient G-set et S-set, represente toutes les hypotheses consistantes |\n",
-    "| **Candidate Elimination** | Algorithme pour mettre a jour G et S efficacement |\n",
-    "\n",
-    "### Comparaison CBH vs Version Space\n",
-    "\n",
-    "| Critere | CBH | Version Space |\n",
-    "|---------|-----|---------------|\n",
-    "| Nombre d'hypotheses | 1 | Toutes (via frontieres) |\n",
-    "| Ordre-dependance | Oui | Non |\n",
-    "| Backtracking | Possible | Jamais |\n",
-    "| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n",
-    "| Complexite memoire | O(1) | O(|G| + |S|) |\n",
-    "\n",
-    "### Prochaines etapes\n",
-    "\n",
-    "Dans le notebook suivant **SL-2-ExplanationBasedLearning**, nous decouvrirons :\n",
-    "- L'apprentissage base sur les explications (EBL)\n",
-    "- Comment transformer une experience unique en regle generale\n",
-    "- L'utilisation de la deduction pour l'apprentissage"
-   ]
+   "source": "---\n\n## 10. Resume\n\n### Points cles\n\n| Concept | Description |\n|---------|-------------|\n| **Hypothese FOL** | Conjonction de contraintes sur les attributs |\n| **Consistance** | Pas de faux positifs ni de faux negatifs |\n| **Generalisation** | Remplacer une contrainte par `?` (couvrir plus) |\n| **Specialisation** | Remplacer `?` par une valeur (couvrir moins) |\n| **CBH** | Maintient une seule hypothese, ajustee incrementellement |\n| **Version Space** | Maintient G-set et S-set, represente toutes les hypotheses consistantes |\n| **Candidate Elimination** | Algorithme pour mettre a jour G et S efficacement |\n\n### Comparaison CBH vs Version Space\n\n| Critere | CBH | Version Space |\n|---------|-----|---------------|\n| Nombre d'hypotheses | 1 | Toutes (via frontieres) |\n| Ordre-dependance | Oui | Non |\n| Backtracking | Possible | Jamais |\n| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n| Complexite memoire | O(1) | O(|G| + |S|) |\n\n### Prochaines etapes\n\nDans le notebook suivant **SL-2 - Apprentissage et Connaissance**, nous decouvrirons :\n- L'apprentissage base sur les explications (EBL)\n- Comment transformer une experience unique en regle generale\n- L'utilisation de la deduction pour l'apprentissage"
   },
   {
    "cell_type": "markdown",
@@ -1770,20 +1713,7 @@
     },
     "tags": []
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## Ressources\n",
-    "\n",
-    "- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitre 19.1\n",
-    "- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)\n",
-    "- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n",
-    "- [Version Space - Wikipedia](https://en.wikipedia.org/wiki/Version_space)\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Notebook suivant** : [SL-2-ExplanationBasedLearning](SL-2-ExplanationBasedLearning.ipynb)"
-   ]
+   "source": "---\n\n## Ressources\n\n- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitre 19.1\n- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)\n- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n- [Version Space - Wikipedia](https://en.wikipedia.org/wiki/Version_space)\n\n---\n\n**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)"
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning.ipynb
@@ -13,31 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# SL-2 --- Apprentissage et Connaissance (EBL & RBL)\n",
-    "\n",
-    "**Navigation** : [Index](../README.md) | [<< SL-1](SL-1-LogicalLearning.ipynb) | [SL-3 >>](SL-3-InductiveLogicProgramming.ipynb)\n",
-    "\n",
-    "## Objectifs d'apprentissage\n",
-    "\n",
-    "A la fin de ce notebook, vous saurez :\n",
-    "1. Comprendre la **contrainte d'entrainement** qui relie hypothese, descriptions et classifications\n",
-    "2. Implementer l'apprentissage base sur les explications (**EBL**) : extraire une regle generale d'un seul exemple\n",
-    "3. Implementer la verification de **determinations** et l'algorithme **MINIMAL-CONSISTENT-DET**\n",
-    "4. Comparer les trois paradigmes : EBL (deductif), RBL (pertinence), KBIL (inductif base sur la connaissance)\n",
-    "\n",
-    "### Prerequis\n",
-    "- SL-1 : Apprentissage logique (CBH, Version Space)\n",
-    "- Python 3.10+\n",
-    "- Notions de logique du premier ordre (predicats, regles d'inference)\n",
-    "\n",
-    "### Duree estimee : 55 minutes\n",
-    "\n",
-    "### References\n",
-    "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitres 19.3-19.4\n",
-    "- G. DeJong, *Explanation-Based Learning* (1981)\n",
-    "- T. Mitchell, *Machine Learning*, Chapitre 11 (Explanation-Based Learning)"
-   ]
+   "source": "# SL-2 --- Apprentissage et Connaissance (EBL & RBL)\n\n**Navigation** : [Index](./README.md) | [<< SL-1](SL-1-LogicalLearning.ipynb)\n\n## Objectifs d'apprentissage\n\nA la fin de ce notebook, vous saurez :\n1. Comprendre la **contrainte d'entrainement** qui relie hypothese, descriptions et classifications\n2. Implementer l'apprentissage base sur les explications (**EBL**) : extraire une regle generale d'un seul exemple\n3. Implementer la verification de **determinations** et l'algorithme **MINIMAL-CONSISTENT-DET**\n4. Comparer les trois paradigmes : EBL (deductif), RBL (pertinence), KBIL (inductif base sur la connaissance)\n\n### Prerequis\n- SL-1 : Apprentissage logique (CBH, Version Space)\n- Python 3.10+\n- Notions de logique du premier ordre (predicats, regles d'inference)\n\n### Duree estimee : 55 minutes\n\n### References\n- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitres 19.3-19.4\n- G. DeJong, *Explanation-Based Learning* (1981)\n- T. Mitchell, *Machine Learning*, Chapitre 11 (Explanation-Based Learning)"
   },
   {
    "cell_type": "code",
@@ -2120,20 +2096,7 @@
     },
     "tags": []
    },
-   "source": [
-    "---\n",
-    "\n",
-    "## Ressources\n",
-    "\n",
-    "- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitres 19.3-19.4\n",
-    "- G. DeJong & R. Mooney, *Explanation-Based Learning: An Alternative View* (1986)\n",
-    "- T. Mitchell, *Machine Learning*, Chapitre 11\n",
-    "- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n",
-    "\n",
-    "---\n",
-    "\n",
-    "**Notebook suivant** : [SL-3 - Inductive Logic Programming](SL-3-InductiveLogicProgramming.ipynb)"
-   ]
+   "source": "---\n\n## Ressources\n\n- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitres 19.3-19.4\n- G. DeJong & R. Mooney, *Explanation-Based Learning: An Alternative View* (1986)\n- T. Mitchell, *Machine Learning*, Chapitre 11\n- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n\n---\n\n**Retour** : [Index SymbolicLearning](./README.md) | [<< SL-1](SL-1-LogicalLearning.ipynb)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Fix stale navigation links in SL-1 pointing to wrong SL-2 filename (`SL-2-ExplanationBasedLearning` -> `SL-2-KnowledgeBasedLearning`)
- Fix stale navigation links in SL-2 pointing to non-existent SL-3 notebook, replaced with link back to series README
- Create README.md for SymbolicLearning series (2 notebooks, AIMA Ch.19, ~105 min)

## Test plan
- [x] Markdown-only changes (C.2 exception: outputs still valid)
- [x] Nav links point to correct existing files
- [x] README.md follows standard series format (IIT, Probas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)