### PR TITLE
docs(sensitivity): fix mislabelled theorem in README (Huang degree theorem, not 'sensitivity <= block sensitivity')

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
@@ -22,7 +22,7 @@ Lean 4 formalization of the Sensitivity Theorem from Boolean function analysis.
 ## Key Results
 
 - **COMPLETE**: All proofs done, 0 sorry
-- Formalization of the Sensitivity Theorem (sensitivity <= block sensitivity)
+- Formalization of the **Huang degree theorem** (Huang 2019, `huang_degree_theorem` in `MainTheorem.lean`): an induced subgraph of the hypercube on more than half its vertices has a vertex of degree `>= sqrt(n)` -- the combinatorial result that resolves the Sensitivity Conjecture (`deg(f) <= s(f)^2`)
 - Boolean hypercube structure
 - Sensitivity and block sensitivity operators
 


### PR DESCRIPTION
## Scope

One-line documentation fix in `MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md` (Key Results, l.25).

## Problem

The README described the formalized result as:

> Formalization of the Sensitivity Theorem (sensitivity <= block sensitivity)

`sensitivity <= block sensitivity` is the **trivial** direction (`s(f) <= bs(f)` always holds) and is **not** what the formalization proves.

## What is actually formalized

`huang_degree_theorem` (`Sensitivity/MainTheorem.lean:84`, Huang 2019):

```lean
theorem huang_degree_theorem (H : Set (Q m.succ)) (hH : Card H >= 2 ^ m + 1) :
    exists q, q in H and sqrt(m + 1) <= Card (H cap q.adjacent)
```

i.e. *an induced subgraph of the hypercube on more than half its vertices has a vertex of degree `>= sqrt(n)`* -- the combinatorial core that resolves the **Sensitivity Conjecture** (`deg(f) <= s(f)^2`). The source comment confirms: "Huang sensitivity theorem also known as the Huang degree theorem."

## Change

Reworded l.25 to name the actual theorem (`huang_degree_theorem`) and state it correctly. **No `.lean` files touched.**

## Verification

- README header (l.3) and `NOTICE.md` were already correct -- only the Key Results parenthetical was wrong.
- Build status unchanged: 0 sorry, `lake build Sensitivity` SUCCESS (per README Status, confirmed against `files-with-sorry=0` for `sensitivity_lean`).

Documentary coquille surfaced while drafting a transversal "grade de certification" reading of the repo.