### PR TITLE
feat(prover): add aesop tactic to harness heuristics (Epic #1468 Lever 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -618,14 +618,17 @@ class TacticTools:
             self._original_content = raw
 
         self._heuristics = {
-            "equality": ["rfl", "exact", "simp", "ring", "omega"],
-            "nat_arithmetic": ["omega", "simp", "decide"],
+            "equality": ["rfl", "exact", "simp", "ring", "omega", "aesop"],
+            "nat_arithmetic": ["omega", "simp", "decide", "aesop"],
             "ring_expression": ["ring", "ring_nf"],
             "forall": ["intro", "intros", "apply"],
             "exists": ["use", "exists", "exact"],
             "and": ["constructor", "exact And.intro"],
             "or": ["left", "right"],
             "implication": ["intro", "apply", "exact"],
+            "lattice": ["aesop", "exact bot_le", "exact le_top", "simp"],
+            "type_class": ["aesop", "infer_instance", "apply_instance"],
+            "sieve": ["aesop", "exact", "simp", "ext"],
         }
 
     def _check_tool_loop(self, tool_name: str, args_key: str) -> Optional[str]:
@@ -682,6 +685,16 @@ class TacticTools:
             detected.append("forall")
         if "exists" in goal_lower or "∃" in goal:
             detected.append("exists")
+        if any(x in goal_lower for x in ["≤", "<=", "≥", ">=", "lattice",
+                                           "bot", "top", "complete_lattice",
+                                           "grothendieck", "topology"]):
+            detected.append("lattice")
+        if any(x in goal_lower for x in ["instance", "infer_instance",
+                                           "category", "functor", "monad"]):
+            detected.append("type_class")
+        if any(x in goal_lower for x in ["sieve", "presieve", "sheaf",
+                                           "covering", "pullback"]):
+            detected.append("sieve")
 
         seen = set()
         for pattern in detected:
@@ -699,6 +712,7 @@ class TacticTools:
                 {"tactic": "rfl", "confidence": 0.3, "pattern": "default"},
                 {"tactic": "simp", "confidence": 0.3, "pattern": "default"},
                 {"tactic": "omega", "confidence": 0.3, "pattern": "default"},
+                {"tactic": "aesop", "confidence": 0.25, "pattern": "default"},
             ]
 
         return json.dumps(suggestions, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Add `aesop` (Automated Extensible Search for Ongoing Proofs) to the Lean prover harness tactic generation pipeline (Epic #1468, Lever 2).

### Changes

**`agent_tests/prover/tools.py`** — TacticTools.\_\_init\_\_ and generate\_tactics:

1. **Added `aesop` to existing heuristic categories**:
   - `equality`: `rfl, exact, simp, ring, omega, aesop`
   - `nat_arithmetic`: `omega, simp, decide, aesop`
   - Default fallback: `rfl, simp, omega, aesop`

2. **Added 3 new heuristic categories** for category-theory/lattice goals:
   - `lattice`: `aesop, exact bot_le, exact le_top, simp`
   - `type_class`: `aesop, infer_instance, apply_instance`
   - `sieve`: `aesop, exact, simp, ext`

3. **Added goal-pattern detection** for new categories:
   - Lattice: detects `≤`, `≥`, `bot`, `top`, `grothendieck`, `topology`
   - Type class: detects `instance`, `infer_instance`, `category`, `functor`
   - Sieve: detects `sieve`, `presieve`, `sheaf`, `covering`, `pullback`

### Evidence

`aesop` automatically solves Grothendieck calibration targets:
- **P1** `trivial_le_discrete` (`bot_le` via lattice reasoning) ✅
- **P2** `pullback_top` (Sieve.pullback of ⊤ = ⊤) ✅

Both tested via `lake env lean` with Mathlib v4.30.0-rc2.

### Scope

- Python-only change (`tools.py` — 16 insertions, 2 deletions)
- No .lean file modifications
- No new dependencies (`aesop` already in Lake manifest via Mathlib)

### Related

- Epic #1468 (SOTA prover)
- Epic #1453 (prover harness)
- Calibration targets: `grothendieck_lean/Grothendieck/Calibration.lean`
- `docs/lean/sota-2026-analysis.md` (15 SOTA systems, Lever 2 = aesop+lean-smt)