### PR TITLE
feat(iit): add PyPhi setup script (Python 3.9 conda env) + fix requirements

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -63,10 +63,14 @@ L'unique notebook couvre le spectre complet : construction de graphes causaux bi
 ### Environnement Python
 
 ```bash
-# Environnement conda recommande (Python 3.10+)
-conda create --name pyphi python=3.13 -y
+# Automated setup (creates conda env + registers kernel)
+powershell -File scripts/setup_pyphi_env.ps1
+
+# Manual setup (Python 3.9 required for PyPhi 1.2.0)
+conda create --name pyphi python=3.9 -y
 conda activate pyphi
-pip install pyphi numpy scipy
+pip install pyphi==1.2.0 numpy scipy ipykernel
+python -m ipykernel install --user --name pyphi --display-name "Python 3 (PyPhi/IIT)"
 ```
 
 ### Dependances
@@ -81,7 +85,7 @@ pip install pyphi numpy scipy
 
 | Probleme | Cause | Solution |
 |----------|-------|----------|
-| Conflits numpy/scipy | Rare (PyPhi 1.2.0 OK sur 3.13) | Utiliser Python 3.10+ |
+| `ImportError: cannot import name 'Iterable'` | PyPhi 1.2.0 utilise `collections.Iterable` (supprime Python 3.10+) | Utiliser Python 3.9 (`conda create -n pyphi python=3.9`) |
 | StateUnreachableError | Etats inaccessibles | Configuration `VALIDATE_SUBSYSTEM_STATES` |
 | Performance | Phi calcul intensif pour grands reseaux | Limiter taille des reseaux |
 

--- a/MyIA.AI.Notebooks/IIT/requirements.txt
+++ b/MyIA.AI.Notebooks/IIT/requirements.txt
@@ -1,14 +1,20 @@
 # IIT (Integrated Information Theory) - Dependencies
 # Install: pip install -r requirements.txt
 #
-# IMPORTANT: PyPhi requires Python 3.7-3.9 (incompatible with 3.10+)
-# Recommended setup:
-#   conda create --name pyphi python=3.7 -y
+# IMPORTANT: PyPhi 1.2.0 requires Python <=3.9
+# (collections.Iterable removed in Python 3.10)
+#
+# Recommended setup (automated):
+#   powershell -File scripts/setup_pyphi_env.ps1
+#
+# Manual setup:
+#   conda create -n pyphi python=3.9 -y
 #   conda activate pyphi
 #   pip install -r requirements.txt
 
 # Core
-pyphi>=1.2.0                 # IIT computation library
+pyphi==1.2.0                 # IIT computation library
 
 # Scientific
-numpy>=1.21,<1.22            # PyPhi requires numpy <1.22 on Python 3.7
+numpy>=1.21                  # Numerical computing
+scipy>=0.13.3                # Scientific computing

