### PR TITLE
feat(prover): retry transient provider errors (5xx/timeout, not 404) (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -46,6 +46,61 @@ from .knowledge import ProofKnowledgeBase
 # still bounds the total session.
 DEFAULT_AGENT_TIMEOUT_S = 600
 
+# Transient-error retry policy. Forensic analysis of prover traces
+# (traces/*.spans.jsonl) showed whole iterations lost to TRANSIENT provider
+# errors (HTTP 5xx, connection reset/aborted, read/connect timeouts) that
+# crashed an agent mid-run with no retry. Retries are bounded: 2 attempts with
+# short exponential backoff (2s, 4s). Note: a 404 is NOT transient — it means a
+# bad/missing model_id (config bug) — and must NOT be retried (see
+# `_is_transient_error`).
+TRANSIENT_RETRY_MAX = 2
+TRANSIENT_RETRY_BACKOFF_S = (2.0, 4.0)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """Return True if `exc` looks like a transient provider/network error.
+
+    Matches ONLY conditions worth retrying:
+      - HTTP 5xx server errors (500, 502, 503, 504),
+      - connection reset / aborted / refused,
+      - read / connect timeouts.
+
+    Explicitly EXCLUDES 404 (bad/missing model_id — a config bug, retrying just
+    wastes time) and other 4xx client errors (401/403/422). `agent_framework`
+    may wrap the underlying httpx / openai error, so we probe both the
+    `status_code` attribute and the stringified message defensively.
+    """
+    # 1. Structured HTTP status code, if the provider exposed one. Checked on
+    #    the exception and a common nested `.response` (httpx-style) attribute.
+    for candidate in (exc, getattr(exc, "response", None)):
+        if candidate is None:
+            continue
+        status = getattr(candidate, "status_code", None)
+        if isinstance(status, int):
+            # 5xx → transient. Any 4xx (incl. 404) → NOT transient.
+            return status in (500, 502, 503, 504)
+
+    # 2. Fall back to message inspection (wrapped errors lose the attribute).
+    msg = str(exc).lower()
+
+    # Guard: never treat an explicit 404 / other 4xx as transient even if the
+    # message also happens to contain a generic word like "timeout".
+    if any(code in msg for code in (" 404", "404 ", "not found",
+                                    " 401", " 403", " 422",
+                                    "unauthorized", "forbidden")):
+        return False
+
+    transient_markers = (
+        "500", "502", "503", "504",
+        "internal server error", "bad gateway",
+        "service unavailable", "gateway timeout",
+        "connection reset", "connection aborted", "connection refused",
+        "connectionreset", "connectionerror",
+        "read timeout", "connect timeout", "timed out", "timeout",
+        "temporarily unavailable", "remote end closed",
+    )
+    return any(marker in msg for marker in transient_markers)
+
 
 @dataclass
 class ProofMessage:
@@ -253,6 +308,51 @@ class AgentExecutor(Executor):
                         self._trace.log(
                             agent=self._agent.name, role="error_retry_failed",
                             content=str(e2)[:200],
+                        )
+            elif _is_transient_error(e):
+                # Transient provider/network error (HTTP 5xx, connection
+                # reset/aborted, read/connect timeout). Forensic: several
+                # iterations were lost when an agent crashed mid-run on a
+                # transient error with no retry. Retry the SAME invocation,
+                # bounded (TRANSIENT_RETRY_MAX) with short exponential backoff.
+                # A 404 / other 4xx never reaches here (_is_transient_error
+                # excludes them — those are config bugs, not worth retrying).
+                response_text = None
+                _last_exc = e
+                for _attempt in range(1, TRANSIENT_RETRY_MAX + 1):
+                    _backoff = TRANSIENT_RETRY_BACKOFF_S[
+                        min(_attempt - 1, len(TRANSIENT_RETRY_BACKOFF_S) - 1)
+                    ]
+                    _retry_msg = (
+                        f"[retry] transient provider error "
+                        f"(attempt {_attempt}/{TRANSIENT_RETRY_MAX}): "
+                        f"{repr(_last_exc)[:120]}"
+                    )
+                    if self._trace:
+                        self._trace.log(
+                            agent=self._agent.name, role="transient_retry",
+                            content=_retry_msg,
+                        )
+                    await asyncio.sleep(_backoff)
+                    try:
+                        response = await self._agent.run(content)
+                        response_text = self._extract_response_text(response)
+                        break
+                    except Exception as e_retry:
+                        _last_exc = e_retry
+                        # Only keep retrying while still transient; a fresh
+                        # non-transient error must fall through immediately.
+                        if not _is_transient_error(e_retry):
+                            break
+                if response_text is None:
+                    # Retries exhausted (or a non-transient error surfaced) —
+                    # fall through to the existing failure handling, do NOT
+                    # swallow the error silently.
+                    response_text = f"Agent error: {_last_exc}"
+                    if self._trace:
+                        self._trace.log(
+                            agent=self._agent.name, role="transient_retry_failed",
+                            content=str(_last_exc)[:200],
                         )
             else:
                 response_text = f"Agent error: {e}"


### PR DESCRIPTION
## What changed

Adds a bounded retry on **transient provider/network errors** to the Lean multi-agent prover `AgentExecutor` (`MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py`) — **one file, +100/-0**.

- New module-level predicate `_is_transient_error(exc) -> bool` that detects retryable failures by probing both the exception's `status_code` and a nested `.response` (httpx-style), with a defensive message-pattern fallback (`agent_framework` may wrap the underlying httpx/openai error).
- New sibling branch in `AgentExecutor`'s `except`, added **next to** the existing context-window-overflow retry (same logging idiom, same try/except shape). On a transient error it retries the **same** agent invocation up to **2 times** with short exponential backoff (**2s, 4s**), logging `[retry] transient provider error (attempt N/2): ...`. After exhaustion (or a non-transient error during retry) it falls through to the existing `Agent error: ...` handling — the error is **not** swallowed silently.

## Why (forensic finding)

Forensic analysis of 14 prover traces (`traces/*.spans.jsonl`, Epic #1453) showed several iterations were lost to **transient** provider errors (HTTP 5xx, connection reset/aborted, read/connect timeout) that crashed an agent mid-run with **no retry**. The existing handling retried **only** context-window overflow.

## CRITICAL caveat — 404 is NOT retried

A **404** means a bad/missing `model_id` (a config bug), so retrying just wastes time. The predicate matches **only** 5xx (500/502/503/504), connection reset/aborted/refused, and read/connect timeouts. It **explicitly excludes** 404 and other 4xx (401/403/422), guarding against messages that contain both a 404 and a generic word like "timeout". (429 rate-limit is also excluded — that cascade is handled by provider selection per #1459, not by retry.)

## Scope / review notes

- Touches **only** `workflow.py`. No `*.lean`, no notebook, no catalog → **conflict-free with #1518** (which owns `config.py`/`provers.py`/`tools.py`/`Nash.lean`).
- **No Lean/proof claim, no sorry change** — this is a standalone harness-reliability PR, already split from any proof work (review-discipline B.4).

## Validation

- `ast.parse` syntax check on `workflow.py`: **OK** (env lacks `agent_framework`, so a full import isn't run — `ast.parse` is the gate).
- Standalone unit test of `_is_transient_error`: 14/14 cases pass — 503/500/502/timeout/connection-reset → True; 404/401/422/"404 + timeout" → False.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
