### PR TITLE
enrich(QC): add 3 exercises each to QC-Py-18 thru QC-Py-25 (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-18-ML-Features-Engineering.ipynb
@@ -816,6 +816,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Features de momentum personnalisees",
+    "",
+    "Le momentum classique compare le prix actuel au prix N jours plus tot. Des variantes plus sophistiquees combinent plusieurs horizons.",
+    "",
+    "**Objectif** : Implementer un score de momentum multi-horizon.",
+    "",
+    "**Regles** :",
+    "- Calculez les retours sur 5, 10, 21, 63 et 252 jours ouvrables",
+    "- Score de momentum = `0.1*ret_5d + 0.15*ret_10d + 0.25*ret_21d + 0.3*ret_63d + 0.2*ret_252d`",
+    "- Ajoutez une mesure de consistence : fraction des 5 retours positifs",
+    "- Affichez les 10 actifs avec le meilleur score momentum",
+    "",
+    "**Indices** :",
+    "- # Indice : `df.pct_change(N)` pour le retour sur N periodes",
+    "- # Indice : La consistence = `(returns > 0).sum() / len(returns)` sur les 5 horizons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Momentum multi-horizon",
+    "# TODO etudiant : Implementer un score momentum combineant 5 horizons",
+    "# Indice : pct_change() pour chaque horizon, puis somme ponderee",
+    "# Etape 1 : Calculer les retours sur 5/10/21/63/252 jours",
+    "# Etape 2 : Appliquer les poids et calculer le score",
+    "# Etape 3 : Calculer la consistence (fraction de retours positifs)",
+    "# Etape 4 : Afficher le top 10 momentum",
+    "",
+    "result = None  # TODO etudiant : remplacer par le score momentum multi-horizon",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b2787f4b",
    "metadata": {
     "papermill": {
@@ -1938,6 +1980,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Features fondamentales personnalisees",
+    "",
+    "Les fundamentals Morningstar offrent des dizaines de ratios. Un feature engineering avance combine plusieurs ratios en un score composite.",
+    "",
+    "**Objectif** : Creer un score de sante financiere composite a partir de 5 ratios fondamentaux.",
+    "",
+    "**Regles** :",
+    "- Calculez 5 ratios : P/E inverse, ROE, Debt/Equity inverse, Current ratio, FCF Yield",
+    "- Normalisez chaque ratio entre 0 et 1 (min-max sur l'univers)",
+    "- Score composite = moyenne ponderee (P/E: 20%, ROE: 30%, D/E: 15%, Current: 15%, FCF: 20%)",
+    "- Classez les actifs par score composite et affichez le top 10",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.preprocessing.MinMaxScaler` pour la normalisation",
+    "- # Indice : Les poids du score composite sont dans l'enonce ci-dessus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Score de sante financiere composite",
+    "# TODO etudiant : Combiner 5 ratios fondamentaux en un score unique",
+    "# Indice : MinMaxScaler + moyenne ponderee avec les poids donnes",
+    "# Etape 1 : Calculer les 5 ratios pour chaque actif",
+    "# Etape 2 : Normaliser entre 0 et 1",
+    "# Etape 3 : Appliquer les poids et calculer le score composite",
+    "# Etape 4 : Classer et afficher le top 10",
+    "",
+    "result = None  # TODO etudiant : remplacer par le score composite",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "d5bb8638",
    "metadata": {
     "papermill": {
@@ -2900,6 +2984,48 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Selection de features par mutual information",
+    "",
+    "La mutual information mesure la dependance non-lineaire entre chaque feature et la cible. Contrairement a la correlation, elle capture les relations non-lineaires.",
+    "",
+    "**Objectif** : Implementer un selector base sur la mutual information et comparer avec la selection par correlation.",
+    "",
+    "**Regles** :",
+    "- Calculez `mutual_info_classif` (ou `mutual_info_regression`) pour chaque feature",
+    "- Selectionnez les 10 features avec le plus haut score MI",
+    "- Comparez avec les 10 features les plus correlees (correlation de Pearson)",
+    "- Affichez un Venn diagram des deux ensembles",
+    "",
+    "**Indices** :",
+    "- # Indice : `from sklearn.feature_selection import mutual_info_classif`",
+    "- # Indice : `from matplotlib_venn import venn2` pour le diagramme de Venn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Selection par mutual information",
+    "# TODO etudiant : Comparer selection MI vs correlation Pearson",
+    "# Indice : mutual_info_classif pour le score, venn2 pour la comparaison",
+    "# Etape 1 : Calculer les scores MI pour chaque feature",
+    "# Etape 2 : Calculer les correlations Pearson absolues",
+    "# Etape 3 : Identifier les top-10 de chaque methode",
+    "# Etape 4 : Afficher le Venn diagram des deux ensembles",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison MI vs Pearson",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-19-ML-Supervised-Classification.ipynb
@@ -496,6 +496,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Generation de labels de trading",
+    "",
+    "Le choix du label impacte directement la performance du modele. Les labels binaires (hausse/baisse) sont simples mais perdent l'information de magnitude.",
+    "",
+    "**Objectif** : Implementer 3 methodes de labeling et comparer leurs distributions.",
+    "",
+    "**Regles** :",
+    "- Methode 1 : Label binaire (retour > 0 = 1, sinon 0)",
+    "- Methode 2 : Label avec seuil (retour > 1% = 1, retour < -1% = -1, sinon 0 = neutre)",
+    "- Methode 3 : Triple barrier (prendre profit a +2%, stop loss a -1.5%, time barrier a 10 jours)",
+    "- Affichez un histogramme des 3 distributions de labels",
+    "",
+    "**Indices** :",
+    "- # Indice : `np.where(condition, 1, 0)` pour le label binaire",
+    "- # Indice : Pour la triple barrier, utilisez `np.argmax` sur les conditions d'atteinte"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Methodes de labeling",
+    "# TODO etudiant : Implementer 3 methodes de labeling et comparer",
+    "# Indice : binaire simple, seuil fixe, triple barrier",
+    "# Etape 1 : Implementer le label binaire",
+    "# Etape 2 : Implementer le label a seuil",
+    "# Etape 3 : Implementer la triple barrier",
+    "# Etape 4 : Afficher les 3 distributions",
+    "",
+    "result = None  # TODO etudiant : remplacer par les 3 methodes de labeling",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -911,6 +953,48 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Importance des features avec permutation",
+    "",
+    "L'importance par defaut (Gini) est biaisee vers les features a haute cardinalite. L'importance par permutation est plus fiable.",
+    "",
+    "**Objectif** : Calculer et comparer l'importance Gini vs permutation importance.",
+    "",
+    "**Regles** :",
+    "- Entrainez un Random Forest sur les features techniques",
+    "- Calculez l'importance Gini (`model.feature_importances_`)",
+    "- Calculez la permutation importance (`sklearn.inspection.permutation_importance`)",
+    "- Affichez un graphique horizontal cote-a-cote des deux classements",
+    "",
+    "**Indices** :",
+    "- # Indice : `from sklearn.inspection import permutation_importance`",
+    "- # Indice : `permutation_importance(model, X_test, y_test, n_repeats=10)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Permutation importance vs Gini",
+    "# TODO etudiant : Comparer les deux methodes d'importance",
+    "# Indice : Gini par defaut + permutation_importance pour la comparaison",
+    "# Etape 1 : Entrainer le Random Forest",
+    "# Etape 2 : Extraire l'importance Gini",
+    "# Etape 3 : Calculer la permutation importance",
+    "# Etape 4 : Afficher les deux classements cote a cote",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison des importances",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1403,6 +1487,48 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Comparaison Random Forest vs XGBoost",
+    "",
+    "Comparer objectivement deux modeles necessite plus que l'accuracy. Le F1-score, l'AUC-ROC et la matrice de confusion donnent une vue plus complete.",
+    "",
+    "**Objectif** : Comparer RF et XGBoost sur 4 metriques et determiner le meilleur modele.",
+    "",
+    "**Regles** :",
+    "- Entrainez RF et XGBoost avec les memes donnees d'entrainement",
+    "- Calculez : accuracy, F1-score (weighted), AUC-ROC, log-loss",
+    "- Affichez un DataFrame comparatif avec les 4 metriques pour chaque modele",
+    "- Tracez les deux courbes ROC sur le meme graphique",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.metrics` fournit `accuracy_score`, `f1_score`, `roc_auc_score`, `log_loss`",
+    "- # Indice : `roc_curve()` retourne les points pour la courbe ROC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Benchmark RF vs XGBoost",
+    "# TODO etudiant : Comparer les deux modeles sur 4 metriques",
+    "# Indice : Entrainer les deux modeles, collecter les predictions, calculer les metriques",
+    "# Etape 1 : Entrainer RF et XGBoost sur les memes donnees",
+    "# Etape 2 : Predire sur le test set avec les deux modeles",
+    "# Etape 3 : Calculer accuracy, F1, AUC-ROC, log-loss pour chaque",
+    "# Etape 4 : Afficher le tableau comparatif et les courbes ROC",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison RF vs XGBoost",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-20-ML-Regression-Prediction.ipynb
@@ -392,6 +392,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Transformation classification en regression",
+    "",
+    "Un probleme de classification (hausse/baisse) peut etre reformule en regression (predire le retour continu). Cette reformulation preserve plus d'information.",
+    "",
+    "**Objectif** : Comparer un classifieur et un regressieur sur le meme dataset financier.",
+    "",
+    "**Regles** :",
+    "- Creez des labels de classification binaire (retour > 0) et des cibles de regression (retour continu)",
+    "- Entrainez un LogisticRegression (classification) et un Ridge (regression)",
+    "- Pour le regressieur, convertissez les predictions en signaux binaires (`pred > 0`)",
+    "- Comparez : accuracy, precision, recall des deux approches",
+    "",
+    "**Indices** :",
+    "- # Indice : `(y_reg > 0).astype(int)` pour convertir les cibles de regression en labels",
+    "- # Indice : `(y_pred_reg > 0).astype(int)` pour convertir les predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Classification vs Regression",
+    "# TODO etudiant : Comparer classification binaire et regression continue",
+    "# Indice : Meme features, cible differente (binaire vs continu)",
+    "# Etape 1 : Preparer les cibles classification et regression",
+    "# Etape 2 : Entrainer LogisticRegression et Ridge",
+    "# Etape 3 : Convertir les predictions regression en signaux binaires",
+    "# Etape 4 : Comparer accuracy, precision, recall",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison classif vs regression",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "---\n",
     "\n",
@@ -900,6 +942,48 @@
     "print(\"  - Lasso: certains coefficients a 0 (feature selection)\")\n",
     "print(\"  - ElasticNet: compromis entre les deux\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Selection du alpha optimal par validation croisee",
+    "",
+    "Ridge et Lasso ont un hyperparametre alpha qui controle la regularisation. Le choix optimal depend des donnees.",
+    "",
+    "**Objectif** : Trouver le alpha optimal pour Ridge, Lasso et ElasticNet via GridSearchCV.",
+    "",
+    "**Regles** :",
+    "- Grille alpha : `[0.001, 0.01, 0.1, 1, 10, 100]`",
+    "- 5-fold cross-validation",
+    "- Pour chaque modele, affichez le meilleur alpha et le score CV associe",
+    "- Tracez l'evolution du score CV en fonction de alpha (log scale)",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.model_selection.GridSearchCV` avec `param_grid={'alpha': alphas}`",
+    "- # Indice : `cv_results_['mean_test_score']` pour les scores CV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Alpha optimal par GridSearchCV",
+    "# TODO etudiant : Trouver le meilleur alpha pour Ridge, Lasso, ElasticNet",
+    "# Indice : GridSearchCV pour chaque modele avec la grille d'alphas",
+    "# Etape 1 : Definir la grille d'alphas",
+    "# Etape 2 : Lancer GridSearchCV pour chaque modele",
+    "# Etape 3 : Extraire les meilleurs alpha et scores",
+    "# Etape 4 : Tracer score vs alpha (log scale)",
+    "",
+    "result = None  # TODO etudiant : remplacer par la recherche alpha optimal",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1438,6 +1522,49 @@
     "    print(\"XGBoost non disponible.\")\n",
     "    print(\"Installer avec: pip install xgboost\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Stacking de regressieurs",
+    "",
+    "Le stacking combine les predictions de plusieurs modeles via un meta-modele. Il surperforme souvent les modeles individuels.",
+    "",
+    "**Objectif** : Implementer un stacking regressor avec Ridge, RF et GradientBoosting comme modeles de base.",
+    "",
+    "**Regles** :",
+    "- Modeles de base : Ridge, RandomForest, GradientBoosting",
+    "- Meta-modele : Lasso (pour la selection de features des predictions)",
+    "- Utilisez 5-fold cross-validation pour le stacking",
+    "- Comparez : chaque modele individuel vs le stacking",
+    "- Metrique : RMSE et R2 sur le test set",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.ensemble.StackingRegressor` avec `estimators=[...]`",
+    "- # Indice : Le meta-modele s'appelle `final_estimator` dans StackingRegressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Stacking de regressieurs",
+    "# TODO etudiant : Combiner Ridge + RF + GB via un meta-modele Lasso",
+    "# Indice : StackingRegressor avec 3 estimators + final_estimator=Lasso",
+    "# Etape 1 : Definir les 3 modeles de base",
+    "# Etape 2 : Configurer le StackingRegressor avec meta-modele Lasso",
+    "# Etape 3 : Entrainer et predire",
+    "# Etape 4 : Comparer RMSE et R2 de chaque modele vs stacking",
+    "",
+    "result = None  # TODO etudiant : remplacer par le stacking",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-Portfolio-Optimization-ML.ipynb
@@ -840,6 +840,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Frontiere efficiente avec contraintes",
+    "",
+    "La frontiere efficiente classique n'impose pas de contraintes realistes. En pratique, on limite les poids individuels et on interdit la vente a decouvert.",
+    "",
+    "**Objectif** : Tracer la frontiere efficiente avec contraintes (long-only, max 30% par actif).",
+    "",
+    "**Regles** :",
+    "- 10 actifs avec rendements et covariance simules",
+    "- Contrainte : 0 <= w_i <= 0.30, somme = 1",
+    "- Calculez 50 points de la frontiere en variant le rendement cible",
+    "- Tracez la frontiere avec les portefeuilles individuels",
+    "- Identifiez le portefeuille de variance minimale et le Sharpe ratio maximum",
+    "",
+    "**Indices** :",
+    "- # Indice : `scipy.optimize.minimize` avec `bounds=[(0, 0.3)]*10`",
+    "- # Indice : Portfolio variance = `w.T @ cov_matrix @ w`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Frontiere efficiente contrainte",
+    "# TODO etudiant : Tracer la frontiere avec long-only + max 30%",
+    "# Indice : scipy.optimize.minimize avec bounds et contraintes",
+    "# Etape 1 : Definir la fonction objectif (variance du portefeuille)",
+    "# Etape 2 : Configurer les bornes et contraintes",
+    "# Etape 3 : Resoudre pour 50 niveaux de rendement cible",
+    "# Etape 4 : Tracer la frontiere et identifier les portefeuilles cles",
+    "",
+    "result = None  # TODO etudiant : remplacer par la frontiere efficiente contrainte",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Interprétation\n",
     "\n",
@@ -1058,6 +1101,48 @@
     "for i, asset in enumerate(returns.columns):\n",
     "    print(f\"{asset:<12} {msr_sample[i]:>9.1%} {msr_shrunk[i]:>9.1%} {msr_shrunk[i]-msr_sample[i]:>9.1%}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Comparaison des estimateurs de covariance",
+    "",
+    "L'estimation de la matrice de covariance est critique pour l'optimisation de portefeuille. Ledoit-Wolf, Oracle Approximating Shrinkage et la covariance empirique ont des proprietes differentes.",
+    "",
+    "**Objectif** : Comparer 3 estimateurs de covariance et leur impact sur l'allocation MV.",
+    "",
+    "**Regles** :",
+    "- Calculez la covariance avec : empirique, Ledoit-Wolf, OAS",
+    "- Pour chaque estimateur, calculez les poids MV optimaux",
+    "- Mesurez la condition number de chaque matrice (`np.linalg.cond`)",
+    "- Affichez les allocations et les condition numbers",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.covariance.LedoitWolf` et `sklearn.covariance.OAS`",
+    "- # Indice : Un condition number eleve = matrice instable = allocations erratiques"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Estimateurs de covariance",
+    "# TODO etudiant : Comparer empirique, Ledoit-Wolf et OAS",
+    "# Indice : 3 estimateurs, poids MV, condition number",
+    "# Etape 1 : Calculer les 3 matrices de covariance",
+    "# Etape 2 : Optimiser les poids MV pour chacune",
+    "# Etape 3 : Calculer le condition number de chaque matrice",
+    "# Etape 4 : Afficher les allocations et les condition numbers",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison des estimateurs",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1748,6 +1833,50 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Backtest de portefeuille ML-optimise",
+    "",
+    "Comparer les allocations ML avec un benchmark equal-weight sur une periode hors-echantillon.",
+    "",
+    "**Objectif** : Implementer un backtest simplifie comparant 3 strategies d'allocation.",
+    "",
+    "**Regles** :",
+    "- Strategie A : Equal weight (1/N)",
+    "- Strategie B : Mean-Variance classique",
+    "- Strategie C : ML-optimise (Black-Litterman avec vues ML)",
+    "- Periode OOS : derniers 20% des donnees",
+    "- Rebalance mensuel",
+    "- Metriques : Sharpe, Max Drawdown, Turnover",
+    "",
+    "**Indices** :",
+    "- # Indice : Calculez les rendements du portefeuille comme `returns.dot(weights)`",
+    "- # Indice : Turnover = `np.abs(weights_new - weights_old).sum() / 2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Backtest comparatif d'allocations",
+    "# TODO etudiant : Comparer equal-weight vs MV vs ML sur periode OOS",
+    "# Indice : 3 strategies, rebalance mensuel, calcul Sharpe/MaxDD/Turnover",
+    "# Etape 1 : Splitter les donnees (80% IS / 20% OOS)",
+    "# Etape 2 : Calculer les poids pour chaque strategie",
+    "# Etape 3 : Simuler les rendements de portefeuille",
+    "# Etape 4 : Afficher les metriques comparatives",
+    "",
+    "result = None  # TODO etudiant : remplacer par le backtest comparatif",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-22-Deep-Learning-LSTM.ipynb
@@ -922,6 +922,50 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Preparation de donnees pour LSTM",
+    "",
+    "Les LSTM necessitent des sequences de longueur fixe. La transformation des donnees brutes en sequences est une etape critique.",
+    "",
+    "**Objectif** : Implementer la creation de sequences glissantes a partir d'une serie temporelle.",
+    "",
+    "**Regles** :",
+    "- Fonction `create_sequences(data, seq_len, horizon)` :",
+    "  - Input : array de forme `(T, features)`",
+    "  - Output : `X` de forme `(N, seq_len, features)`, `y` de forme `(N, horizon)`",
+    "- `seq_len = 60`, `horizon = 5` (predire 5 jours)",
+    "- Normalisez avec un scaler fit sur le train uniquement (pas de leak)",
+    "- Affichez les dimensions des tensors et un exemple de sequence",
+    "",
+    "**Indices** :",
+    "- # Indice : `for i in range(len(data) - seq_len - horizon + 1)` pour la boucle",
+    "- # Indice : Fittez le scaler uniquement sur `data[:split_idx]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Sequences glissantes pour LSTM",
+    "# TODO etudiant : Transformer une serie temporelle en sequences",
+    "# Indice : Fenetre glissante de seq_len, cible a horizon pas",
+    "# Etape 1 : Implementer create_sequences()",
+    "# Etape 2 : Normaliser sans leak (fit sur train uniquement)",
+    "# Etape 3 : Splitter en train/val/test",
+    "# Etape 4 : Afficher les dimensions et un exemple",
+    "",
+    "result = None  # TODO etudiant : remplacer par la preparation de sequences",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "257708b2",
    "metadata": {
     "papermill": {
@@ -1761,6 +1805,48 @@
     "print(f\"  Parameters: {n_params_patchtst:,}\")\n",
     "print(f\"  Patches: {model_patchtst.patch_embedding.n_patches}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Architecture LSTM personnalisee bidirectionnelle",
+    "",
+    "Un LSTM bidirectionnel traite la sequence dans les deux sens, capturant les dependances passees et futures.",
+    "",
+    "**Objectif** : Implementer un BiLSTM pour la prediction de serie temporelle financiere.",
+    "",
+    "**Regles** :",
+    "- Utilisez `nn.LSTM(bidirectional=True, ...)` avec hidden_size=64",
+    "- La sortie bidirectionnelle a 2*hidden_size dimensions",
+    "- Ajoutez une couche lineaire de projection vers la dimension de sortie",
+    "- Comparez LSTM unidirectionnel vs bidirectionnel (MSE, temps d'entrainement)",
+    "",
+    "**Indices** :",
+    "- # Indice : `output, (hn, cn) = self.lstm(x)` retourne `(batch, seq, 2*hidden)` en bidirectionnel",
+    "- # Indice : Le dernier pas de temps suffit pour la prediction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : BiLSTM pour serie temporelle",
+    "# TODO etudiant : Implementer un LSTM bidirectionnel",
+    "# Indice : nn.LSTM(bidirectional=True), projection lineaire",
+    "# Etape 1 : Definir la classe BiLSTMModel",
+    "# Etape 2 : Gerer la dimension 2*hidden de la sortie",
+    "# Etape 3 : Entrainer sur les donnees de training",
+    "# Etape 4 : Comparer avec le LSTM unidirectionnel",
+    "",
+    "result = None  # TODO etudiant : remplacer par le BiLSTM",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -2852,6 +2938,48 @@
     "dir_acc_mixer = np.mean(dir_true_mixer == dir_pred_mixer)\n",
     "print(f\"  Direction Accuracy: {dir_acc_mixer:.2%}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Regularisation par dropout et early stopping",
+    "",
+    "Les modeles profonds sont sujets au surapprentissage, surtout avec peu de donnees financieres. Dropout et early stopping sont deux techniques complementaires.",
+    "",
+    "**Objectif** : Implementer un entrainement avec dropout et early stopping sur un modele LSTM.",
+    "",
+    "**Regles** :",
+    "- Ajoutez un `nn.Dropout(0.3)` entre chaque couche LSTM",
+    "- Implementez l'early stopping : arreter si la val_loss ne s'ameliore pas pendant 10 epochs",
+    "- Comparez les courbes d'apprentissage avec et sans regularisation",
+    "- Affichez les metriques finales (MSE train vs val)",
+    "",
+    "**Indices** :",
+    "- # Indice : `patience=10` dans le early stopping, `best_val_loss = float('inf')`",
+    "- # Indice : Stockez les poids du meilleur modele avec `model.state_dict()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Dropout et early stopping",
+    "# TODO etudiant : Regulariser un LSTM avec dropout + early stopping",
+    "# Indice : nn.Dropout entre les couches, patience=10 pour early stopping",
+    "# Etape 1 : Modifier le modele LSTM pour ajouter du dropout",
+    "# Etape 2 : Implementer la boucle d'entrainement avec early stopping",
+    "# Etape 3 : Entrainer avec et sans regularisation",
+    "# Etape 4 : Comparer les courbes d'apprentissage",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'entrainement regularise",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -803,6 +803,50 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Mecanisme d'attention simplifie",
+    "",
+    "L'attention du Transformer calcule `softmax(QK^T / sqrt(d_k)) * V`. Implementons-la from scratch.",
+    "",
+    "**Objectif** : Implementer l'attention a tete unique sans utiliser `nn.MultiheadAttention`.",
+    "",
+    "**Regles** :",
+    "- Matrices Q, K, V : `nn.Linear(d_model, d_k)` chacune",
+    "- Scores d'attention : `Q @ K.T / sqrt(d_k)`",
+    "- Softmax le long de la derniere dimension",
+    "- Output : `softmax(scores) @ V`",
+    "- Ajoutez un masque causal (triangle inferieur) pour l'autoregression",
+    "- Testez avec `d_model=32`, `seq_len=10`",
+    "",
+    "**Indices** :",
+    "- # Indice : `torch.triu` avec `diagonal=1` pour le masque causal, remplissez avec `-inf`",
+    "- # Indice : `F.softmax(scores, dim=-1)` pour normaliser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Attention a tete unique from scratch",
+    "# TODO etudiant : Implementer QKV attention avec masque causal",
+    "# Indice : 3 lineaires pour Q/K/V, softmax(QK^T/sqrt(d))V",
+    "# Etape 1 : Definir les projections Q, K, V",
+    "# Etape 2 : Calculer les scores d'attention",
+    "# Etape 3 : Appliquer le masque causal et le softmax",
+    "# Etape 4 : Calculer la sortie attentionnee",
+    "",
+    "result = None  # TODO etudiant : remplacer par le mecanisme d'attention",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "3478a141",
    "metadata": {
     "papermill": {
@@ -1318,6 +1362,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Simplified Mamba block",
+    "",
+    "Le bloc Mamba combine une projection lineaire, une convolution 1D et un mecanisme de selection. Cet exercie simplifie cette architecture.",
+    "",
+    "**Objectif** : Implementer un bloc Mamba simplifie en PyTorch.",
+    "",
+    "**Regles** :",
+    "- Projection d'entree : `nn.Linear(d_model, 2*d_model)`",
+    "- Convolution 1D : `nn.Conv1d(d_model, d_model, kernel_size=3, padding=1)`",
+    "- Gate de selection : `sigmoid(x_proj) * x_conv`",
+    "- Projection de sortie : `nn.Linear(d_model, d_model)`",
+    "- Testez sur un batch de sequence `(batch=8, seq=50, d_model=32)`",
+    "",
+    "**Indices** :",
+    "- # Indice : La convolution 1D attend `(batch, channels, seq)` -> transposez",
+    "- # Indice : La gate = `torch.sigmoid(gate_input) * value_input`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Simplified Mamba block",
+    "# TODO etudiant : Implementer un mini bloc Mamba en PyTorch",
+    "# Indice : Linear + Conv1d + gate sigmoid + Linear",
+    "# Etape 1 : Definir la classe SimplifiedMambaBlock(nn.Module)",
+    "# Etape 2 : Implementer le forward avec projection + conv1d + gate",
+    "# Etape 3 : Verifier les dimensions de sortie",
+    "# Etape 4 : Tester sur un batch aleatoire",
+    "",
+    "result = None  # TODO etudiant : remplacer par le bloc Mamba simplifie",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "7e2f6f9c",
    "metadata": {
     "papermill": {
@@ -1790,6 +1877,49 @@
     "print(f\"\\nClassification Report:\")\n",
     "print(classification_report(y_test, y_pred, target_names=['Down', 'Up']))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Benchmark Mamba vs LSTM",
+    "",
+    "Comparer un modele SSM (Mamba) avec un LSTM sur le meme dataset financier.",
+    "",
+    "**Objectif** : Entrainer les deux modeles et comparer leur performance et vitesse.",
+    "",
+    "**Regles** :",
+    "- Meme donnees, meme split train/test",
+    "- LSTM : 2 couches, hidden=64",
+    "- Mamba : d_model=64, d_state=16",
+    "- Comparez : MSE test, temps d'entrainement (epochs/sec), nombre de parametres",
+    "- Affichez un tableau comparatif et les courbes de loss",
+    "",
+    "**Indices** :",
+    "- # Indice : `sum(p.numel() for p in model.parameters())` pour le nombre de parametres",
+    "- # Indice : `time.time()` avant/apres l'entrainement pour le timing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Benchmark Mamba vs LSTM",
+    "# TODO etudiant : Comparer performance et vitesse des deux architectures",
+    "# Indice : Meme config, mesurer MSE + temps + parametres",
+    "# Etape 1 : Configurer les deux modeles avec des capacites comparables",
+    "# Etape 2 : Entrainer et chronometrer chaque modele",
+    "# Etape 3 : Evaluer sur le test set",
+    "# Etape 4 : Afficher le tableau comparatif",
+    "",
+    "result = None  # TODO etudiant : remplacer par le benchmark",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-24-Autoencoders-Anomaly.ipynb
@@ -1115,6 +1115,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Autoencoder variationnel simplifie",
+    "",
+    "Le VAE apprend une distribution latente au lieu d'un vecteur fixe. Il encode `mu` et `log_var`, puis echantillonne via le trick de reparameterisation.",
+    "",
+    "**Objectif** : Implementer un VAE avec un espace latent de dimension 8.",
+    "",
+    "**Regles** :",
+    "- Encodeur : `Linear(input, 32) -> ReLU -> Linear(32, 16)` puis deux tete : `mu` et `log_var`",
+    "- Trick de reparameterisation : `z = mu + eps * exp(0.5 * log_var)`",
+    "- Decodeur : `Linear(8, 16) -> ReLU -> Linear(16, input)`",
+    "- Loss = `reconstruction_loss + 0.001 * KL_divergence`",
+    "- Entrainez 50 epochs et affichez la loss",
+    "",
+    "**Indices** :",
+    "- # Indice : KL divergence = `-0.5 * sum(1 + log_var - mu^2 - exp(log_var))`",
+    "- # Indice : `torch.randn_like(mu)` pour le bruit gaussien"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : VAE simplifie",
+    "# TODO etudiant : Implementer un VAE avec reparameterisation",
+    "# Indice : Encodeur->(mu,log_var), z=mu+eps*exp(0.5*log_var), decodeur",
+    "# Etape 1 : Definir l'encodeur avec les deux tetes mu et log_var",
+    "# Etape 2 : Implementer le trick de reparameterisation",
+    "# Etape 3 : Definir le decodeur",
+    "# Etape 4 : Calculer la loss (reconstruction + KL) et entrainer",
+    "",
+    "result = None  # TODO etudiant : remplacer par le VAE",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b16e8ebd",
    "metadata": {
     "papermill": {
@@ -1986,6 +2029,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Clustering de regimes par DBSCAN",
+    "",
+    "K-Means suppose des clusters spheriques. DBSCAN detecte des clusters de forme arbitraire et identifie les outliers.",
+    "",
+    "**Objectif** : Appliquer DBSCAN pour identifier les regimes de marche et comparer avec K-Means.",
+    "",
+    "**Regles** :",
+    "- Features : rendement et volatilite sur 21 jours",
+    "- DBSCAN : `eps=0.5`, `min_samples=10`",
+    "- K-Means : 3 clusters",
+    "- Comparez : nombre de clusters, silhouette score, proportion d'outliers",
+    "- Affichez le scatter plot colore par cluster pour chaque methode",
+    "",
+    "**Indices** :",
+    "- # Indice : `sklearn.cluster.DBSCAN` retourne `labels_` ou -1 = outlier",
+    "- # Indice : `sklearn.metrics.silhouette_score(X, labels)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : DBSCAN pour regimes de marche",
+    "# TODO etudiant : Comparer DBSCAN et K-Means pour la detection de regimes",
+    "# Indice : DBSCAN(eps, min_samples), comparer avec K-Means 3 clusters",
+    "# Etape 1 : Preparer les features (rendement + volatilite)",
+    "# Etape 2 : Appliquer DBSCAN et K-Means",
+    "# Etape 3 : Calculer le silhouette score pour chaque",
+    "# Etape 4 : Afficher les scatter plots comparatifs",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison DBSCAN vs KMeans",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "6ef3aa00",
    "metadata": {
     "papermill": {
@@ -2445,6 +2531,48 @@
     "    print(f\"  Rendement total: {bh_total:.2%}\")\n",
     "    print(f\"  Sharpe Ratio: {bh_sharpe:.2f}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Detection d'anomalies en temps reel",
+    "",
+    "En production, les anomalies doivent etre detectees en temps reel, point par point, sans voir les donnees futures.",
+    "",
+    "**Objectif** : Implementer un detecteur d'anomalies en streaming avec un autoencoder pre-entraine.",
+    "",
+    "**Regles** :",
+    "- Utilisez un autoencoder simple (encodeur: 32->16->8, decodeur: 8->16->32)",
+    "- Seuil d'anomalie : `mean(reconstruction_error) + 2*std(reconstruction_error)` calcule sur le train",
+    "- Pour chaque nouveau point : encoder-decoder, calculer l'erreur, flag si > seuil",
+    "- Simulez un flux de 100 points et affichez les anomalies detectees",
+    "",
+    "**Indices** :",
+    "- # Indice : L'erreur de reconstruction = `nn.MSELoss()(output, input)`",
+    "- # Indice : Le seuil dynamique utilise les statistiques du set d'entrainement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Detection d'anomalies en streaming",
+    "# TODO etudiant : Detecter les anomalies point par point avec un autoencoder",
+    "# Indice : Seuil = mean + 2*std sur train, flag si depasse",
+    "# Etape 1 : Entrainer l'autoencoder sur les donnees normales",
+    "# Etape 2 : Calculer le seuil d'anomalie",
+    "# Etape 3 : Simuler le flux de donnees",
+    "# Etape 4 : Flaguer et afficher les anomalies en temps reel",
+    "",
+    "result = None  # TODO etudiant : remplacer par le detecteur streaming",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-25-Reinforcement-Learning.ipynb
@@ -396,6 +396,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Modeliser le trading comme un MDP",
+    "",
+    "Le trading se modelise naturellement comme un Processus de Decision Markovien (MDP). Definir les etats, actions et rewards est la premiere etape.",
+    "",
+    "**Objectif** : Formaliser un MDP de trading et implementer la matrice de transition simplifiee.",
+    "",
+    "**Regles** :",
+    "- Etats : 3 regimes de marche (bull, bear, flat) detectes par rendement 20j",
+    "- Actions : 3 actions (buy, sell, hold)",
+    "- Rewards : matrice 3x3 (etat x action) remplie selon la logique financiere",
+    "  - Bull+Buy = +2, Bull+Sell = -1, Bull+Hold = +1",
+    "  - Bear+Buy = -2, Bear+Sell = +2, Bear+Hold = -1",
+    "  - Flat+Buy = 0, Flat+Sell = 0, Flat+Hold = +1",
+    "- Affichez la matrice de rewards et la politique optimale (argmax par ligne)",
+    "",
+    "**Indices** :",
+    "- # Indice : `np.array([[+2, -1, +1], [-2, +2, -1], [0, 0, +1]])` pour la matrice",
+    "- # Indice : La politique optimale = `np.argmax(reward_matrix, axis=1)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : MDP de trading",
+    "# TODO etudiant : Formaliser etat/action/reward et calculer la politique optimale",
+    "# Indice : Matrice 3x3 de rewards, argmax pour la politique",
+    "# Etape 1 : Definir les etats (3 regimes) et les actions (buy/sell/hold)",
+    "# Etape 2 : Remplir la matrice de rewards",
+    "# Etape 3 : Calculer la politique optimale par argmax",
+    "# Etape 4 : Afficher la matrice et la politique",
+    "",
+    "result = None  # TODO etudiant : remplacer par le MDP de trading",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "30457e06",
    "metadata": {
     "papermill": {
@@ -1406,6 +1451,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Environnement de trading personnalisable",
+    "",
+    "L'environnement Gymnasium standard ne capture pas tous les aspects du trading. Ajoutez des contraintes realistes.",
+    "",
+    "**Objectif** : Etendre l'environnement avec des frais de transaction et un drawdown maximum.",
+    "",
+    "**Regles** :",
+    "- Frais de transaction : 10 basis points par trade",
+    "- Drawdown maximum : l'episode se termine si le drawdown depasse 20%",
+    "- Ajoutez un `info` dict contenant : `portfolio_value`, `position`, `drawdown`",
+    "- Testez l'environnement sur 252 pas (1 an de trading)",
+    "",
+    "**Indices** :",
+    "- # Indice : `transaction_cost = abs(new_position - old_position) * price * 0.001`",
+    "- # Indice : `drawdown = (peak - value) / peak`, arreter si > 0.20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Environnement avec frais et drawdown max",
+    "# TODO etudiant : Ajouter des contraintes realistes a l'environnement",
+    "# Indice : 10bps par trade, stop si drawdown > 20%",
+    "# Etape 1 : Ajouter les frais de transaction dans step()",
+    "# Etape 2 : Implementer le suivi du drawdown",
+    "# Etape 3 : Terminer l'episode si drawdown > 20%",
+    "# Etape 4 : Peupler le dictionnaire info",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'environnement etendu",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "e3ccabde",
    "metadata": {
     "papermill": {
@@ -2187,6 +2274,49 @@
     "print(f\"  Random Sharpe: {random_results['avg_sharpe']:.2f}\")\n",
     "print(f\"  Improvement: {eval_results['avg_return'] - random_results['avg_return']:.2f}%\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Reward shaping pour le trading",
+    "",
+    "Le reward par defaut (PnL) peut etre ameliore en penalant la volatilite et le drawdown. Un reward bien concolu accelere l'apprentissage.",
+    "",
+    "**Objectif** : Implementer 3 fonctions de reward et comparer leur impact sur l'agent.",
+    "",
+    "**Regles** :",
+    "- Reward 1 : PnL simple (profit and loss)",
+    "- Reward 2 : PnL ajuste du risque = `pnl - 0.5 * volatility`",
+    "- Reward 3 : Sharpe-like = `mean(returns) / max(std(returns), 1e-6)` sur fenetre 20",
+    "- Pour chaque reward, entrainez un agent DQN simplifie 100 episodes",
+    "- Affichez les courbes de reward cumule par episode",
+    "",
+    "**Indices** :",
+    "- # Indice : Modifiez la methode `step()` de l'environnement pour changer le reward",
+    "- # Indice : Utilisez les memes hyperparametres DQN pour les 3 experiences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Impact du reward shaping",
+    "# TODO etudiant : Comparer 3 fonctions de reward sur l'apprentissage DQN",
+    "# Indice : Modifier env.step() pour chaque reward, meme DQN, comparer",
+    "# Etape 1 : Definir les 3 fonctions de reward",
+    "# Etape 2 : Modifier l'environnement pour accepter differentes fonctions",
+    "# Etape 3 : Entrainer un agent DQN avec chaque reward",
+    "# Etape 4 : Comparer les courbes d'apprentissage",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'experience de reward shaping",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Batch 5 of QC Python exercise rollout for convention #2161 (>= 3 exercises per notebook). 8 notebooks, 24 exercises total.

### Notebooks modified (8)

| Notebook | Exercises | Topics |
|----------|-----------|--------|
| QC-Py-18 ML Features | 3 | Multi-horizon momentum, Fundamental health score, MI vs Pearson selection |
| QC-Py-19 ML Classification | 3 | Trading labels (binary/threshold/triple-barrier), Permutation importance, RF vs XGBoost benchmark |
| QC-Py-20 ML Regression | 3 | Classification-as-regression, Alpha GridSearchCV, Stacking regressor |
| QC-Py-21 Portfolio ML | 3 | Constrained efficient frontier, Covariance estimators (LW/OAS), ML allocation backtest |
| QC-Py-22 Deep Learning | 3 | Sliding sequences for LSTM, BiLSTM architecture, Dropout + early stopping |
| QC-Py-23 Transformers | 3 | QKV attention from scratch, Simplified Mamba block, Mamba vs LSTM benchmark |
| QC-Py-24 Autoencoders | 3 | VAE with reparameterization trick, DBSCAN regime clustering, Streaming anomaly detection |
| QC-Py-25 RL | 3 | Trading MDP formalization, Env with transaction costs + max drawdown, Reward shaping experiment |

### Validation

- C.1 check: PASS (no `raise NotImplementedError`, `assert False`, or `1/0`)
- All stubs: `result = None  # TODO etudiant` + `print("Exercice a completer")`
- Exercise markdown cells: objective + rules + `# Indice` / `# Etape N` hints
- Exercises spread throughout notebooks (after relevant section content)
- All plain Python executable style (NB-18 to NB-25 are not QCAlgorithm reference notebooks)
- **1024 insertions, 0 deletions** (pure enrichment)

### Convention #2161 compliance

Each notebook now has exactly 3 exercise stubs, meeting the >= 3 target.