### PR TITLE
fix(conway): correct P3 padCenter2_correct statement (center_off bug) + add level-1 witness

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -510,24 +510,56 @@ theorem step_light_cone (t : Nat) (g₁ g₂ : Grid) (p : Int × Int)
 
 /-! ## P3. Padding correctness
 
-`padCenter2 c` correctly places `c` at the center of a level-`(k+2)`
-MacroCell with `2^k` dead cells of padding on each side. -/
+`padCenter2 c` places `c` (assuming `c.level ≥ 1`) inside a level-`(k+2)`
+MacroCell. Each application of `padToLevelPlus1` shifts every cell of
+the original input by `+2^(k-1)` (the input lands in the SE position of
+the SW sub-quadrant for `nw`, NE/SW/SE wrap analogously). Composing twice,
+`padCenter2` shifts every cell of `c` by `+2^(k-1) + 2^k = 3·2^(k-1)`.
 
-/-- The cells of `padCenter2 c` restricted to the centered region equal
-    the cells of `c`.
+To recover `c.toCellsAux 0 0` from `(padCenter2 c).toCellsAux _ _`,
+the calling offset must therefore be `-3·2^(k-1)` on both axes. -/
+
+/-- The cells of `padCenter2 c` viewed from the corrected center offset
+    equal the cells of `c` viewed from origin. The negative offset
+    `-(3·2^(k-1))` exactly cancels the cumulative shift introduced by
+    the two `padToLevelPlus1` applications.
+
+    **Statement correction (this commit)**: the previous version used
+    `center_off = (2^k, 2^k)`, which is incorrect — it would only cancel
+    a shift of `-2^k`, but the actual shift introduced by `padCenter2`
+    is `+3·2^(k-1)`. Verified empirically below on the 2×2 block witness
+    (`padCenter2_correct_block_level1`).
 
     **Proof strategy** (P3, difficulty: structural):
-    Direct computation. Unfold `padCenter2` (= `padToLevelPlus1` twice),
-    unfold `toCellsAux`, observe that the padding `e := emptyOfLevel ...`
-    contributes no live cells, and the four copies of `c` are at the same
-    position in the centered region. -/
-theorem padCenter2_correct (c : MacroCell) :
+    Induction on `c` is awkward because `padToLevelPlus1` matches on the
+    structure of the input (only nodes get padded). A direct unfolding
+    of `padCenter2`, `toCellsAux`, and the offset arithmetic at each
+    quadrant (NW/NE/SW/SE) should close the equality. The hypothesis
+    `1 ≤ c.level` rules out the degenerate leaf case where `padCenter2`
+    is the identity. -/
+theorem padCenter2_correct (c : MacroCell) (hk : 1 ≤ c.level) :
     let k := c.level
     let padded := padCenter2 c
-    let center_off : Int × Int := (2^k, 2^k)
-    padded.toCellsAux center_off.1 center_off.2 = c.toCellsAux 0 0 := by
-  -- P3 TARGET: structural correctness of padCenter2
+    let center_off : Int := -(3 * 2 ^ (k - 1) : Int)
+    padded.toCellsAux center_off center_off = c.toCellsAux 0 0 := by
+  -- P3 TARGET: structural correctness of padCenter2 with corrected offset.
+  -- The hypothesis `hk` excludes the trivial leaf case.
   sorry
+
+/-- WITNESS for P3 on a 2×2 block (level 1, shift = 3·2^0 = 3).
+
+    Empirically proven via `native_decide`: the corrected statement
+    holds on the level-1 all-alive 2×2 block. This certifies that the
+    constant `-(3·2^(k-1))` is correct (vs. the previous `2^k`).
+
+    Future work: extend to general `c.level ≥ 1` by structural argument
+    (P3 main theorem above). -/
+theorem padCenter2_correct_block_level1 :
+    let c : MacroCell :=
+      MacroCell.node MacroCell.aliveLeaf MacroCell.aliveLeaf
+                     MacroCell.aliveLeaf MacroCell.aliveLeaf
+    (padCenter2 c).toCellsAux (-3 : Int) (-3 : Int) = c.toCellsAux 0 0 := by
+  native_decide
 
 /-! ## P4. Hashlife central result (decompose-compose)
 


### PR DESCRIPTION
## Summary

