### PR TITLE
docs(symbolicai/scripts): fix README drift (#1660)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/scripts/README.md
@@ -1,54 +1,46 @@
-# Scripts Utilitaires - Série Tweety
+# Scripts Utilitaires - SymbolicAI
 
-Ce répertoire contient les scripts Python utilitaires pour la gestion de la série de notebooks Tweety.
+Ce répertoire contient les scripts Python utilitaires de la série SymbolicAI : installation de dépendances externes (solveurs) et utilitaires de génération/maintenance de documentation des notebooks.
 
 ## Scripts Disponibles
 
-### verify_all_tweety.py
-Script de vérification complète de tous les notebooks Tweety. Exécute chaque notebook avec Papermill et analyse les sorties pour identifier les problèmes.
-
-**Usage:**
-```bash
-python verify_all_tweety.py
-```
-
-**Fonctionnalités:**
-- Exécution de tous les notebooks (Tweety-1 à Tweety-7)
-- Analyse des outputs pour détecter erreurs, warnings, outputs longs
-- Génération d'un résumé de vérification
-- Rapport de succès/échec par notebook
-
-### reorganize_tweety.py
-Script de réorganisation des notebooks Tweety. A été utilisé pour diviser le notebook monolithique original en 7 notebooks thématiques.
-
-**Usage:**
-```bash
-python reorganize_tweety.py
-```
-
-**Historique:**
-- Création de Tweety-5 (Argumentation Abstraite - Dung uniquement)
-- Création de Tweety-6 (Argumentation Structurée - ASPIC+, DeLP, ABA, ASP)
-- Renommage de l'ancien Tweety-6 en Tweety-7
-- Mise à jour des liens de navigation
-
 ### install_clingo.py
-Script d'installation automatique de Clingo (solveur ASP) pour Windows/Linux.
+
+Script d'installation automatique de Clingo (solveur ASP - Answer Set Programming, suite Potassco) pour Windows et Linux. Utilisé par les notebooks Tweety qui font appel à ASP via `ClingoSolver`.
 
 **Usage:**
 ```bash
-python install_clingo.py
+python install_clingo.py [--target-dir ext_tools/clingo] [--force]
 ```
 
 **Fonctionnalités:**
+
 - Téléchargement automatique de Clingo 5.7.1 depuis GitHub
-- Extraction et installation dans ext_tools/clingo/
+- Extraction et installation dans `ext_tools/clingo/`
 - Support Windows (ZIP) et Linux (tar.gz)
-- Vérification de l'installation existante
+- Vérification de l'installation existante (skip si déjà présent, sauf `--force`)
+
+**Note technique:** Dans Clingo 5.0+, `gringo` a été fusionné dans `clingo`. `GringoGrounder` de TweetyProject ne fonctionne donc pas directement, mais `ClingoSolver` reste pleinement opérationnel.
+
+### extract_notebook_content.py
+
+Utilitaire d'analyse de notebooks pour générer/maintenir la documentation. Parcourt tous les notebooks `.ipynb` du répertoire SymbolicAI et extrait pour chacun : le kernel, le nombre de cellules par type, et un aperçu des premières lignes de chaque cellule.
+
+**Usage:**
+```bash
+python extract_notebook_content.py
+```
+
+**Fonctionnalités:**
+
+- Scan récursif des notebooks SymbolicAI
+- Extraction du kernel et statistiques de cellules
+- Génération de previews (3 lignes / 200 caractères max par cellule)
+- Sortie utilisable pour rédaction/mise à jour de README
 
 ## Maintenance
 
-Ces scripts ont été utilisés pour la mise en place et la vérification de la série Tweety. Ils peuvent être réutilisés pour:
-- Vérifier l'intégrité après modifications
-- Réorganiser/refactoriser les notebooks
-- Installer les dépendances externes
+Ces scripts sont des outils d'appui à la série SymbolicAI :
+
+- `install_clingo.py` : à exécuter une fois par environnement pour activer les notebooks ASP de Tweety
+- `extract_notebook_content.py` : utilitaire de génération de documentation, utile lors de la mise à jour des README de séries


### PR DESCRIPTION
## Summary

`MyIA.AI.Notebooks/SymbolicAI/scripts/README.md` described 2 scripts that no longer exist in the directory and omitted 1 script that does exist — concrete drift identified during Epic #1657 README hierarchy refresh.

### Drift detected

| Script | README before | Filesystem | Fix |
|--------|---------------|------------|-----|
| `verify_all_tweety.py` | Documented | Deleted (commit `02f8553c`) | Removed section |
| `reorganize_tweety.py` | Documented | Deleted (commit `02f8553c`) | Removed section |
| `install_clingo.py` | Documented | Exists | Kept (slightly clarified) |
| `extract_notebook_content.py` | **Missing** | Exists (last touched `a2756831`) | **Added section** |

### Scope change

Title broadened from "Scripts Utilitaires - Série Tweety" → "Scripts Utilitaires - SymbolicAI" because `extract_notebook_content.py` scans the **full SymbolicAI directory**, not Tweety-specific. `install_clingo.py` remains Tweety-relevant (ASP solver for Tweety) but is also generally useful in SymbolicAI scope.

### Verification

- `ls MyIA.AI.Notebooks/SymbolicAI/scripts/` → confirmed only `install_clingo.py`, `extract_notebook_content.py`, `README.md` present
- `git log --all --diff-filter=D -- 'MyIA.AI.Notebooks/SymbolicAI/scripts/verify_all_tweety.py'` → confirmed deletion in `02f8553c` (fix(tweety): correct syntax errors and reorganize scripts)
- Read docstring of `extract_notebook_content.py` to draft accurate description

## Refs

Epic #1657 (README hierarchy refresh) — #1660 (SymbolicAI sub-files). Series-level SymbolicAI README already addressed by po-2025 via #1688; this PR is a small, undisputed gap inside the series.

## Test plan

- [x] `git diff --stat` shows insertions/deletions matching narrative (23 insertions, 31 deletions = net trim of stale content)
- [x] No code change, docs-only
- [x] MD032 lint warnings fixed (blank lines around lists)