### PR TITLE
fix(search): add convention prints to Search-6, App-13, App-18

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-13-TSP-Metaheuristics.ipynb
@@ -2041,7 +2041,8 @@
     "\n",
     "    population.sort(key=lambda x: tsp.cout_tournee(x))\n",
     "    meilleure = population[0]\n",
-    "    return meilleure, tsp.cout_tournee(meilleure), historique"
+    "    return meilleure, tsp.cout_tournee(meilleure), historique\n",
+    "print('Fonction algorithme_genetique_hybride_tsp definie')"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-18-HyperparameterTuning.ipynb
@@ -140,7 +140,8 @@
     "    \n",
     "    model = RandomForestClassifier(**rf_params)\n",
     "    scores = cross_val_score(model, X_train, y_train, cv=cv_folds, scoring='accuracy')\n",
-    "    return scores.mean()"
+    "    return scores.mean()\n",
+    "print('Fonction evaluate_random_forest et espace de recherche definis')"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -6,10 +6,10 @@
    "metadata": {
     "id": "nav-header",
     "papermill": {
-     "duration": 0.015878,
-     "end_time": "2026-05-23T01:51:57.810504",
+     "duration": 0.006773,
+     "end_time": "2026-06-02T03:05:13.026321",
      "exception": false,
-     "start_time": "2026-05-23T01:51:57.794626",
+     "start_time": "2026-06-02T03:05:13.019548",
      "status": "completed"
     },
     "tags": []
@@ -45,18 +45,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:57.832019Z",
-     "iopub.status.busy": "2026-05-23T01:51:57.831858Z",
-     "iopub.status.idle": "2026-05-23T01:51:58.643445Z",
-     "shell.execute_reply": "2026-05-23T01:51:58.642938Z"
+     "iopub.execute_input": "2026-06-02T03:05:13.035523Z",
+     "iopub.status.busy": "2026-06-02T03:05:13.035171Z",
+     "iopub.status.idle": "2026-06-02T03:05:13.915918Z",
+     "shell.execute_reply": "2026-06-02T03:05:13.915240Z"
     },
     "id": "imports",
     "outputId": "0ffa3126-c485-4eda-d045-900adea674f0",
     "papermill": {
-     "duration": 0.833415,
-     "end_time": "2026-05-23T01:51:58.643919",
+     "duration": 0.886471,
+     "end_time": "2026-06-02T03:05:13.916952",
      "exception": false,
-     "start_time": "2026-05-23T01:51:57.810504",
+     "start_time": "2026-06-02T03:05:13.030481",
      "status": "completed"
     },
     "tags": []
@@ -93,10 +93,10 @@
    "metadata": {
     "id": "intro-section",
     "papermill": {
-     "duration": 0.03991,
-     "end_time": "2026-05-23T01:51:58.762577",
+     "duration": 0.003788,
+     "end_time": "2026-06-02T03:05:13.924692",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.722667",
+     "start_time": "2026-06-02T03:05:13.920904",
      "status": "completed"
     },
     "tags": []
@@ -130,10 +130,10 @@
    "metadata": {
     "id": "game-model-section",
     "papermill": {
-     "duration": 0.047962,
-     "end_time": "2026-05-23T01:51:58.874491",
+     "duration": 0.00415,
+     "end_time": "2026-06-02T03:05:13.932887",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.826529",
+     "start_time": "2026-06-02T03:05:13.928737",
      "status": "completed"
     },
     "tags": []
@@ -158,22 +158,30 @@
    "id": "game-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:58.980006Z",
-     "iopub.status.busy": "2026-05-23T01:51:58.978091Z",
-     "iopub.status.idle": "2026-05-23T01:51:59.009597Z",
-     "shell.execute_reply": "2026-05-23T01:51:59.004040Z"
+     "iopub.execute_input": "2026-06-02T03:05:13.942839Z",
+     "iopub.status.busy": "2026-06-02T03:05:13.942407Z",
+     "iopub.status.idle": "2026-06-02T03:05:13.948616Z",
+     "shell.execute_reply": "2026-06-02T03:05:13.947832Z"
     },
     "id": "game-class",
     "papermill": {
-     "duration": 0.082848,
-     "end_time": "2026-05-23T01:51:59.013603",
+     "duration": 0.012606,
+     "end_time": "2026-06-02T03:05:13.949675",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.930755",
+     "start_time": "2026-06-02T03:05:13.937069",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classe JeuSommeNulle (abstraite) definie\n"
+     ]
+    }
+   ],
    "source": [
     "# Classe de base abstraite pour un jeu a somme nulle\n",
     "from abc import ABC, abstractmethod\n",
@@ -214,7 +222,8 @@
     "    @abstractmethod\n",
     "    def afficher(self, etat: Any) -> str:\n",
     "        \"\"\"Representation textuelle de l'etat.\"\"\"\n",
-    "        pass"
+    "        pass\n",
+    "print('Classe JeuSommeNulle (abstraite) definie')"
    ]
   },
   {
@@ -223,10 +232,10 @@
    "metadata": {
     "id": "tictactoe-section",
     "papermill": {
-     "duration": 0.031371,
-     "end_time": "2026-05-23T01:51:59.094722",
+     "duration": 0.012488,
+     "end_time": "2026-06-02T03:05:13.966304",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.063351",
+     "start_time": "2026-06-02T03:05:13.953816",
      "status": "completed"
     },
     "tags": []
@@ -246,18 +255,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:59.135323Z",
-     "iopub.status.busy": "2026-05-23T01:51:59.135159Z",
-     "iopub.status.idle": "2026-05-23T01:51:59.142397Z",
-     "shell.execute_reply": "2026-05-23T01:51:59.141928Z"
+     "iopub.execute_input": "2026-06-02T03:05:13.976916Z",
+     "iopub.status.busy": "2026-06-02T03:05:13.976590Z",
+     "iopub.status.idle": "2026-06-02T03:05:13.986905Z",
+     "shell.execute_reply": "2026-06-02T03:05:13.986195Z"
     },
     "id": "tictactoe-class",
     "outputId": "8095c631-decd-4bc7-bcad-850846369168",
     "papermill": {
-     "duration": 0.029361,
-     "end_time": "2026-05-23T01:51:59.143522",
+     "duration": 0.017693,
+     "end_time": "2026-06-02T03:05:13.987868",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.114161",
+     "start_time": "2026-06-02T03:05:13.970175",
      "status": "completed"
     },
     "tags": []
@@ -347,10 +356,10 @@
    "metadata": {
     "id": "aaa9b982",
     "papermill": {
-     "duration": 0.026729,
-     "end_time": "2026-05-23T01:51:59.170251",
+     "duration": 0.006114,
+     "end_time": "2026-06-02T03:05:13.998763",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.143522",
+     "start_time": "2026-06-02T03:05:13.992649",
      "status": "completed"
     },
     "tags": []
@@ -383,10 +392,10 @@
    "metadata": {
     "id": "minimax-section",
     "papermill": {
-     "duration": 0.008981,
-     "end_time": "2026-05-23T01:51:59.193566",
+     "duration": 0.004239,
+     "end_time": "2026-06-02T03:05:14.007069",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.184585",
+     "start_time": "2026-06-02T03:05:14.002830",
      "status": "completed"
     },
     "tags": []
@@ -424,18 +433,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:59.239725Z",
-     "iopub.status.busy": "2026-05-23T01:51:59.239463Z",
-     "iopub.status.idle": "2026-05-23T01:52:01.183920Z",
-     "shell.execute_reply": "2026-05-23T01:52:01.182598Z"
+     "iopub.execute_input": "2026-06-02T03:05:14.017596Z",
+     "iopub.status.busy": "2026-06-02T03:05:14.017160Z",
+     "iopub.status.idle": "2026-06-02T03:05:15.196904Z",
+     "shell.execute_reply": "2026-06-02T03:05:15.195912Z"
     },
     "id": "minimax-impl",
     "outputId": "34905489-07a6-4fa4-e344-6103f39f3bbd",
     "papermill": {
-     "duration": 1.986038,
-     "end_time": "2026-05-23T01:52:01.182516",
+     "duration": 1.186717,
+     "end_time": "2026-06-02T03:05:15.198264",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.196478",
+     "start_time": "2026-06-02T03:05:14.011547",
      "status": "completed"
     },
     "tags": []
@@ -497,10 +506,10 @@
    "metadata": {
     "id": "8dc4ff51",
     "papermill": {
-     "duration": 0.008781,
-     "end_time": "2026-05-23T01:52:01.201932",
+     "duration": 0.003585,
+     "end_time": "2026-06-02T03:05:15.205749",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.193151",
+     "start_time": "2026-06-02T03:05:15.202164",
      "status": "completed"
     },
     "tags": []
@@ -533,10 +542,10 @@
    "metadata": {
     "id": "minimax-analysis",
     "papermill": {
-     "duration": 0.008615,
-     "end_time": "2026-05-23T01:52:01.218295",
+     "duration": 0.003694,
+     "end_time": "2026-06-02T03:05:15.212994",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.209680",
+     "start_time": "2026-06-02T03:05:15.209300",
      "status": "completed"
     },
     "tags": []
@@ -560,10 +569,10 @@
    "metadata": {
     "id": "alphabeta-section",
     "papermill": {
-     "duration": 0.005608,
-     "end_time": "2026-05-23T01:52:01.231696",
+     "duration": 0.003644,
+     "end_time": "2026-06-02T03:05:15.220287",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.226088",
+     "start_time": "2026-06-02T03:05:15.216643",
      "status": "completed"
     },
     "tags": []
@@ -594,18 +603,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:01.256066Z",
-     "iopub.status.busy": "2026-05-23T01:52:01.255816Z",
-     "iopub.status.idle": "2026-05-23T01:52:03.151786Z",
-     "shell.execute_reply": "2026-05-23T01:52:03.150907Z"
+     "iopub.execute_input": "2026-06-02T03:05:15.229462Z",
+     "iopub.status.busy": "2026-06-02T03:05:15.228877Z",
+     "iopub.status.idle": "2026-06-02T03:05:16.525090Z",
+     "shell.execute_reply": "2026-06-02T03:05:16.524353Z"
     },
     "id": "alphabeta-impl",
     "outputId": "e00eae70-363a-4b9f-8c8d-56845ac63313",
     "papermill": {
-     "duration": 1.919135,
-     "end_time": "2026-05-23T01:52:03.150831",
+     "duration": 1.30211,
+     "end_time": "2026-06-02T03:05:16.526218",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.231696",
+     "start_time": "2026-06-02T03:05:15.224108",
      "status": "completed"
     },
     "tags": []
@@ -615,9 +624,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minimax: valeur=0, temps=1.7592s\n",
-      "Alpha-Beta: valeur=0, temps=0.1287s\n",
-      "Speedup: 13.7x\n"
+      "Minimax: valeur=0, temps=1.2479s\n",
+      "Alpha-Beta: valeur=0, temps=0.0405s\n",
+      "Speedup: 30.8x\n"
      ]
     }
    ],
@@ -682,10 +691,10 @@
    "metadata": {
     "id": "627318e5",
     "papermill": {
-     "duration": 0.011109,
-     "end_time": "2026-05-23T01:52:03.161940",
+     "duration": 0.004162,
+     "end_time": "2026-06-02T03:05:16.534881",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.150831",
+     "start_time": "2026-06-02T03:05:16.530719",
      "status": "completed"
     },
     "tags": []
@@ -718,10 +727,10 @@
    "metadata": {
     "id": "iterative-deepening-section",
     "papermill": {
-     "duration": 0.014836,
-     "end_time": "2026-05-23T01:52:03.193790",
+     "duration": 0.004266,
+     "end_time": "2026-06-02T03:05:16.543618",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.178954",
+     "start_time": "2026-06-02T03:05:16.539352",
      "status": "completed"
     },
     "tags": []
@@ -741,18 +750,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:03.229402Z",
-     "iopub.status.busy": "2026-05-23T01:52:03.228896Z",
-     "iopub.status.idle": "2026-05-23T01:52:04.066494Z",
-     "shell.execute_reply": "2026-05-23T01:52:04.061525Z"
+     "iopub.execute_input": "2026-06-02T03:05:16.553581Z",
+     "iopub.status.busy": "2026-06-02T03:05:16.553126Z",
+     "iopub.status.idle": "2026-06-02T03:05:17.079901Z",
+     "shell.execute_reply": "2026-06-02T03:05:17.079109Z"
     },
     "id": "iterative-deepening-impl",
     "outputId": "bc00184b-f1b0-4eaa-e271-0eed965bd926",
     "papermill": {
-     "duration": 0.874651,
-     "end_time": "2026-05-23T01:52:04.068441",
+     "duration": 0.533064,
+     "end_time": "2026-06-02T03:05:17.080869",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.193790",
+     "start_time": "2026-06-02T03:05:16.547805",
      "status": "completed"
     },
     "tags": []
@@ -762,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iterative Deepening: valeur=0.00, action=0, profondeur=9\n"
+      "Iterative Deepening: valeur=0.00, action=0, profondeur=18\n"
      ]
     }
    ],
@@ -845,10 +854,10 @@
    "metadata": {
     "id": "5d62e6c9",
     "papermill": {
-     "duration": 0.011734,
-     "end_time": "2026-05-23T01:52:04.103822",
+     "duration": 0.004023,
+     "end_time": "2026-06-02T03:05:17.088975",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.092088",
+     "start_time": "2026-06-02T03:05:17.084952",
      "status": "completed"
     },
     "tags": []
@@ -880,10 +889,10 @@
    "metadata": {
     "id": "transposition-section",
     "papermill": {
-     "duration": 0.008612,
-     "end_time": "2026-05-23T01:52:04.123561",
+     "duration": 0.003939,
+     "end_time": "2026-06-02T03:05:17.096944",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.114949",
+     "start_time": "2026-06-02T03:05:17.093005",
      "status": "completed"
     },
     "tags": []
@@ -903,18 +912,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:04.163616Z",
-     "iopub.status.busy": "2026-05-23T01:52:04.163077Z",
-     "iopub.status.idle": "2026-05-23T01:52:04.248458Z",
-     "shell.execute_reply": "2026-05-23T01:52:04.246661Z"
+     "iopub.execute_input": "2026-06-02T03:05:17.106615Z",
+     "iopub.status.busy": "2026-06-02T03:05:17.106192Z",
+     "iopub.status.idle": "2026-06-02T03:05:17.123454Z",
+     "shell.execute_reply": "2026-06-02T03:05:17.122737Z"
     },
     "id": "transposition-impl",
     "outputId": "d55a8202-0622-4ca7-b269-8fb761d11d31",
     "papermill": {
-     "duration": 0.109051,
-     "end_time": "2026-05-23T01:52:04.249653",
+     "duration": 0.023658,
+     "end_time": "2026-06-02T03:05:17.124641",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.140602",
+     "start_time": "2026-06-02T03:05:17.100983",
      "status": "completed"
     },
     "tags": []
@@ -924,14 +933,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Alpha-Beta + Transposition: valeur=0, temps=0.0587s"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Alpha-Beta + Transposition: valeur=0, temps=0.0092s\n",
       "Cache: 1565 hits, 3010 misses\n"
      ]
     }
@@ -1001,10 +1003,10 @@
    "metadata": {
     "id": "064d99f8",
     "papermill": {
-     "duration": 0.028062,
-     "end_time": "2026-05-23T01:52:04.319218",
+     "duration": 0.004263,
+     "end_time": "2026-06-02T03:05:17.133415",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.291156",
+     "start_time": "2026-06-02T03:05:17.129152",
      "status": "completed"
     },
     "tags": []
@@ -1036,10 +1038,10 @@
    "metadata": {
     "id": "benchmark-section",
     "papermill": {
-     "duration": 0.02217,
-     "end_time": "2026-05-23T01:52:04.367385",
+     "duration": 0.004637,
+     "end_time": "2026-06-02T03:05:17.142330",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.345215",
+     "start_time": "2026-06-02T03:05:17.137693",
      "status": "completed"
     },
     "tags": []
@@ -1058,18 +1060,18 @@
      "height": 633
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:04.397835Z",
-     "iopub.status.busy": "2026-05-23T01:52:04.397556Z",
-     "iopub.status.idle": "2026-05-23T01:52:11.337028Z",
-     "shell.execute_reply": "2026-05-23T01:52:11.332805Z"
+     "iopub.execute_input": "2026-06-02T03:05:17.152723Z",
+     "iopub.status.busy": "2026-06-02T03:05:17.152382Z",
+     "iopub.status.idle": "2026-06-02T03:05:18.868723Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.868029Z"
     },
     "id": "benchmark-code",
     "outputId": "65944d28-83b4-4b83-8997-3686c981910c",
     "papermill": {
-     "duration": 6.957527,
-     "end_time": "2026-05-23T01:52:11.342234",
+     "duration": 1.723033,
+     "end_time": "2026-06-02T03:05:18.869749",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.384707",
+     "start_time": "2026-06-02T03:05:17.146716",
      "status": "completed"
     },
     "tags": []
@@ -1106,23 +1108,23 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Minimax</td>\n",
-       "      <td>5.000847</td>\n",
+       "      <td>1.269681</td>\n",
        "      <td>0</td>\n",
        "      <td>1.0x</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Alpha-Beta</td>\n",
-       "      <td>0.346236</td>\n",
+       "      <td>0.056275</td>\n",
        "      <td>0</td>\n",
-       "      <td>14.4x</td>\n",
+       "      <td>22.6x</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Alpha-Beta + Trans</td>\n",
-       "      <td>0.017145</td>\n",
+       "      <td>0.013862</td>\n",
        "      <td>0</td>\n",
-       "      <td>291.7x</td>\n",
+       "      <td>91.6x</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1130,9 +1132,9 @@
       ],
       "text/plain": [
        "           Algorithme  Temps (s)  Valeur Speedup\n",
-       "0             Minimax   5.000847       0    1.0x\n",
-       "1          Alpha-Beta   0.346236       0   14.4x\n",
-       "2  Alpha-Beta + Trans   0.017145       0  291.7x"
+       "0             Minimax   1.269681       0    1.0x\n",
+       "1          Alpha-Beta   0.056275       0   22.6x\n",
+       "2  Alpha-Beta + Trans   0.013862       0   91.6x"
       ]
      },
      "metadata": {},
