### PR TITLE
fix(SC-13): re-execute to restore sequential execution_count

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.002712,
-     "end_time": "2026-05-26T19:22:04.985712",
+     "duration": 0.008679,
+     "end_time": "2026-06-02T12:55:00.392699+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:04.983000",
+     "start_time": "2026-06-02T12:55:00.384020+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.001728,
-     "end_time": "2026-05-26T19:22:04.989480",
+     "duration": 0.005551,
+     "end_time": "2026-06-02T12:55:00.405668+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:04.987752",
+     "start_time": "2026-06-02T12:55:00.400117+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,16 +63,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:22:04.993715Z",
-     "iopub.status.busy": "2026-05-26T19:22:04.993510Z",
-     "iopub.status.idle": "2026-05-26T19:22:04.998593Z",
-     "shell.execute_reply": "2026-05-26T19:22:04.998179Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.435307Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.434979Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.449613Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.445563Z"
     },
     "papermill": {
-     "duration": 0.00907,
-     "end_time": "2026-05-26T19:22:05.000151",
+     "duration": 0.030631,
+     "end_time": "2026-06-02T12:55:00.452220+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:04.991081",
+     "start_time": "2026-06-02T12:55:00.421589+00:00",
      "status": "completed"
     },
     "tags": []
@@ -134,10 +134,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.003466,
-     "end_time": "2026-05-26T19:22:05.007497",
+     "duration": 0.008218,
+     "end_time": "2026-06-02T12:55:00.470778+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.004031",
+     "start_time": "2026-06-02T12:55:00.462560+00:00",
      "status": "completed"
     },
     "tags": []
