### PR TITLE
refactor(qc): generify ESGF branding in .claude/ config (#1629 Phase 3c)

### DIFF
--- a/.claude/agent-memory/qc-research-notebook/MEMORY.md
+++ b/.claude/agent-memory/qc-research-notebook/MEMORY.md
@@ -43,7 +43,7 @@ For research tasks, provide:
 
 ## Project Context
 
-- **Workspace**: `MyIA.AI.Notebooks/QuantConnect/ESGF-2026/`
+- **Workspace**: `MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/`
 - **Examples folder**: Contains 11 strategy examples
 - **Research subfolder**: Within each example (e.g., `ETF-Pairs-Trading/research/`)
 

--- a/.claude/agent-memory/qc-strategy-analyzer/failing-strategies-analysis-2026-02-26.md
+++ b/.claude/agent-memory/qc-strategy-analyzer/failing-strategies-analysis-2026-02-26.md
@@ -17,7 +17,7 @@ Analysis of two failing strategies in the Researcher organization:
 
 ### Current Implementation Analysis
 
-**Location**: `c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/lean-workspace/Sector-Momentum-Researcher/`
+**Location**: `c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/lean-workspace/Sector-Momentum-Researcher/`
 
 **Files**:
 - `main.py` - Main algorithm
@@ -179,7 +179,7 @@ def __init__(self, leverage=1.5):  # Match MyPcm.py
 
 ### Current Implementation Analysis
 
-**Location**: `c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/ESGF-2026/lean-workspace/BTC-ML-Researcher/`
+**Location**: `c:/dev/CoursIA/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/lean-workspace/BTC-ML-Researcher/`
 
 **File**: `main.py`
 

--- a/.claude/agent-memory/qc-strategy-improver/MEMORY.md
+++ b/.claude/agent-memory/qc-strategy-improver/MEMORY.md
@@ -21,7 +21,7 @@
 | EMA-Cross-Index | 28789945 | — | 0.384 | ~0.43 expected | RESEARCH DONE, NO BACKTEST YET |
 | TrendStocksLite | 28817425 | — | NEW | **0.719** | v1.0 initial (2026-03-09) |
 | DualMomentumNoTLT | 28817424 | — | NEW | **0.469** | v1.0 initial (2026-03-09) |
-| Trend-Following | 28797562 | ESGF | 0.212 | 0.212 | CEILING REACHED (iter6, 2026-03-09) |
+| Trend-Following | 28797562 | Partner | 0.212 | 0.212 | CEILING REACHED (iter6, 2026-03-09) |
 | TrendFilteredMeanReversion | 28817422 | #40 | NEW | **-0.016** | HARD CEILING: H4 multi-instrument REJECTED (-0.129) |
 | Gaussian-Direction-Classifier | 29398513 | — | 0.864 | **0.761** | v2.0: Beta 1.133->0.540, MaxDD 36.8%->25.6% |
 | **LSTM-Forecasting** | **29443476** | **—** | **0.366** | **0.525** | **v2.1: real MLPClassifier, 7-ETF, alpha -0.008->+0.016. IMPROVED.** |

--- a/.claude/agents/qc-research-notebook.md
+++ b/.claude/agents/qc-research-notebook.md
@@ -180,7 +180,7 @@ print(f"Winner: {'MR' if mr_sharpe > mom_sharpe else 'Momentum'}")
 ### Phase 4: Integration
 
 ```
-1. Sauvegarder dans le dossier ESGF-2026/research/
+1. Sauvegarder dans le dossier partner-course-quant-trading/research/
 2. Mettre a jour le README du projet
 3. Proposer les changements a implementer
 ```
@@ -209,7 +209,7 @@ Task(
     4. Comparer les metriques
     5. Conclure sur les hypotheses
 
-    Sauvegarder dans: ESGF-2026/examples/ETF-Pairs-Trading/research/volatility-filter.ipynb
+    Sauvegarder dans: partner-course-quant-trading/examples/ETF-Pairs-Trading/research/volatility-filter.ipynb
     """,
     description="Research volatility filter"
 )

--- a/.claude/agents/qc-strategy-analyzer.md
+++ b/.claude/agents/qc-strategy-analyzer.md
@@ -180,5 +180,5 @@ ne fassent pas rougir pour sa classe.
 ## Gotchas
 
 - **"In Progress..." status** fait planter read_backtest (bug MCP Pydantic) -> attendre et reessayer
-- **Org ESGF = FREE** -> pas de backtest API, seulement org perso
+- **Org partenaire = FREE** -> pas de backtest API, seulement org perso
 - **1 backtest a la fois** -> sequentiel uniquement

--- a/.claude/agents/qc-strategy-improver.md
+++ b/.claude/agents/qc-strategy-improver.md
@@ -70,8 +70,8 @@ OBLIGATOIRE avant toute iteration:
 
 4. Chercher un notebook existant:
    - projects/{Strategy}/research.ipynb
-   - ESGF-2026/examples/{Strategy}/research.ipynb
-   - ESGF-2026/lean-workspace/{Strategy}-Researcher/research.ipynb
+   - partner-course-quant-trading/examples/{Strategy}/research.ipynb
+   - partner-course-quant-trading/lean-workspace/{Strategy}-Researcher/research.ipynb
 ```
 
 ### Etape 2: Research Notebook (ARTEFACT PRINCIPAL)
@@ -247,7 +247,7 @@ plt.show()
 6. **Long-only en bull** - Short = catastrophique
 7. **SVXY max 30%** - Trailing stop obligatoire
 8. **"In Progress..." = bug MCP** - Attendre et reessayer
-9. **Org perso seulement** - ESGF = FREE, pas de backtest API
+9. **Org perso seulement** - Partner org = FREE, pas de backtest API
 
 ## Principes d'integrite des ameliorations
 

--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -106,7 +106,7 @@ roosync_send(
 ### qc (QuantConnect)
 - Agent: po-2024
 - Issues: #106-113, #81
-- Context: ESGF deadline fin mars, Sprint 1 done, Sprint 2 pending
+- Context: Partner course deadline fin mars, Sprint 1 done, Sprint 2 pending
 - Memory: jared_qc_partnership.md, qc_strategies_catalog.md
 
 ### slides

--- a/.claude/skills/qc-helpers.md
+++ b/.claude/skills/qc-helpers.md
@@ -14,8 +14,8 @@ Documente les patterns et helpers pour utiliser les outils MCP QuantConnect.
 
 - **User ID**: 46613
 - **Org personnelle (PAID)**: `d600793ee4caecb03441a09fc2d00f7f` - Backtest API OK
-- **Org ESGF (FREE)**: `94aa4bcb45ff1d1ef286d93817104cce` - Compile OK, backtest API REFUSE
-- **IMPORTANT**: Toujours specifier `organizationId` dans create_project, sinon defaut = ESGF (FREE)
+- **Org partenaire (FREE)**: `94aa4bcb45ff1d1ef286d93817104cce` - Compile OK, backtest API REFUSE
+- **IMPORTANT**: Toujours specifier `organizationId` dans create_project, sinon defaut = org partenaire (FREE)
 
 ## Outils MCP disponibles
 
@@ -106,7 +106,7 @@ Solution: attendre 30s et reessayer. Ou utiliser list_backtests pour checker le 
 ```
 create_project(name, language="Py", organizationId="d600793ee4caecb03441a09fc2d00f7f")
 
-SANS organizationId -> cree dans ESGF (FREE) -> pas de backtest API!
+SANS organizationId -> cree dans org partenaire (FREE) -> pas de backtest API!
 ```
 
 ## Project IDs
@@ -135,7 +135,7 @@ SANS organizationId -> cree dans ESGF (FREE) -> pas de backtest API!
 | EMA-Cross-Crypto | 28789943 | 1.272 | HEALTHY | — |
 | EMA-Cross-Stocks | 28789946 | 0.872 | HEALTHY | — |
 
-### Org ESGF (94aa4bcb) - Exemples pedagogiques
+### Org partenaire (94aa4bcb) - Exemples pedagogiques
 
 | Projet | Cloud ID | Sharpe | Lang | Note |
 |--------|----------|--------|------|------|
@@ -158,9 +158,9 @@ Les strategies Researcher ont leur code local dans:
 MyIA.AI.Notebooks/QuantConnect/projects/{StrategyName}/main.py
 ```
 
-Les exemples ESGF sont dans:
+Les exemples du cours partenaire sont dans:
 ```
-MyIA.AI.Notebooks/QuantConnect/ESGF-2026/examples/{ProjectName}/main.py
+MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/examples/{ProjectName}/main.py
 ```
 
 ## Classification des performances

--- a/.claude/skills/qc-iterative-improve/SKILL.md
+++ b/.claude/skills/qc-iterative-improve/SKILL.md
@@ -105,8 +105,8 @@ Tracker global: issue #29
 
 4. Verifier si un notebook existe deja
    - projects/{Strategy}/research.ipynb
-   - ESGF-2026/examples/{Strategy}/research.ipynb
-   - ESGF-2026/lean-workspace/{Strategy}-Researcher/research.ipynb
+   - partner-course-quant-trading/examples/{Strategy}/research.ipynb
+   - partner-course-quant-trading/lean-workspace/{Strategy}-Researcher/research.ipynb
 ```
 
 ## Phase 2: Research Notebook (COEUR DU WORKFLOW)
@@ -229,7 +229,7 @@ Le workflow est concu pour survivre aux redemarrages:
 5. **Pas de Universe Selection** - Trop lent. ETFs fixes
 6. **Long-only en bull market** - Short = catastrophique
 7. **"In Progress..." = bug MCP** - Attendre et reessayer
-8. **Org perso seulement** - ESGF = FREE, pas de backtest API
+8. **Org perso seulement** - Partner org = FREE, pas de backtest API
 
 ## Sub-Agent
 


### PR DESCRIPTION
## Summary
- Replace ESGF-specific text in 9 `.claude/` files (agents, skills, agent-memory)
- Path references `ESGF-2026/` → `partner-course-quant-trading/`
- Org labels `ESGF` → `partner` / `partenaire`
- Workspace paths updated in 3 agent-memory files

## Files changed (9)
- `.claude/skills/`: `qc-iterative-improve/SKILL.md`, `qc-helpers.md`, `coordinate/SKILL.md`
- `.claude/agents/`: `qc-strategy-improver.md`, `qc-strategy-analyzer.md`, `qc-research-notebook.md`
- `.claude/agent-memory/`: `qc-strategy-improver/MEMORY.md`, `qc-strategy-analyzer/failing-strategies-*.md`, `qc-research-notebook/MEMORY.md`

## Verification
- `grep -r ESGF .claude/` returns **0 matches** after this PR
- Phase 3c completes the `.claude/` domain (Phase 3a = QC main.py, 3b = docs/scripts/slides)

## Part of #1629
Phase 3c → Phase 4 (final repo-wide grep verification) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)