### PR TITLE
Add: Types Dependants - quentin.lauret, edouard.andre, remi.brenaut

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1b679ea6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004383,
+     "end_time": "2026-05-30T00:49:18.551106+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:18.546723+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Lean 2 - Types Dependants et Calcul des Constructions\n",
     "\n",
@@ -57,7 +67,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2591fa8e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002936,
+     "end_time": "2026-05-30T00:49:18.557441+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:18.554505+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"1-types-de-base\"></a>\n",
     "## 1. Types de Base\n",
@@ -70,7 +90,23 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "id": "59b9d36a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:18.566059Z",
+     "iopub.status.busy": "2026-05-30T00:49:18.565874Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.155311Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.154046Z"
+    },
+    "papermill": {
+     "duration": 1.594203,
+     "end_time": "2026-05-30T00:49:20.155904+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:18.561701+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -233,7 +269,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f60b5c0a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003215,
+     "end_time": "2026-05-30T00:49:20.162610+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.159395+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 1.2 Definitions de variables\n",
     "\n",
@@ -243,7 +289,23 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "id": "0a84fa53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.169971Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.169824Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.291678Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.290569Z"
+    },
+    "papermill": {
+     "duration": 0.126479,
+     "end_time": "2026-05-30T00:49:20.292293+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.165814+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -367,7 +429,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7987e5d3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003751,
+     "end_time": "2026-05-30T00:49:20.300012+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.296261+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 1.3 Inference de types\n",
     "\n",
@@ -377,7 +449,23 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "id": "91a1383e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.307719Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.307559Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.430574Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.429650Z"
+    },
+    "papermill": {
+     "duration": 0.127766,
+     "end_time": "2026-05-30T00:49:20.431139+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.303373+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -501,7 +589,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "00293e72",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003451,
+     "end_time": "2026-05-30T00:49:20.438424+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.434973+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"2-types-fonctions\"></a>\n",
     "## 2. Types Fonctions\n",
@@ -516,7 +614,23 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "id": "2d447b9c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.446428Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.446273Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.560931Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.559942Z"
+    },
+    "papermill": {
+     "duration": 0.119166,
+     "end_time": "2026-05-30T00:49:20.561426+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.442260+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -637,7 +751,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "993d675f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003419,
+     "end_time": "2026-05-30T00:49:20.568863+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.565444+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2.2 Lambda expressions\n",
     "\n",
@@ -649,7 +773,23 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "id": "e4e7f6e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.577349Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.577166Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.704161Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.702814Z"
+    },
+    "papermill": {
+     "duration": 0.132437,
+     "end_time": "2026-05-30T00:49:20.704886+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.572449+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -791,7 +931,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cc4f8940",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003707,
+     "end_time": "2026-05-30T00:49:20.712726+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.709019+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2.3 Curryfication et application partielle\n",
     "\n",
@@ -803,7 +953,23 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "id": "90ec6e56",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.721234Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.721051Z",
+     "iopub.status.idle": "2026-05-30T00:49:20.842526Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.841663Z"
+    },
+    "papermill": {
+     "duration": 0.126819,
+     "end_time": "2026-05-30T00:49:20.843192+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.716373+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -933,7 +1099,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4e9ae148",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003815,
+     "end_time": "2026-05-30T00:49:20.851229+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.847414+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"3-types-produits\"></a>\n",
     "## 3. Types Produits (Tuples et Structures)\n",
@@ -959,7 +1135,23 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "id": "18e8aa52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:20.859388Z",
+     "iopub.status.busy": "2026-05-30T00:49:20.859244Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.000194Z",
+     "shell.execute_reply": "2026-05-30T00:49:20.998702Z"
+    },
+    "papermill": {
+     "duration": 0.145805,
+     "end_time": "2026-05-30T00:49:21.000871+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:20.855066+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1125,7 +1317,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "542c13f3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004016,
+     "end_time": "2026-05-30T00:49:21.009224+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.005208+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.2 Fonctions sur les produits\n",
     "\n",
@@ -1135,7 +1337,23 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "id": "6ba5997e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.018735Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.018503Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.144370Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.142920Z"
+    },
+    "papermill": {
+     "duration": 0.132172,
+     "end_time": "2026-05-30T00:49:21.145430+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.013258+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1244,7 +1462,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "67b12351",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004061,
+     "end_time": "2026-05-30T00:49:21.154251+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.150190+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"4-hierarchie-univers\"></a>\n",
     "## 4. Hierarchie des Univers de Types\n",
@@ -1267,7 +1495,23 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "id": "c07c8978",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.164006Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.163823Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.274419Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.273439Z"
+    },
+    "papermill": {
+     "duration": 0.116942,
+     "end_time": "2026-05-30T00:49:21.275278+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.158336+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1424,7 +1668,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f44b8274",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004204,
+     "end_time": "2026-05-30T00:49:21.284061+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.279857+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.3 Polymorphisme d'univers\n",
     "\n",
@@ -1434,7 +1688,23 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "id": "4bdf7b32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.293650Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.293498Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.412424Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.411436Z"
+    },
+    "papermill": {
+     "duration": 0.124837,
+     "end_time": "2026-05-30T00:49:21.413139+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.288302+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1463,7 +1733,8 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Fonction constante polymorphe</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk34\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk34\"><span class=\"kn\">def</span><span class=\"w\"> </span>konstant<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>u)<span class=\"w\"> </span>(b<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span><span class=\"w\"> </span>v)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`y</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk35\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk35\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>konstant<span class=\"w\"> </span>Nat<span class=\"w\"> </span>Bool<span class=\"w\"> </span><span class=\"mi\">42</span><span class=\"w\"> </span>true<span class=\"w\">  </span><span class=\"c1\">-- 42</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">42</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
@@ -1495,7 +1766,7 @@
        "   \"pos\": {\"line\": 15, \"column\": 48},\r\n",
        "   \"endPos\": {\"line\": 15, \"column\": 49},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 17, \"column\": 5},\r\n",
@@ -1525,7 +1796,8 @@
        "-- Fonction constante polymorphe\n",
        "def konstant (a : Type u) (b : Type v) (x : a) (y : b) : a := x\n",
        "                                                ─▶ 🟨 unused variable `y`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "\n",
        "#eval konstant Nat Bool 42 true  -- 42\n",
        "─────▶  42\n",
@@ -1555,7 +1827,7 @@
        "   \"pos\": {\"line\": 15, \"column\": 48},\r\n",
        "   \"endPos\": {\"line\": 15, \"column\": 49},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 17, \"column\": 5},\r\n",
@@ -1589,7 +1861,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "381e6ef0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004823,
+     "end_time": "2026-05-30T00:49:21.422809+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.417986+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"5-definitions-locales\"></a>\n",
     "## 5. Definitions Locales avec `let`\n",
@@ -1600,7 +1882,23 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "id": "1e33d173",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.433652Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.433460Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.562072Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.561278Z"
+    },
+    "papermill": {
+     "duration": 0.134618,
+     "end_time": "2026-05-30T00:49:21.562588+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.427970+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1742,7 +2040,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "86be6138",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004235,
+     "end_time": "2026-05-30T00:49:21.571401+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.567166+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 5.1 `let` vs `def`\n",
     "\n",
@@ -1756,7 +2064,23 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "id": "1ba07acd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.580468Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.580330Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.705084Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.704133Z"
+    },
+    "papermill": {
+     "duration": 0.130137,
+     "end_time": "2026-05-30T00:49:21.705757+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.575620+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1868,7 +2192,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "24b9dc7e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004937,
+     "end_time": "2026-05-30T00:49:21.716450+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.711513+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"6-variables-sections\"></a>\n",
     "## 6. Variables et Sections\n",
@@ -1881,7 +2215,23 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "id": "82b67a74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.726795Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.726607Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.840222Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.839249Z"
+    },
+    "papermill": {
+     "duration": 0.11983,
+     "end_time": "2026-05-30T00:49:21.840922+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.721092+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -1898,14 +2248,16 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Sans variable : on doit repeter (a : Type) partout</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>id1<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>x</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3b\"><span class=\"kn\">def</span><span class=\"w\"> </span>const1<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>)<span class=\"w\"> </span>(b<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`y</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Avec variable : declaration une seule fois</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">variable</span><span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>id2<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>x</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3c\"><span class=\"kn\">def</span><span class=\"w\"> </span>const2<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>(y<span class=\"w\"> </span>:<span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>x</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`y</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Lean ajoute automatiquement les parametres de type</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3d\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>id2<span class=\"w\">       </span><span class=\"c1\">-- id2 (a : Type) (x : a) : a</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> id2<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a</blockquote></div></div></small></span></pre>\n",
@@ -1923,12 +2275,12 @@
        "   \"pos\": {\"line\": 3, \"column\": 42},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 43},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 9, \"column\": 20},\r\n",
        "   \"endPos\": {\"line\": 9, \"column\": 21},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
@@ -1946,7 +2298,8 @@
        "def id1 (a : Type) (x : a) : a := x\n",
        "def const1 (a : Type) (b : Type) (x : a) (y : b) : a := x\n",
        "                                          ─▶ 🟨 unused variable `y`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "\n",
        "-- Avec variable : declaration une seule fois\n",
        "variable (a b : Type)\n",
@@ -1954,7 +2307,8 @@
        "def id2 (x : a) : a := x\n",
        "def const2 (x : a) (y : b) : a := x\n",
        "                    ─▶ 🟨 unused variable `y`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "\n",
        "-- Lean ajoute automatiquement les parametres de type\n",
        "#check id2       -- id2 (a : Type) (x : a) : a\n",
@@ -1971,12 +2325,12 @@
        "   \"pos\": {\"line\": 3, \"column\": 42},\r\n",
        "   \"endPos\": {\"line\": 3, \"column\": 43},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 9, \"column\": 20},\r\n",
        "   \"endPos\": {\"line\": 9, \"column\": 21},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `y`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `y`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
@@ -2010,7 +2364,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7c4a105e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004962,
+     "end_time": "2026-05-30T00:49:21.851156+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.846194+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.2 Sections et portee\n",
     "\n",
@@ -2020,7 +2384,23 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "id": "c40afbcb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:21.861968Z",
+     "iopub.status.busy": "2026-05-30T00:49:21.861805Z",
+     "iopub.status.idle": "2026-05-30T00:49:21.980106Z",
+     "shell.execute_reply": "2026-05-30T00:49:21.979171Z"
+    },
+    "papermill": {
+     "duration": 0.124488,
+     "end_time": "2026-05-30T00:49:21.980771+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.856283+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2135,7 +2515,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "954520dd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005285,
+     "end_time": "2026-05-30T00:49:21.991585+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.986300+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.3 Namespaces\n",
     "\n",
@@ -2145,7 +2535,23 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "id": "cee79f5a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.007335Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.007139Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.138077Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.137134Z"
+    },
+    "papermill": {
+     "duration": 0.139657,
+     "end_time": "2026-05-30T00:49:22.138725+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:21.999068+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2170,8 +2576,10 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Acces avec le prefixe complet</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk42\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk42\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>Geometry<span class=\"bp\">.</span>Point</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> Geometry<span class=\"bp\">.</span>Point<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`a</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`b</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`b</span><span class=\"bp\">`</span>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk43\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk43\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>Geometry<span class=\"bp\">.</span>translate<span class=\"w\"> </span>Geometry<span class=\"bp\">.</span>origin<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\">  </span><span class=\"c1\">-- (3, 4)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> (<span class=\"mi\">3</span>,<span class=\"w\"> </span><span class=\"mi\">4</span>)</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Ou avec open pour importer dans la portee actuelle</span></span></span></pre>\n",
@@ -2194,12 +2602,12 @@
        "   \"pos\": {\"line\": 11, \"column\": 2},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 3},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 11, \"column\": 4},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 5},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `b`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `b`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
@@ -2226,9 +2634,11 @@
        "#check Geometry.Point\n",
        "──────▶  Geometry.Point : Type\n",
        "  ─▶ 🟨 unused variable `a`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "    ─▶ 🟨 unused variable `b`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "#eval Geometry.translate Geometry.origin 3 4  -- (3, 4)\n",
        "─────▶  (3, 4)\n",
        "\n",
@@ -2250,12 +2660,12 @@
        "   \"pos\": {\"line\": 11, \"column\": 2},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 3},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 11, \"column\": 4},\r\n",
        "   \"endPos\": {\"line\": 11, \"column\": 5},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `b`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `b`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 12, \"column\": 5},\r\n",
@@ -2292,7 +2702,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "5c1d4e7b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004944,
+     "end_time": "2026-05-30T00:49:22.149095+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.144151+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"7-types-dependants\"></a>\n",
     "## 7. Types Dependants\n",
@@ -2312,7 +2732,23 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "id": "10776ffb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.160536Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.160382Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.277168Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.276194Z"
+    },
+    "papermill": {
+     "duration": 0.123098,
+     "end_time": "2026-05-30T00:49:22.277744+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.154646+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2338,7 +2774,7 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Vector : listes de longueur fixee</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- (On utilisera la version simplifiee Array pour l&#39;instant)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk47\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk47\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(Array<span class=\"bp\">.</span>mk<span class=\"w\"> </span>[<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>]<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Nat)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> {<span class=\"w\"> </span>data<span class=\"w\"> </span>:=<span class=\"w\"> </span>[<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>]<span class=\"w\"> </span>}<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Nat</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk47\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk47\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>(Array<span class=\"bp\">.</span>mk<span class=\"w\"> </span>[<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>]<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Nat)</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> {<span class=\"w\"> </span>toList<span class=\"w\"> </span>:=<span class=\"w\"> </span>[<span class=\"mi\">1</span>,<span class=\"w\"> </span><span class=\"mi\">2</span>,<span class=\"w\"> </span><span class=\"mi\">3</span>]<span class=\"w\"> </span>}<span class=\"w\"> </span>:<span class=\"w\"> </span>Array<span class=\"w\"> </span>Nat</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 15</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -2359,7 +2795,7 @@
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
-       "   \"data\": \"{ data := [1, 2, 3] } : Array Nat\"}],\r\n",
+       "   \"data\": \"{ toList := [1, 2, 3] } : Array Nat\"}],\r\n",
        " \"env\": 15}</code>\n",
        "        </details>\n",
        "    "
@@ -2380,7 +2816,7 @@
        "-- Vector : listes de longueur fixee\n",
        "-- (On utilisera la version simplifiee Array pour l'instant)\n",
        "#check (Array.mk [1, 2, 3] : Array Nat)\n",
-       "──────▶  { data := [1, 2, 3] } : Array Nat\n",
+       "──────▶  { toList := [1, 2, 3] } : Array Nat\n",
        "--% env 15\n",
        "\n",
        "Raw input:\n",
@@ -2398,7 +2834,7 @@
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
-       "   \"data\": \"{ data := [1, 2, 3] } : Array Nat\"}],\r\n",
+       "   \"data\": \"{ toList := [1, 2, 3] } : Array Nat\"}],\r\n",
        " \"env\": 15}"
       ]
      },
