### PR TITLE
fix(scripts): replace f-string-in-logging with lazy % formatting in genai-stack

### DIFF
--- a/scripts/genai-stack/commands/auto_validate.py
+++ b/scripts/genai-stack/commands/auto_validate.py
@@ -111,7 +111,7 @@ def prepare_batch(batch_num: int):
 def get_group_notebooks(group_name: str) -> list[Path]:
     """Retourne les notebooks d'un groupe spécifique."""
     if group_name not in NOTEBOOK_SERVICE_MAP:
-        logger.error(f"Groupe inconnu: {group_name}")
+        logger.error("Groupe inconnu: %s", group_name)
         return []
 
     notebooks = []
@@ -134,7 +134,7 @@ def get_group_notebooks(group_name: str) -> list[Path]:
                 found = True
                 break
         if not found:
-            logger.warning(f"Notebook introuvable: {nb_name}")
+            logger.warning("Notebook introuvable: %s", nb_name)
 
     return sorted(set(notebooks))
 

--- a/scripts/genai-stack/commands/docker.py
+++ b/scripts/genai-stack/commands/docker.py
@@ -47,10 +47,10 @@ def _run_cmd(cmd: List[str], cwd: Path = None, capture: bool = True, timeout: in
         )
         return result
     except subprocess.TimeoutExpired:
-        logger.error(f"Timeout: {' '.join(cmd)}")
+        logger.error("Timeout: %s", " ".join(cmd))
         return subprocess.CompletedProcess(cmd, 1, "", "Timeout")
     except Exception as e:
-        logger.error(f"Erreur commande: {e}")
+        logger.error("Erreur commande: %s", e)
         return subprocess.CompletedProcess(cmd, 1, "", str(e))
 
 
@@ -132,25 +132,25 @@ class DockerManager:
     def start_service(self, service_name: str, build: bool = False) -> bool:
         """Demarre un service."""
         if service_name not in SERVICES:
-            logger.error(f"Service inconnu: {service_name}")
+            logger.error("Service inconnu: %s", service_name)
             return False
 
         svc = SERVICES[service_name]
         compose_dir = svc["compose_dir"]
         if not compose_dir.exists():
-            logger.error(f"Repertoire non trouve: {compose_dir}")
+            logger.error("Repertoire non trouve: %s", compose_dir)
             return False
 
-        logger.info(f"Demarrage de {service_name}...")
+        logger.info("Demarrage de %s...", service_name)
         cmd = COMPOSE_CMD + ["up", "-d"]
         if build:
             cmd.append("--build")
 
         result = _run_cmd(cmd, cwd=compose_dir, capture=False, timeout=300)
         if result.returncode == 0:
-            logger.info(f"{service_name} demarre")
+            logger.info("%s demarre", service_name)
             return True
-        logger.error(f"Echec demarrage {service_name}")
+        logger.error("Echec demarrage %s", service_name)
         return False
 
     def stop_service(self, service_name: str) -> bool:
@@ -158,13 +158,13 @@ class DockerManager:
         if service_name not in SERVICES:
             return False
         svc = SERVICES[service_name]
-        logger.info(f"Arret de {service_name}...")
+        logger.info("Arret de %s...", service_name)
         result = _run_cmd(COMPOSE_CMD + ["down"], cwd=svc["compose_dir"], capture=False, timeout=60)
         return result.returncode == 0
 
     def restart_service(self, service_name: str) -> bool:
         """Redemarre un service."""
-        logger.info(f"Redemarrage de {service_name}...")
+        logger.info("Redemarrage de %s...", service_name)
         self.stop_service(service_name)
         time.sleep(3)
         return self.start_service(service_name)

--- a/scripts/genai-stack/commands/notebooks.py
+++ b/scripts/genai-stack/commands/notebooks.py
@@ -74,7 +74,7 @@ class NotebookValidator:
     def find_notebooks_by_group(self, group: str) -> List[Path]:
         """Trouve les notebooks d'un groupe specifique."""
         if group not in NOTEBOOK_SERVICE_MAP:
