### PR TITLE
TP SC-20 Bitcoin Scripting : Jules Lange

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -1910,9 +1910,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -86,10 +86,10 @@
    "id": "utxo-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.266630Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.266414Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.276501Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.275933Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.248734Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.248734Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.270438Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.270438Z"
     },
     "papermill": {
      "duration": 0.013886,
@@ -278,10 +278,10 @@
    "id": "utxo-transactions",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.292989Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.292791Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.297970Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.297599Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.272787Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.272787Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.283966Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.283966Z"
     },
     "papermill": {
      "duration": 0.008881,
@@ -443,10 +443,10 @@
    "id": "script-interpreter",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.320958Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.320753Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.330251Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.329837Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.283966Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.283966Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.307882Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.306876Z"
     },
     "papermill": {
      "duration": 0.014636,
@@ -676,10 +676,10 @@
    "id": "p2pkh-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.347509Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.347335Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.351957Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.351480Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.307882Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.307882Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.321381Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.321381Z"
     },
     "papermill": {
      "duration": 0.008586,
@@ -829,10 +829,10 @@
    "id": "raw-tx-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.371300Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.371048Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.378883Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.378399Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.321381Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.321381Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.341139Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.341139Z"
     },
     "papermill": {
      "duration": 0.012736,
@@ -1016,10 +1016,10 @@
    "id": "bitcoinlib-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.399749Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.399567Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.415756Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.415298Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.343145Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.343145Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.357147Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.357147Z"
     },
     "papermill": {
      "duration": 0.020285,
@@ -1035,13 +1035,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "python-bitcoinlib installe mais erreur au chargement : TypeError\n",
-      "  argument of type 'NoneType' is not iterable\n",
-      "\n",
-      "Sur Windows, libsecp256k1 peut ne pas etre disponible.\n",
-      "Les sections precedentes (UTXO, Script interpreter, Raw TX)\n",
-      "utilisent du Python pur et fonctionnent sans cette dependance.\n",
-      "Pour un support complet : utiliser le kernel WSL SmartContracts.\n"
+      "python-bitcoinlib non installe.\n",
+      "Pour l'installer : pip install python-bitcoinlib\n"
      ]
     }
    ],
