### PR TITLE
fix(lean): scope Lean-15 "0 sorry" claim to the 2 proved Pillars (KS+FWT)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
@@ -13,34 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# Lean-15 : Le Theoreme de Kochen-Specker (Cabello 18 vecteurs) + Free Will Theorem\n",
-    "\n",
-    "**Navigation** : [<< Lean-14 Conway Tribute](Lean-14b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)\n",
-    "\n",
-    "**Kernel** : Python 3 (illustrations + verifications combinatoires) + Lean 4 (WSL) pour les sections 6-7\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Introduction\n",
-    "\n",
-    "En 1967, Simon Kochen et Ernst Specker publient un theoreme qui exclut une large classe d'interpretations de la mecanique quantique : les **theories a variables cachees non-contextuelles**. La preuve originale utilise **117 vecteurs** de R^3. Plusieurs raffinements suivent (33 vecteurs par Peres 1991, 20 par Kernaghan 1994) jusqu'a la preuve la plus compacte connue avec **18 vecteurs de R^4** par Cabello, Estebaranz et Garcia-Alcaine en 1996. C'est cette derniere qui sert de noyau combinatoire au theoreme de libre arbitre de Conway-Kochen (2006).\n",
-    "\n",
-    "Ce notebook couvre les **Piliers 1 et 3** de l'Epic #1651 (Theoreme de Libre Arbitre Conway-Kochen). Il presente :\n",
-    "1. La question : peut-on attribuer une valeur 0/1 aux observables quantiques de maniere non-contextuelle ?\n",
-    "2. La structure : 18 vecteurs de R^4 en 9 bases orthogonales, chacun appartenant a exactement 2 bases\n",
-    "3. L'argument de parite : 9 (impair) vs 2k (pair) -- contradiction\n",
-    "4. Verification computationnelle : aucune coloration valide n'existe sur 2^18 essais\n",
-    "5. Le port Lean 4 : `KochenSpecker.lean` (Pilier 1, PROUVE) + `FreeWillTheorem.lean` (Pilier 2, PROUVE)\n",
-    "6. Verification `lake build` : 0 sorry total\n",
-    "\n",
-    "### Prerequis\n",
-    "- Notions d'algebre lineaire (R^4, bases orthogonales, produit scalaire)\n",
-    "- Notebooks Lean-1 a Lean-7 pour les aspects formels (recommande)\n",
-    "- Lean-12 pour le pattern Lake build + WSL\n",
-    "\n",
-    "### Duree estimee : 75 minutes"
-   ]
+   "source": "# Lean-15 : Le Theoreme de Kochen-Specker (Cabello 18 vecteurs) + Free Will Theorem\n\n**Navigation** : [<< Lean-14 Conway Tribute](Lean-14b-Conway-Game-of-Life-Lean.ipynb) | [Index](README.md)\n\n**Kernel** : Python 3 (illustrations + verifications combinatoires) + Lean 4 (WSL) pour les sections 6-7\n\n---\n\n## Introduction\n\nEn 1967, Simon Kochen et Ernst Specker publient un theoreme qui exclut une large classe d'interpretations de la mecanique quantique : les **theories a variables cachees non-contextuelles**. La preuve originale utilise **117 vecteurs** de R^3. Plusieurs raffinements suivent (33 vecteurs par Peres 1991, 20 par Kernaghan 1994) jusqu'a la preuve la plus compacte connue avec **18 vecteurs de R^4** par Cabello, Estebaranz et Garcia-Alcaine en 1996. C'est cette derniere qui sert de noyau combinatoire au theoreme de libre arbitre de Conway-Kochen (2006).\n\nCe notebook couvre les **Piliers 1 et 3** de l'Epic #1651 (Theoreme de Libre Arbitre Conway-Kochen). Il presente :\n1. La question : peut-on attribuer une valeur 0/1 aux observables quantiques de maniere non-contextuelle ?\n2. La structure : 18 vecteurs de R^4 en 9 bases orthogonales, chacun appartenant a exactement 2 bases\n3. L'argument de parite : 9 (impair) vs 2k (pair) -- contradiction\n4. Verification computationnelle : aucune coloration valide n'existe sur 2^18 essais\n5. Le port Lean 4 : `KochenSpecker.lean` (Pilier 1, PROUVE) + `FreeWillTheorem.lean` (Pilier 2, PROUVE)\n6. Verification `lake build` : 0 sorry dans les 2 Piliers (KochenSpecker + FreeWillTheorem)\n\n### Prerequis\n- Notions d'algebre lineaire (R^4, bases orthogonales, produit scalaire)\n- Notebooks Lean-1 a Lean-7 pour les aspects formels (recommande)\n- Lean-12 pour le pattern Lake build + WSL\n\n### Duree estimee : 75 minutes"
   },
   {
    "cell_type": "markdown",
@@ -853,7 +826,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Nombre de sorrys par module :\n",
+      "Nombre de sorrys dans les 2 Piliers (KS + FWT) :\n",
       "Conway/KochenSpecker.lean:0\n",
       "Conway/FreeWillTheorem.lean:0\n",
       "\n"
@@ -863,38 +836,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fichiers contenant sorry (dans commentaires) : ['Conway/Angel.lean', 'Conway/DoomsdayLemmas.lean', 'Conway/Life/HashlifeCorrectness.lean', 'Conway/Life/HashlifeMemo.lean', 'Conway/Life/Pillars.lean']\n",
+      "Autres modules Conway contenant encore \"sorry\" (HORS scope de ce notebook) :\n",
+      "  - Conway/Angel.lean\n",
+      "  - Conway/DoomsdayLemmas.lean\n",
+      "  - Conway/Life/HashlifeCorrectness.lean\n",
+      "  - Conway/Life/HashlifeMemo.lean\n",
+      "  - Conway/Life/Pillars.lean\n",
       "\n",
-      "Resultat : 0 sorry de production dans tout le workspace conway_lean\n"
+      "Lecture honnete :\n",
+      "  * Piliers 1+2 (KochenSpecker + FreeWillTheorem) : 0 sorry -- formellement PROUVES.\n",
+      "  * Angel.lean / DoomsdayLemmas.lean : \"sorry\" en commentaire/roadmap (pas de preuve trouee).\n",
+      "  * Life/* (Game of Life, Hashlife) : sorrys de PRODUCTION en cours (Phase 2-3) --\n",
+      "    objectifs P4/P5 intractables + lemmes bridge/scaffolding, documentes dans la roadmap Conway.\n",
+      "  => Ce notebook (Piliers 1+2) ne depend PAS des modules Life/* : ses 2 piliers sont complets.\n"
      ]
     }
    ],
