### PR TITLE
refactor(lean): centralize kernel.json wrapper-regression check (#1618)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/scripts/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/scripts/README.md
@@ -25,6 +25,8 @@ Ce repertoire contient les scripts de configuration et de validation des kernels
 | `validate_lean_setup.py` | Validation de l'environnement Lean | `python scripts/validate_lean_setup.py` |
 | | Validation WSL | `python scripts/validate_lean_setup.py --wsl` |
 
+> La validation inclut desormais la detection de la regression wrapper kernel.json (issue #1618) : `~/.lean4-kernel-wrapper.py` v5 vs ancien bash. Logique centralisee dans `scripts/lean/lean_kernel_check.py`, partagee avec `scripts/lean/setup_lean4_all.py` et le validateur SymbolicAI/Lean.
+
 ## Installation complete
 
 ### Etape 0 : Python standard (notebooks 1-12, 14-16)

--- a/MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py
+++ b/MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py
@@ -131,6 +131,41 @@ def check_jupyter_kernel(kernel_name):
         return False
 
 
+def _load_inspect_kernel_wrapper():
+    """Import the canonical wrapper check from scripts/lean/lean_kernel_check.py.
+
+    Returns None if the shared helper cannot be located (graceful degradation).
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "scripts" / "lean" / "lean_kernel_check.py"
+        if candidate.exists():
+            sys.path.insert(0, str(candidate.parent))
+            try:
+                from lean_kernel_check import inspect_kernel_wrapper
+                return inspect_kernel_wrapper
+            except Exception:
+                return None
+    return None
+
+
+_inspect_kernel_wrapper = _load_inspect_kernel_wrapper()
+
+
+def check_kernel_wrapper(kernel_name="lean4-wsl"):
+    """Verifie que kernel.json pointe vers le bon wrapper Python (v5), pas l'ancien bash.
+
+    Detecte la regression du 2026-05-27 (issue #1618). Logique canonique partagee via
+    scripts/lean/lean_kernel_check.py (auparavant absente de ce validateur GameTheory).
+    """
+    if _inspect_kernel_wrapper is None:
+        print_warning("kernel.json: helper lean_kernel_check introuvable (check ignore)")
+        return True
+    status, message = _inspect_kernel_wrapper(kernel_name)
+    {"ok": print_ok, "error": print_error, "warning": print_warning}[status](message)
+    return status == "ok"
+
+
 def check_social_choice_lean():
     """Verifie que le projet Lake social_choice_lean existe"""
     project_path = Path(__file__).parent.parent / "social_choice_lean"
@@ -184,6 +219,7 @@ def validate_windows():
     # Kernels Lean
     checks.append(check_jupyter_kernel("lean4"))
     checks.append(check_jupyter_kernel("lean4-wsl"))
+    checks.append(check_kernel_wrapper("lean4-wsl"))
 
     # Projets Lean
     checks.append(check_social_choice_lean())

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/validate_lean_setup.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/validate_lean_setup.py
@@ -132,46 +132,40 @@ def check_jupyter_kernel(kernel_name):
         return False
 
 
+def _load_inspect_kernel_wrapper():
+    """Import the canonical wrapper check from scripts/lean/lean_kernel_check.py.
+
+    Returns None if the shared helper cannot be located (graceful degradation).
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "scripts" / "lean" / "lean_kernel_check.py"
+        if candidate.exists():
+            sys.path.insert(0, str(candidate.parent))
+            try:
+                from lean_kernel_check import inspect_kernel_wrapper
+                return inspect_kernel_wrapper
+            except Exception:
+                return None
+    return None
+
+
+_inspect_kernel_wrapper = _load_inspect_kernel_wrapper()
+
+
 def check_kernel_wrapper(kernel_name="lean4-wsl"):
     """Verifie que kernel.json pointe vers le bon wrapper Python (v5), pas l'ancien bash.
 
-    Detecte la regression du 2026-05-27 (issue #1618) ou kernel.json pointait vers
-    l'ancien wrapper ~/lean4-jupyter-wrapper.sh au lieu de ~/.lean4-kernel-wrapper.py.
+    Detecte la regression du 2026-05-27 (issue #1618). La logique canonique vit dans
+    scripts/lean/lean_kernel_check.py (source unique partagee avec setup_lean4_all.py
+    et le validateur GameTheory).
     """
-    import json
-
-    candidates = [
-        Path.home() / ".local" / "share" / "jupyter" / "kernels" / kernel_name / "kernel.json",
-    ]
-    appdata = os.environ.get("APPDATA")
-    if appdata:
-        candidates.append(Path(appdata) / "jupyter" / "kernels" / kernel_name / "kernel.json")
-
-    kernel_json = next((p for p in candidates if p.exists()), None)
-    if kernel_json is None:
-        print_warning(f"kernel.json: aucun ({kernel_name}) trouve dans {[str(p) for p in candidates]}")
-        return False
-
-    try:
-        with open(kernel_json, "r", encoding="utf-8") as f:
-            spec = json.load(f)
-        argv = " ".join(str(a) for a in spec.get("argv", []))
-    except Exception as e:
-        print_error(f"kernel.json: erreur lecture ({e})")
-        return False
-
-    if "lean4-jupyter-wrapper.sh" in argv:
-        print_error(
-            f"kernel.json: pointe vers ancien wrapper bash (lean4-jupyter-wrapper.sh) — "
-            "regression #1618. Re-executer setup_lean4_kernel.ps1 pour pointer "
-            "vers ~/.lean4-kernel-wrapper.py (v5)."
-        )
-        return False
-    if ".lean4-kernel-wrapper.py" in argv:
-        print_ok(f"kernel.json ({kernel_name}): wrapper Python v5 correct")
+    if _inspect_kernel_wrapper is None:
+        print_warning("kernel.json: helper lean_kernel_check introuvable (check ignore)")
         return True
-    print_warning(f"kernel.json ({kernel_name}): wrapper inconnu — argv={argv[:120]}")
-    return False
+    status, message = _inspect_kernel_wrapper(kernel_name)
+    {"ok": print_ok, "error": print_error, "warning": print_warning}[status](message)
+    return status == "ok"
 
 
 def check_env_file():

--- a/docs/wsl-kernels-detail.md
+++ b/docs/wsl-kernels-detail.md
@@ -44,6 +44,23 @@ python scripts/notebook_tools/wsl_papermill.py check-env
 - GT-1 Setup : 20/20 cells, 0 errors (3.3s)
 - GT-7 ExtensiveForm : 30/30 cells, 0 errors (2s)
 
+## Lean 4 — setup consolidé (issue #1618)
+
+Point d'entrée unique pour installer/valider le kernel `lean4-wsl` :
+
+```powershell
+python scripts/lean/setup_lean4_all.py              # WSL install + registration + validation
+python scripts/lean/setup_lean4_all.py --check-wrapper  # verifie kernel.json -> bon wrapper
+```
+
+La détection de la régression du 2026-05-27 (kernel.json pointant vers l'ancien wrapper bash `~/lean4-jupyter-wrapper.sh` au lieu du wrapper Python v5 `~/.lean4-kernel-wrapper.py`) est **centralisée** dans `scripts/lean/lean_kernel_check.py` (`inspect_kernel_wrapper`, print-agnostic). Les trois consommateurs y délèguent — plus de logique dupliquée/divergente :
+
+- `scripts/lean/setup_lean4_all.py` (`--check-wrapper`)
+- `MyIA.AI.Notebooks/SymbolicAI/Lean/scripts/validate_lean_setup.py`
+- `MyIA.AI.Notebooks/GameTheory/scripts/validate_lean_setup.py` (auparavant ne détectait PAS la régression)
+
+Test : `python scripts/lean/tests/test_lean_kernel_check.py` (4 cas : ancien bash → error, wrapper v5 → ok, inconnu / absent → warning).
+
 ## Notes complémentaires
 
 - Cold start .NET Interactive : premier démarrage peut timeout (30-60s), retry une fois

--- a/scripts/lean/lean_kernel_check.py
+++ b/scripts/lean/lean_kernel_check.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Canonical kernel.json wrapper check for the lean4-wsl Jupyter kernel.
+
+Single source of truth for detecting the 2026-05-27 regression (issue #1618)
+where ``kernel.json`` pointed to the OLD bash wrapper
+``~/lean4-jupyter-wrapper.sh`` instead of the CORRECT Python wrapper
+``~/.lean4-kernel-wrapper.py`` (v5). The bash wrapper lacks Windows->WSL path
+conversion and NTFS permission handling, so the kernel times out at startup.
+
+Before this module the same check lived (divergently) in three places:
+  - scripts/lean/setup_lean4_all.py            (check_wrapper_registration)
+  - SymbolicAI/Lean/scripts/validate_lean_setup.py (check_kernel_wrapper)
+  - GameTheory/scripts/validate_lean_setup.py  (was MISSING entirely)
+
+``inspect_kernel_wrapper`` is print-agnostic: it returns a structured result so
+each caller can format it with its own style (unicode / ASCII / section header).
+
+Usage as a module:
+    from lean_kernel_check import inspect_kernel_wrapper
+    status, message = inspect_kernel_wrapper("lean4-wsl")
+
+Usage as a CLI:
+    python scripts/lean/lean_kernel_check.py            # check lean4-wsl
+    python scripts/lean/lean_kernel_check.py --kernel lean4-wsl
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+OLD_BASH_WRAPPER = "lean4-jupyter-wrapper.sh"
+CORRECT_PY_WRAPPER = ".lean4-kernel-wrapper.py"
+
+
+def candidate_kernel_json_paths(kernel_name="lean4-wsl"):
+    """Return the kernel.json locations to probe, in priority order.
+
+    Covers both the WSL-side install (~/.local/share/jupyter) and the
+    Windows-side registration (%APPDATA%/jupyter).
+    """
+    candidates = [
+        Path.home() / ".local" / "share" / "jupyter" / "kernels" / kernel_name / "kernel.json",
+    ]
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "jupyter" / "kernels" / kernel_name / "kernel.json")
+    return candidates
+
+
+def inspect_kernel_wrapper(kernel_name="lean4-wsl", kernel_json_path=None):
+    """Inspect kernel.json and classify the wrapper it points to.
+
+    Returns a ``(status, message)`` tuple where ``status`` is one of:
+      - "ok"      : kernel.json points to the correct Python wrapper (v5)
+      - "error"   : kernel.json points to the old bash wrapper (regression #1618)
+      - "warning" : kernel.json not found, unreadable, or unknown argv
+
+    ``kernel_json_path`` overrides the auto-detected location (used by tests).
+    """
+    if kernel_json_path is not None:
+        kernel_json = Path(kernel_json_path)
+        candidates = [kernel_json]
+    else:
+        candidates = candidate_kernel_json_paths(kernel_name)
+        kernel_json = next((p for p in candidates if p.exists()), None)
+
+    if kernel_json is None or not kernel_json.exists():
+        probed = [str(p) for p in candidates]
+        return ("warning", f"kernel.json: aucun ({kernel_name}) trouve dans {probed}")
+
+    try:
+        with open(kernel_json, "r", encoding="utf-8") as f:
+            spec = json.load(f)
+        argv = " ".join(str(a) for a in spec.get("argv", []))
+    except Exception as exc:  # noqa: BLE001 - report any read/parse failure as a warning
+        return ("warning", f"kernel.json ({kernel_name}): erreur lecture ({exc})")
+
+    if OLD_BASH_WRAPPER in argv:
+        return (
+            "error",
+            f"kernel.json ({kernel_name}): pointe vers l'ancien wrapper bash "
+            f"({OLD_BASH_WRAPPER}) — regression #1618. Re-executer "
+            "`python scripts/lean/setup_lean4_all.py --register` pour pointer "
+            f"vers ~/{CORRECT_PY_WRAPPER} (v5).",
+        )
+    if CORRECT_PY_WRAPPER in argv:
+        return ("ok", f"kernel.json ({kernel_name}): wrapper Python v5 correct")
+    return ("warning", f"kernel.json ({kernel_name}): wrapper inconnu — argv={argv[:120]}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verifie que kernel.json pointe vers le bon wrapper Lean 4 (issue #1618)."
+    )
+    parser.add_argument("--kernel", default="lean4-wsl", help="Nom du kernel (defaut: lean4-wsl)")
+    args = parser.parse_args()
+
+    status, message = inspect_kernel_wrapper(args.kernel)
+    prefix = {"ok": "OK:", "error": "ERROR:", "warning": "WARNING:"}[status]
+    print(f"{prefix} {message}")
+    sys.exit(0 if status == "ok" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lean/setup_lean4_all.py
+++ b/scripts/lean/setup_lean4_all.py
@@ -15,11 +15,14 @@ Usage:
 """
 
 import argparse
-import json
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+# Canonical wrapper-regression check (issue #1618) lives in this same dir.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lean_kernel_check import inspect_kernel_wrapper  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GT_SCRIPTS = REPO_ROOT / "MyIA.AI.Notebooks" / "GameTheory" / "scripts"
@@ -110,44 +113,21 @@ def step_validate():
 
 
 def check_wrapper_registration():
-    """Check that kernel.json points to the CORRECT Python wrapper (not old bash)."""
+    """Check that kernel.json points to the CORRECT Python wrapper (not old bash).
+
+    Classification is delegated to the canonical helper
+    ``scripts/lean/lean_kernel_check.inspect_kernel_wrapper`` (issue #1618), which
+    probes both the WSL-side (~/.local/share/jupyter) and Windows-side (%APPDATA%)
+    kernel.json locations.
+    """
     print("=" * 60)
     print("CHECK: kernel.json wrapper registration")
     print("=" * 60)
 
-    kernel_path = Path.home() / "AppData" / "Roaming" / "jupyter" / "kernels" / "lean4-wsl"
-    kernel_json = kernel_path / "kernel.json"
-
-    if not kernel_json.exists():
-        print(f"ERROR: kernel.json not found at {kernel_json}")
-        print("  Run: python scripts/lean/setup_lean4_all.py --register")
-        return False
-
-    with open(kernel_json, encoding="utf-8") as f:
-        config = json.load(f)
-
-    argv = config.get("argv", [])
-    cmd_str = " ".join(argv)
-
-    print(f"kernel.json location: {kernel_json}")
-    print(f"argv: {cmd_str}")
-
-    # Check: must contain the Python wrapper, NOT the old bash wrapper
-    has_python_wrapper = any("lean4-kernel-wrapper.py" in a for a in argv)
-    has_old_bash_wrapper = any("lean4-jupyter-wrapper.sh" in a for a in argv)
-
-    if has_old_bash_wrapper:
-        print("ERROR: kernel.json points to OLD bash wrapper (lean4-jupyter-wrapper.sh)")
-        print("  The bash wrapper lacks Windows->WSL path conversion and will fail.")
-        print("  Fix: python scripts/lean/setup_lean4_all.py --register")
-        return False
-
-    if has_python_wrapper:
-        print("OK: kernel.json points to correct Python wrapper (.lean4-kernel-wrapper.py)")
-        return True
-
-    print(f"WARNING: kernel.json has unexpected argv. Expected .lean4-kernel-wrapper.py")
-    return False
+    status, message = inspect_kernel_wrapper("lean4-wsl")
+    prefix = {"ok": "OK:", "error": "ERROR:", "warning": "WARNING:"}[status]
+    print(f"{prefix} {message}")
+    return status == "ok"
 
 
 def main():

--- a/scripts/lean/tests/test_lean_kernel_check.py
+++ b/scripts/lean/tests/test_lean_kernel_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Tests for the canonical Lean 4 kernel wrapper check (issue #1618).
+
+Verifies that ``inspect_kernel_wrapper`` correctly classifies a kernel.json as:
+  - "error"   when it points to the OLD bash wrapper (the #1618 regression)
+  - "ok"      when it points to the CORRECT Python wrapper (v5)
+  - "warning" when the wrapper is unknown or the file is missing
+
+Run directly (no pytest needed):
+    python scripts/lean/tests/test_lean_kernel_check.py
+
+Or via pytest:
+    pytest scripts/lean/tests/test_lean_kernel_check.py
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from lean_kernel_check import inspect_kernel_wrapper  # noqa: E402
+
+
+def _write_kernel_json(tmpdir, argv):
+    path = Path(tmpdir) / "kernel.json"
+    path.write_text(json.dumps({"argv": argv, "display_name": "Lean 4 (WSL)"}), encoding="utf-8")
+    return path
+
+
+def test_old_bash_wrapper_is_error():
+    with tempfile.TemporaryDirectory() as tmp:
+        kj = _write_kernel_json(tmp, [
+            "wsl.exe", "-d", "Ubuntu", "--", "bash", "/home/jesse/lean4-jupyter-wrapper.sh",
+            "-f", "{connection_file}",
+        ])
+        status, message = inspect_kernel_wrapper("lean4-wsl", kernel_json_path=kj)
+        assert status == "error", message
+        assert "lean4-jupyter-wrapper.sh" in message
+
+
+def test_python_wrapper_is_ok():
+    with tempfile.TemporaryDirectory() as tmp:
+        kj = _write_kernel_json(tmp, [
+            "wsl.exe", "-d", "Ubuntu", "--",
+            "/home/jesse/.lean4-venv/bin/python3", "/home/jesse/.lean4-kernel-wrapper.py",
+            "-f", "{connection_file}",
+        ])
+        status, message = inspect_kernel_wrapper("lean4-wsl", kernel_json_path=kj)
+        assert status == "ok", message
+
+
+def test_unknown_wrapper_is_warning():
+    with tempfile.TemporaryDirectory() as tmp:
+        kj = _write_kernel_json(tmp, ["python", "-m", "some_other_kernel", "-f", "{connection_file}"])
+        status, message = inspect_kernel_wrapper("lean4-wsl", kernel_json_path=kj)
+        assert status == "warning", message
+
+
+def test_missing_file_is_warning():
+    missing = Path(tempfile.gettempdir()) / "definitely-not-a-kernel-1618" / "kernel.json"
+    status, message = inspect_kernel_wrapper("lean4-wsl", kernel_json_path=missing)
+    assert status == "warning", message
+
+
+def _run_all():
+    tests = [
+        test_old_bash_wrapper_is_error,
+        test_python_wrapper_is_ok,
+        test_unknown_wrapper_is_warning,
+        test_missing_file_is_warning,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {t.__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(1 if _run_all() else 0)


### PR DESCRIPTION
## Summary

Closes the residual tech-debt of issue #1618 (Consolidate Lean 4 kernel setup scripts). The single entry point (`scripts/lean/setup_lean4_all.py`) and the wrapper-regression detection (PR #1689) already existed, but the **detection logic was duplicated in 3 divergent places** — and the GameTheory validator was **missing it entirely**:

| Location | Before |
|----------|--------|
| `scripts/lean/setup_lean4_all.py` → `check_wrapper_registration()` | AppData-only |
| `SymbolicAI/Lean/scripts/validate_lean_setup.py` → `check_kernel_wrapper()` | most complete (`~/.local/share` + `%APPDATA%`) |
| `GameTheory/scripts/validate_lean_setup.py` | **absent** — a GameTheory user did NOT detect the #1618 regression |

## Change

- **New** `scripts/lean/lean_kernel_check.py` — single source of truth: `inspect_kernel_wrapper()` is print-agnostic (returns `(status, message)`), probes both WSL-side and Windows-side `kernel.json`. Also runnable standalone (`python scripts/lean/lean_kernel_check.py`).
- The 3 consumers now **delegate** to it (no more divergence). GameTheory's `validate_windows()` now includes the check → **#1618 gap closed**.
- **New** `scripts/lean/tests/test_lean_kernel_check.py` — 4 cases (old bash → error, v5 wrapper → ok, unknown / missing → warning). Runnable without pytest.
- Docs: `docs/wsl-kernels-detail.md` + `MyIA.AI.Notebooks/GameTheory/scripts/README.md`.

## Verification (run locally on myia-po-2025, lean4-wsl kernel present)

- `python scripts/lean/tests/test_lean_kernel_check.py` → **4/4 passed**
- `python scripts/lean/lean_kernel_check.py` → `OK: wrapper Python v5 correct`
- `python scripts/lean/setup_lean4_all.py --check-wrapper` → OK (delegates)
- canonical validator → **13/13 OK** (unicode ✓ style preserved)
- GameTheory validator → `[OK] kernel.json (lean4-wsl): wrapper Python v5 correct` (ASCII style preserved); 12/13 total — the **sole** failure is pre-existing `nashpy: Non installe` (env package, unrelated to this change)

## Scope / anti-collision

- **No `*.lean` files touched** — pure infra Python + docs. Orthogonal to the Conway/KS proof work (Lake-build discipline N/A).
- Single feature, single domain (Lean kernel setup tooling). +292/-70 (deletions = removed duplicated logic; functionality preserved & verified).
- Acceptance criteria #1618: single entry point ✓ (pre-existing), validation detects wrong wrapper ✓ (now in **all** validators), docs updated ✓. (Machine-local "remove old wrapper" is per-machine, out of repo scope.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>