### PR TITLE
fix(smartcontracts): SC-10 ERC-4337 — restore deployable execution (#1747)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002621,
+     "end_time": "2026-05-29T02:42:29.217122",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.214501",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# SC-10-Account-Abstraction - ERC-4337\n",
     "\n",
@@ -30,7 +39,16 @@
   {
    "cell_type": "markdown",
    "id": "web3-setup-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002332,
+     "end_time": "2026-05-29T02:42:29.221808",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.219476",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -43,7 +61,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003003,
+     "end_time": "2026-05-29T02:42:29.227520",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.224517",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -62,14 +89,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "cell-2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:29.233681Z",
+     "iopub.status.busy": "2026-05-29T02:42:29.233516Z",
+     "iopub.status.idle": "2026-05-29T02:42:29.766683Z",
+     "shell.execute_reply": "2026-05-29T02:42:29.766172Z"
+    },
+    "papermill": {
+     "duration": 0.537888,
+     "end_time": "2026-05-29T02:42:29.767991",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.230103",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "web3.py disponible.\n",
+      "py-solc-x disponible.\n",
+      "forge_helper disponible.\n",
+      "Connexion Web3: OK\n",
+      "Deployeur: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
+      "solcx version: 0.8.28\n",
       "Structure UserOperation (ERC-4337):\n",
       "\n",
       "// SPDX-License-Identifier: MIT\n",
@@ -118,6 +166,8 @@
     "    SOLCX_AVAILABLE = False\n",
     "    print('py-solc-x non disponible. Compilation Solc skippee.')\n",
     "\n",
+    "import sys, os\n",
+    "sys.path.insert(0, os.path.abspath(\"..\"))\n",
     "try:\n",
     "    from forge_helper import forge_compile, forge_compile_and_deploy\n",
     "    FORGE_HELPER_AVAILABLE = True\n",
@@ -126,27 +176,37 @@
     "    FORGE_HELPER_AVAILABLE = False\n",
     "    print('forge_helper non disponible. Compilation Foundry skippee.')\n",
     "\n",
+    "deployer = None\n",
+    "\n",
     "if WEB3_AVAILABLE:\n",
-    "    # Connexion au provider (Ganache local ou autre RPC)\n",
+    "    # Connexion au provider (anvil local ou autre RPC)\n",
     "    w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8545'))\n",
     "    connected = w3.is_connected()\n",
     "    print(f'Connexion Web3: {\"OK\" if connected else \"ECHOUEE\"}')\n",
     "\n",
+    "    # Compte deployeur = premier compte finance par anvil\n",
+    "    if connected:\n",
+    "        deployer = w3.eth.accounts[0]\n",
+    "        print(f'Deployeur: {deployer}')\n",
+    "\n",
     "    if not SOLCX_AVAILABLE:\n",
     "        print('Note: py-solc-x non installe. Utilisez forge_helper ou installez avec pip install py-solc-x')\n",
     "\n",
-    "    # Fonction utilitaire de compilation (si solcx disponible)\n",
+    "    # Fonction utilitaire de compilation (si solcx disponible).\n",
+    "    # Version solc alignee sur le pragma des contrats (^0.8.28) et la chaine Foundry.\n",
     "    if SOLCX_AVAILABLE:\n",
     "        try:\n",
-    "            solcx.install_solc('0.8.20')\n",
-    "            solcx.set_solc_version('0.8.20')\n",
+    "            solcx.install_solc('0.8.28')\n",
+    "            solcx.set_solc_version('0.8.28')\n",
     "            print(f'solcx version: {solcx.get_solc_version()}')\n",
     "        except Exception as e:\n",
     "            print(f'Erreur configuration solcx: {e}')\n",
     "            SOLCX_AVAILABLE = False\n",
     "\n",
-    "    def compile_and_deploy(w3_instance, contract_source, contract_name='SimpleAccount'):\n",
-    "        # Compile et deploye un contrat Solidity via solcx\n",
+    "    def compile_and_deploy(w3_instance, contract_source, constructor_arg=None, deploy_from=None):\n",
+    "        # Compile et deploie un contrat Solidity via solcx.\n",
+    "        # constructor_arg : argument unique passe au constructeur (None = aucun).\n",
+    "        # deploy_from     : compte emetteur de la transaction de deploiement.\n",
     "        if not SOLCX_AVAILABLE:\n",
     "            print('solcx non disponible pour compilation.')\n",
     "            return None, None\n",
@@ -154,24 +214,26 @@
     "            compiled = solcx.compile_source(\n",
     "                contract_source,\n",
     "                output_values=['abi', 'bin'],\n",
-    "                solc_version='0.8.20'\n",
+    "                solc_version='0.8.28'\n",
     "            )\n",
     "            contract_id, contract_interface = compiled.popitem()\n",
+    "            contract_name = contract_id.split(':')[-1]\n",
     "            abi = contract_interface['abi']\n",
     "            bytecode = contract_interface['bin']\n",
     "            Contract = w3_instance.eth.contract(abi=abi, bytecode=bytecode)\n",
-    "            tx_hash = Contract.constructor().transact()\n",
+    "            sender = deploy_from if deploy_from is not None else w3_instance.eth.accounts[0]\n",
+    "            ctor_args = [] if constructor_arg is None else [constructor_arg]\n",
+    "            tx_hash = Contract.constructor(*ctor_args).transact({'from': sender})\n",
     "            tx_receipt = w3_instance.eth.wait_for_transaction_receipt(tx_hash)\n",
     "            contract_address = tx_receipt['contractAddress']\n",
     "            deployed_contract = w3_instance.eth.contract(address=contract_address, abi=abi)\n",
-    "            print(f\"Contrat '{contract_name}' deploye a: {contract_address}\")\n",
-    "            return deployed_contract, contract_address\n",
+    "            print(f\"Deploye: {contract_name} a {contract_address}\")\n",
+    "            return deployed_contract, tx_receipt\n",
     "        except Exception as e:\n",
     "            print(f'Erreur compilation/deployment: {e}')\n",
     "            return None, None\n",
     "else:\n",
-    "    print('Web3 non disponible. Cellules dependantes desactivees.')",
-    "\n",
+    "    print('Web3 non disponible. Cellules dependantes desactivees.')\n",
     "# UserOperation structure\n",
     "USER_OP_STRUCT = '''\n",
     "// SPDX-License-Identifier: MIT\n",
@@ -205,6 +267,16 @@
   {
    "cell_type": "markdown",
    "id": "bf805bce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002223,
+     "end_time": "2026-05-29T02:42:29.772535",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.770312",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Structure UserOperation ERC-4337\n",
     "\n",
@@ -230,13 +302,21 @@
     "3. Le `paymasterAndData` permet de sponsoriser les frais de gas (gasless transactions)\n",
     "\n",
     "> **Note technique** : Contrairement à une transaction Ethereum classique, une UserOperation ne contient pas de `value` ni de `to` directs. Ces informations sont encodées dans le `callData`.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00199,
+     "end_time": "2026-05-29T02:42:29.776496",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.774506",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -247,9 +327,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "cell-4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:29.781611Z",
+     "iopub.status.busy": "2026-05-29T02:42:29.781423Z",
+     "iopub.status.idle": "2026-05-29T02:42:29.940347Z",
+     "shell.execute_reply": "2026-05-29T02:42:29.939613Z"
+    },
+    "papermill": {
+     "duration": 0.162511,
+     "end_time": "2026-05-29T02:42:29.941012",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.778501",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -352,6 +447,16 @@
   {
    "cell_type": "markdown",
    "id": "db5fd957",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002363,
+     "end_time": "2026-05-29T02:42:29.946028",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.943665",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Compilation du SimpleAccount avec Foundry\n",
     "\n",
@@ -379,13 +484,21 @@
     "3. L'ABI contient les événements pour le suivi des opérations\n",
     "\n",
     "> **Note technique** : La compilation avec Foundry (`forge_compile`) résout automatiquement les imports `@account-abstraction` et `@openzeppelin` depuis le répertoire `lib/` du projet Foundry.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-4b-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002167,
+     "end_time": "2026-05-29T02:42:29.950388",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.948221",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Version standalone deployable\n",
     "\n",
@@ -396,15 +509,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "cell-4b",
-   "metadata": {},
-   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:29.956032Z",
+     "iopub.status.busy": "2026-05-29T02:42:29.955809Z",
+     "iopub.status.idle": "2026-05-29T02:42:30.029908Z",
+     "shell.execute_reply": "2026-05-29T02:42:30.029270Z"
+    },
+    "papermill": {
+     "duration": 0.077916,
+     "end_time": "2026-05-29T02:42:30.030530",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:29.952614",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: StandaloneSmartAccount a 0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB\n",
+      "Deploye: StandaloneSmartAccount a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n",
       "Owner: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
       "Nonce: 0\n",
       "Balance du smart account: 1 ETH\n"
@@ -493,6 +621,16 @@
   {
    "cell_type": "markdown",
    "id": "2943a99c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002281,
+     "end_time": "2026-05-29T02:42:30.035312",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.033031",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Déploiement et test du StandaloneSmartAccount\n",
     "\n",
@@ -516,13 +654,21 @@
     "3. Le smart account peut recevoir et stocker de l'ETH (fonction `receive()`)\n",
     "\n",
     "> **Note technique** : Cette version standalone illustre les concepts ERC-4337 sans dépendances. En production, utilisez l'infrastructure complète avec EntryPoint et Bundler.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002483,
+     "end_time": "2026-05-29T02:42:30.040371",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.037888",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -533,9 +679,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "cell-6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:30.046186Z",
+     "iopub.status.busy": "2026-05-29T02:42:30.046014Z",
+     "iopub.status.idle": "2026-05-29T02:42:30.207758Z",
+     "shell.execute_reply": "2026-05-29T02:42:30.207232Z"
+    },
+    "papermill": {
+     "duration": 0.165531,
+     "end_time": "2026-05-29T02:42:30.208352",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.042821",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -648,6 +809,16 @@
   {
    "cell_type": "markdown",
    "id": "49794d49",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002328,
+     "end_time": "2026-05-29T02:42:30.213178",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.210850",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Compilation du VerifyingPaymaster\n",
     "\n",
@@ -674,13 +845,21 @@
     "3. Le stake est requis pour éviter les attaques DOS (le paymaster perd son stake s'il fraude)\n",
     "\n",
     "> **Note technique** : En production, le paymaster doit être staké (généralement ~1 ETH) et déposé avec des fonds pour sponsoriser les gas des utilisateurs.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-6b-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002332,
+     "end_time": "2026-05-29T02:42:30.218008",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.215676",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Version standalone deployable\n",
     "\n",
@@ -690,15 +869,30 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "cell-6b",
-   "metadata": {},
-   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:30.223485Z",
+     "iopub.status.busy": "2026-05-29T02:42:30.223321Z",
+     "iopub.status.idle": "2026-05-29T02:42:30.302055Z",
+     "shell.execute_reply": "2026-05-29T02:42:30.301519Z"
+    },
+    "papermill": {
+     "duration": 0.082376,
+     "end_time": "2026-05-29T02:42:30.302575",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.220199",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: StandalonePaymaster a 0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9\n",
+      "Deploye: StandalonePaymaster a 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e\n",
       "Deposit du paymaster: 5 ETH\n",
       "Gas sponsorise pour 0x70997970... : 0.1 ETH\n",
       "Deposit restant: 4.9 ETH\n"
@@ -778,6 +972,16 @@
   {
    "cell_type": "markdown",
    "id": "e7dafb61",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002393,
+     "end_time": "2026-05-29T02:42:30.307437",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.305044",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation : Déploiement et test du StandalonePaymaster\n",
     "\n",
@@ -802,13 +1006,21 @@
     "3. En production, le paymaster vérifie la signature off-chain avant de sponsoriser\n",
     "\n",
     "> **Note technique** : Dans un vrai déploiement ERC-4337, le paymaster rembourse le smart account après l'exécution de la UserOperation. Le montant remboursé est basé sur le gas réellement utilisé.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002284,
+     "end_time": "2026-05-29T02:42:30.312069",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.309785",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -817,9 +1029,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "cell-8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:30.317801Z",
+     "iopub.status.busy": "2026-05-29T02:42:30.317615Z",
+     "iopub.status.idle": "2026-05-29T02:42:30.321049Z",
+     "shell.execute_reply": "2026-05-29T02:42:30.320355Z"
+    },
+    "papermill": {
+     "duration": 0.007142,
+     "end_time": "2026-05-29T02:42:30.321604",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.314462",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -897,7 +1124,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002382,
+     "end_time": "2026-05-29T02:42:30.326537",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.324155",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -906,10 +1142,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "cell-10",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-29T02:42:30.333225Z",
+     "iopub.status.busy": "2026-05-29T02:42:30.332945Z",
+     "iopub.status.idle": "2026-05-29T02:42:30.337599Z",
+     "shell.execute_reply": "2026-05-29T02:42:30.336941Z"
+    },
+    "papermill": {
+     "duration": 0.00915,
+     "end_time": "2026-05-29T02:42:30.338224",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.329074",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice Social Recovery Account - a completer\n",
+      "Implementez les fonctions marquees TODO dans EXERCISE_RECOVERY\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice: Social Recovery Account\n",
     "# Version standalone (sans dependances ERC-4337) - a completer\n",
@@ -997,13 +1257,22 @@
     "'''\n",
     "\n",
     "print(\"Exercice Social Recovery Account - a completer\")\n",
-    "print(\"Implementez les fonctions marquees TODO dans EXERCISE_RECOVERY\")\n",
-    ""
+    "print(\"Implementez les fonctions marquees TODO dans EXERCISE_RECOVERY\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "5efac378",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002991,
+     "end_time": "2026-05-29T02:42:30.343990",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.340999",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Indice : Exercice Social Recovery Account\n",
     "\n",
@@ -1047,13 +1316,21 @@
     "   - Reset `pendingNewOwner`, `recoveryApprovals` et tous les `hasApprovedRecovery`\n",
     "\n",
     "> **Conseil** : Utilisez des boucles `for` pour itérer sur les gardiens dans le constructor et pour reset les approvals dans `cancelRecovery()`.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-11",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002644,
+     "end_time": "2026-05-29T02:42:30.349313",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.346669",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1075,7 +1352,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "fa449d3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002861,
+     "end_time": "2026-05-29T02:42:30.355237",
+     "exception": false,
+     "start_time": "2026-05-29T02:42:30.352376",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1090,8 +1377,28 @@
    "name": "smartcontracts"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.042843,
+   "end_time": "2026-05-29T02:42:30.623157",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "SC-10-Account-Abstraction.ipynb",
+   "output_path": "SC-10-Account-Abstraction.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-29T02:42:27.580314",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Contexte (#1747 — exécution réelle des notebooks SmartContracts)

Re-exécution de **SC-10-Account-Abstraction** depuis un kernel propre (`papermill -k smartcontracts`, anvil local live) : le notebook committé affichait `execution_count` peuplé + 0 erreur, mais ces **outputs étaient périmés** (issus d'une révision source antérieure). Re-exécuté tel quel, il échouait. Trois bugs réels exposés :

| # | Bug | Fix |
|---|-----|-----|
| 1 | `NameError: forge_compile` | `forge_helper.py` est à la racine de la série, pas sur `sys.path` depuis `02-Solidity-Advanced/`. Ajout de `sys.path.insert(0, os.path.abspath(".."))` avant l'import (pattern SC-7). |
| 2 | `NameError: deployer` | Variable utilisée dans les 2 cellules de déploiement standalone mais jamais définie. Ajout `deployer = w3.eth.accounts[0]`. |
| 3 | `compile_and_deploy` cassé | Signature 3-args sans args constructeur / `from`, alors que les appels passent `(w3, SRC, deployer, deployer)` et les contrats ont un constructeur. Restauré `(w3, source, constructor_arg=None, deploy_from=None)` + solc aligné sur **0.8.28** (était 0.8.20, rejetait le pragma `^0.8.28`). |

## Preuve d'exécution (règle D / H.1)

```
Executing: 100%|██████████| 24/24 [00:03<00:00, 7.89cell/s]
Deploye: StandaloneSmartAccount a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318
Owner: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Nonce: 0
Balance du smart account: 1 ETH
Deploye: StandalonePaymaster a 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e
Deposit du paymaster: 5 ETH
Gas sponsorise pour 0x70997970... : 0.1 ETH
Deposit restant: 4.9 ETH
```

- 24/24 cellules exécutées, **0 erreur**, aucun `execution_count: null`.
- 0 `NotImplementedError` / `assert False` / `1/0` (l'exercice Social Recovery reste un stub conforme C.1).
- Committé **avec outputs frais** (C.2). **SC-10 seul** notebook source-modifié (C.3).
- Cellule d'exercice (`SocialRecoveryAccount`, TODO étudiant) **inchangée** — pas de régression de contenu.

## Scope

1 fichier, 1 notebook, 1 domaine (SmartContracts). CI Papermill peut être SKIP (kernel `smartcontracts` + anvil non disponibles en CI) — exécution locale prouvée ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)