### PR TITLE
feat(lean-prover): WSL backend preference for LeanVerifier #1651

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -24,7 +24,15 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 
-def _resolve_lake_command(extra_args: List[str]) -> Tuple[List[str], dict]:
+def _to_wsl_path(win_path: str) -> str:
+    """Convert ``C:\\foo\\bar`` to ``/mnt/c/foo/bar`` for use inside WSL bash."""
+    p = str(win_path).replace("\\", "/")
+    if len(p) >= 2 and p[1] == ":":
+        return f"/mnt/{p[0].lower()}{p[2:]}"
+    return p
+
+
+def _resolve_lake_command(extra_args: List[str], cwd: str = None) -> Tuple[List[str], dict]:
     """Return (argv, env) for invoking ``lake <extra_args>``.
 
     Strategy (in order):
@@ -44,20 +52,22 @@ def _resolve_lake_command(extra_args: List[str]) -> Tuple[List[str], dict]:
     if override and Path(override).exists():
         return [override, *extra_args], env
 
+    # WSL preferred when LEAN_USE_WSL=1 (Conway KS Pilier 1 #1651: WSL .lake
+    # cache is already warm, Windows lake.exe would trigger 1-2h Mathlib
+    # rebuild because OS-specific .c IR files differ).
+    if os.getenv("LEAN_USE_WSL") == "1":
+        cd_prefix = f"cd '{_to_wsl_path(cwd)}' && " if cwd else ""
+        wsl_cmd = cd_prefix + "source ~/.elan/env 2>/dev/null; lake " + " ".join(
+            f"'{a}'" for a in extra_args
+        )
+        return ["wsl", "-d", "Ubuntu", "bash", "-lc", wsl_cmd], env
+
     if platform.system() == "Windows":
         elan_bin = Path.home() / ".elan" / "bin"
         lake_exe = elan_bin / "lake.exe"
         if lake_exe.exists():
             env["PATH"] = f"{elan_bin}{os.pathsep}{env.get('PATH', '')}"
             return [str(lake_exe), *extra_args], env
-
-    # WSL fallback: only attempt if the operator explicitly opted in via
-    # LEAN_USE_WSL=1 (avoid regressing into the silent-source-fails trap).
-    if os.getenv("LEAN_USE_WSL") == "1":
-        wsl_cmd = "source ~/.elan/env 2>/dev/null; lake " + " ".join(
-            f"'{a}'" for a in extra_args
-        )
-        return ["wsl", "bash", "-c", wsl_cmd], env
 
     return ["lake", *extra_args], env
 
@@ -146,7 +156,7 @@ class LeanVerifier:
         if module_name.endswith(".lean"):
             module_name = module_name[:-5]
 
-        cmd, env = _resolve_lake_command(["build", "-R", module_name])
+        cmd, env = _resolve_lake_command(["build", "-R", module_name], cwd=str(project))
 
         try:
             start = time.time()
@@ -277,7 +287,7 @@ class LeanVerifier:
             ]
 
         project = Path(self.project_dir)
-        cmd, env = _resolve_lake_command(["env", "lean", "--stdin"])
+        cmd, env = _resolve_lake_command(["env", "lean", "--stdin"], cwd=str(project))
 
         try:
             stdin_input = f"import {module_name}\n#print axioms {module_name.split('.')[-1]}\n"
@@ -351,7 +361,7 @@ class LeanVerifier:
             if module.endswith(".lean"):
                 module = module[:-5]
 
-            cmd, env = _resolve_lake_command(["build", module])
+            cmd, env = _resolve_lake_command(["build", module], cwd=str(project))
             result = subprocess.run(
                 cmd,
                 cwd=str(project),


### PR DESCRIPTION
## Summary

Environment plumbing for the multi-agent Lean prover (`agent_tests/lean_server.py`). KS Pilier 1 BG iter hit a slow Windows-side Mathlib rebuild because OS-specific `.c` IR files differ between Windows/WSL toolchains, defeating the warm WSL `.lake` cache.

- New `_to_wsl_path()` helper: `C:\foo` -> `/mnt/c/foo` for inside-WSL use
- `_resolve_lake_command()` now takes optional `cwd=` and, when `LEAN_USE_WSL=1`, prepends `cd '<wsl_path>' &&` so the warm `.lake` cache in the project dir is hit
- WSL invocation switched from `["wsl","bash","-c",...]` to `["wsl","-d","Ubuntu","bash","-lc",...]` for explicit distro + login shell
- Three call sites (`build_module()`, axioms check, build retry) updated to pass `cwd=str(project)`

**Diff:** 1 file, +22/-12 (lean_server.py only).

## Honest status — KochenSpecker.lean unchanged

Per `anti-regression.md` and `verify-before-claiming.md`, **no proof is claimed in this PR**:

- `grep -c sorry MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean` = **2** (L159 + L176) — **UNCHANGED**
- Pre-flight baseline = 2 sorrys (`each_vector_in_two_contexts`, `kochen_specker`)
- Post-commit count = 2 sorrys
- KochenSpecker.lean is **not modified** by this branch

## What I attempted on the prover side, and why it failed

1. **DEMO 53/54 prover invocation:** blocked by `LeanVerifier` subprocess hanging on `lake build`
2. **`lake build Conway.KochenSpecker` Windows-side:** would trigger 1-2h Mathlib rebuild (OS-specific `.c` IR mismatch with WSL cache). This PR's WSL backend toggle is the structural fix.
3. **`lake build Conway.KochenSpecker` WSL-side (with WSL toggle):** timed out at 388/3316 modules after 600s — sibling BG agents (Lean-13 Grothendieck, Lean-14 Conway GoL) racing for the same `.lake/packages/mathlib/.lake/build/` directory.
4. **Olean header corruption:** `failed to read file '.../Mathlib/Data/Real/Basic.olean', incompatible header` — partial `lake exe cache get` overlays on a manifest-mismatched build dir (Tactic.olean 21:37, Real.Basic 21:38, Fin.Basic 22:41 — inconsistent timestamps prove rev mismatch).
5. **Direct snippet typecheck:** failed with the same olean header error.

Per `feedback-lean-no-manual-proofs.md`, the prover script is the primary tool. Manual fallback requires verifiable `lake build SUCCESS` (per `lean-merge-discipline.md` rule 1), which the current env state does not provide. Candidate proofs for L159 (`fin_cases v <;> decide`) and L176 (parity argument via `Finset.mul_sum` + `Finset.sum_ite_eq'`) are sketched in agent-memory forensic note (not in this PR — would be claim without proof).

## Recommended next steps (for invoker / future iteration)

1. **Nuke + clean rebuild** `conway_lean/.lake/packages/mathlib/.lake/build/` BEFORE next prover attempt (sibling BG agents must be paused).
2. With `LEAN_USE_WSL=1` now wired correctly, retry DEMO 53 (`each_vector_in_two_contexts`) — fast lemma, isolated.
3. Then DEMO 54 (`kochen_specker`) which depends on DEMO 53.

## Test plan

- [x] `git diff --stat` confirms +22/-12 on `lean_server.py` only
- [x] `grep -c sorry KochenSpecker.lean` = 2 pre-merge (unchanged from main)
- [ ] Smoke test: `LEAN_USE_WSL=1 python -c "from lean_server import _resolve_lake_command; print(_resolve_lake_command(['build','Conway.Doomsday'], cwd='C:/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean'))"` should return a `wsl -d Ubuntu bash -lc` argv with `cd '/mnt/c/...'`
- [ ] Smoke test on a clean Mathlib build dir: `lake build Conway.Doomsday` via the prover env completes in <30s (cache hit)

## Coordination note

`DO NOT merge yourself` per invoker. User is in foreground reviewing. Branch pushed, PR open, reporting back to invoker.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>