### PR TITLE
chore(prover): fix DEMO 34 stale sorry line 321->836 post-#1530 (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -1017,7 +1017,7 @@ DEMOS = {
     34: {
         "name": "LATTICE_DOCTOR_OPTIMAL_TOP",
         "file": str(LATTICE_FILE),
-        "line": 321,
+        "line": 836,
         "sorry_type": "sorry_replacement",
         "theorem_name": "doctor_optimal_eq_top",
         "theorem": "doctor_optimal_eq_top",


### PR DESCRIPTION
## Summary
After #1530 shifted lines in `StableMarriage/Lattice.lean`, DEMO 34
(`LATTICE_DOCTOR_OPTIMAL_TOP`) still pointed at L321 — which no longer
contains a `sorry`. The harness P5 nearest-sorry relocation would then
snap to the closest live sorry (L187, `no_cross_match` Case B) instead of
`doctor_optimal_eq_top`'s sorry at **L836**, silently targeting the wrong
goal.

## Change
- `config.py` DEMO 34 `"line": 321` -> `836` (1 line).

## Verification
Current sorries in Lattice.lean (post-#1530, merged):
```
185:      sorry   # no_cross_match Case A2
187:    sorry     # no_cross_match Case B
836:  sorry       # doctor_optimal_eq_top (theorem at L830)
```
DEMO 34 now resolves to L836 (the doctor_optimal target). No proof or
Lean change; harness config only. Epic #1453.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>