### PR TITLE
fix(slides): remove max-width div wrappers for image positioning (#1240)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -829,3 +829,9 @@ MyIA.AI.Notebooks/QuantConnect/research/rl_multi_asset_curves.png
 
 # PowerShell artifact
 $null
+
+# Root-level libs/ (Tweety JARs downloaded by setup scripts — use SymbolicAI/Tweety/libs/ instead)
+/libs/
+
+# Temp OWL files from notebook execution
+MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/data/temp_*.owl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,25 @@ Incident 2026-04-24 : commit "Mathlib compilation fixes" (#524) a remplace 9 pre
 
 Detail complet : [.claude/rules/code-style.md](.claude/rules/code-style.md) (auto-loaded a chaque session).
 
-### F. Environnement Python — REPARER, ne JAMAIS contourner
+### F. Environnement — REPARER, ne JAMAIS contourner (HARD)
 
-**Regle user 2026-05-06** : un env Python degrade ne se contourne **jamais** par delegation, fallback ou skip. On repare, on demande UAC user au besoin. Detail : [docs/env-python-reparation.md](docs/env-python-reparation.md).
+**Regle user 2026-05-06 (Python) + 2026-05-26 (kernels)** : un env degrade ou un kernel manquant ne se contourne **jamais** par delegation, fallback ou skip. On **installe** le kernel/env manquant sur la machine locale, on demande UAC user au besoin. Detail Python : [docs/env-python-reparation.md](docs/env-python-reparation.md).
+
+**Kernels — installation obligatoire avant toute modification de notebook** :
+
+| Kernel | Installation | Verification |
+|--------|-------------|-------------|
+| .NET Interactive (C#) | `dotnet tool install --global Microsoft.dotnet-interactive@1.0.552801` puis `dotnet interactive jupyter install` | `jupyter kernelspec list` doit montrer `.NET (C#)` |
+| Python 3 | conda env dédié (voir ci-dessous) | `jupyter kernelspec list` doit montrer `python3` |
+| Lean 4 | `elan toolchain install stable` | `jupyter kernelspec list` doit montrer `lean4` |
+
+**Anti-patterns INTERDITS** (incident PR #1591 ML.Net, commit `4ca477e`) :
+- "kernel not available locally" dans un body PR = **manquement grave** à H.2
+- Déleguer la re-exécution à ai-01 au lieu d'installer le kernel = **contournement** de la règle F
+- Committer un notebook sans re-exécuter les cells modifiées = violation C.2
+- "je n'ai pas le temps d'installer" = pas une excuse
+
+**Exception** : GPU-only notebooks (CUDA requis sur machine CPU-only) — documenter explicitement et demander re-exécution sur machine GPU. Mais .NET Interactive, Python, Lean = installables **partout**.
 
 **Envs Conda dedies sur ai-01** (utiliser AVANT de toucher Python systeme) :
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/download_tweety_tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/download_tweety_tools.py
@@ -145,8 +145,19 @@ def get_script_dir() -> pathlib.Path:
     try:
         return pathlib.Path(__file__).parent.resolve()
     except NameError:
-        # Exécuté depuis un notebook ou un REPL
-        return pathlib.Path.cwd()
+        # Exécuté depuis un notebook ou un REPL — chercher le bon répertoire Tweety
+        cwd = pathlib.Path.cwd()
+        # Si CWD est la racine du repo ou un parent, chercher le sous-répertoire Tweety
+        candidate = cwd / "MyIA.AI.Notebooks" / "SymbolicAI" / "Tweety" / "scripts"
+        if candidate.is_dir():
+            return candidate
+        # Si CWD est déjà dans l'arborescence Tweety, utiliser le scripts/ le plus proche
+        for parent in [cwd, *cwd.parents]:
+            scripts_dir = parent / "scripts" / "download_tweety_tools.py"
+            if scripts_dir.exists():
+                return scripts_dir.parent
+        # Dernier recours : CWD (comportement historique)
+        return cwd
 
 
 def download_with_progress(url: str, dest: pathlib.Path, desc: str = "Downloading") -> bool:

--- a/slides/01-introduction/slides.md
+++ b/slides/01-introduction/slides.md
@@ -152,15 +152,11 @@ layout: section
 
 <img src="./images/img_002.png" style="position:absolute; top:80px; right:20px; width:340px;" alt="Quatre definitions de l'IA" />
 
-<div style="max-width:55%;">
-
 - **Des definitions multiples et un concept evolutif**
-  - L'IA n'a pas de definition unique : elle recouvre des approches tres differentes
-  - Concevoir un systeme intelligent n'implique pas de comprendre l'intelligence
+  - L'IA n'a pas de definition unique : elle recouvre des<br>approches tres differentes
+  - Concevoir un systeme intelligent n'implique pas de<br>comprendre l'intelligence
 - **Une definition qui evolue avec la technologie :**
-  - Automates → Calculateurs → Algorithmes → Bases de connaissances → Systemes experts → Apprentissage profond → IA generative
-
-</div>
+  - Automates → Calculateurs → Algorithmes →<br>Bases de connaissances → Systemes experts →<br>Apprentissage profond → IA generative
 
 ---
 
@@ -201,19 +197,15 @@ image: ./images/img_004.png
 
 <img src="./images/img_004.png" style="position:absolute; top:60px; right:20px; width:340px;" alt="Frise chronologique IA" />
 
-<div style="max-width:55%;">
-
 **Les debuts (1943-1970)**
-- **1943** : McCulloch & Pitts modelisent le cerveau comme un circuit logique
+- **1943** : McCulloch & Pitts modelisent le cerveau<br>comme un circuit logique
 - **1950** : Turing pose la question "Can machines think?"
-- **1956** : Conference de Dartmouth -- le terme "Artificial Intelligence" est ne
+- **1956** : Conference de Dartmouth -- le terme<br>"Artificial Intelligence" est ne
 - **Annees 50** : premiers programmes capables d'apprendre
   - Samuel (jeu de dames), Newell & Simon (theoricien logique)
   - Gelernter (geometrie), naissance de Lisp
-- **1965** : Robinson propose un algorithme complet de raisonnement logique
-- **1969-79** : age d'or des systemes experts (bases de connaissances)
-
-</div>
+- **1965** : Robinson propose un algorithme complet<br>de raisonnement logique
+- **1969-79** : age d'or des systemes experts<br>(bases de connaissances)
 
 ---
 
@@ -331,9 +323,7 @@ image: ./images/img_020.png
 
 <img src="./images/img_020.png" style="position:absolute; top:60px; right:20px; width:300px;" alt="Test de Turing" />
 
-<div style="max-width:60%;">
-
-**Alan Turing (1950)** propose un test operationnel : une machine est "intelligente" si un humain ne peut la distinguer d'un autre humain en conversant avec elle.
+**Alan Turing (1950)** propose un test operationnel : une machine<br>est "intelligente" si un humain ne peut la distinguer d'un autre<br>humain en conversant avec elle.
 
 **Competences requises pour reussir le test :**
 - Traitement du langage naturel
@@ -343,13 +333,11 @@ image: ./images/img_020.png
 
 **« Total Turing » (+ camera)** ajoute la vision et la robotique.
 
-**Ces competences definissent les grandes disciplines de l'IA** -- dont quatre seront detaillees dans ce cours.
+**Ces competences definissent les grandes disciplines de l'IA**<br>-- dont quatre seront detaillees dans ce cours.
 
 <div style="font-size:0.78em; opacity:0.8; margin-top:6px;">
 
 *En pratique : Dnn + Portal Keeper -- plateforme web d'agents conversationnels*
-
-</div>
 
 </div>
 
@@ -428,17 +416,13 @@ image: ./images/img_021.png
 
 <img src="./images/img_021.png" style="position:absolute; top:60px; right:20px; width:320px;" alt="Schema agent" />
 
-<div style="max-width:55%;">
-
 **Un agent est une entite autonome qui :**
-- **Percoit** son environnement grace a des capteurs (cameras, micros, senseurs...)
-- **Agit** sur cet environnement par des effecteurs (moteurs, ecrans, haut-parleurs...)
+- **Percoit** son environnement grace a des capteurs<br>(cameras, micros, senseurs...)
+- **Agit** sur cet environnement par des effecteurs<br>(moteurs, ecrans, haut-parleurs...)
 
 **Formalisation :**
-- Un agent implemente une *fonction d'agent* : $f: \mathcal{P}^* \to \mathcal{A}$
-- A partir de l'historique complet de ses percepts, il choisit une action
-
-</div>
+- Un agent implemente une *fonction d'agent* :<br>$f: \mathcal{P}^* \to \mathcal{A}$
+- A partir de l'historique complet de ses percepts,<br>il choisit une action
 
 ---
 
@@ -571,19 +555,15 @@ Chaque environnement de tache possede des proprietes qui influencent la concepti
 
 <img src="./images/img_030.png" style="position:absolute; top:75px; right:20px; width:380px; background:white; padding:6px; border-radius:4px;" alt="Pseudocode agent pilote par table" />
 
-<div style="max-width:55%;">
-
 **f(agent) = Architecture physique + Programme**
 
 **Programme agent pilote par table**
 
 - Taille ? Duree ? Autonomie ?
 
-</div>
+<div style="margin-top:8px;">
 
-<div style="max-width:95%; margin-top:8px;">
-
-Un agent naif pourrait stocker une table "percepts → action" : la table serait gigantesque et impossible a construire.
+Un agent naif pourrait stocker une table "percepts → action" :<br>la table serait gigantesque et impossible a construire.
 
 **Cinq architectures d'agents, par ordre de generalite :**
 
@@ -603,8 +583,6 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 <img src="./images/img_032.png" style="position:absolute; bottom:30px; right:30px; width:340px; background:white; padding:4px; border-radius:4px;" alt="Pseudocode agent reflexe" />
 
-<div style="max-width:48%;">
-
 - **Pas de memoire**
 - **Percepts courants**
 - **Regles Conditions / Actions**
@@ -622,8 +600,6 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 </div>
 
-</div>
-
 <img src="./images/img_033.png" v-click="1" style="position:absolute; bottom:30px; left:30px; width:90px;" alt="A New Kind of Science - Wolfram" />
 
 
@@ -634,8 +610,6 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 <img src="./images/img_034.png" style="position:absolute; top:60px; right:20px; width:380px; background:white; padding:4px; border-radius:4px;" alt="Schema agent modele" />
 
 <img src="./images/img_035.png" style="position:absolute; bottom:30px; right:30px; width:320px; background:white; padding:4px; border-radius:4px;" alt="Pseudocode agent fonde sur un modele" />
-
-<div style="max-width:48%;">
 
 **Caracteristiques :**
 
@@ -654,8 +628,6 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 </div>
 
-</div>
-
 <img src="./images/img_036.png" v-click="1" style="position:absolute; bottom:30px; left:30px; width:90px;" alt="Robot Brooks" />
 
 
@@ -665,15 +637,11 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 <img src="./images/img_037.png" style="position:absolute; top:60px; right:20px; width:400px;" alt="Schema agent buts" />
 
-<div style="max-width:55%;">
-
-**Du reactif au deliberatif** : l'agent ne reagit plus seulement a l'instant present, il anticipe le futur.
+**Du reactif au deliberatif** : l'agent ne reagit plus seulement<br>a l'instant present, il anticipe le futur.
 
 - Considere les consequences de ses actions
 - Planifie des sequences d'actions pour atteindre un objectif
 - Utilise la recherche (exploration) et la planification
-
-</div>
 
 ---
 
@@ -681,18 +649,14 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 <img src="./images/img_038.png" style="position:absolute; top:60px; right:20px; width:400px;" alt="Schema agent utilite" />
 
-<div style="max-width:55%;">
-
 **Quand plusieurs chemins menent au but, lequel choisir ?**
 
-- Une **fonction d'utilite** U : Etat → R attribue un score a chaque etat
+- Une **fonction d'utilite** U : Etat → R attribue<br>un score a chaque etat
 - L'agent choisit l'action qui maximise l'utilite esperee
 
 **Permet d'arbitrer entre :**
 - Probabilite de succes vs importance de l'objectif
 - Risque vs recompense, urgence vs cout
-
-</div>
 
 ---
 
@@ -700,18 +664,14 @@ Un agent naif pourrait stocker une table "percepts → action" : la table serait
 
 <img src="./images/img_039.png" style="position:absolute; top:60px; right:20px; width:400px;" alt="Schema agent apprentissage" />
 
-<div style="max-width:55%;">
-
 **Quatre composants internes :**
 
 - **Element de performance** : choisit les actions
-- **Element d'apprentissage** : ameliore la performance a partir de l'experience
+- **Element d'apprentissage** : ameliore la performance<br>a partir de l'experience
 - **Critique** : evalue les resultats par rapport a un standard fixe
 - **Generateur de problemes** : suggere des actions exploratoires
 
 **Formes d'apprentissage :** supervise, par renforcement, non supervise
-
-</div>
 
 ---
 

--- a/slides/02-resolution-problemes/slides.md
+++ b/slides/02-resolution-problemes/slides.md
@@ -1316,8 +1316,6 @@ layout: section
 
 <img src="./images/img_050.png" style="position:absolute; top:130px; right:20px; width:420px;" alt="Arbre backtracking CSP Australie" />
 
-<div style="max-width:52%;">
-
 ## Exploration vs Inférence
 
 - Exploration $\neq$ inférence
@@ -1338,8 +1336,6 @@ layout: section
   - Prochaines valeurs du domaine ?
   - Quelles inférences ?
   - Comment éviter les assignations illégales ?
-
-</div>
 
 ---
 
@@ -1368,14 +1364,10 @@ layout: section
 
 <img src="./images/img_054.png" style="position:absolute; top:140px; right:20px; width:360px;" alt="Reduction domaines AC" />
 
-<div style="max-width:55%;">
-
 ## Choix de variable (MRV, LCV)
 
-- **Most Constrained Variable**: Variable avec le plus petit domaine
-- **Least Constraining Value**: Valeur qui élimine le moins de choix pour les autres variables
-
-</div>
+- **Most Constrained Variable**: Variable avec le<br>plus petit domaine
+- **Least Constraining Value**: Valeur qui élimine le<br>moins de choix pour les autres variables
 
 ## Choix de valeur (LCV)
 
@@ -1388,8 +1380,6 @@ layout: section
 
 <img src="./images/img_055.png" style="position:absolute; top:120px; right:20px; width:240px;" alt="Décomposition arbre contraintes" />
 
-<div style="max-width:72%;">
-
 ## Décomposition en sous-problèmes
 
 - **Composantes connexes** du graphe: sous-problèmes indépendants
@@ -1400,7 +1390,7 @@ layout: section
 ## Structure d'arbre
 
 - Rare mais structure d'arbre $\rightarrow$ résolution linéaire
-  - **Cohérence d'arc dirigée (DAC):** tri topologique puis DAC en $O(nd^2)$
+  - **Cohérence d'arc dirigée (DAC):** tri topologique puis<br>DAC en $O(nd^2)$
   - Assignation sans retour arrière
 
 ## Approximations de l'arbre
@@ -1413,9 +1403,7 @@ layout: section
 ## Symétrie des valeurs
 
 - Ex: coloration $\rightarrow$ $n!$ permutations équivalentes
-- $\rightarrow$ Contrainte de rupture de symétrie (ex: ordre alphabétique NT<SA<WA)
-
-</div>
+- $\rightarrow$ Contrainte de rupture de symétrie<br>(ex: ordre alphabétique NT<SA<WA)
 
 ---
 


### PR DESCRIPTION
## Summary
- **fix(slides)**: Remove `max-width:NN%` text div wrappers from 01-introduction (10 fixes) and 02-resolution-problemes (3 fixes) — replace with absolute images + targeted `<br>` per issue #1349
- **docs(claude)**: Extend rule F to cover ALL kernels (not just Python) — incident PR #1591 ML.Net (commit 4ca477e) where agent bypassed missing .NET Interactive kernel
- **chore(gitignore)**: Add `/libs/` (root-level Tweety JARs from buggy script) and `temp_*.owl` (notebook execution artifacts)
- **fix(tweety)**: Fix `download_tweety_tools.py` `get_script_dir()` cwd fallback that created `libs/` at repo root instead of `SymbolicAI/Tweety/libs/`

## Verification
- Slides: +22/-74 (div removals, `<br>` insertions). Visual verification via Slidev `?clicks=99` recommended
- Tweety script: logic fix only, no JAR changes
- CLAUDE.md: section F expanded with kernel table + anti-patterns

## Remaining slides work
- **04-probabilites**: ~20 `two-cols` image layouts need per-slide visual verification
- **03-logique**: 1 `max-width` cartouche (acceptable) + 1 `two-cols` QR code (acceptable)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>