### PR TITLE
enrich(Sudoku): add markdown transitions in Sudoku-6 and Sudoku-13 (consecutive code pairs 0)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -60,7 +60,9 @@
     "## Note sur l'approche\n",
     "\n",
     "> **⚠️ Important** : Ce notebook presente la theorie des automates symboliques et montre comment les concepts (predicats, intersection, produit) se compilent naturellement vers des contraintes SMT. Pour une implementation \"pure\" automates avec BDD/MDD, voir [Sudoku-13](Sudoku-13-BDD.ipynb).\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -130,7 +132,9 @@
     "3. Section 6 : Discussion sur quand utiliser chaque approche\n",
     "\n",
     "Cette dualite theorie/pratique est exactement ce que fait la bibliotheque **Automata.Net** : elle fournit des operations d'automates de haut niveau qui sont compilees vers des solveurs (BDD, Z3) pour l'execution.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -160,7 +164,9 @@
     "- Une union de predicats : `digit.Or(letter)`\n",
     "- Une intersection : `lowercase.And(vowel)`\n",
     "- Un complement : `notDigit = digit.Not()`"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -188,7 +194,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-16272.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-44404.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -233,12 +239,12 @@
        "}\r\n",
        "\r\n",
        "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://192.168.1.14:2048/\", \"http://172.31.96.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
