### PR TITLE
fix(lean): detect lean4-wsl kernel.json wrapper regression (#1618)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/validate_lean_setup.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/validate_lean_setup.py
@@ -132,6 +132,48 @@ def check_jupyter_kernel(kernel_name):
         return False
 
 
+def check_kernel_wrapper(kernel_name="lean4-wsl"):
+    """Verifie que kernel.json pointe vers le bon wrapper Python (v5), pas l'ancien bash.
+
+    Detecte la regression du 2026-05-27 (issue #1618) ou kernel.json pointait vers
+    l'ancien wrapper ~/lean4-jupyter-wrapper.sh au lieu de ~/.lean4-kernel-wrapper.py.
+    """
+    import json
+
+    candidates = [
+        Path.home() / ".local" / "share" / "jupyter" / "kernels" / kernel_name / "kernel.json",
+    ]
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "jupyter" / "kernels" / kernel_name / "kernel.json")
+
+    kernel_json = next((p for p in candidates if p.exists()), None)
+    if kernel_json is None:
+        print_warning(f"kernel.json: aucun ({kernel_name}) trouve dans {[str(p) for p in candidates]}")
+        return False
+
+    try:
+        with open(kernel_json, "r", encoding="utf-8") as f:
+            spec = json.load(f)
+        argv = " ".join(str(a) for a in spec.get("argv", []))
+    except Exception as e:
+        print_error(f"kernel.json: erreur lecture ({e})")
+        return False
+
+    if "lean4-jupyter-wrapper.sh" in argv:
+        print_error(
+            f"kernel.json: pointe vers ancien wrapper bash (lean4-jupyter-wrapper.sh) — "
+            "regression #1618. Re-executer setup_lean4_kernel.ps1 pour pointer "
+            "vers ~/.lean4-kernel-wrapper.py (v5)."
+        )
+        return False
+    if ".lean4-kernel-wrapper.py" in argv:
+        print_ok(f"kernel.json ({kernel_name}): wrapper Python v5 correct")
+        return True
+    print_warning(f"kernel.json ({kernel_name}): wrapper inconnu — argv={argv[:120]}")
+    return False
+
+
 def check_env_file():
     """Verifie le fichier .env"""
     env_path = Path(__file__).parent.parent / ".env"
@@ -195,6 +237,7 @@ def validate_windows():
     # Kernels
     checks.append(check_jupyter_kernel("lean4"))
     checks.append(check_jupyter_kernel("python3-wsl"))
+    checks.append(check_kernel_wrapper("lean4-wsl"))
 
     # Fichiers projet
     checks.append(check_env_file())
@@ -227,6 +270,9 @@ def validate_wsl():
     checks.append(check_python())
     checks.append(check_command("elan", "elan"))
     checks.append(check_command("lean", "Lean 4"))
+
+    # Kernel wrapper (regression check #1618)
+    checks.append(check_kernel_wrapper("lean4-wsl"))
 
     # Venv Python WSL
     venv_path = Path.home() / ".python3-wsl-venv"


### PR DESCRIPTION
## Summary

Adds a regression check to `validate_lean_setup.py` for the `lean4-wsl` Jupyter kernel registration. Addresses **acceptance criterion #2** of #1618 ("Validation script detects wrong wrapper registration").

## What changed

- New function `check_kernel_wrapper(kernel_name=\"lean4-wsl\")`:
  - Reads `~/.local/share/jupyter/kernels/lean4-wsl/kernel.json` (or `%APPDATA%/jupyter/kernels/lean4-wsl/kernel.json` on Windows).
  - **ERROR** if `argv` mentions the obsolete bash wrapper `~/lean4-jupyter-wrapper.sh` (regression #1618).
  - **OK** if `argv` points to `~/.lean4-kernel-wrapper.py` (v5).
  - **WARN** otherwise.
- Wired into both `validate_windows()` and `validate_wsl()`.

## Why

Incident 2026-05-27: `kernel.json` pointed to the old bash wrapper, causing the `lean4-wsl` kernel to time out on notebook execution. The validation script did not detect this because it only checked that the kernel was *registered*, not that it pointed to the correct wrapper.

## Test plan

- [x] Syntax check passes (`py_compile`)
- [x] Run locally on Windows machine with correct setup → 13/13 OK, wrapper detected as v5 correct
- [ ] Run locally on WSL (`--wsl`) — to verify by anyone with the WSL kernel registered
- [ ] (Optional) Force broken state and re-run to verify ERROR path

## Scope (not in this PR)

Remaining #1618 acceptance criteria deferred to follow-up PRs:
- [ ] AC#1 Single entry point (`scripts/lean4-setup/setup_all.sh`)
- [ ] AC#3 Archive `~/lean4-jupyter-wrapper.sh` from setup scripts
- [ ] AC#4 Doc update in `docs/wsl-kernels-detail.md`

Closing #1618 is **NOT** appropriate yet — only AC#2 done. Will reference this PR from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)