-   "source": [
-    "# Compter les sorrys dans KochenSpecker.lean + FreeWillTheorem.lean\n",
-    "result_ks = subprocess.run(\n",
-    "    ['wsl', 'bash', '-c',\n",
-    "     f'cd {wsl_path} && grep -c sorry Conway/KochenSpecker.lean Conway/FreeWillTheorem.lean'],\n",
-    "    capture_output=True, text=True, timeout=10\n",
-    ")\n",
-    "\n",
-    "print('Nombre de sorrys par module :')\n",
-    "print(result_ks.stdout.strip())\n",
-    "print()\n",
-    "\n",
-    "# Verifier le nombre total de sorrys dans tout le workspace Conway\n",
-    "result_all = subprocess.run(\n",
-    "    ['wsl', 'bash', '-c',\n",
-    "     f'cd {wsl_path} && find Conway -name \"*.lean\" -exec grep -l sorry {{}} \\\\;'],\n",
-    "    capture_output=True, text=True, timeout=10\n",
-    ")\n",
-    "sorry_files = [f for f in result_all.stdout.strip().split('\\n') if f]\n",
-    "if sorry_files:\n",
-    "    print(f'Fichiers contenant sorry (dans commentaires) : {sorry_files}')\n",
-    "else:\n",
-    "    print('Aucun fichier .lean contenant sorry')\n",
-    "print()\n",
-    "print('Resultat : 0 sorry de production dans tout le workspace conway_lean')"
-   ]
+   "source": "# Compter les sorrys dans les 2 Piliers de CE notebook : KochenSpecker + FreeWillTheorem\nresult_ks = subprocess.run(\n    ['wsl', 'bash', '-c',\n     f'cd {wsl_path} && grep -c sorry Conway/KochenSpecker.lean Conway/FreeWillTheorem.lean'],\n    capture_output=True, text=True, timeout=10\n)\n\nprint('Nombre de sorrys dans les 2 Piliers (KS + FWT) :')\nprint(result_ks.stdout.strip())\nprint()\n\n# Contexte honnete : lister les AUTRES modules Conway qui contiennent encore \"sorry\"\n# (hors scope de ce notebook, qui ne traite que les Piliers 1+2)\nresult_all = subprocess.run(\n    ['wsl', 'bash', '-c',\n     f'cd {wsl_path} && find Conway -name \"*.lean\" -exec grep -l sorry {{}} \\\\;'],\n    capture_output=True, text=True, timeout=10\n)\nautres = sorted(f for f in result_all.stdout.strip().split('\\n')\n                if f and 'KochenSpecker' not in f and 'FreeWillTheorem' not in f)\nprint('Autres modules Conway contenant encore \"sorry\" (HORS scope de ce notebook) :')\nfor f in autres:\n    print(f'  - {f}')\nprint()\nprint('Lecture honnete :')\nprint('  * Piliers 1+2 (KochenSpecker + FreeWillTheorem) : 0 sorry -- formellement PROUVES.')\nprint('  * Angel.lean / DoomsdayLemmas.lean : \"sorry\" en commentaire/roadmap (pas de preuve trouee).')\nprint('  * Life/* (Game of Life, Hashlife) : sorrys de PRODUCTION en cours (Phase 2-3) --')\nprint('    objectifs P4/P5 intractables + lemmes bridge/scaffolding, documentes dans la roadmap Conway.')\nprint('  => Ce notebook (Piliers 1+2) ne depend PAS des modules Life/* : ses 2 piliers sont complets.')"
   },
   {
    "cell_type": "markdown",
@@ -909,18 +867,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : Piliers 1+2 PROUVES\n",
-    "\n",
-    "| Verification | Resultat | Signification |\n",
-    "|--------------|----------|---------------|\n",
-    "| `lake build Conway` | Exit code 0, 3337 jobs | L'ensemble du workspace compile |\n",
-    "| Nombre de sorrys | 0 production sorry | Piliers 1+2 complets |\n",
-    "| `KochenSpecker.lean` | 0 sorry | Parite formellement prouvee (PR #2019) |\n",
-    "| `FreeWillTheorem.lean` | 0 sorry | FWT formellement prouve (PR #2026) |\n",
-    "\n",
-    "Les 2 piliers mathematiques du theoreme de libre arbitre sont maintenant **entierement prouves** en Lean 4. Le Pilier 1 (KS) via argument de parite (`fin_cases v <;> decide` + `Finset.sum_comm` + `omega`), et le Pilier 2 (FWT) via reduction au Pilier 1 (`SatisfiesSPIN` + `SatisfiesTWIN` + structure MIN)."
-   ]
+   "source": "### Interpretation : Piliers 1+2 PROUVES\n\n| Verification | Resultat | Signification |\n|--------------|----------|---------------|\n| `lake build Conway` | Exit code 0, ~3340 jobs | Le workspace compile (les `sorry` residuels sont des warnings, pas des erreurs) |\n| Sorrys Piliers 1+2 | 0 dans KS + FWT | Les 2 piliers de ce notebook sont complets |\n| `KochenSpecker.lean` | 0 sorry | Parite formellement prouvee (PR #2019) |\n| `FreeWillTheorem.lean` | 0 sorry | FWT formellement prouve (PR #2026) |\n\nLes 2 piliers mathematiques du theoreme de libre arbitre sont maintenant **entierement prouves** en Lean 4. Le Pilier 1 (KS) via argument de parite (`fin_cases v <;> decide` + `Finset.sum_comm` + `omega`), et le Pilier 2 (FWT) via reduction au Pilier 1 (`SatisfiesSPIN` + `SatisfiesTWIN` + structure MIN).\n\n> **Perimetre.** Les autres modules `Conway/Life/*` (Game of Life, Hashlife) comportent encore des `sorry` de production : ce sont des chantiers de formalisation en cours (Phase 2-3, objectifs P4/P5 intractables + lemmes bridge/scaffolding), hors du perimetre des Piliers 1+2 traites dans ce notebook."
   },
   {
    "cell_type": "markdown",
@@ -1223,38 +1170,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Resume\n",
-    "\n",
-    "### Concepts cles\n",
-    "\n",
-    "| Concept | Definition | Importance |\n",
-    "|---------|------------|------------|\n",
-    "| **Variables cachees non-contextuelles** | Theorie attribuant des valeurs predeterminees independantes du contexte | Ce que KS exclut |\n",
-    "| **Table Cabello (18 vecteurs)** | 18 vecteurs de R^4 en 9 bases orthogonales, chaque vecteur dans exactement 2 bases | Structure combinatoire minimale |\n",
-    "| **Coloration valide** | Fonction vecteurs -> {0,1} avec exactement un 1 par base | Objet dont on prouve l'inexistence |\n",
-    "| **Argument de parite** | Somme des 1 = 9 (impair) via les bases, mais = 2k (pair) via l'overlap | Contradiction |\n",
-    "| **Theoreme de libre arbitre** | Si experimentateurs libres, alors particules libres | Generalisation de KS via SPIN+TWIN+MIN |\n",
-    "\n",
-    "### Architecture du port Lean 4\n",
-    "\n",
-    "| Module | Statut | Sorry | Role |\n",
-    "|--------|--------|-------|------|\n",
-    "| `KochenSpecker.lean` | PROUVE | 0 | Parite formelle sur la table Cabello |\n",
-    "| `FreeWillTheorem.lean` | PROUVE | 0 | Reduction FWT -> KS (SPIN+TWIN+MIN) |\n",
-    "| `Conway` (workspace) | Compile | 0 production | 3337 jobs, lake build SUCCESS |\n",
-    "\n",
-    "### Verifications realisees dans ce notebook\n",
-    "\n",
-    "1. **54 paires orthogonales** verifiees (9 bases x 6 paires)\n",
-    "2. **Invariant d'overlap** : chaque vecteur dans exactement 2 bases\n",
-    "3. **Recherche exhaustive** : 0/262 144 colorations valides\n",
-    "4. **Lake build** : exit code 0, 0 sorry de production\n",
-    "\n",
-    "### Prochaine etape\n",
-    "\n",
-    "Pour explorer d'autres resultats de John Conway formalises en Lean, voir [Lean-14b-Conway-Game-of-Life-Lean](Lean-14b-Conway-Game-of-Life-Lean.ipynb). Pour la robustesse des reseaux de neurones, voir [Lean-11-TorchLean](Lean-11-TorchLean.ipynb)."
-   ]
+   "source": "## Resume\n\n### Concepts cles\n\n| Concept | Definition | Importance |\n|---------|------------|------------|\n| **Variables cachees non-contextuelles** | Theorie attribuant des valeurs predeterminees independantes du contexte | Ce que KS exclut |\n| **Table Cabello (18 vecteurs)** | 18 vecteurs de R^4 en 9 bases orthogonales, chaque vecteur dans exactement 2 bases | Structure combinatoire minimale |\n| **Coloration valide** | Fonction vecteurs -> {0,1} avec exactement un 1 par base | Objet dont on prouve l'inexistence |\n| **Argument de parite** | Somme des 1 = 9 (impair) via les bases, mais = 2k (pair) via l'overlap | Contradiction |\n| **Theoreme de libre arbitre** | Si experimentateurs libres, alors particules libres | Generalisation de KS via SPIN+TWIN+MIN |\n\n### Architecture du port Lean 4\n\n| Module | Statut | Sorry | Role |\n|--------|--------|-------|------|\n| `KochenSpecker.lean` | PROUVE | 0 | Parite formelle sur la table Cabello |\n| `FreeWillTheorem.lean` | PROUVE | 0 | Reduction FWT -> KS (SPIN+TWIN+MIN) |\n| `Conway` (workspace) | Compile | 0 dans KS+FWT ; WIP dans `Life/*` | ~3340 jobs, lake build SUCCESS |\n\n### Verifications realisees dans ce notebook\n\n1. **54 paires orthogonales** verifiees (9 bases x 6 paires)\n2. **Invariant d'overlap** : chaque vecteur dans exactement 2 bases\n3. **Recherche exhaustive** : 0/262 144 colorations valides\n4. **Lake build** : exit code 0 ; 0 sorry dans les Piliers 1+2 (KS + FWT) -- les modules `Life/*` restent un chantier de formalisation en cours\n\n### Prochaine etape\n\nPour explorer d'autres resultats de John Conway formalises en Lean, voir [Lean-14b-Conway-Game-of-Life-Lean](Lean-14b-Conway-Game-of-Life-Lean.ipynb). Pour la robustesse des reseaux de neurones, voir [Lean-11-TorchLean](Lean-11-TorchLean.ipynb)."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **Lean-15-Kochen-Specker.ipynb** (notebook live-cours EPITA-IS). La cellule 21 listait 5 fichiers Conway contenant `sorry`, les etiquetait a tort "(dans commentaires)", puis affichait une conclusion **fausse** :

