### PR TITLE
feat(sw): add 3 new exercises to SW-7b-Python-OWL — bascule #1455

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -5,10 +5,10 @@
    "id": "header-navigation",
    "metadata": {
     "papermill": {
-     "duration": 0.004655,
-     "end_time": "2026-05-20T14:33:45.552735+00:00",
+     "duration": 0.083139,
+     "end_time": "2026-05-26T09:09:33.345699",
      "exception": false,
-     "start_time": "2026-05-20T14:33:45.548080+00:00",
+     "start_time": "2026-05-26T09:09:33.262560",
      "status": "completed"
     },
     "tags": []
@@ -45,10 +45,10 @@
    "id": "section-1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.00311,
-     "end_time": "2026-05-20T14:33:45.559984+00:00",
+     "duration": 0.038292,
+     "end_time": "2026-05-26T09:09:33.431401",
      "exception": false,
-     "start_time": "2026-05-20T14:33:45.556874+00:00",
+     "start_time": "2026-05-26T09:09:33.393109",
      "status": "completed"
     },
     "tags": []
@@ -67,16 +67,16 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:45.569951Z",
-     "iopub.status.busy": "2026-05-20T14:33:45.569951Z",
-     "iopub.status.idle": "2026-05-20T14:33:46.639523Z",
-     "shell.execute_reply": "2026-05-20T14:33:46.639523Z"
+     "iopub.execute_input": "2026-05-26T09:09:33.584887Z",
+     "iopub.status.busy": "2026-05-26T09:09:33.580785Z",
+     "iopub.status.idle": "2026-05-26T09:09:34.928799Z",
+     "shell.execute_reply": "2026-05-26T09:09:34.928799Z"
     },
     "papermill": {
-     "duration": 1.076831,
-     "end_time": "2026-05-20T14:33:46.640526+00:00",
+     "duration": 1.413658,
+     "end_time": "2026-05-26T09:09:34.937852",
      "exception": false,
-     "start_time": "2026-05-20T14:33:45.563695+00:00",
+     "start_time": "2026-05-26T09:09:33.524194",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "zyf8e47gkb",
    "metadata": {
     "papermill": {
-     "duration": 0.003005,
-     "end_time": "2026-05-20T14:33:46.647531+00:00",
+     "duration": 0.053518,
+     "end_time": "2026-05-26T09:09:35.073722",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.644526+00:00",
+     "start_time": "2026-05-26T09:09:35.020204",
      "status": "completed"
     },
     "tags": []
@@ -117,16 +117,16 @@
    "id": "imports-owlready2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:46.654527Z",
-     "iopub.status.busy": "2026-05-20T14:33:46.653526Z",
-     "iopub.status.idle": "2026-05-20T14:33:46.687088Z",
-     "shell.execute_reply": "2026-05-20T14:33:46.687088Z"
+     "iopub.execute_input": "2026-05-26T09:09:35.229652Z",
+     "iopub.status.busy": "2026-05-26T09:09:35.221215Z",
+     "iopub.status.idle": "2026-05-26T09:09:35.296443Z",
+     "shell.execute_reply": "2026-05-26T09:09:35.296443Z"
     },
     "papermill": {
-     "duration": 0.037557,
-     "end_time": "2026-05-20T14:33:46.688082+00:00",
+     "duration": 0.162284,
+     "end_time": "2026-05-26T09:09:35.308099",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.650525+00:00",
+     "start_time": "2026-05-26T09:09:35.145815",
      "status": "completed"
     },
     "tags": []
@@ -160,10 +160,10 @@
    "id": "section-2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-05-20T14:33:46.694585+00:00",
+     "duration": 0.030523,
+     "end_time": "2026-05-26T09:09:35.393819",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.691583+00:00",
+     "start_time": "2026-05-26T09:09:35.363296",
      "status": "completed"
     },
     "tags": []
@@ -182,16 +182,16 @@
    "id": "create-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:46.701587Z",
