### PR TITLE
fix(search): reorder Search-7-MCTS Exemple guide headings before their code (#1562)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
@@ -1211,6 +1211,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cdfd37bf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004693,
+     "end_time": "2026-05-23T01:52:32.806935",
+     "exception": false,
+     "start_time": "2026-05-23T01:52:32.802242",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple resolu : Analyse de convergence MCTS\n",
+    "\n",
+    "La convergence est une propriete fondamentale de MCTS : plus on augmente le nombre d'iterations, plus la decision se rapproche de l'optimal. L'exemple ci-dessous mesure cette convergence quantitativement sur TicTacToe en comparant l'action choisie par MCTS a l'action optimale Minimax (verite terrain). Les trois graphiques montrent respectivement le taux de choix optimal, la valeur estimee, et le temps de calcul."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "rhge3yrtj9e",
@@ -1416,21 +1435,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdfd37bf",
+   "id": "f14e3762",
    "metadata": {
     "papermill": {
-     "duration": 0.004693,
-     "end_time": "2026-05-23T01:52:32.806935",
+     "duration": 0.01364,
+     "end_time": "2026-05-23T01:52:34.040499",
      "exception": false,
-     "start_time": "2026-05-23T01:52:32.802242",
+     "start_time": "2026-05-23T01:52:34.026859",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exemple resolu : Analyse de convergence MCTS\n",
+    "### Exemple resolu : MCTS sur le jeu de Nim\n",
     "\n",
-    "La convergence est une propriete fondamentale de MCTS : plus on augmente le nombre d'iterations, plus la decision se rapproche de l'optimal. L'exemple ci-dessous mesure cette convergence quantitativement sur TicTacToe en comparant l'action choisie par MCTS a l'action optimale Minimax (verite terrain). Les trois graphiques montrent respectivement le taux de choix optimal, la valeur estimee, et le temps de calcul."
+    "Le jeu de **Nim** est un cas ideal pour comprendre MCTS : l'espace d'etats est petit et la strategie optimale est connue mathematiquement (laisser un multiple de 4 allumettes a l'adversaire). L'exemple ci-dessous montre comment MCTS peut decouvrir cette strategie par simulation, et compare ses performances contre un joueur optimal.\n",
+    "\n",
+    "Observez comment le taux de victoire de MCTS varie en fonction du nombre d'iterations et du fait que MCTS joue en premier ou en second."
    ]
   },
   {
@@ -1560,27 +1581,6 @@
     "print(f\"  Victoires MCTS: {victoires_mcts}/{n_parties}\")\n",
     "print(f\"  Nulles: {nulles}/{n_parties}\")\n",
     "print(f\"  Victoires strategie optimale: {n_parties - victoires_mcts - nulles}/{n_parties}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f14e3762",
-   "metadata": {
-    "papermill": {
-     "duration": 0.01364,
-     "end_time": "2026-05-23T01:52:34.040499",
-     "exception": false,
-     "start_time": "2026-05-23T01:52:34.026859",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exemple resolu : MCTS sur le jeu de Nim\n",
-    "\n",
-    "Le jeu de **Nim** est un cas ideal pour comprendre MCTS : l'espace d'etats est petit et la strategie optimale est connue mathematiquement (laisser un multiple de 4 allumettes a l'adversaire). L'exemple ci-dessous montre comment MCTS peut decouvrir cette strategie par simulation, et compare ses performances contre un joueur optimal.\n",
-    "\n",
-    "Observez comment le taux de victoire de MCTS varie en fonction du nombre d'iterations et du fait que MCTS joue en premier ou en second."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Structural reorg of the `## Exemple guide` section in
`MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb`.
Authorized by DISPATCH S-0525 as a **dedicated PR, separate from labeling**.

Each `### Exemple resolu` markdown heading sat **after** its matching code cell,
producing an off-by-one where every heading described the code *above* it and the
Nim heading misleadingly preceded the Exercice 5 code.

| | before | after |
|---|---|---|
| section | `## Exemple guide` | `## Exemple guide` |
| 1 | code: convergence | **md: convergence heading** |
| 2 | md: convergence heading | **code: convergence** |
| 3 | code: Nim | **md: Nim heading** |
| 4 | md: Nim heading | **code: Nim** |
| 5 | code: Exercice 5 | code: Exercice 5 |

Result: each heading now precedes its matching code.

## What this is NOT

- **No labeling change.** Both worked examples stay `### Exemple resolu` (genuine
  complete solutions — verified content-based, anti-#1214). No relabel, no stub,
  no `Exemple`↔`Exercice` flip.
- **No TOC fix.** The dispatch mentioned "TOC md#24", but full-read shows cell #24
  (`## Exemple guide`) is a section **intro listing the two examples**, not a
  clickable table of contents (notebook has zero `](#…)` anchor links). Nothing to fix there.

## Proof / verification

- Pure markdown-cell reposition — script swaps each heading with its code cell.
- `git diff`: **27 insertions / 27 deletions**, all inside the two markdown cells
  (`cdfd37bf` convergence, `f14e3762` Nim). **0** lines touching
  `execution_count` / `outputs` / `data` / `text` of any code cell.
- Code cell sources, outputs and exec_counts **byte-identical**; exec_counts stay
  monotonic `[1..16]` in document order → **no Papermill re-execution required**
  (C.2 markdown-reorder exception).
- JSON valid, `nbformat: 4`, 41 cells (unchanged), 16 code cells.
- H.3 pre-commit: 0 code cells with `execution_count is None and not outputs`.
- 0 cells deleted, 0 solutions stubbed (anti-regression / labeling rules respected).

Tracks #1455 / #1562 Phase 2. ai-01 to merge (no self-merge).