### PR TITLE
Emile jouannet/sc 12 foundry testing

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -75,10 +75,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:57.837434Z",
-     "iopub.status.busy": "2026-05-26T19:21:57.837191Z",
-     "iopub.status.idle": "2026-05-26T19:21:57.849289Z",
-     "shell.execute_reply": "2026-05-26T19:21:57.847939Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.647947Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.647780Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.652159Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.651791Z"
     },
     "papermill": {
      "duration": 0.018215,
@@ -160,10 +160,10 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:57.867742Z",
-     "iopub.status.busy": "2026-05-26T19:21:57.867496Z",
-     "iopub.status.idle": "2026-05-26T19:21:57.935127Z",
-     "shell.execute_reply": "2026-05-26T19:21:57.934695Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.653960Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.653760Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.675303Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.674944Z"
     },
     "papermill": {
      "duration": 0.072984,
@@ -181,23 +181,11 @@
      "text": [
       "Verification des outils Foundry:\n",
       "--------------------------------------------------\n",
-      "  forge: OK\n",
-      "    forge Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
-      "  cast: OK\n",
-      "    cast Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
-      "  anvil: OK\n",
-      "    anvil Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
+      "  forge: MANQUANT\n",
+      "  cast: MANQUANT\n",
+      "  anvil: MANQUANT\n",
       "--------------------------------------------------\n",
-      "Tous les outils sont installes !\n"
+      "Installez Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup\n"
      ]
     }
    ],
@@ -249,7 +237,7 @@
    "source": [
     "### Interpretation : Verification de l'environnement Foundry\n",
     "\n",
-    "**Resultat obtenu** : les trois outils `forge`, `cast` et `anvil` sont detectes avec leur version 1.5.1-stable.\n",
+    "**Resultat obtenu** : la cellule precedente verifie localement la presence de `forge`, `cast` et `anvil`. Si un outil apparait `MANQUANT`, installer Foundry puis relancer la cellule.\n",
     "\n",
     "| Outil | Role dans le workflow | Verification |\n",
     "|-------|----------------------|-------------|\n",
@@ -258,7 +246,7 @@
     "| **anvil** | Noeud local de test | `anvil --version` |\n",
     "\n",
     "**Points cles** :\n",
-    "- Les trois outils partagent la meme version (build unique Rust) ; une incoherence de version signalerait une installation corrompue\n",
+    "- Quand Foundry est installe, les trois outils partagent normalement la meme version (build unique Rust) ; une incoherence de version signalerait une installation corrompue\n",
     "- Si un outil est MANQUANT, relancer `foundryup` re-installe les trois\n",
     "- `chisel` (REPL Solidity) est optionnel et non verifie ici"
    ]
@@ -290,10 +278,10 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:57.961647Z",
-     "iopub.status.busy": "2026-05-26T19:21:57.961407Z",
-     "iopub.status.idle": "2026-05-26T19:21:57.964970Z",
-     "shell.execute_reply": "2026-05-26T19:21:57.964453Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.677172Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.677011Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.679556Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.679267Z"
     },
     "papermill": {
      "duration": 0.009032,
@@ -379,10 +367,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:57.983353Z",
-     "iopub.status.busy": "2026-05-26T19:21:57.983144Z",
-     "iopub.status.idle": "2026-05-26T19:21:57.986437Z",
-     "shell.execute_reply": "2026-05-26T19:21:57.985921Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.681135Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.680932Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.683244Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.682924Z"
     },
     "papermill": {
      "duration": 0.008593,
@@ -501,10 +489,10 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.011543Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.011174Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.015920Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.015421Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.684738Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.684607Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.686833Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.686533Z"
     },
     "papermill": {
      "duration": 0.010691,
@@ -594,10 +582,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.033537Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.033205Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.037337Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.036662Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.688395Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.688244Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.690745Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.690447Z"
     },
     "papermill": {
      "duration": 0.009672,
@@ -719,10 +707,10 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.056707Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.056286Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.060061Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.059377Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.692255Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.692122Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.694263Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.693995Z"
     },
     "papermill": {
      "duration": 0.009958,
@@ -810,10 +798,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.081879Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.081479Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.108048Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.107491Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.695863Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.695720Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.702227Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.701862Z"
     },
     "papermill": {
      "duration": 0.034753,
@@ -829,16 +817,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "forge disponible: forge Version: 1.7.1\n",
-      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
-      "Build Timestamp: 2026-05-08T07:54:39.315067700Z (1778226879)\n",
-      "Build Profile: dist\n",
+      "forge non installe - sortie attendue :\n",
       "\n",
-      "Pour executer les tests :\n",
-      "  mkdir test-project && cd test-project\n",
-      "  forge init\n",
-      "  # Copiez les contrats ci-dessus dans src/ et test/\n",
-      "  forge test -vvv\n"
+      "  [PASS] test_Decrement() (gas: ~28000)\n",
+      "  [PASS] test_InitialState() (gas: ~5000)\n",
+      "  [PASS] test_Increment() (gas: ~23000)\n",
+      "  [PASS] test_SetNumber() (gas: ~24000)\n",
+      "  Test result: ok. 4 passed; 0 failed\n"
      ]
     }
    ],
