### PR TITLE
fix(SC): kernel metadata smartcontracts->python3 for 02-Solidity-Advanced + 03-Foundry-Testing (7 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -1270,9 +1270,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -1970,9 +1970,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -1467,9 +1467,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -1314,9 +1314,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -1090,9 +1090,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -2504,9 +2504,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -1269,9 +1269,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Summary

Fix kernel metadata for 7 SmartContracts notebooks in `02-Solidity-Advanced/` and `03-Foundry-Testing/` — invalid `smartcontracts` kernel replaced with `python3`.

### Notebooks fixed
| Subdirectory | Notebook | Kernel fix |
|-------------|----------|-----------|
| 02-Solidity-Advanced | SC-7-Token-Standards | `smartcontracts` → `python3` |
| 02-Solidity-Advanced | SC-8-DeFi-Primitives | `smartcontracts` → `python3` |
| 02-Solidity-Advanced | SC-9-DAO-Governance | `smartcontracts` → `python3` |
| 02-Solidity-Advanced | SC-10-Account-Abstraction | `smartcontracts` → `python3` |
| 02-Solidity-Advanced | SC-11-LLM-Assisted | `smartcontracts` → `python3` |
| 03-Foundry-Testing | SC-12-Foundry-Testing | `smartcontracts` → `python3` |
| 03-Foundry-Testing | SC-14-Formal-Verification | `smartcontracts` → `python3` |

Note: SC-13-Fuzz-Invariants already had `python3` kernel — not modified.

### Execution note
All notebooks require **Anvil** (Foundry's local Ethereum node at `http://127.0.0.1:8545`). Same pre-existing execution limitation as #2119 and #2120. Kernel fix is correct — `python3` kernel starts and setup cells execute.

## Validation proof

- **Kernel metadata**: All 7 notebooks now have `kernelspec.name = "python3"`
- **0 NotImplementedError** (verified via grep on each notebook)
- **Source changes**: Kernel metadata only (14 insertions, 14 deletions)
- **Pre-existing Anvil dependency**: documented in #2119, #2120
- **web3.py installed** (rule F): v7.16.0

## Scope

- 7 files changed, 14 insertions, 14 deletions
- Rule F: kernel metadata invalid, python3 kernel available locally
- No code logic changed, no exercises modified
- Follow-up: #2119 (00-Foundations, 3 nb), #2120 (01-Solidity-Foundation, 3 nb)

## Kernel metadata lane progression
- 00-Foundations: 3/3 ✅ (#2119)
- 01-Solidity-Foundation: 4/4 ✅ (#2120, SC-3 already python3)
- 02-Solidity-Advanced: 5/5 ✅ (this PR)
- 03-Foundry-Testing: 3/3 ✅ (this PR + SC-13 already python3)
- Remaining: 04-Privacy-Cryptography (3), 05-Alternative-Chains (5), 06-Real-World (3) = **11 notebooks**