@@ -150,20 +150,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:14:00.993394Z",
-     "iopub.status.busy": "2026-05-14T07:14:00.992744Z",
-     "iopub.status.idle": "2026-05-14T07:14:01.007169Z",
-     "shell.execute_reply": "2026-05-14T07:14:01.004104Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.484300Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.484071Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.488573Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.488074Z"
     },
     "papermill": {
-     "duration": 0.02775,
-     "end_time": "2026-05-14T07:14:01.007848+00:00",
+     "duration": 0.013182,
+     "end_time": "2026-06-02T12:55:00.489185+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:14:00.980098+00:00",
+     "start_time": "2026-06-02T12:55:00.476003+00:00",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +315,10 @@
    "id": "0e47c508",
    "metadata": {
     "papermill": {
-     "duration": 0.003412,
-     "end_time": "2026-05-26T19:22:05.026849",
+     "duration": 0.002145,
+     "end_time": "2026-06-02T12:55:00.493271+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.023437",
+     "start_time": "2026-06-02T12:55:00.491126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -354,10 +354,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.003659,
-     "end_time": "2026-05-26T19:22:05.033885",
+     "duration": 0.002092,
+     "end_time": "2026-06-02T12:55:00.499190+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.030226",
+     "start_time": "2026-06-02T12:55:00.497098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -376,16 +376,16 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:22:05.041840Z",
-     "iopub.status.busy": "2026-05-26T19:22:05.041574Z",
-     "iopub.status.idle": "2026-05-26T19:22:05.045647Z",
-     "shell.execute_reply": "2026-05-26T19:22:05.045193Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.507599Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.507258Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.515377Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.514443Z"
     },
     "papermill": {
-     "duration": 0.008666,
-     "end_time": "2026-05-26T19:22:05.046520",
+     "duration": 0.014316,
+     "end_time": "2026-06-02T12:55:00.516341+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.037854",
+     "start_time": "2026-06-02T12:55:00.502025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -483,10 +483,10 @@
    "id": "04d191ae",
    "metadata": {
     "papermill": {
-     "duration": 0.002121,
-     "end_time": "2026-05-26T19:22:05.050928",
+     "duration": 0.006075,
+     "end_time": "2026-06-02T12:55:00.525453+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.048807",
+     "start_time": "2026-06-02T12:55:00.519378+00:00",
      "status": "completed"
     },
     "tags": []
@@ -518,10 +518,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.003679,
-     "end_time": "2026-05-26T19:22:05.061298",
+     "duration": 0.004937,
+     "end_time": "2026-06-02T12:55:00.534487+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.057619",
+     "start_time": "2026-06-02T12:55:00.529550+00:00",
      "status": "completed"
     },
     "tags": []
@@ -543,16 +543,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:22:05.069803Z",
-     "iopub.status.busy": "2026-05-26T19:22:05.069448Z",
-     "iopub.status.idle": "2026-05-26T19:22:05.072779Z",
-     "shell.execute_reply": "2026-05-26T19:22:05.072410Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.540525Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.540344Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.544467Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.543805Z"
     },
     "papermill": {
-     "duration": 0.008495,
-     "end_time": "2026-05-26T19:22:05.073509",
+     "duration": 0.007808,
+     "end_time": "2026-06-02T12:55:00.545032+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.065014",
+     "start_time": "2026-06-02T12:55:00.537224+00:00",
      "status": "completed"
     },
     "tags": []
@@ -646,10 +646,10 @@
    "id": "7bb68bfd",
    "metadata": {
     "papermill": {
-     "duration": 0.001771,
-     "end_time": "2026-05-26T19:22:05.077156",
+     "duration": 0.003016,
+     "end_time": "2026-06-02T12:55:00.550337+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.075385",
+     "start_time": "2026-06-02T12:55:00.547321+00:00",
      "status": "completed"
     },
     "tags": []
@@ -680,10 +680,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.002134,
-     "end_time": "2026-05-26T19:22:05.081283",
+     "duration": 0.002193,
+     "end_time": "2026-06-02T12:55:00.556298+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.079149",
+     "start_time": "2026-06-02T12:55:00.554105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -702,16 +702,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:22:05.086718Z",
-     "iopub.status.busy": "2026-05-26T19:22:05.086533Z",
-     "iopub.status.idle": "2026-05-26T19:22:05.090053Z",
-     "shell.execute_reply": "2026-05-26T19:22:05.089557Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.563175Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.562225Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.567719Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.567215Z"
     },
     "papermill": {
-     "duration": 0.007243,
-     "end_time": "2026-05-26T19:22:05.090839",
+     "duration": 0.009453,
+     "end_time": "2026-06-02T12:55:00.568278+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.083596",
+     "start_time": "2026-06-02T12:55:00.558825+00:00",
      "status": "completed"
     },
     "tags": []
@@ -796,10 +796,10 @@
    "id": "0e5f4e57",
    "metadata": {
     "papermill": {
-     "duration": 0.001963,
-     "end_time": "2026-05-26T19:22:05.095065",
+     "duration": 0.004562,
+     "end_time": "2026-06-02T12:55:00.575225+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.093102",
+     "start_time": "2026-06-02T12:55:00.570663+00:00",
      "status": "completed"
     },
     "tags": []
@@ -830,32 +830,38 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.001931,
-     "end_time": "2026-05-26T19:22:05.098948",
+     "duration": 0.003201,
+     "end_time": "2026-06-02T12:55:00.583227+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.097017",
+     "start_time": "2026-06-02T12:55:00.580026+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "---\n\n## 6. Exemple guide et Exercice\n\nL'exemple guidé ci-dessous montre un fuzz test résolu (solution étudiante). Un exercice à compléter suit."
+   "source": [
+    "---\n",
+    "\n",
+    "## 6. Exemple guide et Exercice\n",
+    "\n",
+    "L'exemple guidé ci-dessous montre un fuzz test résolu (solution étudiante). Un exercice à compléter suit."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:22:05.103628Z",
-     "iopub.status.busy": "2026-05-26T19:22:05.103456Z",
-     "iopub.status.idle": "2026-05-26T19:22:05.106989Z",
-     "shell.execute_reply": "2026-05-26T19:22:05.106521Z"
+     "iopub.execute_input": "2026-06-02T12:55:00.590547Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.590231Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.594584Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.593627Z"
     },
     "papermill": {
-     "duration": 0.006831,
-     "end_time": "2026-05-26T19:22:05.107730",
+     "duration": 0.017261,
+     "end_time": "2026-06-02T12:55:00.604307+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.100899",
+     "start_time": "2026-06-02T12:55:00.587046+00:00",
      "status": "completed"
     },
     "tags": []
@@ -869,35 +875,142 @@
      ]
     }
    ],
