### PR TITLE
docs(readme): refresh QC series-level READMEs (Epic #1657, sub #1659)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/README.md
@@ -9,18 +9,20 @@ Supports de cours pour l'apprentissage du trading algorithmique avec QuantConnec
 
 | Type | Count | Description |
 |------|-------|-------------|
-| **(a)** quantbook QC Cloud | 14 | QuantBook research or cloud-deploy descriptors |
+| **(a)** quantbook QC Cloud | 16 | QuantBook research or cloud-deploy descriptors (inclut Cloud-06-PCA-StatArb, Cloud-07-TemporalCNN ajoutés 2026-05) |
 | **(b)** research companion | 2 | QuantBook research paired with a course notebook |
 | **(c)** standalone research | 6 | Local yfinance/sklearn training |
 | **(d)** pedagogical placeholder | 33 | Course material with embedded QCAlgorithm strings |
+
+> Récapitulatif : 16+2+6+33 = 57 entrées de classification. Le nombre total de fichiers `.ipynb` dans le dossier est **51** : la différence reflète les notebooks classés dans plusieurs catégories (ex. course material exécuté localement = (c)+(d)). Voir [docs/qc-strategies-status.md](../../../docs/qc-strategies-status.md) pour la classification détaillée.
 
 Full classification: [docs/qc-strategies-status.md](../../../docs/qc-strategies-status.md)
 
 ---
 
-## État réel d'exécution (audit 2026-05-05)
+## État réel d'exécution (audit 2026-05-05, mise à jour 2026-05-28)
 
-Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Aucun output theatrical** (cellules qui printent des métadonnées en se faisant passer pour une exécution) ne subsiste après nettoyage de la PR `chore/qc-strip-fake-outputs`.
+Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Aucun output theatrical** (cellules qui printent des métadonnées en se faisant passer pour une exécution) ne subsiste après nettoyage de la PR `chore/qc-strip-fake-outputs`. Mise à jour 2026-05-28 : ajout des 5 notebooks créés depuis l'audit initial (RL avancé + 2 Cloud).
 
 **Légende** :
 - **EXÉCUTÉ** : cellules avec outputs réels issus d'une vraie exécution kernel
@@ -74,9 +76,14 @@ Suite à l'audit du 5 mai 2026, voici l'état honnête de chaque notebook. **Auc
 | QC-Py-Cloud-05-MLP-Forecasting | EXÉCUTÉ | 1/2 cellules avec outputs |
 | QC-Py-Cloud-05-RegimeSwitching | doc cloud | markdown-only — backtest sur QC Cloud |
 | QC-Py-Cloud-06-VolTargeting | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-Cloud-06-PCA-StatArb | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-Cloud-07-TemporalCNN | doc cloud | markdown-only — backtest sur QC Cloud |
+| QC-Py-33-RL-PPO-Trading | EXÉCUTÉ | 12/12 cellules avec outputs |
+| QC-Py-34-RL-SAC-A2C-Trading | EXÉCUTÉ | 11/11 cellules avec outputs |
+| QC-Py-35-RL-Portfolio-Construction | EXÉCUTÉ | 5/5 cellules avec outputs |
 | QC-Py-Dataset-Workflow | NON EXÉCUTÉ | 11 cellules code, 0 output |
 
-**Récapitulatif** : 46 notebooks total — 14 exécutés, 26 non exécutés, 6 doc cloud.
+**Récapitulatif** : 51 notebooks total — 17 exécutés, 26 non exécutés, 8 doc cloud.
 
 **Politique** : un notebook NON EXÉCUTÉ avec du code réel est préférable à un notebook avec des outputs théâtraux (print de métadonnées prétendant être une exécution). Les patterns théâtraux suivants sont désormais détectés comme erreur par [`scripts/validate_qc_notebooks.py`](../scripts/validate_qc_notebooks.py) :
 - `print("Algorithme charge : {len(qc_code)} caracteres")` — métadonnée d'une string, pas une exécution
@@ -146,6 +153,16 @@ Notebooks d'entrainement de modeles avec checkpoints GPU.
 | [QC-Py-31-Transformer-Training](QC-Py-31-Transformer-Training.ipynb) | Transformer | Checkpoint PyTorch |
 | [QC-Py-32-RL-DQN-Trading](QC-Py-32-RL-DQN-Trading.ipynb) | DQN | Checkpoint PyTorch |
 
+## Reinforcement Learning Avance (QC-Py-33 a 35)
+
+Approfondissement RL au-dela du DQN de la Phase 8 : PPO, SAC/A2C, application portfolio.
+
+| Notebook | Algorithme | Contenu |
+|----------|------------|---------|
+| [QC-Py-33-RL-PPO-Trading](QC-Py-33-RL-PPO-Trading.ipynb) | PPO | Proximal Policy Optimization, clipped surrogate, Stable-Baselines3 |
+| [QC-Py-34-RL-SAC-A2C-Trading](QC-Py-34-RL-SAC-A2C-Trading.ipynb) | SAC + A2C | Soft Actor-Critic + A2C, comparatif algorithmes RL |
+| [QC-Py-35-RL-Portfolio-Construction](QC-Py-35-RL-Portfolio-Construction.ipynb) | RL multi-asset | RL pour allocation multi-asset, contraintes de risque |
+
 ## Paper Trading (QC-Py-40 a 41)
 
 | Notebook | Courtier |
@@ -170,6 +187,8 @@ Notebooks de recherche et strategies executees sur QuantConnect Cloud.
 | [QC-Py-Cloud-05-MLP-Forecasting](QC-Py-Cloud-05-MLP-Forecasting.ipynb) | MLP Forecasting |
 | [QC-Py-Cloud-05-RegimeSwitching](QC-Py-Cloud-05-RegimeSwitching.ipynb) | Regime Switching |
 | [QC-Py-Cloud-06-VolTargeting](QC-Py-Cloud-06-VolTargeting.ipynb) | Volatility Targeting |
+| [QC-Py-Cloud-06-PCA-StatArb](QC-Py-Cloud-06-PCA-StatArb.ipynb) | PCA Statistical Arbitrage |
+| [QC-Py-Cloud-07-TemporalCNN](QC-Py-Cloud-07-TemporalCNN.ipynb) | Temporal CNN |
 
 ## Utilitaires
 

--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -41,7 +41,7 @@ Cette série est une formation complète sur le **trading algorithmique** avec l
 
 ### Contenu
 
-- **53 notebooks Python** (28 cours + 3 training local + 2 paper-trading + 2 dataset + 12 Cloud-ready + 4 RL avance + 2 research)
+- **51 notebooks Python** (28 cours QC-Py-01..28 + 3 training QC-Py-30..32 + 3 RL avance QC-Py-33..35 + 2 paper-trading QC-Py-40..41 + 13 Cloud-ready QC-Py-Cloud-01..07 + 1 dataset workflow + 1 research interne)
 - **18 notebooks sur fondations** avant ML (Universe, Asset Classes, Risk, Framework)
 - **9+ notebooks ML/DL/AI** (Supervised Learning, Deep Learning, Transformers, SSM, RL, LLM, Foundation Models)
 - **Free tier compatible** avec workarounds pour fonctionnalités payantes
@@ -151,9 +151,9 @@ Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders.
 
 ---
 
-### Phase 8 : IA Avancée et Production (3 notebooks, ~4.5h)
+### Phase 8 : IA Avancée et Production (4 notebooks, ~5.5h)
 
-État de l'art : Reinforcement Learning, LLM pour trading signals, déploiement production.
+État de l'art : Reinforcement Learning, LLM pour trading signals, déploiement production, détection de régime de marché.
 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
@@ -162,17 +162,31 @@ Deep Learning pour séries temporelles : LSTM, Transformers, Autoencoders.
 | 27 | [QC-Py-27-Production-Deployment](Python/QC-Py-27-Production-Deployment.ipynb) | 75 min | Paper trading, live trading setup, monitoring, deployment |
 | 28 | [QC-Py-28-Market-Regime-Detection](Python/QC-Py-28-Market-Regime-Detection.ipynb) | 75 min | HMM, regime detection, allocation adaptative |
 
-**Objectifs** : IA state-of-the-art pour trading, déploiement production.
+**Objectifs** : IA state-of-the-art pour trading, déploiement production, détection régime.
+
+---
+
+### Compléments Reinforcement Learning Avancé (3 notebooks, ~4h)
+
+Approfondissement RL au-delà du DQN de la Phase 8 : PPO, SAC/A2C, et application portfolio construction.
+
+| # | Notebook | Durée | Contenu |
+|---|----------|-------|---------|
+| 33 | [QC-Py-33-RL-PPO-Trading](Python/QC-Py-33-RL-PPO-Trading.ipynb) | 90 min | Proximal Policy Optimization, clipped surrogate, Stable-Baselines3 |
+| 34 | [QC-Py-34-RL-SAC-A2C-Trading](Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb) | 75 min | Soft Actor-Critic + A2C, comparatif algorithmes RL |
+| 35 | [QC-Py-35-RL-Portfolio-Construction](Python/QC-Py-35-RL-Portfolio-Construction.ipynb) | 75 min | RL pour allocation multi-asset, contraintes de risque |
+
+**Objectifs** : Comparer les algorithmes RL modernes, appliquer au portfolio multi-asset.
 
 ---
 
 ## Résumé de la Progression
 
-**Total** : **28 notebooks Python** (~32 heures de contenu)
+**Total cours linéaire** : **28 notebooks Python** (QC-Py-01 à QC-Py-28, ~32 heures de contenu) + **23 notebooks compléments** (Phase 4b-RL avancé QC-Py-33..35, paper trading QC-Py-40..41, Cloud strategies QC-Py-Cloud-*, training QC-Py-30..32, dataset workflow).
 
-**Répartition** :
+**Répartition cours linéaire (Phases 1-8)** :
 - **18 notebooks non-ML** (Fondations, Universe, Trading Avancé, Framework, Alternative Data) : ~18h
-- **9 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM) : ~12h
+- **10 notebooks ML/DL/AI** (Supervised Learning, Deep Learning, RL, LLM, Régime) : ~13h
 
 **Progression pédagogique** : Maîtriser les fondations QuantConnect **avant** d'aborder le Machine Learning.
 