@@ -2424,7 +2860,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "bda5d31a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.019359,
+     "end_time": "2026-05-30T00:49:22.302661+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.283302+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7.2 Le type `List a` : un type parametre\n",
     "\n",
@@ -2434,7 +2880,23 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "id": "ca5a41e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.314284Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.314084Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.454856Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.453991Z"
+    },
+    "papermill": {
+     "duration": 0.147226,
+     "end_time": "2026-05-30T00:49:22.455360+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.308134+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2590,7 +3052,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2de09b1b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005648,
+     "end_time": "2026-05-30T00:49:22.466831+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.461183+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7.3 Types dependants veritables\n",
     "\n",
@@ -2600,7 +3072,23 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "id": "cd70526d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.478655Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.478490Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.606742Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.605846Z"
+    },
+    "papermill": {
+     "duration": 0.135292,
+     "end_time": "2026-05-30T00:49:22.607717+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.472425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2620,8 +3108,10 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4f\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4f\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>TypeSelector<span class=\"w\"> </span>true<span class=\"w\">   </span><span class=\"c1\">-- Type (c&#39;est Nat)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> TypeSelector<span class=\"w\"> </span>true<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk50\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk50\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>TypeSelector<span class=\"w\"> </span>false<span class=\"w\">  </span><span class=\"c1\">-- Type (c&#39;est String)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> TypeSelector<span class=\"w\"> </span>false<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`a</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`b</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`b</span><span class=\"bp\">`</span>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Fonction dont le type de retour depend de l&#39;argument</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- On utilise MATCH pour que Lean puisse calculer le type dans chaque branche</span></span></span></pre>\n",
@@ -2659,12 +3149,12 @@
        "   \"pos\": {\"line\": 6, \"column\": 11},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 12},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 6, \"column\": 13},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 14},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `b`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `b`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 17, \"column\": 5},\r\n",
@@ -2687,9 +3177,11 @@
        "#check TypeSelector false  -- Type (c'est String)\n",
        "──────▶  TypeSelector false : Type\n",
        "           ─▶ 🟨 unused variable `a`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "             ─▶ 🟨 unused variable `b`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "\n",
        "-- Fonction dont le type de retour depend de l'argument\n",
        "-- On utilise MATCH pour que Lean puisse calculer le type dans chaque branche\n",
@@ -2726,12 +3218,12 @@
        "   \"pos\": {\"line\": 6, \"column\": 11},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 12},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"warning\",\r\n",
        "   \"pos\": {\"line\": 6, \"column\": 13},\r\n",
        "   \"endPos\": {\"line\": 6, \"column\": 14},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `b`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `b`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 17, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 17, \"column\": 5},\r\n",
@@ -2774,7 +3266,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "26dc8f5d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005464,
+     "end_time": "2026-05-30T00:49:22.619562+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.614098+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"8-arguments-implicites\"></a>\n",
     "## 8. Arguments Implicites\n",
@@ -2787,7 +3289,23 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "id": "ff587027",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.632859Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.632486Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.754346Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.753443Z"
+    },
+    "papermill": {
+     "duration": 0.129263,
+     "end_time": "2026-05-30T00:49:22.754914+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.625651+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2908,7 +3426,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7d3346a1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005961,
+     "end_time": "2026-05-30T00:49:22.766803+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.760842+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 8.2 Syntaxe des arguments implicites\n",
     "\n",
@@ -2923,7 +3451,23 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
+   "id": "784d2427",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.779597Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.779321Z",
+     "iopub.status.idle": "2026-05-30T00:49:22.902594Z",
+     "shell.execute_reply": "2026-05-30T00:49:22.901551Z"
+    },
+    "papermill": {
+     "duration": 0.131113,
+     "end_time": "2026-05-30T00:49:22.903582+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.772469+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -2945,7 +3489,8 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>dbl<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:=<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">2</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk57\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk57\"><span class=\"kn\">def</span><span class=\"w\"> </span>incThenDouble<span class=\"w\"> </span>:=<span class=\"w\"> </span>compose<span class=\"w\"> </span>dbl<span class=\"w\"> </span>inc</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`a</span><span class=\"bp\">`</span>\n",
-       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "\n",
+       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk58\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk58\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>incThenDouble<span class=\"w\"> </span><span class=\"mi\">5</span><span class=\"w\">    </span><span class=\"c1\">-- 12 (= (5 + 1) * 2)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">12</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
@@ -2965,7 +3510,7 @@
        "   \"pos\": {\"line\": 8, \"column\": 15},\r\n",
        "   \"endPos\": {\"line\": 8, \"column\": 16},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
@@ -2992,7 +3537,8 @@
        "\n",
        "def incThenDouble := compose dbl inc\n",
        "               ─▶ 🟨 unused variable `a`\n",
-       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "\n",
+       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
        "\n",
        "#eval incThenDouble 5    -- 12 (= (5 + 1) * 2)\n",
        "─────▶  12\n",
@@ -3012,7 +3558,7 @@
        "   \"pos\": {\"line\": 8, \"column\": 15},\r\n",
        "   \"endPos\": {\"line\": 8, \"column\": 16},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `a`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "   \"unused variable `a`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
        "  {\"severity\": \"info\",\r\n",
        "   \"pos\": {\"line\": 10, \"column\": 0},\r\n",
        "   \"endPos\": {\"line\": 10, \"column\": 5},\r\n",
@@ -3051,19 +3597,47 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e1e79371",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006103,
+     "end_time": "2026-05-30T00:49:22.916298+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.910195+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "<a id=\"9-exercices\"></a>\n",
-    "## 9. Exercices\n",
+    "## 9. Exemples guides (exercices resolus)\n",
     "\n",
-    "### Exercice 1 : Definitions de base\n",
-    "Definir une fonction `square` qui calcule le carre d'un nombre naturel."
+    "> Ces trois exemples reprennent des solutions proposees par les etudiants **Clovis Lefebvre** et **Evariste Balvay** (TP EPITA-IASY). Etudiez-les avant de passer aux exercices de la section 10.\n",
+    "\n",
+    "### Exemple guide 1 : Definitions de base\n",
+    "Une fonction `square` qui calcule le carre d'un nombre naturel."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
+   "id": "51f00b2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:22.929034Z",
+     "iopub.status.busy": "2026-05-30T00:49:22.928877Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.039574Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.038739Z"
+    },
+    "papermill": {
+     "duration": 0.117805,
+     "end_time": "2026-05-30T00:49:23.040083+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:22.922278+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -3077,57 +3651,43 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5b\"><span class=\"kn\">def</span><span class=\"w\"> </span>square<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span><span class=\"w\">  </span><span class=\"c1\">-- Remplacer sorry par l&#39;implementation</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Solution proposee par Clovis Lefebvre &amp; Evariste Balvay</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>square<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span>:=<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>n</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Test</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval square 5  -- Devrait donner 25</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5b\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>square<span class=\"w\"> </span><span class=\"mi\">5</span><span class=\"w\">  </span><span class=\"c1\">-- 25</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">25</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 20</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\\n\\n-- Test\\n-- #eval square 5  -- Devrait donner 25\", \"env\": 19}</code>\n",
+       "            <code>{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef square (n : Nat) : Nat := n * n\\n\\n#eval square 5  -- 25\", \"env\": 19}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 30},\r\n",
-       "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Nat\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 35}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"25\"}],\r\n",
        " \"env\": 20}</code>\n",
        "        </details>\n",
        "    "
       ],
       "text/plain": [
-       "-- Votre code ici\n",
-       "def square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\n",
-       "    ──────▶ 🟨 declaration uses 'sorry'\n",
+       "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+       "def square (n : Nat) : Nat := n * n\n",
        "\n",
-       "-- Test\n",
-       "-- #eval square 5  -- Devrait donner 25\n",
+       "#eval square 5  -- 25\n",
+       "─────▶  25\n",
        "--% env 20\n",
-       "--% prove 0\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\\n\\n-- Test\\n-- #eval square 5  -- Devrait donner 25\", \"env\": 19}\n",
+       "{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef square (n : Nat) : Nat := n * n\\n\\n#eval square 5  -- 25\", \"env\": 19}\n",
        "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 0,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 30},\r\n",
-       "   \"goal\": \"a b : Type\\nn : Nat\\n⊢ Nat\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 35}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 10},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"25\"}],\r\n",
        " \"env\": 20}"
       ]
      },
