### PR TITLE
feat(add): add tp 22 Mehdi AZOUZ, Ryad Gazenay, Hani BOUZIDA

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -5,10 +5,10 @@
    "id": "cell-0",
    "metadata": {
     "papermill": {
-     "duration": 0.002877,
-     "end_time": "2026-05-26T19:24:02.260492",
+     "duration": 0.007612,
+     "end_time": "2026-06-02T19:42:56.302862+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.257615",
+     "start_time": "2026-06-02T19:42:56.295250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -41,10 +41,10 @@
    "id": "cell-1",
    "metadata": {
     "papermill": {
-     "duration": 0.002494,
-     "end_time": "2026-05-26T19:24:02.265675",
+     "duration": 0.005119,
+     "end_time": "2026-06-02T19:42:56.313756+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.263181",
+     "start_time": "2026-06-02T19:42:56.308637+00:00",
      "status": "completed"
     },
     "tags": []
@@ -63,16 +63,16 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.271411Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.271132Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.277994Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.277345Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.326985Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.326440Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.334814Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.333079Z"
     },
     "papermill": {
-     "duration": 0.011229,
-     "end_time": "2026-05-26T19:24:02.279140",
+     "duration": 0.016946,
+     "end_time": "2026-06-02T19:42:56.336200+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.267911",
+     "start_time": "2026-06-02T19:42:56.319254+00:00",
      "status": "completed"
     },
     "tags": []
@@ -132,10 +132,10 @@
    "id": "cell-3",
    "metadata": {
     "papermill": {
-     "duration": 0.002521,
-     "end_time": "2026-05-26T19:24:02.284311",
+     "duration": 0.005658,
+     "end_time": "2026-06-02T19:42:56.347488+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.281790",
+     "start_time": "2026-06-02T19:42:56.341830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -152,16 +152,16 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.291239Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.290604Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.295924Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.295299Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.358886Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.358581Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.364563Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.363705Z"
     },
     "papermill": {
-     "duration": 0.010493,
-     "end_time": "2026-05-26T19:24:02.297379",
+     "duration": 0.012935,
+     "end_time": "2026-06-02T19:42:56.365332+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.286886",
+     "start_time": "2026-06-02T19:42:56.352397+00:00",
      "status": "completed"
     },
     "tags": []
@@ -351,10 +351,10 @@
    "id": "363115b1",
    "metadata": {
     "papermill": {
-     "duration": 0.002833,
-     "end_time": "2026-05-26T19:24:02.303463",
+     "duration": 0.002844,
+     "end_time": "2026-06-02T19:42:56.371383+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.300630",
+     "start_time": "2026-06-02T19:42:56.368539+00:00",
      "status": "completed"
     },
     "tags": []
@@ -392,10 +392,10 @@
    "id": "cell-5",
    "metadata": {
     "papermill": {
-     "duration": 0.003986,
-     "end_time": "2026-05-26T19:24:02.311088",
+     "duration": 0.002746,
+     "end_time": "2026-06-02T19:42:56.376638+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.307102",
+     "start_time": "2026-06-02T19:42:56.373892+00:00",
      "status": "completed"
     },
     "tags": []
@@ -414,16 +414,16 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.319428Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.318819Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.325793Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.324492Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.382721Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.382538Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.385873Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.385084Z"
     },
     "papermill": {
-     "duration": 0.012964,
-     "end_time": "2026-05-26T19:24:02.327474",
+     "duration": 0.007282,
+     "end_time": "2026-06-02T19:42:56.386472+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.314510",
+     "start_time": "2026-06-02T19:42:56.379190+00:00",
      "status": "completed"
     },
     "tags": []
@@ -497,10 +497,10 @@
    "id": "57c3e2b2",
    "metadata": {
     "papermill": {
-     "duration": 0.00563,
-     "end_time": "2026-05-26T19:24:02.338359",
+     "duration": 0.003205,
+     "end_time": "2026-06-02T19:42:56.392264+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.332729",
+     "start_time": "2026-06-02T19:42:56.389059+00:00",
      "status": "completed"
     },
     "tags": []
@@ -541,10 +541,10 @@
    "id": "cell-7",
    "metadata": {
     "papermill": {
-     "duration": 0.005552,
-     "end_time": "2026-05-26T19:24:02.353919",
+     "duration": 0.002594,
+     "end_time": "2026-06-02T19:42:56.397685+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.348367",
+     "start_time": "2026-06-02T19:42:56.395091+00:00",
      "status": "completed"
     },
     "tags": []
@@ -561,16 +561,16 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.368191Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.367447Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.375512Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.374269Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.403505Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.403328Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.407054Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.406110Z"
     },
     "papermill": {
-     "duration": 0.016572,
-     "end_time": "2026-05-26T19:24:02.377499",
+     "duration": 0.007987,
+     "end_time": "2026-06-02T19:42:56.408072+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.360927",
+     "start_time": "2026-06-02T19:42:56.400085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -676,10 +676,10 @@
    "id": "08e40c12",
    "metadata": {
     "papermill": {
-     "duration": 0.005182,
-     "end_time": "2026-05-26T19:24:02.388208",
+     "duration": 0.002737,
+     "end_time": "2026-06-02T19:42:56.413794+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.383026",
+     "start_time": "2026-06-02T19:42:56.411057+00:00",
      "status": "completed"
     },
     "tags": []
@@ -722,10 +722,10 @@
    "id": "cell-9",
    "metadata": {
     "papermill": {
-     "duration": 0.005401,
-     "end_time": "2026-05-26T19:24:02.398787",
+     "duration": 0.002372,
+     "end_time": "2026-06-02T19:42:56.418655+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.393386",
+     "start_time": "2026-06-02T19:42:56.416283+00:00",
      "status": "completed"
     },
     "tags": []
@@ -742,16 +742,16 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.411052Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.410569Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.416058Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.415254Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.425344Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.425095Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.428869Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.428030Z"
     },
     "papermill": {
-     "duration": 0.013806,
-     "end_time": "2026-05-26T19:24:02.417918",
+     "duration": 0.008381,
+     "end_time": "2026-06-02T19:42:56.429413+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.404112",
+     "start_time": "2026-06-02T19:42:56.421032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -839,10 +839,10 @@
    "id": "9211c5c1",
    "metadata": {
     "papermill": {
-     "duration": 0.006319,
-     "end_time": "2026-05-26T19:24:02.428942",
+     "duration": 0.002571,
+     "end_time": "2026-06-02T19:42:56.434733+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.422623",
+     "start_time": "2026-06-02T19:42:56.432162+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,10 +882,10 @@
    "id": "cell-11",
    "metadata": {
     "papermill": {
-     "duration": 0.005795,
-     "end_time": "2026-05-26T19:24:02.439914",
+     "duration": 0.002586,
+     "end_time": "2026-06-02T19:42:56.439837+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.434119",
+     "start_time": "2026-06-02T19:42:56.437251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -902,16 +902,16 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T19:24:02.452875Z",
-     "iopub.status.busy": "2026-05-26T19:24:02.452569Z",
-     "iopub.status.idle": "2026-05-26T19:24:02.459799Z",
-     "shell.execute_reply": "2026-05-26T19:24:02.458852Z"
+     "iopub.execute_input": "2026-06-02T19:42:56.446763Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.446546Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.450627Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.449937Z"
     },
     "papermill": {
-     "duration": 0.015856,
-     "end_time": "2026-05-26T19:24:02.462017",
+     "duration": 0.008469,
+     "end_time": "2026-06-02T19:42:56.451203+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.446161",
+     "start_time": "2026-06-02T19:42:56.442734+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1068,10 +1068,10 @@
    "id": "35563e9e",
    "metadata": {
     "papermill": {
-     "duration": 0.005302,
-     "end_time": "2026-05-26T19:24:02.472906",
+     "duration": 0.002933,
+     "end_time": "2026-06-02T19:42:56.456923+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.467604",
+     "start_time": "2026-06-02T19:42:56.453990+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1109,13 +1109,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-13",
+   "id": "809c8068",
    "metadata": {
     "papermill": {
-     "duration": 0.007157,
-     "end_time": "2026-05-26T19:24:02.485090",
+     "duration": 0.002688,
+     "end_time": "2026-06-02T19:42:56.462438+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.477933",
+     "start_time": "2026-06-02T19:42:56.459750+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1123,7 +1123,461 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Resume\n",
+    "## 7. Exercices pratiques\n",
+    "\n",
+    "Ces trois exercices couvrent les concepts fondamentaux de Solana et Anchor vus dans ce notebook : dérivation de PDA, structure d'un programme Anchor, et modèle de comptes Solana."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b605678",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002573,
+     "end_time": "2026-06-02T19:42:56.467616+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.465043+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Simulation Python de dérivation PDA\n",
+    "\n",
+    "Implémentez en Python la logique de dérivation d'un PDA Solana.\n",
+    "\n",
+    "Un PDA est produit en cherchant un **bump** (entier 255→0) tel que le hash résultant soit \"hors courbe\" ed25519 (on simule cette condition avec le premier octet < 128).\n",
+    "\n",
+    "| Propriété à tester | Résultat attendu |\n",
+    "|--------------------|-----------------|\n",
+    "| Même seeds → même PDA | `True` (déterministe) |\n",
+    "| Seeds différentes → PDAs différents | `True` (unicité par utilisateur) |\n",
+    "| Bump trouvé entre 0 et 255 | Entier valide |\n",
+    "\n",
+    "> **Conseil** : regardez le code de la section 3 (PDAs) pour comprendre la structure `seeds = [b\"counter\", authority.key().as_ref()]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "45ca8817",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T19:42:56.474119Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.473779Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.479516Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.478689Z"
+    },
+    "papermill": {
+     "duration": 0.009996,
+     "end_time": "2026-06-02T19:42:56.480084+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.470088+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PDA alice        : 60ff9343476e7bb2...\n",
+      "Bump             : 255\n",
+      "Deterministe     : True\n",
+      "PDA bob != alice : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Simulation Python de derivation PDA\n",
+    "import hashlib\n",
+    "\n",
+    "def derive_pda_simulee(seeds: list, program_id: str) -> tuple:\n",
+    "    \"\"\"\n",
+    "    Simule la derivation d'un PDA Solana en Python.\n",
+    "\n",
+    "    Convention simplifiee : on cherche le premier bump (255..0) tel que\n",
+    "    SHA256(b\"\".join(seeds) + program_id.encode() + bytes([bump]))\n",
+    "    produise un hash dont le premier octet (int) est < 128\n",
+    "    (simule \"hors courbe ed25519\").\n",
+    "\n",
+    "    Args:\n",
+    "        seeds     : liste de bytes (ex: [b\"counter\", b\"alice_pubkey\"])\n",
+    "        program_id: identifiant du programme (str)\n",
+    "\n",
+    "    Returns:\n",
+    "        (pda_address: str, bump: int) ou (None, None) si aucun bump trouve\n",
+    "    \"\"\"\n",
+    "    seeds_bytes = b\"\".join(seeds)\n",
+    "    for bump in range(255, -1, -1):\n",
+    "        data = seeds_bytes + program_id.encode() + bytes([bump])\n",
+    "        h = hashlib.sha256(data).hexdigest()\n",
+    "        if int(h[:2], 16) < 128:\n",
+    "            return h, bump\n",
+    "    return None, None\n",
+    "\n",
+    "# --- Tests ---\n",
+    "seeds_alice = [b\"counter\", b\"alice_pubkey_example\"]\n",
+    "program_id  = \"MyCounter1111111111111111111111111\"\n",
+    "\n",
+    "pda, bump = derive_pda_simulee(seeds_alice, program_id)\n",
+    "print(f\"PDA alice        : {pda[:16]}...\")\n",
+    "print(f\"Bump             : {bump}\")\n",
+    "pda2, _ = derive_pda_simulee(seeds_alice, program_id)\n",
+    "print(f\"Deterministe     : {pda == pda2}\")\n",
+    "seeds_bob = [b\"counter\", b\"bob_pubkey_example\"]\n",
+    "pda_bob, _ = derive_pda_simulee(seeds_bob, program_id)\n",
+    "print(f\"PDA bob != alice : {pda != pda_bob}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f34b44b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002874,
+     "end_time": "2026-06-02T19:42:56.485909+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.483035+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Compléter un programme Anchor de Vote\n",
+    "\n",
+    "Complétez les parties manquantes du programme de vote Anchor/Rust ci-dessous.\n",
+    "\n",
+    "Les fonctions `create_poll` et `vote` ont leur logique à implémenter, et la struct `CastVote` manque du compte `poll`.\n",
+    "\n",
+    "| Partie à compléter | Indice |\n",
+    "|--------------------|--------|\n",
+    "| `create_poll` — assignation des champs | Utiliser `poll.champ = valeur` directement |\n",
+    "| `vote` — logique de choix | `match choice { 0 => ..., 1 => ..., _ => err!(...) }` |\n",
+    "| `CastVote` — compte `poll` | Ajouter `#[account(mut, seeds=[...], bump)]` |\n",
+    "\n",
+    "> **Rappel PDA** : les seeds `[b\"poll\", authority.key().as_ref()]` garantissent un PDA unique par utilisateur (même pattern que le Counter en section 2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "3549647e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T19:42:56.493895Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.493627Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.499473Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.498224Z"
+    },
+    "papermill": {
+     "duration": 0.011338,
+     "end_time": "2026-06-02T19:42:56.500452+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.489114+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 - Programme de vote Anchor complete :\n",
+      "\n",
+      "use anchor_lang::prelude::*;\n",
+      "\n",
+      "declare_id!(\"Vote1111111111111111111111111111111111111\");\n",
+      "\n",
+      "#[program]\n",
+      "pub mod voting {\n",
+      "    use super::*;\n",
+      "\n",
+      "    pub fn create_poll(\n",
+      "        ctx: Context<CreatePoll>,\n",
+      "        question: String,\n",
+      "        option_a: String,\n",
+      "        option_b: String,\n",
+      "    ) -> Result<()> {\n",
+      "        let poll = &mut ctx.accounts.poll;\n",
+      "        poll.question  = question;\n",
+      "        poll.option_a  = option_a;\n",
+      "        poll.option_b  = option_b;\n",
+      "        poll.votes_a   = 0;\n",
+      "        poll.votes_b   = 0;\n",
+      "        poll.authority = ctx.accounts.authority.key();\n",
+      "        poll.is_open   = true;\n",
+      "        Ok(())\n",
+      "    }\n",
+      "\n",
+      "    pub fn vote(ctx: Context<CastVote>, choice: u8) -> Result<()> {\n",
+      "        let poll = &mut ctx.accounts.poll;\n",
+      "        require!(poll.is_open, PollError::PollClosed);\n",
+      "        match choice {\n",
+      "            0 => poll.votes_a += 1,\n",
+      "            1 => poll.votes_b += 1,\n",
+      "            _ => return err!(PollError::InvalidChoice),\n",
+      "        }\n",
+      "        Ok(())\n",
+      "    }\n",
+      "}\n",
+      "\n",
+      "#[derive(Accounts)]\n",
+      "pub struct CreatePoll<'info> {\n",
+      "    #[account(\n",
+      "        init,\n",
+      "        payer = authority,\n",
+      "        space = 8 + Poll::INIT_SPACE,\n",
+      "        seeds = [b\"poll\", authority.key().as_ref()],\n",
+      "        bump\n",
+      "    )]\n",
+      "    pub poll: Account<'info, Poll>,\n",
+      "    #[account(mut)]\n",
+      "    pub authority: Signer<'info>,\n",
+      "    pub system_program: Program<'info, System>,\n",
+      "}\n",
+      "\n",
+      "#[derive(Accounts)]\n",
+      "pub struct CastVote<'info> {\n",
+      "    #[account(mut, seeds = [b\"poll\", authority.key().as_ref()], bump)]\n",
+      "    pub poll: Account<'info, Poll>,\n",
+      "    pub authority: Signer<'info>,\n",
+      "}\n",
+      "\n",
+      "#[account]\n",
+      "#[derive(InitSpace)]\n",
+      "pub struct Poll {\n",
+      "    pub authority: Pubkey,\n",
+      "    #[max_len(200)] pub question: String,\n",
+      "    #[max_len(100)] pub option_a: String,\n",
+      "    #[max_len(100)] pub option_b: String,\n",
+      "    pub votes_a: u64,\n",
+      "    pub votes_b: u64,\n",
+      "    pub is_open: bool,\n",
+      "}\n",
+      "\n",
+      "#[error_code]\n",
+      "pub enum PollError {\n",
+      "    #[msg(\"Le sondage est ferme\")] PollClosed,\n",
+      "    #[msg(\"Choix invalide : 0 ou 1 uniquement\")] InvalidChoice,\n",
+      "}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Programme Anchor de Vote complete (Rust)\n",
+    "\n",
+    "VOTE_PROGRAM_COMPLET = '''\n",
+    "use anchor_lang::prelude::*;\n",
+    "\n",
+    "declare_id!(\"Vote1111111111111111111111111111111111111\");\n",
+    "\n",
+    "#[program]\n",
+    "pub mod voting {\n",
+    "    use super::*;\n",
+    "\n",
+    "    pub fn create_poll(\n",
+    "        ctx: Context<CreatePoll>,\n",
+    "        question: String,\n",
+    "        option_a: String,\n",
+    "        option_b: String,\n",
+    "    ) -> Result<()> {\n",
+    "        let poll = &mut ctx.accounts.poll;\n",
+    "        poll.question  = question;\n",
+    "        poll.option_a  = option_a;\n",
+    "        poll.option_b  = option_b;\n",
+    "        poll.votes_a   = 0;\n",
+    "        poll.votes_b   = 0;\n",
+    "        poll.authority = ctx.accounts.authority.key();\n",
+    "        poll.is_open   = true;\n",
+    "        Ok(())\n",
+    "    }\n",
+    "\n",
+    "    pub fn vote(ctx: Context<CastVote>, choice: u8) -> Result<()> {\n",
+    "        let poll = &mut ctx.accounts.poll;\n",
+    "        require!(poll.is_open, PollError::PollClosed);\n",
+    "        match choice {\n",
+    "            0 => poll.votes_a += 1,\n",
+    "            1 => poll.votes_b += 1,\n",
+    "            _ => return err!(PollError::InvalidChoice),\n",
+    "        }\n",
+    "        Ok(())\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "#[derive(Accounts)]\n",
+    "pub struct CreatePoll<\\'info> {\n",
+    "    #[account(\n",
+    "        init,\n",
+    "        payer = authority,\n",
+    "        space = 8 + Poll::INIT_SPACE,\n",
+    "        seeds = [b\"poll\", authority.key().as_ref()],\n",
+    "        bump\n",
+    "    )]\n",
+    "    pub poll: Account<\\'info, Poll>,\n",
+    "    #[account(mut)]\n",
+    "    pub authority: Signer<\\'info>,\n",
+    "    pub system_program: Program<\\'info, System>,\n",
+    "}\n",
+    "\n",
+    "#[derive(Accounts)]\n",
+    "pub struct CastVote<\\'info> {\n",
+    "    #[account(mut, seeds = [b\"poll\", authority.key().as_ref()], bump)]\n",
+    "    pub poll: Account<\\'info, Poll>,\n",
+    "    pub authority: Signer<\\'info>,\n",
+    "}\n",
+    "\n",
+    "#[account]\n",
+    "#[derive(InitSpace)]\n",
+    "pub struct Poll {\n",
+    "    pub authority: Pubkey,\n",
+    "    #[max_len(200)] pub question: String,\n",
+    "    #[max_len(100)] pub option_a: String,\n",
+    "    #[max_len(100)] pub option_b: String,\n",
+    "    pub votes_a: u64,\n",
+    "    pub votes_b: u64,\n",
+    "    pub is_open: bool,\n",
+    "}\n",
+    "\n",
+    "#[error_code]\n",
+    "pub enum PollError {\n",
+    "    #[msg(\"Le sondage est ferme\")] PollClosed,\n",
+    "    #[msg(\"Choix invalide : 0 ou 1 uniquement\")] InvalidChoice,\n",
+    "}\n",
+    "'''\n",
+    "\n",
+    "print(\"Exercice 2 - Programme de vote Anchor complete :\")\n",
+    "print(VOTE_PROGRAM_COMPLET)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ba3d8c0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005515,
+     "end_time": "2026-06-02T19:42:56.510864+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.505349+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Modéliser un Counter Solana en Python\n",
+    "\n",
+    "Implémentez la logique du programme Counter Anchor en Python pur pour valider votre compréhension du **modèle de comptes Solana**.\n",
+    "\n",
+    "Contraintes à respecter :\n",
+    "- `initialize` crée un `SolanaAccount` avec `count = 0` et l'`authority` passée\n",
+    "- `increment` vérifie que l'appelant est l'authority avant d'incrémenter\n",
+    "- `decrement` vérifie l'authority ET que `count > 0` (protection underflow comme dans Anchor)\n",
+    "\n",
+    "> **Rappel** : sur Solana, chaque utilisateur possède son propre compte PDA — il n'y a pas d'état global dans le programme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fbf352aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T19:42:56.524795Z",
+     "iopub.status.busy": "2026-06-02T19:42:56.524425Z",
+     "iopub.status.idle": "2026-06-02T19:42:56.538240Z",
+     "shell.execute_reply": "2026-06-02T19:42:56.536715Z"
+    },
+    "papermill": {
+     "duration": 0.02262,
+     "end_time": "2026-06-02T19:42:56.539433+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.516813+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initialise  : count = 0\n",
+      "Increment   : count = 1\n",
+      "Increment   : count = 2\n",
+      "Decrement   : count = 1\n",
+      "Autorite invalide interceptee : Autorite invalide\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : Modeliser un Counter Solana en Python\n",
+    "\n",
+    "class SolanaAccount:\n",
+    "    \"\"\"Simule un compte Solana (programme owner + donnees)\"\"\"\n",
+    "    def __init__(self, owner: str, data: dict):\n",
+    "        self.owner = owner\n",
+    "        self.data = data\n",
+    "\n",
+    "class CounterProgram:\n",
+    "    \"\"\"Simule le programme Counter Anchor.\"\"\"\n",
+    "    PROGRAM_ID = \"Counter1111111111111111111111111111\"\n",
+    "\n",
+    "    def initialize(self, authority: str) -> SolanaAccount:\n",
+    "        return SolanaAccount(\n",
+    "            owner=self.PROGRAM_ID,\n",
+    "            data={\"authority\": authority, \"count\": 0}\n",
+    "        )\n",
+    "\n",
+    "    def increment(self, counter: SolanaAccount, authority: str) -> None:\n",
+    "        if authority != counter.data[\"authority\"]:\n",
+    "            raise ValueError(\"Autorite invalide\")\n",
+    "        counter.data[\"count\"] += 1\n",
+    "\n",
+    "    def decrement(self, counter: SolanaAccount, authority: str) -> None:\n",
+    "        if authority != counter.data[\"authority\"]:\n",
+    "            raise ValueError(\"Autorite invalide\")\n",
+    "        if counter.data[\"count\"] == 0:\n",
+    "            raise ValueError(\"Underflow\")\n",
+    "        counter.data[\"count\"] -= 1\n",
+    "\n",
+    "# --- Tests ---\n",
+    "program = CounterProgram()\n",
+    "alice = \"alice_pubkey_111111\"\n",
+    "\n",
+    "counter = program.initialize(alice)\n",
+    "print(f\"Initialise  : count = {counter.data['count']}\")   # attendu : 0\n",
+    "program.increment(counter, alice)\n",
+    "print(f\"Increment   : count = {counter.data['count']}\")   # attendu : 1\n",
+    "program.increment(counter, alice)\n",
+    "print(f\"Increment   : count = {counter.data['count']}\")   # attendu : 2\n",
+    "program.decrement(counter, alice)\n",
+    "print(f\"Decrement   : count = {counter.data['count']}\")   # attendu : 1\n",
+    "try:\n",
+    "    program.increment(counter, \"intrus_pubkey_000\")\n",
+    "except ValueError as e:\n",
+    "    print(f\"Autorite invalide interceptee : {e}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005848,
+     "end_time": "2026-06-02T19:42:56.551617+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.545769+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "\n",
+    "## 8. Resume\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
@@ -1143,10 +1597,10 @@
    "id": "11ed5661",
    "metadata": {
     "papermill": {
-     "duration": 0.006106,
-     "end_time": "2026-05-26T19:24:02.497714",
+     "duration": 0.00493,
+     "end_time": "2026-06-02T19:42:56.562051+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.491608",
+     "start_time": "2026-06-02T19:42:56.557121+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1162,10 +1616,10 @@
    "id": "fc487a53",
    "metadata": {
     "papermill": {
-     "duration": 0.005223,
-     "end_time": "2026-05-26T19:24:02.507935",
+     "duration": 0.003673,
+     "end_time": "2026-06-02T19:42:56.569949+00:00",
      "exception": false,
-     "start_time": "2026-05-26T19:24:02.502712",
+     "start_time": "2026-06-02T19:42:56.566276+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1197,8 +1651,25 @@
   {
    "cell_type": "markdown",
    "id": "689f6d48",
-   "source": "## Resume et perspectives\n\nCe notebook a permis de decourir l'ecosysteme Solana et le framework Anchor comme alternative a l'ecosysteme Ethereum/Solidity. Nous avons compare les architectures : modele de comptes stateless et execution BPF haute performance (~65 000 TPS theoriques) chez Solana versus stockage dans le contrat et EVM chez Ethereum. Nous avons implemente un programme Counter en Rust avec Anchor, explorant les annotations `#[program]`, `#[account]` et `#[derive(Accounts)]` qui abstraient la complexite du modele de comptes. Nous avons etudie les PDAs (Program Derived Addresses) pour le stockage deterministe et securise de donnees utilisateur, les CPIs (Cross-Program Invocations) pour la composition de programmes, et implémente un escrow atomique de tokens SPL combinant `CpiContext::new` et `CpiContext::new_with_signer` pour les transfers signes par PDA.\n\nLa difference philosophique majeure entre Solana et Ethereum reside dans la separation stricte entre code (programmes stateless) et donnees (comptes independants). Ce modele enable le parallelisme natif des transactions et elimine la contention globale, mais exige une planification plus rigoureuse de la structure des comptes. Les PDAs remplacent les mappings Solidity par des adresses deterministes sans cle privee, offrant une securite inherente contre les acces non autorises. Le framework Anchor simplifie considerablement le developpement en Rust tout en preservant les garanties de securite du type system.\n\nLe notebook suivant, [SC-23-Cross-Chain](../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb), aborde l'interoperabilite entre blockchains et les protocols de communication cross-chain comme Chainlink CCIP.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003023,
+     "end_time": "2026-06-02T19:42:56.576273+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T19:42:56.573250+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a permis de decourir l'ecosysteme Solana et le framework Anchor comme alternative a l'ecosysteme Ethereum/Solidity. Nous avons compare les architectures : modele de comptes stateless et execution BPF haute performance (~65 000 TPS theoriques) chez Solana versus stockage dans le contrat et EVM chez Ethereum. Nous avons implemente un programme Counter en Rust avec Anchor, explorant les annotations `#[program]`, `#[account]` et `#[derive(Accounts)]` qui abstraient la complexite du modele de comptes. Nous avons etudie les PDAs (Program Derived Addresses) pour le stockage deterministe et securise de donnees utilisateur, les CPIs (Cross-Program Invocations) pour la composition de programmes, et implémente un escrow atomique de tokens SPL combinant `CpiContext::new` et `CpiContext::new_with_signer` pour les transfers signes par PDA.\n",
+    "\n",
+    "La difference philosophique majeure entre Solana et Ethereum reside dans la separation stricte entre code (programmes stateless) et donnees (comptes independants). Ce modele enable le parallelisme natif des transactions et elimine la contention globale, mais exige une planification plus rigoureuse de la structure des comptes. Les PDAs remplacent les mappings Solidity par des adresses deterministes sans cle privee, offrant une securite inherente contre les acces non autorises. Le framework Anchor simplifie considerablement le developpement en Rust tout en preservant les garanties de securite du type system.\n",
+    "\n",
+    "Le notebook suivant, [SC-23-Cross-Chain](../06-Real-World/../06-Real-World/SC-23-Cross-Chain.ipynb), aborde l'interoperabilite entre blockchains et les protocols de communication cross-chain comme Chainlink CCIP."
+   ]
   }
  ],
  "metadata": {
@@ -1217,18 +1688,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.14.4"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.58473,
-   "end_time": "2026-05-26T19:24:06.061063",
+   "duration": 1.404584,
+   "end_time": "2026-06-02T19:42:56.794808+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/sc22_output.ipynb",
+   "output_path": "/tmp/SC-22-exec-out.ipynb",
    "parameters": {},
-   "start_time": "2026-05-26T19:24:00.476333",
+   "start_time": "2026-06-02T19:42:55.390224+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

- Complétion du notebook SC-22-Solana-Anchor : exercices pratiques sur Solana et Anchor
- Ajout de 3 exercices : simulation PDA en Python, programme de vote Anchor (Rust), modélisation Counter Solana
- Notebook exécuté avec outputs sauvegardés

## Changes

- `SC-22-Solana-Anchor.ipynb` : ajout section "7. Exercices pratiques" avec 3 exercices complétés

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
