### PR TITLE
fix(search): content-based Exemple/Exercice labeling batch 3 — CSP apps + hybrid (#1562)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-1-NQueens.ipynb
@@ -2016,7 +2016,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1b : le probleme des N-Fous\n",
+    "### Exercice 1b : le probleme des N-Fous\n",
     "\n",
     "**Enonce** : adaptez le probleme pour placer $N$ **fous** sur un echiquier\n",
     "$N \\times N$. Les fous attaquent en diagonale.\n",
@@ -2217,7 +2217,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2b : plage etendue jusqu'a N=50\n",
+    "### Exercice 2b : plage etendue jusqu'a N=50\n",
     "\n",
     "**Enonce** : relancez la comparaison sur une plage plus large :\n",
     "$N \\in \\{20, 25, 30, 35, 40, 45, 50\\}$.\n",
@@ -2462,7 +2462,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3b : brisure de symetrie directe dans CP-SAT\n",
+    "### Exercice 3b : brisure de symetrie directe dans CP-SAT\n",
     "\n",
     "**Enonce** : au lieu d'enumerer toutes les solutions puis de reduire\n",
     "post-facto, ajoutez les contraintes de symetrie **directement dans le\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-11-Picross.ipynb
@@ -2125,7 +2125,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 1b : Resolvez un nouveau puzzle 15x15\n",
+    "#### Exercice 1b : Resolvez un nouveau puzzle 15x15\n",
     "\n",
     "Resoudre le puzzle suivant en utilisant `solve_cpsat`.\n",
     "\n",
@@ -2267,7 +2267,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 2b : Creez un puzzle avec vos propres initiales\n",
+    "#### Exercice 2b : Creez un puzzle avec vos propres initiales\n",
     "\n",
     "Concevez une image binaire representant **vos propres initiales** (ou un dessin simple)\n",
     "et generez le puzzle Picross correspondant.\n",
@@ -2325,7 +2325,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Picross colore (variante avancee)\n",
+    "### Exercice 3 : Picross colore (variante avancee)\n",
     "\n",
     "**Enonce** : dans un Picross colore, chaque bloc a une couleur (en plus de sa longueur). Deux blocs de couleurs differentes **n'ont pas besoin d'espace** entre eux, mais deux blocs de meme couleur oui.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
@@ -1037,9 +1037,9 @@
     "tags": []
    },
    "source": [
-    "## Exemple guide\n",
+    "## Exercices\n",
     "\n",
-    "### Exemple guide 1 : Heuristique LCV (Least Constraining Value)\n",
+    "### Exercice 1 : Heuristique LCV (Least Constraining Value)\n",
     "\n",
     "L'heuristique **LCV** consiste a choisir en priorite les mots qui eliminent le moins de choix pour les autres slots. Implementez cette heuristique dans le solveur backtracking.\n",
     "\n",
@@ -1126,7 +1126,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Generation de Grille Optimisee\n",
+    "### Exercice 2 : Generation de Grille Optimisee\n",
     "\n",
     "La fonction `generate_random_grid` cree des grilles aleatoires qui peuvent etre trop simples ou trop difficiles. Implementez une generation qui maximise le nombre d'intersections.\n",
     "\n",
@@ -1213,7 +1213,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Contraintes de Theme (Reflexion)\n",
+    "### Exercice 3 : Contraintes de Theme (Reflexion)\n",
     "\n",
     "Comment modifieriez-vous le solveur pour generer des grilles sur un theme donne (ex: informatique, nature, sport) ?\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-2-GraphColoring.ipynb
@@ -2256,7 +2256,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 1b : Colorier les pays d'Europe de l'Ouest\n",
+    "#### Exercice 1b : Colorier les pays d'Europe de l'Ouest\n",
     "\n",
     "Construisez un graphe de 8-10 pays d'Europe de l'Ouest avec leurs frontieres\n",
     "et comparez les trois algorithmes.\n",
@@ -2382,7 +2382,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 2b : Comparaison greedy vs optimal sur le dodecahedre\n",
+    "#### Exercice 2b : Comparaison greedy vs optimal sur le dodecahedre\n",
     "\n",
     "Reproduisez l'analyse ci-dessus sur le **dodecahedre** (`nx.dodecahedral_graph()`).\n",
     "\n",
@@ -2544,7 +2544,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 3b : Implementez un algorithme de coloration par saturation\n",
+    "#### Exercice 3b : Implementez un algorithme de coloration par saturation\n",
     "\n",
     "L'algorithme DSATUR (Degree of SATURation) choisit le sommet non colore\n",
     "avec le plus grand nombre de couleurs differentes dans son voisinage.\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-3-NurseScheduling.ipynb
@@ -2192,7 +2192,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 1b : Limite de jours consecutifs configurable\n",
+    "#### Exercice 1b : Limite de jours consecutifs configurable\n",
     "\n",
     "Generalisez la contrainte ci-dessus : ajoutez une contrainte qui limite\n",
     "a **`max_consecutive` jours consecutifs** de travail (parametre configurable).\n",
@@ -2325,7 +2325,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 2b : Preferences avec contraintes obligatoires\n",
+    "#### Exercice 2b : Preferences avec contraintes obligatoires\n",
     "\n",
     "Certaines preferences sont en fait des **contraintes dures** (non-negociables),\n",
     "d'autres restent des preferences souples.\n",
@@ -2458,7 +2458,7 @@
     "tags": []
    },
    "source": [
-    "#### Exemple guide 3b : Contrats avec minimum et maximum de shifts\n",
+    "#### Exercice 3b : Contrats avec minimum et maximum de shifts\n",
     "\n",
     "Dans la realite, les infirmiers a temps partiel ont aussi un **minimum** de shifts\n",
     "a effectuer (garantie d'emploi). Generalisez le modele.\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
@@ -2626,7 +2626,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1b : comptage total des mines\n",
+    "### Exercice 1b : comptage total des mines\n",
     "\n",
     "**Enonce** : au lieu d'ajouter une contrainte `ExactSumConstraint` quand toute\n",
     "la frontiere est couverte, ajoutez systematiquement une contrainte sur le\n",
@@ -2800,7 +2800,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2b : zone de securite configurable\n",
+    "### Exercice 2b : zone de securite configurable\n",
     "\n",
     "**Enonce** : modifiez `MinesweeperBoard` pour que la zone de securite lors du\n",
     "premier clic soit configurable : au lieu d'exclure les 8 voisins, l'utilisateur\n",
@@ -2943,7 +2943,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3b : difficulte experte (30x16, 99 mines)\n",
+    "### Exercice 3b : difficulte experte (30x16, 99 mines)\n",
     "\n",
     "**Enonce** : testez le solveur sur la difficulte \"experte\" du Demineur\n",
     "(grille 30x16 avec 99 mines). Mesurez les memes indicateurs.\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
@@ -2321,9 +2321,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Exemple guide\n",
+    "## 7. Exercices\n",
     "\n",
-    "### Exemple guide 1 : Carre magique en MiniZinc\n",
+    "### Exercice 1 : Carre magique en MiniZinc\n",
     "\n",
     "Un **carre magique** d'ordre $n$ est une grille $n \\times n$ contenant les entiers $1$ a $n^2$, ou la somme de chaque ligne, chaque colonne et les deux diagonales est la meme.\n",
     "\n",
@@ -2445,7 +2445,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Coloration de graphe en MiniZinc\n",
+    "### Exercice 2 : Coloration de graphe en MiniZinc\n",
     "\n",
     "Reprenez le probleme de coloration de graphe de [App-2-GraphColoring](App-2-GraphColoring.ipynb) et ecrivez le modele MiniZinc correspondant.\n",
     "\n",
@@ -2535,7 +2535,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : VRP simplifie en MiniZinc\n",
+    "### Exercice 3 : VRP simplifie en MiniZinc\n",
     "\n",
     "Le **Vehicle Routing Problem** (VRP) consiste a trouver des tournees optimales pour un ensemble de vehicules partant d'un depot et devant visiter des clients.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
@@ -1393,9 +1393,9 @@
     "tags": []
    },
    "source": [
-    "## Exemple guide\n",
+    "## Exercices\n",
     "\n",
-    "### Exemple guide 1 : Heuristique d'Insertion la Moins Chere\n",
+    "### Exercice 1 : Heuristique d'Insertion la Moins Chere\n",
     "\n",
     "Implementez l'heuristique **Cheapest Insertion** qui construit une tournee en inserant chaque ville a la position qui augmente le moins le cout total.\n",
     "\n",
@@ -1546,7 +1546,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Operateur de Voisinage Or-opt\n",
+    "### Exercice 2 : Operateur de Voisinage Or-opt\n",
     "\n",
     "L'operateur **Or-opt** consiste a deplacer un segment de 1 a 3 villes consecutives a une autre position de la tournee. Implementez cet operateur.\n",
     "\n",
@@ -1699,7 +1699,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Parametrisation du Recuit Simule (Reflexion)\n",
+    "### Exercice 3 : Parametrisation du Recuit Simule (Reflexion)\n",
     "\n",
     "Analysez l'impact des parametres du recuit simule sur la qualite de la solution.\n",
     "\n",
@@ -1756,11 +1756,11 @@
     "\n",
     "Modifiez la classe TSPInstance pour supporter le TSP asymetrique (ATSP) ou la distance aller != distance retour.\n",
     "\n",
-    "### Exemple guide 2 : 3-opt\n",
+    "### Exercice : 3-opt\n",
     "\n",
     "Implementez l'amelioration 3-opt qui considere 3 coupures au lieu de 2. Comparez avec 2-opt.\n",
     "\n",
-    "### Exemple guide 3 : TSP avec Fenetres de Temps\n",
+    "### Exercice : TSP avec Fenetres de Temps\n",
     "\n",
     "Ajoutez des contraintes de fenetres de temps : chaque ville doit etre visitee dans un intervalle [a, b].\n",
     "\n",
@@ -2159,7 +2159,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 4 : Recherche Tabou (Tabu Search)\n",
+    "### Exercice 4 : Recherche Tabou (Tabu Search)\n",
     "\n",
     "La **recherche tabou** (Glover, 1986) est une metaheuristique deterministe qui utilise une\n",
     "memoire a court terme pour eviter de revisiter des solutions deja explorees.\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
@@ -1676,7 +1676,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Noyau 5x5 vs 7x7\n",
+    "### Exercice 2 : Noyau 5x5 vs 7x7\n",
     "\n",
     "**Tache** : Reduisez la taille du noyau a 5x5 (25 genes au lieu de 49) et relancez le GA.\n",
     "\n",
@@ -1759,7 +1759,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Effet du taux de mutation\n",
+    "### Exercice 3 : Effet du taux de mutation\n",
     "\n",
     "**Tache** : Lancez le GA PyGAD avec trois taux de mutation differents (5%, 15%, 30%) et comparez les courbes de convergence.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -1028,7 +1028,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1 : 4-Reines avec backtracking manuel\n",
+    "### Exercice 1 : 4-Reines avec backtracking manuel\n",
     "\n",
     "**Enonce** : modelisez et resolvez le probleme des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
     "\n",
@@ -1098,7 +1098,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : comparer MRV sur les 4-Reines\n",
+    "### Exercice 2 : comparer MRV sur les 4-Reines\n",
     "\n",
     "**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit probleme ?"
    ]
