### PR TITLE
feat(qc): ForexCarry QC Cloud validation - NO BEATS verdict

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
@@ -5,10 +5,10 @@
    "id": "775cf581",
    "metadata": {
     "papermill": {
-     "duration": 0.003998,
-     "end_time": "2026-05-03T22:41:37.834752+00:00",
+     "duration": 0.004896,
+     "end_time": "2026-05-25T22:01:36.626295+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:37.830754+00:00",
+     "start_time": "2026-05-25T22:01:36.621399+00:00",
      "status": "completed"
     },
     "tags": []
@@ -42,16 +42,16 @@
    "id": "3c03d33d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:41:37.842651Z",
-     "iopub.status.busy": "2026-05-03T22:41:37.842341Z",
-     "iopub.status.idle": "2026-05-03T22:41:41.567594Z",
-     "shell.execute_reply": "2026-05-03T22:41:41.566501Z"
+     "iopub.execute_input": "2026-05-25T22:01:36.637989Z",
+     "iopub.status.busy": "2026-05-25T22:01:36.637581Z",
+     "iopub.status.idle": "2026-05-25T22:01:42.548613Z",
+     "shell.execute_reply": "2026-05-25T22:01:42.548015Z"
     },
     "papermill": {
-     "duration": 3.730612,
-     "end_time": "2026-05-03T22:41:41.568446+00:00",
+     "duration": 5.917078,
+     "end_time": "2026-05-25T22:01:42.549269+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:37.837834+00:00",
+     "start_time": "2026-05-25T22:01:36.632191+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,21 +68,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  EURUSD: 2863 jours\n"
+      "  EURUSD: 2863 jours\n",
+      "  GBPUSD: 2863 jours\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  GBPUSD: 2863 jours\n",
-      "  AUDUSD: 2863 jours\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  AUDUSD: 2863 jours\n",
       "  NZDUSD: 2863 jours\n"
      ]
     },
@@ -166,10 +160,10 @@
    "id": "c4efe2d6",
    "metadata": {
     "papermill": {
-     "duration": 0.003816,
-     "end_time": "2026-05-03T22:41:41.576357+00:00",
+     "duration": 0.002937,
+     "end_time": "2026-05-25T22:01:42.555397+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:41.572541+00:00",
+     "start_time": "2026-05-25T22:01:42.552460+00:00",
      "status": "completed"
     },
     "tags": []
@@ -187,16 +181,16 @@
    "id": "3c100a60",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:41:41.587347Z",
-     "iopub.status.busy": "2026-05-03T22:41:41.586694Z",
-     "iopub.status.idle": "2026-05-03T22:41:42.206336Z",
-     "shell.execute_reply": "2026-05-03T22:41:42.205128Z"
+     "iopub.execute_input": "2026-05-25T22:01:42.562007Z",
+     "iopub.status.busy": "2026-05-25T22:01:42.561749Z",
+     "iopub.status.idle": "2026-05-25T22:01:43.021124Z",
+     "shell.execute_reply": "2026-05-25T22:01:43.020529Z"
     },
     "papermill": {
-     "duration": 0.627138,
-     "end_time": "2026-05-03T22:41:42.207355+00:00",
+     "duration": 0.463835,
+     "end_time": "2026-05-25T22:01:43.022098+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:41.580217+00:00",
+     "start_time": "2026-05-25T22:01:42.558263+00:00",
      "status": "completed"
     },
     "tags": []