--- a/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.ps1
+++ b/MyIA.AI.Notebooks/IIT/scripts/setup_pyphi_env.ps1
@@ -1,0 +1,95 @@
+# Setup script for PyPhi conda environment (Python 3.9)
+# PyPhi 1.2.0 requires Python <=3.9 (collections.Iterable removed in 3.10)
+#
+# Usage: .\setup_pyphi_env.ps1
+#
+# Creates:
+#   - conda env 'pyphi' with Python 3.9
+#   - Jupyter kernel 'pyphi' (Python 3 - PyPhi/IIT)
+#
+# Prerequisites: conda (miniconda3 or anaconda)
+
+param(
+    [string]$EnvName = "pyphi",
+    [string]$PythonVersion = "3.9"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Setup PyPhi Environment ===" -ForegroundColor Green
+Write-Host "Env name: $EnvName"
+Write-Host "Python version: $PythonVersion"
+Write-Host ""
+
+# 1. Check conda is available
+$condaExe = Get-Command conda -ErrorAction SilentlyContinue
+if (-not $condaExe) {
+    # Try common miniconda3 paths
+    $condaPaths = @(
+        "C:\ProgramData\miniconda3\Scripts\conda.exe",
+        "$env:USERPROFILE\miniconda3\Scripts\conda.exe",
+        "$env:USERPROFILE\anaconda3\Scripts\conda.exe"
+    )
+    foreach ($p in $condaPaths) {
+        if (Test-Path $p) {
+            $condaExe = $p
+            break
+        }
+    }
+}
+
+if (-not $condaExe) {
+    Write-Host "ERROR: conda not found. Install miniconda3 first." -ForegroundColor Red
+    Write-Host "  https://docs.conda.io/en/latest/miniconda.html"
+    exit 1
+}
+
+Write-Host "[1/4] Using conda: $condaExe" -ForegroundColor Cyan
+
+# 2. Create conda env
+$envList = & $condaExe env list 2>$null
+if ($envList -match "$EnvName\s") {
+    Write-Host "[2/4] Conda env '$EnvName' already exists, updating..." -ForegroundColor Yellow
+} else {
+    Write-Host "[2/4] Creating conda env '$EnvName' with Python $PythonVersion..." -ForegroundColor Cyan
+    & $condaExe create -n $EnvName python=$PythonVersion -y 2>&1 | Out-Null
+}
+
+# 3. Install packages
+Write-Host "[3/4] Installing packages..." -ForegroundColor Cyan
+
+# Get the python path for the env
+$envPython = & $condaExe run -n $EnvName python -c "import sys; print(sys.executable)" 2>$null
+if (-not $envPython) {
+    Write-Host "ERROR: Could not find Python in conda env '$EnvName'" -ForegroundColor Red
+    exit 1
+}
+
+& $condaExe run -n $EnvName pip install --quiet pyphi==1.2.0 numpy scipy ipykernel
+
+# 4. Register Jupyter kernel
+Write-Host "[4/4] Registering Jupyter kernel..." -ForegroundColor Cyan
+& $condaExe run -n $EnvName python -m ipykernel install --user --name pyphi --display-name "Python 3 (PyPhi/IIT)"
+
+# 5. Verify
+Write-Host ""
+Write-Host "=== Verification ===" -ForegroundColor Green
+
+$pyphiVer = & $condaExe run -n $EnvName python -c "import pyphi; print(pyphi.__version__)" 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "  PyPhi version: $pyphiVer" -ForegroundColor Green
+} else {
+    Write-Host "  PyPhi: IMPORT FAILED" -ForegroundColor Red
+    Write-Host "  Error: $pyphiVer"
+}
+
+$kernelList = jupyter kernelspec list 2>$null
+if ($kernelList -match "pyphi") {
+    Write-Host "  Kernel 'pyphi': registered" -ForegroundColor Green
+} else {
+    Write-Host "  Kernel 'pyphi': NOT FOUND" -ForegroundColor Red
+}
+
+Write-Host ""
+Write-Host "Setup complete. Activate with: conda activate $EnvName" -ForegroundColor Green
+Write-Host "Use kernel 'Python 3 (PyPhi/IIT)' in Jupyter notebooks." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Add automated setup script for PyPhi environment, fixing the Python 3.10+ incompatibility that has prevented the IIT notebook from executing.

## Problem

PyPhi 1.2.0 uses  which was removed in Python 3.10. The IIT notebook  has never been executable on any machine.

## Solution

Follow the same pattern as other series (Lean WSL, epita_symbolic_ai, coursia-ml-training): dedicated conda env with correct Python version.

## Changes (3 files)

| File | Change |
|------|--------|
|  (NEW) | Creates conda env `pyphi` with Python 3.9, installs pyphi 1.2.0 + deps, registers Jupyter kernel |
|  | Fixes Python version constraint (3.9, not 3.7), adds scipy |
|  | Corrects setup instructions, fixes limitations table |

## Issue

Closes #1943 (setup portion — second notebook IIT-2 is separate PR)

## Validation

- Script syntax verified (PowerShell)
- requirements.txt compatible with Python 3.9
- README instructions match script behavior

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>