### PR TITLE
fix(SC): kernel metadata smartcontracts->python3 for 04-Privacy + 05-Alternative + 06-Real-World (11 notebooks) — COMPLETES lane

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -1992,9 +1992,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -1929,9 +1929,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
@@ -1472,9 +1472,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -1616,9 +1616,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -1756,9 +1756,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -2039,9 +2039,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
@@ -987,9 +987,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -1203,9 +1203,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
@@ -1275,9 +1275,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
@@ -746,9 +746,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -975,9 +975,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (SmartContracts + Foundry)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "smartcontracts"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
## Summary

Fix kernel metadata for 11 SmartContracts notebooks in the last 3 subdirectories — invalid `smartcontracts` kernel replaced with `python3`.

**COMPLETES the SmartContracts kernel metadata lane (24/24 notebooks).**

### Notebooks fixed
| Subdirectory | Notebooks | Count |
|-------------|----------|-------|
| 04-Privacy-Cryptography | SC-15, SC-16, SC-17 | 3 |
| 05-Alternative-Chains | SC-18, SC-19, SC-20, SC-21, SC-22 | 5 |
| 06-Real-World | SC-24, SC-25, SC-26 | 3 |
| **Total** | | **11** |

Note: SC-23 already had `python3` kernel (fixed in cycle 100). `_output.ipynb` artefacts excluded.

### Execution note
All notebooks require **Anvil** (Foundry local Ethereum node). Same pre-existing limitation as #2119, #2120, #2121. Kernel fix is correct.

## Validation proof

- **Kernel metadata**: All 11 notebooks now have `kernelspec.name = "python3"`
- **0 NotImplementedError** (verified via grep)
- **Source changes**: Kernel metadata only (22 insertions, 22 deletions)
- **web3.py installed** (rule F): v7.16.0

## Scope

- 11 files changed, 22 insertions, 22 deletions
- Rule F: kernel metadata invalid, python3 kernel available locally
- No code logic changed, no exercises modified

## Kernel metadata lane — COMPLETE (24/24)

| Subdirectory | Notebooks | Status | PR |
|-------------|-----------|--------|-----|
| 00-Foundations | 3 | ✅ | #2119 |
| 01-Solidity-Foundation | 4 | ✅ | #2120 (SC-3 already python3) |
| 02-Solidity-Advanced | 5 | ✅ | #2121 |
| 03-Foundry-Testing | 3 | ✅ | #2121 (SC-13 already python3) |
| 04-Privacy-Cryptography | 3 | ✅ | **this PR** |
| 05-Alternative-Chains | 5 | ✅ | **this PR** |
| 06-Real-World | 4 | ✅ | **this PR** (SC-23 already python3) |
| **Total** | **24** | **✅ COMPLETE** | **4 PRs** |