### PR TITLE
enrich(Sudoku-13): insert markdown transition between #!import and exercise stub

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -4600,6 +4600,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "380b7b3b",
+   "source": "### Exercice : Solveur Sudoku X avec contraintes de diagonale\n\nL'environnement de base est charge via `#!import`. Nous disposons maintenant des classes `SymbolicFiniteAutomaton`, `CharSet` et `SudokuSymbolicAutomaton` definies dans les sections precedentes.\n\nL'objectif est d'implementer un **Sudoku X** (ou Sudoku diagonal), variante ou les deux grandes diagonales doivent aussi contenir les chiffres 1 a 9 sans repetition. Cela requiert d'ajouter 2 automates supplementaires (diagonale principale et anti-diagonale) au produit d'automates existant.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "229f0a15",


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `Sudoku-13-SymbolicAutomata-Csharp.ipynb`.

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `380b7b3b` | After `0fafda49` (#!import) | "Exercice : Solveur Sudoku X avec contraintes de diagonale" |

## Validation proof

- **Convention C.3**: .NET notebook with `#!import` -- markdown-only insert, previous outputs preserved
- **execution_count**: All 12 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **0 consecutive code pairs remaining** (was 1)

## Scope

- 1 file changed, 7 insertions, 1 deletion
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, outputs preserved