### PR TITLE
docs(readme): refresh root MyIA.AI.Notebooks/README.md — align prose with catalog 500/500 (Epic #1657 #1669 LAST)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -1,6 +1,6 @@
 # MyIA.AI.Notebooks - Ecosysteme de Notebooks CoursIA
 
-Ecosysteme complet de **555 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques.
+Ecosysteme complet de **500 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques. Maturite : **158 PRODUCTION + 294 BETA = 452/500 (90%)** prets cours ; 39 ALPHA + 5 DRAFT + 4 TEMPLATE en developpement.
 
 <!-- CATALOG-STATUS
 series: ALL
@@ -9,20 +9,20 @@ breakdown: GenAI=114, QuantConnect=102, SymbolicAI=98, Search=45, Probas=43, Sud
 maturity: BETA=294, PRODUCTION=158, ALPHA=39, DRAFT=5, TEMPLATE=4
 -->
 
-Dernière mise à jour : 2026-05-23
+Dernière mise à jour : 2026-05-28
 
 ## Vue d'ensemble
 
 | Domaine | Notebooks | Description |
 |---------|-----------|-------------|
-| **GenAI** | 110 | IA Generative (Images, Audio, Video, Texte, Vibe-Coding) |
-| **QuantConnect** | 175 | Trading algorithmique et ML financier (Python + C#) |
-| **SymbolicAI** | 92 | IA Symbolique (Lean, Tweety, SmartContracts, SemanticWeb, Planners) |
+| **GenAI** | 114 | IA Generative (Images, Audio, Video, Texte, SemanticKernel, Vibe-Coding) |
+| **QuantConnect** | 102 | Trading algorithmique et ML financier (Python + C#) |
+| **SymbolicAI** | 98 | IA Symbolique (Lean, Tweety, SmartContracts, SemanticWeb, Planners) |
 | **Search** | 45 | Recherche, CSP, optimisation, metaheuristiques |
+| **Probas** | 43 | Programmation probabiliste (Infer.NET + PyMC) |
 | **Sudoku** | 32 | Resolution de contraintes (.NET C#) |
-| **Probas** | 32 | Programmation probabiliste (Infer.NET + PyMC) |
 | **ML** | 30 | Machine Learning .NET + Python Agents for Data Science |
-| **GameTheory** | 28 | Theorie des Jeux (OpenSpiel, choix social Lean) |
+| **GameTheory** | 25 | Theorie des Jeux (OpenSpiel, choix social Lean) |
 | **RL** | 6 | Reinforcement Learning (Stable-Baselines3) |
 | **CaseStudies** | 4 | Etudes de cas interdisciplinaires (diagnostic medical, planification oncologique) |
 | **IIT** | 1 | Integrated Information Theory (PyPhi) |
@@ -30,26 +30,29 @@ Dernière mise à jour : 2026-05-23
 ### Progression pedagogique
 
 ```text
-GenAI (110 notebooks)
-├── Image/ (19) - Generation d'images
-├── Audio/ (28) - Traitement audio
-├── Video/ (16) - Traitement video
-├── Texte/ (11) - LLMs et texte
+GenAI (114 notebooks)
+├── 00-GenAI-Environment/ (6) - Setup Docker, GPU, services
+├── Image/ (16) - Generation d'images (SDXL, Qwen, Flux)
+├── Audio/ (30) - STT, TTS, music, pipeline audiobook FishAudio S2-Pro
+├── Video/ (16) - Generation video, animation
+├── Texte/ (11) - LLMs, RAG, reasoning
 ├── SemanticKernel/ (20) - SDK Microsoft
+├── FineTuning/ (5) - Fine-tuning LoRA, adapters
 ├── CaseStudies/ (4) - Etudes de cas etudiants
 └── Vibe-Coding/ (5) - Claude-Code + Roo-Code
 
-QuantConnect (175 notebooks)
-├── Python/ (53) - Cours progressifs QC-Py
-├── projects/ (109) - Strategies backtests et ML
-└── partner-course-quant-trading/ (7) - Cours partenaire exercices et templates
+QuantConnect (102 notebooks)
+├── Python/ (51) - Cours progressifs QC-Py
+├── projects/ (49) - Strategies backtests et ML
+└── ML-Training-Pipeline/ (2) - Pipeline training thermal-safe
 
-SymbolicAI (92 notebooks)
+SymbolicAI (98 notebooks)
 ├── SmartContracts/ (27) - Solidity, Web3, blockchain
 ├── SemanticWeb/ (18) - RDF, SPARQL, OWL, C# + Python
-├── Planners/ (14) - PDDL, Fast-Downward, OR-Tools, LLM planning
-├── Lean/ (14) - Theorem proving, LeanDojo
+├── Lean/ (15) - Theorem proving, LeanDojo, social choice
+├── Planners/ (13) - PDDL, Fast-Downward, OR-Tools, LLM planning
 ├── Tweety/ (10) - Logiques classiques, argumentation
+├── SymbolicLearning/ (7) - ILP, NeuroSymbolic, KG-ILP, LLM-Symbolic
 └── Argument_Analysis/ (6) - Analyse d'arguments
 ```
 
@@ -85,14 +88,14 @@ SymbolicAI (92 notebooks)
 
 | Domaine | Notebooks | Lien |
 |---------|-----------|------|
-| **GenAI** | 110 | [GenAI/](GenAI/README.md) |
-| **QuantConnect** | 175 | [QuantConnect/](QuantConnect/README.md) |
-| **SymbolicAI** | 92 | [SymbolicAI/](SymbolicAI/README.md) |
+| **GenAI** | 114 | [GenAI/](GenAI/README.md) |
+| **QuantConnect** | 102 | [QuantConnect/](QuantConnect/README.md) |
+| **SymbolicAI** | 98 | [SymbolicAI/](SymbolicAI/README.md) |
 | **Search** | 45 | [Search/](Search/README.md) |
+| **Probas** | 43 | [Probas/](Probas/README.md) |
 | **Sudoku** | 32 | [Sudoku/](Sudoku/README.md) |
-| **Probas** | 32 | [Probas/](Probas/README.md) |
 | **ML** | 30 | [ML/](ML/README.md) |
-| **GameTheory** | 28 | [GameTheory/](GameTheory/README.md) |
+| **GameTheory** | 25 | [GameTheory/](GameTheory/README.md) |
 | **RL** | 6 | [RL/](RL/README.md) |
 | **CaseStudies** | 4 | [CaseStudies/](CaseStudies/README.md) |
 | **IIT** | 1 | [IIT/](IIT/README.md) |


### PR DESCRIPTION
## Summary

Closes Epic #1657 sub-issue #1669 (root README LAST). All 11 series sub-issues are merged; this aligns the root entry point's human-readable prose with `COURSE_CATALOG.generated.json` (500 entries).

Changes (all verified vs catalog `serie` field):

**Subtitle** : 555 → 500 notebooks + maturity ratio "158 PROD + 294 BETA = 452/500 (90%) prets cours".

**Date** : 2026-05-23 → 2026-05-28.

**Vue d'ensemble table** :
- GenAI 110 → 114
- QuantConnect 175 → 102
- SymbolicAI 92 → 98
- Probas 32 → 43
- GameTheory 28 → 25
- Search/Sudoku/ML/RL/CaseStudies/IIT : unchanged (already correct)

**Progression tree** (per `sous_serie`) :
- GenAI : Image 19→16, Audio 28→30, +00-GenAI-Environment 6, +FineTuning 5 (mentions FishAudio S2-Pro Epic #1273 in Audio)
- QC : Python 53→51, projects 109→49, removed `partner-course-quant-trading 7` (folded into Python), +ML-Training-Pipeline 2
- SymbolicAI : Lean 14→15, Planners 14→13, +SymbolicLearning 7

**Sub-domain links table** : same fixes as Vue d'ensemble.

## CATALOG-STATUS marker

Unchanged. Already at total=500 with breakdown matching the catalog. `expand_catalog_markers.py --check` returns OK (no drift).

## Epic #1657 status

This PR closes the LAST sub-issue. All 12 sub-issues now done:
- ✅ #1665 Sudoku, #1666 RL, #1667 IIT, #1668 CaseStudies, #1661 Search, #1662 Probas, #1663 ML, #1664 GameTheory, #1660 SymbolicAI, #1658 GenAI, #1659 QuantConnect (already closed)
- ✅ #1669 Root (this PR)

## Scope

Single file, +27/-24 lines, prose only — no notebook touched, no CATALOG-STATUS marker mutation.

## Test plan

- [x] `expand_catalog_markers.py --check` → OK (no drift)
- [x] Counts verified via `Counter` on catalog `serie` + `sous_serie` fields
- [x] All sub-issue series counts match their respective README headers (cross-checked with merged #1690 Audio 30, #1688 SymbolicAI 98, etc.)
- [x] No markdown-only structural breaks introduced (pre-existing MD060/MD022 warnings untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)