### PR TITLE
enrich(Sudoku-6): insert markdown transition between CBJ class and benchmark

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "71960cdb",
    "metadata": {
     "papermill": {
-     "duration": 0.003806,
-     "end_time": "2026-04-25T15:02:19.642959",
+     "duration": 0.007773,
+     "end_time": "2026-06-01T22:37:21.747732+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.639153",
+     "start_time": "2026-06-01T22:37:21.739959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
    "id": "537fe538",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.651409Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.650907Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.735597Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.734735Z"
+     "iopub.execute_input": "2026-06-01T22:37:21.763953Z",
+     "iopub.status.busy": "2026-06-01T22:37:21.763662Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.287649Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.286200Z"
     },
     "papermill": {
-     "duration": 0.09036,
-     "end_time": "2026-04-25T15:02:19.736938",
+     "duration": 0.53545,
+     "end_time": "2026-06-01T22:37:22.291024+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.646578",
+     "start_time": "2026-06-01T22:37:21.755574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -108,10 +108,10 @@
    "id": "dbb0a1df",
    "metadata": {
     "papermill": {
-     "duration": 0.003576,
-     "end_time": "2026-04-25T15:02:19.744188",
+     "duration": 0.008802,
+     "end_time": "2026-06-01T22:37:22.310929+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.740612",
+     "start_time": "2026-06-01T22:37:22.302127+00:00",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "0044c653",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.752061Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.751778Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.756563Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.755984Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.327569Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.327001Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.334468Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.333136Z"
     },
     "papermill": {
-     "duration": 0.009774,
-     "end_time": "2026-04-25T15:02:19.757591",
+     "duration": 0.018246,
+     "end_time": "2026-06-01T22:37:22.335707+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.747817",
+     "start_time": "2026-06-01T22:37:22.317461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -169,10 +169,10 @@
    "id": "fa502dad",
    "metadata": {
     "papermill": {
-     "duration": 0.003425,
-     "end_time": "2026-04-25T15:02:19.764514",
+     "duration": 0.006067,
+     "end_time": "2026-06-01T22:37:22.347491+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.761089",
+     "start_time": "2026-06-01T22:37:22.341424+00:00",
      "status": "completed"
     },
     "tags": []
@@ -187,16 +187,16 @@
    "id": "3fcb945a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.772489Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.772005Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.783867Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.783197Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.364005Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.363629Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.381974Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.380545Z"
     },
     "papermill": {
-     "duration": 0.017051,
-     "end_time": "2026-04-25T15:02:19.784910",
+     "duration": 0.027317,
+     "end_time": "2026-06-01T22:37:22.383051+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.767859",
+     "start_time": "2026-06-01T22:37:22.355734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +315,10 @@
    "id": "708f3cdf",
    "metadata": {
     "papermill": {
-     "duration": 0.003985,
-     "end_time": "2026-04-25T15:02:19.793210",
+     "duration": 0.005279,
+     "end_time": "2026-06-01T22:37:22.393962+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.789225",
+     "start_time": "2026-06-01T22:37:22.388683+00:00",
      "status": "completed"
     },
     "tags": []
@@ -349,10 +349,10 @@
    "id": "6c9459a6",
    "metadata": {
     "papermill": {
-     "duration": 0.003719,
-     "end_time": "2026-04-25T15:02:19.800773",
+     "duration": 0.005735,
+     "end_time": "2026-06-01T22:37:22.405539+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.797054",
+     "start_time": "2026-06-01T22:37:22.399804+00:00",
      "status": "completed"
     },
     "tags": []
@@ -369,16 +369,16 @@
    "id": "8a6136dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.809957Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.809626Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.816696Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.815883Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.419185Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.418773Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.427448Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.426547Z"
     },
     "papermill": {
-     "duration": 0.012955,
-     "end_time": "2026-04-25T15:02:19.817770",
+     "duration": 0.017885,
+     "end_time": "2026-06-01T22:37:22.428619+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.804815",
+     "start_time": "2026-06-01T22:37:22.410734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -443,10 +443,10 @@
    "id": "0184debd",
    "metadata": {
     "papermill": {
-     "duration": 0.003988,
-     "end_time": "2026-04-25T15:02:19.825895",
+     "duration": 0.005319,
+     "end_time": "2026-06-01T22:37:22.439599+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.821907",
+     "start_time": "2026-06-01T22:37:22.434280+00:00",
      "status": "completed"
     },
     "tags": []
@@ -466,16 +466,16 @@
    "id": "13e41d53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.835441Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.835052Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.842894Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.842212Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.461089Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.460606Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.471489Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.470081Z"
     },
     "papermill": {
-     "duration": 0.014026,
-     "end_time": "2026-04-25T15:02:19.843969",
+     "duration": 0.021897,
+     "end_time": "2026-06-01T22:37:22.472580+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.829943",
+     "start_time": "2026-06-01T22:37:22.450683+00:00",
      "status": "completed"
     },
     "tags": []
@@ -555,10 +555,10 @@
    "id": "58ad5d46",
    "metadata": {
     "papermill": {
-     "duration": 0.003719,
-     "end_time": "2026-04-25T15:02:19.851681",
+     "duration": 0.006863,
+     "end_time": "2026-06-01T22:37:22.485840+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.847962",
+     "start_time": "2026-06-01T22:37:22.478977+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,16 +573,16 @@
    "id": "5c5d6393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.861420Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.860926Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.866836Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.865964Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.527344Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.526775Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.535827Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.534443Z"
     },
     "papermill": {
-     "duration": 0.012438,
-     "end_time": "2026-04-25T15:02:19.867994",
+     "duration": 0.019139,
+     "end_time": "2026-06-01T22:37:22.537148+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.855556",
+     "start_time": "2026-06-01T22:37:22.518009+00:00",
      "status": "completed"
     },
     "tags": []
@@ -592,7 +592,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BacktrackingSimple defini.\n"
+      "BacktrackingSimple defini."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -633,10 +640,10 @@
    "id": "96136f46",
    "metadata": {
     "papermill": {
-     "duration": 0.004174,
-     "end_time": "2026-04-25T15:02:19.876478",
+     "duration": 0.008985,
+     "end_time": "2026-06-01T22:37:22.554953+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.872304",
+     "start_time": "2026-06-01T22:37:22.545968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,16 +664,16 @@
    "id": "d536dc0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.886086Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.885769Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.893257Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.892387Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.575331Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.574738Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.586869Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.585373Z"
     },
     "papermill": {
-     "duration": 0.013768,
-     "end_time": "2026-04-25T15:02:19.894348",
+     "duration": 0.023836,
+     "end_time": "2026-06-01T22:37:22.588245+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.880580",
+     "start_time": "2026-06-01T22:37:22.564409+00:00",
      "status": "completed"
     },
     "tags": []
@@ -732,10 +739,10 @@
    "id": "a99e1efc",
    "metadata": {
     "papermill": {
-     "duration": 0.003881,
-     "end_time": "2026-04-25T15:02:19.902399",
+     "duration": 0.00724,
+     "end_time": "2026-06-01T22:37:22.603824+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.898518",
+     "start_time": "2026-06-01T22:37:22.596584+00:00",
      "status": "completed"
     },
     "tags": []
@@ -750,16 +757,16 @@
    "id": "38ec4aac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.911720Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.911283Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.917460Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.916803Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.623005Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.622491Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.631537Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.630059Z"
     },
     "papermill": {
-     "duration": 0.012166,
-     "end_time": "2026-04-25T15:02:19.918508",
+     "duration": 0.020522,
+     "end_time": "2026-06-01T22:37:22.632600+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.906342",
+     "start_time": "2026-06-01T22:37:22.612078+00:00",
      "status": "completed"
     },
     "tags": []
@@ -819,10 +826,10 @@
    "id": "07fc6430",
    "metadata": {
     "papermill": {
-     "duration": 0.004138,
-     "end_time": "2026-04-25T15:02:19.926895",
+     "duration": 0.00747,
+     "end_time": "2026-06-01T22:37:22.646083+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.922757",
+     "start_time": "2026-06-01T22:37:22.638613+00:00",
      "status": "completed"
     },
     "tags": []
@@ -839,16 +846,16 @@
    "id": "9f95b034",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.936459Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.935969Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.944829Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.943988Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.662804Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.662351Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.674377Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.672932Z"
     },
     "papermill": {
-     "duration": 0.014989,
-     "end_time": "2026-04-25T15:02:19.945928",
+     "duration": 0.02228,
+     "end_time": "2026-06-01T22:37:22.675575+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.930939",
+     "start_time": "2026-06-01T22:37:22.653295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -940,10 +947,10 @@
    "id": "6711928f",
    "metadata": {
     "papermill": {
-     "duration": 0.004537,
-     "end_time": "2026-04-25T15:02:19.954792",
+     "duration": 0.007438,
+     "end_time": "2026-06-01T22:37:22.690485+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.950255",
+     "start_time": "2026-06-01T22:37:22.683047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -960,16 +967,16 @@
    "id": "ade78048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.964989Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.964433Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.971848Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.971149Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.708121Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.707462Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.719610Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.718122Z"
     },
     "papermill": {
-     "duration": 0.013636,
-     "end_time": "2026-04-25T15:02:19.972946",
+     "duration": 0.022756,
+     "end_time": "2026-06-01T22:37:22.720781+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.959310",
+     "start_time": "2026-06-01T22:37:22.698025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1048,10 +1055,10 @@
    "id": "82aa1e52",
    "metadata": {
     "papermill": {
-     "duration": 0.004108,
-     "end_time": "2026-04-25T15:02:19.981183",
+     "duration": 0.006211,
+     "end_time": "2026-06-01T22:37:22.733612+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.977075",
+     "start_time": "2026-06-01T22:37:22.727401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1068,16 +1075,16 @@
    "id": "bd528b4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:19.990849Z",
-     "iopub.status.busy": "2026-04-25T15:02:19.990309Z",
-     "iopub.status.idle": "2026-04-25T15:02:19.997402Z",
-     "shell.execute_reply": "2026-04-25T15:02:19.996736Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.753575Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.753013Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.763279Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.761900Z"
     },
     "papermill": {
-     "duration": 0.0133,
-     "end_time": "2026-04-25T15:02:19.998516",
+     "duration": 0.022202,
+     "end_time": "2026-06-01T22:37:22.764240+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:19.985216",
+     "start_time": "2026-06-01T22:37:22.742038+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1145,10 +1152,10 @@
    "id": "9ce278e9",
    "metadata": {
     "papermill": {
-     "duration": 0.004083,
-     "end_time": "2026-04-25T15:02:20.006991",
+     "duration": 0.007716,
+     "end_time": "2026-06-01T22:37:22.777835+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:20.002908",
+     "start_time": "2026-06-01T22:37:22.770119+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1163,16 +1170,16 @@
    "id": "6c19a9e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:20.016611Z",
-     "iopub.status.busy": "2026-04-25T15:02:20.016237Z",
-     "iopub.status.idle": "2026-04-25T15:02:20.068141Z",
-     "shell.execute_reply": "2026-04-25T15:02:20.067455Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.791469Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.790981Z",
+     "iopub.status.idle": "2026-06-01T22:37:22.872058Z",
+     "shell.execute_reply": "2026-06-01T22:37:22.870829Z"
     },
     "papermill": {
-     "duration": 0.05797,
-     "end_time": "2026-04-25T15:02:20.069181",
+     "duration": 0.089846,
+     "end_time": "2026-06-01T22:37:22.873128+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:20.011211",
+     "start_time": "2026-06-01T22:37:22.783282+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1193,9 +1200,15 @@
       "---------------------\n",
       "2 4 . | 5 3 . | 6 . . \n",
       "7 . 5 | 2 . . | 3 . 4 \n",
-      ". 8 . | . 4 1 | 9 5 . \n",
+      ". 8 . | . 4 1 | 9 5 . \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Solution (MAC): 45.9ms, 81 assignations, 0 backtracks\n",
+      "Solution (MAC): 72.6ms, 81 assignations, 0 backtracks\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
       "1 7 4 | 9 6 3 | 8 2 5 \n",
       "5 3 8 | 4 2 7 | 1 6 9 \n",
@@ -1241,10 +1254,10 @@
    "id": "142aefae",
    "metadata": {
     "papermill": {
-     "duration": 0.004691,
-     "end_time": "2026-04-25T15:02:20.080667",
+     "duration": 0.005325,
+     "end_time": "2026-06-01T22:37:22.884191+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:20.075976",
+     "start_time": "2026-06-01T22:37:22.878866+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1264,16 +1277,16 @@
    "id": "ad2f5862",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:20.091036Z",
-     "iopub.status.busy": "2026-04-25T15:02:20.090525Z",
-     "iopub.status.idle": "2026-04-25T15:02:30.012769Z",
-     "shell.execute_reply": "2026-04-25T15:02:30.012057Z"
+     "iopub.execute_input": "2026-06-01T22:37:22.897365Z",
+     "iopub.status.busy": "2026-06-01T22:37:22.896917Z",
+     "iopub.status.idle": "2026-06-01T22:37:33.955979Z",
+     "shell.execute_reply": "2026-06-01T22:37:33.954859Z"
     },
     "papermill": {
-     "duration": 9.929182,
-     "end_time": "2026-04-25T15:02:30.014385",
+     "duration": 11.067379,
+     "end_time": "2026-06-01T22:37:33.956894+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:20.085203",
+     "start_time": "2026-06-01T22:37:22.889515+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1294,10 +1307,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING SIMPLE          2889322       499461         9680 2/2\n",
-      "BACKTRACKING MRV LCV             255            0           85 2/2\n",
-      "FORWARD CHECKING                  81            0           50 2/2\n",
-      "MAC                               81            0           94 2/2\n",
+      "BACKTRACKING SIMPLE          2889322       499461        10734 2/2\n",
+      "BACKTRACKING MRV LCV             255            0          114 2/2\n",
+      "FORWARD CHECKING                  81            0           70 2/2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAC                               81            0          123 2/2\n",
       "================================================================================\n"
      ]
     }
@@ -1380,10 +1399,10 @@
    "id": "69cef42b",
    "metadata": {
     "papermill": {
-     "duration": 0.004282,
-     "end_time": "2026-04-25T15:02:30.023749",
+     "duration": 0.009137,
+     "end_time": "2026-06-01T22:37:33.974845+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.019467",
+     "start_time": "2026-06-01T22:37:33.965708+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1409,10 +1428,10 @@
    "id": "e34035b8",
    "metadata": {
     "papermill": {
-     "duration": 0.004114,
-     "end_time": "2026-04-25T15:02:30.032033",
+     "duration": 0.006288,
+     "end_time": "2026-06-01T22:37:33.986807+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.027919",
+     "start_time": "2026-06-01T22:37:33.980519+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1446,16 +1465,16 @@
    "id": "1850070a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:30.041818Z",
-     "iopub.status.busy": "2026-04-25T15:02:30.041507Z",
-     "iopub.status.idle": "2026-04-25T15:02:30.076015Z",
-     "shell.execute_reply": "2026-04-25T15:02:30.075040Z"
+     "iopub.execute_input": "2026-06-01T22:37:34.001957Z",
+     "iopub.status.busy": "2026-06-01T22:37:34.001464Z",
+     "iopub.status.idle": "2026-06-01T22:37:34.054714Z",
+     "shell.execute_reply": "2026-06-01T22:37:34.053674Z"
     },
     "papermill": {
-     "duration": 0.041422,
-     "end_time": "2026-04-25T15:02:30.077520",
+     "duration": 0.06252,
+     "end_time": "2026-06-01T22:37:34.056151+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.036098",
+     "start_time": "2026-06-01T22:37:33.993631+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1465,7 +1484,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CBJ (easy): 23ms, 81 assigns, 0 backtracks, valide=True\n",
+      "CBJ (easy): 38ms, 81 assigns, 0 backtracks, valide=True\n",
       "ConflictBackjumping implemente.\n"
      ]
     }
@@ -1584,21 +1603,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e27d2cc2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006695,
+     "end_time": "2026-06-01T22:37:34.072838+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T22:37:34.066143+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Benchmark CBJ vs autres strategies\n",
+    "\n",
+    "L'implementation du CBJ avec selection MRV converge sur les puzzles faciles. Comparons maintenant ses performances avec le backtracking ameliore (MRV+LCV) et le Forward Checking sur plusieurs puzzles pour observer si le backjumping apporte un gain mesurable."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "85ba2c40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:30.089170Z",
-     "iopub.status.busy": "2026-04-25T15:02:30.088542Z",
-     "iopub.status.idle": "2026-04-25T15:02:30.462912Z",
-     "shell.execute_reply": "2026-04-25T15:02:30.461970Z"
+     "iopub.execute_input": "2026-06-01T22:37:34.084980Z",
+     "iopub.status.busy": "2026-06-01T22:37:34.084693Z",
+     "iopub.status.idle": "2026-06-01T22:37:34.533261Z",
+     "shell.execute_reply": "2026-06-01T22:37:34.532237Z"
     },
     "papermill": {
-     "duration": 0.382261,
-     "end_time": "2026-04-25T15:02:30.464705",
+     "duration": 0.456186,
+     "end_time": "2026-06-01T22:37:34.534270+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.082444",
+     "start_time": "2026-06-01T22:37:34.078084+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1611,22 +1649,28 @@
       "=== Benchmark CBJ vs heuristiques sur 3 puzzles faciles ===\n",
       "================================================================================\n",
       "Strategie                    Assigns   Backtracks    Temps(ms)     Succes\n",
-      "--------------------------------------------------------------------------------\n",
-      "BACKTRACKING MRV LCV             366           10          159 3/3\n"
+      "--------------------------------------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CONFLICT BACK JUMPING             82            1          107 3/3\n"
+      "BACKTRACKING MRV LCV             366           10          205 3/3\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FORWARD CHECKING                  91           10           91 3/3\n",
+      "CONFLICT BACK JUMPING             82            1          131 3/3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FORWARD CHECKING                  91           10           97 3/3\n",
       "================================================================================\n"
      ]
     }
@@ -1698,10 +1742,10 @@
    "id": "69fac6e4",
    "metadata": {
     "papermill": {
-     "duration": 0.004897,
-     "end_time": "2026-04-25T15:02:30.474929",
+     "duration": 0.005304,
+     "end_time": "2026-06-01T22:37:34.545705+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.470032",
+     "start_time": "2026-06-01T22:37:34.540401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1742,16 +1786,16 @@
    "id": "6452d7ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:30.486044Z",
-     "iopub.status.busy": "2026-04-25T15:02:30.485420Z",
-     "iopub.status.idle": "2026-04-25T15:02:30.492932Z",
-     "shell.execute_reply": "2026-04-25T15:02:30.492106Z"
+     "iopub.execute_input": "2026-06-01T22:37:34.557936Z",
+     "iopub.status.busy": "2026-06-01T22:37:34.557655Z",
+     "iopub.status.idle": "2026-06-01T22:37:34.563233Z",
+     "shell.execute_reply": "2026-06-01T22:37:34.562538Z"
     },
     "papermill": {
-     "duration": 0.014316,
-     "end_time": "2026-04-25T15:02:30.493984",
+     "duration": 0.013179,
+     "end_time": "2026-06-01T22:37:34.563995+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.479668",
+     "start_time": "2026-06-01T22:37:34.550816+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1844,18 +1888,35 @@
   {
    "cell_type": "markdown",
    "id": "888465da",
-   "source": "## Resume et perspectives\n\nCe notebook a formalise le Sudoku comme un probleme de satisfaction de contraintes (CSP) binaire selon le cadre academique AIMA (Russell & Norvig, Chapitre 6), avec 81 variables, des domaines a 9 valeurs et 27 contraintes AllDifferent decomposees en paires. Quatre algorithmes de resolution ont ete implementes et compares : le backtracking simple (2,9 millions d'assignations), le backtracking ameliore avec MRV et LCV (255 assignations), le Forward Checking (81 assignations) et le MAC (81 assignations, 0 backtrack). L'ecart de quatre ordres de grandeur entre le backtracking naif et les methodes avec propagation illustre l'importance cruciale de la reduction des domaines.\n\nL'etude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que theoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces competences vers un autre CSP classique avec des topologies variees.\n\nLe notebook suivant, [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb), explore les strategies de resolution humaines (naked singles, hidden singles) qui s'inspirent des techniques de propagation avancees etudiees ici.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00517,
+     "end_time": "2026-06-01T22:37:34.574701+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T22:37:34.569531+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a formalise le Sudoku comme un probleme de satisfaction de contraintes (CSP) binaire selon le cadre academique AIMA (Russell & Norvig, Chapitre 6), avec 81 variables, des domaines a 9 valeurs et 27 contraintes AllDifferent decomposees en paires. Quatre algorithmes de resolution ont ete implementes et compares : le backtracking simple (2,9 millions d'assignations), le backtracking ameliore avec MRV et LCV (255 assignations), le Forward Checking (81 assignations) et le MAC (81 assignations, 0 backtrack). L'ecart de quatre ordres de grandeur entre le backtracking naif et les methodes avec propagation illustre l'importance cruciale de la reduction des domaines.\n",
+    "\n",
+    "L'etude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que theoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces competences vers un autre CSP classique avec des topologies variees.\n",
+    "\n",
+    "Le notebook suivant, [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb), explore les strategies de resolution humaines (naked singles, hidden singles) qui s'inspirent des techniques de propagation avancees etudiees ici."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ebb356b0",
    "metadata": {
     "papermill": {
-     "duration": 0.004722,
-     "end_time": "2026-04-25T15:02:30.503670",
+     "duration": 0.004821,
+     "end_time": "2026-06-01T22:37:34.584631+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:02:30.498948",
+     "start_time": "2026-06-01T22:37:34.579810+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1914,18 +1975,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 13.075969,
-   "end_time": "2026-04-25T15:02:30.735021",
+   "duration": 16.628229,
+   "end_time": "2026-06-01T22:37:35.053279+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python_output.ipynb",
+   "input_path": "Sudoku-6-AIMA-CSP-Python.ipynb",
+   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\sudoku6-test.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T15:02:17.659052",
+   "start_time": "2026-06-01T22:37:18.425050+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `Sudoku-6-AIMA-CSP-Python.ipynb`.

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `e27d2cc2` | After `1850070a` (ConflictBackjumping class) | "Benchmark CBJ vs autres strategies" |

## Validation proof

- **Papermill**: 36/36 cells executed, 0 errors, kernel=python3
- **execution_count**: All 16 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 247 insertions, 186 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
