### PR TITLE
fix(GameTheory): fix 9 broken navigation links in 7 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory 15b - Jeux Cooperatifs en Lean : Formalisation de Shapley\n",
     "\n",
-    "**Navigation** : [<< 15-CooperativeGames (track principal)]([15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 15-CooperativeGames (track principal)](GameTheory-15-CooperativeGames.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Autres side tracks** : [15c-CooperativeGames-Python](GameTheory-15c-CooperativeGames-Python.ipynb)\n",
     "\n",
@@ -3518,7 +3518,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [← SocialChoice/01-Arrow](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | [Index](GameTheory-1-Setup.ipynb) | [Fin de la serie]"
+    "**Navigation** : [← SocialChoice/01-Arrow (notebook non disponible) | [Index](GameTheory-1-Setup.ipynb) | [Fin de la serie]"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory 15c - Jeux Cooperatifs Lean (Python)\n",
     "\n",
-    "**Navigation** : [<< 15-CooperativeGames (track principal)]([15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 15-CooperativeGames (track principal)](GameTheory-15-CooperativeGames.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Autres side tracks** : [15b-Lean-CooperativeGames](GameTheory-15b-Lean-CooperativeGames.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [<< 15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | [Index](README.md) | [17-MultiAgent-RL >>](GameTheory-17-MultiAgent-RL.ipynb)\n",
     "\n",
-    "**Side tracks** : [16b-Lean-SocialChoice](SocialChoice/02-Lean-SocialChoice-Formal.ipynb) | [16c-SocialChoice-Python](SocialChoice/03-Voting-Methods.ipynb)\n",
+    "**Side tracks** : [16b-Lean-SocialChoice (notebook non disponible) | [16c-SocialChoice-Python (notebook non disponible)\n",
     "\n",
     "## Concevoir des Regles pour des Agents Strategiques\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-2b-Lean-Definitions.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# GameTheory 2b - Formalisation Lean : Definitions de Base\n",
     "\n",
-    "**Navigation** : [<< 2-NormalForm (track principal)]([2-NormalForm](GameTheory-2-NormalForm.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 2-NormalForm (track principal)](GameTheory-2-NormalForm.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Kernel** : Lean 4 (WSL)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4b-Lean-NashExistence.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory 4b - Theoreme d'Existence de Nash (Lean)\n",
     "\n",
-    "**Navigation** : [<< 4-NashEquilibrium (track principal)]([4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 4-NashEquilibrium (track principal)](GameTheory-4-NashEquilibrium.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Autres side tracks** : [4c-NashExistence-Python](GameTheory-4c-NashExistence-Python.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory 4c - Theoreme d'Existence de Nash (Python)\n",
     "\n",
-    "**Navigation** : [<< 4-NashEquilibrium (track principal)]([4-NashEquilibrium](GameTheory-4-NashEquilibrium.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 4-NashEquilibrium (track principal)](GameTheory-4-NashEquilibrium.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Autres side tracks** : [4b-Lean-NashExistence](GameTheory-4b-Lean-NashExistence.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8b-Lean-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8b-Lean-CombinatorialGames.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# GameTheory 8b - Jeux Combinatoires en Lean\n",
     "\n",
-    "**Navigation** : [<< 8-CombinatorialGames (track principal)]([8-CombinatorialGames](GameTheory-8-CombinatorialGames.ipynb)) | [Index](README.md)\n",
+    "**Navigation** : [<< 8-CombinatorialGames (track principal)](GameTheory-8-CombinatorialGames.ipynb)) | [Index](README.md)\n",
     "\n",
     "**Autres side tracks** : [8c-CombinatorialGames-Python](GameTheory-8c-CombinatorialGames-Python.ipynb)\n",
     "\n",


### PR DESCRIPTION
Fix 9 broken navigation links in 7 GameTheory notebooks.

Categories:
1. Double-nested markdown syntax: [label]([inner](target.ipynb) -> [label](target.ipynb)
   - GT-2b, GT-4b, GT-4c, GT-8b, GT-15b, GT-15c (6 notebooks)
2. SocialChoice links to non-existent notebooks -> marked as unavailable
   - GT-15b (Arrow Impossibility), GT-16 (Lean-SocialChoice, Voting-Methods)

0 broken internal links remaining in GameTheory.
String-level replacement, no JSON reformatting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>