### PR TITLE
enrich(GameTheory): add pedagogical conclusions to 15 non-Lean notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
@@ -1966,6 +1966,12 @@
     "\n",
     "**Notebook 11 : Jeux Bayesiens** - Information incomplete, types, croyances, et equilibre bayesien de Nash."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfa25ede",
+   "source": "## Resume et perspectives\n\nCe notebook a constitue une etude approfondie des raffinements d'equilibre pour les jeux sous forme extensive, en progressant dans une hierarchie de pouvoir discriminant croissant. L'equilibre parfait de sous-jeux (SPE) a elimine les menaces non credibles en exigeant un Nash dans chaque sous-jeu, comme l'a illustre le jeu d'entree ou la menace de combat n'est pas soutenable. La perfection en mains tremblantes a renforce cette selection en eliminant les equilibres reposant sur des strategies faiblement dominees, ne conservant que les profils robustes aux petites erreurs. L'induction avant a introduit un raisonnement d'une nature differente : plutot que de partir de la fin du jeu, elle exploite les actions observees en debut de partie pour inferer les intentions des joueurs, selectionnant ainsi l'equilibre efficient dans la Chasse au Cerf avec option exterieure.\n\nLe jeu du \"Burn Money\" a synthetise ces concepts de maniere frappante : la simple possibilite de bruler de l'argent modifie l'equilibre meme si personne ne brule effectivement, un phenomene qui rappelle que les options non utilisees peuvent etre aussi informatives que les actions realisees. La hierarchie des raffinements -- Nash, SPE, trembling-hand, forward induction -- forme un outil d'analyse progressif dont le choix depend du contexte et de la richesse informationnelle du jeu etudie.\n\nL'etape suivante introduit les jeux bayesiens et l'information incomplete, ou les joueurs ne connaissent pas les types de leurs adversaires : [GameTheory-11-BayesianGames](GameTheory-11-BayesianGames.ipynb).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -2159,6 +2159,12 @@
     "\n",
     "**Notebook 12 : Jeux de Reputation** - Construction de reputation, cheap talk, et modele de Kreps-Wilson."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e736c2e",
+   "source": "## Resume et perspectives\n\nCe notebook a parcouru les fondements de la theorie des jeux a information incomplete, de la transformation de Harsanyi aux equilibres bayesiens de Nash en passant par les mecanismes d'encheres et de signaling. La Bataille des Sexes avec incertitude a illustre comment l'information incomplete genere trois types d'equilibres (pooling, separateur et hybride), ou le type minoritaire (J2 \"Football\" avec p=0.3) subit systematiquement un gain nul. Le duopole de Cournot bayesien a montre que l'incertitude sur les couts cree une heterogeneite strategique : la firme a cout bas produit davantage qu'en information complete (31.67 vs 30.0), anticipant un adversaire potentiellement moins efficace. Les encheres ont permis de verifier empiriquement le theoreme d'equivalence du revenu : premier prix et second prix generent le meme revenu esperer pour le vendeur, confirme par simulation sur 10000 enchères avec des ecarts inferieurs a 1%.\n\nLe modele de signaling de Spence a introduit le paradoxe de l'education comme signal couteux : dans l'equilibre separateur, les travailleurs hautement productifs s'eduquent non pas pour ameliorer leur productivite, mais pour se distinguer des types bas, avec un gain net identique a celui de l'equilibre pooling (1.5 dans les deux cas). Ce resultat souligne le role de l'asymetrie des couts de signal comme moteur de la revelation d'information, un principe qui s'etend aux garanties produit, aux certifications professionnelles et aux politiques de dividende en finance.\n\nLes concepts d'equilibre bayesien de Nash, de theoreme d'equivalence du revenu et de signaling constitueront les briques fondamentales du notebook suivant, consacre aux jeux de reputation. La ou ce notebook traitait de l'information incomplete statique (les types sont fixes et les jeux simultanes), le prochain explorer comment la reputation se construit dynamiquement a travers des interactions repetees, et comment une probabilite infime d'irrationalite suffit a transformer les predictions de la theorie.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-12-ReputationGames.ipynb
@@ -1707,6 +1707,12 @@
     "\n",
     "**Notebook 13 : CFR et Information Imparfaite** - Algorithmes pour resoudre les grands jeux a information imparfaite (poker, etc.)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff72b49",