+       "    probeAddresses([\"http://192.168.0.20:2048/\", \"http://172.27.208.1:2048/\", \"http://172.28.176.1:2048/\", \"http://127.0.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '16272.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '44404.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -508,7 +514,9 @@
     "### 2.2 Exemples de Predicats CharSet\n",
     "\n",
     "Testons notre classe `CharSet` avec differents types de predicats."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -831,7 +839,9 @@
     "3. Les predicats sont representes de manière symbolique (formules, pas enumeration)\n",
     "\n",
     "> **Note theorique** : Ces predicats sont exactement ce qui distingue les automates symboliques des automates classiques. Dans un DFA classique, chaque transition est etiquettee par un caractere concret. Dans un SFA, chaque transition est etiquettee par un predicat comme `Range('1', '9')`."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -859,7 +869,9 @@
     "- Des etats nommes\n",
     "- Des transitions etiquettees par des predicats `CharSet`\n",
     "- Un etat initial et des etats finaux"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1040,7 +1052,9 @@
     "### 3.2 Exemple : Automate pour Chiffres Sudoku\n",
     "\n",
     "Creons un automate simple qui accepte uniquement des sequences de 9 chiffres entre 1 et 9."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1216,7 +1230,9 @@
     "```\n",
     "\n",
     "**Point important** : Cet automate verifie uniquement le **format** (9 chiffres valides), pas la contrainte d'unicite. Pour verifier que tous les chiffres sont distincts, nous aurions besoin d'un automate plus complexe avec $9! = 362880$ etats (une pour chaque permutation). C'est ici que les automates symboliques avec Z3 deviennent plus interessants."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1454,7 +1470,9 @@
     "### 4.3 Implementation des Operations Automata\n",
     "\n",
     "Etendons notre classe avec les operations fondamentales :\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1509,7 +1527,9 @@
     "| **Intersection** | $A_{sudoku} = \\bigcap_{k=1}^{27} A_k$ | Conjonction de tous les `Distinct` |\n",
     "\n",
     "**Note** : L'encodage direct en Z3 elimine le besoin de construire explicitement 27 automates. C'est exactement ce que fait Automata.Net en interne via sa classe `CharSetSolver`.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1622,7 +1642,9 @@
     "- La puissance de Z3 pour representer les predicats et verifier la distinctivite\n",
     "\n",
     "**Note importante** : Cette classe n'est pas un \"vrai\" automate symbolique avec des etats explicites. C'est une **compilation** vers Z3 qui capture l'essence de la contrainte de ligne (valeurs distinctes).\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1767,7 +1789,9 @@
    },
    "source": [
     "### 5.4 Tests de l'Automate de Ligne\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -2023,7 +2047,9 @@
     "> - Des etats representant differentes phases du traitement\n",
     "> - Des transitions symboliques entre ces etats\n",
     "> - Z3 est utilise pour verifier si un mot est accepte en satisfaisant les predicats"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -2314,7 +2340,9 @@
     "### 6.2 Exemple de Resolution\n",
     "\n",
     "Utilisons notre automate symbolique pour resoudre un puzzle Sudoku.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -3133,7 +3161,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution trouve en 37,36 ms :\r\n"
+      "Solution trouve en 42,26 ms :\r\n"
      ]
     },
     {
@@ -4047,7 +4075,9 @@
     "1. Le produit d'automates combine toutes les contraintes Sudoku\n",
     "2. Z3 trouve automatiquement une solution satisfaisant toutes les contraintes\n",
     "3. L'approche est declarative : nous specifions les contraintes, pas l'algorithme de recherche"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4109,7 +4139,9 @@
     "| **Apprentissage theorie** | Ce notebook | Lien theory/pratique |\n",
     "| **Verification formelle** | Automata.Net (si fonctionnait) | Operations d'algebre |\n",
     "| **BDD/MDD purs** | Sudoku-13 | Vraie approche automata |\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4183,7 +4215,9 @@
     "3. **Maintenance** : Le code est ancien et non maintenu\n",
     "\n",
     "**Recommandation** : Pour de nouveaux projets, utilisez Z3 directement. Pour l'apprentissage, ce notebook avec implementation personnalisee est suffisant.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4253,7 +4287,9 @@
     "| 13 | **BDD/MDD** | **Automates purs** | **~100ms** | **~1s** | ⭐⭐⭐ |\n",
     "\n",
     "L'approche par automates symboliques offre une intuition pedagogique forte, mais la compilation vers Z3 est le compromis pratique adopte par Automata.Net lui-même.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4288,7 +4324,9 @@
     "### Exercice 4 : Comptage de Solutions\n",
     "\n",
     "Modifier le solveur pour compter le nombre total de solutions d'un puzzle donne, en parcourant toutes les feuilles acceptantes de l'automate produit. Comparer avec la methode de force brute."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4334,7 +4372,9 @@
     "\n",
     "La diagonale principale contient les cellules (0,0), (1,1), ..., (8,8).\n",
     "L'anti-diagonale contient les cellules (0,8), (1,7), ..., (8,0)."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -4395,7 +4435,9 @@
     "---\n",
     "\n",
     "**Retour au sommaire** : [Index Sudoku](README.md)\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -4461,6 +4503,13 @@
      "output_type": "display_data"
     },
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SudokuGrid defini.\r\n"
+     ]
+    },
+    {
      "data": {
       "text/markdown": [
        "### Interpretation : Structure de donnees pour la grille Sudoku\n",
@@ -4497,6 +4546,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ISudokuSolver defini.\r\n"
+     ]
     },
     {
      "data": {
@@ -4538,6 +4594,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SudokuHelper defini.\r\n"
+     ]
     },
     {
      "data": {
@@ -4592,12 +4655,41 @@
      "text": [
       "Exercice a completer\r\n"
      ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "## Resume et perspectives\n",
+       "\n",
+       "Ce notebook a pose les fondations de toute la serie Sudoku en definissant trois composants essentiels. La classe `SudokuGrid` encapsule la representation d'une grille 9x9 avec le pre-calcul des voisins (`AllNeighbours`, `CellNeighbours`), ce qui evite les recalculs couteux lors de la resolution. L'interface `ISudokuSolver` implante le pattern Strategie, permettant de permuter les algorithmes de resolution sans modifier le code client. Enfin, la classe `SudokuHelper` fournit une infrastructure de benchmark complete avec chargement de puzzles, mesures de performance et visualisation Plotly.NET.\n",
+       "\n",
+       "L'infrastructure de test (`TestSolvers`, `DisplayResults`) permet de comparer objectivement les solveurs sur trois niveaux de difficulte (Easy, Medium, Hard) avec gestion des timeouts et des disqualifications. Ce cadre de benchmark sera utilise dans tous les notebooks suivants pour mesurer les performances de chaque algorithme.\n",
+       "\n",
+       "Le notebook suivant, [Sudoku-1-Backtracking](Sudoku-1-Backtracking-Csharp.ipynb), utilise ces classes pour implementer le premier algorithme de resolution : le backtracking recursif avec ses heuristiques d'amelioration."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
     "// Charger les types de base depuis le notebook d'environnement\n",
     "#!import Sudoku-0-Environment-Csharp.ipynb\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93879e44",
+   "metadata": {},
+   "source": [
+    "## Exercice : Solveur Sudoku X avec contraintes de diagonale",
+    "",
+    "Implementez un solveur **Sudoku X** (diagonal Sudoku) en completant la classe",
+    " qui utilise les automates symboliques et Z3 pour",
+    "ajouter les contraintes des deux diagonales principales."
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -60,7 +60,9 @@
     "| **Forward Checking** | Propagation 1-niveau | $O(n \\cdot d^2)$ | Moderee |\n",
     "| **AC-3** | Arc-consistance | $O(e \\cdot d^3)$ | Forte |\n",
     "| **MAC** | AC-3 + Backtracking | Variable | Tres forte |"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -118,7 +120,9 @@
    },
    "source": [
     "Configuration du chemin vers les fichiers de puzzles."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -179,7 +183,9 @@
    },
    "source": [
     "## 1. Classe SudokuGrid"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -342,7 +348,9 @@
     "4. L'affichage formate avec `__str__()` separre visuellement les blocs 3x3\n",
     "\n",
     "> **Note technique** : La representation sous forme de liste de listes est optimale pour le Sudoku car elle permet un acces direct en O(1) a n'importe quelle cellule et facilite le parcours des lignes, colonnes et blocs."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -361,7 +369,9 @@
     "## 2. Classe CSP Generique\n",
     "\n",
     "Nous definissons une classe CSP generique inspiree du livre AIMA. Cette classe represente un **CSP binaire** (contraintes entre paires de variables)."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -388,7 +398,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classe CSP definie.\n"
+      "Classe CSP definie."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -458,7 +475,9 @@
     "- **81 variables** : une par cellule (0,0) a (8,8)\n",
     "- **Domaines** : {1..9} pour les cellules vides, {v} pour les cellules fixees\n",
     "- **Contraintes** : AllDifferent representee comme paires binaires !="
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -565,7 +584,9 @@
    },
    "source": [
     "## 4. Backtracking Simple"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -649,7 +670,9 @@
     "\n",
     "### LCV (Least Constraining Value)\n",
     "Heuristique d'**ordonnancement des valeurs** : essayer d'abord la valeur qui elimine le moins de possibilites chez les voisins."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -742,7 +765,9 @@
    },
    "source": [
     "## 6. Backtracking Ameliore (MRV + LCV)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -831,7 +856,9 @@
     "## 7. Forward Checking\n",
     "\n",
     "Le **Forward Checking** propage l'assignation d'une variable vers ses voisins immediats, reduisant leurs domaines et detectant les echecs plus tot."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -952,7 +979,9 @@
     "## 8. Arc Consistency (AC-3)\n",
     "\n",
     "L'algorithme **AC-3** assure que pour chaque arc (Xi, Xj), toute valeur de Xi a un support dans Xj."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -979,7 +1008,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AC3 defini.\n"
+      "AC3 defini."
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -1060,7 +1096,9 @@
     "## 9. MAC (Maintaining Arc Consistency)\n",
     "\n",
     "L'algorithme **MAC** combine le backtracking avec AC-3 : apres chaque assignation, on maintient la consistance d'arc sur tout le CSP."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1155,7 +1193,9 @@
    },
    "source": [
     "## 10. Test et Benchmark"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1193,9 +1233,15 @@
       "---------------------\n",
       "2 4 . | 5 3 . | 6 . . \n",
       "7 . 5 | 2 . . | 3 . 4 \n",
-      ". 8 . | . 4 1 | 9 5 . \n",
+      ". 8 . | . 4 1 | 9 5 . \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
-      "Solution (MAC): 45.9ms, 81 assignations, 0 backtracks\n",
+      "Solution (MAC): 266.8ms, 81 assignations, 0 backtracks\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
       "1 7 4 | 9 6 3 | 8 2 5 \n",
       "5 3 8 | 4 2 7 | 1 6 9 \n",
@@ -1256,7 +1302,9 @@
     "1. Utilise MRV pour choisir la cellule la plus contrainte\n",
     "2. Utilise LCV pour essayer les valeurs les moins contraignantes\n",
     "3. Maintient la consistance d'arc apres chaque assignation"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1294,10 +1342,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING SIMPLE          2889322       499461         9680 2/2\n",
-      "BACKTRACKING MRV LCV             255            0           85 2/2\n",
-      "FORWARD CHECKING                  81            0           50 2/2\n",
-      "MAC                               81            0           94 2/2\n",
+      "BACKTRACKING SIMPLE          2889322       499461        35609 2/2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BACKTRACKING MRV LCV             255            0          481 2/2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FORWARD CHECKING                  81            0          240 2/2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAC                               81            0          479 2/2\n",
       "================================================================================\n"
      ]
     }
@@ -1402,7 +1468,9 @@
     "1. **MRV** est l'heuristique la plus impactante (reduction souvent > 10x)\n",
     "2. **FC** ajoute un gain significatif en detectant les echecs plus tot\n",
     "3. **MAC** est optimal mais plus couteux par noeud (AC-3 a chaque pas)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1438,7 +1506,9 @@
     "Sur les puzzles faciles, CBJ avec MRV fonctionne bien (peu d'assignations). Mais sur les puzzles **difficiles**, CBJ sans propagation de contraintes (Forward Checking, AC-3) ne resout pas les grilles : peu d'assignations mais 0 succes. Cela illustre que **le backjumping seul ne suffit pas** -- il faut le combiner avec des heuristiques de selection de variable ET de propagation de contraintes.\n",
     "\n",
     "**Lecon** : ne jugez pas un algorithme seulement sur des instances faciles. Un algorithme qui semble efficace sur des problemes simples peut echouer sur des instances plus difficiles ou la propagation de contraintes est determinante.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1465,7 +1535,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CBJ (easy): 23ms, 81 assigns, 0 backtracks, valide=True\n",
+      "CBJ (easy): 31ms, 81 assigns, 0 backtracks, valide=True\n",
       "ConflictBackjumping implemente.\n"
      ]
     }
@@ -1584,6 +1654,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6808e557",
+   "metadata": {},
+   "source": [
+    "### Comparaison CBJ avec les autres strategies",
+    "",
+    "L'implementation suivante definit une enumeration des strategies CSP et une fonction",
+    "de comparaison qui execute chaque approche sur le meme graphe de conflits,",
+    "permettant de mesurer objectivement le gain apporte par le Conflict-Based Backjumping."
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "85ba2c40",
@@ -1611,22 +1695,22 @@
       "=== Benchmark CBJ vs heuristiques sur 3 puzzles faciles ===\n",
       "================================================================================\n",
       "Strategie                    Assigns   Backtracks    Temps(ms)     Succes\n",
-      "--------------------------------------------------------------------------------\n",
-      "BACKTRACKING MRV LCV             366           10          159 3/3\n"
+      "--------------------------------------------------------------------------------\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CONFLICT BACK JUMPING             82            1          107 3/3\n"
+      "BACKTRACKING MRV LCV             366           10          737 3/3\n",
+      "CONFLICT BACK JUMPING             82            1          209 3/3\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FORWARD CHECKING                  91           10           91 3/3\n",
+      "FORWARD CHECKING                  91           10          283 3/3\n",
       "================================================================================\n"
      ]
     }
