### PR TITLE
feat(lean): prove Kochen-Specker theorem 18-vector Cabello (Pilier 1.B, Epic #1651)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
@@ -156,7 +156,7 @@ def IsValidColoring (c : Coloring) : Prop :=
 lemma each_vector_in_two_contexts (v : VecIdx) :
     (∑ k : ContextIdx, ∑ i : Fin 4,
       if contextMembers k i = v then (1 : ℕ) else 0) = 2 := by
-  sorry  -- TODO Pilier 1: verify by `decide` / explicit case-split on v
+  fin_cases v <;> decide
 
 /-- **Kochen-Specker Theorem (18-vector Cabello proof)**.
     There is no valid {0,1}-coloring of the 18 vectors compatible
@@ -173,7 +173,42 @@ lemma each_vector_in_two_contexts (v : VecIdx) :
        which is even.
     4. But 9 is odd. Contradiction. -/
 theorem kochen_specker : ¬ ∃ c : Coloring, IsValidColoring c := by
-  sorry  -- TODO Pilier 1: parity argument via Finset double-sum reorder
+  rintro ⟨c, hc⟩
+  have htotal : (∑ k : ContextIdx, ∑ i : Fin 4,
+      if c (contextMembers k i) then (1 : ℕ) else 0) = 9 := by
+    have : ∀ k : ContextIdx,
+        (∑ i : Fin 4, if c (contextMembers k i) then (1 : ℕ) else 0) = 1 := hc
+    simp [this]
+  have hreord : (∑ k : ContextIdx, ∑ i : Fin 4,
+      if c (contextMembers k i) then (1 : ℕ) else 0) =
+      ∑ v : VecIdx, 2 * (if c v then (1 : ℕ) else 0) := by
+    rw [show (∑ k : ContextIdx, ∑ i : Fin 4,
+        if c (contextMembers k i) then (1 : ℕ) else 0) =
+        ∑ v : VecIdx, (∑ k : ContextIdx, ∑ i : Fin 4,
+          if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0) from ?_]
+    · apply Finset.sum_congr rfl
+      intro v _
+      have hv := each_vector_in_two_contexts v
+      have : (∑ k : ContextIdx, ∑ i : Fin 4,
+            if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0) =
+          (if c v then (1 : ℕ) else 0) *
+            (∑ k : ContextIdx, ∑ i : Fin 4,
+              if contextMembers k i = v then (1 : ℕ) else 0) := by
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl; intro k _
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl; intro i _
+        split_ifs <;> simp
+      rw [this, hv]; ring
+    · apply Finset.sum_congr rfl; intro k _
+      apply Finset.sum_congr rfl; intro i _
+      rw [Finset.sum_ite_eq' Finset.univ (contextMembers k i)
+        (fun v => if c v then (1 : ℕ) else 0)]
+      simp
+  have : (9 : ℕ) = 2 * ∑ v : VecIdx, (if c v then (1 : ℕ) else 0) := by
+    have := htotal.symm.trans hreord
+    simpa [Finset.mul_sum] using this
+  omega
 
 end KochenSpecker
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -20,19 +20,19 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/LookAndSayLemmas.lean` | 0 | Lemmas for the Look-and-Say sequence |
 | `Conway/Nim.lean` | 0 | Nim game theory |
 | `Conway/Angel.lean` | 0 | Angel problem |
-| `Conway/KochenSpecker.lean` | 2 | Kochen-Specker theorem (18-vec Cabello, Pilier 1 FWT) |
+| `Conway/KochenSpecker.lean` | 0 | Kochen-Specker theorem (18-vec Cabello, Pilier 1 FWT) |
 | `Conway/Life.lean` | 0 | Game of Life (B3/S23, still lifes/oscillators/spaceships, `native_decide` proofs, Phase 2 Epic #1647) |
 
 ## Key Results
 
-- **COMPLETE**: All proofs done, 0 sorry in production code (except KochenSpecker.lean WIP)
+- **COMPLETE**: All proofs done, 0 sorry in production code
 - Doomsday algorithm correctness
 - FRACTRAN computation formalization
 - Look-and-Say sequence properties
 - Nim game strategy
 - Angel problem formalization
 - Conway's Game of Life cellular automaton — `B3/S23` rules, still lifes (block, beehive), oscillators (blinker, toad, beacon period 2), spaceship (glider). All theorems via `native_decide`.
-- **WIP**: Kochen-Specker theorem (Pilier 1 of Epic #1651 Conway FWT)
+- Kochen-Specker theorem (Pilier 1 of Epic #1651 Conway FWT) — full proof via parity argument (sum = 9 odd vs 2k even, contradiction)
 
 ## Kochen-Specker (Pilier 1 of Free Will Theorem)
 


### PR DESCRIPTION
## Summary

**Pilier 1.B (KS combinatorial kernel) of Epic #1651 Free Will Theorem.** Discharges 2 production sorries in \`Conway/KochenSpecker.lean\`: \`each_vector_in_two_contexts\` and \`kochen_specker\`. Connects the abstract Cabello overlap table to the parity contradiction (sum=9 odd vs 2k even).

## Lean PR body — 4 required elements

### 1. \`grep -c sorry\` before/after

\`\`\`
before: 2 (file: MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean)
after:  0
\`\`\`

### 2. Lake build SUCCESS

**Isolation** (KS_test_proofs.lean scratch — same imports as KochenSpecker.lean):
\`\`\`
\$ wsl -d Ubuntu -- bash -lc 'cd ~/.../conway_lean && \
    /home/jesse/.elan/bin/lake build Conway.KS_test_proofs'
SUCCESS — exit 0 (BG bj34682lv, toolchain leanprover/lean4:v4.30.0-rc2)
\`\`\`

**Production** (Conway.KochenSpecker):
\`\`\`
\$ wsl -d Ubuntu -- bash -lc 'cd ~/.../conway_lean && \
    /home/jesse/.elan/bin/lake build Conway.KochenSpecker'
IN PROGRESS at PR submit (BG blkboski6 in Mathlib compile, cold cache ~25min)
-> blocks self-merge per .claude/rules/lean-merge-discipline.md HARD rule until exit 0 captured
-> SUCCESS log will be posted as PR comment before merge attempt
\`\`\`

### 3. Proof integrity (axiom check)

KochenSpecker.lean uses only:
- \`Mathlib.Data.Real.Basic\` (Mathlib axioms)
- \`Mathlib.Data.Fin.Basic\` (kernel Fin)
- \`Mathlib.Tactic\` (\`omega\`, \`fin_cases\`, \`decide\`)

No user-introduced axioms. \`fin_cases v <;> decide\` reduces to kernel decidability. Parity contradiction closed by \`omega\` on natural numbers.

### 4. Refactor justification

No prover Python refactor in this PR. Pure Lean proof discharge.

## Proofs

### \`each_vector_in_two_contexts\` (overlap lemma)

\`\`\`lean
lemma each_vector_in_two_contexts (v : VecIdx) :
    (∑ k : ContextIdx, ∑ i : Fin 4,
      if contextMembers k i = v then (1 : ℕ) else 0) = 2 := by
  fin_cases v <;> decide
\`\`\`

The Cabello overlap table is decidable per-vector. Case-splitting on the 18 vectors and decoding each Finset sum to a literal Nat gives \`decide\` the kernel fact it needs.

### \`kochen_specker\` (parity contradiction)

\`\`\`lean
theorem kochen_specker : ¬ ∃ c : Coloring, IsValidColoring c := by
  rintro ⟨c, hc⟩
  -- Sum 'exactly one true per context' over the 9 contexts -> total = 9
  have htotal : ... = 9 := by have := hc; simp [this]
  -- Reorder by vector v: each v contributes c(v) * 2 (overlap = 2)
  have hreord : ... = ∑ v, 2 * (if c v then 1 else 0) := by
    rw [...] · apply Finset.sum_congr rfl
              intro v _; rw [Finset.mul_sum, each_vector_in_two_contexts v]; ring
            · -- swap the inner sums via Finset.sum_ite_eq'
  -- 9 = 2k contradicts parity
  have : (9 : ℕ) = 2 * ∑ v, (if c v then 1 else 0) := htotal.symm.trans hreord
  omega
\`\`\`

Tools used: \`Finset.sum_ite_eq'\`, \`Finset.mul_sum\`, \`Finset.sum_congr\`, \`omega\`.

## Epic context

KS is the combinatorial core of the SPIN axiom in the Conway-Kochen Free Will Theorem:

- For spin-1 particles, measuring squared spin components along 4 mutually compatible projectors yields exactly one '1' per orthonormal basis (SPIN axiom).
- A deterministic hidden-variable function -> valid {0,1}-coloring of the 18 vectors.
- KS contradicts that coloring.
- Therefore the particle's response cannot be a function of the past alone.

This unblocks **Pilier 2** (\`FreeWillTheorem.lean\`, future PR) which composes KS with TWIN + MIN.

## Test plan

- [x] \`grep -c sorry KochenSpecker.lean\` returns 0
- [x] BG \`bj34682lv\` (Conway.KS_test_proofs isolation build) exit 0
- [ ] BG \`blkboski6\` (Conway.KochenSpecker production build) exit 0 — pending Mathlib compile
- [ ] No \`sorry\`/\`axiom\` introduced in other Conway/* files (regression check via \`grep -c sorry\`)
- [ ] **Self-merge BLOCKED** until production build log captured per HARD rule

## Related

- Epic #1651 Conway-Kochen Free Will Theorem
- Pilier 1.B (KS) — this PR
- Pilier 2 (Free Will, TWIN+MIN) — future
- Conway GoL Pilier 0 — merged earlier (Life.lean #1658 et al.)
- \`.claude/rules/lean-merge-discipline.md\` — Lake build SUCCESS local OBLIGATOIRE before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)