### PR TITLE
docs(readme): fix ML Lab READMEs (Epic #1657 #1663)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day2/Labs/Lab3-CV-Screening/README.md
@@ -1,1 +1,3 @@
-Utiliser un agent d'IA pour analyser, noter et résumer des CVs par rapport à une offre d'emploi.
+# Lab 3 : CV Screening
+
+**Objectif :** Utiliser un agent d'IA pour analyser, noter et résumer des CVs par rapport à une offre d'emploi.

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/DEBUGGING_REPORT.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/PythonAgentsForDataScience/Day3/Labs/DEBUGGING_REPORT.md
@@ -1,3 +1,0 @@
-# Rapport de Débogage - Jour 3
-
-Ce document suit l'exécution, la validation et le débogage des notebooks du Jour 3.


### PR DESCRIPTION
## Summary

Closes the last open acceptance item from Epic #1657 sub-issue #1663 (audit ML series READMEs).

- **Lab3-CV-Screening/README.md** — add missing `# Lab 3 : CV Screening` H1 title. The file was a single-line description with no header.
- **Day3/Labs/DEBUGGING_REPORT.md** — remove obsolete 3-line stub from earlier debugging session. `grep -rn DEBUGGING_REPORT MyIA.AI.Notebooks/ML/` returns 0 references.

## Acceptance criteria (#1663)

- [x] `ML.Net/README.md` notebook table matches actual files (8 notebooks expected) — verified via `find` (ML-1 through ML-7 + TP-prevision-ventes = 8 ✓)
- [x] `DataScienceWithAgents/README.md` describes both AgenticDataScience and PythonAgentsForDataScience — verified, the README has both tracks with full Lab tables (Labs 1–7 LangChain, Labs 8–17 ADK)
- [x] Lab READMEs have accurate descriptions — verified Lab1, Lab2, Lab4, Lab5, Lab6, Lab7. Lab3 missing H1 fixed in this PR.

## Test plan

- [x] `python scripts/notebook_tools/generate_catalog.py --json-only --git-tracked-only` → 500 entries, OK
- [x] `python scripts/notebook_tools/expand_catalog_markers.py --check` → "All markers up-to-date" (ML/README.md OK, no drift)
- [x] No notebooks touched (docs-only, scope = 2 markdown files)

Refs: Epic #1657, sub-issue #1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)