@@ -1163,7 +1163,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Cryptarithmetique SEND + MORE = MONEY\n",
+    "### Exercice 3 : Cryptarithmetique SEND + MORE = MONEY\n",
     "\n",
     "**Enonce** : le puzzle cryptarithmetique **SEND + MORE = MONEY** consiste a trouver l'affectation de chiffres (0-9) aux lettres telle que l'addition soit correcte. Chaque lettre represente un chiffre distinct, et S et M ne peuvent pas etre 0 (pas de zero initial).\n",
     "\n",
@@ -1271,7 +1271,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 4 : Sudoku 4x4 avec visualisation\n",
+    "### Exercice 4 : Sudoku 4x4 avec visualisation\n",
     "\n",
     "**Enonce** : Un Sudoku 4x4 est une grille 4x4 ou chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
     "\n",
@@ -3005,7 +3005,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1 : 4-Reines avec backtracking manuel\n",
+    "### Exercice 1 : 4-Reines avec backtracking manuel\n",
     "\n",
     "**Enonce** : modelisez et resolvez le probleme des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
     "\n",
@@ -3086,7 +3086,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : comparer MRV sur les 4-Reines\n",
+    "### Exercice 2 : comparer MRV sur les 4-Reines\n",
     "\n",
     "**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit probleme ?"
    ]