-     "iopub.status.busy": "2026-05-20T14:33:46.701587Z",
-     "iopub.status.idle": "2026-05-20T14:33:46.717933Z",
-     "shell.execute_reply": "2026-05-20T14:33:46.717933Z"
+     "iopub.execute_input": "2026-05-26T09:09:35.465733Z",
+     "iopub.status.busy": "2026-05-26T09:09:35.465733Z",
+     "iopub.status.idle": "2026-05-26T09:09:35.516969Z",
+     "shell.execute_reply": "2026-05-26T09:09:35.514418Z"
     },
     "papermill": {
-     "duration": 0.020347,
-     "end_time": "2026-05-20T14:33:46.718934+00:00",
+     "duration": 0.109067,
+     "end_time": "2026-05-26T09:09:35.522700",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.698587+00:00",
+     "start_time": "2026-05-26T09:09:35.413633",
      "status": "completed"
     },
     "tags": []
@@ -267,10 +267,10 @@
    "id": "create-ontology-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:33:46.724934+00:00",
+     "duration": 0.013456,
+     "end_time": "2026-05-26T09:09:35.561768",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.721934+00:00",
+     "start_time": "2026-05-26T09:09:35.548312",
      "status": "completed"
     },
     "tags": []
@@ -298,10 +298,10 @@
    "id": "section-3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:33:46.730933+00:00",
+     "duration": 0.002042,
+     "end_time": "2026-05-26T09:09:35.582902",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.727933+00:00",
+     "start_time": "2026-05-26T09:09:35.580860",
      "status": "completed"
     },
     "tags": []
@@ -320,16 +320,16 @@
    "id": "create-individuals",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:46.738936Z",
-     "iopub.status.busy": "2026-05-20T14:33:46.738936Z",
-     "iopub.status.idle": "2026-05-20T14:33:46.748703Z",
-     "shell.execute_reply": "2026-05-20T14:33:46.748703Z"
+     "iopub.execute_input": "2026-05-26T09:09:35.621110Z",
+     "iopub.status.busy": "2026-05-26T09:09:35.620106Z",
+     "iopub.status.idle": "2026-05-26T09:09:35.630466Z",
+     "shell.execute_reply": "2026-05-26T09:09:35.629558Z"
     },
     "papermill": {
-     "duration": 0.01477,
-     "end_time": "2026-05-20T14:33:46.749706+00:00",
+     "duration": 0.024137,
+     "end_time": "2026-05-26T09:09:35.630466",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.734936+00:00",
+     "start_time": "2026-05-26T09:09:35.606329",
      "status": "completed"
     },
     "tags": []
@@ -384,10 +384,10 @@
    "id": "individuals-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.004002,
-     "end_time": "2026-05-20T14:33:46.756706+00:00",
+     "duration": 0.018645,
+     "end_time": "2026-05-26T09:09:35.654872",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.752704+00:00",
+     "start_time": "2026-05-26T09:09:35.636227",
      "status": "completed"
     },
     "tags": []
@@ -412,10 +412,10 @@
    "id": "section-4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:33:46.762704+00:00",
+     "duration": 0.009234,
+     "end_time": "2026-05-26T09:09:35.672261",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.759704+00:00",
+     "start_time": "2026-05-26T09:09:35.663027",
      "status": "completed"
     },
     "tags": []
@@ -434,16 +434,16 @@
    "id": "restrictions",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:46.770707Z",
-     "iopub.status.busy": "2026-05-20T14:33:46.769706Z",
-     "iopub.status.idle": "2026-05-20T14:33:46.780590Z",
-     "shell.execute_reply": "2026-05-20T14:33:46.780590Z"
+     "iopub.execute_input": "2026-05-26T09:09:35.713852Z",
+     "iopub.status.busy": "2026-05-26T09:09:35.712090Z",
+     "iopub.status.idle": "2026-05-26T09:09:35.731228Z",
+     "shell.execute_reply": "2026-05-26T09:09:35.729847Z"
     },
     "papermill": {
-     "duration": 0.015886,
-     "end_time": "2026-05-20T14:33:46.781591+00:00",
+     "duration": 0.057843,
+     "end_time": "2026-05-26T09:09:35.738777",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.765705+00:00",
+     "start_time": "2026-05-26T09:09:35.680934",
      "status": "completed"
     },
     "tags": []