@@ -1168,10 +1163,10 @@
    "id": "multisig-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.434307Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.433936Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.438965Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.438475Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.357147Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.357147Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.372108Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.372108Z"
     },
     "papermill": {
      "duration": 0.009106,
@@ -1315,10 +1310,10 @@
    "id": "timelock-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.457991Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.457769Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.462685Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.462215Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.372108Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.372108Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.391182Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.391182Z"
     },
     "papermill": {
      "duration": 0.009381,
@@ -1462,10 +1457,10 @@
    "id": "p2sh-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.481979Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.481767Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.486300Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.485852Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.394946Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.394946Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.410853Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.409844Z"
     },
     "papermill": {
      "duration": 0.008871,
@@ -1674,10 +1669,10 @@
    "id": "exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:23:54.513561Z",
-     "iopub.status.busy": "2026-05-26T19:23:54.513332Z",
-     "iopub.status.idle": "2026-05-26T19:23:54.517190Z",
-     "shell.execute_reply": "2026-05-26T19:23:54.516706Z"
+     "iopub.execute_input": "2026-06-01T10:23:26.410853Z",
+     "iopub.status.busy": "2026-06-01T10:23:26.410853Z",
+     "iopub.status.idle": "2026-06-01T10:23:26.432849Z",
+     "shell.execute_reply": "2026-06-01T10:23:26.432849Z"
     },
     "papermill": {
      "duration": 0.009225,
@@ -1688,10 +1683,54 @@
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ESCROW AVEC TIMELOCK\n",
+      "============================================================\n",
+      "\n",
+      "Redeem script :\n",
+      "  OP_IF\n",
+      "  OP_2\n",
+      "  d129fa716698153572e0f19767fdeac8313330d6\n",
+      "  8ef731e6c291f4d813bd41ec3663a334af3024de\n",
+      "  53209930882aa0355fa71eb48d38e09500df2a16\n",
+      "  OP_3\n",
+      "  OP_CHECKMULTISIG\n",
+      "  OP_ELSE\n",
+      "  1000\n",
+      "  OP_CHECKLOCKTIMEVERIFY\n",
+      "  OP_DROP\n",
+      "  8ef731e6c291f4d813bd41ec3663a334af3024de\n",
+      "  OP_CHECKSIG\n",
+      "  OP_ENDIF\n",
+      "\n",
+      "--- Scenario 1 : transaction normale (Alice + Bob) ---\n",
+      "Fonds liberes vers : Bob\n",
+      "\n",
+      "--- Scenario 2 : litige (Alice + Carol) ---\n",
+      "Fonds rembourses vers : Alice\n",
+      "\n",
+      "--- Scenario 3 : timeout (Bob seul apres 1000 blocs) ---\n",
+      "Avant timeout (bloc 500) : refuse (Timeout non atteint)\n",
+      "Apres timeout (bloc 1000), fonds vers : Bob\n"
+     ]
+    }
+   ],
    "source": [
     "import hashlib\n",
-    "import time\n",
+    "\n",
+    "\n",
+    "def sign(pubkey):\n",
+    "    if isinstance(pubkey, str):\n",
+    "        pubkey = pubkey.encode()\n",
+    "    return hashlib.sha256(pubkey).hexdigest()[:16]\n",
+    "\n",
+    "\n",
+    "def valid_signature(signature, pubkey):\n",
+    "    return signature == sign(pubkey)\n",
     "\n",
     "\n",
     "class TimelockEscrow:\n",
@@ -1714,24 +1753,85 @@
     "        self.is_spent = False\n",
     "\n",
     "    def get_redeem_script(self):\n",
-    "        \"\"\"Construire le script de verrouillage.\n",
-    "        TODO: Retourner une liste representant le script Bitcoin.\n",
-    "\n",
-    "        Le script doit implementer :\n",
-    "        - OP_IF : branche multisig 2-of-3 (Alice, Bob, Carol)\n",
-    "        - OP_ELSE : branche timeout (Bob seul apres N blocs)\n",
-    "        - OP_ENDIF\n",
-    "\n",
-    "        Hint: utilisez le format [\n",
+    "        return [\n",
     "            \"OP_IF\",\n",
-    "            \"OP_2\", alice, bob, carol, \"OP_3\", \"OP_CHECKMULTISIG\",\n",
+    "            \"OP_2\", self.alice, self.bob, self.carol, \"OP_3\", \"OP_CHECKMULTISIG\",\n",
     "            \"OP_ELSE\",\n",
-    "            timeout_blocks, \"OP_CHECKLOCKTIMEVERIFY\", \"OP_DROP\",\n",
-    "            bob, \"OP_CHECKSIG\",\n",
-    "            \"OP_ENDIF\"\n",
+    "            self.timeout_blocks, \"OP_CHECKLOCKTIMEVERIFY\", \"OP_DROP\",\n",
+    "            self.bob, \"OP_CHECKSIG\",\n",
+    "            \"OP_ENDIF\",\n",
     "        ]\n",
-    "        \"\"\"\n",
-    "        pass  # TODO: Implementez le script de verrouillage\n"
+    "\n",
+    "    def _check_multisig(self, signatures, signers):\n",
+    "        keys = [self.alice, self.bob, self.carol]\n",
+    "        valid = 0\n",
+    "        seen = set()\n",
+    "        for sig, signer in zip(signatures, signers):\n",
+    "            if signer in keys and signer not in seen and valid_signature(sig, signer):\n",
+    "                valid += 1\n",
+    "                seen.add(signer)\n",
+    "        return valid >= 2\n",
+    "\n",
+    "    def spend_multisig(self, sig_a, signer_a, sig_b, signer_b):\n",
+    "        if self.is_spent:\n",
+    "            raise RuntimeError(\"Escrow deja depense\")\n",
+    "        if not self._check_multisig([sig_a, sig_b], [signer_a, signer_b]):\n",
+    "            raise RuntimeError(\"Multisig 2-of-3 echoue\")\n",
+    "        signers = {signer_a, signer_b}\n",
+    "        if signers == {self.alice, self.bob}:\n",
+    "            recipient = \"Bob\"\n",
+    "        elif signers == {self.alice, self.carol}:\n",
+    "            recipient = \"Alice\"\n",
+    "        else:\n",
+    "            recipient = \"Bob\"\n",
+    "        self.is_spent = True\n",
+    "        return recipient\n",
+    "\n",
+    "    def spend_timeout(self, sig_bob, current_block):\n",
+    "        if self.is_spent:\n",
+    "            raise RuntimeError(\"Escrow deja depense\")\n",
+    "        if current_block < self.creation_block + self.timeout_blocks:\n",
+    "            raise RuntimeError(\"Timeout non atteint\")\n",
+    "        if not valid_signature(sig_bob, self.bob):\n",
+    "            raise RuntimeError(\"Signature de Bob invalide\")\n",
+    "        self.is_spent = True\n",
+    "        return \"Bob\"\n",
+    "\n",
+    "\n",
+    "alice_pk = hashlib.sha256(b\"alice_key\").hexdigest()[:40]\n",
+    "bob_pk = hashlib.sha256(b\"bob_key\").hexdigest()[:40]\n",
+    "carol_pk = hashlib.sha256(b\"carol_key\").hexdigest()[:40]\n",
+    "\n",
+    "print(\"ESCROW AVEC TIMELOCK\")\n",
+    "print(\"=\" * 60)\n",
+    "print()\n",
+    "\n",
+    "escrow = TimelockEscrow(alice_pk, bob_pk, carol_pk, amount=10, timeout_blocks=1000)\n",
+    "print(\"Redeem script :\")\n",
+    "for item in escrow.get_redeem_script():\n",
+    "    print(f\"  {item}\")\n",
+    "print()\n",
+    "\n",
+    "print(\"--- Scenario 1 : transaction normale (Alice + Bob) ---\")\n",
+    "e1 = TimelockEscrow(alice_pk, bob_pk, carol_pk, amount=10)\n",
+    "r1 = e1.spend_multisig(sign(alice_pk), alice_pk, sign(bob_pk), bob_pk)\n",
+    "print(f\"Fonds liberes vers : {r1}\")\n",
+    "print()\n",
+    "\n",
+    "print(\"--- Scenario 2 : litige (Alice + Carol) ---\")\n",
+    "e2 = TimelockEscrow(alice_pk, bob_pk, carol_pk, amount=10)\n",
+    "r2 = e2.spend_multisig(sign(alice_pk), alice_pk, sign(carol_pk), carol_pk)\n",
+    "print(f\"Fonds rembourses vers : {r2}\")\n",
+    "print()\n",
+    "\n",
+    "print(\"--- Scenario 3 : timeout (Bob seul apres 1000 blocs) ---\")\n",
+    "e3 = TimelockEscrow(alice_pk, bob_pk, carol_pk, amount=10, timeout_blocks=1000)\n",
+    "try:\n",
+    "    e3.spend_timeout(sign(bob_pk), current_block=500)\n",
+    "except RuntimeError as err:\n",
+    "    print(f\"Avant timeout (bloc 500) : refuse ({err})\")\n",
+    "r3 = e3.spend_timeout(sign(bob_pk), current_block=1000)\n",
+    "print(f\"Apres timeout (bloc 1000), fonds vers : {r3}\")\n"
    ]
   },
   {
@@ -1777,8 +1877,16 @@
   {
    "cell_type": "markdown",
    "id": "8f41d9e2",
-   "source": "## Resume et perspectives\n\nCe notebook a explore le modele UTXO de Bitcoin et son langage Script a pile, volontairement Turing-incomplet. Nous avons implemente un mini-interpreteur capable d'executer des scripts P2PKH, construit des transactions brutes en serialisant leurs champs binaires, et decouvert les mecanismes avances que sont le multisig (M-of-N), les timelocks (CLTV/CSV) et l'encapsulation P2SH. La comparaison avec Ethereum met en lumiere deux philosophies opposees : la **verification** deterministe et bornee de Bitcoin contre la **computation** expressive mais risque d'Ethereum.\n\nLes scripts Bitcoin, malgre leur simplicite apparente, couvrent la majorite des besoins en conditions de depense : signatures multiples, verrous temporels, et logique conditionnelle. L'arrivee de Taproot (BIP 340-342) en 2021 enrichit ce repertoire avec les signatures Schnorr et les arbres MAST, ouvrant la voie a des scripts plus flexibles tout en preservant la confidentialite. Les adaptations modernes comme les ordinals et les inscriptions montrent que la frontiere entre verification et computation continue d'evolver.\n\nLe parcours SmartContracts s'acheve ici. Depuis les fondements cypherpunk (SC-0) jusqu'au scripting Bitcoin, en passant par Solidity, le test avec Foundry, la verification formelle, la cryptographie avancee (ZKP, chiffrement homomorphique, vote verifiable), les chaines alternatives (Vyper, Ripple/XRP), vous disposez maintenant d'une vision panoramique des technologies de contrats intelligents et de leur ecosysteme. Le notebook final [SC-26-Final-Project](../06-Real-World/SC-26-Final-Project.ipynb) vous invite a consolider ces competences dans un projet integrateur.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore le modele UTXO de Bitcoin et son langage Script a pile, volontairement Turing-incomplet. Nous avons implemente un mini-interpreteur capable d'executer des scripts P2PKH, construit des transactions brutes en serialisant leurs champs binaires, et decouvert les mecanismes avances que sont le multisig (M-of-N), les timelocks (CLTV/CSV) et l'encapsulation P2SH. La comparaison avec Ethereum met en lumiere deux philosophies opposees : la **verification** deterministe et bornee de Bitcoin contre la **computation** expressive mais risque d'Ethereum.\n",
+    "\n",
+    "Les scripts Bitcoin, malgre leur simplicite apparente, couvrent la majorite des besoins en conditions de depense : signatures multiples, verrous temporels, et logique conditionnelle. L'arrivee de Taproot (BIP 340-342) en 2021 enrichit ce repertoire avec les signatures Schnorr et les arbres MAST, ouvrant la voie a des scripts plus flexibles tout en preservant la confidentialite. Les adaptations modernes comme les ordinals et les inscriptions montrent que la frontiere entre verification et computation continue d'evolver.\n",
+    "\n",
+    "Le parcours SmartContracts s'acheve ici. Depuis les fondements cypherpunk (SC-0) jusqu'au scripting Bitcoin, en passant par Solidity, le test avec Foundry, la verification formelle, la cryptographie avancee (ZKP, chiffrement homomorphique, vote verifiable), les chaines alternatives (Vyper, Ripple/XRP), vous disposez maintenant d'une vision panoramique des technologies de contrats intelligents et de leur ecosysteme. Le notebook final [SC-26-Final-Project](../06-Real-World/SC-26-Final-Project.ipynb) vous invite a consolider ces competences dans un projet integrateur."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1816,7 +1924,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

- Rendu du TP SC-20-Bitcoin-Scripting pour le cours de SymbolicAI (Smart Contracts)
- Completion de l'exercice : systeme d'escrow TimelockEscrow combinant multisig 2-of-3 et timelock CLTV
- Notebook execute, outputs presents dans le fichier

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