@@ -929,10 +914,10 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.139143Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.138665Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.143644Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.142731Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.703978Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.703827Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.706489Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.706156Z"
     },
     "papermill": {
      "duration": 0.012188,
@@ -1008,10 +993,10 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.167914Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.167356Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.171798Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.171043Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.708049Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.707912Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.710411Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.710125Z"
     },
     "papermill": {
      "duration": 0.010926,
@@ -1167,10 +1152,10 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.203797Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.203440Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.207316Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.206582Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.712029Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.711884Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.714277Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.713991Z"
     },
     "papermill": {
      "duration": 0.01069,
@@ -1304,10 +1289,10 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.238702Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.238033Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.242228Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.241712Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.715842Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.715710Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.718030Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.717760Z"
     },
     "papermill": {
      "duration": 0.010267,
@@ -1471,10 +1456,10 @@
    "id": "cell-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.279046Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.278788Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.282797Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.282284Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.719620Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.719480Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.721826Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.721520Z"
     },
     "papermill": {
      "duration": 0.010647,
@@ -1562,10 +1547,10 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.303643Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.303317Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.307033Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.306532Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.723283Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.723148Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.725510Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.725245Z"
     },
     "papermill": {
      "duration": 0.010591,
@@ -1677,10 +1662,10 @@
    "id": "cell-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.327089Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.326879Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.330436Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.329712Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.726952Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.726823Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.729059Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.728770Z"
     },
     "papermill": {
      "duration": 0.009777,
@@ -1768,10 +1753,10 @@
    "id": "cell-24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.351380Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.351091Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.354806Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.354329Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.730609Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.730471Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.732685Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.732416Z"
     },
     "papermill": {
      "duration": 0.009951,
@@ -1954,10 +1939,10 @@
    "id": "cell-28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.406170Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.405781Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.409491Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.408903Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.734358Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.734228Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.736604Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.736308Z"
     },
     "papermill": {
      "duration": 0.010878,
@@ -2065,10 +2050,10 @@
    "id": "cell-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.431211Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.430977Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.435889Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.435170Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.738160Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.738027Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.740989Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.740648Z"
     },
     "papermill": {
      "duration": 0.011838,
@@ -2099,23 +2084,44 @@
       "\n",
       "    function setUp() public {\n",
       "        vault = new SimpleVault();\n",
-      "        // TODO: Donner des ETH a Alice et Bob avec vm.deal\n",
+      "        vm.deal(alice, 10 ether);\n",
+      "        vm.deal(bob, 5 ether);\n",
       "    }\n",
       "\n",
       "    function test_Deposit() public {\n",
-      "        // TODO: Tester le depot (vm.prank, deposit, assertEq)\n",
+      "        vm.prank(alice);\n",
+      "        vault.deposit{value: 1 ether}();\n",
+      "\n",
+      "        assertEq(vault.balances(alice), 1 ether);\n",
+      "        assertEq(address(vault).balance, 1 ether);\n",
+      "        assertEq(alice.balance, 9 ether);\n",
       "    }\n",
       "\n",
       "    function test_DepositFailsWithZero() public {\n",
-      "        // TODO: Tester que deposer 0 revert (vm.expectRevert)\n",
+      "        vm.prank(alice);\n",
+      "        vm.expectRevert(bytes(\"Must deposit more than 0\"));\n",
+      "        vault.deposit{value: 0}();\n",
       "    }\n",
       "\n",
       "    function test_Withdraw() public {\n",
-      "        // TODO: Deposer puis retirer, verifier les soldes\n",
+      "        vm.prank(alice);\n",
+      "        vault.deposit{value: 2 ether}();\n",
+      "\n",
+      "        vm.prank(alice);\n",
+      "        vault.withdraw(1 ether);\n",
+      "\n",
+      "        assertEq(vault.balances(alice), 1 ether);\n",
+      "        assertEq(address(vault).balance, 1 ether);\n",
+      "        assertEq(alice.balance, 9 ether);\n",
       "    }\n",
       "\n",
       "    function test_WithdrawFailsWithInsufficientBalance() public {\n",
-      "        // TODO: Tester que retirer plus que le solde revert\n",
+      "        vm.prank(bob);\n",
+      "        vault.deposit{value: 1 ether}();\n",
+      "\n",
+      "        vm.prank(bob);\n",
+      "        vm.expectRevert(bytes(\"Insufficient balance\"));\n",
+      "        vault.withdraw(2 ether);\n",
       "    }\n",
       "}\n",
       "\n",
@@ -2145,23 +2151,44 @@
     "\n",
     "    function setUp() public {\n",
     "        vault = new SimpleVault();\n",
-    "        // TODO: Donner des ETH a Alice et Bob avec vm.deal\n",
+    "        vm.deal(alice, 10 ether);\n",
+    "        vm.deal(bob, 5 ether);\n",
     "    }\n",
     "\n",
     "    function test_Deposit() public {\n",
-    "        // TODO: Tester le depot (vm.prank, deposit, assertEq)\n",
+    "        vm.prank(alice);\n",
+    "        vault.deposit{value: 1 ether}();\n",
+    "\n",
+    "        assertEq(vault.balances(alice), 1 ether);\n",
+    "        assertEq(address(vault).balance, 1 ether);\n",
+    "        assertEq(alice.balance, 9 ether);\n",
     "    }\n",
     "\n",
     "    function test_DepositFailsWithZero() public {\n",
-    "        // TODO: Tester que deposer 0 revert (vm.expectRevert)\n",
+    "        vm.prank(alice);\n",
+    "        vm.expectRevert(bytes(\"Must deposit more than 0\"));\n",
+    "        vault.deposit{value: 0}();\n",
     "    }\n",
     "\n",
     "    function test_Withdraw() public {\n",
-    "        // TODO: Deposer puis retirer, verifier les soldes\n",
+    "        vm.prank(alice);\n",
+    "        vault.deposit{value: 2 ether}();\n",
+    "\n",
+    "        vm.prank(alice);\n",
+    "        vault.withdraw(1 ether);\n",
+    "\n",
+    "        assertEq(vault.balances(alice), 1 ether);\n",
+    "        assertEq(address(vault).balance, 1 ether);\n",
+    "        assertEq(alice.balance, 9 ether);\n",
     "    }\n",
     "\n",
     "    function test_WithdrawFailsWithInsufficientBalance() public {\n",
-    "        // TODO: Tester que retirer plus que le solde revert\n",
+    "        vm.prank(bob);\n",
+    "        vault.deposit{value: 1 ether}();\n",
+    "\n",
+    "        vm.prank(bob);\n",
+    "        vm.expectRevert(bytes(\"Insufficient balance\"));\n",
+    "        vault.withdraw(2 ether);\n",
     "    }\n",
     "}\n",
     "\"\"\"\n",
@@ -2200,10 +2227,10 @@
    "id": "cell-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.457783Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.457549Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.462139Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.461531Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.742490Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.742361Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.744839Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.744567Z"
     },
     "papermill": {
      "duration": 0.011322,
@@ -2317,10 +2344,10 @@
    "id": "cell-32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:21:58.482934Z",
-     "iopub.status.busy": "2026-05-26T19:21:58.482702Z",
-     "iopub.status.idle": "2026-05-26T19:21:58.487027Z",
-     "shell.execute_reply": "2026-05-26T19:21:58.486590Z"
+     "iopub.execute_input": "2026-06-01T21:30:52.746413Z",
+     "iopub.status.busy": "2026-06-01T21:30:52.746263Z",
+     "iopub.status.idle": "2026-06-01T21:30:52.749190Z",
+     "shell.execute_reply": "2026-06-01T21:30:52.748897Z"
     },
     "papermill": {
      "duration": 0.010473,
@@ -2350,21 +2377,42 @@
       "\n",
       "    function setUp() public {\n",
       "        timelock = new Timelock();\n",
-      "        // TODO: Donner des ETH a Alice\n",
+      "        vm.deal(alice, 10 ether);\n",
       "    }\n",
       "\n",
       "    function test_Lock() public {\n",
-      "        // TODO: Verrouiller des ETH, verifier lockTime et lockedAmount\n",
+      "        uint256 startTime = block.timestamp;\n",
+      "\n",
+      "        vm.prank(alice);\n",
+      "        timelock.lock{value: 2 ether}();\n",
+      "\n",
+      "        assertEq(timelock.lockedAmount(alice), 2 ether);\n",
+      "        assertEq(timelock.lockTime(alice), startTime + 1 days);\n",
+      "        assertEq(address(timelock).balance, 2 ether);\n",
       "    }\n",
       "\n",
       "    function test_CannotUnlockBeforeTime() public {\n",
-      "        // TODO: Verrouiller puis tenter de debloquer immediatement\n",
-      "        // Doit revert avec \"Still locked\"\n",
+      "        vm.prank(alice);\n",
+      "        timelock.lock{value: 1 ether}();\n",
+      "\n",
+      "        vm.prank(alice);\n",
+      "        vm.expectRevert(bytes(\"Still locked\"));\n",
+      "        timelock.unlock();\n",
       "    }\n",
       "\n",
       "    function test_CanUnlockAfterTime() public {\n",
-      "        // TODO: Verrouiller, avancer le temps avec skip(1 days + 1),\n",
-      "        // puis debloquer et verifier les soldes\n",
+      "        vm.prank(alice);\n",
+      "        timelock.lock{value: 3 ether}();\n",
+      "\n",
+      "        skip(1 days + 1);\n",
+      "\n",
+      "        uint256 balanceBefore = alice.balance;\n",
+      "        vm.prank(alice);\n",
+      "        timelock.unlock();\n",
+      "\n",
+      "        assertEq(timelock.lockedAmount(alice), 0);\n",
+      "        assertEq(address(timelock).balance, 0);\n",
+      "        assertEq(alice.balance, balanceBefore + 3 ether);\n",
       "    }\n",
       "}\n",
       "\n",
@@ -2392,21 +2440,42 @@
     "\n",
     "    function setUp() public {\n",
     "        timelock = new Timelock();\n",
-    "        // TODO: Donner des ETH a Alice\n",
+    "        vm.deal(alice, 10 ether);\n",
     "    }\n",
     "\n",
     "    function test_Lock() public {\n",
-    "        // TODO: Verrouiller des ETH, verifier lockTime et lockedAmount\n",
+    "        uint256 startTime = block.timestamp;\n",
+    "\n",
+    "        vm.prank(alice);\n",
+    "        timelock.lock{value: 2 ether}();\n",
+    "\n",
+    "        assertEq(timelock.lockedAmount(alice), 2 ether);\n",
+    "        assertEq(timelock.lockTime(alice), startTime + 1 days);\n",
+    "        assertEq(address(timelock).balance, 2 ether);\n",
     "    }\n",
     "\n",
     "    function test_CannotUnlockBeforeTime() public {\n",
-    "        // TODO: Verrouiller puis tenter de debloquer immediatement\n",
-    "        // Doit revert avec \"Still locked\"\n",
+    "        vm.prank(alice);\n",
+    "        timelock.lock{value: 1 ether}();\n",
+    "\n",
+    "        vm.prank(alice);\n",
+    "        vm.expectRevert(bytes(\"Still locked\"));\n",
+    "        timelock.unlock();\n",
     "    }\n",
     "\n",
     "    function test_CanUnlockAfterTime() public {\n",
-    "        // TODO: Verrouiller, avancer le temps avec skip(1 days + 1),\n",
-    "        // puis debloquer et verifier les soldes\n",
+    "        vm.prank(alice);\n",
+    "        timelock.lock{value: 3 ether}();\n",
+    "\n",
+    "        skip(1 days + 1);\n",
+    "\n",
+    "        uint256 balanceBefore = alice.balance;\n",
+    "        vm.prank(alice);\n",
+    "        timelock.unlock();\n",
+    "\n",
+    "        assertEq(timelock.lockedAmount(alice), 0);\n",
+    "        assertEq(address(timelock).balance, 0);\n",
+    "        assertEq(alice.balance, balanceBefore + 3 ether);\n",
     "    }\n",
     "}\n",
     "\"\"\"\n",
@@ -2479,8 +2548,16 @@
   {
    "cell_type": "markdown",
    "id": "d774decb",
-   "source": "## Resume et perspectives\n\nCe notebook a couvert les fondamentaux du framework Foundry pour le test de smart contracts en Solidity. Nous avons commence par l'installation et la verification de l'environnement (forge, cast, anvil), puis explore la structure standard d'un projet Foundry avec ses repertoires `src/`, `test/`, `script/` et `lib/`. L'ecriture de tests en Solidite pur via le pattern DSTest a ete demontree a travers le contrat Counter, illustrant les assertions (`assertEq`, `assertTrue`, `assertGt`) et les fonctions de logging (`emit log_named_uint`).\n\nLes cheatcodes `vm` constituent l'apport le plus puissant de Foundry : `vm.prank` et `vm.startPrank` pour simuler des identites, `vm.deal` pour creer des ETH, `vm.warp` et `vm.roll` pour manipuler le temps blockchain, et `vm.expectRevert` pour tester les cas d'erreur. Ces outils permettent de tester des scenarios complexes (controle d'acces, verrouillage temporel, soldes) sans infrastructure lourde.\n\nLe notebook suivant, [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb), approfondit ces techniques en introduisant le fuzz testing -- la generation automatique d'inputs aleatoires pour decouvrir des bugs aux limites, et les tests d'invariants pour verifier que des proprietes fondamentales restent toujours vraies.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a couvert les fondamentaux du framework Foundry pour le test de smart contracts en Solidity. Nous avons commence par l'installation et la verification de l'environnement (forge, cast, anvil), puis explore la structure standard d'un projet Foundry avec ses repertoires `src/`, `test/`, `script/` et `lib/`. L'ecriture de tests en Solidite pur via le pattern DSTest a ete demontree a travers le contrat Counter, illustrant les assertions (`assertEq`, `assertTrue`, `assertGt`) et les fonctions de logging (`emit log_named_uint`).\n",
+    "\n",
+    "Les cheatcodes `vm` constituent l'apport le plus puissant de Foundry : `vm.prank` et `vm.startPrank` pour simuler des identites, `vm.deal` pour creer des ETH, `vm.warp` et `vm.roll` pour manipuler le temps blockchain, et `vm.expectRevert` pour tester les cas d'erreur. Ces outils permettent de tester des scenarios complexes (controle d'acces, verrouillage temporel, soldes) sans infrastructure lourde.\n",
+    "\n",
+    "Le notebook suivant, [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb), approfondit ces techniques en introduisant le fuzz testing -- la generation automatique d'inputs aleatoires pour decouvrir des bugs aux limites, et les tests d'invariants pour verifier que des proprietes fondamentales restent toujours vraies."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2518,7 +2595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -75,10 +75,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.647947Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.647780Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.652159Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.651791Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.524337Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.524156Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.529684Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.529335Z"
     },
     "papermill": {
      "duration": 0.018215,
@@ -160,10 +160,10 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.653960Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.653760Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.675303Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.674944Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.531580Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.531427Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.588397Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.588009Z"
     },
     "papermill": {
      "duration": 0.072984,
@@ -181,11 +181,23 @@
      "text": [
       "Verification des outils Foundry:\n",
       "--------------------------------------------------\n",
-      "  forge: MANQUANT\n",
-      "  cast: MANQUANT\n",
-      "  anvil: MANQUANT\n",
+      "  forge: OK\n",
+      "    forge Version: 1.7.1\n",
+      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
+      "Build Timestamp: 2026-05-08T07:54:31.470926000Z (1778226871)\n",
+      "Build Profile: dist\n",
+      "  cast: OK\n",
+      "    cast Version: 1.7.1\n",
+      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
+      "Build Timestamp: 2026-05-08T07:54:31.470926000Z (1778226871)\n",
+      "Build Profile: dist\n",
+      "  anvil: OK\n",
+      "    anvil Version: 1.7.1\n",
+      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
+      "Build Timestamp: 2026-05-08T07:54:31.470926000Z (1778226871)\n",
+      "Build Profile: dist\n",
       "--------------------------------------------------\n",
-      "Installez Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup\n"
+      "Tous les outils sont installes !\n"
      ]
     }
    ],
