### PR TITLE
enrich(Search-2): add 2 exercise stubs (1->3, See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-2-Uninformed.ipynb
@@ -5,10 +5,10 @@
    "id": "8be525c4",
    "metadata": {
     "papermill": {
-     "duration": 0.042623,
-     "end_time": "2026-06-01T12:42:36.774357+00:00",
+     "duration": 0.00665,
+     "end_time": "2026-06-03T04:47:37.984766+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:36.731734+00:00",
+     "start_time": "2026-06-03T04:47:37.978116+00:00",
      "status": "completed"
     },
     "tags": []
@@ -43,16 +43,16 @@
    "id": "31ab7819",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:36.805041Z",
-     "iopub.status.busy": "2026-06-01T12:42:36.804775Z",
-     "iopub.status.idle": "2026-06-01T12:42:37.612193Z",
-     "shell.execute_reply": "2026-06-01T12:42:37.611736Z"
+     "iopub.execute_input": "2026-06-03T04:47:38.011380Z",
+     "iopub.status.busy": "2026-06-03T04:47:38.011091Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.087513Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.086119Z"
     },
     "papermill": {
-     "duration": 0.821689,
-     "end_time": "2026-06-01T12:42:37.612781+00:00",
+     "duration": 1.091057,
+     "end_time": "2026-06-03T04:47:39.088885+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:36.791092+00:00",
+     "start_time": "2026-06-03T04:47:37.997828+00:00",
      "status": "completed"
     },
     "tags": []
@@ -91,10 +91,10 @@
    "id": "e29ffacd",
    "metadata": {
     "papermill": {
-     "duration": 0.007375,
-     "end_time": "2026-06-01T12:42:37.624222+00:00",
+     "duration": 0.007013,
+     "end_time": "2026-06-03T04:47:39.103525+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.616847+00:00",
+     "start_time": "2026-06-03T04:47:39.096512+00:00",
      "status": "completed"
     },
     "tags": []
@@ -129,10 +129,10 @@
    "id": "0963973f",
    "metadata": {
     "papermill": {
-     "duration": 0.012048,
-     "end_time": "2026-06-01T12:42:37.645466+00:00",
+     "duration": 0.008051,
+     "end_time": "2026-06-03T04:47:39.118311+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.633418+00:00",
+     "start_time": "2026-06-03T04:47:39.110260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -157,16 +157,16 @@
    "id": "09f62a40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:37.665394Z",
-     "iopub.status.busy": "2026-06-01T12:42:37.664428Z",
-     "iopub.status.idle": "2026-06-01T12:42:37.677999Z",
-     "shell.execute_reply": "2026-06-01T12:42:37.676115Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.133832Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.133253Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.143062Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.141731Z"
     },
     "papermill": {
-     "duration": 0.025466,
-     "end_time": "2026-06-01T12:42:37.679576+00:00",
+     "duration": 0.018929,
+     "end_time": "2026-06-03T04:47:39.143954+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.654110+00:00",
+     "start_time": "2026-06-03T04:47:39.125025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -237,10 +237,10 @@
    "id": "uok4xsg10p",
    "metadata": {
     "papermill": {
-     "duration": 0.011321,
-     "end_time": "2026-06-01T12:42:37.703803+00:00",
+     "duration": 0.006644,
+     "end_time": "2026-06-03T04:47:39.157250+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.692482+00:00",
+     "start_time": "2026-06-03T04:47:39.150606+00:00",
      "status": "completed"
     },
     "tags": []
@@ -257,16 +257,16 @@
    "id": "9627a2ca",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:37.724319Z",
-     "iopub.status.busy": "2026-06-01T12:42:37.723462Z",
-     "iopub.status.idle": "2026-06-01T12:42:37.736746Z",
-     "shell.execute_reply": "2026-06-01T12:42:37.736094Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.172010Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.171538Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.178261Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.177077Z"
     },
     "papermill": {
-     "duration": 0.026717,
-     "end_time": "2026-06-01T12:42:37.739540+00:00",
+     "duration": 0.015067,
+     "end_time": "2026-06-03T04:47:39.179174+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.712823+00:00",
+     "start_time": "2026-06-03T04:47:39.164107+00:00",
      "status": "completed"
     },
     "tags": []
@@ -313,10 +313,10 @@
    "id": "9k59b7qh66s",
    "metadata": {
     "papermill": {
-     "duration": 0.011111,
-     "end_time": "2026-06-01T12:42:37.761505+00:00",
+     "duration": 0.006483,
+     "end_time": "2026-06-03T04:47:39.194190+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.750394+00:00",
+     "start_time": "2026-06-03T04:47:39.187707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -333,16 +333,16 @@
    "id": "1d63afc9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:37.788137Z",
-     "iopub.status.busy": "2026-06-01T12:42:37.786668Z",
-     "iopub.status.idle": "2026-06-01T12:42:37.813577Z",
-     "shell.execute_reply": "2026-06-01T12:42:37.811689Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.209908Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.209490Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.218727Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.217211Z"
     },
     "papermill": {
-     "duration": 0.046699,
-     "end_time": "2026-06-01T12:42:37.817483+00:00",
+     "duration": 0.018551,
+     "end_time": "2026-06-03T04:47:39.219843+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.770784+00:00",
+     "start_time": "2026-06-03T04:47:39.201292+00:00",
      "status": "completed"
     },
     "tags": []
@@ -419,10 +419,10 @@
    "id": "mibeo465qf",
    "metadata": {
     "papermill": {
-     "duration": 0.015449,
-     "end_time": "2026-06-01T12:42:37.865123+00:00",
+     "duration": 0.006468,
+     "end_time": "2026-06-03T04:47:39.232756+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.849674+00:00",
+     "start_time": "2026-06-03T04:47:39.226288+00:00",
      "status": "completed"
     },
     "tags": []
@@ -439,16 +439,16 @@
    "id": "f82b4d1e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:37.900685Z",
-     "iopub.status.busy": "2026-06-01T12:42:37.899476Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.093335Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.092305Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.248580Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.248192Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.517907Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.516727Z"
     },
     "papermill": {
-     "duration": 0.220296,
-     "end_time": "2026-06-01T12:42:38.099026+00:00",
+     "duration": 0.279359,
+     "end_time": "2026-06-03T04:47:39.518705+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:37.878730+00:00",
+     "start_time": "2026-06-03T04:47:39.239346+00:00",
      "status": "completed"
     },
     "tags": []
@@ -535,10 +535,10 @@
    "id": "65e83b44",
    "metadata": {
     "papermill": {
-     "duration": 0.031883,
-     "end_time": "2026-06-01T12:42:38.161412+00:00",
+     "duration": 0.006492,
+     "end_time": "2026-06-03T04:47:39.532165+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.129529+00:00",
+     "start_time": "2026-06-03T04:47:39.525673+00:00",
      "status": "completed"
     },
     "tags": []
@@ -562,16 +562,16 @@
    "id": "715f3c28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.202836Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.202666Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.216637Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.214363Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.548475Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.548063Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.555618Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.554715Z"
     },
     "papermill": {
-     "duration": 0.029443,
-     "end_time": "2026-06-01T12:42:38.218210+00:00",
+     "duration": 0.01716,
+     "end_time": "2026-06-03T04:47:39.556482+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.188767+00:00",
+     "start_time": "2026-06-03T04:47:39.539322+00:00",
      "status": "completed"
     },
     "tags": []
@@ -639,10 +639,10 @@
    "id": "a11be67e",
    "metadata": {
     "papermill": {
-     "duration": 0.029964,
-     "end_time": "2026-06-01T12:42:38.280552+00:00",
+     "duration": 0.006782,
+     "end_time": "2026-06-03T04:47:39.570700+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.250588+00:00",
+     "start_time": "2026-06-03T04:47:39.563918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -674,16 +674,16 @@
    "id": "aabbe221",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.338374Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.338203Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.351661Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.348119Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.586437Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.586017Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.595465Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.594394Z"
     },
     "papermill": {
-     "duration": 0.031215,
-     "end_time": "2026-06-01T12:42:38.352724+00:00",
+     "duration": 0.018786,
+     "end_time": "2026-06-03T04:47:39.596302+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.321509+00:00",
+     "start_time": "2026-06-03T04:47:39.577516+00:00",
      "status": "completed"
     },
     "tags": []
@@ -754,10 +754,10 @@
    "id": "hhe2df30ijf",
    "metadata": {
     "papermill": {
-     "duration": 0.009218,
-     "end_time": "2026-06-01T12:42:38.370696+00:00",
+     "duration": 0.007001,
+     "end_time": "2026-06-03T04:47:39.611954+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.361478+00:00",
+     "start_time": "2026-06-03T04:47:39.604953+00:00",
      "status": "completed"
     },
     "tags": []
@@ -772,16 +772,16 @@
    "id": "c24081b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.390340Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.390133Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.393588Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.392980Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.626849Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.626493Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.631715Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.630667Z"
     },
     "papermill": {
-     "duration": 0.015616,
-     "end_time": "2026-06-01T12:42:38.394629+00:00",
+     "duration": 0.013802,
+     "end_time": "2026-06-03T04:47:39.632644+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.379013+00:00",
+     "start_time": "2026-06-03T04:47:39.618842+00:00",
      "status": "completed"
     },
     "tags": []
@@ -803,7 +803,7 @@
       "  Noeuds explores  : 2\n",
       "  Noeuds generes   : 6\n",
       "  Frontiere max    : 4\n",
-      "  Temps            : 0.05 ms\n"
+      "  Temps            : 0.06 ms\n"
      ]
     }
    ],
@@ -823,10 +823,10 @@
    "id": "f9568757",
    "metadata": {
     "papermill": {
-     "duration": 0.008416,
-     "end_time": "2026-06-01T12:42:38.412326+00:00",
+     "duration": 0.006991,
+     "end_time": "2026-06-03T04:47:39.646509+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.403910+00:00",
+     "start_time": "2026-06-03T04:47:39.639518+00:00",
      "status": "completed"
     },
     "tags": []
@@ -856,16 +856,16 @@
    "id": "8ef67017",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.431467Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.431207Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.691371Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.690101Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.663796Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.663355Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.862258Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.861084Z"
     },
     "papermill": {
-     "duration": 0.271008,
-     "end_time": "2026-06-01T12:42:38.692428+00:00",
+     "duration": 0.208963,
+     "end_time": "2026-06-03T04:47:39.863220+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.421420+00:00",
+     "start_time": "2026-06-03T04:47:39.654257+00:00",
      "status": "completed"
     },
     "tags": []
@@ -895,10 +895,10 @@
    "id": "f77a0545",
    "metadata": {
     "papermill": {
-     "duration": 0.027794,
-     "end_time": "2026-06-01T12:42:38.738187+00:00",
+     "duration": 0.007541,
+     "end_time": "2026-06-03T04:47:39.879615+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.710393+00:00",
+     "start_time": "2026-06-03T04:47:39.872074+00:00",
      "status": "completed"
     },
     "tags": []
@@ -931,16 +931,16 @@
    "id": "db3237fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.792644Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.791965Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.808839Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.806633Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.897636Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.897370Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.906561Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.905292Z"
     },
     "papermill": {
-     "duration": 0.04614,
-     "end_time": "2026-06-01T12:42:38.811311+00:00",
+     "duration": 0.01964,
+     "end_time": "2026-06-03T04:47:39.907452+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.765171+00:00",
+     "start_time": "2026-06-03T04:47:39.887812+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1013,10 +1013,10 @@
    "id": "0d8xpt8gkfbp",
    "metadata": {
     "papermill": {
-     "duration": 0.017044,
-     "end_time": "2026-06-01T12:42:38.844155+00:00",
+     "duration": 0.007552,
+     "end_time": "2026-06-03T04:47:39.922629+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.827111+00:00",
+     "start_time": "2026-06-03T04:47:39.915077+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1031,16 +1031,16 @@
    "id": "4b6ee0a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.866009Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.865779Z",
-     "iopub.status.idle": "2026-06-01T12:42:38.871196Z",
-     "shell.execute_reply": "2026-06-01T12:42:38.870003Z"
+     "iopub.execute_input": "2026-06-03T04:47:39.940365Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.940015Z",
+     "iopub.status.idle": "2026-06-03T04:47:39.945358Z",
+     "shell.execute_reply": "2026-06-03T04:47:39.944158Z"
     },
     "papermill": {
-     "duration": 0.015981,
-     "end_time": "2026-06-01T12:42:38.871855+00:00",
+     "duration": 0.015537,
+     "end_time": "2026-06-03T04:47:39.946206+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.855874+00:00",
+     "start_time": "2026-06-03T04:47:39.930669+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1064,7 +1064,7 @@
       "  Noeuds explores  : 4\n",
       "  Noeuds generes   : 11\n",
       "  Frontiere max    : 5\n",
-      "  Temps            : 0.11 ms\n"
+      "  Temps            : 0.10 ms\n"
      ]
     }
    ],
@@ -1082,10 +1082,10 @@
    "id": "65d43801",
    "metadata": {
     "papermill": {
-     "duration": 0.023051,
-     "end_time": "2026-06-01T12:42:38.912253+00:00",
+     "duration": 0.007861,
+     "end_time": "2026-06-03T04:47:39.962007+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.889202+00:00",
+     "start_time": "2026-06-03T04:47:39.954146+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1110,21 +1110,121 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "338f3840",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008306,
+     "end_time": "2026-06-03T04:47:39.978141+00:00",
+     "exception": false,
+     "start_time": "2026-06-03T04:47:39.969835+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 4 : DFS avec limite de profondeur\n",
+    "\n",
+    "**Objectif** : Implementez `dfs_limited`, une variante de DFS qui s'arrete apres une profondeur maximale donnee. Cette variante est la brique de base de l'algorithme IDDFS.\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Implementez `dfs_limited(problem, max_depth)` qui explore en profondeur mais s'arrete a `max_depth`\n",
+    "2. Testez sur le trajet Bordeaux -> Strasbourg avec differentes limites (1, 2, 3, 4)\n",
+    "3. Observez a partir de quelle profondeur la solution est trouvee\n",
+    "\n",
+    "**Indices** :\n",
+    "- Inspirez-vous de `depth_first_search` mais ajoutez un test `node.depth >= max_depth`\n",
+    "- Utilisez `GraphProblem('Bordeaux', 'Strasbourg', france_graph)`\n",
+    "- La solution est a profondeur 2 (Bordeaux -> Paris -> Strasbourg)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "69af443a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-03T04:47:39.996590Z",
+     "iopub.status.busy": "2026-06-03T04:47:39.996229Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.001973Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.000764Z"
+    },
+    "papermill": {
+     "duration": 0.016317,
+     "end_time": "2026-06-03T04:47:40.002861+00:00",
+     "exception": false,
+     "start_time": "2026-06-03T04:47:39.986544+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Exercice 4 : DFS avec limite de profondeur ---\n",
+    "\n",
+    "def dfs_limited(problem, max_depth, verbose=False):\n",
+    "    \"\"\"\n",
+    "    Recherche en profondeur avec limite de profondeur.\n",
+    "    \n",
+    "    TODO etudiant : implementez cette fonction\n",
+    "    \n",
+    "    Args:\n",
+    "        problem: Probleme de recherche (GraphProblem)\n",
+    "        max_depth: Profondeur maximale d'exploration\n",
+    "        verbose: Afficher les etapes\n",
+    "    \n",
+    "    Returns:\n",
+    "        SearchResult ou None si pas de solution a cette profondeur\n",
+    "    \n",
+    "    Indices :\n",
+    "        - Inspirez-vous de depth_first_search ci-dessus\n",
+    "        - Ajoutez un test : si node.depth >= max_depth, ne pas expanser ce noeud\n",
+    "        - Retournez None si la solution n'est pas trouvee a cette profondeur\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer le DFS avec limite\n",
+    "    # Etape 1 : initialiser noeud, frontiere (pile LIFO), explored (set)\n",
+    "    # Etape 2 : boucle principale (retirer sommet de la pile)\n",
+    "    # Etape 3 : si goal_test -> retourner SearchResult\n",
+    "    # Etape 4 : si node.depth < max_depth -> expanser et empiler les enfants\n",
+    "    # Etape 5 : si frontiere vide -> retourner None\n",
+    "    return None  # TODO etudiant : remplacer\n",
+    "\n",
+    "# Test avec differentes profondeurs\n",
+    "# problem_test = GraphProblem('Bordeaux', 'Strasbourg', france_graph)\n",
+    "# for depth in [1, 2, 3, 4]:\n",
+    "#     result = dfs_limited(problem_test, max_depth=depth)\n",
+    "#     if result and result.found:\n",
+    "#         print(f\"Profondeur {depth}: TROUVE - {result.path} (cout={result.cost})\")\n",
+    "#     else:\n",
+    "#         print(f\"Profondeur {depth}: pas de solution\")\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "72cd4ec3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:38.957154Z",
-     "iopub.status.busy": "2026-06-01T12:42:38.956878Z",
-     "iopub.status.idle": "2026-06-01T12:42:39.213463Z",
-     "shell.execute_reply": "2026-06-01T12:42:39.211531Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.020255Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.019903Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.210344Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.209185Z"
     },
     "papermill": {
-     "duration": 0.27543,
-     "end_time": "2026-06-01T12:42:39.214516+00:00",
+     "duration": 0.200516,
+     "end_time": "2026-06-03T04:47:40.211283+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:38.939086+00:00",
+     "start_time": "2026-06-03T04:47:40.010767+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1154,10 +1254,10 @@
    "id": "8b20329a",
    "metadata": {
     "papermill": {
-     "duration": 0.013251,
-     "end_time": "2026-06-01T12:42:39.239281+00:00",
+     "duration": 0.008978,
+     "end_time": "2026-06-03T04:47:40.229825+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.226030+00:00",
+     "start_time": "2026-06-03T04:47:40.220847+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1170,20 +1270,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "c47a96a0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:39.271178Z",
-     "iopub.status.busy": "2026-06-01T12:42:39.270868Z",
-     "iopub.status.idle": "2026-06-01T12:42:39.644972Z",
-     "shell.execute_reply": "2026-06-01T12:42:39.643922Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.249950Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.249704Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.451592Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.450430Z"
     },
     "papermill": {
-     "duration": 0.390516,
-     "end_time": "2026-06-01T12:42:39.645885+00:00",
+     "duration": 0.213295,
+     "end_time": "2026-06-03T04:47:40.452390+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.255369+00:00",
+     "start_time": "2026-06-03T04:47:40.239095+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1302,10 +1402,10 @@
    "id": "9ec47c6b",
    "metadata": {
     "papermill": {
-     "duration": 0.011377,
-     "end_time": "2026-06-01T12:42:39.668933+00:00",
+     "duration": 0.010608,
+     "end_time": "2026-06-03T04:47:40.473793+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.657556+00:00",
+     "start_time": "2026-06-03T04:47:40.463185+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1331,10 +1431,10 @@
    "id": "22e34d1b",
    "metadata": {
     "papermill": {
-     "duration": 0.01117,
-     "end_time": "2026-06-01T12:42:39.692200+00:00",
+     "duration": 0.010463,
+     "end_time": "2026-06-03T04:47:40.494490+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.681030+00:00",
+     "start_time": "2026-06-03T04:47:40.484027+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1362,20 +1462,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "b9f5f010",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:39.715901Z",
-     "iopub.status.busy": "2026-06-01T12:42:39.715551Z",
-     "iopub.status.idle": "2026-06-01T12:42:39.725261Z",
-     "shell.execute_reply": "2026-06-01T12:42:39.724217Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.517082Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.516699Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.526167Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.524891Z"
     },
     "papermill": {
-     "duration": 0.022747,
-     "end_time": "2026-06-01T12:42:39.726079+00:00",
+     "duration": 0.022263,
+     "end_time": "2026-06-03T04:47:40.527142+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.703332+00:00",
+     "start_time": "2026-06-03T04:47:40.504879+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1451,10 +1551,10 @@
    "id": "dh1xok4wczj",
    "metadata": {
     "papermill": {
-     "duration": 0.015365,
-     "end_time": "2026-06-01T12:42:39.753693+00:00",
+     "duration": 0.010265,
+     "end_time": "2026-06-03T04:47:40.547447+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.738328+00:00",
+     "start_time": "2026-06-03T04:47:40.537182+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1465,20 +1565,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "53f6b1a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:39.781179Z",
-     "iopub.status.busy": "2026-06-01T12:42:39.780922Z",
-     "iopub.status.idle": "2026-06-01T12:42:39.786890Z",
-     "shell.execute_reply": "2026-06-01T12:42:39.785767Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.570474Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.570082Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.575752Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.574459Z"
     },
     "papermill": {
-     "duration": 0.019863,
-     "end_time": "2026-06-01T12:42:39.787906+00:00",
+     "duration": 0.018563,
+     "end_time": "2026-06-03T04:47:40.576665+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.768043+00:00",
+     "start_time": "2026-06-03T04:47:40.558102+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1508,7 +1608,7 @@
       "  Noeuds explores  : 10\n",
       "  Noeuds generes   : 31\n",
       "  Frontiere max    : 6\n",
-      "  Temps            : 0.25 ms\n"
+      "  Temps            : 0.20 ms\n"
      ]
     }
    ],
@@ -1526,10 +1626,10 @@
    "id": "04c1e915",
    "metadata": {
     "papermill": {
-     "duration": 0.011253,
-     "end_time": "2026-06-01T12:42:39.810446+00:00",
+     "duration": 0.009483,
+     "end_time": "2026-06-03T04:47:40.595579+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.799193+00:00",
+     "start_time": "2026-06-03T04:47:40.586096+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1555,20 +1655,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "c1bf61c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:39.837815Z",
-     "iopub.status.busy": "2026-06-01T12:42:39.837430Z",
-     "iopub.status.idle": "2026-06-01T12:42:40.538995Z",
-     "shell.execute_reply": "2026-06-01T12:42:40.537943Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.617936Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.617558Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.796438Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.795377Z"
     },
     "papermill": {
-     "duration": 0.718185,
-     "end_time": "2026-06-01T12:42:40.539750+00:00",
+     "duration": 0.191824,
+     "end_time": "2026-06-03T04:47:40.797225+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:39.821565+00:00",
+     "start_time": "2026-06-03T04:47:40.605401+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1598,10 +1698,10 @@
    "id": "d70d0737",
    "metadata": {
     "papermill": {
-     "duration": 0.025285,
-     "end_time": "2026-06-01T12:42:40.587399+00:00",
+     "duration": 0.008885,
+     "end_time": "2026-06-03T04:47:40.816616+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:40.562114+00:00",
+     "start_time": "2026-06-03T04:47:40.807731+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1640,20 +1740,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "e353dad2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:40.632182Z",
-     "iopub.status.busy": "2026-06-01T12:42:40.631593Z",
-     "iopub.status.idle": "2026-06-01T12:42:40.668161Z",
-     "shell.execute_reply": "2026-06-01T12:42:40.663569Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.835709Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.835324Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.844388Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.843204Z"
     },
     "papermill": {
-     "duration": 0.059307,
-     "end_time": "2026-06-01T12:42:40.669558+00:00",
+     "duration": 0.019828,
+     "end_time": "2026-06-03T04:47:40.845142+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:40.610251+00:00",
+     "start_time": "2026-06-03T04:47:40.825314+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1750,10 +1850,10 @@
    "id": "51lrqc0do0m",
    "metadata": {
     "papermill": {
-     "duration": 0.045594,
-     "end_time": "2026-06-01T12:42:40.729368+00:00",
+     "duration": 0.011162,
+     "end_time": "2026-06-03T04:47:40.865447+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:40.683774+00:00",
+     "start_time": "2026-06-03T04:47:40.854285+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1764,20 +1864,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "c2a90d58",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:40.955880Z",
-     "iopub.status.busy": "2026-06-01T12:42:40.952065Z",
-     "iopub.status.idle": "2026-06-01T12:42:40.986656Z",
-     "shell.execute_reply": "2026-06-01T12:42:40.981935Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.888479Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.888235Z",
+     "iopub.status.idle": "2026-06-03T04:47:40.893286Z",
+     "shell.execute_reply": "2026-06-03T04:47:40.892364Z"
     },
     "papermill": {
-     "duration": 0.164723,
-     "end_time": "2026-06-01T12:42:40.991897+00:00",
+     "duration": 0.017648,
+     "end_time": "2026-06-03T04:47:40.894056+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:40.827174+00:00",
+     "start_time": "2026-06-03T04:47:40.876408+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1800,7 +1900,7 @@
       "  Noeuds explores  : 3\n",
       "  Noeuds generes   : 7\n",
       "  Frontiere max    : 2\n",
-      "  Temps            : 0.55 ms\n"
+      "  Temps            : 0.08 ms\n"
      ]
     }
    ],
@@ -1818,10 +1918,10 @@
    "id": "8654007e",
    "metadata": {
     "papermill": {
-     "duration": 0.030316,
-     "end_time": "2026-06-01T12:42:41.046295+00:00",
+     "duration": 0.012204,
+     "end_time": "2026-06-03T04:47:40.916309+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:41.015979+00:00",
+     "start_time": "2026-06-03T04:47:40.904105+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1849,20 +1949,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "a511d54f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:41.199302Z",
-     "iopub.status.busy": "2026-06-01T12:42:41.198760Z",
-     "iopub.status.idle": "2026-06-01T12:42:41.909228Z",
-     "shell.execute_reply": "2026-06-01T12:42:41.900385Z"
+     "iopub.execute_input": "2026-06-03T04:47:40.940404Z",
+     "iopub.status.busy": "2026-06-03T04:47:40.939967Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.123095Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.122068Z"
     },
     "papermill": {
-     "duration": 0.789379,
-     "end_time": "2026-06-01T12:42:41.914675+00:00",
+     "duration": 0.196727,
+     "end_time": "2026-06-03T04:47:41.123987+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:41.125296+00:00",
+     "start_time": "2026-06-03T04:47:40.927260+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1892,10 +1992,10 @@
    "id": "6b351a0a",
    "metadata": {
     "papermill": {
-     "duration": 0.14094,
-     "end_time": "2026-06-01T12:42:42.166639+00:00",
+     "duration": 0.011572,
+     "end_time": "2026-06-03T04:47:41.146534+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.025699+00:00",
+     "start_time": "2026-06-03T04:47:41.134962+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1908,20 +2008,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "a6f00c7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:42.364147Z",
-     "iopub.status.busy": "2026-06-01T12:42:42.363890Z",
-     "iopub.status.idle": "2026-06-01T12:42:42.370772Z",
-     "shell.execute_reply": "2026-06-01T12:42:42.369743Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.170304Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.170019Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.177647Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.176423Z"
     },
     "papermill": {
-     "duration": 0.052781,
-     "end_time": "2026-06-01T12:42:42.371683+00:00",
+     "duration": 0.020949,
+     "end_time": "2026-06-03T04:47:41.178534+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.318902+00:00",
+     "start_time": "2026-06-03T04:47:41.157585+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1976,10 +2076,10 @@
    "id": "0534d8ca",
    "metadata": {
     "papermill": {
-     "duration": 0.017115,
-     "end_time": "2026-06-01T12:42:42.402668+00:00",
+     "duration": 0.011271,
+     "end_time": "2026-06-03T04:47:41.202039+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.385553+00:00",
+     "start_time": "2026-06-03T04:47:41.190768+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2005,10 +2105,10 @@
    "id": "c90f52b8",
    "metadata": {
     "papermill": {
-     "duration": 0.035147,
-     "end_time": "2026-06-01T12:42:42.453891+00:00",
+     "duration": 0.012494,
+     "end_time": "2026-06-03T04:47:41.226951+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.418744+00:00",
+     "start_time": "2026-06-03T04:47:41.214457+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2021,20 +2121,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "a9239dba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:42.593788Z",
-     "iopub.status.busy": "2026-06-01T12:42:42.593412Z",
-     "iopub.status.idle": "2026-06-01T12:42:42.603196Z",
-     "shell.execute_reply": "2026-06-01T12:42:42.602283Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.252937Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.252642Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.261226Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.260199Z"
     },
     "papermill": {
-     "duration": 0.061606,
-     "end_time": "2026-06-01T12:42:42.604072+00:00",
+     "duration": 0.022782,
+     "end_time": "2026-06-03T04:47:41.262068+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.542466+00:00",
+     "start_time": "2026-06-03T04:47:41.239286+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2130,10 +2230,10 @@
    "id": "de0f681a",
    "metadata": {
     "papermill": {
-     "duration": 0.014256,
-     "end_time": "2026-06-01T12:42:42.632155+00:00",
+     "duration": 0.011983,
+     "end_time": "2026-06-03T04:47:41.285306+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.617899+00:00",
+     "start_time": "2026-06-03T04:47:41.273323+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2159,20 +2259,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "12aac53c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:42.667763Z",
-     "iopub.status.busy": "2026-06-01T12:42:42.666730Z",
-     "iopub.status.idle": "2026-06-01T12:42:42.678555Z",
-     "shell.execute_reply": "2026-06-01T12:42:42.677227Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.310062Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.309689Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.319020Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.317871Z"
     },
     "papermill": {
-     "duration": 0.034453,
-     "end_time": "2026-06-01T12:42:42.679575+00:00",
+     "duration": 0.022898,
+     "end_time": "2026-06-03T04:47:41.319762+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.645122+00:00",
+     "start_time": "2026-06-03T04:47:41.296864+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2222,10 +2322,10 @@
    "id": "sv3nbetj1ts",
    "metadata": {
     "papermill": {
-     "duration": 0.081691,
-     "end_time": "2026-06-01T12:42:42.791591+00:00",
+     "duration": 0.011119,
+     "end_time": "2026-06-03T04:47:41.341192+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.709900+00:00",
+     "start_time": "2026-06-03T04:47:41.330073+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2236,20 +2336,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "f0dfb19c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:43.010861Z",
-     "iopub.status.busy": "2026-06-01T12:42:43.009783Z",
-     "iopub.status.idle": "2026-06-01T12:42:43.750267Z",
-     "shell.execute_reply": "2026-06-01T12:42:43.744190Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.365595Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.365353Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.648032Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.646544Z"
     },
     "papermill": {
-     "duration": 0.859302,
-     "end_time": "2026-06-01T12:42:43.756198+00:00",
+     "duration": 0.296796,
+     "end_time": "2026-06-03T04:47:41.649008+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:42.896896+00:00",
+     "start_time": "2026-06-03T04:47:41.352212+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2316,10 +2416,10 @@
    "id": "8a658937",
    "metadata": {
     "papermill": {
-     "duration": 0.113274,
-     "end_time": "2026-06-01T12:42:43.977217+00:00",
+     "duration": 0.011216,
+     "end_time": "2026-06-03T04:47:41.672955+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:43.863943+00:00",
+     "start_time": "2026-06-03T04:47:41.661739+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2344,13 +2444,96 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d6fc8e21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.013108,
+     "end_time": "2026-06-03T04:47:41.698678+00:00",
+     "exception": false,
+     "start_time": "2026-06-03T04:47:41.685570+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 5 : Comparaison experimentale personnalisee\n",
+    "\n",
+    "**Objectif** : Comparez les 4 algorithmes sur un trajet de votre choix et analysez les resultats.\n",
+    "\n",
+    "Choisissez un trajet dans le graphe `france_graph` qui met en evidence une difference notable entre les algorithmes (par exemple un trajet ou UCS trouve un chemin nettement moins couteux que BFS).\n",
+    "\n",
+    "**Consignes** :\n",
+    "1. Choisissez un depart et une arrivee dans `france_graph`\n",
+    "2. Executez les 4 algorithmes (BFS, DFS, UCS, IDDFS) sur ce trajet\n",
+    "3. Affichez un tableau comparatif : chemin, cout, noeuds explores\n",
+    "4. Identifiez quel algorithme trouve le chemin optimal et pourquoi\n",
+    "\n",
+    "**Indices** :\n",
+    "- Un trajet long (4+ etapes) montrera mieux les differences\n",
+    "- Comparez le cout BFS vs UCS pour voir l'impact des couts non uniformes\n",
+    "- Utilisez `SearchResult.display()` pour afficher chaque resultat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "87f7a692",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-03T04:47:41.725479Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.725109Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.730563Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.729382Z"
+    },
+    "papermill": {
+     "duration": 0.020499,
+     "end_time": "2026-06-03T04:47:41.731421+00:00",
+     "exception": false,
+     "start_time": "2026-06-03T04:47:41.710922+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Exercice 5 : Comparaison experimentale personnalisee ---\n",
+    "\n",
+    "# TODO etudiant : choisissez un depart et une arrivee\n",
+    "depart = None    # TODO etudiant : remplacer par une ville (ex: 'Grenoble')\n",
+    "arrivee = None   # TODO etudiant : remplacer par une ville (ex: 'Lille')\n",
+    "\n",
+    "# TODO etudiant : instanciez le probleme\n",
+    "# problem_custom = GraphProblem(depart, arrivee, france_graph)\n",
+    "\n",
+    "# TODO etudiant : executez les 4 algorithmes\n",
+    "# Etape 1 : res_bfs = breadth_first_search(problem_custom)\n",
+    "# Etape 2 : res_dfs = depth_first_search(problem_custom)\n",
+    "# Etape 3 : res_ucs = uniform_cost_search(problem_custom)\n",
+    "# Etape 4 : res_iddfs = iterative_deepening_search(problem_custom)\n",
+    "\n",
+    "# TODO etudiant : affichez un tableau comparatif\n",
+    "# Indice : utilisez result.display() pour chaque resultat\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "976cd451",
    "metadata": {
     "papermill": {
-     "duration": 0.041917,
-     "end_time": "2026-06-01T12:42:44.130746+00:00",
+     "duration": 0.018806,
+     "end_time": "2026-06-03T04:47:41.763257+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.088829+00:00",
+     "start_time": "2026-06-03T04:47:41.744451+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2382,10 +2565,10 @@
    "id": "7b0672bc",
    "metadata": {
     "papermill": {
-     "duration": 0.12022,
-     "end_time": "2026-06-01T12:42:44.333518+00:00",
+     "duration": 0.014043,
+     "end_time": "2026-06-03T04:47:41.792819+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.213298+00:00",
+     "start_time": "2026-06-03T04:47:41.778776+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2426,20 +2609,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "02105bc6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:44.545171Z",
-     "iopub.status.busy": "2026-06-01T12:42:44.542658Z",
-     "iopub.status.idle": "2026-06-01T12:42:44.590843Z",
-     "shell.execute_reply": "2026-06-01T12:42:44.579571Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.820505Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.819965Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.827329Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.825984Z"
     },
     "papermill": {
-     "duration": 0.171512,
-     "end_time": "2026-06-01T12:42:44.599405+00:00",
+     "duration": 0.02205,
+     "end_time": "2026-06-03T04:47:41.828355+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.427893+00:00",
+     "start_time": "2026-06-03T04:47:41.806305+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2465,7 +2648,7 @@
       "  Noeuds explores  : 6\n",
       "  Noeuds generes   : 13\n",
       "  Frontiere max    : 3\n",
-      "  Temps            : 1.35 ms\n"
+      "  Temps            : 0.12 ms\n"
      ]
     }
    ],
@@ -2497,10 +2680,10 @@
    "id": "10ca099d",
    "metadata": {
     "papermill": {
-     "duration": 0.030359,
-     "end_time": "2026-06-01T12:42:44.754277+00:00",
+     "duration": 0.012486,
+     "end_time": "2026-06-03T04:47:41.853785+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.723918+00:00",
+     "start_time": "2026-06-03T04:47:41.841299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2518,10 +2701,10 @@
    "id": "147da53e",
    "metadata": {
     "papermill": {
-     "duration": 0.024543,
-     "end_time": "2026-06-01T12:42:44.793256+00:00",
+     "duration": 0.013464,
+     "end_time": "2026-06-03T04:47:41.880697+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.768713+00:00",
+     "start_time": "2026-06-03T04:47:41.867233+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2538,20 +2721,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "7cea7d47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:44.874181Z",
-     "iopub.status.busy": "2026-06-01T12:42:44.870935Z",
-     "iopub.status.idle": "2026-06-01T12:42:44.981508Z",
-     "shell.execute_reply": "2026-06-01T12:42:44.977944Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.919690Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.919317Z",
+     "iopub.status.idle": "2026-06-03T04:47:41.941049Z",
+     "shell.execute_reply": "2026-06-03T04:47:41.939366Z"
     },
     "papermill": {
-     "duration": 0.161188,
-     "end_time": "2026-06-01T12:42:44.989500+00:00",
+     "duration": 0.046598,
+     "end_time": "2026-06-03T04:47:41.942316+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:44.828312+00:00",
+     "start_time": "2026-06-03T04:47:41.895718+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2562,7 +2745,14 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Comparaison BFS vs DFS sur le cas profond\n",
+      "Comparaison BFS vs DFS sur le cas profond"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "--------------------------------------------------\n",
       "BFS : 1093 noeuds explores, chemin de longueur 7\n",
       "DFS : 7 noeuds explores, chemin de longueur 7\n",
@@ -2637,10 +2827,10 @@
    "id": "fc1fcb07",
    "metadata": {
     "papermill": {
-     "duration": 0.017371,
-     "end_time": "2026-06-01T12:42:45.079190+00:00",
+     "duration": 0.012736,
+     "end_time": "2026-06-03T04:47:41.968573+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.061819+00:00",
+     "start_time": "2026-06-03T04:47:41.955837+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2655,20 +2845,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "e4ebee1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:45.143600Z",
-     "iopub.status.busy": "2026-06-01T12:42:45.141232Z",
-     "iopub.status.idle": "2026-06-01T12:42:45.185872Z",
-     "shell.execute_reply": "2026-06-01T12:42:45.179331Z"
+     "iopub.execute_input": "2026-06-03T04:47:41.996089Z",
+     "iopub.status.busy": "2026-06-03T04:47:41.995727Z",
+     "iopub.status.idle": "2026-06-03T04:47:42.006281Z",
+     "shell.execute_reply": "2026-06-03T04:47:42.005092Z"
     },
     "papermill": {
-     "duration": 0.097938,
-     "end_time": "2026-06-01T12:42:45.190782+00:00",
+     "duration": 0.025821,
+     "end_time": "2026-06-03T04:47:42.007071+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.092844+00:00",
+     "start_time": "2026-06-03T04:47:41.981250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2682,7 +2872,7 @@
       "==================================================\n",
       "point de rencontre: Paris\n",
       "chemin trouve: Bordeaux -> Paris -> Strasbourg (cout=1075)\n",
-      "noeuds explores: 2 en 0.05 ms\n",
+      "noeuds explores: 2 en 0.01 ms\n",
       "\n",
       "Comparaison :\n",
       "  BFS classique     : 2 noeuds explores\n",
@@ -2781,10 +2971,10 @@
    "id": "c9639a47",
    "metadata": {
     "papermill": {
-     "duration": 0.030479,
-     "end_time": "2026-06-01T12:42:45.332499+00:00",
+     "duration": 0.011179,
+     "end_time": "2026-06-03T04:47:42.030517+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.302020+00:00",
+     "start_time": "2026-06-03T04:47:42.019338+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2803,20 +2993,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "cda4121f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:45.410403Z",
-     "iopub.status.busy": "2026-06-01T12:42:45.408613Z",
-     "iopub.status.idle": "2026-06-01T12:42:45.436523Z",
-     "shell.execute_reply": "2026-06-01T12:42:45.433927Z"
+     "iopub.execute_input": "2026-06-03T04:47:42.055827Z",
+     "iopub.status.busy": "2026-06-03T04:47:42.055372Z",
+     "iopub.status.idle": "2026-06-03T04:47:42.064402Z",
+     "shell.execute_reply": "2026-06-03T04:47:42.063397Z"
     },
     "papermill": {
-     "duration": 0.077006,
-     "end_time": "2026-06-01T12:42:45.438362+00:00",
+     "duration": 0.022952,
+     "end_time": "2026-06-03T04:47:42.065223+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.361356+00:00",
+     "start_time": "2026-06-03T04:47:42.042271+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2941,10 +3131,10 @@
    "id": "0614293c",
    "metadata": {
     "papermill": {
-     "duration": 0.047283,
-     "end_time": "2026-06-01T12:42:45.522584+00:00",
+     "duration": 0.014247,
+     "end_time": "2026-06-03T04:47:42.091361+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.475301+00:00",
+     "start_time": "2026-06-03T04:47:42.077114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2957,20 +3147,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "071cf32a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:45.606310Z",
-     "iopub.status.busy": "2026-06-01T12:42:45.605477Z",
-     "iopub.status.idle": "2026-06-01T12:42:45.626919Z",
-     "shell.execute_reply": "2026-06-01T12:42:45.624715Z"
+     "iopub.execute_input": "2026-06-03T04:47:42.126752Z",
+     "iopub.status.busy": "2026-06-03T04:47:42.126475Z",
+     "iopub.status.idle": "2026-06-03T04:47:42.132310Z",
+     "shell.execute_reply": "2026-06-03T04:47:42.130971Z"
     },
     "papermill": {
-     "duration": 0.06645,
-     "end_time": "2026-06-01T12:42:45.630591+00:00",
+     "duration": 0.023115,
+     "end_time": "2026-06-03T04:47:42.133583+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.564141+00:00",
+     "start_time": "2026-06-03T04:47:42.110468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3008,10 +3198,10 @@
    "id": "0770259c",
    "metadata": {
     "papermill": {
-     "duration": 0.05184,
-     "end_time": "2026-06-01T12:42:45.740462+00:00",
+     "duration": 0.012053,
+     "end_time": "2026-06-03T04:47:42.158861+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.688622+00:00",
+     "start_time": "2026-06-03T04:47:42.146808+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3024,20 +3214,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "id": "1d1e2006",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T12:42:45.817908Z",
-     "iopub.status.busy": "2026-06-01T12:42:45.817499Z",
-     "iopub.status.idle": "2026-06-01T12:42:46.116116Z",
-     "shell.execute_reply": "2026-06-01T12:42:46.108879Z"
+     "iopub.execute_input": "2026-06-03T04:47:42.184059Z",
+     "iopub.status.busy": "2026-06-03T04:47:42.183697Z",
+     "iopub.status.idle": "2026-06-03T04:47:42.283909Z",
+     "shell.execute_reply": "2026-06-03T04:47:42.282600Z"
     },
     "papermill": {
-     "duration": 0.340266,
-     "end_time": "2026-06-01T12:42:46.119111+00:00",
+     "duration": 0.113697,
+     "end_time": "2026-06-03T04:47:42.284782+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:45.778845+00:00",
+     "start_time": "2026-06-03T04:47:42.171085+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3078,10 +3268,10 @@
    "id": "a87492ca",
    "metadata": {
     "papermill": {
-     "duration": 0.10515,
-     "end_time": "2026-06-01T12:42:46.276656+00:00",
+     "duration": 0.013882,
+     "end_time": "2026-06-03T04:47:42.311514+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:46.171506+00:00",
+     "start_time": "2026-06-03T04:47:42.297632+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3132,10 +3322,10 @@
    "id": "6bf9df98",
    "metadata": {
     "papermill": {
-     "duration": 0.092114,
-     "end_time": "2026-06-01T12:42:46.448129+00:00",
+     "duration": 0.013723,
+     "end_time": "2026-06-03T04:47:42.339688+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:46.356015+00:00",
+     "start_time": "2026-06-03T04:47:42.325965+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3151,10 +3341,10 @@
    "id": "cbe50a7f",
    "metadata": {
     "papermill": {
-     "duration": 0.025005,
-     "end_time": "2026-06-01T12:42:46.573621+00:00",
+     "duration": 0.013328,
+     "end_time": "2026-06-03T04:47:42.367181+00:00",
      "exception": false,
-     "start_time": "2026-06-01T12:42:46.548616+00:00",
+     "start_time": "2026-06-03T04:47:42.353853+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3188,14 +3378,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 12.136155,
-   "end_time": "2026-06-01T12:42:47.173398+00:00",
+   "duration": 6.883316,
+   "end_time": "2026-06-03T04:47:42.733171+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed.ipynb",
-   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed.ipynb",
+   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-2-Uninformed_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-01T12:42:35.037243+00:00",
+   "start_time": "2026-06-03T04:47:35.849855+00:00",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Adds 2 exercise stubs to Search-2-Uninformed to meet convention #2161 (>=3 exercises per notebook).

### Search-2-Uninformed (1 -> 3 exercise stubs)

| Exercise | Location | Topic |
|----------|----------|-------|
| Ex 4 (new) | After section 4 (DFS) | DFS with depth limit -- implement `dfs_limited(problem, max_depth)` |
| Ex 5 (new) | After section 7 (Comparison) | Experimental comparison -- choose a route and compare all 4 algorithms |
| Ex 3 (existing) | Section 8 | IDS with memory tracking |

### Validation
- Papermill SUCCESS (7.8s, kernel python3)
- All code cells: `execution_count: int` + outputs present
- 0 `raise NotImplementedError` / `assert False` / `1/0`
- Stubs conform to C.1: `return None` + `# TODO etudiant` + `# Etape N` + `# Indice` + `print("Exercice a completer")`

### Notes
- Search-9 was verified as already conformant (3 stubs: industrial blending, set cover, multi-depot transport)
- CSP series fully conformant (4 exercises each)
- GameTheory fully conformant after tonight's merged PRs
- PR #2240 (previous attempt) was CLOSED without merge; this is a re-do