@@ -458,8 +458,8 @@
       "  Employee = Person AND works_in SOME Department\n",
       "\n",
       "Restriction OWLReady2 :\n",
-      "  manages.some(Department) = ∃ manages . Department\n",
-      "  Person & manages.some(Department) = Person ∩ (∃ manages . Department)\n"
+      "  manages.some(Department) = exists manages . Department\n",
+      "  Person & manages.some(Department) = Person AND (exists manages . Department)\n"
      ]
     }
    ],
@@ -507,10 +507,10 @@
    "id": "restrictions-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003013,
-     "end_time": "2026-05-20T14:33:46.787611+00:00",
+     "duration": 0.021522,
+     "end_time": "2026-05-26T09:09:35.799575",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.784598+00:00",
+     "start_time": "2026-05-26T09:09:35.778053",
      "status": "completed"
     },
     "tags": []
@@ -534,10 +534,10 @@
    "id": "section-5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:33:46.794603+00:00",
+     "duration": 0.018028,
+     "end_time": "2026-05-26T09:09:35.832895",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.791603+00:00",
+     "start_time": "2026-05-26T09:09:35.814867",
      "status": "completed"
     },
     "tags": []
@@ -556,16 +556,16 @@
    "id": "reasoning",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:46.802110Z",
-     "iopub.status.busy": "2026-05-20T14:33:46.801108Z",
-     "iopub.status.idle": "2026-05-20T14:33:47.715092Z",
-     "shell.execute_reply": "2026-05-20T14:33:47.714092Z"
+     "iopub.execute_input": "2026-05-26T09:09:35.864255Z",
+     "iopub.status.busy": "2026-05-26T09:09:35.864255Z",
+     "iopub.status.idle": "2026-05-26T09:09:37.015076Z",
+     "shell.execute_reply": "2026-05-26T09:09:37.015076Z"
     },
     "papermill": {
-     "duration": 0.917488,
-     "end_time": "2026-05-20T14:33:47.715092+00:00",
+     "duration": 1.167958,
+     "end_time": "2026-05-26T09:09:37.015076",
      "exception": false,
-     "start_time": "2026-05-20T14:33:46.797604+00:00",
+     "start_time": "2026-05-26T09:09:35.847118",
      "status": "completed"
     },
     "tags": []
@@ -575,14 +575,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "=== Avant raisonnement ==="
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "=== Avant raisonnement ===\n",
       "Bob types : [company.Person]\n",
       "Alice types : [company.Person]\n",
       "Charlie types : [company.Person]\n",
@@ -594,7 +587,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpgv66hz46\n"
+      "    java -Xmx1000M -cp C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpdytnwgzv\n"
      ]
     },
     {
@@ -604,7 +597,7 @@
       "=== Apres raisonnement (HermiT) ===\n",
       "Bob types : [company.Employee]\n",
       "Alice types : [company.Employee]\n",
-      "Charlie types : [company.Employee, company.Manager]\n",
+      "Charlie types : [company.Manager, company.Employee]\n",
       "\n",
       "Deductions :\n",
       "  Bob est Employee (car works_in SOME Department)\n",
@@ -616,9 +609,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.7952301502227783 seconds\n",
+      "* Owlready2 * HermiT took 0.937913179397583 seconds\n",
       "* Owlready * Reparenting company.Bob: {company.Person} => {company.Employee}\n",
-      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Employee, company.Manager}\n",
+      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Manager, company.Employee}\n",
       "* Owlready * Reparenting company.Alice: {company.Person} => {company.Employee}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
@@ -688,10 +681,10 @@
    "id": "reasoning-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003008,
-     "end_time": "2026-05-20T14:33:47.722100+00:00",
+     "duration": 0.01608,
+     "end_time": "2026-05-26T09:09:37.040291",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.719092+00:00",
+     "start_time": "2026-05-26T09:09:37.024211",
      "status": "completed"
     },
     "tags": []
@@ -718,10 +711,10 @@
    "id": "section-6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.002993,
-     "end_time": "2026-05-20T14:33:47.729093+00:00",
+     "duration": 0.012963,
+     "end_time": "2026-05-26T09:09:37.062497",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.726100+00:00",
+     "start_time": "2026-05-26T09:09:37.049534",
      "status": "completed"
     },
     "tags": []
