### PR TITLE
enrich(Sudoku): add pedagogical conclusions to 10 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-0-Environment-Csharp.ipynb
@@ -919,6 +919,12 @@
     "\n",
     "Console.WriteLine(\"Exercice a completer\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "803f6c70",
+   "source": "## Resume et perspectives\n\nCe notebook a pose les fondations de toute la serie Sudoku en definissant trois composants essentiels. La classe `SudokuGrid` encapsule la representation d'une grille 9x9 avec le pre-calcul des voisins (`AllNeighbours`, `CellNeighbours`), ce qui evite les recalculs couteux lors de la resolution. L'interface `ISudokuSolver` implante le pattern Strategie, permettant de permuter les algorithmes de resolution sans modifier le code client. Enfin, la classe `SudokuHelper` fournit une infrastructure de benchmark complete avec chargement de puzzles, mesures de performance et visualisation Plotly.NET.\n\nL'infrastructure de test (`TestSolvers`, `DisplayResults`) permet de comparer objectivement les solveurs sur trois niveaux de difficulte (Easy, Medium, Hard) avec gestion des timeouts et des disqualifications. Ce cadre de benchmark sera utilise dans tous les notebooks suivants pour mesurer les performances de chaque algorithme.\n\nLe notebook suivant, [Sudoku-1-Backtracking](Sudoku-1-Backtracking-Csharp.ipynb), utilise ces classes pour implementer le premier algorithme de resolution : le backtracking recursif avec ses heuristiques d'amelioration.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -1634,6 +1634,12 @@
     "nb_col2 = count_first_col_placements(grid_col2)\n",
     "print(f\"Nombre de placements valides (puzzle difficile): {nb_col2}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7eb54fb5",
+   "source": "## Resume et perspectives\n\nCe notebook a explore l'algorithme de backtracking pour la resolution de Sudoku, depuis l'implementation recursive naive jusqu'a l'optimisation par l'heuristique MRV (Minimum Remaining Values). Les benchmarks ont montre une difference spectaculaire : le backtracking simple peut necessiter jusqu'a 335 000 appels recursifs sur les puzzles difficiles, tandis que MRV reduit ce nombre a quelques dizaines ou centaines, avec des speedup allant jusqu'a 2 600x. La visualisation matplotlib a permis de distinguer clairement les valeurs initiales des valeurs deduites par le solveur.\n\nL'heuristique MRV illustre le principe \"fail-first\" fondamental en recherche : en traitant d'abord les variables les plus contraintes, on detecte les impasses plus tot et on elague massivement l'arbre de recherche. Cette lecon s'applique au-dela du Sudoku a tous les problemes de satisfaction de contraintes. Les exercices proposes (comptage de solutions, placements valides sur une colonne) approfondissent la maitrise du backtracking et de ses variantes.\n\nLe notebook suivant, [Sudoku-2-DancingLinks-Python](Sudoku-2-DancingLinks-Python.ipynb), aborde une approche radicalement differente : la reformulation du Sudoku comme probleme de couverture exacte, resolue par l'algorithme X de Knuth et la technique des Dancing Links (DLX).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -865,6 +865,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## Resume et perspectives\n\nCe notebook a explore la resolution de Sudoku par **programmation par contraintes** avec Choco-solver, une librairie Java mature appelee depuis C# via le bridge IKVM. L'implementation a couvert deux niveaux de sophistication : un solveur simple (`ChocoSimpleSolver`) posant directement les 27 contraintes `allDifferent` (9 lignes, 9 colonnes, 9 blocs), puis un solveur optimise (`ChocoSolverVariableSelector`) integrant des heuristiques de recherche avancees comme **FirstFail** (equivalent MRV, choisissant la variable au plus petit domaine) et le **noGood recording** pour eviter de revisiter des branches deja ecartees. L'exercice guide sur les N-Reines a permis de transposer le modele CSP vers un autre probleme classique, en exploitant les memes primitives Choco (`allDifferent`, `arithm`, comptage de solutions).\n\nLa comparaison theorique avec OR-Tools, Z3 et python-constraint montre que Choco se situe dans une niche intermediaire : moins performant qu'OR-Tools CP-SAT sur les instances difficiles, mais offrant un acces natif a des contraintes globales optimisees et des strategies de recherche fines (DomOverWDeg, Impact-based search). La limitation technique rencontree avec IKVM dans dotnet-interactive illustre les defis d'interoperabilite Java/.NET en environnement notebook, et confirme l'interet de approaches natives comme OR-Tools pour un usage pedagogique fluide.\n\nLe prochain notebook, **Sudoku-12-Z3-Csharp**, aborde une approche complementaire avec le solveur SMT Z3, qui represente le Sudoku non pas comme un CSP mais comme un systeme de contraintes logiques, offrant des garanties de completude et des techniques de raisonnement differentes (theorie des tableaux, resolution SAT).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 5. Resume\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -1424,6 +1424,12 @@
     "// Console.WriteLine($\"Attendu pour 8-Reines : 92\");\n",
     "Console.WriteLine(\"TODO: Implementez NQueensDLX.CountSolutions()\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf1418a8",
