### PR TITLE
fix(gametheory): relabel GT-4 section 9 headers Exemple guide -> Exercice (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
@@ -1629,15 +1629,15 @@
     "tags": []
    },
    "source": [
-    "## 9. Exemples guides\n",
+    "## 9. Exercices\n",
     "\n",
-    "### Exemple guide 1\n",
+    "### Exercice 1\n",
     "Trouvez l'equilibre mixte de Battle of the Sexes a la main, puis verifiez avec Nashpy.\n",
     "\n",
-    "### Exemple guide 2\n",
+    "### Exercice 2\n",
     "Creez un jeu 3x3 avec exactement 2 equilibres de Nash purs.\n",
     "\n",
-    "### Exemple guide 3\n",
+    "### Exercice 3\n",
     "Analysez comment l'equilibre mixte de Stag Hunt varie quand on change le gain de la cooperation."
    ]
   },


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **GameTheory-4-NashEquilibrium.ipynb** (serie GameTheory, lane PROFONDEUR), dans le cadre du wrapup #2259 / Epic #2162. La section 9 affichait un header markdown `## 9. Exemples guides` + `### Exemple guide 1/2/3` alors que son contenu est un **exercice a completer** — confusion active pour les etudiants pendant le cours EPITA-IS live (un header « Exemple guide » au-dessus d'un stub vide a remplir).

## Diagnostic (content-based, pas par titre)

Le header de cell 30 disait `Exemple guide N` mais le contenu est sans ambiguite un exercice :

| Indice | Verdict |
|--------|---------|
| Cell 30 (md) — enonces = **descriptions de tache** : « Trouvez l'equilibre mixte de Battle of the Sexes... », « Creez un jeu 3x3... », « Analysez comment l'equilibre... varie » | cadrage **exercice** |
| Cell 31 (code) — **ouvre par `# Espace pour les exercices`**, chaque fonction = `pass  # TODO etudiant`, ferme par `print("Exercice a completer")` | **stub d'exercice genuine** |
| Cells 8 et 27 (memes section exercices du notebook) — deja nommees `exercice_dominance_iteree` / `exercice_nash_3x3_rps_biaise` | la section 9 EST la section exercices |

= **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) : « Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** ».

## Preuve git decisive (de-gaming, PAS un revert conteste)

`git log -S '### Exercice 1' -- <GT-4>` (verifie ce cycle) :
- `ec61fd57` (« feat(gametheory): add complete Game Theory notebook series (1-15) ») a cre les headers **`## 9. Exercices` / `### Exercice 1/2/3`** (etat correct d'origine).
- `1a2645d8` (« relabel 28 solution leaks as Exemple guide #1205 Phase 2 ») a fait un **find-replace AVEUGLE** : diff verifie sur GT-4 = `-"### Exercice 1\n"` / `+"### Exemple guide 1\n"` (idem 2/3), **alors que le code etait deja un stub** (rien a de-leaker). C'est exactement le pattern de gaming du leak-scanner de la classe #1214 / #1336.

Cette PR **RESTAURE les labels originaux** (`Exemple guide N` -> `Exercice N`) = annule un commit de gaming documente, et **continue la direction content-based validee** `8b547c83` (#1562/#1570) qui avait corrige les autres notebooks mais manque GT-4. **Pas un revert d'un relabel valide** (#1343).

## Correction

4 headers markdown relabeles (cell 30 uniquement) :
- `## 9. Exemples guides` -> `## 9. Exercices`
- `### Exemple guide 1` -> `### Exercice 1`
- `### Exemple guide 2` -> `### Exercice 2`
- `### Exemple guide 3` -> `### Exercice 3`

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 4 insertions / 4 deletions** — exactement les 4 lignes header de cell 30, 0 reformatage JSON, 0 cellule ajoutee/supprimee (34 cellules avant == apres).
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». 14 cellules code, **0 `execution_count: null`** ; cell 31 (les stubs de section 9) conserve `execution_count: 14` + ses outputs. Aucun re-exec staged (C.3 : seul du source markdown a change).
- **§D exec proof = N/A justifie** : la modif est **markdown-only** (exception C.2, pas de re-exec requis) ; de plus le kernel declare du notebook (`gametheory-wsl`) n'est pas disponible localement, donc une re-execution serait de toute facon impossible — mais elle n'est **pas necessaire** ici puisque aucune cellule code n'a change et les outputs committes restent valides. (Pas de contournement regle F : il n'y a pas de changement de code a re-executer.)
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** (scan Python sur le source des cellules, pas grep brut sur le JSON qui matcherait le base64 d'un PNG).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul).

## Note (residu hors-scope, deliberement differe)

Les commentaires internes et noms de fonctions de cell 31 (`# Exemple guide N`, `def exemple_N_...`) portent encore le meme residu `1a2645d8`. Les renommer en `exercice_N` serait un **changement de code** declenchant une re-execution (C.3) sur un kernel `gametheory-wsl` indisponible — hors-scope de ce fix markdown-only (1 sujet/PR). Le signal dominant du stub reste sans ambiguite (`# Espace pour les exercices`, `pass # TODO etudiant`, `print("Exercice a completer")`). A polir dans un cycle ulterieur touchant le code quand le kernel sera re-executable.

## Scope

Un seul sujet, un seul notebook : exactitude du label exercice sur GT-4-NashEquilibrium. Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025). NE touche PAS les notebooks `*-Lean-*` (GT-2b/4b/8b/15b) qui ont de genuine cellules « Correction » = vrais exemples resolus.

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
