### PR TITLE
fix(search): add optuna to requirements.txt + document OpenSpiel (WSL-only)

### DIFF
--- a/MyIA.AI.Notebooks/Search/requirements.txt
+++ b/MyIA.AI.Notebooks/Search/requirements.txt
@@ -28,6 +28,7 @@ numpy>=1.24
 scipy>=1.10
 pandas>=2.0                  # DataFrames pour analyse et benchmarks
 scikit-learn>=1.3            # ML pour App-18 hyperparameter tuning
+optuna>=3.0                  # Optimisation bayesienne d'hyperparametres (App-18)
 
 # Linear Programming
 pulp>=2.8.0                 # Linear programming with CBC, HiGHS solvers
@@ -38,3 +39,7 @@ papermill>=2.4
 
 # Optional: MiniZinc (requires MiniZinc IDE installed separately)
 # minizinc>=0.9
+
+# Optional: OpenSpiel (Search-7 MCTS/AlphaGo-style) — pas de wheel pip Windows.
+# Installer via WSL/Linux : pip install open_spiel  (cf README, section Search-7)
+# open_spiel>=1.4


### PR DESCRIPTION
## Summary

Install-hygiene fix for the Search series (same class as the RL #1743 fix). Verified gap:

- **`optuna`** — imported by `Applications/Hybrid/App-18-HyperparameterTuning.ipynb` (a curriculum notebook; the README lists "Optuna" among its covered methods) but **absent** from `requirements.txt`. `pip install -r requirements.txt` then running App-18 fails on `import optuna`. → added `optuna>=3.0`.
- **OpenSpiel** (`open_spiel`/`pyspiel`, Search-7 MCTS) — has no pip wheel on Windows, so it is **intentionally** not in the install set. Added a commented note pointing to WSL/Linux install, matching the file's existing MiniZinc/Graphviz optional-dependency style (so students aren't confused when `import pyspiel` fails on Windows).

## Verification (verify-before-claiming)

Import-scan across **all** Search notebooks:
- `optuna` → only App-18 (real gap, fixed)
- `open_spiel`/`pyspiel` → only Search-7 (left out by design — Windows can't pip-install it)
- `cv2`/`PIL` → only the standalone root `PyGad-EdgeDetection.ipynb` (not in the README curriculum tables) → not touched

## Scope

`Search/requirements.txt` only, +5 lines (1 dep + 3-line doc note). No notebook/code touched. Orthogonal to active tracks (test-infra #1739, SmartContracts, QC, Lean, RL).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>