### PR TITLE
docs(rules): note CI scanner gitleaks exists, vigilance still required (#1634 finding)

### DIFF
--- a/.claude/rules/secrets-hygiene.md
+++ b/.claude/rules/secrets-hygiene.md
@@ -18,7 +18,7 @@ S'applique a **tous les agents** ecrivant du code dans le repo.
 
 5. **Si leak detecte** : NE PAS `git revert` (l'historique garde le secret). **Rotater la cle immediatement** chez le provider, creer une branche clean via cherry-pick. Postmortem agent responsable obligatoire.
 
-`.gitignore` seul est insuffisant : il protege les fichiers dedies, pas les literaux inline. En attendant un secret scanner CI, la vigilance est manuelle.
+`.gitignore` seul est insuffisant : il protege les fichiers dedies, pas les literaux inline. Le scanner CI gitleaks est installe (`.pre-commit-config.yaml` v8.21.2 + `.github/workflows/secret-scan.yml`), mais ne couvre pas tous les patterns : la vigilance reste obligatoire (revue body/contenu PR, lecture `gh pr view --json files`, controle des `os.getenv("KEY", "...")` literal-default).
 
 Detail (incident, fix structurel, regex de detection, postmortem template) : [docs/secrets-and-coord-detail.md](../../docs/secrets-and-coord-detail.md#1-secrets-hygiene--content-based-pas-path-based).
 


### PR DESCRIPTION
## Summary
- Updates `.claude/rules/secrets-hygiene.md` to reflect that the secret scanner CI is installed (`.pre-commit-config.yaml` gitleaks v8.21.2 + `.github/workflows/secret-scan.yml`)
- Removes the stale "En attendant un secret scanner CI, la vigilance est manuelle" claim
- Preserves the call for manual vigilance on patterns the scanner does NOT catch (literal-default in `os.getenv`, PR body review, content review of edits)

## Context (#1634 batch 2 finding)
While auditing closure #1076 ("Add secret scanner CI") in #1634 batch 2 (cycle 28/05), I confirmed via cross-ref that `.pre-commit-config.yaml` (gitleaks v8.21.2) + `.github/workflows/secret-scan.yml` are both in place. The rule file `.claude/rules/secrets-hygiene.md` (auto-loaded each session) still claimed the scanner was pending. This propagates stale guidance to every agent each session.

## Test plan
- [x] Diff = 1 file changed, 1 insertion, 1 deletion (`git diff --stat`)
- [x] `.claude/rules/` only (no code touched, no notebook touched)
- [x] No CATALOG-STATUS marker mutation
- [x] No regen catalog

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>