### PR TITLE
test(scripts): add 40 tests for validation/dispatch.py pure functions

### DIFF
--- a/GradeBookApp.Tests/EvaluationRecordTests.cs
+++ b/GradeBookApp.Tests/EvaluationRecordTests.cs
@@ -1,0 +1,153 @@
+using GradeBookApp;
+using Xunit;
+
+namespace GradeBookApp.Tests;
+
+/// <summary>
+/// Tests for EvaluationRecord — computed properties (Note, EvaluatorName, Score).
+/// </summary>
+public class EvaluationRecordTests
+{
+    // --- Note (computed grade) ---
+
+    [Fact]
+    public void Note_AllFours_Eight()
+    {
+        // (4+4+4+4)*2 / 4 = 8.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 4,
+            NoteTheorique = 4,
+            NoteTechnique = 4,
+            NoteOrganisation = 4,
+            NbEvalFields = 4
+        };
+        Assert.Equal(8m, e.Note);
+    }
+
+    [Fact]
+    public void Note_AllOnes_Two()
+    {
+        // (1+1+1+1)*2 / 4 = 2.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 1,
+            NoteTheorique = 1,
+            NoteTechnique = 1,
+            NoteOrganisation = 1,
+            NbEvalFields = 4
+        };
+        Assert.Equal(2m, e.Note);
+    }
+
+    [Fact]
+    public void Note_MixedScores()
+    {
+        // (3+2+4+1)*2 / 4 = 5.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 3,
+            NoteTheorique = 2,
+            NoteTechnique = 4,
+            NoteOrganisation = 1,
+            NbEvalFields = 4
+        };
+        Assert.Equal(5m, e.Note);
+    }
+
+    [Fact]
+    public void Note_ThreeFields()
+    {
+        // (3+3+3)*2 / 3 = 6.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 3,
+            NoteTheorique = 3,
+            NoteTechnique = 3,
+            NoteOrganisation = 0,
+            NbEvalFields = 3
+        };
+        Assert.Equal(6m, e.Note);
+    }
+
+    [Fact]
+    public void Note_MaxScores()
+    {
+        // (5+5+5+5)*2 / 4 = 10.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 5,
+            NoteTheorique = 5,
+            NoteTechnique = 5,
+            NoteOrganisation = 5,
+            NbEvalFields = 4
+        };
+        Assert.Equal(10m, e.Note);
+    }
+
+    [Fact]
+    public void Note_ZeroFields_ReturnsZero()
+    {
+        var e = new EvaluationRecord { NbEvalFields = 0 };
+        Assert.Equal(0m, e.Note);
+    }
+
+    [Fact]
+    public void Note_PrecisionRounding()
+    {
+        // (1+2+3+4)*2 / 4 = 5.0
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 1,
+            NoteTheorique = 2,
+            NoteTechnique = 3,
+            NoteOrganisation = 4,
+            NbEvalFields = 4
+        };
+        Assert.Equal(5m, e.Note);
+    }
+
+    // --- EvaluatorName ---
+
+    [Fact]
+    public void EvaluatorName_CombinesFirstAndLast()
+    {
+        var e = new EvaluationRecord { Prénom = "Jean", Nom = "Dupont" };
+        Assert.Equal("Jean Dupont", e.EvaluatorName);
+    }
+
+    [Fact]
+    public void EvaluatedName_MapsToGroupe()
+    {
+        var e = new EvaluationRecord { Groupe = "Group A" };
+        Assert.Equal("Group A", e.EvaluatedName);
+    }
+
+    [Fact]
+    public void Score_MapsToNote()
+    {
+        var e = new EvaluationRecord
+        {
+            NoteCommunication = 5,
+            NoteTheorique = 5,
+            NoteTechnique = 5,
+            NoteOrganisation = 5,
+            NbEvalFields = 4
+        };
+        Assert.Equal(e.Note, e.Score);
+    }
+
+    [Fact]
+    public void IsTeacherEvaluation_DefaultFalse()
+    {
+        var e = new EvaluationRecord();
+        Assert.False(e.IsTeacherEvaluation);
+    }
+
+    [Fact]
+    public void GroupName_MapsToGroupe()
+    {
+        var e = new EvaluationRecord { Groupe = "TSP" };
+        Assert.Equal("TSP", e.GroupName);
+    }
+}

