### PR TITLE
fix(sc-15): extract nested f-string conditionals for Python <3.12 compat

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003781,
+     "end_time": "2026-05-31T23:30:20.984953+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:20.981172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# SC-15-Zero-Knowledge-Proofs - Preuves a Divulgation Nulle\n",
     "\n",
@@ -31,7 +40,16 @@
   {
    "cell_type": "markdown",
    "id": "zkp-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002692,
+     "end_time": "2026-05-31T23:30:20.990719+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:20.988027+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -80,11 +98,19 @@
    "id": "cave-simulation",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:33.281577Z",
-     "iopub.status.busy": "2026-05-29T01:01:33.280428Z",
-     "iopub.status.idle": "2026-05-29T01:01:33.332039Z",
-     "shell.execute_reply": "2026-05-29T01:01:33.330834Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:20.997638Z",
+     "iopub.status.busy": "2026-05-31T23:30:20.997212Z",
+     "iopub.status.idle": "2026-05-31T23:30:21.016818Z",
+     "shell.execute_reply": "2026-05-31T23:30:21.015996Z"
+    },
+    "papermill": {
+     "duration": 0.024129,
+     "end_time": "2026-05-31T23:30:21.017510+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:20.993381+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -143,7 +169,16 @@
   {
    "cell_type": "markdown",
    "id": "cave-interpretation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002789,
+     "end_time": "2026-05-31T23:30:21.023562+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.020773+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation\n",
     "\n",
@@ -161,7 +196,16 @@
   {
    "cell_type": "markdown",
    "id": "dlog-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002802,
+     "end_time": "2026-05-31T23:30:21.029074+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.026272+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -195,7 +239,16 @@
   {
    "cell_type": "markdown",
    "id": "8199e832",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002632,
+     "end_time": "2026-05-31T23:30:21.034331+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.031699+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Parametres du groupe\n",
     "\n",
@@ -215,7 +268,16 @@
   {
    "cell_type": "markdown",
    "id": "dlog-transition",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002677,
+     "end_time": "2026-05-31T23:30:21.040723+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.038046+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Execution du protocole interactif\n",
     "\n",
@@ -230,11 +292,19 @@
    "id": "dlog-interactive",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:33.334652Z",
-     "iopub.status.busy": "2026-05-29T01:01:33.334384Z",
-     "iopub.status.idle": "2026-05-29T01:01:33.361123Z",
-     "shell.execute_reply": "2026-05-29T01:01:33.360508Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:21.047220Z",
+     "iopub.status.busy": "2026-05-31T23:30:21.047036Z",
+     "iopub.status.idle": "2026-05-31T23:30:21.087153Z",
+     "shell.execute_reply": "2026-05-31T23:30:21.086448Z"
+    },
+    "papermill": {
+     "duration": 0.044328,
+     "end_time": "2026-05-31T23:30:21.087697+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.043369+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -243,10 +313,10 @@
      "text": [
       "pycryptodome disponible.\n",
       "Parametres Discrete Log generes:\n",
-      "  p (premier) = 0xbdeeac34b4ffddec8974640ecca6c3570c0eee...\n",
-      "  g (generateur) = 0xac323140167242f29e55f5293dbd4582ffe3e1...\n",
+      "  p (premier) = 0xe481959396e191850024c3f60afa27f5b9a524...\n",
+      "  g (generateur) = 0xc237918046687e13077f163c84108fae7a56ad...\n",
       "  x (secret) = NON REVELE\n",
-      "  h = g^x mod p = 0x8ef36e716af6e102182d84afbfac9009989032...\n",
+      "  h = g^x mod p = 0x91fbf84cfd0cb84a0469bc35ddc0f60af4948f...\n",
       "Verification: g^x mod p == h : True\n",
       "PROTOCOLE ZKP DU LOGARITHME DISCRET (INTERACTIF)\n",
       "============================================================\n",
@@ -354,7 +424,8 @@
     "        all_valid = False\n",
     "\n",
     "print()\n",
-    "print(f\"Resultat apres {num_rounds} rounds : {\"CONVAINCU\" if all_valid else \"ECHEC\"}\")\n",
+    "verdict_final = \"CONVAINCU\" if all_valid else \"ECHEC\"\n",
+    "print(f\"Resultat apres {num_rounds} rounds : {verdict_final}\")\n",
     "print(f\"Probabilite de fraude : 2^(-{num_rounds}) = {2**-num_rounds:.2e}\")\n",
     "print()\n",
     "print(\"Points cles :\")\n",
@@ -366,7 +437,16 @@
   {
    "cell_type": "markdown",
    "id": "dlog-cheat-transition",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003769,
+     "end_time": "2026-05-31T23:30:21.094598+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.090829+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Et si le prouveur triche ?\n",
     "\n",
@@ -381,11 +461,19 @@
    "id": "dlog-cheat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:33.362715Z",
-     "iopub.status.busy": "2026-05-29T01:01:33.362583Z",
-     "iopub.status.idle": "2026-05-29T01:01:33.671247Z",
-     "shell.execute_reply": "2026-05-29T01:01:33.670436Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:21.101513Z",
+     "iopub.status.busy": "2026-05-31T23:30:21.101331Z",
+     "iopub.status.idle": "2026-05-31T23:30:21.429650Z",
+     "shell.execute_reply": "2026-05-31T23:30:21.428781Z"
+    },
+    "papermill": {
+     "duration": 0.332768,
+     "end_time": "2026-05-31T23:30:21.430330+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.097562+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -442,7 +530,16 @@
   {
    "cell_type": "markdown",
    "id": "dlog-interpretation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003412,
+     "end_time": "2026-05-31T23:30:21.437623+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.434211+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation\n",
     "\n",
@@ -461,7 +558,16 @@
   {
    "cell_type": "markdown",
    "id": "schnorr-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003361,
+     "end_time": "2026-05-31T23:30:21.444881+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.441520+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -496,11 +602,19 @@
    "id": "schnorr-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:33.673713Z",
-     "iopub.status.busy": "2026-05-29T01:01:33.673391Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.324309Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.323521Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:21.452809Z",
+     "iopub.status.busy": "2026-05-31T23:30:21.452563Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.030479Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.029384Z"
+    },
+    "papermill": {
+     "duration": 0.583053,
+     "end_time": "2026-05-31T23:30:22.031259+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:21.448206+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -509,7 +623,7 @@
      "text": [
       "PROTOCOLE DE SCHNORR\n",
       "============================================================\n",
-      "Parametres : p=476128414541885441227276232281... (129 bits)\n",
+      "Parametres : p=372973496737829918499063278235... (129 bits)\n",
       "Cle publique y = g^x mod p\n",
       "\n"
      ]
@@ -606,7 +720,16 @@
   {
    "cell_type": "markdown",
    "id": "schnorr-usage-transition",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003289,
+     "end_time": "2026-05-31T23:30:22.038341+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.035052+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Utilisation : interactif vs non-interactif\n",
     "\n",
@@ -621,11 +744,19 @@
    "id": "schnorr-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.326433Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.326211Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.333046Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.332430Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.045385Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.045218Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.051231Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.050733Z"
+    },
+    "papermill": {
+     "duration": 0.010177,
+     "end_time": "2026-05-31T23:30:22.051801+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.041624+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -637,18 +768,18 @@
       "\n",
       "--- Version INTERACTIVE ---\n",
       "  Etape 1 (Prouveur -> Verificateur) : envoyer R\n",
-      "    R = g^r = 837874387194259418593173672393...\n",
+      "    R = g^r = 556331722503606946810429386173...\n",
       "  Etape 2 (Verificateur -> Prouveur) : envoyer c\n",
-      "    c = 146497132042279559943278346989...\n",
+      "    c = 464672552008515806336580268098...\n",
       "  Etape 3 (Prouveur -> Verificateur) : envoyer s\n",
-      "    s = r + c*x mod q = 417295312324976589797612770726...\n",
+      "    s = r + c*x mod q = 672056519083496568510839395970...\n",
       "  Verification : g^s == R*y^c ? OUI\n",
       "  -> Necessite 3 messages (2 allers-retours)\n",
       "\n",
       "--- Version NON-INTERACTIVE (Fiat-Shamir) ---\n",
       "  Preuve (R, s) calculee localement\n",
-      "    R = 463312854706851498425460623718...\n",
-      "    s = 579189719827152188119275332845...\n",
+      "    R = 123889777092833945866133324383...\n",
+      "    s = 988019786657763818748251895743...\n",
       "    c = SHA256(g || y || R || message) (calcule automatiquement)\n",
       "  Verification : VALIDE\n",
       "  -> Un seul message, pas besoin d'interaction !\n",
@@ -679,7 +810,8 @@
     "print(f\"    s = r + c*x mod q = {str(s)[:30]}...\")\n",
     "\n",
     "valid_inter = schnorr.verify_interactive(y, R, c, s)\n",
-    "print(f\"  Verification : g^s == R*y^c ? {\"OUI\" if valid_inter else \"NON\"}\")\n",
+    "verdict_inter = \"OUI\" if valid_inter else \"NON\"\n",
+    "print(f\"  Verification : g^s == R*y^c ? {verdict_inter}\")\n",
     "print(f\"  -> Necessite 3 messages (2 allers-retours)\")\n",
     "\n",
     "# 2. Version non-interactive (Fiat-Shamir)\n",
@@ -692,21 +824,32 @@
     "print(f\"    c = SHA256(g || y || R || message) (calcule automatiquement)\")\n",
     "\n",
     "valid_ni = schnorr.verify_non_interactive(y, R_ni, s_ni, message)\n",
-    "print(f\"  Verification : {\"VALIDE\" if valid_ni else \"INVALIDE\"}\")\n",
+    "verdict_ni = \"VALIDE\" if valid_ni else \"INVALIDE\"\n",
+    "print(f\"  Verification : {verdict_ni}\")\n",
     "print(f\"  -> Un seul message, pas besoin d'interaction !\")\n",
     "\n",
     "# 3. Tentative de falsification du message\n",
     "print(\"\\n--- Falsification du message ---\")\n",
     "fake_message = b\"Message modifie\"\n",
     "valid_fake = schnorr.verify_non_interactive(y, R_ni, s_ni, fake_message)\n",
-    "print(f\"  Verification avec message modifie : {\"VALIDE\" if valid_fake else \"INVALIDE\"}\")\n",
+    "verdict_fake = \"VALIDE\" if valid_fake else \"INVALIDE\"\n",
+    "print(f\"  Verification avec message modifie : {verdict_fake}\")\n",
     "print(f\"  -> La preuve est liee au message (c'est une signature !)\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8994087a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003107,
+     "end_time": "2026-05-31T23:30:22.058092+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.054985+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Interactif vs Non-interactif\n",
     "\n",
@@ -726,7 +869,16 @@
   {
    "cell_type": "markdown",
    "id": "schnorr-sig-transition",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00324,
+     "end_time": "2026-05-31T23:30:22.064670+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.061430+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### ZKP = Signature numerique\n",
     "\n",
@@ -741,11 +893,19 @@
    "id": "schnorr-signature",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.334907Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.334659Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.340217Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.339602Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.072771Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.072455Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.077937Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.077266Z"
+    },
+    "papermill": {
+     "duration": 0.010291,
+     "end_time": "2026-05-31T23:30:22.078495+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.068204+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -761,15 +921,15 @@
       "\n",
       "Signatures de Schnorr sur differents messages :\n",
       "  Message  : Transferer 10 ETH a 0xBob\n",
-      "  Sig (R)  : 351208180486063551088209272901...\n",
+      "  Sig (R)  : 158982359975231097146814263535...\n",
       "  Valide   : True\n",
       "\n",
       "  Message  : Approuver le contrat 0xDefi\n",
-      "  Sig (R)  : 164795583118405300625445328055...\n",
+      "  Sig (R)  : 273337702379576568407142605220...\n",
       "  Valide   : True\n",
       "\n",
       "  Message  : Voter OUI pour la proposition 42\n",
-      "  Sig (R)  : 372434561971380273649512148655...\n",
+      "  Sig (R)  : 236983287613472594924218644871...\n",
       "  Valide   : True\n",
       "\n",
       "Points cles :\n",
@@ -816,7 +976,16 @@
   {
    "cell_type": "markdown",
    "id": "schnorr-interpretation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003137,
+     "end_time": "2026-05-31T23:30:22.084849+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.081712+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation\n",
     "\n",
@@ -837,7 +1006,16 @@
   {
    "cell_type": "markdown",
    "id": "sigma-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003304,
+     "end_time": "2026-05-31T23:30:22.091729+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.088425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -883,11 +1061,19 @@
    "id": "chaum-pedersen-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.342482Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.342319Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.349278Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.348728Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.100928Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.100589Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.108412Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.107575Z"
+    },
+    "papermill": {
+     "duration": 0.013768,
+     "end_time": "2026-05-31T23:30:22.109088+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.095320+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -896,9 +1082,9 @@
      "text": [
       "PROTOCOLE DE CHAUM-PEDERSEN\n",
       "============================================================\n",
-      "Secret x : 847511399977545995763644498391... (cache)\n",
-      "y1 = g^x : 267822424856598682115100461697...\n",
-      "y2 = h^x : 332842436367731523928041979600...\n",
+      "Secret x : 184953976021735358012809517999... (cache)\n",
+      "y1 = g^x : 144099519228675227780961911467...\n",
+      "y2 = h^x : 179928078688971693015473056840...\n",
       "\n",
       "Objectif : prouver que log_g(y1) == log_h(y2) sans reveler x\n",
       "\n"
@@ -983,7 +1169,16 @@
   {
    "cell_type": "markdown",
    "id": "chaum-pedersen-transition",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003658,
+     "end_time": "2026-05-31T23:30:22.116728+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.113070+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Verification et test de solidite\n",
     "\n",
@@ -998,11 +1193,19 @@
    "id": "chaum-pedersen-verify",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.350951Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.350802Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.356164Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.355673Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.124886Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.124675Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.130435Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.129715Z"
+    },
+    "papermill": {
+     "duration": 0.010671,
+     "end_time": "2026-05-31T23:30:22.130997+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.120326+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1012,9 +1215,9 @@
       "VERIFICATION CHAUM-PEDERSEN\n",
       "============================================================\n",
       "Preuve (R1, R2, s) :\n",
-      "  R1 = 955417350894797554858733899567...\n",
-      "  R2 = 311586520652863502597146744219...\n",
-      "  s  = 883156804031583586004688754508...\n",
+      "  R1 = 207413621502709751242910820459...\n",
+      "  R2 = 294082426057486250619240118364...\n",
+      "  s  = 870547487432934411357072023625...\n",
       "\n",
       "Verification : g^s == R1*y1^c  ET  h^s == R2*y2^c\n",
       "Resultat : VALIDE\n",
@@ -1044,7 +1247,8 @@
     "print(f\"  R2 = {str(R2)[:30]}...\")\n",
     "print(f\"  s  = {str(s)[:30]}...\")\n",
     "print(f\"\\nVerification : g^s == R1*y1^c  ET  h^s == R2*y2^c\")\n",
-    "print(f\"Resultat : {\"VALIDE\" if valid else \"INVALIDE\"}\")\n",
+    "verdict_cp = \"VALIDE\" if valid else \"INVALIDE\"\n",
+    "print(f\"Resultat : {verdict_cp}\")\n",
     "print()\n",
     "\n",
     "# Test avec des exposants differents (la preuve doit echouer)\n",
@@ -1056,7 +1260,8 @@
     "R1_f, R2_f, s_f = cp.prove(secret_x, y1, y2_fake)\n",
     "valid_fake = cp.verify(y1, y2_fake, R1_f, R2_f, s_f)\n",
     "print(f\"y1 = g^x, y2 = h^x_diff (x != x_diff)\")\n",
-    "print(f\"La preuve avec le secret x pour y2 = h^x_diff : {\"VALIDE\" if valid_fake else \"INVALIDE\"}\")\n",
+    "verdict_fake_cp = \"VALIDE\" if valid_fake else \"INVALIDE\"\n",
+    "print(f\"La preuve avec le secret x pour y2 = h^x_diff : {verdict_fake_cp}\")\n",
     "print()\n",
     "print(\"-> La preuve ne fonctionne que si les deux logarithmes sont identiques\")\n",
     "print()\n",
@@ -1069,7 +1274,16 @@
   {
    "cell_type": "markdown",
    "id": "748cebfe",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003728,
+     "end_time": "2026-05-31T23:30:22.138280+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.134552+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Verification Chaum-Pedersen\n",
     "\n",
@@ -1088,7 +1302,16 @@
   {
    "cell_type": "markdown",
    "id": "or-proof-concept",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004051,
+     "end_time": "2026-05-31T23:30:22.146129+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.142078+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Notion de OR-proofs\n",
     "\n",
@@ -1117,7 +1340,16 @@
   {
    "cell_type": "markdown",
    "id": "zk-snarks-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004283,
+     "end_time": "2026-05-31T23:30:22.154523+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.150240+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1170,11 +1402,19 @@
    "id": "r1cs-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.357946Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.357762Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.365241Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.364709Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.164885Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.164500Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.173905Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.172897Z"
+    },
+    "papermill": {
+     "duration": 0.015581,
+     "end_time": "2026-05-31T23:30:22.174627+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.159046+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1285,7 +1525,8 @@
     "    b_str = \" + \".join(f\"{c}*{v}\" for v, c in con[\"B\"].items())\n",
     "    c_str = \" + \".join(f\"{c}*{v}\" for v, c in con[\"C\"].items())\n",
     "    print(f\"  Contrainte {i+1}: ({a_str}) * ({b_str}) = ({c_str})\")\n",
-    "    print(f\"    => {a_val} * {b_val} = {c_val} ? {\"OK\" if valid else \"ECHEC\"}\")\n",
+    "    check = \"OK\" if valid else \"ECHEC\"\n",
+    "    print(f\"    => {a_val} * {b_val} = {c_val} ? {check}\")\n",
     "\n",
     "print(f\"\\nToutes les contraintes satisfaites : {all_valid}\")\n",
     "print(f\"Le prouveur connait x tel que x^3 + x + 5 == {out}\")\n",
@@ -1300,7 +1541,16 @@
   {
    "cell_type": "markdown",
    "id": "0ccc4367",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003715,
+     "end_time": "2026-05-31T23:30:22.182405+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.178690+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Circuit arithmetique et R1CS\n",
     "\n",
@@ -1322,7 +1572,16 @@
   {
    "cell_type": "markdown",
    "id": "snarks-comparison",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003466,
+     "end_time": "2026-05-31T23:30:22.190400+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.186934+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Comparaison des systemes de preuves\n",
     "\n",
@@ -1346,7 +1605,16 @@
   {
    "cell_type": "markdown",
    "id": "exercise-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00347,
+     "end_time": "2026-05-31T23:30:22.197342+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.193872+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1390,11 +1658,19 @@
    "id": "exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T01:01:34.366899Z",
-     "iopub.status.busy": "2026-05-29T01:01:34.366704Z",
-     "iopub.status.idle": "2026-05-29T01:01:34.370702Z",
-     "shell.execute_reply": "2026-05-29T01:01:34.370035Z"
-    }
+     "iopub.execute_input": "2026-05-31T23:30:22.205953Z",
+     "iopub.status.busy": "2026-05-31T23:30:22.205658Z",
+     "iopub.status.idle": "2026-05-31T23:30:22.209915Z",
+     "shell.execute_reply": "2026-05-31T23:30:22.209084Z"
+    },
+    "papermill": {
+     "duration": 0.009817,
+     "end_time": "2026-05-31T23:30:22.210588+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.200771+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1440,7 +1716,16 @@
   {
    "cell_type": "markdown",
    "id": "exercise-hints",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00382,
+     "end_time": "2026-05-31T23:30:22.218090+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.214270+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Indices\n",
     "\n",
@@ -1456,7 +1741,16 @@
   {
    "cell_type": "markdown",
    "id": "summary",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003684,
+     "end_time": "2026-05-31T23:30:22.225235+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.221551+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1499,13 +1793,39 @@
   {
    "cell_type": "markdown",
    "id": "cbeb8e83",
-   "source": "## Resume et perspectives\n\nCe notebook a constitue une plongee approfondie dans les preuves a divulgation nulle (Zero-Knowledge Proofs), des la fondation conceptuelle (analogie de la caverne d'Ali Baba) jusqu'aux architectures zk-SNARKs industrielles. Nous avons implemente le protocole de Schnorr en version interactive puis non-interactive (transformation de Fiat-Shamir), decouvert que cette derniere est exactement une signature numerique -- utilisee dans Bitcoin Taproot (BIP-340). Le protocole de Chaum-Pedersen a illustre la preuve d'egalite de logarithmes discrets, brique essentielle du vote electronique. Enfin, la decomposition d'un calcul arbitraire en circuit arithmetique puis en contraintes R1CS a demystifie le pipeline de construction des zk-SNARKs.\n\nLes ZKP representent un changement de paradigme en cryptographie : prouver sans reveler. Cette propriete trouve des applications majeures dans les zk-rollups (scalabilite L2 sur zkSync, StarkNet), les transactions privees (Zcash, Tornado Cash), et l'identite decentralisee. Le compromis entre taille de preuve et hypotheses de confiance (trusted setup pour Groth16, transparence pour zk-STARKs) guide le choix du systeme selon le contexte. Les implementations completes, reposant sur des pairings de courbes elliptiques (BN254, BLS12-381), depassent le cadre de ce notebook mais les concepts fondamentaux sont maintenant en place.\n\nLe prochain notebook explore le chiffrement homomorphique, une technique complementaire aux ZKP qui permet d'effectuer des calculs directement sur des donnees chiffrees, sans les dechiffrer : [SC-16-Homomorphic-Encryption](SC-16-Homomorphic-Encryption.ipynb).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003402,
+     "end_time": "2026-05-31T23:30:22.232042+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.228640+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a constitue une plongee approfondie dans les preuves a divulgation nulle (Zero-Knowledge Proofs), des la fondation conceptuelle (analogie de la caverne d'Ali Baba) jusqu'aux architectures zk-SNARKs industrielles. Nous avons implemente le protocole de Schnorr en version interactive puis non-interactive (transformation de Fiat-Shamir), decouvert que cette derniere est exactement une signature numerique -- utilisee dans Bitcoin Taproot (BIP-340). Le protocole de Chaum-Pedersen a illustre la preuve d'egalite de logarithmes discrets, brique essentielle du vote electronique. Enfin, la decomposition d'un calcul arbitraire en circuit arithmetique puis en contraintes R1CS a demystifie le pipeline de construction des zk-SNARKs.\n",
+    "\n",
+    "Les ZKP representent un changement de paradigme en cryptographie : prouver sans reveler. Cette propriete trouve des applications majeures dans les zk-rollups (scalabilite L2 sur zkSync, StarkNet), les transactions privees (Zcash, Tornado Cash), et l'identite decentralisee. Le compromis entre taille de preuve et hypotheses de confiance (trusted setup pour Groth16, transparence pour zk-STARKs) guide le choix du systeme selon le contexte. Les implementations completes, reposant sur des pairings de courbes elliptiques (BN254, BLS12-381), depassent le cadre de ce notebook mais les concepts fondamentaux sont maintenant en place.\n",
+    "\n",
+    "Le prochain notebook explore le chiffrement homomorphique, une technique complementaire aux ZKP qui permet d'effectuer des calculs directement sur des donnees chiffrees, sans les dechiffrer : [SC-16-Homomorphic-Encryption](SC-16-Homomorphic-Encryption.ipynb)."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "bbe60389",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003436,
+     "end_time": "2026-05-31T23:30:22.238946+00:00",
+     "exception": false,
+     "start_time": "2026-05-31T23:30:22.235510+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1529,7 +1849,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.58504,
+   "end_time": "2026-05-31T23:30:22.705128+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb",
+   "output_path": "/tmp/sc15_executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-31T23:30:19.120088+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Fix 7 nested f-string syntax errors in SC-15-Zero-Knowledge-Proofs.ipynb that cause SyntaxError on Python <3.12.

Python <3.12 does not support nested quotes inside f-string expressions like:
\\\python
# BROKEN on Python <3.12
print(f\"Result: {\"VALIDE\" if valid else \"INVALIDE\"}\")
\\\

## Fix pattern

Extract conditional to intermediate variable:
\\\python
# WORKS on all Python 3.x
verdict = \"VALIDE\" if valid else \"INVALIDE\"
print(f\"Result: {verdict}\")
\\\

## Locations fixed (7 total, 4 cells)

| Cell | Line pattern | Fix variable |
|------|-------------|-------------|
| dlog-interactive | \"CONVAINCU\"/\"ECHEC\" | \erdict_final\ |
| schnorr-comparison | \"OUI\"/\"NON\" | \erdict_inter\ |
| schnorr-comparison | \"VALIDE\"/\"INVALIDE\" | \erdict_ni\ |
| schnorr-comparison | \"VALIDE\"/\"INVALIDE\" | \erdict_fake\ |
| chaum-pedersen-verify | \"VALIDE\"/\"INVALIDE\" | \erdict_cp\ |
| chaum-pedersen-verify | \"VALIDE\"/\"INVALIDE\" | \erdict_fake_cp\ |
| r1cs-demo | \"OK\"/\"ECHEC\" | \check\ |

## Validation

- Papermill 35/35 cells executed successfully
- 0 SyntaxError
- No nested f-string conditionals remain (grep verified)

## Context

Reported by po-2023. CRITICAL for Monday-readiness: students on Python <3.12 will crash on these cells.