### PR TITLE
enrich(Sudoku): add 56 exercises across 23 notebooks for >=3 target (#2161)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Csharp.ipynb
@@ -696,6 +696,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Verifier qu'une grille est valide\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une methode qui verifie si une grille completement remplie\n",
+    "respecte toutes les contraintes du Sudoku (lignes, colonnes, blocs uniques).\n",
+    "\n",
+    "# Indice\n",
+    "Parcourez chaque ligne, colonne et bloc 3x3 et verifiez que chaque ensemble\n",
+    "contient exactement les chiffres 1 a 9 sans doublon.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Verifier qu'une grille est valide\n",
+    "public bool IsGridValid(int[,] grid)\n",
+    "{\n",
+    "    // TODO: Verifiez que chaque ligne, colonne et bloc 3x3\n",
+    "    // contient les chiffres 1-9 sans doublon\n",
+    "    return false; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "808a9be3",
@@ -963,6 +993,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer backtracking simple et MRV\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances du solveur simple et du solveur MRV sur\n",
+    "des puzzles de differentes difficultes.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez un Stopwatch pour mesurer le temps et comptez les appels recursifs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer backtracking simple et MRV\n",
+    "public Dictionary<string, (double TimeMs, int Calls)> CompareSolvers(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Lancez les deux solveurs sur le meme puzzle et comparez\n",
+    "    // les temps de resolution et le nombre d'appels recursifs\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "486520ad",
    "metadata": {
     "papermill": {
@@ -1084,6 +1143,35 @@
     "// SudokuHelper.DisplayResults(results);\n",
     "\n",
     "Console.WriteLine(\"TODO: Implementez BacktrackingMRVSolver pour comparer les performances\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter le nombre de solutions\n",
+    "\n",
+    "# Objectif\n",
+    "Modifiez le solveur backtracking pour compter le nombre total de solutions\n",
+    "d'un puzzle donne (en arretant apres un maximum pour eviter les boucles infinies).\n",
+    "\n",
+    "# Indice\n",
+    "Ajoutez un compteur global et arretez la recherche apres `maxCount` solutions trouvees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter le nombre de solutions\n",
+    "public int CountSolutions(int[,] puzzle, int maxCount = 100)\n",
+    "{\n",
+    "    // TODO: Modifiez le backtracking pour compter les solutions\n",
+    "    // au lieu de s'arreter a la premiere trouvee\n",
+    "    return 0; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-1-Backtracking-Python.ipynb
@@ -910,6 +910,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les performances Backtracking simple vs MRV\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances du solveur backtracking simple et du solveur MRV\n",
+    "sur les puzzles de differentes difficultes.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez la fonction `benchmark_solver` deja definie avec les deux solveurs.\n",
+    "Affichez les resultats dans un tableau comparatif.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Comparer les performances Backtracking simple vs MRV\n",
+    "def compare_solvers(puzzles: List[str]) -> dict:\n",
+    "    # TODO: Comparez les deux solveurs sur les memes puzzles\n",
+    "    # Retournez un dict avec les temps et nombre d'appels pour chaque solveur\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "df19e441",
    "metadata": {
     "id": "df19e441",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
@@ -605,6 +605,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les contraintes initiales\n",
+    "\n",
+    "# Objectif\n",
+    "Comptez le nombre de contraintes posees par le modele OR-Tools pour un puzzle donne.\n",
+    "\n",
+    "# Indice\n",
+    "Parcourez les contraintes de ligne, colonne, bloc et cellule et comptez-les.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter les contraintes initiales\n",
+    "public Dictionary<string, int> CountConstraints(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Comptez le nombre de contraintes par type (ligne, colonne, bloc, cellule)\n",
+    "    // dans le modele OR-Tools pour ce puzzle\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "56a5b954",
@@ -974,6 +1002,35 @@
     "        }\n",
     "    }\n",
     "}\n\nConsole.WriteLine(\"Classe OrToolsSatSolver definie.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Verifier la validite d'une solution avec OR-Tools\n",
+    "\n",
+    "# Objectif\n",
+    "Utilisez OR-Tools pour verifier qu'une solution proposee satisfait bien\n",
+    "toutes les contraintes du modele.\n",
+    "\n",
+    "# Indice\n",
+    "Creez le modele, fixez les variables aux valeurs de la solution, et verifiez la faisabilite.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Verifier la validite d'une solution avec OR-Tools\n",
+    "public bool VerifySolutionWithORTools(int[,] puzzle, int[,] solution)\n",
+    "{\n",
+    "    // TODO: Creez le modele CP-SAT, fixez les variables aux valeurs de la solution,\n",
+    "    // et verifiez que toutes les contraintes sont satisfaites\n",
+    "    return false; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -1373,6 +1430,35 @@
     "// Utilisation des méthodes de benchmarking\n",
     "var results = SudokuHelper.TestSolvers(solvers);\n",
     "SudokuHelper.DisplayResults(results);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Resoudre le Sudoku X avec contraintes de diagonale\n",
+    "\n",
+    "# Objectif\n",
+    "Ajoutez des contraintes de diagonale au modele OR-Tools pour resoudre\n",
+    "un Sudoku X (ou les deux diagonales doivent aussi contenir 1-9).\n",
+    "\n",
+    "# Indice\n",
+    "Ajoutez une contrainte AllDifferent pour chaque diagonale de la grille.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Resoudre le Sudoku X avec contraintes de diagonale\n",
+    "public int[,] SolveSudokuX(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Ajoutez les contraintes de diagonale au modele CP-SAT\n",
+    "    // et resolvez le puzzle\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
@@ -768,6 +768,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Ajouter une contrainte d'anti-symetrie\n",
+    "\n",
+    "# Objectif\n",
+    "Ajoutez au modele OR-Tools une contrainte qui force la premiere ligne\n",
+    "a etre strictement croissante (1,2,3,4,5,6,7,8,9), eliminant ainsi\n",
+    "les solutions symetriques par rotation/reflection.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez `model.Add(cells[0][i] == i+1)` pour chaque colonne i de la ligne 0.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Ajouter une contrainte d'anti-symetrie\n",
+    "def solve_with_anti_symmetry(grid: SudokuGrid) -> dict:\n",
+    "    # TODO: Construisez le modele CP-SAT avec la contrainte supplementaire\n",
+    "    # que la premiere ligne doit etre (1,2,3,...,9)\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "322xetmzp7c",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
@@ -553,6 +553,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les strategies de recherche Choco\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez au moins 2 strategies de recherche Choco (InputOrder, DomOverWDeg)\n",
+    "et mesurez leur impact sur le temps de resolution.\n",
+    "\n",
+    "# Indice\n",
+    "Configurez le solver avec differentes strategies et lancez les benchmarks.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer les strategies de recherche Choco\n",
+    "public Dictionary<string, double> CompareChocoStrategies(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Testez differentes strategies de recherche Choco\n",
+    "    // et retournez les temps de resolution pour chacune\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "id": "47497b92",
    "cell_type": "code",
    "execution_count": 5,
@@ -936,6 +965,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Resolution avec limite de temps\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une resolution Choco avec un timeout et analysez les resultats\n",
+    "intermediaires obtenus quand le temps est depasse.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez les parametres de timeout du solver et recuperez l'etat partiel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Resolution avec limite de temps\n",
+    "public (bool Solved, int[,] PartialSolution, double TimeMs) SolveWithTimeout(int[,] puzzle, double timeoutSeconds)\n",
+    "{\n",
+    "    // TODO: Lancez la resolution Choco avec un timeout\n",
+    "    // et retournez l'etat (resolu ou partiel) et le temps ecoule\n",
+    "    return (false, null, 0); // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "id": "70a90010",
    "cell_type": "code",
    "execution_count": 7,
@@ -1082,6 +1140,34 @@
     "| **IntDomainMax** | Plus grande valeur |\n",
     "| **IntDomainRandom** | Valeur aleatoire |\n",
     "| **IntDomainMiddle** | Valeur mediane |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comptage de solutions avec Choco\n",
+    "\n",
+    "# Objectif\n",
+    "Utilisez Choco pour compter le nombre total de solutions d'un puzzle Sudoku donne.\n",
+    "\n",
+    "# Indice\n",
+    "Configurez le solver pour chercher toutes les solutions et comptez-les.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comptage de solutions avec Choco\n",
+    "public int CountSolutionsWithChoco(int[,] puzzle, int maxCount = 100)\n",
+    "{\n",
+    "    // TODO: Utilisez Choco pour compter les solutions du puzzle\n",
+    "    // en s'arretant apres maxCount solutions\n",
+    "    return 0; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
@@ -551,6 +551,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Resoudre un Killer Sudoku avec contrainte de somme\n",
+    "\n",
+    "# Objectif\n",
+    "Ajoutez une contrainte de somme sur un bloc 3x3 pour modeliser un Killer Sudoku.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez MkAdd pour sommer les variables d'un bloc et MkEq pour fixer la somme attendue.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Resoudre un Killer Sudoku avec contrainte de somme\n",
+    "public int[,] SolveWithSumConstraint(int[,] puzzle, int blockRow, int blockCol, int targetSum)\n",
+    "{\n",
+    "    // TODO: Ajoutez une contrainte de somme sur le bloc (blockRow, blockCol)\n",
+    "    // et resolvez le puzzle\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "id": "cf526353",
    "cell_type": "code",
    "execution_count": 5,
@@ -825,6 +853,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter le nombre de solutions avec Z3\n",
+    "\n",
+    "# Objectif\n",
+    "Utilisez Z3 pour compter le nombre total de solutions d'un puzzle en\n",
+    "ajoutant iterativement des contraintes d'exclusion.\n",
+    "\n",
+    "# Indice\n",
+    "Apres chaque solution trouvee, ajoutez une contrainte qui exclut cette solution\n",
+    "et relancez le solver.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter le nombre de solutions avec Z3\n",
+    "public int CountSolutionsWithZ3(int[,] puzzle, int maxCount = 100)\n",
+    "{\n",
+    "    // TODO: Comptez les solutions en ajoutant des contraintes d'exclusion\n",
+    "    // a chaque iteration\n",
+    "    return 0; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "id": "9d27fc52",
    "cell_type": "code",
    "execution_count": 8,
@@ -928,6 +986,35 @@
     "4. `ctx` et `CellVariables` sont accessibles statiquement depuis la classe de base\n",
     "\n",
     "**Verification** : Verifiez d'abord avec `EnforceDiagonals = false` (comportement identique au solveur de base)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Coloration de graphe avec Z3\n",
+    "\n",
+    "# Objectif\n",
+    "Utilisez Z3 pour resoudre un probleme de coloration de graphe : colorier\n",
+    "un graphe avec k couleurs telles que deux noeuds adjacents n'ont jamais la meme couleur.\n",
+    "\n",
+    "# Indice\n",
+    "Creez une variable entiere par noeud et ajoutez des contraintes de difference pour chaque arete.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Coloration de graphe avec Z3\n",
+    "public Dictionary<int, int> SolveGraphColoring(int[,] adjacencyMatrix, int numColors)\n",
+    "{\n",
+    "    // TODO: Modelisez le probleme de coloration de graphe avec Z3\n",
+    "    // Retournez un dictionnaire (noeud -> couleur)\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -511,6 +511,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Creer un predicat CharSet personnalise\n",
+    "\n",
+    "# Objectif\n",
+    "Creez un predicat CharSet qui accepte uniquement les chiffres pairs (2, 4, 6, 8).\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez les operateurs d'union et d'intersection pour combiner des ensembles de caracteres.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Creer un predicat CharSet personnalise\n",
+    "public CharSet CreateEvenDigitsPredicate()\n",
+    "{\n",
+    "    // TODO: Creez un CharSet qui accepte uniquement les chiffres pairs (2, 4, 6, 8)\n",
+    "    // en utilisant les operateurs de la bibliotheque Automata\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "9b011981",
@@ -1622,6 +1650,35 @@
     "- La puissance de Z3 pour representer les predicats et verifier la distinctivite\n",
     "\n",
     "**Note importante** : Cette classe n'est pas un \"vrai\" automate symbolique avec des etats explicites. C'est une **compilation** vers Z3 qui capture l'essence de la contrainte de ligne (valeurs distinctes).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Verifier une ligne Sudoku avec un automate\n",
+    "\n",
+    "# Objectif\n",
+    "Construisez un automate symbolique qui verifie qu'une sequence de 9 chiffres\n",
+    "forme une ligne Sudoku valide (pas de doublon, valeurs entre 1 et 9).\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez l'automate pour valider que chaque valeur apparait exactement une fois.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Verifier une ligne Sudoku avec un automate\n",
+    "public bool ValidateSudokuLineWithAutomaton(int[] line)\n",
+    "{\n",
+    "    // TODO: Construisez un automate symbolique qui accepte uniquement\n",
+    "    // les permutations valides des chiffres 1-9 et testez la ligne\n",
+    "    return false; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -448,6 +448,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Construire un BDD pour la contrainte \"exactement un parmi N\"\n",
+    "\n",
+    "# Objectif\n",
+    "Construisez un BDD qui encode la contrainte : parmi N variables booleennes,\n",
+    "exactement une doit etre vraie.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez la negation et la conjonction pour exprimer la contrainte.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Construire un BDD pour la contrainte \"exactement un parmi N\"\n",
+    "public BDD ExactlyOneOfN(BDD[] variables)\n",
+    "{\n",
+    "    // TODO: Construisez un BDD qui est vrai si exactement une des N variables est vraie\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "2bede738",
@@ -1213,6 +1241,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Construire un MDD pour la contrainte \"tous differents\"\n",
+    "\n",
+    "# Objectif\n",
+    "Construisez un MDD (Multi-valued Decision Diagram) qui encode la contrainte\n",
+    "\"tous differents\" pour une ligne de 9 cellules avec valeurs 1-9.\n",
+    "\n",
+    "# Indice\n",
+    "Chaque niveau du MDD represente une cellule, et chaque arc represente une valeur possible\n",
+    "non encore utilisee.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Construire un MDD pour la contrainte \"tous differents\"\n",
+    "public MDD BuildAllDifferentMDD(int numCells, int maxValue)\n",
+    "{\n",
+    "    // TODO: Construisez un MDD qui accepte uniquement les assignments\n",
+    "    // ou toutes les valeurs sont differentes\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "81fe3df4",
@@ -1955,6 +2013,35 @@
     "### 6.3 Test du Solveur\n",
     "\n",
     "Notons que ce solveur est essentiellement du backtracking. La vraie valeur de l'approche MDD serait dans la composition de contraintes, mais l'explosion d'etats la rend impraticable pour Sudoku complet."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les performances BDD vs MDD\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances des solveurs BDD et MDD sur des puzzles de differentes\n",
+    "difficultes en mesurant le temps et la taille des structures.\n",
+    "\n",
+    "# Indice\n",
+    "Mesurez la taille (nombre de noeuds) et le temps de construction et de resolution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer les performances BDD vs MDD\n",
+    "public Dictionary<string, (double TimeMs, int NodeCount)> CompareBDDvsMDD(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Construisez les structures BDD et MDD pour le meme puzzle\n",
+    "    // et comparez les temps de construction et resolution\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -305,6 +305,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les candidats possibles par case\n",
+    "\n",
+    "# Objectif\n",
+    "Pour chaque cellule vide, comptez le nombre de candidats possibles\n",
+    "apres propagation des contraintes.\n",
+    "\n",
+    "# Indice\n",
+    "Appliquez la propagation et comptez les valeurs restantes dans le domaine de chaque cellule.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter les candidats possibles par case\n",
+    "public Dictionary<(int, int), int> CountCandidatesPerCell(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Pour chaque cellule vide, comptez le nombre de valeurs candidates\n",
+    "    // apres propagation des contraintes\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "id": "a009c961",
    "cell_type": "code",
    "execution_count": 4,
@@ -1509,6 +1538,35 @@
     "\n",
     "}\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Verifier la reproductibilite du solver\n",
+    "\n",
+    "# Objectif\n",
+    "Lancez le solver probabiliste plusieurs fois sur le meme puzzle et\n",
+    "verifiez si les resultats sont reproductibles.\n",
+    "\n",
+    "# Indice\n",
+    "Fixez le seed aleatoire et comparez les resultats sur 10 executions.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Verifier la reproductibilite du solver\n",
+    "public bool IsSolverReproducible(int[,] puzzle, int numRuns = 10)\n",
+    "{\n",
+    "    // TODO: Lancez le solver plusieurs fois avec le meme seed\n",
+    "    // et verifiez si les resultats sont identiques\n",
+    "    return false; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -3110,6 +3168,35 @@
     "IterativeProbabilisticSolver.Model.NbIterationCells = 1;\n",
     "var mediumSudoku = SudokuHelper.GetSudokus(SudokuDifficulty.Medium).Skip(1).First();\n",
     "SudokuHelper.SolveSudoku(mediumSudoku, iterativeSolver);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les trois solveurs Infer.NET\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances du solver naive, robust et iteratif sur\n",
+    "des puzzles de differentes difficultes.\n",
+    "\n",
+    "# Indice\n",
+    "Mesurez le taux de succes et le temps de resolution pour chaque solver.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer les trois solveurs Infer.NET\n",
+    "public Dictionary<string, (double SuccessRate, double AvgTimeMs)> CompareInferSolvers(List<int[,]> puzzles)\n",
+    "{\n",
+    "    // TODO: Testez les trois solveurs (naive, robust, iteratif) sur les memes puzzles\n",
+    "    // et retournez les statistiques comparatives\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-17-LLM-Python.ipynb
@@ -686,6 +686,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Optimiser le prompt zero-shot\n",
+    "\n",
+    "# Objectif\n",
+    "Modifiez le prompt zero-shot pour ameliorer le taux de succes.\n",
+    "Testez au moins 2 variantes et comparez les resultats.\n",
+    "\n",
+    "# Indice\n",
+    "Ajoutez des instructions plus precises sur le format de sortie attendu.\n",
+    "Testez avec des puzzles faciles pour mesurer l'impact.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Optimiser le prompt zero-shot\n",
+    "def optimized_zero_shot_solve(grid: List[List[int]], client) -> Optional[List[List[int]]]:\n",
+    "    # TODO: Creez un prompt optimise pour resoudre le Sudoku\n",
+    "    # avec un meilleur taux de succes que le prompt zero-shot de base\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "zero-shot-solver",
@@ -1117,6 +1146,35 @@
     "  - Necessite d'executer du code (risque de securite)\n",
     "  - Plus lent (generation + execution)\n",
     "  - Depend de la capacite du LLM a ecrire du code valide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer zero-shot vs few-shot vs code interpreter\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une fonction qui teste les 3 approches sur les memes puzzles\n",
+    "et retourne un tableau comparatif des taux de succes et temps de resolution.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez les fonctions deja definies pour chaque approche et mesurez le temps\n",
+    "avec `time.time()`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Comparer zero-shot vs few-shot vs code interpreter\n",
+    "def compare_llm_approaches(puzzles: List[str], client, limit: int = 3) -> dict:\n",
+    "    # TODO: Testez les 3 approches LLM sur les memes puzzles\n",
+    "    # et retournez un dict avec le taux de succes et le temps moyen pour chacune\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {
@@ -2126,6 +2184,35 @@
     "- Les exemples few-shot doivent contenir au moins 3 etapes de deduction avec explication\n",
     "- Le format de sortie attendu doit etre : `Etape N : (row, col) = valeur -- [explication]`\n",
     "- Gerer le cas ou le LLM ne respecte pas le format demande"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyser les erreurs du LLM\n",
+    "\n",
+    "# Objectif\n",
+    "Analysez les erreurs commises par le LLM quand il echoue a resoudre un puzzle.\n",
+    "Categorisez les types d'erreurs (violation de ligne, colonne, bloc, valeur hors range).\n",
+    "\n",
+    "# Indice\n",
+    "Comparez la grille produite par le LLM avec la solution correcte et identifiez\n",
+    "les cellules en erreur, puis verifiez quelles contraintes sont violees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Analyser les erreurs du LLM\n",
+    "def analyze_llm_errors(predicted: List[List[int]], solution: List[List[int]]) -> dict:\n",
+    "    # TODO: Comparez la grille predite avec la solution\n",
+    "    # et categorisez les erreurs par type (ligne, colonne, bloc, valeur invalide)\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -1646,6 +1646,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyser la robustesse des solveurs face aux puzzles partiels\n",
+    "\n",
+    "# Objectif\n",
+    "Testez comment chaque solveur se comporte quand on augmente progressivement\n",
+    "le nombre de cases vides dans un puzzle (de 30 a 55 cases vides).\n",
+    "\n",
+    "# Indice\n",
+    "Partez d'un puzzle resolu et supprimez aleatoirement un nombre croissant de valeurs.\n",
+    "Mesurez le temps de resolution pour chaque niveau de difficulte artificielle.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Analyser la robustesse des solveurs face aux puzzles partiels\n",
+    "def measure_robustness(solvers: dict, base_puzzle: str, removal_counts: List[int]) -> dict:\n",
+    "    # TODO: Pour chaque nombre de suppressions, creez un puzzle partiel\n",
+    "    # et testez chaque solveur. Retournez les temps de resolution.\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c7ed8a0e",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Csharp.ipynb
@@ -608,6 +608,36 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Construire la matrice de couverture pour un mini-Sudoku\n",
+    "\n",
+    "# Objectif\n",
+    "Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4\n",
+    "avec DlxLib.\n",
+    "\n",
+    "# Indice\n",
+    "Identifiez les 4 types de contraintes et creez les lignes de la matrice\n",
+    "pour chaque assignation (cellule, valeur) possible.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Construire la matrice de couverture pour un mini-Sudoku 4x4\n",
+    "public List<List<int>> BuildMiniSudokuMatrix()\n",
+    "{\n",
+    "    // TODO: Construisez la matrice binaire de couverture exacte\n",
+    "    // pour un Sudoku 4x4 (chiffres 1-4, blocs 2x2)\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6501a974",
    "metadata": {
     "papermill": {
@@ -1044,6 +1074,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Mesurer le nombre de noeuds explores\n",
+    "\n",
+    "# Objectif\n",
+    "Ajoutez un compteur de noeuds dans la classe DlxCustomized pour mesurer\n",
+    "le nombre de noeuds explores pendant la recherche.\n",
+    "\n",
+    "# Indice\n",
+    "Incremente le compteur a chaque appel recursif de la methode de recherche.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Mesurer le nombre de noeuds explores\n",
+    "public int SolveWithNodeCount(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Resolvez le puzzle et retournez le nombre de noeuds explores\n",
+    "    // par l'algorithme Dancing Links\n",
+    "    return 0; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d53f6662",
    "metadata": {
     "papermill": {
@@ -1159,6 +1218,35 @@
     "### Résultats des Tests\n",
     "\n",
     "Les temps d'exécution seront mesurés et comparés pour chaque solver et chaque niveau de difficulté.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer DLX avec le backtracking classique\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances de Dancing Links (DLXLib + custom) avec le\n",
+    "solveur backtracking classique sur des puzzles de differentes difficultes.\n",
+    "\n",
+    "# Indice\n",
+    "Mesurez le temps et le nombre d'operations pour chaque solveur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer DLX avec le backtracking classique\n",
+    "public void CompareDlxVsBacktracking()\n",
+    "{\n",
+    "    // TODO: Lancez les benchmarks comparatifs entre DLX et backtracking\n",
+    "    // sur des puzzles faciles, moyens et difficiles\n",
+    "    // Affichez les resultats dans un tableau\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-2-DancingLinks-Python.ipynb
@@ -295,6 +295,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Construire la matrice de couverture exacte pour un mini-Sudoku\n",
+    "\n",
+    "# Objectif\n",
+    "Construisez manuellement la matrice de couverture exacte pour un Sudoku 4x4\n",
+    "(et non 9x9), ou chaque ligne/colonne/bloc 2x2 doit contenir les chiffres 1 a 4.\n",
+    "\n",
+    "# Indice\n",
+    "Identifiez les 4 types de contraintes (ligne, colonne, bloc, cellule) et\n",
+    "comptez le nombre de colonnes de la matrice. Pour chaque assignation possible\n",
+    "(cellule, valeur), creez une ligne dans la matrice avec des 1 aux colonnes\n",
+    "des contraintes satisfaites.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Construire la matrice de couverture exacte pour un mini-Sudoku 4x4\n",
+    "def build_mini_sudoku_matrix() -> list:\n",
+    "    # TODO: Construisez la matrice binaire de couverture exacte\n",
+    "    # pour un Sudoku 4x4 (chiffres 1-4, blocs 2x2)\n",
+    "    # Retournez une liste de listes (lignes = assignations, colonnes = contraintes)\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-5",
@@ -1295,6 +1327,36 @@
     "3. Alternativement, utiliser des puzzles integres directement dans le code\n",
     "\n",
     "> **Note technique** : Pour la suite du notebook, nous utilisons des puzzles hardcodes dans le code (comme le puzzle de test en section 6.1) pour garantir que les exemples fonctionnent meme sans fichiers externes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyse de complexite de Dancing Links\n",
+    "\n",
+    "# Objectif\n",
+    "Analysez le nombre de noeuds explores par DLX en fonction de la difficulte\n",
+    "du puzzle. Mesurez et comparez avec le backtracking simple.\n",
+    "\n",
+    "# Etape 1\n",
+    "Ajoutez un compteur de noeuds dans la classe DancingLinks.\n",
+    "# Etape 2\n",
+    "Lancez le benchmark et collectez les donnees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Analyse de complexite de Dancing Links\n",
+    "def count_nodes_explored(puzzle_str: str) -> int:\n",
+    "    # TODO: Resolvez le puzzle avec DLX et retournez\n",
+    "    # le nombre de noeuds explores pendant la recherche\n",
+    "    result = 0  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
@@ -309,6 +309,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Implementer une fonction de fitness ponderee\n",
+    "\n",
+    "# Objectif\n",
+    "Creez une fonction de fitness qui pondere differemment les conflits\n",
+    "de lignes, colonnes et blocs (par exemple, penaliser plus les conflits de lignes).\n",
+    "\n",
+    "# Indice\n",
+    "Au lieu de simplement compter le nombre total de conflits, multipliez chaque\n",
+    "type par un coefficient et sommez.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Implementer une fonction de fitness ponderee\n",
+    "public double WeightedFitness(int[,] grid, double rowWeight = 1.0, double colWeight = 1.0, double blockWeight = 1.0)\n",
+    "{\n",
+    "    // TODO: Calculez un score de fitness pondere selon le type de conflit\n",
+    "    return 0.0; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "9d12b48c",
@@ -422,6 +451,35 @@
     "### Premier chromosome simple\n",
     "\n",
     "Pour ce premier essai, nous représentont chaque cellule par un gène à valeur de 1 à 9. L'initialisation tient compte du masque à résoudre, mais pas les opérateurs qui agissent au hasard."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Creer un operateur de mutation swap intra-ligne\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez un operateur de mutation qui echange deux genes dans la meme ligne\n",
+    "du chromosome.\n",
+    "\n",
+    "# Indice\n",
+    "Choisissez une ligne aleatoire, puis deux positions dans cette ligne, et echangez-les.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Creer un operateur de mutation swap intra-ligne\n",
+    "public int[] SwapMutation(int[] chromosome, int gridSize = 9)\n",
+    "{\n",
+    "    // TODO: Choisissez une ligne aleatoire et echangez deux valeurs\n",
+    "    // non fixees dans cette ligne\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -745,6 +803,35 @@
     "### Chromosome : SudokuPermutationsChromosome\n",
     "\n",
     "Le SudokuPermutationsChromosome est un chromosome simple de 9 gènes qui manipule les permutations de lignes du Sudoku. Chaque gène représente une permutation d'une ligne entière, permettant ainsi une exploration plus efficace des solutions potentielles.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les approches par cellules vs permutations\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances des deux types de chromosomes\n",
+    "(cellules vs permutations de lignes) sur les memes puzzles.\n",
+    "\n",
+    "# Indice\n",
+    "Lancez les deux solveurs avec les memes parametres et comparez les taux de succes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer les approches par cellules vs permutations\n",
+    "public Dictionary<string, double> CompareChromosomeTypes(int[,] puzzle, int runs = 5)\n",
+    "{\n",
+    "    // TODO: Testez les deux approches de chromosomes sur le meme puzzle\n",
+    "    // et retournez le taux de succes moyen de chacune\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Csharp.ipynb
@@ -1212,6 +1212,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Calculer l'energie d'une grille partielle\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une variante de la fonction d'energie qui ne compte les conflits\n",
+    "que dans les lignes/colonnes/blocs contenant au moins une valeur non nulle.\n",
+    "\n",
+    "# Indice\n",
+    "Parcourez chaque unite et ignorez celles ou toutes les valeurs sont a 0.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Calculer l'energie d'une grille partielle\n",
+    "public int ComputePartialEnergy(int[,] grid)\n",
+    "{\n",
+    "    // TODO: Compter les conflits uniquement dans les unites non vides\n",
+    "    return 0; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "10ce9ad0",
@@ -1499,6 +1527,34 @@
     "Ce mouvement **preserve la propriete de permutation** de la ligne : puisqu'on ne fait que permuter deux elements, la ligne reste une permutation de 1 a 9.\n",
     "\n",
     "### Implementation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Generer un voisin par echange dans un bloc\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez un operateur de voisinage qui echange deux valeurs non fixees\n",
+    "dans le meme bloc 3x3 au lieu de la meme ligne.\n",
+    "\n",
+    "# Indice\n",
+    "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Generer un voisin par echange dans un bloc\n",
+    "public (int[,] Grid, (int, int) Pos1, (int, int) Pos2) GenerateBlockNeighbor(int[,] grid, bool[,] isFixed, Random rng)\n",
+    "{\n",
+    "    // TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3\n",
+    "    return (null, (0, 0), (0, 0)); // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -2306,6 +2362,34 @@
     "### Comparaison avec les autres solveurs\n",
     "\n",
     "Utilisons l'infrastructure `SudokuHelper.TestSolvers` pour comparer le recuit simule avec le backtracking."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les schemas de refroidissement\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez le schema de refroidissement lineaire et exponentiel.\n",
+    "Mesurez le taux de succes et le temps moyen pour chaque schema.\n",
+    "\n",
+    "# Indice\n",
+    "Pour le schema exponentiel: T = T_init * alpha^step.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer les schemas de refroidissement\n",
+    "public List<double> ExponentialCooling(double T_init, double T_min, double alpha, int maxSteps)\n",
+    "{\n",
+    "    // TODO: Generez la liste de temperatures selon le schema exponentiel\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-4-SimulatedAnnealing-Python.ipynb
@@ -317,6 +317,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Calculer l'energie d'une grille partiellement remplie\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une variante de `compute_energy` qui calcule le nombre de conflits\n",
+    "uniquement pour les lignes, colonnes et blocs non complets.\n",
+    "\n",
+    "# Indice\n",
+    "Parcourir chaque ligne/colonne/bloc et compter les doublons parmi les valeurs non nulles.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Calculer l'energie d'une grille partiellement remplie\n",
+    "def compute_partial_energy(grid: np.ndarray) -> int:\n",
+    "    # TODO: Compter les conflits (doublons) uniquement dans les\n",
+    "    # lignes/colonnes/blocs qui contiennent des valeurs non nulles\n",
+    "    result = 0  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "69b53f0e",
@@ -484,6 +512,35 @@
     "print(SudokuGrid(init_grid))\n",
     "print(f\"\\nEnergie initiale: {compute_energy(init_grid)}\")\n",
     "print(f\"Objectif: energie = 0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Generer un voisin par echange de bloc\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez un operateur de voisinage qui echange deux valeurs non fixees\n",
+    "dans le meme bloc 3x3 (au lieu de la meme ligne).\n",
+    "\n",
+    "# Indice\n",
+    "Choisissez un bloc aleatoire, puis deux cellules non fixees dans ce bloc,\n",
+    "et echangez leurs valeurs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Generer un voisin par echange de bloc\n",
+    "def generate_block_neighbor(grid: np.ndarray, is_fixed: np.ndarray, rng: random.Random) -> Tuple[np.ndarray, Tuple]:\n",
+    "    # TODO: Echangez deux valeurs non fixees dans un meme bloc 3x3\n",
+    "    # Retournez (nouvelle_grille, position_echangee)\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {
@@ -1982,6 +2039,35 @@
    },
    "source": [
     "## 8. Benchmark sur Plusieurs Puzzles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer les schemas de refroidissement\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez le schema de refroidissement lineaire et exponentiel sur les memes puzzles.\n",
+    "\n",
+    "# Etape 1\n",
+    "Implementez un schema de refroidissement exponentiel: T = T_init * alpha^step\n",
+    "# Etape 2\n",
+    "Lancez les benchmarks et comparez les taux de succes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Comparer les schemas de refroidissement\n",
+    "def exponential_cooling(T_init: float, T_min: float, alpha: float, steps: int) -> List[float]:\n",
+    "    # TODO: Generez une liste de temperatures selon le schema exponentiel\n",
+    "    # T_i = T_init * alpha^i, arretez quand T < T_min\n",
+    "    result = []  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -1236,6 +1236,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Mesurer l'impact du nombre de particules\n",
+    "\n",
+    "# Objectif\n",
+    "Testez le solveur PSO avec differentes tailles d'essaim (10, 50, 100, 200)\n",
+    "et analysez l'impact sur le taux de succes et le temps de resolution.\n",
+    "\n",
+    "# Indice\n",
+    "Pour chaque taille, lancez le solveur sur les memes puzzles et comparez les resultats.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Mesurer l'impact du nombre de particules\n",
+    "public Dictionary<int, (double SuccessRate, double AvgTime)> TestSwarmSizes(int[,] puzzle, int[] sizes)\n",
+    "{\n",
+    "    // TODO: Testez differentes tailles d'essaim et mesurez les performances\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "91bdb51f",
@@ -2141,6 +2169,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyser la convergence du PSO\n",
+    "\n",
+    "# Objectif\n",
+    "Tracez la courbe de convergence (erreur minimale dans l'essaim en fonction\n",
+    "des iterations) pour un puzzle facile et un puzzle difficile.\n",
+    "\n",
+    "# Indice\n",
+    "Enregistrez la meilleure fitness a chaque iteration et affichez avec un graphique.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Analyser la convergence du PSO\n",
+    "public List<int> TrackConvergence(int[,] puzzle, int maxIterations = 500)\n",
+    "{\n",
+    "    // TODO: Executez le PSO et enregistrez l'erreur minimale a chaque iteration\n",
+    "    // Retournez la liste des erreurs pour tracer la courbe de convergence\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6175c49c",
    "metadata": {
     "papermill": {
@@ -2285,6 +2342,35 @@
    "id": "efec4e39",
    "source": "## Resume et perspectives\n\nCe notebook a transpose le Particle Swarm Optimization (PSO) en C# pour la resolution de Sudoku, en reprenant l'encodage par blocs et l'architecture Workers/Explorers. Le solveur `PSOSudokuSolver` a demontre une resolution rapide sur les puzzles faciles (61 ms avec 200 organismes), mais aussi une grande variabilite selon l'initialisation : le benchmark sur 5 puzzles a revele des temps allant de 7 ms a 30 secondes, avec un echec sur un puzzle malgre 10 tentatives. La comparaison des configurations (Conservatif, Standard, Agressif) a confirme que l'essentiel de la performance depend de la chance de l'initialisation aleatoire.\n\nLe mecanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait ameliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.\n\nLe notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des metaheuristiques probabilistes aux methodes deterministes de resolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.",
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Optimiser les parametres PSO avec une grille de recherche\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une recherche en grille (grid search) pour trouver les meilleurs\n",
+    "parametres (w, c1, c2) du PSO.\n",
+    "\n",
+    "# Indice\n",
+    "Testez systematiquement des combinaisons de parametres sur un ensemble de puzzles.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Optimiser les parametres PSO avec une grille de recherche\n",
+    "public (double W, double C1, double C2, double SuccessRate) GridSearchPSO(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Testez differentes combinaisons de parametres (w, c1, c2)\n",
+    "    // et retournez les meilleurs parametres trouves\n",
+    "    return (0, 0, 0, 0); // TODO etudiant\n",
+    "}\n"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -431,6 +431,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Calculer le domaine initial d'une cellule\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une fonction qui retourne l'ensemble des valeurs possibles pour\n",
+    "une cellule donnee en tenant compte des contraintes de ligne, colonne et bloc.\n",
+    "\n",
+    "# Indice\n",
+    "Parcourez la ligne, colonne et bloc de la cellule et excluez les valeurs deja presentees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Calculer le domaine initial d'une cellule\n",
+    "public HashSet<int> GetCellDomain(int[,] grid, int row, int col)\n",
+    "{\n",
+    "    // TODO: Retournez l'ensemble des valeurs possibles pour la cellule (row, col)\n",
+    "    // en excluant les valeurs deja presentees dans la ligne, colonne et bloc\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "c20eecf4",
@@ -1084,6 +1113,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Pre-processing par arc-consistance\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez un pre-traitement qui applique AC-3 avant de lancer le solveur\n",
+    "et mesure l'impact sur le temps de resolution.\n",
+    "\n",
+    "# Indice\n",
+    "Appliquez AC-3 pour reduire les domaines, puis lancez le backtracking sur les domaines reduits.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Pre-processing par arc-consistance\n",
+    "public int[,] PreprocessAndSolve(int[,] puzzle)\n",
+    "{\n",
+    "    // TODO: Appliquez AC-3 en pre-processing pour reduire les domaines,\n",
+    "    // puis lancez le backtracking ameliore sur les domaines reduits\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "67b7faef",
@@ -1594,6 +1652,35 @@
     "- **Forward Checking** est le plus rapide sur les puzzles faciles (moins d'overhead que MAC)\n",
     "- **MAC** a le moins de backtracks (5 en moyenne) - plus stable sur les cas difficiles\n",
     "- La difference de temps (37ms vs 54ms) s'inverse sur les puzzles difficiles où MAC excelle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Comparer Forward Checking et MAC sur des puzzles difficiles\n",
+    "\n",
+    "# Objectif\n",
+    "Comparez les performances de Forward Checking et MAC (Maintaining Arc Consistency)\n",
+    "sur au moins 5 puzzles difficiles.\n",
+    "\n",
+    "# Indice\n",
+    "Mesurez le nombre d'appels recursifs et le temps pour chaque methode.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Comparer Forward Checking et MAC\n",
+    "public Dictionary<string, (double AvgTime, int AvgCalls)> CompareFCvsMAC(List<int[,]> puzzles)\n",
+    "{\n",
+    "    // TODO: Lancez les deux solveurs sur chaque puzzle difficile\n",
+    "    // et retournez les statistiques comparatives\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Csharp.ipynb
@@ -290,6 +290,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les singletons caches (Hidden Singles)\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez la detection des Hidden Singles : une valeur qui ne peut aller\n",
+    "que dans une seule cellule d'une unite (ligne/colonne/bloc).\n",
+    "\n",
+    "# Indice\n",
+    "Pour chaque valeur 1-9, comptez dans combien de cellules d'une unite elle peut apparaitre.\n",
+    "Si exactement 1, c'est un Hidden Single.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter les singletons caches (Hidden Singles)\n",
+    "public List<(int Row, int Col, int Value)> FindHiddenSingles(Dictionary<(int, int), HashSet<int>> candidates)\n",
+    "{\n",
+    "    // TODO: Parcourez chaque unite et trouvez les valeurs qui ne peuvent\n",
+    "    // aller que dans une seule cellule de cette unite\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "4hws1ve74wf",
@@ -729,6 +759,36 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Detection de paires nues (Naked Pairs)\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez la detection des Naked Pairs : quand deux cellules d'une meme unite\n",
+    "ont exactement les memes deux candidats, ces valeurs peuvent etre eliminees\n",
+    "des autres cellules de l'unite.\n",
+    "\n",
+    "# Indice\n",
+    "Parcourez chaque unite et cherchez des paires de cellules avec les memes 2 candidats.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Detection de paires nues (Naked Pairs)\n",
+    "public List<((int, int) Cell1, (int, int) Cell2, HashSet<int> Values)> FindNakedPairs(Dictionary<(int, int), HashSet<int>> candidates)\n",
+    "{\n",
+    "    // TODO: Trouvez les paires nues dans le dictionnaire de candidats\n",
+    "    // Retournez la liste des paires trouvees avec leurs positions et valeurs\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c04k6o5ix8g",
    "metadata": {
     "papermill": {
@@ -1043,6 +1103,35 @@
    },
    "source": [
     "Lancons maintenant les benchmarks comparatifs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyser l'impact de la propagation\n",
+    "\n",
+    "# Objectif\n",
+    "Desactivez l'etape de propagation dans le solveur Norvig et comparez\n",
+    "les performances avec et sans propagation.\n",
+    "\n",
+    "# Indice\n",
+    "Modifiez le solveur pour court-circuiter l'etape eliminate et ne garder que assign.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Analyser l'impact de la propagation\n",
+    "public Dictionary<string, double> CompareWithAndWithoutPropagation(List<int[,]> puzzles)\n",
+    "{\n",
+    "    // TODO: Lancez le solveur Norvig avec et sans propagation\n",
+    "    // et comparez les temps moyens de resolution\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-7-Norvig-Python.ipynb
@@ -653,6 +653,36 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Analyser l'impact de la propagation des contraintes\n",
+    "\n",
+    "# Objectif\n",
+    "Desactivez la propagation (eliminate) dans le solveur de Norvig et comparez\n",
+    "le nombre d'appels recursifs et le temps de resolution.\n",
+    "\n",
+    "# Indice\n",
+    "Modifiez la fonction `solve` pour court-circuiter `eliminate` et mesurer\n",
+    "la difference de performance sur les puzzles difficiles.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Analyser l'impact de la propagation des contraintes\n",
+    "def solve_without_propagation(grid: str) -> Optional[Dict[str, str]]:\n",
+    "    # TODO: Implementez un solveur Norvig sans propagation de contraintes\n",
+    "    # (uniquement assign + backtracking, pas d'eliminate)\n",
+    "    # Comparez le nombre d'appels recursifs avec le solveur complet\n",
+    "    result = None  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "cell-8-benchmark",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Csharp.ipynb
@@ -507,6 +507,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les naked singles par difficulte\n",
+    "\n",
+    "# Objectif\n",
+    "Comptez combien de naked singles peuvent etre trouves dans des puzzles\n",
+    "de differentes difficultes.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez FindNakedSingles sur plusieurs puzzles et calculez la moyenne par difficulte.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter les naked singles par difficulte\n",
+    "public Dictionary<string, double> CountNakedSinglesByDifficulty()\n",
+    "{\n",
+    "    // TODO: Pour chaque difficulte, chargez les puzzles et comptez\n",
+    "    // le nombre moyen de naked singles trouves\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "dbfa6bf5",
@@ -1099,6 +1128,37 @@
     "Le meme raisonnement s'applique en inversant lignes et colonnes.\n",
     "\n",
     "**Generalisation** : Le Swordfish (3 lignes, 3 colonnes) et le Jellyfish (4 lignes, 4 colonnes) suivent le meme principe avec plus de lignes/colonnes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Implementer la technique Hidden Pair\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent\n",
+    "que dans deux cellules d'une meme unite, eliminez les autres candidats de ces cellules.\n",
+    "\n",
+    "# Etape 1\n",
+    "Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
+    "# Etape 2\n",
+    "Verifiez si ces 2 valeurs partagent les memes 2 cellules.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Implementer la technique Hidden Pair\n",
+    "public List<((int, int) Cell1, (int, int) Cell2, HashSet<int> Pair)> FindHiddenPairs(int[,] candidatesGrid)\n",
+    "{\n",
+    "    // TODO: Trouvez les hidden pairs dans la grille de candidats\n",
+    "    // Retournez la liste des paires avec leurs positions et valeurs\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -1994,6 +2054,35 @@
     "### Analyse statistique par difficulte\n",
     "\n",
     "Analysons plus en detail les techniques utilisees sur un ensemble de puzzles pour comprendre la distribution des techniques necessaires par niveau de difficulte."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Mesurer le taux de resolution par strategies humaines\n",
+    "\n",
+    "# Objectif\n",
+    "Determinez quel pourcentage de puzzles peut etre resolu uniquement par\n",
+    "strategies humaines (sans backtracking), par difficulte.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez HumanSolver et comptez les puzzles resolus sans atteindre le backtracking.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Mesurer le taux de resolution par strategies humaines\n",
+    "public Dictionary<string, double> MeasureHumanSolveRate()\n",
+    "{\n",
+    "    // TODO: Pour chaque difficulte, testez les puzzles et comptez\n",
+    "    // combien sont resolus uniquement par strategies humaines\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -507,6 +507,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les naked singles par difficulte\n",
+    "\n",
+    "# Objectif\n",
+    "Comptez combien de naked singles peuvent etre trouves dans des puzzles\n",
+    "de differentes difficultes (facile, moyen, difficile).\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez `find_naked_singles` sur plusieurs puzzles de chaque difficulte\n",
+    "et calculez la moyenne.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Compter les naked singles par difficulte\n",
+    "def count_naked_singles_by_difficulty(puzzles: dict) -> dict:\n",
+    "    # TODO: Pour chaque difficulte, chargez les puzzles et comptez\n",
+    "    # le nombre moyen de naked singles trouves\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dafb3cfb",
    "metadata": {
     "papermill": {
@@ -835,6 +864,38 @@
     "HumanSudokuSolver.apply_naked_pair = apply_naked_pair\n",
     "\n",
     "print(\"Methodes Naked Pair ajoutees.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Implementer la technique Hidden Pair\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez la detection des Hidden Pairs : quand deux valeurs n'apparaissent\n",
+    "que dans deux cellules d'une meme unite (ligne/colonne/bloc), ces deux valeurs\n",
+    "peuvent etre eliminees des candidats des autres cellules de l'unite.\n",
+    "\n",
+    "# Etape 1\n",
+    "Parcourez chaque unite et identifiez les valeurs qui n'apparaissent que 2 fois.\n",
+    "# Etape 2\n",
+    "Verifiez si ces 2 valeurs partagent les memes 2 cellules.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Implementer la technique Hidden Pair\n",
+    "def find_hidden_pairs(candidates: np.ndarray) -> list:\n",
+    "    # TODO: Trouvez les hidden pairs dans la grille\n",
+    "    # candidates[i][j] = ensemble des valeurs candidates pour la cellule (i,j)\n",
+    "    # Retournez une liste de (unite_type, position, paire_de_valeurs)\n",
+    "    result = []  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {
@@ -1487,6 +1548,35 @@
    },
    "source": [
     "## 9. Comparaison avec le Backtracking Simple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Mesurer le taux de resolution par strategies humaines seules\n",
+    "\n",
+    "# Objectif\n",
+    "Determinez quel pourcentage de puzzles peut etre resolu uniquement par\n",
+    "strategies humaines (sans backtracking), par difficulte.\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez le solveur `HumanSudokuSolver` et comptez les puzzles ou\n",
+    "`solve()` retourne True sans utiliser le backtracking de secours.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# EXERCICE : Mesurer le taux de resolution par strategies humaines seules\n",
+    "def measure_human_solve_rate(puzzles_by_difficulty: dict) -> dict:\n",
+    "    # TODO: Pour chaque difficulte, testez les puzzles et comptez\n",
+    "    # combien peuvent etre resolus uniquement par strategies humaines\n",
+    "    result = {}  # TODO etudiant\n",
+    "    return result\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb
@@ -446,6 +446,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Compter les contraintes par cellule\n",
+    "\n",
+    "# Objectif\n",
+    "Pour chaque cellule de la grille Sudoku, comptez le nombre de cellules contraintes\n",
+    "(cellules dans la meme ligne, colonne ou bloc).\n",
+    "\n",
+    "# Indice\n",
+    "Utilisez le graphe construit et comptez le degre de chaque noeud.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Compter les contraintes par cellule\n",
+    "public Dictionary<(int, int), int> CountConstraintsPerCell()\n",
+    "{\n",
+    "    // TODO: Pour chaque cellule (i,j), comptez le nombre de voisins dans le graphe\n",
+    "    // Retournez un dictionnaire (cellule -> nombre de contraintes)\n",
+    "    return null; // TODO etudiant\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5ac5cc57",
    "metadata": {
     "papermill": {
@@ -627,6 +656,35 @@
    },
    "source": [
     "### Test du Backtracking Simple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Implementer l'heuristique de degre (Degree Heuristic)\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez l'heuristique de degre qui, en cas d'egalite entre plusieurs variables\n",
+    "MRV, choisit celle qui a le plus de contraintes avec les variables non assignees.\n",
+    "\n",
+    "# Indice\n",
+    "Triez les variables candidats par nombre de voisins non assignes en cas d'egalite MRV.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Implementer l'heuristique de degre\n",
+    "public (int Row, int Col) SelectVariableWithDegreeHeuristic(int[,] grid, bool[,] isFixed)\n",
+    "{\n",
+    "    // TODO: Selectionnez la cellule non assignee avec le plus petit domaine (MRV)\n",
+    "    // En cas d'egalite, choisissez celle avec le plus de voisins non assignes\n",
+    "    return (-1, -1); // TODO etudiant\n",
+    "}\n"
    ]
   },
   {
@@ -1222,6 +1280,35 @@
    },
    "source": [
     "Execution du benchmark de coloration de graphe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercice : Verifier qu'une coloration est valide\n",
+    "\n",
+    "# Objectif\n",
+    "Implementez une fonction qui verifie si une grille completement remplie\n",
+    "est une solution valide du Sudoku en utilisant le graphe.\n",
+    "\n",
+    "# Indice\n",
+    "Pour chaque arete du graphe, verifiez que les deux noeuds ont des couleurs differentes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// EXERCICE : Verifier qu'une coloration est valide\n",
+    "public bool IsColoringValid(int[,] solution)\n",
+    "{\n",
+    "    // TODO: Verifiez que pour chaque paire de cellules contraintes,\n",
+    "    // les valeurs sont differentes\n",
+    "    return false; // TODO etudiant\n",
+    "}\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Rollout #2161 (>=3 exercises per pedagogical notebook) for the Sudoku family.

### Audit results
- **32 notebooks** in Sudoku family (16 Python + 15 C# + 1 Environment)
- **1 exempt** (Sudoku-0-Environment-Csharp)
- **23 notebooks modified** (needed exercise additions)
- **9 notebooks unchanged** (already had >=3 exercises: Choco-Py, Z3-Py, Infer-Py, NN-Py, Genetic-Py, PSO-Py, CSP-Py, GraphColoring-Py, SA-Py)

### Exercise counts
| Notebook | Before | After |
|----------|--------|-------|
| Sudoku-1-Backtracking-Python | 2 | 3 |
| Sudoku-2-DancingLinks-Python | 1 | 3 |
| Sudoku-4-SimulatedAnnealing-Python | 0 | 3 |
| Sudoku-7-Norvig-Python | 2 | 3 |
| Sudoku-8-HumanStrategies-Python | 0 | 3 |
| Sudoku-10-ORTools-Python | 2 | 3 |
| Sudoku-17-LLM-Python | 0 | 3 |
| Sudoku-18-Comparison-Python | 2 | 3 |
| Sudoku-1-Backtracking-Csharp | 0 | 3 |
| Sudoku-2-DancingLinks-Csharp | 0 | 3 |
| Sudoku-3-Genetic-Csharp | 0 | 3 |
| Sudoku-4-SimulatedAnnealing-Csharp | 0 | 3 |
| Sudoku-5-PSO-Csharp | 1 | 4 |
| Sudoku-6-AIMA-CSP-Csharp | 1 | 4 |
| Sudoku-7-Norvig-Csharp | 0 | 3 |
| Sudoku-8-HumanStrategies-Csharp | 0 | 3 |
| Sudoku-9-GraphColoring-Csharp | 0 | 3 |
| Sudoku-10-ORTools-Csharp | 0 | 3 |
| Sudoku-11-Choco-Csharp | 0 | 3 |
| Sudoku-12-Z3-Csharp | 0 | 3 |
| Sudoku-13-SymbolicAutomata-Csharp | 1 | 3 |
| Sudoku-14-BDD-Csharp | 0 | 3 |
| Sudoku-15-Infer-Csharp | 0 | 3 |

### Compliance
- **C.1**: Stubs use `return None` / `return 0` / `return false` / `return null` / `pass` — no `raise NotImplementedError` / `assert False` / `1/0`
- **H.3**: New exercise cells have `execution_count: null` + `outputs: []` (stubs, not yet executed)
- **Exercise-example labeling**: All new cells are stubs (exercises), not examples
- **Pedagogical placement**: Each exercise preceded by markdown with context + objective + hints

### Total impact
- **+56 exercises** added across 23 notebooks
- All 32 Sudoku notebooks now at >=3 exercises
- **56 stub cells** are not executed (C.1 compliant — stubs don't produce errors)

Ref: #2161