### PR TITLE
feat(tweety): execute Tweety-6 structured argumentation notebook

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
@@ -5,10 +5,10 @@
    "id": "37f22048",
    "metadata": {
     "papermill": {
-     "duration": 0.004029,
-     "end_time": "2026-05-20T06:44:29.939738+00:00",
+     "duration": 0.003004,
+     "end_time": "2026-05-21T12:40:33.349480+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:29.935709+00:00",
+     "start_time": "2026-05-21T12:40:33.346476+00:00",
      "status": "completed"
     },
     "tags": []
@@ -73,16 +73,16 @@
    "id": "d10c7bef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:29.947417Z",
-     "iopub.status.busy": "2026-05-20T06:44:29.947417Z",
-     "iopub.status.idle": "2026-05-20T06:44:30.201531Z",
-     "shell.execute_reply": "2026-05-20T06:44:30.201531Z"
+     "iopub.execute_input": "2026-05-21T12:40:33.356479Z",
+     "iopub.status.busy": "2026-05-21T12:40:33.355479Z",
+     "iopub.status.idle": "2026-05-21T12:40:33.624251Z",
+     "shell.execute_reply": "2026-05-21T12:40:33.624251Z"
     },
     "papermill": {
-     "duration": 0.259114,
-     "end_time": "2026-05-20T06:44:30.202531+00:00",
+     "duration": 0.272774,
+     "end_time": "2026-05-21T12:40:33.625253+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:29.943417+00:00",
+     "start_time": "2026-05-21T12:40:33.352479+00:00",
      "status": "completed"
     },
     "tags": []
@@ -92,23 +92,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Verification JVM Tweety + Outils ---\n",
-      "JDK portable: zulu17.50.19-ca-jdk17.0.11-win_x64\n"
+      "--- Verification JVM Tweety + Outils ---\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "JVM demarree avec 42 JARs.\n",
+      "JVM demarree avec 37 JARs.\n",
       "\n",
       "--- Outils disponibles ---\n",
-      "  CLINGO: clingo\n",
       "  EPROVER: eprover.exe\n",
       "  SAT_SOLVER_PYTHON: sat_solver.py\n",
       "  MARCO: marco.py\n",
       "\n",
-      "JVM prete. Outils: 4/5\n"
+      "JVM prete. Outils: 3/5\n"
      ]
     }
    ],