-   "source": "# Exemple guide : Fuzz tests pour une pile LIFO (solution Mehdi Robardet + Oceane Xiang, TP 2026)\n# Contrat Stack + fuzz tests testFuzz_PushPop et testFuzz_LIFO\n# Solution etudiante : Mehdi Robardet, Oceane Xiang (TP 2026)\n\nEXERCISE_STACK = '''\n// Contrat a tester\ncontract Stack {\n    uint256[] private items;\n    \n    function push(uint256 item) public {\n        items.push(item);\n    }\n    \n    function pop() public returns (uint256) {\n        require(items.length > 0, \"Empty stack\");\n        return items.pop();\n    }\n    \n    function peek() public view returns (uint256) {\n        require(items.length > 0, \"Empty stack\");\n        return items[items.length - 1];\n    }\n    \n    function size() public view returns (uint256) {\n        return items.length;\n    }\n}\n\n// Fuzz test\ncontract StackFuzzTest is Test {\n    Stack stack;\n    \n    function setUp() public {\n        stack = new Stack();\n    }\n    \n    // Invariant: apres push puis pop, size est inchange\n    function testFuzz_PushPop(uint256 value) public {\n        uint256 sizeBefore = stack.size();\n\n        stack.push(value);\n        assertEq(stack.size(), sizeBefore + 1);\n\n        uint256 popped = stack.pop();\n        assertEq(popped, value);\n\n        assertEq(stack.size(), sizeBefore);\n    }\n    \n    // Invariant: LIFO property\n    function testFuzz_LIFO(uint256[] memory values) public {\n        vm.assume(values.length > 0 && values.length <= 100);\n\n        for (uint i = 0; i < values.length; i++) {\n            stack.push(values[i]);\n        }\n\n        for (uint i = values.length; i > 0; i--) {\n            assertEq(stack.pop(), values[i - 1]);\n        }\n    }\n}\n'''\nprint(\"Exemple guide : Stack fuzz tests (solution Mehdi + Oceane)\")"
+   "source": [
+    "# Exemple guide : Fuzz tests pour une pile LIFO (solution Mehdi Robardet + Oceane Xiang, TP 2026)\n",
+    "# Contrat Stack + fuzz tests testFuzz_PushPop et testFuzz_LIFO\n",
+    "# Solution etudiante : Mehdi Robardet, Oceane Xiang (TP 2026)\n",
+    "\n",
+    "EXERCISE_STACK = '''\n",
+    "// Contrat a tester\n",
+    "contract Stack {\n",
+    "    uint256[] private items;\n",
+    "    \n",
+    "    function push(uint256 item) public {\n",
+    "        items.push(item);\n",
+    "    }\n",
+    "    \n",
+    "    function pop() public returns (uint256) {\n",
+    "        require(items.length > 0, \"Empty stack\");\n",
+    "        return items.pop();\n",
+    "    }\n",
+    "    \n",
+    "    function peek() public view returns (uint256) {\n",
+    "        require(items.length > 0, \"Empty stack\");\n",
+    "        return items[items.length - 1];\n",
+    "    }\n",
+    "    \n",
+    "    function size() public view returns (uint256) {\n",
+    "        return items.length;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Fuzz test\n",
+    "contract StackFuzzTest is Test {\n",
+    "    Stack stack;\n",
+    "    \n",
+    "    function setUp() public {\n",
+    "        stack = new Stack();\n",
+    "    }\n",
+    "    \n",
+    "    // Invariant: apres push puis pop, size est inchange\n",
+    "    function testFuzz_PushPop(uint256 value) public {\n",
+    "        uint256 sizeBefore = stack.size();\n",
+    "\n",
+    "        stack.push(value);\n",
+    "        assertEq(stack.size(), sizeBefore + 1);\n",
+    "\n",
+    "        uint256 popped = stack.pop();\n",
+    "        assertEq(popped, value);\n",
+    "\n",
+    "        assertEq(stack.size(), sizeBefore);\n",
+    "    }\n",
+    "    \n",
+    "    // Invariant: LIFO property\n",
+    "    function testFuzz_LIFO(uint256[] memory values) public {\n",
+    "        vm.assume(values.length > 0 && values.length <= 100);\n",
+    "\n",
+    "        for (uint i = 0; i < values.length; i++) {\n",
+    "            stack.push(values[i]);\n",
+    "        }\n",
+    "\n",
+    "        for (uint i = values.length; i > 0; i--) {\n",
+    "            assertEq(stack.pop(), values[i - 1]);\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "'''\n",
+    "print(\"Exemple guide : Stack fuzz tests (solution Mehdi + Oceane)\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "7b3cbeb5",
    "metadata": {
     "papermill": {
-     "duration": 0.001816,
-     "end_time": "2026-05-26T19:22:05.111398",
+     "duration": 0.032323,
+     "end_time": "2026-06-02T12:55:00.671332+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.109582",
+     "start_time": "2026-06-02T12:55:00.639009+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "### Analyse : Fuzz tests pour une pile LIFO\n\n**Solution validée** (Mehdi Robardet, Oceane Xiang, TP 2026) : Les fuzz tests vérifient les deux invariants fondamentaux d'une pile LIFO.\n\n| Test | Invariant | Méthode |\n|------|-----------|---------|\n| `testFuzz_PushPop` | push+pop conserve la taille | Vérifie size avant/après + valeur retournée |\n| `testFuzz_LIFO` | Dernier empilé = premier dépilé | Boucle inverse `i--` pour vérifier l'ordre |\n\n**Points clés** :\n- `vm.assume(values.length > 0 && values.length <= 100)` borne la taille du tableau (sinon out-of-gas)\n- La boucle `for (uint i = values.length; i > 0; i--)` parcourt à l'envers pour vérifier LIFO\n- `assertEq(popped, value)` dans PushPop vérifie que pop retourne exactement la valeur pushée\n- L'approche stateless (setUp recrée la pile) garantit l'indépendance des tests"
+   "source": [
+    "### Analyse : Fuzz tests pour une pile LIFO\n",
+    "\n",
+    "**Solution validée** (Mehdi Robardet, Oceane Xiang, TP 2026) : Les fuzz tests vérifient les deux invariants fondamentaux d'une pile LIFO.\n",
+    "\n",
+    "| Test | Invariant | Méthode |\n",
+    "|------|-----------|---------|\n",
+    "| `testFuzz_PushPop` | push+pop conserve la taille | Vérifie size avant/après + valeur retournée |\n",
+    "| `testFuzz_LIFO` | Dernier empilé = premier dépilé | Boucle inverse `i--` pour vérifier l'ordre |\n",
+    "\n",
+    "**Points clés** :\n",
+    "- `vm.assume(values.length > 0 && values.length <= 100)` borne la taille du tableau (sinon out-of-gas)\n",
+    "- La boucle `for (uint i = values.length; i > 0; i--)` parcourt à l'envers pour vérifier LIFO\n",
+    "- `assertEq(popped, value)` dans PushPop vérifie que pop retourne exactement la valeur pushée\n",
+    "- L'approche stateless (setUp recrée la pile) garantit l'indépendance des tests"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "2d3734f9",
-   "source": "### Exercice : Fuzz tests pour une Queue FIFO\n\nCréez des fuzz tests pour vérifier les propriétés d'une file d'attente (Queue FIFO).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.012211,
+     "end_time": "2026-06-02T12:55:00.698589+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T12:55:00.686378+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Fuzz tests pour une Queue FIFO\n",
+    "\n",
+    "Créez des fuzz tests pour vérifier les propriétés d'une file d'attente (Queue FIFO)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "58201809",
-   "source": "# Exercice : Fuzz tests pour une Queue FIFO\n# TODO etudiant : ecrire des fuzz tests pour verifier les proprietes d'une queue FIFO\n# Indice : inspirez-vous des tests Stack LIFO (Exemple guide ci-dessus)\n# Etape 1 : implementer testFuzz_EnqueueDequeue - verifier que enqueue puis dequeue laisse la taille inchangee\n# Etape 2 : implementer testFuzz_FIFO - verifier que le premier element enfile est le premier defile\n\nEXERCISE_QUEUE = '''\n// Contrat a tester\ncontract Queue {\n    uint256[] private items;\n    uint256 private head;\n\n    function enqueue(uint256 item) public {\n        items.push(item);\n    }\n    \n    function dequeue() public returns (uint256) {\n        require(head < items.length, \"Empty queue\");\n        uint256 value = items[head];\n        head++;\n        return value;\n    }\n    \n    function size() public view returns (uint256) {\n        return items.length - head;\n    }\n}\n\n// Fuzz test\ncontract QueueFuzzTest is Test {\n    Queue queue;\n    \n    function setUp() public {\n        queue = new Queue();\n    }\n    \n    // TODO etudiant : invariant enqueue+dequeue conserve la taille\n    function testFuzz_EnqueueDequeue(uint256 value) public {\n        // TODO etudiant : verifier que enqueue(value) incremente size de 1\n        // TODO etudiant : verifier que dequeue() retourne value\n        // TODO etudiant : verifier que size revient a la valeur initiale\n        pass;\n    }\n    \n    // TODO etudiant : invariant FIFO (first in, first out)\n    function testFuzz_FIFO(uint256[] memory values) public {\n        // TODO etudiant : filtrer avec vm.assume (length > 0, <= 100)\n        // TODO etudiant : enqueue tous les elements\n        // TODO etudiant : dequeue et verifier FIFO (ordre identique a l'insertion)\n        // Indice : contrairement a LIFO, l'ordre de dequeue = l'ordre d'insertion\n        pass;\n    }\n}\n'''\nprint(\"Exercice a completer : Queue FIFO fuzz tests\")",
-   "metadata": {},
-   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T12:55:00.733635Z",
+     "iopub.status.busy": "2026-06-02T12:55:00.731736Z",
+     "iopub.status.idle": "2026-06-02T12:55:00.764487Z",
+     "shell.execute_reply": "2026-06-02T12:55:00.757271Z"
+    },
+    "papermill": {
+     "duration": 0.064578,
+     "end_time": "2026-06-02T12:55:00.772257+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T12:55:00.707679+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -906,6 +1019,63 @@
       "Exercice a completer : Queue FIFO fuzz tests\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice : Fuzz tests pour une Queue FIFO\n",
+    "# TODO etudiant : ecrire des fuzz tests pour verifier les proprietes d'une queue FIFO\n",
+    "# Indice : inspirez-vous des tests Stack LIFO (Exemple guide ci-dessus)\n",
+    "# Etape 1 : implementer testFuzz_EnqueueDequeue - verifier que enqueue puis dequeue laisse la taille inchangee\n",
+    "# Etape 2 : implementer testFuzz_FIFO - verifier que le premier element enfile est le premier defile\n",
+    "\n",
+    "EXERCISE_QUEUE = '''\n",
+    "// Contrat a tester\n",
+    "contract Queue {\n",
+    "    uint256[] private items;\n",
+    "    uint256 private head;\n",
+    "\n",
+    "    function enqueue(uint256 item) public {\n",
+    "        items.push(item);\n",
+    "    }\n",
+    "    \n",
+    "    function dequeue() public returns (uint256) {\n",
+    "        require(head < items.length, \"Empty queue\");\n",
+    "        uint256 value = items[head];\n",
+    "        head++;\n",
+    "        return value;\n",
+    "    }\n",
+    "    \n",
+    "    function size() public view returns (uint256) {\n",
+    "        return items.length - head;\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Fuzz test\n",
+    "contract QueueFuzzTest is Test {\n",
+    "    Queue queue;\n",
+    "    \n",
+    "    function setUp() public {\n",
+    "        queue = new Queue();\n",
+    "    }\n",
+    "    \n",
+    "    // TODO etudiant : invariant enqueue+dequeue conserve la taille\n",
+    "    function testFuzz_EnqueueDequeue(uint256 value) public {\n",
+    "        // TODO etudiant : verifier que enqueue(value) incremente size de 1\n",
+    "        // TODO etudiant : verifier que dequeue() retourne value\n",
+    "        // TODO etudiant : verifier que size revient a la valeur initiale\n",
+    "        pass;\n",
+    "    }\n",
+    "    \n",
+    "    // TODO etudiant : invariant FIFO (first in, first out)\n",
+    "    function testFuzz_FIFO(uint256[] memory values) public {\n",
+    "        // TODO etudiant : filtrer avec vm.assume (length > 0, <= 100)\n",
+    "        // TODO etudiant : enqueue tous les elements\n",
+    "        // TODO etudiant : dequeue et verifier FIFO (ordre identique a l'insertion)\n",
+    "        // Indice : contrairement a LIFO, l'ordre de dequeue = l'ordre d'insertion\n",
+    "        pass;\n",
+    "    }\n",
+    "}\n",
+    "'''\n",
+    "print(\"Exercice a completer : Queue FIFO fuzz tests\")"
    ]
   },
   {
@@ -913,10 +1083,10 @@
    "id": "cell-13",
    "metadata": {
     "papermill": {
-     "duration": 0.00188,
-     "end_time": "2026-05-26T19:22:05.115313",
+     "duration": 0.043444,
+     "end_time": "2026-06-02T12:55:00.853685+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.113433",
+     "start_time": "2026-06-02T12:55:00.810241+00:00",
      "status": "completed"
     },
     "tags": []
@@ -947,7 +1117,16 @@
   {
    "cell_type": "markdown",
    "id": "71eb986a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.035995,
+     "end_time": "2026-06-02T12:55:00.926078+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T12:55:00.890083+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Resume et perspectives\n",
     "\n",
@@ -963,10 +1142,10 @@
    "id": "edcb0a4d",
    "metadata": {
     "papermill": {
-     "duration": 0.002114,
-     "end_time": "2026-05-26T19:22:05.119431",
+     "duration": 0.026937,
+     "end_time": "2026-06-02T12:55:00.992653+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.117317",
+     "start_time": "2026-06-02T12:55:00.965716+00:00",
      "status": "completed"
     },
     "tags": []
@@ -982,10 +1161,10 @@
    "id": "6b11f2d1",
    "metadata": {
     "papermill": {
-     "duration": 0.002182,
-     "end_time": "2026-05-26T19:22:05.123628",
+     "duration": 0.014448,
+     "end_time": "2026-06-02T12:55:01.028529+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:22:05.121446",
+     "start_time": "2026-06-02T12:55:01.014081+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1029,18 +1208,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 4.560276,
-   "end_time": "2026-05-26T19:22:07.785553",
+   "duration": 2.854858,
+   "end_time": "2026-06-02T12:55:01.331900+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc13_output.ipynb",
+   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb",
    "parameters": {},
-   "start_time": "2026-05-26T19:22:03.225277",
+   "start_time": "2026-06-02T12:54:58.477042+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Re-execute `SC-13-Fuzz-Invariants.ipynb` to fix `execution_count:null` on cell idx1 (Fuzz test basique).

### Problem
Cell at index 4 (Fuzz test basique string definition) had `execution_count: null` with output present — the count was lost during the #2092 consolidation (consuming example-guide). This blocked H.3 validation (static checker flags `exec_count is None` as unexecuted).

### Fix
Papermill re-execution with `--kernel python3` (24/24 cells, 2s, 0 errors).

### Verification
```
Before: exec_count sequence = 1, None, 3, 4, 5, 9, 10
After:  exec_count sequence = 1, 2, 3, 4, 5, 6, 7
```

0 null exec_count cells remaining.

### Dispatch reference
ai-01 dispatch 2026-06-02T12:17Z — SC-13 re-exec (re-route from po-2025:CoursIA).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>