@@ -1734,7 +1818,9 @@
     "- Utilisez la classe `CSP` existante avec `constraint_func = lambda v1, val1, v2, val2: val1 != val2`\n",
     "- La methode `generate_random_graph(n, edge_prob)` genere un graphe aleatoire (modele Erdos-Renyi)\n",
     "- Un graphe avec `edge_prob=0.3` et 15 sommets est un bon point de depart pour 3 couleurs"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1845,7 +1931,9 @@
    "cell_type": "markdown",
    "id": "888465da",
    "source": "## Resume et perspectives\n\nCe notebook a formalise le Sudoku comme un probleme de satisfaction de contraintes (CSP) binaire selon le cadre academique AIMA (Russell & Norvig, Chapitre 6), avec 81 variables, des domaines a 9 valeurs et 27 contraintes AllDifferent decomposees en paires. Quatre algorithmes de resolution ont ete implementes et compares : le backtracking simple (2,9 millions d'assignations), le backtracking ameliore avec MRV et LCV (255 assignations), le Forward Checking (81 assignations) et le MAC (81 assignations, 0 backtrack). L'ecart de quatre ordres de grandeur entre le backtracking naif et les methodes avec propagation illustre l'importance cruciale de la reduction des domaines.\n\nL'etude du Conflict-Based Backjumping (CBJ) a fourni un exemple cautionnaire instructif : bien que theoriquement superieur au backtracking chronologique, CBJ sans propagation de contraintes ne surpasse pas Forward Checking ou MAC sur les puzzles difficiles. Cette observation rappelle que le choix d'un algorithme ne se juge pas sur les instances faciles seul. L'exercice sur le coloriage de graphe permet de transferer ces competences vers un autre CSP classique avec des topologies variees.\n\nLe notebook suivant, [Sudoku-8-HumanStrategies-Python](Sudoku-8-HumanStrategies-Python.ipynb), explore les strategies de resolution humaines (naked singles, hidden singles) qui s'inspirent des techniques de propagation avancees etudiees ici.",
