### PR TITLE
fix(sc-5): correct C3 linearization MRO direction

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -914,7 +914,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "cell-12",
    "metadata": {
     "execution": {
@@ -940,49 +940,11 @@
       "--- Linearisation C3 et super ---\n",
       "Deploye: D a 0xc5a5C42992dECbae36851359345FE25997F5C42d\n",
       "  D.foo() = 'A B C D'\n",
-      "  Ordre de resolution : A -> C -> B -> D => 'A B C D'\n"
+      "  Ordre de resolution : A -> B -> C -> D => 'A B C D'\n"
      ]
     }
    ],
-   "source": [
-    "# Super et linearisation\n",
-    "SUPER_EXAMPLE = \"\"\"\n",
-    "// SPDX-License-Identifier: MIT\n",
-    "pragma solidity ^0.8.28;\n",
-    "\n",
-    "contract A {\n",
-    "    function foo() public pure virtual returns (string memory) {\n",
-    "        return \"A\";\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "contract B is A {\n",
-    "    function foo() public pure virtual override returns (string memory) {\n",
-    "        return string.concat(super.foo(), \" B\");\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "contract C is A {\n",
-    "    function foo() public pure virtual override returns (string memory) {\n",
-    "        return string.concat(super.foo(), \" C\");\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// Linearisation C3 : D -> B -> C -> A\n",
-    "// super dans B appelle C (pas A directement)\n",
-    "contract D is B, C {\n",
-    "    function foo() public pure override(B, C) returns (string memory) {\n",
-    "        return string.concat(super.foo(), \" D\");\n",
-    "    }\n",
-    "}\n",
-    "\"\"\"\n",
-    "\n",
-    "print(\"--- Linearisation C3 et super ---\")\n",
-    "d_contract, _ = deploy_named(w3, SUPER_EXAMPLE, \"D\", deployer)\n",
-    "result = d_contract.functions.foo().call()\n",
-    "print(f\"  D.foo() = '{result}'\")\n",
-    "print(f\"  Ordre de resolution : A -> C -> B -> D => '{result}'\")"
-   ]
+   "source": "# Super et linearisation\nSUPER_EXAMPLE = \"\"\"\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract A {\n    function foo() public pure virtual returns (string memory) {\n        return \"A\";\n    }\n}\n\ncontract B is A {\n    function foo() public pure virtual override returns (string memory) {\n        return string.concat(super.foo(), \" B\");\n    }\n}\n\ncontract C is A {\n    function foo() public pure virtual override returns (string memory) {\n        return string.concat(super.foo(), \" C\");\n    }\n}\n\n// Linearisation C3 : D -> C -> B -> A\n// super dans D appelle C (linearisation right-to-left)\ncontract D is B, C {\n    function foo() public pure override(B, C) returns (string memory) {\n        return string.concat(super.foo(), \" D\");\n    }\n}\n\"\"\"\n\nprint(\"--- Linearisation C3 et super ---\")\nd_contract, _ = deploy_named(w3, SUPER_EXAMPLE, \"D\", deployer)\nresult = d_contract.functions.foo().call()\nprint(f\"  D.foo() = '{result}'\")\nprint(f\"  Ordre de resolution : A -> B -> C -> D => '{result}'\")"
   },
   {
    "cell_type": "markdown",
@@ -997,26 +959,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : linearisation C3 et le probleme du diamant\n",
-    "\n",
-    "**Resultat obtenu** : `D.foo()` retourne `'A B C D'`, ce qui revele l'ordre de resolution : A -> C -> B -> D.\n",
-    "\n",
-    "| Etape | Appel | Resultat partiel |\n",
-    "|-------|-------|-----------------|\n",
-    "| 1 | D.foo() appelle super.foo() | transmet a B (voisin de gauche dans `is B, C`) |\n",
-    "| 2 | B.foo() appelle super.foo() | transmet a C (linearisation) |\n",
-    "| 3 | C.foo() appelle super.foo() | transmet a A |\n",
-    "| 4 | A.foo() retourne \"A\" | remonte la chaine |\n",
-    "| 5 | C concatene \" C\" | \"A C\" |\n",
-    "| 6 | B concatene \" B\" | \"A C B\" |\n",
-    "| 7 | D concatene \" D\" | \"A C B D\" |\n",
-    "\n",
-    "**Points cles** :\n",
-    "- La linearisation C3 garantit un ordre **deterministe** et **monotone** : si X apparait avant Y dans la liste des parents, X restera avant Y dans la linearisation finale\n",
-    "- Le contrat `D is B, C` liste B en premier, mais `super` dans B appelle C (pas A). C'est la linearisation qui decide, pas l'ordre de declaration\n",
-    "- Ce mecanisme resout le **probleme du diamant** (diamond problem) : quand deux parents heritent d'un meme ancetre, la linearisation evite les appels doubles\n"
-   ]
+   "source": "### Interpretation : linearisation C3 et le probleme du diamant\n\n**Resultat obtenu** : `D.foo()` retourne `'A B C D'`, ce qui revele l'ordre de resolution : A -> B -> C -> D.\n\n| Etape | Appel | Resultat partiel |\n|-------|-------|-----------------|\n| 1 | D.foo() appelle super.foo() | transmet a C (MRO : D -> C -> B -> A) |\n| 2 | C.foo() appelle super.foo() | transmet a B |\n| 3 | B.foo() appelle super.foo() | transmet a A |\n| 4 | A.foo() retourne \"A\" | remonte la chaine |\n| 5 | B concatene \" B\" | \"A B\" |\n| 6 | C concatene \" C\" | \"A B C\" |\n| 7 | D concatene \" D\" | \"A B C D\" |\n\n**Points cles** :\n- La linearisation C3 garantit un ordre **deterministe** et **monotone** : si X apparait avant Y dans la liste des parents, X restera avant Y dans la linearisation finale\n- Le contrat `D is B, C` liste B en premier, mais la linearisation C3 traite les bases de **droite a gauche** : le MRO est D, C, B, A. Ainsi `super` dans D appelle C (pas B)\n- Ce mecanisme resout le **probleme du diamant** (diamond problem) : quand deux parents heritent d'un meme ancetre, la linearisation evite les appels doubles"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Fix factual error in SC-5 C3-linearization interpretation (cells 19-20). The markdown table and code comments described the wrong MRO direction for `contract D is B, C`.

## Bug

The interpretation claimed MRO = D->B->C->A (left-to-right), deriving result `A C B D`. But Solidity C3 linearization processes bases **right-to-left**, giving MRO = D, C, B, A. The actual output `A B C D` confirms this.

## Changes

| Cell | Type | Change |
|------|------|--------|
| `cell-12` (code) | Solidity comments + Python print | `D -> B -> C -> A` → `D -> C -> B -> A`; print order `A -> C -> B -> D` → `A -> B -> C -> D` |
| `de1ee2c8` (markdown) | Interpretation table + key points | Steps 1-7 rewritten: super chain is D→C→B→A (not D→B→C→A). Key point now explains right-to-left processing |

## Verification

- Output `D.foo() = 'A B C D'` is preserved (execution_count=7) and consistent with corrected interpretation
- Only source code comments and markdown interpretation changed — no functional code change
- Pattern found during systematic scan for interpretation-vs-output mismatches (per user request)

## Related

- Found during scan for PRs with markdown interpretations contradicting actual outputs