### PR TITLE
enrich(SC-15): integrate student ZKP solution as Exemple guide (#2042)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -5,10 +5,10 @@
    "id": "header",
    "metadata": {
     "papermill": {
-     "duration": 0.003781,
-     "end_time": "2026-05-31T23:30:20.984953+00:00",
+     "duration": 0.024891,
+     "end_time": "2026-06-01T17:01:27.949504",
      "exception": false,
-     "start_time": "2026-05-31T23:30:20.981172+00:00",
+     "start_time": "2026-06-01T17:01:27.924613",
      "status": "completed"
     },
     "tags": []
@@ -42,10 +42,10 @@
    "id": "zkp-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002692,
-     "end_time": "2026-05-31T23:30:20.990719+00:00",
+     "duration": 0.016424,
+     "end_time": "2026-06-01T17:01:27.991744",
      "exception": false,
-     "start_time": "2026-05-31T23:30:20.988027+00:00",
+     "start_time": "2026-06-01T17:01:27.975320",
      "status": "completed"
     },
     "tags": []
@@ -98,16 +98,16 @@
    "id": "cave-simulation",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:20.997638Z",
-     "iopub.status.busy": "2026-05-31T23:30:20.997212Z",
-     "iopub.status.idle": "2026-05-31T23:30:21.016818Z",
-     "shell.execute_reply": "2026-05-31T23:30:21.015996Z"
+     "iopub.execute_input": "2026-06-01T17:01:28.022013Z",
+     "iopub.status.busy": "2026-06-01T17:01:28.021698Z",
+     "iopub.status.idle": "2026-06-01T17:01:28.081409Z",
+     "shell.execute_reply": "2026-06-01T17:01:28.080881Z"
     },
     "papermill": {
-     "duration": 0.024129,
-     "end_time": "2026-05-31T23:30:21.017510+00:00",
+     "duration": 0.074389,
+     "end_time": "2026-06-01T17:01:28.082751",
      "exception": false,
-     "start_time": "2026-05-31T23:30:20.993381+00:00",
+     "start_time": "2026-06-01T17:01:28.008362",
      "status": "completed"
     },
     "tags": []
@@ -171,10 +171,10 @@
    "id": "cave-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.002789,
-     "end_time": "2026-05-31T23:30:21.023562+00:00",
+     "duration": 0.005798,
+     "end_time": "2026-06-01T17:01:28.094383",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.020773+00:00",
+     "start_time": "2026-06-01T17:01:28.088585",
      "status": "completed"
     },
     "tags": []
@@ -198,10 +198,10 @@
    "id": "dlog-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.002802,
-     "end_time": "2026-05-31T23:30:21.029074+00:00",
+     "duration": 0.006051,
+     "end_time": "2026-06-01T17:01:28.106060",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.026272+00:00",
+     "start_time": "2026-06-01T17:01:28.100009",
      "status": "completed"
     },
     "tags": []
