### PR TITLE
fix(SymbolicAI): add convention print to 3 silent code cells (#1946)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-5-Heuristics.ipynb
@@ -264,7 +264,15 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes definies : STRIPSAction, STRIPSProblem + heuristique h_max\n"
+     ]
+    }
+   ],
    "source": [
     "@dataclass\n",
     "class STRIPSAction:\n",
@@ -319,7 +327,9 @@
     "    if all(g in fact_costs for g in problem.goal):\n",
     "        return max(fact_costs[g] for g in problem.goal)\n",
     "    else:\n",
-    "        return float('inf')  # But non atteignable"
+    "        return float('inf')  # But non atteignable\n",
+    "print(\"Classes definies : STRIPSAction, STRIPSProblem + heuristique h_max\")\n",
+    ""
    ]
   },
   {
@@ -608,7 +618,7 @@
       "h^max admissible ? True\n",
       "h^add admissible ? True\n",
       "\n",
-      "Actions helpful (h^add) : {'turn_on_2', 'turn_on_1', 'turn_on_3'}\n"
+      "Actions helpful (h^add) : {'turn_on_3', 'turn_on_2', 'turn_on_1'}\n"
      ]
     }
    ],
@@ -738,7 +748,7 @@
      "output_type": "stream",
      "text": [
       "h^FF : 3\n",
-      "Actions helpful : {'turn_on_2', 'turn_on_1', 'turn_on_3'}\n"
+      "Actions helpful : {'turn_on_3', 'turn_on_2', 'turn_on_1'}\n"
      ]
     }
    ],
@@ -932,8 +942,8 @@
      "text": [
       "Landmarks extraits :\n",
       "  - on_1\n",
-      "  - on_2\n",
       "  - on_3\n",
+      "  - on_2\n",
       "\n",
       "Ordre des landmarks : []\n"
      ]
@@ -1042,7 +1052,7 @@
      "output_type": "stream",
      "text": [
       "h_landmark depuis l'etat initial : 3\n",
-      "Landmarks non satisfaits : {'on_2', 'on_1', 'on_3'}\n"
+      "Landmarks non satisfaits : {'on_1', 'on_3', 'on_2'}\n"
      ]
     }
    ],
@@ -1177,8 +1187,8 @@
      "output_type": "stream",
      "text": [
       "Probleme Blocks World simplifie\n",
-      "Etat initial : {'ontable_b', 'ontable_c', 'clear_a', 'handempty', 'ontable_a', 'clear_c', 'clear_b'}\n",
-      "But : {'on_a_b', 'on_b_c'}\n",
+      "Etat initial : {'clear_a', 'clear_c', 'clear_b', 'handempty', 'ontable_a', 'ontable_c', 'ontable_b'}\n",
+      "But : {'on_b_c', 'on_a_b'}\n",
       "Nombre d'actions : 6\n"
      ]
     }

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -691,7 +691,15 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\n"
+     ]
+    }
+   ],
    "source": [
     "def text_to_pddl_domain(description: str, domain_name: str = \"generated\") -> str:\n",
     "    \"\"\"Convertit une description en langage naturel vers PDDL\"\"\"\n",
@@ -737,7 +745,9 @@
     "        )\n",
     "        return response.content[0].text\n",
     "    \n",
-    "    return \";; API non configuree\""
+    "    return \";; API non configuree\"\n",
+    "print(\"Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\")\n",
+    ""
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -22,10 +22,21 @@
      "injected-parameters"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BATCH_MODE = true\n"
+     ]
+    }
+   ],
    "source": [
     "# Parameters\n",
-    "BATCH_MODE = \"true\"\n"
+    "BATCH_MODE = \"true\"\n",
+    "\n",
+    "print(f\"BATCH_MODE = {BATCH_MODE}\")\n",
+    ""
    ]
   },
   {


### PR DESCRIPTION
## Summary

Convention print #1946 : ajout de `print()` informatif sur 3 cells code silencieuses dans SymbolicAI Python.

## Changes

| Notebook | Cell | Avant | Apres |
|----------|------|-------|-------|
| Planners-5-Heuristics | cell[6] | def classes + h_max, 0 output | `print("Classes definies : STRIPSAction, STRIPSProblem + heuristique h_max")` |
| Planners-10-LLM-Planning | cell[18] | def PDDL functions, 0 output | `print("Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem")` |
| SC-14-Formal-Verification | cell[0] | `BATCH_MODE = "true"`, 0 output | `print(f"BATCH_MODE = {BATCH_MODE}")` |

## Validation

- Papermill 3/3 : 0 erreurs, execution end-to-end
- Stubs exercice (TODO) non touches — legitemes sans output
- Insertions > deletions (enrichment)
- Pas de local path leaks

## Scope

Partition po-2024 (CPU/.NET : SymbolicAI non-Lean). Suite de PR #1944 (Search) et #1948 (Linq2Z3).