-            logger.error(f"Groupe inconnu: {group}")
+            logger.error("Groupe inconnu: %s", group)
             return []
 
         nb_names = NOTEBOOK_SERVICE_MAP[group]
@@ -99,14 +99,14 @@ class NotebookValidator:
                 if matches:
                     found.append(matches[0])
                 else:
-                    logger.warning(f"Notebook introuvable: {nb_name}")
+                    logger.warning("Notebook introuvable: %s", nb_name)
 
         return found
 
     def find_notebooks_by_batch(self, batch_num: int) -> List[Path]:
         """Trouve les notebooks d'un batch d'execution."""
         if batch_num not in EXECUTION_BATCHES:
-            logger.error(f"Batch inconnu: {batch_num}. Disponibles: {list(EXECUTION_BATCHES.keys())}")
+            logger.error("Batch inconnu: %d. Disponibles: %s", batch_num, list(EXECUTION_BATCHES.keys()))
             return []
 
         batch = EXECUTION_BATCHES[batch_num]
@@ -128,7 +128,7 @@ class NotebookValidator:
         output_path = output_dir / rel_path
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Validation de : {rel_path}")
+        logger.info("Validation de : %s", rel_path)
 
         start_time = datetime.now()
         status = "success"
@@ -146,7 +146,7 @@ class NotebookValidator:
         for ffmpeg_path in ffmpeg_paths:
             if Path(ffmpeg_path).exists():
                 os.environ["PATH"] = f"{ffmpeg_path};{os.environ.get('PATH', '')}"
-                logger.info(f"Added ffmpeg to PATH: {ffmpeg_path}")
+                logger.info("Added ffmpeg to PATH: %s", ffmpeg_path)
                 break
 
         try:
@@ -161,7 +161,7 @@ class NotebookValidator:
         except Exception as e:
             status = "failed"
             error_msg = str(e)
-            logger.error(f"Echec de {rel_path}: {e}")
+            logger.error("Echec de %s: %s", rel_path, e)
         finally:
             os.environ.clear()
             os.environ.update(original_env)
@@ -178,7 +178,7 @@ class NotebookValidator:
     def run_validation(self) -> List[Dict]:
         """Lance la validation sur tous les notebooks."""
         notebooks = self.find_notebooks()
-        logger.info(f"{len(notebooks)} notebooks trouves dans {self.target_path}")
+        logger.info("%d notebooks trouves dans %s", len(notebooks), self.target_path)
 
         output_dir = Path("rapports/notebook_validation")
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -204,7 +204,7 @@ class NotebookValidator:
         with open(report_path, "w", encoding="utf-8") as f:
             json.dump(report, f, indent=2, ensure_ascii=False)
 
-        logger.info(f"Rapport genere : {report_path.absolute()}")
+        logger.info("Rapport genere : %s", report_path.absolute())
 
         print("\n" + "=" * 40)
         print("RESUME VALIDATION NOTEBOOKS")
@@ -261,7 +261,7 @@ def execute(args) -> int:
 
     if gpu_profile:
         from commands.gpu import profile_apply
-        logger.info(f"Application du profil GPU: {gpu_profile}")
+        logger.info("Application du profil GPU: %s", gpu_profile)
         if not profile_apply(gpu_profile, wait_health=True):
             logger.warning("Profil GPU applique partiellement, execution continue...")
 
@@ -270,11 +270,11 @@ def execute(args) -> int:
     # Mode batch
     if batch_num:
         batch_info = EXECUTION_BATCHES[batch_num]