@@ -241,10 +241,10 @@
    "id": "8199e832",
    "metadata": {
     "papermill": {
-     "duration": 0.002632,
-     "end_time": "2026-05-31T23:30:21.034331+00:00",
+     "duration": 0.011164,
+     "end_time": "2026-06-01T17:01:28.123510",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.031699+00:00",
+     "start_time": "2026-06-01T17:01:28.112346",
      "status": "completed"
     },
     "tags": []
@@ -270,10 +270,10 @@
    "id": "dlog-transition",
    "metadata": {
     "papermill": {
-     "duration": 0.002677,
-     "end_time": "2026-05-31T23:30:21.040723+00:00",
+     "duration": 0.03654,
+     "end_time": "2026-06-01T17:01:28.189143",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.038046+00:00",
+     "start_time": "2026-06-01T17:01:28.152603",
      "status": "completed"
     },
     "tags": []
@@ -292,16 +292,16 @@
    "id": "dlog-interactive",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:21.047220Z",
-     "iopub.status.busy": "2026-05-31T23:30:21.047036Z",
-     "iopub.status.idle": "2026-05-31T23:30:21.087153Z",
-     "shell.execute_reply": "2026-05-31T23:30:21.086448Z"
+     "iopub.execute_input": "2026-06-01T17:01:28.222626Z",
+     "iopub.status.busy": "2026-06-01T17:01:28.222395Z",
+     "iopub.status.idle": "2026-06-01T17:01:28.257353Z",
+     "shell.execute_reply": "2026-06-01T17:01:28.256147Z"
     },
     "papermill": {
-     "duration": 0.044328,
-     "end_time": "2026-05-31T23:30:21.087697+00:00",
+     "duration": 0.047763,
+     "end_time": "2026-06-01T17:01:28.259977",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.043369+00:00",
+     "start_time": "2026-06-01T17:01:28.212214",
      "status": "completed"
     },
     "tags": []
@@ -313,10 +313,10 @@
      "text": [
       "pycryptodome disponible.\n",
       "Parametres Discrete Log generes:\n",
-      "  p (premier) = 0xe481959396e191850024c3f60afa27f5b9a524...\n",
-      "  g (generateur) = 0xc237918046687e13077f163c84108fae7a56ad...\n",
+      "  p (premier) = 0xd1cf871863581558c632a52e37882b359fd1a2...\n",
+      "  g (generateur) = 0xc948beeaf6cd1702bb02f74a7f2cdb10229fef...\n",
       "  x (secret) = NON REVELE\n",
-      "  h = g^x mod p = 0x91fbf84cfd0cb84a0469bc35ddc0f60af4948f...\n",
+      "  h = g^x mod p = 0x8cab6ba5b82fa67d8d18ae08d9c60bb83ec4e0...\n",
       "Verification: g^x mod p == h : True\n",
       "PROTOCOLE ZKP DU LOGARITHME DISCRET (INTERACTIF)\n",
       "============================================================\n",
@@ -439,10 +439,10 @@
    "id": "dlog-cheat-transition",
    "metadata": {
     "papermill": {
-     "duration": 0.003769,
-     "end_time": "2026-05-31T23:30:21.094598+00:00",
+     "duration": 0.00656,
+     "end_time": "2026-06-01T17:01:28.274311",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.090829+00:00",
+     "start_time": "2026-06-01T17:01:28.267751",
      "status": "completed"
     },
     "tags": []
@@ -461,16 +461,16 @@
    "id": "dlog-cheat",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:21.101513Z",
-     "iopub.status.busy": "2026-05-31T23:30:21.101331Z",
-     "iopub.status.idle": "2026-05-31T23:30:21.429650Z",
-     "shell.execute_reply": "2026-05-31T23:30:21.428781Z"
+     "iopub.execute_input": "2026-06-01T17:01:28.293363Z",
+     "iopub.status.busy": "2026-06-01T17:01:28.291978Z",
+     "iopub.status.idle": "2026-06-01T17:01:28.596329Z",
+     "shell.execute_reply": "2026-06-01T17:01:28.595743Z"
     },
     "papermill": {
-     "duration": 0.332768,
-     "end_time": "2026-05-31T23:30:21.430330+00:00",
+     "duration": 0.31548,
+     "end_time": "2026-06-01T17:01:28.597975",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.097562+00:00",
+     "start_time": "2026-06-01T17:01:28.282495",
      "status": "completed"
     },
     "tags": []
@@ -532,10 +532,10 @@
    "id": "dlog-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003412,
-     "end_time": "2026-05-31T23:30:21.437623+00:00",
+     "duration": 0.007474,
+     "end_time": "2026-06-01T17:01:28.613200",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.434211+00:00",
+     "start_time": "2026-06-01T17:01:28.605726",
      "status": "completed"
     },
     "tags": []
@@ -560,10 +560,10 @@
    "id": "schnorr-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003361,
-     "end_time": "2026-05-31T23:30:21.444881+00:00",
+     "duration": 0.007027,
+     "end_time": "2026-06-01T17:01:28.626515",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.441520+00:00",
+     "start_time": "2026-06-01T17:01:28.619488",
      "status": "completed"
     },
     "tags": []
@@ -602,16 +602,16 @@
    "id": "schnorr-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:21.452809Z",
-     "iopub.status.busy": "2026-05-31T23:30:21.452563Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.030479Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.029384Z"
+     "iopub.execute_input": "2026-06-01T17:01:28.641240Z",
+     "iopub.status.busy": "2026-06-01T17:01:28.640636Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.298538Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.297899Z"
     },
     "papermill": {
-     "duration": 0.583053,
-     "end_time": "2026-05-31T23:30:22.031259+00:00",
+     "duration": 0.672168,
+     "end_time": "2026-06-01T17:01:29.304515",
      "exception": false,
-     "start_time": "2026-05-31T23:30:21.448206+00:00",
+     "start_time": "2026-06-01T17:01:28.632347",
      "status": "completed"
     },
     "tags": []
@@ -623,7 +623,7 @@
      "text": [
       "PROTOCOLE DE SCHNORR\n",
       "============================================================\n",
-      "Parametres : p=372973496737829918499063278235... (129 bits)\n",
+      "Parametres : p=463924072502582625690353613972... (129 bits)\n",
       "Cle publique y = g^x mod p\n",
       "\n"
      ]
