### PR TITLE
feat(qc): Quality+LowVol factor tilt — NO BEATS (#35 strategy 5, final)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_quality_lowvol.ipynb
@@ -1,0 +1,401 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recherche Stratégie #5 : Quality + Low Volatility Factor Tilt\n",
+    "\n",
+    "**EPIC #1409 — Curriculum Trading V3, Issue #35 Stratégie 5**  \n",
+    "**Branche** : `feature/quality-lowvol-research`  \n",
+    "**Date** : 2026-05-26 | **Auteur** : myia-po-2024\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "| # | Stratégie | Verdict | PR |\n",
+    "|---|-----------|---------|-----|\n",
+    "| 1 | Dual Momentum (L2) | NO BEATS | #1575 |\n",
+    "| 2 | Risk Parity | NO BEATS | #1578 |\n",
+    "| 3 | Trend Following (L1 TSMOM) | NO BEATS | #1574 |\n",
+    "| 4 | VRP Put-Write | NO BEATS | #1579 |\n",
+    "| **5** | **Quality + LowVol** | **En cours** | **Ce notebook** |\n",
+    "\n",
+    "## Objectifs d'apprentissage\n",
+    "\n",
+    "1. Comprendre les facteurs Quality (qualité des bénéfices) et Low Volatility (anomalie low-vol)\n",
+    "2. Implémenter un scoring combiné qualité + low-vol sur le panier multi-actifs\n",
+    "3. Comparer un portefeuille factor-tilted vs equal-weight B&H via walk-forward 5-fold × 4 seeds\n",
+    "\n",
+    "## Hypothèse\n",
+    "\n",
+    "Les actifs de haute qualité (momentum positif, Sharpe élevé) et faible volatilité surperforment\n",
+    "en termes de ratio risque-rendement. Le tilt factoriel mensuel pourrait générer un Sharpe > B&H.\n",
+    "\n",
+    "## Prérequis\n",
+    "\n",
+    "- Python 3.10+, pandas, numpy, yfinance\n",
+    "- Panier anti-bias 25 symboles (L1/L2/L3 data)\n",
+    "\n",
+    "**Durée estimée** : 15 min"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Panier: 25 symbols, 2957 jours (business days only)\n",
+      "Periode: 2015-01-01 -> 2026-05-01\n",
+      "Symbols: ['SPY', 'RSP', 'IWM', 'XLF', 'XLK', 'XLV', 'XLY', 'XLP', 'XLI', 'XLU', 'XLB', 'XLRE', 'XLC', 'TLT', 'IEF', 'SHY', 'GLD', 'USO', 'DBA', 'EFA', 'EEM', 'BTC-USD', 'ETH-USD', 'LTC-USD', 'XRP-USD']\n"
+     ]
+    }
+   ],
+   "source": "import numpy as np\nimport pandas as pd\nfrom pathlib import Path\n\n# Config\nPANIER_CSV = Path(\"c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/datasets/panier/panier_close_all.csv\")\nLOOKBACK = 252           # 1y lookback for factor scoring\nVOL_LOOKBACK = 63        # 3m volatility\nREBAL_FREQ = 21          # monthly rebalance\nN_LONG = 8               # top N assets to hold\nTX_COST = 0.001          # 10bps transaction cost per trade\nSEEDS = [0, 1, 7, 42]\nN_SPLITS = 5\nFEE_BPS = 10\n\n# Load panier\ndf = pd.read_csv(PANIER_CSV, index_col=0, parse_dates=True)\ndf.index = pd.DatetimeIndex(df.index)\ndf = df.sort_index()\n# Exclude VIX (volatility index, no price return)\nexclude = ['VIX']\ncols = [c for c in df.columns if c not in exclude]\nprices = df[cols].ffill().dropna(how='all')\n# Keep only business days for fair comparison (crypto has 365d, equities only weekdays)\nprices = prices[prices.index.dayofweek < 5]\nprint(f\"Panier: {prices.shape[1]} symbols, {prices.shape[0]} jours (business days only)\")\nprint(f\"Periode: {prices.index.min().date()} -> {prices.index.max().date()}\")\nprint(f\"Symbols: {list(prices.columns)}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Construction des scores factoriels\n",
+    "\n",
+    "On combine deux signaux :\n",
+    "- **Quality** : rendement annualisé sur la période de lookback (proxy pour la qualité)\n",
+    "- **Low Volatility** : volatilité inverse (1/vol) — préférer les actifs moins volatils\n",
+    "\n",
+    "Le score composite normalise chaque facteur (z-score cross-sectionnel) puis les combine 50/50."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Factor scores: 128 mois x 25 symboles\n",
+      "Valid scores per row: min=21, median=25.0, max=25\n",
+      "\n",
+      "Dernier mois top-5:\n",
+      "  SHY     : score = +2.061\n",
+      "  USO     : score = +1.133\n",
+      "  GLD     : score = +0.342\n",
+      "  EEM     : score = +0.279\n",
+      "  IEF     : score = +0.264\n",
+      "\n",
+      "Dernier mois bottom-3:\n",
+      "  BTC-USD : score = -0.954\n",
+      "  XRP-USD : score = -1.335\n",
+      "  LTC-USD : score = -1.368\n"
+     ]
+    }
+   ],
+   "source": "def compute_factor_scores(prices: pd.DataFrame, lookback: int = 252, vol_lb: int = 63) -> pd.DataFrame:\n    \"\"\"Compute monthly quality + low-vol factor scores.\n    \n    Quality = annualized return over lookback (momentum as quality proxy).\n    Low Vol = inverse of realized vol over vol_lb.\n    Score = 0.5 * z(quality) + 0.5 * z(low_vol)\n    \"\"\"\n    ret = prices.pct_change()\n    # Quality: rolling annualized return\n    quality = ret.rolling(lookback, min_periods=int(lookback * 0.8)).mean() * 252\n    # Low vol: inverse of rolling vol\n    vol = ret.rolling(vol_lb, min_periods=int(vol_lb * 0.8)).std() * 252**0.5\n    low_vol = 1.0 / vol.replace(0, np.nan)\n    \n    # Resample to monthly (end of month)\n    quality_m = quality.resample('ME').last()\n    low_vol_m = low_vol.resample('ME').last()\n    \n    # Cross-sectional z-score each month\n    def zscore_cross(row):\n        valid = row.dropna()\n        if len(valid) < 3:\n            return pd.Series(np.nan, index=row.index)\n        mu, sd = valid.mean(), valid.std()\n        if sd < 1e-12:\n            return pd.Series(0.0, index=row.index)\n        return (row - mu) / sd\n    \n    q_z = quality_m.apply(zscore_cross, axis=1)\n    lv_z = low_vol_m.apply(zscore_cross, axis=1)\n    \n    composite = 0.5 * q_z + 0.5 * lv_z\n    return composite.dropna(how='all')\n\nscores = compute_factor_scores(prices)\n# Check coverage\nvalid_per_row = scores.notna().sum(axis=1)\nprint(f\"Factor scores: {scores.shape[0]} mois x {scores.shape[1]} symboles\")\nprint(f\"Valid scores per row: min={valid_per_row.min()}, median={valid_per_row.median()}, max={valid_per_row.max()}\")\nprint(f\"\\nDernier mois top-5:\")\nlast = scores.iloc[-1].dropna().sort_values(ascending=False)\nfor sym, val in last.head(5).items():\n    print(f\"  {sym:8s}: score = {val:+.3f}\")\nprint(f\"\\nDernier mois bottom-3:\")\nfor sym, val in last.tail(3).items():\n    print(f\"  {sym:8s}: score = {val:+.3f}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Backtest factor-tilted portfolio\n",
+    "\n",
+    "A chaque fin de mois, on sélectionne les `N_LONG` meilleurs actifs selon le score composite.\n",
+    "Le portefeuille est equal-weight parmi les sélectionnés. On compare à B&H equal-weight tous les actifs.\n",
+    "Coûts de transaction : `TX_COST` par trade (rotation mensuelle)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\n",
+      "Backtest Quality+LowVol: 127 mois, top-8, tx=10bps\n",
+      "======================================================================\n",
+      "Factor tilt: Sharpe=0.945, CAGR=25.43%\n",
+      "B&H equal:   Sharpe=0.967, CAGR=21.09%\n",
+      "Delta Sharpe: -0.022\n",
+      "\n",
+      "Cumulative: Factor=11.00x, B&H=7.58x\n"
+     ]
+    }
+   ],
+   "source": "def run_factor_tilt_backtest(prices: pd.DataFrame, scores: pd.DataFrame, n_long: int = 8,\n                            tx_cost: float = 0.001) -> pd.DataFrame:\n    \"\"\"Run monthly factor-tilted backtest.\n    \n    Each month: select top n_long by composite score, equal-weight.\n    Returns net of tx costs on position changes.\n    \"\"\"\n    ret = prices.pct_change()\n    # Monthly returns (next month after signal)\n    monthly_ret = ret.resample('ME').apply(lambda x: (1+x).prod()-1)\n    \n    signal_dates = scores.index\n    ret_dates = monthly_ret.index\n    \n    factor_ret = []\n    bh_ret = []\n    dates = []\n    prev_holdings = None\n    \n    for i in range(len(signal_dates) - 1):\n        sig_date = signal_dates[i]\n        future_rets = ret_dates[ret_dates > sig_date]\n        if len(future_rets) == 0:\n            break\n        ret_date = future_rets[0]\n        if ret_date not in monthly_ret.index:\n            continue\n        \n        row_scores = scores.loc[sig_date].dropna()\n        if len(row_scores) < n_long:\n            continue\n        selected = row_scores.nlargest(n_long).index.tolist()\n        \n        next_ret = monthly_ret.loc[ret_date]\n        valid_selected = [s for s in selected if s in next_ret.index and not np.isnan(next_ret[s])]\n        if len(valid_selected) < 3:\n            continue\n        port_ret = next_ret[valid_selected].mean()\n        \n        if prev_holdings is not None:\n            turnover = len(set(valid_selected) - set(prev_holdings)) + len(set(prev_holdings) - set(valid_selected))\n            turnover_frac = turnover / (2 * n_long)\n            port_ret -= turnover_frac * tx_cost\n        else:\n            port_ret -= tx_cost\n        \n        all_valid = next_ret.dropna()\n        bh = all_valid.mean()\n        \n        factor_ret.append(port_ret)\n        bh_ret.append(bh)\n        dates.append(ret_date)\n        prev_holdings = valid_selected\n    \n    result = pd.DataFrame({\n        'factor': factor_ret,\n        'bh': bh_ret\n    }, index=pd.DatetimeIndex(dates))\n    return result\n\nbt = run_factor_tilt_backtest(prices, scores, n_long=N_LONG, tx_cost=TX_COST)\n\ndef sharpe_ann(returns):\n    if len(returns) < 3:\n        return float('nan')\n    mu = returns.mean()\n    sigma = returns.std()\n    if sigma < 1e-12:\n        return float('nan')\n    return (mu / sigma) * 12**0.5\n\nfactor_sharpe = sharpe_ann(bt['factor'])\nbh_sharpe = sharpe_ann(bt['bh'])\n\nif len(bt) > 0:\n    factor_cagr = (1 + bt['factor']).prod() ** (12/len(bt)) - 1\n    bh_cagr = (1 + bt['bh']).prod() ** (12/len(bt)) - 1\nelse:\n    factor_cagr = bh_cagr = float('nan')\n\nprint(f\"{'='*70}\")\nprint(f\"Backtest Quality+LowVol: {len(bt)} mois, top-{N_LONG}, tx={TX_COST*10000:.0f}bps\")\nprint(f\"{'='*70}\")\nprint(f\"Factor tilt: Sharpe={factor_sharpe:.3f}, CAGR={factor_cagr:.2%}\")\nprint(f\"B&H equal:   Sharpe={bh_sharpe:.3f}, CAGR={bh_cagr:.2%}\")\nprint(f\"Delta Sharpe: {factor_sharpe - bh_sharpe:+.3f}\")\nif len(bt) > 0:\n    print(f\"\\nCumulative: Factor={(1+bt['factor']).prod():.2f}x, B&H={(1+bt['bh']).prod():.2f}x\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Walk-forward 5-fold + multi-seed\n",
+    "\n",
+    "Validation robuste : walk-forward 5-fold expanding avec 4 seeds.\n",
+    "Le seed injecte du bruit dans le score (jitter gaussien) pour tester la robustesse du signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\n",
+      "Walk-forward 5-fold\n",
+      "======================================================================\n",
+      " fold  n_oos  factor_sharpe  bh_sharpe     delta\n",
+      "    1     21       0.640845   0.861770 -0.220925\n",
+      "    2     21       1.107810   1.166909 -0.059100\n",
+      "    3     21       0.682636   0.328944  0.353693\n",
+      "    4     21       1.014054   1.359021 -0.344967\n",
+      "    5     21       1.030027   1.159971 -0.129944\n",
+      "\n",
+      "Mean OOS Sharpe:\n",
+      "  Factor tilt: 0.895\n",
+      "  B&H equal:   0.975\n",
+      "  Delta:       -0.080\n",
+      "\n",
+      "============================================================\n",
+      "Multi-seed robustness (4 seeds)\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " seed   sharpe     cagr    max_dd\n",
+      "    0 0.947965 0.253677 -0.298487\n",
+      "    1 0.932791 0.249963 -0.392325\n",
+      "    7 1.040822 0.276956 -0.355309\n",
+      "   42 0.844029 0.219050 -0.478400\n",
+      "\n",
+      "Std Sharpe: 0.0806\n",
+      "Sharpe original: 0.9451\n",
+      "Sharpe moyen bruite: 0.9414\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'='*70}\")\n",
+    "print(f\"Walk-forward 5-fold\")\n",
+    "print(f\"{'='*70}\")\n",
+    "\n",
+    "n = len(bt)\n",
+    "fold_size = n // (N_SPLITS + 1)\n",
+    "\n",
+    "wf_results = []\n",
+    "for k in range(1, N_SPLITS + 1):\n",
+    "    tr_end = fold_size * k\n",
+    "    te_end = min(tr_end + fold_size, n)\n",
+    "    if te_end - tr_end < 10:\n",
+    "        continue\n",
+    "    \n",
+    "    # Use bt data directly (already computed factor scores on full history)\n",
+    "    # For walk-forward, we take the pre-computed returns and split\n",
+    "    test_slice = bt.iloc[tr_end:te_end]\n",
+    "    f_sharpe = sharpe_ann(test_slice['factor'])\n",
+    "    b_sharpe = sharpe_ann(test_slice['bh'])\n",
+    "    wf_results.append({\n",
+    "        'fold': k, 'n_oos': len(test_slice),\n",
+    "        'factor_sharpe': f_sharpe, 'bh_sharpe': b_sharpe,\n",
+    "        'delta': f_sharpe - b_sharpe\n",
+    "    })\n",
+    "\n",
+    "wf_df = pd.DataFrame(wf_results)\n",
+    "print(wf_df[['fold', 'n_oos', 'factor_sharpe', 'bh_sharpe', 'delta']].to_string(index=False))\n",
+    "print(f\"\\nMean OOS Sharpe:\")\n",
+    "print(f\"  Factor tilt: {wf_df['factor_sharpe'].mean():.3f}\")\n",
+    "print(f\"  B&H equal:   {wf_df['bh_sharpe'].mean():.3f}\")\n",
+    "print(f\"  Delta:       {wf_df['delta'].mean():+.3f}\")\n",
+    "\n",
+    "# Multi-seed: add noise to scores and re-run\n",
+    "print(f\"\\n{'='*60}\")\n",
+    "print(f\"Multi-seed robustness ({len(SEEDS)} seeds)\")\n",
+    "print(f\"{'='*60}\")\n",
+    "\n",
+    "seed_results = []\n",
+    "for seed in SEEDS:\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    # Add noise to composite scores\n",
+    "    noisy_scores = scores.copy()\n",
+    "    for col in noisy_scores.columns:\n",
+    "        noise = rng.normal(0, 0.5, len(noisy_scores))  # z-score noise\n",
+    "        noisy_scores[col] = noisy_scores[col] + noise\n",
+    "    \n",
+    "    try:\n",
+    "        bt_seed = run_factor_tilt_backtest(prices, noisy_scores.dropna(how='all'),\n",
+    "                                           n_long=N_LONG, tx_cost=TX_COST)\n",
+    "        if len(bt_seed) < 12:\n",
+    "            continue\n",
+    "        s_sharpe = sharpe_ann(bt_seed['factor'])\n",
+    "        s_cagr = (1 + bt_seed['factor']).prod() ** (12/len(bt_seed)) - 1\n",
+    "        max_dd = ((1+bt_seed['factor']).cumprod() / (1+bt_seed['factor']).cumprod().cummax() - 1).min()\n",
+    "        seed_results.append({\n",
+    "            'seed': seed, 'sharpe': s_sharpe, 'cagr': s_cagr, 'max_dd': max_dd\n",
+    "        })\n",
+    "    except Exception as e:\n",
+    "        print(f\"  Seed {seed}: ERROR {e}\")\n",
+    "\n",
+    "seed_df = pd.DataFrame(seed_results)\n",
+    "if len(seed_df) > 0:\n",
+    "    print(seed_df[['seed', 'sharpe', 'cagr', 'max_dd']].to_string(index=False))\n",
+    "    print(f\"\\nStd Sharpe: {seed_df['sharpe'].std():.4f}\")\n",
+    "    print(f\"Sharpe original: {factor_sharpe:.4f}\")\n",
+    "    print(f\"Sharpe moyen bruite: {seed_df['sharpe'].mean():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Analyse par régime de marché\n",
+    "\n",
+    "On classifie chaque mois en régime Bull/Neutral/Bear selon le rendement SPY sur 6 mois."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "Performance par regime de marche\n",
+      "============================================================\n",
+      "Bull    :  49 mois, Sharpe +1.705, CAGR +70.64%, Vol 35.36%\n",
+      "Neutral :  74 mois, Sharpe +0.528, CAGR +8.83%, Vol 19.62%\n",
+      "Bear    :   4 mois, Sharpe -6.014, CAGR -60.09%, Vol 14.56%\n",
+      "\n",
+      "--- B&H equal par regime ---\n",
+      "Bull    :  49 mois, CAGR +54.94%\n",
+      "Neutral :  74 mois, CAGR +11.20%\n",
+      "Bear    :   4 mois, CAGR -71.45%\n"
+     ]
+    }
+   ],
+   "source": "# Regime analysis using SPY 6-month momentum\nspy = prices['SPY'].dropna()\nspy_6m = spy.pct_change(126).resample('ME').last().dropna()\n\ndef classify_regime(ret):\n    if ret > 0.10:\n        return 'Bull'\n    elif ret < -0.10:\n        return 'Bear'\n    return 'Neutral'\n\nregimes = spy_6m.apply(classify_regime)\n# Convert regimes index to PeriodIndex for alignment\nregimes_period = regimes.copy()\nregimes_period.index = regimes_period.index.to_period('M')\n\nprint(f\"{'='*60}\")\nprint(f\"Performance par regime de marche\")\nprint(f\"{'='*60}\")\n\n# Align regime with backtest dates using PeriodIndex\nbt_period_idx = bt.index.to_period('M')\n\nfor regime in ['Bull', 'Neutral', 'Bear']:\n    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n    mask = np.array(mask)\n    n_months = mask.sum()\n    if n_months < 3:\n        print(f\"{regime:8s}: {n_months} mois (insuffisant)\")\n        continue\n    f_sh = sharpe_ann(bt['factor'][mask])\n    f_cagr = (1+bt['factor'][mask]).prod() ** (12/n_months) - 1\n    f_vol = bt['factor'][mask].std() * 12**0.5\n    print(f\"{regime:8s}: {n_months:3d} mois, Sharpe {f_sh:+.3f}, CAGR {f_cagr:+.2%}, Vol {f_vol:.2%}\")\n\nprint(f\"\\n--- B&H equal par regime ---\")\nfor regime in ['Bull', 'Neutral', 'Bear']:\n    mask = [regimes_period.get(p, None) == regime for p in bt_period_idx]\n    mask = np.array(mask)\n    n_months = mask.sum()\n    if n_months < 3:\n        continue\n    b_cagr = (1+bt['bh'][mask]).prod() ** (12/n_months) - 1\n    print(f\"{regime:8s}: {n_months:3d} mois, CAGR {b_cagr:+.2%}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Verdict et conclusion\n",
+    "\n",
+    "Le verdict est établi selon les critères de l'EPIC #1409 :\n",
+    "- **BEATS** : delta Sharpe ≥ +0.1 sur la majorité des folds OOS, edge ≥ 2σ cross-seed\n",
+    "- **NO BEATS** : delta Sharpe négatif ou edge < 2σ\n",
+    "- **INCONCLUSIVE** : résultats mixtes sans signal clair"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "======================================================================\n",
+      "VERDICT — Strategy #5: Quality + LowVol Factor Tilt\n",
+      "======================================================================\n",
+      "Factor Sharpe:     0.945\n",
+      "B&H Sharpe:        0.967\n",
+      "Delta Sharpe:      -0.022\n",
+      "Walk-forward mean: -0.080 (1/5 folds positive)\n",
+      "Cross-seed edge:   -0.37 sigma\n",
+      "\n",
+      ">>> VERDICT: NO BEATS <<<\n",
+      "\n",
+      "======================================================================\n",
+      "Scoreboard #35 — 5 strategies\n",
+      "======================================================================\n",
+      "  1. Dual Momentum (L2)             | NO BEATS        | #1575\n",
+      "  2. Risk Parity                    | NO BEATS        | #1578\n",
+      "  3. Trend Following (L1)           | NO BEATS        | #1574\n",
+      "  4. VRP Put-Write                  | NO BEATS        | #1579\n",
+      "  5. Quality + LowVol               | NO BEATS        | This PR <<<\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verdict computation\n",
+    "delta_sharpe_full = factor_sharpe - bh_sharpe\n",
+    "mean_wf_delta = wf_df['delta'].mean()\n",
+    "n_positive_folds = (wf_df['delta'] > 0).sum()\n",
+    "\n",
+    "if len(seed_df) >= 2:\n",
+    "    seed_deltas = seed_df['sharpe'].values - bh_sharpe\n",
+    "    mean_sd = seed_deltas.mean()\n",
+    "    std_sd = seed_deltas.std()\n",
+    "    sigma_edge = mean_sd / std_sd if std_sd > 1e-9 else float('nan')\n",
+    "else:\n",
+    "    sigma_edge = float('nan')\n",
+    "\n",
+    "print(f\"{'='*70}\")\n",
+    "print(f\"VERDICT — Strategy #5: Quality + LowVol Factor Tilt\")\n",
+    "print(f\"{'='*70}\")\n",
+    "print(f\"Factor Sharpe:     {factor_sharpe:.3f}\")\n",
+    "print(f\"B&H Sharpe:        {bh_sharpe:.3f}\")\n",
+    "print(f\"Delta Sharpe:      {delta_sharpe_full:+.3f}\")\n",
+    "print(f\"Walk-forward mean: {mean_wf_delta:+.3f} ({n_positive_folds}/{N_SPLITS} folds positive)\")\n",
+    "if not np.isnan(sigma_edge):\n",
+    "    print(f\"Cross-seed edge:   {sigma_edge:.2f} sigma\")\n",
+    "else:\n",
+    "    print(f\"Cross-seed edge:   N/A\")\n",
+    "\n",
+    "if delta_sharpe_full > 0.1 and n_positive_folds >= 3 and (np.isnan(sigma_edge) or sigma_edge >= 2.0):\n",
+    "    verdict = \"BEATS\"\n",
+    "elif delta_sharpe_full < 0 or n_positive_folds < 2:\n",
+    "    verdict = \"NO BEATS\"\n",
+    "else:\n",
+    "    verdict = \"INCONCLUSIVE\"\n",
+    "\n",
+    "print(f\"\\n>>> VERDICT: {verdict} <<<\")\n",
+    "\n",
+    "# Scoreboard #35\n",
+    "print(f\"\\n{'='*70}\")\n",
+    "print(f\"Scoreboard #35 — 5 strategies\")\n",
+    "print(f\"{'='*70}\")\n",
+    "scoreboard = [\n",
+    "    (1, 'Dual Momentum (L2)', 'NO BEATS', '#1575'),\n",
+    "    (2, 'Risk Parity', 'NO BEATS', '#1578'),\n",
+    "    (3, 'Trend Following (L1)', 'NO BEATS', '#1574'),\n",
+    "    (4, 'VRP Put-Write', 'NO BEATS', '#1579'),\n",
+    "    (5, 'Quality + LowVol', verdict, 'This PR'),\n",
+    "]\n",
+    "for n, name, v, pr in scoreboard:\n",
+    "    marker = ' <<<' if n == 5 else ''\n",
+    "    print(f\"  {n}. {name:30s} | {v:15s} | {pr}{marker}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Quality (momentum proxy) + Low Volatility (inverse vol) factor scoring on 25-symbol panier
- Monthly rebalance top-8 assets, 10bps tx, walk-forward 5-fold × 4 seeds
- Factor Sharpe 0.945 vs B&H equal 0.967 (delta **-0.022**)