@@ -740,16 +733,16 @@
    "id": "load-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:47.738536Z",
-     "iopub.status.busy": "2026-05-20T14:33:47.738020Z",
-     "iopub.status.idle": "2026-05-20T14:33:47.760116Z",
-     "shell.execute_reply": "2026-05-20T14:33:47.760116Z"
+     "iopub.execute_input": "2026-05-26T09:09:37.224517Z",
+     "iopub.status.busy": "2026-05-26T09:09:37.222457Z",
+     "iopub.status.idle": "2026-05-26T09:09:37.285979Z",
+     "shell.execute_reply": "2026-05-26T09:09:37.280897Z"
     },
     "papermill": {
-     "duration": 0.028019,
-     "end_time": "2026-05-20T14:33:47.761115+00:00",
+     "duration": 0.15642,
+     "end_time": "2026-05-26T09:09:37.288608",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.733096+00:00",
+     "start_time": "2026-05-26T09:09:37.132188",
      "status": "completed"
     },
     "tags": []
@@ -811,10 +804,10 @@
    "id": "section-7-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003999,
-     "end_time": "2026-05-20T14:33:47.769115+00:00",
+     "duration": 0.033039,
+     "end_time": "2026-05-26T09:09:37.352179",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.765116+00:00",
+     "start_time": "2026-05-26T09:09:37.319140",
      "status": "completed"
     },
     "tags": []
@@ -833,16 +826,16 @@
    "id": "export-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:47.777116Z",
-     "iopub.status.busy": "2026-05-20T14:33:47.777116Z",
-     "iopub.status.idle": "2026-05-20T14:33:47.793120Z",
-     "shell.execute_reply": "2026-05-20T14:33:47.792120Z"
+     "iopub.execute_input": "2026-05-26T09:09:37.424005Z",
+     "iopub.status.busy": "2026-05-26T09:09:37.422940Z",
+     "iopub.status.idle": "2026-05-26T09:09:37.475863Z",
+     "shell.execute_reply": "2026-05-26T09:09:37.469555Z"
     },
     "papermill": {
-     "duration": 0.021005,
-     "end_time": "2026-05-20T14:33:47.793120+00:00",
+     "duration": 0.09907,
+     "end_time": "2026-05-26T09:09:37.481858",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.772115+00:00",
+     "start_time": "2026-05-26T09:09:37.382788",
      "status": "completed"
     },
     "tags": []
@@ -908,10 +901,10 @@
    "id": "section-8-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003998,
-     "end_time": "2026-05-20T14:33:47.801119+00:00",
+     "duration": 0.09547,
+     "end_time": "2026-05-26T09:09:37.651407",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.797121+00:00",
+     "start_time": "2026-05-26T09:09:37.555937",
      "status": "completed"
     },
     "tags": []
@@ -929,10 +922,10 @@
    "id": "comparison-table",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-05-20T14:33:47.808134+00:00",
+     "duration": 0.085386,
+     "end_time": "2026-05-26T09:09:37.808408",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.804133+00:00",
+     "start_time": "2026-05-26T09:09:37.723022",
      "status": "completed"
     },
     "tags": []
@@ -970,10 +963,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T14:33:47.814870+00:00",
+     "duration": 0.092765,
+     "end_time": "2026-05-26T09:09:37.975652",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.811870+00:00",
+     "start_time": "2026-05-26T09:09:37.882887",
      "status": "completed"
     },
     "tags": []
@@ -991,10 +984,10 @@
    "id": "exercise-1-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004001,
-     "end_time": "2026-05-20T14:33:47.822872+00:00",
+     "duration": 0.046056,
+     "end_time": "2026-05-26T09:09:38.044793",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.818871+00:00",
+     "start_time": "2026-05-26T09:09:37.998737",
      "status": "completed"
     },
     "tags": []
