### PR TITLE
docs(symbolicai): add CATALOG-STATUS markers to 6 sub-series READMEs (refs #1660)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/README.md
@@ -1,5 +1,12 @@
 # Argument_Analysis - Analyse Argumentative avec Agents IA
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-Argument_Analysis
+pedagogical_count: 6
+breakdown: Pipeline=5, UI=1
+maturity: PRODUCTION=5, BETA=1
+-->
+
 Pipeline complet d'analyse argumentative combinant Semantic Kernel, TweetyProject et programmation logique pour l'identification et l'evaluation d'arguments dans des textes.
 
 ## Pourquoi cette serie

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -1,5 +1,12 @@
 # Lean - Solveur Mathematique et Verification Formelle
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-Lean
+pedagogical_count: 16
+breakdown: Fondations=5, Etat-de-l-art=6, Applications=3, Kochen-Specker=1, Tribute=1
+maturity: PRODUCTION=6, BETA=10
+-->
+
 Cette serie de **16 notebooks** introduit **Lean 4**, un assistant de preuves et langage de programmation fonctionnel base sur la theorie des types dependants, avec un focus sur les techniques modernes d'utilisation de LLMs pour l'assistance aux preuves, la verification formelle de reseaux de neurones, le port de theoremes phares (theoreme de Kochen-Specker, 18 vecteurs Cabello), et des hommages aux mathematiciens (Grothendieck, langage grothendieckien dans Mathlib 4).
 
 ## Navigation

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -1,5 +1,12 @@
 # Planification Automatique - Automated Planning
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-Planners
+pedagogical_count: 14
+breakdown: Environment=1, Foundation=3, Classical=4, Advanced=3, NeuroSymbolic=3
+maturity: PRODUCTION=10, BETA=4
+-->
+
 Cette serie de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui genere des sequences d'actions pour atteindre des objectifs.
 
 La planification repond a une question differente de celle de l'apprentissage : non pas « que predire ? » mais « **que faire ?** ». A partir d'un modele du monde — un etat initial, des actions avec leurs preconditions et effets, un but — un planificateur cherche automatiquement une suite d'actions qui mene au but. C'est une technologie eprouvee : elle pilote des robots (manipulation, navigation), optimise la logistique et l'ordonnancement, et a dirige des engins spatiaux autonomes (Remote Agent sur Deep Space 1, planification d'activites des rovers martiens). Le langage **PDDL** a standardise la maniere de decrire ces problemes, donnant naissance a tout un ecosysteme de solveurs comparables. La planification connait aujourd'hui un regain d'interet avec les LLMs, comme moyen de doter les modeles de langage d'une capacite d'action verifiable et orientee vers un but.

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -1,5 +1,12 @@
 # Web Semantique - Semantic Web
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-SemanticWeb
+pedagogical_count: 18
+breakdown: RDF-Foundations=6, Linked-Data-Ontologies=5, Modern-Standards=3, Knowledge-Graphs-IA=3, Legacy=1
+maturity: PRODUCTION=6, BETA=12
+-->
+
 Serie de notebooks pour explorer le **Web Semantique**, combinant **.NET C#** (dotNetRDF, fondations) et **Python** (rdflib, standards modernes, IA).
 
 ---

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -1,5 +1,12 @@
 # Smart Contracts - Des Cypherpunks aux Blockchains Modernes
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-SmartContracts
+pedagogical_count: 27
+breakdown: 00-Foundations=3, 01-Solidity-Foundation=4, 02-Solidity-Advanced=5, 03-Foundry-Testing=3, 04-Privacy-Cryptography=3, 05-Alternative-Chains=5, 06-Real-World=4
+maturity: PRODUCTION=11, BETA=16
+-->
+
 Serie de notebooks educatifs couvrant les fondements cryptographiques, le developpement Solidity, les tests, la cryptographie avancee (ZKP, HE, vote verifiable), et les blockchains alternatives.
 
 Un smart contract est un programme qui s'execute tout seul sur une blockchain : une fois deploye, son code fait foi, transfere de la valeur et applique des regles sans intermediaire ni possibilite de revenir en arriere. C'est ce qui fait sa puissance — des ecosystemes entiers (DeFi, NFT, DAO) reposent dessus — et son danger : un bug n'est pas un patch a pousser le lendemain, c'est une faille immuable qui peut couter des millions (le hack de The DAO en 2016, les exploits de ponts cross-chain). D'ou le poids accorde dans cette serie aux **tests, au fuzzing et a la verification formelle** autant qu'au developpement.

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -1,5 +1,12 @@
 # TweetyProject - Serie de Notebooks Jupyter
 
+<!-- CATALOG-STATUS
+series: SymbolicAI-Tweety
+pedagogical_count: 10
+breakdown: Fondations=3, Revision-Croyances=1, Argumentation=4, Applications=2
+maturity: PRODUCTION=6, BETA=4
+-->
+
 Serie complete de 10 notebooks pour explorer [TweetyProject](https://tweetyproject.org/), une bibliotheque Java pour l'intelligence artificielle symbolique.
 
 ## Presentation


### PR DESCRIPTION
## Summary

Add CATALOG-STATUS metadata markers to 6 SymbolicAI sub-series READMEs that were missing them.

## Sub-series covered

| Sub-series | Notebooks | Maturity |
|------------|-----------|----------|
| SmartContracts | 27 | PRODUCTION=11, BETA=16 |
| Lean | 16 | PRODUCTION=6, BETA=10 |
| Planners | 14 | PRODUCTION=10, BETA=4 |
| Tweety | 10 | PRODUCTION=6, BETA=4 |
| SemanticWeb | 18 | PRODUCTION=6, BETA=12 |
| Argument_Analysis | 6 | PRODUCTION=5, BETA=1 |

SymbolicLearning already had its marker. **7/7 sub-series now covered.**

## Scope

- 6 README files, 7 lines added each (CATALOG-STATUS HTML comment block)
- No code or content changes — metadata only
- 0 catalog drift

Refs #1660