### PR TITLE
enrich(SmartContracts): add pedagogical conclusions to 27 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -1627,6 +1627,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "24b12a75",
+   "source": "## Resume et perspectives\n\nCe notebook a retrace la genealogie technologique qui mene du mouvement Cypherpunk des annees 1980 aux smart contracts d'aujourd'hui. En implementant chaque primitive avec du code Python executable, nous avons constate que Bitcoin n'a invente aucune brique fondamentale : SHA-256 pour l'integrite (section 2), la chaine de hash pour l'immuabilite (section 3), l'arbre de Merkle pour la verification legere en O(log N) (section 4), la Proof-of-Work pour le consensus anti-falsification (section 5), les signatures ECDSA pour l'authentification des transactions (section 6), et la DHT Kademlia pour le reseau decentralise (section 7). L'apport de Satoshi Nakamoto fut la combinaison geniale de ces sept briques preexistantes en un systeme coherent.\n\nLa frise chronologique (section 8) revele trois phases distinctes : les fondations cryptographiques (1976-1991), la decentralisation (1991-2002), puis la synthese blockchain (2008-2015). Ethereum ajoute a cet edifice la Turing-completude, transformant un systeme de paiement en ordinateur decentralise capable d'executer du code arbitraire. Comprendre ces fondations est essentiel pour evaluer la securite et les limites des blockchains modernes : chaque compromis technique (scalabilite vs decentralisation, confidentialite vs transparence) trouve son origine dans ces choix architecturaux fondamentaux.\n\nCes bases historiques et techniques posees, le notebook suivant [SC-1-Setup-Foundry](SC-1-Setup-Foundry.ipynb) passe a la pratique en installant l'environnement de developpement Foundry (forge, cast, anvil) qui sera utilise tout au long de la serie SmartContracts.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "643a6d4d",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
@@ -1003,6 +1003,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f406fb62",
+   "source": "## Resume et perspectives\n\nCe notebook a guide l'installation et la verification de la suite Foundry (forge, cast, anvil), l'environnement de developpement moderne pour les smart contracts Ethereum. Les trois composants couvrent l'ensemble du cycle de vie : `forge` pour la compilation, les tests et le deploiement des contrats Solidity ; `cast` pour les interactions avec la blockchain depuis la ligne de commande ; et `anvil` comme noeud Ethereum local fournissant 10 comptes pre-finances pour le developpement et les tests. L'ecriture de tests en Solidity natif (plutot qu'en JavaScript) est l'un des avantages majeurs de Foundry par rapport aux alternatives comme Hardhat ou Truffle.\n\nLe contrat `Hello.sol` et son test `Hello.t.sol` ont illustre les conventions fondamentales de Foundry : le pattern `setUp()` + `testXxx()` pour les tests unitaires, les assertions `assertEq()` pour la verification, et la structure de projet `src/` / `test/` / `lib/`. Le mot-cle `public` generant automatiquement un getter est un premier apercu de la magie Solidity qui sera detaillee dans les notebooks suivants. L'exercice du contrat Counter avec `increment()`, `decrement()` et `vm.expectRevert()` prepare aux patterns de test avance.\n\nL'environnement etant operationnel, le notebook suivant [SC-2-Setup-Web3py](SC-2-Setup-Web3py.ipynb) complete la chaine d'outils en ajoutant l'interaction Python avec Ethereum via web3.py, permettant de compiler, deployer et appeler des contrats Solidity entierement depuis un notebook Jupyter.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "e169ec75",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -1053,6 +1053,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1871b426",
+   "source": "## Resume et perspectives\n\nCe notebook a etabli le pont entre Python et la blockchain en configurant les deux outils essentiels du workflow de developpement : `web3.py` pour interagir avec Ethereum et `py-solc-x` pour compiler du Solidity directement depuis Python. Le parcours complet -- compilation d'un contrat source Solidity en ABI et bytecode, deploiement via transaction sur le noeud local anvil, puis interactions en lecture (`.call()`) et en ecriture (`.transact()`) -- constitue le pattern reutilisable qui servira de base a tous les notebooks suivants de la serie.\n\nLe helper `compile_and_deploy()` encapsule toute la complexite de compilation et deploiement en un seul appel, permettant de se concentrer sur la logique Solidity plutot que sur la plomberie. La demonstration des transactions multi-comptes avec transfert d'ETH entre Alice et Bob a illustre le modele de gas et la difference entre operations de lecture (gratuites) et d'ecriture (consommant du gas). L'exercice du contrat Vault introduit les mappings et le pattern `payable` qui seront approfondis dans les notebooks suivants.\n\nAvec cet environnement operationnel, le notebook suivant [SC-3-Solidity-Basics](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) entre dans le coeur du langage Solidity en explorant les types de donnees (bool, uint, int, address, bytes, string), les variables d'etat et locales, et les conversions de types, le tout compile et deploye reellement sur anvil.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "34dd7a63",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -1420,6 +1420,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "202bc429",
+   "source": "## Resume et perspectives\n\nCe notebook a pose les fondations du langage Solidity en explorant ses types de donnees fondamentaux (booleens, entiers signes et non signes, adresses Ethereum, bytes et strings) et les mecanismes de variables (d'etat persistantes en storage, locales temporaires en memoire, globales comme `msg.sender` et `block.timestamp`). Chaque type a ete compile, deploye et execute reellement sur la blockchain locale anvil, illustrant concretement le cout de stockage et le comportement de chaque operateur.\n\nLa distinction entre variables d'etat et variables locales est centrale dans la programmation Solidity : les premieres persistent sur la blockchain entre les appels de fonction mais coutent du gas, tandis que les secondes sont gratuites mais temporaires. Les variables globales comme `msg.sender`, `msg.value` et `block.timestamp` sont les points d'ancrage entre le contexte d'execution d'une transaction et la logique du contrat. Les conversions de types (`uint256` vers `int256`, `address` vers `address payable`, `string` vers `bytes`) completent ce socle en permettant les manipulations necessaires a la logique metier.\n\nCe socle de types et de variables est le prerequisite direct pour le notebook suivant, [SC-4-Functions-State](SC-4-Functions-State.ipynb), qui approfondit les data locations (`storage`, `memory`, `calldata`), la visibilite des fonctions et les modificateurs (`view`, `pure`, `payable`), ainsi que les custom modifiers.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "dfa6951d",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -1528,6 +1528,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "84e665e3",
+   "source": "## Resume et perspectives\n\nCe notebook a etudie en profondeur les mecanismes qui gouvernent le comportement des fonctions et la gestion des donnees en Solidity. Les data locations (`storage`, `memory`, `calldata`) ne sont pas de simples indications d'optimisation : choisir `storage` pour une reference ou `memory` pour une copie determine si les modifications persistent sur la blockchain, et cette distinction est la source de bugs frequentes chez les developpeurs Solidity debutants. La demonstration du storage vs memory sur les structs a illustre ce piege concret.\n\nLa visibilite des fonctions (`public`, `external`, `internal`, `private`) et les modificateurs (`view`, `pure`, `payable`) definissent le contrat d'interface de chaque fonction. Le choix entre `external` et `public` a un impact mesurable sur la consommation de gas pour les parametres complexes, tandis que les custom modifiers comme `onlyOwner` et `whenNotPaused` permettent de factoriser des preconditions reutilisables a travers tout le contrat. La fonction `payable` et le pattern de transfert moderne `payable(addr).call{value: amount}(\"\")` completent l'arsenal pour les interactions financieres.\n\nCes competences sur les fonctions et l'etat constituent la base technique necessaire pour aborder l'heritage et les interfaces dans le notebook suivant, [SC-5-Inheritance](SC-5-Inheritance.ipynb), ou la composition de comportements via `is`, `virtual`/`override` et les contrats abstraits viendra enrichir l'architecture des smart contracts.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "46ddaf0c",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -1322,6 +1322,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7229b9e",
+   "source": "## Resume et perspectives\n\nCe notebook a explore les mecanismes d'heritage et d'abstraction en Solidity, depuis l'heritage simple avec `virtual`/`override` jusqu'a l'heritage multiple regie par la linearisation C3. L'implementation de l'interface IERC20 a illustre le role central des interfaces dans la standardisation Ethereum : un token comme USDT ou USDC n'est qu'un contrat qui implemente cette interface, permettant a n'importe quel protocol DeFi d'interagir avec lui sans connaitre son implementation. Les contrats abstraits, quant a eux, offrent un compromis entre interface pure et implementation complete, avec des methodes par defaut pouvant etre surchargees.\n\nL'heritage multiple et la linearisation C3 meritent une attention particuliere car ils determinent l'ordre d'appel de `super` dans les chaines d'heritage complexes. Ce mecanisme resout le probleme du diamant de maniere deterministe, mais peut surprendre si l'on ignore les regles de resolution. Le pattern Ownable + Pausable combine par heritage est omnipresent dans les contrats DeFi en production et constitue un modele architectural fondamental.\n\nAvec la maitrise des types (SC-3), des fonctions et de l'etat (SC-4), puis de l'heritage et des interfaces, le notebook suivant [SC-6-Errors-Events](SC-6-Errors-Events.ipynb) complete le socle fondamental en abordant la gestion des erreurs (`require`, `revert`, `assert`, custom errors) et les events pour le logging on-chain.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ee654e9",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -1220,6 +1220,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bc8debc6",
+   "source": "## Resume et perspectives\n\nCe notebook a couvert les mecanismes fondamentaux de gestion des erreurs et de logging dans Solidity. Les trois fonctions de validation (`require`, `revert`, `assert`) offrent un controle precis sur le flux d'execution et le remboursement du gas, tandis que les custom errors (Solidity 0.8.4+) apportent une alternative plus economique et structuree aux chaines de caracteres traditionnelles. Les events, quant a eux, constituent le canal de communication entre les contrats et le monde exterieur : ils permettent aux DApps de reagir en temps reel aux changements d'etat sans avoir a consulter le storage.\n\nLa maitrise combinee de ces trois piliers -- erreurs, custom errors et events -- est indispensable pour ecrire des contrats securises et observables. Le pattern `if (condition) revert CustomError(params)` remplace progressivement le `require(condition, \"string\")` classique dans les best practices Solidity, et la limitation a trois parametres indexes par event impose des choix strategiques selon les requetes de filtrage attendues. Le try/catch, bien que reserve aux appels externes, offre un filet de securite essentiel pour les interactions entre contrats.\n\nCes competences clotent le socle fondamental de Solidity (types, fonctions, heritage, erreurs). Le notebook suivant, [SC-7-Token-Standards](../02-Solidity-Advanced/SC-7-Token-Standards.ipynb), entre dans le domaine avance en explorant les standards ERC-20 et ERC-721 qui governent la grande majorite des tokens deployes sur Ethereum.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "bc7197a7",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -1352,6 +1352,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c4eb7dff",
+   "source": "## Resume et perspectives\n\nCe notebook a demystifie l'account abstraction et le standard ERC-4337, une evolution majeure du modele de compte Ethereum. Nous avons etudie la structure `UserOperation` qui remplace les transactions classiques, avec ses champs `sender`, `nonce`, `callData`, `signature` et `paymasterAndData`. Le `StandaloneSmartAccount` deploye sur anvil a illustre les fonctionnalites fondamentales : execution de transactions (`execute`), batch d'operations (`executeBatch`), changement de proprietaire (`changeOwner`) et compteur de nonce.\n\nLe concept de Paymaster a ete demontre avec un sponsor de gas qui depose des fonds et les alloue aux utilisateurs, simulant le mecanisme de transactions sans frais (gasless). L'exercice de Social Recovery a permis d'appliquer ces concepts a un cas pratique critique : la recuperation de compte via un systeme de gardiens avec un seuil de votes requis, eliminant la dependance aux seed phrases.\n\nLe notebook suivant, [SC-11-LLM-Assisted](SC-11-LLM-Assisted.ipynb), change de perspective en explorant comment les modeles de langage (Claude, GPT) peuvent assister le developpement de smart contracts, de la generation de code a l'audit de securite automatise.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "fa449d3c",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -1796,6 +1796,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2098cd41",
+   "source": "## Resume et perspectives\n\nCe notebook a explore l'integration des Large Language Models dans le workflow de developpement de smart contracts. Nous avons defini quatre templates de prompting specialises (generation de contrats, audit de securite, documentation NatSpec, explication pedagogique) et demontre leur utilisation via les API Anthropic Claude et OpenAI. L'audit assiste par LLM a ete illustre avec le cas classique de la reentrancy dans `VulnerableVault`, ou le pattern Checks-Effects-Interactions constitue la correction canonique.\n\nLe workflow complet (generation, audit, documentation) implemente dans la classe `SolidityLLMAssistant` montre comment automatiser le pipeline industriel. L'alternative locale avec Qwen via Ollama offre une option sans cout et confidentielle, bien que la qualite du code genere soit inferieure aux modeles cloud. La limitation fondamentale demeure : le code genere par LLM doit toujours etre audite manuellement, teste avec Foundry et verifie formellement avant tout deploiement en production.\n\nLe notebook suivant, [SC-12-Foundry-Testing](../03-Foundry-Testing/SC-12-Foundry-Testing.ipynb), introduit le framework Foundry pour ecrire des tests rigoureux en Solidite pur, etape indispensable pour valider tout code -- y compris celui genere par IA.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "b296cad0",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -1441,6 +1441,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f5a1c3d2",
+   "source": "## Resume et perspectives\n\nCe notebook a couvert les trois standards majeurs de tokens Ethereum, de l'implementation manuelle a l'utilisation de bibliotheques auditees. Le standard ERC-20 a ete implemente de zero avec le mecanisme d'allowance (`approve` + `transferFrom`), fondement des DEX et protocoles DeFi. Le standard ERC-721 a demontre la gestion de propriete unique avec les approbations individuelles (`approve`) et globales (`setApprovalForAll`). Le standard ERC-1155 a ete presente comme unification des deux approches, avec ses transferts batch et son efficacite en gas.\n\nL'utilisation des contrats OpenZeppelin (ERC20 + ERC20Burnable + Ownable, ERC721 + ERC721URIStorage) a illustre les bonnes pratiques de production : heritage multiple pour composer des fonctionnalites, securite auditee par la communaute, et personnalisation via des overrides Solidity. La difference entre implementation pedagogique (SimpleERC20, SimpleNFT) et implementation de production (MyToken, MyNFT) reside dans les garde-fous integres (access control, burn, URI storage).\n\nLe notebook suivant, [SC-8-DeFi-Primitives](SC-8-DeFi-Primitives.ipynb), utilise ces standards comme base pour construire des primitives de finance decentralisee : Automated Market Makers avec la formule x*y=k, et protocoles de lending avec collateralisation et health factor.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "9c9a4268",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -1288,6 +1288,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e59a2646",
+   "source": "## Resume et perspectives\n\nCe notebook a explore les primitives fondamentales de la finance decentralisee a travers deux piliers : les Automated Market Makers (AMM) et le lending. La formule de produit constant x*y=k a ete demontree a la fois en simulation Python et en implementation Solidity deployee sur anvil, avec la mise en evidence du mecanisme de fees (0.3%), du price impact non-lineaire et de la protection contre le slippage via le parametre `amountOutMin`. Le swap de 5 WETH pour 9496.59 USDC a illustre concretement l'ecart entre prix spot (2000) et prix d'execution (1899.32).\n\nLe protocole de lending simplifie a introduit les concepts de collateral, LTV (Loan-to-Value a 75%), seuil de liquidation (85%) et health factor. Le health factor de 1.70 obtenu dans la demonstration (10 000 DAI en collateral, 5 000 DAI empruntes) montre une position securisee avec une marge de 41% avant liquidation. Ces mecanismes sont les memes qui governent les protocoles de production comme Aave et Compound.\n\nLe notebook suivant, [SC-9-DAO-Governance](SC-9-DAO-Governance.ipynb), passe des primitives financieres a la gouvernance decentralisee, ou les detenteurs de tokens participent aux decisions du protocole via un systeme de propositions, de votes ponderes et de timelocks de securite.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ec768be",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -1064,6 +1064,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6e54a4c1",
+   "source": "## Resume et perspectives\n\nCe notebook a constitue une plongee complete dans la gouvernance decentralisee on-chain. Nous avons implemente un `GovernanceToken` avec checkpoints de votes et delegation, un mecanisme essentiel pour se proteger des attaques par flash loan (emprunter, voter, rembourser dans le meme bloc). Le `SimpleGovernor` a demontre le cycle de vie complet d'une proposition : creation (avec seuil de tokens requis), transition Pending vers Active apres le voting delay, vote pondere via `getPastVotes`, et resolution basee sur le quorum et la majorite.\n\nLe `SimpleTimelock` a complete l'architecture de gouvernance en ajoutant un delai obligatoire entre l'approbation d'une proposition et son execution. Ce mecanisme de 24 heures (minimum configurable) offre a la communaute une derniere chance de reagir face a une decision malveillante, que ce soit par un exit collectif, un fork ou une contre-proposition. Le hachage `keccak256(abi.encode(target, value, data, eta))` garantit l'unicite et l'integrite de chaque transaction en file d'attente.\n\nLe notebook suivant, [SC-10-Account-Abstraction](SC-10-Account-Abstraction.ipynb), aborde ERC-4337 et l'abstraction de compte, une evolution qui transforme les wallets en contrats intelligents programmables avec recuperation sociale, sponsoring de gas et logique personnalisee.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "414680bb",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -2478,6 +2478,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d774decb",
+   "source": "## Resume et perspectives\n\nCe notebook a couvert les fondamentaux du framework Foundry pour le test de smart contracts en Solidity. Nous avons commence par l'installation et la verification de l'environnement (forge, cast, anvil), puis explore la structure standard d'un projet Foundry avec ses repertoires `src/`, `test/`, `script/` et `lib/`. L'ecriture de tests en Solidite pur via le pattern DSTest a ete demontree a travers le contrat Counter, illustrant les assertions (`assertEq`, `assertTrue`, `assertGt`) et les fonctions de logging (`emit log_named_uint`).\n\nLes cheatcodes `vm` constituent l'apport le plus puissant de Foundry : `vm.prank` et `vm.startPrank` pour simuler des identites, `vm.deal` pour creer des ETH, `vm.warp` et `vm.roll` pour manipuler le temps blockchain, et `vm.expectRevert` pour tester les cas d'erreur. Ces outils permettent de tester des scenarios complexes (controle d'acces, verrouillage temporel, soldes) sans infrastructure lourde.\n\nLe notebook suivant, [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb), approfondit ces techniques en introduisant le fuzz testing -- la generation automatique d'inputs aleatoires pour decouvrir des bugs aux limites, et les tests d'invariants pour verifier que des proprietes fondamentales restent toujours vraies.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "c9ffaa3f",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
@@ -1006,6 +1006,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "71eb986a",
+   "source": "## Resume et perspectives\n\nCe notebook a permis de maitriser les techniques avancees de fuzz testing avec Foundry. Nous avons d'abord explore la generation d'inputs aleatoires pour decouvrir des edge cases invisibles dans les tests unitaires classiques, en appliquant les fonctions `testFuzz_*` sur des operations arithmetiques securisees (`safeAdd`, `safeMul`). Le filtrage d'inputs avec `vm.assume` a ete demontre comme un outil essentiel pour concentrer le fuzzing sur les domaines pertinents (exclusion de zero, bornes uint128, adresses EOA uniquement). Enfin, les tests d'invariants ont illustre comment verifier des proprietes structurelles comme la conservation du total supply d'un token ERC-20 ou la coherence des balances.\n\nLa configuration `foundry.toml` (parametres `runs`, `depth`, `seed`, `max_test_rejects`) offre un controle fin entre couverture et temps d'execution. En production, les contrats critiques sont generalement testes avec des milliers de runs et des seeds fixes pour garantir la reproductibilite des regressions detectees.\n\nLe notebook suivant, [SC-14-Formal-Verification](SC-14-Formal-Verification.ipynb), va au-dela du fuzz testing en introduisant la verification formelle des smart contracts, une approche mathematique qui prouve l'absence de vulnerabilites plutot que de tenter de les decouvrir empiriquement.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "edcb0a4d",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -1232,6 +1232,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17645a92",
+   "source": "## Resume et perspectives\n\nCe notebook a introduit la verification formelle des smart contracts, une approche qui complete les tests unitaires et le fuzz testing en apportant des preuves mathematiques exhaustives. Nous avons explore le langage CVL (Certora Verification Language) pour ecrire des invariants (conservation des tokens, non-negativite des soldes) et des regles de comportement sur un contrat Vault, puis decouvert SMTChecker, l'alternative native et gratuite integree au compilateur Solidity. La detection automatique d'une vulnerabilite de reentrancy par le model checker a illustre la puissance de l'approche : un contre-exemple concret est genere quand une assertion peut etre violee.\n\nLa verification formelle reste un investissement significatif en temps et en expertise, mais elle est indispensable pour les contrats critiques qui securisent des milliards de dollars en valeur verrouillee (DeFi, bridges, protocoles de gouvernance). Les outils evoluent rapidement : Certora Prover pour les specifications expressives en CVL, Halmos pour l'execution symbolique sur l'EVM, et SMTChecker pour les assertions natives sans dependance externe. La complementarite avec les tests classiques (foundry test, fuzz testing, invariant testing) definit une strategie de validation multicouche ou chaque methode couvre les angles morts des autres.\n\nLe prochain notebook aborde les preuves a divulgation nulle (Zero-Knowledge Proofs), une technique cryptographique fondamentale pour la confidentialite sur blockchain : prouver qu'un enonce est vrai sans reveler aucune information supplementaire. Ce concept, au coeur des zk-SNARKs et des zk-rollups, constitue l'un des domaines les plus actifs de la recherche blockchain actuelle : [SC-15-Zero-Knowledge-Proofs](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a915a288",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -1498,6 +1498,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cbeb8e83",
+   "source": "## Resume et perspectives\n\nCe notebook a constitue une plongee approfondie dans les preuves a divulgation nulle (Zero-Knowledge Proofs), des la fondation conceptuelle (analogie de la caverne d'Ali Baba) jusqu'aux architectures zk-SNARKs industrielles. Nous avons implemente le protocole de Schnorr en version interactive puis non-interactive (transformation de Fiat-Shamir), decouvert que cette derniere est exactement une signature numerique -- utilisee dans Bitcoin Taproot (BIP-340). Le protocole de Chaum-Pedersen a illustre la preuve d'egalite de logarithmes discrets, brique essentielle du vote electronique. Enfin, la decomposition d'un calcul arbitraire en circuit arithmetique puis en contraintes R1CS a demystifie le pipeline de construction des zk-SNARKs.\n\nLes ZKP representent un changement de paradigme en cryptographie : prouver sans reveler. Cette propriete trouve des applications majeures dans les zk-rollups (scalabilite L2 sur zkSync, StarkNet), les transactions privees (Zcash, Tornado Cash), et l'identite decentralisee. Le compromis entre taille de preuve et hypotheses de confiance (trusted setup pour Groth16, transparence pour zk-STARKs) guide le choix du systeme selon le contexte. Les implementations completes, reposant sur des pairings de courbes elliptiques (BN254, BLS12-381), depassent le cadre de ce notebook mais les concepts fondamentaux sont maintenant en place.\n\nLe prochain notebook explore le chiffrement homomorphique, une technique complementaire aux ZKP qui permet d'effectuer des calculs directement sur des donnees chiffrees, sans les dechiffrer : [SC-16-Homomorphic-Encryption](SC-16-Homomorphic-Encryption.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "bbe60389",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -1647,6 +1647,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "04322b88",
+   "source": "## Resume et perspectives\n\nCe notebook a explore le chiffrement homomorphique sous ses trois declinaisons : le schema de Paillier (PHE additif) pour les sommes et agregats, le schema CKKS avec TenSEAL (FHE approche) pour le machine learning confidentiel sur des reels, et le partage de secrets de Shamir (MPC) pour le calcul multipartite securise. L'implementation du schema de Paillier a demontre la propriete fondamentale `D(E(a) + E(b)) = a + b` et le chiffrement probabiliste garantissant la securite semantique. Le benchmark CKKS a revele un overhead de 1000 a 10 000 fois par rapport au calcul en clair, prix a payer pour la confidentialite des donnees.\n\nLa comparaison entre chiffrement homomorphique et calcul multipartite (MPC) met en evidence deux modeles de confiance distincts : un seul serveur non fiable pour le HE, plusieurs parties semi-honnetes pour le MPC. En pratique, les deux approches se completent plutot qu'elles ne s'opposent -- le HE pour les scenarios centralises (cloud, vote), le MPC pour les contextes decentralises (encheres, statistiques inter-entreprises). L'emergence de frameworks comme Concrete (Zama) rapproche le FHE du developpeur Python, meme si la performance reste le principal frein a l'adoption a grande echelle.\n\nLe prochain notebook applique directement ces techniques cryptographiques au probleme du vote electronique, en combinant chiffrement homomorphique de Paillier et preuves a divulgation nulle pour construire un systeme de vote verifiable de bout en bout : [SC-17-E2E-Verifiable-Voting](SC-17-E2E-Verifiable-Voting.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "449879d3",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
@@ -959,6 +959,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2606a925",
+   "source": "## Resume et perspectives\n\nCe notebook a montre comment construire un systeme de vote electronique verifiable de bout en bout en combinant le chiffrement homomorphique (Paillier) et les preuves a divulgation nulle. Nous avons chiffre les bulletins sous forme de vecteurs one-hot, effectue le decompte par addition homomorphique sans jamais dechiffrer les votes individuels, genere des preuves de validite des bulletins (somme = 1), et implemente un bulletin board publiquement verifiable. La comparaison avec ElectionGuard (Microsoft) a permis de mesurer l'ecart entre notre construction pedagogique et les systemes production-ready, notamment le chiffrement ElGamal exponentiel, les preuves Chaum-Pedersen non-interactives et le dechiffrement a seuil (k-of-n gardiens).\n\nLe paradoxe du vote electronique -- concilier anonymat et verifiabilite -- trouve sa resolution dans une architecture ou les bulletins sont chiffres (anonymat), le decompte est homomorphique (confidentialite des votes individuels), les preuves ZKP garantissent la validite (integrite), et le bulletin board public assure la transparence (verifiabilite universelle). Le dechiffrement a seuil elimine le point de defaillance unique : aucun gardien seul ne peut trahir le secret du vote. L'integration blockchain, en tant que bulletin board immutable, renforce encore cette garantie structurelle.\n\nLe prochain notebook change de domaine pour explorer les chaines alternatives a Ethereum, en commencant par Vyper, un langage de smart contracts a la syntaxe Python-like et a la philosophie securitaire : [SC-18-Vyper](../05-Alternative-Chains/SC-18-Vyper.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -1590,6 +1590,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "19b17708",
+   "source": "## Resume et perspectives\n\nCe notebook a explore Vyper, un langage de smart contracts dont la syntaxe Python-like et la philosophie minimaliste le distinguent de Solidity. Nous avons ecrit et compile des contrats (stockage, token ERC-20), deploi sur une blockchain locale via web3.py, et compare systematiquement les deux langages sur des exemples equivalents (compteur, controle d'acces, boucles). Les restrictions volontaires de Vyper -- pas d'heritage, pas de modifier, pas de boucles infinies, pas d'assembleur inline -- ne sont pas des limitations mais des garanties de securite qui facilitent l'audit formel.\n\nL'absence de modifier (remplace par des assertions explicites) et l'obligation de borner les boucles (DynArray[T, N]) illustrent un compromis fondamental : sacrifier la concision du code pour la previsibilite de l'execution. Cette approche est particulierement adaptee aux protocoles DeFi critiques comme Curve Finance ou Lido, ou la lisibilite du code et la certitude de terminaison primordent sur l'expressivite. Le bytecode compile identique a celui de Solidity rappelle que l'EVM est agnostique au langage source.\n\nLe prochain notebook quitte l'ecosysteme Ethereum pour decouvrir le protocole Ripple/XRP, une architecture blockchain concue pour les paiements transfrontaliers avec un consensus original (UNL) et des primitives financieres natives : [SC-19-Ripple-XRP](SC-19-Ripple-XRP.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "dbd11a0d",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -1730,6 +1730,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a14c98ef",
+   "source": "## Resume et perspectives\n\nCe notebook a permis de decouvrir l'ecosysteme Ripple/XRP, une blockchain concue pour les paiements transfrontaliers rapides et peu couteux. Nous avons explore le consensus UNL (3-5 secondes, finalite deterministe), manipule les comptes et transactions via `xrpl-py`, et compris les mecanismes natifs des trust lines (systeme de credit IOU), du DEX integre (carnet d'ordres on-chain avec auto-bridging) et des payment channels (micropaiements off-chain instantanes). Les Hooks, equivalents des smart contracts en C/WASM, completent l'architecture en ajoutant la programmabilite manquante.\n\nLa philosophie du XRPL contraste avec celle d'Ethereum : les primitives financieres sont **integrees au protocole** plutot qu'implementees dans des smart contracts. Ce choix architectural privilegie la performance (1500 TPS, frais negligeables) au depens de la flexibilite (impossible de creer de nouvelles primitives sans modifier le protocole). Les Hooks representent un compromis evolutif, permettant une logique programmable attachee aux comptes tout en conservant le modele deterministe du XRPL.\n\nLe prochain notebook explore le modele UTXO et le langage Script de Bitcoin, une approche encore plus minimaliste ou les smart contracts se limitent a des conditions de depense sur une pile, sans aucune machine virtuelle. Cette progression illustre le spectre complet entre computation expressive et verification deterministe : [SC-20-Bitcoin-Scripting](SC-20-Bitcoin-Scripting.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "135011b6",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -1776,6 +1776,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8f41d9e2",
+   "source": "## Resume et perspectives\n\nCe notebook a explore le modele UTXO de Bitcoin et son langage Script a pile, volontairement Turing-incomplet. Nous avons implemente un mini-interpreteur capable d'executer des scripts P2PKH, construit des transactions brutes en serialisant leurs champs binaires, et decouvert les mecanismes avances que sont le multisig (M-of-N), les timelocks (CLTV/CSV) et l'encapsulation P2SH. La comparaison avec Ethereum met en lumiere deux philosophies opposees : la **verification** deterministe et bornee de Bitcoin contre la **computation** expressive mais risque d'Ethereum.\n\nLes scripts Bitcoin, malgre leur simplicite apparente, couvrent la majorite des besoins en conditions de depense : signatures multiples, verrous temporels, et logique conditionnelle. L'arrivee de Taproot (BIP 340-342) en 2021 enrichit ce repertoire avec les signatures Schnorr et les arbres MAST, ouvrant la voie a des scripts plus flexibles tout en preservant la confidentialite. Les adaptations modernes comme les ordinals et les inscriptions montrent que la frontiere entre verification et computation continue d'evolver.\n\nLe parcours SmartContracts s'acheve ici. Depuis les fondements cypherpunk (SC-0) jusqu'au scripting Bitcoin, en passant par Solidity, le test avec Foundry, la verification formelle, la cryptographie avancee (ZKP, chiffrement homomorphique, vote verifiable), les chaines alternatives (Vyper, Ripple/XRP), vous disposez maintenant d'une vision panoramique des technologies de contrats intelligents et de leur ecosysteme. Le notebook final [SC-26-Final-Project](../06-Real-World/SC-26-Final-Project.ipynb) vous invite a consolider ces competences dans un projet integrateur.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "16b54910",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
@@ -977,6 +977,12 @@
     "\n",
     "> **Note technique** : Sur Sui, les objets avec `key` ability sont des \"objets owns\". Ils ont un proprietaire unique (adresse ou autre objet). Quand un objet est transfere, la propriete change instantanement.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c620b5d",