+   "source": "## Resume et perspectives\n\nCe notebook a montre comment l'introduction d'une incertitude meme infime sur les types des joueurs transforme radicalement les predictions de la theorie des jeux. Le modele de Kreps-Wilson a resolu le paradoxe de la chaine de magasins : avec une probabilite $\\epsilon$ d'un type \"Fou\", le monopole rationnel peut imiter ce type pour batir une reputation de durete, dissuadant les entrants et obtenant un gain superieur a l'equilibre d'information complete. Le modele KMRW a produit un resultat analogue pour le Dilemme du Prisonnier fini, ou 5% de probabilite d'un type Tit-for-Tat suffisent a maintenir la cooperation pendant 16 des 20 tours, une amelioration de 160% par rapport a la defection systematique predite par l'induction arriere.\n\nL'analyse du cheap talk, en revanche, a revele les limites de la communication non-couteuse : le modele Crawford-Sobel montre que plus le biais entre expert et decideur augmente, moins d'information est transmise, jusqu'a l'equilibre \"babbling\" ou la parole est totalement vide de contenu. L'equilibre bayesien parfait (PBE) a fourni le cadre formel unificateur, combinant strategies optimales et mise a jour coherente des croyances via la regle de Bayes, et distinguant les equilibres separateurs, pooling et semi-separateurs selon la capacite des signaux a reveler l'information privee.\n\nLes concepts de reputation et de signaling presentes ici eclairent de nombreuses situations reelles : construction de credibilite en negociation internationale, certifications et diplomes comme signaux couteux sur le marche du travail, et communication strategique entre entreprises. Le notebook suivant poursuit cette exploration de l'information imparfaite sous l'angle algorithmique, avec la methode CFR (Counterfactual Regret Minimization) qui permet de calculer des equilibres de Nash dans des jeux a tres grande espace d'etats comme le poker.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -7225,6 +7225,12 @@
     "\n",
     "**Notebook suivant** : [GameTheory-14-DifferentialGames](GameTheory-14-DifferentialGames.ipynb) - Jeux differentiels et equilibres de Stackelberg"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3f4917a",
