### PR TITLE
fix(search): content-based Exemple/Exercice labeling batch 5 — LocalSearch + MCTS (#1562)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-4-LocalSearch.ipynb
@@ -2708,9 +2708,9 @@
     "tags": []
    },
    "source": [
-    "### Exemple 3 : Memoire a long terme pour Tabu Search\n",
+    "### Exercice 3 : Memoire a long terme pour Tabu Search\n",
     "\n",
-    "**Exemple** : Ajoutez une **memoire a long terme** (frequency-based) au Tabu Search pour N-Reines. L'idee est de compter combien de fois chaque mouvement $(col, row)$ a ete effectue, et de **penaliser** les mouvements trop frequents pour forcer la diversification.\n",
+    "**Exercice** : Ajoutez une **memoire a long terme** (frequency-based) au Tabu Search pour N-Reines. L'idee est de compter combien de fois chaque mouvement $(col, row)$ a ete effectue, et de **penaliser** les mouvements trop frequents pour forcer la diversification.\n",
     "\n",
     "Modification du score d'un mouvement :\n",
     "$$\\text{score}(col, row) = \\text{conflits}(col, row) + \\lambda \\cdot \\text{frequence}(col, row)$$\n",

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -2089,7 +2089,7 @@
    "source": [
     "---\n",
     "\n",
-    "### Exemple guide : MCTS sur le jeu de Connect-4\n",
+    "### Exercice : MCTS sur le jeu de Connect-4\n",
     "\n",
     "Implementez le jeu de **Connect-4** (Puissance 4) et testez l'algorithme MCTS dessus.\n",
     "\n",


### PR DESCRIPTION
## Scope

Batch 5 du de-leak content-based de la famille Search (#1562 / Epic #1455). **Deux** relabels LEAK B verifies par contenu, **markdown uniquement**, aucune re-execution (exception C.2).

Regle appliquee ([.claude/rules/exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md), mandat user 2026-05-20) : titre "Exemple"/"Exemple guide" + cellule code = **stub authentique** => relabeler le **titre** en Exercice. Classification **par contenu de la cellule code suivante**, pas par le titre ni par le flag STUB du scanner.

## Relabels (LEAK B confirmes)

| Notebook | Cellule | Avant | Apres | Preuve code |
|----------|---------|-------|-------|-------------|
| Search-4-LocalSearch | md#53 | `### Exemple 3 : Memoire a long terme pour Tabu Search` | `### Exercice 3 : ...` | code#54 = stub authentique (`return None  # TODO etudiant`, `print("Exercice a completer")`). Occupe le slot Exercice-3 (Exercice 1/2/**_3_**/4). Section deja `## 6. Exercices`. |
| Search-7-MCTS | md#38 | `### Exemple guide : MCTS sur le jeu de Connect-4` | `### Exercice : MCTS sur le jeu de Connect-4` | code#39 = stub authentique (classe `ConnectFour`, toutes methodes `pass`/`# TODO`, `print("Exercice charge - completez...")`). Titre/corps/code tous alignes sur Connect-4. |

Lead-in de prose `**Exemple** :` de Search-4 md#53 passe a `**Exercice** :` pour la coherence interne de la cellule (heading + corps doivent s'accorder).

**Section MIXED CONSERVEE** : `## Exemple guide` de Search-7 (md#24) contient de vrais exemples resolus (code#27 `NimGame`, code#37 `benchmark_parametre_c`) ET des stubs => le header de section reste `## Exemple guide` (regle section : ne relabeler le header que si la section est ALL-STUB).

## Escalade — NON TOUCHE (PAS un leak de labeling, pour ai-01/user)

Search-7-MCTS presente des **desalignements d'ordre de cellules** (distincts d'un leak de labeling, donc non corriges ici) :

- md#26 `### Exemple resolu : Analyse de convergence MCTS` -> code#27 = solution **du jeu de Nim** (sujet different du titre).
- md#28 `### Exemple resolu : MCTS sur le jeu de Nim` -> code#29 = stub **"Exercice 5 : Time management"** (`class MCTSTimeManaged`, sujet different du titre).

La solution Nim **existe** (code#27), donc md#28 ne doit **PAS** etre relabele en Exercice : ce serait detruire un exemple resolu existant. C'est un bug de **structure** (cellules mal positionnees) qui necessite une passe de reorganisation, pas un relabel. Egalement : la TOC md#24 liste "Exemple guide 2-5" alors que sa prose dit "les exercices 2 a 5 sont des stubs a completer" (incoherence TOC pre-existante). A trancher par ai-01/user.

## Verification

- `headings.py` apres : md#53 -> `Exercice 3`, md#38 -> `Exercice : Connect-4`, md#28 inchange (`Exemple resolu : Nim`).
- `git diff --stat` : 2 fichiers, 3 insertions / 3 deletions — **100% lignes markdown** (aucun code source, aucun `execution_count`, aucun `outputs` modifie).
- Fichiers hors des PR ouvertes #1565 (batch 3) et #1566 (batch 4) — aucun conflit.

## CI

`catalog-drift` peut etre rouge (faux positif connu sur les batches #1455/#1562, pas un blocage).

## Notes

- Conforme C.1 (stubs sans erreur volontaire : `return None`/`pass`/`print`, pas de `NotImplementedError`).
- Pas de solution resolue, pas d'exemple stubbe, pas de revert de relabel valide.
- Agent : `myia-po-2025`. Merge par ai-01 (les agents ne mergent pas eux-memes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)