-   "metadata": {}
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1895,7 +1983,9 @@
     "---\n",
     "\n",
     "**Navigation** : [<< Sudoku-5-PSO](Sudoku-5-PSO-Python.ipynb) | [Index](README.md) | [Sudoku-8-HumanStrategies >>](Sudoku-8-HumanStrategies-Python.ipynb)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Add pedagogical markdown transition cells between consecutive code pairs in 2 Sudoku notebooks.

## Changes
| Notebook | Pair location | Transition added |
|----------|--------------|------------------|
| Sudoku-6-AIMA-CSP-Python | cells 29->30 (CBJ class -> CBJ comparison) | ### Comparaison CBJ avec les autres strategies |
| Sudoku-13-SymbolicAutomata-Csharp | cells 32->33 (#!import -> exercise) | ## Exercice : Solveur Sudoku X avec contraintes de diagonale |

## Execution proof
- **Sudoku-6**: Papermill 36/36 cells, 0 errors, 16/16 code cells exec_count OK (kernel=python3, 45s)
- **Sudoku-13**: Papermill 35/35 cells, 0 errors, 12/12 code cells exec_count OK (kernel=.net-csharp, 10s)
- Both notebooks: consecutive code pairs 1->0

## Remaining consecutive code pairs in partition
- App-19 (4 pairs): covered by PR #2085 + #2108
- Sudoku-17 (1 pair): covered by PR #2102
- **After all merges: partition = 0 consecutive code pairs**

Co-Authored-By: GLM-5.1 <noreply@anthropic.com>