### PR TITLE
enrich(GameTheory): replace 3 filler conclusions with content-specific summaries

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2628,13 +2628,23 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a permis d explorer les aspects essentiels de gametheory 1 setup. Les points cles :\n",
+    "Ce notebook a installe l'environnement necessaire pour la serie GameTheory et introduit les concepts fondamentaux via le **Dilemme du Prisonnier**.\n",
     "\n",
-    "- Les concepts fondamentaux ont ete presentes et illustres\n",
-    "- Les exercices proposent une mise en pratique progressive\n",
-    "- Les resultats obtenus permettent de valider la comprehension\n",
+    "### Ce que nous avons mis en place\n",
     "\n",
-    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
+    "| Outil | Version | Role |\n",
+    "|-------|---------|------|\n",
+    "| **Nashpy** | 0.0.43 | Calcul d'equilibres de Nash (support enumeration) |\n",
+    "| **OpenSpiel** | 122 jeux | Jeux simultanes, sequentiels, information imparfaite |\n",
+    "| **NetworkX** | 3.6.1 | Visualisation de graphes de jeux |\n",
+    "\n",
+    "### Premier resultat : le paradoxe du Prisonnier\n",
+    "\n",
+    "Avec la matrice classique A=`[[3,0],[5,1]]`, B=`[[3,5],[0,1]]`, l'equilibre de Nash unique est **(Defaut, Defaut)** avec gains **(1, 1)**. Pourtant, la cooperation mutuelle donne **(3, 3)**, qui Pareto-domine. Ce paradoxe illustre le coeur de la theorie des jeux : rationalite individuelle vs optimum collectif.\n",
+    "\n",
+    "Pierre-Feuille-Ciseaux montre un equilibre mixte **uniforme** : chaque joueur joue chaque coup avec probabilite 1/3.\n",
+    "\n",
+    "**Suite** : [GT-2 - Forme normale](GameTheory-2-NormalForm.ipynb) | [Retour au sommaire](README.md)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -1956,7 +1956,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion\n\nCe notebook a permis d'explorer les aspects essentiels de gametheory 14 differentialgames. Les points cles :\n\n- Les concepts fondamentaux ont ete presentes et illustres\n- Les Exemple guides proposent une mise en pratique progressive\n- Les resultats obtenus permettent de valider la comprehension\n\n**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a presente les **jeux differentiels** et les **equilibres de Stackelberg**, des modeles dynamiques ou les joueurs ajustent leurs strategies en continu.\n",
+    "\n",
+    "### Resultats cles\n",
+    "\n",
+    "| Modele | Leader | Follower | Industrie | Insight |\n",
+    "|--------|--------|----------|-----------|---------|\n",
+    "| **Cournot** (statique) | q=30, pi=900 | q=30, pi=900 | 1800 | Symetrie, optimum collectif |\n",
+    "| **Stackelberg** (dynamique) | q=45, pi=1012 | q=22.5, pi=506 | 1519 | Avantage leader +112, perte follower -394 |\n",
+    "\n",
+    "### Lecons principales\n",
+    "\n",
+    "1. **L'avantage du premier joueur** : le leader Stackelberg gagne +12.5% par rapport a Cournot, mais le follower perd -43.75%. L'industrie dans son ensemble est **moins efficace** (1519 vs 1800).\n",
+    "\n",
+    "2. **Jeux LQ et equation de Riccati** : les strategies feedback sont lineaires (u_i = -K_i * x), avec K_1(0)=0.4277 et K_2(0)=-0.4277 dans la course publicitaire. La dynamique est stable.\n",
+    "\n",
+    "3. **Dissuasion d'entree** : en augmentant sa capacite a K=100, le monopole peut dissuader l'entree, mais le profit revient au niveau du monopole (1525).\n",
+    "\n",
+    "**Suite** : [GT-15 - Jeux cooperatifs](GameTheory-15b-Lean-CooperativeGames.ipynb) | [Retour au sommaire](README.md)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
@@ -2129,13 +2129,23 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a permis d explorer les aspects essentiels de gametheory 16g arrow crossseries. Les points cles :\n",
+    "Ce notebook a illustre le **theoreme d'impossibilite d'Arrow** par la simulation empirique, en parallele de la preuve formelle en Lean.\n",
     "\n",
-    "- Les concepts fondamentaux ont ete presentes et illustres\n",
-    "- Les exercices proposent une mise en pratique progressive\n",
-    "- Les resultats obtenus permettent de valider la comprehension\n",
+    "### Resultats de la verification empirique (3 votants, 3 alternatives, 216 profils)\n",
     "\n",
-    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
+    "| Regle | Pareto faible | IIA | Non-dictature | Les 3 satisfaits ? |\n",
+    "|-------|---------------|-----|---------------|--------------------|\n",
+    "| **Borda** | 0 violations | **1104** violations | OK | NON (IIA) |\n",
+    "| **Pluralite** | 0 violations | **3312** violations | OK | NON (IIA) |\n",
+    "| **Dictature** | 0 violations | 0 violations | **Electeur 0 = dictateur** | NON (non-dictature) |\n",
+    "\n",
+    "### Lecon principale\n",
+    "\n",
+    "**Aucune regle de vote ne peut simultanement satisfaire les trois axiomes d'Arrow** : Pareto faible, Independance des Alternatives Irrelevantes (IIA), et Non-dictature. La preuve formelle Lean (~950 lignes, 0 sorry, 0 axiome) garantit ce resultat pour un nombre quelconque de votants et d'alternatives.\n",
+    "\n",
+    "L'IIA est l'axiome le plus difficile a satisfaire : Borda et Pluralite accumulent respectivement 1104 et 3312 violations sur seulement 216 profils. La force brute confirme l'impossibilite sur les petites instances, mais explose en complexite (10 votants, 4 alternatives = 6.3x10^13 profils).\n",
+    "\n",
+    "**Retour au sommaire** : [Social Choice](../README.md) | [GameTheory](../README.md)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Replace 3 generic filler conclusions with content-specific pedagogical summaries referencing actual algorithms, measured benchmark results, and key takeaways.

## Changes (3 notebooks)

| Notebook | Key content added |
|----------|-------------------|
| **GT-1-Setup** | Nashpy/OpenSpiel setup table, Prisoner Dilemma (D,D)=(1,1) vs (C,C)=(3,3) paradox, RPS uniform 1/3 mixed equilibrium |
| **GT-14-DifferentialGames** | Cournot(900) vs Stackelberg(1012/506) comparison table, LQ Riccati K=0.4277, entry deterrence K=100 |
| **01-Arrow** | Empirical verification table (Borda 1104 / Plurality 3312 IIA violations over 216 profiles), Lean proof 950 lines 0 sorry |

## Validation

- Only markdown cells modified (no code changes)
- C.2 exception: outputs preserved (markdown-only edit)
- All conclusions include comparative tables, measured results, and forward navigation links

## Related

- PR #1990 (Search filler conclusions) — same pattern, Search series
- Coordinator dispatch: conclusions content-specific (PAS de filler)