### PR TITLE
chore: resync catalog after SC-1, Lean Hashlife, GenAI promotions

### DIFF
--- a/COURSE_CATALOG.generated.json
+++ b/COURSE_CATALOG.generated.json
@@ -11171,7 +11171,7 @@
     "owner_logique": "po-2024",
     "last_validation": "2026-06-01",
     "last_validator": "jsboige@gmail.com",
-    "issue_pr_associee": "#2069",
+    "issue_pr_associee": "#2035",
     "cells_total": 35,
     "cells_code": 11,
     "cells_markdown": 24,

--- a/COURSE_CATALOG.generated.md
+++ b/COURSE_CATALOG.generated.md
@@ -1,6 +1,6 @@
 # CoursIA Notebook Catalog
 
-Generated: 2026-06-01 11:40
+Generated: 2026-06-01 23:57
 Total notebooks: 505
 
 ## Status Summary
@@ -12,15 +12,15 @@ Total notebooks: 505
 
 ## Maturity Summary
 
-- **PRODUCTION**: 400
-- **BETA**: 62
+- **PRODUCTION**: 405
+- **BETA**: 57
 - **TEMPLATE**: 4
-- **ALPHA**: 34
-- **DRAFT**: 5
+- **ALPHA**: 35
+- **DRAFT**: 4
 
 ## By Series
 
-### GenAI (120 notebooks) — BROKEN:1, DEMO:80, READY:39 | ALPHA:4, BETA:31, DRAFT:3, PRODUCTION:79, TEMPLATE:3
+### GenAI (120 notebooks) — BROKEN:1, DEMO:80, READY:39 | ALPHA:4, BETA:27, DRAFT:3, PRODUCTION:83, TEMPLATE:3
 
 | # | Notebook | Kernel | Status | Maturity | Duration | Owner |
 |---|----------|--------|--------|----------|----------|-------|
@@ -41,7 +41,7 @@ Total notebooks: 505
 | 15 | MusicGen - Generation Musicale par IA | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 16 | Demucs v4 - Separation de Sources Audio | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 17 | Multi-Model TTS Gateway - Synthese Vocale Multi-Mo | Python 3 | DEMO | PRODUCTION | 30min | po-2025 |
-| 18 | Generation MIDI avec midi-model (SkyTNT) | Python 3 | DEMO | BETA | 45min | po-2025 |
+| 18 | Generation MIDI avec midi-model (SkyTNT) | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 19 | Generation de Chansons Completes : YuE vs SongGene | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 20 | TTS Expressif : Fish S2 Pro et Modeles SOTA | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 21 | Ace-Step v1.5 - Generation Musicale avec Paroles | Python 3 | DEMO | BETA | 45min | po-2025 |
@@ -117,7 +117,7 @@ Total notebooks: 505
 | 91 | 1. Introduction a l'IA generative avec l'API OpenA | Python 3 | READY | PRODUCTION | 15min | po-2025 |
 | 92 | Prompt Engineering : Advanced Prompting avec OpenA | Python 3 | DEMO | BETA | 45min | po-2025 |
 | 93 | Structured Outputs : Sorties JSON Garanties avec O | Python 3 | READY | PRODUCTION | 30min | po-2025 |
-| 94 | Function Calling : Connecter les LLMs au Monde Rée | Python 3 | DEMO | BETA | 45min | po-2025 |
+| 94 | Function Calling : Connecter les LLMs au Monde Rée | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 95 | 5. RAG Modern - Retrieval Augmented Generation | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 96 | PDF et Web Search : Sources Documentaires avec Ope | Python 3 | READY | PRODUCTION | 30min | po-2025 |
 | 97 | Code Interpreter : Exécution de Code avec OpenAI | Python 3 | READY | PRODUCTION | 30min | po-2025 |
@@ -141,11 +141,11 @@ Total notebooks: 505
 | 115 | Orchestration de Pipelines Video | Python 3 | DEMO | ALPHA | 45min | po-2025 |
 | 116 | ComfyUI - Workflows Video via API | Python 3 | DEMO | BETA | 45min | po-2025 |
 | 117 | Generation de Videos Educatives | Python 3 | DEMO | DRAFT | 45min | po-2025 |
-| 118 | Workflows Video Creatifs | Python 3 | DEMO | BETA | 45min | po-2025 |
+| 118 | Workflows Video Creatifs | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 119 | Sora API - Generation Video Cloud | Python 3 | DEMO | ALPHA | 45min | po-2025 |
-| 120 | Pipeline Video de Production | Python 3 | DEMO | BETA | 45min | po-2025 |
+| 120 | Pipeline Video de Production | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 
-### Search (46 notebooks) — DEMO:3, READY:43 | BETA:2, DRAFT:1, PRODUCTION:43
+### Search (46 notebooks) — DEMO:3, READY:43 | BETA:2, PRODUCTION:44
 
 | # | Notebook | Kernel | Status | Maturity | Duration | Owner |
 |---|----------|--------|--------|----------|----------|-------|
