### PR TITLE
feat(prover): enforce Δ0 stagnation hard-cap in workflow orchestrator (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/workflow.py
@@ -56,6 +56,21 @@ DEFAULT_AGENT_TIMEOUT_S = 600
 TRANSIENT_RETRY_MAX = 2
 TRANSIENT_RETRY_BACKOFF_S = (2.0, 4.0)
 
+# P1 stagnation hard-cap (Epic #1453). The compile tool (tools.py) computes
+# the number of consecutive Δ0 compiles — a build that succeeds but does NOT
+# reach a new sorry-count low — and mirrors it to
+# `state.consecutive_delta0_compiles`. It also emits a soft `directive` string
+# in the compile result, on which the orchestrator used to rely entirely: the
+# count was written but never enforced. Forensic trace
+# multi_custom_Lattice_L147_zai.json: 26 of 30 compiles were Δ0 (22 consecutive
+# at 4 sorry right from the start) yet the run never terminated — it burned the
+# full iteration + LLM budget making zero proof progress. This ceiling is the
+# hard backstop: it fires at 2x the tools.py soft threshold (3), so the soft
+# directive and the existing Director escalations get a window first, but a run
+# that ignores the signal for this many consecutive Δ0 compiles is yielded
+# rather than left to waste compute.
+DELTA0_STAGNATION_HARDCAP = 6
+
 
 def _is_transient_error(exc: BaseException) -> bool:
     """Return True if `exc` looks like a transient provider/network error.
@@ -150,6 +165,9 @@ class AgentExecutor(Executor):
         self._trace = trace
         self._timeout_s = timeout_s
         self._state = state  # B.3: shared state for plan propagation
+        # P1 (Epic #1453): hard ceiling on consecutive Δ0 compiles; see
+        # DELTA0_STAGNATION_HARDCAP. Read live from state on every iteration.
+        self._delta0_stagnation_hardcap = DELTA0_STAGNATION_HARDCAP
 
     @handler
     async def handle(self, msg: ProofMessage, ctx: WorkflowContext[ProofMessage]) -> None:
@@ -193,6 +211,29 @@ class AgentExecutor(Executor):
                              f"but Director in-flight (calls={msg.director_calls}), "
                              f"allowing +1"),
                 )
+
+        # P1 (Epic #1453): Δ0 stagnation hard-cap. The compile tool mirrors the
+        # consecutive-Δ0 count to state.consecutive_delta0_compiles and emits a
+        # soft directive, but nothing enforced it — a run could compile cleanly
+        # dozens of times without ever lowering the sorry count (forensic L147:
+        # 22 consecutive Δ0 at 4 sorry). Once the count crosses the hard ceiling
+        # the soft signal and every Director escalation have already had their
+        # window, so we yield to stop wasting compute rather than escalate again.
+        _delta0 = (
+            getattr(self._state, "consecutive_delta0_compiles", 0)
+            if self._state else 0
+        )
+        if (not msg.proof_found
+                and _delta0 >= self._delta0_stagnation_hardcap):
+            if self._trace:
+                self._trace.log(
+                    agent=self._agent.name, role="delta0_stagnation_yield",
+                    content=(f"consecutive_delta0_compiles={_delta0} >= "
+                             f"hardcap={self._delta0_stagnation_hardcap}, "
+                             f"yielding to stop no-progress waste"),
+                )
+            await ctx.yield_output(msg)
+            return
 
         # F12: Force Director invocation at iteration 4 (after first
         # Coordinator→Search→Tactic cycle completes). This ensures Director

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1012,3 +1012,80 @@ def test_probe_goal_cache_invalidates_on_file_change(tactic_tools, monkeypatch):
     tactic_tools.compile_probe_goal(line)
 
     assert calls["n"] == 2, "a content change must invalidate the probe cache"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# P1 Δ0 stagnation hard-cap (Epic #1453) — AgentExecutor.handle must yield
+# once consecutive Δ0 compiles cross DELTA0_STAGNATION_HARDCAP.
+#
+# The compile tool (tools.py) already counts consecutive Δ0 compiles (a build
+# that succeeds but does NOT reach a new sorry low) and mirrors the count to
+# state.consecutive_delta0_compiles, but until #1453 nothing consumed it — it
+# relied on the LLM heeding a soft directive string. Forensic
+# multi_custom_Lattice_L147_zai.json: 26/30 compiles were Δ0 (22 consecutive at
+# 4 sorry from the start) yet the run never terminated and burned the full
+# budget. The hard cap is the orchestrator backstop.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _stagnation_agent(name="SearchAgent"):
+    from unittest.mock import AsyncMock, MagicMock
+
+    agent = MagicMock()
+    agent.name = name
+    agent.run = AsyncMock(return_value=MagicMock(
+        messages=[MagicMock(text="ran")]
+    ))
+    return agent
+
+
+def test_delta0_hardcap_yields_and_skips_agent():
+    """At/over the hard cap, handle yields the message and never runs the agent."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, DELTA0_STAGNATION_HARDCAP,
+    )
+
+    state = ProofState(theorem_statement="t")
+    state.consecutive_delta0_compiles = DELTA0_STAGNATION_HARDCAP
+    agent = _stagnation_agent()
+    ex = AgentExecutor(agent, state=state)
+    ctx = _run_handle(ex, ProofMessage(content="x"))
+
+    ctx.yield_output.assert_awaited_once()
+    agent.run.assert_not_awaited()  # no compute wasted past the cap
+
+
+def test_delta0_below_hardcap_runs_agent_normally():
+    """One short of the cap, the run continues — the agent executes as usual."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, DELTA0_STAGNATION_HARDCAP,
+    )
+
+    state = ProofState(theorem_statement="t")
+    state.consecutive_delta0_compiles = DELTA0_STAGNATION_HARDCAP - 1
+    agent = _stagnation_agent()
+    ex = AgentExecutor(agent, state=state)
+    ctx = _run_handle(ex, ProofMessage(content="x"))
+
+    agent.run.assert_awaited_once()  # below the cap → keep working
+    ctx.yield_output.assert_not_awaited()
+
+
+def test_delta0_hardcap_ignored_when_proof_found():
+    """A found proof must not be masked by the stagnation yield (guarded by
+    `not msg.proof_found`)."""
+    from prover.workflow import (
+        AgentExecutor, ProofMessage, DELTA0_STAGNATION_HARDCAP,
+    )
+
+    state = ProofState(theorem_statement="t")
+    state.consecutive_delta0_compiles = DELTA0_STAGNATION_HARDCAP + 5
+    agent = _stagnation_agent()
+    ex = AgentExecutor(agent, state=state)
+    msg = ProofMessage(content="x")
+    msg.proof_found = True
+    ctx = _run_handle(ex, msg)
+
+    # The delta0 path is skipped; the agent runs (proof_found is handled
+    # elsewhere, not pre-empted by the stagnation backstop).
+    agent.run.assert_awaited_once()


### PR DESCRIPTION
## Forensic finding (Epic #1453)

Trace `traces/multi_custom_Lattice_L147_zai.json` — **verified by direct parse** of the raw trace (compile events carry `role=="compile"`, content e.g. `compile: L1=True L2=True(Δ0) ... | 4 sorry | fresh`):

- **30 compiles total**, **26 of them Δ0** (a build that succeeds but does NOT reach a new sorry-count low).
- **22 consecutive Δ0 at 4 sorry right from the start** — the run never lowered the sorry count.
- The full iteration + LLM budget was burned making **zero proof progress**.

This is exactly the "boucles `compile` sans progrès" pathology named in the Epic's *Méthode* step 3.

## Root cause

The compile tool (`prover/tools.py`) already computes the consecutive-Δ0 count (`_consecutive_delta0`, soft threshold 3) and mirrors it to `state.consecutive_delta0_compiles`, plus emits a soft `directive` string in the compile result. But **nothing in `workflow.py` ever consumed that count** (grep-confirmed: zero references) — enforcement relied entirely on the LLM heeding the soft directive, which L147 shows it does not.

## Fix (single concern)

- New module constant `DELTA0_STAGNATION_HARDCAP = 6` (= 2× the `tools.py` soft threshold of 3, so the soft directive and the existing Director escalations get their window first).
- `AgentExecutor.handle` now reads `state.consecutive_delta0_compiles` live and, when the count crosses the ceiling **and no proof has been found**, yields the message to terminate the no-progress run instead of escalating again. The yield mirrors the existing iteration-cap terminal pattern.
- Guarded by `not msg.proof_found` so a found proof is never masked by the backstop.
- Emits a `delta0_stagnation_yield` trace event for future forensic.

Yield-only (not re-escalation) was chosen because the same L147 trace shows the Director was already consulted 10× while stagnation persisted — another escalation would waste more compute, not break the loop.

## Tests

3 new cases in `tests/test_prover_guards.py`:
- `test_delta0_hardcap_yields_and_skips_agent` — at the cap, handle yields and the agent never runs.
- `test_delta0_below_hardcap_runs_agent_normally` — one short of the cap, the run continues.
- `test_delta0_hardcap_ignored_when_proof_found` — a found proof bypasses the backstop.

Full guard suite green: **59 passed** (`coursia-ml-training` env, the one carrying `agent_framework`).

## Scope / non-regression

- +118 / -0 lines, 2 files (`prover/workflow.py`, `tests/test_prover_guards.py`). No proof files touched, no `sorry` introduced.
- P2 (iteration-cap director-in-flight bypass) was inspected in the same trace but did **not** manifest pathologically there (`force_director=2`, `iteration_cap_tolerated=0`), so it is intentionally left out of this PR per the "one concern per PR" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
