### PR TITLE
docs(planners): drop Statut column from Partie tables (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -18,41 +18,41 @@ A l'issue de cette serie, vous saurez :
 
 ### Partie 0 : Environnement (00-Environment/)
 
-| # | Notebook | Kernel | Contenu | Duree | Statut |
-|---|----------|--------|---------|-------|--------|
-| 0 | [Planners-0-Setup](00-Environment/Planners-0-Setup.ipynb) | Python | Installation unified-planning, OR-Tools, Docker Fast Downward | 20 min | COMPLET |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 0 | [Planners-0-Setup](00-Environment/Planners-0-Setup.ipynb) | Python | Installation unified-planning, OR-Tools, Docker Fast Downward | 20 min |
 
 ### Partie 1 : Fondations (01-Foundation/)
 
-| # | Notebook | Kernel | Contenu | Duree | Statut |
-|---|----------|--------|---------|-------|--------|
-| 1 | [Planners-1-Introduction](01-Foundation/Planners-1-Introduction.ipynb) | Python | Concepts, modele STRIPS, triptyque Etat-Action-But | 30 min | COMPLET |
-| 2 | [Planners-2-PDDL-Basics](01-Foundation/Planners-2-PDDL-Basics.ipynb) | Python | Syntaxe PDDL, domaines, problemes, predicats, actions | 40 min | COMPLET |
-| 3 | [Planners-3-State-Space](01-Foundation/Planners-3-State-Space.ipynb) | Python | Espaces d'etats, graphes de recherche, explosion combinatoire | 35 min | COMPLET |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 1 | [Planners-1-Introduction](01-Foundation/Planners-1-Introduction.ipynb) | Python | Concepts, modele STRIPS, triptyque Etat-Action-But | 30 min |
+| 2 | [Planners-2-PDDL-Basics](01-Foundation/Planners-2-PDDL-Basics.ipynb) | Python | Syntaxe PDDL, domaines, problemes, predicats, actions | 40 min |
+| 3 | [Planners-3-State-Space](01-Foundation/Planners-3-State-Space.ipynb) | Python | Espaces d'etats, graphes de recherche, explosion combinatoire | 35 min |
 
 ### Partie 2 : Planification Classique (02-Classical/)
 
-| # | Notebook | Kernel | Contenu | Duree | Statut |
-|---|----------|--------|---------|-------|--------|
-| 4 | [Planners-4-Fast-Downward](02-Classical/Planners-4-Fast-Downward.ipynb) | Python | Architecture FD, Docker, A*, GBFS, EHC, heuristiques | 45 min | COMPLET |
-| 5 | [Planners-5-Heuristics](02-Classical/Planners-5-Heuristics.ipynb) | Python | h-add, h-max, h-FF, landmarks | 40 min | COMPLET |
-| 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min | COMPLET |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 4 | [Planners-4-Fast-Downward](02-Classical/Planners-4-Fast-Downward.ipynb) | Python | Architecture FD, Docker, A*, GBFS, EHC, heuristiques | 45 min |
+| 5 | [Planners-5-Heuristics](02-Classical/Planners-5-Heuristics.ipynb) | Python | h-add, h-max, h-FF, landmarks | 40 min |
+| 6 | [Planners-6-Domains](02-Classical/Planners-6-Domains.ipynb) | Python | Blocks World, Logistics, Gripper, Ferry, Hanoi | 50 min |
 
 ### Partie 3 : Approches Avancees (03-Advanced/)
 
-| # | Notebook | Kernel | Contenu | Duree | Statut |
-|---|----------|--------|---------|-------|--------|
-| 7 | [Planners-7-OR-Tools](03-Advanced/Planners-7-OR-Tools.ipynb) | Python | CP-SAT, programmation par contraintes, scheduling | 45 min | COMPLET |
-| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durees, parallelisme, ordonnancement | 40 min | COMPLET |
-| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, methodes, decomposition | 45 min | COMPLET |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 7 | [Planners-7-OR-Tools](03-Advanced/Planners-7-OR-Tools.ipynb) | Python | CP-SAT, programmation par contraintes, scheduling | 45 min |
+| 8 | [Planners-8-Temporal](03-Advanced/Planners-8-Temporal.ipynb) | Python | PDDL 2.1, durees, parallelisme, ordonnancement | 40 min |
+| 9 | [Planners-9-HTN](03-Advanced/Planners-9-HTN.ipynb) | Python | Hierarchical Task Networks, methodes, decomposition | 45 min |
 
 ### Partie 4 : Neuro-Symbolique (04-NeuroSymbolic/)
 
-| # | Notebook | Kernel | Contenu | Duree | Statut |
-|---|----------|--------|---------|-------|--------|
-| 10 | [Planners-10-LLM-Planning](04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb) | Python | LLMs pour la planification, prompting, plan repair | 50 min | COMPLET |
-| 11 | [Planners-11-Unified-Planning](04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb) | Python | Interface unifiee, multi-solveurs, comparaisons | 40 min | COMPLET |
-| 12 | [Planners-12-LOOP](04-NeuroSymbolic/Planners-12-LOOP.ipynb) | Python | Learning to Plan, modeles neuronaux pour heuristiques | 45 min | COMPLET |
+| # | Notebook | Kernel | Contenu | Duree |
+|---|----------|--------|---------|-------|
+| 10 | [Planners-10-LLM-Planning](04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb) | Python | LLMs pour la planification, prompting, plan repair | 50 min |
+| 11 | [Planners-11-Unified-Planning](04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb) | Python | Interface unifiee, multi-solveurs, comparaisons | 40 min |
+| 12 | [Planners-12-LOOP](04-NeuroSymbolic/Planners-12-LOOP.ipynb) | Python | Learning to Plan, modeles neuronaux pour heuristiques | 45 min |
 
 ---
 


### PR DESCRIPTION
## Summary

Anti-count-obsession dilution on `MyIA.AI.Notebooks/SymbolicAI/Planners/README.md`. Drops the `Statut` column from all 5 "Partie" tables — every row said "COMPLET", which signals "we shipped the TOC" rather than learning content. Identified as the #2 SymbolicAI dilution candidate after SemanticWeb.

## Precedents

- **PR #1719** (Lean) — "Statut de maturite" replaced by "Acquis d'apprentissage" bullets.
- **PR #1732** (SemanticWeb) — 17-row "COMPLET" table replaced by 7 pedagogical bullets ancres on notebooks.

This PR is a lighter cut: surgical column removal from the 5 existing Partie tables, preserving the per-notebook info (Kernel / Contenu / Duree) that is actually informative.

## Tables touched (5)

| Partie | Section | Rows |
|--------|---------|------|
| 0 | Environnement (00-Environment/) | 1 |
| 1 | Fondations (01-Foundation/) | 3 |
| 2 | Planification Classique (02-Classical/) | 3 |
| 3 | Approches Avancees (03-Advanced/) | 3 |
| 4 | Neuro-Symbolique (04-NeuroSymbolic/) | 3 |

## Removed noise

- 13 `COMPLET` cells (one per notebook row)
- 5 `Statut` column headers
- 5 `--------` separator cells

## Preserved (deliberately)

- Lines 1-14: pedagogical intro + Objectifs d'apprentissage.
- All other table columns: `#`, `Notebook`, `Kernel`, `Contenu`, `Duree`.
- "Niveaux de difficulte" table (Foundation / Intermediate / Advanced) — orthogonal pedagogical level info, not redundant with Partie ordering.
- Everything below: Quick Start, Prerequis, Installation, Technologies, Architecture, PDDL refs, Concepts cles, comparaisons, Ressources, ponts cross-series.

## Diff stat

`1 file changed, 23 insertions(+), 23 deletions(-)` — every replaced line has the noise stripped.

## Test plan

- [x] `git diff --stat` confirms 23/23 line replacement on README.md only
- [x] `git diff` confirms no `Statut` / `COMPLET` left in the 5 Partie tables
- [x] No `*.ipynb`, `*.lean`, `*.py` modified
- [ ] Markdown renders cleanly in GitHub preview (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)