```
Resultat : 0 sorry de production dans tout le workspace conway_lean
```

C'est incoherent avec la realite verifiee : les modules `Conway/Life/*` (Game of Life, Hashlife) ont des `sorry` de **production** en cours (warnings `declaration uses sorry` dans le build), pas seulement en commentaire. Signale par ai-01 (dashboard 09:35Z) : « inexactitude pedagogique mineure, fix dedie a planifier ».

## Correction

La revendication "0 sorry" est maintenant **scopee aux 2 Piliers de CE notebook** (KochenSpecker + FreeWillTheorem), qui sont bien a 0 sorry et formellement prouves. Les autres modules sont presentes honnetement comme un chantier de formalisation en cours, hors perimetre.

4 cellules touchees (le claim se propageait sur 4 cellules) :
- **cell 0** (intro, md) : point 6 `0 sorry total` -> `0 sorry dans les 2 Piliers`
- **cell 21** (code) : le compteur KS+FWT reste exact (0/0) ; la liste des autres modules est generee **dynamiquement** (`find ... -exec grep -l sorry`) ; la ligne de conclusion fausse est remplacee par une lecture honnete (Piliers 1+2 = 0 sorry PROUVES ; Angel/Doomsday = sorry en commentaire/roadmap ; Life/* = sorry de production WIP). **Pas de count hardcode** (evite de re-introduire un nombre qui se perime).
- **cell 22** (interpretation, md) : tableau scope aux Piliers + note de perimetre sur `Life/*`
- **cell 31** (resume, md) : ligne workspace `0 production` -> `0 dans KS+FWT ; WIP dans Life/*`

## Verification (section D — notebook PR discipline)

- **Re-execution reelle** : Papermill Windows-side (`--kernel python3 --execution-timeout 1800`), notebook execute de bout en bout. Cell 20 (lake build WSL) + cell 21 (sorry count) re-executees, outputs frais committes.
- **lake build SUCCESS** (ground truth WSL, exit 0, 3340 jobs) : `Conway/KochenSpecker.lean:0`, `Conway/FreeWillTheorem.lean:0`. Warnings `declaration uses sorry` confirmes sur `Life/HashlifeCorrectness`, `Life/HashlifeMemo`, `Life/Pillars` (= les sorry de production, justement ceux que l'ancienne ligne niait).
- **C.1** : `grep -nE "raise NotImplementedError|assert False|1/0"` = 0.
- **C.2** : `execution_count` + `outputs` coherents sur toutes les cellules code.
- **Anti-regression** : 33 cellules avant/apres, 0 supprimee ; les 3 exercices (`ks-ex1/2/3`) et toutes les cellules Exemple/Solution **inchangees** (diff cell-by-cell verifie).
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (cellules notebook uniquement).

## Scope

Un seul sujet : exactitude du message "sorry" sur Lean-15. Aucune modif du code Lean, aucun autre notebook.

See #2162 (Epic Hommages Lean / Conway profondeur). See #2178 (PR ayant ajoute les cellules de conclusion corrigees ici). See #2027 (PR ayant etabli l'etat prouve de Lean-15).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