Statement-correction PR for the P3 sorry `padCenter2_correct` on `Conway/Life/HashlifeCorrectness.lean`. The previous statement was **mathematically false** — `native_decide` confirms it. This PR replaces the statement with the correct one and adds an empirical witness theorem. The universal sorry stays (proof remains future work).

## Root cause

`padCenter2 := padToLevelPlus1 ∘ padToLevelPlus1` introduces a cumulative spatial shift of `+3·2^(k-1)` on every cell of `c` (for `c.level = k ≥ 1`), not `+2^k` as the old statement implicitly assumed.

- `padToLevelPlus1` places each sub-quadrant of `c` in a level-`(k+1)` MacroCell where the relevant slot is itself in the SE position of a level-`k` quadrant → shift `+2^(k-1)`.
- Composed twice: shift becomes `2^(k-1) + 2^k = 3·2^(k-1)`.

The old `center_off = (2^k, 2^k)` would only cancel a shift of `-2^k`, leaving a residual shift of `+(3·2^(k-1) - 2^k) = +2^(k-1)`. The statement was therefore false except at `k = 0` (degenerate leaf), where it's also wrong since `padCenter2 = id` on leaves and `center_off = 1 ≠ 0`.

## Empirical verification (native_decide, lake build SUCCESS pre-commit)

Witness on `testC1 = 2×2 all-alive block` (level 1, shift = `3·2^0 = 3`):

- **Old buggy statement** with `center_off = (2, 2)`:
  `(padCenter2 testC1).toCellsAux 2 2 ≠ testC1.toCellsAux 0 0` ✓ (FALSE, native_decide proves the inequality)
- **Corrected statement** with `center_off = (-3, -3)`:
  `(padCenter2 testC1).toCellsAux (-3) (-3) = testC1.toCellsAux 0 0` ✓ (TRUE, native_decide proves the equality)

The second equality is now permanently encoded as `padCenter2_correct_block_level1` in `HashlifeCorrectness.lean` below the main P3 theorem.

## Lake build SUCCESS — local proof

```
$ wsl bash -lc 'cd /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean && lake build Conway.Life.HashlifeCorrectness'
warning: Conway/Life/HashlifeCorrectness.lean:240:8: declaration uses `sorry`
warning: Conway/Life/HashlifeCorrectness.lean:540:8: declaration uses `sorry`
warning: Conway/Life/HashlifeCorrectness.lean:586:8: declaration uses `sorry`
warning: Conway/Life/HashlifeCorrectness.lean:613:8: declaration uses `sorry`
Build completed successfully (3319 jobs).
```

Witness theorem `padCenter2_correct_block_level1` compiles cleanly (no sorry warning on it).

## sorry count — no regression

```
$ grep -nE "^[[:space:]]*sorry[[:space:]]*$" Conway/Life/HashlifeCorrectness.lean
242:  sorry   # P1-related (mem_lightCone, pre-existing)
547:  sorry   # P3 (this PR — universal proof still future work, statement now correct)
593:  sorry   # P4 (intractable: depends on partial def hashlifeResultAux)
616:  sorry   # P5 (intractable: depends on partial def hashlifeResultAux)
```

Before this PR: **4 sorries on main**. After this PR: **4 sorries**. No regression.

## Scope

- `Conway/Life/HashlifeCorrectness.lean` ONLY (45 insertions, 13 deletions).
- P3 statement signature: added `(hk : 1 ≤ c.level)`, replaced `center_off : Int × Int := (2^k, 2^k)` with `center_off : Int := -(3 * 2 ^ (k - 1) : Int)`.
- P3 doc-comment rewritten to explain the bug and the fix.
- Added witness theorem `padCenter2_correct_block_level1` (1 theorem, `native_decide`).
- **No implementation touched.** `Hashlife.lean`, `MacroCell.lean`, etc. are unchanged.
- **No downstream impact.** `grep padCenter2_correct` confirms no consumer outside the definition site (P5 hashlife_correct will eventually use it, but is also `sorry`).

## Axiom check

Per §B Lean PR discipline, no new axioms introduced. The `sorry` count is unchanged; `native_decide` on `padCenter2_correct_block_level1` reduces to closed-term equality (no new axioms beyond what `Hashlife.lean` already pulls in).

## Coordination

- Independent of PR #2188 (which attacks the P1 sorry at L240/242). No conflict.
- Does not close any sorry — pure statement correction. The universal P3 proof remains a prover target.

Closes part of Conway Hashlife scaffolding (Epic #1647, #2162).