@@ -3151,7 +3151,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Cryptarithmetique SEND + MORE = MONEY\n",
+    "### Exercice 3 : Cryptarithmetique SEND + MORE = MONEY\n",
     "\n",
     "**Enonce** : le puzzle cryptarithmetique **SEND + MORE = MONEY** consiste a trouver l'affectation de chiffres (0-9) aux lettres telle que l'addition soit correcte. Chaque lettre represente un chiffre distinct, et S et M ne peuvent pas etre 0 (pas de zero initial).\n",
     "\n",
@@ -3259,7 +3259,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 4 : Sudoku 4x4 avec visualisation\n",
+    "### Exercice 4 : Sudoku 4x4 avec visualisation\n",
     "\n",
     "**Enonce** : Un Sudoku 4x4 est une grille 4x4 ou chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-2-Consistency.ipynb
@@ -2615,9 +2615,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Exemple guide\n",
+    "## 7. Exercices\n",
     "\n",
-    "### Exemple guide 1 : AC-3 a la main\n",
+    "### Exercice 1 : AC-3 a la main\n",
     "\n",
     "Considerez le CSP suivant avec 3 variables :\n",
     "\n",
@@ -2682,7 +2682,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : Path Consistency (PC-2)\n",
+    "### Exercice 2 : Path Consistency (PC-2)\n",
     "\n",
     "La **consistance de chemin** (path consistency) est le niveau au-dessus de la consistance d'arc. Un chemin $(X_i, X_j, X_k)$ est path-consistent si pour toute assignation consistante $(X_i = a, X_k = c)$, il existe une valeur $b \\in D_j$ telle que $(X_i = a, X_j = b)$ et $(X_j = b, X_k = c)$ sont toutes deux consistantes.\n",
     "\n",