@@ -722,10 +722,10 @@
    "id": "schnorr-usage-transition",
    "metadata": {
     "papermill": {
-     "duration": 0.003289,
-     "end_time": "2026-05-31T23:30:22.038341+00:00",
+     "duration": 0.011909,
+     "end_time": "2026-06-01T17:01:29.334792",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.035052+00:00",
+     "start_time": "2026-06-01T17:01:29.322883",
      "status": "completed"
     },
     "tags": []
@@ -744,16 +744,16 @@
    "id": "schnorr-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.045385Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.045218Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.051231Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.050733Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.366283Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.365268Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.380846Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.379309Z"
     },
     "papermill": {
-     "duration": 0.010177,
-     "end_time": "2026-05-31T23:30:22.051801+00:00",
+     "duration": 0.03572,
+     "end_time": "2026-06-01T17:01:29.383672",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.041624+00:00",
+     "start_time": "2026-06-01T17:01:29.347952",
      "status": "completed"
     },
     "tags": []
@@ -768,18 +768,18 @@
       "\n",
       "--- Version INTERACTIVE ---\n",
       "  Etape 1 (Prouveur -> Verificateur) : envoyer R\n",
-      "    R = g^r = 556331722503606946810429386173...\n",
+      "    R = g^r = 172570347468577105098146335477...\n",
       "  Etape 2 (Verificateur -> Prouveur) : envoyer c\n",
-      "    c = 464672552008515806336580268098...\n",
+      "    c = 146663872365602404411964563061...\n",
       "  Etape 3 (Prouveur -> Verificateur) : envoyer s\n",
-      "    s = r + c*x mod q = 672056519083496568510839395970...\n",
+      "    s = r + c*x mod q = 262085755160385812269953206628...\n",
       "  Verification : g^s == R*y^c ? OUI\n",
       "  -> Necessite 3 messages (2 allers-retours)\n",
       "\n",
       "--- Version NON-INTERACTIVE (Fiat-Shamir) ---\n",
       "  Preuve (R, s) calculee localement\n",
-      "    R = 123889777092833945866133324383...\n",
-      "    s = 988019786657763818748251895743...\n",
+      "    R = 445205625915499780316991679466...\n",
+      "    s = 746174820779108029434834621766...\n",
       "    c = SHA256(g || y || R || message) (calcule automatiquement)\n",
       "  Verification : VALIDE\n",
       "  -> Un seul message, pas besoin d'interaction !\n",
@@ -842,10 +842,10 @@
    "id": "8994087a",
    "metadata": {
     "papermill": {
-     "duration": 0.003107,
-     "end_time": "2026-05-31T23:30:22.058092+00:00",
+     "duration": 0.015601,
+     "end_time": "2026-06-01T17:01:29.412354",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.054985+00:00",
+     "start_time": "2026-06-01T17:01:29.396753",
      "status": "completed"
     },
     "tags": []
@@ -871,10 +871,10 @@
    "id": "schnorr-sig-transition",
    "metadata": {
     "papermill": {
-     "duration": 0.00324,
-     "end_time": "2026-05-31T23:30:22.064670+00:00",
+     "duration": 0.010815,
+     "end_time": "2026-06-01T17:01:29.433303",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.061430+00:00",
+     "start_time": "2026-06-01T17:01:29.422488",
      "status": "completed"
     },
     "tags": []
@@ -893,16 +893,16 @@
    "id": "schnorr-signature",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.072771Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.072455Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.077937Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.077266Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.461231Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.457704Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.479747Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.476919Z"
     },
     "papermill": {
-     "duration": 0.010291,
-     "end_time": "2026-05-31T23:30:22.078495+00:00",
+     "duration": 0.038245,
+     "end_time": "2026-06-01T17:01:29.482288",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.068204+00:00",
+     "start_time": "2026-06-01T17:01:29.444043",
      "status": "completed"
     },
     "tags": []
@@ -921,15 +921,15 @@
       "\n",
       "Signatures de Schnorr sur differents messages :\n",
       "  Message  : Transferer 10 ETH a 0xBob\n",
-      "  Sig (R)  : 158982359975231097146814263535...\n",
+      "  Sig (R)  : 330974516306173802175039034887...\n",
       "  Valide   : True\n",
       "\n",
       "  Message  : Approuver le contrat 0xDefi\n",
-      "  Sig (R)  : 273337702379576568407142605220...\n",
+      "  Sig (R)  : 358177777836332147147925813014...\n",
       "  Valide   : True\n",
       "\n",
       "  Message  : Voter OUI pour la proposition 42\n",
-      "  Sig (R)  : 236983287613472594924218644871...\n",
+      "  Sig (R)  : 103215387335229987608122433366...\n",
       "  Valide   : True\n",
       "\n",
       "Points cles :\n",
@@ -978,10 +978,10 @@
    "id": "schnorr-interpretation",
    "metadata": {
     "papermill": {
-     "duration": 0.003137,
-     "end_time": "2026-05-31T23:30:22.084849+00:00",
+     "duration": 0.021887,
+     "end_time": "2026-06-01T17:01:29.512612",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.081712+00:00",
+     "start_time": "2026-06-01T17:01:29.490725",
      "status": "completed"
     },
     "tags": []
@@ -1008,10 +1008,10 @@
    "id": "sigma-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003304,
-     "end_time": "2026-05-31T23:30:22.091729+00:00",
+     "duration": 0.014574,
+     "end_time": "2026-06-01T17:01:29.550201",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.088425+00:00",
+     "start_time": "2026-06-01T17:01:29.535627",
      "status": "completed"
     },
     "tags": []
@@ -1061,16 +1061,16 @@
    "id": "chaum-pedersen-impl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.100928Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.100589Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.108412Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.107575Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.586017Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.584960Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.605857Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.604742Z"
     },
     "papermill": {
-     "duration": 0.013768,
-     "end_time": "2026-05-31T23:30:22.109088+00:00",
+     "duration": 0.048698,
+     "end_time": "2026-06-01T17:01:29.609094",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.095320+00:00",
+     "start_time": "2026-06-01T17:01:29.560396",
      "status": "completed"
     },
     "tags": []
