### PR TITLE
fix(prover): latch in-place proofs in VerifyExecutor before doomed re-verify (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -680,6 +680,80 @@ class VerifyExecutor(Executor):
             await ctx.send_message(msg)
             return
 
+        # P1 latch-success (Epic #1453, 2026-05-23 forensic): detect the case
+        # where TacticAgent has ALREADY proved the target in-place before this
+        # verify runs. tools.file_replace_lines edits the REAL target file on
+        # disk (tools.py:1091) and its own build_check already passed, but
+        # SorryContext.sorry_line is frozen at session start (provers.py:203)
+        # and is NEVER updated. The downstream verify_sorry_replacement then
+        # finds no sorry at the frozen line, P5-relocates to a nearest
+        # UNRELATED sorry, injects msg.tactic there -> goal mismatch ->
+        # spurious tactic_failed that MASKS a genuine proof. Latch here, before
+        # that doomed re-verify, when all three hold (else fall through to the
+        # existing verify -> P5 path preserved, no regression):
+        #   1. the frozen target line no longer contains "sorry"
+        #   2. the current raw sorry count is STRICTLY below the session-start
+        #      count (full_file snapshot) -> distinguishes "a sorry was proved"
+        #      from "lines merely shifted" (a shift leaves the count unchanged)
+        #   3. a confirming build of the ACTUAL file succeeds
+        # Cost: one file read + count per verify; a build only in the rare
+        # in-place-proof case (conditions 1+2), and that build replaces the
+        # doomed relocated one (net-zero) and is cache-eligible by content hash.
+        try:
+            from pathlib import Path as _LatchPath
+            from .verifier import get_verifier as _latch_get_verifier
+            _latch_fp = self._sorry_ctx.filepath
+            _latch_cur = _LatchPath(_latch_fp).read_text(encoding="utf-8")
+            _latch_lines = _latch_cur.split("\n")
+            _latch_target = self._sorry_ctx.sorry_line
+            _latch_line_clear = (
+                1 <= _latch_target <= len(_latch_lines)
+                and "sorry" not in _latch_lines[_latch_target - 1]
+            )
+            _latch_orig = (
+                self._sorry_ctx.full_file.count("sorry")
+                if getattr(self._sorry_ctx, "full_file", "")
+                else (self._original_sorry_count or 0)
+            )
+            _latch_now = _latch_cur.count("sorry")
+            if _latch_line_clear and _latch_now < _latch_orig:
+                _latch_verifier = _latch_get_verifier(
+                    str(_LatchPath(_latch_fp).parent.parent))
+                _latch_rel = (f"{_LatchPath(_latch_fp).parent.name}/"
+                              f"{_LatchPath(_latch_fp).name}")
+                _latch_build = _latch_verifier.verify_project_file(_latch_rel)
+                if _latch_build.get("success"):
+                    msg.proof_found = True
+                    self._consecutive_build_fails = 0
+                    self._consecutive_noprogress = 0
+                    if self._trace:
+                        self._trace.log(
+                            agent="VerifyExecutor", role="verify",
+                            content=(f"PROOF FOUND (in-place latch): frozen line "
+                                     f"{_latch_target} clear, sorry {_latch_orig}"
+                                     f"->{_latch_now}, clean build OK"),
+                            tool_name="verify_project_file",
+                            tool_result="success=True",
+                        )
+                    try:
+                        self._kb.record_success(
+                            goal=self._sorry_ctx.goal_state or "",
+                            tactic=msg.tactic,
+                            theorem="",
+                            file=f"{_latch_fp}:{_latch_target}",
+                        )
+                    except Exception:
+                        pass
+                    await ctx.yield_output(msg)
+                    return
+        except Exception as _latch_err:
+            if self._trace:
+                self._trace.log(
+                    agent="VerifyExecutor", role="latch_error",
+                    content=(f"in-place latch check failed, falling through "
+                             f"to verify_sorry_replacement: {_latch_err}"),
+                )
+
         result = verify_sorry_replacement(
             filepath=self._sorry_ctx.filepath,
             sorry_line=self._sorry_ctx.sorry_line,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -640,3 +640,150 @@ def test_f9_graceful_degradation_when_no_director_wired():
         f"F9 gate trapped a no-Director session: {out[:200]}"
     )
     assert state.intractable is True
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# P1 latch-success (Epic #1453, 2026-05-23 forensic) — in-place-proof detector
+#
+# Bug: tools.file_replace_lines edits the REAL target file in place and its
+# own build_check passes, but SorryContext.sorry_line is frozen at session
+# start (provers.py:203) and is NEVER updated. The downstream
+# verify_sorry_replacement then finds no sorry at the frozen line,
+# P5-relocates to a nearest UNRELATED sorry, injects the tactic there ->
+# goal mismatch -> spurious tactic_failed that MASKS the genuine proof.
+#
+# The latch in VerifyExecutor.handle catches this BEFORE the doomed re-verify
+# when all three hold (else it falls through, P5 path preserved):
+#   1. the frozen target line no longer contains "sorry"
+#   2. the current raw sorry count is STRICTLY below the session-start count
+#      (full_file snapshot) -> distinguishes a real proof from a line shift
+#   3. a confirming build of the actual file succeeds
+# These tests pin the decision offline (verifier + re-verify mocked, no lake).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _make_verify_executor(filepath, sorry_line, full_file, goal_state=""):
+    from prover.workflow import VerifyExecutor
+
+    sctx = SorryContext(
+        filepath=str(filepath), sorry_line=sorry_line, indentation=2,
+        indent_str="  ", full_file=full_file, goal_state=goal_state,
+    )
+    return VerifyExecutor(sorry_context=sctx, imports="")
+
+
+def _run_handle(executor, msg):
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    ctx = AsyncMock()
+    ctx.yield_output = AsyncMock()
+    ctx.send_message = AsyncMock()
+    asyncio.run(executor.handle(msg, ctx))
+    return ctx
+
+
+def _patch_verifier_and_reverify(monkeypatch, build_success=True):
+    """Mock the verifier (condition 3) and record any re-verify fall-through."""
+    import prover.verifier as vmod
+    import prover.lean_utils as lu
+
+    class _FakeVerifier:
+        def verify_project_file(self, rel, force=False):
+            return {"success": build_success, "errors": "", "raw_output": ""}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
+
+    reverify_calls = []
+    monkeypatch.setattr(
+        lu, "verify_sorry_replacement",
+        lambda **k: (reverify_calls.append(k)
+                     or {"success": False, "errors": "REACHED_REVERIFY"}),
+    )
+    return reverify_calls
+
+
+def test_p1_latch_fires_on_in_place_proof(tmp_path, monkeypatch):
+    """All three conditions hold -> latch sets proof_found, no re-verify run."""
+    from prover.workflow import ProofMessage
+
+    proved = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  trivial\n"
+    )
+    fake = tmp_path / "Proved.lean"
+    fake.write_text(proved, encoding="utf-8")
+    # Session-start snapshot had ONE sorry; it is now proved (count 1 -> 0).
+    session_full = proved.replace("  trivial\n", "  sorry\n")
+    assert session_full.count("sorry") == 1 and proved.count("sorry") == 0
+
+    reverify_calls = _patch_verifier_and_reverify(monkeypatch, build_success=True)
+
+    ex = _make_verify_executor(fake, sorry_line=3, full_file=session_full)
+    msg = ProofMessage(content="x", tactic="trivial", sorry_count=1)
+    ctx = _run_handle(ex, msg)
+
+    assert msg.proof_found is True, "latch must set proof_found on in-place proof"
+    assert reverify_calls == [], (
+        "verify_sorry_replacement must NOT run when the latch fires"
+    )
+    ctx.yield_output.assert_awaited_once()
+
+
+def test_p1_latch_skips_when_sorry_count_not_dropped(tmp_path, monkeypatch):
+    """Condition 2 fails (count unchanged = a shift) -> re-verify runs instead."""
+    from prover.workflow import ProofMessage
+
+    # Frozen line is clear, but the session snapshot has the SAME sorry count
+    # (the sorry merely moved). The latch must defer to the existing verify.
+    content = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  trivial\n"
+        "-- a stray sorry mention in a comment\n"
+    )
+    fake = tmp_path / "Shift.lean"
+    fake.write_text(content, encoding="utf-8")
+    session_full = content  # identical -> same count -> no drop
+
+    reverify_calls = _patch_verifier_and_reverify(monkeypatch, build_success=True)
+
+    ex = _make_verify_executor(fake, sorry_line=3, full_file=session_full)
+    msg = ProofMessage(content="x", tactic="trivial", sorry_count=1)
+    _run_handle(ex, msg)
+
+    assert msg.proof_found is False, "latch must not fire without a sorry drop"
+    assert len(reverify_calls) == 1, "re-verify must run when the latch is skipped"
+
+
+def test_p1_latch_skips_when_target_line_still_has_sorry(tmp_path, monkeypatch):
+    """Condition 1 fails (frozen line still has sorry) -> re-verify runs.
+
+    Even though a sorry was removed elsewhere (count dropped), the frozen
+    target line still carries a sorry, so latching success would be a false
+    positive. Condition 1 vetoes it.
+    """
+    from prover.workflow import ProofMessage
+
+    content = (
+        "import Mathlib.Tactic\n"
+        "theorem t1 : True := by\n"
+        "  sorry\n"  # frozen line 3 — STILL a sorry
+    )
+    fake = tmp_path / "StillSorry.lean"
+    fake.write_text(content, encoding="utf-8")
+    # Session snapshot had TWO sorries (count dropped 2 -> 1) so cond 2 holds.
+    session_full = content + "theorem t2 : True := by\n  sorry\n"
+    assert session_full.count("sorry") == 2 and content.count("sorry") == 1
+
+    reverify_calls = _patch_verifier_and_reverify(monkeypatch, build_success=True)
+
+    ex = _make_verify_executor(fake, sorry_line=3, full_file=session_full)
+    msg = ProofMessage(content="x", tactic="omega", sorry_count=2)
+    _run_handle(ex, msg)
+
+    assert msg.proof_found is False, (
+        "latch must not fire while the frozen target line still has a sorry"
+    )
+    assert len(reverify_calls) == 1, "re-verify must run when condition 1 vetoes"


