### PR TITLE
docs(stable-marriage): honest transitive sorry deps for gale_shapley_man_optimal (G.9)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md
@@ -25,14 +25,14 @@ Le prover test harness `_GoalExtract.lean` contient 2 sorry de scaffolding (non-
 | `gale_shapley_terminates` | Algorithm terminates in at most n^2 steps | 0 | CLOSED (`trivial`) |
 | `gale_shapley_produces_matching` | Output is a valid bijection | 0 | CLOSED (identity witness) |
 | `gale_shapley_stable` | No blocking pair exists | 0 | **CLOSED via PR #1194** (port mmaaz-git upstream) |
-| `gale_shapley_man_optimal` | Proposers get best achievable partners | 0 | **CLOSED via PR #1521** (multi-agent prover GPT-5.5) |
-| `gale_shapley_woman_pessimal` | Receivers get worst achievable partners | 0 | **CLOSED via PR #1521** |
+| `gale_shapley_man_optimal` | Proposers get best achievable partners | 0 (body) | **CLOSED via PR #1521** body, BUT transitively depends on `doctor_optimal_eq_top` (L836 sorry) — see note below |
+| `gale_shapley_woman_pessimal` | Receivers get worst achievable partners | 0 (body) | **CLOSED via PR #1521** body, BUT same transitive dependency on L836 |
 | `meetSpouse_injective` | Spouse map is injective | 0 | **CLOSED via PR #1522** (multi-agent prover GPT-5.5) |
-| `Lattice.Case A2` (L185) | Knuth rotation Case A2 | 1 | INTRACTABLE (Knuth 1976 sub-case) |
-| `Lattice.Case B` (L187) | Knuth rotation Case B | 1 | INTRACTABLE (Knuth 1976 sub-case) |
-| `doctor_optimal_eq_top` (L836) | Doctor-optimal = top of stable lattice | 1 | Conditional on `no_cross_match` (axiom) |
+| `Lattice.no_cross_match` Case A2 (L185) | Knuth rotation Case A2 | 1 | INTRACTABLE (Knuth 1976 sub-case, user mandate "stays as sorry" per PR #1530) |
+| `Lattice.no_cross_match` Case B (L187) | Knuth rotation Case B | 1 | INTRACTABLE (Knuth 1976 sub-case, same mandate) |
+| `doctor_optimal_eq_top` (L836) | Doctor-optimal = top of stable lattice | 1 | Transitively conditional on `no_cross_match` (L185/L187 sorry, **NOT axiom**) |
 
-**Important**: les 3 sorrys restants vivent dans `Lattice.lean` et representent la machinerie complete du lattice de matchings stables (Knuth 1976, Wu-Roth 2018) qui n'existe pas encore dans Mathlib4. Tous **INTRACTABLE** par le prover LLM courant (cf [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO per project).
+**Important — transitive dependency** : les theoremes `gale_shapley_man_optimal` et `gale_shapley_woman_pessimal` ont 0 sorry **dans leur corps** mais appellent `doctor_optimal_eq_top` (L836) qui contient 1 sorry. Le claim "CLOSED via PR #1521" est correct au sens mecanique (corps des theoremes principaux fermes) mais **incomplet au sens transitif**. Les 3 sorrys restants vivent dans `Lattice.lean` et representent la machinerie complete du lattice de matchings stables (Knuth 1976, Wu-Roth 2018) qui n'existe pas encore dans Mathlib4. `no_cross_match` est un `lemma ... := by sorry` (PAS un `axiom`), per mandate user PR #1530. Tous **INTRACTABLE** par le prover LLM courant (4 traces 2026-05-23/24 sur A2/B/L836 = 0 sorry-delta net, cf `agent_tests/prover/traces/*Lattice*.json` et [LEAN_INVENTORY.md](../LEAN_INVENTORY.md) GO/NO-GO per project).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Documentation drift fix on `stable_marriage_lean/README.md` per culture du doute (G.9) and prover-forensic survey 2026-05-29.

## Findings

The prover-forensic Opus sub-agent surveyed the 3 production sorries in `Lattice.lean` and identified **two documentation issues**:

1. **Hidden transitive dependency** : `gale_shapley_man_optimal` and `gale_shapley_woman_pessimal` were documented as "CLOSED via PR #1521" with sorry=0. Their **bodies** are indeed sorry-free, but both call `doctor_optimal_eq_top` (L836) which has 1 sorry. Per G.9 ("culture du doute"), this transitive dependency must be explicit.

2. **Wrong sorry kind** : `doctor_optimal_eq_top` (L836) was described as "Conditional on `no_cross_match` (axiom)". `no_cross_match` is actually a `lemma ... := by sorry` (Cases A2/B at L185/L187), **not** an `axiom`. Per user mandate cited in PR #1530 body ("no_cross_match stays as sorry"), the axiom path was explicitly rejected.

## Empirical backing

4 prover traces 2026-05-23/24 (multi + autonomous, openrouter + zai) on L185/L187/L836:

| Trace | Target | Iter | Wall-clock | sorry-delta net |
|-------|--------|-----:|-----------:|-----------------|
| `multi_custom_Lattice_L145_openrouter_result.json` | A2 | 0 | 187s | 0 |
| `autonomous_custom_Lattice_L145_openrouter_result.json` | A2 | 8 | 495s | 0 (best_sorry=3 transient) |
| `multi_custom_Lattice_L147_openrouter_result.json` | B | 0 | 645s | reports -2 BUT `proof: null` (silent-success bug) |
| `autonomous_LATTICE_DOCTOR_OPTIMAL_TOP_zai_result.json` | L836 | 10 | 9689s (~2h41) | 0 (best_sorry=4 transient) |

Cumulative: **0 sorry-delta net** across all 4 traces. "INTRACTABLE" classification is empirically substantiated.

## Diff

- 12 lines (6+ / 6-) in `MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/README.md`
- No code change. Sorry inventory unchanged (3 in Lattice.lean).

## Test plan

- [x] `lake build StableMarriage` — unchanged (no code touched, doc-only)
- [x] `grep -c sorry MyIA.AI.Notebooks/GameTheory/stable_marriage_lean/StableMarriage/Lattice.lean` returns 3
- [x] Documentation matches verified file:line locations (Lattice.lean L185/L187/L836)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)