+   "source": "## Resume et perspectives\n\nCe notebook a introduit le langage Move et la blockchain Sui comme alternative au paradigme Ethereum/Solidity. Nous avons compare les modeles fondamentaux : la semantique de ressources lineaires de Move (ou chaque asset existe en un seul exemplaire et ne peut etre duplique) face aux etats globaux mutables de Solidity. Nous avons explore le systeme d'abilities (`key`, `store`, `copy`, `drop`) qui permet au compilateur de garantir la securite des ressources des la compilation, implemente un module de token natif avec le pattern One-Time Witness (OTW) pour l'enregistrement de currency, cree un NFT avec transfert et destruction via le modele objet de Sui, et applique ces concepts a un exercice d'escrow illustrant le verrouillage et la liberation de fonds.\n\nLe modele objet de Sui represente un changement de paradigme par rapport aux mappings Ethereum : chaque NFT, chaque token est un objet independant avec son propre UID et son proprietaire, eliminant le besoin d'index globaux et permettant le parallelisme natif des transactions. Les abilities Move offrent un controle granulaire sur le comportement des types : un token (`Coin`) ne peut pas etre copie (pas de double-spend garantit par le type system), un NFT peut etre detruit explicitement via destructuring pattern (`let NFT { id, name: _, ... } = nft`), et les capabilities comme `AdminCap` controlent les droits de mintage par transfert d'objet.\n\nLe notebook suivant, [SC-22-Solana-Anchor](SC-22-Solana-Anchor.ipynb), poursuit l'exploration des chaines alternatives avec Solana et le framework Anchor, en etudiant les Program Derived Addresses (PDAs) et les Cross-Program Invocations (CPIs).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -1193,6 +1193,12 @@
     "\n",
     "> **Note technique** : Sur Solana, les escrows sont des PDAs (pas de contrats intelligents avec etat). Le PDA signe les transferts via `new_with_signer`, ce qui est impossible sur EVM.\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "689f6d48",
