### PR TITLE
fix(catalog): drift CI green — tool 'sous_serie or root' + GenAI 117 to 114 align catalog

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: GameTheory
 pedagogical_count: 25
-breakdown: =21, SocialChoice=4
+breakdown: root=21, SocialChoice=4
 maturity: BETA=21, ALPHA=2, PRODUCTION=2
 -->
 

--- a/MyIA.AI.Notebooks/GenAI/README.md
+++ b/MyIA.AI.Notebooks/GenAI/README.md
@@ -2,14 +2,14 @@
 
 <!-- CATALOG-STATUS
 series: GenAI
-pedagogical_count: 117
-breakdown: Audio=30, SemanticKernel=20, Image=19, Video=16, Texte=11, 00-GenAI-Environment=6, FineTuning=5, Vibe-Coding=5, CaseStudies=4, root=1
-maturity: BETA=74, PRODUCTION=33, ALPHA=4, DRAFT=3, TEMPLATE=3
+pedagogical_count: 114
+breakdown: Audio=30, SemanticKernel=20, Image=16, Video=16, Texte=11, 00-GenAI-Environment=6, FineTuning=5, Vibe-Coding=5, CaseStudies=4, root=1
+maturity: BETA=71, PRODUCTION=33, ALPHA=4, DRAFT=3, TEMPLATE=3
 -->
 
 Ce parcours vous forme a la maitrise de l'IA generative dans toute sa diversite : generer des images, synthetiser la voix, composer de la musique, produire des videos, orchestrer des agents autonomes, et deployer des applications en production. Chaque modalite suit une progression en quatre niveaux, du premier pas avec une API jusqu'aux pipelines multi-modeles de production.
 
-**117 notebooks** | **10 sous-domaines** | **~90-100h** | **95%+ valides**
+**114 notebooks** | **10 sous-domaines** | **~90-100h** | **95%+ valides**
 
 ## Pourquoi ce parcours ?
 
@@ -20,7 +20,7 @@ L'IA generative a transforme la creation de contenu en 2024-2026. Un developpeur
 ```text
 GenAI/
 ├── 00-GenAI-Environment/    # Setup et configuration (6 notebooks)
-├── Image/                   # Generation d'images (19 notebooks)
+├── Image/                   # Generation d'images (16 notebooks)
 ├── Audio/                   # Speech, TTS, musique, separation (30 notebooks)
 ├── Video/                   # Generation et comprehension video (16 notebooks)
 ├── Texte/                   # LLMs et generation de texte (11 notebooks)
@@ -49,7 +49,7 @@ On commence par les fondamentaux : appeler DALL-E 3 et GPT-5 pour generer des im
 
 **Fil rouge** : construire un generateur de contenu visuel pour l'education (diagrammes scientifiques, illustrations pedagogiques, motifs decoratifs).
 
-[README complet](Image/README.md) | 19 notebooks | ~6-8h
+[README complet](Image/README.md) | 16 notebooks | ~6-8h
 
 ---
 

--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: IIT
 pedagogical_count: 1
-breakdown: =1
+breakdown: root=1
 maturity: BETA=1
 -->
 

--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: Probas
 pedagogical_count: 43
-breakdown: Infer=20, _python_port=20, =3
+breakdown: Infer=20, _python_port=20, root=3
 maturity: BETA=33, PRODUCTION=10
 -->
 

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: RL
 pedagogical_count: 6
-breakdown: =6
+breakdown: root=6
 maturity: PRODUCTION=5, BETA=1
 -->
 

--- a/MyIA.AI.Notebooks/Search/README.md
+++ b/MyIA.AI.Notebooks/Search/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: Search
 pedagogical_count: 45
-breakdown: Applications=20, Part1-Foundations=11, Part2-CSP=9, =5
+breakdown: Applications=20, Part1-Foundations=11, Part2-CSP=9, root=5
 maturity: BETA=22, PRODUCTION=22, DRAFT=1
 -->
 

--- a/MyIA.AI.Notebooks/Sudoku/README.md
+++ b/MyIA.AI.Notebooks/Sudoku/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: Sudoku
 pedagogical_count: 32
-breakdown: =32
+breakdown: root=32
 maturity: BETA=24, PRODUCTION=8
 -->
 

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: SymbolicAI
 pedagogical_count: 98
-breakdown: SmartContracts=27, SemanticWeb=18, Lean=15, Planners=13, Tweety=10, SymbolicLearning=7, Argument_Analysis=6, =2
+breakdown: SmartContracts=27, SemanticWeb=18, Lean=15, Planners=13, Tweety=10, SymbolicLearning=7, Argument_Analysis=6, root=2
 maturity: BETA=83, PRODUCTION=9, ALPHA=6
 -->
 

--- a/scripts/notebook_tools/expand_catalog_markers.py
+++ b/scripts/notebook_tools/expand_catalog_markers.py
@@ -73,9 +73,9 @@ def _sorted_counter(c: Counter) -> dict[str, int]:
 
 
 def compute_breakdown(entries: list[dict], serie: str) -> dict[str, int]:
-    """Compute breakdown by sous_serie for a given serie."""
+    """Compute breakdown by sous_serie for a given serie. Entries without sous_serie group as 'root'."""
     serie_entries = [e for e in entries if e.get("serie") == serie]
-    return _sorted_counter(Counter(e.get("sous_serie", "_root") for e in serie_entries))
+    return _sorted_counter(Counter((e.get("sous_serie") or "root") for e in serie_entries))
 
 
 def compute_maturity_distribution(entries: list[dict], serie: str | None = None) -> dict[str, int]:


### PR DESCRIPTION
## Summary

Unblocks catalog drift CI for ALL future PRs (was UNSTABLE on main).

**Two bugs fixed:**

### 1. Tool bug in `expand_catalog_markers.py:78`
`Counter(e.get('sous_serie', '_root'))` returned `None` keys instead of fallback for entries where `sous_serie` exists with value None.

Python semantics: `dict.get(k, default)` only returns default for MISSING keys, **not** for None values.

Fix: `Counter((e.get('sous_serie') or 'root') for e in serie_entries)` collapses both None and missing to 'root'.

Side-effect: 7 series READMEs had cosmetic `=N` empty keys → now `root=N` (GameTheory, IIT, Probas, RL, Search, Sudoku, SymbolicAI).

### 2. GenAI README drift (117 → 114)
Marker had been manually edited to 117 in #1690, but catalog says 114.

3 `Image/examples/` notebooks (history-geography, literature-visual, science-diagrams) exist on disk but are NOT in catalog (heuristic excludes them as worked examples vs core pedagogical).

Aligned marker + narrative to catalog truth:
- `pedagogical_count: 117` → `114`
- `Image=19` → `Image=16` (3 examples not in catalog)
- `BETA=74` → `BETA=71`
- L12, L23, L52 narrative updates matched

## Verification

```
$ python scripts/notebook_tools/expand_catalog_markers.py --check
Loaded 500 entries from COURSE_CATALOG.generated.json
... 12 READMEs OK (no drift) ...
All markers up-to-date
```

## Test plan
- [x] `--check` reports "All markers up-to-date" (no exit 1)
- [x] No new entries added to COURSE_CATALOG.generated.json (root README unchanged)
- [x] GenAI README narrative matches marker counts (3 places)
- [x] Tool fix idempotent (re-running produces identical output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)