### PR TITLE
fix(qc): Alpha-Correlation-Analysis MultiIndex + idxmax NaN guard (#1916 Phase 5)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Alpha-Correlation-Analysis/quantbook.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "26887cdc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003774,
+     "end_time": "2026-06-01T00:17:39.798137+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:39.794363+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Alpha Correlation Analysis\n",
     "\n",
@@ -49,40 +59,66 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "a28746c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:07.225412Z",
-     "iopub.status.busy": "2026-05-12T16:05:07.225292Z",
-     "iopub.status.idle": "2026-05-12T16:05:07.933958Z",
-     "shell.execute_reply": "2026-05-12T16:05:07.932955Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:39.805609Z",
+     "iopub.status.busy": "2026-06-01T00:17:39.805427Z",
+     "iopub.status.idle": "2026-06-01T00:17:40.186223Z",
+     "shell.execute_reply": "2026-06-01T00:17:40.185361Z"
+    },
+    "papermill": {
+     "duration": 0.38556,
+     "end_time": "2026-06-01T00:17:40.187017+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:39.801457+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Analysis period: 2020-01-01 00:00:00 to 2024-12-31 23:59:59.999999\n"
+      "Local environment detected - yfinance will be used for data\n"
      ]
     }
    ],
    "source": [
     "# QuantConnect Research Environment\n",
-    "from AlgorithmImports import *\n",
+    "from datetime import datetime, timedelta\n",
+    "try:\n",
+    "    from AlgorithmImports import *\n",
+    "except (ImportError, ModuleNotFoundError):\n",
+    "    pass\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
     "\n",
     "# Initialize QuantBook\n",
-    "qb = QuantBook()\n",
-    "\n",
-    "# Set analysis period\n",
-    "qb.SetStartDate(2020, 1, 1)\n",
-    "qb.SetEndDate(2024, 12, 31)\n",
-    "\n",
-    "print(f\"Analysis period: {qb.StartDate} to {qb.EndDate}\")"
+    "try:\n",
+    "    qb = QuantBook()\n",
+    "    # Set analysis period\n",
+    "    qb.SetStartDate(2020, 1, 1)\n",
+    "    qb.SetEndDate(2024, 12, 31)\n",
+    "    print(f\"Analysis period: {qb.StartDate} to {qb.EndDate}\")\n",
+    "except NameError:\n",
+    "    print(\"Local environment detected - yfinance will be used for data\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6933c691",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003481,
+     "end_time": "2026-06-01T00:17:40.194366+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:40.190885+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Define Alpha Strategies\n",
     "\n",
@@ -92,54 +128,60 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "e5fcd665",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:07.952223Z",
-     "iopub.status.busy": "2026-05-12T16:05:07.952056Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.054140Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.053344Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:40.202602Z",
+     "iopub.status.busy": "2026-06-01T00:17:40.202245Z",
+     "iopub.status.idle": "2026-06-01T00:17:40.207113Z",
+     "shell.execute_reply": "2026-06-01T00:17:40.206343Z"
+    },
+    "papermill": {
+     "duration": 0.010015,
+     "end_time": "2026-06-01T00:17:40.207701+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:40.197686+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Added 18 assets\n"
+      "Using 18 tickers (local environment)\n"
      ]
     }
    ],
    "source": [
-    "# Add assets for our alpha universe\n",
-    "assets = {\n",
-    "    'SPY': qb.AddEquity('SPY', Resolution.DAILY).Symbol,\n",
-    "    'TLT': qb.AddEquity('TLT', Resolution.DAILY).Symbol,\n",
-    "    'GLD': qb.AddEquity('GLD', Resolution.DAILY).Symbol,\n",
-    "    'XLP': qb.AddEquity('XLP', Resolution.DAILY).Symbol,\n",
-    "    'IEF': qb.AddEquity('IEF', Resolution.DAILY).Symbol,\n",
-    "    'AAPL': qb.AddEquity('AAPL', Resolution.DAILY).Symbol,\n",
-    "    'MSFT': qb.AddEquity('MSFT', Resolution.DAILY).Symbol,\n",
-    "    'GOOGL': qb.AddEquity('GOOGL', Resolution.DAILY).Symbol,\n",
-    "    'AMZN': qb.AddEquity('AMZN', Resolution.DAILY).Symbol,\n",
-    "    'NVDA': qb.AddEquity('NVDA', Resolution.DAILY).Symbol,\n",
-    "    # Sector ETFs\n",
-    "    'XLK': qb.AddEquity('XLK', Resolution.DAILY).Symbol,\n",
-    "    'XLE': qb.AddEquity('XLE', Resolution.DAILY).Symbol,\n",
-    "    'XLF': qb.AddEquity('XLF', Resolution.DAILY).Symbol,\n",
-    "    'XLV': qb.AddEquity('XLV', Resolution.DAILY).Symbol,\n",
-    "    'XLY': qb.AddEquity('XLY', Resolution.DAILY).Symbol,\n",
-    "    'XLP': qb.AddEquity('XLP', Resolution.DAILY).Symbol,\n",
-    "    'XLB': qb.AddEquity('XLB', Resolution.DAILY).Symbol,\n",
-    "    'XLRE': qb.AddEquity('XLRE', Resolution.DAILY).Symbol,\n",
-    "    'XLU': qb.AddEquity('XLU', Resolution.DAILY).Symbol,\n",
-    "}\n",
+    "# Define tickers for our alpha universe\n",
+    "tickers = ['SPY', 'TLT', 'GLD', 'XLP', 'IEF', 'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA',\n",
+    "           'XLK', 'XLE', 'XLF', 'XLV', 'XLY', 'XLB', 'XLRE', 'XLU']\n",
     "\n",
-    "print(f\"Added {len(assets)} assets\")"
+    "# Register assets on QC Cloud\n",
+    "assets = {}\n",
+    "try:\n",
+    "    for t in tickers:\n",
+    "        assets[t] = qb.AddEquity(t, Resolution.DAILY).Symbol\n",
+    "    print(f\"Added {len(assets)} assets to QuantBook\")\n",
+    "except NameError:\n",
+    "    print(f\"Using {len(tickers)} tickers (local environment)\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "337bdcb6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003281,
+     "end_time": "2026-06-01T00:17:40.214428+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:40.211147+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Pivot de la série 'close' en DataFrame large, avec remapping des colonnes Symbol → ticker pour Alpha-Correlation-Analysis."
    ]
@@ -147,120 +189,93 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "492de5f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.055629Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.055518Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.335757Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.334969Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:40.222010Z",
+     "iopub.status.busy": "2026-06-01T00:17:40.221825Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.631444Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.630629Z"
+    },
+    "papermill": {
+     "duration": 2.414255,
+     "end_time": "2026-06-01T00:17:42.632031+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:40.217776+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data shape: (1825, 3)\n",
-      "Date range: 2012-09-28 16:00:00 to 2019-12-31 16:00:00\n"
+      "Data shape: (1255, 18)\n",
+      "Tickers loaded: 18/18\n",
+      "Date range: 2021-06-01 00:00:00 to 2026-05-29 00:00:00\n",
+      "Columns: ['SPY', 'TLT', 'GLD', 'XLP', 'IEF', 'AAPL', 'MSFT', 'GOOGL', 'AMZN', 'NVDA', 'XLK', 'XLE', 'XLF', 'XLV', 'XLY', 'XLB', 'XLRE', 'XLU']\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th>symbol</th>\n",
-       "      <th>AAPL</th>\n",
-       "      <th>GOOGL</th>\n",
-       "      <th>SPY</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>time</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2012-09-28 16:00:00</th>\n",
-       "      <td>20.615099</td>\n",
-       "      <td>377.250</td>\n",
-       "      <td>121.773920</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2012-10-01 16:00:00</th>\n",
-       "      <td>20.382458</td>\n",
-       "      <td>380.990</td>\n",
-       "      <td>122.036199</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2012-10-02 16:00:00</th>\n",
-       "      <td>20.431273</td>\n",
-       "      <td>378.495</td>\n",
-       "      <td>122.256176</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2012-10-03 16:00:00</th>\n",
-       "      <td>20.753509</td>\n",
-       "      <td>381.250</td>\n",
-       "      <td>122.738432</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2012-10-04 16:00:00</th>\n",
-       "      <td>20.600887</td>\n",
-       "      <td>384.025</td>\n",
-       "      <td>123.753708</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "symbol                    AAPL    GOOGL         SPY\n",
-       "time                                               \n",
-       "2012-09-28 16:00:00  20.615099  377.250  121.773920\n",
-       "2012-10-01 16:00:00  20.382458  380.990  122.036199\n",
-       "2012-10-02 16:00:00  20.431273  378.495  122.256176\n",
-       "2012-10-03 16:00:00  20.753509  381.250  122.738432\n",
-       "2012-10-04 16:00:00  20.600887  384.025  123.753708"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Fetch historical data\n",
-    "history = qb.History(list(assets.values()), 365*5, Resolution.Daily)\n",
+    "# Fetch historical data per-ticker (avoids MultiIndex Symbol lookup issue)\n",
+    "data = {}\n",
+    "for ticker in tickers:\n",
+    "    loaded = False\n",
+    "    # Try QC Cloud per-ticker\n",
+    "    try:\n",
+    "        hist = qb.History(assets[ticker], 365*5, Resolution.Daily)\n",
+    "        if hasattr(hist, 'shape') and len(hist) > 0:\n",
+    "            if isinstance(hist.index, pd.MultiIndex):\n",
+    "                try:\n",
+    "                    df_t = hist.loc[ticker]\n",
+    "                except KeyError:\n",
+    "                    df_t = hist.droplevel(0)\n",
+    "            else:\n",
+    "                df_t = hist.copy()\n",
+    "            if len(df_t) > 0:\n",
+    "                data[ticker] = df_t['close']\n",
+    "                loaded = True\n",
+    "    except (NameError, KeyError, TypeError):\n",
+    "        pass\n",
     "\n",
-    "# Process data\n",
-    "closes = history['close'].unstack(level=0)\n",
+    "    # yfinance fallback for this ticker\n",
+    "    if not loaded:\n",
+    "        try:\n",
+    "            import yfinance as yf\n",
+    "            raw = yf.Ticker(ticker).history(period=\"5y\", auto_adjust=True)\n",
+    "            if len(raw) > 0:\n",
+    "                series = raw['Close']\n",
+    "                series.index = series.index.tz_localize(None)\n",
+    "                data[ticker] = series\n",
+    "                loaded = True\n",
+    "        except Exception as e:\n",
+    "            print(f\"  WARNING: {ticker} unavailable ({e})\")\n",
+    "\n",
+    "closes = pd.DataFrame(data)\n",
+    "# Forward-fill to align different ticker date ranges, drop entirely-empty columns\n",
+    "closes = closes.ffill().dropna(axis=1, how='all').dropna(how='all')\n",
     "\n",
     "print(f\"Data shape: {closes.shape}\")\n",
+    "print(f\"Tickers loaded: {len(closes.columns)}/{len(tickers)}\")\n",
     "print(f\"Date range: {closes.index.min()} to {closes.index.max()}\")\n",
-    "closes.head()"
+    "print(f\"Columns: {list(closes.columns)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a54b1dd5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003647,
+     "end_time": "2026-06-01T00:17:42.639782+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.636135+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Implement Alpha Strategies\n",
     "\n",
@@ -270,13 +285,22 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "407313b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.337238Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.337040Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.341004Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.340330Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.648121Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.647792Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.653185Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.652359Z"
+    },
+    "papermill": {
+     "duration": 0.010113,
+     "end_time": "2026-06-01T00:17:42.653690+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.643577+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -314,7 +338,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "9991ab05",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003359,
+     "end_time": "2026-06-01T00:17:42.660569+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.657210+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "La moyenne mobile exponentielle est calculée pour identifier les signaux directionnels de la stratégie Alpha-Correlation-Analysis."
    ]
@@ -322,21 +356,30 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "570d61a9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.342241Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.342125Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.355054Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.354391Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.668716Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.668533Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.681671Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.680673Z"
+    },
+    "papermill": {
+     "duration": 0.018368,
+     "end_time": "2026-06-01T00:17:42.682270+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.663902+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "EMA Cross SPY - Total Return: 73.01%\n",
-      "Signal distribution: {1: 1549, 0: 276}\n"
+      "EMA Cross SPY - Total Return: 48.05%\n",
+      "Signal distribution: {1: 944, 0: 311}\n"
      ]
     }
    ],
@@ -374,7 +417,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "713dfcd9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003371,
+     "end_time": "2026-06-01T00:17:42.689299+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.685928+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Calcul des métriques de performance (Sharpe, CAGR, drawdown) pour évaluer la qualité du backtest de la stratégie Alpha-Correlation-Analysis."
    ]
@@ -382,20 +435,29 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "8181d197",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.356261Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.356138Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.360875Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.360191Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.696843Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.696682Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.701066Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.700457Z"
+    },
+    "papermill": {
+     "duration": 0.008979,
+     "end_time": "2026-06-01T00:17:42.701478+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.692499+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Momentum SPY - Total Return: 48.97%\n"
+      "Momentum SPY - Total Return: 51.12%\n"
      ]
     }
    ],
@@ -420,7 +482,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b3135ce4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003525,
+     "end_time": "2026-06-01T00:17:42.708820+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.705295+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Définition de dual_momentum_alpha() : fonction d'allocation ou de signal utilisée dans la comparaison des stratégies de Alpha-Correlation-Analysis."
    ]
@@ -428,44 +500,30 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "be7191ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.362287Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.362155Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.902245Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.900804Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.716878Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.716690Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.730122Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.729441Z"
+    },
+    "papermill": {
+     "duration": 0.018544,
+     "end_time": "2026-06-01T00:17:42.730799+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.712255+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "\"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3812\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3811\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m3812\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_engine\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcasted_key\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   3813\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:167\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:196\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7096\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[31mKeyError\u001b[39m: 'TLT'",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3819\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3818\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[32m-> \u001b[39m\u001b[32m3819\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   3820\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[32m   3821\u001b[39m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[32m   3822\u001b[39m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[32m   3823\u001b[39m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n",
-      "\u001b[31mKeyError\u001b[39m: 'TLT'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\"",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[7]\u001b[39m\u001b[32m, line 41\u001b[39m\n\u001b[32m     37\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m strategy_returns, signals\n\u001b[32m     39\u001b[39m \u001b[38;5;66;03m# Test\u001b[39;00m\n\u001b[32m     40\u001b[39m dm_returns, dm_signals = dual_momentum_alpha(\n\u001b[32m---> \u001b[39m\u001b[32m41\u001b[39m     closes[\u001b[33m'\u001b[39m\u001b[33mSPY\u001b[39m\u001b[33m'\u001b[39m], \u001b[43mcloses\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mTLT\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m, closes[\u001b[33m'\u001b[39m\u001b[33mGLD\u001b[39m\u001b[33m'\u001b[39m], closes[\u001b[33m'\u001b[39m\u001b[33mXLP\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     42\u001b[39m )\n\u001b[32m     43\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mDual Momentum - Total Return: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdm_returns.sum()\u001b[38;5;132;01m:\u001b[39;00m\u001b[33m.2%\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     44\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAsset allocation: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mdm_signals[\u001b[33m'\u001b[39m\u001b[33masset\u001b[39m\u001b[33m'\u001b[39m].value_counts().to_dict()\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     88\u001b[39m mKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m newargs \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\""
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dual Momentum - Total Return: 96.51%\n",
+      "Asset allocation: {'GLD': 615, 'SPY': 446, 'XLP': 190, 'TLT': 4}\n"
      ]
     }
    ],
@@ -490,8 +548,9 @@
     "    })\n",
     "    \n",
     "    # Defensive: if SPY momentum < 0, choose best defensive\n",
+    "    # fillna(0): during lookback warmup, treat momentum as neutral\n",
     "    signals = pd.DataFrame(index=momentums.index)\n",
-    "    signals['asset'] = momentums.idxmax(axis=1)\n",
+    "    signals['asset'] = momentums.fillna(0).idxmax(axis=1)\n",
     "    \n",
     "    # Calculate returns\n",
     "    spy_ret = spy_prices.pct_change().shift(-1)\n",
@@ -518,7 +577,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4d9a7258",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003628,
+     "end_time": "2026-06-01T00:17:42.738074+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.734446+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Calcul du Z-score du spread pour détecter les déviations statistiques et générer les signaux d'entrée/sortie dans Alpha-Correlation-Analysis."
    ]
@@ -526,20 +595,29 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "814cf281",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.904126Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.903979Z",
-     "iopub.status.idle": "2026-05-12T16:05:08.911068Z",
-     "shell.execute_reply": "2026-05-12T16:05:08.910017Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.746054Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.745877Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.751590Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.750922Z"
+    },
+    "papermill": {
+     "duration": 0.01064,
+     "end_time": "2026-06-01T00:17:42.752125+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.741485+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Reversion SPY - Total Return: 22.94%\n"
+      "Mean Reversion SPY - Total Return: 18.50%\n"
      ]
     }
    ],
@@ -574,7 +652,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "64a7cb1c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003563,
+     "end_time": "2026-06-01T00:17:42.759014+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.755451+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Définition de all_weather_allocation() : calcul des poids d'allocation statique pour le portefeuille Alpha-Correlation-Analysis."
    ]
@@ -582,45 +670,29 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "d5839d63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:08.912932Z",
-     "iopub.status.busy": "2026-05-12T16:05:08.912786Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.030868Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.029661Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.766725Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.766553Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.771361Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.770844Z"
+    },
+    "papermill": {
+     "duration": 0.00971,
+     "end_time": "2026-06-01T00:17:42.772027+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.762317+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "\"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3812\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3811\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m3812\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_engine\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcasted_key\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   3813\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:167\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:196\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7096\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[31mKeyError\u001b[39m: 'TLT'",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3819\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3818\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[32m-> \u001b[39m\u001b[32m3819\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   3820\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[32m   3821\u001b[39m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[32m   3822\u001b[39m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[32m   3823\u001b[39m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n",
-      "\u001b[31mKeyError\u001b[39m: 'TLT'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\"",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 20\u001b[39m\n\u001b[32m     11\u001b[39m     strategy_returns = (\n\u001b[32m     12\u001b[39m         spy_weight * spy_ret +\n\u001b[32m     13\u001b[39m         tlt_weight * tlt_ret +\n\u001b[32m     14\u001b[39m         gld_weight * gld_ret +\n\u001b[32m     15\u001b[39m         xlp_weight * xlp_ret\n\u001b[32m     16\u001b[39m     )\n\u001b[32m     18\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m strategy_returns\n\u001b[32m---> \u001b[39m\u001b[32m20\u001b[39m aw_returns = \u001b[43mall_weather_allocation\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     21\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAll Weather - Total Return: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00maw_returns.sum()\u001b[38;5;132;01m:\u001b[39;00m\u001b[33m.2%\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 7\u001b[39m, in \u001b[36mall_weather_allocation\u001b[39m\u001b[34m(spy_weight, tlt_weight, gld_weight, xlp_weight)\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;250m\u001b[39m\u001b[33;03m\"\"\"All-Weather-style static allocation.\u001b[39;00m\n\u001b[32m      3\u001b[39m \n\u001b[32m      4\u001b[39m \u001b[33;03mPermanent portfolio with balanced allocation.\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[33;03m\"\"\"\u001b[39;00m\n\u001b[32m      6\u001b[39m spy_ret = closes[\u001b[33m'\u001b[39m\u001b[33mSPY\u001b[39m\u001b[33m'\u001b[39m].pct_change().shift(-\u001b[32m1\u001b[39m)\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m tlt_ret = \u001b[43mcloses\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mTLT\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.pct_change().shift(-\u001b[32m1\u001b[39m)\n\u001b[32m      8\u001b[39m gld_ret = closes[\u001b[33m'\u001b[39m\u001b[33mGLD\u001b[39m\u001b[33m'\u001b[39m].pct_change().shift(-\u001b[32m1\u001b[39m)\n\u001b[32m      9\u001b[39m xlp_ret = closes[\u001b[33m'\u001b[39m\u001b[33mXLP\u001b[39m\u001b[33m'\u001b[39m].pct_change().shift(-\u001b[32m1\u001b[39m)\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     88\u001b[39m mKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m newargs \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['TLT']; Original Key: ['TLT']\""
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All Weather - Total Return: 30.96%\n"
      ]
     }
    ],
@@ -650,7 +722,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7bf18335",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003293,
+     "end_time": "2026-06-01T00:17:42.778777+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.775484+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Generate Return Streams for All Alphas"
    ]
@@ -658,44 +740,39 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "72261a48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.032414Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.032279Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.166677Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.165776Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.786230Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.786004Z",
+     "iopub.status.idle": "2026-06-01T00:17:42.851436Z",
+     "shell.execute_reply": "2026-06-01T00:17:42.850752Z"
+    },
+    "papermill": {
+     "duration": 0.070069,
+     "end_time": "2026-06-01T00:17:42.852103+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.782034+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "\"No key found for either mapped or original key. Mapped Key: ['MSFT']; Original Key: ['MSFT']\"",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3812\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3811\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m3812\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_engine\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mcasted_key\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   3813\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m err:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:167\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/index.pyx:196\u001b[39m, in \u001b[36mpandas._libs.index.IndexEngine.get_loc\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32mpandas/_libs/hashtable_class_helper.pxi:7096\u001b[39m, in \u001b[36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[39m\u001b[34m()\u001b[39m\n",
-      "\u001b[31mKeyError\u001b[39m: 'MSFT'",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/indexes/base.py:3819\u001b[39m, in \u001b[36mIndex.get_loc\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   3818\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m InvalidIndexError(key)\n\u001b[32m-> \u001b[39m\u001b[32m3819\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(key) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01merr\u001b[39;00m\n\u001b[32m   3820\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m:\n\u001b[32m   3821\u001b[39m     \u001b[38;5;66;03m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[32m   3822\u001b[39m     \u001b[38;5;66;03m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[32m   3823\u001b[39m     \u001b[38;5;66;03m#  the TypeError.\u001b[39;00m\n",
-      "\u001b[31mKeyError\u001b[39m: 'MSFT'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:86\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     85\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m---> \u001b[39m\u001b[32m86\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mf\u001b[49m\u001b[43m(\u001b[49m\u001b[43m*\u001b[49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     87\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/opt/miniconda3/lib/python3.11/site-packages/pandas/core/frame.py:4113\u001b[39m, in \u001b[36mDataFrame.__getitem__\u001b[39m\u001b[34m(self, key)\u001b[39m\n\u001b[32m   4112\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._getitem_multilevel(key)\n\u001b[32m-> \u001b[39m\u001b[32m4113\u001b[39m indexer = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_loc\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   4114\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m is_integer(indexer):\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['MSFT']; Original Key: ['MSFT']\"",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 11\u001b[39m\n\u001b[32m      6\u001b[39m alpha_returns[\u001b[33m'\u001b[39m\u001b[33mEMA-Cross-SPY\u001b[39m\u001b[33m'\u001b[39m] = ema_returns\n\u001b[32m      8\u001b[39m \u001b[38;5;66;03m# 2. EMA Cross on Tech (equal weight AAPL, MSFT, GOOGL, AMZN, NVDA)\u001b[39;00m\n\u001b[32m      9\u001b[39m tech_returns = (\n\u001b[32m     10\u001b[39m     closes[\u001b[33m'\u001b[39m\u001b[33mAAPL\u001b[39m\u001b[33m'\u001b[39m].pct_change() +\n\u001b[32m---> \u001b[39m\u001b[32m11\u001b[39m     \u001b[43mcloses\u001b[49m\u001b[43m[\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mMSFT\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m]\u001b[49m.pct_change() +\n\u001b[32m     12\u001b[39m     closes[\u001b[33m'\u001b[39m\u001b[33mGOOGL\u001b[39m\u001b[33m'\u001b[39m].pct_change() +\n\u001b[32m     13\u001b[39m     closes[\u001b[33m'\u001b[39m\u001b[33mAMZN\u001b[39m\u001b[33m'\u001b[39m].pct_change() +\n\u001b[32m     14\u001b[39m     closes[\u001b[33m'\u001b[39m\u001b[33mNVDA\u001b[39m\u001b[33m'\u001b[39m].pct_change()\n\u001b[32m     15\u001b[39m ) / \u001b[32m5\u001b[39m\n\u001b[32m     16\u001b[39m ema_tech_returns, _ = ema_cross_alpha(closes[\u001b[33m'\u001b[39m\u001b[33mAAPL\u001b[39m\u001b[33m'\u001b[39m] * closes[\u001b[33m'\u001b[39m\u001b[33mMSFT\u001b[39m\u001b[33m'\u001b[39m] * closes[\u001b[33m'\u001b[39m\u001b[33mGOOGL\u001b[39m\u001b[33m'\u001b[39m])  \u001b[38;5;66;03m# Proxy\u001b[39;00m\n\u001b[32m     17\u001b[39m \u001b[38;5;66;03m# Use equal-weight tech benchmark with EMA timing\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m/Lean/Launcher/bin/Debug/PandasMapper.py:90\u001b[39m, in \u001b[36mwrap_keyerror_function.<locals>.wrapped_function\u001b[39m\u001b[34m(*args, **kwargs)\u001b[39m\n\u001b[32m     88\u001b[39m mKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m newargs \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m     89\u001b[39m oKey = [\u001b[38;5;28mstr\u001b[39m(arg) \u001b[38;5;28;01mfor\u001b[39;00m arg \u001b[38;5;129;01min\u001b[39;00m args \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(arg, Symbol)]\n\u001b[32m---> \u001b[39m\u001b[32m90\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo key found for either mapped or original key. Mapped Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mmKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m; Original Key: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00moKey\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mKeyError\u001b[39m: \"No key found for either mapped or original key. Mapped Key: ['MSFT']; Original Key: ['MSFT']\""
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Return streams shape: (1254, 7)\n",
+      "\n",
+      "Total Returns:\n",
+      "EMA-Cross-Tech     1.005607\n",
+      "Dual-Momentum      0.965069\n",
+      "Momentum-SPY       0.511179\n",
+      "EMA-Cross-SPY      0.480501\n",
+      "Trend-Following    0.440954\n",
+      "All-Weather        0.309586\n",
+      "Mean-Reversion     0.185011\n",
+      "dtype: float64\n"
      ]
     }
    ],
@@ -756,7 +833,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e0bc3d76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004422,
+     "end_time": "2026-06-01T00:17:42.860931+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.856509+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Correlation Matrix Analysis"
    ]
@@ -764,24 +851,57 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "a201c081",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.168308Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.168176Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.182327Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.181676Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:42.869741Z",
+     "iopub.status.busy": "2026-06-01T00:17:42.869557Z",
+     "iopub.status.idle": "2026-06-01T00:17:44.451136Z",
+     "shell.execute_reply": "2026-06-01T00:17:44.450176Z"
+    },
+    "papermill": {
+     "duration": 1.58706,
+     "end_time": "2026-06-01T00:17:44.451965+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:42.864905+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'returns_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Calculate correlation matrix\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m corr_matrix = \u001b[43mreturns_df\u001b[49m.corr()\n\u001b[32m      4\u001b[39m \u001b[38;5;66;03m# Plot heatmap\u001b[39;00m\n\u001b[32m      5\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mmatplotlib\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mpyplot\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mplt\u001b[39;00m\n",
-      "\u001b[31mNameError\u001b[39m: name 'returns_df' is not defined"
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABGYAAAPeCAYAAABOdxxlAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3Qd4FFX3x/FfEtIhHUKvofdeBKki/FFRQbADKlYURSxYQCwgvlIsWBFFRUARwUYTEQsg0nvvvSWhJoGQ/3Nv3l12wwbBl2TD+v08z+rO7N3Z2ZmEzJ4951y/jIyMDAEAAAAAACDX+ef+SwIAAAAAAMAgMAMAAAAAAOAlBGYAAAAAAAC8hMAMAAAAAACAlxCYAQAAAAAA8BICMwAAAAAAAF5CYAYAAAAAAMBLCMwAAAAAAAB4CYEZAAAAAAAALyEwAwC47Pn5+emFF174x8/t1avXJd8nXH7Mz5D5ebiUfvnlF7tN839kKl26tLp3787hAADgvwjMAADytHfeecd+sG3YsKEuZ+Y9uN4iIiLUvHlz/fDDD/94m4MGDdLkyZOVly1dulS33367SpQooeDgYMXExKhNmzb6+OOPlZ6eLl/6Of3kk0+Ul7Ro0cL+rJUvX97j4zNnznT+PE6cOPGit7969WobzNq6desl2FsAAP698nl7BwAAOJ+xY8fab9gXLFigjRs3KiEh4bI9YFdddZXuvPNOZWRkaNu2bXr33Xd17bXXaurUqbr66qv/UWCmc+fOuv7665UXjRo1Svfff7/i4+N1xx132ADB0aNHNWvWLN19993as2ePnnnmGflKYCYuLu6cTJArr7xSJ0+eVFBQkFf2KyQkxP7emN+fBg0anPO7ZR5PSUn5R9s2gZmBAwfaAJD5Hb1Q69atk78/3w0CAOBAYAYAkGdt2bJFc+fO1aRJk3TffffZD5IDBgzQ5apChQo2e8ShU6dOqlKlit54441/FJjJCWfOnFFaWpr9wP6/mD9/vg3KNG7cWD/++KMKFCjgfOzRRx/VwoULtXLlyhzd3+PHjys8PFzeZAIQ/+ux/F+UK1dOp0+f1rhx49wCMyYY880336hDhw76+uuvc3w/TDDSvGZoaKjNnAIAAGfxdQUAIM8ygZjo6Gj74dFkhpjli+kVsnbtWnXp0sWWDcXGxqp3797ZZgeYkqBq1arZD41Vq1bVtGnT3B43GS4PPvigKlasaD9cmu3ddNNN/1MZR+XKlW2WxaZNm9zWp6am2gCUyQ4y+2PKgJ588km73sG8PxN4GDNmjLMcxZGtYf7vKYPBUw8VR48dc2zN+zavZ967Kcsxj/3xxx/q06ePChYsaIMcN9xwgw4cOPC3781kUpjnm+26BmUc6tWr55ZdYt7L448/7ix5Msf59ddftx/oL2Z/58yZY89ToUKFVLx4cefzTFZSs2bN7Hsw+2N+platWvW378OUXLVq1cpuz7yWCaSZTCdX5libbZnXdpwLk0Vyvh4zX331lerWrWt/lszPgAnY7dq1y22MOT758+e3601WlLlvzkPfvn0vqgzslltu0YQJE2wQy+G7777TiRMn7O9HVhfys26Ot1lntGzZ0vm+He/THJNrrrlG06dPt+fabOf99993PuY49+b8mueb97V//37n9k2wrXr16jawZH42AADwZWTMAADyLPPh+8Ybb7RlIObDpflA/Ndff6l+/foX9HzzodN8CBw8eLDN4HjzzTeVmJioTz/91G3c77//brNyzIdR86HdjDPZLNu3b7cfSg3zuiZ75+abb7Yf+M2HVLM/5gO4KekICwu76PeXnJxs98d8+HQwH56vu+46u0/33nuvDd6sWLFCw4cP1/r16509ZT777DPdc889NgvCjDNct3Mxfv75Z3355Zc24GGCBOaYmd4wxsMPP2yDYyZQZN7ziBEj7DjzQT875gO/KVcyZTwlS5b829c3H87Ne549e7YtcapVq5b9QP/EE0/YoIR57xe6v+Ycmg/5/fv3d36gN8eqW7duNitpyJAhdv/MuWvatKmWLFly3jIcM84EgMz+5cuXzwY0zGuY8/TQQw/ZMeaYmONkAifPPvusXWfKt7Jjgho9evSwP8fmZ3Pfvn02a8oEwcz+REVFOceaAIzZb9NjyQSqfvrpJw0dOtSe6wceeEAX4tZbb7VBORM0MUEm44svvlDr1q1twCmrC/lZN+f2kUcesb8rphzN/Jwajv87SpbM763JduvZs6cN9GRlgjmjR49WjRo1bIaV+T00zM+bCXaZffZ21hMAADkuAwCAPGjhwoUmVSJj5syZdvnMmTMZxYsXz+jdu/c5Y824AQMGOJfNfbPuuuuucxv34IMP2vXLli1ze25QUFDGxo0bnevM42b9W2+95Vx34sSJc1533rx5dtynn376t+/HjLv77rszDhw4kLF//377/tq1a2fX/+c//3GO++yzzzL8/f0zfvvtN7fnv/fee3bsH3/84VwXHh6e0a1bt3Ney6wrVarUOesdxyXrfpnXW7Vqldv6jz/+2D7Wpk0be+wdHnvssYyAgICMpKSkbN+r4/h5OleeTJ482Y5/+eWX3dZ37tw5w8/Pz+3c/N3+Nm3aNOP06dPO9UePHs2IiorK6Nmzp9v4vXv3ZkRGRrqt93R8PJ33q6++OqNs2bJu66pWrZrRvHnzc8bOnj3bbtP830hLS8soVKhQRrVq1TJOnjzpHPf999/bcf3793c7j2bdiy++6LbN2rVrZ9StWzfj75j9Mftl1KtXz/78GYmJifZnfsyYMc79++qrry76Z908x/W9uTI/f+axadOmeXws68/t+++/b8d//vnnGfPnz7c/Y48++ujfvkcAAHwBpUwAgDybLWOyDkyZg+Ob9a5du2r8+PEXXMbhyGhwMFkNhul54srMEuSabWK+vTflT5s3b3auM6UYDqdOndKhQ4dsqZHJbli8ePEF7c9HH31kszlMloIp7zBZJaZEyZQKuZa4mKyDSpUq6eDBg86bI9PBZJVcamZ2KFOi44nJxnEtfzLlQOb4m3KX7Bw5csT+31MJkyfmfAQEBNgMDFemtMnEYkwZ0oXur8nMMNtynXkoKSnJZm64Hk8zxmSh/N3xdD3vJsPJPNe8vvnZMMsXy/TWMSU7JuvGtfeMKa0y59zTLF0mk8SVOQeuP5sXmjVjslFMiZCZgcm8f1OW5sml+Fk3ypQpc8G9k8zPmRlrfkdNo2jz+2iaWwMA8G9AKRMAIM8xH/xNAMYEZUwDYAfzQdqUcZiARtu2bf92O1mnCTYf9kwz1qx9YTyV25jyHVNm5GBm1jFlJ6bniCmvce19cqEf0Dt27GjLb8yHY1MuYj54mrIa1xlqNmzYoDVr1tgAjieufTguFfMBOjtZj405LobrscnKBLUMMwPThTBBnqJFi54TyHGUxWQNAp1vf7M+Zo6n4QhsZbev2THlRaasZt68efZcuTLnPTIyUhfD8V48lfWYwIwpYXNlgjdZfxay/mxeCFOWZHrTmCCXCXqa/i/ZBc4uxc/6352n7AKX5nfUnDNTSuUaIAIAwJcRmAEA5Dmmh4iZStkEZ8wtK/PB8kICM1llbXzr4Jph4cr1A6n5Jt98UDUzCpmZhswHcrM984HXtanq+Zh+HSY7x/i///s/2x/FBGpMAMr00jHMtkzT02HDhnnchmmO+0/fZ3aZRuf7AHwhxyYrk11h+rGY3jg54Xz7m/Uxx7kxfWYKFy58znizn9kxTZlNHxYTMDHnwxx70+/IZPiYvjcXet7/F9kd/4tVpEgR2yPGBDZNsOl8MzFdip9142IDK6afjKPBtfnZMa8NAMC/AYEZAECeYwIvptxn5MiR5zxmyjHMNL/vvffe337wM9+8u35rv3HjRvvB8nzNXrNjyj9MA1nzwdbBzPBkymT+KdMU1XzAf+6552xZifnwazIGli1bZgMC2QVYHLJ73GRUeNqv85UfXUqmOazJUDEBth07dvxtMKlUqVK2qa3JsHHN4jCzajke/6ccJWrm58kRFLtQptGvCRR8++23bplDnsqf/u5cOTjei2mMmzWLx6z7X97rhZQzmYbRpiTJBAb/15/1C33PF8IEYk1AyARcTfDLZPeY0qacPB4AAOQV9JgBAOQppozCBF9MqYWZIjvrzWSYmA/w5sPy38ka2Hnrrbfs/9u3b/+PMheyZomY7V3MtMWesjVMHxVTujRlyhTnTFKmfOTDDz/0eGxcpw42s9V4CsCYYIQpOVm+fLnbB18T0MotpvzHHC/TL+TYsWPnPL5o0SI71bdhggTmOL799ttuY0zQynz4/yfny8F8uDflSqZszPRLyep8U387slWylvKYbJKssjsXWZneQiZIZAKLrtOfmxIj83Nges3kFPP7Y87LO++8Y4Mf/+vPumO2pP8lOOnaG8gETU050wcffGB/N8wMXefLzAIAwFeQMQMAyFNMwMUEXsz0xJ40atTI9twwWTWmGfD5mP40Zjvt2rWzPUI+//xzmzVQs2bNi94vEygy5TCmrMM0njXbM1kejum0/6nu3bvbqZ3NNM7XX3+9DWSYqaBNw1eTmXHFFVfYD8Qme8SsN9NImw/3Rt26de0+mDIb06PFZAeZPjym5OSpp56yWTimoa5jeugKFSpcVPPW/0WTJk1sYMw0uTWlQOZ9mZ4/5tyakhVznl9++WU79tprr7XlXGaqadP/x5yfGTNm2GCVKaf5p9OAGyYoY967ef06derYY2N+fsxU6KbRrjm+WQNCDo7sDbN/JrvJBJhMwMwEVkygy5U5F+Z1zHsypVxmjKe+NoGBgfZcm+myTRNh05TYMV22yeR67LHHlFPMz66ZNvtS/aybac1NEMe8HxOwCg4Otu/Z0xTc52MCXeZcmGnETbmfIxB0++2322NqfoYAAPBp3p4WCgAAV9dee21GSEhIxvHjx7M9MN27d88IDAzMOHjw4Hmny169erWdcrlAgQIZ0dHRGb169XKbotjx3Iceeuhvp/Q1Uwz36NEjIy4uLiN//vx2yuS1a9d6nPrXk+xex3jhhRfOmVJ5yJAhdqrj4OBgu+9meuSBAwdmJCcnO59nXv/KK6/MCA0Ntc933Y8ZM2bYKZnNtMgVK1a00xBnN122p/1yTD/9119/nXf657+zaNGijFtvvTWjaNGi9pyZ99K6dWs7VXN6errbtNZmKm7HuPLly9tpxF2n6v4n++u63+acmSmyzc9XuXLl7M+RmbbcwdPx+fbbbzNq1Khhn1O6dGl7XkaPHm3HbdmyxW367Q4dOtifNfOYY+rs7I7XhAkT7LTX5vzGxMRk3HbbbRk7d+50G2POp5kSPStP+/l302Vnx9N02Rfzs/7hhx/aqcPN9Nau79OMNcfDE9ft7Nixw54T83uf1Q033GDf/+bNm//2vQIAcDnzM//xdnAIAIBLyWQFDBw40JapmAa7AAAAQF5FjxkAAAAAAAAvITADAAAAAADgJQRmAAAAAAAAvITADADAJ3vMmBZq9JcBAADwXb/++qudPdHMTunn56fJkyf/7XPM7JBmpkYzm6CZSdHMCpiVmVnSzJYYEhJiZ7xcsGCBchKBGQAAAAAAcNk5fvy4atasaQMpF2LLli3q0KGDWrZsqaVLl+rRRx/VPffco+nTpzvHTJgwQX369NGAAQO0ePFiu/2rr75a+/fvz7H3waxMAAAAAADgsubn56dvvvlG119/fbZjnnrqKf3www9auXKlc93NN9+spKQkTZs2zS6bDJn69evr7bfftstnzpxRiRIl9PDDD+vpp5/OkX0nYwYAAAAAAHhdamqqjhw54nYz6y6VefPmqU2bNm7rTDaMWW+kpaVp0aJFbmP8/f3tsmNMTsiXY1sGAAAAAAB5gt8DjZTXDYhvp4EDB7qvGzDA9g+8FPbu3av4+Hi3dWbZBIBOnjypxMREpaenexyzdu1a5RQCMwAAAAAAwOv69etn+7u4Mk16fR2BGfhMdBUXLuPd+c77zb68lUPnQ37r8oXzfuG3O3p1X3Dp7e01xXn/9z39OcQ+pGmRF53395/81Kv7gkurUOidzvujVz/I4fUxd1V5x3m/9de3eXVfcGnN6jSWQ+oFwcHBORqIKVy4sPbt2+e2zixHREQoNDRUAQEB9uZpjHluTqHHDAAAAAAA8HmNGzfWrFmz3NbNnDnTrjeCgoJUt25dtzGm+a9ZdozJCWTMAAAAAADg4/z8/eRrjh07po0bN7pNh22mwY6JiVHJkiVtadSuXbv06aeZ2aj333+/nW3pySef1F133aWff/5ZX375pZ2pycGUUnXr1k316tVTgwYNNGLECDstd48ePXLsfRCYAQAAAAAAl52FCxeqZcuWzmVHfxoTWPnkk0+0Z88ebd++3fl4mTJlbBDmscce0xtvvKHixYtr1KhRdmYmh65du+rAgQPq37+/bRZcq1YtO5V21obAlxKBGQAAAAAAcNlp0aKFMjIysn3cBGc8PWfJkiXn3W6vXr3sLbcQmAEAAAAAwMf5YimTr6D5LwAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPBxlDLlXWTMAAAAAAAAeAmBGQAAAAAAAC+hlAkAAAAAAB9HKVPeRcYMAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HF+fn7e3gVkg4wZAAAAAAAALyEwAwAAAAAA4CUEZgAAAAAAALyEHjMAAAAAAPg4psvOu8iYAQAAAAAA8BICMwAAAAAAAF5CKRMAAAAAAD6OUqa8i4wZAAAAAAAALyEwAwAAAAAA4CWUMgEAAAAA4OMoZcq7yJgBAAAAAADwEgIzAAAAAAAAXkIpEwAAAAAAPo5SpryLjBkAAAAAAAAvITADAAAAAADgJZQyAQAAAADg4yhlyrvImAEAAAAAAPASAjMAAAAAAABeQmAGAAAAAADAS+gxAwAAAACAj6PHTN5FxgwAAAAAAICXEJgBAAAAAADwEkqZAAAAAADwcZQy5V1kzAAAAAAAAHgJgRkAAAAAAAAvoZQJAAAAAAAf5+fn5+1dQDbImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+jlmZ8i4yZgAAAAAAALyEwAwAAAAAAICXEJgBAAAAAADwEnrMAAAAAADg4+gxk3eRMQMAAAAAAOAlBGYAAAAAAAC8hFImAAAAAAB8HKVM/+LATPfu3TVmzJhz1l999dWaNm2aSpcurW3btmncuHG6+eab3cZUrVpVq1ev1scff2y342rw4MF67rnn9Oqrr+qJJ564oH3ZuHGjXnnlFc2cOVMHDhxQ0aJF1ahRIz3++OOqV6+e8oply5bp+eef1/z583XkyBEVLlxYDRs21FtvvaVChQpp69atKlOmjHN8TEyM6tatqyFDhig8PFy1atXSqFGjdOuttzrHnDlzRk2bNrXveeLEifJlzRJq6YmrblfdkhVVNKqgrn/vSU1Z9ut5n9O8fB0N69xbVYuU0Y7EfXp56icaM/8HtzEPNu9kt1s4IkbLdm7UwxOG6q9tq3P43cCTGxKu0i0Vr1FMSKQ2JW3XiCVjtObwJo9j32zxnGoXqnLO+nm7l+jJ3/9j719ZrL46lmutitFlFBlcQD1m9NPGpG0cfC/oUf3/9GDt61UwLFqrD27Vs79+oCX7N2Q7vmfNa9WtWnsVKxCnwyeP6vtNczVo3qdKTT9lH29UtIoerH2DahRKUOHwGHX/YZCmbfkzF98RXP38zQZNG79WyYdTVCIhSrc+UkdlK8d6PEhzvt+kedO3ateWZLtcqkKMbuxZ3W18yolT+vqD5Vry+y4dO5KmuCLhanNjebXomMCBz2WTxi/UuDHzdfjQMZWrEK9Hn2qrKtWLeRy7ZeMBffTuHK1bvVd79yTr4b5XqcvtDdzGLF20XePGzNO6NXt16MAxvTKss65sVTGX3g2yWvzjDv05ebuOJ6WpUOn8anNPBRWtEPm3B2r1b3v13bBVKt8gTjf2q+lc//v4zVrz+z4dPZgi/3z+KlyugK68rdwFbROXVseyV6lLhQ6Z11TJ2/XW0jFal7g52/HhgWG6u2oXNS1aTwWC8mv/iYMaufwzLdi7zD4emi9EPap0VtOi9RUVEqGNSVs1ctln590mgFwqZWrXrp327NnjdjOBGIcSJUrY4IsrE5TYu3evDTR4Mnr0aD355JP2/xdi4cKFNnixfv16vf/++zbg880336hSpUo2MJOdU6cyL+5ziwkYtW7d2gZbpk+frjVr1thjYwIqx48fdxv7008/2WNpxh07dkzt27e3gRsTrHr44YftYw5Dhw7V5s2b9d5778nXhQeHatmuDXpo/OsXNL50bBH98NBQzV6/SLUG3akRP0/QqNv7qW3lhs4xXeq20bBOvTXwh1GqM6iblu3coOmPjFDBAtE5+E7gSasSjdSr5u36ZNUk3TPzWW1M2q6hVz6tqOAIj+OfnTtcHb99wHm7Y9oTOn0mXbN3nv1wHpovWCsOrtN7y8/+u4Tc1zGhqV5oepeG/jVBbSf00apDWzTuuhcUF+r5Qv2GClfq2cZ3auhf43Xl2F7q8/Nb6li+qfo1vsM5JixfiFYd3Kp+c97PxXcCTxb8vF0T3lmq67pX1YAP26pEuSgNf2KOjiSmeBy/bul+NWhdUk8Mb6lnRrZRTKFQDes7R4kHTjjHmO2tXLBX9zzbSC+Paa+rOlfQ2DcWa+kfuzgJuWjW9NV6e+hP6n5fM40ad7cSKhTS4w+OV+Jh9+sWh5SUUypSLFr39W6pmDjP13kpJ9OUUCFeffpdncN7j79jAig/f7xBV3Qto+5D69vAzJcvLrVBmvNJ3n9Ss8dsVPEqUec8FlM0TFf1rKi7RjTSbYPqKrJQqCYMXKITyeffJi6tFsUb6f4at+nTNZN0/6znbGBmSNPsr6ny+QXotaZPKz4sTgP/fFPdZ/TV0MWjdPBkonPM43V6qm58dQ1e+K7umfm0Fu5bodea9VNcCNfMgNcDM8HBwTbrw/UWHX32l/O2227TnDlztGPHDuc6E3Ax6/PlOzepx4w9efKkXnzxRZtRMnfu3PO+fkZGhs24KV++vH777Td16NBB5cqVs5klAwYM0JQpU+w4k4ni5+enCRMmqHnz5goJCdHYsWNttol5reLFi9v3Yp5nsn0c0tLS1KtXLxUpUsQ+p1SpUjajx/HaL7zwgkqWLGmfawIsjzzySLb7+scffyg5OdlmvNSuXdtmxrRs2VLDhw93y5IxYmNj7bE02T6vv/669u3bpz///NMGZWrWrKmePXvacWvXrlX//v31wQcfKC4uTr5u2qp5ev7b9zV52ZwLGn9/sxu15dBu9f36Ta3du1Uj50zUxCWz9VjrsxlcfVrfog//mKJP5v2gNXu36v5xQ3QiLUV3Nb4mB98JPOla4f/03ebZ+nHrHG09skuvL/pIKadT1aFMc4/jj6Yd1+GUZOetfnx1paanavaOs4GZ6dt+1yerv9HCfSs56F50X62OGrtqhsavmaX1iTv05Ox3dfJ0qm6u3Mbj+PqFK+mvPWv0zfpftePofs3ZsVST1/+q2oXKO8f8vH2xhvw5VlM3z8/FdwJPZny1Tld2KKum7cuqaOlI3dGnnoJC8un3H7d4HH/vc43V6vryKlk+WkVKRaj7E/Xt39Q1i/c5x2xceVBN2pVWpdqFbLZM82vL2UyczWsOcxJy0YTP/tS1N9ZSh+trqky5gur73P8pJCSffpic+Q16VpWrFdVDfVqrTbuqCgr0nLzdqGmCevZqoStbVcrhvcff+evb7ap5VTHVaF1UcSXy6+r7KykwOEArZu3O9jln0jP03fBVanpzWUXFh57zeJUrC6t0zRhFFQ5VwZL51apHeaWdSNf+bcc4Ibmoc/n2+nHrbE3f9qu2Hd2lEYtH22ukdqU8X1O1K91CEUH51X/ecK06tF77ThzU8oNrtTl5u308yD/QZiF/sGKcVhxcq93H99mgz+5j+3RtWc9/y5H7pUx5/fZvlSea/8bHx9vSJkfJ04kTJ2xw5K677vI4/qOPPtItt9yiwMBA+3+zfD5Lly7VqlWrbGaMv/+5bzkqyj2S//TTT6t37942W8Xs1xtvvGEzTkzwY/ny5Xbdddddpw0bMtPr33zzTX377bf68ssvtW7dOhvMMSVaxtdff22DKiZLx4yfPHmyqlevnu2+mkDL6dOnbTaPuQC9UKGhoc4gkQkumSwbE4T68MMPbVDKlImZfca5Gpetpp/W/uW2bvrq+WpcNvM8BQbks2VRrmPMuTHLjjHIHfn8A1QhuowWuQRQMpShhftXqmrs2Q/j59OhTAvN2j5fKempObinuFiB/vlUo1A5/bpjmdu5/W3nMtUr7Ll84a+9a+1zHIGYkhHxalWqrmZtW8QJyGNOn0rXtnWJqlw33rnO399PVerGa9Pqgxe0jdTUdKWfzlB4gWDnuoRqcTY7xmTRmH+X1y7Zp707jqpq/bOvg5x16lS61q/Zo7oNy7id23oNy2jV8p0c/stc+qkz2rvpqErVjHGuMx+cSteI1q51mWWGnvzx5RaFRQapZpuiF/QaS2fsUnBYPpuNg9xhsl8qRJXR4v3u11RmuUo211RNitbR6sMb9Ejt7prY4R2NavOqbq14nfyV+WE6wD/A3tL+W07skJqepmpxFXL4HQGXt1xp/vv9998rf373f2ifeeYZe3MwQRgTOHn22WdtDxRHRktWJkPGPD5v3jy7fPvtt6tZs2Y2eJL1NRwcARRTtnQhHn30Ud14443OZROQeeqpp5w9cEwvl9mzZ2vEiBEaOXKktm/fbrNxTA8XExQxGTMO5jETbGnTpo0NJJnMmQYN3OuoXZmeN+a4mP4w999/vx3bqlUr3XnnnTaA5UlSUpJeeukl+/4d2zb7YPbvnnvusZk+M2bMuKD3/m9UOCJW+464f7tqliND8yskMFjRYQWULyCfhzGJqhSfGYBD7ogMKmCDM4dT3S8GE1OSVarA31/8VY4pp3JRJTVk4Yc5uJf4J2JCI+y5PXAyyW39gRNJSogq7vE5JlMmJiRCUzoNlp/8bBB1zIqpenORb/fRuhwdTU7TmTMZiogJcVsfER2iPduPXNA2Jr6/TFFxITaY42B61Hw6dKH63vSdAgIyv2nr1reeKtYsdMnfAzxLTjyh9PQMxcS6lyRFx4Zr29ZDHLbL3Imjp5RxJkPhkUFu68OignRo19myQlc7Vydp+azd6jEs++tdY+NfB/XtsJU6lZqu/NHB6vpCbYVFuL8Oco7pqWeCKOYaylViyhGVyOaaqkh4IdUuWEWzts9Vvz9eU7H8hdW7VncF+OfTZ2sm6eTpFJtJc3vl67X96C677VYlmthAz+5jezmdgLczZkwpjslacb2ZoIMrU15k+qT8+uuvtowpu2wZ05vGBG1MqY5hgjcmCGEybAyTrWICFI6byRq5mMwTw7URsAkE7d69W1dccYXbGLNsMmoMk5Fi3lPFihVtmZJrEOSmm26yZVdly5a1pUUmE8ZkxBiDBg1y21cTxDFMg2LTX8f0gzENkM3/TVBpxYoVbvvQpEkT+zxTFmYaBptj4Bq86dGjhy2vMqVNERGea0Vdpaam2vfrejPrAF9hsmVMs+DsGgXj8tKkWDX1rttZT895X1d92Uc9fhys1qXr6bF6Xby9a7jEfhy7Rgt+3qGHXmpqSygcZk3aoE2rD+nhQU31/Adt1eWBWvp8xGKtXsgHAMAbUk+e1vdvrFK7Byr9bZClZPVoG7y5fXA9lakdoymvr/jbvjXwLpMZk5h6RMMWj9KGpK36Zed8jV03RdeWaeUcM/ivd+2XJV92GKlpN4zRDQlXa/aOuTpzkZ/HkDO8XaZEKZOXM2ZMA9+EhPPPkGB6ydxxxx2254vpk2ICGJ6YsiVTluTae8b0gDHBnLvvvtuW65gZjByKFStme6wY5v+mb8uF7O/FqFOnjrZs2aKpU6fahrxdunSxGTIms8c0NjblTWa9mQ3qwQcf1H/+8x/bJ8cEp8xYB9N/xrV/jAnqmJsJ4Jj9Npk7rjNcmUBMlSpV7Nis5VgO5jh56tPjiemLM3DgQLd15nyYHjm+bO+RQ4qPOJuia5jl5JPHlHIqVQePpet0+mkPY6Ltc5F7ktOO2sa9McHuzWCjQyJ1KMU90yKrkIBgtS7RWB+tIpsiLzp88og9twVD3f8tKxgWpf0nzjYVdPVkw1s1cd0v+mL1TLu89tA2heUL1n9aPqQRC7+yKdnIGwpEBtnyliOH3Rv9msa/kVmyaLIyszj9+MUa9R3awjYMdkhLPa1Jo1booZeuUM3GmX8/zeM7NiZq+oR1qlKvcA69G7iKjA6z2UqHD7k3+k08dFyx2TT2xeUjrECg/SB1PEtT3hNJaQqPOjfwkrT3pJL3p+jrQcud6xxfkL7W6Wf1fLuRoouE2eWgkAAFFQlTdBGpWMVIffDgXJtp07gT2ci5ITn1qNLPpNtrKFfRIRG2J58n5lrrdEa6zrj8fd1+ZLdiQ6NtaZR5bM/x/erz68v2uissMFSHU5L0XIOH7XoAebzHjIPJkjEBi44dO7o1B3YwGSNmdqVffvnFLfvGLJvSJhN4KVCggA0COW6m94rJqjEBDNMnxgRxPJUCZcdkmpiAiWnK68osm226juvatavt6WICJqa3zOHDmaUvZh+uvfZa24vGsa/mvZiZl1z3NbsASlBQkM0Syjorkwn6mPXZBWUuVr9+/WzjYdebWefr5m1eqdYV3adLv6pyA83bnJmhdCr9tBZtX6fWFes7Hzcla2bZMQa5w3xwX5+4RXXjq549F/JT3UJVtepQ9lMqGy1LNLSlLjO2/Z4Le4qLderMaS3fv0nNStRwO7dNi9fQwr3rPD7HzKZ1JsP93/T0/y6b31HkHfkCA1SqYrRb415T2rRm0T6Vq5J9U/qp49bo+89W67HXrlTpSu7BcdNvJv30GRvwceUf4Mc3s7koMDBAFSoX0aIFW93OrVmuWsNzGSIuHwGBmVNZb1t+tpzblDZtXZFogylZxRYL010jGtpMGMetfP04laqWmR0TEZd9INb88236zSB3mCDK+qQtql3Q/ZqqdsFqWp3NNZUpUyoWHm/HORQvUNjOymS258r08jNBmfyBYXbihbl76P8GeD1jxpTDmNIctxfOl++cGYIqV66sgwcPKiwsM5LuKVvG9FC58sorz3msfv369nGTjZKVoxmuyWIx/WhMHxtTGmRKp7777jtbemQCQtl54oknbOaIo++N2ZYJCJmyKWPYsGG2ZMhktZjmwl999ZXtK2MCJp988onS09NtFo95X59//rkN1Lj2ocnaj2f8+PG2n02FChXstwxmH3/88cdzphS/1MysUebmC9NlJxQ8ezFYJraoahYvr8PHj2hH4j4N6viAikUVVLcxL9rH3/ttknq16KwhN/TS6LnfqVXFeupSp7U6jDw7jfqwWeM0ptvzWrh9jRZsXa1HW3VVeHCIPp73g1fe47/ZhPU/6pkG92vt4c22JOmmCu0Vmi9EP27J/B1+tsEDOnjysN5fkVne6FrG9PuuRTqSdu6MDwWCwu3Uj46pHEsWKGL/by4osvvWCJfe+0un6I02vbVs/0Yt2bdBPWtea6e7Hr/mJ/v4W20e1Z7jhzRo3md2eebWv+xMTisObtGSvetUOqqInmp4m13vCNiEBYaoTGTm+bTnNiJeVePKKCnlqHYdu7Cms7g02t5UUR8N/lOlK8aoTOVY/TRxnVJTTuuK9plNY0cNmq/ouDB1ujczOGeyZKZ8vFI9n2ukuMLhSj500q4PDs2nkLBAhYYHqmLNgvry3aUKDApQbOEwrVt6QHOnb1PXh87tUYec0/WOhhr0/LeqVKWInXHpq7ELdPLkKf1fx8xz+fJz3yquUAHd/0hLZ8PgrZsOZN4/na4D+49qw9q9Cg0LUvGSmQG4EyfStGv72WDAnl1JdkxEZKjii5wbEEDOqX9dSf3w5moVLhehIuUjtPD77TqVkq7qrTP/bTWlSwVigtX8jgTlCwpQwVLuPR+DwwPt/x3r01LSNW/iFiXUL6j80UE6efSUFv+4U0cPp6piE/pD5aaJG6bqqXr32S+91iZuUqeEdgrJF6zp2zKvqZ6qd78Nuny0KvOa6tvNP6ljubZ6qOYdmrxphu0xc2vFjpq0cbpzm/Xiq9vAzY6je1Qsf7zurX6rth/do2lbf83V9wbP/s2zHuV1uRKYMVNLm8CFK9OPxVFi5MqU5XhiZhsyQQ3ThNeTTp062YwYU/ZjmuxmZQI6JtvG9G8xvV5MAMjsk+nTYprkno/pG2OyR0xz4v3799tMGTMLk2n4a5gsnddee802GQ4ICLBBIhNIMUEaE5x59dVX1adPHxugMTMymUBLdu/TbNsEcMxrmenDTaDEvI6ZPtuUeuHv1StZWb/0ece5PPymR+3/zVTXPT59SUUi41Qy5myK+9ZDe2wQZvhNvdW7ZRftTNqvez4frBlrzk6n/OWin1Qwf5RevKanbRa8dOcGtXvrMe0/ypSsue3nHfMVFRyhu6t1VkxIlDYmbVPfX1+1Nc9GfFisMrJkUZQoUEQ1C1bSY3MGedxm06J1bbDHYWDjzCntR6/6Wh+v+jpH3w/OmrLxd8WGRujJBreqYHi0Vh3Yolu+G6iDJzODY8UKxLllyAz/60sbvH664W0qnD9Gh04e0cwtf2nw/M+dY2oVStCkG15xLr/Y7G77/wlrZqn3rDc5/LmoQauSOpqUqskfr7QlTWZa68dea+4sZTq874RbptMvUzbq9KkzenfAXLftXNetqjr2qGbv39e/sb7+cLk+fGW+jh9JU2x8mG64p7paXFeOc5uLWl9dRUmJx/XRu3N0+OBxJVSM1+vv3KyY2MwP4vv2JLud24P7j+qum8/OqDn+0/n2VqtuSb31Uea1zrpVe/RIz7O/y28PzQzQtru2hp596dpcfHeo3DReJ46k6ffxm3U8MVWFyhRQl/61FB6V+WXekQMpF5WlaCZIPbzzhCbPXqGTR9IUWiBQhRMidNsrde3U2cg9pkeMaQLcvUpnW9K0KXmbnv59iPOaqpC9pjpbtnTg5GE9/fureqDGHfqwzWAbtJm0cZrGr/vOOSY8X5juqdZVcaExOpp2TL/t/kujV36p9CwZNQDc+WVcbGdc/Cv5PdDI27uASyjj3fnO+82+vJVj60N+6/KF837htzt6dV9w6e3tNcV5//c9/TnEPqRpkcwsTmP/yU+9ui+4tAqF3um8P3r1gxxeH3NXlbNfBrb++jav7gsurVmdMqsjfEnc0A7K6w4+/u+sSMhTPWYAAAAAAAD+TXKllAkAAAAAAHgPPWbyLjJmAAAAAAAAvITADAAAAAAAgJdQygQAAAAAgI+jlCnvImMGAAAAAADASwjMAAAAAAAAeAmlTAAAAAAA+Dg/Pz9v7wKyQcYMAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HHMypR3kTEDAAAAAADgJQRmAAAAAAAAvIRSJgAAAAAAfBylTHkXGTMAAAAAAABeQmAGAAAAAADASwjMAAAAAAAAeAk9ZgAAAAAA8HH0mMm7yJgBAAAAAADwEgIzAAAAAAAAXkIpEwAAAAAAPs6ftIw8i1MDAAAAAADgJQRmAAAAAAAAvIRSJgAAAAAAfFyAn5+3dwHZIGMGAAAAAADASwjMAAAAAAAAeAmlTAAAAAAA+LgAf0qZ8ioyZgAAAAAAALyEwAwAAAAAAICXUMoEAAAAAICPY1amvIuMGQAAAAAAAC8hMAMAAAAAAOAlBGYAAAAAAAC8hB4zAAAAAAD4uADSMvIsTg0AAAAAAICXEJgBAAAAAACXpZEjR6p06dIKCQlRw4YNtWDBgmzHtmjRQn5+fufcOnTo4BzTvXv3cx5v165djr4HSpkAAAAAAPBxvjhd9oQJE9SnTx+99957NigzYsQIXX311Vq3bp0KFSp0zvhJkyYpLS3NuXzo0CHVrFlTN910k9s4E4j5+OOPncvBwcE5+j7ImAEAAAAAAJedYcOGqWfPnurRo4eqVKliAzRhYWEaPXq0x/ExMTEqXLiw8zZz5kw7PmtgxgRiXMdFR0fn6PsgMAMAAAAAALwuNTVVR44ccbuZdZ6YzJdFixapTZs2znX+/v52ed68eRf0eh999JFuvvlmhYeHu63/5ZdfbMZNxYoV9cADD9jMmpxEYAYAAAAAgH9BKVNevw0ePFiRkZFuN7POk4MHDyo9PV3x8fFu683y3r17//Z4mF40K1eu1D333HNOGdOnn36qWbNmaciQIZozZ47at29vXyun0GMGAAAAAAB4Xb9+/WzPGFc51d/FZMtUr15dDRo0cFtvMmgczOM1atRQuXLlbBZN69atc2RfyJgBAAAAAABeFxwcrIiICLdbdoGZuLg4BQQEaN++fW7rzbLpC3M+x48f1/jx43X33Xf/7T6VLVvWvtbGjRuVUwjMAAAAAADg4wL8/fL87WIEBQWpbt26tuTI4cyZM3a5cePG533uV199ZXvX3H777X/7Ojt37rQ9ZooUKaKcQmAGAAAAAABcdvr06aMPP/xQY8aM0Zo1a2yjXpMNY2ZpMu68805bHuWpjOn6669XbGys2/pjx47piSee0Pz587V161Yb5OnYsaMSEhLsNNw5hR4zAAAAAADgstO1a1cdOHBA/fv3tw1/a9WqpWnTpjkbAm/fvt3O1ORq3bp1+v333zVjxoxztmdKo5YvX24DPUlJSSpatKjatm2rl156Kcd63RgEZgAAAAAAwGWpV69e9uaJadiblZkCOyMjw+P40NBQTZ8+XbmNwAwAAAAAAD4u4OJauCAX0WMGAAAAAADASwjMAAAAAAAAeAmlTAAAAAAA+LiLnY4auYeMGQAAAAAAAC8hMAMAAAAAAOAllDIBAAAAAODjAvwoZcqr/DKym8AbAAAAAAD4hCbjb1FeN/fmcfo3opQJAAAAAADASyhlAgAAAADAxzErU95FYAYXpNmXt3KkfMhvXb5w3vd7oJFX9wWXVsa78533b5vWg8PrY8a2+9h5f33S617dF1xaFaL6Ou+fOP0dh9eHhOW71nl/7p4BXt0XXHpNigx03n/yj3s5xD7ktSs+8PYu4F+EUiYAAAAAAAAvIWMGAAAAAAAfF8CkTHkWGTMAAAAAAABeQmAGAAAAAADASwjMAAAAAAAAeAk9ZgAAAAAA8HFMl513kTEDAAAAAADgJQRmAAAAAAAAvIRSJgAAAAAAfFyAH/Nl51VkzAAAAAAAAHgJgRkAAAAAAAAvoZQJAAAAAAAfRylT3kXGDAAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPBxAaRl5FmcGgAAAAAAAC8hMAMAAAAAAOAllDIBAAAAAODjmJUp7yJjBgAAAAAAwEsIzAAAAAAAAHgJgRkAAAAAAAAvoccMAAAAAAA+LsDfz9u7gGyQMQMAAAAAAOAlBGYAAAAAAAC8hFImAAAAAAB8HNNl511kzAAAAAAAAHgJgRkAAAAAAAAvoZQJAAAAAAAfF0BaRp7FqQEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+jlmZ8i4yZgAAAAAAALyEwAwAAAAAAICXUMoEAAAAAICPC/D38/YuIBtkzAAAAAAAAHgJgRkAAAAAAAAvITADAAAAAADgJfSYAQAAAADAxzFddt5FxgwAAAAAAICXEJgBAAAAAADwEkqZAAAAAADwcQGkZeRZnBoAAAAAAAAvITADAAAAAADgJZQyAQAAAADg45iVKe8iYwYAAAAAAMBLCMwAAAAAAAB4CaVMAAAAAAD4uAA/b+8BskPGDAAAAAAAgJcQmPFRfn5+mjx5srd3AwAAAAAA5GYpU/fu3TVmzJhz1l999dWaNm2aSpcurW3btmncuHG6+eab3cZUrVpVq1ev1scff2y342rw4MF67rnn9Oqrr+qJJ564oH3ZuHGjXnnlFc2cOVMHDhxQ0aJF1ahRIz3++OOqV6+evOmFF17QwIEDzzsmIyMj1/bHF92QcJVuqXiNYkIitSlpu0YsGaM1hzd5HPtmi+dUu1CVc9bP271ET/7+H3v/ymL11bFca1WMLqPI4ALqMaOfNiZty/H3AXfNEmrpiatuV92SFVU0qqCuf+9JTVn263kPU/PydTSsc29VLVJGOxL36eWpn2jM/B/cxjzYvJPdbuGIGC3buVEPTxiqv7at5vDnsqtKtlKHMu0VGRSp7Ue3a8yasdqcvCXb8WH5QtWlfCfVi6+r/EHhOnjykD5bM07LDi63j7cu0VJtSrZUwdA4u7zz2C59s/FbLTu4ItfeE8764atVmjR2uRIPnVSZ8jG67/EmqlC1kMdDNH3yWv3843pt25xolxMqxenOB+q7jTd/J8d+sEgzpqzV8WNpqlwjXg8+2VRFS0Zy2HPZhC/+0JiPf9Ghg0dVoWIRPfXMDapWo2S242dOX6Z33pqm3bsSVbJUnB7p00HNrqzsfLz/M+P13ZSFbs9pckVFjfygZ46+D3g265sNmjp+jZIPp6hkQpRue6SuylaO9Th2zveb9Mf0Ldq1Jdkul64Qo049a7iNTzlxSl99sFxLft+pY0fSVLBIuNrcWEEtOyZwCnLZ5lm7tHHaDqUmpymiRH7VuC1B0WUjPI7d/vteLRm9zm2dfz4/XfvBlc7lxR+t1Y4/9rmNKVQtWo371MihdwD4hhzpMdOuXTsbXHEVHBzsvF+iRAn7uGtgZv78+dq7d6/Cw8M9bnP06NF68skn7f8vJDCzcOFCtW7dWtWqVdP777+vSpUq6ejRo5oyZYoNzMyZM8fj806dOqXAwEDltL59++r+++93LtevX1/33nuvevbkguNSaFWikXrVvF1DF43W6sMbdVP59hp65dO6derjSko9cs74Z+cOV6D/2V+HiKD8+rjtq5q980/nutB8wVpxcJ1m75ivp+rfe0n2ExcvPDhUy3Zt0Oi53+mb+4f87fjSsUX0w0ND9d5v3+i2jweodcV6GnV7P+1JPqgZazLPb5e6bTSsU2/dP26I/tyySo+2ulnTHxmhii901YGjmR8KkfMaFW6g2yrdrNGrPtWmpM1qV/oqPV3vcfX9rZ+OpB09Z3yAX4Cerv+EjqQe0ZtLR+pwaqLiQuJ04vQJ55jDKYc1ft1E7T2xT6asulmxK9SnziN6Zu4A7Tq2m9Oai36buUmj3pivh55qaoMr345fqf69p+q9L7soKib0nPErFu/WlW0TbLAlMChAX3+6TP0fmaqR4zortlDmtcLXny3T91+u0qP9myu+aAGNfX+R3eY74zsrKJg2erll+tSlGvrat3p2QCdVq15SX3z2mx6870NN/v5JxcQWOGf80iVb1e+JsXr40fZq1ryKpv6wRH0e/kTjJj6qhPJFnOOaNK2ogS93dS4HBXFOveHPn7dr/DtLdGefeja4MnPiOg194hcN/qyDIqJDzhm/dul+NWpdSglV4+zv7o/j1uj1vr/olU/aK7pgmB1jtrdm8X7d+2wjxRUO18qFe/XZ8EWKigtV7SuKeeFd/jvtWrBfqyZsUo07Kii6bAFtnrlL84atUOtB9RUcEeTxOflCA9R6UIPzbtcEYmrfXckteIO8wd+Pc/GvKmUyQZjChQu73aKjo52P33bbbTYwsmPHDuc6E3Ax6/PlO/ePrhl78uRJvfjiizpy5Ijmzp173tc336CZjJvy5cvrt99+U4cOHVSuXDnVqlVLAwYMsMEZY+vWrbbkZ8KECWrevLlCQkI0duxYnTlzxr5W8eLF7XsxzzPZPg5paWnq1auXihQpYp9TqlQpm9HjeG2TDVOyZEn7XJOl88gjj5yzj/nz53c7PgEBASpQoIBz2QSIunTpoqioKMXExKhjx452f12ZY2ayjMzrmH0x++Tq4MGDuuGGGxQWFmaPxbfffqt/i64V/k/fbZ6tH7fO0dYju/T6oo+UcjpVHco09zj+aNpxHU5Jdt7qx1dXanqqZu84G5iZvu13fbL6Gy3ctzIX3wmymrZqnp7/9n1NXuY5uJrV/c1u1JZDu9X36ze1du9WjZwzUROXzNZjrc8Ghvu0vkUf/jFFn8z7QWv2brUBmhNpKbqr8TWcgFzUvnRbzd7xq37d9bt2Hd9tAzSp6WlqXqyZx/EtijdT/sBwDV/yltYnbbTZMmsT12n70bN/W5YcWGazZ/ad2GeDM19tmKSU0ylKiCyXi+8MxuRxK3R1x0pqc21FlSwbrQefbqrgkHya+Z37t68OfV9spQ6dq6hshViVKB2lh59tpjNnMrRs4S7n31sT3OnSo7YaNS+tMuVj9dgLLXT44AnNn0M2Y276fMwc3di5oTre0EDlEgrbAE1ISKAmT/rL4/hxn/9mgy7d7mqpsuXi9dAj7VS5SjGN/+IPt3EmEBNXMMJ5i4jM/FCP3DXjq7W6skM5NWtfVsVKR+rOPvUVFJJPv/242eP4+55rrFbXl1fJ8tEqUipCPZ6ob39fVy8+m0WxceUhXdGutCrVjldckfxqcW2CSiREafOaQ7n4zrBx+k6VurKISjUrrIhi4ap5Z3kFBPlr2297z3twQiKD3G5Z+Qf6uz0eFJ7zX3oDlzuv9JiJj4+3pU2OkqcTJ07Y4Mhdd93lcfxHH32kW265xWaymP+b5fNZunSpVq1aZTNj/P3PfYsm2OHq6aefVu/evbVmzRq7X2+88YaGDh2q119/XcuXL7frrrvuOm3YsMGOf/PNN22Q48svv9S6detsMMeUaBlff/21hg8fbrN0zHjT56V69eoXdXxMUMa8pgnUmMDSH3/8YQM5JhPJBIWMd999Vw899JDNslmxYoXdn4QE9/RPUyplgjvmPfzf//2fDXwdPnxYvi6ff4AqRJfRIpcASoYytHD/SlWNLX9B2+hQpoVmbZ+vlPTUHNxT5IbGZavpp7XuHw6mr56vxmUzfy8DA/LZsijXMeYC0iw7xiDnmeyXMhGltfLQqrPnQRlaeWi1ykd5Tm2vU6i2NiRtUvcqt+udliP06hUv6bqyHeRnc2POZdabrJzgfMHamOS5rBE549SpdG1ce1A1G5z9Jtzf30+16hfTuhX7L2gbqSmnlZ5+RvkjMjNw9+0+akuiarlsMzx/kCpULai1K9zT6JFzTqWd1prVu9SwcQXnOnPt1bBReS1f5jlAtnzpNvu4q8ZXVLTrXS38a5NaNRug6zsM0Ssvfq2kpOM59C6QndOn0rV1XaKq1o13+92tUjdeG1dfWBAlNTVd6aczFF7g7Af4hGqxWvLHbiUeOGH/5q5Zsk/7dhxVtfqFORm55MzpM0redlQFq5z98tzP388uJ246N7vcIT01XTOemK/pj8/Xn2+u1JFd5/5eHlybpKm95+qnfgu07NP1Sjt2KsfeB+ArciQn9Pvvv7eBBFfPPPOMvTmYIIwJnDz77LOaOHGiM6MlK5MhYx6fN2+eXb799tvVrFkzGzzJ+hoOjgCKKV+6EI8++qhuvPFG57IJyDz11FPOUqshQ4Zo9uzZGjFihEaOHKnt27fbDJSmTZvajBuTMeNgHjMZL23atLGBJJM506DB+dP9sjJBKpO1M2rUKLt9w5R+mYDSL7/8orZt2+rll1+2x88ElFzLoVyZrCETyDIGDRpkA0oLFiywAR5fFhlUwAZnDqdm1jY7JKYkq1SBon/7/Mox5VQuqqSGLPwwB/cSuaVwRKz2HXEPSJrlyND8CgkMVnRYAeULyOdhTKIqxWcGXJHzCgQVUIB/gJLT3C8Gj6Qmq2i45wv1QqEFVSWmsubumafXFg1X4bB4da9yh/L55dOkTZmZkUaJ/MX1QqNnFegfaIOtwxe/bTNykHuOJKXoTHqGorOULJkSpp3bki5oG5+MXKCYuDAbzDFMUMaxjazbTDyc+RhyXmLScRswi4l1vyaLjS2grVs8B90OHjx6TolTbGx+HTp0tmTRZNS0alNdxYrHaOeOQ3prxI/qdd8ojfniYQUEMHdFbjmanGYz1SJi3EuWIqNDtHd79h/eXX31/jJFxYWoat2z/5abHjWfDP1LfW76VgEBfjYg0L1vfVWs6bnnFC691KOnlHFGCo5wz2Yxy0f3nC0JdpW/cKhq9aioyBL5derkadub5rdBS9TqpfoKjckMmheqFqMideIUXjBEx/enaPXXWzRv+Apd+Wxte57hXUyXnXflyF+2li1b2qwV15trPxXDlBcdO3ZMv/76qy3JyS5bxjQJNkGbmjVr2mUTvDGBEBO8MEy2ignQOG4mw+Rim+a6NgI2gaDdu3friiuucBtjlk1GjSPgYd5TxYoVbZnSjBkznONuuukmW3ZVtmxZ2y/mm2++0enTp53BEdd9NUEcT5YtW2YbF5uMGcdYU86UkpKiTZs2af/+/XYfTQ+d86lR42yTLdO7JyIiwj43O6mpqfb9u97Mun8bky1jmgVn1ygYQN5gAtdH0o5o1MpPtPXINs3fu0BTNn+nViVauI3bfXyP7SnTf/5LmrVjtu6vcY+Khf99kBZ5x1djluq3mZv1zJCr6B3zL9Hu/2qrRauqKl+hiFq2rqY337lbq1busFk0uHz8MHa1Fvy8XQ+/1EyBwQHO9T9N2qDNqw+p96BmGvDB1er6QC19PmKRVi08fwkNvCsmIVIlryisyJL5FVcxSg0eqqrgAoHa+svZLzuKNyykIrXjFFE8vw3QNOpdTUlbjtosGgC5HJgxQQBTVuN6M4EFV6aXzB133GF7vvz555+2zMYTU7ZkypLMeMfNzNxkgjmGKTFyDQCZIEuFCpnptGvXrr3g/b0YderU0ZYtW/TSSy/ZIIwpF+rcubOzsbEpb3rnnXcUGhqqBx98UFdeeaUtTzLBKdd9Nf1nPDEBq7p1654T3Fq/fr1uvfVWu90LkbWJsfkQYzJxsmP65ERGRrrdHL1zLifJaUd1+ky6YoLdZ+WIDonUoZTz/1EICQhW6xKN9f2WX3J4L5Fb9h45pPgI939/zHLyyWNKOZWqg8eSdDr9tIcx0fa5yB1H044q/Uy6IoPcZ4KICI5UsoeG3UZSapL2Ht9rS54cdh/bo+iQKFsa5ZCeka59J/bb4M2E9RO1/ch2XV36qhx8N8gqIipE/gF+52SyJB0+qeiY8/cNmfT5ctv498U329s+Mg7RsaHObZy7zQv7O4n/XXRUuM1gOXzomNt6k/0SG+d5Zpe4uAI67JIdkzn+mM2yyU7xErGKig7Xju0HOW25qEBkkC1dOnI4xW19cmKKIv7m92zq+LX64Ys1evw/LVSi3Nk2Ammpp/X1qOW6+cHaqtWkmH3MzMhUv2VJTZtwYdfu+N+ZgIqfv5R6xL3MyCx76hvjiX8+fxukOb4/+yzF8EKhCsofeN4xALzUY8bBZMmYxr6msa1rc2AH0zvFzK5kyndcAxRm2ZQ2mcCLySpxDQCZoIXJqqlSpYrtE+MpEJGUlP2Hc5NVYgImpq+LK7Nstuk6rmvXrvrwww9t9o7pLePo32L24dprr7WlQ459Ne/FBKdc99VTo2NH4MeUYxUqVOicAJcJlpj3bHrazJo1S5dSv379lJyc7HYz6y43JiizPnGL6sZXdestUbdQVa06lFnmlp2WJRraniMztv2eC3uK3DBv80o7E5Orqyo30LzNmdMln0o/rUXb16l1xfpuQUyz7BiDnGeCJ1uObFXV2Cpuv7fVYitrQ9JGj89Zn7hR8eHxbj1lCocXVmJKot1edvz8/N1mYUPOCwwMsNNdL/8rs3GvYRv5/rVbFatnX7pgZl2aMHqxXhjRTuUrF3R7zMzCZIIzy1y2eeJYmtavOqBK1c/2w0DOCgzKZxv3/jn/7N9Xc+214M+NqlHzbKm3qxq1SmmBy3hj/rz1dn129u1NUnLSCcVlE+xBzsgXGKDSFaPdGvea3901i/YpoYrn6bINMxPTd5+t0uOvNVeZSu5ffJh+M+mnz9iggCsTvL3YrHf8czaoUqqADqw5O/tkxpkMuxxd7sJ+z8z4IzuPKyQq+0DOycOpSjt+SsEXGOxBzjLVZHn99m+VI1empvzFTH3t9kL58ikuLs5tXeXKle3MQWbWoOyyZUx/FpNxkpXpp2Ie/89//nPOY+ZDlenJYvq8mH40po+N6TdjMlG+++47W3qU3XTZhpmO22TyOPremG2ZgJApmzKGDRtmZ0GqXbu2bXD31Vdf2b4ypgfMJ598ovT0dDVs2NC+r88//9wGalz70Pwdkz1k3pcJWDlmh9q2bZsmTZpkpww3y2bmJ5OBY4I37du3t1OBm+DRww8/rH/KzO7kOq355WzC+h/1TIP7tfbwZluSdFOF9grNF6Ift2Se92cbPKCDJw/r/RWZJXGuZUy/71qkI2nu3/wZBYLCFR8Wp7iQzCBiyQKZU3oeTkmyMzkh96bLTihY3LlcJraoahYvr8PHj2hH4j4N6viAikUVVLcxL9rH3/ttknq16KwhN/SyU2y3qlhPXeq0VoeRjzu3MWzWOI3p9rwWbl+jBVtX69FWXRUeHKKP5/3Aac1FU7fO0H3V79GW5K3alGymy26r4IBgzdmVGSi9v/o9SkxNslkvxk87Zqttqda6o/KtmrHtJxUOj1fHsh00fdtPzm12rdBZyw4s18GUQwoNCFWToo1UOaaihiwcyrnNZdffUl3DX5yjhMoFVaFKQU0Zv1IpKafU5prMLNdhL8xWbMFwdXsosy/bxE+XauwHi+zsTCYIk3gos+dBSGigQsMC7d/6626upgkfL1HREpF2zOfvL7R9aBo1v/C/ufjf3d6tufo/M15VqhZ3Tpd98mSaOt6QGfB+rt84FSoUqUce+z+7fMvtzdSz+zv69JNf1OzKKpo+dYlWr9yp51/IzD4+cTxV7787Q62vqmGza3bsOKQ3hn6vEiVjbe8Z5K62N1XSqMHzVbpijMpWjtGMiettM+6m7cvaxz8cNN9Oc33TvZltB0yWzOSPV9jZmcxU2Mn/7QcVHJpPIWGBCg0PVMWaBfXlu8sUFBSg2MLhWrd0v+ZO36qbHzq33yRyTsLVxbV41FpFlS6g6DIFtGnmLqWnnlHJppn9gBZ9uFah0UGq0jnzXK/7dquiy0bYLBjbY2bqDp04lKqSzTKviU+npNsxReoWtFk3Jktm1Veb7XjTewZALgdmzNTSJnDhyvRj8VRaFBvrOdpuZh8yQQ3ThNeTTp062YwY07cla8mOYQI6JtvmlVdesb1eTADI7FOTJk1sE9/zMX1jTLaIaa5rerKYTBkz65Fp+GuYjJXXXnvNZrWYaa5NkOjHH3+0QRoTnHn11VfVp08fG6AxMzKZYFB279MTE9AxvXfMezdNiU3QpVixYranjMnUMbp162Z7zpgZoPr27WuDXo5yKkg/75ivqOAI3V2ts2JCorQxaZv6/vqqEv9bEhEfFqsM0/HMRYkCRVSzYCU9NmeQx0PYtGhdG+xxGNg4cxr00au+1servuaw55J6JSvrlz7vOJeH3/So/b+Z6rrHpy+pSGScSsacbTC49dAeG4QZflNv9W7ZRTuT9uuezwdrxpqzU6F/uegnFcwfpRev6WmbBS/duUHt3npM+4/6/ixmeYnpEWOaAHcuf70igyO17ch2DVk4zPaRMWJDY93Klg6nHNarC4fqjkq3aPAVLykxNVHTts3Ud5t/dI6JCCqg+2v0VFRwpE6cOqkdR3fYoIyZ7Qm5q9lV5ZSclGKDLSbIYqbBHjiivaJjM7+cObDvuFtjyKmT1uj0qTN6td/ZQJtxyz11dGvPuvZ+pztqKuXkab09+DcdP5amKjXjNfCNdvShyWVXt6+lxMPH9O7b03Xo4FFVrFRUI9+/R7FxmaVJe/ckyv+/kxkYtWqX1qDXbtPIN6fp7RFTVbJUnIa91V0J5TOvHf0D/LVh3R59N2Whjh5JUcFCEWrcpIIefLidnUIbuathq5I6mpRigy3Jh1NUMiFKfV5rocj/NgQ+ZH53Xb7lnj1lg/3dHTnAPfu8Y7equr5H5myHD/RvookfLtf7r8zX8SNpio0PU6d7qqvldZ5n4UPOKNagkG0CvHbyVqUmpymiRH41eqy6s5Tp5OEUt8ymtOOntXTMejs2MCyfDeg0e6aWnWrbMGOTdxzX9j/26dSJ0zaTplDVGFW6obQCAmnaDZyPXwY5g7gAzb68lePkQ37r8oXzvt8Djby6L7i0Mt6d77x/27QeHF4fM7bdx87765Ne9+q+4NKqENXXef/E6e84vD4kLN+1zvtz9wzw6r7g0mtSZKDz/pN/3Msh9iGvXfGBfE3f33oqr3u92b9zZlxClwAAAAAAAF5CYAYAAAAAAMBLKNQFAAAAAMDH+f+bpz3K48iYAQAAAAAA8BICMwAAAAAAAF5CYAYAAAAAAMBL6DEDAAAAAICPC6DFTJ5FxgwAAAAAAICXEJgBAAAAAADwEkqZAAAAAADwccyWnXeRMQMAAAAAAOAlBGYAAAAAAAC8hFImAAAAAAB8HLMy5V1kzAAAAAAAAHgJgRkAAAAAAAAvoZQJAAAAAAAf5+/n5+1dQDbImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+jlmZ8i4yZgAAAAAAALyEwAwAAAAAALgsjRw5UqVLl1ZISIgaNmyoBQsWZDv2k08+kZ+fn9vNPM9VRkaG+vfvryJFiig0NFRt2rTRhg0bcvQ9EJgBAAAAAACXnQkTJqhPnz4aMGCAFi9erJo1a+rqq6/W/v37s31ORESE9uzZ47xt27bN7fHXXntNb775pt577z39+eefCg8Pt9tMSUnJsfdBYAYAAAAAAB/n75f3bxdr2LBh6tmzp3r06KEqVarYYEpYWJhGjx6d7XNMlkzhwoWdt/j4eLdsmREjRui5555Tx44dVaNGDX366afavXu3Jk+erJxCYAYAAAAAAFxW0tLStGjRIltq5ODv72+X582bl+3zjh07plKlSqlEiRI2+LJq1SrnY1u2bNHevXvdthkZGWlLpM63zf8VgRkAAAAAAOB1qampOnLkiNvNrPPk4MGDSk9Pd8t4McyyCa54UrFiRZtNM2XKFH3++ec6c+aMmjRpop07d9rHHc+7mG1eCgRmAAAAAADwcQF+fnn+NnjwYJuh4noz6y6Vxo0b684771StWrXUvHlzTZo0SQULFtT7778vb8rn1VcHAAAAAACQ1K9fP9vM11VwcLDHYxMXF6eAgADt27fPbb1ZNr1jLkRgYKBq166tjRs32mXH88w2zKxMrts0wZycQsYMAAAAAADwuuDgYDtrkustu8BMUFCQ6tatq1mzZjnXmdIks2wyYy6EKYVasWKFMwhTpkwZG5xx3aYppzKzM13oNv8JMmYAAAAAAPBx/2TWo7yuT58+6tatm+rVq6cGDRrYGZWOHz9uZ2kyTNlSsWLFnOVQL774oho1aqSEhAQlJSXpP//5j50u+5577nHO2PToo4/q5ZdfVvny5W2g5vnnn1fRokV1/fXX59j7IDADAAAAAAAuO127dtWBAwfUv39/25zXlBtNmzbN2bx3+/btdqYmh8TERDu9thkbHR1tM27mzp1rp9p2ePLJJ21w595777XBm6ZNm9pthoSE5Nj7IDADAAAAAAAuS7169bI3T3755Re35eHDh9vb+ZisGZNZY265hcAMAAAAAAA+LsAHS5l8Bc1/AQAAAAAAvITADAAAAAAAgJdQygQAAAAAgI9z6YGLPIZTAwAAAAAA4CUEZgAAAAAAALyEwAwAAAAAAICX0GMGAAAAAAAfF+DHfNl5FRkzAAAAAAAAXkJgBgAAAAAAwEsoZQIAAAAAwMf5U8mUZ5ExAwAAAAAA4CUEZgAAAAAAALyEUiYAAAAAAHxcAKVMeRYZMwAAAAAAAF5CYAYAAAAAAMBLKGUCAAAAAMDHMStT3kXGDAAAAAAAgJcQmAEAAAAAAPASAjMAAAAAAABeQo8ZAAAAAAB8XIAf82XnVWTMAAAAAAAAeIlfRkZGhrdeHAAAAAAA5LxRqx7M84f5nqrv6N+IUiYAAAAAAHwc02XnXZQyAQAAAAAAeAkZM7gghd/uyJHyIXt7TXHev21aD6/uCy6tse0+dt73e6ARh9fHZLw733l/8YGXvbovuLTqFHzOef9QyjgOrw+JDbnFeX/8+l5e3RdcejdXeNt5v/XXt3GIfcisTmO9vQv4FyEwAwAAAACAjwtgUqY8i1ImAAAAAAAALyEwAwAAAAAA4CWUMgEAAAAA4OP8/ahlyqvImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+jlmZ8i4yZgAAAAAAALyEwAwAAAAAAICXEJgBAAAAAADwEnrMAAAAAADg45guO+8iYwYAAAAAAMBLCMwAAAAAAAB4CaVMAAAAAAD4OEqZ8i4yZgAAAAAAALyEwAwAAAAAAICXUMoEAAAAAICPo5Qp7yJjBgAAAAAAwEsIzAAAAAAAAHgJpUwAAAAAAPg4fz/yMvIqzgwAAAAAAICXEJgBAAAAAADwEkqZAAAAAADwcczKlHeRMQMAAAAAAOAlBGYAAAAAAAC8hMAMAAAAAACAl9BjBgAAAAAAH0ePmbyLjBkAAAAAAAAvITADAAAAAADgJZQyAQAAAADg4yhlyrvImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+zp+8jDyLjBkAAAAAAAAvITADAAAAAADgJZQyAQAAAADg45iVKe8iYwYAAAAAAMBLCMwAAAAAAAB4CaVMAAAAAAD4OEqZ8i4yZgAAAAAAALyEwAwAAAAAAICXEJgBAAAAAADwEnrMAAAAAADg4/z9yMvIqzgzAAAAAAAAXkJgBgAAAAAAwEsoZQIAAAAAwMcxXXbeRcYMAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HGUMuVdZMwAAAAAAAB4ySXLmOnevbvGjBmj++67T++9957bYw899JDeeecddevWTZ988onyshdeeEGTJ0/W0qVLvbYPW7Zs0bPPPqtffvlFhw8fVlxcnOrWrashQ4aoUqVKdoyfn59zfEREhKpVq6aXXnpJNWrUsPcfeeQRPfPMM27b7dKli7Zv364//vhDAQEB8nU9qv+fHqx9vQqGRWv1wa169tcPtGT/hmzH96x5rbpVa69iBeJ0+ORRfb9prgbN+1Sp6afs442KVtGDtW9QjUIJKhweo+4/DNK0LX/m4juCw1UlW6lDmfaKDIrU9qPbNWbNWG1O3pLtAQrLF6ou5TupXnxd5Q8K18GTh/TZmnFadnC5fbx1iZZqU7KlCobG2eWdx3bpm43fatnBFRz0XNQsoZaeuOp21S1ZUUWjCur6957UlGW/nvc5zcvX0bDOvVW1SBntSNynl6d+ojHzf3Ab82DzTna7hSNitGznRj08Yaj+2rY6h98NPJnx9Tp9N26Vkg+fVMly0er+WAMlVMn8vctq1rcb9Nu0zdq5Ockul6kYo6731XYb/+4rf+jXqZvdnlejQVH1G9aaE5DLvh6/QGPH/KHDB48poUJh9Xm6vapUL+5x7OaN+zXqndlau2a39u5OVu8nrlbX2xv/T9tEzvrzhx2aO2mrjiWmKb5Mfv3ffZVUvELk3z5vxa97NfE/K1SpYUHd8lwt5/qMjAzNHrtJi2bsUsrx0ypZOUrXPFhJsUXDc/idIKuOZa9SlwodFBMSqU3J2/XW0jFal+j+76qr8MAw3V21i5oWracCQfm1/8RBjVz+mRbsXWYfD80Xoh5VOqtp0fqKConQxqStGrnss/NuE8AlzpgpUaKExo8fr5MnTzrXpaSk6IsvvlDJkiU53hfg1KlTuuqqq5ScnKxJkyZp3bp1mjBhgqpXr66kpMyLU4ePP/5Ye/bssYEWE7y55pprdOTIEX3wwQcaOHCgVqw4+6Hyq6++0vfff2+DZ/+GoEzHhKZ6oeldGvrXBLWd0EerDm3RuOteUFyo54uIGypcqWcb36mhf43XlWN7qc/Pb6lj+abq1/gO55iwfCFadXCr+s15PxffCbJqVLiBbqt0syZtnKLn5r6g7Ud36Ol6jysiqIDHgxXgF6Cn6z+huNA4vbl0pPr+1k+jVn6ixNRE55jDKYc1ft1EPTt3oJ6bO1CrDq1RnzqPqFj+opyAXBQeHKpluzboofGvX9D40rFF9MNDQzV7/SLVGnSnRvw8QaNu76e2lRs6x3Sp20bDOvXWwB9Gqc6gblq2c4OmPzJCBQtE5+A7gSfzZm3VZ28vVKceNTToow4qlRCtV/vMUnLi2WsGV2uW7FWTNqX13FtXaeD77RQbH67BfX7S4QMn3MbVbFhU707p7Lw9/EJTTkAu+2naSr35+nTddV8LfTz+PiVUjNdjD3yuw4eOeRyfknJKRYtH64FH2ig2Lv8l2SZyzsrf9mr6qHVqcUtZ3TeioQqXKaDP+i/WsaS08z4vcd9JzRi9XqWqRp3z2O9fb9Wf3+/QtQ9WVs/XGygwJECf9V+iU2npOfhOkFWL4o10f43b9OmaSbp/1nM2MDOk6dOKCo7weLDy+QXotaZPKz4sTgP/fFPdZ/TV0MWjdPDk2Wuqx+v0VN346hq88F3dM/NpLdy3Qq8166e4EP7u5pVSprx++7e6pIGZOnXq2OCMCSg4mPsmKFO7dm3nutTUVJvRUahQIYWEhKhp06b666+/nI+bTBGTETJ9+nT7vNDQULVq1Ur79+/X1KlTVblyZZslcuutt+rEibMXaGfOnNHgwYNVpkwZ+5yaNWtq4sSJ52x31qxZqlevnsLCwtSkSRMb/DBMNo8JaCxbtsyOMzezbuvWrfa+axaNCZKYdWab/8s+Z7Vq1Spt2rTJZhg1atRIpUqV0hVXXKGXX37ZLruKiopS4cKFbYbMu+++awNiM2fO1HXXXWdfx2QomUDPgQMHbNbSq6++qooVK+rf4L5aHTV21QyNXzNL6xN36MnZ7+rk6VTdXLmNx/H1C1fSX3vW6Jv1v2rH0f2as2OpJq//VbULlXeO+Xn7Yg35c6ymbp6fi+8EWbUv3Vazd/yqX3f9rl3Hd2v0KpPVlKbmxZp5PFgtijdT/sBwDV/yltYnbbTZMmsT19mAjsOSA8ts9sy+E/u098Q+fbVhklJOpyghshwnIBdNWzVPz3/7viYvm3NB4+9vdqO2HNqtvl+/qbV7t2rknImauGS2Hmt9s3NMn9a36MM/puiTeT9ozd6tun/cEJ1IS9Fdja/JwXcCT34Yv1qtri2vFh0SVLxMlO5+opGCQgL0y/ebPI7vNaCZ2t5YUaXLx6hYqUjd+1QjZZyRVi7c4zYuMMhfUbGhzlv+iGBOQC4b/9k8XXdjHV1zfW2VKVdITz53jYJDAvX95CUex1epVky9+rTVVe2rKzAo4JJsEzln7uRtqnt1cdVuU0yFSubXNQ9WVmBwgJbM3JXtc86kZ+jroSvU4tZyio4PdXvMZMvM/3a7ruxSRpUaFbKBnhsfq6qjh1O1dv4BTmUu6ly+vX7cOlvTt/2qbUd3acTi0UpNT1W7Us09jm9XuoUigvKr/7zhWnVovfadOKjlB9dqc/J2+3iQf6CuLFZfH6wYpxUH12r38X026LP72D5dW9bzNTiAHOoxc9ddd9lMDofRo0erR48ebmOefPJJff311zZ7Y/HixUpISNDVV19ty3aylhW9/fbbmjt3rnbs2GFLcUaMGGEzcH744QfNmDFDb731lnO8Ccp8+umntpTKBDgee+wx3X777Zozx/0i35QJDR06VAsXLlS+fPnsPhtdu3bV448/rqpVq9pMFHMz6y7Gxe5zVgULFpS/v78NKKWnX/i3BiYQZKSlZX578cYbb+jQoUO2vOnBBx+0wZuHH35Y/waB/vlUo1A5/bojM6XSyFCGftu5TPUKew5M/bV3rX2OIxBTMiJerUrV1axti3Jtv/H3TPZLmYjSWnloldu5XXlotcpHJXh8Tp1CtbUhaZO6V7ld77QcoVeveEnXle0gP3mOyJv1JisnOF+wNiZ5/sCIvKFx2Wr6ae3ZoL4xffV8NS5b3d4PDMhny6Jcx5gPBGbZMQa54/SpdG1Zf1jV6hV2rvP391O1ekW0YdWFfRBLTU3X6dNnzgm8rF6yT/dd86X63DJFH73+p44mp17y/Uf2Tp06rXVrdqteo7LOdeY6pn6jslq5fGee2Sb+mdOnzmjPxqMqWzPG5Vz4qWytGO1Yl5zt834Zv1nhkUGq27aYx0waUxJVtlasc11IeKCKVYjQjrXu2eHIOSb7pUJUGS3ev9LtmsosV4k9+8WkqyZF62j14Q16pHZ3Tezwjka1eVW3VrxO/v+9pgrwD7C3tP+2AXAwX6BVi6vA6QRyc1YmEwjp16+ftm3bZpdNmY0pb3Jklhw/ftxmd5hMlPbt29t1H374oc30+Oijj/TEE084t2WyREy2iHH33Xfb7ZpskrJlM/9Qd+7cWbNnz9ZTTz1ls3AGDRqkn376SY0bZ9Ypm3G///673n//fTVvfjby+8orrziXn376aXXo0MGWXJngRv78+W2wxmSi/BMXs8+eFCtWTG+++aYNXpnsHZPZ07JlS912223ObWRlMnCee+45W6LkeF8mO8cEyNq2bavw8HAtX77crS+NL4sJjVA+/wAdOOn+x/3AiSQlRHmuTTeZMjEhEZrSabD9YG4+0I1ZMVVvLjqbcQXvKxBUwP7BT0474rb+SGqyioZ7/p0tFFpQVWIqa+6eeXpt0XAVDotX9yp3KJ9fPk3aNMU5rkT+4nqh0bMK9A9USnqqhi9+22bkIO8qHBGrfUfcA/pmOTI0v0ICgxUdVkD5AvJ5GJOoSvGlc3lv/92OJKfab9AjY9y/OY+MCdHubdl/uHP1xTuLFR0XaoM5rmVM9ZuXVKEi+bVv11FN+GCphvSdpRffayf/AOY3yA1JiSeUnp6hmFj3kqSY2HBt23Iwz2wT/8yJI2k6cyZD+aOD3NbnjwrSwZ3HPT5n26pEm01z/xvumd4OJijj2Ib7NoOdjyHnRQZnXlMlprj/G5yYckQlCngu5S4SXki1C1bRrO1z1e+P11Qsf2H1rtVdAf759NmaSTp5OsVm0txe+XptP7rLbrtViSY20LP72F5OK5CbgRmT8WECHSbwYr6ZNPdN/xMHE6Qw5TWO4IURGBioBg0aaM2aNW7bMo1sHeLj423pkWtwwqxbsGCBvb9x40YboDD9WVyZDBLXMqqs2y1SJPMCz5QcXYo+OBezz2PHjrXNkh1MyVOzZs1s2dGdd95pg1nz58+3/WFM0Onbb791e3+33HKLDcaYEiZz3E1gy/X1TSmVKX+qVauWLYn6Oya4ZW6ugoOD7c3XNSlWTb3rdtbTc97X4n3rVSayiF5qdo8eO95Fwxd+6e3dw//ABCSPpB2xfWXMN0Fbj2xTdEiUOpRu7xaY2X18j56ZO0Ch+ULVsHB93V/jHr3856sEZ4A8YMpnK22Pmuffaqug4LOlL03alHHeN82Eze3RrpNtFo1rAAdA7kg9cVqThq3Udb2q2IwZ+BaTGZOYekTDFo/SGWVoQ9JWxYVGq0v5DjYwYwz+6109UfdefdlhpNLPpNsxs3fMVfmos/9ew3v8/fjS4l8TmDFMaVCvXr3s/ZEjR/7j7ZiAjeuHK9dlxzrTV8Y4diyzGZwpFzJZJ66yBhaybtdwbMcTkz5rmECTgwku/a/7bHrBNGx4tkml634XKFBA1157rb2ZLBxT6mX+7xqYGT58uNq0aaPIyEgbmPHEZP+Y24UwpWAmS8fVgAEDbHnW5eTwySM6fSZdBUPdm80VDIvS/hNnm5O5erLhrZq47hd9sXqmXV57aJvC8gXrPy0f0oiFX9kP9PC+o2lH7R/5yCD3pnQRwZFKTnXPonFISk2yz3E9h7uP7bHBGVMalZ6RWTJo/r/vxH573wRvykaU1tWlr9LoVWNy9D3hn9t75JDiI86m1xtmOfnkMaWcStXBY+k6nX7aw5ho+1zknojIYPkH+NnZmFwlH06xfWHO5/svVunbsSv1zIirbMPg84kvVkAFooK1d+dRAjO5JCo6TAEBfuc05T186Lhismns641t4p8JiwiypUtZM1lM49/80ed+cXd470kl7U/RFy+d7cvouH4e2PEnPfxeE2f2jdlGgZiz2ziWlKrCZT038sell5yaeU0VHeI+MUZ0SIQOZ8micTiUkqTTGek2KOOw/chuxYZG29Io89ie4/vV59eXFRIQrLDAUB1OSdJzDR626wFkL0dCZu3atbOZKiZ4YQIKrsqVK6egoCBb4uRgxpnmv1WqVPnHr2meawIwZjpo07PG9WYaEl8os29Ze7s4gh6m54zDpZhO2wRfXPfT0ScmKxPMMdNkmzIwV6bcyjwvu6DMxTJlV2Y2KNebWXe5OXXmtJbv36RmJc5mD5nypKbFa2jh3sxGz1mF5gvWGdNV0kX6f5f/LSVglwMTPNlyZKuqxlZxO7fVYitrQ9JGj89Zn7hR8eHxbj1lCocXVmJKojMo44mfn7/tV4S8a97mlWpdsZ7buqsqN9C8zZkz0p1KP61F29epdcX6zsfN77NZdoxB7sgXGKAyFWK0ctHZVHZTHrFq0V6Vr5r937Bvx67SpDEr9PTrrVWu0tl+FNk5tP+4jiWnKiru/MEeXDqBgflUsXJRLfpzi3Od+QJq4Z+bVa1G8TyzTfwz+QL9VSShgDYvP+z2u7tl2WGVqHjuTJdxxcP04NuNdf+bjZy3ig0KqnT1GHs/Ii7ENgM2wZnNy84GyFNOnNau9UdUotK5MzghZ5ggyvqkLapdsKpznblWql2wmlYf2uDxOaZMqViWa6riBQrbWZnM9lyZsnATlMkfGKb68dU1dw99G4HzyZFPHaa8xlGWlHVqZtPv5IEHHrC9ZGJiYmz50GuvvWbLkExPlv8lyNG3b1/b8Nf88TYzPZnAggkAmX4rZoaiC1G6dGlt2bLFBl6KFy9ut2sCJqYkyMxqZGZ8MmVPpqdLTjCva7JU7rjjDhtsMoEi07zYNFHOri/NpeJLZUvvL52iN9r01rL9G7Vk3wb1rHmtne56/Jqf7ONvtXlUe44f0qB5n9nlmVv/sjM5rTi4RUv2rlPpqCJ6quFtdr0jYBMWGGJLnBxMg+CqcWWUlHJUu45R855bpm6dofuq36MtyVu1KXmz2pVuq+CAYM3Z9bt9/P7q9ygxNUkT1mf2B/ppx2y1LdVad1S+VTO2/aTC4fHqWLaDpm/L/FkwulborGUHlutgyiGFBoSqSdFGqhxTUUMWDs2194XM6bITCp790FUmtqhqFi+vw8ePaEfiPg3q+ICKRRVUtzEv2sff+22SerXorCE39NLoud+pVcV66lKntTqMfNy5jWGzxmlMt+e1cPsaLdi6Wo+26qrw4BB9PO8HDnku63BzFb37yh8qWylWCZXjNPXLNUo9eVrNO2TOfvbOS38oumCobrm/jl3+9vOV+uqjZeo1oKkKFsmvpEOZ2TYhofkUEhaolBOn9PXHy9WgeUmbdWN6zJg+NCZrpmYDprrPTTff0VgvP/+NKlUtamdcmvD5fKWcPGVnVDJefHaSChaK0AO92zib+27ZdMDZGPrA/qNav3aPwsKCVLxk7AVtE7mnyfWl9M3wVSqWEGEb9M6bsl1pKemq3Sbz98yULhWIDdZV3crbWbbiS7lnNYWEZ37ccF3f6LqS+nXCFsUWDbOBmp8/32SzZyo1ujRfNuLCTNwwVU/Vu0/rE7dobeImdUpop5B8wZq+LXPilKfq3W+DLh+tmmCXv938kzqWa6uHat6hyZtm2B4zt1bsqEkbpzu3WS++ug3c7Di6R8Xyx+ve6rdq+9E9mrb1V05LHuBo1Iy8J8e+DjbBkOyYAIcJnpjgw9GjR22DWzPNdHT0/za/vZmByGSPmJKczZs32+mkzRTezzzzzAVvo1OnTnaKb9Nw10yJbRrodu/e3QZGTOCobt26dsppE0wyjXUvNRMMMsEhU1LkmKbbsWyCTrgwUzb+rtjQCD3Z4FYVDI/WqgNbdMt3A3XwZGZqZrECcW4ZMsP/+tKm2j7d8DYVzh+jQyePaOaWvzR4/ufOMbUKJWjSDa84l19slhlInLBmlnrPepNTk0vm711gmwB3Ln+9IoMjte3Idg1ZOMz2kTFiQ2PdypYOpxzWqwuH6o5Kt2jwFS8pMTVR07bN1Hebf3SOiQgqoPtr9FRUcKROnDqpHUd32KCMme0Juadeycr6pc87zuXhNz1q/2+muu7x6UsqEhmnkjFnmzxvPbTHBmGG39RbvVt20c6k/brn88GaseZP55gvF/2kgvmj9OI1PW2z4KU7N6jdW49p/1H3hsDIeY1bl9aRpBRNHLVMSYdP2rKkp4e2UtR/GwIf3HdcrqXvMyevtzPCjHjO/WK+U48a6nx3TVsatX1Ton6duknHj52yjYFr1C+im3rWynYKZuSMNu2qKSnxuD58Z7YOHzym8hULa9g7tzub9+7bm2zLYRwO7j+q7l3fdy5/MWauvdWuV0ojP+pxQdtE7qnWrLCOJ6fp57GbdCwxs9zojoF1nKVMyQdSdLHJxU07ldaplHR99/YapRw/rZJVonT7wNr87uayX3bOt02Au1fpbEuaNiVv09O/D7F9ZIxCYbFurRwOnDysp39/VQ/UuEMfthlsgzaTNk7T+HXfOceE5wvTPdW6Ki40RkfTjum33X9p9Movz5ulDEDyy3D9bQOyUfjtjhwbH7K319mmt7dNc5/OHpe3se0+dt73e8DzjBi4fGW8O995f/GBl726L7i06hQ8m4l7KGUch9eHxIbc4rw/fn1mD0b4jpsrvO283/rr27y6L7i0ZnUa63OHdO6eAcrrmhRx73n6b0EDBQAAAAAAfJw/vTPzLObLAgAAAAAA8BICMwAAAAAAAF5CKRMAAAAAAD7O37XLPvIUzgwAAAAAAICXEJgBAAAAAACXpZEjR6p06dIKCQlRw4YNtWDBgmzHfvjhh2rWrJmio6PtrU2bNueM7969u/z8/Nxu7dq1y9H3QGAGAAAAAIB/waxMef12sSZMmKA+ffpowIABWrx4sWrWrKmrr75a+/fv9zj+l19+0S233KLZs2dr3rx5KlGihNq2batdu3a5jTOBmD179jhv48aNU04iMAMAAAAAAC47w4YNU8+ePdWjRw9VqVJF7733nsLCwjR69GiP48eOHasHH3xQtWrVUqVKlTRq1CidOXNGs2bNchsXHByswoULO28muyYnEZgBAAAAAACXlbS0NC1atMiWIzn4+/vbZZMNcyFOnDihU6dOKSYm5pzMmkKFCqlixYp64IEHdOjQIeUkZmUCAAAAAABel5qaam9Zs1fMLauDBw8qPT1d8fHxbuvN8tq1ay/o9Z566ikVLVrULbhjyphuvPFGlSlTRps2bdIzzzyj9u3b22BPQECAcgKBGQAAAAAAfNw/6eGS2wYPHqyBAwe6rTP9Y1544YVL/lqvvvqqxo8fb7NjTONgh5tvvtl5v3r16qpRo4bKlStnx7Vu3Vo5gVImAAAAAADgdf369VNycrLbzazzJC4uzmaw7Nu3z229WTZ9Yc7n9ddft4GZGTNm2MDL+ZQtW9a+1saNG5VTCMwAAAAAAACvCw4OVkREhNvNUxmTERQUpLp167o17nU08m3cuHG2r/Haa6/ppZde0rRp01SvXr2/3aedO3faHjNFihRRTqGUCQAAAAAAH+fv53t5GX369FG3bt1sgKVBgwYaMWKEjh8/bmdpMu68804VK1bMlkgZQ4YMUf/+/fXFF1+odOnS2rt3r12fP39+ezt27JgtperUqZPNujE9Zp588kklJCTYabhzCoEZAAAAAABw2enatasOHDhggy0myGKmwTaZMI6GwNu3b7czNTm8++67djanzp07e+xjY0qjli9frjFjxigpKck2Bm7btq3NsMkuc+dSIDADAAAAAAAuS7169bI3T0zDXldbt24977ZCQ0M1ffp05TYCMwAAAAAA+LjLYVamfyvfKzIDAAAAAAC4TBCYAQAAAAAA8BJKmQAAAAAA8HH+opQpryJjBgAAAAAAwEsIzAAAAAAAAHgJpUwAAAAAAPg4ZmXKu8iYAQAAAAAA8BICMwAAAAAAAF5CYAYAAAAAAMBL6DEDAAAAAICP8/cjLyOv4swAAAAAAAB4CYEZAAAAAAAAL6GUCQAAAAAAH8d02XkXGTMAAAAAAABeQmAGAAAAAADASyhlAgAAAADAx/kxK1OeRcYMAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HH+5GXkWWTMAAAAAAAAeAmBGQAAAAAAAC8hMAMAAAAAAOAl9JgBAAAAAMDHMV123kXGDAAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPBx/n7kZeRVnBkAAAAAAAAvITADAAAAAADgJZQyAQAAAADg4/zIy8izyJgBAAAAAADwEgIzAAAAAAAAXkIpEwAAAAAAPo5ZmfIuMmYAAAAAAAC8hMAMAAAAAACAl1DKBAAAAACAj2NWpryLjBkAAAAAAAAv8cvIyMjw1osDAAAAAICct/PYB3n+MBfPf6/+jciYAQAAAAAA8BJ6zAAAAAAA4OOYLjvvIjCDC/L7nv4cKR/StMiLzvvrk1736r7g0qoQ1dd5f/GBlzm8PqZOweec9/0eaOTVfcGllfHufOf93cdHcXh9SNHwe5z3X/jzPq/uCy69Fxq+77w/d88ADrEPaVJkoLd3Af8ilDIBAAAAAAB4CRkzAAAAAAD4OD8/8jLyKs4MAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HH+5GXkWWTMAAAAAAAAeAmBGQAAAAAAAC+hlAkAAAAAAB/HrEx5FxkzAAAAAAAAXkJgBgAAAAAAwEsoZQIAAAAAwMf5+5GXkVdxZgAAAAAAALyEwAwAAAAAAICXEJgBAAAAAADwEnrMAAAAAADg4/wU4O1dQDbImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+jumy8y4yZgAAAAAAALyEwAwAAAAAAICXUMoEAAAAAICP8yMvI88iYwYAAAAAAMBLCMwAAAAAAAB4CaVMAAAAAAD4OGZlyrvImAEAAAAAAPASAjMAAAAAAABeQikTAAAAAAA+zs+PvIy8ijMDAAAAAADgJQRmAAAAAAAAvITADAAAAAAAgJfQYwYAAAAAAB/nT15GnkXGDAAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPBxTJedd5ExAwAAAAAA4CUEZgAAAAAAALyEUiYAAAAAAHycvx95GXkVZwYAAAAAAMBLCMwAAAAAAAB4CaVMAAAAAAD4OD/yMvIsMmYAAAAAAAC8hMAMAAAAAACAlxCYAQAAAAAA8BJ6zAAAAAAA4OOYLjvvImMGAAAAAADASwjMAAAAAAAAeAmlTAAAAAAA+Dimy867yJgBAAAAAADwkjwbmOnevbuuv/56b+8GAAAAAABA3ihlMsGSMWPGZD4xXz7FxMSoRo0auuWWW+xj/v65G+dp0aKF5syZo8GDB+vpp592e6xDhw768ccfNWDAAL3wwgvK68zxS0pK0uTJk729Kz7j5282aNr4tUo+nKISCVG69ZE6Kls51uPYOd9v0rzpW7VrS7JdLlUhRjf2rO42PuXEKX39wXIt+X2Xjh1JU1yRcLW5sbxadEzItfeETD98tUqTxi5X4qGTKlM+Rvc93kQVqhbyeHimT16rn39cr22bE+1yQqU43flAfbfxGRkZGvvBIs2YslbHj6Wpco14PfhkUxUtGckh94IZX6/Td+NWKfnwSZUsF63ujzVQQpU4j2NnfbtBv03brJ2bk+xymYox6npfbbfx777yh36dutnteTUaFFW/Ya1z+J3AVbOEWnriqttVt2RFFY0qqOvfe1JTlv163oPUvHwdDevcW1WLlNGOxH16eeonGjP/B7cxDzbvZLdbOCJGy3Zu1MMThuqvbas5+LnsmwmLNeHTv3T40HGVq1BIjzzZWpWrFfE4dsumg/r43d+1fs0+7dtzRA893lKdb6uX7ba/+PhPffjWr+p0S131eqJVDr4LZGf9T7u09sftOpmcpugS+VX3jvKKLRfhcezm3/bozw/Xua3zD/RT14+a2/tnTp/R8q+3aPeywzq2/6SCwvIpvmq0anYpq7DoYE5CLpv1zQZNHb/GXi+XTIjSbY/UPe/18h/Ttzivl0tXiFGnnjXOuV7+yl4v77TXywXt9XIFteR6OU9gVqa866IjKe3atdOePXu0detWTZ06VS1btlTv3r11zTXX6PTp08ptJUqU0CeffOK2bteuXZo1a5aKFPF8QQDft+Dn7ZrwzlJd172qBnzYViXKRWn4E3N0JDHF4/h1S/erQeuSemJ4Sz0zso1iCoVqWN85SjxwwjnGbG/lgr2659lGenlMe13VuYLGvrFYS//YlYvvDL/N3KRRb8zXLXfX0YgxN6hMQqz6956qpMMnPR6cFYt368q2CRr0zjX6z6iOiiuUX/0fmapD+487x3z92TJ9/+UqPfhUU73+UUeFhATabaal5v6/af9282Zt1WdvL1SnHjU06KMOKpUQrVf7zFJyoufzu2bJXjVpU1rPvXWVBr7fTrHx4Rrc5ycddvndNWo2LKp3p3R23h5+oWkuvSM4hAeHatmuDXpo/OsXdFBKxxbRDw8N1ez1i1Rr0J0a8fMEjbq9n9pWbugc06VuGw3r1FsDfxilOoO6adnODZr+yAgVLBDNgc9FP09fq3eH/aJu9zbRB1/cqXLlC+rJh75S4uGz/866Sk05paLFonTvI1cqJi78vNteu2qPvvt6mcqWL5hDe4+/s23+fi35YqOqXV9a7V6sp6iS+TX7P8uVciQt2+cEhgbo+jcbO2/XDWvsfOx02hkd3npM1TqWUruX6qnpI1V1dM8J/TZ8BScjl/3583aNf2eJOnavphc+vNpeLw994pdsr5fXLt2vRq1L6anhrfTcyKsUUyhMr/f9xe162Wxv5YI9uvfZRhr03+vlz99YpCVcLwOXNjATHByswoULq1ixYqpTp46eeeYZTZkyxQZpTIDEBGz8/Py0dOlS53NMJohZ98svv9jl9PR03X333SpTpoxCQ0NVsWJFvfHGG/onTEDo4MGD+uOPP5zrTFZP27ZtVaiQ+zfoiYmJuvPOOxUdHa2wsDC1b99eGzZscD5u9j8qKkrff/+93SczpnPnzjpx4oTdZunSpe1zH3nkEfseHFJTU9W3b197TMLDw9WwYUPne3Xd7vTp01W5cmXlz5/fGeAyTEaP2b45juY4OY6VuZn75vg5mONq1pnj/L/ss6+b8dU6XdmhrJq2L6uipSN1R596CgrJp99/3OJx/L3PNVar68urZPloFSkVoe5P1LdZFGsW73OO2bjyoJq0K61KtQvZbJnm15azmTib1xzOxXeGyeNW6OqOldTm2ooqWTZaDz7dVMEh+TTzO/dv5xz6vthKHTpXUdkKsSpROkoPP9tMZ85kaNnCzICaOc/fjl+pLj1qq1Hz0ipTPlaPvdBChw+e0Pw52zjgueyH8avV6tryatEhQcXLROnuJxopKCRAv3y/yeP4XgOaqe2NFVW6fIyKlYrUvU81UsYZaeXCzH9fHQKD/BUVG+q85Y/gW9ncNm3VPD3/7fuavGzOBY2/v9mN2nJot/p+/abW7t2qkXMmauKS2Xqs9c3OMX1a36IP/5iiT+b9oDV7t+r+cUN0Ii1FdzW+JgffCbL6auxCdbihhtp3rK7SZePU59m2NsA9dcpKjwerUtUiuv+xFmp1dWUFBgZke0BPnkjTK8/+oL7Pt1WBiBAOvJesm7ZD5VoUUdkriyiyWLjqd6+gfMH+2jzH/d9ZN35SaFTw2VtkkPMhkyHT6qmaKtmwkCKKhCkuIVJ17yxvgzXHD3oOCCBnzPhqra7sUE7N2pdVsdKRurNPfXu9/NuP7lmmDvdluV7u8d/r5dVu18uHdIW9Xo5XXJH8anFtwn+vlw9xGpFjRo4caT/3hoSE2M/iCxYsOO/4r776SpUqVbLjq1evbittXJmf6/79+9tEDxOvaNOmjVvcICdcktqjVq1aqWbNmpo0adIFjT9z5oyKFy9uD8jq1avtmzYBni+//PKiXzsoKEi33XabPv74Y+c6E6y46667PJYLLVy4UN9++63mzZtnD/j//d//6dSpU84xJqDx5ptvavz48Zo2bZoNjtxwww32ZJnbZ599pvfff18TJ050PqdXr152e+Y5y5cv10033WQDL64nz2z39ddft8//9ddftX37dhvMMcz/u3Tp4gzWmFuTJk0u+Bj8k332ZadPpWvbukRVrhvvXOfv76cqdeO1afXBC9pGamq60k9nKLzA2Q9vCdXibHaM+VbA/OysXbJPe3ccVdX6Z18HOevUqXRtXHtQNRsUczu3teoX07oV+y9oG6kpp5Wefsb5wXzf7qO2JKqWyzbD8wepQtWCWrvi7IUGcud3d8v6w6pWr7Db+a1Wr4g2rDpwwb+7p0+fPb8Oq5fs033XfKk+t0zRR6//qaPJqZd8/3FpNS5bTT+t/ctt3fTV89W4bHV7PzAgny2Lch1j/m02y44xyJ1/l9ev2au6DUu5/d7WaVhKq5bv/p+2PeLVn9SoaVnVbVj6Euwp/on00ya75agKVz2bhebn76f4KtE6uPFIts87nZKuKY/N05RH5+nX4SuUvNNz9pTDqROnbTAnKJwJY3Pzb+7WdYmq6uF6eePqQxd5vXw28JZQLVZL/tjtvF5es2Sf9u04qmr1z/5th/f4+fnn+dvFmjBhgvr06WNbmCxevNjGJa6++mrt3+/5s8HcuXNtKxaTKLJkyRLb19bcVq48+2XCa6+9Zj9fv/fee/rzzz9t8oXZZkpKzgWPL9m/fibiZIISFyIwMFADBw50LpvMGRPYMIEZE6C4WCYI06xZM5t1s2jRIiUnJ9tMGtfeMiZIYgIyJrPGEfQYO3asLYUyfV1MMMUwQZp3331X5cqVs8sm+8QENvbt22czXapUqWLLt2bPnq2uXbvaAIsJCpn/Fy1a1BloMQESs37QoEHO7ZoT69iuCea8+OKL9r7ZronEmcwbk410sS52n33d0eQ0mxEREeP+7VpEdIj2bM/+IsLVxPeXKSouxP5xcjA9aj4dulB9b/pOAQF+9sKkW996qljTc28TXHpHklJ0Jj1D0TGhbuujYkK1c9vZzLLz+WTkAsXEhdlgjmGCMo5tZN1mYjblUcgZR5JT7fmNzHIuImNCtHtbZj373/nincWKjgu1wRzXMqb6zUuqUJH82rfrqCZ8sFRD+s7Si++1k39Anu2B/69XOCJW+464ZySa5cjQ/AoJDFZ0WAHlC8jnYUyiKsXzQT63JCed/O+/y2Fu683y9q3/PKP05+lrtGHtPr332R2XYC/xT6UePWWzEEMizn7wNkIig2z5kScRhcPU8J5KiioRrlMn07Xmxx2a+dJi/d/g+grLcm1mpKela+mXm1WqUSEFhhKY8fb1cmR0iPZe4PXyV/+9Xq5a9+znF9Oj5pOhf6nPTd86r5e7963P9TJyzLBhw9SzZ0/16NHDLpvP3D/88INGjx59Th9aw8QMTELEE088YZdfeuklzZw5U2+//bZ9rgkojhgxQs8995w6duxox3z66aeKj4+3cYObbz6buXspXbJ//cwbMCU2F5NuZA6WCWicPHlSaWlpqlWrlsexJoBy3333OZdN2ZQJxDiYqFj58uVtRogJPtxxxx22ObGrNWvW2HUmtckhNjbWlv+YxxxMKZAjwGGYE2DSokyAw3WdIwK3YsUKWyJUoUIFt9czQRaz/ey2a9KisoviXayL3efsmH02t6yla+b2b/Lj2DVa8PMOPTmipQKDz6ZYz5q0QZtWH9LDg5raPhbrlx3Q5yMW27KIKi7f8CPv+mrMUv02c7MGvdNBQcFc/PmaKZ+ttD1qnn+rrYJcfnebtCnjvG+aCZvbo10n2ywa1wAOgLxh/94jevs/P+s/79zEv9WXobjykfbmXE6I0A9PL9DGn/eoRuez/x47GgH/MXK1lCFbIoXLxw9jV9uejk+NaOV2vfzTpA3avPqQeg9qZq+X1y3br89HLLLXy1W5XsYFSL2Iz6QmhmASM/r16+dcZyYkMqVHJvHDE7PeZNi4Mtkwjkl4tmzZor1799ptOERGRto4gnlung/MmOCGyXxxzMxkAjUOrqVChim5MVklQ4cOVePGjVWgQAH95z//sWlCnlx33XVuARXTy8VT1owJ9pjSqL+rKfu7bB5XJtjkaZ0pxzKOHTumgIAA+wNh/u/KNTDiaRuux8iTCzmW/2Sfs2Nmt3LNZDIul1mtXBWIDLKpmEcOu6eamUZm5pv38zGzOP34xRr1HdrCNkBzME1gJ41aoYdeukI1G2dmRpnHd2xM1PQJ6wjM5JKIqBD5B/idk8liGv9m/bY2q0mfL9fXny7TS2//n+0j4xAdG+rchsmkcd1mWZdxyHkRkcH2/JrZmFyZmSLMBd35fP/FKn07dqWeGXGVbRh8PvHFCqhAVLD27jxKYCYP23vkkOIjYtzWmeXkk8eUcipVB4+l63T6aQ9jou1zkTsio0L/+++ye/aEWY6JPX9j3+yY2ZrM8++97VPnOpOVs3zxDn3z5WLNmN9HAWS75YrgAoEylQVZG/2mJKfZrJkL4Z/PX9GlCujo/pMegzKmr0yrp2uRLZNHrpeTE1MUkSVzNaup49fqhy/W6ImhLc+5Xv561HI9/FJTt+vl7RuTNG3CWgIzeYDf+T9+5gmDL+Izqek1a5IkTBKCK7O8du1aj9s3QRdP4816x+OOddmNyQmXJIf7559/tpkjnTp1UsGCmV3zHY1tDddGwIajnOjBBx9U7dq1lZCQoE2bPDd2NEzgxoxx3EzZT1a33nqr3Ydq1arZ0p2sTNNdM2uUa/Dn0KFDWrduncfxF8rsv/lhMNkorvtobhdTlmR65WRtznshx/JSMpFGUwbmenONPl4u8gUGqFTFaLfGvSZVc82ifSqXzZS7xtRxa/T9Z6v12GtXqnQl9wt9Uz9r6qzNHzBX5mL0zN8E2HDpmCaRZrrr5X+dnQnLNvL9a7cqVs++pMzMujRh9GK9MKKdyld2n9kjvmgBG5xZ5rLNE8fStH7VAVWqTv+g3P7dLVMhRisX7XU7v6sW7VX5qtnPyPLt2FWaNGaFnn69tcpV+vtgmpmR61hyqqLizn/hCe+at3mlWld0n0L5qsoNNG9z5swtp9JPa9H2dWpdsb7blxBm2TEGufPvcoXKhbV4wTa331uzXLVG5gezi1WnQSmN/rK7Ro3r5rxVrFJYbdpXsfcJyuSegHz+iildQHtXnS0XzjiToX2rE20mzIUwPw9JO4+5NQB2BGWO7j2hlk/VtAEg5P7f3NIVo90a9zqulxOqZP+39Mdxa/TdZ6v0+GvNVSab6+WsbULM9fLffSEN+Npn0hzPmDFpRSZSZIIIpoeJ6aViolqmp4uZ8chkjTRq1EivvvqqzaAxAQtTn+XKlB2ZOi0zS5EZY/qh/PXXX/b+P2VmHjIBjKyZIq6vaWrETP2ZaYRrgj2m5sxk3zhqx/4JU8Jkmg+b924ygEyg5sCBA3a67ho1aqhDhw4XtB1TemSOhwkUmRIoky5lgjumB46JDr7yyitav369fY2c4ktlS21vqqiPBv+p0hVjVKZyrH6auM42fb2ifebP2KhB8xUdF6ZO99awyyZLZsrHK9XzuUaKKxyu5P/2HQkOzaeQsECFhgeqYs2C+vLdpQoMClBs4TCtW3pAc6dvU9eHPJfgIWdcf0t1DX9xjhIqF1SFKgU1ZfxKpaScUptrMlOgh70wW7EFw9XtoQZ2eeKnSzX2g0V2diYThEk8lPmtbkhooELDAu0HueturqYJHy9R0RKRdszn7y+02TONmp9tZonc0eHmKnr3lT9UtlKsEirHaeqXa5R68rSad8gs13znpT8UXTBUt9xfxy5/+/lKffXRMvUa0FQFi+RX0n9/d0P++7ubcuKUvv54uRo0L2mzbkyPGdOHxmTN1Gzwzz404p9Pl51QsLhzuUxsUdUsXl6Hjx/RjsR9GtTxARWLKqhuYzL7r7332yT1atFZQ27opdFzv1OrivXUpU5rdRj5uHMbw2aN05huz2vh9jVasHW1Hm3VVeHBIfp43g+cplx002319OqAH1WhSmFVrlpEE79YqJSTp9Tuumr28UHP/6CChQqo58NXOhsGb9t80NmA9OD+Y9q4bp9CQ4NUrGS0wsKDVCbBPRhr/s2OiAw9Zz1yXsV2JTT/wzWKKVNAsWULaN2MnTqdekZlrswsBZ33/hqFRgerVpeydnnl5K2KLRehAvGhSjtx2vaYOXEw1c7s5AjK/P7WKiVuO6Yr+1S3gZ6TSZllC0H5A20wCLmj7U2VNGrwfHu9XLZyjGZMXG+vl82spsaHg+bbLzFuuremXTZZMpM/XmFnZzr/9fIyBdnr5XCtW7pfc6dv1c1cLyMHPpPGxcXZ+IOJS7gyy9klSZj15xvv+L9ZZ9qPuI7JrvWKVwIzJhBjdtD0azHBENPfxXQs7tatm7P0xvSOMV2O69ata3u4mK7GZvpqB9MvxnRANo1ozYci0xXZZM+Y3jH/CzNt9PmYZry9e/e2QSRTj3bllVfaWYuyC+ZcKLPdl19+WY8//rh27dplf0BMcMq8zoUyASMzm1K9evVseZTpldOiRQuNGzdODzzwgA3y1K9f376Oo1ExstegVUkdTUrV5I9X2hRNM03fY681d5YyHd53wq0n0i9TNur0qTN6d8Bct+1c162qOvbIvLC8r39jff3hcn34ynwdP5Km2Pgw3XBPdbW47mx/H+S8ZleVU3JSig22mCCLmQZ74Ij2io7NLEM6sO+4bTTnMHXSGntuX+33k9t2brmnjm7tWdfe73RHTaWcPK23B/+m48fSVKVmvAa+0Y7eBl7QuHVp2+R54qhltpzMlCU9PbSVsznzQXt+z46fOXm9Pb8jnvvVbTudetRQ57tr2m/ptm9K1K9TN+n4sVO2MXCN+kV0U89aNsiK3FOvZGX90ucd5/Lwmx61/zdTXff49CUViYxTyZizF1FbD+2xQZjhN/VW75ZdtDNpv+75fLBmrDmb+frlop9UMH+UXrymp20WvHTnBrV76zHtP/rPm87i4rW6upKSE0/ok3f/0OFDx1WuYiENebuzs5Rp/96jbhmnhw4cU89bzpYpTfjsL3urWbeERnyYM7X7+OdMU97Uo2laMWmLLWGKLplfLZ6o4cyAOXEoRa5tJtOOn9aC0evsWDPLksm4afN8bTvVth2fmKpdSzLLDac9t9DttVr1q6n4yucvR8Wl09BeL6fYYIspGy6ZEKU+r7VwXi8fMn9zXc7t7Ckb7N/ckQP+cNtOx25VdX2PzNnwHujfRBM/XK73Xa6XO91TXS2vS+DU4ZILCgqyMQeTFGFmVjJM+w6zbCbb8cS0UjGPP/po5nWIYZr/mvWGSRYxwRkzxhGIOXLkiK28MZ/Lc4pfBnlluAC/7+nPcfIhTYtkfiNtrE963av7gkurQlRf5/3FB17m8PqYOgXPZqD6PdDIq/uCSyvj3fnO+7uPj+Lw+pCi4fc477/w59nJLOAbXmj4vvP+3D0DvLovuLSaFHHvc+ITzsxSnuff+qKnyzZJIqYqpkGDBnZGJTPbs+kxY/rCmMoWUyVjqnwc02U3b97cVviY6hbT/9bMpGym2jZtUYwhQ4bYx8eMGWMDNc8//7ydgdr0sw0JOX/P0n+KaUkAAAAAAMBlp2vXrraVSP/+/W3LFZPlYqp8HM17zSzQjsoew/S6/eKLL2y7lWeeeca2PDEzMjmCMsaTTz6p48eP695771VSUpKaNm1qt5lTQRmDwAwAAAAAALgs9erVK9vSJdMuJCvTGuR87UFMy4sXX3zR3nILgRkAAAAAAHxdxhlv7wGyQdtzAAAAAAAALyEwAwAAAAAA4CWUMgEAAAAA4OsoZcqzyJgBAAAAAADwEgIzAAAAAAAAXkIpEwAAAAAAvo5SpjyLjBkAAAAAAAAvITADAAAAAADgJZQyAQAAAADg686c8fYeIBtkzAAAAAAAAHgJgRkAAAAAAAAvITADAAAAAADgJfSYAQAAAADA1zFddp5FxgwAAAAAAICXEJgBAAAAAADwEkqZAAAAAADwdZQy5VlkzAAAAAAAAHgJgRkAAAAAAAAvoZQJAAAAAABfRylTnkXGDAAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPB1Z854ew+QDTJmAAAAAAAAvITADAAAAAAAgJdQygQAAAAAgK9jVqY8i4wZAAAAAAAALyEwAwAAAAAA4CUEZgAAAAAAALyEHjMAAAAAAPg6eszkWWTMAAAAAAAAeAmBGQAAAAAAAC+hlAkAAAAAAF9HKVOeRcYMAAAAAACAlxCYAQAAAAAA8BJKmQAAAAAA8HEZGenK6/z070TGDAAAAAAAgJcQmAEAAAAAAPASSpkAAAAAAPB1Z854ew+QDTJmAAAAAAAAvITADAAAAAAAgJcQmAEAAAAAAPASeswAAAAAAODrMugxk1eRMQMAAAAAAOAlBGYAAAAAAAC8hFImAAAAAAB8HaVMeRYZMwAAAAAAAF5CYAYAAAAAAMBLKGUCAAAAAMDXUcqUZ5ExAwAAAAAA4CUEZgAAAAAAALzELyMjI8NbLw4AAAAAAHJexv4P8vxh9it0r/6NyJgBAAAAAADwEgIzAAAAAAAAXsKsTLgg+09+ypHyIYVC73TeP3H6O6/uCy6tsHzXOu8fShnH4fUxsSG3OO/vPj7Kq/uCS6to+D3O+34PNOLw+pCMd+c778/f+4JX9wWXXqPCZ8/pm8se4BD7kEdqviufc+aMt/cA2SBjBgAAAAAAwEsIzAAAAAAAAHgJgRkAAAAAAAAvoccMAAAA8P/t3Qd4U2UXwPEDLZQW6KKFsvfelC1LtqCCC1FQUAQFBZSh8jlAFHCBCqLgQEVBREQUQZYgey8ZBdl7CIUyW+j4nvNiQtMBRdre5vb/e548bW7S8DaXpLnnngEAdhdHj5mMiowZAAAAAAAAixCYAQAAAAAAsAilTAAAAAAA2B2lTBkWGTMAAAAAAAAWITADAAAAAABgEUqZAAAAAACwO0qZMiwyZgAAAAAAACxCYAYAAAAAAMAilDIBAAAAAGB3sbFWrwDJIGMGAAAAAADAIgRmAAAAAAAALEIpEwAAAAAAdsdUpgyLjBkAAAAAAACLEJgBAAAAAACwCIEZAAAAAAAAi9BjBgAAAAAAu6PHTIZFxgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAADsLjbW6hUgGWTMAAAAAAAAWITADAAAAAAAgEUoZQIAAAAAwO5i46xeAZJBxgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAADsjqlMGRYZMwAAAAAAABYhMAMAAAAAAGARSpkAAAAAALA7SpkyLDJmAAAAAAAALEJgBgAAAAAAwCIEZgAAAAAAACxCjxkAAAAAAOwuNs7qFSAZZMwAAAAAAABYhMAMAAAAAACwtfDwcOnUqZP4+vqKv7+/dOvWTS5cuHDD+/fu3VvKli0r3t7eUqRIEenTp49ERES43C9LliyJLlOmTLmltVHKBAAAAACA3WXycdmdOnWSY8eOyfz58+Xq1avyxBNPSI8ePWTy5MlJ3v/o0aPm8v7770uFChXkwIED8swzz5ht06ZNc7nvV199Ja1bt3Ze18DPrSAwAwAAAAAAbCssLEzmzJkja9eulZo1a5ptY8aMkTZt2pjAS4ECBRL9TKVKleSnn35yXi9ZsqQMGzZMOnfuLNHR0eLp6ekSiAkJCfnP66OUCQAAAAAAWC4qKkrOnTvnctFtt2vlypUmeOIIyqjmzZtL1qxZZfXq1Sl+HC1j0lKo+EEZ9eyzz0pQUJDUrl1bJkyYIHFxt9ZomcAMAAAAAACZoZQpg19GjBghfn5+LhfddruOHz8uefPmddmmwZXAwEBzW0qcOnVK3nzzTVP+FN/QoUNl6tSppkTqgQcekF69eplsnFtBKRMAAAAAALDcoEGDpF+/fi7bvLy8kr3/yy+/LO+8885Ny5hul2butG3b1vSaGTJkiMttr732mvP76tWry8WLF+W9994zjYJTisAMAAAAAACwnJeX1w0DMQn1799funbtesP7lChRwvR/OXnypMt27ROjk5du1hvm/PnzprFv7ty55eeff5Zs2bLd8P516tQxmTVagpXS34XADAAAAAAAdhd7a31P3EFwcLC53Ey9evXk7Nmzsn79egkNDTXbFi5cKLGxsSaQcqNMmVatWpkAy6+//io5cuS46b+1adMmCQgIuKUAE4EZAAAAAABgW+XLlzdZL927d5dx48aZcdnPPfecdOzY0TmR6ciRI9KsWTOZOHGiaeKrQZmWLVvKpUuX5LvvvnM2I1YaDPLw8JCZM2fKiRMnpG7duiZoo31mhg8fLgMGDLil9RGYAQAAAAAAtjZp0iQTjNHgi05j0ka9o0ePdt6uwZqdO3eaQIzasGGDc2JTqVKlXB5r3759UqxYMVPWNHbsWHnhhRfMJCa936hRo0wA6FYQmAEAAAAAALYWGBgokydPTvZ2DbTEH3PdpEmTm4691iwcvdwuAjMAAAAAANidjqRGhpTV6gXg5jRy9+GHH/JUAQAAAABgM7edMaOjqb755ht5+umnTROd+J599ln55JNPpEuXLvL111+L1cGNAwcOmO+9vb2lZMmS0rdvX3nqqacko1u7dq3kzJnT6mW4nelT1sn336yS8NMXpGSZfPL8Sy2lQuWCSd533+5/5MtPF8vO7cfl+LEI6T2ghXToXNvlPpvWH5Tvv1kpO8OOy+l/LsiwUQ9Ko6Zl0+m3QXw/TF4u33z1p5w+dV7KlM0vL/3vPqlUpUiyT9L8uZvlkzFz5OiRM1KkaJD06ddWGjYq77z99f9NkZm/rHP5mfp3lJWxn91abShu309T1sikb5ZL+KkLUqpMiPR7+S6pULlQkvfdu/ukfPHJItkRdlSOH42QvgNbycOd693WYyJt/fzDBvlh4loJP31RSpbJK31ebCblK+VP8r779pySrz5dJn+HnZATx87Js/3vlAc71Uz2sSd/tVo+H7NEHngkVJ4b2DQNfwsk1LBUNRnYorOEFikrBfyDpf24F+WXzUtu+EQ1Ll1DRj3YVyrmLy6HzpyQt37/Wr5ZNcvlPr0aP2AeN8Q3UDYf3i29fxgpaw9sZwdYYMHPf8vvU3ZIRPhlKVwyQDr3DZWS5fMked8/Z+6W5XP3y+F9Z831YmUD5cHuVV3u36Xx90n+7MPPVJM2j1z/+4y0t2XOYdk486BcOntF8hTNJY2eLCP5Svne9Od2LT8h8z7aJsVrBkmbF6u43BZ++KKsnLRHjm4/I7GxcRJYKKe07l9ZcgfdfJoNkFmlSsZM4cKFZcqUKXL58mXntsjISFO/VaRI8gdL6W3o0KFy7Ngx2bp1q3Tu3Nk05Pn9998tXdOVK1dueh/t+Ozj45Mu67GLP+Zul49HLpCuTzeUL77vJqXK5JX+vabImfCLSd4/MvKq5C8YIE/3vVMCg5IOgkVeviKlyuSTfoNapfHqcSNzf98kI9/9VZ7u1UIm//i8lClbQHo9/bmEnz6f5P03bdwvgwZOkvb315bvp70gTZpWkn69v5bdu4653K9+g7Iy/8/XnZcR73ViR6SzBXO2yuj358qTTzeRr6Y8LaXK5pMXen5ngqvJvW4LFAqQnn2aS56gXKnymEg7C+fukE9H/SldetSXzyY/LiVLB8uLz/6Y7PtylO7fgv7So0+jZN+XHXZsOyYzf9osJUrffFwmUl9OL2/ZfGSXPDvl/RTdv1ie/DLr2ZGy6O/1Um344/Lhwh/ki86DpGX56+NKO4Q2l1EP9JU3Zn0hNYZ3kc2Hd8ncPh9KcO4AdmE6W73wgHw/dqO061JJ3vi8tRQu6S/vD1gk585EJnn/HZtOSt1mReXlD5vJa5+0lMBgH3P/8H+uNdNUH01v73Lp9lIdyZJFpGbjwun4m2HXihOybOIuqfVgMenwTi0JKppLZg7bJJcibnx8cu7kZVn+7W7JX94v0W0Rxy/J9NfXS0BBH2k/pIZ0fK+21HygmHhko1Ajw4zLzuiXTCpVXiE1atQwwZnp06c7t+n3GpSpXr26c5vOCB8xYoQUL17cZK1UrVpVpk2b5rw9JiZGunXr5ry9bNmy8tFHHyXK0Gnfvr28//77kj9/fsmTJ4/JzNEOyjeTO3duCQkJkRIlSshLL71kmv/oOCsHnWuuGTQaCPH19ZWmTZvK5s2bzW1///23ZMmSRXbs2OHymB988IHJvnHQoM9dd90luXLlknz58sljjz0mp06dcmkgpJ2gn3/+eQkKCjIz0bWh0JAhQ8zzpbPOdVxXnz59ki1lOnjwoLRr1878G7rODh06mBFdDvpY1apVk2+//db8rJ+fnxkDdv580geudvTDt6vlnvurSdv2VaV4yWAZ8GobyZHDU2bNuLY/EypfqYA826+ZNG9dUbJnSzqRrG6DUtL9uSbSqGm5NF49buS7bxbL/Q/WkXb31ZaSpULklcEPSI4c2WTG9LVJ3v/775aaoEuXJ++UEiXzybN9Wkv5CgVlyuTlLvfLnt1TgoJ9nRdfP4Kh6W3Ktyvl3vtryN3tq0vxknnlxVfvFq8c2eS3GRuTvH+FSgXluX4tpcVdlSVbdo9UeUyknR8nrZO291WRu9pVlmIlgqTfKy3Na/f3X7Ymef9yFfPLMy80kaatyku2bEnvX3X50hUZ9sosGfBaS8nty9lYK8zZtlJe+3W8zNi8OEX3f6bh/bLv9FEZ8NNo2XF8v4xdPE2mbVwkLzTr6LxPv2aPyOfLf5GvV86SsOP75Znv35FLVyLlyXp3p+FvgqTMmbpTGt9dUhq1KSEFi/lJ1/61JHsOT1kye2+S93/mtfrS7L7SUrR0gBQo6ivdXqxtsia2r7/+WdU/j7fLZePyw1K+ej7JWyDpIDvSxqbfDknFZgWk/J0FTFZLk+5lxTN7VglbdDTZn9F9OX/Mdqndobj45fVOdPuqKXulaPU8Ur9zKQkunlv8QnykeM1g8fHLzm4EbiDVQpdPPvmkfPXVV87rEyZMkCeeeMLlPhqU0ZngWvK0bds2M1JKM1cWL17sDNwUKlRIfvzxR9m+fbu8/vrr8r///U+mTp3q8jiLFi2SPXv2mK9aRqVlUrdSKqX/zk8//SRnzpyR7Nmvv0k89NBDcvLkSZNFs379ehNw0lFa4eHhUqZMGalZs6YZsRWfXn/00UedgR0N5mgwat26dTJnzhwTMNHASXy6Zv13ly9fbp4LXYsGeMaPHy+7du2SGTNmSOXKlZNduwZldE36vGlgae/evfLwww+73E+fH32c3377zVz0vm+//bZkBlevxsjfYccktE5x57asWbNIzTrFZdtfhy1dG27P1SvRErb9iNSpV8a5TUfd1albWv7afK1UMaG/Nh0wt8dX746yZnt869bukaYNB0v7tu/IsKE/ydmzSZ/FR9q4ejVadoYdlZp1S7js21p1S8jW//i6TYvHxO28Lx+X0DpF4+2LLFKjTlHZ9lfyBwAp8eHbC6RugxISWqcYu8dN1CtRSRbscA2mz92+SuqVuPbZJ5uHpymLin8fPYml1x33QfqIvhoj+/8Ol4qhIS6v3Yqh+WT3tusnHm8kKipGYqLjJJdv0gfmWh61eeVRE/hB+omJjpV/9p6XQpUDnduyZM1irh//+1yyP7d22j7x9s0mFZoWSHRbXGycHNhwWvzz+8ivwzbJhKeWyo//Wyd71/yTZr8HYBepNpVJAyyDBg1y9nHRoIOWN/3555/melRUlAwfPlwWLFgg9epd6wGgmSvLli0zAYnGjRubGeBvvPGG8zE1c2blypUmMBM/uBEQECAff/yxeHh4SLly5aRt27byxx9/3HRWuGbJvPrqq2Yt0dHRJmPG0WNG17FmzRoTmNGsFaVZORrc0KyeHj16SKdOncy/++abbzqzaDSA891335nrepsGZfT3jB+g0mwiva8Gd1Tp0qXl3Xffdd5n1qxZJpOnefPm5jnQzJnatV37mzjo77llyxYzN10fV2mwq2LFiqYXTa1atZwBHA1WaZaQ0swd/dlhw4aJ3UWcuSQxMXESmMc19T0gT045sP+0ZevC7Ttz9qLExMRKYB7XM2p58uSW/ftOJvkzp06dl8A8uRPcP5ecjlf6pBk1TZtXloKFAuXwodMy5sPZ8tzTX8g3k3uLhwept+nhrPN167pv9XV8YN+pDPOY+G8izl6W2Jg4CQh0zUTT6wf3h//np3Xh3DDZteOEjPv2MXaNGwnxzSMnzrnud73u551LcmTzkgCf3OLp4ZnEfc5IuXwE4NLT+Ygo89r1C3DNRtPrxw6mLBN76rhN4h/kLRXiBXfiWzZnn+TwySahjShjSk+R566aQIqPv2vATK+fOXq97Cy+ozvOStjCY/Lwu9eONxK6dO6KXI2MkQ2/HJA6D5eQep1KysFNp+X3kVuk/eDqUrACpYiWYypThpVqRxxa/qMBEg0GaOaMfq+lOg67d++WS5cuSYsWLUwJjuOiQQXN7nAYO3ashIaGmsfT2z/77DNTuhOfBiE0KOOgJU0aUFEaFIn/+PF/duDAgbJp0yZZuHCh1KlTx2SplCpVytymJUsXLlwwpVHxf14DII71aTnQ/v37ZdWqVc5sGc2q0eCQ4zE0iyf+zztui/876u8Xn2bqaH8eDVRpcOnnn382gaOkhIWFmYCMIyijKlSoIP7+/uY2By1hcgRlEj5HydGA1blz51wuug2wu9ZtqkuTphWldJn8cmezSjL6k26ybeshk0UDIGM6efycfPzeQnnlrbaS3SvVzjMBSEW/TdouqxcelD5vNZDsXkmXJC79fa/Ua1402duRMVy5HC0LxmyXO58uJ97JZD/Jv5OYtXSp2t1FJLhYbgltX0yK1QiSbfOOpOt6AXeTqp9ktJxJ+6c4AizxadDDkR1SsKDrZBxHhopm2AwYMEBGjhxpsmo0sPDee+/J6tWrXe6vWSXxae8XzRBRzzzzjEt2jfZrcdBAkQZi9KLlUloupOVJGtjQ9WnwwpHhE58GPZRmtWipkjY1rlu3rvnas2dPl9/xnnvukXfeeSfRY+hjOyScsKRBlp07d5psIi1N6tWrl/m9tfwo4e+aUjd6jpKjpWbxM5bU4MGDTc8ad+IX4CMeHlnM1I/4zpy+KHlu0kASGVuAf06TwZKwcatmv+QJSnqCQFBQ7kSNgU+f1iCsaxZNfIUK5xH/gJxy6OCpRGVQSBv+ztet677V13FgMo19rXhM/Dd+/t6S1SOLnAl3PQur1xNmN6aUTmvSn+/RaaJzm57Z/2vDIfl56gaZt6ofGW8Z1PFzpyWf7/XyCaXXIy5fkMirUXLqQoxEx0QncZ8A87NIP7n9vMxrNyJBo1+97hd4455Os6eEyazJ2+XFkXdKkZJJZ0rs3HzSZN70GnxHqq4bN5fDN5spXdJpTPHp9YRZNCrixGU5/0+kzHrnL5cSQ/VJx0XS6cM6kisoh/n/ElgoQXZkQR85tjOC3QKkV2CmdevWZsqQBgG0qW18GvzQAIxmsGjZUlK0/Kl+/fomMOEQP9MkJbQ8SS83o8EQ7cui5Ve//PKLyXw5fvy4eHp6mmyT5Gg504svviiPPPKI6e2iWTQO+hjaL0Z/Xh/nVmizYw3q6EWbGWumjZYs6WPGV758eTl06JC5OLJmtB+P9rfR5/h26HPRr1+/JINm7kSbRJYpn1/Wr9nvHGetjcr0+v0dkx+1iowvW3ZP07h39apdJrNFacBxzerd8vAjSX+oq1KtqKxZtUs6Pd7IuW3Vyr/N9uScOH5WIs5ekqBkgj1IfdmyeUrZ8gVk/ep90rhpeee+Xbd6rzzQsXaGeUzczvtyiGxYc0Aa3Fna+b6s1+972PXvXErVqF1UJkzt6rLtnSFzpEixQHmka22CMhnYyr1bpU0l19H2LcrXlpV7t5jvr8ZEy/qDO6VZ2VrOsdv62VKvf/znj5asObPyzOYhxcoEyvb1xyW0YSGzzTTy3XBCmt93vd9bQhqQmfnddhnwXhMpXi7psdpKGwjrOO0ipShxSW8enlkluERuObz1jJSofW2inZY26fXKrV1PoquAAj7S8X3Xv52rp+yVK5Ex0rBraROU0cfMWzJ3olKos8cuMSo7o6CUKXMEZrS8yFFOE7/USGn2i2bDaMNf/WDcoEEDiYiIMMEYnSzUpUsX03tFS5vmzp1r+svoVCHtm6Lfp4W+fftKpUqVTKNe7e+iWTo68Un7v2g/mKNHj5oMn/vuu89k1qj777/fZMno5c4773TJyNGAyueff26CNhq80QCRlnBpJtAXX3yR6Dlx0PIvnUil5VU6Flt71migpmjRxAeOuk7N9NEAkU5q0pInDWRpsMuxxv9KgzDuGIhJysOP1ZHhr/0q5SrkNxOXfpy0Ri5fvipt2lUxt7/16q8SlDe3PNPnTmdjyv17rjUmuxodI/+cPC+7dhwXb5/sUqjItUDfpUtX5MjB6/Xux46cNffx9fOWfPkTjwtE2ujcpbG8/r8pUqFiIalUuYhM/napXL58Rdrdd63e+dVB30vevH7S54U25vojnRtK966fyMSv/5SGjSrI3N83yvath+W1IQ9e268Xo2T8p/OkWYsqJrvm0KHT8tHI36RwkTym9wzST8fH6slbr/0s5SoWMBOXfvhulURevmomKqmhr0yX4Ly+0rNvc2dz333/vm61QaW+bv/ecUx8zOs2T4oeE+nnoU415e3Bs6VMhRApXzG/TJu8zuyL1vdeC7IOf22WBOfNLd17N3K+Lx/Ye8q5f0+dvCC7d54Qb+/sUrBIgPjkzC7FS7mOx87hnc28JyfcjrQfl10q+NpBuyqep4BULVRawi+ek0NnTsjwdj2loH+wdPlmqLl93NLp8lyTB+Wd+56TCStmStOyNaVDjWbSdmx/52OM+uN7+abLa7LuYJis2b9dnm/6sOT0yiFfrZzF7kxnrTuUlc9HrJLi5QKlRLk8MnfaTom6HC0N77r2+Xz8sJUSEOwtHXpUcwZlpk/YYqYzBYXklLOnL5vtObw9TS8Zh8sXr8qaPw/KI714P7ZKtbsLyx9jwyRvidySt5SvbJ59SKKjYqR8k2vHNws+3i45A72k3qMlxTO7h+Qp4ppt6pXz2qFk/O3V7y0qcz/YKgXK+0vBSgFycFO47F9/WtoPYT8DN5LqRdkaZEmONs3V3jFaMqPZJloipBkhOnlJPf3007Jx40aTyaJnRjTAoUEHnZKUFjTDpGXLlmb60+zZs83llVdeMdOk/vnnH1O61KhRIzP2On6ASbNatCGxNvaNT4M0GmjSJsP6uNqfRYMrmkmkk0CSo8+DTkzSbBUN0GjgZebMmabfTUL6vGiGT+/evc3a9HH18ceMGZPKz457a9aqgpw9c1G+/HSxhJ+6KKXK5pP3P+nobAJ64liEeS4dTp08L092/NJ5fcrEVeZSLbSIjPnyWlPJnduOSZ/u1xo9q49HLjBfW99TRV558550/O0yt1Z3VZMz4Rfk04/nyulT56VsuQIydvxTkifoWmnS8WNnJGu8fVutejEZ/m4nGTt6jnz84e9SpGiQjBrTVUqVvlZemNUjq+zaeUxm/rJOzp+LNAf+9eqXkV69W5sR2kg/zVtXMq/bzz9ZJOGnLkjpsiEy6pPO11+3xyPMNJD4r9uuD493Xp/8zQpzqV6zqIz98okUPSbST9NW5Uxz9q8/XW7KyUqWzSvvfPygs5Tp5PHzLvv39D8XpPsj18uUfvh2rblUDS0sH35+PVsV1qtZpLz82e8T5/UPHnrefNVR109MfFPy+wVJkcDrjV/3nz5mgjAfPNRX+t7ZQQ6fPSlPfTdC5oVdL12fun6BBOfyl6F3dzfNgjcd3iWtx7wgJ8//92bR+G/qNC0q585GmWBLRHikyW7RTBi/wGujksNPXnJ57S78ZbdEX42Vj19f5vI47btWkvueuD5Va9UfB0TiROo2Sz6DFWmrdP18cvncVVk9da8pYQoqllvu/l9VZynT+VOREu8jVYpo9k3j7mVlw4wDsvSrXeJfwEda968kBcpdaw0BIGlZ4hzFgcANnLx8/cMx3F9e78ed31+KnmnpWpC6fDyvBwlPR37P02szeXI84vz+6MUvLF0LUleBnNemRKosPevy9NpI3KfXhkaoVcfdq28fbq5uyPV9Onrz9d6TcH99qn4qdhO76iXJ6LLWTdyvNTNgDiwAAAAAAIBFCMwAAAAAAABYhMAMAAAAAACARehsCQAAAACA3TEuO8MiYwYAAAAAAMAiBGYAAAAAAAAsQikTAAAAAAB2RylThkXGDAAAAAAAgEUIzAAAAAAAAFiEUiYAAAAAAOwuNs7qFSAZZMwAAAAAAABYhMAMAAAAAACARShlAgAAAADA7pjKlGGRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAAC7o5QpwyJjBgAAAAAAwCIEZgAAAAAAACxCYAYAAAAAAMAi9JgBAAAAAMDuYuOsXgGSQcYMAAAAAACARQjMAAAAAAAAWIRSJgAAAAAA7I5x2RkWGTMAAAAAAAAWITADAAAAAABgEUqZAAAAAACwO0qZMiwyZgAAAAAAACxCYAYAAAAAAMAilDIBAAAAAGB3sXFWrwDJIGMGAAAAAADAIgRmAAAAAAAALEJgBgAAAAAAwCL0mAEAAAAAwO4Yl51hkTEDAAAAAABgEQIzAAAAAAAAFqGUCQAAAAAAu6OUKcMiYwYAAAAAAMAiBGYAAAAAAAAsQikTAAAAAAB2Fxtn9QqQDDJmAAAAAAAALEJgBgAAAAAAwCKUMgEAAAAAYHdMZcqwyJgBAAAAAACwCIEZAAAAAAAAi1DKBAAAAACAzcXFMJUpoyJjBgAAAAAAwCIEZgAAAAAAACxCYAYAAAAAAMAi9JgBAAAAAMDuYukxk1GRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAAC7Y1x2hkXGDAAAAAAAgEWyxMXF0QEIAAAAAAAbi5n8uGR0Ho9OlMyIUiYAAAAAAGwujqlMGRalTAAAAAAAABYhYwYpMmF7L54pG3mywifO71ccG2zpWpC66ud/w/n9lL+f4+m1mY5lPnZ+P2T105auBalrSJ3xzu9XHR/C02sjdUOu788sPetauhakvrhPVzm/f3vdMzzFNvJyzXFWLwGZCIEZAAAAAADsjqlMGRalTAAAAAAAABYhMAMAAAAAAGARSpkAAAAAALC7mFirV4BkkDEDAAAAAABgEQIzAAAAAAAAFiEwAwAAAAAAYBF6zAAAAAAAYHNxsXFWLwHJIGMGAAAAAADAIgRmAAAAAAAALEIpEwAAAAAAdhdDKVNGRcYMAAAAAACARQjMAAAAAAAAWIRSJgAAAAAA7I6pTBkWGTMAAAAAAAAWITADAAAAAABgEUqZAAAAAACwuTimMmVYZMwAAAAAAABYhMAMAAAAAACARShlAgAAAADA7mJjrV4BkkHGDAAAAAAAgEUIzAAAAAAAAFsLDw+XTp06ia+vr/j7+0u3bt3kwoULN/yZJk2aSJYsWVwuzzzzjMt9Dh48KG3bthUfHx/JmzevDBw4UKKjo29pbZQyAQAAAAAAW+vUqZMcO3ZM5s+fL1evXpUnnnhCevToIZMnT77hz3Xv3l2GDh3qvK4BGIeYmBgTlAkJCZEVK1aYx3/88cclW7ZsMnz48BSvjcAMAAAAAAB2l4nHZYeFhcmcOXNk7dq1UrNmTbNtzJgx0qZNG3n//felQIECyf6sBmI08JKUefPmyfbt22XBggWSL18+qVatmrz55pvy0ksvyZAhQyR79uwpWh+lTAAAAAAAwLZWrlxpypccQRnVvHlzyZo1q6xevfqGPztp0iQJCgqSSpUqyaBBg+TSpUsuj1u5cmUTlHFo1aqVnDt3TrZt25bi9ZExAwAAAAAALBcVFWUu8Xl5eZnL7Th+/Ljp/xKfp6enBAYGmtuS8+ijj0rRokVNRs1ff/1lMmF27twp06dPdz5u/KCMcly/0eMmRMYMAAAAAAA2Fxcbl+EvI0aMED8/P5eLbkvOyy+/nKg5b8LLjh07/vNzpj1oNANGs2K0R83EiRPl559/lj179khqImMGAAAAAABYbtCgQdKvXz+XbTfKlunfv7907dr1ho9ZokQJ0yPm5MmTLtt1cpJOakquf0xS6tSpY77u3r1bSpYsaX52zZo1Lvc5ceKE+Xorj0tgBgAAAAAAWM7rFsuWgoODzeVm6tWrJ2fPnpX169dLaGio2bZw4UKJjY11BltSYtOmTeZr/vz5nY87bNgwE/RxlErp1CcdyV2hQoUUPy6lTAAAAAAAZIapTBn9kkbKly8vrVu3NqOvNcNl+fLl8txzz0nHjh2dE5mOHDki5cqVc2bAaLmSTljSYM7+/fvl119/NaOwGzVqJFWqVDH3admypQnAPPbYY7J582aZO3euvPrqq/Lss8/eUoCJwAwAAAAAALC1SZMmmcBLs2bNzJjsBg0ayGeffea8/erVq6axr2Pqko661jHYGnzRn9OyqQceeEBmzpzp/BkPDw/57bffzFfNnuncubMJ3gwdOvSW1kYpEwAAAAAAsLXAwECZPHlysrcXK1ZM4uKuZ+0ULlxYFi9efNPH1alNs2fPvq21EZgBAAAAAMDu0rBUCLeHUiYAAAAAAACLEJgBAAAAAACwCIEZAAAAAAAAi9BjBgAAAAAAm4uLpcdMRkXGDAAAAAAAgEUIzAAAAAAAAFiEUiYAAAAAAOwuJtbqFSAZZMwAAAAAAABYhMAMAAAAAACARShlAgAAAADA5pjKlHGRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAAC7i4mzegVIBhkzAAAAAAAAFiEwAwAAAAAAYBFbB2b+/PNPyZIli5w9e9Zc//rrr8Xf31/cxZAhQ6RatWpWLwMAAAAA4O5i4zL+JZOyRY+ZlStXSoMGDaR169Yya9as//w4devWNYGQcePGObfp9z179pSvvvpKunbt6tyu3+/Zs0eWLl0qqUEDSD///LO0b98+VR4PIhtmH5LVMw7KxbNXJG+xXNL8qTJSoIzfTZ+a7UuPy8xR26R07SC5f1BV5/ZlU/ZK2LITcv5UpGT1zCohJXNLo04lU/SYSF1//LxLfp8SJhHhkVKklL906hMqJcrnSfK+i3/bI8vn7pMj+yLM9WJlAuWB7lVc7h956ar8+NlfsnHZYblw7ooE588pze8vI3e2K8Wus8DqWYdkxfT9cuHMFclXPJe0ebqcFErB62zLkuMy7b0tUq5OsDzy6vWgdlxcnCyatEfWzzsikRejpUh5f7m7VznJUyBnGv8mSOjvBUdkx+yDcjniigQUziWhj5WWPCV9k3yi9i49Jqs/3+myLWu2LPLwl43N97HRsfLXT/vk6OZwuXDysmT38ZR8FQOkaocS4hPgxZOfzhb8/Lf8PmWHRIRflsIlA6Rz31Apmcz78p8zd8vyufvl8L5rJ86KlQ2UB7tXdbl/l8bfJ/mzDz9TTdo8Uj6Nfgsk1LBUNRnYorOEFikrBfyDpf24F+WXzUtu+EQ1Ll1DRj3YVyrmLy6HzpyQt37/Wr5Z5fr5vFfjB8zjhvgGyubDu6X3DyNl7YHt7AALhM07LFtnHbr2vlwkp9TtUkaCk3lf3rX4mCz7bIfLNo9sWeXxr6+9Lzv+5m78aZ/8veiYXLkYLXnL+Em9J8uIX4hPmv8ugDuzRcbMl19+Kb1795YlS5bI0aNH//Pj3HnnnSbLJr5FixZJ4cKFE23X602bNhV3o2+W0dHRYncaQFn41S654+Hi0nVkLROYmTp0kwnS3EjEycuy6JvdUqhC4syqwAI+0qJ7WXnyw7rSaXio+OX1lh/e2CiXIm78mEhdqxcelCmfbJR2XSvJkM9bSeGS/jJy4J9y7kxkkvffsemk1G1WVF76oKm8OraFBOb1kfcH/Cln/rnkvI8+3tY1x6THK3Vl+Dd3SYsHy8h3H62XjcuPsPvS2dalx2XuFzulySMl5OkP60hI8dzy7esb5MJNXrtnTlyWeRP+lqIVE792l/20X1b/dkju6VVeur9fW7Ll8JBvX98oV6/EpOFvgoQOrDopGyfvlkrti0nroTXFv0guWfTeXxJ5Lvl9m83bQ9qPrue83DuqnvO26CuxEr7/glRqV1Rav1lTGvSpKOePXZKlH2zhyU9nqxcekO/HbpR2XSrJG5+3Nu/L7w9YdNP35Zc/bCavfdJSAoP1fXmRhMd7X/5oenuXS7eX6kiWLCI1GxdOx98MOb28ZfORXfLslPdT9GQUy5NfZj07Uhb9vV6qDX9cPlz4g3zReZC0LF/HeZ8Ooc1l1AN95Y1ZX0iN4V1k8+FdMrfPhxKcO4AnPJ3tXXlC1kzaLdXuLyb3vlVTAovkknlvbzZBmhu9Lz88tr7z8tBH19+X1ZbfDkrY3CNS74kycvfQUPH08jCPGc3fXMDegZkLFy7IDz/8YLJa2rZta8qVbicws3PnTjl+/Lhz2+LFi+Xll192Cczs27dPDhw4YO6vDh06JB06dDBlUoGBgdKuXTvZv3+/8/5r166VFi1aSFBQkPj5+Unjxo1lw4YNztuLFStmvt53330mc8Zx3eHbb7812/RnO3bsKOfPn3feFhsbKyNGjJDixYuLt7e3VK1aVaZNm5aonOv333+X0NBQ8fLykmXLlondrf31oFRtUVCqNCsgQYVzSatnykk2Lw/Z8kfygbvYmDiZ+cE2adCxhPjn8050e4VGIVKsaqD4h3hLcJFc0vSJ0nLlUoycPHAhjX8bxDfvxx3SqG1JaXhXCSlYzE8e71dLsufwlKWz9yb5RD39aj1p2r60FCkdIPmL+soTA2uZAOX2DSec99m99bTc0bqYlKueT4Ly55Im95SSwqX8ZW/YaZ78dLZixgEJbVVIqjcvKHmL5JK7e5U3r92N84/c8LX708gt0uTRkhKQ4LWr+3rVrwelUYfiUq5uXhPouf+FinI+PEp2rPonHX4jOOycc0hKNskvJRrlF7+COaVW1zLi6ZVV9i4+lvyTlEXE29/r+sUvu/MmzZBp+lJVKVInr/jm95GgUn4S+nhpE6y5eCrpgADSxpypO6Xx3SWlUZtr78td+197X16SzPvyM6/Vl2b3lZaipQOkQFFf6fZibYmNjZPt66+/L/vn8Xa5bFx+WMpXzyd5C+RiN6ajOdtWymu/jpcZmxen6P7PNLxf9p0+KgN+Gi07ju+XsYunybSNi+SFZh2d9+nX7BH5fPkv8vXKWRJ2fL888/07culKpDxZ7+40/E2QlG2/H5IydxaQ0o3zi3+hnFL/ybLmfVkzY5KjxxU+/l7OS/z3ZfP5as5hqdK+qBStGWwCPY16lpfLZ6/IwfWn2AmAnQMzU6dOlXLlyknZsmWlc+fOMmHCBPOm8F/ccccdki1bNpMlo7Zv3y6XL1+Wbt26yenTp01ARuntOXLkkHr16snVq1elVatWkjt3blPWtHz5csmVK5cpq7py5Vq0WQMpXbp0MQGRVatWSenSpaVNmzbOAIsGbpSWSx07dsx5XWm51IwZM+S3334zFw0Uvf32287bNSgzceJEU3K1bds2eeGFF8zzoPeLT4NL+nNhYWFSpUoVsbOYq7FyfM95KVo10LktS9YsUqxKgBzZea2cJSnLp+4TH7/sUrV5gRT9G5vmHREvH0+TjYP0EX01RvbvPCMVQ/M5t2XNmkUqhOaT3dtTFkSJioqRmOg4yZn7+geJUpXyyMblR00Wjb5/hG08IScOnZdKtULS5PdA0qKvxsqx3eelRLzXru7fEtUC5dANXrt/TtkrOf2yS2jLgklm0mhJVIlq10skcuTMJgXL+MqhHdfKKJD2YqI1u+W8hFQMcHlfzlchQE7tPpfsz0VHxsgvL6yUX55fKUs+2CIRhy/e8N+5einaBHOy57RFpbb7vC//HS4VQ0NcXrf6Pr1726lbel/O5Xv9fTk+LY/avPKoCfwgY6tXopIs2HH9c6yau32V1CtR2XyfzcPTlEXFv4/+3dXrjvsg/d6XT++7IAUqub4v568UKCd3Jf++fDUyRqb2WSE/9F4hC0ZukTPx3pcv/BNpgjAF4r3XaxA9qGTuGz4m0k9cTFyGv2RWnnYoY9JAhNJgSEREhAlKNGnS5JYfK2fOnFK7dm2TZfLII4+Yr9q7RrNM6tevb65rZop+1aCMbv/uu+9M1soXX3xhIsiOAItmz+j9WrZsmajk6bPPPjO36zrvvvtuCQ4ONtt1W0iI64GgPrZmAWngRz322GPyxx9/yLBhwyQqKkqGDx8uCxYsMOtRJUqUMAGg8ePHm8wch6FDh5qsnczg0vmrEhcbZw7U4vPxzy6nj1xPk47v8Paz8tcfR+WJUbVv+Ni7156SX0dtlatRMZIrwEseHlJdfJL5IInUdz7iijmr6huYw2W7X0AOOX4wZX/wfxy/WfyDcrgcRGiPmq9HrpV+D/0qHh5ZzAeTrgNqSdmqeVP9d0DyLp27tn9zBbi+pnL5Z5dTyRyQH9h2xmTTPPNR3SRv16CM4zFcH9PLeRvSXpR5XxbJkeD9ModfdlN+lBTfEB+p81Q58S+cU65ejpGw2Ydk/psbpM2IWuKT4D1AxVyJkU1T90rRunklm7fbf7xxG+cjokzWmr4Px6fXjx28nuF7I1PHbRL/IG+pEO99Ob5lc/ZJDp9sEtqIMqaMLsQ3j5w4F+6yTa/7eeeSHNm8JMAnt3h6eCZxnzNSLp9rxjjS4305ziXjRXn7ZpOIo0n/zfUr4CMNepSTAPO+HG1608wasl7ue6e25MyTQy79W3ac6DH9spuADQCbZsxo2dGaNWtMEEV5enrKww8/bII1N3Pw4EGT2eK4aIBDaUDHUbakXx0BHg1yxN/uKGPavHmz7N692wROHI+l5UyRkZEm20WdOHFCunfvbjJltBzJ19fXlGDpGm5GS5gcQRmVP39+OXnypPle/91Lly6ZgEv830UzaBz/tkPNmjVv+m9poOfcuXMuF91md1GXo+W3j7ZJ657lbhpkKVI5wARvOo+oKcWrB8ov72+5ad8aZByzJm2XNQsPSu83G5ryGIcF03fJ3u2npe/whjL4s1bycM9q8t2H62Xbuutljch4oi5Fy/RRW+Xe5yokCsTC/QWV9pPiDUIkoGhuyVvOXxr2qSheubPJ7oWJU+y1EfDysdtF4sSUSMF9/DZpu+kd1uetBpI93vtyfEt/3yv1mhdN9nYA6SNvaT8p1TBE8hTLLSHlA6Tp85VMwH3nwv/e4xPANW59SkkDMNrItkCBAi7pkJrJ8vHHH9/wZ/VnNm3a5LyuwRSlARfNRjly5IgJwAwYMMAZmNEsFA14aE8ZRxaMBli0d8ukSZMS/RuOTBgtY9JSqI8++kiKFi1q1qcZLo5SpxvR0qr4NCtHs2gc/7bSSVQFC7qm8Ou/kTAb6Ga0LOqNN95w2TZ48GAzttud+OTOZjIeLiZoXKZR/JwJzpqrs8cvS8TJSPlp+F/ObY5yuHcfWCjdP64rAfmvdZLPnsNDsuf3kYD8IgXL+slnvVaYTJt6D3CWJz3k9stuUuTPhbv2j4g4Eym+gYn7AsWn00JmTQ6TgSPvNI0pHa5ERctPX/wlvd9sIFXrXXsv0dsP7j4rc37YIRVrUs6UXjQwqvs3YSaLNv7VDLWEwo9flrMnI2Xym5sSvXbfaLdAeo+r78y+0cfIHXj9MS6cjZKQEteD3khbGlDJklUSNfqNjLhismZSQqfhaZDm/MnLSQZltK9M05erkS2TznL7eUlWjyzmfTg+ve6XRGZTfLOnhMmsydvlxZF3SpGSSTd+3bn5pMm86TX4jlRdN9LG8XOnJZ/v9XJUpdcjLl+QyKtRcupCjETHRCdxnwDzs0jv9+UsiRr9Xj53Vbz9vFL8vpynaC45d+KyMzvdPEbEFZfpeHo9sCh/czOETDyOOqNz28CMBmQ0M2TkyJGmXCg+HTn9/fffm94zydHsmlKlEo/C1ZKl7NmzyyeffGKyXjToomrVqiX//POP6WHjKHlSNWrUMM2H8+bNazJhkqJ9Z/TxtK+M0sDOqVOnEgVgYmJubUJIhQoVTABGM2/ily39V4MGDZJ+/frdMMDjDnRsn46yPvBXuJSpcy04pqma+7eckdC7CiW6f56CPvLkh9enBailk/fIlcsx0qxbGfENSv6Dpabma78ZpA/PbB5SrGyAadxbo+G1famlL2HrT5hGksmZ/X2Y/Pbddun/bmMpXs71w6D2NdA6az1ojE8PNP5rvyr8N57Zskr+Urll71/hUr5eXuf+3bc5XGq3TVzCEFTIR3p97DoNYuG3uyXqcozc1aOsee16eGYxwZm9m09L/n8DMZGXouXI3+ekVhvKItKLh2dWCSyWW45vOyuFQq+/L5/YfkbKNE/cGygp+n/h7OELUqBKnkRBmfPHL0nTQdXMgQYseF8uEyjb1x+X0Hjvy/o+3fy+5LOXNCAz87vtMuC9JlK8XNJjtZU2ENZx2kVKMbHHHazcu1XaVHJ9X25Rvras3HttWtrVmGhZf3CnNCtbyzl2W0866vWP//zRkjVn5vflPMVzybFtZ0yjXsf78rGtZ6R8Ej3bkqKv9TOHLkqhatc+W+UKziHe/tnNY2pWjbpyKVpO7Tkv5VL4Xg9kVm4bmNFGuGfOnDGNebU8KL4HHnjAZNO89957t/y4Otmobt26MmbMGNMM2MPjWtqsBmvib3dksnTq1Mn8OzqJSfu4FCpUyExsmj59urz44ovmupYw6WQlLSfS8qCBAweafydhyZL2jtHH1mBIQMDNP4BoiZNm9GjDX82i0X442mNHA0EaJNJMnVuh/647BmKSUuveIjJr9HYJKekr+Uv7yrrfDppmZZWb5Te3a+mSnj1v/Fgp8czuIcFFXRv4euW8tn8d269ExsjKafukVK1gc5B3+fxV2TD7sJnsUrY+fUjSU8uHyskXI1aZD+olygfKvGl/S1RktDS461pTyM+HrzK9Ch7qUdVc1yyZGV9tMdOZgkJySsTpa2d1vLw9Tc8C75zZpGzVYJn66WbJnt1D8oTklJ2bTsqKuful47PV0vV3g0j99kXl5w+2ScFSvqZB78pfDprXX/V/m3Jr6VLuPF7SoktpyZbdQ/IleO3m+Lfpa/ztde8tIkt+2Cd5CviYqU0Lv9tjXv/l6l77IIr0UbZ1YVn1eZgEFs8teUrklp3zDkt0VKwUb3TtfXnl+DDxDvCSah2uvZa3ztgveUr6Su583uaDvfaYuXQqykx2cgRllo3ZJmcOXJBG/SqbA4rLZ6+V32bPlc0cdCB9tO5QVj4fscoEvkuUyyNzp+00ZcIN7ypubh8/bKUEBHtLhx7VnEGZ6RO2mOlM+r589t/35Rz/vi87XL54Vdb8eVAe6VWdXWnhuOxSwddPahXPU0CqFiot4RfPyaEzJ2R4u55S0D9Yunwz1Nw+bul0ea7Jg/LOfc/JhBUzpWnZmtKhRjNpO7a/8zFG/fG9fNPlNVl3MEzW7N8uzzd9WHJ65ZCvVs6y5HfMzCreVViWjd8heYrnluCSvrJtjr4vx5gpTWrJp9tN5kvNjiXN9U3T90lwKT/xDfGWqIvaY+agXDgVKWWaFHAG2Sq0LiSbZxwwfcI0ULNx2j4TrCkSGmTp7wpkdG4bmNHAS/PmzRMFZRyBmXfffVf++ut6acqt0HKmJUuWJGogrFkpOpHJ0V9G+fj4mPu+9NJLcv/995tJS1pW1KxZM2cGja61R48eJrumcOHCpp+No0TKQTN/NFvl888/Nz8ff9z2jbz55pumZErLkPbu3WsaCOu/87///U8ys/IN8plGosum7JWLZ6Ikb/Hc0uH1apLT/1rg6dw/kc5mzSmRNatI+OFLMmPRFrl87op4584mIaV8pdOwUDM6G+mnTtMicv5spAm2RIRHSpFS/tLv3SbOlPnTJy5K/F276JddZtrP2MHLXR6nXZeK0v6JaxMger5eX6Z9/peMH7ZKLp67Inny+cgDT1WWO+9NnFWHtFWpYYgpQ1w4aY9cOHOt3OixN2o4S5kizGv31h6zwQPFTGB25sdhEnkxWopU8JfOb1Q3gR2kH23KG3X+imyZvs+UMAUUySVNBlZxNom8dNp13165GC1rJuw099UpS5px0/y16mbUtrn/mSg5svFa6cOcV9e5/FtNB1WVfOXJsEgvdZoWlXNno0yw5dr7coDJhPH7t8Q0/OQlU6bosPCX3eZ9+ePXl7k8TvuuleS+f9+X1ao/Dpi+QXWbFU233wWuahYpL3/2+8R5/YOHnjdfddT1ExPflPx+QVIk8HrJ7/7Tx0wQ5oOH+krfOzvI4bMn5anvRsi8sNXO+0xdv0CCc/nL0Lu7m2bBmw7vktZjXpCT510bAiPtlaiXTyLPXzXBk2vlRrmk5UvX35cvno5y+byswZjlX+ww99WTmJpx03ZIDTNq26Hy3UVMcGfFlztNUD1vGT9p+VJVcyIUGUAMmf4ZVZY4cvWRAhO29+J5spEnK1z/kLXi2GBL14LUVT//9T5RU/5+jqfXZjqWud4/bcjqpy1dC1LXkDrjnd+vOu5evd1wY3VDru/PLD2TniAH9xX36Srn92+ve8bStSB1vVxznO2e0kv9XVuAZEQ+I+dJZkSeLwAAAAAAgEXctpQJAAAAAACkjPZjQ8ZExgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAADsLoZSpoyKjBkAAAAAAACLEJgBAAAAAACwCIEZAAAAAAAAi9BjBgAAAAAAm2NcdsZFxgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAABsLo5x2RkWGTMAAAAAAAAWITADAAAAAABgEUqZAAAAAACwOaYyZVxkzAAAAAAAAFiEwAwAAAAAAIBFKGUCAAAAAMDmYpnKlGGRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAACbYypTxkXGDAAAAAAAgEUIzAAAAAAAAFiEwAwAAAAAAIBF6DEDAAAAAIDNxcXGWr0EJIOMGQAAAAAAAIsQmAEAAAAAALAIpUwAAAAAANhcXEyc1UtAMsiYAQAAAAAAsAiBGQAAAAAAAItQygQAAAAAgM3FxVLKlFGRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAACbYypTxkXGDAAAAAAAgEUIzAAAAAAAAFiEwAwAAAAAAIBF6DEDAAAAAIDNMS474yJjBgAAAAAAwCIEZgAAAAAAACxCKRMAAAAAADYXGxtn9RKQDDJmAAAAAAAALEJgBgAAAAAAwCKUMgEAAAAAYHNxMZQyZVRkzAAAAAAAAFiEwAwAAAAAAIBFKGUCAAAAAMDm4pjKlGGRMQMAAAAAAGARAjMAAAAAAAAWoZQJAAAAAACbo5Qp4yJjBgAAAAAAwCIEZgAAAAAAACxCYAYAAAAAAMAiWeLi4uKs+scBAAAAAEDaO9ymZoZ/mgvNXieZERkzAAAAAAAAFiEwAwAAAAAAYBHGZSNFmv3UiWfKRv54YJLz+xeX97B0LUhd797xmfN7Xrf2fu2uODbY0rUgddXP/4bz+9Gbe/L02kifqp86v3973TOWrgWp7+Wa45zfZ+lZl6fYRuI+XSV2Excba/USkAwyZgAAAAAAACxCYAYAAAAAAMAilDIBAAAAAGBzcTEMZM6oyJgBAAAAAACwCIEZAAAAAAAAi1DKBAAAAACAzcXFUsqUUZExAwAAAAAAYBECMwAAAAAAwNbCw8OlU6dO4uvrK/7+/tKtWze5cOFCsvffv3+/ZMmSJcnLjz/+6LxfUrdPmTLlltZGKRMAAAAAADYXm8lLmTp16iTHjh2T+fPny9WrV+WJJ56QHj16yOTJk5O8f+HChc394/vss8/kvffek7vuustl+1dffSWtW7d2XtfAz60gMAMAAAAAAGwrLCxM5syZI2vXrpWaNWuabWPGjJE2bdrI+++/LwUKFEj0Mx4eHhISEuKy7eeff5YOHTpIrly5XLZrICbhfW8FpUwAAAAAAMC2Vq5caYInjqCMat68uWTNmlVWr16dosdYv369bNq0yZRAJfTss89KUFCQ1K5dWyZMmCBxcbeWnUTGDAAAAAAAsFxUVJS5xOfl5WUut+P48eOSN29el22enp4SGBhobkuJL7/8UsqXLy/169d32T506FBp2rSp+Pj4yLx586RXr16md02fPn1SvD4yZgAAAAAAsLm4mLgMfxkxYoT4+fm5XHRbcl5++eVkG/Q6Ljt27Ljt5+7y5cumF01S2TKvvfaa3HHHHVK9enV56aWX5MUXXzR9aG4FGTMAAAAAAMBygwYNkn79+rlsu1G2TP/+/aVr1643fMwSJUqY/i8nT5502R4dHW0mNaWkN8y0adPk0qVL8vjjj9/0vnXq1JE333zTZP6kNNOHwAwAAAAAALCc1y2WLQUHB5vLzdSrV0/Onj1r+sSEhoaabQsXLpTY2FgTSElJGdO9996bon9L+9AEBATc0u9BYAYAAAAAAJuLy8TjssuXL2/GWXfv3l3GjRtnxmU/99xz0rFjR+dEpiNHjkizZs1k4sSJpomvw+7du2XJkiUye/bsRI87c+ZMOXHihNStW1dy5MhhRnEPHz5cBgwYcEvrIzADAAAAAABsbdKkSSYYo8EXncb0wAMPyOjRo523a7Bm586dpmQpPp2yVKhQIWnZsmWix8yWLZuMHTtWXnjhBTOJqVSpUjJq1CgTALoVBGYAAAAAAICtBQYGmga+ySlWrFiSY641A0YvSdEsHL3cLgIzAAAAAADYnE49QsbEuGwAAAAAAACLEJgBAAAAAACwCKVMAAAAAADYXGaeypTRkTEDAAAAAABgEQIzAAAAAAAAFqGUCQAAAAAAm6OUKeMiYwYAAAAAAMAiBGYAAAAAAAAsQmAGAAAAAADAIvSYAQAAAADA5uJiGJedUZExAwAAAAAAYBECMwAAAAAAABahlAkAAAAAAJuLjaWUKaMiYwYAAAAAAMAiBGYAAAAAAAAsQikTAAAAAAA2Fxtr9QqQHDJmAAAAAAAALEJgBgAAAAAAwCKUMgEAAAAAYHOUMmVcZMwAAAAAAABYhMAMAAAAAACARQjMAAAAAAAAWIQeMwAAAAAA2Bw9ZjIuMmYAAAAAAAAsQmAGAAAAAADAIpQyAQAAAABgc7FxVq8AySFjBgAAAAAAwCIEZgAAAAAAACxCKRMAAAAAADbHVKaMi4wZAAAAAAAAi9gyMDNkyBCpVq1amv4bTZo0keeff955vVixYvLhhx+myb+1f/9+yZIli2zatClNHh8AAAAAALh5KZMGDm5k8ODBJmCSUXTt2lW++eabRNt37dolpUqVkoykcOHCcuzYMQkKCrJ6KW6lXYkW0qFMWwnM4Sd7Ig7KmE3fyM4ze5O9f85sPtKtYgdpUKCm5M6eS05eOiVj//pW1hzfbG739swhT1R4UBoUqCX+OXxl99n9Mnbztzd8TKSNvX8ckd1zDklUxBXxLZxLqnQqJQElfJO878Flx2XjhJ0u27J6ZpF7PmvkvL7hyx1yaPkJl/vkrRQg9fpVSaPfAMnhdWtvf/y8S36fEiYR4ZFSpJS/dOoTKiXK50nyvot/2yPL5+6TI/sizPViZQLlge5VXO4feemq/PjZX7Jx2WG5cO6KBOfPKc3vLyN3tstYf8czgy1zDsvGmQfl0tkrkqdoLmn0ZBnJVyrp9+X4di0/IfM+2ibFawZJmxdd33PDD1+UlZP2yNHtZyQ2Nk4CC+WU1v0rS+6gHGn4myApYfMOy9ZZh+RyxBUJKJJT6nYpI8Elk96/uxYfk2Wf7XDZ5pEtqzz+dWPn9bi4ONn40z75e9ExuXIxWvKW8ZN6T5YRvxAfdkA6aliqmgxs0VlCi5SVAv7B0n7ci/LL5iU3/JnGpWvIqAf7SsX8xeXQmRPy1u9fyzerZrncp1fjB8zjhvgGyubDu6X3DyNl7YHtafzbICUoZcoEgRkNHDj88MMP8vrrr8vOndcPhnLlyuXyZhwTEyOenta2uGndurV89dVXLtuCg4Mlo/Hw8JCQkBCrl+FWmhSqK89U6SQfbpwgO8L3yP2lW8s7DV6WrvMGyNmoc4nu75nFQ95t8LK57Y3Vo+XU5XDJ5xMkF65ect6nf43uUtyvkIxY96mcvnxGmhe5Q95tOEi6zXtRTkWeSeffMPM6suakbPthj1R5rIwElMgte+cfkZWjtkiz4bXEyzd7kj/j6e0hzYbXvuHjaiCmerdyLsEbpC9et/a2euFBmfLJRnm8X00TXJk/baeMHPinjPi2rfgGJD7Q3rHppNRtVlRKVQySbNk9ZPb3YfL+gD9l2Nd3SUDwtYM3fbywDSelxyt1JSgkp2xdd1y+/WC9+Ad5S/U7ClrwW2ZOu1ackGUTd0mT7mUlX2k/2TzrkMwctkke/bCu+Pgl/b6szp28LMu/3S35y/slui3i+CWZ/vp6qdC0gNTuUFyye3uYQI0e4CN97V15QtZM2i31nyxrgjHb5hySeW9vlvvfryPeyezfbN4e5vbkTuBu+e2ghM09Ig2eLie583rLhh/3mce8793a4pndI81/J1yT08tbNh/ZJRNWzJSfn3nnpk9LsTz5ZdazI2Xc0p+l01eDpVnZmvJF50FyLOKUzAtbbe7TIbS5jHqgrzzz/Tuyet82eb5pR5nb50MpO+Rh+ec8n5eB5KTaXzcNHDgufn5+5g3YcX3Hjh2SO3du+f333yU0NFS8vLxk2bJlEhsbKyNGjJDixYuLt7e3VK1aVaZNm+Z8zD///NM8zh9//CE1a9YUHx8fqV+/vkvAR7399tuSL18+829069ZNIiMjU7RmXUf8detFgyBq8eLFUrt2bXOf/Pnzy8svvyzR0dEpfj4OHjwo7dq1MwEpX19f6dChg5w4ce2MfEREhPl31q1bZ67r8xAYGCh169Z1/vx3331nMmWSKmVK6fPy1ltvSd68ec3z8tRTT5nfIa1LvDKKB0vfJbP3L5K5B5bIgfNH5MMNEyQqJkpaF71+tia+1sWaiG/2XPL6yg9k2+m/5cSlU/LXqR2yN+KguT171mzSqGAt+WzL97Ll1A45evGETAybLkcvnJB7SjRP598uc9s997AUbZRfijYMEd+COaXq46XFI3tWObD0+A1/LodfdpdLQlmzZXW5PXvObGn4WyApvG7tbd6PO6RR25LS8K4SUrCYnzzer5Zkz+EpS2cnnXX49Kv1pGn70lKkdIDkL+orTwysZU7sbN9wPbtt99bTckfrYlKuej4Jyp9LmtxTSgqX8pe9YafT8TfDpt8OScVmBaT8nQVMVosGaDyzZ5WwRUeTfXI0A2b+mO0m6OKX1zvR7aum7JWi1fNI/c6lJLh4bpNJUbxm8A0DPUgb234/JGXuLCClG+cX/0I5TYDG0yuryYxJjn5O9fH3cl7iB3DM63jOYanSvqgUrRksgUVySaOe5eXy2StycP0pdmM6mrNtpbz263iZsXlxiu7/TMP7Zd/pozLgp9Gy4/h+Gbt4mkzbuEheaNbReZ9+zR6Rz5f/Il+vnCVhx/ebAM2lK5HyZL270/A3Adxfup520MCABlHCwsKkSpUqJigzceJEGTdunGzbtk1eeOEF6dy5swmKxPfKK6/IyJEjTSBDs2yefPJJ521Tp041JVLDhw83t2sQ5ZNPPrmtdR45ckTatGkjtWrVks2bN8unn34qX375pQl0pIQGWjQoEx4ebn6X+fPny969e+Xhhx82t2vgSgMkGmBRW7ZsMX/ANm7cKBcuXDDb9OcaN046iJCS52XSpEkybNgweeedd2T9+vVSpEgR83tkBpr9Usa/uGw4udW5LU7izPUKeUon+TP1C9SQ7eG7pE/1rjKt7SfyRfO35dGy90pWuXaGxyOrh7lcibnq8nNRMVekUlCZNP6N4BAbHSsRB85LcIUA57YsWbOY62f2JM6EcoiJipF5A1fJ3P6rZPXorXLuyMVE9zm146z83neFLBi0RjZP/FuuXHDd10hbvG7tLfpqjOzfeUYqhuZzbsuaNYtUCM0nu7enLIgSFRUjMdFxkjP39QO8UpXyyMblR+XMP5fMwV7YxhNy4tB5qVSLLNP0EhMdK//sPS+FKge6vC/r9eN/J/++vHbaPvH2zWYyYhKKi42TAxtOi39+H/l12CaZ8NRS+fF/62Tvmn/S7PdA8vv39L4LUqCS69/d/JUC5eSu5Pfv1cgYmdpnhfzQe4UsGLlFzhy+/nf3wj+RJghToOL1x8zu4ylBJXPf8DFhvXolKsmCHWtdts3dvkrqlahsvs/m4WnKouLfR9+b9brjPrC+lCmjXzKrdA3MDB06VFq0aCElS5aUnDlzmmDKhAkTpFWrVlKiRAnT90UDM+PHj3f5OQ0waJCiQoUKJrizYsUKZ1aMNtzVLBm9lC1b1gRP9H4p8dtvv5mMFsfloYceMts1sKPZKh9//LGUK1dO2rdvL2+88YYJgmjQ5WY0k0WDLZMnTzYZQnXq1DEBKA22rF271tk82BGY0a/6vJQvX95kEjm23Swwc6PnZcyYMeY5eeKJJ6RMmTKmtKxy5czxhujnldsEUc5EXutL4HAm8pzpN5OU/DnzSqOCtcVDssqg5e/KdztmyEOl20in8veZ2y9HR5pMms7l20ueHP4mYNO88B0m0KPXkT6izl+VuFgRL1/XbBa9HhlxJcmfyRXiLdWeKCt1eleS0B7lzAeEpcM3yuXwKOd98lYKlBpPlZM7BlaRig+VkFM7I2TlB1vMwQHSB69bezsfccVkSPgGupYs+QXkkHPhl1P0GD+O3yz+QTmkYuj1oIv2qClQzFf6PfSrdG8+VUa9uFg6Px8qZavmTfXfAUmLPKfvy3Hi4++ayaLXtd9MUo7uOCthC4/JnU9fLx+N79K5K+bAfsMvB6RI1UC559VqUqJ2kPw+cosc2U4pRPr/3Y1LVLKkQbXLEdf/jsbnV8BHGvQoJ836VZbGvcrrkbnMGrJeLp6+9hnV8f8i0WP6ZTcBG2RcIb555MS5cJdtet3PO5fkyOYlQbn8xdPDM4n7nDE/CyCDBGa07MZh9+7dcunSJROQiB8c0QDGnj17XH5Os2scNCNGnTx50nzV7BsNfMRXr1495/dLly51eXzNJHG48847TXmQ4zJ69GjnY+pjxK+HveOOO0w2y+HDh2/6e+rPa2DHUYqkNHji7+9vblMaUNEgjPba0YCNBmocwZqjR4+a50ev38iNnhcta9JSrPgSXk8oKipKzp0753LRbZmBBlrORJ2TURu+kF1n98ufh1fJpJ2/yD3FmzrvM2Ltp5JFssjUtmNlzn3fyH2lWsmiQyskNo6D94wssJSfFLkjRPyK5JKgsv5S+9mK4pU7m+z/83qKfaE6eSV/9SDxLZRL8tcIkrp9K8nZfedNFg0yLl63mcesSdtlzcKD0vvNhpLN63r/iQXTd8ne7ael7/CGMvizVvJwz2ry3YfrZdu6G5c2wjpXLkfLgjHbTVDGO5m+YPLvOTAtXap2dxEJLpZbQtsXk2I1gmTbvCPpul7curyl/aRUwxDJUyy3hJQPkKbPV5Icvtll58LkS9sAILNL1+67miXj4CjZmTVrlhQs6NqgT/u6xJct2/Wz445gSUoyVxzBoPhjprUXTfz1WDWBqVGjRnL+/HnZsGGDLFmyxGQPaY8bLfXSXjsFChSQ0qWTLrtJjeclKVpapplBGXmaVkpERJ2XmNgYCUiQHROQw1fCE2TROJyOPCvRcTESK9eDLAfPHZU83gGmxEJvO3bxpPRb8pbk8PASn2zeEh55Vl6t3dtsR/rQgEqWrCJR5xKUlJ27mmTfmKRk9cxqgjQXTyZ/lj5nXm/JniubuU/8simkHV639pbbL7spXToX7toDLuJMpPgGJu4vEt/vU3bIrMlhMnDknVK45PUMxStR0fLTF39J7zcbSNV618ph9PaDu8/KnB92SMWalDOlhxy++r6cJVF2jF5PmEWjIk5clvP/RMqsd/5ybtNMRvVJx0XS6cM6kisoh2T1yCKBhVwn9AQU9JFjO5P+O460/LubxUxjiu/yuavi7ef6ef1Gf3d1Ute5E9f+7jr+X+hj+gRcfwy9Hlg0d6quH6nr+LnTks/3etmi0usRly9I5NUoOXUhRqJjopO4T4D5WQDJs6y1vWaQaABGm+RqcCT+JX6myc1o+c/q1de6gDusWrXK+b02FY7/2NoINyWPuXLlSucHBbV8+XLzs4UKFUrRzx86dMhcHLZv3y5nz551lllp9oxmvGi5lAZYtGRKgzXaZ0ZLrG5WxnQzWtblKJtySHg9oUGDBpnGxPEvus3daBDl77P7pHpwRec2zXSpHlxJtp/eleTPaJlSwZz5zP0cCuUOkVOXz5jHiy8yJsoEZXJl85Fa+SrLimPr0/C3QaKgStHc8k/Y9VR2TbHW6wHJjO1MSO9/7vBFyZHEAYODljlduXhVvGgymW543dqbZzYPKVY2wKVxr5Y2ha0/IaUqJJ/erpOYZn67Tfq/21iKl3P9oK/9ZrT/hQZr49MD+vh/v5G2PDyzSnCJ3HJ4q+v7sl4PKZP4fTmggI90fL+2PPxuLeeleGiQFKwYYL7XoIw+Zt6SueXM0euTEdXZY5cYlZ3OdF/kKZ5Ljm1z3b/Htp6RvKVT9ndXX+tnDl10BmRyBecQb//sLo955VK0nNpzPsWPCWus3LvVTGKKr0X52rJy7xbz/dWYaFl/cKc0K1vL5eSxXnfcB9ayun8MPWaSZ9m8ag1yDBgwwDT81SyPBg0amECABkB0ilGXLl1S9Dh9+/Y1vWk0M0bLjbRUSRsJa8+a/6pXr16md03v3r3lueeeM2VBmjnSr18/yZr15rGs5s2bm34unTp1Mo+j05z0MTXYEr+cS0uVtBfMgw8+aK7rZCYN6ui48bFjx8rt0LV3797d/Hs6sUkf86+//rrh86KBsoTZSu5q2q7f5aWaT8vfZ/bJjjN75IFSrSWHp5fMPXCtsfRLNZ8xQZcvt/1grv+6d4G0K9lSnq36mMzYM08K5gqRR8u2k+m75zofs2a+yiZwc+j8MSmYK5/0qPyoHDx/TObsX2LZ75kZlWpVSDZ8sUP8i+WWgOK5Zc/8IxITFStFGlw7O77+8x3iHZBdKjx47f/6zl/3S0AJX5MFc/VytOz+/ZBcOh0lRRpeK/+Ljowx98kfGmyybjRLZtuPe839tfcM0g+vW3tr+VA5+WLEKilWNlBKlA+UedP+lqjIaGlw17XX6ufDV5kx1w/1qGqua5bMjK+2mOlMOgo74vS1s+1e3p6SwyebeOfMJmWrBsvUTzdL9uwekickp+zcdFJWzN0vHZ/NHBMIM4pqdxeWP8aGSd4SuSVvKV/ZPPuQREfFSPkm1zKZFny8XXIGekm9R0uaUch5iuRy+XmvnNc+jsbfXv3eojL3g61SoLy/FKwUIAc3hcv+9ael/ZDq6fzboeJdhWXZ+B2Sp3juf8dlHzb7V6c0qSWfbjeZLzU7ljTXN03fJ8Gl/MQ3xFuiLkbL1lkH5cKpSCnz7/8HPVCv0LqQbJ5xQHxDfEygZqM2g/bPLkVCg3jC03lcdqng6yedi+cpIFULlZbwi+fk0JkTMrxdTynoHyxdvhlqbh+3dLo81+RBeee+58yI7aZla0qHGs2k7dj+zscY9cf38k2X12TdwTBZs3+7PN/0YcnplUO+WjmLfQtkxMCMevPNNyU4ONiU0OjUIs0iqVGjhvzvf/9L8WPopCPtSfPiiy+axrcPPPCA9OzZU+bOvX5Afau0tGr27NkycOBAU1akARNtpPvqq6+m6Of1D84vv/xigiOaBaPBnNatW5sgTHwaqNHATfxeMvq9ToK6WX+Zm9GgkD6nGvzS50XHdWsAa82aNZIZaI8YbSbatcKDpqRpT8QBeXnZO6aPjMrrk8fljOo/l8Pl5WVvS88qj8nnzUeYoM303XNkys6Zzvvk9PSRpyo9LEHegXL+ygVZenStTNg6VWISZNQgbRWsndc0I9wxY79ERVwR38K5pO4LlZ2lTJfDI13OoF+5GC2bvvnb3Debj6cJ6DT8XzUzalvpfSMOXZSDy0/I1UvRJpMmb8VAKXdfMfHIZllSYabE69be6jQtIufPRppgS0R4pBQp5S/93m0ifv82BD594qLEa+0mi37ZJdFXY2Xs4OUuj9OuS0Vp/8S1ZvY9X68v0z7/S8YPWyUXz12RPPl85IGnKsud91pTppxZla6fz5S2rJ6615QwBRXLLXf/r6ozQ+L8qUiXfZsSJWoHS+PuZWXDjAOy9Ktd4l/AR1r3ryQFytFwP72VqJdPIs9fNcGTa+VGuaTlS1WczXsvno5y6cuowZjlX+ww9/XKmc1k3LQdUsOM2naofHcRE9xZ8eVOky2Tt4yftHypqgncIf3ULFJe/ux3fZrtBw89b77qqOsnJr4p+f2CpEjg9bLQ/aePmSDMBw/1lb53dpDDZ0/KU9+NkHlh16sXpq5fIMG5/GXo3d1Nw99Nh3dJ6zEvyMnzrg2BAbjKEke+b6ahjZa1j8233357yz/b7KdOabImWOOPB643wX5xeQ92g428e8dnzu953dr7tbvi2GBL14LUVT//9R5vozf35Om1kT5VP3V+//a6ZyxdC1LfyzXHOb/P0rMuT7GNxH16vT2GXSwvmvQ0vIzkjgM7JDOyNGMGaUcnXo0bN86MIvfw8JDvv/9eFixYIPPnz+dpBwAAAAAggyAwY1OaUqrlWMOGDTOlTNoM+KeffjL9bwAAAAAAQMZAYMamdBqVZsgAAAAAAKBTkZAx0dkSAAAAAADAIgRmAAAAAAAALEIpEwAAAAAANkcpU8ZFxgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAABsjlKmjIuMGQAAAAAAAIsQmAEAAAAAALAIgRkAAAAAAACL0GMGAAAAAACbi4uLs3oJSAYZMwAAAAAAABYhMAMAAAAAAGARSpkAAAAAALA5xmVnXGTMAAAAAAAAWITADAAAAAAAgEUoZQIAAAAAwOYoZcq4yJgBAAAAAACwCIEZAAAAAAAAi1DKBAAAAACAzVHKlHGRMQMAAAAAAGARAjMAAAAAAAAWITADAAAAAABgEXrMAAAAAABgc/SYybjImAEAAAAAALAIgRkAAAAAAACLUMoEAAAAAIDNUcqUcZExAwAAAAAAYBECMwAAAAAAABahlAkAAAAAAJujlCnjImMGAAAAAADAIgRmAAAAAAAALEIpEwAAAAAANkcpU8ZFxgwAAAAAAIBFCMwAAAAAAABYhFImAAAAAABsLjbO6hUgOWTMAAAAAAAAWITADAAAAAAAgEUIzAAAAAAAAFiEHjMAAAAAANgc47IzLjJmAAAAAAAALEJgBgAAAAAAwCKUMgEAAAAAYHOUMmVcZMwAAAAAAABYhMAMAAAAAACARShlAgAAAADA5ihlyrjImAEAAAAAALAIgRkAAAAAAGBrw4YNk/r164uPj4/4+/un6Gfi4uLk9ddfl/z584u3t7c0b95cdu3a5XKf8PBw6dSpk/j6+prH7datm1y4cOGW1kZgBgAAAACATFDKlNEvaenKlSvy0EMPSc+ePVP8M++++66MHj1axo0bJ6tXr5acOXNKq1atJDIy0nkfDcps27ZN5s+fL7/99pssWbJEevTocUtro8cMAAAAAACwtTfeeMN8/frrr1OcLfPhhx/Kq6++Ku3atTPbJk6cKPny5ZMZM2ZIx44dJSwsTObMmSNr166VmjVrmvuMGTNG2rRpI++//74UKFAgRf9Wljj91wAAAAAAgG1NzlJWMroHIv+SqKgol21eXl7mklo0MPP888/L2bNnb3i/vXv3SsmSJWXjxo1SrVo15/bGjRub6x999JFMmDBB+vfvL2fOnHHeHh0dLTly5JAff/xR7rvvvhStiYwZQMS8+EeMGCGDBg1K1Rc9Mgb2r32xb+2LfWtv7F/7Yt/aF/vW/T0at1MyuiFDhjgzWxwGDx5stqe348ePm6+aIROfXnfcpl/z5s3rcrunp6cEBgY675MS9JgB/v1Do28ACaOzsAf2r32xb+2LfWtv7F/7Yt/aF/sW6WHQoEESERHhctFtyXn55ZclS5YsN7zs2LEjw+88MmYAAAAAAIDlvG6xbEnLiLp27XrD+5QoUeI/rSUkJMR8PXHihJnK5KDXHaVNep+TJ0+6/JyWMumkJsfPpwSBGQAAAAAA4HaCg4PNJS0UL17cBFf++OMPZyDm3LlzZjqTY7JTvXr1TK+a9evXS2hoqNm2cOFCiY2NlTp16qT436KUCQAAAAAA2NrBgwdl06ZN5mtMTIz5Xi8XLlxw3qdcuXLy888/m++1DEqbBL/11lvy66+/ypYtW+Txxx83k5bat29v7lO+fHlp3bq1dO/eXdasWSPLly+X5557zkxsSulEJkXGDPBvypw2laLxrz2xf+2LfWtf7Ft7Y//aF/vWvti3cHevv/66fPPNN87r1atXN18XLVokTZo0Md/v3LnT9LVxePHFF+XixYvSo0cPkxnToEEDMx5bpy45TJo0yQRjmjVrJlmzZpUHHnhARo8efUtrY1w2AAAAAACARShlAgAAAAAAsAiBGQAAAAAAAIsQmAEAAAAAALAIgRkAAAAAAACLEJgBAAAAcMt03OySJUvMpBIAwH/HVCYAgFuIi4uTLFmyWL0MAEA8OjI2LCxMihcvzvNiMzpKOKm/u7pN93upUqWka9eucuedd1qyPsBOyJhBptShQwc5c+aM1csAcAvuuOMO2b17N88ZAGQglSpVkr1791q9DKSB1q1bm32bM2dOE3zRS65cuWTPnj1Sq1YtOXbsmDRv3lx++eUXnn/gNnne7gMA7ujw4cNSsWJF+fzzz6Vt27ZWLwdpRFOr16xZIydPnpTY2FiX2x5//HGedzdTqFAhqVatmrzzzjvy7LPPWr0cpGFm1LRp02TRokVJvnanT5/Oc++mLl68KG+//bb88ccfSe5bDu7d01tvvSUDBgyQN998U0JDQ81BfHy+vr6WrQ2359SpU9K/f3957bXXEu3zAwcOyLx582Tw4MFm37dr146nG7gNlDIh037wf//9980fk0cffVQ+/PBDcwYA9jFz5kzp1KmTXLhwwXwojJ+Kq9+Hh4dbuj78Nz/++KM899xzUqVKFfnqq69MsAb20rdvXxk/frw5M5svX75EafS63+GeHnnkEVm8eLE89thjkj9//kT7Vvc93E/WrNcT8OPvU0f5qfahgXvy8/OT9evXm5Kl+DR7VYNwERERsmPHDpM9c/78ecvWCdgBgRlkavrH5IknnpDjx49L7969xdPTNYmsT58+lq0Nt6dMmTLSpk0bGT58uPj4+PB02sg///xjMmbmz59vDvASvm5HjRpl2dpw+wIDA+W7774zr1/Yi7+/v8yaNcuUJcI+NNh2I40bN063tSB1aXD8vffeS5RlPHHiRBk4cKCcOHFCtm/fbvax/m0G8N9RyoRMrVy5ctKtWzd55pln5IMPPnA5wNOzPARm3NeRI0fM/iMoY88D9/Lly8vPP/8sGzduTPS6hfufoS1RooTVy0AaCAgIMK9f2AuBF/vSk5b6GVmzZjQrRq1du1a++OIL+d///meuz50715QZA7g9ZMwg09Io/1NPPSXLli0zpUxdunSxeklIRffff7907NjRNHqGfWzbts2cudNStAkTJjAJwoa++eYbmTNnjtm/3t7eVi8HqUgzobRJqO5jgub2snTpUlOCqH2CtOS0YMGC8u2335pJTQ0aNLB6ebgNkyZNko8//lh27txprpctW9YEbLQVgLp8+bJzShOA/47ADDKlKVOmmD4VVatWNf0KihQpYvWSkAp+/fVX5/eaUjt06FBTqla5cmXJli2by33vvfdennM3o01DhwwZYj4MfvTRR5I7d26rl4Q0oB/y77vvPlm+fLkUK1Ys0Wt3w4YNPO9uPHpXp7lo7xH2rX389NNPpqxU+7ppMEZLWzTrTQ/mZ8+ebS4AgBsjMINMSScG6EGeRvxhzwaEN0IzQvekzUI/++wzueeee6xeCtKQZrnpRKYHH3wwyea/2rQd7umNN9644e3sW/cNuL3wwgsmm1ED5ps3bzaBGS01veuuu0wfP7i3K1euJDlJjRObQOohMINMadeuXeYD/+rVq80fm9q1a0twcLDVywJwA6dPnzZTH7Tpr75uta9BpUqVeM5sGDjXngWUPwDuQcvSNEtGs6DiB2a0rKlChQoSGRlp9RJxG5+Xn3zySVmxYoXLdiZuAamP5r/IlC5evGga/zrO4ugHialTp0qrVq2sXhqAZPz1118mW+bSpUvmujb91T4knTt35jmzkcKFC5sR97AvbSQaFhZmvq9YsaLJuID7CgkJMeOTNTATn/bwo5G3e+vatav5W/vbb78lOeIeQOohYwaZkgZgLly4IO+//75pVvbmm2/Kli1bzJkB2INOZCpVqlSiyVpa864fILXhM9yLZlAEBQXJp59+al63r776qpnMdPToUauXhlSk45THjBkj48aNS3SgB/empRDalP3PP/80o7PV2bNnTRNv7f1G5qp7GjFihGnsrIHyFi1amJ4yBw4cMOVNr732GmXjbp7BqIFUPZkJIG0RmEGmpAd38+bNkxo1ajg/GOoIT/3KmVp70IkQ2gw4NDQ0UeNQbfx7+PBhy9aG/0YP5DSdWlPjlWbO6OtVJ6zlyZOHp9VGI5V130ZHR5sSiYTNf3UiF9zTww8/bMpbJk6caEbeKy2B0amIGkj//vvvrV4i/gMtaxk+fLgJ0DgyGr28vGTAgAHmxBfcl47I/uCDDygtBdIBgRlk2iaxWsaUN29e5zYtZ9JSCR3tCPenGRVbt241H/bj02wZ7UtCzbt9XreOfgawBx2lfCN6EA/35OfnJwsWLDAHe/GtWbNGWrZsaU6OwH1p7y/9G6sZyRpAz5Url9VLwm1auHChyU7VwFtSEy45mQmkHnrMINPSs3TxJwXoGR+tedfmog5VqlSxaHW4XRqQmTNnjhmLHt/vv//OQbwb06awenDnoBMi/vjjDxOEc2AUunsj8GJf+npNeGCndFvCaS9wP9mzZ3dmNMIemjdvbr42a9bMZTvNf4HUR8YMMu2Zd21gpn9YEnJsZ6Sye9Nadw3KDBw4UJo2bWq26QH8yJEjTX+Z7t27W71EpME4dF637u/gwYM3vJ3xrO6rXbt2JitGS5YKFChgth05ckQ6depkSti0ZxTcc6DC22+/bf7GJjVSWcvX4J4WL158w9t1OiKA1EFgBpmSNqVLiaJFi6b5WpB2tEnssGHDnM1htZHokCFD5PHHH+dpBzJ44Dw5MTEx6boepJ5Dhw6ZjLZt27aZ6VuObVpeqj3BChUqxNPthh555BFzAP/YY48lObmnb9++lq0NANwFgRkAtvfPP/+It7c39e6AG9CeQfFdvXpVNm7cKKNGjTKB1vvvv9+yteH2aUaq9pnZsWOHua5NgB3lEnDfxuw6Te2OO+6weilIBdpvUYOlGiTX72+Ekn8g9RCYQaZ06tQpk3obPyNGz+Dp+Gzd3r59e3n00UctXSNun0510bGse/bsMftTG8Vq9ow2q6Mpofv5+++/TRlE7dq1nds0df6tt95yvm7/97//WbpGpB098HvvvffMaxpAxqFDE3REtmPSFuzTaP9mpf9kMAKph+a/yJR69+5t6tu134jSmuiGDRuabSVLlpSuXbuaPzaalgv3LVdr3bq16VcRFRUlLVq0MIGZd955x1wfN26c1UvELXrppZfMVAhHYGbfvn1yzz33mNeunrXTUa06Xvn555/nubWhsmXLytq1a61eBm7R6NGjpUePHmZSnn5/I3369OH5dUM6Evv11183E9X0PRjuTf+2BgcHO78HkD7ImEGmPbvz9ddfO5uWaaaMHqhrarWnp6e5Pm3aNFm1apXVS8V/pNkTGoj58ssvJU+ePM6Rynq2XRv/7tq1i+fWzWhPiqlTp0q9evXMdc2U0dfppk2bzHXd12PGjHFeh3s6d+6cy3U9U3vs2DHTH0rfo9m/7vf3dt26deZ9WL9Pjp59p0ms+6hevbpLLxkdk62vVe3llnDy1oYNGyxYIQC4FzJmkClpiqZ+eHBYuHCh6VugQRmlzQn17Dvc19KlS2XFihVmfGd8ut91CgjcswQxfnPQRYsWmYwZhyZNmkj//v0tWh1Ss19FwuahesCngbkpU6bwRLuZ+GfcOftur5MfsD+dgqd/W/VEpn7VrHIAaYPADDIl7TGivSocPWbWrFkj3bp1c96uBwVa7gL3peM6k6p9Pnz4sMmkgfsJDAw0mRN6gK77V8/C9+vXz3n7lStXkqyDh3vRgFt82uNA0+pLlSrlDJ7DHvQ9esuWLeZvsY7LhvsYPHiw1UtAOhg+fLgsWbLElIFrtnHBggVNkMYRqCldujT7AUglWVPrgQB3UrduXVPrrgd3Wgpx/vx5adq0qUuTUccoT7inli1byocffugSbLtw4YL5MNmmTRtL14b/Rj8Eai8DHa+r+1Zfv7rNYfv27S6ZcHBP+lrV6S6OD//aQ6hcuXLmNj1AgPvS/k9acugIyjRq1Ehq1Khh/t7S1Nl9aZnw6dOnE23XE2B6G9xX586d5bPPPjOfizXbWBuwq169ejnflwGkDnrMIFPS8X/NmjUzvQx0co9OctEDPgdt+pszZ04axLohDw8Pk1Wh2ROtWrUyGRTaT6ZmzZrma1BQkDm402kDcC/79+83TZx1ypbuZw2u9uzZ0yW1XntYfPDBB5auE6nzGk74GtUDP93GFBD3paWIM2bMMO/H+vXZZ581GVLffvutKSlevny51UvEbU7xie/EiRMm6KZ/j+G+Ll26JMuWLTPBU329bty40Uzg0hMj/L0FUg+BGWTqfhX6ITAkJETq1KmTaCxrhQoVbtioEBn/A6IG3bQnhQbiNFtGz8x26tRJvL29rV4m/iPdpzraXktbdIpafNrgWQ/8tMko3Ps1rAd0jqkgDnrGVg/oEzYHhvvQyUzaJFZfpzqpSSf4aPab9p6pWrUq+9bN/Prrr86guE5k8vPzc96mAdQ//vhD5s+fLzt37rRwlbgd9evXdwnEaBajZrpRegikPoq1kWlp5kS7du1ceo/ogZ4eFLRt29bStSF1aD8KTcOFvfapHsA5aHBVD9a9vLxctsP9aAN2RylT165dzT6Nf5CnAVY9SID7ypcvnyk5zJ8/v8yZM0c+/fRT5xl5zZSCezYA1tdsly5dXG7TyUxaWjpy5EiLVofUoJPwNINcy5b0ogEagjJA2iAwA/xLM2R0DCv10O7viy++kFy5ct3wPn369Em39SDt3HXXXbxubcJxtl3LD7VBd/zMNp2upr3BtPkk3NcTTzwhHTp0MIEZPZhv3ry52b569Wr6Vbgh7fOlNLt47dq15oQX7EVLSLVBt5YxzZ07V1555RXzfqyZM3feeSfvyUAqopQJ+JceCGgpBIEZ96YZT5omf6Ozr3pAsHfv3nRdF9IGr1v7eeONN2TAgAHmLC3s56effpKDBw/KQw89ZN6rlZbB6Jj0+FmsADIWDZqvX79ePv74Y5k0aVKy0y8B/DcEZoB/cYBn7yaEsCdet4B7uHr1qrRu3do01WfErv1cvHhRFi9ebIJuCZv9kqHqvjZs2GCyZfSiDYB1imnlypWd/WYIpgKph1Im4F86mSkwMJDnw81pNgwyj/Hjx5u+FbAPbfyrGTPaOPTkyZPmLG18nKF1T9pzRPsEwX60OWybNm1MryAN0OhnKR2woM2d9SQJgRn3Vbt2balevboJwmgpqTb+jd/kGUDqIWMGSPCBX2tpixYtSnMzG2XMxG/sDCDj9w3Ss+7PPfecsxdJfJyhdV8vvPCCaer89ttvW70UpCLNnihTpozJhtKDdi0L10CcNt/v27evs7E33I9OwfP19bV6GUCmQMYMMrXnn3/epGR269bNBGX0jMCKFSvMWZ7ffvvNfNiAexk8eHCixr80draXyMhIGTNmjCxatMhkVDgaUMZPvYb70nT5pUuXSrVq1axeCtJg3P2ECRNkwYIFEhoamqiP0KhRo3jO3ZAOTtDsRT35of3doqKiTL++d99910xrIjDjvhxBGe0tExYW5vxMVaNGDYtXBtgPgRlkatOmTXOOU545c6ZpCKujAb/99lvTeV5H8cL9AjMJJSyFgHvTQOq8efPkwQcfNGnWlK/ZS+HChXnN2tTWrVudB3R///23y228jt2XZsc4MlI1W1Uz3nSssmbPHDp0yOrl4TboyY+HH37Y9A/SBt3q7NmzZiLTlClTJDg4mOcXSCUEZpCpaQ10SEiI+X727NlmjKem4z755JPy0UcfWb08AEnQbDZ9vd5xxx08Pzb04Ycfyssvv2zOwBcrVszq5SAVaZYb7Ed7kOi4bG3qrJnHr7/+uvl8pSe5KlWqZPXycBt69+4tFy5ckG3btplgm9q+fbvJhNLeQd9//z3PL5BKaLiATE2bhuofGC1jmjNnjrRo0cJs1wZ2Nxq3DPdCY2d7KViwoJnGBHvSs7M6AaRkyZJmP2sj0fgXuL/du3fL3Llz5fLly+Y6WY3ubfjw4aYflBo2bJjp0dezZ0/5559/5LPPPrN6ebgN+tn4k08+cQZlHKVMY8eOld9//53nFkhFZMwgU3viiSdMloyjwWTz5s3N9tWrV0u5cuWsXh5SyaBBg0zwTevgaezs/kaOHCkvvfSSaTSp+xP2y5iBPZ0+fdr8zdXMGf2bu2vXLtOLRMsT9WBeX9twPzVr1nR+r6VMejAPe9AeblqqlpBuS9jfDcDtYSoTMj3tM6M10A899JAUKlTIPB/ffPONqaVl+of7orGzfelZWD24W7JkiWnUnfBDY3h4uGVrA5C8xx9/3PSs+OKLL8wZeJ3eo4EZzZ7p16+fKZeA+zZ21ky3PXv2yKOPPmqy3Y4ePWqaxyZsyA/3oZ+DtaeMlizpdEt15MgR6dSpkwmm/vzzz1YvEbANAjNAAvoHyNHgDO5Lg2wzZswwZ/L0a69evcyHRq15X7hwIY2d3ZhmtmlzST3LruWICZuGau073Jse3H311Vfmq/b70rPwmjZfpEgRqVixotXLw3+kPd00CFO1alVz4O4IzGjj/SpVqpheFnA/Bw4ckNatW5v3ZZ3IpI2ddb/qqGy9rtmNcE964vLee+81QVNtzO7Ypr2Dfv31V+cJTQC3j1ImZGrvvPOOaS6pPQ2UnoX/6aefTGmTNhfVD4pwTzR2ti8dab9y5UpzcAf70ekfd911l2nurFlR2rNCAzN6EP/ll1+aLEe4p4sXL5ost4Q0y83Ly8uSNeH2aQBGT4LoazRPnjzO7ffdd590796dp9iNaTBmw4YNZsS9Ti1Vmu3mKP0HkHpo/otMTc/iOM4AzJ8/31z0rKye+RkwYIDVy8NtoLGzfWn/J0fTUNiPTmR66623zPtx9uzZndubNm0qq1atsnRtuD0NGzaUiRMnOq9rtpv2qXj33XfN+F24p6VLl8qrr77q8npVeuJLy17g3vR1qsMxdEKTXoxSqxEAABxYSURBVAjKAGmDjBlkasePH3cGZnQEr2bMtGzZ0nyYqFOnjtXLw22gsbN9vf3229K/f3+TSVG5cuVEPWa0pwHc15YtW2Ty5MmJtmvWjGbCwX1pAKZZs2aybt06uXLlirz44oumREIzZpYvX2718vAfaXBNG+wndPjwYSbouaHRo0en+L46MhtA6iAwg0xNG5dprawGZ3SKgJ6ldYzuTOpDBtzHkCFDTA20o7GzI01ex6DrGXm4L81oU3qAF5++bvXMHq9d96Y9vo4dOybFixd32b5x40YzKh3uS9+Ttf/Ixx9/bA7YtafM/fffL88++6xz3DLcj57Q0mlqjtHY+j6s+3bw4MHSpk0bq5eHW/TBBx+k6H66nwnMAKmH5r/I1J577jmTKVO6dGnzoX///v1mesCUKVPMmT2tq4V90NjZPj1IbqRx48bpthakPi0jXb16tfz4449SpkwZ8z584sQJM9FHL3qwByDj0MyYVq1ameC4jkDXfjP6NSgoyPSJ0mw3AMCNEZhBpnb16lUz8UOzKrp27SrVq1d3ni3Qs3lPPfWU1UvEf0RjZ8A9aYmLZlB8/fXXJvvJ09PTfNURvLpNs97gnkqVKiWdO3c2o3b1hAjsNS5bT2r99ddfJlumRo0aZj97e3tbvTQAcAsEZgDYkpZBTJo0SerXr2+aiGr/oB9++EGmTp1qRnrOmzfP6iXiP9IzsDfSqFEjnlsb0Nfp1q1bzUGeBs05kHd/etJD+wetX79eQkNDTZBGpyLqGG24H81O1JLSJk2aSL169RL1+4J76tevX4rvO2rUqDRdC5CZEJhBprdnzx5TGx0WFmaeiwoVKsjzzz8vJUqUyPTPjTvTs3Tay0D7B+koz8jISBk/frzZpo2dz5w5Y/US8R9lzZo1yVp3B3rMABmbvg9r4Pz777+Xffv2mYlMGqTRUjW4D8001tLSAwcOmL+5GpzRfanBmlq1apHd5qZSOiFN/+4uXLgwzdcDZBYEZpCpzZ07V+69916pVq2a3HHHHWabTobYvHmzzJw504wHhHsqUKCATJs2zWTMlC1b1jR21ibAO3fuNB8Yz507Z/US8R9FREQkKknUHlGvvfaamdSUsCkw3Iv2qdDX7qJFi+TkyZNm4kt806dPt2xtSH06Ar1nz56mBIagqnvS/nx6gK5Bmj///NOUh2u/Pv1cpWPuBw4caPUSASDDIzCDTE3T47VhnY7fjU+n9mipC81/3ReNnTMfPSjQFGwtk4D70gw3zW7Ts7b58uVzyYZSX331lWVrQ+pZs2aNKWvSElMNlN9zzz2mRwnc3969e2XChAkyZswYU4pIwM0+TZ5VoUKFrF4KYEuMy0ampuVL2nMkoSeffNKUN8G9exkUK1bMnLnTCVt69k7pGN5evXpZvTykAT2I14wouLdvv/3WZMUwZtf+JUyaTaGN2nVktuM9Gu5Jy5k0W8Zx0Wy3unXrMiXPzWnGomYcjxw50gTZlA7H6N+/v7zyyitJlhYD+G8IzCBTCw4Olk2bNiVqKqnbGO/o3rQJoY7dTeiFF16wZD1IPVrykLD0RQNumvmmZYlwb35+fvT4sqly5cqZUlKdutWxY0cTTIX7mjhxojMQc+rUKVM6rA2Bu3fvbvYzzYDdnwZfvvzyS/P31VHyv2zZMhkyZIjp3aflwwBSB6VMyNSGDh1qMiu0dEk/UDh6zOgZPC2J0J4VcF80drYnPUOn5S0akIlPz85q+rwe/MF9ffPNNzJnzhyzLxm1ay+7du1iupbN3ouLFCliPkN169aNQIxN+/WNGzfO9GOM75dffjHZx0eOHLFsbYDdEJhBpqYHdlqypCmaR48edf4R0kZ1ffr0SdTbAO6Dxs72TplPeHCg2W85cuSwbE1IPZcvX5b77rvPBMm1HDHhWXd6f7m3s2fPmubOGjjXv7WBgYFmn2r2TMGCBa1eHm6BHrBrtoz299LsiQYNGpjR2Zo1o+PQ+Qzl/vTvqmaplilTxmW7lg1rhqq+XwNIHQRmkGlFR0ebxoPa/Fc/EJ4/f95ZOwv3R2Nne6fPP/zww+Ll5eWy/cqVK6Z5KCN33VuHDh3MRKYHH3wwyea/gwcPtmxtuD16gKdT0/z9/c0kHz24K1GihLz66qty8OBB89qGe9q+fbtzKpNeoqKiTOmLNvFOqqwY7qFOnTrmMnr0aJftvXv3lrVr15qpagBSB4EZZGo+Pj6mAXDRokWtXgrS4CzPli1bEqXNa/PJKlWqmLN7cE8eHh6mp0zCPlCnT58225gA4t5y5sxpMt707DvsRYMymkmhDdn1JMjmzZtNYGbFihXy6KOPmmAN3J9mIH/yySdMZbIBDba1bdvWlKzVq1fPbFu5cqUZrDB79mxp2LCh1UsEbIPmv8jUateuLRs3biQwY0M0drZ3CWJSKfI6ylMbx8K9FS5cWHx9fa1eBtLAunXr5LPPPku0XUuYjh8/znPupnQCk2a5ObJl9ASIliBq3y/NmIH70rI03Z9jx46VHTt2mG06RU37y2jpP4DUQ2AGmZr+YdGRf3pAp2fx9ExtfJpZAfekUyF69Oghe/fuTbKxM9yzPE0DMnrRM++entf/hGmWjI7fbd26taVrxO3Tnl8vvvii6V+hPWZgH1p+eO7cuUTb9cBPg+lwv89QGojRkjR9P9aTXVqCqMEY/btL3y/3pZ+dihcvbv7eagCG6UtA2qOUCZmaNg1NyDHtRb9SEuG+aOxsP2+88YbzqwZUc+XK5bwte/bs5iD+gQceMN/DfQUEBMilS5dMHzAtN03Y/Dc8PNyyteH2PPXUU6bkcOrUqabpr/ac0dLE9u3bS6NGjUwzfrgPLW3RIIxetJ+Mvl5hz5Jh7eumfWYYcQ+kHQIzyNQSTndJiN4z7onGzvYfp6wfEjkba9/9eyNdunRJt7UgdUVERJiMCi1p0ob7eiZeS5i05OX3339PlLUK9/P222/LM888Yxo8w71PXOpr0xGYid8TCkDaIDADwJZo7Gx/OoVJexvExsa6bNcmhQAyrmXLlplsmQsXLkiNGjWkefPmVi8JqUT7Q23atIkDeDdHYAZIf/SYQaa0fv16M77xl19+SdRkUs/oaVq1plRXrVrVsjXi9tDY2b527dolTz75pJnkEh8liPahZaQzZswwU/NUxYoV5d577zXp9XB/OnEr/tStDRs2yOuvvy6//fabpevC7dP3Ybg/Rz+3hNsApB0CM8i0zSWbNm2a5OQPnerSokULee+99+S7776zZH24fTR2tq+uXbuaRpN6EJc/f34+LNrM7t27pU2bNnLkyBEpW7as2TZixAgzrWnWrFlSsmRJq5eI/0BHoM+fP9/0gNJeM1oSoVNeXn75ZZk5c6a0atWK5xXIQAE2/VurDbtVZGSkKVFLWG44ffp0i1YI2A+lTMiU9IP9zz//nOzUpS1btki7du1MV3q4Jxo725d+MNSst3Llylm9FKQBDcroQcGkSZNMg1ilDWM7d+5sXtcanIF7+fLLL82kPN2fZ86ckTx58sioUaOkd+/epl9U3759pXz58lYvE6ng0KFDpncQ2W3u7YknnkjR/b766qs0XwuQWRCYQaakTUM1RV5HASZFx+5WqFBBLl++nO5rQ+qgsbN91apVSz744AOXUgjYK/C2atUqqVy5sst2bTypk1+0Lwnci54Eeeyxx2TgwIHy008/yUMPPWQa/up0pkKFClm9PAAALEcpEzKl4OBg2blzZ7KBGU2vDgoKSvd1IfUwUcu+3nnnHXnxxRdl+PDh5uA94TjlpEoU4T40dV4n9iSkARlGobunPXv2mGCMuv/++00popYLE5Rx77H2Ke05woh7e/j+++9Nry+mpwFpg4wZZNoUTe1jsHTp0kS3aQp9w4YNpXTp0qRouiEaO2eeMrWEBwU0/7WHxx9/3DSD1fIXbeKtVq9ebUphQkND5euvv7Z6ibhFTHjJfGPt42PEvT0wcQtIW2TMIFN69dVXzQf8OnXqSP/+/Z0NJjVTRhsD//3333z4d1M0dra/RYsWWb0EpKHRo0ebA7l69eo5s6Gio6PNmdqPPvqI595NffHFF5IrVy7n/tQAW8LM1D59+li0Otwqgi2ZDxO3gLRFxgwyrXXr1pmO89u3b3eeedc/OtpbRpuZaR8LuB8aOwP2GYuuwXKljWFLlSpl9ZLwHxUrVuymZS96Ow333ce5c+dSfF/KS+0hd+7cpteXTlQDkPoIzCDT27RpkzkA0KBMmTJlpFq1apn+OXFnNHbOHLQMcfz48eZA7scff5SCBQvKt99+a/pG0RQYANK+PO1mwTbKS+1l2bJlUrNmTfM5C0Dqo5QJmZ4GYvSyfPlyxnXaAI2d7U+nuuiEl06dOpleJFFRUWZ7RESEaQg8e/Zsq5eI/2Do0KEput/rr7/O82sDhw8fNmOVHT2jYM+S0i1btqT5WpA+OOkBpC0yZoB/0dTMHmjsbH/Vq1eXF154wTSJjZ9avXHjRrnrrrvk+PHjVi8R/4EeoOuBet68eZPtZaBn6DUYB/fH31z70qlqOsFH+wppQ/6YmBirl4Rb/Bub0olbvB8DqYeMGeBfNDWzBxo725+Oum/UqFGi7X5+fnL27FlL1oTbp0G1hQsXmlT5J598Uu6++26yKWyMv7n2s2TJEjNNTbMaNciqo9HHjh1r9bJwi9q3b+/8PjIyUj755BPTf1EbsqtVq1bJtm3bpFevXjy3QCoiMAPAVrT574IFC0xj544dOyZq7Dx//nyaiLq5kJAQM+5eG4omrH+nKaH7mjVrlhw9etSM4R04cKA8/fTTJitKgzSOyXkAMhbNUNQJWxqQ0YbAHTp0MOWlM2bMMH9z4X4GDx7s/P6pp54y09LefPPNRPc5dOiQBasD7ItSJuBfkydPlnbt2knOnDnNdU299fDw4PlxYzR2tqcRI0bId999JxMmTJAWLVqYnjIHDhww5U2vvfaa9O7d2+olIpXOvuuEPD37XrlyZRNw9fb25rm10eu4Z8+e4u/vb/VS8B/dc8895nXatm1b0/OrdevW5nOTjrnXElMCM+5PM1F1imnp0qVdtuvQDM1u1N5uAFIHGTPAvx599FHz9e+//zZ10Trh5dixYzw/bozGzvb08ssvS2xsrDRr1kwuXbpkypq8vLxkwIABBGVspFatWrJ//37Zvn276R909epVAjM2MmjQIKuXgNv0+++/m2wKDbAlPHCHPWgwXIdjJNy/uo3pTEDqIjADiJiDux9++MGcgV+5cqU5C9CvXz+eGxv1rtDsGcpc7EHL01555RVT7qIlTRcuXDBnZnPlymX10pAK9D1Y34unTp0qZcqUMQ29NXCuzWLh3jQTVcte/vjjDzl58qQJsManPYbgPrR8VEuYQkNDzVRLnZanJcSwj+eff94E3rTJb+3atc221atXm/dozVAFkHooZUKmpg3MNDvmxx9/lCJFikhYWJgZAdmwYUOrl4ZUFH9yD4CM6d133zUH7adOnTJlERqQqVKlitXLQip67rnnzD7W0pf8+fMnmvzywQcf8Hy7oYsXLzpPbq1Zs8YE4EaNGmX6Q+nfX7g3DZJ/9NFH5jOy0iBc3759TT8hAKmHwAwypZEjR5oPEFob+8gjj0jnzp2latWq1EXbFIEZe9EpEWPGjDFB1KTOujO+033HZWuAXKcxZc+ePdn76QEf3FNQUJBMnDhR2rRpY/VSkIZT8zSLRsvBdUqe9gH79ddfeb4B4CYoZUKm9NJLL5nL0KFDafCbCYwfP17y5cvnvE5jZ/fWrVs3mTdvnjz44IMmtTrhWXe4J+0VpPtSx7Amh33t3jTgVqpUKauXgTSkE9Q0+02bO8+cOdOcBIP7u3LlSpInQjSYDiB1kDGDTEk/MOi0Dz3zrhkzWhddqVIlMmZsjsbO9pkSoZOY7rjjDquXAuAWs1X37t0rH3/8MUE2wA3o9CUtSVuxYoXL9ri4OPMa1hNdAFIHGTPItNMg9LJ48WJzNqdOnTrmLJ7+oTlz5ozVy0MqorGz/RQsWJC+BZmETv7QZuw6dQv2aBarJYg6zadixYrmZEh806dPt2xtABLr2rWreHp6ym+//ZZkXygAqYeMGUBEzp8/L5MnTzZBmvXr15vyCC2TYDKT+6Kxs33pQd3o0aNl3LhxUrRoUauXgzSkk5iYqGYf2tD5RjSTFUDGkTNnTvO5uFy5clYvBbA9AjNAAlu2bDGN6zRQo/W0cC80dra/f/75x0yDWLJkifj4+CQ66x4eHm7Z2pC6aNwNANapVauWmZbWoEEDdgOQxgjMAMm4evVqogM+ZHyacptUY2fdlzoyu0KFCpauD7evefPmcvDgQdMEWJs6J0yt7tKlC0+zTRCYAQDrLFy4UF599VUZPny4VK5cOdHnYs1qBJA6CMwgU9JxnTejB3vaFBjuhcbO9qdZMitXrjQj7mFvmrnYrl07k04Pe5g2bZpMnTrVBFd10kt8jLoHMpasWbOarwlPgND8F0h9NP9Fpm1mlitXLpNdoX9ckkJgxj3R2Nn+tNb98uXLVi8D6eDRRx/lebYR7Q31yiuvmL/Bv/zyi+k5s2fPHlm7dq08++yzVi8PQALarBtA+iBjBpmSToM4ceKEdO7c2YwBrFKlitVLQhqhsbP9zJs3T9544w0ZNmwYqdU2cf/996f4vkzuce+g6uDBg+WRRx5xKVN7/fXXTW8oHaMNAEBmRGAGmdbq1avNFKYffvjBjMrWfhWdOnWiXtbGaOxsD6RWZ75pPfExuce9yxDDwsLMNLW8efPK/PnzTUnirl27pG7dunL69GmrlwgggaVLl8r48eNl79698uOPP0rBggXl22+/leLFi9MUGEhFBGaQ6WlJhP6h0Q/7a9askfbt25uAjZeXV6Z/buyKxs7ubfHixTe8vXHjxum2FgApp9kxP/30k1SvXl1q1qwp3bt3l6efftpkwXXs2JGJakAGo69X7beoJy41GLN9+3bzOtbsttmzZ5sLgNRBYAb4l47e1RRr/Xrq1CkJCAjguXFDNHYGgIzpqaeeksKFC5u/tWPHjpWBAwfKHXfcIevWrTPlbF9++aXVSwQQjwZRX3jhBXn88cddyg83btwod911lxw/fpznC0glBGaQqR05ckS++eYbky1z8eJFZ88ZrYOH+5a5pKSxs/YzgPs6e/asOYjTsghH3yh97fr5+Vm9NKQCJvfYU2xsrLno+7OaMmWKrFixQkqXLm0yZ7Jnz271EgEkKD/ULJlixYq5BGa0rKlChQoSGRnJ8wWkkmsz0IBMRkd1aqRfPwzqNIiRI0fKoUOH5N133yUo4+bKly9vPtzr2R0teTlz5kyiC0EZ96Zn10uWLCkffPCB2Zd6GTVqlNnGuF17TO7RnjP58uUzZ2Vr164tefLkMQcC+r4N9w6cO4IySsuXdH/37t2boAyQAYWEhMju3bsTbV+2bJkJ0ABIPWTMINN+OCxSpIipmdUP/8np06dPuq4LqYPGzvbWsGFD07D7888/dx7kRUdHmzIJPXjXckS4Lyb3ZI5GojomWzOjaCQKZFwjRoyQ7777zvRebNGihekpc+DAAVPe9Nprr5mgKoDUQWAGmZKmZGo5y43o7XqQB/dFY2d78vb2NpkUCUsONd1aG4peunTJsrXh9jG5x75oJAq4Fy0JHz58uAnQOP626nCMAQMGyJtvvmn18gBboZQJmdL+/ftl3759N7wQlLHHAbyWNL3xxhumHEL7GXDQ7v58fX3l4MGDibZrOaLWwMP9U+cd5Yaa2bhq1Srzvb4vJ9c3Cu7hrbfeknHjxplst2zZsjm3awNgyhCBjCUmJsZkuD377LPmPXnr1q3m/fiff/4hKAOkAQIzyJTatGkjERERzutvv/22aSbqcPr0adPUDO7d2FnP8mgfIe1jUKtWLdm2bRvTtmzg4Ycflm7duskPP/xggjF60aCbljI98sgjVi8Pt6lp06by66+/mu+114ymzGsKve73++67j+fXje3cuVMaNWqUaLs27Y7/NxiA9Tw8PKRly5amN5/27tPPxXqSSwcsAEh91zuwAZnInDlzJCoqynldD+A7dOgg/v7+zn4V+gES7tnYWadsaePfVq1amcbObdu2NR8wYA/vv/++KTXUbCh9rWoWhX5o7Nmzpwmywr199tlnZnKP0jO12vhXJ/fce++9ZnIP3L+RqJYTx0cjUSBjqlSpkskgL168uNVLAWyPHjPItM1/jx8/Lnnz5jXX448AVCdOnJACBQqYNE64Fxo7Zx5alqYNRJVOZNLeJAAyLhqJAu53InPQoEGmdCk0NFRy5syZqLQYQOogMINMicCMfdHY2b6efPLJFN1Pp0fAfd1sqlZSpTBwDzQSBdzD0KFDpX///i592+IPzdDXsl7nBCaQegjMIFPSshbNmAkODjbX9Q/PX3/95UzVJGMGyJgB1aJFi0r16tVv2AT2559/Ttd1IfX3c0LxDwg4EHB/V65cMSVNFy5cMH0r6FkBZLzPyceOHZOwsLAb3q9x48bptibA7ugxg0xJD+q6du1qRv6pyMhIeeaZZ5wpmvH7z8D9Gjt///33ppmk0p4jum8d/YO0sXPDhg3NaGW4F+0ho/tWp/NoU9jOnTtLYGCg1ctCKtNGk/FdvXrVjEd/7bXXZNiwYTzfbohsN8C9OE5+EHgB0g8ZM8iU9KAuJbSJLNy7TE3rnzdt2kT/IJvQoOn06dNNuZI2hNXGzjqhSSdHxM+qgP1oQ+9+/frJ+vXrrV4KbhHZboD7vWY1e9yRWQ4g7RGYAWAr9A/KPA4cOCBff/21TJw40Uxn0nHolETY144dO6RmzZqm/AXuRadrababliKS7Qa4x2cpzTy+2QmP8PDwdFsTYHeUMgEA3PaDo35o1JRr+o7Yh/b7ik/3r/Y60LLEatWqWbYu/Hdjx46VUaNGObPddMoL2W5AxvbGG284y8IBpD0yZgDYCo2dM08p07Jly+Tuu+82Z+Bbt26dZNNYuHfALb66deua/V6uXDnL1obUQbYb4F7ZxwDSHhkzAGyFxs721atXL5kyZYoULlzYNBPV0oigoCCrl4VUps2dEx4gaJ+DHDly8FzbBNluQMZGzzYg/ZExA8BWaOxs74O5IkWKmHHZN/rQqBk1cE+xsbGmb5Duw/3795v9XLx4cXnwwQflscce42DBjZHtBrgPMmaA9EdgBgDgFnTEfUrO4jFNzX2z3e655x6ZPXu2VK1a1ZQs6bawsDDZsmWL3HvvvTJjxgyrl4lUyHbr1KkT2W4AAMRDYAYAAFhOA2p9+/aVX375Re68806X2xYuXCjt27eXjz/+WB5//HHL1oj/hmw3AABujMAMAACwXMuWLaVp06by8ssvJ3n78OHDZfHixTJ37tx0XxtuD9luAADcGIEZAABguZCQEJkzZ06yI7E3btwod911l5kUAgAAYCfMFgUAAJYLDw+XfPnyJXu73nbmzJl0XRMAAEB6IDADAAAsFxMTI56ensne7uHhIdHR0em6JgAAgPSQ/CcgAACAdKITmLQXiZeXV7LjlgEAAOyIwAwAALBcly5dbnofJjIBAAA7ovkvAAAAAACARegxAwAAAAAAYBECMwAAAAAAABYhMAMAAAAAAGARAjMAAAAAAAAWITADAAAAAABgEQIzAAAAAAAAFiEwAwAAAAAAYBECMwAAAAAAAGKN/wMb3S1HNz2nLwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x1000 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Correlation Matrix:\n",
+      "                 EMA-Cross-SPY  EMA-Cross-Tech  Momentum-SPY  Dual-Momentum  \\\n",
+      "EMA-Cross-SPY            1.000           0.711         0.815          0.283   \n",
+      "EMA-Cross-Tech           0.711           1.000         0.632          0.200   \n",
+      "Momentum-SPY             0.815           0.632         1.000          0.248   \n",
+      "Dual-Momentum            0.283           0.200         0.248          1.000   \n",
+      "Mean-Reversion           0.113           0.054         0.101          0.138   \n",
+      "All-Weather              0.425           0.277         0.397          0.518   \n",
+      "Trend-Following          0.688           0.549         0.691          0.279   \n",
+      "\n",
+      "                 Mean-Reversion  All-Weather  Trend-Following  \n",
+      "EMA-Cross-SPY             0.113        0.425            0.688  \n",
+      "EMA-Cross-Tech            0.054        0.277            0.549  \n",
+      "Momentum-SPY              0.101        0.397            0.691  \n",
+      "Dual-Momentum             0.138        0.518            0.279  \n",
+      "Mean-Reversion            1.000        0.273            0.463  \n",
+      "All-Weather               0.273        1.000            0.500  \n",
+      "Trend-Following           0.463        0.500            1.000  \n"
      ]
     }
    ],
@@ -806,7 +926,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ddc2c281",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005053,
+     "end_time": "2026-06-01T00:17:44.461925+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.456872+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Calcul de la matrice de corrélation entre les instruments pour l'analyse de diversification de la stratégie Alpha-Correlation-Analysis."
    ]
@@ -814,24 +944,40 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "45468e67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.183828Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.183719Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.198646Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.197910Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:44.472037Z",
+     "iopub.status.busy": "2026-06-01T00:17:44.471797Z",
+     "iopub.status.idle": "2026-06-01T00:17:44.480685Z",
+     "shell.execute_reply": "2026-06-01T00:17:44.479802Z"
+    },
+    "papermill": {
+     "duration": 0.014831,
+     "end_time": "2026-06-01T00:17:44.481254+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.466423+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'returns_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[12]\u001b[39m\u001b[32m, line 3\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Find least correlated pairs\u001b[39;00m\n\u001b[32m      2\u001b[39m pairs = []\n\u001b[32m----> \u001b[39m\u001b[32m3\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i, alpha1 \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(\u001b[43mreturns_df\u001b[49m.columns):\n\u001b[32m      4\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m alpha2 \u001b[38;5;129;01min\u001b[39;00m returns_df.columns[i+\u001b[32m1\u001b[39m:]:\n\u001b[32m      5\u001b[39m         corr = corr_matrix.loc[alpha1, alpha2]\n",
-      "\u001b[31mNameError\u001b[39m: name 'returns_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 10 Least Correlated Pairs:\n",
+      "                               Pair  Correlation\n",
+      "8   EMA-Cross-Tech / Mean-Reversion     0.053828\n",
+      "12    Momentum-SPY / Mean-Reversion     0.101160\n",
+      "3    EMA-Cross-SPY / Mean-Reversion     0.113459\n",
+      "15   Dual-Momentum / Mean-Reversion     0.138500\n",
+      "7    EMA-Cross-Tech / Dual-Momentum     0.200210\n",
+      "11     Momentum-SPY / Dual-Momentum     0.247990\n",
+      "18     Mean-Reversion / All-Weather     0.273308\n",
+      "9      EMA-Cross-Tech / All-Weather     0.277077\n",
+      "17  Dual-Momentum / Trend-Following     0.278780\n",
+      "2     EMA-Cross-SPY / Dual-Momentum     0.283054\n"
      ]
     }
    ],
@@ -855,7 +1001,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "fb31d0c4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004255,
+     "end_time": "2026-06-01T00:17:44.489937+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.485682+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Regime Analysis\n",
     "\n",
@@ -865,24 +1021,39 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "50ba5e4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.200130Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.200019Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.219522Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.218839Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:44.500807Z",
+     "iopub.status.busy": "2026-06-01T00:17:44.500589Z",
+     "iopub.status.idle": "2026-06-01T00:17:44.520671Z",
+     "shell.execute_reply": "2026-06-01T00:17:44.519563Z"
+    },
+    "papermill": {
+     "duration": 0.026474,
+     "end_time": "2026-06-01T00:17:44.521334+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.494860+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'returns_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[13]\u001b[39m\u001b[32m, line 7\u001b[39m\n\u001b[32m      4\u001b[39m spy_trend = spy_returns.rolling(\u001b[32m60\u001b[39m).sum()\n\u001b[32m      6\u001b[39m \u001b[38;5;66;03m# Regime classifications\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m7\u001b[39m regimes = pd.DataFrame(index=\u001b[43mreturns_df\u001b[49m.index)\n\u001b[32m      8\u001b[39m regimes[\u001b[33m'\u001b[39m\u001b[33mvol_regime\u001b[39m\u001b[33m'\u001b[39m] = pd.cut(\n\u001b[32m      9\u001b[39m     spy_volatility,\n\u001b[32m     10\u001b[39m     bins=[\u001b[32m0\u001b[39m, spy_volatility.quantile(\u001b[32m0.33\u001b[39m), spy_volatility.quantile(\u001b[32m0.67\u001b[39m), \u001b[38;5;28mfloat\u001b[39m(\u001b[33m'\u001b[39m\u001b[33minf\u001b[39m\u001b[33m'\u001b[39m)],\n\u001b[32m     11\u001b[39m     labels=[\u001b[33m'\u001b[39m\u001b[33mLow-Vol\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mMed-Vol\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mHigh-Vol\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     12\u001b[39m )\n\u001b[32m     13\u001b[39m regimes[\u001b[33m'\u001b[39m\u001b[33mtrend_regime\u001b[39m\u001b[33m'\u001b[39m] = pd.cut(\n\u001b[32m     14\u001b[39m     spy_trend,\n\u001b[32m     15\u001b[39m     bins=[-\u001b[38;5;28mfloat\u001b[39m(\u001b[33m'\u001b[39m\u001b[33minf\u001b[39m\u001b[33m'\u001b[39m), -\u001b[32m0.05\u001b[39m, \u001b[32m0.05\u001b[39m, \u001b[38;5;28mfloat\u001b[39m(\u001b[33m'\u001b[39m\u001b[33minf\u001b[39m\u001b[33m'\u001b[39m)],\n\u001b[32m     16\u001b[39m     labels=[\u001b[33m'\u001b[39m\u001b[33mBear\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mSideways\u001b[39m\u001b[33m'\u001b[39m, \u001b[33m'\u001b[39m\u001b[33mBull\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     17\u001b[39m )\n",
-      "\u001b[31mNameError\u001b[39m: name 'returns_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Regime Distribution:\n",
+      "regime\n",
+      "Bull-Low-Vol         270\n",
+      "Sideways-Med-Vol     238\n",
+      "Sideways-High-Vol    205\n",
+      "Bull-Med-Vol         158\n",
+      "Bear-High-Vol        125\n",
+      "Sideways-Low-Vol     102\n",
+      "Bull-High-Vol         78\n",
+      "Bear-Med-Vol          18\n",
+      "Name: count, dtype: int64\n"
      ]
     }
    ],
@@ -914,7 +1085,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a7fabe57",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005459,
+     "end_time": "2026-06-01T00:17:44.532741+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.527282+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Classification des régimes de marché (tendanciel / retour à la moyenne) pour adapter les paramètres de Alpha-Correlation-Analysis."
    ]
@@ -922,24 +1103,69 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "4a5785e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.220880Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.220769Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.237936Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.237274Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:44.546696Z",
+     "iopub.status.busy": "2026-06-01T00:17:44.546352Z",
+     "iopub.status.idle": "2026-06-01T00:17:44.847313Z",
+     "shell.execute_reply": "2026-06-01T00:17:44.846750Z"
+    },
+    "papermill": {
+     "duration": 0.310004,
+     "end_time": "2026-06-01T00:17:44.848087+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.538083+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'returns_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[14]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Analyze alpha performance by regime\u001b[39;00m\n\u001b[32m      2\u001b[39m regime_performance = {}\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m alpha \u001b[38;5;129;01min\u001b[39;00m \u001b[43mreturns_df\u001b[49m.columns:\n\u001b[32m      5\u001b[39m     alpha_perf = []\n\u001b[32m      6\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m regime \u001b[38;5;129;01min\u001b[39;00m regimes[\u001b[33m'\u001b[39m\u001b[33mregime\u001b[39m\u001b[33m'\u001b[39m].unique():\n",
-      "\u001b[31mNameError\u001b[39m: name 'returns_df' is not defined"
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABPEAAAMWCAYAAACQuxMsAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3Qd0VFUXhuEvCRB6Db333nuRLqgUAbEgKiiI0hVQmgKigmIFFJDee5MuHaSDVOm9Q0gChBJ6/nVO/kwyKTRJMsD7rDUrc+/cuXPLZMqevfdxCwwMDBQAAAAAAAAAl+Ue0xsAAAAAAAAA4P4I4gEAAAAAAAAujiAeAAAAAAAA4OII4gEAAAAAAAAujiAeAAAAAAAA4OII4gEAAAAAAAAujiAeAAAAAAAA4OII4gEAAAAAAAAujiAeAAAAAAAA4OII4gEAgIfm5uamNm3acMT+g169etnj+KQ0bdpUCRMmfKbPyfOwj5GpXLmyvQAAABDEAwAA2rVrlxo2bKjMmTMrbty4Sp8+vV588UUNHDjwmT86o0ePtkG14EusWLHs/pvA0enTpx9rndevX7fBupUrV+pZkSVLFnt8qlevHuHtw4YNcxzDLVu2yFWdOXPGnpvt27fH2PMDAADgccR6rHsBAIBnxrp161SlShVlypRJH374odKkSaOTJ09qw4YN6t+/v9q2bavnQe/evZU1a1bduHHD7rsJ3qxZs0b//vuvDWw+ahDvq6++stfDZlF98cUX6tKli55G5jisWLFC586ds8+T0CZMmGBvN8fPlZkgnjk3JihZpEiRGHl+PIrFixdH2boBAMDThSAeAADPuW+//VZJkiTR5s2blTRpUqfbvL29o317rl27pgQJEkT747788ssqUaKEvd68eXN5eXnp+++/15w5c/TGG288sccxmVzm8jQqX768fZ5MmTJF7du3d8w/deqU/v77b9WvX18zZsx46p8LMfn8CCtOnDhRtm4AAPB0oZwWAIDn3OHDh5U/f/5wATwjVapUEd5n9uzZKlCggDw9Pe19Fy1a5HT78ePH1apVK+XOnVvx4sVTihQp9Prrr+vYsWMRliquWrXKLm8eL0OGDE694/bt22eDJIkTJ7brMcGjiLK9xo8fr+LFi9vHS548ud566y2bUfi4XnjhBcfxCXbr1i316NHDPo4JfJoAk1nOZKcFM/uYMmVKe91kfAWXYZr9Cb1fod25c0dff/21smfPbo+pyRLr1q2bbt68+dDbe+TIEdWsWdNuU7p06WzmWGBgoL3N/DXrfPXVV8PdzxxLsy8fffTRAx/DZJw1aNBAEydOdJo/adIkJUuWzD5+WDt37rSlp9myZbP3Nxl8H3zwgXx9fZ2WCz4ue/bs0dtvv23XV6FChUi3xZTDmuNsMh2vXr1q55nyVrPu1KlTO56bI0eOdNzHlDeXLFnSXn///fcd58Y8D5/E88Mwz1dTmm6eg2Z/TeDPBPoiOi6VKlWyz1fznP/mm280atQouz2h/0/C9sQz+2CWmTp1qn1+mdLeRIkS2ce8fPmyfc588skn9n/J9BE0+xnR8+hJ/78AAICo93T+DAwAAJ4Y0wdv/fr1tizQBOYexJQQzpw50wbdTPBgwIABeu2113TixAkbZDNMtpYp0zWBAROgMEGJwYMH22CECdLEjx/faZ1mXSYgYwJkJvsqNBPAMwGovn372jJG83gXL17U2LFjnbIJv/zyS7usyZK6cOGC7edXsWJFbdu2LcIA5YMEB1JMMCmYv7+/hg8frkaNGtnS4ytXrmjEiBE2eLVp0yZbnmn2w+xry5YtbWaaCXoZhQoVivSxzDaPGTPGBmI6duyojRs32v3du3evZs2a9cBtvXv3rl566SWVKVNG/fr1s0HVnj172uCgCeaZoM8777xjb/Pz87NBm2Bz5861+2VufxgmwFajRg0bvDJBR8ME9cy2x44dO9zyS5YssQFGE0wyAbzdu3dr6NCh9q85n2EDmibYmzNnTvXp08cRhAzLPL/MMTcBsj///NMGos6fP2/3P3jwFXMeFi5cqGbNmtn9M4GtvHnz2uNhnmctWrRwBOLKlSunJ/H8MPtkshVNYM2UTJuAqgm21atXz2YomudDcLDRlLCbbe3atatdzjyvTODxYZnnh9lv8ziHDh2yz3dz/N3d3e3/hwmKBpf9mjJgs89R+f8CAACiQSAAAHiuLV68ONDDw8NeypYtG/j5558H/vXXX4G3bt0Kt6z56BAnTpzAQ4cOOebt2LHDzh84cKBj3vXr18Pdd/369Xa5sWPHOuaNGjXKzqtQoULgnTt3nJbv2bOnva1u3bpO81u1amXnm8c1jh07Zrf922+/dVpu165dgbFixQo3P6zgbVi6dGnghQsXAk+ePBk4ffr0wJQpUwZ6enra6WBmG2/evOl0/4sXLwamTp068IMPPnDMM+sx6zT7EFbwfgXbvn27nW7evLnTcp06dbLzly9fft/tb9KkiV2ubdu2jnn37t0LrFWrlj1XZluM/fv32+UGDx7sdH9zfLNkyWLvcz+ZM2e26zTHIE2aNIFff/21nb9nzx673lWrVjmO5ebNm+/7XJg0aZJdbvXq1eGOS6NGjSLcxwQJEtjra9asCUycOLHdlhs3bjiWadasWWDatGkDfXx8nO771ltvBSZJksSxHWbbzOOYbX0Yj/L8qFatWmDBggWdtssc13LlygXmzJnTMc+cKzc3t8Bt27Y55vn6+gYmT57cPtbRo0cd8ytVqmQvwVasWGGXKVCggNP/qDluZp0vv/yy0/ab/2lz7oL91/8XAAAQcyinBQDgOWdGoTWZeHXr1tWOHTtstpbJcjLZRBGVAZrRSYMzsIIzzEypq8m2CmYyhILdvn3blk7myJHDZvhs3bo13DpNVpuHh0eE29e6dWun6eCBNhYsWGD/mqzAe/fu2awiHx8fx8VkfZmMrtClrvdj9stkb2XMmNFmlZnsKLP/weW9htnG4B5l5jFNVpvJdjMZYRHt18MI3o8OHTo4zTcZecb8+fMfaj0m+yxYcDaaKf9dunSpnZcrVy6VLl3aDkARzGy/yVZr3LhxuIy4yJhjYI61KaE1zPrMMQvOagsr9HPBlO6ac2My5oyIjtnHH38c6WObc2mem9WqVbPnPThzzcSXTaZbnTp17PXQzwOzvCkzfdzz87DPD3Msly9fbo+NydAMfnzz3DfbcPDgQcdotiZTsmzZsk4Da5jsSHMeHtZ7773nlPlozq3Zd1NOHJqZb8pkzfP0Sf6/AACA6Ec5LQAAsH3CzJd7E/QxgTxTwvnLL7/YYIXpPZYvXz7HUTKj2IZlSgpNCV+wgIAAW+5nenyZwEXoskgTUAnLlPtFxgQWQjMBRFMyGFzOaIIjZv1hlwsWUYlnRH7//Xcb6DLbZ/qorV69OsLyRlP2+tNPP9neZyZA+TD7cD+mf6DZHxPkDM0EVUzQ09z+IOb+pudcaGZfjND91UzgxwT3zDpNGfW0adPsPrz77ruPtM2mpNaUNZvniimlNWXTkQUBTXDL9G6bPHlyuIFSHuW5YAKAtWrVsn3cTIlq6MFBTDnopUuXbJmuuUTkvw7S8qDnhylpNc9DU6ZqLpFtgwmOm+NvgnhhhX0O3E/Y/0PT19AwQcaw803Qzmy3KXd/Uv8vAAAg+hHEAwAADibLzAT0zMUELEwfMxPoMf3VgkWWMRc6UGey5UwAz/QhM8EKE0gwQR4T7DEBhftlaz1I2GCRWZ+ZZzLKIto209z/YZQqVcox+qjpYWYGVTDBqv379zvWYQYDMIM0mNs/++wzO3iAeUwTsAw7wMGjethMuP/CHP9PP/3UZs+ZgTPM/ph9NgOQPAqT3WWCqeb8Hj161B6nyJiML9Mf0Rwvk3lmjqU5Z6aH36M8F0zA7JVXXrE98EwmW+3atR23Ba/H9PVr0qRJhPe/X0/CJ/H8CN6GTp06RTjAx6MG6R4ksv/DB/1/Pqn/FwAAEP0I4gEAgAgFByzOnj37yEdo+vTpNphiMtZCZ1KZbKlHZTKHQmdnmYwnE4gwg10YJphkAhRmmeDss/8qODBnBh/47bff7OABwftlMt5M1mLooFvoIOejBuRMRpzZH7OfZuCFYGagBnO8zO0PYu5vyplD7/+BAwfs3+DjFFyyabLZTBDPlG6uXbtWv/76qx6HGdzDjKhqtjl0WWhoJjtz2bJlNhMv9MAKZl8flTmmZrvNCLtm8AsThAoetdWUuZpBVswAH6bs9UHriYrnR3AmpMlke9A2mHNqnsdhRTTvSYuK/xcAABA96IkHAMBzzvTAimgU0OBebY+apRUc5Ai7TjP6pQmyPE4ZY9j1GC+//LL9a0Z/NY9nAkVhH9NMm55kj8MEiEz2lQlymQCkEZy5FPpxzEiypqdgaMGj7z5M0NJklxlhg2k///yz/WuCbg/DBJOCme0z0yagZPrHhWZKZ80IwSYzzuyPyc57HGZUUxO8DB2oDSui42U8buDQZIqaAKrJFDX978yIwMGPY0ZINn3xzCjLYZly22Cml53xOAHl+z0/TFammffHH39EGPgOvQ0mU888Z0ypeuiy49D9CqNKVP2/AACAqEcmHgAAzzlT+nr9+nXVr19fefLksX3xTPnjlClTbBaXKal9VKbUcdy4cbaM1vTTMwELM8CC6cn1qEy5phl0w5RfmvWYElBTxli4cGFHZpHJCOvatavt/2ZKHU1Wlrmf6e3XokULW+L4OEygy2R9jR492g64YPbLBJHMsTLBNfMYQ4YMsft49epVp5JQM88cQ5PtZDLgChQoYC9hmf0wWYuml5sJLFWqVMkGp0zvPbMvJtvrQeLGjWtLTM16TKmryVIzA2KYklmTpRaa2W5zHkyZtAmEmuDT4zDZZL169brvMmbAk4oVK9rBUkzvPdMPbvHixfa4PS5zbOfNm6eqVava7V+1apU9rt99950NSJv9NwOlmONvAmNmQAvz3DPXg58vptegOW/meWKCeuY+j9PTMOzzwwScTZltwYIF7TaY7DyTUWmet6dOnbI9BI3PP//cPo/NoDLm/89sw/Dhw22fO7OdUVlaHZX/LwAAIGqRiQcAwHPuxx9/tIEik3lnRkg1FxNEatWqlc0yMwGPR9W/f387iILJLDKjrJrMJBNIeZx+WyYQZvqhmZJFE5gyAzOMGDHCaRlzm8nCMgM8mAwjE4QwI4fWqFHDBgD/S9aSCXqYY2SyCE0/vD59+thgTLt27fTXX385+sqFZYIyJmhletCZ0lNTihsZs6zZ7s2bN9s+c2aUUxNkMYNBPAyTWWWCeOfOnbOBJbMekyX39ddfR5jN9uabb9rrjzqgxeMwA1+YzDMT4DL7ZLIDTZDxvzDBQXPszeAfJhBmylBTp05tn7cm6GwCreZ5Yp6HJij2/fffO+5rHt8ESM0xM4E3c25MIPBJPD9M4HDLli02UGoCe2ZkZRMsNM/L0OXEZvAJE3A0pcjm+WSy+UwANnhkWROUjUpR9f8CAACilltgRPUzAAAAMcxkeZkAgylD9PLyiunNeaaYwKIJhJqgX3DpL2KeCeCaclyT1RnZABUAAOD5RSYeAADAc8T0bzPZg6aHHAG8mBMQEOA0bXrRmRJ0U45LAA8AAESEnngAAADPAW9vb1vSbMp6TcCoffv2Mb1Jz7WyZcvagTBMSa3pm2cyI/39/fXll1/G9KYBAAAXRRAPAADgOWBGpG3cuLEdyGLAgAEqUqRITG/Sc82MSmwCqmZAEzOQRbFixWwgzwwEAgAAEBF64gEAAAAAAAAujp54AAAAAAAAgIsjiAcAAAAAAAC4OIJ4AAAAAAAAgItjYAsAAAAAAAC4FLeWZWLkcQMHb5CrIhMPAAAAAAAAcHFk4iHarTnbg6P+DKuQtneM/3KC6P116sbd+RzyZ1hcj1qO67fv/RWj24KoE9u9puP6Hr/vOdTPsHzJOzuuB54dFKPbgqjjlraV4/q1239yqJ9hCWK/6rh+5fasGN0WRJ1EsetzeGGRiQcAAAAAAAC4OIJ4AAAAAAAAgIujnBYAAAAAAAAuxc3dLaY3weWQiQcAAAAAAAC4ODLxAAAAAAAA4FLIxAuPTDwAAAAAAADAxRHEAwAAAAAAAFwc5bQAAAAAAABwKZTThkcmHgAAAAAAAODiCOIBAAAAAAAALo4gHgAAAAAAAODi6IkHAAAAAAAAl0JPvPDIxAMAAAAAAABcHEE8AAAAAAAAwMVRTgsAAAAAAACX4ubmFtOb4HLIxAMAAAAAAABcHJl4AAAAAAAAcCkMbBEemXgAAAAAAACAiyMTDwAAAAAAAC6FTLzwyMQDAAAAAAAAXBxBPAAAAAAAAMDFEcQDAAAAAAAAXBxBPAAAAAAAAMDFMbAFAAAAAAAAXAoDW4RHJh4AAAAAAADg4sjEAwAAAAAAgEshEy88MvEAAAAAAAAAF0cmHgAAAAAAAFwKmXjhkYkHAAAAAAAAuDiCeAAAAAAAAICLo5wWAAAAAAAALoVy2vDIxAMAAAAAAABcHEE8AAAAAAAAwMURxHtIK1eulJubmy5dumSnR48eraRJk+pp0atXLxUpUiSmNwMAAAAAAACPgZ54Yaxfv14VKlTQSy+9pPnz5+txlSlTxgbNhgwZ4phnrrds2VKjRo1S06ZNHfPN9cOHD+vvv//Wk2CCjbNmzVK9evWeyPog7d/hrb8m79exA3667HtDrb8ur2IvZLjvoVk+66C9+Jy7ruSp46v2O3lVrmZWp2WWTNuvFXMOy+/8dSVMEkclKmXUax8WUmxPDw57DDn6zSxlSZE23PzfV01Xm8k/RnifhsWq6us6Lez9DnqfVOdZv2vh7vURLju40ef6uGIDfTLtF/VfPuWJbz8ezeSJazRm5Ar5+FxRrtzp1KV7fRUslDnCZZcu2akRQ5fq5Akf3b5zT5kzeend9yurTt0SjmUG/7ZIixZu17lzlxQ7tofy5cugNu1fUaHCEa8T0WPShNUaNXK5fHz8lTtPenXr3jDS83zo4Fn9NnCB9uw+qTNn/NS5S32926SK0zJ3797ToN8Wat7czfa5kzJVYtWrV1oftaxp34MR/XZvO6fZE3bp8H4fXfQJUJfvqql0pYf7v9u747y+aL1AmbIl0y9j6zmd5ynDt2nVX4d1yTdAyVLGV9VXcur19wtznl3A4tWHNHnOLu0+4K3L/jc0a9jbypsz5X3vc/CorwaMWq/d+7115vwVdW1dUU1eLxrp8kMnbNbPw9bpvdeKqFvbSlGwF3iQKZPWaeyoVfK179Np9Xm3V1WgYKYH3u+vBdvV9fOJqlw1v34e0MQxPzAwUEN+X6xZ0zfpypUAFS6aRd2+rK9Mme//3EHUmjppvcbZ83xVOXOn1Wfd6qpAwYwRLjt39hZ99cV0p3lx4sTSuq3fOKaXL/lXM6Zu1L49p3X58nVNmN5OufOk4zQ+heiJFx6ZeGGMGDFCbdu21erVq3XmzBk9ripVqtjsvdBWrFihjBkzhptvpqtWraqnjXkTvHPnjp4Ht27cVYbsSfXOJ8UfavkVfx7SjGE7VbdpAX09+iW92rSAxv+6VdvXnXYss2HpcU0fulN1m+TXN2NeVtPPS2nTihOaMXxnFO4JHqTkd+8rTedXHJfq/dva+dP+WR7h8mWzFdSkD3prxLq5KtqniWbvWK3ZH/dT/nTZwi1br3AllclaQKcveXMiXMCihdv04/d/6qNWNTV5egf74a5li6Hy9b0S4fJJksRX84+qa+zE9po+q5NebVBKPbtP1to1+xzLZM6SUl27N9CM2Z9p9Li2Spc+uVp++If8/K5G454htIULtqrf97PUsvVLmjbjM+XOnV4ffTgo0vMccOOWMmRMoU861JGXV+IIlxkxfKmmTF6jbl+8rjnzu6lDx7oaOWKZJoxfzcGPITdu3FaWnMnVomPZR7rftSs31f/r1SpUIvyXu1njdmnRrH36sGNZDZzcQO+1KqFZE3Zq/rQ9T3DL8bgCbtxW8YLp1KlF+Ye+z42bt5UxbRJ1bFFeKZPHv++yu/ad05S5/yp3di9OUgz5a+F2/dxvrlq0rK6J09rb4E7rj0bIz/f+76lnTvvpl5/mq2hx5x/PjTEjV2rShLXq1qOBxkxsq3jx4th13rx5Owr3BPezeOEO/dJvnj5sWV3jp7W1wdq2DzjPCRJ6atHK7o7L3MWdnW4PCLilIsUyq+2nL3Hw8cwhiBfK1atXNWXKFJstV6tWLVsy+1+CePv379e5c+cc81atWqUuXbo4BfGOHj2q48eP2+WNkydP6o033rClusmTJ9err76qY8eOOZbfvHmzXnzxRXl5eSlJkiSqVKmStm7d6rg9S5Ys9m/9+vXtr8TB08HGjRtn55n7vvXWW7pyJeRLzL1799S3b19lzZpV8eLFU+HChTV9+vRwJcULFy5U8eLF5enpqTVr1uh5ULB0WjVoXvCB2XfB1i8+pkp1sqtU1UxKmS6hSlfLpEp1smnhxJAv+4f/9VGOgl4qUz2zvNImUIGSaexyR/f6ReGe4EF8rl7SeX8/x6V2wfI65H1Sqw6G/J+F1r7Km1q0Z4N+XDJB+84dU4+5Q7X15H61qdTQabl0SVJq4Jsd1XhUT92+e5cT4QLGjV6lBq+XUb0GpZQ9Rxp90bOh4saNrdkzN0W4fMlSOVSteiFly55aGTN5qfG7FZUzV1pt23rUscwrtYurTLlcNgiUI2cader8qq5evaGD+x//RyH8N2PHrFDD18upfoMyyp4jrXr0ekNx48bRrJkbIly+YMHM6vRZPb1Sq7j9ZT8i27cdVZWqBVWpcn6lT59CNWoWVbnyebRr13FOVwwpXjajGn9UXGUqO3/ueZAh/dap4ovZlLtA+Cycfbu8VeqFTCpRPqNSpU2kclWzqkip9Dq4x+cJbjke16s18qp1k9IqW/zBWVnBCuZJo89bvqBa1XLbbOnIXLt+S52++Utfd6qmxAk9OUkxZMLYv1W/YWm9Wr+kfe/t3qOBfZ/+c9bmSO9jMmi7d56kj1u9qAwZkodLQJg4bo2at6hmM/RMsKh3nzd1wdtfK5ftjoY9QkQmjF2jeg1LqW79EvY8d+1Rz75Pz5m1JdIDZr6TenklclxSeCVyur1W3WI2KFiqbA4OOp45BPFCmTp1qvLkyaPcuXPrnXfe0ciRI+2L/eMoX768YseObbPvjD179iggIEDNmjWTr6+vDd4Z5va4ceOqbNmyun37tmrWrKlEiRLZ0tq1a9cqYcKEtrT31q1bdnkTdGvSpIkNnm3YsEE5c+bUK6+84gjGmSCfYUp2z54965g2TMnu7NmzNW/ePHsxQcXvvvvOcbsJ4I0dO9aW/e7evVuffvqpPQ5mudBMINLcb+/evSpUqNBjHZ9n3Z3b9xQ7jvOHw9hxYunoPj/duXPPTmcv4KXj+y/qyF5fO33hzFXt2nBWhcqEL+VEzIjtEUvvlHpJI9fPi3SZstkKaOk+5w+Tf+3ZYDP0Qn/QGPd+T/2wZLz2nA0J+CDm3L51R3v3nFKZMrkc89zd3VWmbC7t3B7yw0lkzHvDxvUHdOzYBRUvkS3Sx5gxdb0SJYqrXJRwxAhzDkxZbJmyucOc59zasf3x/xeLFM2qjRsO6NjRoKzafftOa+vWI3rhhbxPZLsRPZbNO6Bzp6/ozWYRl1PmKZhKO7ec1ekTl+300YO+tvS2WNmH+0EPT6/e/VeqcpksKlfi4QOEeLJu3zbv06dVukwOp9fv0mVyaueOyH8wGTp4qZInT6h6r5UKd9vpU362BULpsjkd8xIliqcChTLed52I2vO8L4LzXKpMjvuek4Drt1T7xe9Uq1pfdWg7RocPnec0PaPM96iYuLgyeuKFKaU1QSvDBM4uX75sA1iVK1d+5AObIEEClSpVymavNWrUyP41vfZM9lq5cuXstMl4M39NAM/MHz9+vM2GGz58uOOJY4JxJivPLFejRo1wZbdDhw61t5vtrF27tlKmDPol2cxLkyaN07Jm3Sa70AQJjXfffVfLli3Tt99+q5s3b6pPnz5aunSp3R4jW7ZsNlj4xx9/2Iy/YL1797bZgIhc/pJp9Pf8IypaIb0y50pmg3Vm+u6de7p6+aaSpohnM/DM9e/aLjcRAd29G6jKdbOr1jv5OLQuwpS/Jo2XUKPXR94fM03iFDZjL7Tz/hft/GCda7yrO3fvasCKqVG6vXh4Fy9ds7/Wh/3lNkWKRDp6JPJyZ9M/58XKX9kPneZDZrcvX1PZciEBImPVyt3q3HGcLe/zSplIQ4Z/rGTJEnJ6YvI8p4jgPB99/A/8zT+srmtXb6hOrW/l4eFmX7/bfVJLteuUfAJbjehw5uRljRu0Rd8OqSWPWBH/pt3gvUK6fv2W2r41Q+7ubrp3L9Bm+1WqmZ2T9Aybv2y/9hzw1vQhb8X0pjzXLl0Mev1OHub1O3mKhI4fUMIymfEmS2/S9E8ivN301QteR9j3BBPcQ/S7dPH6/89zwgjO84UI72Nal3zZ+zVbXn31yg2NH71aH7wzSFNnd1DqNEmiacuBmEMQ7/9M6eumTZvsgBD2wMSKpTfffNMG9h4UxDtx4oTy5QsJvHTr1s1ezP2mTZtm55kgXPB6TEDMTL///vv274cffmjn79ixQ4cOHXIE2YLduHHDZtEZ58+f1xdffGHv5+3trbt37+r69et2Gx7ElNGGXnfatGntOgzzuGY9YYNzJgOwaFHnX6hLlAhp4h4ZExQ0l9BMoNJcngd13suny3431KfVUhOfU+LkcVXupSxaNGmfI0C7b5u35o/fq3c+KaZs+VLI+/RVTRq4TXPH7lad9/LH9C5AUrPydbRw9wadvfz4pVPFMuW2JbfF+oY0VcbTK0ECT02d2dF+sd+44aB+6venLZ01pbbBzHWzzKVL1zRj2gZ91mGsxk9uHy6QhKe7n+K8eVv0/Q/vKUfOtNq395S+7ztTqVIl0av1Ssf05uEBzBfGX3qu0lvNiyl9psi/8K1ddlSr/zqiT7+qrExZk+roQT+N+HWjknnFV9VaIZk8iHpzl+xTz59CetMO7feqShRK/8Qf56z3FfX5bZVG/lhfnp58TXqaXLt2Q192nawve72mZMkSxPTmIAoVKpLZXoIVLpJZDev+rJnTNqpl2xoc+2cMA1uEx7vT/5lgnRmkIV26dE7lUibo9Ntvv+l+zH22b9/umDa97AzT585kuZ0+fdoG3Tp16uQI4pnsNhOYMz3wgrPrTE8+02tuwoQJ4R4jOMPOlNKactz+/fsrc+bMdvtM5lxwue39mPLe0EwwyWTnBT+2YUbkTZ/e+UNR2MCbyTJ8EFOa+9VXXznN69mzp3r16qXnQRzPWPqgcym917GE/P1uKGmKuFo174jixo+lREmDjufskbtUtkZmVawd9It+hmxJdTPgjsb+tMVm45lf/RFzMiVPo+p5SqrBH13uu9w5f1+lTuzccyV14mR2vvFCjiJKlSiZTnw723F7LI9Y+um1dvqk6lvK+kX9KNoD3E+ypAnk4eHu+FU+mBnswPRWiYzJvgsewS5P3vQ6euS8Rgxb5hTEix/f0y5jLoUKZ1Gdl/po9oyNataiOiclps6z76Od5wf56cc/1bx5dds3z8iVK53Onrmo4UOXEMR7Cty4fluH9vroyAFfDfs5aCTxwHuB9ke31yqMUs9fa9qBLsb8tlkN3i2oF14MKpnPnCO5Lpy7qpljdxLEi2ZVymdTobwhFSapU0ZNdrMZtdb3YoAafDjJMe/uvUBt2XlaE2bt0M4lbexrCqJe0mRBr99+YV6/zWAHYbPojVMn/XTm9EV90iakp7nJnjVKFu6imXM/c9zPrCNlysRO7wm5czNyaUxImiz+/8/z1QjO88P9n8eK7aHcedPp5Imgz97As44gnulfdueO7QX3008/2ZLV0OrVq6dJkybZXnmRHsRYsZQjR/immaZsNk6cOBo0aJDNpjMBOqNkyZK6cOGC7bkXXHZrFCtWzA6skSpVKiVOHPGIeKZPnlmf6YNnmCCgj49PuGCdydB7FCaT0ATrTEZf6NLZx9W1a1d16NDBad7zkoUXWqxY7kqeKmj0s03LT6hw2XSO4Nytm3fD/bLg7vH/aduLkSBeTHq/bG15X7mo+f+uu+9y64/8q2q5S6r/8imOeS/mKaX1R3bZ6+M2LgzfM6/trxq3cZFG3afXHqKW6VGZN18Gm01XtXpQ/0Lzo4aZfuvtCg+9HvMFwfRdu+8ygYG69YBlEHXnOV/+jLZ/nRmUJOQ871ejxhUfe703Am5F+Pod/IURri1egjj6dbzzDyiLZu7Vri1n9VmfqkqdLuiL480bpmw+zHk2ZbWP2S8Zjy9h/Dj2EtXKFM+oOSMbO83r9v0SZcuUXM0bFSeAF41ixzbv0+m1aeMhValWwPH6babfbFQu3PJZsqbU1FnO3z0GDfxL167d1Gdd6ipN2iSKFcvD/oCzacNBOyK9YQaf+nfnSb3+xqONbI0nd57z/P88V66W33GeN288pDciOM+RZVcfOnhO5V9wbm+CZwOZeOERxJPsIA8XL160g06YUVtDe+2112yW3g8//KBHZUZ4LVOmjAYOHGgHuvDwCBrowAT2Qs8PzpBr3LixfRwzIq3pO5chQwY7cu3MmTP1+eef22kzkIUZYdaUtPr7++uzzz6zjxO2bNb0ujPrNoGzZMmSPXBbTZmtyRQ0g1mYF07Tv8/0BDRBQxNQNBmAj+JZK501v9qbctdgPueu6cTBi0qQOI5SpE6gGUN36qLPdTXvVsbefu7kFR3d62vLZK9duaXFU/fr9NHLatYlpMzKBPQWT9uvTDmSKVu+5Hb9s0f8q8Ll0smdX3ljlMlSfb9sLY3ZsEB37zkHxMc06aHTly6o25+D7XT/FVO0qsNgdaj2tub/u1ZvlXhRJTLnVYuJQYPG+F3zt5fQzOi0JlPvwPkHl8Ej6rzbtJK+7DpJ+QtkVIGCmTR+7CoFBNxSvfpBP6x07zJRqVIlVvsOte30iKFLla9ARmXM6GWDcn+v3qv5c7eoe4+gkYivX7+p4X8stSPeeXkltuW0kyeulff5y3qxZhFOZQx5r0kVde86/v/nObPGj135//Mc9HrctfM4pUqdRJ92qGunTVD28OGgkeVN78Pz3pdtuWxwhqVRuUoBDftjsdKmTW5HITaDpIwdvcKOgIuYEXD9ts6dCnmtPX/mio4e8FXCxJ5KmSah7X/nd+Ga2vesZANxmbM7fzZKkiyuYnt6OM0vWSGjpo/eIa/UCZUpW1Id2e+rOZN3q1ptSmldwSX/Gzp7/oq8/5/Bc/TkRfvXK3l8pUwRVDXSuc9fSuWVUB1blLfTt27f1eFjQX1sb9+5p/M+V7X34AXFjxdbmTMktYHCXNm8nB4nXtzYSpo4brj5iHqN33tBPbtPVb78Gexr+MTxa+zrd916Qa19TPmsaWPQ9tOX5ekZ274eh2YGljJCz3/73QoaPnS5MmX2Urr0yTX4t8VKmSqxI4CE6Nf4vQrq1X1auPNcp15QAkyPribJJYnafPqSnR42eKkKFsqkDJlS2J54Y0et1rkzF1XvtZC+tJcvX9e5s5fsyMPG8f/31zPZmP8lEx9wBQTx/l9KW7169XABvOAgXr9+/bRz587HOsCmpHb16tXh+uqZbDczMq25PVj8+PHtsp07d1aDBg3siLOmtLVatWqOzDyzrS1atLBZexkzZrSDUQSX6QYzGYUmC27YsGH2/seOPXikRePrr7+2ZbumFPbIkSN2cAzzOKa/3/Pu2P6L+uHToJGGjSm/B5VPl6uZRc26ltYl3wD5nb/uuN1kY/w1db/On7xiG2bnLpJK3X6rJq+0IaXItd/NZ5PtZo/YpYs+AbbM1gTwGjQLGdUUMcOU0WZOkVYj182NsMw2dBaGybh7e2QPfVP3I/V59WMdvHBS9YZ8rt1njkTzVuNRvfRyUV30u6pBAxfJx8dfufOk16A/WjjKbc6dveiUhWM+UPbpPUPnz1+yXxayZkutb79vbNdjmHKQo0e9Naf9ZtuQO2nSBPbD6KhxbcJ9sUD0efmVYrp48ap+G7DAnuc8eTNoyNCWNtBqnA1znr0vXFbDBv0c06NHLreXEiVzaPTYdnZety8aamD/+fqm91T5+V21XwBff6O8WrYK+oKB6Hd4n4++bL3QMT1qwCb7t8orOdTuy4q66HtdF85fe6R1ftihrCYO/UdDf1xn+9wmSxlfNerl1hsfEJR3BcvXHrFZcsE69A46/62blFbb94MC6mfOX3EaZdDb55rqfzjRMT1yylZ7KVk4vcb1D/pBBq6j5stFdPHiNRtoM+0vTPbcb0OahXqfvvTI7WeafFDZvp9/02uGrly5oSLFsth1mvd1xIwaLxe253nIb0vsec6VJ50GDvkg0vPs7x+gb3rNtMsmThzPZvKNGN9S2bKndiyzesUeffXFdMd0t8+CSuQ/bFlNH7VmgEY83dwCTeM3IBqtOduD4/0Mq5C2t+O6W0uyUp5VgYM3OK7fuBv56L14+sX1qOW4fvveXzG6LYg6sd1rOq7v8fueQ/0My5e8s+N64NlBMbotiDpuaVs5rl+7/SeH+hmWIParjutXbgcN0ohnT6LYz2cf7aTfhnw+iU6XurvuZ146swIAAAAAAAAujnJaAAAAAAAAuBQGtgiPTDwAAAAAAADAxRHEAwAAAAAAgMtl4sXE5VGdPn1a77zzjlKkSKF48eKpYMGC2rJli6IC5bQAAAAAAADAI7p48aLKly+vKlWqaOHChUqZMqUOHjyoZMmSKSoQxAMAAAAAAIBLeRp64n3//ffKmDGjRo0a5ZiXNWvWKHs8ymkBAAAAAAAASTdv3pS/v7/TxcyLyJw5c1SiRAm9/vrrSpUqlYoWLaphw4ZF2XEkiAcAAAAAAABI6tu3r5IkSeJ0MfMicuTIEQ0ePFg5c+bUX3/9pZYtW6pdu3YaM2ZMlBxLymkBAAAAAADgUmKqnLZr167q0KGD0zxPT88Il713757NxOvTp4+dNpl4//77r4YMGaImTZo88W0jiAcAAAAAAAAoKGAXWdAurLRp0ypfvnxO8/LmzasZM2ZEybGknBYAAAAAAAB4RGZk2v379zvNO3DggDJnzqyoQBAPAAAAAAAAeESffvqpNmzYYMtpDx06pIkTJ2ro0KFq3bq1ogLltAAAAAAAAHApMdUT71GULFlSs2bNsn30evfuraxZs+rXX39V48aNFRUI4gEAAAAAAACPoXbt2vYSHSinBQAAAAAAAFwcmXgAAAAAAABwKU9DOW10IxMPAAAAAAAAcHFk4gEAAAAAAMCluLmRiRcWmXgAAAAAAACAiyMTDwAAAAAAAC6FnnjhkYkHAAAAAAAAuDiCeAAAAAAAAICLI4gHAAAAAAAAuDiCeAAAAAAAAICLY2ALAAAAAAAAuBQGtgiPTDwAAAAAAADAxZGJBwAAAAAAAJdCJl54ZOIBAAAAAAAALo4gHgAAAAAAAODiKKcFAAAAAACAS3En7SwcDgkAAAAAAADg4sjEAwAAAAAAgEvxcHOL6U1wOWTiAQAAAAAAAC6OIB4AAAAAAADg4gjiAQAAAAAAAC6OnngAAAAAAABwKR7u9MQLyy0wMDAw3FwAAAAAAAAghmQb8VqMPO6RZjPkqiinBQAAAAAAAFwc5bQAAAAAAABwKR5ulNOGRRAP0e5e4DKO+jPM3a2a43qq/nVidFsQdbzbzw2ZuL2QQ/0si/2y4+rWC9/E6KYg6hRL+YXj+vRD7TjUz7CGOQY4rt++91eMbguiTmz3mo7rl25O41A/w5J6vu64fsQ/5P8bz5ZsiXlvRhCCeAAAAAAAAHApHjSAC4dDAgAAAAAAALg4MvEAAAAAAADgUuiJFx6ZeAAAAAAAAICLI4gHAAAAAAAAuDiCeAAAAAAAAICLI4gHAAAAAAAAuDgGtgAAAAAAAIBLYWCL8MjEAwAAAAAAAFwcmXgAAAAAAABwKR7ubjG9CS6HTDwAAAAAAADAxRHEAwAAAAAAAFwc5bQAAAAAAABwKR5U04ZDJh4AAAAAAADg4sjEAwAAAAAAgEthYIvwyMQDAAAAAAAAXBxBPAAAAAAAAMDFEcQDAAAAAAAAXBxBPAAAAAAAAMDFMbAFAAAAAAAAXIqHm1tMb4LLIRMPAAAAAAAAcHFk4gEAAAAAAMCleLiTiRcWmXgAAAAAAACAiyMTDwAAAAAAAC7Fg0S8cMjEAwAAAAAAAFwcQTwAAAAAAADAxVFOCwAAAAAAAJfCwBbhkYkHAAAAAAAAuDiCeAAAAAAAAICLI4gHAAAAAAAAuDh64gEAAAAAAMCleLi5xfQmuBwy8QAAAAAAAAAX99xk4jVt2lSXLl3S7NmzY3pTAAAAAAAAcB9k4rlYEM8E1saMGRO0IbFiKXny5CpUqJAaNWpkb3N3j95EwcqVK2vVqlXq27evunTp4nRbrVq1tGDBAvXs2VO9evWSqyNoGTUmTFilkSOWyMfHX3nyZFD3L95QoUJZIl1+0aKtGtB/rk6f9lXmzKnUsVM9VapUwHG7Wc9PP87W2rV7deXKdZUokdOuM0uWVFG0B3iQz0o30mdl3naad9DvlMqPaxnpfVoUqaumhV5W+kQp5Rfgr7mH1unbtWN08+5txzJpEiRXjwpNVTVzccWL7amjl86q/ZL+2uF9iJMSgwIDAzXg94WaNn2D/K8EqFjRrOr15evKkjllpPf5Y9gSLV66U0eOeitu3NgqWiSLOn1aR9mypnYs0+OrKVq3/oC8L/grfvw4Klokq10me7aQZRA99m4/r3kTd+vIfj9d8g1Qhz6VVLJipkiXH/ztWq1eeCTc/PRZkujH8XXt9SWz9mvJ7APyOXvNTmfImkQNmhZSkbLpo3BPcD+rph7R7nXndeHUNcWO46FMeZOq5vu5lDJDgvveL+DqbS0Ze9DeN+DKbSVNFU+1WuRR7pJBrwHLJhzS8omHne7jlSGBPv2jAickBk2asFqjRi63n6Ny50mvbt0bqmChzBEue+jgWf02cIH27D6pM2f81LlLfb3bpIrTMnfv3tOg3xZq3tzN8vG5opSpEqtevdL6qGVNuVHKFaOmTd6gCaPXyNfnqnLmSqOOXWsrf8EMES4778+t+vrLmU7z4sSJpb+3hHx3u379pn7/dbFWLd8r/8vXlTZ9Mr35dlk1eKNUlO8LIrZr6xlNH7dNh/Z5y8/nur784WWVq5wt0sO1dvlhzZ/xrw4f8NHt23eVOVtyvfNhKRUv6/ze7uN9VSMHrteW9cd188YdpcuQRJ/2qKZc+fiehadbjGfivfTSSxo1apTu3r2r8+fPa9GiRWrfvr2mT5+uOXPm2OBedMqYMaNGjx7tFMQ7ffq0li1bprRp00brtsC1LFiwRd9/N0O9ejVSocJZNHbMcn3YfKAWLOylFCkShVt+29bD6tRxpD7t8KoqVy6gefO2qG2bPzR9RlflypXOBg/atP5DsWJ76PdBHylhgngaPXqZPvhggObN+1Lx43vGyH5C2utzXK/P+sJxKO7cuxfpYWmQu5K+KN9EnywdoM1n9ip7svQa8GJ7Ex1Sj79H2GWSeCbQvDf6ae2pXWr0Zy/5BvgrW9J0unzzKoc7hg0buUzjJqzWd982Vob0KdT/twVq9tEQLfizizw9Y0d4n01bDqtxowoqWCCT7t65p5/7z1ezFkM0/88ujv/b/Pkyqk6tEkqbNqkuX76ugYMWqVmLwVr2Vw95eNDJIjrdDLijTDmSqXKtHPq5+6oHLt+kfUk1+riY05f7Lk3nqUyVkABB8pTx7TJpMiSSAqXVCw/rx64r1XdkLWXMljTK9gWRO7rLT2VqZVL6XEl07+49LR5zUKO/2KL2Q8orTtyIP0veuX1Po77YogRJ4ujtbkWUOEVcXfIOUNwEzsunypxQH3xTwjHt7kF/npi0cMFW9ft+lnr0elOFCmXWuLGr9NGHgzR3wRcRfh4LuHFLGTKmUI2aRdTvu1kRrnPE8KWaMnmNvu37jnLkTKPd/57QF90mKmGieHrn3UrRsFeIyJJFu9T/h4Xq/GVd5S+YUZPHr1P7j0dr6pxPlDxFwgjvkyChp6bN+SRkRpgg7K8/LNQ/m47oq74NlTZdMm1cf0g/fDtXXikTqWKVvJyIGHAj4Lay5UqhGnXz6pvPFz5w+V3bzqho6Yxq0qqMEiby1JK5e9Wrw3z9MrqhcuQO+gHmiv8NdWw+U4WLp9fX/esoSdJ4On3ykhIm5vsVnn4x/k3C09NTadKkUfr06VWsWDF169ZNf/75pxYuXGiDaceOHbO/gG3fvt1xH1MWa+atXLnSTpsAYLNmzZQ1a1bFixdPuXPnVv/+/R9re2rXri0fHx+tXbvWMc9kC9aoUUOpUjlH7S9evKj33ntPyZIlU/z48fXyyy/r4MGDjtvN9idNmlTz5s2z22SWadiwoa5fv27XmSVLFnvfdu3a2X0IdvPmTXXq1MkekwQJEqh06dKOfQ293r/++kt58+ZVwoQJbTD07Nmz9naTKWjWb46jOU7Bx8pczHVz/IKZ42rmmeP8X7b5eTBm9HK9/np5NXitrHLkSKteXzVS3LhxNHPGugiXHztuhSpUyKdmzV5U9uxp1b59HeXNl1ETJwSdy2PHvLVjx1H17PmWChbMoqzZUqtnr7d088YtzZ+/JZr3DqHdDbwr7+uXHBe/G/6RHqCSafNo09m9mrl/lU5e8dbKE9s068BqFU2Ty7FM2xINdeaKj82823b+oE74n7fLHbt8jgMfg0wgfey41WrZooaqVy2oPLnTqV+fxvL2vqyly3ZFer8Rf3ysBvVKK2eOtMqTJ72++/ZtnTl7Ubv3nHIs8+br5VSyRHYbGDQBvU/a1tLZc5d0+rRfNO0dgpnsuDdbFFXJSpFn34UWP2EcJU0Rz3E5ss9X167cUqVa2R3LFK+QUUXLplfajImVNlNivflRUcWNF0uH9lzgwMeQpl+XULEX0yt15oRKmy2xGnYoqEsXbuj0ochfv/9Zctpm373zZVFlzpdMyVLHU9aCye39Q3N3d1Oi5J6Oiwn6IeaMHbNCDV8vp/oNyih7jrTq0esN+3ls1swNES5fsGBmdfqsnl6pVdxmZUVk+7ajqlK1oCpVzq/06U3Ar6jKlc+jXbuOR/He4H4mjV2rV18roTr1iitb9lTq8mVdxY0XW3Nn/xPpfcz3mhReiUIuYYJ9u7af0Ct1i6p4yWxKlz6Z6jcsqRy50mjPvyHv4YheJctnVpOWZVS+SuTZd6F93PEFvf5eMeXOn1rpMyVV09ZllS5jEm1cHfR91pg2ZptSpk6oDj2r2eXSpE+s4mUy2Ww8PF3Mb98xcXFlLrl5VatWVeHChTVzpnM6dGTu3bunDBkyaNq0adqzZ4969Ohhg4FTp0595MeOEyeOGjdubLMDg5nA1gcffBBhyeqWLVtsxuD69evtF8JXXnlFt2+HlNCZ4NeAAQM0efJkm2VoAmn169e3pbnmMm7cOP3xxx828zBYmzZt7PrMfXbu3KnXX3/dBulCBwjNen/88Ud7/9WrV+vEiRM28GeYv2+88YYjsGcu5cqVe+hj8Djb/Ky7deuOdu8+obLlcjvmmXLvsmXzaPv2oxHeZ8f2oypbLo/TvArl8zmWv33rjv0bOtvHrNN8wNz6j3PpDqJX1qTptLPZaG1uOkyDa3a0ZbKR2Xx2nwqnyq6iqXPa6cyJU6talhJaeiwkEFszaylt9z6k4a901u4Px2lZo1/1Tv4a0bIviNypU7664OOvcmVDAq6JEsVT4UKZtW1HyAfBB7lyNcD+TZIkfoS3m9KdmbM3KkOGFEqTliytp83KeYdUoERapUwTcdaHyfpat/SoLdXJmT/y1wpErxvXgj6LxU8YcUatsW+jtzLmSao5g/aqT+MV6t9qrVZOOaJ7dwOdlvM9c13fvbtSP36wWlN/2Gmz9RAzzGcnUxZbpqzz5zEzbT53Pa4iRbNq44YDOnbU207v23daW7ce0QsvkJkVU27fvqN9e8+oVJnsTue6ZOns2rXjZKT3C7h+S6/W/EF1XuynTu3G68ih8063FyySSX+v3Cfv8/72u9uWTUd08riPSpfNEaX7g6hz716gAq7fVqIkIVl2G/4+qpx5U+nbLov0Vo2Rat14ihbO2s1pwDMhxstpI5MnTx4bwHoYsWPH1ldffeWYNhl5JghmgngmmPWoTMDuhRdesNl8//zzjy5fvmwz9EL3wjMBNRO8Mxl7wQGyCRMm2HJcM3iGCbwZJqA3ePBgZc8e9AZkstpMEMyUDpsMunz58qlKlSpasWKF3nzzTRuMMwFE8zddunSOoJwJppn5ffr0cax3yJAhjvWawF/v3r3tdbNek5FoMvpMluOjetRtfh5cunjVllSlSOH867z5he/oUecPB8FMnxavMGUdZnkz38iaLY3SpkuuX37+U72+elvx4sXRmDHLde7cJV24cDkK9wb388+5A2q3+FcdvnRaqeMnU6fSjTSn4XeqOL6Nrt0O/8XNZOAlj5tYc1//Xm5yU2yPWBq9c4H6b57mWCZzkjRqWvBlDdk2W79unmYDft9WbqHb9+5oyt7lnJAYcsHniv0btvzKTAf/nz7Mj0h9vptle+nlyunccmHC5DX68ac5uh5wS1mzptKooS0VJ7bLvu0iAqY3z/aNZ9SmR/j+ZycOX1SPjxfp9q27NguvQ5/KypCVIK2rfKGbP3S/MudLqtRZwpdXBvM7F6BL5/1UuHJaNelVTL5nr9uAnnm/r/Z20Bf6DLmT6LVPC9jeelf8btr+eMM+36R2g8rLMz7/z9Ht4qVr//88Fv51O7LPYw+j+YfVde3qDdWp9a08PNx0926g2n1SS7XrlHwCW43HcenidXuuw5bNmunjR30ivE/mLF764qv6NrPu6tUbtpde8/eGatLMdkqdJigDq1PX2ur71Wwb5POI5S53Nzd161lPRUtk5UQ9pWaM36aAgNuqWD0kEHvutL/tm9fg7cJ68/3iOrDbW0N++tu2MXqxtnOSBVwbA1uE57KfPswvI4/SSPb333/XyJEjbfArICBAt27dUpEiRSJc1gTbPvroI8e0Kd01QbtgJgswZ86cNtPMBKrefffdcL359u7da+eZUtdgKVKksCWo5rZgphw1OBhmpE6d2pakmmBY6Hne3kG//O3atcuWqebKFZIZYpiAnFl/ZOs1/fqC1/FfPeo2R8Rsr7mELZ02FwSJHdtDAwe00BdfjFeZ0p1snyyT2fdCxfy2nxpixvLjISUae3TMBvW2fjBCr+aqoIm7l4Rbvlz6Avqk5OvqvGKItp7br6xJ0+qbSi3U4Zqfft40xS5jPiDuOH9IfdaNs9P/XjiiPCkyq0nBlwniRaM587ao51chGdp/DGrxn9f51TfTdfDQWU0c2z7cbXVrFVf5srl14YK/Roxerk86jdakce0j7bUH12N63Zny2pIVM4a7LV2mxPpuVC1dv3pbG1cetwNi9BhYg0CeC5g7eK/OH7+iFj+EfEaLSOC9QCVIGkf12ua3fe7S50wif9+b+nvGUUcQL3eJkOzKNFkT2aDeD++v1q6/z6lEzYib6+Pps2jhNtu7+Psf3lOOnGm1b+8pfd93plKlSqJX693/eQTXUbBwJnsJVqhwJr1Zr79mTd+sj9tUt/OmTtygf3ee0o8D3lGadEm1/Z9j+qHPXHmlSqRSZcjGe9qsWHRAE4ZtVs8fX1HS5PGdXt9NJp4ptTVMr7zjR3y1YOa/BPHw1HPZIJ4JhJmMuuARak1QL1joclXDlH2abLWffvpJZcuWVaJEifTDDz9o48aNEa67bt26TsE303suomw8Exg05bmbNm167P0wWYKhmcBkRPNMNodx9epVeXh42AxA8ze00EG0iNYR+hhF5GGO5eNsc0TMCL+hsyONp2Vk34gkTZbQBtl8fZ2zc3x9rsjLyzk7L5iZ7+N75b7L5y+QSbNmd9OVKwG2bCB58kR6841+dj5cg/+tazp86YyyJol4YJsuZd/RtH0rNGH3Yju91/e44seKqx+rtdEvm6YqUIE6f+2i9vs5l34c9Dup2jkevswd/13VKgVsqWzoMnnD1/eKUqUM6ZFipvPkfvAoo72/na6Vq/Zo/Ji2SpMmfAaWKc01FzPSbeHCmVWqXDctWbZTtV8pzul8Cpj3ylXzD+uFmlntL/dhmXlpMgS9nmfLk0JH9vpq0bR9av55mRjYWgSbM3iP9m+6oObfl1QSr7j3PTCmv53Jugo9UEXKjAl09eItO+hFrNjhu87ESxhbXunj26w9RL9kSRP8//NYmM9XvubzVeRZlw/y049/qnnz6rZvnmEGIDt75qKGD11CEC+GJE0W355rP1/nQcDMdHKviNsbRPQ6nStPWp064Wunb9y4rcEDluj7X99WhYpBJdlmxNsD+85qwui1BPGeMisXH1T/b1ao23c17UAXoSX3iq9M2ZI5zcuYJbnWLg8/+jzwtHHJnnjLly+3GWmvvfaaUqYM+gU0eNAGI/QgF0ZwSWurVq1UtGhR5ciRQ4cPR95TzAT5zDLBF1N6Gtbbb79tt6FAgQK2fDQsM6DEnTt3nAKFvr6+2r9/f4TLPyyz/SYTz2S5hd5Gc3mU0ljT2y/swBMPcyyflK5du9oy5NAXM+9pZfrU5c+fSRvW73fMM0HMDRv2q0iRiNPvCxfJqg3r9znNW7dub4TLmy/6JoBnBrv499/jqla1UBTsBR5HgthxlSVJGhuIi0i8WJ66F+gc0L77/+ngbGIz8EWOZM5BoWzJ0uuU/5PJnsXDSZggrjJnSum45MieRim9Emv9hpB+o6b8ZsfO4ypaOMt9gzsmgLdk2S6NGdlaGTOEZElHfqeg+wUHDuH69m47r3OnrqhK7YfLzLgXGKjbt5+vAZ9cifn/MgG8Peu99UGfEkqeJuIelaGZclsTjDPlt8F8T1+3wb2IAnjBox37nQ1aBtEvdpxYypc/o+1fF/rz2MYN++3nrsd1I+CW3NydK4BMcDf0cwPRK3bsWMqTN502bzzidK7NdMHC4bOjI2LKcQ8fPG9HnjXu3LlrL6ZCIty5DvNZDq5t5V8H9EvvZer87YsqVSH8Z7Z8hdPq1PGQwRyN0ycuKVWaxw/2A64ixjPxTMnluXPnbMDJ9Fwzvd9MFpfpQWdGfjXZaGXKlNF3331nM/NMcOuLL75wWocpfR07dqwdrdUsY/q3bd682V5/XGYEVhPsCpuBFvoxX331VX344Yd2kAcTGOzSpYvN6jPzH5cpozUDa5h9N5mFJqh34cIFLVu2TIUKFVKtWrUeaj2m/NUcDxNUNGW4SZIksYFA07PPZMN9++23OnDggH2MqPAsls42aVpVXbuMVYECmVWwUGY7OlpAwE3VbxCUpt2582ilTpVUHTrWs9PvvVtF7733i0aNXKpKlQtowfwtdnCMr3o3dqxz0aKtSp4soe2Nd+DAafX5dpqqVSus8hUePxCM/6ZXhQ/019FNNsCWJmFyfV7mbd29d0+zDqyyt/9W41Odveqrb9eNtdOLj27Sx0XradeFI9p67oAtp+1StrGdH/yB8I9tf2r+6/3UvuTrmnNgjR259t0CNdVp2W+crhhkgqzvvVtRg4cuVubMKZUhfXL1/22BLZ+qXq2gY7kmzX7Xi9UK6Z23X3CU0M5b8I8GDWiuBAk87eAYRqKEce0IiSdP+mjBom0qXy6PkidPaPtcDh2xVHE9Y6vSC/xvR7cb12/r3OmQrJ0LZ6/q2EE/JUzkKa80CTRpyFZdvBCgVl+Wd7rfivmHlCOflzKG+SXfMPcpUia9vFInsM201y45aoN+XX6uFi37hPBML7udq87akWY948Wy/euMuAliKbZnUCbltJ92KXEKT9VsGtSypNQrGbVh7gnN/2OfytbNJJ/T17Vy6hGVrROSDb9w+H7lKZ1SSVPFk7/vDS2bcNgGewpXijg7G1HvvSZV1L3reOUvkFEFCmbW+LErFRBwS/XqB1XZdO08TqlSJ9GnHeo6BsM4fDhoNHhT9XDe+7Itl40f31OZMgf9wF25SgEN+2Ox0qZNrhw502jvnlMaO3qFHQEXMafRe+XV+4sZypsvnfIVzKDJ49fZgGvtekEZk726TVfK1InVun3QYGHDhyxXgUIZlTFTCl3xv6Hxo//WubOXVLdBCXt7woRxVaxEFg38eZE848ZS2rRJtfWfY1o4d7vad3qZUx1DzGAkZ06G9AM/f8Zfh/dfUKIkcW3QbdRv6+V74Zo6fVXdUUL7U69l+rhjBTvyrJ/PNTvfnNMECYO+f9ZrVFgdm83U5FFbbK+8/bu97cAW7bpVjqG9BJ6hIJ4J2pl+bqa/nAmcmX50ZmTUJk2aOMo/Ta+7Zs2aqXjx4rbnXL9+/VSjRsjIjqa/3bZt2+wgC+ZLWaNGjWxWnul1918kTXr/BtVmoIn27dvbgKPpwVexYkU7emtkgb+HZdb7zTffqGPHjjp9+rS8vLxsINM8zsMywUUzqmyJEiVsia7p7Ve5cmVNmjRJLVu2tAHBkiVL2scJHoQD9/fKKyV00e+qBgycJ58L/sqbN4OGDmvjKI81ZRfubiG/3Bctll0//PiB+v86R7/8MkeZs6TUwN8+siUawS54X9b3300PKgNJmUSvvlpaLVvyISImpU2YQn+81EnJ4iaWb8BlbTyzR69M7STfgKBAjRmp1mTcBDN970zJbNey7yhNwhR2ucVHNjn63xnbzx9U0/l91L3ce+pY6i2d8D+vL1cN04z9QYFBxJwPP6hmv/z16DVF/lcCVLxYNg0f8pFT3zoTlLt4MaScZ9KUtfbvu+87B2H7ftNIDeqVVhzP2Nqy9YjGjFslf/8A23C9RInsmjS+fbhm7Ih6R/b56ut2If0sxw0M6ntZ8eVsatm9vC75BsjnfNAXgGDXr97SppUn9F77iJva+1+8oUHfrLX3jZ8gtjJlT2YDeIVKhry+I3ptWhDUsmB4l81O81/7pICKvRiUCX35QoBCJ+AkTRlPTb8uoQXD9mlg63U2wFeubmZVbBjyI/Bl3xua0m+nrvvfUoIkcZQ5fzJ9/HMZex0x4+VXitnX5N8GLLCDEOXJm0FDhrYM+Tx29qLcQ2XVeV+4rIYN+jmmR49cbi8lSubQ6LHt7LxuXzTUwP7z9U3vqfLzu6qUqRLr9TfKq2Wrl2JgDxHsxZcK6tLFaxo6aJl8fa4qV+60+nVwE6X4/2AX589dcjrXJnBnBq0wyyZKHE958qXTsLEtlC17Kscy3/R7U7/3X6yeXafJ/3KAHTX+47YvqsEbpTjwMeTg3gvq/PFsx/TQX4I+Z1WvlUcde1Wzg0x5nwv5Mc4E40yW5e/9VttLsODlDRPc+/KHlzX69/WaOHyL0qRLrI86VFDVl0NGtsbTwSNMljQkt8AHNVIDnrB7gcs4ps8wd7eQTJRU/evE6LYg6ni3nxsycfu//WACFxc75IeFrRe+idFNQdQpljKkymH6oaDABp5NDXMMcFy/fe+vGN0WRJ3Y7jUd1y/dnMahfoYl9QxJyDjiH/L/jWdLtsTP53tzg3lNYuRxZ9YeI1cV45l4AAAAAAAAQGgeYXpYwkUHtgAAAAAAAAAQgkw8AAAAAAAAuBQP0s7C4ZAAAAAAAAAALo4gHgAAAAAAAODiKKcFAAAAAACAS2Fgi/DIxAMAAAAAAABcHEE8AAAAAAAAwMURxAMAAAAAAABcHD3xAAAAAAAA4FI83N1iehNcDpl4AAAAAAAAgIsjiAcAAAAAAAC4OMppAQAAAAAA4FI83CinDYtMPAAAAAAAAMDFkYkHAAAAAAAAl+JB2lk4HBIAAAAAAADAxZGJBwAAAAAAAJdCT7zwyMQDAAAAAAAAXBxBPAAAAAAAAMDFEcQDAAAAAAAAXBxBPAAAAAAAAMDFMbAFAAAAAAAAXIqHW0xvgeshEw8AAAAAAABwcWTiAQAAAAAAwKW4u5GKFxaZeAAAAAAAAMB/8N1338nNzU2ffPKJogqZeAAAAAAAAHApT1NPvM2bN+uPP/5QoUKFovRxyMQDAAAAAAAAHsPVq1fVuHFjDRs2TMmSJVNUIogHAAAAAAAAPIbWrVurVq1aql69uqIa5bQAAAAAAABwKe4xVE578+ZNewnN09PTXsKaPHmytm7dastpowOZeAAAAAAAAICkvn37KkmSJE4XMy+skydPqn379powYYLixo0bLceOTDwAAAAAAABAUteuXdWhQwenYxFRFt4///wjb29vFStWzDHv7t27Wr16tX777Tebzefh4fFEjylBPAAAAAAAAECRl86GVa1aNe3atctp3vvvv688efKoc+fOTzyAZxDEAwAAAAAAgEvxiKGeeA8rUaJEKlCggNO8BAkSKEWKFOHmPyn0xAMAAAAAAABcHJl4AAAAAAAAwH+0cuVKRSWCeAAAAAAAAHAp7u4uXk8bA9wCAwMDY+KBAQAAAAAAgIh8vrZFjByYfuWHylWRiQcAAAAAAACX4uoDW8QEBrYAAAAAAAAAXByZeIh2gVrBUX+GuamK4zrn+vk4z5duTovRbUHUSur5uuP6+eujOdzPqNTxmzquH7vyW4xuC6JWlkRtHNf9b83gcD+jEsd5zXH9xt35MbotiFpxPWo5rh+/MojD/YzKnKiVnke0xAuPTDwAAAAAAADAxRHEAwAAAAAAAFwcQTwAAAAAAADAxRHEAwAAAAAAAFwcA1sAAAAAAADApXi4xfQWuB4y8QAAAAAAAAAXRyYeAAAAAAAAXIq7G6l4YZGJBwAAAAAAALg4gngAAAAAAACAi6OcFgAAAAAAAC6FgS3CIxMPAAAAAAAAcHFk4gEAAAAAAMCluDOuRThk4gEAAAAAAAAujiAeAAAAAAAA4OII4gEAAAAAAAAujp54AAAAAAAAcCkebjTFC4tMPAAAAAAAAMDFEcQDAAAAAAAAXBzltAAAAAAAAHAp7lTThkMmHgAAAAAAAODiyMQDAAAAAACAS/EgEy8cMvEAAAAAAAAAF0cmHgAAAAAAAFyKO2ln4XBIAAAAAAAAABdHEA8AAAAAAABwcQTxAAAAAAAAABdHEA8AAAAAAABwcQxsAQAAAAAAAJfi4eYW05vgcsjEAwAAAAAAAFwcmXgAAAAAAABwKe4k4oVDJh4AAAAAAADg4gjiAQAAAAAAAC6OcloAAAAAAAC4FA/KacMhEw8AAAAAAABwcU9dJl7Tpk01ZsyYcPNr1qypRYsWKUuWLDp+/LgmTZqkt956y2mZ/Pnza8+ePRo1apRdT2h9+/bVF198oe+++06fffbZQ23LoUOH9O2332rJkiW6cOGC0qVLpzJlyqhjx44qUaKEXMWOHTv05ZdfasOGDfL391eaNGlUunRpDRw4UKlSpdKxY8eUNWtWx/LJkydX8eLF9f333ytBggQqUqSIhg8frrffftuxzL1791ShQgW7z9OnT9fzYsKElRoxYrF8LvgrT54M+uLLN1WoUMixC2vRwn/Uv/8cnT7tq8xZUqlTp/qqVKmg4/bAwEANHDBX06atkb9/gIoVy66evRopS5bU0bRHiAjn+fkxbfIGTRi9Rr4+V5UzVxp17Fpb+QtmiHT5K/4BGjxwqVYu2y3/ywFKky6pPv38FZV/IfdjrxNRb+aUfzR5zEb5+V5V9lyp1L5zDeUrkC7S5adO2KQ/p23T+XP+SpI0nipXz6MWbSvL0zPoY9MbrwzSubOXw92v3hvF1KFrzSjdF0Rs19bTmjZuqw7uvSA/n2vq+eMrKlc5e6SHa83yQ5o3/V8dOXBBt2/fVeZsKfROi1IqUTbzY68T0WfqpPUaP/rvoNfZ3Gn0Wdc6yl8wY4TLzp39j3p/OcNpXpw4sbT2n96O6aGDlmrxwp06f/6yYsfyUJ586dWqXQ0VKBTxOhF9Jk9cozEjV8jH54py5U6nLt3rq2ChkP/T0GZMW6+5f27RoUPn7HS+fBnU9pNXnJa/fu2mfv1lnlYs+1eXL11T+vQp1OidF/TGW+WibZ/gbKd9rf1HB/d6//+1trbK3+e11tfnmob+sloH9nrrzMlLqvdWEbXsWCnccquXHtTowet1/qy/0mdMquZty6tUhci/t8E1MbDFM5KJ99JLL+ns2bNOFxO0C5YxY0YbqAvNBLDOnTtng1IRGTlypD7//HP792Fs2bLFBroOHDigP/74wwYHZ82apTx58tggXmRu376t6GSCi9WqVbOBub/++kt79+61x8YE365du+a07NKlS+2xNMtdvXpVL7/8sg3ymcBm27Zt7W3BfvrpJx05ckRDhgzR82LBgi36ru90tW5dWzNndVPuPBnUvNlA+fr6R7j81q2H1bHjCDVsWF6zZndX9WpF1Kb1EB04cNqxzPBhizVu3Ar16vW2pk7trHjx4th13rwZvc8ThOA8Pz+WLNql/j8sVLOPq2jMlFbKkTuN2n882gZ6InL79h21/Wi0zp65qL4/NdLUOZ+oW896Spkq8WOvE1Fv2V979PtPy9T0owoaPvED5ciVWp1aTdFFP+f3wGBLFu7W0AEr7fLjZn6ozj1f0fK/9mrYwJWOZYaOb6pZS9o6Lj8PDvrRsMqLeTilMeRGwG1ly+mlNp3Df5GLyK5tZ1SsdEZ93b+ufhv3lgqVSK+en87ToX0XHnudiB6LF+3Urz8sUPOPq2nc1NbKmSut2n406r6vswkSemrhiq6Oy5y/nH+wz5TZS591q6tJM9pr2NiPlC59MrX5aKQu+vHaHZMWLdymH7//Ux+1qqnJ0zsod550atliqHx9r0S4/JZNh/VyrWIaPqqVxk1sp9Rpkqrlh3/o/PlLjmV+7Pen1v29T32+b6xZ87qo8XsV9d23M7Vy+b/RuGcILeS1tvJDHZjbt+4qSbL4evuDUsqWM2WEy+zecUZ9ui/US6/m1+AJb9sfYHp1mqejh3w4+HjqPZVBPE9PT5tNFvqSLFkyx+2NGzfWqlWrdPLkScc8E5wz82PFCp98aJYNCAhQ7969babaunXr7vv4JnvKZPLlzJlTf//9t2rVqqXs2bPbjLWePXvqzz//tMuZDDc3NzdNmTJFlSpVUty4cTVhwgSbxWYeK0OGDHZfzP1MFmGwW7duqU2bNkqbNq29T+bMmW2mYPBj9+rVS5kyZbL3NcG4du3aRbqta9eu1eXLl20mXdGiRW3GXZUqVfTLL784Zd8ZKVKksMfSZBH++OOPOn/+vDZu3GgDeIULF9aHH35ol9u3b5969OihoUOHysvLS8+L0aOW6vU3yuu118opR450+uqrtxU3bmzNmBHx82Xc2OWq8EJ+NWteQ9mzp1X7T+oqX75MmjB+peNcjh27TB+3fFnVqhexQcHv+70vb+9LWrp0ezTvHYJxnp8fk8au1auvlVCdesWVLXsqdfmyruLGi22zNiIyd9ZW+V++rh9+bazCRTPbL3nFSmRVrtxpH3udiHpTx29S7QaF9cqrhZQlu5c6dn9JcePG0vzZOyNc/t8dp1SgSAa9+HJ+pU2XVKXKZlO1l/Jp7+6QH7KSJo+vFF4JHZd1fx+yv/IXKZ6JUxpDSpbPoqatyqp8lYfLlGvZsaLeaFJcufOnVvpMSfVB63JKlympNvx99LHXiegxcewa1XutpOrWN6+zqdW1x6uKGy+O5syK/HXWfB738krkuKTwSuR0+0u1iqh02RzKkDG5sudIrU8+e0XXrt7UwQNBGV2IGeNGr1KD18uoXoNSyp4jjb7o2dB+9p49c1OEy/f94R292ai88uRNr6zZUqvX12/q3r1Abdpw0LHM9m3HVKdeSZUslUPp0ydXwzfK2gy/f3ediMY9Q2ilymfR+63KqUKVHA91YNKkS6xWnSrpxdp5lSBhnAiXmT15u0qWzaw33iuuTFmTq2nLssqRJ5XmTN3BwcdT76kM4j1I6tSpbXltcNnt9evXbSDtgw8+iHD5ESNGqFGjRoodO7b9a6bvZ/v27dq9e7fNuHN3D38IkyZN6jTdpUsXtW/f3mbBme3q37+/zWQzgbKdO3faeXXr1tXBg0FvMAMGDNCcOXM0depU7d+/3wb+TJmwMWPGDBuAM9l/ZvnZs2erYMGQ8sywTFDuzp07NkvQBI0eVrx48RwBRfPBx2TvmYDlsGHDbADTlCqbbX5e3Lp1R7t3n1C5cnkd88y5L1sur7ZvOxLhfbZvP6JyZZ2zMspXyGfnG6dO+ejCBX+ndSZKFE+FCmeNdJ2IWpzn54fJqtu394xKlcnu9D9dsnR27doR8gNQaKtX7lPBwpnUr89cvVS5rxrVH6DRw1bq7t17j71ORC1TJnlg7zmVKB3yo5W7u5uKl86i3TtDsqJDK1A4gw7sOac9/56x02dOXdSGtYdVpkL2SB9jyYLdeuXVwvb9Ek8n80U/4NotJUrsGdObgvuwr7N7zOtsDqfXWfO6u2tH5EGYgOu3VKdGP9Wq/r06th2nw4fO3/cxZk3frISJ4jr9SIPodfvWHe3dc0plyuRyOtdlyubSzu3HHmodN27c0p07d5U4SXzHvCJFs2jVit02O898N9q08aCOH7ugsuVD2mLg6bdn51kVLeX8w1qJspm0dxeBeTz9nrqeeMa8efOUMGFCp3ndunWzl2AmYGeCbN27d7c924Iz5cIymXfm9vXr19vpd955Ry+88IINtIV9jGDBwTZTOvswPvnkEzVo0MAxbYJ3nTt3dvTsM73nVqxYoV9//VW///67Tpw4YbP8TM8584XAZOIFM7eZwFz16tVt0NFk5JUqVSrSxzY9+sxxMf3sPv74Y7ts1apV9d5779lgZ0QuXbqkr7/+2u5/8LrNNpjta968uc0gXLx4sZ4nFy9etV/UU6QIKZszvFIk0tEjEb8Z+Pj4K4VX+OXNfMME8IyI1hm8DKIX5/n5cenidfs/nTyF8+u8mT5+NOJSizOn/PTPpkuqWauQfhn0nk6d8FO/b+fozp17at6y6mOtE1Hrsj0ngUqWPH6Yc5JAJ475Rngfk4Fn7tfm/XEyP33dvXNPrzYsqnebRdwv6e8VB3T1yg29XCfyH9Tg+qaP26qAgNuq9GLOmN4U3Mf9XmePHQ0phQ4tc5aU+rJ3A+XIlcb+r44fs0bN3h2iKbM+Ueo0SRzL/b1qn7p/Nlk3btyWV8pE+m3oB0qaLOI2PIh6Fy9dC/rsHSZrMoX97O39UOv49ad5SpkqiQ38BevSvYF695yqGlV6K1Ysd/tdq2fvN1S8BBm3z5KLvtfDvfebLHo/34hbaQBPk6cyE8+Ug5psuNAXE6AKzZS4mr5uq1evtqW0kWXhmV56JsBnykUNE+gzASuTuWeYLDgTzAq+mGy0R8loM0IPcmGChmfOnFH58uWdljHTJlPPMJluZp9y585tS2VDB8xef/11W/qbLVs2W95qMuxMpp3Rp08fp201AT/DDL5h+gGa/nVmcA/z1wQgd+3a5bQN5cqVs/czpclmMAxzDEIH+t5//31b4mvKaxMndg48hXXz5k27r6EvZh4APK3uBZpgUAJ17VFPefOl14svFdT7H1bWzGkRl/Xg6bRty3GNH7neDlAxfOL7+uanBlq/5rDGDF0T4fLzZ+9Q6fLZ5ZXK+Ysmnh7LF+3X+GGb1L3vS/ZLHp4thYpkUq26xWw/teIls+mHXxorWbIE4V67S5TMpgnT22rEuI9UtnxOdes0iX6mT7ERw5Zp0YJt+mXA+/L0jO2YP2n839q547j6/95Mk6Z1UMfP66rP1zO1Yd2BGN1eABHzcHOLkYsreyqDeGZwihw5cjhdzMANoZned++++67tUWf6upl+eBExpbOmNNYsH3wxg1QED3BhSkZDBwtNQC5XrlyO3nAPu72PolixYjp69KjNhjMBuzfeeEMNGzZ0DNphSmwHDRpkS15btWqlihUr2gEzTCAz9Laafnmh+92ZAKDJAjTBQnObuR6aCdqZ4N3Fixd1+PBhvfLKK+G2LfgYPYjp4ZckSRKnS3Bfv6dRsmQJ5eHhHm4QCx/fK/IKk20XzMz39Yl8+ZQpg/4+yjoRtTjPz4+kyeLb/+mwjdDNdHKviLOwTR+lTJlT2PsFy5I1pR0d0ZRfPc46EbVM42sPDzdd9Lse5pxcC5fJE2zEoNWqUauAajcoouw5U6li1dxq0aaSxo9ab0suQzt35rL+2XhMteoF/RCIp8/Kvw7o16+Xq/t3L6lYaXoaurr7vc6aDK2HESu2hw3onTrpnI0bL34cZcyUwrZN+LL3a/Zx/py15YluPx5esqQJgj57+zgPYmEGtTDvx/djRrMdNXyZhgz/2Pa7C11eO+DXBerU+VVVrpLf3tao8Quq+XIRjRm9gtPzDEmWIn649/5LftdtJj7wtHsqg3gPy2TfmUErXn31VaeBL4KZTDQzyuzKlSudgl9m2pTXmiBdokSJnIKFJnBmsvXy5ctn+9qZQSoiKkeNjMlgMwE0M+BEaGbarDP0cm+++abtQWeCa6YXnp+fn73NbEOdOnVs77zgbTX7YgKZobc1smBbnDhxbPZh2NFpTYDQzA/b0+9xdO3a1Q6oEfpi5j2t4sSJpfz5M2n9+pDArTn3G9bvU5Gi2SK8T5Ei2bR+g3Ogd926vXa+kSGDlw3khV7n1asB2rnjaKTrRNTiPD8/YseOpTx502nzxiNO/9NmumDhjJFmc5w66ef0un/iuI8tuzLre5x1ImrFju2hXHnT2EBbyDkJ1NZNx5W/UPoI73Pjxh25uTv/Amv66BlhM/EXzNlpM7fKvvBwzbjhWlYsOqCfei9Vl29rqnQF58G+4Jrs62w+8zp7yPl1dsNhG3x7GKZE89DBcw8MBJnXCtOXDTEjdpxYypsvgzaGGpTCnGszXahIUK/wiIwasVxDhyzRoKEtlL+A83uvaX9heuS5u4V/jQ/7Iw2ebvkKpdW2zc79iLduPKm8BdPE2Dbh8ZiPYDFxcWVPZU88U5ZpykNDMwGrsCOl5s2bVz4+PoofP36kWXim55vJZAurZMmS9vYffvgh3G3BAz2YvnSmf57pu2fKU0357ty5c235qwkeRuazzz6zGYLBffrMukzw0JTuGj///LMtWzWjyZoGrtOmTbN98ExwbfTo0bp7965Kly5t92v8+PE2qBe6b17Y/oGTJ0+2/fdMBqH5AmK2ccGCBfZxo4oZOddcniVN36+uLp1Hq0CBzCpUKIvGjFmugIBbatAgqE9S589HKVXqpOrYsb6dfve9qnrv3Z80cuQSVa5UUPMXbNbuf4+rd+/GjufRe+9V05DBC5Ulcyqlz+ClAf3nKFWqpKpePXz/RnCe8WQ1eq+8en8xQ3nzpVO+ghk0efw63Qi4pdr1itvbe3WbrpSpE6t1+xp2+rU3S2na5I36+fsFeqNRGZ044avRw1fpzbfLPvQ6Ef3eeKeU+vaYp9z50ihvgXSaNnGz7X1mRqs1vv1iri2F/ahdZTtdrmIOO6JtrtyplbdgOp0+eVEjBq9WuYo5nbIwzRe+hX/u1Eu1C9q+SohZZuCCMycvO6bPnfbX4f0XlChJXKVKk0gjf1snH++r+rx3DUcJ7Y89l6plpxeUp0Bq+fkE/bDpGTeWEiT0fKh1Ima8/V4FfdV9uvLmz6D8BTNo0ri19vNYnXrF7O09u01TylSJ1eaTmnZ62OBlNsCXIWMKXb0SoHGj/9a5s5fsSOLB53nksBWqWDmv/VHG9N2bNnmDLnj7q1oNel3GpHebVtKXXSfZYFyBgpk0fuwqe67r1Q/q2d29y0SlSpVY7TvUttMjhy/ToIGL9N0P7yhduuTy+X//6fjxPRU/gacSJoyrEiWz6+cf58ozbmylTZdM/2w+rHlzttjsPMSM8K+1l///WuupVGkSa8Rva+VrX7+D/qcNc7u9b8BtXboYYKdjxXZX5mwp7Px6bxVRpxYzNH38VpWqkMVmXR/Yc17tu1WNgT0EnqynMoi3aNEiG+QKzfSPi6i81ZSRRsSMumoCYGaAiYi89tprNtPO9JkzA0iEZYJ/JovP9JszvelMsNBsk+krZwaAuB/T585kppmBN7y9vW0GnhmN1gxmYZjsv379+tkBNDw8PGxA0QTdTEDPBPK+++47dejQwQbzzMi0JigX2X6adZtgn3mskydP2sCaeZzhw4fbcmM8vFdeKSE/vysaOGCuHZQib94MGja8raP09cxZP6fsjWLFsuvHH5vp11/n6Jef/1SWLKn02+8fK1eukOyP5h/WUEDATfXoMUH+/tdVvHgOu87QvTsQvTjPzw/T0+7SxWsaOmiZLYk1oxD+OriJUvy/zPL8uUuODCwjdZqkGjCkiX7pt0CNG/6mlKkS6a3GZfXuBxUfep2IftVq5rNfykcO/tuW0ebInUo//v6Go6Tm/Dl/p9fu95qXl0nSGD5olS54X7Xleyaw92GbSk7r3bLxqL1vrXpBwUDErAN7vPX5x7Mc03/8EtTD8MXaedSp14s2SHfhXEgJ5sKZu21G1m/fr7KXYMHLP8w6ETNqvFRIl/yu6Y/fl9pSy1x50mrAkPcdAyCYAF3okaKv+N/Qt71m2WUTJY5ne5qOGPexsmUP6vvs7uFmB8WYP2ebff1OkjS+8uXPoKFjWih7jogHgUP0eOnlorrod9UG5sygb7nzpNegP1qEOtcXnd6np01eZ0cM7/jJGKf1fNyqhlq2ecle//7Hd9X/l/nq+vl4+V++rrTpkqtN+1f0+psRD16EqGdeaz/7eIZj+o9f/rZ/X6ydV5/1qmFfv73POZdVt2w80XH94F5vrVi0X6nTJtK4uUF98PMXTqeu376k0YPWadTv65QuY1L1+rG2suZwTvqB6/Nw8ay4mOAW+KijNAD/UaDoOfEsc1MVx3XO9fNxni/dnBaj24KoldTzdcf189dHc7ifUanjN3VcP3bltxjdFkStLInaOK773wr54oxnS+I4rzmu37g7P0a3BVErrkctx/XjVwZxuJ9RmRO10vNozN6Y2e8meV33f+mpzMQDAAAAAADAsytsD0s84wNbAAAAAAAAAM8CgngAAAAAAACAiyOIBwAAAAAAALg4gngAAAAAAACAi2NgCwAAAAAAALgUD8a1CIdMPAAAAAAAAMDFkYkHAAAAAAAAl+LuRipeWGTiAQAAAAAAAC6OIB4AAAAAAADg4iinBQAAAAAAgEuhnDY8MvEAAAAAAAAAF0cmHgAAAAAAAFwKmXjhkYkHAAAAAAAAuDiCeAAAAAAAAICLI4gHAAAAAAAAuDiCeAAAAAAAAICLY2ALAAAAAAAAuBR3N/LOwuKIAAAAAAAAAC6OTDwAAAAAAAC4FHc3t5jeBJdDJh4AAAAAAADg4sjEAwAAAAAAgEshEy88MvEAAAAAAAAAF0cQDwAAAAAAAHBxlNMCAAAAAADApVBOGx6ZeAAAAAAAAICLI4gHAAAAAAAAuDiCeAAAAAAAAICLoyceAAAAAAAAXIo7eWfhkIkHAAAAAAAAuDiCeAAAAAAAAICLo5wWAAAAAAAALsXdzS2mN8HlkIkHAAAAAAAAuDgy8QAAAAAAAOBSyMQLj0w8AAAAAAAAwMWRiQcAAAAAAACX4u5G3llYboGBgYHh5gIAAAAAAAAxZOnJrjHyuNUz9pWrIqwJAAAAAAAAuDiCeAAAAAAAAICLoyceol2gVnDUn2FuquK4fu3TF2N0WxB1EvyyxHH92u0/OdTPsASxX3Vc3+7TJ0a3BVGniFc3x3WfG+M51M8wr7jvhEwE8Pr9zIoX8tp9/c7cGN0URK34seo4ri8+0ZnD/Yyqken7mN4EuAiCeAAAAAAAAHAp7m5uMb0JLodyWgAAAAAAAMDFkYkHAAAAAAAAl0ImXnhk4gEAAAAAAAAujkw8AAAAAAAAuBQy8cIjEw8AAAAAAAB4RH379lXJkiWVKFEipUqVSvXq1dP+/fsVVQjiAQAAAAAAAI9o1apVat26tTZs2KAlS5bo9u3bqlGjhq5du6aoQDktAAAAAAAAXIq7m+vnnS1atMhpevTo0TYj759//lHFihWf+OMRxAMAAAAAAAAk3bx5015C8/T0tJcHuXz5sv2bPHnyKDmWrh/WBAAAAAAAAKKpz12SJEmcLmbeg9y7d0+ffPKJypcvrwIFCkTJtpGJBwAAAAAAAEjq2rWrOnTo4HQsHiYLz/TG+/fff7VmzZooO44E8QAAAAAAAOBS3OUWI4/r+ZCls6G1adNG8+bN0+rVq5UhQ4Yo2zaCeAAAAAAAAMAjCgwMVNu2bTVr1iytXLlSWbNmVVQiiAcAAAAAAAA8IlNCO3HiRP35559KlCiRzp07Z+ebPnrx4sXTk0YQDwAAAAAAAC7F3S1mymkfxeDBg+3fypUrO80fNWqUmjZtqieNIB4AAAAAAADwGOW00YkgHgAAAAAAAFyKu5t7TG+Cy+GIAAAAAAAAAC6OTDwAAAAAAAC4lKehJ150IxMPAAAAAAAAcHEE8QAAAAAAAAAXRxAPAAAAAAAAeFZ74u3Zs0cnTpzQrVu3nObXrVv3SWwXAAAAAAAAgMcN4h05ckT169fXrl275ObmpsDAQDvfXDfu3r37qKsEAAAAAAAAHBjY4gmU07Zv315Zs2aVt7e34sePr927d2v16tUqUaKEVq5c+airAwAAAAAAAPCkM/HWr1+v5cuXy8vLS+7u7vZSoUIF9e3bV+3atdO2bdsedZUAAAAAAACAg7sbwziE9chHxJTLJkqUyF43gbwzZ87Y65kzZ9b+/fsfdXUAAAAAAAAAnnQmXoECBbRjxw5bUlu6dGn169dPceLE0dChQ5UtW7ZHXR0AAAAAAADghJ54TyCI98UXX+jatWv2eu/evVW7dm298MILSpEihaZMmfKoqwMAAAAAAADwpIN4NWvWdFzPkSOH9u3bJz8/PyVLlswxQi0AAAAAAACAGAziRSR58uRPYjUAAAAAAACA3EWi2H8O4plS2u+++07Lli2Tt7e37t2753T7kSNHHnWVAAAAAAAAAJ5kEK958+ZatWqV3n33XaVNm5YS2ueAKZOeNWuW6tWrF9ObAgAAAAAA8Fx65CDewoULNX/+fJUvX15RrWnTphozZkyEffkWLVqkLFmy6Pjx45o0aZLeeustp2Xy58+vPXv2aNSoUXY9ofXt29cO0GEyCj/77LOH2pZDhw7p22+/1ZIlS3ThwgWlS5dOZcqUUceOHVWiRAnFpF69eumrr7667zKBgYHRtj3PsgkTVmrEiMXyueCvPHky6Isv31ShQlkjXX7Rwn/Uv/8cnT7tq8xZUqlTp/qqVKmg03kZOGCupk1bI3//ABUrll09ezVSliypo2mP8DDivN5escvV1s1Zg3Rn9axIl3PPVlCxq74u9wy55J4khW6M6Km7/64Lt5xbqkyKU6e5PLIXktzdde/8Cd0c9ZUCL13ghESzKZPWaeyoVfL1uaJcudPq826vqkDBTA+8318Ltqvr5xNVuWp+/TygiWP+siW7NGPqBu3dc1qXL1/XpOmfKHeedFG8F7ifPdvPae7E3Tq6z1cXfQPUqW8VlawY+Tke9M0arVp4ONz8DFmS6KcJIT9m/TVjn+ZO/FeX/AKUOUdyvf9pKeXIl5KTEcNmTN6siWPWy8/nqnLkSq1Pu7ykfAXTR7hsm2ZjtW3L8XDzy76QQz/+1sheL1/46wjv2+rTamrctNwT3no8CvMZasDgxZo2c5P8rwSoWJEs6tWtvrJkfrj/w6EjV+inAQv13tsV1P3zuhGu/8M2I/X32v36/ef3VL1qAU5QDJgyca3GjFrpeJ/u3K2+ChSK+DXcvAePGLZMJ0/46M6du8qUKaXebVpJtesWdyxj1tP/5/lav+6ArprnTfFs+rx7PWV+yOcNnqzFkw5ox5ozOn/yqmJ7uitrvuR6tXl+pc6YKNL7rF1wTJuWnNTZY/52OmPOpKrzQT5lyZPMsczNgDv6c/hu7Vp3Vtf8bylFmgSqVC+bKtSJ/Hsb8LRwf9Q7mAEsorMH3ksvvaSzZ886XUzQLljGjBltoC60DRs26Ny5c0qQIEGE6xw5cqQ+//xz+/dhbNmyRcWLF9eBAwf0xx9/2OCgyUzLkyePDeJF5vbt24oOnTp1cjo+GTJksCMHh56H/27Bgi36ru90tW5dWzNndVPuPBnUvNlA+foGvYGEtXXrYXXsOEING5bXrNndVb1aEbVpPUQHDpx2LDN82GKNG7dCvXq9ralTOytevDh2nTdvRs9zBw/mUbC83DPn1b1LPg9c1i1OXN07fUS3ZgyMfJkUaRWv3S+6531CN37vqIAfPtLtxRMUeIdzHt3+WrhdP/ebqxYtq2vitPbKmTutWn80Qn6+V+97vzOn/fTLT/NVtHj4D4IBAbdUpFgWtfv05SjccjwK80E+c45k+qBj6YdavuknpfTHnDccl0GzGiphYk+VqZrFscy6pUc1duBmvfZBYX03so5df58OS3X5YgAnJwYtXbRbA39cog8+qqiRkz9Ujtyp1aHlRF30vRbh8n1+fl1zln3quIyb8ZE8PNxU5cV8jmVC324u3b6qIzOOW+XqeaNxzxCRYaNXatzEterVvYGmjmtrP0M1azXioT5D7fz3pCZP36DcudJGusyY8X/TickF3qd/6jdHH7V6UROnfaJcudOp1UfD5Od7JcLlkySJp+YtqmnMhLaaOrOjXq1fUr2+mKJ1a/Y7ArOfthutU6d89evAppo0/VOlTZdMHzf7QwHXb0bz3sE4tNNHL9TNqo4DKqr1d+V1906gfu+yzr53R+bQDh8Vr5Je7X4orw79KypZynga1GWtLvmEvAfPHLJLe7d4670uxdV9RDVVbpBd037baYN6eLq4u7nFyOWZCuJ9/fXX6tGjh65fv67o4OnpqTRp0jhdTCAxWOPGjW1578mTJx3zTHDOzI8VK3yioVk2ICDABrn8/f21bl34LJnQzIu9yeTLmTOn/v77b9WqVUvZs2dXkSJF1LNnT/355592uWPHjtmy0ylTpqhSpUqKGzeuJkyYYHsGmscygTWzL+Z+Josw2K1bt9SmTRtbmmzukzlzZpspGPzYJssuU6ZM9r4m+69du3bhtjFhwoROx8fDw0OJEiVyTJtg4htvvKGkSZPaAOyrr75qtzc0c8xM9qJ5HLMtZptC8/HxUf369RU/fnx7LObMmaPnzehRS/X6G+X12mvllCNHOn311duKGze2ZsyI+Dk0buxyVXghv5o1r6Hs2dOq/Sd1lS9fJk0Yv9JxfseOXaaPW76satWL2KDg9/3el7f3JS1duj2a9w4RcUuSQnEatNbN8X2le5F/mAh2d99m3V44Wnd3rY10mTivvK+7ezfp9tzhunf6sAJ9z+ru7vXS1UuchGg2Yezfqt+wtP2Qny17anXv0cD+T/85a3Ok97l79566d56kj1u9qAwZwv+gZX7tb9HyRZUumzOKtx4Pq2jZDHqrRTGVqpT5oZaPnzCOkqaI57gc2eera1duqnKtHI5l5k/Zo2p1cqpKrZzKkDWpmn9WVnE8PbRi3iFOTAyaMm6D6jQoqlr1iihr9pT67Ita8owbW/NmR/yemjhJPKXwSui4bN5w1C5f9cWQAF3o283l75X7VaxkFqXPEPJZFNHPfoaasEYtP6ym6lXyK0+utOr39ZvyvuCvpSt23/e+167f1GfdJumbHg2VJFG8CJfZu++MRo77W32+eiOK9gAPY/yYVWpg36dLKXuONOre8zX7Pj17ZsTv0yVK5VDV6gXte3rGTF56+90XlDNXWm3betTefuK4j3btOK7uPV5T/oKZlCVrKnXr0cAGfhcu4LN3TGjVt5zK1MystFkSK0P2JHrns2K66B2gkwcj/1zcpGsJVaybTRlyJFWaTIn0doeiMkVn+7eFVLQc3eOn0i9mVM7CKW0WXvlaWZQ+e2Id338xmvYMiOEgXtGiRVWsWDF7+fnnn/XXX38pderUKliwoGN+8CW6me0w5bXBZbcmuGgCaR988EGEy48YMUKNGjVS7Nix7V8zfT/bt2/X7t27bcadu3v4w2UCY6F16dJF7du31969e+129e/fXz/99JN+/PFH7dy5086rW7euDh48aJcfMGCADYhNnTpV+/fvt4E/UyZszJgxQ7/88ovN/jPLz5492x7zR2ECeOYxTVDPBCHXrl1rg34mw9EEEI3BgwerdevWatGihXbt2mW3J0eOkC8rhinXNYFAsw+vvPKKDZL6+fnpeXHr1h3t3n1C5cqFfLA3z4ey5fJq+7aIB3PZvv2IypXN4zSvfIV8dr5x6pSPLlzwd1pnokTxVKhw1kjXiWjk5ibPxp11e8U0BZ47/sTW6ZGvtO55n5LnR30Vv/dUxf1kgDwKUJIV3W7fvmNLXkuXyeH0P126TE7t3BH5+R46eKmSJ0+oeq+ViqYtRUxbPu+gCpZIq5RpEtrpO7fv6sh+XxUsGVIm7e7upoIl0ungv5TEx5Tbt+9q/96zKlkmq9N5KVEmq/7deeqh1jFv1jZVfym/4sWPE+HtJkt33d+HVLt+kSe23Xg8p0776YLPFZUrndPpM1Thghm17T6v4UbvPrNV6YU8Klcm4h9bTEZ1x24T1aNrPaX0irykD1Hr9q3/v0+XzfVI79OhA70bNxzUsWPeKl4im+PzvBEnTiyndZrp7f8P9CFm3bgWlEkbP1HEr8MRuXXzju7euacEoe5jynJ3rT9ns/PMc+HA9gvyPnVNeYqnipLtBlyuJ15MDmgwb948G3QKrVu3bvYSzATsTJCte/fumj59uiNTLiyTeWduX79+vZ1+55139MILL9hAW9jHCBYcbDOlsw/jk08+UYMGDRzTJnjXuXNnR8++77//XitWrNCvv/6q33//XSdOnLCZbRUqVLCZfCYTL5i5zWTSVa9e3QYdTUZeqVKP9sXRBDRNNuDw4cMdg5CY8mMTfFy5cqVq1Kihb775xh4/E3wMVrJkSaf1mGxEE/Q0+vTpY4OPmzZtssHA58HFi1dtBk6KFImd5nulSKSjR85FeB8fH3+l8Aq/vJlvmACeEdE6g5dBzIld9U3p3r379sB7VG4Jk8otbnzFrvambi0cbbPxPPKWkOf7PXVj0Ge6d3jnE3ss3N+li9fs/3TyFM5f0JKnSKhjR70jvI/5Jd9k6Zk+d3g++F24ru0bTqtdz4qOef6Xbure3UAlSR7XaVkzfebE5RjYShiXLl7X3buB9n84tOQpEujE0Qe3Q9iz67SOHLqgrr3qRLrMwjk7FT9+HFWqRiltTDMBPCNFmPOdInki+URSamnMX7Rde/ad1vQJbSNdpu+Pc1W0cGab4YeYc/FS8Pt0mHOcIlGk79PGlSsBqlnla/tjnQnQdf2ygcqUCwoEmsy7NGmTauCvC/RFz4a2BHv82NU6f+6y7XeNmHXvXqBmDN6lbPmTK11W5+9H9/Pn8D1KkiKuchcL6WvYsHUhTf51u75s9JfcPdzsjzpvfVpEOQp5RdHWI6q4uz1y8egz76GCeKZsNKZUqVLFZoqFFrYnnylx/eijj7R69WpbFhpZFp7ppWcCfIULF7bTJtBngmYm0NWsWTObBWfWE3oQj0cdECL0IBcmaHjmzJlwg4CY6R07djiCYy+++KJy585tA2K1a9e2gTXj9ddft8G+bNmy2dtMBlydOnVsmbAJpJlLMNOnzwT5wjKPYwblMJl4od24cUOHDx+Wt7e33cZq1ardd78KFSrkuG56DSZOnNjeNzI3b960l9BMqa65AK7Go1hVeb4REpi5MewLxapYXzd+avVkH+j/b0J3/12vO6tm2uv3zhyWe5b8QQNnEMRzWdeu3dCXXSfry16vKVmyiPut4tljBrhIkDCOSlbMGNObgig2b9Z2Zc+ZKtJBMOwys7erxisF5en5yOPC4T+aM3+ren4T9L5p/DHw/Udex9lzl/RtvzkaOeRDeXrGjnCZZSt3a8OmQ5o1hR9rnlYJEnhq8owOtsfdxo0HbU890/7ClNrGju2hn/o31VdfTlWlcj3k4RGU2Vf+hTwMAugCpg3cYQer+OSXkB/OHmTx5APauvKU2v1YQbHjeDjmr/7ziI7tvagWvUsreer4OrTTV9MG7rTBvjzFyMbD0+2xP4WYwR5MyaiRL18+O/BDVDABo7ClnWGZoNa7775rg40bN260g05ExJTOmtLY0L3yTJaaCfyZIJ4pcy1dOqTxdfr06bVv3z573fw1ZcUPs72PwpQgHz161AYMly5daktWTeadyRg0g3aYElsz34yK26pVK/3www+2r9/HH39slw1m+uVF5OrVq/bcmABlWClTpoywRDgiJhMwNJPVZ45dZExfv7Aj5przY3r8PY2SJUto3+jDDmJhfu31CpNtF8zM9/WJfPmUKYP+mnWmSpXEaZm8eTJEwV4gMqYnXcCPQf/rRqzCFW3WXLweIf83bh4eivPqR4pdqYECvn73sQ5m4LXLCrx7R/fOO5eBmNFpPbIx6l10Sposgf2fDtsc25TLpYigfOrUST+dOX1Rn7QZ7fSLsVGycBfNnPuZMmZKEQ1bjuhifsRbOf+gXqiZTbFih3wxSJzU0/6qf9nvhtPyZjpp8oj7ayHqJU0W3w5KEXZgGj/fa0ruFXG1RbCA67e09K/dat6qUqTLbN96QieO+ap3v5BqC0SfqpXzqXCokcODyyJ9fa8q1f8/T9lpvyvKkyviz8S795ySr99VNWjU3zHPZHpt3npUE6as065NfbRh02GdOOWnki84JzC07TROJYpm1bgRH0fB3iEiyZIGv087/0/7+l4JV+kSmvlukylzULZV7rzpdfSIt0YOW26DeEa+/Bk0ZWYHm7FnyvBNi4x33+qvfPn5sSYmTR24Q/9uPK/2P1WwA1U8jGXTDmrp5ANq8315pc8W8l3q1s27mjtyj5r3Kq0CpdPYeeb204cva/m0QwTxnjKuPsjEUxHEO3XqlC2rNL3VgvvBXbp0SeXKldPkyZPtAA4xwWTfmdLVN99802ngi2Cm15sJPJoS0tCZfKavW+XKlW2QzpTMhs1YM9l6Jkhp+tqZdYcNepl9D9sXL5jJVjPBNXOszGAXwcx06LJYs5xZt7k0bNjQZt2Z7TLbGS9ePJt9Zy6mb53ZRrMvJvj3MKMEm+VMpmGqVKns40TE9OBbtmyZzXp8Urp27aoOHTo4zXuas/BMr4z8+TNp/fp9ql49qFTbBDE3rN+nxu9UjvA+RYpk0/oN+9SkaUiW47p1e+18I0MGLxvIM+vMmzfog8PVqwHaueOoGjV6+F+g8ATcDFDgzZARrW6vn687uzc4LRL3o766889S3dn41+M/jgngndgv91TOHxTdU6ZXoN/5x18vHlns2LGUN196bdp4SFWqFXD8T5vpNxuF71GYJWtKTZ3l/Jo2aOBfunbtpj7rUldp0oZ8eMSzYc+28zp36oqq1HHum2UCetlyp9CuLWdVsmImR0D333/OquZrD9d6A0+eybDJnTettmw8popV8zjOyz8bj+q1t5xbhIS1fMle23+rZq2C9+2XlztfWuXMHfSFENErYYK49hI6yG761a3fdFB58wQF7a5evaEdu06q0etlI1xHmdI5NHe68+t41x5TlS1rKn34fmUbMGrxQRW93sC5dU2dhj+ra6c6qlIpZNRiRL3YcYLep01fu/Dv085VTvcTeC9Qt26HH5zM9FA0jh+/oD27T6lV2+ejRZCrMf/LZtTYnWvP2mw6r7QPlxCzdMpB/TVxvx0YI1Nu5+/+pj+eGeU2uJVUMPMDnHk+AM9dEK958+Z2sASThWdKQA2TLfb+++/b20KPvPokmJLMc+ece46ZTDovL+d69rx589oRVM3oqZFl4ZnAWcWK4YMjpv+bud1kuYVl/vlNDzmTHWf655m+eyaQZjLc5s6dq8WLF9vMuMh89tlnNgMtuE+fWZcZLCM4M84MFGJGgzVZfiZAOG3aNNsHzwQGR48erbt379rsQLNf48ePt0G90H3zHsQMQGH2y4xIGzxK7vHjxzVz5kx9/vnndtpkx5nMPhPoe/nll3XlyhUbaGzbNvJ+IQ/yLJbONn2/urp0Hq0CBTKrUKEsGjNmuW1+3KBB0Bf+zp+PUqrUSdWxY307/e57VfXeuz9p5MglqlypoOYv2Kzd/x5X796NHc+t996rpiGDFypL5lRKn8FLA/rPUapUSR2BQsSQ61cUeD1MT517dxTo76fACyEN0uO27Kc7u9bqzpqgUaoVJ67cvUJKsdxSpJF7uuwKvO6vwEtBDe/NQBme73VXrMM7dffQDnnkKSmP/GV14/eO0bRzCNb4vRfUs/tU+6t8/gIZNXH8Gvs/XbdeUFsEUz5rsmTbfvqyLb3KkdP5y3uiREFfKEPPv3z5us6dvaQL3kG90YL79pjsPi8apMeIG9dv22BcMO8zV3TsgJ8SJo4jrzQJNXHwP/Lzua42X77gdL8V8w4qRz4vZcoW/ofBWm/m06Bv1yh7nhTKns9LC6bu1c0bd5xGsEX0e/PdMvr2yz+VJ39a5SuQTlPHb9KNgNuqVS+ojcrX3WfLK1UitWxfLVyA7oUquZUkacSfIa9dvakVi/eqTccXo2U/8GD2M1TjCho8bLkyZ/JShvTJ1f/3xTYrL3QvuyYthurFqvn1zlvlbRAwVw7n1/H48eIoaZL4jvkmMBjRYBbp0iRVxvQP/vEcT9Y7TSqpR7fJ9n26QMFMmjjub/s+bUaVN77oOsm+T7f79BU7PWLYMuXPn1EZMqaw2Zpr/t6r+XP/UdcvX3Osc8lfO2xbjDRpk+ngwbP6oe+fqly1gMqWD/pei+g1deBO/bP8pD78qozixo8l//9nucdNENuO+m6M/f4fJfWKq7rNgv63l0w+oAVj96lJ1+JKkSa+4z6e8WLZS7wEsZWjUAr9OexfxfF0V7JUppzWR5uWnFD9jx9tkEjEPDd64v33IJ4JWK1bt84RwDPM9YEDB9og15NmgoImyBWaebzgMtfQUqSIuJTJjMJqAmBmgImIvPbaazbTzvSYC1s2apjgn8ni+/bbb/Xhhx/aYKHZJpN9aHrW3U+7du10+fJlO3CE6SFnsvrM6K9mMAvDZP7169fPDqDh4eFhA4oLFiywAT0TyPvuu+9sRpsJ5pmRaU3gMLL9jIgJ/plegWbfzYAbJkBnyoRND7zgzLwmTZrYHnlmJNxOnTrZAKnJCISzV14pIT+/Kxo4YK4dlCJv3gwaNrytozz2zFk/ubmH/OJTrFh2/fhjM/366xz98vOfypIllX77/WPlyhUS5Gn+YQ0FBNxUjx4T5O9/XcWL57DrjKxXC1yLm1dauSUIyXB1z5hL8dr85Jj2rNfS/r29abFuTQr6keDurrW6Na2/YldvpDj1W+vehVO6Ofor3Tu6Owb24PlW8+Uiunjxmgb/tli+PleUO086/TakmaOc1gTjTCPkR7FqxR71+mKqY7rrZxPt3xYtq+vj1kH9ThG9Du/zVe+2IRm0YwdusX8rvZxdrb6ooEu+AfI9f83pPtev3tLGlcfV9JOIB5MqVz2r/C/d0NTh23XJL0BZciZX15+qU04bw8zIsmaAi+GDVsnP56py5k6tnwa97WiMf/6cv9P7tHH8mI92bjupX4YE/cAWkaWLditQgXrxZQY6cCUfNq1sAzo9vp4h/ys3VLxoFg0f1MzpM9TJk772dR5P8fu031UN/u0vx/v07380D/U+fdGp1O7G9Vvq8/VMeZ+/ZJ8HWbKl0jffvW3XE8x8hjd98nx9rsorZSLVrltCLT6uHiP7B2nN3KBRgQd0WuN0OBp3KqoyNYMSVy56X1fopLo1847qzu17GtF7s9N9Xn43t155L2jgofe7l9ScEXs0pu8/un7llpKljq/a7+dThdpZOOx46rkFPuLIDbly5bIBsbCjpJqRSt9++207iAJwP4FawQF6hrkppCz72qdkLTyrEvyyxHH92u3/ZyLimZQg9quO69t9QgZUwrOliFc3x3WfG+NjdFsQtbzivhMyEcDr9zMrXshr9/U7c2N0UxC14scKGVV78YmIk1bw9KuR6Xs9jw5e/jlGHjdnEuf2C67kkcfrNaWZpszSZKYFM9fbt29ve9IBAAAAAAAAiOFy2qZNm+r69eu2T1vwKK937tyx183gEuYSzAzOAAAAAAAAACCag3gP6gEHAAAAAAAA/Bfuj148+sx75CCeGQQBAAAAAAAAgIsF8fz9/R96hcEjngIAAAAAAACPw82NTLzHCuIlTZpUbqHHdY6AGeTWLHP37t2HWSUAAAAAAACAJxnEW7FixUOtbNeuXQ/7uAAAAAAAAACeZBCvUqVKkd525coVTZo0ScOHD9c///yjNm3aPOxjAwAAAAAAAOG4U04bzmMXGK9evdoOcpE2bVr9+OOPqlq1qjZs2PC4qwMAAAAAAADwJEanPXfunEaPHq0RI0bYwS7eeOMN3bx5U7Nnz1a+fPkeZVUAAAAAAABAhNweP+/smfXQR6ROnTrKnTu3du7cqV9//VVnzpzRwIEDo3brAAAAAAAAADx8Jt7ChQvVrl07tWzZUjlz5uTQAQAAAAAAAK6WibdmzRo7iEXx4sVVunRp/fbbb/Lx8YnarQMAAAAAAADw8EG8MmXKaNiwYTp79qw++ugjTZ48WenSpdO9e/e0ZMkSG+ADAAAAAAAA8OQ9cpfABAkS6IMPPrCZebt27VLHjh313XffKVWqVKpbt24UbCIAAAAAAACeJ+5u7jFycWX/aevMQBf9+vXTqVOnNGnSpCe3VQAAAAAAAAAefWCL+/Hw8FC9evXsBQAAAAAAAPgv3P5b3tkziSMCAAAAAAAAPA+ZeAAAAAAAAMCT4ur96WICRwQAAAAAAABwcWTiAQAAAAAAwKW4kYkXDpl4AAAAAAAAgIsjiAcAAAAAAAC4OIJ4AAAAAAAAgIsjiAcAAAAAAAC4OAa2AAAAAAAAgEtxJ+8sHDLxAAAAAAAAABdHJh4AAAAAAABcipsbeWdhcUQAAAAAAAAAF0cQDwAAAAAAAHBxlNMCAAAAAADApbhTThsOmXgAAAAAAACAiyMTDwAAAAAAAC7FTR4xvQkuh0w8AAAAAAAAwMURxAMAAAAAAABcHEE8AAAAAAAAwMW5BQYGBsb0RgAAAAAAAADBfG9MipGDkSJuI5c9CQxsAQAAAAAAAJfi7kbxaFgcEQAAAAAAAMDFkYmHaHfq6lCO+jMsQ8IWjuuvz28ao9uCqDOt1mjH9UCt4FA/w9xUxXE98MLwGN0WRB23lM0d1w9c+pFD/QzLlbST43rg6QExui2IOm7p2zmuLzr+OYf6GfZS5n6O62evj4zRbUHUSRv/g+fy8LqRdxYOmXgAAAAAAACAiyMTDwAAAAAAAC6FnnjhkYkHAAAAAAAAuDiCeAAAAAAAAICLo5wWAAAAAAAALsXNjbyzsDgiAAAAAAAAgIsjiAcAAAAAAAC4OIJ4AAAAAAAAgIujJx4AAAAAAABcijt5ZxEcEwAAAAAAAAAujUw8AAAAAAAAuBRGpw2PTDwAAAAAAADAxRHEAwAAAAAAAFwc5bQAAAAAAABwKe5u5J2FxREBAAAAAAAAXBxBPAAAAAAAAMDFEcQDAAAAAAAAXBw98QAAAAAAAOBS3Mg7C4dMPAAAAAAAAMDFEcQDAAAAAAAAXBzltAAAAAAAAHAp7m7knYXFEQEAAAAAAABcHJl4AAAAAAAAcCkMbBEemXgAAAAAAACAiyMTDwAAAAAAAC6FnnjhkYkHAAAAAAAAuDiCeAAAAAAAAICLI4gHAAAAAAAAPIbff/9dWbJkUdy4cVW6dGlt2rRJUYUgHgAAAAAAAPCIpkyZog4dOqhnz57aunWrChcurJo1a8rb21tRgSAeAAAAAAAAXIqbm3uMXB7Fzz//rA8//FDvv/++8uXLpyFDhih+/PgaOXKkogJBPAAAAAAAAEDSzZs35e/v73Qx88K6deuW/vnnH1WvXj0kyObubqfXr18fJceSIB4AAAAAAABciltgzFz69u2rJEmSOF3MvLB8fHx09+5dpU6d2mm+mT537lyUHJNYUbJWAAAAAAAA4CnTtWtX2+cuNE9PT7kCMvGeQ2bUlF9//TWmNwMAAAAAAMCleHp6KnHixE6XiIJ4Xl5e8vDw0Pnz553mm+k0adI8H5l4TZs21ZgxY/TRRx/ZhoChtW7dWoMGDVKTJk00evRoxXQg7Pjx4/Z6vHjxlD17drVv317NmzeXq9u8ebMSJEgQ05vx1Nm59ZSmjN2sg3vPy9fnmr76sa4qVMl53/ts33JSg39eqeNHfJUydSI1blZaL9Ut4Lh94siNWrPioE4c85OnZyzlK5ROLdpVVMYsyaNhj/Ag9bLXUuM8r2v+0cUavWdihMtUzlBBrQs7/9/funtbjRd96Jh+PWc9lU9XWiniJtedwDs6cvmYJu2foUOXjnASYtiECSs1YsRi+VzwV548GfTFl2+qUKGskS6/aOE/6t9/jk6f9lXmLKnUqVN9VapU0HF7YGCgBg6Yq2nT1sjfP0DFimVXz16NlCWLc4o9op89NyPWatrcnfK/clPFCqZTz041lCVjskjvc/X6LQ0YtkZLVx+U78Xrypsrlbq3r6qCedM6lslT4YcI7/tZq0pq9napKNkXROzfbWc1c/xOHd7nIz+f6+rW70WVrZTloQ7Xnh3n1LXlPGXOlkwDxr/mmD9t9HatW3lUp49fVhxPD+UpmFpN25RShsxJOQ0xbPHqw5o8d7d2H/TWZf+bmjX0DeXNkfK+95k6b7f+XLJfB4/62en8uVLq02ZlVChv6v+0Xjx5SyYd0I61Z+V98opix/FQ1nzJVad5PqXOmCjS++xYc8bez+fMNd29E6iU6ROoSsMcKlk9o7397p17mj96r/ZsOi/fs9cVN0Es5S6WUnWa5VOSFPE4jTFo1pStmjxmo/x8rylHrlRq17m68hZIF+Gyd27f1YSRG/TXvH91wfuKMmVOrhbtK6t0+WxOy5nb/ui/UpvWHtGNG3eUPmNSde71ivLkD3kPx1Mg8F7MPK7bwy0WJ04cFS9eXMuWLVO9evXsvHv37tnpNm3aPD+ZeBkzZtTkyZMVEBDgmHfjxg1NnDhRmTJlkqvo3bu3zp49q3///VfvvPOOHZFk4cKFMbpNprHig6RMmdKOloJHExBwW9lzpVS7ztUeavmzpy+re/uZKlIio/6Y9K5ee7uYfvpmsTavO+YUGKz7ehH9Nvpt9RvU0H64+Lz1dPtYiFnZk2TVi5kq65j/iQcue/32dX24tL3j0mp5R6fbz147pxH/jlPH1V/oy3Xf6sJ1H31ZqpMSx4n8gyii3oIFW/Rd3+lq3bq2Zs7qptx5Mqh5s4Hy9fWPcPmtWw+rY8cRatiwvGbN7q7q1YqoTeshOnDgtGOZ4cMWa9z/2rsP8KbKLoDjp0AZhbLasvfee++9lyAoggqCAwSUKYgCgoosUUCWDNmyFJAle++9QZC9oawCZbT9nvP2S9q0BYu2TZr8f8+Tp8nN6Nt7m+Tec897zoz1MmDAWzJv3meSKFF885pPnvCetrdJs3bJjAX7ZECPmjJvYqvgbdNtvjx58vyFz/nyu5Wybfc5GfJlPVkyvY2UL5lF2n46T67ffGB9zObFHWwu3/SpI25uIrUq54qhvwwW/o+fS9acKeWjnuVeaaX4PXgiI7/aIIVLpIswMFj/9fwybHIjGTSqnvme7tdlhfjzPW13j/2fS/GCaaXH+5Hf3rsOXpb61XLKtO8by69jmkkanyTSrtcSuX7T7z+9LqLe6cO3pWKjrNL1x0rS8btyEhAQJOP6bJcnj1/8me3hGV9qtswln/5YST6bUFVK1c4ks4fvl+N7bpj7nz4JkIt/3ZParXJLj7GVpV3/UnLjop/83G8nm9CO1v15XMaOWCdtPiwvP89uI9lzpZKeHefJHd+HET5+8tjN8sfCA9KlVw2ZtrC9NHq9qHzZ/Xf560RIJtSD+/7Sqc1MiRcvjgwZ01ymLWwnHbtVE8+kCWPwL4Or6Natm/z8888mGe348ePSoUMHefjwoelW6zJBvGLFiplA3m+//WZdptc1gFe0aFHrMo1wanHBrFmzmmy4woULy4IFC6z3a4HBdu3aWe/PnTu3/Pjjj+Ey/zRiOnz4cEmbNq14eXmZjL9nz/75gMvT09OkSGbLlk0+++wzSZkypaxevdp6/927d01mngbNNP2yWrVqcvDgQXPfqVOnxM3NTU6cOGHzmiNHjjRZfRYaIKxbt64kSZLEFEd8++23TfFEiypVqpgI76effmpSOWvXrm2yDQYMGGDWl6Z8pkuXTrp06fLC6bQXLlyQxo0bm9+h42zRooVNOqi+VpEiRWTGjBnmuVrU8c0335QHD0IOYlxB6fJZ5b2OFaRCtZdn31n8sfCgpEmfTDp0qyKZs3pJkzeKSqXquWTh7L3Wx3w3ppnJzMuS3dt8YfX6qo7cuPbAZPvBfhLGTSBdinwo4w9NlYfPHv3j44P0/f7knvVy76ltEGjLlR1y+PYxufH4plzyuyLTjs8RD3cPyeSZIRr/CvyTX6aukeYtykuzZuUkR4508tVXb0nChO6ycOG2CB8/Y/o6qVAxv7RrX0uyZ08rn3zaSPLlyySzZm4w9+tn7/Tpa+WjDnWleo0iJig4ZGhbuXHjrqxZc4ANYkdm28zfKx+9U0aqV8wpuXOkkiFf1JMbt/1kzea/InyO/5NnsmrjKenRsbKULJJRMmdIIZ3blZdM6VPInN9DtqePVxKby7otp6V0sUySMT2ZWjGtRLmM8vZHJaVslRdn00Zk7HdbpHKtHCbLLqyvfqwrNRrkkszZUkrWXF7yab/KcvOan5w+EbIvBvtoXCu3fPxOSSlbPPLfpcP71pK3Ghc0mXXZMqWQr3tUlcCgINm+/9J/el1EvQ7flpXStTJJ2ixJJX32ZNKqR1G5c+OxXPzr7gufk7OwtxSukE7SZPIU73SJpcpr2SVdtqTy95Hb5v5Eid3l4yHlpGjl9CajL0velNKsUyET2PO98c/7e4ge82fulvpNC0vdxoXMMVG3vrXN/tjyRYcjfPyqpUelVbuyUqZidkmXIbk0blFUypTPJnNn7LI+ZvbUHZIqTVLp/VV9k9GXNn1yKVk2q6R/SfY9HDgTzx6XV/DGG2+YeFK/fv1M3OTAgQOycuXKcM0unDqIp9577z2ZOnWq9faUKVPCRTI1gDd9+nQz7fbo0aPStWtXkxG3ceNGa5AvQ4YMMn/+fDl27JhZqZ9//rnMmzfP5nXWr18vZ86cMT81eqpTdV9luq7+noULF8qdO3dMOqVF8+bN5caNGyY7T9sOa3CyevXq4uvrK7ly5ZISJUrIrFmzbF5Lb7/11lvWIKAG/jRwuWfPHvOPoME1DbKFpmPW37t161azLnQsGgycMGGC/PXXX7Jo0SIpWLDgC8euATwdk643DUL+/fff5h8xNF0/+jpLly41F33sd999F+l15IqOHboixUpltllWsmwWs/xFHvoFt63mLJF9tSvwtuy7cdAE3iIb9BtbdbiMqzZCehXvIhmSRJz+r+K5xZUamaqY4OD5+xejcNR4FU+fPpejRy9IuXJ5bdrBly2XVw7sj3ia84EDf0u5snlslpWvkM8sV5cu3ZKbN+/bvKanZyIpVDjrC18TMePSlXty8/ZDKVcy5DPZM0kCKZQvrRw4EvFn8vOAIJP5kSC+beWRhAniyd5DIdmXod3yfSgbt/0tzepH/J0Lx7Pmj5Ny7coDadm+WKQe/9AveMaDZ1LHKG6N/+bxk+fy/HmgJPMkO8fRPX74zJptF9mTNyf33zSZdtkLer3wcf4Pn5nsaY/E7lE2VkTes2cBcvL4NSleOuT7OU4cNyleWo+ZIv6uffbsucSPH9dmWfyE8eRwqGD8to2nJXe+NNK/5yJpUm20tH9zqiz9jROqiD6aWKXl1p48eSI7d+6U0qVLR9vvcriaeBYajNOOIJa6cxqg0im2GzYEZzzoyvn2229lzZo1UrZsWbNMM+K2bNligleVK1cWd3d3+eqrr6yvqRl527dvN0G80IGwFClSyJgxY0xBwjx58kj9+vXNHGadHvsymn33xRdfmLE8f/7cZOJZauLpOHbt2mWCeJYCiBqd1UCYZgt+8MEH0qpVK/N7Bw0aZM3O02DfzJkzzW29TwN4+neGDmZqlqI+VgOBKmfOnDJ06FDrY5YtW2YyBGvUqGHWgWbklSoVcV0e/TsPHz4sZ8+eNa+rNDCaP39+UzuvZMmS1mCfBjY1+1BpRqA+95tvvon0NnU1vrcfSYqUttOW9fbDh0/lif8zSZDQdmchMDBIfhq+QQoUTidZc3jH8GhhUS5tacmWNLP03jowUivlit9VGXtoslx4cEk84iWShtnqyjflvpCum/qKr/8d6+OKpSosXYt2kPhx45tsvUE7h8mDZyHTdxCz7tzxk4CAQPHySmqz3NvLU87+HXE7+Fu37ouXd/jH63KlATwV0WtaHgP7uPn/KTleKWzrwXqnSGwCbxFJ4hFfihRIJ2N/2S7ZsniJdwoPWbbmuBw4ekUyvSDLbtGKI5LYIz5TaWOJKxfuybSfdst3ExtI3Hj/fF5bv6d/Hrld8hZKLZmzU7vWGYyYuF1SeSWWcmTdOTR97/02/ohkzZ9S0mW1/Y6NKNjXr+Wf8vxZoAkGNe9cSPIUTxXhY589DZAlk45JsSoZJCFBPLu4d+eRBAYEScqUtt/PKbw85MK54AzKsDSjTrP3ChfLKOkyppB9u87J5nWnzOtYXLl8VxbP3y8tWpeU1u3KyomjV2XU0LUSL15cqdOIE22I3Rw2E0+noGowTQNHmpGn13W6qMXp06fl0aNHUrNmTTMN1HLRAJRmjVn89NNPptCgvp7eP3HiRDN9NDQNWGkAz0Kn1WrwTWkALfTrh35uz549TarkunXrTKRVs99y5Mhh7tNps35+fmZ6bujna7DMMj6dknru3DnZsWOHNQtPs/U0kGh5Dc0ODP18y32h/0b9+0LTDECtJ6hBTQ1E/v777ybIGBGds63BO0sAT+XLl0+SJ09u7rPQabSWAF7YdRQRDWzev3/f5qLL8GKjvlsr587cki8GN2A12Yk2nmib/y358cAEeRYYuRpmp+6ekU2Xt5naecd8T8rwvaPl/tMHUjNTVZvHHb19XHpu7idfbPtGDtw8LN2KdaQmHhBN/lh1TIrV/MF60Uybf2Pol/UkSIKkcpNxUqja96amXv0aecyBYUQWLjsiDWrlNY2K4Ng0iD+s3zp564Nikj5T5KY+jx+2VS78fUd6fV0t2scHW3+sOSnF6k2wXva8ZFZDZE2cvVeWr/9LxgysGy7jFo5lwZhDcu3cfWnzeYl/fGyCRPGk17gq0n1MZanfNq8smnBE/joYfvq71rf85es95nqLLoWiZdyIHp171pD0mVLKO00nSY1Sw+TH79ZI3UYFxS3Ud3NQYJDkypNa3u9cWXLmSS0NmxWRBq8VliULyMZD7OfQ31g6pdbS0UODcaFpgMySdZY+fXqb+yyZb5q516NHDxkxYoTJ1tMg1LBhw0x6Y2iarRaa1qrTzDP10Ucf2WTtaX05Cw0qatBOLzplV6es6hRZDYLp+DTQZckcDE0DZEqz5XS6rDbsKFOmjPmpRRBD/40NGzaUIUOGhHsNfW2LsJ1mNSB38uRJk6Wo02M7duxo/m6dAhv2b42sl62jiOhU59BZkKp///6mvp6rSOnlIXd8betr6O3EieOHy8IbNWSt7NhyRkb+/KbpYgv7yJYsiyRPkEyGVgj5340bJ67kTZlL6mSuLm+taC+BpgLeiwUEBcjZ+xckjYftWd8nAU/l2qMb5vLX3TMyqsp3Ui1jJVl0Zlm0/T14sRQpkkjcuHHCNbG4dfuBeIfJtrPQ5bdvvfjxPj7BP/U1U6VKZvOYvHmorRSTqlbIYabKWjx9GhC8be48lFTeSUK2zZ2HkjdHxBkaSuvfzRzTUh49fip+D5+a53btt0Qypgsf9Nlz8JKcveArI79qGOV/D6Le40fP5PTxW/L3qdsyfvg260FfUJBI43KTZOCoulK4RHqbAN7uLRdk8IQG4p065H8IMaNquaw2HWRTh3of/xuT5+6Xn+fskynDG0vu7Mx+cPQA3tEd16TLiAqS3OefO8jqSRaf9MH/HxmyJ5PrFx7Iml9PmXp5oQN4U7/ebergdRpaniw8O0qWwkPixHUT3zBZ8XduP5KUXrbHuBbJU3rINyObmsZU9+89Fm+fJDJx1EZJlz5k38vLO4lkzmb73tYa5ZvWnoymvwSIOQ4dxKtTp47ptqoBI23YEJoGyjRYp5lxOnU2IjoFt1y5ciaIZRE6gy0ydIqsXv6JBs60jpxOAV68eLHJqLt27ZrEixfPZLG9iE6p7dWrl7Rs2dLUotPsPAt9Da1vp8/X13kV2shDA4B60UYdmsGn02b1NUPLmzevXLx40Vws2XhaP1Dr8ek6/rd0PWiXloiCq64iX6F0smvLWZtle3ecN8tD1+sYPXSdbFl/Wr6f2ELShvryQcw7fOuYdNvY12ZZx8Lt5IrfNRNs+6cAnoojbqZhxf4bwU1sXsRN4oh7HOqv2Ev8+PEkf/5Msn37CalRo4hZpicmdmw/Ia1aV4nwOUWKZJPtO07Iu21COlRv23bcLFcZMnibQJ6+Zt68wZ+nfn6P5dDBs9KyZaUY+bsQMhVWL6E/a328Esv2PRckb87gQIDfwydy6NhVadkkePu/jEei+OZy776/bNl1Tnp0CL/fsWDpIcmfO7XkyfnioCAch0fi+DJmdjObZcsWHpNDe65In8E1JHU6T+v/zoTh22T7xnMyeGwDSZPu5VP5EDPv6f9i0q/7ZPysvTJpSEMpmJv3q6PS997Cnw7Loa1XpdPw8uKVNvG/fB0xU2vDBvBuXn4onYeVl8RJo+b/Cv+Ou3tcyZ03jezbeV4qVs1lnT69d9c5ee0N29lmYWnWu08qT3n+LEA2rj0pVWuG1C0uUCS9XDzva/P4ixd8JXVaPsNjnVdsMuEKHDqIp1NcLVM6Q093VZpVp1l22sxCD7wqVKgg9+7dM4E77bD67rvvmlpxOr32zz//NPXwtLuq1nnT69Hhk08+kQIFCpgmFFqPTrP/tPOt1qvT+nVXrlwxmYOvvfaaydhTTZs2Ndl3eqlatapNpp8G37RVsQb4NNCnwUSdRqwZhpMmTQq3Tix0CrJ25tUpvh4eHqbGngb1Mme2bbKgdJyaQajBRO1Yq9NuNeipgVHLGP8NDdg5W9Du8aOncvliSEesa1fuy+mTN0wTCv1CmDR6s9y66Se9B9Y19zdsVlgWz90vE37cKHUbFZD9uy/KhjUn5dsfmtpMoV278oQM+r6xeHjEF99bwWehEicJn62H6Ocf4C8X/S6Hy6DT2nWW5Z0Kv29q3c0+GdwJ+/UcjcyU2msPb0hidw9plK2u+CTykrUXN5n7E8SNL01zNJQ91w/InSd3Jal7EqmdpbqkTJhCtl8N6aKFmNembQ3p/dkvUqBAZilUKItMm7ZOHj9+Kk2bljP3f9ZrqqRKnVy6d3/N3H77nWryztsjZMqU1VKlckFZtny3HD1yXgYObGXu1xNO77xTXcaPWyFZMqeS9Bm8ZdSPSyRVquTWQCHsw2yb5sVl/LTtkiVjCkmfNpmMmrRFUnklkRoVQzqOt/lkrtSolFNaNws+4bV551nTfjprphRy/vJdGfbTBsmWKaU0rV/A5vU1IPjn+lPyWaeIA8CIuey6q5dCsmWvX3lgMu2SJE0gqdIkkWk/7ZLbNx9KtwFVTbZO2Lp2yVMkMsXSQy8fN2yrbPrzjPQdVst0ttTsEEsQMEFCh96Ndnp37/vL1RsP5Mb/953O/n8fzTulh/j8v77WZ4PXSCrvxNL9/eD62Zp9N+qXnaZLbfo0ntZ6mR6J3CVxoviRfl1Ev/mjD8m+9Zek/VelJWGieHLf198s19p18RMEHwPNHLpXknklkobtghMPVs85JRlzJTedaTVwd2zXddm95qK06FLYGsCbMmi3XPrrrnwwqIwJFlleVxtmxHN32EpTTq1565IyuN8y04gib4G0smD2HvF//EzqNg6uXfftF0vFO5WnfNAl+ATascNX5NaNB5Ijd2rz85cJW00m9ZttStu85sdtZsrMydulSs08pibe0oUHpfuXtolBQGzk8HsfGpB7EW0IobXudOqmZrHpNFXNNNMOtOrDDz+U/fv3mww53YHXYJgGqLRbbHTQzLVatWqZLrjLly83l759+5quujdv3jTTZytVqmTTaliDkZotp802tGlFaBrQ06CkNtDQ19WachqI0wxF7aL4IroetHOsZsJpME+DdH/88YepzxeWrhfNHOzcubMZm76uvv7o0aOjeO3EfiePXZfuH4Z0Nh73ffBU6VoN8stnX9WR27ceyo1rIQcPmlX3zY9NZdz36+X3OfvFO1US6f5FLSlZLiQzc8mC4Gytbh/Ydkzu2b+21Glke5AIx+CdyMucHbZI7J5YPirY1kzD1Y6zf98/J323fS2X/ILr9QQGBUn6JGmlSoYK4umexAQEz9w9K/22f2t9DOyjXr0S4uv7QEaP+sM0pcibN4P8PKmzdXrslau+NvVVihXLLsOHt5MfflgiI79fLFmypJIxP30kuXKFTLlr/34tefz4ifTrN0vu338kxYvnMK+ZIAFBeXtr36qUPPZ/Jv2G/in3/Z5I8YLp5ecRr9vUr7tw+a7cufvYetvP74l8P2GTXLvpJ8mTJpSalXNJ1w8qins825Noy9acMJ8L9WuEdCZGzDt9/KZ83jGkRMHkH4JrDlern1O69qtiGk7dvB5xI5MXWbEw+GTy5x2W2iz/5MvKUqNBcNYI7GPdtrPy+dB11tvdBq0yPz9+p6R0bhPc0O3KjQc2n+NzlhyRZ88C5ZMBK21eK/RzIvO6iH5bl54zP0f32Gqz/K0eRaV0rUzm+p0bj82xjMVT/wAT/Lt367G4J4grqTImkbc/Ky7FqgR/T9+95S9Htgc3rxrawbbkUadh5W2m3CLmVKudV+7eeSRTx20R39sPJUfuVDL0pxbW6bTXr923eR8/ffJcJv+02TSvSOQRX8qUzyafD6ovnqG6TOfJn1YGjXhNfh69UaZN3GqOyzr1rCY16+Vn08Y2ZOKF4xYU+mgUiAGX/Caynp1YhiQfWK83X9bGrmNB9Jlf/xfr9SBZz6p2Ym4S0qQl6OYku44F0cfNp731+qm7w1nVTixX8h7W60GXR9l1LIg+bum7WK+vPN+LVe3E6mQear1+9ZFtUgicR1qP98QlPYueBKx/5B48u84ROXwmHgAAAAAAAFzMS5ppuiom/gMAAAAAAAAOjkw8AAAAAAAAOBZq4oVDJh4AAAAAAADg4AjiAQAAAAAAAA6OIB4AAAAAAADg4AjiAQAAAAAAAA6OxhYAAAAAAABwLDS2CIdMPAAAAAAAAMDBkYkHAAAAAAAAx0ImXjhk4gEAAAAAAAAOjiAeAAAAAAAA4OCYTgsAAAAAAADHEhho7xE4HDLxAAAAAAAAAAdHJh4AAAAAAAAcC40twiETDwAAAAAAAHBwBPEAAAAAAAAAB0cQDwAAAAAAAHBwBPEAAAAAAAAAB0djCwAAAAAAADgWGluEQyYeAAAAAAAA4ODIxAMAAAAAAIBjIRMvHDLxAAAAAAAAAAdHJh4AAAAAAAAcSlBQgF1+r5s4LjLxAAAAAAAAAAdHEA8AAAAAAABwcEynBQAAAAAAgGMJDLT3CBwOmXgAAAAAAACAgyOIBwAAAAAAADg4gngAAAAAAACAg6MmHgAAAAAAABxLEDXxwiITDwAAAAAAAHBwZOIBAAAAAADAsZCJFw6ZeAAAAAAAAICDI4gHAAAAAAAAODim0wIAAAAAAMCxMJ02HLegoKCg8IsBAAAAAAAA+wi6Ockuv9fNp704KjLxAAAAAAAA4FjIxAuHmngAAAAAAACAgyMTDzHu/tOFrHUnljR+M+t1/4EN7ToWRJ+E/f6wXr/lP5NV7cS8E7a2Xr/y0D5TGhD90iUOmTZy0W88q9yJZUzykfX6rusD7ToWRJ9SqftZr/sHLGNVO7GEcetbr199NMWuY0H0SevxHqsXBpl4AAAAAAAAgIMjiAcAAAAAAAA4OKbTAgAAAAAAwLEEBtp7BA6HTDwAAAAAAADAwZGJBwAAAAAAAMcSRCZeWGTiAQAAAAAAAA6OTDwAAAAAAAA4FjLxwiETDwAAAAAAAHBwBPEAAAAAAAAAB8d0WgAAAAAAADgWptOGQyYeAAAAAAAA4OAI4gEAAAAAAAAOjiAeAAAAAAAA4OCoiQcAAAAAAADHEhho7xE4HDLxAAAAAAAAAAdHEA8AAAAAAABwcEynBQAAAAAAgGMJYjptWGTiAQAAAAAAAA6OTDwAAAAAAAA4FjLxwiETDwAAAAAAAHBwZOIBAAAAAADAsQRSEy8sMvEAAAAAAAAAB0cQDwAAAAAAAHBwBPEAAAAAAAAAB0cQDwAAAAAAAHBwNLYAAAAAAACAYwkMsvcIHA6ZeAAAAAAAAICDIxMPAAAAAAAAjiUw0N4jcDhk4gEAAAAAAAAOjkw8AAAAAAAAOBYy8cIhEw8AAAAAAABwcATxAAAAAAAAAAfHdFoAAAAAAAA4lsAge4/A4ThsEK9NmzYybdo0+fDDD2X8+PE293388ccyduxYeffdd+WXX34RRzZgwABZtGiRHDhwwG5jOHv2rPTt21c2bNggvr6+4u3tLcWLF5chQ4ZInjx5zGPc3Nysj0+aNKkUKFBABg0aJIUKFTLXu3TpIp9//rnN67Zo0UIuXLggW7dulbhx44ormDdnu8z8ZbPcvuUnOXOnkZ59Gkr+ghkjfOwfi/bKwC8X2iyLHz+ebN070Hp74tg1smrFIbl+/Z64x4srefKll45dakmBQhG/JmJOvMotJU7+SuKW1Fsk4LkEXj0tz9fPkKDLp174nARdJolb8tThlj/fvUyer7D9HFPubw2QuDmKy9O530jgyR1R/jfgny38dbfMnrZdfG/5SY5cqaVr7zqSr2D6CB/bqd102b/nfLjlZSvmkOFjWprrX3+5WFYsOWRzf+ly2eX7cW+xOezk4N6LMnf6bjl1/JrcvvVQBo1oIhWq5nzpcw7suSBjv18v587cFp/UnvJ2+7JSp1EBm8f8PnefeV3f2w8le65U0qVXdclbIG00/zV4kUP7Lsm86Xvkr+M3zHb+anhDKV81x0tX2IE9F2X895vk/N+6nZNIq3alpXaj/Nb7AwICZfqEHbJ2xXGznb28k0jthvmkVfvSNvtNiFknDlyXZb8el3MnfeXu7cfyyTeVpETFl+83bV11VpbNOSbXLz2QRIndpXCZdPJmh2LimSyBuf+bLqvlxIEb4Z6nj+sxtGq0/S34Z7/O3iLTpqyXW7ceSK7c6aR339ekYKHMET524fzt8sfiPXL69DVzO1++DNL503o2jy+cr1uEz+3avYG0aVeNTWIn+p3667Sd5rM2h36nflZD8hZIF+Fjnz8LkFlTdsifS4/IzRsPJFPmlPLBJ1WkdPls//o1gdjEYYN4KmPGjPLrr7/KyJEjJVGiRGaZv7+/zJ49WzJlymTv4cUKz549k5o1a0ru3Lnlt99+k7Rp08qlS5dkxYoVcvfuXZvHTp06VerUqSO3bt0yQb8GDRrIkSNHZOLEidK8eXNp2LChFCxY0Dx2/vz5snTpUtm/f7/LBPBWrTwkPwxbLr2/bCIFCmWQOTO2SecPp8qCP7pJSq8kET4ncZIE5n6LsLv8mTJ7S8/PG0n6DCnlyZNnMmfGVun04RT5fVl3SZEy4tdEzAi8fUUCV4yXoDvXRNwTSNzSjSV+q4HyZMwHIo/uR/icJ5O6ibiFVCmIkyqzxH/7awk8tiXcY/X1JIgzS/a0ZuVRGT18tfT8op4J3M2btVO6dZgtcxZ3lBReicM9/tvvm8uzZwHW2/fuPpI2LSZK1Zr5bB5Xpnx2+XxgI+tt9/iu8RnpqPz9n0n2XD5St3EB6ddj8T8+/urlu9Kny2/S8PXC0vfrBrJv13kZNmilpPROLKXKZTWPWffnCRn3/Qbp+nlNyVswrSyYtVd6fTxfpv/eTlKkDP+/g+jn//iZZMvlY4KtA3r+8Y+Pv3r5nnzxySJp0KyQ9PmmjuzfdVFGfL3abOeS5bKYx8ydtkf+WHBQen1VW7Jk95JTx67LsK9Wme/211oWjYG/ChF54v9cMmVPLpXrZZcfv9j0jyvp1OEbMuHb7dKqUzEpWi6D3Ln1SKaO2CVThu40AUD1ydeV5PmzQOtz/O4/kb7vLZdSVTnesKeVK/bL8CGL5Yv+zaVgoUwya8Ym6fDBRFm8rLd4eXmGe/yeXWekbv1iUrhIFkmQIJ5MmbROOrw/QRYu6SWpUyc3j1m7cYDNc7ZsPiEDvpwrNWoVjrG/C7bW/Xlcxo5YJ9361jJBtgWz90jPjvNkxqL3I/xOnTx2s6xedlR6fFlHMmX1kt3bzsqX3X+Xn35pLTnzpP5XrwnEJg5dE69YsWImkKfBJwu9rgG8okVDdp6ePHliMsVSpUolCRMmlAoVKsju3but92sGmp4x/fPPP83zNCBYrVo1uXHjhglm5c2b12SfvfXWW/Lo0SPr8wIDA2Xw4MGSNWtW85zChQvLggULwr3u2rVrpUSJEuLh4SHlypWTkydPmvs1S/Crr76SgwcPmsfpRZedO3fOXA+dnacBNV2mr/lfxhzW0aNH5cyZMyZzsUyZMpI5c2YpX768fP311+Z2aMmTJ5c0adKYzLtx48bJ48ePZfXq1dKoUSPzezTzUYOCN2/eNNmQ3333nQkOuorZ07dIk2YlpdFrxSVb9tTSp19jSZgoviz5fe8Ln6Pb0Nvb03rx8rbd4ahTv4iULptDMmRMKdlzpJZPe9aTh35P5K9TwWcQYT+BRzZK4NmDEnT3ugTdvCDPV00St4SJJU7q4IO7CGlw7+Fd6yVOzpIS6HtFAs8fsXmYW+qsEq9sE3m25Mfo/0PwQnNn7JCGTYtK/SZFJGt2H+n5RX1JkNBdli6KOHM6abJEJhPHctm946x5fLWaeW0ep0G70I9LmjT4JBTsQ8/Mt/u4olSslitSj1+y4KCkSZ9MOnarKpmzeclrbxaTytVzy4JZe6yPmT9rj9R/rZDUbVxQsmTzNgcJCRO6y4rFtu91xJxS5bPKex3LS4VqL8++s1i68JDZzh91qyyZs3pJkzeKSKXqOWXh7H3Wxxw9eEXKVckuZSpmkzTpkkmlGrmkeJnMcuIo39H2VLhMemn+fhEpUSlysxb+OnJLfNIkltqv55FU6ZJI7kKppFqjnHLmxC3rY5IkTSDJvRJZL0d2X5P4CeJKqSoRZ3whZsz4ZaM0bV5GmjQtJdlzpJEv+r9uPmsX/bYrwscPHtZa3mhZXvLkTS9Zs6WWAYPekMDAINm14y/rY7x9ktpcNqw7IiVL6b64F5vVTubP3C31mxaWuo0LSZbs+p1a22zn5YsOR/j4VUuPSqt2ZaVMxeySLkNyadyiqJQpn03mztj1r18TiE0cOoin3nvvPZMhZjFlyhRp27atzWN69eolCxcuNNNv9+3bJzly5JDatWubqaNhp7aOGTNGtm3bJhcvXjTTQX/44QeT2bds2TJZtWqVjB492vp4DeBNnz7dTOfVYFjXrl2ldevWsnHjRpvX1ay1ESNGyJ49eyRevHhmzOqNN96Q7t27S/78+eXq1avmostexauOOSwfHx+JEyeOCT4GBIRkkPwTS+bj06dPzc8ff/xRbt++babYduzY0QT6OnfuLK7i2bPncuLYFSlVJuTgQNdrqTLZ5fDBCy983uNHT6VhraFSv8YQ6d55hpw5ff2lv+P3BbsliWdCyZWbKVkOJU48iVu8jgT5+0ngtXORf06hqhJwYI3t8ngJxL1pD3m2fHxwsA92oRl1J49flZJlgjOrVJw4blKiTFY5cuhSpF5j6e/7pUad/JLII77Ncp1yW7/KCHmz0U8y7OvlJmMPscexQ1ekeCnbA/eSZbPIscNXrP87OjW3eOnMNv87xUpnlqOHgh8Dx3fs0FUpVso2y6qEbudDV6238xdOZzL0Lp2/Y26fOXVTjhy4IqX+n6mH2CFnAW+5feORHNh+WYKCguSe72PZteGCCQa+yMZlp6VM9SySMJFDT1pyas+ePpfjxy5JmTK5bPa9y5TNJYcORG5fzN//qTx/HiBJk3lEeP/tWw9k86Zj8lqzUlE2bvyb/bHw36nFS+vn8eUXPOe5xA8zyyF+wnhyeP+lf/2acGCBgfa5ODCH/2bSoFmfPn3k/PngOkRaf02n2Foy1h4+fGiyxjTDrW7dumbZzz//bDLIJk+eLD179rS+lmafaRaaateunXldzVLLli14/vzrr78u69evl88++8xk93377beyZs0aKVu2rLlfH7dlyxaZMGGCVK5c2fq633zzjfV27969pX79+mbarwbCkiRJYgJ7muH2b7zKmCOSPn16GTVqlAl0alagZgxWrVpVWrVqZX2NsDSz74svvjDTZC1/l2b9aTC1Vq1akjhxYjl06JBL1YO5e+eRqY0Tdtqs3j539maEz8mcxUe+HNhUcuRKI34P/GXmtC3S7u3xMvf3TyV1mmTWx23eeEL69vzVTPny9vGUMRPfk+QpSPN2BJpJ596sp5lOKw/uyNOZ/UQe34/cc/OUEUmYWAIOrLVZHq92ewm8eEICT+2MplEj8u/poAje04nlwtmQ7IwXOXb4svx9+qb0GdDQZnmZctmlcvU8ki59crl88Y5MGL1eunecIxNmtJW4cR3+vBlETO2cFF62B3w6vfqh31N54v9MHjx4IoEBQZIiZZjHpPSQC+dsTx7Csbdz8gi24aOHup2fS4KE8eTNNiVNdnzbZr+Y4IHO0GjbsbxUr2ebfQvHlqtgKunwZTn5acAWefY0wHz2Fy2XXt7tWjLCx585dksunb0n7T+znbGCmHXn7kOz7x12FotOoz37d/j6hRH5YcRS8UmVzAT+IrJk8W7x8Egg1WsWipIx49Xdu/PIfKemDDPFVb+HL5y7HeFzSpbNajLtChfLKOkyppB9u87J5nWnzOv829cEYhOHD+JpJpkGxTRIp2fP9Lo2ZrDQgJZO8bQEupS7u7uUKlVKjh8/bvNa2qTBInXq1Gb6a+hAli7btSs4Dff06dMmmKX15ELTzLTQU3nDvq7WnFM67TUq6va9yphnzZplGoFY6LTbihUrmqmv77zzjgl87tixw9Sz0wDlkiVLbP6+li1bmsCdTqPV9a5B0NC/X6fz6hTcIkWKmGm5L6NBUL2EliBBAnNxFYWKZDIXi8JFMkvzxiPlt/m7pEPnkPVeomQ2mbWgs9y981AWLdwtn/eYI1NndXhhnT1EvTgFKot7g4+tt5/OHiBBF45J4LlD8nTCJyIeSSVusVri3uwzeTq5u8ije//4mnGL1pTA03tF/EIO6uPkKiVxshSSpxM/YTPGckt/PyDZc6YK1wSjRt2Q5gfZc6aW7LlSS4v6Y0x2XonSIVl/ABzfxtWnZN3KE/L5N/XM1Oozp27I2BEbxdsnsdRqGNIAA47t8rl7MnPUXmnSpqAULJXWNMP4dex+mTp8l7zfO3ygbuOyM5IxW3LJni/keAOxz+Sf18rK5ftl8rSPJUEC9wgfo9Ny6zUo/sL74Zg696xhatW+03SSKTiePkMKqduooCxfzFRZuAaHD+IpnZ7aqVMnc/2nn37616+jwT0LzSILfduyTM+yKj8/P/NTp6xqNltoYQNRYV9XWV4nIno2V2lQ0kIDkf91zFq7rnTp0tb7Qo/b09PTNKbQi2b36XRj/Rk6iKcNRGrUqCHJkiUzQbyIaFahXv6JTkXWzL/Q+vfvb6YHx0bJU3iYLBrf28H/FxZ6O6LCuhGJ5x5XcudJJ5cu2p4B0ql4GTN5mUvBwpmkaf0Rsvj3PdK2fZUo/RvwYoGndsnTCSFdZ4Me/H8bPXsiQXeuity5Ks8vn5T4H08wwbmArSG1MSOUzEfiZC0sz+YNtlmsATy3lGkkwWe/2ix3b97bBA2fTrftAI3ofk+7RfCefigpvV8eQNdp8mv+PCrtO4ZkZL+I7ljq77p0wZcgXiyh2Zh3bttOgb5z+6EkThLf1ECMEzeOxInrJnd8wzzG95F5LmIH3VZ3I9iGHol1Owfv50z8cZPJxqtaO7j+b7ac3nL96gOZM3U3QbxY5I+ZRyRnQR+p3zK4CVGm7CnMNv6602pp3r6wJPcOqVvq//i57Fh3Xpq9R2aWvaVIntjse+uU19Bu335g6ky/jHaznTpprUyY3MF0tI3Ivj1/y7mzN2ToiLejdNx4NclSeJjvVF/fhzbL9Xv4Rd+pmkX9zcim8uTJc7l/77F4+ySRiaM2Srr0yf71a8KBOfjUVnuIFXN7tGOqZsBpoEuDT6Flz55d4sePb6bZWujjtLFFvny2HQNfhT5Xg3UXLlwwNfZCX7TZRmTp2MLWorMEyLRGnkXoJhf/lgbqQo/TUtcuLA385cmTx0xFDk2n/OrzXhTAexU67ffevXs2F10WW7m7x5M8+dLJ7p2nrcs0eLp7xxkTeIsMnRJw+q9r/7jjoQV4tQ4IYtDTxyZYZ7nI8+BakOFog5p4/3y2Nl6RGiIP70ngXyENdtTzrQvk6fjO8nRCF+vFLF81mSYXMcxdg+p508qeneds3nt7d5413adfZt3q4+Y9Wrt+cLful7lx/b6pieflQ2ZtbJGvUDrZtzu4hIfFnp3nJV/BdNb/nVx505iutaH/d/R2/kIRHyzC8eQrlFb27bKtabt3x3mz3MLf/3m40iFaVymQzuKxyhP/AIkTpgKMbkcVJLZd4ndtOC/PnwVIuVpkTtube/x4kjdfBtkZqimF7nvr7UJFXlyXcurkdTJx/GoZO/EDyV/gxcdsv/+2U/LlzyC587y4NiJian8sjezbafudunfXOclX6OXbRjsQ+6TylIDngbJx7UkpXyXnf35NIDaIFZl4OsXTMjVWr4em9dk6dOhgat+lTJnSTGEdOnSomQqrNeT+S0CsR48eppmFfmFox1sNRGmwUOvDaafWyMiSJYucPXvWBOkyZMhgXleDazotVbu7audbnXqrNeiig/5ezYB7++23TWBSg4ramEMbhLyojl5UcMaps2+9U0G+6rtA8ubPIPkLZpA5M7bK48dPpWGTYub+/p/PF59USaXTp8GB5p/HrTUBPu125ffgscz4ZbNcu3pXGjcrYc3mmfLzeqlUJa+phac1uub/ukNu3rgv1Wv9c3AA0cg9gcSr2EICTu6SID9fcdPptCXqi1tSLwk4FnLCwP3tryXwxHYJ2L0s1JPdJG7hGhJwaJ1IUJgzRw/vSlAEzSyC7t00XXARs954u4x88+ViyZM/reQrkE7mzdwl/o+fSf0mhc39g/ouEu9UntLhk+rhGlpUrJpbkiW3raf1SN/T4zdJlRp5xMsriVy+dEfGjlxjuk+XLpc9Rv82hNDPWq1PaHH18j05ffK6eCZNJKnTJpWfR2+SmzceyOeD6pv7G71eWBbN3S/jf9gg9RoXlH27L8iG1Sdk8I/NrK/RvFUJ+a7/csmVL43kzZ9WFszeY/536jQKmU4Ne2znkM/Xq1fuy+mTN8QzaUKznSeN3iK3bvpJ74F1zP0NmhWSxXMPmGw73W77d1+UjWtOyTc/NLG+RtmK2WT2lF2SKo2nZMnuJadP3JSFs/ZJncZMpbUn/0fP5PrlkOysm1f95PxfvpI4aQLxTp1Y5k7YL3duPZaP+pYz9xctn16mDN0paxadkkL/n047c/ReyZbXS1J4e4SbSlusQkbxTOZc+7Cx1dttKsuXfeaYYFyBgplk5vSNZt+7yWvBjSj69p4tqVIllU+6NTC3p0xaK2NHr5TvhrWWdOlSyq2bwXWMte6dR+KQbern5y+r/jwo3Xs2stNfhtCaty4pg/stk9z6nVog5DtVO8Crb79YavbHPugSPANCG03duvFAcuRObX7+MmGrBAUGyZttSkf6NRGLBNqebEEsCeIpDZy9iAbDNNCmgaoHDx6Y5g1//vmnpEiR4j/9Tu3EqllpOjX077//luTJk0uxYsXk888jP+WtWbNm8ttvv5lmEnfv3jXNIdq0aWOCaBpkLF68uOTOndsEHrVpRFTTwKEGEnVq67lz58wZZcttDVAi8mrVKSR3fR/KhJ/WmNT+XHnSyqjxba0FdzVAF/qM/YP7/vLNgN/NY/VgMW++9DJ5xkeSLXtqc7+meWtTjGVL9pt6eBoQ0DOCE6d9INlzBD8GdhIYKG5eGSR+8+qmHp42swi88pc8/aW3BN0MydyIkyKNBOn9ocTJVkTckqeSgP2r7TBwvArtLKvB80ljN4rvLT/JmTu1jBj7lrUe5fVr98UtTPrG+XO35ND+izJyfKtwrxc3jpucOXVdViw5aJrZ6A5nqbLZ5P2Pq0j8+LHm69bpnDx2Tbp+MNd6e+z3683P2g3zS++v6sntW35y41pIQCBt+uQyeFRT+WnEevltzj7xSZ1Een5ZR0qVC8nMqVY7jymc/cu4rWYKdvbcqWTImNeZpmNHJ49dlx4fhpQ6GP/9RvOzVoN80uur2uJ762GY7ZxMvv6xiYz7fqP8PueAeKdKIt2/qCklQ3We7dSrqvwybpuM+m6d+azw8k4i9ZsVlLffp+GBPZ096SvffhLS+X32mH3mZ4U62eTDz8vK3dv+cvt6yGyTSnWzi/+j57Lmt1My56d94pEkvuQrllre+Mi2xvXVC/fl1KGb0mtEtRj8a/AydeoWlTu+fiYwd+vWfZM1N3bCB6H2ve9YsyrV/F+3mc6k3T+dZvM6H3WsJR06BQfwldbKk6AgqVvf9n8A9lGtdl7zGTt13BbznZojdyoZ+lML63dq2P2xp0+ey+SfNsuVy3dNWaIy5bOZE3Gengkj/ZpAbOYWFLowGxAD7j9dyHp2Yknjh2Sr+A+07dwJ55Gw3x/W67f8Z9p1LIhe3glbW69feTiJ1e2k0iVub71+0W+8XceC6JUxyUfW67uuD2R1O6lSqftZr/sHhJ4xAGeTMG5wJrm6+miKXceC6JPW4z2XXL1B+7+0y+91KzpIHFWsqIkHAAAAAAAAuDKCeAAAAAAAAICDI4gHAAAAAAAAODiCeAAAAAAAAEA00Uaj2tw0a9askihRIsmePbv0799fnj59+kqvQ7s8AAAAAAAAOJZA5+nDeuLECQkMDJQJEyZIjhw55MiRI/L+++/Lw4cPZfjw4ZF+HYJ4AAAAAAAAQDSpU6eOuVhky5ZNTp48KePGjSOIBwAAAAAAgFgsMFCc2b179yRlypSv9Bwy8QAAAAAAAAARefLkibmEliBBAnOJKqdPn5bRo0e/UhaeorEFAAAAAAAAICKDBw+WZMmS2Vx0WUR69+4tbm5uL71oPbzQLl++bKbWNm/e3NTFexVk4gEAAAAAAMCx2Gk6bZ8+faRbt242y16Uhde9e3dp06bNS19P699ZXLlyRapWrSrlypWTiRMnvvLYCOIBAAAAAAAA8mpTZ318fMwlMjQDTwN4xYsXl6lTp0qcOK8+OZYgHgAAAAAAABxKUFCQXX6vWzS8pgbwqlSpIpkzZzZ18G7evGm9L02aNJF+HYJ4AAAAAAAAQDRZvXq1aWahlwwZMvzrYCWNLQAAAAAAAIBoonXzNFgX0eVVEMQDAAAAAAAAHBzTaQEAAAAAAOBY7NSd1pGRiQcAAAAAAAA4OIJ4AAAAAAAAgINjOi0AAAAAAAAcC9NpwyETDwAAAAAAAHBwZOIBAAAAAADAsQQG2XsEDodMPAAAAAAAAMDBkYkHAAAAAAAAx0JNvHDIxAMAAAAAAAAcHEE8AAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAwMHR2AIAAAAAAACOhcYW4ZCJBwAAAAAAADg4MvEAAAAAAADgWAKD7D0Ch0MmHgAAAAAAAODgCOIBAAAAAAAADo7ptAAAAAAAAHAsNLYIh0w8AAAAAAAAwMGRiQcAAAAAAADHQiZeOGTiAQAAAAAAAA7OLSgoiJ69AAAAAAAAcBiBKzvY5ffGqTNOHBWZeAAAAAAAAICDI4gHAAAAAAAAODgaWyDG3fafw1p3Yl4JW1qvz/urs13HgujTIudo6/Vb/jNZ1U7MO2Fr6/Xrj36x61gQfVJ7tLFeP/dgDKvaiWXx7BRy48F8ew4F0cmzufVqYNBa1rUTi+NW3Xr96qMpdh0Lok9aj/dcc/UGUv0tLDLxAAAAAAAAAAdHJh4AAAAAAAAcS2CgvUfgcMjEAwAAAAAAABwcmXgAAAAAAABwLGTihUMmHgAAAAAAAODgyMQDAAAAAACAY6E7bThk4gEAAAAAAAAOjiAeAAAAAAAA4OAI4gEAAAAAAAAOjiAeAAAAAAAA4OBobAEAAAAAAADHEhho7xE4HDLxAAAAAAAAAAdHJh4AAAAAAAAcSlBAkL2H4HDIxAMAAAAAAAAcHEE8AAAAAAAAwMExnRYAAAAAAACOJZDptGGRiQcAAAAAAAA4ODLxAAAAAAAA4FhobBEOmXgAAAAAAACAgyOIBwAAAAAAADg4gngAAAAAAACAgyOIBwAAAAAAADg4GlsAAAAAAADAoQQFBtl7CA6HTDwAAAAAAADAwZGJBwAAAAAAAMcSQCZeWGTiAQAAAAAAAA6OTDwAAAAAAAA4loBAe4/A4ZCJBwAAAAAAADg4gngAAAAAAACAg2M6LQAAAAAAABxKUCCNLcIiEw8AAAAAAABwcATxAAAAAAAAAAdHEO8fDBgwQIoUKRKtG6FKlSry6aefWm9nyZJFfvjhh2j5XefOnRM3Nzc5cOBAtLw+AAAAAAAAXKQmngaZXqZ///4muOYo2rRpI9OmTQu3/K+//pIcOXKII8mYMaNcvXpVvL297T2UWGnhr7tk1rSt4nvLT3LkSiPdeteVfAUzvPDxD+4/lglj1snGtcfl/r3HkiZtMvmkVx0pVzGXuf/hwyfy80/rZOO6E3LH96HkypNGPu1VV/IVSB+DfxVC2zjvbzm+/YbcvPRQ3OPHkYx5k0utNrnEJ0PiF66oyb13y7kjd8Itz1XCW94eUMxcXzfrtBzefE3u3fSXuPHiSLocSaXGOzkkY+7kbAA7Wvjrbpk9bfv/39OppWvvOpKvYMTvv07tpsv+PefDLS9bMYcMH9PSXH/06KmM+2GtbF5/Uu7deyzp0ieX11uWktdaFI/2vwUv9tvcvfLrtJ3ie9tPsudKJZ98VkvyFUj3wsfPm7VLFs/fL9ev3ZdkyRNJlRp55IPOVSRBguDdphb1xsq1q/fCPa9Ji2LSrU9tNoUdHN53WebP2Cd/Hb8pvrceSv/h9aRclewvfPztWw9l4sgt8tfxG3Ll4l1p/GZh6dC9ks1jnj8PkF+n7pU1S4/LrZsPJUPm5NKuc3kpWS5zDPxF+CdBQUEyasJamf/7Hrnv5y/FCmeSAb0bSZZML97HHT1hrYz5eb3NsqyZvWXlwpCT6TdvPZChP66UbbvOmP00vf+j96pI7er52Sh2MGvWRpkyebXcunVf8uTJIH2/aCGFCmV54eNXrtwno378Qy5fvi2ZM6eS7j2aSOXKBaz3583TMcLn9ej5mrRrVzNa/gb8s9/n7vv/9/RDyZErlXT5rIbkfcn39PxZu2XJ/APW7+nKNXLL+50rW7+n36g3Tq5fvR/ueU1aFJVP+9Rik8QmAdTEixVBPA0yWcydO1f69esnJ0+etC5LkiSJzRd4QECAxItn3z+lTp06MnXqVJtlPj4+4mjixo0radKksfcwYqU1K4/IqOF/Ss8vGkj+gull7qwd0rXDTJmzuJOk9Ar5n7R49uy5fPLRDEmRMrF8M7yF+KTyNAd9STwTWh/z3YAl8vfpG9Lvm9fEx8dTVi47JJ98OF1m//ax+KROGsN/IZQG40rVzyjpcyaTwIAgWTP9L5n25V7pMq6cxE8Y8edMy75FJOB5oPX2o/vPZGzn7ZK/QmrrMq/0iaXBR3klRZpE8uxJoGxffF6mfblPuv5cQRIni8/Kt4M1K4/K6OGrpecX9Uzgbt6sndKtw2yZs7ijpPAKH7T99vvm8uxZgPX2vbuPpE2LiVK1Zj7rstHDV8neXeek37dNJG265LJr+98y4tvl4p0qiVSskjvG/jaEWPvnMflpxFrp3reOCdzNn71benScK7MWfWA+n8NaveKoTBy1QT4bUF8KFE4vF8/7yuB+y0RPL3bqUcM8ZuLMNhIQGPKeP3v6pnTr8KtUrZmHVW8n/o+fSbac3lK7UT4Z2HP5Pz7+2dMASZ4ikbR8r4T8Pjvi2Qm/jN0h61aclE/7VpOMWVLInh0XZGDPZTJycnPJkcfx9vFczc/TNsuMX3fIdwOaSYb0KeTHcWukXedpsnxeF0mQwP2Fz8uZLZVMHdvWeltPrIX2Wf8Fcv+Bv4wb0VpSJPeQP1YelE/7/CoLp3eQfHleHFRA1Fu+fI8M+W6hDBjQUgoVziLTp62T99uPluUrBoiXl2e4x+/fd0Z6dJ8iXbs1lipVCsjSpXukc6cJsmBhH8mVK3jbbdo82OY5mzcdky++mCm1ahVlE9rJuj+Py9gR66Rb31omcLdg9h7p2XGezFj0foTf02tWHJOJozbKZwPqSf7C6eXSeV/5rt9y8z39cY/q5jETZr4b5nv6lvToMFcq8z0NJ+CQ02k1yGS5JEuWzGTmWW6fOHFCPD09ZcWKFVK8eHFJkCCBbNmyRQIDA2Xw4MGSNWtWSZQokRQuXFgWLFhgfc0NGzaY11m7dq2UKFFCPDw8pFy5cjbBQfXdd99J6tSpze9o166d+Pv7R2rMOo7Q49aLBszUxo0bpVSpUuYxadOmld69e8vz588jvT4uXLggjRs3NsHLpEmTSosWLeT69evmvnv37pnfs2fPHnNb10PKlCmlTJky1ufPnDnTZOBFNJ02suvl66+/llSpUpn10r59e/M3RPc0Y0fz64zt0qhpMWnQpKhkzZ5Ken3RQBIkdJeli/ZH+Pilv+832XdDRr4phYpmkrTpU0jRElkkZ+7gIOoT/2eyYe0x6di1phQtnkUyZPKS9h2qSoaMKeW3+btj+K+DxbsDi0uxGukldeYkkjabpzTtWsBkz105Hf5snoWHp7t4pkhgvZw5cFvcE8SRAqGCeIWrpJXsRbwkZRoP89p12ueWJ4+ey7WzD1j5djJ3xg5p2LSo1G9SRLJm95GeX9T//3s64gP6pMkSiZd3Eutl946z5vHVaua1PubwgUtSt2EhKVYyi6RNn1wav17MZPgdP3IlBv8yhDZv5i5p0LSw1GtcSLJk9zbBvIQJ48myRYciXFFHDl6SAkUySM26+U0gtlTZbFK9Tj45fjTkBGPylB42/wvbNp+W9BmTS5HimVj5dlKyfBZp07GslK/64uy70NKkSyodelSSmg3ySuIkCSJ8zNrlJ+XNtiWkVIUskjZDMmn4ekEpWS6LLJwV8fc+Yo6exJ8+Z5t0aFdFalTJK3lyppGhA1+XGzcfyJoNx1/6XA3a+Xh7Wi8pk9sGCfYfuiit3ygjhQpkkIwZUkrH9lUlqWdCOXqCz/GYNu2XddK8eXlp2qys5MiRVgZ81VISJowvvy3cFuHjp89YLxUq5DMZddmzp5VPPmkoefNllNmzNlgf4+OTzOaybt1BKV06l2TMyCwle5k/c7fUb1pY6v7/e7pb39qSMKG7LF90OMLHHzl4WQoWySA16uaTtOmSScmyWaV6nbwv/Z7evvm0pDPf08HHxEBs5pBBvMjQIJIG3I4fPy6FChUyAbzp06fL+PHj5ejRo9K1a1dp3bq1CaCF1rdvXxkxYoQJemn23nvvvWe9b968eWaa7rfffmvu14Db2LFj/9M4L1++LPXq1ZOSJUvKwYMHZdy4cTJ58mQTFIsMDcppAM/X19f8LatXr5a///5b3njjDXO/Bjk1mKbBOHX48GETlNu/f7/4+fmZZfq8ypUrv/T3vGy9zJo1S7755hsZMmSI7N27VzJlymT+DleiWXUnj1+REmWyWZfFiRNHSpbJJkcOXYrwOVs2npQChTLI8MHLpH7VYdKq6U8ybdImCQgIPiv0PCBQAgKCrGnfFnr70P4L0fwXIbL8HwYH3BMlefFZ/bD2rrosBSuleWHm3vNngbJn5SVJmDiepMka/kwyop9m1J08flVKlslqXRYnjpuUKJP1he/piAL1Nerkl0QeIZmUulO5ZeMpuXn9vjnI1Ky8C+d9TSAI9tnOp45fkxKlbbdz8dJZ5OihyxE+p0DhDHLq2DU59v/A65VLd2TH1jNSpkL2F/6O1cuPSr3Ghf+xHAhiF9228eMHn5C1SJAwnhw9QDDH3i5dviM3b/tJuVIh70vPJAmlcIEMsv/wxZc+9/yF21KhzhCp3niEdP9inly5dtfm/qKFMsqK1Ufk7r1HZj982Z+H5MmT51KqeMjnCKLf06fP5ejRC1K2XG6bfe+yZfPIgQNnI3zOwQNnpWw524zoCuXzvfDxOkV348Yj0qxZuSgePV5tf+yaFC+dOdz39LEXfk+nl5PHrllPkF65dDcS39PHzMk8vqdjocAg+1wcmENOp42MgQMHSs2awXULnjx5YgJva9askbJly5pl2bJlMxl6EyZMsAlgaTDKclsDgfXr1zfZdgkTJjTNJDT7Ti9KA236mpHJxlu6dKnNNN+6devK/PnzTRBQs+DGjBljPjTy5MkjV65ckc8++8xME9Yvo5fRDDkNzJ09e9aaTafByvz588vu3btNcFAbY2gQr0ePHuanrhfNWNS/X6f56rJevXq99Pe8bL2MHj3arJO2bYOnHui4V61aZQ0SuoK7dx6ZgFvYabMpvRLL+bO3InzO5Ut35NqVs1KrXiEZ8VMruXTBV4Z/u0yePw+Udh9VkcSJE5iDxakTN0rmrN7mtVevOGwCCJqNB/sLDAyS5T+fkEz5kkvqLJELtl06eU9unPeT17qEr51zctdNmTf0kDx7EiBJUiSQdwcVZyqtA76nL7zgPR3ascOX5e/TN6XPgIY2y7Wm3pCBy6RJrR9NtkccNzf5rH99KVKcGlr2cO//2zlFSo/w2/nc7Qifoxl4+rxObWeI7sLpVPnGrxeVt9tFfJC3ef0p8XvgL3UbFoyWvwH2U7xMJlk4+4AULJbeZOLt33VRtq47YwI7sC8N4CmvMJ/hXimTyK3bL85wL1Qgowwe0MzUudPadz/9vE5atf9Z/pjbRZIkDs7I/OG7N6Vrn7lSuvq3Ei9uHJMRNGb4W5I5o1c0/1UI7e4dP3Pi28vLtryMl7ennD0bPCMpoqCcd5hptvp4XR6RRYt2SOLECaVmLdeaXeRI9PtWy9ekDDNtNoWXxwu/pzUDT5/Xue0s6/d0o9eLSOt2wXGAsLb8/3u6TsOQ2ohAbBZrM/F06qfF6dOn5dGjRyZ4pYE0y0WDXWfOnLF5nmbtWWimnbpx44b5qVl9pUuXtnm8JSioNm/ebPP6mqFmUbVqVTNF1XIZNWqU9TX1NUJH/cuXL28CYJcu/XO2hz5fg3eWAJ7Kly+fJE+e3NynNPimATutDahZdxrUswT2NGCo60dvv8zL1otOrdXpwKGFvR2WBlbv379vc9FlriQoUA8cE8tn/RpKnnzppEadAvJu+4qyaH7w1GfV75umEhQk0rjm91Kl5CCZP3uneZxbHLI5HMHSccdNQK5Fr5D3xz/Zu/qypM6SRDLkThbuvqyFUkjHUWXl/WGlJGdxb5k75KD43XWt94WzWPr7AcmeM1W4JhgL5uyWo4cuyZAf35Apc9pLp+41ZcS3K2X3jr/tNla8Gm1eMnPKdtOgYtLstvL1iKayfcsZmTZxS4SPX7booJQun128U5FV62x0um36jMmk/eszpX7Zn2Ts0I1Sq1FevqPtYMmKA1K04kDrRZuO/BuVy+eSujUKmOm3FcvmlIk/vmPq361YHTJt78dxa82yX8a2lYUzOkjbVuXl095z5eTpa1H4F8ER/LZwuzRoUPKlNRThePbvuSAzp+wwDSp+nt1GBo14TXZsOSPTJ26N8PHLFx2S0uWz8T0dSwUFBNnl4shibSZe4sQh0XpLRtiyZcskfXrbAyqtQxeau3vIh7QlsBbZM6oaOLTUklNaOy/0eOzVibZSpUry4MED2bdvn2zatMlkJWpNPp1urLUB06VLJzlz5nzpa/yX9RIRnd781VdfOXRX4VeRPIWHxI3rZjobhqYdlFJ6h29qobx8PCVevDgSN25IrDxLNh+5fcvPTM91d49nMu7GTmkrjx89NR3QvH085cue8yVdhhTR/jfhnwN4J3fflPbflZRk3iHNSF7mqf9zObzpmlRvFXE6v06v9UqnFw/JmCe5jHx/i5l6W7kFUy1jw3vaQt+va/48Ku072pYp0DqXE0atk8EjW0i5SsGfuVoP76+T12TOtB1m+j1iVrL/b+c7vo/Cb+cIGhKpyWM3Sa36BaRB0+DMDA3WatOEYV+vkLfblzfTfCyuXbkne3eek0HDm0bzXwJ70MYXA0Y0kKdPnsv9e/7i5ZNYJo/eJmnShz9Jg+hVrVJeKVwgo81US3X7tp+k8g4JoN/29ZM8uYJPRkdGUs9EkiWzt1y45GtuX7h0W2bO2yFL53aWnNmD9/P19fYcOCez5u2UgZ83jsK/Ci+TPEUSsw99+7ZtFt3tWw/E2zvi5m+6PGwm5osev2fPaZPR9/3I4BlYsN/3dBzdH/N9aLP8zu1HJms+IlPGbpZa9fObercqW04fefz4mYz4eqW0bl8ugu/p8zJw+GvR/JcAMSfWZuKFpplpGqzTBhAaSAt9CZ3B9k/y5s0rO3futFm2Y8cO63VtmBH6tbXJQ2Rec/v27aY2ksXWrVvNczNkyBCp51+8eNFcLI4dOyZ37941f7fSrDzNpNMpuxqM0ym7GtjTung6zfef6uH9k9y5c5upu6GFvR1Wnz59TNON0BddFltpwC133nSyd2dITQ0Ncu7Z+bepexeRQkUyyqWLvjbB0Avnb4u3TxLzeqFpTS0N4N2//1h2bj9NF0s70veqBvCObb8h731TQlKksZ2G9zJHtlyXgGeBUrhq5A4gTHftZ0zLsgd397iSO29a2bPznM30aX2Pv+g9bbFu9XF59vS51K5vO31Sp8rrJWwmbdw4ccxrwz7bOVfeNCbQZqHbYt+u85K/kO1JPwt//+fhtqHlgCD0d7lavuSQKZ5dtqJ9TuIhZsRPEM90mNapfVvWnZGylamNFtN0qqtOZ7VccmRLJT5eSWT77pAZN35+/nLwyCUpWjDy+/4PHz2Ri5d8TYML9dj/mfkZOghg+RwP+/5H9IofP57kz59JdmwPaban+9Q7dpyUIkUifg8WLpJVdmw/YbNs27bjET5+4YJt5vXz5Pnn4zFE9/5YGtm387zt/tiuc5LvBd/TetI0/Hs04u/pFUsOm+/pMhUj1/QIDkiPpe1xcWCxNhMvNA2IaT04bWahH+4VKlQwQSMNlmk313fffTdSr/PJJ59ImzZtTMadTnnV6bLaJEPr6/1bHTt2NLX2OnfuLJ06dTJTUzUjrVu3bv9YD0/VqFFDChYsKK1atTKvo11t9TU1MBd6SrFOl9Xada+//rq5rR1qNQA4d+5c+emnn+S/0LG///775vdp51p9zUOHDr10vWhQNWwWZGz35ttl5esvf5c8+dNJvgLpZe7MHSY7Q7vVqoF9fxOfVEmlwyc1zO3XWpSUBb/ukh+GrJTXW5aSixd8ZfqkzdL8rZAp2zu2ntavG8mU2dsE/H4auUoyZ/GWBo1pc28vGsA7tPGavPVFEYnvEU8e3Ame7prQI564JwgucL5gxGFJ6pVQarWxzXDdt+qy5CmTSjyShjQ6sGTobZx7VvKU9hHPlAnk4f1nsmvpBXlw+4nkrxDcrRgx7423y8g3Xy6WPPnTSr4C6UwXU31P128SfGZ3UN9FZupFh0+qh2toUbFqbkmW3DbAqx0ui5bILD99v8Y0qEmTNpns33tBViw9JF16BNdwRcxr0bqUDO63VHLnSyN5C6ST+bN3mzP2WuBaffPFH2Y7f9gluOxEuUo5zP9CrtypJW/BdHL54h2ZPG6Tya4MnVmtBxkrFh+SOg0Kmqxr2JdmyF65eM96+9rl+3Lm5E3xTJZQUqXxlCljtsmtG37Sa2At62P0fvPcx8/k3p3H5nY897iSOVtwXdoTR66Z52TP5SO3bvrJzIm7zAFii3eK2+EvRGg6a+SdluVk3OQNJqiXIX0KMw02lY+n6VZr8W6HKVKzSj7TbVYN+WGFVK2YR9KlTW462Y6esNYEAxrUDv48yJbFx7xev28Xy2ef1JXkyROZbrdbd56RCSNbsxFi2Lttqkmf3tOlQIHMUrBQZpk+bb08fvxEXmsaXO7os89+kdSpkku37k3M7XferirvvDNSpk5ZI5WrFJDly/aY5hhfDWxl87p+fo/lzz/3Sa/PyKJ2BM1bl5TB/Zb9/3s6rSyYvcfsj9VtHHyy9Nsvlprv6Q+6BCemlK2Uw3S0zZFby5pYvqc3m+/vsN/TKxcfltoNCvA9DafiFEE8NWjQIPHx8THTOLV7q2anFStWTD7//PNIv4Z2fNUaetoEQps6NGvWTDp06CB//vnnvx6XTu9dvny59OzZ00xt1eCaNon44osvIr2TsnjxYhNI0+w6DfxpswoN2IWmQT0N8oWufafXtSPuP9XD+ycaQNR1qoFSXS8tWrQwwc5du3aJK9FadXfvPJSfx64X31t+kjN3Gvl+bGvrlKzr1+7ZnBVKnSaZjBz3towatlLeaT5OvFMllRatSkvrthWsj3no5y/jRq01nSyTJkskVarnlQ87VzcHEbCPXcuDa1VO6RNSu1C99ml+KVYj+IzgvZv+4c4A3rz0UM4fu2uaVYSlWT16//61V+TR/acmyJc+Z1JpN6SkpM788qmbiD7aWVYbXEwau/H/7+nUMmLsW6He0/fDZWSdP3dLDu2/KCPH2x4QWHw1pKmM/3GdfNVnkcms1UDeh52qSpPmHPTbS/Xa+cx2njJus5lGqzv9w39qYZ2mE3Y7v9O+vGhVCf2/uHnDz0y91gOD9zvZZrXv2XnWPLd+k8jXzET0OXXshvT66Hfr7Qkjg2sY1myQR3oMqCm+tx7KzWu20+c7tvrVev2v4zdk/cpTkjqtp0z/o41Z9vRJgEwbt0OuXr4viRK5S8nymaXXwJqSxNO5TlLGVu+/W1Ee+z81ATetYVe8SCaZNOpdm/pmmmV3527INL1r1+9Lt77zTOfZlCkSS/HCmWXeLx+a68o9XlyZ+OPbMmL0Kvmo2wx59OipZMroJd8NaCqVK4R0SUXMqFevhNzx9ZNRo5fKrZv3JW/eDDLx507W6bFXr9yROG4hQZuixbLLsOHvyY8/LJGRI5dI5iw+MnrMh5IrVzqb112+bK8JyNevX5JN6QCq1c5rvqenjtti/Z4e+pLv6bfblzPf05PHbjYnWrT0gX5Pt+tUyeZ1NQtfn1uP72k4GbcgcsPxL2gTEa27N2PGjFd+7m3/OaxzJ+aVsKX1+ry/Ott1LIg+LXKGnEi45T+TVe3EvBOGZJ9cf/SLXceC6JPaIzhwpc49GMOqdmJZPDuF3Hgw355DQXTybG69Ghi0lnXtxOK4hcwYuPpoil3HguiT1uM9l1y9T0cFzzSMafG7LBBH5TSZeIg+2vl3/PjxUrt2bYkbN67MmTNH1qxZI6tXr2a1AwAAAAAAxACCeIjUlF6dEvzNN9+Y6bTa6GLhwoWmXh8AAAAAAECUC6CpUFgE8fCPtCuvZt4BAAAAAADAPgjiAQAAAAAAwKEEBZKJF1ZIOx8AAAAAAAAADolMPAAAAAAAADgWauKFQyYeAAAAAAAA4OAI4gEAAAAAAAAOjum0AAAAAAAAcCxMpw2HTDwAAAAAAADAwRHEAwAAAAAAABwcQTwAAAAAAADAwVETDwAAAAAAAA4lKDDI3kNwOGTiAQAAAAAAAA6OIB4AAAAAAADg4JhOCwAAAAAAAMcSEGjvETgcMvEAAAAAAAAAB0cmHgAAAAAAABwKjS3CIxMPAAAAAAAAcHBk4gEAAAAAAMCxBATZewQOh0w8AAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAwMERxAMAAAAAAAAcHI0tAAAAAAAA4FgCaWwRFpl4AAAAAAAAQAx48uSJFClSRNzc3OTAgQOv9Fwy8QAAAAAAAOBQggKcMxOvV69eki5dOjl48OArP5dMPAAAAAAAACCarVixQlatWiXDhw//V88nEw8AAAAAAACOxU418Z48eWIuoSVIkMBc/ovr16/L+++/L4sWLRIPD49/9Rpk4gEAAAAAAAAiMnjwYEmWLJnNRZf9F0FBQdKmTRv56KOPpESJEv/6dQjiAQAAAAAAACLSp08fuXfvns1Fl0Wkd+/epkHFyy4nTpyQ0aNHy4MHD174OpHFdFoAAAAAAAA4loBAu/zaBK8wdbZ79+4mw+5lsmXLJuvWrZPt27eHe13NymvVqpVMmzYtUr+PIB4AAAAAAADwinx8fMzln4waNUq+/vpr6+0rV65I7dq1Ze7cuVK6dOlI/z6CeAAAAAAAAEA0yZQpk83tJEmSmJ/Zs2eXDBkyRPp1qIkHAAAAAAAAODgy8QAAAAAAAOBQggKDxFllyZLFdKx9VWTiAQAAAAAAAA7OLejfhP4AAAAAAACAaPKwa027rNvEI1eLoyKIB0STJ0+eyODBg6VPnz6Rbk+N2Ilt7RrYzq6Dbe0a2M6ug23tGtjOroNtDVdGEA+IJvfv35dkyZLJvXv3JGnSpKxnJ8a2dg1sZ9fBtnYNbGfXwbZ2DWxn18G2hiujJh4AAAAAAADg4AjiAQAAAAAAAA6OIB4AAAAAAADg4AjiAdFEm1n079+fphYugG3tGtjOroNt7RrYzq6Dbe0a2M6ug20NV0ZjCwAAAAAAAMDBkYkHAAAAAAAAODiCeAAAAAAAAICDI4gHAAAAAAAAODiCeAAAAAAAAICDI4gHAAAAAAAAOLh49h4AAAAAAPxXTZs2jfRjf/vtN1Z4LHXo0KFIP7ZQoULROhZEL7Y1EB5BPACIpFGjRkV6XXXp0oX1GouxrQEg9kmWLJm9h4AYUKRIEXFzc5OgoKAI77fcpz8DAgLYJrEY2xoIzy3oRZ9+ACItRYoUZkchMnx9fVmzsVTWrFkj9Tj9X/j777+jfTyIPmxr18Bnt+tgWwPO4/z585F+bObMmaN1LIhebGsgPDLxgCjwww8/sB5dwNmzZ+09BMQQtrVr4LPbdbCtXdfNmzfl5MmT5nru3LnFx8fH3kPCf0RgznWwrYHwyMQDgP/IktAc2WxMxF5sawCIHR4+fCidO3eW6dOnS2BgoFkWN25ceeedd2T06NHi4eFh7yEiipw5c8YE6o8fP25u58uXTz755BPJnj0769jJsK0ButMC0ULrbyxcuFC+/vprc/n999+pyeGE9MCgYMGCkihRInPR4skzZsyw97AQDdjWroHPbtfBtnZ+3bp1k40bN8off/whd+/eNZfFixebZd27d7f38BBF/vzzTxO027Vrl9kP08vOnTslf/78snr1atazE2FbA8HIxAOi2OnTp6VevXpy+fJlM21D6TSOjBkzyrJlyzgr6CS+//57+fLLL6VTp05Svnx5s2zLli3y008/mcBt165d7T1ERBG2tWvgs9t1sK1dg7e3tyxYsECqVKlis3z9+vXSokULM80WsV/RokWldu3a8t1339ks7927t6xatUr27dtnt7EharGtgWAE8YAopgE8nXI3a9YsSZkypVl2+/Ztad26tcSJE8cE8uAcjQ+++uorMy0ntGnTpsmAAQOoqeZE2Naugc9u18G2dg06XXbv3r2SN29em+VHjx6VUqVKmem2iP0SJkwohw8flpw5c9osP3XqlMnK8/f3t9vYELXY1kAwGlsAUUynaezYscMawFNeXl7mDKElYwux39WrV6VcuXLhlusyvQ/Og23tGvjsdh1sa9dQtmxZ6d+/vymHoAf/6vHjx+YEnN4H56CNSg4cOBAuiKfLUqVKZbdxIeqxrYFgBPGAKJYgQQJ58OBBuOV+fn4SP3581reTyJEjh8ybN08+//xzm+Vz584NtyOJ2I1t7Rr47HYdbGvXoI0O6tSpIxkyZJDChQubZQcPHjQBPa2tBefw/vvvywcffCB///239eTq1q1bZciQIaYuIpwH2xoIxnRaIIrp9EqtvzF58mQzXUNpgV394ilevLj88ssvrHMnoI1L3njjDalRo4Y1w1J3GteuXWuCe6+99pq9h4gowrZ2DXx2uw62tXMbM2aMKWGSPHlyefTokSlvcuLECXOfTq1t1aqVaUaF2N+cRrsNawkbDdiOGDFCrly5Yu5Lly6d9OzZU7p06SJubm72Hir+I7Y1YIsgHhDFtPvZu+++a7qhubu7m2XPnz+XRo0amQBesmTJWOex2JEjR6RAgQLmutbaGTlypBw/ftx6cKAd77TwLmI/trVr4bPbdbCtnZvuZz179kyaNGki7du3l2rVqtl7SIgGadKkkTZt2ki7du2sMyAsM2E8PT1Z506EbQ3YIogHRJHXX3/d7Cxqhyw966fd70IHd3RKHmI/bU5SsmRJs63ffPNNdhSdGNvaNfDZ7TrY1q5B697Nnz9fpk6dKps2bZJMmTLJe++9J23btjVTa+EcBg0aZJqJnT171kyj1WCedh3WhiZwLmxrwBZBPCCKVK9eXTZs2GBS+HVHUS/a1RLOZfPmzebAYMGCBRIYGGgOCnXHsWLFivYeGqIY29o18NntOtjWrkfrpOksCG1ucenSJVMCQ7+zNUvPMlsCsZvue+t+mZa+0Om1GsjTE62lS5e299AQxdjWQDCCeEAUOn/+vNmR0J1FvV65cmWzI9GsWTNTSBvO4+HDh6b2nR4caLBHMy31wECnUmvaP5wH29r58dntOtjWrknrpq1Zs8Z8Zy9atEgSJ04sN27csPewEIW0gdyvv/5qtvG2bdvMLBjdL6O5hfNhW8PVEcQDosm6detkypQp8vvvv5sAXsuWLc10Dm1uAeeiU6c1eDtjxgy5du2a6Ya3ZMkSew8L0YBt7fz47HYdbGvXsn79etN07LfffjP7ZXfu3LH3kBBNli1bZhrYaP1LbYoA58W2hisiiAdEMy2yO3v2bPn888/l3r17pskFnDNbSzvg9enTh51GJ8e2dg18drsOtrXzunjxojnJptlZFy5ckEqVKpnsLJ0hkTBhQnsPD1FIOxHrDAnd3lu2bJHs2bObk+e9e/dmPTsZtjVcXTx7DwBwZlpsV3cc9aIBPK3FAueiRbM141JrsWgjBK3FogcIcD5sa9fBZ7frYFs7n6dPn5psO/1u1mzLtGnTmlIXGtDJli2bvYeHKKZTZ3VbazMTPVGutYq1EYIGbOFc2NZAMDLxgCjm7+9vmh7oDoUe9GfMmNHa6EKvI/a7cuWKNTir0ytDd0XTOjtwHmxr18Fnt+tgWzu3lClTmkydBg0amO/m2rVrm5NscC5Dhw41WXenTp2SEiVKmG2tpWs8PT3tPTREMbY1YIsgHhBFdu3aZQJ3c+fONQcIr732mjnrq93w3NzcWM9Oom7duqY4tre3t6m3ots4d+7c9h4WogHb2jXw2e062Nau4fvvv5e3335bfHx8rMvmzJkjjRo14kSbE9Ht27p1axO8K1CggL2Hg2jEtgZsEcQDooie5S1cuLDZmWjVqpWkSJGCdeuE9CBAt7Ge4Y8bN65ZdunSJUmXLh1n+p0M29o18NntOtjWritp0qRy4MABptM6kWfPnom7u7vNsoIFC8ry5cuZ+eJk2NaALYJ4QBTZt2+fFCtWzGZZx44dZeDAgSZrC86LgwPXwbZ2Pnx2uw62tevSKZYHDx4kiOfk2M6ug20NV0aBCCCKhA3gqZkzZ8r9+/dZx04uKCjI3kNADGFbOx8+u10H2xoAAMR2BPGAaMQBPwDEPnx2uw62tWtYsWKFKXsB51axYkVJlCiRvYeBGMC2hiuLZ+8BAEBs9/nnn5tueHB+bGsAiH0qVKhg7yEgBmg9PLgGtjVcGTXxAAAAADiV69evS48ePWTt2rVy48aNcFmXAQEBdhsbok6mTJmkSpUqUrlyZalatSp1D53MkiVLXqkhGeAKCOIB0SAwMFBOnz5tdhr1emiVKlVincdS3bp1i/Rjv//++2gdC2KOHuj98ssv1gPBsO/pdevWsTmcwDvvvGMOAPUzOnv27PYeDqLYq9Sn1QY2iP3q1q0rFy5ckE6dOknatGnFzc3N5v7GjRvbbWyIOlp/etOmTbJhwwaz750+fXoT0NOLBvdy5szJ6o7lXcVD0/dx6IB86Pc1gXm4CoJ4QBTbsWOHvPXWW3L+/PlwZ331i4YvmNhLD/DDdjp8/vy55M6d29w+deqUxI0bV4oXL05gx4noAaAG8erXrx/hgeDIkSPtNjZEnfbt25sDwdAHgZbsDg4CneNAMOx790X4nnae7pWbN2+WIkWK2HsoiCFXr16VjRs3ytKlS2Xu3LnmpBvvZ+exZs0a+eyzz+Tbb7+VsmXLmmXbt2+XL774wiyrWbOmvYcIxAhq4gFR7KOPPpISJUrIsmXLIjzgR+y1fv16m0w7PUCYNm2apEiRwiy7c+eOtG3b1hTbhfP49ddfZd68eVKvXj17DwXRaNKkSebn5cuXTTBPDwRHjBghH374ofksv3TpEuvfST6/z507J71795Y2bdrYHAjq5/ngwYPtOEpEpYwZM9K4xEU8evRItmzZYrLx9L2+f/9+KVCggDkRA+fx6aefyvjx421qXNauXVs8PDzkgw8+kOPHj9t1fEBMIRMPiGKJEyeWgwcPSo4cOVi3TkwzdVatWiX58+e3WX7kyBGpVauWXLlyxW5jQ9TSjoZ6YJArVy5WrQsdDOqBoG53zbjNly+fOSiEc6hevbrJvGzZsqXN8tmzZ8vEiRPNdkfsp9/RGoifMGGCZMmSxd7DQTQpV66c+XzOmzevNXtayyJYTrDCeWjn4d27d5sAbWiHDh2S0qVLy+PHj+02NiAm2U4yB/Cf6ZeITseC89dXunnzZrjluuzBgwd2GROiR/fu3eXHH38ko8MFOg/rwaCXl5fJ0vL39zc/r127RgDPyWjWnWbMh6XLdu3aZZcxIWpo4Ea7xevlzTffNAFZrXGpmfOW5ZYLnMOJEyfMCfQ8efKYiwbzCOA5p5IlS5r61Nq0xkKv9+zZU0qVKmXXsQExiUw8IAroGSCLM2fOmNoM+oVSsGBBcXd3t3lsoUKFWOdOUgRfa+3oWX7LjsPOnTvNdtfptDotC7FX06ZNwzWv0IM+zbwM+57+7bffYnh0iK6aaT4+PtK1a1ez/cm8dF5ax1SbGgwdOtRmea9evWTx4sVy8uRJu40N/82rfPe+++67rG4noPWnDx8+bAK2WgZByyHEjx/f2q32/ffft/cQEUU0SeK1114zNah1ury6ePGiqVu7aNEiZkHBZRDEA6KwYHbYRhbWN9r/76OxhXNNuevRo4dMmTJFnj17ZpbFixdP2rVrJ8OGDTNnhRF7aW3DyJo6dWq0jgUxQ8sg6AGgHghqgN5yEKjTs/RCUM95LF++XJo1a2YO+DR7XmkG3l9//SULFy6k/iUQS+m+9t69e2XMmDEya9YsGls46TZevXq1ycBUmnlZo0YNapDDpRDEA6KAdqKNrMyZM7POncjDhw9N9qXSKTsE7wDnCepp52EOBJ2TZm+MGzfO5kBQG1NZsjvgHGUvIqInVBMkSGAC9Yj9tG6pnnzRi9Yz1ZImOhPGUh9Ps27hfLTkhb6PaSAIV0QQDwD+Y2q/BvG0iLIW3LVkXAKIXfS9q8XRQx8MahBASyDogaAG9ADEvlkSL5IhQwbTobh///7msYiddBZE0aJFzee0palFsmTJ7D0sRIPAwED55ptvTIdarYWn02qzZcsmX375pWleo7NhAFcQz94DAJzNkiVLIlyuO5IJEyY003eyZs0a4+NC1Lp9+7a0aNHCdLDUbavTsHRHQncgtKCy1sqDc9CDg4gOBEO/p/VAUGvvIPbSmod+fn5SuHBhcyCodZS0vmXy5MntPTREA50yrV1L//77b5k/f77pOD5jxgzz/VyhQgXWuRP45ZdfpG/fvubz2VK7VqdNa908rV2sjaiGDx9usnm0sQ1iJ19fX0maNKm9h4EY8PXXX5v3r9YzDV3rULvV/vDDDwTx4DII4gFRrEmTJhHWxwtdF08PELQAK92zYi8tfq8NDi5cuGCmYVm88cYbpnMWQTznUadOHTPtTqfnWA4Ed+/ebRra6MHhsWPHTD0WbXDBtJ3Ya+bMmSZox8Gg89O6d2+//ba0atXKTMV78uSJWX7v3j359ttvTc08xH56sK/fxXrCzaJhw4bms1wDuGvXrpVMmTKZzB6CeLGX5TNba+EdP37cXM+XL58UK1bMziNDVJs+fbpMnDhRqlevbsofWOjJN0tpBMAVkDsORDEttqot0PWnHhDoRa9r8eylS5earlmaxaVNERB7rVq1SoYMGWKm44SmHbJepUYiHN+tW7eke/fu1m7EetH3sb6HtSai/i9oVsegQYPsPVT8B/Xr17ceDF66dMlc4LzZHDod6+eff7bpNl2+fHkT1INz2LZtm8mkDkuXbd++3VzXk6p6Mg6x140bN0wmvO57d+nSxVxKlChhAj2abQnncfny5Qg70Oo0W0uTOcAVEMQDotgnn3wi33//vdl58PT0NBe9rh1Le/bsaQ4SNOVbA3uIvTR44+HhEeG0Dp2aA+cxb948admyZbjlb775prlP6f0nT560w+gQVfQgYODAgaaWkjYg0otOpdXgrN4H56HvVa2bFZZu+7t379plTIh62qRk8uTJ4ZbrMksDEz2pyqyI2K1z586mFMLRo0fNPphejhw5YmqaakAPzkMzLPWEalgLFiyIMGAPOCum0wJRTJscRDQdS5dp7R1LtpZm9yD20ml3mtZvyb7SadJ6oK91OqiN5ly07p1mdIQ9+6vL9D6l295yHbGT1s7Sg/vvvvvOnGxR2txiwIABpgueTrmDc0iTJo1pSqSF0EPT7a21TeEctN5d8+bNZcWKFSZLS+3Zs8dMu9ODfktpBC2Dgdhr5cqVsmbNGpvSJhrs+emnn6RWrVp2HRuiVr9+/eTdd981GXm636VlTPSkjO6P62wnwFUQxAOiWPHixU3GnX6h+Pj4mGWazt+rVy/rTqQ2QbCcBUbspME6zbDUA4KnT5+a7Ws5C7x161Z7Dw9RfJZfa69ovR3Le1gP/CZNmmSto/Tnn39KkSJFWO+xvH6WbtNGjRpZl2lnWm140LFjR4J4TkQLomvW/JQpU8wJmCtXrpjplTpFXrscwjnoe1kDdlpDy5IpXbduXVOT2BLA7dChg51Hif9Kgzmhp8Vb6DKyqJ2L1h3+448/TNZ84sSJTVBPax/qspo1a9p7eECMcQsKW30fwH+iO4r6JXP27FlroO7ixYvm7P7ixYslV65cZgfywYMHprA2Yi+tdzhmzBg5ePCgmcqhOxIff/yxpE2b1t5DQxSbNWuW2daWA8HcuXOb4N5bb71lbj9+/NjarRaxk247bVain9Gh6TbXAK1uYzgH3fXVBhaDBw+WR48emWVaBkGDeNS2BGIX3efWafBz5syRdOnSmWWaqaWNa3Sq9O+//27vIQJAlCKIB0QDPfOnxe5PnTplPeDXM0Rx4lCGEgAckTYf0suoUaNslmuwVjMvd+zYYbexIXpoFrVOq9WTMDr9LkmSJKzqWE4D8QUKFDD7W3r9ZTTTFrGfnijXrEudDRH65Ln+H+jJc2a+AHA2BPEA4BVEtotdpkyZWK9ALLJx40bToVbfu2XLljXLdIqlHgwuX77c1MEE4Ng0eHft2jVJlSqVua4Z0hFNOtLlAQEBdhkjop5uY62Lp9OnldbHq1GjBqvaSUS2Vqml9jjg7AjiAVFAMzc++OADMx0rbBZHWHTKit3ixo1rvW45MNCDgdDLODiI/VKmTGkyab29vc10nNDbOCytgwjnoLXRtBh66ANBrYdnmaKF2O29996L1OO0Vh5ip/Pnz5tAvH5m6/WX0Q7UcF76Oa4ZepZZMYi9NCCv71ctYaIB+hfRWqeAKyCIB0SBrFmzmgYHXl5e5voL33BubpwliuXixYsnGTJkkDZt2kjDhg3N7YgULlw4xseGqG1y8Oabb5o6WXr9ZbRTGpzXpUuXTBFtLY4P5zgQLFq0aITZWRbU0AJiP61XrLWKybiM/ebPn29OrmzYsME0p9ETMvXq1aNMEVwWQTwAeAU6TUeDOlOnTjWFlFu3bi3t2rUzGTsAnA8Hgs5DGw9p8XsN5LVt29Z8fmvWLZzLkiVLIvW40J2o4Xz47HY+2rDkl19+MRdtSqQNAnUfPGfOnPYeGhCjCOIBwL+0ZcsWE8zTM4RaFF13JPRCAxPncP/+/Ug9LmnSpNE+FtgPB4LO5cmTJ/Lbb7+ZrI5t27aZOoj6uV2rVq2XTptH7BH2OziiuniUvXB+fHY7fx3bAQMGyKZNm+TWrVum9AngKgjiAVGkW7dukXrc999/zzp3MtevX5eWLVuaHYqbN2+S2eEkLEXRX4T6h66BA0HnpTXTNKNj+vTp8vz5c9Pdkg61zsfT09O8jyNbHB/Ogc9u5+Tv7y8LFiwwJ2K0a7xm1OoMGS1/AriKiIs5AXhl+/fvD5elVbx4cUmUKJF1GWf5nYtmcehOhGbi5c6d2xTET548ub2HhSiyfv16m4Cd1l+ZNGmSpE+fnnUMOIHQ3UupmwXELv/UdEoD83AeO3fulMmTJ8u8efNMQF7r4i1cuJAMPLgkgnhANBzwW878zp49mzO/Tubq1asma0On0d65c0datWolW7dulQIFCth7aIhilStXDteZuEyZMrynnUzTpk1fer/WvoRzTqfVk20NGjSQMWPGSJ06dSiFAMQiP/zwg72HgBiSP39+uXHjhulOq7NeaB4HV8d0WiCaMH3DObm7u5tMLO1Iqin8ejsihQoVivGxIXrxnnZO2uAgMjRwj9itY8eO8uuvv0rGjBlNFoeehPH29rb3sBDN+OwGYn/WdOLEiSVevHgvzb709fWN0XEB9kIQD4gm7DQ6f8Fsy44EBbNdA+9pIPZ/fmfKlEmKFi360gNBzdSD89DmQ1ofLWvWrPYeCmIgUD9w4ECC805Ga95Fhp5gB1wB02kB4BWcPXuW9eXCqGvpGubMmWMybfXMP5zHO++8w3vYBWul+fn5mcBt2K61ZO04n5kzZ0qPHj0I4jkZgnOALYJ4QBQ5dOiQzW3Nzjpx4oTZeQyNaZaxW+bMme09BNipVpp2RPvoo4/CBXbI2nE+H374oZQuXZr6h05GO9HC+VErzXWFnRkB50XWJVwZ02mBaOhyF+6N9v/l+pMOeM6nYMGCsnz5clNnCc6DWmmui6nTroOsS8B58NntWtPkDxw4wMk2uCQy8YAowjRL13Xu3Dl59uyZvYeBKEYjA8D5kXXpGsjacQ0PHjyw9xAQQ8i6hCsjiAdEEaZZAs6PrB3XsGLFChxXbCAAABiASURBVEmXLp29h4EYwIGga6BWmvPat2+fuLu7m1kRavHixeYkXL58+WTAgAESP358ew8RAKKUbYVXAFFKdyguXrzIWnUyz58/N93PLl26ZG5XrFhREiVKZO9hIYaydq5fv866dnIVKlSQhAkT2nsYAKIIwVrn/l4+deqUuf7333/Lm2++KR4eHjJ//nzp1auXvYeHaMy6zJYtG+sXLolMPCAaMc3SOcWLF0+GDRtmOh0qrYcH18CBoHPRjpWR7Tis2R5wPmRdArGbBvCKFClirmvgrlKlSjJ79mzZunWrCejR6MR5kHUJBCOIBwD/QrVq1WTjxo2SJUsW1h8QSzVp0sTeQ4ADZF3C+VErzblPrgUGBprra9askQYNGpjr2mzs1q1bdh4dojrrsnfv3mamkyXr8rXXXjPB20ePHhGwhcsgiAdE8TTLb7/9Vt577z3JkCED0yydWN26dc2OxOHDh6V48eKSOHFim/sbNWpkt7Eh+pC141z69+9v7yEghpB16XrI2nENJUqUkK+//lpq1KhhTq6OGzfO2nAuderU9h4eohBZl0AwtyDmBgFR3t5eAztkaDm3OHFeXFJUp+cFBATE6HgAAC/21VdfRXr1ENx1DiVLljQn25o1a2aydvLnz2+ydnbv3i3169cna8dJHDx4UFq1amVqUHfr1s36/u3cubPcvn3bTK2Fc0iaNKns3btXcubMKTVr1jRZl5988olcuHBBcufOLY8fP7b3EIEYQRAPiGKNGzeWpk2byrvvvsu6BWIpsnZcQ4oUKSJdE8/X1zfaxwMg6iRLlsxk42XPnl2GDBki69atkz///NNaK43GY87N399f4saNazrXwnlK2eg0ac26bNeunRw7dkxy5MhhMjD1uEtrkQOugOm0QBRjmiUQ+1ErzTVQ8BxwXtRKcw0avNGAjja0CI0O485n5MiRJuty0aJF0rdvXxPAUwsWLJBy5crZe3hAjCETD4hiTLN0HQ8fPjRn/zSN/+nTpzb3denSxW7jAgDYIuvS9ZC14zon3ZYvXy6ZM2eWtm3bmqBe+vTp7T0sxCCyLuFqCOIBwL+wf/9+qVevnumGpcG8lClTmi5oHh4ekipVKlN/B0DsocH4l8mUKVOMjQVRb9q0aZF+LOUwnAO10lzHzZs3ZcaMGeZ9rlMsdbqlNpnTAB/TaZ0/6xJwNQTxAOBfqFKliuTKlUvGjx9v6u7owYLuKLZu3doU2dW6iIi9yNpxzSzql9XHo1kN4BzI2nFuWgdx6tSpMmnSJEmSJInZL+vYsaNphoDYjaxLIBhBPCAaMM3S+SVPnlx27txpumHp9e3bt0vevHnNMj1TeOLECXsPEf8BWTuuRwPxoT179sxk3H7//ffyzTffEJh3ImRdugaydlzP1atXZfr06SaId+nSJdOZ+PLly6b0ydChQ6Vr1672HiL+I7IuAYJ4QJRjmqVr8PHxkW3btpkzu5qRN3r0aKldu7YJ3hUvXtwEcgHEfsuWLZNhw4bJhg0b7D0URBGyLl0DWTuuQU+4LFmyxATuVq1aJYUKFZL27dvLW2+9JUmTJjWP+f3338302jt37th7uIhCZF3CVdGdFohiepavYcOG1mmWO3bssJlmCedQtGhR2b17twniVa5cWfr162dq4mlNlgIFCth7eIhCZO24Ns221fc6nOtk28uyLuEctINl6Kyd/v37UyvNCaVNm1YCAwOlZcuWsmvXLilSpEi4x1StWtXMmoBzZV2uXr3aXOLGjWvqVB8+fFjy5ctH1iWcHtNpgSjGNEvXsGfPHnnw4IHZMbxx44a888471sy8KVOmSOHChe09REQRsnZcw/37921uBwUFmYOEAQMGmAzbAwcO2G1siBlkXTo3snackwZpmzdvLgkTJrT3UBDNyLoEgpGJB0QxzbrTg36lXUo1i0drpWlW3sWLF1nfTqJEiRLW67qdV65cadfxIPqQteM6J2DCNrbQQF7GjBnl119/tdu4EHPIunReZO04r7ffftveQ0AMIesSCEYmHhDFatWqJW3atDG1ON5//305dOiQdOnSxZwp1Foc2vgAzuH58+emTtaZM2fM9vb09JQrV66YGizaEQ3Ojawd56Lv5dBBPD0Zo7Uvc+TIIfHicc7TmZB16RrI2nGt2RHz5s0zJ86fPn1qc99vv/1mt3EhapF1CQQjiAdEMaZZuobz589LnTp1zA7jkydP5NSpU5ItWzZT91Bva01EOLfTp0+badM0MXEOt2/fFi8vL3Nds6Z//vlnefz4sTRq1EgqVqxo7+EhmqfIh866LFu2LOvbCXh7e1trpelJ1Yhqpd29e9fUuD179qxdxoj/Tt+zWtJEm4tpYws9ma77ZNevX5fXXnvNNLwAAGdCEA8A/mXXO828mzx5sjnwP3jwoAniaTaPHiz89ddfrFcnQdaOc9NC2NqMSAN3WtNSDwg1QK/BWQ326M8FCxaY9zycA1mXroGsHdeg3Wg//PBD+fjjj81+me6PZc2a1SzT6ZdfffWVvYeIKETWJSASXLgLQJTSaZZr1qyRCRMmmOYHSqdZ+vn5saadxObNm+WLL76Q+PHj2yzPkiWLXL582W7jQvTUSkuRIoX1kjJlStP9bPv27TJu3DhWeSzXq1cvKViwoGzatEmqVKkiDRo0kPr168u9e/dMCQQ9EPzuu+/sPUxEId3e2lVcL3ryRbsb6gkZfU/DuWql0ezA+WlJE/3MVrpPpideNNO2a9euMnHiRHsPD1FIT7KVK1dOjh8/Lr///ruZMn/06FFZt26dqT0OuAqKvADRPM2yZs2a5szgkCFDmGbpRHSKTkBAQLjlly5dMtsbzkN3DqmV5rx2795ttrFmc+j0aD3o69ixo7VBUefOnaVMmTL2HiZiIOty5MiRZF06GbJ2nJ+eXLOcME+fPr0cOXLEBOp1qvSjR4/sPTxEoW+//dZ8TluyLn/88UebrEvAVZCJB0QxrYmmnUs1gyNRokTW5VqXY+3ataxvJ6E1V3744QfrbQ3yaKZl//79pV69enYdG6IWWTvOzdfXV9KkSWOua0OaxIkTm4PCiA4QEbuRdelayNpxDZUqVTLZtKp58+ZmP1zLmmgtxOrVq9t7eIhCZF0CwcjEA6JhmuW2bduYZunkRowYYYoo67RKf39/051W6+Bpfbw5c+bYe3iIAmTtuI6wTQ7C3oZzIOvStZC14xrGjBlj9sNU3759xd3d3eyHN2vWzJQ9gfMg6xIIRhAPiGJMs3QNGTJkMMWT9Uz/oUOHTBZeu3btpFWrVjYZmIj9WTuzZs0yBdIttdK0a6llmqXWSqPhQezXpk0bSZAggbmuB4MfffSRychTWhYBzoGsS9fysqydatWq0fDASWidWgudFt+7d2+7jgfRn3Wp+2aWrEsth6HLyLqEKyGIB0TTNEtLMV2mWTqn27dvm6y71q1bm/pKGtg5efKkqb9TsWJFew8PUYCsHdfw7rvv2tzW93RY77zzTgyOCNGJrEvXQdaOa9DP56pVq5oAT/bs2e09HEQjsi6BYG5BQUFB/78OIApoYwOdZqlvLZ1eqfXxLNMsdaptqlSpWM9OPMVSfy5YsIDsLCeg2/PatWvW96wWUdbsS+1mqa5fvy7p0qWLsMEJAMd8T9etW9eadfnHH3+YjKzQWZcrV67kPe0ktMyF7oN169ZNBg0aJKNHj5bGjRubrJ1ixYrJb7/9Zu8hIgq0b9/edBc/ffq0aWyhXae107j+1P00AHA2BPGAaPD8+XObaZa6s8g0S+egB4Dx4sUz0zV0iuXSpUtN0Db0FMu9e/fKjh077D1URMEBvwbqfHx8rEE8fU9rJzRFEA+IXdq2bRupx02dOjXax4KYmT6t0+P1ZIuWOhk6dKiplaaBHa2VFrqBDWK/y5cvm2Dexo0bzeXUqVOmY6meXIdzIOsSCEYQD4imaZbKMs3y8ePH0qhRI6ZZOgFvb29Tf6NQoUImQJs0aVIz7bJ48eLm/hMnTkiZMmXk7t279h4q/iOydgAAiB0ePXokW7ZskfXr18uGDRtk3759pvnY/v377T00RBGyLoFgBPGAKMI0S9fAFEvXQdYOAMReZO24hs8//9wE7TRYlzdvXut0Wq2RR7alcyLrEq6OxhZAFKGTpeugMLprYEodAMRe2pF28ODBpnM8tdKcl3aJ17IX/fv3l6ZNm0quXLnsPSREMw3O6qwn/Zk8eXJT5sZS+gRwBWTiAVGEaZaugSmWAADEHmTtODdtOKU18DQbTxvIafDWko2nF4J6zoOsSyAYQTwgijDN0jUwxRIAgNiDWmmuF9QbOXKkzJo1yzQ0oYO8cx1racZd165dybqES2M6LRCFmGbp/JhiCQBA7Mza0c7y1EpzLkFBQWYb67bWiza3uH//vmlAptsczkO3syXrcsSIEWRdwmWRiQdEEaZZAgAAOAaydlyD1kXz8/OTwoULW6fRVqxY0dRKg3Mj6xKuiiAeEEWYZgkAAOAYqJXmGpYtW2aCdkmTJrX3UGDnrEudRg24AoJ4AAAAAJwaWTvO7fTp03LmzBkzXTpRokQm4BO2zA1iN7IugWDUxAMAAADgVKiV5hpu374tLVq0kPXr15ug3V9//SXZsmWTdu3amaCP1k6Dc5g5cyZZlwCZeAAAAACcDVk7ruGdd96RGzduyKRJk0wDE8241CDen3/+Kd26dZOjR4/ae4iIYmRdwtWRiQcAAADAqZC14xpWrVplAnYZMmSwWZ4zZ045f/683caFqEfWJRAszv9/AgAAAIBTqF+/vml2oFk7GuR5/PixdZotnMfDhw/Fw8Mj3HJfX19JkCCBXcaE6NG1a1dxd3eXCxcu2GzzN954Q1auXMlqh8sgiAcAAADA6bJ2qlevLrly5ZJ69erJ1atXzXKtlda9e3d7Dw9RRDvTTp8+3Xpb6+IFBgbK0KFDpWrVqqxnJ8u6HDJkCFmXcHkE8QAAAAA4FbJ2XIMG6yZOnCh169aVp0+fSq9evaRAgQKyadMmE/CB8yDrEghGEA8AAACAUyFrxzVowO7UqVNSoUIFady4sQn0NG3aVPbv3y/Zs2e39/AQhci6BILR2AIAAACAUyFrx3UkS5ZM+vbta+9hIAayLnWK/J49e6xZl9p9WOsfbt26lfUPl+EWRHVXAAAAAE5E6+AVL15cBg0aJJ6ennLo0CHJnDmzvPnmm6Zm2oIFC+w9RPxLui0jq1ChQqxnJ3Lv3j0ZM2aMHDx4UPz8/KRYsWLy8ccfS9q0ae09NCDGEMQDAAAA4FSOHDlisnb0IH/dunXSqFEjm6wdplrGXnHixDENLDQXRX9aWHJTQi8LCAiwyxgBILownRYAAACAU9ZK06wdzcTTrB2tlUbWTux39uxZ63WtfdejRw/p2bOnlC1b1izbvn27jBgxwky/ROxG1iUQHpl4AAAAAIBYp1SpUjJgwAAzfTq05cuXy5dffil79+6129jw35F1CYRHJh4AAACAWI+sHddz+PBhyZo1a7jluuzYsWN2GROiDlmXQHhk4gEAAACI9cjacT1a81CnTk+aNEnix49vlmnn0vbt25u6iPv27bP3EBFFyLoEgpGJBwAAACDWI2vH9YwfP14aNmwoGTJksHai1YxMbW7xxx9/2Ht4iEJkXQLByMQDAAAA4FTI2nEdDx8+lFmzZsmJEyfM7bx588pbb70liRMntvfQEIXIugSCEcQDAAAA4FQSJUpkplJqQCe048ePm2DA48eP7TY2AK9u165dJusyKCgowqxLDdwDroAgHgAAAACnQtaO81qyZInUrVtX3N3dzfWXadSoUYyNC9GPrEuAIB4AAAAAJ0PWjnM3MLl27ZqkSpXKXH8RzdAKCAiI0bEBQHQjEw8AAACA0yFrB4jdyLoEwiOIBwAAAACINbZv3y63b9+WBg0aWJdNnz5d+vfvb4K3TZo0kdGjR0uCBAnsOk78N2RdAuHFi2AZAAAAAMQqZO24joEDB0qVKlWsQbzDhw9Lu3btpE2bNqaZybBhwyRdunQyYMAAew8V/0FgYGCE1wFXRiYeAAAAgFiPrB3XkTZtWtORtESJEuZ23759ZePGjbJlyxZze/78+SYr79ixY3YeKf4rsi4BWy+uBAoAAAAAsYRm6mizA8v1F11odhD73blzR1KnTm29rQE87VhrUbJkSbl48aKdRoeozro8evSo9bYl67JGjRrSu3dvE8wdPHgwKx0ugyAeAAAAAKfJ2lm6dKnNMq2VljVrVhPg++CDD+TJkyd2Gx+ihgbwzp49a64/ffpU9u3bJ2XKlLHe/+DBA3F3d2d1O4EDBw5I9erVrbd//fVXKV26tPz888/SrVs3GTVqlMybN8+uYwRiEkE8AAAAAE6BrB3XUK9ePZOFtXnzZunTp494eHhIxYoVrfcfOnRIsmfPbtcxImqQdQnYIogHAAAAwCmQteMaBg0aJPHixZPKlSubjCy9xI8f33r/lClTpFatWnYdI6IGWZeALbrTAgAAAHAKZO24Bm9vb9m0aZPcu3dPkiRJInHjxrW5Xxtb6HI4T9blkCFDZNGiRWRdwuWRiQcAAADAKZC141qSJUsWLoCnUqZMaZOZh9iLrEvAFpl4AAAAAJwCWTuAcyHrErBFEA8AAACA02TtNG3a1NRK0+mU06ZNo1Ya4CRZlxHRrEvAlbgFBQUF2XsQAAAAABBVXlQrzdfX1yxnqiUAIDYiiAcAAAAAAAA4OBpbAAAAAAAAAA6OIB4AAAAAAADg4AjiAQAAAAAAAA6OIB4AAAAAAADg4AjiAQAAQH755RdJnjw5awIAAMBBEcQDAABwcG3atBE3NzdzcXd3l6xZs0qvXr3E398/yn7HG2+8IadOnYqy1wMAAEDUihfFrwcAAIBoUKdOHZk6dao8e/ZM9u7dK++++64J6g0ZMiRKXj9RokTmAgAAAMdEJh4AAEAskCBBAkmTJo1kzJhRmjRpIjVq1JDVq1eb+wIDA2Xw4MEmQ08DcYULF5YFCxbYPH/JkiWSM2dOSZgwoVStWlWmTZtmgoB3796NcDrtgAEDpEiRIjJlyhTJlCmTJEmSRDp27CgBAQEydOhQM5ZUqVLJN998Y/N79PXat28vPj4+kjRpUqlWrZocPHgwRtYRAACAMyMTDwAAIJY5cuSIbNu2TTJnzmxuawBv5syZMn78eBOo27Rpk7Ru3doE0ipXrixnz56V119/XT755BMTYNu/f7/06NHjH3/PmTNnZMWKFbJy5UpzXV/j77//lly5csnGjRvNGN577z0TUCxdurR5TvPmzU0gUZ+XLFkymTBhglSvXt1M1U2ZMmW0rxsAAABnRRAPAAAgFli6dKnJhnv+/Lk8efJE4sSJI2PGjDHXv/32W1mzZo2ULVvWPDZbtmyyZcsWE0DTIJ7+zJ07twwbNszcr9c1EBg2iy4szfDTTDxPT0/Jly+fyeA7efKkLF++3Px+fR2dzrt+/XoTxNPfuWvXLrlx44bJHFTDhw+XRYsWmczADz74IAbWFAAAgHMiiAcAABALaABt3Lhx8vDhQxk5cqTEixdPmjVrJkePHpVHjx5JzZo1bR7/9OlTKVq0qLmugbeSJUva3F+qVKl//J1ZsmQxATyL1KlTS9y4cU0AL/QyDdopnTbr5+cnXl5eNq/z+PFjk8kHAACAf48gHgAAQCyQOHFiyZEjh7mu2XFa927y5MlSoEABs2zZsmWSPn16m+dYsuH+Le2EG5qlO27YZZqxpzSAlzZtWtmwYUO41wpdbw8AAACvjiAeAABALKOZcJ9//rl069bN1JrTYN2FCxfM1NmI6LRXnQIb2u7du6N8XMWKFZNr166ZLEHN4gMAAEDUoTstAABALKQNJHRqq9a70yYVXbt2NR1nddrqvn37ZPTo0ea2+vDDD+XEiRPy2WefmaDfvHnzTDdaSyZdVNEGF1qXT7vnrlq1Ss6dO2eaX/Tt21f27NkTZb8HAADAFZGJBwAAEAtptlunTp1k6NChpvusdqLVLrXaPVanrmpWnGbrqaxZs5rGEt27d5cff/zRBNo0sNahQ4f/POU2NA0Iasafvnbbtm3l5s2bkiZNGqlUqZKpnQcAAIB/zy0oKCjoPzwfAAAAsZB2ph0/frxcvHjR3kMBAABAJJCJBwAA4ALGjh1rOtRq59itW7fKsGHDTCYfAAAAYgeCeAAAAC7gr7/+kq+//lp8fX0lU6ZMZmptnz597D0sAAAARBLTaQEAAAAAAAAHR3daAAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAwMERxAMAAAAAAAAcHEE8AAAAAAAAQBzb/wB0DQroa82yDQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1400x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Sharpe by Regime:\n",
+      "Regime           Bear-High-Vol  Bear-Med-Vol  Bull-High-Vol  Bull-Low-Vol  \\\n",
+      "Alpha                                                                       \n",
+      "All-Weather               1.98          7.04           0.33          0.18   \n",
+      "Dual-Momentum             0.09          5.86          -0.23          1.73   \n",
+      "EMA-Cross-SPY             0.00          0.00           0.60          0.87   \n",
+      "EMA-Cross-Tech            0.00         -4.16           0.41          1.70   \n",
+      "Mean-Reversion            1.02          4.53           0.00         -0.97   \n",
+      "Momentum-SPY              0.53         -3.74           0.75          1.00   \n",
+      "Trend-Following           0.69          2.73           0.78          0.87   \n",
+      "\n",
+      "Regime           Bull-Med-Vol  Sideways-High-Vol  Sideways-Low-Vol  \\\n",
+      "Alpha                                                                \n",
+      "All-Weather              1.48              -1.14              0.40   \n",
+      "Dual-Momentum            2.65               0.18              0.58   \n",
+      "EMA-Cross-SPY            1.21               0.53              0.28   \n",
+      "EMA-Cross-Tech           0.77              -0.44              0.39   \n",
+      "Mean-Reversion           1.42              -1.21              2.32   \n",
+      "Momentum-SPY             1.08               1.87              0.27   \n",
+      "Trend-Following          1.19              -0.58              0.07   \n",
+      "\n",
+      "Regime           Sideways-Med-Vol  \n",
+      "Alpha                              \n",
+      "All-Weather                  0.51  \n",
+      "Dual-Momentum                1.26  \n",
+      "EMA-Cross-SPY                1.10  \n",
+      "EMA-Cross-Tech               2.28  \n",
+      "Mean-Reversion               0.96  \n",
+      "Momentum-SPY                 0.90  \n",
+      "Trend-Following              0.87  \n"
      ]
     }
    ],
@@ -980,7 +1206,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "b43cccfd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004886,
+     "end_time": "2026-06-01T00:17:44.858693+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.853807+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Complementarity Score\n",
     "\n",
@@ -993,24 +1229,52 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "0914f18a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.239738Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.239570Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.266527Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.265668Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:44.870018Z",
+     "iopub.status.busy": "2026-06-01T00:17:44.869801Z",
+     "iopub.status.idle": "2026-06-01T00:17:45.073572Z",
+     "shell.execute_reply": "2026-06-01T00:17:45.072816Z"
+    },
+    "papermill": {
+     "duration": 0.210924,
+     "end_time": "2026-06-01T00:17:45.074109+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:44.863185+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'returns_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[15]\u001b[39m\u001b[32m, line 62\u001b[39m\n\u001b[32m     60\u001b[39m \u001b[38;5;66;03m# Calculate scores for all pairs\u001b[39;00m\n\u001b[32m     61\u001b[39m complementarity = []\n\u001b[32m---> \u001b[39m\u001b[32m62\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m i, alpha1 \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(\u001b[43mreturns_df\u001b[49m.columns):\n\u001b[32m     63\u001b[39m     \u001b[38;5;28;01mfor\u001b[39;00m alpha2 \u001b[38;5;129;01min\u001b[39;00m returns_df.columns[i+\u001b[32m1\u001b[39m:]:\n\u001b[32m     64\u001b[39m         scores = calculate_complementarity_score(\n\u001b[32m     65\u001b[39m             returns_df[alpha1],\n\u001b[32m     66\u001b[39m             returns_df[alpha2],\n\u001b[32m     67\u001b[39m             regimes\n\u001b[32m     68\u001b[39m         )\n",
-      "\u001b[31mNameError\u001b[39m: name 'returns_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 10 Most Complementary Pairs:\n",
+      "                               Pair  correlation  regime_diversification  \\\n",
+      "8   EMA-Cross-Tech / Mean-Reversion        0.054                   1.919   \n",
+      "12    Momentum-SPY / Mean-Reversion        0.101                   1.372   \n",
+      "7    EMA-Cross-Tech / Dual-Momentum        0.200                   1.253   \n",
+      "15   Dual-Momentum / Mean-Reversion        0.138                   1.084   \n",
+      "11     Momentum-SPY / Dual-Momentum        0.248                   1.299   \n",
+      "9      EMA-Cross-Tech / All-Weather        0.277                   1.616   \n",
+      "3    EMA-Cross-SPY / Mean-Reversion        0.113                   0.840   \n",
+      "18     Mean-Reversion / All-Weather        0.273                   1.080   \n",
+      "17  Dual-Momentum / Trend-Following        0.279                   0.980   \n",
+      "13       Momentum-SPY / All-Weather        0.397                   1.314   \n",
+      "\n",
+      "    downside_protection  total_score  \n",
+      "8                 0.000        0.778  \n",
+      "12                0.045        0.769  \n",
+      "7                 0.163        0.753  \n",
+      "15                0.000        0.745  \n",
+      "11                0.000        0.701  \n",
+      "9                 0.051        0.699  \n",
+      "3                 0.021        0.695  \n",
+      "18                0.000        0.691  \n",
+      "17                0.040        0.688  \n",
+      "13                0.000        0.641  \n"
      ]
     }
    ],
@@ -1096,7 +1360,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f1754cab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004846,
+     "end_time": "2026-06-01T00:17:45.083897+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.079051+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Top Pairs Analysis\n",
     "\n",
@@ -1106,24 +1380,88 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "421446f1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.267871Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.267759Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.284252Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.283537Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:45.095547Z",
+     "iopub.status.busy": "2026-06-01T00:17:45.095361Z",
+     "iopub.status.idle": "2026-06-01T00:17:45.104756Z",
+     "shell.execute_reply": "2026-06-01T00:17:45.104156Z"
+    },
+    "papermill": {
+     "duration": 0.015725,
+     "end_time": "2026-06-01T00:17:45.105286+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.089561+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'comp_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[16]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Select top 3 pairs for detailed analysis\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m top_pairs = \u001b[43mcomp_df\u001b[49m.head(\u001b[32m3\u001b[39m)[\u001b[33m'\u001b[39m\u001b[33mPair\u001b[39m\u001b[33m'\u001b[39m].tolist()\n\u001b[32m      4\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m pair_str \u001b[38;5;129;01min\u001b[39;00m top_pairs:\n\u001b[32m      5\u001b[39m     \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00m\u001b[33m'\u001b[39m\u001b[33m=\u001b[39m\u001b[33m'\u001b[39m*\u001b[32m60\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n",
-      "\u001b[31mNameError\u001b[39m: name 'comp_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "============================================================\n",
+      "Analysis: EMA-Cross-Tech / Mean-Reversion\n",
+      "============================================================\n",
+      "\n",
+      "EMA-Cross-Tech:\n",
+      "  Annual Return: 20.21%\n",
+      "  Volatility: 18.29%\n",
+      "  Sharpe: 1.10\n",
+      "\n",
+      "Mean-Reversion:\n",
+      "  Annual Return: 3.72%\n",
+      "  Volatility: 6.61%\n",
+      "  Sharpe: 0.56\n",
+      "\n",
+      "Combined (50/50):\n",
+      "  Annual Return: 11.96%\n",
+      "  Volatility: 9.89%\n",
+      "  Sharpe: 1.21\n",
+      "  Correlation: 0.054\n",
+      "\n",
+      "============================================================\n",
+      "Analysis: Momentum-SPY / Mean-Reversion\n",
+      "============================================================\n",
+      "\n",
+      "Momentum-SPY:\n",
+      "  Annual Return: 10.27%\n",
+      "  Volatility: 10.63%\n",
+      "  Sharpe: 0.97\n",
+      "\n",
+      "Mean-Reversion:\n",
+      "  Annual Return: 3.72%\n",
+      "  Volatility: 6.61%\n",
+      "  Sharpe: 0.56\n",
+      "\n",
+      "Combined (50/50):\n",
+      "  Annual Return: 7.00%\n",
+      "  Volatility: 6.53%\n",
+      "  Sharpe: 1.07\n",
+      "  Correlation: 0.101\n",
+      "\n",
+      "============================================================\n",
+      "Analysis: EMA-Cross-Tech / Dual-Momentum\n",
+      "============================================================\n",
+      "\n",
+      "EMA-Cross-Tech:\n",
+      "  Annual Return: 20.21%\n",
+      "  Volatility: 18.29%\n",
+      "  Sharpe: 1.10\n",
+      "\n",
+      "Dual-Momentum:\n",
+      "  Annual Return: 19.39%\n",
+      "  Volatility: 17.70%\n",
+      "  Sharpe: 1.10\n",
+      "\n",
+      "Combined (50/50):\n",
+      "  Annual Return: 19.80%\n",
+      "  Volatility: 13.94%\n",
+      "  Sharpe: 1.42\n",
+      "  Correlation: 0.200\n"
      ]
     }
    ],
@@ -1163,7 +1501,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "9b659b7c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005241,
+     "end_time": "2026-06-01T00:17:45.116356+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.111115+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Recommendations\n",
     "\n",
@@ -1173,24 +1521,66 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "876f2ff1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.285805Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.285690Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.303767Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.303031Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:45.128349Z",
+     "iopub.status.busy": "2026-06-01T00:17:45.128143Z",
+     "iopub.status.idle": "2026-06-01T00:17:45.144481Z",
+     "shell.execute_reply": "2026-06-01T00:17:45.143825Z"
+    },
+    "papermill": {
+     "duration": 0.023446,
+     "end_time": "2026-06-01T00:17:45.145014+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.121568+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'comp_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Generate recommendations\u001b[39;00m\n\u001b[32m      2\u001b[39m recommendations = []\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m _, row \u001b[38;5;129;01min\u001b[39;00m \u001b[43mcomp_df\u001b[49m.head(\u001b[32m10\u001b[39m).iterrows():\n\u001b[32m      5\u001b[39m     alpha1, alpha2 = [a.strip() \u001b[38;5;28;01mfor\u001b[39;00m a \u001b[38;5;129;01min\u001b[39;00m row[\u001b[33m'\u001b[39m\u001b[33mPair\u001b[39m\u001b[33m'\u001b[39m].split(\u001b[33m'\u001b[39m\u001b[33m/\u001b[39m\u001b[33m'\u001b[39m)]\n\u001b[32m      7\u001b[39m     \u001b[38;5;66;03m# Calculate expected combined Sharpe\u001b[39;00m\n",
-      "\u001b[31mNameError\u001b[39m: name 'comp_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Top 10 Complementary Alpha Pairs for Composites:\n",
+      "                              Pair  Correlation  Sharpe_1  Sharpe_2  \\\n",
+      "0  EMA-Cross-Tech / Mean-Reversion        0.054     1.105     0.563   \n",
+      "1    Momentum-SPY / Mean-Reversion        0.101     0.967     0.563   \n",
+      "2   EMA-Cross-Tech / Dual-Momentum        0.200     1.105     1.096   \n",
+      "3   Dual-Momentum / Mean-Reversion        0.138     1.096     0.563   \n",
+      "4     Momentum-SPY / Dual-Momentum        0.248     0.967     1.096   \n",
+      "5     EMA-Cross-Tech / All-Weather        0.277     1.105     0.598   \n",
+      "6   EMA-Cross-SPY / Mean-Reversion        0.113     0.872     0.563   \n",
+      "7     Mean-Reversion / All-Weather        0.273     0.563     0.598   \n",
+      "8  Dual-Momentum / Trend-Following        0.279     1.096     0.658   \n",
+      "9       Momentum-SPY / All-Weather        0.397     0.967     0.598   \n",
+      "\n",
+      "   Combined_Sharpe  Synergy  Regime_Div  DD_Protection  \n",
+      "0            1.210    0.376       1.919          0.000  \n",
+      "1            1.071    0.306       1.372          0.045  \n",
+      "2            1.420    0.320       1.253          0.163  \n",
+      "3            1.171    0.342       1.084          0.000  \n",
+      "4            1.302    0.270       1.299          0.000  \n",
+      "5            1.128    0.277       1.616          0.051  \n",
+      "6            0.989    0.272       0.840          0.021  \n",
+      "7            0.722    0.142       1.080          0.000  \n",
+      "8            1.128    0.251       0.980          0.040  \n",
+      "9            0.938    0.156       1.314          0.000  \n",
+      "\n",
+      "Synergistic Pairs (10):\n",
+      "                              Pair  Combined_Sharpe  Synergy\n",
+      "0  EMA-Cross-Tech / Mean-Reversion            1.210    0.376\n",
+      "1    Momentum-SPY / Mean-Reversion            1.071    0.306\n",
+      "2   EMA-Cross-Tech / Dual-Momentum            1.420    0.320\n",
+      "3   Dual-Momentum / Mean-Reversion            1.171    0.342\n",
+      "4     Momentum-SPY / Dual-Momentum            1.302    0.270\n",
+      "5     EMA-Cross-Tech / All-Weather            1.128    0.277\n",
+      "6   EMA-Cross-SPY / Mean-Reversion            0.989    0.272\n",
+      "7     Mean-Reversion / All-Weather            0.722    0.142\n",
+      "8  Dual-Momentum / Trend-Following            1.128    0.251\n",
+      "9       Momentum-SPY / All-Weather            0.938    0.156\n"
      ]
     }
    ],
@@ -1231,7 +1621,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "36af0715",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005087,
+     "end_time": "2026-06-01T00:17:45.155242+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.150155+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Walk-Forward Validation Framework\n",
     "\n",
@@ -1241,24 +1641,48 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "76f3efd9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T16:05:09.305043Z",
-     "iopub.status.busy": "2026-05-12T16:05:09.304923Z",
-     "iopub.status.idle": "2026-05-12T16:05:09.322383Z",
-     "shell.execute_reply": "2026-05-12T16:05:09.321611Z"
-    }
+     "iopub.execute_input": "2026-06-01T00:17:45.168033Z",
+     "iopub.status.busy": "2026-06-01T00:17:45.167832Z",
+     "iopub.status.idle": "2026-06-01T00:17:45.185544Z",
+     "shell.execute_reply": "2026-06-01T00:17:45.184825Z"
+    },
+    "papermill": {
+     "duration": 0.024579,
+     "end_time": "2026-06-01T00:17:45.186184+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.161605+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'comp_df' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 41\u001b[39m\n\u001b[32m     38\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m pd.DataFrame(results)\n\u001b[32m     40\u001b[39m \u001b[38;5;66;03m# Example: Test top pair\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m41\u001b[39m top_pair = \u001b[43mcomp_df\u001b[49m.iloc[\u001b[32m0\u001b[39m][\u001b[33m'\u001b[39m\u001b[33mPair\u001b[39m\u001b[33m'\u001b[39m]\n\u001b[32m     42\u001b[39m alpha1, alpha2 = [a.strip() \u001b[38;5;28;01mfor\u001b[39;00m a \u001b[38;5;129;01min\u001b[39;00m top_pair.split(\u001b[33m'\u001b[39m\u001b[33m/\u001b[39m\u001b[33m'\u001b[39m)]\n\u001b[32m     44\u001b[39m wf_results = walk_forward_validation(returns_df, alpha1, alpha2)\n",
-      "\u001b[31mNameError\u001b[39m: name 'comp_df' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Walk-Forward Validation: EMA-Cross-Tech / Mean-Reversion\n",
+      "                      Period  Train_Corr  Test_Return  Test_Sharpe\n",
+      "0   2021-06-01 to 2022-08-29    0.057506    -0.151942    -1.662360\n",
+      "1   2021-08-30 to 2022-11-28    0.059558    -0.129811    -4.520180\n",
+      "2   2021-11-29 to 2023-03-01    0.041652    -0.042323    -0.432370\n",
+      "3   2022-03-01 to 2023-05-31    0.018414     0.674825     5.440688\n",
+      "4   2022-05-31 to 2023-08-30    0.013267     0.190718     1.804279\n",
+      "5   2022-08-30 to 2023-11-29    0.039571    -0.251398    -2.718211\n",
+      "6   2022-11-29 to 2024-03-01    0.017564     0.347188     3.268694\n",
+      "7   2023-03-02 to 2024-05-31    0.016980     0.274166     2.469639\n",
+      "8   2023-06-01 to 2024-08-30    0.138705    -0.092481    -0.715447\n",
+      "9   2023-08-31 to 2024-11-29    0.258915     0.215528     2.461700\n",
+      "10  2023-11-30 to 2025-03-05    0.286068     0.027320     0.244899\n",
+      "11  2024-03-04 to 2025-06-04    0.248321     0.095622     0.750411\n",
+      "12  2024-06-03 to 2025-09-04    0.074195     0.359873     4.465036\n",
+      "13  2024-09-03 to 2025-12-03    0.008155     0.284876     2.897551\n",
+      "14  2024-12-02 to 2026-03-06    0.023313    -0.096559    -1.202214\n",
+      "\n",
+      "Average Test Sharpe: 0.84\n"
      ]
     }
    ],
@@ -1315,7 +1739,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5c997565",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005147,
+     "end_time": "2026-06-01T00:17:45.196773+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T00:17:45.191626+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. Next Steps\n",
     "\n",
@@ -1359,9 +1793,21 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.14"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 7.736873,
+   "end_time": "2026-06-01T00:17:45.773117+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Alpha-Correlation-Analysis\\quantbook.ipynb",
+   "output_path": "C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\QuantConnect\\projects\\Alpha-Correlation-Analysis\\quantbook_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-01T00:17:38.036244+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
Fix 11 error cells in Alpha-Correlation-Analysis quantbook.ipynb caused by QC Cloud PandasMapper MultiIndex Symbol lookup.

## Root Cause
Batch \qb.History(list(assets.values()))\ returned Symbol objects as MultiIndex level 0. String-keyed lookups like \closes['TLT']\ / \closes['MSFT']\ failed via PandasMapper with \KeyError: No key found for either mapped or original key\.

Secondary issue: \momentums.idxmax(axis=1)\ raised \ValueError: Encountered all NA values\ on all-NaN rows during the 126-day lookback warmup period.

## Changes (4 cells edited)
| Cell | Fix |
|------|-----|
| Cell 1 (imports) | Local env guard: \datetime\ import before \AlgorithmImports\, QuantBook try/except |
| Cell 3 (assets) | String-keyed \ssets\ dict, NameError guard |
| Cell 5 (data) | Per-ticker \qb.History()\ with yfinance fallback, \fill()\/\dropna()\ for alignment |
| Cell 13 (dual_momentum) | \momentums.fillna(0).idxmax()\ to handle lookback warmup |

## Validation
- Papermill SUCCESS: 18/18 code cells, 0 errors, 9.8s
- \
otebook_tools.py execute\ confirms clean run

Part of #1916 (QC error-cells). Previous phases: #1982 (Phase 1, 7 nb), #1986 (Phase 2, CSharp-CTG), #1991 (Phase 3, BTC-EMA), #1992 (Phase 4, EMATrend composite).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>