### PR TITLE
docs(gametheory/scripts): fix README drift — accurate kernel table + Etape 4→3 (Epic #1657 #1664)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/scripts/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts GameTheory
 
-Ce repertoire contient les scripts de configuration et validation pour les notebooks Lean de la serie GameTheory.
+Ce repertoire contient les scripts de configuration et de validation des kernels utilises par la serie GameTheory : kernel Python WSL pour les notebooks OpenSpiel/CFR (`GameTheory-13`, `GameTheory-17`), et kernel Lean 4 (WSL) pour les notebooks Lean natifs (`-2b`, `-8b`, `-15b`, `SocialChoice/02-Lean-SocialChoice-Formal`).
 
 ## Scripts disponibles
 
@@ -72,20 +72,28 @@ python scripts/validate_lean_setup.py
 python scripts/validate_lean_setup.py --wsl
 ```
 
-### Etape 4 : Redemarrer VSCode
+### Etape 3 : Redemarrer VSCode
 
 Fermer et rouvrir completement VSCode pour que les nouveaux kernels soient detectes.
 
 ## Architecture des kernels
 
+Les notebooks Lean natifs sont suffixes `-b` (kernel Lean 4) ; les notebooks Python miroirs sont suffixes `-c` quand un parallele Python existe.
+
 | Notebook | Kernel | Description |
 |----------|--------|-------------|
-| 1-16 | Python | Notebooks Python classiques |
-| 17 (Lean-Definitions) | **Lean 4 (WSL)** | Definitions formelles, cellules Lean natives |
-| 18 (Lean-NashExistence) | Python (WSL) | Lecture guidee, orchestration via lean_runner.py |
-| 19 (Lean-CombinatorialGames) | **Lean 4 (WSL)** | PGame mathlib, cellules Lean natives |
-| 20 (Lean-SocialChoice) | **Lean 4 (WSL)** | Arrow, Sen, electeur median |
-| 21 (Lean-CooperativeGames) | **Lean 4 (WSL)** | Formalisation Shapley |
+| `GameTheory-1` a `GameTheory-12`, `-14`, `-16` | Python (Windows) | Notebooks Python classiques (Nashpy, sympy, networkx) |
+| `GameTheory-2b-Lean-Definitions` | **Lean 4 (WSL)** | Definitions formelles, cellules Lean natives |
+| `GameTheory-4b-Lean-NashExistence` | Python (WSL) | Lecture guidee, orchestration via `lean_runner.py` |
+| `GameTheory-4c-NashExistence-Python` | Python (Windows) | Miroir numerique (sympy, scipy) |
+| `GameTheory-8b-Lean-CombinatorialGames` | **Lean 4 (WSL)** | PGame mathlib, cellules Lean natives |
+| `GameTheory-8c-CombinatorialGames-Python` | Python (Windows) | Miroir Sprague-Grundy en Python |
+| `GameTheory-13-ImperfectInfo-CFR` | Python (WSL) | OpenSpiel CFR (WSL requis : pas de wheel Windows) |
+| `GameTheory-15-CooperativeGames` | Python (Windows) | Solutions cooperatives (Shapley, core, nucleolus) |
+| `GameTheory-15b-Lean-CooperativeGames` | **Lean 4 (WSL)** | Formalisation Shapley (Lean 4) |
+| `GameTheory-15c-CooperativeGames-Python` | Python (Windows) | Miroir Python du calcul Shapley |
+| `GameTheory-17-MultiAgent-RL` | Python (WSL) | OpenSpiel multi-agent RL (idem GT-13, WSL requis) |
+| `SocialChoice/02-Lean-SocialChoice-Formal` | **Lean 4 (WSL)** | Arrow, Sen, electeur median |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Scope

Fixe 2 drifts dans `MyIA.AI.Notebooks/GameTheory/scripts/README.md` flagges par @myia-po-2025 dans PR #1681 comme **out-of-scope** (audit only) :

> _"numerotation 17-21 et Etape 4 sans Etape 3 — flagge audit, hors scope refresh proof-status"_

### Drift 1 — table "Architecture des kernels"

La table mentionnait des notebooks `17/18/19/20/21` qui **n'existent pas** sur le filesystem. Les notebooks reels utilisent un schema `-b` (Lean natif) / `-c` (miroir Python) intercale :

| Avant | Apres |
|-------|-------|
| `GameTheory-17` | `GameTheory-2b-Lean-Definitions` |
| `GameTheory-18` | `GameTheory-4b-Lean-NashExistence` + `-4c-NashExistence-Python` |
| `GameTheory-19` | `GameTheory-8b-Lean-CombinatorialGames` + `-8c-CombinatorialGames-Python` |
| `GameTheory-20` | `SocialChoice/02-Lean-SocialChoice-Formal` |
| `GameTheory-21` | `GameTheory-15b-Lean-CooperativeGames` + `-15c-CooperativeGames-Python` |

Table rewrite : 6 lignes generiques -> **12 lignes** mappant chaque notebook reel + son kernel + sa description. Source de verite : `ls MyIA.AI.Notebooks/GameTheory/` (verifie 2026-05-28).

Ajoute aussi `GameTheory-13-ImperfectInfo-CFR` et `GameTheory-17-MultiAgent-RL` (Python WSL OpenSpiel) qui etaient absents.

### Drift 2 — numerotation Etapes

Header sequence etait : `Etape 0` / `Etape 1a` / `Etape 1b` / `Etape 2` / **`Etape 4`** (trou). Renumerote en `Etape 3 : Redemarrer VSCode` (pas de manque, juste un bug de numerotation).

### Intro broadened

L'intro mentionnait uniquement "scripts pour les notebooks Lean". Elargie pour refleter que les scripts couvrent **a la fois** OpenSpiel/CFR (Python WSL pour GT-13, GT-17) et Lean 4 (WSL).

## Hors scope

- Pas de `.lean` / `.ipynb` / `.py` / `.sh` touche
- Pas de modification du contenu des scripts decrits — uniquement le README qui les documente
- Conway / Grothendieck (WIP @myia-po-2026 BG agents) : non couverts ici, sub-folders `conway_lean/` et `grothendieck_lean/` non encore committed
- `social_choice_lean_peters/` + `lean_game_defs/` : flagges accurate par @myia-po-2025 dans #1681, rien a corriger

## Epic context

3eme PR de la cascade #1664 (GameTheory READMEs hierarchy) :
1. #1681 (@myia-po-2025) : 5 Lean sub-folders + audit drift (MERGED)
2. _(po-2026 BG WIP)_ : conway_lean/ + grothendieck_lean/ (a venir)
3. **#XXXX (cette PR)** : scripts/README.md drift

Closes (partial) #1664. Epic #1657 progresse de 9/12 a 10/12 sub-issues couvertes.

## Verifications

- Filesystem source : `ls MyIA.AI.Notebooks/GameTheory/*.ipynb` + `ls MyIA.AI.Notebooks/GameTheory/SocialChoice/`
- Pre-existing CI failure (catalog-drift GenAI 117 vs 114) sans rapport — territoire @myia-po-2025
- Pas de notebook re-execute (regle C.3 : modifs README pure docs uniquement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)