### PR TITLE
docs(symbolicai): add Tweety/scripts and SmartContracts/scripts READMEs (#1660)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
@@ -1,0 +1,80 @@
+# Scripts SmartContracts
+
+Ce repertoire contient les scripts de configuration de l'environnement pour la serie SmartContracts (Solidity + Foundry + analyse symbolique). L'environnement principal est cross-plateforme (Mac/Linux natif, Windows via WSL) et utilise un kernel Jupyter dedie `smartcontracts`.
+
+## Scripts disponibles
+
+### Setup principal
+
+- [setup.sh](setup.sh) — Setup cross-plateforme : installe Foundry (`forge`, `cast`, `anvil`), cree un venv Python `~/.smartcontracts-venv`, installe les dependances, enregistre le kernel Jupyter `smartcontracts`. Detecte automatiquement l'OS (Mac natif / Linux natif / WSL).
+
+  ```bash
+  # Mac/Linux (natif)
+  bash scripts/setup.sh
+
+  # Windows (depuis PowerShell, delegue a WSL)
+  wsl -d Ubuntu -- bash /mnt/d/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
+  ```
+
+### Setup WSL (Windows uniquement)
+
+- [setup_wsl_smartcontracts.sh](setup_wsl_smartcontracts.sh) — Variante WSL-only de `setup.sh` : installe Foundry, le venv Python avec les paquets Linux-only, et le wrapper de kernel `~/.smartcontracts-kernel-wrapper.sh` qui gere la conversion des chemins Windows -> WSL (workaround pour le bug Jupyter qui mange les backslashes).
+
+  ```bash
+  # A executer dans WSL Ubuntu
+  bash setup_wsl_smartcontracts.sh
+  ```
+
+- [setup_wsl_kernel.ps1](setup_wsl_kernel.ps1) — Enregistre le kernel Jupyter `SmartContracts (WSL)` cote Windows, pointe vers le wrapper installe par `setup_wsl_smartcontracts.sh`. A executer **apres** le script WSL.
+
+  ```powershell
+  # PowerShell Windows, apres le setup WSL
+  .\setup_wsl_kernel.ps1
+  ```
+
+### Template
+
+- [_wrapper_template.sh](_wrapper_template.sh) — Template de wrapper de kernel WSL. Gere le bug de conversion des chemins Windows transmis par Jupyter (backslashes manges par WSL) en recherchant le fichier de connexion dans les locations temp connues. Reference pour creer d'autres wrappers WSL (Tweety, Lean, etc.). **Ne pas executer directement** — utilise comme modele par `setup_wsl_smartcontracts.sh`.
+
+## Architecture des kernels
+
+| Plateforme | Kernel | Wrapper |
+|---|---|---|
+| Mac/Linux natif | `smartcontracts` | Aucun (direct `~/.smartcontracts-venv/bin/python`) |
+| Windows (via WSL) | `SmartContracts (WSL)` | `~/.smartcontracts-kernel-wrapper.sh` (conversion chemins) |
+
+## Sequence d'installation Windows complete
+
+```bash
+# Etape 1 : WSL Ubuntu
+cd /mnt/d/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts
+bash setup_wsl_smartcontracts.sh
+```
+
+```powershell
+# Etape 2 : PowerShell Windows
+cd D:\CoursIA\MyIA.AI.Notebooks\SymbolicAI\SmartContracts\scripts
+.\setup_wsl_kernel.ps1
+```
+
+```text
+# Etape 3 : Redemarrer VSCode pour que le kernel soit detecte
+```
+
+## Dependances installees
+
+- **Foundry** : `forge` (compilation), `cast` (interaction RPC), `anvil` (local node)
+- **Python** : voir `requirements.txt` au niveau de la serie SmartContracts (`web3`, `slither-analyzer`, `mythril` sous Linux)
+- **JDK 17+** : requis pour certains outils d'analyse symbolique JVM-based
+
+## Troubleshooting
+
+- **Kernel ne demarre pas (Windows)** : verifier `wsl -d Ubuntu -- cat /tmp/smartcontracts-kernel-wrapper.log` pour les erreurs de conversion de chemin.
+- **`forge` introuvable** : le PATH peut ne pas etre charge ; lancer `source ~/.bashrc` dans WSL avant de demarrer Jupyter.
+- **Erreur d'installation `mythril` sur Mac** : `mythril` est Linux-only ; l'installation echoue silencieusement sur Mac, c'est attendu.
+
+## Voir aussi
+
+- [SmartContracts/README.md](../README.md) — Vue d'ensemble de la serie SmartContracts
+- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau serie
+- [.claude/rules/wsl-kernels.md](../../../../.claude/rules/wsl-kernels.md) — Regles HARD pour les kernels WSL

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/README.md
@@ -1,0 +1,59 @@
+# Scripts Tweety
+
+Ce repertoire contient les scripts utilitaires pour la serie Tweety (`Tweety-1-Setup` a `Tweety-9b-*` + `Tweety-Defeasible-Reasoning`). Ils couvrent le telechargement des dependances (JARs TweetyProject, Clingo, JDK Zulu portable), la calibration des solveurs SAT, et la verification de l'integrite des notebooks.
+
+## Scripts disponibles
+
+### Telechargement des dependances
+
+- [download_tweety_tools.py](download_tweety_tools.py) — Telecharge les JARs TweetyProject depuis Maven Central, les ressources (`*.txt`, `*.aba`, `*.aspic`), Clingo (Windows/Linux), SPASS (Linux), JDK Zulu 17 portable, et les bibliotheques natives SAT (Minisat, Lingeling, Picosat). Mode selectif via flags `--jars`/`--resources`/`--clingo`/`--jdk`/`--native-sat` ou `--all`.
+
+  ```bash
+  python scripts/download_tweety_tools.py --all
+  ```
+
+### Calibration et comparaison SAT
+
+- [sat_calibration.py](sat_calibration.py) — Recherche des configurations de problemes SAT ou chaque solveur (Minisat, Glucose, Lingeling, Picosat, ...) gagne au moins un test. Utilise `pysat`, timeouts par test, et un budget configurable. Sert de base pour calibrer les exemples pedagogiques.
+
+  ```bash
+  python scripts/sat_calibration.py
+  ```
+
+- [sat_comparison_demo.py](sat_comparison_demo.py) — Demonstration pedagogique de comparaison de performance des solveurs SAT sur des problemes classiques de difficulte croissante. Sortie textuelle utilisable directement dans une cellule notebook.
+
+  ```bash
+  python scripts/sat_comparison_demo.py
+  ```
+
+### Validation et verification
+
+- [validate_syntax.py](validate_syntax.py) — Parcourt les cellules de code Python des notebooks Tweety et signale les erreurs de syntaxe (`ast.parse`) avec numero de ligne et identifiant de cellule. Utile en pre-commit ou apres une edition manuelle.
+
+  ```bash
+  python scripts/validate_syntax.py
+  ```
+
+- [verify_all_tweety.py](verify_all_tweety.py) — Verification complete de la serie : structure JSON, configuration kernel (`python3`), presence de cellules markdown/code, prerequis (JDK, JPype, JARs Tweety), et execution optionnelle via Papermill ou cell-by-cell. Sortie structuree (JSON ou texte) selon les flags.
+
+  ```bash
+  # Verification structurelle seule
+  python scripts/verify_all_tweety.py --structure-only
+
+  # Verification + execution Papermill (long)
+  python scripts/verify_all_tweety.py --execute
+  ```
+
+## Dependances
+
+- Python 3.10+
+- `pysat` (calibration/comparaison SAT)
+- `JPype1` (notebooks Tweety executes)
+- JDK 17+ (Zulu portable installable via `download_tweety_tools.py --jdk`)
+- Clingo (optionnel, pour notebooks ASP) — installable via `download_tweety_tools.py --clingo`
+
+## Voir aussi
+
+- [Tweety/README.md](../README.md) — Vue d'ensemble de la serie Tweety
+- [SymbolicAI/scripts/README.md](../../scripts/README.md) — Scripts SymbolicAI niveau serie (extraction notebook, installation Clingo)
+- [scripts/notebook_tools/](../../../../scripts/notebook_tools/) — Outils generiques (validate / execute / skeleton / analyze)


### PR DESCRIPTION
## Summary

Fills two README gaps in the SymbolicAI sub-series script directories, addressing sub-issue #1660 (SymbolicAI README hierarchy refresh).

- `MyIA.AI.Notebooks/SymbolicAI/Tweety/scripts/README.md` (new) — Documents 5 helper scripts:
  - `download_tweety_tools.py` (Maven JARs + Clingo + JDK Zulu + native SAT libs)
  - `sat_calibration.py` (per-solver SAT problem calibration)
  - `sat_comparison_demo.py` (pedagogical SAT solver benchmark)
  - `validate_syntax.py` (AST syntax check on notebook code cells)
  - `verify_all_tweety.py` (full structural + Papermill verification)
- `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md` (new) — Documents 4 setup scripts:
  - `setup.sh` (cross-platform Foundry + venv + kernel)
  - `setup_wsl_smartcontracts.sh` (WSL Linux-only deps + wrapper install)
  - `setup_wsl_kernel.ps1` (Windows-side kernel registration)
  - `_wrapper_template.sh` (reference template for WSL path-conversion wrappers)
  - Includes kernel architecture table, full Windows-via-WSL install sequence, troubleshooting.

Both READMEs follow the `GameTheory/scripts/README.md` format established by #1697 (already merged). Bullet lists used in place of tables to avoid the markdown lint MD060 alignment warnings encountered on #1705.

## Scope

- Pure docs-only (139 insertions, 0 modifications, 0 deletions to existing files).
- Reused content grounded in script docstrings + first-line headers (read prior to authoring).
- No notebook touched, no code logic changed.

## Test plan

- [x] `git diff --stat` confirms additions only (2 new files, 139 lines).
- [x] Headers + usage commands cross-checked against actual script content.
- [x] No regression on existing `SymbolicAI/scripts/README.md` (untouched).
- [ ] Optional: catalog regeneration to confirm no incidental marker changes.

Closes part of #1660. Other sub-series (Lean, SemanticWeb, Planners, SymbolicLearning, Argument_Analysis) READMEs verified to already exist and remain in scope of #1660 for content-drift audits in a follow-up cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)