### PR TITLE
docs(ml): add motivated intros to ML.Net + DataScienceWithAgents sub-series (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/README.md
@@ -2,6 +2,8 @@
 
 Formation complete en Data Science Python avec integration d'agents IA. Combine les fondamentaux NumPy/Pandas avec deux tracks complementaires : LangChain (3 jours) et Google ADK (4 jours).
 
+Au-dela des bibliotheques classiques, cette formation explore un changement de paradigme : passer de *l'ecriture* de code data science a *l'orchestration* d'**agents LLM** qui le produisent et l'executent. Apres les fondations NumPy/Pandas, le track **LangChain** apprend a construire des agents capables d'interroger un DataFrame, de nettoyer un jeu de donnees ou de scorer des candidatures ; le track **Google ADK** monte en puissance avec des systemes multi-agents (boucles planner-coder, frameworks DS-STAR / MLE-STAR) jusqu'a concourir sur des competitions Kaggle. L'enjeu pedagogique n'est pas seulement technique : il s'agit de comprendre *quand* un agent autonome accelere reellement le travail d'analyse, et *comment* l'encadrer (outils, validation, garde-fous).
+
 ## Vue d'ensemble
 
 | Statistique | Valeur |

--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -2,6 +2,10 @@
 
 Serie de notebooks couvrant ML.NET, la bibliotheque open-source de Microsoft pour le Machine Learning dans l'ecosysteme .NET.
 
+ML.NET apporte le machine learning **nativement dans l'ecosysteme .NET** : on entraine et on consomme des modeles directement en C#, sans quitter sa stack applicative ni dependre d'un runtime Python. C'est un choix pense pour les developpeurs autant que pour les data scientists — l'AutoML abaisse la barriere d'entree, et les modeles s'executent *in-process* dans des applications existantes (API web, services, desktop). L'interoperabilite **ONNX** permet d'importer des modeles entraines ailleurs (scikit-learn, PyTorch, Hugging Face) et de les servir cote .NET : ML.NET devient ainsi un pont concret entre la recherche en Python et la production en entreprise.
+
+Le parcours va du premier pipeline (ML-1) jusqu'a une application complete : preparation des donnees et feature engineering (ML-2), entrainement et AutoML (ML-3), evaluation rigoureuse par cross-validation et importance des variables (ML-4), puis les fonctionnalites avancees — prevision de series temporelles par SSA (ML-5), interoperabilite ONNX (ML-6) et systemes de recommandation (ML-7) — avant un TP capstone qui marie ML.NET et la regression bayesienne d'Infer.NET.
+
 ## Vue d'ensemble
 
 | Statistique | Valeur |


### PR DESCRIPTION
## Contexte — mandat user 2026-05-29

Enrichissement profond ciblé au **niveau sous-séries ML**, **mode strictement additif** (suite du sweep top-level + SymbolicAI sub-series).

## Problème

Les deux sous-READMEs ML enchaînaient sur des tables après une intro d'une seule phrase, sans narratif de motivation.

## Changement (additif, +6 / -0 sur 2 fichiers)

- **ML.Net** — ajoute : ce qui distingue ML.NET (ML natif en C#/.NET sans runtime Python, AutoML pour développeurs, exécution *in-process* en entreprise, pont ONNX Python→production) + l'arc du parcours (pipeline → AutoML → éval → avancé → TP Infer.NET).
- **DataScienceWithAgents** — ajoute : le changement de paradigme (écrire du code → orchestrer des agents LLM), tracks LangChain puis Google ADK (planner-coder, DS-STAR/MLE-STAR, Kaggle), et l'enjeu pédagogique (quand/comment encadrer un agent autonome).

**Préservé** : toutes les tables (Vue d'ensemble, notebooks, contenu détaillé, statuts ✅/📚), parcours, concepts clés.

## Vérification

- ` expand_catalog_markers.py --check ` → no drift (pas de marker dans ces sous-READMEs)
- diff **6+/0-** — purement additif, 0 suppression, 0 ajustement de total

🤖 Generated with [Claude Code](https://claude.com/claude-code)