### PR TITLE
fix(catalog): resync ALL + SymbolicAI maturity markers (unblock drift CI fleet-wide)

### DIFF
--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -10,7 +10,7 @@ Le catalogue rassemble près de 500 notebooks répartis sur les onze domaines ci
 series: ALL
 total: 504
 breakdown: GenAI=120, QuantConnect=101, SymbolicAI=100, Search=45, Probas=43, Sudoku=32, ML=27, GameTheory=25, RL=6, CaseStudies=4, IIT=1
-maturity: PRODUCTION=357, BETA=107, ALPHA=31, DRAFT=5, TEMPLATE=4
+maturity: PRODUCTION=358, BETA=106, ALPHA=31, DRAFT=5, TEMPLATE=4
 -->
 
 Dernière mise à jour : 2026-05-28

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -4,7 +4,7 @@
 series: SymbolicAI
 pedagogical_count: 100
 breakdown: SmartContracts=27, SemanticWeb=18, Lean=17, Planners=13, Tweety=10, SymbolicLearning=7, Argument_Analysis=6, root=2
-maturity: PRODUCTION=88, BETA=11, ALPHA=1
+maturity: PRODUCTION=89, BETA=10, ALPHA=1
 -->
 
 L'intelligence artificielle n'est pas qu'apprentissage automatique et réseaux de neurones. Une grande partie de l'IA classique repose sur le **raisonnement symbolique** : représenter la connaissance sous forme de propositions, de règles et de structures logiques, puis dériver mécaniquement de nouvelles conclusions. C'est cette tradition — des systèmes experts des années 80 aux assistants de preuve modernes comme Lean 4 — que cette série explore en profondeur.


### PR DESCRIPTION
## Summary

Two `CATALOG-STATUS` markers on `main` are stale versus the regenerated catalog, causing the **Catalog Drift Check** to FAIL on every PR that touches a notebook or README — a fleet-wide block (verified on #1954, #1979).

`expand_catalog_markers.py --check` on current main:
```
[MyIA.AI.Notebooks/README.md]            Updated CATALOG-STATUS block for ALL
[MyIA.AI.Notebooks/SymbolicAI/README.md] Updated CATALOG-STATUS block for SymbolicAI
DRIFT DETECTED: 2 stale markers found
```

## Fix

Re-injected the two markers from the regenerated catalog (`generate_catalog.py --json-only --git-tracked-only` then `expand_catalog_markers.py`):
- **ALL**: `PRODUCTION 357 -> 358, BETA 107 -> 106`
- **SymbolicAI**: `PRODUCTION 88 -> 89, BETA 11 -> 10`

Pure marker-lag resync (one notebook was promoted upstream without re-injecting markers). **No notebook or content change.** The `COURSE_CATALOG.generated.json` is intentionally **not** committed — the CI regenerates it on every run and does not diff the committed copy; committing it only produces ~147 lines of symmetric ordering churn.

## Effect

Once merged, `main` is drift-green again, so the pending catalog cascade (#1954, #1970, #1979, ...) only needs a trivial rebase instead of each carrying its own marker fix.

## Test plan
- [x] `expand_catalog_markers.py --check` passes locally after inject
- [x] Only 2 README files changed, +1/-1 line each (marker block only)