@@ -1016,29 +1009,21 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:47.830872Z",
-     "iopub.status.busy": "2026-05-20T14:33:47.830872Z",
-     "iopub.status.idle": "2026-05-20T14:33:48.429832Z",
-     "shell.execute_reply": "2026-05-20T14:33:48.428831Z"
+     "iopub.execute_input": "2026-05-26T09:09:38.097851Z",
+     "iopub.status.busy": "2026-05-26T09:09:38.097851Z",
+     "iopub.status.idle": "2026-05-26T09:09:38.800042Z",
+     "shell.execute_reply": "2026-05-26T09:09:38.798451Z"
     },
     "papermill": {
-     "duration": 0.603961,
-     "end_time": "2026-05-20T14:33:48.429832+00:00",
+     "duration": 0.718115,
+     "end_time": "2026-05-26T09:09:38.800042",
      "exception": false,
-     "start_time": "2026-05-20T14:33:47.825871+00:00",
+     "start_time": "2026-05-26T09:09:38.081927",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpe_avyx7d -Y\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1047,6 +1032,14 @@
       "Pierre : ['Person']\n",
       "Marie  : ['Person']\n",
       "Lucie  : ['Person']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * Running HermiT...\n",
+      "    java -Xmx1000M -cp C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpbzftuesm -Y\n"
      ]
     },
     {
@@ -1064,7 +1057,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.5754704475402832 seconds\n",
+      "* Owlready2 * HermiT took 0.659339189529419 seconds\n",
       "* Owlready * Reparenting family2.Lucie: {family2.Person} => {family2.Child}\n",
       "* Owlready * Reparenting family2.Pierre: {family2.Person} => {family2.Parent}\n",
       "* Owlready * Reparenting family2.Marie: {family2.Person} => {family2.Parent}\n",
@@ -1132,10 +1125,10 @@
    "id": "exercise-2-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-05-20T14:33:48.437839+00:00",
+     "duration": 0.010626,
+     "end_time": "2026-05-26T09:09:38.815929",
      "exception": false,
-     "start_time": "2026-05-20T14:33:48.433839+00:00",
+     "start_time": "2026-05-26T09:09:38.805303",
      "status": "completed"
     },
     "tags": []
@@ -1157,16 +1150,16 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:48.446550Z",
-     "iopub.status.busy": "2026-05-20T14:33:48.446550Z",
-     "iopub.status.idle": "2026-05-20T14:33:49.013307Z",
-     "shell.execute_reply": "2026-05-20T14:33:49.012297Z"
+     "iopub.execute_input": "2026-05-26T09:09:38.848272Z",
+     "iopub.status.busy": "2026-05-26T09:09:38.848272Z",
+     "iopub.status.idle": "2026-05-26T09:09:39.535843Z",
+     "shell.execute_reply": "2026-05-26T09:09:39.535326Z"
     },
     "papermill": {
-     "duration": 0.572764,
-     "end_time": "2026-05-20T14:33:49.014311+00:00",
+     "duration": 0.703288,
+     "end_time": "2026-05-26T09:09:39.538857",
      "exception": false,
-     "start_time": "2026-05-20T14:33:48.441547+00:00",
+     "start_time": "2026-05-26T09:09:38.835569",
      "status": "completed"
     },
     "tags": []
@@ -1177,7 +1170,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpnqa8d5ef\n"
+      "    java -Xmx1000M -cp C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpj4nbm2o2\n"
      ]
     },
     {
@@ -1203,7 +1196,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.5442514419555664 seconds\n",
+      "* Owlready2 * HermiT took 0.6495697498321533 seconds\n",
       "* Owlready * Reparenting movies.DarkKnight: {movies.Movie} => {movies.ActionMovie}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
@@ -1284,10 +1277,10 @@
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.004,
-     "end_time": "2026-05-20T14:33:49.021613+00:00",
+     "duration": 0.010083,
+     "end_time": "2026-05-26T09:09:39.558955",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.017613+00:00",
+     "start_time": "2026-05-26T09:09:39.548872",
      "status": "completed"
     },
     "tags": []
@@ -1325,10 +1318,10 @@
    "id": "3b081608",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-05-20T14:33:49.030614+00:00",
+     "duration": 0.011146,
+     "end_time": "2026-05-26T09:09:39.588938",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.025614+00:00",
+     "start_time": "2026-05-26T09:09:39.577792",
      "status": "completed"
     },
     "tags": []
@@ -1351,16 +1344,16 @@
    "id": "89008950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:49.039614Z",
