### PR TITLE
docs(rules): convention 3 exercices par notebook (#2161)

### DIFF
--- a/.claude/rules/three-exercises-per-notebook.md
+++ b/.claude/rules/three-exercises-per-notebook.md
@@ -1,0 +1,41 @@
+# Convention : 3 exercices par notebook pedagogique
+
+**Source** : mandat user 2026-06-02. Issue #2161.
+**Scope** : tout notebook pedagogique (`MyIA.AI.Notebooks/**/*.ipynb`) sauf setup/environment (0-1 ex OK).
+
+## Regle HARD
+
+Chaque notebook pedagogique vise **>= 3 exercices** (cellules code stub). Les exercices **cohabitent** avec les exemples guids (cf [exercise-example-labeling.md](exercise-example-labeling.md)).
+
+### Classification et stubs
+
+- **Exercice** = cellule code avec stub (`pass` / `return None` / `print("Exercice a completer")` / `result = None  # TODO`). Jamais `raise NotImplementedError` / `assert False` / `1/0` (regle C.1).
+- **Exemple** = cellule code avec solution complete fonctionnelle. Ne JAMAIS stubber.
+- Classification **par contenu**, pas par titre (cf [exercise-example-labeling.md](exercise-example-labeling.md) section "Classification PAR CONTENU").
+
+### Exceptions
+
+| Type de notebook | Minimum exercices | Justification |
+|------------------|-------------------|---------------|
+| Setup / Environment (ex: `*-Setup*`, `*-0-Environment*`) | 0-1 | Configuration seul, pas de concept a exercer |
+| Notebook purement Lean (ex: `*-Lean-*`) | 0-2 | Preuves formelles = paradigme different |
+| Archive / Legacy | 0 | Pas maintenir |
+
+### Placement pedagogique
+
+- Exercices **repartis** dans le notebook (pas tous en fin).
+- Chaque exercice **precede d'un markdown** : contexte + objectif + indices (`# Indice`, `# Etape N`).
+- Exercice **suit un exemple guide** demonstrant le meme concept quand possible.
+
+### Application progressive (rollout)
+
+1. **Notebooks nouvellement cre**s : 3 exercices obligatoires des la creation.
+2. **Notebooks modifies** (enrichissement, fix) : profiter de l'edition pour ajouter des exercices si sous le seuil.
+3. **Rollout systematique** : tracker par famille via issues filles (ne PAS tout faire d'un coup).
+
+## Liens
+
+- [exercise-example-labeling.md](exercise-example-labeling.md) — classification par contenu, interdits, incidents
+- [notebook-conventions.md](notebook-conventions.md) — C.1 stubs, C.2 outputs, C.3 scope re-exec
+- [anti-regression.md](anti-regression.md) — ne pas stripper les exemples resolu
+- CLAUDE.md section C — regles notebooks user 2026-04-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [.claude/rules/proactive-coordination.md](.claude/rules/proactive-coordination.md) - 1 PR/wakeup + main track + side-track async via sous-agents spécialistes (mandat user 2026-05-23)
 - [.claude/rules/user-blocker-signaling.md](.claude/rules/user-blocker-signaling.md) - Re-poke chaque fin de session quand le user bloque (mandat user 2026-05-28, anti-dilution wakeup)
 - [.claude/rules/harness-hygiene.md](.claude/rules/harness-hygiene.md) - Info 3 tiers : harnais succinct / docs pérenne / dashboard éphémère (mandat user 2026-06-01)
+- [.claude/rules/three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md) - Convention >=3 exercices par notebook, rollout progressif (#2161)
 
 ---
 


### PR DESCRIPTION
## Summary

Document the convention "3 exercices par notebook pedagogique" as a formal rule in `.claude/rules/`, per issue #2161 (mandat user 2026-06-02).

## Changes

- **New** `.claude/rules/three-exercises-per-notebook.md` — convention >=3 exercises per notebook
  - Classification by content (stub=Exercice, solution=Exemple) — references `exercise-example-labeling.md`
  - Exceptions: setup (0-1), pure Lean (0-2), archive (0)
  - Placement guidelines: distributed, preceded by markdown context, follows example guide
  - Progressive rollout: new notebooks = mandatory, modifications = opportunistic, systematic via issues filles
- **Updated** `CLAUDE.md` rules list — added pointer to new rule

## No duplication

- Stub patterns: reference C.1 + `notebook-conventions.md` (not re-listed)
- Classification rules: reference `exercise-example-labeling.md` (not re-stated)
- Anti-regression: reference `anti-regression.md` (not re-stated)

## Partition audit (deliverable 3 — dashboard, not repo)

Reported on dashboard workspace CoursIA-2. Summary:

| Family | Notebooks | >=3 exercises | Under 3 | No exercises |
|--------|-----------|---------------|---------|--------------|
| Search | 46 | 21 (46%) | 17 | 8 |
| SymbolicAI | 102 | 22 (22%) | 49 | 31 |
| GameTheory | 28 | 4 (14%) | 19 | 5 |
| Sudoku | 32 | 2 (6%) | 11 | 19 |
| **Total** | **208** | **49 (24%)** | **96** | **63** |

Closes #2161