### PR TITLE
enrich(QC): add 3 exercises each to QC-Py-14/15/16/17 (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-14-Portfolio-Construction-Execution.ipynb
@@ -500,6 +500,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Allocation equal-weight avec rebalancement conditionnel",
+    "",
+    "L'`EqualWeightingPortfolioConstructionModel` rebalance a intervalle fixe. Une variante intelligente ne rebalance que si l'ecart par rapport aux poids cibles depasse un seuil de tolerance.",
+    "",
+    "**Objectif** : Implementer un PCM equal-weight qui ne rebalance que si le drift depasse 5%.",
+    "",
+    "**Regles** :",
+    "- Poids cible : 1/N pour chaque actif",
+    "- Ne rebalance que si `max(|w_actuel - w_cible|) > 0.05` pour au moins un actif",
+    "- Loggez chaque decision (rebalance ou skip) avec la raison",
+    "- Testez avec 4 actifs sur une periode de 1 an",
+    "",
+    "**Indices** :",
+    "- # Indice : `portfolio[symbol]` donne le holding actuel, `portfolio.TotalPortfolioValue` la valeur totale",
+    "- # Indice : `weight_actuel = holding.Quantity * holding.Price / total_value`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 1 : Equal-weight avec rebalancement conditionnel",
+    "# TODO etudiant : Implementer un PCM equal-weight avec seuil de drift",
+    "# Indice : Comparer poids actuels vs cible (1/N), rebalancer si drift > 5%",
+    "# Etape 1 : Definir la classe ConditionalEqualWeightPCM",
+    "# Etape 2 : Calculer les poids actuels du portfolio",
+    "# Etape 3 : Verifier si le drift depasse le seuil de 5%",
+    "# Etape 4 : Creer ou non les targets en fonction du drift",
+    "",
+    "result = None  # TODO etudiant : remplacer par le modele equal-weight conditionnel",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -920,6 +962,48 @@
     "| Prend en compte les correlations | Plus lent (optimisation numerique) |\n",
     "| Configurable (Long/Short) | Necessite suffisamment d'historique |"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Optimisation Mean-Variance avec contraintes sectorielles",
+    "",
+    "L'optimisation Mean-Variance classique ne tient pas compte de la concentration sectorielle. On ajoute des contraintes pour limiter l'exposition a un seul secteur.",
+    "",
+    "**Objectif** : Implementer un PCM Mean-Variance avec contrainte sectorielle max 30% par secteur.",
+    "",
+    "**Regles** :",
+    "- Utilisez 5 actifs repartis en 3 secteurs (Technology, Healthcare, Energy)",
+    "- Contrainte : poids total par secteur <= 30%",
+    "- Contrainte supplementaire : poids individuel entre 2% et 35%",
+    "- Affichez les poids optimaux et la allocation par secteur",
+    "",
+    "**Indices** :",
+    "- # Indice : Utilisez `scipy.optimize.minimize` avec des contraintes lineaires",
+    "- # Indice : Definissez les contraintes comme `{'type': 'ineq', 'fun': lambda w: 0.30 - sum(w[tech_indices])}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 2 : Mean-Variance avec contraintes sectorielles",
+    "# TODO etudiant : Implementer l'optimisation MV avec limites sectorielles",
+    "# Indice : scipy.optimize.minimize + contraintes lineaires par secteur",
+    "# Etape 1 : Definir la matrice de covariance et les rendements attendus",
+    "# Etape 2 : Definir les contraintes (somme=1, secteurs, bornes individuelles)",
+    "# Etape 3 : Resoudre l'optimisation",
+    "# Etape 4 : Afficher les poids optimaux et la repartition sectorielle",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'optimisation Mean-Variance contrainte",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1616,6 +1700,48 @@
     "---"
    ],
    "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Risk Parity manuel avec contraintes",
