### PR TITLE
docs(rules): code cells emit informative output (anti false-positive maturity)

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -30,6 +30,17 @@ paths: MyIA.AI.Notebooks/**/*.ipynb
 - Working directory explicite pour notebooks avec paths relatifs
 - `BATCH_MODE=true` pour notebooks avec widgets interactifs
 
+## Cellules code : output systematique (anti faux-positif maturite)
+
+**Convention user 2026-05-31.** Toute cellule code executable doit produire un **output**, pour que la porte catalogue `all_have_outputs` soit un signal **vrai** (et non un cas a forgiver cote detecteur). On corrige l'**artefact**, pas l'instrument de mesure.
+
+- Cellule setup / imports / defs / guards qui ne produit rien naturellement => ajouter un **print informatif de confirmation** : `print("Imports OK : semantic_kernel, nest_asyncio")`, `print(f"Kernel configure : {kernel.service_id}")`, `print(f"{len(funcs)} fonctions definies")`.
+- **Print informatif, jamais du bruit.** `print("ok")` repete partout = gaming du detecteur (famille incident #1214), INTERDIT. Le print doit dire ce que la cellule a accompli.
+- **JAMAIS printer une valeur de secret / cle** (`print(api_key)` interdit). Confirmer la presence sans reveler : `print("Cle API chargee" if key else "Cle MANQUANTE")`.
+- Stub d'exercice : garde `print("Exercice a completer")` (deja conforme C.1, aucun changement).
+- **Un print ne remplace PAS l'execution reelle** : une cellule LLM/API doit montrer sa **vraie** reponse, pas un `print("done")` creux sur un appel echoue. Provisionner le `.env` d'abord (regle F), puis re-executer.
+- **Forward convention** : appliquer en editant/finalisant un notebook (surtout pour le faire passer BETA -> PROD) et pour tout nouveau notebook. Ne PAS reserialiser en masse des notebooks deja PRODUCTION juste pour ajouter des prints (churn C.3 interdit).
+
 ## Patterns stub d'exercice (rule C.1)
 
 `raise NotImplementedError` / `assert False` / `1/0` **INTERDITS partout** (notebook doit s'executer end-to-end). Patterns corrects :


### PR DESCRIPTION
## Summary

Codifies the user-mandated convention (2026-05-31): **every executable code cell should emit an informative output**, so the catalog `all_have_outputs` maturity gate becomes a TRUE signal instead of something the detector must forgive. Fixes the **artifact**, not the measuring instrument.

## Context

Several SymbolicAI notebooks were stuck at BETA because their setup/import/def cells produce nothing, tripping `all_have_outputs`. The prior instinct was to teach the catalog detector to forgive silent setup cells; the user's directive is the cleaner lever — make the cell genuinely print a confirmation, which is also better pedagogy (the student sees each cell ran).

## Guardrails baked into the rule

- Informative prints only (`print("Imports OK : ...")`, `print(f"Kernel configure : ...")`) — **never** noise like repeated `print("ok")` (that is detector-gaming, incident #1214 family).
- **Never** print a secret/key value.
- Exercise stubs keep `print("Exercice a completer")` (already C.1-consistent).
- A print is **not** a substitute for real execution — LLM/API cells must show real responses (provision `.env` per rule F first).
- Forward convention: apply when editing/finalizing a notebook (esp. BETA -> PROD) and for new notebooks; do **not** mass-reserialize already-PRODUCTION notebooks just to add prints (C.3 churn).

## Scope

Single file, `.claude/rules/notebook-conventions.md` (rules, auto-loaded). No code, no notebooks, no secrets.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>