### PR TITLE
docs(readme): refresh Audio README — 30 notebooks + 04-13 FishAudio S2-Pro mention (#1658)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Audio/README.md
@@ -4,7 +4,7 @@
 
 Le traitement audio est souvent le parent pauvre de l'IA generative, eclipsé par les images et le texte. Pourtant, la voix et la musique sont les modalites les plus naturelles de l'interaction humaine. Cette serie couvre l'ensemble de la chaine audio IA : reconnaissance vocale, synthese, clonage, generation musicale, et orchestration de pipelines.
 
-29 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028, livre 18/05/2026, 8 PRs, post-mortem [ici](../../docs/epic-1028-audiobook-postmortem.md)).
+30 notebooks repartis sur 4 niveaux progressifs, des bases STT/TTS aux applications de production, dont un pipeline audiobook agentique complet (Epic #1028, livre 18/05/2026, 8 PRs, post-mortem [ici](../../docs/epic-1028-audiobook-postmortem.md)) etendu par une variante FishAudio S2-Pro avec 29 tags prosodiques officiels et validation WER (Epic #1273, en cours).
 
 ## Fil rouge : construire un podcast automatise
 
@@ -62,7 +62,7 @@ Les composants existent, il faut les assembler. Ce niveau construit les pipeline
 
 ### 04-Applications - Cas d'usage production
 
-Application directe : les notebooks de ce niveau mettent en oeuvre des workflows complets. 04-1 a 04-5 couvrent la narration de cours, la transcription batch, la composition musicale, la synchronisation audio-video et le live coding. 04-6 a 04-12 forment un pipeline audiobook agentique complet (Epic #1028) : benchmark des voix, analyse litteraire, casting vocal, annotation prosodique, generation TTS et compilation finale.
+Application directe : les notebooks de ce niveau mettent en oeuvre des workflows complets. 04-1 a 04-5 couvrent la narration de cours, la transcription batch, la composition musicale, la synchronisation audio-video et le live coding. 04-6 a 04-12 forment un pipeline audiobook agentique complet (Epic #1028) : benchmark des voix, analyse litteraire, casting vocal, annotation prosodique, generation TTS et compilation finale. 04-13 etend le pipeline avec FishAudio S2-Pro et 29 tags prosodiques officiels (Epic #1273).
 
 | Notebook | Contenu | Service | VRAM |
 |----------|---------|---------|------|


### PR DESCRIPTION
## Summary

Drift fix on `MyIA.AI.Notebooks/GenAI/Audio/README.md` post-merge #1689 (which added Lean kernel auto-install). Contributes to Epic #1657 sub-issue #1658 (GenAI README hierarchy).

- Line 7 subtitle: 29 → 30 notebooks
- Line 65 prose: append "04-13 etend le pipeline avec FishAudio S2-Pro et 29 tags prosodiques officiels (Epic #1273)"

## Counts verified

- 01-Foundation = 5 notebooks
- 02-Advanced = 9 (incl 02-9-AceStep)
- 03-Orchestration = 3
- 04-Applications = 13 (04-1 to 04-13)
- **Total = 30** (matches filesystem)

## Scope

Single file, +2/-2 lines, no notebook touched. Structure table (line 20) was already at "13 notebooks", row 04-13 was already in tables.

## Test plan

- [x] git diff --stat = 1 file +2/-2
- [x] Counts match `find . -name "*.ipynb" -not -name "*_output.ipynb"`
- [x] No notebook re-execution required (markdown-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)