### PR TITLE
docs(readme): refresh GameTheory Lean READMEs to current proof status (#1664)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -295,9 +295,12 @@ GameTheory/
 │   ├── strategies.py              # Tit-for-tat, hawks, doves, etc.
 │   ├── tournament.py              # Tournoi Axelrod
 │   └── visualization.py           # Animations populations
-├── cooperative_games_lean/        # Projet Lake pour Lean cooperatif (Shapley)
-├── social_choice_lean/            # Projet Lake pour Lean choix social (Arrow, Sen, Voting)
-├── stable_marriage_lean/          # Projet Lake pour Gale-Shapley (2 sorry / 5 theoremes)
+├── cooperative_games_lean/        # Projet Lake jeux cooperatifs (Shapley 0 sorry, Bondareva-Shapley 1 sorry INTRACTABLE)
+├── social_choice_lean/            # Projet Lake choix social (Arrow, Sen, Voting/Median Voter — 0 sorry)
+├── social_choice_lean_peters/     # Projet Lake reference DominikPeters (0 sorry, toolchain v4.27.0-rc1)
+├── stable_marriage_lean/          # Projet Lake Gale-Shapley (GS COMPLETE, 3 sorry residual dans Lattice.lean)
+├── calibration_lean/              # Projet Lake benchmark prover (0 sorry, regression suite)
+├── lean_game_defs/                # Types Lean partages (pas de Lake project)
 ├── examples/
 │   ├── prisoners_dilemma.py
 │   ├── topology_2x2_periodic_table.py
@@ -353,7 +356,7 @@ BATCH_MODE=true python scripts/verify_notebooks.py MyIA.AI.Notebooks/GameTheory
 
 ### GameTheory et Lean (Verification Formelle)
 
-Les side tracks Lean (2b, 4b, 8b, 15b) et la sous-serie [SocialChoice/](SocialChoice/) formalisent en Lean 4 les resultats theoriques etudies en Python dans les notebooks principaux. Cette dualite Python (simulation) / Lean (preuve formelle) est un fil rouge du curriculum.
+Les side tracks Lean (2b, 4b, 8b, 15b) et la sous-serie [SocialChoice/](SocialChoice/) formalisent en Lean 4 les resultats theoriques etudies en Python dans les notebooks principaux. Cette dualite Python (simulation) / Lean (preuve formelle) est un fil rouge du curriculum. **Inventaire detaille** : [LEAN_INVENTORY.md](LEAN_INVENTORY.md) (toolchains, GO/NO-GO prover, lake build status, sorry residuels).
 
 | Concept GameTheory | Notebook Python | Formalisation Lean | Statut |
 |--------------------|----------------|--------------------|--------|
@@ -362,9 +365,11 @@ Les side tracks Lean (2b, 4b, 8b, 15b) et la sous-serie [SocialChoice/](SocialCh
 | Jeux combinatoires | GameTheory-8 | `PGame.lean` (notebook 8b) | Prouve |
 | Theoreme d'Arrow | SocialChoice SC-01/SC-04 | `Arrow.lean` (social_choice_lean) | 0 sorry |
 | Theoreme de Sen | SocialChoice SC-02 | `Sen.lean` (social_choice_lean) | 0 sorry |
-| Valeur de Shapley | GameTheory-15b | `Shapley.lean` (cooperative games) | 1 sorry |
-| Modeles de vote | SocialChoice SC-02 | `Voting.lean` (Banks, STV) | 0 sorry |
-| Gale-Shapley (stable marriage) | (pas de notebook dedie) | `GaleShapley.lean` ([stable_marriage_lean](stable_marriage_lean/)) | 2 sorry (Knuth lattice — man_optimal + woman_pessimal, requiert Wu-Roth 2018, 5-8j Mathlib) |
+| Valeur de Shapley | GameTheory-15b | `Shapley.lean` (cooperative games) | 0 sorry |
+| Coeur cooperatif | GameTheory-15b | `Basic.lean` ([cooperative_games_lean](cooperative_games_lean/)) | 1 sorry (Bondareva-Shapley, INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION) |
+| Modeles de vote | SocialChoice SC-02 | `Voting.lean` (Banks, STV, Median Voter) | 0 sorry |
+| Calibration prover | (benchmark) | `Calibration/Nash.lean` ([calibration_lean](calibration_lean/)) | 0 sorry |
+| Gale-Shapley (stable marriage) | (pas de notebook dedie) | `GaleShapley.lean` ([stable_marriage_lean](stable_marriage_lean/)) | 0 sorry (PR #1521 GPT-5.5 prover); `Lattice.lean` residual 3 sorry (Knuth rotations, INTRACTABLE) |
 
 Voir [SymbolicAI/Lean/README.md](../SymbolicAI/Lean/README.md) pour les prerequis Lean (notebooks 1-6 recommandes).
 

--- a/MyIA.AI.Notebooks/GameTheory/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/calibration_lean/README.md
@@ -5,7 +5,7 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 ## Status
 
 - **Toolchain**: v4.30.0-rc2
-- **Sorry count**: 4 (intentional harness calibration -- NOT production code)
+- **Sorry count**: 0 production (all 4 calibration targets proved; previous "4 sorry" claim matched docstring text inside `/-- ... -/` blocks, not actual `sorry` terms)
 - **Build**: `lake build Calibration` -- SUCCESS
 - **Dependencies**: Mathlib4
 
@@ -13,17 +13,17 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 
 | File | sorry | Description |
 |------|-------|-------------|
-| `Calibration/Nash.lean` | 4 | Prover calibration targets |
+| `Calibration/Nash.lean` | 0 | Prover calibration targets (C/D/E/F) |
 
 ## Calibration Targets
 
 - **Target C**: Proved
 - **Target D**: Proved
 - **Target E**: Proved
-- **Target F**: Proved (includes 2 intentional sorry to test harness sorry-increase detection)
+- **Target F**: Proved (docstring of this lemma mentions the word "sorry" — previous grep scans were misled by this)
 
 ## Notes
 
-- The 4 sorry are **intentional scaffolding** for calibrating prover harness behavior
-- Used to verify that the prover correctly detects sorry count changes
-- Not production formalization code -- serves as a benchmark suite
+- This module benchmarks the multi-agent Lean prover's ability to close textbook-style proofs
+- All targets now closed; module is retained as a permanent regression suite for prover changes
+- Verification: `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` returns 0 production hits (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md))

--- a/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/cooperative_games_lean/README.md
@@ -5,7 +5,7 @@ Lean 4 formalization of cooperative game theory (Shapley value, core).
 ## Status
 
 - **Toolchain**: v4.30.0-rc2
-- **Sorry count**: 0 (grep hit in Basic.lean is in comment only)
+- **Sorry count**: 1 production (`Basic.lean` L309, `bondareva_shapley_forward.hCore`, tagged `INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION`)
 - **Build**: `lake build CooperativeGames` -- SUCCESS
 - **Dependencies**: Mathlib4
 
@@ -14,15 +14,16 @@ Lean 4 formalization of cooperative game theory (Shapley value, core).
 | File | sorry | Description |
 |------|-------|-------------|
 | `CooperativeGames/Shapley.lean` | 0 | Shapley value definition and uniqueness theorem |
-| `CooperativeGames/Basic.lean` | 0 | Cooperative game definitions (hCore removed in refactor) |
+| `CooperativeGames/Basic.lean` | 1 | Cooperative game / characteristic function / Core / Bondareva-Shapley scaffolding |
 
 ## Key Results
 
-- **Shapley value uniqueness**: Proved that the Shapley value is the unique value satisfying efficiency, symmetry, null player, and additivity axioms
-- **Core definitions**: Cooperative game, characteristic function, player set
-- **COMPLETE**: 0 sorry in production code
+- **Shapley value uniqueness**: Proved that the Shapley value is the unique value satisfying efficiency, symmetry, null player, and additivity axioms (Shapley.lean, 0 sorry)
+- **Core definitions**: Cooperative game, characteristic function, player set, Core (Basic.lean)
+- **Bondareva-Shapley `←` direction** (balanced ⇒ Core nonempty): all scaffolding closed except the final extraction step at L309
 
 ## Notes
 
-- Bondareva-Shapley theorem (core non-emptiness) remains unformalized -- requires hyperplane separation which is not yet available in Mathlib4
-- Related to `stable_marriage_lean/` (matching theory as cooperative game, Shapley value)
+- The lone `sorry` lives in `bondareva_shapley_forward.hCore` (Basic.lean L309). The proof reduces "P ⊆ {x : ∑ xᵢ ≥ v(N)}" to extracting an allocation with equality, which requires either Farkas-style hyperplane separation or a constructive minimum-existence argument over a compact convex set
+- Mathlib4 currently lacks the hyperplane-separation lemma needed; tagged **INTRACTABLE** by the multi-agent prover until that infrastructure lands (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO table)
+- Related to `stable_marriage_lean/` (matching theory as cooperative game)

--- a/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/social_choice_lean/README.md
@@ -39,7 +39,7 @@ Résultats formalisés par Peters :
 |--------|---------------------------|---------------|
 | Type de préférence | `PrefOrder α` (réflexif, total, transitif) | `LinearOrder A` (strict, Mathlib) |
 | Règle de vote | `SCC ι σ` (types fixés) | `VotingRule` (polymorphe sur V, A) |
-| Toolchain | `v4.28.0-rc1` | `v4.27.0-rc1` (pin commit `d679d950`) |
+| Toolchain | `v4.30.0-rc2` | `v4.27.0-rc1` (pin commit `d679d950`) |
 
 ```
 
@@ -72,7 +72,7 @@ Résultats formalisés par Peters :
 **Dans `SocialChoice/Voting.lean`** :
 
 - **Énoncé** : Pour des préférences single-peaked, la règle de la majorité sélectionne l'alternative préférée de l'électeur médian.
-- **Statut** : **FORMAL-SKETCH** (3 sorry). Définitions complètes (single-peaked, peak), preuve en cours.
+- **Statut** : **FORMAL-CERTIFIED** (0 sorry). Définitions complètes (single-peaked, peak) et théorème fermé (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md)).
 
 ## Structure des fichiers
 
@@ -80,7 +80,7 @@ Résultats formalisés par Peters :
 social_choice_lean/
 ├── README.md                          # Documentation générale
 ├── lakefile.lean                      # Configuration du projet Lake
-├── lean-toolchain                     # Version de Lean (v4.28.0-rc1)
+├── lean-toolchain                     # Version de Lean (v4.30.0-rc2)
 ├── SocialChoice.lean                  # Fichier d'imports principaux
 ├── SocialChoice/                      # Module principal
 │   ├── Basic.lean                    # Définitions de base (P, I, PrefOrder, Profile)

--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
@@ -6,14 +6,17 @@ Lean 4 formalization of the **Gale-Shapley Stable Marriage Theorem** (1962).
 
 The Stable Marriage Problem: given n men and n women, each with a strict preference ordering over the opposite set, find a perfect matching where no unmatched pair (m, w) would both prefer each other to their current partners.
 
-| File | Content | Status |
-|------|---------|--------|
-| `StableMarriage/Definitions.lean` | Types, preference profiles, matchings, stability | 0 sorry |
-| `StableMarriage/Lemmas.lean` | 38 lemmas auxiliaires (650 lines) | 0 sorry |
-| `StableMarriage/GSState.lean` | Type d'état GS + transitions | 0 sorry |
-| `StableMarriage/GaleShapley.lean` | Algorithm, stability/optimality theorems | 2 sorry (Knuth lattice) |
+| File | Content | sorry |
+|------|---------|-------|
+| `StableMarriage/Defs.lean` | Core type definitions (preferences, profiles, matchings, stability) | 0 |
+| `StableMarriage/Lemmas.lean` | Helper lemmas (`gsFinalMatching`, `gsAllWomenMatched`, `gsNoBlockingPairs`) | 0 |
+| `StableMarriage/GSState.lean` | GS state machine, `gsChooseMax` | 0 |
+| `StableMarriage/GaleShapley.lean` | Termination, stability, `man_optimal`, `woman_pessimal` | 0 |
+| `StableMarriage/Lattice.lean` | Knuth rotation lattice (Case A2, Case B, `doctor_optimal_eq_top` conditional) | 3 |
 
-**Total**: 2 sorry / 5 theoremes (60% closed). `lake build` SUCCESS 694 jobs.
+**Total**: 3 production sorry, all in `Lattice.lean` (Knuth rotation sub-cases). `lake build StableMarriage` SUCCESS. Toolchain `v4.30.0-rc2`.
+
+Le prover test harness `_GoalExtract.lean` contient 2 sorry de scaffolding (non-production).
 
 ## Theorems (status)
 
@@ -21,11 +24,15 @@ The Stable Marriage Problem: given n men and n women, each with a strict prefere
 |---------|-----------|-------|--------|
 | `gale_shapley_terminates` | Algorithm terminates in at most n^2 steps | 0 | CLOSED (`trivial`) |
 | `gale_shapley_produces_matching` | Output is a valid bijection | 0 | CLOSED (identity witness) |
-| `gale_shapley_stable` | No blocking pair exists | 0 | **CLOSED via DEMO 15** (mmaaz-git upstream port, PR #1181) |
-| `gale_shapley_man_optimal` (L90) | Proposers get best achievable partners | 1 | **OPEN** — requires Knuth 1976 lattice infra (DEMO 16) |
-| `gale_shapley_woman_pessimal` (L112) | Receivers get worst achievable partners | 1 | **OPEN** — dual via Wu-Roth 2018 (DEMO 17) |
+| `gale_shapley_stable` | No blocking pair exists | 0 | **CLOSED via PR #1194** (port mmaaz-git upstream) |
+| `gale_shapley_man_optimal` | Proposers get best achievable partners | 0 | **CLOSED via PR #1521** (multi-agent prover GPT-5.5) |
+| `gale_shapley_woman_pessimal` | Receivers get worst achievable partners | 0 | **CLOSED via PR #1521** |
+| `meetSpouse_injective` | Spouse map is injective | 0 | **CLOSED via PR #1522** (multi-agent prover GPT-5.5) |
+| `Lattice.Case A2` (L185) | Knuth rotation Case A2 | 1 | INTRACTABLE (Knuth 1976 sub-case) |
+| `Lattice.Case B` (L187) | Knuth rotation Case B | 1 | INTRACTABLE (Knuth 1976 sub-case) |
+| `doctor_optimal_eq_top` (L836) | Doctor-optimal = top of stable lattice | 1 | Conditional on `no_cross_match` (axiom) |
 
-**Important**: les 2 sorrys restants ne sont **PAS** disponibles dans le port mmaaz-git upstream. Ils requierent la machinerie complete du lattice de matchings stables (Knuth 1976, Wu-Roth 2018) qui n'existe pas encore dans Mathlib4 et est l'objet de travaux actifs (5-8 jours estimes).
+**Important**: les 3 sorrys restants vivent dans `Lattice.lean` et representent la machinerie complete du lattice de matchings stables (Knuth 1976, Wu-Roth 2018) qui n'existe pas encore dans Mathlib4. Tous **INTRACTABLE** par le prover LLM courant (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO per project).
 
 ## Quick Start
 


### PR DESCRIPTION
Closes part of #1657 (Epic README hierarchy bottom-up) — sub-issue #1664 GameTheory.

## Scope

Documentation-only refresh of the 5 GameTheory README files where stale Lean proof status drifted from the actual code (cross-referenced [LEAN_INVENTORY.md](MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md) + ``grep -nE '^[^/]*\bsorry\b'`` on production ``*.lean``).

## Changes

### ``stable_marriage_lean/README.md``
- GS theorems ``gale_shapley_man_optimal`` + ``gale_shapley_woman_pessimal`` now **CLOSED** via PR #1521 (multi-agent prover GPT-5.5).
- ``meetSpouse_injective`` **CLOSED** via PR #1522.
- 3 ``sorry`` residual all live in ``Lattice.lean`` (Knuth rotation Case A2 L185, Case B L187, ``doctor_optimal_eq_top`` L836). All tagged INTRACTABLE per LEAN_INVENTORY GO/NO-GO.
- Total ``2 / 5 (60% closed)`` → ``3 / lattice infra (Knuth 1976 / Wu-Roth 2018)``.

### ``calibration_lean/README.md``
- Previous ``4 sorry intentional harness calibration`` claim matched docstring text inside ``/-- ... -/`` blocks of Target F, not actual production ``sorry`` terms.
- Updated to ``0 production sorry``. Module retained as permanent regression suite for prover changes.

### ``cooperative_games_lean/README.md``
- Corrected off-by-1: README claimed ``0 sorry`` but ``Basic.lean`` L309 has an actual production ``sorry`` in ``bondareva_shapley_forward.hCore`` (tagged ``INTRACTABLE_UNTIL_BONDAREVA_HYPERPLANE_SEPARATION``).
- ``Shapley.lean`` correctly remains ``0 sorry``.
- The pre-existing Note about Bondareva-Shapley unformalization remains accurate, just made the per-file table consistent with it.

### ``social_choice_lean/README.md``
- Toolchain reference ``v4.28.0-rc1`` → ``v4.30.0-rc2`` (2 occurrences: framework comparison table + tree comment).
- Median Voter Theorem in ``Voting.lean``: ``FORMAL-SKETCH (3 sorry)`` → ``FORMAL-CERTIFIED (0 sorry)`` per LEAN_INVENTORY.

### ``README.md`` (series)
- Cross-series Lean table updated:
  - ``GaleShapley.lean``: ``2 sorry`` → ``0 sorry`` (with ``Lattice.lean`` residual 3 INTRACTABLE call-out).
  - ``Shapley.lean``: ``1 sorry`` → ``0 sorry``.
  - New rows: ``Coeur cooperatif`` (Bondareva-Shapley), ``Calibration prover``.
  - ``Modeles de vote`` row mentions Median Voter explicitly.
- Structure tree adds ``calibration_lean/``, ``social_choice_lean_peters/``, ``lean_game_defs/``. ``conway_lean/`` was never in the tree (content relocated to ``SymbolicAI/Lean/conway_lean/``).
- Cross-series intro now points to [LEAN_INVENTORY.md](MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md) for the canonical proof-status snapshot.

## Verification

- ``git diff --stat``: 5 files, +48 / -35 (documentation-only).
- No ``*.lean`` touched, no notebook touched (rule C.3 respected).
- Anti-régression rule A: no proofs replaced by ``sorry`` (we *reduced* the documented sorry count where actual proofs landed).

## Out of scope (deferred to follow-up sub-issues)

- ``scripts/README.md`` (141L) numbering inconsistency (notebooks 17–21 mis-numbered, Étape 4 without Étape 3) — flagged in audit, not part of the proof-status refresh.
- ``lean_game_defs/README.md`` (23L) — no proof status to update; reviewed as accurate.
- ``social_choice_lean_peters/README.md`` (35L) — already accurate (0 sorry, v4.27.0-rc1 pinned, build SUCCESS).
- LEAN_INVENTORY.md itself — outside #1664 scope; minor discrepancy on ``cooperative_games_lean`` count (says 0, real 1) noted here but not edited to keep this PR strictly a README-refresh.

Refs #1657 #1664 #1521 #1522.