### PR TITLE
fix(ml-training): panier_loader yfinance fallback to unblock L6 DT Full Sweep (#1409)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
@@ -23,12 +23,15 @@ Usage:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 PANIER_DIR = Path(__file__).resolve().parent.parent.parent / "datasets" / "panier"
+DEFAULT_START = "2015-01-01"
+DEFAULT_END = "2026-05-23"
 
 PANIER_GROUPS = {
     "us_equity_broad": ["SPY", "RSP", "IWM"],
@@ -71,6 +74,8 @@ def get_panier_symbols(group: str | None = None) -> list[str]:
 def _find_file(symbol: str, panier_dir: Path | None = None) -> Path | None:
     """Find the CSV file for a symbol in the panier directory."""
     panier_dir = panier_dir or PANIER_DIR
+    if not panier_dir.exists():
+        return None
     variants = [
         f"{symbol.replace('-', '_')}_*.csv",
         f"{TICKER_MAP.get(symbol, symbol).replace('-', '_').replace('^', '')}_*.csv",
@@ -83,11 +88,79 @@ def _find_file(symbol: str, panier_dir: Path | None = None) -> Path | None:
     return None
 
 
+def ensure_symbol(
+    symbol: str,
+    start: str | None = None,
+    end: str | None = None,
+    panier_dir: Path | None = None,
+) -> Path | None:
+    """Ensure a symbol's CSV exists locally; download via yfinance if missing.
+
+    Returns the path of the (existing or newly fetched) CSV, or None when the
+    download fails. Output matches the convention written by
+    `scripts/datasets/build_panier_anti_bias.py`:
+    `<SYMBOL_underscored>_<start>_<end>.csv` with `Date,Close,High,Low,Open,Volume`.
+
+    yfinance is imported lazily so the loader stays import-safe on machines
+    without the dependency installed for pure-read use cases.
+    """
+    panier_dir = panier_dir or PANIER_DIR
+    panier_dir.mkdir(parents=True, exist_ok=True)
+
+    existing = _find_file(symbol, panier_dir)
+    if existing is not None:
+        return existing
+
+    start = start or DEFAULT_START
+    end = end or DEFAULT_END
+
+    try:
+        import yfinance as yf
+    except ImportError:
+        print(
+            f"[panier_loader] yfinance not installed; cannot fetch {symbol}. "
+            f"Install with `pip install yfinance` or pre-populate {panier_dir}.",
+            file=sys.stderr,
+        )
+        return None
+
+    ticker = TICKER_MAP.get(symbol, symbol)
+    try:
+        df = yf.download(
+            ticker,
+            start=start,
+            end=end,
+            progress=False,
+            auto_adjust=True,
+            actions=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — network/HTTP errors vary by provider
+        print(f"[panier_loader] yfinance download failed for {ticker}: {exc}", file=sys.stderr)
+        return None
+
+    if df is None or df.empty:
+        print(f"[panier_loader] yfinance returned no data for {ticker}", file=sys.stderr)
+        return None
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+
+    keep = [c for c in ("Close", "High", "Low", "Open", "Volume") if c in df.columns]
+    df = df[keep]
+    df.index.name = "Date"
+
+    fname = f"{symbol.replace('-', '_').replace('^', '')}_{start}_{end}.csv"
+    out_path = panier_dir / fname
+    df.to_csv(out_path)
+    return out_path
+
+
 def load_panier(
     group: str | None = None,
     start: str | None = None,
     end: str | None = None,
     panier_dir: Path | None = None,
+    auto_fetch: bool = False,
 ) -> dict[str, pd.DataFrame]:
     """Load panier data as dict of DataFrames keyed by symbol.
 
@@ -96,9 +169,15 @@ def load_panier(
     group : str or None
         Filter to a specific asset class group. None = all symbols.
     start, end : str or None
-        Date range filter (inclusive).
+        Date range filter (inclusive). Also used as the yfinance fetch window
+        when `auto_fetch=True`.
     panier_dir : Path or None
         Override panier data directory.
+    auto_fetch : bool
+        If True, missing symbols are downloaded via yfinance into `panier_dir`
+        (matching `build_panier_anti_bias.py` naming) before being loaded.
+        Default False preserves the historical silent-skip behaviour so callers
+        opt in explicitly to network access.
 
     Returns
     -------
@@ -110,6 +189,8 @@ def load_panier(
 
     for symbol in symbols:
         path = _find_file(symbol, panier_dir)
+        if path is None and auto_fetch:
+            path = ensure_symbol(symbol, start=start, end=end, panier_dir=panier_dir)
         if path is None:
             continue
 
@@ -263,3 +344,73 @@ def compute_cross_asset_features(
         features[f"vol_{col}"] = returns[col].rolling(lookback).std()
 
     return features.dropna()
+
+
+def _cli() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Panier loader utilities (verify integrity, pre-fetch missing symbols).",
+    )
+    parser.add_argument(
+        "--ensure-all",
+        action="store_true",
+        help="Download any missing panier symbol via yfinance, then exit.",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Print validate_panier_integrity() summary.",
+    )
+    parser.add_argument("--start", default=DEFAULT_START)
+    parser.add_argument("--end", default=DEFAULT_END)
+    parser.add_argument(
+        "--panier-dir",
+        default=None,
+        help=f"Override panier directory (default: {PANIER_DIR}).",
+    )
+    args = parser.parse_args()
+
+    panier_dir = Path(args.panier_dir) if args.panier_dir else PANIER_DIR
+
+    if args.ensure_all:
+        missing_before = [
+            s for s in get_panier_symbols() if _find_file(s, panier_dir) is None
+        ]
+        print(
+            f"[panier_loader] ensure-all: {len(missing_before)} missing in {panier_dir}"
+        )
+        ok, failed = 0, []
+        for symbol in missing_before:
+            path = ensure_symbol(
+                symbol, start=args.start, end=args.end, panier_dir=panier_dir
+            )
+            if path is not None:
+                ok += 1
+                print(f"  + {symbol} -> {path.name}")
+            else:
+                failed.append(symbol)
+                print(f"  ! {symbol} FAILED")
+        print(
+            f"[panier_loader] ensure-all done: {ok} fetched, {len(failed)} failed"
+        )
+        if failed:
+            print(f"  failed: {failed}")
+            return 1
+
+    if args.validate:
+        report = validate_panier_integrity(panier_dir=panier_dir)
+        print(
+            f"[panier_loader] validate: ok={report['ok']}/{report['total']}, "
+            f"missing={report['missing']}, issues={len(report['issues'])}"
+        )
+        for issue in report["issues"][:10]:
+            print(f"  - {issue}")
+        if len(report["issues"]) > 10:
+            print(f"  ... ({len(report['issues']) - 10} more)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())


### PR DESCRIPTION
## Summary

- Unblocks **L6 DT Full Sweep on ai-01** (Epic #1409) by making `panier_loader.load_panier()` self-sufficient. Previously, missing CSVs in `MyIA.AI.Notebooks/QuantConnect/datasets/panier/` (gitignored) caused silent `continue`, returning an empty dict on any fresh machine.
- New `ensure_symbol()` helper lazily downloads via `yfinance` with the same naming convention as `scripts/datasets/build_panier_anti_bias.py`.
- `load_panier(..., auto_fetch=True)` opt-in flag; default `False` preserves historical behaviour.
- New CLI `python panier_loader.py --ensure-all` for pre-flight pre-population on a fresh worker.

## Why this matters

`#1409` L6 DT Full Sweep is the next ML curriculum step after **L4 DT (BEATS 24/26)** and **L5 PatchTST (NO BEATS 0/26)**. Dashboard status: *"Bloqué par data loader (datasets/panier/ gitignored sur ai-01). Fix en cours par po-2024."* This PR is that fix.

## Scope

- Single file: `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py` (+152 / -1)
- Backwards compatible: `auto_fetch=False` is the default; existing callers (`sweep_l4_decision_transformer.py`, `sweep_l6_dt_extension.py`) are unchanged.
- `yfinance` import is **lazy** inside `ensure_symbol()` — the module stays importable without the dep.

## Test plan

- [x] `load_panier(start=2020-01-01, end=2020-03-31)` on existing po-2024 data: 26/26 frames, SPY shape `(62, 5)`, columns `['Close','High','Low','Open','Volume']`. ✅
- [x] `validate_panier_integrity()` on existing data: `ok=26/26, missing=0, issues=0`. ✅
- [x] `ensure_symbol('SPY', start=2024-01-01, end=2024-01-15)` in an **empty** temp dir: yfinance fetched `(9, 5)`, filename `SPY_2024-01-01_2024-01-15.csv`, columns match convention. ✅
- [ ] (post-merge, ai-01) `python panier_loader.py --ensure-all` then `python sweep_l6_dt_extension.py` → confirms L6 unblock end-to-end.

## Rules compliance

- **Anti-régression**: no deletions of existing logic, only additions. `load_panier()` default behaviour preserved (silent skip).
- **Code style**: PEP 8, type hints, no emojis, French/English mixed comments OK in code.
- **Secrets hygiene**: no inline literals, yfinance public API.
- **Notebook conventions C.1-C.3**: not applicable (script-only change, no notebooks touched).