### PR TITLE
fix(semanticweb): nav/title BETA-readiness for SW Python sub-series (#999)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -14,9 +14,9 @@
     "tags": []
    },
    "source": [
-    "# SW-11-RDFStar\n",
+    "# SW-10-Python-RDFStar\n",
     "\n",
-    "**Navigation** : [<< 10-JSONLD](SW-10-JSONLD.ipynb) | [Index](README.md) | [12-KnowledgeGraphs >>](SW-12-KnowledgeGraphs.ipynb)\n",
+    "**Navigation** : [<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)\n",
     "\n",
     "## RDF 1.2 (RDF-Star) : Assertions sur des Assertions\n",
     "\n",
@@ -43,7 +43,7 @@
     "\n",
     "### Prerequis\n",
     "- Python 3.10+\n",
-    "- Notebook [SW-8-PythonRDF](SW-8-PythonRDF.ipynb) (bases rdflib)\n",
+    "- Notebook [SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb) (bases rdflib)\n",
     "- rdflib >= 7.0\n",
     "\n",
     "### Note sur le support RDF-Star dans rdflib\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -14,9 +14,9 @@
     "tags": []
    },
    "source": [
-    "# SW-13-GraphRAG\n",
+    "# SW-12-Python-GraphRAG\n",
     "\n",
-    "**Navigation** : [<< 12-KnowledgeGraphs](SW-12-KnowledgeGraphs.ipynb) | [Index](README.md)\n",
+    "**Navigation** : [<< 11-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) | [Index](README.md) | [13-Reasoners >>](SW-13-Python-Reasoners.ipynb)\n",
     "\n",
     "## GraphRAG : Graphes de Connaissances et LLMs\n",
     "\n",
@@ -46,7 +46,7 @@
     "\n",
     "### Prerequis\n",
     "- Python 3.10+\n",
-    "- Notebook [SW-12-KnowledgeGraphs](SW-12-KnowledgeGraphs.ipynb) (construction de KG avec rdflib)\n",
+    "- Notebook [SW-11-Python-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb) (construction de KG avec rdflib)\n",
     "- (Optionnel) Cle API OpenAI ou Anthropic (le notebook fonctionne sans grace aux donnees de demonstration)"
    ]
   },


### PR DESCRIPTION
## Summary

Epic #999 (SymbolicAI modernisation) side-track on the 5 SemanticWeb **Python** notebooks (SW-8..SW-12).

**Honest scoping finding:** all 5 notebooks were already fully pedagogically enriched (0 consecutive code cells; intro + interpretation cells throughout; nav headers, learning objectives, concept tables, exercises/examples) and fully executed (0 cells in error). **There was no enrichment gap to fill.** Adding generic filler markdown would violate the anti-duplication / no-generic-content / no-pendulum rules, so I did not.

The only genuine BETA-readiness defects were **stale title + navigation/prereq links** left over from an earlier file renumbering. This PR fixes exactly those, markdown-only.

## Per-notebook changes

### `SW-10-Python-RDFStar.ipynb` (header-nav cell, index 0 — markdown)
- Title `# SW-11-RDFStar` -> `# SW-10-Python-RDFStar`
- Nav `[<< 10-JSONLD](SW-10-JSONLD.ipynb) | [Index] | [12-KnowledgeGraphs >>](SW-12-KnowledgeGraphs.ipynb)` -> `[<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index] | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)`
- Prereq `[SW-8-PythonRDF](SW-8-PythonRDF.ipynb)` -> `[SW-8-Python-SHACL](SW-8-Python-SHACL.ipynb)`

### `SW-12-Python-GraphRAG.ipynb` (header-nav cell, index 0 — markdown)
- Title `# SW-13-GraphRAG` -> `# SW-12-Python-GraphRAG`
- Nav back-link `[<< 12-KnowledgeGraphs](SW-12-KnowledgeGraphs.ipynb)` -> `[<< 11-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb)`, **added** forward link `[13-Reasoners >>](SW-13-Python-Reasoners.ipynb)` (judgment call — target verified to exist)
- Prereq `[SW-12-KnowledgeGraphs](SW-12-KnowledgeGraphs.ipynb)` -> `[SW-11-Python-KnowledgeGraphs](SW-11-Python-KnowledgeGraphs.ipynb)`

### Left unchanged (with reason)
- `SW-8-Python-SHACL.ipynb`, `SW-9-Python-JSONLD.ipynb`, `SW-11-Python-KnowledgeGraphs.ipynb` — headers already correct, already fully enriched, 0 consecutive code cells.

## §D notebook-PR checklist
1. **Execution proof**: not re-executed — change is **markdown-only** (header cell). All code cells remain executed with outputs intact (SW-10: 19/19, SW-12: 15/15), 0 errors. Re-execution not required under C.2 (markdown-only exception).
2. **0 NotImplementedError / volontary errors**: unchanged (no code touched).
3. **Cells = `execution_count: <int>` + `outputs: [...]` coherent**: preserved — diff-guard confirms **0 changes** to lines matching `execution_count` / `outputs` / code-cell `data`/`text`.
4. **No `# Solution` / `# Exemple resolu` cell deleted**: no cell deleted, no relabel, no stub, no Exemple<->Exercice conversion.

## Verification run
- `git diff --stat`: 2 files, **8 insertions / 8 deletions** (all inside markdown `source` arrays, + benign EOF newline normalization).
- **Diff-guard**: `CLEAN: no execution_count/outputs/code-data lines changed`.
- **JSON valid** on both; cell 0 confirmed `markdown`; code cells executed=19/19 & 15/15, errors=0.
- All nav/prereq link targets confirmed to exist on disk (SW-8/9/11/13 Python files present).

Markdown-only, **0 code/output/execution_count touched (C.2)**. Scope: only the 2 notebooks with defects staged by explicit name (the 8 pre-existing unrelated `sudoku_models/*.pt` worktree modifications were **not** staged).

Do not self-merge — ai-01 coordinator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
