### PR TITLE
fix(conway): close mem_lightCone_of_manhattan_le with nested mem_flatMap (HashlifeCorrectness 4→3)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -240,21 +240,60 @@ private theorem int_natAbs_sub_comm (a b : Int) :
 theorem mem_lightCone_of_manhattan_le (p q : Int × Int) (t : Nat)
     (h : manhattan p q ≤ t) : q ∈ lightCone p t := by
   unfold manhattan at h
+  -- h : Int.natAbs (p.1 - q.1) + Int.natAbs (p.2 - q.2) ≤ t
+  -- Switch sub order to match lightCone's filterMap predicate (q - p form).
+  rw [int_natAbs_sub_comm p.1 q.1, int_natAbs_sub_comm p.2 q.2] at h
+  -- h : Int.natAbs (q.1 - p.1) + Int.natAbs (q.2 - p.2) ≤ t
+  -- Derive per-coordinate Int bounds via Int.abs_le (omega does not propagate
+  -- natAbs through the toNat-cast subgoals reliably).
+  have hxNat : Int.natAbs (q.1 - p.1) ≤ t :=
+    Nat.le_trans (Nat.le_add_right _ _) h
+  have hyNat : Int.natAbs (q.2 - p.2) ≤ t :=
+    Nat.le_trans (Nat.le_add_left _ _) h
+  have hx_abs : |q.1 - p.1| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hxNat
+  have hy_abs : |q.2 - p.2| ≤ (t : Int) := by
+    rw [Int.abs_eq_natAbs]; exact_mod_cast hyNat
+  obtain ⟨hx_lo, hx_hi⟩ := abs_le.mp hx_abs
+  obtain ⟨hy_lo, hy_hi⟩ := abs_le.mp hy_abs
+  -- Both differences are in [-t, t]; their +t lift is in [0, 2t].
+  have hx_nn : (0 : Int) ≤ q.1 - p.1 + (t : Int) := by linarith
+  have hy_nn : (0 : Int) ≤ q.2 - p.2 + (t : Int) := by linarith
+  -- Witnesses i and j into List.range (2t+1).
+  set i : Nat := (q.1 - p.1 + (t : Int)).toNat with hi_def_eq
+  set j : Nat := (q.2 - p.2 + (t : Int)).toNat with hj_def_eq
+  have hi_cast : (↑i : Int) = q.1 - p.1 + (t : Int) := by
+    rw [hi_def_eq]; exact Int.toNat_of_nonneg hx_nn
+  have hj_cast : (↑j : Int) = q.2 - p.2 + (t : Int) := by
+    rw [hj_def_eq]; exact Int.toNat_of_nonneg hy_nn
+  have hi_lt : i < 2 * t + 1 := by
+    have h_int : (↑i : Int) < ((2 * t + 1 : Nat) : Int) := by
+      rw [hi_cast]; push_cast; linarith
+    exact_mod_cast h_int
+  have hj_lt : j < 2 * t + 1 := by
+    have h_int : (↑j : Int) < ((2 * t + 1 : Nat) : Int) := by
+      rw [hj_cast]; push_cast; linarith
+    exact_mod_cast h_int
+  have hi_image : p.1 - (t : Int) + ↑i = q.1 := by rw [hi_cast]; ring
+  have hj_image : p.2 - (t : Int) + ↑j = q.2 := by rw [hj_cast]; ring
+  -- Assemble the membership proof.
+  -- Note: Lean elaborates `List.range n |>.map (fun i => p.1 - ↑t + i)` (where i : Nat)
+  -- as `List.map (fun (i : Int) => p.1 - ↑t + i) (List.range n |>.map (↑·))` —
+  -- a composition of two maps. We need two nested `List.mem_map.mpr` calls.
   unfold lightCone
