### PR TITLE
docs(semweb): replace "Statut de maturite" table with Acquis d'apprentissage (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -260,27 +260,17 @@ Ce notebook bonus compare differents raisonneurs OWL (owlrl, HermiT, reasonable,
 
 ---
 
-## Statut de maturite
+## Acquis d'apprentissage
 
-| # | Notebook | Kernel | Cellules | Exercices | Statut |
-|---|----------|--------|----------|-----------|--------|
-| 1 | SW-1-CSharp-Setup | .NET | 18 | - | **COMPLET** |
-| 2 | SW-2-CSharp-RDFBasics | .NET | 48 | 2 | **COMPLET** |
-| 2b | SW-2b-Python-RDFBasics | Python | 30 | 2 | **COMPLET** |
-| 3 | SW-3-CSharp-GraphOperations | .NET | 34 | 3 | **COMPLET** |
-| 4 | SW-4-CSharp-SPARQL | .NET | 36 | 3 | **COMPLET** |
-| 4b | SW-4b-Python-SPARQL | Python | 25 | 2 | **COMPLET** |
-| 5 | SW-5-CSharp-LinkedData | .NET | 38 | 3 | **COMPLET** |
-| 5b | SW-5b-Python-LinkedData | Python | 25 | 2 | **COMPLET** |
-| 6 | SW-6-CSharp-RDFS | .NET | 33 | 2 | **COMPLET** |
-| 7 | SW-7-CSharp-OWL | .NET | 35 | 2 | **COMPLET** |
-| 7b | SW-7b-Python-OWL | Python | 30 | 2 | **COMPLET** |
-| 8 | SW-8-Python-SHACL | Python | 43 | 3 | **COMPLET** |
-| 9 | SW-9-Python-JSONLD | Python | 60 | 3 | **COMPLET** |
-| 10 | SW-10-Python-RDFStar | Python | 52 | 2 | **COMPLET** |
-| 11 | SW-11-Python-KnowledgeGraphs | Python | 75 | 3 | **COMPLET** |
-| 12 | SW-12-Python-GraphRAG | Python | 44 | 3 | **COMPLET** |
-| 13 | SW-13-Python-Reasoners (bonus) | Python | 38 | 3 | **COMPLET** |
+A l'issue de cette serie, l'apprenant est capable de :
+
+- **Modeliser un domaine en RDF** (triplets, IRIs, litteraux typees, namespaces) et manipuler des graphes en C# avec dotNetRDF (`SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`) ou en Python avec rdflib (`SW-2b-Python-RDFBasics.ipynb`).
+- **Interroger un graphe en SPARQL 1.1** (SELECT, CONSTRUCT, ASK, DESCRIBE, federations via SERVICE) cote .NET (`SW-4-CSharp-SPARQL.ipynb`) et Python (`SW-4b-Python-SPARQL.ipynb`), puis publier des donnees Linked Data resolvables (`SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`).
+- **Formaliser une ontologie en RDFS puis OWL** (classes, proprietes, restrictions, hierarchies) et tirer parti d'un raisonneur pour materialiser les inferences (`SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`).
+- **Valider la conformite d'un graphe** avec SHACL (NodeShapes/PropertyShapes, contraintes de cardinalite et de type, rapport de validation) via pySHACL (`SW-8-Python-SHACL.ipynb`).
+- **Serialiser et echanger des donnees RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interoperer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
+- **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modeliser metadonnees et reification compacte (`SW-10-Python-RDFStar.ipynb`).
+- **Construire et exploiter un graphe de connaissances integre a un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les reponses generatives sur des donnees structurees (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the 17-row "Statut de maturite" table (lines L263-L282 of `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md`) with a 7-bullet "Acquis d'apprentissage" section ancrée sur les notebooks reels de la serie.

Part of Epic #1657 (anti-count-obsession). Follows the precedents:
- #1719 (SymbolicAI/Lean README dilution)
- #1717 (QuantConnect README dilution)

## What the diluted table claimed

A 17-row table cataloguing each notebook by:
- `#` / `Notebook` name / `Kernel` (.NET vs Python)
- `Cellules` count (18, 48, 30, 34, 36, 25, 38, 25, 33, 35, 30, 43, 60, 52, 75, 44, 38)
- `Exercices` count (-, 2, 2, 3, 3, 2, 3, 2, 2, 2, 2, 3, 3, 2, 3, 3, 3)
- `Statut` column where **every single row was "COMPLET"** (zero informational value, pure publication theater)

The kernel/exercise count overlap with the L17 "Vue d'ensemble" stat table (which is kept — that one carries genuine info: kernel breakdown, total duration, langage split). The cellules count is recoverable from the notebooks themselves and not actionable for a learner.

## What replaces it

7 "Acquis d'apprentissage" bullets that walk the learner through the progression :

1. Modeliser un domaine en RDF -> `SW-2-CSharp-RDFBasics.ipynb`, `SW-3-CSharp-GraphOperations.ipynb`, `SW-2b-Python-RDFBasics.ipynb`
2. Interroger en SPARQL 1.1 + publier Linked Data -> `SW-4-CSharp-SPARQL.ipynb`, `SW-4b-Python-SPARQL.ipynb`, `SW-5-CSharp-LinkedData.ipynb`, `SW-5b-Python-LinkedData.ipynb`
3. Formaliser une ontologie en RDFS/OWL + raisonneurs -> `SW-6-CSharp-RDFS.ipynb`, `SW-7-CSharp-OWL.ipynb`, `SW-7b-Python-OWL.ipynb`, `SW-13-Python-Reasoners.ipynb`
4. Valider un graphe avec SHACL -> `SW-8-Python-SHACL.ipynb`
5. Serialiser/echanger en JSON-LD -> `SW-9-Python-JSONLD.ipynb`
6. Annoter avec RDF-Star / SPARQL-Star -> `SW-10-Python-RDFStar.ipynb`
7. Graphe de connaissances + GraphRAG -> `SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`

Each bullet cites the concrete notebook(s) so the table-as-index function is preserved without the "COMPLET" theater.

## Scope discipline

- Docs-only PR, one file modified: `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md`
- `git diff --stat`: **+11 / -21 lines** (net dilution, removing noise)
- The L17 "Vue d'ensemble" 5-row stat table is **untouched** (it carries kernel/langage/duree info that is informative)
- No other section modified, no notebook touched, no Lean/code file touched
- Linked Epic: #1657

## Test plan

- [x] Branch starts from `origin/main` via `git worktree`
- [x] Single file changed, single section replaced
- [x] Notebook filenames cited match `ls MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/*.ipynb`
- [x] No emojis (per `.claude/rules/code-style.md`)
- [x] Conventional commit
- [ ] Coordinator merge (po-2026 does not self-merge per CLAUDE.md section A)

Epic: #1657
Precedents: #1719 #1717

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>