### PR TITLE
fix(catalog): correct GameTheory pedagogical_count 25->28

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -2,8 +2,8 @@
 
 <!-- CATALOG-STATUS
 series: GameTheory
-pedagogical_count: 25
-breakdown: root=21, SocialChoice=4
+pedagogical_count: 28
+breakdown: root=24, SocialChoice=4
 maturity: BETA=21, ALPHA=2, PRODUCTION=2
 -->
 


### PR DESCRIPTION
## Summary

CATALOG-STATUS in GameTheory README was stale:  with .

Actual count (verified by scanning all notebooks with execution_count):
- Root notebooks: **24** (was 21)
- SocialChoice: **4** (correct)
- **Total: 28** (was 25)

3 root notebooks were missing from the catalog count.

## Changes
- : updated CATALOG-STATUS pedagogical_count and breakdown

## Validation
- Scan via  confirms 28 notebooks with executed code cells
- README table already lists all 28 notebooks correctly (the table was right, only the CATALOG-STATUS header was stale)

## Context
- Catalog-drift is a known CI issue (ai-01 diag 2026-05-29T16:41Z)
- Partition: CoursIA-2 (Search/SymbolicAI/Sudoku/GameTheory non-Lean)