### PR TITLE
fix(scripts): add PEP 484 type hints — Optional parameters + return annotations

### DIFF
--- a/scripts/genai-stack/commands/audio_apis.py
+++ b/scripts/genai-stack/commands/audio_apis.py
@@ -355,7 +355,7 @@ def test_service(service_name: str) -> bool:
 # E2E Tests — real generation/transcription/separation
 # ============================================================================
 
-def _get_auth_headers(service_name: str = None) -> dict:
+def _get_auth_headers(service_name: Optional[str] = None) -> dict:
     """Load API key from .env file (service-specific key or generic)."""
     from pathlib import Path
     env_file = Path(__file__).resolve().parent.parent.parent.parent / "MyIA.AI.Notebooks" / "GenAI" / ".env"

--- a/scripts/genai-stack/commands/docker.py
+++ b/scripts/genai-stack/commands/docker.py
@@ -17,7 +17,7 @@ import time
 import subprocess
 import logging
 from pathlib import Path
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Optional, Tuple
 
 try:
     import requests
@@ -33,7 +33,7 @@ from config import SERVICES, load_env
 logger = logging.getLogger("DockerManager")
 
 
-def _run_cmd(cmd: List[str], cwd: Path = None, capture: bool = True, timeout: int = 60) -> subprocess.CompletedProcess:
+def _run_cmd(cmd: List[str], cwd: Optional[Path] = None, capture: bool = True, timeout: int = 60) -> subprocess.CompletedProcess:
     """Execute une commande shell."""
     try:
         result = subprocess.run(
@@ -202,7 +202,7 @@ class DockerManager:
                     })
         return {"available": True, "count": len(gpus), "gpus": gpus}
 
-    def print_status(self, include_remote: bool = False):
+    def print_status(self, include_remote: bool = False) -> None:
         """Affiche le statut de tous les services."""
         print("\n" + "=" * 70)
         print("  STATUT DES SERVICES GENAI")

--- a/scripts/genai-stack/commands/notebooks.py
+++ b/scripts/genai-stack/commands/notebooks.py
@@ -190,7 +190,7 @@ class NotebookValidator:
             results.append(self.validate_notebook(nb, output_dir))
         return results
 
