### PR TITLE
enrich(Sudoku-10): insert markdown transition between pip install and imports

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "2455ea10",
    "metadata": {
     "papermill": {
-     "duration": 0.00269,
-     "end_time": "2026-05-13T08:02:06.105293",
+     "duration": 0.003497,
+     "end_time": "2026-06-01T20:56:54.476215+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.102603",
+     "start_time": "2026-06-01T20:56:54.472718+00:00",
      "status": "completed"
     },
     "tags": []
@@ -65,16 +65,16 @@
    "id": "31f3025f-f1c7-4b39-bbcc-fe29c9da0ea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:06.110790Z",
-     "iopub.status.busy": "2026-05-13T08:02:06.110790Z",
-     "iopub.status.idle": "2026-05-13T08:02:09.263112Z",
-     "shell.execute_reply": "2026-05-13T08:02:09.263112Z"
+     "iopub.execute_input": "2026-06-01T20:56:54.484446Z",
+     "iopub.status.busy": "2026-06-01T20:56:54.484206Z",
+     "iopub.status.idle": "2026-06-01T20:57:06.576278Z",
+     "shell.execute_reply": "2026-06-01T20:57:06.574926Z"
     },
     "papermill": {
-     "duration": 3.15582,
-     "end_time": "2026-05-13T08:02:09.263112",
+     "duration": 12.097269,
+     "end_time": "2026-06-01T20:57:06.577378+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:06.107292",
+     "start_time": "2026-06-01T20:56:54.480109+00:00",
      "status": "completed"
     },
     "tags": []
@@ -84,16 +84,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: ortools in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (9.15.6755)\n",
-      "Requirement already satisfied: absl-py>=2.0.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (2.4.0)\n",
-      "Requirement already satisfied: numpy>=2.0.2 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (2.3.4)\n",
-      "Requirement already satisfied: pandas>=2.0.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (3.0.2)\n",
-      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (6.33.6)\n",
-      "Requirement already satisfied: typing-extensions>=4.12 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (4.15.0)\n",
-      "Requirement already satisfied: immutabledict>=3.0.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from ortools) (4.3.1)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from pandas>=2.0.0->ortools) (2.9.0.post0)\n",
-      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from pandas>=2.0.0->ortools) (2025.2)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python311\\lib\\site-packages (from python-dateutil>=2.8.2->pandas>=2.0.0->ortools) (1.17.0)\n"
+      "Requirement already satisfied: ortools in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (9.15.6755)\n",
+      "Requirement already satisfied: absl-py>=2.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.0)\n",
+      "Requirement already satisfied: numpy>=2.0.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (2.4.2)\n",
+      "Requirement already satisfied: pandas>=2.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (3.0.2)\n",
+      "Requirement already satisfied: protobuf<6.34,>=6.33.1 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (6.33.5)\n",
+      "Requirement already satisfied: typing-extensions>=4.12 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from ortools) (4.15.0)\n",
+      "Requirement already satisfied: immutabledict>=3.0.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from ortools) (4.3.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas>=2.0.0->ortools) (2.9.0.post0)\n",
+      "Requirement already satisfied: tzdata in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pandas>=2.0.0->ortools) (2026.1)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from python-dateutil>=2.8.2->pandas>=2.0.0->ortools) (1.17.0)\n"
      ]
     },
     {
@@ -101,7 +101,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "[notice] A new release of pip is available: 24.0 -> 26.1.1\n",
+      "[notice] A new release of pip is available: 25.2 -> 26.1.1\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     }
@@ -112,21 +112,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "76bf3efc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003679,
+     "end_time": "2026-06-01T20:57:06.585286+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T20:57:06.581607+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Importation et verification de la bibliotheque\n",
+    "\n",
+    "OR-Tools est maintenant installe. La cellule suivante importe le module `cp_model` depuis le package `ortools.sat.python` et verifie que l'installation est fonctionnelle. Le sous-module **SAT** (Boolean Satisfiability) fournit le solveur CP-SAT qui combine programmation par contraintes et techniques de resolution SAT."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "ce562fc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:09.269288Z",
-     "iopub.status.busy": "2026-05-13T08:02:09.268289Z",
-     "iopub.status.idle": "2026-05-13T08:02:09.565029Z",
-     "shell.execute_reply": "2026-05-13T08:02:09.565029Z"
+     "iopub.execute_input": "2026-06-01T20:57:06.595636Z",
+     "iopub.status.busy": "2026-06-01T20:57:06.595254Z",
+     "iopub.status.idle": "2026-06-01T20:57:10.697839Z",
+     "shell.execute_reply": "2026-06-01T20:57:10.696896Z"
     },
     "papermill": {
-     "duration": 0.299915,
-     "end_time": "2026-05-13T08:02:09.566204",
+     "duration": 4.109822,
+     "end_time": "2026-06-01T20:57:10.698913+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.266289",
+     "start_time": "2026-06-01T20:57:06.589091+00:00",
      "status": "completed"
     },
     "tags": []
