### PR TITLE
fix(SC): kernel metadata smartcontracts->python3 for 00-Foundations (3 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -344,20 +344,20 @@
       "MINI-BLOCKCHAIN (4 blocs)\n",
       "======================================================================\n",
       "Bloc 0 : Bloc Genesis\n",
-      "  Hash     : f801f8462f6b9013a3dc54fc23919032...\n",
+      "  Hash     : b18e0f6ad8500759601fd515bc238201...\n",
       "  Prev     : 00000000000000000000000000000000...\n",
       "\n",
       "Bloc 1 : Alice envoie 10 BTC a Bob\n",
-      "  Hash     : ec6b184b75bd28c18c9cf2539fb9ff18...\n",
-      "  Prev     : f801f8462f6b9013a3dc54fc23919032...\n",
+      "  Hash     : ffd26728a189b49241413d8f5a569135...\n",
+      "  Prev     : b18e0f6ad8500759601fd515bc238201...\n",
       "\n",
       "Bloc 2 : Bob envoie 5 BTC a Charlie\n",
-      "  Hash     : 515a7ec4e357518e46258d2b987ae77c...\n",
-      "  Prev     : ec6b184b75bd28c18c9cf2539fb9ff18...\n",
+      "  Hash     : 19eb547779b52fee648fe959a2b8ac2f...\n",
+      "  Prev     : ffd26728a189b49241413d8f5a569135...\n",
       "\n",
       "Bloc 3 : Charlie envoie 2 BTC a Dave\n",
-      "  Hash     : 9f9becf060eed1e302af3dbae4454ab1...\n",
-      "  Prev     : 515a7ec4e357518e46258d2b987ae77c...\n",
+      "  Hash     : a21d166a991aeb18e17fe523af1e9039...\n",
+      "  Prev     : 19eb547779b52fee648fe959a2b8ac2f...\n",
       "\n"
      ]
     }
@@ -443,14 +443,14 @@
       "Bloc 1 original : 'Alice envoie 10 BTC a Bob'\n",
       "Bloc 1 modifie  : 'Alice envoie 1000 BTC a Bob'\n",
       "\n",
-      "Hash original   : ec6b184b75bd28c18c9cf2539fb9ff185e19562f...\n",
-      "Hash recalcule  : ca03c508bebd8caaed1546ab81caf24a460b7e1f...\n",
+      "Hash original   : ffd26728a189b49241413d8f5a56913522caede5...\n",
+      "Hash recalcule  : d334ebd0f93371ef21f19726d4f71604c4a440e9...\n",
       "\n",
       "VERIFICATION DE LA CHAINE :\n",
       "  Bloc 1 -> previous_hash OK\n",
       "  Bloc 2 -> previous_hash INVALIDE\n",
-      "    Attendu : ca03c508bebd8caaed1546ab81caf24a...\n",
-      "    Trouve  : ec6b184b75bd28c18c9cf2539fb9ff18...\n",
+      "    Attendu : d334ebd0f93371ef21f19726d4f71604...\n",
+      "    Trouve  : ffd26728a189b49241413d8f5a569135...\n",
       "  Bloc 3 -> previous_hash OK\n",
       "\n",
       "-> Le bloc 2 pointe vers l'ancien hash du bloc 1 : la fraude est detectee !\n",
@@ -872,13 +872,13 @@
       "Difficulte 3 (cible: 000xxxxx) :\n",
       "  Nonce    :        410\n",
       "  Hash     : 000fcfcc32f345988c3f635964699b0b...\n",
-      "  Temps    : 0.0003s\n",
+      "  Temps    : 0.0004s\n",
       "  Essais   : ~410 (theorique: ~4,096)\n",
       "\n",
       "Difficulte 4 (cible: 0000xxxx) :\n",
       "  Nonce    :     39,430\n",
       "  Hash     : 000034fef981e1dc59961bd97dcd6c69...\n",
-      "  Temps    : 0.0337s\n",
+      "  Temps    : 0.0376s\n",
       "  Essais   : ~39,430 (theorique: ~65,536)\n",
       "\n"
      ]
@@ -890,7 +890,7 @@
       "Difficulte 5 (cible: 00000xxx) :\n",
       "  Nonce    :    214,484\n",
       "  Hash     : 00000bb794a36ce9ac55025613a1a499...\n",
-      "  Temps    : 0.1729s\n",
+      "  Temps    : 0.2056s\n",
       "  Essais   : ~214,484 (theorique: ~1,048,576)\n",
       "\n"
      ]
@@ -1019,12 +1019,12 @@
      "text": [
       "SIGNATURES NUMERIQUES (Courbes Elliptiques)\n",
       "======================================================================\n",
-      "Cle privee (secret) : 0x4757ae66e19c29e342ec3f97f6c1df...\n",
-      "Cle publique X      : 0x6821babe0a70f5732369346ca0532b...\n",
-      "Cle publique Y      : 0xc6928625010c656a56263752f1a8a7...\n",
+      "Cle privee (secret) : 0x35c40ea2a0c825822ee139e9d6a39d...\n",
+      "Cle publique X      : 0x3d16fa5b9ed5b7c0c5a3be046e8c37...\n",
+      "Cle publique Y      : 0x592fadcdb218dbcc0547cc2486b05b...\n",
       "\n",
       "Transaction : Envoyer 1 ETH de 0xAlice a 0xBob\n",
-      "Signature   : 1275ecb0a762a2197f8dc435b0c649aebd3641716bb078293638c678e03d1690...\n",
+      "Signature   : 16b4fec8a038fe68a724f25e67887d38e70360581e6dd62050db368c733dee9f...\n",
       "Taille      : 64 octets\n",
       "\n",
       "Verification : VALIDE (la transaction est authentique)\n",
@@ -1653,9 +1653,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
-   "language": "python",
-   "name": "smartcontracts"
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
@@ -1029,9 +1029,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
-   "language": "python",
-   "name": "smartcontracts"
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -1079,9 +1079,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
-   "language": "python",
-   "name": "smartcontracts"
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Summary

Fix kernel metadata for 3 SmartContracts notebooks in `00-Foundations/` — invalid `smartcontracts` kernel replaced with `python3`.

### Notebooks fixed
| Notebook | Kernel fix | Papermill | Notes |
|----------|-----------|-----------|-------|
| SC-0-Cypherpunk-Origins | `smartcontracts` → `python3` | 36/36 OK, kernel=python3 | Output refresh from Papermill re-exec |
| SC-1-Setup-Foundry | `smartcontracts` → `python3` | 26/26 OK, kernel=python3 | Output refresh from Papermill re-exec |
| SC-2-Setup-Web3py | `smartcontracts` → `python3` | NameError (pre-existing) | `web3` module not installed — unrelated to kernel fix |

## Validation proof

- **Papermill SC-0**: 36/36 cells executed, 0 errors, kernel=python3
- **Papermill SC-1**: 26/26 cells executed, 0 errors, kernel=python3
- **SC-2 pre-existing error**: `NameError: name 'Web3' is not defined` — web3.py not installed locally. Try/except import in cell [7] but subsequent usage outside try block. **Not related to kernel metadata change.**
- **Kernel metadata**: All 3 notebooks now have `kernelspec.name = "python3"`
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Kernel metadata only + output refresh (SC-0)

## Scope

- 3 files changed, 27 insertions, 27 deletions
- Rule F: kernel metadata invalid, python3 kernel available locally
- No code logic changed, no exercises modified