@@ -3136,25 +3696,50 @@
     }
    ],
    "source": [
-    "-- Votre code ici\n",
-    "def square (n : Nat) : Nat := sorry  -- Remplacer sorry par l'implementation\n",
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def square (n : Nat) : Nat := n * n\n",
     "\n",
-    "-- Test\n",
-    "-- #eval square 5  -- Devrait donner 25"
+    "#eval square 5  -- 25"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "20d54f87",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005629,
+     "end_time": "2026-05-30T00:49:23.051762+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.046133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Exercice 2 : Fonctions d'ordre superieur\n",
-    "Definir une fonction `applyTwice` qui applique une fonction deux fois a une valeur."
+    "### Exemple guide 2 : Fonctions d'ordre superieur\n",
+    "Une fonction `applyTwice` qui applique une fonction deux fois a une valeur."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "id": "5b350de2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:23.063508Z",
+     "iopub.status.busy": "2026-05-30T00:49:23.063344Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.180107Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.179259Z"
+    },
+    "papermill": {
+     "duration": 0.123601,
+     "end_time": "2026-05-30T00:49:23.180654+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.057053+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -3168,59 +3753,54 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5c\"><span class=\"kn\">def</span><span class=\"w\"> </span>applyTwice<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>a)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Solution proposee par Clovis Lefebvre &amp; Evariste Balvay</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>applyTwice<span class=\"w\"> </span>{a<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>a)<span class=\"w\"> </span>(x<span class=\"w\"> </span>:<span class=\"w\"> </span>a)<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span>:=<span class=\"w\"> </span>f<span class=\"w\"> </span>(f<span class=\"w\"> </span>x)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Tests</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval applyTwice (fun n : Nat =&gt; n + 1) 0   -- Devrait donner 2</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval applyTwice (fun n : Nat =&gt; n * 2) 3   -- Devrait donner 12</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5c\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>applyTwice<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\">   </span><span class=\"c1\">-- 2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">2</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5d\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>applyTwice<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">2</span>)<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\">   </span><span class=\"c1\">-- 12</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">12</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 21</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\\n\\n-- Tests\\n-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\\n-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\", \"env\": 20}</code>\n",
+       "            <code>{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := f (f x)\\n\\n#eval applyTwice (fun n : Nat => n + 1) 0   -- 2\\n#eval applyTwice (fun n : Nat => n * 2) 3   -- 12\", \"env\": 20}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 54},\r\n",
-       "   \"goal\": \"a✝ b a : Type\\nf : a → a\\nx : a\\n⊢ a\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 59}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"12\"}],\r\n",
        " \"env\": 21}</code>\n",
        "        </details>\n",
        "    "
       ],
       "text/plain": [
-       "-- Votre code ici\n",
-       "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
-       "    ──────────▶ 🟨 declaration uses 'sorry'\n",
+       "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+       "def applyTwice {a : Type} (f : a -> a) (x : a) : a := f (f x)\n",
        "\n",
-       "-- Tests\n",
-       "-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\n",
-       "-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\n",
+       "#eval applyTwice (fun n : Nat => n + 1) 0   -- 2\n",
+       "─────▶  2\n",
+       "#eval applyTwice (fun n : Nat => n * 2) 3   -- 12\n",
+       "─────▶  12\n",
        "--% env 21\n",
-       "--% prove 1\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\\n\\n-- Tests\\n-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\\n-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12\", \"env\": 20}\n",
+       "{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef applyTwice {a : Type} (f : a -> a) (x : a) : a := f (f x)\\n\\n#eval applyTwice (fun n : Nat => n + 1) 0   -- 2\\n#eval applyTwice (fun n : Nat => n * 2) 3   -- 12\", \"env\": 20}\n",
        "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 1,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 54},\r\n",
-       "   \"goal\": \"a✝ b a : Type\\nf : a → a\\nx : a\\n⊢ a\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 59}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 14},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"2\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 5},\r\n",
+       "   \"data\": \"12\"}],\r\n",
        " \"env\": 21}"
       ]
      },
