### PR TITLE
feat(lean): Grothendieck Phase 2 — Sieve pullback identities (#2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -23,3 +23,4 @@ import Grothendieck.SchemesTour
 import Grothendieck.ZariskiSite
 import Grothendieck.MathlibMap
 import Grothendieck.Calibration
+import Grothendieck.SieveLattice

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
@@ -1,0 +1,88 @@
+/-
+Grothendieck tribute — Part 6: Sieve pullback identities and lattice laws
+Alexandre Grothendieck (1928-2014).
+
+Phase 2 extension (#2159, Epic #2162).
+
+Part 1 (CategoryAndSites.lean) introduces sieves, the three axioms,
+and the complete lattice on Sieve X. This module records the basic
+identities of pullback along morphisms:
+
+  - Pullback along the identity is the identity (pullback_id).
+  - Pullback composes contravariantly (pullback_pullback).
+  - Pullback of the bottom sieve is bottom (pullback_bot).
+  - Pullback is monotone in the sieve (pullback_monotone).
+
+These complete the picture started by Part 5 calibration P2
+(pullback_top in Calibration.lean), and pave the way for Phase 3
+work on sieve generation and sheafification.
+
+Epic #1646, Phase 2 (#2159). All `sorry`s eliminated at creation.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck
+
+open CategoryTheory
+
+/-!
+## Pullback along the identity is the identity
+
+`Sieve.pullback (𝟙 X) S = S`. Pulling back along the identity does
+nothing: `g` is in the pullback iff `g ≫ 𝟙 X = g` is in `S`.
+-/
+
+/-- CALIBRATION (ext + simp): pullback along the identity morphism
+    is the identity transformation on sieves. -/
+theorem pullback_id {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    (Sieve.pullback (𝟙 X) S) = S := by
+  ext Y f
+  simp [Sieve.pullback]
+
+/-!
+## Pullback composes contravariantly
+
+For a sieve `S` on `X` and morphisms `f : Y ⟶ X`, `g : Z ⟶ Y`, pulling
+back `S` along `f` and then along `g` gives the same sieve as pulling
+back `S` along the composite `g ≫ f`.
+-/
+
+/-- CALIBRATION (ext + simp + assoc): pullback composes contravariantly.
+    Pulling back along `g ≫ f` equals pulling back along `f` then `g`. -/
+theorem pullback_pullback {C : Type*} [Category C] {X Y Z : C} (S : Sieve X)
+    (f : Y ⟶ X) (g : Z ⟶ Y) :
+    (Sieve.pullback g (Sieve.pullback f S)) = Sieve.pullback (g ≫ f) S := by
+  ext W h
+  simp [Sieve.pullback, Category.assoc]
+
+/-!
+## Pullback of the bottom sieve is the bottom sieve
+
+The empty sieve has no arrows; pulling it back along any morphism still
+gives the empty sieve. Dual to `pullback_top` (Calibration P2).
+-/
+
+/-- CALIBRATION (ext + simp): pullback of the bottom sieve along any
+    morphism is the bottom sieve. -/
+theorem pullback_bot {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X) :
+    (Sieve.pullback f (⊥ : Sieve X)) = (⊥ : Sieve Y) := by
+  ext Z g
+  simp [Sieve.pullback]
+
+/-!
+## Pullback is monotone in the sieve
+
+If `S ≤ T`, then for any `f : Y ⟶ X`, `Sieve.pullback f S ≤ Sieve.pullback f T`.
+This is the order-theoretic component of pullback's functoriality.
+-/
+
+/-- CALIBRATION (intro + simp + apply): pullback is monotone in the sieve. -/
+theorem pullback_monotone {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    {S T : Sieve X} (hST : S ≤ T) :
+    Sieve.pullback f S ≤ Sieve.pullback f T := by
+  intro Z g hg
+  simp [Sieve.pullback] at hg ⊢
+  exact hST _ hg
+
+end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -15,6 +15,8 @@ The goal is to give learners a curated entry point into:
 
 ## Structure
 
+### Phase 1 (Tour) — `0 sorry`
+
 | File | Content | Lines |
 |------|---------|-------|
 | `Grothendieck/CategoryAndSites.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | ~110 |
@@ -22,6 +24,12 @@ The goal is to give learners a curated entry point into:
 | `Grothendieck/ZariskiSite.lean` | Zariski pretopology, zariskiTopology_eq bridge theorem, subcanonical | ~60 |
 | `Grothendieck/MathlibMap.lean` | `#check` index of all Grothendieck-related Mathlib definitions | ~70 |
 | `Grothendieck/Calibration.lean` | 4 micro-proof targets for prover harness (Epic #1453) | ~60 |
+
+### Phase 2 (Extension) — `0 sorry` (Issue #2159, Epic #2162)
+
+| File | Content | Lines |
+|------|---------|-------|
+| `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback` (contravariant composition), `pullback_bot`, `pullback_monotone` | ~90 |
 
 ## Build
 


### PR DESCRIPTION
## Summary

Add `Grothendieck/SieveLattice.lean` — Phase 2 extension of the Grothendieck tribute workspace (Epic #1646, Issue #2159, Epic #2162).

Four calibration-style theorems on `Sieve.pullback`, all proved via `ext + simp` (same style as Part 5 P2 `pullback_top` already in Calibration.lean):

| Theorem | Statement |
|---------|-----------|
| `pullback_id` | `Sieve.pullback (𝟙 X) S = S` |
| `pullback_pullback` | `Sieve.pullback g (Sieve.pullback f S) = Sieve.pullback (g ≫ f) S` (contravariant composition) |
| `pullback_bot` | `Sieve.pullback f (⊥ : Sieve X) = ⊥` (dual to Calibration P2 `pullback_top`) |
| `pullback_monotone` | `S ≤ T → Sieve.pullback f S ≤ Sieve.pullback f T` |

## Lean PR §B four elements (pr-review-discipline.md)

**1. `grep -c sorry` before/after**:
```
$ grep -nE "^\s*sorry\b|:= sorry|by sorry|exact sorry" \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/*.lean \
    MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
$ echo "rc=$?"
rc=1  # no matches
```
**Production sorry count: 0 → 0** (Phase 1 was already 0, Phase 2 stays 0).

**2. Lake build SUCCESS**:
```
$ wsl bash -lc 'export PATH="$HOME/.elan/bin:$PATH" && \
    cd /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && \
    lake build Grothendieck'
✔ [2464/2465] Built Grothendieck (146s)
Build completed successfully (2465 jobs).
```
Toolchain: `leanprover/lean4:v4.30.0-rc2` (aligned with other SymbolicAI/Lean projects).

**3. Proof integrity**: No axioms introduced. Each theorem uses only `ext`, `simp [Sieve.pullback]`, `simp [Category.assoc]`, and the underlying `LE` definition on Sieves. Direct Mathlib API only (`Mathlib.CategoryTheory.Sites.Grothendieck`, already imported by Phase 1).

**4. Scope justification**: Pure Lean addition. No prover harness changes, no refactor of existing files. Each theorem is independently provable; pedagogical extension of Part 1.

## Anti-régression

- No existing proof replaced or weakened (only additions).
- Existing files untouched except for the single `import Grothendieck.SieveLattice` line added to `Grothendieck.lean`.
- README updated to reflect Phase 1 / Phase 2 structure.
- All Phase 1 modules (`CategoryAndSites`, `SchemesTour`, `ZariskiSite`, `MathlibMap`, `Calibration`) still build at 0 sorry.

## Test plan

- [x] Lake build via WSL Ubuntu — SUCCESS (146s for full Grothendieck module, 131s for SieveLattice alone)
- [x] `grep -c sorry` strict check — 0 in production code
- [x] No regression on Phase 1 modules (full rebuild green)
- [x] README updated with Phase 2 entry

## Refs

- Issue #2159 (Grothendieck Phase 2, lane po-2026)
- Epic #2162 (Phase 2+ rollout)
- Epic #1646 (Grothendieck tribute)
- Epic #1453 (prover harness calibration ladder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)