--- a/GradeBookApp.Tests/FoldAccentsTests.cs
+++ b/GradeBookApp.Tests/FoldAccentsTests.cs
@@ -1,0 +1,119 @@
+using GradeBookApp;
+using Xunit;
+
+namespace GradeBookApp.Tests;
+
+/// <summary>
+/// Tests for Program.FoldAccents — Lucene-based accent folding via StandardAnalyzer + ASCIIFoldingFilter.
+/// Note: StandardAnalyzer tokenizes, lowercases, and removes spaces/punctuation. ASCIIFoldingFilter removes accents.
+/// </summary>
+public class FoldAccentsTests
+{
+    private static readonly Func<string, string> _foldAccents;
+
+    static FoldAccentsTests()
+    {
+        var method = typeof(Program).GetMethod("FoldAccents",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        _foldAccents = (Func<string, string>)Delegate.CreateDelegate(typeof(Func<string, string>), method);
+    }
+
+    [Fact]
+    public void PlainAscii_LowercasedAndSpacesRemoved()
+    {
+        // StandardAnalyzer lowercases and concatenates tokens
+        Assert.Equal("helloworld", _foldAccents("hello world"));
+    }
+
+    [Fact]
+    public void FrenchAccents_RemovedAndLowered()
+    {
+        Assert.Equal("aeiou", _foldAccents("aéiôù"));
+    }
+
+    [Fact]
+    public void Cedilla_Removed()
+    {
+        Assert.Equal("francais", _foldAccents("français"));
+    }
+
+    [Fact]
+    public void AccentedCapitals_RemovedAndLowered()
+    {
+        // StandardAnalyzer lowercases; accents removed by ASCIIFoldingFilter
+        Assert.Equal("aeiou", _foldAccents("ÀÉÎÔÙ"));
+    }
+
+    [Fact]
+    public void EmptyString_ReturnsEmpty()
+    {
+        Assert.Equal("", _foldAccents(""));
+    }
+
+    [Fact]
+    public void NullInput_ReturnsNull()
+    {
+        // IsNullOrWhiteSpace short-circuits: returns input unchanged
+        Assert.Null(_foldAccents(null!));
+    }
+
+    [Fact]
+    public void MixedAccentsAndAscii_SpacesRemovedLowered()
+    {
+        Assert.Equal("theophilegautier", _foldAccents("Théophile Gautier"));
+    }
+
+    [Fact]
+    public void GermanUmlaut_Removed()
+    {
+        Assert.Equal("munchen", _foldAccents("München"));
+    }
+
+    [Fact]
+    public void SpanishTilde_Removed()
+    {
+        Assert.Equal("elnino", _foldAccents("El niño"));
+    }
+
+    [Fact]
+    public void HyphenRemoved_ApostropheKept()
+    {
+        // StandardAnalyzer removes hyphens (token boundary) but keeps apostrophes within tokens
+        Assert.Equal("test123_o'brien", _foldAccents("test-123_O'brien"));
+    }
+
+    [Fact]
+    public void MultipleAccentsSameWord()
+    {
+        Assert.Equal("revelee", _foldAccents("Révélée"));
+    }
+
+    [Fact]
+    public void AeLigature_Removed()
+    {
+        Assert.Equal("aether", _foldAccents("Æther"));
+    }
+
+    [Fact]
+    public void WhitespaceOnly_ReturnsSame()
+    {
+        // IsNullOrWhiteSpace returns the input unchanged
+        Assert.Equal("   ", _foldAccents("   "));
+    }
+
+    [Fact]
+    public void AccentedSingleChar()
+    {
+        Assert.Equal("e", _foldAccents("é"));
+    }
+
+    [Fact]
+    public void AccentedString_UsedForComparison()
+    {
+        // Real use case: compare names ignoring accents, case, and spaces
+        var a = _foldAccents("Théophile Gautier");
+        var b = _foldAccents("theophile gautier");
+        Assert.Equal(a, b);
+    }
+}

--- a/GradeBookApp.Tests/GradeBookApp.Tests.csproj
+++ b/GradeBookApp.Tests/GradeBookApp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GradeBookApp\GradeBookApp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GradeBookApp.Tests/ProjectModelTests.cs
+++ b/GradeBookApp.Tests/ProjectModelTests.cs
@@ -1,0 +1,705 @@
+using GradeBookApp;
+using Xunit;
+
+namespace GradeBookApp.Tests;
+
+/// <summary>
+/// Tests for ProjectModel — GroupEvaluation.Moyenne, GroupSizeBonus,
+/// StatisticalNormalization, ProcessEvaluations filtering logic.
+/// </summary>
+public class ProjectModelTests
+{
+    // Helper to create a simple accent-folder (identity for tests that don't need it)
+    private static string IdentityFold(string s) => s;
+
+    private static StudentRecord MakeStudent(string prenom, string nom, string email, string? sujet1 = null)
+        => new() { Prénom = prenom, Nom = nom, Email = email, SujetProjet1 = sujet1 };
+
+    private static EvaluationRecord MakeEval(
+        string email, string nom, string prenom, string groupe,
+        int comm, int theo, int tech, int org,
+        bool isTeacher = false)
+        => new()
+        {
+            Email = email,
+            Nom = nom,
+            Prénom = prenom,
+            Groupe = groupe,
+            NoteCommunication = comm,
+            NoteTheorique = theo,
+            NoteTechnique = tech,
+            NoteOrganisation = org,
+            IsTeacher = isTeacher,
+            NbEvalFields = 4
+        };
+
+    // ================================================================
+    // GroupEvaluation.Moyenne — weighted average of student + teacher evals
+    // ================================================================
+
+    [Fact]
+    public void GroupEval_Moyenne_NoValidEvals_ReturnsZero()
+    {
+        var g = new GroupEvaluation { TeacherWeight = 2m };
+        Assert.Equal(0m, g.Moyenne);
+    }
+
+    [Fact]
+    public void GroupEval_Moyenne_StudentOnlyEvals()
+    {
+        var g = new GroupEvaluation { TeacherWeight = 2m };
+        g.SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s1@e.fr", "A", "Alice", "G1", 3, 3, 3, 3),
+            MakeEval("s2@e.fr", "B", "Bob", "G1", 5, 5, 5, 5),
+        });
+        // (6 + 10) / 2 = 8.0
+        Assert.Equal(8m, g.Moyenne);
+    }
+
+    [Fact]
+    public void GroupEval_Moyenne_TeacherOnlyEvals()
+    {
+        var g = new GroupEvaluation { TeacherWeight = 2m };
+        g.SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("teacher@e.fr", "Prof", "Jean", "G1", 5, 5, 5, 5, isTeacher: true),
+        });
+        // Only teacher: 10.0
+        Assert.Equal(10m, g.Moyenne);
+    }
+
+    [Fact]
+    public void GroupEval_Moyenne_StudentPlusTeacher()
+    {
+        var g = new GroupEvaluation { TeacherWeight = 2m };
+        g.SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s1@e.fr", "A", "Alice", "G1", 2, 2, 2, 2), // Note=4
+            MakeEval("teacher@e.fr", "Prof", "Jean", "G1", 5, 5, 5, 5, isTeacher: true), // Note=10
+        });
+        // studentAvg=4, teacherAvg=10, weight=2: (4 + 10*2) / (1+2) = 24/3 = 8.0
+        Assert.Equal(8m, g.Moyenne);
+    }
+
+    [Fact]
+    public void GroupEval_Moyenne_MultipleTeachers()
+    {
+        var g = new GroupEvaluation { TeacherWeight = 1m };
+        g.SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s1@e.fr", "A", "Alice", "G1", 3, 3, 3, 3), // Note=6
+            MakeEval("t1@e.fr", "T1", "Prof1", "G1", 5, 5, 5, 5, isTeacher: true), // Note=10
+            MakeEval("t2@e.fr", "T2", "Prof2", "G1", 1, 1, 1, 1, isTeacher: true), // Note=2
+        });
+        // studentAvg=6, teacherAvg=(10+2)/2=6, weight=1: (6 + 6*1) / (1+1) = 12/2 = 6.0
+        Assert.Equal(6m, g.Moyenne);
+    }
+
+    // ================================================================
+    // GroupSizeBonus — static lookup table
+    // ================================================================
+
+    [Fact]
+    public void ApplyGroupSizeBonus_Solo_GetPlus3()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord> { MakeStudent("A", "Alice", "a@e.fr", "TSP") },
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        // Manually add group with 1 member
+        proj.Groups.Add("TSP", new GroupEvaluation
+        {
+            Groupe = "TSP",
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "Alice", "a@e.fr") }
+        });
+        proj.Groups["TSP"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s@e.fr", "B", "Bob", "TSP", 4, 4, 4, 4), // Note=8
+        });
+
+        proj.ApplyGroupSizeBonus();
+
+        Assert.Equal(3m, proj.Groups["TSP"].GroupSizeBonus);
+        Assert.Equal(11m, proj.Groups["TSP"].NoteAvecBonus); // 8 + 3
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_Trio_GetZero()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = new List<StudentRecord>
+            {
+                MakeStudent("A", "A", "a@e"),
+                MakeStudent("B", "B", "b@e"),
+                MakeStudent("C", "C", "c@e"),
+            }
+        });
+        proj.Groups["G1"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s@e", "X", "X", "G1", 5, 5, 5, 5), // Note=10
+        });
+
+        proj.ApplyGroupSizeBonus();
+
+        Assert.Equal(0m, proj.Groups["G1"].GroupSizeBonus);
+        Assert.Equal(10m, proj.Groups["G1"].NoteAvecBonus);
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_FourStudents_GetMinus1()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        var members = Enumerable.Range(0, 4)
+            .Select(i => MakeStudent($"S{i}", $"S{i}", $"s{i}@e"))
+            .ToList();
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = members
+        });
+        proj.Groups["G1"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("x@e", "X", "X", "G1", 5, 5, 5, 5), // Note=10
+        });
+
+        proj.ApplyGroupSizeBonus();
+
+        Assert.Equal(-1m, proj.Groups["G1"].GroupSizeBonus);
+        Assert.Equal(9m, proj.Groups["G1"].NoteAvecBonus);
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_ClampsTo20()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+        proj.Groups["G1"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("s@e", "B", "B", "G1", 5, 5, 5, 5), // Note=10
+        });
+
+        proj.ApplyGroupSizeBonus();
+
+        // 10 + 3 = 13, within [0,20]
+        Assert.Equal(13m, proj.Groups["G1"].NoteAvecBonus);
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_ClampsTo0()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        var members = Enumerable.Range(0, 6)
+            .Select(i => MakeStudent($"S{i}", $"S{i}", $"s{i}@e"))
+            .ToList();
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = members
+        });
+        proj.Groups["G1"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("x@e", "X", "X", "G1", 1, 1, 1, 1), // Note=2
+        });
+
+        proj.ApplyGroupSizeBonus();
+
+        // 2 + (-3) = -1, clamped to 0
+        Assert.Equal(0m, proj.Groups["G1"].NoteAvecBonus);
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_EmptyGroup_Skipped()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = new List<StudentRecord>()
+        });
+
+        proj.ApplyGroupSizeBonus(); // Should not throw
+
+        Assert.Equal(0m, proj.Groups["G1"].GroupSizeBonus);
+    }
+
+    [Fact]
+    public void ApplyGroupSizeBonus_UnknownSize_Throws()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        var members = Enumerable.Range(0, 7)
+            .Select(i => MakeStudent($"S{i}", $"S{i}", $"s{i}@e"))
+            .ToList();
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            GroupMembers = members
+        });
+        proj.Groups["G1"].SetValidEvaluations(new List<EvaluationRecord>
+        {
+            MakeEval("x@e", "X", "X", "G1", 3, 3, 3, 3),
+        });
+
+        Assert.Throws<Exception>(() => proj.ApplyGroupSizeBonus());
+    }
+
+    // ================================================================
+    // Statistical Normalization — z-score + target mean/stdev
+    // ================================================================
+
+    [Fact]
+    public void Normalization_SingleGroup_SetsToTargetMean()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            NoteAvecBonus = 12m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        // Single group: stdev=0, all get targetMean
+        Assert.Equal(11m, proj.Groups["G1"].NoteRectifiée);
+    }
+
+    [Fact]
+    public void Normalization_TwoEqualGroups_BothGetTargetMean()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            NoteAvecBonus = 10m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+        proj.Groups.Add("G2", new GroupEvaluation
+        {
+            Groupe = "G2",
+            NoteAvecBonus = 10m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("B", "B", "b@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        // Both equal: stdev=0, both get targetMean
+        Assert.Equal(11m, proj.Groups["G1"].NoteRectifiée);
+        Assert.Equal(11m, proj.Groups["G2"].NoteRectifiée);
+    }
+
+    [Fact]
+    public void Normalization_PreservesRankOrder()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("Low", new GroupEvaluation
+        {
+            Groupe = "Low",
+            NoteAvecBonus = 8m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+        proj.Groups.Add("High", new GroupEvaluation
+        {
+            Groupe = "High",
+            NoteAvecBonus = 14m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("B", "B", "b@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        // Rank order preserved: Low < High
+        Assert.True(proj.Groups["Low"].NoteRectifiée < proj.Groups["High"].NoteRectifiée);
+    }
+
+    [Fact]
+    public void Normalization_SymmetricAroundMean()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            NoteAvecBonus = 8m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+        proj.Groups.Add("G2", new GroupEvaluation
+        {
+            Groupe = "G2",
+            NoteAvecBonus = 14m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("B", "B", "b@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        // Mean=11, both equidistant: G1 and G2 should be symmetric around 11
+        var delta1 = 11m - proj.Groups["G1"].NoteRectifiée;
+        var delta2 = proj.Groups["G2"].NoteRectifiée - 11m;
+        Assert.True(Math.Abs(delta1 - delta2) < 0.01m);
+    }
+
+    [Fact]
+    public void Normalization_ClampsTo20()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("Low", new GroupEvaluation
+        {
+            Groupe = "Low",
+            NoteAvecBonus = 6m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "a@e") }
+        });
+        proj.Groups.Add("High", new GroupEvaluation
+        {
+            Groupe = "High",
+            NoteAvecBonus = 19m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("B", "B", "b@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        Assert.True(proj.Groups["High"].NoteRectifiée <= 20m);
+        Assert.True(proj.Groups["Low"].NoteRectifiée >= 0m);
+    }
+
+    [Fact]
+    public void Normalization_WeightedByGroupSize()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        // 3 students at 8, 1 student at 16 → weighted mean = 10
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            NoteAvecBonus = 8m,
+            GroupMembers = new List<StudentRecord>
+            {
+                MakeStudent("A", "A", "a@e"),
+                MakeStudent("B", "B", "b@e"),
+                MakeStudent("C", "C", "c@e"),
+            }
+        });
+        proj.Groups.Add("G2", new GroupEvaluation
+        {
+            Groupe = "G2",
+            NoteAvecBonus = 16m,
+            GroupMembers = new List<StudentRecord> { MakeStudent("D", "D", "d@e") }
+        });
+
+        proj.ApplyStatisticalNormalization(targetMean: 11m, targetStdev: 4m);
+
+        // G1 (majority, below mean) should be closer to targetMean than G2
+        // Both should be finite
+        Assert.True(proj.Groups["G1"].NoteRectifiée > 0m);
+        Assert.True(proj.Groups["G2"].NoteRectifiée > 0m);
+    }
+
+    [Fact]
+    public void Normalization_EmptyGroups_NoOp()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.ApplyStatisticalNormalization(); // No groups at all — should not throw
+    }
+
+    [Fact]
+    public void Normalization_GroupsWithoutMembers_Skipped()
+    {
+        var proj = new ProjectEvaluation(
+            new List<StudentRecord>(),
+            new List<EvaluationRecord>(),
+            "PrCon", "teacher@e.fr", IdentityFold);
+
+        proj.Groups.Add("G1", new GroupEvaluation
+        {
+            Groupe = "G1",
+            NoteAvecBonus = 10m,
+            GroupMembers = new List<StudentRecord>() // empty
+        });
+
+        proj.ApplyStatisticalNormalization(); // Should not throw
+    }
+
+    // ================================================================
+    // ProcessEvaluations — filtering (auto-eval, double eval, non-inscrit)
+    // ================================================================
+
+    [Fact]
+    public void Process_AutoEval_Rejected()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "Dupont", "alice@e.fr", "TSP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("alice@e.fr", "Dupont", "Alice", "TSP", 5, 5, 5, 5), // Self-eval
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Single(proj.RejectedEvaluations);
+        Assert.Contains("Auto", proj.RejectedEvaluations[0].Reason);
+    }
+
+    [Fact]
+    public void Process_DoubleEval_SecondRejected()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "A", "alice@e.fr", "TSP"),
+            MakeStudent("Bob", "B", "bob@e.fr", "VRP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("bob@e.fr", "B", "Bob", "TSP", 3, 3, 3, 3),
+            MakeEval("bob@e.fr", "B", "Bob", "TSP", 5, 5, 5, 5), // Double
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Single(proj.RejectedEvaluations);
+        Assert.Contains("double", proj.RejectedEvaluations[0].Reason);
+    }
+
+    [Fact]
+    public void Process_NonInscrit_Rejected()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "A", "alice@e.fr", "TSP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("unknown@e.fr", "Stranger", "X", "TSP", 3, 3, 3, 3),
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Single(proj.RejectedEvaluations);
+        Assert.Contains("non-inscrit", proj.RejectedEvaluations[0].Reason);
+    }
+
+    [Fact]
+    public void Process_TeacherEval_MarkedAsTeacher()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "A", "alice@e.fr", "TSP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("teacher@e.fr", "Prof", "Jean", "TSP", 5, 5, 5, 5),
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Empty(proj.RejectedEvaluations);
+        Assert.True(proj.Groups["TSP"].ValidEvaluations[0].IsTeacher);
+    }
+
+    [Fact]
+    public void Process_ValidStudentEval_Accepted()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "A", "alice@e.fr", "TSP"),
+            MakeStudent("Bob", "B", "bob@e.fr", "VRP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("bob@e.fr", "B", "Bob", "TSP", 4, 4, 4, 4),
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Empty(proj.RejectedEvaluations);
+        Assert.Single(proj.Groups["TSP"].ValidEvaluations);
+    }
+
+    [Fact]
+    public void Process_GroupMembersMatchBySujet()
+    {
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Alice", "A", "alice@e.fr", "TSP"),
+            MakeStudent("Bob", "B", "bob@e.fr", "VRP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("bob@e.fr", "B", "Bob", "TSP", 3, 3, 3, 3),
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", IdentityFold);
+        proj.ProcessEvaluations();
+
+        Assert.Single(proj.Groups["TSP"].GroupMembers);
+        Assert.Equal("Alice", proj.Groups["TSP"].GroupMembers[0].Prénom);
+    }
+
+    // ================================================================
+    // HasStudent — group membership check
+    // ================================================================
+
+    [Fact]
+    public void HasStudent_MatchingEmail_ReturnsTrue()
+    {
+        var g = new GroupEvaluation
+        {
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "alice@e.fr") }
+        };
+        Assert.True(g.HasStudent("alice@e.fr"));
+    }
+
+    [Fact]
+    public void HasStudent_NonMatchingEmail_ReturnsFalse()
+    {
+        var g = new GroupEvaluation
+        {
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "alice@e.fr") }
+        };
+        Assert.False(g.HasStudent("bob@e.fr"));
+    }
+
+    [Fact]
+    public void HasStudent_NullUID_ReturnsFalse()
+    {
+        var g = new GroupEvaluation
+        {
+            GroupMembers = new List<StudentRecord> { MakeStudent("A", "A", "alice@e.fr") }
+        };
+        Assert.False(g.HasStudent(null));
+    }
+
+    // ================================================================
+    // RejectedEvaluation record
+    // ================================================================
+
+    [Fact]
+    public void RejectedEval_StoresReason()
+    {
+        var eval = new EvaluationRecord { Groupe = "TSP" };
+        var rejected = new RejectedEvaluation(eval, "Auto-evaluation.");
+        Assert.Equal("Auto-evaluation.", rejected.Reason);
+        Assert.Same(eval, rejected.Evaluation);
+    }
+
+    // ================================================================
+    // NormalizationDelta
+    // ================================================================
+
+    [Fact]
+    public void NormalizationDelta_Calculated()
+    {
+        var g = new GroupEvaluation
+        {
+            NoteAvecBonus = 10m,
+            NoteRectifiée = 11.5m
+        };
+        Assert.Equal(1.5m, g.NormalizationDelta);
+    }
+
+    // ================================================================
+    // FinalGrade equals NoteRectifiée
+    // ================================================================
+
+    [Fact]
+    public void FinalGrade_EqualsNoteRectifiee()
+    {
+        var g = new GroupEvaluation { NoteRectifiée = 14.3m };
+        Assert.Equal(14.3m, g.FinalGrade);
+    }
+
+    // ================================================================
+    // Accent-insensitive matching in ProcessEvaluations
+    // ================================================================
+
+    [Fact]
+    public void Process_AccentedNames_MatchCorrectly()
+    {
+        // Use the real FoldAccents from Program via reflection
+        var method = typeof(Program).GetMethod("FoldAccents",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(method);
+        var foldAccents = (Func<string, string>)Delegate.CreateDelegate(typeof(Func<string, string>), method);
+
+        var students = new List<StudentRecord>
+        {
+            MakeStudent("Théophile", "Gautier", "theo@e.fr", "TSP"),
+        };
+        var evals = new List<EvaluationRecord>
+        {
+            MakeEval("other@e.fr", "Gautier", "Theophile", "TSP", 3, 3, 3, 3), // Accented vs not
+        };
+
+        var proj = new ProjectEvaluation(students, evals, "PrCon", "teacher@e.fr", foldAccents);
+        proj.ProcessEvaluations();
+
+        // The eval from "Theophile Gautier" should be recognized as self-eval (auto)
+        Assert.Single(proj.RejectedEvaluations);
+        Assert.Contains("Auto", proj.RejectedEvaluations[0].Reason);
+    }
+}

