### PR TITLE
feat(sw): TP conversion batch 4 — SL-1, Lean-5, SW-2b (#1455)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -2957,83 +2957,76 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Exercices a completer\n"
-   ]
+   "source": "## Exemples guides : Preuves tactiques\n\nVoici trois exemples complets illustrant les tactiques `constructor`, `rw` et `cases`."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": "-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\n-- Demonstrateur : constructor, intro, cases, exact\ntheorem and_assoc_practice (p q r : Prop) : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n  constructor\n  · intro h\n    cases h with\n    | intro hpq hr =>\n      cases hpq with\n      | intro hp hq =>\n        constructor\n        · exact hp\n        · constructor\n          · exact hq\n          · exact hr\n  · intro h\n    cases h with\n    | intro hp hqr =>\n      cases hqr with\n      | intro hq hr =>\n        constructor\n        · constructor\n          · exact hp\n          · exact hq\n        · exact hr\n\n-- Exemple guide 2 : Manipulation arithmetique avec rw\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n  rw [Nat.two_mul]\n  rw [Nat.add_comm b a]\n\n-- Exemple guide 3 : Distribution avec tactics\n-- Demonstrateur : constructor, intro, cases, left/right\ntheorem or_distrib_practice (p q r : Prop) :\n  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n  constructor\n  · intro h\n    cases h with\n    | intro hp hqr =>\n      cases hqr with\n      | inl hq =>\n        left\n        constructor\n        · exact hp\n        · exact hq\n      | inr hr =>\n        right\n        constructor\n        · exact hp\n        · exact hr\n  · intro h\n    cases h with\n    | inl hpq =>\n      cases hpq with\n      | intro hp hq =>\n        constructor\n        · exact hp\n        · left\n          exact hq\n    | inr hpr =>\n      cases hpr with\n      | intro hp hr =>\n        constructor\n        · exact hp\n        · right\n          exact hr"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Exercices a completer\n\nRemplacez `sorry` par votre preuve en utilisant les tactiques vues dans les exemples ci-dessus.\n\n### Exercice 1 : Commutativite de la conjunction\n\nProuvez que `p /\\ q <-> q /\\ p` en utilisant `constructor`, `intro`, `cases` et `exact`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "language": "lean4"
+   },
+   "outputs": [],
    "source": [
-     "-- Exercice 1 : Associativite de la conjonction (avec tactics)\n",
-     "-- TODO etudiant : completer la preuve en utilisant constructor, intro, cases, exact\n",
-     "theorem and_assoc_practice (p q r : Prop) : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-     "  constructor\n",
-     "  · intro h\n",
-     "    cases h with\n",
-     "    | intro hpq hr =>\n",
-     "      cases hpq with\n",
-     "      | intro hp hq =>\n",
-     "        constructor\n",
-     "        · exact hp\n",
-     "        · constructor\n",
-     "          · exact hq\n",
-     "          · exact hr\n",
-     "  · intro h\n",
-     "    cases h with\n",
-     "    | intro hp hqr =>\n",
-     "      cases hqr with\n",
-     "      | intro hq hr =>\n",
-     "        constructor\n",
-     "        · constructor\n",
-     "          · exact hp\n",
-     "          · exact hq\n",
-     "        · exact hr\n",
-     "\n",
-     "-- Exercice 2 : Manipulation arithmetique avec rw\n",
-     "-- TODO etudiant : utiliser rw pour simplifier (a + b) + (b + a) = 2 * (a + b)\n",
-     "-- Indice : Nat.add_comm, Nat.two_mul\n",
-     "theorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-     "  rw [Nat.two_mul]\n",
-     "  rw [Nat.add_comm b a]\n",
-     "\n",
-     "-- Exercice 3 : Distribution avec tactics\n",
-     "-- TODO etudiant : prouver la distribution avec constructor, intro, cases, left/right\n",
-     "theorem or_distrib_practice (p q r : Prop) :\n",
-     "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-     "  constructor\n",
-     "  · intro h\n",
-     "    cases h with\n",
-     "    | intro hp hqr =>\n",
-     "      cases hqr with\n",
-     "      | inl hq =>\n",
-     "        left\n",
-     "        constructor\n",
-     "        · exact hp\n",
-     "        · exact hq\n",
-     "      | inr hr =>\n",
-     "        right\n",
-     "        constructor\n",
-     "        · exact hp\n",
-     "        · exact hr\n",
-     "  · intro h\n",
-     "    cases h with\n",
-     "    | inl hpq =>\n",
-     "      cases hpq with\n",
-     "      | intro hp hq =>\n",
-     "        constructor\n",
-     "        · exact hp\n",
-     "        · left\n",
-     "          exact hq\n",
-     "    | inr hpr =>\n",
-     "      cases hpr with\n",
-     "      | intro hp hr =>\n",
-     "        constructor\n",
-     "        · exact hp\n",
-     "        · right\n",
-     "          exact hr\n"
+    "-- Exercice 1 : Commutativite de la conjunction\n",
+    "-- TODO etudiant : prouvez p /\\ q <-> q /\\ p\n",
+    "theorem and_comm_exercise (p q : Prop) : p /\\ q <-> q /\\ p := sorry\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Addition avec associativite et commutativite\n",
+    "\n",
+    "Prouvez que `(a + b) + c = (c + a) + b` en utilisant `rw` avec les lemmes de `Nat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "language": "lean4"
+   },
+   "outputs": [],
+   "source": [
+    "-- Exercice 2 : Rearrangement avec rw\n",
+    "-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\n",
+    "-- Indice : Nat.add_assoc, Nat.add_comm\n",
+    "theorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : De Morgan avec tactics\n",
+    "\n",
+    "Prouvez que `¬(p ∨ q) <-> ¬p ∧ ¬q` en utilisant `constructor`, `intro`, `cases`, `contradiction`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "language": "lean4"
+   },
+   "outputs": [],
+   "source": [
+    "-- Exercice 3 : De Morgan\n",
+    "-- TODO etudiant : prouvez la premiere direction de De Morgan\n",
+    "theorem de_morgan_exercise (p q : Prop) : ¬(p \\/ q) -> ¬p /\\ ¬q := sorry\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -5,10 +5,10 @@
    "id": "header-navigation",
    "metadata": {
     "papermill": {
-     "duration": 0.005351,
-     "end_time": "2026-05-23T18:57:44.335197+00:00",
+     "duration": 0.022122,
+     "end_time": "2026-05-25T02:03:49.722054+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:44.329846+00:00",
+     "start_time": "2026-05-25T02:03:49.699932+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,10 +44,10 @@
    "id": "section-1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002595,
-     "end_time": "2026-05-23T18:57:44.342140+00:00",
+     "duration": 0.002528,
+     "end_time": "2026-05-25T02:03:49.729829+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:44.339545+00:00",
+     "start_time": "2026-05-25T02:03:49.727301+00:00",
      "status": "completed"
     },
     "tags": []
@@ -66,16 +66,16 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:44.348017Z",
-     "iopub.status.busy": "2026-05-23T18:57:44.347845Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.307586Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.307056Z"
+     "iopub.execute_input": "2026-05-25T02:03:49.735988Z",
+     "iopub.status.busy": "2026-05-25T02:03:49.735828Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.706113Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.705357Z"
     },
     "papermill": {
-     "duration": 0.964296,
-     "end_time": "2026-05-23T18:57:45.308417+00:00",
+     "duration": 0.973866,
+     "end_time": "2026-05-25T02:03:50.706619+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:44.344121+00:00",
+     "start_time": "2026-05-25T02:03:49.732753+00:00",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "install-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002495,
-     "end_time": "2026-05-23T18:57:45.313504+00:00",
+     "duration": 0.002151,
+     "end_time": "2026-05-25T02:03:50.711371+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.311009+00:00",
+     "start_time": "2026-05-25T02:03:50.709220+00:00",
      "status": "completed"
     },
     "tags": []
@@ -119,16 +119,16 @@
    "id": "imports-rdflib",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.318840Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.318670Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.411875Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.411278Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.716879Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.716725Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.827604Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.827005Z"
     },
     "papermill": {
-     "duration": 0.096819,
-     "end_time": "2026-05-23T18:57:45.412491+00:00",
+     "duration": 0.114656,
+     "end_time": "2026-05-25T02:03:50.828133+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.315672+00:00",
+     "start_time": "2026-05-25T02:03:50.713477+00:00",
      "status": "completed"
     },
     "tags": []