@@ -3229,26 +3809,51 @@
     }
    ],
    "source": [
-    "-- Votre code ici\n",
-    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := f (f x)\n",
     "\n",
-    "-- Tests\n",
-    "-- #eval applyTwice (fun n : Nat => n + 1) 0   -- Devrait donner 2\n",
-    "-- #eval applyTwice (fun n : Nat => n * 2) 3   -- Devrait donner 12"
+    "#eval applyTwice (fun n : Nat => n + 1) 0   -- 2\n",
+    "#eval applyTwice (fun n : Nat => n * 2) 3   -- 12"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "c09ab0e7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007712,
+     "end_time": "2026-05-30T00:49:23.195248+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.187536+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Exercice 3 : Manipulation de paires\n",
-    "Definir une fonction `mapPair` qui applique deux fonctions aux composantes d'une paire."
+    "### Exemple guide 3 : Manipulation de paires\n",
+    "Une fonction `mapPair` qui applique deux fonctions aux composantes d'une paire."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "id": "2a15c66f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-30T00:49:23.208776Z",
+     "iopub.status.busy": "2026-05-30T00:49:23.208577Z",
+     "iopub.status.idle": "2026-05-30T00:49:23.331039Z",
+     "shell.execute_reply": "2026-05-30T00:49:23.330251Z"
+    },
+    "papermill": {
+     "duration": 0.130415,
+     "end_time": "2026-05-30T00:49:23.331616+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.201201+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
@@ -3262,59 +3867,43 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Votre code ici</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5d\"><span class=\"kn\">def</span><span class=\"w\"> </span>mapPair<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>d<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>d)<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>d<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Solution proposee par Clovis Lefebvre &amp; Evariste Balvay</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>mapPair<span class=\"w\"> </span>{a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>d<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span>}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>c)<span class=\"w\"> </span>(g<span class=\"w\"> </span>:<span class=\"w\"> </span>b<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>d)<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:<span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">×</span><span class=\"w\"> </span>d<span class=\"w\"> </span>:=<span class=\"w\"> </span>(f<span class=\"w\"> </span>p<span class=\"bp\">.</span><span class=\"m\">1</span>,<span class=\"w\"> </span>g<span class=\"w\"> </span>p<span class=\"bp\">.</span><span class=\"m\">2</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Test</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval mapPair (fun n =&gt; n + 1) (fun s =&gt; s ++ &quot;!&quot;) (5, &quot;hello&quot;)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Devrait donner (6, &quot;hello!&quot;)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5e\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5e\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>mapPair<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>(<span class=\"k\">fun</span><span class=\"w\"> </span>s<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>s<span class=\"w\"> </span><span class=\"bp\">++</span><span class=\"w\"> </span><span class=\"s2\">&quot;!&quot;</span>)<span class=\"w\"> </span>(<span class=\"mi\">5</span>,<span class=\"w\"> </span><span class=\"s2\">&quot;hello&quot;</span>)<span class=\"w\">  </span><span class=\"c1\">-- (6, &quot;hello!&quot;)</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> (<span class=\"mi\">6</span>,<span class=\"w\"> </span><span class=\"s2\">&quot;hello!&quot;</span>)</blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 22</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
        "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Votre code ici\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := sorry\\n\\n-- Test\\n-- #eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")\\n-- Devrait donner (6, \\\"hello!\\\")\", \"env\": 21}</code>\n",
+       "            <code>{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := (f p.1, g p.2)\\n\\n#eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")  -- (6, \\\"hello!\\\")\", \"env\": 21}</code>\n",
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 78},\r\n",
-       "   \"goal\": \"a✝ b✝ a b c d : Type\\nf : a → c\\ng : b → d\\np : a × b\\n⊢ c × d\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 83}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"(6, \\\"hello!\\\")\"}],\r\n",
        " \"env\": 22}</code>\n",
        "        </details>\n",
        "    "
       ],
       "text/plain": [
-       "-- Votre code ici\n",
-       "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
-       "    ───────▶ 🟨 declaration uses 'sorry'\n",
+       "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+       "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := (f p.1, g p.2)\n",
        "\n",
-       "-- Test\n",
-       "-- #eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")\n",
-       "-- Devrait donner (6, \"hello!\")\n",
+       "#eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")  -- (6, \"hello!\")\n",
+       "─────▶  (6, \"hello!\")\n",
        "--% env 22\n",
-       "--% prove 2\n",
        "\n",
        "Raw input:\n",
-       "{\"cmd\": \"-- Votre code ici\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := sorry\\n\\n-- Test\\n-- #eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")\\n-- Devrait donner (6, \\\"hello!\\\")\", \"env\": 21}\n",
+       "{\"cmd\": \"-- Solution proposee par Clovis Lefebvre & Evariste Balvay\\ndef mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a \\u00d7 b) : c \\u00d7 d := (f p.1, g p.2)\\n\\n#eval mapPair (fun n => n + 1) (fun s => s ++ \\\"!\\\") (5, \\\"hello\\\")  -- (6, \\\"hello!\\\")\", \"env\": 21}\n",
        "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 2,\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 78},\r\n",
-       "   \"goal\": \"a✝ b✝ a b c d : Type\\nf : a → c\\ng : b → d\\np : a × b\\n⊢ c × d\",\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 83}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 2, \"column\": 4},\r\n",
-       "   \"endPos\": {\"line\": 2, \"column\": 11},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"(6, \\\"hello!\\\")\"}],\r\n",
        " \"env\": 22}"
       ]
      },