@@ -1082,9 +1082,9 @@
      "text": [
       "PROTOCOLE DE CHAUM-PEDERSEN\n",
       "============================================================\n",
-      "Secret x : 184953976021735358012809517999... (cache)\n",
-      "y1 = g^x : 144099519228675227780961911467...\n",
-      "y2 = h^x : 179928078688971693015473056840...\n",
+      "Secret x : 905155080749554090843898193595... (cache)\n",
+      "y1 = g^x : 324150878504193832254688749863...\n",
+      "y2 = h^x : 307910321336771043016247475246...\n",
       "\n",
       "Objectif : prouver que log_g(y1) == log_h(y2) sans reveler x\n",
       "\n"
@@ -1171,10 +1171,10 @@
    "id": "chaum-pedersen-transition",
    "metadata": {
     "papermill": {
-     "duration": 0.003658,
-     "end_time": "2026-05-31T23:30:22.116728+00:00",
+     "duration": 0.010174,
+     "end_time": "2026-06-01T17:01:29.642258",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.113070+00:00",
+     "start_time": "2026-06-01T17:01:29.632084",
      "status": "completed"
     },
     "tags": []
@@ -1193,16 +1193,16 @@
    "id": "chaum-pedersen-verify",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.124886Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.124675Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.130435Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.129715Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.658771Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.658188Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.669107Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.667973Z"
     },
     "papermill": {
-     "duration": 0.010671,
-     "end_time": "2026-05-31T23:30:22.130997+00:00",
+     "duration": 0.020114,
+     "end_time": "2026-06-01T17:01:29.670186",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.120326+00:00",
+     "start_time": "2026-06-01T17:01:29.650072",
      "status": "completed"
     },
     "tags": []
@@ -1215,9 +1215,9 @@
       "VERIFICATION CHAUM-PEDERSEN\n",
       "============================================================\n",
       "Preuve (R1, R2, s) :\n",
-      "  R1 = 207413621502709751242910820459...\n",
-      "  R2 = 294082426057486250619240118364...\n",
-      "  s  = 870547487432934411357072023625...\n",
+      "  R1 = 108902582381154629980768192075...\n",
+      "  R2 = 112877326286843882856039395926...\n",
+      "  s  = 731434607641613731878841722620...\n",
       "\n",
       "Verification : g^s == R1*y1^c  ET  h^s == R2*y2^c\n",
       "Resultat : VALIDE\n",
@@ -1276,10 +1276,10 @@
    "id": "748cebfe",
    "metadata": {
     "papermill": {
-     "duration": 0.003728,
-     "end_time": "2026-05-31T23:30:22.138280+00:00",
+     "duration": 0.008853,
+     "end_time": "2026-06-01T17:01:29.685641",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.134552+00:00",
+     "start_time": "2026-06-01T17:01:29.676788",
      "status": "completed"
     },
     "tags": []
@@ -1304,10 +1304,10 @@
    "id": "or-proof-concept",
    "metadata": {
     "papermill": {
-     "duration": 0.004051,
-     "end_time": "2026-05-31T23:30:22.146129+00:00",
+     "duration": 0.00796,
+     "end_time": "2026-06-01T17:01:29.706886",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.142078+00:00",
+     "start_time": "2026-06-01T17:01:29.698926",
      "status": "completed"
     },
     "tags": []
@@ -1342,10 +1342,10 @@
    "id": "zk-snarks-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.004283,
-     "end_time": "2026-05-31T23:30:22.154523+00:00",
+     "duration": 0.006908,
+     "end_time": "2026-06-01T17:01:29.723149",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.150240+00:00",
+     "start_time": "2026-06-01T17:01:29.716241",
      "status": "completed"
     },
     "tags": []
@@ -1402,16 +1402,16 @@
    "id": "r1cs-demo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.164885Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.164500Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.173905Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.172897Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.742968Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.742105Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.761014Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.759277Z"
     },
     "papermill": {
-     "duration": 0.015581,
-     "end_time": "2026-05-31T23:30:22.174627+00:00",
+     "duration": 0.032942,
+     "end_time": "2026-06-01T17:01:29.762526",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.159046+00:00",
+     "start_time": "2026-06-01T17:01:29.729584",
      "status": "completed"
     },
     "tags": []
@@ -1543,10 +1543,10 @@
    "id": "0ccc4367",
    "metadata": {
     "papermill": {
-     "duration": 0.003715,
-     "end_time": "2026-05-31T23:30:22.182405+00:00",
+     "duration": 0.009302,
+     "end_time": "2026-06-01T17:01:29.779452",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.178690+00:00",
+     "start_time": "2026-06-01T17:01:29.770150",
      "status": "completed"
     },
     "tags": []
@@ -1574,10 +1574,10 @@
    "id": "snarks-comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.003466,
-     "end_time": "2026-05-31T23:30:22.190400+00:00",
+     "duration": 0.006618,
+     "end_time": "2026-06-01T17:01:29.794398",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.186934+00:00",
+     "start_time": "2026-06-01T17:01:29.787780",
      "status": "completed"
     },
     "tags": []
@@ -1607,10 +1607,10 @@
    "id": "exercise-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00347,
-     "end_time": "2026-05-31T23:30:22.197342+00:00",
+     "duration": 0.007618,
+     "end_time": "2026-06-01T17:01:29.808704",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.193872+00:00",
+     "start_time": "2026-06-01T17:01:29.801086",
      "status": "completed"
     },
     "tags": []