@@ -2758,7 +2758,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : FC vs MAC sur Sudoku 4x4\n",
+    "### Exercice 3 : FC vs MAC sur Sudoku 4x4\n",
     "\n",
     "Un Sudoku 4x4 utilise les chiffres 1 a 4 dans une grille 4x4 divisee en 4 blocs 2x2. Les regles sont les memes que le 9x9 : chaque chiffre apparait exactement une fois par ligne, colonne et bloc.\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-4-Scheduling.ipynb
@@ -1422,7 +1422,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 1 : JSSP avec deadlines serrees\n",
+    "### Exercice 1 : JSSP avec deadlines serrees\n",
     "\n",
     "**Enonce** : Resolvez un JSSP avec 4 jobs et 3 machines, en ajoutant des deadlines\n",
     "plus strictes. Utilisez les donnees suivantes :\n",
@@ -1630,7 +1630,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 2 : RCPSP avec budget limite\n",
+    "### Exercice 2 : RCPSP avec budget limite\n",
     "\n",
     "**Enonce** : Etendez le modele RCPSP pour gerer un budget global. Chaque tache\n",
     "a un cout, et le budget total ne doit pas etre depasse.\n",
@@ -1833,7 +1833,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 3 : Nurse Scheduling avec equilibrage de charge\n",
+    "### Exercice 3 : Nurse Scheduling avec equilibrage de charge\n",
     "\n",
     "**Enonce** : Ajoutez une contrainte d'equilibrage : chaque infirmier doit travailler\n",
     "entre `min_shifts` et `max_shifts` tours sur la semaine.\n",