-  simp only [List.mem_flatMap]
-  refine ⟨q.1, ?_, ?_⟩
-  · simp only [List.mem_map, List.mem_range]
-    refine ⟨(q.1 - p.1 + t).toNat, ?_, ?_⟩
-    · omega
-    · omega
-  · simp only [List.mem_filterMap]
-    refine ⟨q.2, ?_, ?_⟩
-    · simp only [List.mem_map, List.mem_range]
-      refine ⟨(q.2 - p.2 + t).toNat, ?_, ?_⟩
-      · omega
-      · omega
-    · have hd : Int.natAbs (q.1 - p.1) + Int.natAbs (q.2 - p.2) ≤ t := by omega
-      simp [hd, show (q.1, q.2) = q from rfl]
+  refine List.mem_flatMap.mpr ⟨q.1, ?_, ?_⟩
+  · -- q.1 ∈ List.map (fun (i : Int) => p.1 - ↑t + i) (do let a ← range; pure ↑a)
+    refine List.mem_map.mpr ⟨(↑i : Int), ?_, hi_image⟩
+    -- ↑i ∈ do let a ← range; pure ↑a — use mem_flatMap on the do/pure form
+    refine List.mem_flatMap.mpr ⟨i, List.mem_range.mpr hi_lt, ?_⟩
+    exact List.mem_singleton.mpr rfl
+  · refine List.mem_filterMap.mpr ⟨q.2, ?_, ?_⟩
+    · -- q.2 ∈ List.map (fun (j : Int) => p.2 - ↑t + j) (do let a ← range; pure ↑a)
+      refine List.mem_map.mpr ⟨(↑j : Int), ?_, hj_image⟩
+      refine List.mem_flatMap.mpr ⟨j, List.mem_range.mpr hj_lt, ?_⟩
+      exact List.mem_singleton.mpr rfl
+    · -- (if d ≤ t then some (q.1, q.2) else none) = some q
+      simp only [if_pos h]
 
 /-- Reverse direction: every cell in `lightCone p t` is within Manhattan
     distance `t` of `p`. The light cone is exactly the Manhattan ball of

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -239,7 +239,22 @@ private theorem int_natAbs_sub_comm (a b : Int) :
     Manhattan ball of radius `t`, which is exactly what `lightCone p t` enumerates. -/
 theorem mem_lightCone_of_manhattan_le (p q : Int × Int) (t : Nat)
     (h : manhattan p q ≤ t) : q ∈ lightCone p t := by
-  sorry
+  unfold manhattan at h
+  unfold lightCone
+  simp only [List.mem_flatMap]
+  refine ⟨q.1, ?_, ?_⟩
+  · simp only [List.mem_map, List.mem_range]
+    refine ⟨(q.1 - p.1 + t).toNat, ?_, ?_⟩
+    · omega
+    · omega
+  · simp only [List.mem_filterMap]
+    refine ⟨q.2, ?_, ?_⟩
+    · simp only [List.mem_map, List.mem_range]
+      refine ⟨(q.2 - p.2 + t).toNat, ?_, ?_⟩
+      · omega
+      · omega
+    · have hd : Int.natAbs (q.1 - p.1) + Int.natAbs (q.2 - p.2) ≤ t := by omega
+      simp [hd, show (q.1, q.2) = q from rfl]
 
 /-- Reverse direction: every cell in `lightCone p t` is within Manhattan
     distance `t` of `p`. The light cone is exactly the Manhattan ball of


### PR DESCRIPTION
## Summary

Closes the bridge lemma `mem_lightCone_of_manhattan_le` in `Conway.Life.HashlifeCorrectness`. Replaces PR #2173 (stale base, broken `simp` approach) with a clean rebase onto current main and a working proof using nested `List.mem_flatMap`.

**Epic** : #1647 (Conway Life Phase 3b — light-cone bound)
**Phase** : 3b (P1 — geometric witness)
**Supersedes** : #2173

## Proof strategy

`q ∈ lightCone p t` unfolds to membership in `rs.flatMap (fun r => cs.filterMap ...)`. Lean elaborates `rs := List.range n |>.map (fun i : Nat => p.1 - ↑t + i)` as a **composition of TWO maps** :
- outer : `List.map (fun (i : Int) => p.1 - ↑t + i)`
- inner : `do let a ← List.range n; pure (↑a : Int)`

