### PR TITLE
enrich(Sudoku): add 3 transition cells to Sudoku-8-HumanStrategies-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -1280,7 +1280,7 @@
       ". 8 . | . 4 1 | 9 5 . \n",
       "\n",
       "Resolu: True\n",
-      "Temps: 2.05ms\n",
+      "Temps: 2.68ms\n",
       "\n",
       "Statistiques des strategies:\n",
       "  Naked Single: 14\n",
@@ -1375,16 +1375,16 @@
      "text": [
       "\n",
       "=== Benchmark: Strategies Humaines (5 puzzles) ===\n",
-      "  Puzzle 1: OK, 0.72ms\n",
-      "  Puzzle 2: OK, 1.93ms\n",
-      "  Puzzle 3: OK, 2.76ms\n",
-      "  Puzzle 4: OK, 3.22ms\n",
-      "  Puzzle 5: OK, 2.60ms\n",
+      "  Puzzle 1: OK, 1.27ms\n",
+      "  Puzzle 2: OK, 1.84ms\n",
+      "  Puzzle 3: OK, 2.40ms\n",
+      "  Puzzle 4: OK, 2.90ms\n",
+      "  Puzzle 5: OK, 2.58ms\n",
       "\n",
       "Resume:\n",
       "  Resolus: 5/5\n",
-      "  Temps total: 11.22ms\n",
-      "  Temps moyen: 2.24ms\n",
+      "  Temps total: 10.99ms\n",
+      "  Temps moyen: 2.20ms\n",
       "\n",
       "Strategies utilisees:\n",
       "  Hidden Single: 149\n",
@@ -1518,22 +1518,16 @@
       "=== Comparaison : Strategies Humaines vs Backtracking ===\n",
       "\n",
       "Puzzle 1:\n",
-      "  Humain: True, 0.60ms\n",
-      "  Backtracking: True, 1.65ms, 49 appels\n",
+      "  Humain: True, 0.57ms\n",
+      "  Backtracking: True, 1.96ms, 49 appels\n",
       "\n",
       "Puzzle 2:\n",
-      "  Humain: True, 1.69ms\n",
-      "  Backtracking: True, 9.48ms, 201 appels\n",
+      "  Humain: True, 1.84ms\n",
+      "  Backtracking: True, 8.54ms, 201 appels\n",
       "\n",
-      "Puzzle 3:\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Humain: True, 2.89ms\n",
-      "  Backtracking: True, 15.09ms, 295 appels\n"
+      "Puzzle 3:\n",
+      "  Humain: True, 2.66ms\n",
+      "  Backtracking: True, 17.47ms, 295 appels\n"
      ]
     }
    ],
@@ -1722,14 +1716,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Methode definie : find_hidden_pairs"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "Methode definie : find_hidden_pairs\n"
      ]
     }
    ],
@@ -1887,6 +1874,12 @@
     "\n",
     "print(\"Exercice a completer : Hidden Pairs dans les blocs\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80384432",
+   "source": "### Exemple guide 2 : Swordfish\n\nLe **Swordfish** est une generalisation du X-Wing sur trois lignes (ou colonnes) au lieu de deux : une valeur forme un pattern de 3 lignes x 3 colonnes ou elle est confinee, permettant l'elimination de ses candidats dans les colonnes (ou lignes) correspondantes en dehors du pattern. L'exemple ci-dessous implemente la detection dans les deux orientations.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -2063,6 +2056,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "960e87f0",
+   "source": "### Exemple guide 3 : XY-Wing\n\nLe **XY-Wing** est une technique basee sur trois cellules bi-valuees (ayant exactement deux candidats). Un **pivot** avec les candidats {X, Y} est connecte a deux **ailes** : l'une avec {X, Z} et l'autre avec {Y, Z}. La valeur Z peut alors etre eliminee de toute cellule visible simultanement par les deux ailes. L'exemple ci-dessous implemente la recherche exhaustive de tous les XY-Wings dans la grille.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 17,
    "id": "c0fded61",
@@ -2087,7 +2086,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Methodes definies : _are_peers, find_xy_wings\n"
+      "Methodes definies : _are_peers, find_xy_wings"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -2278,6 +2284,12 @@
     "\n",
     "print(\"Exercice a completer : XY-Wing pour un pivot donne\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dda45ce9",
+   "source": "### Validation des techniques avancees\n\nLes trois exemples precedents (Hidden Pair, Swordfish, XY-Wing) sont maintenant integres a la classe `HumanSudokuSolver`. La cellule suivante teste leur detection sur le puzzle de reference, puis realise une resolution complete en combinant toutes les techniques avancees avant de finir avec le fallback backtracking.",
+   "metadata": {}
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Insert 3 markdown transition cells between consecutive code pairs in `Sudoku-8-HumanStrategies-Python.ipynb` (section 10: techniques avancees).

### Cells inserted (bottom-to-top)
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `dda45ce9` | After `b667ffe1` (XY-Wing stub) | "Validation des techniques avancees" |
| 2 | `960e87f0` | After `ffc701dc` (Swordfish stub) | "Exemple guide 3 : XY-Wing" |
| 3 | `80384432` | After `d8dacad0` (Hidden Pair stub) | "Exemple guide 2 : Swordfish" |

## Validation proof

- **Papermill**: 46/46 cells executed, 0 errors, kernel=python3
- **execution_count**: All 19 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Markdown-only insertions**: +18 lines of markdown transitions
- **No source code modified**: only markdown cells inserted + outputs refreshed from re-execution

## Scope

- 1 file changed, 42 insertions, 30 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