-        logger.info(f"\n{'=' * 60}")
-        logger.info(f"  BATCH {batch_num}: {batch_info['name']}")
-        logger.info(f"  Profil GPU: {batch_info['profile']}")
-        logger.info(f"  Groupes: {', '.join(batch_info['groups'])}")
-        logger.info(f"{'=' * 60}")
+        logger.info("\n%s", "=" * 60)
+        logger.info("  BATCH %d: %s", batch_num, batch_info['name'])
+        logger.info("  Profil GPU: %s", batch_info['profile'])
+        logger.info("  Groupes: %s", ", ".join(batch_info['groups']))
+        logger.info("%s", "=" * 60)
 
         notebooks = validator.find_notebooks_by_batch(batch_num)
         if not notebooks:
@@ -293,7 +293,7 @@ def execute(args) -> int:
     elif group:
         notebooks = validator.find_notebooks_by_group(group)
         if not notebooks:
-            logger.error(f"Aucun notebook trouve pour le groupe '{group}'")
+            logger.error("Aucun notebook trouve pour le groupe '%s'", group)
             return 1
 
         output_dir = Path("rapports/notebook_validation")
@@ -307,7 +307,7 @@ def execute(args) -> int:
     # Mode serie
     elif series:
         if series not in NOTEBOOK_SERIES:
-            logger.error(f"Serie inconnue: {series}")
+            logger.error("Serie inconnue: %s", series)
             return 1
 
         all_results = []
@@ -331,7 +331,7 @@ def execute(args) -> int:
         output_dir = Path("rapports/notebook_validation")
         if output_dir.exists():
             shutil.rmtree(output_dir)
-            logger.info(f"Nettoyage: {output_dir} supprime")
+            logger.info("Nettoyage: %s supprime", output_dir)
 
     return 1 if any(r['status'] == 'failed' for r in results) else 0
 

--- a/scripts/genai-stack/commands/validate.py
+++ b/scripts/genai-stack/commands/validate.py
@@ -46,7 +46,7 @@ class VRAMManager:
         try:
             return self.client.free_memory(unload_models=unload_models)
         except Exception as e:
-            logger.error(f"Erreur liberation VRAM: {e}")
+            logger.error("Erreur liberation VRAM: %s", e)
             return {"error": str(e)}
 
     def get_vram_stats(self) -> dict:
@@ -63,7 +63,7 @@ class VRAMManager:
                 }
             return {}
         except Exception as e:
-            logger.error(f"Erreur stats VRAM: {e}")
+            logger.error("Erreur stats VRAM: %s", e)
             return {"error": str(e)}
 
 
@@ -76,18 +76,18 @@ class ModelSwitcher:
 
     def switch_to(self, model_name: str) -> bool:
         if model_name not in MODEL_CONFIGS:
-            logger.error(f"Modele inconnu: {model_name}")
+            logger.error("Modele inconnu: %s", model_name)
             return False
 
         if self.current_model == model_name:
-            logger.info(f"Modele {model_name} deja charge")
+            logger.info("Modele %s deja charge", model_name)
             return True
 
-        logger.info(f"Switch vers modele: {model_name}")
+        logger.info("Switch vers modele: %s", model_name)
         logger.info("Liberation VRAM...")
         result = self.vram.free_vram(unload_models=True)
         if "error" in result:
-            logger.warning(f"Attention lors liberation VRAM: {result['error']}")
+            logger.warning("Attention lors liberation VRAM: %s", result['error'])
 
         time.sleep(2)
 
@@ -95,7 +95,7 @@ class ModelSwitcher:
         if stats and "error" not in stats:
             vram_free_mb = stats.get('vram_free', 0) / (1024 * 1024)
             required_mb = MODEL_CONFIGS[model_name]['vram_required_mb']
-            logger.info(f"VRAM libre: {vram_free_mb:.0f}MB, requis: {required_mb}MB")
+            logger.info("VRAM libre: %.0fMB, requis: %dMB", vram_free_mb, required_mb)
 
         self.current_model = model_name
         return True
