### PR TITLE
enrich(Sudoku-10,Sudoku-12): add exercises for #2161 rollout (1->3, 2->3)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "2455ea10",
    "metadata": {
     "papermill": {
-     "duration": 0.003497,
-     "end_time": "2026-06-01T20:56:54.476215+00:00",
+     "duration": 0.005499,
+     "end_time": "2026-06-02T21:29:44.857842+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:56:54.472718+00:00",
+     "start_time": "2026-06-02T21:29:44.852343+00:00",
      "status": "completed"
     },
     "tags": []
@@ -65,16 +65,16 @@
    "id": "31f3025f-f1c7-4b39-bbcc-fe29c9da0ea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:56:54.484446Z",
-     "iopub.status.busy": "2026-06-01T20:56:54.484206Z",
-     "iopub.status.idle": "2026-06-01T20:57:06.576278Z",
-     "shell.execute_reply": "2026-06-01T20:57:06.574926Z"
+     "iopub.execute_input": "2026-06-02T21:29:44.869195Z",
+     "iopub.status.busy": "2026-06-02T21:29:44.868713Z",
+     "iopub.status.idle": "2026-06-02T21:29:57.076641Z",
+     "shell.execute_reply": "2026-06-02T21:29:57.075631Z"
     },
     "papermill": {
-     "duration": 12.097269,
-     "end_time": "2026-06-01T20:57:06.577378+00:00",
+     "duration": 12.214725,
+     "end_time": "2026-06-02T21:29:57.077931+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:56:54.480109+00:00",
+     "start_time": "2026-06-02T21:29:44.863206+00:00",
      "status": "completed"
     },
     "tags": []
@@ -116,10 +116,10 @@
    "id": "76bf3efc",
    "metadata": {
     "papermill": {
-     "duration": 0.003679,
-     "end_time": "2026-06-01T20:57:06.585286+00:00",
+     "duration": 0.004869,
+     "end_time": "2026-06-02T21:29:57.086709+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:06.581607+00:00",
+     "start_time": "2026-06-02T21:29:57.081840+00:00",
      "status": "completed"
     },
     "tags": []
@@ -136,16 +136,16 @@
    "id": "ce562fc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:06.595636Z",
-     "iopub.status.busy": "2026-06-01T20:57:06.595254Z",
-     "iopub.status.idle": "2026-06-01T20:57:10.697839Z",
-     "shell.execute_reply": "2026-06-01T20:57:10.696896Z"
+     "iopub.execute_input": "2026-06-02T21:29:57.096514Z",
+     "iopub.status.busy": "2026-06-02T21:29:57.096277Z",
+     "iopub.status.idle": "2026-06-02T21:30:00.694096Z",
+     "shell.execute_reply": "2026-06-02T21:30:00.693260Z"
     },
     "papermill": {
-     "duration": 4.109822,
-     "end_time": "2026-06-01T20:57:10.698913+00:00",
+     "duration": 3.603561,
+     "end_time": "2026-06-02T21:30:00.694972+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:06.589091+00:00",
+     "start_time": "2026-06-02T21:29:57.091411+00:00",
      "status": "completed"
     },
     "tags": []
