### PR TITLE
refactor(qc): remove ESGF branding from remaining 34 files (#1629 Phase 4)

### DIFF
--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -36,7 +36,7 @@ jobs:
 
         base = 'MyIA.AI.Notebooks'
         EXCLUDE_ALWAYS = {'.ipynb_checkpoints', 'obj', 'bin', '__pycache__', '.git'}
-        EXCLUDE_PED = {'research', 'archive', '_output', 'ESGF', 'examples'}
+        EXCLUDE_PED = {'research', 'archive', '_output', 'partner-course', 'examples'}
         CATALOG_RE = re.compile(r'<!--\s*CATALOG-STATUS\s*\n(.*?)\n\s*-->', re.DOTALL)
 
         for series in sorted(os.listdir(base)):

--- a/.gitignore
+++ b/.gitignore
@@ -643,7 +643,11 @@ MyIA.AI.Notebooks/QuantConnect/TrendStocks*/
 MyIA.AI.Notebooks/QuantConnect/TurnOfMonth-Researcher/
 MyIA.AI.Notebooks/QuantConnect/VIX-TermStructure-Researcher/
 MyIA.AI.Notebooks/QuantConnect/lean.json
-MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/
+MyIA.AI.Notebooks/QuantConnect/partner-course-Workspace/
+
+# NuGet build artifacts
+MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/lean-workspace/**/obj/
+MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/lean-workspace/**/bin/
 
 # Generated secrets (security - never commit raw tokens)
 .secrets/.env.generated

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/docs/INSTALLATION-CLAUDE-CODE.md
@@ -534,7 +534,7 @@ claude mcp add --transport stdio serena -- uvx --from git+https://github.com/ora
 
 **Note** : Utilisez `--context claude-code` pour eviter les conflits avec les outils natifs de Claude Code.
 
-#### 7. QuantConnect (Trading Algorithmique - Cours ESGF)
+#### 7. QuantConnect (Trading Algorithmique - Cours partenaire)
 
 Le serveur MCP QuantConnect permet a Claude Code d'interagir directement avec la plateforme QuantConnect : creer des projets, compiler du code, lancer des backtests, analyser les resultats. Indispensable pour le cours de trading algorithmique.
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_what_dl_can_predict.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_what_dl_can_predict.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "> **Context**: 27+ experiments across 8 architectures (MoE, LSTM, Transformer, PatchTST, iTransformer, Mamba, STGAT, MTGNN) failed to beat daily binary direction prediction on modern financial data, even with strict walk-forward OOS validation and multi-seed verification (4/5 seeds FAIL, seed=42 BEAT was +1.5sigma outlier). This notebook investigates what DL *can* predict, to inform a productive pivot.\n",
     "\n",
-    "**Deadline**: 09/05/2026 | **Epic**: NN #754 | **ESGF**: 19/05/2026\n",
+    "**Deadline**: 09/05/2026 | **Epic**: NN #754 | **Partner**: 19/05/2026\n",
     "\n",
     "---\n",
     "\n",
@@ -822,7 +822,7 @@
     "<a id='section-3'></a>\n",
     "## Section 3: Pivot Options for Epic NN #754\n",
     "\n",
-    "Three strategic pivots ranked by feasibility, evidence strength, and ESGF pedagogical impact."
+    "Three strategic pivots ranked by feasibility, evidence strength, and partner course pedagogical impact."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-01-Setup.ipynb
@@ -46,7 +46,7 @@
     "> Ce notebook est un **support de cours** a lire ici (GitHub ou Jupyter local).\n",
     "> **Ne l'uploadez pas dans QuantConnect Lab** - il n'est pas concu pour y etre execute.\n",
     "> \n",
-    "> **Pour votre projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/` dans votre projet QC Lab, puis cliquez Backtest.\n",
+    "> **Pour votre projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/` dans votre projet QC Lab, puis cliquez Backtest.\n",
     "> \n",
     "\n",
     "---"

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-02-Platform-Fundamentals.ipynb
@@ -66,7 +66,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-05-Universe-Selection.ipynb
@@ -62,7 +62,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-06-Options-Trading.ipynb
@@ -42,7 +42,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-07-Futures-Forex.ipynb
@@ -59,7 +59,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-09-Order-Types.ipynb
@@ -42,7 +42,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-10-Risk-Portfolio-Management.ipynb
@@ -62,7 +62,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-11-Technical-Indicators.ipynb
@@ -64,7 +64,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -60,7 +60,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-13-Alpha-Models.ipynb
@@ -59,7 +59,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -75,7 +75,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -95,7 +95,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -62,7 +62,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -94,7 +94,7 @@
     "> Le code QCAlgorithm presente ici est a **copier dans `main.py`** de votre projet QuantConnect Lab.\n",
     "> Ne tentez pas de faire \"Run All\" -- les imports `AlgorithmImports` n'existent pas en Jupyter local.\n",
     ">\n",
-    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `ESGF-2026/templates/`, puis adaptez-le.\n",
+    "> **Pour demarrer un projet QC** : copiez un `main.py` depuis `projects/` ou `partner-course-quant-trading/templates/`, puis adaptez-le.\n",
     "\n",
     "---"
    ]

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ESGF Kit - Recherche ML RandomForest Sector Rotation\n",
+    "# Partner Course Kit - Recherche ML RandomForest Sector Rotation\n",
     "\n",
     "Ce notebook explore l'approche ML RandomForest pour la rotation sectorielle sur 9 ETFs sectoriels americains.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ESGF Kit - Recherche ML XGBoost Sector Rotation\n",