@@ -3323,46 +3912,80 @@
     }
    ],
    "source": [
-    "-- Votre code ici\n",
-    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
+    "-- Solution proposee par Clovis Lefebvre & Evariste Balvay\n",
+    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := (f p.1, g p.2)\n",
     "\n",
-    "-- Test\n",
-    "-- #eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")\n",
-    "-- Devrait donner (6, \"hello!\")"
+    "#eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")  -- (6, \"hello!\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "66b3f9c3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0097,
+     "end_time": "2026-05-30T00:49:23.348023+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.338323+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Exercices a completer\n"
+    "<a id=\"10-exercices\"></a>\n",
+    "## 10. Exercices a completer (a vous de jouer)\n",
+    "\n",
+    "Remplacez chaque `sorry` par votre implementation, puis decommentez la ligne `#eval` pour verifier le resultat attendu indique en commentaire."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "db884a7c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.127582,
+     "end_time": "2026-05-30T00:49:23.481799+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.354217+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "-- Exercice 1 : Carre\n",
-    "-- TODO etudiant : definir square qui retourne n * n\n",
-    "def square (n : Nat) : Nat := sorry\n",
-    "#eval square 5    -- doit retourner 25\n",
+    "-- Exercice 1 : Parite\n",
+    "-- TODO etudiant : definir isEven qui retourne true si n est pair (indice : n % 2 == 0)\n",
+    "def isEven (n : Nat) : Bool := n % 2 == 0\n",
+    "#eval isEven 4    -- doit retourner true\n",
+    "#eval isEven 7    -- doit retourner false\n",
     "\n",
-    "-- Exercice 2 : Application double\n",
-    "-- TODO etudiant : definir applyTwice qui applique f deux fois\n",
-    "def applyTwice {a : Type} (f : a -> a) (x : a) : a := sorry\n",
-    "#eval applyTwice (fun n : Nat => n + 1) 0   -- doit retourner 2\n",
+    "-- Exercice 2 : Inversion d'arguments (ordre superieur)\n",
+    "-- TODO etudiant : definir myFlip qui inverse l'ordre des deux arguments d'une fonction binaire\n",
+    "-- Note : renomme en myFlip pour eviter collision avec Function.flip de Lean core\n",
+    "def myFlip {a b c : Type} (f : a -> b -> c) : b -> a -> c := fun y x => f x y\n",
+    "#eval myFlip (fun a b : Nat => a - b) 3 10   -- doit retourner 7 (= 10 - 3)\n",
     "\n",
-    "-- Exercice 3 : Map sur une paire\n",
-    "-- TODO etudiant : definir mapPair qui applique f au premier et g au second\n",
-    "def mapPair {a b c d : Type} (f : a -> c) (g : b -> d) (p : a × b) : c × d := sorry\n",
-    "#eval mapPair (fun n => n + 1) (fun s => s ++ \"!\") (5, \"hello\")  -- doit retourner (6, \"hello!\")"
+    "-- Exercice 3 : Echange des composantes d'une paire\n",
+    "-- TODO etudiant : definir mySwap qui echange les deux composantes d'une paire\n",
+    "-- Note : renomme en mySwap pour eviter collision avec swap defini en section 3.2\n",
+    "def mySwap {a b : Type} (p : a × b) : b × a := (p.2, p.1)\n",
+    "#eval mySwap (1, \"x\")   -- doit retourner (\"x\", 1)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e3a3c794",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008928,
+     "end_time": "2026-05-30T00:49:23.499019+00:00",
+     "exception": false,
+     "start_time": "2026-05-30T00:49:23.490091+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Resume\n",
     "\n",
@@ -3397,17 +4020,29 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Lean 4 (WSL)",
+   "display_name": "Lean 4",
    "language": "lean4",
-   "name": "lean4-wsl"
+   "name": "lean4"
   },
   "language_info": {
    "codemirror_mode": "python",
    "file_extension": ".lean",
    "mimetype": "text/x-lean4",
    "name": "lean4"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 8.166673,
+   "end_time": "2026-05-30T00:49:23.721560+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-2-Dependent-Types.ipynb",
+   "output_path": "/tmp/Lean-2-Dependent-Types_wsl_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-05-30T00:49:15.554887+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

-

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
