### PR TITLE
feat(sc3): consolidate 2 exercises to Exemple guides + new stubs

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -5,10 +5,10 @@
    "id": "32be0c30",
    "metadata": {
     "papermill": {
-     "duration": 0.003301,
-     "end_time": "2026-05-26T19:16:38.062659",
+     "duration": 0.008167,
+     "end_time": "2026-06-01T22:56:01.750043",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.059358",
+     "start_time": "2026-06-01T22:56:01.741876",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "web3-setup-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.00247,
-     "end_time": "2026-05-26T19:16:38.067984",
+     "duration": 0.003611,
+     "end_time": "2026-06-01T22:56:01.757657",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.065514",
+     "start_time": "2026-06-01T22:56:01.754046",
      "status": "completed"
     },
     "tags": []
@@ -60,20 +60,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "web3-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:38.074124Z",
-     "iopub.status.busy": "2026-05-26T19:16:38.073800Z",
-     "iopub.status.idle": "2026-05-26T19:16:38.716496Z",
-     "shell.execute_reply": "2026-05-26T19:16:38.715643Z"
+     "iopub.execute_input": "2026-06-01T22:56:01.770822Z",
+     "iopub.status.busy": "2026-06-01T22:56:01.770567Z",
+     "iopub.status.idle": "2026-06-01T22:56:02.486192Z",
+     "shell.execute_reply": "2026-06-01T22:56:02.484029Z"
     },
     "papermill": {
-     "duration": 0.646936,
-     "end_time": "2026-05-26T19:16:38.717476",
+     "duration": 0.726719,
+     "end_time": "2026-06-01T22:56:02.488282",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.070540",
+     "start_time": "2026-06-01T22:56:01.761563",
      "status": "completed"
     },
     "tags": []
@@ -137,10 +137,10 @@
    "id": "92d66063",
    "metadata": {
     "papermill": {
-     "duration": 0.003246,
-     "end_time": "2026-05-26T19:16:38.724164",
+     "duration": 0.002892,
+     "end_time": "2026-06-01T22:56:02.494109",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.720918",
+     "start_time": "2026-06-01T22:56:02.491217",
      "status": "completed"
     },
     "tags": []
@@ -171,20 +171,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "2512bcfe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:38.731771Z",
-     "iopub.status.busy": "2026-05-26T19:16:38.731397Z",
-     "iopub.status.idle": "2026-05-26T19:16:38.788953Z",
-     "shell.execute_reply": "2026-05-26T19:16:38.788324Z"
+     "iopub.execute_input": "2026-06-01T22:56:02.503922Z",
+     "iopub.status.busy": "2026-06-01T22:56:02.503709Z",
+     "iopub.status.idle": "2026-06-01T22:56:02.950664Z",
+     "shell.execute_reply": "2026-06-01T22:56:02.950134Z"
     },
     "papermill": {
-     "duration": 0.062641,
-     "end_time": "2026-05-26T19:16:38.789911",
+     "duration": 0.453494,
+     "end_time": "2026-06-01T22:56:02.951607",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.727270",
+     "start_time": "2026-06-01T22:56:02.498113",
      "status": "completed"
     },
     "tags": []
@@ -194,7 +194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: Counter a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n"
+      "Deploye: Counter a 0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1\n"
      ]
     }
    ],
@@ -227,10 +227,10 @@
    "id": "bc4013f3",
    "metadata": {
     "papermill": {
-     "duration": 0.00328,
-     "end_time": "2026-05-26T19:16:38.798887",
+     "duration": 0.003438,
+     "end_time": "2026-06-01T22:56:02.958091",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.795607",
+     "start_time": "2026-06-01T22:56:02.954653",
      "status": "completed"
     },
     "tags": []
@@ -245,20 +245,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "470cc7c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:38.807287Z",
-     "iopub.status.busy": "2026-05-26T19:16:38.806984Z",
-     "iopub.status.idle": "2026-05-26T19:16:38.902707Z",
-     "shell.execute_reply": "2026-05-26T19:16:38.902169Z"
+     "iopub.execute_input": "2026-06-01T22:56:02.965888Z",
+     "iopub.status.busy": "2026-06-01T22:56:02.965680Z",
+     "iopub.status.idle": "2026-06-01T22:56:04.328658Z",
+     "shell.execute_reply": "2026-06-01T22:56:04.327931Z"
     },
     "papermill": {
-     "duration": 0.101608,
-     "end_time": "2026-05-26T19:16:38.903884",
+     "duration": 1.36797,
+     "end_time": "2026-06-01T22:56:04.329999",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.802276",
+     "start_time": "2026-06-01T22:56:02.962029",
      "status": "completed"
     },
     "tags": []