@@ -1140,7 +1142,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATvdJREFUeJzt3QeYVOXdP+4HLBQFLCiIoNiiYJdmS8QSe4klMUoSezRZjYkl0dgSa4zREM2qr2KJXWNLohGNxsQesWD0xS4qigpWRFAR9n99n/c3859ddmF33eMuu/d9XQMzZ8/MPnPmzNnzOU/rVFNTU5MAAACAFte55V8SAAAACEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjfAAmrgwIFp3333TQuSkSNH5ltb1Npli88yPtPGrrv44oun9qwp26MtiX1orbXWSm3F5Zdfnjp16pQee+yx1Jb961//yuWM/9uz5h63X3311bx94vMEFjxCN9DmvPzyy+nggw9OK6+8curatWvq2bNn2mSTTdIf/vCHNHPmzNYuHnwlZsyYkX71q1+1+xACAO3dwq1dAIBKt99+e/r2t7+dunTpkn7wgx/kGqPPP/88PfDAA+noo49O//u//5suuuii1i5mm/D888+nzp1dO20vLr744jRnzpxaofvXv/51vt9WWwcATeO4DR2T0A20GRMnTkzf/e5304orrpj++c9/puWWW678s6qqqvTSSy/lUN4eRdiKiwtRs99YcWGCBd8nn3ySFltssbTIIou0dlE67LbvCMcLWm8fqKmpSZ9++mnq1q2b4zZ0UC61AW3Gb3/72zR9+vR0ySWX1ArcJauuumo6/PDDy4+/+OKLdMopp6RVVlkln8hEX7lf/vKX6bPPPqv1vFi+44475ma6Q4cOzSc+a6+9drnZ7s0335wfxwnskCFD0pNPPllv/9lXXnklbbPNNvkErV+/funkk0/OJ1OVfve736WNN944Lb300vn3xOvdeOONc72X6Jt36KGHpquvvjqtueaaufxjx45t0mvU7Rs4a9asXDO62mqr5fcSz990003TP/7xj1rPiwsaX//61/P7WGKJJdIuu+ySnn322VrrRLPmKGNc6IjfEev16tUr7bfffrkGtjGiRUJ8NvEehg8fnu6///5614vP66STTsqfb2yHAQMGpJ///OdzfY7xPuL9RFni81h99dXz5z0/l112Wdpiiy3Ssssum19/8ODB6YILLmjUe3jttdfSzjvvnLdVPP9nP/tZuvPOO+vte/rnP/85f1bxfnv37p2+973vpTfffLPefSm6UGy//fapR48eadSoUXP1YY7+m8sss0y+H59p/L64xedSKV7/W9/6Vn7NWP+oo45Ks2fPnqsfaOxT1dXVuctG9+7d09Zbb50mTZqU99/4DvXv3z+XO/aF999/f67tcMcdd5T3mSjzDjvskFudVHr77bfz/hGvFds5vsPxelGG+bn11ltzq5bYb+P/W265pcGwOXr06PydiXX79OmTu6J88MEH8/0d89r2TXnd2BabbbZZfn50fRk2bFi65ppr5lpvwoQJafPNN8/be/nll8/Ht+bu+/M6XsQ+cMABB+RjUixfaaWV0o9+9KMcyuv+riOOOCLvJ/E57rrrrmnq1KnN+qzrE/tN7H9xLI3tHNtmu+22S0899dRc677xxht5v638XtV9z/F+43XqO97stddeqW/fvrX29caUe177wIsvvph23333/LqxD8R+HBeBP/rooyYfS0p/c+JYUfqb8z//8z/1Hrebst3q89xzz6U99tgjLbXUUrnc8fv++te/Nuq5wFdHTTfQZvztb3/LoSACZ2MceOCB6U9/+lM+4TjyyCPTf/7zn3TGGWfkAFn3pD3C4957751PpCMMRQjZaaed0oUXXpiD249//OO8Xjz/O9/5zlxNAOPkbtttt00bbrhhPnmOE944WY7gH+G7JPqdR0iLE7k46b3uuutyc/nbbrstnwTWDb833HBDPrmMkFYKXE15jUoRyKL8sV0i5E6bNi0PnvTEE0+kb37zm3mdu+++O5/QxXaO9aOP/HnnnZf7zMd6dQeuim0RJ/HxuvHzMWPG5BPOM888c56fTVw4iW0dn+VPf/rTfMEi3lOcGEawKImwE8uj+8APf/jDNGjQoPT000+n3//+9+mFF17IYSzEyXOcxK6zzjp5e8cJb3ymDz74YJqfOCmOoBK/Z+GFF877WXze8bujBcW8asDiBPutt97KF3viZDzC1b333jvXujG4UQTOCGCxrd555538OUb54iJOXCgoiX0mLt7EBYTYDyOU1RXBKMod4SnC0W677ZaXx/uv3CfjdUaMGJFfJz7bs88+O1/oiOdVirAW+9Jhhx2WT/JjH47PNt5fXDz4xS9+kbdn7AsRAC699NLyc6+88sq0zz775N8Vn3uEoChblD/eW2mficASn1P8jlg2ZcqUfKHk9ddfn+eAaHfddVd+bgSY2HbvvfdeObzXFftUaVv/5Cc/ya1j/vjHP+ZyxLaeX2uBhrZ9Y1831tl///3z/nTsscfmzzXWieNBHF9KIqzH8SI+t9jOcdEstnEEq/j+NWXfn9fxYvLkyfm7/uGHH+bXWGONNXIIj98Xn9Oiiy5afn58LksuuWQ+bsWFkLjIEK91/fXXN/mzrk98x6PMcayKY0Z8ByJoxgWKuAARFwVCHHO23HLLvF/Eto7l8Xvj/VXac88984WiUpejkihTfIcjuC600EJNLnd9+0B8N2JZBP/YTvFdj+0Yx9zYtnHBsanHkvgbEhcHYt866KCD8kXCL7Pd6hPftzh2x0WdY445Jl9wiH0kLmjcdNNN+dgBtBE1AG3ARx99FFXGNbvsskuj1h8/fnxe/8ADD6y1/KijjsrL//nPf5aXrbjiinnZQw89VF5255135mXdunWree2118rL/+d//icvv/fee8vL9tlnn7zssMMOKy+bM2dOzQ477FCz6KKL1kydOrW8fMaMGbXK8/nnn9estdZaNVtssUWt5fF6nTt3rvnf//3fud5bY18j3leUrWTdddfNZZqX9dZbr2bZZZetee+998rLnnrqqVyWH/zgB+VlJ510Ui7j/vvvX+v5u+66a83SSy89z98R5Y3fEb/rs88+Ky+/6KKL8mtuttlm5WVXXnll/t33339/rde48MIL87oPPvhgfvz73/8+P67c1o1Vd3uGbbbZpmbllVeutSzKVVm2s88+O//OW2+9tbxs5syZNWussUatfaT0fuMzip+X3HbbbXm9E088ca596ZhjjpmrTPGz+ExL4r3GuvFZ1Ldu/Ozkk0+utXz99devGTJkSPnxxIkT83rLLLNMzYcfflhefuyxx+blsc/MmjWrvHyvvfbK+/Snn36aH3/88cc1SyyxRM1BBx1U6/e8/fbbNb169Sov/+CDD/LrnXXWWTVNFfvJcsstV6t8d911V369yu0R+0gsu/rqq2s9f+zYsfUur6uhbd/Y143y9ejRo2bEiBG1PufS8aAk9qF43hVXXFFeFt+Dvn371uy+++5N3vfndbyI72wsHzdu3Fzvt1Smyy67LD9/q622qlXOn/3sZzULLbRQebs39rNuSOwzs2fPrrUs9r8uXbrU2k9Hjx6dy3PDDTeUl33yySc1q666aq3vVZR1+eWXr7XNQjwv1rvvvvuaXO6G9oEnn3wyL//zn//cIseS0t+c2Ifqqnvcbux2K32X4/Ms2XLLLWvWXnvt8ve1tN023njjmtVWW22e7wX4amleDrQJUSsborlfY/z973/P/0dzyUpR4x3q9v2OWrSNNtqo/DhqB0PU9K2wwgpzLY/ah7qiVqhuc8+oIYkaxpJoRlhZ2xVNE6PJY9QS1xU1GVGuupryGpWi1i1qPqKZZH2ixnb8+PG5hihqnEui9jRqwkvbtNIhhxxS63GUI2oiS59XfaJ2PWo547mVNW3xe0s1RpVNsqOGL2ro3n333fItPpdQqlUu1RT/5S9/qTXYWGNUbs/YlvH6se3jM65sOlpX1F5GDVLUapVE882otarv/UaNV2Uf22iVEO+rvnEI6tZEN1d9n099+27UolVu+9J+Hq0+osaucnns06Vm8VFTHTV9UWNX+flEDWOsW/p8YhvHZx215o1p6l13n4xaysryxf5Y97sR+0qsEz+rLEs06Y9mufW1QKhP3W3f2NeNbfHxxx/nGsW6fanjeFApnhfbtiS2TdRIV342jd33GzpexPcgakijxU40Ka6rbpmiJrxyWewr0VoiulA05bNuSLQ+KbUOiteN40SpG0jlsSuOM9H1IFoolURtc5Svbvljv431o9tRSdTMx/cyaqqbW+66+0Bp34vm4PPqPtOUY0nUWkft+fw0drvVFS1WonVAtKSI/bL0vuP58Xvj70Dd7i1A69G8HGgToh9biJOHxogTxThRib6QlaJZYAS00olkSWWwrjzJqmzqXLm8bnCI3xVNsit97Wtfy/9X9lmN5oinnnpqDhKVfRTrngCXTsrq05TXqBTNrqMPbZQr+sVG89bvf//75SbJpW1SXzPHOPmPE866gwrV3W7RPLW0fUqfWV2l3xN9yytFE9262zBODKM7QKn/cl0RZktNTaNpezSdj9ATzVOj6W6cuM9vJOBoHhxNah9++OG5TqjjRLnuhYDK9xFNtetu97r73Ly2awSqaD5cKUJufU2nmyqCX93tFp9PfaG3uft/6QJOKQjWVdoHIjhEs9646BX9oaMbRnQHiBkI4jvZkIb2lVA3dERZ4vOK7g3z2lfmpb5t39jXjX7AoTFzcMfvqLvfxGfz3//+t8n7fkPHi+iPHRe/Gjsn+Ly+y6XyNOazbkhcBIguFeeff35unl/Z3zrGl6j8zOM7VHf71Pf9ie99NIOPPsrRfD/Cd4TwaLJden5Ty13fPhDbNi7gnnPOObkrRlyQiIttceGk8vjQlGNJQ8f35m63uqI7SDSCOOGEE/KtoX0oLlAArU/oBtqEODGKvmvPPPNMk543vyBaUur719jldQdIa4wYKCxO1L7xjW/kE6iozYmgGYPv1DfQUmWtSXNfo1I8J4JB1AZHP9kIqdE/NPqtR1htjpbcPg2dcEY/1zjZrU8pFMa2uu+++3KtVdQcRy101HjFiXa814bKGdsjAnqE3/gd8XpR6xgn7rFtmlpr3hIqa7a+jIbec1PWnd/nW9o+0We2vvBcWUseffej1jVqX+MCTgSB6KMdtXHrr79++rKiLBGMIxTVp6HwOr9t3xKv25zvTWP3/XkdL1qyTE35rOtz+umn5888+rzH4HzRmia2dewXzf2excWb6I8d/ZQjdEcf6ugTHmG8pKnlbuj7F+MhRGuc0vEz+pvH/vvII4/kkN7UY0ljP6/mbrfSz2IMhoZq1OteIARaj9ANtBlRMxYjXkctQmVT8PrEtGJx0hG1HFFLWxKD0ERTw/h5S4rfFU0IS7XbIQY7CqVBemLgmqh9jMBROS1MBObG+rKvESdsMRhU3KJWKIJ4DJgWobu0TWKAn/pGwI3BmVpi6pzS74nPprL2KUZXj5qcddddt7wsapJjlN44mZ3fBZQ4EY314hYnvXGyetxxx+UgvtVWW9X7nDhJj9YCUVNWWdPXmKbI8T5iIKMIJZVlixqm+t5vbNe6tW2xrLn7YmMvKBUpPp8QobShbVx3/ajtjlt8/uutt14OM1ddddV895W66u6n8drRlSMGjvqyAbQ5r1vaFnFhsCXCTFP2/YYuBsTFyqZeqJxXeZryWdcVg7fFaO0xiGKlOB7HsaXyM48y1/1e1XdcCtF8OmqCo1Y/LrTF8TbCeEuVu1JcBInb8ccfnx566KG8T8RFy2h59GWOJS2x3eoqtRqKi7Jf9n0DxdOnG2gzYqqcCH0RECM81xU1DXHyFWK6lxBNDyuVao3mNcp3c8VoxiVxwhiP44QnTppLNUlxEll3yqa6oxDPy5d5jejLVyn6BUY4KDVRj1rzCEEx4nuc0JXECXDU7JS26ZcV/UsjEMTJauW0RTHyc+XvLZ1QR7/Diy++eK7XiRqtaO4e6pvGKt5LqDvVUH21e5U1jNEMtDEXMaL2KMpWOf1OzLVbt6zxfuOEP95vZVliCqNoPtzcfbE0snbdbfZVim0QwS4ucMRFk7pKU05FU9vYNpUiDMUYDfP6fCr3yco+sdFPNy541N1X4nsRtYF1xYjUzd1OjX3dmGYt3k/UftZ9r81p+dHYfX9eF6FilOoIgzGuQF1NLVNjP+t5fdfq/s7ot163X3EcZ2LU9cppEGP/iQuu9Yla7diHYh+JFi6x3Vqy3CECfXzWlSJ8xzYu7b9f5ljSEtutrjjmjBw5Mo90HmMjNOd9A18dNd1AmxEn6dGEOk6yovY6+oNGf8UIblHrECcipflNo7Y0Bl+KE7U4KY7BbB599NF8YhYnolFz0JKi9jlO+OJ3xuA8EaiimXNMN1ZqfhrhKkJ/9KWOppDRny6mvIngW9mXc16+zGvEIEtxEhYDQEWNd5yIx4lt5QBwZ511Vp6yKFoSxNy+pSnDoi9i3TmgmysuRETNUPS7jJrf+DyjhjtOTuv26Y4+59F0NAYEixqjqFmKABQ177G8NM9t9FeP5uWxfaKmLLZLNL+PZp+lAZXqE0EpmoBGs+coT9T+R8iJE9b6TlQrxfpxYSUGaIopwyIgRhPk0iBapVq6eL/RnzlaF8R+GOuXpgyLWrmYg7g5otY1PtOo3YsWFvGZxvehsX14W0KEmZgmKT6nDTbYIM9bHPt7TPcU+398XrGNotVHXHyKQBRljia9MW1fbId4zrxEiI3PNT7HaGIbF1hin4ypmSoH0IptG59JrB/jHcRnG9s+asnj2BDbu3JwrsZq7OvGtohmxHFRMKaGi+9n9IuO2uoIjXHsaYrG7vvzEkEzLpjFeyhNOxb7dZQ7xhKonKqupT7rebVUiu9pfA9iqsCY/iy+L3W/8zEQYbxOHN8ff/zx/L2KpuH1TZ0Xoixx/ItWLRGAK5uWt0S5Q3SBiONkDNwW37UI4FGmCMQxnd2XPZbMS2O3W33ib0N8b+ICQWzXeE5856K1WMyF3ti5voGvwFc8WjrAfL3wwgt5mpeBAwfm6Ytimp5NNtmk5rzzzqs1NUpMdfTrX/+6ZqWVVqpZZJFFagYMGJCnQqpcpzRFS31TacUhsKqqqtay0rQslVMfxfQuiy22WM3LL79cs/XWW9d07969pk+fPnkqp7pTvVxyySV5qpaY7iWmlorpXUrTb83vdzf1NepOPXPqqafWDB8+PE+fE1OhxXNPO+20PKVVpbvvvjtvz1inZ8+eNTvttFPNhAkTaq1T+n11p+gqTT8U22l+zj///PzZxPsYOnRonuKn7rRcIcp35pln1qy55pp53SWXXDJPexWfbUwlF+655548nVy/fv3yPhH/x/RWsa/Mz1//+teaddZZp6Zr1655n4rfdemll871Puor2yuvvJL3ndhWMe3WkUceWXPTTTfl5z7yyCO11r3++uvzlF3xHpZaaqmaUaNG1bzxxhu11intS/WpO2VYiGnuYlvEe66cPqyh16m7n9S3P4eYlqm+KZJKn2/dKahi/ZgaKaZgiu24yiqr1Oy77741jz32WP75u+++m/fn2OeiXLFeTK1VOS3UvMQ2HTRoUN52gwcPrrn55pvr3R6lqedim8RnEseGmDLp5z//ec3kyZPn+Tvmte2b8rqxP8WUTKXvT3znrr322vLPYx+Kfbm+31/3/TRm35/f8SKmPIypw2L/jNeI6ati3dJ0ffP6TOtOj9iYz7ohcdyN70dM/xbbJo4xDz/8cL3fqyjzzjvvnI+lvXv3rjn88MPLU7TVLU847rjj8s9iWrGGNKbcDe0D8T2P6RHjOfHc+P5uvvnm+VjZnGNJQ39zGpoyrDHbrb4pw0L8XYrPP6aki7+DMc3ajjvuWHPjjTc2uK2Ar16n+OerCPcAC6qoXY8a48paNzqu6NIQtddRk2RkYABgfvTpBoAGRPP7StGXN/pQxhRXAjcA0Bj6dANAA2Iu8BipOAb7ikGTYhTu6HPb0PRSAAB1Cd0A0IAYGTnmO4+QHYNcxSBh11133VyDOQEANESfbgAAACiIPt0AAABQEKEbAAAACqJP9zzMmTMnTZ48OfXo0SN16tSptYsDAABAGxE9tT/++OPUr1+/1Llzw/XZQvc8ROAeMGBAaxcDAACANmrSpEmpf//+Df5c6J6HqOEubcSePXu2dnEAAABoI6ZNm5YraUu5sSFC9zyUmpRH4Ba6AQAAqGt+XZENpAYAAAAFEboBAACgIEI3AAAAFEToBgAAgIII3fWorq5OgwcPTsOGDWvtotBG/OpXv8oDJNR3++KLL+b53Ouuuy5tsMEGqVu3bmmppZZKe+yxR3r55ZdrrRPz+/3sZz/LUw0suuiiaZVVVkm//vWv53rtxx9/PG277bZ5YL/u3bunTTfdNN1999211pkyZUr60Y9+lAYOHJi6du2allxyyTR8+PB06aWXtuAWAQAAGqNTTczoTYNDwPfq1St99NFHRi/v4CJ0Rwju3bt3DsSVHnzwwbTQQgvV+7xLLrkkHXjggfn+SiutlN577728Xy277LLpqaeeSn379k1z5sxJW2yxRfr3v/+dFllkkbTyyiunF198MS///ve/n6644or8/P/+979po402SjNmzMjl6NKlS3rzzTfz7/773/+ett5667zeyJEj82vF8rXWWiu99dZbOYiHv/71r2mnnXYqeGsBAED7N62ReVFNNzTBDjvskB555JFat4YC9+eff56OOeaYfH/33XdPr7zySnr22WfzPH4Rgk8//fT8s1tvvTWH5HDzzTen5557Lo0ePTo/vvLKK9MTTzyR7x9//PE5cEcNdrzWq6++mkaMGJFmz56djjrqqLxOXEN76KGH8v2DDjoojR8/Ppex5LXXXsv/x3OOPfbYHPCjNjxq4IcOHZrOOuusArceAAB0PEI3NMFNN92Um4kvt9xyaccdd0xPPvlkg+uOGzcuvfvuu+XQHfr165c23HDDfH/s2LH5/zvuuCP/H6+7/fbb11q/tF40My81I48a7QjuCy+8cNp5553zsqeffjpNnjw5N3ffZJNN8rKLL744rbfeevn3xfJYd9999y13ofjNb36TXn/99bT66qunpZdeOr/G7bffXsBWAwCAjkvohkaKGu1oDh41zW+//XYOqNHcu6HgPWnSpPL9aE5e0qdPn/x/BN7K9SL4du7cudY6pfUivM+cObPB16p8vVtuuSVts802uTY7mrBHrfriiy+e1l9//dwPPETz9bDffvvldeJxNH1X0w0AAC1L6IZG2HvvvXN4jXAaTcRLtdSfffZZrjVuisYMo9DYoRbqWy+ajd955515wLboX3L//ffnckaf9HPPPTevE7X0Ufs9ZsyYtPzyy6fNN988nXrqqbmZOQAA0HKEbmiEr33ta7UCadQkR810ZQ1zXQMGDCjfLw1kVnl/hRVWqLVe1GbH4Gl114/1YuC0aH7e0GuV1ouLAhdeeGH5QkEM6BAjnK+xxhp5WamJepQ/+or/8pe/zDXgL7zwQjrzzDNz0/Tp06d/iS0FAABUErqhESKQVobrf/zjH7k5dojm5mHLLbfM4TZqmkNMOVcK5tEXPES/69LAZjH1V+X/n376aR6FvHL90s+j/3a8frjrrrvyFGPRzztGIw9rr7127i8eNdsljz32WP4/yhmDroXFFlusPBL6Msssk0477bR022235anIwjvvvJOef/75ArYgAAB0TKYMmwdThlESwTpCd9RKR3CNEcbjqxP3H3300Tyve6wTo4Pvs88+6fLLL8/Pu+iii9LBBx8815RhUXMdfakjKEff65jm64EHHshThsWUZFHzHLXeUVt99dVX5+fH+tGHPPp2150yLIJzhPNZs2alQYMGlecBj/vR//yDDz7Ij2O9GIE9RkKP0dNjXvAI36V+49HnO15ziSWWaLVtDQAACwJThkELimbYUdMcoTam61pxxRXTqFGjcg1xBO6G/PCHP0xXXXVVHkW8NLr4brvtlqf1isAdIjTHoGw/+clPcgCOwBxNxU888cRyeA/rrrtunlrsm9/8Zq4VjwC/8cYb59rxUm15hPZ//etf6ZBDDskhf+LEibmWPEJ9rBeBO3zjG9/Iz4lg/8wzz+QLCDFXeIykLnADAEDLUdM9D2q6AQAAqI+abgAAAGhlC7d2AWgZpT65QNsW/fFLI9cDAND+Cd31iHmX4xYDXC0ogXvQGmukGTNntnZRgPno3q1beva55wRvAIAOQp/udtCnO+ZbHjJkSLpqq63SoIq5pIG25dn330/fu/vuPADfBhts0NrFAQDgK8iLarrbkQjcGyyzTGsXAwAAgP/HQGoAAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQXY/q6uo0ePDgNGzYsNYuCgAAAAswobseVVVVacKECWncuHGtXRQAAAAWYEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6K5HdXV1Gjx4cBo2bFhrFwUAAIAFmNBdj6qqqjRhwoQ0bty41i4KAAAACzChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhO56VFdXp8GDB6dhw4a1dlEAAABYgAnd9aiqqkoTJkxI48aNa+2iAAAAsAATugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAAChIuw/dt912W1p99dXTaqutlsaMGdPaxQEAAKADWTi1Y1988UU64ogj0r333pt69eqVhgwZknbddde09NJLt3bRAAAA6ADadU33o48+mtZcc820/PLLp8UXXzxtt9126a677mrtYgEAANBBtOnQfd9996Wddtop9evXL3Xq1Cndeuutc61TXV2dBg4cmLp27ZpGjBiRg3bJ5MmTc+AuiftvvvnmV1Z+AAAAOrY2Hbo/+eSTtO666+ZgXZ/rr78+Nx8/6aST0hNPPJHX3WabbdKUKVO+8rICAADAAhW6ozn4qaeemvth1+ecc85JBx10UNpvv/3S4MGD04UXXpi6d++eLr300vzzqCGvrNmO+7GsIZ999lmaNm1arRsAAAC0y9A9L59//nl6/PHH01ZbbVVe1rlz5/z44Ycfzo+HDx+ennnmmRy2p0+fnu64445cE96QM844Iw+4VroNGDDgK3kvAAAAtE8LbOh+99130+zZs1OfPn1qLY/Hb7/9dr6/8MILp7PPPjttvvnmab311ktHHnnkPEcuP/bYY9NHH31Uvk2aNKnw9wEAAED71a6nDAs777xzvjVGly5d8g0AAAA6dE13796900ILLZTeeeedWsvjcd++fVutXAAAALDAh+5FF100DRkyJN1zzz3lZXPmzMmPN9poo1YtGwAAALT55uUx+NlLL71Ufjxx4sQ0fvz4tNRSS6UVVlghTxe2zz77pKFDh+ZB00aPHp2nGYvRzAEAAKC1tenQ/dhjj+VB0EoiZIcI2pdffnnac88909SpU9OJJ56YB0+LwdLGjh071+BqAAAA0BradOgeOXJkqqmpmec6hx56aL61pOrq6nyL0dEBAACgw/XpLlJVVVWaMGFCGjduXGsXBQAAgAWY0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInTXI+boHjx4cBo2bFhrFwUAAIAFmNBdD/N0AwAA0BKEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIIs3JwnzZo1K7399ttpxowZaZlllklLLbVUy5cMAAAAOkpN98cff5wuuOCCtNlmm6WePXumgQMHpkGDBuXQveKKK6aDDjrIFFsAAADQ1NB9zjnn5JB92WWXpa222irdeuutafz48emFF15IDz/8cDrppJPSF198kbbeeuu07bbbphdffDEtyKqrq9PgwYPTsGHDWrsoAAAAtPfm5VGDfd9996U111yz3p8PHz487b///unCCy/Mwfz+++9Pq622WlpQVVVV5du0adNSr169Wrs4AAAAtOfQfe211zbqxbp06ZIOOeSQL1smAAAAaBe+9OjlURsczc2fffbZlikRAAAAdNTQ/Z3vfCf98Y9/zPdnzpyZhg4dmpets8466aabbiqijAAAANAxQnf07f7617+e799yyy2ppqYmffjhh+ncc89Np556ahFlBAAAgI4Ruj/66KPyvNxjx45Nu+++e+revXvaYYcdFvhRywEAAKBVQ/eAAQPyNGGffPJJDt0xTVj44IMPUteuXVu0cAAAANDuRy+v9NOf/jSNGjUqLb744mmFFVZII0eOLDc7X3vttYsoIwAAAHSM0P3jH/84z8s9adKk9M1vfjN17vx/leUrr7yyPt0AAADwZUJ3iBHLY7TyiRMnplVWWSUtvPDCuU83AAAA8CX6dM+YMSMdcMABefC0NddcM73++ut5+WGHHZZ+85vfpPaguro6DR48OA0bNqy1iwIAAEBHCt3HHntseuqpp9K//vWvWgOnbbXVVun6669P7UFVVVWaMGFCGjduXGsXBQAAgI7UvPzWW2/N4XrDDTdMnTp1Ki+PWu+XX365pcsHAAAAHaeme+rUqWnZZZeda3lMIVYZwgEAAKCj69ycQdRuv/328uNS0B4zZkzaaKONWrZ0AAAA0JGal59++ulpu+22y32ev/jii/SHP/wh33/ooYfSv//972JKCQAAAB2hpnvTTTdN48ePz4F77bXXTnfddVdubv7www+nIUOGFFNKAAAA6CjzdMfc3BdffHHLlwYAAAA6WuieNm1ao1+wZ8+eX6Y8AAAA0LFC9xJLLNHokclnz579ZcsEAAAAHSd033vvveX7r776ajrmmGPSvvvuWx6tPPpz/+lPf0pnnHFGcSUFAACABUyjQvdmm21Wvn/yySenc845J+21117lZTvvvHMeVO2iiy5K++yzTzElBQAAgPY+ennUasdc3XXFskcffTS1B9XV1Wnw4MFp2LBhrV0UAAAAOlLoHjBgQL0jl48ZMyb/rD2oqqrKc4+PGzeutYsCAABAR5oy7Pe//33afffd0x133JFGjBiRl0UN94svvphuuummIsoIAAAAHaOme/vtt88Be6eddkrvv/9+vsX9F154If8MAAAAaGZNd+jfv386/fTTm/NUAAAA6DCaFbo//PDD3KR8ypQpac6cObV+9oMf/KClygYAAAAdK3T/7W9/S6NGjUrTp09PPXv2TJ06dSr/LO4L3QAAANDMPt1HHnlk2n///XPojhrvDz74oHyL/t0AAABAM0P3m2++mX7yk5+k7t27N/WpAAAA0KE0OXRvs8026bHHHiumNAAAANCR+3TvsMMO6eijj04TJkxIa6+9dlpkkUVq/XznnXduyfIBAABAxwndBx10UP7/5JNPnutnMZDa7NmzW6ZkAAAA0NGal8cUYQ3dBG4A+Gpdd911aYMNNkjdunVLSy21VNpjjz3Syy+/PM/nHHvssWnQoEF5FpKuXbumFVdcMQ+S+tprr9W7/pNPPpm6dOmSL67H7bnnnqv18y+++CKdddZZuQVcvF6vXr3SkCFD0u23315e55hjjkkbbbRRWnbZZfM6K6+8cjrssMPy9KMA0J41OXQDAG3DJZdckvbaa68cipdbbrl88fumm25KG2+8cXr77bcbfN6dd96ZPvnkk7TaaqulAQMGpNdffz1ddtlledyWumbOnJn23nvv9Pnnn9f7WjU1NWn33XdPP//5z9MzzzyT+vfvn1ZaaaU0ceLEXK6SM888M40bNy716dMnLb300vnnf/zjH9OWW26ZL9wDQHvVrND973//O+20005p1VVXzbfox33//fe3fOkAgHpFCI7a4xCh95VXXknPPvts6tGjR649Pv300xt87kMPPZSD9uOPP55efPHF9L3vfS8vf/7559N7771Xa90jjjgi12x/+9vfrve1rr/++vTXv/41LbbYYunBBx9ML730Uho/fnx+nZ/+9Kfl9Y477rj01ltvpaeffjr/7ihziKD+1FNP5ftx0SBq4aMWPGrDo+Z+6NChuRYdADpM6L7qqqvSVlttlacMi6nD4hZN2uJK9TXXXJPag+rq6jR48OA0bNiw1i4KANQrao3ffffdfL8UYPv165c23HDDfH/s2LENPjcC7fnnn59GjBiRa7vjb3uIv30RdEv+9re/pQsvvDA3A99+++0bDN0hgnIE6wj9q6yySvrVr36VFl100fJ6p556alpmmWXy/YUWWijXxpdE0/XS39/f/OY3OZSvvvrquUY8QnplM3UAaPcDqZ122mnpt7/9bfrZz35WXhbB+5xzzkmnnHJKboK2oKuqqsq3adOm5X5pANDWTJo0qXw/+kmXRPPtEMF1XuLnjz76aPnx+uuvn2677bbcZztE8/QDDjgg99OOv/vRd7w+UTseIhxHH/Hll18+L4sBV6O2O5qQ1xVN26+44op8f5NNNslhP0Ste9hvv/3SxRdfnO9Pnz491+ADQIep6Y7ma9G0vK5oYh79swCA1hN9rBsjapRjALRoOr755pvn/tejRo0qD4p68MEHp48//ji3Youa8YbEa5Rqr6OZeLxeDMoWLrroojRr1qxa60+dOjW3jot111hjjfTnP/+5/LMdd9wxh/4xY8bk8B7lihryytp3AGj3oTsGXLnnnnvmWn733XfnnwEAxav8m1s5Anjp/gorrDDf14igHM24S32v//Wvf5X/xkcojn7j0Vx98cUXT4ccckj5eTEy+S9+8Yt8P8JxiKbjAwcOzPeHDx+e/4/A/eabb5afFzXg8Xr/+c9/8v8xHkwMAFcSA7k98cQT6Ze//GWueX/hhRfyAGxRGx413gDQIUL3kUcemZuT/+hHP0pXXnllvsUf4viDfdRRRxVTSgCglhh3JPo8hxixPEyePDk98sgj+f62226b/4/a5LiVmnlHE+4Y+Kw0Ynj8X9n/O5p+l8TP4nHcPvvss/LyGTNmlB/HOC+lGuzSlGOPPfZY/j8GVyuF6vvuuy/3444WczGt2b333pt69+5d6z3997//zeE9urJFU/cY6C2888475WbsANDu+3RH2O7bt286++yz0w033JCXxVyfMZDKLrvsUkQZAYA6YpCyGKE8moFH6I6BzKIPdTQJjzBbGtm8FFZLg65FzXP8vY7a63hOBNq4hZjuK5p+h1dffbXW77v88stzX+sQfawjyIcYAyX6X0fgXnfddXPILs3jHbXhpUHSvvnNb+aa82g+Hv3JR44cWX7tE044Ie2www75vCLeU5QjwnepX3oM3hqDswFAhwjdYdddd803AKD1/PCHP8y1yb/73e9yEI6+17vttlvurx0jmdcnmp1/61vfyrXIEcijD3gE2qixPv744/NgaE2xxBJL5GbiEbBj/u8Y4G2DDTbIA66WpiILpXm+4/dVDuBWqiUP3/jGN3Lz8qjxjqnEYiT0LbbYIp100kn59wDAgqhTTWNHXKmYoiSam8U0I5Wif1b0DYv5NNuL0ujlH330UZNPQr5KcYIS/ese/8530gb/bzoWoO15YurUNOSGG3LYiVACAED7z4tN7tMdzcgqpykpieZq8TMAAACgmc3LJ0yYUG8NTYwyGj8DgBD9cUv9iIG2LcYBaMyI9wB8BaE7BkSJAVdi8JVKb731Vlp44WZ1EQegHQbu1QcNSp/OmNHaRQEaoWv37un5Z58VvAEK0OSUvPXWW6djjz02/eUvf8nt18OHH36Y59SMkUkBIGq4I3BvcMqJafGVVmzt4gDzMH3ia+mJE07O31uhG6ANhO4YITVGF11xxRVzk/Iwfvz41KdPnzxnNwCUROBeYtDqrV0MAIAFJ3Qvv/zyeSqPq6++Oj311FOpW7dued7OvfbaKy2yyCLFlBIAAAAWQM3qhB1zgsbcoAAAAEBquSnDQjQj33TTTVO/fv3Sa6+9lpf9/ve/z/28AQAAgGaG7gsuuCAdccQRabvttksffPBBmj17dl6+5JJLptGjRzf15QAAAKDdanLoPu+889LFF1+cjjvuuFpThA0dOjQ9/fTTLV0+AAAA6Dihe+LEieVRy+vO3/3JJ5+0VLkAAACg44XulVZaKU8RVtfYsWPToEGDWqpcAAAA0PFGL4/+3FVVVenTTz9NNTU16dFHH03XXnttOuOMM9KYMWNSe1BdXZ1vpf7qAAAA8JWE7gMPPDDPzX388cenGTNmpL333juPYv6HP/whffe7303tQVxUiNu0adNSr169Wrs4AAAAdKR5ukeNGpVvEbqnT5+ell122ZYvGQAAAHS0Pt0zZ87MYTt07949P46pwu66664iygcAAAAdJ3Tvsssu6Yorrsj3P/zwwzR8+PB09tln5+UxhzcAAADQzND9xBNPpK9//ev5/o033pj69u2bXnvttRzEzz333Ka+HAAAALRbTQ7d0bS8R48e+X40Kd9tt91S586d04YbbpjDNwAAANDM0L3qqqumW2+9NU2aNCndeeedaeutt87Lp0yZknr27NnUlwMAAIB2q8mh+8QTT0xHHXVUGjhwYBoxYkTaaKONyrXe66+/fhFlBAAAgI4xZdgee+yRNt100/TWW2+lddddt7x8yy23TLvuumtLlw8AAAA61jzdMXha3CrFKOYAAABAE5uXH3LIIemNN95ozKrp+uuvT1dffXWj1gUAAIDU0Wu6l1lmmbTmmmumTTbZJO20005p6NChqV+/fqlr167pgw8+SBMmTEgPPPBAuu666/Lyiy66qPiSAwAAQHsI3aeccko69NBD05gxY9L555+fQ3almEJsq622ymF72223LaqsAAAA0D77dPfp0ycdd9xx+Ra126+//nqaOXNm6t27d1pllVVSp06dii0pAAAAdISB1JZccsl8AwAAAFpwnm4AAACgcYRuAAAAKIjQDQAAAAURugEAAKCthO4YsXzGjBnlx6+99loaPXp0uuuuu1q6bAAAANCxQvcuu+ySrrjiinz/ww8/TCNGjEhnn312Xn7BBRcUUUYAAADoGKH7iSeeSF//+tfz/RtvvDHP3x213RHEzz333CLKCAAAAB0jdEfT8h49euT70aR8t912S507d04bbrhhDt8AAABAM0P3qquumm699dY0adKkdOedd6att946L58yZUrq2bNnU18OAAAA2q0mh+4TTzwxHXXUUWngwIFp+PDhaaONNirXeq+//vpFlBEAAAAWSAs39Ql77LFH2nTTTdNbb72V1l133fLyLbfcMu26664tXT4AAADoOKE79O3bN9+iiXkYMGBArvVuL6qrq/Nt9uzZrV0UAAAAOlLz8i+++CKdcMIJqVevXrmJedzi/vHHH59mzZqV2oOqqqo0YcKENG7cuNYuCgAAAB2ppvuwww5LN998c/rtb39b7s/98MMPp1/96lfpvffeM1c3AAAANDd0X3PNNem6665L2223XXnZOuusk5uY77XXXkI3AAAANLd5eZcuXXKT8rpWWmmltOiiizb15QAAAKDdanLoPvTQQ9Mpp5ySPvvss/KyuH/aaaflnwEAAADNbF7+5JNPpnvuuSf179+/PGXYU089lT7//PM8bdhuu+1WXjf6fgMAAEBH1eTQvcQSS6Tdd9+91rLozw0AAAB8ydB92WWXNfUpAAAA0CE1uU83AAAAUFBNd8zFfeKJJ6Z77703TZkyJc2ZM6fWz99///2mviQAAAC0S00O3d///vfTSy+9lA444IDUp0+f1KlTp2JKBgAAAB0tdN9///3pgQceKI9cDgAAALRQn+411lgjzZw5s6lPAwAAgA6nyaH7/PPPT8cdd1z697//nft3T5s2rdYNAAAA+BLzdEe43mKLLWotr6mpyf27Z8+e3dSXBAAAgHapyaF71KhRaZFFFknXXHONgdQAAACgJUP3M888k5588sm0+uqrN/WpAAAA0KE0uU/30KFD06RJk4opDQAAAHTkmu7DDjssHX744enoo49Oa6+9dm5qXmmdddZpyfIBAABAxwnde+65Z/5///33Ly+Lft0GUgMAAIAvGbonTpzY1KcAAABAh9Tk0L3iiisWUxIAAADo6AOphSuvvDJtsskmqV+/fum1117Ly0aPHp3+8pe/tHT5AAAAoOOE7gsuuCAdccQRafvtt08ffvhhuQ/3EksskYM3AAAA0MzQfd5556WLL744HXfccWmhhRaqNZXY008/3dSXAwAAgHarc3MGUlt//fXnWt6lS5f0ySeftFS5AAAAoOOF7pVWWimNHz9+ruVjx45NgwYNaqlyAQAAQMcZvfzkk09ORx11VO7PXVVVlT799NM8N/ejjz6arr322nTGGWekMWPGFFtaAAAAaI+h+9e//nU65JBD0oEHHpi6deuWjj/++DRjxoy0995751HM//CHP6Tvfve7xZYWAAAA2mPojlrtklGjRuVbhO7p06enZZddtqjyAQAAQPsP3aFTp061Hnfv3j3fAAAAgC8Zur/2ta/NFbzrev/995vykgAAANBuNSl0R7/uXr16FVcaAAAA6KihOwZK038bAAAAWnie7vk1KwcAAACaGborRy8HAAAAWrB5+Zw5cxq7KgAAANCUmm4AAACgaYRuAAAAKIjQDQAAAAXpEKF71113TUsuuWTaY489WrsoAAAAdCAdInQffvjh6YorrmjtYgAAANDBdIjQPXLkyNSjR4/WLgYAAAAdTKuH7vvuuy/ttNNOqV+/fqlTp07p1ltvnWud6urqNHDgwNS1a9c0YsSI9Oijj7ZKWQEAAGCBCt2ffPJJWnfddXOwrs/111+fjjjiiHTSSSelJ554Iq+7zTbbpClTppTXWW+99dJaa601123y5Mlf4TsBAACA2hZOrWy77bbLt4acc8456aCDDkr77bdffnzhhRem22+/PV166aXpmGOOycvGjx/fImX57LPP8q1k2rRpLfK6AAAAdEytXtM9L59//nl6/PHH01ZbbVVe1rlz5/z44YcfbvHfd8YZZ6RevXqVbwMGDGjx3wEAAEDH0aZD97vvvptmz56d+vTpU2t5PH777bcb/ToR0r/97W+nv//976l///4NBvZjjz02ffTRR+XbpEmTvvR7AAAAoONq9eblX4W77767Uet16dIl3wAAAKDd13T37t07LbTQQumdd96ptTwe9+3bt9XKBQAAAAt86F500UXTkCFD0j333FNeNmfOnPx4o402atWyAQAAQJtvXj59+vT00ksvlR9PnDgxj0a+1FJLpRVWWCFPF7bPPvukoUOHpuHDh6fRo0fnacZKo5kDAABAW9Xqofuxxx5Lm2++eflxhOwQQfvyyy9Pe+65Z5o6dWo68cQT8+BpMSf32LFj5xpcDQAAANqaVg/dI0eOTDU1NfNc59BDD823r0p1dXW+xcjpAAAA0C77dLeWqqqqNGHChDRu3LjWLgoAAAALMKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFETorkfM0T148OA0bNiw1i4KAAAACzChux7m6QYAAKAlCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFETorkd1dXUaPHhwGjZsWGsXBQAAgAWY0F2PqqqqNGHChDRu3LjWLgoAAAALMKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInTXo7q6Og0ePDgNGzastYsCAADAAkzorkdVVVWaMGFCGjduXGsXBQAAgAWY0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQnc9qqur0+DBg9OwYcNauygAAAAswITuelRVVaUJEyakcePGtXZRAAAAWIAJ3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG661FdXZ0GDx6chg0b1tpFAQAAYAEmdNejqqoqTZgwIY0bN661iwIAAMACTOgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQobse1dXVafDgwWnYsGGtXRQAAAAWYEJ3PaqqqtKECRPSuHHjWrsoAAAALMCEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAALeq6665LG2ywQerWrVtaaqml0h577JFefvnl+T7vvPPOS4MHD05dunRJyy67bNp///3TO++8U2udww47LK277rpp4YUXTp06dUp9+/ad63UGDhyYf1bfbeTIkeX1br755rTlllumXr16lX8+duzYFtoK8H8W/n//AwAAfGmXXHJJOvDAA/P9lVZaKb333nvppptuSvfff3966qmn6g3J4YQTTkinnnpqvr/aaqulN954I1122WXp4YcfTo8//njq3r17/tmVV16ZFl100Rzmp06dWu9rrb/++rV+z5w5c9K4cePy/eWWW668/L777ksPPvhg6t+/f5o2bVoLbgX4/6npBgAAWsTnn3+ejjnmmHx/9913T6+88kp69tlnU48ePdKUKVPS6aefXu/zojb7zDPPzPePPPLI9MILL6RHHnkk1zw/99xz6cILLyyv+/TTT+fX2n777Rssxy233JKfX7r9/Oc/r1VTXnLsscfmsD1mzJgGX2v27Nl5vZVXXjl17do1h/2hQ4ems846q4lbh45K6K5HdXV1btYybNiw1i4KAAAsMKI2+d133y2H7tCvX7+04YYb5vsNNd2+++6706xZs2o9b5111kmrrrrqXM8bMGBAk8v1u9/9Lv+/8cYb51tJnz59cq35/LLBb37zm/T666+n1VdfPS299NI5+N9+++1NLgcdk9Bdj6qqqjRhwoRyExQAAGD+Jk2aVL4ffbIrw22I4NqSz2uMaNb+n//8J98/6qijmvz8F198Mf+/33775ebx8TiazKvpprGEbgAAoFA1NTVf6fPqq+WOfuK77LJLk5+/44475mbu0QR9+eWXT5tvvnnuex7NzKExhG4AAKBFVDb9jn7Xde+vsMIKLfq8+Xn++efT3/72t3Jf8c6dmx5/ttlmm/TEE0+kX/7yl3mAtuhvHv3PN9lkkzR9+vRmlYuORegGAABaRIyJFH2eQ4xYHiZPnpwHMwvbbrtt/n+NNdbItz/+8Y/5cUzbFVOAVT7vv//9b3rppZdqPa+pzj777Fxbvswyy6R99tmnWa8R5Yjnn3baaem2227LI6mXBn+LUA/zI3QDAAAtIgYlK41QHuE5RvweNGhQ+vjjj1Pv3r3LI5tHWI1badC1mN7r6KOPLgflGLAsBl+LwBzNwg8++ODy74h5tmOAtZhjO8RrxOO4lfpul2rJY3qxcOihh+aRx+s699xz8/NGjRpVXhZzg8eyX/ziF/nxDTfckGvio7Z9yJAhae21187LYwqzVVZZpYCtSHsjdAMAAC3mhz/8YbrqqqvSeuutl2u5oz/0brvtlh566KE8knlDoiZ59OjRuQZ84sSJabHFFsu10zGXdtwvefXVV9PLL7+cg3xpSq94HLeZM2eW14ta9E8//TR169Yt/fjHP673d77//vv5eVHOkrfeeisvi5rs8I1vfCPXtMdc388880y+ELDFFlukO+64Iy2xxBItss1o3zrVtMToBO1UzNnXq1ev9NFHH6WePXumtir6mMRVt8e/8520wTLLtHZxgAY8MXVqGnLDDblZ2gYbbJDas9Jx6RtXXZKWGLR6axcHmIcPn30+3fe9AzrEsQmgNfKimm4AAAAoyP+NVgAAAB1AzPdc6kcMtG29e/du9sj1bYnQDQBAhwncqw8alD6dMaO1iwI0Qtfu3dPzzz67wAdvoRsAgA4hargjcK919OlpsRVWbu3iAPPwyeuvpGfO+mX+3grdAACwAInA3XPVQa1dDKCDMJAaAAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABVm4qBduD2pqavL/06ZNS23Z9OnT/+//WbPStM8/b+3iAA2I72j+f/r0Nn9caanj0hczZqZZ0z9p7eIA8xDf0w53bJo5I33xyf/dB9qmL2bOaPPHplK5SrmxIZ1q5rdGB/bGG2+kAQMGtHYxAAAAaKMmTZqU+vfv3+DPhe55mDNnTpo8eXLq0aNH6tSpU2sXhw4mrpzFRZ/4Evfs2bO1iwPguAS0SY5NtJaI0h9//HHq169f6ty54Z7bmpfPQ2y4eV2xgK9C/PHwBwRoSxyXgLbIsYnW0KtXr/muYyA1AAAAKIjQDQAAAAURuqGN6tKlSzrppJPy/wBtgeMS0BY5NtHWGUgNAAAACqKmGwAAAAoidAMAAEBBhG4AAAAoiNANBRk5cmT66U9/2uj1X3311dSpU6c0fvz4QssFtB//+te/8nHjww8/bPRzfvWrX6X11luv0HIBbYtjBbQuoRuaYN99981/tA455JC5flZVVZV/FuuEm2++OZ1yyimNfu0BAwakt956K6211lotWmZgwffwww+nhRZaKO2www6prR8fS7ell146bbvttum///1vk1/nW9/6VmHlhPZqQThOtLdjxeWXX17rvdR3i0oVELqhiSIcX3fddWnmzJnlZZ9++mm65ppr0gorrFBettRSS6UePXo0+nXjD2Xfvn3Twgsv3OJlBhZsl1xySTrssMPSfffdlyZPnpzaqjhxjouHcbvnnnvy8WzHHXds7WJBh7CgHCfa+rGi1PKwMfbcc8/y+4jbRhttlA466KBay+K8seTzzz8vsOS0ZUI3NNEGG2yQD6BRk10S9yNwr7/++g02Lx84cGA6/fTT0/7775/DeKx/0UUXNdi8vNQU7M4778yv261bt7TFFlukKVOmpDvuuCMNGjQo9ezZM+29995pxowZ5dcZO3Zs2nTTTdMSSyyRrx7HH7GXX365/PMrrrgiLb744unFF18sL/vxj3+c1lhjjVqvA7QN06dPT9dff3360Y9+lGuwomalIfGz+O7feuutabXVVktdu3ZN22yzTZo0adJc61555ZX5uNSrV6/03e9+N3388ceNPo40JObIjYuHcYtmqcccc0z+3VOnTi2vE4+/853v5NeOi5O77LJLuSYomrP+6U9/Sn/5y1/KtURxLAy/+MUv0te+9rXUvXv3tPLKK6cTTjghzZo1q8nbEzr6cSI4VrSMODcrvY+4Lbroovn3lh7H+9p9993Taaedlvr165dWX3318jYdOnRoPh+M9eJcLs7vSkrngHFBItaL19x4443T888/X17nqaeeSptvvnl+jTgfHDJkSHrssccKeZ98eUI3NEME58suu6z8+NJLL0377bfffJ939tln54Pnk08+mYNu/HGsPIDWJ/6w/PGPf0wPPfRQ+Q/Q6NGjc8367bffnu6666503nnnldf/5JNP0hFHHJEPvHGw7ty5c9p1113TnDlz8s9/8IMfpO233z6NGjUqffHFF/k1xowZk66++up8UAfalhtuuCFfFIuTte9973v5eFNTU9Pg+nHxLE7w4gLbgw8+mPtwxolypTgpjpPt2267Ld/+/e9/p9/85jeNPo40NgRcddVVadVVV80n4yFOfOPEPk4S77///ly+uAgYtV5RA3TUUUflY1xlLVicaIZ4TgSFCRMmpD/84Q/p4osvTr///e+bsUWh/WnqcSI4Vnw1YrvEud4//vGPvA1L7y+6IEZwju0bFxNK3RMrHXfccfncMbZvtAaI88+SOI/r379/GjduXHr88cdzwF9kkUW+0vdGE9QAjbbPPvvU7LLLLjVTpkyp6dKlS82rr76ab127dq2ZOnVq/lmsEzbbbLOaww8/vPzcFVdcseZ73/te+fGcOXNqll122ZoLLrggP544cWL8dax58skn8+N77703P7777rvLzznjjDPyspdffrm87OCDD67ZZpttGixzlCue8/TTT5eXvf/++zX9+/ev+dGPflTTp0+fmtNOO63FthHQsjbeeOOa0aNH5/uzZs2q6d27dz4+VB4nPvjgg/z4sssuy48feeSR8vOfffbZvOw///lPfnzSSSfVdO/evWbatGnldY4++uiaESNGNOk4Ulcc+xZaaKGaxRZbLN9i/eWWW67m8ccfL69z5ZVX1qy++ur5+Ffy2Wef1XTr1q3mzjvvLL9OHEvn56yzzqoZMmTIfNeDjn6cCI4VjT9WlM7HmqPuuV+UMc6zouzzMm7cuPw7P/744wbPAW+//fa8bObMmflxjx49ai6//PJmlZOvnppuaIZlllmm3Hwrarzjfu/evef7vHXWWad8P5oNRZOiyuZE83tOnz59ys2lKpdVvkY0G99rr73yOtHcKJqEhddff728zpJLLpn7fl1wwQVplVVWyVdHgbYnakceffTR/J0OUdMRfQjj+9uQWGfYsGHlx1H7Fc0zn3322fKyOC5Ujjmx3HLLNek4st122+Vap7itueaa5edFU8foIhO3KHfUVMW6r732Wv551Oq89NJL+XeXnh/NRmNcjPk1SY2ms5tsskk+bsbzjj/++FrHNeiomnOcKK3nWPF/omx1y1l6HLcoW3Otvfbaudl5paiZ3mmnnXJXw3iPm222WV5et5yV54Cx7UNp+0cLgwMPPDBttdVWufVBY5r103qM2ATNFE18Dj300Hy/urq6Uc+p2+wngvf8mmBVPifWn99rxEF8xRVXzM2pov9Q/CxGRK87eEcMtBKDt0WTrGge1pRB34CvRpw0RzeQ+C6XRJPR6A8Z3U6a68seR6JLSmkwycrXWmyxxXIT0ZJYL/qBxuuceuqpuRlp9DuM7iz1Xcyc16jM0ZTy17/+dT45j9eMAS2j2SV0dPM7TsT3pbk6yrHi73//e7nf95tvvpnH5amcwjX6bjdXvNdKcc4VZYtbvL94PxG243Hdc7W654ChtP2j+2H0BY9ugjHWz0knnZTfazTvp+0RuqGZSv2K4iAYB8q24L333stXvOOP1te//vW87IEHHphrvegffuaZZ6a//e1vecCRuHgQA5IAbUecREdfyzhZ3HrrrWv9LKbJufbaa3PNVH3Pi/5/w4cPz4/jmBB9NWPwxZY6jiy//PKNeq04PkYfz9JJdwxEGbVQyy67bK4Vq0/UCM2ePXuuY1ac2Ef/xpJSjRh0ZI05TtQ3zWnpuY4V/yeeU1KaRabyokBLeu655/K2i9rp0sjmzR0ALQaMi9vPfvaz3OIgWl8K3W2T5uXQTFFLHE2wYqCOuN8WRLPxGIQkRkWPZln//Oc/c/OjSjHq6Pe///30k5/8JDeXiqus8YftxhtvbLVyA3OLAXc++OCDdMABB+Sao8pbjIbbUNPRqBmJaYP+85//5CaMMTjPhhtuWD6xbonjSEM+++yz9Pbbb+dbHB+jHFFjFbVhIWqgoitOjEIcgyNNnDgxj9Ibx6M33ngjrxPNU2O+3jiZf/fdd3PtU4yuHDVBUYsTTSjPPffcdMsttzR6W0J71dzjRHCsaB3RpDwuGMQguK+88kr661//mgdVa4q4OBEVJrFN4qJCDDQXA6o19oIJXz2hG76EuPra0BXY1hBXieMPTfzxjD+4ceXzrLPOqrXO4Ycfnps6xfRlpb5Gcf/ggw/OTaqAtiFOlqOvXn1NQ+NkOmpG4oSzrhj3IVqwRLPD6NcY/RHjwlpLHkcaEtMHRb/DuI0YMSKfBP75z3/OTTVLZYuuLXHSudtuu+UTxAgL0U+zdCyNOW5jBOaY6SGaXcbJ5M4775zLESeZMb1Q1GbFNEDQ0TX3OBEcK1pHlDXGBIr3O3jw4Fzj/bvf/a5JrxGVPVFbHjPSRE13jOQeFSnRrJ62qVOMptbahQAAvrw4kfvpT3+am4gCNMSxAr5aaroBAACgIEI3AAAAFETzcgAAACiImm4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAAEjF+P8A8G3epNaGNfwAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAATvZJREFUeJzt3QecFPX9P/4PWEBUbNhQ7EbBLmA3NmKNGkvs0dg1Zy/faIwldmPDcmoUezf22KMx9oIF29lFxAoWRIoN7vd4f/Lf/e8dd3AHN3DePZ+Px8ru3Ozs7MzsOK/5tA61tbW1CQAAAGhxHVt+kQAAAIDQDQAAAAVS0g0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRugF+oRRZZJP3xj39MvyTrrrtufrRG03rdYl/GPm3qvLPMMktqy5qzPVqTOIaWXXbZ1FpcddVVqUOHDumFF15Irdl///vfvJ7xb1s2ueftDz/8MG+f2J/AL4/QDbQ677//ftp3333TYostljp37py6du2a1lxzzXTeeeelsWPHTuvVg6lizJgx6YQTTmjzIQQA2rrpp/UKAFS699570+9///vUqVOntOuuu+YSox9//DE9+eST6cgjj0xvvPFGuvTSS220lNLbb7+dOnZ077StuOyyy9L48ePrhO6//e1v+XlrrR0ANI/zNrRPQjfQagwePDjtsMMOaeGFF07/+c9/0vzzz1/+W1VVVXrvvfdyKG+LImzFzYUo2W+quDHBL9/o0aPTzDPPnGaYYYZpvSrtdtu3h/MF0+4YqK2tTd9//32aaaaZnLehnVJEArQaf//739OoUaPS5ZdfXidwlyyxxBLp4IMPLr/++eef00knnZQWX3zxfCETbeX+8pe/pB9++KHO+2L6b3/721xNt0+fPvnCZ7nllitX27399tvz67iA7d27d3r55ZcbbD/7wQcfpI022ihfoHXv3j2deOKJ+WKq0llnnZXWWGONNNdcc+XPieXdeuutE3yXaJt3wAEHpOuvvz4ts8wyef0feOCBZi2jftvAn376KZeMLrnkkvm7xPvXWmut9O9//7vO++KGxtprr52/x+yzz5623HLL9Oabb9aZJ6o1xzrGjY74jJhvttlmS7vvvnsugW2KqJEQ+ya+wyqrrJKeeOKJBueL/XX88cfn/RvboUePHun//u//JtiP8T3i+8S6xP5Yaqml8v6elCuvvDKtv/76aZ555snL79WrV7r44oub9B2GDBmStthii7yt4v2HHnpoevDBBxtse/rPf/4z76v4vt26dUu77LJL+uSTTxo8lqIJxaabbppmnXXWtPPOO0/Qhjnab84999z5eezT+Lx4xH6pFMv/3e9+l5cZ8x9xxBFp3LhxE7QDjWOquro6N9no0qVL2nDDDdPQoUPz8Ru/oQUXXDCvdxwLX3/99QTb4f777y8fM7HOm222Wa51Uunzzz/Px0csK7Zz/IZjebEOk3LnnXfmWi1x3Ma/d9xxR6Nhs3///vk3E/POO++8uSnKN998M8nPmNi2b85yY1uss846+f3R9KVv377phhtumGC+mpqatN566+XtvcACC+Tz2+Qe+xM7X8QxsOeee+ZzUkxfdNFF0/77759Def3POuyww/JxEvtxq622SsOHD5+sfd2QOG7i+ItzaWzn2DabbLJJeuWVVyaY9+OPP87HbeXvqv53ju8by2nofLPjjjum+eabr86x3pT1ntgx8O6776ZtttkmLzeOgTiO4ybwt99+2+xzSen/OXGuKP0/5x//+EeD5+3mbLeGvPXWW2nbbbdNc845Z17v+Ly77767Se8Fph4l3UCr8a9//SuHggicTbHXXnulq6++Ol9wHH744em5555Lp512Wg6Q9S/aIzzutNNO+UI6wlCEkM033zxdcsklObj96U9/yvPF+7fbbrsJqgDGxd3GG2+cVltttXzxHBe8cbEcwT/Cd0m0O4+QFhdycdF700035ery99xzT74IrB9+b7nllnxxGSGtFLias4xKEchi/WO7RMgdOXJk7jzppZdeSr/5zW/yPA8//HC+oIvtHPNHG/kLLrggt5mP+ep3XBXbIi7iY7nx9wEDBuQLzjPOOGOi+yZunMS2jn15yCGH5BsW8Z3iwjCCRUmEnZgezQf22Wef1LNnz/Taa6+lc889N73zzjs5jIW4eI6L2OWXXz5v77jgjX361FNPpUmJi+IIKvE5008/fT7OYn/HZ0cNiomVgMUF9meffZZv9sTFeISrRx99dIJ5o3OjCJwRwGJbffHFF3k/xvrFTZy4UVASx0zcvIkbCHEcRiirL4JRrHeEpwhHW2+9dZ4e37/ymIzlrLrqqnk5sW/PPvvsfKMj3lcpwlocSwceeGC+yI9jOPZtfL+4efDnP/85b884FiIAXHHFFeX3XnvttWm33XbLnxX7PUJQrFusf3y30jETgSX2U3xGTBs2bFi+UfLRRx9NtEO0hx56KL83Akxsu6+++qoc3uuLY6q0rQ866KBcO+bCCy/M6xHbelK1BRrb9k1dbsyzxx575OPp6KOPzvs15onzQZxfSiKsx/ki9lts57hpFts4glX8/ppz7E/sfPHpp5/m3/qIESPyMpZeeukcwuPzYj/NOOOM5ffHfpljjjnyeStuhMRNhljWzTff3Ox93ZD4jcc6x7kqzhnxG4igGTco4gZE3BQIcc7ZYIMN8nER2zqmx+fG96u0/fbb5xtFpSZHJbFO8RuO4DrddNM1e70bOgbitxHTIvjHdorfemzHOOfGto0bjs09l8T/Q+LmQBxbe++9d75JOCXbrSHxe4tzd9zUOeqoo/INhzhG4obGbbfdls8dQCtRC9AKfPvtt1FkXLvllls2af5Bgwbl+ffaa68604844og8/T//+U952sILL5ynPf300+VpDz74YJ4200wz1Q4ZMqQ8/R//+Eee/uijj5an7bbbbnnagQceWJ42fvz42s0226x2xhlnrB0+fHh5+pgxY+qsz48//li77LLL1q6//vp1psfyOnbsWPvGG29M8N2auoz4XrFuJSussEJep4lZccUVa+eZZ57ar776qjztlVdeyeuy6667lqcdf/zxeR332GOPOu/faqutaueaa66Jfkasb3xGfNYPP/xQnn7ppZfmZa6zzjrladdee23+7CeeeKLOMi655JI871NPPZVfn3vuufl15bZuqvrbM2y00Ua1iy22WJ1psV6V63b22Wfnz7zzzjvL08aOHVu79NJL1zlGSt839lH8veSee+7J8x133HETHEtHHXXUBOsUf4t9WhLfNeaNfdHQvPG3E088sc70lVZaqbZ3797l14MHD87zzT333LUjRowoTz/66KPz9Dhmfvrpp/L0HXfcMR/T33//fX793Xff1c4+++y1e++9d53P+fzzz2tnm2228vRvvvkmL+/MM8+sba44Tuaff/466/fQQw/l5VVujzhGYtr1119f5/0PPPBAg9Pra2zbN3W5sX6zzjpr7aqrrlpnP5fOByVxDMX7rrnmmvK0+B3MN998tdtss02zj/2JnS/iNxvTBw4cOMH3La3TlVdemd/fr1+/Out56KGH1k433XTl7d7Ufd2YOGbGjRtXZ1ocf506dapznPbv3z+vzy233FKeNnr06Nollliizu8q1nWBBRaos81CvC/me/zxx5u93o0dAy+//HKe/s9//rNFziWl/+fEMVRf/fN2U7db6bcc+7Nkgw02qF1uueXKv9fSdltjjTVql1xyyYl+F2DqUr0caBWiVDZEdb+muO+++/K/UV2yUpR4h/ptv6MUbfXVVy+/jtLBECV9Cy200ATTo/ShvigVql/dM0pIooSxJKoRVpZ2RdXEqPIYpcT1RUlGrFd9zVlGpSh1i5KPqCbZkCixHTRoUC4hihLnkig9jZLw0jattN9++9V5HesRJZGl/dWQKF2PUs54b2VJW3xuqcSoskp2lPBFCd2XX35ZfsR+CaVS5VJJ8V133VWns7GmqNyesS1j+bHtYx9XVh2tL0ovowQpSrVKovpmlFo19H2jxKuyjW3USojv1VA/BPVLoidXQ/unoWM3StEqt33pOI9aH1FiVzk9julStfgoqY6Sviixq9w/UcIY85b2T2zj2NdRat6Uqt71j8kopaxcvzge6/824liJeeJvlesSVfqjWm5DNRAaUn/bN3W5sS2+++67XKJYvy11nA8qxfti25bEtokS6cp909Rjv7HzRfwOooQ0auxEleL66q9TlIRXTotjJWpLRBOK5uzrxkTtk1LtoFhunCdKzUAqz11xnommB1FDqSRKm2P96q9/HLcxfzQ7KomS+fhdRkn15K53/WOgdOxFdfCJNZ9pzrkkSq2j9HxSmrrd6osaK1E7IGpSxHFZ+t7x/vjc+P9A/eYtwLSjejnQKkQ7thAXD00RF4pxoRJtIStFtcAIaKULyZLKYF15kVVZ1blyev3gEJ8VVbIr/epXv8r/VrZZjeqIJ598cg4SlW0U618Aly7KGtKcZVSKatfRhjbWK9rFRvXWP/zhD+UqyaVt0lA1x7j4jwvO+p0K1d9uUT21tH1K+6y+0udE2/JKUUW3/jaMC8NoDlBqv1xfhNlSVdOo2h5V5yP0RPXUqLobF+6T6sE9qgdHldpnnnlmggvquFCufyOg8ntEVe36273+MTex7RqBKqoPV4qQ21DV6eaK4Fd/u8X+aSj0Tu7xX7qBUwqC9ZWOgQgOUa03bnpFe+hohhHNAWIEgvhNNqaxYyXUDx2xLrG/onnDxI6ViWlo2zd1udEOODRlDO74jPrHTeybV199tdnHfmPni2iPHTe/mjom+MR+y6X1acq+bkzcBIgmFRdddFGunl/Z3jr6l6jc5/Ebqr99Gvr9xO8+qsFHG+Wovh/hO0J4VNkuvb+5693QMRDbNm7gnnPOObkpRtyQiJttceOk8vzQnHNJY+f3yd1u9UVzkKgEceyxx+ZHY8dQ3KAApj2hG2gV4sIo2q69/vrrzXrfpIJoSantX1On1+8grSmio7C4UPv1r3+dL6CiNCeCZnS+01BHS5WlJpO7jErxnggGURoc7WQjpEb70Gi3HmF1crTk9mnsgjPaucbFbkNKoTC21eOPP55LraLkOEqho8QrLrTjuza2nrE9IqBH+I3PiOVFqWNcuMe2aW6peUuoLNmaEo195+bMO6n9W9o+0Wa2ofBcWUoebfej1DVKX+MGTgSBaKMdpXErrbRSmlKxLhGMIxQ1pLHwOqlt3xLLnZzfTVOP/YmdL1pynZqzrxty6qmn5n0ebd6jc76oTRPbOo6Lyf2dxc2baI8d7ZQjdEcb6mgTHmG8pLnr3djvL/pDiNo4pfNntDeP4/fZZ5/NIb2555Km7q/J3W6lv0UfDI2VqNe/QQhMO0I30GpEyVj0eB2lCJVVwRsSw4rFRUeUckQpbUl0QhNVDePvLSk+K6oQlkq3Q3R2FEqd9ETHNVH6GIGjcjivCMxNNaXLiAu26AwqHlEqFEE8OkyL0F3aJtHBT0M94EbnTC0xdE7pc2LfVJY+Re/qUZKzwgorlKdFSXL00hsXs5O6gRIXojFfPOKiNy5WjznmmBzE+/Xr1+B74iI9agtESVllSV9TqiLH94iOjCKUVK5blDA19H1ju9YvbYtpk3ssNvWGUpFi/4QIpY1t4/rzR2l3PGL/r7jiijnMXHfddZM8Vuqrf5zGsqMpR3QcNaUBdHKWW9oWcWOwJcJMc479xm4GxM3K5t6onNj6NGdf1xedt0Vv7dGJYqU4H8e5pXKfxzrX/101dF4KUX06SoKjVD9utMX5NsJ4S613pbgJEo+//vWv6emnn87HRNy0jJpHU3IuaYntVl+p1lDclJ3S7w0UT5tuoNWIoXIi9EVAjPBcX5Q0xMVXiOFeQlQ9rFQqNZpYL9+TK3ozLokLxngdFzxx0VwqSYqLyPpDNtXvhXhipmQZ0ZavUrQLjHBQqqIepeYRgqLH97igK4kL4CjZKW3TKRXtSyMQxMVq5bBF0fNz5eeWLqij3eFll102wXKiRCuqu4eGhrGK7xLqDzXUUOleZQljVANtyk2MKD2KdascfifG2q2/rvF944I/vm/lusQQRlF9eHKPxVLP2vW32dQU2yCCXdzgiJsm9ZWGnIqqtrFtKkUYij4aJrZ/Ko/Jyjax0U43bnjUP1bidxGlgfVFj9STu52autwYZi2+T5R+1v+uk1Pzo6nH/sRuQkUv1REGo1+B+pq7Tk3d1xP7rdX/zGi3Xr9dcZxnotf1ymEQ4/iJG64NiVLtOIbiGIkaLrHdWnK9QwT62NeVInzHNi4dv1NyLmmJ7VZfnHPWXXfd3NN59I0wOd8bmHqUdAOtRlykRxXquMiK0utoDxrtFSO4RalDXIiUxjeN0tLofCku1OKiODqzef755/OFWVyIRslBS4rS57jgi8+MznkiUEU15xhurFT9NMJVhP5oSx1VIaM9XQx5E8G3si3nxEzJMqKTpbgIiw6gosQ7LsTjwrayA7gzzzwzD1kUNQlibN/SkGHRFrH+GNCTK25ERMlQtLuMkt/Yn1HCHRen9dt0R5vzqDoaHYJFiVGULEUAipL3mF4a5zbaq0f18tg+UVIW2yWq30e1z1KHSg2JoBRVQKPac6xPlP5HyIkL1oYuVCvF/HFjJTpoiiHDIiBGFeRSJ1qlUrr4vtGeOWoXxHEY85eGDItSuRiDeHJEqWvs0yjdixoWsU/j99DUNrwtIcJMDJMU+2nllVfO4xbH8R7DPcXxH/srtlHU+oibTxGIYp2jSm8M2xfbId4zMRFiY7/GfowqtnGDJY7JGJqpsgOt2LaxT2L+6O8g9m1s+yglj3NDbO/KzrmaqqnLjW0R1YjjpmAMDRe/z2gXHaXVERrj3NMcTT32JyaCZtwwi+9QGnYsjutY7+hLoHKoupba1xOrqRS/0/gdxFCBMfxZ/F7q/+ajI8JYTpzfX3zxxfy7iqrhDQ2dF2Jd4vwXtVoiAFdWLW+J9Q7RBCLOk9FxW/zWIoDHOkUgjuHspvRcMjFN3W4Nif83xO8mbhDEdo33xG8uaovFWOhNHesbmAqmcm/pAJP0zjvv5GFeFllkkTx8UQzTs+aaa9ZecMEFdYZGiaGO/va3v9UuuuiitTPMMENtjx498lBIlfOUhmhpaCitOAVWVVXVmVYalqVy6KMY3mXmmWeuff/992s33HDD2i5dutTOO++8eSin+kO9XH755XmolhjuJYaWiuFdSsNvTeqzm7uM+kPPnHzyybWrrLJKHj4nhkKL955yyil5SKtKDz/8cN6eMU/Xrl1rN99889qampo685Q+r/4QXaXhh2I7TcpFF12U9018jz59+uQhfuoPyxVi/c4444zaZZZZJs87xxxz5GGvYt/GUHLhkUceycPJde/ePR8T8W8MbxXHyqTcfffdtcsvv3xt586d8zEVn3XFFVdM8D0aWrcPPvggHzuxrWLYrcMPP7z2tttuy+999tln68x788035yG74jvMOeectTvvvHPtxx9/XGee0rHUkPpDhoUY5i62RXznyuHDGltO/eOkoeM5xLBMDQ2RVNq/9YegivljaKQYgim24+KLL177xz/+sfaFF17If//yyy/z8RzHXKxXzBdDa1UOCzUxsU179uyZt12vXr1qb7/99ga3R2noudgmsU/i3BBDJv3f//1f7aeffjrRz5jYtm/OcuN4iiGZSr+f+M3deOON5b/HMRTHckOfX//7NOXYn9T5IoY8jKHD4viMZcTwVTFvabi+ie3T+sMjNmVfNybOu/H7iOHfYtvEOeaZZ55p8HcV67zFFlvkc2m3bt1qDz744PIQbfXXJxxzzDH5bzGsWGOast6NHQPxO4/hEeM98d74/a633nr5XDk555LG/p/T2JBhTdluDQ0ZFuL/S7H/Y0i6+P9gDLP229/+tvbWW29tdFsBU1+H+M/UCPcAv1RRuh4lxpWlbrRf0aQhSq+jJEnPwADApGjTDQCNiOr3laItb7ShjCGuBG4AoCm06QaARsRY4NFTcXT2FZ0mRS/c0ea2seGlAADqE7oBoBHRM3KMdx4hOzq5ik7Cbrrppgk6cwIAaIw23QAAAFAQbboBAACgIEI3AAAAFESb7okYP358+vTTT9Oss86aOnToUNQ+AAAA4BcmRt/+7rvvUvfu3VPHjo2XZwvdExGBu0ePHkXsHwAAANqAoUOHpgUXXLDRvwvdExEl3KWN2LVr15bfOwAAAPwijRw5MhfSlnJjY4TuiShVKY/ALXQDAABQ36SaIutIDQAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6oQkef/zxtOmmm6a55547d5QQj0suuWSS7zv77LPTuuuum+aff/7UqVOntPDCC6fddtstffDBBxPM++qrr6Ztt902f8aMM86YFlhggbTddtvVmedf//pXWnvttdOcc86ZZplllrT++uunp59+uvz3Dz/8sLx+DT1OOOEE+xsAAKYivZdDE7z00kvp3//+d1psscXSl19+2eRtdsEFF6SPPvooLbXUUmmmmWZKgwcPTtdcc0166KGH0ttvv13uFf/JJ59MG264YRo7dmyetswyy6RRo0alu+66q7ysq666Ku2+++75eYT3CNGPPvpoWm+99fJNgVVXXTUH+/i30ogRI/JnhQj/AADA1KOkG5rgD3/4Qx6H78EHH2zW9tp7771z6fObb76ZS7cPOeSQPP3zzz9PjzzySH5eW1ub54vAvfPOO+e/vfzyy+ndd9+tE/Avuuii/O8qq6ySw3ssb6211ko//vhjOvbYY8uh+tlnn63z6NevX/7bHHPMkZcfxo0bl44++uh8E6Fz58655LxPnz7pzDPPdDwAAEALErqhCeaaa65cUt1cxxxzTFpooYXKr6NqeEmUSpeqlb/11lvlAB6l4rPNNluuOv7OO++U5x8/fnydcQBLVcbDY489ln766acJPv+rr75KV155ZX6+//775yrpobq6Op1++unlUvj4fq+99lq69957HQ8AANCChG6YSqJ0+dJLL83Po4R5gw02yM9LVb/DDTfckLp06ZKfR9XxaA8eJeWh1L77ueeey++PxxNPPJGnRWl3Q9Xeo3R8zJgxOeAfeOCB5elRih6iuvorr7ySX0dAV9INAAAtS+iGqWD06NFpq622ytXT55tvvtwhWqmk++effy7Pt+eee+ZS70GDBqXpppsut+uOttzhyCOPTGeddVYumf7iiy9ytfAtttii/N4ZZpihzmf+8MMPuUQ77LLLLvlzS37729/mUvIBAwbkDtuiXfjJJ5+cq5kDAAAtR+iGgkUb7XXWWScH7V/96lfpqaeeSr169Sr/PUJvSd++ffO/iy66aO7FPJRKuiMkH3744TmUR+l1TU1NOUhH9fB4VIoO2yKcl95XaaONNsqdw/3lL39JK620Uq7GfsYZZ6Q111wzB30AAKBlCN3QQqK6+NJLL507KCt544030mqrrZZefPHF3J77mWeeydXCK0XHaKVezF944YX875AhQ9Lw4cPz8yWXXDL/O2zYsBy0S6LH8quvvjo/33777cvtu0ttw2O4srDZZpulnj171vnMaEceof6UU05J99xzT16/ECG9sro7AAAwZYRuaILbb789LbHEErmNdclxxx2Xp5V6BH///fdzYP3ss8/K82y99dY5QIfvvvsuj/UdITweUbU7RAdtpfGzY1oE5BVWWCG3AY+S7H322Sf/LTo9i6HEohQ8SsxjXaIK+eKLL55OOumkOusbpeql8BzV0uu75ZZbUo8ePXInb717907LLbdcnh7tyWN5AABAyxC6oQliuLAI1aUAHaIkOqZ98sknjb4vQnFJtNOOTtBKj48//rj8t0MPPTQH7mWXXTYPBzbrrLPmYcqi5LtUzXyeeebJQTvWJeZZcMEF0wEHHJBLz+u3xY6236VS9F//+tcTrFdM23jjjXOP6K+//nouGY/e0u+///40++yzOyYAAKCFdKiNq20aFOEmhm769ttvy9V/AQAAYGQT86KSbgAAACjI9EUtmKkr2vs2NE4z0Lp069Ytt6UHAKB9ELrbSODuufTSaczYsdN6VYBJ6DLTTOnNt94SvAEA2gmhuw2IEu4I3Nf165d61utQC2g93vz667TLww/n36zSbgCA9kHobkMicK/8//V0DQAAwLSnIzUAAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIG0+dN9zzz1pqaWWSksuuWQaMGDAtF4dAAAA2pHpUxv2888/p8MOOyw9+uijabbZZku9e/dOW221VZprrrmm9aoBAADQDrTpku7nn38+LbPMMmmBBRZIs8wyS9pkk03SQw89NK1XCwAAgHaiVYfuxx9/PG2++eape/fuqUOHDunOO++cYJ7q6uq0yCKLpM6dO6dVV101B+2STz/9NAfuknj+ySefTLX1BwAAoH1r1aF79OjRaYUVVsjBuiE333xzrj5+/PHHp5deeinPu9FGG6Vhw4ZN9XUFAACAX1TojurgJ598cm6H3ZBzzjkn7b333mn33XdPvXr1Spdccknq0qVLuuKKK/Lfo4S8smQ7nse0xvzwww9p5MiRdR4AAADQJkP3xPz444/pxRdfTP369StP69ixY379zDPP5NerrLJKev3113PYHjVqVLr//vtzSXhjTjvttNzhWunRo0ePqfJdAAAAaJt+saH7yy+/TOPGjUvzzjtvnenx+vPPP8/Pp59++nT22Wen9dZbL6244orp8MMPn2jP5UcffXT69ttvy4+hQ4cW/j0AAABou9r0kGFhiy22yI+m6NSpU34AAABAuy7p7tatW5puuunSF198UWd6vJ5vvvmm2XoBAADALz50zzjjjKl3797pkUceKU8bP358fr366qtP03UDAACAVl+9PDo/e++998qvBw8enAYNGpTmnHPOtNBCC+XhwnbbbbfUp0+f3Gla//798zBj0Zs5AAAATGutOnS/8MILuRO0kgjZIYL2VVddlbbffvs0fPjwdNxxx+XO06KztAceeGCCztUAAABgWmjVoXvddddNtbW1E53ngAMOyA8AAABobX6xbboBAACgtRO6G1BdXZ169eqV+vbtO/X3CAAAAG2G0N2AqqqqVFNTkwYOHDj19wgAAABthtANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0N2A6urq1KtXr9S3b9+itjsAAADtgNDdgKqqqlRTU5MGDhw49fcIAAAAbYbQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6G1BdXZ169eqV+vbtW9R2BwAAoB0QuhtQVVWVampq0sCBA6f+HgEAAKDNELoBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChuwHV1dWpV69eqW/fvkVtdwAAANoBobsBVVVVqaamJg0cOHDq7xEAAADaDKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQncDqqurU69evVLfvn2L2u4AAAC0A0J3A6qqqlJNTU0aOHDg1N8jAAAAtBlCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROhuQHV1derVq1fq27dvUdsdAACAdkDobkBVVVWqqalJAwcOnPp7BAAAgDZD6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCdwOqq6tTr169Ut++fYva7gAAALQDQncDqqqqUk1NTRo4cODU3yMAAAC0GUI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKMj0k/Omn376KX3++edpzJgxae65505zzjlny68ZAAAAtJeS7u+++y5dfPHFaZ111kldu3ZNiyyySOrZs2cO3QsvvHDae++9jWsNAAAAzQ3d55xzTg7ZV155ZerXr1+6884706BBg9I777yTnnnmmXT88cenn3/+OW244YZp4403Tu+++25TFgsAAABtWpOqlw8cODA9/vjjaZlllmnw76usskraY4890iWXXJKD+RNPPJGWXHLJll5XAAAAaHuh+8Ybb2zSwjp16pT222+/KV0nAAAAaBOmuPfykSNH5urmb775ZsusEQAAALTX0L3ddtulCy+8MD8fO3Zs6tOnT562/PLLp9tuu62IdQQAAID2Ebqjbffaa6+dn99xxx2ptrY2jRgxIp1//vnp5JNPLmIdAQAAoH2E7m+//bY8LvcDDzyQttlmm9SlS5e02Wab6bUcAAAApiR09+jRIw8TNnr06By6Y5iw8M0336TOnTs3d3EAAADQvnsvr3TIIYeknXfeOc0yyyxpoYUWSuuuu2652vlyyy1XxDoCAABA+wjdf/rTn/K43EOHDk2/+c1vUseO/yssX2yxxbTpBgAAgCkJ3SF6LI/eygcPHpwWX3zxNP300+c23QAAAMAUtOkeM2ZM2nPPPXPnacsss0z66KOP8vQDDzwwnX766c1dHAAAALRZzQ7dRx99dHrllVfSf//73zodp/Xr1y/dfPPNLb1+AAAA0H6ql9955505XK+22mqpQ4cO5elR6v3++++39PoBAABA+ynpHj58eJpnnnkmmB5DiFWGcAAAAGjvOk5OJ2r33ntv+XUpaA8YMCCtvvrqLbt2AAAA0J6ql5966qlpk002STU1Nennn39O5513Xn7+9NNPp8cee6yYtQQAAID2UNK91lprpUGDBuXAvdxyy6WHHnooVzd/5plnUu/evYtZSwAAAGgv43TH2NyXXXZZy68NAAAAtLfQPXLkyCYvsGvXrlOyPgAAANC+Qvfss8/e5J7Jx40bN6XrBAAAAO0ndD/66KPl5x9++GE66qij0h//+Mdyb+XRnvvqq69Op512WnFrCgAAAL8wTQrd66yzTvn5iSeemM4555y04447lqdtscUWuVO1Sy+9NO22227FrCkAAAC09d7Lo1Q7xuquL6Y9//zzLbVeAAAA0P5Cd48ePRrsuXzAgAH5b21BdXV16tWrV+rbt++0XhUAAADa05Bh5557btpmm23S/fffn1ZdddU8LUq433333XTbbbeltqCqqio/otf22WabbVqvDgAAAO2lpHvTTTfNAXvzzTdPX3/9dX7E83feeSf/DQAAAJjMku6w4IILplNPPXVy3goAAADtxmSF7hEjRuQq5cOGDUvjx4+v87ddd921pdYNAAAA2lfo/te//pV23nnnNGrUqNS1a9fUoUOH8t/iudANAAAAk9mm+/DDD0977LFHDt1R4v3NN9+UH9G+GwAAAJjM0P3JJ5+kgw46KHXp0qW5bwUAAIB2pdmhe6ONNkovvPBCMWsDAAAA7blN92abbZaOPPLIVFNTk5Zbbrk0wwwz1Pn7Flts0ZLrBwAAAO0ndO+999753xNPPHGCv0VHauPGjWuZNQMAAID2FrrrDxEGAAAAtFCbbgAAAKDA0P3YY4+lzTffPC2xxBL5Ee24n3jiiclZFAAAALRZzQ7d1113XerXr18eMiyGDovHTDPNlDbYYIN0ww03FLOWAAAA0B7adJ9yyinp73//ezr00EPL0yJ4n3POOemkk05KO+20U0uvIwAAALSPku4PPvggVy2vL6qYDx48uKXWCwAAANpf6O7Ro0d65JFHJpj+8MMP578BAAAAk1m9/PDDD8/VyQcNGpTWWGONPO2pp55KV111VTrvvPOauzgAAABos5oduvfff/8033zzpbPPPjvdcssteVrPnj3TzTffnLbccssi1hEAAADaR+gOW221VX4AAAAALdime+DAgem5556bYHpMe+GFF5q7OAAAAGizmh26q6qq0tChQyeY/sknn+S/AQAAAJMZumtqatLKK688wfSVVlop/w0AAACYzNDdqVOn9MUXX0ww/bPPPkvTTz9ZTcQBAACgTWp26N5www3T0Ucfnb799tvytBEjRqS//OUv6Te/+U1Lrx8AAAD8YjW7aPqss85Kv/71r9PCCy+cq5SHGLN73nnnTddee20R6wgAAADtI3QvsMAC6dVXX03XX399euWVV9JMM82Udt9997TjjjumGWaYoZi1BAAAgF+gyWqEPfPMM6d99tmn5dcGAAAA2nOb7hDVyNdaa63UvXv3NGTIkDzt3HPPTXfddVdLrx8AAAC0n9B98cUXp8MOOyxtsskm6Ztvvknjxo3L0+eYY47Uv3//ItYRAAAA2kfovuCCC9Jll12WjjnmmDpDhPXp0ye99tprLb1+AAAA0H5C9+DBg8u9ltcfv3v06NEttV4AAADQ/kL3oosumocIq++BBx5IPXv2bKn1AgAAgPbXe3m0566qqkrff/99qq2tTc8//3y68cYb02mnnZYGDBhQzFoCAABAewjde+21Vx6b+69//WsaM2ZM2mmnnXIv5uedd17aYYcdillLAAAAaC/jdO+88875EaF71KhRaZ555mn5NQMAAID21qZ77NixOWyHLl265NcxVNhDDz1UxPoBAABA+wndW265Zbrmmmvy8xEjRqRVVlklnX322Xl6jOENAAAATGbofumll9Laa6+dn996661pvvnmS0OGDMlB/Pzzz2/u4gAAAKDNanbojqrls846a34eVcq33nrr1LFjx7Taaqvl8A0AAABMZuheYokl0p133pmGDh2aHnzwwbThhhvm6cOGDUtdu3Zt7uIAAACgzWp26D7uuOPSEUcckRZZZJG06qqrptVXX71c6r3SSisVsY4AAADQPoYM23bbbdNaa62VPvvss7TCCiuUp2+wwQZpq622aun1AwAAgPY1Tnd0nhaPStGLOQAAANDM6uX77bdf+vjjj5sya7r55pvT9ddf36R5AQAAILX3ku655547LbPMMmnNNddMm2++eerTp0/q3r176ty5c/rmm29STU1NevLJJ9NNN92Up1966aXFrzkAAAC0hdB90kknpQMOOCANGDAgXXTRRTlkV4ohxPr165fD9sYbb1zUugIAAEDbbNM977zzpmOOOSY/onT7o48+SmPHjk3dunVLiy++eOrQoUOxawoAAADtoSO1OeaYIz8AAACAFhynGwAAAGgaoRsAAAAKInQDAABAQdpF6N5qq61yG/Rtt912Wq8KAAAA7UizQ3f0WD5mzJjy6yFDhqT+/funhx56KLVWBx98cLrmmmum9WoAAADQzjQ7dG+55ZblADtixIi06qqrprPPPjtPv/jii1NrtO666+axxAEAAKBVh+6XXnoprb322vn5rbfemsfvjtLuCOLnn39+s1fg8ccfT5tvvnnq3r17Huv7zjvvnGCe6urqtMgii6TOnTvnkP/88883+3MAAACg1YfuqFpeKjWOKuVbb7116tixY1pttdVy+G6u0aNHpxVWWCEH64bcfPPN6bDDDkvHH398Dvwx70YbbZSGDRtWnmfFFVdMyy677ASPTz/9tNnrAwAAAC1l+ua+YYkllsil0dE52YMPPpgOPfTQPD1CcNeuXZu9Aptsskl+NOacc85Je++9d9p9993z60suuSTde++96YorrkhHHXVUnjZo0KDUEn744Yf8KBk5cmSLLBcAAID2qdkl3ccdd1w64ogjcnXvVVZZJa2++urlUu+VVlqpRVfuxx9/TC+++GLq16/f/7/CHTvm188880xqaaeddlqabbbZyo8ePXq0+GcAAADQfjQ7dMewWx999FF64YUXckl3yQYbbJDOPffcFl25L7/8Mo0bNy63G68Urz///PMmLydC+u9///t03333pQUXXLDRwH700Uenb7/9tvwYOnToFH8HAAAA2q9mVy8P8803X36UQmmUCEepd2v18MMPN2m+Tp065QcAAABMk5Lun3/+OR177LG5+nVUMY9HPP/rX/+afvrpp9SSunXrlqabbrr0xRdf1JkeryP0AwAAQJsK3QceeGC69NJL09///vf08ssv50c8v/zyy9NBBx3Uois344wzpt69e6dHHnmkPG38+PH5daktOQAAALSZ6uU33HBDuummm+r0OL788svnKuY77rhjuvjii5u1vFGjRqX33nuv/Hrw4MG5N/I555wzLbTQQnm4sN122y316dMnV2Hv379/Hmas1Js5AAAAtJnQHW2eo0p5fYsuumgumW6u6JBtvfXWK7+OkB0iaF911VVp++23T8OHD8+9pkfnaTEm9wMPPDBB52oAAADwiw/dBxxwQDrppJPSlVdeWe50LMa2PuWUU/LfmmvddddNtbW1k/zMyVk2AAAA/KJCd7ThjjbVMfTWCiuskKe98soreUztGDZs6623Ls97++23t+zaAgAAQFsO3bPPPnvaZptt6kyL9txtSXV1dX7EGOEAAAAw1UJ3VCtv66qqqvJj5MiReTg0AAAAmCpDhgEAAAAFlXR/9dVXuSfxRx99NA0bNiyPm13p66+/bu4iAQAAoE1qduj+wx/+kMfV3nPPPfOwXR06dChmzQAAAKC9he4nnngiPfnkk+WeywEAAIAWatO99NJLp7Fjxzb3bQAAANDuNDt0X3TRRemYY45Jjz32WG7fHT18Vz4AAACAKRinO8L1+uuvX2d6bW1tbt9tbGsAAACYzNC98847pxlmmCHdcMMNOlIDAACAlgzdr7/+enr55ZfTUkstldqq6urq/FBqDwAAwFRt092nT580dOjQ1JZVVVWlmpqaNHDgwGm9KgAAALSnku4DDzwwHXzwwenII49Myy23XK5qXmn55ZdvyfUDAACA9hO6t99++/zvHnvsUZ4WHajpSA0AAACmMHQPHjy4uW8BAACAdqnZoXvhhRcuZk0AAACgvXekFq699tq05pprpu7du6chQ4bkaf3790933XVXS68fAAAAtJ/QffHFF6fDDjssbbrppmnEiBHlYbVmn332HLwBAACAyQzdF1xwQbrsssvSMccck6abbro6Q4m99tprzV0cAAAAtFkdJ6cjtZVWWmmC6Z06dUqjR49uqfUCAACA9he6F1100TRo0KAJpj/wwAOpZ8+eLbVeAAAA0H56Lz/xxBPTEUcckdtzV1VVpe+//z6Pzf3888+nG2+8MZ122mlpwIABxa4tAAAAtMXQ/be//S3tt99+aa+99kozzTRT+utf/5rGjBmTdtppp9yL+XnnnZd22GGH1BZUV1fnR6mTOAAAACg0dEepdsnOO++cHxG6R40aleaZZ57UlkRJfjxGjhyZZptttmm9OgAAALT10B06dOhQ53WXLl3yAwAAAJjC0P2rX/1qguBd39dff92cRQIAAECb1azQHe26VbcGAACAAoYMi47Sdtttt4k+AICp56abbkorr7xy7uR0zjnnTNtuu216//33J/m+Cy64IPXq1St16tQp982yxx57pC+++KLOPFG7raFHdKZa6eeff05nnnlmWm655VLnzp3zDfrevXune++9tzzP0UcfnYcW7dq1a55n4YUXzp85ZMiQFtwaAPALLumeVLVyAGDquvzyy/OoImHRRRdNX331VbrtttvSE088kV555ZU033zzNfi+Y489Np188sn5+ZJLLpk+/vjjdOWVV6ZnnnkmvfjiixP017LiiivmcF7So0ePOh2tbrPNNunuu+/OrxdffPE0yyyzpMGDB6eXX345bbbZZnn6gw8+mEaPHp0/Lzoqfe+99/JnPv300+mtt94qYOsAwC+spLuy93IAYNr68ccf01FHHZWfR+j94IMP0ptvvplmnXXWNGzYsHTqqac2+L4ozT7jjDPy88MPPzy988476dlnn8031yP8XnLJJRO854477sjzlB777rtv+W8333xzDtwzzzxzeuqpp3KYHjRoUL4BcMghh5Tni3D90Ucf5VD/7rvvpl122SVPf/vtt/O8IUZE2X///XOoj5A/99xzpzXXXDNdffXVLbz1AKAVhu7x48e3uaHBAOCXauDAgenLL78sh+7QvXv3tNpqq+XnDzzwQIPve/jhh9NPP/1U533LL798WmKJJRp9X58+fXLp9zLLLJNOP/309MMPP9QJ3WGxxRZLxxxzTA79Udp9wgknpBlnnLE8X1Qpv+iii9Kqq66aS7uvu+66PD2quEe1+HDcccfl0D98+PD8WbGs5557Lj366KMtss0AoNW36QYAWoehQ4eWn1feFJ933nnzv1Gq3BLvm2OOOdKCCy6YS55rampy2+xdd921/PcoqQ6vvfZaeumll9ICCyyQS91PPPHEdNhhh9VZViz7+eefz6XhYaWVVkr//ve/y03YogS8VP09lhXLiVL7Qw89dDK2EAC0DkI3ALQhk9scrKH3RVXyqPod1cU/+eSTtP766+fpt9xySzm8RydqYbrppsvtyKOKenSQFi699NJyqXqIUvKYP+ZZb731cpvvnXfeOY0bNy7/ffPNNy+H7uhobaONNsodvpVuCADAL5HQDQC/QJWdmUVpcP3nCy200BS/L6qCl0qho3r5VlttVf5bKXRHyXaI9teLLLJIfr7KKqvkfyNwR1ivFOF8qaWWKrf3/u9//5seeeSR/HyfffZJjz32WC4hX3rppXP776im3q9fv2ZvHwBoLYRuAPgF6tu3b5prrrny8+ixPHz66ae5dDpsvPHG+d8Ir/G48MIL8+sNNtggTT/99HXe9+qrr5arfJfe9/jjj6dbb721XAr9/fffp7vuuqv8+VESHUqBONphl4b/euGFF/K/0bna/PPPn6uNR2dr0T9MiH8r245Hr+Yhqp5HW+6zzjor93Z+zz335OlvvPFGubM1APilEbobUF1dnTt2iQsaAGiNopOyUg/lEZ6jI7MYB/u7775L3bp1K/dsHm2u41HqdC2GETvyyCPz87PPPjuXOkfna1G9PDo4K/VMHu2pf//73+cxt6OjteikLTphC7vvvnu5hLuqqioH8AjnK6ywQl6HAQMG5L/9+c9/zm3Bo7R7yy23zMuKeWJZF198cZ4n2ovHjYBw/vnn5/WL4c9inO+oXh7is0qdrQHAL43Q3YC4gIjOYqJnWABoraI6dvQCHuNoRyl3VAXfeuut8/BcEWwbc8opp6T+/fvnEvAYTztKpHfbbbdcuh3Pw1prrZX222+/XN085onS6QjC0bt4tNUumX322fO44DvuuGOuOh7VzldeeeV07bXX5rbZIZbxu9/9LnfKFjcAvvnmm9zDeQT8GBu8a9eueb4Y03vttddOY8eOzR2zRY/n0c77vvvuK1dzB4Bfmg61BuBu1MiRI/Nd+W+//bZ8QdAaRQ+vcSH04nbbpZXnnntarw7QiJeGD0+9b7klt1ONUAIAQNvPi0q6AQAAoCD/60kFAFpYjMlcakcMtG7RD0BjPd4DMGWEbgAKCdxL9eyZvh8zxtaFX4DOXbqkt998U/AGKIDQDUCLixLuCNwrn3RcmmXR/w0tBbROowYPSS8de2L+3SrtBmh5QjcAhYnAPXvPpWxhAKDd0pEaAAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQncDqqurU69evVLfvn2L2u4AAAC0A0J3A6qqqlJNTU0aOHDg1N8jAAAAtBlCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROhuQHV1derVq1fq27dvUdsdAACAdkDobkBVVVWqqalJAwcOnPp7BAAAgDZD6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6G1BdXZ169eqV+vbtW9R2BwAAoB0QuhtQVVWVampq0sCBA6f+HgEAAKDNELoBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQncDqqurU69evVLfvn2L2u4AAAC0A0J3A6qqqlJNTU0aOHDg1N8jAAAAtBlCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAANCibrrpprTyyiunmWaaKc0555xp2223Te+///4k33fBBRekXr16pU6dOqV55pkn7bHHHumLL76oM8+BBx6YVlhhhTT99NOnDh06pPnmm2+C5Tz88MNp7bXXTnPPPXeaccYZ87LWXXfddNddd9WZb/jw4enggw9Oiy++eOrcuXNaZJFF0tFHH51++OGHFtgK8D9CNwAA0GIuv/zytOOOO6aXX345zT///GncuHHptttuS2ussUb6/PPPG33fsccemw466KD05ptvpoUXXjiNGjUqXXnllTksjxkzpjzftddemz777LMc5hvz+uuv50cE8mWWWSZ999136bHHHktbb711evrpp/M8EawjmJ9//vnpk08+SUsvvXQO+KeffnraYYcdHBG0GKEbAABoET/++GM66qij8vNtttkmffDBBzlEzzrrrGnYsGHp1FNPbfB9EXbPOOOM/Pzwww9P77zzTnr22WdzSfZbb72VLrnkkvK8r732Wl7Wpptu2uh67L///umbb77J80b4v+eee/L08ePHp2eeeSY/f+SRR9Lbb7+dn8dNgUGDBqW77747v77zzjvL4TzCfyyvR48euQQ+Ss/XXHPNdPXVVztqaBKhGwAAaBEDBw5MX375ZTl0h+7du6fVVlstP3/ggQcafF9UB//pp5/qvG/55ZdPSyyxxATvi/A7KRGOhwwZkj93pZVWSptvvnme3rFjx1ziXgrgJTG98t/SOoXjjjsuh/6oih6l5nED4bnnnkuPPvpos7YN7df003oFAACAtmHo0KHl59GOumTeeefN/3700UfNft+7777b6PsmZuzYsTkcl8w888y5uvrqq6+eX6+11lq5+ntUVY9q51G9vFTyHaLKeYjPL1V/P+aYY/Lzr7/+us46w8Qo6QYAAApVW1s7Vd8XIkTH+7/66qvcTnv06NFpn332SS+99FL+++yzz55Ls6MUPAL5hx9+mH73u9/l6WGGGWbI/5ZKySN0R1vzjTbaKHf4VrqRAJMidAMAAC2isup3tLuu/3yhhRZq0fc1RXS49uc//znNMcccacSIEemss84q/y16So923FElPtqAx99inrDUUkvlfyOoRydshx12WA7yL774YjrhhBNSv379JnudaF+EbgAAoEX07ds3zTXXXOXOycKnn36aO0ULG2+8cf43wms8Lrzwwvx6gw02yEOAVb7v1VdfTe+9916d9zXVgAEDchXwkugUrRSmo8S7JNarNDxYVEeP4chKpdxR5Tw8//zzuS13BPIHH3yw3CnbG2+8kUvRYVKEbgAAoEXEmNilHsojPC+22GKpZ8+eeciubt26lXs2j7bT8Sh1uhZDex155JH5+dlnn51LmaMTtKgevuSSS6Z99923/BkxhFh0sHb77bfn17GMeB2PUhvuk08+ObcNj/dGaXa03y5VVd91113Ly4r5Yr2i07Zo311a5plnnpkWWGCB/DyGFIv1W3TRRVPv3r1z9fIQf5/YsGVQInQDAAAtJqpjX3fddWnFFVfMpdwx7FdpfOzoybwxp5xySurfv38uAR88eHBuZ73bbrulxx9/PD8vibbX77//fg7yIcYBj9fxiNLqEONsR9iP6ukx/FiUvkdYvu+++8q9o4d11lknB+roLO3nn3/O4fyOO+5IBx98cHmezTbbLI/nHcuOIcg6d+6c23nHsuK7waR0qJ2S3gnauJEjR6bZZpstffvtt6lr166ptYrOIOKu24vbbZdWnnvuab06QCNeGj489b7lltwWbOWVV27T26l0Xvr1dZen2Xv+r00c0DqNePPt9Pgue7aLcxPAtMiLSroBAACgIMbpBgCg3YjxnkvtiIHWrVu3blPUc31rIXQDANBuAvdSPXum78eMmdarAjRB5y5d0ttvvvmLD95CNwAA7UKUcEfgXvbIU9PMCy02rVcHmIjRH32QXj/zL/l3K3QDAMAvSATurkv0nNarAbQTOlIDAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgINMXteC2oLa2Nv87cuTI1JqNGjXqf//+9FMa+eOP03p1gEbEbzT/O2pUqz+vtNR56ecxY9NPo0ZP69UBJiJ+p+3u3DR2TPp59P+eA63Tz2PHtPpzU2m9SrmxMR1qJzVHO/bxxx+nHj16TOvVAAAAoJUaOnRoWnDBBRv9u9A9EePHj0+ffvppmnXWWVOHDh2K2D8w0TtncdMnfsRdu3a1pYBpznkJaI2cm5hWovz6u+++S927d08dOzbeclv18omIDTexOxYwNUTgFrqB1sR5CWiNnJuYFmabbbZJzqMjNQAAACiI0A0AAAAFEbqhlerUqVM6/vjj878ArYHzEtAaOTfR2ulIDQAAAAqipBsAAAAKInQDAABAQYRuAAAAKIjQDQVZd9110yGHHNLk+T/88MPUoUOHNGjQIPsEaJL//ve/+bwxYsSIJm+xE044Ia244oq2MLQjzhUwbQnd0Ax//OMf8wXufvvtN8Hfqqqq8t9innD77benk046qcnL7tGjR/rss8/Ssssua58AdTzzzDNpuummS5tttlmrPz+WHnPNNVfaeOON06uvvtrs5fzud78rbD2hrfolnCfa2rniqquuqvNdGnpEoQoI3dBMEY5vuummNHbs2PK077//Pt1www1poYUWKk+bc84506yzztrk5cb/KOebb740/fTT2ydAHZdffnk68MAD0+OPP54+/fTTVrt14sI5bh7G45FHHsnns9/+9rfTerWgXfilnCda+7miVPOwKbbffvvy94jH6quvnvbee+860+K6seTHH38scM1pzYRuaKaVV145n0CjJLsknkfgXmmllRqtXr7IIoukU089Ne2xxx45jMf8l156aaPVy0tVwR588MG83Jlmmimtv/76adiwYen+++9PPXv2TF27dk077bRTGjNmTHk5DzzwQFprrbXS7LPPnu8ex//E3n///fLfr7nmmjTLLLOkd999tzztT3/6U1p66aXrLAdoHUaNGpVuvvnmtP/+++cSrChZaUz8LX77d955Z1pyySVT586d00YbbZSGDh06wbzXXnttPi/NNttsaYcddkjfffddk88jExsrN24exiOqsB911FH5s4cPH16eJ15vt912edlxc3LLLbcslwRF1ferr7463XXXXeVSojgXhj//+c/pV7/6VerSpUtabLHF0rHHHpt++umnZm9PaO/nieBc0TLi2qx0zovHjDPOmM9RpddxDtxmm23SKaeckrp3756WWmqp8vm3T58++Xow5otrubi+KyldA8YNiZgvlrnGGmukt99+uzzPK6+8ktZbb728jLge7N27d3rhhRda6JvR0oRumAwRnK+88sry6yuuuCLtvvvuk3zf2WefnU+eL7/8cg668T/HyhNoQ+Ii9MILL0xPP/10+WK1f//+uWT93nvvTQ899FC64IILyvOPHj06HXbYYfnEGyfrjh07pq222iqNHz8+/33XXXdNm266adp5553Tzz//nJcxYMCAdP311+eTOtC63HLLLfmmWFys7bLLLvl8U1tb2+j8cfMsLvDiBttTTz2V23tHqK4UATqC+T333JMfjz32WDr99NObfB5pagi47rrr0hJLLJGDe4iQHDcB4iLxiSeeyOsXNwGj1CtKgI444oh8jqssBYsLzRDviaBQU1OTzjvvvHTZZZelc889dzK2KLQ9zT1PBOeKqSPOoXGt9+9//zufb0vnwmiCGME5zsVx47HUPLHSMccck68d41wctQHi+rMkruMWXHDBNHDgwPTiiy/mgD/DDDNMpW9Fs9UCTbbbbrvVbrnllrXDhg2r7dSpU+2HH36YH507d64dPnx4/lvME9ZZZ53agw8+uPzehRdeuHaXXXYpvx4/fnztPPPMU3vxxRfn14MHD47/O9a+/PLL+fWjjz6aXz/88MPl95x22ml52vvvv1+etu+++9ZutNFGja5zrFe857XXXitP+/rrr2sXXHDB2v3337923nnnrT3llFMcBdBKrbHGGrX9+/fPz3/66afabt265fND5Xnim2++ya+vvPLK/PrZZ58tv//NN9/M05577rn8+vjjj6/t0qVL7ciRI8vzHHnkkbWrrrpqs84j9cW5b7rppqudeeaZ8yPmn3/++WtffPHF8jzXXntt7VJLLZXPfyU//PBD7UwzzVT74IMPlpcT59JJOfPMM2t79+49yfmgvZ8ngnNF088VpeuxyVH/2i/OZ3GdFee5iRk4cGD+zO+++67Ra8B77703Txs7dmx+Peuss9ZeddVVk7WeTH1KumEyzD333OXqW1HiHc+7des2yfctv/zy5edRbSiqFFVWJ5rUe+add95y1crKaZXLiGrjO+64Y54nqhtF9dHw0UcfleeZY445ctuviy++OC2++OL57ijQ+kTpyPPPP59/0yFKOqINYfx+GxPz9O3bt/w6Sr+iKvebb75Znhbnhco+J+aff/5mnUc22WSTXEIdj2WWWab8vqjqGE1k4hHrHaXaMe+QIUPy36NU57333sufXXp/VDGPfjEmVX09qs6uueaa+bwZ7/vrX/9a57wG7dXknCdK8zlX/E+cx+qf00qv4xHnscm13HLL5WrnlaJkevPNN89NDeN8uM466+Tp9c9pldeAcZ4OpXN11Ebaa6+9Ur9+/XJNpaY0AWLa0WMTTKao4nPAAQfk59XV1U16T/1qPxG8J1Vds/I9Mf+klhEn8YUXXjhXvYz2Q/G36BG9fucd0dFKdN4W1TejKmlzOn0Dpo64aI5mIPFbLokqo9F2OpqdTK4pPY9Ek5RSZ5KVy5p55plzdfKSmC/ajMdyTj755FzlPNodRnOWhm5mTqxX5qhK+be//S0H+VhmdGgZ1S6hvZvUeSJ+L5OrvZwr7rvvvnIfEZ988knul6dyCNdouz254rtWimuuWLd4xPeL7xNhO17Xv1arfw0YSts/mh9GW/BoJhh9/Rx//PH5u0ZTIFofoRsmU6kNYpwE40TZGnz11Vf5jnf8T2vttdfO05588skJ5ov24WeccUb617/+lTsnipsH0XkR0HrERXS0y46LxQ033LDO32KYnBtvvDGXYjf0vmj/t8oqq+TXcU6Idt3R+WJLnUcWWGCBJi0rzo/RHrx00R0dUUaJ9TzzzJNL0BsSJULjxo2b4JwVF/bRvrGkVHoO7VlTzhMNDXNaeq9zxf/E+aWkNIpM5U2BlvTWW2/l82yUTpd6Np/cDtCic8l4HHroobmmQ9S+FLpbJ9XLYTJFKXFU14xOfeJ5axDVxqPDougVPapw/uc//8nVjypFD8V/+MMf0kEHHZSrS8Vd1rgIvvXWW6fZegMTig53vvnmm7TnnnvmkqPKR/SG21jV0SgZiWGDnnvuuVyFMTrnWW211cohvCXOI4354Ycf0ueff54fcX6M9YgSqygNC1ECFU1xosfy6Eht8ODBuZfeOB99/PHHeZ6oyh7j9Ubw//LLL3PpU/TEHiVBUYoTVSjPP//8dMcddzhsaPcm9zzhXDHtRJXyuLkYneB+8MEH6e67786dqjVH3MiMApM4f8YNyOiUMjpUa+rNVaY+oRumQJTUNFZaMy1EiVJclMaFdvwPN+58nnnmmXXmOfjgg3NVpxi+rNTWKJ7vu+++uUoV0DrExXK01WuoamhcTEfJSITT+qLfh6jBEtUOow10tEeMG2steR5pTAw1Fu0O47Hqqqvmi8B//vOfuapmad2iaUtcdG699db5AjHCQrTpLp1LY4zb6IE5RnqIapdxMbnFFlvk9YiLzBiKLEq+Y8gwaO8m9zwRnCumjTivRZ9AcW7s1atXLvE+66yzmrWMKOyJ0vIYkSZKumPUhyhIiWr1tE4doje1ab0SAMCUiwu5Qw45JFcnB3CugNZBSTcAAAAUROgGAACAgqheDgAAAAVR0g0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAKkY/w84moepDWKeywAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -1203,10 +1205,10 @@
    "metadata": {
     "id": "ecf56b75",
     "papermill": {
-     "duration": 0.027675,
-     "end_time": "2026-05-23T01:52:11.421077",
+     "duration": 0.004095,
+     "end_time": "2026-06-02T03:05:18.878228",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.393402",
+     "start_time": "2026-06-02T03:05:18.874133",
      "status": "completed"
     },
     "tags": []
@@ -1238,10 +1240,10 @@
    "metadata": {
     "id": "exercices-section",
     "papermill": {
-     "duration": 0.095695,
-     "end_time": "2026-05-23T01:52:11.518787",
+     "duration": 0.004334,
+     "end_time": "2026-06-02T03:05:18.886650",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.423092",
+     "start_time": "2026-06-02T03:05:18.882316",
      "status": "completed"
     },
     "tags": []
@@ -1277,18 +1279,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:11.713447Z",
-     "iopub.status.busy": "2026-05-23T01:52:11.711521Z",
-     "iopub.status.idle": "2026-05-23T01:52:11.767138Z",
-     "shell.execute_reply": "2026-05-23T01:52:11.758628Z"
+     "iopub.execute_input": "2026-06-02T03:05:18.896711Z",
+     "iopub.status.busy": "2026-06-02T03:05:18.896433Z",
+     "iopub.status.idle": "2026-06-02T03:05:18.902508Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.901884Z"
     },
     "id": "o8n7ldilw8",
     "outputId": "ba99b363-232c-4fd5-fbed-30a94d877075",
     "papermill": {
-     "duration": 0.163577,
-     "end_time": "2026-05-23T01:52:11.771188",
+     "duration": 0.012224,
+     "end_time": "2026-06-02T03:05:18.903366",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.607611",
+     "start_time": "2026-06-02T03:05:18.891142",
      "status": "completed"
     },
     "tags": []
@@ -1350,10 +1352,10 @@
    "metadata": {
     "id": "5f5508cf",
     "papermill": {
-     "duration": 0.085328,
-     "end_time": "2026-05-23T01:52:11.890245",
+     "duration": 0.003874,
+     "end_time": "2026-06-02T03:05:18.911524",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.804917",
+     "start_time": "2026-06-02T03:05:18.907650",
      "status": "completed"
     },
     "tags": []
@@ -1368,17 +1370,17 @@
    "id": "0sdp0t3db7ro",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.052933Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.050969Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.088862Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.080541Z"
+     "iopub.execute_input": "2026-06-02T03:05:18.920922Z",
+     "iopub.status.busy": "2026-06-02T03:05:18.920630Z",
+     "iopub.status.idle": "2026-06-02T03:05:18.925097Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.924340Z"
     },
     "id": "0sdp0t3db7ro",
     "papermill": {
-     "duration": 0.167301,
-     "end_time": "2026-05-23T01:52:12.107874",
+     "duration": 0.010896,
+     "end_time": "2026-06-02T03:05:18.926279",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.940573",
+     "start_time": "2026-06-02T03:05:18.915383",
      "status": "completed"
     },
     "tags": []
@@ -1411,10 +1413,10 @@
    "metadata": {
     "id": "52c7cc97",
     "papermill": {
-     "duration": 0.02955,
-     "end_time": "2026-05-23T01:52:12.174534",
+     "duration": 0.004934,
+     "end_time": "2026-06-02T03:05:18.936532",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.144984",
+     "start_time": "2026-06-02T03:05:18.931598",
      "status": "completed"
     },
     "tags": []
@@ -1432,18 +1434,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.351409Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.350009Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.396374Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.387365Z"
+     "iopub.execute_input": "2026-06-02T03:05:18.947488Z",
+     "iopub.status.busy": "2026-06-02T03:05:18.947132Z",
+     "iopub.status.idle": "2026-06-02T03:05:18.951936Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.951125Z"
     },
     "id": "7aqlxw701c3",
     "outputId": "2e179132-c5be-439b-c967-28ddf93efb6a",
     "papermill": {
-     "duration": 0.146833,
-     "end_time": "2026-05-23T01:52:12.400002",
+     "duration": 0.011748,
+     "end_time": "2026-06-02T03:05:18.953094",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.253169",
+     "start_time": "2026-06-02T03:05:18.941346",
      "status": "completed"
     },
     "tags": []
@@ -1491,10 +1493,10 @@
    "metadata": {
     "id": "279946a9",
     "papermill": {
-     "duration": 0.084835,
-     "end_time": "2026-05-23T01:52:12.551452",
+     "duration": 0.004245,
+     "end_time": "2026-06-02T03:05:18.961768",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.466617",
+     "start_time": "2026-06-02T03:05:18.957523",
      "status": "completed"
     },
     "tags": []
@@ -1512,18 +1514,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.730509Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.728523Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.764310Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.760570Z"
+     "iopub.execute_input": "2026-06-02T03:05:18.970971Z",
+     "iopub.status.busy": "2026-06-02T03:05:18.970678Z",
+     "iopub.status.idle": "2026-06-02T03:05:18.976091Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.975465Z"
     },
     "id": "m7qk49cywe",
     "outputId": "775a2367-2b56-44dc-a95f-12ec1c565cde",
     "papermill": {
-     "duration": 0.136765,
-     "end_time": "2026-05-23T01:52:12.762134",
+     "duration": 0.01134,
+     "end_time": "2026-06-02T03:05:18.977238",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.625369",
+     "start_time": "2026-06-02T03:05:18.965898",
      "status": "completed"
     },
     "tags": []
@@ -1576,9 +1578,20 @@
   {
    "cell_type": "markdown",
    "id": "80b7c394",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004213,
+     "end_time": "2026-06-02T03:05:18.985796",
+     "exception": false,
+     "start_time": "2026-06-02T03:05:18.981583",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Extension du modele\n\nVariante de la recherche adversariale avec evaluation heuristique avancee."
+    "### Extension du modele\n",
+    "\n",
+    "Variante de la recherche adversariale avec evaluation heuristique avancee."
    ]
   },
   {
@@ -1587,17 +1600,17 @@
    "id": "d8trzalzkan",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.840382Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.839435Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.849118Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.847921Z"
+     "iopub.execute_input": "2026-06-02T03:05:18.995929Z",
+     "iopub.status.busy": "2026-06-02T03:05:18.995584Z",
+     "iopub.status.idle": "2026-06-02T03:05:19.000624Z",
+     "shell.execute_reply": "2026-06-02T03:05:18.999607Z"
     },
     "id": "d8trzalzkan",
     "papermill": {
-     "duration": 0.054179,
-     "end_time": "2026-05-23T01:52:12.847871",
+     "duration": 0.01184,
+     "end_time": "2026-06-02T03:05:19.001992",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.793692",
+     "start_time": "2026-06-02T03:05:18.990152",
      "status": "completed"
     },
     "tags": []
