### PR TITLE
feat(lean): add structured conclusions to Lean-12 and Lean-15

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-12-Sensitivity-Theorem.ipynb
@@ -1031,6 +1031,11 @@
   },
   {
    "cell_type": "markdown",
+   "source": "## Resume\n\n### Concepts cles\n\n| Concept | Definition | Role dans la preuve |\n|---------|------------|---------------------|\n| **Sensibilite $s(f)$** | Nombre maximal de bits dont le changement inverse la sortie | Grandeur a borner |\n| **Sensibilite par blocs $bs(f)$** | Generalisation aux changements par blocs | Intermediaire cle |\n| **Degre $\\deg(f)$** | Degre du polynome representant $f$ | Relie a $s(f)$ via $s(f) \\geq \\sqrt{\\deg(f)}$ |\n| **Matrice signante $A_n$** | Matrice de recurence $A_n^2 = n \\cdot I_{2^n}$ | Outil central de la preuve de Huang |\n| **Theoreme de Huang (2019)** | $s(f) \\geq \\sqrt{n}$ pour toute fonction boolenne non constante sur $n$ bits | Resultat principal |\n\n### Etapes de la preuve formelle en Lean\n\n1. **Comptage de dimension** : L'image d'un sous-espace de dimension $2^{n-1}$ par $A_n$ est de dimension $2^{n-1}$\n2. **Extraction du vecteur propre** : Un vecteur non nul existe dans l'intersection $Im(A_n) \\cap V^\\perp$\n3. **Inegalite sur les normes** : La norme de $A_n v$ est bornee par $\\sqrt{n} \\|v\\|$, donnant $s(f) \\geq \\sqrt{n}$\n\n### Port Lean 4\n\n| Fichier | Lignes | Role |\n|---------|--------|------|\n| `Hypercube.lean` | 125 | Combinatoire de l'hypercube |\n| `VectorSpace.lean` | 132 | Espace vectoriel et dualite |\n| `Operator.lean` | 101 | Operateurs de Huang et Knuth |\n| `MainTheorem.lean` | 132 | Theoreme principal |\n| **Total** | **~490** | **0 sorry** |\n\nLa formalisation originale se trouve dans `Mathlib/Archive/Sensitivity.lean`. Le port CoursIA dans `sensitivity_lean/` adapte les noms pour un usage pedagogique.\n\n### Prochaine etape\n\nLe notebook **Lean-13-Grothendieck-Tribute** explore un autre domaine ou les mathematiques formelles rencontrent Lean : la topologie des schemas.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## 7. Pour aller plus loin\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
@@ -5,7 +5,7 @@
    "id": "036d81a3",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.334913",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.334913",
@@ -47,7 +47,7 @@
    "id": "6e8ff305",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.334913",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.334913",
@@ -200,7 +200,7 @@
    "id": "f328fcf7",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.769056",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.769056",
@@ -227,7 +227,7 @@
    "id": "90619ad3",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.769056",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.769056",
@@ -312,7 +312,7 @@
    "id": "c73e4ec6",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.790124",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.790124",
@@ -445,7 +445,7 @@
    "id": "db25eeee",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:37:25.816373",
      "exception": false,
      "start_time": "2026-06-01T10:37:25.816373",
@@ -927,7 +927,7 @@
    "id": "a0c6b75b",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-01T10:44:39.131021",
      "exception": false,
      "start_time": "2026-06-01T10:44:39.131021",
@@ -982,6 +982,12 @@
     "| 2 | `FreeWillTheorem.lean` | PROUVE (PR #2026) |\n",
     "| 3 | Notebook companion | Ce fichier (Lean-15), mis a jour |"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e3c6ace",
+   "source": "## Resume\n\n### Concepts cles\n\n| Concept | Definition | Importance |\n|---------|------------|------------|\n| **Variables cachees non-contextuelles** | Theorie attribuant des valeurs predeterminees independantes du contexte | Ce que KS exclut |\n| **Table Cabello (18 vecteurs)** | 18 vecteurs de R^4 en 9 bases orthogonales, chaque vecteur dans exactement 2 bases | Structure combinatoire minimale |\n| **Coloration valide** | Fonction vecteurs -> {0,1} avec exactement un 1 par base | Objet dont on prouve l'inexistence |\n| **Argument de parite** | Somme des 1 = 9 (impair) via les bases, mais = 2k (pair) via l'overlap | Contradiction |\n| **Theoreme de libre arbitre** | Si experimentateurs libres, alors particules libres | Generalisation de KS via SPIN+TWIN+MIN |\n\n### Architecture du port Lean 4\n\n| Module | Statut | Sorry | Role |\n|--------|--------|-------|------|\n| `KochenSpecker.lean` | PROUVE | 0 | Parite formelle sur la table Cabello |\n| `FreeWillTheorem.lean` | PROUVE | 0 | Reduction FWT -> KS (SPIN+TWIN+MIN) |\n| `Conway` (workspace) | Compile | 0 production | 3337 jobs, lake build SUCCESS |\n\n### Verifications realisees dans ce notebook\n\n1. **54 paires orthogonales** verifiees (9 bases x 6 paires)\n2. **Invariant d'overlap** : chaque vecteur dans exactement 2 bases\n3. **Recherche exhaustive** : 0/262 144 colorations valides\n4. **Lake build** : exit code 0, 0 sorry de production\n\n### Prochaine etape\n\nPour explorer d'autres resultats de John Conway formalises en Lean, voir [Lean-14-Conway-Tribute](Lean-14-Conway-Tribute.ipynb). Pour la robustesse des reseaux de neurones, voir [Lean-11-TorchLean](Lean-11-TorchLean.ipynb).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Audit des 17 notebooks Lean pour le cours EPITA-IS demain (3 juin). 

**Resultat** : 6/8 notebooks identifies comme manquants avaient DEJA une conclusion complete (Lean-2 a Lean-8). Seuls 2 necessitaient un ajout :

- **Lean-12-Sensitivity-Theorem** : Ajout resume avec table des concepts, etapes de la preuve formelle, et stats du port Lean (490 lignes, 0 sorry)
- **Lean-15-Kochen-Specker** : Ajout resume avec table KS/FWT, architecture du port Lean, et checklist des verifications

## Changes

| Notebook | Modification |
|----------|-------------|
| Lean-12-Sensitivity-Theorem | +1 cell markdown (resume avant section 7) |
| Lean-15-Kochen-Specker | +1 cell markdown (resume avant section 9) |

## Validation

- Insertions uniquement (18 insertions, 7 deletions mineures de reformatage)
- Pas de cellule code modifiee = pas de re-execution necessaire
- Structure pedagogique conforme (table recapitulative + prochaine etape)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>