@@ -268,12 +268,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Booleens: bool (true/false), && (and), || (or), ! (not) ---\n",
-      "Deploye: BoolExample a 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512\n",
-      "  Deploye : 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512\n",
-      "  isActive = True\n",
+      "--- Booleens: bool (true/false), && (and), || (or), ! (not) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: BoolExample a 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE\n",
+      "  Deploye : 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE\n",
+      "  isActive = True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Apres toggle() : False\n",
-      "  True && False = False\n",
+      "  True && False = False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  True || False = True\n"
      ]
     }
@@ -321,10 +339,10 @@
    "id": "ee580d1f",
    "metadata": {
     "papermill": {
-     "duration": 0.003332,
-     "end_time": "2026-05-26T19:16:38.910945",
+     "duration": 0.003301,
+     "end_time": "2026-06-01T22:56:04.338920",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.907613",
+     "start_time": "2026-06-01T22:56:04.335619",
      "status": "completed"
     },
     "tags": []
@@ -351,10 +369,10 @@
    "id": "7a3ff246",
    "metadata": {
     "papermill": {
-     "duration": 0.003187,
-     "end_time": "2026-05-26T19:16:38.917451",
+     "duration": 0.005843,
+     "end_time": "2026-06-01T22:56:04.350132",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.914264",
+     "start_time": "2026-06-01T22:56:04.344289",
      "status": "completed"
     },
     "tags": []
@@ -365,20 +383,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "c45e972c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:38.925881Z",
-     "iopub.status.busy": "2026-05-26T19:16:38.925380Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.001145Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.000444Z"
+     "iopub.execute_input": "2026-06-01T22:56:04.364987Z",
+     "iopub.status.busy": "2026-06-01T22:56:04.364404Z",
+     "iopub.status.idle": "2026-06-01T22:56:05.379488Z",
+     "shell.execute_reply": "2026-06-01T22:56:05.377862Z"
     },
     "papermill": {
-     "duration": 0.080831,
-     "end_time": "2026-05-26T19:16:39.002106",
+     "duration": 1.024554,
+     "end_time": "2026-06-01T22:56:05.380929",
      "exception": false,
-     "start_time": "2026-05-26T19:16:38.921275",
+     "start_time": "2026-06-01T22:56:04.356375",
      "status": "completed"
     },
     "tags": []
@@ -388,12 +406,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Entiers: uint8, uint256, int8, int256 (signes/non signes) ---\n",
-      "Deploye: IntExample a 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\n",
-      "  Deploye : 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\n",
-      "  add(100, 200) = 300\n",
+      "--- Entiers: uint8, uint256, int8, int256 (signes/non signes) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: IntExample a 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c\n",
+      "  Deploye : 0x3Aa5ebB10DC797CAC828524e59A333d0A371443c\n",
+      "  add(100, 200) = 300\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  subtract(10, 3) = 7\n",
-      "  multiply(7, 6) = 42\n",
+      "  multiply(7, 6) = 42\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  modulo(17, 5) = 2\n"
      ]
     }
@@ -446,10 +482,10 @@
    "id": "2d430aab",
    "metadata": {
     "papermill": {
-     "duration": 0.003175,
-     "end_time": "2026-05-26T19:16:39.008782",
+     "duration": 0.00348,
+     "end_time": "2026-06-01T22:56:05.389883",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.005607",
+     "start_time": "2026-06-01T22:56:05.386403",
      "status": "completed"
     },
     "tags": []
@@ -478,10 +514,10 @@
    "id": "4084956c",
    "metadata": {
     "papermill": {
-     "duration": 0.003256,
-     "end_time": "2026-05-26T19:16:39.015345",
+     "duration": 0.002564,
+     "end_time": "2026-06-01T22:56:05.395069",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.012089",
+     "start_time": "2026-06-01T22:56:05.392505",
      "status": "completed"
     },
     "tags": []
@@ -492,20 +528,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "d833b35a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.024212Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.023836Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.111111Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.110287Z"
+     "iopub.execute_input": "2026-06-01T22:56:05.401966Z",
+     "iopub.status.busy": "2026-06-01T22:56:05.401732Z",
+     "iopub.status.idle": "2026-06-01T22:56:06.293198Z",
+     "shell.execute_reply": "2026-06-01T22:56:06.288387Z"
     },
     "papermill": {
-     "duration": 0.094164,
-     "end_time": "2026-05-26T19:16:39.113033",
+     "duration": 0.905335,
+     "end_time": "2026-06-01T22:56:06.303052",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.018869",
+     "start_time": "2026-06-01T22:56:05.397717",
      "status": "completed"
     },
     "tags": []
@@ -515,13 +551,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Adresses: address (20 octets), address payable (transfert ETH) ---\n",
-      "Deploye: AddressExample a 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9\n",
-      "  Deploye : 0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9\n",
+      "--- Adresses: address (20 octets), address payable (transfert ETH) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: AddressExample a 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d\n",
+      "  Deploye : 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d\n",
       "  owner = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
-      "  deployer = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
+      "  deployer = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  owner == deployer : True\n",
-      "  balance(deployer) = 10000.00 ETH\n"
+      "  balance(deployer) = 9999.99 ETH\n"
      ]
     }
    ],
