### PR TITLE
enrich(symbolicai): add conclusions to 5 Python notebooks (Lean + Tweety)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -1720,6 +1720,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## Conclusion\n\nCe notebook a configure l'ensemble de la chaine d'outils necessaire pour travailler avec Lean 4 dans Jupyter : **elan** (gestionnaire de versions), **Lean 4** (proof assistant et langage fonctionnel), **lean4_jupyter** (kernel Jupyter), et les kernels specialises **Lean 4 (WSL)** et **Python 3 (WSL)**. Le diagnostic automatise verifie chaque composant et l'installation automatique comble les lacunes detectees.\n\nL'environnement ainsi prepare couvre deux modes d'utilisation : les notebooks Lean natifs (Lean-2 a Lean-6) pour les preuves interactives via le kernel Lean, et les notebooks Python avec integration Lean (Lean-7 a Lean-15) pour les illustrations computationnelles et les approches hybrides LLM. L'exercice final (premier theoreme en Lean 4) valide concretement que la chaine elan + Lean + REPL fonctionne de bout en bout.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
@@ -1031,6 +1031,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## Conclusion\n\nLe theoreme de sensibilite de Huang (2019) resout une conjecture ouverte pendant 27 ans avec une preuve de 2 pages s'appuyant sur deux ingredients d'algebre lineaire : une **signing matrix** $A_n$ verifiant $A_n^2 = n \\cdot I$ et le **theoreme d'entrelacement de Cauchy**. Le resultat etablit que pour toute fonction booleenne $f$, la sensibilite locale $s(f)$ est bornee inferieurement par $\\sqrt{\\deg(f)}$, connectant proprietes locales et globales.\n\nLe port Lean 4 (~490 lignes, 0 sorry) decompose la preuve en quatre modules (Hypercube, VectorSpace, Operator, MainTheorem) et compile via `lake build` avec Mathlib comme unique dependance. Le theoreme eclaire egalement la robustesse des reseaux de neurones binarises (BNN) : tout BNN de degre polynomial $d$ possede au moins un point sensible a $\\sqrt{d}$ bits, ce qui complete les approches continues (IBP/CROWN) du notebook Lean-11 TorchLean.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 7. Pour aller plus loin\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
@@ -893,6 +893,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e587b1b5",
+   "source": "## Conclusion\n\nLe theoreme de Kochen-Specker (version Cabello, 18 vecteurs) demontre qu'aucune attribution non-contextuelle de valeurs 0/1 aux observables quantiques n'est possible. L'argument repose sur une structure combinatoire elegante : 18 vecteurs de R^4 organises en 9 bases orthogonales, chaque vecteur appartenant a exactement 2 bases. L'impossibilite resulte d'un simple argument de parite -- 9 (impair) ne peut pas egaler 2k (pair) -- confirme par recherche exhaustive sur les 262 144 colorations possibles.\n\nLe port Lean 4 dans `conway_lean/Conway/KochenSpecker.lean` formalise cet argument et constitue le Pilier 1 du theoreme de libre arbitre de Conway-Kochen (Epic #1651). Les Piliers 2 et 3 (axiomes SPIN, TWIN, MIN et theoreme principal) s'appuieront sur ce fondement combinatoire.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab8d7f98",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
@@ -1923,6 +1923,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ae99d752",
+   "source": "## Conclusion\n\nCe notebook a couvert huit extensions des frameworks de Dung, chacune apportant une capacite de modelisation specifique :\n\n1. **ADF** : conditions d'acceptation propositionnelles (solveur SAT natif requis)\n2. **Frameworks bipolaires** (Evidential vs Necessity) : relations de support disjonctif ou conjonctif\n3. **WAF** : poids sur les attaques avec seuils de tolerance alpha/gamma\n4. **SAF** : votes sociaux et propagation iteratrice de scores (ISS)\n5. **SetAF** : attaques collectives (un ensemble attaque un argument)\n6. **EAF/REAF** : meta-attaques recursives (attaquer une attaque)\n\nCes extensions ne sont pas mutuellement exclusives : un framework peut combiner poids, supports et attaques collectives. Leur richness reflete la complexite des debats reels ou les arguments interagissent selon des modalites multiples (force, evidence, consensus, dependance).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "7f9856bd",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
@@ -951,6 +951,12 @@
      ]
     }
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1664b5b4",
+   "source": "## Conclusion\n\nCe notebook a explore deux extensions majeures de l'argumentation au-dela du cadre binaire de Dung :\n\n1. **Semantiques de classement** (Categorizer, Burden-Based, Discussion-Based, Tuples, Counting, Propagation) qui produisent un ordre ou des scores continus sur les arguments, permettant de prioriser des options meme lorsque plusieurs arguments sont acceptes.\n\n2. **Argumentation probabiliste** qui modelise l'incertitude sur la structure du graphe lui-meme via des distributions sur les sous-graphes, des probabilites d'acceptabilite, et des loteries avec utilite attendue.\n\nLe lien entre ces deux approches est profond : les semantiques de classement fournissent des scores interpretables comme des degres de confiance, tandis que l'argumentation probabiliste ancre ces degres dans une theorie formelle de l'incertitude. Ensemble, elles permettent la prise de decision rationnelle dans des debats complexes ou les preuves sont incompletes ou contestables.",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add pedagogical conclusion cells to 5 SymbolicAI Python notebooks that had complete outputs but lacked a conclusion section, blocking their promotion from BETA to PRODUCTION maturity.

## Notebooks modified (5)

| Notebook | Sub-series | Change |
|----------|-----------|--------|
|  | Lean | Setup summary: elan, lake, Lean 4 toolchain, REPL |
|  | Lean | Sensitivity theorem key concepts |
|  | Lean | Kochen-Specker 18-vector Cabello, parity argument, link to Lean port Conway/KochenSpecker.lean (Epic #1651) |
|  | Tweety | Extended argumentation frameworks summary |
|  | Tweety | Ranking-based and probabilistic approaches |

## Validation

- Markdown-only changes, no code cells modified, existing outputs preserved
- C.2 exception applies (markdown-only edits)
- 0 errors, 0 NotImplementedError in all notebooks
- Each conclusion is specific and pedagogically relevant

## Catalog impact

Expected promotion: 5 notebooks BETA -> PRODUCTION (subject to catalog heuristic).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>