### PR TITLE
enrich(GameTheory-3): add 2 distributed exercises (0->3, #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -1,9 +1,18 @@
 {
  "cells": [
   {
-   "id": "0bd1bfea",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1b4941ff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028921,
+     "end_time": "2026-06-02T22:25:24.449112+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:24.420191+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory-3-Topology2x2\n",
     "\n",
@@ -34,10 +43,25 @@
    ]
   },
   {
-   "id": "4dfac306",
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "e3e6ed22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:24.499786Z",
+     "iopub.status.busy": "2026-06-02T22:25:24.499440Z",
+     "iopub.status.idle": "2026-06-02T22:25:27.226066Z",
+     "shell.execute_reply": "2026-06-02T22:25:27.223785Z"
+    },
+    "papermill": {
+     "duration": 2.753833,
+     "end_time": "2026-06-02T22:25:27.227639+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:24.473806+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -63,8 +87,18 @@
    ]
   },
   {
-   "id": "8bd4df10",
    "cell_type": "markdown",
+   "id": "2672f030",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02021,
+     "end_time": "2026-06-02T22:25:27.266904+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.246694+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Configuration de l'environnement\n",
     "\n",
@@ -74,13 +108,21 @@
     "- **NetworkX** : représentation du graphe de transformations\n",
     "- **dataclasses** : structure de données pour les jeux\n",
     "- **itertools.permutations** : génération de toutes les permutations ordinales"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "7da2b534",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6c9f6896",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023419,
+     "end_time": "2026-06-02T22:25:27.311681+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.288262+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Representation ordinale des jeux 2x2\n",
     "\n",
@@ -103,8 +145,18 @@
    ]
   },
   {
-   "id": "381c87c3",
    "cell_type": "markdown",
+   "id": "68e21274",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019576,
+     "end_time": "2026-06-02T22:25:27.354036+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.334460+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Pourquoi la représentation ordinale ?\n",
     "\n",
@@ -122,14 +174,28 @@
     "Ces deux jeux sont **stratégiquement identiques** car ils ont le même ordre ordinal : (3, 1, 4, 2).\n",
     "\n",
     "> **Note** : Cette approche suppose que les joueurs sont **ordinaux** dans leurs préférences, c'est-à-dire qu'ils se soucient uniquement de l'ordre, pas de l'intensité des différences."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "f2a65a8f",
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "8a4d5374",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:27.411842Z",
+     "iopub.status.busy": "2026-06-02T22:25:27.410978Z",
+     "iopub.status.idle": "2026-06-02T22:25:27.427679Z",
+     "shell.execute_reply": "2026-06-02T22:25:27.425639Z"
+    },
+    "papermill": {
+     "duration": 0.045213,
+     "end_time": "2026-06-02T22:25:27.429415+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.384202+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -199,9 +265,18 @@
    ]
   },
   {
-   "id": "808dd1a8",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "81edc7d9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.020799,
+     "end_time": "2026-06-02T22:25:27.471350+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.450551+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Jeux classiques en representation ordinale\n",
     "\n",
@@ -209,10 +284,25 @@
    ]
   },
   {
-   "id": "321af6fa",
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "0576189f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:27.528014Z",
+     "iopub.status.busy": "2026-06-02T22:25:27.527303Z",
+     "iopub.status.idle": "2026-06-02T22:25:27.541714Z",
+     "shell.execute_reply": "2026-06-02T22:25:27.539498Z"
+    },
+    "papermill": {
+     "duration": 0.044895,
+     "end_time": "2026-06-02T22:25:27.543627+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.498732+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -344,8 +434,18 @@
    ]
   },
   {
-   "id": "c7c01f10",
    "cell_type": "markdown",
+   "id": "70c4392e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.022004,
+     "end_time": "2026-06-02T22:25:27.587824+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.565820+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Observations sur les jeux classiques\n",
     "\n",
@@ -365,13 +465,21 @@
     "- Stag Hunt, Battle of Sexes, Pure Coordination : deux équilibres sur la diagonale\n",
     "- Chicken : deux équilibres hors diagonale\n",
     "- Matching Pennies : aucun équilibre pur (conflit pur)"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "8650edaa",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "aa50d755",
+   "metadata": {
+    "papermill": {
+     "duration": 0.050128,
+     "end_time": "2026-06-02T22:25:27.660357+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.610229+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la representation ordinale\n",
     "\n",
@@ -395,9 +503,18 @@
    ]
   },
   {
-   "id": "a11e02a8",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1252907d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024597,
+     "end_time": "2026-06-02T22:25:27.720672+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.696075+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Swaps de gains : transformations elementaires\n",
     "\n",
@@ -414,10 +531,25 @@
    ]
   },
   {
-   "id": "f03fc076",
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "id": "c9dd08ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:27.791519Z",
+     "iopub.status.busy": "2026-06-02T22:25:27.790807Z",
+     "iopub.status.idle": "2026-06-02T22:25:27.803963Z",
+     "shell.execute_reply": "2026-06-02T22:25:27.801812Z"
+    },
+    "papermill": {
+     "duration": 0.047122,
+     "end_time": "2026-06-02T22:25:27.805701+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.758579+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -490,8 +622,18 @@
    ]
   },
   {
-   "id": "4fbe8646",
    "cell_type": "markdown",
+   "id": "8c0c851c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025615,
+     "end_time": "2026-06-02T22:25:27.969870+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.944255+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Recherche de chemins par BFS\n",
     "\n",
@@ -508,14 +650,28 @@
     "- Temps : O(6 × 576) = exploration des arêtes\n",
     "\n",
     "Le résultat montre que PD et Stag Hunt ne sont distants que de **2 swaps**, confirmant leur proximité structurelle."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "5d5aa63a",
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "d06a5ef1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.017177Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.016729Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.032634Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.030663Z"
+    },
+    "papermill": {
+     "duration": 0.041365,
+     "end_time": "2026-06-02T22:25:28.034196+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:27.992831+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -617,9 +773,18 @@
    ]
   },
   {
-   "id": "c13e63c1",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "45b28b9b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023155,
+     "end_time": "2026-06-02T22:25:28.079653+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.056498+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation de la transformation PD -> Stag Hunt\n",
     "\n",
@@ -642,9 +807,90 @@
    ]
   },
   {
-   "id": "4fe896b5",
    "cell_type": "markdown",
-   "metadata": {},
+   "execution_count": null,
+   "id": "fa327791",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02584,
+     "end_time": "2026-06-02T22:25:28.150350+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.124510+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "### Exercice 1 : Voisins de swap d'un jeu personnalise\n",
+    "\n",
+    "Creez un jeu 2x2 ordinal de votre choix et explorez ses 6 voisins dans le graphe des swaps. Pour chaque voisin, identifiez sa famille et ses equilibres de Nash.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Indice 1` : Utilisez `OrdinalGame(row_payoffs=(...), col_payoffs=(...), name=\"MonJeu\")` pour creer un jeu (chaque tuple doit etre une permutation de 1,2,3,4)\n",
+    "- `# Indice 2` : Les 6 voisins s'obtiennent avec `apply_row_swap()` et `apply_col_swap()` pour les 3 paires de rangs (1,2), (2,3), (3,4)\n",
+    "- `# Etape 1` : Choisissez un jeu qui n'est pas dans `CLASSIC_GAMES` (une permutation originale)\n",
+    "- `# Etape 2` : Pour chaque voisin, utilisez `classify_game_family()` et `find_pure_nash()` pour le decrire\n",
+    "- `# Etape 3` : Trouvez quel(s) voisin(s) appartiennent a une famille differente de votre jeu de depart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2ebe90c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.199400Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.198751Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.207466Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.205564Z"
+    },
+    "papermill": {
+     "duration": 0.036358,
+     "end_time": "2026-06-02T22:25:28.209086+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.172728+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : exploration des voisins de swap\n"
+     ]
+    }
+   ],
+   "source": [
+    "def explore_swap_neighbors(game: OrdinalGame) -> list:\n",
+    "    # TODO etudiant : implementer l'exploration des voisins de swap\n",
+    "    # Etape 1 : iterer sur les 3 paires de swaps [(1,2), (2,3), (3,4)]\n",
+    "    # Etape 2 : pour chaque paire, calculer le voisin Row et le voisin Col\n",
+    "    # Etape 3 : pour chaque voisin, determiner sa famille et ses equilibres de Nash\n",
+    "    # Etape 4 : retourner une liste de dicts avec les informations de chaque voisin\n",
+    "    # Indice : utilisez apply_row_swap, apply_col_swap, classify_game_family, find_pure_nash\n",
+    "    return []  # TODO etudiant : remplacer\n",
+    "\n",
+    "# mon_jeu = OrdinalGame(row_payoffs=(2, 4, 1, 3), col_payoffs=(1, 3, 4, 2), name=\"MonJeu\")\n",
+    "# resultats = explore_swap_neighbors(mon_jeu)\n",
+    "print(\"Exercice a completer : exploration des voisins de swap\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "803054de",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025253,
+     "end_time": "2026-06-02T22:25:28.257092+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.231839+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Graphe des transformations\n",
     "\n",
@@ -656,8 +902,18 @@
    ]
   },
   {
-   "id": "2b46035b",
    "cell_type": "markdown",
+   "id": "9f14cea8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.030819,
+     "end_time": "2026-06-02T22:25:28.316371+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.285552+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Le graphe des jeux comme espace topologique\n",
     "\n",
@@ -669,14 +925,28 @@
     "- Quelle est la distance entre deux jeux ? (nombre minimal de swaps)\n",
     "- Existe-t-il des \"régions\" dans cet espace ? (groupes de jeux similaires)\n",
     "- Le graphe a-t-il une structure géométrique particulière ? (spoiler: oui, c'est un tore !)"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "0b0f299f",
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 7,
+   "id": "28da115f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.381348Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.380909Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.391896Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.390212Z"
+    },
+    "papermill": {
+     "duration": 0.046743,
+     "end_time": "2026-06-02T22:25:28.393293+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.346550+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -709,8 +979,18 @@
    ]
   },
   {
-   "id": "e3c2ff9c",
    "cell_type": "markdown",
+   "id": "4b209677",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027001,
+     "end_time": "2026-06-02T22:25:28.443683+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.416682+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Generation exhaustive\n",
     "\n",
@@ -727,14 +1007,28 @@
     "- **78 classes** apres elimination de la symetrie entre joueurs (echanger Row et Col)\n",
     "\n",
     "> **Note** : Nous travaillons avec les 576 pour avoir le graphe complet. Les 144 jeux distincts correspondent aux \"noyaux\" de Robinson & Goforth."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "b46bd745",
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 8,
+   "id": "cda139de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.500351Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.498344Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.545990Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.543979Z"
+    },
+    "papermill": {
+     "duration": 0.079249,
+     "end_time": "2026-06-02T22:25:28.547639+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.468390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -795,8 +1089,18 @@
    ]
   },
   {
-   "id": "0db7bd38",
    "cell_type": "markdown",
+   "id": "92a351ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024071,
+     "end_time": "2026-06-02T22:25:28.595782+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.571711+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Structure du graphe\n",
     "\n",
@@ -811,14 +1115,28 @@
     "Le graphe est **connexe**, ce qui signifie qu'on peut transformer n'importe quel jeu en n'importe quel autre par une sequence finie de swaps.\n",
     "\n",
     "> **Interpretation geometrique** : Ce graphe a la structure d'un **tore** (forme de doughnut). Les swaps pour Row correspondent a un deplacement dans une direction, ceux pour Col dans l'autre. Cette structure torique est au coeur de la \"topologie des jeux 2x2\" de Robinson & Goforth."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "b7357088",
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 9,
+   "id": "847786c2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.659496Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.659065Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.672985Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.670927Z"
+    },
+    "papermill": {
+     "duration": 0.0427,
+     "end_time": "2026-06-02T22:25:28.674679+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.631979+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -870,8 +1188,18 @@
    ]
   },
   {
-   "id": "9720141f",
    "cell_type": "markdown",
+   "id": "3deb0f93",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02501,
+     "end_time": "2026-06-02T22:25:28.722208+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.697198+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Propriétés du graphe de swaps\n",
     "\n",
@@ -888,13 +1216,21 @@
     "**Implications** :\n",
     "- Tout jeu peut se transformer en tout autre jeu par des modifications progressives des préférences\n",
     "- La \"distance\" entre jeux mesure leur similarité structurelle"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "36c9ad34",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "48c8913d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.025606,
+     "end_time": "2026-06-02T22:25:28.773940+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.748334+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Proximite strategique entre jeux\n",
     "\n",
@@ -916,9 +1252,18 @@
    ]
   },
   {
-   "id": "7df88a60",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d3876a3e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.027451,
+     "end_time": "2026-06-02T22:25:28.826243+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.798792+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Classification par structure de Nash\n",
     "\n",
@@ -926,10 +1271,25 @@
    ]
   },
   {
-   "id": "f32eee45",
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 10,
+   "id": "c3a05aaf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:28.880989Z",
+     "iopub.status.busy": "2026-06-02T22:25:28.880321Z",
+     "iopub.status.idle": "2026-06-02T22:25:28.901724Z",
+     "shell.execute_reply": "2026-06-02T22:25:28.899924Z"
+    },
+    "papermill": {
+     "duration": 0.052231,
+     "end_time": "2026-06-02T22:25:28.903037+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.850806+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1022,8 +1382,18 @@
    ]
   },
   {
-   "id": "45a48fcb",
    "cell_type": "markdown",
+   "id": "12fb1fe3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.02576,
+     "end_time": "2026-06-02T22:25:28.950881+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.925121+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Analyse de la distribution Nash\n",
     "\n",
@@ -1037,13 +1407,21 @@
     "- **4 Nash** : Toutes les cellules sont Nash (jeu trivial) → 0%\n",
     "\n",
     "Notez que 3 Nash est **structurellement impossible** : si trois cellules sont des équilibres, la symétrie des meilleures réponses implique que la quatrième l'est aussi."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "8d331f11",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "0112b5ea",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028323,
+     "end_time": "2026-06-02T22:25:29.009848+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:28.981525+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Distribution des equilibres : que nous dit-elle ?\n",
     "\n",
@@ -1066,9 +1444,18 @@
    ]
   },
   {
-   "id": "aca1b459",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d206e873",
+   "metadata": {
+    "papermill": {
+     "duration": 0.037369,
+     "end_time": "2026-06-02T22:25:29.092015+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:29.054646+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Visualisation: \"Table periodique\" des jeux\n",
     "\n",
@@ -1076,8 +1463,18 @@
    ]
   },
   {
-   "id": "e8fb964c",
    "cell_type": "markdown",
+   "id": "25ccfcd7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024118,
+     "end_time": "2026-06-02T22:25:29.140889+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:29.116771+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Visualisation des jeux 2x2\n",
     "\n",
@@ -1089,14 +1486,28 @@
     "- Cellules **vertes** = équilibres de Nash purs\n",
     "- Cellules **grises** = issues non-Nash\n",
     "- Chaque cellule contient (gain Ligne, gain Colonne) en notation ordinale (1-4)"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "feb73066",
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 11,
+   "id": "d4ad9343",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:29.197767Z",
+     "iopub.status.busy": "2026-06-02T22:25:29.197302Z",
+     "iopub.status.idle": "2026-06-02T22:25:30.688448Z",
+     "shell.execute_reply": "2026-06-02T22:25:30.684432Z"
+    },
+    "papermill": {
+     "duration": 1.523108,
+     "end_time": "2026-06-02T22:25:30.690048+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:29.166940+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1178,8 +1589,18 @@
    ]
   },
   {
-   "id": "7f6e9e9c",
    "cell_type": "markdown",
+   "id": "1a727551",
+   "metadata": {
+    "papermill": {
+     "duration": 0.032937,
+     "end_time": "2026-06-02T22:25:30.758283+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:30.725346+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Grille des jeux classiques\n",
     "\n",
@@ -1194,14 +1615,28 @@
     "- **Aucun Nash** (Matching Pennies) : Aucune cellule verte - equilibre mixte uniquement\n",
     "\n",
     "> **Remarque pedagogique** : Cette representation visuelle permet d'identifier immediatement le \"type\" d'un jeu en regardant simplement la position des cellules vertes."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "6e0e1b3e",
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": 12,
+   "id": "c4d9b3da",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:30.841363Z",
+     "iopub.status.busy": "2026-06-02T22:25:30.840975Z",
+     "iopub.status.idle": "2026-06-02T22:25:31.266239Z",
+     "shell.execute_reply": "2026-06-02T22:25:31.264052Z"
+    },
+    "papermill": {
+     "duration": 0.47073,
+     "end_time": "2026-06-02T22:25:31.267686+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:30.796956+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1259,8 +1694,18 @@
    ]
   },
   {
-   "id": "011ab58b",
    "cell_type": "markdown",
+   "id": "5d87ad30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.03673,
+     "end_time": "2026-06-02T22:25:31.342843+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:31.306113+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Que montrent ces transformations ?\n",
     "\n",
@@ -1278,13 +1723,21 @@
     "- Deux équilibres : (C,C) et (D,D)\n",
     "- (C,C) est Pareto-optimal et préféré par tous\n",
     "- Le problème n'est plus le \"dilemme\" mais la **confiance** pour atteindre le bon équilibre"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "7de98af9",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8906a916",
+   "metadata": {
+    "papermill": {
+     "duration": 0.028582,
+     "end_time": "2026-06-02T22:25:31.401151+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:31.372569+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Familles de jeux\n",
     "\n",
@@ -1292,10 +1745,25 @@
    ]
   },
   {
-   "id": "af73859c",
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 13,
+   "id": "3b5241a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:31.463118Z",
+     "iopub.status.busy": "2026-06-02T22:25:31.462561Z",
+     "iopub.status.idle": "2026-06-02T22:25:31.476487Z",
+     "shell.execute_reply": "2026-06-02T22:25:31.474936Z"
+    },
+    "papermill": {
+     "duration": 0.046865,
+     "end_time": "2026-06-02T22:25:31.477729+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:31.430864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1376,8 +1844,18 @@
    ]
   },
   {
-   "id": "cecc31c1",
    "cell_type": "markdown",
+   "id": "4ecdc767",
+   "metadata": {
+    "papermill": {
+     "duration": 0.033533,
+     "end_time": "2026-06-02T22:25:31.545255+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:31.511722+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Classification des jeux classiques\n",
     "\n",
@@ -1399,14 +1877,28 @@
     "| **Matching Pennies** | MIXED_ONLY | Aucun Nash pur, conflit total |\n",
     "\n",
     "> **Note** : La distinction COORDINATION vs ANTI_COORDINATION est fondamentale. Dans les jeux de coordination, les joueurs veulent etre \"ensemble\" (meme strategie). Dans les jeux d'anti-coordination, ils veulent etre \"differents\"."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "26d4aa27",
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 14,
+   "id": "32776d53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:31.620234Z",
+     "iopub.status.busy": "2026-06-02T22:25:31.619678Z",
+     "iopub.status.idle": "2026-06-02T22:25:32.002984Z",
+     "shell.execute_reply": "2026-06-02T22:25:32.000221Z"
+    },
+    "papermill": {
+     "duration": 0.427864,
+     "end_time": "2026-06-02T22:25:32.004635+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:31.576771+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1450,8 +1942,18 @@
    ]
   },
   {
-   "id": "83093d70",
    "cell_type": "markdown",
+   "id": "d60549c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.037558,
+     "end_time": "2026-06-02T22:25:32.078661+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.041103+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation de la distribution des familles\n",
     "\n",
@@ -1464,13 +1966,90 @@
     "- **DOMINANT** est une sous-catégorie de SINGLE_NASH où la stratégie est \"évidente\" par dominance\n",
     "\n",
     "Cette distribution n'est pas aléatoire : elle reflète la structure combinatoire des préférences ordinales sur 4 cellules."
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "06d75eae",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "305ac347",
+   "metadata": {
+    "papermill": {
+     "duration": 0.04327,
+     "end_time": "2026-06-02T22:25:32.164273+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.121003+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Cartographie des voisins d'un jeu classique\n",
+    "\n",
+    "Choisissez un jeu classique (par exemple Deadlock ou Harmony) et construisez un \"portrait\" complet de ses 6 voisins dans le graphe des swaps : famille, equilibres de Nash, issues Pareto-optimales. Comparez l'efficacite sociale de chaque voisin avec le jeu original.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Indice 1` : Utilisez les fonctions `apply_row_swap(game, r1, r2)` et `apply_col_swap(game, r1, r2)` pour les paires (1,2), (2,3), (3,4)\n",
+    "- `# Indice 2` : Pour chaque voisin, utilisez `classify_game_family()`, `find_pure_nash()`, et `find_pareto_optimal()` (definie en section 8)\n",
+    "- `# Etape 1` : Choisissez un jeu classique et calculez ses 6 voisins\n",
+    "- `# Etape 2` : Pour chaque voisin, determinez s'il a un Nash Pareto-domine (comme le PD)\n",
+    "- `# Etape 3` : Identifiez quel(s) swap(s) transforment un DOMINANT en COORDINATION ou ANTI_COORDINATION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b21a4eb2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:32.239175Z",
+     "iopub.status.busy": "2026-06-02T22:25:32.238531Z",
+     "iopub.status.idle": "2026-06-02T22:25:32.247200Z",
+     "shell.execute_reply": "2026-06-02T22:25:32.245312Z"
+    },
+    "papermill": {
+     "duration": 0.047261,
+     "end_time": "2026-06-02T22:25:32.248422+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.201161+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : cartographie des voisins\n"
+     ]
+    }
+   ],
+   "source": [
+    "def portrait_voisins(game: OrdinalGame) -> list:\n",
+    "    # TODO etudiant : implementer le portrait complet des 6 voisins\n",
+    "    # Etape 1 : calculer les 6 voisins avec apply_row_swap et apply_col_swap pour (1,2), (2,3), (3,4)\n",
+    "    # Etape 2 : pour chaque voisin, calculer famille, Nash purs, Pareto-optimal\n",
+    "    # Etape 3 : comparer l'efficacite sociale de chaque voisin avec le jeu original\n",
+    "    # Indice : la fonction find_pareto_optimal est definie en section 8\n",
+    "    return []  # TODO etudiant : remplacer\n",
+    "\n",
+    "# jeu_choisi = CLASSIC_GAMES[\"Deadlock\"]\n",
+    "# resultats = portrait_voisins(jeu_choisi)\n",
+    "print(\"Exercice a completer : cartographie des voisins\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ddb6034",
+   "metadata": {
+    "papermill": {
+     "duration": 0.038784,
+     "end_time": "2026-06-02T22:25:32.323157+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.284373+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Efficacite sociale : Pareto\n",
     "\n",
@@ -1478,10 +2057,25 @@
    ]
   },
   {
-   "id": "86722086",
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 16,
+   "id": "65292e27",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:32.411041Z",
+     "iopub.status.busy": "2026-06-02T22:25:32.410459Z",
+     "iopub.status.idle": "2026-06-02T22:25:32.432814Z",
+     "shell.execute_reply": "2026-06-02T22:25:32.430794Z"
+    },
+    "papermill": {
+     "duration": 0.069658,
+     "end_time": "2026-06-02T22:25:32.434061+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.364403+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1599,9 +2193,18 @@
    ]
   },
   {
-   "id": "6ac0d1d3",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "962ca97c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.046575,
+     "end_time": "2026-06-02T22:25:32.524432+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.477857+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Le Dilemme du Prisonnier : l'exception qui confirme la regle\n",
     "\n",
@@ -1628,8 +2231,18 @@
    ]
   },
   {
-   "id": "a37b1a38",
    "cell_type": "markdown",
+   "id": "ecf3001c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.046828,
+     "end_time": "2026-06-02T22:25:32.614624+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.567796+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Résumé visuel : Nash vs Pareto\n",
     "\n",
@@ -1645,13 +2258,21 @@
     "| **BoS** | Les deux Nash | ✅ OUI | 7 chacun | Aucune amélioration possible |\n",
     "\n",
     "**Observation** : Dans Chicken et BoS, les équilibres de Nash sont Pareto-optimaux. Le problème n'est pas l'inefficacité mais la **coordination** - quel équilibre choisir ?"
-   ],
-   "metadata": {}
+   ]
   },
   {
-   "id": "9136dda5",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "108383c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.046784,
+     "end_time": "2026-06-02T22:25:32.708292+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.661508+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Observation cle\n",
     "\n",
@@ -1661,9 +2282,18 @@
    ]
   },
   {
-   "id": "b74424db",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d930a921",
+   "metadata": {
+    "papermill": {
+     "duration": 0.04009,
+     "end_time": "2026-06-02T22:25:32.800615+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.760525+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Resume\n",
     "\n",
@@ -1694,9 +2324,18 @@
    ]
   },
   {
-   "id": "9de2ae8e",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "96276066",
+   "metadata": {
+    "papermill": {
+     "duration": 0.052822,
+     "end_time": "2026-06-02T22:25:32.891760+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.838938+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. Exemples guides\n",
     "\n",
@@ -1711,18 +2350,50 @@
    ]
   },
   {
-   "id": "9791729e",
    "cell_type": "markdown",
+   "id": "d9a7fc63",
+   "metadata": {
+    "papermill": {
+     "duration": 0.042221,
+     "end_time": "2026-06-02T22:25:32.969334+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:32.927113+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Pistes de solution\n\n**Exercice 1** : Utilisez la fonction `find_swap_path()` avec `CLASSIC_GAMES[\"Chicken\"]` et `CLASSIC_GAMES[\"Matching Pennies\"]` pour découvrir la séquence optimale.\n\n**Exercice 2** : Réfléchissez à la structure des meilleures réponses dans un jeu 2x2. Combien de Nash purs peut-on avoir au maximum ?\n\n> **Réflexion** : Pensez à la symétrie des meilleures réponses. Si trois cellules sont des équilibres, pourquoi la quatrième ne le serait-elle pas aussi ?\n\n**Exercice 3** : Utilisez `find_swap_path()` et `show_transformation_chain()` pour visualiser la transformation PD → Harmony."
-   ],
-   "metadata": {}
+    "### Pistes de solution\n",
+    "\n",
+    "**Exercice 1** : Utilisez la fonction `find_swap_path()` avec `CLASSIC_GAMES[\"Chicken\"]` et `CLASSIC_GAMES[\"Matching Pennies\"]` pour découvrir la séquence optimale.\n",
+    "\n",
+    "**Exercice 2** : Réfléchissez à la structure des meilleures réponses dans un jeu 2x2. Combien de Nash purs peut-on avoir au maximum ?\n",
+    "\n",
+    "> **Réflexion** : Pensez à la symétrie des meilleures réponses. Si trois cellules sont des équilibres, pourquoi la quatrième ne le serait-elle pas aussi ?\n",
+    "\n",
+    "**Exercice 3** : Utilisez `find_swap_path()` et `show_transformation_chain()` pour visualiser la transformation PD → Harmony."
+   ]
   },
   {
-   "id": "0a613a2a",
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": 17,
+   "id": "683ba13f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:25:33.050277Z",
+     "iopub.status.busy": "2026-06-02T22:25:33.049871Z",
+     "iopub.status.idle": "2026-06-02T22:25:33.056429Z",
+     "shell.execute_reply": "2026-06-02T22:25:33.054719Z"
+    },
+    "papermill": {
+     "duration": 0.055809,
+     "end_time": "2026-06-02T22:25:33.059715+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:33.003906+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1738,9 +2409,18 @@
    ]
   },
   {
-   "id": "65d97e80",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e0e384d4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.035721,
+     "end_time": "2026-06-02T22:25:33.138986+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:33.103265+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### A retenir\n",
     "\n",
@@ -1759,9 +2439,18 @@
    ]
   },
   {
-   "id": "59ee8ec9",
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6e564759",
+   "metadata": {
+    "papermill": {
+     "duration": 0.043797,
+     "end_time": "2026-06-02T22:25:33.225105+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:25:33.181308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "\n",
@@ -1775,8 +2464,32 @@
    "display_name": "Python (GameTheory WSL + OpenSpiel)",
    "language": "python",
    "name": "gametheory-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 12.278244,
+   "end_time": "2026-06-02T22:25:33.958514+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-3-Topology2x2.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-3-Topology2x2_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-06-02T22:25:21.680270+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
Add 2 exercise stubs to GameTheory-3-Topology2x2 to meet convention >=3 exercises per notebook (#2161).

## Exercises added
- **Exercise 1** (after section 3, swaps): `explore_swap_neighbors()` — explore the 6 swap-neighbors of a custom OrdinalGame, classify each by family and Nash equilibria
- **Exercise 2** (after section 7, families): `portrait_voisins()` — build a full portrait of 6 neighbors of a classic game: family, Nash, Pareto-optimality

## Existing exercise (unchanged)
- **Exercise 3** (section 10): exploration topologique — 3 guided exercises

## Validation
- Papermill: 17/17 code cells, 0 errors, 13.6s
- Diff: +840/-127

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>