@@ -566,10 +614,10 @@
    "id": "76c02140",
    "metadata": {
     "papermill": {
-     "duration": 0.007151,
-     "end_time": "2026-05-26T19:16:39.126035",
+     "duration": 0.003395,
+     "end_time": "2026-06-01T22:56:06.312774",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.118884",
+     "start_time": "2026-06-01T22:56:06.309379",
      "status": "completed"
     },
     "tags": []
@@ -597,10 +645,10 @@
    "id": "e6c05c03",
    "metadata": {
     "papermill": {
-     "duration": 0.006374,
-     "end_time": "2026-05-26T19:16:39.138593",
+     "duration": 0.002857,
+     "end_time": "2026-06-01T22:56:06.320773",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.132219",
+     "start_time": "2026-06-01T22:56:06.317916",
      "status": "completed"
     },
     "tags": []
@@ -615,16 +663,16 @@
    "id": "4a799a26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.154426Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.153734Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.272761Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.272125Z"
+     "iopub.execute_input": "2026-06-01T22:56:06.328561Z",
+     "iopub.status.busy": "2026-06-01T22:56:06.328282Z",
+     "iopub.status.idle": "2026-06-01T22:56:07.708113Z",
+     "shell.execute_reply": "2026-06-01T22:56:07.707420Z"
     },
     "papermill": {
-     "duration": 0.128681,
-     "end_time": "2026-05-26T19:16:39.273698",
+     "duration": 1.385933,
+     "end_time": "2026-06-01T22:56:07.709737",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.145017",
+     "start_time": "2026-06-01T22:56:06.323804",
      "status": "completed"
     },
     "tags": []
@@ -634,17 +682,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Bytes/String: bytes32 (fixe), bytes (dynamique), string (UTF-8) ---\n",
-      "Deploye: BytesExample a 0x0B306BF915C4d645ff596e518fAf3F9669b97016\n",
-      "  Deploye : 0x0B306BF915C4d645ff596e518fAf3F9669b97016\n"
+      "--- Bytes/String: bytes32 (fixe), bytes (dynamique), string (UTF-8) ---\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  message = 'Hello Solidity'\n",
-      "  getLength() = 14\n",
+      "Deploye: BytesExample a 0x59b670e9fA9D0A427751Af201D676719a970857b\n",
+      "  Deploye : 0x59b670e9fA9D0A427751Af201D676719a970857b\n",
+      "  message = 'Hello Solidity'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  getLength() = 14\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Apres setMessage : 'Solidity rocks!'\n",
       "  concatenate('Hello', ' World') = 'Hello World'\n"
      ]
@@ -695,10 +755,10 @@
    "id": "7ddaf0ca",
    "metadata": {
     "papermill": {
-     "duration": 0.00642,
-     "end_time": "2026-05-26T19:16:39.284087",
+     "duration": 0.006016,
+     "end_time": "2026-06-01T22:56:07.724355",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.277667",
+     "start_time": "2026-06-01T22:56:07.718339",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +786,10 @@
    "id": "5c705d32",
    "metadata": {
     "papermill": {
-     "duration": 0.003445,
-     "end_time": "2026-05-26T19:16:39.292703",
+     "duration": 0.004722,
+     "end_time": "2026-06-01T22:56:07.734874",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.289258",
+     "start_time": "2026-06-01T22:56:07.730152",
      "status": "completed"
     },
     "tags": []
@@ -748,16 +808,16 @@
    "id": "e1dec068",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.302273Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.301836Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.399880Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.399232Z"
+     "iopub.execute_input": "2026-06-01T22:56:07.744605Z",
+     "iopub.status.busy": "2026-06-01T22:56:07.744215Z",
+     "iopub.status.idle": "2026-06-01T22:56:09.099890Z",
+     "shell.execute_reply": "2026-06-01T22:56:09.099353Z"
     },
     "papermill": {
-     "duration": 0.104691,
-     "end_time": "2026-05-26T19:16:39.401045",
+     "duration": 1.361777,
+     "end_time": "2026-06-01T22:56:09.100970",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.296354",
+     "start_time": "2026-06-01T22:56:07.739193",
      "status": "completed"
     },
     "tags": []
@@ -767,12 +827,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Variables d'etat : persistees sur la blockchain entre les appels ---\n",
-      "Deploye: StateVariables a 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707\n",
-      "  Deploye : 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707\n",
-      "  storedData = 42\n",
+      "--- Variables d'etat : persistees sur la blockchain entre les appels ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: StateVariables a 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44\n",
+      "  Deploye : 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44\n",
+      "  storedData = 42\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  owner = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
-      "  isInitialized() = True\n",
+      "  isInitialized() = True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  Apres setData(100) : storedData = 100\n"
      ]
     }
