### PR TITLE
docs(readme): align root README with ML 30->27 (Epic #1657 follow-up #1699)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -1,12 +1,12 @@
 # MyIA.AI.Notebooks - Ecosysteme de Notebooks CoursIA
 
-Ecosysteme complet de **500 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques. Maturite : **158 PRODUCTION + 294 BETA = 452/500 (90%)** prets cours ; 39 ALPHA + 5 DRAFT + 4 TEMPLATE en developpement.
+Ecosysteme complet de **497 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques. Maturite : **158 PRODUCTION + 291 BETA = 449/497 (90%)** prets cours ; 39 ALPHA + 5 DRAFT + 4 TEMPLATE en developpement.
 
 <!-- CATALOG-STATUS
 series: ALL
-total: 500
-breakdown: GenAI=114, QuantConnect=102, SymbolicAI=98, Search=45, Probas=43, Sudoku=32, ML=30, GameTheory=25, RL=6, CaseStudies=4, IIT=1
-maturity: BETA=294, PRODUCTION=158, ALPHA=39, DRAFT=5, TEMPLATE=4
+total: 497
+breakdown: GenAI=114, QuantConnect=102, SymbolicAI=98, Search=45, Probas=43, Sudoku=32, ML=27, GameTheory=25, RL=6, CaseStudies=4, IIT=1
+maturity: BETA=291, PRODUCTION=158, ALPHA=39, DRAFT=5, TEMPLATE=4
 -->
 
 Dernière mise à jour : 2026-05-28
@@ -21,7 +21,7 @@ Dernière mise à jour : 2026-05-28
 | **Search** | 45 | Recherche, CSP, optimisation, metaheuristiques |
 | **Probas** | 43 | Programmation probabiliste (Infer.NET + PyMC) |
 | **Sudoku** | 32 | Resolution de contraintes (.NET C#) |
-| **ML** | 30 | Machine Learning .NET + Python Agents for Data Science |
+| **ML** | 27 | Machine Learning .NET + Python Agents for Data Science |
 | **GameTheory** | 25 | Theorie des Jeux (OpenSpiel, choix social Lean) |
 | **RL** | 6 | Reinforcement Learning (Stable-Baselines3) |
 | **CaseStudies** | 4 | Etudes de cas interdisciplinaires (diagnostic medical, planification oncologique) |
@@ -94,7 +94,7 @@ SymbolicAI (98 notebooks)
 | **Search** | 45 | [Search/](Search/README.md) |
 | **Probas** | 43 | [Probas/](Probas/README.md) |
 | **Sudoku** | 32 | [Sudoku/](Sudoku/README.md) |
-| **ML** | 30 | [ML/](ML/README.md) |
+| **ML** | 27 | [ML/](ML/README.md) |
 | **GameTheory** | 25 | [GameTheory/](GameTheory/README.md) |
 | **RL** | 6 | [RL/](RL/README.md) |
 | **CaseStudies** | 4 | [CaseStudies/](CaseStudies/README.md) |


### PR DESCRIPTION
## Summary

Suite directe à **#1699 MERGED** (`MyIA.AI.Notebooks/ML/README.md` corrigé 30→27 après audit filesystem DSWA=19 + ML.Net=8).
Cette PR aligne le **root README** (`MyIA.AI.Notebooks/README.md`) avec cette réalité.

## Updates (6+/6-)

| Ligne | Avant | Après |
|---|---|---|
| L3 prose | "500 notebooks" / "294 BETA = 452/500" | "497 notebooks" / "291 BETA = 449/497" |
| L7 CATALOG-STATUS | `total: 500` | `total: 497` |
| L8 CATALOG-STATUS | `..., ML=30, GameTheory=25, ...` | `..., ML=27, GameTheory=25, ...` |
| L9 CATALOG-STATUS | `BETA=294, ...` | `BETA=291, ...` |
| L24 Vue d'ensemble | `\| **ML** \| 30 \|` | `\| **ML** \| 27 \|` |
| L97 Liens sous-domaines | `\| **ML** \| 30 \|` | `\| **ML** \| 27 \|` |

## Recalculs

- 500 - 3 (correction ML 30→27) = **497** ✓
- 294 - 3 (ML BETA drop 23→20 propagé) = **291** ✓
- 158 PRODUCTION + 291 BETA = **449/497 = 90.3%** (arrondi 90%) ✓
- 39 ALPHA + 5 DRAFT + 4 TEMPLATE = 48 dev ; 449 + 48 = 497 ✓

## Scope strict

- README-only, pas de `.ipynb` / `.lean` / `.cs` / `.py` touché.
- Pas de regen `COURSE_CATALOG.generated.json` (l'outil corrigé par #1698 le fera).
- Ordre breakdown préservé : ML=27 > GameTheory=25.

## Reference

- Epic #1657 (README hierarchy refresh, bottom-up)
- Follow-up direct de #1699 (ML series README, merged)
- Aligne avec correctif outil drift #1698 (po-2026)

## Test plan

- [x] Diff = 1 fichier, 6+/-6 lignes ciblees
- [x] Tous chiffres recalcules et coherents (total, BETA, %)
- [x] Catalog drift CI devrait passer GREEN (root + ML series désormais alignés)
- [x] Aucune autre serie touchée (autre que ML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)