### PR TITLE
fix(smartcontracts): SC-15 ZKP execution bug — undefined y/q (#1747)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -76,8 +76,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "cave-simulation",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:33.281577Z",
+     "iopub.status.busy": "2026-05-29T01:01:33.280428Z",
+     "iopub.status.idle": "2026-05-29T01:01:33.332039Z",
+     "shell.execute_reply": "2026-05-29T01:01:33.330834Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ANALOGIE DE LA CAVERNE D'ALI BABA\n",
+      "============================================================\n",
+      "Prouveur honnete  (1000 essais, 20 rounds) : 1000/1000 reussis\n",
+      "Prouveur fraudeur (1000 essais, 20 rounds) : 0/1000 reussis\n",
+      "\n",
+      "Probabilite theorique de fraude sur 20 rounds : 2^(-20) = 0.0000009537\n",
+      "-> Environ 1 chance sur 1,048,576 de tromper le verificateur\n"
+     ]
+    }
+   ],
    "source": [
     "import random\n",
     "\n",
@@ -115,23 +138,7 @@
     "print()\n",
     "print(f\"Probabilite theorique de fraude sur 20 rounds : 2^(-20) = {2**-20:.10f}\")\n",
     "print(f\"-> Environ 1 chance sur {2**20:,} de tromper le verificateur\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ANALOGIE DE LA CAVERNE D'ALI BABA\n",
-      "============================================================\n",
-      "Prouveur honnete  (1000 essais, 20 rounds) : 1000/1000 reussis\n",
-      "Prouveur fraudeur (1000 essais, 20 rounds) : 0/1000 reussis\n",
-      "\n",
-      "Probabilite theorique de fraude sur 20 rounds : 2^(-20) = 0.0000009537\n",
-      "-> Environ 1 chance sur 1,048,576 de tromper le verificateur\n"
-     ]
-    }
-   ],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "markdown",
@@ -188,6 +195,7 @@
   {
    "cell_type": "markdown",
    "id": "8199e832",
+   "metadata": {},
    "source": [
     "### Interpretation : Parametres du groupe\n",
     "\n",
@@ -202,8 +210,7 @@
     "**Pourquoi un safe prime ?** Le sous-groupe d'ordre q n'a pas de sous-groupe propre, ce qui elimine les attaques par sous-groupe petit (Pohlig-Hellman). La cle publique `y = g^x mod p` ne revele pas x car le probleme du logarithme discret est calculement infaisable dans ce groupe.\n",
     "\n",
     "**Note** : 128 bits est pedagogique. En production, on utilise 256 bits (RFC 7919) pour une securite de 128 bits equivalente AES.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
@@ -219,8 +226,51 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "dlog-interactive",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:33.334652Z",
+     "iopub.status.busy": "2026-05-29T01:01:33.334384Z",
+     "iopub.status.idle": "2026-05-29T01:01:33.361123Z",
+     "shell.execute_reply": "2026-05-29T01:01:33.360508Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pycryptodome disponible.\n",
+      "Parametres Discrete Log generes:\n",
+      "  p (premier) = 0xbdeeac34b4ffddec8974640ecca6c3570c0eee...\n",
+      "  g (generateur) = 0xac323140167242f29e55f5293dbd4582ffe3e1...\n",
+      "  x (secret) = NON REVELE\n",
+      "  h = g^x mod p = 0x8ef36e716af6e102182d84afbfac9009989032...\n",
+      "Verification: g^x mod p == h : True\n",
+      "PROTOCOLE ZKP DU LOGARITHME DISCRET (INTERACTIF)\n",
+      "============================================================\n",
+      "  Round  1 : g^s == R*y^c ? OK\n",
+      "  Round  2 : g^s == R*y^c ? OK\n",
+      "  Round  3 : g^s == R*y^c ? OK\n",
+      "  Round  4 : g^s == R*y^c ? OK\n",
+      "  Round  5 : g^s == R*y^c ? OK\n",
+      "  Round  6 : g^s == R*y^c ? OK\n",
+      "  Round  7 : g^s == R*y^c ? OK\n",
+      "  Round  8 : g^s == R*y^c ? OK\n",
+      "  Round  9 : g^s == R*y^c ? OK\n",
+      "  Round 10 : g^s == R*y^c ? OK\n",
+      "\n",
+      "Resultat apres 10 rounds : CONVAINCU\n",
+      "Probabilite de fraude : 2^(-10) = 9.77e-04\n",
+      "\n",
+      "Points cles :\n",
+      "  - Le secret x n'a JAMAIS ete transmis au verificateur\n",
+      "  - Chaque round utilise un nonce r different (aleatoire)\n",
+      "  - s = r + c*x est masque par r, impossible de deduire x\n"
+     ]
+    }
+   ],
    "source": [
     "# %% Cellule - Parametres Discrete Log avec import guards\n",
     "# Guard: verification pycryptodome\n",
@@ -252,6 +302,8 @@
     "\n",
     "    # Generation des parametres\n",
     "    p, g, x, h = generate_dlog_params(bits=256)\n",
+    "    y = h          # cle publique / engagement = g^x mod p (notation des protocoles suivants)\n",
+    "    q = p - 1      # ordre du groupe multiplicatif Z_p* (Fermat: g^(p-1) == 1 mod p)\n",
     "\n",
     "    print('Parametres Discrete Log generes:')\n",
     "    print(f'  p (premier) = {hex(p)[:40]}...')\n",
@@ -260,8 +312,7 @@
     "    print(f'  h = g^x mod p = {hex(h)[:40]}...')\n",
     "    print(f'Verification: g^x mod p == h : {pow(g, x, p) == h}')\n",
     "else:\n",
-    "    print('Generation des parametres discrete log skippee (pycryptodome requis).')",
-    "\n",
+    "    print('Generation des parametres discrete log skippee (pycryptodome requis).')\n",
     "# Protocole interactif du logarithme discret\n",
     "from Crypto.Util.number import getRandomRange\n",
     "\n",
@@ -310,36 +361,7 @@
     "print(\"  - Le secret x n'a JAMAIS ete transmis au verificateur\")\n",
     "print(\"  - Chaque round utilise un nonce r different (aleatoire)\")\n",
     "print(\"  - s = r + c*x est masque par r, impossible de deduire x\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PROTOCOLE ZKP DU LOGARITHME DISCRET (INTERACTIF)\n",
-      "============================================================\n",
-      "  Round  1 : g^s == R*y^c ? OK\n",
-      "  Round  2 : g^s == R*y^c ? OK\n",
-      "  Round  3 : g^s == R*y^c ? OK\n",
-      "  Round  4 : g^s == R*y^c ? OK\n",
-      "  Round  5 : g^s == R*y^c ? OK\n",
-      "  Round  6 : g^s == R*y^c ? OK\n",
-      "  Round  7 : g^s == R*y^c ? OK\n",
-      "  Round  8 : g^s == R*y^c ? OK\n",
-      "  Round  9 : g^s == R*y^c ? OK\n",
-      "  Round 10 : g^s == R*y^c ? OK\n",
-      "\n",
-      "Resultat apres 10 rounds : CONVAINCU\n",
-      "Probabilite de fraude : 2^(-10) = 9.77e-04\n",
-      "\n",
-      "Points cles :\n",
-      "  - Le secret x n'a JAMAIS ete transmis au verificateur\n",
-      "  - Chaque round utilise un nonce r different (aleatoire)\n",
-      "  - s = r + c*x est masque par r, impossible de deduire x\n"
-     ]
-    }
-   ],
-   "execution_count": 3
+   ]
   },
   {
    "cell_type": "markdown",
@@ -355,8 +377,36 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "dlog-cheat",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:33.362715Z",
+     "iopub.status.busy": "2026-05-29T01:01:33.362583Z",
+     "iopub.status.idle": "2026-05-29T01:01:33.671247Z",
+     "shell.execute_reply": "2026-05-29T01:01:33.670436Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TENTATIVE DE FRAUDE (prouveur ne connait PAS x)\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tentatives de fraude : 1000\n",
+      "Fraudes reussies     : 0\n",
+      "-> La probabilite de deviner s correctement est 1/q ~ 2^(-256)\n",
+      "-> Un seul round suffit pour une securite de 128 bits avec de grands parametres\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstration : un prouveur frauduleux echoue\n",
     "print(\"TENTATIVE DE FRAUDE (prouveur ne connait PAS x)\")\n",
@@ -387,28 +437,7 @@
     "print(f\"Fraudes reussies     : {frauds_reussies}\")\n",
     "print(f\"-> La probabilite de deviner s correctement est 1/q ~ 2^(-{q.bit_length()})\")\n",
     "print(\"-> Un seul round suffit pour une securite de 128 bits avec de grands parametres\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TENTATIVE DE FRAUDE (prouveur ne connait PAS x)\n",
-      "============================================================\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Tentatives de fraude : 1000\n",
-      "Fraudes reussies     : 0\n",
-      "-> La probabilite de deviner s correctement est 1/q ~ 2^(-128)\n",
-      "-> Un seul round suffit pour une securite de 128 bits avec de grands parametres\n"
-     ]
-    }
-   ],
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "markdown",
@@ -463,8 +492,29 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "schnorr-class",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:33.673713Z",
+     "iopub.status.busy": "2026-05-29T01:01:33.673391Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.324309Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.323521Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PROTOCOLE DE SCHNORR\n",
+      "============================================================\n",
+      "Parametres : p=476128414541885441227276232281... (129 bits)\n",
+      "Cle publique y = g^x mod p\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from Crypto.Util.number import getPrime, getRandomRange\n",
     "from Crypto.Hash import SHA256\n",
