### PR TITLE
fix(gametheory): relabel Exemples guides -> Exercices on GT-15-CooperativeGames (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
@@ -2196,9 +2196,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Exemples guides\n",
+    "## Exercices\n",
     "\n",
-    "### Exemple guide 1 : Jeu de vote au Conseil de l'UE\n",
+    "### Exercice 1 : Jeu de vote au Conseil de l'UE\n",
     "\n",
     "Le Conseil de l'UE utilise la majorité qualifiée : 55% des États (15/27) représentant 65% de la population.\n",
     "\n",


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **GameTheory-15-CooperativeGames.ipynb** (serie GameTheory, lane PROFONDEUR), dans le cadre du wrapup #2259 / Epic #2162. La section finale affichait un header markdown `## Exemples guides` + `### Exemple guide 1` alors que son contenu est un **exercice a completer** — confusion active pour les etudiants pendant le cours EPITA-IS live (un header « Exemple guide » au-dessus d'un stub vide a remplir).

## Diagnostic (content-based, pas par titre)

L'incoherence est doublement evidente — le header de cell44 contredit a la fois son propre stub ET ses sections soeurs :

| Indice | Verdict |
|--------|---------|
| Cell44 (md) — enonce = **description de tache** : « Modelisez ce systeme et calculez les indices de pouvoir... » | cadrage **exercice** |
| Cell45 (code, exec 22) — **ouvre par `# Exercice 1 - À compléter`**, contient `# TODO etudiant`, code de solution **commente**, ferme par `print("Exercice a completer")` | **stub d'exercice genuine** |
| Cells 46/48 (md) — sections soeurs de la MEME section, **deja** nommees `### Exercice 2` / `### Exercice 3` (sur stubs cell47/49 identiques) | la section EST une section exercices |

Le header `## Exemples guides` / `### Exemple guide 1` etait donc le **seul** element incoherent, isole au milieu d'exercices 2 et 3 correctement labelises.

= **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) : « Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** ».

## Preuve git decisive (de-gaming, PAS un revert conteste)

`git show cbe23c1e -- <GT-15>` (verifie ce cycle) — l'etat **AVANT** ce commit (lignes `-` du diff) contenait :
```
## Exercices
### Exercice 1 : Jeu de vote au Conseil de l'UE
# Exercice 1 - À compléter          <- code DEJA un stub
### Exercice 2 : Core d'un jeu de partage
# Exercice 2 - À compléter
### Exercice 3 : Coalition alternative
# Exercice 3 - À compléter
```
Le commit `cbe23c1e` (« feat(GameTheory): rename solved exercises to "Exemple guide" ») a flippe **`## Exercices` -> `## Exemples guides`** et **`### Exercice 1` -> `### Exemple guide 1`** **alors que cell45 etait deja un stub** (`# Exercice 1 - À compléter`, rien a de-leaker) — et de facon **incoherente** (il a laisse `### Exercice 2` / `### Exercice 3` intacts). C'est exactement le pattern de gaming du leak-scanner de la classe #1214 / #1336. `1a2645d8` (#1205 Phase 2) est ensuite passe par la sans rectifier.

Cette PR **RESTAURE les labels originaux** (`## Exemples guides` / `### Exemple guide 1` -> `## Exercices` / `### Exercice 1`) = annule un relabel de gaming documente et **continue la direction content-based validee** `8b547c83` (#1562/#1570) / #2278 / #2272 / #2286 / #2290 / #2291. **Pas un revert d'un relabel valide** (#1343).

## Correction

2 headers markdown relabeles (cell44 uniquement) :
- `## Exemples guides` -> `## Exercices`
- `### Exemple guide 1 : Jeu de vote au Conseil de l'UE` -> `### Exercice 1 : ...`

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe. **Residu nul** : scan `Exemple guide` post-edit = **0** (le commentaire interne de cell45 disait deja `# Exercice 1`) — fix complet en markdown seul.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 2 insertions / 2 deletions** — exactement les 2 lignes header de cell44, 0 reformatage JSON, 0 cellule ajoutee/supprimee (**51 cellules avant == apres**).
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». 24 cellules code, **0 `execution_count: null`** ; cell45 (le stub de la section) conserve `execution_count: 22` + ses outputs. Aucun re-exec staged (C.3 : seul du source markdown a change).
- **§D exec proof = N/A justifie** : modif **markdown-only** (exception C.2, pas de re-exec requis) ; de plus le kernel declare (`gametheory-wsl` / OpenSpiel) n'est pas disponible localement, donc une re-execution serait impossible — mais elle n'est **pas necessaire** ici (aucune cellule code n'a change, outputs committes valides). Pas de contournement regle F : il n'y a pas de changement de code a re-executer.
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** (scan Python sur le source des cellules, pas grep brut sur le JSON qui matcherait le base64 d'un PNG).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul ; GT-15-CooperativeGames, PAS le variant Lean).

## Scope

Un seul sujet, un seul notebook : exactitude du label exercice sur GT-15-CooperativeGames (section finale). Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025). NE touche PAS les notebooks `*-Lean-*`.

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