@@ -177,10 +177,10 @@
    "id": "22c84ceb",
    "metadata": {
     "papermill": {
-     "duration": 0.00342,
-     "end_time": "2026-06-01T20:57:10.706026+00:00",
+     "duration": 0.003017,
+     "end_time": "2026-06-02T21:30:00.701586+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.702606+00:00",
+     "start_time": "2026-06-02T21:30:00.698569+00:00",
      "status": "completed"
     },
     "tags": []
@@ -196,10 +196,10 @@
    "id": "jbo187l6xm",
    "metadata": {
     "papermill": {
-     "duration": 0.003211,
-     "end_time": "2026-06-01T20:57:10.712666+00:00",
+     "duration": 0.002597,
+     "end_time": "2026-06-02T21:30:00.706998+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.709455+00:00",
+     "start_time": "2026-06-02T21:30:00.704401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -214,16 +214,16 @@
    "id": "90syyx3imf8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:10.721615Z",
-     "iopub.status.busy": "2026-06-01T20:57:10.721209Z",
-     "iopub.status.idle": "2026-06-01T20:57:10.728163Z",
-     "shell.execute_reply": "2026-06-01T20:57:10.726899Z"
+     "iopub.execute_input": "2026-06-02T21:30:00.714147Z",
+     "iopub.status.busy": "2026-06-02T21:30:00.713865Z",
+     "iopub.status.idle": "2026-06-02T21:30:00.718604Z",
+     "shell.execute_reply": "2026-06-02T21:30:00.718010Z"
     },
     "papermill": {
-     "duration": 0.012794,
-     "end_time": "2026-06-01T20:57:10.729036+00:00",
+     "duration": 0.009516,
+     "end_time": "2026-06-02T21:30:00.719185+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.716242+00:00",
+     "start_time": "2026-06-02T21:30:00.709669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -233,7 +233,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
+      "Dossier Puzzles: c:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
       "Fichiers disponibles: ['Sudoku_Easy51.txt', 'Sudoku_hardest.txt', 'Sudoku_top95.txt']\n"
      ]
     }
@@ -262,10 +262,10 @@
    "id": "a7a4b062",
    "metadata": {
     "papermill": {
-     "duration": 0.003704,
-     "end_time": "2026-06-01T20:57:10.736560+00:00",
+     "duration": 0.002684,
+     "end_time": "2026-06-02T21:30:00.724860+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.732856+00:00",
+     "start_time": "2026-06-02T21:30:00.722176+00:00",
      "status": "completed"
     },
     "tags": []
@@ -280,16 +280,16 @@
    "id": "b26eb748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:10.745701Z",
-     "iopub.status.busy": "2026-06-01T20:57:10.745376Z",
-     "iopub.status.idle": "2026-06-01T20:57:10.758965Z",
-     "shell.execute_reply": "2026-06-01T20:57:10.757879Z"
+     "iopub.execute_input": "2026-06-02T21:30:00.732037Z",
+     "iopub.status.busy": "2026-06-02T21:30:00.731829Z",
+     "iopub.status.idle": "2026-06-02T21:30:00.747807Z",
+     "shell.execute_reply": "2026-06-02T21:30:00.747022Z"
     },
     "papermill": {
-     "duration": 0.019556,
-     "end_time": "2026-06-01T20:57:10.759816+00:00",
+     "duration": 0.020793,
+     "end_time": "2026-06-02T21:30:00.748781+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.740260+00:00",
+     "start_time": "2026-06-02T21:30:00.727988+00:00",
      "status": "completed"
     },
     "tags": []
@@ -362,10 +362,10 @@
    "id": "21797f07",
    "metadata": {
     "papermill": {
-     "duration": 0.003677,
-     "end_time": "2026-06-01T20:57:10.767192+00:00",
+     "duration": 0.003198,
+     "end_time": "2026-06-02T21:30:00.755193+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.763515+00:00",
+     "start_time": "2026-06-02T21:30:00.751995+00:00",
      "status": "completed"
     },
     "tags": []
@@ -413,16 +413,16 @@
    "id": "d8a967af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:10.775816Z",
-     "iopub.status.busy": "2026-06-01T20:57:10.775533Z",
-     "iopub.status.idle": "2026-06-01T20:57:10.865793Z",
-     "shell.execute_reply": "2026-06-01T20:57:10.864804Z"
+     "iopub.execute_input": "2026-06-02T21:30:00.762531Z",
+     "iopub.status.busy": "2026-06-02T21:30:00.762319Z",
+     "iopub.status.idle": "2026-06-02T21:30:00.841116Z",
+     "shell.execute_reply": "2026-06-02T21:30:00.840387Z"
     },
     "papermill": {
-     "duration": 0.095869,
-     "end_time": "2026-06-01T20:57:10.866672+00:00",
+     "duration": 0.083633,
+     "end_time": "2026-06-02T21:30:00.841889+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.770803+00:00",
+     "start_time": "2026-06-02T21:30:00.758256+00:00",
      "status": "completed"
     },
     "tags": []
@@ -445,7 +445,7 @@
       ". 1 7 | . . . | . . . \n",
       ". . . | . 3 6 | . 4 . \n",
       "\n",
-      "Résolu: True en 80.12 ms\n",
+      "Résolu: True en 71.40 ms\n",
       "\n",
       "Solution:\n",
       "8 5 9 | 6 1 2 | 4 3 7 \n",
@@ -531,10 +531,10 @@
    "id": "5llfojb1uvw",
    "metadata": {
     "papermill": {
-     "duration": 0.003752,
-     "end_time": "2026-06-01T20:57:10.874200+00:00",
+     "duration": 0.00328,
+     "end_time": "2026-06-02T21:30:00.848709+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.870448+00:00",
+     "start_time": "2026-06-02T21:30:00.845429+00:00",
      "status": "completed"
     },
     "tags": []
@@ -560,13 +560,100 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-count-solutions",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00293,
+     "end_time": "2026-06-02T21:30:00.854935+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:00.852005+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Compter le nombre de solutions\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Par defaut, le solveur CP-SAT s'arrete a la premiere solution trouvee. Mais pour un puzzle Sudoku, on peut vouloir savoir s'il existe des **solutions alternatives**. OR-Tools fournit un mecanisme de callback pour enumerer les solutions.\n",
+    "\n",
+    "Implementez `count_solutions(grid, max_count=10)` qui utilise `solver.SearchForAllSolutions()` avec un callback pour compter (et optionnellement afficher) les solutions d'un puzzle.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Creez une classe `SolutionCounter(cp_model.CpSolverSolutionCallback)` avec un compteur\n",
+    "- Etape 2 : Dans `OnSolutionCallback`, incrementez le compteur et optionnellement arretez si `max_count` atteint\n",
+    "- Etape 3 : Appelez `solver.SearchForAllSolutions(model, callback)` au lieu de `solver.Solve(model)`\n",
+    "- Etape 4 : Retournez le nombre de solutions trouvees\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ex-count-solutions-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T21:30:00.862131Z",
+     "iopub.status.busy": "2026-06-02T21:30:00.861900Z",
+     "iopub.status.idle": "2026-06-02T21:30:00.865997Z",
+     "shell.execute_reply": "2026-06-02T21:30:00.865233Z"
+    },
+    "papermill": {
+     "duration": 0.008794,
+     "end_time": "2026-06-02T21:30:00.866655+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:00.857861+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de solutions trouvees : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Compter le nombre de solutions\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Creez un callback heritant de cp_model.CpSolverSolutionCallback\n",
+    "#   - Comptez chaque solution dans OnSolutionCallback\n",
+    "#   - Utilisez solver.SearchForAllSolutions(model, callback)\n",
+    "\n",
+    "def count_solutions(grid, max_count: int = 10) -> int:\n",
+    "    \"\"\"Compte les solutions d un puzzle Sudoku avec OR-Tools.\n",
+    "\n",
+    "    Args:\n",
+    "        grid: instance de SudokuGrid\n",
+    "        max_count: nombre max de solutions a chercher\n",
+    "\n",
+    "    Returns:\n",
+    "        Nombre de solutions trouvees\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez le comptage de solutions\n",
+    "    return 0\n",
+    "\n",
+    "\n",
+    "# Test rapide sur un puzzle facile\n",
+    "test_count = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "n_solutions = count_solutions(test_count, max_count=5)\n",
+    "print(f\"Nombre de solutions trouvees : {n_solutions}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "95rtxz9u43",
    "metadata": {
     "papermill": {
-     "duration": 0.004256,
-     "end_time": "2026-06-01T20:57:10.883049+00:00",
+     "duration": 0.002969,
+     "end_time": "2026-06-02T21:30:00.872853+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.878793+00:00",
+     "start_time": "2026-06-02T21:30:00.869884+00:00",
      "status": "completed"
     },
     "tags": []
@@ -596,20 +683,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "322xetmzp7c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:10.891337Z",
-     "iopub.status.busy": "2026-06-01T20:57:10.890950Z",
-     "iopub.status.idle": "2026-06-01T20:57:11.257285Z",
-     "shell.execute_reply": "2026-06-01T20:57:11.256521Z"
+     "iopub.execute_input": "2026-06-02T21:30:00.880289Z",
+     "iopub.status.busy": "2026-06-02T21:30:00.880034Z",
+     "iopub.status.idle": "2026-06-02T21:30:01.250402Z",
+     "shell.execute_reply": "2026-06-02T21:30:01.249719Z"
     },
     "papermill": {
-     "duration": 0.37224,
-     "end_time": "2026-06-01T20:57:11.258454+00:00",
+     "duration": 0.375448,
+     "end_time": "2026-06-02T21:30:01.251295+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:10.886214+00:00",
+     "start_time": "2026-06-02T21:30:00.875847+00:00",
      "status": "completed"
     },
     "tags": []
@@ -632,7 +719,7 @@
       "\n",
       "Solveur              Résolus    Temps total     Temps moyen    \n",
       "------------------------------------------------------------\n",
-      "OR-Tools CP-SAT      10/10           152.16 ms        15.22 ms\n",
+      "OR-Tools CP-SAT      10/10           156.54 ms        15.65 ms\n",
       "\n",
       "============================================================\n",
       "Benchmark: Puzzles Difficiles (Top 11) (11 puzzles)\n",
@@ -644,18 +731,25 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solveur              Résolus    Temps total     Temps moyen    \n",
+      "Solveur              Résolus    Temps total     Temps moyen    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "------------------------------------------------------------\n",
-      "OR-Tools CP-SAT      11/11           202.47 ms        18.41 ms\n"
+      "OR-Tools CP-SAT      11/11           203.41 ms        18.49 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'solved': 11, 'total_time': 0.20247364044189453}"
+       "{'solved': 11, 'total_time': 0.20341253280639648}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -702,10 +796,10 @@
    "id": "gs8555282sd",
    "metadata": {
     "papermill": {
-     "duration": 0.004067,
-     "end_time": "2026-06-01T20:57:11.266847+00:00",
+     "duration": 0.003692,
+     "end_time": "2026-06-02T21:30:01.258949+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:11.262780+00:00",
+     "start_time": "2026-06-02T21:30:01.255257+00:00",
      "status": "completed"
     },
     "tags": []
@@ -726,20 +820,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "obch45ox3ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:11.276500Z",
-     "iopub.status.busy": "2026-06-01T20:57:11.276223Z",
-     "iopub.status.idle": "2026-06-01T20:57:11.356543Z",
-     "shell.execute_reply": "2026-06-01T20:57:11.355625Z"
+     "iopub.execute_input": "2026-06-02T21:30:01.270385Z",
+     "iopub.status.busy": "2026-06-02T21:30:01.269994Z",
+     "iopub.status.idle": "2026-06-02T21:30:01.347765Z",
+     "shell.execute_reply": "2026-06-02T21:30:01.346886Z"
     },
     "papermill": {
-     "duration": 0.086386,
-     "end_time": "2026-06-01T20:57:11.357242+00:00",
+     "duration": 0.085812,
+     "end_time": "2026-06-02T21:30:01.348625+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:11.270856+00:00",
+     "start_time": "2026-06-02T21:30:01.262813+00:00",
      "status": "completed"
     },
     "tags": []
@@ -825,10 +919,10 @@
    "id": "631a94a7",
    "metadata": {
     "papermill": {
-     "duration": 0.00332,
-     "end_time": "2026-06-01T20:57:11.363963+00:00",
+     "duration": 0.005512,
+     "end_time": "2026-06-02T21:30:01.357851+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:11.360643+00:00",
+     "start_time": "2026-06-02T21:30:01.352339+00:00",
      "status": "completed"
     },
     "tags": []
@@ -859,20 +953,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d32b39fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T20:57:11.371777Z",
-     "iopub.status.busy": "2026-06-01T20:57:11.371528Z",
-     "iopub.status.idle": "2026-06-01T20:57:11.376948Z",
-     "shell.execute_reply": "2026-06-01T20:57:11.376143Z"
+     "iopub.execute_input": "2026-06-02T21:30:01.368414Z",
+     "iopub.status.busy": "2026-06-02T21:30:01.368034Z",
+     "iopub.status.idle": "2026-06-02T21:30:01.373919Z",
+     "shell.execute_reply": "2026-06-02T21:30:01.373018Z"
     },
     "papermill": {
-     "duration": 0.010409,
-     "end_time": "2026-06-01T20:57:11.377670+00:00",
+     "duration": 0.012951,
+     "end_time": "2026-06-02T21:30:01.374749+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:11.367261+00:00",
+     "start_time": "2026-06-02T21:30:01.361798+00:00",
      "status": "completed"
     },
     "tags": []
@@ -939,10 +1033,10 @@
    "id": "rnozjwu8rs",
    "metadata": {
     "papermill": {
-     "duration": 0.003134,
-     "end_time": "2026-06-01T20:57:11.384119+00:00",
+     "duration": 0.003768,
+     "end_time": "2026-06-02T21:30:01.382327+00:00",
      "exception": false,
-     "start_time": "2026-06-01T20:57:11.380985+00:00",
+     "start_time": "2026-06-02T21:30:01.378559+00:00",
      "status": "completed"
     },
     "tags": []
@@ -998,6 +1092,104 @@
     "\n",
     "**Navigation** : [<< Python Backtracking](Sudoku-1-Backtracking-Python.ipynb) | [Index](README.md) | [Z3 Python >>](Sudoku-12-Z3-Python.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ex-add-all-different",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004024,
+     "end_time": "2026-06-02T21:30:01.390025+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:01.386001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Ajouter une contrainte AllDifferent personnalisee\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Dans le solveur OR-Tools actuel, les contraintes sont ajoutees ligne par ligne, colonne par colonne et bloc par bloc. Generalisez cette approche en implementant une fonction `add_all_different_constraint(model, variables)` qui utilise `model.AddAllDifferent(variables)` pour rendre le code plus modulaire.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : La fonction prend un modele CP-SAT et une liste de variables `IntVar`\n",
+    "- Etape 2 : Appelez `model.AddAllDifferent(variables)` sur la liste\n",
+    "- Etape 3 : Utilisez cette fonction dans un mini-solveur qui modelise un Sudoku 4x4\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ex-add-all-different-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T21:30:01.402502Z",
+     "iopub.status.busy": "2026-06-02T21:30:01.402136Z",
+     "iopub.status.idle": "2026-06-02T21:30:01.408034Z",
+     "shell.execute_reply": "2026-06-02T21:30:01.407122Z"
+    },
+    "papermill": {
+     "duration": 0.014495,
+     "end_time": "2026-06-02T21:30:01.408734+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:01.394239+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pas de solution\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Ajouter une contrainte AllDifferent personnalisee\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Creez une fonction add_all_different_constraint(model, variables)\n",
+    "#   - Utilisez model.AddAllDifferent(variables)\n",
+    "#   - Testez sur un mini-Sudoku 4x4 (4 couleurs, 4 lignes, 4 colonnes, 4 blocs 2x2)\n",
+    "\n",
+    "def add_all_different_constraint(model, variables):\n",
+    "    \"\"\"Ajoute une contrainte AllDifferent sur une liste de variables.\n",
+    "\n",
+    "    Args:\n",
+    "        model: modele cp_model.CpModel\n",
+    "        variables: liste de variables IntVar\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez la contrainte AllDifferent\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "def solve_mini_sudoku_4x4(hints: dict) -> list:\n",
+    "    \"\"\"Resout un mini-Sudoku 4x4 en utilisant add_all_different_constraint.\n",
+    "\n",
+    "    Args:\n",
+    "        hints: dictionnaire {(row, col): value} des indices pre-remplis\n",
+    "\n",
+    "    Returns:\n",
+    "        Grille 4x4 resolue, ou liste vide si pas de solution\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : modelisez le mini-Sudoku 4x4\n",
+    "    return []\n",
+    "\n",
+    "\n",
+    "# Test\n",
+    "hints_4x4 = {(0, 0): 1, (0, 3): 4, (1, 1): 4, (1, 2): 1, (2, 1): 1, (2, 2): 4, (3, 0): 4, (3, 3): 1}\n",
+    "result = solve_mini_sudoku_4x4(hints_4x4)\n",
+    "if result:\n",
+    "    for row in result:\n",
+    "        print(row)\n",
+    "else:\n",
+    "    print(\"Pas de solution\")\n"
+   ]
   }
  ],
  "metadata": {
@@ -1020,14 +1212,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 20.562341,
-   "end_time": "2026-06-01T20:57:11.949743+00:00",
+   "duration": 20.199505,
+   "end_time": "2026-06-02T21:30:01.978071+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Sudoku-10-ORTools-Python.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\sudoku10-test.ipynb",
+   "output_path": "Sudoku-10_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-06-01T20:56:51.387402+00:00",
+   "start_time": "2026-06-02T21:29:41.778566+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "z3-header",
    "metadata": {
     "papermill": {
-     "duration": 0.003784,
-     "end_time": "2026-04-25T14:47:18.711697",
+     "duration": 0.004373,
+     "end_time": "2026-06-02T21:30:08.480039+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.707913",
+     "start_time": "2026-06-02T21:30:08.475666+00:00",
      "status": "completed"
     },
     "tags": []
@@ -47,16 +47,16 @@
    "id": "ce562fc7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:18.720539Z",
-     "iopub.status.busy": "2026-04-25T14:47:18.719933Z",
-     "iopub.status.idle": "2026-04-25T14:47:18.805478Z",
-     "shell.execute_reply": "2026-04-25T14:47:18.804749Z"
+     "iopub.execute_input": "2026-06-02T21:30:08.488573Z",
+     "iopub.status.busy": "2026-06-02T21:30:08.488325Z",
+     "iopub.status.idle": "2026-06-02T21:30:08.568614Z",
+     "shell.execute_reply": "2026-06-02T21:30:08.567495Z"
     },
     "papermill": {
-     "duration": 0.092439,
-     "end_time": "2026-04-25T14:47:18.807395",
+     "duration": 0.085799,
+     "end_time": "2026-06-02T21:30:08.569657+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.714956",
+     "start_time": "2026-06-02T21:30:08.483858+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,10 +89,10 @@
    "id": "z3-intro",
    "metadata": {
     "papermill": {
-     "duration": 0.003205,
-     "end_time": "2026-04-25T14:47:18.815095",
+     "duration": 0.003478,
+     "end_time": "2026-06-02T21:30:08.576849+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.811890",
+     "start_time": "2026-06-02T21:30:08.573371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -106,10 +106,10 @@
    "id": "z3-theory",
    "metadata": {
     "papermill": {
-     "duration": 0.003254,
-     "end_time": "2026-04-25T14:47:18.821707",
+     "duration": 0.003503,
+     "end_time": "2026-06-02T21:30:08.583676+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.818453",
+     "start_time": "2026-06-02T21:30:08.580173+00:00",
      "status": "completed"
     },
     "tags": []
@@ -123,10 +123,10 @@
    "id": "5hp6xynh8oi",
    "metadata": {
     "papermill": {
-     "duration": 0.005387,
-     "end_time": "2026-04-25T14:47:18.832227",
+     "duration": 0.003367,
+     "end_time": "2026-06-02T21:30:08.590728+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.826840",
+     "start_time": "2026-06-02T21:30:08.587361+00:00",
      "status": "completed"
     },
     "tags": []
@@ -141,16 +141,16 @@
    "id": "6ughleuceoj",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:18.844564Z",
-     "iopub.status.busy": "2026-04-25T14:47:18.843881Z",
-     "iopub.status.idle": "2026-04-25T14:47:18.850790Z",
-     "shell.execute_reply": "2026-04-25T14:47:18.849802Z"
+     "iopub.execute_input": "2026-06-02T21:30:08.598908Z",
+     "iopub.status.busy": "2026-06-02T21:30:08.598644Z",
+     "iopub.status.idle": "2026-06-02T21:30:08.605325Z",
+     "shell.execute_reply": "2026-06-02T21:30:08.604407Z"
     },
     "papermill": {
-     "duration": 0.014446,
-     "end_time": "2026-04-25T14:47:18.851970",
+     "duration": 0.012075,
+     "end_time": "2026-06-02T21:30:08.606161+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.837524",
+     "start_time": "2026-06-02T21:30:08.594086+00:00",
      "status": "completed"
     },
     "tags": []
@@ -160,7 +160,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
+      "Dossier Puzzles: c:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
       "Fichiers disponibles: ['Sudoku_Easy51.txt', 'Sudoku_hardest.txt', 'Sudoku_top95.txt']\n"
      ]
     }
@@ -188,10 +188,10 @@
    "id": "f6997cbf",
    "metadata": {
     "papermill": {
-     "duration": 0.003037,
-     "end_time": "2026-04-25T14:47:18.858815",
+     "duration": 0.005044,
+     "end_time": "2026-06-02T21:30:08.614717+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.855778",
+     "start_time": "2026-06-02T21:30:08.609673+00:00",
      "status": "completed"
     },
     "tags": []
@@ -212,10 +212,10 @@
    "id": "c0d8af3c2d9b36c",
    "metadata": {
     "papermill": {
-     "duration": 0.005418,
-     "end_time": "2026-04-25T14:47:18.868289",
+     "duration": 0.005371,
+     "end_time": "2026-06-02T21:30:08.623596+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.862871",
+     "start_time": "2026-06-02T21:30:08.618225+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,16 +230,16 @@
    "id": "b26eb748",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:18.880055Z",
-     "iopub.status.busy": "2026-04-25T14:47:18.879592Z",
-     "iopub.status.idle": "2026-04-25T14:47:18.889643Z",
-     "shell.execute_reply": "2026-04-25T14:47:18.888946Z"
+     "iopub.execute_input": "2026-06-02T21:30:08.633576Z",
+     "iopub.status.busy": "2026-06-02T21:30:08.633230Z",
+     "iopub.status.idle": "2026-06-02T21:30:08.642003Z",
+     "shell.execute_reply": "2026-06-02T21:30:08.641134Z"
     },
     "papermill": {
-     "duration": 0.018391,
-     "end_time": "2026-04-25T14:47:18.891540",
+     "duration": 0.015849,
+     "end_time": "2026-06-02T21:30:08.642696+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.873149",
+     "start_time": "2026-06-02T21:30:08.626847+00:00",
      "status": "completed"
     },
     "tags": []
@@ -312,10 +312,10 @@
    "id": "e8a142b7e7420aee",
    "metadata": {
     "papermill": {
-     "duration": 0.003344,
-     "end_time": "2026-04-25T14:47:18.900152",
+     "duration": 0.003653,
+     "end_time": "2026-06-02T21:30:08.649831+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.896808",
+     "start_time": "2026-06-02T21:30:08.646178+00:00",
      "status": "completed"
     },
     "tags": []
@@ -330,16 +330,16 @@
    "id": "00f60d3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:18.909563Z",
-     "iopub.status.busy": "2026-04-25T14:47:18.909151Z",
-     "iopub.status.idle": "2026-04-25T14:47:19.538027Z",
-     "shell.execute_reply": "2026-04-25T14:47:19.537230Z"
+     "iopub.execute_input": "2026-06-02T21:30:08.662720Z",
+     "iopub.status.busy": "2026-06-02T21:30:08.662363Z",
+     "iopub.status.idle": "2026-06-02T21:30:09.175266Z",
+     "shell.execute_reply": "2026-06-02T21:30:09.174308Z"
     },
     "papermill": {
-     "duration": 0.635048,
-     "end_time": "2026-04-25T14:47:19.539345",
+     "duration": 0.52069,
+     "end_time": "2026-06-02T21:30:09.176111+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:18.904297",
+     "start_time": "2026-06-02T21:30:08.655421+00:00",
      "status": "completed"
     },
     "tags": []
@@ -368,7 +368,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Résolu: True en 619.48 ms\n",
+      "Résolu: True en 503.60 ms\n",
       "\n",
       "Solution:\n",
       "8 5 9 | 6 1 2 | 4 3 7 \n",
@@ -454,10 +454,10 @@
    "id": "2uoak5nyx4b",
    "metadata": {
     "papermill": {
-     "duration": 0.003898,
-     "end_time": "2026-04-25T14:47:19.547315",
+     "duration": 0.003819,
+     "end_time": "2026-06-02T21:30:09.184125+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:19.543417",
+     "start_time": "2026-06-02T21:30:09.180306+00:00",
      "status": "completed"
     },
     "tags": []
@@ -487,16 +487,16 @@
    "id": "f40ab878",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:19.558494Z",
-     "iopub.status.busy": "2026-04-25T14:47:19.557906Z",
-     "iopub.status.idle": "2026-04-25T14:47:23.527897Z",
-     "shell.execute_reply": "2026-04-25T14:47:23.525653Z"
+     "iopub.execute_input": "2026-06-02T21:30:09.194363Z",
+     "iopub.status.busy": "2026-06-02T21:30:09.194115Z",
+     "iopub.status.idle": "2026-06-02T21:30:11.406565Z",
+     "shell.execute_reply": "2026-06-02T21:30:11.405535Z"
     },
     "papermill": {
-     "duration": 3.977875,
-     "end_time": "2026-04-25T14:47:23.530301",
+     "duration": 2.218568,
+     "end_time": "2026-06-02T21:30:11.407477+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:19.552426",
+     "start_time": "2026-06-02T21:30:09.188909+00:00",
      "status": "completed"
     },
     "tags": []
@@ -515,8 +515,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z3 Int:        450.06 ms\n",
-      "  Z3 BitVec:     111.68 ms\n",
+      "  Z3 Int:        405.41 ms\n",
+      "  Z3 BitVec:      99.52 ms\n",
       "\n",
       "Puzzle 2:\n"
      ]
@@ -525,8 +525,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z3 Int:        958.08 ms\n",
-      "  Z3 BitVec:     148.51 ms\n",
+      "  Z3 Int:        622.83 ms\n",
+      "  Z3 BitVec:      76.36 ms\n",
       "\n",
       "Puzzle 3:\n"
      ]
@@ -535,8 +535,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z3 Int:        459.34 ms\n",
-      "  Z3 BitVec:     153.00 ms\n",
+      "  Z3 Int:        273.25 ms\n",
+      "  Z3 BitVec:      87.06 ms\n",
       "\n",
       "Puzzle 4:\n"
      ]
@@ -545,8 +545,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z3 Int:        677.19 ms\n",
-      "  Z3 BitVec:     243.87 ms\n",
+      "  Z3 Int:        258.20 ms\n",
+      "  Z3 BitVec:      83.65 ms\n",
       "\n",
       "Puzzle 5:\n"
      ]
@@ -555,8 +555,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Z3 Int:        518.76 ms\n",
-      "  Z3 BitVec:     231.27 ms\n"
+      "  Z3 Int:        187.37 ms\n",
+      "  Z3 BitVec:     106.91 ms\n"
      ]
     }
    ],