+   "source": "## Resume et perspectives\n\nCe notebook a permis de decourir l'ecosysteme Solana et le framework Anchor comme alternative a l'ecosysteme Ethereum/Solidity. Nous avons compare les architectures : modele de comptes stateless et execution BPF haute performance (~65 000 TPS theoriques) chez Solana versus stockage dans le contrat et EVM chez Ethereum. Nous avons implemente un programme Counter en Rust avec Anchor, explorant les annotations `#[program]`, `#[account]` et `#[derive(Accounts)]` qui abstraient la complexite du modele de comptes. Nous avons etudie les PDAs (Program Derived Addresses) pour le stockage deterministe et securise de donnees utilisateur, les CPIs (Cross-Program Invocations) pour la composition de programmes, et implémente un escrow atomique de tokens SPL combinant `CpiContext::new` et `CpiContext::new_with_signer` pour les transfers signes par PDA.\n\nLa difference philosophique majeure entre Solana et Ethereum reside dans la separation stricte entre code (programmes stateless) et donnees (comptes independants). Ce modele enable le parallelisme natif des transactions et elimine la contention globale, mais exige une planification plus rigoureuse de la structure des comptes. Les PDAs remplacent les mappings Solidity par des adresses deterministes sans cle privee, offrant une securite inherente contre les acces non autorises. Le framework Anchor simplifie considerablement le developpement en Rust tout en preservant les garanties de securite du type system.\n\nLe notebook suivant, [SC-23-Cross-Chain](../06-Real-World/SC-23-Cross-Chain.ipynb), aborde l'interoperabilite entre blockchains et les protocols de communication cross-chain comme Chainlink CCIP.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -1174,6 +1174,12 @@
     "- Le nonce a deja ete utilise (revert)\n",
     "- Le montant depasse la limite quotidienne (rate limiting)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9366ef57",
