### PR TITLE
fix(tests): skip TestLeanExecution when lean binary absent (#1737 #1739 follow-up)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py
+++ b/MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py
@@ -8,6 +8,7 @@ when available, or just validates file structure otherwise.
 """
 
 import os
+import shutil
 import sys
 import unittest
 from pathlib import Path
@@ -25,6 +26,11 @@ try:
     HAS_LEAN_RUNNER = True
 except ImportError:
     HAS_LEAN_RUNNER = False
+
+# Even if lean_runner is importable, LeanRunner(backend='auto') crashes in
+# setUpClass when the `lean` ELF binary is missing (typical on CI runners
+# without elan). Guard the execution class on the binary's presence on PATH.
+HAS_LEAN_BINARY = shutil.which('lean') is not None
 
 # Lean files to test
 LEAN_FILES = [
@@ -103,7 +109,10 @@ class TestLeanBasicContent(unittest.TestCase):
         self.assertIn("arrow", content.lower())
 
 
-@unittest.skipIf(not HAS_LEAN_RUNNER, "lean_runner.py not available")
+@unittest.skipIf(
+    not (HAS_LEAN_RUNNER and HAS_LEAN_BINARY),
+    "lean_runner.py or lean executable not available",
+)
 class TestLeanExecution(unittest.TestCase):
     """Test Lean code execution using lean_runner.py."""
 


### PR DESCRIPTION
## Summary

Targeted CI repair for the pre-existing `ML Pipeline Tests (CPU)` failure that affects **every** open PR (including #1737, #1739, and any future PR).

## Problem

`MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py` has a weak import guard:

```python
try:
    from lean_runner import LeanRunner
    HAS_LEAN_RUNNER = True
except ImportError:
    HAS_LEAN_RUNNER = False

@unittest.skipIf(not HAS_LEAN_RUNNER, "lean_runner.py not available")
class TestLeanExecution(unittest.TestCase):
    @classmethod
    def setUpClass(cls):
        cls.runner = LeanRunner(backend='auto')  # crashes if `lean` binary missing
```

On the GHA Ubuntu runner, `lean_runner.py` **is** importable, so the class is **not** skipped. Then `LeanRunner(backend='auto')` raises:

```
FileNotFoundError: Lean executable not found. Please install Lean 4 via elan: ...
```

This produces **2 ERRORs** in `setUpClass` on every PR's `ML Pipeline Tests (CPU)` job, regardless of what that PR changed.

**Evidence**: GHA run [26610516033](https://github.com/jsboige/CoursIA/actions/runs/26610516033) (on PR #1739) shows the FileNotFoundError trace. PR #1737 documents this fix option in its body.

## Fix

Add a complementary `HAS_LEAN_BINARY = shutil.which('lean') is not None` check and require **both** flags on the class decorator:

```python
import shutil
# ...
HAS_LEAN_BINARY = shutil.which('lean') is not None

@unittest.skipIf(
    not (HAS_LEAN_RUNNER and HAS_LEAN_BINARY),
    "lean_runner.py or lean executable not available",
)
class TestLeanExecution(unittest.TestCase):
    ...
```

- **CI runner without lean** -> class cleanly skipped (no more setUpClass crash).
- **Dev machine with elan/WSL lean on PATH** -> tests still execute as before.
- **Additive only**: `HAS_LEAN_RUNNER` logic is untouched.
- **No `try/except` in `setUpClass`** (that would mask real local failures).
- **Does NOT** attempt to install Lean in CI (separate, larger PR scope).

## Diff stat

```
 MyIA.AI.Notebooks/GameTheory/tests/test_lean_definitions.py | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)
```

One file, +10/-1, all additive.

## Impact

Unblocks `ML Pipeline Tests (CPU)` on **all currently-open PRs** once this lands on `main`. Downstream PRs (#1737, #1739, and future PRs not touching `test_lean_definitions.py`) should see the job go green for the right reason (TestLeanExecution skipped on runners without lean), instead of failing for a reason orthogonal to their changes.

## Test plan

- [x] `git diff --stat`: +10/-1, one file
- [x] Local sanity: `python -c "import shutil; shutil.which('lean')"` succeeds
- [x] No change to `HAS_LEAN_RUNNER` logic
- [x] No `try/except` added in `setUpClass`
- [ ] After merge: re-run `ML Pipeline Tests (CPU)` on #1737/#1739 and confirm `TestLeanExecution` is skipped instead of erroring

## Related

- #1737 (documented this fix option)
- #1739 (PR with the failing GHA run 26610516033)
- Skip behavior reference: [docs/lean/](https://github.com/jsboige/CoursIA/tree/main/docs/lean) for prover env requirements

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>