### PR TITLE
docs(readme): refresh CATALOG-STATUS markers post-#1703 (Epic #1657, unblocks #1705)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -2,9 +2,9 @@
 
 <!-- CATALOG-STATUS
 series: GameTheory
-pedagogical_count: 28
-breakdown: root=24, SocialChoice=4
-maturity: BETA=24, ALPHA=2, PRODUCTION=2
+pedagogical_count: 25
+breakdown: root=21, SocialChoice=4
+maturity: BETA=21, ALPHA=2, PRODUCTION=2
 -->
 
 La théorie des jeux est le langage mathématique de la stratégie. Elle modélise les situations où des agents rationnels prennent des décisions dont le résultat dépend des choix des autres : enchères, négociations commerciales, élections, poker, guerre commerciale, allocation de ressources. Cette dualité entre coopération et compétition est omniprésente en économie, en sciences politiques et en informatique (mécanismes de vote, smart contracts, réseaux). Le prix Nobel d'économie a été décerné à des théoriciens des jeux à sept reprises entre 1994 et 2020 — c'est un domaine vivant et influent.

--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -4,7 +4,7 @@
 series: ML
 pedagogical_count: 27
 breakdown: DataScienceWithAgents=19, ML.Net=8
-maturity: BETA=20, ALPHA=4, PRODUCTION=3
+maturity: BETA=21, ALPHA=3, PRODUCTION=3
 -->
 
 Vous êtes développeur ou analyste et vous voulez construire des modèles prédictifs sans devenir data scientist théoricien ? Cette série vous forme au Machine Learning pratique avec deux stack complémentaires : **ML.NET** pour l'écosystème .NET/C# (8 notebooks, ~6h) et **Python Data Science with Agents** pour les pipelines modernes enrichis de LLMs (19 notebooks, ~17h). À la fin, vous saurez charger des données, entraîner un modèle, l'évaluer rigoureusement, et le déployer en production.

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -4,9 +4,9 @@ Ecosysteme complet de **500 notebooks** Jupyter pour l'apprentissage des technol
 
 <!-- CATALOG-STATUS
 series: ALL
-total: 500
-breakdown: GenAI=114, QuantConnect=102, SymbolicAI=98, Search=45, Probas=43, Sudoku=32, GameTheory=28, ML=27, RL=6, CaseStudies=4, IIT=1
-maturity: BETA=294, PRODUCTION=158, ALPHA=39, DRAFT=5, TEMPLATE=4
+total: 497
+breakdown: GenAI=114, QuantConnect=102, SymbolicAI=98, Search=45, Probas=43, Sudoku=32, ML=27, GameTheory=25, RL=6, CaseStudies=4, IIT=1
+maturity: BETA=292, PRODUCTION=158, ALPHA=38, DRAFT=5, TEMPLATE=4
 -->
 
 Dernière mise à jour : 2026-05-28


### PR DESCRIPTION
## Summary

Re-aligns 3 stale CATALOG-STATUS marker blocks left inconsistent on `main` after #1703 (`fix(catalog): exclude _executed.ipynb`), which shrunk `COURSE_CATALOG.generated.json` from 500 → 497 entries without refreshing the embedded markers in the affected READMEs.

This unblocks the catalog-drift CI gate (`expand_catalog_markers.py --check`) on **#1705** mechanically: that PR's CI was failing on drift inherited from `main`, not on its own changes.

### Marker changes

| File | Field | Before | After |
|------|-------|--------|-------|
| `MyIA.AI.Notebooks/README.md` | `total` | 500 | **497** |
| `MyIA.AI.Notebooks/README.md` | `breakdown: GameTheory=` | 28 | **25** |
| `MyIA.AI.Notebooks/README.md` | `maturity: BETA=` | 294 | **292** |
| `MyIA.AI.Notebooks/README.md` | `maturity: ALPHA=` | 39 | **38** |
| `MyIA.AI.Notebooks/GameTheory/README.md` | `pedagogical_count` | 28 | **25** |
| `MyIA.AI.Notebooks/GameTheory/README.md` | `breakdown: root=` | 24 | **21** |
| `MyIA.AI.Notebooks/GameTheory/README.md` | `maturity: BETA=` | 24 | **21** |
| `MyIA.AI.Notebooks/ML/README.md` | `maturity: BETA=` | 20 | **21** |
| `MyIA.AI.Notebooks/ML/README.md` | `maturity: ALPHA=` | 4 | **3** |

ML pedagogical_count stays at 27 (1 notebook re-classified BETA←ALPHA after re-execution).

### Scope (HARD — section A/D)

- ✅ CATALOG-STATUS HTML markers ONLY — anti-régression compliant (no notebook touch, no `.cs`/`.py`/`.lean` touch)
- ✅ No `COURSE_CATALOG.generated.json` regeneration — catalog drift policy respected
- ✅ Tool used: `scripts/notebook_tools/expand_catalog_markers.py` (existing CI script, no new code)
- ✅ Verification: `python scripts/notebook_tools/expand_catalog_markers.py --check` now exits **0** ("All markers up-to-date")
- Diff size: 3 files, 7+/7-

### Follow-ups (NOT in this PR — split intentional)

1. **3 GameTheory notebooks missing from catalog**: `GameTheory-8-CombinatorialGames.ipynb`, `GameTheory-8b-Lean-CombinatorialGames.ipynb`, `GameTheory-8c-CombinatorialGames-Python.ipynb` exist on FS + are git-tracked, but `analyze_notebook()` in `generate_catalog.py` returns None for them post-#1703. Likely a JSON/encoding edge case. Needs a dedicated investigation issue — fixing it touches the generator, not the marker layer.
2. **Prose update**: root README L3/L24/L97 still says "500 notebooks" / "GameTheory | 28"; GameTheory README L32 still claims "**17 notebooks principaux** + ... = 28 notebooks". Left out of this PR to keep CI-gate fix surgical; will be addressed once #1 above is resolved (so the numbers align everywhere consistently rather than chasing a moving target).

### Test plan

- [x] Local: `git pull` main (commit `2ac975d9`), then `python scripts/notebook_tools/expand_catalog_markers.py` → 3 files modified
- [x] Local: `python scripts/notebook_tools/expand_catalog_markers.py --check` → exit 0, "All markers up-to-date"
- [x] Diff scope verified: only `<!-- CATALOG-STATUS ... -->` blocks, no prose, no code
- [ ] CI: catalog-drift check on this PR → expected green
- [ ] After merge: rebase #1705 → catalog-drift CI green there too

Epic: #1657 (README hierarchy)
Unblocks: #1705 (po-2026 lean_game_defs README)
Cause: #1703 (catalog _executed exclusion) left markers stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)