### PR TITLE
feat(sw): add 3 advanced exercises to SW-9-Python-JSONLD — bascule #1455

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -5,10 +5,10 @@
    "id": "header-nav",
    "metadata": {
     "papermill": {
-     "duration": 0.027134,
-     "end_time": "2026-05-23T12:07:54.553455",
+     "duration": 0.029049,
+     "end_time": "2026-05-26T09:19:50.277005",
      "exception": false,
-     "start_time": "2026-05-23T12:07:54.526321",
+     "start_time": "2026-05-26T09:19:50.247956",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "install-section",
    "metadata": {
     "papermill": {
-     "duration": 0.070273,
-     "end_time": "2026-05-23T12:07:54.637766",
+     "duration": 0.051727,
+     "end_time": "2026-05-26T09:19:50.381464",
      "exception": false,
-     "start_time": "2026-05-23T12:07:54.567493",
+     "start_time": "2026-05-26T09:19:50.329737",
      "status": "completed"
     },
     "tags": []
@@ -60,16 +60,16 @@
    "id": "install-pip",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:54.853912Z",
-     "iopub.status.busy": "2026-05-23T12:07:54.852416Z",
-     "iopub.status.idle": "2026-05-23T12:07:56.105095Z",
-     "shell.execute_reply": "2026-05-23T12:07:56.104506Z"
+     "iopub.execute_input": "2026-05-26T09:19:50.433519Z",
+     "iopub.status.busy": "2026-05-26T09:19:50.432519Z",
+     "iopub.status.idle": "2026-05-26T09:19:51.635288Z",
+     "shell.execute_reply": "2026-05-26T09:19:51.634280Z"
     },
     "papermill": {
-     "duration": 1.34265,
-     "end_time": "2026-05-23T12:07:56.104425",
+     "duration": 1.228292,
+     "end_time": "2026-05-26T09:19:51.635288",
      "exception": false,
-     "start_time": "2026-05-23T12:07:54.761775",
+     "start_time": "2026-05-26T09:19:50.406996",
      "status": "completed"
     },
     "tags": []
@@ -92,10 +92,10 @@
    "id": "section1-title",
    "metadata": {
     "papermill": {
-     "duration": 0.082044,
-     "end_time": "2026-05-23T12:07:56.266001",
+     "duration": 0.019904,
+     "end_time": "2026-05-26T09:19:51.671139",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.183957",
+     "start_time": "2026-05-26T09:19:51.651235",
      "status": "completed"
     },
     "tags": []
@@ -131,16 +131,16 @@
    "id": "demo-json-vs-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:56.366384Z",
-     "iopub.status.busy": "2026-05-23T12:07:56.365708Z",
-     "iopub.status.idle": "2026-05-23T12:07:56.388666Z",
-     "shell.execute_reply": "2026-05-23T12:07:56.382252Z"
+     "iopub.execute_input": "2026-05-26T09:19:51.699613Z",
+     "iopub.status.busy": "2026-05-26T09:19:51.699613Z",
+     "iopub.status.idle": "2026-05-26T09:19:51.707839Z",
+     "shell.execute_reply": "2026-05-26T09:19:51.707839Z"
     },
     "papermill": {
-     "duration": 0.074807,
-     "end_time": "2026-05-23T12:07:56.387169",
+     "duration": 0.020509,
+     "end_time": "2026-05-26T09:19:51.707839",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.312362",
+     "start_time": "2026-05-26T09:19:51.687330",
      "status": "completed"
     },
     "tags": []
@@ -195,10 +195,10 @@
    "id": "interpretation-json-vs-jsonld",
    "metadata": {
     "papermill": {
-     "duration": 0.030635,
-     "end_time": "2026-05-23T12:07:56.451387",
+     "duration": 0.015765,
+     "end_time": "2026-05-26T09:19:51.739604",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.420752",
+     "start_time": "2026-05-26T09:19:51.723839",
      "status": "completed"
     },
     "tags": []
@@ -219,10 +219,10 @@
    "id": "section2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.062702,
-     "end_time": "2026-05-23T12:07:56.547253",
+     "duration": 0.042632,
+     "end_time": "2026-05-26T09:19:51.802890",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.484551",
+     "start_time": "2026-05-26T09:19:51.760258",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "section2-context",
    "metadata": {
     "papermill": {
-     "duration": 0.097429,
-     "end_time": "2026-05-23T12:07:56.756458",
+     "duration": 0.011178,
+     "end_time": "2026-05-26T09:19:51.828398",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.659029",
+     "start_time": "2026-05-26T09:19:51.817220",
      "status": "completed"
     },
     "tags": []
@@ -263,16 +263,16 @@
    "id": "context-examples",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:56.943961Z",
-     "iopub.status.busy": "2026-05-23T12:07:56.943582Z",
-     "iopub.status.idle": "2026-05-23T12:07:56.951578Z",
-     "shell.execute_reply": "2026-05-23T12:07:56.950121Z"
+     "iopub.execute_input": "2026-05-26T09:19:51.861846Z",
+     "iopub.status.busy": "2026-05-26T09:19:51.859841Z",
+     "iopub.status.idle": "2026-05-26T09:19:51.879575Z",
+     "shell.execute_reply": "2026-05-26T09:19:51.877688Z"
     },
     "papermill": {
-     "duration": 0.076943,
-     "end_time": "2026-05-23T12:07:56.950022",
+     "duration": 0.034086,
+     "end_time": "2026-05-26T09:19:51.879575",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.873079",
+     "start_time": "2026-05-26T09:19:51.845489",
      "status": "completed"
     },
     "tags": []
@@ -366,10 +366,10 @@
    "id": "section2-id-type",
    "metadata": {
     "papermill": {
-     "duration": 0.005916,
-     "end_time": "2026-05-23T12:07:56.969950",
+     "duration": 0.01252,
+     "end_time": "2026-05-26T09:19:51.904758",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.964034",
+     "start_time": "2026-05-26T09:19:51.892238",
      "status": "completed"
     },
     "tags": []
@@ -387,16 +387,16 @@
    "id": "id-type-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:57.003414Z",
-     "iopub.status.busy": "2026-05-23T12:07:57.002963Z",
-     "iopub.status.idle": "2026-05-23T12:07:57.009907Z",
-     "shell.execute_reply": "2026-05-23T12:07:57.008770Z"
+     "iopub.execute_input": "2026-05-26T09:19:51.936912Z",
+     "iopub.status.busy": "2026-05-26T09:19:51.935276Z",
+     "iopub.status.idle": "2026-05-26T09:19:51.968677Z",
+     "shell.execute_reply": "2026-05-26T09:19:51.962489Z"
     },
     "papermill": {
-     "duration": 0.020421,
-     "end_time": "2026-05-23T12:07:57.008584",
+     "duration": 0.058742,
+     "end_time": "2026-05-26T09:19:51.976919",
      "exception": false,
-     "start_time": "2026-05-23T12:07:56.988163",
+     "start_time": "2026-05-26T09:19:51.918177",
      "status": "completed"
     },
     "tags": []
@@ -459,10 +459,10 @@
    "id": "section2-graph",
    "metadata": {
     "papermill": {
-     "duration": 0.015781,
-     "end_time": "2026-05-23T12:07:57.028095",
+     "duration": 0.061202,
+     "end_time": "2026-05-26T09:19:52.081070",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.012314",
+     "start_time": "2026-05-26T09:19:52.019868",
      "status": "completed"
     },
     "tags": []
@@ -479,16 +479,16 @@
    "id": "graph-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:57.094453Z",
-     "iopub.status.busy": "2026-05-23T12:07:57.093791Z",
-     "iopub.status.idle": "2026-05-23T12:07:57.115709Z",
-     "shell.execute_reply": "2026-05-23T12:07:57.111105Z"
+     "iopub.execute_input": "2026-05-26T09:19:52.281174Z",
+     "iopub.status.busy": "2026-05-26T09:19:52.277091Z",
+     "iopub.status.idle": "2026-05-26T09:19:52.325190Z",
+     "shell.execute_reply": "2026-05-26T09:19:52.320526Z"
     },
     "papermill": {
-     "duration": 0.04901,
-     "end_time": "2026-05-23T12:07:57.110812",
+     "duration": 0.144067,
+     "end_time": "2026-05-26T09:19:52.341267",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.061802",
+     "start_time": "2026-05-26T09:19:52.197200",
      "status": "completed"
     },
     "tags": []
@@ -542,10 +542,10 @@
    "id": "section2-forms",
    "metadata": {
     "papermill": {
-     "duration": 0.047494,
-     "end_time": "2026-05-23T12:07:57.204444",
+     "duration": 0.144329,
+     "end_time": "2026-05-26T09:19:52.566753",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.156950",
+     "start_time": "2026-05-26T09:19:52.422424",
      "status": "completed"
     },
     "tags": []
@@ -568,16 +568,16 @@
    "id": "forms-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:57.373932Z",
-     "iopub.status.busy": "2026-05-23T12:07:57.373597Z",
-     "iopub.status.idle": "2026-05-23T12:07:57.402747Z",
-     "shell.execute_reply": "2026-05-23T12:07:57.398182Z"
+     "iopub.execute_input": "2026-05-26T09:19:52.711467Z",
+     "iopub.status.busy": "2026-05-26T09:19:52.705545Z",
+     "iopub.status.idle": "2026-05-26T09:19:52.775102Z",
+     "shell.execute_reply": "2026-05-26T09:19:52.769014Z"
     },
     "papermill": {
-     "duration": 0.11692,
-     "end_time": "2026-05-23T12:07:57.403979",
+     "duration": 0.157034,
+     "end_time": "2026-05-26T09:19:52.788505",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.287059",
+     "start_time": "2026-05-26T09:19:52.631471",
      "status": "completed"
     },
     "tags": []
@@ -681,10 +681,10 @@
    "id": "interpretation-forms",
    "metadata": {
     "papermill": {
-     "duration": 0.019519,
-     "end_time": "2026-05-23T12:07:57.448025",
+     "duration": 0.059254,
+     "end_time": "2026-05-26T09:19:52.904159",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.428506",
+     "start_time": "2026-05-26T09:19:52.844905",
      "status": "completed"
     },
     "tags": []
@@ -700,10 +700,10 @@
    "id": "section3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.006045,
-     "end_time": "2026-05-23T12:07:57.493824",
+     "duration": 0.018461,
+     "end_time": "2026-05-26T09:19:52.963466",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.487779",
+     "start_time": "2026-05-26T09:19:52.945005",
      "status": "completed"
     },
     "tags": []
@@ -735,10 +735,10 @@
    "id": "section3-explore",
    "metadata": {
     "papermill": {
-     "duration": 0.031724,
-     "end_time": "2026-05-23T12:07:57.540416",
+     "duration": 0.016516,
+     "end_time": "2026-05-26T09:19:52.981044",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.508692",
+     "start_time": "2026-05-26T09:19:52.964528",
      "status": "completed"
     },
     "tags": []
@@ -755,16 +755,16 @@
    "id": "schema-namespace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:57.677434Z",
-     "iopub.status.busy": "2026-05-23T12:07:57.677161Z",
-     "iopub.status.idle": "2026-05-23T12:07:58.039905Z",
-     "shell.execute_reply": "2026-05-23T12:07:58.039121Z"
+     "iopub.execute_input": "2026-05-26T09:19:53.008647Z",
+     "iopub.status.busy": "2026-05-26T09:19:53.008647Z",
+     "iopub.status.idle": "2026-05-26T09:19:53.121599Z",
+     "shell.execute_reply": "2026-05-26T09:19:53.121599Z"
     },
     "papermill": {
-     "duration": 0.451143,
-     "end_time": "2026-05-23T12:07:58.038962",
+     "duration": 0.130857,
+     "end_time": "2026-05-26T09:19:53.124162",
      "exception": false,
-     "start_time": "2026-05-23T12:07:57.587819",
+     "start_time": "2026-05-26T09:19:52.993305",
      "status": "completed"
     },
     "tags": []
@@ -831,10 +831,10 @@
    "id": "section3-load-product",
    "metadata": {
     "papermill": {
-     "duration": 0.055205,
-     "end_time": "2026-05-23T12:07:58.112947",
+     "duration": 0.020894,
+     "end_time": "2026-05-26T09:19:53.159559",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.057742",
+     "start_time": "2026-05-26T09:19:53.138665",
      "status": "completed"
     },
     "tags": []
@@ -851,16 +851,16 @@
    "id": "load-product",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:58.288910Z",
-     "iopub.status.busy": "2026-05-23T12:07:58.287857Z",
-     "iopub.status.idle": "2026-05-23T12:07:58.328612Z",
-     "shell.execute_reply": "2026-05-23T12:07:58.322541Z"
+     "iopub.execute_input": "2026-05-26T09:19:53.190312Z",
+     "iopub.status.busy": "2026-05-26T09:19:53.190312Z",
+     "iopub.status.idle": "2026-05-26T09:19:53.216394Z",
+     "shell.execute_reply": "2026-05-26T09:19:53.213279Z"
     },
     "papermill": {
-     "duration": 0.115091,
-     "end_time": "2026-05-23T12:07:58.324529",
+     "duration": 0.043077,
+     "end_time": "2026-05-26T09:19:53.216394",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.209438",
+     "start_time": "2026-05-26T09:19:53.173317",
      "status": "completed"
     },
     "tags": []
@@ -943,10 +943,10 @@
    "id": "interpretation-product",
    "metadata": {
     "papermill": {
-     "duration": 0.058656,
-     "end_time": "2026-05-23T12:07:58.507727",
+     "duration": 0.055456,
+     "end_time": "2026-05-26T09:19:53.311644",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.449071",
+     "start_time": "2026-05-26T09:19:53.256188",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +974,10 @@
    "id": "section4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.031522,
-     "end_time": "2026-05-23T12:07:58.560278",
+     "duration": 0.0,
+     "end_time": "2026-05-26T09:19:53.359411",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.528756",
+     "start_time": "2026-05-26T09:19:53.359411",
      "status": "completed"
     },
     "tags": []
@@ -995,10 +995,10 @@
    "id": "section4-build",
    "metadata": {
     "papermill": {
-     "duration": 0.11379,
-     "end_time": "2026-05-23T12:07:58.735571",
+     "duration": 0.007203,
+     "end_time": "2026-05-26T09:19:53.388229",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.621781",
+     "start_time": "2026-05-26T09:19:53.381026",
      "status": "completed"
     },
     "tags": []
@@ -1015,16 +1015,16 @@
    "id": "build-graph-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:58.855879Z",
-     "iopub.status.busy": "2026-05-23T12:07:58.849264Z",
-     "iopub.status.idle": "2026-05-23T12:07:59.030503Z",
-     "shell.execute_reply": "2026-05-23T12:07:59.026340Z"
+     "iopub.execute_input": "2026-05-26T09:19:53.483137Z",
+     "iopub.status.busy": "2026-05-26T09:19:53.483137Z",
+     "iopub.status.idle": "2026-05-26T09:19:53.531650Z",
+     "shell.execute_reply": "2026-05-26T09:19:53.529131Z"
     },
     "papermill": {
-     "duration": 0.265528,
-     "end_time": "2026-05-23T12:07:59.026052",
+     "duration": 0.105029,
+     "end_time": "2026-05-26T09:19:53.533656",
      "exception": false,
-     "start_time": "2026-05-23T12:07:58.760524",
+     "start_time": "2026-05-26T09:19:53.428627",
      "status": "completed"
     },
     "tags": []
@@ -1038,6 +1038,22 @@
       "\n",
       "=== Serialisation JSON-LD ===\n",
       "[\n",
+      "  {\n",
+      "    \"@id\": \"https://example.org/people/charles_babbage\",\n",
+      "    \"@type\": [\n",
+      "      \"https://schema.org/Person\"\n",
+      "    ],\n",
+      "    \"https://schema.org/jobTitle\": [\n",
+      "      {\n",
+      "        \"@value\": \"Inventor\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"https://schema.org/name\": [\n",
+      "      {\n",
+      "        \"@value\": \"Charles Babbage\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
       "  {\n",
       "    \"@id\": \"https://example.org/people/ada_lovelace\",\n",
       "    \"@type\": [\n",
@@ -1067,22 +1083,6 @@
       "    \"https://schema.org/name\": [\n",
       "      {\n",
       "        \"@value\": \"Ada Lovelace\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"https://example.org/people/charles_babbage\",\n",
-      "    \"@type\": [\n",
-      "      \"https://schema.org/Person\"\n",
-      "    ],\n",
-      "    \"https://schema.org/jobTitle\": [\n",
-      "      {\n",
-      "        \"@value\": \"Inventor\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Charles Babbage\"\n",
       "      }\n",
       "    ]\n",
       "  }\n",
@@ -1133,10 +1133,10 @@
    "id": "interpretation-build",
    "metadata": {
     "papermill": {
-     "duration": 0.016179,
-     "end_time": "2026-05-23T12:07:59.072120",
+     "duration": 0.072934,
+     "end_time": "2026-05-26T09:19:53.635793",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.055941",
+     "start_time": "2026-05-26T09:19:53.562859",
      "status": "completed"
     },
     "tags": []
@@ -1157,10 +1157,10 @@
    "id": "section4-person-compact",
    "metadata": {
     "papermill": {
-     "duration": 0.043432,
-     "end_time": "2026-05-23T12:07:59.167255",
+     "duration": 0.054638,
+     "end_time": "2026-05-26T09:19:53.752050",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.123823",
+     "start_time": "2026-05-26T09:19:53.697412",
      "status": "completed"
     },
     "tags": []
@@ -1177,16 +1177,16 @@
    "id": "compact-serialization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:59.235866Z",
-     "iopub.status.busy": "2026-05-23T12:07:59.235568Z",
-     "iopub.status.idle": "2026-05-23T12:07:59.245756Z",
-     "shell.execute_reply": "2026-05-23T12:07:59.243177Z"
+     "iopub.execute_input": "2026-05-26T09:19:53.959605Z",
+     "iopub.status.busy": "2026-05-26T09:19:53.959605Z",
+     "iopub.status.idle": "2026-05-26T09:19:53.988322Z",
+     "shell.execute_reply": "2026-05-26T09:19:53.988322Z"
     },
     "papermill": {
-     "duration": 0.029617,
-     "end_time": "2026-05-23T12:07:59.247269",
+     "duration": 0.120311,
+     "end_time": "2026-05-26T09:19:53.988322",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.217652",
+     "start_time": "2026-05-26T09:19:53.868011",
      "status": "completed"
     },
     "tags": []
@@ -1212,6 +1212,12 @@
       "  },\n",
       "  \"@graph\": [\n",
       "    {\n",
+      "      \"@id\": \"ex:charles_babbage\",\n",
+      "      \"@type\": \"schema:Person\",\n",
+      "      \"jobTitle\": \"Inventor\",\n",
+      "      \"name\": \"Charles Babbage\"\n",
+      "    },\n",
+      "    {\n",
       "      \"@id\": \"ex:ada_lovelace\",\n",
       "      \"@type\": \"schema:Person\",\n",
       "      \"birthDate\": {\n",
@@ -1222,12 +1228,6 @@
       "      \"jobTitle\": \"Mathematician and Writer\",\n",
       "      \"knows\": \"ex:charles_babbage\",\n",
       "      \"name\": \"Ada Lovelace\"\n",
-      "    },\n",
-      "    {\n",
-      "      \"@id\": \"ex:charles_babbage\",\n",
-      "      \"@type\": \"schema:Person\",\n",
-      "      \"jobTitle\": \"Inventor\",\n",
-      "      \"name\": \"Charles Babbage\"\n",
       "    }\n",
       "  ]\n",
       "}\n"
@@ -1264,10 +1264,10 @@
    "id": "section5-title",
    "metadata": {
     "papermill": {
-     "duration": 0.015775,
-     "end_time": "2026-05-23T12:07:59.295056",
+     "duration": 0.027028,
+     "end_time": "2026-05-26T09:19:54.046484",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.279281",
+     "start_time": "2026-05-26T09:19:54.019456",
      "status": "completed"
     },
     "tags": []
@@ -1285,10 +1285,10 @@
    "id": "section5-parse",
    "metadata": {
     "papermill": {
-     "duration": 0.027109,
-     "end_time": "2026-05-23T12:07:59.322165",
+     "duration": 0.057826,
+     "end_time": "2026-05-26T09:19:54.133105",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.295056",
+     "start_time": "2026-05-26T09:19:54.075279",
      "status": "completed"
     },
     "tags": []
@@ -1303,16 +1303,16 @@
    "id": "parse-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:07:59.405744Z",
-     "iopub.status.busy": "2026-05-23T12:07:59.405380Z",
-     "iopub.status.idle": "2026-05-23T12:08:00.160787Z",
-     "shell.execute_reply": "2026-05-23T12:08:00.156892Z"
+     "iopub.execute_input": "2026-05-26T09:19:54.276985Z",
+     "iopub.status.busy": "2026-05-26T09:19:54.276985Z",
+     "iopub.status.idle": "2026-05-26T09:19:55.980833Z",
+     "shell.execute_reply": "2026-05-26T09:19:55.980833Z"
     },
     "papermill": {
-     "duration": 0.812962,
-     "end_time": "2026-05-23T12:08:00.156744",
+     "duration": 1.761879,
+     "end_time": "2026-05-26T09:19:55.983441",
      "exception": false,
-     "start_time": "2026-05-23T12:07:59.343782",
+     "start_time": "2026-05-26T09:19:54.221562",
      "status": "completed"
     },
     "tags": []
@@ -1325,17 +1325,17 @@
       "Triples charges : 11\n",
       "\n",
       "=== Tous les triples ===\n",
-      "  ex:pycon2025  http://schema.org/name  PyCon France 2025\n",
-      "  N159117229cd9485fb983abd9125db2bb  rdf:type  http://schema.org/Organization\n",
-      "  Nd594cf91a9624ac5961d8cbda5b50c41  http://schema.org/name  Strasbourg\n",
-      "  ex:pycon2025  http://schema.org/endDate  2025-10-26\n",
-      "  ex:pycon2025  http://schema.org/organizer  N159117229cd9485fb983abd9125db2bb\n",
-      "  Nd594cf91a9624ac5961d8cbda5b50c41  http://schema.org/address  Palais de la Musique et des Congres\n",
-      "  ex:pycon2025  http://schema.org/location  Nd594cf91a9624ac5961d8cbda5b50c41\n",
-      "  Nd594cf91a9624ac5961d8cbda5b50c41  rdf:type  http://schema.org/Place\n",
       "  ex:pycon2025  rdf:type  http://schema.org/Event\n",
       "  ex:pycon2025  http://schema.org/startDate  2025-10-23\n",
-      "  N159117229cd9485fb983abd9125db2bb  http://schema.org/name  AFPy\n"
+      "  ex:pycon2025  http://schema.org/location  Ne8d23e83e3b14cc89506da19f6b52e3d\n",
+      "  Ne8d23e83e3b14cc89506da19f6b52e3d  rdf:type  http://schema.org/Place\n",
+      "  Ne8d23e83e3b14cc89506da19f6b52e3d  http://schema.org/address  Palais de la Musique et des Congres\n",
+      "  Nfb59b64dbf44406e9b2084ce11783c93  http://schema.org/name  AFPy\n",
+      "  Ne8d23e83e3b14cc89506da19f6b52e3d  http://schema.org/name  Strasbourg\n",
+      "  Nfb59b64dbf44406e9b2084ce11783c93  rdf:type  http://schema.org/Organization\n",
+      "  ex:pycon2025  http://schema.org/name  PyCon France 2025\n",
+      "  ex:pycon2025  http://schema.org/organizer  Nfb59b64dbf44406e9b2084ce11783c93\n",
+      "  ex:pycon2025  http://schema.org/endDate  2025-10-26\n"
      ]
     }
    ],
@@ -1382,10 +1382,10 @@
    "id": "section5-sparql",
    "metadata": {
     "papermill": {
-     "duration": 0.09567,
-     "end_time": "2026-05-23T12:08:00.378606",
+     "duration": 0.0474,
+     "end_time": "2026-05-26T09:19:56.071461",
      "exception": false,
-     "start_time": "2026-05-23T12:08:00.282936",
+     "start_time": "2026-05-26T09:19:56.024061",
      "status": "completed"
     },
     "tags": []
@@ -1402,16 +1402,16 @@
    "id": "sparql-jsonld",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:00.642492Z",
-     "iopub.status.busy": "2026-05-23T12:08:00.641052Z",
-     "iopub.status.idle": "2026-05-23T12:08:01.835209Z",
-     "shell.execute_reply": "2026-05-23T12:08:01.830593Z"
+     "iopub.execute_input": "2026-05-26T09:19:56.171236Z",
+     "iopub.status.busy": "2026-05-26T09:19:56.171236Z",
+     "iopub.status.idle": "2026-05-26T09:19:57.149074Z",
+     "shell.execute_reply": "2026-05-26T09:19:57.148259Z"
     },
     "papermill": {
-     "duration": 1.328003,
-     "end_time": "2026-05-23T12:08:01.834122",
+     "duration": 1.039785,
+     "end_time": "2026-05-26T09:19:57.150883",
      "exception": false,
-     "start_time": "2026-05-23T12:08:00.506119",
+     "start_time": "2026-05-26T09:19:56.111098",
      "status": "completed"
     },
     "tags": []
@@ -1466,10 +1466,10 @@
    "id": "section5-convert",
    "metadata": {
     "papermill": {
-     "duration": 0.048248,
-     "end_time": "2026-05-23T12:08:01.942455",
+     "duration": 0.019487,
+     "end_time": "2026-05-26T09:19:57.226014",
      "exception": false,
-     "start_time": "2026-05-23T12:08:01.894207",
+     "start_time": "2026-05-26T09:19:57.206527",
      "status": "completed"
     },
     "tags": []
@@ -1486,16 +1486,16 @@
    "id": "convert-turtle",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.062104Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.061685Z",
-     "iopub.status.idle": "2026-05-23T12:08:02.072608Z",
-     "shell.execute_reply": "2026-05-23T12:08:02.071619Z"
+     "iopub.execute_input": "2026-05-26T09:19:57.447195Z",
+     "iopub.status.busy": "2026-05-26T09:19:57.432725Z",
+     "iopub.status.idle": "2026-05-26T09:19:57.476576Z",
+     "shell.execute_reply": "2026-05-26T09:19:57.476010Z"
     },
     "papermill": {
-     "duration": 0.049295,
-     "end_time": "2026-05-23T12:08:02.071586",
+     "duration": 0.151769,
+     "end_time": "2026-05-26T09:19:57.477804",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.022291",
+     "start_time": "2026-05-26T09:19:57.326035",
      "status": "completed"
     },
     "tags": []
@@ -1534,10 +1534,10 @@
    "id": "section5-roundtrip",
    "metadata": {
     "papermill": {
-     "duration": 0.015543,
-     "end_time": "2026-05-23T12:08:02.101295",
+     "duration": 0.044744,
+     "end_time": "2026-05-26T09:19:57.537212",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.085752",
+     "start_time": "2026-05-26T09:19:57.492468",
      "status": "completed"
     },
     "tags": []
@@ -1554,16 +1554,16 @@
    "id": "roundtrip-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.132198Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.131968Z",
-     "iopub.status.idle": "2026-05-23T12:08:02.154954Z",
-     "shell.execute_reply": "2026-05-23T12:08:02.153586Z"
+     "iopub.execute_input": "2026-05-26T09:19:57.758353Z",
+     "iopub.status.busy": "2026-05-26T09:19:57.749781Z",
+     "iopub.status.idle": "2026-05-26T09:19:57.893957Z",
+     "shell.execute_reply": "2026-05-26T09:19:57.884984Z"
     },
     "papermill": {
-     "duration": 0.039151,
-     "end_time": "2026-05-23T12:08:02.156230",
+     "duration": 0.289317,
+     "end_time": "2026-05-26T09:19:57.902881",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.117079",
+     "start_time": "2026-05-26T09:19:57.613564",
      "status": "completed"
     },
     "tags": []
@@ -1595,7 +1595,7 @@
       "    ],\n",
       "    \"http://schema.org/location\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n0cea0d62a79f49ebb4512b8737bc0798b1\"\n",
+      "        \"@id\": \"_:n4e88895728d54b6b857d53a2837b1436b1\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -1605,7 +1605,7 @@
       "    ],\n",
       "    \"http://schema.org/organizer\": [\n",
       "      {\n",
-      "        \"@id\": \"_:n0cea0d62a79f49ebb4512b8737bc0798b2\"\n",
+      "        \"@id\": \"_:n4e88895728d54b6b857d53a2837b1436b2\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/startDate\": [\n",
@@ -1616,7 +1616,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n0cea0d62a79f49ebb4512b8737bc0798b1\",\n",
+      "    \"@id\": \"_:n4e88895728d54b6b857d53a2837b1436b1\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Place\"\n",
       "    ],\n",
@@ -1632,7 +1632,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:n0cea0d62a79f49ebb4512b8737bc0798b2\",\n",
+      "    \"@id\": \"_:n4e88895728d54b6b857d53a2837b1436b2\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Organization\"\n",
       "    ],\n",
@@ -1687,10 +1687,10 @@
    "id": "interpretation-roundtrip",
    "metadata": {
     "papermill": {
-     "duration": 0.014577,
-     "end_time": "2026-05-23T12:08:02.179986",
+     "duration": 0.026904,
+     "end_time": "2026-05-26T09:19:58.001747",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.165409",
+     "start_time": "2026-05-26T09:19:57.974843",
      "status": "completed"
     },
     "tags": []
@@ -1711,10 +1711,10 @@
    "id": "section6-title",
    "metadata": {
     "papermill": {
-     "duration": 0.083328,
-     "end_time": "2026-05-23T12:08:02.291303",
+     "duration": 0.108557,
+     "end_time": "2026-05-26T09:19:58.168106",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.207975",
+     "start_time": "2026-05-26T09:19:58.059549",
      "status": "completed"
     },
     "tags": []
@@ -1732,10 +1732,10 @@
    "id": "section6-recipe",
    "metadata": {
     "papermill": {
-     "duration": 0.134289,
-     "end_time": "2026-05-23T12:08:02.531548",
+     "duration": 0.029265,
+     "end_time": "2026-05-26T09:19:58.268539",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.397259",
+     "start_time": "2026-05-26T09:19:58.239274",
      "status": "completed"
     },
     "tags": []
@@ -1752,16 +1752,16 @@
    "id": "recipe-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.583170Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.582868Z",
-     "iopub.status.idle": "2026-05-23T12:08:02.590249Z",
-     "shell.execute_reply": "2026-05-23T12:08:02.589196Z"
+     "iopub.execute_input": "2026-05-26T09:19:58.367347Z",
+     "iopub.status.busy": "2026-05-26T09:19:58.366328Z",
+     "iopub.status.idle": "2026-05-26T09:19:58.383078Z",
+     "shell.execute_reply": "2026-05-26T09:19:58.383078Z"
     },
     "papermill": {
-     "duration": 0.024749,
-     "end_time": "2026-05-23T12:08:02.589028",
+     "duration": 0.041855,
+     "end_time": "2026-05-26T09:19:58.383078",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.564279",
+     "start_time": "2026-05-26T09:19:58.341223",
      "status": "completed"
     },
     "tags": []
@@ -1902,10 +1902,10 @@
    "id": "section6-event",
    "metadata": {
     "papermill": {
-     "duration": 0.009239,
-     "end_time": "2026-05-23T12:08:02.611774",
+     "duration": 0.013903,
+     "end_time": "2026-05-26T09:19:58.419685",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.602535",
+     "start_time": "2026-05-26T09:19:58.405782",
      "status": "completed"
     },
     "tags": []
@@ -1922,16 +1922,16 @@
    "id": "event-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.643938Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.643477Z",
-     "iopub.status.idle": "2026-05-23T12:08:02.649546Z",
-     "shell.execute_reply": "2026-05-23T12:08:02.648737Z"
+     "iopub.execute_input": "2026-05-26T09:19:58.454926Z",
+     "iopub.status.busy": "2026-05-26T09:19:58.454926Z",
+     "iopub.status.idle": "2026-05-26T09:19:58.469549Z",
+     "shell.execute_reply": "2026-05-26T09:19:58.469111Z"
     },
     "papermill": {
-     "duration": 0.020837,
-     "end_time": "2026-05-23T12:08:02.648607",
+     "duration": 0.028479,
+     "end_time": "2026-05-26T09:19:58.469549",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.627770",
+     "start_time": "2026-05-26T09:19:58.441070",
      "status": "completed"
     },
     "tags": []
@@ -2024,10 +2024,10 @@
    "id": "section6-breadcrumb-faq",
    "metadata": {
     "papermill": {
-     "duration": 0.013635,
-     "end_time": "2026-05-23T12:08:02.673789",
+     "duration": 0.01345,
+     "end_time": "2026-05-26T09:19:58.498065",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.660154",
+     "start_time": "2026-05-26T09:19:58.484615",
      "status": "completed"
     },
     "tags": []
@@ -2046,16 +2046,16 @@
    "id": "breadcrumb-faq-schema",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.702628Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.702417Z",
-     "iopub.status.idle": "2026-05-23T12:08:02.711286Z",
-     "shell.execute_reply": "2026-05-23T12:08:02.709858Z"
+     "iopub.execute_input": "2026-05-26T09:19:58.542872Z",
+     "iopub.status.busy": "2026-05-26T09:19:58.542872Z",
+     "iopub.status.idle": "2026-05-26T09:19:58.554332Z",
+     "shell.execute_reply": "2026-05-26T09:19:58.554332Z"
     },
     "papermill": {
-     "duration": 0.032833,
-     "end_time": "2026-05-23T12:08:02.709434",
+     "duration": 0.031086,
+     "end_time": "2026-05-26T09:19:58.556966",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.676601",
+     "start_time": "2026-05-26T09:19:58.525880",
      "status": "completed"
     },
     "tags": []
@@ -2161,10 +2161,10 @@
    "id": "interpretation-usecases",
    "metadata": {
     "papermill": {
-     "duration": 0.016131,
-     "end_time": "2026-05-23T12:08:02.739636",
+     "duration": 0.014998,
+     "end_time": "2026-05-26T09:19:58.588801",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.723505",
+     "start_time": "2026-05-26T09:19:58.573803",
      "status": "completed"
     },
     "tags": []
@@ -2195,10 +2195,10 @@
    "id": "section7-title",
    "metadata": {
     "papermill": {
-     "duration": 0.034827,
-     "end_time": "2026-05-23T12:08:02.806436",
+     "duration": 0.014434,
+     "end_time": "2026-05-26T09:19:58.616760",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.771609",
+     "start_time": "2026-05-26T09:19:58.602326",
      "status": "completed"
     },
     "tags": []
@@ -2217,16 +2217,16 @@
    "id": "format-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:02.991097Z",
-     "iopub.status.busy": "2026-05-23T12:08:02.989834Z",
-     "iopub.status.idle": "2026-05-23T12:08:03.015360Z",
-     "shell.execute_reply": "2026-05-23T12:08:03.014355Z"
+     "iopub.execute_input": "2026-05-26T09:19:58.645087Z",
+     "iopub.status.busy": "2026-05-26T09:19:58.645087Z",
+     "iopub.status.idle": "2026-05-26T09:19:58.673782Z",
+     "shell.execute_reply": "2026-05-26T09:19:58.673782Z"
     },
     "papermill": {
-     "duration": 0.144142,
-     "end_time": "2026-05-23T12:08:03.014201",
+     "duration": 0.042849,
+     "end_time": "2026-05-26T09:19:58.673782",
      "exception": false,
-     "start_time": "2026-05-23T12:08:02.870059",
+     "start_time": "2026-05-26T09:19:58.630933",
      "status": "completed"
     },
     "tags": []
@@ -2289,9 +2289,9 @@
       "============================================================\n",
       "=== N-Triples (314 octets, 3 lignes) ===\n",
       "============================================================\n",
-      "<https://example.org/people/curie> <https://schema.org/birthDate> \"1867-11-07\"^^<http://www.w3.org/2001/XMLSchema#date> .\n",
       "<https://example.org/people/curie> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Person> .\n",
       "<https://example.org/people/curie> <https://schema.org/name> \"Marie Curie\" .\n",
+      "<https://example.org/people/curie> <https://schema.org/birthDate> \"1867-11-07\"^^<http://www.w3.org/2001/XMLSchema#date> .\n",
       "\n"
      ]
     }
@@ -2337,10 +2337,10 @@
    "id": "interpretation-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.015036,
-     "end_time": "2026-05-23T12:08:03.047446",
+     "duration": 0.016989,
+     "end_time": "2026-05-26T09:19:58.711867",
      "exception": false,
-     "start_time": "2026-05-23T12:08:03.032410",
+     "start_time": "2026-05-26T09:19:58.694878",
      "status": "completed"
     },
     "tags": []
@@ -2370,10 +2370,10 @@
    "id": "section8-title",
    "metadata": {
     "papermill": {
-     "duration": 0.013081,
-     "end_time": "2026-05-23T12:08:03.079101",
+     "duration": 0.014322,
+     "end_time": "2026-05-26T09:19:58.733064",
      "exception": false,
-     "start_time": "2026-05-23T12:08:03.066020",
+     "start_time": "2026-05-26T09:19:58.718742",
      "status": "completed"
     },
     "tags": []
@@ -2392,16 +2392,16 @@
    "id": "load-product-rdflib",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:03.115104Z",
-     "iopub.status.busy": "2026-05-23T12:08:03.114788Z",
-     "iopub.status.idle": "2026-05-23T12:08:03.748594Z",
-     "shell.execute_reply": "2026-05-23T12:08:03.747592Z"
+     "iopub.execute_input": "2026-05-26T09:19:58.770009Z",
+     "iopub.status.busy": "2026-05-26T09:19:58.770009Z",
+     "iopub.status.idle": "2026-05-26T09:19:59.816864Z",
+     "shell.execute_reply": "2026-05-26T09:19:59.816864Z"
     },
     "papermill": {
-     "duration": 0.652294,
-     "end_time": "2026-05-23T12:08:03.747460",
+     "duration": 1.069236,
+     "end_time": "2026-05-26T09:19:59.816864",
      "exception": false,
-     "start_time": "2026-05-23T12:08:03.095166",
+     "start_time": "2026-05-26T09:19:58.747628",
      "status": "completed"
     },
     "tags": []
@@ -2523,10 +2523,10 @@
    "id": "interpretation-product-rdflib",
    "metadata": {
     "papermill": {
-     "duration": 0.016636,
-     "end_time": "2026-05-23T12:08:03.774729",
+     "duration": 0.014069,
+     "end_time": "2026-05-26T09:19:59.845271",
      "exception": false,
-     "start_time": "2026-05-23T12:08:03.758093",
+     "start_time": "2026-05-26T09:19:59.831202",
      "status": "completed"
     },
     "tags": []
@@ -2547,10 +2547,10 @@
    "id": "exercises-title",
    "metadata": {
     "papermill": {
-     "duration": 0.126508,
-     "end_time": "2026-05-23T12:08:03.966940",
+     "duration": 0.018181,
+     "end_time": "2026-05-26T09:19:59.892255",
      "exception": false,
-     "start_time": "2026-05-23T12:08:03.840432",
+     "start_time": "2026-05-26T09:19:59.874074",
      "status": "completed"
     },
     "tags": []
@@ -2577,16 +2577,16 @@
    "id": "exercise1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:04.046842Z",
-     "iopub.status.busy": "2026-05-23T12:08:04.046147Z",
-     "iopub.status.idle": "2026-05-23T12:08:04.442891Z",
-     "shell.execute_reply": "2026-05-23T12:08:04.437342Z"
+     "iopub.execute_input": "2026-05-26T09:19:59.917759Z",
+     "iopub.status.busy": "2026-05-26T09:19:59.917759Z",
+     "iopub.status.idle": "2026-05-26T09:20:01.031916Z",
+     "shell.execute_reply": "2026-05-26T09:20:01.031916Z"
     },
     "papermill": {
-     "duration": 0.419708,
-     "end_time": "2026-05-23T12:08:04.443766",
+     "duration": 1.128938,
+     "end_time": "2026-05-26T09:20:01.031916",
      "exception": false,
-     "start_time": "2026-05-23T12:08:04.024058",
+     "start_time": "2026-05-26T09:19:59.902978",
      "status": "completed"
     },
     "tags": []
@@ -2625,19 +2625,19 @@
      "text": [
       "\n",
       "Triples : 13\n",
-      "  https://example.org/people/jlange http://schema.org/sameAs https://twitter.com/jlange\n",
-      "  https://example.org/people/jlange http://schema.org/email jules.lange@hotmail.fr\n",
-      "  N8038a1412b3a42e89c6381de97fe657f http://schema.org/name EPITA\n",
-      "  N991f85c2b0bf407c95c6b2662d3bbcf6 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/CollegeOrUniversity\n",
-      "  N991f85c2b0bf407c95c6b2662d3bbcf6 http://schema.org/name EPITA Paris\n",
-      "  https://example.org/people/jlange http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
-      "  https://example.org/people/jlange http://schema.org/telephone +33-6-12-34-56-78\n",
-      "  https://example.org/people/jlange http://schema.org/name Jules Lange\n",
-      "  https://example.org/people/jlange http://schema.org/worksFor N8038a1412b3a42e89c6381de97fe657f\n",
       "  https://example.org/people/jlange http://schema.org/sameAs https://linkedin.com/in/jules-lange\n",
-      "  N8038a1412b3a42e89c6381de97fe657f http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
+      "  https://example.org/people/jlange http://schema.org/alumniOf Nd8a567e0c8574feb9cfe3d22ac9629c3\n",
+      "  Nd8a567e0c8574feb9cfe3d22ac9629c3 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/CollegeOrUniversity\n",
+      "  https://example.org/people/jlange http://schema.org/telephone +33-6-12-34-56-78\n",
+      "  https://example.org/people/jlange http://schema.org/worksFor N70b8def235f64b33b3008e9da1082acc\n",
+      "  N70b8def235f64b33b3008e9da1082acc http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
+      "  https://example.org/people/jlange http://schema.org/email jules.lange@hotmail.fr\n",
+      "  N70b8def235f64b33b3008e9da1082acc http://schema.org/name EPITA\n",
+      "  https://example.org/people/jlange http://schema.org/name Jules Lange\n",
+      "  Nd8a567e0c8574feb9cfe3d22ac9629c3 http://schema.org/name EPITA Paris\n",
+      "  https://example.org/people/jlange http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
       "  https://example.org/people/jlange http://schema.org/jobTitle Etudiant ingenieur\n",
-      "  https://example.org/people/jlange http://schema.org/alumniOf N991f85c2b0bf407c95c6b2662d3bbcf6\n"
+      "  https://example.org/people/jlange http://schema.org/sameAs https://twitter.com/jlange\n"
      ]
     }
    ],
@@ -2681,10 +2681,10 @@
    "id": "5ef791b8",
    "metadata": {
     "papermill": {
-     "duration": 0.094529,
-     "end_time": "2026-05-23T12:08:04.642760",
+     "duration": 0.062358,
+     "end_time": "2026-05-26T09:20:01.228089",
      "exception": false,
-     "start_time": "2026-05-23T12:08:04.548231",
+     "start_time": "2026-05-26T09:20:01.165731",
      "status": "completed"
     },
     "tags": []
@@ -2709,16 +2709,16 @@
    "id": "3a7cb7af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:04.900221Z",
-     "iopub.status.busy": "2026-05-23T12:08:04.899795Z",
-     "iopub.status.idle": "2026-05-23T12:08:04.907704Z",
-     "shell.execute_reply": "2026-05-23T12:08:04.906251Z"
+     "iopub.execute_input": "2026-05-26T09:20:01.426007Z",
+     "iopub.status.busy": "2026-05-26T09:20:01.426007Z",
+     "iopub.status.idle": "2026-05-26T09:20:01.456566Z",
+     "shell.execute_reply": "2026-05-26T09:20:01.453838Z"
     },
     "papermill": {
-     "duration": 0.127573,
-     "end_time": "2026-05-23T12:08:04.906629",
+     "duration": 0.116616,
+     "end_time": "2026-05-26T09:20:01.457687",
      "exception": false,
-     "start_time": "2026-05-23T12:08:04.779056",
+     "start_time": "2026-05-26T09:20:01.341071",
      "status": "completed"
     },
     "tags": []
@@ -2749,10 +2749,10 @@
    "id": "exercise2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.047538,
-     "end_time": "2026-05-23T12:08:05.001349",
+     "duration": 0.064236,
+     "end_time": "2026-05-26T09:20:01.561062",
      "exception": false,
-     "start_time": "2026-05-23T12:08:04.953811",
+     "start_time": "2026-05-26T09:20:01.496826",
      "status": "completed"
     },
     "tags": []
@@ -2783,16 +2783,16 @@
    "id": "exercise2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:05.083368Z",
-     "iopub.status.busy": "2026-05-23T12:08:05.081840Z",
-     "iopub.status.idle": "2026-05-23T12:08:05.098486Z",
-     "shell.execute_reply": "2026-05-23T12:08:05.097060Z"
+     "iopub.execute_input": "2026-05-26T09:20:01.707324Z",
+     "iopub.status.busy": "2026-05-26T09:20:01.706334Z",
+     "iopub.status.idle": "2026-05-26T09:20:01.719329Z",
+     "shell.execute_reply": "2026-05-26T09:20:01.718330Z"
     },
     "papermill": {
-     "duration": 0.052536,
-     "end_time": "2026-05-23T12:08:05.097985",
+     "duration": 0.080242,
+     "end_time": "2026-05-26T09:20:01.722382",
      "exception": false,
-     "start_time": "2026-05-23T12:08:05.045449",
+     "start_time": "2026-05-26T09:20:01.642140",
      "status": "completed"
     },
     "tags": []