@@ -158,10 +177,10 @@
    "id": "22c84ceb",
    "metadata": {
     "papermill": {
-     "duration": 0.001988,
-     "end_time": "2026-05-13T08:02:09.570222",
+     "duration": 0.00342,
+     "end_time": "2026-06-01T20:57:10.706026+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.568234",
+     "start_time": "2026-06-01T20:57:10.702606+00:00",
      "status": "completed"
     },
     "tags": []
@@ -177,10 +196,10 @@
    "id": "jbo187l6xm",
    "metadata": {
     "papermill": {
-     "duration": 0.001999,
-     "end_time": "2026-05-13T08:02:09.574319",
+     "duration": 0.003211,
+     "end_time": "2026-06-01T20:57:10.712666+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.572320",
+     "start_time": "2026-06-01T20:57:10.709455+00:00",
      "status": "completed"
     },
     "tags": []
@@ -195,16 +214,16 @@
    "id": "90syyx3imf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:09.579357Z",
-     "iopub.status.busy": "2026-05-13T08:02:09.579357Z",
-     "iopub.status.idle": "2026-05-13T08:02:09.583433Z",
-     "shell.execute_reply": "2026-05-13T08:02:09.583433Z"
+     "iopub.execute_input": "2026-06-01T20:57:10.721615Z",
+     "iopub.status.busy": "2026-06-01T20:57:10.721209Z",
+     "iopub.status.idle": "2026-06-01T20:57:10.728163Z",
+     "shell.execute_reply": "2026-06-01T20:57:10.726899Z"
     },
     "papermill": {
-     "duration": 0.008118,
-     "end_time": "2026-05-13T08:02:09.584437",
+     "duration": 0.012794,
+     "end_time": "2026-06-01T20:57:10.729036+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.576319",
+     "start_time": "2026-06-01T20:57:10.716242+00:00",
      "status": "completed"
     },
     "tags": []
@@ -214,7 +233,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: C:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
+      "Dossier Puzzles: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
       "Fichiers disponibles: ['Sudoku_Easy51.txt', 'Sudoku_hardest.txt', 'Sudoku_top95.txt']\n"
      ]
     }
