### PR TITLE
docs: add motivated intros to SmartContracts/Tweety/Planners + CaseStudies (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -9,6 +9,8 @@ maturity: PRODUCTION=2, ALPHA=1, BETA=1
 
 Etudes de cas interdisciplinaires combinant plusieurs domaines de l'IA dans des projets appliques.
 
+C'est ici que les techniques etudiees isolement ailleurs dans le cursus **convergent sur un meme probleme realiste**. La ou un notebook thematique enseigne une methode, une etude de cas en exige plusieurs a la fois : un diagnostic medical mobilise recherche informee (A*), validation par contraintes (Z3) et algorithmes genetiques ; une planification oncologique combine ontologie, planification CSP (OR-Tools) et inference probabiliste (Pyro) — exactement comme le ferait un vrai projet d'IA applique, ou aucune technique ne suffit seule. Chaque cas suit une structure **student / solution** : vous construisez vous-meme le systeme integre a partir d'un template, puis vous le confrontez a une solution de reference. La valeur pedagogique tient autant a l'**integration** des briques qu'au **realisme du domaine** (donnees patients, contraintes cliniques reelles).
+
 **4 notebooks** | **2 projets** | **~6-8h**
 
 ## Structure

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -2,6 +2,8 @@
 
 Cette serie de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui genere des sequences d'actions pour atteindre des objectifs.
 
+La planification repond a une question differente de celle de l'apprentissage : non pas « que predire ? » mais « **que faire ?** ». A partir d'un modele du monde — un etat initial, des actions avec leurs preconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mene au but. C'est une technologie eprouvee : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activites des rovers martiens). Le langage **PDDL** a standardise la maniere de decrire ces problemes, donnant naissance a tout un ecosysteme de solveurs comparables. La planification connait aujourd'hui un regain d'interet avec les LLMs, comme moyen de doter les modeles de langage d'une capacite d'action verifiable et orientee vers un but.
+
 ## Objectifs d'apprentissage
 
 A l'issue de cette serie, vous saurez :

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -2,6 +2,10 @@
 
 Serie de notebooks educatifs couvrant les fondements cryptographiques, le developpement Solidity, les tests, la cryptographie avancee (ZKP, HE, vote verifiable), et les blockchains alternatives.
 
+Un smart contract est un programme qui s'execute tout seul sur une blockchain : une fois deploye, son code fait foi, transfere de la valeur et applique des regles sans intermediaire ni possibilite de revenir en arriere. C'est ce qui fait sa puissance — des ecosystemes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch a pousser le lendemain, c'est une faille immuable qui peut couter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'ou le poids accorde dans cette serie aux **tests, au fuzzing et a la verification formelle** autant qu'au developpement.
+
+Le parcours suit le fil annonce par le titre : on part des **primitives cryptographiques** des cypherpunks (hachage, arbres de Merkle, preuve de travail, signatures) pour comprendre *pourquoi* une blockchain tient, puis on construit en **Solidity** (types, heritage, standards ERC, DeFi, gouvernance), on **securise** (Foundry, invariants, verification formelle), on explore la **cryptographie pour la vie privee** (ZKP, chiffrement homomorphique, vote verifiable de bout en bout), avant d'elargir aux **chaines alternatives** (Vyper, XRP, Bitcoin Script, Move/Sui, Solana) et au **deploiement reel** sur testnet puis mainnet. L'objectif final n'est pas seulement de savoir ecrire un contrat, mais de savoir le rendre digne de confiance.
+
 ## Vue d'Ensemble
 
 | Metrique | Valeur |

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -13,6 +13,8 @@ TweetyProject est une collection de bibliotheques Java couvrant :
 
 Les notebooks utilisent **JPype** pour integrer Java dans Python, permettant un apprentissage interactif.
 
+A l'heure des modeles statistiques et des LLMs, pourquoi etudier ces logiques symboliques ? Parce qu'elles apportent ce que l'apprentissage seul ne garantit pas : un raisonnement **explicite, verifiable et explicable**. L'argumentation computationnelle (cadres de Dung, ASPIC+, ABA) modelise la facon dont des agents confrontent des arguments, gerent les contradictions et aboutissent a des conclusions justifiees — avec des applications en raisonnement juridique, en aide a la decision, en negociation multi-agents, et de plus en plus comme couche de controle au-dessus des LLMs (detecter les incoherences, structurer un debat). La revision de croyances (AGM) formalise comment un agent rationnel met a jour ses connaissances face a une information nouvelle ou contradictoire. L'interet de TweetyProject est de reunir tous ces formalismes sous un meme toit : on experimente d'une logique a l'autre sans avoir a reimplementer chaque solveur.
+
 ## Structure de la Serie
 
 | # | Notebook | Theme | Duree |


### PR DESCRIPTION
## Contexte — mandat user 2026-05-29

Enrichissement profond ciblé au **niveau sous-séries** (suite de root/GameTheory/QC/Probas/IIT), **mode strictement additif**.

## Problème

Trois sous-séries SymbolicAI avaient une **intro d'une seule phrase**, sans le narratif de motivation présent dans les séries déjà enrichies.

## Changement (additif, +8 / -0 sur 3 fichiers)

- **SmartContracts** — ajoute : ce qu'est un smart contract (code auto-exécutable immuable), les enjeux (DeFi/NFT/DAO vs bugs irréversibles → d'où le poids des tests/vérif formelle), et l'arc cypherpunk → Solidity → sécurité → crypto vie privée → chaînes alternatives → déploiement réel.
- **Tweety** — ajoute : pourquoi le symbolique à l'ère des LLMs (raisonnement explicite/vérifiable/explicable), argumentation computationnelle, révision de croyances AGM, couche de contrôle au-dessus des LLMs.
- **Planners** — ajoute : « que faire ? » vs « que prédire ? », applications éprouvées (robotique, logistique, engins spatiaux NASA), rôle de PDDL, regain avec les LLMs.

**SemanticWeb non touché** : possède déjà une section "Présentation" riche (vision Berners-Lee) — pas de padding inutile.

## Vérification

- ` expand_catalog_markers.py --check ` → **"All markers up-to-date"** (markers non touchés)
- diff **8+/0-** — purement additif, 0 suppression, 0 ajustement de total

🤖 Generated with [Claude Code](https://claude.com/claude-code)