@@ -1618,7 +1618,9 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Exercice : ZKP de preimage de hash\n",
+    "## 6. Exemple guide : ZKP de preimage de hash\n",
+    "\n",
+    "*Solution proposee par Clovis Lefebvre, Evariste Balvay.*\n",
     "\n",
     "### Objectif\n",
     "\n",
@@ -1630,26 +1632,13 @@
     "\n",
     "### Approche\n",
     "\n",
-    "On utilise un schema de **commit-and-reveal** avec defi aleatoire :\n",
-    "\n",
-    "1. Le prouveur genere un nonce `r` aleatoire\n",
-    "2. Il calcule `commitment = SHA256(secret || r)`\n",
-    "3. Le verificateur envoie un challenge `c` (0 ou 1)\n",
-    "4. Si c=0 : le prouveur revele `r` et le verificateur verifie que\n",
-    "   `SHA256(secret || r)` correspond au commitment (sans apprendre secret)\n",
-    "   -- en fait le verificateur ne peut pas verifier sans secret !\n",
-    "\n",
-    "**Approche corrigee** (schema de Guillou-Quisquater simplifie) :\n",
-    "\n",
-    "On utilise plutot une approche basee sur le logarithme discret.\n",
+    "On utilise une approche basee sur le logarithme discret.\n",
     "Le prouveur encode son secret comme exposant et utilise le protocole de Schnorr.\n",
     "\n",
