### PR TITLE
chore(harness): codify 3-tier info hygiene discipline

### DIFF
--- a/.claude/rules/harness-hygiene.md
+++ b/.claude/rules/harness-hygiene.md
@@ -1,0 +1,31 @@
+# Harness hygiene — info à 3 tiers, harnais succinct
+
+S'applique à **tous les agents** du cluster CoursIA (workers `po-*` + coordinateur `ai-01`). Source : mandat user 2026-06-01 — « une bonne discipline de consolidation de l'information dans des dispatchs qui n'encombrent pas en permanence le harnais ; le répertoire docs est là pour accueillir la doc pérenne référencée succinctement par les fichiers du harnais ».
+
+## Règle HARD — 3 tiers d'information
+
+| Tier | Support | Contenu | Discipline |
+|------|---------|---------|------------|
+| **Harnais** (auto-loaded chaque session) | `CLAUDE.md`, `.claude/rules/*.md`, `MEMORY.md` per-machine | Règles durables + **pointeurs succincts** vers `docs/` | **Succinct.** Référence, ne détaille pas. |
+| **Doc pérenne** | `docs/<theme>.md` | Détail durable (procédures, état vérifié, leçons consolidées, inventaires de référence) | Référencé **succinctement** depuis le harnais. |
+| **Éphémère** | Dashboard RooSync workspace | État de cycle, logs de coordination, rapports de session, dispatches | **Jamais** dans le harnais ni dans un fichier du repo. |
+
+## Anti-patterns interdits
+
+- **Gonfler le harnais** avec des logs de cycle datés, des numéros de PR mergées, des SHA — ça vit sur le **dashboard**, pas dans `MEMORY.md` ni `CLAUDE.md`.
+- Créer un fichier `*_REPORT.md` / `*_AUDIT.md` / `*_COORDINATION.md` / `*_STATUS.md` dans le repo (rapport = dashboard).
+- Dupliquer dans `MEMORY.md` / `CLAUDE.md` un détail qui a (ou devrait avoir) sa place dans `docs/`.
+- Recréer des dizaines de `feedback_*.md` locaux : une leçon cross-machine va dans `CLAUDE.md` / `rules` / `docs`.
+
+## Discipline de consolidation (avant d'ajouter au harnais)
+
+1. **Est-ce durable ?** Non → dashboard. Oui → étape 2.
+2. **Est-ce du détail ?** Oui → `docs/<theme>.md` + 1 ligne pointeur dans le harnais. Non (règle / pointeur bref) → harnais directement.
+3. **Préserver avant de réduire** (cf CLAUDE.md global « Consolider != Archiver ») : merger le contenu durable dans sa cible AVANT de trimmer la source. Citer la cible comme preuve.
+
+## Voir aussi
+
+- CLAUDE.md global — « Knowledge Preservation » + « Consolider != Archiver »
+- [proactive-coordination.md](proactive-coordination.md) — reporting dashboard
+- [coordinator-discipline.md](coordinator-discipline.md) — rapports coord = dashboard, pas repo
+- [../../docs/procedures-recurrentes.md](../../docs/procedures-recurrentes.md) — procédures + leçons cycle merge consolidées

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [.claude/rules/coordinator-discipline.md](.claude/rules/coordinator-discipline.md) - ai-01 merge actif + no-languishing demandes user
 - [.claude/rules/proactive-coordination.md](.claude/rules/proactive-coordination.md) - 1 PR/wakeup + main track + side-track async via sous-agents spécialistes (mandat user 2026-05-23)
 - [.claude/rules/user-blocker-signaling.md](.claude/rules/user-blocker-signaling.md) - Re-poke chaque fin de session quand le user bloque (mandat user 2026-05-28, anti-dilution wakeup)
+- [.claude/rules/harness-hygiene.md](.claude/rules/harness-hygiene.md) - Info 3 tiers : harnais succinct / docs pérenne / dashboard éphémère (mandat user 2026-06-01)
 
 ---
 

