### PR TITLE
fix(prover): default agent_timeout_s=900 in AutonomousProver.prove_sorry

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -749,7 +749,14 @@ class AutonomousProver:
         self.config_label = f"auto-{provider}"
 
     def prove_sorry(self, demo: dict, max_iterations: int = 10,
-                    strategic_hints: str = "", agent_timeout_s: int = 0) -> dict:
+                    # agent_timeout_s default was 0 (no timeout), letting a
+                    # stuck provider hang indefinitely on a bare prove_sorry()
+                    # call (observed: TacticAgent z.ai 1680s, GLM single-call
+                    # 1200s+). Normal single-agent call is ~60-120s, so a 900s
+                    # hard cap kills pathological hangs with generous headroom.
+                    # Routes through the ContextVar-safe asyncio.wait branch
+                    # below. Pass agent_timeout_s=0 explicitly to disable.
+                    strategic_hints: str = "", agent_timeout_s: int = 900) -> dict:
         # Same OTel wiring as MultiAgentSorryProver — single-agent runs benefit
         # just as much from a durable span log of LLM-tool interactions.
         otel_session = f"auto_{demo['name']}_{self.provider}_{int(time.time())}"


### PR DESCRIPTION
## Summary

`AutonomousProver.prove_sorry` defaulted `agent_timeout_s=0` (no timeout). Bare callers that don't pass the value inherited the infinite-hang risk: a stuck provider could block the run indefinitely. Observed pathologies in traces: TacticAgent z.ai **1680s**, GLM single-call **1200s+**.

This sets the default to **900s** (a single-agent call normally runs ~60-120s, so 900s is a generous hard cap that only kills runaway hangs). The value routes through the existing ContextVar-safe `asyncio.wait` branch (provers.py ~945-995). `agent_timeout_s=0` remains explicitly available to disable the cap.

## Scope (1 file, harness Python only)

- `agent_tests/prover/provers.py`: `prove_sorry` signature default `0` -> `900` + 7-line co-located rationale comment.
- **No `.lean` touched** -> not gated by lean-merge-discipline section 1.
- AST parse: OK.

## Blast radius (grep-verified)

Bare `AutonomousProver.prove_sorry()` callers that gain the cap:
- `run_baselines.py:89`, `run_prover_bg.py:89`, `multi_agent_proof.py:124/230`.

Unaffected: `run_prover.py:30` passes `agent_timeout_s=timeout` explicitly. `MultiAgentSorryProver.prove_sorry` uses a separate `workflow_timeout_s` param (not touched). No caller relies on `0`=infinite as a feature; `0` stays explicitly available.

## Verification
- `python -c 'import ast; ast.parse(...)'` -> AST OK
- `git diff --cached --stat` -> 1 file changed, 8 insertions(+), 1 deletion(-)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>