@@ -243,10 +262,10 @@
    "id": "a7a4b062",
    "metadata": {
     "papermill": {
-     "duration": 0.002001,
-     "end_time": "2026-05-13T08:02:09.588438",
+     "duration": 0.003704,
+     "end_time": "2026-06-01T20:57:10.736560+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.586437",
+     "start_time": "2026-06-01T20:57:10.732856+00:00",
      "status": "completed"
     },
     "tags": []
@@ -261,16 +280,16 @@
    "id": "b26eb748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:09.593436Z",
-     "iopub.status.busy": "2026-05-13T08:02:09.593436Z",
-     "iopub.status.idle": "2026-05-13T08:02:09.599299Z",
-     "shell.execute_reply": "2026-05-13T08:02:09.599299Z"
+     "iopub.execute_input": "2026-06-01T20:57:10.745701Z",
+     "iopub.status.busy": "2026-06-01T20:57:10.745376Z",
+     "iopub.status.idle": "2026-06-01T20:57:10.758965Z",
+     "shell.execute_reply": "2026-06-01T20:57:10.757879Z"
     },
     "papermill": {
-     "duration": 0.009868,
-     "end_time": "2026-05-13T08:02:09.600304",
+     "duration": 0.019556,
+     "end_time": "2026-06-01T20:57:10.759816+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.590436",
+     "start_time": "2026-06-01T20:57:10.740260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +362,10 @@
    "id": "21797f07",
    "metadata": {
     "papermill": {
-     "duration": 0.002,
-     "end_time": "2026-05-13T08:02:09.649302",
+     "duration": 0.003677,
+     "end_time": "2026-06-01T20:57:10.767192+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.647302",
+     "start_time": "2026-06-01T20:57:10.763515+00:00",
      "status": "completed"
     },
     "tags": []
@@ -394,16 +413,16 @@
    "id": "d8a967af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:09.654303Z",
-     "iopub.status.busy": "2026-05-13T08:02:09.654303Z",
-     "iopub.status.idle": "2026-05-13T08:02:09.684317Z",
-     "shell.execute_reply": "2026-05-13T08:02:09.684317Z"
+     "iopub.execute_input": "2026-06-01T20:57:10.775816Z",
+     "iopub.status.busy": "2026-06-01T20:57:10.775533Z",
+     "iopub.status.idle": "2026-06-01T20:57:10.865793Z",
+     "shell.execute_reply": "2026-06-01T20:57:10.864804Z"
     },
     "papermill": {
-     "duration": 0.034099,
-     "end_time": "2026-05-13T08:02:09.685402",
+     "duration": 0.095869,
+     "end_time": "2026-06-01T20:57:10.866672+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.651303",
+     "start_time": "2026-06-01T20:57:10.770803+00:00",
      "status": "completed"
     },
     "tags": []
@@ -426,7 +445,7 @@
       ". 1 7 | . . . | . . . \n",
       ". . . | . 3 6 | . 4 . \n",
       "\n",
-      "Résolu: True en 23.99 ms\n",
+      "Résolu: True en 80.12 ms\n",
       "\n",
       "Solution:\n",
       "8 5 9 | 6 1 2 | 4 3 7 \n",
@@ -512,10 +531,10 @@
    "id": "5llfojb1uvw",
    "metadata": {
     "papermill": {
-     "duration": 0.00302,
-     "end_time": "2026-05-13T08:02:09.690422",
+     "duration": 0.003752,
+     "end_time": "2026-06-01T20:57:10.874200+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.687402",
+     "start_time": "2026-06-01T20:57:10.870448+00:00",
      "status": "completed"
     },
     "tags": []
@@ -544,10 +563,10 @@
    "id": "95rtxz9u43",
    "metadata": {
     "papermill": {
-     "duration": 0.002016,
-     "end_time": "2026-05-13T08:02:09.694445",
+     "duration": 0.004256,
+     "end_time": "2026-06-01T20:57:10.883049+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.692429",
+     "start_time": "2026-06-01T20:57:10.878793+00:00",
      "status": "completed"
     },
     "tags": []
@@ -581,16 +600,16 @@
    "id": "322xetmzp7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:09.699434Z",
-     "iopub.status.busy": "2026-05-13T08:02:09.699434Z",
-     "iopub.status.idle": "2026-05-13T08:02:10.045616Z",
-     "shell.execute_reply": "2026-05-13T08:02:10.045616Z"
+     "iopub.execute_input": "2026-06-01T20:57:10.891337Z",
+     "iopub.status.busy": "2026-06-01T20:57:10.890950Z",
+     "iopub.status.idle": "2026-06-01T20:57:11.257285Z",
+     "shell.execute_reply": "2026-06-01T20:57:11.256521Z"
     },
     "papermill": {
-     "duration": 0.350192,
-     "end_time": "2026-05-13T08:02:10.046621",
+     "duration": 0.37224,
+     "end_time": "2026-06-01T20:57:11.258454+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:09.696429",
+     "start_time": "2026-06-01T20:57:10.886214+00:00",
      "status": "completed"
     },
     "tags": []
@@ -611,16 +630,9 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solveur              Résolus    Temps total     Temps moyen    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Solveur              Résolus    Temps total     Temps moyen    \n",
       "------------------------------------------------------------\n",
-      "OR-Tools CP-SAT      10/10           150.90 ms        15.09 ms\n",
+      "OR-Tools CP-SAT      10/10           152.16 ms        15.22 ms\n",
       "\n",
       "============================================================\n",
       "Benchmark: Puzzles Difficiles (Top 11) (11 puzzles)\n",
@@ -632,22 +644,15 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solveur              Résolus    Temps total     Temps moyen    "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Solveur              Résolus    Temps total     Temps moyen    \n",
       "------------------------------------------------------------\n",
-      "OR-Tools CP-SAT      11/11           186.90 ms        16.99 ms\n"
+      "OR-Tools CP-SAT      11/11           202.47 ms        18.41 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'solved': 11, 'total_time': 0.1869044303894043}"
+       "{'solved': 11, 'total_time': 0.20247364044189453}"
       ]
      },
      "execution_count": 6,
