### PR TITLE
docs(lean): restore maturity table removed by #1719 (additive mandate, Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -70,6 +70,27 @@ A l'issue de la serie, vous saurez :
 
 Pour l'etat formel detaille des modules support (preuves resolues vs `sorry` residuels), voir [LEAN_INVENTORY.md](../../GameTheory/LEAN_INVENTORY.md) et le [README du projet conway_lean](conway_lean/README.md).
 
+## Statut de maturite
+
+| # | Notebook | Cellules | Exercices | Solutions | Statut |
+|---|----------|----------|-----------|-----------|--------|
+| 1 | Setup | ~17 | - | - | **COMPLET** |
+| 2 | Dependent-Types | ~50 | 3 | 3 | **COMPLET** |
+| 3 | Propositions-Proofs | ~50 | 3 | 3 | **COMPLET** |
+| 4 | Quantifiers | ~46 | 3 | 3 | **COMPLET** |
+| 5 | Tactics | ~70 | 3 | 3 | **COMPLET** |
+| 6 | Mathlib-Essentials | ~45 | 3 | 3 | **COMPLET** |
+| 7 | LLM-Integration | ~50 | 2 | 2 | **COMPLET** |
+| 7b | Examples | ~40 | 3 | 3 | **COMPLET** |
+| 8 | Agentic-Proving | ~70 | 2 | 2 | **COMPLET** |
+| 9 | SK-Multi-Agents | ~50 | 2 | 2 | **COMPLET** |
+| 10 | LeanDojo | ~100 | 2 | 0 | **COMPLET** |
+| 11 | TorchLean | ~40 | 3 | Oui | **COMPLET** |
+| 11a | TorchLean Python | ~45 | 3 | Oui | **COMPLET** |
+| 12 | Sensitivity-Theorem | ~31 | 4 | Non | **NOUVEAU** |
+| 13 | Grothendieck-Tribute | ~23 | 0 | - | **NOUVEAU** (hommage) |
+| 15 | Kochen-Specker | ~25 | 1 | 0 | **NOUVEAU** |
+
 Tous les notebooks incluent :
 - Navigation header/footer avec liens vers notebooks precedent/suivant
 - Plan de ce Notebook avec liens ancres (notebooks 2-4)


### PR DESCRIPTION
## Contexte — enforcement du recadrage user 2026-05-29 (mode strictement additif)

#1719 (mergé 2026-05-28T23:21Z) a **supprimé** la table "Statut de maturité" 16 lignes du README Lean (`SymbolicAI/Lean/README.md`, +12/-20) en la remplaçant par une section "Acquis d'apprentissage". C'est une **régression** vs la direction explicite du user : « je t'ai pas dit de virer trop de trucs, **plutôt d'en ajouter** », décision **« Restaurer la table »** pour le cas identique de GameTheory (#1722).

3e occurrence du pattern de suppression (avec #1711 corrigé en interne + #1732 corrigé avant merge ce cycle). Cette PR ferme le dernier cas **déjà mergé** sur main.

## Changement (additif, +21 / -0)

- **RESTAURE** `## Statut de maturité` (16 lignes : Lean-1→15, Cellules/Exercices/Solutions/Statut) — verbatim de l'état pré-#1719.
- **CONSERVE** la section "Acquis d'apprentissage" ajoutée par #1719 — les deux cohabitent (modèle GameTheory #1722, SemanticWeb #1732).

## Vérification

- ` expand_catalog_markers.py --check ` → "All markers up-to-date" (marker non touché)
- diff **+21/-0** — purement additif, 0 suppression
- **Anti-collision** : aucun PR ouvert sur `SymbolicAI/Lean/README.md` (#1714 et #1704 touchent `conway_lean/README.md`, fichier distinct). po-2026 travaille sur les `.lean`/conway_lean, pas ce README top-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)