### PR TITLE
chore(gitignore): ignore ESGF-Workspace/ (local QC Lean CLI workspace)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -644,6 +644,7 @@ MyIA.AI.Notebooks/QuantConnect/TurnOfMonth-Researcher/
 MyIA.AI.Notebooks/QuantConnect/VIX-TermStructure-Researcher/
 MyIA.AI.Notebooks/QuantConnect/lean.json
 MyIA.AI.Notebooks/QuantConnect/partner-course-Workspace/
+MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/
 
 # NuGet build artifacts
 MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/lean-workspace/**/obj/


### PR DESCRIPTION
## Summary

- Add `MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/` to `.gitignore`, right beside `partner-course-Workspace/`
- Same pattern: local QuantConnect Lean CLI workspace populated by the ESGF campaign (17 sub-projects: ESGF-AllWeather, ESGF-EMA-Cross-*, ESGF-ML-RandomForest/XGBoost, ESGF-Option-Wheel, ESGF-RL-DQN-Trading, ESGF-RegimeSwitching, etc. + `data/`, `lean.json`)
- Surfaced as an untracked directory blocking a clean `git status` on `ai-01`

## Companion cleanups (already done locally on `ai-01`, no commit needed)

While triaging the dirty status I also restored two unintended local drifts (not part of this PR):
- `COURSE_CATALOG.generated.json` had been regenerated and **lost provenance** on 4 entries (`#1489`, `#999, #1141`, `#999, #1507`, `#969, #1436` → overwritten by `#1644`/`#1629`). Restored with `git checkout` per `Catalog Drift` decision (regen doesn't preserve `last_validator`).
- 3 SmartContracts `foundry-lib` submodules had floated upstream (`account-abstraction`, `forge-std`, `openzeppelin-contracts`). Restored via `git submodule update --init --recursive`.

## Test plan

- [x] `git status` clean on `ai-01` after `git add .gitignore`
- [x] `git check-ignore -v MyIA.AI.Notebooks/QuantConnect/ESGF-Workspace/` confirms ignore rule (post-commit)
- [ ] No CI gate touches this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)