### PR TITLE
test(prover): fix 2 stale F9 fixtures for B2 gate (#1224, #1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -608,6 +608,9 @@ def test_f9_intractable_accepted_after_director_consultation():
     # Simulate AgentExecutor recording a real Director run.
     state.director_consulted = True
     state.director_consulted_count = 1
+    # B2 gate (#1224): the always-wired SearchAgent (provers.py:255) has also
+    # explored reference_docs/ by the time the Coordinator gives up.
+    state.search_agent_consulted = True
 
     out = ct.mark_sorry_intractable("director also failed")
     assert "REFUSED" not in out, f"F9 gate over-restrictive: {out[:200]}"
@@ -631,6 +634,10 @@ def test_f9_graceful_degradation_when_no_director_wired():
     director_agent = None
     if director_agent is None:
         state.director_consulted = True
+    # The SearchAgent is always wired (provers.py:255, unconditional), so by
+    # the time intractable is reached it has run and cleared the B2 gate
+    # (#1224). Only the Director has a no-wire auto-bypass.
+    state.search_agent_consulted = True
 
     from prover.tools import CoordinatorTools
     ct = CoordinatorTools(state=state, filepath="", trace=None)


### PR DESCRIPTION
## Summary
Fix 2 pre-existing test failures in `test_prover_guards.py` caused by the B2 gate (#1224) being added after the F9 tests were written.

`mark_sorry_intractable` (tools.py:2004-2041) now has **two** ordered gates:
1. F9 — `director_consulted` must be True
2. B2 (#1224) — `search_agent_consulted` must be True

Two F9 tests set only `director_consulted`, so they hit `REFUSED (B2 gate)` and asserted `"REFUSED" not in out` → fail.

## Why this is a faithful fix (not test-gaming)
The SearchAgent is wired **unconditionally** in production (provers.py:255 — no `if` guard, unlike the optional Director at L277). `search_agent_consulted` is set True at runtime when it runs (workflow.py:493). So by the time the Coordinator reaches `mark_sorry_intractable`, the SearchAgent has always run. Setting the flag in the fixtures mirrors real runtime state. **The B2 gate logic is unchanged** — only stale test state is corrected.

Confirmed no latent production trap: only the Director has a no-wire auto-bypass (provers.py:294-295); the SearchAgent never needs one because it always exists.

## Verification
```
python -m pytest tests/test_prover_guards.py -q
39 passed (was 37 passed, 2 failed)
```

Fixes the 2 F9 failures flagged during the #1539 P1-latch review (deliberately not bundled there for scope discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)