+   "source": "## Resume et perspectives\n\nCe notebook a explore les defis et les solutions de l'interoperabilite entre blockchains. Nous avons etudie les problemes fondamentaux du cross-chain (finalite, securite, latence, cout, oracle), implemente des contrats Chainlink CCIP pour l'envoi et la reception de messages cross-chain avec transfert de tokens, examine les chain selectors et l'architecture de routage de Chainlink, et analyse les vulnerabilites specifiques aux systemes cross-chain (reentrancy cross-chain, double-spend, manipulation d'oracle, exploits de bridge, attaques de gouvernance).\n\nL'enjeu central de l'interoperabilite est le compromis entre securite et performance : les protocols bases sur des oracles (CCIP) offrent une securite elevee au prix d'une latence plus importante, tandis que les solutions ultra-legers (LayerZero) privilegient la rapidite avec un modele de confiance different. Les exploits historiques majeurs (Ronin Bridge 625M$, Wormhole 320M$, Harmony 100M$) rappellent que les bridges concentrent un risque systemique considerable et qu'une verification rigoureuse de la finalite, des rate limits et des mecanismes de pause d'urgence sont indispensables.\n\nLe notebook suivant, [SC-24-Testnet-Deploy](SC-24-Testnet-Deploy.ipynb), aborde le deploiement concret de contrats sur des reseaux de test publics (Sepolia, XRP Testnet) avant le passage en production.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
@@ -1265,6 +1265,12 @@
     "\n",
     "[Retour au sommaire](../README.md)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37cb5100",
