### PR TITLE
fix(qc): BTC-EMA-Cross research yfinance fallback (#1916 Phase 3)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-EMA-Cross/research_robustness.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "fa0ddcee",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002968,
+     "end_time": "2026-06-01T00:01:05.312197+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:05.309229+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Research: Robustness BTC-EMA-Cross sur Régimes Étendus (2019-2025)\n",
     "\n",
@@ -43,36 +53,45 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "d9f2d8b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:18.357028Z",
-     "iopub.status.busy": "2026-05-12T18:50:18.356903Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.382115Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.381451Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:05.318142Z",
+     "iopub.status.busy": "2026-06-01T00:01:05.317942Z",
+     "iopub.status.idle": "2026-06-01T00:01:06.419221Z",
+     "shell.execute_reply": "2026-06-01T00:01:06.418490Z"
+    },
+    "papermill": {
+     "duration": 1.105748,
+     "end_time": "2026-06-01T00:01:06.420590+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:05.314842+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "✓ BTC data loaded: 0 bars\n"
+      "QuantBook returned empty data, using yfinance fallback\n"
      ]
     },
     {
-     "ename": "IndexError",
-     "evalue": "index 0 is out of bounds for axis 0 with size 0",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mIndexError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:1018\u001b[39m, in \u001b[36mRangeIndex.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1017\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m1018\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_range\u001b[49m\u001b[43m[\u001b[49m\u001b[43mnew_key\u001b[49m\u001b[43m]\u001b[49m\n\u001b[32m   1019\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[31mIndexError\u001b[39m: range object index out of range",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mIndexError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 20\u001b[39m\n\u001b[32m     17\u001b[39m df = df.sort_index()\n\u001b[32m     19\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m✓ BTC data loaded: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mlen\u001b[39m(df)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m bars\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m20\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m  Period: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[43mdf\u001b[49m\u001b[43m.\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m[\u001b[49m\u001b[32;43m0\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m → \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdf.index[-\u001b[32m1\u001b[39m]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     21\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m  Columns: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdf.columns.tolist()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     22\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mFirst 3 bars:\u001b[39m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:1020\u001b[39m, in \u001b[36mRangeIndex.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   1018\u001b[39m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._range[new_key]\n\u001b[32m   1019\u001b[39m     \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n\u001b[32m-> \u001b[39m\u001b[32m1020\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m(\n\u001b[32m   1021\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mindex \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mkey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m is out of bounds for axis 0 with size \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mlen\u001b[39m(\u001b[38;5;28mself\u001b[39m)\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m   1022\u001b[39m         ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   1023\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m is_scalar(key):\n\u001b[32m   1024\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mIndexError\u001b[39;00m(\n\u001b[32m   1025\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33monly integers, slices (`:`), \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1026\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mellipsis (`...`), numpy.newaxis (`None`) \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1027\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mand integer or boolean \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1028\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33marrays are valid indices\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1029\u001b[39m     )\n",
-      "\u001b[31mIndexError\u001b[39m: index 0 is out of bounds for axis 0 with size 0"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BTC data: 2707 bars\n",
+      "  Period: 2019-01-01 00:00:00 -> 2026-05-30 00:00:00\n",
+      "  Columns: ['open', 'high', 'low', 'close', 'volume']\n",
+      "\n",
+      "First 3 bars:\n",
+      "                   open         high          low        close      volume\n",
+      "Date                                                                      \n",
+      "2019-01-01  3746.713379  3850.913818  3707.231201  3843.520020  4324200990\n",
+      "2019-01-02  3849.216309  3947.981201  3817.409424  3943.409424  5244856836\n",
+      "2019-01-03  3931.048584  3935.685059  3826.222900  3836.741211  4530215219\n"
      ]
     }
    ],
@@ -84,19 +103,40 @@
     "from datetime import datetime, timedelta\n",
     "import json\n",
     "\n",
-    "# Initialiser QuantBook\n",
-    "qb = QuantBook()\n",
-    "\n",
     "# Charger BTCUSD Daily depuis 2019-01-01\n",
-    "btc = qb.AddCrypto(\"BTCUSD\", Resolution.Daily).Symbol\n",
-    "history = qb.History(btc, datetime(2019, 1, 1), datetime.now(), Resolution.Daily)\n",
+    "# Primary: QuantBook (QC Cloud), Fallback: yfinance (local)\n",
+    "try:\n",
+    "    qb = QuantBook()\n",
+    "    btc = qb.AddCrypto(\"BTCUSD\", Resolution.Daily).Symbol\n",
+    "    history = qb.History(btc, datetime(2019, 1, 1), datetime.now(), Resolution.Daily)\n",
+    "    if isinstance(history.index, pd.MultiIndex):\n",
+    "        df = history.loc[btc].copy()\n",
+    "    else:\n",
+    "        df = history.copy()\n",
+    "    df = df.sort_index()\n",
+    "    if len(df) == 0:\n",
+    "        raise ValueError(\"QuantBook returned 0 bars for BTCUSD\")\n",
+    "    print(f\"BTC data loaded via QuantBook: {len(df)} bars\")\n",
+    "except Exception:\n",
+    "    import yfinance as yf\n",
+    "    print(\"QuantBook returned empty data, using yfinance fallback\")\n",
+    "    ticker = yf.Ticker(\"BTC-USD\")\n",
+    "    raw = ticker.history(start=\"2019-01-01\", end=datetime.now().strftime(\"%Y-%m-%d\"), auto_adjust=True)\n",
+    "    df = raw.rename(columns={\"Close\": \"close\", \"Open\": \"open\", \"High\": \"high\", \"Low\": \"low\", \"Volume\": \"volume\"})\n",
+    "    df = df[[\"open\", \"high\", \"low\", \"close\", \"volume\"]].dropna()\n",
+    "    df.index = df.index.tz_localize(None)\n",
     "\n",
-    "# Convertir en DataFrame\n",
-    "df = history.loc[btc] if isinstance(history.index, pd.MultiIndex) else history\n",
-    "df = df.sort_index()\n",
+    "# Guard: empty DataFrame\n",
+    "if len(df) == 0:\n",
+    "    print(\"WARNING: No BTC data available. Using synthetic data for structure validation.\")\n",
+    "    dates = pd.date_range(\"2019-01-01\", periods=2520, freq=\"D\")\n",
+    "    np.random.seed(42)\n",
+    "    close = 7000 * np.exp(np.cumsum(np.random.normal(0.0003, 0.04, len(dates))))\n",
+    "    df = pd.DataFrame({\"close\": close, \"open\": close * 0.999, \"high\": close * 1.01,\n",
+    "                        \"low\": close * 0.99, \"volume\": 1e9}, index=dates)\n",
     "\n",
-    "print(f\"✓ BTC data loaded: {len(df)} bars\")\n",
-    "print(f\"  Period: {df.index[0]} → {df.index[-1]}\")\n",
+    "print(f\"BTC data: {len(df)} bars\")\n",
+    "print(f\"  Period: {df.index[0]} -> {df.index[-1]}\")\n",
     "print(f\"  Columns: {df.columns.tolist()}\")\n",
     "print(f\"\\nFirst 3 bars:\")\n",
     "print(df.head(3))"
@@ -104,7 +144,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f4a53ba5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002627,
+     "end_time": "2026-06-01T00:01:06.426432+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.423805+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Classification des régimes de marché (tendanciel / retour à la moyenne) pour adapter les paramètres de CSharp-BTC-EMA-Cross."
    ]
@@ -112,26 +162,42 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "06af81d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:19.389058Z",
-     "iopub.status.busy": "2026-05-12T18:50:19.388915Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.595678Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.594797Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:06.433227Z",
+     "iopub.status.busy": "2026-06-01T00:01:06.432980Z",
+     "iopub.status.idle": "2026-06-01T00:01:06.454581Z",
+     "shell.execute_reply": "2026-06-01T00:01:06.453492Z"
+    },
+    "papermill": {
+     "duration": 0.026631,
+     "end_time": "2026-06-01T00:01:06.455597+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.428966+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "'close'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Cell 3: Détection des régimes de marché\u001b[39;00m\n\u001b[32m      2\u001b[39m \n\u001b[32m      3\u001b[39m \u001b[38;5;66;03m# Calculer rendement glissant 126 jours (environ 6 mois crypto)\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m df[\u001b[33m'\u001b[39m\u001b[33mreturns_126d\u001b[39m\u001b[33m'\u001b[39m] = \u001b[43mdf\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mclose\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.pct_change(\u001b[32m126\u001b[39m)\n\u001b[32m      6\u001b[39m \u001b[38;5;66;03m# Classifier régimes\u001b[39;00m\n\u001b[32m      7\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mclassify_regime\u001b[39m(ret):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.columns.nlevels > \u001b[32m1\u001b[39m:\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[32m   4115\u001b[39m     indexer = [indexer]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:417\u001b[39m, in \u001b[36mRangeIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m    415\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m    416\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Hashable):\n\u001b[32m--> \u001b[39m\u001b[32m417\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n\u001b[32m    418\u001b[39m \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n\u001b[32m    419\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n",
-      "\u001b[31mKeyError\u001b[39m: 'close'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Régimes de marché détectés:\n",
+      "         close                   \n",
+      "         count    first      last\n",
+      "regime                           \n",
+      "bear       540   7493.0   75488.0\n",
+      "bull       893   5830.0  113458.0\n",
+      "sideways  1148  10241.0   73755.0\n",
+      "unknown    126   3844.0    5747.0\n",
+      "\n",
+      "Périodes clés:\n",
+      "  COVID crash (Mar 2020): 32 bars\n",
+      "  Bull 2020-2021: 397 bars\n",
+      "  Bear 2022: 365 bars\n",
+      "  Recovery 2023-2024: 731 bars\n"
      ]
     }
    ],
@@ -177,7 +243,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "dbf9aad0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002336,
+     "end_time": "2026-06-01T00:01:06.460531+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.458195+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Les ratios (Sharpe, drawdown) sont calculés sur plusieurs fenêtres de backtest pour évaluer la robustesse de la stratégie CSharp-BTC-EMA-Cross."
    ]
@@ -185,13 +261,22 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "9ac652dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:19.597301Z",
-     "iopub.status.busy": "2026-05-12T18:50:19.597174Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.653869Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.652803Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:06.466492Z",
+     "iopub.status.busy": "2026-06-01T00:01:06.466272Z",
+     "iopub.status.idle": "2026-06-01T00:01:06.749828Z",
+     "shell.execute_reply": "2026-06-01T00:01:06.748931Z"
+    },
+    "papermill": {
+     "duration": 0.287744,
+     "end_time": "2026-06-01T00:01:06.750457+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.462713+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -200,21 +285,82 @@
      "text": [
       "============================================================\n",
       "BACKTEST EMA(18,23) - Période complète 2019-2025\n",
-      "============================================================\n"
+      "============================================================\n",
+      "  sharpe: 1.052\n",
+      "  max_dd: -0.523\n",
+      "  total_return: 14.142\n",
+      "  n_trades: 31\n",
+      "  win_rate: 0.516\n",
+      "  days: 2707\n",
+      "\n",
+      "============================================================\n",
+      "BACKTEST PAR RÉGIME\n",
+      "============================================================\n",
+      "\n",
+      "BULL (893 days):\n",
+      "  sharpe: 2.022\n",
+      "  max_dd: -0.358\n",
+      "  total_return: 12.31\n",
+      "  n_trades: 9\n",
+      "  win_rate: 0.526\n"
      ]
     },
     {
-     "ename": "KeyError",
-     "evalue": "'close'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 60\u001b[39m\n\u001b[32m     57\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33mBACKTEST EMA(18,23) - Période complète 2019-2025\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m     58\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33m\"\u001b[39m\u001b[33m=\u001b[39m\u001b[33m\"\u001b[39m * \u001b[32m60\u001b[39m)\n\u001b[32m---> \u001b[39m\u001b[32m60\u001b[39m full_results = \u001b[43mema_cross_backtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     61\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m k, v \u001b[38;5;129;01min\u001b[39;00m full_results.items():\n\u001b[32m     62\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m  \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mk\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mv\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 18\u001b[39m, in \u001b[36mema_cross_backtest\u001b[39m\u001b[34m(data, fast_period, slow_period, up_margin, down_margin)\u001b[39m\n\u001b[32m      4\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[33;03mBacktest vectorisé de la stratégie EMA Cross.\u001b[39;00m\n\u001b[32m      6\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m     15\u001b[39m \u001b[33;03m    dict: Métriques de performance\u001b[39;00m\n\u001b[32m     16\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     17\u001b[39m \u001b[38;5;66;03m# Calculer EMAs\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m18\u001b[39m ema_fast = \u001b[43mdata\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mclose\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.ewm(span=fast_period, adjust=\u001b[38;5;28;01mFalse\u001b[39;00m).mean()\n\u001b[32m     19\u001b[39m ema_slow = data[\u001b[33m'\u001b[39m\u001b[33mclose\u001b[39m\u001b[33m'\u001b[39m].ewm(span=slow_period, adjust=\u001b[38;5;28;01mFalse\u001b[39;00m).mean()\n\u001b[32m     21\u001b[39m \u001b[38;5;66;03m# Générer signaux (state machine pour éviter flip-flop)\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.columns.nlevels > \u001b[32m1\u001b[39m:\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[32m   4115\u001b[39m     indexer = [indexer]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:417\u001b[39m, in \u001b[36mRangeIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m    415\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m    416\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Hashable):\n\u001b[32m--> \u001b[39m\u001b[32m417\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n\u001b[32m    418\u001b[39m \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n\u001b[32m    419\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n",
-      "\u001b[31mKeyError\u001b[39m: 'close'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "BEAR (540 days):\n",
+      "  sharpe: -0.349\n",
+      "  max_dd: -0.601\n",
+      "  total_return: -0.492\n",
+      "  n_trades: 8\n",
+      "  win_rate: 0.473\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "SIDEWAYS (1148 days):\n",
+      "  sharpe: 0.768\n",
+      "  max_dd: -0.391\n",
+      "  total_return: 9.199\n",
+      "  n_trades: 11\n",
+      "  win_rate: 0.503\n",
+      "\n",
+      "============================================================\n",
+      "PÉRIODES CLÉS\n",
+      "============================================================\n",
+      "\n",
+      "COVID Crash (Mar 2020) (32 days):\n",
+      "  sharpe: -3.326\n",
+      "  max_dd: -0.133\n",
+      "  total_return: -0.1\n",
+      "  n_trades: 1\n",
+      "  win_rate: 0.286\n",
+      "\n",
+      "Bull 2020-2021 (397 days):\n",
+      "  sharpe: 2.877\n",
+      "  max_dd: -0.254\n",
+      "  total_return: 4.647\n",
+      "  n_trades: 2\n",
+      "  win_rate: 0.563\n",
+      "\n",
+      "Bear 2022 (365 days):\n",
+      "  sharpe: -1.642\n",
+      "  max_dd: -0.44\n",
+      "  total_return: -0.427\n",
+      "  n_trades: 5\n",
+      "  win_rate: 0.443\n",
+      "\n",
+      "Recovery 2023-2024 (731 days):\n",
+      "  sharpe: 1.654\n",
+      "  max_dd: -0.367\n",
+      "  total_return: 2.236\n",
+      "  n_trades: 7\n",
+      "  win_rate: 0.507\n"
      ]
     }
    ],
@@ -325,7 +471,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "3a95f267",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002645,
+     "end_time": "2026-06-01T00:01:06.756097+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.753452+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Les EMA (période courte et longue) sont calculées sur les données BTC/C# pour reproduire les signaux de croisement de la stratégie EMA-Cross."
    ]
@@ -333,13 +489,22 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "d8a04027",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:19.655671Z",
-     "iopub.status.busy": "2026-05-12T18:50:19.655503Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.704671Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.703456Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:06.763342Z",
+     "iopub.status.busy": "2026-06-01T00:01:06.763077Z",
+     "iopub.status.idle": "2026-06-01T00:01:07.534544Z",
+     "shell.execute_reply": "2026-06-01T00:01:07.533703Z"
+    },
+    "papermill": {
+     "duration": 0.776245,
+     "end_time": "2026-06-01T00:01:07.535102+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:06.758857+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -352,17 +517,35 @@
      ]
     },
     {
-     "ename": "KeyError",
-     "evalue": "'close'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[4]\u001b[39m\u001b[32m, line 19\u001b[39m\n\u001b[32m     17\u001b[39m grid_results = []\n\u001b[32m     18\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m fast, slow \u001b[38;5;129;01min\u001b[39;00m param_grid:\n\u001b[32m---> \u001b[39m\u001b[32m19\u001b[39m     results = \u001b[43mema_cross_backtest\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfast_period\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfast\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mslow_period\u001b[49m\u001b[43m=\u001b[49m\u001b[43mslow\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     20\u001b[39m     results[\u001b[33m'\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m'\u001b[39m] = fast\n\u001b[32m     21\u001b[39m     results[\u001b[33m'\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m'\u001b[39m] = slow\n",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 18\u001b[39m, in \u001b[36mema_cross_backtest\u001b[39m\u001b[34m(data, fast_period, slow_period, up_margin, down_margin)\u001b[39m\n\u001b[32m      4\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[33;03mBacktest vectorisé de la stratégie EMA Cross.\u001b[39;00m\n\u001b[32m      6\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m     15\u001b[39m \u001b[33;03m    dict: Métriques de performance\u001b[39;00m\n\u001b[32m     16\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m     17\u001b[39m \u001b[38;5;66;03m# Calculer EMAs\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m18\u001b[39m ema_fast = \u001b[43mdata\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mclose\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.ewm(span=fast_period, adjust=\u001b[38;5;28;01mFalse\u001b[39;00m).mean()\n\u001b[32m     19\u001b[39m ema_slow = data[\u001b[33m'\u001b[39m\u001b[33mclose\u001b[39m\u001b[33m'\u001b[39m].ewm(span=slow_period, adjust=\u001b[38;5;28;01mFalse\u001b[39;00m).mean()\n\u001b[32m     21\u001b[39m \u001b[38;5;66;03m# Générer signaux (state machine pour éviter flip-flop)\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.columns.nlevels > \u001b[32m1\u001b[39m:\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[32m   4115\u001b[39m     indexer = [indexer]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:417\u001b[39m, in \u001b[36mRangeIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m    415\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m    416\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Hashable):\n\u001b[32m--> \u001b[39m\u001b[32m417\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n\u001b[32m    418\u001b[39m \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n\u001b[32m    419\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n",
-      "\u001b[31mKeyError\u001b[39m: 'close'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Résultats triés par Sharpe (période complète):\n",
+      " fast  slow  sharpe  max_dd  total_return  n_trades\n",
+      "   12    26   1.253  -0.588        29.048        35\n",
+      "   15    20   1.228  -0.609        26.030        34\n",
+      "   21    55   1.106  -0.502        17.898        19\n",
+      "   30    50   1.072  -0.527        15.933        18\n",
+      "   18    23   1.052  -0.523        14.142        31\n",
+      "\n",
+      "============================================================\n",
+      "ROBUSTESSE PAR RÉGIME (Sharpe moyen)\n",
+      "============================================================\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Paramètres triés par Sharpe moyen sur tous les régimes:\n",
+      " fast  slow  avg_sharpe_regimes  min_sharpe_regime\n",
+      "   21    55               0.902             -0.102\n",
+      "   30    50               0.874             -0.186\n",
+      "   18    23               0.814             -0.349\n",
+      "   12    26               0.735             -0.531\n",
+      "   15    20               0.729             -0.511\n"
      ]
     }
    ],
@@ -429,7 +612,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "43289e50",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002418,
+     "end_time": "2026-06-01T00:01:07.540189+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:07.537771+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Validation walk-forward (train 252 j / test 63 j) pour évaluer la stabilité de CSharp-BTC-EMA-Cross dans le temps."
    ]
@@ -437,13 +630,22 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "78887ee2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:19.706150Z",
-     "iopub.status.busy": "2026-05-12T18:50:19.706020Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.743664Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.743028Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:07.545670Z",
+     "iopub.status.busy": "2026-06-01T00:01:07.545488Z",
+     "iopub.status.idle": "2026-06-01T00:01:09.270338Z",
+     "shell.execute_reply": "2026-06-01T00:01:09.269472Z"
+    },
+    "papermill": {
+     "duration": 1.728705,
+     "end_time": "2026-06-01T00:01:09.271074+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:07.542369+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -453,27 +655,66 @@
       "============================================================\n",
       "WALK-FORWARD VALIDATION\n",
       "Train: 252 days, Test: 63 days (rolling)\n",
-      "============================================================\n",
-      "\n",
-      "Nombre de périodes walk-forward: 0\n",
-      "\n",
-      "Détail par période:\n",
-      "Empty DataFrame\n",
-      "Columns: []\n",
-      "Index: []\n"
+      "============================================================\n"
      ]
     },
     {
-     "ename": "KeyError",
-     "evalue": "'train_sharpe'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 56\u001b[39m\n\u001b[32m     53\u001b[39m \u001b[38;5;28mprint\u001b[39m(wf_df.to_string(index=\u001b[38;5;28;01mFalse\u001b[39;00m))\n\u001b[32m     55\u001b[39m \u001b[38;5;66;03m# Calculer efficiency\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m56\u001b[39m avg_train_sharpe = \u001b[43mwf_df\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mtrain_sharpe\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.mean()\n\u001b[32m     57\u001b[39m avg_test_sharpe = wf_df[\u001b[33m'\u001b[39m\u001b[33mtest_sharpe\u001b[39m\u001b[33m'\u001b[39m].mean()\n\u001b[32m     58\u001b[39m efficiency = (avg_test_sharpe / avg_train_sharpe * \u001b[32m100\u001b[39m) \u001b[38;5;28;01mif\u001b[39;00m avg_train_sharpe > \u001b[32m0\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[32m0\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4111\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.columns.nlevels > \u001b[32m1\u001b[39m:\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n\u001b[32m   4115\u001b[39m     indexer = [indexer]\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/range.py:417\u001b[39m, in \u001b[36mRangeIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m    415\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m    416\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(key, Hashable):\n\u001b[32m--> \u001b[39m\u001b[32m417\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n\u001b[32m    418\u001b[39m \u001b[38;5;28mself\u001b[39m._check_indexing_error(key)\n\u001b[32m    419\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key)\n",
-      "\u001b[31mKeyError\u001b[39m: 'train_sharpe'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Nombre de périodes walk-forward: 38\n",
+      "\n",
+      "Détail par période:\n",
+      "test_start   test_end  best_fast  best_slow  train_sharpe  test_sharpe  benchmark_sharpe\n",
+      "2019-09-10 2019-11-11         12         26         2.115       -3.345            -4.286\n",
+      "2019-11-12 2020-01-13         21         55         2.240        0.000            -0.048\n",
+      "2020-01-14 2020-03-16         21         55         1.389       -1.165            -1.078\n",
+      "2020-03-17 2020-05-18         12         26        -0.350        3.996             3.996\n",
+      "2020-05-19 2020-07-20         12         26         1.155       -1.330            -1.831\n",
+      "2020-07-21 2020-09-21         12         26         1.400        1.103             0.824\n",
+      "2020-09-22 2020-11-23         15         20         1.039        7.179             7.179\n",
+      "2020-11-24 2021-01-25         30         50         2.950        3.643             3.643\n",
+      "2021-01-26 2021-03-29         12         26         3.176        4.068             4.078\n",
+      "2021-03-30 2021-05-31         12         26         3.885       -2.990            -4.196\n",
+      "2021-06-01 2021-08-02         18         23         3.655       -5.216            -5.216\n",
+      "2021-08-03 2021-10-04         18         23         2.363        0.260             0.260\n",
+      "2021-10-05 2021-12-06         18         23         1.403        0.441             0.441\n",
+      "2021-12-07 2022-02-07         12         26         0.561       -3.295             0.000\n",
+      "2022-02-08 2022-04-11         12         26         0.263       -0.701            -1.556\n",
+      "2022-04-12 2022-06-13         30         50         0.385       -1.702            -2.896\n",
+      "2022-06-14 2022-08-15         21         55        -0.143        0.928             0.744\n",
+      "2022-08-16 2022-10-17         30         50        -0.581        0.000             0.000\n",
+      "2022-10-18 2022-12-19         18         23        -0.406       -3.279            -3.279\n",
+      "2022-12-20 2023-02-20         18         23        -1.619        4.836             4.836\n",
+      "2023-02-21 2023-04-24         18         23         0.159        0.229             0.229\n",
+      "2023-04-25 2023-06-26         30         50         1.328       -3.577            -2.365\n",
+      "2023-06-27 2023-08-28         21         55         0.844        0.000             0.000\n",
+      "2023-08-29 2023-10-30         12         26         1.750        4.591             4.044\n",
+      "2023-10-31 2024-01-01         12         26         1.742        3.175             3.193\n",
+      "2024-01-02 2024-03-04         12         26         2.108        5.053             4.242\n",
+      "2024-03-05 2024-05-06         12         26         3.653       -0.823            -0.316\n",
+      "2024-05-07 2024-07-08         12         26         2.760        0.204             0.043\n",
+      "2024-07-09 2024-09-09         12         26         1.948       -2.887            -1.997\n",
+      "2024-09-10 2024-11-11         12         26         0.558        4.937             4.937\n",
+      "2024-11-12 2025-01-13         15         20         0.666        0.707             0.600\n",
+      "2025-01-14 2025-03-17         15         20         0.883       -0.775            -0.622\n",
+      "2025-03-18 2025-05-19         21         55         1.206        2.289             1.949\n",
+      "2025-05-20 2025-07-21         15         20         2.471        1.127             0.435\n",
+      "2025-07-22 2025-09-22         30         50         1.455        0.000            -2.976\n",
+      "2025-09-23 2025-11-24         15         20         1.057       -2.116            -2.475\n",
+      "2025-11-25 2026-01-26         12         26         0.148       -1.730            -2.191\n",
+      "2026-01-27 2026-03-30         12         26        -1.352       -2.368            -2.987\n",
+      "\n",
+      "============================================================\n",
+      "WALK-FORWARD SUMMARY\n",
+      "============================================================\n",
+      "Avg Train Sharpe (optimized): 1.270\n",
+      "Avg Test Sharpe (optimized): 0.302\n",
+      "Avg Benchmark Sharpe (18,23): 0.141\n",
+      "Walk-Forward Efficiency: 23.8%\n",
+      "\n",
+      "✗ Efficiency < 60%: Risque d'overfitting\n"
      ]
     }
    ],
@@ -553,7 +794,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ccee57ca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002893,
+     "end_time": "2026-06-01T00:01:09.277460+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:09.274567+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Résultats et Findings\n",
     "\n",
@@ -591,24 +842,69 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "4d1a70e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T18:50:19.745105Z",
-     "iopub.status.busy": "2026-05-12T18:50:19.744993Z",
-     "iopub.status.idle": "2026-05-12T18:50:19.769496Z",
-     "shell.execute_reply": "2026-05-12T18:50:19.768822Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:01:09.286371Z",
+     "iopub.status.busy": "2026-06-01T00:01:09.285989Z",
+     "iopub.status.idle": "2026-06-01T00:01:09.297096Z",
+     "shell.execute_reply": "2026-06-01T00:01:09.296264Z"
+    },
+    "papermill": {
+     "duration": 0.017216,
+     "end_time": "2026-06-01T00:01:09.297887+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:01:09.280671+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'full_results' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[6]\u001b[39m\u001b[32m, line 12\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Cell 8: Export Recommendations JSON\u001b[39;00m\n\u001b[32m      2\u001b[39m \n\u001b[32m      3\u001b[39m \u001b[38;5;66;03m# Synthétiser les recommandations\u001b[39;00m\n\u001b[32m      4\u001b[39m recommendations = {\n\u001b[32m      5\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mproject_id\u001b[39m\u001b[33m\"\u001b[39m: \u001b[32m21193838\u001b[39m,\n\u001b[32m      6\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mproject_name\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mCSharp-BTC-EMA-Cross\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      7\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33manalysis_date\u001b[39m\u001b[33m\"\u001b[39m: datetime.now().strftime(\u001b[33m\"\u001b[39m\u001b[33m%\u001b[39m\u001b[33mY-\u001b[39m\u001b[33m%\u001b[39m\u001b[33mm-\u001b[39m\u001b[38;5;132;01m%d\u001b[39;00m\u001b[33m\"\u001b[39m),\n\u001b[32m      8\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mcurrent_period\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33m2021-10-16 → 2026\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m      9\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mtested_period\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33m2019-01-01 → 2025\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     10\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mcurrent_sharpe\u001b[39m\u001b[33m\"\u001b[39m: \u001b[32m1.094\u001b[39m,\n\u001b[32m     11\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mfindings\u001b[39m\u001b[33m\"\u001b[39m: {\n\u001b[32m---> \u001b[39m\u001b[32m12\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mfull_period_sharpe\u001b[39m\u001b[33m\"\u001b[39m: \u001b[43mfull_results\u001b[49m[\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m],\n\u001b[32m     13\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mfull_period_max_dd\u001b[39m\u001b[33m\"\u001b[39m: full_results[\u001b[33m'\u001b[39m\u001b[33mmax_dd\u001b[39m\u001b[33m'\u001b[39m],\n\u001b[32m     14\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mcovid_crash_sharpe\u001b[39m\u001b[33m\"\u001b[39m: period_results.get(\u001b[33m'\u001b[39m\u001b[33mCOVID Crash (Mar 2020)\u001b[39m\u001b[33m'\u001b[39m, {}).get(\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mN/A\u001b[39m\u001b[33m'\u001b[39m),\n\u001b[32m     15\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mwalk_forward_efficiency\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mround\u001b[39m(efficiency, \u001b[32m1\u001b[39m),\n\u001b[32m     16\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mbest_params_overall\u001b[39m\u001b[33m\"\u001b[39m: {\n\u001b[32m     17\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mint\u001b[39m(grid_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m'\u001b[39m]),\n\u001b[32m     18\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mint\u001b[39m(grid_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m'\u001b[39m]),\n\u001b[32m     19\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mfloat\u001b[39m(grid_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m])\n\u001b[32m     20\u001b[39m         },\n\u001b[32m     21\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mbest_params_robust\u001b[39m\u001b[33m\"\u001b[39m: {\n\u001b[32m     22\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mint\u001b[39m(robustness_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m'\u001b[39m]),\n\u001b[32m     23\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mint\u001b[39m(robustness_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m'\u001b[39m]),\n\u001b[32m     24\u001b[39m             \u001b[33m\"\u001b[39m\u001b[33mavg_sharpe_regimes\u001b[39m\u001b[33m\"\u001b[39m: \u001b[38;5;28mfloat\u001b[39m(robustness_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mavg_sharpe_regimes\u001b[39m\u001b[33m'\u001b[39m])\n\u001b[32m     25\u001b[39m         }\n\u001b[32m     26\u001b[39m     },\n\u001b[32m     27\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mvalidation_status\u001b[39m\u001b[33m\"\u001b[39m: {\n\u001b[32m     28\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mh1_covid_crash\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mPASS\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m period_results.get(\u001b[33m'\u001b[39m\u001b[33mCOVID Crash (Mar 2020)\u001b[39m\u001b[33m'\u001b[39m, {}).get(\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m, \u001b[32m0\u001b[39m) > \u001b[32m0.5\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mFAIL\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     29\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mh2_full_period\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mPASS\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[32m0.7\u001b[39m <= full_results[\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m] <= \u001b[32m0.9\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mFAIL\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     30\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mh3_walk_forward\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mPASS\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m efficiency > \u001b[32m60\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mFAIL\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m     31\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33mh4_params_18_23\u001b[39m\u001b[33m\"\u001b[39m: \u001b[33m\"\u001b[39m\u001b[33mPASS\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m grid_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mfast\u001b[39m\u001b[33m'\u001b[39m] == \u001b[32m18\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m grid_df.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mslow\u001b[39m\u001b[33m'\u001b[39m] == \u001b[32m23\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33mFAIL\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m     32\u001b[39m     },\n\u001b[32m     33\u001b[39m     \u001b[33m\"\u001b[39m\u001b[33mrecommended_changes\u001b[39m\u001b[33m\"\u001b[39m: []\n\u001b[32m     34\u001b[39m }\n\u001b[32m     36\u001b[39m \u001b[38;5;66;03m# Décider des changements\u001b[39;00m\n\u001b[32m     37\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m full_results[\u001b[33m'\u001b[39m\u001b[33msharpe\u001b[39m\u001b[33m'\u001b[39m] >= \u001b[32m0.7\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m efficiency > \u001b[32m60\u001b[39m:\n",
-      "\u001b[31mNameError\u001b[39m: name 'full_results' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "============================================================\n",
+      "RECOMMENDATIONS EXPORTÉES\n",
+      "============================================================\n",
+      "{\n",
+      "  \"project_id\": 21193838,\n",
+      "  \"project_name\": \"CSharp-BTC-EMA-Cross\",\n",
+      "  \"analysis_date\": \"2026-06-01\",\n",
+      "  \"current_period\": \"2021-10-16 \\u2192 2026\",\n",
+      "  \"tested_period\": \"2019-01-01 \\u2192 2025\",\n",
+      "  \"current_sharpe\": 1.094,\n",
+      "  \"findings\": {\n",
+      "    \"full_period_sharpe\": 1.052,\n",
+      "    \"full_period_max_dd\": -0.523,\n",
+      "    \"covid_crash_sharpe\": -3.326,\n",
+      "    \"walk_forward_efficiency\": 23.8,\n",
+      "    \"best_params_overall\": {\n",
+      "      \"fast\": 12,\n",
+      "      \"slow\": 26,\n",
+      "      \"sharpe\": 1.253\n",
+      "    },\n",
+      "    \"best_params_robust\": {\n",
+      "      \"fast\": 21,\n",
+      "      \"slow\": 55,\n",
+      "      \"avg_sharpe_regimes\": 0.902\n",
+      "    }\n",
+      "  },\n",
+      "  \"validation_status\": {\n",
+      "    \"h1_covid_crash\": \"FAIL\",\n",
+      "    \"h2_full_period\": \"FAIL\",\n",
+      "    \"h3_walk_forward\": \"FAIL\",\n",
+      "    \"h4_params_18_23\": \"FAIL\"\n",
+      "  },\n",
+      "  \"recommended_changes\": [\n",
+      "    {\n",
+      "      \"file\": \"None\",\n",
+      "      \"reason\": \"Extended period validation failed (Sharpe=1.052, target 0.7-0.9)\"\n",
+      "    }\n",
+      "  ]\n",
+      "}\n",
+      "\n",
+      "✓ Saved to: research_robustness_recommendations.json\n"
      ]
     }
    ],
@@ -702,9 +998,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.41787,
+   "end_time": "2026-06-01T00:01:09.762757+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-BTC-EMA-Cross\\research_robustness.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\CSharp-BTC-EMA-Cross\\research_robustness_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-01T00:01:03.344887+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
Fix 6 error cells in CSharp-BTC-EMA-Cross/research_robustness.ipynb caused by QuantBook returning 0 bars for BTCUSD.

## Root Cause
Cell 1 called `qb.History()` for BTCUSD which returned an empty enumerable (0 bars). This caused:
- `IndexError` on `df.index[0]` (empty DataFrame)
- `KeyError 'close'` (no columns in empty df)
- `KeyError 'train_sharpe'` (walk-forward produced 0 results)
- `NameError 'full_results'` (undefined from previous cell error)
- Cascading NameError in remaining cells

## Fix
QuantBook primary + yfinance fallback + synthetic data guard (same pattern as PR #1982):
1. Try QuantBook with Symbol object (not string)
2. If empty/error, fall back to yfinance `BTC-USD` ticker
3. If still empty, generate synthetic data for structure validation

## Validation
- Papermill: 6/6 code cells OK, 0 errors, 8.4s
- yfinance loaded 2707 BTC-USD bars (2019-2026)
- Results: Sharpe 1.052, MaxDD -52.3%, Total Return 1414%
- No forbidden patterns (`raise NotImplementedError`, `assert False`, `1/0`)
- All `execution_count` set, all outputs present

## Scope
- 1 notebook: `CSharp-BTC-EMA-Cross/research_robustness.ipynb`
- 1 cell source changed (cell 1 - data loading)
- 432 insertions, 124 deletions (fix code + new outputs)

Part of #1916 Phase 3. Follows PR #1982 (7 Research-Executor) and PR #1986 (CTG-Momentum).