### PR TITLE
docs(scripts): catalog scripts/lean/ setup tooling in scripts-reference

### DIFF
--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -62,6 +62,9 @@ Les scripts `scripts/fix_*.py` / `scripts/recycle_*.py` à la racine sont des on
 | `scripts/environment/install-ffmpeg.{ps1,sh}` | Installer ffmpeg (audio/vidéo) |
 | `scripts/kernels/lean4-wsl/` | Kernel Lean 4 WSL |
 | `scripts/kernels/validate_lean11.py` | Validation Lean-11 |
+| `scripts/lean/setup_lean4_all.py` | **Point d'entrée unique** setup kernel Lean 4 : `--wsl-only` / `--register` / `--validate` / `--check-wrapper` (orchestre WSL install + registration Windows + validation) — cf [docs/wsl-kernels-detail.md](wsl-kernels-detail.md) |
+| `scripts/lean/lean_kernel_check.py` | Détection canonique régression wrapper kernel.json (#1618) : `inspect_kernel_wrapper` (partagé par les 2 validateurs + l'orchestrateur) |
+| `scripts/lean/smoke_test_epita_is.py` | Smoke-test kernels Lean EPITA-IS |
 | `scripts/mcp-maintenance/` | Maintenance MCP (config, docs, scripts) — cf `README_MCP_MAINTENANCE.md` |
 | `scripts/validation/dispatch.py` + `matrix.yml` | Matrice de validation / dispatch |
 | `scripts/genai-stack/genai.py` | GenAI Docker (ComfyUI + Qwen) + validation — cf [docs/genai-services.md](genai-services.md) |


### PR DESCRIPTION
## Summary

Completion of #1618 / #1729: the canonical Lean 4 kernel setup tooling under `scripts/lean/` was absent from `docs/scripts-reference.md` — the catalog agents are **mandated** to consult before reimprovising a tool. Adds 3 entries to the "Maintenance & environnement" section:

- `scripts/lean/setup_lean4_all.py` — single entry point (`--wsl-only` / `--register` / `--validate` / `--check-wrapper`)
- `scripts/lean/lean_kernel_check.py` — canonical kernel.json wrapper-regression check (#1618), shared by both validators + the orchestrator
- `scripts/lean/smoke_test_epita_is.py` — EPITA-IS Lean kernel smoke-test

## Scope

`docs/scripts-reference.md` only, +3 lines. No code. Pure catalog accuracy so the mandated "use the dedicated tool, don't reimprovise" rule actually works for Lean setup.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>