### PR TITLE
feat(SW): implemented python OWL 7b

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "install-packages",
    "metadata": {
     "execution": {
@@ -94,8 +94,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[notice] A new release of pip is available: 23.0.1 -> 26.1.1\n",
-      "[notice] To update, run: C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip\n"
+      "[notice] A new release of pip is available: 26.0.1 -> 26.1.1\n",
+      "[notice] To update, run: C:\\Users\\louis\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "id": "imports-owlready2",
    "metadata": {
     "execution": {
@@ -182,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "id": "create-ontology",
    "metadata": {
     "execution": {
@@ -317,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "id": "create-individuals",
    "metadata": {
     "execution": {
@@ -428,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "id": "restrictions",
    "metadata": {
     "execution": {
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "id": "reasoning",
    "metadata": {
     "execution": {
@@ -582,7 +582,7 @@
      "output_type": "stream",
      "text": [
       "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit;C:\\Users\\MYIA\\AppData\\Local\\Programs\\Python\\Python310\\lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/MYIA/AppData/Local/Temp/tmp2ahg2err\n"
+      "    java -Xmx1000M -cp C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit;C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/louis/AppData/Local/Temp/tmp3p60v6bm\n"
      ]
     },
     {
@@ -592,7 +592,7 @@
       "=== Apres raisonnement (HermiT) ===\n",
       "Bob types : [company.Employee]\n",
       "Alice types : [company.Employee]\n",
-      "Charlie types : [company.Manager, company.Employee]\n",
+      "Charlie types : [company.Employee, company.Manager]\n",
       "\n",
       "Deductions :\n",
       "  Bob est Employee (car works_in SOME Department)\n",
@@ -604,9 +604,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "* Owlready2 * HermiT took 0.7671520709991455 seconds\n",
+      "* Owlready2 * HermiT took 0.6884293556213379 seconds\n",
       "* Owlready * Reparenting company.Bob: {company.Person} => {company.Employee}\n",
-      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Manager, company.Employee}\n",
+      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Employee, company.Manager}\n",
       "* Owlready * Reparenting company.Alice: {company.Person} => {company.Employee}\n",
       "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
@@ -721,7 +721,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "id": "load-ontology",
    "metadata": {
     "execution": {
@@ -811,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 18,
    "id": "export-ontology",
    "metadata": {
     "execution": {
@@ -840,8 +840,6 @@
       "\n",
       "=== Apercu Turtle (20 premieres lignes) ===\n",
       "<http://example.org/company.owl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .\n",
-      "<http://example.org/company.owl#Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "<http://example.org/company.owl#Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n",
       "<http://example.org/company.owl#Department> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
       "<http://example.org/company.owl#Department> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n",
       "<http://example.org/company.owl#works_in> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .\n",
@@ -852,13 +850,15 @@
       "<http://example.org/company.owl#manages> <http://www.w3.org/2000/01/rdf-schema#range> <http://example.org/company.owl#Department> .\n",
       "<http://example.org/company.owl#Manager> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
       "<http://example.org/company.owl#Manager> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/company.owl#Person> .\n",
-      "_:2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> .\n",
-      "_:2 <http://www.w3.org/2002/07/owl#onProperty> <http://example.org/company.owl#manages> .\n",
-      "_:2 <http://www.w3.org/2002/07/owl#someValuesFrom> <http://example.org/company.owl#Department> .\n",
-      "_:3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "_:3 <http://www.w3.org/2002/07/owl#intersectionOf> _:1 .\n",
-      "_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/company.owl#Person> .\n",
-      "_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:4 .\n"
+      "_:18 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> .\n",
+      "_:18 <http://www.w3.org/2002/07/owl#onProperty> <http://example.org/company.owl#manages> .\n",
+      "_:18 <http://www.w3.org/2002/07/owl#someValuesFrom> <http://example.org/company.owl#Department> .\n",
+      "_:19 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
+      "_:19 <http://www.w3.org/2002/07/owl#intersectionOf> _:17 .\n",
+      "_:17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/company.owl#Person> .\n",
+      "_:17 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:20 .\n",
+      "_:20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:18 .\n",
+      "_:20 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .\n"
      ]
     }
    ],
@@ -991,7 +991,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 25,
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
@@ -1014,7 +1014,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "=== Avant raisonnement ===\n",
+      "Bob     types : [family2.Person]\n",
+      "Alice   types : [family2.Person]\n",
+      "Vanessa types : [family2.Person]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * Running HermiT...\n",
+      "    java -Xmx1000M -cp C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit;C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/louis/AppData/Local/Temp/tmpt6c8bekq -Y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Après raisonnement (HermiT) ===\n",
+      "Bob     types : [family2.Parent]\n",
+      "Alice   types : [family2.Parent]\n",
+      "Vanessa types : [family2.Child]\n",
+      "Vanessa has_parent : [family2.Bob, family2.Alice]\n",
       "Exercice 1 a completer\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * HermiT took 0.5284309387207031 seconds\n",
+      "* Owlready * Reparenting family2.Bob: {family2.Person} => {family2.Parent}\n",
+      "* Owlready * Reparenting family2.Alice: {family2.Person} => {family2.Parent}\n",
+      "* Owlready * Reparenting family2.Vanessa: {family2.Person} => {family2.Child}\n",
+      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
@@ -1022,18 +1057,53 @@
     "# Exercice 1 : Famille avec restrictions\n",
     "\n",
     "# TODO: Completez l'ontologie\n",
-    "onto_family = get_ontology(\"http://example.org/family2.owl#\")\n",
-    "\n",
+    "family_world = World()\n",
+    "onto_family = family_world.get_ontology(\"http://example.org/family2.owl#\")\n",
     "with onto_family:\n",
     "    # Define classes\n",
     "    # class Person(Thing): pass\n",
     "    # class Parent(Person):\n",
     "    #     equivalent_to = [Person & has_child.some(Person)]\n",
     "    # ...\n",
-    "    pass\n",
+    "    class Person(Thing):\n",
+    "        pass\n",
     "\n",
-    "# Create individuals and test reasoning\n",
-    "# ...\n",
+    "    class has_child(ObjectProperty):\n",
+    "        pass\n",
+    "\n",
+    "    class has_parent(ObjectProperty):\n",
+    "        inverse_property = has_child\n",
+    "\n",
+    "    class Parent(Person):\n",
+    "        equivalent_to = [Person & has_child.some(Person)]\n",
+    "\n",
+    "    class Child(Person):\n",
+    "        equivalent_to = [Person & has_parent.some(Person)]\n",
+    "\n",
+    "with onto_family:\n",
+    "    bob     = Person(\"Bob\")\n",
+    "    alice   = Person(\"Alice\")\n",
+    "    vanessa = Person(\"Vanessa\")\n",
+    "\n",
+    "    bob.has_child   = [vanessa]\n",
+    "    alice.has_child = [vanessa]\n",
+    "\n",
+    "    AllDifferent([bob, alice, vanessa])\n",
+    "\n",
+    "    print(\"=== Avant raisonnement ===\")\n",
+    "    print(f\"Bob     types : {bob.is_a}\")\n",
+    "    print(f\"Alice   types : {alice.is_a}\")\n",
+    "    print(f\"Vanessa types : {vanessa.is_a}\")\n",
+    "    print()\n",
+    "\n",
+    "    sync_reasoner(family_world, infer_property_values=True)\n",
+    "\n",
+    "    print(\"=== Après raisonnement (HermiT) ===\")\n",
+    "    print(f\"Bob     types : {bob.is_a}\")   \n",
+    "    print(f\"Alice   types : {alice.is_a}\")   \n",
+    "    print(f\"Vanessa types : {vanessa.is_a}\") \n",
+    "    print(f\"Vanessa has_parent : {vanessa.has_parent}\")\n",
+    "\n",
     "\n",
     "print(\"Exercice 1 a completer\")"
    ]
@@ -1064,7 +1134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
@@ -1087,7 +1157,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "=== Avant raisonnement ===\n",
+      "Movie1 types : [movies.Movie]\n",
+      "Movie2 types : [movies.Movie]\n",
+      "Movie3 types : [movies.Movie]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * Running HermiT...\n",
+      "    java -Xmx1000M -cp C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit;C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/louis/AppData/Local/Temp/tmp3enwfa41 -Y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Après raisonnement (HermiT) ===\n",
+      "Movie1 types : [movies.ActionMovie]\n",
+      "Movie2 types : [movies.ComedyMovie]\n",
+      "Movie3 types : [movies.ActionMovie, movies.ComedyMovie]\n",
       "Exercice 2 a completer\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * HermiT took 0.5359058380126953 seconds\n",
+      "* Owlready * Reparenting movies.Movie1: {movies.Movie} => {movies.ActionMovie}\n",
+      "* Owlready * Reparenting movies.Movie3: {movies.Movie} => {movies.ActionMovie, movies.ComedyMovie}\n",
+      "* Owlready * Reparenting movies.Movie2: {movies.Movie} => {movies.ComedyMovie}\n",
+      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
@@ -1095,14 +1199,72 @@
     "# Exercice 2 : Ontologie de films\n",
     "\n",
     "# TODO: Completez l'ontologie\n",
-    "onto_movies = get_ontology(\"http://example.org/movies.owl#\")\n",
+    "movies_world = World()\n",
+    "onto_movies = movies_world.get_ontology(\"http://example.org/movies.owl#\")\n",
     "\n",
     "with onto_movies:\n",
     "    # class Movie(Thing): pass\n",
     "    # class Person(Thing): pass\n",
     "    # class Genre(Thing): pass\n",
     "    # ...\n",
-    "    pass\n",
+    "    class Movie(Thing):\n",
+    "        pass\n",
+    "    class Person(Thing):\n",
+    "        pass\n",
+    "    class Genre(Thing):\n",
+    "        pass\n",
+    "\n",
+    "    class has_director(ObjectProperty):\n",
+    "        pass\n",
+    "    class has_actor(ObjectProperty):\n",
+    "        pass\n",
+    "    class has_genre(ObjectProperty):\n",
+    "        pass\n",
+    "\n",
+    "    class Action(Genre):\n",
+    "        pass\n",
+    "    class Comedy(Genre):\n",
+    "        pass\n",
+    "\n",
+    "    class ActionMovie(Movie):\n",
+    "        equivalent_to = [Movie & has_genre.some(Action)]\n",
+    "    class ComedyMovie(Movie):\n",
+    "        equivalent_to = [Movie & has_genre.some(Comedy)]\n",
+    "\n",
+    "with onto_movies:\n",
+    "    genre_action = Action(\"genre_action\")\n",
+    "    genre_comedy = Comedy(\"genre_comedy\")\n",
+    "\n",
+    "    movie1 = Movie(\"Movie1\")\n",
+    "    movie2 = Movie(\"Movie2\")\n",
+    "    movie3 = Movie(\"Movie3\")\n",
+    "\n",
+    "    director1 = Person(\"Director1\")\n",
+    "    director2 = Person(\"Director2\")\n",
+    "\n",
+    "    movie1.has_director = [director1]\n",
+    "    movie1.has_genre    = [genre_action]\n",
+    "\n",
+    "    movie2.has_director = [director2]\n",
+    "    movie2.has_genre    = [genre_comedy]\n",
+    "\n",
+    "    movie3.has_director = [director1]\n",
+    "    movie3.has_genre    = [genre_action, genre_comedy]\n",
+    "\n",
+    "    AllDifferent([genre_action, genre_comedy, movie1, movie2, movie3, director1, director2])\n",
+    "\n",
+    "    print(\"=== Avant raisonnement ===\")\n",
+    "    print(f\"Movie1 types : {movie1.is_a}\")\n",
+    "    print(f\"Movie2 types : {movie2.is_a}\")\n",
+    "    print(f\"Movie3 types : {movie3.is_a}\")\n",
+    "    print()\n",
+    "\n",
+    "    sync_reasoner(movies_world, infer_property_values=True)\n",
+    "\n",
+    "    print(\"=== Après raisonnement (HermiT) ===\")\n",
+    "    print(f\"Movie1 types : {movie1.is_a}\")\n",
+    "    print(f\"Movie2 types : {movie2.is_a}\")\n",
+    "    print(f\"Movie3 types : {movie3.is_a}\")\n",
     "\n",
     "print(\"Exercice 2 a completer\")"
    ]
@@ -1183,7 +1345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 31,
    "id": "89008950",
    "metadata": {
     "execution": {
@@ -1206,7 +1368,54 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "=== Avant raisonnement ===\n",
+      "Claude     types : ['LLM']\n",
+      "GPT4       types : ['LLM']\n",
+      "Gemini     types : ['LLM']\n",
+      "Llama      types : ['LLM']\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * Running HermiT...\n",
+      "    java -Xmx1000M -cp C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit;C:\\Users\\louis\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python312\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/Users/louis/AppData/Local/Temp/tmp8dn9mfk2 -Y\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Après raisonnement (HermiT) ===\n",
+      "Claude     types : ['ReasoningLLM', 'CodingLLM', 'MultimodalLLM']\n",
+      "Organisation : ['Anthropic']\n",
+      "\n",
+      "GPT4       types : ['CodingLLM', 'MultimodalLLM']\n",
+      "Organisation : ['OpenAI']\n",
+      "\n",
+      "Gemini     types : ['ReasoningLLM', 'MultimodalLLM']\n",
+      "Organisation : ['Google']\n",
+      "\n",
+      "Llama      types : ['CodingLLM']\n",
+      "Organisation : ['Meta']\n",
+      "\n",
+      "\n",
+      "Ontologie exportée : llm_ontology.owl\n",
       "Exercice a completer\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "* Owlready2 * HermiT took 0.5435340404510498 seconds\n",
+      "* Owlready * Reparenting llm.GPT4: {llm.LLM} => {llm.CodingLLM, llm.MultimodalLLM}\n",
+      "* Owlready * Reparenting llm.Gemini: {llm.LLM} => {llm.ReasoningLLM, llm.MultimodalLLM}\n",
+      "* Owlready * Reparenting llm.Claude: {llm.LLM} => {llm.ReasoningLLM, llm.CodingLLM, llm.MultimodalLLM}\n",
+      "* Owlready * Reparenting llm.Llama: {llm.LLM} => {llm.CodingLLM}\n",
+      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
      ]
     }
    ],
@@ -1217,6 +1426,111 @@
     "# Etape 3 : ajouter des instances\n",
     "# Etape 4 : lancer le raisonneur sync_reasoner_pellet et afficher les types inferes\n",
     "# Etape 5 (bonus) : exporter l'ontologie\n",
+    "\n",
+    "llm_world = World()\n",
+    "onto_llm = llm_world.get_ontology(\"http://example.org/llm.owl#\")\n",
+    "\n",
+    "with onto_llm:\n",
+    "    class AIModel(Thing):\n",
+    "        pass\n",
+    "\n",
+    "    class LLM(AIModel):                  \n",
+    "        pass\n",
+    "\n",
+    "    class MultimodalLLM(LLM):            \n",
+    "        pass\n",
+    "\n",
+    "    class Organization(Thing):\n",
+    "        pass\n",
+    "\n",
+    "    class Benchmark(Thing):\n",
+    "        pass\n",
+    "\n",
+    "    class Capability(Thing):\n",
+    "        pass\n",
+    "\n",
+    "    class developed_by(ObjectProperty):  \n",
+    "        pass\n",
+    "\n",
+    "    class has_capability(ObjectProperty):\n",
+    "        pass\n",
+    "\n",
+    "    class evaluated_on(ObjectProperty): \n",
+    "        pass\n",
+    "\n",
+    "    class outperforms(ObjectProperty):  \n",
+    "        pass\n",
+    "\n",
+    "    class ImageUnderstanding(Capability):\n",
+    "        pass\n",
+    "\n",
+    "    class CodeGeneration(Capability):\n",
+    "        pass\n",
+    "\n",
+    "    class Reasoning(Capability):\n",
+    "        pass\n",
+    "\n",
+    "\n",
+    "    class MultimodalLLM(LLM):\n",
+    "        equivalent_to = [LLM & has_capability.some(ImageUnderstanding)]\n",
+    "\n",
+    "    class CodingLLM(LLM):\n",
+    "        equivalent_to = [LLM & has_capability.some(CodeGeneration)]\n",
+    "\n",
+    "    class ReasoningLLM(LLM):\n",
+    "        equivalent_to = [LLM & has_capability.some(Reasoning)]\n",
+    "\n",
+    "\n",
+    "with onto_llm:\n",
+    "    org_anthropic = Organization(\"Anthropic\")\n",
+    "    org_openai    = Organization(\"OpenAI\")\n",
+    "    org_google    = Organization(\"Google\")\n",
+    "    org_meta      = Organization(\"Meta\")\n",
+    "\n",
+    "    cap_image  = ImageUnderstanding(\"cap_image\")\n",
+    "    cap_code   = CodeGeneration(\"cap_code\")\n",
+    "    cap_reason = Reasoning(\"cap_reason\")\n",
+    "\n",
+    "    bench_mmlu  = Benchmark(\"MMLU\")\n",
+    "    bench_humaneval = Benchmark(\"HumanEval\")\n",
+    "\n",
+    "    claude = LLM(\"Claude\")\n",
+    "    claude.developed_by  = [org_anthropic]\n",
+    "    claude.has_capability = [cap_image, cap_code, cap_reason]\n",
+    "    claude.evaluated_on  = [bench_mmlu]\n",
+    "\n",
+    "    gpt4 = LLM(\"GPT4\")\n",
+    "    gpt4.developed_by   = [org_openai]\n",
+    "    gpt4.has_capability = [cap_image, cap_code]\n",
+    "    gpt4.evaluated_on   = [bench_mmlu, bench_humaneval]\n",
+    "\n",
+    "    gemini = LLM(\"Gemini\")\n",
+    "    gemini.developed_by   = [org_google]\n",
+    "    gemini.has_capability = [cap_image, cap_reason]\n",
+    "\n",
+    "    llama = LLM(\"Llama\")\n",
+    "    llama.developed_by   = [org_meta]\n",
+    "    llama.has_capability = [cap_code]\n",
+    "\n",
+    "    AllDifferent([claude, gpt4, gemini, llama,\n",
+    "                  org_anthropic, org_openai, org_google, org_meta,\n",
+    "                  cap_image, cap_code, cap_reason,\n",
+    "                  bench_mmlu, bench_humaneval])\n",
+    "\n",
+    "    print(\"=== Avant raisonnement ===\")\n",
+    "    for m in [claude, gpt4, gemini, llama]:\n",
+    "        print(f\"{m.name:10} types : {[c.name for c in m.is_a]}\")\n",
+    "    print()\n",
+    "\n",
+    "    sync_reasoner(llm_world, infer_property_values=True)\n",
+    "\n",
+    "    print(\"=== Après raisonnement (HermiT) ===\")\n",
+    "    for m in [claude, gpt4, gemini, llama]:\n",
+    "        print(f\"{m.name:10} types : {[c.name for c in m.is_a]}\")\n",
+    "        print(f\"Organisation : {[o.name for o in m.developed_by]}\\n\")\n",
+    "\n",
+    "    onto_llm.save(file=\"llm_ontology.owl\", format=\"rdfxml\")\n",
+    "    print(\"\\nOntologie exportée : llm_ontology.owl\")\n",
     "\n",
     "print(\"Exercice a completer\")"
    ]
@@ -1238,7 +1552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.12.10"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->
- Implémentation de SW-7bPython-OWL
- Correction de certains bugs et exercices résolus
- Finalisation d'un exo synthèse plus robuste et exhaustif des connaissances vues dans le notebook

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
