### PR TITLE
docs(semanticweb): add RDF.Net-Legacy + movie_kg_interactive.html to structure tree (#1660)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -379,8 +379,18 @@ SemanticWeb/
 ├── SW-10-Python-RDFStar.ipynb
 ├── SW-11-Python-KnowledgeGraphs.ipynb
 ├── SW-12-Python-GraphRAG.ipynb
-└── SW-13-Python-Reasoners.ipynb     # Bonus
+├── SW-13-Python-Reasoners.ipynb     # Bonus
+├── movie_kg_interactive.html        # Livrable interactif SW-11 (pyvis)
+└── RDF.Net-Legacy/                  # Archive C# RDF.NET (pre-migration Python)
+    ├── RDF.Net.ipynb                # Notebook .NET historique
+    ├── Example.ttl                  # Donnees Turtle
+    ├── example.srj                  # Resultats SPARQL JSON
+    └── example.srx                  # Resultats SPARQL XML
 ```
+
+> **Note** — `RDF.Net-Legacy/` conserve l'ancien notebook C# (kernel .NET Interactive)
+> avant la bascule pedagogique vers Python (`SW-2b-Python-RDFBasics.ipynb` et suivants).
+> Archive de reference, non maintenue. Pour le RDF actuel, voir SW-2 / SW-2b.
 
 ## Ressources
 


### PR DESCRIPTION
## Summary

- Filesystem drift: SemanticWeb README structure tree (L353-383) omitted `RDF.Net-Legacy/` and `movie_kg_interactive.html`
- Adds both entries with a short note explaining `RDF.Net-Legacy/` is a pre-Python migration archive (C# .NET Interactive notebook, kept for reference, not maintained)
- Documents `movie_kg_interactive.html` as the SW-11 pyvis interactive knowledge graph deliverable

## Drift detected

```
SemanticWeb/
├── RDF.Net-Legacy/                  # NOT IN README — 4 files (notebook + Turtle + 2 SPARQL results)
│   ├── RDF.Net.ipynb
│   ├── Example.ttl
│   ├── example.srj
│   └── example.srx
└── movie_kg_interactive.html        # NOT IN README — SW-11 livrable
```

`ls` shows both exist on disk; README structure section was outdated.

## Epic context

- Epic #1657 (README hierarchy refresh post-#1634 audit)
- Sub-issue #1660 (SymbolicAI sub-series audit)
- Cycle 3 PR (after #1705 GameTheory lean_game_defs and #1707 Tweety/SmartContracts scripts READMEs)

## Test plan

- [x] `ls MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/RDF.Net-Legacy/` confirms 4 files
- [x] `ls MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/movie_kg_interactive.html` exists
- [x] Markdown structure tree balanced (├── / └──)
- [x] No content change to notebooks or scripts

Docs-only, no code paths affected.