### PR TITLE
fix(Sudoku): insert markdown transition between consecutive code cells in Sudoku-17-LLM-Python

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "intro",
    "metadata": {
     "papermill": {
-     "duration": 0.008951,
-     "end_time": "2026-06-01T16:54:25.203812+00:00",
+     "duration": 0.004035,
+     "end_time": "2026-06-02T13:05:06.620430+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.194861+00:00",
+     "start_time": "2026-06-02T13:05:06.616395+00:00",
      "status": "completed"
     },
     "tags": []
@@ -37,16 +37,16 @@
    "id": "f166be80-7bf6-408f-b027-031f96c338ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:25.218557Z",
-     "iopub.status.busy": "2026-06-01T16:54:25.218089Z",
-     "iopub.status.idle": "2026-06-01T16:54:25.237454Z",
-     "shell.execute_reply": "2026-06-01T16:54:25.236280Z"
+     "iopub.execute_input": "2026-06-02T13:05:06.629152Z",
+     "iopub.status.busy": "2026-06-02T13:05:06.628880Z",
+     "iopub.status.idle": "2026-06-02T13:05:06.641278Z",
+     "shell.execute_reply": "2026-06-02T13:05:06.640567Z"
     },
     "papermill": {
-     "duration": 0.028019,
-     "end_time": "2026-06-01T16:54:25.238530+00:00",
+     "duration": 0.017388,
+     "end_time": "2026-06-02T13:05:06.642032+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.210511+00:00",
+     "start_time": "2026-06-02T13:05:06.624644+00:00",
      "status": "completed"
     },
     "tags": []
@@ -60,17 +60,27 @@
      ]
     }
    ],
