### PR TITLE
enrich(Sudoku-5-PSO-Python): add error breakdown + convergence exercises (1->3, #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -194,7 +194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
+      "Dossier Puzzles: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
      ]
     }
    ],
@@ -1132,7 +1132,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution trouvee en 1.99s:\n",
+      "Solution trouvee en 2.24s:\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
       "1 7 4 | 9 6 3 | 8 2 5 \n",
       "5 3 8 | 4 2 7 | 1 6 9 \n",
@@ -1199,6 +1199,62 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-pso-error-breakdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Decomposition des erreurs par type\n",
+    "\n",
+    "### Contexte\n",
+    "Le PSO minimise une fonction d'erreur globale. Comprendre **quels types de contraintes** sont violes aide a diagnostiquer les difficultes de resolution.\n",
+    "\n",
+    "### Objectif\n",
+    "Implementez la fonction  qui decompose le nombre de violations en erreurs de lignes, colonnes et blocs.\n",
+    "\n",
+    "### Ce que la fonction doit retourner\n",
+    "Un dictionnaire avec 3 cles : , , , chacune contenant le nombre de doublons trouves.\n",
+    "\n",
+    "### Indices\n",
+    "- Pour chaque ligne : comptez les valeurs en double avec \n",
+    "- Un doublon =  pour chaque valeur\n",
+    "- Les blocs 3x3 sont indexes par "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex-pso-error-breakdown-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice count_errors_by_type a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def count_errors_by_type(grid: np.ndarray) -> dict:\n",
+    "    \"\"\"Decompose les erreurs d'une grille par type de contrainte.\n",
+    "\n",
+    "    Args:\n",
+    "        grid: Grille 9x9 en array numpy\n",
+    "\n",
+    "    Returns:\n",
+    "        Dictionnaire {\"rows\": int, \"cols\": int, \"blocks\": int}\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Compter les doublons par ligne\n",
+    "    # Etape 2 : Compter les doublons par colonne\n",
+    "    # Etape 3 : Compter les doublons par bloc 3x3\n",
+    "    return {\"rows\": 0, \"cols\": 0, \"blocks\": 0}  # TODO etudiant\n",
+    "\n",
+    "\n",
+    "# Testez votre fonction\n",
+    "print(\"Exercice count_errors_by_type a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "execution_count": null,
    "id": "9f0f856f",
    "metadata": {
@@ -1218,7 +1274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "16434222",
    "metadata": {
     "execution": {
@@ -1251,7 +1307,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK, 36 vides, 1.52s\n",
+      "  Puzzle 1: OK, 36 vides, 1.34s\n",
       "Tentative 1/5\n",
       "  Epoch 0, Best error: 29\n"
      ]
@@ -1267,22 +1323,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 2: OK, 49 vides, 28.80s\n",
+      "  Puzzle 2: OK, 49 vides, 28.88s\n",
       "\n",
       "Resume:\n",
       "  Resolus: 2/2\n",
-      "  Temps total: 30.32s\n",
-      "  Temps moyen: 15.16s\n"
+      "  Temps total: 30.22s\n",
+      "  Temps moyen: 15.11s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'solved': True, 'errors': 0, 'time': 1.5157010555267334},\n",
-       " {'solved': True, 'errors': 0, 'time': 28.79954218864441}]"
+       "[{'solved': True, 'errors': 0, 'time': 1.3386695384979248},\n",
+       " {'solved': True, 'errors': 0, 'time': 28.876943588256836}]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1368,6 +1424,64 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-pso-convergence",
+   "metadata": {},
+   "source": [
+    "## Exercice : Detection de convergence\n",
+    "\n",
+    "### Contexte\n",
+    "Le PSO s'arrete apres un nombre fixe d'epochs. Mais si la solution stagne, continuer est inutile. Un **critere de convergence** permet d'arreter plus tot.\n",
+    "\n",
+    "### Objectif\n",
+    "Implementez la fonction  qui detecte si le PSO a converge, en verifiant que l'erreur n'a pas baisse depuis un nombre donne d'epochs.\n",
+    "\n",
+    "### Ce que la fonction doit verifier\n",
+    "1. La liste  contient au moins  elements\n",
+    "2. La difference entre l'erreur la plus recente et celle d'il y a  epochs est inferieure a \n",
+    "\n",
+    "### Indices\n",
+    "- Comparez  avec \n",
+    "- Si la liste a moins de  elements, retournez  (pas assez de donnees)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ex-pso-convergence-code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice has_converged a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def has_converged(error_history: list, patience: int = 50, threshold: float = 0.01) -> bool:\n",
+    "    \"\"\"Detecte si le PSO a converge.\n",
+    "\n",
+    "    Args:\n",
+    "        error_history: Liste des erreurs par epoch\n",
+    "        patience: Nombre d'epochs sans amelioration avant convergence\n",
+    "        threshold: Seuil de variation considere comme stagnation\n",
+    "\n",
+    "    Returns:\n",
+    "        True si le PSO a converge (stagnation detectee)\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Verifier que la liste a assez d'elements\n",
+    "    # Etape 2 : Comparer erreur recente vs erreur d'il y a patience epochs\n",
+    "    # Etape 3 : Retourner True si la variation est inferieure au seuil\n",
+    "    return False  # TODO etudiant : implementez la detection\n",
+    "\n",
+    "\n",
+    "# Testez votre fonction\n",
+    "print(\"Exercice has_converged a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "execution_count": null,
    "id": "1afbd0e5",
    "metadata": {
@@ -1387,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "5487473c",
    "metadata": {
     "execution": {
@@ -1419,7 +1533,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Conservateur: 1.09s - Succes\n",
+      "Conservateur: 1.13s - Succes\n",
       "Tentative 1/10\n",
       "  Epoch 0, Best error: 23\n"
      ]
@@ -1428,7 +1542,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Standard: 1.99s - Succes\n",
+      "Standard: 1.96s - Succes\n",
       "Tentative 1/20\n",
       "  Epoch 0, Best error: 21\n"
      ]
@@ -1437,7 +1551,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agressif: 2.55s - Succes\n"
+      "Agressif: 2.42s - Succes\n"
      ]
     }
    ],
@@ -1520,7 +1634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "b879f289",
    "metadata": {
     "execution": {
@@ -1665,7 +1779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "wys24hodpo",
    "metadata": {
     "execution": {


### PR DESCRIPTION
## Summary

Add 2 exercises to Sudoku-5-PSO-Python to reach convention #2161 threshold.

### Changes

**Exercise 1: count_errors_by_type** (after first test, section 5)
- Decompose PSO error into row/column/block violation counts
- Stub: `return {"rows": 0, "cols": 0, "blocks": 0}  # TODO etudiant`

**Exercise 2: has_converged** (after benchmark, section 6)
- Implement stagnation-based early stopping
- Stub: `return False  # TODO etudiant`

**Exercise 3: Hybrid PSO with local search** (existing, section 8)

### Validation
- Papermill: 14/14 code cells, 0 errors
- C.1 compliant, C.2 outputs captured
- Distribution: sections 5, 6, 8