### PR TITLE
test: register 2 orphan suites + fix Lean-test CI regression from #1737

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py
@@ -109,8 +109,13 @@ class TestLeanExecution(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Initialize Lean runner."""
-        cls.runner = LeanRunner(backend='auto')
+        """Initialize Lean runner. Skip the whole class if no Lean toolchain
+        is available (e.g. CPU CI runners without elan/lean installed) instead
+        of erroring at setup."""
+        try:
+            cls.runner = LeanRunner(backend='auto')
+        except (FileNotFoundError, RuntimeError, OSError) as exc:
+            raise unittest.SkipTest(f"Lean toolchain not available: {exc}")
 
     @classmethod
     def tearDownClass(cls):

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,8 @@ testpaths =
     MyIA.AI.Notebooks/GameTheory/tests
     MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests
+    scripts/tests
+    MyIA.AI.Notebooks/QuantConnect/scripts/tests
 pythonpath =
     MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts
 addopts = -v --tb=short --import-mode importlib


### PR DESCRIPTION
## Summary

Two parts (both test-infra CI-safety):

### 1. Fix CI regression introduced by #1737 (priority)
#1737 registered `GameTheory/tests`, but `test_lean_definitions.py::TestLeanExecution` invokes the **Lean executable** via `LeanRunner(backend='auto')` in `setUpClass` → `FileNotFoundError` → **ERROR** on CPU CI runners without elan/lean. (Masked locally where Lean is installed — my bad on the #1737 review.) The existing guard only checked the `lean_runner` **module**, not the **executable**.
**Fix**: `try/except (FileNotFoundError/RuntimeError/OSError) → unittest.SkipTest` so the class skips cleanly instead of erroring. This unbreaks `ML Pipeline Tests (CPU)` on main.

### 2. Register 2 more green CI-safe orphan suites
| Suite | Local result |
|-------|------|
| `scripts/tests` (garch baseline) | 11 passed (`arch` already in ML CI) |
| `MyIA.AI.Notebooks/QuantConnect/scripts/tests` (validate_qc_research) | 16 passed |

`scripts/quantconnect/tests` (audit_projects, 4 failed) deliberately NOT registered — real bug flagged to po-2023.

## Verification
- GameTheory suite still 69 green locally (with Lean); skip path triggers only when Lean absent.
- diff: pytest.ini +2 testpaths, test_lean_definitions.py +7/-2 (skip guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)