+   "source": "## Resume et perspectives\n\nCe notebook a presente deux implementations de l'algorithme Dancing Links (DLX) pour la resolution de Sudoku par couverture exacte. L'approche reformule le Sudoku comme une matrice de 729 lignes (une par couple cellule-valeur) et 324 colonnes (contraintes de cellule, ligne, colonne et bloc), qu'il s'agit de couvrir exactement. La bibliotheque DlxLib offre une solution concise et maintenable, tandis que l'implementation personnalisee `DlxCustomized` demontrre la maitrise complete de la structure de listes doublement chainees circulaires avec les operations `cover` et `uncover` en O(1).\n\nLes benchmarks ont revele un contraste surprenant : l'implementation personnalisee est environ 40 a 80 fois plus rapide que DlxLib sur tous les niveaux de difficulte (3-5 ms contre 150-290 ms). Cette difference s'explique par l'optimisation de la selection de colonne minimum et l'absence d'abstraction superflue. L'exercice sur les N-Reines illustre la generalite de l'approche : tout probleme de couverture exacte peut etre resolu par DLX, des pentominos au Picross.\n\nLe notebook [Search-App-11-Picross](../Search/Applications/App-11-Picross.ipynb) approfondit l'application de Dancing Links au probleme du Picross, un autre cas d'usage spectaculaire de la couverture exacte.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -2282,6 +2282,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "efec4e39",
+   "source": "## Resume et perspectives\n\nCe notebook a transpose le Particle Swarm Optimization (PSO) en C# pour la resolution de Sudoku, en reprenant l'encodage par blocs et l'architecture Workers/Explorers. Le solveur `PSOSudokuSolver` a demontre une resolution rapide sur les puzzles faciles (61 ms avec 200 organismes), mais aussi une grande variabilite selon l'initialisation : le benchmark sur 5 puzzles a revele des temps allant de 7 ms a 30 secondes, avec un echec sur un puzzle malgre 10 tentatives. La comparaison des configurations (Conservatif, Standard, Agressif) a confirme que l'essentiel de la performance depend de la chance de l'initialisation aleatoire.\n\nLe mecanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait ameliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.\n\nLe notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des metaheuristiques probabilistes aux methodes deterministes de resolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "af77878b",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -1757,6 +1757,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c6f15b91",
+   "source": "## Resume et perspectives\n\nCe notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double role (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : de 1 seconde pour les puzzles chanceux a plus de 30 secondes pour les cas defavorables, avec un taux de succes de 80% sur les puzzles faciles. La stagnation frequente a erreur=2 illustre la difficulte des metaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.\n\nL'analyse des parametres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration \"Conservatrice\" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration \"Agressive\" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise precisement a resoudre le probleme de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.\n\nLe notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche deterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "execution_count": null,
    "id": "66458d28",
    "metadata": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1699,6 +1699,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "339cfefc",
