### PR TITLE
fix(catalog): resync 3 stale README markers post-rollout

### DIFF
--- a/MyIA.AI.Notebooks/Probas/README.md
+++ b/MyIA.AI.Notebooks/Probas/README.md
@@ -3,7 +3,7 @@
 <!-- CATALOG-STATUS
 series: Probas
 pedagogical_count: 43
-breakdown: Infer=20, PyMC=20, root=3
+breakdown: Infer=20, _python_port=20, root=3
 maturity: PRODUCTION=31, BETA=12
 -->
 

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -8,9 +8,9 @@ Le catalogue rassemble près de 500 notebooks répartis sur les onze domaines ci
 
 <!-- CATALOG-STATUS
 series: ALL
-total: 510
-breakdown: GenAI=120, SymbolicAI=104, QuantConnect=101, Search=46, Probas=43, Sudoku=32, ML=27, GameTheory=25, RL=6, CaseStudies=4, IIT=2
-maturity: PRODUCTION=408, BETA=52, ALPHA=42, DRAFT=4, TEMPLATE=4
+total: 508
+breakdown: GenAI=120, SymbolicAI=102, QuantConnect=101, Search=46, Probas=43, Sudoku=32, ML=27, GameTheory=25, RL=6, CaseStudies=4, IIT=2
+maturity: PRODUCTION=407, BETA=51, ALPHA=42, DRAFT=4, TEMPLATE=4
 -->
 
 Dernière mise à jour : 2026-05-28

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -2,9 +2,9 @@
 
 <!-- CATALOG-STATUS
 series: SymbolicAI
-pedagogical_count: 104
-breakdown: SmartContracts=27, Lean=21, SemanticWeb=18, Planners=13, Tweety=10, SymbolicLearning=7, Argument_Analysis=6, root=2
-maturity: PRODUCTION=100, BETA=3, ALPHA=1
+pedagogical_count: 102
+breakdown: SmartContracts=27, Lean=19, SemanticWeb=18, Planners=13, Tweety=10, SymbolicLearning=7, Argument_Analysis=6, root=2
+maturity: PRODUCTION=99, BETA=2, ALPHA=1
 -->
 
 L'intelligence artificielle n'est pas qu'apprentissage automatique et réseaux de neurones. Une grande partie de l'IA classique repose sur le **raisonnement symbolique** : représenter la connaissance sous forme de propositions, de règles et de structures logiques, puis dériver mécaniquement de nouvelles conclusions. C'est cette tradition — des systèmes experts des années 80 aux assistants de preuve modernes comme Lean 4 — que cette série explore en profondeur.


### PR DESCRIPTION
## Summary

Resync 3 stale CATALOG-STATUS markers detected by `expand_catalog_markers.py --check`:

| File | Change | Cause |
|------|--------|-------|
| `MyIA.AI.Notebooks/README.md` | total 510->508, SymbolicAI 104->102, PROD 408->407 | 2 Lean notebooks moved/removed during SymbolicAI Lean consolidation |
| `MyIA.AI.Notebooks/SymbolicAI/README.md` | count 104->102, Lean 21->19, PROD 100->99 | Same — Lean notebooks restructured |
| `MyIA.AI.Notebooks/Probas/README.md` | breakdown: `PyMC=20` -> `_python_port=20` | Catalog picks up folder name from generated JSON (post-rename #2249) |

## Validation
- `expand_catalog_markers.py --check` now reports 0 drift
- No code changes, README markers only (3 files, +7/-7)

See #2161