### PR TITLE
SC1 Nabil Chartouni Lucas Majerczyk Wilfrid Wangon Zekou

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
@@ -1,0 +1,66 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Usage
+
+### Build
+
+```shell
+$ forge build
+```
+
+### Test
+
+```shell
+$ forge test
+```
+
+### Format
+
+```shell
+$ forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+$ forge snapshot
+```
+
+### Anvil
+
+```shell
+$ anvil
+```
+
+### Deploy
+
+```shell
+$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+$ cast <subcommand>
+```
+
+### Help
+
+```shell
+$ forge --help
+$ anvil --help
+$ cast --help
+```

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/foundry.toml
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/script/Counter.s.sol
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/script/Counter.s.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {Counter} from "../src/Counter.sol";
+
+contract CounterScript is Script {
+    Counter public counter;
+
+    function setUp() public {}
+
+    function run() public {
+        vm.startBroadcast();
+
+        counter = new Counter();
+
+        vm.stopBroadcast();
+    }
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/src/Counter.sol
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/src/Counter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+contract Counter {
+    // Une variable count (uint256)
+    uint256 private count;
+
+    // Une fonction increment() qui augmente count
+    function increment() public {
+        count += 1;
+    }
+
+    // Une fonction decrement() qui diminue count (si > 0)
+    function decrement() public {
+        require(count > 0, "Counter: count is already zero");
+        count -= 1;
+    }
+
+    // Une fonction getCount() qui retourne count
+    function getCount() public view returns (uint256) {
+        return count;
+    }
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/src/Counter.sol
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/src/Counter.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.28;
 
 contract Counter {
-    // Une variable count (uint256)
-    uint256 private count;
+    // Une variable count (uint256), publique : genere un getter automatique count()
+    uint256 public count;
 
     // Une fonction increment() qui augmente count
     function increment() public {
@@ -12,7 +12,7 @@ contract Counter {
 
     // Une fonction decrement() qui diminue count (si > 0)
     function decrement() public {
-        require(count > 0, "Counter: count is already zero");
+        require(count > 0, "Cannot decrement below zero");
         count -= 1;
     }
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/test/Counter.t.sol
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/test/Counter.t.sol
@@ -32,7 +32,14 @@ contract CounterTest is Test {
     // Verifie qu'on ne peut pas decrementer sous zero
     function testDecrementZero() public {
         assertEq(counter.getCount(), 0);
-        vm.expectRevert(bytes("Counter: count is already zero"));
+        vm.expectRevert(bytes("Cannot decrement below zero"));
         counter.decrement();
+    }
+
+    // Verifie que le getter automatique public count() et getCount() sont coherents
+    function testPublicGetter() public {
+        counter.increment();
+        assertEq(counter.count(), 1);
+        assertEq(counter.count(), counter.getCount());
     }
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/test/Counter.t.sol
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/test/Counter.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "../src/Counter.sol";
+
+contract CounterTest is Test {
+    Counter counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    // Verifie que increment() fonctionne
+    function testIncrement() public {
+        assertEq(counter.getCount(), 0);
+        counter.increment();
+        assertEq(counter.getCount(), 1);
+        counter.increment();
+        assertEq(counter.getCount(), 2);
+    }
+
+    // Verifie que decrement() fonctionne
+    function testDecrement() public {
+        counter.increment();
+        counter.increment();
+        assertEq(counter.getCount(), 2);
+        counter.decrement();
+        assertEq(counter.getCount(), 1);
+    }
+
+    // Verifie qu'on ne peut pas decrementer sous zero
+    function testDecrementZero() public {
+        assertEq(counter.getCount(), 0);
+        vm.expectRevert(bytes("Counter: count is already zero"));
+        counter.decrement();
+    }
+}


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

-

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [x] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
