### PR TITLE
fix(scripts): replace bare except: with specific exceptions + comfyui_client cleanup

### DIFF
--- a/scripts/genai-stack/commands/audio_apis.py
+++ b/scripts/genai-stack/commands/audio_apis.py
@@ -219,7 +219,7 @@ def start_service(service_name: str, wait_health: bool = True) -> bool:
                 if resp.status_code == 200:
                     print("OK")
                     return True
-            except:
+            except Exception:
                 pass
             print(".", end="", flush=True)
 
@@ -308,7 +308,7 @@ def test_service(service_name: str) -> bool:
         try:
             data = resp.json()
             print(f"  Details: {json.dumps(data, indent=4)[:300]}")
-        except:
+        except (ValueError, json.JSONDecodeError):
             print(f"  Reponse (text): {resp.text[:200]}")
 
     except Exception as e:

--- a/scripts/genai-stack/core/auth_manager.py
+++ b/scripts/genai-stack/core/auth_manager.py
@@ -158,7 +158,7 @@ class GenAIAuthManager:
             # Mettre à jour les permissions (lecture seule pour user si possible)
             try:
                 os.chmod(self.config_file, 0o600)
-            except:
+            except OSError:
                 pass
                 
             logger.info(f"✅ Configuration sauvegardée: {self.config_file}")
@@ -353,7 +353,7 @@ SESSION_EXPIRE_HOURS=24
                         else:
                             content = raw_content
                             is_valid = (content == ref_hash)
-                    except:
+                    except OSError:
                         content = "[READ_ERROR]"
                 
                 locations.append(TokenLocation(

--- a/scripts/genai-stack/core/comfyui_client.py
+++ b/scripts/genai-stack/core/comfyui_client.py
@@ -15,6 +15,8 @@ import sys
 import os
 import json
 import time
+import uuid
+import logging
 import requests
 import urllib3
 from pathlib import Path
@@ -55,7 +57,7 @@ class ComfyUIClient:
     def __init__(self, config: ComfyUIConfig = None):
         self.config = config or ComfyUIConfig()
         self.session = requests.Session()
-        self.client_id = "ComfyUIClient-" + str(time.time())
+        self.client_id = f"ComfyUIClient-{uuid.uuid4().hex[:12]}"
         
         # Headers par défaut
         self.session.headers.update({
@@ -106,7 +108,7 @@ class ComfyUIClient:
             self._request('GET', '/system_stats')
             return True
         except Exception as e:
-            print(f"DEBUG: is_reachable failed: {e}")
+            logging.debug("is_reachable failed: %s", e)
             return False
 
     def get_system_stats(self) -> Dict[str, Any]:

--- a/scripts/genai-stack/validate_all_notebooks.py
+++ b/scripts/genai-stack/validate_all_notebooks.py
@@ -104,7 +104,7 @@ def execute_notebook(notebook_path: Path, timeout: int = 300) -> Tuple[bool, str
         if output_path.exists():
             try:
                 output_path.unlink()
-            except:
+            except OSError:
                 pass
 
 def main():

--- a/scripts/notebook_tools/exec_dotnet_persist.py
+++ b/scripts/notebook_tools/exec_dotnet_persist.py
@@ -146,7 +146,7 @@ def _wait_idle(kc, timeout=10):
             msg = kc.get_iopub_msg(timeout=2)
             if msg['msg_type'] == 'status' and msg['content'].get('execution_state') == 'idle':
                 return
-        except:
+        except Exception:
             pass
 
 

--- a/scripts/notebook_tools/notebook_helpers.py
+++ b/scripts/notebook_tools/notebook_helpers.py
@@ -984,7 +984,7 @@ class NotebookExecutor:
             try:
                 kc.stop_channels()
                 km.shutdown_kernel(now=True)
-            except:
+            except Exception:
                 pass
 
     def _wait_for_idle(self, kc, timeout: int = 10) -> None:
@@ -994,7 +994,7 @@ class NotebookExecutor:
                 msg = kc.get_iopub_msg(timeout=timeout)
                 if msg['msg_type'] == 'status' and msg['content']['execution_state'] == 'idle':
                     break
-            except:
+            except Exception:
                 break
 
     def execute_notebook_cell_by_cell(
@@ -1135,7 +1135,7 @@ class NotebookExecutor:
             try:
                 kc.stop_channels()
                 km.shutdown_kernel(now=True)
-            except:
+            except Exception:
                 pass
 
         return result


### PR DESCRIPTION
## Summary

Replace 9 bare `except:` clauses in production scripts that silently swallow `KeyboardInterrupt`, `SystemExit`, and `MemoryError`. Also fix 2 bugs in comfyui_client.py (debug print residue, fragile client_id).

## Changes

### Bare except: fixes (6 files)

| File | Before | After |
|------|--------|-------|
| `exec_dotnet_persist.py:149` | `except:` | `except Exception:` |
| `notebook_helpers.py:987` | `except:` (kernel cleanup) | `except Exception:` |
| `notebook_helpers.py:997` | `except:` (kernel idle wait) | `except Exception:` |
| `notebook_helpers.py:1138` | `except:` (kernel cleanup) | `except Exception:` |
| `validate_all_notebooks.py:107` | `except:` (unlink) | `except OSError:` |
| `audio_apis.py:222` | `except:` (health poll) | `except Exception:` |
| `audio_apis.py:311` | `except:` (JSON parse) | `except (ValueError, json.JSONDecodeError):` |
| `auth_manager.py:161` | `except:` (chmod) | `except OSError:` |
| `auth_manager.py:356` | `except:` (file read) | `except OSError:` |

### comfyui_client.py bug fixes

- `is_reachable()`: Replace `print(f"DEBUG: ...")` with `logging.debug("...", ...)` — debug residue in production
- `__init__()`: Replace `str(time.time())` with `uuid.uuid4().hex[:12]` for client_id — avoids float precision issues and collisions

## Validation

- 759/759 tests pass, 0 regressions
- All modified files are pure exception handler changes (no logic changes)
- 2 remaining bare `except:` in `archive/` (not production code) left untouched

## Technical debt discovered (not fixed in this PR)

- CIVITAI token literal at `auth_manager.py:279` (secrets-hygiene violation) — needs token rotation by user before code fix
- 187 f-string-in-logging calls across genai-stack (style/perf debt, low priority)
- ~20 missing type hints (PEP 484 `Optional` and return annotations)