### PR TITLE
test(notebook-tools): add 30 tests for auto_enrich_notebooks + exec_single_cell

### DIFF
--- a/scripts/notebook_tools/tests/test_auto_enrich_notebooks.py
+++ b/scripts/notebook_tools/tests/test_auto_enrich_notebooks.py
@@ -1,0 +1,138 @@
+"""Tests for auto_enrich_notebooks.py — notebook enrichment ratio and cell creation."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from auto_enrich_notebooks import (
+    calculate_ratio,
+    create_interpretation_cell,
+    load_notebook,
+    save_notebook,
+)
+
+
+def _nb(cells: list[dict]) -> dict:
+    """Build a minimal notebook dict."""
+    return {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+# --- calculate_ratio ---
+
+
+class TestCalculateRatio:
+    def test_all_markdown(self):
+        nb = _nb([
+            {"cell_type": "markdown", "source": ["# Title"]},
+            {"cell_type": "markdown", "source": ["## Section"]},
+        ])
+        assert calculate_ratio(nb) == 100.0
+
+    def test_all_code(self):
+        nb = _nb([
+            {"cell_type": "code", "source": ["x = 1"]},
+            {"cell_type": "code", "source": ["y = 2"]},
+        ])
+        assert calculate_ratio(nb) == 0.0
+
+    def test_balanced(self):
+        nb = _nb([
+            {"cell_type": "markdown", "source": ["text"]},
+            {"cell_type": "code", "source": ["x = 1"]},
+        ])
+        assert calculate_ratio(nb) == 50.0
+
+    def test_empty_notebook(self):
+        nb = _nb([])
+        assert calculate_ratio(nb) == 0.0
+
+    def test_three_code_one_md(self):
+        nb = _nb([
+            {"cell_type": "markdown", "source": ["text"]},
+            {"cell_type": "code", "source": ["x = 1"]},
+            {"cell_type": "code", "source": ["y = 2"]},
+            {"cell_type": "code", "source": ["z = 3"]},
+        ])
+        assert calculate_ratio(nb) == 25.0
+
+    def test_ignores_raw_cells(self):
+        """Non-markdown, non-code cells are not counted in total."""
+        nb = _nb([
+            {"cell_type": "markdown", "source": ["text"]},
+            {"cell_type": "raw", "source": ["raw content"]},
+        ])
+        # md=1, code=0, total=1 -> 100%
+        assert calculate_ratio(nb) == 100.0
+
+
+# --- create_interpretation_cell ---
+
+
+class TestCreateInterpretationCell:
+    def test_returns_markdown(self):
+        cell = create_interpretation_cell("Test", "Some content")
+        assert cell["cell_type"] == "markdown"
+
+    def test_contains_title(self):
+        cell = create_interpretation_cell("My Analysis", "Body text")
+        source = "".join(cell["source"])
+        assert "My Analysis" in source
+
+    def test_contains_content(self):
+        cell = create_interpretation_cell("Title", "Line1\nLine2")
+        source = "".join(cell["source"])
+        assert "Line1" in source
+        assert "Line2" in source
+
+    def test_source_is_list(self):
+        cell = create_interpretation_cell("Title", "Content")
+        assert isinstance(cell["source"], list)
+
+    def test_has_metadata(self):
+        cell = create_interpretation_cell("Title", "Content")
+        assert "metadata" in cell
+
+    def test_interpretation_header_prefix(self):
+        cell = create_interpretation_cell("Plot", "desc")
+        source = "".join(cell["source"])
+        assert "Interprétation - Plot" in source
+
+
+# --- load_notebook / save_notebook ---
+
+
+class TestLoadSaveNotebook:
+    def test_roundtrip(self, tmp_path):
+        nb = _nb([
+            {"cell_type": "code", "source": ["x = 1"]},
+        ])
+        p = tmp_path / "test.ipynb"
+        save_notebook(p, nb)
+        loaded = load_notebook(p)
+        assert loaded["cells"] == nb["cells"]
+
+    def test_save_creates_file(self, tmp_path):
+        p = tmp_path / "new.ipynb"
+        save_notebook(p, _nb([]))
+        assert p.exists()
+
+    def test_load_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_notebook(tmp_path / "nope.ipynb")
+
+    def test_save_preserves_unicode(self, tmp_path):
+        nb = _nb([
+            {"cell_type": "markdown", "source": ["# Résumé\nInterprétation"]},
+        ])
+        p = tmp_path / "unicode.ipynb"
+        save_notebook(p, nb)
+        loaded = load_notebook(p)
+        assert "Résumé" in "".join(loaded["cells"][0]["source"])

--- a/scripts/notebook_tools/tests/test_exec_single_cell.py
+++ b/scripts/notebook_tools/tests/test_exec_single_cell.py
@@ -1,0 +1,120 @@
+"""Tests for exec_single_cell.py — single cell execution helpers."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from exec_single_cell import _source, _is_dotnet_bootstrap
+
+
+# --- _source ---
+
+
+class TestSource:
+    def test_list_source_joined(self):
+        cell = {"source": ["line1\n", "line2\n", "line3"]}
+        assert _source(cell) == "line1\nline2\nline3"
+
+    def test_string_source_passthrough(self):
+        cell = {"source": "x = 1\ny = 2"}
+        assert _source(cell) == "x = 1\ny = 2"
+
+    def test_empty_list(self):
+        cell = {"source": []}
+        assert _source(cell) == ""
+
+    def test_single_item_list(self):
+        cell = {"source": ["only line"]}
+        assert _source(cell) == "only line"
+
+    def test_missing_source_key(self):
+        cell = {}
+        with pytest.raises(KeyError):
+            _source(cell)
+
+
+# --- _is_dotnet_bootstrap ---
+
+
+class TestIsDotnetBootstrap:
+    def test_normal_execute_result_not_bootstrap(self):
+        output = {
+            "output_type": "execute_result",
+            "data": {"text/plain": "42"},
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is False
+
+    def test_normal_stream_not_bootstrap(self):
+        output = {
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "hello",
+        }
+        assert _is_dotnet_bootstrap(output) is False
+
+    def test_dotnet_interactive_div_detected(self):
+        output = {
+            "output_type": "display_data",
+            "data": {
+                "text/html": "<div class='dotnet-interactive-this-cell'>port info</div>",
+            },
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is True
+
+    def test_http_port_detected(self):
+        output = {
+            "output_type": "execute_result",
+            "data": {
+                "text/html": "<div>HttpPort=44528</div>",
+            },
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is True
+
+    def test_html_as_list(self):
+        output = {
+            "output_type": "display_data",
+            "data": {
+                "text/html": ["<div>", "dotnet-interactive-this-cell", "</div>"],
+            },
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is True
+
+    def test_normal_html_not_bootstrap(self):
+        output = {
+            "output_type": "display_data",
+            "data": {
+                "text/html": "<h1>Results</h1>",
+            },
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is False
+
+    def test_error_output_not_bootstrap(self):
+        output = {
+            "output_type": "error",
+            "ename": "RuntimeError",
+            "evalue": "fail",
+            "traceback": [],
+        }
+        assert _is_dotnet_bootstrap(output) is False
+
+    def test_no_data_key(self):
+        output = {
+            "output_type": "display_data",
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is False
+
+    def test_html_as_empty_list(self):
+        output = {
+            "output_type": "display_data",
+            "data": {"text/html": []},
+            "metadata": {},
+        }
+        assert _is_dotnet_bootstrap(output) is False


### PR DESCRIPTION
## Summary
- **auto_enrich_notebooks.py**: 17 tests covering `calculate_ratio`, `create_interpretation_cell`, `load_notebook`, `save_notebook`
- **exec_single_cell.py**: 13 tests covering `_source` (list/string source extraction) and `_is_dotnet_bootstrap` (dotnet-interactive HTTP port filter)

## Test plan
- [x] 527/527 tests passing (30 new)
- [x] No regressions in existing tests
- [x] Pure unit tests, no external dependencies (Docker, Jupyter kernel)