### PR TITLE
feat(lean): Conway's Game of Life Phase 1 foundations (Epic #1647)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -11,13 +11,19 @@ Despite extreme simplicity, the rule supports universal computation
 (Conway 1982; Rendell 2000) and self-replication (Wade 2010 — Gemini).
 
 This file is the FOUNDATIONS module of the Phase 2 tribute (Epic #1647):
-- Game state encoded as a `Finset (Int × Int)` of live cells
-- Step function implementing the B3/S23 rule
+- Game state encoded as a `List (Int × Int)` of live cells (sorted, unique)
+- Step function implementing the B3/S23 rule via list operations
 - Iterated `evolve`
 - Predicates `IsStillLife`, `IsOscillator`, `IsSpaceship`
 - Witnesses for the canonical small patterns
   (block, beehive, blinker, toad, beacon, glider)
-- Microproofs verifiable by `native_decide` on the discretised support
+- Microproofs verifiable by `native_decide` on list equality
+
+The list representation avoids the `Quot.lift` / `Eq.rec` bottleneck
+that arises when Lean's kernel tries to decide `Finset` equality
+constructed via `image`/`biUnion`/`filter` on `Int × Int`. List
+equality reduces to cons-by-cons structural comparison, which the
+kernel and native code generator handle efficiently.
 
 The hashlife optimisation (Gosper 1984), the RLE parser, and the three
 community pillars (Gemini, OTCA Metapixel, Carlini 8-bit computer) are
@@ -26,37 +32,39 @@ deferred to Phases 2 to 9 of Epic #1647.
 This module is fully proven (no gaps).
 -/
 
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Finset.Prod
-import Mathlib.Data.Int.Interval
-import Mathlib.Logic.Function.Iterate
+import Mathlib.Tactic
 
 namespace Conway
 namespace Life
 
 /-! ## Basic types
 
-We model the live cells as a finite set of integer coordinates.
-Dead cells are simply those not in the set. This is the standard
-"sparse" representation, used by Golly, lifelib, and most simulators.
+We model the live cells as a sorted, deduplicated list of integer
+coordinates. Dead cells are those not in the list.
 -/
 
-/-- A grid of Conway's Game of Life: the finite set of live cells. -/
-abbrev Grid := Finset (Int × Int)
+/-- Lexicographic ordering on `Int × Int` for sorting. -/
+def lexLt (a b : Int × Int) : Bool :=
+  if a.1 < b.1 then true
+  else if a.1 > b.1 then false
+  else a.2 < b.2
+
+/-- A grid of Conway's Game of Life: sorted, deduplicated list of live cells.
+    We use `List` rather than `Finset` because list equality is decided by
+    structural comparison (no `Quot.lift`), which `native_decide` handles. -/
+abbrev Grid := List (Int × Int)
 
 /-! ## Neighborhood
 
 The Moore (king-move) neighborhood: 8 cells surrounding a given cell.
+We return them as a plain list (order does not matter for counting).
 -/
 
 /-- The 8 Moore neighbors of a cell `p`. -/
-def neighbors (p : Int × Int) : Finset (Int × Int) :=
-  (({-1, 0, 1} : Finset Int) ×ˢ ({-1, 0, 1} : Finset Int)).image
-    (fun d => (p.1 + d.1, p.2 + d.2)) |>.erase p
-
-/-- Sanity: a Moore neighborhood has exactly 8 cells. -/
-theorem neighbors_card (p : Int × Int) : (neighbors p).card = 8 := by
-  native_decide
+def mooreNeighbors (p : Int × Int) : List (Int × Int) :=
+  [(p.1 - 1, p.2 - 1), (p.1 - 1, p.2), (p.1 - 1, p.2 + 1),
+   (p.1, p.2 - 1),                 (p.1, p.2 + 1),
+   (p.1 + 1, p.2 - 1), (p.1 + 1, p.2), (p.1 + 1, p.2 + 1)]
 
 /-! ## The B3/S23 rule
 
@@ -64,32 +72,35 @@ For every cell, count its live Moore neighbors:
 - A dead cell with exactly 3 live neighbors becomes alive (Birth = B3)
 - A live cell with 2 or 3 live neighbors stays alive (Survival = S23)
 - Otherwise the cell is dead
-
-We implement this by iterating over the bounding box (live cells and their
-neighbors) and selecting those that survive or are born.
 -/
+
+/-- Check if a cell is alive in a grid (membership test). -/
+def isAlive (g : Grid) (p : Int × Int) : Bool :=
+  g.elem p
 
 /-- Count the live Moore neighbors of `p` in grid `g`. -/
 def liveNeighborCount (g : Grid) (p : Int × Int) : Nat :=
-  (neighbors p ∩ g).card
+  (mooreNeighbors p).countP (isAlive g)
 
 /-- The B3/S23 rule: should `p` be alive at the next generation? -/
 def aliveNext (g : Grid) (p : Int × Int) : Bool :=
   let n := liveNeighborCount g p
-  if p ∈ g then
-    decide (n = 2 ∨ n = 3)   -- S23
+  if isAlive g p then
+    n == 2 || n == 3   -- S23
   else
-    decide (n = 3)           -- B3
+    n == 3             -- B3
 
-/-- Candidate cells for next-step survival: live cells and their neighbors.
-    No new cell can be born outside this bounding zone (B3 requires 3 live
-    neighbors among the 8 Moore neighbors of a dead cell). -/
-def candidates (g : Grid) : Finset (Int × Int) :=
-  g ∪ g.biUnion neighbors
+/-- Candidate cells for next-step: live cells and their neighbors. -/
+def candidates (g : Grid) : List (Int × Int) :=
+  g ++ g.flatMap mooreNeighbors
+
+/-- Sort a list lexicographically and remove duplicates. -/
+def sortDedup (l : List (Int × Int)) : List (Int × Int) :=
+  (l.mergeSort (fun a b => lexLt a b = true)).eraseDups
 
 /-- One step of Conway's Game of Life (B3/S23 rule). -/
 def step (g : Grid) : Grid :=
-  (candidates g).filter (aliveNext g)
+  sortDedup ((candidates g).filter (fun p => aliveNext g p))
 
 /-- Iterated step: `evolve n g` applies `step` `n` times to `g`. -/
 def evolve (n : Nat) (g : Grid) : Grid :=
@@ -99,98 +110,93 @@ def evolve (n : Nat) (g : Grid) : Grid :=
 
 @[simp] theorem evolve_succ (n : Nat) (g : Grid) :
     evolve (n + 1) g = step (evolve n g) := by
-  simp [evolve, Function.iterate_succ', Function.comp]
+  simp [evolve, Function.iterate_succ_apply']
 
-/-! ## Pattern predicates -/
+/-! ## Pattern predicates
 
-/-- A still life: a grid unchanged by one step of evolution.
-    The simplest non-trivial fixed points of `step`. -/
-def IsStillLife (g : Grid) : Prop := step g = g
+We define Boolean-valued predicates (returning `Bool`) so that `native_decide`
+can evaluate them by compiling to native code and comparing `Bool` equality.
+No `Decidable` synthesis or `Quot.lift` needed — just `Bool` reduction.
+-/
 
-instance (g : Grid) : Decidable (IsStillLife g) :=
-  inferInstanceAs (Decidable (step g = g))
+/-- A still life: a grid unchanged by one step of evolution. -/
+def isStillLife (g : Grid) : Bool := step g == g
 
 /-- A pure oscillator of period `n`: returns to itself in exactly `n` steps. -/
-def IsOscillator (g : Grid) (n : Nat) : Prop := evolve n g = g
-
-instance (g : Grid) (n : Nat) : Decidable (IsOscillator g n) :=
-  inferInstanceAs (Decidable (evolve n g = g))
+def isOscillator (g : Grid) (n : Nat) : Bool := evolve n g == g
 
 /-- Translate every cell of a grid by a fixed displacement `v`. -/
 def shift (v : Int × Int) (g : Grid) : Grid :=
-  g.image (fun p => (p.1 + v.1, p.2 + v.2))
+  sortDedup (g.map (fun p => (p.1 + v.1, p.2 + v.2)))
 
 /-- A spaceship of period `n` and displacement `v`: after `n` steps the
-    pattern reappears, translated by `v`. (`v = (0, 0)` recovers oscillators.) -/
-def IsSpaceship (g : Grid) (n : Nat) (v : Int × Int) : Prop :=
-  evolve n g = shift v g
-
-instance (g : Grid) (n : Nat) (v : Int × Int) :
-    Decidable (IsSpaceship g n v) :=
-  inferInstanceAs (Decidable (evolve n g = shift v g))
+    pattern reappears, translated by `v`. -/
+def isSpaceship (g : Grid) (n : Nat) (v : Int × Int) : Bool :=
+  evolve n g == shift v g
 
 /-! ## Canonical patterns
 
 These are the most famous small patterns of Conway's Game of Life,
 discovered in the early 1970s by Conway's group at Cambridge and by
 players of the M.I.T. PDP-6/PDP-10 community.
+
+Each pattern is given in sorted lexicographic order so that `step`
+produces a list in the same order, enabling `native_decide` to verify
+equality by structural comparison.
 -/
 
-/-- The **Block**: a 2×2 square. The smallest still life. -/
-def block : Grid := {(0, 0), (0, 1), (1, 0), (1, 1)}
+/-- The **Block**: a 2x2 square. The smallest still life. -/
+def block : Grid := [(0, 0), (0, 1), (1, 0), (1, 1)]
 
 /-- The **Beehive**: a 6-cell hexagonal still life. -/
-def beehive : Grid :=
-  {(1, 0), (2, 0), (0, 1), (3, 1), (1, 2), (2, 2)}
+def beehive : Grid := [(0, 1), (1, 0), (1, 2), (2, 0), (2, 2), (3, 1)]
 
 /-- The **Blinker** (horizontal): three cells in a row. Period-2 oscillator. -/
-def blinker_h : Grid := {(0, 0), (1, 0), (2, 0)}
+def blinker_h : Grid := [(0, 0), (1, 0), (2, 0)]
 
 /-- The **Blinker** (vertical): three cells in a column. -/
-def blinker_v : Grid := {(1, -1), (1, 0), (1, 1)}
+def blinker_v : Grid := [(1, -1), (1, 0), (1, 1)]
 
 /-- The **Toad** (phase 1): a period-2 oscillator. -/
-def toad : Grid :=
-  {(1, 0), (2, 0), (3, 0), (0, 1), (1, 1), (2, 1)}
+def toad : Grid := [(0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0)]
 
 /-- The **Beacon** (phase 1): two blocks touching diagonally. Period 2. -/
 def beacon : Grid :=
-  {(0, 0), (1, 0), (0, 1), (1, 1),
-   (2, 2), (3, 2), (2, 3), (3, 3)}
+  [(0, 0), (0, 1), (1, 0), (1, 1), (2, 2), (2, 3), (3, 2), (3, 3)]
 
 /-- The **Glider** (phase 1, south-east bound): the smallest spaceship.
     After 4 generations it reappears, translated by (1, -1). -/
-def glider : Grid :=
-  {(0, 0), (1, 0), (2, 0), (2, 1), (1, 2)}
+def glider : Grid := [(0, 0), (1, 0), (1, 2), (2, 0), (2, 1)]
 
 /-! ## Microproofs
 
 These are the first formal results of Phase 1: simple verifications of
-classic patterns by `native_decide`. Each one is a finite computation
-on small `Finset (Int × Int)` and exercises every layer of the model
-(`step`, `evolve`, `shift`, the three predicates).
+classic patterns by `native_decide`. The predicates return `Bool`, so
+`native_decide` compiles the step function to native code, evaluates the
+Boolean expression, and checks it equals `true`. No `Decidable` synthesis
+or `Quot.lift` involved.
 -/
 
-/-- The Block is a still life: `step block = block`. -/
-theorem block_still_life : IsStillLife block := by native_decide
+/-- The Block is a still life: `isStillLife block = true`. -/
+theorem block_still_life : isStillLife block = true := by native_decide
 
 /-- The Beehive is a still life. -/
-theorem beehive_still_life : IsStillLife beehive := by native_decide
+theorem beehive_still_life : isStillLife beehive = true := by native_decide
 
 /-- The horizontal Blinker oscillates with period 2. -/
-theorem blinker_period_two : IsOscillator blinker_h 2 := by native_decide
+theorem blinker_period_two : isOscillator blinker_h 2 = true := by native_decide
 
 /-- One step turns the horizontal Blinker into the vertical Blinker. -/
-theorem blinker_step : step blinker_h = blinker_v := by native_decide
+theorem blinker_step : (step blinker_h == blinker_v) = true := by native_decide
 
 /-- The Toad oscillates with period 2. -/
-theorem toad_period_two : IsOscillator toad 2 := by native_decide
+theorem toad_period_two : isOscillator toad 2 = true := by native_decide
 
 /-- The Beacon oscillates with period 2. -/
-theorem beacon_period_two : IsOscillator beacon 2 := by native_decide
+theorem beacon_period_two : isOscillator beacon 2 = true := by native_decide
 
 /-- The Glider is a spaceship of period 4, displacement `(1, -1)`. -/
-theorem glider_spaceship : IsSpaceship glider 4 (1, -1) := by native_decide
+theorem glider_spaceship : isSpaceship glider 4 (1, -1) = true := by native_decide
 
 end Life
 end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+## Conway's Game of Life — Phase 1 foundations
+
+John Horton Conway (1937-2020) invented the Game of Life in 1970 in
+collaboration with the Cambridge graduate students Michael Guy and others.
+A cellular automaton on the integer plane with the celebrated B3/S23 rule.
+Despite extreme simplicity, the rule supports universal computation
+(Conway 1982; Rendell 2000) and self-replication (Wade 2010 — Gemini).
+
+This file is the FOUNDATIONS module of the Phase 2 tribute (Epic #1647):
+- Game state encoded as a `Finset (Int × Int)` of live cells
+- Step function implementing the B3/S23 rule
+- Iterated `evolve`
+- Predicates `IsStillLife`, `IsOscillator`, `IsSpaceship`
+- Witnesses for the canonical small patterns
+  (block, beehive, blinker, toad, beacon, glider)
+- Microproofs verifiable by `native_decide` on the discretised support
+
+The hashlife optimisation (Gosper 1984), the RLE parser, and the three
+community pillars (Gemini, OTCA Metapixel, Carlini 8-bit computer) are
+deferred to Phases 2 to 9 of Epic #1647.
+
+This module is fully proven (no gaps).
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Int.Interval
+import Mathlib.Logic.Function.Iterate
+
+namespace Conway
+namespace Life
+
+/-! ## Basic types
+
+We model the live cells as a finite set of integer coordinates.
+Dead cells are simply those not in the set. This is the standard
+"sparse" representation, used by Golly, lifelib, and most simulators.
+-/
+
+/-- A grid of Conway's Game of Life: the finite set of live cells. -/
+abbrev Grid := Finset (Int × Int)
+
+/-! ## Neighborhood
+
+The Moore (king-move) neighborhood: 8 cells surrounding a given cell.
+-/
+
+/-- The 8 Moore neighbors of a cell `p`. -/
+def neighbors (p : Int × Int) : Finset (Int × Int) :=
+  (({-1, 0, 1} : Finset Int) ×ˢ ({-1, 0, 1} : Finset Int)).image
+    (fun d => (p.1 + d.1, p.2 + d.2)) |>.erase p
+
+/-- Sanity: a Moore neighborhood has exactly 8 cells. -/
+theorem neighbors_card (p : Int × Int) : (neighbors p).card = 8 := by
+  native_decide
+
+/-! ## The B3/S23 rule
+
+For every cell, count its live Moore neighbors:
+- A dead cell with exactly 3 live neighbors becomes alive (Birth = B3)
+- A live cell with 2 or 3 live neighbors stays alive (Survival = S23)
+- Otherwise the cell is dead
+
+We implement this by iterating over the bounding box (live cells and their
+neighbors) and selecting those that survive or are born.
+-/
+
+/-- Count the live Moore neighbors of `p` in grid `g`. -/
+def liveNeighborCount (g : Grid) (p : Int × Int) : Nat :=
+  (neighbors p ∩ g).card
+
+/-- The B3/S23 rule: should `p` be alive at the next generation? -/
+def aliveNext (g : Grid) (p : Int × Int) : Bool :=
+  let n := liveNeighborCount g p
+  if p ∈ g then
+    decide (n = 2 ∨ n = 3)   -- S23
+  else
+    decide (n = 3)           -- B3
+
+/-- Candidate cells for next-step survival: live cells and their neighbors.
+    No new cell can be born outside this bounding zone (B3 requires 3 live
+    neighbors among the 8 Moore neighbors of a dead cell). -/
+def candidates (g : Grid) : Finset (Int × Int) :=
+  g ∪ g.biUnion neighbors
+
+/-- One step of Conway's Game of Life (B3/S23 rule). -/
+def step (g : Grid) : Grid :=
+  (candidates g).filter (aliveNext g)
+
+/-- Iterated step: `evolve n g` applies `step` `n` times to `g`. -/
+def evolve (n : Nat) (g : Grid) : Grid :=
+  step^[n] g
+
+@[simp] theorem evolve_zero (g : Grid) : evolve 0 g = g := rfl
+
+@[simp] theorem evolve_succ (n : Nat) (g : Grid) :
+    evolve (n + 1) g = step (evolve n g) := by
+  simp [evolve, Function.iterate_succ', Function.comp]
+
+/-! ## Pattern predicates -/
+
+/-- A still life: a grid unchanged by one step of evolution.
+    The simplest non-trivial fixed points of `step`. -/
+def IsStillLife (g : Grid) : Prop := step g = g
+
+instance (g : Grid) : Decidable (IsStillLife g) :=
+  inferInstanceAs (Decidable (step g = g))
+
+/-- A pure oscillator of period `n`: returns to itself in exactly `n` steps. -/
+def IsOscillator (g : Grid) (n : Nat) : Prop := evolve n g = g
+
+instance (g : Grid) (n : Nat) : Decidable (IsOscillator g n) :=
+  inferInstanceAs (Decidable (evolve n g = g))
+
+/-- Translate every cell of a grid by a fixed displacement `v`. -/
+def shift (v : Int × Int) (g : Grid) : Grid :=
+  g.image (fun p => (p.1 + v.1, p.2 + v.2))
+
+/-- A spaceship of period `n` and displacement `v`: after `n` steps the
+    pattern reappears, translated by `v`. (`v = (0, 0)` recovers oscillators.) -/
+def IsSpaceship (g : Grid) (n : Nat) (v : Int × Int) : Prop :=
+  evolve n g = shift v g
+
+instance (g : Grid) (n : Nat) (v : Int × Int) :
+    Decidable (IsSpaceship g n v) :=
+  inferInstanceAs (Decidable (evolve n g = shift v g))
+
+/-! ## Canonical patterns
+
+These are the most famous small patterns of Conway's Game of Life,
+discovered in the early 1970s by Conway's group at Cambridge and by
+players of the M.I.T. PDP-6/PDP-10 community.
+-/
+
+/-- The **Block**: a 2×2 square. The smallest still life. -/
+def block : Grid := {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+/-- The **Beehive**: a 6-cell hexagonal still life. -/
+def beehive : Grid :=
+  {(1, 0), (2, 0), (0, 1), (3, 1), (1, 2), (2, 2)}
+
+/-- The **Blinker** (horizontal): three cells in a row. Period-2 oscillator. -/
+def blinker_h : Grid := {(0, 0), (1, 0), (2, 0)}
+
+/-- The **Blinker** (vertical): three cells in a column. -/
+def blinker_v : Grid := {(1, -1), (1, 0), (1, 1)}
+
+/-- The **Toad** (phase 1): a period-2 oscillator. -/
+def toad : Grid :=
+  {(1, 0), (2, 0), (3, 0), (0, 1), (1, 1), (2, 1)}
+
+/-- The **Beacon** (phase 1): two blocks touching diagonally. Period 2. -/
+def beacon : Grid :=
+  {(0, 0), (1, 0), (0, 1), (1, 1),
+   (2, 2), (3, 2), (2, 3), (3, 3)}
+
+/-- The **Glider** (phase 1, south-east bound): the smallest spaceship.
+    After 4 generations it reappears, translated by (1, -1). -/
+def glider : Grid :=
+  {(0, 0), (1, 0), (2, 0), (2, 1), (1, 2)}
+
+/-! ## Microproofs
+
+These are the first formal results of Phase 1: simple verifications of
+classic patterns by `native_decide`. Each one is a finite computation
+on small `Finset (Int × Int)` and exercises every layer of the model
+(`step`, `evolve`, `shift`, the three predicates).
+-/
+
+/-- The Block is a still life: `step block = block`. -/
+theorem block_still_life : IsStillLife block := by native_decide
+
+/-- The Beehive is a still life. -/
+theorem beehive_still_life : IsStillLife beehive := by native_decide
+
+/-- The horizontal Blinker oscillates with period 2. -/
+theorem blinker_period_two : IsOscillator blinker_h 2 := by native_decide
+
+/-- One step turns the horizontal Blinker into the vertical Blinker. -/
+theorem blinker_step : step blinker_h = blinker_v := by native_decide
+
+/-- The Toad oscillates with period 2. -/
+theorem toad_period_two : IsOscillator toad 2 := by native_decide
+
+/-- The Beacon oscillates with period 2. -/
+theorem beacon_period_two : IsOscillator beacon 2 := by native_decide
+
+/-- The Glider is a spaceship of period 4, displacement `(1, -1)`. -/
+theorem glider_spaceship : IsSpaceship glider 4 (1, -1) := by native_decide
+
+end Life
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md
@@ -21,6 +21,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 | `Conway/Nim.lean` | 0 | Nim game theory |
 | `Conway/Angel.lean` | 0 | Angel problem |
 | `Conway/KochenSpecker.lean` | 2 | Kochen-Specker theorem (18-vec Cabello, Pilier 1 FWT) |
+| `Conway/Life.lean` | 0 | Game of Life (B3/S23, still lifes/oscillators/spaceships, `native_decide` proofs, Phase 2 Epic #1647) |
 
 ## Key Results
 
@@ -30,6 +31,7 @@ Lean 4 formalization of Conway's mathematical games and algorithms.
 - Look-and-Say sequence properties
 - Nim game strategy
 - Angel problem formalization
+- Conway's Game of Life cellular automaton — `B3/S23` rules, still lifes (block, beehive), oscillators (blinker, toad, beacon period 2), spaceship (glider). All theorems via `native_decide`.
 - **WIP**: Kochen-Specker theorem (Pilier 1 of Epic #1651 Conway FWT)
 
 ## Kochen-Specker (Pilier 1 of Free Will Theorem)


### PR DESCRIPTION
## Summary

Formal implementation of Conway's Game of Life (Phase 1 foundations) in Lean 4 with Mathlib, as part of the Conway tribute series (Epic #1647, Pilier 2).

### Design

- **Grid representation**: `List (Int × Int)` (sorted, deduplicated) — avoids the `Quot.lift`/`Eq.rec` bottleneck that blocks `decide`/`native_decide` on `Finset (Int × Int)`
- **Step function**: B3/S23 rule via list operations (`++`, `flatMap`, `filter`, `mergeSort`, `eraseDups`)
- **Pattern predicates**: Boolean-valued (`isStillLife`, `isOscillator`, `isSpaceship`) enabling `native_decide` proofs
- **Proofs**: 7 microproofs verified by native code compilation

### Microproofs (all verified)

| Pattern | Type | Theorem |
|---------|------|---------|
| Block | Still life | `block_still_life` |
| Beehive | Still life | `beehive_still_life` |
| Blinker | Period-2 oscillator | `blinker_period_two`, `blinker_step` |
| Toad | Period-2 oscillator | `toad_period_two` |
| Beacon | Period-2 oscillator | `beacon_period_two` |
| Glider | Period-4 spaceship (1,-1) | `glider_spaceship` |

### Build

```
Lake build SUCCESS (3316 jobs, 162s)
grep -c sorry Conway/Life.lean → 0
```

### Lessons learned

- `Finset (Int × Int)` equality requires `Quot.lift` which blocks both `decide` (kernel reduction stuck on `Eq.rec`) and `native_decide` (Finset operations over `Int×Int` exceed native compile limits)
- `List` equality = cons-by-cons structural comparison — `native_decide` handles it efficiently
- Boolean predicates (`Bool` return) + `native_decide` on `(f x = true)` is the clean pattern for computable proofs on list-based data

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>