+   "source": "## Resume et perspectives\n\nCe notebook a explore les algorithmes de resolution des jeux a information imparfaite en se concentrant sur la famille CFR (Counterfactual Regret Minimization). Partant du concept fondamental de regret et du regret matching d'Hart et Mas-Colell, nous avons implemente CFR vanilla sur le Kuhn Poker et observe la convergence de la strategie moyenne vers l'equilibre de Nash theorique, avec des resultats proches des valeurs analytiques (par exemple, un bluff optimal de 1/3 avec le Jack). Les variantes CFR+ (regrets non-negatifs) et MCCFR (echantillonnage externe) ont ete comparees : si CFR+ n'apporte pas d'avantage sur ce petit jeu de 12 information sets, l'echantillonnage Monte Carlo accelere significativement la resolution (21000 it/s contre 5800 pour le vanilla) tout en maintenant une qualite de convergence comparable.\n\nLa comparaison avec l'implementation optimisee d'OpenSpiel a permis de valider notre approche pedagogique tout en illustrant les differences de performance entre Python et C++. L'entrainement sur Leduc Poker (936 information sets) a montre la robustesse de CFR face a des jeux de taille intermediaire. Enfin, l'apercu de Deep CFR a situe ces algorithmes dans leur contexte historique : de Libratus (2017) a Pluribus (2019), les methodes combineant regret matching et reseaux de neurones ont permis de resoudre le Texas Hold'em, un jeu de l'ordre de $10^{14}$ etats.\n\nCes techniques de resolution a information imparfaite trouvent des applications bien au-dela du poker : negociation strategique, jeux de securite avec information cachee, allocation d'encheres, et meme conception de mecanismes. Le notebook suivant aborde les jeux differentiels et les equilibres de Stackelberg, ou l'information imparfaite se combine a la dynamique temporelle continue.",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -1210,6 +1210,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c36229aa",
+   "source": "## Resume et perspectives\n\nCe notebook compagnon a illustre les concepts fondamentaux de la theorie des jeux cooperatifs a travers des implementations Python concretes. La valeur de Shapley, calculee exactement par enumeration des permutations, a revele le principe de rarete dans le jeu de gants ou le detenteur de la ressource complementaire rare obtient 4/6 de la valeur totale. La preuve du Core vide pour le jeu de majorite simple a 3 joueurs a montre comment la sommation des contraintes de stabilite mene a une contradiction (2 >= 3), illustrant l'instabilite coalitionnelle inhierente a ce type de jeu. Les indices de pouvoir de Shapley et Banzhaf ont ensuite demontre que le pouvoir reel peut differer significativement du poids nominal dans les jeux de vote ponderes, les non-permanents du Conseil de securite disposant d'un ratio pouvoir/poids plus eleve que les permanents.\n\nLa propriete de convexite s'est revelee determinante pour la stabilite des allocations : dans les jeux convexes (supermodulaires), la valeur de Shapley est garantie d'appartenir au Core, tandis que les jeux non convexes comme celui de la majorite ou des gants ne beneficient pas de cette garantie. Cette distinction entre \"juste\" (Shapley) et \"stable\" (Core) est au coeur de la theorie cooperative, et les exercices proposes permettent d'approfondir ces concepts sur des applications concretes (aeroport, fusion d'entreprises, jeux politiques).\n\nLes concepts de valeur de Shapley, de Core et d'indices de pouvoir trouvent des applications directes en economie (repartition des couts), en sciences politiques (analyse du pouvoir de vote) et en intelligence artificielle (explicabilite des modeles via les valeurs de Shapley en ML). Le passage a l'echelle vers des jeux a un grand nombre de joueurs necessite des methodes d'approximation Monte Carlo de la valeur de Shapley, constituant un domaine de recherche actif.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "43bdd0a8",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm.ipynb
@@ -2130,6 +2130,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "33048a4b",
+   "source": "## Resume et perspectives\n\nCe notebook a pose les fondements de la representation des jeux en forme normale, le formalisme de base de la theorie des jeux strategique. Nous avons defini le triplet $G = (N, S, u)$ et implemente une classe Python pour manipuler les matrices de gains de jeux a deux joueurs. L'etude des jeux classiques -- Dilemme du Prisonnier, Chasse au Cerf, Bataille des Sexes, Jeu du Poulet, Matching Pennies -- a revele la diversite des structures d'interaction : dominance strategique, probleme de coordination, anti-coordination et competition pure. Les concepts de strategie dominante, meilleure reponse et elimination iteree des strategies dominees (IESDS) fournissent les premiers outils de prediction du comportement rationnel.\n\nL'analyse de Pierre-Feuille-Ciseaux a introduit la necessite des strategies mixtes : lorsque les meilleures reponses forment un cycle, aucun equilibre en strategies pures n'existe, et la randomisation uniforme constitue le seul equilibre stable. Cette observation motive naturellement l'etude systematique des equilibres de Nash dans les notebooks suivants.\n\nLe notebook suivant, [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb), approfondit la classification topologique des jeux 2x2 en etudiant les 144 configurations possibles des matrices de gains, leurs symetries et les relations entre types de jeux.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cbd1ee05",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -1511,6 +1511,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b1c24332",
+   "source": "## Resume et perspectives\n\nCe notebook a explore en profondeur les equilibres de Nash, concept central de la theorie des jeux introduit par John Nash en 1950. Nous avons distingue les equilibres purs (action deterministe) des equilibres mixtes (randomisation optimale), et implemente les algorithmes de Support Enumeration, Lemke-Howson et Vertex Enumeration via Nashpy. La condition d'indifference -- a l'equilibre mixte, un joueur doit etre indifferent entre toutes les actions jouees avec probabilite positive -- a permis le calcul analytique des equilibres pour les jeux 2x2. L'analyse parametrique a mis en evidence les transitions de phase entre types de jeux (Harmony, Dilemme, Coordination) et montre comment un petit changement d'incitation peut transformer radicalement la structure des equilibres.\n\nUn point crucial est la multiplicite des equilibres dans de nombreux jeux (Stag Hunt, Battle of Sexes), qui pose le probleme de la selection : comment les joueurs se coordonnent-ils ? Les reponses -- points focaux de Schelling, communication, histoire des interactions -- motivent l'etude des jeux sous forme extensive et de l'evolution des strategies dans les notebooks suivants.\n\nLe notebook suivant, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), se concentre sur une classe particulierement structuree : les jeux a somme nulle, ou le theoreme minimax de Von Neumann garantit l'existence d'une valeur unique du jeu et d'equilibres calculables par programmation lineaire.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "237a5982",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -1770,6 +1770,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "64a79aa9",
+   "source": "## Resume et perspectives\n\nCe notebook a illustre numeriquement le fondement mathematique du theoreme d'existence de Nash : le theoreme du point fixe de Brouwer. Nous avons implemente des algorithmes de recherche de points fixes en 1D (methode de Babylone) et sur le simplexe 2D, puis observe la convergence des dynamiques de meilleure reponse perturbee vers l'equilibre de Matching Pennies (0.5, 0.5). Les contre-exemples ont montre pourquoi chaque hypothese de Brouwer est necessaire : un domaine non compact permet la fuite a l'infini, une fonction discontinue peut sauter par-dessus la diagonale, et un domaine non convexe autorise les rotations sans point fixe.\n\nLa lecture guidee du depot math-xmum/Brouwer a revele la chaine de preuves formelle en Lean 4 : Lemme de Scarf (combinatoire des colorages) puis Lemme de Sperner puis Brouwer sur le simplexe puis extension au produit de simplexes puis existence de Nash. Cette architecture modulaire, ou un resultat combinatoire profond (~3000 lignes) engendre par deductions successives le theoreme de Nash, illustre la puissance des mathematiques formalisees.\n\nLe notebook companion [GameTheory-4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb) propose la formalisation Lean 4 correspondante, tandis que le notebook suivant dans la serie principale, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), specialise l'analyse aux jeux a somme nulle ou le theoreme minimax de Von Neumann fournit des garanties encore plus fortes.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "604e7ae0",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-5-ZeroSum-Minimax.ipynb
@@ -1366,6 +1366,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aa1d788a",
+   "source": "## Resume et perspectives\n\nCe notebook a etudie les jeux a somme nulle et le theoreme minimax de Von Neumann (1928), pierre angulaire de la theorie des jeux. Nous avons defini les strategies maximin (Row maximise son pire cas) et minimax (Col minimise le meilleur cas de Row), puis demontre que l'ecart entre ces deux valeurs se resout en strategies mixtes. La resolution par programmation lineaire a confirme que les valeurs primale et duale coincident, illustrant la dualite forte LP. L'application au Colonel Blotto a revele un principe strategique contre-intuitif : la concentration des forces sur un sous-ensemble de fronts surpasse la repartition uniforme, avec seulement 3 strategies jouees a l'equilibre sur les 15 possibles.\n\nLe theoreme minimax garantit l'existence d'une valeur unique du jeu pour toute matrice de gains, ce qui rend les jeux a somme nulle particulierement bien comportes. Cette propriete ne s'etend pas aux jeux generaux (a somme non nulle), pour lesquels il faut recourir au theoreme de Nash et a ses algorithmes de resolution (Support Enumeration, Lemke-Howson).\n\nLe notebook suivant, [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb), quitte le cadre statique pour explorer la theorie des jeux evolutionnaire : comment la cooperation emerge-t-elle dans le Dilemme du Prisonnier Itere, et quelles strategies survivent dans une population en evolution ?",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "ac7247b6",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6-EvolutionTrust.ipynb
@@ -1831,6 +1831,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "12eb612d",
+   "source": "## Resume et perspectives\n\nCe notebook a explore l'emergence de la cooperation a travers le Dilemme du Prisonnier Itere et la theorie des jeux evolutionnaire. Nous avons implemente les strategies classiques du tournoi d'Axelrod -- Tit-for-Tat, Grudger, Pavlov, AlwaysCooperate, AlwaysDefect -- et reproduit le resultat historique : les strategies \"gentilles, retorsives et pardonnantes\" dominent les strategies agressives dans un tournoi round-robin. La dynamique du replicateur a montre comment Tit-for-Tat peut envahir une population majoritairement defectrice, illustrant le concept de strategie evolutivement stable (ESS) de Maynard Smith. L'analyse de l'impact du bruit a revele que Tit-for-Two-Tats est plus robuste aux erreurs que Tit-for-Tat, car sa tolerance a deux trahisons consecutives absorbe les accidents de transmission.\n\nLes lecons d'Axelrod -- etre gentil, provoquable, indulgent et clair -- transcendent la theorie des jeux pour s'appliquer a la conception de systemes multi-agents, aux mecanismes de reputation en ligne et aux protocoles de cooperation internationale. La condition fondamentale pour la cooperation reste l'\"ombre du futur\" : la repetition indefinie des interactions rend la punition credible et la cooperation rationnelle.\n\nLe notebook suivant, [GameTheory-7-ExtensiveForm](GameTheory-7-ExtensiveForm.ipynb), elargit notre analyse aux jeux sous forme extensive, ou les joueurs jouent sequentiellement et ou l'information imparfaite introduit de nouvelles subtilites strategiques.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "700085e9",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm.ipynb
@@ -1648,6 +1648,12 @@
     "\n",
     "**Notebook 8 : Jeux Combinatoires** - Theorie de Conway, jeux de Nim et theoreme de Sprague-Grundy."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "225fe7df",