+   "source": "## Resume et perspectives\n\nCe notebook a permis de franchir le cap entre le developpement local (anvil) et les reseaux publics de test. Nous avons configure une connexion Web3 a Sepolia via un provider RPC (Alchemy), prepare un wallet de test approvisionne via faucet, compile et deploys un contrat SimpleStorage sur un reseau public avec des transactions reelles (bien que la monnaie soit sans valeur), interagi avec le contrat deploye en lecture (gratuite) et en ecriture (cout en testnet ETH), et decouvert le testnet XRP Ledger avec `xrpl-py` pour des paiements cross-ledger.\n\nL'apprentissage central est la difference fondamentale entre les environnements de developpement : anvil offre un feedback instantane mais ne simule pas la latence reelle des blocs (~12s sur Sepolia), les testnets reproduisent fidelement les conditions mainnet (latence, gas, persistance) sans cout financier, et le mainnet impose une responsabilite totale ou chaque transaction coute de l'argent reel et est irreversible. La comparaison entre les temps de confirmation Ethereum (~12s) et XRP Ledger (~3-5s) illustre aussi les compromis de conception entre decentralisation et performance.\n\nLe notebook suivant, [SC-25-Mainnet-Deploy](SC-25-Mainnet-Deploy.ipynb), aborde le deploiement sur un Layer 2 mainnet (Base) avec du gas reel, l'estimation des couts et les considerations de securite pour la production.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
@@ -736,6 +736,12 @@
     "\n",
     "[Retour au sommaire](../README.md)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7aac3e34",
