### PR TITLE
docs(scripts): update scripts-reference.md test coverage (46 files, 1729 tests)

### DIFF
--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -77,20 +77,22 @@ Les scripts `scripts/fix_*.py` / `scripts/recycle_*.py` à la racine sont des on
 | `scripts/execute_with_env.py`, `scripts/execute_dotnet_notebook.py`, `scripts/execute_sudoku_python.py` | Wrappers d'exécution avec env |
 | `scripts/quantconnect/`, `scripts/smartcontracts/`, `scripts/sudoku/`, `scripts/datasets/`, `scripts/tests/` | Outils par domaine |
 
-## Tests — `scripts/notebook_tools/tests/`
+## Tests — `scripts/tests/` + `scripts/notebook_tools/tests/`
 
-35 fichiers de test, 759 tests au total (pytest). Couverture par domaine :
+46 fichiers de test dans `scripts/tests/`, 1729 tests au total (pytest). Couverture par domaine :
 
-| Domaine | Fichiers de test | Modules couverts |
-|---------|---------------|---------------|
-| **notebook_tools/** | 26 | CLI principal, helpers, skeleton, lint, catalogue (generate/expand/verify/coverage), qualite C.1/C.2/C.3, leak detection, forensic, execution (.NET/WSL/QC/ Papermill), enrich, reporting |
-| **genai-stack/** | 7 | config.py (load_env, SERVICES, NOTEBOOK_SERVICE_MAP, GPU_PROFILES, EXECUTION_BATCHES, MODEL_CONFIGS), commands/validate.py (BatchNotebookValidator), commands/audio_apis.py + commands/models.py (static config), core/comfyui_client.py (ComfyUIConfig, ComfyUIClient, WorkflowManager, ComfyUIError) |
-| **top-level scripts/** | 3 | fix_robust_dotenv.py, extract_pptx_titles.py, extract_slidev_titles.py |
+| Domaine | Fichiers | Modules couverts |
+| ------- | -------- | --------------- |
+| **notebook_tools/** | 14 | CLI principal (notebook_tools.py pure fn), helpers, skeleton, lint, catalogue (generate/expand/verify/coverage), qualite C.1/C.2/C.3, leak detection, forensic, execution (exec_single_cell, wsl_papermill, batch_reexecute, execute_qcpy_docker), enrich, reporting |
+| **genai-stack/** | 8 | config.py, commands/validate.py, commands/audio_apis.py, commands/models.py, commands/notebooks.py, commands/auth.py, core/comfyui_client.py, core/auth_manager.py |
+| **sudoku/core/** | 5 | solvers.py (Norvig CSP), graph.py (edge index), dataset.py (parse_81 + collate_fn), generation.py (grid + puzzles), models.py (SudokuRRN + count_params). evaluate.py = GPU-only, non CPU-testable |
+| **top-level scripts/** | 7 | fix_robust_dotenv.py, extract_pptx_titles.py, extract_slidev_titles.py, validate_pr_notebooks.py, weekly_digest.py, validate_sc_notebooks.py, epita_prcon_autograde.py |
 | **datasets/** | 2 | stitch_crypto.py, build_panier_anti_bias.py |
+| **autres** | 10 | validate_qc_projects.py, series_progress_manager.py, update_navigation.py, scan_student_forks.py, catalog_coverage.py, qc_classify.py, forensic_scan.py, generate_parcours.py, check_c2_compliance.py, verify_catalog_readme.py |
 
-Lancer la suite : `python -m pytest scripts/notebook_tools/tests/ -v` (depuis la racine du repo).
+Lancer la suite : `python -m pytest scripts/tests/ -v` (depuis la racine du repo).
 
-Modules non testes (intentionnellement) : commands/docker.py, commands/notebooks.py, commands/auth.py, commands/gpu.py, commands/quant.py (CLI wrappers, subprocess calls, API externe).
+Modules genai-stack non testes (intentionnellement) : commands/docker.py (subprocess Docker), commands/gpu.py (nvidia-smi subprocess), commands/quant.py (API externe).
 
 ## Voir aussi
 


### PR DESCRIPTION
## Summary

Update `docs/scripts-reference.md` test coverage section to reflect actual state after 19 PRs of test-coverage work (cycles 69-87, po-2024:CoursIA-2).

### Changes
- Test count: **35 files / 759 tests** -> **46 files / 1729 tests**
- **genai-stack**: 7 -> **8** tested modules (added commands/auth.py + core/auth_manager.py + commands/notebooks.py)
- **sudoku/core**: new section (**5** files: solvers, graph, dataset/generation, models). evaluate.py noted as GPU-only
- Removed commands/auth.py, commands/notebooks.py from "Modules non testes" list
- Updated test run command to `scripts/tests/`

### Scope
Documentation only. 0 code changes.

### Verification
```
python -m pytest scripts/tests/ --co -q
======================== 1729 tests collected ========================
```