@@ -137,7 +137,7 @@ class BatchNotebookValidator:
         if group not in NOTEBOOK_SERVICE_MAP:
             return {"error": f"Groupe inconnu: {group}"}
         notebooks = NOTEBOOK_SERVICE_MAP[group]
-        logger.info(f"Validation groupe '{group}': {len(notebooks)} notebooks")
+        logger.info("Validation groupe '%s': %d notebooks", group, len(notebooks))
         if group in ["qwen", "zimage"]:
             self.switcher.switch_to(group)
         results = {}
@@ -177,8 +177,8 @@ class BatchNotebookValidator:
             total += group_total
             valid += group_valid
             status = "OK" if group_valid == group_total else "PARTIEL"
-            logger.info(f"  {group}: {group_valid}/{group_total} {status}")
-        logger.info(f"TOTAL: {valid}/{total} notebooks valides")
+            logger.info("  %s: %d/%d %s", group, group_valid, group_total, status)
+        logger.info("TOTAL: %d/%d notebooks valides", valid, total)
         return valid == total
 
 
@@ -200,7 +200,7 @@ class ComfyUIValidator:
                 logger.error("ComfyUI inaccessible sur localhost:8188")
                 return False
         except Exception as e:
-            logger.error(f"ComfyUI inaccessible: {e}")
+            logger.error("ComfyUI inaccessible: %s", e)
             return False
         logger.info("Service ComfyUI en ligne")
         return True
@@ -220,10 +220,10 @@ class ComfyUIValidator:
             if resp.status_code == 200:
                 logger.info("Authentification reussie")
             else:
-                logger.error(f"Echec authentification (HTTP {resp.status_code})")
+                logger.error("Echec authentification (HTTP %d)", resp.status_code)
                 return False
         except Exception as e:
-            logger.error(f"Erreur connexion: {e}")
+            logger.error("Erreur connexion: %s", e)
             return False
 
         logger.info("Test acces API protege...")
@@ -232,10 +232,10 @@ class ComfyUIValidator:
             if resp.status_code in [200, 400]:
                 logger.info("API accessible")
                 return True
-            logger.error(f"API refusee (HTTP {resp.status_code})")
+            logger.error("API refusee (HTTP %d)", resp.status_code)
             return False
         except Exception as e:
-            logger.error(f"Erreur API: {e}")
+            logger.error("Erreur API: %s", e)
             return False
 
     def check_nodes(self, check_nunchaku: bool = False) -> bool:
@@ -251,51 +251,51 @@ class ComfyUIValidator:
                 return False
 
             available_nodes = set(object_info.keys())
-            logger.info(f"{len(available_nodes)} noeuds detectes au total")
+            logger.info("%d noeuds detectes au total", len(available_nodes))
 
             missing_qwen = [n for n in EXPECTED_QWEN_NODES if n not in available_nodes]
             missing_native = [n for n in REQUIRED_NATIVE_NODES if n not in available_nodes]
 
             for node in missing_qwen:
-                logger.error(f"  MANQUANT (Qwen): {node}")
+                logger.error("  MANQUANT (Qwen): %s", node)
             if not missing_qwen:
-                logger.info(f"OK: {len(EXPECTED_QWEN_NODES)} noeuds Qwen presents")
+                logger.info("OK: %d noeuds Qwen presents", len(EXPECTED_QWEN_NODES))
 
             for node in missing_native:
-                logger.error(f"  MANQUANT (natif): {node}")
+                logger.error("  MANQUANT (natif): %s", node)
             if not missing_native:
-                logger.info(f"OK: {len(REQUIRED_NATIVE_NODES)} noeuds natifs presents")
+                logger.info("OK: %d noeuds natifs presents", len(REQUIRED_NATIVE_NODES))
 
             if check_nunchaku:
                 missing_nunchaku = [n for n in EXPECTED_NUNCHAKU_NODES if n not in available_nodes]
                 for node in missing_nunchaku:
