### PR TITLE
test(prover): lock AutonomousProver increase-case gate (#1483)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -84,6 +84,33 @@ def _refuse_honest_sorry(filepath: str, sorry_line: int,
     return None
 
 
+def _autonomous_success_gate(final_sorry: int, original_sorry_count: int,
+                             final_build_ok: bool) -> tuple[bool, bool]:
+    """Decide AutonomousProver session success from the post-verify counts (P4).
+
+    Pure decision behind the increase-case gate (#1483). A file that BUILDS
+    (``final_build_ok``) is a success when the sorry count DECREASED, or when it
+    stayed/INCREASED through strategic decomposition (structural progress) while
+    still > 0. A build failure is never a success. The increase-case is the
+    point P4 targets: a decomposition that raises the sorry count but still
+    compiles 0 errors must report success and must NOT be reverted — the revert
+    branch upstream is keyed on ``final_build_ok`` (``level_1_build``) alone, so
+    a sorry increase never reaches it as long as the build passes.
+
+    Returns ``(success, structural_progress)``.
+    """
+    structural_progress = (
+        final_sorry >= original_sorry_count
+        and final_build_ok
+        and final_sorry > 0
+    )
+    success = (
+        (final_sorry < original_sorry_count or structural_progress)
+        and final_build_ok
+    )
+    return success, structural_progress
+
+
 class MultiAgentSorryProver:
     """Multi-agent sorry replacement using WorkflowBuilder graph.
 
@@ -1138,16 +1165,11 @@ class AutonomousProver:
                           f"reverting.", flush=True)
 
         # P4: success also covers structural progress (sorry increase from
-        # strategic decomposition) as long as the file builds.
-        structural_progress_autonomous = (
-            final_sorry >= original_sorry_count
-            and final_build_ok
-            and final_sorry > 0
-        )
-        success = (
-            (final_sorry < original_sorry_count
-             or structural_progress_autonomous)
-            and final_verify_ok
+        # strategic decomposition) as long as the file builds. Decision is
+        # extracted to a pure helper so the increase-case is unit-testable
+        # (#1483). final_build_ok == final_verify_ok here (set at line ~1102).
+        success, structural_progress_autonomous = _autonomous_success_gate(
+            final_sorry, original_sorry_count, final_build_ok
         )
         self.trace.end_session_span(success, f"{original_sorry_count}->{final_sorry}")
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -891,3 +891,71 @@ def test_p1_latch_skips_on_implicit_sorry(tmp_path, monkeypatch):
     assert len(reverify_calls) == 1, (
         "re-verify must run when the effective (build-aware) count did not drop"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1483 — AutonomousProver increase-case gate: a strategic decomposition that
+# RAISES the sorry count but still compiles (lake build SUCCESS, 0 errors) must
+# be reported as success and must NOT be reverted. The revert branch upstream
+# (provers.py ~1105) is keyed on `level_1_build` alone, so a sorry increase
+# never reaches it while the build passes; `_autonomous_success_gate` is the
+# pure decision behind the final success/structural-progress flags. P4 intent:
+# "never revert a file solely because sorry increased".
+# ──────────────────────────────────────────────────────────────────────────
+def test_autonomous_gate_increase_case_is_success_no_revert():
+    """sorry 4 -> 5 (decomposition) + build OK => success, structural progress."""
+    from prover.provers import _autonomous_success_gate
+
+    success, structural = _autonomous_success_gate(
+        final_sorry=5, original_sorry_count=4, final_build_ok=True,
+    )
+    assert success is True, (
+        "increase-case that still builds must report success (P4 #1483)"
+    )
+    assert structural is True, (
+        "a building sorry increase is structural progress, not a regression"
+    )
+
+
+def test_autonomous_gate_increase_case_reverts_when_build_fails():
+    """sorry 4 -> 5 but build FAILS => not success (revert territory)."""
+    from prover.provers import _autonomous_success_gate
+
+    success, structural = _autonomous_success_gate(
+        final_sorry=5, original_sorry_count=4, final_build_ok=False,
+    )
+    assert success is False
+    assert structural is False
+
+
+@pytest.mark.parametrize(
+    "final_sorry,original,build_ok,exp_success,exp_struct",
+    [
+        # increase + build OK -> success via structural progress (#1483 core)
+        (5, 4, True, True, True),
+        # same count + build OK + >0 -> structural progress (no regression)
+        (4, 4, True, True, True),
+        # decrease + build OK -> plain success, not structural
+        (3, 4, True, True, False),
+        # fully solved + build OK -> success, not structural (count 0)
+        (0, 4, True, True, False),
+        # increase + build FAIL -> never success
+        (5, 4, False, False, False),
+        # decrease + build FAIL -> never success (false positive guard)
+        (3, 4, False, False, False),
+        # degenerate 0 -> 0 (no sorry to prove): no progress, not structural
+        # (struct needs final_sorry > 0). Preserves the pre-extraction formula.
+        (0, 0, True, False, False),
+    ],
+)
+def test_autonomous_gate_matrix(final_sorry, original, build_ok,
+                                exp_success, exp_struct):
+    from prover.provers import _autonomous_success_gate
+
+    success, structural = _autonomous_success_gate(
+        final_sorry=final_sorry,
+        original_sorry_count=original,
+        final_build_ok=build_ok,
+    )
+    assert success is exp_success
+    assert structural is exp_struct


### PR DESCRIPTION
## Scope

Closes the remaining acceptance item on #1483 — the **increase-case test** — at the unit level. F1/F2 (the code fixes) were already resolved in #1463 (verified line-by-line on current `main`); this PR adds the regression guard that locks the P4 increase-case behaviour so it cannot silently regress.

## What P4 / the increase-case is

A *strategic decomposition* can RAISE the sorry count (e.g. 1 sorry split into 2 sub-lemmas) while the file still compiles 0 errors. P4 intent: **never revert a file solely because the sorry count increased** — only revert on a build failure. The revert branch (`provers.py` ~1105) is already keyed on `level_1_build` alone, so a sorry increase never reaches it while the build passes.

## Change

- Extract the AutonomousProver session-success decision into a pure, unit-testable helper `_autonomous_success_gate(final_sorry, original_sorry_count, final_build_ok) -> (success, structural_progress)`.
- **Behaviour-identical** to the inline computation it replaces:
  - on the no-revert path `final_build_ok == final_verify_ok`;
  - on the revert path `final_sorry` is reset to `original_sorry_count`, so the old (`... and final_verify_ok`) and new (`... and final_build_ok`) formulas yield the same result.
- Regression tests in `tests/test_prover_guards.py`:
  - `test_autonomous_gate_increase_case_is_success_no_revert` — sorry 4→5 + build OK ⇒ `success=True`, `structural=True` (the scenario P4 targets).
  - `test_autonomous_gate_increase_case_reverts_when_build_fails` — sorry 4→5 + build FAIL ⇒ not success.
  - `test_autonomous_gate_matrix` — 7-row matrix (decrease / hold / solve / build-fail / degenerate 0→0).

## Verification

- 54 prover-guard tests pass (`coursia-ml-training` env, pytest 9.0.3). The degenerate `0→0` row was corrected to assert the *real* pre-existing behaviour (no progress ⇒ not success), not forced to a wrong expectation.
- AST + import sanity check OK; `_autonomous_success_gate(5,4,True) == (True, True)`.

## Rule B note

Pure Python harness test/refactor: **no `.lean` touched, sorry counts unchanged** (the helper preserves existing semantics and the tests guard against regressions). The grep/lake-build/proof-integrity items of Rule B are N/A here — there is no Lean claim. The end-to-end real Lean calibration target (acceptance bullet 2: `grep -c sorry` increase + `lake build SUCCESS` on a live agent run) remains for a po-2026 BG iteration; #1483 stays open on that integration item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)