### PR TITLE
fix(prover): report actual_iterations in run_prover_bg summary (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -101,6 +101,8 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     print(f"\n{'='*60}")
     print(f"RESULT: {result.get('status', 'unknown')}")
     print(f"  Sorry: {original_sorry} → {final_sorry}")
+    _actual_iters = result.get("iterations") if isinstance(result, dict) else None
+    print(f"  Iterations: {_actual_iters if _actual_iters is not None else '?'}/{iterations} (actual/budget)")
     print(f"  Time: {elapsed:.1f}s")
     print(f"  Trace: {trace_path}")
     print(f"{'='*60}")
@@ -111,7 +113,16 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
         "mode": mode,
         "provider": provider,
         "coordinator_provider": coordinator_provider or "openrouter (default)",
+        # `iterations` is the REQUESTED budget (the max_iterations CLI arg). Kept
+        # under this key for backward compat with existing trace analyzers.
+        # `actual_iterations` is how many iterations the prover actually ran
+        # (from the prover result; None if the run crashed before reporting).
+        # Forensic (#1453 P4): the summary previously exposed only the budget, so
+        # a run that hit the cap and one that exited early after 2 iterations were
+        # indistinguishable in the top-level field — the actual count was buried
+        # in `result["iterations"]`. Both are now legible side by side.
         "iterations": iterations,
+        "actual_iterations": result.get("iterations") if isinstance(result, dict) else None,
         "original_sorry": original_sorry,
         "final_sorry": final_sorry,
         "sorry_delta": final_sorry - original_sorry,


### PR DESCRIPTION
## Summary

Single-subject observability fix for the prover BG harness (Part of #1453 — forensic backlog item **P4**, "iterations = max not actual").

`run_prover_bg.py`'s result-summary JSON exposed only `iterations` = the **requested budget** (the `max_iterations` CLI arg, default 8). The prover's **actual** iteration count (`state.iteration`) is already reported correctly by the inner provers (`provers.py:661`, `provers.py:1338`) but only inside the nested `result` object — the top-level summary field hid it. When the prover-forensic survey analysed the 15-24 May traces, a run that exhausted the cap and one that exited early after 2 iterations were indistinguishable from the top-level `iterations` field.

## Change (additive, +11/-0, 1 file)

- Add `actual_iterations` to the summary dict: `result.get("iterations")`, resolving to `None` if the run crashed before reporting. The existing `iterations` (budget) key is **kept unchanged** for backward compat with existing trace analyzers — no rename (per the P4 note "ne pas renommer").
- Add a matching `Iterations: <actual>/<budget> (actual/budget)` line to the RESULT stdout block for live monitoring during long BG runs.

## Verification (GPU-free — reporting-only change, no prover run required)

- `python -m py_compile run_prover_bg.py` -> OK (syntax valid).
- Logic check of the new field expression:
  - `{'status':'proved','iterations':3}` -> `actual_iterations=3`
  - `{'status':'no_progress','iterations':2}` -> `actual_iterations=2`
  - `{'error':'boom'}` -> `actual_iterations=None` (honest on crash)
  - non-dict -> `actual_iterations=None`
- `git diff origin/main` = **+11/-0**, pure-append: 0 existing lines deleted or modified, LF preserved (committed blob = 0 CRLF).
- No Lean / notebook / ML / QC files touched -> review criteria A-G N/A; no catalog touch -> `catalog-drift` unaffected.

Part of #1453.