@@ -173,10 +173,10 @@
    "id": "imports-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002159,
-     "end_time": "2026-05-23T18:57:45.417217+00:00",
+     "duration": 0.002275,
+     "end_time": "2026-05-25T02:03:50.832785+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.415058+00:00",
+     "start_time": "2026-05-25T02:03:50.830510+00:00",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "id": "section-2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002084,
-     "end_time": "2026-05-23T18:57:45.421474+00:00",
+     "duration": 0.002028,
+     "end_time": "2026-05-25T02:03:50.836883+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.419390+00:00",
+     "start_time": "2026-05-25T02:03:50.834855+00:00",
      "status": "completed"
     },
     "tags": []
@@ -226,16 +226,16 @@
    "id": "create-graph",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.426900Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.426732Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.433998Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.433453Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.841711Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.841575Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.846978Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.846412Z"
     },
     "papermill": {
-     "duration": 0.010958,
-     "end_time": "2026-05-23T18:57:45.434606+00:00",
+     "duration": 0.008467,
+     "end_time": "2026-05-25T02:03:50.847394+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.423648+00:00",
+     "start_time": "2026-05-25T02:03:50.838927+00:00",
      "status": "completed"
     },
     "tags": []
@@ -248,13 +248,13 @@
       "Nombre de triples dans le graphe : 7\n",
       "\n",
       "Triples dans le graphe :\n",
+      "  ex:Alice -- rdf:type --> foaf:Person\n",
       "  ex:Bob -- foaf:name --> \"Bob Martin\"\n",
-      "  ex:Alice -- foaf:name --> \"Alice Dupont\"\n",
-      "  ex:Bob -- foaf:age --> \"25\"^^xsd:integer\n",
       "  ex:Alice -- foaf:age --> \"30\"^^xsd:integer\n",
-      "  ex:Alice -- foaf:knows --> ex:Bob\n",
       "  ex:Bob -- rdf:type --> foaf:Person\n",
-      "  ex:Alice -- rdf:type --> foaf:Person\n"
+      "  ex:Bob -- foaf:age --> \"25\"^^xsd:integer\n",
+      "  ex:Alice -- foaf:name --> \"Alice Dupont\"\n",
+      "  ex:Alice -- foaf:knows --> ex:Bob\n"
      ]
     }
    ],
@@ -296,10 +296,10 @@
    "id": "create-graph-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002166,
-     "end_time": "2026-05-23T18:57:45.439128+00:00",
+     "duration": 0.002038,
+     "end_time": "2026-05-25T02:03:50.851682+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.436962+00:00",
+     "start_time": "2026-05-25T02:03:50.849644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -329,10 +329,10 @@
    "id": "section-3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002216,
-     "end_time": "2026-05-23T18:57:45.443472+00:00",
+     "duration": 0.002024,
+     "end_time": "2026-05-25T02:03:50.855876+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.441256+00:00",
+     "start_time": "2026-05-25T02:03:50.853852+00:00",
      "status": "completed"
     },
     "tags": []
@@ -351,16 +351,16 @@
    "id": "node-types",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.449121Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.448944Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.453565Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.452885Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.860763Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.860620Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.864355Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.864001Z"
     },
     "papermill": {
-     "duration": 0.008536,
-     "end_time": "2026-05-23T18:57:45.454323+00:00",
+     "duration": 0.007045,
+     "end_time": "2026-05-25T02:03:50.864955+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.445787+00:00",
+     "start_time": "2026-05-25T02:03:50.857910+00:00",
      "status": "completed"
     },
     "tags": []
@@ -373,7 +373,7 @@
       "URIRef       : http://example.org/Alice\n",
       "  type       : URIRef\n",
       "\n",
-      "BNode        : Na9d961dc30304f65b1914bd973547e63\n",
+      "BNode        : Ncdfcbfa63340474a832ce5aed61a7e85\n",
       "  type       : BNode\n",
       "\n",
       "Literal examples:\n",
@@ -429,10 +429,10 @@
    "id": "node-types-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002631,
-     "end_time": "2026-05-23T18:57:45.459672+00:00",
+     "duration": 0.00207,
+     "end_time": "2026-05-25T02:03:50.869262+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.457041+00:00",
+     "start_time": "2026-05-25T02:03:50.867192+00:00",
      "status": "completed"
     },
     "tags": []
@@ -459,10 +459,10 @@
    "id": "section-4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003239,
-     "end_time": "2026-05-23T18:57:45.465474+00:00",
+     "duration": 0.002058,
+     "end_time": "2026-05-25T02:03:50.873386+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.462235+00:00",
+     "start_time": "2026-05-25T02:03:50.871328+00:00",
      "status": "completed"
     },
     "tags": []
@@ -481,16 +481,16 @@
    "id": "serialize-turtle",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.472486Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.472303Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.479319Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.478757Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.878448Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.878325Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.883232Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.882769Z"
     },
     "papermill": {
-     "duration": 0.011812,
-     "end_time": "2026-05-23T18:57:45.480158+00:00",
+     "duration": 0.008311,
+     "end_time": "2026-05-25T02:03:50.883758+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.468346+00:00",
+     "start_time": "2026-05-25T02:03:50.875447+00:00",
      "status": "completed"
     },
     "tags": []
@@ -533,10 +533,10 @@
    "id": "serialize-turtle-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002503,
-     "end_time": "2026-05-23T18:57:45.485451+00:00",
+     "duration": 0.002175,
+     "end_time": "2026-05-25T02:03:50.888254+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.482948+00:00",
+     "start_time": "2026-05-25T02:03:50.886079+00:00",
      "status": "completed"
     },
     "tags": []
@@ -558,16 +558,16 @@
    "id": "serialize-formats",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.491698Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.491365Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.505186Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.504554Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.893435Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.893306Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.903277Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.902815Z"
     },
     "papermill": {
-     "duration": 0.01781,
-     "end_time": "2026-05-23T18:57:45.505695+00:00",
+     "duration": 0.013395,
+     "end_time": "2026-05-25T02:03:50.903796+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.487885+00:00",
+     "start_time": "2026-05-25T02:03:50.890401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -578,34 +578,17 @@
      "output_type": "stream",
      "text": [
       "=== Format N-Triples ===\n",
-      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/name> \"Bob Martin\" .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/name> \"Alice Dupont\" .\n",
-      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/age> \"25\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/Bob> .\n",
-      "<http://example.org/Bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n",
       "<http://example.org/Alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n",
+      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/name> \"Bob Martin\" .\n",
+      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+      "<http://example.org/Bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n",
+      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/age> \"25\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/name> \"Alice Dupont\" .\n",
+      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/Bob> .\n",
       "\n",
       "\n",
       "=== Format JSON-LD ===\n",
       "[\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/Bob\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/age\": [\n",
-      "      {\n",
-      "        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n",
-      "        \"@value\": 25\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Bob Martin\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
       "  {\n",
       "    \"@id\": \"http://example.org/Alice\",\n",
       "    \"@type\": [\n",
@@ -625,6 +608,23 @@
       "    \"http://xmlns.com/foaf/0.1/name\": [\n",
       "      {\n",
       "        \"@value\": \"Alice Dupont\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
+      "  {\n",
+      "    \"@id\": \"http://example.org/Bob\",\n",
+      "    \"@type\": [\n",
+      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
+      "    ],\n",
+      "    \"http://xmlns.com/foaf/0.1/age\": [\n",
+      "      {\n",
+      "        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n",
+      "        \"@value\": 25\n",
+      "      }\n",
+      "    ],\n",
+      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
+      "      {\n",
+      "        \"@value\": \"Bob Martin\"\n",
       "      }\n",
       "    ]\n",
       "  }\n",
@@ -653,10 +653,10 @@
    "id": "serialize-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.002452,
-     "end_time": "2026-05-23T18:57:45.510860+00:00",
+     "duration": 0.002155,
+     "end_time": "2026-05-25T02:03:50.908118+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.508408+00:00",
+     "start_time": "2026-05-25T02:03:50.905963+00:00",
      "status": "completed"
     },
     "tags": []
@@ -679,10 +679,10 @@
    "id": "section-5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002315,
-     "end_time": "2026-05-23T18:57:45.515829+00:00",
+     "duration": 0.002194,
+     "end_time": "2026-05-25T02:03:50.914148+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.513514+00:00",
+     "start_time": "2026-05-25T02:03:50.911954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -701,16 +701,16 @@
    "id": "load-example-ttl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.522463Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.522268Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.530528Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.530055Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.919424Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.919286Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.926174Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.925661Z"
     },
     "papermill": {
-     "duration": 0.012851,
-     "end_time": "2026-05-23T18:57:45.531235+00:00",
+     "duration": 0.010152,
+     "end_time": "2026-05-25T02:03:50.926640+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.518384+00:00",
+     "start_time": "2026-05-25T02:03:50.916488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -723,10 +723,10 @@
       "Triples charges depuis Example.ttl : 4\n",
       "\n",
       "Contenu de Example.ttl :\n",
-      "  _:n8e52419b4ec04037a1871c9bc7af4ff0b1 -- ex:fullname --> \"Dave Beckett\"\n",
-      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- ex:editor --> _:n8e52419b4ec04037a1871c9bc7af4ff0b1\n",
-      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- dc:title --> \"RDF/XML Syntax Specification (Revised)\"\n",
-      "  _:n8e52419b4ec04037a1871c9bc7af4ff0b1 -- ex:homePage --> <http://purl.org/net/dajobe/>\n"
+      "  _:nf171ff941a2a4d9d85253449f11d76ecb1 -- ex:fullname --> \"Dave Beckett\"\n",
+      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- ex:editor --> _:nf171ff941a2a4d9d85253449f11d76ecb1\n",
+      "  _:nf171ff941a2a4d9d85253449f11d76ecb1 -- ex:homePage --> <http://purl.org/net/dajobe/>\n",
+      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- dc:title --> \"RDF/XML Syntax Specification (Revised)\"\n"
      ]
     }
    ],
