### PR TITLE
enrich(Tweety): add ASPIC+ exercise to Tweety-6 for >=3 target (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
@@ -471,6 +471,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73d6def2",
+   "source": "### Exercice : Debat contradictoire avec ASPIC+\n\nLa section 4.2 a montre comment ASPIC+ convertit une theorie structuree en cadre de Dung. Construisez votre propre theorie ASPIC+ pour modeliser un debat contradictoire sur l'approbation d'un projet.\n\n#### Contexte\n\nUn comite doit decider si un **projet** doit etre approuve ou rejete :\n\n- **Axiomes** : `budget_disponible`, `equipe_prete`\n- **Regle defaisable r1** : `budget_disponible, equipe_prete => approuver`\n- **Regle defaisable r2** : `risque_eleve => rejeter`\n- **Regle defaisable r3** : `approuver => !rejeter`\n\nLe conflit : si `risque_eleve` etait aussi un axiome, les arguments pour `approuver` et `rejeter` s'attaqueraient mutuellement.\n\n#### Objectifs\n\n1. Construire une theorie `AspicArgumentationTheory` avec les 3 regles et 2 axiomes\n2. Convertir en AF de Dung avec `asDungTheory()`\n3. Calculer l'extension grounded avec `SimpleGroundedReasoner`\n4. Interpreter : quels arguments sont acceptes ?\n\n#### Bonus\n\nAjoutez `risque_eleve` comme axiome supplementaire et observez comment le conflit modifie l'extension grounded. Comparez avec l'exemple de la section 4.2.1 ou `d` et `!d` s'annulent mutuellement.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "30c5b4bc",
+   "source": "# --- Exercice : Debat contradictoire avec ASPIC+ ---\n# TODO etudiant : construisez une theorie ASPIC+ et analysez les conflits\n#\n# Etape 1 : importer les classes ASPIC+ (cf section 4.2.1)\n#   from org.tweetyproject.arg.aspic.syntax import AspicArgumentationTheory, DefeasibleInferenceRule\n#   from org.tweetyproject.arg.aspic.ruleformulagenerator import PlFormulaGenerator\n#   from org.tweetyproject.logics.pl.syntax import Proposition, Negation\n#   from org.tweetyproject.arg.dung.reasoner import SimpleGroundedReasoner\n#\n# Etape 2 : creer la theorie ASPIC+ avec PlFormulaGenerator\n# Etape 3 : definir les propositions (budget_disponible, equipe_prete, risque_eleve, approuver, rejeter)\n# Etape 4 : ajouter les 3 regles defaisables et les 2 axiomes\n#   r1: budget_disponible, equipe_prete => approuver\n#   r2: risque_eleve => rejeter\n#   r3: approuver => !rejeter\n#   Axiomes: budget_disponible, equipe_prete\n# Etape 5 : convertir en Dung avec asDungTheory() et calculer l'extension grounded\n# Etape 6 : afficher les arguments, attaques et extension\n#\n# Indice : la regle r3 utilise Negation(Proposition(\"rejeter\")) comme conclusion\n# Indice : sans risque_eleve comme axiome, l'extension grounded contient approuver\n# Indice : ajoutez risque_eleve comme axiome supplementaire (bonus) pour observer le conflit\n\nif not jvm_ready:\n    print(\"ERREUR: JVM non demarree.\")\nelse:\n    aspic_theory_ex = None   # TODO etudiant : remplacer par la theorie ASPIC+ construite\n    grounded_ext = None      # TODO etudiant : remplacer par l'extension grounded\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "06220aec",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Add 1 exercise stub to Tweety-6-Structured-Argumentation to reach >=3 exercise convention (#2161).

| Notebook | Before->After | New exercise |
|----------|--------------|--------------|
| Tweety-6-Structured-Argumentation | 2->3 | Debat contradictoire avec ASPIC+ (committee approval scenario) |

**Note**: SW-6-CSharp-RDFS (3 exercises) and SW-7-CSharp-OWL (3 exercises) were verified and already meet the convention. No changes needed.

## Validation

**C.1**: Stub uses `aspic_theory_ex = None  # TODO etudiant` + `print("Exercice a completer")`. No raise NotImplementedError/assert False.
**JVM guard**: Stub guarded by `if not jvm_ready` check for clean execution without JVM.

See #2161