+   "source": "## Resume et perspectives\n\nCe notebook a couvert le passage critique du testnet vers le deploiement mainnet sur un Layer 2. Nous avons explore la configuration de Base (L2 de Coinbase), l'estimation des couts de deploiement en comparant le gas reel par rapport aux previsions, le processus de compilation et deploiement d'un contrat Solidity avec `web3.py` et `py-solc-x`, la verification de contrat sur BaseScan pour rendre le code source lisible par la communaute, et les considerations de securite essentielles avant tout deploiement en production (audit, testnet prealable, gestion des cles, proxy pattern pour l'evolutivite).\n\nL'avantage principal des L2 comme Base et Polygon est la reduction drastique des couts (de $5-50 sur Ethereum L1 a $0.01-0.50 sur L2) tout en heritant de la securite du layer 1 via les preuves d'optimistic rollups ou les preuves de validite (ZK rollups). Le processus de deploiement lui-meme est identique a celui du testnet : seul le chain_id et le RPC changent. Cependant, l'irreversibilite du deploiement mainnet impose une discipline stricte : tests complets sur testnet, estimation du gas avant signature, et verification systematique du code source sur l'explorateur de blocs.\n\nLe notebook suivant, [SC-26-Final-Project](SC-26-Final-Project.ipynb), propose un projet capstone integrant l'ensemble des concepts de la serie : smart contract de gouvernance, chiffrement homomorphique, preuves ZKP et deploiement complet.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -965,6 +965,12 @@
     "\n",
     "[Retour au sommaire](../README.md)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25574559",
