### PR TITLE
test(datasets): add 31 tests for build_panier_anti_bias and stitch_crypto

### DIFF
--- a/scripts/notebook_tools/tests/test_build_panier_anti_bias.py
+++ b/scripts/notebook_tools/tests/test_build_panier_anti_bias.py
@@ -1,0 +1,102 @@
+"""Tests for build_panier_anti_bias.py — panier symbol management and anti-bias policy."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load module directly by file path to avoid conflict with HuggingFace 'datasets'
+_MOD_PATH = Path(__file__).resolve().parent.parent.parent / "datasets" / "build_panier_anti_bias.py"
+_spec = importlib.util.spec_from_file_location("build_panier_anti_bias", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+get_all_symbols = _mod.get_all_symbols
+get_group = _mod.get_group
+PANIER = _mod.PANIER
+FORBIDDEN_SYMBOLS = _mod.FORBIDDEN_SYMBOLS
+TICKER_MAP = _mod.TICKER_MAP
+
+
+# --- PANIER structure ---
+
+
+class TestPanierConfig:
+    def test_panier_has_required_groups(self):
+        expected = {
+            "us_equity_broad", "us_equity_sectors", "volatility",
+            "us_bonds", "commodities", "international", "crypto",
+        }
+        assert set(PANIER.keys()) == expected
+
+    def test_panier_minimum_symbols(self):
+        """At least 22 symbols required for diversification."""
+        total = sum(len(v) for v in PANIER.values())
+        assert total >= 22
+
+    def test_no_forbidden_in_panier(self):
+        """No FAANG+ individual stocks in the panier."""
+        all_symbols = set()
+        for group in PANIER.values():
+            all_symbols.update(group.keys())
+        forbidden_present = all_symbols & FORBIDDEN_SYMBOLS
+        assert forbidden_present == set(), f"Forbidden symbols found: {forbidden_present}"
+
+    def test_forbidden_symbols_set(self):
+        assert FORBIDDEN_SYMBOLS == {"AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "TSLA", "META"}
+
+    def test_ticker_map_has_vix(self):
+        assert TICKER_MAP.get("VIX") == "^VIX"
+
+
+# --- get_all_symbols ---
+
+
+class TestGetAllSymbols:
+    def test_returns_list(self):
+        result = get_all_symbols()
+        assert isinstance(result, list)
+
+    def test_contains_spy(self):
+        assert "SPY" in get_all_symbols()
+
+    def test_contains_btc(self):
+        assert "BTC-USD" in get_all_symbols()
+
+    def test_no_duplicates(self):
+        symbols = get_all_symbols()
+        assert len(symbols) == len(set(symbols))
+
+    def test_minimum_count(self):
+        assert len(get_all_symbols()) >= 22
+
+
+# --- get_group ---
+
+
+class TestGetGroup:
+    def test_spy_is_equity_broad(self):
+        assert get_group("SPY") == "us_equity_broad"
+
+    def test_btc_is_crypto(self):
+        assert get_group("BTC-USD") == "crypto"
+
+    def test_gld_is_commodities(self):
+        assert get_group("GLD") == "commodities"
+
+    def test_tlt_is_bonds(self):
+        assert get_group("TLT") == "us_bonds"
+
+    def test_unknown_symbol(self):
+        assert get_group("FAKE") == "unknown"
+
+    def test_all_symbols_have_group(self):
+        """Every symbol in PANIER should resolve to its group."""
+        for group_name, group_dict in PANIER.items():
+            for symbol in group_dict:
+                assert get_group(symbol) == group_name, f"{symbol} should be in {group_name}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/scripts/notebook_tools/tests/test_stitch_crypto.py
+++ b/scripts/notebook_tools/tests/test_stitch_crypto.py
@@ -1,0 +1,184 @@
+"""Tests for stitch_crypto.py — crypto dataset stitching pure functions."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Load module directly by file path to avoid conflict with HuggingFace 'datasets'
+_MOD_PATH = Path(__file__).resolve().parent.parent.parent / "datasets" / "stitch_crypto.py"
+_spec = importlib.util.spec_from_file_location("stitch_crypto", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+validate_overlap = _mod.validate_overlap
+stitch_datasets = _mod.stitch_datasets
+quality_report = _mod.quality_report
+
+
+def _make_df(rows: list[tuple]) -> pd.DataFrame:
+    """Build a minimal DataFrame with timestamp, close, source columns.
+
+    rows: list of (timestamp_str, close_value, source_name)
+    """
+    return pd.DataFrame(rows, columns=["timestamp", "close", "source"]).assign(
+        timestamp=lambda d: pd.to_datetime(d["timestamp"]),
+        close=lambda d: pd.to_numeric(d["close"]),
+        open=lambda d: d["close"],
+        high=lambda d: d["close"],
+        low=lambda d: d["close"],
+        volume_btc=1.0,
+        volume_usd=100.0,
+    )
+
+
+# --- validate_overlap ---
+
+
+class TestValidateOverlap:
+    def test_no_overlap(self):
+        a = _make_df([("2020-01-01", 100, "A"), ("2020-01-02", 101, "A")])
+        b = _make_df([("2021-01-01", 200, "B"), ("2021-01-02", 201, "B")])
+        result = validate_overlap(a, b)
+        assert result["has_overlap"] is False
+
+    def test_perfect_overlap(self):
+        a = _make_df([("2020-01-01", 100, "A"), ("2020-01-02", 101, "A")])
+        b = _make_df([("2020-01-01", 100, "B"), ("2020-01-02", 101, "B")])
+        result = validate_overlap(a, b)
+        assert result["has_overlap"] is True
+        assert result["common_points"] == 2
+        assert result["mean_diff_pct"] == 0.0
+        assert result["within_threshold"] is True
+
+    def test_close_price_mismatch(self):
+        """Two overlapping periods with different close prices."""
+        a = _make_df([("2020-01-01", 100, "A"), ("2020-01-02", 101, "A")])
+        b = _make_df([("2020-01-01", 200, "B"), ("2020-01-02", 202, "B")])
+        result = validate_overlap(a, b)
+        assert result["has_overlap"] is True
+        assert result["common_points"] == 2
+        assert result["mean_diff_pct"] >= 50.0
+        assert result["within_threshold"] is False
+
+    def test_partial_overlap(self):
+        """Overlap of a single point where periods touch at boundary.
+
+        Note: validate_overlap uses overlap_start >= overlap_end to detect
+        no overlap, so periods sharing only an endpoint have no overlap
+        (strict inequality). Use wider overlap for single-point match.
+        """
+        a = _make_df([("2020-01-01", 100, "A"), ("2020-01-02", 101, "A"), ("2020-01-03", 102, "A")])
+        b = _make_df([("2020-01-02", 101, "B"), ("2020-01-03", 102, "B"), ("2020-01-04", 103, "B")])
+        result = validate_overlap(a, b)
+        assert result["has_overlap"] is True
+        assert result["common_points"] == 2
+
+    def test_empty_dataframe_crashes(self):
+        """Empty DataFrame with NaT min/max causes TypeError in validate_overlap.
+
+        This is a known behavior — validate_overlap doesn't guard against
+        empty inputs.
+        """
+        a = pd.DataFrame(columns=["timestamp", "close", "source"])
+        b = _make_df([("2020-01-01", 100, "B")])
+        with pytest.raises(TypeError):
+            validate_overlap(a, b)
+
+
+# --- stitch_datasets ---
+
+
+class TestStitchDatasets:
+    def test_single_source(self):
+        a = _make_df([("2020-01-01", 100, "A"), ("2020-01-02", 101, "A")])
+        result = stitch_datasets([a])
+        assert len(result) == 2
+
+    def test_non_overlapping_sources(self):
+        a = _make_df([("2020-01-01", 100, "A")])
+        b = _make_df([("2020-01-02", 101, "B")])
+        result = stitch_datasets([a, b])
+        assert len(result) == 2
+        assert result.iloc[0]["source"] == "A"
+        assert result.iloc[1]["source"] == "B"
+
+    def test_overlapping_priority_first(self):
+        """First dataset wins on overlap (keep='first')."""
+        a = _make_df([("2020-01-01", 100, "A")])
+        b = _make_df([("2020-01-01", 200, "B")])
+        result = stitch_datasets([a, b])
+        assert len(result) == 1
+        assert result.iloc[0]["close"] == 100
+        assert result.iloc[0]["source"] == "A"
+
+    def test_sorted_output(self):
+        b = _make_df([("2020-01-03", 102, "B")])
+        a = _make_df([("2020-01-01", 100, "A")])
+        result = stitch_datasets([b, a])
+        assert result.iloc[0]["close"] == 100
+        assert result.iloc[1]["close"] == 102
+
+    def test_empty_sources_crashes(self):
+        """pd.concat([]) raises ValueError — stitch_datasets doesn't guard against empty input."""
+        with pytest.raises(ValueError):
+            stitch_datasets([])
+
+    def test_three_sources(self):
+        a = _make_df([("2020-01-01", 100, "A")])
+        b = _make_df([("2020-01-02", 101, "B")])
+        c = _make_df([("2020-01-03", 102, "C")])
+        result = stitch_datasets([a, b, c])
+        assert len(result) == 3
+
+
+# --- quality_report ---
+
+
+class TestQualityReport:
+    def test_basic_report(self):
+        df = _make_df([
+            ("2020-01-01 00:00", 100, "A"),
+            ("2020-01-01 01:00", 101, "A"),
+            ("2020-01-01 02:00", 102, "A"),
+        ])
+        report = quality_report(df)
+        assert report["total_rows"] == 3
+        assert report["num_gaps"] == 0
+        assert report["nan_close"] == 0
+
+    def test_gap_detection(self):
+        df = _make_df([
+            ("2020-01-01 00:00", 100, "A"),
+            ("2020-01-01 01:00", 101, "A"),
+            # Gap: missing 02:00, 03:00
+            ("2020-01-01 04:00", 102, "A"),
+        ])
+        report = quality_report(df)
+        assert report["num_gaps"] >= 1
+
+    def test_source_breakdown(self):
+        df = _make_df([
+            ("2020-01-01 00:00", 100, "bitstamp"),
+            ("2020-01-01 01:00", 101, "binance"),
+            ("2020-01-01 02:00", 102, "bitstamp"),
+        ])
+        report = quality_report(df)
+        assert report["sources"]["bitstamp"] == 2
+        assert report["sources"]["binance"] == 1
+
+    def test_price_range(self):
+        df = _make_df([
+            ("2020-01-01 00:00", 100, "A"),
+            ("2020-01-01 01:00", 200, "A"),
+            ("2020-01-01 02:00", 150, "A"),
+        ])
+        report = quality_report(df)
+        assert report["min_close"] == 100.0
+        assert report["max_close"] == 200.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds 31 tests covering pure functions in `scripts/datasets/` (first coverage for dataset scripts).

### Test files (2 new)
| File | Tests | Functions covered |
|------|-------|-------------------|
| `test_build_panier_anti_bias.py` | 16 | PANIER config validation (5), `get_all_symbols` (5), `get_group` (6) |
| `test_stitch_crypto.py` | 15 | `validate_overlap` (5), `stitch_datasets` (6), `quality_report` (4) |

### Validation
- 669/669 tests passing (was 638 at cycle 38)
- 0 regressions
- Full suite: `python -m pytest scripts/notebook_tools/tests/ -q` = 669 passed in 2.96s

### Technical note
Uses `importlib.util` to load modules by file path, bypassing the HuggingFace `datasets` package name conflict.

### Documented edge cases
- `validate_overlap`: strict overlap check (`overlap_start >= overlap_end` = no overlap); empty DataFrame causes TypeError
- `stitch_datasets`: empty list causes ValueError from `pd.concat([])`
- `FORBIDDEN_SYMBOLS`: panier validated to contain no FAANG+ individual stocks