### PR TITLE
docs(readme): refresh ML series — drift fix 30->27 notebooks (DSWA 22->19) (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -2,12 +2,12 @@
 
 <!-- CATALOG-STATUS
 series: ML
-pedagogical_count: 30
-breakdown: DataScienceWithAgents=22, ML.Net=8
-maturity: BETA=23, ALPHA=4, PRODUCTION=3
+pedagogical_count: 27
+breakdown: DataScienceWithAgents=19, ML.Net=8
+maturity: BETA=20, ALPHA=4, PRODUCTION=3
 -->
 
-Vous êtes développeur ou analyste et vous voulez construire des modèles prédictifs sans devenir data scientist théoricien ? Cette série vous forme au Machine Learning pratique avec deux stack complémentaires : **ML.NET** pour l'écosystème .NET/C# (8 notebooks, ~6h) et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs (22 notebooks, ~20h). À la fin, vous saurez charger des données, entraîner un modèle, l'évaluer rigoureusement, et le déployer en production.
+Vous êtes développeur ou analyste et vous voulez construire des modèles prédictifs sans devenir data scientist théoricien ? Cette série vous forme au Machine Learning pratique avec deux stack complémentaires : **ML.NET** pour l'écosystème .NET/C# (8 notebooks, ~6h) et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs (19 notebooks, ~17h). À la fin, vous saurez charger des données, entraîner un modèle, l'évaluer rigoureusement, et le déployer en production.
 
 ## Parcours d'apprentissage
 
@@ -15,7 +15,7 @@ Vous êtes développeur ou analyste et vous voulez construire des modèles préd
 
 Le parcours ML.NET couvre le pipeline complet en C# : les notebooks 1-2 introduisent ML.NET et la préparation de données (IDataView, encodage). Le notebook 3 couvre l'entraînement (SDCA, LightGBM, AutoML). Le notebook 4 est crucial : évaluation rigoureuse par cross-validation et Permutation Feature Importance. Les notebooks 5-7 abordent les séries temporelles, l'export ONNX pour la production, et les systèmes de recommandation. Le TP final (prévision de ventes) combine ML.NET et Infer.NET pour une régression bayésienne. Ce track présuppose .NET 9.0 + dotnet-interactive.
 
-### Track B : Data Science with Agents (Python, 22 notebooks, ~20h)
+### Track B : Data Science with Agents (Python, 19 notebooks, ~17h)
 
 Le parcours Python commence par les fondations (NumPy/Pandas) puis se divise en deux sous-tracks. Le sous-track **LangChain** (Labs 1-7) couvre le data wrangling, la visualisation, le ML classique (régression, classification, clustering), les modèles d'ensemble et le NLP de base. Le sous-track **Google ADK** (Labs 8-17) monte en complexité avec le deep learning (PyTorch), l'analyse de survivors, le dashboarding, et les pipelines agentic (agents LLM pour automatiser le workflow data science). Ce track présuppose Python 3.10+ avec PyTorch, scikit-learn et pandas.
 
@@ -25,7 +25,7 @@ Cette série sert les cours **ECE / EPITA / EPF** en introduction au Machine Lea
 
 **Slides de cours associes** : [06-apprentissage/](../../slides/06-apprentissage/) | **Livre de reference** : [Hands-On AI Trading](https://www.hands-on-ai-trading.com/) (chapitres ML)
 
-**30 notebooks** | **2 sous-domaines** | **~25h** | **.NET Interactive + Python**
+**27 notebooks** | **2 sous-domaines** | **~23h** | **.NET Interactive + Python**
 
 ## Structure
 


### PR DESCRIPTION
## Summary

Drift fix on `MyIA.AI.Notebooks/ML/README.md` aligned with filesystem reality.

**Avant** : `pedagogical_count: 30` (`DataScienceWithAgents=22, ML.Net=8`) / "~25h"
**Apres** : `pedagogical_count: 27` (`DataScienceWithAgents=19, ML.Net=8`) / "~23h"

## Audit filesystem (verifie cellule par cellule)

| Sous-serie | Notebooks pedagogiques | Verification |
|---|---|---|
| `ML.Net/` | **8** | ML-1 a ML-7 + TP-prevision-ventes (inchange) |
| `DataScienceWithAgents/01-PythonForDataScience/` | **2** | 1.2-NumPy, 1.3-Pandas |
| `DataScienceWithAgents/AgenticDataScience/` | **10** | Lab8..Lab17 (`_executed` exclus) |
| `DataScienceWithAgents/PythonAgentsForDataScience/` | **7** | Lab1..Lab7 (2 `_executed` exclus) |
| **DSWA total** | **19** | (pas 22) |
| **ML total** | **27** | (pas 30) |

Les fichiers `*_executed.ipynb` et `*_output.ipynb` sont des artefacts Papermill exclus du `pedagogical_count` par convention de la serie.

## Edits (6 lignes / 6 lignes)

- L5-6 : `CATALOG-STATUS` `pedagogical_count`, `breakdown`, `maturity`
- L10 : prose intro Python track (`(22 notebooks, ~20h)` -> `(19 notebooks, ~17h)`)
- L18 : heading Track B (`(Python, 22 notebooks, ~20h)` -> `(Python, 19 notebooks, ~17h)`)
- L28 : stats line (`**30 notebooks** ... **~25h**` -> `**27 notebooks** ... **~23h**`)

## Scope strict (regles C.3 + anti-regression)

- README-only refresh.
- **Pas** de `.ipynb` modifie (aucune cellule code/markdown).
- **Pas** de `.lean` / `.cs` / `.py` modifie.
- **Pas** de regeneration `COURSE_CATALOG.generated.json`.
- Root README `MyIA.AI.Notebooks/README.md` **NON modifie** dans cette PR pour eviter race avec #1695 (just merged par po-2026). Cycle suivant ajustera la ligne ML root 30->27.

## Reference

- Epic #1657 (README hierarchy refresh, bottom-up)
- Suit #1694 (Sudoku README), #1696 (FineTuning README) MERGED

## Test plan

- [x] Diff `git diff --stat` = 1 fichier, 6+/-6 lignes (cible CATALOG-STATUS + prose alignee)
- [x] Filesystem audit cellule par cellule documente ci-dessus
- [x] Pas de notebook touche (verifie : `git diff --stat` sur `*.ipynb` = 0)
- [ ] Catalog drift CI : peut signaler le mismatch root vs ML (volontaire, sera corrige post-#1695)

🤖 Generated with [Claude Code](https://claude.com/claude-code)