+   "source": "## Resume et perspectives\n\nCe notebook a permis de construire les fondements de la representation extensive des jeux, en passant de la matrice de gains statique a l'arbre de jeu dynamique. Les concepts centraux exploites -- noeuds de decision, ensembles d'information (infosets), strategies pures et comportementales -- constituent le vocabulaire de base pour analyser toute interaction strategique sequentielle. La distinction entre information parfaite (chaque joueur connait l'historique complet) et information imparfaite (certains etats sont indistinguables) s'est revelee fondamentale : elle determine les strategies disponibles pour chaque joueur et la complexite de l'analyse. L'integration avec OpenSpiel a illustre comment ces concepts s'appliquent a des jeux reels comme le Kuhn Poker, ou le bluff emerge naturellement de la structure d'information asymetrique.\n\nLa conversion entre forme extensive et forme normale a mis en evidence un phenomene important : la representation extensive est plus parcimonieuse, car la forme normale peut exploser exponentiellement en fonction du nombre de noeuds de decision. Le jeu d'entree sur le marche a egalement souleve la question des menaces non credibles, que la forme extensive detecte mais ne resout pas formellement.\n\nLe notebook suivant plonge dans la theorie des jeux combinatoires avec le celebre theoreme de Sprague-Grundy : [GameTheory-8-CombinatorialGames](GameTheory-8-CombinatorialGames.ipynb).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
@@ -926,6 +926,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d4ed1f1d",
+   "source": "## Resume et perspectives\n\nCe notebook a etabli les fondements de la theorie des jeux combinatoires impartiaux, depuis la classification des positions en P-positions (perdantes pour le joueur courant) et N-positions (gagnantes) jusqu'au theoreme de Sprague-Grundy, resultat central qui affirme que tout jeu impartial fini est equivalent a un tas de Nim. Le theoreme de Bouton a fourni un critere elegant pour determiner la position gagnante au Nim (la nim-sum, ou XOR des tailles de tas), tandis que la fonction mex (minimum excludant) a permis de calculer recursivement les valeurs de Grundy pour des jeux de soustraction plus generaux. L'observation de la periodicite des valeurs de Grundy dans les jeux de soustraction ouvre la porte a l'analyse de jeux plus complexes, ou les structures periodiques simplifient considerablement la recherche de strategies optimales.\n\nLes side tracks associes approfondissent ces concepts : le [notebook 8b](GameTheory-8b-Lean-CombinatorialGames.ipynb) propose une formalisation en Lean 4 avec les PGame de Mathlib, tandis que le [notebook 8c](GameTheory-8c-CombinatorialGames-Python.ipynb) explore le jeu de Wythoff et les jeux multi-composantes en Python. La serie principale se poursuit avec l'etude de l'induction arriere pour resoudre les jeux sequentiels : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "74a5a589",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
@@ -1275,6 +1275,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77b9d5a4",
+   "source": "## Resume et perspectives\n\nCe notebook a approfondi la theorie des jeux combinatoires au-dela des fondations du notebook 8, en explorant trois axes complementaires. Premierement, l'analyse de la periodicite des valeurs de Grundy a revele que les sequences deviennent predictibles apres un certain point, avec des periodes d'autant plus longues que l'ensemble de coups est inhabituel (l'absence du coup \"1\" engendre ainsi des periodes nettement plus etendues). Deuxiemement, le jeu de Wythoff a illustre un lien remarquable entre combinatoire et geometrie : les P-positions s'alignent sur des droites de pente egale au nombre d'or, formalisees par les sequences de Beatty qui partitionnent les entiers positifs. Troisiemement, l'etude du jeu de Chomp a introduit les jeux partizans et le theoreme de Gale, dont la preuve non-constructive par \"strategy stealing\" garantit l'existence d'une strategie gagnante pour le premier joueur sans la construire.\n\nCes approfondissements montrent que la theorie de Sprague-Grundy, loin de se limiter au Nim, offre un cadre unificateur pour une large classe de jeux. La retour au track principal s'effectue avec le notebook sur l'induction arriere : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "3bd9cdcc",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-9-BackwardInduction.ipynb
@@ -1708,6 +1708,12 @@
     "\n",
     "**Notebook 10 : Induction Avant et SPE** - Raffinements des equilibres, menaces credibles, et jeux de signaling."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7e00514",
