### PR TITLE
feat(lean): prove lightCone_zero — P0 sorry eliminated (6→5)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -189,8 +189,9 @@ theorem self_mem_lightCone (p : Int × Int) (t : Nat) : p ∈ lightCone p t := b
     computation — `simp [lightCone]` followed by `decide`, or a direct `List`
     evaluation after `Prod.ext`. -/
 theorem lightCone_zero (p : Int × Int) : lightCone p 0 = [p] := by
-  -- P0 TARGET (easiest): light cone of radius zero — first prover ramp rung
-  sorry
+  simp [lightCone, List.range_succ, List.map_cons, List.map_nil,
+        List.flatMap_cons, List.flatMap_nil, List.filterMap_cons,
+        List.filterMap_nil, Int.natAbs]
 
 /-! ## P2. Light-cone locality (speed of light = 1)
 


### PR DESCRIPTION
## Summary

Eliminates one  from Conway Phase 3b scaffolding ([HashlifeCorrectness.lean](MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean)).

The theorem `lightCone_zero` proves that the light cone of radius 0 is exactly `[p]`. Proof by `simp` with list lemmas:

```lean
theorem lightCone_zero (p : Int × Int) : lightCone p 0 = [p] := by
  simp [lightCone, List.range_succ, List.map_cons, List.map_nil,
        List.flatMap_cons, List.flatMap_nil, List.filterMap_cons,
        List.filterMap_nil, Int.natAbs]
```

## Context

This confirms the BG prover candidate from ai-01's pass (PR #2088 iteration). The prover reported `success=True` at the sub-goal level but `DELTA 0` at the file level — a **verify-vs-recompile discrepancy** in the harness (candidate forensic #1453). Manual verification via `lake build` confirms the proof is correct.

## Verification

- `lake build Conway.Life.HashlifeCorrectness`: **SUCCESS** (3319 jobs)
- `grep -c sorry`: **5** (was 6 — 1 eliminated)
- Conway project total sorry: **5** (all in HashlifeCorrectness.lean)
- No existing proof touched, no regression

## Sorry status after this PR

| # | Theorem | Status |
|---|---------|--------|
| P0 | `self_mem_lightCone` | sorry (warm-up) |
| P0 | `lightCone_zero` | **PROVED** ← this PR |
| P2 | `step_light_cone` | sorry (intermediate) |
| P3 | `padCenter2_correct` | sorry (structural) |
| P4 | `hashlifeResult_central_correct` | sorry (hard) |
| P5 | `hashlife_correct` | sorry (hard) |

## Files

- `Conway/Life/HashlifeCorrectness.lean`: 3 lines changed (+1 proof, -1 sorry, -1 comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
