### PR TITLE
fix(prover): remove dead LEAVERN abandon token from Director instructions (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/instructions.py
@@ -218,7 +218,6 @@ TACTICS:
 REGLES:
 - Max 500 tokens de sortie
 - Pas de sorry dans tes suggestions
-- Si le but semble hors de portee, dis LEAVERN (abandon)
 - Adapte tes suggestions aux ERREURS PASSEES (ne repete pas ce qui a echoue)
 - Tu peux suggérer des `have` intermediaires pour decomposer
 - Priorise les tactiques Mathlib disponibles sur les raisonnements from-scratch


### PR DESCRIPTION
## Summary
Epic #1453 forensic-driven harness fix. The `prover-forensic` pass over the real spans (`prover/baselines/traces/`, 71 files) found **28/39 DirectorAgent responses were "LEAVERN"** — a give-up token the harness never acts on. This deletes the dead instruction (`instructions.py:221`) so the frontier Director spends its bounded budget on strategic guidance instead.

## Verification (sans complaisance — every claim checked against code)
- **Director has `tools=[]`** (`agents.py:165`) — it physically cannot abandon a sorry.
- **The only abandon path** is the Coordinator's `mark_sorry_intractable` (`agents.py:128`, `tools.py:2017`), gated by F9 (Director consulted) + B2 (SearchAgent), which sets `state.intractable` → yield at `workflow.py:543-557`.
- **LEAVERN from the Director is plain text**: sets no state, calls no tool, routes nowhere. It is only filtered if it leaks as a *tactic* (`_CONTROL_SIGNALS`, `workflow.py:436` — **kept** as defense-in-depth).
- **No test references LEAVERN** (grep `--include=*.py` over `tests/` + `prover/`).

## Why pure deletion (no replacement — no pendulum)
The Director already has constructive guidance at line 223 (`have` decompositions), and abandon stays the Coordinator's gated decision after Director consultation (F9). Removing the dead token leaves no gap.

## Rejected alternative
The forensic's higher-effort "consume LEAVERN → trigger intractable" was **rejected**: it would let the Director unilaterally bypass the F9/B2 intractable gates deliberately added per the C37 forensic to prevent premature abandons.

## Test plan
- [x] `tests/test_prover_guards.py`: **59 passed** (`coursia-ml-training` env)
- [x] grep confirms no `.py` test/code dependency on LEAVERN beyond the deleted line + the kept defensive filter

cc @myia-po-2026 (shared Epic #1453 — your in-flight prover BG runs will simply stop being told to emit the no-op token; no behavioral gate changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)