### PR TITLE
enrich(SL-6): insert transition markdown between consecutive code pair

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb
@@ -5,10 +5,10 @@
    "id": "cc001308",
    "metadata": {
     "papermill": {
-     "duration": 0.029086,
-     "end_time": "2026-05-27T10:11:26.761825+00:00",
+     "duration": 0.005076,
+     "end_time": "2026-06-02T00:29:25.670515+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:26.732739+00:00",
+     "start_time": "2026-06-02T00:29:25.665439+00:00",
      "status": "completed"
     },
     "tags": []
@@ -46,10 +46,10 @@
    "id": "a521d3e8",
    "metadata": {
     "papermill": {
-     "duration": 0.010426,
-     "end_time": "2026-05-27T10:11:26.787885+00:00",
+     "duration": 0.003879,
+     "end_time": "2026-06-02T00:29:25.678755+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:26.777459+00:00",
+     "start_time": "2026-06-02T00:29:25.674876+00:00",
      "status": "completed"
     },
     "tags": []
@@ -93,10 +93,10 @@
    "id": "fb76430f",
    "metadata": {
     "papermill": {
-     "duration": 0.00276,
-     "end_time": "2026-05-27T10:11:26.795132+00:00",
+     "duration": 0.004118,
+     "end_time": "2026-06-02T00:29:25.687017+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:26.792372+00:00",
+     "start_time": "2026-06-02T00:29:25.682899+00:00",
      "status": "completed"
     },
     "tags": []
@@ -115,16 +115,16 @@
    "id": "6422a73a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:26.805081Z",
-     "iopub.status.busy": "2026-05-27T10:11:26.804804Z",
-     "iopub.status.idle": "2026-05-27T10:11:27.993427Z",
-     "shell.execute_reply": "2026-05-27T10:11:27.992734Z"
+     "iopub.execute_input": "2026-06-02T00:29:25.696182Z",
+     "iopub.status.busy": "2026-06-02T00:29:25.695965Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.141265Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.140554Z"
     },
     "papermill": {
-     "duration": 1.195433,
-     "end_time": "2026-05-27T10:11:27.994368+00:00",
+     "duration": 10.45094,
+     "end_time": "2026-06-02T00:29:36.141898+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:26.798935+00:00",
+     "start_time": "2026-06-02T00:29:25.690958+00:00",
      "status": "completed"
     },
     "tags": []
@@ -136,6 +136,15 @@
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 25.2 -> 26.1.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
     }
    ],
    "source": [
@@ -144,21 +153,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "859f5cfd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003526,
+     "end_time": "2026-06-02T00:29:36.149131+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T00:29:36.145605+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Importation et construction du Knowledge Graph\n",
+    "\n",
+    "La bibliotheque **rdflib** est la reference Python pour manipuler les graphs RDF. La cellule suivante importe les composants necessaires et construit un Knowledge Graph de relations familiales : `parentOf`, `grandparentOf` (incomplet), `siblingOf` et `marriedTo`. L'incompletude deliberee de `grandparentOf` est le moteur du rule mining -- c'est ce que nous chercherons a completer automatiquement."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "1cd6d433",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:28.012994Z",
-     "iopub.status.busy": "2026-05-27T10:11:28.012767Z",
-     "iopub.status.idle": "2026-05-27T10:11:28.119103Z",
-     "shell.execute_reply": "2026-05-27T10:11:28.118511Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.156767Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.156598Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.321348Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.320763Z"
     },
     "papermill": {
-     "duration": 0.120848,
-     "end_time": "2026-05-27T10:11:28.123157+00:00",
+     "duration": 0.169626,
+     "end_time": "2026-06-02T00:29:36.322143+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.002309+00:00",
+     "start_time": "2026-06-02T00:29:36.152517+00:00",
      "status": "completed"
     },
     "tags": []
