### PR TITLE
docs(readme): align root prose to catalog 497/GameTheory=25 (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -1,6 +1,6 @@
 # MyIA.AI.Notebooks - Ecosysteme de Notebooks CoursIA
 
-Ecosysteme complet de **500 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques. Maturite : **158 PRODUCTION + 294 BETA = 452/500 (90%)** prets cours ; 39 ALPHA + 5 DRAFT + 4 TEMPLATE en developpement.
+Ecosysteme complet de **497 notebooks** Jupyter pour l'apprentissage des technologies AI/ML modernes, organisé par domaines thématiques. Maturite : **158 PRODUCTION + 292 BETA = 450/497 (91%)** prets cours ; 38 ALPHA + 5 DRAFT + 4 TEMPLATE en developpement.
 
 <!-- CATALOG-STATUS
 series: ALL
@@ -21,7 +21,7 @@ Dernière mise à jour : 2026-05-28
 | **Search** | 45 | Recherche, CSP, optimisation, metaheuristiques |
 | **Probas** | 43 | Programmation probabiliste (Infer.NET + PyMC) |
 | **Sudoku** | 32 | Resolution de contraintes (.NET C#) |
-| **GameTheory** | 28 | Theorie des Jeux (OpenSpiel, choix social Lean) |
+| **GameTheory** | 25 | Theorie des Jeux (OpenSpiel, choix social Lean) |
 | **ML** | 27 | Machine Learning .NET + Python Agents for Data Science |
 | **RL** | 6 | Reinforcement Learning (Stable-Baselines3) |
 | **CaseStudies** | 4 | Etudes de cas interdisciplinaires (diagnostic medical, planification oncologique) |
@@ -94,7 +94,7 @@ SymbolicAI (98 notebooks)
 | **Search** | 45 | [Search/](Search/README.md) |
 | **Probas** | 43 | [Probas/](Probas/README.md) |
 | **Sudoku** | 32 | [Sudoku/](Sudoku/README.md) |
-| **GameTheory** | 28 | [GameTheory/](GameTheory/README.md) |
+| **GameTheory** | 25 | [GameTheory/](GameTheory/README.md) |
 | **ML** | 27 | [ML/](ML/README.md) |
 | **RL** | 6 | [RL/](RL/README.md) |
 | **CaseStudies** | 4 | [CaseStudies/](CaseStudies/README.md) |


### PR DESCRIPTION
## Summary

Surgical prose alignment of root [MyIA.AI.Notebooks/README.md](MyIA.AI.Notebooks/README.md) to its own CATALOG-STATUS marker. Marker has been correct since #1706 (497 total / GameTheory=25). Prose at L3, L24, L97 still referenced the pre-#1703 catalog (500 notebooks / GameTheory=28). Visible inconsistency between marker and prose right above/below it.

3 insertions / 3 deletions, no marker mutation, no notebook/lean/cs/py touched.

## Changes

- **L3** (intro)  : `500 notebooks` → `497 notebooks` ; `158 PRODUCTION + 294 BETA = 452/500 (90%)` → `158 PRODUCTION + 292 BETA = 450/497 (91%)` ; `39 ALPHA` → `38 ALPHA`
- **L24** (Vue d'ensemble table) : `GameTheory | 28` → `GameTheory | 25`
- **L97** (Liens vers sous-domaines table) : `GameTheory | 28` → `GameTheory | 25`

## Verification (pre-commit)

- ` python scripts/notebook_tools/expand_catalog_markers.py --check ` → ` All markers up-to-date ` (no marker drift)
- ` git diff --cached --stat ` → 3+/3-, prose-only
- Source of truth : ` scripts/notebook_tools/COURSE_CATALOG.generated.json ` (post-#1703 : 497 entries, GameTheory=25)
- Marker (L5-L10) verified against catalog with ` jq ` : EXACT match (already clean)

## Anti-régression

- 0 modifications dans `*.ipynb`, `*.lean`, `*.cs`, `*.py`
- 0 modifications dans `COURSE_CATALOG.generated.json` (anti-drift)
- 0 modifications dans `.env*` ou secrets
- 0 cellules `# Solution` / `# Exemple résolu` supprimées
- Marker non touché (déjà clean depuis #1706)

## Follow-ups encore actifs (NON adressés ici)

Hérités de #1706, + nouveau drift QC détecté ce cycle :

1. **GameTheory-8 / 8b / 8c exclus du catalog** : `scripts/notebook_tools/generate_catalog.py:441` retourne `None` sur `JSONDecodeError` / `UnicodeDecodeError`. À investiguer en issue dédiée.
2. **QC filesystem-vs-catalog drift** (détecté ce cycle) :
   - `QuantConnect/Python/*.ipynb` (hors `_executed`/`_output`) = **53** ; marker = **51** → 2 notebooks manquants au catalog
   - `QuantConnect/ML-Training-Pipeline/*.ipynb` (hors `_executed`/`_output`) = **4** ; marker = **2** → 2 notebooks manquants
   - Même pathologie générateur que (1), à inclure dans la même issue
3. **Root L71** : `QuantConnect Cloud: 95 projets` — historique, filesystem actuel = 116 projets. Hors scope (référence "Cloud-deployed only"), à valider avec coordinateur.

Ces points **ne doivent pas** être patchés via marker manipulation ni catalog regen (anti-régression catalog).

## Test plan

- [x] `expand_catalog_markers.py --check` → 0 drift
- [x] `git diff --cached --stat` → 3+/3-
- [x] Aucun fichier de code touché (notebooks/lean/cs/py)
- [x] Marker non modifié
- [ ] CI `catalog-drift` SUCCESS (post-merge)
- [ ] CI `gitleaks` SUCCESS
- [ ] CI `staleness` SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)