-    "### A implementer\n",
-    "\n",
-    "Completez la classe `HashPreimageZKP` ci-dessous.\n",
-    "\n",
-    "**Indice** : convertissez le hash de la preimage en un element du groupe\n",
-    "et utilisez le protocole de Schnorr pour prouver la connaissance de cet element."
+    "La classe `HashPreimageZKP` ci-dessous implemente les trois etapes :\n",
+    "1. **`register`** : calcule le hash public et derive la cle publique via exponentiation modulaire\n",
+    "2. **`prove`** : protocole de Schnorr non-interactif (Fiat-Shamir) pour generer une preuve\n",
+    "3. **`verify`** : verification de la preuve en recalculant le challenge"
    ]
   },
   {
@@ -1658,25 +1647,33 @@
    "id": "exercise-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-31T23:30:22.205953Z",
-     "iopub.status.busy": "2026-05-31T23:30:22.205658Z",
-     "iopub.status.idle": "2026-05-31T23:30:22.209915Z",
-     "shell.execute_reply": "2026-05-31T23:30:22.209084Z"
+     "iopub.execute_input": "2026-06-01T17:01:29.835466Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.835115Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.922202Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.921113Z"
     },
     "papermill": {
-     "duration": 0.009817,
-     "end_time": "2026-05-31T23:30:22.210588+00:00",
+     "duration": 0.098676,
+     "end_time": "2026-06-01T17:01:29.923507",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.200771+00:00",
+     "start_time": "2026-06-01T17:01:29.824831",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preuve valide pour secret correct : True\n",
+      "Preuve valide pour preuve forgee  : False\n"
+     ]
+    }
+   ],
    "source": [
     "import hashlib\n",
     "from Crypto.Util.number import getRandomRange\n",
-    "from Crypto.Hash import SHA256\n",
     "\n",
     "\n",
     "class HashPreimageZKP:\n",
@@ -1701,16 +1698,85 @@
     "        self.g = g\n",
     "\n",
     "    def register(self, secret: bytes):\n",
-    "        \"\"\"Enregistrer un secret et publier (h_pub, y).\n",
+    "        \"\"\"Enregistrer un secret et publier (h_pub, y, x_derived).\n",
     "\n",
-    "        TODO:\n",
     "        1. Calculer h_pub = SHA256(secret).hexdigest()\n",
     "        2. Convertir h_pub en entier x_derived = int(h_pub, 16) % self.q\n",
     "        3. Calculer y = pow(self.g, x_derived, self.p)\n",
     "        4. Retourner (h_pub, y, x_derived)\n",
-    "           h_pub et y sont publics, x_derived est le secret du prouveur\n",
     "        \"\"\"\n",
-    "        pass  # TODO: Implementez register()\n"
+    "        h_pub = hashlib.sha256(secret).hexdigest()\n",
+    "        x_derived = int(h_pub, 16) % self.q\n",
+    "        y = pow(self.g, x_derived, self.p)\n",
+    "        return h_pub, y, x_derived\n",
+    "\n",
+    "    def prove(self, x_derived: int, y: int, h_pub: str) -> tuple:\n",
+    "        \"\"\"Protocole de Schnorr non-interactif (Fiat-Shamir).\n",
+    "\n",
+    "        1. Generer un nonce aleatoire r\n",
+    "        2. Calculer l'engagement R = g^r mod p\n",
+    "        3. Calculer le defi via Fiat-Shamir :\n",
+    "             c = H(g || y || R || h_pub) mod q\n",
+    "        4. Calculer la reponse s = (r - c * x_derived) mod q\n",
+    "\n",
+    "        Retourne le tuple de preuve (R, s, c).\n",
+    "        \"\"\"\n",
+    "        r = getRandomRange(1, self.q)\n",
+    "        R = pow(self.g, r, self.p)\n",
+    "\n",
+    "        c_input = f\"{self.g}|{y}|{R}|{h_pub}\".encode()\n",
+    "        c = int(hashlib.sha256(c_input).hexdigest(), 16) % self.q\n",
+    "\n",
+    "        s = (r - c * x_derived) % self.q\n",
+    "\n",
+    "        return R, s, c\n",
+    "\n",
+    "    def verify(self, proof: tuple, y: int, h_pub: str) -> bool:\n",
+    "        \"\"\"Verifier une preuve de Schnorr.\n",
+    "\n",
+    "        1. Reconstruire R' = g^s * y^c mod p\n",
+    "        2. Recalculer le defi c' = H(g || y || R' || h_pub) mod q\n",
+    "        3. Accepter si et seulement si c' == c\n",
+    "        \"\"\"\n",
+    "        R, s, c = proof\n",
+    "        R_prime = (pow(self.g, s, self.p) * pow(y, c, self.p)) % self.p\n",
+    "\n",
+    "        challenge_input = f\"{self.g}|{y}|{R_prime}|{h_pub}\".encode()\n",
+    "        c_prime = int(hashlib.sha256(challenge_input).hexdigest(), 16) % self.q\n",
+    "\n",
+    "        return c_prime == c\n",
+    "\n",
+    "\n",
+    "# --- Validation ---\n",
+    "# Parametres RFC 3526 MODP Group 14 (2048 bits, pedagogique simplifie)\n",
+    "p = int(\n",
+    "    \"FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1\"\n",
+    "    \"29024E088A67CC74020BBEA63B139B22514A08798E3404DD\"\n",
+    "    \"EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245\"\n",
+    "    \"E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED\"\n",
+    "    \"EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D\"\n",
+    "    \"C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F\"\n",
+    "    \"83655D23DCA3AD961C62F356208552BB9ED529077096966D\"\n",
+    "    \"670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B\"\n",
+    "    \"E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9\"\n",
+    "    \"DE2BCBF6955817183995497CEA956AE515D2261898FA0510\"\n",
+    "    \"15728E5A8AACAA68FFFFFFFFFFFFFFFF\", 16\n",
+    ")\n",
+    "q = (p - 1) // 2\n",
+    "g = 2\n",
+    "\n",
+    "zkp = HashPreimageZKP(p, q, g)\n",
+    "\n",
+    "secret = b\"mon_secret_super_prive\"\n",
+    "h_pub, y, x_derived = zkp.register(secret)\n",
+    "\n",
+    "proof = zkp.prove(x_derived, y, h_pub)\n",
+    "valid = zkp.verify(proof, y, h_pub)\n",
+    "print(f\"Preuve valide pour secret correct : {valid}\")\n",
+    "\n",
+    "# Preuve forgee : doit echouer\n",
+    "fake_proof = (proof[0], proof[1] + 1, proof[2])\n",
+    "print(f\"Preuve valide pour preuve forgee  : {zkp.verify(fake_proof, y, h_pub)}\")"
    ]
   },
   {
@@ -1718,35 +1784,38 @@
    "id": "exercise-hints",
    "metadata": {
     "papermill": {
-     "duration": 0.00382,
-     "end_time": "2026-05-31T23:30:22.218090+00:00",
+     "duration": 0.007301,
+     "end_time": "2026-06-01T17:01:29.939262",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.214270+00:00",
+     "start_time": "2026-06-01T17:01:29.931961",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Indices\n",
+    "### Interpretation de l'exemple guide\n",
     "\n",
-    "Si vous etes bloque :\n",
+    "| Test | Resultat attendu | Explication |\n",
+    "|------|-----------------|-------------|\n",
+    "| Secret correct | `True` | Le prouveur honnete : `R' = g^s * y^c = g^(r-cx) * g^(cx) = g^r = R` |\n",
+    "| Preuve forgee | `False` | Modifier `s` casse l'equation : `g^(s+1) != R * y^c` |\n",
     "\n",
-    "1. Pour `register` : utilisez `hashlib.sha256(secret).hexdigest()` puis `int(..., 16) % self.q`\n",
-    "2. Pour `prove` : c'est exactement le protocole de Schnorr non-interactif avec x_derived comme secret\n",
-    "3. Pour `verify` : recalculez le challenge de la meme maniere et verifiez l'equation\n",
-    "4. Pour le hash dans `prove`/`verify`, concatenez les representations en bytes des grands entiers :\n",
-    "   `SHA256.new(g.to_bytes(256, 'big') + y.to_bytes(256, 'big') + R.to_bytes(256, 'big'))`"
+    "**Points cles de l'implementation** :\n",
+    "- `register` derive un expose secret `x_derived` a partir du hash SHA-256 du secret, puis calcule la cle publique `y = g^x_derived mod p`\n",
+    "- `prove` utilise le protocole de Schnorr avec la variante `s = (r - c*x) mod q` et un challenge Fiat-Shamir `H(g|y|R|h_pub)`\n",
+    "- `verify` reconstruit `R' = g^s * y^c` et verifie que le challenge recalcule correspond au challenge original : si `c' == c`, la preuve est valide\n",
+    "- L'utilisation de parametres RFC 3526 (2048 bits) assure une securite production-grade pour le groupe multiplicatif"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "summary",
+   "id": "d550dacb",
    "metadata": {
     "papermill": {
-     "duration": 0.003684,
-     "end_time": "2026-05-31T23:30:22.225235+00:00",
+     "duration": 0.00715,
+     "end_time": "2026-06-01T17:01:29.953381",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.221551+00:00",
+     "start_time": "2026-06-01T17:01:29.946231",
      "status": "completed"
     },
     "tags": []
@@ -1754,7 +1823,94 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Resume\n",
+    "## 7. Exercice : ZKP de double preimage de hash\n",
+    "\n",
+    "### Objectif\n",
+    "\n",
+    "Etendre la classe `HashPreimageZKP` pour prouver la connaissance de **deux secrets**\n",
+    "dont les hashes sont connus publiquement, sans reveler aucun des deux secrets.\n",
+    "\n",
+    "### Contexte\n",
+    "\n",
+    "Dans un systeme de vote electronique, un electeur doit prouver qu'il connait\n",
+    "les preimages de deux hashes `h1 = SHA256(secret1)` et `h2 = SHA256(secret2)`\n",
+    "(pour un vote a deux tours, par exemple) sans reveler ses secrets.\n",
+    "\n",
+    "### A implementer\n",
+    "\n",
+    "Completez la methode `prove_double` de la classe `DoubleHashZKP` ci-dessous.\n",
+    "\n",
+    "**Indice** : utilisez deux preuves de Schnorr independantes, une pour chaque secret,\n",
+    "et combinez-les en un seul tuple de preuve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9a7accb4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T17:01:29.969811Z",
+     "iopub.status.busy": "2026-06-01T17:01:29.969496Z",
+     "iopub.status.idle": "2026-06-01T17:01:29.977392Z",
+     "shell.execute_reply": "2026-06-01T17:01:29.974734Z"
+    },
+    "papermill": {
+     "duration": 0.018181,
+     "end_time": "2026-06-01T17:01:29.978698",
+     "exception": false,
+     "start_time": "2026-06-01T17:01:29.960517",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : implementez prove_double dans DoubleHashZKP\n"
+     ]
+    }
+   ],
+   "source": [
+    "class DoubleHashZKP(HashPreimageZKP):\n",
+    "    \"\"\"ZKP prouvant la connaissance de deux preimages de hash.\"\"\"\n",
+    "\n",
+    "    def prove_double(self, x1_derived: int, y1: int, h1_pub: str,\n",
+    "                     x2_derived: int, y2: int, h2_pub: str) -> tuple:\n",
+    "        \"\"\"Prouver la connaissance de deux secrets en une seule operation.\n",
+    "\n",
+    "        TODO etudiant : generer deux preuves de Schnorr independantes\n",
+    "        (une pour chaque secret) et les retourner combinees.\n",
+    "\n",
+    "        Retourne un tuple ((R1, s1, c1), (R2, s2, c2)).\n",
+    "        \"\"\"\n",
+    "        # TODO etudiant : implementez prove_double\n",
+    "        return (None, None, None), (None, None, None)\n",
+    "\n",
+    "\n",
+    "# Validation\n",
+    "print(\"Exercice a completer : implementez prove_double dans DoubleHashZKP\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "summary",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006896,
+     "end_time": "2026-06-01T17:01:29.993073",
+     "exception": false,
+     "start_time": "2026-06-01T17:01:29.986177",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Resume\n",
     "\n",
     "### Recapitulatif des protocoles\n",
     "\n",
@@ -1765,6 +1921,7 @@
     "| **Chaum-Pedersen** | \"log_g(y1) = log_h(y2)\" | Les deux | O(1) |\n",
     "| **OR-proof** | \"Je connais x1 ou x2\" | Les deux | O(1) |\n",
     "| **zk-SNARK** | \"Je connais un temoin w pour C(w)=1\" | Non | O(1) verification |\n",
+    "| **HashPreimageZKP** | \"Je connait la preimage de h\" | Non (Fiat-Shamir) | O(1) |\n",
     "\n",
     "### Concepts cles\n",
     "\n",
@@ -1795,10 +1952,10 @@
    "id": "cbeb8e83",
    "metadata": {
     "papermill": {
-     "duration": 0.003402,
-     "end_time": "2026-05-31T23:30:22.232042+00:00",
+     "duration": 0.006647,
+     "end_time": "2026-06-01T17:01:30.006636",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.228640+00:00",
+     "start_time": "2026-06-01T17:01:29.999989",
      "status": "completed"
     },
     "tags": []
@@ -1818,10 +1975,10 @@
    "id": "bbe60389",
    "metadata": {
     "papermill": {
-     "duration": 0.003436,
-     "end_time": "2026-05-31T23:30:22.238946+00:00",
+     "duration": 0.007543,
+     "end_time": "2026-06-01T17:01:30.020698",
      "exception": false,
-     "start_time": "2026-05-31T23:30:22.235510+00:00",
+     "start_time": "2026-06-01T17:01:30.013155",
      "status": "completed"
     },
     "tags": []
@@ -1849,18 +2006,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.58504,
-   "end_time": "2026-05-31T23:30:22.705128+00:00",
+   "duration": 5.05641,
+   "end_time": "2026-06-01T17:01:30.270103",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb",
-   "output_path": "/tmp/sc15_executed.ipynb",
+   "input_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-15-Zero-Knowledge-Proofs.ipynb",
+   "output_path": "d:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SmartContracts\\04-Privacy-Cryptography\\SC-15-Zero-Knowledge-Proofs.ipynb",
    "parameters": {},
-   "start_time": "2026-05-31T23:30:19.120088+00:00",
+   "start_time": "2026-06-01T17:01:25.213693",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Consolidation of student PR #2042 (Clovis Lefebvre, Evariste Balvay) for SC-15-Zero-Knowledge-Proofs.

## Changes

- **Section 6 relabeled** as 'Exemple guide : ZKP de preimage de hash' with student attribution
- **Exercise stub replaced** with complete student solution: HashPreimageZKP class implementing register/prove/verify methods using Schnorr protocol with Fiat-Shamir transformation
- **Hints cell converted** to interpretation of the exemple guide output
- **New section 7 exercise** added: 'ZKP de double preimage de hash' with DoubleHashZKP stub class
- **Summary renumbered** from section 7 to section 8, with HashPreimageZKP added to protocol table

## Preuve execution

Papermill SUCCESS: 37/37 cells, 0 errors, 11 code cells all executed.
- exercise-code output: True (valid proof) / False (forged proof)
- 0 NotImplementedError cells, 0 cells with null execution_count

## Scope

Single notebook: SC-15-Zero-Knowledge-Proofs.ipynb. No other files modified.
Student PR #2042 content sections (OR-proofs, zk-SNARKs) NOT affected - only exercise section integrated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>