+   "source": "## Resume et perspectives\n\nCe notebook a transpose en C# le cadre academique AIMA pour la resolution de Sudoku par programmation par contraintes. La classe generique `CSP<TVariable, TValue>` a permis d'implementer quatre algorithmes de complexite croissante : le backtracking simple (145 millions d'assignations), le backtracking ameliore MRV+LCV (527 assignations), le Forward Checking (97 assignations) et le MAC (86 assignations, 5 backtracks). Le benchmark sur 5 puzzles faciles a confirme que MAC est le plus robuste avec un minimum de retours en arriere, tandis que Forward Checking est le plus rapide sur les instances faciles grace a son overhead reduit.\n\nL'implementation des heuristiques MRV (selection de la variable la plus contrainte) et LCV (ordonnancement des valeurs les moins contraignantes) a illustre les principes \"fail-first\" et \"succeed-first\" fondamentaux en recherche combinatoire. L'exercice CBJ (Conflict-Based Backjumping) complete cette etude en proposant d'implementer un mecanisme de remontee directe vers la variable responsable d'un conflit, evitant ainsi les retours en arriere chronologiques inutiles.\n\nLe notebook suivant, [Sudoku-7-Norvig](Sudoku-7-Norvig.ipynb), presente l'approche de Peter Norvig qui combine propagation de contraintes (naked singles, hidden singles) et recherche pour une resolution elegante et performante.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "b265202c",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -1843,6 +1843,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "888465da",
+   "source": "## Resume et perspectives\n\nCe notebook a formalise le Sudoku comme un probleme de satisfaction de contraintes (CSP) binaire selon le cadre academique AIMA (Russell & Norvig, Chapitre 6), avec 81 variables, des domaines a 9 valeurs et 27 contraintes AllDifferent decomposees en paires. Quatre algorithmes de resolution ont ete implementes et compares : le backtracking simple (2,9 millions d'assignations), le backtracking ameliore avec MRV et LCV (255 assignations), le Forward Checking (81 assignations) et le MAC (81 assignations, 0 backtrack). L'ecart de quatre ordres de grandeur entre le backtracking naif et les methodes avec propagation illustre l'importance cruciale de la reduction des domaines.\n\nL'etude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que theoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces competences vers un autre CSP classique avec des topologies variees.\n\nLe notebook suivant, [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb), explore les strategies de resolution humaines (naked singles, hidden singles) qui s'inspirent des techniques de propagation avancees etudiees ici.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "ebb356b0",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -2333,6 +2333,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7f7e6a12",
+   "source": "## Resume et perspectives\n\nCe notebook a explore la resolution de Sudoku par **deduction logique progressive**, en implementant les techniques utilisees par les experts humains : **Naked Singles** et **Hidden Singles** pour les puzzles faciles, **Naked Pairs** et **Pointing Pairs** pour le niveau intermediaire, et **X-Wing** pour les grilles avancees. Les techniques supplementaires (Hidden Pairs, Swordfish, XY-Wing) ont ete presentees en exemples guides pour illustrer les strategies expert. Le benchmark sur 5 puzzles faciles a montre que les Hidden Singles dominent avec 149 applications (60% des deductions), suivis des Naked Singles (91 occurrences), tandis que les techniques avancees comme X-Wing ne representent que 2% des cas -- confirmant que la majorite des puzzles courants se resolvent par inference directe sans recours au backtracking.\n\nLa comparaison avec le backtracking simple a mis en evidence un avantage qualificatif majeur : les strategies humaines produisent une **chaine de deductions explicable**, ou chaque placement est justifie par une technique logique identifiable, tandis que le backtracking procede par essai-erreur opaque. En termes de performance, le solveur humain est 2 a 5 fois plus rapide sur les puzzles faciles et ne necessite aucun appel recursif, la ou le backtracking accumule 49 a 295 appels. Le mecanisme de fallback vers le backtracking garantit toutefois la completude du solveur sur les instances ou les techniques de deduction atteignent leurs limites.\n\nLe prochain notebook, **Sudoku-9-GraphColoring-Python**, change de paradigme en modelisant le Sudoku comme un probleme de **coloration de graphe** avec NetworkX, ou les 81 cellules deviennent des sommets et les contraintes d'exclusion des aretes, permettant de comparer des heuristiques de coloration (MRV, LCV, Welsh-Powell) sur cette structure reguliere.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "b1e81497",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -1084,6 +1084,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "94f0165b",
+   "source": "## Resume et perspectives\n\nCe notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n\nLes benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n\nLe prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "022b15c7",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Add "Resume et perspectives" conclusion cells to 10 Sudoku notebooks missing them.

## Notebooks enriched

| Notebook | Content focus |
|----------|--------------|
| Sudoku-0-Environment-Csharp | C# environment setup |
| Sudoku-1-Backtracking-Python | Backtracking algorithm |
| Sudoku-2-DancingLinks-Csharp | Knuth's Algorithm X / Dancing Links |
| Sudoku-5-PSO-Python | Particle Swarm Optimization |
| Sudoku-5-PSO-Csharp | PSO in C# |
| Sudoku-6-AIMA-CSP-Python | CSP solving with AIMA |
| Sudoku-6-AIMA-CSP-Csharp | CSP solving in C# |
| Sudoku-8-HumanStrategies-Python | Human-like strategies (naked/hidden singles) |
| Sudoku-9-GraphColoring-Python | Graph coloring approach |
| Sudoku-11-Choco-Csharp | Choco constraint solver |

## Proof
- 10/10 verified with conclusion cell
- 0 code cells modified (markdown-only)
- Sudoku series: 32/32 now have conclusions

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>