+    "# Partner Course Kit - Recherche ML XGBoost Sector Rotation\n",
     "\n",
     "Ce notebook explore l'approche ML XGBoost (Gradient Boosting) pour la rotation sectorielle sur 9 ETFs sectoriels americains.\n",
     "\n",

--- a/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ESGF Kit - Recherche Framework Composite (Alpha Models)\n",
+    "# Partner Course Kit - Recherche Framework Composite (Alpha Models)\n",
     "\n",
     "Ce notebook explore l'approche QC Framework avec modele composite combinant deux alpha models :\n",
     "1. **SectorMomentum** : Long sectors avec momentum positif au-dessus de SMA200\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ForexCarry/research.ipynb
@@ -1517,7 +1517,7 @@
      "text": [
       "=== VALIDATION QC CLOUD (ForexCarry project 28657908) ===\n",
       "Periode: 2015-01-01 a 2026-05-24\n",
-      "Cloud ID: 28657908 (ESGF_School org)\n",
+      "Cloud ID: 28657908 (Partner org)\n",
       "\n",
       "               Test  Sharpe  CAGR%  MaxDD%  NetProfit%  Trades\n",
       "     v3e-SPY filter  -2.347 -0.307     7.3      -3.444     113\n",
@@ -1545,7 +1545,7 @@
     "\n",
     "print('=== VALIDATION QC CLOUD (ForexCarry project 28657908) ===')\n",
     "print(f'Periode: 2015-01-01 a 2026-05-24')\n",
-    "print(f'Cloud ID: 28657908 (ESGF_School org)')\n",
+    "print(f'Cloud ID: 28657908 (Partner org)')\n",
     "print()\n",
     "print(qc_results.to_string(index=False))\n",
     "print()\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/HAR-RV-Kelly/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Research: ESGF-HAR-RV-Kelly\n",
+    "# Research: Partner-HAR-RV-Kelly\n",
     "\n",
     "HAR-RV (Heterogeneous Autoregressive Realized Volatility) avec critere de Kelly sur un portefeuille multi-actifs.\n",
     "\n",
@@ -19,7 +19,7 @@
     "\n",
     "**Actifs** : SPY, EFA, EEM, TLT, GLD, DBC.\n",
     "\n",
-    "**Calibration cible** : `ESGFHARRVKelly` dans `main.py`"
+    "**Calibration cible** : `PartnerHARRVKelly` dans `main.py`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendFilteredMeanReversion/research.ipynb
@@ -1153,7 +1153,7 @@
     "| H4: Multi-instruments | Position sizing dilue, correlation SPY/QQQ | Sharpe degrade |\n",
     "| H5: Retirer filtre regime | Plus de trades bear = falling knives | MaxDD augmente |\n",
     "\n",
-    "### Lecons cles pour le cours ESGF\n",
+    "### Lecons cles pour le cours partenaire\n",
     "\n",
     "1. **Un signal rentable ne suffit pas** : le win rate de 73% prouve que le signal\n",
     "   RSI(2) est valide. Mais si la strategie n'est investie que 15% du temps,\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocksLite/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TrendStocksLite/research.ipynb
@@ -1065,7 +1065,7 @@
     "- **Stop-loss** : ATR trailing stop par position\n",
     "- **Universe dynamique** : Remplacer les 15 tickers fixes par un filtre dollar volume\n",
     "\n",
-    "### Usage pedagogique (Module M2 ESGF)\n",
+    "### Usage pedagogique (Module M2 (cours partenaire))\n",
     "\n",
     "Ce notebook est ideal pour le Module 2 (Momentum) car il illustre :\n",
     "1. **Trend-following basique** : Faber TAA avec filtres multi-indicateurs\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/TurnOfMonth/research.ipynb
@@ -888,7 +888,7 @@
     "**Strategie archivee.** Sharpe ceiling ~0.13 sur la periode 2015-2026.\n",
     "\n",
     "**Note importante** : Cette strategie etait marquee \"PENDING\" dans le dashboard\n",
-    "ESGF-2026 et n'a pas ete activement iteree ou backtestee lors du cycle d'optimisation\n",
+    "partner-course-quant-trading et n'a pas ete activement iteree ou backtestee lors du cycle d'optimisation\n",
     "d'avril 2026. Les resultats ci-dessus proviennent du travail anterieur.\n",
     "\n",
     "| Metrique | Meilleure version (v2.1) | Plafond structurel |\n",

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-Ensemble-Conservative/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Research: ESGF-VolEnsemble-Conservative\n",
+    "# Research: Partner-VolEnsemble-Conservative\n",
     "\n",
     "Ensemble GARCH(1,1) + HAR(1,5,22) avec positionnement conservateur et filtre de regime.\n",
     "\n",
@@ -17,11 +17,11 @@
     "un ciblage de volatilite inverse a 8% annualises (plus conservateur que le GARCH seul a 10%).\n",
     "\n",
     "Un **filtre de regime** base sur SPY vs SMA200 reduit l'allocation de 50% en marche baissier.\n",
-    "C'est la plus conservatrice des 3 strategies ESGF.\n",
+    "C'est la plus conservatrice des 3 strategies partner.\n",
     "\n",
     "**Actifs** : SPY, EFA, EEM, TLT, GLD, DBC.\n",
     "\n",
-    "**Calibration cible** : `ESGFVolEnsembleConservative` dans `main.py`"
+    "**Calibration cible** : `PartnerVolEnsembleConservative` dans `main.py`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Vol-GARCH-Target/research.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Research: ESGF-GARCH-VolTarget\n",
+    "# Research: Partner-GARCH-VolTarget\n",
     "\n",
     "GARCH(1,1) volatilite targeting sur un portefeuille multi-actifs.\n",
     "\n",
@@ -16,7 +16,7 @@
     "\n",
     "**Actifs** : SPY, EFA, EEM, TLT, GLD, DBC (multi-actifs style AQR).\n",
     "\n",
-    "**Calibration cible** : `ESGFGARCHVolTarget` dans `main.py`"
+    "**Calibration cible** : `PartnerGARCHVolTarget` dans `main.py`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -42,7 +42,7 @@ GenAI (110 notebooks)
 QuantConnect (175 notebooks)
 ├── Python/ (53) - Cours progressifs QC-Py
 ├── projects/ (109) - Strategies backtests et ML
-└── ESGF-2026/ (7) - Cours ESGF exercices et templates
+└── partner-course-quant-trading/ (7) - Cours partenaire exercices et templates
 
 SymbolicAI (92 notebooks)
 ├── SmartContracts/ (27) - Solidity, Web3, blockchain
@@ -135,7 +135,7 @@ docker-compose up -d
 1. **GenAI** - Toutes les series sauf Orchestration
 2. **ML** - Tutoriels .NET + Python Agents
 3. **SymbolicAI** - SmartContracts, SemanticWeb
-4. **QuantConnect/ESGF-2026/** - Exercices trading
+4. **QuantConnect/partner-course-quant-trading/** - Exercices trading
 
 ### Expert (120h+)
 1. **GenAI/03-Orchestration** + **04-Applications**

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Peut-on appliquer les techniques d'IA aux marches financiers ? Cette serie repon
 
 **ML Training Pipeline** -- Pipeline complet d'entrainement et d'evaluation de modeles DL pour le forecasting financier : LSTM, Transformer, iTransformer, PatchTST, Mamba. Donnees crypto panier (10 coins) avec validation walk-forward stricte, evaluation zero-shot de modeles foundation (Chronos-Bolt, Kronos), et baselines comparatives (GARCH, random walk, majority class).
 
-**ESGF-2026** -- Exemples de projets etudiants et notebooks de recherche issus du cours ESGF.
+**partner-course-quant-trading** -- Exemples de projets etudiants et notebooks de recherche issus du cours partenaire.
 
 Python | [README detaille](MyIA.AI.Notebooks/QuantConnect/README.md) | [Strategies](MyIA.AI.Notebooks/QuantConnect/projects/README.md)
 
@@ -172,7 +172,7 @@ CoursIA/
       Python/                  Notebooks pedagogiques
       projects/                Strategies backtestees
       ML-Training-Pipeline/    Pipeline DL forecasting
-      ESGF-2026/               Projets etudiants
+      partner-course-quant-trading/ Projets etudiants
     EPF/                       Projets transversaux (Python)
     IIT/                       Information integree (Python)
     Config/                    Configuration API

--- a/STABLE_SNAPSHOT.md
+++ b/STABLE_SNAPSHOT.md
@@ -76,10 +76,10 @@
 | `projects/Framework_Composite_EMATrend/quantbook_composite_research.ipynb` | Quantbook | Composite framework |
 | `projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb` | Robustness | C# strategy |
 | `projects/CSharp-CTG-Momentum/research_robustness.ipynb` | Robustness | C# strategy |
-| `ESGF-2026/examples/Crypto-MultiCanal/research_archive.ipynb` | Archive | Archived research |
-| `ESGF-2026/kit-transitoire/01-ML-RandomForest/research.ipynb` | Template | Student kit |
-| `ESGF-2026/kit-transitoire/02-ML-XGBoost/research.ipynb` | Template | Student kit |
-| `ESGF-2026/kit-transitoire/03-Framework-Composite/research.ipynb` | Template | Student kit |
+| `partner-course-quant-trading/examples/Crypto-MultiCanal/research_archive.ipynb` | Archive | Archived research |
+| `partner-course-quant-trading/kit-transitoire/01-ML-RandomForest/research.ipynb` | Template | Student kit |
+| `partner-course-quant-trading/kit-transitoire/02-ML-XGBoost/research.ipynb` | Template | Student kit |
+| `partner-course-quant-trading/kit-transitoire/03-Framework-Composite/research.ipynb` | Template | Student kit |
 | `ML-Training-Pipeline/ML-Research-Template.ipynb` | Template | ML template |
 | `Python/research/research_classification.ipynb` | Research | Classification |
 | `Python/research/research_lstm.ipynb` | Research | LSTM |
@@ -124,7 +124,7 @@
 
 | Notebook | Code | Exec | % Exec | Notes |
 |----------|------|------|--------|-------|
-| `ESGF-2026/examples/Crypto-MultiCanal/research.ipynb` | 24 | 15 | 63% | 15/24, 0 outputs |
+| `partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb` | 24 | 15 | 63% | 15/24, 0 outputs |
 | `projects/CSharp-BTC-MACD-ADX/Research.ipynb` | 21 | 18 | 86% | 18/21, 0 outputs |
 | `projects/ML-TextClassification/quantbook.ipynb` | 14 | 4 | 29% | 4/14 |
 | `projects/PairsTrading/quantbook.ipynb` | 7 | 3 | 43% | 3/7 |
@@ -162,7 +162,7 @@ These 5 quantbooks have >50% error cells and need QC Cloud re-execution:
 Majority are research/quantbook notebooks requiring QC Cloud execution.
 
 - 9 `Research-Executor/research_*.ipynb` — template research notebooks
-- 3 `ESGF-2026/kit-transitoire/` — student kit templates
+- 3 `partner-course-quant-trading/kit-transitoire/` — student kit templates
 - 4 `Python/QC-Py-XX-*.ipynb` — course notebooks (01, 04, 19, Dataset)
 - Remaining: project-specific quantbooks and research notebooks
 
@@ -190,7 +190,7 @@ Most are partially-executed quantbooks. Sudoku-16-NN is 95% complete (1 cell).
 All problematic QuantConnect notebooks share `last_commit: 2026-05-12T18:46:04+02:00` — batch-committed during a recent sweep. This confirms they were touched structurally without re-execution (rule H.1).
 
 Notebooks with `pre_rule_c2: true` (3) predate the C.2 rule (committed before 2026-04-26):
-- `ESGF-2026/examples/Crypto-MultiCanal/research.ipynb`
+- `partner-course-quant-trading/examples/Crypto-MultiCanal/research.ipynb`
 - `projects/CSharp-BTC-MACD-ADX/Research.ipynb`
 - `projects/Portfolio-Optimization-ML/research.ipynb`
 

--- a/docs/teaching-context.md
+++ b/docs/teaching-context.md
@@ -8,7 +8,7 @@ Documentation transversale sur l'organisation de l'enseignement annuel : calendr
 |-------|-------|---------------------|
 | EPF | GenAI Bachelor 3A (MSBNS3IN03), classes MIN1/MIN2/MIS | Termine, notes transmises |
 | ECE | IA Finance Ing4 (Gr01/02/03) | Termine, notes rendues debut mai |
-| Partner (ESGF) | Algo Trading QuantConnect | En cours, soutenances finales fin mai, **grading debut juin** |
+| Partner | Algo Trading QuantConnect | En cours, soutenances finales fin mai, **grading debut juin** |
 | EPITA | Programmation par Contraintes | Soutenances 2 batchs **terminees**, suivi TP bonus rempli, notes projet faites |
 | EPITA | IA Symbolique | Cours en cours ; TPs notebooks rendus sur CoursIA = points bonus des projets EPITA-IS |
 

--- a/scripts/quantconnect/audit_projects.py
+++ b/scripts/quantconnect/audit_projects.py
@@ -109,7 +109,7 @@ def classify_project(
         return "TEST", "Name contains test/validation pattern"
 
     # Partner course validation projects
-    if "ESGF-" in name and "Validation" in name:
+    if "partner-" in name and "Validation" in name:
         return "TEST", "Partner course validation project"
 
     # 2. SUPERSEDED detection
@@ -165,7 +165,7 @@ def classify_project(
                 except (ValueError, TypeError):
                     pass
             # Check if it's a Framework/Cloud/ML naming (might be in development)
-            dev_patterns = ["Framework_", "Cloud-", "ESGF-Framework", "partner-"]
+            dev_patterns = ["Framework_", "Cloud-", "Partner-Framework", "partner-"]
             if any(name.startswith(p) for p in dev_patterns):
                 return "ALIVE", "Framework project, no backtests yet"
             return "DEAD", "No backtests"

--- a/scripts/quantconnect/tests/test_audit_projects.py
+++ b/scripts/quantconnect/tests/test_audit_projects.py
@@ -129,7 +129,7 @@ class TestClassifyProject:
         assert cat == "TEST"
 
     def test_partner_validation(self):
-        cat, reason = self._classify(name="ESGF-2026-Validation")
+        cat, reason = self._classify(name="partner-course-2026-Validation")
         assert cat == "TEST"
         # Matches generic "-Validation" pattern before partner-specific check
         assert "validation" in reason.lower()


### PR DESCRIPTION
## Summary

Phase 4 of #1629 ESGF genericization — finalizes the remaining 34 files across 9 domains. PR created on behalf of po-2024 (rate-limited at push time).

- Root config (2): .gitignore, catalog-drift.yml
- Root docs (4): README.md, STABLE_SNAPSHOT.md, MyIA.AI.Notebooks/README.md, teaching-context.md
- QC Python notebooks (15): markdown source cells
- QC project research (7): titles, class names (ESGFHARRVKelly → PartnerHARRVKelly etc)
- Kit-transitoire (3): ESGF Kit → Partner Course Kit
- ML-Training-Pipeline docs (1), GenAI doc (1), Scripts (2), .gitignore obj/bin rule (1)

## Triage decisions (per dispatch ai-01)

**Category (b) PRESERVED** (9 files): historical audits, `catalog_enrichment.json` (QC Cloud project IDs), `forensic_results.json`, slide JSONs — historical context kept.

**Category (c) NO ACTION** (10 files): papermill metadata (5), base64 false positives (5).

## #1629 generification coverage

- Phase 1: project renames (merged #1637)
- Phase 2: ESGF-2026 dir rename (merged #1638)
- Phase 3a: QC class names (merged #1640)
- Phase 3b: docs/slides/scripts (merged #1642)
- Phase 3c: .claude/ agents/skills/memory (merged #1649)
- **Phase 4: remaining 34 files (THIS PR)**

## Test plan

- [x] No blind replace on historical audits
- [x] No replace on QC Cloud project IDs
- [x] All triage decisions documented
- [ ] CI catalog-drift verification (auto)

Author: po-2024 (commit 54fc36f6). PR creation by ai-01 after rate-limit reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)