### PR TITLE
fix(lean): clean stale sorry comments from Conway Angel and DoomsdayLemmas

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Angel.lean
@@ -17,7 +17,7 @@ Angel's move-set (a Chebyshev ball), where the power-1 Angel is exactly a chess
 king. Homage to a MathOverflow contribution on Conway's pursuit-evasion results
 (post 357433).
 
-The `sorry`s are intentional calibration scaffolding, not regressions (Epic #1453).
+All `sorry`s have been eliminated (Epic #1453, #1651).
 -/
 
 import Mathlib.Data.Int.Interval

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/DoomsdayLemmas.lean
@@ -14,7 +14,7 @@ a HARNESS CALIBRATION ladder for the prover co-evolution Epic (#1453):
         : NOT closed (free `d`); a naive `decide` fails because `d` is a variable.
           The Director must DECOMPOSE: `cases d <;> rfl`.                    (medium)
 
-The `sorry`s are intentional scaffolding, not regressions (Epic #1453).
+All `sorry`s have been eliminated (Epic #1453, #1651).
 -/
 
 import Conway.Doomsday


### PR DESCRIPTION
## Summary

Clean stale `sorry scaffolding` comments from Angel.lean and DoomsdayLemmas.lean.

Both files have **0 production sorry** — all proofs are complete (native_decide). The comments claiming "intentional scaffolding" were stale leftovers from the calibration phase (Epic #1453).

## Changes

- `Conway/Angel.lean` L20: "The sorrys are intentional scaffolding" → "All sorrys have been eliminated"
- `Conway/DoomsdayLemmas.lean` L17: same update

## Verification

```
grep -c sorry Angel.lean        # 1 (in comment only)
grep -c sorry DoomsdayLemmas.lean  # 1 (in comment only)
```

No code changes. Comment-only. No Lake build needed.

## Conway sorry status (verified)

| File | Production sorry |
|------|-----------------|
| Angel.lean | 0 |
| DoomsdayLemmas.lean | 0 |
| Doomsday.lean | 0 |
| Fractran.lean | 0 |
| Life.lean | 0 |
| LookAndSay.lean | 0 |
| LookAndSayLemmas.lean | 0 |
| Nim.lean | 0 |
| KochenSpecker.lean | 2 (blocked by whnf Fin 18 timeout #1704) |