### PR TITLE
fix(scripts): add missing requirements.txt for notebook_tools and sudoku

### DIFF
--- a/scripts/notebook_tools/requirements.txt
+++ b/scripts/notebook_tools/requirements.txt
@@ -1,0 +1,8 @@
+# Notebook Tools - Dependencies
+# Core execution
+jupyter-client>=8.0.0
+papermill>=2.4.0
+
+# QuantConnect Docker executor
+requests>=2.28.0
+websocket-client>=1.6.0

--- a/scripts/sudoku/requirements.txt
+++ b/scripts/sudoku/requirements.txt
@@ -1,0 +1,10 @@
+# Sudoku - Dependencies
+# Core computation
+numpy>=1.24.0
+
+# Deep learning (RRN model, training, evaluation)
+torch>=2.0.0
+
+# Data loading
+datasets>=2.14.0
+huggingface_hub>=0.20.0


### PR DESCRIPTION
## Summary
Add `requirements.txt` for two directories that had third-party imports but no dependency declaration.

## Problem
- `scripts/notebook_tools/` — 15+ scripts importing jupyter-client, papermill, requests, websocket-client with no requirements.txt
- `scripts/sudoku/` — 10+ scripts importing numpy, torch, datasets, huggingface_hub with no requirements.txt

## Changes
| File | Dependencies declared |
|------|----------------------|
| `scripts/notebook_tools/requirements.txt` | jupyter-client, papermill, requests, websocket-client |
| `scripts/sudoku/requirements.txt` | numpy, torch, datasets, huggingface_hub |

Reference: `scripts/genai-stack/requirements.txt` (existing, same pattern).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>