### PR TITLE
fix(links): repair 6 broken navigation links in Search/Planners notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# App-15 : Planification de Calendrier Sportif (CSP)\n",
     "\n",
-    "**Navigation** : [<< App-11 Picross](../Search/App-11-Picross.ipynb) | [Index](../../README.md) | [App-16 Crossword >>](App-16-Crossword-CSP.ipynb)\n",
+    "**Navigation** : [<< App-11 Picross](App-11-Picross.ipynb) | [Index](../../README.md) | [App-16 Crossword >>](App-16-Crossword-CSP.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",

--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
@@ -14,8 +14,8 @@
     "tags": []
    },
    "source": [
-    "**Navigation** : [Index](../../../README.md) | [<< App-10 Python](../Applications/Hybrid/App-10-Portfolio.ipynb)\n\n",
-    "#**Navigation** : [Index](../../../README.md) | [<< App-10 Python](../Applications/Hybrid/App-10-Portfolio.ipynb)\n\n# Installation de GeneticSharp\n"
+    "**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)\n\n",
+    "#**Navigation** : [Index](../../../README.md) | [<< App-10 Python](App-10-Portfolio.ipynb)\n\n# Installation de GeneticSharp\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-1-Introduction.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# Planners-1-Introduction a la Planification Automatique\n",
     "\n",
-    "**Navigation** : [Index](../../README.md) | [<< Setup](../00-Environment/Planners-0-Setup.ipynb) | [PDDL Syntax >>](Planners-2-PDDL-Syntax.ipynb)\n",
+    "**Navigation** : [Index](../../README.md) | [<< Setup](../00-Environment/Planners-0-Setup.ipynb) | [PDDL Syntax >>](Planners-2-PDDL-Basics.ipynb)\n",
     "\n",
     "---\n",
     "\n",
@@ -1247,7 +1247,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Notebook suivant** : [Planners-2-PDDL-Syntax](Planners-2-PDDL-Syntax.ipynb)"
+    "**Notebook suivant** : [Planners-2-PDDL-Syntax](Planners-2-PDDL-Basics.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Repair 6 broken navigation links in Search and Planners notebooks.

### Fixes applied

| # | Notebook | Broken link | Fix | Root cause |
|---|----------|------------|-----|------------|
| 1-2 | `Planners-1-Introduction` | `Planners-2-PDDL-Syntax.ipynb` (x2) | `Planners-2-PDDL-Basics.ipynb` | File renamed |
| 3-4 | `App-10b-Portfolio-CSharp` | `../Applications/Hybrid/App-10-Portfolio.ipynb` (x2) | `App-10-Portfolio.ipynb` | Same directory, over-resolved |
| 5 | `App-15-SportsScheduling` | `../Search/App-11-Picross.ipynb` | `App-11-Picross.ipynb` | Same directory, over-resolved |
| 6 | `GeneticSharp-EdgeDetection` | `../../Sudoku/Sudoku-3-Genetic-Csharp.ipynb` | `../Sudoku/Sudoku-3-Genetic-Csharp.ipynb` | Path depth too deep |

## Validation proof

- **Markdown-only changes**: 4 files, 6 insertions, 6 deletions
- **No code modified**: zero source cells changed
- **Convention C.3**: markdown-only inserts do not require re-execution

## Scope

- 4 files changed: Planners (SymbolicAI), App-10b/App-15/GeneticSharp (Search)
- No exercises modified, no code logic changed
- Complements PR #2131 (Sudoku broken links, 84 links in 17 files)
