### PR TITLE
enrich(search,sudoku): add pedagogical conclusions to 3 Python notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-4-JobShopScheduling.ipynb
@@ -2694,6 +2694,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "410f14fd",
+   "source": "## Conclusion\n\nCe notebook a explore le **Job-Shop Scheduling Problem (JSSP)**, l'un des problemes combinatoires les plus etudies en recherche operationnelle, en suivant une progression pedagogique des heuristiques simples vers la resolution exacte.\n\n### Concepts cles a retenir\n\n| Concept | Role dans le JSSP |\n|---------|-------------------|\n| **Makespan** | Objectif principal : minimiser le temps d'achevement de la derniere operation |\n| **Dispatching rules** (SPT, LPT, MOR, FIFO) | Heuristiques instantanees mais sans garantie d'optimalite |\n| **Variables d'intervalle** | Representation native (start, duration, end) dans CP-SAT pour les taches |\n| **Contrainte NoOverlap** | Garantit qu'une machine ne traite qu'une operation a la fois |\n| **Borne inferieure** | max(longueur du job le plus long, charge de la machine la plus chargee) |\n| **Multi-objectif** | Compromis entre makespan et retard total via ponderation |\n\n### Enseignements principaux\n\n1. **Les heuristiques sont rapides mais approximatives** : les dispatching rules produisent une solution en moins d'une milliseconde, mais avec un ecart de 10 a 60% par rapport a l'optimal.\n2. **CP-SAT est remarquablement performant** : grace aux variables d'intervalle et a la propagation avancee (theta-tree, edge finding), le solveur trouve l'optimal en quelques millisecondes sur les petites instances.\n3. **Le multi-objectif change la nature du probleme** : il n'existe pas de solution unique optimale pour tous les criteres ; le front de Pareto offre les compromis possibles.\n4. **La modelisation declarative est un atout** : le modele CP-SAT se concentre sur le \"quoi\" (contraintes) plutot que le \"comment\" (algorithme de recherche).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-s7-next",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
+++ b/MyIA.AI.Notebooks/Search/PyGad-EdgeDetection.ipynb
@@ -1859,6 +1859,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3f9ba5b7",
+   "source": "## Resume des apprentissages\n\nCe TP a illustre comment les **algorithmes genetiques** peuvent optimiser automatiquement un filtre convolutif de detection de bords, en utilisant la bibliotheque PyGAD.\n\n### Concepts cles abordes\n\n| Concept | Mise en oeuvre dans le TP |\n|---------|--------------------------|\n| **Chromosome** | Ensemble de 20 genes (matrices 7x7) dont la somme forme le filtre convolutif |\n| **Fonction de fitness** | Correlation normalisee avec le filtre Sobel de reference, penalisee par la somme des coefficients |\n| **Selection steady-state** | Les meilleurs individus sont conserves d'une generation a l'autre |\n| **Croisement uniforme** | Chaque gene est echange independamment entre les deux parents |\n| **Mutation aleatoire** | 10% des genes sont modifies aleatoirement pour maintenir la diversite |\n| **Convergence progressive** | L'evolution ameliore iterativement le filtre sur 100 generations |\n\n### Points essentiels a retenir\n\n1. **La representation du probleme est cruciale** : decomposer le filtre en sous-matrices (genes) permet une evolution progressive et une exploration plus efficace de l'espace des solutions.\n2. **La fonction de fitness guide l'evolution** : la combinaison de correlation et de penalisation evite les solutions triviales (filtre uniforme) tout en ciblant le resultat souhaite.\n3. **Les operateurs genetiques sont configurables** : le choix de la selection, du croisement et de la mutation influence directement la qualite et la vitesse de convergence.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "zmavnksyb4p",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -2586,6 +2586,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9754859f",
+   "source": "## Conclusion\n\nCe notebook a compare **4 solveurs Python** representatifs de paradigmes algorithmiques distincts pour la resolution du Sudoku.\n\n### Concepts cles a retenir\n\n| Concept | Solveur(s) concerne(s) | Idee principale |\n|---------|----------------------|-----------------|\n| Recherche exhaustive | Backtracking simple | Explorer systematiquement l'arbre des possibilites |\n| Heuristique MRV | BT + MRV | Choisir la variable la plus contrainte pour detecter les impasses plus tot |\n| Propagation de contraintes | Norvig | Eliminer les valeurs impossibles avant la recherche |\n| Programmation par contraintes | OR-Tools CP-SAT | Declarer les contraintes, laisser le solveur trouver la solution |\n| Forward checking | Norvig + FC | Verifier la coherence des domaines apres chaque assignation |\n\n### Enseignements principaux\n\n1. **La propagation domine** : le solveur Norvig resout la majorite des puzzles sans aucun backtracking, confirmant que reduire l'espace de recherche est plus efficace que d'explorer plus intelligemment.\n2. **Les heuristiques comptent** : MRV divise le nombre d'appels recursifs par 4 a 1000x selon la difficulte du puzzle, pour un surcout constant par appel.\n3. **La previsibilite est cruciale** : en production, un solveur rapide mais imprevisible (backtracking) est souvent moins desirable qu'un solveur legerement plus lent mais constant (CP-SAT).\n4. **La difficulte n'est pas monotone** : le nombre de cases vides ne predit pas la difficulte algorithmique. La structure des contraintes importe davantage.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cc9jfr0kb",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Add conclusion cells to 3 Python notebooks that had complete outputs but lacked a conclusion section, blocking their promotion from BETA to PRODUCTION maturity.

## Notebooks modified (3)

| Notebook | Series | Change |
|----------|--------|--------|
|  | Search | Added concepts table (chromosome, fitness, selection, crossover, mutation, convergence) + 3 key takeaways |
|  | Search/CSP | Added concepts table (makespan, dispatching, interval vars, NoOverlap, lower bound, multi-objective) + 4 lessons |
|  | Sudoku | Added concepts table (exhaustive search, MRV, constraint propagation, CP-SAT, forward checking) + 4 lessons |

## Validation

- **Markdown-only changes** — no code cells modified, existing outputs preserved
- **C.2 exception** — markdown-only edits do not require re-execution
- **0 errors, 0 NotImplementedError** in all notebooks
- **Pedagogical content** — each conclusion is specific to the notebook's topic

## Catalog impact

Expected promotion: 3 notebooks BETA -> PRODUCTION (subject to catalog heuristic).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>