@@ -296,10 +290,10 @@
    "id": "91f5cdb8",
    "metadata": {
     "papermill": {
-     "duration": 0.005961,
-     "end_time": "2026-05-03T22:41:42.219038+00:00",
+     "duration": 0.004164,
+     "end_time": "2026-05-25T22:01:43.031176+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:42.213077+00:00",
+     "start_time": "2026-05-25T22:01:43.027012+00:00",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +312,16 @@
    "id": "e7d9932e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:41:42.232718Z",
-     "iopub.status.busy": "2026-05-03T22:41:42.232192Z",
-     "iopub.status.idle": "2026-05-03T22:41:42.964307Z",
-     "shell.execute_reply": "2026-05-03T22:41:42.963173Z"
+     "iopub.execute_input": "2026-05-25T22:01:43.040092Z",
+     "iopub.status.busy": "2026-05-25T22:01:43.039925Z",
+     "iopub.status.idle": "2026-05-25T22:01:43.475765Z",
+     "shell.execute_reply": "2026-05-25T22:01:43.474944Z"
     },
     "papermill": {
-     "duration": 0.740293,
-     "end_time": "2026-05-03T22:41:42.965272+00:00",
+     "duration": 0.441291,
+     "end_time": "2026-05-25T22:01:43.476444+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:42.224979+00:00",
+     "start_time": "2026-05-25T22:01:43.035153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -482,18 +476,38 @@
   {
    "cell_type": "markdown",
    "id": "399c64d7",
-   "source": "### Interpretation: Le momentum FX pur (baseline)\n\n**Constat** : la strategie actuelle (composite 3M/12M, L/S 2+2, 7 paires, position 15%) produit un **Sharpe de -0.156** avec un CAGR de -0.6% et un MaxDD de -13.95%. Le diagnostic BROKEN est confirme.\n\n**Causes probables** :\n- Le momentum FX sur 2018-2026 est domine par le cycle de hausses de taux de la Fed (2018, 2022-2023), qui soutient le dollar de maniere persistante et contredit les signaux momentum classiques\n- L'approche Long/Short symetrique (2 long, 2 short) cree une exposition USD ambigue : on achete et vend des devises contre le dollar simultanement, annulant le benefice directionnel\n- Le position sizing a 15% x 4 positions = 60% d'exposition cumulee, mais les signaux sont bruites et la concentration dans les paires correlees amplifie les pertes\n\n**Perspective** : le FX momentum \"pur\" sans filtre de regime est structurellement defavorise sur cette periode. Les hypotheses suivantes testeront des correctifs (filtres DXY, volatilite, reduction d'univers).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00623,
+     "end_time": "2026-05-25T22:01:43.489092+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:01:43.482862+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Le momentum FX pur (baseline)\n",
+    "\n",
+    "**Constat** : la strategie actuelle (composite 3M/12M, L/S 2+2, 7 paires, position 15%) produit un **Sharpe de -0.156** avec un CAGR de -0.6% et un MaxDD de -13.95%. Le diagnostic BROKEN est confirme.\n",
+    "\n",
+    "**Causes probables** :\n",
+    "- Le momentum FX sur 2018-2026 est domine par le cycle de hausses de taux de la Fed (2018, 2022-2023), qui soutient le dollar de maniere persistante et contredit les signaux momentum classiques\n",
+    "- L'approche Long/Short symetrique (2 long, 2 short) cree une exposition USD ambigue : on achete et vend des devises contre le dollar simultanement, annulant le benefice directionnel\n",
+    "- Le position sizing a 15% x 4 positions = 60% d'exposition cumulee, mais les signaux sont bruites et la concentration dans les paires correlees amplifie les pertes\n",
+    "\n",
+    "**Perspective** : le FX momentum \"pur\" sans filtre de regime est structurellement defavorise sur cette periode. Les hypotheses suivantes testeront des correctifs (filtres DXY, volatilite, reduction d'univers)."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "687c09de",
    "metadata": {
     "papermill": {
-     "duration": 0.006231,
-     "end_time": "2026-05-03T22:41:42.978779+00:00",
+     "duration": 0.005627,
+     "end_time": "2026-05-25T22:01:43.500678+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:42.972548+00:00",
+     "start_time": "2026-05-25T22:01:43.495051+00:00",
      "status": "completed"
     },
     "tags": []
@@ -510,16 +524,16 @@
    "id": "20de51c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:41:42.994372Z",
-     "iopub.status.busy": "2026-05-03T22:41:42.993849Z",
-     "iopub.status.idle": "2026-05-03T22:42:03.778663Z",
-     "shell.execute_reply": "2026-05-03T22:42:03.777617Z"
+     "iopub.execute_input": "2026-05-25T22:01:43.515683Z",
+     "iopub.status.busy": "2026-05-25T22:01:43.515463Z",
+     "iopub.status.idle": "2026-05-25T22:01:56.261912Z",
+     "shell.execute_reply": "2026-05-25T22:01:56.261481Z"
     },
     "papermill": {
-     "duration": 20.79424,
-     "end_time": "2026-05-03T22:42:03.779686+00:00",
+     "duration": 12.756402,
+     "end_time": "2026-05-25T22:01:56.262607+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:41:42.985446+00:00",
+     "start_time": "2026-05-25T22:01:43.506205+00:00",
      "status": "completed"
     },
     "tags": []
@@ -587,18 +601,37 @@
   {
    "cell_type": "markdown",
    "id": "533b8e81",
-   "source": "### Interpretation: Lookback periods optimaux\n\n**Conclusions** :\n- **Seule 1 configuration sur 44** atteint un Sharpe positif (21j/189j, poids 50/50, Sharpe 0.024). C'est quasi du bruit statistique\n- **Sharpe moyen : -0.145**. Le momentum FX composite est systematiquement negatif sur 2018-2026 avec la configuration L/S baseline\n- Les lookbacks courts (21-42j) performent legerement mieux que les longs (252j), mais la difference est marginale et aucun n'est positif\n- Le poids entre court et long terme n'a pas d'impact significatif (tous les weights testes produisent des Sharpe negatifs)\n\n**Diagnostic** : le momentum FX \"pur\" (L/S, pas de filtre) ne fonctionne pas sur cette periode. La raison structurelle est que 2018-2026 est domine par le cycle de hausses de taux de la Fed — le dollar reste fort, et les signaux momentum sont contraries par les flux de taux d'interet. Il faut soit un filtre de regime (DXY), soit abandonner le L/S pour du long-only conditionnel.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004521,
+     "end_time": "2026-05-25T22:01:56.272050+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:01:56.267529+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Lookback periods optimaux\n",
+    "\n",
+    "**Conclusions** :\n",
+    "- **Seule 1 configuration sur 44** atteint un Sharpe positif (21j/189j, poids 50/50, Sharpe 0.024). C'est quasi du bruit statistique\n",
+    "- **Sharpe moyen : -0.145**. Le momentum FX composite est systematiquement negatif sur 2018-2026 avec la configuration L/S baseline\n",
+    "- Les lookbacks courts (21-42j) performent legerement mieux que les longs (252j), mais la difference est marginale et aucun n'est positif\n",
+    "- Le poids entre court et long terme n'a pas d'impact significatif (tous les weights testes produisent des Sharpe negatifs)\n",
+    "\n",
+    "**Diagnostic** : le momentum FX \"pur\" (L/S, pas de filtre) ne fonctionne pas sur cette periode. La raison structurelle est que 2018-2026 est domine par le cycle de hausses de taux de la Fed — le dollar reste fort, et les signaux momentum sont contraries par les flux de taux d'interet. Il faut soit un filtre de regime (DXY), soit abandonner le L/S pour du long-only conditionnel."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "d2efc530",
    "metadata": {
     "papermill": {
-     "duration": 0.008658,
-     "end_time": "2026-05-03T22:42:03.797439+00:00",
+     "duration": 0.004536,
+     "end_time": "2026-05-25T22:01:56.281049+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:03.788781+00:00",
+     "start_time": "2026-05-25T22:01:56.276513+00:00",
      "status": "completed"
     },
     "tags": []
@@ -616,16 +649,16 @@
    "id": "b4d07782",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:03.815211Z",
-     "iopub.status.busy": "2026-05-03T22:42:03.814749Z",
-     "iopub.status.idle": "2026-05-03T22:42:06.537878Z",
-     "shell.execute_reply": "2026-05-03T22:42:06.536324Z"
+     "iopub.execute_input": "2026-05-25T22:01:56.291946Z",
+     "iopub.status.busy": "2026-05-25T22:01:56.291740Z",
+     "iopub.status.idle": "2026-05-25T22:01:57.675120Z",
+     "shell.execute_reply": "2026-05-25T22:01:57.674634Z"
     },
     "papermill": {
-     "duration": 2.7333,
-     "end_time": "2026-05-03T22:42:06.539050+00:00",
+     "duration": 1.38981,
+     "end_time": "2026-05-25T22:01:57.675658+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:03.805750+00:00",
+     "start_time": "2026-05-25T22:01:56.285848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -695,18 +728,37 @@
   {
    "cell_type": "markdown",
    "id": "0a87b46f",
-   "source": "### Interpretation: Long-only vs Long/Short\n\n**Conclusions** :\n- **Aucune configuration L/S ou Long-only n'est profitable** avec les parametres baseline (lookback 63/252, poids 0.6/0.4)\n- **L3/S3 full LS** (Sharpe 0.006) est la seule config proche du neutre. Plus de positions (3+3) lisse le bruit mais ne cree pas d'alpha\n- **Long-only** (L3/S0, L2/S0, L1/S0) : tous negatifs (Sharpe -0.17 a -0.26). Sans short, le signal momentum pur ne capture pas les tendances baissieres des devises\n- **L2/S2 current** (Sharpe -0.156) : la configuration originale perd de l'argent, confirmant le diagnostic BROKEN\n\n**Point important** : ces resultats ne condamnent pas le Long-only — ils montrent que le Long-only a besoin d'un filtre directionnel (DXY) pour fonctionner. Le Long-only sans filtre expose systematiquement a la force du dollar, qui domine 2018-2026 (fed tightening).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.006962,
+     "end_time": "2026-05-25T22:01:57.690228+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:01:57.683266+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Long-only vs Long/Short\n",
+    "\n",
+    "**Conclusions** :\n",
+    "- **Aucune configuration L/S ou Long-only n'est profitable** avec les parametres baseline (lookback 63/252, poids 0.6/0.4)\n",
+    "- **L3/S3 full LS** (Sharpe 0.006) est la seule config proche du neutre. Plus de positions (3+3) lisse le bruit mais ne cree pas d'alpha\n",
+    "- **Long-only** (L3/S0, L2/S0, L1/S0) : tous negatifs (Sharpe -0.17 a -0.26). Sans short, le signal momentum pur ne capture pas les tendances baissieres des devises\n",
+    "- **L2/S2 current** (Sharpe -0.156) : la configuration originale perd de l'argent, confirmant le diagnostic BROKEN\n",
+    "\n",
+    "**Point important** : ces resultats ne condamnent pas le Long-only — ils montrent que le Long-only a besoin d'un filtre directionnel (DXY) pour fonctionner. Le Long-only sans filtre expose systematiquement a la force du dollar, qui domine 2018-2026 (fed tightening)."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "89b0b878",
    "metadata": {
     "papermill": {
-     "duration": 0.010511,
-     "end_time": "2026-05-03T22:42:06.565182+00:00",
+     "duration": 0.007081,
+     "end_time": "2026-05-25T22:01:57.704288+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:06.554671+00:00",
+     "start_time": "2026-05-25T22:01:57.697207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -725,16 +777,16 @@
    "id": "2b0300eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:06.586843Z",
-     "iopub.status.busy": "2026-05-03T22:42:06.586474Z",
-     "iopub.status.idle": "2026-05-03T22:42:09.396626Z",
-     "shell.execute_reply": "2026-05-03T22:42:09.395019Z"
+     "iopub.execute_input": "2026-05-25T22:01:57.721188Z",
+     "iopub.status.busy": "2026-05-25T22:01:57.720861Z",
+     "iopub.status.idle": "2026-05-25T22:01:59.265133Z",
+     "shell.execute_reply": "2026-05-25T22:01:59.264684Z"
     },
     "papermill": {
-     "duration": 2.821976,
-     "end_time": "2026-05-03T22:42:09.397769+00:00",
+     "duration": 1.554531,
+     "end_time": "2026-05-25T22:01:59.266367+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:06.575793+00:00",
+     "start_time": "2026-05-25T22:01:57.711836+00:00",
      "status": "completed"
     },
     "tags": []
@@ -808,18 +860,38 @@
   {
    "cell_type": "markdown",
    "id": "d89194dd",
-   "source": "### Interpretation: Impact du nombre de paires\n\n**Conclusions** :\n- **4 diversified** (EURUSD, AUDUSD, USDJPY, USDCAD) : seul sous-ensemble avec un Sharpe positif (0.069). La diversification geographique (Europe, commodity, Asie, Ameriques) reduit la correlation tout en preservant le signal\n- **4 major** (EURUSD, GBPUSD, USDJPY, USDCHF) : Sharpe -0.017. Les paires europeennes (EUR, GBP, CHF) sont trop correlees entre elles\n- **5 sans NZD/CHF** : Sharpe -0.027. Ajouter GBPUSD aux 4 diversified n'apporte pas de diversification supplementaire\n- **3 commodity** (AUD, NZD, CAD) : Sharpe -0.399. Les devises commodity sont trop correlees et subissent les memes chocs\n- **All 7** : Sharpe -0.156. Redondance du signal, les paires correlees se neutralisent\n\n**Lecon** : la qualite de l'univers prime sur la quantite. 4 paires decorrelees > 7 paires correlees. Les devises \"commodity\" (AUD, NZD, CAD) forment un bloc correle qui dilue le signal momentum.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00819,
+     "end_time": "2026-05-25T22:01:59.283162+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:01:59.274972+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Impact du nombre de paires\n",
+    "\n",
+    "**Conclusions** :\n",
+    "- **4 diversified** (EURUSD, AUDUSD, USDJPY, USDCAD) : seul sous-ensemble avec un Sharpe positif (0.069). La diversification geographique (Europe, commodity, Asie, Ameriques) reduit la correlation tout en preservant le signal\n",
+    "- **4 major** (EURUSD, GBPUSD, USDJPY, USDCHF) : Sharpe -0.017. Les paires europeennes (EUR, GBP, CHF) sont trop correlees entre elles\n",
+    "- **5 sans NZD/CHF** : Sharpe -0.027. Ajouter GBPUSD aux 4 diversified n'apporte pas de diversification supplementaire\n",
+    "- **3 commodity** (AUD, NZD, CAD) : Sharpe -0.399. Les devises commodity sont trop correlees et subissent les memes chocs\n",
+    "- **All 7** : Sharpe -0.156. Redondance du signal, les paires correlees se neutralisent\n",
+    "\n",
+    "**Lecon** : la qualite de l'univers prime sur la quantite. 4 paires decorrelees > 7 paires correlees. Les devises \"commodity\" (AUD, NZD, CAD) forment un bloc correle qui dilue le signal momentum."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3b1a898c",
    "metadata": {
     "papermill": {
-     "duration": 0.013854,
-     "end_time": "2026-05-03T22:42:09.425974+00:00",
+     "duration": 0.008628,
+     "end_time": "2026-05-25T22:01:59.299802+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:09.412120+00:00",
+     "start_time": "2026-05-25T22:01:59.291174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -839,16 +911,16 @@
    "id": "51ff3291",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:09.454248Z",
-     "iopub.status.busy": "2026-05-03T22:42:09.453739Z",
-     "iopub.status.idle": "2026-05-03T22:42:12.381262Z",
-     "shell.execute_reply": "2026-05-03T22:42:12.379776Z"
+     "iopub.execute_input": "2026-05-25T22:01:59.317051Z",
+     "iopub.status.busy": "2026-05-25T22:01:59.316871Z",
+     "iopub.status.idle": "2026-05-25T22:02:00.779993Z",
+     "shell.execute_reply": "2026-05-25T22:02:00.779376Z"
     },
     "papermill": {
-     "duration": 2.943809,
-     "end_time": "2026-05-03T22:42:12.382374+00:00",
+     "duration": 1.472646,
+     "end_time": "2026-05-25T22:02:00.780651+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:09.438565+00:00",
+     "start_time": "2026-05-25T22:01:59.308005+00:00",
      "status": "completed"
     },
     "tags": []
@@ -934,18 +1006,38 @@
   {
    "cell_type": "markdown",
    "id": "a4bac7a2",
-   "source": "### Interpretation: Filtres DXY vs SPY SMA200\n\n**Conclusions** :\n- **Tous les filtres degradent la performance** par rapport au no-filter (Sharpe -0.156) dans le cadre L/S baseline. Aucun filtre ne rend le FX momentum L/S profitable\n- **SPY > SMA200** (Sharpe -0.312) : pire resultat. Le filtre equities est inadequat pour le FX — les regimes de marche equities ne correspondent pas aux regimes de devise\n- **DXY < SMA200** (Sharpe -0.200) : legerement meilleur que SPY mais toujours negatif. Le filtre DXY long terme est trop lent pour capturer les tendances FX\n- **DXY < SMA50** (Sharpe -0.464) : paradoxalement le pire filtre en mode L/S. Le DXY court reagir trop vite et cree des whipsaws\n- **SPY + DXY** (Sharpe -0.253) : la combinaison double le risque de manquer des opportunites\n\n**Insight important** : ces resultats negatifs s'expliquent parce que le test utilise la configuration L/S baseline (2 long, 2 short). Le filtre DXY ne prend son sens que combine avec un approche long-only (comme le montre la synthese v3e). Le DXY est un filtre directionnel, pas un filtre risk-on/off.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.009963,
+     "end_time": "2026-05-25T22:02:00.801727+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:02:00.791764+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Filtres DXY vs SPY SMA200\n",
+    "\n",
+    "**Conclusions** :\n",
+    "- **Tous les filtres degradent la performance** par rapport au no-filter (Sharpe -0.156) dans le cadre L/S baseline. Aucun filtre ne rend le FX momentum L/S profitable\n",
+    "- **SPY > SMA200** (Sharpe -0.312) : pire resultat. Le filtre equities est inadequat pour le FX — les regimes de marche equities ne correspondent pas aux regimes de devise\n",
+    "- **DXY < SMA200** (Sharpe -0.200) : legerement meilleur que SPY mais toujours negatif. Le filtre DXY long terme est trop lent pour capturer les tendances FX\n",
+    "- **DXY < SMA50** (Sharpe -0.464) : paradoxalement le pire filtre en mode L/S. Le DXY court reagir trop vite et cree des whipsaws\n",
+    "- **SPY + DXY** (Sharpe -0.253) : la combinaison double le risque de manquer des opportunites\n",
+    "\n",
+    "**Insight important** : ces resultats negatifs s'expliquent parce que le test utilise la configuration L/S baseline (2 long, 2 short). Le filtre DXY ne prend son sens que combine avec un approche long-only (comme le montre la synthese v3e). Le DXY est un filtre directionnel, pas un filtre risk-on/off."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "d5939e85",
    "metadata": {
     "papermill": {
-     "duration": 0.014929,
-     "end_time": "2026-05-03T22:42:12.411951+00:00",
+     "duration": 0.01087,
+     "end_time": "2026-05-25T22:02:00.822950+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:12.397022+00:00",
+     "start_time": "2026-05-25T22:02:00.812080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -963,16 +1055,16 @@
    "id": "84608db1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:12.442393Z",
-     "iopub.status.busy": "2026-05-03T22:42:12.441813Z",
-     "iopub.status.idle": "2026-05-03T22:42:14.842757Z",
-     "shell.execute_reply": "2026-05-03T22:42:14.841765Z"
+     "iopub.execute_input": "2026-05-25T22:02:00.847179Z",
+     "iopub.status.busy": "2026-05-25T22:02:00.846954Z",
+     "iopub.status.idle": "2026-05-25T22:02:02.305879Z",
+     "shell.execute_reply": "2026-05-25T22:02:02.305117Z"
     },
     "papermill": {
-     "duration": 2.417554,
-     "end_time": "2026-05-03T22:42:14.843864+00:00",
+     "duration": 1.47246,
+     "end_time": "2026-05-25T22:02:02.306738+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:12.426310+00:00",
+     "start_time": "2026-05-25T22:02:00.834278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1048,18 +1140,37 @@
   {
    "cell_type": "markdown",
    "id": "7d41c56b",
-   "source": "### Interpretation: Filtre de volatilite (regime)\n\n**Conclusions** :\n- **Vol < median** (Sharpe 0.041) : seul filtre de volatilite qui produit un Sharpe positif. Investir uniquement quand la volatilite FX est basse ameliore legerement la performance\n- **Vol < P75** (Sharpe -0.021) : seuil trop laxiste, laisse passer des regimes de volatilite encore dommageables\n- **SPY + Vol<P75** (Sharpe -0.180) : la combinaison avec le filtre SPY degrade le resultat, confirmant que le filtre equities est inapproprie pour le FX\n- **No filter** (Sharpe -0.156) : la strategie de base perd de l'argent sans filtre\n\n**Point cle** : le filtre de volatilite seul n'est pas suffisant pour rendre le FX momentum profitable. Il apporte une amelioration marginale (+0.197 de Sharpe vs no filter) mais reste insuffisant sans un filtre directionnel DXY. La combinaison volatilite + DXY serait a explorer.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.013251,
+     "end_time": "2026-05-25T22:02:02.334161+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:02:02.320910+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Filtre de volatilite (regime)\n",
+    "\n",
+    "**Conclusions** :\n",
+    "- **Vol < median** (Sharpe 0.041) : seul filtre de volatilite qui produit un Sharpe positif. Investir uniquement quand la volatilite FX est basse ameliore legerement la performance\n",
+    "- **Vol < P75** (Sharpe -0.021) : seuil trop laxiste, laisse passer des regimes de volatilite encore dommageables\n",
+    "- **SPY + Vol<P75** (Sharpe -0.180) : la combinaison avec le filtre SPY degrade le resultat, confirmant que le filtre equities est inapproprie pour le FX\n",
+    "- **No filter** (Sharpe -0.156) : la strategie de base perd de l'argent sans filtre\n",
+    "\n",
+    "**Point cle** : le filtre de volatilite seul n'est pas suffisant pour rendre le FX momentum profitable. Il apporte une amelioration marginale (+0.197 de Sharpe vs no filter) mais reste insuffisant sans un filtre directionnel DXY. La combinaison volatilite + DXY serait a explorer."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "22dd689a",
    "metadata": {
     "papermill": {
-     "duration": 0.014428,
-     "end_time": "2026-05-03T22:42:14.875276+00:00",
+     "duration": 0.013149,
+     "end_time": "2026-05-25T22:02:02.360591+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:14.860848+00:00",
+     "start_time": "2026-05-25T22:02:02.347442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1077,16 +1188,16 @@
    "id": "3b4f99ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:14.911621Z",
-     "iopub.status.busy": "2026-05-03T22:42:14.911229Z",
-     "iopub.status.idle": "2026-05-03T22:42:17.602586Z",
-     "shell.execute_reply": "2026-05-03T22:42:17.601182Z"
+     "iopub.execute_input": "2026-05-25T22:02:02.388628Z",
+     "iopub.status.busy": "2026-05-25T22:02:02.388414Z",
+     "iopub.status.idle": "2026-05-25T22:02:03.743839Z",
+     "shell.execute_reply": "2026-05-25T22:02:03.743133Z"
     },
     "papermill": {
-     "duration": 2.712715,
-     "end_time": "2026-05-03T22:42:17.604601+00:00",
+     "duration": 1.370409,
+     "end_time": "2026-05-25T22:02:03.744422+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:14.891886+00:00",
+     "start_time": "2026-05-25T22:02:02.374013+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1207,18 +1318,43 @@
   {
    "cell_type": "markdown",
    "id": "39bea02e",
-   "source": "### Interpretation: Synthese des configurations candidates\n\n**Classement final** :\n- **v3e** (3 pairs LO, short mom, DXY<SMA50) : Sharpe **1.687**, CAGR 3.5%, MaxDD -1.76% — clairement la meilleure configuration. Le filtre DXY court (SMA50) est le facteur cle, combiné avec un momentum court (21j dominant) et seulement 3 paires tres liquides\n- **v3a** (4 div, DXY filter) : Sharpe 0.501 — correct mais en deca de v3e. L'univers plus large (4 paires) dilue le signal\n- **v3d** (Top-1, DXY+SPY) : Sharpe 0.191 — le double filtre est trop restrictif\n- **v3c** (Minimal LS, no filter) : Sharpe -0.034 — sans filtre, le LS ne fonctionne pas\n- **Baseline** : Sharpe -0.312 — confirme la strategie actuelle est cassee\n- **v3b** (5 pairs, SPY+vol) : Sharpe -0.318 — le filtre SPY est inapproprie pour le FX\n\n**Facteurs de succes de v3e** :\n1. Momentum court (21j/126j, poids 0.7/0.3) : capture les tendances FX rapides\n2. DXY < SMA50 : n'investit que quand le dollar est en faiblesse recente\n3. 3 paires seulement (EURUSD, AUDUSD, USDJPY) : concentration sur les plus liquides\n4. Long-only avec position unique (top-1) : simplicite et evite l'exposition USD ambigue",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.013924,
+     "end_time": "2026-05-25T22:02:03.773117+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:02:03.759193+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation: Synthese des configurations candidates\n",
+    "\n",
+    "**Classement final** :\n",
+    "- **v3e** (3 pairs LO, short mom, DXY<SMA50) : Sharpe **1.687**, CAGR 3.5%, MaxDD -1.76% — clairement la meilleure configuration. Le filtre DXY court (SMA50) est le facteur cle, combiné avec un momentum court (21j dominant) et seulement 3 paires tres liquides\n",
+    "- **v3a** (4 div, DXY filter) : Sharpe 0.501 — correct mais en deca de v3e. L'univers plus large (4 paires) dilue le signal\n",
+    "- **v3d** (Top-1, DXY+SPY) : Sharpe 0.191 — le double filtre est trop restrictif\n",
+    "- **v3c** (Minimal LS, no filter) : Sharpe -0.034 — sans filtre, le LS ne fonctionne pas\n",
+    "- **Baseline** : Sharpe -0.312 — confirme la strategie actuelle est cassee\n",
+    "- **v3b** (5 pairs, SPY+vol) : Sharpe -0.318 — le filtre SPY est inapproprie pour le FX\n",
+    "\n",
+    "**Facteurs de succes de v3e** :\n",
+    "1. Momentum court (21j/126j, poids 0.7/0.3) : capture les tendances FX rapides\n",
+    "2. DXY < SMA50 : n'investit que quand le dollar est en faiblesse recente\n",
+    "3. 3 paires seulement (EURUSD, AUDUSD, USDJPY) : concentration sur les plus liquides\n",
+    "4. Long-only avec position unique (top-1) : simplicite et evite l'exposition USD ambigue"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "9f150a2e",
    "metadata": {
     "papermill": {
-     "duration": 0.022358,
-     "end_time": "2026-05-03T22:42:17.655637+00:00",
+     "duration": 0.014166,
+     "end_time": "2026-05-25T22:02:03.802231+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:17.633279+00:00",
+     "start_time": "2026-05-25T22:02:03.788065+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1249,16 +1385,16 @@
    "id": "4b6baf98",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T22:42:17.707716Z",
-     "iopub.status.busy": "2026-05-03T22:42:17.707419Z",
-     "iopub.status.idle": "2026-05-03T22:42:17.718229Z",
-     "shell.execute_reply": "2026-05-03T22:42:17.716769Z"
+     "iopub.execute_input": "2026-05-25T22:02:03.832549Z",
+     "iopub.status.busy": "2026-05-25T22:02:03.832323Z",
+     "iopub.status.idle": "2026-05-25T22:02:03.839338Z",
+     "shell.execute_reply": "2026-05-25T22:02:03.838789Z"
     },
     "papermill": {
-     "duration": 0.038698,
-     "end_time": "2026-05-03T22:42:17.719409+00:00",
+     "duration": 0.023777,
+     "end_time": "2026-05-25T22:02:03.840122+00:00",
      "exception": false,
-     "start_time": "2026-05-03T22:42:17.680711+00:00",
+     "start_time": "2026-05-25T22:02:03.816345+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1320,6 +1456,106 @@
     "    print('VERDICT: Le FX momentum ne fonctionne pas sur cette periode.')\n",
     "    print('Recommandation: pivoter vers une autre approche (carry dynamique, mean-reversion FX, ou autre asset class).')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b974f511",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012178,
+     "end_time": "2026-05-25T22:02:03.865597+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:02:03.853419+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Validation QC Cloud (2026-05-26)\n",
+    "\n",
+    "La configuration v3e (Sharpe 1.687 en yfinance) a ete validee sur QC Cloud avec\n",
+    "des donnees institutionnelles. **Resultat : le Sharpe yfinance n'est PAS reproductible.**\n",
+    "\n",
+    "| Test QC Cloud | Sharpe | CAGR% | MaxDD% | NetProfit% | Trades | Description |\n",
+    "|---------------|--------|-------|--------|------------|--------|-------------|\n",
+    "| v3e-SPY | -2.347 | -0.31 | 7.3 | -3.44 | 113 | SPY>SMA200 filter (adaptation) |\n",
+    "| v3e-EURUSD | -2.677 | -0.13 | 4.0 | -1.43 | 85 | EURUSD>SMA50 proxy DXY |\n",
+    "| v3f-no-filter | -1.111 | -0.54 | 19.2 | -6.03 | 348 | No filter, top-2, weekly |\n",
+    "| **SPY-Parking** | **0.476** | **10.93** | 17.7 | **133.57** | 221 | SPY core + FX overlay |\n",
+    "\n",
+    "**Cause de l'ecart yfinance vs QC Cloud** :\n",
+    "1. **Donnees differents** : yfinance = close ajustees gratuites, QC = bid/ask institutional avec slippage\n",
+    "2. **Filtre DXY indisponible** : QC Cloud n'a pas le ticker DXY (DX-Y.NYB), proxy EURUSD ne capture pas le meme signal\n",
+    "3. **Transaction costs** : FX a des spreads bid/ask significatifs sur les donnees QC qui ne sont pas modelises dans yfinance\n",
+    "4. **Survivorship / look-ahead** : le filtre DXY<SMA50 en yfinance peut beneficier d'un leger look-ahead dans les prix de cloture"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "782527be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-25T22:02:03.895663Z",
+     "iopub.status.busy": "2026-05-25T22:02:03.895450Z",
+     "iopub.status.idle": "2026-05-25T22:02:03.903181Z",
+     "shell.execute_reply": "2026-05-25T22:02:03.902323Z"
+    },
+    "papermill": {
+     "duration": 0.024288,
+     "end_time": "2026-05-25T22:02:03.903993+00:00",
+     "exception": false,
+     "start_time": "2026-05-25T22:02:03.879705+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== VALIDATION QC CLOUD (ForexCarry project 28657908) ===\n",
+      "Periode: 2015-01-01 a 2026-05-24\n",
+      "Cloud ID: 28657908 (ESGF_School org)\n",
+      "\n",
+      "               Test  Sharpe  CAGR%  MaxDD%  NetProfit%  Trades\n",
+      "     v3e-SPY filter  -2.347 -0.307     7.3      -3.444     113\n",
+      "   v3e-EURUSD proxy  -2.677 -0.126     4.0      -1.427      85\n",
+      " v3f-no-filter-top2  -1.111 -0.544    19.2      -6.028     348\n",
+      "SPY-Parking-CoreSat   0.476 10.931    17.7     133.571     221\n",
+      "\n",
+      "VERDICT: NO BEATS\n",
+      "Le momentum FX pur ne fonctionne pas sur QC Cloud.\n",
+      "La meilleure strategie existante est SPY-Parking-CoreSatellite (Sharpe 0.476).\n",
+      "\n",
+      "Ecart yfinance (1.687) vs QC Cloud (-2.677): 4.36 points de Sharpe.\n",
+      "Cause principale: filtre DXY non disponible + donnees institutionnelles.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Resume de la validation QC Cloud\n",
+    "qc_results = pd.DataFrame([\n",
+    "    {'Test': 'v3e-SPY filter', 'Sharpe': -2.347, 'CAGR%': -0.307, 'MaxDD%': 7.3, 'NetProfit%': -3.444, 'Trades': 113},\n",
+    "    {'Test': 'v3e-EURUSD proxy', 'Sharpe': -2.677, 'CAGR%': -0.126, 'MaxDD%': 4.0, 'NetProfit%': -1.427, 'Trades': 85},\n",
+    "    {'Test': 'v3f-no-filter-top2', 'Sharpe': -1.111, 'CAGR%': -0.544, 'MaxDD%': 19.2, 'NetProfit%': -6.028, 'Trades': 348},\n",
+    "    {'Test': 'SPY-Parking-CoreSat', 'Sharpe': 0.476, 'CAGR%': 10.931, 'MaxDD%': 17.7, 'NetProfit%': 133.571, 'Trades': 221},\n",
+    "])\n",
+    "\n",
+    "print('=== VALIDATION QC CLOUD (ForexCarry project 28657908) ===')\n",
+    "print(f'Periode: 2015-01-01 a 2026-05-24')\n",
+    "print(f'Cloud ID: 28657908 (ESGF_School org)')\n",
+    "print()\n",
+    "print(qc_results.to_string(index=False))\n",
+    "print()\n",
+    "print('VERDICT: NO BEATS')\n",
+    "print('Le momentum FX pur ne fonctionne pas sur QC Cloud.')\n",
+    "print('La meilleure strategie existante est SPY-Parking-CoreSatellite (Sharpe 0.476).')\n",
+    "print()\n",
+    "print('Ecart yfinance (1.687) vs QC Cloud (-2.677): 4.36 points de Sharpe.')\n",
+    "print('Cause principale: filtre DXY non disponible + donnees institutionnelles.')"
+   ]
   }
  ],
  "metadata": {
@@ -1342,14 +1578,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 43.083043,
-   "end_time": "2026-05-03T22:42:18.420090+00:00",
+   "duration": 29.631953,
+   "end_time": "2026-05-25T22:02:04.273338+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ForexCarry\\research.ipynb",
    "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\ForexCarry\\research_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-03T22:41:35.337047+00:00",
+   "start_time": "2026-05-25T22:01:34.641385+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary
- **3 QC Cloud backtests** validate FX momentum v3e config (yfinance Sharpe 1.687)
- **All 3 QC Cloud runs are negative**: Sharpe -2.677, -2.347, -1.111
- **Verdict: NO BEATS** — FX momentum is not reproducible on institutional data
- Best existing QC strategy: SPY-Parking-CoreSatellite (Sharpe 0.476, CAGR 10.9%)

## QC Cloud Results (project 28657908, 2015-2026)

| Test | Sharpe | CAGR% | MaxDD% | NetProfit% | Description |
|------|--------|-------|--------|------------|-------------|
| v3e-SPY | -2.347 | -0.31 | 7.3 | -3.44 | SPY>SMA200 filter |
| v3e-EURUSD | -2.677 | -0.13 | 4.0 | -1.43 | EURUSD>SMA50 proxy DXY |
| v3f-no-filter | -1.111 | -0.54 | 19.2 | -6.03 | No filter, top-2 weekly |
| SPY-Parking | **0.476** | **10.93** | 17.7 | **133.57** | Existing best |

## Why yfinance result (1.687) fails on QC Cloud
1. DXY ticker unavailable in QC — proxy EURUSD doesn't capture same signal
2. Institutional bid/ask spreads vs yfinance adjusted closes
3. FX transaction costs not modeled in yfinance backtest
4. Possible look-ahead bias in yfinance close prices

## Papermill execution
- 11/11 code cells executed, 0 errors, 31.5s
- H.3 check: PASSED (no cells with exec_count=None and no outputs)

## Next steps
- ForexCarry project should pivot to SPY-Parking-CoreSatellite improvement
- Or consider alternative FX approaches (mean-reversion, carry with dynamic rates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)