### PR TITLE
fix(planners): restore corrupted cell 38 + convention print in Planners-10

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -5,10 +5,10 @@
    "id": "1f5f5ce0",
    "metadata": {
     "papermill": {
-     "duration": 0.003662,
-     "end_time": "2026-05-25T01:06:13.081366+00:00",
+     "duration": 0.008008,
+     "end_time": "2026-06-02T08:52:40.856372",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.077704+00:00",
+     "start_time": "2026-06-02T08:52:40.848364",
      "status": "completed"
     },
     "tags": []
@@ -38,10 +38,10 @@
    "id": "ef5407b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002411,
-     "end_time": "2026-05-25T01:06:13.089468+00:00",
+     "duration": 0.002926,
+     "end_time": "2026-06-02T08:52:40.862967",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.087057+00:00",
+     "start_time": "2026-06-02T08:52:40.860041",
      "status": "completed"
     },
     "tags": []
@@ -68,10 +68,10 @@
    "id": "d0d78572",
    "metadata": {
     "papermill": {
-     "duration": 0.002839,
-     "end_time": "2026-05-25T01:06:13.094746+00:00",
+     "duration": 0.004328,
+     "end_time": "2026-06-02T08:52:40.870451",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.091907+00:00",
+     "start_time": "2026-06-02T08:52:40.866123",
      "status": "completed"
     },
     "tags": []
@@ -86,16 +86,16 @@
    "id": "43659e21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:13.101361Z",
-     "iopub.status.busy": "2026-05-25T01:06:13.101183Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.399954Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.399266Z"
+     "iopub.execute_input": "2026-06-02T08:52:40.879256Z",
+     "iopub.status.busy": "2026-06-02T08:52:40.878852Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.110183Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.109657Z"
     },
     "papermill": {
-     "duration": 1.302757,
-     "end_time": "2026-05-25T01:06:14.400348+00:00",
+     "duration": 1.236565,
+     "end_time": "2026-06-02T08:52:42.110860",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.097591+00:00",
+     "start_time": "2026-06-02T08:52:40.874295",
      "status": "completed"
     },
     "tags": []
@@ -154,10 +154,10 @@
    "id": "qwhoava1aus",
    "metadata": {
     "papermill": {
-     "duration": 0.002828,
-     "end_time": "2026-05-25T01:06:14.406035+00:00",
+     "duration": 0.003192,
+     "end_time": "2026-06-02T08:52:42.117396",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.403207+00:00",
+     "start_time": "2026-06-02T08:52:42.114204",
      "status": "completed"
     },
     "tags": []
@@ -172,16 +172,16 @@
    "id": "35bf6b1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.411842Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.411696Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.416147Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.415672Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.124564Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.124330Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.129349Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.128931Z"
     },
     "papermill": {
-     "duration": 0.008127,
-     "end_time": "2026-05-25T01:06:14.416742+00:00",
+     "duration": 0.009627,
+     "end_time": "2026-06-02T08:52:42.130031",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.408615+00:00",
+     "start_time": "2026-06-02T08:52:42.120404",
      "status": "completed"
     },
     "tags": []