@@ -1637,10 +1650,10 @@
    "metadata": {
     "id": "b252120f",
     "papermill": {
-     "duration": 0.009767,
-     "end_time": "2026-05-23T01:52:12.875825",
+     "duration": 0.004586,
+     "end_time": "2026-06-02T03:05:19.011289",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.866058",
+     "start_time": "2026-06-02T03:05:19.006703",
      "status": "completed"
     },
     "tags": []
@@ -1658,18 +1671,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.897056Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.896685Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.903852Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.902703Z"
+     "iopub.execute_input": "2026-06-02T03:05:19.021481Z",
+     "iopub.status.busy": "2026-06-02T03:05:19.021074Z",
+     "iopub.status.idle": "2026-06-02T03:05:19.026481Z",
+     "shell.execute_reply": "2026-06-02T03:05:19.025873Z"
     },
     "id": "au3i41rhmcu",
     "outputId": "25f4944b-ce8e-4862-d827-04a9eb61f0f7",
     "papermill": {
-     "duration": 0.018852,
-     "end_time": "2026-05-23T01:52:12.904224",
+     "duration": 0.011569,
+     "end_time": "2026-06-02T03:05:19.027432",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.885372",
+     "start_time": "2026-06-02T03:05:19.015863",
      "status": "completed"
     },
     "tags": []