-                    logger.warning(f"  MANQUANT (Nunchaku): {node}")
+                    logger.warning("  MANQUANT (Nunchaku): %s", node)
                 if not missing_nunchaku:
-                    logger.info(f"OK: {len(EXPECTED_NUNCHAKU_NODES)} noeuds Nunchaku presents")
+                    logger.info("OK: %d noeuds Nunchaku presents", len(EXPECTED_NUNCHAKU_NODES))
 
             return len(missing_qwen) == 0 and len(missing_native) == 0
         except Exception as e:
-            logger.error(f"Erreur verification noeuds: {e}")
+            logger.error("Erreur verification noeuds: %s", e)
             return False
 
     def check_generation(self, workflow_filename="workflow_qwen_native_t2i.json") -> bool:
         logger.info("\n" + "=" * 60)
-        logger.info(f"TEST GENERATION ({workflow_filename})")
+        logger.info("TEST GENERATION (%s)", workflow_filename)
         logger.info("=" * 60)
 
         workflow_path = WORKFLOWS_DIR / workflow_filename
         if not workflow_path.exists():
-            logger.error(f"Workflow introuvable: {workflow_path}")
+            logger.error("Workflow introuvable: %s", workflow_path)
             return False
 
-        logger.info(f"Soumission du workflow {workflow_filename}...")
+        logger.info("Soumission du workflow %s...", workflow_filename)
         try:
             workflow = WorkflowManager.load(str(workflow_path))
             prompt_id = self.client.queue_prompt(workflow)
             if not prompt_id:
                 logger.error("Echec soumission workflow")
                 return False
-            logger.info(f"Job ID: {prompt_id} - Attente generation...")
+            logger.info("Job ID: %s - Attente generation...", prompt_id)
             result = self.client.wait_for_prompt(prompt_id, timeout=300)
             if not result:
                 logger.error("Timeout ou erreur recuperation resultat")
@@ -310,7 +310,7 @@ class ComfyUIValidator:
             logger.info("Generation reussie!")
             return True
         except Exception as e:
