### PR TITLE
docs(claude): remettre une dose de scepticisme — verdicts != preuves (incident #274)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ S'applique a **tous les agents** (executants, coordinateur, reviewers humains et
 
 | # | Regle | Resume |
 |---|-------|--------|
-| G.1 | Verifier claims contre code | `grep`/`Read` avant d'affirmer une absence. Pas de propagation par confiance |
+| G.1 | Verifier claims ET verdicts contre la source | `grep`/`Read` avant d'affirmer une absence. **Un verdict d'un autre agent (NO-GO / COMPLETE / DONE / FALSE POSITIVE) se relit contre le scope reel de l'issue AVANT d'agir : le label n'est pas la preuve, son raisonnement peut reposer sur une premisse fausse ou une issue mal attribuee.** Pas de propagation par confiance |
 | G.2 | Metriques honnetes pas binaires | sorry=0 sans lake build SUCCESS = invalide. BEATS sans multi-seed = invalide |
 | G.3 | Pas de "DONE" sur progres marginal | Pourcentage explicite + liste residuelle obligatoires |
 | G.4 | Composites trop larges = split | > 3000 lignes / 15 fichiers / 4 features / 1 domaine = CHANGES_REQUESTED |
@@ -153,7 +153,7 @@ S'applique a **tous les agents** (executants, coordinateur, reviewers humains et
 | G.6 | Audit avant merge cascade | Lire le diff + verifier 1 claim par PR avant merge |
 | G.7 | Stagnation cross-cycle = escalade | Pas d'acceptation "BLOCKED" sans preuve concrete |
 | G.8 | Bots reviewers pas de rubber-stamp | APPROVE > 3 PRs en < 10 min = contester. APPROVED sur composite = CHANGES_REQUESTED |
-| G.9 | Culture du doute | Se demander "puis-je avoir tort ?" avant rapport/merge. Reproduire les "breakthrough" |
+| G.9 | Culture du doute | Se demander "puis-je avoir tort ?" avant rapport/merge/**close d'issue**. Reproduire les "breakthrough". **Fermer une issue = lire son body complet + confronter le verdict invoque a ce body, jamais sur le label seul (incident #274 : close hallucinee sur un NO-GO base sur une issue mal attribuee).** |
 
 ### H. Validation REELLE — pas de complaisance, jamais
 

--- a/docs/regles-vigilance-detail.md
+++ b/docs/regles-vigilance-detail.md
@@ -14,6 +14,8 @@ Avant de relayer un diagnostic technique d'un autre agent dans un dispatch ou un
 
 **Incident 2026-05-07** : agent a affirme "MultiAgentSorryProver doesn't exist" pendant 3 sessions, alors qu'il etait fully implemented dans `prover/agents.py`, `prover/workflow.py`, `prover/tools.py`, `prover/provers.py`. Cf [.claude/rules/verify-before-claiming.md](../.claude/rules/verify-before-claiming.md).
 
+**Incident 2026-05-24 (#274)** : ai-01 a ferme #274 (ComfyUI-RookieUI) sur un verdict "NO-GO (scope mismatch)" repris d'un audit po-2023 anterieur, SANS relire le body de l'issue. Or l'audit evaluait RookieUI contre une exigence "UI d'edition video" que #274 n'a JAMAIS formulee (#274 demande une sidebar generation d'IMAGE style A1111) — issue mal attribuee, l'audit confondait #274 avec une autre. Pire, la close a AJOUTE un rationale fabrique ("overlaps Forge/SDNext, no pedagogical value") contredisant le body. Detecte par le user ("Pure hallucination, tu as lu l'issue ?"), reverte (reopen + rétractation). **Lecon (G.1 + G.9) : un verdict est un claim comme un autre — son label ne dispense pas de relire la source qu'il pretend juger. Fermer une issue sur un label sans confronter son raisonnement au body = hallucination par procuration.**
+
 ---
 
 ## G.2 — Metriques honnetes, pas binaires


### PR DESCRIPTION
## Contexte

Suite a l'incident #274 (close hallucinee : verdict NO-GO repris sans relire le body de l'issue ; l'audit source confondait #274 avec une autre issue, et la close a ajoute un rationale fabrique). Le user a demande de "remettre une dose de scepticisme dans CLAUDE.md".

## Changements (2 lignes de table + 1 incident)

Conforme a la regle globale **No-Pendulum** : on aiguise les regles existantes G.1/G.9, on n'ajoute pas de bloc contre-poids.

- **G.1** "Verifier claims contre code" -> "Verifier claims ET verdicts contre la source" : un verdict d'un autre agent (NO-GO/COMPLETE/DONE/FALSE POSITIVE) se relit contre le scope reel de l'issue AVANT d'agir.
- **G.9** "Culture du doute" : fermer une issue = lire body complet + confronter le verdict au body, jamais sur le label seul.
- **docs/regles-vigilance-detail.md** (G.1) : incident #274 documente (le label n'est pas la preuve, hallucination par procuration).

## Scope

docs-only, 2 fichiers, 4 insertions / 2 deletions. Pas de code touche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