-     "iopub.status.busy": "2026-05-20T14:33:49.039614Z",
-     "iopub.status.idle": "2026-05-20T14:33:49.632669Z",
-     "shell.execute_reply": "2026-05-20T14:33:49.631880Z"
+     "iopub.execute_input": "2026-05-26T09:09:39.614560Z",
+     "iopub.status.busy": "2026-05-26T09:09:39.613565Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.317759Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.317123Z"
     },
     "papermill": {
-     "duration": 0.598574,
-     "end_time": "2026-05-20T14:33:49.633187+00:00",
+     "duration": 0.71617,
+     "end_time": "2026-05-26T09:09:40.319617",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.034613+00:00",
+     "start_time": "2026-05-26T09:09:39.603447",
      "status": "completed"
     },
     "tags": []
@@ -1371,7 +1364,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\.conda\\envs\\epita_symbolic_ai\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmpnv0waq2w\n"
+      "    java -Xmx1000M -cp C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\jsboi\\.conda\\envs\\mcp-jupyter\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/jsboi/AppData/Local/Temp/tmpfopambf_\n"
      ]
     },
     {
@@ -1403,7 +1396,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.5675661563873291 seconds\n",
+      "* Owlready2 * HermiT took 0.6816225051879883 seconds\n",
       "* Owlready * Reparenting ecosystem.Loup: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
       "* Owlready * Reparenting ecosystem.Renard: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
@@ -1471,10 +1464,10 @@
    "id": "b4f1d994",
    "metadata": {
     "papermill": {
-     "duration": 0.005001,
-     "end_time": "2026-05-20T14:33:49.641739+00:00",
+     "duration": 0.020589,
+     "end_time": "2026-05-26T09:09:40.340206",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.636738+00:00",
+     "start_time": "2026-05-26T09:09:40.319617",
      "status": "completed"
     },
     "tags": []
@@ -1492,10 +1485,10 @@
    "id": "7cd240c4",
    "metadata": {
     "papermill": {
-     "duration": 0.005002,
-     "end_time": "2026-05-20T14:33:49.649744+00:00",
+     "duration": 0.011041,
+     "end_time": "2026-05-26T09:09:40.360800",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.644742+00:00",
+     "start_time": "2026-05-26T09:09:40.349759",
      "status": "completed"
     },
     "tags": []
@@ -1519,16 +1512,16 @@
    "id": "115f4e6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:49.658249Z",
-     "iopub.status.busy": "2026-05-20T14:33:49.658249Z",
-     "iopub.status.idle": "2026-05-20T14:33:49.663755Z",
-     "shell.execute_reply": "2026-05-20T14:33:49.663755Z"
+     "iopub.execute_input": "2026-05-26T09:09:40.382649Z",
+     "iopub.status.busy": "2026-05-26T09:09:40.382649Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.399680Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.398571Z"
     },
     "papermill": {
-     "duration": 0.012014,
-     "end_time": "2026-05-20T14:33:49.664756+00:00",
+     "duration": 0.034441,
+     "end_time": "2026-05-26T09:09:40.402066",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.652742+00:00",
+     "start_time": "2026-05-26T09:09:40.367625",
      "status": "completed"
     },
     "tags": []
@@ -1555,10 +1548,10 @@
    "id": "f322477f",
    "metadata": {
     "papermill": {
-     "duration": 0.005,
-     "end_time": "2026-05-20T14:33:49.673756+00:00",
+     "duration": 0.016072,
+     "end_time": "2026-05-26T09:09:40.432691",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.668756+00:00",
+     "start_time": "2026-05-26T09:09:40.416619",
      "status": "completed"
     },
     "tags": []
@@ -1577,16 +1570,16 @@
    "id": "c8c823ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T14:33:49.683758Z",
-     "iopub.status.busy": "2026-05-20T14:33:49.682760Z",
-     "iopub.status.idle": "2026-05-20T14:33:49.695761Z",
-     "shell.execute_reply": "2026-05-20T14:33:49.695761Z"
+     "iopub.execute_input": "2026-05-26T09:09:40.449510Z",
+     "iopub.status.busy": "2026-05-26T09:09:40.449510Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.465162Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.465162Z"
     },
     "papermill": {
-     "duration": 0.019508,
-     "end_time": "2026-05-20T14:33:49.697265+00:00",
+     "duration": 0.030763,
+     "end_time": "2026-05-26T09:09:40.465162",
      "exception": false,
-     "start_time": "2026-05-20T14:33:49.677757+00:00",
+     "start_time": "2026-05-26T09:09:40.434399",
      "status": "completed"
     },
     "tags": []
@@ -1606,6 +1599,191 @@
     "# Indice : a placer dans le bloc with onto: , puis creer un individu et raisonner\n",
     "\n",
     "print(\"Exercice a completer\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8786019",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01761,
+     "end_time": "2026-05-26T09:09:40.482772",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.465162",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Restrictions de cardinalite (`min`, `exactly`)\n",
+    "\n",
+    "Modelisez la classe `BigFamily` = Person qui `has_child` **au moins 3** Person. Creez ensuite la classe `Couple` = Person qui `has_partner` **exactement 1** Person.\n",
+    "\n",
+    "Creez un individu avec 3+ enfants, lancez le raisonneur et verifiez qu'il est classe `BigFamily`.\n",
+    "\n",
+    "**Indice** : `equivalent_to = [Person & has_child.min(3, Person)]` pour le minimum. Utilisez `.exactly(N, Class)` pour la cardinalite exacte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3630d512",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:09:40.512661Z",
+     "iopub.status.busy": "2026-05-26T09:09:40.512661Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.518182Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.516809Z"
+    },
+    "papermill": {
+     "duration": 0.021157,
+     "end_time": "2026-05-26T09:09:40.518762",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.497605",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : restrictions de cardinalite (min, exactly)\n",
+    "# TODO etudiant : definir BigFamily = Person & has_child.min(3, Person)\n",
+    "# Indice : creer un parent avec 3 enfants ; sync_reasoner ; verifier is_a BigFamily\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d738e83d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00388,
+     "end_time": "2026-05-26T09:09:40.534596",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.530716",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Restriction universelle `only` (`AllValuesFrom`)\n",
+    "\n",
+    "Modelisez la classe `Vegan` = Person qui `eats` **uniquement** des `Plant`. Attention : `some` (existentiel) signifie 'au moins un', tandis que `only` (universel) signifie 'tous'. Un Vegan n'est PAS forcement defini par 'mange au moins une plante' mais par 'tout ce qu'il mange est une plante'.\n",
+    "\n",
+    "Creez deux individus : Alice qui mange uniquement des plantes (Carrot, Apple), et Bob qui mange une plante et un animal (Carrot, Cow). Apres raisonnement, seul Alice doit etre classe `Vegan`.\n",
+    "\n",
+    "**Indice** : `equivalent_to = [Person & eats.only(Plant)]`. Definissez `Plant` et `Animal` comme classes disjointes (`AllDisjoint`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8c16ee8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:09:40.550428Z",
+     "iopub.status.busy": "2026-05-26T09:09:40.550428Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.581889Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.581889Z"
+    },
+    "papermill": {
+     "duration": 0.034129,
+     "end_time": "2026-05-26T09:09:40.584557",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.550428",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : restriction universelle only (AllValuesFrom)\n",
+    "# TODO etudiant : Vegan = Person & eats.only(Plant)\n",
+    "# Indice : 2 individus (Alice tout-plantes, Bob plante+animal) ; seul Alice doit etre Vegan\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92159084",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010703,
+     "end_time": "2026-05-26T09:09:40.606718",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.596015",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : Propriete transitive (`TransitiveProperty`)\n",
+    "\n",
+    "Modelisez la propriete `is_part_of` comme **transitive** : si A `is_part_of` B et B `is_part_of` C, alors le raisonneur doit inferer A `is_part_of` C.\n",
+    "\n",
+    "Creez les individus `Finger`, `Hand`, `Arm`, `Body` avec la chaine :\n",
+    "- Finger `is_part_of` Hand\n",
+    "- Hand `is_part_of` Arm\n",
+    "- Arm `is_part_of` Body\n",
+    "\n",
+    "Apres `sync_reasoner`, verifiez que Finger.is_part_of contient bien Body (via transitivite).\n",
+    "\n",
+    "**Indice** : declarer la classe `is_part_of(ObjectProperty, TransitiveProperty)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "ae732ead",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:09:40.635445Z",
+     "iopub.status.busy": "2026-05-26T09:09:40.635445Z",
+     "iopub.status.idle": "2026-05-26T09:09:40.651106Z",
+     "shell.execute_reply": "2026-05-26T09:09:40.649573Z"
+    },
+    "papermill": {
+     "duration": 0.034875,
+     "end_time": "2026-05-26T09:09:40.653732",
+     "exception": false,
+     "start_time": "2026-05-26T09:09:40.618857",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : propriete transitive\n",
+    "# TODO etudiant : declarer is_part_of(ObjectProperty, TransitiveProperty)\n",
+    "# Indice : chaine Finger -> Hand -> Arm -> Body ; sync_reasoner ; verifier Finger.is_part_of inclut Body\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   }
  ],
@@ -1629,14 +1807,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.018551,
-   "end_time": "2026-05-20T14:33:49.928237+00:00",
+   "duration": 8.712588,
+   "end_time": "2026-05-26T09:09:40.901156",
    "environment_variables": {},
    "exception": null,
-   "input_path": "SW-7b-Python-OWL.ipynb",
-   "output_path": "SW-7b-Python-OWL.ipynb",
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T14:33:43.909686+00:00",
+   "start_time": "2026-05-26T09:09:32.188568",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Track 1 #1455 bascule pour EPITA-IS SW (cours 3 du 1er juin) : ajoute 3 nouveaux exercices après les Exemples guidés existants dans `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb`.

Exemples guidés préexistants (cells 25/27/30) : `equivalent_to` + `some()`, famille/films, écosystème synthèse. Exercices 1+2 préexistants (cells 33/35) : `equivalent_to` véhicules, `AllDisjoint`.

Les 3 nouveaux exercices testent des compétences OWL **non couvertes** par les Exemples ou Exercices existants :

- **Exercice 3 — Restrictions de cardinalité** (`min`/`exactly`) : `BigFamily = Person & has_child.min(3, Person)`, `Couple = ... .exactly(1, ...)`
- **Exercice 4 — Restriction universelle** (`only` / `AllValuesFrom`) : `Vegan = Person & eats.only(Plant)` — distinction conceptuelle clé vs `some` (existentiel)
- **Exercice 5 — Propriété transitive** : `is_part_of(ObjectProperty, TransitiveProperty)` — chaîne Finger → Hand → Arm → Body inférée

Tous les stubs respectent **C.1 (notebook-conventions)** : `print(\"Exercice a completer\")`, **aucun** `raise NotImplementedError` / `assert False` / `1/0`. Indices conservés en commentaires `# TODO etudiant`.

Classification respecte la règle [exercise-example-labeling](../blob/main/.claude/rules/exercise-example-labeling.md) : nouveaux exercices = stubs (Exercice), exemples guidés préservés intacts.

## Test plan

- [x] **Papermill execution** : conda env `mcp-jupyter`, kernel `python3`, `--cwd MyIA.AI.Notebooks/SymbolicAI/SemanticWeb` (cell 8 export OWL utilise `data/` relatif) : **42/42 cells, 0 errors, 16/16 code cells exécutées** (sorties commitées, règle C.2)
- [x] **C.1 compliance** : `grep -nE \"raise NotImplementedError|assert False|1/0\" SW-7b-Python-OWL.ipynb` → 0 match
- [x] **C.2 compliance** : 16/16 cells code avec `execution_count` + `outputs`
- [x] **C.3 compliance** : seul `SW-7b-Python-OWL.ipynb` touché, scope strict
- [x] **Anti-régression** : 8 sections fondamentales (cells 2-22) + 3 Exemples guidés (cells 25/27/30) + 2 Exercices préexistants (cells 33/35) préservés ; ajout uniquement
- [x] **Pédagogie** : les 3 nouveaux exercices testent des skills OWL (`min`/`exactly` cardinalité, `only` universal, `TransitiveProperty`) absents des cells existantes → progression cohérente après les Exemples guidés

Refs #1455