@@ -754,10 +754,10 @@
    "id": "load-example-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004272,
-     "end_time": "2026-05-23T18:57:45.538045+00:00",
+     "duration": 0.002162,
+     "end_time": "2026-05-25T02:03:50.931272+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.533773+00:00",
+     "start_time": "2026-05-25T02:03:50.929110+00:00",
      "status": "completed"
     },
     "tags": []
@@ -780,10 +780,10 @@
    "id": "section-6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002742,
-     "end_time": "2026-05-23T18:57:45.543128+00:00",
+     "duration": 0.002152,
+     "end_time": "2026-05-25T02:03:50.935808+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.540386+00:00",
+     "start_time": "2026-05-25T02:03:50.933656+00:00",
      "status": "completed"
     },
     "tags": []
@@ -801,10 +801,10 @@
    "id": "comparison-table",
    "metadata": {
     "papermill": {
-     "duration": 0.002392,
-     "end_time": "2026-05-23T18:57:45.548222+00:00",
+     "duration": 0.008044,
+     "end_time": "2026-05-25T02:03:50.946012+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.545830+00:00",
+     "start_time": "2026-05-25T02:03:50.937968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -843,10 +843,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002299,
-     "end_time": "2026-05-23T18:57:45.552919+00:00",
+     "duration": 0.002328,
+     "end_time": "2026-05-25T02:03:50.950748+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.550620+00:00",
+     "start_time": "2026-05-25T02:03:50.948420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -864,16 +864,16 @@
    "id": "exercise-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002398,
-     "end_time": "2026-05-23T18:57:45.557699+00:00",
+     "duration": 0.002168,
+     "end_time": "2026-05-25T02:03:50.955115+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.555301+00:00",
+     "start_time": "2026-05-25T02:03:50.952947+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Reproduire le graphe \"Hello World\" de SW-2\n",
+    "### Exemple guide 1 : Reproduire le graphe \"Hello World\" de SW-2\n",
     "\n",
     "Dans le notebook SW-2 (dotNetRDF), nous avons cree un graphe contenant :\n",
     "```\n",
@@ -881,7 +881,7 @@
     "<http://www.dotnetrdf.org>  <http://example.org/says>  \"Bonjour tout le Monde\"@fr\n",
     "```\n",
     "\n",
-    "Reproduisez ce graphe en Python avec rdflib, puis serialisez-le en Turtle et en N-Triples."
+    "Voici la reproduction en Python avec rdflib."
    ]
   },
   {
@@ -890,16 +890,16 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.563840Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.563670Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.568113Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.567576Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.960413Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.960254Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.964160Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.963696Z"
     },
     "papermill": {
-     "duration": 0.00851,
-     "end_time": "2026-05-23T18:57:45.568795+00:00",
+     "duration": 0.007419,
+     "end_time": "2026-05-25T02:03:50.964769+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.560285+00:00",
+     "start_time": "2026-05-25T02:03:50.957350+00:00",
      "status": "completed"
     },
     "tags": []
@@ -919,26 +919,22 @@
       "\n",
       "\n",
       "=== N-Triples ===\n",
-      "<http://www.dotnetrdf.org> <http://example.org/says> \"Bonjour tout le Monde\"@fr .\n",
       "<http://www.dotnetrdf.org> <http://example.org/says> \"Hello World\" .\n",