@@ -825,10 +903,10 @@
    "id": "66819446",
    "metadata": {
     "papermill": {
-     "duration": 0.006368,
-     "end_time": "2026-05-26T19:16:39.413541",
+     "duration": 0.003038,
+     "end_time": "2026-06-01T22:56:09.109508",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.407173",
+     "start_time": "2026-06-01T22:56:09.106470",
      "status": "completed"
     },
     "tags": []
@@ -856,10 +934,10 @@
    "id": "81046cc6",
    "metadata": {
     "papermill": {
-     "duration": 0.006647,
-     "end_time": "2026-05-26T19:16:39.427096",
+     "duration": 0.003924,
+     "end_time": "2026-06-01T22:56:09.117367",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.420449",
+     "start_time": "2026-06-01T22:56:09.113443",
      "status": "completed"
     },
     "tags": []
@@ -874,16 +952,16 @@
    "id": "8052eb2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.440972Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.440463Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.538200Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.537209Z"
+     "iopub.execute_input": "2026-06-01T22:56:09.126603Z",
+     "iopub.status.busy": "2026-06-01T22:56:09.126205Z",
+     "iopub.status.idle": "2026-06-01T22:56:10.390958Z",
+     "shell.execute_reply": "2026-06-01T22:56:10.389958Z"
     },
     "papermill": {
-     "duration": 0.107089,
-     "end_time": "2026-05-26T19:16:39.539918",
+     "duration": 1.272282,
+     "end_time": "2026-06-01T22:56:10.393756",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.432829",
+     "start_time": "2026-06-01T22:56:09.121474",
      "status": "completed"
     },
     "tags": []
@@ -893,10 +971,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Variables locales : temporaires, en memoire (non stockees) ---\n",
-      "Deploye: LocalVariables a 0xa513E6E4b8f2a923D98304ec87F64353C4D5C853\n",
-      "  Deploye : 0xa513E6E4b8f2a923D98304ec87F64353C4D5C853\n",
-      "  calculate(3, 4) = 19\n",
+      "--- Variables locales : temporaires, en memoire (non stockees) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: LocalVariables a 0x4A679253410272dd5232B3Ff7cF5dbB88f295319\n",
+      "  Deploye : 0x4A679253410272dd5232B3Ff7cF5dbB88f295319\n",
+      "  calculate(3, 4) = 19\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "  result sur la blockchain = 19\n",
       "  computeOnly(5, 6) : sum=11, product=30 (pas stocke)\n"
      ]