@@ -278,10 +290,10 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.677172Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.677011Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.679556Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.679267Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.590344Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.590174Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.592844Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.592514Z"
     },
     "papermill": {
      "duration": 0.009032,
@@ -367,10 +379,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.681135Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.680932Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.683244Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.682924Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.594436Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.594289Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.596658Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.596371Z"
     },
     "papermill": {
      "duration": 0.008593,
@@ -489,10 +501,10 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.684738Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.684607Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.686833Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.686533Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.598272Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.598132Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.600385Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.600108Z"
     },
     "papermill": {
      "duration": 0.010691,
@@ -582,10 +594,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.688395Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.688244Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.690745Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.690447Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.601952Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.601816Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.604289Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.603990Z"
     },
     "papermill": {
      "duration": 0.009672,
@@ -707,10 +719,10 @@
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.692255Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.692122Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.694263Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.693995Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.605828Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.605696Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.607861Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.607566Z"
     },
     "papermill": {
      "duration": 0.009958,
@@ -798,10 +810,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.695863Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.695720Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.702227Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.701862Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.609436Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.609303Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.625740Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.625391Z"
     },
     "papermill": {
      "duration": 0.034753,
@@ -817,13 +829,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "forge non installe - sortie attendue :\n",
+      "forge disponible: forge Version: 1.7.1\n",
+      "Commit SHA: 4072e48705af9d93e3c0f6e29e93b5e9a40caed8\n",
+      "Build Timestamp: 2026-05-08T07:54:31.470926000Z (1778226871)\n",
+      "Build Profile: dist\n",
       "\n",
-      "  [PASS] test_Decrement() (gas: ~28000)\n",
-      "  [PASS] test_InitialState() (gas: ~5000)\n",
-      "  [PASS] test_Increment() (gas: ~23000)\n",
-      "  [PASS] test_SetNumber() (gas: ~24000)\n",
-      "  Test result: ok. 4 passed; 0 failed\n"
+      "Pour executer les tests :\n",
+      "  mkdir test-project && cd test-project\n",
+      "  forge init\n",
+      "  # Copiez les contrats ci-dessus dans src/ et test/\n",
+      "  forge test -vvv\n"
      ]
     }
    ],
