### PR TITLE
feat(ml-pipeline): propagate auto_fetch through sweeps L1/L2/L4/L6 + MoE (#1409)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1_tsmom.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1_tsmom.py
@@ -351,6 +351,9 @@ def main():
     parser.add_argument("--gap", type=int, default=21, help="WF gap (trading days)")
     parser.add_argument("--stress", action="store_true",
                         help="Run 50bps stress test alongside normal")
+    parser.add_argument("--no-auto-fetch", action="store_true",
+                        help="Skip yfinance fallback for missing panier symbols "
+                             "(default: auto-fetch on, see PR #1726)")
     args = parser.parse_args()
 
     print("L1 TSMOM Baseline — Anti-Bias Panier (26 symbols, 7 asset classes)")
@@ -370,7 +373,7 @@ def main():
         )
     else:
         print("\nLoading panier data...")
-        closes = load_panier_closes()
+        closes = load_panier_closes(auto_fetch=not args.no_auto_fetch)
         closes = closes.dropna(how="all")
         print(f"  Loaded {len(closes.columns)} symbols, {len(closes)} rows "
               f"({closes.index.min().date()} -> {closes.index.max().date()})")

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L2_dual_momentum.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L2_dual_momentum.py
@@ -401,6 +401,9 @@ def main():
     parser.add_argument("--top-n", type=int, default=TOP_N)
     parser.add_argument("--n-splits", type=int, default=5)
     parser.add_argument("--gap", type=int, default=21)
+    parser.add_argument("--no-auto-fetch", action="store_true",
+                        help="Skip yfinance fallback for missing panier symbols "
+                             "(default: auto-fetch on, see PR #1726)")
     args = parser.parse_args()
 
     print("L2 Cross-Sectional + Dual Momentum — Anti-Bias Panier")
@@ -414,7 +417,7 @@ def main():
             index=dates, columns=["SPY", "TLT", "GLD", "BTC-USD", "EFA", "SHY", "XLF", "EEM"],
         )
     else:
