### PR TITLE
fix(symbolic-ai): add Console.WriteLine to Linq2Z3 stub (convention #1946)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
@@ -41,13 +41,128 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
-       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Z3.Linq</span></li></ul></div><div></div></div>"
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.17.208.1:2048/\",\"http://fe80::4dcf:dde3:135d:4312%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:3d42:dc67:d4da:6aab:2048/\",\"http://2a01:e0a:9d4:f320:480e:198:8d11:595a:2048/\",\"http://2a01:e0a:9d4:f320:f5f8:1fb6:d747:7089:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1371168.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Z3.Linq, 2.0.1</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -99,15 +214,15 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "X1 = 3, X2 = 0, X3 = 1, X4 = 0, X5 = 1\r\n"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -263,8 +378,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -427,17 +542,15 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:00.2345640"
+       "Durée Cannibales et Missionaires 00:00:00.2245639"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
        "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>1 - ((3M, 3C, 1), (0, 0M, 0C))\\r\\n2 - ((2M, 2C, 0), (1, 1M, 1C))\\r\\n3 - ((3M, 3C, 1), (0, 0M, 0C))\\r\\n4 - ((2M, 2C, 0), (1, 1M, 1C))\\r\\n5 - ((3M, 3C, 1), (0, 0M, 0C))\\r\\n6 - ((2M, 2C, 0), (1, 1M, 1C))\\r\\n7 - ((3M, 2C, 1), (0, 0M, 1C))\\r\\n8 - ((2M, 2C, 0), (1, 1M, 1C))\\r\\n9 - ((3M, 2C, 1), (0, 0M, 1C...</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>NbMissionaries</td><td><div class=\"dni-plaintext\"><pre>3</pre></div></td></tr><tr><td>SizeBoat</td><td><div class=\"dni-plaintext\"><pre>2</pre></div></td></tr><tr><td>Length</td><td><div class=\"dni-plaintext\"><pre>22</pre></div></td></tr><tr><td>Canibals</td><td><div class=\"dni-plaintext\"><pre>[ 3, 2, 3, 2, 3, 2, 2, 2, 2, 0, 1, 0, 2, 0, 1, 1, 2, 2, 3, 1 ... (2 more) ]</pre></div></td></tr><tr><td>Missionaries</td><td><div class=\"dni-plaintext\"><pre>[ 3, 2, 3, 2, 3, 2, 3, 2, 3, 3, 3, 3, 3, 3, 3, 1, 2, 0, 0, 0 ... (2 more) ]</pre></div></td></tr></tbody></table></div></details><style>\r\n",
@@ -473,7 +586,9 @@
        "}\r\n",
        "</style>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -541,17 +656,15 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:00.0993108"
+       "Durée Cannibales et Missionaires 00:00:00.1172951"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
        "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>1 - ((3M, 3C, 1), (0, 0M, 0C))\\r\\n2 - ((3M, 1C, 0), (1, 0M, 2C))\\r\\n3 - ((3M, 2C, 1), (0, 0M, 1C))\\r\\n4 - ((3M, 0C, 0), (1, 0M, 3C))\\r\\n5 - ((3M, 1C, 1), (0, 0M, 2C))\\r\\n6 - ((1M, 1C, 0), (1, 2M, 2C))\\r\\n7 - ((2M, 2C, 1), (0, 1M, 1C))\\r\\n8 - ((0M, 2C, 0), (1, 3M, 1C))\\r\\n9 - ((0M, 3C, 1), (0, 3M, 0C...</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>NbMissionaries</td><td><div class=\"dni-plaintext\"><pre>3</pre></div></td></tr><tr><td>SizeBoat</td><td><div class=\"dni-plaintext\"><pre>2</pre></div></td></tr><tr><td>Length</td><td><div class=\"dni-plaintext\"><pre>12</pre></div></td></tr><tr><td>Canibals</td><td><div class=\"dni-plaintext\"><pre>[ 3, 1, 2, 0, 1, 1, 2, 2, 3, 1, 1, 0 ]</pre></div></td></tr><tr><td>Missionaries</td><td><div class=\"dni-plaintext\"><pre>[ 3, 3, 3, 3, 3, 1, 2, 0, 0, 0, 1, 0 ]</pre></div></td></tr></tbody></table></div></details><style>\r\n",
@@ -587,11 +700,13 @@
        "}\r\n",
        "</style>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -658,17 +773,15 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/plain": [
-       "Durée Cannibales et Missionaires 00:00:30.6416903"
+       "Durée Cannibales et Missionaires 00:00:32.0611563"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
-     "metadata": {},
      "data": {
       "text/html": [
        "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>1 - ((30M, 30C, 1), (0, 0M, 0C))\\r\\n2 - ((30M, 23C, 0), (1, 0M, 7C))\\r\\n3 - ((30M, 24C, 1), (0, 0M, 6C))\\r\\n4 - ((24M, 24C, 0), (1, 6M, 6C))\\r\\n5 - ((25M, 25C, 1), (0, 5M, 5C))\\r\\n6 - ((22M, 22C, 0), (1, 8M, 8C))\\r\\n7 - ((23M, 23C, 1), (0, 7M, 7C))\\r\\n8 - ((20M, 20C, 0), (1, 10M, 10C))\\r\\n9 - ((21M,...</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>NbMissionaries</td><td><div class=\"dni-plaintext\"><pre>30</pre></div></td></tr><tr><td>SizeBoat</td><td><div class=\"dni-plaintext\"><pre>7</pre></div></td></tr><tr><td>Length</td><td><div class=\"dni-plaintext\"><pre>28</pre></div></td></tr><tr><td>Canibals</td><td><div class=\"dni-plaintext\"><pre>[ 30, 23, 24, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8 ... (8 more) ]</pre></div></td></tr><tr><td>Missionaries</td><td><div class=\"dni-plaintext\"><pre>[ 30, 30, 30, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8 ... (8 more) ]</pre></div></td></tr></tbody></table></div></details><style>\r\n",
@@ -704,11 +817,13 @@
        "}\r\n",
        "</style>"
       ]
-     }
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
       "\r\n",
       "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
@@ -753,32 +868,16 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "// TODO: Définissez le problème de planification\n",
-    "// - 5 tâches avec des durées différentes\n",
-    "// - 3 machines avec des capacités différentes\n",
-    "// - Contrainte : chaque tâche sur une seule machine\n",
-    "// - Contrainte : capacité machine non dépassée\n",
-    "// - Objectif : minimiser le temps total de complétion\n",
-    "\n",
-    "public class PlanningProblem\n",
-    "{\n",
-    "    // TODO: Propriétés du problème\n",
-    "    // public int[] TaskDurations { get; set; }\n",
-    "    // public int[] MachineCapacities { get; set; }\n",
-    "    // public int[,] Assignment { get; set; } // tâche -> machine\n",
-    "    \n",
-    "}\n",
-    "\n",
-    "// TODO: Créez le théorème LINQ pour le problème\n",
-    "// var theorem = from t in ctx.NewTheorem<PlanningProblem>()\n",
-    "//     where ... // Vos contraintes\n",
-    "//     select t;\n",
-    "\n",
-    "// TODO: Résolvez et affichez la solution\n",
-    "// var solution = theorem.Optimize(...);\n"
-   ]
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : modeliser un probleme de planification avec Z3.Linq\r\n"
+     ]
+    }
+   ],
+   "source": "// TODO: Définissez le problème de planification\n// - 5 tâches avec des durées différentes\n// - 3 machines avec des capacités différentes\n// - Contrainte : chaque tâche sur une seule machine\n// - Contrainte : capacité machine non dépassée\n// - Objectif : minimiser le temps total de complétion\n\npublic class PlanningProblem\n{\n    // TODO: Propriétés du problème\n    // public int[] TaskDurations { get; set; }\n    // public int[] MachineCapacities { get; set; }\n    // public int[,] Assignment { get; set; } // tâche -> machine\n    \n}\n\n// TODO: Créez le théorème LINQ pour le problème\n// var theorem = from t in ctx.NewTheorem<PlanningProblem>()\n//     where ... // Vos contraintes\n//     select t;\n\n// TODO: Résolvez et affichez la solution\n// var solution = theorem.Optimize(...);\n\nConsole.WriteLine(\"Exercice a completer : modeliser un probleme de planification avec Z3.Linq\");"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Apply convention print #1946 to Linq2Z3 .NET notebook exercise stub.

## Changes
- Added `Console.WriteLine("Exercice a completer : modeliser un probleme de planification avec Z3.Linq")` to the exercise stub cell
- Re-executed with Papermill `.net-csharp` kernel: 20/20 cells, 0 errors
- Stub cell now produces output (convention #1946: no silent code cells)

## Validation
- Papermill end-to-end with `.net-csharp` kernel
- 0 NotImplementedError, 0 runtime errors
- `execution_count: 7` + 1 output for the stub cell

## Related
- Convention #1946: print informatif for silent code cells
- Dispatch #1947: SymbolicAI .NET notebooks -> PROD