### PR TITLE
fix(deps): add arch to QC requirements (GARCH baseline)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/requirements.txt
+++ b/MyIA.AI.Notebooks/QuantConnect/requirements.txt
@@ -93,6 +93,7 @@ PyPortfolioOpt>=1.5.5
 # ===============================
 empyrical>=0.5.5
 pyfolio>=0.9.2
+arch>=6.1.0  # GARCH models for volatility baseline tests
 
 # ===============================
 # Configuration & Environment


### PR DESCRIPTION
## Summary

Adds `arch>=6.1.0` to QuantConnect requirements.txt.

The garch_baseline test suite (9 tests) depends on the `arch` package for GARCH volatility modeling. It was missing from requirements.txt, causing import failures on fresh installs.

## Testing

- `pip install arch` in Python 3.11 resolved 9 failing tests
- 282/282 tests pass after install
- No code changes, dependency declaration only