### PR TITLE
docs(readme): Search sub-series prose + Sudoku-16 numbering fix (#1665, #1661)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,6 +1,10 @@
 # Search - Applications
 
-Sous-serie de **20 notebooks** appliquant les algorithmes de recherche et de programmation par contraintes a des problemes du monde reel. Les notebooks sont desormais organises par categorie technique.
+Les 20 notebooks d'application illustrent chaque concept de la serie Search sur des **problemes reels** adaptes de projets etudiants EPITA, EPF et ECE. Chaque application combine une ou plusieurs techniques abordees dans les Parties 1-2 et montre comment elles se comportent sur des instances concretes.
+
+Les applications sont organisees en trois categories : **Search pur** (jeux combinatoires), **CSP** (problemes de satisfaction de contraintes : N-Queens, ordonnancement, demineur, mots croises), et **Hybride** (metaheuristiques et GA : detection de contours, optimisation de portefeuille, TSP, VRP). La plupart des notebooks sont autonomes et pointent vers les pre-requis pertinents.
+
+Sous-serie de **20 notebooks** | **~13h20** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
 
 ## Structure
 

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -1,6 +1,10 @@
 # Partie 1 : Search Fondamental
 
-Algorithmes de recherche classiques et metaheuristiques.
+Cette partie couvre les **algorithmes de recherche classiques**, depuis l'exploration systematique d'espaces d'etats (BFS, DFS, A*) jusqu'aux metaheuristiques inspirees de la nature (algorithmes genetiques, PSO). Le fil rouge est la reduction progressive de l'espace de recherche : comment passer d'une enumeration aveugle a une exploration intelligemment guidee.
+
+Vous commencerez par formaliser des problemes sous forme d'espaces d'etats (Search-1), puis decouvrirez les trois grands paradigmes : recherche systematique (BFS/A*), optimisation locale (Hill Climbing, recuit simule), et recherche dans les jeux (Minimax, MCTS). Les notebooks avances couvrent des extensions industrielles (programmation lineaire, automates symboliques, metaheuristiques comparees).
+
+**11 notebooks** | **~12h30** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `z3-solver`)
 
 ## Notebooks
 

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -2,6 +2,12 @@
 
 > **Pivot vers SymbolicAI** : Z3, Planning, Logic. Cette partie fait le pont entre les algorithmes de recherche et l'IA symbolique.
 
+La programmation par contraintes (CSP) represente un **changement de paradigme** : au lieu de concevoir un algorithme d'exploration, on declare les contraintes du probleme et le solveur trouve les solutions. Ce modele declaratif est au coeur des outils industriels (ordonnancement, logistique, verification) et s'applique naturellement aux problemes NP-difficiles.
+
+Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a la propagation de contraintes (AC-3, MAC en CSP-2), puis aux extensions avancees : contraintes globales (CSP-3), ordonnancement industriel (CSP-4), optimisation combinatoire (CSP-5), hybridation avec SAT/ML/LLM (CSP-6). Les trois derniers notebooks explorent les frontiers : contraintes souples, temporelles et distribuees.
+
+**9 notebooks** | **~9h** | Python 3.10+ (`ortools`)
+
 ## Notebooks
 
 | # | Notebook | Duree | Contenu | Prerequis |

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -42,9 +42,9 @@
     "tags": []
    },
    "source": [
-    "# Sudoku-10 : Résolution par Réseaux de Neurones\n",
+    "# Sudoku-16 : Résolution par Réseaux de Neurones\n",
     "\n",
-    "**Navigation** : [<< Sudoku-9-HumanStrategies](Sudoku-9-HumanStrategies.ipynb) | [Index](README.md) | [Sudoku-11-Comparison >>](Sudoku-11-Comparison.ipynb)\n",
+    "**Navigation** : [<< Sudoku-15-Infer-Python](Sudoku-15-Infer-Python.ipynb) | [Index](README.md) | [Sudoku-17-LLM-Python >>](Sudoku-17-LLM-Python.ipynb)\n",
     "\n",
     "**Voir aussi** : [GenAI](../GenAI/README.md) pour les réseaux de neurones\n",
     "\n",
@@ -3214,11 +3214,11 @@
    "source": [
     "---\n",
     "\n",
-    "**Navigation** : [<< Sudoku-9-HumanStrategies](Sudoku-9-HumanStrategies.ipynb) | [Index](README.md) | [Sudoku-11-Comparison >>](Sudoku-11-Comparison.ipynb)\n",
+    "**Navigation** : [<< Sudoku-15-Infer-Python](Sudoku-15-Infer-Python.ipynb) | [Index](README.md) | [Sudoku-17-LLM-Python >>](Sudoku-17-LLM-Python.ipynb)\n",
     "\n",
     "**Voir aussi** : \n",
     "- [GenAI](../GenAI/README.md) - Série sur l'IA générative et les réseaux de neurones\n",
-    "- [Sudoku-11-Comparison](Sudoku-11-Comparison.ipynb) - Benchmark comparatif de tous les solveurs\n",
+    "- [Sudoku-17-LLM-Python](Sudoku-17-LLM-Python.ipynb) - Benchmark comparatif de tous les solveurs\n",
     "\n",
     "### Notebooks associés\n",
     "- [Sudoku-1-Backtracking](Sudoku-1-Backtracking.ipynb) : solveur algorithmique de référence\n",


### PR DESCRIPTION
## Summary
- Add pedagogical introductory prose to 3 Search sub-series READMEs (Part1-Foundations, Part2-CSP, Applications) — previously bare file listings
- Fix Sudoku-16 internal title "Sudoku-10" -> "Sudoku-16" and navigation links (Sudoku-9->15, Sudoku-11->17)

## Test plan
- [x] Read updated READMEs — prose accurate, covers learning objectives
- [x] Sudoku-16: `grep -c "Sudoku-10\|Sudoku-9-HumanStrategies\|Sudoku-11-Comparison"` = 0

Part of Epic #1657 (README hierarchy refresh). Closes #1665 (Sudoku). Progresses #1661 (Search).