### PR TITLE
test: register orphaned CI-safe unit suites (GameTheory + DataScience) in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ testpaths =
     tests
     scripts/notebook_tools/tests
     scripts/lean/tests
+    MyIA.AI.Notebooks/GameTheory/tests
+    MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests
 pythonpath =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts


### PR DESCRIPTION
## Summary

Follow-up to #1734. Two existing, **green** unit suites were never collected by CI because they were absent from `pytest.ini` `testpaths` — so regressions in them would go unnoticed (the same silent-drift class that left 10 catalog tests broken in #1734):

| Suite | Tests | Runtime deps |
|-------|------:|--------------|
| `MyIA.AI.Notebooks/GameTheory/tests` | 69 | numpy + scipy + stdlib |
| `MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests` | 2 | numpy + pandas |

Both need **only deps the ML CI already installs** (numpy/pandas/scipy/sklearn/arch/xgboost/joblib/pyarrow). Verified there are **no runtime calls to lean/lake/wsl/nashpy**:
- `game_theory_utils` uses `scipy.optimize.linprog` (no nashpy);
- `test_lean_definitions` does static `.lean` **file-structure** checks with a graceful `lean_runner` import fallback (no `lake`/`wsl` invocation).

## Verification

Combined run of all newly-registered non-ML suites (notebook_tools + lean + GameTheory + DataScience): **342 passed** (no cross-suite import collisions under `--import-mode importlib`). GameTheory alone: 69 passed; DataScience: 2 passed.

## Scope

`pytest.ini` only, +2 lines. No test or impl code touched. Pure CI-coverage gain. Orthogonal to README/proof/QC work.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>