### PR TITLE
fix(Planners-10): add convention print to PlanningState/Action class definitions

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -5,10 +5,10 @@
    "id": "1f5f5ce0",
    "metadata": {
     "papermill": {
-     "duration": 0.003662,
-     "end_time": "2026-05-25T01:06:13.081366+00:00",
+     "duration": 0.005348,
+     "end_time": "2026-06-02T09:47:41.340964+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.077704+00:00",
+     "start_time": "2026-06-02T09:47:41.335616+00:00",
      "status": "completed"
     },
     "tags": []
@@ -38,10 +38,10 @@
    "id": "ef5407b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002411,
-     "end_time": "2026-05-25T01:06:13.089468+00:00",
+     "duration": 0.00465,
+     "end_time": "2026-06-02T09:47:41.352070+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.087057+00:00",
+     "start_time": "2026-06-02T09:47:41.347420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,10 +68,10 @@
    "id": "d0d78572",
    "metadata": {
     "papermill": {
-     "duration": 0.002839,
-     "end_time": "2026-05-25T01:06:13.094746+00:00",
+     "duration": 0.004255,
+     "end_time": "2026-06-02T09:47:41.360591+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.091907+00:00",
+     "start_time": "2026-06-02T09:47:41.356336+00:00",
      "status": "completed"
     },
     "tags": []
@@ -86,16 +86,16 @@
    "id": "43659e21",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:13.101361Z",
-     "iopub.status.busy": "2026-05-25T01:06:13.101183Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.399954Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.399266Z"
+     "iopub.execute_input": "2026-06-02T09:47:41.370584Z",
+     "iopub.status.busy": "2026-06-02T09:47:41.370357Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.485460Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.484531Z"
     },
     "papermill": {
-     "duration": 1.302757,
-     "end_time": "2026-05-25T01:06:14.400348+00:00",
+     "duration": 2.12153,
+     "end_time": "2026-06-02T09:47:43.486250+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:13.097591+00:00",
+     "start_time": "2026-06-02T09:47:41.364720+00:00",
      "status": "completed"
     },
     "tags": []
@@ -154,10 +154,10 @@
    "id": "qwhoava1aus",
    "metadata": {
     "papermill": {
-     "duration": 0.002828,
-     "end_time": "2026-05-25T01:06:14.406035+00:00",
+     "duration": 0.004294,
+     "end_time": "2026-06-02T09:47:43.495582+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.403207+00:00",
+     "start_time": "2026-06-02T09:47:43.491288+00:00",
      "status": "completed"
     },
     "tags": []
@@ -172,16 +172,16 @@
    "id": "35bf6b1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.411842Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.411696Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.416147Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.415672Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.506266Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.505820Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.514984Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.514068Z"
     },
     "papermill": {
-     "duration": 0.008127,
-     "end_time": "2026-05-25T01:06:14.416742+00:00",
+     "duration": 0.015854,
+     "end_time": "2026-06-02T09:47:43.515886+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.408615+00:00",
+     "start_time": "2026-06-02T09:47:43.500032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -235,10 +235,10 @@
    "id": "12709dc5",
    "metadata": {
     "papermill": {
-     "duration": 0.002445,
-     "end_time": "2026-05-25T01:06:14.421726+00:00",
+     "duration": 0.004655,
+     "end_time": "2026-06-02T09:47:43.525328+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.419281+00:00",
+     "start_time": "2026-06-02T09:47:43.520673+00:00",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "58885d01",
    "metadata": {
     "papermill": {
-     "duration": 0.002713,
-     "end_time": "2026-05-25T01:06:14.427107+00:00",
+     "duration": 0.004693,
+     "end_time": "2026-06-02T09:47:43.535430+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.424394+00:00",
+     "start_time": "2026-06-02T09:47:43.530737+00:00",
      "status": "completed"
     },
     "tags": []
@@ -278,21 +278,30 @@
    "id": "99cd77aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.433588Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.433414Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.439877Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.439403Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.545896Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.545538Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.554511Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.553775Z"
     },
     "papermill": {
-     "duration": 0.010602,
-     "end_time": "2026-05-25T01:06:14.440359+00:00",
+     "duration": 0.015133,
+     "end_time": "2026-06-02T09:47:43.555209+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.429757+00:00",
+     "start_time": "2026-06-02T09:47:43.540076+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Classes definies : PlanningState (2 champs), Action (4 champs)\n",
+      "Fonction definie : generate_plan_direct\n"
+     ]
+    }
+   ],
    "source": [
     "@dataclass\n",
     "class PlanningState:\n",
@@ -368,7 +377,10 @@
     "    except json.JSONDecodeError as e:\n",
     "        print(f\"Erreur parsing JSON: {e}\")\n",
     "    \n",
-    "    return []"
+    "    return []\n",
+    "\n",
+    "print(f\"Classes definies : PlanningState ({len(PlanningState.__dataclass_fields__)} champs), Action ({len(Action.__dataclass_fields__)} champs)\")\n",
+    "print(f\"Fonction definie : generate_plan_direct\")"
    ]
   },
   {
@@ -376,10 +388,10 @@
    "id": "erhfybdkgim",
    "metadata": {
     "papermill": {
-     "duration": 0.002489,
-     "end_time": "2026-05-25T01:06:14.445604+00:00",
+     "duration": 0.004529,
+     "end_time": "2026-06-02T09:47:43.564282+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.443115+00:00",
+     "start_time": "2026-06-02T09:47:43.559753+00:00",
      "status": "completed"
     },
     "tags": []
@@ -394,16 +406,16 @@
    "id": "0dd0d8b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.451896Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.451723Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.455573Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.455048Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.574715Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.574506Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.578853Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.578230Z"
     },
     "papermill": {
-     "duration": 0.007817,
-     "end_time": "2026-05-25T01:06:14.456092+00:00",
+     "duration": 0.010593,
+     "end_time": "2026-06-02T09:47:43.579656+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.448275+00:00",
+     "start_time": "2026-06-02T09:47:43.569063+00:00",
      "status": "completed"
     },
     "tags": []
@@ -461,10 +473,10 @@
    "id": "ef0bf497",
    "metadata": {
     "papermill": {
-     "duration": 0.002652,
-     "end_time": "2026-05-25T01:06:14.461624+00:00",
+     "duration": 0.0044,
+     "end_time": "2026-06-02T09:47:43.588696+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.458972+00:00",
+     "start_time": "2026-06-02T09:47:43.584296+00:00",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +495,10 @@
    "id": "87819ac5",
    "metadata": {
     "papermill": {
-     "duration": 0.002622,
-     "end_time": "2026-05-25T01:06:14.467016+00:00",
+     "duration": 0.003729,
+     "end_time": "2026-06-02T09:47:43.596422+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.464394+00:00",
+     "start_time": "2026-06-02T09:47:43.592693+00:00",
      "status": "completed"
     },
     "tags": []
@@ -503,16 +515,16 @@
    "id": "03a9a0cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.475835Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.475665Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.479629Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.478849Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.606008Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.605751Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.610136Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.609406Z"
     },
     "papermill": {
-     "duration": 0.010657,
-     "end_time": "2026-05-25T01:06:14.480284+00:00",
+     "duration": 0.010314,
+     "end_time": "2026-06-02T09:47:43.610887+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.469627+00:00",
+     "start_time": "2026-06-02T09:47:43.600573+00:00",
      "status": "completed"
     },
     "tags": []
@@ -572,10 +584,10 @@
    "id": "akalpwcqg8i",
    "metadata": {
     "papermill": {
-     "duration": 0.0031,
-     "end_time": "2026-05-25T01:06:14.487308+00:00",
+     "duration": 0.004199,
+     "end_time": "2026-06-02T09:47:43.619476+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.484208+00:00",
+     "start_time": "2026-06-02T09:47:43.615277+00:00",
      "status": "completed"
     },
     "tags": []
@@ -590,16 +602,16 @@
    "id": "1fc7c73f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.494392Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.494217Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.497624Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.496910Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.629666Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.629462Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.633213Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.632420Z"
     },
     "papermill": {
-     "duration": 0.008032,
-     "end_time": "2026-05-25T01:06:14.498318+00:00",
+     "duration": 0.010224,
+     "end_time": "2026-06-02T09:47:43.634033+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.490286+00:00",
+     "start_time": "2026-06-02T09:47:43.623809+00:00",
      "status": "completed"
     },
     "tags": []
@@ -634,10 +646,10 @@
    "id": "e3bf2623",
    "metadata": {
     "papermill": {
-     "duration": 0.002911,
-     "end_time": "2026-05-25T01:06:14.504329+00:00",
+     "duration": 0.004174,
+     "end_time": "2026-06-02T09:47:43.642701+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.501418+00:00",
+     "start_time": "2026-06-02T09:47:43.638527+00:00",
      "status": "completed"
     },
     "tags": []
@@ -657,10 +669,10 @@
    "id": "2bcb8964",
    "metadata": {
     "papermill": {
-     "duration": 0.002773,
-     "end_time": "2026-05-25T01:06:14.509906+00:00",
+     "duration": 0.004616,
+     "end_time": "2026-06-02T09:47:43.651721+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.507133+00:00",
+     "start_time": "2026-06-02T09:47:43.647105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -677,16 +689,16 @@
    "id": "b7dbc7df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.515798Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.515667Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.519320Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.518896Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.662023Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.661682Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.666556Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.665892Z"
     },
     "papermill": {
-     "duration": 0.007317,
-     "end_time": "2026-05-25T01:06:14.519778+00:00",
+     "duration": 0.010947,
+     "end_time": "2026-06-02T09:47:43.667154+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.512461+00:00",
+     "start_time": "2026-06-02T09:47:43.656207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -746,8 +758,7 @@
     "        return response.content[0].text\n",
     "    \n",
     "    return \";; API non configuree\"\n",
-    "print(\"Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\")\n",
-    ""
+    "print(\"Fonctions PDDL definies : text_to_pddl_domain, text_to_pddl_problem\")\n"
    ]
   },
   {
@@ -755,10 +766,10 @@
    "id": "2tbqoup6bpy",
    "metadata": {
     "papermill": {
-     "duration": 0.0025,
-     "end_time": "2026-05-25T01:06:14.524778+00:00",
+     "duration": 0.004174,
+     "end_time": "2026-06-02T09:47:43.675669+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.522278+00:00",
+     "start_time": "2026-06-02T09:47:43.671495+00:00",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +784,16 @@
    "id": "3f111a44",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.530729Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.530450Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.533795Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.533117Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.686419Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.685936Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.690664Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.689769Z"
     },
     "papermill": {
-     "duration": 0.007003,
-     "end_time": "2026-05-25T01:06:14.534344+00:00",
+     "duration": 0.011522,
+     "end_time": "2026-06-02T09:47:43.691529+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.527341+00:00",
+     "start_time": "2026-06-02T09:47:43.680007+00:00",
      "status": "completed"
     },
     "tags": []
@@ -835,10 +846,10 @@
    "id": "0fc6c205",
    "metadata": {
     "papermill": {
-     "duration": 0.002681,
-     "end_time": "2026-05-25T01:06:14.539672+00:00",
+     "duration": 0.004816,
+     "end_time": "2026-06-02T09:47:43.701401+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.536991+00:00",
+     "start_time": "2026-06-02T09:47:43.696585+00:00",
      "status": "completed"
     },
     "tags": []
@@ -857,10 +868,10 @@
    "id": "d805d708",
    "metadata": {
     "papermill": {
-     "duration": 0.002803,
-     "end_time": "2026-05-25T01:06:14.545209+00:00",
+     "duration": 0.004764,
+     "end_time": "2026-06-02T09:47:43.710874+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.542406+00:00",
+     "start_time": "2026-06-02T09:47:43.706110+00:00",
      "status": "completed"
     },
     "tags": []
@@ -875,16 +886,16 @@
    "id": "a6442f2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.552452Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.552306Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.555967Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.555554Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.722487Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.722146Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.727365Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.726704Z"
     },
     "papermill": {
-     "duration": 0.008127,
-     "end_time": "2026-05-25T01:06:14.556435+00:00",
+     "duration": 0.012195,
+     "end_time": "2026-06-02T09:47:43.728015+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.548308+00:00",
+     "start_time": "2026-06-02T09:47:43.715820+00:00",
      "status": "completed"
     },
     "tags": []
@@ -945,10 +956,10 @@
    "id": "b53ae144",
    "metadata": {
     "papermill": {
-     "duration": 0.002533,
-     "end_time": "2026-05-25T01:06:14.561561+00:00",
+     "duration": 0.004467,
+     "end_time": "2026-06-02T09:47:43.737139+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.559028+00:00",
+     "start_time": "2026-06-02T09:47:43.732672+00:00",
      "status": "completed"
     },
     "tags": []
@@ -974,10 +985,10 @@
    "id": "a2dd3e4e",
    "metadata": {
     "papermill": {
-     "duration": 0.002778,
-     "end_time": "2026-05-25T01:06:14.567017+00:00",
+     "duration": 0.004226,
+     "end_time": "2026-06-02T09:47:43.745861+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.564239+00:00",
+     "start_time": "2026-06-02T09:47:43.741635+00:00",
      "status": "completed"
     },
     "tags": []
@@ -994,16 +1005,16 @@
    "id": "5a76dd94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.573167Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.573029Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.576509Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.575894Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.757240Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.756724Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.765439Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.764283Z"
     },
     "papermill": {
-     "duration": 0.007334,
-     "end_time": "2026-05-25T01:06:14.576953+00:00",
+     "duration": 0.016047,
+     "end_time": "2026-06-02T09:47:43.766390+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.569619+00:00",
+     "start_time": "2026-06-02T09:47:43.750343+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1059,10 +1070,10 @@
    "id": "23b37e55",
    "metadata": {
     "papermill": {
-     "duration": 0.002856,
-     "end_time": "2026-05-25T01:06:14.582353+00:00",
+     "duration": 0.004698,
+     "end_time": "2026-06-02T09:47:43.776216+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.579497+00:00",
+     "start_time": "2026-06-02T09:47:43.771518+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1079,16 +1090,16 @@
    "id": "25a34715",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.588586Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.588441Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.591762Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.591281Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.786685Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.786453Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.791512Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.790741Z"
     },
     "papermill": {
-     "duration": 0.007069,
-     "end_time": "2026-05-25T01:06:14.592205+00:00",
+     "duration": 0.011344,
+     "end_time": "2026-06-02T09:47:43.792202+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.585136+00:00",
+     "start_time": "2026-06-02T09:47:43.780858+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1136,10 +1147,10 @@
    "id": "57m8ot06t6t",
    "metadata": {
     "papermill": {
-     "duration": 0.002807,
-     "end_time": "2026-05-25T01:06:14.597633+00:00",
+     "duration": 0.004504,
+     "end_time": "2026-06-02T09:47:43.803147+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.594826+00:00",
+     "start_time": "2026-06-02T09:47:43.798643+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,16 +1165,16 @@
    "id": "ceae3028",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.604469Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.604323Z",
-     "iopub.status.idle": "2026-05-25T01:06:14.607466Z",
-     "shell.execute_reply": "2026-05-25T01:06:14.606985Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.813621Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.813398Z",
+     "iopub.status.idle": "2026-06-02T09:47:43.817840Z",
+     "shell.execute_reply": "2026-06-02T09:47:43.817184Z"
     },
     "papermill": {
-     "duration": 0.006969,
-     "end_time": "2026-05-25T01:06:14.607919+00:00",
+     "duration": 0.010827,
+     "end_time": "2026-06-02T09:47:43.818514+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.600950+00:00",
+     "start_time": "2026-06-02T09:47:43.807687+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1203,10 +1214,10 @@
    "id": "b4510646",
    "metadata": {
     "papermill": {
-     "duration": 0.002639,
-     "end_time": "2026-05-25T01:06:14.613226+00:00",
+     "duration": 0.004496,
+     "end_time": "2026-06-02T09:47:43.827713+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.610587+00:00",
+     "start_time": "2026-06-02T09:47:43.823217+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1229,10 +1240,10 @@
    "id": "0ac5363f",
    "metadata": {
     "papermill": {
-     "duration": 0.002692,
-     "end_time": "2026-05-25T01:06:14.618570+00:00",
+     "duration": 0.004313,
+     "end_time": "2026-06-02T09:47:43.836645+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.615878+00:00",
+     "start_time": "2026-06-02T09:47:43.832332+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1247,16 +1258,16 @@
    "id": "f6ea658d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:14.624565Z",
-     "iopub.status.busy": "2026-05-25T01:06:14.624428Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.089865Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.089187Z"
+     "iopub.execute_input": "2026-06-02T09:47:43.847025Z",
+     "iopub.status.busy": "2026-06-02T09:47:43.846635Z",
+     "iopub.status.idle": "2026-06-02T09:47:45.609684Z",
+     "shell.execute_reply": "2026-06-02T09:47:45.608951Z"
     },
     "papermill": {
-     "duration": 0.469242,
-     "end_time": "2026-05-25T01:06:15.090419+00:00",
+     "duration": 1.76947,
+     "end_time": "2026-06-02T09:47:45.610413+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:14.621177+00:00",
+     "start_time": "2026-06-02T09:47:43.840943+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1296,10 +1307,10 @@
    "id": "426be437",
    "metadata": {
     "papermill": {
-     "duration": 0.003312,
-     "end_time": "2026-05-25T01:06:15.097634+00:00",
+     "duration": 0.005955,
+     "end_time": "2026-06-02T09:47:45.622079+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.094322+00:00",
+     "start_time": "2026-06-02T09:47:45.616124+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1328,10 +1339,10 @@
    "id": "bd9ef406",
    "metadata": {
     "papermill": {
-     "duration": 0.003102,
-     "end_time": "2026-05-25T01:06:15.104123+00:00",
+     "duration": 0.005179,
+     "end_time": "2026-06-02T09:47:45.634608+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.101021+00:00",
+     "start_time": "2026-06-02T09:47:45.629429+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1356,16 +1367,16 @@
    "id": "3f7e47d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.111239Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.111078Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.113723Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.113234Z"
+     "iopub.execute_input": "2026-06-02T09:47:45.647596Z",
+     "iopub.status.busy": "2026-06-02T09:47:45.647188Z",
+     "iopub.status.idle": "2026-06-02T09:47:45.652465Z",
+     "shell.execute_reply": "2026-06-02T09:47:45.651495Z"
     },
     "papermill": {
-     "duration": 0.007167,
-     "end_time": "2026-05-25T01:06:15.114510+00:00",
+     "duration": 0.013282,
+     "end_time": "2026-06-02T09:47:45.653378+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.107343+00:00",
+     "start_time": "2026-06-02T09:47:45.640096+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1411,10 +1422,10 @@
    "id": "y1zezpybwo9",
    "metadata": {
     "papermill": {
-     "duration": 0.002757,
-     "end_time": "2026-05-25T01:06:15.120218+00:00",
+     "duration": 0.006492,
+     "end_time": "2026-06-02T09:47:45.665928+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.117461+00:00",
+     "start_time": "2026-06-02T09:47:45.659436+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1432,16 +1443,16 @@
    "id": "c0k81u0utji",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.126661Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.126483Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.130249Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.129779Z"
+     "iopub.execute_input": "2026-06-02T09:47:45.680823Z",
+     "iopub.status.busy": "2026-06-02T09:47:45.680553Z",
+     "iopub.status.idle": "2026-06-02T09:47:45.687273Z",
+     "shell.execute_reply": "2026-06-02T09:47:45.685725Z"
     },
     "papermill": {
-     "duration": 0.007725,
-     "end_time": "2026-05-25T01:06:15.130735+00:00",
+     "duration": 0.016724,
+     "end_time": "2026-06-02T09:47:45.688195+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.123010+00:00",
+     "start_time": "2026-06-02T09:47:45.671471+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1456,10 +1467,10 @@
    "id": "p10-ex-md",
    "metadata": {
     "papermill": {
-     "duration": 0.002746,
-     "end_time": "2026-05-25T01:06:15.136618+00:00",
+     "duration": 0.005177,
+     "end_time": "2026-06-02T09:47:45.701281+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.133872+00:00",
+     "start_time": "2026-06-02T09:47:45.696104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1479,16 +1490,16 @@
    "id": "p10-ex-stub",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T01:06:15.143776Z",
-     "iopub.status.busy": "2026-05-25T01:06:15.143631Z",
-     "iopub.status.idle": "2026-05-25T01:06:15.146417Z",
-     "shell.execute_reply": "2026-05-25T01:06:15.145795Z"
+     "iopub.execute_input": "2026-06-02T09:47:45.713421Z",
+     "iopub.status.busy": "2026-06-02T09:47:45.713010Z",
+     "iopub.status.idle": "2026-06-02T09:47:45.718849Z",
+     "shell.execute_reply": "2026-06-02T09:47:45.717273Z"
     },
     "papermill": {
-     "duration": 0.007162,
-     "end_time": "2026-05-25T01:06:15.146905+00:00",
+     "duration": 0.013611,
+     "end_time": "2026-06-02T09:47:45.720177+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.139743+00:00",
+     "start_time": "2026-06-02T09:47:45.706566+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1516,10 +1527,10 @@
    "id": "6c2833b7",
    "metadata": {
     "papermill": {
-     "duration": 0.002934,
-     "end_time": "2026-05-25T01:06:15.152764+00:00",
+     "duration": 0.005186,
+     "end_time": "2026-06-02T09:47:45.731653+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.149830+00:00",
+     "start_time": "2026-06-02T09:47:45.726467+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1549,10 +1560,10 @@
    "id": "a95fe4f8",
    "metadata": {
     "papermill": {
-     "duration": 0.00269,
-     "end_time": "2026-05-25T01:06:15.158556+00:00",
+     "duration": 0.005289,
+     "end_time": "2026-06-02T09:47:45.742520+00:00",
      "exception": false,
-     "start_time": "2026-05-25T01:06:15.155866+00:00",
+     "start_time": "2026-06-02T09:47:45.737231+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1577,8 +1588,25 @@
   {
    "cell_type": "markdown",
    "id": "c3e3007f",
-   "source": "## Resume et perspectives\n\nCe notebook a explore l'integration des **Large Language Models** avec la planification automatique, illustrant six strategies distinctes allant de la generation directe de plans a l'utilisation du LLM comme heuristique. L'approche directe, bien que simple, souffre d'un manque de garanties : les LLMs peuvent halluciner des actions inexistentes ou produire des plans invalides. Les techniques de raisonnement avance (Chain-of-Thought, Tree-of-Thought) ameliorent la coherence des plans generes, tandis que la traduction langage naturel vers PDDL, couplee a un validateur formel, offre la voie la plus fiable vers des plans corrects. L'exemple guide de traduction NL-vers-PDDL avec validation pas-a-pas a montre comment combiner la flexibilite linguistique du LLM avec la rigueur de la verification symbolique.\n\nLe couplage LLM-planification ouvre des perspectives considerables pour la democratisation de la planification automatique. Un utilisateur non expert peut desormais decrire un probleme en langage naturel et obtenir un plan formel, sans maitriser la syntaxe PDDL. Cependant, les limitations restent importantes : le cout des appels API (prohibitif pour l'usage heuristique dans la boucle de recherche), la latence, et surtout le risque d'hallucination imposent de toujours valider formellement les plans produits. L'approche neuro-symbolique, ou le LLM genere des hypotheses que le solveur symbolique valide et raffine, represente le compromis le plus prometteur pour les applications critiques.\n\nLe notebook suivant, [Planners-11-Unified-Planning](Planners-11-Unified-Planning.ipynb), presente l'interface unifiee unified-planning qui permet de comparer facilement differents solveurs sur un meme probleme, un complement naturel aux approches LLM-presentees ici.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.006569,
+     "end_time": "2026-06-02T09:47:45.754813+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T09:47:45.748244+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore l'integration des **Large Language Models** avec la planification automatique, illustrant six strategies distinctes allant de la generation directe de plans a l'utilisation du LLM comme heuristique. L'approche directe, bien que simple, souffre d'un manque de garanties : les LLMs peuvent halluciner des actions inexistentes ou produire des plans invalides. Les techniques de raisonnement avance (Chain-of-Thought, Tree-of-Thought) ameliorent la coherence des plans generes, tandis que la traduction langage naturel vers PDDL, couplee a un validateur formel, offre la voie la plus fiable vers des plans corrects. L'exemple guide de traduction NL-vers-PDDL avec validation pas-a-pas a montre comment combiner la flexibilite linguistique du LLM avec la rigueur de la verification symbolique.\n",
+    "\n",
+    "Le couplage LLM-planification ouvre des perspectives considerables pour la democratisation de la planification automatique. Un utilisateur non expert peut desormais decrire un probleme en langage naturel et obtenir un plan formel, sans maitriser la syntaxe PDDL. Cependant, les limitations restent importantes : le cout des appels API (prohibitif pour l'usage heuristique dans la boucle de recherche), la latence, et surtout le risque d'hallucination imposent de toujours valider formellement les plans produits. L'approche neuro-symbolique, ou le LLM genere des hypotheses que le solveur symbolique valide et raffine, represente le compromis le plus prometteur pour les applications critiques.\n",
+    "\n",
+    "Le notebook suivant, [Planners-11-Unified-Planning](Planners-11-Unified-Planning.ipynb), presente l'interface unifiee unified-planning qui permet de comparer facilement differents solveurs sur un meme probleme, un complement naturel aux approches LLM-presentees ici."
+   ]
   }
  ],
  "metadata": {
@@ -1597,18 +1625,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.145247,
-   "end_time": "2026-05-25T01:06:15.523575+00:00",
+   "duration": 7.815906,
+   "end_time": "2026-06-02T09:47:46.544832+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-10-LLM-Planning.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Planners\\04-NeuroSymbolic\\Planners-10-LLM-Planning_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb",
+   "output_path": "C:/Users/jsboi/AppData/Local/Temp/planners10_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-25T01:06:11.378328+00:00",
+   "start_time": "2026-06-02T09:47:38.728926+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Add convention print to silent code cell in `Planners-10-LLM-Planning.ipynb`.

### Cell fixed

| # | Cell ID | Content | Print added |
|---|---------|---------|-------------|
| 1 | `99cd77aa` | `PlanningState` + `Action` dataclasses + `generate_plan_direct` function | `Classes definies : PlanningState (2 champs), Action (4 champs)` + `Fonction definie : generate_plan_direct` |

## Validation proof

- **Papermill**: 44/44 cells executed, 0 errors, kernel=python3
- **execution_count**: All 16 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **Source changes**: 1 print line added to cell 99cd77aa
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 233 insertions, 205 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
