### PR TITLE
feat(lean): Kochen-Specker 18-vec scaffold (Pilier 1 FWT #1651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Kochen-Specker Theorem (18-vector Cabello proof)
+
+No `{0, 1}`-coloring of the 18 unit vectors of R^3 listed below is compatible
+with the orthogonality constraint: in every orthogonal triplet, exactly one
+vector receives color `1`.
+
+This is the combinatorial kernel used in the Conway-Kochen Free Will Theorem
+(Pilier 1 of Epic #1651). The 18-vector proof is due to Cabello, Estebaranz
+and Garcia-Alcaine (1996), tightening the original 117-vector proof by
+Kochen and Specker (1967) and the 33-vector proof by Conway and Kochen (2006).
+
+Source: Cabello, Estebaranz, Garcia-Alcaine,
+       "Bell-Kochen-Specker theorem: A proof with 18 vectors",
+       Phys. Lett. A 212 (1996), 183-187.
+-/
+
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Tactic
+
+namespace Conway
+
+namespace KochenSpecker
+
+/-!
+## The 18 Cabello vectors
+
+The 18 vectors are grouped into 9 orthogonal triplets. Each triplet
+contributes 3 mutually orthogonal unit vectors. The coloring constraint
+requires exactly one `1` per triplet, so we need exactly 9 vectors
+colored `1`. A parity argument (via the overlap structure where each
+vector appears in exactly 2 triplets) shows this is impossible.
+
+Reference: Cabello et al. 1996, Table 1.
+The 9 triplets are:
+
+  T0: (1,0,0)  (0,1,0)  (0,0,1)
+  T1: (1,1,0)  (1,-1,0) (0,0,1)     -- normalized by sqrt(2)
+  T2: (1,0,1)  (1,0,-1) (0,1,0)     -- normalized by sqrt(2)
+  T3: (0,1,1)  (0,1,-1) (1,0,0)     -- normalized by sqrt(2)
+  T4: (1,1,1)  (1,-1,-1) (1,1,-1)   -- normalized by sqrt(3) [NOT orthogonal]
+  T5: (1,-1,1) (-1,1,1) (-1,-1,1)   -- normalized by sqrt(3)
+  T6: (1,1,-1) (-1,1,-1) (-1,-1,-1) -- normalized by sqrt(3)
+  T7: (1,1,0)  (1,-1,0) (0,0,1)     -- duplicate of T1
+  T8: (0,1,1)  (0,1,-1) (1,0,0)     -- duplicate of T3
+
+NOTE: The actual Cabello proof uses 9 specific triplets with exactly 18
+distinct vectors where each vector appears in exactly 2 triplets (giving
+the parity contradiction). The exact triplet assignment will be refined
+during proof development. This scaffold captures the structure and
+theorem statement.
+-/
+
+/-!
+## Abstract formulation
+
+Rather than formalizing the exact R^3 vectors immediately, we state the
+theorem abstractly: given 18 abstract vectors and 9 orthogonal triplets
+where each vector appears in exactly 2 triplets, no {0,1}-coloring
+satisfying "exactly one 1 per triplet" exists.
+-/
+
+/-- An abstract index for 18 vectors. -/
+abbrev VecIdx := Fin 18
+
+/-- An abstract index for 9 triplets. -/
+abbrev TripletIdx := Fin 9
+
+/-- The triplet membership: which 3 vectors form each orthogonal triplet.
+    This encodes the Cabello overlap structure where each vector appears
+    in exactly 2 triplets. -/
+def tripletMembers : TripletIdx → Fin 3 → VecIdx
+  -- T0: standard basis
+  | 0, 0 => 0   -- (1,0,0)
+  | 0, 1 => 1   -- (0,1,0)
+  | 0, 2 => 2   -- (0,0,1)
+  -- T1: xy-plane diagonals + z
+  | 1, 0 => 3   -- (1,1,0)/√2
+  | 1, 1 => 4   -- (1,-1,0)/√2
+  | 1, 2 => 2   -- (0,0,1) — shared with T0
+  -- T2: xz-plane diagonals + y
+  | 2, 0 => 5   -- (1,0,1)/√2
+  | 2, 1 => 6   -- (1,0,-1)/√2
+  | 2, 2 => 1   -- (0,1,0) — shared with T0
+  -- T3: yz-plane diagonals + x
+  | 3, 0 => 7   -- (0,1,1)/√2
+  | 3, 1 => 8   -- (0,1,-1)/√2
+  | 3, 2 => 0   -- (1,0,0) — shared with T0
+  -- T4: body diagonal type 1
+  | 4, 0 => 9   -- (1,1,1)/√3
+  | 4, 1 => 10  -- (1,-1,-1)/√3
+  | 4, 2 => 11  -- (1,-1,1)/√3
+  -- T5: body diagonal type 2
+  | 5, 0 => 12  -- (-1,1,1)/√3
+  | 5, 1 => 11  -- (1,-1,1)/√3 — shared with T4
+  | 5, 2 => 3   -- (1,1,0)/√2 — shared with T1
+  -- T6: body diagonal type 3
+  | 6, 0 => 13  -- (-1,1,-1)/√3
+  | 6, 1 => 9   -- (1,1,1)/√3 — shared with T4
+  | 6, 2 => 7   -- (0,1,1)/√2 — shared with T3
+  -- T7: body diagonal type 4
+  | 7, 0 => 14  -- (-1,-1,1)/√3
+  | 7, 1 => 10  -- (1,-1,-1)/√3 — shared with T4
+  | 7, 2 => 5   -- (1,0,1)/√2 — shared with T2
+  -- T8: remaining
+  | 8, 0 => 15  -- (1,1,-1)/√3
+  | 8, 1 => 12  -- (-1,1,1)/√3 — shared with T5
+  | 8, 2 => 6   -- (1,0,-1)/√2 — shared with T2
+  | _, _ => 0   -- unreachable
+
+/-- A {0,1}-coloring of the 18 vectors. -/
+def Coloring := VecIdx → Bool
+
+/-- A coloring is valid iff every triplet has exactly one vector colored `true`. -/
+def IsValidColoring (c : Coloring) : Prop :=
+  ∀ t : TripletIdx,
+    (∑ i : Fin 3, if c (tripletMembers t i) then (1 : ℕ) else 0) = 1
+
+/-- Key property: each vector appears in exactly 2 triplets.
+    This is the Cabello overlap structure that enables the parity proof. -/
+lemma each_vector_in_two_triplets (v : VecIdx) :
+    (∑ t : TripletIdx, ∑ i : Fin 3,
+      if tripletMembers t i = v then (1 : ℕ) else 0) = 2 := by
+  sorry  -- TODO: verify by computation
+
+/-- **Kochen-Specker Theorem (18-vector Cabello proof)**.
+    There is no valid {0,1}-coloring of the 18 vectors compatible
+    with the orthogonality constraint.
+
+    Proof sketch (parity argument):
+    1. A valid coloring requires exactly 9 ones (one per triplet).
+    2. Counting ones by vector: each colored vector contributes to
+       exactly 2 triplets (by `each_vector_in_two_triplets`), so
+       the total triplet-count of ones = 2 × (number of colored vectors).
+    3. But the total triplet-count must also equal 9 (one per triplet).
+    4. Since 9 is odd and 2 × k is even for all k, contradiction. -/
+theorem kochen_specker : ¬ IsValidColoring := by
+  sorry  -- TODO: Pilier 1 — complete proof via parity argument
+
+end KochenSpecker
+
+/-!
+## Connection to Free Will Theorem (Pilier 2)
+
+The KS theorem is the combinatorial core of the SPIN axiom:
+for spin-1 particles, measuring the squared spin component along
+3 orthogonal axes always yields a permutation of (1, 1, 0).
+If the response were a deterministic function of hidden variables,
+it would define a valid {0,1}-coloring — contradicting KS.
+Hence the particle's response cannot be a function of the past.
+
+This connection will be formalized in Pilier 2 (FreeWillTheorem.lean).
+-/
+
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
@@ -4,18 +4,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 ## Kochen-Specker Theorem (18-vector Cabello proof)
 
-No `{0, 1}`-coloring of the 18 unit vectors of R^3 listed below is compatible
-with the orthogonality constraint: in every orthogonal triplet, exactly one
-vector receives color `1`.
+No `{0, 1}`-coloring of the 18 unit vectors of R^4 listed below is compatible
+with the orthogonality constraint: in every orthogonal basis (4 mutually
+orthogonal vectors), exactly one vector receives color `1`.
 
 This is the combinatorial kernel used in the Conway-Kochen Free Will Theorem
 (Pilier 1 of Epic #1651). The 18-vector proof is due to Cabello, Estebaranz
 and Garcia-Alcaine (1996), tightening the original 117-vector proof by
-Kochen and Specker (1967) and the 33-vector proof by Conway and Kochen (2006).
+Kochen and Specker (1967), the 33-vector proof of Peres (1991), and the
+20-vector construction of Kernaghan (1994).
 
 Source: Cabello, Estebaranz, Garcia-Alcaine,
        "Bell-Kochen-Specker theorem: A proof with 18 vectors",
        Phys. Lett. A 212 (1996), 183-187.
+Table: Wikipedia "Kochen-Specker theorem" (Overview section), which
+       reproduces the original Cabello et al. table.
 -/
 
 import Mathlib.Data.Real.Basic
@@ -27,119 +30,150 @@ namespace Conway
 namespace KochenSpecker
 
 /-!
-## The 18 Cabello vectors
+## The 18 Cabello vectors and 9 orthogonal bases (R^4)
 
-The 18 vectors are grouped into 9 orthogonal triplets. Each triplet
-contributes 3 mutually orthogonal unit vectors. The coloring constraint
-requires exactly one `1` per triplet, so we need exactly 9 vectors
-colored `1`. A parity argument (via the overlap structure where each
-vector appears in exactly 2 triplets) shows this is impossible.
+The 9 orthogonal bases (contexts) are columns of the following table.
+Each column contains 4 mutually orthogonal vectors of R^4. Every vector
+appears in exactly 2 columns, yielding the overlap structure that
+enables the parity contradiction.
 
-Reference: Cabello et al. 1996, Table 1.
-The 9 triplets are:
+Columns (bases) of the Cabello table:
 
-  T0: (1,0,0)  (0,1,0)  (0,0,1)
-  T1: (1,1,0)  (1,-1,0) (0,0,1)     -- normalized by sqrt(2)
-  T2: (1,0,1)  (1,0,-1) (0,1,0)     -- normalized by sqrt(2)
-  T3: (0,1,1)  (0,1,-1) (1,0,0)     -- normalized by sqrt(2)
-  T4: (1,1,1)  (1,-1,-1) (1,1,-1)   -- normalized by sqrt(3) [NOT orthogonal]
-  T5: (1,-1,1) (-1,1,1) (-1,-1,1)   -- normalized by sqrt(3)
-  T6: (1,1,-1) (-1,1,-1) (-1,-1,-1) -- normalized by sqrt(3)
-  T7: (1,1,0)  (1,-1,0) (0,0,1)     -- duplicate of T1
-  T8: (0,1,1)  (0,1,-1) (1,0,0)     -- duplicate of T3
+  C0:  (0,0,0,1)  (0,0,1,0)  (1,1,0,0)  (1,-1,0,0)
+  C1:  (0,0,0,1)  (0,1,0,0)  (1,0,1,0)  (1,0,-1,0)
+  C2:  (1,-1,1,-1) (1,-1,-1,1) (1,1,0,0) (0,0,1,1)
+  C3:  (1,-1,1,-1) (1,1,1,1)   (1,0,-1,0) (0,1,0,-1)
+  C4:  (0,0,1,0)  (0,1,0,0)  (1,0,0,1)  (1,0,0,-1)
+  C5:  (1,-1,-1,1) (1,1,1,1)  (1,0,0,-1) (0,1,-1,0)
+  C6:  (1,1,-1,1) (1,1,1,-1)  (1,-1,0,0) (0,0,1,1)
+  C7:  (1,1,-1,1) (-1,1,1,1)  (1,0,1,0)  (0,1,0,-1)
+  C8:  (1,1,1,-1) (-1,1,1,1)  (1,0,0,1)  (0,1,-1,0)
 
-NOTE: The actual Cabello proof uses 9 specific triplets with exactly 18
-distinct vectors where each vector appears in exactly 2 triplets (giving
-the parity contradiction). The exact triplet assignment will be refined
-during proof development. This scaffold captures the structure and
-theorem statement.
+The 18 distinct vectors (after deduplication across columns):
+
+  v0  = (0,0,0,1)   v9  = (0,0,1,1)
+  v1  = (0,0,1,0)   v10 = (1,1,1,1)
+  v2  = (1,1,0,0)   v11 = (0,1,0,-1)
+  v3  = (1,-1,0,0)  v12 = (1,0,0,1)
+  v4  = (0,1,0,0)   v13 = (1,0,0,-1)
+  v5  = (1,0,1,0)   v14 = (0,1,-1,0)
+  v6  = (1,0,-1,0)  v15 = (1,1,-1,1)
+  v7  = (1,-1,1,-1) v16 = (1,1,1,-1)
+  v8  = (1,-1,-1,1) v17 = (-1,1,1,1)
+
+Overlap structure (each vector in exactly 2 contexts):
+
+  v0  ∈ {C0,C1}   v6  ∈ {C1,C3}   v12 ∈ {C4,C8}
+  v1  ∈ {C0,C4}   v7  ∈ {C2,C3}   v13 ∈ {C4,C5}
+  v2  ∈ {C0,C2}   v8  ∈ {C2,C5}   v14 ∈ {C5,C8}
+  v3  ∈ {C0,C6}   v9  ∈ {C2,C6}   v15 ∈ {C6,C7}
+  v4  ∈ {C1,C4}   v10 ∈ {C3,C5}   v16 ∈ {C6,C8}
+  v5  ∈ {C1,C7}   v11 ∈ {C3,C7}   v17 ∈ {C7,C8}
 -/
 
 /-!
 ## Abstract formulation
 
-Rather than formalizing the exact R^3 vectors immediately, we state the
-theorem abstractly: given 18 abstract vectors and 9 orthogonal triplets
-where each vector appears in exactly 2 triplets, no {0,1}-coloring
-satisfying "exactly one 1 per triplet" exists.
+Rather than formalizing the exact R^4 coordinates and orthogonality
+predicates (which require Real-valued inner products), we state the
+theorem combinatorially: given 18 abstract vector indices and 9
+contexts of size 4 with the Cabello overlap, no {0,1}-coloring
+satisfying "exactly one 1 per context" exists.
+
+The orthogonality of each context is implicit in the index encoding:
+`contextMembers` reflects the Cabello table; verifying the inner
+products vanish is a separate (computational) lemma left for the
+geometric formalization (Pilier 2).
 -/
 
-/-- An abstract index for 18 vectors. -/
+/-- An abstract index for the 18 distinct vectors. -/
 abbrev VecIdx := Fin 18
 
-/-- An abstract index for 9 triplets. -/
-abbrev TripletIdx := Fin 9
+/-- An abstract index for the 9 orthogonal bases (contexts). -/
+abbrev ContextIdx := Fin 9
 
-/-- The triplet membership: which 3 vectors form each orthogonal triplet.
-    This encodes the Cabello overlap structure where each vector appears
-    in exactly 2 triplets. -/
-def tripletMembers : TripletIdx → Fin 3 → VecIdx
-  -- T0: standard basis
-  | 0, 0 => 0   -- (1,0,0)
-  | 0, 1 => 1   -- (0,1,0)
-  | 0, 2 => 2   -- (0,0,1)
-  -- T1: xy-plane diagonals + z
-  | 1, 0 => 3   -- (1,1,0)/√2
-  | 1, 1 => 4   -- (1,-1,0)/√2
-  | 1, 2 => 2   -- (0,0,1) — shared with T0
-  -- T2: xz-plane diagonals + y
-  | 2, 0 => 5   -- (1,0,1)/√2
-  | 2, 1 => 6   -- (1,0,-1)/√2
-  | 2, 2 => 1   -- (0,1,0) — shared with T0
-  -- T3: yz-plane diagonals + x
-  | 3, 0 => 7   -- (0,1,1)/√2
-  | 3, 1 => 8   -- (0,1,-1)/√2
-  | 3, 2 => 0   -- (1,0,0) — shared with T0
-  -- T4: body diagonal type 1
-  | 4, 0 => 9   -- (1,1,1)/√3
-  | 4, 1 => 10  -- (1,-1,-1)/√3
-  | 4, 2 => 11  -- (1,-1,1)/√3
-  -- T5: body diagonal type 2
-  | 5, 0 => 12  -- (-1,1,1)/√3
-  | 5, 1 => 11  -- (1,-1,1)/√3 — shared with T4
-  | 5, 2 => 3   -- (1,1,0)/√2 — shared with T1
-  -- T6: body diagonal type 3
-  | 6, 0 => 13  -- (-1,1,-1)/√3
-  | 6, 1 => 9   -- (1,1,1)/√3 — shared with T4
-  | 6, 2 => 7   -- (0,1,1)/√2 — shared with T3
-  -- T7: body diagonal type 4
-  | 7, 0 => 14  -- (-1,-1,1)/√3
-  | 7, 1 => 10  -- (1,-1,-1)/√3 — shared with T4
-  | 7, 2 => 5   -- (1,0,1)/√2 — shared with T2
-  -- T8: remaining
-  | 8, 0 => 15  -- (1,1,-1)/√3
-  | 8, 1 => 12  -- (-1,1,1)/√3 — shared with T5
-  | 8, 2 => 6   -- (1,0,-1)/√2 — shared with T2
-  | _, _ => 0   -- unreachable
+/-- Context membership: which 4 vector indices form each orthogonal basis.
+    Encodes the Cabello overlap structure where each vector appears
+    in exactly 2 contexts. -/
+def contextMembers : ContextIdx → Fin 4 → VecIdx
+  -- C0: standard basis-like {v0, v1, v2, v3}
+  | 0, 0 => 0   -- (0,0,0,1)
+  | 0, 1 => 1   -- (0,0,1,0)
+  | 0, 2 => 2   -- (1,1,0,0)
+  | 0, 3 => 3   -- (1,-1,0,0)
+  -- C1: {v0, v4, v5, v6}
+  | 1, 0 => 0   -- (0,0,0,1)   shared with C0
+  | 1, 1 => 4   -- (0,1,0,0)
+  | 1, 2 => 5   -- (1,0,1,0)
+  | 1, 3 => 6   -- (1,0,-1,0)
+  -- C2: {v7, v8, v2, v9}
+  | 2, 0 => 7   -- (1,-1,1,-1)
+  | 2, 1 => 8   -- (1,-1,-1,1)
+  | 2, 2 => 2   -- (1,1,0,0)    shared with C0
+  | 2, 3 => 9   -- (0,0,1,1)
+  -- C3: {v7, v10, v6, v11}
+  | 3, 0 => 7   -- (1,-1,1,-1)  shared with C2
+  | 3, 1 => 10  -- (1,1,1,1)
+  | 3, 2 => 6   -- (1,0,-1,0)   shared with C1
+  | 3, 3 => 11  -- (0,1,0,-1)
+  -- C4: {v1, v4, v12, v13}
+  | 4, 0 => 1   -- (0,0,1,0)    shared with C0
+  | 4, 1 => 4   -- (0,1,0,0)    shared with C1
+  | 4, 2 => 12  -- (1,0,0,1)
+  | 4, 3 => 13  -- (1,0,0,-1)
+  -- C5: {v8, v10, v13, v14}
+  | 5, 0 => 8   -- (1,-1,-1,1)  shared with C2
+  | 5, 1 => 10  -- (1,1,1,1)    shared with C3
+  | 5, 2 => 13  -- (1,0,0,-1)   shared with C4
+  | 5, 3 => 14  -- (0,1,-1,0)
+  -- C6: {v15, v16, v3, v9}
+  | 6, 0 => 15  -- (1,1,-1,1)
+  | 6, 1 => 16  -- (1,1,1,-1)
+  | 6, 2 => 3   -- (1,-1,0,0)   shared with C0
+  | 6, 3 => 9   -- (0,0,1,1)    shared with C2
+  -- C7: {v15, v17, v5, v11}
+  | 7, 0 => 15  -- (1,1,-1,1)   shared with C6
+  | 7, 1 => 17  -- (-1,1,1,1)
+  | 7, 2 => 5   -- (1,0,1,0)    shared with C1
+  | 7, 3 => 11  -- (0,1,0,-1)   shared with C3
+  -- C8: {v16, v17, v12, v14}
+  | 8, 0 => 16  -- (1,1,1,-1)   shared with C6
+  | 8, 1 => 17  -- (-1,1,1,1)   shared with C7
+  | 8, 2 => 12  -- (1,0,0,1)    shared with C4
+  | 8, 3 => 14  -- (0,1,-1,0)   shared with C5
 
 /-- A {0,1}-coloring of the 18 vectors. -/
 def Coloring := VecIdx → Bool
 
-/-- A coloring is valid iff every triplet has exactly one vector colored `true`. -/
+/-- A coloring is valid iff every context (orthogonal basis) has
+    exactly one vector colored `true`. -/
 def IsValidColoring (c : Coloring) : Prop :=
-  ∀ t : TripletIdx,
-    (∑ i : Fin 3, if c (tripletMembers t i) then (1 : ℕ) else 0) = 1
+  ∀ k : ContextIdx,
+    (∑ i : Fin 4, if c (contextMembers k i) then (1 : ℕ) else 0) = 1
 
-/-- Key property: each vector appears in exactly 2 triplets.
+/-- Key property: each of the 18 vectors appears in exactly 2 contexts.
     This is the Cabello overlap structure that enables the parity proof. -/
-lemma each_vector_in_two_triplets (v : VecIdx) :
-    (∑ t : TripletIdx, ∑ i : Fin 3,
-      if tripletMembers t i = v then (1 : ℕ) else 0) = 2 := by
-  sorry  -- TODO: verify by computation
+lemma each_vector_in_two_contexts (v : VecIdx) :
+    (∑ k : ContextIdx, ∑ i : Fin 4,
+      if contextMembers k i = v then (1 : ℕ) else 0) = 2 := by
+  sorry  -- TODO Pilier 1: verify by `decide` / explicit case-split on v
 
 /-- **Kochen-Specker Theorem (18-vector Cabello proof)**.
     There is no valid {0,1}-coloring of the 18 vectors compatible
     with the orthogonality constraint.
 
     Proof sketch (parity argument):
-    1. A valid coloring requires exactly 9 ones (one per triplet).
-    2. Counting ones by vector: each colored vector contributes to
-       exactly 2 triplets (by `each_vector_in_two_triplets`), so
-       the total triplet-count of ones = 2 × (number of colored vectors).
-    3. But the total triplet-count must also equal 9 (one per triplet).
-    4. Since 9 is odd and 2 × k is even for all k, contradiction. -/
-theorem kochen_specker : ¬ IsValidColoring := by
-  sorry  -- TODO: Pilier 1 — complete proof via parity argument
+    1. A valid coloring assigns exactly one `1` per context, so summing
+       over all 9 contexts gives a total of 9 ones (counted with
+       multiplicity over contexts).
+    2. Reordering the double sum: each vector `v` contributes
+       `(number of contexts containing v) * c(v)` to the total.
+       By `each_vector_in_two_contexts`, that factor is always 2.
+    3. Hence the total ones = 2 * (number of vectors colored `1`),
+       which is even.
+    4. But 9 is odd. Contradiction. -/
+theorem kochen_specker : ¬ ∃ c : Coloring, IsValidColoring c := by
+  sorry  -- TODO Pilier 1: parity argument via Finset double-sum reorder
 
 end KochenSpecker
 
@@ -148,12 +182,14 @@ end KochenSpecker
 
 The KS theorem is the combinatorial core of the SPIN axiom:
 for spin-1 particles, measuring the squared spin component along
-3 orthogonal axes always yields a permutation of (1, 1, 0).
+3 (or, in the 4D version here, 4) mutually compatible projectors
+always yields a fixed pattern (one "1" per orthonormal basis).
 If the response were a deterministic function of hidden variables,
 it would define a valid {0,1}-coloring — contradicting KS.
-Hence the particle's response cannot be a function of the past.
+Hence the particle's response cannot be a function of the past alone.
 
-This connection will be formalized in Pilier 2 (FreeWillTheorem.lean).
+This connection will be formalized in Pilier 2 (FreeWillTheorem.lean),
+together with the TWIN and MIN axioms.
 -/
 
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -20,17 +20,33 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/LookAndSayLemmas.lean` | 0 | Lemmas for the Look-and-Say sequence |
 | `Conway/Nim.lean` | 0 | Nim game theory |
 | `Conway/Angel.lean` | 0 | Angel problem |
+| `Conway/KochenSpecker.lean` | 2 | Kochen-Specker theorem (18-vec Cabello, Pilier 1 FWT) |
 
 ## Key Results
 
-- **COMPLETE**: All proofs done, 0 sorry in production code
+- **COMPLETE**: All proofs done, 0 sorry in production code (except KochenSpecker.lean WIP)
 - Doomsday algorithm correctness
 - FRACTRAN computation formalization
 - Look-and-Say sequence properties
 - Nim game strategy
 - Angel problem formalization
+- **WIP**: Kochen-Specker theorem (Pilier 1 of Epic #1651 Conway FWT)
+
+## Kochen-Specker (Pilier 1 of Free Will Theorem)
+
+The `KochenSpecker.lean` module formalizes the 18-vector proof by Cabello,
+Estebaranz and Garcia-Alcaine (1996). It is the combinatorial kernel of the
+Conway-Kochen Free Will Theorem (2006/2009, Epic #1651).
+
+**Hall of Fame**:
+- Kochen & Specker (1967) — original 117-vector proof
+- Cabello, Estebaranz, Garcia-Alcaine (1996) — 18-vector tight proof
+- Conway & Kochen (2006) — 33-vector proof + Free Will Theorem
+- Peres (1991), Mermin (1993) — simplifications and pedagogy
 
 ## Notes
 
 - Part of the GameTheory Lean series
 - Companion notebooks in the GameTheory series
+- Cross-link: Epic #1647 Conway Phase 2 (Life-as-Computation)
+- Cross-link: Epic #1651 Conway Phase 3 (Free Will Theorem)


### PR DESCRIPTION
## Summary
- Scaffold `Conway/KochenSpecker.lean` with abstract 18-vector Cabello formulation
- Triplet overlap structure (each vector in exactly 2 triplets), coloring constraint, theorem statement
- 2 sorry TODO: `each_vector_in_two_triplets` lemma + `kochen_specker` proof (parity argument)
- README updated with KS module entry + Hall of Fame

## Test plan
- [x] Syntax check (Python parser, 0 warnings)
- [ ] `lake build Conway.KochenSpecker` — pending WSL build (sorry = expected compile)
- [ ] `grep -c sorry Conway/KochenSpecker.lean` = 2 (both in TODO proof blocks)

Part of Epic #1651 Conway Phase 3 (Free Will Theorem), Pilier 1.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>