### PR TITLE
enrich(SymbolicLearning): insert transition cell in SL-3-RelevanceLearning

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb
@@ -5,10 +5,10 @@
    "id": "dbf96c32",
    "metadata": {
     "papermill": {
-     "duration": 0.0034,
-     "end_time": "2026-05-30T07:36:20.188024+00:00",
+     "duration": 0.005453,
+     "end_time": "2026-06-01T22:57:21.737774+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.184624+00:00",
+     "start_time": "2026-06-01T22:57:21.732321+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,16 +41,16 @@
    "id": "4eb99804",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.194575Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.194275Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.200506Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.199727Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.749460Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.749183Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.758981Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.757894Z"
     },
     "papermill": {
-     "duration": 0.010465,
-     "end_time": "2026-05-30T07:36:20.201333+00:00",
+     "duration": 0.017074,
+     "end_time": "2026-06-01T22:57:21.760406+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.190868+00:00",
+     "start_time": "2026-06-01T22:57:21.743332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,10 +91,10 @@
    "id": "359e4cd2",
    "metadata": {
     "papermill": {
-     "duration": 0.002357,
-     "end_time": "2026-05-30T07:36:20.206401+00:00",
+     "duration": 0.00474,
+     "end_time": "2026-06-01T22:57:21.770074+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.204044+00:00",
+     "start_time": "2026-06-01T22:57:21.765334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -138,10 +138,10 @@
    "id": "3a901336",
    "metadata": {
     "papermill": {
-     "duration": 0.002227,
-     "end_time": "2026-05-30T07:36:20.211037+00:00",
+     "duration": 0.004793,
+     "end_time": "2026-06-01T22:57:21.780926+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.208810+00:00",
+     "start_time": "2026-06-01T22:57:21.776133+00:00",
      "status": "completed"
     },
     "tags": []
@@ -174,16 +174,16 @@
    "id": "6b2244c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.216584Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.216395Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.224391Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.223826Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.791990Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.791692Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.804379Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.803344Z"
     },
     "papermill": {
-     "duration": 0.011832,
-     "end_time": "2026-05-30T07:36:20.225031+00:00",
+     "duration": 0.019522,
+     "end_time": "2026-06-01T22:57:21.805291+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.213199+00:00",
+     "start_time": "2026-06-01T22:57:21.785769+00:00",
      "status": "completed"
     },
     "tags": []
@@ -294,10 +294,10 @@
    "id": "3fd9dbce",
    "metadata": {
     "papermill": {
-     "duration": 0.002131,
-     "end_time": "2026-05-30T07:36:20.229754+00:00",
+     "duration": 0.007265,
+     "end_time": "2026-06-01T22:57:21.817523+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.227623+00:00",
+     "start_time": "2026-06-01T22:57:21.810258+00:00",
      "status": "completed"
     },
     "tags": []
@@ -321,10 +321,10 @@
    "id": "29d1b9a6",
    "metadata": {
     "papermill": {
-     "duration": 0.002242,
-     "end_time": "2026-05-30T07:36:20.234183+00:00",
+     "duration": 0.005486,
+     "end_time": "2026-06-01T22:57:21.827935+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.231941+00:00",
+     "start_time": "2026-06-01T22:57:21.822449+00:00",
      "status": "completed"
     },
     "tags": []
@@ -347,16 +347,16 @@
    "id": "b19e64de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.239473Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.239305Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.245491Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.245057Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.840947Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.840528Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.853789Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.852231Z"
     },
     "papermill": {
-     "duration": 0.009845,
-     "end_time": "2026-05-30T07:36:20.246156+00:00",
+     "duration": 0.022023,
+     "end_time": "2026-06-01T22:57:21.854821+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.236311+00:00",
+     "start_time": "2026-06-01T22:57:21.832798+00:00",
      "status": "completed"
     },
     "tags": []
@@ -474,10 +474,10 @@
    "id": "1bfe64c6",
    "metadata": {
     "papermill": {
-     "duration": 0.002375,
-     "end_time": "2026-05-30T07:36:20.250911+00:00",
+     "duration": 0.006169,
+     "end_time": "2026-06-01T22:57:21.868193+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.248536+00:00",
+     "start_time": "2026-06-01T22:57:21.862024+00:00",
      "status": "completed"
     },
     "tags": []
@@ -502,16 +502,16 @@
    "id": "0aecc697",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.256532Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.256374Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.260735Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.260279Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.882891Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.882435Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.889728Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.888928Z"
     },
     "papermill": {
-     "duration": 0.008206,
-     "end_time": "2026-05-30T07:36:20.261332+00:00",
+     "duration": 0.015989,
+     "end_time": "2026-06-01T22:57:21.891415+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.253126+00:00",
+     "start_time": "2026-06-01T22:57:21.875426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -586,10 +586,10 @@
    "id": "5ea54d7e",
    "metadata": {
     "papermill": {
-     "duration": 0.002377,
-     "end_time": "2026-05-30T07:36:20.266173+00:00",
+     "duration": 0.006154,
+     "end_time": "2026-06-01T22:57:21.902757+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.263796+00:00",
+     "start_time": "2026-06-01T22:57:21.896603+00:00",
      "status": "completed"
     },
     "tags": []
@@ -627,16 +627,16 @@
    "id": "6319964e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.271937Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.271769Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.279363Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.278862Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.915174Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.914880Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.927316Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.926403Z"
     },
     "papermill": {
-     "duration": 0.011265,
-     "end_time": "2026-05-30T07:36:20.279890+00:00",
+     "duration": 0.0198,
+     "end_time": "2026-06-01T22:57:21.928194+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.268625+00:00",
+     "start_time": "2026-06-01T22:57:21.908394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -770,10 +770,10 @@
    "id": "1ed6994f",
    "metadata": {
     "papermill": {
-     "duration": 0.002489,
-     "end_time": "2026-05-30T07:36:20.284702+00:00",
+     "duration": 0.004674,
+     "end_time": "2026-06-01T22:57:21.937729+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.282213+00:00",
+     "start_time": "2026-06-01T22:57:21.933055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -797,10 +797,10 @@
    "id": "72861666",
    "metadata": {
     "papermill": {
-     "duration": 0.002384,
-     "end_time": "2026-05-30T07:36:20.289389+00:00",
+     "duration": 0.004679,
+     "end_time": "2026-06-01T22:57:21.947208+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.287005+00:00",
+     "start_time": "2026-06-01T22:57:21.942529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -825,16 +825,16 @@
    "id": "8352f3b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.295587Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.295414Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.301698Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.301188Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.958155Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.957863Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.967886Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.966934Z"
     },
     "papermill": {
-     "duration": 0.010419,
-     "end_time": "2026-05-30T07:36:20.302434+00:00",
+     "duration": 0.01705,
+     "end_time": "2026-06-01T22:57:21.968829+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.292015+00:00",
+     "start_time": "2026-06-01T22:57:21.951779+00:00",
      "status": "completed"
     },
     "tags": []
@@ -915,10 +915,10 @@
    "id": "61cf237e",
    "metadata": {
     "papermill": {
-     "duration": 0.002546,
-     "end_time": "2026-05-30T07:36:20.307454+00:00",
+     "duration": 0.005093,
+     "end_time": "2026-06-01T22:57:21.979601+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.304908+00:00",
+     "start_time": "2026-06-01T22:57:21.974508+00:00",
      "status": "completed"
     },
     "tags": []
@@ -933,16 +933,16 @@
    "id": "bad47a00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.313693Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.313411Z",
-     "iopub.status.idle": "2026-05-30T07:36:20.318090Z",
-     "shell.execute_reply": "2026-05-30T07:36:20.317332Z"
+     "iopub.execute_input": "2026-06-01T22:57:21.991591Z",
+     "iopub.status.busy": "2026-06-01T22:57:21.991177Z",
+     "iopub.status.idle": "2026-06-01T22:57:21.997802Z",
+     "shell.execute_reply": "2026-06-01T22:57:21.996999Z"
     },
     "papermill": {
-     "duration": 0.008416,
-     "end_time": "2026-05-30T07:36:20.318577+00:00",
+     "duration": 0.013966,
+     "end_time": "2026-06-01T22:57:21.998592+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.310161+00:00",
+     "start_time": "2026-06-01T22:57:21.984626+00:00",
      "status": "completed"
     },
     "tags": []
@@ -990,21 +990,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3913ca3c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005086,
+     "end_time": "2026-06-01T22:57:22.009142+00:00",
+     "exception": false,
+     "start_time": "2026-06-01T22:57:22.004056+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Selection statistique : Information Mutuelle avec sklearn\n",
+    "\n",
+    "L'approche RBL a identifie `{R1, R2}` comme determination minimale avec une **garantie logique** (si determination il y a, RBL la trouve). Mais que se passe-t-il si les donnees sont bruitees ou que la determination exacte n'existe pas ?\n",
+    "\n",
+    "L'**information mutuelle** (sklearn) mesure la dependance statistique entre chaque attribut et la cible, sans exiger de determination fonctionnelle exacte. La cellule suivante calcule ces scores et compare les attributs selectionnes par sklearn avec la determination RBL."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "7c8627eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:20.324260Z",
-     "iopub.status.busy": "2026-05-30T07:36:20.324113Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.333753Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.332993Z"
+     "iopub.execute_input": "2026-06-01T22:57:22.022638Z",
+     "iopub.status.busy": "2026-06-01T22:57:22.022355Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.359309Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.357968Z"
     },
     "papermill": {
-     "duration": 8.013244,
-     "end_time": "2026-05-30T07:36:28.334358+00:00",
+     "duration": 13.345993,
+     "end_time": "2026-06-01T22:57:35.360323+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:20.321114+00:00",
+     "start_time": "2026-06-01T22:57:22.014330+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,7 +1052,7 @@
       "N8       |         0.0000 | #10 (noise)\n",
       "\n",
       "Top-2 sklearn : {'R1', 'R2'}\n",
-      "Determination RBL : {'R1', 'R2'}\n",
+      "Determination RBL : {'R2', 'R1'}\n",
       "Concordance : True\n"
      ]
     }
@@ -1080,10 +1101,10 @@
    "id": "cf88517c",
    "metadata": {
     "papermill": {
-     "duration": 0.003547,
-     "end_time": "2026-05-30T07:36:28.341799+00:00",
+     "duration": 0.006115,
+     "end_time": "2026-06-01T22:57:35.371575+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.338252+00:00",
+     "start_time": "2026-06-01T22:57:35.365460+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1115,16 +1136,16 @@
    "id": "ffe3e3fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:28.352481Z",
-     "iopub.status.busy": "2026-05-30T07:36:28.351847Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.360084Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.358988Z"
+     "iopub.execute_input": "2026-06-01T22:57:35.384764Z",
+     "iopub.status.busy": "2026-06-01T22:57:35.384282Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.393683Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.392539Z"
     },
     "papermill": {
-     "duration": 0.013803,
-     "end_time": "2026-05-30T07:36:28.361040+00:00",
+     "duration": 0.016693,
+     "end_time": "2026-06-01T22:57:35.394546+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.347237+00:00",
+     "start_time": "2026-06-01T22:57:35.377853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1191,10 +1212,10 @@
    "id": "79de4eaf",
    "metadata": {
     "papermill": {
-     "duration": 0.005333,
-     "end_time": "2026-05-30T07:36:28.372207+00:00",
+     "duration": 0.006267,
+     "end_time": "2026-06-01T22:57:35.406654+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.366874+00:00",
+     "start_time": "2026-06-01T22:57:35.400387+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1217,10 +1238,10 @@
    "id": "6d1d952f",
    "metadata": {
     "papermill": {
-     "duration": 0.005342,
-     "end_time": "2026-05-30T07:36:28.382935+00:00",
+     "duration": 0.004886,
+     "end_time": "2026-06-01T22:57:35.417904+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.377593+00:00",
+     "start_time": "2026-06-01T22:57:35.413018+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1249,16 +1270,16 @@
    "id": "7c4e0e96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:28.395481Z",
-     "iopub.status.busy": "2026-05-30T07:36:28.395203Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.402281Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.401158Z"
+     "iopub.execute_input": "2026-06-01T22:57:35.429042Z",
+     "iopub.status.busy": "2026-06-01T22:57:35.428621Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.434556Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.433568Z"
     },
     "papermill": {
-     "duration": 0.014843,
-     "end_time": "2026-05-30T07:36:28.403488+00:00",
+     "duration": 0.012813,
+     "end_time": "2026-06-01T22:57:35.435336+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.388645+00:00",
+     "start_time": "2026-06-01T22:57:35.422523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1319,10 +1340,10 @@
    "id": "b2ed3f33",
    "metadata": {
     "papermill": {
-     "duration": 0.005446,
-     "end_time": "2026-05-30T07:36:28.414827+00:00",
+     "duration": 0.005171,
+     "end_time": "2026-06-01T22:57:35.445455+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.409381+00:00",
+     "start_time": "2026-06-01T22:57:35.440284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1348,16 +1369,16 @@
    "id": "5f23755b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:28.426898Z",
-     "iopub.status.busy": "2026-05-30T07:36:28.426711Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.431819Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.431135Z"
+     "iopub.execute_input": "2026-06-01T22:57:35.457355Z",
+     "iopub.status.busy": "2026-06-01T22:57:35.457114Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.463560Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.462605Z"
     },
     "papermill": {
-     "duration": 0.01212,
-     "end_time": "2026-05-30T07:36:28.432346+00:00",
+     "duration": 0.013843,
+     "end_time": "2026-06-01T22:57:35.464385+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.420226+00:00",
+     "start_time": "2026-06-01T22:57:35.450542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1408,10 +1429,10 @@
    "id": "68e70655",
    "metadata": {
     "papermill": {
-     "duration": 0.002742,
-     "end_time": "2026-05-30T07:36:28.438196+00:00",
+     "duration": 0.004512,
+     "end_time": "2026-06-01T22:57:35.473848+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.435454+00:00",
+     "start_time": "2026-06-01T22:57:35.469336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1426,16 +1447,16 @@
    "id": "cc196778",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:28.445012Z",
-     "iopub.status.busy": "2026-05-30T07:36:28.444733Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.448804Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.448129Z"
+     "iopub.execute_input": "2026-06-01T22:57:35.483728Z",
+     "iopub.status.busy": "2026-06-01T22:57:35.483517Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.487266Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.486488Z"
     },
     "papermill": {
-     "duration": 0.008407,
-     "end_time": "2026-05-30T07:36:28.449341+00:00",
+     "duration": 0.009585,
+     "end_time": "2026-06-01T22:57:35.487979+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.440934+00:00",
+     "start_time": "2026-06-01T22:57:35.478394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1472,10 +1493,10 @@
    "id": "ba0bdbc2",
    "metadata": {
     "papermill": {
-     "duration": 0.00278,
-     "end_time": "2026-05-30T07:36:28.455150+00:00",
+     "duration": 0.004489,
+     "end_time": "2026-06-01T22:57:35.496967+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.452370+00:00",
+     "start_time": "2026-06-01T22:57:35.492478+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1490,16 +1511,16 @@
    "id": "8072ef89",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T07:36:28.462204Z",
-     "iopub.status.busy": "2026-05-30T07:36:28.461963Z",
-     "iopub.status.idle": "2026-05-30T07:36:28.465962Z",
-     "shell.execute_reply": "2026-05-30T07:36:28.465364Z"
+     "iopub.execute_input": "2026-06-01T22:57:35.507119Z",
+     "iopub.status.busy": "2026-06-01T22:57:35.506819Z",
+     "iopub.status.idle": "2026-06-01T22:57:35.511734Z",
+     "shell.execute_reply": "2026-06-01T22:57:35.510938Z"
     },
     "papermill": {
-     "duration": 0.008455,
-     "end_time": "2026-05-30T07:36:28.466553+00:00",
+     "duration": 0.011171,
+     "end_time": "2026-06-01T22:57:35.512531+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.458098+00:00",
+     "start_time": "2026-06-01T22:57:35.501360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1560,10 +1581,10 @@
    "id": "5eba2e20",
    "metadata": {
     "papermill": {
-     "duration": 0.002836,
-     "end_time": "2026-05-30T07:36:28.472317+00:00",
+     "duration": 0.004284,
+     "end_time": "2026-06-01T22:57:35.521278+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.469481+00:00",
+     "start_time": "2026-06-01T22:57:35.516994+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1602,10 +1623,10 @@
    "id": "730925ce",
    "metadata": {
     "papermill": {
-     "duration": 0.002855,
-     "end_time": "2026-05-30T07:36:28.478093+00:00",
+     "duration": 0.00449,
+     "end_time": "2026-06-01T22:57:35.532024+00:00",
      "exception": false,
-     "start_time": "2026-05-30T07:36:28.475238+00:00",
+     "start_time": "2026-06-01T22:57:35.527534+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1642,18 +1663,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 10.255255,
-   "end_time": "2026-05-30T07:36:28.819194+00:00",
+   "duration": 17.402391,
+   "end_time": "2026-06-01T22:57:36.232082+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-3-RelevanceLearning.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sl3_exec.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-3-RelevanceLearning.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-3-RelevanceLearning_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-30T07:36:18.563939+00:00",
+   "start_time": "2026-06-01T22:57:18.829691+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `SL-3-RelevanceLearning.ipynb`.

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `3913ca3c` | After `bad47a00` (MINIMAL-CONSISTENT-DET search) | "Selection statistique : Information Mutuelle avec sklearn" |

## Validation proof

- **Papermill**: 32/32 cells executed, 0 errors, kernel=python3, 20.1s
- **execution_count**: All 13 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 173 insertions, 152 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