@@ -641,10 +641,10 @@
    "id": "imahujoijal",
    "metadata": {
     "papermill": {
-     "duration": 0.006089,
-     "end_time": "2026-04-25T14:47:23.543012",
+     "duration": 0.004237,
+     "end_time": "2026-06-02T21:30:11.416402+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.536923",
+     "start_time": "2026-06-02T21:30:11.412165+00:00",
      "status": "completed"
     },
     "tags": []
@@ -672,13 +672,103 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-verify-z3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004914,
+     "end_time": "2026-06-02T21:30:11.426738+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:11.421824+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Verifier la validite d une solution Z3\n",
+    "\n",
+    "### Enonce\n",
+    "\n",
+    "Z3 peut trouver une solution, mais comment verifier independamment que cette solution est **correcte** ? Implementez une fonction qui prend un modele Z3 satisfait et verifie manuellement que toutes les contraintes Sudoku sont respectees.\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- Etape 1 : Extraire les valeurs du modele Z3 avec \n",
+    "- Etape 2 : Verifiez que chaque ligne contient les chiffres 1-9 sans doublon\n",
+    "- Etape 3 : Verifiez que chaque colonne contient les chiffres 1-9 sans doublon\n",
+    "- Etape 4 : Verifiez que chaque bloc 3x3 contient les chiffres 1-9 sans doublon\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ex-verify-z3-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T21:30:11.435869Z",
+     "iopub.status.busy": "2026-06-02T21:30:11.435518Z",
+     "iopub.status.idle": "2026-06-02T21:30:11.482293Z",
+     "shell.execute_reply": "2026-06-02T21:30:11.481660Z"
+    },
+    "papermill": {
+     "duration": 0.052686,
+     "end_time": "2026-06-02T21:30:11.483343+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:11.430657+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solution verifiee : False\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Verifier la validite d une solution Z3\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Extrayez les valeurs du modele avec model[cell_var].as_long()\n",
+    "#   - Verifiez lignes, colonnes et blocs 3x3\n",
+    "#   - Retournez True si la solution est valide, False sinon\n",
+    "\n",
+    "def verify_z3_solution(model, cells) -> bool:\n",
+    "    \"\"\"Verifie manuellement qu une solution Z3 est valide.\n",
+    "\n",
+    "    Args:\n",
+    "        model: modele Z3 satisfait (z3.ModelRef)\n",
+    "        cells: dictionnaire {(r,c): z3.Int} des variables\n",
+    "\n",
+    "    Returns:\n",
+    "        True si la solution respecte toutes les contraintes Sudoku\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez la verification\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "# Test rapide\n",
+    "test_v = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "solver_v = Z3Solver()\n",
+    "success_v = solver_v.solve(test_v)\n",
+    "if success_v:\n",
+    "    # Utilisez le modele interne du solveur pour verifier\n",
+    "    print(f\"Solution verifiee : {verify_z3_solution(None, None)}\")\n",
+    "else:\n",
+    "    print(\"Pas de solution\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "64d13639",
    "metadata": {
     "papermill": {
-     "duration": 0.007137,
-     "end_time": "2026-04-25T14:47:23.557751",
+     "duration": 0.004414,
+     "end_time": "2026-06-02T21:30:11.491665+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.550614",
+     "start_time": "2026-06-02T21:30:11.487251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -721,10 +811,10 @@
    "id": "tkp1ie77lp",
    "metadata": {
     "papermill": {
-     "duration": 0.010132,
-     "end_time": "2026-04-25T14:47:23.576290",
+     "duration": 0.003713,
+     "end_time": "2026-06-02T21:30:11.499271+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.566158",
+     "start_time": "2026-06-02T21:30:11.495558+00:00",
      "status": "completed"
     },
     "tags": []
@@ -746,10 +836,10 @@
    "id": "e023cbf7",
    "metadata": {
     "papermill": {
-     "duration": 0.013181,
-     "end_time": "2026-04-25T14:47:23.601289",
+     "duration": 0.003949,
+     "end_time": "2026-06-02T21:30:11.506978+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.588108",
+     "start_time": "2026-06-02T21:30:11.503029+00:00",
      "status": "completed"
     },
     "tags": []
@@ -767,20 +857,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "1a64a347a19917fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:23.621399Z",
-     "iopub.status.busy": "2026-04-25T14:47:23.620542Z",
-     "iopub.status.idle": "2026-04-25T14:47:23.631252Z",
-     "shell.execute_reply": "2026-04-25T14:47:23.629533Z"
+     "iopub.execute_input": "2026-06-02T21:30:11.515712Z",
+     "iopub.status.busy": "2026-06-02T21:30:11.515464Z",
+     "iopub.status.idle": "2026-06-02T21:30:11.520587Z",
+     "shell.execute_reply": "2026-06-02T21:30:11.519688Z"
     },
     "papermill": {
-     "duration": 0.021407,
-     "end_time": "2026-04-25T14:47:23.633909",
+     "duration": 0.010659,
+     "end_time": "2026-06-02T21:30:11.521215+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.612502",
+     "start_time": "2026-06-02T21:30:11.510556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -846,10 +936,10 @@
    "id": "1dce56fa54547e7b",
    "metadata": {
     "papermill": {
-     "duration": 0.006241,
-     "end_time": "2026-04-25T14:47:23.646713",
+     "duration": 0.003286,
+     "end_time": "2026-06-02T21:30:11.528032+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.640472",
+     "start_time": "2026-06-02T21:30:11.524746+00:00",
      "status": "completed"
     },
     "tags": []
@@ -862,20 +952,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "e3dfb7e7221340ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:23.668091Z",
-     "iopub.status.busy": "2026-04-25T14:47:23.667264Z",
-     "iopub.status.idle": "2026-04-25T14:47:32.181862Z",
-     "shell.execute_reply": "2026-04-25T14:47:32.180528Z"
+     "iopub.execute_input": "2026-06-02T21:30:11.536455Z",
+     "iopub.status.busy": "2026-06-02T21:30:11.536130Z",
+     "iopub.status.idle": "2026-06-02T21:30:12.970316Z",
+     "shell.execute_reply": "2026-06-02T21:30:12.969477Z"
     },
     "papermill": {
-     "duration": 8.52656,
-     "end_time": "2026-04-25T14:47:32.183600",
+     "duration": 1.4398,
+     "end_time": "2026-06-02T21:30:12.971105+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:23.657040",
+     "start_time": "2026-06-02T21:30:11.531305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -905,20 +995,20 @@
      "output_type": "stream",
      "text": [
       "Solution trouvée :\n",
-      "1 4 3 | 2 6 7 | 9 5 8 \n",
-      "9 2 5 | 8 1 3 | 6 7 4 \n",
-      "7 8 6 | 4 9 5 | 1 2 3 \n",
+      "1 2 5 | 7 8 9 | 3 4 6 \n",
+      "7 4 6 | 2 1 3 | 9 8 5 \n",
+      "3 8 9 | 6 4 5 | 1 2 7 \n",
       "---------------------\n",
-      "2 3 1 | 7 8 9 | 4 6 5 \n",
-      "5 6 4 | 1 3 2 | 8 9 7 \n",
-      "8 9 7 | 6 5 4 | 2 3 1 \n",
+      "2 3 1 | 8 9 7 | 6 5 4 \n",
+      "5 6 4 | 3 2 1 | 7 9 8 \n",
+      "8 9 7 | 4 5 6 | 2 3 1 \n",
       "---------------------\n",
-      "3 1 2 | 9 7 8 | 5 4 6 \n",
-      "6 5 9 | 3 4 1 | 7 8 2 \n",
-      "4 7 8 | 5 2 6 | 3 1 9 \n",
+      "4 1 3 | 9 7 8 | 5 6 2 \n",
+      "6 5 2 | 1 3 4 | 8 7 9 \n",
+      "9 7 8 | 5 6 2 | 4 1 3 \n",
       "\n",
-      "Diagonale principale : [1, 2, 6, 7, 3, 4, 5, 8, 9] — tous distincts : True\n",
-      "Diagonale secondaire : [8, 7, 1, 9, 3, 6, 2, 5, 4] — tous distincts : True\n"
+      "Diagonale principale : [1, 4, 9, 8, 2, 6, 5, 7, 3] — tous distincts : True\n",
+      "Diagonale secondaire : [6, 8, 1, 7, 2, 4, 3, 5, 9] — tous distincts : True\n"
      ]
     }
    ],
@@ -1012,10 +1102,10 @@
    "id": "96e575c4",
    "metadata": {
     "papermill": {
-     "duration": 0.006649,
-     "end_time": "2026-04-25T14:47:32.195833",
+     "duration": 0.00385,
+     "end_time": "2026-06-02T21:30:12.979738+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:32.189184",
+     "start_time": "2026-06-02T21:30:12.975888+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1043,20 +1133,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "4a506113",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T14:47:32.207994Z",
-     "iopub.status.busy": "2026-04-25T14:47:32.207431Z",
-     "iopub.status.idle": "2026-04-25T14:47:32.214965Z",
-     "shell.execute_reply": "2026-04-25T14:47:32.213945Z"
+     "iopub.execute_input": "2026-06-02T21:30:12.989626Z",
+     "iopub.status.busy": "2026-06-02T21:30:12.989268Z",
+     "iopub.status.idle": "2026-06-02T21:30:12.995442Z",
+     "shell.execute_reply": "2026-06-02T21:30:12.994689Z"
     },
     "papermill": {
-     "duration": 0.015765,
-     "end_time": "2026-04-25T14:47:32.216449",
+     "duration": 0.012489,
+     "end_time": "2026-06-02T21:30:12.996182+00:00",
      "exception": false,
-     "start_time": "2026-04-25T14:47:32.200684",
+     "start_time": "2026-06-02T21:30:12.983693+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1130,8 +1220,21 @@
   {
    "cell_type": "markdown",
    "id": "d7796c4b",
-   "source": "## Conclusion\n\nCe notebook a présenté deux approches Z3 pour modéliser et résoudre le Sudoku : les entiers symboliques (Int) et les vecteurs de bits (BitVec 4 bits). La comparaison montre que les BitVectors sont systématiquement plus rapides (1.5x à 6.7x), car leur domaine restreint (16 valeurs sur 4 bits) permet à Z3 d'utiliser des algorithmes de propagation plus efficaces. La contrainte `Distinct`, disponible nativement pour les entiers mais nécessitant une décomposition par paires pour les BitVectors, illustre le compromis entre simplicité d'API et performance. Au-delà du Sudoku, Z3 est un outil de résolution SMT polyvalent, applicable à la vérification de programmes, l'analyse de sécurité et la synthèse de code. Les exercices proposés (comptage de solutions, contraintes diagonales, coloration de graphe) montrent comment étendre le modèle de base vers des variantes plus riches.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003516,
+     "end_time": "2026-06-02T21:30:13.003476+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T21:30:12.999960+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a présenté deux approches Z3 pour modéliser et résoudre le Sudoku : les entiers symboliques (Int) et les vecteurs de bits (BitVec 4 bits). La comparaison montre que les BitVectors sont systématiquement plus rapides (1.5x à 6.7x), car leur domaine restreint (16 valeurs sur 4 bits) permet à Z3 d'utiliser des algorithmes de propagation plus efficaces. La contrainte `Distinct`, disponible nativement pour les entiers mais nécessitant une décomposition par paires pour les BitVectors, illustre le compromis entre simplicité d'API et performance. Au-delà du Sudoku, Z3 est un outil de résolution SMT polyvalent, applicable à la vérification de programmes, l'analyse de sécurité et la synthèse de code. Les exercices proposés (comptage de solutions, contraintes diagonales, coloration de graphe) montrent comment étendre le modèle de base vers des variantes plus riches."
+   ]
   }
  ],
  "metadata": {
@@ -1150,18 +1253,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 15.961848,
-   "end_time": "2026-04-25T14:47:32.454657",
+   "duration": 8.012573,
+   "end_time": "2026-06-02T21:30:13.461515+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-12-Z3-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-12-Z3-Python_output.ipynb",
+   "input_path": "Sudoku-12-Z3-Python.ipynb",
+   "output_path": "Sudoku-12_exec.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T14:47:16.492809",
+   "start_time": "2026-06-02T21:30:05.448942+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Add exercises to Sudoku-10-ORTools-Python and Sudoku-12-Z3-Python per convention #2161 (>=3 exercises per notebook).

### Sudoku-10-ORTools-Python (1->3 exercises)
- **Exercise 2** (`count_solutions`): Uses OR-Tools CP-SAT `SearchForAllSolutions` with a callback to enumerate solutions. Placed after OR-Tools interpretation section.
- **Exercise 3** (`add_all_different_constraint` + `solve_mini_sudoku_4x4`): Modular AllDifferent constraint + mini-Sudoku 4x4. Placed after benchmark interpretation section.

### Sudoku-12-Z3-Python (2->3 exercises)
- **Exercise 3** (`verify_z3_solution`): Manually verify that a Z3 model satisfies Sudoku constraints. Placed after Z3 solution interpretation.

## Validation

- **C.1**: All stubs use `return 0` / `pass` / `return []` + `# TODO etudiant`, no `raise NotImplementedError` / `assert False` / `1/0`
  ```
  grep -cE "raise NotImplementedError|assert False|1/0" Sudoku-10-ORTools-Python.ipynb Sudoku-12-Z3-Python.ipynb → 0
  ```
- **C.2**: Papermill end-to-end execution — **23/23 cells** (Sudoku-10) and **25/25 cells** (Sudoku-12), 0 errors, all `execution_count: int` + `outputs: [...]`
- **Pedagogical placement**: Exercises spread throughout notebooks, each preceded by markdown with context/objective/step-by-step hints

## Diff stats
```
Sudoku-10-ORTools-Python.ipynb  | 398 +++++++++++++++------
Sudoku-12-Z3-Python.ipynb       | 367 ++++++++++++-------
2 files changed, 530 insertions(+), 235 deletions(-)
```

Refs #2161