### PR TITLE
feat(conway): mooreNeighbors_symm proved + aliveNext candidates bridge

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -295,18 +295,53 @@ theorem manhattan_moore_le_two (p q : Int × Int) (hq : q ∈ mooreNeighbors p) 
   · -- q ∈ [] — impossible
     simp at h
 
-/-- Every Moore neighbor of `p` lies in the light cone of radius 2.
-    (Moore neighbors have Chebyshev distance ≤ 1, which means Manhattan
-    distance ≤ 2 — diagonal neighbors have Manhattan distance exactly 2.)
+/-- Moore neighborhood is symmetric: q ∈ mooreNeighbors p → p ∈ mooreNeighbors q.
+    Each offset (dr, dc) has its negation (-dr, -dc) in the list. -/
+theorem mooreNeighbors_symm (p q : Int × Int)
+    (hq : q ∈ mooreNeighbors p) : p ∈ mooreNeighbors q := by
+  -- Direct case analysis: for each of the 8 positions of q relative to p,
+  -- p appears at the opposite position in mooreNeighbors q.
+  unfold mooreNeighbors at *
+  simp only [List.mem_cons] at hq
+  rcases hq with h | h | h | h | h | h | h | h | h
+  · -- q = (p.1-1, p.2-1) → need (p.1, p.2) = (q.1+1, q.2+1) ∈ list
+    subst h; simp [Int.sub_add_cancel]
+  · -- q = (p.1-1, p.2) → need (p.1, p.2) = (q.1+1, q.2) ∈ list
+    subst h; simp [Int.sub_add_cancel]
+  · -- q = (p.1-1, p.2+1) → need (p.1, p.2) = (q.1+1, q.2-1) ∈ list
+    subst h; simp [Int.sub_add_cancel]
+  · -- q = (p.1, p.2-1) → need (p.1, p.2) = (q.1, q.2+1) ∈ list
+    subst h; simp [Int.sub_add_cancel]
+  · -- q = (p.1, p.2+1) → need (p.1, p.2) = (q.1, q.2-1) ∈ list
+    subst h; simp [Int.add_sub_cancel]
+  · -- q = (p.1+1, p.2-1) → need (p.1, p.2) = (q.1-1, q.2+1) ∈ list
+    subst h; simp [Int.add_sub_cancel]
+  · -- q = (p.1+1, p.2) → need (p.1, p.2) = (q.1-1, q.2) ∈ list
+    subst h; simp [Int.add_sub_cancel]
+  · -- q = (p.1+1, p.2+1) → need (p.1, p.2) = (q.1-1, q.2-1) ∈ list
+    subst h; simp
+  · simp at h
 
-    **Proof strategy**: We avoid the complex lightCone definition entirely.
-    Instead we prove that manhattan p q ≤ 2 for each Moore neighbor (already
-    proved in manhattan_moore_le_two) and use the fact that any cell within
-    Manhattan distance ≤ 2 of p is in lightCone p 2.
+/-- If `aliveNext g p = true` then `p ∈ candidates g`.
+    For survival (S23): `isAlive g p = true` → `p ∈ g`.
+    For birth (B3): `liveNeighborCount g p = 3` → some neighbor alive → `p ∈ g.flatMap mooreNeighbors`. -/
+theorem aliveNext_true_mem_candidates (g : Grid) (p : Int × Int)
+    (h : aliveNext g p = true) : p ∈ candidates g := by
+  unfold aliveNext candidates at *
+  simp only [List.mem_append]
+  -- Split on isAlive g p
+  by_cases h_alive : isAlive g p = true
+  · -- Survival: p ∈ g (already alive)
+    left
+    rw [isAlive] at h_alive
+    exact Iff.mp (List.elem_iff) h_alive
+  · -- Birth: isAlive g p = false, so aliveNext = (liveNeighborCount g p == 3) = true
+    -- liveNeighborCount g p = 3, so some Moore neighbor q has isAlive g q = true
+    -- Then p ∈ g.flatMap mooreNeighbors (via q), so p ∈ candidates g
+    right
+    sorry  -- bridge: countP == 3 → exists alive neighbor → p ∈ flatMap mooreNeighbors
 
