### PR TITLE
feat(lean): P0 light-cone warm-up lemmas for Hashlife scaffolding (#2080/#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -146,6 +146,52 @@ def BoxAssezGrand (g : Grid) (n : Nat) : Prop := box_assez_grand g n = true
 instance (g : Grid) (n : Nat) : Decidable (BoxAssezGrand g n) :=
   inferInstanceAs (Decidable (box_assez_grand g n = true))
 
+/-! ## P0. Light-cone warm-up lemmas (prover ramp)
+
+Elementary facts about `manhattan` and `lightCone` that feed the **base case**
+of P2 (`step_light_cone` at `t = 0`). `manhattan_self` and `manhattan_comm` are
+hand-proved here (genuine content — `manhattan` is a metric-like quantity, these
+are the reflexivity and symmetry axioms). `self_mem_lightCone` and
+`lightCone_zero` are left as `sorry`: they are the *easiest* rungs of the
+scaffolding, deliberately stated below P2's intermediate difficulty so the
+multi-agent prover (Epic #1453) has a gentle warm-up target before attacking the
+locality induction. They are genuine NEW targets, not regressions — no proof is
+removed. -/
+
+/-- The Manhattan distance from a cell to itself is zero. -/
+theorem manhattan_self (p : Int × Int) : manhattan p p = 0 := by
+  unfold manhattan
+  omega
+
+/-- The Manhattan distance is symmetric. -/
+theorem manhattan_comm (p q : Int × Int) : manhattan p q = manhattan q p := by
+  unfold manhattan
+  omega
+
+/-- Every cell lies in its own light cone, for any radius `t`.
+
+    **Proof strategy** (P0, difficulty: easy):
+    `manhattan p p = 0 ≤ t` (by `manhattan_self`), so `p` passes the `d ≤ t`
+    filter. Unfold `lightCone`; the `i = t` term of `rs` gives
+    `p.1 - t + t = p.1` and the `j = t` term of `cs` gives `p.2`, so the pair
+    `(p.1, p.2) = p` is produced. Discharge membership over
+    `List.flatMap`/`List.filterMap` with `List.mem_flatMap` /
+    `List.mem_filterMap`. -/
+theorem self_mem_lightCone (p : Int × Int) (t : Nat) : p ∈ lightCone p t := by
+  -- P0 TARGET (easy): reflexivity of the light cone — warm-up rung for P2's base case
+  sorry
+
+/-- The light cone of radius `0` is exactly the singleton `[p]`.
+
+    **Proof strategy** (P0, difficulty: easy):
+    With `t = 0`, `List.range 1 = [0]`, so `rs = [p.1]` and `cs = [p.2]`; the
+    filter keeps `(p.1, p.2)` since `d = 0 ≤ 0`. The whole expression reduces by
+    computation — `simp [lightCone]` followed by `decide`, or a direct `List`
+    evaluation after `Prod.ext`. -/
+theorem lightCone_zero (p : Int × Int) : lightCone p 0 = [p] := by
+  -- P0 TARGET (easiest): light cone of radius zero — first prover ramp rung
+  sorry
+
 /-! ## P2. Light-cone locality (speed of light = 1)
 
 The state of cell `p` after `t` generations of B3/S23 depends only on the


### PR DESCRIPTION
## Summary

Manual nudge to the Conway Phase 3b scaffolding `Conway/Life/HashlifeCorrectness.lean` (merged in #2080). Adds a **P0 warm-up section** *below* P2's intermediate difficulty, so the multi-agent prover (Epic #1453) has a gentle ramp before attacking the locality induction.

| Lemma | Line | Status | Note |
|-------|------|--------|------|
| `manhattan_self` | 162 | **proved** | `unfold manhattan; omega` — reflexivity of the Manhattan metric |
| `manhattan_comm` | 167 | **proved** | `unfold manhattan; omega` — symmetry |
| `self_mem_lightCone` | 180 | `sorry` (NEW P0 target) | every cell lies in its own light cone — easy reflexivity |
| `lightCone_zero` | 191 | `sorry` (NEW P0 target) | light cone of radius 0 = singleton — easiest rung |

The 2 hand-proved lemmas are **genuine new content** (metric axioms feeding P2's base case). The 2 new `sorry` are **documented prover targets**, deliberately the easiest rungs — NEW targets, **not regressions** (no existing proof removed; same pattern as #2080's P2-P5).

## Verification (Lean discipline — local build on ai-01)

```
lake build Conway.Life.HashlifeCorrectness Conway
> Built Conway.Life.HashlifeCorrectness (189s)
> Built Conway (193s)
Build completed successfully (3338 jobs).  EXIT=0
```

`grep -c sorry HashlifeCorrectness.lean`: **4 -> 6**

- Pre-nudge sorries (P2-P5): 166/185/215/242 -> preserved, now 212/231/261/288
- New P0 sorries: 180 (`self_mem_lightCone`), 191 (`lightCone_zero`)
- The 2 hand-proved lemmas compile clean (absent from sorry list, build exit 0)

## Why

#1453 success metric = iterations-to-success on known difficulty. A warm-up rung below P2 lets the local Qwen tactic agent confirm the patch->build->sorry-delta loop on a trivial target before the Director escalates to P4/P5. Per `lean-merge-discipline.md` §2, ai-01 launches a BG prover pass on `lightCone_zero` after merge.

Refs #2080, #1453, Epic #1647.