### PR TITLE
docs(genai-image): dilute count/hours/validation% into 'Acquis d'apprentissage' (#1657, #1658)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -2,16 +2,24 @@
 
 [← Documentation GenAI](../README.md) | [↑ ..](../README.md) | [→ Docker Management](../00-GenAI-Environment/00-2-Docker-Services-Management.ipynb)
 
-La generation d'images par IA est la deuxieme modalite generative la plus accessible apres le texte. Elle couvre un spectre large : generation from scratch (DALL-E, FLUX), edition d'images existantes (Qwen Image Edit), upscaling (Real-ESRGAN), et orchestration de workflows multi-modeles via ComfyUI. 19 notebooks repartis sur 5 niveaux progressifs.
+La generation d'images par IA est la deuxieme modalite generative la plus accessible apres le texte. Elle couvre un spectre large : generation from scratch (DALL-E, FLUX), edition d'images existantes (Qwen Image Edit), upscaling (Real-ESRGAN), et orchestration de workflows multi-modeles via ComfyUI. La progression va du prompt cloud one-shot au workflow ComfyUI multi-modeles oriente production.
 
 ## Fil rouge : construire un generateur de contenu visuel educatif
 
 L'objectif fil rouge de cette serie est de construire un systeme capable de produire des visuels pedagogiques de qualite : diagrammes, illustrations conceptuelles, et images d'identite pour des supports de cours. Chaque niveau apporte une brique supplementaire : generation simple via API cloud (niveau 1), modeles avances et edition fine (niveau 2), comparaison et orchestration multi-modeles (niveau 3), workflows de production (niveau 4), et cas d'usage concrets par domaine (examples).
 
-## Vue d'ensemble
+## Acquis d'apprentissage
 
-19 notebooks organisés en 5 sous-dossiers, représentant environ 6 à 8 heures d'apprentissage intensif dans le domaine de la génération d'images par IA, avec un taux de validation de 100%.
+A l'issue de la serie, l'apprenant sait :
 
+- **Choisir la bonne modalite** : API cloud (DALL-E 3, GPT-5 Image) vs ComfyUI auto-heberge (SD XL, FLUX, Qwen) selon le besoin (controle, cout, debit, donnees sensibles).
+- **Manipuler une image en code** : PIL/OpenCV pour redimensionnement, masques, compositing, conversion VAE latents <-> pixels.
+- **Concevoir un workflow ComfyUI** : graphe de noeuds (Sampler, VAE, ConditioningCombine, ModelSampling), import/export JSON, batching et seeds reproductibles.
+- **Editer plutot que regenerer** : Qwen Image Edit, ControlNet, inpainting (zones a regenerer dans un visuel existant) — moins couteux et plus controlable que repartir de zero.
+- **Composer plusieurs modeles** : pipeline base + LoRA style + upscaler + post-processing pour atteindre une qualite "supports de cours".
+- **Operationnaliser** : gestion VRAM (quantizations Nunchaku INT4 / FP8), file d'attente ComfyUI, monitoring GPU, deploiement derriere une API.
+
+La structure detaillee (notebooks par niveau, contenu, services utilises) est listee plus bas. Le decompte canonique reside dans `CATALOG-STATUS.json` du depot.
 
 ## Structure
 


### PR DESCRIPTION
## Summary

- Replace **Image/README.md** L11-13 'Vue d'ensemble' (19 notebooks / 6-8h / taux validation 100%) with 'Acquis d'apprentissage' section listing 6 concrete skills.
- Rephrase L5 trailing count line ('19 notebooks repartis sur 5 niveaux progressifs') into content-oriented progression hook.
- Canonical count redirected to `CATALOG-STATUS.json` to avoid prose duplication.

## Pattern

Continuation of Epic #1657 (README hierarchy refresh) sub-issue #1658 (GenAI). Applies the po-2025 #1711 'content over counts' pattern endorsed by user mandate 2026-05-29:

> Pas mal de readme sont encore trop quantitatifs, attaches au nombre de notebooks et leur etat, l'obsession du catalog n'est pas bonne dans le depot.

Audio/Video/Texte/SemanticKernel sub-READMEs already content-rich (Fil rouge + content tables intact) — no rewrite needed there. Image was the strongest count-obsession target in GenAI sub-tree.

## Acquis listed

- Choisir la modalite (cloud vs ComfyUI)
- Manipuler une image en code (PIL/OpenCV/VAE)
- Concevoir un workflow ComfyUI
- Editer plutot que regenerer (Qwen Edit, ControlNet, inpainting)
- Composer plusieurs modeles (LoRA + upscaler + post)
- Operationnaliser (VRAM, file d'attente, monitoring, deploiement)

## Test plan

- [x] Read full README before edit — content tables L33-65 (Foundation/Advanced/Orchestration/Applications/examples) preserved untouched
- [x] L5 + L11-13 only blocks rewritten — Fil rouge L7-9 preserved
- [x] No CATALOG-STATUS marker stripped (none present in this file; referenced in body as canonical source)
- [x] Markdown lint MD012 (multiple blank lines) fixed before commit
- [x] Diff stat: +11/-3, scope minimal (anti-pendulum, no surrounding cleanup)

Cycle 5 worker po-2024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)