@@ -551,21 +601,7 @@
     "print(f\"Parametres : p={str(schnorr.p)[:30]}... ({schnorr.p.bit_length()} bits)\")\n",
     "print(f\"Cle publique y = g^x mod p\")\n",
     "print()"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PROTOCOLE DE SCHNORR\n",
-      "============================================================\n",
-      "Parametres : p=554452293842134481016447573724... (129 bits)\n",
-      "Cle publique y = g^x mod p\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 5
+   ]
   },
   {
    "cell_type": "markdown",
@@ -581,8 +617,48 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "schnorr-comparison",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.326433Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.326211Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.333046Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.332430Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "COMPARAISON : INTERACTIF vs NON-INTERACTIF (Fiat-Shamir)\n",
+      "============================================================\n",
+      "\n",
+      "--- Version INTERACTIVE ---\n",
+      "  Etape 1 (Prouveur -> Verificateur) : envoyer R\n",
+      "    R = g^r = 837874387194259418593173672393...\n",
+      "  Etape 2 (Verificateur -> Prouveur) : envoyer c\n",
+      "    c = 146497132042279559943278346989...\n",
+      "  Etape 3 (Prouveur -> Verificateur) : envoyer s\n",
+      "    s = r + c*x mod q = 417295312324976589797612770726...\n",
+      "  Verification : g^s == R*y^c ? OUI\n",
+      "  -> Necessite 3 messages (2 allers-retours)\n",
+      "\n",
+      "--- Version NON-INTERACTIVE (Fiat-Shamir) ---\n",
+      "  Preuve (R, s) calculee localement\n",
+      "    R = 463312854706851498425460623718...\n",
+      "    s = 579189719827152188119275332845...\n",
+      "    c = SHA256(g || y || R || message) (calcule automatiquement)\n",
+      "  Verification : VALIDE\n",
+      "  -> Un seul message, pas besoin d'interaction !\n",
+      "\n",
+      "--- Falsification du message ---\n",
+      "  Verification avec message modifie : INVALIDE\n",
+      "  -> La preuve est liee au message (c'est une signature !)\n"
+     ]
+    }
+   ],
    "source": [
     "# Comparaison interactive vs non-interactive\n",
     "print(\"COMPARAISON : INTERACTIF vs NON-INTERACTIF (Fiat-Shamir)\")\n",
@@ -625,44 +701,12 @@
     "valid_fake = schnorr.verify_non_interactive(y, R_ni, s_ni, fake_message)\n",
     "print(f\"  Verification avec message modifie : {\"VALIDE\" if valid_fake else \"INVALIDE\"}\")\n",
     "print(f\"  -> La preuve est liee au message (c'est une signature !)\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "COMPARAISON : INTERACTIF vs NON-INTERACTIF (Fiat-Shamir)\n",
-      "============================================================\n",
-      "\n",
-      "--- Version INTERACTIVE ---\n",
-      "  Etape 1 (Prouveur -> Verificateur) : envoyer R\n",
-      "    R = g^r = 369061744915902003702033577962...\n",
-      "  Etape 2 (Verificateur -> Prouveur) : envoyer c\n",
-      "    c = 262907934598020509140333394349...\n",
-      "  Etape 3 (Prouveur -> Verificateur) : envoyer s\n",
-      "    s = r + c*x mod q = 633687693328400512309889810471...\n",
-      "  Verification : g^s == R*y^c ? OUI\n",
-      "  -> Necessite 3 messages (2 allers-retours)\n",
-      "\n",
-      "--- Version NON-INTERACTIVE (Fiat-Shamir) ---\n",
-      "  Preuve (R, s) calculee localement\n",
-      "    R = 167949948152626763424463029622...\n",
-      "    s = 196233056738072179279470953518...\n",
-      "    c = SHA256(g || y || R || message) (calcule automatiquement)\n",
-      "  Verification : VALIDE\n",
-      "  -> Un seul message, pas besoin d'interaction !\n",
-      "\n",
-      "--- Falsification du message ---\n",
-      "  Verification avec message modifie : INVALIDE\n",
-      "  -> La preuve est liee au message (c'est une signature !)\n"
-     ]
-    }
-   ],
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "8994087a",
+   "metadata": {},
    "source": [
     "### Interpretation : Interactif vs Non-interactif\n",
     "\n",
@@ -677,8 +721,7 @@
     "- La version non-interactive transforme la ZKP en **signature numerique** : le message est lie a la preuve\n",
     "- Changer un seul octet du message invalide la preuve (le challenge change completement)\n",
     "- Bitcoin Taproot (BIP-340) utilise exactement ce schema pour les transactions\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
@@ -694,8 +737,49 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "schnorr-signature",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.334907Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.334659Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.340217Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.339602Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SCHNORR : ZKP = SIGNATURE\n",
+      "============================================================\n",
+      "\n",
+      "Schema de signature de Schnorr :\n",
+      "  Signer(x, message)   -> (R, s) = preuve ZKP non-interactive\n",
+      "  Verifier(y, message, R, s) -> vrai/faux\n",
+      "\n",
+      "Signatures de Schnorr sur differents messages :\n",
+      "  Message  : Transferer 10 ETH a 0xBob\n",
+      "  Sig (R)  : 351208180486063551088209272901...\n",
+      "  Valide   : True\n",
+      "\n",
+      "  Message  : Approuver le contrat 0xDefi\n",
+      "  Sig (R)  : 164795583118405300625445328055...\n",
+      "  Valide   : True\n",
+      "\n",
+      "  Message  : Voter OUI pour la proposition 42\n",
+      "  Sig (R)  : 372434561971380273649512148655...\n",
+      "  Valide   : True\n",
+      "\n",
+      "Points cles :\n",
+      "  - Chaque signature a un R different (nonce aleatoire)\n",
+      "  - La verification ne necessite que la cle publique y\n",
+      "  - Bitcoin utilise les signatures Schnorr depuis Taproot (BIP-340)\n",
+      "  - Avantage sur ECDSA : linearite -> aggregation de signatures possible\n"
+     ]
+    }
+   ],
    "source": [
     "# La preuve non-interactive de Schnorr EST une signature\n",
     "print(\"SCHNORR : ZKP = SIGNATURE\")\n",
@@ -727,41 +811,7 @@
     "print(\"  - La verification ne necessite que la cle publique y\")\n",
     "print(\"  - Bitcoin utilise les signatures Schnorr depuis Taproot (BIP-340)\")\n",
     "print(\"  - Avantage sur ECDSA : linearite -> aggregation de signatures possible\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SCHNORR : ZKP = SIGNATURE\n",
-      "============================================================\n",
-      "\n",
-      "Schema de signature de Schnorr :\n",
-      "  Signer(x, message)   -> (R, s) = preuve ZKP non-interactive\n",
-      "  Verifier(y, message, R, s) -> vrai/faux\n",
-      "\n",
-      "Signatures de Schnorr sur differents messages :\n",
-      "  Message  : Transferer 10 ETH a 0xBob\n",
-      "  Sig (R)  : 312753813960364170480981450300...\n",
-      "  Valide   : True\n",
-      "\n",
-      "  Message  : Approuver le contrat 0xDefi\n",
-      "  Sig (R)  : 512170747138649403014659170622...\n",
-      "  Valide   : True\n",
-      "\n",
-      "  Message  : Voter OUI pour la proposition 42\n",
-      "  Sig (R)  : 451255729865399607970689808787...\n",
-      "  Valide   : True\n",
-      "\n",
-      "Points cles :\n",
-      "  - Chaque signature a un R different (nonce aleatoire)\n",
-      "  - La verification ne necessite que la cle publique y\n",
-      "  - Bitcoin utilise les signatures Schnorr depuis Taproot (BIP-340)\n",
-      "  - Avantage sur ECDSA : linearite -> aggregation de signatures possible\n"
-     ]
-    }
-   ],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
@@ -829,8 +879,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "chaum-pedersen-impl",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.342482Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.342319Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.349278Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.348728Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PROTOCOLE DE CHAUM-PEDERSEN\n",
+      "============================================================\n",
+      "Secret x : 847511399977545995763644498391... (cache)\n",
+      "y1 = g^x : 267822424856598682115100461697...\n",
+      "y2 = h^x : 332842436367731523928041979600...\n",
+      "\n",
+      "Objectif : prouver que log_g(y1) == log_h(y2) sans reveler x\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from Crypto.Util.number import getRandomRange\n",
     "from Crypto.Hash import SHA256\n",
