### PR TITLE
fix(ci): C.1 checker no longer flags dates as 1/0 — shared scanner (#1505)

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -54,6 +54,36 @@ def _is_in_docstring(line: str, in_doc: bool) -> tuple[bool, bool]:
     return in_doc, is_inside
 
 
+def scan_c1_source(source: str) -> list[tuple[str, str]]:
+    """Scan one code cell's source for C.1 forbidden patterns.
+
+    Returns a list of (offending_line, pattern_desc) tuples. Comment lines,
+    inline comments, and docstring bodies are skipped, and patterns are matched
+    with digit-bounded regexes (C1_PATTERNS) rather than substrings — so
+    legitimate data such as the date "21/02/2022" (which contains "1/0" as a
+    substring) is not flagged. This is the single shared C.1 detector; both
+    notebook_lint and validate_pr_notebooks consume it to avoid divergence
+    (#1505).
+    """
+    hits: list[tuple[str, str]] = []
+    in_docstring = False
+    for line in source.split("\n"):
+        stripped = line.lstrip()
+        # Skip any comment line (commented-out code is not executable)
+        if stripped.startswith("#"):
+            continue
+        # Strip inline comments before checking patterns
+        code_part = line.split("#")[0].rstrip()
+        # Track and skip docstring content
+        in_docstring, is_inside = _is_in_docstring(line, in_docstring)
+        if is_inside:
+            continue
+        for pattern, desc in C1_PATTERNS:
+            if re.search(pattern, code_part):
+                hits.append((line.strip(), desc))
+    return hits
+
+
 def check_c1(notebook: dict) -> list[dict]:
     """Check C.1: no intentional errors in code cells."""
     violations = []
@@ -61,26 +91,13 @@ def check_c1(notebook: dict) -> list[dict]:
         if cell.get("cell_type") != "code":
             continue
         source = "".join(cell.get("source", []))
-        in_docstring = False
-        for line in source.split("\n"):
-            stripped = line.lstrip()
-            # Skip any comment line (commented-out code is not executable)
-            if stripped.startswith("#"):
-                continue
-            # Strip inline comments before checking patterns
-            code_part = line.split("#")[0].rstrip()
-            # Track and skip docstring content
-            in_docstring, is_inside = _is_in_docstring(line, in_docstring)
-            if is_inside:
-                continue
-            for pattern, desc in C1_PATTERNS:
-                if re.search(pattern, code_part):
-                    violations.append({
-                        "check": "C1",
-                        "cell_index": i,
-                        "line": line.strip(),
-                        "pattern": desc,
-                    })
+        for offending_line, desc in scan_c1_source(source):
+            violations.append({
+                "check": "C1",
+                "cell_index": i,
+                "line": offending_line,
+                "pattern": desc,
+            })
     return violations
 
 

--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -1,0 +1,110 @@
+"""Tests for validate_pr_notebooks.py — CI C.1/H.1/H.3 merge gate.
+
+Focus: the C.1 detector must use the shared digit-bounded, comment/docstring-aware
+scanner (#1505), so legitimate data like the date "21/02/2022" is no longer flagged
+as a "1/0" division while a real `1/0` still fails.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from validate_pr_notebooks import validate_notebook
+
+
+def _write_nb(cells, tmp_path, name="test.ipynb", kernel="python3"):
+    """Write a notebook dict to a temp file and return its Path."""
+    nb = {
+        "cells": cells,
+        "metadata": {"kernelspec": {"name": kernel}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    p = tmp_path / name
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    return p
+
+
+def _code(source, execution_count=1, outputs=None):
+    """Build an executed code cell (exec_count + outputs set so only C.1 can fail)."""
+    if isinstance(source, str):
+        source = [source + "\n"]
+    return {
+        "cell_type": "code",
+        "source": source,
+        "execution_count": execution_count,
+        "outputs": outputs or [],
+    }
+
+
+def _c1_errors(result):
+    return [e for e in result["errors"] if "C.1" in e]
+
+
+def test_date_literal_not_flagged_as_division(tmp_path):
+    """A date like 21/02/2022 contains '1/0' as a substring but is legitimate data."""
+    nb = _write_nb([_code('source_name = "Kremlin Discours 21/02/2022"')], tmp_path)
+    result = validate_notebook(nb)
+    assert result["passed"], result["errors"]
+    assert _c1_errors(result) == []
+
+
+def test_real_division_by_zero_flagged(tmp_path):
+    """A genuine 1/0 (digit-bounded) must still fail C.1."""
+    nb = _write_nb([_code("x = 1/0")], tmp_path)
+    result = validate_notebook(nb)
+    assert not result["passed"]
+    assert any("1/0" in e for e in _c1_errors(result))
+
+
+def test_division_by_zero_with_spaces_flagged(tmp_path):
+    """`1 / 0` with whitespace is still a division by zero."""
+    nb = _write_nb([_code("y = 1 / 0")], tmp_path)
+    result = validate_notebook(nb)
+    assert not result["passed"]
+    assert any("1/0" in e for e in _c1_errors(result))
+
+
+def test_raise_not_implemented_flagged(tmp_path):
+    nb = _write_nb([_code("raise NotImplementedError('todo')")], tmp_path)
+    result = validate_notebook(nb)
+    assert not result["passed"]
+    assert any("raise NotImplementedError" in e for e in _c1_errors(result))
+
+
+def test_assert_false_flagged(tmp_path):
+    nb = _write_nb([_code("assert False, 'nope'")], tmp_path)
+    result = validate_notebook(nb)
+    assert not result["passed"]
+    assert any("assert False" in e for e in _c1_errors(result))
+
+
+def test_banned_pattern_in_comment_not_flagged(tmp_path):
+    """A commented-out 1/0 is not executable, so it must not trip C.1."""
+    nb = _write_nb([_code("x = 5  # this would be 1/0 but it is a comment")], tmp_path)
+    result = validate_notebook(nb)
+    assert result["passed"], result["errors"]
+    assert _c1_errors(result) == []
+
+
+def test_banned_pattern_in_multiline_docstring_not_flagged(tmp_path):
+    """1/0 inside a multi-line docstring is prose, not executable code.
+
+    Note: the shared scanner tracks multi-line triple-quote state. A single-line
+    `1/0` embedded in a regular string literal is a broader, pre-existing
+    limitation (would need full tokenization) and is intentionally out of #1505's
+    scope, which targets the date substring false positive.
+    """
+    src = 'def f():\n    """\n    Demonstrates the error 1/0 conceptually.\n    """\n    return 5'
+    nb = _write_nb([_code(src)], tmp_path)
+    result = validate_notebook(nb)
+    assert result["passed"], result["errors"]
+    assert _c1_errors(result) == []
+
+
+def test_clean_notebook_passes(tmp_path):
+    nb = _write_nb([_code("total = 2 + 2\nprint(total)")], tmp_path)
+    result = validate_notebook(nb)
+    assert result["passed"], result["errors"]

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -21,10 +21,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+# Shared C.1 detector (#1505): digit-bounded regex, comment/docstring-aware.
+# Both this CI gate and notebook_lint.py consume the same scanner so the two
+# C.1 checkers can never diverge again (the old substring match here flagged
+# dates like "21/02/2022" because "1/0" is a substring of "1/02").
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from notebook_lint import scan_c1_source
 
-# Patterns banned by rule C.1
-C1_BANNED = ["raise NotImplementedError", "assert False", "1/0"]
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Kernels that cannot be executed via Papermill in CI (skip execution check,
 # but still check C.1 and structural validity)
@@ -117,13 +121,13 @@ def validate_notebook(nb_path: Path) -> dict:
 
         result["total_code"] += 1
 
-        # C.1 check: banned patterns
-        for pattern in C1_BANNED:
-            if pattern in source:
-                result["passed"] = False
-                result["errors"].append(
-                    f"cell {i}: C.1 violation — '{pattern}' found"
-                )
+        # C.1 check: forbidden patterns via the shared digit-bounded,
+        # comment/docstring-aware scanner (#1505 — no more date false positives)
+        for _line, desc in scan_c1_source(source):
+            result["passed"] = False
+            result["errors"].append(
+                f"cell {i}: C.1 violation — '{desc}' found"
+            )
 
         # H.3 check: execution_count must not be null (skip for non-Papermill kernels)
         if not skip_exec:


### PR DESCRIPTION
## Summary
The CI C.1 gate (`validate_pr_notebooks.py`) matched the banned `1/0` pattern by **substring**, so any string containing `1/0` — notably dates like `21/02/2022` (`1/02` contains `1/0`) — produced a false C.1 failure. This is what forced #1497 to merge via `--admin`.

Fix: factor the canonical **digit-bounded, comment/docstring-aware** C.1 detector from `notebook_lint.py` into a shared `scan_c1_source()` and consume it from **both** modules, so the two C.1 checkers can never diverge again (the issue's "ideal" acceptance item).

## Changes
- `notebook_lint.py`: extract `scan_c1_source(source) -> list[(line, desc)]`; `check_c1` now delegates to it (behaviour unchanged).
- `validate_pr_notebooks.py`: replace the substring `C1_BANNED` loop with `scan_c1_source` (imported from the sibling module).
- `tests/test_validate_pr_notebooks.py` (new, 8 tests).

## Verification (run locally, coursia-ml-training env)
- 8/8 new tests pass; 15/15 existing `test_check_c2_compliance.py` still pass.
- **Real-world**: the cited `Argument_Analysis_UI_configuration.ipynb` (Kremlin date) — previously a false FAIL — now **PASSES**:
  ```
  Notebook PR Validation: 1/1 passed
  ```
- A genuine `x = 1/0` still **FAILS** the gate:
  ```
  FAIL ... cell 0: C.1 violation — '1/0' found
  ```
- `notebook_lint.py` runs clean on the cited notebook post-refactor (`1/1 pass`).

## Acceptance (issue #1505)
- [x] No longer flags `21/02/2022` / `dd/0X` dates
- [x] Still flags real `1/0` (digit-bounded) + `raise NotImplementedError` + `assert False`
- [x] Unit test added (date PASS + real `1/0` FAIL, and more)
- [x] C.1 patterns factored into one shared place with `notebook_lint.py`

## Known limitation (out of scope, documented in the test)
A `1/0` embedded in a **single-line** string literal (e.g. `"divide 1/0 case"`) is still flagged — a broader pre-existing limitation shared by both checkers that would need full Python tokenization. #1505 targets the date substring FP only; multi-line docstrings are skipped.

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)