### PR TITLE
fix(conway): implement hashlifeResultMemo - replace sorry with real memoized recursion (HashlifeMemo 3->2 sorry)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMemo.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeMemo.lean
@@ -114,8 +114,57 @@ We expose two surfaces:
 
     where `hashlifeResultAuxMemoBody` mirrors `hashlifeResultAux` but
     recurses through `hashlifeResultMemo` to thread the cache. -/
-def hashlifeResultMemo (_c : MacroCell) : StateM MemoCache MacroCell := by
-  sorry
+partial def hashlifeResultMemo (c : MacroCell) : StateM MemoCache MacroCell := do
+  let cache ← get
+  match cache.get? c with
+  | some r => return r
+  | none =>
+    let r ← hashlifeResultMemoBody c
+    modify (·.insert c r)
+    return r
+where
+  hashlifeResultMemoBody (c : MacroCell) : StateM MemoCache MacroCell := do
+    match c with
+    | node (node nw_nw nw_ne nw_sw nw_se)
+          (node ne_nw ne_ne ne_sw ne_se)
+          (node sw_nw sw_ne sw_sw sw_se)
+          (node se_nw se_ne se_sw se_se) => do
+      if c.level == 2 then
+        pure (step4x4 c)
+      else do
+        -- Form the 9 overlapping level-(k-1) sub-cells
+        let n1 := node nw_nw nw_ne nw_sw nw_se
+        let n2 := node nw_ne ne_nw nw_se ne_sw
+        let n3 := node ne_nw ne_ne ne_sw ne_se
+        let n4 := node nw_sw nw_se sw_nw sw_ne
+        let n5 := node nw_se ne_sw sw_ne se_nw
+        let n6 := node ne_sw ne_se se_nw se_ne
+        let n7 := node sw_nw sw_ne sw_sw sw_se
+        let n8 := node sw_ne se_nw sw_se se_sw
+        let n9 := node se_nw se_ne se_sw se_se
+        -- Recurse on each sub-cell
+        let r1 ← hashlifeResultMemo n1
+        let r2 ← hashlifeResultMemo n2
+        let r3 ← hashlifeResultMemo n3
+        let r4 ← hashlifeResultMemo n4
+        let r5 ← hashlifeResultMemo n5
+        let r6 ← hashlifeResultMemo n6
+        let r7 ← hashlifeResultMemo n7
+        let r8 ← hashlifeResultMemo n8
+        let r9 ← hashlifeResultMemo n9
+        -- Form the 4 overlapping super-cells
+        let q_nw := node r1 r2 r4 r5
+        let q_ne := node r2 r3 r5 r6
+        let q_sw := node r4 r5 r7 r8
+        let q_se := node r5 r6 r8 r9
+        -- Recurse on each super-cell
+        let out_nw ← hashlifeResultMemo q_nw
+        let out_ne ← hashlifeResultMemo q_ne
+        let out_sw ← hashlifeResultMemo q_sw
+        let out_se ← hashlifeResultMemo q_se
+        pure (node out_nw out_ne out_sw out_se)
+    | leaf _ => pure deadLeaf
+    | _ => pure (emptyOfLevel (max 1 (c.level - 1)))
 
 /-- Convenience: run `hashlifeResultMemo` from the empty cache,
     discarding the final cache state. Returns the same `MacroCell` as


### PR DESCRIPTION
## Summary

Replace the `sorry` placeholder for `hashlifeResultMemo` in `HashlifeMemo.lean` with a real `partial def` that mirrors `hashlifeResultAux` but threads a `MemoCache` (`Std.HashMap MacroCellId MacroCell`) through `StateM`.

### Implementation details

- **Cache hit**: return cached result immediately (short-circuit the 9^k recursion)
- **Cache miss**: recurse via `hashlifeResultMemoBody`, then insert result into cache
- **Body**: mirrors the 9-subcell + 4-super-cell decomposition of `hashlifeResultAux`
  - Level 2: delegates to `step4x4` (base case)
  - Higher levels: forms 9 overlapping level-(k-1) sub-cells, recurses, forms 4 super-cells, recurses again
  - Leaf/malformed: returns `deadLeaf` or `emptyOfLevel`

### Sorry count

| File | Before | After | Delta |
|------|--------|-------|-------|
| HashlifeMemo.lean | 3 | 2 | **-1** |
| HashlifeCorrectness.lean | 2 | 2 | 0 (INTRACTABLE P4/P5) |
| Pillars.lean | 4 | 4 | 0 (scaffolding) |
| **Total Conway** | **9** | **8** | **-1** |

### Build verification

```
lake build Conway.Life.HashlifeMemo — SUCCESS (3319 jobs, 12s)
```

### Anti-regression

- No existing proofs modified
- 2 remaining sorry in HashlifeMemo are correctness bridge theorems (Phase 3c roadmap)
- The implementation follows the exact specification documented in the module comments

See #2157, #1651.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>