### PR TITLE
fix(gametheory): relabel GT-1-Setup mislabeled exercise (Stag Hunt, content-based)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -2303,11 +2303,11 @@
    "source": [
     "---\n",
     "\n",
-    "## 7. Exemple guide : Autres jeux classiques\n",
+    "## 7. Autres jeux classiques\n",
     "\n",
     "Modifiez les gains pour creer d'autres jeux celebres. Utilisez `support_enumeration()` pour trouver leurs equilibres.\n",
     "\n",
-    "### Exemple guide 1 : Jeu de coordination (Stag Hunt)\n",
+    "### Exercice 1 : Jeu de coordination (Stag Hunt)\n",
     "\n",
     "Dans la **Chasse au cerf**, deux chasseurs peuvent :\n",
     "- Chasser le cerf ensemble (necessite cooperation) -> gain eleve\n",


### PR DESCRIPTION
## Objet

Fix d'exactitude pedagogique sur **GameTheory-1-Setup.ipynb** (serie GameTheory, lane PROFONDEUR), dans le cadre du wrapup #2259 / Epic #2162. La section 7 « Autres jeux classiques » affichait un header `## 7. Exemple guide` + un sous-header `### Exemple guide 1` au-dessus d'un **stub d'exercice a completer** — confusion active pour les etudiants pendant le cours EPITA-IS live.

Particularite de ce notebook (vs GT-3/4/14/15) : la section 7 n'est **pas** une section d'exercices pure gamee — elle **melange genuinement** un exercice mislabel, un vrai worked-example etudiant, et un exercice deja correct. Le fix est donc **chirurgical** (cell56 uniquement), pas un flip de section entiere.

## Diagnostic (content-based, pas par titre)

La section 7 coexiste 3 jeux classiques, chacun classifie **par son contenu code** :

| Cellules | Header (avant) | Contenu code reel | Verdict |
|----------|----------------|-------------------|---------|
| cell56 (md) + cell57 (code, exec 18) | `### Exemple guide 1 : Jeu de coordination (Stag Hunt)` | **stub** : `# Exercice 1 : Stag Hunt`, `# Exercice: Definir les matrices...`, `# Indice:`, ferme par `print("Exercice a completer")` | **exercice mislabel** -> a corriger |
| cell58 (md) + cell59 (code, exec 19) | `### Exemple guide : ... Pierre-Feuille-Ciseaux (soumis par JertyanECE)` | **solution complete fonctionnelle** : `A_rps`/`B_rps` definis, `nash.Game(...)`, `support_enumeration()` execute | **vrai exemple resolu etudiant** -> NE PAS toucher |
| cell61 (md) + cell62 (code, exec 20) | `### Exercice 3 : Jeu de la Poule Mouillee (Chicken Game)` | **stub** (`# Exercice: Definir les matrices...`) | **deja correctement labelise** -> NE PAS toucher |

Le seul element incoherent etait donc le couple de headers de **cell56** :
1. `### Exemple guide 1` au-dessus du stub Stag Hunt = **cas-2** de [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) (« Titre **Exemple** + cellule code = stub vide => **relabeler le titre en Exercice** »). Le commentaire interne du stub dit deja `# Exercice 1`.
2. Le header de section `## 7. Exemple guide : Autres jeux classiques` qui qualifie **exclusivement** « Exemple guide » une section en realite **mixte** (un exercice + un exemple etudiant + un exercice).

## Preuve git decisive (de-gaming, PAS un revert conteste)

`git log -S` / `git show` (verifie ce cycle) :
- `1a2645d8` (« relabel 28 solution leaks as Exemple guide #1205 Phase 2 ») a fait un **find-replace AVEUGLE** : diff verifie sur GT-1-Setup = `-"## 7. Exercice : Autres jeux classiques"` -> `+"## 7. Exemple guide : Autres jeux classiques"` ; `-"### Exercice 1 : Jeu de coordination (Stag Hunt)"` -> `+"### Exemple guide 1 : ..."` ; idem `### Exercice 3` (Chicken). C'est le pattern de gaming du leak-scanner de la classe #1214 / #1336 (les cellules code etaient deja des stubs, rien a de-leaker).
- `5432f148` (« feat(ece): transform student exercises to exemples guides + new exercises ») est **legitime** et orthogonal : l'etudiant JertyanECE a soumis une solution complete pour Pierre-Feuille-Ciseaux, donc cet exercice est devenu un **vrai** Exemple guide (cohabitation : « quand un exercice est resolu/soumis il devient un exemple »). Chicken a ete renumerote/restaure `### Exercice 3` au passage.

Cette section etant aujourd'hui **mixte** (a cause du legitime `5432f148`), la restauration verbatim de l'original `## 7. Exercice` serait elle-meme inexacte (la section contient maintenant un vrai exemple). La correction la plus honnete = **neutraliser** le qualificatif de section (`## 7. Autres jeux classiques`) et laisser chaque sous-header porter le bon label (modele de cohabitation Exemple/Exercice). **Pas un revert d'un relabel valide** (#1343) ; continue la direction content-based validee `8b547c83` (#1562/#1570) / #2278 / #2272 / #2286 / #2290 / #2291 / #2293.

## Correction

2 headers markdown relabeles (**cell56 uniquement**) :
- `## 7. Exemple guide : Autres jeux classiques` -> `## 7. Autres jeux classiques` (header neutre : section mixte)
- `### Exemple guide 1 : Jeu de coordination (Stag Hunt)` -> `### Exercice 1 : Jeu de coordination (Stag Hunt)` (cas-2, au-dessus d'un stub)

Aucune cellule code touchee, aucun stub rempli, aucun exemple resolu stubbe. **Residu `Exemple guide` post-edit = 2 occurrences, mais LEGITIMES** : cell58 (header) + cell59 (commentaire code) = le vrai worked-example PFC soumis par JertyanECE, deliberement preserve (NE doit PAS etre relabelise).

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = **1 fichier, 2 insertions / 2 deletions** — exactement les 2 lignes header de cell56, 0 reformatage JSON, 0 cellule ajoutee/supprimee (**66 cellules avant == apres**, JSON re-parse OK).
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». 20 cellules code, **0 `execution_count: null`** ; cell57 (stub Stag Hunt) conserve `execution_count: 18` + ses outputs, cell59 (exemple PFC) conserve `execution_count: 19`. Aucun re-exec staged (C.3 : seul du source markdown a change).
- **§D exec proof = N/A justifie** : modif **markdown-only** (exception C.2, pas de re-exec requis) ; de plus le kernel declare (`gametheory-wsl` / « Python (GameTheory WSL + OpenSpiel) ») n'est pas disponible localement, donc une re-execution serait impossible — mais elle n'est **pas necessaire** ici (aucune cellule code n'a change, outputs committes valides). Pas de contournement regle F : il n'y a pas de changement de code a re-executer.
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** (scan Python sur le source des cellules, pas grep brut sur le JSON).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee ; le vrai exemple PFC (cell58/59) est **preserve intact**.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche (notebook seul ; GT-1-Setup, PAS un variant Lean).
- **3-exercices (#2161)** : GT-1-Setup = notebook **Setup** (exempt 0-1 ex) ; n'empeche pas le fix de label, qui le rend par ailleurs plus correct (la section 7 expose desormais clairement 2 exercices + 1 exemple).

## Scope

Un seul sujet, un seul notebook, une seule cellule : exactitude du label exercice sur GT-1-Setup section 7. Aucun autre notebook touche, aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; Lean<3ex = po-2025). NE touche PAS les notebooks `*-Lean-*` (GT-2b/4b/8b/15b = genuine cellules « Correction »).

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