@@ -2803,6 +2803,17 @@
      "output_type": "stream",
      "text": [
       "[\n",
+      "  {\n",
+      "    \"@id\": \"https://example.org/saint-exupery\",\n",
+      "    \"@type\": [\n",
+      "      \"https://schema.org/Person\"\n",
+      "    ],\n",
+      "    \"https://schema.org/name\": [\n",
+      "      {\n",
+      "        \"@value\": \"Antoine de Saint-Exupery\"\n",
+      "      }\n",
+      "    ]\n",
+      "  },\n",
       "  {\n",
       "    \"@id\": \"https://example.org/book1\",\n",
       "    \"@type\": [\n",
@@ -2826,17 +2837,6 @@
       "    \"https://schema.org/name\": [\n",
       "      {\n",
       "        \"@value\": \"Le Petit Prince\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"https://example.org/saint-exupery\",\n",
-      "    \"@type\": [\n",
-      "      \"https://schema.org/Person\"\n",
-      "    ],\n",
-      "    \"https://schema.org/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Antoine de Saint-Exupery\"\n",
       "      }\n",
       "    ]\n",
       "  }\n",
@@ -2873,10 +2873,10 @@
    "id": "8ad733a9",
    "metadata": {
     "papermill": {
-     "duration": 0.015053,
-     "end_time": "2026-05-23T12:08:05.127477",
+     "duration": 0.014204,
+     "end_time": "2026-05-26T09:20:01.762638",
      "exception": false,
-     "start_time": "2026-05-23T12:08:05.112424",
+     "start_time": "2026-05-26T09:20:01.748434",
      "status": "completed"
     },
     "tags": []
@@ -2909,16 +2909,16 @@
    "id": "35feca2f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:05.174958Z",
-     "iopub.status.busy": "2026-05-23T12:08:05.174728Z",
-     "iopub.status.idle": "2026-05-23T12:08:05.180020Z",
-     "shell.execute_reply": "2026-05-23T12:08:05.178656Z"
+     "iopub.execute_input": "2026-05-26T09:20:01.853599Z",
+     "iopub.status.busy": "2026-05-26T09:20:01.852239Z",
+     "iopub.status.idle": "2026-05-26T09:20:01.866588Z",
+     "shell.execute_reply": "2026-05-26T09:20:01.866588Z"
     },
     "papermill": {
-     "duration": 0.035237,
-     "end_time": "2026-05-23T12:08:05.178490",
+     "duration": 0.086944,
+     "end_time": "2026-05-26T09:20:01.870208",
      "exception": false,
-     "start_time": "2026-05-23T12:08:05.143253",
+     "start_time": "2026-05-26T09:20:01.783264",
      "status": "completed"
     },
     "tags": []
@@ -2948,10 +2948,10 @@
    "id": "exercise3-title",
    "metadata": {
     "papermill": {
-     "duration": 0.016895,
-     "end_time": "2026-05-23T12:08:05.229179",
+     "duration": 0.013645,
+     "end_time": "2026-05-26T09:20:01.913875",
      "exception": false,
-     "start_time": "2026-05-23T12:08:05.212284",
+     "start_time": "2026-05-26T09:20:01.900230",
      "status": "completed"
     },
     "tags": []
@@ -2974,16 +2974,16 @@
    "id": "exercise3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:05.308595Z",
-     "iopub.status.busy": "2026-05-23T12:08:05.308008Z",
-     "iopub.status.idle": "2026-05-23T12:08:08.013622Z",
-     "shell.execute_reply": "2026-05-23T12:08:08.012531Z"
+     "iopub.execute_input": "2026-05-26T09:20:01.958985Z",
+     "iopub.status.busy": "2026-05-26T09:20:01.958985Z",
+     "iopub.status.idle": "2026-05-26T09:20:04.006290Z",
+     "shell.execute_reply": "2026-05-26T09:20:04.005302Z"
     },
     "papermill": {
-     "duration": 2.766352,
-     "end_time": "2026-05-23T12:08:08.012417",
+     "duration": 2.069097,
+     "end_time": "2026-05-26T09:20:04.006290",
      "exception": false,
-     "start_time": "2026-05-23T12:08:05.246065",
+     "start_time": "2026-05-26T09:20:01.937193",
      "status": "completed"
     },
     "tags": []
@@ -3128,10 +3128,10 @@
    "id": "d02931a8",
    "metadata": {
     "papermill": {
-     "duration": 0.009261,
-     "end_time": "2026-05-23T12:08:08.031447",
+     "duration": 0.097775,
+     "end_time": "2026-05-26T09:20:04.139796",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.022186",
+     "start_time": "2026-05-26T09:20:04.042021",
      "status": "completed"
     },
     "tags": []
@@ -3157,16 +3157,16 @@
    "id": "9521dae4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:08.079565Z",
-     "iopub.status.busy": "2026-05-23T12:08:08.079223Z",
-     "iopub.status.idle": "2026-05-23T12:08:08.084193Z",
-     "shell.execute_reply": "2026-05-23T12:08:08.083198Z"
+     "iopub.execute_input": "2026-05-26T09:20:04.332330Z",
+     "iopub.status.busy": "2026-05-26T09:20:04.330339Z",
+     "iopub.status.idle": "2026-05-26T09:20:04.357521Z",
+     "shell.execute_reply": "2026-05-26T09:20:04.356022Z"
     },
     "papermill": {
-     "duration": 0.025391,
-     "end_time": "2026-05-23T12:08:08.083106",
+     "duration": 0.102715,
+     "end_time": "2026-05-26T09:20:04.360519",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.057715",
+     "start_time": "2026-05-26T09:20:04.257804",
      "status": "completed"
     },
     "tags": []
@@ -3197,10 +3197,10 @@
    "id": "4a9cd33a",
    "metadata": {
     "papermill": {
-     "duration": 0.016343,
-     "end_time": "2026-05-23T12:08:08.112356",
+     "duration": 0.090513,
+     "end_time": "2026-05-26T09:20:04.498381",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.096013",
+     "start_time": "2026-05-26T09:20:04.407868",
      "status": "completed"
     },
     "tags": []
@@ -3222,16 +3222,16 @@
    "id": "6aa6a1e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:08.157691Z",
-     "iopub.status.busy": "2026-05-23T12:08:08.157447Z",
-     "iopub.status.idle": "2026-05-23T12:08:08.568494Z",
-     "shell.execute_reply": "2026-05-23T12:08:08.567390Z"
+     "iopub.execute_input": "2026-05-26T09:20:04.625313Z",
+     "iopub.status.busy": "2026-05-26T09:20:04.624177Z",
+     "iopub.status.idle": "2026-05-26T09:20:07.387761Z",
+     "shell.execute_reply": "2026-05-26T09:20:07.387761Z"
     },
     "papermill": {
-     "duration": 0.439168,
-     "end_time": "2026-05-23T12:08:08.567344",
+     "duration": 2.782446,
+     "end_time": "2026-05-26T09:20:07.387761",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.128176",
+     "start_time": "2026-05-26T09:20:04.605315",
      "status": "completed"
     },
     "tags": []
@@ -3316,7 +3316,7 @@
       "    ],\n",
       "    \"http://schema.org/location\": [\n",
       "      {\n",
-      "        \"@id\": \"_:Nf5493317e1c241df8f91211fe04848bf\"\n",
+      "        \"@id\": \"_:N3576a8e94b7c4baa9772f72ff501cabc\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -3326,13 +3326,13 @@
       "    ],\n",
       "    \"http://schema.org/performer\": [\n",
       "      {\n",
-      "        \"@id\": \"_:Ncd6119c515cb4b3596c16db5f25c69ea\"\n",
+      "        \"@id\": \"_:N1462f754b7874e87bcc2b98d22b17a21\"\n",
       "      },\n",
       "      {\n",
-      "        \"@id\": \"_:N779d2ff8a0de48efa3b3d61693a01747\"\n",
+      "        \"@id\": \"_:N677dec5916c24c2185800b1d58d7f52e\"\n",
       "      },\n",
       "      {\n",
-      "        \"@id\": \"_:N88dbbc6d39dc4756936f7eea60b49fcc\"\n",
+      "        \"@id\": \"_:Nb416deafeae24c898d8447d86beafbb0\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/startDate\": [\n",
@@ -3343,15 +3343,15 @@
       "    ],\n",
       "    \"http://schema.org/subEvent\": [\n",
       "      {\n",
-      "        \"@id\": \"_:N1650f61f687f410184ad9f3d2c03ee7b\"\n",
+      "        \"@id\": \"_:N17c915ce17a946f189ef78a10a98fc9b\"\n",
       "      },\n",
       "      {\n",
-      "        \"@id\": \"_:N3ec909c6b03f4d5187581896a077e0a8\"\n",
+      "        \"@id\": \"_:N5afae2b899c247cea5dd63911057f3d3\"\n",
       "      }\n",
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:Nf5493317e1c241df8f91211fe04848bf\",\n",
+      "    \"@id\": \"_:N3576a8e94b7c4baa9772f72ff501cabc\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Place\"\n",
       "    ],\n",
@@ -3367,7 +3367,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:N1650f61f687f410184ad9f3d2c03ee7b\",\n",
+      "    \"@id\": \"_:N17c915ce17a946f189ef78a10a98fc9b\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Event\"\n",
       "    ],\n",
@@ -3390,7 +3390,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:N3ec909c6b03f4d5187581896a077e0a8\",\n",
+      "    \"@id\": \"_:N5afae2b899c247cea5dd63911057f3d3\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Event\"\n",
       "    ],\n",
@@ -3413,13 +3413,13 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:Ncd6119c515cb4b3596c16db5f25c69ea\",\n",
+      "    \"@id\": \"_:N1462f754b7874e87bcc2b98d22b17a21\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Person\"\n",
       "    ],\n",
       "    \"http://schema.org/affiliation\": [\n",
       "      {\n",
-      "        \"@id\": \"_:Nb32e1e812f414bceab8081389331c8f3\"\n",
+      "        \"@id\": \"_:N325194dc330844aaa724f1cc57053fd4\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -3429,7 +3429,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:Nb32e1e812f414bceab8081389331c8f3\",\n",
+      "    \"@id\": \"_:N325194dc330844aaa724f1cc57053fd4\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Organization\"\n",
       "    ],\n",
@@ -3440,13 +3440,13 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:N779d2ff8a0de48efa3b3d61693a01747\",\n",
+      "    \"@id\": \"_:N677dec5916c24c2185800b1d58d7f52e\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Person\"\n",
       "    ],\n",
       "    \"http://schema.org/affiliation\": [\n",
       "      {\n",
-      "        \"@id\": \"_:Nb7b63002dbb44580919f8ff2f660f71e\"\n",
+      "        \"@id\": \"_:N6ec84279b8ce4a53903a12d56d092813\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -3456,7 +3456,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:Nb7b63002dbb44580919f8ff2f660f71e\",\n",
+      "    \"@id\": \"_:N6ec84279b8ce4a53903a12d56d092813\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Organization\"\n",
       "    ],\n",
@@ -3467,13 +3467,13 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:N88dbbc6d39dc4756936f7eea60b49fcc\",\n",
+      "    \"@id\": \"_:Nb416deafeae24c898d8447d86beafbb0\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Person\"\n",
       "    ],\n",
       "    \"http://schema.org/affiliation\": [\n",
       "      {\n",
-      "        \"@id\": \"_:Nc8c9d42f5a2a43069ed67b92134f9ad2\"\n",
+      "        \"@id\": \"_:N6f93356d7fbc4e4686aa34d3d0be57cc\"\n",
       "      }\n",
       "    ],\n",
       "    \"http://schema.org/name\": [\n",
@@ -3483,7 +3483,7 @@
       "    ]\n",
       "  },\n",
       "  {\n",
-      "    \"@id\": \"_:Nc8c9d42f5a2a43069ed67b92134f9ad2\",\n",
+      "    \"@id\": \"_:N6f93356d7fbc4e4686aa34d3d0be57cc\",\n",
       "    \"@type\": [\n",
       "      \"http://schema.org/Organization\"\n",
       "    ],\n",
@@ -3496,42 +3496,42 @@
       "]\n",
       "\n",
       "Triples generes : 36\n",
-      "  Nc8c9d42f5a2a43069ed67b92134f9ad2 http://schema.org/name Sorbonne Universite\n",
-      "  N779d2ff8a0de48efa3b3d61693a01747 http://schema.org/affiliation Nb7b63002dbb44580919f8ff2f660f71e\n",
-      "  N88dbbc6d39dc4756936f7eea60b49fcc http://schema.org/affiliation Nc8c9d42f5a2a43069ed67b92134f9ad2\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/endDate 2026-06-17\n",
-      "  Nf5493317e1c241df8f91211fe04848bf http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Place\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/name Symposium IA Symbolique 2026\n",
-      "  https://example.org/conf/symbolicai2026 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Conference\n",
-      "  Ncd6119c515cb4b3596c16db5f25c69ea http://schema.org/affiliation Nb32e1e812f414bceab8081389331c8f3\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/subEvent N3ec909c6b03f4d5187581896a077e0a8\n",
-      "  N1650f61f687f410184ad9f3d2c03ee7b http://schema.org/endDate 2026-06-15T12:00\n",
-      "  N779d2ff8a0de48efa3b3d61693a01747 http://schema.org/name Bob Durand\n",
-      "  N88dbbc6d39dc4756936f7eea60b49fcc http://schema.org/name Claire Petit\n",
-      "  N3ec909c6b03f4d5187581896a077e0a8 http://schema.org/endDate 2026-06-16T17:00\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/location Nf5493317e1c241df8f91211fe04848bf\n",
-      "  Nc8c9d42f5a2a43069ed67b92134f9ad2 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
-      "  Nf5493317e1c241df8f91211fe04848bf http://schema.org/name EPITA Paris\n",
-      "  Ncd6119c515cb4b3596c16db5f25c69ea http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
-      "  N1650f61f687f410184ad9f3d2c03ee7b http://schema.org/startDate 2026-06-15T09:00\n",
+      "  N5afae2b899c247cea5dd63911057f3d3 http://schema.org/name Session - Argumentation et dialogues\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/location N3576a8e94b7c4baa9772f72ff501cabc\n",
+      "  N1462f754b7874e87bcc2b98d22b17a21 http://schema.org/affiliation N325194dc330844aaa724f1cc57053fd4\n",
+      "  N6ec84279b8ce4a53903a12d56d092813 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
+      "  N5afae2b899c247cea5dd63911057f3d3 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Event\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/subEvent N17c915ce17a946f189ef78a10a98fc9b\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/performer N1462f754b7874e87bcc2b98d22b17a21\n",
       "  https://example.org/conf/symbolicai2026 http://schema.org/startDate 2026-06-15\n",
-      "  N3ec909c6b03f4d5187581896a077e0a8 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Event\n",
-      "  Nb7b63002dbb44580919f8ff2f660f71e http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/performer N779d2ff8a0de48efa3b3d61693a01747\n",
-      "  N3ec909c6b03f4d5187581896a077e0a8 http://schema.org/startDate 2026-06-16T14:00\n",
-      "  N779d2ff8a0de48efa3b3d61693a01747 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
-      "  N1650f61f687f410184ad9f3d2c03ee7b http://schema.org/name Session - Logiques non monotones\n",
-      "  Ncd6119c515cb4b3596c16db5f25c69ea http://schema.org/name Alice Martin\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/performer N88dbbc6d39dc4756936f7eea60b49fcc\n",
-      "  N3ec909c6b03f4d5187581896a077e0a8 http://schema.org/name Session - Argumentation et dialogues\n",
-      "  Nb32e1e812f414bceab8081389331c8f3 http://schema.org/name INRIA\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/performer Ncd6119c515cb4b3596c16db5f25c69ea\n",
-      "  Nf5493317e1c241df8f91211fe04848bf http://schema.org/address 14-16 rue Voltaire, 94270 Le Kremlin-Bicetre\n",
-      "  N1650f61f687f410184ad9f3d2c03ee7b http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Event\n",
-      "  Nb32e1e812f414bceab8081389331c8f3 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
-      "  https://example.org/conf/symbolicai2026 http://schema.org/subEvent N1650f61f687f410184ad9f3d2c03ee7b\n",
-      "  N88dbbc6d39dc4756936f7eea60b49fcc http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
-      "  Nb7b63002dbb44580919f8ff2f660f71e http://schema.org/name CNRS\n"
+      "  N3576a8e94b7c4baa9772f72ff501cabc http://schema.org/address 14-16 rue Voltaire, 94270 Le Kremlin-Bicetre\n",
+      "  N1462f754b7874e87bcc2b98d22b17a21 http://schema.org/name Alice Martin\n",
+      "  N5afae2b899c247cea5dd63911057f3d3 http://schema.org/endDate 2026-06-16T17:00\n",
+      "  Nb416deafeae24c898d8447d86beafbb0 http://schema.org/name Claire Petit\n",
+      "  N1462f754b7874e87bcc2b98d22b17a21 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
+      "  N325194dc330844aaa724f1cc57053fd4 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
+      "  N3576a8e94b7c4baa9772f72ff501cabc http://schema.org/name EPITA Paris\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/name Symposium IA Symbolique 2026\n",
+      "  N6ec84279b8ce4a53903a12d56d092813 http://schema.org/name CNRS\n",
+      "  N325194dc330844aaa724f1cc57053fd4 http://schema.org/name INRIA\n",
+      "  N6f93356d7fbc4e4686aa34d3d0be57cc http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Organization\n",
+      "  Nb416deafeae24c898d8447d86beafbb0 http://schema.org/affiliation N6f93356d7fbc4e4686aa34d3d0be57cc\n",
+      "  N17c915ce17a946f189ef78a10a98fc9b http://schema.org/name Session - Logiques non monotones\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/performer N677dec5916c24c2185800b1d58d7f52e\n",
+      "  N677dec5916c24c2185800b1d58d7f52e http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
+      "  Nb416deafeae24c898d8447d86beafbb0 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Person\n",
+      "  N6f93356d7fbc4e4686aa34d3d0be57cc http://schema.org/name Sorbonne Universite\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/subEvent N5afae2b899c247cea5dd63911057f3d3\n",
+      "  N5afae2b899c247cea5dd63911057f3d3 http://schema.org/startDate 2026-06-16T14:00\n",
+      "  N17c915ce17a946f189ef78a10a98fc9b http://schema.org/startDate 2026-06-15T09:00\n",
+      "  N17c915ce17a946f189ef78a10a98fc9b http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Event\n",
+      "  N3576a8e94b7c4baa9772f72ff501cabc http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Place\n",
+      "  N677dec5916c24c2185800b1d58d7f52e http://schema.org/affiliation N6ec84279b8ce4a53903a12d56d092813\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/performer Nb416deafeae24c898d8447d86beafbb0\n",
+      "  N677dec5916c24c2185800b1d58d7f52e http://schema.org/name Bob Durand\n",
+      "  N17c915ce17a946f189ef78a10a98fc9b http://schema.org/endDate 2026-06-15T12:00\n",
+      "  https://example.org/conf/symbolicai2026 http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://schema.org/Conference\n",
+      "  https://example.org/conf/symbolicai2026 http://schema.org/endDate 2026-06-17\n"
      ]
     }
    ],
