### PR TITLE
docs(ml.net): drop Statut column from 3 tables (Epic #1657)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/README.md
+++ b/MyIA.AI.Notebooks/ML/ML.Net/README.md
@@ -18,26 +18,26 @@ Le parcours va du premier pipeline (ML-1) jusqu'a une application complete : pre
 
 ### Fondamentaux (ML-1 à ML-4)
 
-| # | Notebook | Contenu | Duree | Statut |
-|---|----------|---------|-------|--------|
-| 1 | [ML-1-Introduction](ML-1-Introduction.ipynb) | Hello ML.NET World, pipeline de base | 30-40 min | ✅ Validé |
-| 2 | [ML-2-Data&Features](ML-2-Data%26Features.ipynb) | IDataView, TextLoader, encodage | 40-50 min | ✅ Validé |
-| 3 | [ML-3-Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb) | SDCA, LightGBM, AutoML | 45-60 min | ✅ Validé |
-| 4 | [ML-4-Evaluation](ML-4-Evaluation.ipynb) | Cross-validation, metriques, PFI | 40-50 min | ✅ Validé |
+| # | Notebook | Contenu | Duree |
+|---|----------|---------|-------|
+| 1 | [ML-1-Introduction](ML-1-Introduction.ipynb) | Hello ML.NET World, pipeline de base | 30-40 min |
+| 2 | [ML-2-Data&Features](ML-2-Data%26Features.ipynb) | IDataView, TextLoader, encodage | 40-50 min |
+| 3 | [ML-3-Entrainement&AutoML](ML-3-Entrainement%26AutoML.ipynb) | SDCA, LightGBM, AutoML | 45-60 min |
+| 4 | [ML-4-Evaluation](ML-4-Evaluation.ipynb) | Cross-validation, metriques, PFI | 40-50 min |
 
 ### Fonctionnalités avancées (ML-5 à ML-7)
 
-| # | Notebook | Contenu | Duree | Statut |
-|---|----------|---------|-------|--------|
-| 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | 45-60 min | 📚 Référence |
-| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | 45-60 min | 📚 Référence |
-| 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | 45-60 min | 📚 Référence |
+| # | Notebook | Contenu | Duree |
+|---|----------|---------|-------|
+| 5 | [ML-5-TimeSeries](ML-5-TimeSeries.ipynb) | **Time Series Forecasting** avec ForecastBySsa (SSA) | 45-60 min |
+| 6 | [ML-6-ONNX](ML-6-ONNX.ipynb) | **ONNX Integration** : modèles Python/PyTorch dans .NET | 45-60 min |
+| 7 | [ML-7-Recommendation](ML-7-Recommendation.ipynb) | **Recommandation** : Matrix Factorization, collaborative filtering | 45-60 min |
 
 ### TP Pratique
 
-| # | Notebook | Contenu | Duree | Statut |
-|---|----------|---------|-------|--------|
-| TP | [TP-prevision-ventes](TP-prevision-ventes.ipynb) | Regression avec ML.NET + Infer.NET bayésien | 45-60 min | ✅ Validé |
+| # | Notebook | Contenu | Duree |
+|---|----------|---------|-------|
+| TP | [TP-prevision-ventes](TP-prevision-ventes.ipynb) | Regression avec ML.NET + Infer.NET bayésien | 45-60 min |
 
 ## Contenu detaille
 


### PR DESCRIPTION
## Summary

Anti-count-obsession dilution cleanup on `MyIA.AI.Notebooks/ML/ML.Net/README.md`. Drops the pure-noise **Statut** column (`Validé` / `Référence` markers) from the 3 notebook tables :

- **Fondamentaux (ML-1 à ML-4)** — 4 rows, `Validé` markers
- **Fonctionnalités avancées (ML-5 à ML-7)** — 3 rows, `Référence` markers
- **TP Pratique** — 1 row, `Validé` marker

Total: 8 noise cells + 3 headers + 3 separators dropped.

## Scope

- **One file only** : `MyIA.AI.Notebooks/ML/ML.Net/README.md`
- **+14 / -14**, pure column-drop, **additive zero**
- **PRESERVED verbatim** :
  - Pedagogical intro (`Le parcours va du premier pipeline...`)
  - `Vue d'ensemble` Statistique/Valeur table (NOT a noise table)
  - All `Contenu detaille` section tables (per-notebook breakdowns)
  - `Dataset`, `Installation`, `Prerequisites`, `Concepts cles`, `Parcours recommande`, `Ressources`, `Licence` sections

## Precedent

PR #1733 (Planners) — exact same pattern (drop `Statut` column from 5 `Partie` tables, +23/-23 diff, pure column-drop). MERGED. This PR replicates that pattern on ML.NET.

## Anti-pattern guard (incident #1719 → #1735)

This PR does **NOT** :
- Touch the `Vue d'ensemble` table (which is not noise, it's a stats table)
- Delete the pedagogical intro or any pedagogical content
- Remove rows from any table (pure column-drop only)

User mandate 2026-05-29 (commit 951219e5) : keep additions, drop only pure noise.

## Verification

```
git diff --stat
 MyIA.AI.Notebooks/ML/ML.Net/README.md | 28 ++++++++++++++--------------
 1 file changed, 14 insertions(+), 14 deletions(-)

grep -nE "Statut|Validé|Référence" MyIA.AI.Notebooks/ML/ML.Net/README.md
# (no matches)
```

## Test plan

- [x] Visual diff review : pure column-drop, zero pedagogical content modified
- [x] Grep confirms 0 `Statut` / `Validé` / `Référence` markers remain
- [x] Intro preserved verbatim
- [x] `Vue d'ensemble` stats table preserved verbatim
- [x] All other section content preserved verbatim
- [ ] Markdown renders cleanly on GitHub (auto-check post-merge)