### PR TITLE
fix(prover): resolve Lake root for nested Lean files (lean_server walk-up)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py
@@ -116,8 +116,28 @@ class LeanVerifier:
             return {"success": False, "errors": "No project directory set", "raw_output": ""}
 
         project = Path(self.project_dir)
-        if not (project / "lakefile.lean").exists() and not (project / "lakefile.toml").exists():
-            return {"success": False, "errors": f"Not a Lake project: {project}", "raw_output": ""}
+        # The prover derives project_dir as `<file>.parent.parent`, which is the
+        # Lake root only for files directly under the top package (e.g.
+        # `Conway/Nim.lean` -> root `conway_lean`). For files nested deeper (e.g.
+        # `Conway/Life/HashlifeCorrectness.lean`) that yields `conway_lean/Conway`,
+        # which holds no lakefile. Walk up to the real Lake root and re-root
+        # `relative_path` with the directory names we passed (so the module name
+        # resolves to `Conway.Life.HashlifeCorrectness`). Backward-compatible: a
+        # project_dir that already holds the lakefile is used unchanged.
+        def _has_lakefile(p: Path) -> bool:
+            return (p / "lakefile.lean").exists() or (p / "lakefile.toml").exists()
+
+        if not _has_lakefile(project):
+            cur = project
+            prefix = []
+            while cur != cur.parent and not _has_lakefile(cur):
+                prefix.insert(0, cur.name)
+                cur = cur.parent
+            if _has_lakefile(cur):
+                project = cur
+                relative_path = "/".join(prefix + [relative_path])
+            else:
+                return {"success": False, "errors": f"Not a Lake project: {project}", "raw_output": ""}
 
         target_file = project / relative_path
         cache_key = self._compute_cache_key(target_file) if target_file.exists() else None


### PR DESCRIPTION
## Summary

The multi-agent prover derives `project_dir` as `<file>.parent.parent`, which is the Lake root **only** for files directly under the top package (e.g. `Conway/Nim.lean` -> `conway_lean`). For 3-level files like `conway_lean/Conway/Life/HashlifeCorrectness.lean` that yields `conway_lean/Conway`, which holds no lakefile -> the verifier returned `"Not a Lake project"` and the file could never be targeted.

`verify_project_file` now walks up to the real Lake root and re-roots `relative_path` with the directory names it walked past, so the module resolves to `Conway.Life.HashlifeCorrectness`.

## Scope
- **1 file** (`agent_tests/lean_server.py`), +22/-2. Pure harness Python, **no `.lean` touched** -> no proof regression, no `sorry` delta, no catalogue impact.
- **Backward-compatible**: a `project_dir` that already holds the lakefile is used unchanged (the walk-up branch only fires when no lakefile is present at the derived root).

## Verification
- `python -c ast.parse` -> parses clean.
- Functional: a BG multi-agent prover pass targeting `Conway/Life/HashlifeCorrectness.lean:193` (`lightCone_zero`) with this fix in place **resolves the lake root correctly** (baseline build found the 6 documented sorries at their real lines; goal `lightCone p 0 = [p] : Prop` extracted cleanly) — previously this would have failed at root resolution.

Unblocks targeting any `Conway/Life/*` sorry with the prover (Conway Phase 3b scaffolding #2080).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>