@@ -194,15 +194,15 @@ Total notebooks: 505
 | 43 | CSP-8 : Temporels - Raisonnement sur le Temps | Python 3 | DEMO | PRODUCTION | 45min | po-2025 |
 | 44 | CSP-9-Distributed : CSP Distribués (DisCSP) | Python 3 | READY | PRODUCTION | 45min | po-2025 |
 | 45 | Search - Portfolio Optimization avec GeneticSharp | .NET (C#) | READY | PRODUCTION | 30min | po-2025 |
-| 46 | TP : Algorithmes Genetiques pour la Detection de B | Python 3 | READY | DRAFT | 30min | po-2025 |
+| 46 | TP : Algorithmes Genetiques pour la Detection de B | Python 3 | READY | PRODUCTION | 30min | po-2025 |
 
-### ML (27 notebooks) — DEMO:5, READY:22 | ALPHA:1, BETA:1, PRODUCTION:25
+### ML (27 notebooks) — DEMO:4, READY:23 | ALPHA:1, BETA:1, PRODUCTION:25
 
 | # | Notebook | Kernel | Status | Maturity | Duration | Owner |
 |---|----------|--------|--------|----------|----------|-------|
 | 1 | 1.2 - Manipulation de Données avec NumPy | Python 3 | READY | BETA | 15min | po-2023 |
 | 2 | 1.3 - Analyse de Données avec Pandas | Python 3 | READY | PRODUCTION | 15min | po-2023 |
-| 3 | Lab 8: Introduction au Framework ADK et Multi-Prov | Python 3 | DEMO | PRODUCTION | 30min | po-2023 |
+| 3 | Lab 8: Introduction au Framework ADK et Multi-Prov | Python 3 | READY | PRODUCTION | 30min | po-2023 |
 | 4 | Lab 9: Premier Agent ADK pour Data Science | Python 3 | READY | PRODUCTION | 30min | po-2023 |
 | 5 | Lab 10: Data File Analyzer (DS-STAR Component) | Python 3 | READY | PRODUCTION | 30min | po-2023 |
 | 6 | Lab 11: Planner-Coder-Verifier Loop (DS-STAR Core) | Python 3 | READY | PRODUCTION | 30min | po-2023 |
@@ -228,7 +228,7 @@ Total notebooks: 505
 | 26 | ML-7 : Systèmes de Recommandation avec ML.NET | .NET (C#) | READY | PRODUCTION | 45min | po-2023 |
 | 27 | TP : Prevision des ventes d'assurance | .NET (C#) | READY | PRODUCTION | 30min | po-2023 |
 
-### SymbolicAI (100 notebooks) — DEMO:6, READY:94 | ALPHA:1, BETA:3, PRODUCTION:96
+### SymbolicAI (100 notebooks) — DEMO:6, READY:94 | ALPHA:2, BETA:1, PRODUCTION:97
 
 | # | Notebook | Kernel | Status | Maturity | Duration | Owner |
 |---|----------|--------|--------|----------|----------|-------|
@@ -254,7 +254,7 @@ Total notebooks: 505
 | 20 | Lean 7 - Integration des LLMs pour l'Assistance au | Python 3 (WSL) | READY | PRODUCTION | 45min | po-2024 |
 | 21 | Lean 7b - Exemples Progressifs et Benchmarks | Python 3 (WSL) | READY | PRODUCTION | 30min | po-2024 |
 | 22 | Lean 8 - Agents Autonomes pour Demonstration de Th | Python 3 | READY | PRODUCTION | 30min | po-2024 |
-| 23 | Description du notebook | Python 3 | DEMO | BETA | 45min | po-2024 |
+| 23 | Description du notebook | Python 3 | DEMO | ALPHA | 45min | po-2024 |
 | 24 | LINQ to Z3 - Résolution de Contraintes Déclarative | .NET (C#) | READY | PRODUCTION | 30min | po-2024 |
 | 25 | OR-Tools : Résolution du Problème du Régime de Sti | .NET (C#) | READY | PRODUCTION | 45min | po-2024 |
 | 26 | Planners-0-Setup | Python 3 | READY | PRODUCTION | 30min | po-2024 |
@@ -275,7 +275,7 @@ Total notebooks: 505
 | 41 | SW-10-Python-RDFStar | Python 3 | READY | PRODUCTION | 45min | po-2024 |
 | 42 | SW-11-Python-KnowledgeGraphs | Python 3 | READY | PRODUCTION | 1h | po-2024 |
 | 43 | SW-12-Python-GraphRAG | Python 3 | READY | PRODUCTION | 45min | po-2024 |
-| 44 | SW-14-Reasoners | Python 3 | READY | BETA | 45min | po-2024 |
+| 44 | SW-14-Reasoners | Python 3 | READY | PRODUCTION | 45min | po-2024 |
 | 45 | SW-2-RDFBasics | .NET (C#) | READY | PRODUCTION | 45min | po-2024 |
 | 46 | SW-2b-Python-RDFBasics | Python 3 | READY | PRODUCTION | 30min | po-2024 |
 | 47 | SW-3-GraphOperations | .NET (C#) | READY | PRODUCTION | 1h | po-2024 |
@@ -291,7 +291,7 @@ Total notebooks: 505
 | 57 | SC-0-Cypherpunk-Origins - Les origines Cypherpunk  | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
 | 58 | SC-1-Setup-Foundry - Environnement Smart Contracts | Python (SmartContracts + Found | READY | PRODUCTION | 15min | po-2024 |
 | 59 | SC-2-Setup-Web3py - Python et la Blockchain | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
-| 60 | SC-3-Solidity-Basics - Fondements de Solidity | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
+| 60 | SC-3-Solidity-Basics - Fondements de Solidity | .venv | READY | PRODUCTION | 30min | po-2024 |
 | 61 | SC-4-Functions-State - Fonctions et Etat | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
 | 62 | SC-5-Inheritance - Heritage et Interfaces | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
 | 63 | SC-6-Errors-Events - Erreurs et Evenements | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
@@ -301,7 +301,7 @@ Total notebooks: 505
 | 67 | SC-8-DeFi-Primitives - Primitives DeFi | Python (SmartContracts + Found | READY | PRODUCTION | 15min | po-2024 |
 | 68 | SC-9-DAO-Governance - Gouvernance DAO | Python (SmartContracts + Found | READY | PRODUCTION | 15min | po-2024 |
 | 69 | SC-12-Foundry-Testing - Tests avec Foundry | Python (SmartContracts + Found | READY | PRODUCTION | 45min | po-2024 |
-| 70 | SC-13-Fuzz-Invariants - Fuzz Testing | Python (SmartContracts + Found | READY | PRODUCTION | 15min | po-2024 |
+| 70 | SC-13-Fuzz-Invariants - Fuzz Testing | Python 3 | READY | PRODUCTION | 15min | po-2024 |
 | 71 | SC-14-Formal-Verification - Verification Formelle | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
 | 72 | SC-15-Zero-Knowledge-Proofs - Preuves a Divulgatio | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
 | 73 | SC-16-Homomorphic-Encryption - Chiffrement Homomor | Python (SmartContracts + Found | READY | PRODUCTION | 30min | po-2024 |
@@ -469,7 +469,7 @@ Total notebooks: 505
 | 24 | SocialChoice 03 - Methodes de Vote et Paradoxes | Python 3 | READY | PRODUCTION | 45min | po-2024 |
 | 25 | SocialChoice 04 - Agregation Computationnelle : SA | Python 3 (WSL) | READY | PRODUCTION | 45min | po-2024 |
 
-### Sudoku (32 notebooks) — DEMO:1, READY:31 | PRODUCTION:32
+### Sudoku (32 notebooks) — DEMO:2, READY:30 | BETA:1, PRODUCTION:31
 
 | # | Notebook | Kernel | Status | Maturity | Duration | Owner |
 |---|----------|--------|--------|----------|----------|-------|
@@ -487,7 +487,7 @@ Total notebooks: 505
 | 12 | Résolution de Sudoku avec Infer.NET | .NET (C#) | READY | PRODUCTION | 45min | po-2023 |
 | 13 | Sudoku-15-Infer-Python : Resolution Probabiliste a | Python 3 | READY | PRODUCTION | 30min | po-2023 |
 | 14 | Sudoku-16 : Résolution par Réseaux de Neurones | Python 3 | DEMO | PRODUCTION | 1h | po-2023 |
-| 15 | Notebook 17: Resolution de Sudoku avec Large Langu | Python 3 | READY | PRODUCTION | 30min | po-2023 |
+| 15 | Notebook 17: Resolution de Sudoku avec Large Langu | Python 3 | DEMO | BETA | 30min | po-2023 |
 | 16 | Comparaison des Solveurs de Sudoku | Python 3 | READY | PRODUCTION | 45min | po-2023 |
 | 17 | Resolution de Sudoku avec Algorithm X et Dancing L | .NET (C#) | READY | PRODUCTION | 30min | po-2023 |
 | 18 | Sudoku-Python-DancingLinks : Dancing Links / Algor | Python 3 | READY | PRODUCTION | 30min | po-2023 |


### PR DESCRIPTION
## Summary
Resync COURSE_CATALOG.generated.{json,md} to reflect merges since last regen:
- SC-1 Foundry Counter project (Nabil+Lucas+Wilfrid)
- Lean Hashlife Phase 3b scaffold (#2080)
- GenAI promotions: midi-model, function-calling, workflows video x2
- Various SC consolidations merged by ai-01

## Drift
+22 insertions / -22 deletions (maturity changes only)

## Pre-machage
- `generate_catalog.py --git-tracked-only` : 505 entries generated
- `expand_catalog_markers.py` : 0 README markers expanded (already up to date)
- No notebook source modified, catalog files only

## Stats
| Before | After |
|--------|-------|
| 400 PRODUCTION | 405 PRODUCTION (+5) |
| 62 BETA | 57 BETA |
| 34 ALPHA | 35 ALPHA (+1 Hashlife) |
| 5 DRAFT | 4 DRAFT |