@@ -697,10 +702,10 @@
    "id": "gs8555282sd",
    "metadata": {
     "papermill": {
-     "duration": 0.003002,
-     "end_time": "2026-05-13T08:02:10.051622",
+     "duration": 0.004067,
+     "end_time": "2026-06-01T20:57:11.266847+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:10.048620",
+     "start_time": "2026-06-01T20:57:11.262780+00:00",
      "status": "completed"
     },
     "tags": []
@@ -725,16 +730,16 @@
    "id": "obch45ox3ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:10.057622Z",
-     "iopub.status.busy": "2026-05-13T08:02:10.057622Z",
-     "iopub.status.idle": "2026-05-13T08:02:10.115484Z",
-     "shell.execute_reply": "2026-05-13T08:02:10.115484Z"
+     "iopub.execute_input": "2026-06-01T20:57:11.276500Z",
+     "iopub.status.busy": "2026-06-01T20:57:11.276223Z",
+     "iopub.status.idle": "2026-06-01T20:57:11.356543Z",
+     "shell.execute_reply": "2026-06-01T20:57:11.355625Z"
     },
     "papermill": {
-     "duration": 0.062867,
-     "end_time": "2026-05-13T08:02:10.116488",
+     "duration": 0.086386,
+     "end_time": "2026-06-01T20:57:11.357242+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:10.053621",
+     "start_time": "2026-06-01T20:57:11.270856+00:00",
      "status": "completed"
     },
     "tags": []
@@ -820,10 +825,10 @@
    "id": "631a94a7",
    "metadata": {
     "papermill": {
-     "duration": 0.002005,
-     "end_time": "2026-05-13T08:02:10.121070",
+     "duration": 0.00332,
+     "end_time": "2026-06-01T20:57:11.363963+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:10.119065",
+     "start_time": "2026-06-01T20:57:11.360643+00:00",
      "status": "completed"
     },
     "tags": []
@@ -858,16 +863,16 @@
    "id": "d32b39fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-13T08:02:10.127072Z",
-     "iopub.status.busy": "2026-05-13T08:02:10.127072Z",
-     "iopub.status.idle": "2026-05-13T08:02:10.131028Z",
-     "shell.execute_reply": "2026-05-13T08:02:10.131028Z"
+     "iopub.execute_input": "2026-06-01T20:57:11.371777Z",
+     "iopub.status.busy": "2026-06-01T20:57:11.371528Z",
+     "iopub.status.idle": "2026-06-01T20:57:11.376948Z",
+     "shell.execute_reply": "2026-06-01T20:57:11.376143Z"
     },
     "papermill": {
-     "duration": 0.007964,
-     "end_time": "2026-05-13T08:02:10.132033",
+     "duration": 0.010409,
+     "end_time": "2026-06-01T20:57:11.377670+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:10.124069",
+     "start_time": "2026-06-01T20:57:11.367261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -934,10 +939,10 @@
    "id": "rnozjwu8rs",
    "metadata": {
     "papermill": {
-     "duration": 0.002199,
-     "end_time": "2026-05-13T08:02:10.136317",
+     "duration": 0.003134,
+     "end_time": "2026-06-01T20:57:11.384119+00:00",
      "exception": false,
-     "start_time": "2026-05-13T08:02:10.134118",
+     "start_time": "2026-06-01T20:57:11.380985+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1011,18 +1016,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.387141,
-   "end_time": "2026-05-13T08:02:10.388977",
+   "duration": 20.562341,
+   "end_time": "2026-06-01T20:57:11.949743+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sudoku10.ipynb",
+   "input_path": "Sudoku-10-ORTools-Python.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\sudoku10-test.ipynb",
    "parameters": {},
-   "start_time": "2026-05-13T08:02:05.001836",
+   "start_time": "2026-06-01T20:56:51.387402+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `Sudoku-10-ORTools-Python.ipynb`.

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `76bf3efc` | After `31f3025f-f` (pip install ortools) | "Importation et verification bibliotheque" |

## Validation proof

- **Papermill**: 19/19 cells executed, 0 errors, kernel=python3
- **execution_count**: All 8 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 130 insertions, 125 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