The omega tactic in the original `· omega` (lines 248/254) cannot discharge bounds on `(q.1 - p.1 + t).toNat` because `Int.natAbs` is opaque to it after `unfold manhattan at h`. Fix : decompose into 3 explicit steps BEFORE any omega/conversion :

1. `int_natAbs_sub_comm` flip `(p-q).natAbs ↔ (q-p).natAbs` to align with `lightCone` convention.
2. `abs_le.mp` + `Int.abs_eq_natAbs` lift natAbs ≤ t to `|q-p| ≤ (t:Int)` (Int).
3. `Int.toNat_of_nonneg` + `set i := (...).toNat` + `linarith`/`exact_mod_cast` to prove `i < 2*t+1` without omega on coercions.

Final membership : outer `List.mem_map.mpr ⟨↑i, ..., hi_image⟩`, inner `List.mem_flatMap.mpr ⟨i, mem_range, mem_singleton.mpr rfl⟩`.

## Lean PR discipline (4 elements per .claude/rules/pr-review-discipline.md §B)

### 1. \`grep -c sorry\` before/after by file modified

\`\`\`
# Before (origin/main):
$ grep -c 'sorry' MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
4   # real declarations only (excludes comment occurrences)

# After (this PR):
$ grep -c 'sorry' MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
3   # at L584/L615/L638 = P3/P4/P5 downstream (unchanged)
\`\`\`

Net: **-1 sorry** in the file. `mem_lightCone_of_manhattan_le` desormais PROUVÉ. No other Conway module touched (anti-régression preserved).

### 2. Lake build SUCCESS

\`\`\`
$ cd MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean
$ lake build Conway.Life.HashlifeCorrectness
\`\`\`

**Result** (WSL Ubuntu, Lean v4.30.0-rc2) :
- `Build completed successfully (3319 jobs).`
- 3 remaining sorry warnings at L584/L615/L638 (P3/P4/P5 downstream — separate targets)
- 7 pre-existing `unusedSimpArgs` linter hints at L394-408 — **not introduced by this PR**
- 0 errors

### 3. Proof integrity

The closed declaration is a theorem, not a definition; no axiom introduced. The proof uses only `unfold`, `simp only`, `rw`, `refine`, `set`, `linarith`, `exact_mod_cast`, `push_cast`, `ring`, `obtain`, `List.mem_*` — all sound Mathlib tactics. No `native_decide`, no `sorry`, no `Classical`-dependent steps.

### 4. Justification (not a prover refactor)

Pure proof addition (replacing one sorry by a tactical proof). No code in `prover/` touched. No public API change (theorem signature unchanged).

## Diff

- `HashlifeCorrectness.lean` : +53 / -14

## Test plan

- [x] Local Lake build SUCCESS for `Conway.Life.HashlifeCorrectness` (3319 jobs)
- [x] No regression : 3 sorries remain at unchanged line ranges (L584/L615/L638)
- [x] No `native_decide` used (the theorem is purely tactical)
- [x] Branch rebased onto current main (includes #2186 step_light_cone + Sudoku/Tweety enrichments)
- [ ] Coordinator (ai-01) re-runs `lake build Conway.Life.HashlifeCorrectness` locally before merge (per `.claude/rules/lean-merge-discipline.md`)

## Follow-up

3 sorries remain in HashlifeCorrectness (P3/P4/P5 downstream consumers of this bridge) :
- L584 — downstream reachability lemma
- L615 — downstream reachability lemma  
- L638 — downstream reachability lemma

These will be closed in subsequent PRs (multi-cycle Phase 3b completion).

## Replaces #2173

PR #2173 had a stale base (pre-`step_light_cone` merge, missing 13 main commits) AND a non-compiling proof attempt (`simp` flow gave metavariable inference failure on the nested `do/pure` form). This PR is a clean rebase + working fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)