### PR TITLE
enrich(SemanticWeb): add pedagogical conclusions to 8 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
@@ -454,6 +454,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4dbb35c2",
+   "source": "## Resume et perspectives\n\nCe premier notebook a pose les fondations du Web semantique en couvrant trois aspects essentiels. D'une part, le contexte historique : la vision de Tim Berners-Lee d'un Web comprehensible par les machines, concrétisée par la pile technologique du W3C (URI, RDF, RDFS, SPARQL, OWL, SHACL). D'autre part, l'installation et la configuration de dotNetRDF, la bibliotheque C# qui nous accompagnera tout au long de la serie. Enfin, la creation de notre premier graphe RDF, illustrant le modele fondamental des triplets (sujet-predicat-objet) et les differents types de noeuds (URI, literal, literal avec langue).\n\nLes concepts maitrisés ici -- graphe, triplet, noeuds URI et literals, methode `Assert()` -- constituent le socle sur lequel s'appuient tous les notebooks suivants. La distinction entre `IUriNode` et `ILiteralNode` est particulierement importante car elle conditionne la maniere dont les donnees sont representees et interrogees.\n\nDans le notebook suivant (**SW-2-RDFBasics**), nous approfondirons ces bases avec les differents formats de serialisation (Turtle, N-Triples, RDF/XML, JSON-LD), les blank nodes, et la lecture de fichiers RDF existants.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
@@ -4439,6 +4439,18 @@
     "\n",
     "print(\"Exercice a completer : property paths transitifs sur l'ontologie\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conclusion-sw11",
+   "metadata": {},
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore la construction et l'exploration de Knowledge Graphs a partir de donnees structurees. Nous avons vu le pipeline complet : chargement CSV, definition d'un vocabulaire RDF, transformation en triplets, verification par SPARQL, puis serialisation dans plusieurs formats (Turtle, JSON-LD, N-Triples). La bibliotheque kglab offre une couche d'abstraction qui simplifie la creation et l'interrogation de Knowledge Graphs en encapsulant les operations rdflib courantes.\n",
+    "\n",
+    "La visualisation, qu'elle soit statique (matplotlib + NetworkX) ou interactive (pyvis), permet de comprendre la topologie du graphe et d'identifier des patterns structurels. Nous avons egalement introduit OWLReady2 pour la manipulation d'ontologies OWL et le raisonnement automatique via HermiT, ainsi que les dimensions de qualite (completude, coherence) essentielles pour valider un Knowledge Graph en production. Ces competences constituent le socle technique necessaire pour aborder les systemes de GraphRAG et le raisonnement avance sur donnees liees."
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-12-Python-GraphRAG.ipynb
@@ -366,7 +366,7 @@
    "id": "section3-text",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:35:50.229443",
      "exception": false,
      "start_time": "2026-05-26T09:35:50.229443",
@@ -883,7 +883,7 @@
    "id": "interpretation-build-kg",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:35:50.425250",
      "exception": false,
      "start_time": "2026-05-26T09:35:50.425250",
@@ -1974,7 +1974,7 @@
    "id": "interpretation-api-patterns",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:35:51.600503",
      "exception": false,
      "start_time": "2026-05-26T09:35:51.600503",
@@ -2094,7 +2094,7 @@
    "id": "exercise2-title",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:35:51.649614",
      "exception": false,
      "start_time": "2026-05-26T09:35:51.649614",
@@ -2625,6 +2625,12 @@
     "\n",
     "**Navigation** : [<< 12-KnowledgeGraphs](SW-12-KnowledgeGraphs.ipynb) | [Index](README.md)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "322e9483",
+   "source": "## Resume et perspectives\n\nCe notebook a presente le GraphRAG, une evolution majeure du RAG classique qui combine la puissance des LLMs avec la structure des graphes de connaissances. Le pipeline complet a ete couvert : extraction d'entites et relations depuis un texte brut (via LLM ou donnees de demonstration), construction d'un graphe RDF avec rdflib, extraction de sous-graphes pertinents par parcours BFS, et generation de reponses augmentees par le contexte structure du graphe.\n\nLes resultats ont montre l'avantage decisif du GraphRAG sur les questions multi-hop : alors que le RAG classique cherche des chunks de texte par similarite, le GraphRAG traverse les relations du graphe pour reconstituer un contexte complet et factuel. La detection de communautes (algorithme de modularite, inspire de Leiden utilise par Microsoft GraphRAG) a illustre comment les entites se regroupent naturellement en clusters semantiques, permettant des requetes thematiques a differents niveaux de granularite.\n\nLa gestion robuste des cles API (detection automatique, fallback vers les donnees de demonstration, verification au demarrage) garantit que le notebook fonctionne dans tous les environnements, avec ou sans acces a un LLM. Ce pattern est transposable a tout notebook utilisant des services externes.\n\nDans le notebook suivant (**SW-13-Python-Reasoners**), nous comparerons les raisonneurs OWL (owlrl, HermiT, reasonable, Growl) pour comprendre les compromis entre expressivite, performance et facilite d'integration.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -2664,6 +2664,12 @@
     "\n",
     "**Navigation** : [<< 13-GraphRAG](SW-13-GraphRAG.ipynb) | [Index](README.md)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69c7dbc6",
