### PR TITLE
Lean-13-Grothendieck-Tribute  emile jouannet

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Grothendieck-Tribute.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-13-Grothendieck-Tribute.ipynb
@@ -127,10 +127,10 @@
    "id": "lean13-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:18.963680Z",
-     "iopub.status.busy": "2026-06-03T04:33:18.963389Z",
-     "iopub.status.idle": "2026-06-03T04:33:18.983833Z",
-     "shell.execute_reply": "2026-06-03T04:33:18.982191Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.912615Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.912518Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.925414Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.925201Z"
     },
     "papermill": {
      "duration": 0.027765,
@@ -146,8 +146,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setup OK : grothendieck_lean project trouve a D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\SymbolicAI\\Lean\\grothendieck_lean\n",
-      "  WSL path : /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean\n",
+      "Setup OK : grothendieck_lean project trouve a /Users/emilejouannet/EPITA/scia/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean\n",
+      "  Execution Lean : native lake env lean\n",
       "  6 modules Grothendieck detectes\n"
      ]
     }
@@ -157,10 +157,11 @@
     "import textwrap\n",
     "import re\n",
     "import os\n",
+    "import shutil\n",
+    "import tempfile\n",
     "from pathlib import Path\n",
     "\n",
     "# --- Path resolution: find the grothendieck_lean Lake project ---\n",
-    "# Follows the same pattern as Lean-14/15 (Conway/Kochen-Specker).\n",
     "# Must work both interactively (CWD = repo root) and under Papermill (CWD may differ).\n",
     "\n",
     "def find_grothendieck_lean_project():\n",
@@ -170,11 +171,8 @@
     "    and Papermill execution (where CWD may differ from notebook location).\n",
     "    Returns an ABSOLUTE path.\n",
     "    \"\"\"\n",
-    "    # Starting points to search from\n",
     "    starts = [Path.cwd().resolve()]\n",
     "\n",
-    "    # Try to find the notebook's own directory from __vsc_ipynb_file__ or common patterns\n",
-    "    # When running under Papermill, the notebook file path is passed as a parameter\n",
     "    nb_file = os.environ.get('NB_FILE') or globals().get('__vsc_ipynb_file__')\n",
     "    if nb_file:\n",
     "        starts.append(Path(nb_file).resolve().parent)\n",
@@ -188,31 +186,32 @@
     "            current = current.parent\n",
     "            if current == current.parent:\n",
     "                break\n",
-    "    raise FileNotFoundError(\"grothendieck_lean/ not found — check working directory\")\n",
+    "    raise FileNotFoundError(\"grothendieck_lean/ not found -- check working directory\")\n",
     "\n",
     "def win_to_wsl(win_path: Path) -> str:\n",
     "    \"\"\"Convert Windows path to WSL path using drive letter.\"\"\"\n",
     "    p = win_path.resolve()\n",
     "    drive_letter = p.drive\n",
     "    if not drive_letter or len(drive_letter) < 2:\n",
-    "        # Already a WSL-style path or UNC — try to extract from string\n",
     "        s = str(p)\n",
     "        if s.startswith('/mnt/'):\n",
     "            return s\n",
-    "        # Fallback: assume D: drive (most common for this repo)\n",
-    "        drive_letter = 'D:'\n",
+    "        return s\n",
     "    drive = drive_letter[0].lower()\n",
     "    return f'/mnt/{drive}{p.as_posix()[2:]}'\n",
     "\n",
     "WIN_LEAN_PROJECT = find_grothendieck_lean_project()\n",
     "LEAN_PROJECT = win_to_wsl(WIN_LEAN_PROJECT)\n",
+    "USE_NATIVE_LEAN = shutil.which('lake') is not None and os.name != 'nt'\n",
     "\n",
     "def wsl(cmd, timeout=60):\n",
-    "    \"\"\"Run a bash command inside WSL Ubuntu.\"\"\"\n",
+    "    \"\"\"Run a bash command inside WSL Ubuntu when available.\"\"\"\n",
     "    full = ['wsl', '-d', 'Ubuntu', '--', 'bash', '-lc', cmd]\n",
     "    try:\n",
     "        r = subprocess.run(full, capture_output=True, text=True, timeout=timeout)\n",
     "        return r.returncode, r.stdout, r.stderr\n",
