### PR TITLE
fix(lint): exclude QC reference cells from C.2 + fix META KeyError

### DIFF
--- a/scripts/notebook_tools/notebook_lint.py
+++ b/scripts/notebook_tools/notebook_lint.py
@@ -116,6 +116,10 @@ def check_c2(notebook: dict) -> list[dict]:
         if all(l.startswith("#") for l in lines):
             continue
 
+        # Skip QC reference cells (not executable locally)
+        if "[REFERENCE QC]" in source or "[REFERENCE QC] Code a copier" in source:
+            continue
+
         exec_count = cell.get("execution_count")
         if exec_count is None:
             violations.append({
@@ -295,12 +299,14 @@ def main():
             continue
         print(f"  {rel} ({len(r['violations'])} issues):")
         for v in r["violations"][:5]:
+            cell_ref = f"cell #{v['cell_index']}" if "cell_index" in v else ""
+            prefix = f"[{v['check']}] {cell_ref}: " if cell_ref else f"[{v['check']}]: "
             if "pattern" in v:
-                print(f"    [{v['check']}] cell #{v['cell_index']}: {v['pattern']} → {v['line'][:60]}")
+                print(f"    {prefix}{v['pattern']} → {v['line'][:60]}")
             elif "reason" in v:
                 preview = v.get("source_preview", "")
                 extra = f" → {preview[:50]}" if preview else ""
-                print(f"    [{v['check']}] cell #{v['cell_index']}: {v['reason']}{extra}")
+                print(f"    {prefix}{v['reason']}{extra}")
 
     return 1
 


### PR DESCRIPTION
## Summary
- Exclude cells containing `[REFERENCE QC]` from C.2 execution_count check — these are non-executable code snippets meant for QC Cloud copy-paste, not local execution
- Fix `KeyError: 'cell_index'` in human-readable output for META violations (META violations have no cell_index, only check + reason)

## Impact
- Reduces false positive C.2 violations from **155 → 17** (138 QC-Py reference cells excluded)
- Remaining 17 violations are `quantbook.ipynb` files in QC projects (QC Cloud only, separate issue)
- No functional change to lint logic, only display fix + legitimate exclusion

## Test plan
- [x] `python scripts/notebook_tools/notebook_lint.py --all --check c2,structure,meta` — 478/504 pass (was erroring with KeyError)
- [x] `python scripts/notebook_tools/notebook_lint.py --all --check c1` — 504/504 pass (unchanged)