### PR TITLE
fix(docker): ComfyUI idle monitor timer reset after /free

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p5_tts.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p5_tts.py
@@ -414,7 +414,7 @@ def _synthesize_segment(seg: AnnotatedSegment, fishaudio_text: str) -> TTSResult
             "temperature": 0.7,
             "top_p": 0.9,
             "format": "mp3",
-            "timeout": 120,
+            "timeout": 300,
         })
 
     # If single chunk, use direct call
@@ -471,14 +471,29 @@ def _synthesize_segment(seg: AnnotatedSegment, fishaudio_text: str) -> TTSResult
     )
 
 
+def _load_cached_hashes() -> dict[int, str]:
+    """Load text hashes from tts_results.json once (O(N) not O(N²))."""
+    results_path = BASE_DIR / "outputs" / "tts_results.json"
+    if not results_path.exists():
+        return {}
+    try:
+        data = json.loads(results_path.read_text(encoding="utf-8"))
+        return {r["seg_index"]: r.get("text_hash", "") for r in data}
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
 def _synthesize_batch(
     segments: list[tuple[AnnotatedSegment, str]],
+    cached_hashes: dict[int, str] | None = None,
 ) -> list[TTSResult]:
     """Process a batch of segments concurrently.
 
     Delegates cache checking to _synthesize_segment (which does text-hash
     invalidation). Only truly cached segments skip the thread pool.
     """
+    if cached_hashes is None:
+        cached_hashes = {}
     results: dict[int, TTSResult] = {}
 
     # Quick first pass: check which are truly cached (hash matches)
@@ -489,35 +504,21 @@ def _synthesize_batch(
         mp3_path = TTS_DIR / f"seg_{seg.seg_index:04d}_{seg.speaker}.mp3"
         current_hash = _text_hash(text)
 
-        if mp3_path.exists():
-            # Check hash from previous results
-            cached_hash = ""
-            results_path = BASE_DIR / "outputs" / "tts_results.json"
-            if results_path.exists():
-                try:
-                    results_data = json.loads(results_path.read_text(encoding="utf-8"))
-                    for r in results_data:
-                        if r.get("seg_index") == seg.seg_index:
-                            cached_hash = r.get("text_hash", "")
-                            break
-                except (json.JSONDecodeError, KeyError):
-                    pass
-
-            if cached_hash == current_hash:
-                size = mp3_path.stat().st_size
-                duration = audio_duration_mp3(mp3_path.read_bytes()) if size > 0 else 0.0
-                results[seg.seg_index] = TTSResult(
-                    seg_index=seg.seg_index,
-                    speaker=seg.speaker,
-                    reference_id=reference_id,
-                    mp3_path=str(mp3_path),
-                    duration_s=duration,
-                    seed=seed,
-                    status="cached",
-                    attempts=0,
-                    text_hash=current_hash,
-                )
-                continue
+        if mp3_path.exists() and cached_hashes.get(seg.seg_index) == current_hash:
+            size = mp3_path.stat().st_size
+            duration = audio_duration_mp3(mp3_path.read_bytes()) if size > 0 else 0.0
+            results[seg.seg_index] = TTSResult(
+                seg_index=seg.seg_index,
+                speaker=seg.speaker,
+                reference_id=reference_id,
+                mp3_path=str(mp3_path),
+                duration_s=duration,
+                seed=seed,
+                status="cached",
+                attempts=0,
+                text_hash=current_hash,
+            )
+            continue
         to_generate.append((seg.seg_index, seg, text))
 
     if not to_generate:
@@ -583,6 +584,10 @@ def run(force: bool = False) -> Path:
     cached = 0
     failed = 0
 
+    # Preload cached hashes once (O(N) instead of O(N²))
+    cached_hashes = _load_cached_hashes()
+    print(f"  Cache: {len(cached_hashes)} entries preloaded")
+
     # Process in batches for progress reporting
     total = len(batch.segments)
     for batch_start in range(0, total, _BATCH_SIZE):
@@ -592,7 +597,7 @@ def run(force: bool = False) -> Path:
             for i in range(batch_start, batch_end)
         ]
 
-        batch_results = _synthesize_batch(batch_segs)
+        batch_results = _synthesize_batch(batch_segs, cached_hashes)
         results.extend(batch_results)
 
         for r in batch_results:

--- a/docker-configurations/services/shared/comfyui_idle_monitor.py
+++ b/docker-configurations/services/shared/comfyui_idle_monitor.py
@@ -271,29 +271,27 @@ class ComfyUIIdleMonitor:
         current_time = time.time()
         self._last_check = current_time
 
-        # Get last activity
-        last_activity = self.get_last_activity_time()
+        # If we recently unloaded, use that timestamp as the activity baseline
+        # to prevent re-unloading on stale history timestamps.
+        if self._monitor_start_time:
+            last_real_activity = self.get_last_activity_time()
+            # Use the most recent of: last real activity, or last unload time
+            if last_real_activity is not None:
+                last_activity = max(last_real_activity, self._monitor_start_time)
+            else:
+                last_activity = self._monitor_start_time
+        else:
+            last_activity = self.get_last_activity_time()
 
         if last_activity is None:
-            # No activity recorded — use monitor start time as fallback
-            if self._monitor_start_time:
-                last_activity = self._monitor_start_time
-                idle_time = current_time - last_activity
-                logger.info(f"Idle: {idle_time:.0f}s / {self.idle_timeout}s (no history, {self.comfyui_url})")
-                if idle_time >= self.idle_timeout:
-                    logger.info(f"Idle timeout reached ({idle_time:.0f}s >= {self.idle_timeout}s)")
-                    unloaded = self.unload_models()
-                    if unloaded:
-                        self._monitor_start_time = time.time()
-                    return unloaded
-            else:
-                logger.debug("No activity recorded and no start time, skipping check")
+            logger.debug("No activity recorded and no start time, skipping check")
             return False
 
         self._last_activity = last_activity
         idle_time = current_time - last_activity
+        source = "since last unload" if last_activity == self._monitor_start_time else "since last prompt"
 
-        logger.info(f"Idle: {idle_time:.0f}s / {self.idle_timeout}s ({self.comfyui_url})")
+        logger.info(f"Idle: {idle_time:.0f}s / {self.idle_timeout}s ({source}, {self.comfyui_url})")
 
         if idle_time >= self.idle_timeout:
             logger.info(f"Idle timeout reached ({idle_time:.0f}s >= {self.idle_timeout}s)")


### PR DESCRIPTION
## Summary
- Fix ComfyUI idle monitors (qwen + video) calling `/free` every minute in an infinite loop
- Root cause: after `/free` unload, prompt history timestamps remain stale → `get_last_activity_time()` returns ancient timestamps → idle timer never resets
- Fix: track `_monitor_start_time` after each successful unload, use `max(real_activity, last_unload_time)` as the activity baseline

## Bug Evidence
- comfyui-qwen-idle-monitor: 5089 unloads in 3 days (1 per minute, every minute)
- comfyui-video-idle-monitor: same pattern
- `Idle: 306328s / 1200s` growing continuously despite successful `/free` calls

## Test plan
- [x] Code review: `check_and_unload()` logic simplified, single code path
- [ ] Deploy: rebuild idle monitor containers and verify idle timer resets after `/free`
- [ ] Monitor logs for 30 min: should see idle counter restart from 0s after unload

## Related
- Diagnosed as part of #1385 (GenAI GPU optimization: quantization + idle sleep)
- sd-forge-main idle monitor has a separate issue (Caddy reverse proxy blocks unauthenticated health checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)