--- a/GradeBookApp.Tests/StudentRecordTests.cs
+++ b/GradeBookApp.Tests/StudentRecordTests.cs
@@ -1,0 +1,102 @@
+using GradeBookApp;
+using Xunit;
+
+namespace GradeBookApp.Tests;
+
+/// <summary>
+/// Tests for StudentRecord — computed properties (Moyenne, Sujets).
+/// </summary>
+public class StudentRecordTests
+{
+    // --- Moyenne ---
+
+    [Fact]
+    public void Moyenne_EmptyNotes_ReturnsZero()
+    {
+        var s = new StudentRecord();
+        Assert.Equal(0m, s.Moyenne);
+    }
+
+    [Fact]
+    public void Moyenne_SingleNote()
+    {
+        var s = new StudentRecord { Notes = new List<decimal> { 14m } };
+        Assert.Equal(14m, s.Moyenne);
+    }
+
+    [Fact]
+    public void Moyenne_MultipleNotes()
+    {
+        var s = new StudentRecord { Notes = new List<decimal> { 10m, 14m, 18m } };
+        Assert.Equal(14m, s.Moyenne);
+    }
+
+    [Fact]
+    public void Moyenne_Precision()
+    {
+        var s = new StudentRecord { Notes = new List<decimal> { 10m, 11m } };
+        Assert.Equal(10.5m, s.Moyenne);
+    }
+
+    // --- Sujets ---
+
+    [Fact]
+    public void Sujets_BothNull_ReturnsEmpty()
+    {
+        var s = new StudentRecord();
+        Assert.Empty(s.Sujets);
+    }
+
+    [Fact]
+    public void Sujets_OneSujet()
+    {
+        var s = new StudentRecord { SujetProjet1 = "TSP" };
+        Assert.Single(s.Sujets);
+        Assert.Contains("TSP", s.Sujets);
+    }
+
+    [Fact]
+    public void Sujets_TwoSujets()
+    {
+        var s = new StudentRecord { SujetProjet1 = "TSP", SujetProjet2 = "VRP" };
+        Assert.Equal(2, s.Sujets.Count);
+    }
+
+    [Fact]
+    public void Sujets_SecondOnly()
+    {
+        var s = new StudentRecord { SujetProjet2 = "VRP" };
+        Assert.Single(s.Sujets);
+        Assert.Contains("VRP", s.Sujets);
+    }
+
+    // --- Compatibility properties ---
+
+    [Fact]
+    public void FirstName_MapsToPrenom()
+    {
+        var s = new StudentRecord { Prénom = "Jean" };
+        Assert.Equal("Jean", s.FirstName);
+    }
+
+    [Fact]
+    public void LastName_MapsToNom()
+    {
+        var s = new StudentRecord { Nom = "Dupont" };
+        Assert.Equal("Dupont", s.LastName);
+    }
+
+    [Fact]
+    public void UID_MapsToEmail()
+    {
+        var s = new StudentRecord { Email = "jean@epita.fr" };
+        Assert.Equal("jean@epita.fr", s.UID);
+    }
+
+    [Fact]
+    public void Course_IsPrCon()
+    {
+        var s = new StudentRecord();
+        Assert.Equal("PrCon", s.Course);
+    }
+}