@@ -944,10 +1034,10 @@
    "id": "a997e432",
    "metadata": {
     "papermill": {
-     "duration": 0.007584,
-     "end_time": "2026-05-26T19:16:39.555157",
+     "duration": 0.004528,
+     "end_time": "2026-06-01T22:56:10.409083",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.547573",
+     "start_time": "2026-06-01T22:56:10.404555",
      "status": "completed"
     },
     "tags": []
@@ -975,10 +1065,10 @@
    "id": "71a21c01",
    "metadata": {
     "papermill": {
-     "duration": 0.007225,
-     "end_time": "2026-05-26T19:16:39.570416",
+     "duration": 0.005006,
+     "end_time": "2026-06-01T22:56:10.419893",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.563191",
+     "start_time": "2026-06-01T22:56:10.414887",
      "status": "completed"
     },
     "tags": []
@@ -993,16 +1083,16 @@
    "id": "f5180f71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.586348Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.585982Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.659884Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.659222Z"
+     "iopub.execute_input": "2026-06-01T22:56:10.431677Z",
+     "iopub.status.busy": "2026-06-01T22:56:10.431297Z",
+     "iopub.status.idle": "2026-06-01T22:56:11.008761Z",
+     "shell.execute_reply": "2026-06-01T22:56:11.008035Z"
     },
     "papermill": {
-     "duration": 0.083672,
-     "end_time": "2026-05-26T19:16:39.661228",
+     "duration": 0.585318,
+     "end_time": "2026-06-01T22:56:11.009915",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.577556",
+     "start_time": "2026-06-01T22:56:10.424597",
      "status": "completed"
     },
     "tags": []
@@ -1012,12 +1102,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Variables globales : msg.sender, block.timestamp, block.number ---\n",
-      "Deploye: GlobalVariables a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n",
-      "  Deploye : 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n",
+      "--- Variables globales : msg.sender, block.timestamp, block.number ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deploye: GlobalVariables a 0x09635F643e140090A9A8Dcd712eD6285858ceBef\n",
+      "  Deploye : 0x09635F643e140090A9A8Dcd712eD6285858ceBef\n",
       "  msg.sender   = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
-      "  block.timestamp = 1780302110\n",
-      "  block.number = 10\n",
+      "  block.timestamp = 1780354570\n",
+      "  block.number = 29\n",
       "  block.gaslimit = 30,000,000\n"
      ]
     }
@@ -1070,10 +1166,10 @@
    "id": "7e820f41",
    "metadata": {
     "papermill": {
-     "duration": 0.007274,
-     "end_time": "2026-05-26T19:16:39.675605",
+     "duration": 0.004512,
+     "end_time": "2026-06-01T22:56:11.018864",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.668331",
+     "start_time": "2026-06-01T22:56:11.014352",
      "status": "completed"
     },
     "tags": []
@@ -1090,16 +1186,16 @@
    "id": "74d4bb51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.692357Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.691893Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.696650Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.695931Z"
+     "iopub.execute_input": "2026-06-01T22:56:11.028597Z",
+     "iopub.status.busy": "2026-06-01T22:56:11.028065Z",
+     "iopub.status.idle": "2026-06-01T22:56:11.032587Z",
+     "shell.execute_reply": "2026-06-01T22:56:11.031918Z"
     },
     "papermill": {
-     "duration": 0.014769,
-     "end_time": "2026-05-26T19:16:39.697940",
+     "duration": 0.010481,
+     "end_time": "2026-06-01T22:56:11.033600",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.683171",
+     "start_time": "2026-06-01T22:56:11.023119",
      "status": "completed"
     },
     "tags": []