+    "    except FileNotFoundError:\n",
+    "        return 127, '', 'WSL executable not found'\n",
     "    except subprocess.TimeoutExpired:\n",
     "        return -1, '', f'TIMEOUT after {timeout}s'\n",
     "\n",
@@ -255,13 +254,22 @@
     "# --- Lake build ---\n",
     "\n",
     "def run_lake_build(targets='Grothendieck', timeout=1500):\n",
-    "    \"\"\"Run lake build in WSL against the grothendieck_lean project.\n",
-    "\n",
-    "    Returns (returncode, stdout, stderr).\n",
-    "    \"\"\"\n",
+    "    \"\"\"Run lake build against the grothendieck_lean project.\"\"\"\n",
+    "    if USE_NATIVE_LEAN:\n",
+    "        try:\n",
+    "            r = subprocess.run(\n",
+    "                ['lake', 'build', targets],\n",
+    "                cwd=WIN_LEAN_PROJECT,\n",
+    "                capture_output=True,\n",
+    "                text=True,\n",
+    "                timeout=timeout,\n",
+    "            )\n",
+    "            return r.returncode, r.stdout, r.stderr\n",
+    "        except subprocess.TimeoutExpired:\n",
+    "            return -1, '', f'TIMEOUT after {timeout}s'\n",
     "    return wsl(\n",
     "        f'source ~/.elan/env 2>/dev/null; cd {LEAN_PROJECT} && lake build {targets} 2>&1 | tail -20',\n",
-    "        timeout=timeout\n",
+    "        timeout=timeout,\n",
     "    )\n",
     "\n",
     "# --- Lean snippet execution ---\n",
@@ -273,9 +281,28 @@
     "    Returns combined stdout+stderr.\n",
     "    \"\"\"\n",
     "    snippet = textwrap.dedent(snippet).strip() + '\\n'\n",
-    "    # Write snippet to temp file in WSL\n",
+    "    if USE_NATIVE_LEAN:\n",
+    "        with tempfile.NamedTemporaryFile('w', suffix='.lean', delete=False, encoding='utf-8') as tmp:\n",
+    "            tmp.write(snippet)\n",
+    "            tmp_path = tmp.name\n",
+    "        try:\n",
+    "            r = subprocess.run(\n",
+    "                ['lake', 'env', 'lean', tmp_path],\n",
+    "                cwd=WIN_LEAN_PROJECT,\n",
+    "                capture_output=True,\n",
+    "                text=True,\n",
+    "                timeout=timeout_s,\n",
+    "            )\n",
+    "            return (r.stdout or '') + (r.stderr or '')\n",
+    "        except subprocess.TimeoutExpired:\n",
+    "            return f'TIMEOUT after {timeout_s}s'\n",
+    "        finally:\n",
+    "            try:\n",
+    "                Path(tmp_path).unlink()\n",
+    "            except OSError:\n",
+    "                pass\n",
+    "\n",
     "    write_cmd = f\"cat > /tmp/lean13_snippet.lean << 'LEAN_EOF'\\n{snippet}LEAN_EOF\"\n",
-    "    # Execute with lake env lean (uses the project's Mathlib cache)\n",
     "    lean_cmd = f'cd {LEAN_PROJECT} && lake env lean /tmp/lean13_snippet.lean 2>&1'\n",
     "    full_cmd = f'{write_cmd}\\n{lean_cmd}'\n",
     "    rc, out, err = wsl(full_cmd, timeout=timeout_s)\n",
@@ -296,9 +323,10 @@
     "\n",
     "# Verify project is accessible\n",
     "assert (WIN_LEAN_PROJECT / 'lakefile.lean').exists(), 'grothendieck_lean/lakefile.lean not found'\n",
+    "mode = 'native lake env lean' if USE_NATIVE_LEAN else 'WSL lake env lean'\n",
     "print(f'Setup OK : grothendieck_lean project trouve a {WIN_LEAN_PROJECT}')\n",