-   "source": "try:\n    import dotenv\n    import os\n    dotenv.load_dotenv(dotenv_path='../GenAI/.env')\n    DOTENV_AVAILABLE = True\nexcept ImportError:\n    DOTENV_AVAILABLE = False\n    print(\"python-dotenv non disponible. Utilisez les variables d'environnement directement.\")\nprint(f\"Environnement charge : dotenv={'OK' if DOTENV_AVAILABLE else 'absent'}\")"
+   "source": [
+    "try:\n",
+    "    import dotenv\n",
+    "    import os\n",
+    "    dotenv.load_dotenv(dotenv_path='../GenAI/.env')\n",
+    "    DOTENV_AVAILABLE = True\n",
+    "except ImportError:\n",
+    "    DOTENV_AVAILABLE = False\n",
+    "    print(\"python-dotenv non disponible. Utilisez les variables d'environnement directement.\")\n",
+    "print(f\"Environnement charge : dotenv={'OK' if DOTENV_AVAILABLE else 'absent'}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "intro-llm",
    "metadata": {
     "papermill": {
-     "duration": 0.005681,
-     "end_time": "2026-06-01T16:54:25.251074+00:00",
+     "duration": 0.003594,
+     "end_time": "2026-06-02T13:05:06.649198+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.245393+00:00",
+     "start_time": "2026-06-02T13:05:06.645604+00:00",
      "status": "completed"
     },
     "tags": []
@@ -115,16 +125,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:25.266406Z",
-     "iopub.status.busy": "2026-06-01T16:54:25.266125Z",
-     "iopub.status.idle": "2026-06-01T16:54:25.274227Z",
-     "shell.execute_reply": "2026-06-01T16:54:25.273243Z"
+     "iopub.execute_input": "2026-06-02T13:05:06.657194Z",
+     "iopub.status.busy": "2026-06-02T13:05:06.656918Z",
+     "iopub.status.idle": "2026-06-02T13:05:06.661680Z",
+     "shell.execute_reply": "2026-06-02T13:05:06.661021Z"
     },
     "papermill": {
-     "duration": 0.016292,
-     "end_time": "2026-06-01T16:54:25.275123+00:00",
+     "duration": 0.009755,
+     "end_time": "2026-06-02T13:05:06.662188+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.258831+00:00",
+     "start_time": "2026-06-02T13:05:06.652433+00:00",
      "status": "completed"
     },
     "tags": []
@@ -160,10 +170,10 @@
    "id": "5a555dba",
    "metadata": {
     "papermill": {
-     "duration": 0.005264,
-     "end_time": "2026-06-01T16:54:25.286156+00:00",
+     "duration": 0.003379,
+     "end_time": "2026-06-02T13:05:06.669615+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.280892+00:00",
+     "start_time": "2026-06-02T13:05:06.666236+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,16 +188,16 @@
    "id": "puzzle-loader",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:25.299728Z",
-     "iopub.status.busy": "2026-06-01T16:54:25.299465Z",
-     "iopub.status.idle": "2026-06-01T16:54:25.322446Z",
-     "shell.execute_reply": "2026-06-01T16:54:25.321237Z"
+     "iopub.execute_input": "2026-06-02T13:05:06.677556Z",
+     "iopub.status.busy": "2026-06-02T13:05:06.677364Z",
+     "iopub.status.idle": "2026-06-02T13:05:06.702687Z",
+     "shell.execute_reply": "2026-06-02T13:05:06.702003Z"
     },
     "papermill": {
-     "duration": 0.030387,
-     "end_time": "2026-06-01T16:54:25.323461+00:00",
+     "duration": 0.030347,
+     "end_time": "2026-06-02T13:05:06.703355+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.293074+00:00",
+     "start_time": "2026-06-02T13:05:06.673008+00:00",
      "status": "completed"
     },
     "tags": []
@@ -302,10 +312,10 @@
    "id": "6e41d8bb",
    "metadata": {
     "papermill": {
-     "duration": 0.004667,
-     "end_time": "2026-06-01T16:54:25.333297+00:00",
+     "duration": 0.003547,
+     "end_time": "2026-06-02T13:05:06.710494+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.328630+00:00",
+     "start_time": "2026-06-02T13:05:06.706947+00:00",
      "status": "completed"
     },
     "tags": []
@@ -346,10 +356,10 @@
    "id": "api-setup",
    "metadata": {
     "papermill": {
-     "duration": 0.004901,
-     "end_time": "2026-06-01T16:54:25.343487+00:00",
+     "duration": 0.003535,
+     "end_time": "2026-06-02T13:05:06.717722+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.338586+00:00",
+     "start_time": "2026-06-02T13:05:06.714187+00:00",
      "status": "completed"
     },
     "tags": []
@@ -383,16 +393,16 @@
    "id": "171c8f00-f501-4be4-9130-b4422d35c895",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:25.355641Z",
-     "iopub.status.busy": "2026-06-01T16:54:25.355360Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.605086Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.604350Z"
+     "iopub.execute_input": "2026-06-02T13:05:06.725923Z",
+     "iopub.status.busy": "2026-06-02T13:05:06.725711Z",
+     "iopub.status.idle": "2026-06-02T13:05:16.957780Z",
+     "shell.execute_reply": "2026-06-02T13:05:16.956948Z"
     },
     "papermill": {
-     "duration": 12.257479,
-     "end_time": "2026-06-01T16:54:37.605970+00:00",
+     "duration": 10.237167,
+     "end_time": "2026-06-02T13:05:16.958490+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:25.348491+00:00",
+     "start_time": "2026-06-02T13:05:06.721323+00:00",
      "status": "completed"
     },
     "tags": []
@@ -402,23 +412,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: openai in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (2.38.0)\n",
-      "Requirement already satisfied: anyio<5,>=3.5.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (4.13.0)\n",
-      "Requirement already satisfied: distro<2,>=1.7.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (1.9.0)\n",
-      "Requirement already satisfied: httpx<1,>=0.23.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (0.28.1)\n",
-      "Requirement already satisfied: jiter<1,>=0.10.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (0.14.0)\n",
-      "Requirement already satisfied: pydantic<3,>=1.9.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (2.13.4)\n",
-      "Requirement already satisfied: sniffio in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (1.3.1)\n",
-      "Requirement already satisfied: tqdm>4 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (4.67.3)\n",
-      "Requirement already satisfied: typing-extensions<5,>=4.11 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from openai) (4.15.0)\n",
-      "Requirement already satisfied: idna>=2.8 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from anyio<5,>=3.5.0->openai) (3.11)\n",
-      "Requirement already satisfied: certifi in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpx<1,>=0.23.0->openai) (2026.2.25)\n",
-      "Requirement already satisfied: httpcore==1.* in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
-      "Requirement already satisfied: h11>=0.16 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
-      "Requirement already satisfied: annotated-types>=0.6.0 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
-      "Requirement already satisfied: pydantic-core==2.46.4 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pydantic<3,>=1.9.0->openai) (2.46.4)\n",
-      "Requirement already satisfied: typing-inspection>=0.4.2 in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
-      "Requirement already satisfied: colorama in C:\\Users\\jsboi\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python313\\site-packages (from tqdm>4->openai) (0.4.6)\n"
+      "Requirement already satisfied: openai in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (2.24.0)\n",
+      "Requirement already satisfied: anyio<5,>=3.5.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (4.13.0)\n",
+      "Requirement already satisfied: distro<2,>=1.7.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (1.9.0)\n",
+      "Requirement already satisfied: httpx<1,>=0.23.0 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from openai) (0.28.1)\n",
+      "Requirement already satisfied: jiter<1,>=0.10.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (0.14.0)\n",
+      "Requirement already satisfied: pydantic<3,>=1.9.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (2.12.5)\n",
+      "Requirement already satisfied: sniffio in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (1.3.1)\n",
+      "Requirement already satisfied: tqdm>4 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (4.67.3)\n",
+      "Requirement already satisfied: typing-extensions<5,>=4.11 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from openai) (4.15.0)\n",
+      "Requirement already satisfied: idna>=2.8 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from anyio<5,>=3.5.0->openai) (3.11)\n",
+      "Requirement already satisfied: certifi in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from httpx<1,>=0.23.0->openai) (2025.11.12)\n",
+      "Requirement already satisfied: httpcore==1.* in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from httpx<1,>=0.23.0->openai) (1.0.9)\n",
+      "Requirement already satisfied: h11>=0.16 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.41.5 in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from pydantic<3,>=1.9.0->openai) (2.41.5)\n",
+      "Requirement already satisfied: typing-inspection>=0.4.2 in c:\\users\\jsboi\\appdata\\roaming\\python\\python313\\site-packages (from pydantic<3,>=1.9.0->openai) (0.4.2)\n",
+      "Requirement already satisfied: colorama in c:\\users\\jsboi\\appdata\\local\\programs\\python\\python313\\lib\\site-packages (from tqdm>4->openai) (0.4.6)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 25.2 -> 26.1.1\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     }
    ],
@@ -431,10 +450,10 @@
    "id": "cc3b5572",
    "metadata": {
     "papermill": {
-     "duration": 0.004347,
-     "end_time": "2026-06-01T16:54:37.614885+00:00",
+     "duration": 0.004718,
+     "end_time": "2026-06-02T13:05:16.968038+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.610538+00:00",
+     "start_time": "2026-06-02T13:05:16.963320+00:00",
      "status": "completed"
     },
     "tags": []
@@ -456,16 +475,16 @@
    "id": "llm-client",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.625310Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.625055Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.632770Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.632017Z"
+     "iopub.execute_input": "2026-06-02T13:05:16.980382Z",
+     "iopub.status.busy": "2026-06-02T13:05:16.980144Z",
+     "iopub.status.idle": "2026-06-02T13:05:16.989126Z",
+     "shell.execute_reply": "2026-06-02T13:05:16.988190Z"
     },
     "papermill": {
-     "duration": 0.013881,
-     "end_time": "2026-06-01T16:54:37.633426+00:00",
+     "duration": 0.015507,
+     "end_time": "2026-06-02T13:05:16.989979+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.619545+00:00",
+     "start_time": "2026-06-02T13:05:16.974472+00:00",
      "status": "completed"
     },
     "tags": []
@@ -623,10 +642,10 @@
    "id": "approach-1-zero-shot",
    "metadata": {
     "papermill": {
-     "duration": 0.004158,
-     "end_time": "2026-06-01T16:54:37.641840+00:00",
+     "duration": 0.004668,
+     "end_time": "2026-06-02T13:05:16.999537+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.637682+00:00",
+     "start_time": "2026-06-02T13:05:16.994869+00:00",
      "status": "completed"
     },
     "tags": []
@@ -672,16 +691,16 @@
    "id": "zero-shot-solver",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.652446Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.652163Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.659153Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.658470Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.011330Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.011101Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.018324Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.017627Z"
     },
     "papermill": {
-     "duration": 0.013442,
-     "end_time": "2026-06-01T16:54:37.659907+00:00",
+     "duration": 0.013321,
+     "end_time": "2026-06-02T13:05:17.019070+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.646465+00:00",
+     "start_time": "2026-06-02T13:05:17.005749+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,10 +809,10 @@
    "id": "1b1995fd",
    "metadata": {
     "papermill": {
-     "duration": 0.004495,
-     "end_time": "2026-06-01T16:54:37.669215+00:00",
+     "duration": 0.004862,
+     "end_time": "2026-06-02T13:05:17.028387+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.664720+00:00",
+     "start_time": "2026-06-02T13:05:17.023525+00:00",
      "status": "completed"
     },
     "tags": []
@@ -828,10 +847,10 @@
    "id": "approach-2-few-shot",
    "metadata": {
     "papermill": {
-     "duration": 0.005114,
-     "end_time": "2026-06-01T16:54:37.680004+00:00",
+     "duration": 0.004609,
+     "end_time": "2026-06-02T13:05:17.037390+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.674890+00:00",
+     "start_time": "2026-06-02T13:05:17.032781+00:00",
      "status": "completed"
     },
     "tags": []
@@ -886,16 +905,16 @@
    "id": "few-shot-solver",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.694746Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.694166Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.700813Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.699857Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.047672Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.047442Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.053085Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.052158Z"
     },
     "papermill": {
-     "duration": 0.01528,
-     "end_time": "2026-06-01T16:54:37.701813+00:00",
+     "duration": 0.012367,
+     "end_time": "2026-06-02T13:05:17.054093+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.686533+00:00",
+     "start_time": "2026-06-02T13:05:17.041726+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1023,10 +1042,10 @@
    "id": "dec74b42",
    "metadata": {
     "papermill": {
-     "duration": 0.005894,
-     "end_time": "2026-06-01T16:54:37.713315+00:00",
+     "duration": 0.004266,
+     "end_time": "2026-06-02T13:05:17.062749+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.707421+00:00",
+     "start_time": "2026-06-02T13:05:17.058483+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1061,10 +1080,10 @@
    "id": "approach-3-code-interpreter",
    "metadata": {
     "papermill": {
-     "duration": 0.00614,
-     "end_time": "2026-06-01T16:54:37.725659+00:00",
+     "duration": 0.004011,
+     "end_time": "2026-06-02T13:05:17.071058+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.719519+00:00",
+     "start_time": "2026-06-02T13:05:17.067047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1106,16 +1125,16 @@
    "id": "code-interpreter",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.744528Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.744213Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.753535Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.752701Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.080228Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.080030Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.087121Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.086283Z"
     },
     "papermill": {
-     "duration": 0.020033,
-     "end_time": "2026-06-01T16:54:37.754687+00:00",
+     "duration": 0.012737,
+     "end_time": "2026-06-02T13:05:17.087793+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.734654+00:00",
+     "start_time": "2026-06-02T13:05:17.075056+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1217,10 +1236,10 @@
    "id": "a197dc35",
    "metadata": {
     "papermill": {
-     "duration": 0.005123,
-     "end_time": "2026-06-01T16:54:37.765721+00:00",
+     "duration": 0.004163,
+     "end_time": "2026-06-02T13:05:17.096274+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.760598+00:00",
+     "start_time": "2026-06-02T13:05:17.092111+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1257,10 +1276,10 @@
    "id": "benchmark",
    "metadata": {
     "papermill": {
-     "duration": 0.004752,
-     "end_time": "2026-06-01T16:54:37.775454+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-02T13:05:17.104317+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.770702+00:00",
+     "start_time": "2026-06-02T13:05:17.100317+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1277,16 +1296,16 @@
    "id": "benchmark-llm",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.787016Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.786762Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.798238Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.797300Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.114607Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.114368Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.125017Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.124141Z"
     },
     "papermill": {
-     "duration": 0.018875,
-     "end_time": "2026-06-01T16:54:37.799006+00:00",
+     "duration": 0.017481,
+     "end_time": "2026-06-02T13:05:17.126058+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.780131+00:00",
+     "start_time": "2026-06-02T13:05:17.108577+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1433,10 +1452,10 @@
    "id": "fd98ca7b",
    "metadata": {
     "papermill": {
-     "duration": 0.005233,
-     "end_time": "2026-06-01T16:54:37.809099+00:00",
+     "duration": 0.005097,
+     "end_time": "2026-06-02T13:05:17.135902+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.803866+00:00",
+     "start_time": "2026-06-02T13:05:17.130805+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1468,10 +1487,10 @@
    "id": "analysis",
    "metadata": {
     "papermill": {
-     "duration": 0.004851,
-     "end_time": "2026-06-01T16:54:37.818682+00:00",
+     "duration": 0.005783,
+     "end_time": "2026-06-02T13:05:17.148389+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.813831+00:00",
+     "start_time": "2026-06-02T13:05:17.142606+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1522,10 +1541,10 @@
    "id": "exercises",
    "metadata": {
     "papermill": {
-     "duration": 0.004693,
-     "end_time": "2026-06-01T16:54:37.827903+00:00",
+     "duration": 0.006332,
+     "end_time": "2026-06-02T13:05:17.159318+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.823210+00:00",
+     "start_time": "2026-06-02T13:05:17.152986+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1563,16 +1582,16 @@
    "id": "avt0s3bqehi",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.839271Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.839038Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.848879Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.848067Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.170297Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.170000Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.179974Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.179142Z"
     },
     "papermill": {
-     "duration": 0.017044,
-     "end_time": "2026-06-01T16:54:37.849694+00:00",
+     "duration": 0.016702,
+     "end_time": "2026-06-02T13:05:17.180700+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.832650+00:00",
+     "start_time": "2026-06-02T13:05:17.163998+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1840,10 +1859,10 @@
    "id": "10dc39c1",
    "metadata": {
     "papermill": {
-     "duration": 0.004411,
-     "end_time": "2026-06-01T16:54:37.861821+00:00",
+     "duration": 0.004561,
+     "end_time": "2026-06-02T13:05:17.190200+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.857410+00:00",
+     "start_time": "2026-06-02T13:05:17.185639+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1870,16 +1889,16 @@
    "id": "35ffea28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.872951Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.872687Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.879554Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.878506Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.200513Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.200295Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.205925Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.204943Z"
     },
     "papermill": {
-     "duration": 0.01423,
-     "end_time": "2026-06-01T16:54:37.880533+00:00",
+     "duration": 0.01172,
+     "end_time": "2026-06-02T13:05:17.206556+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.866303+00:00",
+     "start_time": "2026-06-02T13:05:17.194836+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1944,21 +1963,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2abed6d2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004636,
+     "end_time": "2026-06-02T13:05:17.215918+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T13:05:17.211282+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Affichage de la grille de reference\n",
+    "\n",
+    "Le solveur `SinglePassLLMSolver` est maintenant defini. Verifions l'etat de notre grille exemple avant de l'utiliser :"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
    "id": "d68e18a5-c358-4804-b906-ef0ee0cc4f12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.897078Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.896702Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.901966Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.900893Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.226368Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.226162Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.229687Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.229022Z"
     },
     "papermill": {
-     "duration": 0.016007,
-     "end_time": "2026-06-01T16:54:37.902880+00:00",
+     "duration": 0.009892,
+     "end_time": "2026-06-02T13:05:17.230563+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.886873+00:00",
+     "start_time": "2026-06-02T13:05:17.220671+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1991,10 +2029,10 @@
    "id": "fefd8a4a",
    "metadata": {
     "papermill": {
-     "duration": 0.00841,
-     "end_time": "2026-06-01T16:54:37.917450+00:00",
+     "duration": 0.004851,
+     "end_time": "2026-06-02T13:05:17.240645+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.909040+00:00",
+     "start_time": "2026-06-02T13:05:17.235794+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2010,10 +2048,10 @@
    "id": "99q8jpxuu94",
    "metadata": {
     "papermill": {
-     "duration": 0.006071,
-     "end_time": "2026-06-01T16:54:37.929666+00:00",
+     "duration": 0.005114,
+     "end_time": "2026-06-02T13:05:17.250333+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.923595+00:00",
+     "start_time": "2026-06-02T13:05:17.245219+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2049,10 +2087,10 @@
    "id": "78722786",
    "metadata": {
     "papermill": {
-     "duration": 0.005896,
-     "end_time": "2026-06-01T16:54:37.941706+00:00",
+     "duration": 0.004646,
+     "end_time": "2026-06-02T13:05:17.259584+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.935810+00:00",
+     "start_time": "2026-06-02T13:05:17.254938+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2096,16 +2134,16 @@
    "id": "3c6c33f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T16:54:37.958470Z",
-     "iopub.status.busy": "2026-06-01T16:54:37.958193Z",
-     "iopub.status.idle": "2026-06-01T16:54:37.965441Z",
-     "shell.execute_reply": "2026-06-01T16:54:37.964505Z"
+     "iopub.execute_input": "2026-06-02T13:05:17.270765Z",
+     "iopub.status.busy": "2026-06-02T13:05:17.270517Z",
+     "iopub.status.idle": "2026-06-02T13:05:17.277213Z",
+     "shell.execute_reply": "2026-06-02T13:05:17.276138Z"
     },
     "papermill": {
-     "duration": 0.01839,
-     "end_time": "2026-06-01T16:54:37.966286+00:00",
+     "duration": 0.013498,
+     "end_time": "2026-06-02T13:05:17.277899+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.947896+00:00",
+     "start_time": "2026-06-02T13:05:17.264401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2187,10 +2225,10 @@
    "id": "conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.005782,
-     "end_time": "2026-06-01T16:54:37.977751+00:00",
+     "duration": 0.004606,
+     "end_time": "2026-06-02T13:05:17.287366+00:00",
      "exception": false,
-     "start_time": "2026-06-01T16:54:37.971969+00:00",
+     "start_time": "2026-06-02T13:05:17.282760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2268,14 +2306,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 16.256206,
-   "end_time": "2026-06-01T16:54:38.445052+00:00",
+   "duration": 13.572287,
+   "end_time": "2026-06-02T13:05:17.753270+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python.ipynb",
    "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-17-LLM-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-01T16:54:22.188846+00:00",
+   "start_time": "2026-06-02T13:05:04.180983+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Insert 1 markdown transition cell between consecutive code pair in `Sudoku-17-LLM-Python.ipynb` (cells 27-28: `SinglePassLLMSolver` class definition followed by `print_grid(example_grid)` call without pedagogical context).

### Cell inserted
| # | Cell ID | Position | Content |
|---|---------|----------|---------|
| 1 | `2abed6d2` | After `35ffea28` (SinglePassLLMSolver class) | "Affichage de la grille de reference" |

## Validation proof

- **Papermill**: 35/35 cells executed, 0 errors, kernel=python3, 16s
- **execution_count**: All 13 code cells have integer exec_count, 0 null
- **0 NotImplementedError** (verified via grep)
- **0 consecutive code pairs** (was 1 before fix)
- **Source changes**: Exactly 1 markdown cell inserted, no code modified
- **Output refresh**: Papermill re-execution refreshed outputs (expected)

## Scope

- 1 file changed, 213 insertions, 175 deletions (output refresh from Papermill re-exec)
- No exercises modified, no code logic changed
- Convention C.3: markdown-only inserts do not require re-execution, but Papermill confirms all outputs valid
