### PR TITLE
test(genai-stack): add 15 tests for commands/validate.py — notebook syntax + find

### DIFF
--- a/scripts/notebook_tools/tests/test_genai_validate.py
+++ b/scripts/notebook_tools/tests/test_genai_validate.py
@@ -1,0 +1,201 @@
+"""Tests for genai-stack commands/validate.py — BatchNotebookValidator pure methods."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# Load module by file path
+_MOD_PATH = Path(__file__).resolve().parent.parent.parent / "genai-stack" / "commands" / "validate.py"
+_spec = importlib.util.spec_from_file_location("genai_validate", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+BatchNotebookValidator = _mod.BatchNotebookValidator
+
+
+class _DummySwitcher:
+    """Minimal model switcher stub for BatchNotebookValidator init."""
+    current_model = None
+    def switch_to(self, m):
+        return True
+
+
+def _make_validator(tmp_path):
+    """Create a BatchNotebookValidator with dummy switcher and tmp_path as notebooks_dir."""
+    return BatchNotebookValidator(_DummySwitcher(), notebooks_dir=tmp_path)
+
+
+def _write_nb(path: Path, cells=None, metadata=None, **extra):
+    """Write a minimal .ipynb JSON file."""
+    nb = {
+        "cells": cells or [],
+        "metadata": metadata or {"kernelspec": {"name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    nb.update(extra)
+    path.write_text(json.dumps(nb), encoding="utf-8")
+    return path
+
+
+def _code(source: str, **extra):
+    """Build a code cell dict."""
+    cell = {"cell_type": "code", "source": [source], "metadata": {}, "outputs": None, "execution_count": None}
+    cell.update(extra)
+    return cell
+
+
+def _md(source: str, **extra):
+    """Build a markdown cell dict."""
+    cell = {"cell_type": "markdown", "source": [source], "metadata": {}}
+    cell.update(extra)
+    return cell
+
+
+# --- _validate_notebook_syntax ---
+
+
+class TestValidateNotebookSyntax:
+    def test_valid_notebook(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[
+            _code("print('hello')"),
+            _md("# Title"),
+        ])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 2
+        assert result["code_cells"] == 1
+
+    def test_missing_cells_key(self, tmp_path):
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps({"metadata": {}}), encoding="utf-8")
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is False
+        assert "cells" in result["error"]
+
+    def test_missing_metadata_key(self, tmp_path):
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps({"cells": []}), encoding="utf-8")
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is False
+        assert "metadata" in result["error"]
+
+    def test_invalid_json(self, tmp_path):
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text("{not valid json}", encoding="utf-8")
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is False
+        assert "JSON" in result["error"]
+
+    def test_empty_cells_list(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 0
+        assert result["code_cells"] == 0
+
+    def test_all_code_cells(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[
+            _code("a = 1"),
+            _code("b = 2"),
+            _code("c = a + b"),
+        ])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 3
+        assert result["code_cells"] == 3
+
+    def test_all_markdown_cells(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[
+            _md("# Title"),
+            _md("Some text"),
+        ])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 2
+        assert result["code_cells"] == 0
+
+    def test_mixed_cells(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[
+            _md("# Intro"),
+            _code("x = 1"),
+            _md("## Section"),
+            _code("y = 2"),
+            _code("z = x + y"),
+        ])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 5
+        assert result["code_cells"] == 3
+
+    def test_path_in_result(self, tmp_path):
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert str(nb_path) == result["path"]
+
+    def test_nonexistent_file(self, tmp_path):
+        nb_path = tmp_path / "does_not_exist.ipynb"
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is False
+        assert "error" in result
+
+    def test_cells_without_cell_type_key(self, tmp_path):
+        """Cells missing 'cell_type' should not be counted as code cells."""
+        nb_path = _write_nb(tmp_path / "test.ipynb", cells=[
+            {"source": ["x = 1"], "metadata": {}},
+        ])
+        validator = _make_validator(tmp_path)
+        result = validator._validate_notebook_syntax(nb_path)
+        assert result["valid"] is True
+        assert result["cell_count"] == 1
+        assert result["code_cells"] == 0  # no cell_type → not counted as code
+
+
+# --- _find_notebook ---
+
+
+class TestFindNotebook:
+    def test_exact_name_match(self, tmp_path):
+        nb = tmp_path / "01-Intro.ipynb"
+        _write_nb(nb, cells=[])
+        validator = _make_validator(tmp_path)
+        result = validator._find_notebook("01-Intro.ipynb")
+        assert result is not None
+        assert result.name == "01-Intro.ipynb"
+
+    def test_fuzzy_match(self, tmp_path):
+        """Fuzzy match uses *{name}* glob — the full filename must appear as substring."""
+        nb = tmp_path / "copy-01-Intro.ipynb"
+        _write_nb(nb, cells=[])
+        validator = _make_validator(tmp_path)
+        result = validator._find_notebook("01-Intro.ipynb")
+        assert result is not None
+
+    def test_not_found(self, tmp_path):
+        validator = _make_validator(tmp_path)
+        result = validator._find_notebook("does-not-exist.ipynb")
+        assert result is None
+
+    def test_nested_directory(self, tmp_path):
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        _write_nb(sub / "nested.ipynb", cells=[])
+        validator = _make_validator(tmp_path)
+        result = validator._find_notebook("nested.ipynb")
+        assert result is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Add test coverage for `scripts/genai-stack/commands/validate.py` pure methods.

### Test classes (15 tests)
| Class | Tests | What it covers |
|-------|-------|----------------|
| `TestValidateNotebookSyntax` | 11 | Valid notebook, missing cells/metadata keys, invalid JSON, empty cells, all-code, all-md, mixed cells, path in result, nonexistent file, cells without cell_type |
| `TestFindNotebook` | 4 | Exact name match, fuzzy match (`*{name}*` glob), not found, nested directory search |

### Technique
- Module loaded via `importlib.util` (bcrypt dependency installed)
- Dummy model switcher stub for BatchNotebookValidator init
- `tmp_path` fixtures for all file I/O tests

## Validation
- `740/740` tests passing (15 new)
- 0 regressions

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>