### PR TITLE
docs(probas): add real-world examples narrative (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -244,6 +244,19 @@ pip install pyro-ppl torch matplotlib numpy
 | Finance | 11, 15, 20 |
 | E-commerce | 12 |
 
+### Exemples concrets
+
+Derriere chaque modele de la serie se cache un systeme reel deja en production :
+
+- **TrueSkill** (notebook 6) est l'algorithme que Microsoft utilise pour apparier des millions de joueurs sur Xbox Live : il maintient pour chaque joueur une competence *gaussienne* (moyenne + incertitude) mise a jour apres chaque partie, generalisant l'Elo des echecs aux jeux en equipe.
+- **Item Response Theory** (notebook 5) est le moteur des tests adaptatifs comme le GMAT ou le GRE : la difficulte de chaque question est calibree probabilistiquement, et le test s'ajuste en temps reel au niveau estime du candidat.
+- **Les reseaux bayesiens** (notebooks 4, 7) fondent les systemes d'aide au diagnostic medical (de QMR-DT aux outils modernes) et le filtrage anti-spam : ils propagent l'incertitude entre symptomes, causes et observations.
+- **LDA / topic models** (notebook 9) structurent automatiquement de grands corpus — decouverte de thematiques dans des archives de presse, cartographie de la litterature scientifique, analyse de tickets support.
+- **Les HMM** (notebook 11, et `PyMC-HMM-Trading-Alpha`) detectent les regimes caches : phases de marche en finance, reconnaissance de la parole, segmentation de sequences biologiques.
+- **Les systemes de recommandation bayesiens** (notebook 12) sont la version « avec barre d'incertitude » du collaborative filtering de Netflix ou Amazon — utile pour decider quand explorer un nouvel item plutot que d'exploiter une preference connue.
+- **Le crowdsourcing** (notebook 10) modelise la fiabilite de chaque annotateur (Mechanical Turk, labellisation de datasets) pour reconstruire la verite terrain malgre des votes bruites.
+- **La theorie de la decision et les MDPs** (notebooks 14-20) relient la serie au controle sequentiel : gestion de stocks, maintenance predictive, et passerelle directe vers le [reinforcement learning](../RL/).
+
 ## Ressources
 
 ### Infer.NET


### PR DESCRIPTION
## Contexte — mandat user 2026-05-29

Enrichissement profond ciblé, **mode purement additif**. Suite de #1715 (root), #1722 (GameTheory).

## Problème

La section "Domaines d'application" n'était qu'une **table index** (domaine → numéro de notebook), sans contenu narratif.

## Changement (additif, +13 / -0)

**AJOUTE** une sous-section `### Exemples concrets` : 8 systèmes réels en production, chacun ancré sur un modèle de la série :

- **TrueSkill** (nb 6) → matchmaking Xbox Live
- **IRT** (nb 5) → tests adaptatifs GMAT/GRE
- **Réseaux bayésiens** (nb 4, 7) → diagnostic médical, anti-spam
- **LDA** (nb 9) → topic discovery corpus presse / littérature
- **HMM** (nb 11) → régimes de marché, reconnaissance vocale
- **Recommandation bayésienne** (nb 12) → Netflix/Amazon avec incertitude
- **Crowdsourcing** (nb 10) → fiabilité annotateurs Mechanical Turk
- **MDPs** (nb 14-20) → passerelle vers le RL

## Vérification

- ` expand_catalog_markers.py --check ` → **"All markers up-to-date"** (marker non touché)
- diff **13+/0-** — purement additif, 0 suppression, 0 ajustement de total

🤖 Generated with [Claude Code](https://claude.com/claude-code)