@@ -3612,10 +3612,10 @@
    "id": "68b4a35f",
    "metadata": {
     "papermill": {
-     "duration": 0.016052,
-     "end_time": "2026-05-23T12:08:08.600594",
+     "duration": 0.136171,
+     "end_time": "2026-05-26T09:20:07.596181",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.584542",
+     "start_time": "2026-05-26T09:20:07.460010",
      "status": "completed"
     },
     "tags": []
@@ -3637,16 +3637,16 @@
    "id": "08d2cdb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T12:08:08.631970Z",
-     "iopub.status.busy": "2026-05-23T12:08:08.631616Z",
-     "iopub.status.idle": "2026-05-23T12:08:08.636651Z",
-     "shell.execute_reply": "2026-05-23T12:08:08.635578Z"
+     "iopub.execute_input": "2026-05-26T09:20:07.880342Z",
+     "iopub.status.busy": "2026-05-26T09:20:07.870251Z",
+     "iopub.status.idle": "2026-05-26T09:20:07.934032Z",
+     "shell.execute_reply": "2026-05-26T09:20:07.926873Z"
     },
     "papermill": {
-     "duration": 0.021281,
-     "end_time": "2026-05-23T12:08:08.636761",
+     "duration": 0.252644,
+     "end_time": "2026-05-26T09:20:07.954081",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.615480",
+     "start_time": "2026-05-26T09:20:07.701437",
      "status": "completed"
     },
     "tags": []
