### PR TITLE
fix(probas): complete requirements.txt — PyMC/arviz/scipy/pandas/yfinance/hmmlearn/sklearn

### DIFF
--- a/MyIA.AI.Notebooks/Probas/requirements.txt
+++ b/MyIA.AI.Notebooks/Probas/requirements.txt
@@ -2,9 +2,27 @@
 # Install: pip install -r requirements.txt
 #
 # Note: 20 notebooks are C# (.NET Interactive) using Infer.NET.
-# This file covers the Python notebook (Pyro_RSA_Hyperbole).
+# Python notebooks: Pyro_RSA_Hyperbole, PyMC-HMM-Trading-Alpha,
+#   and _python_port/PyMC-* series (20 notebooks).
 
-# Core
+# === Pyro (RSA Hyperbole) ===
 pyro-ppl>=1.8                # Probabilistic programming (Pyro)
 torch>=2.0                   # PyTorch (Pyro backend)
+
+# === PyMC (_python_port/ series + HMM Trading Alpha) ===
+pymc>=5.0                    # Probabilistic programming (PyMC)
+arviz>=0.14                  # Bayesian diagnostics & visualization
+
+# === Scientific computing ===
+numpy>=1.24                  # Core numerics
+scipy>=1.10                  # Statistical functions, optimization
+pandas>=2.0                  # Data handling
 matplotlib>=3.7              # Visualization
+
+# === PyMC-HMM-Trading-Alpha specific ===
+yfinance>=0.2                # Yahoo Finance data download
+hmmlearn>=0.3                # Hidden Markov Models
+scikit-learn>=1.2            # StandardScaler (HMM), LatentDirichletAllocation (PyMC-9)
+
+# === Optional (not imported but used indirectly) ===
+# networkx>=3.0              # Graph utilities


### PR DESCRIPTION
## Summary

`Probas/requirements.txt` ne couvrait que 3 packages (pyro-ppl, torch, matplotlib) alors que les 21 notebooks Python de la série importent **11 packages tiers**.

## Bug réel

`pip install -r requirements.txt` puis exécution des notebooks PyMC → `ModuleNotFoundError` sur pymc, arviz, scipy, pandas, yfinance, hmmlearn, scikit-learn.

## Changes

| Section | Ajouté | Notebooks concernés |
|---------|--------|---------------------|
| PyMC | `pymc>=5.0`, `arviz>=0.14` | 20 notebooks `_python_port/PyMC-*` |
| Scientific | `numpy`, `scipy`, `pandas` | Multiple notebooks |
| HMM Trading | `yfinance>=0.2`, `hmmlearn>=0.3`, `scikit-learn>=1.2` | PyMC-HMM-Trading-Alpha + PyMC-9 |

## Verification

Scan exhaustif des imports (`re.finditer` sur toutes les cellules code de 21 notebooks .ipynb) vs requirements.txt existant → 8 packages manquants identifiés et ajoutés.

Scope: `requirements.txt` seul (+20/-2 lignes). 0 notebook/code modifié.