### PR TITLE
fix(gametheory): add python-sat and z3-solver to requirements.txt

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/requirements.txt
+++ b/MyIA.AI.Notebooks/GameTheory/requirements.txt
@@ -32,6 +32,10 @@ sympy>=1.12
 # Optional: Deep learning for Deep CFR
 # torch>=2.0.0
 
+# SAT/SMT Solvers (SocialChoice/04, GameTheory-1 setup check)
+python-sat>=0.1.8             # PySAT — SAT solving (Glucose3, Minisat22, Cadical103)
+z3-solver>=4.13               # Microsoft Z3 SMT solver
+
 # Utilities
 python-dotenv>=1.0.0
 


### PR DESCRIPTION
## Summary

`GameTheory/requirements.txt` manque `python-sat` (PySAT) et `z3-solver` (Z3 SMT solver), tous deux importés par `SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb`.

## Bug réel

`pip install -r requirements.txt` puis exécution du notebook SAT/Z3 → `ModuleNotFoundError` sur pysat et z3.

## Changes

| Package | Notebook | Import |
|---------|----------|--------|
| `python-sat>=0.1.8` | SocialChoice/04, GameTheory-1 setup | `from pysat.solvers import Glucose3` |
| `z3-solver>=4.13` | SocialChoice/04 | `from z3 import Solver, Bool, And, Or, Not` |

Scope: `requirements.txt` seul (+4 lignes). 0 notebook/code modifié.

Note: `open_spiel` (déjà listé) a des wheels pip Windows récents (v1.6.15) — pas de blocage WSL contrairement à ce qui a été documenté pour Search.