## Key Results
| Metric | Factor Tilt | B&H Equal |
|--------|-------------|-----------|
| Sharpe | 0.945 | 0.967 |
| CAGR | 25.43% | 21.09% |
| Cumulative | 11.00x | 7.58x |

Walk-forward: 1/5 folds positive. Cross-seed edge: -0.37σ. Multi-seed robust (std 0.08).

## Verdict: **NO BEATS**
Higher CAGR but lower risk-adjusted return. Low-vol bias toward bonds/defensive reduces Sharpe vs the naturally strong B&H equal-weight.

## Papermill Execution
```
Input: research_quality_lowvol.ipynb
Output: 12/12 cells OK, 0 errors, 5s execution
Kernel: python3
```

## #35 Scoreboard — COMPLETE (5/5)
| # | Strategy | Verdict | PR |
|---|----------|---------|-----|
| 1 | Dual Momentum (L2) | NO BEATS | #1575 |
| 2 | Risk Parity | NO BEATS | #1578 |
| 3 | Trend Following (L1 TSMOM) | NO BEATS | #1574 |
| 4 | VRP Put-Write | NO BEATS | #1579 |
| 5 | **Quality + LowVol** | **NO BEATS** | **This PR** |

**Conclusion**: B&H 2015-2025 Sharpe 1.15 is a very high bar. No classical strategy beats it after costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)