### PR TITLE
docs(iit): add scientific significance and debates section (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -95,6 +95,17 @@ La Theorie de l'Information Integree (IIT) propose une approche mathematique de 
 
 **Phi** mesure le degre d'integration informationnelle d'un systeme. Un Phi > 0 indique une integration irreductible, suggerant une forme de conscience.
 
+## Portee scientifique et debats
+
+L'IIT n'est pas qu'une speculation philosophique : elle a engendre des outils utilises en clinique et alimente l'un des debats les plus vifs des neurosciences.
+
+- **Mesure clinique de la conscience.** Le *Perturbational Complexity Index* (PCI), inspire des principes de l'IIT, est utilise pour evaluer la conscience chez des patients non communicants (coma, etat vegetatif, anesthesie). Le protocole « zap-and-zip » (stimulation TMS + EEG, compression de la reponse) distingue empiriquement les etats conscients des etats inconscients — une retombee concrete et reproductible d'une theorie de la conscience.
+- **Une theorie concurrente.** L'IIT s'oppose frontalement aux theories de type *Global Workspace* (Dehaene, Baars), qui font de la conscience une diffusion globale de l'information plutot qu'une integration causale locale. Des programmes de tests adversariaux (collaboration Templeton) confrontent leurs predictions sur des donnees reelles.
+- **Enjeu pour l'IA.** L'IIT predit qu'un reseau purement *feed-forward* (comme l'inference d'un LLM classique) a un Phi nul : il calcule sans « etre » conscient, faute de boucles causales integrees. Cette these est centrale dans les discussions sur la conscience artificielle.
+- **Controverse.** Le calcul exact de Phi est computationnellement intractable au-dela de petits reseaux (d'ou le coarse-graining du notebook), et la theorie a fait l'objet d'une critique publique retentissante (lettre ouverte de 2023 la qualifiant de « pseudoscience ») — un cas d'ecole pour discuter des criteres de scientificite d'une theorie de l'esprit.
+
+Ces tensions font de l'IIT un excellent terrain pour exercer l'esprit critique : on y manipule un formalisme precis (calculable avec PyPhi) tout en gardant a l'esprit les limites de son interpretation.
+
 ## Ressources
 
 ### Documentation PyPhi


### PR DESCRIPTION
## Contexte — mandat user 2026-05-29

Enrichissement profond ciblé, **mode purement additif**. IIT était le README le plus thin sur les *enjeux* (la théorie était expliquée, mais pas pourquoi elle compte).

## Changement (additif, +11 / -0)

**AJOUTE** `## Portée scientifique et débats` :

- **Mesure clinique de la conscience** — le Perturbational Complexity Index (PCI), protocole « zap-and-zip » TMS-EEG, évalue la conscience de patients non communicants (coma, anesthésie). Retombée concrète et reproductible.
- **Théorie concurrente** — opposition Global Workspace (Dehaene/Baars), tests adversariaux Templeton.
- **Enjeu IA** — Phi nul des réseaux feed-forward (LLM en inférence) : central pour la conscience artificielle.
- **Controverse** — intractabilité du calcul exact de Phi + lettre ouverte 2023 « pseudoscience ». Cas d'école pour l'esprit critique.

## Vérification

- ` expand_catalog_markers.py --check ` → **"All markers up-to-date"** (marker non touché)
- diff **11+/0-** — purement additif, 0 suppression, 0 ajustement de total
- Contenu factuel et balancé (PCI/Casali-Massimini, débat GWT, controverse 2023 réelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)