### PR TITLE
fix(scripts): replace last bare except in validate_lean11.py

### DIFF
--- a/scripts/kernels/validate_lean11.py
+++ b/scripts/kernels/validate_lean11.py
@@ -30,7 +30,7 @@ def validate_notebook():
             json.load(f)
         print('✓ Format JSON valide')
         structure_score += 3
-    except:
+    except (json.JSONDecodeError, OSError):
         print('✗ Format JSON invalide')
 
     # Kernel


### PR DESCRIPTION
## Summary
Replace the last remaining bare `except:` clause in the entire scripts/ directory with specific exception types.

## Details
- **File**: `scripts/kernels/validate_lean11.py:33`
- **Before**: `except:` (catches everything including KeyboardInterrupt)
- **After**: `except (json.JSONDecodeError, OSError):` (only catches JSON parse errors and file I/O errors)

## Milestone
**Zero bare `except:` clauses remaining in scripts/ directory.**

Over cycles 44-51, po-2024 eliminated all bare excepts across production scripts:
- Cycle 44: 9 bare excepts in genai-stack (PR #1815)
- Cycle 51: 1 last bare except in validate_lean11.py (this PR)

## Testing
- 759/759 tests pass