+      "<http://www.dotnetrdf.org> <http://example.org/says> \"Bonjour tout le Monde\"@fr .\n",
       "\n"
      ]
     }
    ],
    "source": [
     "if RDFLIB_AVAILABLE:\n",
-    "    # Exercice 1 : Reproduire le graphe Hello World de SW-2\n",
-    "    # Completez le code ci-dessous\n",
-    "\n",
+    "    # Exemple guide 1 : Reproduire le graphe Hello World de SW-2\n",
     "    g_hello = Graph()\n",
     "\n",
     "    # Define subject and predicate URIs\n",
     "    dotnetrdf = URIRef(\"http://www.dotnetrdf.org\")\n",
     "    says = URIRef(\"http://example.org/says\")\n",
     "\n",
-    "    # TODO: Add the two triples\n",
-    "    # g_hello.add((..., ..., ...))  # \"Hello World\"\n",
-    "    # g_hello.add((..., ..., ...))  # \"Bonjour tout le Monde\"@fr\n",
+    "    # Ajouter les deux triples\n",
     "    g_hello.add((dotnetrdf, says, Literal(\"Hello World\")))\n",
     "    g_hello.add((dotnetrdf, says, Literal(\"Bonjour tout le Monde\", lang=\"fr\")))\n",
     "\n",
@@ -950,7 +946,7 @@
     "    print(\"=== N-Triples ===\")\n",
     "    print(g_hello.serialize(format=\"nt\"))\n",
     "else:\n",
-    "    print(\"rdflib non disponible : exercice 1 ignore.\")"
+    "    print(\"rdflib non disponible : exemple 1 ignore.\")"
    ]
   },
   {
@@ -958,26 +954,18 @@
    "id": "exercise-2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002295,
-     "end_time": "2026-05-23T18:57:45.573554+00:00",
+     "duration": 0.002214,
+     "end_time": "2026-05-25T02:03:50.969670+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.571259+00:00",
+     "start_time": "2026-05-25T02:03:50.967456+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Graphe de livre avec tous les types de noeuds\n",
+    "### Exemple guide 2 : Graphe de livre avec tous les types de noeuds\n",
     "\n",
-    "Crez un graphe RDF decrivant un livre avec :\n",
-    "- Un URI pour le livre (`ex:Book123`)\n",
-    "- Un titre (litteral simple)\n",
-    "- Un nombre de pages (litteral type)\n",
-    "- Un auteur (URI)\n",
-    "- Une description en francais (litteral avec langue)\n",
-    "- Un blank node pour l'editeur (avec nom et URL)\n",
-    "\n",
-    "Serialisez le resultat en Turtle."
+    "Creation d'un graphe RDF decrivant un livre avec URI, litteraux types, langue et blank node."
    ]
   },
   {
@@ -986,16 +974,16 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.579791Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.579530Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.584860Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.584309Z"
+     "iopub.execute_input": "2026-05-25T02:03:50.974781Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.974652Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.978672Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.978229Z"
     },
     "papermill": {
-     "duration": 0.00942,
-     "end_time": "2026-05-23T18:57:45.585576+00:00",
+     "duration": 0.007413,
+     "end_time": "2026-05-25T02:03:50.979264+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.576156+00:00",
+     "start_time": "2026-05-25T02:03:50.971851+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1023,19 +1011,11 @@
    ],
    "source": [
     "if RDFLIB_AVAILABLE:\n",
-    "    # Exercice 2 : Creer un graphe de livre\n",
-    "\n",
+    "    # Exemple guide 2 : Graphe de livre avec tous les types de noeuds\n",
     "    g_book = Graph()\n",
     "    EX = Namespace(\"http://example.org/\")\n",
     "    g_book.bind(\"ex\", EX)\n",
     "\n",
-    "    # TODO: Completez le graphe\n",
-    "    # - ex:Book123 a ex:Book\n",
-    "    # - ex:Book123 ex:title \"...\"\n",
-    "    # - ex:Book123 ex:pages ... (typed literal)\n",
-    "    # - ex:Book123 ex:author ex:Author123\n",
-    "    # - ex:Book123 ex:description \"...\"@fr\n",
-    "    # - Create a blank node for publisher with ex:publisherName and ex:publisherURL\n",
     "    g_book.add((EX.Book123, RDF.type, EX.Book))\n",
     "    g_book.add((EX.Book123, EX.title, Literal(\"Le Petit Prince\")))\n",
     "    g_book.add((EX.Book123, EX.pages, Literal(96, datatype=XSD.integer)))\n",
@@ -1055,7 +1035,7 @@
     "    print(\"=== Livre en Turtle ===\")\n",
     "    print(g_book.serialize(format=\"turtle\"))\n",
     "else:\n",
-    "    print(\"rdflib non disponible : exercice 2 ignore.\")"
+    "    print(\"rdflib non disponible : exemple 2 ignore.\")"
    ]
   },
   {
@@ -1063,10 +1043,10 @@
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002359,
-     "end_time": "2026-05-23T18:57:45.590650+00:00",
+     "duration": 0.002282,
+     "end_time": "2026-05-25T02:03:50.983804+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.588291+00:00",
+     "start_time": "2026-05-25T02:03:50.981522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1100,13 +1080,223 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90d513e0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002188,
+     "end_time": "2026-05-25T02:03:50.988260+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:50.986072+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Creer un graphe de cours\n",
+    "\n",
+    "Creez un graphe RDF decrivant un **cours universitaire** avec :\n",
+    "- Un URI pour le cours (`ex:Math101`)\n",
+    "- Un titre (litteral simple)\n",
+    "- Un nombre de credits (litteral type integer)\n",
+    "- Un enseignant (URI)\n",
+    "- Une description en anglais (litteral avec langue `en`)\n",
+    "\n",
+    "Serialisez le resultat en Turtle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "10f13476",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-25T02:03:50.993316Z",
+     "iopub.status.busy": "2026-05-25T02:03:50.993185Z",
+     "iopub.status.idle": "2026-05-25T02:03:50.995896Z",
+     "shell.execute_reply": "2026-05-25T02:03:50.995469Z"
+    },
+    "papermill": {
+     "duration": 0.005841,
+     "end_time": "2026-05-25T02:03:50.996300+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:50.990459+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : creez un graphe RDF pour un cours\n"
+     ]
+    }
+   ],
+   "source": [
+    "if RDFLIB_AVAILABLE:\n",
+    "    # TODO etudiant : creer un graphe de cours\n",
+    "    g_course = Graph()\n",
+    "    EX = Namespace(\"http://example.org/\")\n",
+    "    g_course.bind(\"ex\", EX)\n",
+    "\n",
+    "    # Indice : inspirez-vous de l'exemple guide 2\n",
+    "    # Etape 1 : ajouter les triples pour le cours\n",
+    "    # g_course.add((EX.Math101, ...))\n",
+    "\n",
+    "    # Etape 2 : serialiser en Turtle\n",
+    "    # print(g_course.serialize(format=\"turtle\"))\n",
+    "\n",
+    "    print(\"Exercice a completer : creez un graphe RDF pour un cours\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exercice 1 ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f66c5f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002275,
+     "end_time": "2026-05-25T02:03:51.000892+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:50.998617+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Explorer et filtrer un graphe charge\n",
+    "\n",
+    "Chargez le fichier `data/Example.ttl` vu dans la section 5, puis :\n",
+    "1. Affichez tous les triples contenant un blank node\n",
+    "2. Comptez le nombre de litteraux vs URI comme objet\n",
+    "3. Serialisez le graphe en JSON-LD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f94c21c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-25T02:03:51.006064Z",
+     "iopub.status.busy": "2026-05-25T02:03:51.005938Z",
+     "iopub.status.idle": "2026-05-25T02:03:51.009330Z",
+     "shell.execute_reply": "2026-05-25T02:03:51.008852Z"
+    },
+    "papermill": {
+     "duration": 0.006565,
+     "end_time": "2026-05-25T02:03:51.009698+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:51.003133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Graphe charge : 4 triples\n",
+      "Exercice a completer : explorez et filtrez le graphe\n"
+     ]
+    }
+   ],
+   "source": [
+    "if RDFLIB_AVAILABLE:\n",
+    "    # TODO etudiant : explorer et filtrer un graphe charge\n",
+    "    g_loaded = Graph()\n",
+    "    g_loaded.parse(\"data/Example.ttl\", format=\"turtle\")\n",
+    "\n",
+    "    # Indice : utilisez isinstance(o, BNode), isinstance(o, Literal), isinstance(o, URIRef)\n",
+    "    # Etape 1 : afficher les triples avec blank nodes\n",
+    "    # Etape 2 : compter litteraux vs URI\n",
+    "    # Etape 3 : serialiser en JSON-LD\n",
+    "\n",
+    "    print(f\"Graphe charge : {len(g_loaded)} triples\")\n",
+    "    print(\"Exercice a completer : explorez et filtrez le graphe\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exercice 2 ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41f918c4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002354,
+     "end_time": "2026-05-25T02:03:51.014535+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:51.012181+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice de synthese : Construire un graphe pour un reseau social\n",
+    "\n",
+    "Creez un graphe RDF modelisant un **mini reseau social** avec :\n",
+    "- Au moins 3 personnes (URI) avec nom et email\n",
+    "- Des relations `foaf:knows` entre les personnes\n",
+    "- Au moins un blank node pour une publication partagee\n",
+    "- Serialisation en Turtle + une requete SPARQL listant les amis d'une personne"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "ef5e0b54",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-25T02:03:51.019848Z",
+     "iopub.status.busy": "2026-05-25T02:03:51.019719Z",
+     "iopub.status.idle": "2026-05-25T02:03:51.022107Z",
+     "shell.execute_reply": "2026-05-25T02:03:51.021704Z"
+    },
+    "papermill": {
+     "duration": 0.005588,
+     "end_time": "2026-05-25T02:03:51.022499+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:51.016911+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : construisez un graphe RDF pour un reseau social\n"
+     ]
+    }
+   ],
+   "source": [
+    "if RDFLIB_AVAILABLE:\n",
+    "    # TODO etudiant : construire un graphe pour un reseau social\n",
+    "    # Indice : inspirez-vous de l'exemple guide 3 (equipe de recherche)\n",
+    "    # Etape 1 : creer le graphe et les namespaces (foaf + un namespace custom)\n",
+    "    # Etape 2 : ajouter 3+ personnes avec foaf:name, foaf:mbox, foaf:knows\n",
+    "    # Etape 3 : ajouter une publication (BNode) partagee par 2+ personnes\n",
+    "    # Etape 4 : serialiser en Turtle\n",
+    "    # Etape 5 : requete SPARQL pour trouver les amis d'une personne\n",
+    "\n",
+    "    print(\"Exercice a completer : construisez un graphe RDF pour un reseau social\")\n",
+    "else:\n",
+    "    print(\"rdflib non disponible : exercice de synthese ignore.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "425fdc5f",
    "metadata": {
     "papermill": {
-     "duration": 0.002294,
-     "end_time": "2026-05-23T18:57:45.595286+00:00",
+     "duration": 0.002279,
+     "end_time": "2026-05-25T02:03:51.027069+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.592992+00:00",
+     "start_time": "2026-05-25T02:03:51.024790+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1114,9 +1304,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice de synthese : Construire un graphe RDF complet\n",
+    "## Exemple guide 3 : Construire un graphe RDF complet\n",
     "\n",
-    "Combinez les concepts vus dans ce notebook pour creer un **graphe RDF representant une equipe de recherche** avec ses membres, publications et affiliations.\n",
+    "Combinez les concepts pour creer un **graphe RDF representant une equipe de recherche** avec ses membres, publications et affiliations.\n",
     "\n",
     "### Contraintes\n",
     "- Utiliser au moins **3 types de noeuds** : URI, BNode, Literal\n",
@@ -1133,20 +1323,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "efc3c013",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T18:57:45.601601Z",
-     "iopub.status.busy": "2026-05-23T18:57:45.601427Z",
-     "iopub.status.idle": "2026-05-23T18:57:45.739079Z",
-     "shell.execute_reply": "2026-05-23T18:57:45.738524Z"
+     "iopub.execute_input": "2026-05-25T02:03:51.032533Z",
+     "iopub.status.busy": "2026-05-25T02:03:51.032409Z",
+     "iopub.status.idle": "2026-05-25T02:03:51.171609Z",
+     "shell.execute_reply": "2026-05-25T02:03:51.171170Z"
     },
     "papermill": {
-     "duration": 0.141518,
-     "end_time": "2026-05-23T18:57:45.739715+00:00",
+     "duration": 0.142944,
+     "end_time": "2026-05-25T02:03:51.172302+00:00",
      "exception": false,
-     "start_time": "2026-05-23T18:57:45.598197+00:00",
+     "start_time": "2026-05-25T02:03:51.029358+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1156,27 +1346,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "http://example.org/research/ResearchTeam https://schema.org/subjectOf N00544eca638a4f14b84d039cfd3bb7a3\n",
-      "http://example.org/research/AliceMartin https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
-      "http://example.org/research/BobDupont https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
-      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/mbox mailto:bob.dupont@example.org\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/datePublished 2026-05-20\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/name Construire un graphe RDF complet\n",
-      "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/name Equipe de recherche IA et Web Semantique\n",
-      "http://example.org/research/BobDupont http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
       "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/AliceMartin\n",
-      "http://example.org/research/AliceMartin http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/keyword RDF\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/author http://example.org/research/AliceMartin\n",
+      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/mbox mailto:bob.dupont@example.org\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/datePublished 2026-05-20\n",
       "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/BobDupont\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 http://www.w3.org/1999/02/22-rdf-syntax-ns#type https://schema.org/ScholarlyArticle\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/author http://example.org/research/BobDupont\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/author http://example.org/research/AliceMartin\n",
       "http://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/name Alice Martin\n",
-      "http://example.org/research/ResearchTeam http://www.w3.org/2000/01/rdf-schema#label Semantic Web AI Team\n",
-      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/name Bob Dupont\n",
-      "N00544eca638a4f14b84d039cfd3bb7a3 https://schema.org/keyword Semantic Web\n",
-      "http://example.org/research/ResearchTeam http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Group\n",
       "http://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/mbox mailto:alice.martin@example.org\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/keyword RDF\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/name Construire un graphe RDF complet\n",
+      "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/name Equipe de recherche IA et Web Semantique\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/author http://example.org/research/BobDupont\n",
+      "http://example.org/research/BobDupont http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
+      "http://example.org/research/BobDupont https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
+      "http://example.org/research/ResearchTeam https://schema.org/subjectOf Naec2db6b4e8f4705abf610e59bebb677\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 http://www.w3.org/1999/02/22-rdf-syntax-ns#type https://schema.org/ScholarlyArticle\n",
+      "http://example.org/research/AliceMartin http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
+      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/name Bob Dupont\n",
+      "http://example.org/research/ResearchTeam http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Group\n",
+      "http://example.org/research/AliceMartin https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
+      "http://example.org/research/ResearchTeam http://www.w3.org/2000/01/rdf-schema#label Semantic Web AI Team\n",
+      "Naec2db6b4e8f4705abf610e59bebb677 https://schema.org/keyword Semantic Web\n",
       "=== Turtle ===\n",
       "@prefix ex: <http://example.org/research/> .\n",
       "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
@@ -1235,12 +1425,12 @@
       "    ],\n",
       "    \"https://schema.org/subjectOf\": [\n",
       "      {\n",
-      "        \"@id\": \"_:N00544eca638a4f14b84d039cfd3bb7a3\"\n",
+      "        \"@id\": \"_:Naec2db6b4e8f4705abf610e59bebb677\"\n",
       "      }\n",
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:N00544eca638a4f14b84d039cfd3bb7a3\",\n",
+      "    \"@id\": \"_:Naec2db6b4e8f4705abf610e59bebb677\",\n",
       "    \"@type\": [\n",
       "      \"https://schema.org/ScholarlyArticle\"\n",
       "    ],\n",
@@ -1330,7 +1520,7 @@
    ],
    "source": [
     "if RDFLIB_AVAILABLE:\n",
-    "    # TODO etudiant : construire un graphe RDF representant une equipe de recherche\n",
+    "    # Exemple guide 3 : Construire un graphe RDF complet\n",
     "    from rdflib import Graph, Namespace, URIRef, BNode, Literal\n",
     "    from rdflib.namespace import RDF, RDFS, FOAF, XSD\n",
     "\n",
@@ -1406,7 +1596,7 @@
     "    for row in g_team.query(query):\n",
     "        print(row.authorName)\n",
     "else:\n",
-    "    print(\"rdflib non disponible : exercice de synthese ignore.\")"
+    "    print(\"rdflib non disponible : exemple guide 3 ignore.\")"
    ]
   }
  ],