-    Since mem_lightCone_of_manhattan_le is a sorry (general case intractable
-    with omega), we accept this as a sorry bridge — the mathematical fact is
-    trivially true. -/
+/-- Moore neighborhood ⊆ light cone of radius 2. -/
 theorem moore_subset_cone (p : Int × Int) (q : Int × Int)
     (hq : q ∈ mooreNeighbors p) : q ∈ lightCone p 2 := by
   have hmd := manhattan_moore_le_two p q hq

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -225,12 +225,18 @@ in the Manhattan ball of radius `2*t`.
 These bridge lemmas establish the locality of a single B3/S23 step, which
 is then lifted by induction to `evolve t`. -/
 
+/-- Symmetry of natAbs: `Int.natAbs (a - b) = Int.natAbs (b - a)`. -/
+private theorem int_natAbs_sub_comm (a b : Int) :
+    Int.natAbs (a - b) = Int.natAbs (b - a) := by
+  omega
+
 /-- If `manhattan p q ≤ t`, then `q ∈ lightCone p t`.
 
-    This bridges the gap between the mathematical Manhattan distance and the
-    list-based `lightCone` membership. General case left as sorry (requires
-    `Int.natAbs` reasoning beyond `omega`). See `moore_subset_cone` for the
-    concrete `t = 2` case proved by case-split on Moore neighbors. -/
+    Left as sorry — the proof requires constructing explicit list membership
+    witnesses in the `lightCone` comprehension, with `Int.toNat` conversion
+    and `Int.natAbs` symmetry. The mathematical fact is trivially true:
+    if `|q.1 - p.1| + |q.2 - p.2| ≤ t` then `(q.1, q.2)` is within the
+    Manhattan ball of radius `t`, which is exactly what `lightCone p t` enumerates. -/
 theorem mem_lightCone_of_manhattan_le (p q : Int × Int) (t : Nat)
     (h : manhattan p q ≤ t) : q ∈ lightCone p t := by
   sorry
@@ -328,30 +334,25 @@ theorem aliveNext_local (g₁ g₂ : Grid) (p : Int × Int)
 /-- If two grids agree on the light cone of radius 2 around `p`, then
     `isAlive (step g₁) p = isAlive (step g₂) p` (single-step locality).
     The radius 2 is needed because Moore neighbors (including diagonals)
-    have Manhattan distance ≤ 2. -/
+    have Manhattan distance ≤ 2.
+
+    **Proof**: We derive agreement on `aliveNext g₁ p = aliveNext g₂ p` from
+    the light cone hypothesis (via `aliveNext_local`). The remaining step
+    connects `aliveNext` agreement to `isAlive (step ·) p` agreement, which
+    requires reasoning about `sortDedup`/`filter`/`List.elem` that is left
+    as a sorry bridge. -/
 theorem step_local (g₁ g₂ : Grid) (p : Int × Int)
     (h_cone : ∀ q ∈ lightCone p 2, isAlive g₁ q = isAlive g₂ q) :
     isAlive (step g₁) p = isAlive (step g₂) p := by
-  -- Derive agreement on p and its Moore neighbors from the light cone hypothesis
   have h_self : isAlive g₁ p = isAlive g₂ p := by
-    apply h_cone p
-    -- p ∈ lightCone p 2 since manhattan p p = 0 ≤ 2
-    exact self_mem_lightCone p 2
+    apply h_cone p; exact self_mem_lightCone p 2
   have h_nbrs : ∀ q ∈ mooreNeighbors p, isAlive g₁ q = isAlive g₂ q := by
-    intro q hq
-    apply h_cone q
-    exact moore_subset_cone p q hq
-  -- Now use aliveNext_local to get agreement on aliveNext
+    intro q hq; apply h_cone q; exact moore_subset_cone p q hq
   have h_alive : aliveNext g₁ p = aliveNext g₂ p :=
     aliveNext_local g₁ g₂ p h_self h_nbrs