--- a/MyIA.AI.Notebooks/QuantConnect/projects/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/README.md
@@ -1,9 +1,14 @@
 # QuantConnect Algorithmic Trading Projects
 
-Dernière mise à jour : 2026-05-05
+Dernière mise à jour : 2026-05-28 (audit comptage 2026-05-05 + drift refresh)
 
-Bibliothèque pédagogique de **78 stratégies** de trading algorithmique sur QuantConnect Cloud
-+ **8 clones QC Strategy Library** + **6 composants Framework** + **3 research/tools** = **95 projets**.
+Bibliothèque pédagogique d'environ **116 projets** de trading algorithmique sur QuantConnect Cloud
+(decompte filesystem 2026-05-28 hors `_docs`). Le décompte de référence du **2026-05-05** était
+**78 stratégies pédagogiques + 8 clones QC Strategy Library + 6 composants Framework + 3 research/tools = 95 projets**
+— **~21 stratégies/research dirs ajoutées depuis** (Adaptive-Conformal-Risk, ML Research keepers M12/M15,
+Decision Transformer L4, Inverse-Vol Ridge, etc.). Un recompte détaillé est en cours ; la classification
+par catégorie (Robuste/Historique/Exploratoire) ci-dessous reste valide pour les entrées listées.
+
 Chaque stratégie illustre un concept ou une famille de stratégies ; les performances varient
 volontairement pour montrer que toutes les idées académiques ne survivent pas au backtest réaliste.
 