@@ -235,10 +235,10 @@
    "id": "12709dc5",
    "metadata": {
     "papermill": {
-     "duration": 0.002445,
-     "end_time": "2026-05-25T01:06:14.421726+00:00",
+     "duration": 0.002842,
+     "end_time": "2026-06-02T08:52:42.135813",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.419281+00:00",
+     "start_time": "2026-06-02T08:52:42.132971",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "58885d01",
    "metadata": {
     "papermill": {
-     "duration": 0.002713,
-     "end_time": "2026-05-25T01:06:14.427107+00:00",
+     "duration": 0.003056,
+     "end_time": "2026-06-02T08:52:42.142022",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.424394+00:00",
+     "start_time": "2026-06-02T08:52:42.138966",
      "status": "completed"
     },
     "tags": []
@@ -278,21 +278,29 @@
    "id": "99cd77aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.433588Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.433414Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.439877Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.439403Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.148984Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.148771Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.155893Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.155323Z"
     },
     "papermill": {
-     "duration": 0.010602,
-     "end_time": "2026-05-25T01:06:14.440359+00:00",
+     "duration": 0.011659,
+     "end_time": "2026-06-02T08:52:42.156648",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.429757+00:00",
+     "start_time": "2026-06-02T08:52:42.144989",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes definies : PlanningState, Action, generate_plan_direct\n"
+     ]
+    }
+   ],
    "source": [
     "@dataclass\n",
     "class PlanningState:\n",
@@ -368,7 +376,9 @@
     "    except json.JSONDecodeError as e:\n",
     "        print(f\"Erreur parsing JSON: {e}\")\n",
     "    \n",
-    "    return []"
+    "    return []\n",
+    "\n",
+    "print(f\"Classes definies : PlanningState, Action, generate_plan_direct\")"
    ]
   },
   {
@@ -376,10 +386,10 @@
    "id": "erhfybdkgim",
    "metadata": {
     "papermill": {
-     "duration": 0.002489,
-     "end_time": "2026-05-25T01:06:14.445604+00:00",
+     "duration": 0.002976,
+     "end_time": "2026-06-02T08:52:42.162832",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.443115+00:00",
+     "start_time": "2026-06-02T08:52:42.159856",
      "status": "completed"
     },
     "tags": []
@@ -394,16 +404,16 @@
    "id": "0dd0d8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.451896Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.451723Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.455573Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.455048Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.169481Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.169294Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.173835Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.173321Z"
     },
     "papermill": {
-     "duration": 0.007817,
-     "end_time": "2026-05-25T01:06:14.456092+00:00",
+     "duration": 0.008838,
+     "end_time": "2026-06-02T08:52:42.174579",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.448275+00:00",
+     "start_time": "2026-06-02T08:52:42.165741",
      "status": "completed"
     },
     "tags": []
@@ -461,10 +471,10 @@
    "id": "ef0bf497",
    "metadata": {
     "papermill": {
-     "duration": 0.002652,
-     "end_time": "2026-05-25T01:06:14.461624+00:00",
+     "duration": 0.002951,
+     "end_time": "2026-06-02T08:52:42.180770",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.458972+00:00",
+     "start_time": "2026-06-02T08:52:42.177819",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +493,10 @@
    "id": "87819ac5",
    "metadata": {
     "papermill": {
-     "duration": 0.002622,
-     "end_time": "2026-05-25T01:06:14.467016+00:00",
+     "duration": 0.003037,
+     "end_time": "2026-06-02T08:52:42.186765",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.464394+00:00",
+     "start_time": "2026-06-02T08:52:42.183728",
      "status": "completed"
     },
     "tags": []
@@ -503,16 +513,16 @@
    "id": "03a9a0cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.475835Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.475665Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.479629Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.478849Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.194269Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.193980Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.198043Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.197637Z"
     },
     "papermill": {
-     "duration": 0.010657,
-     "end_time": "2026-05-25T01:06:14.480284+00:00",
+     "duration": 0.009046,
+     "end_time": "2026-06-02T08:52:42.198855",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.469627+00:00",
+     "start_time": "2026-06-02T08:52:42.189809",
      "status": "completed"
     },
     "tags": []
@@ -572,10 +582,10 @@
    "id": "akalpwcqg8i",
    "metadata": {
     "papermill": {
-     "duration": 0.0031,
-     "end_time": "2026-05-25T01:06:14.487308+00:00",
+     "duration": 0.003309,
+     "end_time": "2026-06-02T08:52:42.205744",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.484208+00:00",
+     "start_time": "2026-06-02T08:52:42.202435",
      "status": "completed"
     },
     "tags": []
@@ -590,16 +600,16 @@
    "id": "1fc7c73f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.494392Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.494217Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.497624Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.496910Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.213057Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.212746Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.216963Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.216518Z"
     },
     "papermill": {
-     "duration": 0.008032,
-     "end_time": "2026-05-25T01:06:14.498318+00:00",
+     "duration": 0.009178,
+     "end_time": "2026-06-02T08:52:42.218095",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.490286+00:00",
+     "start_time": "2026-06-02T08:52:42.208917",
      "status": "completed"
     },
     "tags": []
@@ -634,10 +644,10 @@
    "id": "e3bf2623",
    "metadata": {
     "papermill": {
-     "duration": 0.002911,
-     "end_time": "2026-05-25T01:06:14.504329+00:00",
+     "duration": 0.003156,
+     "end_time": "2026-06-02T08:52:42.224793",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.501418+00:00",
+     "start_time": "2026-06-02T08:52:42.221637",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +667,10 @@
    "id": "2bcb8964",
    "metadata": {
     "papermill": {
-     "duration": 0.002773,
-     "end_time": "2026-05-25T01:06:14.509906+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-02T08:52:42.231977",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.507133+00:00",
+     "start_time": "2026-06-02T08:52:42.227977",
      "status": "completed"
     },
     "tags": []
@@ -677,16 +687,16 @@
    "id": "b7dbc7df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.515798Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.515667Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.519320Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.518896Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.240740Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.240168Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.245343Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.244774Z"
     },
     "papermill": {
-     "duration": 0.007317,
-     "end_time": "2026-05-25T01:06:14.519778+00:00",
+     "duration": 0.010581,
+     "end_time": "2026-06-02T08:52:42.246193",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.512461+00:00",
+     "start_time": "2026-06-02T08:52:42.235612",
      "status": "completed"
     },
     "tags": []
@@ -746,8 +756,7 @@
     "        return response.content[0].text\n",
     "    \n",
     "    return \";; API non configuree\"\n",
-    "print(\"Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\")\n",
-    ""
+    "print(\"Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\")\n"
    ]
   },
   {
@@ -755,10 +764,10 @@
    "id": "2tbqoup6bpy",
    "metadata": {
     "papermill": {
-     "duration": 0.0025,
-     "end_time": "2026-05-25T01:06:14.524778+00:00",
+     "duration": 0.003928,
+     "end_time": "2026-06-02T08:52:42.254125",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.522278+00:00",
+     "start_time": "2026-06-02T08:52:42.250197",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +782,16 @@
    "id": "3f111a44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.530729Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.530450Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.533795Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.533117Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.262897Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.262608Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.268374Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.267647Z"
     },
     "papermill": {
-     "duration": 0.007003,
-     "end_time": "2026-05-25T01:06:14.534344+00:00",
+     "duration": 0.011492,
+     "end_time": "2026-06-02T08:52:42.269346",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.527341+00:00",
+     "start_time": "2026-06-02T08:52:42.257854",
      "status": "completed"
     },
     "tags": []
@@ -835,10 +844,10 @@
    "id": "0fc6c205",
    "metadata": {
     "papermill": {
-     "duration": 0.002681,
-     "end_time": "2026-05-25T01:06:14.539672+00:00",
+     "duration": 0.003662,
+     "end_time": "2026-06-02T08:52:42.277062",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.536991+00:00",
+     "start_time": "2026-06-02T08:52:42.273400",
      "status": "completed"
     },
     "tags": []
@@ -857,10 +866,10 @@
    "id": "d805d708",
    "metadata": {
     "papermill": {
-     "duration": 0.002803,
-     "end_time": "2026-05-25T01:06:14.545209+00:00",
+     "duration": 0.003431,
+     "end_time": "2026-06-02T08:52:42.284158",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.542406+00:00",
+     "start_time": "2026-06-02T08:52:42.280727",
      "status": "completed"
     },
     "tags": []
@@ -875,16 +884,16 @@
    "id": "a6442f2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.552452Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.552306Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.555967Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.555554Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.291825Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.291589Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.298711Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.295598Z"
     },
     "papermill": {
-     "duration": 0.008127,
-     "end_time": "2026-05-25T01:06:14.556435+00:00",
+     "duration": 0.01316,
+     "end_time": "2026-06-02T08:52:42.300684",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.548308+00:00",
+     "start_time": "2026-06-02T08:52:42.287524",
      "status": "completed"
     },
     "tags": []
@@ -945,10 +954,10 @@
    "id": "b53ae144",
    "metadata": {
     "papermill": {
-     "duration": 0.002533,
-     "end_time": "2026-05-25T01:06:14.561561+00:00",
+     "duration": 0.003751,
+     "end_time": "2026-06-02T08:52:42.308766",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.559028+00:00",
+     "start_time": "2026-06-02T08:52:42.305015",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +983,10 @@
    "id": "a2dd3e4e",
    "metadata": {
     "papermill": {
-     "duration": 0.002778,
-     "end_time": "2026-05-25T01:06:14.567017+00:00",
+     "duration": 0.004088,
+     "end_time": "2026-06-02T08:52:42.316715",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.564239+00:00",
+     "start_time": "2026-06-02T08:52:42.312627",
      "status": "completed"
     },
     "tags": []
@@ -994,16 +1003,16 @@
    "id": "5a76dd94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.573167Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.573029Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.576509Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.575894Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.325913Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.325556Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.330230Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.329657Z"
     },
     "papermill": {
-     "duration": 0.007334,
-     "end_time": "2026-05-25T01:06:14.576953+00:00",
+     "duration": 0.010487,
+     "end_time": "2026-06-02T08:52:42.331097",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.569619+00:00",
+     "start_time": "2026-06-02T08:52:42.320610",
      "status": "completed"
     },
     "tags": []
@@ -1059,10 +1068,10 @@
    "id": "23b37e55",
    "metadata": {
     "papermill": {
-     "duration": 0.002856,
-     "end_time": "2026-05-25T01:06:14.582353+00:00",
+     "duration": 0.003655,
+     "end_time": "2026-06-02T08:52:42.339074",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.579497+00:00",
+     "start_time": "2026-06-02T08:52:42.335419",
      "status": "completed"
     },
     "tags": []
@@ -1079,16 +1088,16 @@
    "id": "25a34715",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.588586Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.588441Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.591762Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.591281Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.346950Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.346742Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.350938Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.350537Z"
     },
     "papermill": {
-     "duration": 0.007069,
-     "end_time": "2026-05-25T01:06:14.592205+00:00",
+     "duration": 0.009,
+     "end_time": "2026-06-02T08:52:42.351597",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.585136+00:00",
+     "start_time": "2026-06-02T08:52:42.342597",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1145,10 @@
    "id": "57m8ot06t6t",
    "metadata": {
     "papermill": {
-     "duration": 0.002807,
-     "end_time": "2026-05-25T01:06:14.597633+00:00",
+     "duration": 0.003181,
+     "end_time": "2026-06-02T08:52:42.358150",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.594826+00:00",
+     "start_time": "2026-06-02T08:52:42.354969",
      "status": "completed"
     },
     "tags": []
@@ -1154,16 +1163,16 @@
    "id": "ceae3028",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.604469Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.604323Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.607466Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.606985Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.365537Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.365218Z",
+     "iopub.status.idle": "2026-06-02T08:52:42.368939Z",
+     "shell.execute_reply": "2026-06-02T08:52:42.368452Z"
     },
     "papermill": {
-     "duration": 0.006969,
-     "end_time": "2026-05-25T01:06:14.607919+00:00",
+     "duration": 0.008337,
+     "end_time": "2026-06-02T08:52:42.369643",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.600950+00:00",
+     "start_time": "2026-06-02T08:52:42.361306",
      "status": "completed"
     },
     "tags": []
@@ -1203,10 +1212,10 @@
    "id": "b4510646",
    "metadata": {
     "papermill": {
-     "duration": 0.002639,
-     "end_time": "2026-05-25T01:06:14.613226+00:00",
+     "duration": 0.003378,
+     "end_time": "2026-06-02T08:52:42.376151",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.610587+00:00",
+     "start_time": "2026-06-02T08:52:42.372773",
      "status": "completed"
     },
     "tags": []
@@ -1229,10 +1238,10 @@
    "id": "0ac5363f",
    "metadata": {
     "papermill": {
-     "duration": 0.002692,
-     "end_time": "2026-05-25T01:06:14.618570+00:00",
+     "duration": 0.003164,
+     "end_time": "2026-06-02T08:52:42.382479",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.615878+00:00",
+     "start_time": "2026-06-02T08:52:42.379315",
      "status": "completed"
     },
     "tags": []
@@ -1247,16 +1256,16 @@
    "id": "f6ea658d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.624565Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.624428Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.089865Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.089187Z"
+     "iopub.execute_input": "2026-06-02T08:52:42.389786Z",
+     "iopub.status.busy": "2026-06-02T08:52:42.389551Z",
+     "iopub.status.idle": "2026-06-02T08:52:46.734782Z",
+     "shell.execute_reply": "2026-06-02T08:52:46.734149Z"
     },
     "papermill": {
-     "duration": 0.469242,
-     "end_time": "2026-05-25T01:06:15.090419+00:00",
+     "duration": 4.350416,
+     "end_time": "2026-06-02T08:52:46.736046",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.621177+00:00",
+     "start_time": "2026-06-02T08:52:42.385630",
      "status": "completed"
     },
     "tags": []
@@ -1296,10 +1305,10 @@
    "id": "426be437",
    "metadata": {
     "papermill": {
-     "duration": 0.003312,
-     "end_time": "2026-05-25T01:06:15.097634+00:00",
+     "duration": 0.01106,
+     "end_time": "2026-06-02T08:52:46.757132",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.094322+00:00",
+     "start_time": "2026-06-02T08:52:46.746072",
      "status": "completed"
     },
     "tags": []
@@ -1328,10 +1337,10 @@
    "id": "bd9ef406",
    "metadata": {
     "papermill": {
-     "duration": 0.003102,
-     "end_time": "2026-05-25T01:06:15.104123+00:00",
+     "duration": 0.00686,
+     "end_time": "2026-06-02T08:52:46.771078",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.101021+00:00",
+     "start_time": "2026-06-02T08:52:46.764218",
      "status": "completed"
     },
     "tags": []
@@ -1356,16 +1365,16 @@
    "id": "3f7e47d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.111239Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.111078Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.113723Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.113234Z"
+     "iopub.execute_input": "2026-06-02T08:52:46.786227Z",
+     "iopub.status.busy": "2026-06-02T08:52:46.786041Z",
+     "iopub.status.idle": "2026-06-02T08:52:46.790331Z",
+     "shell.execute_reply": "2026-06-02T08:52:46.789525Z"
     },
     "papermill": {
-     "duration": 0.007167,
-     "end_time": "2026-05-25T01:06:15.114510+00:00",
+     "duration": 0.012254,
+     "end_time": "2026-06-02T08:52:46.791229",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.107343+00:00",
+     "start_time": "2026-06-02T08:52:46.778975",
      "status": "completed"
     },
     "tags": []
@@ -1411,10 +1420,10 @@
    "id": "y1zezpybwo9",
    "metadata": {
     "papermill": {
-     "duration": 0.002757,
-     "end_time": "2026-05-25T01:06:15.120218+00:00",
+     "duration": 0.004125,
+     "end_time": "2026-06-02T08:52:46.799924",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.117461+00:00",
+     "start_time": "2026-06-02T08:52:46.795799",
      "status": "completed"
     },
     "tags": []
@@ -1432,23 +1441,268 @@
    "id": "c0k81u0utji",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.126661Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.126483Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.130249Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.129779Z"
+     "iopub.execute_input": "2026-06-02T08:52:46.807221Z",
+     "iopub.status.busy": "2026-06-02T08:52:46.807044Z",
+     "iopub.status.idle": "2026-06-02T08:52:46.817688Z",
+     "shell.execute_reply": "2026-06-02T08:52:46.817111Z"
     },
     "papermill": {
-     "duration": 0.007725,
-     "end_time": "2026-05-25T01:06:15.130735+00:00",
+     "duration": 0.015575,
+     "end_time": "2026-06-02T08:52:46.818434",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.123010+00:00",
+     "start_time": "2026-06-02T08:52:46.802859",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt NL défini.\n",
+      "\n",
+      "Tu es un planificateur robotique expert.\n",
+      "\n",
+      "## Domaine : robot-simple\n",
+      "Un robot peut se déplacer entre des emplacements, ramasser des objets et les déposer.\n",
+      "Actions disponibles :\n",
+      "  - move(robot, from, to)  : déplace le robot de `from` vers `to`\n",
+      "      PRECONDITION : robot se trouve en `from`\n",
+      "      EFFE ...\n",
+      "⚠ Aucune API configurée — utilisation du plan exemple.\n",
+      "\n",
+      "Plan brut retourné par le LLM :\n",
+      "  move(robot, A, B)\n",
+      "  pick(robot, obj1, B)\n",
+      "  move(robot, B, A)\n",
+      "  drop(robot, obj1, A)\n",
+      "\n",
+      "Séquence PDDL :\n",
+      "  1. (move robot A B)\n",
+      "  2. (pick robot obj1 B)\n",
+      "  3. (move robot B A)\n",
+      "  4. (drop robot obj1 A)\n",
+      "\n",
+      "============================================================\n",
+      "VALIDATION DU PLAN\n",
+      "============================================================\n",
+      "État initial : ['at(robot,A)', 'at_obj(obj1,B)', 'free(robot)']\n",
+      "But          : ['at_obj(obj1,A)']\n",
+      "------------------------------------------------------------\n",
+      "Étape 1 : ✓ move(robot, A, B)\n",
+      "          → État : ['at(robot,B)', 'at_obj(obj1,B)', 'free(robot)']\n",
+      "Étape 2 : ✓ pick(robot, obj1, B)\n",
+      "          → État : ['at(robot,B)', 'has(robot,obj1)']\n",
+      "Étape 3 : ✓ move(robot, B, A)\n",
+      "          → État : ['at(robot,A)', 'has(robot,obj1)']\n",
+      "Étape 4 : ✓ drop(robot, obj1, A)\n",
+      "          → État : ['at(robot,A)', 'at_obj(obj1,A)', 'free(robot)']\n",
+      "------------------------------------------------------------\n",
+      "But atteint  : ✓ OUI\n",
+      "Plan VALIDE et COMPLET ✓\n",
+      "============================================================\n"
+     ]
+    }
+   ],
    "source": [
-    "# Exemple guide : Solution completeimport json, reDOMAIN = {    \"actions\": {        \"move\": {\"params\": [\"robot\", \"from\", \"to\"],                  \"pre\": [\"at(robot,from)\"],                  \"eff_pos\": [\"at(robot,to)\"], \"eff_neg\": [\"at(robot,from)\"]},        \"pick\": {\"params\": [\"robot\", \"obj\", \"loc\"],                  \"pre\": [\"at(robot,loc)\", \"at_obj(obj,loc)\", \"free(robot)\"],                 \"eff_pos\": [\"has(robot,obj)\"], \"eff_neg\": [\"at_obj(obj,loc)\", \"free(robot)\"]},        \"drop\": {\"params\": [\"robot\", \"obj\", \"loc\"],                 \"pre\": [\"at(robot,loc)\", \"has(robot,obj)\"],                 \"eff_pos\": [\"at_obj(obj,loc)\", \"free(robot)\"], \"eff_neg\": [\"has(robot,obj)\"]},    }}INITIAL_STATE = {\"at(robot,A)\", \"free(robot)\", \"at_obj(obj1,B)\"}GOAL_STATE    = {\"at_obj(obj1,A)\"}prompt_nl = \"\"\"Tu es un planificateur robotique expert.## Domaine : robot-simpleUn robot peut se déplacer entre des emplacements, ramasser des objets et les déposer.Actions disponibles :  - move(robot, from, to)  : déplace le robot de `from` vers `to`      PRECONDITION : robot se trouve en `from`      EFFET        : robot se trouve en `to`, n'est plus en `from`  - pick(robot, obj, loc)  : robot prend l'objet `obj` à l'emplacement `loc`      PRECONDITION : robot en `loc`, objet en `loc`, robot libre (free)      EFFET        : robot tient l'objet, objet n'est plus en `loc`, robot n'est plus libre  - drop(robot, obj, loc)  : robot pose l'objet `obj` à l'emplacement `loc`      PRECONDITION : robot en `loc`, robot tient `obj`      EFFET        : objet posé en `loc`, robot redevient libre, robot ne tient plus l'objet## État initial- robot se trouve en A- robot est libre (ne tient rien)- objet1 se trouve en B## But- objet1 doit se trouver en A## Instructions1. Raisonne étape par étape (quels faits changent à chaque action ?).2. Fournis le plan UNIQUEMENT sous forme JSON stricte, sans texte autour :[  {\"action\": \"move\",  \"params\": [\"robot\", \"A\", \"B\"]},  {\"action\": \"pick\",  \"params\": [\"robot\", \"obj1\", \"B\"]},  {\"action\": \"move\",  \"params\": [\"robot\", \"B\", \"A\"]},  {\"action\": \"drop\",  \"params\": [\"robot\", \"obj1\", \"A\"]}]Réponds avec le JSON seulement, encadré par des triples backticks json.\"\"\"print(\"Prompt NL défini.\")print(prompt_nl[:300], \"...\")def call_llm_for_plan(prompt: str) -> list:    \"\"\"Appelle le LLM et retourne la liste des actions parsées.\"\"\"    raw = None    if anthropic_client:        response = anthropic_client.messages.create(            model=config.model_anthropic,            max_tokens=config.max_tokens,            messages=[{\"role\": \"user\", \"content\": prompt}]        )        raw = response.content[0].text    elif openai_client:        response = openai_client.chat.completions.create(            model=config.model_openai,            max_tokens=config.max_tokens,            messages=[{\"role\": \"user\", \"content\": prompt}],            extra_body={\"chat_template_kwargs\": {\"enable_thinking\": False}}        )        raw = response.choices[0].message.content    else:        print(\"⚠ Aucune API configurée — utilisation du plan exemple.\")        return [            {\"action\": \"move\",  \"params\": [\"robot\", \"A\", \"B\"]},            {\"action\": \"pick\",  \"params\": [\"robot\", \"obj1\", \"B\"]},            {\"action\": \"move\",  \"params\": [\"robot\", \"B\", \"A\"]},            {\"action\": \"drop\",  \"params\": [\"robot\", \"obj1\", \"A\"]},        ]    print(\"Réponse brute LLM :\\n\", raw[:500])    # Extraire le JSON (entre ```json ... ``` ou premier [ ... ])    m = re.search(r\"```(?:json)?\\s*([\\s\\S]*?)```\", raw)    if m:        json_str = m.group(1)    else:        start = raw.find(\"[\")        end   = raw.rfind(\"]\") + 1        json_str = raw[start:end] if start != -1 else \"[]\"    try:        return json.loads(json_str)    except json.JSONDecodeError as e:        print(f\"Erreur parsing JSON : {e}\")        return []llm_plan_raw = call_llm_for_plan(prompt_nl)print(\"\\nPlan brut retourné par le LLM :\")for step in llm_plan_raw:    print(f\"  {step['action']}({', '.join(step['params'])})\")def to_pddl_action(step: dict) -> str:    \"\"\"Formate une action dict en chaîne PDDL.\"\"\"    return f\"({step['action']} {' '.join(step['params'])})\"pddl_sequence = [to_pddl_action(s) for s in llm_plan_raw]print(\"\\nSéquence PDDL :\")for i, a in enumerate(pddl_sequence, 1):    print(f\"  {i}. {a}\")def substitute(template: str, params: list, param_names: list) -> str:    \"\"\"Remplace les noms de paramètres formels par les valeurs concrètes.        Utilise une regex avec lookbehind/lookahead sur les délimiteurs PDDL    ( '(' ',' ')' ) pour éviter les remplacements partiels de sous-chaînes.    Exemple sans fix : 'at_obj(obj,loc)' avec obj->obj1 donnait 'at_obj1(obj1,loc)'.    \"\"\"    result = template    for name, val in zip(param_names, params):        result = re.sub(r'(?<=[,(])' + re.escape(name) + r'(?=[,)])', val, result)    return resultdef apply_action(state: set, action_name: str, params: list) -> tuple:    \"\"\"    Applique une action à un état.    Retourne (nouvel_état, ok, message_erreur).    \"\"\"    if action_name not in DOMAIN[\"actions\"]:        return state, False, f\"Action inconnue : {action_name}\"    spec        = DOMAIN[\"actions\"][action_name]    param_names = spec[\"params\"]    # Vérifier les préconditions    for pre_template in spec[\"pre\"]:        pre_grounded = substitute(pre_template, params, param_names)        if pre_grounded not in state:            return state, False, f\"Précondition non satisfaite : {pre_grounded}\"    # Appliquer les effets    new_state = set(state)    for neg in spec[\"eff_neg\"]:        new_state.discard(substitute(neg, params, param_names))    for pos in spec[\"eff_pos\"]:        new_state.add(substitute(pos, params, param_names))    return new_state, True, \"OK\"def validate_plan(plan: list, initial: set, goal: set) -> bool:    \"\"\"Valide le plan étape par étape et affiche le détail.\"\"\"    state = set(initial)    print(\"\\n\" + \"=\"*60)    print(\"VALIDATION DU PLAN\")    print(\"=\"*60)    print(f\"État initial : {sorted(state)}\")    print(f\"But          : {sorted(goal)}\")    print(\"-\"*60)    all_ok = True    for i, step in enumerate(plan, 1):        action = step[\"action\"]        params = step[\"params\"]        state, ok, msg = apply_action(state, action, params)        status = \"✓\" if ok else \"✗\"        print(f\"Étape {i} : {status} {action}({', '.join(params)})\")        if not ok:            print(f\"          → ERREUR : {msg}\")            all_ok = False        else:            print(f\"          → État : {sorted(state)}\")    print(\"-\"*60)    goal_reached = goal.issubset(state)    print(f\"But atteint  : {'✓ OUI' if goal_reached else '✗ NON'}\")    if not all_ok:        print(\"Plan INVALIDE (préconditions non respectées).\")    elif goal_reached:        print(\"Plan VALIDE et COMPLET ✓\")    else:        print(\"Plan valide mais but non atteint.\")    print(\"=\"*60)    return all_ok and goal_reachedsuccess = validate_plan(llm_plan_raw, INITIAL_STATE, GOAL_STATE)"
+    "import json, re\n",
+    "\n",
+    "DOMAIN = {\n",
+    "    \"actions\": {\n",
+    "        \"move\": {\"params\": [\"robot\", \"from\", \"to\"], \n",
+    "                 \"pre\": [\"at(robot,from)\"], \n",
+    "                 \"eff_pos\": [\"at(robot,to)\"], \"eff_neg\": [\"at(robot,from)\"]},\n",
+    "        \"pick\": {\"params\": [\"robot\", \"obj\", \"loc\"], \n",
+    "                 \"pre\": [\"at(robot,loc)\", \"at_obj(obj,loc)\", \"free(robot)\"],\n",
+    "                 \"eff_pos\": [\"has(robot,obj)\"], \"eff_neg\": [\"at_obj(obj,loc)\", \"free(robot)\"]},\n",
+    "        \"drop\": {\"params\": [\"robot\", \"obj\", \"loc\"],\n",
+    "                 \"pre\": [\"at(robot,loc)\", \"has(robot,obj)\"],\n",
+    "                 \"eff_pos\": [\"at_obj(obj,loc)\", \"free(robot)\"], \"eff_neg\": [\"has(robot,obj)\"]},\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "INITIAL_STATE = {\"at(robot,A)\", \"free(robot)\", \"at_obj(obj1,B)\"}\n",
+    "GOAL_STATE    = {\"at_obj(obj1,A)\"}\n",
+    "\n",
+    "prompt_nl = \"\"\"\n",
+    "Tu es un planificateur robotique expert.\n",
+    "\n",
+    "## Domaine : robot-simple\n",
+    "Un robot peut se déplacer entre des emplacements, ramasser des objets et les déposer.\n",
+    "Actions disponibles :\n",
+    "  - move(robot, from, to)  : déplace le robot de `from` vers `to`\n",
+    "      PRECONDITION : robot se trouve en `from`\n",
+    "      EFFET        : robot se trouve en `to`, n'est plus en `from`\n",
+    "  - pick(robot, obj, loc)  : robot prend l'objet `obj` à l'emplacement `loc`\n",
+    "      PRECONDITION : robot en `loc`, objet en `loc`, robot libre (free)\n",
+    "      EFFET        : robot tient l'objet, objet n'est plus en `loc`, robot n'est plus libre\n",
+    "  - drop(robot, obj, loc)  : robot pose l'objet `obj` à l'emplacement `loc`\n",
+    "      PRECONDITION : robot en `loc`, robot tient `obj`\n",
+    "      EFFET        : objet posé en `loc`, robot redevient libre, robot ne tient plus l'objet\n",
+    "\n",
+    "## État initial\n",
+    "- robot se trouve en A\n",
+    "- robot est libre (ne tient rien)\n",
+    "- objet1 se trouve en B\n",
+    "\n",
+    "## But\n",
+    "- objet1 doit se trouver en A\n",
+    "\n",
+    "## Instructions\n",
+    "1. Raisonne étape par étape (quels faits changent à chaque action ?).\n",
+    "2. Fournis le plan UNIQUEMENT sous forme JSON stricte, sans texte autour :\n",
+    "[\n",
+    "  {\"action\": \"move\",  \"params\": [\"robot\", \"A\", \"B\"]},\n",
+    "  {\"action\": \"pick\",  \"params\": [\"robot\", \"obj1\", \"B\"]},\n",
+    "  {\"action\": \"move\",  \"params\": [\"robot\", \"B\", \"A\"]},\n",
+    "  {\"action\": \"drop\",  \"params\": [\"robot\", \"obj1\", \"A\"]}\n",
+    "]\n",
+    "Réponds avec le JSON seulement, encadré par des triples backticks json.\n",
+    "\"\"\"\n",
+    "\n",
+    "print(\"Prompt NL défini.\")\n",
+    "print(prompt_nl[:300], \"...\")\n",
+    "\n",
+    "def call_llm_for_plan(prompt: str) -> list:\n",
+    "    \"\"\"Appelle le LLM et retourne la liste des actions parsées.\"\"\"\n",
+    "    raw = None\n",
+    "\n",
+    "    if anthropic_client:\n",
+    "        response = anthropic_client.messages.create(\n",
+    "            model=config.model_anthropic,\n",
+    "            max_tokens=config.max_tokens,\n",
+    "            messages=[{\"role\": \"user\", \"content\": prompt}]\n",
+    "        )\n",
+    "        raw = response.content[0].text\n",
+    "    elif openai_client:\n",
+    "        response = openai_client.chat.completions.create(\n",
+    "            model=config.model_openai,\n",
+    "            max_tokens=config.max_tokens,\n",
+    "            messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "            extra_body={\"chat_template_kwargs\": {\"enable_thinking\": False}}\n",
+    "        )\n",
+    "        raw = response.choices[0].message.content\n",
+    "    else:\n",
+    "        print(\"⚠ Aucune API configurée — utilisation du plan exemple.\")\n",
+    "        return [\n",
+    "            {\"action\": \"move\",  \"params\": [\"robot\", \"A\", \"B\"]},\n",
+    "            {\"action\": \"pick\",  \"params\": [\"robot\", \"obj1\", \"B\"]},\n",
+    "            {\"action\": \"move\",  \"params\": [\"robot\", \"B\", \"A\"]},\n",
+    "            {\"action\": \"drop\",  \"params\": [\"robot\", \"obj1\", \"A\"]},\n",
+    "        ]\n",
+    "\n",
+    "    print(\"Réponse brute LLM :\\n\", raw[:500])\n",
+    "\n",
+    "    # Extraire le JSON (entre ```json ... ``` ou premier [ ... ])\n",
+    "    m = re.search(r\"```(?:json)?\\s*([\\s\\S]*?)```\", raw)\n",
+    "    if m:\n",
+    "        json_str = m.group(1)\n",
+    "    else:\n",
+    "        start = raw.find(\"[\")\n",
+    "        end   = raw.rfind(\"]\") + 1\n",
+    "        json_str = raw[start:end] if start != -1 else \"[]\"\n",
+    "\n",
+    "    try:\n",
+    "        return json.loads(json_str)\n",
+    "    except json.JSONDecodeError as e:\n",
+    "        print(f\"Erreur parsing JSON : {e}\")\n",
+    "        return []\n",
+    "\n",
+    "\n",
+    "llm_plan_raw = call_llm_for_plan(prompt_nl)\n",
+    "print(\"\\nPlan brut retourné par le LLM :\")\n",
+    "for step in llm_plan_raw:\n",
+    "    print(f\"  {step['action']}({', '.join(step['params'])})\")\n",
+    "\n",
+    "def to_pddl_action(step: dict) -> str:\n",
+    "    \"\"\"Formate une action dict en chaîne PDDL.\"\"\"\n",
+    "    return f\"({step['action']} {' '.join(step['params'])})\"\n",
+    "\n",
+    "pddl_sequence = [to_pddl_action(s) for s in llm_plan_raw]\n",
+    "print(\"\\nSéquence PDDL :\")\n",
+    "for i, a in enumerate(pddl_sequence, 1):\n",
+    "    print(f\"  {i}. {a}\")\n",
+    "\n",
+    "\n",
+    "def substitute(template: str, params: list, param_names: list) -> str:\n",
+    "    \"\"\"Remplace les noms de paramètres formels par les valeurs concrètes.\n",
+    "    \n",
+    "    Utilise une regex avec lookbehind/lookahead sur les délimiteurs PDDL\n",
+    "    ( '(' ',' ')' ) pour éviter les remplacements partiels de sous-chaînes.\n",
+    "    Exemple sans fix : 'at_obj(obj,loc)' avec obj->obj1 donnait 'at_obj1(obj1,loc)'.\n",
+    "    \"\"\"\n",
+    "    result = template\n",
+    "    for name, val in zip(param_names, params):\n",
+    "        result = re.sub(r'(?<=[,(])' + re.escape(name) + r'(?=[,)])', val, result)\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "def apply_action(state: set, action_name: str, params: list) -> tuple:\n",
+    "    \"\"\"\n",
+    "    Applique une action à un état.\n",
+    "    Retourne (nouvel_état, ok, message_erreur).\n",
+    "    \"\"\"\n",
+    "    if action_name not in DOMAIN[\"actions\"]:\n",
+    "        return state, False, f\"Action inconnue : {action_name}\"\n",
+    "\n",
+    "    spec        = DOMAIN[\"actions\"][action_name]\n",
+    "    param_names = spec[\"params\"]\n",
+    "\n",
+    "    # Vérifier les préconditions\n",
+    "    for pre_template in spec[\"pre\"]:\n",
+    "        pre_grounded = substitute(pre_template, params, param_names)\n",
+    "        if pre_grounded not in state:\n",
+    "            return state, False, f\"Précondition non satisfaite : {pre_grounded}\"\n",
+    "\n",
+    "    # Appliquer les effets\n",
+    "    new_state = set(state)\n",
+    "    for neg in spec[\"eff_neg\"]:\n",
+    "        new_state.discard(substitute(neg, params, param_names))\n",
+    "    for pos in spec[\"eff_pos\"]:\n",
+    "        new_state.add(substitute(pos, params, param_names))\n",
+    "\n",
+    "    return new_state, True, \"OK\"\n",
+    "\n",
+    "\n",
+    "def validate_plan(plan: list, initial: set, goal: set) -> bool:\n",
+    "    \"\"\"Valide le plan étape par étape et affiche le détail.\"\"\"\n",
+    "    state = set(initial)\n",
+    "    print(\"\\n\" + \"=\"*60)\n",
+    "    print(\"VALIDATION DU PLAN\")\n",
+    "    print(\"=\"*60)\n",
+    "    print(f\"État initial : {sorted(state)}\")\n",
+    "    print(f\"But          : {sorted(goal)}\")\n",
+    "    print(\"-\"*60)\n",
+    "\n",
+    "    all_ok = True\n",
+    "    for i, step in enumerate(plan, 1):\n",
+    "        action = step[\"action\"]\n",
+    "        params = step[\"params\"]\n",
+    "        state, ok, msg = apply_action(state, action, params)\n",
+    "\n",
+    "        status = \"✓\" if ok else \"✗\"\n",
+    "        print(f\"Étape {i} : {status} {action}({', '.join(params)})\")\n",
+    "        if not ok:\n",
+    "            print(f\"          → ERREUR : {msg}\")\n",
+    "            all_ok = False\n",
+    "        else:\n",
+    "            print(f\"          → État : {sorted(state)}\")\n",
+    "\n",
+    "    print(\"-\"*60)\n",
+    "    goal_reached = goal.issubset(state)\n",
+    "    print(f\"But atteint  : {'✓ OUI' if goal_reached else '✗ NON'}\")\n",
+    "    if not all_ok:\n",
+    "        print(\"Plan INVALIDE (préconditions non respectées).\")\n",
+    "    elif goal_reached:\n",
+    "        print(\"Plan VALIDE et COMPLET ✓\")\n",
+    "    else:\n",
+    "        print(\"Plan valide mais but non atteint.\")\n",
+    "    print(\"=\"*60)\n",
+    "    return all_ok and goal_reached\n",
+    "\n",
+    "\n",
+    "success = validate_plan(llm_plan_raw, INITIAL_STATE, GOAL_STATE)"
    ]
   },
   {
@@ -1456,10 +1710,10 @@
    "id": "p10-ex-md",
    "metadata": {
     "papermill": {
-     "duration": 0.002746,
-     "end_time": "2026-05-25T01:06:15.136618+00:00",
+     "duration": 0.003224,
+     "end_time": "2026-06-02T08:52:46.825021",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.133872+00:00",
+     "start_time": "2026-06-02T08:52:46.821797",
      "status": "completed"
     },
     "tags": []
@@ -1479,16 +1733,16 @@
    "id": "p10-ex-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.143776Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.143631Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.146417Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.145795Z"
+     "iopub.execute_input": "2026-06-02T08:52:46.832085Z",
+     "iopub.status.busy": "2026-06-02T08:52:46.831910Z",
+     "iopub.status.idle": "2026-06-02T08:52:46.834797Z",
+     "shell.execute_reply": "2026-06-02T08:52:46.834283Z"
     },
     "papermill": {
-     "duration": 0.007162,
-     "end_time": "2026-05-25T01:06:15.146905+00:00",
+     "duration": 0.007278,
+     "end_time": "2026-06-02T08:52:46.835497",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.139743+00:00",
+     "start_time": "2026-06-02T08:52:46.828219",
      "status": "completed"
     },
     "tags": []
@@ -1516,10 +1770,10 @@
    "id": "6c2833b7",
    "metadata": {
     "papermill": {
-     "duration": 0.002934,
-     "end_time": "2026-05-25T01:06:15.152764+00:00",
+     "duration": 0.003455,
+     "end_time": "2026-06-02T08:52:46.842619",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.149830+00:00",
+     "start_time": "2026-06-02T08:52:46.839164",
      "status": "completed"
     },
     "tags": []
@@ -1549,10 +1803,10 @@
    "id": "a95fe4f8",
    "metadata": {
     "papermill": {
-     "duration": 0.00269,
-     "end_time": "2026-05-25T01:06:15.158556+00:00",
+     "duration": 0.003397,
+     "end_time": "2026-06-02T08:52:46.849496",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.155866+00:00",
+     "start_time": "2026-06-02T08:52:46.846099",
      "status": "completed"
     },
     "tags": []
@@ -1577,8 +1831,25 @@
   {
    "cell_type": "markdown",
    "id": "c3e3007f",
-   "source": "## Resume et perspectives\n\nCe notebook a explore l'integration des **Large Language Models** avec la planification automatique, illustrant six strategies distinctes allant de la generation directe de plans a l'utilisation du LLM comme heuristique. L'approche directe, bien que simple, souffre d'un manque de garanties : les LLMs peuvent halluciner des actions inexistentes ou produire des plans invalides. Les techniques de raisonnement avance (Chain-of-Thought, Tree-of-Thought) ameliorent la coherence des plans generes, tandis que la traduction langage naturel vers PDDL, couplee a un validateur formel, offre la voie la plus fiable vers des plans corrects. L'exemple guide de traduction NL-vers-PDDL avec validation pas-a-pas a montre comment combiner la flexibilite linguistique du LLM avec la rigueur de la verification symbolique.\n\nLe couplage LLM-planification ouvre des perspectives considerables pour la democratisation de la planification automatique. Un utilisateur non expert peut desormais decrire un probleme en langage naturel et obtenir un plan formel, sans maitriser la syntaxe PDDL. Cependant, les limitations restent importantes : le cout des appels API (prohibitif pour l'usage heuristique dans la boucle de recherche), la latence, et surtout le risque d'hallucination imposent de toujours valider formellement les plans produits. L'approche neuro-symbolique, ou le LLM genere des hypotheses que le solveur symbolique valide et raffine, represente le compromis le plus prometteur pour les applications critiques.\n\nLe notebook suivant, [Planners-11-Unified-Planning](Planners-11-Unified-Planning.ipynb), presente l'interface unifiee unified-planning qui permet de comparer facilement differents solveurs sur un meme probleme, un complement naturel aux approches LLM-presentees ici.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003686,
+     "end_time": "2026-06-02T08:52:46.857166",
+     "exception": false,
+     "start_time": "2026-06-02T08:52:46.853480",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore l'integration des **Large Language Models** avec la planification automatique, illustrant six strategies distinctes allant de la generation directe de plans a l'utilisation du LLM comme heuristique. L'approche directe, bien que simple, souffre d'un manque de garanties : les LLMs peuvent halluciner des actions inexistentes ou produire des plans invalides. Les techniques de raisonnement avance (Chain-of-Thought, Tree-of-Thought) ameliorent la coherence des plans generes, tandis que la traduction langage naturel vers PDDL, couplee a un validateur formel, offre la voie la plus fiable vers des plans corrects. L'exemple guide de traduction NL-vers-PDDL avec validation pas-a-pas a montre comment combiner la flexibilite linguistique du LLM avec la rigueur de la verification symbolique.\n",
+    "\n",
+    "Le couplage LLM-planification ouvre des perspectives considerables pour la democratisation de la planification automatique. Un utilisateur non expert peut desormais decrire un probleme en langage naturel et obtenir un plan formel, sans maitriser la syntaxe PDDL. Cependant, les limitations restent importantes : le cout des appels API (prohibitif pour l'usage heuristique dans la boucle de recherche), la latence, et surtout le risque d'hallucination imposent de toujours valider formellement les plans produits. L'approche neuro-symbolique, ou le LLM genere des hypotheses que le solveur symbolique valide et raffine, represente le compromis le plus prometteur pour les applications critiques.\n",
+    "\n",
+    "Le notebook suivant, [Planners-11-Unified-Planning](Planners-11-Unified-Planning.ipynb), presente l'interface unifiee unified-planning qui permet de comparer facilement differents solveurs sur un meme probleme, un complement naturel aux approches LLM-presentees ici."
+   ]
   }
  ],
  "metadata": {
@@ -1597,18 +1868,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.145247,
-   "end_time": "2026-05-25T01:06:15.523575+00:00",
+   "duration": 8.676018,
+   "end_time": "2026-06-02T08:52:47.343399",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-10-LLM-Planning.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-10-LLM-Planning_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb",
    "parameters": {},
-   "start_time": "2026-05-25T01:06:11.378328+00:00",
+   "start_time": "2026-06-02T08:52:38.667381",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Fixes 2 issues in Planners-10-LLM-Planning.ipynb found during convention prints audit:

### 1. Cell 38 corrupted (single-line mash)
- The Exemple guide cell (NL→PDDL pipeline with DOMAIN, substitute(), apply_action(), validate_plan()) was mashed to a single 6905-char line by commit d25c5d98 (TP conversions batch 3)
- Restored clean multiline source (196 newlines, 7066 chars) from last good commit 030fc8b2

### 2. Cell 8 silent (convention print)
- Cell defining PlanningState, Action, generate_plan_direct had no output
- Added `print(f"Classes definies : PlanningState, Action, generate_plan_direct")`

## Validation

- Papermill re-executed: 16/16 code cells with outputs, 0 errors
- All exercise stubs preserved (C.1 compliant)
- No content changes beyond the two fixes above

## Scope

Single notebook: Planners-10-LLM-Planning.ipynb (rest of Planners series is clean — all silent cells are legitimate exercise stubs)