### PR TITLE
fix(lean): rename flip/swap stubs in Lean-2 to avoid redeclaration

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
@@ -5,10 +5,10 @@
    "id": "1b679ea6",
    "metadata": {
     "papermill": {
-     "duration": 0.005048,
-     "end_time": "2026-05-27T01:57:15.826807+00:00",
+     "duration": 0.004383,
+     "end_time": "2026-05-30T00:49:18.551106+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:15.821759+00:00",
+     "start_time": "2026-05-30T00:49:18.546723+00:00",
      "status": "completed"
     },
     "tags": []
@@ -70,10 +70,10 @@
    "id": "2591fa8e",
    "metadata": {
     "papermill": {
-     "duration": 0.002262,
-     "end_time": "2026-05-27T01:57:15.832369+00:00",
+     "duration": 0.002936,
+     "end_time": "2026-05-30T00:49:18.557441+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:15.830107+00:00",
+     "start_time": "2026-05-30T00:49:18.554505+00:00",
      "status": "completed"
     },
     "tags": []
@@ -93,16 +93,16 @@
    "id": "59b9d36a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:15.838384Z",
-     "iopub.status.busy": "2026-05-27T01:57:15.838075Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.057709Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.057009Z"
+     "iopub.execute_input": "2026-05-30T00:49:18.566059Z",
+     "iopub.status.busy": "2026-05-30T00:49:18.565874Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.155311Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.154046Z"
     },
     "papermill": {
-     "duration": 0.223352,
-     "end_time": "2026-05-27T01:57:16.058367+00:00",
+     "duration": 1.594203,
+     "end_time": "2026-05-30T00:49:20.155904+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:15.835015+00:00",
+     "start_time": "2026-05-30T00:49:18.561701+00:00",
      "status": "completed"
     },
     "tags": []
@@ -272,10 +272,10 @@
    "id": "f60b5c0a",
    "metadata": {
     "papermill": {
-     "duration": 0.002466,
-     "end_time": "2026-05-27T01:57:16.063580+00:00",
+     "duration": 0.003215,
+     "end_time": "2026-05-30T00:49:20.162610+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.061114+00:00",
+     "start_time": "2026-05-30T00:49:20.159395+00:00",
      "status": "completed"
     },
     "tags": []
@@ -292,16 +292,16 @@
    "id": "0a84fa53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.069502Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.069371Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.191241Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.190569Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.169971Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.169824Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.291678Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.290569Z"
     },
     "papermill": {
-     "duration": 0.12567,
-     "end_time": "2026-05-27T01:57:16.191761+00:00",
+     "duration": 0.126479,
+     "end_time": "2026-05-30T00:49:20.292293+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.066091+00:00",
+     "start_time": "2026-05-30T00:49:20.165814+00:00",
      "status": "completed"
     },
     "tags": []
@@ -432,10 +432,10 @@
    "id": "7987e5d3",
    "metadata": {
     "papermill": {
-     "duration": 0.002572,
-     "end_time": "2026-05-27T01:57:16.197295+00:00",
+     "duration": 0.003751,
+     "end_time": "2026-05-30T00:49:20.300012+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.194723+00:00",
+     "start_time": "2026-05-30T00:49:20.296261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -452,16 +452,16 @@
    "id": "91a1383e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.203355Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.203228Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.326791Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.326067Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.307719Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.307559Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.430574Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.429650Z"
     },
     "papermill": {
-     "duration": 0.127368,
-     "end_time": "2026-05-27T01:57:16.327226+00:00",
+     "duration": 0.127766,
+     "end_time": "2026-05-30T00:49:20.431139+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.199858+00:00",
+     "start_time": "2026-05-30T00:49:20.303373+00:00",
      "status": "completed"
     },
     "tags": []
@@ -592,10 +592,10 @@
    "id": "00293e72",
    "metadata": {
     "papermill": {
-     "duration": 0.002839,
-     "end_time": "2026-05-27T01:57:16.333353+00:00",
+     "duration": 0.003451,
+     "end_time": "2026-05-30T00:49:20.438424+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.330514+00:00",
+     "start_time": "2026-05-30T00:49:20.434973+00:00",
      "status": "completed"
     },
     "tags": []
@@ -617,16 +617,16 @@
    "id": "2d447b9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.339327Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.339205Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.452958Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.452205Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.446428Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.446273Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.560931Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.559942Z"
     },
     "papermill": {
-     "duration": 0.117367,
-     "end_time": "2026-05-27T01:57:16.453394+00:00",
+     "duration": 0.119166,
+     "end_time": "2026-05-30T00:49:20.561426+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.336027+00:00",
+     "start_time": "2026-05-30T00:49:20.442260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -754,10 +754,10 @@
    "id": "993d675f",
    "metadata": {
     "papermill": {
-     "duration": 0.002881,
-     "end_time": "2026-05-27T01:57:16.459547+00:00",
+     "duration": 0.003419,
+     "end_time": "2026-05-30T00:49:20.568863+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.456666+00:00",
+     "start_time": "2026-05-30T00:49:20.565444+00:00",
      "status": "completed"
     },
     "tags": []
@@ -776,16 +776,16 @@
    "id": "e4e7f6e8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.465912Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.465775Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.592048Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.591264Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.577349Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.577166Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.704161Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.702814Z"
     },
     "papermill": {
-     "duration": 0.130063,
-     "end_time": "2026-05-27T01:57:16.592493+00:00",
+     "duration": 0.132437,
+     "end_time": "2026-05-30T00:49:20.704886+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.462430+00:00",
+     "start_time": "2026-05-30T00:49:20.572449+00:00",
      "status": "completed"
     },
     "tags": []
@@ -934,10 +934,10 @@
    "id": "cc4f8940",
    "metadata": {
     "papermill": {
-     "duration": 0.003046,
-     "end_time": "2026-05-27T01:57:16.598907+00:00",
+     "duration": 0.003707,
+     "end_time": "2026-05-30T00:49:20.712726+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.595861+00:00",
+     "start_time": "2026-05-30T00:49:20.709019+00:00",
      "status": "completed"
     },
     "tags": []
@@ -956,16 +956,16 @@
    "id": "90ec6e56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.605690Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.605569Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.728055Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.727327Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.721234Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.721051Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.842526Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.841663Z"
     },
     "papermill": {
-     "duration": 0.126667,
-     "end_time": "2026-05-27T01:57:16.728540+00:00",
+     "duration": 0.126819,
+     "end_time": "2026-05-30T00:49:20.843192+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.601873+00:00",
+     "start_time": "2026-05-30T00:49:20.716373+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1102,10 +1102,10 @@
    "id": "4e9ae148",
    "metadata": {
     "papermill": {
-     "duration": 0.003097,
-     "end_time": "2026-05-27T01:57:16.735125+00:00",
+     "duration": 0.003815,
+     "end_time": "2026-05-30T00:49:20.851229+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.732028+00:00",
+     "start_time": "2026-05-30T00:49:20.847414+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1138,16 +1138,16 @@
    "id": "18e8aa52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.742548Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.742419Z",
-     "iopub.status.idle": "2026-05-27T01:57:16.878702Z",
-     "shell.execute_reply": "2026-05-27T01:57:16.877920Z"
+     "iopub.execute_input": "2026-05-30T00:49:20.859388Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.859244Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.000194Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.998702Z"
     },
     "papermill": {
-     "duration": 0.140636,
-     "end_time": "2026-05-27T01:57:16.879152+00:00",
+     "duration": 0.145805,
+     "end_time": "2026-05-30T00:49:21.000871+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.738516+00:00",
+     "start_time": "2026-05-30T00:49:20.855066+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1320,10 +1320,10 @@
    "id": "542c13f3",
    "metadata": {
     "papermill": {
-     "duration": 0.003156,
-     "end_time": "2026-05-27T01:57:16.885942+00:00",
+     "duration": 0.004016,
+     "end_time": "2026-05-30T00:49:21.009224+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.882786+00:00",
+     "start_time": "2026-05-30T00:49:21.005208+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1340,16 +1340,16 @@
    "id": "6ba5997e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:16.894229Z",
-     "iopub.status.busy": "2026-05-27T01:57:16.894081Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.018965Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.018124Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.018735Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.018503Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.144370Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.142920Z"
     },
     "papermill": {
-     "duration": 0.129625,
-     "end_time": "2026-05-27T01:57:17.019467+00:00",
+     "duration": 0.132172,
+     "end_time": "2026-05-30T00:49:21.145430+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:16.889842+00:00",
+     "start_time": "2026-05-30T00:49:21.013258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1465,10 +1465,10 @@
    "id": "67b12351",
    "metadata": {
     "papermill": {
-     "duration": 0.004291,
-     "end_time": "2026-05-27T01:57:17.028069+00:00",
+     "duration": 0.004061,
+     "end_time": "2026-05-30T00:49:21.154251+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.023778+00:00",
+     "start_time": "2026-05-30T00:49:21.150190+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1498,16 +1498,16 @@
    "id": "c07c8978",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.037656Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.037490Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.146264Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.145489Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.164006Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.163823Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.274419Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.273439Z"
     },
     "papermill": {
-     "duration": 0.114377,
-     "end_time": "2026-05-27T01:57:17.146765+00:00",
+     "duration": 0.116942,
+     "end_time": "2026-05-30T00:49:21.275278+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.032388+00:00",
+     "start_time": "2026-05-30T00:49:21.158336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1671,10 +1671,10 @@
    "id": "f44b8274",
    "metadata": {
     "papermill": {
-     "duration": 0.003683,
-     "end_time": "2026-05-27T01:57:17.154258+00:00",
+     "duration": 0.004204,
+     "end_time": "2026-05-30T00:49:21.284061+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.150575+00:00",
+     "start_time": "2026-05-30T00:49:21.279857+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1691,16 +1691,16 @@
    "id": "4bdf7b32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.161864Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.161729Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.278378Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.277613Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.293650Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.293498Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.412424Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.411436Z"
     },
     "papermill": {
-     "duration": 0.121033,
-     "end_time": "2026-05-27T01:57:17.278842+00:00",
+     "duration": 0.124837,
+     "end_time": "2026-05-30T00:49:21.413139+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.157809+00:00",
+     "start_time": "2026-05-30T00:49:21.288302+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1864,10 +1864,10 @@
    "id": "381e6ef0",
    "metadata": {
     "papermill": {
-     "duration": 0.003948,
-     "end_time": "2026-05-27T01:57:17.287213+00:00",
+     "duration": 0.004823,
+     "end_time": "2026-05-30T00:49:21.422809+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.283265+00:00",
+     "start_time": "2026-05-30T00:49:21.417986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1885,16 +1885,16 @@
    "id": "1e33d173",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.295033Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.294890Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.420746Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.420002Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.433652Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.433460Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.562072Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.561278Z"
     },
     "papermill": {
-     "duration": 0.130604,
-     "end_time": "2026-05-27T01:57:17.421391+00:00",
+     "duration": 0.134618,
+     "end_time": "2026-05-30T00:49:21.562588+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.290787+00:00",
+     "start_time": "2026-05-30T00:49:21.427970+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2043,10 +2043,10 @@
    "id": "86be6138",
    "metadata": {
     "papermill": {
-     "duration": 0.003827,
-     "end_time": "2026-05-27T01:57:17.429269+00:00",
+     "duration": 0.004235,
+     "end_time": "2026-05-30T00:49:21.571401+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.425442+00:00",
+     "start_time": "2026-05-30T00:49:21.567166+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2067,16 +2067,16 @@
    "id": "1ba07acd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.438055Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.437896Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.564815Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.564235Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.580468Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.580330Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.705084Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.704133Z"
     },
     "papermill": {
-     "duration": 0.132058,
-     "end_time": "2026-05-27T01:57:17.565337+00:00",
+     "duration": 0.130137,
+     "end_time": "2026-05-30T00:49:21.705757+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.433279+00:00",
+     "start_time": "2026-05-30T00:49:21.575620+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2195,10 +2195,10 @@
    "id": "24b9dc7e",
    "metadata": {
     "papermill": {
-     "duration": 0.003838,
-     "end_time": "2026-05-27T01:57:17.573684+00:00",
+     "duration": 0.004937,
+     "end_time": "2026-05-30T00:49:21.716450+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.569846+00:00",
+     "start_time": "2026-05-30T00:49:21.711513+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2218,16 +2218,16 @@
    "id": "82b67a74",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.582418Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.582282Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.694850Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.693489Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.726795Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.726607Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.840222Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.839249Z"
     },
     "papermill": {
-     "duration": 0.117712,
-     "end_time": "2026-05-27T01:57:17.695355+00:00",
+     "duration": 0.11983,
+     "end_time": "2026-05-30T00:49:21.840922+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.577643+00:00",
+     "start_time": "2026-05-30T00:49:21.721092+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2367,10 +2367,10 @@
    "id": "7c4a105e",
    "metadata": {
     "papermill": {
-     "duration": 0.00429,
-     "end_time": "2026-05-27T01:57:17.704382+00:00",
+     "duration": 0.004962,
+     "end_time": "2026-05-30T00:49:21.851156+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.700092+00:00",
+     "start_time": "2026-05-30T00:49:21.846194+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2387,16 +2387,16 @@
    "id": "c40afbcb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.714303Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.714076Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.831841Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.831130Z"
+     "iopub.execute_input": "2026-05-30T00:49:21.861968Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.861805Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.980106Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.979171Z"
     },
     "papermill": {
-     "duration": 0.123589,
-     "end_time": "2026-05-27T01:57:17.832312+00:00",
+     "duration": 0.124488,
+     "end_time": "2026-05-30T00:49:21.980771+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.708723+00:00",
+     "start_time": "2026-05-30T00:49:21.856283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2518,10 +2518,10 @@
    "id": "954520dd",
    "metadata": {
     "papermill": {
-     "duration": 0.0045,
-     "end_time": "2026-05-27T01:57:17.841185+00:00",
+     "duration": 0.005285,
+     "end_time": "2026-05-30T00:49:21.991585+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.836685+00:00",
+     "start_time": "2026-05-30T00:49:21.986300+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2538,16 +2538,16 @@
    "id": "cee79f5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.850285Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.850117Z",
-     "iopub.status.idle": "2026-05-27T01:57:17.978893Z",
-     "shell.execute_reply": "2026-05-27T01:57:17.978227Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.007335Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.007139Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.138077Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.137134Z"
     },
     "papermill": {
-     "duration": 0.13417,
-     "end_time": "2026-05-27T01:57:17.979627+00:00",
+     "duration": 0.139657,
+     "end_time": "2026-05-30T00:49:22.138725+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.845457+00:00",
+     "start_time": "2026-05-30T00:49:21.999068+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2705,10 +2705,10 @@
    "id": "5c1d4e7b",
    "metadata": {
     "papermill": {
-     "duration": 0.004335,
-     "end_time": "2026-05-27T01:57:17.988691+00:00",
+     "duration": 0.004944,
+     "end_time": "2026-05-30T00:49:22.149095+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.984356+00:00",
+     "start_time": "2026-05-30T00:49:22.144151+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2735,16 +2735,16 @@
    "id": "10776ffb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:17.997802Z",
-     "iopub.status.busy": "2026-05-27T01:57:17.997657Z",
-     "iopub.status.idle": "2026-05-27T01:57:18.116069Z",
-     "shell.execute_reply": "2026-05-27T01:57:18.115278Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.160536Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.160382Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.277168Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.276194Z"
     },
     "papermill": {
-     "duration": 0.124204,
-     "end_time": "2026-05-27T01:57:18.116968+00:00",
+     "duration": 0.123098,
+     "end_time": "2026-05-30T00:49:22.277744+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:17.992764+00:00",
+     "start_time": "2026-05-30T00:49:22.154646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2863,10 +2863,10 @@
    "id": "bda5d31a",
    "metadata": {
     "papermill": {
-     "duration": 0.004617,
-     "end_time": "2026-05-27T01:57:18.126789+00:00",
+     "duration": 0.019359,
+     "end_time": "2026-05-30T00:49:22.302661+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.122172+00:00",
+     "start_time": "2026-05-30T00:49:22.283302+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2883,16 +2883,16 @@
    "id": "ca5a41e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:18.136435Z",
-     "iopub.status.busy": "2026-05-27T01:57:18.136310Z",
-     "iopub.status.idle": "2026-05-27T01:57:18.274432Z",
-     "shell.execute_reply": "2026-05-27T01:57:18.273530Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.314284Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.314084Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.454856Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.453991Z"
     },
     "papermill": {
-     "duration": 0.143524,
-     "end_time": "2026-05-27T01:57:18.274966+00:00",
+     "duration": 0.147226,
+     "end_time": "2026-05-30T00:49:22.455360+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.131442+00:00",
+     "start_time": "2026-05-30T00:49:22.308134+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3055,10 +3055,10 @@
    "id": "2de09b1b",
    "metadata": {
     "papermill": {
-     "duration": 0.004634,
-     "end_time": "2026-05-27T01:57:18.284904+00:00",
+     "duration": 0.005648,
+     "end_time": "2026-05-30T00:49:22.466831+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.280270+00:00",
+     "start_time": "2026-05-30T00:49:22.461183+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3075,16 +3075,16 @@
    "id": "cd70526d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:18.295639Z",
-     "iopub.status.busy": "2026-05-27T01:57:18.295477Z",
-     "iopub.status.idle": "2026-05-27T01:57:18.422528Z",
-     "shell.execute_reply": "2026-05-27T01:57:18.421458Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.478655Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.478490Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.606742Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.605846Z"
     },
     "papermill": {
-     "duration": 0.133535,
-     "end_time": "2026-05-27T01:57:18.423055+00:00",
+     "duration": 0.135292,
+     "end_time": "2026-05-30T00:49:22.607717+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.289520+00:00",
+     "start_time": "2026-05-30T00:49:22.472425+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3269,10 +3269,10 @@
    "id": "26dc8f5d",
    "metadata": {
     "papermill": {
-     "duration": 0.005699,
-     "end_time": "2026-05-27T01:57:18.434014+00:00",
+     "duration": 0.005464,
+     "end_time": "2026-05-30T00:49:22.619562+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.428315+00:00",
+     "start_time": "2026-05-30T00:49:22.614098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3292,16 +3292,16 @@
    "id": "ff587027",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:18.444854Z",
-     "iopub.status.busy": "2026-05-27T01:57:18.444713Z",
-     "iopub.status.idle": "2026-05-27T01:57:18.564393Z",
-     "shell.execute_reply": "2026-05-27T01:57:18.563645Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.632859Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.632486Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.754346Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.753443Z"
     },
     "papermill": {
-     "duration": 0.125779,
-     "end_time": "2026-05-27T01:57:18.564845+00:00",
+     "duration": 0.129263,
+     "end_time": "2026-05-30T00:49:22.754914+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.439066+00:00",
+     "start_time": "2026-05-30T00:49:22.625651+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3429,10 +3429,10 @@
    "id": "7d3346a1",
    "metadata": {
     "papermill": {
-     "duration": 0.018988,
-     "end_time": "2026-05-27T01:57:18.589372+00:00",
+     "duration": 0.005961,
+     "end_time": "2026-05-30T00:49:22.766803+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.570384+00:00",
+     "start_time": "2026-05-30T00:49:22.760842+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3454,16 +3454,16 @@
    "id": "784d2427",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:18.602921Z",
-     "iopub.status.busy": "2026-05-27T01:57:18.602776Z",
-     "iopub.status.idle": "2026-05-27T01:57:20.010886Z",
-     "shell.execute_reply": "2026-05-27T01:57:20.010231Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.779597Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.779321Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.902594Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.901551Z"
     },
     "papermill": {
-     "duration": 1.415171,
-     "end_time": "2026-05-27T01:57:20.011350+00:00",
+     "duration": 0.131113,
+     "end_time": "2026-05-30T00:49:22.903582+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:18.596179+00:00",
+     "start_time": "2026-05-30T00:49:22.772469+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3600,10 +3600,10 @@
    "id": "e1e79371",
    "metadata": {
     "papermill": {
-     "duration": 0.005106,
-     "end_time": "2026-05-27T01:57:20.021971+00:00",
+     "duration": 0.006103,
+     "end_time": "2026-05-30T00:49:22.916298+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.016865+00:00",
+     "start_time": "2026-05-30T00:49:22.910195+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3624,16 +3624,16 @@
    "id": "51f00b2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:20.033024Z",
-     "iopub.status.busy": "2026-05-27T01:57:20.032876Z",
-     "iopub.status.idle": "2026-05-27T01:57:20.145683Z",
-     "shell.execute_reply": "2026-05-27T01:57:20.144899Z"
+     "iopub.execute_input": "2026-05-30T00:49:22.929034Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.928877Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.039574Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.038739Z"
     },
     "papermill": {
-     "duration": 0.118944,
-     "end_time": "2026-05-27T01:57:20.146186+00:00",
+     "duration": 0.117805,
+     "end_time": "2026-05-30T00:49:23.040083+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.027242+00:00",
+     "start_time": "2026-05-30T00:49:22.922278+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3707,10 +3707,10 @@
    "id": "20d54f87",
    "metadata": {
     "papermill": {
-     "duration": 0.005356,
-     "end_time": "2026-05-27T01:57:20.157260+00:00",
+     "duration": 0.005629,
+     "end_time": "2026-05-30T00:49:23.051762+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.151904+00:00",
+     "start_time": "2026-05-30T00:49:23.046133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3726,16 +3726,16 @@
    "id": "5b350de2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:20.168610Z",
-     "iopub.status.busy": "2026-05-27T01:57:20.168481Z",
-     "iopub.status.idle": "2026-05-27T01:57:20.284114Z",
-     "shell.execute_reply": "2026-05-27T01:57:20.283314Z"
+     "iopub.execute_input": "2026-05-30T00:49:23.063508Z",
+     "iopub.status.busy": "2026-05-30T00:49:23.063344Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.180107Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.179259Z"
     },
     "papermill": {
-     "duration": 0.122352,
-     "end_time": "2026-05-27T01:57:20.284839+00:00",
+     "duration": 0.123601,
+     "end_time": "2026-05-30T00:49:23.180654+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.162487+00:00",
+     "start_time": "2026-05-30T00:49:23.057053+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3821,10 +3821,10 @@
    "id": "c09ab0e7",
    "metadata": {
     "papermill": {
-     "duration": 0.009589,
-     "end_time": "2026-05-27T01:57:20.301497+00:00",
+     "duration": 0.007712,
+     "end_time": "2026-05-30T00:49:23.195248+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.291908+00:00",
+     "start_time": "2026-05-30T00:49:23.187536+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3840,16 +3840,16 @@
    "id": "2a15c66f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:20.315904Z",
-     "iopub.status.busy": "2026-05-27T01:57:20.315738Z",
-     "iopub.status.idle": "2026-05-27T01:57:20.436565Z",
-     "shell.execute_reply": "2026-05-27T01:57:20.435849Z"
+     "iopub.execute_input": "2026-05-30T00:49:23.208776Z",
+     "iopub.status.busy": "2026-05-30T00:49:23.208577Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.331039Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.330251Z"
     },
     "papermill": {
-     "duration": 0.128993,
-     "end_time": "2026-05-27T01:57:20.437090+00:00",
+     "duration": 0.130415,
+     "end_time": "2026-05-30T00:49:23.331616+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.308097+00:00",
+     "start_time": "2026-05-30T00:49:23.201201+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3923,10 +3923,10 @@
    "id": "66b3f9c3",
    "metadata": {
     "papermill": {
-     "duration": 0.005859,
-     "end_time": "2026-05-27T01:57:20.449596+00:00",
+     "duration": 0.0097,
+     "end_time": "2026-05-30T00:49:23.348023+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.443737+00:00",
+     "start_time": "2026-05-30T00:49:23.338323+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3944,16 +3944,16 @@
    "id": "db884a7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:20.461802Z",
-     "iopub.status.busy": "2026-05-27T01:57:20.461657Z",
-     "iopub.status.idle": "2026-05-27T01:57:20.573994Z",
-     "shell.execute_reply": "2026-05-27T01:57:20.573185Z"
+     "iopub.execute_input": "2026-05-30T00:49:23.361524Z",
+     "iopub.status.busy": "2026-05-30T00:49:23.361358Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.481114Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.479448Z"
     },
     "papermill": {
-     "duration": 0.119362,
-     "end_time": "2026-05-27T01:57:20.574790+00:00",
+     "duration": 0.127582,
+     "end_time": "2026-05-30T00:49:23.481799+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.455428+00:00",
+     "start_time": "2026-05-30T00:49:23.354217+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3978,20 +3978,22 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval isEven 7    -- doit retourner false</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : Inversion d&#39;arguments (ordre superieur)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : definir flip qui inverse l&#39;ordre des deux arguments d&#39;une fonction binaire</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk60\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk60\"><span class=\"kn\">def</span><span class=\"w\"> </span>flip<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">❌</span><span class=\"w\"> </span><span class=\"ss\">`flip</span><span class=\"bp\">`</span><span class=\"w\"> </span>has<span class=\"w\"> </span>already<span class=\"w\"> </span>been<span class=\"w\"> </span>declared</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval flip (fun a b : Nat =&gt; a - b) 3 10   -- doit retourner 7 (= 10 - 3)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : definir myFlip qui inverse l&#39;ordre des deux arguments d&#39;une fonction binaire</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk60\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk60\"><span class=\"kn\">def</span><span class=\"w\"> </span>myFlip<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval myFlip (fun a b : Nat =&gt; a - b) 3 10   -- doit retourner 7 (= 10 - 3)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : Echange des composantes d&#39;une paire</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : definir swap qui echange les deux composantes d&#39;une paire</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk61\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk61\"><span class=\"kn\">def</span><span class=\"w\"> </span>swap<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">❌</span><span class=\"w\"> </span><span class=\"ss\">`swap</span><span class=\"bp\">`</span><span class=\"w\"> </span>has<span class=\"w\"> </span>already<span class=\"w\"> </span>been<span class=\"w\"> </span>declared</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval swap (1, &quot;x&quot;)   -- doit retourner (&quot;x&quot;, 1)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : definir mySwap qui echange les deux composantes d&#39;une paire</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk61\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk61\"><span class=\"kn\">def</span><span class=\"w\"> </span>mySwap<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval mySwap (1, &quot;x&quot;)   -- doit retourner (&quot;x&quot;, 1)</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 23</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : Parite\\n-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\\ndef isEven (n : Nat) : Bool := sorry\\n-- #eval isEven 4    -- doit retourner true\\n-- #eval isEven 7    -- doit retourner false\\n\\n-- Exercice 2 : Inversion d'arguments (ordre superieur)\\n-- TODO etudiant : definir flip qui inverse l'ordre des deux arguments d'une fonction binaire\\ndef flip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\\n-- #eval flip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\\n\\n-- Exercice 3 : Echange des composantes d'une paire\\n-- TODO etudiant : definir swap qui echange les deux composantes d'une paire\\ndef swap {a b : Type} (p : a \\u00d7 b) : b \\u00d7 a := sorry\\n-- #eval swap (1, \\\"x\\\")   -- doit retourner (\\\"x\\\", 1)\", \"env\": 22}</code>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : Parite\\n-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\\ndef isEven (n : Nat) : Bool := sorry\\n-- #eval isEven 4    -- doit retourner true\\n-- #eval isEven 7    -- doit retourner false\\n\\n-- Exercice 2 : Inversion d'arguments (ordre superieur)\\n-- TODO etudiant : definir myFlip qui inverse l'ordre des deux arguments d'une fonction binaire\\n-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core\\ndef myFlip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\\n-- #eval myFlip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\\n\\n-- Exercice 3 : Echange des composantes d'une paire\\n-- TODO etudiant : definir mySwap qui echange les deux composantes d'une paire\\n-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2\\ndef mySwap {a b : Type} (p : a \\u00d7 b) : b \\u00d7 a := sorry\\n-- #eval mySwap (1, \\\"x\\\")   -- doit retourner (\\\"x\\\", 1)\", \"env\": 22}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
@@ -3999,20 +4001,28 @@
        " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 31},\r\n",
        "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Bool\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 36}}],\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 36}},\r\n",
+       "  {\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 61},\r\n",
+       "   \"goal\": \"a✝ b✝ a b c : Type\\nf : a → b → c\\n⊢ b → a → c\",\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 66}},\r\n",
+       "  {\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 47},\r\n",
+       "   \"goal\": \"a✝ b✝ a b : Type\\np : a × b\\n⊢ b × a\",\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 52}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 4},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 10},\r\n",
        "   \"data\": \"declaration uses 'sorry'\"},\r\n",
-       "  {\"severity\": \"error\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 8},\r\n",
-       "   \"data\": \"`flip` has already been declared\"},\r\n",
-       "  {\"severity\": \"error\",\r\n",
-       "   \"pos\": {\"line\": 14, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 14, \"column\": 8},\r\n",
-       "   \"data\": \"`swap` has already been declared\"}],\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 4},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 10},\r\n",
+       "   \"data\": \"declaration uses 'sorry'\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 4},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 10},\r\n",
+       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
        " \"env\": 23}</code>\n",
        "        </details>\n",
        "    "
@@ -4026,40 +4036,50 @@
        "-- #eval isEven 7    -- doit retourner false\n",
        "\n",
        "-- Exercice 2 : Inversion d'arguments (ordre superieur)\n",
-       "-- TODO etudiant : definir flip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
-       "def flip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\n",
-       "    ────▶ ❌ `flip` has already been declared\n",
-       "-- #eval flip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
+       "-- TODO etudiant : definir myFlip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
+       "-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core\n",
+       "def myFlip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\n",
+       "    ──────▶ 🟨 declaration uses 'sorry'\n",
+       "-- #eval myFlip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
        "\n",
        "-- Exercice 3 : Echange des composantes d'une paire\n",
-       "-- TODO etudiant : definir swap qui echange les deux composantes d'une paire\n",
-       "def swap {a b : Type} (p : a × b) : b × a := sorry\n",
-       "    ────▶ ❌ `swap` has already been declared\n",
-       "-- #eval swap (1, \"x\")   -- doit retourner (\"x\", 1)\n",
+       "-- TODO etudiant : definir mySwap qui echange les deux composantes d'une paire\n",
+       "-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2\n",
+       "def mySwap {a b : Type} (p : a × b) : b × a := sorry\n",
+       "    ──────▶ 🟨 declaration uses 'sorry'\n",
+       "-- #eval mySwap (1, \"x\")   -- doit retourner (\"x\", 1)\n",
        "--% env 23\n",
-       "--% prove 0\n",
+       "--% prove 2\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : Parite\\n-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\\ndef isEven (n : Nat) : Bool := sorry\\n-- #eval isEven 4    -- doit retourner true\\n-- #eval isEven 7    -- doit retourner false\\n\\n-- Exercice 2 : Inversion d'arguments (ordre superieur)\\n-- TODO etudiant : definir flip qui inverse l'ordre des deux arguments d'une fonction binaire\\ndef flip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\\n-- #eval flip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\\n\\n-- Exercice 3 : Echange des composantes d'une paire\\n-- TODO etudiant : definir swap qui echange les deux composantes d'une paire\\ndef swap {a b : Type} (p : a \\u00d7 b) : b \\u00d7 a := sorry\\n-- #eval swap (1, \\\"x\\\")   -- doit retourner (\\\"x\\\", 1)\", \"env\": 22}\n",
+       "{\"cmd\": \"-- Exercice 1 : Parite\\n-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\\ndef isEven (n : Nat) : Bool := sorry\\n-- #eval isEven 4    -- doit retourner true\\n-- #eval isEven 7    -- doit retourner false\\n\\n-- Exercice 2 : Inversion d'arguments (ordre superieur)\\n-- TODO etudiant : definir myFlip qui inverse l'ordre des deux arguments d'une fonction binaire\\n-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core\\ndef myFlip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\\n-- #eval myFlip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\\n\\n-- Exercice 3 : Echange des composantes d'une paire\\n-- TODO etudiant : definir mySwap qui echange les deux composantes d'une paire\\n-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2\\ndef mySwap {a b : Type} (p : a \\u00d7 b) : b \\u00d7 a := sorry\\n-- #eval mySwap (1, \\\"x\\\")   -- doit retourner (\\\"x\\\", 1)\", \"env\": 22}\n",
        "Raw output:\n",
        "{\"sorries\":\r\n",
        " [{\"proofState\": 0,\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 31},\r\n",
        "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Bool\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 36}}],\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 36}},\r\n",
+       "  {\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 61},\r\n",
+       "   \"goal\": \"a✝ b✝ a b c : Type\\nf : a → b → c\\n⊢ b → a → c\",\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 66}},\r\n",
+       "  {\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 47},\r\n",
+       "   \"goal\": \"a✝ b✝ a b : Type\\np : a × b\\n⊢ b × a\",\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 52}}],\r\n",
        " \"messages\":\r\n",
        " [{\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 3, \"column\": 4},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 10},\r\n",
        "   \"data\": \"declaration uses 'sorry'\"},\r\n",
-       "  {\"severity\": \"error\",\r\n",
-       "   \"pos\": {\"line\": 9, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 9, \"column\": 8},\r\n",
-       "   \"data\": \"`flip` has already been declared\"},\r\n",
-       "  {\"severity\": \"error\",\r\n",
-       "   \"pos\": {\"line\": 14, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 14, \"column\": 8},\r\n",
-       "   \"data\": \"`swap` has already been declared\"}],\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 10, \"column\": 4},\r\n",
+       "   \"endPos\": {\"line\": 10, \"column\": 10},\r\n",
+       "   \"data\": \"declaration uses 'sorry'\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 16, \"column\": 4},\r\n",
+       "   \"endPos\": {\"line\": 16, \"column\": 10},\r\n",
+       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
        " \"env\": 23}"
       ]
      },
@@ -4075,14 +4095,16 @@
     "-- #eval isEven 7    -- doit retourner false\n",
     "\n",
     "-- Exercice 2 : Inversion d'arguments (ordre superieur)\n",
-    "-- TODO etudiant : definir flip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
-    "def flip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\n",
-    "-- #eval flip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
+    "-- TODO etudiant : definir myFlip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
+    "-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core\n",
+    "def myFlip {a b c : Type} (f : a -> b -> c) : b -> a -> c := sorry\n",
+    "-- #eval myFlip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
     "\n",
     "-- Exercice 3 : Echange des composantes d'une paire\n",
-    "-- TODO etudiant : definir swap qui echange les deux composantes d'une paire\n",
-    "def swap {a b : Type} (p : a × b) : b × a := sorry\n",
-    "-- #eval swap (1, \"x\")   -- doit retourner (\"x\", 1)"
+    "-- TODO etudiant : definir mySwap qui echange les deux composantes d'une paire\n",
+    "-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2\n",
+    "def mySwap {a b : Type} (p : a × b) : b × a := sorry\n",
+    "-- #eval mySwap (1, \"x\")   -- doit retourner (\"x\", 1)"
    ]
   },
   {
@@ -4090,10 +4112,10 @@
    "id": "e3a3c794",
    "metadata": {
     "papermill": {
-     "duration": 0.006111,
-     "end_time": "2026-05-27T01:57:20.586859+00:00",
+     "duration": 0.008928,
+     "end_time": "2026-05-30T00:49:23.499019+00:00",
      "exception": false,
-     "start_time": "2026-05-27T01:57:20.580748+00:00",
+     "start_time": "2026-05-30T00:49:23.490091+00:00",
      "status": "completed"
     },
     "tags": []
@@ -4144,14 +4166,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.345327,
-   "end_time": "2026-05-27T01:57:20.807288+00:00",
+   "duration": 8.166673,
+   "end_time": "2026-05-30T00:49:23.721560+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb",
    "output_path": "/tmp/Lean-2-Dependent-Types_wsl_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-27T01:57:14.461961+00:00",
+   "start_time": "2026-05-30T00:49:15.554887+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
@
## Summary

Lean-2-Dependent-Types cell 48 declared `flip` and `swap` which already existed in the Lean session (`Function.flip` from `import Init` and `swap` from cell 16). This caused `has already been declared` errors blocking all subsequent cells.

## Changes

- Renamed `flip` → `myFlip` and `swap` → `mySwap` in cell 48 (exercise stubs only)
- Added `-- Note:` inline comments explaining WHY the rename was needed
- Updated TODO comments and commented `#eval` examples to match new names
- No production proofs affected (exercise stubs with `sorry` only)

## Validation

- Papermill via `wsl_papermill.py` with kernel `lean4-wsl`: 24/24 code cells, 0 errors, 10.8s
- `notebook_tools.py validate --quick`: OK, 0 warnings, 0 errors
- `notebook_lint.py`: Pass
- Cell 48 now shows only `🟨 declaration uses sorry` warnings (expected for exercise stubs)
- No sorry count regression (exercise stubs unchanged)

## Context

EPITA-IS course readiness for Monday June 1. Part of Lean P0 fixes dispatched by ai-01.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
@