### PR TITLE
fix(prover): close #1500 implicit-sorry false positive in both success gates

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -455,6 +455,27 @@ class MultiAgentSorryProver:
                 # Force-clear best snapshot so callers don't claim spurious progress
                 tactic_tools._best_content = None
                 tactic_tools._best_sorry_count = original_sorry_count
+            else:
+                # Build passed — but a passing build can still hide an IMPLICIT
+                # sorry: when the agent replaces an explicit `sorry` with a search
+                # tactic (apply?/exact?/solve_by_elim) that finds nothing, Lean
+                # emits a "declaration uses sorry" WARNING (not an error), so the
+                # build succeeds while the text no longer contains "sorry" (#1500).
+                # compile() already folds that warning into
+                # final_verify["sorry_count"] (build-aware: max of text + warning
+                # counts); the text-only final_sorry read above misses it. Adopt
+                # the build-aware count whenever it is higher so the success gate
+                # below cannot fire on a vanished-text / implicit sorry.
+                _verify_sorry = final_verify.get("sorry_count")
+                if isinstance(_verify_sorry, int) and _verify_sorry > final_sorry:
+                    print(
+                        f"  Build-aware sorry count {_verify_sorry} > text count "
+                        f"{final_sorry}: {_verify_sorry - final_sorry} implicit "
+                        f"sorry (apply?/exact?/solve_by_elim). Using build-aware "
+                        f"count for the success gate (#1500)."
+                    )
+                    final_sorry = _verify_sorry
+                    structural_progress = False
 
         # Success now also covers structural progress: file changed but
         # compiles, even if sorry count didn't decrease. Provers.py used to

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -722,7 +722,20 @@ class VerifyExecutor(Executor):
                 _latch_rel = (f"{_LatchPath(_latch_fp).parent.name}/"
                               f"{_LatchPath(_latch_fp).name}")
                 _latch_build = _latch_verifier.verify_project_file(_latch_rel)
-                if _latch_build.get("success"):
+                # Build-aware re-count: a passing build can still emit
+                # "declaration uses sorry" warnings when the agent swapped an
+                # explicit `sorry` for a search tactic (apply?/exact?/
+                # solve_by_elim) that found nothing — an IMPLICIT sorry that the
+                # text count above misses (#1500). Fold the warning count the
+                # same way tools.compile() does and require the EFFECTIVE count
+                # to have dropped below the session-start count, else the
+                # "in-place proof" is illusory and we must fall through to the
+                # normal verify path.
+                from .tools import _count_sorries_from_build_output
+                _latch_build_warn = _count_sorries_from_build_output(
+                    _latch_build.get("raw_output", ""))
+                _latch_effective = max(_latch_now, _latch_build_warn)
+                if _latch_build.get("success") and _latch_effective < _latch_orig:
                     msg.proof_found = True
                     self._consecutive_build_fails = 0
                     self._consecutive_noprogress = 0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -690,14 +690,20 @@ def _run_handle(executor, msg):
     return ctx
 
 
-def _patch_verifier_and_reverify(monkeypatch, build_success=True):
-    """Mock the verifier (condition 3) and record any re-verify fall-through."""
+def _patch_verifier_and_reverify(monkeypatch, build_success=True, raw_output=""):
+    """Mock the verifier (condition 3) and record any re-verify fall-through.
+
+    ``raw_output`` lets a test inject a build log carrying a "declaration uses
+    sorry" warning so the build-aware latch guard (#1500) can be exercised
+    without a real lake build.
+    """
     import prover.verifier as vmod
     import prover.lean_utils as lu
 
     class _FakeVerifier:
         def verify_project_file(self, rel, force=False):
-            return {"success": build_success, "errors": "", "raw_output": ""}
+            return {"success": build_success, "errors": "",
+                    "raw_output": raw_output}
 
     monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _FakeVerifier())
 
@@ -794,3 +800,94 @@ def test_p1_latch_skips_when_target_line_still_has_sorry(tmp_path, monkeypatch):
         "latch must not fire while the frozen target line still has a sorry"
     )
     assert len(reverify_calls) == 1, "re-verify must run when condition 1 vetoes"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1500 — implicit-sorry blind spot: a passing build can still hide a sorry
