### PR TITLE
enrich(SymbolicLearning): insert 2 transition cells in SL-7-LLM-SymbolicLearning

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "097196f2",
    "metadata": {
     "papermill": {
-     "duration": 0.013213,
-     "end_time": "2026-05-27T16:55:06.444219+00:00",
+     "duration": 0.007447,
+     "end_time": "2026-06-01T22:52:50.687740+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.431006+00:00",
+     "start_time": "2026-06-01T22:52:50.680293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "3dc32d19",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.466082Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.465882Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.471846Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.471149Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.703434Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.702934Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.714117Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.712910Z"
     },
     "papermill": {
-     "duration": 0.014376,
-     "end_time": "2026-05-27T16:55:06.472584+00:00",
+     "duration": 0.020117,
+     "end_time": "2026-06-01T22:52:50.715587+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.458208+00:00",
+     "start_time": "2026-06-01T22:52:50.695470+00:00",
      "status": "completed"
     },
     "tags": []
@@ -99,10 +99,10 @@
    "id": "23731406",
    "metadata": {
     "papermill": {
-     "duration": 0.003329,
-     "end_time": "2026-05-27T16:55:06.479196+00:00",
+     "duration": 0.005283,
+     "end_time": "2026-06-01T22:52:50.726416+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.475867+00:00",
+     "start_time": "2026-06-01T22:52:50.721133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "f1d96718",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.487156Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.486882Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.490994Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.490352Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.738328Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.737917Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.744315Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.743104Z"
     },
     "papermill": {
-     "duration": 0.00843,
-     "end_time": "2026-05-27T16:55:06.491606+00:00",
+     "duration": 0.013568,
+     "end_time": "2026-06-01T22:52:50.745141+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.483176+00:00",
+     "start_time": "2026-06-01T22:52:50.731573+00:00",
      "status": "completed"
     },
     "tags": []
@@ -204,10 +204,10 @@
    "id": "3827f67e",
    "metadata": {
     "papermill": {
-     "duration": 0.002609,
-     "end_time": "2026-05-27T16:55:06.497517+00:00",
+     "duration": 0.007038,
+     "end_time": "2026-06-01T22:52:50.758373+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.494908+00:00",
+     "start_time": "2026-06-01T22:52:50.751335+00:00",
      "status": "completed"
     },
     "tags": []
@@ -229,10 +229,10 @@
    "id": "59e172f2",
    "metadata": {
     "papermill": {
-     "duration": 0.003293,
-     "end_time": "2026-05-27T16:55:06.504506+00:00",
+     "duration": 0.005529,
+     "end_time": "2026-06-01T22:52:50.770577+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.501213+00:00",
+     "start_time": "2026-06-01T22:52:50.765048+00:00",
      "status": "completed"
     },
     "tags": []
@@ -267,16 +267,16 @@
    "id": "581df035",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.511775Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.511594Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.518188Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.517497Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.784872Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.784585Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.795472Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.794204Z"
     },
     "papermill": {
-     "duration": 0.011732,
-     "end_time": "2026-05-27T16:55:06.518777+00:00",
+     "duration": 0.019856,
+     "end_time": "2026-06-01T22:52:50.796503+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.507045+00:00",
+     "start_time": "2026-06-01T22:52:50.776647+00:00",
      "status": "completed"
     },
     "tags": []
@@ -342,21 +342,47 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "72e21fc7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005619,
+     "end_time": "2026-06-01T22:52:50.807898+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T22:52:50.802279+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Construction du prompt de generation de regles\n",
+    "\n",
+    "Le domaine etant defini avec ses 12 exemples et 10 attributs, l'etape suivante consiste a construire un **prompt structure** qui sera soumis au LLM pour qu'il genere des hypotheses. Ce prompt suit un format systematique :\n",
+    "\n",
+    "1. **Role** : \"Tu es un expert en apprentissage symbolique\" (guidage du comportement)\n",
+    "2. **Contexte** : les attributs disponibles et la cible (`WillWait`)\n",
+    "3. **Exemples** : les cas positifs et negatifs presentes ligne par ligne\n",
+    "4. **Format attendu** : clauses de Horn (`condition1 AND condition2 => WillWait`)\n",
+    "\n",
+    "En pratique avec un vrai LLM, la qualite du prompt determine directement la qualite des hypotheses generees."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "eed948cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.525909Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.525673Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.530034Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.529546Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.820474Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.820030Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.827814Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.826620Z"
     },
     "papermill": {
-     "duration": 0.00861,
-     "end_time": "2026-05-27T16:55:06.530593+00:00",
+     "duration": 0.015382,
+     "end_time": "2026-06-01T22:52:50.828666+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.521983+00:00",
+     "start_time": "2026-06-01T22:52:50.813284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -446,10 +472,10 @@
    "id": "85c22afd",
    "metadata": {
     "papermill": {
-     "duration": 0.002865,
-     "end_time": "2026-05-27T16:55:06.536394+00:00",
+     "duration": 0.006991,
+     "end_time": "2026-06-01T22:52:50.841693+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.533529+00:00",
+     "start_time": "2026-06-01T22:52:50.834702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -468,16 +494,16 @@
    "id": "1c109513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.542967Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.542794Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.548545Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.548043Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.859034Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.858528Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.872304Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.871251Z"
     },
     "papermill": {
-     "duration": 0.009868,
-     "end_time": "2026-05-27T16:55:06.549113+00:00",
+     "duration": 0.02674,
+     "end_time": "2026-06-01T22:52:50.874039+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.539245+00:00",
+     "start_time": "2026-06-01T22:52:50.847299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -589,10 +615,10 @@
    "id": "bf930a24",
    "metadata": {
     "papermill": {
-     "duration": 0.003286,
-     "end_time": "2026-05-27T16:55:06.558104+00:00",
+     "duration": 0.007617,
+     "end_time": "2026-06-01T22:52:50.889657+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.554818+00:00",
+     "start_time": "2026-06-01T22:52:50.882040+00:00",
      "status": "completed"
     },
     "tags": []
@@ -623,10 +649,10 @@
    "id": "d6bb9fe1",
    "metadata": {
     "papermill": {
-     "duration": 0.003732,
-     "end_time": "2026-05-27T16:55:06.565387+00:00",
+     "duration": 0.007695,
+     "end_time": "2026-06-01T22:52:50.904572+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.561655+00:00",
+     "start_time": "2026-06-01T22:52:50.896877+00:00",
      "status": "completed"
     },
     "tags": []
@@ -653,16 +679,16 @@
    "id": "2c0873ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.573394Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.573179Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.581556Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.580977Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.920797Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.920336Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.933144Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.931941Z"
     },
     "papermill": {
-     "duration": 0.01401,
-     "end_time": "2026-05-27T16:55:06.582322+00:00",
+     "duration": 0.022398,
+     "end_time": "2026-06-01T22:52:50.934136+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.568312+00:00",
+     "start_time": "2026-06-01T22:52:50.911738+00:00",
      "status": "completed"
     },
     "tags": []
@@ -784,10 +810,10 @@
    "id": "0f9984a1",
    "metadata": {
     "papermill": {
-     "duration": 0.003203,
-     "end_time": "2026-05-27T16:55:06.588869+00:00",
+     "duration": 0.006224,
+     "end_time": "2026-06-01T22:52:50.946527+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.585666+00:00",
+     "start_time": "2026-06-01T22:52:50.940303+00:00",
      "status": "completed"
     },
     "tags": []
@@ -819,16 +845,16 @@
    "id": "9a30e01b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.596464Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.596276Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.601248Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.600655Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.961094Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.960673Z",
+     "iopub.status.idle": "2026-06-01T22:52:50.968453Z",
+     "shell.execute_reply": "2026-06-01T22:52:50.967416Z"
     },
     "papermill": {
-     "duration": 0.009732,
-     "end_time": "2026-05-27T16:55:06.601903+00:00",
+     "duration": 0.016287,
+     "end_time": "2026-06-01T22:52:50.969393+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.592171+00:00",
+     "start_time": "2026-06-01T22:52:50.953106+00:00",
      "status": "completed"
     },
     "tags": []
@@ -911,10 +937,10 @@
    "id": "74c02d03",
    "metadata": {
     "papermill": {
-     "duration": 0.003046,
-     "end_time": "2026-05-27T16:55:06.610040+00:00",
+     "duration": 0.005777,
+     "end_time": "2026-06-01T22:52:50.981098+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.606994+00:00",
+     "start_time": "2026-06-01T22:52:50.975321+00:00",
      "status": "completed"
     },
     "tags": []
@@ -950,16 +976,16 @@
    "id": "83e5f5eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.617925Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.617741Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.626479Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.625814Z"
+     "iopub.execute_input": "2026-06-01T22:52:50.997548Z",
+     "iopub.status.busy": "2026-06-01T22:52:50.997051Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.013646Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.012459Z"
     },
     "papermill": {
-     "duration": 0.013813,
-     "end_time": "2026-05-27T16:55:06.627066+00:00",
+     "duration": 0.026495,
+     "end_time": "2026-06-01T22:52:51.014481+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.613253+00:00",
+     "start_time": "2026-06-01T22:52:50.987986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1124,10 +1150,10 @@
    "id": "3653b321",
    "metadata": {
     "papermill": {
-     "duration": 0.003224,
-     "end_time": "2026-05-27T16:55:06.633538+00:00",
+     "duration": 0.006609,
+     "end_time": "2026-06-01T22:52:51.027835+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.630314+00:00",
+     "start_time": "2026-06-01T22:52:51.021226+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,16 +1180,16 @@
    "id": "dc08268f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.650749Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.650578Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.655274Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.654752Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.043580Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.043088Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.052412Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.051095Z"
     },
     "papermill": {
-     "duration": 0.019017,
-     "end_time": "2026-05-27T16:55:06.655786+00:00",
+     "duration": 0.018937,
+     "end_time": "2026-06-01T22:52:51.053626+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.636769+00:00",
+     "start_time": "2026-06-01T22:52:51.034689+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1239,10 +1265,10 @@
    "id": "a575226a",
    "metadata": {
     "papermill": {
-     "duration": 0.003577,
-     "end_time": "2026-05-27T16:55:06.662945+00:00",
+     "duration": 0.006731,
+     "end_time": "2026-06-01T22:52:51.067758+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.659368+00:00",
+     "start_time": "2026-06-01T22:52:51.061027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1268,10 +1294,10 @@
    "id": "1bd557a0",
    "metadata": {
     "papermill": {
-     "duration": 0.003548,
-     "end_time": "2026-05-27T16:55:06.670050+00:00",
+     "duration": 0.007027,
+     "end_time": "2026-06-01T22:52:51.081847+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.666502+00:00",
+     "start_time": "2026-06-01T22:52:51.074820+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1311,16 +1337,16 @@
    "id": "f9d67f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.677435Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.677252Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.686093Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.685276Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.100013Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.099567Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.116040Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.114779Z"
     },
     "papermill": {
-     "duration": 0.013487,
-     "end_time": "2026-05-27T16:55:06.686605+00:00",
+     "duration": 0.027557,
+     "end_time": "2026-06-01T22:52:51.117242+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.673118+00:00",
+     "start_time": "2026-06-01T22:52:51.089685+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1451,21 +1477,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2f9d2c01",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005961,
+     "end_time": "2026-06-01T22:52:51.130158+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T22:52:51.124197+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Execution du pipeline avec Chain-of-Thought\n",
+    "\n",
+    "Le pipeline `NeuroSymbolicPipeline` ci-dessus a ete execute **sans** l'option Chain-of-Thought. Activons maintenant le CoT pour observer comment les traces de raisonnement enrichissent le pool de candidats :\n",
+    "\n",
+    "- **Sans CoT** : seules les 5 regles simulees par `simulate_llm_response()` sont candidates\n",
+    "- **Avec CoT** : 3 regles supplementaires sont extraites des traces de raisonnement sur les exemples positifs, portant le total a 8 candidates\n",
+    "\n",
+    "Cette comparaison illustre le gain qualitatif du CoT : les regles extraites des traces sont ancrees dans des exemples concrets, tandis que les regles globales risquent davantage d'etre des sur-generalisations."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "8917b738",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.694033Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.693849Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.698447Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.697819Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.144132Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.143727Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.149196Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.148200Z"
     },
     "papermill": {
-     "duration": 0.009012,
-     "end_time": "2026-05-27T16:55:06.699052+00:00",
+     "duration": 0.013849,
+     "end_time": "2026-06-01T22:52:51.150239+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.690040+00:00",
+     "start_time": "2026-06-01T22:52:51.136390+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1515,10 +1565,10 @@
    "id": "a2edb6e2",
    "metadata": {
     "papermill": {
-     "duration": 0.003097,
-     "end_time": "2026-05-27T16:55:06.705264+00:00",
+     "duration": 0.005892,
+     "end_time": "2026-06-01T22:52:51.165652+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.702167+00:00",
+     "start_time": "2026-06-01T22:52:51.159760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1547,16 +1597,16 @@
    "id": "54a6b7c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.712732Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.712556Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.717633Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.717108Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.180575Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.180165Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.187961Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.186779Z"
     },
     "papermill": {
-     "duration": 0.010028,
-     "end_time": "2026-05-27T16:55:06.718349+00:00",
+     "duration": 0.016997,
+     "end_time": "2026-06-01T22:52:51.188827+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.708321+00:00",
+     "start_time": "2026-06-01T22:52:51.171830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1617,10 +1667,10 @@
    "id": "d74db354",
    "metadata": {
     "papermill": {
-     "duration": 0.003731,
-     "end_time": "2026-05-27T16:55:06.725365+00:00",
+     "duration": 0.007055,
+     "end_time": "2026-06-01T22:52:51.202887+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.721634+00:00",
+     "start_time": "2026-06-01T22:52:51.195832+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1644,10 +1694,10 @@
    "id": "3c2e7728",
    "metadata": {
     "papermill": {
-     "duration": 0.003325,
-     "end_time": "2026-05-27T16:55:06.731830+00:00",
+     "duration": 0.006317,
+     "end_time": "2026-06-01T22:52:51.215922+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.728505+00:00",
+     "start_time": "2026-06-01T22:52:51.209605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1672,16 +1722,16 @@
    "id": "dada4cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.739489Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.739298Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.747020Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.746410Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.230170Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.229717Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.241262Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.240139Z"
     },
     "papermill": {
-     "duration": 0.012578,
-     "end_time": "2026-05-27T16:55:06.747615+00:00",
+     "duration": 0.020018,
+     "end_time": "2026-06-01T22:52:51.242195+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.735037+00:00",
+     "start_time": "2026-06-01T22:52:51.222177+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1807,10 +1857,10 @@
    "id": "3cc1a67b",
    "metadata": {
     "papermill": {
-     "duration": 0.003156,
-     "end_time": "2026-05-27T16:55:06.753931+00:00",
+     "duration": 0.00585,
+     "end_time": "2026-06-01T22:52:51.254252+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.750775+00:00",
+     "start_time": "2026-06-01T22:52:51.248402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1838,10 +1888,10 @@
    "id": "ba9beb92",
    "metadata": {
     "papermill": {
-     "duration": 0.003001,
-     "end_time": "2026-05-27T16:55:06.760348+00:00",
+     "duration": 0.005956,
+     "end_time": "2026-06-01T22:52:51.266112+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.757347+00:00",
+     "start_time": "2026-06-01T22:52:51.260156+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1857,10 +1907,10 @@
    "id": "3c800f32",
    "metadata": {
     "papermill": {
-     "duration": 0.003077,
-     "end_time": "2026-05-27T16:55:06.766699+00:00",
+     "duration": 0.008558,
+     "end_time": "2026-06-01T22:52:51.280503+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.763622+00:00",
+     "start_time": "2026-06-01T22:52:51.271945+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1883,16 +1933,16 @@
    "id": "5101d0d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.774256Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.774081Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.777856Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.777352Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.296965Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.296542Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.302716Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.301645Z"
     },
     "papermill": {
-     "duration": 0.00817,
-     "end_time": "2026-05-27T16:55:06.778338+00:00",
+     "duration": 0.014962,
+     "end_time": "2026-06-01T22:52:51.303582+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.770168+00:00",
+     "start_time": "2026-06-01T22:52:51.288620+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1939,10 +1989,10 @@
    "id": "2936e442",
    "metadata": {
     "papermill": {
-     "duration": 0.003577,
-     "end_time": "2026-05-27T16:55:06.784986+00:00",
+     "duration": 0.006039,
+     "end_time": "2026-06-01T22:52:51.315913+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.781409+00:00",
+     "start_time": "2026-06-01T22:52:51.309874+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1964,16 +2014,16 @@
    "id": "174aa8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.792428Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.792256Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.795473Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.794992Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.329923Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.329509Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.334745Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.333704Z"
     },
     "papermill": {
-     "duration": 0.007708,
-     "end_time": "2026-05-27T16:55:06.796043+00:00",
+     "duration": 0.013427,
+     "end_time": "2026-06-01T22:52:51.335602+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.788335+00:00",
+     "start_time": "2026-06-01T22:52:51.322175+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2017,10 +2067,10 @@
    "id": "0962260b",
    "metadata": {
     "papermill": {
-     "duration": 0.003126,
-     "end_time": "2026-05-27T16:55:06.802454+00:00",
+     "duration": 0.006344,
+     "end_time": "2026-06-01T22:52:51.348367+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.799328+00:00",
+     "start_time": "2026-06-01T22:52:51.342023+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2042,16 +2092,16 @@
    "id": "3548d43c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T16:55:06.809642Z",
-     "iopub.status.busy": "2026-05-27T16:55:06.809477Z",
-     "iopub.status.idle": "2026-05-27T16:55:06.813948Z",
-     "shell.execute_reply": "2026-05-27T16:55:06.813456Z"
+     "iopub.execute_input": "2026-06-01T22:52:51.364249Z",
+     "iopub.status.busy": "2026-06-01T22:52:51.363741Z",
+     "iopub.status.idle": "2026-06-01T22:52:51.371348Z",
+     "shell.execute_reply": "2026-06-01T22:52:51.370223Z"
     },
     "papermill": {
-     "duration": 0.009094,
-     "end_time": "2026-05-27T16:55:06.814595+00:00",
+     "duration": 0.016956,
+     "end_time": "2026-06-01T22:52:51.372374+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.805501+00:00",
+     "start_time": "2026-06-01T22:52:51.355418+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2116,10 +2166,10 @@
    "id": "7cb00ad4",
    "metadata": {
     "papermill": {
-     "duration": 0.00297,
-     "end_time": "2026-05-27T16:55:06.821084+00:00",
+     "duration": 0.007538,
+     "end_time": "2026-06-01T22:52:51.388572+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.818114+00:00",
+     "start_time": "2026-06-01T22:52:51.381034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2171,10 +2221,10 @@
    "id": "b2e6b9c6",
    "metadata": {
     "papermill": {
-     "duration": 0.003315,
-     "end_time": "2026-05-27T16:55:06.827307+00:00",
+     "duration": 0.006301,
+     "end_time": "2026-06-01T22:52:51.402166+00:00",
      "exception": false,
-     "start_time": "2026-05-27T16:55:06.823992+00:00",
+     "start_time": "2026-06-01T22:52:51.395865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2212,18 +2262,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.237346,
-   "end_time": "2026-05-27T16:55:06.960291+00:00",
+   "duration": 5.544179,
+   "end_time": "2026-06-01T22:52:51.869142+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-7-LLM-SymbolicLearning.ipynb",
-   "output_path": "SL-7-executed.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-7-LLM-SymbolicLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-27T16:55:04.722945+00:00",
+   "start_time": "2026-06-01T22:52:46.324963+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 2 markdown transition cells between consecutive code pairs in `SL-7-LLM-SymbolicLearning.ipynb`.

### Cells inserted (bottom-to-top)
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `72e21fc7` | After `581df035` (ATTRIBUTES domain definition) | "Construction du prompt de generation de regles" |
| 2 | `2f9d2c01` | After `f9d67f71` (NeuroSymbolicPipeline class) | "Execution du pipeline avec Chain-of-Thought" |

## Validation proof

- **Papermill**: 40/40 cells executed, 0 errors, kernel=python3
- **execution_count**: All 16 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 2 markdown cells inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 234 insertions, 184 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid