### PR TITLE
fix(partition): add missing cell IDs to 23 notebooks (391 cells)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "db1bae74",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -1971,6 +1971,7 @@
    ]
   },
   {
+   "id": "49700304",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "0bd1bfea",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,6 +34,7 @@
    ]
   },
   {
+   "id": "4dfac306",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -61,6 +63,7 @@
    ]
   },
   {
+   "id": "8bd4df10",
    "cell_type": "markdown",
    "source": [
     "### Configuration de l'environnement\n",
@@ -75,6 +78,7 @@
    "metadata": {}
   },
   {
+   "id": "7da2b534",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -99,6 +103,7 @@
    ]
   },
   {
+   "id": "381c87c3",
    "cell_type": "markdown",
    "source": [
     "### Pourquoi la représentation ordinale ?\n",
@@ -121,6 +126,7 @@
    "metadata": {}
   },
   {
+   "id": "f2a65a8f",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -193,6 +199,7 @@
    ]
   },
   {
+   "id": "808dd1a8",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -202,6 +209,7 @@
    ]
   },
   {
+   "id": "321af6fa",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -336,6 +344,7 @@
    ]
   },
   {
+   "id": "c7c01f10",
    "cell_type": "markdown",
    "source": [
     "### Observations sur les jeux classiques\n",
@@ -360,6 +369,7 @@
    "metadata": {}
   },
   {
+   "id": "8650edaa",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -385,6 +395,7 @@
    ]
   },
   {
+   "id": "a11e02a8",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -403,6 +414,7 @@
    ]
   },
   {
+   "id": "f03fc076",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -478,6 +490,7 @@
    ]
   },
   {
+   "id": "4fbe8646",
    "cell_type": "markdown",
    "source": [
     "### Recherche de chemins par BFS\n",
@@ -499,6 +512,7 @@
    "metadata": {}
   },
   {
+   "id": "5d5aa63a",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
@@ -603,6 +617,7 @@
    ]
   },
   {
+   "id": "c13e63c1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -627,6 +642,7 @@
    ]
   },
   {
+   "id": "4fe896b5",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -640,6 +656,7 @@
    ]
   },
   {
+   "id": "2b46035b",
    "cell_type": "markdown",
    "source": [
     "### Le graphe des jeux comme espace topologique\n",
@@ -656,6 +673,7 @@
    "metadata": {}
   },
   {
+   "id": "0b0f299f",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
@@ -691,6 +709,7 @@
    ]
   },
   {
+   "id": "e3c2ff9c",
    "cell_type": "markdown",
    "source": [
     "### Interpretation : Generation exhaustive\n",
@@ -712,6 +731,7 @@
    "metadata": {}
   },
   {
+   "id": "b46bd745",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
@@ -775,6 +795,7 @@
    ]
   },
   {
+   "id": "0db7bd38",
    "cell_type": "markdown",
    "source": [
     "### Interpretation : Structure du graphe\n",
@@ -794,6 +815,7 @@
    "metadata": {}
   },
   {
+   "id": "b7357088",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -848,6 +870,7 @@
    ]
   },
   {
+   "id": "9720141f",
    "cell_type": "markdown",
    "source": [
     "### Propriétés du graphe de swaps\n",
@@ -869,6 +892,7 @@
    "metadata": {}
   },
   {
+   "id": "36c9ad34",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -892,6 +916,7 @@
    ]
   },
   {
+   "id": "7df88a60",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -901,6 +926,7 @@
    ]
   },
   {
+   "id": "f32eee45",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
@@ -996,6 +1022,7 @@
    ]
   },
   {
+   "id": "45a48fcb",
    "cell_type": "markdown",
    "source": [
     "### Analyse de la distribution Nash\n",
@@ -1014,6 +1041,7 @@
    "metadata": {}
   },
   {
+   "id": "8d331f11",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1038,6 +1066,7 @@
    ]
   },
   {
+   "id": "aca1b459",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1047,6 +1076,7 @@
    ]
   },
   {
+   "id": "e8fb964c",
    "cell_type": "markdown",
    "source": [
     "### Visualisation des jeux 2x2\n",
@@ -1063,6 +1093,7 @@
    "metadata": {}
   },
   {
+   "id": "feb73066",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
@@ -1147,6 +1178,7 @@
    ]
   },
   {
+   "id": "7f6e9e9c",
    "cell_type": "markdown",
    "source": [
     "### Interpretation : Grille des jeux classiques\n",
@@ -1166,6 +1198,7 @@
    "metadata": {}
   },
   {
+   "id": "6e0e1b3e",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
@@ -1226,6 +1259,7 @@
    ]
   },
   {
+   "id": "011ab58b",
    "cell_type": "markdown",
    "source": [
     "### Que montrent ces transformations ?\n",
@@ -1248,6 +1282,7 @@
    "metadata": {}
   },
   {
+   "id": "7de98af9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1257,6 +1292,7 @@
    ]
   },
   {
+   "id": "af73859c",
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
@@ -1340,6 +1376,7 @@
    ]
   },
   {
+   "id": "cecc31c1",
    "cell_type": "markdown",
    "source": [
     "### Interpretation : Classification des jeux classiques\n",
@@ -1366,6 +1403,7 @@
    "metadata": {}
   },
   {
+   "id": "26d4aa27",
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
@@ -1412,6 +1450,7 @@
    ]
   },
   {
+   "id": "83093d70",
    "cell_type": "markdown",
    "source": [
     "### Interprétation de la distribution des familles\n",
@@ -1429,6 +1468,7 @@
    "metadata": {}
   },
   {
+   "id": "06d75eae",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1438,6 +1478,7 @@
    ]
   },
   {
+   "id": "86722086",
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
@@ -1558,6 +1599,7 @@
    ]
   },
   {
+   "id": "6ac0d1d3",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1586,6 +1628,7 @@
    ]
   },
   {
+   "id": "a37b1a38",
    "cell_type": "markdown",
    "source": [
     "### Résumé visuel : Nash vs Pareto\n",
@@ -1606,6 +1649,7 @@
    "metadata": {}
   },
   {
+   "id": "9136dda5",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1617,6 +1661,7 @@
    ]
   },
   {
+   "id": "b74424db",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1649,6 +1694,7 @@
    ]
   },
   {
+   "id": "9de2ae8e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1665,6 +1711,7 @@
    ]
   },
   {
+   "id": "9791729e",
    "cell_type": "markdown",
    "source": [
     "### Pistes de solution\n\n**Exercice 1** : Utilisez la fonction `find_swap_path()` avec `CLASSIC_GAMES[\"Chicken\"]` et `CLASSIC_GAMES[\"Matching Pennies\"]` pour découvrir la séquence optimale.\n\n**Exercice 2** : Réfléchissez à la structure des meilleures réponses dans un jeu 2x2. Combien de Nash purs peut-on avoir au maximum ?\n\n> **Réflexion** : Pensez à la symétrie des meilleures réponses. Si trois cellules sont des équilibres, pourquoi la quatrième ne le serait-elle pas aussi ?\n\n**Exercice 3** : Utilisez `find_swap_path()` et `show_transformation_chain()` pour visualiser la transformation PD → Harmony."
@@ -1672,6 +1719,7 @@
    "metadata": {}
   },
   {
+   "id": "0a613a2a",
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
@@ -1690,6 +1738,7 @@
    ]
   },
   {
+   "id": "65d97e80",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1710,6 +1759,7 @@
    ]
   },
   {
+   "id": "59ee8ec9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "3ea68e45",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2124,6 +2125,7 @@
    ]
   },
   {
+   "id": "accc1188",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-16-Crossword-CSP.ipynb
@@ -1226,6 +1226,7 @@
    ]
   },
   {
+   "id": "24d2900a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-10-SymbolicAutomata.ipynb
@@ -3784,6 +3784,7 @@
    ]
   },
   {
+   "id": "40a6ca12",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -33500,6 +33500,7 @@
    ]
   },
   {
+   "id": "ea6682c9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-8-DancingLinks.ipynb
@@ -3003,6 +3003,7 @@
    ]
   },
   {
+   "id": "d1a4b81e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -1848,6 +1848,7 @@
    ]
   },
   {
+   "id": "f3c72f85",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "c8d1dc43",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,6 +38,7 @@
    ]
   },
   {
+   "id": "3872729d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -63,6 +65,7 @@
    ]
   },
   {
+   "id": "efce6f53",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -207,6 +210,7 @@
    "source": "// Configuration du repertoire de travail\n// Recherche le repertoire Sudoku depuis le repertoire courant\nusing System;\nusing System.IO;\nusing System.Net.Http;\n\nstring FindSudokuDir()\n{\n    var dir = new DirectoryInfo(Directory.GetCurrentDirectory());\n    while (dir != null)\n    {\n        // Check if we're in the Sudoku directory\n        if (File.Exists(Path.Combine(dir.FullName, \"Sudoku-0-Environment-Csharp.ipynb\")))\n            return dir.FullName;\n        // Check if Sudoku is a subdirectory\n        var candidate = Path.Combine(dir.FullName, \"MyIA.AI.Notebooks\", \"Sudoku\");\n        if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, \"Sudoku-0-Environment-Csharp.ipynb\")))\n            return candidate;\n        dir = dir.Parent;\n    }\n    return Directory.GetCurrentDirectory();\n}\n\nvar sudokuDir = FindSudokuDir();\nDirectory.SetCurrentDirectory(sudokuDir);\n\nconst string ChocoVersion = \"4.10.17\";\nconst string ChocoJar = $\"choco-solver-{ChocoVersion}-jar-with-dependencies.jar\";\nconst string ChocoUrl = $\"https://repo1.maven.org/maven2/org/choco-solver/choco-solver/{ChocoVersion}/{ChocoJar}\";\n\nif (!File.Exists(ChocoJar))\n{\n    Console.WriteLine($\"Telechargement de {ChocoJar} depuis Maven...\");\n    using var client = new HttpClient();\n    var data = client.GetByteArrayAsync(ChocoUrl).Result;\n    File.WriteAllBytes(ChocoJar, data);\n    Console.WriteLine($\"Telecharge: {ChocoJar} ({data.Length} bytes)\");\n}\nelse\n{\n    Console.WriteLine($\"Choco-solver JAR deja present: {ChocoJar}\");\n}\n\nConsole.WriteLine($\"Repertoire de travail: {sudokuDir}\");"
   },
   {
+   "id": "7cf3380a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -214,6 +218,7 @@
    ]
   },
   {
+   "id": "95769451",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -253,6 +258,7 @@
    ]
   },
   {
+   "id": "f518dc4f",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -260,6 +266,7 @@
    ]
   },
   {
+   "id": "8104d0c1",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -298,6 +305,7 @@
    ]
   },
   {
+   "id": "c8113d13",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -305,6 +313,7 @@
    ]
   },
   {
+   "id": "a51ee321",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -534,6 +543,7 @@
    ]
   },
   {
+   "id": "d10922fa",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -543,6 +553,7 @@
    ]
   },
   {
+   "id": "47497b92",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -651,6 +662,7 @@
    ]
   },
   {
+   "id": "6502aeea",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -663,6 +675,7 @@
    ]
   },
   {
+   "id": "2ef76df4",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -909,11 +922,13 @@
    ]
   },
   {
+   "id": "bfe954a3",
    "cell_type": "markdown",
    "metadata": {},
    "source": "> **Note technique** : Le solveur Choco via IKVM ne peut pas s'executer dans l'environnement\n> dotnet-interactive actuel. Deux problemes d'environnement ont ete identifies :\n>\n> 1. **Assembly System.Text.Json v8.0.0.5** : Les DLL IKVM reference cette version (NuGet 8.0.5\n>    target net462), mais le runtime dotnet-interactive fournit la version 8.0.0.0 (.NET 8).\n> 2. **IKVM_HOME non configure** : Le runtime IKVM requiert un repertoire home specifique avec\n>    une structure de fichiers Java/.NET qui n'est pas disponible dans le kernel notebook.\n>\n> Le code Choco (modeles, contraintes, strategies de recherche) est correct et suit l'API\n> Choco-solver 4.10.x. Pour l'executer, il faudrait recompiler les DLL IKVM pour .NET 10\n> ou utiliser un environnement IKVM complet en dehors du notebook interactif.\n>\n> **Statut** : toutes les cellules code executent sans erreur (catch sur l'initialisation IKVM)."
   },
   {
+   "id": "3015e9b9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -921,6 +936,7 @@
    ]
   },
   {
+   "id": "70a90010",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -985,6 +1001,7 @@
    ]
   },
   {
+   "id": "e0e0d4de",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -992,6 +1009,7 @@
    ]
   },
   {
+   "id": "75aa2399",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -1041,6 +1059,7 @@
    "source": "// Test avec le solveur optimise\n// Note : le runtime IKVM necessite un environnement specifique (IKVM_HOME, assembly v8.0.0.5)\n// qui n'est pas disponible dans dotnet-interactive .NET 10. Le code ci-dessous est correct\n// mais ne peut pas s'executer dans cet environnement notebook.\ntry\n{\n    var solver = new ChocoSolverVariableSelector();\n    var stopwatch = System.Diagnostics.Stopwatch.StartNew();\n\n    var solution = solver.Solve(testPuzzle);\n    stopwatch.Stop();\n\n    Console.WriteLine($\"\\nSolution trouvee en {stopwatch.ElapsedMilliseconds} ms:\");\n    Console.WriteLine(solution);\n}\ncatch (System.TypeInitializationException ex)\n{\n    Console.WriteLine($\"[IKVM Runtime] {ex.InnerException?.Message ?? ex.Message}\");\n    Console.WriteLine(\"Le solveur Choco via IKVM ne peut pas s'initialiser dans dotnet-interactive.\");\n    Console.WriteLine(\"Cause : IKVM necessite un runtime Java/.NET specifique non disponible ici.\");\n    Console.WriteLine(\"Le code est correct et fonctionnerait avec un runtime IKVM complet.\");\n}"
   },
   {
+   "id": "43bd982b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1066,6 +1085,7 @@
    ]
   },
   {
+   "id": "fcc13536",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1087,6 +1107,7 @@
    ]
   },
   {
+   "id": "5ecf654c",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1153,11 +1174,13 @@
    ]
   },
   {
+   "id": "4fe11add",
    "cell_type": "markdown",
    "source": "## Resume et perspectives\n\nCe notebook a explore la resolution de Sudoku par **programmation par contraintes** avec Choco-solver, une librairie Java mature appelee depuis C# via le bridge IKVM. L'implementation a couvert deux niveaux de sophistication : un solveur simple (`ChocoSimpleSolver`) posant directement les 27 contraintes `allDifferent` (9 lignes, 9 colonnes, 9 blocs), puis un solveur optimise (`ChocoSolverVariableSelector`) integrant des heuristiques de recherche avancees comme **FirstFail** (equivalent MRV, choisissant la variable au plus petit domaine) et le **noGood recording** pour eviter de revisiter des branches deja ecartees. L'exercice guide sur les N-Reines a permis de transposer le modele CSP vers un autre probleme classique, en exploitant les memes primitives Choco (`allDifferent`, `arithm`, comptage de solutions).\n\nLa comparaison theorique avec OR-Tools, Z3 et python-constraint montre que Choco se situe dans une niche intermediaire : moins performant qu'OR-Tools CP-SAT sur les instances difficiles, mais offrant un acces natif a des contraintes globales optimisees et des strategies de recherche fines (DomOverWDeg, Impact-based search). La limitation technique rencontree avec IKVM dans dotnet-interactive illustre les defis d'interoperabilite Java/.NET en environnement notebook, et confirme l'interet de approaches natives comme OR-Tools pour un usage pedagogique fluide.\n\nLe prochain notebook, **Sudoku-12-Z3-Csharp**, aborde une approche complementaire avec le solveur SMT Z3, qui represente le Sudoku non pas comme un CSP mais comme un systeme de contraintes logiques, offrant des garanties de completude et des techniques de raisonnement differentes (theorie des tableaux, resolution SAT).",
    "metadata": {}
   },
   {
+   "id": "9507e0d9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "89962877",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,6 +44,7 @@
    ]
   },
   {
+   "id": "9016b055",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -80,6 +82,7 @@
    ]
   },
   {
+   "id": "5f811f2c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -89,6 +92,7 @@
    ]
   },
   {
+   "id": "15096401",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -195,6 +199,7 @@
    ]
   },
   {
+   "id": "f93d667a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -204,6 +209,7 @@
    ]
   },
   {
+   "id": "37b248ab",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -360,6 +366,7 @@
    ]
   },
   {
+   "id": "dbdb820e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -371,6 +378,7 @@
    ]
   },
   {
+   "id": "82873937",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -533,6 +541,7 @@
    ]
   },
   {
+   "id": "3f116202",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -542,6 +551,7 @@
    ]
   },
   {
+   "id": "cf526353",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -607,6 +617,7 @@
    ]
   },
   {
+   "id": "326bf677",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -616,6 +627,7 @@
    ]
   },
   {
+   "id": "13185b89",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -698,6 +710,7 @@
    ]
   },
   {
+   "id": "29d71930",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -707,6 +720,7 @@
    ]
   },
   {
+   "id": "7cbb9973",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -801,6 +815,7 @@
    ]
   },
   {
+   "id": "008967cc",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -810,6 +825,7 @@
    ]
   },
   {
+   "id": "9d27fc52",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -850,6 +866,7 @@
    ]
   },
   {
+   "id": "8af4bf6c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -878,6 +895,7 @@
    ]
   },
   {
+   "id": "fdec7a9b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -891,6 +909,7 @@
    ]
   },
   {
+   "id": "abb8c6f4",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -912,6 +931,7 @@
    ]
   },
   {
+   "id": "bb6ac47c",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -969,6 +989,7 @@
    ]
   },
   {
+   "id": "713807d9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -989,6 +1010,7 @@
    ]
   },
   {
+   "id": "5e3f4e98",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -1055,6 +1077,7 @@
    ]
   },
   {
+   "id": "23abb281",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1075,6 +1098,7 @@
    ]
   },
   {
+   "id": "f6b5e689",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -1138,6 +1162,7 @@
    ]
   },
   {
+   "id": "a5cfbbf3",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1165,6 +1190,7 @@
    ]
   },
   {
+   "id": "8a6fd356",
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
@@ -1241,6 +1267,7 @@
    ]
   },
   {
+   "id": "1923ae48",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1263,6 +1290,7 @@
    ]
   },
   {
+   "id": "f1929938",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -4337,6 +4337,7 @@
    ]
   },
   {
+   "id": "7b97ac39",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -3025,6 +3025,7 @@
    ]
   },
   {
+   "id": "b0e544db",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "7e4e8300",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,6 +49,7 @@
    ]
   },
   {
+   "id": "e7eef7c2",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -81,6 +83,7 @@
    ]
   },
   {
+   "id": "c1519e7d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -90,6 +93,7 @@
    ]
   },
   {
+   "id": "43960a6f",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -169,6 +173,7 @@
    ]
   },
   {
+   "id": "3b1ef3eb",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -182,6 +187,7 @@
    ]
   },
   {
+   "id": "50fc7316",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -291,6 +297,7 @@
    ]
   },
   {
+   "id": "bcd9c434",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -298,6 +305,7 @@
    ]
   },
   {
+   "id": "a009c961",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -1175,6 +1183,7 @@
    ]
   },
   {
+   "id": "a4283007",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1197,6 +1206,7 @@
    ]
   },
   {
+   "id": "98dcaa9a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1215,6 +1225,7 @@
    ]
   },
   {
+   "id": "17e91a97",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -1403,6 +1414,7 @@
    ]
   },
   {
+   "id": "87590673",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1414,6 +1426,7 @@
    ]
   },
   {
+   "id": "91759baa",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -1499,6 +1512,7 @@
    ]
   },
   {
+   "id": "84f38449",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1521,6 +1535,7 @@
    ]
   },
   {
+   "id": "78d2808a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1530,6 +1545,7 @@
    ]
   },
   {
+   "id": "ea382a18",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -2370,6 +2386,7 @@
    ]
   },
   {
+   "id": "273eae98",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2392,6 +2409,7 @@
    ]
   },
   {
+   "id": "d9fc4c4d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2411,6 +2429,7 @@
    ]
   },
   {
+   "id": "06f2fcf0",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -2959,6 +2978,7 @@
    ]
   },
   {
+   "id": "53bd72a2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2966,6 +2986,7 @@
    ]
   },
   {
+   "id": "2e053fcd",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2989,6 +3010,7 @@
    ]
   },
   {
+   "id": "96b6b947",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -3027,6 +3049,7 @@
    ]
   },
   {
+   "id": "ed807c60",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -3034,6 +3057,7 @@
    ]
   },
   {
+   "id": "204c7e88",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -3089,6 +3113,7 @@
    ]
   },
   {
+   "id": "c196ae07",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -3111,6 +3136,7 @@
    ]
   },
   {
+   "id": "f79d4d73",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -3120,6 +3146,7 @@
    ]
   },
   {
+   "id": "557f65be",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -18873,6 +18900,7 @@
    ]
   },
   {
+   "id": "034836ed",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18896,6 +18924,7 @@
    ]
   },
   {
+   "id": "c398468b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18903,6 +18932,7 @@
    ]
   },
   {
+   "id": "ed1d4348",
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
@@ -40327,6 +40357,7 @@
    ]
   },
   {
+   "id": "6d298c88",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40336,6 +40367,7 @@
    ]
   },
   {
+   "id": "06ddc48b",
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
@@ -40379,6 +40411,7 @@
    ]
   },
   {
+   "id": "145eb42c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40401,6 +40434,7 @@
    ]
   },
   {
+   "id": "1f5ac673",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40412,6 +40446,7 @@
    ]
   },
   {
+   "id": "c51a81e1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40435,6 +40470,7 @@
    ]
   },
   {
+   "id": "addaced3",
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
@@ -40491,6 +40527,7 @@
    ]
   },
   {
+   "id": "9d6818e7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40524,6 +40561,7 @@
    ]
   },
   {
+   "id": "51643391",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40535,6 +40573,7 @@
    ]
   },
   {
+   "id": "ca4328a9",
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -2591,6 +2591,7 @@
    ]
   },
   {
+   "id": "2bf8d86f",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Linq2Z3.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "eb287323",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -29,6 +30,7 @@
    ]
   },
   {
+   "id": "79b92166",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -170,6 +172,7 @@
    ]
   },
   {
+   "id": "915085d9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -195,6 +198,7 @@
    ]
   },
   {
+   "id": "6b4633a5",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -202,6 +206,7 @@
    ]
   },
   {
+   "id": "30d255b2",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -257,6 +262,7 @@
    ]
   },
   {
+   "id": "a837cc9d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -287,6 +293,7 @@
    ]
   },
   {
+   "id": "0150dd9b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -305,6 +312,7 @@
    ]
   },
   {
+   "id": "304a7525",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -312,6 +320,7 @@
    ]
   },
   {
+   "id": "9df36f62",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -357,6 +366,7 @@
    ]
   },
   {
+   "id": "ae81b995",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -366,6 +376,7 @@
    ]
   },
   {
+   "id": "81be40bd",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -522,6 +533,7 @@
    ]
   },
   {
+   "id": "f48c3bf9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -530,6 +542,7 @@
    ]
   },
   {
+   "id": "975033e5",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -616,6 +629,7 @@
    ]
   },
   {
+   "id": "294ccea7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -637,6 +651,7 @@
    ]
   },
   {
+   "id": "0c63f03c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,6 +659,7 @@
    ]
   },
   {
+   "id": "3f484b9b",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -741,6 +757,7 @@
    ]
   },
   {
+   "id": "f31c4f30",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -761,6 +778,7 @@
    ]
   },
   {
+   "id": "4f41208e",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -858,6 +876,7 @@
    ]
   },
   {
+   "id": "f29c78e7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -865,6 +884,7 @@
    ]
   },
   {
+   "id": "48855bf8",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/OR-tools-Stiegler.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "5100b7cb",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,6 +38,7 @@
    ]
   },
   {
+   "id": "87435baa",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -86,6 +88,7 @@
    ]
   },
   {
+   "id": "e0e061ba",
    "cell_type": "markdown",
    "source": [
     "## Étape 1 : Configuration de l'environnement C#\n",
@@ -102,6 +105,7 @@
    "metadata": {}
   },
   {
+   "id": "9b195341",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -116,6 +120,7 @@
    ]
   },
   {
+   "id": "0471905e",
    "cell_type": "markdown",
    "source": [
     "## Étape 2 : Installation de la bibliothèque OR-Tools\n",
@@ -131,6 +136,7 @@
    "metadata": {}
   },
   {
+   "id": "4165f7f7",
    "cell_type": "markdown",
    "source": [
     "## Étape 3 : Comprendre les données du problème\n",
@@ -179,6 +185,7 @@
    "metadata": {}
   },
   {
+   "id": "979980c7",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -205,6 +212,7 @@
    ]
   },
   {
+   "id": "ecc17726",
    "cell_type": "markdown",
    "source": [
     "## Étape 4 : Importer le solveur de programmation linéaire\n",
@@ -221,6 +229,7 @@
    "metadata": {}
   },
   {
+   "id": "2c2fe901",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -325,6 +334,7 @@
    ]
   },
   {
+   "id": "cb4cdab0",
    "cell_type": "markdown",
    "source": [
     "## Étape 5 : Chargement des données en mémoire\n",
@@ -347,6 +357,7 @@
    "metadata": {}
   },
   {
+   "id": "d44c4bb0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -354,6 +365,7 @@
    ]
   },
   {
+   "id": "dc6a25f5",
    "cell_type": "markdown",
    "source": [
     "## Étape 6 : Création du solveur de programmation linéaire\n",
@@ -394,6 +406,7 @@
    "metadata": {}
   },
   {
+   "id": "983f2cc6",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -420,6 +433,7 @@
    ]
   },
   {
+   "id": "73b1c5cd",
    "cell_type": "markdown",
    "source": [
     "### Interprétation du nombre de variables\n",
@@ -439,6 +453,7 @@
    "metadata": {}
   },
   {
+   "id": "9f878ebe",
    "cell_type": "markdown",
    "source": [
     "## Étape 7 : Définition des variables de décision\n",
@@ -456,6 +471,7 @@
    "metadata": {}
   },
   {
+   "id": "4c031b06",
    "cell_type": "markdown",
    "source": [
     "### Interprétation de la structure du problème\n",
@@ -481,6 +497,7 @@
    "metadata": {}
   },
   {
+   "id": "1ef4f606",
    "cell_type": "markdown",
    "source": [
     "## Étape 8 : Définition des contraintes et de la fonction objectif\n",
@@ -515,6 +532,7 @@
    "metadata": {}
   },
   {
+   "id": "151e8d7c",
    "cell_type": "markdown",
    "source": [
     "## Conclusion et perspectives\n",
@@ -582,6 +600,7 @@
    "metadata": {}
   },
   {
+   "id": "67b52370",
    "cell_type": "markdown",
    "source": [
     "## Exemple guide : Optimisation de Portefeuille Simplifiee\n",
@@ -614,6 +633,7 @@
    "metadata": {}
   },
   {
+   "id": "1df93dcb",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -660,6 +680,7 @@
    ]
   },
   {
+   "id": "be9bbcf3",
    "cell_type": "markdown",
    "source": [
     "## Étape 9 : Résolution du problème et analyse des résultats\n",
@@ -673,6 +694,7 @@
    "metadata": {}
   },
   {
+   "id": "6a158746",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -680,6 +702,7 @@
    ]
   },
   {
+   "id": "97e4c1c3",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -788,6 +811,7 @@
    ]
   },
   {
+   "id": "2f1ad627",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -795,6 +819,7 @@
    ]
   },
   {
+   "id": "0e3259f4",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -858,6 +883,7 @@
    ]
   },
   {
+   "id": "8948ed9a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -865,6 +891,7 @@
    ]
   },
   {
+   "id": "95ae37ca",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -896,6 +923,7 @@
    ]
   },
   {
+   "id": "2ad09dc7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -903,6 +931,7 @@
    ]
   },
   {
+   "id": "431b03e7",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -948,6 +977,7 @@
    ]
   },
   {
+   "id": "7b3b3e26",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -955,6 +985,7 @@
    ]
   },
   {
+   "id": "8e2148b3",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1131,6 +1162,7 @@
    ]
   },
   {
+   "id": "098672a1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1146,6 +1178,7 @@
    ]
   },
   {
+   "id": "d78363c0",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
@@ -1172,6 +1205,7 @@
    ]
   },
   {
+   "id": "1eac7a2e",
    "cell_type": "markdown",
    "source": "## Conclusion\n\nCe notebook a illustre la resolution d'un probleme classique de programmation lineaire avec Google OR-Tools et le solveur GLOP. Vous avez appris a formuler un probleme d'optimisation reel (le regime de Stigler) en variables de decision, contraintes lineaires et fonction objectif, puis a interpreter la solution optimale obtenue en quelques millisecondes.\n\nLes points cles a retenir sont la traduction d'un probleme metier en modele mathematique (77 variables, 9 contraintes), la difference entre solution optimale mathematiquement et solution praticable (absence de variante alimentaire), et les extensions possibles vers des modeles multi-objectifs ou avec contraintes de diversite. Ces competences sont transposables a de nombreux domaines industriels : logistique, finance, planification energetique et ordonnancement.",
    "metadata": {}

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-1-CSharp-Setup.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "2b64981c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,6 +34,7 @@
    ]
   },
   {
+   "id": "41f77862",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -87,6 +89,7 @@
    ]
   },
   {
+   "id": "c3f3a0b6",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,6 +112,7 @@
    ]
   },
   {
+   "id": "7958c9cb",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -129,6 +133,7 @@
    ]
   },
   {
+   "id": "e642d689",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -149,6 +154,7 @@
    ]
   },
   {
+   "id": "c69b0ae1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -160,6 +166,7 @@
    ]
   },
   {
+   "id": "0b2a1c00",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -169,6 +176,7 @@
    ]
   },
   {
+   "id": "8a0bbc1d",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -200,6 +208,7 @@
    ]
   },
   {
+   "id": "c4a90ae2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -215,6 +224,7 @@
    ]
   },
   {
+   "id": "41b7fd8f",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -232,6 +242,7 @@
    ]
   },
   {
+   "id": "2b05ac71",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -241,6 +252,7 @@
    ]
   },
   {
+   "id": "27a202dd",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -262,6 +274,7 @@
    ]
   },
   {
+   "id": "3d2f2117",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -279,6 +292,7 @@
    ]
   },
   {
+   "id": "c4ea3b05",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -291,6 +305,7 @@
    ]
   },
   {
+   "id": "2d6dc951",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -353,6 +368,7 @@
    ]
   },
   {
+   "id": "fc35ac60",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -379,6 +395,7 @@
    ]
   },
   {
+   "id": "11b846cd",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -425,6 +442,7 @@
    ]
   },
   {
+   "id": "64752199",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -459,6 +477,7 @@
    "metadata": {}
   },
   {
+   "id": "d56e8df4",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -474,6 +493,7 @@
    ]
   },
   {
+   "id": "4a4ae99f",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "10e7f893",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,6 +39,7 @@
    ]
   },
   {
+   "id": "f6459281",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -49,6 +51,7 @@
    ]
   },
   {
+   "id": "53133886",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -100,6 +103,7 @@
    ]
   },
   {
+   "id": "9ba0527e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -117,6 +121,7 @@
    ]
   },
   {
+   "id": "92742223",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -160,6 +165,7 @@
    ]
   },
   {
+   "id": "4cf32b71",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -272,6 +278,7 @@
    ]
   },
   {
+   "id": "e49cc186",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -293,6 +300,7 @@
    ]
   },
   {
+   "id": "72d2a80c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -310,6 +318,7 @@
    ]
   },
   {
+   "id": "7410c515",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,6 +330,7 @@
    ]
   },
   {
+   "id": "3041c7ba",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -381,6 +391,7 @@
    ]
   },
   {
+   "id": "26f9c4e2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,6 +409,7 @@
    ]
   },
   {
+   "id": "f5d96f11",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -412,6 +424,7 @@
    ]
   },
   {
+   "id": "95ffc2ff",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -497,6 +510,7 @@
    ]
   },
   {
+   "id": "d162b4e0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -521,6 +535,7 @@
    ]
   },
   {
+   "id": "d5bbcdff",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -538,6 +553,7 @@
    ]
   },
   {
+   "id": "28f51f31",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -648,6 +664,7 @@
    ]
   },
   {
+   "id": "8c36bab2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -671,6 +688,7 @@
    ]
   },
   {
+   "id": "431e484d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -680,6 +698,7 @@
    ]
   },
   {
+   "id": "561943e3",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -812,6 +831,7 @@
    ]
   },
   {
+   "id": "7dc9d166",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -832,6 +852,7 @@
    ]
   },
   {
+   "id": "a2fe9e6a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -859,6 +880,7 @@
    ]
   },
   {
+   "id": "4a2585fc",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -1001,6 +1023,7 @@
    ]
   },
   {
+   "id": "8e9e3e1f",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1028,6 +1051,7 @@
    ]
   },
   {
+   "id": "87c80bec",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1037,6 +1061,7 @@
    ]
   },
   {
+   "id": "49d9380c",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -1100,6 +1125,7 @@
    ]
   },
   {
+   "id": "f250cc5b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1116,6 +1142,7 @@
    ]
   },
   {
+   "id": "2fd14cca",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1129,6 +1156,7 @@
    ]
   },
   {
+   "id": "146feb7d",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1181,6 +1209,7 @@
    ]
   },
   {
+   "id": "b6910cc2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1190,6 +1219,7 @@
    ]
   },
   {
+   "id": "a1c36aeb",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -1242,6 +1272,7 @@
    ]
   },
   {
+   "id": "90efd7b3",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1262,6 +1293,7 @@
    ]
   },
   {
+   "id": "0b9ffcf1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1271,6 +1303,7 @@
    ]
   },
   {
+   "id": "2075a309",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -1329,6 +1362,7 @@
    ]
   },
   {
+   "id": "2944ef16",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1354,6 +1388,7 @@
    ]
   },
   {
+   "id": "279aaf86",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1363,6 +1398,7 @@
    ]
   },
   {
+   "id": "f61b5cd4",
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
@@ -1426,6 +1462,7 @@
    ]
   },
   {
+   "id": "b8a02a0a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1448,6 +1485,7 @@
    ]
   },
   {
+   "id": "555cfd0d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1457,6 +1495,7 @@
    ]
   },
   {
+   "id": "b95bfb90",
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
@@ -1546,6 +1585,7 @@
    ]
   },
   {
+   "id": "f4b5aacb",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1569,6 +1609,7 @@
    ]
   },
   {
+   "id": "ab14289a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1588,6 +1629,7 @@
    ]
   },
   {
+   "id": "238f34c3",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1607,6 +1649,7 @@
    ]
   },
   {
+   "id": "bca0041c",
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
@@ -1725,6 +1768,7 @@
    ]
   },
   {
+   "id": "d4903638",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1746,6 +1790,7 @@
    ]
   },
   {
+   "id": "612d2741",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1757,6 +1802,7 @@
    ]
   },
   {
+   "id": "2d3519c7",
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
@@ -1867,6 +1913,7 @@
    ]
   },
   {
+   "id": "ef7ab444",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1889,6 +1936,7 @@
    ]
   },
   {
+   "id": "ab4412b7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1913,6 +1961,7 @@
    ]
   },
   {
+   "id": "ffddcdbd",
    "cell_type": "code",
    "metadata": {},
    "execution_count": 16,
@@ -1938,6 +1987,7 @@
    ]
   },
   {
+   "id": "d45f0265",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "cc1e41ca",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -28,6 +29,7 @@
    ]
   },
   {
+   "id": "989805da",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,6 +39,7 @@
    ]
   },
   {
+   "id": "ee1f12c2",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -63,6 +66,7 @@
    ]
   },
   {
+   "id": "e9cc9978",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -70,6 +74,7 @@
    ]
   },
   {
+   "id": "ad3417a4",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -102,6 +107,7 @@
    ]
   },
   {
+   "id": "9051c4a1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -150,6 +156,7 @@
    ]
   },
   {
+   "id": "6631f386",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -173,6 +180,7 @@
    ]
   },
   {
+   "id": "18f198c6",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -262,6 +270,7 @@
    ]
   },
   {
+   "id": "d442df83",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -271,6 +280,7 @@
    ]
   },
   {
+   "id": "8df5dc46",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -308,6 +318,7 @@
    ]
   },
   {
+   "id": "841d83f1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -317,6 +328,7 @@
    ]
   },
   {
+   "id": "7856db20",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -457,6 +469,7 @@
    ]
   },
   {
+   "id": "d7416022",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -464,6 +477,7 @@
    ]
   },
   {
+   "id": "dc1b6fd7",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -667,6 +681,7 @@
    ]
   },
   {
+   "id": "cd4b16a1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -674,6 +689,7 @@
    ]
   },
   {
+   "id": "bb084df6",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -916,6 +932,7 @@
    ]
   },
   {
+   "id": "9138db19",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -923,6 +940,7 @@
    ]
   },
   {
+   "id": "71170586",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -932,6 +950,7 @@
    ]
   },
   {
+   "id": "c283dc77",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -1048,6 +1067,7 @@
    ]
   },
   {
+   "id": "a0a770e4",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1055,6 +1075,7 @@
    ]
   },
   {
+   "id": "3ce8a403",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1099,6 +1120,7 @@
    ]
   },
   {
+   "id": "0242cf07",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1106,6 +1128,7 @@
    ]
   },
   {
+   "id": "b71fcd56",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -1152,6 +1175,7 @@
    ]
   },
   {
+   "id": "7a6cb3bc",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1159,6 +1183,7 @@
    ]
   },
   {
+   "id": "423bd7d0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1189,6 +1214,7 @@
    ]
   },
   {
+   "id": "a0b446d3",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -1241,6 +1267,7 @@
    ]
   },
   {
+   "id": "3eeaf39e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1248,6 +1275,7 @@
    ]
   },
   {
+   "id": "279583a2",
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
@@ -1298,6 +1326,7 @@
    ]
   },
   {
+   "id": "4708df05",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1305,6 +1334,7 @@
    ]
   },
   {
+   "id": "b6170a5e",
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
@@ -1358,6 +1388,7 @@
    ]
   },
   {
+   "id": "28057652",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1365,6 +1396,7 @@
    ]
   },
   {
+   "id": "4e3abc2d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1390,6 +1422,7 @@
    ]
   },
   {
+   "id": "292e57c8",
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
@@ -1517,6 +1550,7 @@
    ]
   },
   {
+   "id": "cc867bf3",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1524,6 +1558,7 @@
    ]
   },
   {
+   "id": "a4e9321b",
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
@@ -1602,6 +1637,7 @@
    ]
   },
   {
+   "id": "11dcd037",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1609,6 +1645,7 @@
    ]
   },
   {
+   "id": "d70d8874",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1620,6 +1657,7 @@
    ]
   },
   {
+   "id": "69374d43",
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
@@ -1689,6 +1727,7 @@
    ]
   },
   {
+   "id": "788079d0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1696,6 +1735,7 @@
    ]
   },
   {
+   "id": "996591ac",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1713,6 +1753,7 @@
    ]
   },
   {
+   "id": "1e2449de",
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
@@ -1735,6 +1776,7 @@
    "source": "// Exercice 1 : Remplacez l'URI par une personne de votre choix\n// Exemple : http://dbpedia.org/resource/Marie_Curie\n\n// string exQuery = \"SELECT ?property ?value WHERE { <http://dbpedia.org/resource/Marie_Curie> ?property ?value . } LIMIT 20\";\n// ExecuteAndDisplaySparqlQuery(endpoint, exQuery, 20);\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
+   "id": "1c83c75e",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1748,6 +1790,7 @@
    ]
   },
   {
+   "id": "8a441517",
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
@@ -1770,6 +1813,7 @@
    "source": "// Exercice 2 : Remplacez Q7186 par le QID de votre personne\n\n// string exWd = @\"\n// SELECT ?propertyLabel ?valueLabel\n// WHERE {\n//   wd:Q7186 ?prop ?value .\n//   ?property wikibase:directClaim ?prop .\n//   SERVICE wikibase:label { bd:serviceParam wikibase:language 'fr,en'. }\n// }\n// LIMIT 20\";\n// ExecuteAndDisplaySparqlQuery(wikidataEndpoint, exWd, 20);\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
+   "id": "c7a7ccd7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1783,6 +1827,7 @@
    ]
   },
   {
+   "id": "90c25a18",
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
@@ -1805,6 +1850,7 @@
    "source": "// Exercice 3 : Trouvez les liens owl:sameAs puis interrogez Wikidata\n\n// Etape 1 : Liens owl:sameAs depuis DBpedia\n// string sameAsQ = @\"\n// SELECT ?sameAs\n// WHERE {\n//   <http://dbpedia.org/resource/Paris> owl:sameAs ?sameAs .\n//   FILTER(STRSTARTS(STR(?sameAs), 'http://www.wikidata.org/'))\n// }\";\n// ExecuteAndDisplaySparqlQuery(endpoint, sameAsQ);\n\n// Etape 2 : Details Wikidata (Q90 = Paris)\n// string wdQ = @\"\n// SELECT ?propertyLabel ?valueLabel\n// WHERE {\n//   wd:Q90 ?prop ?value .\n//   ?property wikibase:directClaim ?prop .\n//   SERVICE wikibase:label { bd:serviceParam wikibase:language 'fr'. }\n// }\n// LIMIT 15\";\n// ExecuteAndDisplaySparqlQuery(wikidataEndpoint, wdQ, 15);\n\nConsole.WriteLine(\"Exercice a completer\");"
   },
   {
+   "id": "8aa46fad",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "aac2f270",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -29,6 +30,7 @@
    ]
   },
   {
+   "id": "783c9510",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,6 +40,7 @@
    ]
   },
   {
+   "id": "6b6a532d",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -83,6 +86,7 @@
    ]
   },
   {
+   "id": "73626e5c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -126,6 +130,7 @@
    ]
   },
   {
+   "id": "db438444",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -150,6 +155,7 @@
    ]
   },
   {
+   "id": "8e13a8a2",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -170,6 +176,7 @@
    ]
   },
   {
+   "id": "98b659cd",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -263,6 +270,7 @@
    ]
   },
   {
+   "id": "63fec4aa",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -280,6 +288,7 @@
    ]
   },
   {
+   "id": "70d3a487",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -289,6 +298,7 @@
    ]
   },
   {
+   "id": "ca526232",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -369,6 +379,7 @@
    ]
   },
   {
+   "id": "e11c768a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -387,6 +398,7 @@
    ]
   },
   {
+   "id": "7802d354",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,6 +410,7 @@
    ]
   },
   {
+   "id": "3c530b05",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -449,6 +462,7 @@
    ]
   },
   {
+   "id": "5f11c456",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -456,6 +470,7 @@
    ]
   },
   {
+   "id": "8c899c50",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -520,6 +535,7 @@
    ]
   },
   {
+   "id": "6950d6f0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -538,6 +554,7 @@
    ]
   },
   {
+   "id": "7fe60d4c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -575,6 +592,7 @@
    ]
   },
   {
+   "id": "9b16871c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -584,6 +602,7 @@
    ]
   },
   {
+   "id": "51a5d770",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -709,6 +728,7 @@
    ]
   },
   {
+   "id": "76cdf808",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -730,6 +750,7 @@
    ]
   },
   {
+   "id": "9e1ee1d9",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -739,6 +760,7 @@
    ]
   },
   {
+   "id": "b4c622bd",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -820,6 +842,7 @@
    ]
   },
   {
+   "id": "ec479e56",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -842,6 +865,7 @@
    ]
   },
   {
+   "id": "7262ff54",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -853,6 +877,7 @@
    ]
   },
   {
+   "id": "da3fba7e",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -915,6 +940,7 @@
    ]
   },
   {
+   "id": "1a37b277",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -924,6 +950,7 @@
    ]
   },
   {
+   "id": "9fb2c11f",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1014,6 +1041,7 @@
    ]
   },
   {
+   "id": "e4c19a3c",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1035,11 +1063,13 @@
    ]
   },
   {
+   "id": "073bfe37",
    "cell_type": "markdown",
    "metadata": {},
    "source": "---\n\n## Exercices\n\n### Exercice 1 : Creer un vocabulaire RDFS pour une bibliotheque\n\nCreez un schema RDFS pour un domaine de bibliotheque avec :\n- Classes : `Publication`, `Book`, `Article`, `Author`, `Publisher`\n- Hierarchie : `Book` et `Article` sont des sous-classes de `Publication`\n- Proprietes : `title` (domain: Publication, range: string), `writtenBy` (domain: Publication, range: Author), `publishedBy` (domain: Book, range: Publisher), `year` (domain: Publication, range: integer)\n- Instances : au moins 2 livres et 1 article avec leurs auteurs\n- Appliquez le raisonneur RDFS et verifiez que les types sont bien inferes"
   },
   {
+   "id": "0214ccc5",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -1080,11 +1110,13 @@
    ]
   },
   {
+   "id": "dc59eb0f",
    "cell_type": "markdown",
    "metadata": {},
    "source": "### Exercice 2 : Chaine d'inference par sous-classes\n\nCreez une hierarchie de classes plus profonde pour tester la transitivite :\n- `LivingThing` > `Animal` > `Vertebrate` > `Mammal` > `Primate` > `Human`\n- Creez une instance `alice rdf:type Human`\n- Appliquez l'inference et verifiez que `alice` est aussi de type `LivingThing`, `Animal`, `Vertebrate`, `Mammal` et `Primate`\n- Comptez le nombre de triplets avant et apres inference"
   },
   {
+   "id": "1eb8763b",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -1124,6 +1156,7 @@
    ]
   },
   {
+   "id": "77536030",
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "id": "129fd325",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,6 +40,7 @@
    ]
   },
   {
+   "id": "aa5a3547",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,6 +50,7 @@
    ]
   },
   {
+   "id": "2db697a3",
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -102,6 +105,7 @@
    ]
   },
   {
+   "id": "aa9886b7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -118,6 +122,7 @@
    ]
   },
   {
+   "id": "5478b351",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -170,6 +175,7 @@
    ]
   },
   {
+   "id": "b8f01b54",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -181,6 +187,7 @@
    ]
   },
   {
+   "id": "c3d10a16",
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -354,6 +361,7 @@
    ]
   },
   {
+   "id": "9e19c8ec",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -375,6 +383,7 @@
    ]
   },
   {
+   "id": "88d38d0b",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -398,6 +407,7 @@
    ]
   },
   {
+   "id": "0a5c2659",
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -536,6 +546,7 @@
    ]
   },
   {
+   "id": "4955a2de",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -555,6 +566,7 @@
    ]
   },
   {
+   "id": "08df13bb",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -585,6 +597,7 @@
    ]
   },
   {
+   "id": "42f8cd84",
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
@@ -797,6 +810,7 @@
    ]
   },
   {
+   "id": "a39d5f11",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -820,6 +834,7 @@
    ]
   },
   {
+   "id": "6a623067",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -873,6 +888,7 @@
    ]
   },
   {
+   "id": "c2d6d291",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -884,6 +900,7 @@
    ]
   },
   {
+   "id": "9aabd906",
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
@@ -1109,6 +1126,7 @@
    ]
   },
   {
+   "id": "3656e61d",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1127,6 +1145,7 @@
    ]
   },
   {
+   "id": "89d81bf5",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1136,6 +1155,7 @@
    ]
   },
   {
+   "id": "21e60ad5",
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -1247,6 +1267,7 @@
    ]
   },
   {
+   "id": "541bd226",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1263,6 +1284,7 @@
    ]
   },
   {
+   "id": "3da3ef94",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1272,6 +1294,7 @@
    ]
   },
   {
+   "id": "a4a46f4c",
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
@@ -1417,6 +1440,7 @@
    ]
   },
   {
+   "id": "b5aa5eb0",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1435,6 +1459,7 @@
    ]
   },
   {
+   "id": "82c97407",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1444,6 +1469,7 @@
    ]
   },
   {
+   "id": "b999ac9f",
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
@@ -1589,6 +1615,7 @@
    ]
   },
   {
+   "id": "3f0cd9f7",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1610,6 +1637,7 @@
    ]
   },
   {
+   "id": "ae8fc7a1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1619,6 +1647,7 @@
    ]
   },
   {
+   "id": "a0692f2f",
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
@@ -1755,6 +1784,7 @@
    ]
   },
   {
+   "id": "4e3a5bf1",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1780,6 +1810,7 @@
    ]
   },
   {
+   "id": "c464fa19",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1799,6 +1830,7 @@
    ]
   },
   {
+   "id": "455c0c07",
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
@@ -1836,6 +1868,7 @@
    ]
   },
   {
+   "id": "43f75519",
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1854,6 +1887,7 @@
    ]
   },
   {
+   "id": "d012fb36",
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
@@ -1891,6 +1925,7 @@
    ]
   },
   {
+   "id": "2baa5a9a",
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

Add missing `cell_id` to 23 notebooks in the po-2024 partition (391 cells total).
Cell IDs are required for `NotebookEdit` targeting and nbformat compliance.

### By series
| Series | Notebooks | Cells fixed |
|--------|-----------|-------------|
| Search | App-16, GeneticSharp, Search-8/10/11 | 5 |
| Sudoku | Sudoku-4/10/11/12/13/14/15 | 7 |
| GameTheory | GT-1/3/14, Arrow-1 | 4 |
| SymbolicAI | Linq2Z3, OR-tools-Stiegler, SW-1/2/5/6/7 | 7 |

## Validation proof

- **Diff purity**: 391 insertions, 0 deletions, 0 source changes, 0 output changes
- **JSON validity**: All 176 partition notebooks parse correctly (0 JSONDecodeError)
- **Post-fix scan**: 0 remaining missing cell IDs across entire partition
- **Convention C.3**: metadata-only change, no re-execution required

## Scope

- 23 files changed, 391 insertions
- No code modified, no outputs touched