@@ -294,10 +322,10 @@
    "id": "c7f62d31",
    "metadata": {
     "papermill": {
-     "duration": 0.044689,
-     "end_time": "2026-05-27T10:11:28.186147+00:00",
+     "duration": 0.004123,
+     "end_time": "2026-06-02T00:29:36.330762+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.141458+00:00",
+     "start_time": "2026-06-02T00:29:36.326639+00:00",
      "status": "completed"
     },
     "tags": []
@@ -327,10 +355,10 @@
    "id": "09e1dbc5",
    "metadata": {
     "papermill": {
-     "duration": 0.044992,
-     "end_time": "2026-05-27T10:11:28.271157+00:00",
+     "duration": 0.004358,
+     "end_time": "2026-06-02T00:29:36.339423+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.226165+00:00",
+     "start_time": "2026-06-02T00:29:36.335065+00:00",
      "status": "completed"
     },
     "tags": []
@@ -349,16 +377,16 @@
    "id": "135b849e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:28.373605Z",
-     "iopub.status.busy": "2026-05-27T10:11:28.373197Z",
-     "iopub.status.idle": "2026-05-27T10:11:28.387248Z",
-     "shell.execute_reply": "2026-05-27T10:11:28.385753Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.349589Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.349354Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.356517Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.355847Z"
     },
     "papermill": {
-     "duration": 0.076013,
-     "end_time": "2026-05-27T10:11:28.396376+00:00",
+     "duration": 0.013422,
+     "end_time": "2026-06-02T00:29:36.357286+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.320363+00:00",
+     "start_time": "2026-06-02T00:29:36.343864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -444,10 +472,10 @@
    "id": "4e7a7a8e",
    "metadata": {
     "papermill": {
-     "duration": 0.040625,
-     "end_time": "2026-05-27T10:11:28.476242+00:00",
+     "duration": 0.00402,
+     "end_time": "2026-06-02T00:29:36.365637+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.435617+00:00",
+     "start_time": "2026-06-02T00:29:36.361617+00:00",
      "status": "completed"
     },
     "tags": []
@@ -471,10 +499,10 @@
    "id": "2ebba873",
    "metadata": {
     "papermill": {
-     "duration": 0.057204,
-     "end_time": "2026-05-27T10:11:28.583638+00:00",
+     "duration": 0.003996,
+     "end_time": "2026-06-02T00:29:36.373659+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.526434+00:00",
+     "start_time": "2026-06-02T00:29:36.369663+00:00",
      "status": "completed"
     },
     "tags": []
@@ -507,16 +535,16 @@
    "id": "91350691",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:28.683883Z",
-     "iopub.status.busy": "2026-05-27T10:11:28.678578Z",
-     "iopub.status.idle": "2026-05-27T10:11:28.745805Z",
-     "shell.execute_reply": "2026-05-27T10:11:28.739482Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.383916Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.383696Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.390967Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.390078Z"
     },
     "papermill": {
-     "duration": 0.118347,
-     "end_time": "2026-05-27T10:11:28.751763+00:00",
+     "duration": 0.013578,
+     "end_time": "2026-06-02T00:29:36.391592+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.633416+00:00",
+     "start_time": "2026-06-02T00:29:36.378014+00:00",
      "status": "completed"
     },
     "tags": []
@@ -528,7 +556,7 @@
      "text": [
       "Test de compute_body_pairs :\n",
       "  r1 = {('C', 'D'), ('A', 'B')}\n",
-      "  r2 = {('D', 'F'), ('B', 'E')}\n",
+      "  r2 = {('B', 'E'), ('D', 'F')}\n",
       "  JOIN result = {('A', 'E'), ('C', 'F')}\n",
       "  Attendu : (('A', 'E'), ('C', 'F'))\n",
       "  Correct : True\n"
@@ -619,10 +647,10 @@
    "id": "2f9e5ce7",
    "metadata": {
     "papermill": {
-     "duration": 0.033353,
-     "end_time": "2026-05-27T10:11:28.807567+00:00",
+     "duration": 0.004505,
+     "end_time": "2026-06-02T00:29:36.400300+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.774214+00:00",
+     "start_time": "2026-06-02T00:29:36.395795+00:00",
      "status": "completed"
     },
     "tags": []
@@ -646,10 +674,10 @@
    "id": "55e6358c",
    "metadata": {
     "papermill": {
-     "duration": 0.025381,
-     "end_time": "2026-05-27T10:11:28.873072+00:00",
+     "duration": 0.00442,
+     "end_time": "2026-06-02T00:29:36.408952+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.847691+00:00",
+     "start_time": "2026-06-02T00:29:36.404532+00:00",
      "status": "completed"
     },
     "tags": []
@@ -668,16 +696,16 @@
    "id": "93a15c8b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:28.945528Z",
-     "iopub.status.busy": "2026-05-27T10:11:28.941838Z",
-     "iopub.status.idle": "2026-05-27T10:11:29.037036Z",
-     "shell.execute_reply": "2026-05-27T10:11:29.032497Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.419936Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.419689Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.428661Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.427804Z"
     },
     "papermill": {
-     "duration": 0.146924,
-     "end_time": "2026-05-27T10:11:29.039987+00:00",
+     "duration": 0.015629,
+     "end_time": "2026-06-02T00:29:36.429427+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:28.893063+00:00",
+     "start_time": "2026-06-02T00:29:36.413798+00:00",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +819,10 @@
    "id": "f171e286",
    "metadata": {
     "papermill": {
-     "duration": 0.038804,
-     "end_time": "2026-05-27T10:11:29.099881+00:00",
+     "duration": 0.004437,
+     "end_time": "2026-06-02T00:29:36.438698+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.061077+00:00",
+     "start_time": "2026-06-02T00:29:36.434261+00:00",
      "status": "completed"
     },
     "tags": []
@@ -820,10 +848,10 @@
    "id": "d17f08c2",
    "metadata": {
     "papermill": {
-     "duration": 0.04535,
-     "end_time": "2026-05-27T10:11:29.185648+00:00",
+     "duration": 0.00464,
+     "end_time": "2026-06-02T00:29:36.447935+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.140298+00:00",
+     "start_time": "2026-06-02T00:29:36.443295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -842,16 +870,16 @@
    "id": "e5d644f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:29.251459Z",
-     "iopub.status.busy": "2026-05-27T10:11:29.248131Z",
-     "iopub.status.idle": "2026-05-27T10:11:29.298781Z",
-     "shell.execute_reply": "2026-05-27T10:11:29.295681Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.458626Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.458387Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.465707Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.464878Z"
     },
     "papermill": {
-     "duration": 0.089949,
-     "end_time": "2026-05-27T10:11:29.302519+00:00",
+     "duration": 0.013891,
+     "end_time": "2026-06-02T00:29:36.466492+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.212570+00:00",
+     "start_time": "2026-06-02T00:29:36.452601+00:00",
      "status": "completed"
     },
     "tags": []
@@ -967,10 +995,10 @@
    "id": "5dc0af7c",
    "metadata": {
     "papermill": {
-     "duration": 0.034226,
-     "end_time": "2026-05-27T10:11:29.370821+00:00",
+     "duration": 0.004138,
+     "end_time": "2026-06-02T00:29:36.475127+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.336595+00:00",
+     "start_time": "2026-06-02T00:29:36.470989+00:00",
      "status": "completed"
     },
     "tags": []
@@ -999,10 +1027,10 @@
    "id": "16b4761d",
    "metadata": {
     "papermill": {
-     "duration": 0.034929,
-     "end_time": "2026-05-27T10:11:29.453495+00:00",
+     "duration": 0.003715,
+     "end_time": "2026-06-02T00:29:36.482744+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.418566+00:00",
+     "start_time": "2026-06-02T00:29:36.479029+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1021,16 +1049,16 @@
    "id": "b1263c6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:29.543743Z",
-     "iopub.status.busy": "2026-05-27T10:11:29.540477Z",
-     "iopub.status.idle": "2026-05-27T10:11:29.630184Z",
-     "shell.execute_reply": "2026-05-27T10:11:29.622760Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.491814Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.491588Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.497479Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.496861Z"
     },
     "papermill": {
-     "duration": 0.144683,
-     "end_time": "2026-05-27T10:11:29.636569+00:00",
+     "duration": 0.011957,
+     "end_time": "2026-06-02T00:29:36.498276+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.491886+00:00",
+     "start_time": "2026-06-02T00:29:36.486319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1132,10 +1160,10 @@
    "id": "1a969bc5",
    "metadata": {
     "papermill": {
-     "duration": 0.019103,
-     "end_time": "2026-05-27T10:11:29.698818+00:00",
+     "duration": 0.003743,
+     "end_time": "2026-06-02T00:29:36.505860+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.679715+00:00",
+     "start_time": "2026-06-02T00:29:36.502117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1159,10 +1187,10 @@
    "id": "d71be242",
    "metadata": {
     "papermill": {
-     "duration": 0.012762,
-     "end_time": "2026-05-27T10:11:29.726350+00:00",
+     "duration": 0.004076,
+     "end_time": "2026-06-02T00:29:36.514047+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.713588+00:00",
+     "start_time": "2026-06-02T00:29:36.509971+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1181,16 +1209,16 @@
    "id": "4022209e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:29.814870Z",
-     "iopub.status.busy": "2026-05-27T10:11:29.810371Z",
-     "iopub.status.idle": "2026-05-27T10:11:29.895815Z",
-     "shell.execute_reply": "2026-05-27T10:11:29.885387Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.523009Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.522837Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.528570Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.527940Z"
     },
     "papermill": {
-     "duration": 0.141761,
-     "end_time": "2026-05-27T10:11:29.904970+00:00",
+     "duration": 0.011144,
+     "end_time": "2026-06-02T00:29:36.529152+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.763209+00:00",
+     "start_time": "2026-06-02T00:29:36.518008+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1288,10 +1316,10 @@
    "id": "e22df85d",
    "metadata": {
     "papermill": {
-     "duration": 0.041831,
-     "end_time": "2026-05-27T10:11:30.013469+00:00",
+     "duration": 0.004001,
+     "end_time": "2026-06-02T00:29:36.537071+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:29.971638+00:00",
+     "start_time": "2026-06-02T00:29:36.533070+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1314,10 +1342,10 @@
    "id": "f1e0ba93",
    "metadata": {
     "papermill": {
-     "duration": 0.01769,
-     "end_time": "2026-05-27T10:11:30.061846+00:00",
+     "duration": 0.004478,
+     "end_time": "2026-06-02T00:29:36.546124+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.044156+00:00",
+     "start_time": "2026-06-02T00:29:36.541646+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1336,16 +1364,16 @@
    "id": "6759ffea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:30.076098Z",
-     "iopub.status.busy": "2026-05-27T10:11:30.075688Z",
-     "iopub.status.idle": "2026-05-27T10:11:30.085157Z",
-     "shell.execute_reply": "2026-05-27T10:11:30.083944Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.556962Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.556750Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.563981Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.563227Z"
     },
     "papermill": {
-     "duration": 0.01744,
-     "end_time": "2026-05-27T10:11:30.086126+00:00",
+     "duration": 0.014174,
+     "end_time": "2026-06-02T00:29:36.564860+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.068686+00:00",
+     "start_time": "2026-06-02T00:29:36.550686+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1423,10 +1451,10 @@
    "id": "c00743ef",
    "metadata": {
     "papermill": {
-     "duration": 0.005541,
-     "end_time": "2026-05-27T10:11:30.098480+00:00",
+     "duration": 0.004578,
+     "end_time": "2026-06-02T00:29:36.574324+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.092939+00:00",
+     "start_time": "2026-06-02T00:29:36.569746+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1451,10 +1479,10 @@
    "id": "a6ccf734",
    "metadata": {
     "papermill": {
-     "duration": 0.005519,
-     "end_time": "2026-05-27T10:11:30.109320+00:00",
+     "duration": 0.004764,
+     "end_time": "2026-06-02T00:29:36.583709+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.103801+00:00",
+     "start_time": "2026-06-02T00:29:36.578945+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1473,16 +1501,16 @@
    "id": "092cac51",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:30.122944Z",
-     "iopub.status.busy": "2026-05-27T10:11:30.122467Z",
-     "iopub.status.idle": "2026-05-27T10:11:30.130971Z",
-     "shell.execute_reply": "2026-05-27T10:11:30.129543Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.594434Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.594164Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.599987Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.599166Z"
     },
     "papermill": {
-     "duration": 0.016845,
-     "end_time": "2026-05-27T10:11:30.132075+00:00",
+     "duration": 0.012407,
+     "end_time": "2026-06-02T00:29:36.600810+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.115230+00:00",
+     "start_time": "2026-06-02T00:29:36.588403+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1551,10 +1579,10 @@
    "id": "01ea5c6c",
    "metadata": {
     "papermill": {
-     "duration": 0.005189,
-     "end_time": "2026-05-27T10:11:30.142688+00:00",
+     "duration": 0.004474,
+     "end_time": "2026-06-02T00:29:36.610089+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.137499+00:00",
+     "start_time": "2026-06-02T00:29:36.605615+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1578,10 +1606,10 @@
    "id": "671bff9b",
    "metadata": {
     "papermill": {
-     "duration": 0.004912,
-     "end_time": "2026-05-27T10:11:30.152521+00:00",
+     "duration": 0.006567,
+     "end_time": "2026-06-02T00:29:36.621368+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.147609+00:00",
+     "start_time": "2026-06-02T00:29:36.614801+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1599,10 +1627,10 @@
    "id": "341c7bfb",
    "metadata": {
     "papermill": {
-     "duration": 0.005096,
-     "end_time": "2026-05-27T10:11:30.162766+00:00",
+     "duration": 0.004672,
+     "end_time": "2026-06-02T00:29:36.630639+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.157670+00:00",
+     "start_time": "2026-06-02T00:29:36.625967+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1625,16 +1653,16 @@
    "id": "409ababa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:30.174646Z",
-     "iopub.status.busy": "2026-05-27T10:11:30.174385Z",
-     "iopub.status.idle": "2026-05-27T10:11:30.179296Z",
-     "shell.execute_reply": "2026-05-27T10:11:30.178214Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.641656Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.641422Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.645051Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.644394Z"
     },
     "papermill": {
-     "duration": 0.01236,
-     "end_time": "2026-05-27T10:11:30.180304+00:00",
+     "duration": 0.010787,
+     "end_time": "2026-06-02T00:29:36.646245+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.167944+00:00",
+     "start_time": "2026-06-02T00:29:36.635458+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1679,10 +1707,10 @@
    "id": "719920a9",
    "metadata": {
     "papermill": {
-     "duration": 0.00674,
-     "end_time": "2026-05-27T10:11:30.197359+00:00",
+     "duration": 0.004724,
+     "end_time": "2026-06-02T00:29:36.656019+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.190619+00:00",
+     "start_time": "2026-06-02T00:29:36.651295+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1708,16 +1736,16 @@
    "id": "89b763a7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:30.210661Z",
-     "iopub.status.busy": "2026-05-27T10:11:30.209960Z",
-     "iopub.status.idle": "2026-05-27T10:11:30.218579Z",
-     "shell.execute_reply": "2026-05-27T10:11:30.215911Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.668882Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.668538Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.674167Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.673378Z"
     },
     "papermill": {
-     "duration": 0.016226,
-     "end_time": "2026-05-27T10:11:30.219681+00:00",
+     "duration": 0.014132,
+     "end_time": "2026-06-02T00:29:36.674947+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.203455+00:00",
+     "start_time": "2026-06-02T00:29:36.660815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1781,10 +1809,10 @@
    "id": "44737d28",
    "metadata": {
     "papermill": {
-     "duration": 0.011137,
-     "end_time": "2026-05-27T10:11:30.237570+00:00",
+     "duration": 0.004519,
+     "end_time": "2026-06-02T00:29:36.684367+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.226433+00:00",
+     "start_time": "2026-06-02T00:29:36.679848+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1810,16 +1838,16 @@
    "id": "d20502d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-27T10:11:30.253001Z",
-     "iopub.status.busy": "2026-05-27T10:11:30.252728Z",
-     "iopub.status.idle": "2026-05-27T10:11:30.259209Z",
-     "shell.execute_reply": "2026-05-27T10:11:30.258279Z"
+     "iopub.execute_input": "2026-06-02T00:29:36.694632Z",
+     "iopub.status.busy": "2026-06-02T00:29:36.694272Z",
+     "iopub.status.idle": "2026-06-02T00:29:36.698331Z",
+     "shell.execute_reply": "2026-06-02T00:29:36.697782Z"
     },
     "papermill": {
-     "duration": 0.015285,
-     "end_time": "2026-05-27T10:11:30.259870+00:00",
+     "duration": 0.010226,
+     "end_time": "2026-06-02T00:29:36.699060+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.244585+00:00",
+     "start_time": "2026-06-02T00:29:36.688834+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1868,18 +1896,35 @@
   {
    "cell_type": "markdown",
    "id": "a1ba5b56",
-   "source": "## Resume et perspectives\n\nCe notebook a explore l'intersection entre la Programmation Logique Inductive (ILP) et les Knowledge Graphs, en montrant comment les techniques de minage de regles d'association s'adaptent aux donnees du Web Semantique. La construction d'un Knowledge Graph familial avec rdflib a illustre la correspondance naturelle entre triples RDF `(sujet, predicat, objet)` et faits logiques `predicat(sujet, objet)`. L'algorithme de rule mining inspire d'AMIE3 a decouvert automatiquement des regles de Horn dans ce graphe, notamment la regle compositionnelle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)` avec une confiance de 0.36 et une PCA confiance de 0.62.\n\nLa distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 7 triples sur les 8 possibles.\n\nLes proprietes logiques detectees automatiquement (symetrie de `siblingOf` et `marriedTo`, composition `parentOf ^ parentOf => grandparentOf`) correspondent aux proprietes OWL declarees manuellement dans les ontologies formelles. Le rule mining les apprend directement des donnees, offrant une alternative scalable a la modelisation ontologique manuelle. Le notebook suivant, [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb), prolonge cette reflexion en explorant comment les grands modeles de langage peuvent generer et valider des regles symboliques, ouvrant la voie a une cooperation entre approches statistiques a grande echelle et raisonnement formel.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004388,
+     "end_time": "2026-06-02T00:29:36.707910+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T00:29:36.703522+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore l'intersection entre la Programmation Logique Inductive (ILP) et les Knowledge Graphs, en montrant comment les techniques de minage de regles d'association s'adaptent aux donnees du Web Semantique. La construction d'un Knowledge Graph familial avec rdflib a illustre la correspondance naturelle entre triples RDF `(sujet, predicat, objet)` et faits logiques `predicat(sujet, objet)`. L'algorithme de rule mining inspire d'AMIE3 a decouvert automatiquement des regles de Horn dans ce graphe, notamment la regle compositionnelle `parentOf(X,Y) ^ parentOf(Y,Z) => grandparentOf(X,Z)` avec une confiance de 0.36 et une PCA confiance de 0.62.\n",
+    "\n",
+    "La distinction entre confiance standard et PCA confiance est centrale dans le contexte des Knowledge Graphs. L'Open World Assumption (OWA) signifie que l'absence d'un triple ne signifie pas que le fait est faux -- il est simplement inconnu. La PCA confiance corrige partiellement cette limitation en excluant du denominateur les paires dont le sujet n'a aucun triple de tete connu. L'application pratique des regles decouvertes a permis de completer le graphe en inferant 2 nouveaux triples `grandparentOf` manquants, passant de 5 a 7 triples sur les 8 possibles.\n",
+    "\n",
+    "Les proprietes logiques detectees automatiquement (symetrie de `siblingOf` et `marriedTo`, composition `parentOf ^ parentOf => grandparentOf`) correspondent aux proprietes OWL declarees manuellement dans les ontologies formelles. Le rule mining les apprend directement des donnees, offrant une alternative scalable a la modelisation ontologique manuelle. Le notebook suivant, [SL-7 - LLM + Symbolic Learning](SL-7-LLM-SymbolicLearning.ipynb), prolonge cette reflexion en explorant comment les grands modeles de langage peuvent generer et valider des regles symboliques, ouvrant la voie a une cooperation entre approches statistiques a grande echelle et raisonnement formel."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "c4b6e83b",
    "metadata": {
     "papermill": {
-     "duration": 0.005535,
-     "end_time": "2026-05-27T10:11:30.270445+00:00",
+     "duration": 0.004382,
+     "end_time": "2026-06-02T00:29:36.716740+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.264910+00:00",
+     "start_time": "2026-06-02T00:29:36.712358+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1930,10 +1975,10 @@
    "id": "cf1b23f7",
    "metadata": {
     "papermill": {
-     "duration": 0.006011,
-     "end_time": "2026-05-27T10:11:30.281591+00:00",
+     "duration": 0.004616,
+     "end_time": "2026-06-02T00:29:36.725764+00:00",
      "exception": false,
-     "start_time": "2026-05-27T10:11:30.275580+00:00",
+     "start_time": "2026-06-02T00:29:36.721148+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1972,18 +2017,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.653418,
-   "end_time": "2026-05-27T10:11:30.637463+00:00",
+   "duration": 13.843734,
+   "end_time": "2026-06-02T00:29:37.086687+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-6-KnowledgeGraphs-ILP.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-6-KnowledgeGraphs-ILP.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\SymbolicAI\\SymbolicLearning\\SL-6-KnowledgeGraphs-ILP_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-27T10:11:24.984045+00:00",
+   "start_time": "2026-06-02T00:29:23.242953+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `SL-6-KnowledgeGraphs-ILP.ipynb`.

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `859f5cfd` | After `6422a73a` (pip install rdflib) | "Importation et construction du Knowledge Graph" |

## Validation proof

- **Papermill**: 41/41 cells executed, 0 errors, kernel=python3, 16.3s
- **execution_count**: All 13 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 223 insertions, 178 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>