--- a/scripts/tests/test_validation_dispatch.py
+++ b/scripts/tests/test_validation_dispatch.py
@@ -1,0 +1,372 @@
+"""Tests for scripts/validation/dispatch.py — pure functions.
+
+Tests cover:
+- _worst_severity: severity ranking from issue list
+- _classify_maturity: maturity classification from struct + issues
+- build_aggregate: cross-family summary aggregation
+
+These are pure functions with no I/O, safe to test without fixtures.
+"""
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+# Add scripts parent to path so we can import dispatch
+DISPATCH_DIR = Path(__file__).resolve().parent.parent / "validation"
+sys.path.insert(0, str(DISPATCH_DIR))
+
+from dispatch import _worst_severity, _classify_maturity, build_aggregate
+
+
+# --- Helpers ---
+
+@dataclass
+class FakeValidationIssue:
+    """Minimal ValidationIssue-compatible object for testing."""
+    issue_type: str
+    category: str = "test"
+    cell_index: int = 0
+    message: str = ""
+
+
+@dataclass
+class FakeStruct:
+    """Minimal struct compatible with _classify_maturity's attribute access."""
+    has_cells: bool = True
+    code_cells: int = 0
+    valid_json: bool = True
+    cells_with_output: int = 0
+    cells_with_errors: int = 0
+    markdown_cells: int = 0
+
+
+def _make_struct(
+    code_cells: int = 3,
+    cells_with_output: int = 3,
+    cells_with_errors: int = 0,
+    markdown_cells: int = 2,
+    has_cells: bool = True,
+    valid_json: bool = True,
+) -> FakeStruct:
+    return FakeStruct(
+        has_cells=has_cells,
+        code_cells=code_cells,
+        valid_json=valid_json,
+        cells_with_output=cells_with_output,
+        cells_with_errors=cells_with_errors,
+        markdown_cells=markdown_cells,
+    )
+
+
+# =============================================================================
+# _worst_severity
+# =============================================================================
+
+class TestWorstSeverity:
+    """Tests for _worst_severity(issues) -> 'error' | 'warning' | 'ok'."""
+
+    def test_empty_list_returns_ok(self):
+        assert _worst_severity([]) == "ok"
+
+    def test_single_error_returns_error(self):
+        issues = [FakeValidationIssue(issue_type="error")]
+        assert _worst_severity(issues) == "error"
+
+    def test_single_warning_returns_warning(self):
+        issues = [FakeValidationIssue(issue_type="warning")]
+        assert _worst_severity(issues) == "warning"
+
+    def test_single_info_returns_ok(self):
+        issues = [FakeValidationIssue(issue_type="info")]
+        assert _worst_severity(issues) == "ok"
+
+    def test_error_takes_priority_over_warning(self):
+        issues = [
+            FakeValidationIssue(issue_type="warning"),
+            FakeValidationIssue(issue_type="error"),
+        ]
+        assert _worst_severity(issues) == "error"
+
+    def test_error_takes_priority_over_info(self):
+        issues = [
+            FakeValidationIssue(issue_type="info"),
+            FakeValidationIssue(issue_type="error"),
+        ]
+        assert _worst_severity(issues) == "error"
+
+    def test_multiple_warnings_returns_warning(self):
+        issues = [
+            FakeValidationIssue(issue_type="warning"),
+            FakeValidationIssue(issue_type="warning"),
+        ]
+        assert _worst_severity(issues) == "warning"
+
+    def test_multiple_infos_returns_ok(self):
+        issues = [
+            FakeValidationIssue(issue_type="info"),
+            FakeValidationIssue(issue_type="info"),
+        ]
+        assert _worst_severity(issues) == "ok"
+
+    def test_error_warning_info_mixed_returns_error(self):
+        issues = [
+            FakeValidationIssue(issue_type="info"),
+            FakeValidationIssue(issue_type="warning"),
+            FakeValidationIssue(issue_type="error"),
+        ]
+        assert _worst_severity(issues) == "error"
+
+    def test_warning_before_info_in_order(self):
+        """Warning appears first in iteration — should return warning."""
+        issues = [
+            FakeValidationIssue(issue_type="warning"),
+            FakeValidationIssue(issue_type="info"),
+        ]
+        assert _worst_severity(issues) == "warning"
+
+
+# =============================================================================
+# _classify_maturity
+# =============================================================================
+
+class TestClassifyMaturity:
+    """Tests for _classify_maturity(struct, issues) -> str."""
+
+    # --- DRAFT cases ---
+
+    def test_no_cells_returns_draft(self):
+        struct = _make_struct(code_cells=0, has_cells=False, cells_with_output=0)
+        assert _classify_maturity(struct, []) == "DRAFT"
+
+    def test_code_cells_zero_returns_draft(self):
+        """has_cells=True but code_cells=0 → DRAFT."""
+        struct = _make_struct(code_cells=0, has_cells=True, cells_with_output=0)
+        assert _classify_maturity(struct, []) == "DRAFT"
+
+    def test_invalid_json_returns_draft(self):
+        struct = _make_struct(valid_json=False)
+        assert _classify_maturity(struct, []) == "DRAFT"
+
+    def test_no_outputs_returns_draft(self):
+        """Code cells exist but zero outputs → DRAFT."""
+        struct = _make_struct(code_cells=3, cells_with_output=0)
+        assert _classify_maturity(struct, []) == "DRAFT"
+
+    def test_outputs_but_no_markdown_returns_draft(self):
+        """All code has outputs, zero markdown cells → DRAFT."""
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=0)
+        assert _classify_maturity(struct, []) == "DRAFT"
+
+    # --- ALPHA cases ---
+
+    def test_partial_outputs_returns_alpha(self):
+        """Some but not all code cells have outputs → ALPHA."""
+        struct = _make_struct(code_cells=3, cells_with_output=2, markdown_cells=1)
+        assert _classify_maturity(struct, []) == "ALPHA"
+
+    def test_all_outputs_but_errors_returns_alpha(self):
+        """All code has outputs + markdown, but errors present → ALPHA."""
+        struct = _make_struct(
+            code_cells=3, cells_with_output=3, cells_with_errors=1, markdown_cells=2
+        )
+        assert _classify_maturity(struct, []) == "ALPHA"
+
+    def test_one_output_of_three_returns_alpha(self):
+        struct = _make_struct(code_cells=3, cells_with_output=1, markdown_cells=1)
+        assert _classify_maturity(struct, []) == "ALPHA"
+
+    # --- BETA cases ---
+
+    def test_all_outputs_markdown_many_issues_returns_beta(self):
+        """All outputs + markdown + >2 issues → BETA."""
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        issues = [FakeValidationIssue(issue_type="warning") for _ in range(3)]
+        assert _classify_maturity(struct, issues) == "BETA"
+
+    def test_all_outputs_markdown_3_issues_returns_beta(self):
+        """Exactly 3 issues → BETA (threshold is <=2 for PRODUCTION)."""
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        issues = [FakeValidationIssue(issue_type="info") for _ in range(3)]
+        assert _classify_maturity(struct, issues) == "BETA"
+
+    def test_all_outputs_markdown_10_issues_returns_beta(self):
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        issues = [FakeValidationIssue(issue_type="info") for _ in range(10)]
+        assert _classify_maturity(struct, issues) == "BETA"
+
+    # --- PRODUCTION cases ---
+
+    def test_all_outputs_markdown_zero_issues_returns_production(self):
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        assert _classify_maturity(struct, []) == "PRODUCTION"
+
+    def test_all_outputs_markdown_one_issue_returns_production(self):
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        issues = [FakeValidationIssue(issue_type="warning")]
+        assert _classify_maturity(struct, issues) == "PRODUCTION"
+
+    def test_all_outputs_markdown_two_issues_returns_production(self):
+        """Exactly 2 issues → still PRODUCTION (boundary)."""
+        struct = _make_struct(code_cells=3, cells_with_output=3, markdown_cells=2)
+        issues = [FakeValidationIssue(issue_type="info"), FakeValidationIssue(issue_type="info")]
+        assert _classify_maturity(struct, issues) == "PRODUCTION"
+
+    # --- Edge cases ---
+
+    def test_single_code_cell_with_output_and_md_is_production(self):
+        struct = _make_struct(code_cells=1, cells_with_output=1, markdown_cells=1)
+        assert _classify_maturity(struct, []) == "PRODUCTION"
+
+    def test_all_outputs_errors_and_markdown_is_alpha_not_beta(self):
+        """Errors take priority over issue count → ALPHA."""
+        struct = _make_struct(
+            code_cells=3, cells_with_output=3, cells_with_errors=2, markdown_cells=2
+        )
+        assert _classify_maturity(struct, []) == "ALPHA"
+
+    def test_markdown_one_cell_minimum(self):
+        """1 markdown cell is enough (has_md check uses >0)."""
+        struct = _make_struct(code_cells=2, cells_with_output=2, markdown_cells=1)
+        assert _classify_maturity(struct, []) == "PRODUCTION"
+
+
+# =============================================================================
+# build_aggregate
+# =============================================================================
+
+class TestBuildAggregate:
+    """Tests for build_aggregate(all_results) -> dict."""
+
+    def _make_result(
+        self,
+        total: int = 10,
+        pass_count: int = 7,
+        warn: int = 2,
+        fail: int = 1,
+        production: int = 5,
+        beta: int = 3,
+        alpha: int = 1,
+        draft: int = 1,
+        broken: list | None = None,
+        duration: float = 5.0,
+    ) -> dict:
+        return {
+            "name": "TestFamily",
+            "total": total,
+            "pass": pass_count,
+            "warn": warn,
+            "fail": fail,
+            "skip": 0,
+            "broken": broken or [],
+            "maturity": {
+                "PRODUCTION": production,
+                "BETA": beta,
+                "ALPHA": alpha,
+                "DRAFT": draft,
+            },
+            "status": {"READY": 0, "DEMO": 0, "RESEARCH": 0, "BROKEN": 0},
+            "duration_s": duration,
+        }
+
+    def test_empty_list_returns_zeros(self):
+        result = build_aggregate([])
+        assert result["n_families"] == 0
+        assert result["totals"]["total"] == 0
+        assert result["totals"]["pass"] == 0
+        assert result["totals"]["pass_rate"] == 0.0
+        assert result["n_broken"] == 0
+        assert result["total_duration_s"] == 0.0
+
+    def test_single_family(self):
+        r = self._make_result(total=10, pass_count=8, warn=1, fail=1)
+        result = build_aggregate([r])
+        assert result["n_families"] == 1
+        assert result["totals"]["total"] == 10
+        assert result["totals"]["pass"] == 8
+        assert result["totals"]["warn"] == 1
+        assert result["totals"]["fail"] == 1
+        assert result["totals"]["pass_rate"] == 80.0
+
+    def test_multiple_families_sum(self):
+        r1 = self._make_result(total=10, pass_count=8, warn=1, fail=1, production=5, beta=3, alpha=1, draft=1)
+        r2 = self._make_result(total=5, pass_count=3, warn=1, fail=1, production=2, beta=1, alpha=1, draft=1)
+        result = build_aggregate([r1, r2])
+        assert result["n_families"] == 2
+        assert result["totals"]["total"] == 15
+        assert result["totals"]["pass"] == 11
+        assert result["totals"]["pass_rate"] == pytest.approx(73.3, abs=0.1)
+
+    def test_maturity_aggregation(self):
+        r1 = self._make_result(production=5, beta=3, alpha=1, draft=1)
+        r2 = self._make_result(production=2, beta=1, alpha=1, draft=1)
+        result = build_aggregate([r1, r2])
+        assert result["maturity"]["PRODUCTION"] == 7
+        assert result["maturity"]["BETA"] == 4
+        assert result["maturity"]["ALPHA"] == 2
+        assert result["maturity"]["DRAFT"] == 2
+
+    def test_broken_flattened(self):
+        r1 = self._make_result(broken=[{"path": "a.ipynb", "reason": "err"}])
+        r2 = self._make_result(broken=[
+            {"path": "b.ipynb", "reason": "err1"},
+            {"path": "c.ipynb", "reason": "err2"},
+        ])
+        result = build_aggregate([r1, r2])
+        assert result["n_broken"] == 3
+        assert len(result["broken"]) == 3
+        paths = [b["path"] for b in result["broken"]]
+        assert "a.ipynb" in paths
+        assert "b.ipynb" in paths
+        assert "c.ipynb" in paths
+
+    def test_pass_rate_calculation(self):
+        r = self._make_result(total=20, pass_count=15, warn=3, fail=2)
+        result = build_aggregate([r])
+        assert result["totals"]["pass_rate"] == 75.0
+
+    def test_pass_rate_rounded_to_one_decimal(self):
+        r = self._make_result(total=7, pass_count=3, warn=2, fail=2)
+        result = build_aggregate([r])
+        assert result["totals"]["pass_rate"] == pytest.approx(42.9, abs=0.1)
+
+    def test_total_duration_summed(self):
+        r1 = self._make_result(duration=3.2)
+        r2 = self._make_result(duration=4.8)
+        result = build_aggregate([r1, r2])
+        assert result["total_duration_s"] == 8.0
+
+    def test_missing_maturity_keys_tolerated(self):
+        """Family result missing some maturity keys should default to 0."""
+        r = self._make_result()
+        r["maturity"] = {"PRODUCTION": 5}  # Missing BETA, ALPHA, DRAFT
+        result = build_aggregate([r])
+        assert result["maturity"]["PRODUCTION"] == 5
+        assert result["maturity"]["BETA"] == 0
+        assert result["maturity"]["ALPHA"] == 0
+        assert result["maturity"]["DRAFT"] == 0
+
+    def test_no_broken_entries(self):
+        r = self._make_result(broken=[])
+        result = build_aggregate([r])
+        assert result["n_broken"] == 0
+        assert result["broken"] == []
+
+    def test_zero_total_gives_zero_pass_rate(self):
+        """Edge case: family with total=0."""
+        r = self._make_result(total=0, pass_count=0, warn=0, fail=0)
+        result = build_aggregate([r])
+        assert result["totals"]["pass_rate"] == 0.0
+
+    def test_all_pass_gives_100_rate(self):
+        r = self._make_result(total=10, pass_count=10, warn=0, fail=0)
+        result = build_aggregate([r])
+        assert result["totals"]["pass_rate"] == 100.0
+
+    def test_duration_rounded_to_one_decimal(self):
+        r1 = self._make_result(duration=3.14159)
+        r2 = self._make_result(duration=2.71828)
+        result = build_aggregate([r1, r2])
+        assert result["total_duration_s"] == 5.9


### PR DESCRIPTION
## Summary

Add 40 tests covering the 3 pure functions of `scripts/validation/dispatch.py` (reusable per-family notebook validation CLI, LIVE in `docs/scripts-reference.md`).

### Functions tested

| Function | Tests | Branches covered |
|----------|-------|-----------------|
| `_worst_severity(issues)` | 10 | empty, error, warning, info, priority ordering, mixed |
| `_classify_maturity(struct, issues)` | 17 | DRAFT (5 entry paths), ALPHA (3), BETA (3), PRODUCTION (4), edges (2) |
| `build_aggregate(all_results)` | 13 | empty, single, multi-family sum, maturity agg, broken flatten, pass_rate, rounding, tolerance for missing keys |

### Validation

```
40 passed in 1.72s
```

### Context

- Cycle 90 backlog pickup (no new coordinator dispatch)
- `dispatch.py` confirmed LIVE: referenced in `docs/scripts-reference.md`, reads `matrix.yml`, uses `notebook_tools.NotebookValidator`
- Dead-code lesson applied: skipped `fix_csp9_abt.py` (one-shot, 0 callers outside itself)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>