-    def save_report(self, results: List[Dict]):
+    def save_report(self, results: List[Dict]) -> None:
         """Sauvegarde le rapport JSON."""
         report = {
             "timestamp": datetime.now().isoformat(),

--- a/scripts/genai-stack/commands/validate.py
+++ b/scripts/genai-stack/commands/validate.py
@@ -104,7 +104,7 @@ class ModelSwitcher:
 class BatchNotebookValidator:
     """Validation batch de notebooks avec switching automatique."""
 
-    def __init__(self, model_switcher, notebooks_dir: Path = None):
+    def __init__(self, model_switcher: Any, notebooks_dir: Optional[Path] = None) -> None:
         self.switcher = model_switcher
         self.notebooks_dir = notebooks_dir or GENAI_DIR
         self.results: Dict[str, Dict[str, Any]] = {}
@@ -150,7 +150,7 @@ class BatchNotebookValidator:
         self.results[group] = results
         return results
 
-    def run_full_validation(self, series: str = None) -> Dict:
+    def run_full_validation(self, series: Optional[str] = None) -> Dict:
         """Validation de tous les groupes (ou d'une serie specifique).
 
         Args:

--- a/scripts/genai-stack/core/auth_manager.py
+++ b/scripts/genai-stack/core/auth_manager.py
@@ -62,7 +62,7 @@ class AuditReport:
     inconsistencies: List[Dict]
     recommendations: List[str]
     
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         return {
             'timestamp': self.timestamp,
             'locations': [asdict(loc) for loc in self.locations],
@@ -73,7 +73,7 @@ class AuditReport:
 class GenAIAuthManager:
     """Gestionnaire principal d'authentification (Singleton Facade)"""
     
-    def __init__(self, root_dir: Path = None):
+    def __init__(self, root_dir: Optional[Path] = None) -> None:
         self.root_dir = root_dir if root_dir else PROJECT_ROOT
         self.secrets_dir = self.root_dir / ".secrets"
         self.secrets_dir.mkdir(exist_ok=True, parents=True)
@@ -125,7 +125,7 @@ class GenAIAuthManager:
             logger.error("Erreur chargement config: %s", e)
             return None
 
-    def create_unified_config(self, raw_token: str = None) -> bool:
+    def create_unified_config(self, raw_token: Optional[str] = None) -> bool:
         """Crée ou recrée la configuration unifiée"""
         logger.info("🔐 Création configuration unifiée...")
         
@@ -214,7 +214,7 @@ class GenAIAuthManager:
         logger.info("Synchronisation terminee: %d/%d operations reussies.", success_count, total_ops)
         return success_count == total_ops
 
-    def _update_env_file(self, env_path: Path, raw_token: str, bcrypt_hash: str):
+    def _update_env_file(self, env_path: Path, raw_token: str, bcrypt_hash: str) -> None:
         """Met à jour les variables d'auth dans un fichier .env sans toucher au reste"""
         if not env_path.exists():
             # Créer nouveau si n'existe pas

--- a/scripts/genai-stack/core/comfyui_client.py
+++ b/scripts/genai-stack/core/comfyui_client.py
@@ -54,7 +54,7 @@ class ComfyUIError(Exception):
 class ComfyUIClient:
     """Client API pour ComfyUI"""
     
-    def __init__(self, config: ComfyUIConfig = None):
+    def __init__(self, config: Optional[ComfyUIConfig] = None) -> None:
         self.config = config or ComfyUIConfig()
         self.session = requests.Session()
         self.client_id = f"ComfyUIClient-{uuid.uuid4().hex[:12]}"
@@ -115,7 +115,7 @@ class ComfyUIClient:
         """Récupère les stats système"""
         return self._request('GET', '/system_stats').json()
 
-    def get_object_info(self, node_class: str = None) -> Dict[str, Any]:
+    def get_object_info(self, node_class: Optional[str] = None) -> Dict[str, Any]:
         """Récupère les infos sur les nodes"""
         endpoint = f'/object_info/{node_class}' if node_class else '/object_info'
         return self._request('GET', endpoint).json()

--- a/scripts/notebook_tools/notebook_tools.py
+++ b/scripts/notebook_tools/notebook_tools.py
@@ -203,23 +203,23 @@ class Colors:
         cls.CYAN = cls.MAGENTA = cls.BOLD = cls.END = ''
 
 
-def print_ok(msg: str):
+def print_ok(msg: str) -> None:
     print(f"{Colors.GREEN}[OK]{Colors.END} {msg}")
 
 
-def print_error(msg: str):
+def print_error(msg: str) -> None:
     print(f"{Colors.RED}[X]{Colors.END} {msg}")
 
 
-def print_warning(msg: str):
+def print_warning(msg: str) -> None:
     print(f"{Colors.YELLOW}[!]{Colors.END} {msg}")
 
 
-def print_info(msg: str):
+def print_info(msg: str) -> None:
     print(f"{Colors.CYAN}[i]{Colors.END} {msg}")
 
 
-def print_section(title: str):
+def print_section(title: str) -> None:
     print(f"\n{Colors.BOLD}{Colors.BLUE}{'='*60}{Colors.END}")
     print(f"{Colors.BOLD}{Colors.BLUE}{title:^60}{Colors.END}")
     print(f"{Colors.BOLD}{Colors.BLUE}{'='*60}{Colors.END}\n")
@@ -911,7 +911,7 @@ class EnvironmentChecker:
                 return True, "unknown"
         return False, ""
 
-    def check_python_package(self, pkg_name: str, import_name: str = None) -> Tuple[bool, str]:
+    def check_python_package(self, pkg_name: str, import_name: Optional[str] = None) -> Tuple[bool, str]:
         """Check if a Python package is installed"""
         if import_name is None:
             import_name = pkg_name.replace("-", "_")
@@ -1259,7 +1259,7 @@ class NotebookExecutor:
 # NOTEBOOK DISCOVERER
 # =============================================================================
 
-def discover_notebooks(target: str, repo_root: Path = None,
+def discover_notebooks(target: str, repo_root: Optional[Path] = None,
                        python_only: bool = False, dotnet_only: bool = False,
                        recursive: bool = True) -> List[Path]:
     """Discover notebooks based on target specification"""


### PR DESCRIPTION
## Summary

Add proper `Optional[X] = None` annotations and missing return type hints across 7 production modules. PEP 484 requires `Optional[X]` for parameters with `None` default; bare `X = None` is technically a type error under strict checking.

## Changes

### genai-stack/core/
- `comfyui_client.py`: `__init__(Optional[ComfyUIConfig])`, `get_object_info(Optional[str])`
- `auth_manager.py`: `__init__(Optional[Path])`, `create_unified_config(Optional[str])`, `to_dict() -> Dict`, `_update_env_file() -> None`

### genai-stack/commands/
- `validate.py`: `__init__(Any, Optional[Path])`, `run_full_validation(Optional[str])`
- `docker.py`: `_run_cmd(... Optional[Path])`, `print_status() -> None`, added `Optional` to typing imports
- `notebooks.py`: `save_report() -> None`
- `audio_apis.py`: `_get_auth_headers(Optional[str])`

### notebook_tools/
- `notebook_tools.py`: `print_ok/error/warning/info/section() -> None`, `check_python_package(... Optional[str])`, `discover_notebooks(... Optional[Path])`

## Validation

- 759/759 tests pass, 0 regressions
- Pure type annotation changes, no logic modifications