### PR TITLE
feat(prover): fix multi-workspace LSP premise retrieval (Epic #1468 Lever 1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -344,8 +344,15 @@ class LeanVerifier:
             f"  {tactic}\n"
         )
 
-        tmp_file = project / "SocialChoice" / "_LeanSearch.lean"
-        if not (project / "SocialChoice").exists():
+        # Derive temp file from module_name (e.g. "Grothendieck.Calibration"
+        # -> project/Grothendieck/_LeanSearch.lean). Falls back to scanning
+        # subdirectories if the derived path doesn't exist.
+        module_parts = module_name.split(".")
+        if len(module_parts) > 1:
+            tmp_file = project / module_parts[0] / "_LeanSearch.lean"
+        else:
+            tmp_file = project / "SocialChoice" / "_LeanSearch.lean"
+        if not tmp_file.parent.exists():
             for subdir in project.iterdir():
                 if subdir.is_dir() and (subdir / "lakefile.lean").exists():
                     continue

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/tools.py
@@ -422,7 +422,8 @@ class SearchTools:
             project_dir = str(Path(self._filepath).parent.parent)
             verifier = get_verifier(project_dir)
             subdir = Path(self._filepath).parent.name
-            module_name = f"{subdir}"
+            stem = Path(self._filepath).stem
+            module_name = f"{subdir}.{stem}"
 
             results = []
             for tactic in ["exact?", "apply?"]:


### PR DESCRIPTION
## Summary

Fix two bugs in the `exact?`/`apply?` premise-retrieval pipeline (Epic #1468 Lever 1) that prevented LSP search from working on non-SocialChoice Lean workspaces.

### Changes

**`lean_server.py` - `search_lean()` temp-file derivation:**
- Before: hardcoded `project / "SocialChoice" / "_LeanSearch.lean"` with fallback scanning
- After: derives path from `module_name` parts (e.g. `Grothendieck.Calibration` -> `Grothendieck/_LeanSearch.lean`), then falls back to scanning only if the derived dir doesn't exist

**`tools.py` - `_search_via_lsp()` module_name:**
- Before: `module_name = f"{subdir}"` -> `import Grothendieck` (fails if no `Grothendieck.lean` root)
- After: `module_name = f"{subdir}.{stem}"` -> `import Grothendieck.Calibration` (correct dotted import)

### Lever 1 Calibration Results

Tested `exact?` and `apply?` on all 4 Grothendieck calibration targets:

| Target | `exact?` | `apply?` | Found lemma |
|--------|----------|----------|-------------|
| P1: trivial <= discrete | HIT | HIT | `GrothendieckTopology.le_def.mpr ...` |
| P2: Sieve.pullback top = top | HIT | HIT | `Sieve.pullback_top` |
| P3: zariskiTopology_eq | HIT | HIT | `Scheme.zariskiTopology_eq` |
| P4: IsSheaf bot | HIT | HIT | `Presieve.isSheaf_bot` |

**Hit-rate: 4/4 = 100%** (both `exact?` and `apply?`)

### Test plan
- [x] Python syntax validated for both files
- [x] Manual lake build test of all 4 targets with `exact?`/`apply?`
- [ ] CI (existing prover tests should pass unchanged)

### Files changed
- `agent_tests/lean_server.py` (temp-file path derivation)
- `agent_tests/prover/tools.py` (module_name fix)