### PR TITLE
fix(Sudoku): add convention print #1946 to 3 silent C# cells

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -375,7 +375,10 @@
     "\n",
     "        return true;\n",
     "    }\n",
-    "}\n"
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Classe BacktrackingDotNetSolver definie avec succes\");\n",
+    ""
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -116,7 +116,18 @@
     }
    },
    "outputs": [],
-   "source": "// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n// Les DLLs doivent etre dans le meme repertoire que le notebook\n#r \"IKVM.Runtime.dll\"\n#r \"IKVM.Java.dll\"\n#r \"IKVM.CoreLib.dll\"\n\n// Charger la DLL Choco-solver pré-compilée\n#r \"org.chocosolver.solver.dll\""
+   "source": [
+    "// Charger les DLLs IKVM runtime (requis pour Choco-solver)\n",
+    "// Les DLLs doivent etre dans le meme repertoire que le notebook\n",
+    "#r \"IKVM.Runtime.dll\"\n",
+    "#r \"IKVM.Java.dll\"\n",
+    "#r \"IKVM.CoreLib.dll\"\n",
+    "\n",
+    "// Charger la DLL Choco-solver pré-compilée\n",
+    "#r \"org.chocosolver.solver.dll\"\n",
+    "Console.WriteLine(\"DLLs Choco-solver et runtime IKVM chargees\");\n",
+    ""
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -163,34 +163,161 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Classe BDDNode definie avec succes.\r\n"
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::3256:b4d8:946e:168d%16:2048/\",\"http://172.17.208.1:2048/\",\"http://fe80::4dcf:dde3:135d:4312%44:2048/\",\"http://172.21.192.1:2048/\",\"http://2a01:e0a:9d4:f320:c57c:4a4d:5bd9:ca21:2048/\",\"http://2a01:e0a:9d4:f320:3d42:dc67:d4da:6aab:2048/\",\"http://2a01:e0a:9d4:f320:480e:198:8d11:595a:2048/\",\"http://2a01:e0a:9d4:f320:f5f8:1fb6:d747:7089:2048/\",\"http://fe80::5418:77a8:a4bf:a1ed%18:2048/\",\"http://192.168.0.49:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '1426892.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Operations disponibles :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Classe BDDNode definie avec succes.\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - True/False : Terminaux (feuilles)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Operations disponibles :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Create(var, low, high) : Cree un noeud de decision\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - True/False : Terminaux (feuilles)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - Evaluate(assign) : Evalue le BDD\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Create(var, low, high) : Cree un noeud de decision\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  - CountNodes() : Compte les noeuds\r\n"
+     "output_type": "stream",
+     "text": [
+      "  - Evaluate(assign) : Evalue le BDD\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  - CountNodes() : Compte les noeuds\r\n"
+     ]
     }
    ],
    "source": [
@@ -342,84 +469,122 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Exemple 1 : Constante TRUE ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Exemple 1 : Constante TRUE ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 1\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 1\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Valeur : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Valeur : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Exemple 2 : Variable x ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Exemple 2 : Variable x ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "x?\r\n  |-> |(True)\r\n  |-> |(False)\r\n"
+     "output_type": "stream",
+     "text": [
+      "x?\r\n",
+      "  |-> |(True)\r\n",
+      "  |-> |(False)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 3\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 3\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Eval(x=true) : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Eval(x=true) : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Eval(x=false) : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Eval(x=false) : False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Exemple 3 : x AND y ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Exemple 3 : x AND y ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "x?\r\n  |-> |y?\r\n  |  |-> |  |(True)\r\n  |  |-> |  |(False)\r\n  |-> |(False)\r\n"
+     "output_type": "stream",
+     "text": [
+      "x?\r\n",
+      "  |-> |y?\r\n",
+      "  |  |-> |  |(True)\r\n",
+      "  |  |-> |  |(False)\r\n",
+      "  |-> |(False)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Eval(x=true, y=true) : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Eval(x=true, y=true) : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Eval(x=true, y=false) : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Eval(x=true, y=false) : False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Eval(x=false, y=true) : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Eval(x=false, y=true) : False\r\n"
+     ]
     }
    ],
    "source": [
@@ -530,9 +695,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "BDDOperations OK (Apply/And/Or/Not).\r\n"
+     "output_type": "stream",
+     "text": [
+      "BDDOperations OK (Apply/And/Or/Not).\r\n"
+     ]
     }
    ],
    "source": [
@@ -650,74 +817,102 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test 1 : x AND NOT x ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test 1 : x AND NOT x ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Resultat : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Resultat : False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Attendu : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Attendu : False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 1\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 1\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test 2 : x OR NOT x ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test 2 : x OR NOT x ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Resultat : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Resultat : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Attendu : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Attendu : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 1\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 1\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test 3 : Distributivite ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test 3 : Distributivite ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds (gauche) : 7\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds (gauche) : 7\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds (droite) : 7\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds (droite) : 7\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Equivalent (x=T,y=T,z=F) : True == True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Equivalent (x=T,y=T,z=F) : True == True\r\n"
+     ]
     }
    ],
    "source": [
@@ -808,9 +1003,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDDNode OK (Pretty/ToString/Evaluate).\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDDNode OK (Pretty/ToString/Evaluate).\r\n"
+     ]
     }
    ],
    "source": [
@@ -938,9 +1135,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "RowMDDBuilder OK (memoization bitmask).\r\n"
+     "output_type": "stream",
+     "text": [
+      "RowMDDBuilder OK (memoization bitmask).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1035,64 +1234,88 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Construction du MDD pour une ligne Sudoku...\r\n"
+     "output_type": "stream",
+     "text": [
+      "Construction du MDD pour une ligne Sudoku...\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Attention: 9! = 362880 permutations valides\r\n"
+     "output_type": "stream",
+     "text": [
+      "Attention: 9! = 362880 permutations valides\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDD construit!\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDD construit!\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Nombre de noeuds : 5611771\r\n"
+     "output_type": "stream",
+     "text": [
+      "Nombre de noeuds : 5611771\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test 1 : Ligne valide ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test 1 : Ligne valide ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Resultat : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Resultat : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Attendu : True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Attendu : True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test 2 : Ligne invalide (doublon de 1) ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test 2 : Ligne invalide (doublon de 1) ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Resultat : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Resultat : False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Attendu : False\r\n"
+     "output_type": "stream",
+     "text": [
+      "Attendu : False\r\n"
+     ]
     }
    ],
    "source": [
@@ -1212,9 +1435,11 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDDOperations OK (Product).\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDDOperations OK (Product).\r\n"
+     ]
     }
    ],
    "source": [
@@ -1329,69 +1554,97 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Test du Produit MDD ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Test du Produit MDD ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Grille 2x2 (valeurs 1-2)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Grille 2x2 (valeurs 1-2)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDD Ligne 0 (2 cellules, valeurs 1-2) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDD Ligne 0 (2 cellules, valeurs 1-2) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 7\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 7\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDD Contrainte (r0_c0 != 1) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDD Contrainte (r0_c0 != 1) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "r0_c0?\n  1 -> |  (INVALID)\n  2 -> |  (VALID)\r\n"
+     "output_type": "stream",
+     "text": [
+      "r0_c0?\n",
+      "  1 -> |  (INVALID)\n",
+      "  2 -> |  (VALID)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "MDD Produit (ligne 0 INTERSECT r0_c0 != 1) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "MDD Produit (ligne 0 INTERSECT r0_c0 != 1) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Noeuds : 5\r\n"
+     "output_type": "stream",
+     "text": [
+      "Noeuds : 5\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Test (r0_c0=1, r0_c1=2) : False (attendu: False)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Test (r0_c0=1, r0_c1=2) : False (attendu: False)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Test (r0_c0=2, r0_c1=1) : True (attendu: True)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Test (r0_c0=2, r0_c1=1) : True (attendu: True)\r\n"
+     ]
     }
    ],
    "source": [
@@ -1542,19 +1795,25 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Classe SudokuMDDSolver definie avec succes.\r\n"
+     "output_type": "stream",
+     "text": [
+      "Classe SudokuMDDSolver definie avec succes.\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Note: Cette implementation utilise le backtracking classique\r\n"
+     "output_type": "stream",
+     "text": [
+      "Note: Cette implementation utilise le backtracking classique\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "car les MDD complets pour Sudoku seraient trop volumineux.\r\n"
+     "output_type": "stream",
+     "text": [
+      "car les MDD complets pour Sudoku seraient trop volumineux.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1720,574 +1979,803 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "=== Puzzle Sudoku Facile ===\r\n"
+     "output_type": "stream",
+     "text": [
+      "=== Puzzle Sudoku Facile ===\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nSolution trouve en 0,61 ms :\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Solution trouve en 0,50 ms :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-------+-------+-------\r\n"
+     "output_type": "stream",
+     "text": [
+      "-------+-------+-------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-------+-------+-------\r\n"
+     "output_type": "stream",
+     "text": [
+      "-------+-------+-------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-------+-------+-------\r\n"
+     "output_type": "stream",
+     "text": [
+      "-------+-------+-------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "6 "
+     "output_type": "stream",
+     "text": [
+      "6 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "9 "
+     "output_type": "stream",
+     "text": [
+      "9 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "5 "
+     "output_type": "stream",
+     "text": [
+      "5 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "4 "
+     "output_type": "stream",
+     "text": [
+      "4 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "1 "
+     "output_type": "stream",
+     "text": [
+      "1 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "7 "
+     "output_type": "stream",
+     "text": [
+      "7 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "| "
+     "output_type": "stream",
+     "text": [
+      "| "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "3 "
+     "output_type": "stream",
+     "text": [
+      "3 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "8 "
+     "output_type": "stream",
+     "text": [
+      "8 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2 "
+     "output_type": "stream",
+     "text": [
+      "2 "
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "-------+-------+-------\r\n"
+     "output_type": "stream",
+     "text": [
+      "-------+-------+-------\r\n"
+     ]
     }
    ],
    "source": [
@@ -2600,7 +3088,15 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : solveur BDD avec propagation de contraintes\r\n"
+     ]
+    }
+   ],
    "source": [
     "// A COMPLETER : Solveur BDD avec propagation de contraintes\n",
     "\n",
@@ -2650,7 +3146,9 @@
     "// string puzzle = \"003020600900305001001806400008102900700000008006708200002609500800203009005010300\";\n",
     "// var propagator = new BDDConstraintPropagator();\n",
     "// var solution = propagator.Solve(puzzle);\n",
-    "// Console.WriteLine(solution != null ? \"Solution trouvee !\" : \"Echec !\");"
+    "// Console.WriteLine(solution != null ? \"Solution trouvee !\" : \"Echec !\");\n",
+    "Console.WriteLine(\"Exercice a completer : solveur BDD avec propagation de contraintes\");\n",
+    ""
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Convention print #1946 : ajout de `Console.WriteLine()` informatif sur 3 cells code C# silencieuses dans Sudoku .NET.

## Changes

| Notebook | Cell | Avant | Apres |
|----------|------|-------|-------|
| Sudoku-1-Backtracking-Csharp | cell[6] | class def, 0 output | `Console.WriteLine("Classe BacktrackingDotNetSolver definie avec succes")` |
| Sudoku-11-Choco-Csharp | cell[4] | #r DLL loading, 0 output | `Console.WriteLine("DLLs Choco-solver et runtime IKVM chargees")` |
| Sudoku-14-BDD-Csharp | cell[32] | exercise stub, 0 output | `Console.WriteLine("Exercice a completer : solveur BDD avec propagation de contraintes")` |

## Validation

- **Sudoku-14** : Papermill `.net-csharp` 33/33 cells, 0 errors, outputs verifiés
- **Sudoku-1/11** : Papermill echoue sur `#!import` (problème structurel .NET Interactive, pas lie au convention print). Code C# correct, outputs populera quand executé dans Jupyter Lab
- Insertions > deletions (enrichment)

## Scope

Partition po-2024 (.NET/C# : Sudoku). Suite de PR #1951 (SymbolicAI Python convention print).