### PR TITLE
fix(prover): cache compile_probe_goal by content hash (#1460)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -602,6 +602,16 @@ class TacticTools:
         # return a LOOP DETECTED error to force the agent to change approach.
         self._tool_call_history: deque = deque(maxlen=20)
         self._loop_threshold = 3  # consecutive identical calls before triggering
+        # #1460: cache compile_probe_goal results keyed by (file content hash,
+        # sorry_line). Probing the goal state runs the Lean server (~seconds);
+        # forensics found 54 exact-repeat probes of the *same unchanged goal*
+        # (~2.2h wasted). The content hash is a stronger invalidation signal
+        # than the issue's suggested 60s TTL: the goal at a line can only change
+        # when the file content changes, so a content-keyed cache never returns
+        # a stale goal and avoids wall-clock nondeterminism. Re-probing the same
+        # goal stays legitimate (probe -> edit elsewhere -> re-probe), so this is
+        # a cache, not a loop-error like file_read_lines.
+        self._probe_goal_cache: dict = {}
         if filepath and Path(filepath).exists():
             raw = Path(filepath).read_text(encoding="utf-8")
             self._original_file_size = len(raw)
@@ -1417,12 +1427,36 @@ class TacticTools:
             return True
 
     def compile_probe_goal(self, sorry_line: int) -> str:
-        """Extract the Lean goal state at a specific sorry line by probing. Returns the goal text."""
+        """Extract the Lean goal state at a specific sorry line by probing. Returns the goal text.
+
+        Result is cached by (file content hash, sorry_line) (#1460). The goal at a
+        line only changes when the file changes, so a repeat probe of an unchanged
+        file is served from cache instead of re-running the Lean server. The cache
+        auto-invalidates when any edit changes the content hash.
+        """
         from .lean_utils import get_goal_state
+        cache_key = None
+        if self._filepath and Path(self._filepath).exists():
+            content = Path(self._filepath).read_text(encoding="utf-8")
+            content_hash = hashlib.md5(content.encode()).hexdigest()
+            cache_key = (content_hash, sorry_line)
+            cached = self._probe_goal_cache.get(cache_key)
+            if cached is not None:
+                if self._trace:
+                    self._trace.log(
+                        agent="TacticTools", role="probe_goal_cache_hit",
+                        content=f"probe_goal line {sorry_line} served from cache",
+                        duration_s=0.0,
+                    )
+                return cached
         goal = get_goal_state(self._filepath, sorry_line)
         if goal:
-            return json.dumps({"goal": goal, "line": sorry_line})
-        return json.dumps({"goal": None, "line": sorry_line, "hint": "Could not extract goal"})
+            result = json.dumps({"goal": goal, "line": sorry_line})
+        else:
+            result = json.dumps({"goal": None, "line": sorry_line, "hint": "Could not extract goal"})
+        if cache_key is not None:
+            self._probe_goal_cache[cache_key] = result
+        return result
 
     def compile(self, check_axioms: bool = False) -> str:
         """3-level verification: build SUCCESS + sorry count delta + axiom whitelist.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -959,3 +959,56 @@ def test_autonomous_gate_matrix(final_sorry, original, build_ok,
     )
     assert success is exp_success
     assert structural is exp_struct
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1460 — compile_probe_goal caching. Probing the goal state runs the Lean
+# server; forensics found 54 exact-repeat probes of the same unchanged goal
+# (~2.2h wasted). The cache is keyed by (file content hash, sorry_line): a
+# repeat probe of an unchanged file is served from cache, and any edit that
+# changes the content hash invalidates it (a content key is a stronger
+# invalidation signal than a wall-clock TTL — the goal can only change when
+# the file does).
+# ──────────────────────────────────────────────────────────────────────────
+def test_probe_goal_caches_unchanged_file(tactic_tools, monkeypatch):
+    """Two probes of the same file hit the Lean server once; second is cached."""
+    import json
+    import prover.lean_utils as lean_utils
+
+    calls = {"n": 0}
+
+    def fake_get_goal_state(filepath, line):
+        calls["n"] += 1
+        return f"goal at {line}"
+
+    monkeypatch.setattr(lean_utils, "get_goal_state", fake_get_goal_state)
+    line = tactic_tools._test_sorry_line
+
+    first = tactic_tools.compile_probe_goal(line)
+    second = tactic_tools.compile_probe_goal(line)
+
+    assert calls["n"] == 1, "unchanged file must serve the second probe from cache"
+    assert first == second, "cached result must be identical to the first probe"
+    assert json.loads(first)["goal"] == f"goal at {line}"
+
+
+def test_probe_goal_cache_invalidates_on_file_change(tactic_tools, monkeypatch):
+    """Editing the file changes its content hash, so the next probe recomputes."""
+    import prover.lean_utils as lean_utils
+
+    calls = {"n": 0}
+
+    def fake_get_goal_state(filepath, line):
+        calls["n"] += 1
+        return f"goal v{calls['n']}"
+
+    monkeypatch.setattr(lean_utils, "get_goal_state", fake_get_goal_state)
+    line = tactic_tools._test_sorry_line
+
+    tactic_tools.compile_probe_goal(line)
+    # Mutate the underlying file: the content hash changes -> cache miss.
+    path = Path(tactic_tools._filepath)
+    path.write_text(path.read_text(encoding="utf-8") + "\n-- edit\n", encoding="utf-8")
+    tactic_tools.compile_probe_goal(line)
+
+    assert calls["n"] == 2, "a content change must invalidate the probe cache"


### PR DESCRIPTION
## Summary

Caches `TacticTools.compile_probe_goal` results keyed by `(file content hash, sorry_line)`. Probing the Lean goal state runs the Lean server (~seconds); forensic analysis (`baselines/forensic_analysis.md`) found **54 exact-repeat probes of the same unchanged goal (~2.2h wasted)**. A repeat probe of an unchanged file is now served from cache; any edit that changes the content hash invalidates it.

This is the one genuinely-unaddressed slice of #1460. The other sub-features already exist in the harness (verified, file:line):
- `_check_tool_loop` (tools.py:621, threshold 3) already guards `file_read_lines` / `file_replace_lines` / `file_insert_lines` / `file_replace_sorry`
- F11 search-loop cap (tools.py:290) caps `search_mathlib_lemmas` same-query-0-result loops at 3
- `_consecutive_delta0` (#1536, tools.py:576) tracks no-progress compiles
- `compile()` caches via the verifier (tools.py:1448)

## Design note

The content-hash key is a **stronger invalidation signal than the issue's suggested 60s TTL**: the goal at a line can only change when the file content changes, so a content-keyed cache never returns a stale goal and avoids wall-clock nondeterminism (which would also make tests flaky). Re-probing the same goal stays legitimate (probe → edit elsewhere → re-probe), so this is a *cache*, not a loop-error like `file_read_lines`.

## Scope / Rule B

Pure Python harness change. **No `.lean` files touched, sorry counts unchanged** (`git diff --cached --name-only | grep -c '.lean$'` = 0) — so the Lean-PR checklist (grep -c sorry / lake build) is N/A, consistent with #1539/#1536/#1543/#1549/#1550.

Diff: 2 files, +90/−3.

## Tests

Adds 2 offline deterministic tests (monkeypatched `get_goal_state`):
- `test_probe_goal_caches_unchanged_file` — two probes hit the Lean server once
- `test_probe_goal_cache_invalidates_on_file_change` — a content edit forces recompute

Full guard suite **54 → 56 passing** (`coursia-ml-training` env, pytest 9.0.3):
```
tests/test_prover_guards.py ............................................ [ 78%]
............                                                             [100%]
56 passed in 0.87s
```

Part of Epic #1453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)