-    "print(f'  WSL path : {LEAN_PROJECT}')\n",
-    "print(f'  {len(GROTHENDIECK_MODULES)} modules Grothendieck detectes')"
+    "print(f'  Execution Lean : {mode}')\n",
+    "print(f'  {len(GROTHENDIECK_MODULES)} modules Grothendieck detectes')\n"
    ]
   },
   {
@@ -307,10 +335,10 @@
    "id": "087578d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:18.994328Z",
-     "iopub.status.busy": "2026-06-03T04:33:18.993944Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.002650Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.001835Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.926542Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.926453Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.931556Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.931344Z"
     },
     "papermill": {
      "duration": 0.014329,
@@ -331,7 +359,7 @@
       "Total : 527 lignes Lean\n",
       "\n",
       "Pour lancer le build complet (validation formelle) :\n",
-      "  wsl -d Ubuntu -- bash -lc \"cd /mnt/d/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n"
+      "  wsl -d Ubuntu -- bash -lc \"cd /Users/emilejouannet/EPITA/scia/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean && lake build Grothendieck\"\n"
      ]
     }
    ],
@@ -387,10 +415,10 @@
    "id": "lean13-check-functor-yoneda",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.018888Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.018627Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.024307Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.023262Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.932655Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.932558Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.934826Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.934629Z"
     },
     "papermill": {
      "duration": 0.010878,
@@ -561,10 +589,10 @@
    "id": "lean13-check-sieves",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.046804Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.046486Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.051757Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.050601Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.935878Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.935808Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.937746Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.937564Z"
     },
     "papermill": {
      "duration": 0.010652,
@@ -685,10 +713,10 @@
    "id": "lean13-check-sheaves",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.076489Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.076046Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.081882Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.080578Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.938783Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.938708Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.940873Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.940704Z"
     },
     "papermill": {
      "duration": 0.01282,
@@ -859,10 +887,10 @@
    "id": "lean13-check-scheme",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.108093Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.107849Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.114270Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.112887Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.941910Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.941822Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.944013Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.943819Z"
     },
     "papermill": {
      "duration": 0.013276,
@@ -1020,10 +1048,10 @@
    "id": "lean13-check-bigzariski",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.140999Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.140502Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.146387Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.145383Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.945122Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.945054Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.947174Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.947002Z"
     },
     "papermill": {
      "duration": 0.012125,
@@ -1189,10 +1217,10 @@
    "id": "lean13-check-morphisms",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.178631Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.178269Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.183102Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.182225Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.948208Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.948141Z",
+     "iopub.status.idle": "2026-06-03T16:47:01.950243Z",
+     "shell.execute_reply": "2026-06-03T16:47:01.950035Z"
     },
     "papermill": {
      "duration": 0.017414,
@@ -1427,10 +1455,10 @@
    "id": "6e9d167b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.216402Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.216051Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.221278Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.220058Z"
+     "iopub.execute_input": "2026-06-03T16:47:01.951550Z",
+     "iopub.status.busy": "2026-06-03T16:47:01.951475Z",
+     "iopub.status.idle": "2026-06-03T16:47:13.225310Z",
+     "shell.execute_reply": "2026-06-03T16:47:13.224942Z"
     },
     "papermill": {
      "duration": 0.011303,
@@ -1446,27 +1474,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer\n"
+      "CategoryTheory.Limits.HasLimits : (C : Type u_2) → [CategoryTheory.Category.{u_1, u_2} C] → Prop\n",
+      "@CategoryTheory.Adjunction : {C : Type u_3} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_3} C] →\n",
+      "    {D : Type u_4} →\n",
+      "      [inst_1 : CategoryTheory.Category.{u_2, u_4} D] →\n",
+      "        CategoryTheory.Functor C D → CategoryTheory.Functor D C → Type (max (max (max u_3 u_4) u_1) u_2)\n",
+      "@CategoryTheory.Adjunction.adjunctionOfEquivLeft : {C : Type u_3} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_3} C] →\n",
+      "    {D : Type u_4} →\n",
+      "      [inst_1 : CategoryTheory.Category.{u_2, u_4} D] →\n",
+      "        {G : CategoryTheory.Functor D C} →\n",
+      "          {F_obj : C → D} →\n",
+      "            (e : (X : C) → (Y : D) → (F_obj X ⟶ Y) ≃ (X ⟶ G.obj Y)) →\n",
+      "              (he :\n",
+      "                  ∀ (X : C) (Y Y' : D) (g : Y ⟶ Y') (h : F_obj X ⟶ Y),\n",
+      "                    (e X Y') (CategoryTheory.CategoryStruct.comp h g) =\n",
+      "                      CategoryTheory.CategoryStruct.comp ((e X Y) h) (G.map g)) →\n",
+      "                CategoryTheory.Adjunction.leftAdjointOfEquiv e he ⊣ G\n",
+      "\n",
+      "Lecture : HasLimits exprime l'existence de toutes les limites dans une categorie, tandis qu'Adjunction formalise une adjonction F ⊣ G entre deux foncteurs.\n"
      ]
     }
    ],
    "source": [
     "# Exercice 1 : limites et adjonction\n",
-    "# TODO etudiant : utiliser run_lean pour faire un #check de CategoryTheory.Limits.HasLimits\n",
-    "# Etape 1 : construire un snippet Lean avec l'import approprie\n",
-    "# Etape 2 : appeler run_lean(snippet, timeout_s=120)\n",
-    "# Etape 3 : afficher le resultat et identifier la signature de HasLimits\n",
-    "# Etape 4 : explorer ensuite CategoryTheory.Adjunction\n",
+    "# Exploration de deux constructions categoriques centrales : limites et adjonctions.\n",
     "\n",
     "snippet_ex1 = \"\"\"\n",
     "import Mathlib.CategoryTheory.Limits.Shapes.Products\n",
     "import Mathlib.CategoryTheory.Adjunction.Basic\n",
     "\n",
     "#check @CategoryTheory.Limits.HasLimits\n",
+    "#check @CategoryTheory.Adjunction\n",
+    "#check @CategoryTheory.Adjunction.adjunctionOfEquivLeft\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex1 = None  # TODO etudiant : remplacer par run_lean(snippet_ex1)\n",
-    "print(\"Exercice 1 a completer\")"
+    "resultat_ex1 = run_lean(snippet_ex1, timeout_s=300)\n",
+    "print(resultat_ex1)\n",
+    "print(\"Lecture : HasLimits exprime l'existence de toutes les limites dans une categorie, tandis qu'Adjunction formalise une adjonction F ⊣ G entre deux foncteurs.\")\n"
    ]
   },
   {
@@ -1475,10 +1521,10 @@
    "id": "3091aa4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.231774Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.231431Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.236943Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.235759Z"
+     "iopub.execute_input": "2026-06-03T16:47:13.226891Z",
+     "iopub.status.busy": "2026-06-03T16:47:13.226757Z",
+     "iopub.status.idle": "2026-06-03T16:47:17.189255Z",
+     "shell.execute_reply": "2026-06-03T16:47:17.188760Z"
     },
     "papermill": {
      "duration": 0.0121,
@@ -1494,26 +1540,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer\n"
+      "@CategoryTheory.Sieve.pullback : {C : Type u_2} →\n",
+      "  [inst : CategoryTheory.Category.{u_1, u_2} C] → {X Y : C} → (Y ⟶ X) → CategoryTheory.Sieve X → CategoryTheory.Sieve Y\n",
+      "@CategoryTheory.GrothendieckTopology.pullback_stable : ∀ {C : Type u_2} [inst : CategoryTheory.Category.{u_1, u_2} C]\n",
+      "  {X Y : C} {S : CategoryTheory.Sieve X} (J : CategoryTheory.GrothendieckTopology C) (f : Y ⟶ X),\n",
+      "  S ∈ J X → CategoryTheory.Sieve.pullback f S ∈ J Y\n",
+      "\n",
+      "Lecture : pullback_stable est exactement l'axiome SGA de stabilite des cribles couvrants par image inverse.\n"
      ]
     }
    ],
    "source": [
-    "# Exercice 2 : raffinement de cribles (pullback_stable)\n",
-    "# TODO etudiant : trouver le lemme Mathlib de stabilite d'un crible couvrant par image inverse\n",
-    "# Indice : cherchez un lemme dont la conclusion contient \"GrothendieckTopology.PullbackSieve\" ou similaire\n",
-    "# Etape 1 : faire un #check de CategoryTheory.Sieve.pullback pour voir le type\n",
-    "# Etape 2 : chercher dans Mathlib.CategoryTheory.Sites.Sieves un lemme de la forme \"Sieve.pullback_mem_supersieve\"\n",
-    "# Etape 3 : afficher la signature\n",
+    "# Exercice 2 : raffinement de cribles et stabilite par pullback\n",
+    "# On inspecte la signature de Sieve.pullback et le champ pullback_stable d'une topologie de Grothendieck.\n",
     "\n",
     "snippet_ex2 = \"\"\"\n",
     "import Mathlib.CategoryTheory.Sites.Sieves\n",
+    "import Mathlib.CategoryTheory.Sites.Grothendieck\n",
     "\n",
     "#check @CategoryTheory.Sieve.pullback\n",
+    "#check @CategoryTheory.GrothendieckTopology.pullback_stable\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex2 = None  # TODO etudiant : remplacer par run_lean(snippet_ex2)\n",
-    "print(\"Exercice 2 a completer\")"
+    "resultat_ex2 = run_lean(snippet_ex2, timeout_s=300)\n",
+    "print(resultat_ex2)\n",
+    "print(\"Lecture : pullback_stable est exactement l'axiome SGA de stabilite des cribles couvrants par image inverse.\")\n"
    ]
   },
   {
@@ -1522,10 +1573,10 @@
    "id": "550858c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T04:33:19.247849Z",
-     "iopub.status.busy": "2026-06-03T04:33:19.247433Z",
-     "iopub.status.idle": "2026-06-03T04:33:19.252035Z",
-     "shell.execute_reply": "2026-06-03T04:33:19.251128Z"
+     "iopub.execute_input": "2026-06-03T16:47:17.192357Z",
+     "iopub.status.busy": "2026-06-03T16:47:17.192211Z",
+     "iopub.status.idle": "2026-06-03T16:47:44.734852Z",
+     "shell.execute_reply": "2026-06-03T16:47:44.734304Z"
     },
     "papermill": {
      "duration": 0.010479,
@@ -1541,17 +1592,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer\n"
+      "theorem AlgebraicGeometry.Scheme.zariskiTopology_eq.{u} : AlgebraicGeometry.Scheme.zariskiTopology =\n",
+      "  AlgebraicGeometry.Scheme.zariskiPretopology.toGrothendieck :=\n",
+      "Eq.symm CategoryTheory.Precoverage.toGrothendieck_toPretopology_eq_toGrothendieck\n",
+      "\n",
+      "Lignes non vides affichees : 3\n",
+      "Lecture : la preuve est un renversement d'egalite (`Eq.symm`) applique au pont general `Precoverage.toGrothendieck_toPretopology_eq_toGrothendieck`.\n"
      ]
     }
    ],
    "source": [
     "# Exercice 3 : Zariski pretopologie vs topologie\n",
-    "# TODO etudiant : afficher le corps du lemme zariskiTopology_eq avec #print\n",
-    "# Etape 1 : utiliser #print plutot que #check pour obtenir le terme de preuve\n",
-    "# Etape 2 : compter les lignes de la preuve\n",
-    "# Etape 3 : identifier la tactique principale (exact, rfl, decide, etc.)\n",
-    "# Etape 4 : comparer avec la preuve papier de SGA 4\n",
+    "# #print expose le terme de preuve reliant la pretopologie de Zariski a la topologie engendree.\n",
     "\n",
     "snippet_ex3 = \"\"\"\n",
     "import Mathlib.AlgebraicGeometry.Sites.BigZariski\n",
@@ -1559,8 +1611,11 @@
     "#print AlgebraicGeometry.Scheme.zariskiTopology_eq\n",
     "\"\"\"\n",
     "\n",
-    "resultat_ex3 = None  # TODO etudiant : remplacer par run_lean(snippet_ex3)\n",
-    "print(\"Exercice 3 a completer\")"
+    "resultat_ex3 = run_lean(snippet_ex3, timeout_s=300)\n",
+    "print(resultat_ex3)\n",
+    "proof_lines = [line for line in resultat_ex3.splitlines() if line.strip()]\n",
+    "print(f\"Lignes non vides affichees : {len(proof_lines)}\")\n",
+    "print(\"Lecture : la preuve est un renversement d'egalite (`Eq.symm`) applique au pont general `Precoverage.toGrothendieck_toPretopology_eq_toGrothendieck`.\")\n"
    ]
   },
   {
@@ -1641,7 +1696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

-TP realise par emile.jouannet, groupe individuel.
Complete les exercices du notebook Lean-13-Grothendieck-Tribute sur les limites, adjonctions, cribles et topologie de Zariski.
Execute les snippets Lean via lake env lean et regenere les outputs du notebook.

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