@@ -868,7 +883,9 @@
    "source": [
     "### Interpretation : Resultats des tests\n",
     "\n",
-    "**Indicateurs de succes** :\n",
+    "**Note de validation** : si la cellule precedente affiche `forge non installe - sortie attendue`, les lignes `[PASS]` sont un exemple statique fourni par le fallback pedagogique du notebook. Elles ne constituent pas une execution reelle de `forge test`. Pour obtenir une preuve d'execution Foundry, installer Foundry puis relancer la cellule afin qu'elle affiche la version de `forge` et les commandes a executer.\n",
+    "\n",
+    "**Indicateurs de succes lors d'une execution reelle** :\n",
     "\n",
     "| Element | Signification |\n",
     "|---------|---------------|\n",
@@ -914,10 +931,10 @@
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.703978Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.703827Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.706489Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.706156Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.627650Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.627466Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.630185Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.629816Z"
     },
     "papermill": {
      "duration": 0.012188,
@@ -993,10 +1010,10 @@
    "id": "cell-16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.708049Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.707912Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.710411Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.710125Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.631792Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.631649Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.634217Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.633911Z"
     },
     "papermill": {
      "duration": 0.010926,
@@ -1152,10 +1169,10 @@
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.712029Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.711884Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.714277Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.713991Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.635818Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.635677Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.638215Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.637722Z"
     },
     "papermill": {
      "duration": 0.01069,
@@ -1289,10 +1306,10 @@
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.715842Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.715710Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.718030Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.717760Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.639864Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.639721Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.642143Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.641858Z"
     },
     "papermill": {
      "duration": 0.010267,
@@ -1456,10 +1473,10 @@
    "id": "cell-21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.719620Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.719480Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.721826Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.721520Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.643797Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.643657Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.645991Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.645707Z"
     },
     "papermill": {
      "duration": 0.010647,
@@ -1547,10 +1564,10 @@
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.723283Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.723148Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.725510Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.725245Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.647482Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.647347Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.649793Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.649504Z"
     },
     "papermill": {
      "duration": 0.010591,
@@ -1662,10 +1679,10 @@
    "id": "cell-23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.726952Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.726823Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.729059Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.728770Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.651238Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.651105Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.653354Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.653086Z"
     },
     "papermill": {
      "duration": 0.009777,
@@ -1753,10 +1770,10 @@
    "id": "cell-24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.730609Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.730471Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.732685Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.732416Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.654897Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.654761Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.657066Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.656770Z"
     },
     "papermill": {
      "duration": 0.009951,
@@ -1939,10 +1956,10 @@
    "id": "cell-28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.734358Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.734228Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.736604Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.736308Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.658777Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.658643Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.661081Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.660789Z"
     },
     "papermill": {
      "duration": 0.010878,
@@ -2050,10 +2067,10 @@
    "id": "cell-29",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.738160Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.738027Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.740989Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.740648Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.662580Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.662449Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.665442Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.665165Z"
     },
     "papermill": {
      "duration": 0.011838,
@@ -2227,10 +2244,10 @@
    "id": "cell-31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.742490Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.742361Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.744839Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.744567Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.666983Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.666871Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.669279Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.668987Z"
     },
     "papermill": {
      "duration": 0.011322,
@@ -2344,10 +2361,10 @@
    "id": "cell-32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T21:30:52.746413Z",
-     "iopub.status.busy": "2026-06-01T21:30:52.746263Z",
-     "iopub.status.idle": "2026-06-01T21:30:52.749190Z",
-     "shell.execute_reply": "2026-06-01T21:30:52.748897Z"
+     "iopub.execute_input": "2026-06-02T08:12:07.670760Z",
+     "iopub.status.busy": "2026-06-02T08:12:07.670655Z",
+     "iopub.status.idle": "2026-06-02T08:12:07.673582Z",
+     "shell.execute_reply": "2026-06-02T08:12:07.673314Z"
     },
     "papermill": {
      "duration": 0.010473,


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

-
  - TP réalisé par emile.jouannet, groupe individuel.
  - Complète les exercices du notebook SC-12 Foundry Testing
  sur SimpleVault et Timelock.
  - Ajoute et valide des tests Foundry utilisant vm.deal,
  vm.prank, vm.expectRevert et skip, avec exécution réelle
  via forge test

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