@@ -904,24 +978,7 @@
     "print(f\"y2 = h^x : {str(y2)[:30]}...\")\n",
     "print(f\"\\nObjectif : prouver que log_g(y1) == log_h(y2) sans reveler x\")\n",
     "print()"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PROTOCOLE DE CHAUM-PEDERSEN\n",
-      "============================================================\n",
-      "Secret x : 567744681017151405944173209174... (cache)\n",
-      "y1 = g^x : 499875821683500302214224391905...\n",
-      "y2 = h^x : 183318859273529833377947277955...\n",
-      "\n",
-      "Objectif : prouver que log_g(y1) == log_h(y2) sans reveler x\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 8
+   ]
   },
   {
    "cell_type": "markdown",
@@ -937,8 +994,44 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "chaum-pedersen-verify",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.350951Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.350802Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.356164Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.355673Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VERIFICATION CHAUM-PEDERSEN\n",
+      "============================================================\n",
+      "Preuve (R1, R2, s) :\n",
+      "  R1 = 955417350894797554858733899567...\n",
+      "  R2 = 311586520652863502597146744219...\n",
+      "  s  = 883156804031583586004688754508...\n",
+      "\n",
+      "Verification : g^s == R1*y1^c  ET  h^s == R2*y2^c\n",
+      "Resultat : VALIDE\n",
+      "\n",
+      "--- Test avec exposants differents ---\n",
+      "y1 = g^x, y2 = h^x_diff (x != x_diff)\n",
+      "La preuve avec le secret x pour y2 = h^x_diff : INVALIDE\n",
+      "\n",
+      "-> La preuve ne fonctionne que si les deux logarithmes sont identiques\n",
+      "\n",
+      "Applications :\n",
+      "  - Vote electronique : prouver qu'un bulletin chiffre est bien forme\n",
+      "  - Transferts confidentiels : prouver qu'un montant est conserve\n",
+      "  - Echange de cles : prouver la coherence de Diffie-Hellman\n"
+     ]
+    }
+   ],
    "source": [
     "# Generer et verifier la preuve de Chaum-Pedersen\n",
     "R1, R2, s = cp.prove(secret_x, y1, y2)\n",
@@ -971,40 +1064,12 @@
     "print(\"  - Vote electronique : prouver qu'un bulletin chiffre est bien forme\")\n",
     "print(\"  - Transferts confidentiels : prouver qu'un montant est conserve\")\n",
     "print(\"  - Echange de cles : prouver la coherence de Diffie-Hellman\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "VERIFICATION CHAUM-PEDERSEN\n",
-      "============================================================\n",
-      "Preuve (R1, R2, s) :\n",
-      "  R1 = 239279045927739821298484131234...\n",
-      "  R2 = 405206469004155039332812728531...\n",
-      "  s  = 297869925875621516669741910107...\n",
-      "\n",
-      "Verification : g^s == R1*y1^c  ET  h^s == R2*y2^c\n",
-      "Resultat : VALIDE\n",
-      "\n",
-      "--- Test avec exposants differents ---\n",
-      "y1 = g^x, y2 = h^x_diff (x != x_diff)\n",
-      "La preuve avec le secret x pour y2 = h^x_diff : INVALIDE\n",
-      "\n",
-      "-> La preuve ne fonctionne que si les deux logarithmes sont identiques\n",
-      "\n",
-      "Applications :\n",
-      "  - Vote electronique : prouver qu'un bulletin chiffre est bien forme\n",
-      "  - Transferts confidentiels : prouver qu'un montant est conserve\n",
-      "  - Echange de cles : prouver la coherence de Diffie-Hellman\n"
-     ]
-    }
-   ],
-   "execution_count": 9
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "748cebfe",
+   "metadata": {},
    "source": [
     "### Interpretation : Verification Chaum-Pedersen\n",
     "\n",
@@ -1018,8 +1083,7 @@
     "- Le prouveur demontre que le meme exposant x est utilise pour `g^x` et `h^x`\n",
     "- Applications directes : vote electronique (preuve de bulletin bien forme), coherence Diffie-Hellman, transferts confidentiels\n",
     "- La solidite repose sur le fait qu'il est impossible de satisfaire les deux equations si les exposants different\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1102,8 +1166,55 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "r1cs-demo",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.357946Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.357762Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.365241Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.364709Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CIRCUIT ARITHMETIQUE SIMPLIFIE\n",
+      "============================================================\n",
+      "Equation a prouver : x^3 + x + 5 == 35\n",
+      "(Le prouveur connait x=3, le verificateur ne doit pas l'apprendre)\n",
+      "\n",
+      "Temoin (witness) - toutes les variables intermediaires :\n",
+      "  1     = 1\n",
+      "  x     = 3\n",
+      "  sym1  = 9\n",
+      "  y     = 27\n",
+      "  sym2  = 30\n",
+      "  out   = 35\n",
+      "\n",
+      "Contraintes R1CS (Rank-1 Constraint System) :\n",
+      "  Chaque contrainte : (A . witness) * (B . witness) = (C . witness)\n",
+      "\n",
+      "  Contrainte 1: (1*x) * (1*x) = (1*sym1)\n",
+      "    => 3 * 3 = 9 ? OK\n",
+      "  Contrainte 2: (1*sym1) * (1*x) = (1*y)\n",
+      "    => 9 * 3 = 27 ? OK\n",
+      "  Contrainte 3: (1*y + 1*x + 5*1) * (1*1) = (1*out)\n",
+      "    => 35 * 1 = 35 ? OK\n",
+      "\n",
+      "Toutes les contraintes satisfaites : True\n",
+      "Le prouveur connait x tel que x^3 + x + 5 == 35\n",
+      "\n",
+      "En vrai zk-SNARK :\n",
+      "  1. Le temoin serait encode comme polynomes sur un corps fini\n",
+      "  2. La preuve serait ~200 octets (2 elements de courbe elliptique)\n",
+      "  3. La verification prendrait ~5ms (3 pairings)\n",
+      "  4. Le verificateur n'apprendrait pas x\n"
+     ]
+    }
+   ],
    "source": [
     "# Demonstration simplifiee : circuit arithmetique et R1CS\n",
     "# On veut prouver que l'on connait x tel que x^3 + x + 5 == 35 (reponse : x=3)\n",
@@ -1184,51 +1295,12 @@
     "print(\"  2. La preuve serait ~200 octets (2 elements de courbe elliptique)\")\n",
     "print(\"  3. La verification prendrait ~5ms (3 pairings)\")\n",
     "print(\"  4. Le verificateur n'apprendrait pas x\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CIRCUIT ARITHMETIQUE SIMPLIFIE\n",
-      "============================================================\n",
-      "Equation a prouver : x^3 + x + 5 == 35\n",
-      "(Le prouveur connait x=3, le verificateur ne doit pas l'apprendre)\n",
-      "\n",
-      "Temoin (witness) - toutes les variables intermediaires :\n",
-      "  1     = 1\n",
-      "  x     = 3\n",
-      "  sym1  = 9\n",
-      "  y     = 27\n",
-      "  sym2  = 30\n",
-      "  out   = 35\n",
-      "\n",
-      "Contraintes R1CS (Rank-1 Constraint System) :\n",
-      "  Chaque contrainte : (A . witness) * (B . witness) = (C . witness)\n",
-      "\n",
-      "  Contrainte 1: (1*x) * (1*x) = (1*sym1)\n",
-      "    => 3 * 3 = 9 ? OK\n",
-      "  Contrainte 2: (1*sym1) * (1*x) = (1*y)\n",
-      "    => 9 * 3 = 27 ? OK\n",
-      "  Contrainte 3: (1*y + 1*x + 5*1) * (1*1) = (1*out)\n",
-      "    => 35 * 1 = 35 ? OK\n",
-      "\n",
-      "Toutes les contraintes satisfaites : True\n",
-      "Le prouveur connait x tel que x^3 + x + 5 == 35\n",
-      "\n",
-      "En vrai zk-SNARK :\n",
-      "  1. Le temoin serait encode comme polynomes sur un corps fini\n",
-      "  2. La preuve serait ~200 octets (2 elements de courbe elliptique)\n",
-      "  3. La verification prendrait ~5ms (3 pairings)\n",
-      "  4. Le verificateur n'apprendrait pas x\n"
-     ]
-    }
-   ],
-   "execution_count": 10
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "0ccc4367",
+   "metadata": {},
    "source": [
     "### Interpretation : Circuit arithmetique et R1CS\n",
     "\n",
@@ -1245,8 +1317,7 @@
     "- Chaque contrainte R1CS est de la forme `(A.s) * (B.s) = (C.s)` ou s est le temoin\n",
     "- Les additions sont absorbees dans les vecteurs (pas de porte d'addition separee)\n",
     "- En zk-SNARK reel, ces contraintes sont encodees comme polynomes puis verifiees par pairings de courbes elliptiques, sans jamais reveler le temoin\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1315,8 +1386,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "exercise-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T01:01:34.366899Z",
+     "iopub.status.busy": "2026-05-29T01:01:34.366704Z",
+     "iopub.status.idle": "2026-05-29T01:01:34.370702Z",
+     "shell.execute_reply": "2026-05-29T01:01:34.370035Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import hashlib\n",
     "from Crypto.Util.number import getRandomRange\n",
@@ -1355,9 +1435,7 @@
     "           h_pub et y sont publics, x_derived est le secret du prouveur\n",
     "        \"\"\"\n",
     "        pass  # TODO: Implementez register()\n"
-   ],
-   "outputs": [],
-   "execution_count": 11
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1420,6 +1498,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bbe60389",
    "metadata": {},
    "source": [
     "---\n",
@@ -1444,7 +1523,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Contexte (issue #1747 — vérification exécution SmartContracts)

En exécutant la série via le kernel `smartcontracts` (env vérifié : Foundry 1.5.1 + solc 0.8.28), **SC-15-Zero-Knowledge-Proofs échouait** : `NameError: name 'y' is not defined` (et `q` aussi).

## Cause

La cellule génère les paramètres `p, g, x, h = generate_dlog_params()`, mais le protocole interactif DLOG et la démo de fraude appellent `zkp_dlog_interactive(g, y, x, p, q)` / `zkp_dlog_cheat(g, y, p, q)` avec :
- `y` (clé publique / engagement) — jamais défini (s'appelle `h`)
- `q` (ordre du groupe) — jamais défini

## Fix (minimal, 2 lignes)

Après la génération des paramètres :
```python
y = h        # clé publique = g^x mod p
q = p - 1    # ordre de Z_p* (Fermat: g^(p-1) ≡ 1 mod p ⇒ exposants mod p-1)
```
La vérification `g^s == R·y^c mod p` est alors mathématiquement valide (q = p-1 : g^(p-1)≡1, donc réduire l'exposant mod p-1 ne change pas g^exp).

## Vérification (exécution réelle)

Ré-exécuté via kernel `smartcontracts` : **34 cellules, 0 erreur**, `execution_count` complet. Outputs rafraîchis et committés (C.2). Le diff large (≈ 346/267) = **churn d'outputs** (valeurs crypto aléatoires régénérées), pas de la logique.

## Notes
- Découvert dans le cadre de #1747 : mon scan initial "7 shallow" était **biaisé** (ne comptait que les appels SDK blockchain, ratait le crypto pur-Python). Re-scan corrigé : SC-0/15/16 ont du vrai code ; le seul souci réel était **cet bug d'exécution SC-15**. SC-0 + SC-16 ré-exécutés OK (0 erreur).
- **[non inclus]** working-tree : SW-11/SW-12 portent un changement parasite `display_name: "Python 3"→"base"` (pas de moi) — signalé sur dashboard, non committé ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)