### PR TITLE
fix(prover): P3 dynamic already-solved pre-check — skip spawn on 0-sorry target (#1453)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -64,6 +64,42 @@ def run_prover(demo_num: int = None, filepath: str = None, line: int = None,
     print(f"  Initial sorry count: {original_sorry}")
     print()
 
+    # P3 (#1453): dynamic pre-check — skip the (expensive) prover spawn when the
+    # target file already has no sorry. The static PROVED_DEMOS set (above) only
+    # covers demos curated by hand and goes stale; a target solved since the last
+    # curation — or any direct --file/--line target that is already clean — would
+    # otherwise still spawn a full multi-agent run for zero work (the forensic
+    # "already-solved schedule" pathology). A count of 0 is a SAFE skip signal:
+    # str.count("sorry") only ever OVER-counts (it also matches comments/strings),
+    # so == 0 guarantees there is genuinely nothing to prove and can never skip a
+    # live target. (count > 0 still spawns the prover, exactly as before.)
+    if original_sorry == 0:
+        print(f"Already solved: 0 sorry in {filepath} — skipping prover spawn.")
+        trace_name = f"{mode}_{name.replace(' ', '_')}_{provider}"
+        summary = {
+            "name": name,
+            "mode": mode,
+            "provider": provider,
+            "coordinator_provider": coordinator_provider or "openrouter (default)",
+            "iterations": iterations,
+            "actual_iterations": 0,
+            "original_sorry": 0,
+            "final_sorry": 0,
+            "sorry_delta": 0,
+            "elapsed_s": 0.0,
+            "result": {"status": "already_solved",
+                       "reason": "0 sorry in target file (pre-check, no prover spawn)"},
+            "trace_file": None,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        summary_path = TRACES_DIR / f"{trace_name}_result.json"
+        summary_path.write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+        print(f"Summary: {summary_path}")
+        return summary
+
     trace = TraceLogger(output_dir=str(TRACES_DIR))
 
     if mode == "multi":


### PR DESCRIPTION
## Prover harness #1453 — P3: dynamic already-solved pre-check

Side-track ai-01 (forensic backlog #1453, calm-window, **Lean-safe : 0 fichier `.lean` touche**, GPU-free).

### Probleme (forensic "already-solved schedule")

`run_prover_bg.py` skip deja les cibles **demo** connues via le set statique `PROVED_DEMOS` (resolution demo, avant spawn). Mais ce set est **cure a la main et se perime** : une cible resolue depuis la derniere curation — ou n'importe quelle cible directe `--file/--line` deja propre — declenche quand meme un **run multi-agent complet pour zero travail**. C'est la pathologie "already-solved schedule" relevee par le forensic (#1453).

### Fix (additif, +36/-0)

Pre-check **dynamique** insere apres le calcul de `original_sorry`, avant la construction du prover : si `original_sorry == 0`, la cible n'a plus aucun sorry -> on ecrit un summary `already_solved` et on `return` sans spawn.

```python
if original_sorry == 0:
    print(f"Already solved: 0 sorry in {filepath} — skipping prover spawn.")
    ...
    "result": {"status": "already_solved",
               "reason": "0 sorry in target file (pre-check, no prover spawn)"},
    ...
    return summary
```

### Pourquoi `== 0` est un signal SUR (anti-faux-skip)

`str.count("sorry")` ne fait que **SUR-compter** (il matche aussi les commentaires / chaines). Donc `== 0` garantit qu'il n'y a **genuinement aucun** sorry a prouver et **ne peut jamais skipper une cible vivante**. Tout `count > 0` spawn le prover exactement comme avant — comportement inchange sur les vraies cibles. (La contrainte connue "naive grep -c sorry over-counts" joue ici en faveur de la surete : le sur-comptage ne produit que des faux-NEGATIFS de skip, jamais des faux-positifs.)

### Coherence avec #2281 (P4)

Branche depuis `origin/main` (HEAD `91fac793`) qui contient deja #2281 (`actual_iterations`). Le summary `already_solved` expose `actual_iterations: 0` (coherent avec le champ P4). **Verifie : `actual_iterations` du run normal intact (ligne 161), aucun revert de #2281.** Le pre-check `return summary` respecte le contrat de la fonction (retour summary), contrairement au `sys.exit(0)` de `PROVED_DEMOS` qui agit avant que `name`/`filepath` soient resolus — non touche (un sujet par PR).

### Verification

- `python -m py_compile run_prover_bg.py` -> OK
- `git diff --numstat origin/main` -> `36 0` (pur append, 0 deletion)
- 0 fichier `.lean` touche -> **§B Lean discipline N/A** (aucune preuve modifiee, aucun `grep -c sorry` Lean concerne)

Part of #1453.
