### PR TITLE
enrich(Sudoku): add transition markdown in Sudoku-6-AIMA-CSP-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -1383,6 +1383,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bde18977",
+   "source": "### Resolution avec MAC\n\nLe puzzle est charge. Appliquons maintenant l'algorithme MAC (Maintaining Arc Consistency) — le plus performant de notre arsenal. MAC combine la selection heuristique des variables (MRV), l'ordonnancement des valeurs (LCV) et la propagation complete de contraintes (AC-3) apres chaque assignation.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "8a2e903f",
@@ -1650,6 +1656,12 @@
    "source": [
     "/// <summary>\n/// MAC avec affichage verbose de la progression.\n/// TODO : Implementer toute la logique verbose\n/// </summary>\npublic static class MACVerbose\n{\n    public static Dictionary<TVariable, TValue>? Solve<TVariable, TValue>(\n        CSP<TVariable, TValue> csp,\n        Dictionary<TVariable, TValue>? assignment = null,\n        Dictionary<TVariable, List<TValue>>? currentDomains = null,\n        bool verbose = false,\n        int depth = 0)\n        where TVariable : notnull\n    {\n        // TODO : Implementer un solveur MAC similaire a MAC.Solve\n        // mais avec affichage verbose de la progression :\n        // - Afficher l'assignation (variable, valeur) avec indentation selon depth\n        // - Compter et afficher les domaines réduits par AC-3\n        // - Afficher les backtracks avec indentation\n        \n        // TODO etudiant : implementer MAC verbose\n        return null;\n    }\n}\n\n// Extension pour repeter une chaine (utile pour l'indentation)\npublic static class StringExtensions\n{\n    public static string Repeat(string s, int count)\n    {\n        return string.Concat(Enumerable.Repeat(s, count));\n    }\n}\n\nConsole.WriteLine(\"MACVerbose a implementer !\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d12145c",
+   "source": "### Exercice complementaire : Conflict-Based Backjumping\n\nL'exercice precedent (`MACVerbose`) vous a demande d'ajouter un affichage detaille a MAC. Nous allons maintenant explorer une **amelioration structurelle** du backtracking : le **Conflict-Based Backjumping (CBJ)**.\n\nLe backtracking classique remonte d'un niveau a la fois lors d'un echec. Le CBJ, lui, maintient un **ensemble de conflits** pour chaque variable et remonte directement vers la variable responsable de l'impasse. C'est un gain considerable sur les instances difficiles ou de nombreux retours en arriere sont dus a une variable lointaine.\n\n**Principe** : quand toutes les valeurs de $X_i$ echouent, on identifie la variable $X_j$ la plus recente dans le conflict set de $X_i$, et on remonte directement a $X_j$ (en fusionnant les conflict sets au passage).",
+   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Insert 2 pedagogical transition markdown cells between consecutive code pairs in `Sudoku-6-AIMA-CSP-Csharp.ipynb`:

1. **Between puzzle loading and MAC test**: Explains MAC strategy before execution - combines MRV variable selection, LCV value ordering, and AC-3 constraint propagation.

2. **Between MACVerbose stub and CBJ stub**: Introduces Conflict-Based Backjumping as a structural improvement over chronological backtracking, explaining the conflict set concept and direct jump mechanism.

## Validation proof

- **Markdown-only changes**: +12 insertions, 0 deletions. No code cells modified.
- **Convention C.3**: Previous outputs preserved (modifications uniquement markdown -> outputs precedents valides).
- **Papermill**: Not applicable for .NET notebooks with `#!import` (known limitation - VS Code/JupyterLab resolves relative paths). Cf notebook-conventions.md section Execution.
- **0 errors in existing outputs**: All cells have `execution_count: <int>` + coherent outputs from prior execution.
- **Structure check**: 2 consecutive code pairs eliminated (was 2, now 0).

## Checklist
- [x] No `raise NotImplementedError` / `assert False` / `1/0` introduced
- [x] No code cells modified (markdown transitions only)
- [x] Content-specific transitions (not generic)
- [x] Bottom-to-top insertion order (anti index-shift)