### PR DESCRIPTION
## Summary

Epic #1657 sub-issue #1659 — refresh QuantConnect series-level READMEs against actual filesystem state (2026-05-28). 3 READMEs edited, 2 verified accurate.

## Changes

**QC/README.md** (series root):
- Phase 8 header: "3 notebooks" → "4 notebooks" (the table already listed 4; only the header was stale)
- New "Compléments Reinforcement Learning Avancé" section for QC-Py-33/34/35 (PPO, SAC/A2C, Portfolio-Construction)
- Notebook breakdown: 53 → 51 with explicit ranges per bucket
- Résumé de la Progression: 28 cours linéaire + 23 compléments, 10 ML/DL/AI

**QC/Python/README.md**:
- Audit table État réel: +5 missing entries (QC-Py-33/34/35 EXÉCUTÉ; Cloud-06-PCA-StatArb + Cloud-07-TemporalCNN doc cloud)
- Récapitulatif: 46 → 51 notebooks (17 exécutés, 26 non exécutés, 8 doc cloud)
- 4-Type classification: (a) 14 → 16, with explanatory note on multi-category counts
- Phase tables: new RL Avancé section (QC-Py-33..35), Cloud-06/07 entries

**QC/projects/README.md**:
- "95 projets" → "environ 116 projets" with explicit drift note (~21 strategies/research added since 2026-05-05)
- Date 2026-05-05 → 2026-05-28

**ML-Training-Pipeline/README.md** & **partner-course/README.md**: verified accurate, no changes.

## Scope discipline

- **No notebook touched** (C.3 compliant: no \`.ipynb\` re-execution, no execution_count changes)
- **No COURSE_CATALOG.generated.json regeneration** (anti-drift catalog)
- **No secrets, no .env touched**
- Pure prose/structure refresh

## Verification

- Filesystem counts cross-checked via \`ls\` (51 Python notebooks, 116 project dirs, 4 ML-Training notebooks)
- Execution status of 5 new audit entries verified via JSON parsing (\`execution_count\` + \`outputs\` per cell)

## Test plan
- [ ] Renders correctly on GitHub
- [ ] Cross-links between READMEs still resolve
- [ ] Notebook counts match filesystem (51 Python, 116 projects, 4 ML-Training)
- [ ] No regression in existing prose (anti-régression: no \`# Solution\` cell stripped)

Closes #1659 (sub-issue of Epic #1657).

🤖 Generated with [Claude Code](https://claude.com/claude-code)