@@ -1430,14 +1620,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.771061,
-   "end_time": "2026-05-23T18:57:45.963185+00:00",
+   "duration": 2.998897,
+   "end_time": "2026-05-25T02:03:51.426206+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sw2b_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2b-Python-RDFBasics.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SemanticWeb\\SW-2b-Python-RDFBasics_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-23T18:57:43.192124+00:00",
+   "start_time": "2026-05-25T02:03:48.427309+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -5,25 +5,49 @@
    "id": "6b0e8fee",
    "metadata": {
     "papermill": {
-     "duration": 0.005912,
-     "end_time": "2026-05-23T00:11:16.210700+00:00",
+     "duration": 0.017845,
+     "end_time": "2026-05-25T02:03:46.699580+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.204788+00:00",
+     "start_time": "2026-05-25T02:03:46.681735+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "# SL-1 - Apprentissage Logique : CBH Search et Version Space\n\n**Navigation** : [Index](./README.md) | [EBL & RBL >>](SL-2-KnowledgeBasedLearning.ipynb)\n\n## Objectifs d'apprentissage\n\nA la fin de ce notebook, vous saurez :\n1. Representer des hypotheses comme des formules logiques (conjonctions de predicats)\n2. Definir la notion de consistance d'une hypothese (faux positifs / faux negatifs)\n3. Implementer l'algorithme **Current-Best-Hypothesis** (CBH) search avec generalisation et specialisation\n4. Implementer l'algorithme **Version Space / Candidate Elimination** avec G-set et S-set\n5. Comprendre les limites de l'apprentissage par espace de versions (bruit, disjonctions)\n\n### Prerequis\n- Python 3.10+\n- Connaissances basiques en logique propositionnelle et predicats\n- Notions de generalisation / specialisation en apprentissage\n\n### Duree estimee : 50 minutes\n\n### References\n- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitre 19.1\n- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)"
+   "source": [
+    "# SL-1 - Apprentissage Logique : CBH Search et Version Space\n",
+    "\n",
+    "**Navigation** : [Index](./README.md) | [EBL & RBL >>](SL-2-KnowledgeBasedLearning.ipynb)\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "A la fin de ce notebook, vous saurez :\n",
+    "1. Representer des hypotheses comme des formules logiques (conjonctions de predicats)\n",
+    "2. Definir la notion de consistance d'une hypothese (faux positifs / faux negatifs)\n",
+    "3. Implementer l'algorithme **Current-Best-Hypothesis** (CBH) search avec generalisation et specialisation\n",
+    "4. Implementer l'algorithme **Version Space / Candidate Elimination** avec G-set et S-set\n",
+    "5. Comprendre les limites de l'apprentissage par espace de versions (bruit, disjonctions)\n",
+    "\n",
+    "### Prerequis\n",
+    "- Python 3.10+\n",
+    "- Connaissances basiques en logique propositionnelle et predicats\n",
+    "- Notions de generalisation / specialisation en apprentissage\n",
+    "\n",
+    "### Duree estimee : 50 minutes\n",
+    "\n",
+    "### References\n",
+    "- Russell & Norvig, *Artificial Intelligence: A Modern Approach*, 3e ed., Chapitre 19.1\n",
+    "- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "2b4d29e4",
    "metadata": {
     "papermill": {
-     "duration": 0.007344,
-     "end_time": "2026-05-23T00:11:16.224830+00:00",
+     "duration": 0.010677,
+     "end_time": "2026-05-25T02:03:46.718694+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.217486+00:00",
+     "start_time": "2026-05-25T02:03:46.708017+00:00",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +91,16 @@
    "id": "dc85e1f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.239485Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.239229Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.251009Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.250449Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.734760Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.734379Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.752123Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.751320Z"
     },
     "papermill": {
-     "duration": 0.022488,
-     "end_time": "2026-05-23T00:11:16.252445+00:00",
+     "duration": 0.026739,
+     "end_time": "2026-05-25T02:03:46.753232+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.229957+00:00",
+     "start_time": "2026-05-25T02:03:46.726493+00:00",
      "status": "completed"
     },
     "tags": []
@@ -154,10 +178,10 @@
    "id": "62d393f1",
    "metadata": {
     "papermill": {
-     "duration": 0.009,
-     "end_time": "2026-05-23T00:11:16.268778+00:00",
+     "duration": 0.002418,
+     "end_time": "2026-05-25T02:03:46.758884+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.259778+00:00",
+     "start_time": "2026-05-25T02:03:46.756466+00:00",
      "status": "completed"
     },
     "tags": []
@@ -181,10 +205,10 @@
    "id": "ee8b228d",
    "metadata": {
     "papermill": {
-     "duration": 0.00564,
-     "end_time": "2026-05-23T00:11:16.283159+00:00",
+     "duration": 0.002339,
+     "end_time": "2026-05-25T02:03:46.763384+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.277519+00:00",
+     "start_time": "2026-05-25T02:03:46.761045+00:00",
      "status": "completed"
     },
     "tags": []
@@ -212,16 +236,16 @@
    "id": "4b2b04b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.295800Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.295587Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.301959Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.301413Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.768759Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.768604Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.773749Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.773331Z"
     },
     "papermill": {
-     "duration": 0.014479,
-     "end_time": "2026-05-23T00:11:16.302920+00:00",
+     "duration": 0.008766,
+     "end_time": "2026-05-25T02:03:46.774388+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.288441+00:00",
+     "start_time": "2026-05-25T02:03:46.765622+00:00",
      "status": "completed"
     },
     "tags": []
@@ -305,10 +329,10 @@
    "id": "3fcf13d2",
    "metadata": {
     "papermill": {
-     "duration": 0.005744,
-     "end_time": "2026-05-23T00:11:16.312862+00:00",
+     "duration": 0.002323,
+     "end_time": "2026-05-25T02:03:46.778990+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.307118+00:00",
+     "start_time": "2026-05-25T02:03:46.776667+00:00",
      "status": "completed"
     },
     "tags": []
@@ -332,10 +356,10 @@
    "id": "3fb92770",
    "metadata": {
     "papermill": {
-     "duration": 0.007368,
-     "end_time": "2026-05-23T00:11:16.327521+00:00",
+     "duration": 0.002224,
+     "end_time": "2026-05-25T02:03:46.783668+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.320153+00:00",
+     "start_time": "2026-05-25T02:03:46.781444+00:00",
      "status": "completed"
     },
     "tags": []
@@ -369,16 +393,16 @@
    "id": "e4d6947a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.344789Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.344511Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.351865Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.350976Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.789442Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.789279Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.795504Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.794848Z"
     },
     "papermill": {
-     "duration": 0.017543,
-     "end_time": "2026-05-23T00:11:16.352487+00:00",
+     "duration": 0.009951,
+     "end_time": "2026-05-25T02:03:46.796076+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.334944+00:00",
+     "start_time": "2026-05-25T02:03:46.786125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -479,10 +503,10 @@
    "id": "b1a2400b",
    "metadata": {
     "papermill": {
-     "duration": 0.004883,
-     "end_time": "2026-05-23T00:11:16.362631+00:00",
+     "duration": 0.00284,
+     "end_time": "2026-05-25T02:03:46.801632+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.357748+00:00",
+     "start_time": "2026-05-25T02:03:46.798792+00:00",
      "status": "completed"
     },
     "tags": []
@@ -508,10 +532,10 @@
    "id": "77fbb6ab",
    "metadata": {
     "papermill": {
-     "duration": 0.006994,
-     "end_time": "2026-05-23T00:11:16.375485+00:00",
+     "duration": 0.002693,
+     "end_time": "2026-05-25T02:03:46.806973+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.368491+00:00",
+     "start_time": "2026-05-25T02:03:46.804280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -555,16 +579,16 @@
    "id": "ebd916fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.389952Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.389646Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.396408Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.395902Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.813373Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.813193Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.820114Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.819436Z"
     },
     "papermill": {
-     "duration": 0.015726,
-     "end_time": "2026-05-23T00:11:16.397135+00:00",
+     "duration": 0.011092,
+     "end_time": "2026-05-25T02:03:46.820674+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.381409+00:00",
+     "start_time": "2026-05-25T02:03:46.809582+00:00",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +701,10 @@
    "id": "462c713b",
    "metadata": {
     "papermill": {
-     "duration": 0.006314,
-     "end_time": "2026-05-23T00:11:16.408225+00:00",
+     "duration": 0.002743,
+     "end_time": "2026-05-25T02:03:46.826278+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.401911+00:00",
+     "start_time": "2026-05-25T02:03:46.823535+00:00",
      "status": "completed"
     },
     "tags": []
@@ -709,10 +733,10 @@
    "id": "22c65a7f",
    "metadata": {
     "papermill": {
-     "duration": 0.005521,
-     "end_time": "2026-05-23T00:11:16.417443+00:00",
+     "duration": 0.002736,
+     "end_time": "2026-05-25T02:03:46.831610+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.411922+00:00",
+     "start_time": "2026-05-25T02:03:46.828874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -757,16 +781,16 @@
    "id": "cf277e5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.430288Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.430042Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.438835Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.438224Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.837747Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.837558Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.846444Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.845790Z"
     },
     "papermill": {
-     "duration": 0.017002,
-     "end_time": "2026-05-23T00:11:16.439164+00:00",
+     "duration": 0.012751,
+     "end_time": "2026-05-25T02:03:46.846902+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.422162+00:00",
+     "start_time": "2026-05-25T02:03:46.834151+00:00",
      "status": "completed"
     },
     "tags": []
@@ -923,10 +947,10 @@
    "id": "98b8d953",
    "metadata": {
     "papermill": {
-     "duration": 0.005518,
-     "end_time": "2026-05-23T00:11:16.449708+00:00",
+     "duration": 0.002563,
+     "end_time": "2026-05-25T02:03:46.852480+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.444190+00:00",
+     "start_time": "2026-05-25T02:03:46.849917+00:00",
      "status": "completed"
     },
     "tags": []
@@ -955,10 +979,10 @@
    "id": "e4ab2892",
    "metadata": {
     "papermill": {
-     "duration": 0.008128,
-     "end_time": "2026-05-23T00:11:16.466595+00:00",
+     "duration": 0.002355,
+     "end_time": "2026-05-25T02:03:46.860212+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.458467+00:00",
+     "start_time": "2026-05-25T02:03:46.857857+00:00",
      "status": "completed"
     },
     "tags": []
@@ -981,16 +1005,16 @@
    "id": "e5d20a7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.480811Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.480438Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.486955Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.486374Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.867860Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.867711Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.873166Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.872599Z"
     },
     "papermill": {
-     "duration": 0.01359,
-     "end_time": "2026-05-23T00:11:16.487859+00:00",
+     "duration": 0.00898,
+     "end_time": "2026-05-25T02:03:46.873602+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.474269+00:00",
+     "start_time": "2026-05-25T02:03:46.864622+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1095,10 +1119,10 @@
    "id": "15fc8c86",
    "metadata": {
     "papermill": {
-     "duration": 0.004729,
-     "end_time": "2026-05-23T00:11:16.498224+00:00",
+     "duration": 0.002565,
+     "end_time": "2026-05-25T02:03:46.878547+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.493495+00:00",
+     "start_time": "2026-05-25T02:03:46.875982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1122,10 +1146,10 @@
    "id": "ccca7f32",
    "metadata": {
     "papermill": {
-     "duration": 0.008016,
-     "end_time": "2026-05-23T00:11:16.514842+00:00",
+     "duration": 0.002494,
+     "end_time": "2026-05-25T02:03:46.883778+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.506826+00:00",
+     "start_time": "2026-05-25T02:03:46.881284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1144,16 +1168,16 @@
    "id": "c68c743e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.530483Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.530228Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.537380Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.536939Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.889915Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.889758Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.897331Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.896772Z"
     },
     "papermill": {
-     "duration": 0.017871,
-     "end_time": "2026-05-23T00:11:16.538020+00:00",
+     "duration": 0.011447,
+     "end_time": "2026-05-25T02:03:46.897799+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.520149+00:00",
+     "start_time": "2026-05-25T02:03:46.886352+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1291,10 +1315,10 @@
    "id": "de22cbc0",
    "metadata": {
     "papermill": {
-     "duration": 0.008193,
-     "end_time": "2026-05-23T00:11:16.550628+00:00",
+     "duration": 0.002515,
+     "end_time": "2026-05-25T02:03:46.903111+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.542435+00:00",
+     "start_time": "2026-05-25T02:03:46.900596+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1321,10 +1345,10 @@
    "id": "f98934d2",
    "metadata": {
     "papermill": {
-     "duration": 0.009592,
-     "end_time": "2026-05-23T00:11:16.569572+00:00",
+     "duration": 0.002591,
+     "end_time": "2026-05-25T02:03:46.908183+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.559980+00:00",
+     "start_time": "2026-05-25T02:03:46.905592+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1347,16 +1371,16 @@
    "id": "0ff352e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.586916Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.586697Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.591086Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.590643Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.914619Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.914449Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.918399Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.917760Z"
     },
     "papermill": {
-     "duration": 0.013253,
-     "end_time": "2026-05-23T00:11:16.592107+00:00",
+     "duration": 0.008038,
+     "end_time": "2026-05-25T02:03:46.918886+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.578854+00:00",
+     "start_time": "2026-05-25T02:03:46.910848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1402,10 +1426,10 @@
    "id": "ce6eb73f",
    "metadata": {
     "papermill": {
-     "duration": 0.008558,
-     "end_time": "2026-05-23T00:11:16.607625+00:00",
+     "duration": 0.002704,
+     "end_time": "2026-05-25T02:03:46.924246+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.599067+00:00",
+     "start_time": "2026-05-25T02:03:46.921542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1422,16 +1446,16 @@
    "id": "ad095fa3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.625347Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.624981Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.630115Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.629517Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.930928Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.930757Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.934892Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.934428Z"
     },
     "papermill": {
-     "duration": 0.012704,
-     "end_time": "2026-05-23T00:11:16.629481+00:00",
+     "duration": 0.008299,
+     "end_time": "2026-05-25T02:03:46.935339+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.616777+00:00",
+     "start_time": "2026-05-25T02:03:46.927040+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1494,10 +1518,10 @@
    "id": "0ec254c5",
    "metadata": {
     "papermill": {
-     "duration": 0.006239,
-     "end_time": "2026-05-23T00:11:16.641690+00:00",
+     "duration": 0.002744,
+     "end_time": "2026-05-25T02:03:46.940795+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.635451+00:00",
+     "start_time": "2026-05-25T02:03:46.938051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1520,22 +1544,18 @@
    "id": "23cff9a5",
    "metadata": {
     "papermill": {
-     "duration": 0.005782,
-     "end_time": "2026-05-23T00:11:16.654033+00:00",
+     "duration": 0.003046,
+     "end_time": "2026-05-25T02:03:46.947002+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.648251+00:00",
+     "start_time": "2026-05-25T02:03:46.943956+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "---\n",
+    "### Exemple guide : CBH avec un ordre different\n",
     "\n",
-    "## 9. Exercices\n",
-    "\n",
-    "### Exercice 1 : Exploration du CBH\n",
-    "\n",
-    "Modifiez l'ordre des exemples et observez comment l'hypothese CBH change."
+    "L'ordre des exemples influence le resultat de CBH. Voici ce qui se passe quand on place les negatifs en premier."
    ]
   },
   {
@@ -1544,16 +1564,16 @@
    "id": "d1ecd1cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.666839Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.666608Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.670380Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.669951Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.953216Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.953059Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.956734Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.956252Z"
     },
     "papermill": {
-     "duration": 0.011883,
-     "end_time": "2026-05-23T00:11:16.671474+00:00",
+     "duration": 0.00754,
+     "end_time": "2026-05-25T02:03:46.957187+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.659591+00:00",
+     "start_time": "2026-05-25T02:03:46.949647+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1570,24 +1590,84 @@
     }
    ],
    "source": [
-    "# Exercice 1 : CBH avec un ordre different\n",
-    "# TODO etudiant : Reorganisez les exemples en placant d'abord les negatifs, puis les positifs.\n",
-    "# Etape 1 : Separer les exemples positifs et negatifs\n",
+    "# Exemple guide : CBH avec un ordre different (negatifs d'abord)\n",
     "positifs = [e for e in EXAMPLES if e[\"WillWait\"]]\n",
     "negatifs = [e for e in EXAMPLES if not e[\"WillWait\"]]\n",
     "\n",
-    "# Etape 2 : Creer un ordre different (negatifs d'abord, puis positifs)\n",
-    "reordered = negatifs + positifs  # TODO etudiant : essayez d'autres ordres\n",
+    "reordered = negatifs + positifs\n",
     "\n",
-    "# Etape 3 : Executer CBH sur l'ordre modifie\n",
     "cbh_reord, trace_reord = current_best_hypothesis(reordered)\n",
     "\n",
     "print(f\"Hypothese CBH (negatifs d'abord) : {cbh_reord}\")\n",
     "fp_r, fn_r = count_errors(cbh_reord, EXAMPLES)\n",
     "print(f\"Faux positifs : {fp_r}, Faux negatifs : {fn_r}\")\n",
-    "print(f\"Consistante : {is_consistent(cbh_reord, EXAMPLES)}\")\n",
+    "print(f\"Consistante : {is_consistent(cbh_reord, EXAMPLES)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e767a280",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002738,
+     "end_time": "2026-05-25T02:03:46.962653+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:46.959915+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : CBH avec ordre personnalise\n",
     "\n",
-    "# Indice : Comparez avec le resultat de la section 4. Que constatez-vous ?"
+    "Testez CBH avec un ordre **aleatoire** des exemples. Executez plusieurs fois et comparez les hypotheses obtenues. Que constatez-vous sur la stabilite de CBH ?\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Melangez les exemples avec `import random; random.shuffle(shuffled)`\n",
+    "2. Executez CBH sur les exemples melanges\n",
+    "3. Repetez 3 fois et comparez les resultats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f2c3a922",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-25T02:03:46.968928Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.968774Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.972235Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.971582Z"
+    },
+    "papermill": {
+     "duration": 0.007486,
+     "end_time": "2026-05-25T02:03:46.972742+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T02:03:46.965256+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : testez CBH avec un ordre aleatoire\n",
+      "Comparez les hypotheses finales sur 3 executions avec des seeds differents\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "\n",
+    "# TODO etudiant : testez CBH avec un ordre aleatoire (3 executions)\n",
+    "# Indice : copiez EXAMPLES, melangez avec random.shuffle, executez current_best_hypothesis\n",
+    "random.seed(42)\n",
+    "shuffled = EXAMPLES.copy()\n",
+    "random.shuffle(shuffled)\n",
+    "print(\"Exercice a completer : testez CBH avec un ordre aleatoire\")\n",
+    "print(\"Comparez les hypotheses finales sur 3 executions avec des seeds differents\")"
    ]
   },
   {
@@ -1595,10 +1675,10 @@
    "id": "4bfff412",
    "metadata": {
     "papermill": {
-     "duration": 0.004699,
-     "end_time": "2026-05-23T00:11:16.681315+00:00",
+     "duration": 0.002577,
+     "end_time": "2026-05-25T02:03:46.978073+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.676616+00:00",
+     "start_time": "2026-05-25T02:03:46.975496+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1611,20 +1691,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "883aa023",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T00:11:16.694787Z",
-     "iopub.status.busy": "2026-05-23T00:11:16.694562Z",
-     "iopub.status.idle": "2026-05-23T00:11:16.698260Z",
-     "shell.execute_reply": "2026-05-23T00:11:16.697813Z"
+     "iopub.execute_input": "2026-05-25T02:03:46.985628Z",
+     "iopub.status.busy": "2026-05-25T02:03:46.985469Z",
+     "iopub.status.idle": "2026-05-25T02:03:46.988853Z",
+     "shell.execute_reply": "2026-05-25T02:03:46.988245Z"
     },
     "papermill": {
-     "duration": 0.011647,
-     "end_time": "2026-05-23T00:11:16.699418+00:00",
+     "duration": 0.008237,
+     "end_time": "2026-05-25T02:03:46.989308+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.687771+00:00",
+     "start_time": "2026-05-25T02:03:46.981071+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1665,10 +1745,10 @@
    "id": "ec85b3dd",
    "metadata": {
     "papermill": {
-     "duration": 0.004759,
-     "end_time": "2026-05-23T00:11:16.712093+00:00",
+     "duration": 0.002862,
+     "end_time": "2026-05-25T02:03:46.994938+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.707334+00:00",
+     "start_time": "2026-05-25T02:03:46.992076+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1690,30 +1770,76 @@
    "id": "a464171c",
    "metadata": {
     "papermill": {
-     "duration": 0.00813,
-     "end_time": "2026-05-23T00:11:16.725093+00:00",
+     "duration": 0.002762,
+     "end_time": "2026-05-25T02:03:47.000752+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.716963+00:00",
+     "start_time": "2026-05-25T02:03:46.997990+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "---\n\n## 10. Resume\n\n### Points cles\n\n| Concept | Description |\n|---------|-------------|\n| **Hypothese FOL** | Conjonction de contraintes sur les attributs |\n| **Consistance** | Pas de faux positifs ni de faux negatifs |\n| **Generalisation** | Remplacer une contrainte par `?` (couvrir plus) |\n| **Specialisation** | Remplacer `?` par une valeur (couvrir moins) |\n| **CBH** | Maintient une seule hypothese, ajustee incrementellement |\n| **Version Space** | Maintient G-set et S-set, represente toutes les hypotheses consistantes |\n| **Candidate Elimination** | Algorithme pour mettre a jour G et S efficacement |\n\n### Comparaison CBH vs Version Space\n\n| Critere | CBH | Version Space |\n|---------|-----|---------------|\n| Nombre d'hypotheses | 1 | Toutes (via frontieres) |\n| Ordre-dependance | Oui | Non |\n| Backtracking | Possible | Jamais |\n| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n| Complexite memoire | O(1) | O(|G| + |S|) |\n\n### Prochaines etapes\n\nDans le notebook suivant **SL-2 - Apprentissage et Connaissance**, nous decouvrirons :\n- L'apprentissage base sur les explications (EBL)\n- Comment transformer une experience unique en regle generale\n- L'utilisation de la deduction pour l'apprentissage"
+   "source": [
+    "---\n",
+    "\n",
+    "## 10. Resume\n",
+    "\n",
+    "### Points cles\n",
+    "\n",
+    "| Concept | Description |\n",
+    "|---------|-------------|\n",
+    "| **Hypothese FOL** | Conjonction de contraintes sur les attributs |\n",
+    "| **Consistance** | Pas de faux positifs ni de faux negatifs |\n",
+    "| **Generalisation** | Remplacer une contrainte par `?` (couvrir plus) |\n",
+    "| **Specialisation** | Remplacer `?` par une valeur (couvrir moins) |\n",
+    "| **CBH** | Maintient une seule hypothese, ajustee incrementellement |\n",
+    "| **Version Space** | Maintient G-set et S-set, represente toutes les hypotheses consistantes |\n",
+    "| **Candidate Elimination** | Algorithme pour mettre a jour G et S efficacement |\n",
+    "\n",
+    "### Comparaison CBH vs Version Space\n",
+    "\n",
+    "| Critere | CBH | Version Space |\n",
+    "|---------|-----|---------------|\n",
+    "| Nombre d'hypotheses | 1 | Toutes (via frontieres) |\n",
+    "| Ordre-dependance | Oui | Non |\n",
+    "| Backtracking | Possible | Jamais |\n",
+    "| Bruit | Robuste (peut revenir) | Fragile (VS vide) |\n",
+    "| Complexite memoire | O(1) | O(|G| + |S|) |\n",
+    "\n",
+    "### Prochaines etapes\n",
+    "\n",
+    "Dans le notebook suivant **SL-2 - Apprentissage et Connaissance**, nous decouvrirons :\n",
+    "- L'apprentissage base sur les explications (EBL)\n",
+    "- Comment transformer une experience unique en regle generale\n",
+    "- L'utilisation de la deduction pour l'apprentissage"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "902a1f86",
    "metadata": {
     "papermill": {
-     "duration": 0.004753,
-     "end_time": "2026-05-23T00:11:16.734574+00:00",
+     "duration": 0.002905,
+     "end_time": "2026-05-25T02:03:47.006709+00:00",
      "exception": false,
-     "start_time": "2026-05-23T00:11:16.729821+00:00",
+     "start_time": "2026-05-25T02:03:47.003804+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "---\n\n## Ressources\n\n- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitre 19.1\n- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)\n- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n- [Version Space - Wikipedia](https://en.wikipedia.org/wiki/Version_space)\n\n---\n\n**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)"
+   "source": [
+    "---\n",
+    "\n",
+    "## Ressources\n",
+    "\n",
+    "- Russell & Norvig, *AI: A Modern Approach*, 3e ed., Chapitre 19.1\n",
+    "- Tom Mitchell, *Machine Learning*, Chapitre 2 (Concept Learning)\n",
+    "- [AIMA Python Code](https://github.com/aimacode/aima-python) - Implementations de reference\n",
+    "- [Version Space - Wikipedia](https://en.wikipedia.org/wiki/Version_space)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Notebook suivant** : [SL-2 - Apprentissage et Connaissance](SL-2-KnowledgeBasedLearning.ipynb)"
+   ]
   }
  ],
  "metadata": {
@@ -1732,18 +1858,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.384842,
-   "end_time": "2026-05-23T00:11:16.990492+00:00",
+   "duration": 2.178374,
+   "end_time": "2026-05-25T02:03:47.132792+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning.ipynb",
-   "output_path": "d:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-1-LogicalLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-23T00:11:14.605650+00:00",
+   "start_time": "2026-05-25T02:03:44.954418+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary
- Convert **7 exercises with complete solutions** to Exemple guide + add new exercise stubs (Epic #1455)
- Notebooks: SL-1-LogicalLearning, Lean-5-Tactics, SW-2b-Python-RDFBasics

## Changes by notebook

### SL-1-LogicalLearning (SymbolicLearning)
- Exercice 1 (CBH reorder, complete solution) → **Exemple guide** + new random-order CBH exercise

### Lean-5-Tactics
- 3 exercises in "Exercices à compléter" section (complete Lean proofs) → **Exemples guides 1-3**
- +3 new sorry-based exercise stubs (and_comm, rearrange, de_morgan)

### SW-2b-Python-RDFBasics
- Exercice 1 (Hello World RDF, complete) → **Exemple guide 1**
- Exercice 2 (Book graph, complete) → **Exemple guide 2**
- Exercice de synthèse (research team, complete) → **Exemple guide 3**
- +3 new exercise stubs (course graph, graph exploration, social network synthesis)

## Validation
- Papermill SUCCESS on SL-1 (2.7s) and SW-2b (3.5s)
- Lean-5 sorry stubs are valid Lean 4 (compile with warning)
- C.1 check: 0 violations (no NotImplementedError/assert False/1/0)
- Content-based labeling per `.claude/rules/exercise-example-labeling.md`

## Cumulative #1455
- Batch 1: 6 notebooks (Tweety 1-4, 6, 7)
- Batch 2: 10 notebooks (SC, Lean, Linq2Z3)
- Batch 3: 4 notebooks (Tweety 5/8/9, Planners-10)
- **Batch 4: 3 notebooks (SL-1, Lean-5, SW-2b)**
- **Total: 23 notebooks converted across 4 batches**

🤖 Generated with [Claude Code](https://claude.com/claude-code)