### PR TITLE
feat(lean): prove all Nash calibration targets (sorry 4→0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/calibration_lean/Calibration/Nash.lean
+++ b/MyIA.AI.Notebooks/GameTheory/calibration_lean/Calibration/Nash.lean
@@ -62,14 +62,15 @@ def Trahir : Fin 2 := ⟨1, by omega⟩
     Expected iterations: 3-5 (search → fail → fallback → case split → close). -/
 theorem strictly_domin_defect_pd :
     strictlyDominates1 prisonersDilemma Trahir Cooperer := by
-  sorry
+  unfold strictlyDominates1; intro a2; fin_cases a2 <;> decide
 
 /-- Target D (P2): (D, D) is a pure Nash equilibrium of Prisoner's Dilemma.
     Exercises P2: requires Fin 2 case analysis + Int comparison across both players.
     Expected iterations: 4-7 (unfold → case split → arithmetic → close). -/
 theorem pd_defect_is_pure_ne :
     isPureNashEquilibrium prisonersDilemma Trahir Trahir := by
-  sorry
+  unfold isPureNashEquilibrium
+  constructor <;> intro a <;> fin_cases a <;> norm_num [prisonersDilemma, Trahir]
 
 /-- Target E (P1+P2): (C, C) is NOT a pure Nash equilibrium.
     Harder: requires constructing a counterexample (defect beats cooperate).
@@ -77,7 +78,11 @@ theorem pd_defect_is_pure_ne :
     Expected iterations: 5-10 (unfold → negation → construct witness → decide). -/
 theorem pd_cooperate_not_ne :
     ¬ isPureNashEquilibrium prisonersDilemma Cooperer Cooperer := by
-  sorry
+  unfold Not
+  intro h
+  rcases h with ⟨h1, h2⟩
+  have hdev := h1 Trahir
+  norm_num [isPureNashEquilibrium, prisonersDilemma, Cooperer, Trahir] at hdev
 
 /-! ## Sorry-Increase Calibration Target (P4) -/
 
@@ -94,4 +99,4 @@ theorem pd_cooperate_not_ne :
     Expected iterations: 3-5 (unfold → constructor → 2 sorries → maybe prove one). -/
 theorem pd_defect_is_ne_decomposable :
     isPureNashEquilibrium prisonersDilemma Trahir Trahir := by
-  sorry
+  exact pd_defect_is_pure_ne


### PR DESCRIPTION
## Summary
- All 4 calibration theorems in `Calibration/Nash.lean` proved by multi-agent prover (GPT-5.5 via openrouter)
- Targets C/D/E (DEMO 35/36/37) proved independently, Target F delegates to Target D proof

### Proofs applied
| Target | Theorem | Tactic | DEMO |
|--------|---------|--------|------|
| C | `strictly_domin_defect_pd` | `unfold strictlyDominates1; intro a2; fin_cases a2 <;> decide` | 35 |
| D | `pd_defect_is_pure_ne` | `unfold isPureNashEquilibrium; constructor <;> intro a <;> fin_cases a <;> norm_num [prisonersDilemma, Trahir]` | 36 |
| E | `pd_cooperate_not_ne` | `unfold Not; intro h; rcases h with ⟨h1, h2⟩; have hdev := h1 Trahir; norm_num [...] at hdev` | 37 |
| F | `pd_defect_is_ne_decomposable` | `exact pd_defect_is_pure_ne` | 36 |

### Verification
- `grep -c sorry Calibration/Nash.lean`: **8→4** (4 real sorry in proofs → 0; 4 in comments unchanged)
- `grep -c axiom Calibration/Nash.lean`: **0**
- `lake build Calibration.Nash`: **SUCCESS (3324 jobs, 0 errors)**

## Test plan
- [x] `lake build Calibration.Nash` passes locally
- [x] `grep -c sorry` shows 0 proof-level sorry (4 in comments only)
- [x] No `axiom` introduced
- [x] All 4 theorems proved (not just Target D delegated to F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)