@@ -1728,10 +1741,10 @@
    "metadata": {
     "id": "882136fd",
     "papermill": {
-     "duration": 0.011367,
-     "end_time": "2026-05-23T01:52:12.926879",
+     "duration": 0.004448,
+     "end_time": "2026-06-02T03:05:19.036706",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.915512",
+     "start_time": "2026-06-02T03:05:19.032258",
      "status": "completed"
     },
     "tags": []
@@ -1746,10 +1759,10 @@
    "metadata": {
     "id": "conclusion-section",
     "papermill": {
-     "duration": 0.009721,
-     "end_time": "2026-05-23T01:52:12.946828",
+     "duration": 0.004455,
+     "end_time": "2026-06-02T03:05:19.046161",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.937107",
+     "start_time": "2026-06-02T03:05:19.041706",
      "status": "completed"
     },
     "tags": []
@@ -1802,18 +1815,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 17.302546,
-   "end_time": "2026-05-23T01:52:13.509207",
+   "duration": 8.329868,
+   "end_time": "2026-06-02T03:05:19.391996",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb",
    "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb",
    "parameters": {},
-   "start_time": "2026-05-23T01:51:56.206661",
+   "start_time": "2026-06-02T03:05:11.062128",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Add convention prints (PR #1946) to silent code cells in 3 Search notebooks + Papermill re-execution for Search-6.

## Changes

### Search-6-AdversarialSearch.ipynb (RE-EXECUTED)
- Cell 4 (`JeuSommeNulle` abstract class): added `print("Classe JeuSommeNulle (abstraite) definie")`
- Papermill: 38/38 cells, 8s, 0 errors
- 14/14 code cells with outputs (2 exercise stubs correctly have no output)

### App-13-TSP-Metaheuristics.ipynb (PRINT ONLY)
- Cell 40 (`algorithme_genetique_hybride_tsp`): added convention print
- **No re-exec**: pre-existing `three_opt` signature bug (function takes 2 args, called with `max_iter=30` kwarg). Out of scope for this PR.

### App-18-HyperparameterTuning.ipynb (PRINT ONLY)
- Cell 4 (`evaluate_random_forest` + param_space): added convention print
- **No re-exec**: `GeneticHyperparamOptimizer` times out on CPU (120s limit). GPU-dependent.

## Validation

- Search-6: 0 null execution_count, 0 errors, all code cells with outputs
- No `raise NotImplementedError` / `assert False` / `1/0` (C.1 compliant)
- No source deletions — only additions

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>