### PR TITLE
fix(SC): kernel metadata smartcontracts->python3 for 01-Solidity-Foundation (3 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -1556,9 +1556,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -1645,9 +1645,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -1246,9 +1246,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Summary

Fix kernel metadata for 3 SmartContracts notebooks in `01-Solidity-Foundation/` — invalid `smartcontracts` kernel replaced with `python3`.

### Notebooks fixed
| Notebook | Kernel fix | Papermill | Notes |
|----------|-----------|-----------|-------|
| SC-4-Functions-State | `smartcontracts` → `python3` | Pre-existing Anvil error | web3.py installed (rule F), Anvil node not running |
| SC-5-Inheritance | `smartcontracts` → `python3` | Pre-existing Anvil error | web3.py installed (rule F), Anvil node not running |
| SC-6-Errors-Events | `smartcontracts` → `python3` | Pre-existing Anvil error | web3.py installed (rule F), Anvil node not running |

### Note on execution errors
All 3 notebooks require **Anvil** (Foundry's local Ethereum node) running at `http://127.0.0.1:8545`. This is a blockchain development prerequisite, not a bug. The kernel fix is correct — `smartcontracts` kernel never existed, `python3` starts and executes setup cells successfully until the Anvil connection assertion.

## Validation proof

- **web3.py installed** (rule F): `pip install web3` → v7.16.0
- **Kernel start**: python3 kernel starts, imports (web3, solcx) resolve correctly
- **Pre-existing error**: `AssertionError: Impossible de se connecter a http://127.0.0.1:8545` — Anvil not running
- **Kernel metadata**: All 3 notebooks now have `kernelspec.name = "python3"`
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Kernel metadata only (6 insertions, 6 deletions)

## Scope

- 3 files changed, 6 insertions, 6 deletions
- Rule F: kernel metadata invalid, python3 kernel available locally
- No code logic changed, no exercises modified
- Follow-up: #2119 fixed 00-Foundations (3 notebooks)