### PR TITLE
fix(gametheory): relabel sections 7+LQ Exemple guide -> Exercice on GT-14-DifferentialGames (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
@@ -1718,21 +1718,21 @@
     "tags": []
    },
    "source": [
-    "## 7. Exemples guides\n",
+    "## 7. Exercices\n",
     "\n",
-    "### Exemple guide 1 : Stackelberg asymetrique\n",
+    "### Exercice 1 : Stackelberg asymetrique\n",
     "\n",
     "Analysez un duopole de Stackelberg ou le leader et le follower ont des couts marginaux differents ($c_L \\neq c_F$).\n",
     "\n",
-    "### Exemple guide 2 : Jeu LQ a somme nulle\n",
+    "### Exercice 2 : Jeu LQ a somme nulle\n",
     "\n",
     "Implementez et resolvez un jeu differentiel a somme nulle (poursuite-evasion).\n",
     "\n",
-    "### Exemple guide 3 : Commitment value\n",
+    "### Exercice 3 : Commitment value\n",
     "\n",
     "Calculez la \"valeur de l'engagement\" : la difference de profit pour le leader entre Stackelberg et Cournot.\n",
     "\n",
-    "### Exemple guide 4 : Stackelberg a 3 joueurs\n",
+    "### Exercice 4 : Stackelberg a 3 joueurs\n",
     "\n",
     "Modelisez un jeu avec un leader et deux followers qui reagissent simultanement."
    ]
@@ -1808,7 +1808,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemple guide : Jeu differentiel linear-quadratic\n",
+    "## Exercice : Jeu differentiel linear-quadratic\n",
     "\n",
     "**Objectifs** :\n",
     "\n",


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **GameTheory-14-DifferentialGames.ipynb** (serie GameTheory, lane PROFONDEUR), dans le cadre du wrapup #2259 / Epic #2162. Deux sections affichaient un header markdown `Exemple guide` alors que leur contenu est un **exercice a completer** — confusion active pour les etudiants (un header « Exemple guide » au-dessus d'un stub vide a remplir).

## Diagnostic (content-based, pas par titre)

Deux sections, meme incoherence header-vs-contenu :

| Section | Header (avant) | Contenu reel | Verdict |
|---------|----------------|--------------|---------|
| cell28 (md) + cell29 (code, exec 10) | `## 7. Exemples guides` + `### Exemple guide 1/2/3/4` | enonces = **descriptions de tache** (« Analysez… », « Implementez et resolvez… », « Calculez… », « Modelisez… ») ; code = **stub** (`# Espace pour les exercices`, `def commitment_value(...): ... pass`, `print("Exercice a completer : ...")`), commentaire interne dit deja `# Exercice 3` | **exercice** |
| cell30 (md) + cell31 (code, exec 11) | `## Exemple guide : Jeu differentiel linear-quadratic` | « Objectifs » / « Questions » = cadrage tache ; code = **stub** (`# Exercice : Duopole dynamique LQ`, `# Exercice: Definir les parametres`, `print("Exercice a completer : ...")`) | **exercice** |

= **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) : « Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** ». Les seuls elements incoherents etaient les headers markdown — le code (stub), ses commentaires internes (`# Exercice N`) et les prints (`Exercice a completer`) disent tous deja « exercice ».

Les vrais exemples resolus du notebook (cell26 `EntryGame` = solution complete fonctionnelle, cell27 interpretation) ne portent **pas** le label « Exemple guide » et **ne sont pas touches**.

## Preuve git decisive (de-gaming, PAS un revert conteste)

`git log -S '### Exercice 1' / '### Exemple guide 1' / '## 7. Exemples guides' / '## 7. Exercices' -- <GT-14>` (verifie ce cycle) :
- `3fb94774` (« refactor(gametheory): reorganize notebooks with side tracks ») a cree la section avec les headers **`## 7. Exercices` / `### Exercice 1`** (etat correct d'origine).
- `1a2645d8` (« relabel 28 solution leaks as Exemple guide #1205 Phase 2 ») a fait un **find-replace AVEUGLE** : il a flippe `## 7. Exercices` -> `## 7. Exemples guides` et `### Exercice N` -> `### Exemple guide N`, **alors que le code etait deja un stub** (rien a de-leaker). C'est exactement le pattern de gaming du leak-scanner de la classe #1214 / #1336.

Cette PR **RESTAURE les labels originaux** (`Exemple guide` -> `Exercice`) = annule un commit de gaming documente et **continue la direction content-based validee** `8b547c83` (#1562/#1570) / #2278 / #2272 / #2286 / #2290. **Pas un revert d'un relabel valide** (#1343).

## Correction

6 headers markdown relabeles (cells 28 et 30 uniquement) :
- `## 7. Exemples guides` -> `## 7. Exercices`
- `### Exemple guide 1 : Stackelberg asymetrique` -> `### Exercice 1 : ...`
- `### Exemple guide 2 : Jeu LQ a somme nulle` -> `### Exercice 2 : ...`
- `### Exemple guide 3 : Commitment value` -> `### Exercice 3 : ...`
- `### Exemple guide 4 : Stackelberg a 3 joueurs` -> `### Exercice 4 : ...`
- `## Exemple guide : Jeu differentiel linear-quadratic` -> `## Exercice : ...`

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe. **Residu nul** : contrairement a GT-4, aucun residu `Exemple guide` ne subsiste dans les commentaires/noms de fonctions (les commentaires disaient deja `# Exercice N`) — scan `Exemple guide` post-edit = **0**, fix complet en markdown seul.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 6 insertions / 6 deletions** — exactement les 6 lignes header, 0 reformatage JSON, 0 cellule ajoutee/supprimee (**36 cellules avant == apres**).
- **§D exec proof = REEL** : kernel declare `python3` (Python 3) disponible localement -> re-execution Papermill Windows-side du notebook **edite** (`--kernel python3 --execution-timeout 1800`) -> **EXIT 0, 36/36 cellules, 0 erreur** (output ecrit en `/tmp`, PAS dans le repo — C.3). Sorties des 2 stubs d'exercice :
  - cell29 -> `Exercice a completer : Valeur de l engagement (Stackelberg vs Cournot)`
  - cell31 -> `Exercice a completer : Duopole dynamique LQ (equations differentielles)`
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». 12 cellules code, **0 `execution_count: null`** (0 hollow). Aucun re-exec staged dans le repo (C.3 : seul du source markdown a change ; le run Papermill ci-dessus est une preuve hors-repo).
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** (scan Python sur le source des cellules, pas grep brut sur le JSON qui matcherait le base64 d'un PNG).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul).

## Scope

Un seul sujet, un seul notebook : exactitude du label exercice sur GT-14-DifferentialGames (sections 7 et LQ). Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025). NE touche PAS les notebooks `*-Lean-*`.

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