--- a/docs/procedures-recurrentes.md
+++ b/docs/procedures-recurrentes.md
@@ -107,3 +107,47 @@ python -c "import json,sys; nb=json.load(open(sys.argv[1])); bad=[i for i,c in e
 ```
 
 Si fail → (a) exécuter localement (env complet H.2), OU (b) dispatcher RooSync sur machine compatible, OU (c) déplacer dans `_pending_execution/` avec issue ouverte.
+
+## Cycle merge coordinateur — leçons durables (ai-01)
+
+Leçons récurrentes du cycle review+merge, consolidées depuis les logs de cycle. À relire plutôt que de les ré-apprendre incident par incident.
+
+### Cascade catalogue (HARD)
+
+Toute PR touchant `COURSE_CATALOG.generated.json` rend les autres PRs catalog-touchers DIRTY/CONFLICTING au merge (le catalogue est régénéré globalement). Donc :
+
+- Merger les PRs **non-catalogue d'abord**, puis les catalog-touchers **un-par-un**.
+- Conflit catalogue = l'auteur **rebase + régénère** : `python scripts/notebook_tools/generate_catalog.py --json --git-tracked-only` (parité CI = N entrées git-tracked ; `--json` nu inclut les `_output.ipynb` locaux = drift), puis `expand_catalog_markers.py`.
+- **JAMAIS** force-resolve le conflit côté coord ; **JAMAIS** force-push la branche de l'auteur.
+- Check CI **rouge "Notebook catalog drift" = NON mergeable** (propagerait le drift) → bounce à l'auteur pour re-régénérer.
+- **Cascade-independence** : une PR dont le drift-check = SUCCESS **et** qui ne touche pas le catalogue est **indépendante** — ne pas la hold à tort dans la file cascade.
+
+### Trap "APPROVED"
+
+`reviewDecision=APPROVED` provient du bot **requis** `clusterManager-Myia` (Hermes/NanoClaw, même compte, distingués par préfixe body `[Hermes]`/`[NanoClaw]`). Mon `gh pr review --request-changes` en `myia-ai-01` **ne flippe PAS** le flag aggregate. Lever un hold = soit `--approve` documenté par evidence, soit admin-merge via `gh auth switch -u jsboige`. Toujours lire body + tous comments + diff (pas le seul flag).
+
+### Qualité enrichissement
+
+**Toujours** sampler le markdown ajouté avant merge : content-specific (interprétation réelle du résultat) = OK ; filler générique ("Suite du traitement", "Analyse des résultats") = REJET (gaming du détecteur, famille #1214).
+
+### Dead-code
+
+Vérifier qu'un script cible est **LIVE** (existe + exporté + ≥1 caller réel + catalogué) AVANT d'écrire/merger des tests dessus. Un test qui importe un module supprimé casse la suite.
+
+### mergeable != ready
+
+Un flip `MERGEABLE` (conflit résolu) ne lève PAS un hold qualité (gate P5, validation user). Distinguer "merge-conflict résolu" de "gate qualité franchi".
+
+### Maturité catalogue = README au render-time
+
+Les flips BETA→PRODUCTION se vérifient via le **badge counts** du README (`PRODUCTION=N→M`), PAS par grep `maturity` dans le JSON (champ vide au render). Ordering non-stable = diff symétrique = churn cosmétique ; `issue_pr_associee` non-préservé au regen.
+
+### Métriques outputs
+
+`output_type` count ≠ missing-outputs. Le vrai métrique "non-exécuté" = `execution_count: null` **ET** `outputs` vide. Un diff de reserialization (churn C.3) n'est pas une régression d'exécution.
+
+### Commandes / vigilance
+
+- Diff d'un fichier d'une PR : `gh pr diff N -- path` n'est **pas** supporté → `git fetch origin pull/N/head:prN` puis `git show prN:path`.
+- Une self-review de worker peut **sur-alarmer** (ex. flag "API key exposée" sur un print masqué) → lire le diff réel avant de propager une consigne "rotate".
+- Fast-merges (<9 min, compte `jsboige`) bypassent les bots (poll ~30 min) : low-risk mais le gate review est contourné — réserver au forensic/auto trivial.


### PR DESCRIPTION
## Summary
Mandat user 2026-06-01 : appliquer fleet-wide une discipline de consolidation — le **harnais** (CLAUDE.md / .claude/rules / MEMORY.md per-machine) reste **succinct et reference** ; le repertoire **docs/** accueille la doc perenne ; l'**ephemere de cycle** (PRs mergees, SHA, dispatches) vit sur le **dashboard**.

- `.claude/rules/harness-hygiene.md` (NEW) : regle HARD 3 tiers + anti-patterns (gonfler le harnais de logs de cycle, `*_REPORT.md` dans le repo, duplication harnais/docs) + discipline de consolidation (preserver avant reduire).
- `docs/procedures-recurrentes.md` : section "Cycle merge coordinateur — lecons durables" consolidant les lecons recurrentes (cascade catalogue, trap APPROVED, enrich-quality, dead-code, mergeable!=ready, maturite catalogue render-time, metriques outputs). Preservation des lecons avant trim de MEMORY.md.
- `CLAUDE.md` : pointeur vers la nouvelle regle.

## Effet immediat (exemplar)
MEMORY.md per-machine ai-01 trimme **22 KB -> 10 KB (-53 %)** : logs de cycle quotidiens retires (lecons durables preservees dans docs/), gardant l'etat durable + actionnable (Lean Monday, bloqueurs user, partition cluster, watches operationnelles). MEMORY.md est local (hors git) — non inclus dans cette PR.

## Test plan
Docs + rule only, aucun code/notebook/catalogue touche. Pas de cascade, pas de build requis. Liens relatifs verifies.