+    "",
+    "Le Risk Parity attribue un poids inversement proportionnel a la volatilite de chaque actif. En pratique, on ajoute des contraintes (poids min/max, concentration max).",
+    "",
+    "**Objectif** : Implementer un modele Risk Parity avec contraintes dans un algorithme QCAlgorithm.",
+    "",
+    "**Regles** :",
+    "- Creez un custom `PortfolioConstructionModel` qui calcule les poids Risk Parity",
+    "- Contraintes : poids minimum 5%, poids maximum 40%, somme = 100%",
+    "- Utilisez la volatilite sur 63 jours (3 mois) comme mesure de risque",
+    "- Comparez avec l'`EqualWeightingPortfolioConstructionModel` sur 3 actifs",
+    "",
+    "**Indices** :",
+    "- # Indice : Poids Risk Parity = `(1/vol_i) / sum(1/vol_j)` puis clippez entre 0.05 et 0.40",
+    "- # Indice : `self.Securities[symbol].VolatilityModel.Volatility` pour obtenir la volatilite"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 3 : Risk Parity avec contraintes",
+    "# TODO etudiant : Implementer un PCM Risk Parity avec poids min/max",
+    "# Indice : 1/vol normalise, puis clip [0.05, 0.40], renormaliser",
+    "# Etape 1 : Definir la classe CustomRiskParityPCM heritant de PortfolioConstructionModel",
+    "# Etape 2 : Calculer les poids bruts (inverse volatilite)",
+    "# Etape 3 : Appliquer les contraintes min/max et renormaliser",
+    "# Etape 4 : Creer les targets de portfolio pour chaque insight",
+    "",
+    "result = None  # TODO etudiant : remplacer par le modele Risk Parity contraint",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -1791,6 +1791,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Grid search personnalise",
+    "",
+    "Le grid search standard explore toutes les combinaisons, ce qui est couteux. Un grid search adaptatif explore les zones prometteuses en priorite.",
+    "",
+    "**Objectif** : Implementer un grid search a deux niveaux (coarse-to-fine) sur les parametres SMA.",
+    "",
+    "**Regles** :",
+    "- Niveau coarse : tester `window` de 5 a 50 par pas de 10, `threshold` de 0.001 a 0.01 par pas de 0.002",
+    "- Selectionner les 3 meilleures configurations du niveau coarse",
+    "- Niveau fine : explorer autour des 3 meilleures avec un pas divise par 5",
+    "- Utilisez la fonction `backtest_sma_strategy()` definie ci-dessus",
+    "",
+    "**Indices** :",
+    "- # Indice : Stockez les resultats coarse dans un DataFrame, puis `.nsmallest(3, 'sharpe')` ou `.nlargest(3, 'sharpe')`",
+    "- # Indice : Pour le niveau fine, creez un nouvel espace de recherche centre sur chaque meilleure config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Grid search personnalise (coarse-to-fine)",
+    "# TODO etudiant : Implementer un grid search a deux niveaux",
+    "# Indice : Niveau coarse (large) puis niveau fine (etroit) autour des meilleurs",
+    "# Etape 1 : Definir l'espace de recherche coarse",
+    "# Etape 2 : Executer le grid search coarse et collecter les resultats",
+    "# Etape 3 : Identifier les 3 meilleures configurations",
+    "# Etape 4 : Definir l'espace fine autour de chaque meilleure config",
+    "# Etape 5 : Executer le grid search fine et afficher les resultats finaux",
+    "",
+    "result = None  # TODO etudiant : remplacer par le grid search coarse-to-fine",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "641b9206",
    "metadata": {
     "papermill": {
@@ -2536,6 +2579,46 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Ratio d'efficacite Walk-Forward",
+    "",
+    "Le ratio d'efficacite compare la performance hors-echantillon a la performance en-echantillon. Un ratio > 0.5 indique une bonne robustesse.",
+    "",
+    "**Objectif** : Calculer le ratio d'efficacite moyen de la walk-forward analysis.",
+    "",
+    "**Regles** :",
+    "- Pour chaque fold de la walk-forward, calculez : `efficiency = sharpe_OOS / sharpe_IS` (si `sharpe_IS > 0`)",
+    "- Calculez le ratio moyen sur tous les folds",
+    "- Un ratio > 0.5 = modele robuste, < 0.3 = surapprentissage probable",
+    "",
+    "**Indices** :",
+    "- # Indice : Parcourez les resultats de `walk_forward_results` (variable definie ci-dessus)",
+    "- # Indice : Protegez contre la division par zero avec `max(sharpe_IS, 1e-6)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Ratio d'efficacite Walk-Forward",
+    "# TODO etudiant : Calculer le ratio d'efficacite moyen de la WFA",
+    "# Indice : Parcourez les folds et comparez sharpe_OOS / sharpe_IS",
+    "# Etape 1 : Identifier les colonnes IS et OOS dans les resultats WFA",
+    "# Etape 2 : Calculer le ratio pour chaque fold",
+    "# Etape 3 : Calculer et interpreter le ratio moyen",
+    "",
+    "result = None  # TODO etudiant : remplacer par le calcul du ratio d'efficacite",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "0d90f9f6",
    "metadata": {
     "papermill": {
@@ -2951,6 +3034,47 @@
     "\n",
     "---"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Penalisation de la complexite",
+    "",
+    "La validation croisee brute favorise parfois les modeles les plus complexes. L'information criterion (AIC/BIC) penalise le nombre de parametres.",
+    "",
+    "**Objectif** : Implementer un score de fitness penalise qui combine la performance Sharpe et un terme de complexite.",
+    "",
+    "**Regles** :",
+    "- Utilisez le resultat du grid search precedent (dictionnaire `results` avec colonnes `sharpe`, `lookback`, `hold`)",
+    "- Le score penalise = `sharpe - lambda * log(n_params)` ou `n_params = lookback * hold` et `lambda = 0.05`",
+    "- Affichez les 5 meilleures configurations selon ce score penalise",
+    "",
+    "**Indices** :",
+    "- # Indice : `np.log()` pour le terme de penalisation",
+    "- # Indice : Triez avec `.sort_values()` sur la colonne du score penalise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Penalisation de la complexite",
+    "# TODO etudiant : Implementer un score penalise combinant Sharpe et complexite",
+    "# Indice : Ajoutez une colonne 'penalized_score' au DataFrame results",
+    "# Indice : n_params = lookback * hold, lambda = 0.05",
+    "# Etape 1 : Calculer le nombre de parametres pour chaque configuration",
+    "# Etape 2 : Appliquer la penalisation logarithmique",
+    "# Etape 3 : Trier et afficher les 5 meilleures configurations",
+    "",
+    "result = None  # TODO etudiant : remplacer par le calcul du score penalise",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-16-Alternative-Data.ipynb
@@ -606,6 +606,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Strategie de rotation sectorielle",
+    "",
+    "Les fundamentals Morningstar permettent de classer les secteurs par attractivite. Une strategie de rotation sectorielle alloue plus de capital aux secteurs les plus attractifs.",
+    "",
+    "**Objectif** : Implementer une strategie qui selectionne les 2 meilleurs secteurs selon les fundamentals et sous-pondere les autres.",
+    "",
+    "**Regles** :",
+    "- Classez les 11 secteurs Morningstar par ratio P/E (croissant) et ROE (decroissant)",
+    "- Score combine = `rank(PE) * 0.4 + rank(ROE) * 0.6`",
+    "- Allouez 30% aux 2 meilleurs secteurs, 5% aux 3 suivants, 0% aux autres",
+    "- Rebalance mensuellement",
+    "",
+    "**Indices** :",
+    "- # Indice : `Fundamentals[symbol].ValuationRatios.PERatio` pour le P/E",
+    "- # Indice : `Fundamentals[symbol].OperationRatios.ROE.Value` pour le ROE",
+    "- # Indice : `FineFundamental` dans `OnFrameworkData` donne acces aux fundamentals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 1 : Rotation sectorielle basee sur les fundamentals",
+    "# TODO etudiant : Implementer une allocation sectorielle dynamique",
+    "# Indice : Scorer les secteurs par PE + ROE, allouer proportionnellement",
+    "# Etape 1 : Selectionner les actifs dans chaque secteur Morningstar",
+    "# Etape 2 : Calculer le score combine (PE + ROE) par secteur",
+    "# Etape 3 : Classer et determiner les poids d'allocation",
+    "# Etape 4 : Generer les insights d'allocation dans OnFrameworkData",
+    "",
+    "result = None  # TODO etudiant : remplacer par la strategie de rotation sectorielle",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -1406,6 +1449,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Source de donnees personnalisee multi-format",
+    "",
+    "QuantConnect accepte les CSV mais aussi les JSON et les donnees en temps reel via API. Cet exercice combine deux sources en une seule custom data source.",
+    "",
+    "**Objectif** : Creer une custom data source qui fusionne des donnees CSV (historique) et JSON (temps reel simule).",
+    "",
+    "**Regles** :",
+    "- Definissez une classe `MultiFormatData` heritant de `DynamicData`",
+    "- Methode `GetSource()` : retourne differentes URL selon la date (avant 2020 = CSV, apres = JSON)",
+    "- Methode `Reader()` : parsez selon le format et remplissez les proprietes",
+    "- Proprietes : `sentiment_score`, `volume_indicator`, `signal_strength`",
+    "",
+    "**Indices** :",
+    "- # Indice : `SourceType` peut etre `Csv` ou `Rest` selon le format",
+    "- # Indice : Utilisez `self.SetField()` pour les propriete dynamiques"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 2 : Custom data source multi-format (CSV + JSON)",
+    "# TODO etudiant : Creer une source fusionnant CSV historique et JSON temps reel",
+    "# Indice : Heriter de DynamicData, differencier par date dans GetSource()",
+    "# Etape 1 : Definir la classe MultiFormatData(PythonData)",
+    "# Etape 2 : Implementer GetSource() avec logique CSV/JSON selon la date",
+    "# Etape 3 : Implementer Reader() avec parsing multi-format",
+    "# Etape 4 : Utiliser les donnees dans OnData()",
+    "",
+    "result = None  # TODO etudiant : remplacer par la source multi-format",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### 5.2 FRED Data Integration\n",
     "\n",
@@ -2038,6 +2123,48 @@
    "source": [
     "**Resultats Backtest QC Cloud** - \n\n| Metrique | Valeur |\n|----------|--------|\n| Status | Completed |\n| Sharpe Ratio | 0.000 |\n| Sortino Ratio | 0.000 |\n| CAGR | 0.0% |\n| Net Profit | 0.00% |\n| Total Orders | 0 |\n| Trades | 0 |\n| Win Rate | 0% |\n| Max Drawdown | 0.0% |\n| End Equity | $100,000.00 |\n| Total Fees | $0.00 |\n| Backtest ID |  |\n\n> PEADStrategy — No entry trigger (ProcessEarningsSurprise never called)\n\n*Periode: Q1 2023 (2023-01-01 to 2023-03-31), Capital initial: $100,000*"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Strategie PEAD multi-facteurs",
+    "",
+    "Le PEAD classique achete apres un earnings surprise positif. Une version multi-facteurs combine earnings surprise, volume anormal et volatilite implicite.",
+    "",
+    "**Objectif** : Implementer un modele PEAD qui filtre les signaux avec des conditions de volume et volatilite.",
+    "",
+    "**Regles** :",
+    "- Signal d'entree : earnings surprise > 5% ET volume du jour > 1.5x volume moyen 20j",
+    "- Filtre de volatilite : ne pas entrer si volatilite 20j > 2x la volatilite 60j",
+    "- Position sizing : `min(surprise_pct / 20, 0.10)` (max 10% du portfolio)",
+    "- Sortie : apres 10 jours ou si le prix revient au pre-earnings",
+    "",
+    "**Indices** :",
+    "- # Indice : `self.Securities[symbol].Volume` pour le volume du jour",
+    "- # Indice : Utilisez une `RollingWindow[TradeBar]` pour calculer les volumes et volatilites glissantes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# [REFERENCE QC] Exercice 3 : Strategie PEAD multi-facteurs",
+    "# TODO etudiant : Implementer un modele PEAD avec filtres volume et volatilite",
+    "# Indice : Combinez earnings surprise + volume anormal + filtre volatilite",
+    "# Etape 1 : Detecter les earnings surprises dans OnData",
+    "# Etape 2 : Calculer le volume ratio (jour / moyenne 20j)",
+    "# Etape 3 : Calculer le ratio de volatilite (20j / 60j)",
+    "# Etape 4 : Appliquer les filtres et generer les ordres",
+    "",
+    "result = None  # TODO etudiant : remplacer par la strategie PEAD multi-facteurs",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-17-Sentiment-Analysis.ipynb
@@ -1088,6 +1088,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Scoring VADER personnalise",
+    "",
+    "VADER attribue des scores de sentiment composes (compound). Mais les headlines financieres utilisent un jargon specifique que VADER ne maitrise pas parfaitement.",
+    "",
+    "**Objectif** : Implementer un scoreur VADER ameliore avec desboost lexicale financier.",
+    "",
+    "**Regles** :",
+    "- Chargez les memes headlines simulees que ci-dessus",
+    "- Ajoutez au lexique VADER les termes financiers : `'beat'`, `'miss'`, `'surge'`, `'plunge'`, `'rally'` avec des scores manuels",
+    "- Comparez les scores compound originaux vs. ameliores sur les 10 premieres headlines",
+    "- Affichez un DataFrame avec les colonnes : `headline`, `score_original`, `score_enhanced`, `delta`",
+    "",
+    "**Indices** :",
+    "- # Indice : `analyzer.lexicon['beat'] = 2.0` pour ajouter au lexique VADER",
+    "- # Indice : `SentimentIntensityAnalyzer()` de `vaderSentiment`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Scoring VADER personnalise avec boost lexical financier",
+    "# TODO etudiant : Ameliorer VADER avec un lexique financier personnalise",
+    "# Indice : Modifier le lexique interne de SentimentIntensityAnalyzer",
+    "# Etape 1 : Charger les headlines et instancier VADER",
+    "# Etape 2 : Ajouter les termes financiers au lexique",
+    "# Etape 3 : Comparer scores originaux vs ameliores",
+    "# Etape 4 : Afficher le DataFrame de comparaison",
+    "",
+    "result = None  # TODO etudiant : remplacer par le scoring VADER ameliore",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "173d8e42",
    "metadata": {
     "papermill": {
@@ -2065,6 +2107,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Reglage du SentimentAlphaModel",
+    "",
+    "Le modele `SentimentAlphaModelSimulator` utilise un seuil de confiance et une fenetre de lookback. Le choix de ces hyperparametres impacte directement la performance.",
+    "",
+    "**Objectif** : Tester 3 configurations differentes du simulateur et comparer les performances.",
+    "",
+    "**Regles** :",
+    "- Configuration A : `confidence_threshold=0.3`, `lookback=5`",
+    "- Configuration B : `confidence_threshold=0.5`, `lookback=10`",
+    "- Configuration C : `confidence_threshold=0.7`, `lookback=20`",
+    "- Pour chaque config : instancier le simulateur, generer les signaux, calculer le Sharpe ratio",
+    "- Affichez un tableau comparatif des 3 configurations",
+    "",
+    "**Indices** :",
+    "- # Indice : Reutilisez la classe `SentimentAlphaModelSimulator` definie ci-dessus",
+    "- # Indice : Bouclez sur les 3 configs avec des dictionnaires de parametres"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Reglage du SentimentAlphaModel",
+    "# TODO etudiant : Tester 3 configurations et comparer les performances",
+    "# Indice : Bouclez sur les configurations avec un dictionnaire de parametres",
+    "# Etape 1 : Definir les 3 configurations (threshold, lookback)",
+    "# Etape 2 : Pour chaque config, instancier et simuler",
+    "# Etape 3 : Collecter les metriques (Sharpe, nombre de trades)",
+    "# Etape 4 : Afficher le tableau comparatif",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison des configurations",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "ffba4f5a",
    "metadata": {
     "papermill": {
@@ -2519,6 +2604,48 @@
     "    print(f\"  Prix moyen de vente (euphorie): ${avg_sell_price:.2f}\")\n",
     "    print(f\"  Gain theorique: {(avg_sell_price/avg_buy_price - 1)*100:.1f}%\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Logique de signal contrarien amelioree",
+    "",
+    "La strategie contrarienne simple achete quand le sentiment est tres bas et vend quand il est tres haut. Une version amelioree incorpore la volatilite du sentiment.",
+    "",
+    "**Objectif** : Implementer un signal contrarien pondere par la volatilite du sentiment.",
+    "",
+    "**Regles** :",
+    "- Calculez un Z-score du sentiment sur une fenetre glissante de 20 periodes",
+    "- Calculez la volatilite du sentiment (ecart-type sur 20 periodes)",
+    "- Signal = `-Z_score * (1 / max(volatilite, 0.01))` (inverse du sentiment, pondere par l'inverse de la volatilite)",
+    "- Affichez les 10 derniers signaux avec leur classification (BUY/SELL/HOLD)",
+    "",
+    "**Indices** :",
+    "- # Indice : `rolling(20).mean()` et `rolling(20).std()` pour le Z-score",
+    "- # Indice : Seuils : signal > 0.5 = BUY, < -0.5 = SELL, sinon HOLD"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Logique de signal contrarien amelioree",
+    "# TODO etudiant : Implementer un signal contrarien pondere par la volatilite",
+    "# Indice : Z-score = (sentiment - mean) / std sur fenetre glissante",
+    "# Etape 1 : Calculer le Z-score du sentiment sur 20 periodes",
+    "# Etape 2 : Calculer la volatilite du sentiment sur 20 periodes",
+    "# Etape 3 : Combiner en signal pondere",
+    "# Etape 4 : Classifier en BUY/SELL/HOLD et afficher les 10 derniers",
+    "",
+    "result = None  # TODO etudiant : remplacer par le signal contrarien ameliore",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Batch 4 of QC Python exercise rollout for convention #2161 (>= 3 exercises per notebook).

### Notebooks modified (4)

| Notebook | Exercises added | Topics |
|----------|----------------|--------|
| QC-Py-14 Portfolio Construction | 3 | Equal-weight conditional rebalancing, Mean-variance sector constraints, Risk parity with bounds |
| QC-Py-15 Parameter Optimization | 3 | Coarse-to-fine grid search, Walk-forward efficiency ratio, Complexity-penalized fitness |
| QC-Py-16 Alternative Data | 3 | Sector rotation via fundamentals, Multi-format custom data source, PEAD multi-factor strategy |
| QC-Py-17 Sentiment Analysis | 3 | VADER custom financial lexicon, SentimentAlphaModel tuning, Volatility-weighted contrarian signal |

### Validation

- C.1 check: PASS (no `raise NotImplementedError`, `assert False`, or `1/0`)
- All stubs: `result = None  # TODO etudiant` + `print("Exercice a completer")`
- Exercise markdown cells: objective + rules + `# Indice` / `# Etape N` hints
- Exercises spread throughout notebooks (not clustered at end)
- QCAlgorithm-style exercises in NB-14/16 (marked `[REFERENCE QC]`), plain Python in NB-15/17
- 504 insertions, 0 deletions (pure enrichment)

### Convention #2161 compliance

Each notebook now has exactly 3 exercise stubs, meeting the >= 3 target.