+   "source": "## Resume et perspectives\n\nCe notebook a explore l'induction arriere comme methode fondamentale de resolution des jeux sequentiels a information parfaite, en l'illustrant a travers trois paradoxes classiques de la theorie des jeux. Le jeu du mille-pattes a revele l'ecart le plus frappant entre prediction theorique (prendre immediatement, gains totaux de 1) et comportement observe (les joueurs cooperent sur plusieurs tours, gains totaux bien superieurs), mettant en lumiere les limites de l'hypothese de rationalite parfaite. Le jeu d'escalade (war of attrition) a montre comment l'avantage du premier joueur est systematiquement renforce par l'induction arriere, l'adversaire abandonnant des le premier tour. Enfin, le paradoxe de la chaine de magasins de Selten a illustre pourquoi la reputation -- une menace de combat repetee -- ne peut etre soutenable sous information complete, menant a la necessite de modeliser l'incertitude sur les types d'adversaires.\n\nLes simulations de rationalite limitee ont constitue un resultat marquant : une faible probabilite d'irrationalite suffit a transformer radicalement les resultats, suggerant que la connaissance commune de la rationalite est une hypothese forte dont la relaxation enrichit considerablement le modele predictif.\n\nLe raffinement de ces concepts se poursuit avec l'etude des menaces credibles et de l'induction avant : [GameTheory-10-ForwardInduction-SPE](GameTheory-10-ForwardInduction-SPE.ipynb).",
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -2766,6 +2766,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "319435e3",
+   "source": "## Resume et perspectives\n\nCe notebook a demontre comment les solveurs SAT et SMT permettent de verifier mecaniquement les theoremes d'impossibilite du choix social. En encodant les axiomes d'Arrow (Pareto, IIA, non-dictature) et de Sen (liberte minimale, Pareto, transitivite) sous forme de clauses CNF ou de contraintes entieres, nous avons obtenu des resultats UNSAT qui constituent des preuves formelles de ces theorems. L'approche SAT (PySAT) avec ses variables booleennes et ses milliers de clauses offre un encodage exhaustif mais verbeux, tandis que l'approche SMT (Z3) avec ses variables entieres representant les rangs sociaux produit un encodage plus compact et plus lisible, capable en prime de trouver des modeles SAT quand le theoreme ne s'applique pas (cas a 2 alternatives).\n\nL'analyse de la relaxation des axiomes a confirme que chaque condition est individuellement necessaire a l'impossibilite : retirer n'importe lequel des trois axiomes d'Arrow permet de retrouver une SWF satisfaisante (dictature, Borda, ou classement constant). Les benchmarks de performance ont egalement mis en evidence l'explosion combinatoire du nombre de profils, qui croit comme $(m!)^n$, rendant l'approche praticable uniquement pour de petites instances malgre l'utilisation de solveurs CDCL modernes comme Glucose3 et CaDiCaL.\n\nLes techniques presentees ici ouvrent la voie a des applications plus larges de la verification formelle en theorie du choix social, notamment l'analyse de theoremes de Gibbard-Satterthwaite (manipulation strategique) ou de Muller-Satterthwaite (monotonie), ainsi que l'exploration de conditions relachees ou de variations axiomatiques grace a la flexibilite de l'encodage SMT.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "sc-04-footer",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