+#
+# When the agent swaps an explicit `sorry` for a search tactic
+# (apply?/exact?/solve_by_elim) that finds nothing, Lean emits a
+# "declaration uses sorry" WARNING (not an error). The build SUCCEEDS and the
+# text no longer contains the token "sorry", so a text-only count reports 0 —
+# a false positive. The fix folds the build-warning count into the decision
+# (the same max() that tools.compile() already uses) in BOTH success gates:
+#   - prover/provers.py  run_session success gate (final_sorry adoption)
+#   - prover/workflow.py P1 in-place latch (effective-count condition)
+# `_count_sorries_from_build_output` is the shared primitive; tests below pin
+# the primitive and the latch decision offline (no lake build needed).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# A realistic lake build log fragment with one implicit-sorry warning.
+_IMPLICIT_SORRY_LOG = (
+    "Building TestSpace\n"
+    "warning: ./TestSpace/Fake.lean:42:0: declaration uses 'sorry'\n"
+    "Build completed successfully.\n"
+)
+
+
+def test_count_sorries_from_build_output_counts_warning():
+    """The shared primitive counts a 'declaration uses sorry' warning."""
+    from prover.tools import _count_sorries_from_build_output
+
+    assert _count_sorries_from_build_output(_IMPLICIT_SORRY_LOG) == 1
+
+
+@pytest.mark.parametrize("log", [
+    "Build completed successfully.\n",          # clean build, no warning
+    "info: building\nwarning: unused variable x\n",  # unrelated warning
+    "",                                          # empty
+])
+def test_count_sorries_from_build_output_zero_when_no_sorry(log):
+    """No 'uses sorry' warning -> count 0 (no false positives on clean logs)."""
+    from prover.tools import _count_sorries_from_build_output
+
+    assert _count_sorries_from_build_output(log) == 0
+
+
+def test_count_sorries_from_build_output_counts_multiple_declarations():
+    """One warning per flagged declaration."""
+    from prover.tools import _count_sorries_from_build_output
+
+    log = (
+        "warning: ./A.lean:3:0: declaration uses 'sorry'\n"
+        "warning: ./A.lean:9:0: declaration uses `sorry`\n"
+    )
+    assert _count_sorries_from_build_output(log) == 2
+
+
+def test_p1_latch_skips_on_implicit_sorry(tmp_path, monkeypatch):
+    """#1500: frozen line text-clear + text count dropped + build SUCCEEDS,
+    but the build log warns 'declaration uses sorry' (the agent swapped the
+    explicit sorry for `apply?` which found nothing). The effective count did
+    NOT actually drop, so the latch must NOT fire — it must fall through to the
+    normal verify path instead of claiming a spurious in-place proof.
+    """
+    from prover.workflow import ProofMessage
+
+    # Text shows no "sorry" (replaced by apply?), but the build will warn.
+    swapped = (
+        "import Mathlib.Tactic\n"
+        "theorem t : True := by\n"
+        "  apply?\n"
+    )
+    fake = tmp_path / "Implicit.lean"
+    fake.write_text(swapped, encoding="utf-8")
+    session_full = swapped.replace("  apply?\n", "  sorry\n")
+    # Condition 1 (frozen line clear) and condition 2 (text 1 -> 0) both hold.
+    assert session_full.count("sorry") == 1 and swapped.count("sorry") == 0
+
+    reverify_calls = _patch_verifier_and_reverify(
+        monkeypatch, build_success=True, raw_output=_IMPLICIT_SORRY_LOG,
+    )
+
+    ex = _make_verify_executor(fake, sorry_line=3, full_file=session_full)
+    msg = ProofMessage(content="x", tactic="apply?", sorry_count=1)
+    _run_handle(ex, msg)
+
+    assert msg.proof_found is False, (
+        "latch must NOT fire when the build still warns 'uses sorry' (#1500)"
+    )
+    assert len(reverify_calls) == 1, (
+        "re-verify must run when the effective (build-aware) count did not drop"
+    )


### PR DESCRIPTION
## Scope
Closes #1500. Pure Python harness fix — wires the **already-existing** build-aware sorry counter into the two success gates that still counted by text only.

## Bug (#1500)
When the TacticAgent swaps an explicit `sorry` for a search tactic (`apply?`/`exact?`/`solve_by_elim`) that finds nothing, Lean emits a `declaration uses sorry` **warning** (not an error). `lake build` SUCCEEDS, but the file text no longer contains the token `sorry`. Two gates counted sorries by text only and fired on the vanished token → reported a proof that does not exist (incident: BG2 GaleShapley L98, Cycle 86, `final_sorry: 0` false positive).

## Fix (2 gates, same blind spot)
- **`prover/provers.py`** `run_session` success gate: `final_sorry` was `read_text().count("sorry")`. On a build-OK file it now adopts the build-aware count `compile()` already computes — `final_verify["sorry_count"] = max(text, "uses sorry" warnings)` — before the gate runs.
- **`prover/workflow.py`** P1 in-place latch: condition was text-count-only; it now folds the build-warning count via `_count_sorries_from_build_output` (the same primitive `compile()` uses) and requires the **effective** count to have dropped before latching `proof_found`, else falls through to the normal verify path.

## Note on the issue's proposed fix
The issue suggested `total = explicit + implicit`. That double-counts: an explicit `sorry` ALSO emits the `uses sorry` warning. I used the build-aware `max(text, warning)` that the harness already standardizes on in `tools.compile()` — correct and consistent. No new detection logic added (the issue's premise that "the harness does not check build output" is stale: `_count_sorries_from_build_output` + build-aware `compile()` already exist in `tools.py`; the gates simply now consume them).

## Verification
- **No `*.lean` touched** → every Lean file `grep -c sorry` before == after (this fix guards AGAINST spurious sorry-count drops; it cannot change proof content). Rule B proof-progress body N/A — no proof claim made.
- `git diff --stat`: 3 files, +135/-4 (insertions dominate, zero production-code deletion).
- Offline deterministic tests (no lake), `tests/test_prover_guards.py`:
  - `_count_sorries_from_build_output` primitive — warning / clean / unrelated-warning / multi-declaration
  - `test_p1_latch_skips_on_implicit_sorry` — build OK + `uses sorry` warning → latch must NOT fire, re-verify runs
- Full suite: **45 passed** (`coursia-ml-training` env, pytest 9.0.3).

```
tests\test_prover_guards.py ............................................. [100%]
============================= 45 passed in 0.95s ==============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)