### PR TITLE
feat(prover): P2 Delta0-compile stagnation guard (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -94,6 +94,10 @@ class ProofState:
     consecutive_failures: int = 0
     last_compile_errors: List[Dict[str, Any]] = field(default_factory=list)
     best_sorry_count: int = 999
+    # P2 (#1453): mirrored from TacticTools.compile() — consecutive successful
+    # compiles that did not reach a new sorry-count low (Delta0-stagnation).
+    # Lets workflow executors force-route a stuck session without re-deriving it.
+    consecutive_delta0_compiles: int = 0
 
     # B.3: Explicit attack plan set by CoordinatorAgent
     plan: List[str] = field(default_factory=list)
@@ -164,6 +168,7 @@ class ProofState:
             "consecutive_failures": self.consecutive_failures,
             "error_count": self.error_count,
             "best_sorry_count": self.best_sorry_count,
+            "consecutive_delta0_compiles": self.consecutive_delta0_compiles,
             "discovered_lemmas": list(self.discovered_lemmas),
             "plan": list(self.plan),
             "plan_phase": self.plan_phase,
@@ -186,6 +191,7 @@ class ProofState:
         self.consecutive_failures = cp["consecutive_failures"]
         self.error_count = cp["error_count"]
         self.best_sorry_count = cp["best_sorry_count"]
+        self.consecutive_delta0_compiles = cp.get("consecutive_delta0_compiles", 0)
         self.discovered_lemmas = cp["discovered_lemmas"]
         self.plan = cp["plan"]
         self.plan_phase = cp["plan_phase"]

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -566,6 +566,15 @@ class TacticTools:
         self._best_content: Optional[str] = None
         self._best_sorry_count: int = 999
         self._original_sorry_count: int = 999
+        # P2 (#1453): Delta0-compile stagnation tracking. Counts consecutive
+        # successful compiles that failed to reach a new sorry-count low. The
+        # verbatim loop detector (_check_tool_loop) only catches *identical*
+        # tool calls; it misses the dominant forensic pathology where the agent
+        # makes *different* edits that each build OK but never lower the sorry
+        # count. See compile() for the guard rationale.
+        self._min_compile_sorry_count: Optional[int] = None
+        self._consecutive_delta0: int = 0
+        self._stagnation_threshold: int = 3
         self._original_file_size: int = 0
         self._original_content: Optional[str] = None
         # Decomposition budget: how many new sorries the agents may introduce
@@ -1462,6 +1471,40 @@ class TacticTools:
         level_2 = sorry_delta >= 0
         level_3 = None
 
+        # P2 (#1453): Delta0-compile stagnation guard. A successful build that
+        # does not reach a new sorry-count low is "no proof progress". 3+ such
+        # in a row (21 were observed on Lattice_L147 with zero noprogress events)
+        # means the agent is churning equivalent edits. Surface a hard directive
+        # so it changes strategy instead of burning the iteration budget. A real
+        # new low (including after a within-budget decomposition that is then
+        # discharged) resets the streak. Build failures are a different pathology
+        # (handled by F1 consecutive_build_fails) and leave the streak unchanged.
+        stagnation = False
+        directive = None
+        if success:
+            if self._min_compile_sorry_count is None:
+                self._min_compile_sorry_count = sorry_count
+            elif sorry_count < self._min_compile_sorry_count:
+                self._min_compile_sorry_count = sorry_count
+                self._consecutive_delta0 = 0
+            else:
+                self._consecutive_delta0 += 1
+            stagnation = self._consecutive_delta0 >= self._stagnation_threshold
+            if stagnation:
+                directive = (
+                    f"STAGNATION: {self._consecutive_delta0} consecutive successful "
+                    f"compiles without lowering sorry_count (still {sorry_count}). "
+                    f"Repeating the same class of edit will not progress. CHANGE "
+                    f"STRATEGY NOW: probe the goal state at the sorry "
+                    f"(compile_probe_goal), decompose the goal differently, search "
+                    f"reference_docs for a lemma, or request Director guidance. Do "
+                    f"NOT submit another minor variant."
+                )
+        # Mirror into shared state so VerifyExecutor/Coordinator can force-route
+        # a stuck session without re-deriving the streak.
+        if self._state is not None:
+            self._state.consecutive_delta0_compiles = self._consecutive_delta0
+
         if check_axioms and success:
             module_name = relative_path.replace("/", ".").replace("\\", ".")
             if module_name.endswith(".lean"):
@@ -1482,6 +1525,7 @@ class TacticTools:
                 agent="TacticAgent", role="compile",
                 content=f"compile: L1={level_1} L2={level_2}(Δ{sorry_delta}) L3={level_3} "
                         f"| {sorry_count} sorry (text={text_sorry_count},implicit={implicit_sorry}) "
+                        f"| Δ0streak={self._consecutive_delta0}{' STAGNATION' if stagnation else ''} "
                         f"| {'CACHED' if cached else 'fresh'}",
                 duration_s=duration, tool_name="compile",
                 tool_result=raw_output[:500],
@@ -1497,6 +1541,9 @@ class TacticTools:
             "implicit_sorry_count": implicit_sorry,
             "sorry_delta": sorry_delta,
             "original_sorry_count": self._original_sorry_count,
+            "consecutive_delta0": self._consecutive_delta0,
+            "stagnation": stagnation,
+            "directive": directive,
             "error_count": len(errors), "errors": errors[:10],
             "compile_time_s": round(duration, 1),
             "cached": cached,


### PR DESCRIPTION
## Summary

Harness instrumentation for Epic #1453 (prover co-evolution). Addresses the **dominant forensic pathology** found this cycle: the multi-agent prover burns iteration budget on *successful* compiles that never reduce the sorry count.

`TacticTools.compile()` now tracks **consecutive successful compiles that fail to reach a new sorry-count low** (`Delta0`-stagnation). The pre-existing verbatim loop detector (`_check_tool_loop`, threshold 3) only catches *identical* tool calls — it structurally misses the case where the agent makes *different* edits that each build OK yet never lower the count. Forensic: **21 such consecutive Delta0-compiles on `Lattice_L147`** with zero `_consecutive_noprogress` events.

## What changed

- `tools.py` `TacticTools.__init__`: `_min_compile_sorry_count`, `_consecutive_delta0`, `_stagnation_threshold = 3` (consistent with `_loop_threshold`).
- `tools.py` `TacticTools.compile()`: increments the streak on a successful build that does not reach a new sorry-count low; **resets** on a real new low (incl. a within-budget decomposition later discharged); **leaves unchanged** on build failure (a different pathology, handled by F1 `consecutive_build_fails`). Surfaces `consecutive_delta0` / `stagnation` / `directive` in the JSON result + trace line. The `directive` is a hard "CHANGE STRATEGY NOW" message steering the agent to probe the goal / decompose differently / search / request Director — aligned with the existing F5/F9/B2 escalation gates (does **not** auto-mark intractable).
- `state.py` `ProofState`: new `consecutive_delta0_compiles` field, mirrored from `compile()` so `VerifyExecutor`/`Coordinator` can force-route a stuck session without re-deriving the streak (consumer = follow-up P1 routing). Added to checkpoint save/restore for symmetry.

## Validation

**Rule B (Lean PR) points 1-3 = N/A:** 0 `.lean` files in this diff, no sorry-count / lake-build / proof-progress claim. This is pure Python harness instrumentation. Point 4 (justify the prover change): it is the captured #1453 P2 deliverable, not a refactor smuggling a Lean claim.

Smoke-tested in isolation (verifier monkeypatched, no lake build):
```
OK churn: streaks [0, 1, 2, 3] stagnation@ 3
OK reset-on-new-low: streak 0
OK re-increment after reset: streak 1
OK build-failure-neutral: streak 1
OK checkpoint round-trip
ALL P2 SMOKE ASSERTIONS PASSED
```
`py_compile` clean on both modules. No existing prover test suite to regress.

## Scope

2 files, +53 lines. Single subject (P2 stagnation guard). Follow-ups (separate PRs): P1 Director-budget early-yield wiring the `consecutive_delta0_compiles` mirror into `VerifyExecutor` routing; reclassification of DEMO 34 as ill-posed (see #1453 comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