@@ -1171,10 +1267,10 @@
    "id": "dc39b619",
    "metadata": {
     "papermill": {
-     "duration": 0.008122,
-     "end_time": "2026-05-26T19:16:39.713318",
+     "duration": 0.004363,
+     "end_time": "2026-06-01T22:56:11.042420",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.705196",
+     "start_time": "2026-06-01T22:56:11.038057",
      "status": "completed"
     },
     "tags": []
@@ -1182,7 +1278,7 @@
    "source": [
     "---\n",
     "\n",
-    "## 5. Exemples guidés"
+    "## 5. Exemples guidés et Exercices"
    ]
   },
   {
@@ -1190,18 +1286,18 @@
    "id": "76724e0a",
    "metadata": {
     "papermill": {
-     "duration": 0.007614,
-     "end_time": "2026-05-26T19:16:39.728630",
+     "duration": 0.004253,
+     "end_time": "2026-06-01T22:56:11.050920",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.721016",
+     "start_time": "2026-06-01T22:56:11.046667",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Contrat SimpleStorage\n",
+    "### Exemple guide 1 : Contrat SimpleStorage\n",
     "\n",
-    "Creez un contrat qui stocke et recupere une valeur uint256."
+    "Un contrat qui stocke et recupere une valeur uint256. Solution complete compilee et deployee."
    ]
   },
   {
@@ -1210,16 +1306,16 @@
    "id": "9ead9cef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.741254Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.740420Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.799210Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.798673Z"
+     "iopub.execute_input": "2026-06-01T22:56:11.061663Z",
+     "iopub.status.busy": "2026-06-01T22:56:11.061020Z",
+     "iopub.status.idle": "2026-06-01T22:56:12.743234Z",
+     "shell.execute_reply": "2026-06-01T22:56:12.741743Z"
     },
     "papermill": {
-     "duration": 0.065301,
-     "end_time": "2026-05-26T19:16:39.800066",
+     "duration": 1.691654,
+     "end_time": "2026-06-01T22:56:12.746804",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.734765",
+     "start_time": "2026-06-01T22:56:11.055150",
      "status": "completed"
     },
     "tags": []
@@ -1229,15 +1325,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: SimpleStorage a 0x9A676e781A523b5d0C0e43731313A708CB607508\n",
-      "Valeur initiale : 0\n",
-      "Après set(42) : 42\n",
-      "Après set(1337) : 1337\n"
+      "Deploye: SimpleStorage a 0xc5a5C42992dECbae36851359345FE25997F5C42d\n",
+      "Valeur initiale : 0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres set(42) : 42\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Apres set(1337) : 1337\n"
      ]
     }
    ],
    "source": [
-    "# Votre code ici\n",
+    "# Exemple guide 1 : Contrat SimpleStorage\n",
     "EXERCICE_1 = '''\n",
     "// SPDX-License-Identifier: MIT\n",
     "pragma solidity ^0.8.28;\n",
@@ -1259,9 +1367,9 @@
     "simplestorage, receipt = compile_and_deploy(w3, EXERCICE_1, deployer)\n",
     "print(f\"Valeur initiale : {simplestorage.functions.get().call()}\")  # 0\n",
     "simplestorage.functions.set(42).transact({'from': deployer})\n",
-    "print(f\"Après set(42) : {simplestorage.functions.get().call()}\")    # 42\n",
+    "print(f\"Apres set(42) : {simplestorage.functions.get().call()}\")    # 42\n",
     "simplestorage.functions.set(1337).transact({'from': deployer})\n",
-    "print(f\"Après set(1337) : {simplestorage.functions.get().call()}\")  # 1337"
+    "print(f\"Apres set(1337) : {simplestorage.functions.get().call()}\")  # 1337"
    ]
   },
   {
@@ -1269,16 +1377,16 @@
    "id": "cb4678ee",
    "metadata": {
     "papermill": {
-     "duration": 0.003769,
-     "end_time": "2026-05-26T19:16:39.807827",
+     "duration": 0.003143,
+     "end_time": "2026-06-01T22:56:12.756072",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.804058",
+     "start_time": "2026-06-01T22:56:12.752929",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Indice** : Declarez une variable d'etat privee (ex: `uint256 private data;`), puis utilisez-la dans `set()` et `get()`.\n"
+    "**Analyse** : Le contrat `SimpleStorage` utilise une variable d'etat `uint256 private data` pour stocker une valeur. La fonction `set()` modifie le storage (coûte du gas), tandis que `get()` est `view` (lecture seule, gratuite). La valeur initiale d'un `uint256` est 0 (valeur par defaut).\n"
    ]
   },
   {
@@ -1286,36 +1394,36 @@
    "id": "dc5615bc",
    "metadata": {
     "papermill": {
-     "duration": 0.003977,
-     "end_time": "2026-05-26T19:16:39.815571",
+     "duration": 0.004524,
+     "end_time": "2026-06-01T22:56:12.766006",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.811594",
+     "start_time": "2026-06-01T22:56:12.761482",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Contrat Owner\n",
+    "### Exemple guide 2 : Contrat Owner\n",
     "\n",
-    "Creez un contrat qui stocke l'adresse du proprietaire et permet de la changer."
+    "Un contrat qui stocke l'adresse du proprietaire et permet de la changer. Solution complete compilee et deployee."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "id": "9200ef5b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:16:39.824953Z",
-     "iopub.status.busy": "2026-05-26T19:16:39.824690Z",
-     "iopub.status.idle": "2026-05-26T19:16:39.877911Z",
-     "shell.execute_reply": "2026-05-26T19:16:39.877304Z"
+     "iopub.execute_input": "2026-06-01T22:56:12.776635Z",
+     "iopub.status.busy": "2026-06-01T22:56:12.776285Z",
+     "iopub.status.idle": "2026-06-01T22:56:14.043313Z",
+     "shell.execute_reply": "2026-06-01T22:56:14.042339Z"
     },
     "papermill": {
-     "duration": 0.059184,
-     "end_time": "2026-05-26T19:16:39.878849",
+     "duration": 1.273471,
+     "end_time": "2026-06-01T22:56:14.044232",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.819665",
+     "start_time": "2026-06-01T22:56:12.770761",
      "status": "completed"
     },
     "tags": []
@@ -1325,19 +1433,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: Owner a 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE\n",
+      "Deploye: Owner a 0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690\n",
       "Owner initial    : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
       "Deployer         : 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
-      "Sont identiques  : True\n",
+      "Sont identiques  : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Après changeOwner(0x70997970...)\n",
-      "Nouvel owner : 0x70997970C51812dc3A010C7d01b50e0d17dc79C8\n",
+      "Apres changeOwner(0x70997970...)\n",
+      "Nouvel owner : 0x70997970C51812dc3A010C7d01b50e0d17dc79C8\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Changement OK : True\n"
      ]
     }
    ],
    "source": [
-    "# Votre code ici\n",
+    "# Exemple guide 2 : Contrat Owner\n",
     "EXERCICE_2 = '''\n",
     "// SPDX-License-Identifier: MIT\n",
     "pragma solidity ^0.8.28;\n",
@@ -1364,7 +1484,7 @@
     "\n",
     "new_owner = w3.eth.accounts[1]\n",
     "owner.functions.changeOwner(new_owner).transact({'from': deployer})\n",
-    "print(f\"\\nAprès changeOwner({new_owner[:10]}...)\")\n",
+    "print(f\"\\nApres changeOwner({new_owner[:10]}...)\")\n",
     "print(f\"Nouvel owner : {owner.functions.owner().call()}\")\n",
     "print(f\"Changement OK : {owner.functions.owner().call().lower() == new_owner.lower()}\")"
    ]
