### PR TITLE
feat(lean): prove Kochen-Specker theorem — 0 sorry (Conway FWT #1651 Pilier 1)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/KochenSpecker.lean
@@ -156,7 +156,7 @@ def IsValidColoring (c : Coloring) : Prop :=
 lemma each_vector_in_two_contexts (v : VecIdx) :
     (∑ k : ContextIdx, ∑ i : Fin 4,
       if contextMembers k i = v then (1 : ℕ) else 0) = 2 := by
-  sorry  -- TODO Pilier 1: verify by `decide` / explicit case-split on v
+  fin_cases v <;> decide
 
 /-- **Kochen-Specker Theorem (18-vector Cabello proof)**.
     There is no valid {0,1}-coloring of the 18 vectors compatible
@@ -173,7 +173,70 @@ lemma each_vector_in_two_contexts (v : VecIdx) :
        which is even.
     4. But 9 is odd. Contradiction. -/
 theorem kochen_specker : ¬ ∃ c : Coloring, IsValidColoring c := by
-  sorry  -- TODO Pilier 1: parity argument via Finset double-sum reorder
+  rintro ⟨c, hc⟩
+  -- Let S = total ones counted with multiplicity over contexts.
+  set S : ℕ := ∑ k : ContextIdx, ∑ i : Fin 4,
+      if c (contextMembers k i) then (1 : ℕ) else 0 with hS_def
+  -- Step 1: S = 9, since each context has exactly one `1`.
+  have hS9 : S = 9 := by
+    have hsum : S = ∑ _k : ContextIdx, (1 : ℕ) := by
+      apply Finset.sum_congr rfl
+      intro k _; exact hc k
+    rw [hsum]; decide
+  -- Step 2: rewrite each cell indicator as a sum over v.
+  -- (if c (members k i) then 1 else 0) = ∑ v, (if members k i = v then ind(c v) else 0)
+  have hCell : ∀ (k : ContextIdx) (i : Fin 4),
+      (if c (contextMembers k i) then (1 : ℕ) else 0)
+        = ∑ v : VecIdx,
+            if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0 := by
+    intro k i
+    -- The sum has exactly one nonzero term: at v = contextMembers k i.
+    rw [Finset.sum_eq_single (contextMembers k i)]
+    · simp
+    · intro v _ hv
+      rw [if_neg hv.symm]
+    · intro h
+      exact (h (Finset.mem_univ _)).elim
+  -- Step 3: substitute and swap the v-sum outside.
+  have hS_even : S = 2 * (∑ v : VecIdx, if c v then (1 : ℕ) else 0) := by
+    -- First rewrite S into triple-nested form.
+    have h1 : S = ∑ k : ContextIdx, ∑ i : Fin 4, ∑ v : VecIdx,
+        if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0 := by
+      apply Finset.sum_congr rfl
+      intro k _
+      apply Finset.sum_congr rfl
+      intro i _
+      exact hCell k i
+    rw [h1]
+    -- Swap v outside via two Finset.sum_comm applications.
+    -- ∑ k, ∑ i, ∑ v, F = ∑ k, ∑ v, ∑ i, F   (inner swap, per k)
+    rw [show (∑ k : ContextIdx, ∑ i : Fin 4, ∑ v : VecIdx,
+              (if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0))
+            = ∑ k : ContextIdx, ∑ v : VecIdx, ∑ i : Fin 4,
+              (if contextMembers k i = v then (if c v then (1 : ℕ) else 0) else 0) from by
+      apply Finset.sum_congr rfl
+      intro k _
+      exact Finset.sum_comm]
+    -- Now: ∑ k, ∑ v, ∑ i, F. Swap k and v (outer).
+    rw [Finset.sum_comm]
+    -- Goal: ∑ v, ∑ k, ∑ i, F = 2 * ∑ v, ind(c v)
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro v _
+    -- Goal: ∑ k, ∑ i, (if k,i=v then ind(c v) else 0) = 2 * ind(c v)
+    by_cases hcv : c v
+    · -- ind(c v) = 1
+      simp only [hcv, if_true]
+      have hlem := each_vector_in_two_contexts v
+      -- hlem: ∑ k, ∑ i, (if k,i = v then 1 else 0) = 2
+      -- Goal after simp: ∑ k, ∑ i, (if k,i = v then 1 else 0) = 2 * 1
+      rw [hlem]; rfl
+    · -- ind(c v) = 0, all terms 0
+      simp [hcv]
+  -- Step 4: combine to get 9 = 2 * N, contradiction.
+  have h2div : 2 ∣ S := ⟨_, hS_even⟩
+  rw [hS9] at h2div
+  omega
 
 end KochenSpecker
 


### PR DESCRIPTION
## Summary

Eliminates the **last 2 production sorry** in the Conway workspace by proving the Kochen-Specker theorem (18-vector Cabello proof). The entire `conway_lean` workspace now has **0 production sorry**.

### Changes

**`Conway/KochenSpecker.lean`** (+65 lines, -2 sorry):

1. **`each_vector_in_two_contexts`** — proved by `fin_cases v <;> decide`
   - Generates 18 sub-goals (one per VecIdx value)
   - Each solved by kernel `decide` over the 36-element domain `Fin 9 × Fin 4`

2. **`kochen_specker`** — proved by explicit parity argument:
   - Step 1: `S = 9` (each context has exactly one `1`, sum over 9 contexts)
   - Step 2: Cell indicator rewrite `(if c (members k i) then 1 else 0) = ∑ v, indicator(members k i = v) * indicator(c v)`
   - Step 3: Triple-sum reorder via `Finset.sum_comm` → `S = 2 * Σ indicator(c v)` using the overlap lemma
   - Step 4: `2 | 9` contradiction closed by `omega`

### Sorry count

| File | Before | After |
|------|--------|-------|
| `KochenSpecker.lean` | 2 | **0** |
| All other Conway files | 0 | 0 |
| **Total conway_lean** | **2** | **0** |

### Validation

- `lake build Conway` — **SUCCESS** (3335 jobs)
- `grep -c sorry` — **0** (code-only; comment "sorry scaffolding" in Conway.lean excluded)
- No axioms, no `native_decide` timeout (structured proof, not brute-force)

### Key technical insight

Previous attempt with `native_decide` on `kochen_specker` timed out (2^18 colorings × 9 contexts = whnf timeout on Fin 18). The solution: the **parity argument is a mathematical proof**, not a brute-force search. Combined with `fin_cases v <;> decide` for the combinatorial lemma (where each individual case is trivial), the full theorem compiles cleanly.

### Scope

- Single file: `Conway/KochenSpecker.lean` (+65 lines)
- No changes to any other files
- Epic: Conway Free Will Theorem #1651 Pilier 1
- Catalog-free (Lean only)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>