### PR TITLE
fix(catalog): correct Planners pedagogical_count 14->13

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -2,9 +2,9 @@
 
 <!-- CATALOG-STATUS
 series: SymbolicAI-Planners
-pedagogical_count: 14
-breakdown: Environment=1, Foundation=3, Classical=4, Advanced=3, NeuroSymbolic=3
-maturity: PRODUCTION=10, BETA=4
+pedagogical_count: 13
+breakdown: Environment=1, Foundation=3, Classical=3, Advanced=3, NeuroSymbolic=3
+maturity: PRODUCTION=9, BETA=4
 -->
 
 Cette serie de notebooks introduit la **Planification Automatique**, une branche fondamentale de l'IA qui genere des sequences d'actions pour atteindre des objectifs.


### PR DESCRIPTION
## Summary

CATALOG-STATUS in Planners README was stale: pedagogical_count: 14 with Classical=4.

Actual count (verified by scanning notebooks with execution_count):
- Environment: 1 (Setup)
- Foundation: 3 (Intro, PDDL, State-Space)
- Classical: **3** (was 4 — Fast-Downward, Heuristics, Domains)
- Advanced: 3 (OR-Tools, Temporal, HTN)
- NeuroSymbolic: 3 (LLM, Unified, LOOP)
- **Total: 13** (was 14)

Also adjusted maturity: PRODUCTION 10->9 (one fewer).

## Changes
- MyIA.AI.Notebooks/SymbolicAI/Planners/README.md: CATALOG-STATUS header only

## Context
- Catalog-drift detected during idle-pickup scan
- Partition: CoursIA-2 (SymbolicAI non-Lean)