### PR TITLE
fix(secrets): replace CIVITAI_TOKEN literal with os.getenv in auth_manager.py

### DIFF
--- a/scripts/genai-stack/core/auth_manager.py
+++ b/scripts/genai-stack/core/auth_manager.py
@@ -276,8 +276,8 @@ class GenAIAuthManager:
 # Date: {datetime.now().isoformat()}
 
 # --- API KEYS ---
-CIVITAI_TOKEN=c39ba121e12e5b40ac67a87836431e34
-HF_TOKEN=HF_TOKEN_REDACTED
+CIVITAI_TOKEN={os.getenv("CIVITAI_TOKEN", "")}
+HF_TOKEN={os.getenv("HF_TOKEN", "")}
 QWEN_API_TOKEN={config.get('bcrypt_hash')}
 
 # --- GPU ---


### PR DESCRIPTION
## Summary
Replace hardcoded CIVITAI_TOKEN and HF_TOKEN string literals in the .env template generator with `os.getenv()` calls.

## Details
- **auth_manager.py:279**: `CIVITAI_TOKEN=c39ba121e12e5b40ac67a87836431e34` -> `CIVITAI_TOKEN={os.getenv("CIVITAI_TOKEN", "")}`
- **auth_manager.py:280**: `HF_TOKEN=HF_TOKEN_REDACTED` -> `HF_TOKEN={os.getenv("HF_TOKEN", "")}`

The `reconstruct_env_file()` method generates a .env template. The old code hardcoded a real Civitai API token as a literal, violating the secrets-hygiene rule (no inline secrets in source code).

## Security Note
The literal token `c39ba12...` is already in git history. **Token rotation at Civitai is recommended** if not already performed. This PR prevents the literal from appearing in future code.

## Testing
- 759/759 tests pass
- Module import verified (GenAIAuthManager loads without error)

Refs: secrets-hygiene rule, incident 2026-05-14 pattern.