### PR TITLE
enrich(Sudoku-7,Sudoku-9): add exercises for #2161 rollout

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "67435a9a",
    "metadata": {
     "papermill": {
-     "duration": 0.021778,
-     "end_time": "2026-05-14T07:32:39.635495+00:00",
+     "duration": 0.003281,
+     "end_time": "2026-06-02T17:30:04.539574+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.613717+00:00",
+     "start_time": "2026-06-02T17:30:04.536293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -30,10 +30,10 @@
    "id": "3ff35849",
    "metadata": {
     "papermill": {
-     "duration": 0.008811,
-     "end_time": "2026-05-14T07:32:39.661893+00:00",
+     "duration": 0.002329,
+     "end_time": "2026-06-02T17:30:04.544620+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.653082+00:00",
+     "start_time": "2026-06-02T17:30:04.542291+00:00",
      "status": "completed"
     },
     "tags": []
@@ -64,10 +64,10 @@
    "id": "e1bbeb9d",
    "metadata": {
     "papermill": {
-     "duration": 0.007836,
-     "end_time": "2026-05-14T07:32:39.675395+00:00",
+     "duration": 0.002368,
+     "end_time": "2026-06-02T17:30:04.549307+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.667559+00:00",
+     "start_time": "2026-06-02T17:30:04.546939+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,16 +82,16 @@
    "id": "cell-1-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.682026Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.681852Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.690272Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.689452Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.555599Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.555401Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.561024Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.560313Z"
     },
     "papermill": {
-     "duration": 0.012817,
-     "end_time": "2026-05-14T07:32:39.690947+00:00",
+     "duration": 0.009864,
+     "end_time": "2026-06-02T17:30:04.561643+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.678130+00:00",
+     "start_time": "2026-06-02T17:30:04.551779+00:00",
      "status": "completed"
     },
     "tags": []
@@ -118,10 +118,10 @@
    "id": "59f3d83a",
    "metadata": {
     "papermill": {
-     "duration": 0.004862,
-     "end_time": "2026-05-14T07:32:39.698274+00:00",
+     "duration": 0.002647,
+     "end_time": "2026-06-02T17:30:04.567917+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.693412+00:00",
+     "start_time": "2026-06-02T17:30:04.565270+00:00",
      "status": "completed"
     },
     "tags": []
@@ -148,10 +148,10 @@
    "id": "ca285f16",
    "metadata": {
     "papermill": {
-     "duration": 0.00563,
-     "end_time": "2026-05-14T07:32:39.714089+00:00",
+     "duration": 0.002463,
+     "end_time": "2026-06-02T17:30:04.572853+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.708459+00:00",
+     "start_time": "2026-06-02T17:30:04.570390+00:00",
      "status": "completed"
     },
     "tags": []
@@ -168,16 +168,16 @@
    "id": "cell-2-constants",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.742363Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.741475Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.755018Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.753229Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.578688Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.578413Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.583816Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.583241Z"
     },
     "papermill": {
-     "duration": 0.031415,
-     "end_time": "2026-05-14T07:32:39.756085+00:00",
+     "duration": 0.009008,
+     "end_time": "2026-06-02T17:30:04.584285+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.724670+00:00",
+     "start_time": "2026-06-02T17:30:04.575277+00:00",
      "status": "completed"
     },
     "tags": []
@@ -226,10 +226,10 @@
    "id": "c6283f68",
    "metadata": {
     "papermill": {
-     "duration": 0.004574,
-     "end_time": "2026-05-14T07:32:39.765082+00:00",
+     "duration": 0.002522,
+     "end_time": "2026-06-02T17:30:04.589399+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.760508+00:00",
+     "start_time": "2026-06-02T17:30:04.586877+00:00",
      "status": "completed"
     },
     "tags": []
@@ -260,16 +260,16 @@
    "id": "cell-3-assign-eliminate",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.775571Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.775378Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.783358Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.781922Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.595196Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.595054Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.599744Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.599240Z"
     },
     "papermill": {
-     "duration": 0.014814,
-     "end_time": "2026-05-14T07:32:39.785417+00:00",
+     "duration": 0.008595,
+     "end_time": "2026-06-02T17:30:04.600452+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.770603+00:00",
+     "start_time": "2026-06-02T17:30:04.591857+00:00",
      "status": "completed"
     },
     "tags": []
@@ -328,10 +328,10 @@
    "id": "021ed51f",
    "metadata": {
     "papermill": {
-     "duration": 0.002966,
-     "end_time": "2026-05-14T07:32:39.791747+00:00",
+     "duration": 0.002717,
+     "end_time": "2026-06-02T17:30:04.606036+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.788781+00:00",
+     "start_time": "2026-06-02T17:30:04.603319+00:00",
      "status": "completed"
     },
     "tags": []
@@ -352,16 +352,16 @@
    "id": "cell-4-parse",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.805618Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.805247Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.813323Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.811886Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.611978Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.611831Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.615716Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.615288Z"
     },
     "papermill": {
-     "duration": 0.018773,
-     "end_time": "2026-05-14T07:32:39.814449+00:00",
+     "duration": 0.007677,
+     "end_time": "2026-06-02T17:30:04.616317+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.795676+00:00",
+     "start_time": "2026-06-02T17:30:04.608640+00:00",
      "status": "completed"
     },
     "tags": []
@@ -400,10 +400,10 @@
    "id": "848caf7d",
    "metadata": {
     "papermill": {
-     "duration": 0.00659,
-     "end_time": "2026-05-14T07:32:39.825609+00:00",
+     "duration": 0.002626,
+     "end_time": "2026-06-02T17:30:04.621504+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.819019+00:00",
+     "start_time": "2026-06-02T17:30:04.618878+00:00",
      "status": "completed"
     },
     "tags": []
@@ -431,16 +431,16 @@
    "id": "cell-5-solve",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.835749Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.835166Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.842393Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.841465Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.627552Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.627416Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.631633Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.630925Z"
     },
     "papermill": {
-     "duration": 0.013925,
-     "end_time": "2026-05-14T07:32:39.843147+00:00",
+     "duration": 0.008036,
+     "end_time": "2026-06-02T17:30:04.632189+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.829222+00:00",
+     "start_time": "2026-06-02T17:30:04.624153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -484,10 +484,10 @@
    "id": "f5e7edea",
    "metadata": {
     "papermill": {
-     "duration": 0.01074,
-     "end_time": "2026-05-14T07:32:39.857728+00:00",
+     "duration": 0.002624,
+     "end_time": "2026-06-02T17:30:04.637540+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.846988+00:00",
+     "start_time": "2026-06-02T17:30:04.634916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -504,16 +504,16 @@
    "id": "cell-6-display",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.873836Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.873485Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.879340Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.878447Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.643664Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.643474Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.647612Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.646766Z"
     },
     "papermill": {
-     "duration": 0.016028,
-     "end_time": "2026-05-14T07:32:39.880198+00:00",
+     "duration": 0.008044,
+     "end_time": "2026-06-02T17:30:04.648243+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.864170+00:00",
+     "start_time": "2026-06-02T17:30:04.640199+00:00",
      "status": "completed"
     },
     "tags": []
@@ -538,8 +538,8 @@
     "                                for c in cols))\n",
     "        if r in 'CF':\n",
     "            result.append(line)\n",
-    "    return '\\n'.join(result)",
-    "\nprint(\"Fonction definie : display\")\n"
+    "    return '\\n'.join(result)\n",
+    "print(\"Fonction definie : display\")\n"
    ]
   },
   {
@@ -547,10 +547,10 @@
    "id": "test-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003959,
-     "end_time": "2026-05-14T07:32:39.889943+00:00",
+     "duration": 0.00288,
+     "end_time": "2026-06-02T17:30:04.654209+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.885984+00:00",
+     "start_time": "2026-06-02T17:30:04.651329+00:00",
      "status": "completed"
     },
     "tags": []
@@ -567,16 +567,16 @@
    "id": "cell-7-test",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.895973Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.895806Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.903897Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.903146Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.661206Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.660948Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.668727Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.668030Z"
     },
     "papermill": {
-     "duration": 0.011979,
-     "end_time": "2026-05-14T07:32:39.904535+00:00",
+     "duration": 0.012195,
+     "end_time": "2026-06-02T17:30:04.669326+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.892556+00:00",
+     "start_time": "2026-06-02T17:30:04.657131+00:00",
      "status": "completed"
     },
     "tags": []
@@ -601,7 +601,7 @@
       "\n",
       "Resolution...\n",
       "\n",
-      "Resolu en 2.36 ms\n",
+      "Resolu en 1.89 ms\n",
       "4 8 3 |9 2 1 |6 5 7 \n",
       "9 6 7 |3 4 5 |8 2 1 \n",
       "2 5 1 |8 7 6 |4 9 3 \n",
@@ -638,10 +638,10 @@
    "id": "f50e4660",
    "metadata": {
     "papermill": {
-     "duration": 0.002243,
-     "end_time": "2026-05-14T07:32:39.908712+00:00",
+     "duration": 0.004058,
+     "end_time": "2026-06-02T17:30:04.676478+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.906469+00:00",
+     "start_time": "2026-06-02T17:30:04.672420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -658,16 +658,16 @@
    "id": "cell-8-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:39.919046Z",
-     "iopub.status.busy": "2026-05-14T07:32:39.918786Z",
-     "iopub.status.idle": "2026-05-14T07:32:39.993357Z",
-     "shell.execute_reply": "2026-05-14T07:32:39.992759Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.683660Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.683468Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.762052Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.761321Z"
     },
     "papermill": {
-     "duration": 0.082156,
-     "end_time": "2026-05-14T07:32:39.994080+00:00",
+     "duration": 0.083287,
+     "end_time": "2026-06-02T17:30:04.762818+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.911924+00:00",
+     "start_time": "2026-06-02T17:30:04.679531+00:00",
      "status": "completed"
     },
     "tags": []
@@ -680,19 +680,13 @@
       "\n",
       "Benchmark: Puzzles Faciles (20 puzzles)\n",
       "  Resolus: 20/20\n",
-      "  Temps total: 44.19 ms\n",
-      "  Temps moyen: 2.21 ms/puzzle\n",
+      "  Temps total: 41.44 ms\n",
+      "  Temps moyen: 2.07 ms/puzzle\n",
       "\n",
-      "Benchmark: Puzzles Difficiles (11 puzzles)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Benchmark: Puzzles Difficiles (11 puzzles)\n",
       "  Resolus: 11/11\n",
-      "  Temps total: 30.30 ms\n",
-      "  Temps moyen: 2.75 ms/puzzle\n"
+      "  Temps total: 31.05 ms\n",
+      "  Temps moyen: 2.82 ms/puzzle\n"
      ]
     }
    ],
@@ -737,10 +731,10 @@
    "id": "162evydrpdu",
    "metadata": {
     "papermill": {
-     "duration": 0.002928,
-     "end_time": "2026-05-14T07:32:39.999347+00:00",
+     "duration": 0.003291,
+     "end_time": "2026-06-02T17:30:04.769796+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:39.996419+00:00",
+     "start_time": "2026-06-02T17:30:04.766505+00:00",
      "status": "completed"
     },
     "tags": []
@@ -765,13 +759,107 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-hidden-singles",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003287,
+     "end_time": "2026-06-02T17:30:04.776347+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:30:04.773060+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Detection des singletons caches (Hidden Singles)\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "La technique des **singletons caches** (Hidden Singles) est une heuristique de propagation complementaire a l'assign/eliminate de Norvig. Si un chiffre `d` ne peut apparaitre que dans **une seule case** d'une unite (ligne, colonne ou bloc), alors `d` doit etre assigne a cette case, meme si d'autres candidats sont encore possibles.\n",
+    "\n",
+    "**Exemple** : Si dans la ligne A, seul `A3` peut contenir le chiffre `7` (tous les autres `A1, A2, A4...` ont elimine `7`), alors `A3 = 7` est force.\n",
+    "\n",
+    "Implementez la fonction `hidden_singles(values)` qui parcourt toutes les unites et detecte ces singletons caches.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Pour chaque unite de `unitlist` et chaque chiffre `d` de 1 a 9\n",
+    "- Etape 2 : Collectez les cases de l'unite ou `d` est encore candidat\n",
+    "- Etape 3 : Si une seule case peut contenir `d`, assignez `d` a cette case avec `assign(values, s, d)`\n",
+    "- Etape 4 : Retournez `True` si au moins une assignation, `False` sinon\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex-hidden-singles-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:30:04.784728Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.784501Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.791402Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.790622Z"
+    },
+    "papermill": {
+     "duration": 0.01249,
+     "end_time": "2026-06-02T17:30:04.792216+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:30:04.779726+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Singletons caches detectes : False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Detection des singletons caches (Hidden Singles)\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Parcourez unitlist pour chaque unite\n",
+    "#   - Pour chaque chiffre d (1-9), trouvez les cases de l unite ou d est candidat\n",
+    "#   - Si une seule case peut contenir d, assignez d a cette case\n",
+    "#   - Utilisez assign(values, s, d) pour chaque assignation\n",
+    "#   - Renvoyez True si au moins une assignation, False sinon\n",
+    "\n",
+    "def hidden_singles(values):\n",
+    "    \"\"\"Detecte et assigne les singletons caches dans toutes les unites.\n",
+    "\n",
+    "    Args:\n",
+    "        values: dictionnaire {square: candidats}\n",
+    "\n",
+    "    Returns:\n",
+    "        True si au moins une assignation a eu lieu, False sinon\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez la detection des singletons caches\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "# Test rapide\n",
+    "test_grid_hs = '..3.2.6..9..3.5..1..18.64....81.29..7.......8..67.82....26.95..8..2.3..9..5.1.3..'\n",
+    "values_hs = parse_grid(test_grid_hs)\n",
+    "if values_hs:\n",
+    "    result = hidden_singles(values_hs)\n",
+    "    print(f\"Singletons caches detectes : {result}\")\n",
+    "else:\n",
+    "    print(\"Grille invalide\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gy8q93llr0t",
    "metadata": {
     "papermill": {
-     "duration": 0.002791,
-     "end_time": "2026-05-14T07:32:40.005408+00:00",
+     "duration": 0.003688,
+     "end_time": "2026-06-02T17:30:04.800022+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:40.002617+00:00",
+     "start_time": "2026-06-02T17:30:04.796334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -802,20 +890,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "sw7jd6fdkc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:40.010711Z",
-     "iopub.status.busy": "2026-05-14T07:32:40.010497Z",
-     "iopub.status.idle": "2026-05-14T07:32:40.018193Z",
-     "shell.execute_reply": "2026-05-14T07:32:40.017437Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.808811Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.808580Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.818342Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.817680Z"
     },
     "papermill": {
-     "duration": 0.011102,
-     "end_time": "2026-05-14T07:32:40.018863+00:00",
+     "duration": 0.015181,
+     "end_time": "2026-06-02T17:30:04.819090+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:40.007761+00:00",
+     "start_time": "2026-06-02T17:30:04.803909+00:00",
      "status": "completed"
     },
     "tags": []
@@ -931,10 +1019,10 @@
    "id": "31556af2",
    "metadata": {
     "papermill": {
-     "duration": 0.002087,
-     "end_time": "2026-05-14T07:32:40.023107+00:00",
+     "duration": 0.003462,
+     "end_time": "2026-06-02T17:30:04.826223+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:40.021020+00:00",
+     "start_time": "2026-06-02T17:30:04.822761+00:00",
      "status": "completed"
     },
     "tags": []
@@ -964,20 +1052,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "f183e45e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-14T07:32:40.028255Z",
-     "iopub.status.busy": "2026-05-14T07:32:40.028111Z",
-     "iopub.status.idle": "2026-05-14T07:32:40.032687Z",
-     "shell.execute_reply": "2026-05-14T07:32:40.031975Z"
+     "iopub.execute_input": "2026-06-02T17:30:04.833931Z",
+     "iopub.status.busy": "2026-06-02T17:30:04.833735Z",
+     "iopub.status.idle": "2026-06-02T17:30:04.839217Z",
+     "shell.execute_reply": "2026-06-02T17:30:04.838388Z"
     },
     "papermill": {
-     "duration": 0.007809,
-     "end_time": "2026-05-14T07:32:40.033281+00:00",
+     "duration": 0.010281,
+     "end_time": "2026-06-02T17:30:04.839761+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:40.025472+00:00",
+     "start_time": "2026-06-02T17:30:04.829480+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1030,18 +1118,31 @@
   {
    "cell_type": "markdown",
    "id": "e61fc027",
-   "source": "## Conclusion\n\nCe notebook a presenté l'approche élégante de Peter Norvig pour résoudre le Sudoku en ~80 lignes de Python. La méthode repose sur deux piliers : la **propagation de contraintes** (élimination des candidats impossibles via les pairs et les unités) et le **backtracking** guidé par l'heuristique MRV (choisir la case avec le moins de valeurs possibles). Le benchmark montre des performances remarquables (~2 ms par puzzle en moyenne), avec une faible sensibilité à la difficulté de la grille. Cette implémentation illustre un principe fondamental en intelligence artificielle : un bon encodage du problème (représentation par dictionnaire de candidats) combiné à une heuristique pertinente (MRV) peut surpasser des approches algorithmiquement plus complexes. Les exercices proposés (mini-Sudoku 4x4, paires nues) permettent d'étendre le solveur avec des techniques de propagation avancées.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00341,
+     "end_time": "2026-06-02T17:30:04.846543+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:30:04.843133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a presenté l'approche élégante de Peter Norvig pour résoudre le Sudoku en ~80 lignes de Python. La méthode repose sur deux piliers : la **propagation de contraintes** (élimination des candidats impossibles via les pairs et les unités) et le **backtracking** guidé par l'heuristique MRV (choisir la case avec le moins de valeurs possibles). Le benchmark montre des performances remarquables (~2 ms par puzzle en moyenne), avec une faible sensibilité à la difficulté de la grille. Cette implémentation illustre un principe fondamental en intelligence artificielle : un bon encodage du problème (représentation par dictionnaire de candidats) combiné à une heuristique pertinente (MRV) peut surpasser des approches algorithmiquement plus complexes. Les exercices proposés (mini-Sudoku 4x4, paires nues) permettent d'étendre le solveur avec des techniques de propagation avancées."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b00eeb33",
    "metadata": {
     "papermill": {
-     "duration": 0.002244,
-     "end_time": "2026-05-14T07:32:40.037935+00:00",
+     "duration": 0.003587,
+     "end_time": "2026-06-02T17:30:04.853662+00:00",
      "exception": false,
-     "start_time": "2026-05-14T07:32:40.035691+00:00",
+     "start_time": "2026-06-02T17:30:04.850075+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1093,18 +1194,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1.944464,
-   "end_time": "2026-05-14T07:32:40.168117+00:00",
+   "duration": 3.093775,
+   "end_time": "2026-06-02T17:30:05.322922+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-7-Norvig-Python_output.ipynb",
+   "input_path": "Sudoku-7-Norvig-Python.ipynb",
+   "output_path": "Sudoku-7-Norvig-Python_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-05-14T07:32:38.223653+00:00",
+   "start_time": "2026-06-02T17:30:02.229147+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "403f4734",
    "metadata": {
     "papermill": {
-     "duration": 0.003725,
-     "end_time": "2026-04-25T15:03:11.160592",
+     "duration": 0.004474,
+     "end_time": "2026-06-02T17:32:58.634391+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.156867",
+     "start_time": "2026-06-02T17:32:58.629917+00:00",
      "status": "completed"
     },
     "tags": []
@@ -44,16 +44,16 @@
      "start_time": "2026-04-20T08:09:57.302191300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.167748Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.167286Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.623825Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.622849Z"
+     "iopub.execute_input": "2026-06-02T17:32:58.642695Z",
+     "iopub.status.busy": "2026-06-02T17:32:58.642505Z",
+     "iopub.status.idle": "2026-06-02T17:32:58.933041Z",
+     "shell.execute_reply": "2026-06-02T17:32:58.932342Z"
     },
     "papermill": {
-     "duration": 0.461381,
-     "end_time": "2026-04-25T15:03:11.625069",
+     "duration": 0.295549,
+     "end_time": "2026-06-02T17:32:58.933706+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.163688",
+     "start_time": "2026-06-02T17:32:58.638157+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,7 +63,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NetworkX version: 3.4.2\n",
+      "NetworkX version: 3.6.1\n",
       "Graphes Sudoku disponibles: True\n"
      ]
     }
@@ -83,10 +83,10 @@
    "id": "e3b99014",
    "metadata": {
     "papermill": {
-     "duration": 0.002578,
-     "end_time": "2026-04-25T15:03:11.630554",
+     "duration": 0.002905,
+     "end_time": "2026-06-02T17:32:58.939916+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.627976",
+     "start_time": "2026-06-02T17:32:58.937011+00:00",
      "status": "completed"
     },
     "tags": []
@@ -120,16 +120,16 @@
      "start_time": "2026-04-20T08:11:59.150112600Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.636806Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.636438Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.643204Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.642262Z"
+     "iopub.execute_input": "2026-06-02T17:32:58.947177Z",
+     "iopub.status.busy": "2026-06-02T17:32:58.946897Z",
+     "iopub.status.idle": "2026-06-02T17:32:58.951403Z",
+     "shell.execute_reply": "2026-06-02T17:32:58.950867Z"
     },
     "papermill": {
-     "duration": 0.011197,
-     "end_time": "2026-04-25T15:03:11.644231",
+     "duration": 0.008965,
+     "end_time": "2026-06-02T17:32:58.951949+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.633034",
+     "start_time": "2026-06-02T17:32:58.942984+00:00",
      "status": "completed"
     },
     "tags": []
@@ -170,10 +170,10 @@
    "id": "b6bb9148",
    "metadata": {
     "papermill": {
-     "duration": 0.002563,
-     "end_time": "2026-04-25T15:03:11.649553",
+     "duration": 0.002979,
+     "end_time": "2026-06-02T17:32:58.957919+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.646990",
+     "start_time": "2026-06-02T17:32:58.954940+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,16 +194,16 @@
      "start_time": "2026-04-20T08:12:07.647028300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.656627Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.655960Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.663615Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.662652Z"
+     "iopub.execute_input": "2026-06-02T17:32:58.964806Z",
+     "iopub.status.busy": "2026-06-02T17:32:58.964638Z",
+     "iopub.status.idle": "2026-06-02T17:32:58.969657Z",
+     "shell.execute_reply": "2026-06-02T17:32:58.969030Z"
     },
     "papermill": {
-     "duration": 0.012401,
-     "end_time": "2026-04-25T15:03:11.664638",
+     "duration": 0.009408,
+     "end_time": "2026-06-02T17:32:58.970285+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.652237",
+     "start_time": "2026-06-02T17:32:58.960877+00:00",
      "status": "completed"
     },
     "tags": []
@@ -240,10 +240,10 @@
    "id": "50545bc9",
    "metadata": {
     "papermill": {
-     "duration": 0.003292,
-     "end_time": "2026-04-25T15:03:11.671010",
+     "duration": 0.003022,
+     "end_time": "2026-06-02T17:32:58.976229+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.667718",
+     "start_time": "2026-06-02T17:32:58.973207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -262,13 +262,106 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-cell-constraints",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003076,
+     "end_time": "2026-06-02T17:32:58.982513+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:58.979437+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Compter les contraintes par cellule\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Dans le graphe de contraintes du Sudoku, chaque arete represente une exclusion mutuelle entre deux cellules. Les cellules les plus contraintes (celles qui ont le plus de voisins non encore resolus) sont les plus difficiles a remplir.\n",
+    "\n",
+    "Implementez `count_unassigned_constraints(coloring, G)` qui retourne un dictionnaire `{vertex: count}` indiquant, pour chaque cellule non coloriee, combien de ses voisins sont egalement non colories.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Identifiez les sommets non colories (`coloring[v] == 0`)\n",
+    "- Etape 2 : Pour chaque sommet non colorie, comptez ses voisins non colories\n",
+    "- Etape 3 : Retournez le dictionnaire trie par nombre de contraintes decroissant\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ex-cell-constraints-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:32:58.990267Z",
+     "iopub.status.busy": "2026-06-02T17:32:58.989904Z",
+     "iopub.status.idle": "2026-06-02T17:32:58.994832Z",
+     "shell.execute_reply": "2026-06-02T17:32:58.994193Z"
+    },
+    "papermill": {
+     "duration": 0.010097,
+     "end_time": "2026-06-02T17:32:58.995656+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:58.985559+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de cellules non colories : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Compter les contraintes par cellule\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Identifiez les sommets non colories (coloring[v] == 0)\n",
+    "#   - Pour chaque sommet non colorie, comptez ses voisins non colories\n",
+    "#   - Retournez le dictionnaire trie par contraintes decroissantes\n",
+    "\n",
+    "def count_unassigned_constraints(coloring: list, G) -> dict:\n",
+    "    \"\"\"Compte les voisins non colories pour chaque cellule non coloriee.\n",
+    "\n",
+    "    Args:\n",
+    "        coloring: liste de 81 entiers (0=non colorie)\n",
+    "        G: graphe NetworkX des contraintes\n",
+    "\n",
+    "    Returns:\n",
+    "        Dictionnaire {vertex: count} trie par count decroissant\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez le comptage des contraintes\n",
+    "    return {}\n",
+    "\n",
+    "\n",
+    "# Test rapide avec un coloring partiel (grille facile, quelques indices)\n",
+    "# 0 = case vide, 1-9 = chiffre attribue\n",
+    "test_coloring = [0]*81\n",
+    "# Quelques valeurs pre-remplies (ligne 0: 4,_,3,_,2,_,6,_,7)\n",
+    "for i, v in enumerate([4,0,3,0,2,0,6,0,7]):\n",
+    "    test_coloring[i] = v\n",
+    "constraints = count_unassigned_constraints(test_coloring, G)\n",
+    "print(f\"Nombre de cellules non colories : {len(constraints)}\")\n",
+    "if constraints:\n",
+    "    top = list(constraints.items())[:3]\n",
+    "    print(f\"Top 3 cellules les plus contraintes : {top}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b9920bf3",
    "metadata": {
     "papermill": {
-     "duration": 0.002889,
-     "end_time": "2026-04-25T15:03:11.677044",
+     "duration": 0.003133,
+     "end_time": "2026-06-02T17:32:59.001936+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.674155",
+     "start_time": "2026-06-02T17:32:58.998803+00:00",
      "status": "completed"
     },
     "tags": []
@@ -279,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "ee1b47b6",
    "metadata": {
     "ExecuteTime": {
@@ -287,16 +380,16 @@
      "start_time": "2026-04-20T08:14:06.261561900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.684538Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.683968Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.695018Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.693733Z"
+     "iopub.execute_input": "2026-06-02T17:32:59.009598Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.009412Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.015386Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.014862Z"
     },
     "papermill": {
-     "duration": 0.016633,
-     "end_time": "2026-04-25T15:03:11.696610",
+     "duration": 0.010646,
+     "end_time": "2026-06-02T17:32:59.015929+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.679977",
+     "start_time": "2026-06-02T17:32:59.005283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -381,10 +474,10 @@
    "id": "69b3809b",
    "metadata": {
     "papermill": {
-     "duration": 0.003955,
-     "end_time": "2026-04-25T15:03:11.703772",
+     "duration": 0.003134,
+     "end_time": "2026-06-02T17:32:59.022165+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.699817",
+     "start_time": "2026-06-02T17:32:59.019031+00:00",
      "status": "completed"
     },
     "tags": []
@@ -397,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "e52a9d76",
    "metadata": {
     "ExecuteTime": {
@@ -405,16 +498,16 @@
      "start_time": "2026-04-20T08:15:12.638358300Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.712276Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.711790Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.724380Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.723466Z"
+     "iopub.execute_input": "2026-06-02T17:32:59.029502Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.029174Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.037601Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.036865Z"
     },
     "papermill": {
-     "duration": 0.017943,
-     "end_time": "2026-04-25T15:03:11.725584",
+     "duration": 0.013025,
+     "end_time": "2026-06-02T17:32:59.038174+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.707641",
+     "start_time": "2026-06-02T17:32:59.025149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -437,7 +530,7 @@
       "7 . 5 | 2 . . | 3 . 4 \n",
       ". 8 . | . 4 1 | 9 5 . \n",
       "\n",
-      "Resolu: True en 2.56 ms\n",
+      "Resolu: True en 1.88 ms\n",
       "Noeuds explores: 37\n",
       "Backtracks: 0\n",
       "\n",
@@ -527,10 +620,10 @@
    "id": "4taoqji9bpb",
    "metadata": {
     "papermill": {
-     "duration": 0.003014,
-     "end_time": "2026-04-25T15:03:11.731927",
+     "duration": 0.003173,
+     "end_time": "2026-06-02T17:32:59.044997+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.728913",
+     "start_time": "2026-06-02T17:32:59.041824+00:00",
      "status": "completed"
     },
     "tags": []
@@ -556,13 +649,103 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-degree-heuristic",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002998,
+     "end_time": "2026-06-02T17:32:59.051092+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:59.048094+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Heuristique de degre (Degree Heuristic)\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "L'heuristique MRV choisit le sommet avec le moins de couleurs disponibles. Mais quand plusieurs sommets ont le meme nombre de couleurs possibles (egalite MRV), l'**heuristique de degre** les departage en choisissant celui qui a le **plus de voisins non colories**. Ce sommet est le plus contraignant, donc le colorier en premier reduit l'arbre de recherche.\n",
+    "\n",
+    "Implementez `select_unassigned_vertex(coloring, G)` qui combine MRV + degre.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Collectez tous les sommets non colories (`coloring[v] == 0`)\n",
+    "- Etape 2 : Pour chacun, calculez le nombre de couleurs disponibles (couleurs 1-9 deja prises par les voisins)\n",
+    "- Etape 3 : Trouvez le minimum de couleurs disponibles (MRV)\n",
+    "- Etape 4 : En cas d'egalite, departagez avec le degre (nombre de voisins non colories)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ex-degree-heuristic-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:32:59.058626Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.058416Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.062783Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.062002Z"
+    },
+    "papermill": {
+     "duration": 0.009228,
+     "end_time": "2026-06-02T17:32:59.063485+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:59.054257+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prochain sommet a colorier : -1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Heuristique de degre (MRV + Degree)\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Collectez les sommets non colories (coloring[v] == 0)\n",
+    "#   - Pour chacun, calculez les couleurs disponibles (couleurs des voisins deja prises)\n",
+    "#   - Trouvez le minimum de couleurs (MRV)\n",
+    "#   - En cas d egalite, choisissez le sommet avec le plus de voisins non colories\n",
+    "\n",
+    "def select_unassigned_vertex(coloring: list, G) -> int:\n",
+    "    \"\"\"Selectionne le prochain sommet a colorier avec MRV + degre.\n",
+    "\n",
+    "    Args:\n",
+    "        coloring: liste de 81 entiers (0=non colorie)\n",
+    "        G: graphe NetworkX des contraintes\n",
+    "\n",
+    "    Returns:\n",
+    "        Index du sommet a colorier, ou -1 si tous sont colories\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez MRV + degree heuristic\n",
+    "    return -1\n",
+    "\n",
+    "\n",
+    "# Test rapide avec une grille partiellement remplie\n",
+    "test_coloring_dh = [0]*81\n",
+    "for i, v in enumerate([4,0,3,0,2,0,6,0,7]):\n",
+    "    test_coloring_dh[i] = v\n",
+    "vertex = select_unassigned_vertex(test_coloring_dh, G)\n",
+    "print(f\"Prochain sommet a colorier : {vertex}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6f0fd4c0",
    "metadata": {
     "papermill": {
-     "duration": 0.003181,
-     "end_time": "2026-04-25T15:03:11.738131",
+     "duration": 0.003288,
+     "end_time": "2026-06-02T17:32:59.070079+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.734950",
+     "start_time": "2026-06-02T17:32:59.066791+00:00",
      "status": "completed"
     },
     "tags": []
@@ -573,7 +756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "11e2b2f2",
    "metadata": {
     "ExecuteTime": {
@@ -581,16 +764,16 @@
      "start_time": "2026-04-20T08:16:19.956182900Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.745446Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.744752Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.884758Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.883969Z"
+     "iopub.execute_input": "2026-06-02T17:32:59.077709Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.077505Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.187298Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.186555Z"
     },
     "papermill": {
-     "duration": 0.144886,
-     "end_time": "2026-04-25T15:03:11.885890",
+     "duration": 0.114829,
+     "end_time": "2026-06-02T17:32:59.188073+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.741004",
+     "start_time": "2026-06-02T17:32:59.073244+00:00",
      "status": "completed"
     },
     "tags": []
@@ -603,7 +786,7 @@
       "\n",
       "Benchmark: Puzzles Faciles (3 puzzles)\n",
       "Succes: 3/3\n",
-      "Temps moyen: 2.96 ms\n",
+      "Temps moyen: 2.47 ms\n",
       "\n",
       "Benchmark: Puzzles Difficiles (2 puzzles)\n"
      ]
@@ -613,23 +796,23 @@
      "output_type": "stream",
      "text": [
       "Succes: 2/2\n",
-      "Temps moyen: 59.62 ms\n"
+      "Temps moyen: 46.88 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
        "[{'success': True,\n",
-       "  'time_ms': 10.452508926391602,\n",
+       "  'time_ms': 8.841276168823242,\n",
        "  'nodes': 164,\n",
        "  'backtracks': 104},\n",
        " {'success': True,\n",
-       "  'time_ms': 108.78992080688477,\n",
+       "  'time_ms': 84.9144458770752,\n",
        "  'nodes': 1496,\n",
        "  'backtracks': 1437}]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -665,10 +848,10 @@
    "id": "9mkm25kzhhd",
    "metadata": {
     "papermill": {
-     "duration": 0.00352,
-     "end_time": "2026-04-25T15:03:11.892906",
+     "duration": 0.003211,
+     "end_time": "2026-06-02T17:32:59.194940+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.889386",
+     "start_time": "2026-06-02T17:32:59.191729+00:00",
      "status": "completed"
     },
     "tags": []
@@ -698,13 +881,112 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-valid-coloring",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003314,
+     "end_time": "2026-06-02T17:32:59.201354+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:59.198040+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Verification d'une coloration valide\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Avant d'accepter une solution de Sudoku, il est essentiel de verifier que la coloration obtenue est une **coloration propre** du graphe de contraintes : deux sommets adjacents ne doivent pas partager la meme couleur.\n",
+    "\n",
+    "Implementez la fonction `is_valid_coloring(coloring, G)` qui verifie cette propriete sur l'ensemble du graphe.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Parcourez toutes les aretes du graphe avec `G.edges()`\n",
+    "- Etape 2 : Pour chaque arete `(u, v)`, verifiez que `coloring[u] != coloring[v]`\n",
+    "- Etape 3 : Verifiez aussi qu'aucun sommet n'a la couleur 0 (non colorie)\n",
+    "- Etape 4 : Retournez `True` si la coloration est propre et complete, `False` sinon\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex-valid-coloring-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T17:32:59.209500Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.209203Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.216900Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.216358Z"
+    },
+    "papermill": {
+     "duration": 0.013047,
+     "end_time": "2026-06-02T17:32:59.217642+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:59.204595+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coloration valide : False"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Verification d'une coloration valide\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Parcourez toutes les aretes avec G.edges()\n",
+    "#   - Pour chaque arete (u, v), verifiez coloring[u] != coloring[v]\n",
+    "#   - Verifiez qu aucun sommet n a la couleur 0\n",
+    "#   - Retournez True si la coloration est propre et complete\n",
+    "\n",
+    "def is_valid_coloring(coloring: list, G) -> bool:\n",
+    "    \"\"\"Verifie qu une coloration est propre (pas de conflits) et complete.\n",
+    "\n",
+    "    Args:\n",
+    "        coloring: liste de 81 entiers (0=non colorie, 1-9=couleur)\n",
+    "        G: graphe NetworkX des contraintes Sudoku\n",
+    "\n",
+    "    Returns:\n",
+    "        True si la coloration est propre et complete, False sinon\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez la verification de coloration\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "# Test rapide sur une grille resolue\n",
+    "test_gc = SudokuGrid.from_string('..3.2.6..9..3.5..1..18.64....81.29..7.......8..67.82....26.95..8..2.3..9..5.1.3..')\n",
+    "success, _, _ = solve_with_mrv_backtracking(test_gc)\n",
+    "if success:\n",
+    "    coloring = test_gc.to_coloring()\n",
+    "    print(f\"Coloration valide : {is_valid_coloring(coloring, nx.sudoku_graph())}\")\n",
+    "else:\n",
+    "    print(\"Pas de solution\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ytp2bllgm1n",
    "metadata": {
     "papermill": {
-     "duration": 0.003309,
-     "end_time": "2026-04-25T15:03:11.899682",
+     "duration": 0.0036,
+     "end_time": "2026-06-02T17:32:59.224581+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.896373",
+     "start_time": "2026-06-02T17:32:59.220981+00:00",
      "status": "completed"
     },
     "tags": []
@@ -734,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "id": "dlfjm9oprek",
    "metadata": {
     "ExecuteTime": {
@@ -742,16 +1024,16 @@
      "start_time": "2026-04-20T08:45:26.966039400Z"
     },
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.907996Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.907425Z",
-     "iopub.status.idle": "2026-04-25T15:03:11.940736Z",
-     "shell.execute_reply": "2026-04-25T15:03:11.940008Z"
+     "iopub.execute_input": "2026-06-02T17:32:59.232977Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.232766Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.264665Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.263914Z"
     },
     "papermill": {
-     "duration": 0.038785,
-     "end_time": "2026-04-25T15:03:11.941851",
+     "duration": 0.037605,
+     "end_time": "2026-06-02T17:32:59.265713+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.903066",
+     "start_time": "2026-06-02T17:32:59.228108+00:00",
      "status": "completed"
     },
     "tags": []
@@ -761,14 +1043,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LCV - Noeuds: 182, Backtracks: 122"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "LCV - Noeuds: 182, Backtracks: 122\n",
       "MRV pur - Noeuds: 164, Backtracks: 104\n"
      ]
     }
@@ -880,10 +1155,10 @@
    "id": "e33c5566",
    "metadata": {
     "papermill": {
-     "duration": 0.003263,
-     "end_time": "2026-04-25T15:03:11.948560",
+     "duration": 0.004084,
+     "end_time": "2026-06-02T17:32:59.274179+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.945297",
+     "start_time": "2026-06-02T17:32:59.270095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -912,10 +1187,10 @@
    "id": "5b18e409",
    "metadata": {
     "papermill": {
-     "duration": 0.003559,
-     "end_time": "2026-04-25T15:03:11.955680",
+     "duration": 0.004237,
+     "end_time": "2026-06-02T17:32:59.282542+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.952121",
+     "start_time": "2026-06-02T17:32:59.278305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -955,20 +1230,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "39831a5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:03:11.963426Z",
-     "iopub.status.busy": "2026-04-25T15:03:11.963155Z",
-     "iopub.status.idle": "2026-04-25T15:03:12.002572Z",
-     "shell.execute_reply": "2026-04-25T15:03:12.001777Z"
+     "iopub.execute_input": "2026-06-02T17:32:59.291406Z",
+     "iopub.status.busy": "2026-06-02T17:32:59.291192Z",
+     "iopub.status.idle": "2026-06-02T17:32:59.322955Z",
+     "shell.execute_reply": "2026-06-02T17:32:59.322300Z"
     },
     "papermill": {
-     "duration": 0.044741,
-     "end_time": "2026-04-25T15:03:12.003804",
+     "duration": 0.037281,
+     "end_time": "2026-06-02T17:32:59.323587+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:11.959063",
+     "start_time": "2026-06-02T17:32:59.286306+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1054,10 +1329,10 @@
    "id": "10f7be5f",
    "metadata": {
     "papermill": {
-     "duration": 0.003586,
-     "end_time": "2026-04-25T15:03:12.011257",
+     "duration": 0.003417,
+     "end_time": "2026-06-02T17:32:59.330567+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:12.007671",
+     "start_time": "2026-06-02T17:32:59.327150+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1085,18 +1360,35 @@
   {
    "cell_type": "markdown",
    "id": "94f0165b",
-   "source": "## Resume et perspectives\n\nCe notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n\nLes benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n\nLe prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003552,
+     "end_time": "2026-06-02T17:32:59.337485+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T17:32:59.333933+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a montre comment modeliser le Sudoku comme un **probleme de coloration de graphe** en utilisant NetworkX et sa fonction `nx.sudoku_graph()`, qui genere automatiquement un graphe regulier de 81 sommets et 810 aretes (degre 20 par sommet). L'implementation a couvert trois strategies de coloration : le **backtracking avec heuristique MRV** (Minimum Remaining Values), qui s'est revelee la plus efficace avec 0 backtrack sur les puzzles faciles ; l'heuristique **LCV** (Least Constraining Value), qui ordonne les couleurs candidates par impact minimal sur les voisins mais s'est revelee contre-productive sur le graphe regulier du Sudoku ; et l'heuristique **Welsh-Powell** (tri par degre decroissant), inadaptee a la structure reguliere du graphe Sudoku puisque tous les sommets ont un degre identique.\n",
+    "\n",
+    "Les benchmarks comparatifs ont permis de quantifier ces differences : MRV resout un puzzle facile en 37 noeuds et 0 backtrack, tandis que Welsh-Powell necessite 992 noeuds et 955 backtracks sur la meme instance. Cette experience illustre un principe fondamental de la resolution de problemes combinatoires : l'efficacite d'une heuristique depend fortement de la structure du graphe sous-jacent. Les heuristiques conques pour des graphes heterogenes (cartes geographiques, allocation de registres) perdent leur avantage sur les graphes reguliers comme celui du Sudoku.\n",
+    "\n",
+    "Le prochain notebook, **Sudoku-10-ORTools-Python**, passe a une approche industrielle de la programmation par contraintes avec OR-Tools CP-SAT, un solveur qui combine propagation de contraintes, recherche locale et programmation lineaire pour atteindre des performances nettement superieures sur les instances difficiles."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "022b15c7",
    "metadata": {
     "papermill": {
-     "duration": 0.00338,
-     "end_time": "2026-04-25T15:03:12.017919",
+     "duration": 0.003568,
+     "end_time": "2026-06-02T17:32:59.344956+00:00",
      "exception": false,
-     "start_time": "2026-04-25T15:03:12.014539",
+     "start_time": "2026-06-02T17:32:59.341388+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1142,18 +1434,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.013724,
-   "end_time": "2026-04-25T15:03:12.157130",
+   "duration": 3.512842,
+   "end_time": "2026-06-02T17:32:59.803361+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-9-GraphColoring-Python_output.ipynb",
+   "input_path": "Sudoku-9-GraphColoring-Python.ipynb",
+   "output_path": "Sudoku-9-GraphColoring-Python_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T15:03:09.143406",
+   "start_time": "2026-06-02T17:32:56.290519+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Add exercises to 2 Sudoku notebooks per convention #2161 (>=3 exercises per notebook).

### Sudoku-7-Norvig-Python (2 -> 3 exercises)
- **Hidden Singles** (after benchmark interpretation): detect cells where only one digit is possible in a unit

### Sudoku-9-GraphColoring-Python (0 -> 3 exercises)
- **Count unassigned constraints** (after graph stats): count non-colored neighbors per cell
- **MRV + Degree heuristic** (after MRV interpretation): combine MRV with degree tie-breaking
- **Valid coloring check** (after benchmark): verify proper graph coloring

### Validation
- Papermill: Sudoku-7 28/28 cells, Sudoku-9 29/29 cells, 0 errors
- C.1: all stubs use `return False`/`return -1`/`return {}` + TODO, no raise/assert/1-0
- C.2: all code cells have execution_count int + outputs
- Exercises distributed throughout notebooks (not all at end)
- Each exercise preceded by markdown with context + objective + graduated hints

### Rollout #2161 progress
| Notebook | Before | After |
|----------|--------|-------|
| Sudoku-7-Norvig-Python | 2 | 3 |
| Sudoku-9-GraphColoring-Python | 0 | 3 |

Conforme: Sudoku-1, Sudoku-2, Sudoku-3, Sudoku-4, Sudoku-5, Sudoku-6, Sudoku-7, Sudoku-9 = 8/32