+   "source": "## Resume et perspectives\n\nCe projet capstone a permis de consolider l'ensemble des competences developpees tout au long de la serie SmartContracts. En construisant un systeme de vote decentralise complet, nous avons articule cinq piliers fondamentaux : la programmation de smart contracts en Solidity avec une machine a etats robuste (Registration, Voting, Tallying, Ended), le chiffrement homomorphique Paillier pour garantir la confidentialite des bulletins tout en permettant un decompte verifiable, les preuves a divulgation nulle (ZKP) pour prouver la validite de chaque bulletin sans reveler son contenu, le deploiement progressif d'anvil vers les testnets publics, et la validation automatisee via les tests Foundry avec cheatcodes.\n\nL'integration de ces composants illustre un principe central de la securite blockchain : la separation entre privacy (protection du contenu individuel via chiffrement) et verifiability (preuve publique de correction via ZKP). Le modele de state machine du contrat, combine au typage fort du chiffrement homomorphique et aux commitment schemes, forme une architecture ou chaque couche apporte une garantie complementaire. Ce pattern de composition de primitives cryptographiques se retrouve dans les systemes de vote reels (comme les implementations basées sur MACI ou Semaphore) et dans les protocoles DeFi avances utilisant des preuves a divulgation nulle pour la conformite reglementaire.\n\nLes perspectives d'approfondissement incluent l'utilisation de zk-SNARKs (Groth16, PLONK) pour des preuves plus succinctes et verificables on-chain a cout reduit, l'implementation d'un mecanisme de seuil de dechiffrement (threshold decryption) pour eliminer le point de confiance unique de l'autorite de decompte, et le deploiement sur un L2 (Base, Arbitrum) pour beneficier de couts de transaction negligeables tout en heritant de la securite d'Ethereum.",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add "Resume et perspectives" conclusion cells to all 27 SmartContracts notebooks (SC-0 through SC-26).

## Content

Each conclusion contains:
- 2-3 paragraphs in French, specific to the notebook's content
- References the key concepts covered (Solidity, Foundry, DeFi, ZK proofs, HE, etc.)
- A transition sentence toward the next notebook in the series
- No emojis, no code cells modified

## Motivation

Dispatch ai-01 T1 URGENT: quality notebooks SemanticWeb + SmartContracts before lundi cours EPITA-IS #3 (J-2).

## Proof

- 27/27 notebooks verified with conclusion cell
- 0 code cells modified (markdown-only insertions)
- 0 C.1 violations
- 0 missing outputs

## Files changed

27 notebooks across 7 subdirectories (00-Foundations through 06-Real-World).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>