@@ -3674,13 +3674,239 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6ac0a68b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.056335,
+     "end_time": "2026-05-26T09:20:08.061428",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.005093",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : `@list` vs ensemble par defaut (ordre des elements)\n",
+    "\n",
+    "Par defaut, les tableaux JSON en JSON-LD sont consideres comme des **multisets non ordonnes** : l'ordre des elements n'est pas significatif. Le mot-cle `@list` force une interpretation **ordonnee** (RDF list / `rdf:first`/`rdf:rest`).\n",
+    "\n",
+    "Modelisez une recette de cuisine avec un champ `recipeIngredient` au format `@list` (les ingredients doivent etre ajoutes dans l'ordre indique) et un champ `recipeCategory` au format ensemble (l'ordre est arbitraire).\n",
+    "\n",
+    "Chargez le document dans rdflib et verifiez que les triples generes pour `recipeIngredient` utilisent bien la structure `rdf:first`/`rdf:rest`/`rdf:nil` (alors que `recipeCategory` produit des triples plats).\n",
+    "\n",
+    "**Indice** :\n",
+    "```json\n",
+    "\"recipeIngredient\": {\"@list\": [\"farine\", \"sucre\", \"oeufs\"]}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "04768456",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:20:08.226649Z",
+     "iopub.status.busy": "2026-05-26T09:20:08.226649Z",
+     "iopub.status.idle": "2026-05-26T09:20:08.277381Z",
+     "shell.execute_reply": "2026-05-26T09:20:08.266239Z"
+    },
+    "papermill": {
+     "duration": 0.13297,
+     "end_time": "2026-05-26T09:20:08.280639",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.147669",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Recipe avec @list pour ingredients ordonnes\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 5 : @list pour ordonner les ingredients\n",
+    "# TODO etudiant : creer un Recipe JSON-LD avec recipeIngredient en @list\n",
+    "# Indice : inspecter les triples generes (rdflib) pour voir rdf:first/rdf:rest/rdf:nil\n",
+    "\n",
+    "import json\n",
+    "from rdflib import Graph\n",
+    "\n",
+    "recipe_jsonld = None  # TODO etudiant : creer le document\n",
+    "\n",
+    "print(\"Exercice a completer : Recipe avec @list pour ingredients ordonnes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f38b0127",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016902,
+     "end_time": "2026-05-26T09:20:08.349715",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.332813",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 6 : Annotations multilingues avec `@language`\n",
+    "\n",
+    "JSON-LD permet d'attacher une langue a une chaine de caracteres via `@language` (dans `@context` ou inline). Cela genere en RDF un litteral avec tag de langue (par exemple `\"Bonjour\"@fr`).\n",
+    "\n",
+    "Modelisez une `Article` Schema.org avec :\n",
+    "- `headline` en francais, anglais et espagnol (3 versions)\n",
+    "- `description` en francais et anglais (2 versions)\n",
+    "\n",
+    "Utilisez la syntaxe `\"@value\"` + `\"@language\"` pour chaque valeur multilingue. Chargez dans rdflib et listez les litteraux distincts avec leur langue via SPARQL.\n",
+    "\n",
+    "**Indice** :\n",
+    "```json\n",
+    "\"headline\": [\n",
+    "  {\"@value\": \"Titre francais\", \"@language\": \"fr\"},\n",
+    "  {\"@value\": \"English title\", \"@language\": \"en\"}\n",
+    "]\n",
+    "```\n",
+    "\n",
+    "SPARQL utile : `SELECT ?lit ?lang WHERE { ?s schema:headline ?lit . BIND(LANG(?lit) AS ?lang) }`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "981b8c6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:20:08.431492Z",
+     "iopub.status.busy": "2026-05-26T09:20:08.429584Z",
+     "iopub.status.idle": "2026-05-26T09:20:08.463802Z",
+     "shell.execute_reply": "2026-05-26T09:20:08.454986Z"
+    },
+    "papermill": {
+     "duration": 0.083615,
+     "end_time": "2026-05-26T09:20:08.467981",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.384366",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : Article avec headlines multilingues\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 6 : annotations multilingues @language\n",
+    "# TODO etudiant : Article avec headline (fr/en/es) et description (fr/en)\n",
+    "# Indice : utiliser {\"@value\": ..., \"@language\": ...} ; SPARQL LANG(?lit)\n",
+    "\n",
+    "import json\n",
+    "from rdflib import Graph\n",
+    "\n",
+    "article_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD multilingue\n",
+    "\n",
+    "print(\"Exercice a completer : Article avec headlines multilingues\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24210cde",
+   "metadata": {
+    "papermill": {
+     "duration": 0.030075,
+     "end_time": "2026-05-26T09:20:08.556205",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.526130",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 7 : `@reverse` pour propriete inverse\n",
+    "\n",
+    "Le mot-cle `@reverse` permet d'exprimer une relation **en sens inverse** depuis l'objet vers le sujet, sans avoir a definir une propriete miroir dans le vocabulaire. Utile pour Schema.org ou seul `parent` est defini (pas `child`).\n",
+    "\n",
+    "Modelisez une famille en partant d'un parent et en attachant ses enfants via `@reverse: parent` (l'enfant pointe vers son parent en RDF, mais c'est ecrit depuis le parent en JSON-LD).\n",
+    "\n",
+    "Verifiez en SPARQL que les triples generes sont bien `?enfant schema:parent ?parent` (et non l'inverse).\n",
+    "\n",
+    "**Indice** :\n",
+    "```json\n",
+    "{\n",
+    "  \"@id\": \"https://example.org/parent/marie\",\n",
+    "  \"@type\": \"Person\",\n",
+    "  \"name\": \"Marie\",\n",
+    "  \"@reverse\": {\n",
+    "    \"parent\": [\n",
+    "      {\"@id\": \"https://example.org/child/lucie\", \"@type\": \"Person\", \"name\": \"Lucie\"}\n",
+    "    ]\n",
+    "  }\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "91d35432",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-26T09:20:08.596846Z",
+     "iopub.status.busy": "2026-05-26T09:20:08.594825Z",
+     "iopub.status.idle": "2026-05-26T09:20:08.612152Z",
+     "shell.execute_reply": "2026-05-26T09:20:08.612152Z"
+    },
+    "papermill": {
+     "duration": 0.035404,
+     "end_time": "2026-05-26T09:20:08.612152",
+     "exception": false,
+     "start_time": "2026-05-26T09:20:08.576748",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : famille modelisee avec @reverse: parent\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 7 : @reverse pour propriete inverse\n",
+    "# TODO etudiant : modeliser une famille via @reverse: parent\n",
+    "# Indice : verifier en SPARQL que les triples sont (?child schema:parent ?parent)\n",
+    "\n",
+    "import json\n",
+    "from rdflib import Graph\n",
+    "\n",
+    "family_jsonld = None  # TODO etudiant : remplacer par le document JSON-LD avec @reverse\n",
+    "\n",
+    "print(\"Exercice a completer : famille modelisee avec @reverse: parent\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "summary-title",
    "metadata": {
     "papermill": {
-     "duration": 0.016695,
-     "end_time": "2026-05-23T12:08:08.667513",
+     "duration": 0.021087,
+     "end_time": "2026-05-26T09:20:08.652956",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.650818",
+     "start_time": "2026-05-26T09:20:08.631869",
      "status": "completed"
     },
     "tags": []
@@ -3728,10 +3954,10 @@
    "id": "footer-nav",
    "metadata": {
     "papermill": {
-     "duration": 0.033784,
-     "end_time": "2026-05-23T12:08:08.701297",
+     "duration": 0.028054,
+     "end_time": "2026-05-26T09:20:08.696400",
      "exception": false,
-     "start_time": "2026-05-23T12:08:08.667513",
+     "start_time": "2026-05-26T09:20:08.668346",
      "status": "completed"
     },
     "tags": []
@@ -3763,18 +3989,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.267801,
-   "end_time": "2026-05-23T12:08:09.066783",
+   "duration": 22.629536,
+   "end_time": "2026-05-26T09:20:11.812444",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb",
    "output_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb",
    "parameters": {},
-   "start_time": "2026-05-23T12:07:52.798982",
+   "start_time": "2026-05-26T09:19:49.182908",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Track 1 #1455 bascule pour EPITA-IS SW (cours 3 du 1er juin) : ajoute 3 exercices avancés après les Exemples et Exercices préexistants dans `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb`.

SW-9 avait **déjà le pattern bascule appliqué** : 4 Exemples guidés (Person, Turtle->JSON-LD, Recipe, Conferences) + 4 Exercices (Organization, JSON-LD->Turtle, Event, Cours universitaire). Cette PR enrichit le notebook avec des compétences avancées **non couvertes**.

Les 3 nouveaux exercices testent des keywords JSON-LD avancés :

- **Exercice 5 — `@list` vs ensemble par défaut** : modélise une recette avec `recipeIngredient` ordonné (rdf:first/rdf:rest/rdf:nil) et `recipeCategory` non ordonné ; vérification structurelle des triples générés
- **Exercice 6 — Annotations multilingues `@language`** : `Article.headline` en fr/en/es et `Article.description` en fr/en ; SPARQL `LANG(?lit)` pour lister les littéraux par langue
- **Exercice 7 — `@reverse`** : exprimer une relation inverse Schema.org (parent ← child) sans redéfinir une propriété miroir dans le vocabulaire

Tous les stubs respectent **C.1 (notebook-conventions)** : `print(\"Exercice a completer\")`, **aucun** `raise NotImplementedError` / `assert False` / `1/0`. Indices avec snippets JSON-LD pour démarrer l'étudiant.

Classification respecte la règle [exercise-example-labeling](../blob/main/.claude/rules/exercise-example-labeling.md) : nouveaux exercices = stubs (Exercice), aucun Exemple ou Exercice préexistant touché.

## Test plan

- [x] **Papermill execution** : conda env `mcp-jupyter`, kernel `python3`, `--cwd MyIA.AI.Notebooks/SymbolicAI/SemanticWeb` : **76/76 cells, 0 errors, 30/30 code cells exécutées** (sorties commitées, règle C.2)
- [x] **C.1 compliance** : `grep -nE \"raise NotImplementedError|assert False|1/0\"` → 0 match
- [x] **C.2 compliance** : 30/30 cells code avec `execution_count` + `outputs`
- [x] **C.3 compliance** : seul `SW-9-Python-JSONLD.ipynb` touché, scope strict
- [x] **Anti-régression** : sections 1-8 + 4 Exemples guidés + 4 Exercices préexistants préservés ; ajout uniquement (entre Exercice 4 et `## Resume`)
- [x] **Pédagogie** : `@list`, `@language`, `@reverse` sont des keywords JSON-LD essentiels non couverts par les Exemples ou Exercices existants → enrichissement cohérent

Refs #1455