### PR TITLE
fix(socialchoice): relabel 3 exercise headers (Exemple guide -> Exercice) in 03-Voting (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -1822,7 +1822,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemple guide 1 : Paradoxe de Condorcet et Cycles\n",
+    "## Exercice 1 : Paradoxe de Condorcet et Cycles\n",
     "\n",
     "**Objectifs** :\n",
     "1. Implementer une fonction de recherche du gagnant de Condorcet\n",
@@ -1958,7 +1958,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemple guide 2 : Comparaison des methodes de vote\n",
+    "## Exercice 2 : Comparaison des methodes de vote\n",
     "\n",
     "**Objectifs** :\n",
     "1. Appliquer les methodes existantes a de nouveaux profils pour observer les divergences\n",
@@ -2089,7 +2089,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemple guide 3 : Theoreme d'Arrow et proprietes d'agregation\n",
+    "## Exercice 3 : Theoreme d'Arrow et proprietes d'agregation\n",
     "\n",
     "**Objectifs** :\n",
     "1. Verifier experimentalement la propriete IIA sur la regle de Borda\n",


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **03-Voting-Methods.ipynb** (serie GameTheory/SocialChoice, kernel `python3`), dans le cadre du wrapup #2259 / Epic #2162. Les 3 sections d'exercices avaient un header markdown `## Exemple guide N` alors que leur contenu est un **exercice a completer** — confusion active pour les etudiants pendant le cours EPITA-IS live.

## Diagnostic (content-based, pas par titre)

Pour chacune des 3 sections, le header markdown disait `## Exemple guide N` mais :

| Indice | Verdict |
|--------|---------|
| Code (cells 37/39/41) = `def ...: # Exercice: Implementez ici` + `# Indice` + `pass`, finissant par `print("Exercice a completer : ...")` | **stub d'exercice genuine** |
| Commentaire interne de chaque cellule code | dit **deja** `# Exercice N` |
| Body markdown de chaque section | dit **« Ce que vous devez implementer »** |

Le seul element incoherent etait donc le **header markdown** (`Exemple guide N`), en contradiction avec le code (stub), son propre commentaire interne (`# Exercice N`) et le body (« vous devez implementer »).

= **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) : « Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** ». **Pas un revert conteste** : continue la passe validee `8b547c83` (#1562/#1570, content-based `Exemple guide -> Exercice`) qui avait manque ces 3 headers ; les anciens labels « Exemple guide » sont un residu des find-replace aveugles `37ee5f78`/`1a2645d8` (classe #1214).

## Correction

3 headers markdown relabeles (cells 36/38/40) :
- `## Exemple guide 1 : Paradoxe de Condorcet et Cycles` -> `## Exercice 1 : ...`
- `## Exemple guide 2 : Comparaison des methodes de vote` -> `## Exercice 2 : ...`
- `## Exemple guide 3 : Theoreme d'Arrow et proprietes d'agregation` -> `## Exercice 3 : ...`

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 3 insertions / 3 deletions** — exactement les 3 lignes header, 0 reformatage JSON, 0 cellule ajoutee/supprimee.
- **C.2 (exception markdown-only)** : modif uniquement markdown -> les outputs committes precedents restent valides. 16 cellules code, **0 `execution_count: null`** (0 hollow). Aucun re-exec staged (C.3 : seul le source markdown a change).
- **§D exec proof (non committe)** : par prudence (cours live), re-execution Papermill Windows-side `--kernel python3 --execution-timeout 1800` du notebook edite -> **EXIT 0, 43/43 cellules, 0 erreur** (output ecrit en `/tmp`, PAS dans le repo).
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0**. (Un grep brut sur le JSON matche `1/0` dans le base64 d'un PNG matplotlib en sortie = faux positif, hors source.)
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul).

## Scope

Un seul sujet, un seul notebook : exactitude du label exercice sur 03-Voting. Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025).

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
