### PR TITLE
fix(kernel): normalize display_name myvenv to Python 3 (3 CSP notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -2531,7 +2531,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myvenv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
@@ -2100,7 +2100,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myvenv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
@@ -2035,7 +2035,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myvenv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Summary

Same systemic issue as #1769 (conda env leaked into kernelspec.display_name).

3 Search/Part2-CSP notebooks had `myvenv` as display_name instead of `Python 3`:
- CSP-5-Optimization.ipynb
- CSP-6-Hybridization.ipynb
- CSP-8-Temporal.ipynb

## Changes
- **Metadata-only**: only `metadata.kernelspec.display_name` changed
- **Zero source/output touched**: no cell content modified
- **3 files, 3 insertions, 3 deletions**

## Context
- Follow-up to #1769 (32 notebooks fixed) and subsequent fixes in main
- Partition: CoursIA-2 (Search/SymbolicAI/Sudoku/GameTheory non-Lean)
- Scan exhaustif: 17 notebooks initially found with leaked envs, 14 already fixed by prior merges, these 3 remaining

## Validation
- `notebook_tools.py analyze` confirms 0 errors in all 3 notebooks
- display_name now consistent with kernel standard