### PR TITLE
fix(gametheory): relabel section 10 Exemple guide -> Exercice on GT-3-Topology2x2 (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
@@ -2337,15 +2337,15 @@
     "tags": []
    },
    "source": [
-    "## 10. Exemples guides\n",
+    "## 10. Exercices\n",
     "\n",
-    "### Exemple guide 1\n",
+    "### Exercice 1\n",
     "Trouvez la sequence de swaps minimale pour transformer Chicken en Matching Pennies.\n",
     "\n",
-    "### Exemple guide 2\n",
+    "### Exercice 2\n",
     "Identifiez tous les jeux a exactement 3 equilibres de Nash purs.\n",
     "\n",
-    "### Exemple guide 3\n",
+    "### Exercice 3\n",
     "Creez une visualisation montrant le \"chemin\" entre le Dilemme du Prisonnier et Harmony sur le graphe des jeux."
    ]
   },


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **GameTheory-3-Topology2x2.ipynb** (serie GameTheory, lane PROFONDEUR), dans le cadre du wrapup #2259 / Epic #2162. La section 10 affichait un header markdown `## 10. Exemples guides` + `### Exemple guide 1/2/3` alors que son contenu est un **exercice a completer** — confusion active pour les etudiants pendant le cours EPITA-IS live (un header « Exemple guide » au-dessus d'un stub vide a remplir).

## Diagnostic (content-based, pas par titre)

Le header de cell49 disait `Exemple guide N` mais tout le reste de la section dit « exercice » :

| Indice | Verdict |
|--------|---------|
| Cell49 (md) — enonces = **descriptions de tache** : « Trouvez la sequence de swaps minimale... », « Identifiez tous les jeux a exactement 3 equilibres... », « Creez une visualisation montrant le chemin... » | cadrage **exercice** |
| Cell50 (md, `### Pistes de solution`) — appelle **deja** les 3 items `**Exercice 1/2/3**` et donne des indices | la section EST une section exercices |
| Cell51 (code, exec_count 17) — **ouvre par `# Espace pour les exercices`**, ferme par `print("Exercice a completer : exploration topologique")` | **stub d'exercice genuine** |

= **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) : « Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** ». Le header etait le **seul** element incoherent (en contradiction avec cell50 « Exercice N » et cell51 stub).

## Preuve git decisive (de-gaming, PAS un revert conteste)

`git log -S '### Exercice 1' -- <GT-3>` (verifie ce cycle) :
- `ec61fd57` (« feat(gametheory): add complete Game Theory notebook series (1-15) ») a cree les headers **`## 10. Exercices` / `### Exercice 1/2/3`** (etat correct d'origine).
- `1a2645d8` (« relabel 28 solution leaks as Exemple guide #1205 Phase 2 ») a fait un **find-replace AVEUGLE** : diff verifie sur GT-3 = `-"## 10. Exercices\n"` / `+"## 10. Exemples guides\n"` (idem `### Exercice 1/2/3` -> `### Exemple guide 1/2/3`), **alors que le code etait deja un stub** (rien a de-leaker). C'est exactement le pattern de gaming du leak-scanner de la classe #1214 / #1336.
- `4880261e` (#2202, « enrich GameTheory-3: add 2 distributed exercises 0->3 ») **n'a PAS touche** la section 10 (grep vide sur `## 10.`/`Exemple guide`) ; il a **ajoute** des sections distinctes `### Exercice 1 : Voisins de swap` / `### Exercice 2 : Cartographie` ailleurs. Orthogonal — aucun conflit avec ce fix.

Cette PR **RESTAURE les labels originaux** (`Exemple guide N` -> `Exercice N`) = annule un commit de gaming documente et **continue la direction content-based validee** `8b547c83` (#1562/#1570) / #2278 / #2272 / #2286. **Pas un revert d'un relabel valide** (#1343).

## Correction

4 headers markdown relabeles (cell49 uniquement) :
- `## 10. Exemples guides` -> `## 10. Exercices`
- `### Exemple guide 1` -> `### Exercice 1`
- `### Exemple guide 2` -> `### Exercice 2`
- `### Exemple guide 3` -> `### Exercice 3`

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe. **Residu nul** : contrairement a GT-4, aucun residu `Exemple guide` ne subsiste dans les commentaires/noms de cell51 (scan `Exemple guide` post-edit = 0) — le fix est complet en markdown seul.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 4 insertions / 4 deletions** — exactement les 4 lignes header de cell49, 0 reformatage JSON, 0 cellule ajoutee/supprimee (54 cellules avant == apres).
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». 17 cellules code, **0 `execution_count: null`** ; cell51 (le stub de section 10) conserve `execution_count: 17` + ses outputs. Aucun re-exec staged (C.3 : seul du source markdown a change).
- **§D exec proof = N/A justifie** : modif **markdown-only** (exception C.2, pas de re-exec requis) ; de plus le kernel declare (`gametheory-wsl` / « Python (GameTheory WSL + OpenSpiel) ») n'est pas disponible localement, donc une re-execution serait impossible — mais elle n'est **pas necessaire** ici (aucune cellule code n'a change, outputs committes valides). Pas de contournement regle F : il n'y a pas de changement de code a re-executer.
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** (scan Python sur le source des cellules, pas grep brut sur le JSON qui matcherait le base64 d'un PNG).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul).

## Scope

Un seul sujet, un seul notebook : exactitude du label exercice sur GT-3-Topology2x2 (section 10). Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025). NE touche PAS les notebooks `*-Lean-*`.

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