-        closes = load_panier_closes().dropna(how="all")
+        closes = load_panier_closes(auto_fetch=not args.no_auto_fetch).dropna(how="all")
         forbidden = set(closes.columns) & {"AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "TSLA", "META"}
         if forbidden:
             closes = closes.drop(columns=list(forbidden))

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py
@@ -209,10 +209,15 @@ def load_panier_closes(
     start: str | None = None,
     end: str | None = None,
     panier_dir: Path | None = None,
+    auto_fetch: bool = False,
 ) -> pd.DataFrame:
     """Load aligned close prices for panier symbols.
 
     Returns DataFrame indexed by Date with columns = symbols.
+
+    auto_fetch: when True, missing per-symbol CSVs are fetched via yfinance
+    (lazy import) before assembly. The pre-computed summary path always
+    bypasses fetch — delete panier_close_all.csv to force per-symbol rebuild.
     """
     panier_dir = panier_dir or PANIER_DIR
 
@@ -227,7 +232,13 @@ def load_panier_closes(
         return df
 
     # Build from individual files
-    data = load_panier(group=group, start=start, end=end, panier_dir=panier_dir)
+    data = load_panier(
+        group=group,
+        start=start,
+        end=end,
+        panier_dir=panier_dir,
+        auto_fetch=auto_fetch,
+    )
     closes = {}
     for symbol, df in data.items():
         if "Close" in df.columns:
@@ -243,12 +254,21 @@ def load_panier_returns(
     start: str | None = None,
     end: str | None = None,
     panier_dir: Path | None = None,
+    auto_fetch: bool = False,
 ) -> pd.DataFrame:
     """Load aligned daily returns for panier symbols.
 
     Returns DataFrame of pct_change() values, dropping the first row.
+
+    auto_fetch: propagated to load_panier_closes().
     """
-    closes = load_panier_closes(group=group, start=start, end=end, panier_dir=panier_dir)
+    closes = load_panier_closes(
+        group=group,
+        start=start,
+        end=end,
+        panier_dir=panier_dir,
+        auto_fetch=auto_fetch,
+    )
     return closes.pct_change().dropna()
 
 

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l4_decision_transformer.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l4_decision_transformer.py
@@ -335,6 +335,9 @@ def main():
                         help="Quick test: 2 symbols, 2 seeds, 2 epochs")
     parser.add_argument("--output", type=str, default=None,
                         help="Output path for results JSON")
+    parser.add_argument("--no-auto-fetch", action="store_true",
+                        help="Skip yfinance fallback for missing panier symbols "
+                             "(default: auto-fetch on, see PR #1726)")
     args = parser.parse_args()
 
     # Device
@@ -362,8 +365,8 @@ def main():
     print(f"  WF folds={args.n_splits}, epochs/fold={args.epochs_per_fold}, "
           f"commission={args.commission_bps}bps")
 
-    # Load panier
-    panier = load_panier(start="2015-01-01")
+    # Load panier (auto_fetch missing CSVs via yfinance unless --no-auto-fetch)
+    panier = load_panier(start="2015-01-01", auto_fetch=not args.no_auto_fetch)
     loaded_symbols = [s for s in symbols if s in panier]
     if len(loaded_symbols) < len(symbols):
         missing = [s for s in symbols if s not in panier]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l6_dt_extension.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l6_dt_extension.py
@@ -1119,6 +1119,12 @@ def main():
     parser.add_argument(
         "--output", type=str, default=None, help="Output path for results JSON"
     )
+    parser.add_argument(
+        "--no-auto-fetch",
+        action="store_true",
+        help="Skip yfinance fallback for missing panier symbols "
+             "(default: auto-fetch on, see PR #1726)",
+    )
     args = parser.parse_args()
 
     # Device
@@ -1163,8 +1169,8 @@ def main():
     print(f"  Architecture: DualHeadDT (d={args.d_model}, h={args.nhead}, "
           f"L={args.num_layers}, ctx={args.context_length})")
 
-    # Load panier
-    panier = load_panier(start="2015-01-01")
+    # Load panier (auto_fetch missing CSVs via yfinance unless --no-auto-fetch)
+    panier = load_panier(start="2015-01-01", auto_fetch=not args.no_auto_fetch)
     loaded_symbols = [s for s in symbols if s in panier]
     if len(loaded_symbols) < len(symbols):
         missing = [s for s in symbols if s not in panier]

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_moe.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_moe.py
@@ -172,7 +172,7 @@ def _train_moe_panier(
     symbols = get_panier_symbols(group=panier_group)
     log.info(f"PANIER mode: loading {len(symbols)} symbols from group '{panier_group or 'all'}'")
 
-    panier = load_panier(group=panier_group, start=start, end=end)
+    panier = load_panier(group=panier_group, start=start, end=end, auto_fetch=True)
     loaded = {s: df for s, df in panier.items() if len(df) >= 500}
     log.info(f"Loaded {len(loaded)}/{len(symbols)} symbols with >= 500 rows")
 


### PR DESCRIPTION
## Summary

Cycle 7 follow-up of PR #1726 (panier_loader yfinance lazy fallback).
Single-PR concentre, additive only, +44/-9 across 6 files.

- `load_panier_closes()` and `load_panier_returns()` in [panier_loader.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/panier_loader.py) now accept `auto_fetch=False`, propagated to `load_panier()`.
- 4 sweep scripts get a new `--no-auto-fetch` CLI flag (auto-fetch ON by default):
  - [sweep_l4_decision_transformer.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l4_decision_transformer.py) (L4 DT BEATS 24/26 reproducible)
  - [sweep_l6_dt_extension.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/sweep_l6_dt_extension.py) (L6 DT extension, dual-head + cost-aware)
  - [L1_tsmom.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L1_tsmom.py) (TSMOM baseline)
  - [L2_dual_momentum.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/L2_dual_momentum.py) (cross-sectional + dual momentum)
- [train_moe.py](MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_moe.py) `_train_moe_panier()` bulk load sets `auto_fetch=True` (no CLI flag; bulk training path always wants the fetch attempt). Single-symbol fallback paths and `train_transformer.py:418-419` left untouched — `data_sources` fallback already covers them.

## Smoke tests (verified)

```
$ python -c "from panier_loader import load_panier_closes, load_panier_returns; ..."
load_panier:         ...auto_fetch: 'bool' = False...
load_panier_closes:  ...auto_fetch: 'bool' = False...
load_panier_returns: ...auto_fetch: 'bool' = False...

$ python sweep_l4_decision_transformer.py --help
  --no-auto-fetch       Skip yfinance fallback for missing panier symbols
$ python sweep_l6_dt_extension.py --help
  --no-auto-fetch       Skip yfinance fallback ...
$ python L1_tsmom.py --help
  --no-auto-fetch       Skip yfinance fallback ...
$ python L2_dual_momentum.py --help
  --no-auto-fetch       Skip yfinance fallback ...
$ python -c "import train_moe; print('train_moe import OK')"
train_moe import OK
```

## Out of scope

5 scripts have local `load_panier` defs with different signatures (deeper refactor):
- `L3_trend_long_horizon_gpu.py`, `l1_tsmom_baseline.py`, `l2_cross_sectional_momentum.py`, `l3_regime_trend.py`, `build_dataset_v2.py`

## Why

Closes follow-up item from PR #1726 review. Unblocks any panier sweep where the 26-symbol roster is incomplete on the local data dir — the previous behavior was a silent `continue` on missing CSVs; now the missing roster is auto-fetched via yfinance on first sweep (lazy import), and the `--no-auto-fetch` flag preserves the prior strict behavior when needed.

## Test plan

- [x] Signatures verified (3 helpers accept `auto_fetch`)
- [x] 4 sweep `--help` print `--no-auto-fetch`
- [x] `train_moe.py` imports clean
- [ ] Optional: smoke-run L1_tsmom.py with `--no-auto-fetch` to confirm pre-existing behavior unchanged (skipped here — relies on full panier; CI doesn't have yfinance hits anyway)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)