### PR TITLE
enrich(gametheory): GT-4,8,8c,15c exercises (#2161 batch 4)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "8d2d1c46",
    "metadata": {
     "papermill": {
-     "duration": 0.020032,
-     "end_time": "2026-05-20T23:40:47.597177+00:00",
+     "duration": 0.004429,
+     "end_time": "2026-06-02T22:36:13.991861+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:47.577145+00:00",
+     "start_time": "2026-06-02T22:36:13.987432+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,16 +43,16 @@
    "id": "65dc3847",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:47.621227Z",
-     "iopub.status.busy": "2026-05-20T23:40:47.620990Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.050430Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.049839Z"
+     "iopub.execute_input": "2026-06-02T22:36:14.003089Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.002688Z",
+     "iopub.status.idle": "2026-06-02T22:36:14.704420Z",
+     "shell.execute_reply": "2026-06-02T22:36:14.703313Z"
     },
     "papermill": {
-     "duration": 0.441901,
-     "end_time": "2026-05-20T23:40:48.054893+00:00",
+     "duration": 0.70861,
+     "end_time": "2026-06-02T22:36:14.705664+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:47.612992+00:00",
+     "start_time": "2026-06-02T22:36:13.997054+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,10 +82,10 @@
    "id": "11c24553",
    "metadata": {
     "papermill": {
-     "duration": 0.011876,
-     "end_time": "2026-05-20T23:40:48.075301+00:00",
+     "duration": 0.005646,
+     "end_time": "2026-06-02T22:36:14.715864+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.063425+00:00",
+     "start_time": "2026-06-02T22:36:14.710218+00:00",
      "status": "completed"
     },
     "tags": []
@@ -106,16 +106,16 @@
    "id": "46862ef1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.122762Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.122239Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.129865Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.128995Z"
+     "iopub.execute_input": "2026-06-02T22:36:14.725797Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.725374Z",
+     "iopub.status.idle": "2026-06-02T22:36:14.731093Z",
+     "shell.execute_reply": "2026-06-02T22:36:14.730113Z"
     },
     "papermill": {
-     "duration": 0.038896,
-     "end_time": "2026-05-20T23:40:48.135842+00:00",
+     "duration": 0.011773,
+     "end_time": "2026-06-02T22:36:14.731886+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.096946+00:00",
+     "start_time": "2026-06-02T22:36:14.720113+00:00",
      "status": "completed"
     },
     "tags": []
@@ -159,10 +159,10 @@
    "id": "c1c7ec32",
    "metadata": {
     "papermill": {
-     "duration": 0.030691,
-     "end_time": "2026-05-20T23:40:48.190190+00:00",
+     "duration": 0.004331,
+     "end_time": "2026-06-02T22:36:14.740591+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.159499+00:00",
+     "start_time": "2026-06-02T22:36:14.736260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -181,16 +181,16 @@
    "id": "52c83b97",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.252511Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.250972Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.292688Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.285146Z"
+     "iopub.execute_input": "2026-06-02T22:36:14.751037Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.750581Z",
+     "iopub.status.idle": "2026-06-02T22:36:14.757619Z",
+     "shell.execute_reply": "2026-06-02T22:36:14.756546Z"
     },
     "papermill": {
-     "duration": 0.095881,
-     "end_time": "2026-05-20T23:40:48.301193+00:00",
+     "duration": 0.013458,
+     "end_time": "2026-06-02T22:36:14.758450+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.205312+00:00",
+     "start_time": "2026-06-02T22:36:14.744992+00:00",
      "status": "completed"
     },
     "tags": []
@@ -245,10 +245,10 @@
    "id": "ebcebb55",
    "metadata": {
     "papermill": {
-     "duration": 0.031382,
-     "end_time": "2026-05-20T23:40:48.356653+00:00",
+     "duration": 0.004628,
+     "end_time": "2026-06-02T22:36:14.767855+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.325271+00:00",
+     "start_time": "2026-06-02T22:36:14.763227+00:00",
      "status": "completed"
     },
     "tags": []
@@ -274,16 +274,16 @@
    "id": "69170cd4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.410361Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.409499Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.419921Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.418330Z"
+     "iopub.execute_input": "2026-06-02T22:36:14.779609Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.779317Z",
+     "iopub.status.idle": "2026-06-02T22:36:14.785742Z",
+     "shell.execute_reply": "2026-06-02T22:36:14.784569Z"
     },
     "papermill": {
-     "duration": 0.045429,
-     "end_time": "2026-05-20T23:40:48.422470+00:00",
+     "duration": 0.013533,
+     "end_time": "2026-06-02T22:36:14.786651+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.377041+00:00",
+     "start_time": "2026-06-02T22:36:14.773118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -328,10 +328,10 @@
    "id": "ee963af9",
    "metadata": {
     "papermill": {
-     "duration": 0.005221,
-     "end_time": "2026-05-20T23:40:48.438377+00:00",
+     "duration": 0.00508,
+     "end_time": "2026-06-02T22:36:14.796934+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.433156+00:00",
+     "start_time": "2026-06-02T22:36:14.791854+00:00",
      "status": "completed"
     },
     "tags": []
@@ -355,21 +355,102 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ex-glove-extended-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005323,
+     "end_time": "2026-06-02T22:36:14.806995+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:14.801672+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Jeu de gants etendu a 4 joueurs\n",
+    "\n",
+    "**Objectif** : Etendre le jeu de gants a 4 joueurs : L1, L2 (gants gauches) et R1, R2 (gants droits). Definir la fonction caracteristique, calculer les valeurs de Shapley, et interpreter comment le marche 2-vs-2 repartit la valeur.\n",
+    "\n",
+    "**Contexte** : Le jeu a 3 joueurs montre que le detenteur de la ressource rare obtient 4/6. Avec 2 gants de chaque cote, le marche est equilibre.\n",
+    "\n",
+    "# Indice : Joueurs 0,1 = gants gauches, joueurs 2,3 = gants droits. v(S) = min(gauches, droites).\n",
+    "# Etape 1 : Definir glove_game_4(S).\n",
+    "# Etape 2 : Calculer shapley_value_exact(glove_game_4, 4).\n",
+    "# Etape 3 : Comparer avec le resultat a 3 joueurs (ressource rare vs equilibre)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "ex-glove-extended-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:36:14.818605Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.818228Z",
+     "iopub.status.idle": "2026-06-02T22:36:14.824713Z",
+     "shell.execute_reply": "2026-06-02T22:36:14.823598Z"
+    },
+    "papermill": {
+     "duration": 0.013764,
+     "end_time": "2026-06-02T22:36:14.825708+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:14.811944+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Total: 0.0000\n",
+      "Interpretation: \n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_shapley_glove_etendu() -> dict:\n",
+    "    \"\"\"\n",
+    "    Jeu de gants etendu a 4 joueurs (2 gauches, 2 droites).\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'shapley_values': liste des 4 valeurs de Shapley\n",
+    "            'total': somme des valeurs (= v(N))\n",
+    "            'interpretation': texte d'interpretation\n",
+    "    \"\"\"\n",
+    "    return {\"shapley_values\": [], \"total\": 0.0, \"interpretation\": \"\"}  # TODO etudiant\n",
+    "\n",
+    "result_glove4 = exercice_shapley_glove_etendu()\n",
+    "labels_4 = ['L1', 'L2', 'R1', 'R2']\n",
+    "for label, val in zip(labels_4, result_glove4['shapley_values']):\n",
+    "    print(f\"  {label}: {val:.4f}\")\n",
+    "print(f\"\\nTotal: {result_glove4['total']:.4f}\")\n",
+    "print(f\"Interpretation: {result_glove4['interpretation']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "443631a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.449955Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.449426Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.637478Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.636776Z"
+     "iopub.execute_input": "2026-06-02T22:36:14.837150Z",
+     "iopub.status.busy": "2026-06-02T22:36:14.836709Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.039947Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.038928Z"
     },
     "papermill": {
-     "duration": 0.197047,
-     "end_time": "2026-05-20T23:40:48.639637+00:00",
+     "duration": 0.21032,
+     "end_time": "2026-06-02T22:36:15.040856+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.442590+00:00",
+     "start_time": "2026-06-02T22:36:14.830536+00:00",
      "status": "completed"
     },
     "tags": []
@@ -415,10 +496,10 @@
    "id": "6e56fe89",
    "metadata": {
     "papermill": {
-     "duration": 0.005308,
-     "end_time": "2026-05-20T23:40:48.652988+00:00",
+     "duration": 0.005402,
+     "end_time": "2026-06-02T22:36:15.052390+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.647680+00:00",
+     "start_time": "2026-06-02T22:36:15.046988+00:00",
      "status": "completed"
     },
     "tags": []
@@ -433,20 +514,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "7a8740a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.665841Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.665602Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.670749Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.669967Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.066279Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.065877Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.072597Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.071457Z"
     },
     "papermill": {
-     "duration": 0.013908,
-     "end_time": "2026-05-20T23:40:48.671802+00:00",
+     "duration": 0.014701,
+     "end_time": "2026-06-02T22:36:15.073399+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.657894+00:00",
+     "start_time": "2026-06-02T22:36:15.058698+00:00",
      "status": "completed"
     },
     "tags": []
@@ -492,10 +573,10 @@
    "id": "8a8e5051",
    "metadata": {
     "papermill": {
-     "duration": 0.004573,
-     "end_time": "2026-05-20T23:40:48.682953+00:00",
+     "duration": 0.005306,
+     "end_time": "2026-06-02T22:36:15.085009+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.678380+00:00",
+     "start_time": "2026-06-02T22:36:15.079703+00:00",
      "status": "completed"
     },
     "tags": []
@@ -515,20 +596,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "91eaa7f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.702659Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.701398Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.711804Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.709500Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.097332Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.096875Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.102472Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.101306Z"
     },
     "papermill": {
-     "duration": 0.028186,
-     "end_time": "2026-05-20T23:40:48.715266+00:00",
+     "duration": 0.013415,
+     "end_time": "2026-06-02T22:36:15.103374+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.687080+00:00",
+     "start_time": "2026-06-02T22:36:15.089959+00:00",
      "status": "completed"
     },
     "tags": []
@@ -594,10 +675,10 @@
    "id": "00b2e99a",
    "metadata": {
     "papermill": {
-     "duration": 0.013057,
-     "end_time": "2026-05-20T23:40:48.739599+00:00",
+     "duration": 0.006994,
+     "end_time": "2026-06-02T22:36:15.116849+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.726542+00:00",
+     "start_time": "2026-06-02T22:36:15.109855+00:00",
      "status": "completed"
     },
     "tags": []
@@ -618,20 +699,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "621ba23b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.799968Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.799343Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.815200Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.809773Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.129195Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.128883Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.134434Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.133580Z"
     },
     "papermill": {
-     "duration": 0.053199,
-     "end_time": "2026-05-20T23:40:48.821202+00:00",
+     "duration": 0.013533,
+     "end_time": "2026-06-02T22:36:15.135317+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.768003+00:00",
+     "start_time": "2026-06-02T22:36:15.121784+00:00",
      "status": "completed"
     },
     "tags": []
@@ -674,10 +755,10 @@
    "id": "ecfb28f3",
    "metadata": {
     "papermill": {
-     "duration": 0.03798,
-     "end_time": "2026-05-20T23:40:48.885186+00:00",
+     "duration": 0.004828,
+     "end_time": "2026-06-02T22:36:15.145241+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.847206+00:00",
+     "start_time": "2026-06-02T22:36:15.140413+00:00",
      "status": "completed"
     },
     "tags": []
@@ -692,20 +773,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "4062d8c2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.916971Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.916640Z",
-     "iopub.status.idle": "2026-05-20T23:40:48.926254Z",
-     "shell.execute_reply": "2026-05-20T23:40:48.925342Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.156510Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.156221Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.166625Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.165581Z"
     },
     "papermill": {
-     "duration": 0.024914,
-     "end_time": "2026-05-20T23:40:48.927244+00:00",
+     "duration": 0.017455,
+     "end_time": "2026-06-02T22:36:15.167499+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.902330+00:00",
+     "start_time": "2026-06-02T22:36:15.150044+00:00",
      "status": "completed"
     },
     "tags": []
@@ -790,10 +871,10 @@
    "id": "6baf6290",
    "metadata": {
     "papermill": {
-     "duration": 0.009604,
-     "end_time": "2026-05-20T23:40:48.941771+00:00",
+     "duration": 0.004979,
+     "end_time": "2026-06-02T22:36:15.178037+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.932167+00:00",
+     "start_time": "2026-06-02T22:36:15.173058+00:00",
      "status": "completed"
     },
     "tags": []
@@ -819,20 +900,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "e365f7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:48.973548Z",
-     "iopub.status.busy": "2026-05-20T23:40:48.972824Z",
-     "iopub.status.idle": "2026-05-20T23:40:49.095535Z",
-     "shell.execute_reply": "2026-05-20T23:40:49.095058Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.190156Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.189756Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.345896Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.344821Z"
     },
     "papermill": {
-     "duration": 0.159601,
-     "end_time": "2026-05-20T23:40:49.115047+00:00",
+     "duration": 0.163352,
+     "end_time": "2026-06-02T22:36:15.346667+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:48.955446+00:00",
+     "start_time": "2026-06-02T22:36:15.183315+00:00",
      "status": "completed"
     },
     "tags": []
@@ -888,10 +969,10 @@
    "id": "96c72b60",
    "metadata": {
     "papermill": {
-     "duration": 0.053137,
-     "end_time": "2026-05-20T23:40:49.202121+00:00",
+     "duration": 0.005572,
+     "end_time": "2026-06-02T22:36:15.358113+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.148984+00:00",
+     "start_time": "2026-06-02T22:36:15.352541+00:00",
      "status": "completed"
     },
     "tags": []
@@ -906,20 +987,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "1ef86331",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:49.292885Z",
-     "iopub.status.busy": "2026-05-20T23:40:49.291044Z",
-     "iopub.status.idle": "2026-05-20T23:40:49.366319Z",
-     "shell.execute_reply": "2026-05-20T23:40:49.356205Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.373124Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.372657Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.380075Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.379012Z"
     },
     "papermill": {
-     "duration": 0.124491,
-     "end_time": "2026-05-20T23:40:49.370772+00:00",
+     "duration": 0.015293,
+     "end_time": "2026-06-02T22:36:15.380814+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.246281+00:00",
+     "start_time": "2026-06-02T22:36:15.365521+00:00",
      "status": "completed"
     },
     "tags": []
@@ -977,10 +1058,10 @@
    "id": "3c7846aa",
    "metadata": {
     "papermill": {
-     "duration": 0.007815,
-     "end_time": "2026-05-20T23:40:49.388180+00:00",
+     "duration": 0.005384,
+     "end_time": "2026-06-02T22:36:15.391854+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.380365+00:00",
+     "start_time": "2026-06-02T22:36:15.386470+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1001,20 +1082,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "4cf40a9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:49.401827Z",
-     "iopub.status.busy": "2026-05-20T23:40:49.401506Z",
-     "iopub.status.idle": "2026-05-20T23:40:49.409093Z",
-     "shell.execute_reply": "2026-05-20T23:40:49.408166Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.404301Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.403882Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.411085Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.410323Z"
     },
     "papermill": {
-     "duration": 0.016152,
-     "end_time": "2026-05-20T23:40:49.410027+00:00",
+     "duration": 0.014727,
+     "end_time": "2026-06-02T22:36:15.411996+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.393875+00:00",
+     "start_time": "2026-06-02T22:36:15.397269+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1078,13 +1159,106 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-convex-core-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005506,
+     "end_time": "2026-06-02T22:36:15.423097+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:15.417591+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Convexite et appartenance au Core\n",
+    "\n",
+    "**Objectif** : Definir un jeu cooperatif a 3 joueurs avec une fonction caracteristique de votre choix. Tester la convexite avec `is_convex`, calculer la valeur de Shapley avec `shapley_value_exact`, puis verifier si Shapley appartient au Core avec `is_in_core`.\n",
+    "\n",
+    "**Contexte** : Pour les jeux convexes, Shapley est garanti dans le Core. Pour les jeux non convexes, ce n'est pas certain.\n",
+    "\n",
+    "# Indice : Essayer v(S) = |S| * (|S| - 1) / 2 (jeu convexe) et v(S) = 1 si |S| >= 2 (majorite, non convexe).\n",
+    "# Etape 1 : Definir deux fonctions caracteristiques (une convexe, une non convexe).\n",
+    "# Etape 2 : Tester la convexite de chacune.\n",
+    "# Etape 3 : Calculer Shapley et verifier l'appartenance au Core."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ex-convex-core-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:36:15.435595Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.435144Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.441325Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.440473Z"
+    },
+    "papermill": {
+     "duration": 0.013832,
+     "end_time": "2026-06-02T22:36:15.442205+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:15.428373+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu 1 (convexe attendu):\n",
+      "  Convexe: False\n",
+      "  Shapley: []\n",
+      "  Dans Core: False\n",
+      "\n",
+      "Jeu 2 (non convexe attendu):\n",
+      "  Convexe: False\n",
+      "  Shapley: []\n",
+      "  Dans Core: False\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_convexite_et_core() -> dict:\n",
+    "    \"\"\"\n",
+    "    Analyse convexite et Core pour deux jeux cooperatifs.\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'game1': {'convex': bool, 'shapley': list, 'in_core': bool}\n",
+    "            'game2': {'convex': bool, 'shapley': list, 'in_core': bool}\n",
+    "    \"\"\"\n",
+    "    return {\n",
+    "        \"game1\": {\"convex\": False, \"shapley\": [], \"in_core\": False},\n",
+    "        \"game2\": {\"convex\": False, \"shapley\": [], \"in_core\": False}\n",
+    "    }  # TODO etudiant\n",
+    "\n",
+    "result_cc = exercice_convexite_et_core()\n",
+    "print(\"Jeu 1 (convexe attendu):\")\n",
+    "print(f\"  Convexe: {result_cc['game1']['convex']}\")\n",
+    "print(f\"  Shapley: {result_cc['game1']['shapley']}\")\n",
+    "print(f\"  Dans Core: {result_cc['game1']['in_core']}\")\n",
+    "\n",
+    "print(\"\\nJeu 2 (non convexe attendu):\")\n",
+    "print(f\"  Convexe: {result_cc['game2']['convex']}\")\n",
+    "print(f\"  Shapley: {result_cc['game2']['shapley']}\")\n",
+    "print(f\"  Dans Core: {result_cc['game2']['in_core']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab51184f",
    "metadata": {
     "papermill": {
-     "duration": 0.004508,
-     "end_time": "2026-05-20T23:40:49.419533+00:00",
+     "duration": 0.005793,
+     "end_time": "2026-06-02T22:36:15.453815+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.415025+00:00",
+     "start_time": "2026-06-02T22:36:15.448022+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1121,10 +1295,10 @@
    "id": "89d42c89",
    "metadata": {
     "papermill": {
-     "duration": 0.005266,
-     "end_time": "2026-05-20T23:40:49.429183+00:00",
+     "duration": 0.005642,
+     "end_time": "2026-06-02T22:36:15.465438+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.423917+00:00",
+     "start_time": "2026-06-02T22:36:15.459796+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1153,20 +1327,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "83115469",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:49.441562Z",
-     "iopub.status.busy": "2026-05-20T23:40:49.441158Z",
-     "iopub.status.idle": "2026-05-20T23:40:49.448211Z",
-     "shell.execute_reply": "2026-05-20T23:40:49.447043Z"
+     "iopub.execute_input": "2026-06-02T22:36:15.478243Z",
+     "iopub.status.busy": "2026-06-02T22:36:15.477827Z",
+     "iopub.status.idle": "2026-06-02T22:36:15.483271Z",
+     "shell.execute_reply": "2026-06-02T22:36:15.482140Z"
     },
     "papermill": {
-     "duration": 0.014753,
-     "end_time": "2026-05-20T23:40:49.449236+00:00",
+     "duration": 0.013208,
+     "end_time": "2026-06-02T22:36:15.484097+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.434483+00:00",
+     "start_time": "2026-06-02T22:36:15.470889+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1211,18 +1385,35 @@
   {
    "cell_type": "markdown",
    "id": "c36229aa",
-   "source": "## Resume et perspectives\n\nCe notebook compagnon a illustre les concepts fondamentaux de la theorie des jeux cooperatifs a travers des implementations Python concretes. La valeur de Shapley, calculee exactement par enumeration des permutations, a revele le principe de rarete dans le jeu de gants ou le detenteur de la ressource complementaire rare obtient 4/6 de la valeur totale. La preuve du Core vide pour le jeu de majorite simple a 3 joueurs a montre comment la sommation des contraintes de stabilite mene a une contradiction (2 >= 3), illustrant l'instabilite coalitionnelle inhierente a ce type de jeu. Les indices de pouvoir de Shapley et Banzhaf ont ensuite demontre que le pouvoir reel peut differer significativement du poids nominal dans les jeux de vote ponderes, les non-permanents du Conseil de securite disposant d'un ratio pouvoir/poids plus eleve que les permanents.\n\nLa propriete de convexite s'est revelee determinante pour la stabilite des allocations : dans les jeux convexes (supermodulaires), la valeur de Shapley est garantie d'appartenir au Core, tandis que les jeux non convexes comme celui de la majorite ou des gants ne beneficient pas de cette garantie. Cette distinction entre \"juste\" (Shapley) et \"stable\" (Core) est au coeur de la theorie cooperative, et les exercices proposes permettent d'approfondir ces concepts sur des applications concretes (aeroport, fusion d'entreprises, jeux politiques).\n\nLes concepts de valeur de Shapley, de Core et d'indices de pouvoir trouvent des applications directes en economie (repartition des couts), en sciences politiques (analyse du pouvoir de vote) et en intelligence artificielle (explicabilite des modeles via les valeurs de Shapley en ML). Le passage a l'echelle vers des jeux a un grand nombre de joueurs necessite des methodes d'approximation Monte Carlo de la valeur de Shapley, constituant un domaine de recherche actif.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005629,
+     "end_time": "2026-06-02T22:36:15.495339+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:15.489710+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook compagnon a illustre les concepts fondamentaux de la theorie des jeux cooperatifs a travers des implementations Python concretes. La valeur de Shapley, calculee exactement par enumeration des permutations, a revele le principe de rarete dans le jeu de gants ou le detenteur de la ressource complementaire rare obtient 4/6 de la valeur totale. La preuve du Core vide pour le jeu de majorite simple a 3 joueurs a montre comment la sommation des contraintes de stabilite mene a une contradiction (2 >= 3), illustrant l'instabilite coalitionnelle inhierente a ce type de jeu. Les indices de pouvoir de Shapley et Banzhaf ont ensuite demontre que le pouvoir reel peut differer significativement du poids nominal dans les jeux de vote ponderes, les non-permanents du Conseil de securite disposant d'un ratio pouvoir/poids plus eleve que les permanents.\n",
+    "\n",
+    "La propriete de convexite s'est revelee determinante pour la stabilite des allocations : dans les jeux convexes (supermodulaires), la valeur de Shapley est garantie d'appartenir au Core, tandis que les jeux non convexes comme celui de la majorite ou des gants ne beneficient pas de cette garantie. Cette distinction entre \"juste\" (Shapley) et \"stable\" (Core) est au coeur de la theorie cooperative, et les exercices proposes permettent d'approfondir ces concepts sur des applications concretes (aeroport, fusion d'entreprises, jeux politiques).\n",
+    "\n",
+    "Les concepts de valeur de Shapley, de Core et d'indices de pouvoir trouvent des applications directes en economie (repartition des couts), en sciences politiques (analyse du pouvoir de vote) et en intelligence artificielle (explicabilite des modeles via les valeurs de Shapley en ML). Le passage a l'echelle vers des jeux a un grand nombre de joueurs necessite des methodes d'approximation Monte Carlo de la valeur de Shapley, constituant un domaine de recherche actif."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "43bdd0a8",
    "metadata": {
     "papermill": {
-     "duration": 0.011501,
-     "end_time": "2026-05-20T23:40:49.466645+00:00",
+     "duration": 0.005791,
+     "end_time": "2026-06-02T22:36:15.507425+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:49.455144+00:00",
+     "start_time": "2026-06-02T22:36:15.501634+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1251,18 +1442,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.727501,
-   "end_time": "2026-05-20T23:40:49.841843+00:00",
+   "duration": 5.44844,
+   "end_time": "2026-06-02T22:36:16.520833+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15c-CooperativeGames-Python.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-15c-CooperativeGames-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T23:40:46.114342+00:00",
+   "start_time": "2026-06-02T22:36:11.072393+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -5,10 +5,10 @@
    "id": "d456d803",
    "metadata": {
     "papermill": {
-     "duration": 0.004619,
-     "end_time": "2026-05-21T00:52:57.673294+00:00",
+     "duration": 0.006621,
+     "end_time": "2026-06-02T22:35:26.583690+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:52:57.668675+00:00",
+     "start_time": "2026-06-02T22:35:26.577069+00:00",
      "status": "completed"
     },
     "tags": []
@@ -51,16 +51,16 @@
    "id": "74d1cafc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:52:57.681591Z",
-     "iopub.status.busy": "2026-05-21T00:52:57.681335Z",
-     "iopub.status.idle": "2026-05-21T00:53:09.710568Z",
-     "shell.execute_reply": "2026-05-21T00:53:09.707016Z"
+     "iopub.execute_input": "2026-06-02T22:35:26.596232Z",
+     "iopub.status.busy": "2026-06-02T22:35:26.595817Z",
+     "iopub.status.idle": "2026-06-02T22:35:31.849493Z",
+     "shell.execute_reply": "2026-06-02T22:35:31.848507Z"
     },
     "papermill": {
-     "duration": 12.036279,
-     "end_time": "2026-05-21T00:53:09.714487+00:00",
+     "duration": 5.261075,
+     "end_time": "2026-06-02T22:35:31.850820+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:52:57.678208+00:00",
+     "start_time": "2026-06-02T22:35:26.589745+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,10 +91,10 @@
    "id": "95f96fe5",
    "metadata": {
     "papermill": {
-     "duration": 0.011276,
-     "end_time": "2026-05-21T00:53:09.742842+00:00",
+     "duration": 0.004506,
+     "end_time": "2026-06-02T22:35:31.859868+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.731566+00:00",
+     "start_time": "2026-06-02T22:35:31.855362+00:00",
      "status": "completed"
     },
     "tags": []
@@ -124,16 +124,16 @@
    "id": "aba0b712",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:09.756764Z",
-     "iopub.status.busy": "2026-05-21T00:53:09.756378Z",
-     "iopub.status.idle": "2026-05-21T00:53:09.771273Z",
-     "shell.execute_reply": "2026-05-21T00:53:09.769878Z"
+     "iopub.execute_input": "2026-06-02T22:35:31.870302Z",
+     "iopub.status.busy": "2026-06-02T22:35:31.869740Z",
+     "iopub.status.idle": "2026-06-02T22:35:31.880730Z",
+     "shell.execute_reply": "2026-06-02T22:35:31.879700Z"
     },
     "papermill": {
-     "duration": 0.022898,
-     "end_time": "2026-05-21T00:53:09.772799+00:00",
+     "duration": 0.017825,
+     "end_time": "2026-06-02T22:35:31.881708+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.749901+00:00",
+     "start_time": "2026-06-02T22:35:31.863883+00:00",
      "status": "completed"
     },
     "tags": []
@@ -214,10 +214,10 @@
    "id": "1ef44828",
    "metadata": {
     "papermill": {
-     "duration": 0.003814,
-     "end_time": "2026-05-21T00:53:09.781706+00:00",
+     "duration": 0.00428,
+     "end_time": "2026-06-02T22:35:31.891103+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.777892+00:00",
+     "start_time": "2026-06-02T22:35:31.886823+00:00",
      "status": "completed"
     },
     "tags": []
@@ -236,16 +236,16 @@
    "id": "d2e3fd16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:09.793679Z",
-     "iopub.status.busy": "2026-05-21T00:53:09.793433Z",
-     "iopub.status.idle": "2026-05-21T00:53:09.802360Z",
-     "shell.execute_reply": "2026-05-21T00:53:09.801215Z"
+     "iopub.execute_input": "2026-06-02T22:35:31.900220Z",
+     "iopub.status.busy": "2026-06-02T22:35:31.899878Z",
+     "iopub.status.idle": "2026-06-02T22:35:31.908033Z",
+     "shell.execute_reply": "2026-06-02T22:35:31.907063Z"
     },
     "papermill": {
-     "duration": 0.014604,
-     "end_time": "2026-05-21T00:53:09.803075+00:00",
+     "duration": 0.013919,
+     "end_time": "2026-06-02T22:35:31.908897+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.788471+00:00",
+     "start_time": "2026-06-02T22:35:31.894978+00:00",
      "status": "completed"
     },
     "tags": []
@@ -348,10 +348,10 @@
    "id": "6425c9f0",
    "metadata": {
     "papermill": {
-     "duration": 0.003365,
-     "end_time": "2026-05-21T00:53:09.810411+00:00",
+     "duration": 0.003909,
+     "end_time": "2026-06-02T22:35:31.916894+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.807046+00:00",
+     "start_time": "2026-06-02T22:35:31.912985+00:00",
      "status": "completed"
     },
     "tags": []
@@ -379,13 +379,105 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-dominance-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003845,
+     "end_time": "2026-06-02T22:35:31.924945+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:31.921100+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Elimination iterative des strategies dominees\n",
+    "\n",
+    "**Objectif** : Implementer l'elimination iterative des strategies strictement dominees pour un jeu 2x2, puis verifier que les strategies survivantes correspondent aux equilibres de Nash purs trouves par `find_pure_nash`.\n",
+    "\n",
+    "**Contexte** : Dans le Dilemme du Prisonnier, Defaire domine Cooperer. Apres elimination, il ne reste qu'un seul profil : (D,D), qui est l'equilibre de Nash.\n",
+    "\n",
+    "# Indice : Pour chaque joueur, comparer les gains de chaque action contre toutes les actions de l'adversaire.\n",
+    "# Etape 1 : Identifier les strategies strictement dominees pour chaque joueur.\n",
+    "# Etape 2 : Les eliminer et verifier si de nouvelles dominations apparaissent.\n",
+    "# Etape 3 : Comparer les strategies survivantes avec les equilibres de Nash."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ex-dominance-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:35:31.934487Z",
+     "iopub.status.busy": "2026-06-02T22:35:31.934078Z",
+     "iopub.status.idle": "2026-06-02T22:35:31.940696Z",
+     "shell.execute_reply": "2026-06-02T22:35:31.939561Z"
+    },
+    "papermill": {
+     "duration": 0.012861,
+     "end_time": "2026-06-02T22:35:31.941576+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:31.928715+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PD - Survivants Row: [], Col: []\n",
+      "PD - Profils survivants: []\n",
+      "\n",
+      "Stag Hunt - Survivants Row: [], Col: []\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_dominance_iteree(A: np.ndarray, B: np.ndarray) -> dict:\n",
+    "    \"\"\"\n",
+    "    Elimination iterative des strategies strictement dominees.\n",
+    "    \n",
+    "    Args:\n",
+    "        A: matrice des gains du joueur Row (m x n)\n",
+    "        B: matrice des gains du joueur Col (m x n)\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'surviving_row': liste des indices de lignes survivantes\n",
+    "            'surviving_col': liste des indices de colonnes survivantes\n",
+    "            'nash_profiles': liste des profils (i,j) survivants\n",
+    "    \"\"\"\n",
+    "    return {\"surviving_row\": [], \"surviving_col\": [], \"nash_profiles\": []}  # TODO etudiant\n",
+    "\n",
+    "# Test : Dilemme du Prisonnier\n",
+    "A_pd = np.array([[3, 0], [5, 1]])\n",
+    "B_pd = np.array([[3, 5], [0, 1]])\n",
+    "result_pd = exercice_dominance_iteree(A_pd, B_pd)\n",
+    "print(f\"PD - Survivants Row: {result_pd['surviving_row']}, Col: {result_pd['surviving_col']}\")\n",
+    "print(f\"PD - Profils survivants: {result_pd['nash_profiles']}\")\n",
+    "\n",
+    "# Test : Stag Hunt (pas de domination)\n",
+    "A_sh = np.array([[4, 0], [3, 3]])\n",
+    "B_sh = np.array([[4, 3], [0, 3]])\n",
+    "result_sh = exercice_dominance_iteree(A_sh, B_sh)\n",
+    "print(f\"\\nStag Hunt - Survivants Row: {result_sh['surviving_row']}, Col: {result_sh['surviving_col']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "66997a2b",
    "metadata": {
     "papermill": {
-     "duration": 0.00374,
-     "end_time": "2026-05-21T00:53:09.817673+00:00",
+     "duration": 0.004317,
+     "end_time": "2026-06-02T22:35:31.950077+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.813933+00:00",
+     "start_time": "2026-06-02T22:35:31.945760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -409,20 +501,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "bbef352e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:09.825890Z",
-     "iopub.status.busy": "2026-05-21T00:53:09.825672Z",
-     "iopub.status.idle": "2026-05-21T00:53:10.913601Z",
-     "shell.execute_reply": "2026-05-21T00:53:10.912439Z"
+     "iopub.execute_input": "2026-06-02T22:35:31.959192Z",
+     "iopub.status.busy": "2026-06-02T22:35:31.958811Z",
+     "iopub.status.idle": "2026-06-02T22:35:32.381983Z",
+     "shell.execute_reply": "2026-06-02T22:35:32.381065Z"
     },
     "papermill": {
-     "duration": 1.093352,
-     "end_time": "2026-05-21T00:53:10.914503+00:00",
+     "duration": 0.428812,
+     "end_time": "2026-06-02T22:35:32.382687+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:09.821151+00:00",
+     "start_time": "2026-06-02T22:35:31.953875+00:00",
      "status": "completed"
     },
     "tags": []
@@ -493,10 +585,10 @@
    "id": "161d0adc",
    "metadata": {
     "papermill": {
-     "duration": 0.004811,
-     "end_time": "2026-05-21T00:53:10.924855+00:00",
+     "duration": 0.004276,
+     "end_time": "2026-06-02T22:35:32.392012+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:10.920044+00:00",
+     "start_time": "2026-06-02T22:35:32.387736+00:00",
      "status": "completed"
     },
     "tags": []
@@ -517,20 +609,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "46a4b947",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:10.935686Z",
-     "iopub.status.busy": "2026-05-21T00:53:10.935438Z",
-     "iopub.status.idle": "2026-05-21T00:53:10.944584Z",
-     "shell.execute_reply": "2026-05-21T00:53:10.943887Z"
+     "iopub.execute_input": "2026-06-02T22:35:32.402148Z",
+     "iopub.status.busy": "2026-06-02T22:35:32.401787Z",
+     "iopub.status.idle": "2026-06-02T22:35:32.409353Z",
+     "shell.execute_reply": "2026-06-02T22:35:32.408580Z"
     },
     "papermill": {
-     "duration": 0.015645,
-     "end_time": "2026-05-21T00:53:10.945119+00:00",
+     "duration": 0.013652,
+     "end_time": "2026-06-02T22:35:32.409996+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:10.929474+00:00",
+     "start_time": "2026-06-02T22:35:32.396344+00:00",
      "status": "completed"
     },
     "tags": []
@@ -609,10 +701,10 @@
    "id": "6c7d7d0d",
    "metadata": {
     "papermill": {
-     "duration": 0.003245,
-     "end_time": "2026-05-21T00:53:10.951111+00:00",
+     "duration": 0.004261,
+     "end_time": "2026-06-02T22:35:32.418651+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:10.947866+00:00",
+     "start_time": "2026-06-02T22:35:32.414390+00:00",
      "status": "completed"
     },
     "tags": []
@@ -641,20 +733,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "10709513",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:10.959336Z",
-     "iopub.status.busy": "2026-05-21T00:53:10.959184Z",
-     "iopub.status.idle": "2026-05-21T00:53:10.971566Z",
-     "shell.execute_reply": "2026-05-21T00:53:10.967886Z"
+     "iopub.execute_input": "2026-06-02T22:35:32.428731Z",
+     "iopub.status.busy": "2026-06-02T22:35:32.428422Z",
+     "iopub.status.idle": "2026-06-02T22:35:32.435457Z",
+     "shell.execute_reply": "2026-06-02T22:35:32.434686Z"
     },
     "papermill": {
-     "duration": 0.017529,
-     "end_time": "2026-05-21T00:53:10.973457+00:00",
+     "duration": 0.013105,
+     "end_time": "2026-06-02T22:35:32.436059+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:10.955928+00:00",
+     "start_time": "2026-06-02T22:35:32.422954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -768,10 +860,10 @@
    "id": "e965f0d9",
    "metadata": {
     "papermill": {
-     "duration": 0.025286,
-     "end_time": "2026-05-21T00:53:11.014005+00:00",
+     "duration": 0.004143,
+     "end_time": "2026-06-02T22:35:32.444548+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:10.988719+00:00",
+     "start_time": "2026-06-02T22:35:32.440405+00:00",
      "status": "completed"
     },
     "tags": []
@@ -808,10 +900,10 @@
    "id": "70a146f5",
    "metadata": {
     "papermill": {
-     "duration": 0.00723,
-     "end_time": "2026-05-21T00:53:11.030912+00:00",
+     "duration": 0.004202,
+     "end_time": "2026-06-02T22:35:32.452965+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:11.023682+00:00",
+     "start_time": "2026-06-02T22:35:32.448763+00:00",
      "status": "completed"
     },
     "tags": []
@@ -824,20 +916,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "67430632",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:11.047241Z",
-     "iopub.status.busy": "2026-05-21T00:53:11.046966Z",
-     "iopub.status.idle": "2026-05-21T00:53:11.094721Z",
-     "shell.execute_reply": "2026-05-21T00:53:11.093769Z"
+     "iopub.execute_input": "2026-06-02T22:35:32.462795Z",
+     "iopub.status.busy": "2026-06-02T22:35:32.462450Z",
+     "iopub.status.idle": "2026-06-02T22:35:32.512243Z",
+     "shell.execute_reply": "2026-06-02T22:35:32.511535Z"
     },
     "papermill": {
-     "duration": 0.056083,
-     "end_time": "2026-05-21T00:53:11.095968+00:00",
+     "duration": 0.056213,
+     "end_time": "2026-06-02T22:35:32.513347+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:11.039885+00:00",
+     "start_time": "2026-06-02T22:35:32.457134+00:00",
      "status": "completed"
     },
     "tags": []
@@ -914,10 +1006,10 @@
    "id": "9844b8d4",
    "metadata": {
     "papermill": {
-     "duration": 0.006093,
-     "end_time": "2026-05-21T00:53:11.108655+00:00",
+     "duration": 0.004432,
+     "end_time": "2026-06-02T22:35:32.522550+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:11.102562+00:00",
+     "start_time": "2026-06-02T22:35:32.518118+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,20 +1022,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "326b9261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:11.119891Z",
-     "iopub.status.busy": "2026-05-21T00:53:11.119628Z",
-     "iopub.status.idle": "2026-05-21T00:53:12.054905Z",
-     "shell.execute_reply": "2026-05-21T00:53:12.052815Z"
+     "iopub.execute_input": "2026-06-02T22:35:32.533190Z",
+     "iopub.status.busy": "2026-06-02T22:35:32.532936Z",
+     "iopub.status.idle": "2026-06-02T22:35:32.856998Z",
+     "shell.execute_reply": "2026-06-02T22:35:32.855838Z"
     },
     "papermill": {
-     "duration": 0.943634,
-     "end_time": "2026-05-21T00:53:12.057127+00:00",
+     "duration": 0.330829,
+     "end_time": "2026-06-02T22:35:32.857988+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:11.113493+00:00",
+     "start_time": "2026-06-02T22:35:32.527159+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1040,10 +1132,10 @@
    "id": "9e3ec9bc",
    "metadata": {
     "papermill": {
-     "duration": 0.011845,
-     "end_time": "2026-05-21T00:53:12.078916+00:00",
+     "duration": 0.00533,
+     "end_time": "2026-06-02T22:35:32.869160+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:12.067071+00:00",
+     "start_time": "2026-06-02T22:35:32.863830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1068,20 +1160,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1ed024cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:12.099154Z",
-     "iopub.status.busy": "2026-05-21T00:53:12.098889Z",
-     "iopub.status.idle": "2026-05-21T00:53:14.119422Z",
-     "shell.execute_reply": "2026-05-21T00:53:14.114557Z"
+     "iopub.execute_input": "2026-06-02T22:35:32.881445Z",
+     "iopub.status.busy": "2026-06-02T22:35:32.881050Z",
+     "iopub.status.idle": "2026-06-02T22:35:33.180721Z",
+     "shell.execute_reply": "2026-06-02T22:35:33.179795Z"
     },
     "papermill": {
-     "duration": 2.03498,
-     "end_time": "2026-05-21T00:53:14.123615+00:00",
+     "duration": 0.306836,
+     "end_time": "2026-06-02T22:35:33.181444+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:12.088635+00:00",
+     "start_time": "2026-06-02T22:35:32.874608+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1169,10 +1261,10 @@
    "id": "2fedfc68",
    "metadata": {
     "papermill": {
-     "duration": 0.027452,
-     "end_time": "2026-05-21T00:53:14.182218+00:00",
+     "duration": 0.005309,
+     "end_time": "2026-06-02T22:35:33.192502+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.154766+00:00",
+     "start_time": "2026-06-02T22:35:33.187193+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1204,10 +1296,10 @@
    "id": "060a0b74",
    "metadata": {
     "papermill": {
-     "duration": 0.022549,
-     "end_time": "2026-05-21T00:53:14.227629+00:00",
+     "duration": 0.004959,
+     "end_time": "2026-06-02T22:35:33.202851+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.205080+00:00",
+     "start_time": "2026-06-02T22:35:33.197892+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1220,20 +1312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "9684efae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:14.249464Z",
-     "iopub.status.busy": "2026-05-21T00:53:14.248955Z",
-     "iopub.status.idle": "2026-05-21T00:53:14.275641Z",
-     "shell.execute_reply": "2026-05-21T00:53:14.267094Z"
+     "iopub.execute_input": "2026-06-02T22:35:33.214120Z",
+     "iopub.status.busy": "2026-06-02T22:35:33.213743Z",
+     "iopub.status.idle": "2026-06-02T22:35:33.223991Z",
+     "shell.execute_reply": "2026-06-02T22:35:33.223320Z"
     },
     "papermill": {
-     "duration": 0.041074,
-     "end_time": "2026-05-21T00:53:14.277126+00:00",
+     "duration": 0.017108,
+     "end_time": "2026-06-02T22:35:33.224829+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.236052+00:00",
+     "start_time": "2026-06-02T22:35:33.207721+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1289,10 +1381,10 @@
    "id": "794b553a",
    "metadata": {
     "papermill": {
-     "duration": 0.008531,
-     "end_time": "2026-05-21T00:53:14.294443+00:00",
+     "duration": 0.005141,
+     "end_time": "2026-06-02T22:35:33.235245+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.285912+00:00",
+     "start_time": "2026-06-02T22:35:33.230104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1314,21 +1406,105 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ex-rps-biased-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005028,
+     "end_time": "2026-06-02T22:35:33.245271+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:33.240243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Pierre-Feuille-Ciseaux biaise\n",
+    "\n",
+    "**Objectif** : Construire un jeu Pierre-Feuille-Ciseaux biaise ou gagner avec Pierre rapporte 2 au lieu de 1. Calculer l'equilibre mixte via `nash.Game(...).support_enumeration()` et verifier que la distribution n'est plus uniforme.\n",
+    "\n",
+    "**Contexte** : L'exemple ci-dessus montre que le RPS standard a un equilibre uniforme (1/3, 1/3, 1/3). Que se passe-t-il si on desequilibre les gains ?\n",
+    "\n",
+    "# Indice : Modifier la matrice A_rps pour que la ligne Pierre (index 0) batte Ciseaux avec gain 2 au lieu de 1.\n",
+    "# Etape 1 : Construire la matrice biaisee A_biased.\n",
+    "# Etape 2 : Calculer les equilibres avec support_enumeration.\n",
+    "# Etape 3 : Verifier que les probabilites different de 1/3."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
+   "id": "ex-rps-biased-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:35:33.256569Z",
+     "iopub.status.busy": "2026-06-02T22:35:33.256191Z",
+     "iopub.status.idle": "2026-06-02T22:35:33.261461Z",
+     "shell.execute_reply": "2026-06-02T22:35:33.260454Z"
+    },
+    "papermill": {
+     "duration": 0.012074,
+     "end_time": "2026-06-02T22:35:33.262245+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:33.250171+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Matrice biaisee:\n",
+      "None\n",
+      "\n",
+      "Sigma Row: None\n",
+      "Sigma Col: None\n",
+      "Uniforme ? True\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_nash_3x3_rps_biaise() -> dict:\n",
+    "    \"\"\"\n",
+    "    Construit un RPS biaise (gain Pierre=2) et calcule l'equilibre mixte.\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'A_biased': la matrice biaisee\n",
+    "            'sigma_row': strategie mixte de Row\n",
+    "            'sigma_col': strategie mixte de Col\n",
+    "            'is_uniform': True si (1/3, 1/3, 1/3), False sinon\n",
+    "    \"\"\"\n",
+    "    return {\"A_biased\": None, \"sigma_row\": None, \"sigma_col\": None, \"is_uniform\": True}  # TODO etudiant\n",
+    "\n",
+    "result_rps = exercice_nash_3x3_rps_biaise()\n",
+    "print(f\"Matrice biaisee:\\n{result_rps['A_biased']}\")\n",
+    "print(f\"\\nSigma Row: {result_rps['sigma_row']}\")\n",
+    "print(f\"Sigma Col: {result_rps['sigma_col']}\")\n",
+    "print(f\"Uniforme ? {result_rps['is_uniform']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "93804d35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:14.315240Z",
-     "iopub.status.busy": "2026-05-21T00:53:14.314774Z",
-     "iopub.status.idle": "2026-05-21T00:53:14.343932Z",
-     "shell.execute_reply": "2026-05-21T00:53:14.341542Z"
+     "iopub.execute_input": "2026-06-02T22:35:33.274005Z",
+     "iopub.status.busy": "2026-06-02T22:35:33.273700Z",
+     "iopub.status.idle": "2026-06-02T22:35:33.282442Z",
+     "shell.execute_reply": "2026-06-02T22:35:33.281664Z"
     },
     "papermill": {
-     "duration": 0.042073,
-     "end_time": "2026-05-21T00:53:14.345955+00:00",
+     "duration": 0.015594,
+     "end_time": "2026-06-02T22:35:33.283079+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.303882+00:00",
+     "start_time": "2026-06-02T22:35:33.267485+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1403,10 +1579,10 @@
    "id": "876d04be",
    "metadata": {
     "papermill": {
-     "duration": 0.024156,
-     "end_time": "2026-05-21T00:53:14.383150+00:00",
+     "duration": 0.005054,
+     "end_time": "2026-06-02T22:35:33.293448+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.358994+00:00",
+     "start_time": "2026-06-02T22:35:33.288394+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1444,10 +1620,10 @@
    "id": "55e85a35",
    "metadata": {
     "papermill": {
-     "duration": 0.012881,
-     "end_time": "2026-05-21T00:53:14.445652+00:00",
+     "duration": 0.005164,
+     "end_time": "2026-06-02T22:35:33.303737+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.432771+00:00",
+     "start_time": "2026-06-02T22:35:33.298573+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1467,20 +1643,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "0d74b671",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-21T00:53:14.493380Z",
-     "iopub.status.busy": "2026-05-21T00:53:14.491469Z",
-     "iopub.status.idle": "2026-05-21T00:53:14.536205Z",
-     "shell.execute_reply": "2026-05-21T00:53:14.527680Z"
+     "iopub.execute_input": "2026-06-02T22:35:33.315714Z",
+     "iopub.status.busy": "2026-06-02T22:35:33.315401Z",
+     "iopub.status.idle": "2026-06-02T22:35:33.319689Z",
+     "shell.execute_reply": "2026-06-02T22:35:33.318914Z"
     },
     "papermill": {
-     "duration": 0.073868,
-     "end_time": "2026-05-21T00:53:14.542089+00:00",
+     "duration": 0.011121,
+     "end_time": "2026-06-02T22:35:33.320344+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.468221+00:00",
+     "start_time": "2026-06-02T22:35:33.309223+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1521,18 +1697,35 @@
   {
    "cell_type": "markdown",
    "id": "b1c24332",
-   "source": "## Resume et perspectives\n\nCe notebook a explore en profondeur les equilibres de Nash, concept central de la theorie des jeux introduit par John Nash en 1950. Nous avons distingue les equilibres purs (action deterministe) des equilibres mixtes (randomisation optimale), et implemente les algorithmes de Support Enumeration, Lemke-Howson et Vertex Enumeration via Nashpy. La condition d'indifference -- a l'equilibre mixte, un joueur doit etre indifferent entre toutes les actions jouees avec probabilite positive -- a permis le calcul analytique des equilibres pour les jeux 2x2. L'analyse parametrique a mis en evidence les transitions de phase entre types de jeux (Harmony, Dilemme, Coordination) et montre comment un petit changement d'incitation peut transformer radicalement la structure des equilibres.\n\nUn point crucial est la multiplicite des equilibres dans de nombreux jeux (Stag Hunt, Battle of Sexes), qui pose le probleme de la selection : comment les joueurs se coordonnent-ils ? Les reponses -- points focaux de Schelling, communication, histoire des interactions -- motivent l'etude des jeux sous forme extensive et de l'evolution des strategies dans les notebooks suivants.\n\nLe notebook suivant, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), se concentre sur une classe particulierement structuree : les jeux a somme nulle, ou le theoreme minimax de Von Neumann garantit l'existence d'une valeur unique du jeu et d'equilibres calculables par programmation lineaire.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005096,
+     "end_time": "2026-06-02T22:35:33.330691+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:33.325595+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a explore en profondeur les equilibres de Nash, concept central de la theorie des jeux introduit par John Nash en 1950. Nous avons distingue les equilibres purs (action deterministe) des equilibres mixtes (randomisation optimale), et implemente les algorithmes de Support Enumeration, Lemke-Howson et Vertex Enumeration via Nashpy. La condition d'indifference -- a l'equilibre mixte, un joueur doit etre indifferent entre toutes les actions jouees avec probabilite positive -- a permis le calcul analytique des equilibres pour les jeux 2x2. L'analyse parametrique a mis en evidence les transitions de phase entre types de jeux (Harmony, Dilemme, Coordination) et montre comment un petit changement d'incitation peut transformer radicalement la structure des equilibres.\n",
+    "\n",
+    "Un point crucial est la multiplicite des equilibres dans de nombreux jeux (Stag Hunt, Battle of Sexes), qui pose le probleme de la selection : comment les joueurs se coordonnent-ils ? Les reponses -- points focaux de Schelling, communication, histoire des interactions -- motivent l'etude des jeux sous forme extensive et de l'evolution des strategies dans les notebooks suivants.\n",
+    "\n",
+    "Le notebook suivant, [GameTheory-5-ZeroSum-Minimax](GameTheory-5-ZeroSum-Minimax.ipynb), se concentre sur une classe particulierement structuree : les jeux a somme nulle, ou le theoreme minimax de Von Neumann garantit l'existence d'une valeur unique du jeu et d'equilibres calculables par programmation lineaire."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "237a5982",
    "metadata": {
     "papermill": {
-     "duration": 0.042596,
-     "end_time": "2026-05-21T00:53:14.600410+00:00",
+     "duration": 0.005105,
+     "end_time": "2026-06-02T22:35:33.340935+00:00",
      "exception": false,
-     "start_time": "2026-05-21T00:53:14.557814+00:00",
+     "start_time": "2026-06-02T22:35:33.335830+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1561,18 +1754,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 19.090645,
-   "end_time": "2026-05-21T00:53:15.377855+00:00",
+   "duration": 10.959768,
+   "end_time": "2026-06-02T22:35:34.136414+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb",
-   "output_path": "C:/Users/jsboi/AppData/Local/Temp/gt4_out.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4-NashEquilibrium.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-4-NashEquilibrium_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-21T00:52:56.287210+00:00",
+   "start_time": "2026-06-02T22:35:23.176646+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb
@@ -5,10 +5,10 @@
    "id": "309e9b77",
    "metadata": {
     "papermill": {
-     "duration": 0.015188,
-     "end_time": "2026-05-20T23:40:40.702182+00:00",
+     "duration": 0.004854,
+     "end_time": "2026-06-02T22:35:45.350188+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:40.686994+00:00",
+     "start_time": "2026-06-02T22:35:45.345334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -76,16 +76,16 @@
    "id": "64f3b476",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:40.737472Z",
-     "iopub.status.busy": "2026-05-20T23:40:40.736372Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.140466Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.139702Z"
+     "iopub.execute_input": "2026-06-02T22:35:45.361193Z",
+     "iopub.status.busy": "2026-06-02T22:35:45.360887Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.214528Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.212958Z"
     },
     "papermill": {
-     "duration": 0.423724,
-     "end_time": "2026-05-20T23:40:41.141006+00:00",
+     "duration": 1.860696,
+     "end_time": "2026-06-02T22:35:47.216263+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:40.717282+00:00",
+     "start_time": "2026-06-02T22:35:45.355567+00:00",
      "status": "completed"
     },
     "tags": []
@@ -114,10 +114,10 @@
    "id": "104def24",
    "metadata": {
     "papermill": {
-     "duration": 0.001675,
-     "end_time": "2026-05-20T23:40:41.145017+00:00",
+     "duration": 0.00583,
+     "end_time": "2026-06-02T22:35:47.228748+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.143342+00:00",
+     "start_time": "2026-06-02T22:35:47.222918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -149,16 +149,16 @@
    "id": "cca06d83",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.149257Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.149022Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.153516Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.152815Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.242470Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.241843Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.251599Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.250287Z"
     },
     "papermill": {
-     "duration": 0.007459,
-     "end_time": "2026-05-20T23:40:41.154063+00:00",
+     "duration": 0.017927,
+     "end_time": "2026-06-02T22:35:47.252628+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.146604+00:00",
+     "start_time": "2026-06-02T22:35:47.234701+00:00",
      "status": "completed"
     },
     "tags": []
@@ -226,13 +226,103 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-pn-classify-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005073,
+     "end_time": "2026-06-02T22:35:47.265138+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:47.260065+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Classification P/N avec ensemble de soustraction arbitraire\n",
+    "\n",
+    "**Objectif** : Generaliser `classify_123_game` a un ensemble de soustraction arbitraire (par exemple S({1,3}) ou le joueur peut retirer 1 ou 3 jetons). Identifier les P-positions et determiner la periodicite.\n",
+    "\n",
+    "**Contexte** : La classification 1-2-3 montre une periodicite de 4. Avec S({1,3}), la structure change.\n",
+    "\n",
+    "# Indice : Adapter classify_123_game en remplacant [1,2,3] par un ensemble parametrable.\n",
+    "# Etape 1 : Implementer classify_game(n_max, moves).\n",
+    "# Etape 2 : Identifier le motif des P-positions.\n",
+    "# Etape 3 : Calculer la periode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ex-pn-classify-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:35:47.278202Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.277683Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.285712Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.284476Z"
+    },
+    "papermill": {
+     "duration": 0.01685,
+     "end_time": "2026-06-02T22:35:47.286961+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:47.270111+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P-positions S({1,3}): []\n",
+      "Periode: None\n",
+      "\n",
+      "P-positions S({2,5}): []\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_classification_pn(n_max: int = 20, moves: set = None) -> dict:\n",
+    "    \"\"\"\n",
+    "    Classifie les positions P/N pour un jeu de soustraction arbitraire.\n",
+    "    \n",
+    "    Args:\n",
+    "        n_max: taille maximale a analyser\n",
+    "        moves: ensemble des coups autorises (defaut: {1, 3})\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'positions': dict {n: 'P' ou 'N'}\n",
+    "            'p_positions': liste des positions perdantes\n",
+    "            'period': periode detectee (ou None)\n",
+    "    \"\"\"\n",
+    "    if moves is None:\n",
+    "        moves = {1, 3}\n",
+    "    return {\"positions\": {}, \"p_positions\": [], \"period\": None}  # TODO etudiant\n",
+    "\n",
+    "# Test : S({1,3})\n",
+    "result_pn = exercice_classification_pn(20, {1, 3})\n",
+    "print(f\"P-positions S({{1,3}}): {result_pn['p_positions']}\")\n",
+    "print(f\"Periode: {result_pn['period']}\")\n",
+    "\n",
+    "# Test : S({2,5})\n",
+    "result_pn2 = exercice_classification_pn(20, {2, 5})\n",
+    "print(f\"\\nP-positions S({{2,5}}): {result_pn2['p_positions']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "44637721",
    "metadata": {
     "papermill": {
-     "duration": 0.001738,
-     "end_time": "2026-05-20T23:40:41.157897+00:00",
+     "duration": 0.005223,
+     "end_time": "2026-06-02T22:35:47.298474+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.156159+00:00",
+     "start_time": "2026-06-02T22:35:47.293251+00:00",
      "status": "completed"
     },
     "tags": []
@@ -259,20 +349,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "376cfa99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.162816Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.162492Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.166685Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.166075Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.310666Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.310147Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.318799Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.317519Z"
     },
     "papermill": {
-     "duration": 0.007335,
-     "end_time": "2026-05-20T23:40:41.167166+00:00",
+     "duration": 0.016318,
+     "end_time": "2026-06-02T22:35:47.319940+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.159831+00:00",
+     "start_time": "2026-06-02T22:35:47.303622+00:00",
      "status": "completed"
     },
     "tags": []
@@ -326,10 +416,10 @@
    "id": "8b993aef",
    "metadata": {
     "papermill": {
-     "duration": 0.002361,
-     "end_time": "2026-05-20T23:40:41.176579+00:00",
+     "duration": 0.005361,
+     "end_time": "2026-06-02T22:35:47.331073+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.174218+00:00",
+     "start_time": "2026-06-02T22:35:47.325712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -342,20 +432,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3d8a4421",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.181389Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.181220Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.186152Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.185234Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.348480Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.347993Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.356379Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.355083Z"
     },
     "papermill": {
-     "duration": 0.008677,
-     "end_time": "2026-05-20T23:40:41.187149+00:00",
+     "duration": 0.021026,
+     "end_time": "2026-06-02T22:35:47.357418+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.178472+00:00",
+     "start_time": "2026-06-02T22:35:47.336392+00:00",
      "status": "completed"
     },
     "tags": []
@@ -412,10 +502,10 @@
    "id": "ed6eb8a0",
    "metadata": {
     "papermill": {
-     "duration": 0.002245,
-     "end_time": "2026-05-20T23:40:41.192440+00:00",
+     "duration": 0.004367,
+     "end_time": "2026-06-02T22:35:47.366783+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.190195+00:00",
+     "start_time": "2026-06-02T22:35:47.362416+00:00",
      "status": "completed"
     },
     "tags": []
@@ -432,20 +522,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "1ef1f943",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.197616Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.197437Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.201106Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.200594Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.449835Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.449416Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.461811Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.460702Z"
     },
     "papermill": {
-     "duration": 0.006888,
-     "end_time": "2026-05-20T23:40:41.201604+00:00",
+     "duration": 0.039565,
+     "end_time": "2026-06-02T22:35:47.473939+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.194716+00:00",
+     "start_time": "2026-06-02T22:35:47.434374+00:00",
      "status": "completed"
     },
     "tags": []
@@ -489,10 +579,10 @@
    "id": "52956bb3",
    "metadata": {
     "papermill": {
-     "duration": 0.002175,
-     "end_time": "2026-05-20T23:40:41.205648+00:00",
+     "duration": 0.005898,
+     "end_time": "2026-06-02T22:35:47.485930+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.203473+00:00",
+     "start_time": "2026-06-02T22:35:47.480032+00:00",
      "status": "completed"
     },
     "tags": []
@@ -512,20 +602,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "51613141",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.210614Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.210398Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.214941Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.214343Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.505749Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.505071Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.513825Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.512372Z"
     },
     "papermill": {
-     "duration": 0.007917,
-     "end_time": "2026-05-20T23:40:41.215401+00:00",
+     "duration": 0.019086,
+     "end_time": "2026-06-02T22:35:47.515119+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.207484+00:00",
+     "start_time": "2026-06-02T22:35:47.496033+00:00",
      "status": "completed"
     },
     "tags": []
@@ -583,10 +673,10 @@
    "id": "67e27c05",
    "metadata": {
     "papermill": {
-     "duration": 0.001899,
-     "end_time": "2026-05-20T23:40:41.219051+00:00",
+     "duration": 0.007541,
+     "end_time": "2026-06-02T22:35:47.529540+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.217152+00:00",
+     "start_time": "2026-06-02T22:35:47.521999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -611,20 +701,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "addfecf3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.224567Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.224408Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.228875Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.228331Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.548732Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.548151Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.556867Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.555617Z"
     },
     "papermill": {
-     "duration": 0.00778,
-     "end_time": "2026-05-20T23:40:41.229248+00:00",
+     "duration": 0.019499,
+     "end_time": "2026-06-02T22:35:47.557985+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.221468+00:00",
+     "start_time": "2026-06-02T22:35:47.538486+00:00",
      "status": "completed"
     },
     "tags": []
@@ -634,7 +724,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Position: [4, 7, 9]\n",
+      "Position: [4, 7, 9]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Valeurs de Grundy: [4, 7, 9]\n",
       "Nim-sum: 10\n",
       "Type: N-position\n",
@@ -675,13 +772,98 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-sg-sum-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006902,
+     "end_time": "2026-06-02T22:35:47.571382+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:47.564480+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Verification du theoreme de Sprague-Grundy\n",
+    "\n",
+    "**Objectif** : Prendre deux jeux de soustraction G1=S({1,2}) et G2=S({1,3}), calculer les valeurs de Grundy individuelles pour n=0..15, puis verifier que Grundy(G1+G2) = Grundy(G1) XOR Grundy(G2) pour plusieurs tailles.\n",
+    "\n",
+    "**Contexte** : Le theoreme de Sprague-Grundy affirme que la somme de jeux impartiaux se decompose via le XOR. Verifions-le sur un exemple concret.\n",
+    "\n",
+    "# Indice : Pour chaque n, calculer Grundy de G1 et G2 separement.\n",
+    "# Etape 1 : Calculer grundy_subtraction pour les deux jeux.\n",
+    "# Etape 2 : Pour la somme, le Grundy total = XOR des deux.\n",
+    "# Etape 3 : Verifier que le resultat est coherent avec la classification P/N."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ex-sg-sum-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:35:47.587637Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.587122Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.595636Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.594195Z"
+    },
+    "papermill": {
+     "duration": 0.018718,
+     "end_time": "2026-06-02T22:35:47.596825+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:47.578107+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "G1=S({1,2}): []\n",
+      "G2=S({1,3}): []\n",
+      "XOR:           []\n",
+      "Verification: False\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_sprague_grundy_somme(n_max: int = 15) -> dict:\n",
+    "    \"\"\"\n",
+    "    Verifie le theoreme de Sprague-Grundy sur la somme S({1,2}) + S({1,3}).\n",
+    "    \n",
+    "    Args:\n",
+    "        n_max: taille maximale a analyser\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'g1_values': liste des Grundy de G1=S({1,2})\n",
+    "            'g2_values': liste des Grundy de G2=S({1,3})\n",
+    "            'xor_values': liste des XOR\n",
+    "            'verification_ok': True si le theoreme est verifie\n",
+    "    \"\"\"\n",
+    "    return {\"g1_values\": [], \"g2_values\": [], \"xor_values\": [], \"verification_ok\": False}  # TODO etudiant\n",
+    "\n",
+    "result_sg = exercice_sprague_grundy_somme(15)\n",
+    "print(f\"G1=S({{1,2}}): {result_sg['g1_values'][:10]}\")\n",
+    "print(f\"G2=S({{1,3}}): {result_sg['g2_values'][:10]}\")\n",
+    "print(f\"XOR:           {result_sg['xor_values'][:10]}\")\n",
+    "print(f\"Verification: {result_sg['verification_ok']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b843b282",
    "metadata": {
     "papermill": {
-     "duration": 0.00161,
-     "end_time": "2026-05-20T23:40:41.232859+00:00",
+     "duration": 0.006004,
+     "end_time": "2026-06-02T22:35:47.609727+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.231249+00:00",
+     "start_time": "2026-06-02T22:35:47.603723+00:00",
      "status": "completed"
     },
     "tags": []
@@ -700,20 +882,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "fc33e083",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.237711Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.237430Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.241978Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.241463Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.627587Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.627074Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.636465Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.635196Z"
     },
     "papermill": {
-     "duration": 0.00805,
-     "end_time": "2026-05-20T23:40:41.242552+00:00",
+     "duration": 0.021732,
+     "end_time": "2026-06-02T22:35:47.637706+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.234502+00:00",
+     "start_time": "2026-06-02T22:35:47.615974+00:00",
      "status": "completed"
     },
     "tags": []
@@ -791,10 +973,10 @@
    "id": "07c9e578",
    "metadata": {
     "papermill": {
-     "duration": 0.001737,
-     "end_time": "2026-05-20T23:40:41.246467+00:00",
+     "duration": 0.006439,
+     "end_time": "2026-06-02T22:35:47.650107+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.244730+00:00",
+     "start_time": "2026-06-02T22:35:47.643668+00:00",
      "status": "completed"
     },
     "tags": []
@@ -847,10 +1029,10 @@
    "id": "965cb434",
    "metadata": {
     "papermill": {
-     "duration": 0.001807,
-     "end_time": "2026-05-20T23:40:41.250042+00:00",
+     "duration": 0.008475,
+     "end_time": "2026-06-02T22:35:47.664522+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.248235+00:00",
+     "start_time": "2026-06-02T22:35:47.656047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -875,20 +1057,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "782b5526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T23:40:41.254652Z",
-     "iopub.status.busy": "2026-05-20T23:40:41.254432Z",
-     "iopub.status.idle": "2026-05-20T23:40:41.258009Z",
-     "shell.execute_reply": "2026-05-20T23:40:41.257428Z"
+     "iopub.execute_input": "2026-06-02T22:35:47.682210Z",
+     "iopub.status.busy": "2026-06-02T22:35:47.681677Z",
+     "iopub.status.idle": "2026-06-02T22:35:47.687983Z",
+     "shell.execute_reply": "2026-06-02T22:35:47.686708Z"
     },
     "papermill": {
-     "duration": 0.006996,
-     "end_time": "2026-05-20T23:40:41.258785+00:00",
+     "duration": 0.015603,
+     "end_time": "2026-06-02T22:35:47.689090+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.251789+00:00",
+     "start_time": "2026-06-02T22:35:47.673487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -927,18 +1109,33 @@
   {
    "cell_type": "markdown",
    "id": "d4ed1f1d",
-   "source": "## Resume et perspectives\n\nCe notebook a etabli les fondements de la theorie des jeux combinatoires impartiaux, depuis la classification des positions en P-positions (perdantes pour le joueur courant) et N-positions (gagnantes) jusqu'au theoreme de Sprague-Grundy, resultat central qui affirme que tout jeu impartial fini est equivalent a un tas de Nim. Le theoreme de Bouton a fourni un critere elegant pour determiner la position gagnante au Nim (la nim-sum, ou XOR des tailles de tas), tandis que la fonction mex (minimum excludant) a permis de calculer recursivement les valeurs de Grundy pour des jeux de soustraction plus generaux. L'observation de la periodicite des valeurs de Grundy dans les jeux de soustraction ouvre la porte a l'analyse de jeux plus complexes, ou les structures periodiques simplifient considerablement la recherche de strategies optimales.\n\nLes side tracks associes approfondissent ces concepts : le [notebook 8b](GameTheory-8b-Lean-CombinatorialGames.ipynb) propose une formalisation en Lean 4 avec les PGame de Mathlib, tandis que le [notebook 8c](GameTheory-8c-CombinatorialGames-Python.ipynb) explore le jeu de Wythoff et les jeux multi-composantes en Python. La serie principale se poursuit avec l'etude de l'induction arriere pour resoudre les jeux sequentiels : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.006599,
+     "end_time": "2026-06-02T22:35:47.702104+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:35:47.695505+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a etabli les fondements de la theorie des jeux combinatoires impartiaux, depuis la classification des positions en P-positions (perdantes pour le joueur courant) et N-positions (gagnantes) jusqu'au theoreme de Sprague-Grundy, resultat central qui affirme que tout jeu impartial fini est equivalent a un tas de Nim. Le theoreme de Bouton a fourni un critere elegant pour determiner la position gagnante au Nim (la nim-sum, ou XOR des tailles de tas), tandis que la fonction mex (minimum excludant) a permis de calculer recursivement les valeurs de Grundy pour des jeux de soustraction plus generaux. L'observation de la periodicite des valeurs de Grundy dans les jeux de soustraction ouvre la porte a l'analyse de jeux plus complexes, ou les structures periodiques simplifient considerablement la recherche de strategies optimales.\n",
+    "\n",
+    "Les side tracks associes approfondissent ces concepts : le [notebook 8b](GameTheory-8b-Lean-CombinatorialGames.ipynb) propose une formalisation en Lean 4 avec les PGame de Mathlib, tandis que le [notebook 8c](GameTheory-8c-CombinatorialGames-Python.ipynb) explore le jeu de Wythoff et les jeux multi-composantes en Python. La serie principale se poursuit avec l'etude de l'induction arriere pour resoudre les jeux sequentiels : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb)."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "74a5a589",
    "metadata": {
     "papermill": {
-     "duration": 0.001786,
-     "end_time": "2026-05-20T23:40:41.262618+00:00",
+     "duration": 0.006089,
+     "end_time": "2026-06-02T22:35:47.715238+00:00",
      "exception": false,
-     "start_time": "2026-05-20T23:40:41.260832+00:00",
+     "start_time": "2026-06-02T22:35:47.709149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -967,18 +1164,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.191593,
-   "end_time": "2026-05-20T23:40:41.506175+00:00",
+   "duration": 6.914054,
+   "end_time": "2026-06-02T22:35:49.286220+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-8-CombinatorialGames.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8-CombinatorialGames.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8-CombinatorialGames_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-20T23:40:39.314582+00:00",
+   "start_time": "2026-06-02T22:35:42.372166+00:00",
    "version": "2.7.0"
   }
  },

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "8607eedc",
    "metadata": {
     "papermill": {
-     "duration": 0.002097,
-     "end_time": "2026-05-11T00:05:00.599600+00:00",
+     "duration": 0.007379,
+     "end_time": "2026-06-02T22:35:59.922803+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.597503+00:00",
+     "start_time": "2026-06-02T22:35:59.915424+00:00",
      "status": "completed"
     },
     "tags": []
@@ -52,16 +52,16 @@
    "id": "338533ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:00.605945Z",
-     "iopub.status.busy": "2026-05-11T00:05:00.605794Z",
-     "iopub.status.idle": "2026-05-11T00:05:00.920943Z",
-     "shell.execute_reply": "2026-05-11T00:05:00.919704Z"
+     "iopub.execute_input": "2026-06-02T22:35:59.934298Z",
+     "iopub.status.busy": "2026-06-02T22:35:59.933982Z",
+     "iopub.status.idle": "2026-06-02T22:36:00.790222Z",
+     "shell.execute_reply": "2026-06-02T22:36:00.788836Z"
     },
     "papermill": {
-     "duration": 0.318951,
-     "end_time": "2026-05-11T00:05:00.921703+00:00",
+     "duration": 0.863069,
+     "end_time": "2026-06-02T22:36:00.791870+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.602752+00:00",
+     "start_time": "2026-06-02T22:35:59.928801+00:00",
      "status": "completed"
     },
     "tags": []
@@ -92,10 +92,10 @@
    "id": "0e9e8f9c",
    "metadata": {
     "papermill": {
-     "duration": 0.001703,
-     "end_time": "2026-05-11T00:05:00.925286+00:00",
+     "duration": 0.005819,
+     "end_time": "2026-06-02T22:36:00.805284+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.923583+00:00",
+     "start_time": "2026-06-02T22:36:00.799465+00:00",
      "status": "completed"
     },
     "tags": []
@@ -114,16 +114,16 @@
    "id": "8e00f9de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:00.929260Z",
-     "iopub.status.busy": "2026-05-11T00:05:00.929050Z",
-     "iopub.status.idle": "2026-05-11T00:05:00.933181Z",
-     "shell.execute_reply": "2026-05-11T00:05:00.932317Z"
+     "iopub.execute_input": "2026-06-02T22:36:00.820778Z",
+     "iopub.status.busy": "2026-06-02T22:36:00.820083Z",
+     "iopub.status.idle": "2026-06-02T22:36:00.829542Z",
+     "shell.execute_reply": "2026-06-02T22:36:00.828263Z"
     },
     "papermill": {
-     "duration": 0.006793,
-     "end_time": "2026-05-11T00:05:00.933608+00:00",
+     "duration": 0.019225,
+     "end_time": "2026-06-02T22:36:00.830601+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.926815+00:00",
+     "start_time": "2026-06-02T22:36:00.811376+00:00",
      "status": "completed"
     },
     "tags": []
@@ -178,10 +178,10 @@
    "id": "d1ba17eb",
    "metadata": {
     "papermill": {
-     "duration": 0.00208,
-     "end_time": "2026-05-11T00:05:00.937511+00:00",
+     "duration": 0.006265,
+     "end_time": "2026-06-02T22:36:00.843582+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.935431+00:00",
+     "start_time": "2026-06-02T22:36:00.837317+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,16 +206,16 @@
    "id": "d8df1425",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:00.941321Z",
-     "iopub.status.busy": "2026-05-11T00:05:00.941169Z",
-     "iopub.status.idle": "2026-05-11T00:05:00.946158Z",
-     "shell.execute_reply": "2026-05-11T00:05:00.945492Z"
+     "iopub.execute_input": "2026-06-02T22:36:00.860458Z",
+     "iopub.status.busy": "2026-06-02T22:36:00.859968Z",
+     "iopub.status.idle": "2026-06-02T22:36:00.873998Z",
+     "shell.execute_reply": "2026-06-02T22:36:00.872674Z"
     },
     "papermill": {
-     "duration": 0.007702,
-     "end_time": "2026-05-11T00:05:00.946714+00:00",
+     "duration": 0.023045,
+     "end_time": "2026-06-02T22:36:00.875159+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.939012+00:00",
+     "start_time": "2026-06-02T22:36:00.852114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -286,10 +286,10 @@
    "id": "2c05ba20",
    "metadata": {
     "papermill": {
-     "duration": 0.001639,
-     "end_time": "2026-05-11T00:05:00.949905+00:00",
+     "duration": 0.006088,
+     "end_time": "2026-06-02T22:36:00.887895+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.948266+00:00",
+     "start_time": "2026-06-02T22:36:00.881807+00:00",
      "status": "completed"
     },
     "tags": []
@@ -323,16 +323,16 @@
    "id": "957cda6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:00.954721Z",
-     "iopub.status.busy": "2026-05-11T00:05:00.954562Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.144592Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.143901Z"
+     "iopub.execute_input": "2026-06-02T22:36:00.901663Z",
+     "iopub.status.busy": "2026-06-02T22:36:00.901227Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.432526Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.431134Z"
     },
     "papermill": {
-     "duration": 0.193343,
-     "end_time": "2026-05-11T00:05:01.144977+00:00",
+     "duration": 0.54029,
+     "end_time": "2026-06-02T22:36:01.433500+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:00.951634+00:00",
+     "start_time": "2026-06-02T22:36:00.893210+00:00",
      "status": "completed"
     },
     "tags": []
@@ -396,10 +396,10 @@
    "id": "778627a5",
    "metadata": {
     "papermill": {
-     "duration": 0.002178,
-     "end_time": "2026-05-11T00:05:01.149299+00:00",
+     "duration": 0.005562,
+     "end_time": "2026-06-02T22:36:01.444524+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.147121+00:00",
+     "start_time": "2026-06-02T22:36:01.438962+00:00",
      "status": "completed"
     },
     "tags": []
@@ -429,16 +429,16 @@
    "id": "5914dfd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.155133Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.154981Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.159625Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.158865Z"
+     "iopub.execute_input": "2026-06-02T22:36:01.455329Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.454944Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.462487Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.461526Z"
     },
     "papermill": {
-     "duration": 0.008499,
-     "end_time": "2026-05-11T00:05:01.160206+00:00",
+     "duration": 0.014363,
+     "end_time": "2026-06-02T22:36:01.463366+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.151707+00:00",
+     "start_time": "2026-06-02T22:36:01.449003+00:00",
      "status": "completed"
     },
     "tags": []
@@ -508,10 +508,10 @@
    "id": "c7da668f",
    "metadata": {
     "papermill": {
-     "duration": 0.001881,
-     "end_time": "2026-05-11T00:05:01.164335+00:00",
+     "duration": 0.005181,
+     "end_time": "2026-06-02T22:36:01.474928+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.162454+00:00",
+     "start_time": "2026-06-02T22:36:01.469747+00:00",
      "status": "completed"
     },
     "tags": []
@@ -545,16 +545,16 @@
    "id": "1cbb3a71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.169337Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.169206Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.313579Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.312193Z"
+     "iopub.execute_input": "2026-06-02T22:36:01.484880Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.484527Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.769729Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.768920Z"
     },
     "papermill": {
-     "duration": 0.147867,
-     "end_time": "2026-05-11T00:05:01.314398+00:00",
+     "duration": 0.291385,
+     "end_time": "2026-06-02T22:36:01.770419+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.166531+00:00",
+     "start_time": "2026-06-02T22:36:01.479034+00:00",
      "status": "completed"
     },
     "tags": []
@@ -627,10 +627,10 @@
    "id": "291de63b",
    "metadata": {
     "papermill": {
-     "duration": 0.005403,
-     "end_time": "2026-05-11T00:05:01.325912+00:00",
+     "duration": 0.005121,
+     "end_time": "2026-06-02T22:36:01.779908+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.320509+00:00",
+     "start_time": "2026-06-02T22:36:01.774787+00:00",
      "status": "completed"
     },
     "tags": []
@@ -661,16 +661,16 @@
    "id": "ba07a932",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.333845Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.333591Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.338424Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.337676Z"
+     "iopub.execute_input": "2026-06-02T22:36:01.789443Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.789099Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.795719Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.794851Z"
     },
     "papermill": {
-     "duration": 0.009108,
-     "end_time": "2026-05-11T00:05:01.338811+00:00",
+     "duration": 0.012488,
+     "end_time": "2026-06-02T22:36:01.796389+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.329703+00:00",
+     "start_time": "2026-06-02T22:36:01.783901+00:00",
      "status": "completed"
     },
     "tags": []
@@ -733,13 +733,95 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-wythoff-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004066,
+     "end_time": "2026-06-02T22:36:01.804974+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:01.800908+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Generation et verification des P-positions de Wythoff\n",
+    "\n",
+    "**Objectif** : Generer les N premieres P-positions de Wythoff en utilisant la formule du nombre d'or, verifier chaque position avec `is_wythoff_p_position`, puis trouver un coup gagnant depuis une N-position donnee.\n",
+    "\n",
+    "**Contexte** : Les fonctions `wythoff_p_positions`, `is_wythoff_p_position` et `wythoff_winning_move` sont deja implementees. Utilisez-les pour explorer la structure.\n",
+    "\n",
+    "# Indice : Les P-positions suivent les sequences de Beatty avec le nombre d'or.\n",
+    "# Etape 1 : Generer les 15 premieres P-positions.\n",
+    "# Etape 2 : Verifier chaque position avec is_wythoff_p_position.\n",
+    "# Etape 3 : Pour les N-positions (10,15), (8,12), trouver le coup gagnant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ex-wythoff-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:36:01.814552Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.814208Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.818582Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.817965Z"
+    },
+    "papermill": {
+     "duration": 0.01,
+     "end_time": "2026-06-02T22:36:01.819124+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:01.809124+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P-positions: []\n",
+      "Toutes verifiees: False\n",
+      "Coups gagnants: {}\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_wythoff_verification(n_max: int = 15) -> dict:\n",
+    "    \"\"\"\n",
+    "    Genere et verifie les P-positions de Wythoff.\n",
+    "    \n",
+    "    Args:\n",
+    "        n_max: nombre de P-positions a generer\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'p_positions': liste des (a, b) P-positions\n",
+    "            'all_verified': True si toutes passe is_wythoff_p_position\n",
+    "            'winning_moves': dict {(a,b): coup_gagnant} pour des N-positions\n",
+    "    \"\"\"\n",
+    "    return {\"p_positions\": [], \"all_verified\": False, \"winning_moves\": {}}  # TODO etudiant\n",
+    "\n",
+    "result_wythoff = exercice_wythoff_verification(15)\n",
+    "print(f\"P-positions: {result_wythoff['p_positions'][:8]}\")\n",
+    "print(f\"Toutes verifiees: {result_wythoff['all_verified']}\")\n",
+    "print(f\"Coups gagnants: {result_wythoff['winning_moves']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b08bd369",
    "metadata": {
     "papermill": {
-     "duration": 0.002925,
-     "end_time": "2026-05-11T00:05:01.344455+00:00",
+     "duration": 0.004244,
+     "end_time": "2026-06-02T22:36:01.827705+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.341530+00:00",
+     "start_time": "2026-06-02T22:36:01.823461+00:00",
      "status": "completed"
     },
     "tags": []
@@ -758,20 +840,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "33ca9616",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.351368Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.351190Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.357076Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.356147Z"
+     "iopub.execute_input": "2026-06-02T22:36:01.837954Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.837620Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.846815Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.845975Z"
     },
     "papermill": {
-     "duration": 0.010135,
-     "end_time": "2026-05-11T00:05:01.357616+00:00",
+     "duration": 0.015102,
+     "end_time": "2026-06-02T22:36:01.847437+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.347481+00:00",
+     "start_time": "2026-06-02T22:36:01.832335+00:00",
      "status": "completed"
     },
     "tags": []
@@ -861,13 +943,95 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex-composite-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004371,
+     "end_time": "2026-06-02T22:36:01.856216+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:01.851845+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Analyse d'un jeu composite a trois composantes\n",
+    "\n",
+    "**Objectif** : Construire un jeu composite avec trois composantes de soustraction differentes, calculer le Grundy total via XOR, determiner le type de position (P ou N), et trouver un coup gagnant si possible.\n",
+    "\n",
+    "**Contexte** : La classe `CompositeGame` implemente le theoreme de Sprague-Grundy pour les jeux composites. Utilisez-la pour analyser une nouvelle configuration.\n",
+    "\n",
+    "# Indice : Utiliser CompositeGame avec differentes combinaisons de moves.\n",
+    "# Etape 1 : Definir 3 composantes avec des moves differents de l'exemple.\n",
+    "# Etape 2 : Calculer les Grundy individuels et le total.\n",
+    "# Etape 3 : Si N-position, trouver le coup gagnant et verifier que le nouveau Grundy = 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ex-composite-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-02T22:36:01.866424Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.866149Z",
+     "iopub.status.idle": "2026-06-02T22:36:01.870341Z",
+     "shell.execute_reply": "2026-06-02T22:36:01.869768Z"
+    },
+    "papermill": {
+     "duration": 0.010534,
+     "end_time": "2026-06-02T22:36:01.871078+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:01.860544+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Grundy individuels: []\n",
+      "Grundy total: 0\n",
+      "Position: P\n",
+      "Coup gagnant: None\n",
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def exercice_composite_grundy() -> dict:\n",
+    "    \"\"\"\n",
+    "    Analyse un jeu composite avec S({1,2,3}), S({2,4}), S({1,5}).\n",
+    "    \n",
+    "    Returns:\n",
+    "        dict avec :\n",
+    "            'component_grundys': liste des Grundy individuels\n",
+    "            'total_grundy': Grundy total (XOR)\n",
+    "            'position_type': 'P' ou 'N'\n",
+    "            'winning_move': (composante, nouvelle_taille) ou None\n",
+    "    \"\"\"\n",
+    "    return {\"component_grundys\": [], \"total_grundy\": 0, \"position_type\": \"P\", \"winning_move\": None}  # TODO etudiant\n",
+    "\n",
+    "result_comp = exercice_composite_grundy()\n",
+    "print(f\"Grundy individuels: {result_comp['component_grundys']}\")\n",
+    "print(f\"Grundy total: {result_comp['total_grundy']}\")\n",
+    "print(f\"Position: {result_comp['position_type']}\")\n",
+    "print(f\"Coup gagnant: {result_comp['winning_move']}\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1740acf3",
    "metadata": {
     "papermill": {
-     "duration": 0.002802,
-     "end_time": "2026-05-11T00:05:01.363382+00:00",
+     "duration": 0.004274,
+     "end_time": "2026-06-02T22:36:01.879762+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.360580+00:00",
+     "start_time": "2026-06-02T22:36:01.875488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -882,20 +1046,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "e3f4c588",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.370191Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.370036Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.695958Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.695190Z"
+     "iopub.execute_input": "2026-06-02T22:36:01.889270Z",
+     "iopub.status.busy": "2026-06-02T22:36:01.889086Z",
+     "iopub.status.idle": "2026-06-02T22:36:02.436989Z",
+     "shell.execute_reply": "2026-06-02T22:36:02.436008Z"
     },
     "papermill": {
-     "duration": 0.330209,
-     "end_time": "2026-05-11T00:05:01.696533+00:00",
+     "duration": 0.554013,
+     "end_time": "2026-06-02T22:36:02.437906+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.366324+00:00",
+     "start_time": "2026-06-02T22:36:01.883893+00:00",
      "status": "completed"
     },
     "tags": []
@@ -964,10 +1128,10 @@
    "id": "e7b38b59",
    "metadata": {
     "papermill": {
-     "duration": 0.003621,
-     "end_time": "2026-05-11T00:05:01.703995+00:00",
+     "duration": 0.005969,
+     "end_time": "2026-06-02T22:36:02.450180+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.700374+00:00",
+     "start_time": "2026-06-02T22:36:02.444211+00:00",
      "status": "completed"
     },
     "tags": []
@@ -992,20 +1156,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "ce498575",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.712362Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.712203Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.717134Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.716253Z"
+     "iopub.execute_input": "2026-06-02T22:36:02.463313Z",
+     "iopub.status.busy": "2026-06-02T22:36:02.463052Z",
+     "iopub.status.idle": "2026-06-02T22:36:02.470348Z",
+     "shell.execute_reply": "2026-06-02T22:36:02.469518Z"
     },
     "papermill": {
-     "duration": 0.009991,
-     "end_time": "2026-05-11T00:05:01.717696+00:00",
+     "duration": 0.015235,
+     "end_time": "2026-06-02T22:36:02.471151+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.707705+00:00",
+     "start_time": "2026-06-02T22:36:02.455916+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1080,10 +1244,10 @@
    "id": "095a449b",
    "metadata": {
     "papermill": {
-     "duration": 0.004012,
-     "end_time": "2026-05-11T00:05:01.725374+00:00",
+     "duration": 0.005808,
+     "end_time": "2026-06-02T22:36:02.483001+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.721362+00:00",
+     "start_time": "2026-06-02T22:36:02.477193+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1112,20 +1276,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "b9d45809",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.734380Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.734218Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.904918Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.904003Z"
+     "iopub.execute_input": "2026-06-02T22:36:02.495415Z",
+     "iopub.status.busy": "2026-06-02T22:36:02.495154Z",
+     "iopub.status.idle": "2026-06-02T22:36:02.781954Z",
+     "shell.execute_reply": "2026-06-02T22:36:02.780825Z"
     },
     "papermill": {
-     "duration": 0.176366,
-     "end_time": "2026-05-11T00:05:01.905533+00:00",
+     "duration": 0.294328,
+     "end_time": "2026-06-02T22:36:02.782738+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.729167+00:00",
+     "start_time": "2026-06-02T22:36:02.488410+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1135,7 +1299,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\ipykernel_1442884\\1014831080.py:14: UserWarning: Setting the 'color' property will override the edgecolor or facecolor properties.\n",
+      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\ipykernel_2160036\\1014831080.py:14: UserWarning: Setting the 'color' property will override the edgecolor or facecolor properties.\n",
       "  rect = plt.Rectangle((col, row), 0.9, 0.9, color=color, edgecolor='brown')\n"
      ]
     },
@@ -1211,10 +1375,10 @@
    "id": "945cdfb0",
    "metadata": {
     "papermill": {
-     "duration": 0.004227,
-     "end_time": "2026-05-11T00:05:01.914426+00:00",
+     "duration": 0.006658,
+     "end_time": "2026-06-02T22:36:02.795947+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.910199+00:00",
+     "start_time": "2026-06-02T22:36:02.789289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1239,20 +1403,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "4f665c65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-11T00:05:01.924798Z",
-     "iopub.status.busy": "2026-05-11T00:05:01.924636Z",
-     "iopub.status.idle": "2026-05-11T00:05:01.927204Z",
-     "shell.execute_reply": "2026-05-11T00:05:01.926473Z"
+     "iopub.execute_input": "2026-06-02T22:36:02.809553Z",
+     "iopub.status.busy": "2026-06-02T22:36:02.809290Z",
+     "iopub.status.idle": "2026-06-02T22:36:02.813854Z",
+     "shell.execute_reply": "2026-06-02T22:36:02.812983Z"
     },
     "papermill": {
-     "duration": 0.008746,
-     "end_time": "2026-05-11T00:05:01.927629+00:00",
+     "duration": 0.012611,
+     "end_time": "2026-06-02T22:36:02.814703+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.918883+00:00",
+     "start_time": "2026-06-02T22:36:02.802092+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1285,18 +1449,33 @@
   {
    "cell_type": "markdown",
    "id": "77b9d5a4",
-   "source": "## Resume et perspectives\n\nCe notebook a approfondi la theorie des jeux combinatoires au-dela des fondations du notebook 8, en explorant trois axes complementaires. Premierement, l'analyse de la periodicite des valeurs de Grundy a revele que les sequences deviennent predictibles apres un certain point, avec des periodes d'autant plus longues que l'ensemble de coups est inhabituel (l'absence du coup \"1\" engendre ainsi des periodes nettement plus etendues). Deuxiemement, le jeu de Wythoff a illustre un lien remarquable entre combinatoire et geometrie : les P-positions s'alignent sur des droites de pente egale au nombre d'or, formalisees par les sequences de Beatty qui partitionnent les entiers positifs. Troisiemement, l'etude du jeu de Chomp a introduit les jeux partizans et le theoreme de Gale, dont la preuve non-constructive par \"strategy stealing\" garantit l'existence d'une strategie gagnante pour le premier joueur sans la construire.\n\nCes approfondissements montrent que la theorie de Sprague-Grundy, loin de se limiter au Nim, offre un cadre unificateur pour une large classe de jeux. La retour au track principal s'effectue avec le notebook sur l'induction arriere : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.006261,
+     "end_time": "2026-06-02T22:36:02.826952+00:00",
+     "exception": false,
+     "start_time": "2026-06-02T22:36:02.820691+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a approfondi la theorie des jeux combinatoires au-dela des fondations du notebook 8, en explorant trois axes complementaires. Premierement, l'analyse de la periodicite des valeurs de Grundy a revele que les sequences deviennent predictibles apres un certain point, avec des periodes d'autant plus longues que l'ensemble de coups est inhabituel (l'absence du coup \"1\" engendre ainsi des periodes nettement plus etendues). Deuxiemement, le jeu de Wythoff a illustre un lien remarquable entre combinatoire et geometrie : les P-positions s'alignent sur des droites de pente egale au nombre d'or, formalisees par les sequences de Beatty qui partitionnent les entiers positifs. Troisiemement, l'etude du jeu de Chomp a introduit les jeux partizans et le theoreme de Gale, dont la preuve non-constructive par \"strategy stealing\" garantit l'existence d'une strategie gagnante pour le premier joueur sans la construire.\n",
+    "\n",
+    "Ces approfondissements montrent que la theorie de Sprague-Grundy, loin de se limiter au Nim, offre un cadre unificateur pour une large classe de jeux. La retour au track principal s'effectue avec le notebook sur l'induction arriere : [GameTheory-9-BackwardInduction](GameTheory-9-BackwardInduction.ipynb)."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "3bd9cdcc",
    "metadata": {
     "papermill": {
-     "duration": 0.004095,
-     "end_time": "2026-05-11T00:05:01.935977+00:00",
+     "duration": 0.006218,
+     "end_time": "2026-06-02T22:36:02.839523+00:00",
      "exception": false,
-     "start_time": "2026-05-11T00:05:01.931882+00:00",
+     "start_time": "2026-06-02T22:36:02.833305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1341,18 +1520,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.255914,
-   "end_time": "2026-05-11T00:05:02.164173+00:00",
+   "duration": 6.476105,
+   "end_time": "2026-06-02T22:36:03.411620+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "/mnt/d/dev/CoursIA/MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb",
-   "output_path": "/tmp/GameTheory-8c-CombinatorialGames-Python_wsl_output.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8c-CombinatorialGames-Python.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\GameTheory\\GameTheory-8c-CombinatorialGames-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-05-11T00:04:59.908259+00:00",
+   "start_time": "2026-06-02T22:35:56.935515+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
## Summary

Rollout #2161 — Add exercises to 4 GameTheory notebooks to reach the >=3 exercises per notebook convention.

### Changes (4 notebooks, +8 exercises total)

| Notebook | Before | After | New exercises |
|----------|--------|-------|---------------|
| GT-4-NashEquilibrium | 1 | 3 | Iterated dominance elimination, Biased RPS 3x3 |
| GT-8-CombinatorialGames | 1 | 3 | Sprague-Grundy XOR verification, P/N classification |
| GT-8c-CombinatorialGames-Python | 1 | 3 | Wythoff P-positions verification, Composite Grundy |
| GT-15c-CooperativeGames-Python | 1 | 3 | Extended glove game 4 players, Convexity & Core |

### Exercise design principles
- Each exercise targets a concept demonstrated by a worked example but not yet exercised
- Each preceded by a markdown cell with context + objective + hints (`# Indice`, `# Etape N`)
- Distributed mid-notebook (not clustered at end)
- Stubs conform to C.1: `return {...}  # TODO etudiant` / `pass`

### Validation
- **Papermill**: 4/4 SUCCESS (python3 kernel)
- **Execution coverage**: 100% (all code cells have `execution_count` + `outputs`)
- **Exercise count**: 3 stubs per notebook (verified)
- **C.1 compliance**: No `raise NotImplementedError`, no `assert False`, no `1/0`

### GameTheory compliance (#2161)
After this PR: **15/24 notebooks OK** (up from 11/24). Remaining: GT-3, GT-13, GT-16, GT-17 (all at 0, need +3).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>