### PR DESCRIPTION
## Summary

P1 forensic fix for the prover harness (Epic #1453 co-evolution). Fixes a bug where a **genuine proof is masked as a `tactic_failed`** because of a frozen `sorry_line`.

### Root cause (verified in code)
- `TacticAgent` can prove a target **in-place**: `tools.file_replace_lines` (tools.py) edits the **real** target file on disk and its own `build_check` already passes.
- `SorryContext.sorry_line` is **frozen at session start** (provers.py:203) and never updated.
- `VerifyExecutor.handle` (workflow.py) then runs `verify_sorry_replacement` against that **stale** line on the **already-edited** file. There is no `sorry` at the frozen line, so the **P5 relocation** (lean_utils.py:654-669) jumps to a nearest **unrelated** `sorry`, injects `msg.tactic` there → goal mismatch → spurious `tactic_failed` that **masks the real proof**.

### Fix
In `VerifyExecutor.handle`, **before** the doomed `verify_sorry_replacement`, latch `proof_found=True` only when **all three** hold (else fall through → P5 path **preserved**, no regression):
1. the frozen target line no longer contains `sorry`;
2. the current raw `sorry` count is **strictly below** the session-start count (`full_file` snapshot) — distinguishes "a sorry was proved" from "lines merely shifted" (a shift leaves the count unchanged);
3. a **confirming build of the actual file** succeeds (`verify_project_file`, cache-eligible by content hash → reuses `file_replace_lines`' prior build).

Wrapped in try/except that traces and falls through on any error.

## Rule B compliance (Lean/prover PR)
- **No `*.lean` files touched** — `git diff --stat` is `workflow.py` + `test_prover_guards.py` only.
- **Sorry counts unchanged** across all Lean modules (this PR changes Python harness logic, not proofs). The whole point is to STOP genuine proofs from being silently discarded.
- Pure **harness bug fix**, additive: **221 insertions, 0 deletions** — no anti-regression risk.
- Python harness change **is** the subject (Epic #1453) — not a refactor smuggled alongside a Lean claim, so no split needed.

## Evidence (offline, deterministic — no lake build, no LLM)
3 unit tests added to `tests/test_prover_guards.py` (verifier + re-verify monkeypatched):

```
$ python -m pytest tests/test_prover_guards.py -q -k p1_latch
3 passed, 36 deselected in 0.83s
```

- `test_p1_latch_fires_on_in_place_proof` — proved file (target line clear, count 1→0... session_full 1 sorry) → `proof_found is True`, re-verify NOT called, `yield_output` awaited once.
- `test_p1_latch_skips_when_sorry_count_not_dropped` — condition 2 veto (count unchanged) → `proof_found is False`, falls through to re-verify.
- `test_p1_latch_skips_when_target_line_still_has_sorry` — condition 1 veto (line still `sorry`) → `proof_found is False`, falls through.

Full file: **37 passed, 2 failed**. The 2 failures (`test_f9_*`) are **pre-existing on clean main HEAD** (verified by stashing this change and re-running): a recently-added "B2 gate" on `mark_sorry_intractable` makes those fixtures return `REFUSED (B2 gate)`. **Not introduced by this PR** — flagged separately to po-2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)