+   "source": "## Resume et perspectives\n\nCe notebook a compare quatre raisonneurs OWL couvrant un spectre allant de l'implementation Python pure au code compile en Rust et en C, avec des profils OWL allant de RL (polynomial) a DL (NExpTime-complet). Les benchmarks sur l'ontologie pizza ont revele des ecarts de performance considerables : reasonable (Rust) est environ 20 fois plus rapide qu'owlrl (Python), tandis qu'HermiT (Java, OWL 2 DL complet) offre une expressivite superieure au prix d'un temps d'execution plus eleve.\n\nLa difference majeure entre les profils OWL 2 RL et OWL 2 DL a ete illustree par les exercices : le profil RL (owlrl, reasonable) materialise efficacement les hierarchies de classes, les proprietes transitives et les inferences de base, mais ne supporte pas la classification automatique par restrictions `someValuesFrom`. Le profil DL (HermiT) detecte les incoherences ontologiques et classifie les instances selon des regles complexes, ce qui est indispensable dans les domaines critiques (medecine, industrie). Le choix du raisonneur depend donc du compromis entre expressivite requise et performances acceptables.\n\nCe notebook conclut la serie Semantic Web. Au fil des 14 notebooks, vous avez parcouru l'ensemble de la pile technologique : les triplets RDF (SW-1 a SW-3), les requetes SPARQL (SW-4 a SW-5), les schemas et ontologies RDFS/OWL (SW-6 a SW-7), la validation SHACL (SW-8), les formats modernes JSON-LD et RDF-Star (SW-9 a SW-10), les graphes de connaissances (SW-11), l'integration avec les LLMs via GraphRAG (SW-12), et enfin les moteurs d'inference (SW-13 et SW-14).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -1113,6 +1113,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "50b0ec9a",
+   "source": "## Resume et perspectives\n\nCe sidetrack Python a permis de decouvrir **rdflib**, l'equivalent Python de dotNetRDF, et de mettre en parallele les deux ecosystemes. Nous avons explore la creation de graphes RDF avec l'API pythonique de rdflib (`g.add((s, p, o))`), les trois types de noeuds fondamentaux (URIRef, BNode, Literal avec datatype et langue), et la serialisation dans les formats standards (Turtle, N-Triples, JSON-LD). Le tableau de correspondance detaille entre dotNetRDF et rdflib constitue une reference utile pour passer d'un ecosysteme a l'autre.\n\nL'exemple guide 3 a montre la construction d'un graphe complet representant une equipe de recherche, combinant URI, blank nodes et litteraux types, puis interrogeant le resultat en SPARQL. Cette approche progressive illustre bien la philosophie de rdflib : des tuples Python simples pour manipuler des donnees RDF, avec un acces direct aux namespaces W3C preconfigures.\n\nDans le notebook suivant (**SW-3-CSharp-GraphOperations**), nous retournerons a dotNetRDF pour explorer les operations avancees sur les graphes (fusion, requetes LINQ, listes RDF), tandis que le sidetrack **SW-4b-Python-SPARQL** permettra de mettre en pratique les requetes SPARQL avec rdflib.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "90d513e0",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
@@ -279,7 +279,7 @@
    "id": "sparql-select-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:01:12.093979",
      "exception": false,
      "start_time": "2026-05-26T09:01:12.093979",
@@ -882,7 +882,7 @@
    "id": "comparison-table",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:01:12.394078",
      "exception": false,
      "start_time": "2026-05-26T09:01:12.394078",
