### PR TITLE
test(qc): add 24 tests for AlgorithmTester + fix f-string/CSS bugs

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/scripts/test_algorithms.py
+++ b/MyIA.AI.Notebooks/QuantConnect/scripts/test_algorithms.py
@@ -282,15 +282,15 @@ class AlgorithmTester:
     <meta charset="utf-8">
     <title>QuantConnect Algorithms Test Report</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        h1 { color: #0066cc; }
-        table { border-collapse: collapse; width: 100%; margin-top: 20px; }
-        th, td { border: 1px solid #ddd; padding: 12px; text-align: left; }
-        th { background-color: #0066cc; color: white; }
-        tr:nth-child(even) { background-color: #f2f2f2; }
-        .success { color: green; font-weight: bold; }
-        .failed { color: red; font-weight: bold; }
-        .metric { text-align: right; }
+        body {{ font-family: Arial, sans-serif; margin: 20px; }}
+        h1 {{ color: #0066cc; }}
+        table {{ border-collapse: collapse; width: 100%; margin-top: 20px; }}
+        th, td {{ border: 1px solid #ddd; padding: 12px; text-align: left; }}
+        th {{ background-color: #0066cc; color: white; }}
+        tr:nth-child(even) {{ background-color: #f2f2f2; }}
+        .success {{ color: green; font-weight: bold; }}
+        .failed {{ color: red; font-weight: bold; }}
+        .metric {{ text-align: right; }}
     </style>
 </head>
 <body>
@@ -325,9 +325,9 @@ class AlgorithmTester:
                 <td>{algo_name}</td>
                 <td>{result['language']}</td>
                 <td class="{status_class}">{status.upper()}</td>
-                <td class="metric">{metrics.get('sharpe_ratio', 'N/A'):.2f if isinstance(metrics.get('sharpe_ratio'), (int, float)) else 'N/A'}</td>
-                <td class="metric">{metrics.get('total_return', 'N/A'):.2%} if isinstance(metrics.get('total_return'), (int, float)) else 'N/A'}</td>
-                <td class="metric">{metrics.get('max_drawdown', 'N/A'):.2%} if isinstance(metrics.get('max_drawdown'), (int, float)) else 'N/A'}</td>
+                <td class="metric">{f"{metrics.get('sharpe_ratio'):.2f}" if isinstance(metrics.get('sharpe_ratio'), (int, float)) else 'N/A'}</td>
+                <td class="metric">{metrics.get('total_return', 'N/A') if not isinstance(metrics.get('total_return'), (int, float)) else f"{metrics.get('total_return'):.2%}"}</td>
+                <td class="metric">{metrics.get('max_drawdown', 'N/A') if not isinstance(metrics.get('max_drawdown'), (int, float)) else f"{metrics.get('max_drawdown'):.2%}"}</td>
                 <td class="metric">{metrics.get('trades', 'N/A')}</td>
                 <td class="metric">{result.get('duration', 0):.1f}</td>
             </tr>

--- a/MyIA.AI.Notebooks/QuantConnect/scripts/tests/test_algorithms.py
+++ b/MyIA.AI.Notebooks/QuantConnect/scripts/tests/test_algorithms.py
@@ -1,0 +1,247 @@
+"""Tests for test_algorithms.py — QC Algorithms Backtest Runner.
+
+These tests cover the pure-logic parts of AlgorithmTester without running
+actual LEAN CLI backtests (no subprocess, no network).
+
+Run from the tests directory:
+    python -m pytest test_algorithms.py -v
+"""
+
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from test_algorithms import AlgorithmTester
+
+
+# --- AlgorithmTester.__init__ ---
+
+
+class TestInit:
+    def test_defaults(self):
+        t = AlgorithmTester()
+        assert t.mode == "lean-cli"
+        assert t.verbose is True
+        assert t.results == []
+
+    def test_custom_mode(self):
+        t = AlgorithmTester(mode="mcp", verbose=False)
+        assert t.mode == "mcp"
+        assert t.verbose is False
+
+    def test_results_list_independent(self):
+        a = AlgorithmTester()
+        b = AlgorithmTester()
+        a.results.append({"test": 1})
+        assert b.results == []
+
+
+# --- AlgorithmTester.log ---
+
+
+class TestLog:
+    def test_verbose_prints(self, capsys):
+        t = AlgorithmTester(verbose=True)
+        t.log("hello", "INFO")
+        out = capsys.readouterr().out
+        assert "hello" in out
+
+    def test_silent_no_output(self, capsys):
+        t = AlgorithmTester(verbose=False)
+        t.log("hidden", "INFO")
+        out = capsys.readouterr().out
+        assert out == ""
+
+    def test_level_prefixes(self, capsys):
+        t = AlgorithmTester(verbose=True)
+        t.log("test", "SUCCESS")
+        out = capsys.readouterr().out
+        # Should contain some prefix character (checkmark or similar)
+        assert "test" in out
+
+    def test_unknown_level(self, capsys):
+        t = AlgorithmTester(verbose=True)
+        t.log("msg", "CUSTOM")
+        out = capsys.readouterr().out
+        assert "msg" in out
+
+
+# --- AlgorithmTester._parse_lean_output ---
+
+
+class TestParseLeanOutput:
+    def setup_method(self):
+        self.tester = AlgorithmTester(verbose=False)
+
+    def test_all_metrics(self):
+        output = """
+Backtest completed.
+Total Net Profit: 15.30%
+Sharpe Ratio: 1.42
+Drawdown: -8.50%
+Total Trades: 120
+Win Rate: 58.30%
+"""
+        metrics = self.tester._parse_lean_output(output)
+        assert abs(metrics["total_return"] - 0.153) < 1e-6
+        assert abs(metrics["sharpe_ratio"] - 1.42) < 1e-6
+        assert abs(metrics["max_drawdown"] - (-0.085)) < 1e-6
+        assert metrics["trades"] == 120.0
+        assert abs(metrics["win_rate"] - 0.583) < 1e-6
+
+    def test_negative_return(self):
+        output = "Total Net Profit: -5.20%"
+        metrics = self.tester._parse_lean_output(output)
+        assert abs(metrics["total_return"] - (-0.052)) < 1e-6
+
+    def test_sharpe_only(self):
+        output = "Sharpe Ratio: 2.10"
+        metrics = self.tester._parse_lean_output(output)
+        assert "sharpe_ratio" in metrics
+        assert "total_return" not in metrics
+
+    def test_empty_output(self):
+        metrics = self.tester._parse_lean_output("")
+        assert metrics == {}
+
+    def test_no_matching_patterns(self):
+        output = "Some random log output\nNothing useful here"
+        metrics = self.tester._parse_lean_output(output)
+        assert metrics == {}
+
+    def test_zero_values(self):
+        output = "Total Net Profit: 0.00%\nSharpe Ratio: 0.00\nTotal Trades: 0\nWin Rate: 0.00%"
+        metrics = self.tester._parse_lean_output(output)
+        assert metrics["total_return"] == 0.0
+        assert metrics["sharpe_ratio"] == 0.0
+        assert metrics["trades"] == 0.0
+        assert metrics["win_rate"] == 0.0
+
+    def test_large_sharpe(self):
+        output = "Sharpe Ratio: -3.75"
+        metrics = self.tester._parse_lean_output(output)
+        assert abs(metrics["sharpe_ratio"] - (-3.75)) < 1e-6
+
+    def test_percent_converted_to_decimal(self):
+        """Percentages are divided by 100."""
+        output = "Total Net Profit: 100.00%\nMax Drawdown: -50.00%"
+        # Note: the regex uses 'Drawdown:' not 'Max Drawdown:'
+        metrics = self.tester._parse_lean_output(output)
+        assert abs(metrics["total_return"] - 1.0) < 1e-6
+
+    def test_trades_as_integer_value(self):
+        output = "Total Trades: 42"
+        metrics = self.tester._parse_lean_output(output)
+        assert metrics["trades"] == 42.0
+
+
+# --- AlgorithmTester._test_with_mcp / _test_with_cloud_api ---
+
+
+class TestUnimplementedModes:
+    def test_mcp_returns_failed(self):
+        t = AlgorithmTester(mode="mcp", verbose=False)
+        result = t._test_with_mcp(Path("test.py"), "2020-01-01", "2023-12-31", "python")
+        assert result["status"] == "failed"
+        assert "not implemented" in result["error"].lower()
+
+    def test_cloud_returns_failed(self):
+        t = AlgorithmTester(mode="cloud", verbose=False)
+        result = t._test_with_cloud_api(Path("test.py"), "2020-01-01", "2023-12-31", "python")
+        assert result["status"] == "failed"
+        assert "not implemented" in result["error"].lower()
+
+
+# --- AlgorithmTester.generate_report ---
+
+
+class TestGenerateReport:
+    def test_empty_results_no_file(self, tmp_path):
+        t = AlgorithmTester(verbose=False)
+        report_path = tmp_path / "report.html"
+        t.generate_report(report_path)
+        assert not report_path.exists()
+
+    def test_generates_html(self, tmp_path):
+        t = AlgorithmTester(verbose=False)
+        t.results = [
+            {
+                "algorithm": "test_algo.py",
+                "language": "python",
+                "status": "success",
+                "metrics": {"sharpe_ratio": 1.5, "total_return": 0.10, "max_drawdown": -0.05, "trades": 50},
+                "duration": 12.3,
+            }
+        ]
+        report_path = tmp_path / "report.html"
+        t.generate_report(report_path)
+        assert report_path.exists()
+        content = report_path.read_text(encoding="utf-8")
+        assert "test_algo.py" in content
+        assert "SUCCESS" in content
+        assert "1.50" in content  # Sharpe displayed
+
+    def test_mixed_results(self, tmp_path):
+        t = AlgorithmTester(verbose=False)
+        t.results = [
+            {
+                "algorithm": "good.py",
+                "language": "python",
+                "status": "success",
+                "metrics": {},
+                "duration": 5.0,
+            },
+            {
+                "algorithm": "bad.py",
+                "language": "csharp",
+                "status": "failed",
+                "metrics": {},
+                "error": "Compilation error",
+                "duration": 1.0,
+            },
+        ]
+        report_path = tmp_path / "report.html"
+        t.generate_report(report_path)
+        content = report_path.read_text(encoding="utf-8")
+        assert "good.py" in content
+        assert "bad.py" in content
+        assert "FAILED" in content
+
+    def test_report_creates_parent_dirs(self, tmp_path):
+        t = AlgorithmTester(verbose=False)
+        t.results = [
+            {"algorithm": "a.py", "language": "python", "status": "success", "metrics": {}, "duration": 1.0}
+        ]
+        nested = tmp_path / "sub" / "dir" / "report.html"
+        t.generate_report(nested)
+        assert nested.exists()
+
+
+# --- AlgorithmTester.test_all ---
+
+
+class TestTestAll:
+    def test_empty_directory(self, tmp_path):
+        t = AlgorithmTester(verbose=False)
+        results = t.test_all(tmp_path, "python", "2020-01-01", "2023-12-31")
+        assert results == []
+
+    def test_finds_python_files(self, tmp_path):
+        (tmp_path / "algo1.py").write_text("# test", encoding="utf-8")
+        (tmp_path / "algo2.py").write_text("# test", encoding="utf-8")
+        (tmp_path / "readme.md").write_text("# docs", encoding="utf-8")
+        t = AlgorithmTester(verbose=False)
+        # test_all calls test_algorithm which tries lean-cli — it will fail
+        # but we verify it finds and attempts the 2 .py files
+        results = t.test_all(tmp_path, "python", "2020-01-01", "2023-12-31")
+        assert len(results) == 2
+        # Both will fail (no lean CLI) but the attempt was made
+        assert all(r["status"] == "failed" for r in results)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add 24 unit tests for test_algorithms.py (AlgorithmTester class) + fix 2 pre-existing bugs discovered during testing.

## Bugs Fixed

1. SyntaxError in f-string ternary (L328-330): {value:.2f if isinstance(...)} is invalid Python 3.12+ syntax. Fixed to proper ternary inside f-string.
2. CSS brace conflict in HTML template: { } in CSS were interpreted by str.format() as placeholder keys (KeyError). Escaped to {{ }}.

## Tests Added (24)

| Class | Tests | Covers |
|-------|-------|--------|
| TestInit | 3 | Constructor defaults, custom mode, independent results |
| TestLog | 4 | Verbose output, silent mode, level prefixes |
| TestParseLeanOutput | 8 | All metrics, negative return, partial, empty, zero values |
| TestUnimplementedModes | 2 | MCP/cloud return proper failure |
| TestGenerateReport | 4 | Empty results, HTML gen, mixed results, dir creation |
| TestTestAll | 2 | Empty dir, finds .py files |

## Test Results

24/24 passed, 109/109 total QC scripts tests (0 regression)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>