-            logger.error(f"Erreur test generation: {e}")
+            logger.error("Erreur test generation: %s", e)
             return False
 
     def run_suite(self, full=True, auth_only=False, nodes_only=False,
@@ -342,12 +342,12 @@ def check_forge_api() -> bool:
     try:
         resp = requests.get(f"{FORGE_URL}/sdapi/v1/sd-models", timeout=5)
         if resp.status_code == 200:
-            logger.info(f"OK Forge-Turbo accessible sur {FORGE_URL}")
+            logger.info("OK Forge-Turbo accessible sur %s", FORGE_URL)
             return True
-        logger.warning(f"Forge-Turbo repond avec HTTP {resp.status_code}")
+        logger.warning("Forge-Turbo repond avec HTTP %d", resp.status_code)
         return False
     except Exception as e:
-        logger.warning(f"Forge-Turbo inaccessible: {e}")
+        logger.warning("Forge-Turbo inaccessible: %s", e)
         return False
 
 
@@ -356,17 +356,17 @@ def check_vllm_api() -> bool:
     try:
         resp = requests.get(f"{VLLM_ZIMAGE_URL}/health", timeout=5)
         if resp.status_code == 200:
-            logger.info(f"OK vLLM Z-Image accessible sur {VLLM_ZIMAGE_URL}")
+            logger.info("OK vLLM Z-Image accessible sur %s", VLLM_ZIMAGE_URL)
             models_resp = requests.get(f"{VLLM_ZIMAGE_URL}/v1/models", timeout=5)
             if models_resp.status_code == 200:
                 models = models_resp.json().get('data', [])
                 model_names = [m.get('id', 'unknown') for m in models]
-                logger.info(f"  Modeles disponibles: {model_names}")
+                logger.info("  Modeles disponibles: %s", model_names)
             return True
-        logger.warning(f"vLLM Z-Image repond avec HTTP {resp.status_code}")
+        logger.warning("vLLM Z-Image repond avec HTTP %d", resp.status_code)
         return False
     except Exception as e:
-        logger.warning(f"vLLM Z-Image inaccessible: {e}")
+        logger.warning("vLLM Z-Image inaccessible: %s", e)
         return False
 
 
@@ -375,15 +375,15 @@ def check_whisper_api() -> bool:
     try:
         resp = requests.get(f"{WHISPER_URL}/", timeout=10)
         if resp.status_code == 200:
-            logger.info(f"OK Whisper-WebUI accessible sur {WHISPER_URL}")
+            logger.info("OK Whisper-WebUI accessible sur %s", WHISPER_URL)
             return True
         elif resp.status_code == 401:
-            logger.info(f"OK Whisper-WebUI accessible (auth requise) sur {WHISPER_URL}")
+            logger.info("OK Whisper-WebUI accessible (auth requise) sur %s", WHISPER_URL)
             return True
-        logger.warning(f"Whisper-WebUI repond avec HTTP {resp.status_code}")
+        logger.warning("Whisper-WebUI repond avec HTTP %d", resp.status_code)
         return False
     except Exception as e:
-        logger.warning(f"Whisper-WebUI inaccessible: {e}")
+        logger.warning("Whisper-WebUI inaccessible: %s", e)
         return False
 
 
@@ -392,21 +392,21 @@ def check_comfyui_video_api() -> bool:
     try:
         resp = requests.get(f"{COMFYUI_VIDEO_URL}/system_stats", timeout=10)
         if resp.status_code == 200:
-            logger.info(f"OK ComfyUI-Video accessible sur {COMFYUI_VIDEO_URL}")
+            logger.info("OK ComfyUI-Video accessible sur %s", COMFYUI_VIDEO_URL)
             data = resp.json()
             devices = data.get('devices', [])
             if devices:
                 dev = devices[0]
                 vram_total = dev.get('vram_total', 0) / (1024**3)
-                logger.info(f"  GPU: {dev.get('name', '?')} ({vram_total:.1f}GB)")
+                logger.info("  GPU: %s (%.1fGB)", dev.get('name', '?'), vram_total)
             return True
         elif resp.status_code == 401:
-            logger.info(f"OK ComfyUI-Video accessible (auth requise) sur {COMFYUI_VIDEO_URL}")
+            logger.info("OK ComfyUI-Video accessible (auth requise) sur %s", COMFYUI_VIDEO_URL)
             return True
-        logger.warning(f"ComfyUI-Video repond avec HTTP {resp.status_code}")
+        logger.warning("ComfyUI-Video repond avec HTTP %d", resp.status_code)
         return False
     except Exception as e:
-        logger.warning(f"ComfyUI-Video inaccessible: {e}")
+        logger.warning("ComfyUI-Video inaccessible: %s", e)
         return False
 
 

--- a/scripts/genai-stack/core/auth_manager.py
+++ b/scripts/genai-stack/core/auth_manager.py
@@ -102,7 +102,7 @@ class GenAIAuthManager:
         try:
             return bcrypt.checkpw(raw_token.encode('utf-8'), bcrypt_hash.encode('utf-8'))
         except Exception as e:
-            logger.error(f"Erreur validation bcrypt: {e}")
+            logger.error("Erreur validation bcrypt: %s", e)
             return False
 
     def is_bcrypt_hash(self, token: str) -> bool:
@@ -122,7 +122,7 @@ class GenAIAuthManager:
             with open(self.config_file, 'r', encoding='utf-8') as f:
                 return json.load(f)
         except Exception as e:
-            logger.error(f"Erreur chargement config: {e}")
+            logger.error("Erreur chargement config: %s", e)
             return None
 
     def create_unified_config(self, raw_token: str = None) -> bool:
@@ -161,11 +161,11 @@ class GenAIAuthManager:
             except OSError:
                 pass
                 
-            logger.info(f"✅ Configuration sauvegardée: {self.config_file}")
+            logger.info("Configuration sauvegardee: %s", self.config_file)
             return True
-            
+
         except Exception as e:
-            logger.error(f"❌ Erreur création config: {e}")
+            logger.error("Erreur creation config: %s", e)
             return False
 
     # =========================================================================
@@ -199,19 +199,19 @@ class GenAIAuthManager:
                     if type_ in ['secrets_file', 'docker_secrets']:
                         # Écriture directe du hash
                         path.write_text(bcrypt_hash, encoding='utf-8')
-                        logger.info(f"✅ Écrit hash dans: {path}")
+                        logger.info("Ecrit hash dans: %s", path)
                         success_count += 1
-                        
+
                     elif type_ == 'env_file':
-                        # Mise à jour intelligente du .env
+                        # Mise a jour intelligente du .env
                         self._update_env_file(path, raw_token, bcrypt_hash)
-                        logger.info(f"✅ Mis à jour .env: {path}")
+                        logger.info("Mis a jour .env: %s", path)
                         success_count += 1
-                        
+
                 except Exception as e:
-                    logger.error(f"❌ Erreur synchro {path}: {e}")
-        
-        logger.info(f"Synchronisation terminée: {success_count}/{total_ops} opérations réussies.")
+                    logger.error("Erreur synchro %s: %s", path, e)
+
+        logger.info("Synchronisation terminee: %d/%d operations reussies.", success_count, total_ops)
         return success_count == total_ops
 
     def _update_env_file(self, env_path: Path, raw_token: str, bcrypt_hash: str):
@@ -261,9 +261,9 @@ class GenAIAuthManager:
             backup_path = env_path.with_suffix(f".backup.{int(time.time())}")
             try:
                 shutil.copy2(env_path, backup_path)
-                logger.info(f"Backup .env créé: {backup_path}")
+                logger.info("Backup .env cree: %s", backup_path)
             except Exception as e:
-                logger.error(f"Erreur backup .env: {e}")
+                logger.error("Erreur backup .env: %s", e)
                 return False
 
         config = self.load_config()
@@ -309,10 +309,10 @@ SESSION_EXPIRE_HOURS=24
         try:
             env_path.parent.mkdir(parents=True, exist_ok=True)
             env_path.write_text(content, encoding='utf-8')
-            logger.info(f"✅ Fichier .env reconstruit: {env_path}")
+            logger.info("Fichier .env reconstruit: %s", env_path)
             return True
         except Exception as e:
-            logger.error(f"Erreur écriture .env: {e}")
+            logger.error("Erreur ecriture .env: %s", e)
             return False
 
     # =========================================================================


### PR DESCRIPTION
## Summary

Replace 84 f-string-in-logging calls with lazy `%`-style formatting across 5 production modules in `scripts/genai-stack/`.

## Why

Python logging supports lazy formatting via `%` operator: `logger.info("msg %s", var)` avoids string interpolation when the log level filters out the message. F-strings (`logger.info(f"msg {var}`)\) always evaluate, wasting CPU on DEBUG calls with INFO threshold.

## Files changed

| File | Count | Scope |
|------|-------|-------|
| `commands/validate.py` | 44 | VRAM, auth, nodes, generation, Forge/vLLM/Whisper/ComfyUI-Video health checks |
| `commands/notebooks.py` | 17 | Group/batch/series validation, Papermill execution |
| `core/auth_manager.py` | 12 | bcrypt validation, config save, credential sync, .env rebuild |
| `commands/docker.py` | 9 | Service lifecycle (start/stop/restart), command execution |
| `commands/auto_validate.py` | 2 | Group/notebook lookup |

Also removed emoji characters from auth_manager.py logging for cleaner output.

## Not changed

- 83 occurrences in `archive/` (non-production, left untouched)
- Notebook files (not applicable)
- Test files (not applicable)

## Validation

- 759/759 tests pass, 0 regressions