@@ -1374,16 +1494,157 @@
    "id": "418c85f3",
    "metadata": {
     "papermill": {
-     "duration": 0.003764,
-     "end_time": "2026-05-26T19:16:39.886669",
+     "duration": 0.003721,
+     "end_time": "2026-06-01T22:56:14.051586",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.882905",
+     "start_time": "2026-06-01T22:56:14.047865",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "**Indice** : Dans le constructor, initialisez `owner` avec `msg.sender`. Dans `changeOwner`, affectez simplement `_newOwner` a `owner`.\n"
+    "**Analyse** : Le contrat `Owner` utilise le pattern ownership : le constructor capture `msg.sender` (l'adresse du deployeur) comme owner initial. La fonction `changeOwner()` met a jour cette adresse. Notez que dans cette version simplifiee, n'importe qui peut changer l'owner — un vrai contrat ajouterait un `require(msg.sender == owner)`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13b120cb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00683,
+     "end_time": "2026-06-01T22:56:14.062147",
+     "exception": false,
+     "start_time": "2026-06-01T22:56:14.055317",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Contrat CounterEvents\n",
+    "\n",
+    "Creez un compteur qui emet un evenement a chaque incrementation. Les events sont le mecanisme de logging on-chain en Solidity.\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Definir un `event` avec des parametres indexes\n",
+    "2. Emettre un event avec `emit` dans une fonction\n",
+    "3. Capturer l'event dans les logs de transaction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "19d9b240",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:56:14.071370Z",
+     "iopub.status.busy": "2026-06-01T22:56:14.070929Z",
+     "iopub.status.idle": "2026-06-01T22:56:14.075919Z",
+     "shell.execute_reply": "2026-06-01T22:56:14.075257Z"
+    },
+    "papermill": {
+     "duration": 0.011002,
+     "end_time": "2026-06-01T22:56:14.077326",
+     "exception": false,
+     "start_time": "2026-06-01T22:56:14.066324",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Contrat CounterEvents\n",
+    "# TODO etudiant : implementer un compteur qui emet un evenement a chaque incrementation\n",
+    "# Etape 1 : Definir un event Counted(address indexed caller, uint256 newCount)\n",
+    "# Etape 2 : Implementer increment() qui emet l'event\n",
+    "# Etape 3 : Implementer getCount() view returns (uint256)\n",
+    "EXERCICE_3 = \"\"\"\n",
+    "// SPDX-License-Identifier: MIT\n",
+    "pragma solidity ^0.8.28;\n",
+    "\n",
+    "contract CounterEvents {\n",
+    "    // TODO etudiant : event, variable d'etat, et fonctions\n",
+    "}\n",
+    "\"\"\"\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba113c2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006422,
+     "end_time": "2026-06-01T22:56:14.088459",
+     "exception": false,
+     "start_time": "2026-06-01T22:56:14.082037",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : Contrat OwnedCounter\n",
+    "\n",
+    "Combinez les concepts des exemples precedents : creez un compteur qui ne peut etre incremente que par le proprietaire du contrat.\n",
+    "\n",
+    "**Objectifs** :\n",
+    "1. Combiner variables d'etat (`uint256`, `address`) et controle d'acces\n",
+    "2. Utiliser `require()` pour proteger une fonction\n",
+    "3. Deployer et tester le controle d'ownership sur anvil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1443c632",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:56:14.098188Z",
+     "iopub.status.busy": "2026-06-01T22:56:14.097739Z",
+     "iopub.status.idle": "2026-06-01T22:56:14.102529Z",
+     "shell.execute_reply": "2026-06-01T22:56:14.101317Z"
+    },
+    "papermill": {
+     "duration": 0.011421,
+     "end_time": "2026-06-01T22:56:14.104125",
+     "exception": false,
+     "start_time": "2026-06-01T22:56:14.092704",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 4 : Contrat OwnedCounter\n",
+    "# TODO etudiant : implementer un compteur avec controle d'ownership\n",
+    "# Etape 1 : Definir une variable d'etat uint256 public count et address public owner\n",
+    "# Etape 2 : Capturer msg.sender dans le constructor\n",
+    "# Etape 3 : Implementer increment() avec require(msg.sender == owner, \"Not owner\")\n",
+    "# Etape 4 : Implementer getCount() view returns (uint256)\n",
+    "EXERCICE_4 = \"\"\"\n",
+    "// SPDX-License-Identifier: MIT\n",
+    "pragma solidity ^0.8.28;\n",
+    "\n",
+    "contract OwnedCounter {\n",
+    "    // TODO etudiant : variables d'etat et fonctions\n",
+    "}\n",
+    "\"\"\"\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
@@ -1391,10 +1652,10 @@
    "id": "058d684a",
    "metadata": {
     "papermill": {
-     "duration": 0.003568,
-     "end_time": "2026-05-26T19:16:39.893867",
+     "duration": 0.003917,
+     "end_time": "2026-06-01T22:56:14.115294",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.890299",
+     "start_time": "2026-06-01T22:56:14.111377",
      "status": "completed"
     },
     "tags": []
@@ -1421,7 +1682,16 @@
   {
    "cell_type": "markdown",
    "id": "202bc429",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004035,
+     "end_time": "2026-06-01T22:56:14.123361",
+     "exception": false,
+     "start_time": "2026-06-01T22:56:14.119326",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Resume et perspectives\n",
     "\n",
@@ -1437,10 +1707,10 @@
    "id": "dfa6951d",
    "metadata": {
     "papermill": {
-     "duration": 0.004111,
-     "end_time": "2026-05-26T19:16:39.901745",
+     "duration": 0.003936,
+     "end_time": "2026-06-01T22:56:14.131357",
      "exception": false,
-     "start_time": "2026-05-26T19:16:39.897634",
+     "start_time": "2026-06-01T22:56:14.127421",
      "status": "completed"
     },
     "tags": []
@@ -1468,18 +1738,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.9397,
-   "end_time": "2026-05-26T19:16:40.156054",
+   "duration": 14.36874,
+   "end_time": "2026-06-01T22:56:14.369165",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc3_output.ipynb",
+   "output_path": "SC-3-exec-output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-26T19:16:36.216354",
+   "start_time": "2026-06-01T22:56:00.000425",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Consolidation SC-3 Solidity Basics per exercise-example-labeling.md rule.

### Changes
- **Exercice 1 (SimpleStorage)** → **Exemple guide 1** (complete solution compiled and deployed)
- **Exercice 2 (Owner)** → **Exemple guide 2** (complete solution compiled and deployed)
- **Indice** → **Analyse** interpretation cells (content-based)
- **New Exercice 3**: CounterEvents (event + counter stub with TODO)
- **New Exercice 4**: OwnedCounter (ownership + counter stub with TODO)
- Section heading: `## 5. Exemples guides` → `## 5. Exemples guides et Exercices`

### Validation
- **Papermill**: 41/41 cells, 0 errors, 14s execution
- **Anvil** (Foundry 1.7.1 via WSL): local blockchain running
- **C.1 check**: 0 `raise NotImplementedError`, 0 `assert False`, 0 `1/0`
- **C.2 check**: all 14 code cells have `execution_count: <int>` + coherent outputs
- **C.3 scope**: only SC-3 source changed

### Rationale
SC-3 exercices 1 and 2 had complete working Solidity contracts (SimpleStorage, Owner) with compilation, deployment, and test calls on anvil. Per content-based labeling: solution cell = Exemple guide. The code was never stub/TODO. Two new exercise stubs (CounterEvents, OwnedCounter) added to maintain pedagogical balance.

### Files changed
- `SC-3-Solidity-Basics.ipynb`: +493/-223 (enrichment + real execution outputs)