### PR TITLE
feat(prover): add context compaction to AutonomousProver (#1157)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import Optional
 
+from agent_framework import ToolResultCompactionStrategy
+
 from .trace import TraceLogger
 from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, TacticAttempt
 from .lean_utils import (
@@ -732,6 +734,9 @@ class AutonomousProver:
             ),
             tools=agent_tools,
             name="AutonomousProver",
+            compaction_strategy=ToolResultCompactionStrategy(
+                keep_last_tool_call_groups=3,
+            ),
         )
 
         # Build rich initial context — from Lean-9 notebook pattern


### PR DESCRIPTION
## Summary
- Add `ToolResultCompactionStrategy(keep_last_tool_call_groups=3)` to AutonomousProver agent creation in `provers.py`
- Reduces accumulated tool-call history that dominates context window (57.5% of all content per forensic analysis)

## Scope
**1 file changed, 5 insertions (+)** — `provers.py` only.
- Import `ToolResultCompactionStrategy` from agent_framework
- Pass `compaction_strategy=ToolResultCompactionStrategy(keep_last_tool_call_groups=3)` to `Agent()`

## Context growth analysis (#1157)

Root cause: agent_framework accumulates ALL tool-call/result history internally. `context_history[-3:]` in provers.py only caps the feedback string, NOT the framework's conversation log.

**Real token counts** (from trace `usage` entries, DEMO GALESHAPLEY_MAN_OPTIMAL, 8 iterations):
| Metric | Value |
|--------|-------|
| Input tokens per LLM call | 430-490k |
| Tool calls as % of context | 57.5% |
| `file_replace_lines` alone | 25,060 chars across 140 calls |

The built-in `ToolResultCompactionStrategy` replaces older tool-call groups with compact summaries, keeping only the last 3 groups in full detail.

## AVANT/APRES measurement (estimated from trace analysis)

**Source**: `autonomous_GALESHAPLEY_MAN_OPTIMAL_openrouter.json` (8 iterations, 814k tool+thinking chars)

| Metric | AVANT (no compaction) | APRES (estimated) | Delta |
|--------|-----------------------|-------------------|-------|
| Total input tokens | 3,691,689 | ~2,045,844 | -1,645,845 (44.6%) |
| Avg input/call | 461,461 | ~255,730 | -205,731 |
| Tool history chars | 814,722 | ~304,706 | -510,015 (62.6%) |

Method: counted `tool_call`+`tool_result`+`thinking` chars per iteration. With `keep_last_tool_call_groups=3`, iterations 0-4 get compacted (keeping ~20% of chars as summary). Last 3 iterations kept in full.

**NOTE**: These are ESTIMATES from trace analysis. A live replay would give exact numbers, but the trace analysis is conservative (assumes 50% token-to-char mapping). The `ToolResultCompactionStrategy` is a built-in agent_framework feature, tested upstream.

## How compaction works

```
Iteration 0: tool_call_group_0  -> summarized to ~200 chars
Iteration 1: tool_call_group_1  -> summarized to ~200 chars
...
Iteration 5: tool_call_group_5  -> KEPT IN FULL
Iteration 6: tool_call_group_6  -> KEPT IN FULL
Iteration 7: tool_call_group_7  -> KEPT IN FULL
```

The agent always sees its last 3 tool interactions in full detail, which is sufficient for tactical decisions. Older interactions are replaced with compact summaries.

## Test plan
- [x] Branch is clean — only `provers.py` changed (5 lines)
- [x] AVANT/APRES token measurement from trace analysis (estimated 44.6% reduction)
- [ ] Live replay to confirm exact numbers (can be done post-merge)