@@ -2012,7 +2012,7 @@
     "tags": []
    },
    "source": [
-    "### Exemple guide 4 : Exploration du front de Pareto\n",
+    "### Exercice 4 : Exploration du front de Pareto\n",
     "\n",
     "**Enonce** : Au lieu d'utiliser une ponderation fixe, trouvez plusieurs solutions\n",
     "Pareto-optimales en variant les poids `weight_makespan` et `weight_tardiness`.\n",


### PR DESCRIPTION
## Summary

Batch 3 of the content-based Exemple/Exercice de-leak for the **Search** notebook family (Epic #1455 / Issue #1562), per `.claude/rules/exercise-example-labeling.md` (mandat user 2026-05-20, incidents #1214/#1336).

**48 stub-backed `Exemple guide` headings relabeled to `Exercice`** across **12 notebooks**. Markdown-only change: code cells, `execution_count` and `outputs` are untouched — C.2 exception (no Papermill re-execution needed). Diff = **48 insertions / 48 deletions, all heading swaps, 0 code lines changed**.

## Classification methodology (content-based, HARD rule)

Headings classified by whether their **following code cell** is a stub or a complete solution — never by title text:
- code = complete working solution -> **Exemple** (KEPT, never relabeled)
- code = stub (`# TODO` / `pass` / `return None` / "a completer" / empty) -> **Exercice** (relabeled)

MIXED notebooks are respected: worked-example `Exemple guide` headings whose next code cell is a real solution are **KEPT untouched** (App-1 base, App-9 base, App-11 bases 1/2, App-13 supplementaires section). Only stub-backed headings were relabeled.

## Files (12)

| Notebook | Pattern | Relabels |
|----------|---------|----------|
| Part2-CSP/CSP-1-Fundamentals | 4 items × 2 duplicate blocks | 8 |
| Part2-CSP/CSP-2-Consistency | ALL-EXERCISE (section + 3 items) | 4 |
| Part2-CSP/CSP-4-Scheduling | MIXED (section header KEPT, 4 stub items) | 4 |
| Applications/CSP/App-1-NQueens | 3 b-variant stubs (base example KEPT) | 3 |
| Applications/CSP/App-2-GraphColoring | 3 level-4 b-variant stubs | 3 |
| Applications/CSP/App-3-NurseScheduling | 3 level-4 b-variant stubs | 3 |
| Applications/CSP/App-6-Minesweeper | 3 b-variant stubs | 3 |
| Applications/CSP/App-8-MiniZinc | ALL-EXERCISE (section + 3 items) | 4 |
| Applications/CSP/App-11-Picross | MIXED (2 b-variants + 1 stub; bases KEPT) | 3 |
| Applications/CSP/App-16-Crossword-CSP | ALL-EXERCISE (section + 3 items) | 4 |
| Applications/Hybrid/App-9-EdgeDetection | MIXED (2 stubs; base KEPT) | 2 |
| Applications/Hybrid/App-13-TSP-Metaheuristics | 7 relabels incl. md#35 scanner-blind block (manual) | 7 |

## Verification

- **Scanner** (`scan_leaks.py`) on the 12 files: **0 LEAK B remaining**.
- One residual LEAK A flag in App-13 (cell#33 `### Exercice 3` -> cell#36 SOLUTION) is a **confirmed FALSE POSITIVE**: `Exercice 3` is a code-free reflection exercise ("pas de code requis") whose answer is an empty markdown template (cell#34); cell#36's code belongs to the subsequent `### Exemple guide 1 : TSP Asymetrique` worked example. The scanner is blind to multi-heading single markdown cells.
- All 12 files parse as valid JSON with `execution_count` + `outputs` preserved.

## Escalation — App-5-Timetabling (LEAK A, NOT in this PR)

`Applications/CSP/App-5-Timetabling.ipynb` is the **sole batch-3 judgment case** (title "Exercice" + complete solution code). Per the HARD rule, judgment cases are **not auto-resolved** (do not blindly stub or relabel). **Excluded from this PR — escalated to ai-01/user for a decision** (stub the solution while keeping the Exercice title + `# TODO`/`# Indice`, vs. relabel to Exemple).

## Notes for reviewer

- **catalog-drift** CI is a known **non-required false positive** on #1455/#1562 batches (heading-text-only change).
- No code execution changed, so `notebook-execution-required` is satisfied by preserved prior outputs.
- App-13 md#35 (a single markdown cell with 4 headings) was handled **manually** because the scanner only inspects the first code cell within 3 of a heading and is blind to multi-heading cells.

Batch 4 (deferred for composite-size discipline): Part1-Foundations (Search-2/3/8/9/10/11), root GeneticSharp-EdgeDetection (LEAK B), root CSPs_Intro (LEAK A, escalate).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
