### PR TITLE
enrich(Sudoku-9-Python): add 3 distributed exercises (0->3, #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "403f4734",
    "metadata": {
     "papermill": {
-     "duration": 0.003725,
-     "end_time": "2026-04-25T15:03:11.160592",
+     "duration": 0.024887,
+     "end_time": "2026-06-02T17:25:48.506348+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.156867",
+     "start_time": "2026-06-02T17:25:48.481461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,16 +44,16 @@
      "start_time": "2026-04-20T08:09:57.302191300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.167748Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.167286Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.623825Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.622849Z"
+     "iopub.execute_input": "2026-06-02T17:25:48.576579Z",
+     "iopub.status.busy": "2026-06-02T17:25:48.575247Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.090307Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.089633Z"
     },
     "papermill": {
-     "duration": 0.461381,
-     "end_time": "2026-04-25T15:03:11.625069",
+     "duration": 0.554963,
+     "end_time": "2026-06-02T17:25:49.091089+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.163688",
+     "start_time": "2026-06-02T17:25:48.536126+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,7 +63,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NetworkX version: 3.4.2\n",
+      "NetworkX version: 3.6.1\n",
       "Graphes Sudoku disponibles: True\n"
      ]
     }
@@ -83,10 +83,10 @@
    "id": "e3b99014",
    "metadata": {
     "papermill": {
-     "duration": 0.002578,
-     "end_time": "2026-04-25T15:03:11.630554",
+     "duration": 0.004673,
+     "end_time": "2026-06-02T17:25:49.101721+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.627976",
+     "start_time": "2026-06-02T17:25:49.097048+00:00",
      "status": "completed"
     },
     "tags": []
@@ -120,16 +120,16 @@
      "start_time": "2026-04-20T08:11:59.150112600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.636806Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.636438Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.643204Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.642262Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.115216Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.114518Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.133417Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.132658Z"
     },
     "papermill": {
-     "duration": 0.011197,
-     "end_time": "2026-04-25T15:03:11.644231",
+     "duration": 0.026635,
+     "end_time": "2026-06-02T17:25:49.134696+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.633034",
+     "start_time": "2026-06-02T17:25:49.108061+00:00",
      "status": "completed"
     },
     "tags": []
@@ -170,10 +170,10 @@
    "id": "b6bb9148",
    "metadata": {
     "papermill": {
-     "duration": 0.002563,
-     "end_time": "2026-04-25T15:03:11.649553",
+     "duration": 0.005052,
+     "end_time": "2026-06-02T17:25:49.145460+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.646990",
+     "start_time": "2026-06-02T17:25:49.140408+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,16 +194,16 @@
      "start_time": "2026-04-20T08:12:07.647028300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.656627Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.655960Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.663615Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.662652Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.158268Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.158068Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.174209Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.170834Z"
     },
     "papermill": {
-     "duration": 0.012401,
-     "end_time": "2026-04-25T15:03:11.664638",
+     "duration": 0.026224,
+     "end_time": "2026-06-02T17:25:49.177401+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.652237",
+     "start_time": "2026-06-02T17:25:49.151177+00:00",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "50545bc9",
    "metadata": {
     "papermill": {
-     "duration": 0.003292,
-     "end_time": "2026-04-25T15:03:11.671010",
+     "duration": 0.020008,
+     "end_time": "2026-06-02T17:25:49.208376+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.667718",
+     "start_time": "2026-06-02T17:25:49.188368+00:00",
      "status": "completed"
     },
     "tags": []
@@ -265,10 +265,10 @@
    "id": "b9920bf3",
    "metadata": {
     "papermill": {
-     "duration": 0.002889,
-     "end_time": "2026-04-25T15:03:11.677044",
+     "duration": 0.007688,
+     "end_time": "2026-06-02T17:25:49.231975+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.674155",
+     "start_time": "2026-06-02T17:25:49.224287+00:00",
      "status": "completed"
     },
     "tags": []
@@ -287,16 +287,16 @@
      "start_time": "2026-04-20T08:14:06.261561900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.684538Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.683968Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.695018Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.693733Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.246518Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.246133Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.253557Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.252824Z"
     },
     "papermill": {
-     "duration": 0.016633,
-     "end_time": "2026-04-25T15:03:11.696610",
+     "duration": 0.016175,
+     "end_time": "2026-06-02T17:25:49.254273+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.679977",
+     "start_time": "2026-06-02T17:25:49.238098+00:00",
      "status": "completed"
     },
     "tags": []
@@ -378,13 +378,106 @@
   },
   {
    "cell_type": "markdown",
+   "id": "874f2b77",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004841,
+     "end_time": "2026-06-02T17:25:49.263520+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.258679+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Categoriser les voisins d'une cellule\n",
+    "\n",
+    "**Objectif** : Ecrire une fonction qui categorise les voisins d'une cellule dans le graphe Sudoku en trois groupes : ligne, colonne et bloc.\n",
+    "\n",
+    "**Contexte** : Chaque cellule du Sudoku a exactement 20 voisins dans le graphe de contraintes. Ces voisins se repartissent en :\n",
+    "- **8 voisins de ligne** (meme ligne, sauf la cellule elle-meme)\n",
+    "- **8 voisins de colonne** (meme colonne, sauf la cellule elle-meme)\n",
+    "- **4 voisins de bloc** (meme bloc 3x3, hors ligne et colonne deja comptees)\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Convertir `(row, col)` en index de sommet : `vertex = row * 9 + col`\n",
+    "2. Parcourir les voisins dans le graphe `G` : `G.neighbors(vertex)`\n",
+    "3. Pour chaque voisin, determiner s'il est dans la meme ligne, la meme colonne ou le meme bloc\n",
+    "4. Retourner un dictionnaire avec les trois categories\n",
+    "\n",
+    "**Indice** : Un voisin `v` est dans la meme ligne si `v // 9 == row`, dans la meme colonne si `v % 9 == col`, et dans le meme bloc si les deux coordonnees de bloc `(r//3, c//3)` coincident."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f74254ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:25:49.274563Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.274266Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.285319Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.284138Z"
+    },
+    "papermill": {
+     "duration": 0.019323,
+     "end_time": "2026-06-02T17:25:49.287096+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.267773+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellule (4,4) : 0 voisins au total\n",
+      "  row: 0 voisins\n",
+      "  column: 0 voisins\n",
+      "  block: 0 voisins\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def categorize_neighbors(row: int, col: int, G) -> dict:\n",
+    "    \"\"\"\n",
+    "    Categorise les voisins d'une cellule dans le graphe Sudoku.\n",
+    "    \n",
+    "    Args:\n",
+    "        row, col: coordonnees de la cellule (0-indexed)\n",
+    "        G: graphe NetworkX du Sudoku\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec cles 'row', 'column', 'block' contenant les listes de sommets voisins\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer la categorisation des voisins\n",
+    "    # Etape 1 : convertir (row, col) en index de sommet\n",
+    "    # Etape 2 : parcourir G.neighbors(vertex)\n",
+    "    # Etape 3 : classer chaque voisin en ligne/colonne/bloc\n",
+    "    # Etape 4 : retourner le dictionnaire\n",
+    "    return {\"row\": [], \"column\": [], \"block\": []}  # TODO etudiant : remplacer par le calcul reel\n",
+    "\n",
+    "# Test sur la cellule (4, 4) -- centre de la grille\n",
+    "G_test = nx.sudoku_graph()\n",
+    "neighbors = categorize_neighbors(4, 4, G_test)\n",
+    "print(f\"Cellule (4,4) : {sum(len(v) for v in neighbors.values())} voisins au total\")\n",
+    "for cat, verts in neighbors.items():\n",
+    "    print(f\"  {cat}: {len(verts)} voisins\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "69b3809b",
    "metadata": {
     "papermill": {
-     "duration": 0.003955,
-     "end_time": "2026-04-25T15:03:11.703772",
+     "duration": 0.006262,
+     "end_time": "2026-06-02T17:25:49.298818+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.699817",
+     "start_time": "2026-06-02T17:25:49.292556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -397,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "e52a9d76",
    "metadata": {
     "ExecuteTime": {
@@ -405,16 +498,16 @@
      "start_time": "2026-04-20T08:15:12.638358300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.712276Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.711790Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.724380Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.723466Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.320807Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.319636Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.337751Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.337086Z"
     },
     "papermill": {
-     "duration": 0.017943,
-     "end_time": "2026-04-25T15:03:11.725584",
+     "duration": 0.033562,
+     "end_time": "2026-06-02T17:25:49.338576+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.707641",
+     "start_time": "2026-06-02T17:25:49.305014+00:00",
      "status": "completed"
     },
     "tags": []
@@ -437,7 +530,7 @@
       "7 . 5 | 2 . . | 3 . 4 \n",
       ". 8 . | . 4 1 | 9 5 . \n",
       "\n",
-      "Resolu: True en 2.56 ms\n",
+      "Resolu: True en 1.58 ms\n",
       "Noeuds explores: 37\n",
       "Backtracks: 0\n",
       "\n",
@@ -527,10 +620,10 @@
    "id": "4taoqji9bpb",
    "metadata": {
     "papermill": {
-     "duration": 0.003014,
-     "end_time": "2026-04-25T15:03:11.731927",
+     "duration": 0.006162,
+     "end_time": "2026-06-02T17:25:49.350217+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.728913",
+     "start_time": "2026-06-02T17:25:49.344055+00:00",
      "status": "completed"
     },
     "tags": []
@@ -556,13 +649,99 @@
   },
   {
    "cell_type": "markdown",
+   "id": "188eec04",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003899,
+     "end_time": "2026-06-02T17:25:49.358597+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.354698+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Trouver la cellule la plus contrainte (MRV)\n",
+    "\n",
+    "**Objectif** : Implementer l'heuristique MRV (Minimum Remaining Values) pour identifier la cellule la plus contrainte d'une grille partiellement remplie.\n",
+    "\n",
+    "**Contexte** : L'heuristique MRV est au coeur du solveur backtracking efficace. Elle choisit la cellule qui a le moins de valeurs possibles, car c'est celle qui echouera le plus vite si un mauvais choix est fait — permettant de couper des branches inutiles tot.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Pour chaque cellule vide (valeur 0), calculer les couleurs disponibles via les voisins dans le graphe\n",
+    "2. Trouver la cellule avec le minimum de couleurs disponibles\n",
+    "3. Retourner ses coordonnees et le nombre de couleurs disponibles\n",
+    "\n",
+    "**Indice** : Inspirez-vous de `get_available_colors` et `select_mrv_vertex` du solveur ci-dessus, mais adaptez pour travailler avec `SudokuGrid` et retourner un resultat comprehensible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "eb92f3d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:25:49.375077Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.373725Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.385821Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.384684Z"
+    },
+    "papermill": {
+     "duration": 0.024617,
+     "end_time": "2026-06-02T17:25:49.387040+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.362423+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellule la plus contrainte : (-1, -1) avec 0 couleur(s) disponible(s)\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def find_most_constrained_cell(grid: SudokuGrid, G) -> Tuple[int, int, int]:\n",
+    "    \"\"\"\n",
+    "    Trouve la cellule vide la plus contrainte (MRV) dans la grille.\n",
+    "    \n",
+    "    Args:\n",
+    "        grid: grille de Sudoku partiellement remplie\n",
+    "        G: graphe NetworkX du Sudoku\n",
+    "    \n",
+    "    Returns:\n",
+    "        (row, col, num_available_colors) de la cellule la plus contrainte\n",
+    "        Retourne (-1, -1, 0) si la grille est complete.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer l'heuristique MRV\n",
+    "    # Etape 1 : convertir la grille en coloration (grid.to_coloring())\n",
+    "    # Etape 2 : pour chaque sommet non colore, calculer les couleurs disponibles\n",
+    "    # Etape 3 : trouver le sommet avec le minimum de couleurs disponibles\n",
+    "    # Etape 4 : convertir l'index du sommet en (row, col) et retourner\n",
+    "    return (-1, -1, 0)  # TODO etudiant : remplacer par le calcul reel\n",
+    "\n",
+    "# Test sur le puzzle facile\n",
+    "test_mrv = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "G_mrv = nx.sudoku_graph()\n",
+    "row, col, n_colors = find_most_constrained_cell(test_mrv, G_mrv)\n",
+    "print(f\"Cellule la plus contrainte : ({row}, {col}) avec {n_colors} couleur(s) disponible(s)\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6f0fd4c0",
    "metadata": {
     "papermill": {
-     "duration": 0.003181,
-     "end_time": "2026-04-25T15:03:11.738131",
+     "duration": 0.009755,
+     "end_time": "2026-06-02T17:25:49.408457+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.734950",
+     "start_time": "2026-06-02T17:25:49.398702+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,7 +752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "11e2b2f2",
    "metadata": {
     "ExecuteTime": {
@@ -581,16 +760,16 @@
      "start_time": "2026-04-20T08:16:19.956182900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.745446Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.744752Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.884758Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.883969Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.428041Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.427881Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.542565Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.542133Z"
     },
     "papermill": {
-     "duration": 0.144886,
-     "end_time": "2026-04-25T15:03:11.885890",
+     "duration": 0.13232,
+     "end_time": "2026-06-02T17:25:49.549611+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.741004",
+     "start_time": "2026-06-02T17:25:49.417291+00:00",
      "status": "completed"
     },
     "tags": []
@@ -603,7 +782,7 @@
       "\n",
       "Benchmark: Puzzles Faciles (3 puzzles)\n",
       "Succes: 3/3\n",
-      "Temps moyen: 2.96 ms\n",
+      "Temps moyen: 2.61 ms\n",
       "\n",
       "Benchmark: Puzzles Difficiles (2 puzzles)\n"
      ]
@@ -613,23 +792,23 @@
      "output_type": "stream",
      "text": [
       "Succes: 2/2\n",
-      "Temps moyen: 59.62 ms\n"
+      "Temps moyen: 45.13 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "[{'success': True,\n",
-       "  'time_ms': 10.452508926391602,\n",
+       "  'time_ms': 8.42142105102539,\n",
        "  'nodes': 164,\n",
        "  'backtracks': 104},\n",
        " {'success': True,\n",
-       "  'time_ms': 108.78992080688477,\n",
+       "  'time_ms': 81.83932304382324,\n",
        "  'nodes': 1496,\n",
        "  'backtracks': 1437}]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -665,10 +844,10 @@
    "id": "9mkm25kzhhd",
    "metadata": {
     "papermill": {
-     "duration": 0.00352,
-     "end_time": "2026-04-25T15:03:11.892906",
+     "duration": 0.014277,
+     "end_time": "2026-06-02T17:25:49.585487+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.889386",
+     "start_time": "2026-06-02T17:25:49.571210+00:00",
      "status": "completed"
     },
     "tags": []
@@ -698,13 +877,101 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02bb5282",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017027,
+     "end_time": "2026-06-02T17:25:49.637375+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.620348+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Comparer les strategies de coloration\n",
+    "\n",
+    "**Objectif** : Implementer une fonction qui compare les performances de MRV et Welsh-Powell sur plusieurs puzzles et produit un tableau comparatif.\n",
+    "\n",
+    "**Contexte** : Comparer des algorithmes sur une seule instance peut etre trompeur. Une comparaison rigoureuse necessite d'executer les deux strategies sur plusieurs puzzles et de calculer des statistiques (moyenne, pire cas).\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Pour chaque puzzle, executer les deux solveurs et collecter noeuds exploites et backtracks\n",
+    "2. Calculer les moyennes pour chaque metrique\n",
+    "3. Retourner un dictionnaire avec les resultats compacts\n",
+    "\n",
+    "**Indice** : Utilisez les fonctions `solve_with_mrv_backtracking` et `solve_with_welsh_powell` definies ci-dessus. Structurez les resultats comme : `{\"MRV\": {\"avg_nodes\": ..., \"avg_backtracks\": ...}, \"WelshPowell\": {...}}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "33141e04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:25:49.676287Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.676038Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.680915Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.679854Z"
+    },
+    "papermill": {
+     "duration": 0.018783,
+     "end_time": "2026-06-02T17:25:49.682821+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.664038+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Resultats a completer\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def compare_strategies(puzzles: List[str], n: int = 3) -> dict:\n",
+    "    \"\"\"\n",
+    "    Compare MRV et Welsh-Powell sur n puzzles et retourne les statistiques.\n",
+    "    \n",
+    "    Args:\n",
+    "        puzzles: liste de puzzles en format chaine 81 caracteres\n",
+    "        n: nombre de puzzles a tester\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict: {\"MRV\": {\"avg_nodes\": ..., \"avg_backtracks\": ...}, \n",
+    "               \"WelshPowell\": {\"avg_nodes\": ..., \"avg_backtracks\": ...}}\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer la comparaison des strategies\n",
+    "    # Etape 1 : pour chaque puzzle dans puzzles[:n], creer une grille\n",
+    "    # Etape 2 : executer solve_with_mrv_backtracking et collecter (nodes, backtracks)\n",
+    "    # Etape 3 : executer solve_with_welsh_powell et collecter (nodes, backtracks)\n",
+    "    # Etape 4 : calculer les moyennes et retourner le dictionnaire\n",
+    "    return {}  # TODO etudiant : remplacer par le calcul reel\n",
+    "\n",
+    "# Test sur 3 puzzles faciles\n",
+    "results = compare_strategies(easy_puzzles, n=3)\n",
+    "if results:\n",
+    "    for strategy, stats in results.items():\n",
+    "        print(f\"{strategy}: avg_nodes={stats['avg_nodes']:.0f}, avg_backtracks={stats['avg_backtracks']:.0f}\")\n",
+    "else:\n",
+    "    print(\"Resultats a completer\")\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ytp2bllgm1n",
    "metadata": {
     "papermill": {
-     "duration": 0.003309,
-     "end_time": "2026-04-25T15:03:11.899682",
+     "duration": 0.008023,
+     "end_time": "2026-06-02T17:25:49.696939+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.896373",
+     "start_time": "2026-06-02T17:25:49.688916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -734,7 +1001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "dlfjm9oprek",
    "metadata": {
     "ExecuteTime": {
@@ -742,16 +1009,16 @@
      "start_time": "2026-04-20T08:45:26.966039400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.907996Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.907425Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.940736Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.940008Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.711201Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.710967Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.741928Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.741427Z"
     },
     "papermill": {
-     "duration": 0.038785,
-     "end_time": "2026-04-25T15:03:11.941851",
+     "duration": 0.039357,
+     "end_time": "2026-06-02T17:25:49.742717+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.903066",
+     "start_time": "2026-06-02T17:25:49.703360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -761,14 +1028,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LCV - Noeuds: 182, Backtracks: 122"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "LCV - Noeuds: 182, Backtracks: 122\n",
       "MRV pur - Noeuds: 164, Backtracks: 104\n"
      ]
     }
@@ -880,10 +1140,10 @@
    "id": "e33c5566",
    "metadata": {
     "papermill": {
-     "duration": 0.003263,
-     "end_time": "2026-04-25T15:03:11.948560",
+     "duration": 0.005009,
+     "end_time": "2026-06-02T17:25:49.752571+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.945297",
+     "start_time": "2026-06-02T17:25:49.747562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -912,10 +1172,10 @@
    "id": "5b18e409",
    "metadata": {
     "papermill": {
-     "duration": 0.003559,
-     "end_time": "2026-04-25T15:03:11.955680",
+     "duration": 0.005613,
+     "end_time": "2026-06-02T17:25:49.765478+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.952121",
+     "start_time": "2026-06-02T17:25:49.759865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -955,20 +1215,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "39831a5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.963426Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.963155Z",
-     "iopub.status.idle": "2026-04-25T15:03:12.002572Z",
-     "shell.execute_reply": "2026-04-25T15:03:12.001777Z"
+     "iopub.execute_input": "2026-06-02T17:25:49.778794Z",
+     "iopub.status.busy": "2026-06-02T17:25:49.778565Z",
+     "iopub.status.idle": "2026-06-02T17:25:49.824217Z",
+     "shell.execute_reply": "2026-06-02T17:25:49.823511Z"
     },
     "papermill": {
-     "duration": 0.044741,
-     "end_time": "2026-04-25T15:03:12.003804",
+     "duration": 0.053663,
+     "end_time": "2026-06-02T17:25:49.825276+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.959063",
+     "start_time": "2026-06-02T17:25:49.771613+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1054,10 +1314,10 @@
    "id": "10f7be5f",
    "metadata": {
     "papermill": {
-     "duration": 0.003586,
-     "end_time": "2026-04-25T15:03:12.011257",
+     "duration": 0.008775,
+     "end_time": "2026-06-02T17:25:49.840305+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:12.007671",
+     "start_time": "2026-06-02T17:25:49.831530+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1085,18 +1345,35 @@
   {
    "cell_type": "markdown",
    "id": "94f0165b",
-   "source": "## Resume et perspectives\n\nCe notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n\nLes benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n\nLe prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005105,
+     "end_time": "2026-06-02T17:25:49.850207+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:25:49.845102+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n",
+    "\n",
+    "Les benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n",
+    "\n",
+    "Le prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "022b15c7",
    "metadata": {
     "papermill": {
-     "duration": 0.00338,
-     "end_time": "2026-04-25T15:03:12.017919",
+     "duration": 0.004787,
+     "end_time": "2026-06-02T17:25:49.859910+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:12.014539",
+     "start_time": "2026-06-02T17:25:49.855123+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1142,18 +1419,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.12"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.013724,
-   "end_time": "2026-04-25T15:03:12.157130",
+   "duration": 11.237787,
+   "end_time": "2026-06-02T17:25:50.110297+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T15:03:09.143406",
+   "start_time": "2026-06-02T17:25:38.872510+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Add 3 exercise stubs to Sudoku-9-GraphColoring-Python for convention #2161 (>=3 exercises per notebook).

### Exercises added

| # | Title | Concept | Placement |
|---|-------|---------|-----------|
| 1 |  | Classify graph neighbors (row/col/block) | After SudokuGrid class |
| 2 |  | MRV heuristic: find most constrained cell | After MRV interpretation |
| 3 |  | Benchmark MRV vs Welsh-Powell | After benchmark interpretation |

### Validation

- **Papermill**: 11/11 code cells, 0 errors, 12.7s
- **H.3**: all code cells have  + 
- **C.1**: stubs use  +  +  + 
- **Distribution**: exercises in sections 3, 4, 5 (not clustered at end)

### C.1 stubs

- Ex 1: 
- Ex 2: 
- Ex 3: 

### Rollout #2161 progress (Sudoku)

- Sudoku-1: 2->3 (PR #2169)
- Sudoku-6: 1->3 (PR #2175)
- Sudoku-9: 0->3 (this PR)
- ~27 notebooks remaining