### PR TITLE
fix(rl): complete RL requirements.txt (torch, pettingzoo, pandas) + README (#295)

### DIFF
--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -138,7 +138,7 @@ python -m venv venv
 venv\Scripts\activate  # Windows
 
 # Dependances de base (notebooks 1-4)
-pip install "stable-baselines3[extra]>=2.0.0a4" gymnasium numpy matplotlib
+pip install "stable-baselines3[extra]>=2.0.0a4" gymnasium numpy pandas matplotlib
 
 # Pour le notebook 3 (parking environment)
 pip install highway-env moviepy
@@ -157,6 +157,7 @@ pip install "pettingzoo[classic]>=1.24.0"
 | stable-baselines3 | >=2.0.0a4 | Algorithmes RL (notebooks 1-3) |
 | gymnasium | latest | Interface environnements |
 | numpy | latest | Calcul numerique |
+| pandas | >=2.0 | Tableaux de resultats (notebook 4) |
 | matplotlib | latest | Visualisation |
 | torch | latest | Reseaux de neurones (notebook 5) |
 | pettingzoo | >=1.24.0 | Multi-agent (notebook 6) |

--- a/MyIA.AI.Notebooks/RL/requirements.txt
+++ b/MyIA.AI.Notebooks/RL/requirements.txt
@@ -2,13 +2,16 @@
 # Install: pip install -r requirements.txt
 
 # Core RL
-stable-baselines3[extra]>=2.0  # RL algorithms (PPO, DQN, A2C, etc.)
-gymnasium>=0.29                # OpenAI Gym successor
+stable-baselines3[extra]>=2.0  # RL algorithms (PPO, DQN, A2C, etc.) — notebooks 1-3
+gymnasium>=0.29                # OpenAI Gym successor — all notebooks
+torch>=2.0                     # Reseaux de neurones from scratch — notebook 5 (DQN, REINFORCE)
+pettingzoo[classic]>=1.24.0    # Multi-agent environments — notebook 6 (IQL, PettingZoo)
 
 # Environments
 highway-env>=1.8               # Highway driving environment (Notebook 3)
 
-# Visualization
+# Data / Visualization
+pandas>=2.0                    # Tableaux de resultats Q-Learning — notebook 4
 moviepy>=1.0                   # Video recording of agent behavior
 matplotlib>=3.7
 numpy>=1.24


### PR DESCRIPTION
## Summary

Advancing #295 (RL series). First did the issue's "audit current state": the series is **no longer thin** — 6 notebooks (sb_1/2/3 = PPO/wrappers/HER, rl_4/5/6 = MDP-Q-Learning/DQN-PG/multi-agent), README content-rich, 0 committed errors. But found a real **install-breaking bug**:

`MyIA.AI.Notebooks/RL/requirements.txt` covered only notebooks 1-3 deps. Running `pip install -r requirements.txt` then opening notebooks 4/5/6 fails:

| Notebook | Imports | In requirements.txt before? |
|----------|---------|------------------------------|
| rl_4 (MDP/Q-Learning) | `pandas` | ❌ missing |
| rl_5 (DQN/REINFORCE) | `torch` | ❌ (only transitive via sb3) |
| rl_6 (multi-agent) | `pettingzoo` | ❌ missing → ModuleNotFoundError |

The README dep table already documented `torch` + `pettingzoo` (as separate install layers), and requirements.txt already pins the nb3-specific `highway-env` — so the omission of nb5/nb6 deps + `pandas` was an inconsistency, not by design.

## Fix
- `requirements.txt`: add `torch>=2.0`, `pettingzoo[classic]>=1.24.0`, `pandas>=2.0` with per-notebook comments.
- `README.md`: add `pandas` to the base-install line + dependency table (already listed torch/pettingzoo).

## Verification
- Import-scan across the 6 RL notebooks vs requirements (table above).
- `rl_4_mdp_dp_qlearning.ipynb` executed **end-to-end via papermill** (37 cells, **0 errors**) on gymnasium/numpy/pandas/matplotlib — confirms pandas is genuinely needed and the base notebook now resolves.

## Scope
2 files, +8/-4. No notebook source/outputs touched (C.3). Orthogonal to test-infra (#1739), SmartContracts, QC, Lean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>