### PR TITLE
docs(lean): dilute count-obsession into pedagogical learning outcomes (Epic #1657 #1660)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -57,26 +57,18 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 
 **Duree totale** : ~12h45
 
-## Statut de maturite
+## Acquis d'apprentissage
 
-| # | Notebook | Cellules | Exercices | Solutions | Statut |
-|---|----------|----------|-----------|-----------|--------|
-| 1 | Setup | ~17 | - | - | **COMPLET** |
-| 2 | Dependent-Types | ~50 | 3 | 3 | **COMPLET** |
-| 3 | Propositions-Proofs | ~50 | 3 | 3 | **COMPLET** |
-| 4 | Quantifiers | ~46 | 3 | 3 | **COMPLET** |
-| 5 | Tactics | ~70 | 3 | 3 | **COMPLET** |
-| 6 | Mathlib-Essentials | ~45 | 3 | 3 | **COMPLET** |
-| 7 | LLM-Integration | ~50 | 2 | 2 | **COMPLET** |
-| 7b | Examples | ~40 | 3 | 3 | **COMPLET** |
-| 8 | Agentic-Proving | ~70 | 2 | 2 | **COMPLET** |
-| 9 | SK-Multi-Agents | ~50 | 2 | 2 | **COMPLET** |
-| 10 | LeanDojo | ~100 | 2 | 0 | **COMPLET** |
-| 11 | TorchLean | ~40 | 3 | Oui | **COMPLET** |
-| 11a | TorchLean Python | ~45 | 3 | Oui | **COMPLET** |
-| 12 | Sensitivity-Theorem | ~31 | 4 | Non | **NOUVEAU** |
-| 13 | Grothendieck-Tribute | ~23 | 0 | - | **NOUVEAU** (hommage) |
-| 15 | Kochen-Specker | ~25 | 1 | 0 | **NOUVEAU** |
+A l'issue de la serie, vous saurez :
+
+- **Modeliser** un raisonnement mathematique dans le Calcul des Constructions : types dependants, univers, propositions comme types (Curry-Howard). Notebooks 2-3 ancrent ces objets sur des exemples concrets (Vector, propositions logiques) plutot que sur de l'abstraction nue.
+- **Prouver** un theoreme en mode tactique avec les briques Mathlib : `intro`/`apply`/`exact`/`rfl` pour la structure, `ring`/`linarith`/`omega`/`simp` pour l'arithmetique et la simplification, `induction`/`cases`/`rcases` pour l'analyse de cas. Notebooks 4-6.
+- **Integrer un LLM** au workflow de preuve : patterns LeanCopilot et AlphaProof (n-best, MCTS), prompts goal-aware, comparaison ND-search vs CoT, agents APOLLO/Erdos. Notebooks 7-9.
+- **Tracer et explorer** une base de preuves a grande echelle : LeanDojo (parsing AST, theorem extraction, interaction Dojo), reseaux de neurones verifies via IBP/CROWN (TorchLean). Notebooks 10-11.
+- **Porter** un theoreme de recherche en Lean 4 : theoreme de sensibilite (Huang 2019, hypercube et signing matrix), theoreme de Kochen-Specker (Cabello 18 vecteurs, argument de parite, contextuality quantique). Notebooks 12, 15.
+- **Lire le langage grothendieckien** dans Mathlib 4 : categories et foncteurs, cribles et topologies de Grothendieck, faisceaux, schemas et sites, morphismes etales/lisses — comme entree vers la geometrie algebrique formalisee. Notebook 13.
+
+Pour l'etat formel detaille des modules support (preuves resolues vs `sorry` residuels), voir [LEAN_INVENTORY.md](../../GameTheory/LEAN_INVENTORY.md) et le [README du projet conway_lean](conway_lean/README.md).
 
 Tous les notebooks incluent :
 - Navigation header/footer avec liens vers notebooks precedent/suivant


### PR DESCRIPTION
## Summary

Suite et duplique du pattern applique au README GameTheory dans #1711, sur le README de la sous-serie Lean.

**Mandat user 2026-05-29** : *"pas mal de readme sont encore trop quantitatifs, attaches au nombre de notebooks et leur etat ; l'obsession du catalog n'est pas bonne. Agrementer de contenu reellement informatif sur le contenu des series, diluer les chiffres dans du plus pertinent."*

## Changement

`MyIA.AI.Notebooks/SymbolicAI/Lean/README.md` :

- **Supprime** : section *"Statut de maturite"* (16 lignes de decomptes Cellules/Exercices/Solutions + drapeaux COMPLET/NOUVEAU). Bruit quantitatif sans valeur pedagogique pour le lecteur d'un README.
- **Remplace par** : section *"Acquis d'apprentissage"* avec **6 competences concretes** (modeliser / prouver / integrer LLM / tracer / porter un theoreme / lire le langage grothendieckien). Chaque ligne est **ancree sur les notebooks reels** (numero + sujet) et decrit *quoi* le lecteur saura faire, pas combien de cellules il aura lues.
- **Ajoute** : pointeur honnete vers [LEAN_INVENTORY.md](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/GameTheory/LEAN_INVENTORY.md) et [conway_lean/README.md](https://github.com/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/README.md) pour l'etat formel des modules support (preuves resolues vs `sorry` residuels). C'est la, et seulement la, que les chiffres sont pertinents.

## Conserve (count-pertinent, pas count-obsession)

- Tableaux **Structure** Partie 1-4 (notebook + contenu + duree par notebook) — *quoi* + *combien de temps* = pertinent.
- Tableau **Modes d'execution suggeres** — sequences guidees Fondations / Avec Mathlib / Complet / Avec Pilier 1.B / Avec hommages.
- Sections **Quick Start**, **Prerequisites**, **Installation**, **Prover daemon**.

## Verification

- `python scripts/notebook_tools/expand_catalog_markers.py --check` : *"All markers up-to-date"* (CATALOG-STATUS non touche).
- `git diff --stat` : 12+/20- net dilution.
- 0 .ipynb / .lean / .cs / .py touche. Pas de catalog regen.

## Test plan

- [x] Drift CI green (catalog markers up-to-date)
- [x] Diff lisible : table -> bullets, contenu prime sur decompte
- [x] Liens internes valides (LEAN_INVENTORY.md + conway_lean/README.md existent)
- [ ] Self-merge apres CI green

Epic #1657 README hierarchy / sub #1660 SymbolicAI READMEs.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>