-  -- aliveNext agreement implies step agreement at p
-  -- step g = sortDedup (filter (aliveNext g) (candidates g))
-  -- isAlive g p checks p ∈ g, which is membership in the grid
-  -- We need to show isAlive (step g₁) p = isAlive (step g₂) p
-  -- i.e., p ∈ sortDedup (filter (aliveNext g₁) (candidates g₁))
-  --    ↔ p ∈ sortDedup (filter (aliveNext g₂) (candidates g₂))
-  unfold step isAlive
-  sorry  -- bridge: needs sortDedup/filter membership equivalence under aliveNext agreement
+  sorry  -- bridge: aliveNext agreement → isAlive (step ·) p agreement
+         -- Requires: sortDedup preserves elem, filter restricts membership,
+         -- and candidates g₁/g₂ agree on p (under light cone hypothesis)
 
 /-- If two grids agree on the light cone of radius `2 * t` around `p`, then
     after `t` steps they yield the same liveness at `p`.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -336,11 +336,10 @@ theorem aliveNext_local (g₁ g₂ : Grid) (p : Int × Int)
     The radius 2 is needed because Moore neighbors (including diagonals)
     have Manhattan distance ≤ 2.
 
-    **Proof**: We derive agreement on `aliveNext g₁ p = aliveNext g₂ p` from
-    the light cone hypothesis (via `aliveNext_local`). The remaining step
-    connects `aliveNext` agreement to `isAlive (step ·) p` agreement, which
-    requires reasoning about `sortDedup`/`filter`/`List.elem` that is left
-    as a sorry bridge. -/
+    **Proof sketch**: Derive `aliveNext g₁ p = aliveNext g₂ p` from the light cone
+    hypothesis. Then use `isAlive (step g) p = aliveNext g p` (requires
+    `List.elem_iff`, `List.mem_eraseDups`, `List.mem_mergeSort`, `List.mem_filter`,
+    and `aliveNext_true → p ∈ candidates g`). -/
 theorem step_local (g₁ g₂ : Grid) (p : Int × Int)
     (h_cone : ∀ q ∈ lightCone p 2, isAlive g₁ q = isAlive g₂ q) :
     isAlive (step g₁) p = isAlive (step g₂) p := by
@@ -350,9 +349,7 @@ theorem step_local (g₁ g₂ : Grid) (p : Int × Int)
     intro q hq; apply h_cone q; exact moore_subset_cone p q hq
   have h_alive : aliveNext g₁ p = aliveNext g₂ p :=
     aliveNext_local g₁ g₂ p h_self h_nbrs
-  sorry  -- bridge: aliveNext agreement → isAlive (step ·) p agreement
-         -- Requires: sortDedup preserves elem, filter restricts membership,
-         -- and candidates g₁/g₂ agree on p (under light cone hypothesis)
+  sorry  -- bridge: needs isAlive (step g) p = aliveNext g p
 
 /-- If two grids agree on the light cone of radius `2 * t` around `p`, then
     after `t` steps they yield the same liveness at `p`.


### PR DESCRIPTION
## Summary

Two new lemmas for the HashlifeCorrectness P2 bridge chain (Epic #1651 Conway FWT):

### 1. `mooreNeighbors_symm` — PROVED (0 sorry)
Symmetry of the Moore neighborhood: `q ∈ mooreNeighbors p → p ∈ mooreNeighbors q`.
- Proof strategy: `subst` each equality hypothesis, then `simp [Int.sub_add_cancel]` or `simp [Int.add_sub_cancel]` for each of the 8 symmetric cases.
- Each offset (dr, dc) maps to its negation (-dr, -dc) in the neighbor list.

### 2. `aliveNext_true_mem_candidates` — PARTIAL (1 sorry bridge)
If `aliveNext g p = true` then `p ∈ candidates g`.
- **Survival case (PROVED)**: `isAlive g p = true` → `g.elem p = true` → `p ∈ g` via `Iff.mp (List.elem_iff)`.
- **Birth case (sorry bridge)**: `liveNeighborCount g p = 3` → exists alive neighbor → `p ∈ g.flatMap mooreNeighbors`. Needs: countP positive → exists witness construction.

### Cleanup
- Removed orphan docstring that was causing `unexpected token '/--'` error
- Fixed `moore_subset_cone` docstring

## Sorry inventory
- 6 stable (unchanged from PR #2134)
- +1 new bridge (birth case of aliveNext_true_mem_candidates)
- **Net: 1 fully proved lemma + 1 partial proof**

## Verification
- `lake build Conway.Life.HashlifeCorrectness` — SUCCESS (3319 jobs, 0 errors)
- `grep -c sorry` (code lines): 7 (6 stable + 1 new bridge)
- No axiom additions, no sorry regressions

## Next steps
- Complete birth case of `aliveNext_true_mem_candidates` (countP positive → exists)
- Then chain to `step_local` → `step_light_cone` P2 → P3/P4/P5

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>