@@ -1144,6 +1144,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f68cef6f",
+   "source": "## Resume et perspectives\n\nCe sidetrack a couvert les principales fonctionnalites du langage SPARQL appliquees a rdflib : les requetes SELECT pour projeter des variables, FILTER pour le filtrage conditionnel, OPTIONAL pour les jointures externes respectant le principe du monde ouvert, UNION pour combiner plusieurs patterns, et LIMIT/OFFSET pour la pagination. L'exemple guide de synthese a egalement introduit CONSTRUCT pour generer de nouveaux graphes RDF et les agregations GROUP BY/COUNT.\n\nLa comparaison systematique entre dotNetRDF et rdflib a montre que la syntaxe SPARQL est identique dans les deux bibliotheques -- seuls different les wrappers d'execution (`g.query()` en Python, `g.ExecuteQuery()` en C#). Les exercices proposent d'explorer des fonctionnalites avancees : requetes ASK (booleennes), BIND/CONCAT pour la construction de chaines, les chemins de propriete transitifs (`rdfs:subClassOf+`), et les agregations avec HAVING.\n\nDans le notebook suivant (**SW-5-CSharp-LinkedData**), nous decouvrirons les donnees liees en interrogeant des endpoints publics comme DBpedia et Wikidata, puis le sidetrack **SW-5b-Python-LinkedData** presentera l'equivalent Python avec SPARQLWrapper.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "e797dcac",
    "metadata": {
     "papermill": {
@@ -1267,7 +1273,7 @@
    "id": "dc7cbffb",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:01:12.546445",
      "exception": false,
      "start_time": "2026-05-26T09:01:12.546445",

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -1315,6 +1315,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5045fbe7",
+   "source": "## Resume et perspectives\n\nCe sidetrack a presente la manipulation d'ontologies OWL en Python avec OWLReady2, en mettant en lumiere la difference de philosophie avec dotNetRDF. Alors que dotNetRDF travaille au niveau des triples (bas niveau), OWLReady2 offre une API orientee classes (haut niveau) ou les ontologies sont definies comme des classes Python heritant de `Thing`, les proprietes comme des sous-classes d'`ObjectProperty` ou `DataProperty`, et les restrictions OWL s'expriment naturellement (`manages.some(Department)` pour `someValuesFrom`).\n\nLe point fort d'OWLReady2 est l'integration du raisonneur **HermiT** (OWL 2 DL complet), qui permet de deduire automatiquement de nouvelles connaissances. Les exemples guides ont illustre cette puissance : classification automatique d'individus en `Employee` ou `Manager` selon leurs proprietes, classification en `Parent`/`Child` via les restrictions `equivalent_to`, et meme la categorisation de films en `ActionMovie` selon leur genre. L'exemple de synthese sur les ecosystemes a combine hierarchie de classes, restrictions et raisonnement pour classifier le renard et le loup comme carnivores.\n\nDans le notebook suivant (**SW-8-Python-SHACL**), nous aborderons la validation de donnees avec pySHACL, puis **SW-9-Python-JSONLD** presentera le format JSON-LD pour l'integration web, avant le notebook **SW-11-Python-KnowledgeGraphs** qui combine ces technologies pour construire des graphes de connaissances.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "3b081608",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
@@ -974,7 +974,7 @@
    "id": "section4-title",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-26T09:19:53.359411",
      "exception": false,
      "start_time": "2026-05-26T09:19:53.359411",
@@ -3971,6 +3971,12 @@
     "\n",
     "**Navigation** : [<< 8-Python-SHACL](SW-8-Python-SHACL.ipynb) | [Index](README.md) | [10-Python-RDFStar >>](SW-10-Python-RDFStar.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ad12fbb",
+   "source": "## Resume et perspectives\n\nCe notebook a explore JSON-LD comme pont entre l'ecosysteme JSON du Web et le Linked Data du Web semantique. Nous avons couvert la syntaxe fondamentale (`@context`, `@id`, `@type`, `@graph`), les trois formes de representation (compacte, etendue, aplatie), et le vocabulaire Schema.org avec ses 800+ types utilises par Google, Microsoft et Yahoo pour les donnees structurees. Les cas d'usage pratiques (Recipe, Event, FAQPage, BreadcrumbList) ont illustre comment JSON-LD alimente les rich snippets dans les resultats de recherche.\n\nL'aller-retour JSON-LD vers Turtle vers JSON-LD a demontre la fidelite des conversions via rdflib : les 11 triples sont conserves intact a travers le cycle complet. La comparaison des formats RDF a montre que JSON-LD excelle dans l'integration web et l'interaction avec les developpeurs, tandis que Turtle reste le format de reference pour l'edition humaine et les ontologies. La serialisation programmatique avec contexte compact a revele la puissance de rdflib pour generer du JSON-LD lisible directement depuis un graphe RDF.\n\nDans le notebook suivant (**SW-10-Python-RDFStar**), nous decouvrirons RDF 1.2 (RDF-Star), une extension majeure de RDF permettant de faire des assertions sur des assertions (quoted triples), ouvrant la voie a des metadonnees sur les relations elles-memes.",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add "Resume et perspectives" conclusion cells to 8 SemanticWeb notebooks that were missing them.

## Notebooks enriched

| Notebook | Content focus |
|----------|--------------|
| SW-1-CSharp-Setup | dotNetRDF setup, C# environment |
| SW-2b-Python-RDFBasics | Python RDF basics with rdflib |
| SW-4b-Python-SPARQL | SPARQL queries with rdflib |
| SW-7b-Python-OWL | OWL ontology manipulation |
| SW-9-Python-JSONLD | JSON-LD format, context, framing |
| SW-11-Python-KnowledgeGraphs | KG construction, kglab, visualization |
| SW-12-Python-GraphRAG | Graph-based RAG |
| SW-13-Python-Reasoners | Reasoning engines, inference |

## Proof
- 8/8 notebooks verified with conclusion cell
- 0 code cells modified (markdown-only insertions)
- 0 C.1 violations, 0 missing outputs

## Motivation
Dispatch ai-01 T1 URGENT: quality notebooks SemanticWeb + SmartContracts before lundi cours EPITA-IS #3 (J-2).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>