Add "Resume et perspectives" conclusion cells to 15 GameTheory (non-Lean) notebooks missing them.

## Notebooks enriched

| Notebook | Content focus |
|----------|--------------|
| GameTheory-2-NormalForm | Normal form games, payoff matrices |
| GameTheory-4-NashEquilibrium | Nash equilibrium concept |
| GameTheory-4c-NashExistence-Python | Nash existence proof, Python |
| GameTheory-5-ZeroSum-Minimax | Zero-sum games, minimax |
| GameTheory-6-EvolutionTrust | Evolutionary trust, prisoner's dilemma |
| GameTheory-7-ExtensiveForm | Extensive form games |
| GameTheory-8-CombinatorialGames | Combinatorial game theory |
| GameTheory-8c-CombinatorialGames-Python | CGT in Python |
| GameTheory-9-BackwardInduction | Backward induction |
| GameTheory-10-ForwardInduction-SPE | Forward induction, SPE |
| GameTheory-11-BayesianGames | Bayesian games |
| GameTheory-12-ReputationGames | Reputation, signaling |
| GameTheory-13-ImperfectInfo-CFR | CFR algorithm |
| GameTheory-15c-CooperativeGames-Python | Cooperative games |
| 04-Computational-Aggregation-SAT-Z3 | SAT/Z3 aggregation |

## Proof
- 15/15 verified with conclusion cell
- 0 code cells modified (markdown-only)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>