### PR TITLE
fix(kernel): normalize display_name 'base' to 'Python 3' across 32 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -2302,7 +2302,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -524,7 +524,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -1127,7 +1127,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
@@ -1180,7 +1180,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/02-SemanticKernel-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/02-SemanticKernel-Advanced.ipynb
@@ -1752,7 +1752,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
@@ -1621,7 +1621,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb
@@ -705,7 +705,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb
@@ -2960,7 +2960,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10a-SemanticKernel-NotebookMaker-batch.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10a-SemanticKernel-NotebookMaker-batch.ipynb
@@ -5070,7 +5070,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb
@@ -4561,7 +4561,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -4943,7 +4943,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -1810,7 +1810,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -1306,7 +1306,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -1669,7 +1669,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -2302,7 +2302,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -2848,7 +2848,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -1357,7 +1357,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -1843,7 +1843,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -1939,7 +1939,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -2153,7 +2153,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/notebooks/1.2-Manipulation_de_Donnees_avec_NumPy.ipynb
@@ -353,7 +353,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Search/CSPs_Intro.ipynb
+++ b/MyIA.AI.Notebooks/Search/CSPs_Intro.ipynb
@@ -1575,7 +1575,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-9-Distributed.ipynb
@@ -2700,7 +2700,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
@@ -2142,7 +2142,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -1130,7 +1130,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-0-init.ipynb
@@ -2323,7 +2323,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-3-orchestration.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Agentic-3-orchestration.ipynb
@@ -963,7 +963,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
@@ -2452,7 +2452,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -1253,7 +1253,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics.ipynb
@@ -2090,7 +2090,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
@@ -1188,7 +1188,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -1287,7 +1287,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Summary

32 Python notebooks have `kernelspec.display_name = "base"` (conda env name leaked) instead of the canonical `"Python 3"`. All are `name: python3, language: python` — purely a metadata cosmetic issue.

## Root cause

When notebooks were executed in a conda environment named "base", the kernel metadata captured the env name rather than the canonical display name.

## Changes

- 32 files, metadata-only (kernelspec.display_name)
- **Zero** cell source, outputs, or execution_count modified
- Affects: GenAI/Texte (10), GenAI/SemanticKernel (7), SymbolicAI/Argument_Analysis (3), SymbolicAI/Planners (2), Search (3), Sudoku (1), CaseStudies (2), ML (1), SemanticWeb (1), Tweety (1)

## Verification

Scanned all ~500 notebooks for `display_name: "base"`, confirmed all 32 matches are Python kernel (`name=python3`). Each diff is exactly 1 line changed.