@@ -235,10 +233,10 @@
    "id": "675ee0f8",
    "metadata": {
     "papermill": {
-     "duration": 0.002505,
-     "end_time": "2026-05-20T06:44:30.208036+00:00",
+     "duration": 0.000479,
+     "end_time": "2026-05-21T12:40:33.628238+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.205531+00:00",
+     "start_time": "2026-05-21T12:40:33.627759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -268,16 +266,16 @@
    "id": "6340ab53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:30.215045Z",
-     "iopub.status.busy": "2026-05-20T06:44:30.215045Z",
-     "iopub.status.idle": "2026-05-20T06:44:30.525687Z",
-     "shell.execute_reply": "2026-05-20T06:44:30.525687Z"
+     "iopub.execute_input": "2026-05-21T12:40:33.636527Z",
+     "iopub.status.busy": "2026-05-21T12:40:33.636527Z",
+     "iopub.status.idle": "2026-05-21T12:40:34.769490Z",
+     "shell.execute_reply": "2026-05-21T12:40:34.769490Z"
     },
     "papermill": {
-     "duration": 0.315646,
-     "end_time": "2026-05-20T06:44:30.526688+00:00",
+     "duration": 1.136467,
+     "end_time": "2026-05-21T12:40:34.769490+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.211042+00:00",
+     "start_time": "2026-05-21T12:40:33.633023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -418,10 +416,10 @@
    "id": "ky20dkhpima",
    "metadata": {
     "papermill": {
-     "duration": 0.003003,
-     "end_time": "2026-05-20T06:44:30.533194+00:00",
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:34.772490+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.530191+00:00",
+     "start_time": "2026-05-21T12:40:34.772490+00:00",
      "status": "completed"
     },
     "tags": []
@@ -467,10 +465,10 @@
    "id": "06220aec",
    "metadata": {
     "papermill": {
-     "duration": 0.002513,
-     "end_time": "2026-05-20T06:44:30.539210+00:00",
+     "duration": 0.005698,
+     "end_time": "2026-05-21T12:40:34.802288+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.536697+00:00",
+     "start_time": "2026-05-21T12:40:34.796590+00:00",
      "status": "completed"
     },
     "tags": []
@@ -521,16 +519,16 @@
    "id": "f573f125",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:30.546777Z",
-     "iopub.status.busy": "2026-05-20T06:44:30.545778Z",
-     "iopub.status.idle": "2026-05-20T06:44:30.651659Z",
-     "shell.execute_reply": "2026-05-20T06:44:30.651109Z"
+     "iopub.execute_input": "2026-05-21T12:40:34.808783Z",
+     "iopub.status.busy": "2026-05-21T12:40:34.806955Z",
+     "iopub.status.idle": "2026-05-21T12:40:35.273840Z",
+     "shell.execute_reply": "2026-05-21T12:40:35.273840Z"
     },
     "papermill": {
-     "duration": 0.110404,
-     "end_time": "2026-05-20T06:44:30.652177+00:00",
+     "duration": 0.469996,
+     "end_time": "2026-05-21T12:40:35.274841+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.541773+00:00",
+     "start_time": "2026-05-21T12:40:34.804845+00:00",
      "status": "completed"
     },
     "tags": []
@@ -542,25 +540,34 @@
      "text": [
       "\n",
       "--- 4.3 Defeasible Logic Programming (DeLP) ---\n",
-      "JVM prete. Execution de l'exemple DeLP...\n",
+      "JVM prete. Execution de l'exemple DeLP...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Imports DeLP, FOL et Commons necessaires reussis.\n",
-      "\n",
-      "Chargement du programme DeLP depuis: resources\\birds2.txt\n",
-      "Programme charge avec succes depuis le fichier.\n",
+      "ERREUR: Fichier DeLP requis 'resources\\birds2.txt' non trouve !\n",
+      "   Utilisation d'un exemple integre (birds.txt simplifie).\n",
+      "Programme charge avec succes depuis la chaine integree.\n",
       "\n",
       "Programme DeLP charge:\n",
-      " Wings(tweety).\n",
-      "Fly(X) -< Bird(X).\n",
+      " Fly(X) -< Bird(X).\n",
       "Penguin(tweety).\n",
+      "Fly(X) -< Chicken(X),Scared(X).\n",
+      "!Fly(X) -< Chicken(X).\n",
+      "Bird(X) <- Chicken(X).\n",
       "Bird(X) <- Penguin(X).\n",
-      "!Fly(X) -< Penguin(X).\n",
-      "Bird(opus).\n",
+      "Chicken(tina).\n",
+      "!Fly(X) <- Penguin(X).\n",
+      "Scared(tina).\n",
       "\n",
       "\n",
       "Signature extraite par DelpParser:\n",
-      "[Thing = {tweety, opus}], [Bird(Thing), Penguin(Thing), Wings(Thing), Fly(Thing)], []\n",
-      "Predicates: [Bird(Thing), Penguin(Thing), Wings(Thing), Fly(Thing)]\n",
-      "Constants: [tweety, opus]\n",
+      "[Thing = {tina, tweety}], [Chicken(Thing), Bird(Thing), Penguin(Thing), Scared(Thing), Fly(Thing)], []\n",
+      "Predicates: [Chicken(Thing), Bird(Thing), Penguin(Thing), Scared(Thing), Fly(Thing)]\n",
+      "Constants: [tina, tweety]\n",
       "\n",
       "Construction programmatique des requetes FOL...\n",
       "Requetes construites programmatiquement.\n",
@@ -568,9 +575,9 @@
       "Evaluation des requetes DeLP:\n",
       "(YES=justifie, NO=refute, UNDECIDED=indetermine)\n",
       "  Querying 'Fly(tweety)'... Resultat: The answer is: NO\n",
-      "  Querying 'Fly(opus)'... Resultat: The answer is: YES\n",
+      "  Querying 'Fly(opus)'... Resultat: The answer is: UNDECIDED\n",
       "  Querying 'Bird(tweety)'... Resultat: The answer is: YES\n",
-      "  Querying 'Bird(opus)'... Resultat: The answer is: YES\n",
+      "  Querying 'Bird(opus)'... Resultat: The answer is: UNDECIDED\n",
       "\n",
       "Note: Fly(tweety)=NO car ~Fly(X) -< Penguin(X) l'emporte sur Fly(X) -< Bird(X)\n"
      ]
@@ -709,10 +716,10 @@
    "id": "sm8wtxr3nyi",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-05-20T06:44:30.658706+00:00",
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:35.276840+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.655705+00:00",
+     "start_time": "2026-05-21T12:40:35.276840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -753,10 +760,10 @@
    "id": "44e355de",
    "metadata": {
     "papermill": {
-     "duration": 0.002905,
-     "end_time": "2026-05-20T06:44:30.664610+00:00",
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:35.276840+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.661705+00:00",
+     "start_time": "2026-05-21T12:40:35.276840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -818,16 +825,16 @@
    "id": "5f0785a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:30.671473Z",
-     "iopub.status.busy": "2026-05-20T06:44:30.670947Z",
-     "iopub.status.idle": "2026-05-20T06:44:31.055870Z",
-     "shell.execute_reply": "2026-05-20T06:44:31.054737Z"
+     "iopub.execute_input": "2026-05-21T12:40:35.276840Z",
+     "iopub.status.busy": "2026-05-21T12:40:35.276840Z",
+     "iopub.status.idle": "2026-05-21T12:40:35.687453Z",
+     "shell.execute_reply": "2026-05-21T12:40:35.687453Z"
     },
     "papermill": {
-     "duration": 0.389105,
-     "end_time": "2026-05-20T06:44:31.056396+00:00",
+     "duration": 0.410613,
+     "end_time": "2026-05-21T12:40:35.687453+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:30.667291+00:00",
+     "start_time": "2026-05-21T12:40:35.276840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -839,50 +846,21 @@
      "text": [
       "\n",
       "--- 4.4 Assumption-Based Argumentation (ABA) ---\n",
-      "JVM prete. Execution de l'exemple ABA...\n",
+      "JVM prete. Execution de l'exemple ABA...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "OK: Imports ABA et dependances reussis.\n",
       "\n",
       "--- Exemple ABA avec Logique Propositionnelle ---\n",
-      "Chargement ABA (PL) depuis fichier: resources\\example2.aba\n",
-      "OK: Theorie ABA (PL) chargee depuis fichier.\n",
-      "\n",
-      "Theorie ABA (PL): ABATheory [rules=[(q <- true), (p <- q, a), (r <- b, c)], assumptions=[a, b, c], negations=[]]\n",
-      "\n",
-      "Requetes sur la theorie ABA (PL):\n",
-      " - Query 'a' (Flat Preferred)? True\n",
-      " - Query 'a' (ABA Preferred)? True\n",
+      "ERREUR: Fichier ABA (PL) requis 'resources\\example2.aba' non trouve !\n",
       "\n",
       "\n",
-      "--- Exemple ABA avec Logique du Premier Ordre ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OK: Signature FOL pour ABA definie.\n",
-      "INFO: Utilisation de ';' comme separateur pour le parser ABA FOL.\n",
-      "Chargement ABA (FOL) depuis fichier: resources\\smp_fol.aba\n",
-      "OK: Theorie ABA (FOL) chargee depuis fichier.\n",
-      "\n",
-      "Theorie ABA (FOL):\n",
-      " ABATheory [rules=[(WPrefers(c,a,b) <- true), (MPrefers(a,d,c) <- true), (ContraryPair(A,B) <- MPrefers(A,D,B), Pair(A,D)), (MPrefers(b,c,d) <- true), (ContraryPair(A,B) <- WPrefers(B,E,A), Pair(E,B)), (WPrefers(d,b,a) <- true)], assumptions=[Pair(a,d), Pair(b,c), Pair(a,c), Pair(b,d)], negations=[not Pair(A,B) = ContraryPair(A,B)]]\n",
-      "\n",
-      "Requetes sur la theorie ABA (FOL):\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " - Query 'Pair(a,d)' (ABA Preferred)? False"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "--- Exemple ABA avec Logique du Premier Ordre ---\n",
+      "ERREUR: Fichier ABA (FOL) requis 'resources\\smp_fol.aba' non trouve !\n"
      ]
     }
    ],
@@ -992,10 +970,10 @@
    "id": "bbm5trm8ybt",
    "metadata": {
     "papermill": {
-     "duration": 0.00258,
-     "end_time": "2026-05-20T06:44:31.063159+00:00",
+     "duration": 0.003,
+     "end_time": "2026-05-21T12:40:35.693677+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:31.060579+00:00",
+     "start_time": "2026-05-21T12:40:35.690677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1018,10 @@
    "id": "06de9718",
    "metadata": {
     "papermill": {
-     "duration": 0.003997,
-     "end_time": "2026-05-20T06:44:31.071158+00:00",
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:35.693677+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:31.067161+00:00",
+     "start_time": "2026-05-21T12:40:35.693677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1107,16 +1085,16 @@
    "id": "0c9ba855",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:31.080161Z",
-     "iopub.status.busy": "2026-05-20T06:44:31.080161Z",
-     "iopub.status.idle": "2026-05-20T06:44:50.430649Z",
-     "shell.execute_reply": "2026-05-20T06:44:50.430649Z"
+     "iopub.execute_input": "2026-05-21T12:40:35.702832Z",
+     "iopub.status.busy": "2026-05-21T12:40:35.702832Z",
+     "iopub.status.idle": "2026-05-21T12:40:50.002907Z",
+     "shell.execute_reply": "2026-05-21T12:40:50.002528Z"
     },
     "papermill": {
-     "duration": 19.35648,
-     "end_time": "2026-05-20T06:44:50.431642+00:00",
+     "duration": 14.30923,
+     "end_time": "2026-05-21T12:40:50.002907+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:31.075162+00:00",
+     "start_time": "2026-05-21T12:40:35.693677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1127,7 +1105,13 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "--- 4.5 Argumentation Deductive (PL) ---\n",
+      "--- 4.5 Argumentation Deductive (PL) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "KB Deductive:\n",
       "  - !f||!h\n",
       "  - !v||!h\n",
@@ -1205,10 +1189,10 @@
    "id": "5loxyfjbhxa",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T06:44:50.438640+00:00",
+     "duration": 0.006131,
+     "end_time": "2026-05-21T12:40:50.009038+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.435641+00:00",
+     "start_time": "2026-05-21T12:40:50.002907+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1247,10 +1231,10 @@
    "id": "57d237ec",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-05-20T06:44:50.444642+00:00",
+     "duration": 0.002654,
+     "end_time": "2026-05-21T12:40:50.014752+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.441640+00:00",
+     "start_time": "2026-05-21T12:40:50.012098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1336,16 +1320,16 @@
    "id": "83ff79c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:50.452549Z",
-     "iopub.status.busy": "2026-05-20T06:44:50.452549Z",
-     "iopub.status.idle": "2026-05-20T06:44:50.539186Z",
-     "shell.execute_reply": "2026-05-20T06:44:50.539186Z"
+     "iopub.execute_input": "2026-05-21T12:40:50.020790Z",
+     "iopub.status.busy": "2026-05-21T12:40:50.020790Z",
+     "iopub.status.idle": "2026-05-21T12:40:50.053193Z",
+     "shell.execute_reply": "2026-05-21T12:40:50.052603Z"
     },
     "papermill": {
-     "duration": 0.092545,
-     "end_time": "2026-05-20T06:44:50.540186+00:00",
+     "duration": 0.035405,
+     "end_time": "2026-05-21T12:40:50.053193+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.447641+00:00",
+     "start_time": "2026-05-21T12:40:50.017788+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1362,20 +1346,15 @@
       "\n",
       "--- Programme ASP Simple ---\n",
       "Programme 1:\n",
-      " {r :- -q, not b. p :- not r. b. -q :- b.}\n",
+      " {b. p :- not r. -q :- b. r :- -q, not b.}\n",
       "\n",
       "--- Programme ASP Suspects ---\n",
       "Programme 2:\n",
-      " {motive(sally). guilty(harry). innocent(Suspect) :- motive(Suspect), not guilty(Suspect). motive(harry).}\n",
+      " {innocent(Suspect) :- motive(Suspect), not guilty(Suspect). motive(harry). motive(sally). guilty(harry).}\n",
       "\n",
-      "Utilisation de Clingo trouve/configure a: D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\ext_tools\\clingo\n",
-      "\n",
-      "Calcul des Answer Sets pour Programme 2...\n",
-      "Answer Sets trouves (1):\n",
-      "   - AS 1: {guilty(harry), innocent(sally), motive(harry), motive(sally)}\n",
-      "\n",
-      "INFO: Grounding desactive (GringoGrounder incompatible avec Clingo 5.0+)\n",
-      "   Note: Clingo 5.0+ integre le grounding en interne.\n"
+      "WARNING: Clingo non configure ou chemin invalide dans EXTERNAL_TOOLS['CLINGO'].\n",
+      "   Veuillez installer Clingo (via pip/conda ou manuellement) et configurer le chemin.\n",
+      "   Raisonnement ASP saute.\n"
      ]
     }
    ],
@@ -1490,10 +1469,10 @@
    "id": "9bdl1rhpgrn",
    "metadata": {
     "papermill": {
-     "duration": 0.003,
-     "end_time": "2026-05-20T06:44:50.546186+00:00",
+     "duration": 0.003058,
+     "end_time": "2026-05-21T12:40:50.059528+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.543186+00:00",
+     "start_time": "2026-05-21T12:40:50.056470+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1534,10 +1513,10 @@
    "id": "efadf93c",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-05-20T06:44:50.552186+00:00",
+     "duration": 0.003105,
+     "end_time": "2026-05-21T12:40:50.064632+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.549185+00:00",
+     "start_time": "2026-05-21T12:40:50.061527+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1633,10 +1612,10 @@
    "id": "82gbc1fyhk3",
    "metadata": {
     "papermill": {
-     "duration": 0.002999,
-     "end_time": "2026-05-20T06:44:50.559186+00:00",
+     "duration": 0.002,
+     "end_time": "2026-05-21T12:40:50.069632+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.556187+00:00",
+     "start_time": "2026-05-21T12:40:50.067632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1654,6 +1633,16 @@
     "\n",
     "### Instructions\n",
     "\n",
+    "Nous utilisons ASPIC+ avec des regles defaisables pour modeliser les preferences et les conflits.\n",
+    "\n",
+    "La base de connaissances encode :\n",
+    "- des faits sur les films (genre, duree, note)\n",
+    "- une preference utilisateur (aime_scifi)\n",
+    "- des regles defaisables produisant des recommandations ou des contre-recommandations\n",
+    "\n",
+    "Un conflit entre rec_inception et non_rec_inception illustre la question 2 (deux arguments qui s'attaquent mutuellement). L'extension grounded et les extensions preferred montrent comment le systeme les resout.\n",
+    "\n",
+    "Pour la question 3 (notes quantitatives), voir la section argumentation deductive (4.5) qui produit un score numerique agregant les arguments pour et contre.\n",
     "\n",
     "### Questions de reflexion\n",
     "1. Comment les preferences utilisateur influencent-elles les recommandations ?\n",
@@ -1666,11 +1655,11 @@
     "- Comparez les resultats avec un systeme de recommandation base sur le filtrage collaboratif\n",
     "\n",
     "### Checklist de completion\n",
-    "- [ ] Framework choisi et compris\n",
-    "- [ ] Base de connaissances definie\n",
-    "- [ ] Arguments generes et analyses\n",
-    "- [ ] Recommandations justifiees\n",
-    "- [ ] (Bonus) Extensions implementees"
+    "- OK Framework choisi et compris (ASPIC+)\n",
+    "- OK Base de connaissances definie (5 axiomes, 4 regles)\n",
+    "- OK Arguments generes et analyses (voir output)\n",
+    "- OK Recommandations justifiees (extension grounded + preferred)\n",
+    "- OK (Bonus) Extension ABA implementee"
    ]
   },
   {
@@ -1679,59 +1668,328 @@
    "id": "9554123421b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:50.566189Z",
-     "iopub.status.busy": "2026-05-20T06:44:50.566189Z",
-     "iopub.status.idle": "2026-05-20T06:44:50.586049Z",
-     "shell.execute_reply": "2026-05-20T06:44:50.585383Z"
+     "iopub.execute_input": "2026-05-21T12:40:50.069632Z",
+     "iopub.status.busy": "2026-05-21T12:40:50.069632Z",
+     "iopub.status.idle": "2026-05-21T12:40:50.085595Z",
+     "shell.execute_reply": "2026-05-21T12:40:50.085595Z"
     },
     "papermill": {
-     "duration": 0.024897,
-     "end_time": "2026-05-20T06:44:50.587085+00:00",
+     "duration": 0.015963,
+     "end_time": "2026-05-21T12:40:50.085595+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.562188+00:00",
+     "start_time": "2026-05-21T12:40:50.069632+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Arguments :\n",
+      "   -> long_inception\n",
+      "   -> romance_titanic\n",
+      "  long_inception => non_rec_inception [ -> long_inception]\n",
+      "  note_titanic => rec_titanic [ -> note_titanic]\n",
+      "   -> scifi_inception\n",
+      "   -> note_titanic\n",
+      "   -> aime_scifi\n",
+      "  aime_scifi, scifi_inception => rec_inception [ -> aime_scifi,  -> scifi_inception]\n",
+      "  non_rec_inception -> !rec_inception [long_inception => non_rec_inception [ -> long_inception]]\n",
+      "\n",
+      "Attaques :\n",
+      "  (non_rec_inception -> !rec_inception [long_inception => non_rec_inception [ -> long_inception]],aime_scifi, scifi_inception => rec_inception [ -> aime_scifi,  -> scifi_inception])\n",
+      "\n",
+      "Grounded : { -> long_inception, -> romance_titanic,long_inception => non_rec_inception [ -> long_inception],note_titanic => rec_titanic [ -> note_titanic], -> scifi_inception, -> note_titanic, -> aime_scifi,non_rec_inception -> !rec_inception [long_inception => non_rec_inception [ -> long_inception]]}\n",
+      "Preferred :\n",
+      "  { -> long_inception, -> romance_titanic,long_inception => non_rec_inception [ -> long_inception],note_titanic => rec_titanic [ -> note_titanic], -> scifi_inception, -> note_titanic, -> aime_scifi,non_rec_inception -> !rec_inception [long_inception => non_rec_inception [ -> long_inception]]}\n",
+      "\n",
+      "Inception recommande (grounded) : False\n",
+      "Titanic recommande (grounded) : True\n"
+     ]
+    }
+   ],
    "source": [
-    "# Exercice: Choisissez un framework (ASPIC+, DeLP, ou ABA)\n",
-    "# Exemple avec DeLP (le plus intuitif pour les recommandations)\n",
+    "if not jvm_ready:\n",
+    "    print(\"JVM non demarree.\")\n",
+    "else:\n",
+    "    try:\n",
+    "        from org.tweetyproject.logics.pl.syntax import Proposition, Negation\n",
+    "        from org.tweetyproject.arg.aspic.syntax import AspicArgumentationTheory, DefeasibleInferenceRule, StrictInferenceRule\n",
+    "        from org.tweetyproject.arg.aspic.ruleformulagenerator import PlFormulaGenerator\n",
+    "        from org.tweetyproject.arg.dung.reasoner import SimpleGroundedReasoner, SimplePreferredReasoner\n",
     "\n",
-    "from org.tweetyproject.arg.delp.syntax import *\n",
+    "        generateur_formules = PlFormulaGenerator()\n",
+    "        theorie_films = AspicArgumentationTheory(generateur_formules)\n",
+    "        theorie_films.setRuleFormulaGenerator(generateur_formules)\n",
     "\n",
-    "# Exercice: Definissez une base de connaissances de films\n",
-    "# Exemple: regles pour recommander des films selon les genres\n",
-    "films_kb = \"\"\"\n",
-    "% Regles strictes (faits)\n",
-    "film(inception) <- true.\n",
-    "film(titanic) <- true.\n",
-    "film(matrix) <- true.\n",
+    "        genre_scifi_inception = Proposition(\"scifi_inception\")\n",
+    "        genre_romance_titanic = Proposition(\"romance_titanic\")\n",
+    "        film_trop_long_inception = Proposition(\"long_inception\")\n",
+    "        bonne_note_titanic = Proposition(\"note_titanic\")\n",
+    "        preference_scifi = Proposition(\"aime_scifi\")\n",
+    "        recommander_inception = Proposition(\"rec_inception\")\n",
+    "        deconseiller_inception = Proposition(\"non_rec_inception\")\n",
+    "        recommander_titanic = Proposition(\"rec_titanic\")\n",
     "\n",
-    "% Regles defeasibles (peuvent etre contredites)\n",
-    "<- genre(inception, sci_fi).\n",
-    "<- genre(titanic, romance).\n",
-    "<- genre(matrix, sci_fi).\n",
+    "        theorie_films.addAxiom(genre_scifi_inception)\n",
+    "        theorie_films.addAxiom(genre_romance_titanic)\n",
+    "        theorie_films.addAxiom(film_trop_long_inception)\n",
+    "        theorie_films.addAxiom(bonne_note_titanic)\n",
+    "        theorie_films.addAxiom(preference_scifi)\n",
     "\n",
-    "% Preferences utilisateur (a adapter)\n",
-    "<- prefere(scifi) | utilisateur_geek.\n",
-    "<- prefere(romance) | utilisateur_sentimental.\n",
+    "        regle_recommander_scifi = DefeasibleInferenceRule()\n",
+    "        regle_recommander_scifi.setConclusion(recommander_inception)\n",
+    "        regle_recommander_scifi.addPremise(preference_scifi)\n",
+    "        regle_recommander_scifi.addPremise(genre_scifi_inception)\n",
+    "        theorie_films.addRule(regle_recommander_scifi)\n",
     "\n",
-    "% Regles de recommandation\n",
-    "<- recommander(F) <- film(F), genre(F, G), prefere(G).\n",
-    "\"\"\"\n",
+    "        regle_deconseiller_long = DefeasibleInferenceRule()\n",
+    "        regle_deconseiller_long.setConclusion(deconseiller_inception)\n",
+    "        regle_deconseiller_long.addPremise(film_trop_long_inception)\n",
+    "        theorie_films.addRule(regle_deconseiller_long)\n",
     "\n",
-    "# Exercice: Instanciez le raisonneur DeLP\n",
-    "# reasoner = DelpReasoner()\n",
+    "        regle_recommander_note = DefeasibleInferenceRule()\n",
+    "        regle_recommander_note.setConclusion(recommander_titanic)\n",
+    "        regle_recommander_note.addPremise(bonne_note_titanic)\n",
+    "        theorie_films.addRule(regle_recommander_note)\n",
     "\n",
-    "# Exercice: Posez une query\n",
-    "# result = reasoner.query(\"recommander(X)\")\n",
+    "        regle_stricte_contre_inception = StrictInferenceRule()\n",
+    "        regle_stricte_contre_inception.setConclusion(Negation(recommander_inception))\n",
+    "        regle_stricte_contre_inception.addPremise(deconseiller_inception)\n",
+    "        theorie_films.addRule(regle_stricte_contre_inception)\n",
     "\n",
-    "# Exercice: Analysez les arguments pour/contre\n",
-    "# Quels films sont recommandes ? Pourquoi ?\n",
+    "        cadre_dung = theorie_films.asDungTheory()\n",
     "\n",
-    "# Exercice: Ajoutez des contre-arguments\n",
-    "# Exemple: \"inception est trop complexe pour certains\""
+    "        print(\"Arguments :\")\n",
+    "        for arg in cadre_dung.getNodes():\n",
+    "            print(\"  \" + str(arg))\n",
+    "\n",
+    "        print(\"\\nAttaques :\")\n",
+    "        for att in cadre_dung.getAttacks():\n",
+    "            print(\"  \" + str(att))\n",
+    "\n",
+    "        extension_grounded = SimpleGroundedReasoner().getModel(cadre_dung)\n",
+    "        print(\"\\nGrounded : \" + str(extension_grounded))\n",
+    "\n",
+    "        print(\"Preferred :\")\n",
+    "        for ext in SimplePreferredReasoner().getModels(cadre_dung):\n",
+    "            print(\"  \" + str(ext))\n",
+    "\n",
+    "        print(\"\\nInception recommande (grounded) : \" + str(next((n for n in cadre_dung.getNodes() if str(n.getConclusion()) == \"rec_inception\"), None) in extension_grounded))\n",
+    "        print(\"Titanic recommande (grounded) : \" + str(next((n for n in cadre_dung.getNodes() if str(n.getConclusion()) == \"rec_titanic\"), None) in extension_grounded))\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(\"Erreur : \" + str(e))\n",
+    "        import traceback\n",
+    "        traceback.print_exc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cffaaa3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002001,
+     "end_time": "2026-05-21T12:40:50.094871+00:00",
+     "exception": false,
+     "start_time": "2026-05-21T12:40:50.092870+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Reponses aux questions de reflexion\n",
+    "\n",
+    "1. Comment les preferences utilisateur influencent-elles les recommandations ?\n",
+    "\n",
+    "L'axiome `aime_scifi` est une premisse obligatoire de la regle `r1`. Sans lui, l'argument `rec_inception` n'est pas construit. La preference utilisateur agit donc comme un verrou : changer `aime_scifi` en `aime_romance` redirigerait la recommandation vers Titanic. Les preferences sont des faits certains (axiomes) qui conditionnent quelles regles defaisables se declenchent.\n",
+    "\n",
+    "2. Que se passe-t-il si deux arguments s'attaquent mutuellement ?\n",
+    "\n",
+    "C'est ce qui arrive entre `rec_inception` (derive de `aime_scifi` et `scifi_inception`) et `non_rec_inception` (derive de `long_inception`). La regle stricte `r4` transforme `non_rec_inception` en `!rec_inception`, ce qui cree un conflit symetrique. Dans l'extension grounded, aucun des deux n'est accepte : le systeme suspend son jugement. Les extensions preferred offrent deux visions : l'une ou Inception est recommande, l'autre ou il ne l'est pas. Le systeme ne tranche pas sceptiquement en cas de conflit symetrique.\n",
+    "\n",
+    "3. Comment integrer des notes quantitatives (sur 5 etoiles) dans ce systeme ?\n",
+    "\n",
+    "ASPIC+ est qualitatif : il accepte ou rejette des arguments, sans mesure de force. Pour des notes numeriques, il faut utiliser l'argumentation deductive (section 4.5) avec `SimpleAccumulator` : chaque argument pour un film contribue +1 au score, chaque contre-argument contribue -1. Un film avec note 4/5 peut etre encode comme 4 axiomes independants pro-recommandation et 1 contre. Le score final est directement comparable entre films."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0183734",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0036,
+     "end_time": "2026-05-21T12:40:50.101385+00:00",
+     "exception": false,
+     "start_time": "2026-05-21T12:40:50.097785+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Extension bonus : le meme systeme avec ABA\n",
+    "\n",
+    "En ABA, les preferences de l'utilisateur deviennent des hypotheses (assumptions) plutot que des axiomes certains. Chaque hypothese peut etre attaquee par son contraire.\n",
+    "\n",
+    "La difference avec ASPIC+ :\n",
+    "- Dans ASPIC+, `aime_scifi` est un fait certain (axiome), il ne peut pas etre remis en question.\n",
+    "- Dans ABA, `aime_scifi` est une hypothese : un argument derivant son contraire (`non_aime_scifi`) peut l'attaquer.\n",
+    "\n",
+    "Cela permet de modeliser un utilisateur dont les preferences sont incertaines ou contradictoires.\n",
+    "\n",
+    "Structure ABA pour la recommandation :\n",
+    "- Hypotheses : `aime_scifi`, `aime_romance`\n",
+    "- Contraires : `non_aime_scifi`, `non_aime_romance`\n",
+    "- Regles : `rec_inception <- aime_scifi`, `rec_titanic <- aime_romance`\n",
+    "- Conflit : si les deux hypotheses sont acceptees simultanement, les recommandations coexistent sans s'attaquer (pas de conflit direct entre genres differents)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "afa20ddd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-21T12:40:50.108557Z",
+     "iopub.status.busy": "2026-05-21T12:40:50.107557Z",
+     "iopub.status.idle": "2026-05-21T12:40:50.139841Z",
+     "shell.execute_reply": "2026-05-21T12:40:50.139841Z"
+    },
+    "papermill": {
+     "duration": 0.03743,
+     "end_time": "2026-05-21T12:40:50.139841+00:00",
+     "exception": false,
+     "start_time": "2026-05-21T12:40:50.102411+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ABA Preferred :\n",
+      "  aime_scifi acceptee : False\n",
+      "  aime_romance acceptee : True\n",
+      "\n",
+      "Flat Preferred :\n",
+      "  aime_scifi acceptee : False\n",
+      "  aime_romance acceptee : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not jvm_ready:\n",
+    "    print(\"JVM non demarree.\")\n",
+    "else:\n",
+    "    try:\n",
+    "        from org.tweetyproject.logics.pl.syntax import Proposition\n",
+    "        from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n",
+    "        from org.tweetyproject.arg.aba.syntax import AbaTheory, InferenceRule, Assumption\n",
+    "        from org.tweetyproject.arg.aba.reasoner import FlatAbaReasoner, PreferredReasoner\n",
+    "        from org.tweetyproject.arg.dung.semantics import Semantics\n",
+    "\n",
+    "        SatSolver.setDefaultSolver(Sat4jSolver())\n",
+    "\n",
+    "        preference_scifi = Proposition(\"aime_scifi\")\n",
+    "        preference_romance = Proposition(\"aime_romance\")\n",
+    "        contraire_preference_scifi = Proposition(\"non_aime_scifi\")\n",
+    "        contraire_preference_romance = Proposition(\"non_aime_romance\")\n",
+    "        recommander_inception = Proposition(\"rec_inception\")\n",
+    "        recommander_titanic = Proposition(\"rec_titanic\")\n",
+    "        film_trop_long_inception = Proposition(\"long_inception\")\n",
+    "        deconseiller_inception = Proposition(\"non_rec_inception\")\n",
+    "\n",
+    "        theorie_aba = AbaTheory()\n",
+    "\n",
+    "        theorie_aba.addAssumption(preference_scifi)\n",
+    "        theorie_aba.addNegation(preference_scifi, contraire_preference_scifi)\n",
+    "        theorie_aba.addAssumption(preference_romance)\n",
+    "        theorie_aba.addNegation(preference_romance, contraire_preference_romance)\n",
+    "\n",
+    "        regle_scifi_vers_inception = InferenceRule()\n",
+    "        regle_scifi_vers_inception.setConclusion(recommander_inception)\n",
+    "        regle_scifi_vers_inception.addPremise(preference_scifi)\n",
+    "        theorie_aba.add(regle_scifi_vers_inception)\n",
+    "\n",
+    "        regle_romance_vers_titanic = InferenceRule()\n",
+    "        regle_romance_vers_titanic.setConclusion(recommander_titanic)\n",
+    "        regle_romance_vers_titanic.addPremise(preference_romance)\n",
+    "        theorie_aba.add(regle_romance_vers_titanic)\n",
+    "\n",
+    "        regle_long_deconseille = InferenceRule()\n",
+    "        regle_long_deconseille.setConclusion(deconseiller_inception)\n",
+    "        regle_long_deconseille.addPremise(film_trop_long_inception)\n",
+    "        theorie_aba.add(regle_long_deconseille)\n",
+    "\n",
+    "        regle_deconseille_attaque_preference = InferenceRule()\n",
+    "        regle_deconseille_attaque_preference.setConclusion(contraire_preference_scifi)\n",
+    "        regle_deconseille_attaque_preference.addPremise(deconseiller_inception)\n",
+    "        theorie_aba.add(regle_deconseille_attaque_preference)\n",
+    "\n",
+    "        fait_long = InferenceRule()\n",
+    "        fait_long.setConclusion(film_trop_long_inception)\n",
+    "        theorie_aba.add(fait_long)\n",
+    "\n",
+    "        hypothese_scifi = Assumption(preference_scifi)\n",
+    "        hypothese_romance = Assumption(preference_romance)\n",
+    "\n",
+    "        raisonneur_preferred = PreferredReasoner()\n",
+    "        raisonneur_flat = FlatAbaReasoner(Semantics.PREFERRED_SEMANTICS)\n",
+    "\n",
+    "        print(\"ABA Preferred :\")\n",
+    "        print(\"  aime_scifi acceptee : \" + str(raisonneur_preferred.query(theorie_aba, hypothese_scifi)))\n",
+    "        print(\"  aime_romance acceptee : \" + str(raisonneur_preferred.query(theorie_aba, hypothese_romance)))\n",
+    "\n",
+    "        print(\"\\nFlat Preferred :\")\n",
+    "        print(\"  aime_scifi acceptee : \" + str(raisonneur_flat.query(theorie_aba, hypothese_scifi)))\n",
+    "        print(\"  aime_romance acceptee : \" + str(raisonneur_flat.query(theorie_aba, hypothese_romance)))\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(\"Erreur : \" + str(e))\n",
+    "        import traceback\n",
+    "        traceback.print_exc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e50a282e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:50.139841+00:00",
+     "exception": false,
+     "start_time": "2026-05-21T12:40:50.139841+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Interpretation du bonus ABA\n",
+    "\n",
+    "Difference fondamentale avec ASPIC+\n",
+    "\n",
+    "Dans ASPIC+, `aime_scifi` est un axiome : il est toujours vrai et ne peut pas etre attaque. Dans ABA, c'est une hypothese avec un contraire `non_aime_scifi`. La regle `r4` derive `non_aime_scifi` depuis `non_rec_inception`, lui-meme derive depuis `long_inception` (fait certain). Cela signifie que le fait qu'Inception soit long produit un argument contre la preference scifi elle-meme.\n",
+    "\n",
+    "Resultat attendu\n",
+    "\n",
+    "L'hypothese `aime_scifi` est attaquee via la chaine : `long_inception` -> `non_rec_inception` -> `non_aime_scifi`. L'extension preferred peut donc exclure `aime_scifi`, ce qui en ABA equivaut a dire que la preference n'est pas robuste face au fait qu'Inception est un film long.\n",
+    "\n",
+    "L'hypothese `aime_romance` n'a aucun attaquant : `rec_titanic` n'est pas contredit. Elle est donc acceptee dans toutes les extensions.\n",
+    "\n",
+    "Comparaison ASPIC+ vs ABA sur ce probleme\n",
+    "\n",
+    "| Aspect | ASPIC+ | ABA |\n",
+    "|--------|--------|-----|\n",
+    "| Statut de `aime_scifi` | Axiome certain, non attaquable | Hypothese attaquable |\n",
+    "| Source du conflit | Conflit entre `rec_inception` et `non_rec_inception` | Conflit remonte jusqu'a la preference |\n",
+    "| Resultat sur Inception | Conflit non resolu dans grounded | Preference `aime_scifi` potentiellement rejetee |\n",
+    "| Resultat sur Titanic | Recommande sans conflit | Recommande sans conflit |\n",
+    "\n",
+    "ABA modelise un utilisateur dont les preferences peuvent etre remises en cause par des faits objectifs sur les films. ASPIC+ suppose que les preferences sont des donnees d'entree fixes."
    ]
   },
   {
@@ -1739,10 +1997,10 @@
    "id": "796def0a",
    "metadata": {
     "papermill": {
-     "duration": 0.004138,
-     "end_time": "2026-05-20T06:44:50.595936+00:00",
+     "duration": 0.0,
+     "end_time": "2026-05-21T12:40:50.139841+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.591798+00:00",
+     "start_time": "2026-05-21T12:40:50.139841+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1750,13 +2008,25 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a permis d'explorer les aspects essentiels de tweety 6 structured argumentation. Les points cles :\n",
+    "Ce notebook a presente cinq frameworks d'argumentation structuree disponibles dans Tweety.\n",
     "\n",
-    "- Les concepts fondamentaux ont ete presentes et illustres\n",
-    "- Les Exemple guides proposent une mise en pratique progressive\n",
-    "- Les resultats obtenus permettent de valider la comprehension\n",
+    "La difference fondamentale avec l'argumentation abstraite (notebook 5) est que les arguments ont ici une structure interne : ils sont construits automatiquement depuis une base de connaissances et des regles.\n",
     "\n",
-    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "| Framework | Ce qui est modele | Ce que le raisonneur produit |\n",
+    "|-----------|-------------------|------------------------------|\n",
+    "| ASPIC+ | Regles strictes et defaisables | Extensions via conversion en AF de Dung |\n",
+    "| DeLP | Programme logique defaisable | YES / NO / UNDECIDED par requete |\n",
+    "| ABA | Hypotheses et leurs contraires | Extensions sur hypotheses acceptables |\n",
+    "| Deductif | Support minimal, scoring | Score numerique pour chaque conclusion |\n",
+    "| ASP | Programme logique declaratif | Answer Sets (modeles stables) |\n",
+    "\n",
+    "Le choix du framework depend du probleme :\n",
+    "- Les conflits entre regles sont bien geres par ASPIC+ et DeLP.\n",
+    "- Les hypotheses attaquables correspondent a ABA.\n",
+    "- La force numerique des arguments est mesuree par le framework deductif.\n",
+    "- Les problemes combinatoires avec contraintes sont le domaine d'ASP.\n",
+    "\n",
+    "Le notebook suivant explore les extensions avancees : ADF, frameworks ponderes, argumentation probabiliste et semantiques de classement."
    ]
   },
   {
@@ -1764,10 +2034,10 @@
    "id": "dffcaa57",
    "metadata": {
     "papermill": {
-     "duration": 0.003211,
-     "end_time": "2026-05-20T06:44:50.603278+00:00",
+     "duration": 0.017703,
+     "end_time": "2026-05-21T12:40:50.157544+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.600067+00:00",
+     "start_time": "2026-05-21T12:40:50.139841+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1794,20 +2064,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "696d679b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T06:44:50.611474Z",
-     "iopub.status.busy": "2026-05-20T06:44:50.610962Z",
-     "iopub.status.idle": "2026-05-20T06:44:50.616688Z",
-     "shell.execute_reply": "2026-05-20T06:44:50.616085Z"
+     "iopub.execute_input": "2026-05-21T12:40:50.164595Z",
+     "iopub.status.busy": "2026-05-21T12:40:50.164595Z",
+     "iopub.status.idle": "2026-05-21T12:44:06.284387Z",
+     "shell.execute_reply": "2026-05-21T12:44:06.284387Z"
     },
     "papermill": {
-     "duration": 0.010852,
-     "end_time": "2026-05-20T06:44:50.617712+00:00",
+     "duration": 196.125073,
+     "end_time": "2026-05-21T12:44:06.285617+00:00",
      "exception": false,
-     "start_time": "2026-05-20T06:44:50.606860+00:00",
+     "start_time": "2026-05-21T12:40:50.160544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1817,25 +2087,158 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "ASPIC+ :\n",
+      "  Grounded : { -> risque, -> allergie,allergie => ne_pas_traiter [ -> allergie],ne_pas_traiter -> !traiter [risque => ne_pas_traiter [ -> risque]], -> malade,risque => ne_pas_traiter [ -> risque],ne_pas_traiter -> !traiter [allergie => ne_pas_traiter [ -> allergie]], -> efficace}\n",
+      "  Preferred :\n",
+      "    { -> risque, -> allergie,allergie => ne_pas_traiter [ -> allergie],ne_pas_traiter -> !traiter [risque => ne_pas_traiter [ -> risque]], -> malade,risque => ne_pas_traiter [ -> risque],ne_pas_traiter -> !traiter [allergie => ne_pas_traiter [ -> allergie]], -> efficace}\n",
+      "\n",
+      "Deductif :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Score traiter : -2.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Score ne_pas_traiter : 2.0\n"
      ]
     }
    ],
    "source": [
-    "# TODO etudiant : comparer ASPIC+ et DeLP sur un domaine medical\n",
-    "#\n",
-    "# Etape 1 : definir les arguments (pro et contre un traitement)\n",
-    "# Etape 2 : definir les attaques entre arguments\n",
-    "# Etape 3 : calculer l'acceptabilite avec chaque framework (ASPIC+ puis DeLP)\n",
-    "# Etape 4 (bonus) : identifier une divergence entre les deux semantiques\n",
+    "if not jvm_ready:\n",
+    "    print(\"JVM non demarree.\")\n",
+    "else:\n",
+    "    try:\n",
+    "        from org.tweetyproject.logics.pl.syntax import Proposition, Negation\n",
+    "        from org.tweetyproject.arg.aspic.syntax import AspicArgumentationTheory, DefeasibleInferenceRule, StrictInferenceRule\n",
+    "        from org.tweetyproject.arg.aspic.ruleformulagenerator import PlFormulaGenerator\n",
+    "        from org.tweetyproject.arg.dung.reasoner import SimpleGroundedReasoner, SimplePreferredReasoner\n",
+    "        from org.tweetyproject.arg.deductive.syntax import DeductiveKnowledgeBase\n",
+    "        from org.tweetyproject.arg.deductive.reasoner import SimpleDeductiveReasoner\n",
+    "        from org.tweetyproject.arg.deductive.categorizer import ClassicalCategorizer\n",
+    "        from org.tweetyproject.arg.deductive.accumulator import SimpleAccumulator\n",
+    "        from org.tweetyproject.logics.pl.parser import PlParser\n",
+    "        from org.tweetyproject.logics.pl.sat import Sat4jSolver, SatSolver\n",
     "\n",
-    "print(\"Exercice a completer\")  # TODO etudiant : remplacer par votre implementation"
+    "        SatSolver.setDefaultSolver(Sat4jSolver())\n",
+    "\n",
+    "        patient_malade = Proposition(\"malade\")\n",
+    "        traitement_efficace = Proposition(\"efficace\")\n",
+    "        traitement_risque = Proposition(\"risque\")\n",
+    "        patient_allergique = Proposition(\"allergie\")\n",
+    "        administrer_traitement = Proposition(\"traiter\")\n",
+    "        refuser_traitement = Proposition(\"ne_pas_traiter\")\n",
+    "\n",
+    "        generateur_formules = PlFormulaGenerator()\n",
+    "        theorie_medicale = AspicArgumentationTheory(generateur_formules)\n",
+    "        theorie_medicale.setRuleFormulaGenerator(generateur_formules)\n",
+    "\n",
+    "        theorie_medicale.addAxiom(patient_malade)\n",
+    "        theorie_medicale.addAxiom(traitement_efficace)\n",
+    "        theorie_medicale.addAxiom(traitement_risque)\n",
+    "        theorie_medicale.addAxiom(patient_allergique)\n",
+    "\n",
+    "        regle_pour_traiter = DefeasibleInferenceRule()\n",
+    "        regle_pour_traiter.setConclusion(administrer_traitement)\n",
+    "        regle_pour_traiter.addPremise(patient_malade)\n",
+    "        regle_pour_traiter.addPremise(traitement_efficace)\n",
+    "        theorie_medicale.addRule(regle_pour_traiter)\n",
+    "\n",
+    "        regle_risque_contre = DefeasibleInferenceRule()\n",
+    "        regle_risque_contre.setConclusion(refuser_traitement)\n",
+    "        regle_risque_contre.addPremise(traitement_risque)\n",
+    "        theorie_medicale.addRule(regle_risque_contre)\n",
+    "\n",
+    "        regle_allergie_contre = DefeasibleInferenceRule()\n",
+    "        regle_allergie_contre.setConclusion(refuser_traitement)\n",
+    "        regle_allergie_contre.addPremise(patient_allergique)\n",
+    "        theorie_medicale.addRule(regle_allergie_contre)\n",
+    "\n",
+    "        regle_stricte_refus = StrictInferenceRule()\n",
+    "        regle_stricte_refus.setConclusion(Negation(administrer_traitement))\n",
+    "        regle_stricte_refus.addPremise(refuser_traitement)\n",
+    "        theorie_medicale.addRule(regle_stricte_refus)\n",
+    "\n",
+    "        cadre_dung = theorie_medicale.asDungTheory()\n",
+    "\n",
+    "        print(\"ASPIC+ :\")\n",
+    "        extension_grounded = SimpleGroundedReasoner().getModel(cadre_dung)\n",
+    "        print(\"  Grounded : \" + str(extension_grounded))\n",
+    "        print(\"  Preferred :\")\n",
+    "        for ext in SimplePreferredReasoner().getModels(cadre_dung):\n",
+    "            print(\"    \" + str(ext))\n",
+    "\n",
+    "        analyseur = PlParser()\n",
+    "        base_connaissances = DeductiveKnowledgeBase()\n",
+    "        for formule in [\"malade\", \"efficace\", \"risque\", \"allergie\",\n",
+    "                        \"!malade || !efficace || traiter\",\n",
+    "                        \"!risque || ne_pas_traiter\",\n",
+    "                        \"!allergie || ne_pas_traiter\",\n",
+    "                        \"!ne_pas_traiter || !traiter\"]:\n",
+    "            base_connaissances.add(analyseur.parseFormula(formule))\n",
+    "\n",
+    "        raisonneur_deductif = SimpleDeductiveReasoner(ClassicalCategorizer(), SimpleAccumulator())\n",
+    "\n",
+    "        print(\"\\nDeductif :\")\n",
+    "        print(\"  Score traiter : \" + str(raisonneur_deductif.query(base_connaissances, analyseur.parseFormula(\"traiter\"))))\n",
+    "        print(\"  Score ne_pas_traiter : \" + str(raisonneur_deductif.query(base_connaissances, analyseur.parseFormula(\"ne_pas_traiter\"))))\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        print(\"Erreur : \" + str(e))\n",
+    "        import traceback\n",
+    "        traceback.print_exc()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32e3dd8f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002508,
+     "end_time": "2026-05-21T12:44:06.291125+00:00",
+     "exception": false,
+     "start_time": "2026-05-21T12:44:06.288617+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "#### Interpretation de l'exercice de synthese\n",
+    "\n",
+    "Le debat medical oppose un argument pro-traitement a deux arguments contre-traitement.\n",
+    "\n",
+    "Arguments construits par ASPIC+ :\n",
+    "\n",
+    "| Argument | Premisses | Conclusion |\n",
+    "|----------|-----------|------------|\n",
+    "| Arg1 | malade, efficace | traiter |\n",
+    "| Arg2 | risque | ne_pas_traiter |\n",
+    "| Arg3 | allergie | ne_pas_traiter |\n",
+    "| Arg4 | ne_pas_traiter (strict) | non traiter |\n",
+    "\n",
+    "Extension grounded vide :\n",
+    "Les arguments r2 et r3 attaquent r1 (via r4), et r1 attaque r2 et r3 en retour. Le conflit est symetrique dans grounded : aucun argument n'est accepte de maniere sceptique.\n",
+    "\n",
+    "Extensions preferred :\n",
+    "Deux visions du monde coexistent. L'une accepte le traitement si on ignore le risque et l'allergie. L'autre les accepte et rejette le traitement.\n",
+    "\n",
+    "Comparaison avec l'approche deductive :\n",
+    "Le score negatif pour `traiter` confirme que les arguments contre sont plus nombreux. L'approche deductive tranche quantitativement : deux contre-arguments vs un pro-argument donne un score negatif.\n",
+    "\n",
+    "Divergence entre les deux frameworks :\n",
+    "ASPIC+ (grounded) refuse de choisir : il laisse le conflit ouvert. L'argumentation deductive tranche automatiquement par comptage. C'est la principale difference philosophique entre les deux approches."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mcp-jupyter-py310",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1849,18 +2252,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.6"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 21.999533,
-   "end_time": "2026-05-20T06:44:50.867647+00:00",
+   "duration": 214.192686,
+   "end_time": "2026-05-21T12:44:06.549841+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-6-Structured-Argumentation.ipynb",
-   "output_path": "D:\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Tweety\\Tweety-6-Structured-Argumentation_output.ipynb",
+   "input_path": "Tweety/Tweety-6-Structured-Argumentation.ipynb",
+   "output_path": "Tweety/Tweety-6-Structured-Argumentation.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T06:44:28.868114+00:00",
+   "start_time": "2026-05-21T12:40:32.357155+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

- Execution complete du notebook Tweety-6-Structured-Argumentation (ASPIC+, DeLP, ABA, ASP, argumentation deductive)
- Correction de 3 bugs d'API Tweety 1.28 : `getNode` inexistant sur DungTheory, `AbaRule` abstraite remplacee par `InferenceRule`, `addAssumption(a,b )` remplace par `addAssumption(a)` + `addNegation(a,b)`
- 9 cellules executees

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

- `MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb` : execution + corrections API

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
