### PR TITLE
enrich(QC): add 3 exercises each to QC-Py-26/27/28/30/31/32/33/34 (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -337,6 +337,50 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Estimation des couts API pour le trading",
+    "",
+    "Chaque appel LLM a un cout. En trading haute frequence, les couts API peuvent manger les profits.",
+    "",
+    "**Objectif** : Calculer le cout quotidien d'un systeme LLM de trading.",
+    "",
+    "**Regles** :",
+    "- Modele GPT-4 : $0.03/1K tokens input, $0.06/1K tokens output",
+    "- Chaque analyse de headline : ~200 tokens input + ~50 tokens output",
+    "- Frequence : 50 analyses par jour (ouverture, midday, pre-close)",
+    "- Ajoutez une marge de securite de 20%",
+    "- Calculez le cout quotidien, mensuel et annuel",
+    "- Determinez le PnL minimum requis pour couvrir les couts API",
+    "",
+    "**Indices** :",
+    "- # Indice : `cout_par_analyse = (input_tokens/1000)*prix_in + (output_tokens/1000)*prix_out`",
+    "- # Indice : PnL minimum = cout_annuel * (1 + marge)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Estimation couts API",
+    "# TODO etudiant : Calculer le cout quotidien d'un systeme LLM",
+    "# Indice : tokens * prix + marge de 20%",
+    "# Etape 1 : Definir les prix et parametres",
+    "# Etape 2 : Calculer le cout par analyse",
+    "# Etape 3 : Calculer les couts quotidien/mensuel/annuel",
+    "# Etape 4 : Calculer le PnL minimum pour couvrir les couts",
+    "",
+    "result = None  # TODO etudiant : remplacer par le calcul des couts",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -903,6 +947,49 @@
     "agg_signal, agg_conf = analyzer.aggregate_signals(results)\n",
     "print(f\"\\nSignal Agrege: {agg_signal:.2f} (confiance: {agg_conf:.2f})\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Prompt engineering pour le sentiment financier",
+    "",
+    "La qualite du prompt impacte directement la qualite du signal. Comparez 3 styles de prompts.",
+    "",
+    "**Objectif** : Comparer zero-shot, few-shot et chain-of-thought pour l'analyse de sentiment.",
+    "",
+    "**Regles** :",
+    "- Zero-shot : `Analysez le sentiment de cette headline : {headline}`",
+    "- Few-shot : ajoutez 3 exemples etiquetes avant la question",
+    "- Chain-of-thought : demandez un raisonnement etape par etape",
+    "- Evaluez sur 10 headlines avec labels pre-definis",
+    "- Affichez l'accuracy de chaque approche",
+    "",
+    "**Indices** :",
+    "- # Indice : Simulez les reponses LLM avec des fonctions mock",
+    "- # Indice : Labels pre-definis = `{'AAPL beats expectations': 1, 'Market crash fears': -1, ...}`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Prompt engineering compare",
+    "# TODO etudiant : Comparer zero-shot, few-shot et chain-of-thought",
+    "# Indice : 3 templates de prompt, evaluer sur 10 headlines",
+    "# Etape 1 : Definir les 3 templates de prompt",
+    "# Etape 2 : Creer les labels de reference",
+    "# Etape 3 : Simuler les reponses LLM pour chaque approche",
+    "# Etape 4 : Calculer et afficher les accuracies",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison de prompts",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1505,6 +1592,49 @@
     "\n",
     "visualize_hybrid_signals(demo_signals)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Systeme de vote LLM multi-modeles",
+    "",
+    "Combinez les signaux de plusieurs LLM (simules) via un systeme de vote majoritaire.",
+    "",
+    "**Objectif** : Implementer un ensemble de modeles LLM avec vote pondere.",
+    "",
+    "**Regles** :",
+    "- Simulez 3 LLM avec des biais differents (bullish, bearish, neutral)",
+    "- Chaque LLM retourne un signal : +1 (buy), 0 (hold), -1 (sell)",
+    "- Vote pondere : bullish_poids=0.3, bearish_poids=0.4, neutral_poids=0.3",
+    "- Signal final = sign(somme_ponderee)",
+    "- Testez sur 20 headlines et affichez la matrice de confusion",
+    "",
+    "**Indices** :",
+    "- # Indice : Chaque LLM est une fonction `lambda headline: signal` avec un biais",
+    "- # Indice : `np.sign()` pour le signal final"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Systeme de vote LLM",
+    "# TODO etudiant : Implementer un ensemble multi-LLM avec vote pondere",
+    "# Indice : 3 LLM simules, vote pondere, signal final = sign(somme)",
+    "# Etape 1 : Definir les 3 LLM simules avec biais differents",
+    "# Etape 2 : Implementer le vote pondere",
+    "# Etape 3 : Appliquer sur 20 headlines",
+    "# Etape 4 : Afficher la matrice de confusion",
+    "",
+    "result = None  # TODO etudiant : remplacer par le systeme de vote",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -385,6 +385,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Pipeline de validation pre-deploiement",
+    "",
+    "Avant de deployer une strategie en production, un pipeline automatise verifie les pre-requis.",
+    "",
+    "**Objectif** : Implementer un pipeline de validation en 4 etapes.",
+    "",
+    "**Regles** :",
+    "- Etape 1 : Backtest minimum 2 ans avec Sharpe > 0.5",
+    "- Etape 2 : Walk-forward validation (5 folds) avec ratio OOS/IS > 0.3",
+    "- Etape 3 : Stress test : performance sous scenarios extremes (-20% market, vol x3)",
+    "- Etape 4 : Paper trading 30 jours avec slippage 5bps",
+    "- Chaque etape retourne PASS/FAIL avec metriques",
+    "",
+    "**Indices** :",
+    "- # Indice : Chaque etape est une fonction `validate_X() -> (bool, dict)`",
+    "- # Indice : Simulez les metriques avec des valeurs realistes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Pipeline validation pre-deploiement",
+    "# TODO etudiant : Implementer 4 etapes de validation",
+    "# Indice : Chaque etape = fonction retournant (PASS/FAIL, metriques)",
+    "# Etape 1 : Verifier backtest 2 ans + Sharpe > 0.5",
+    "# Etape 2 : Verifier walk-forward ratio > 0.3",
+    "# Etape 3 : Verifier stress test scenarios",
+    "# Etape 4 : Verifier paper trading 30j + slippage",
+    "",
+    "result = None  # TODO etudiant : remplacer par le pipeline",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -782,6 +825,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Configuration live trading",
+    "",
+    "Le passage du paper au live trading exige une configuration rigoureuse. Un seul parametre oublie peut causer des pertes.",
+    "",
+    "**Objectif** : Creer une checklist de configuration et un validateur automatique.",
+    "",
+    "**Regles** :",
+    "- Checklist : broker config, risk limits, max position size, daily loss limit, kill switch",
+    "- Validateur : verifie que chaque parametre est dans les bornes acceptables",
+    "- Bornes : max_position < 20% NAV, daily_loss_limit < 2%, kill_switch = True",
+    "- Affichez le rapport de validation (PASS/FAIL par parametre)",
+    "",
+    "**Indices** :",
+    "- # Indice : Representez la config comme un dictionnaire `{param: value}`",
+    "- # Indice : Bouclez sur les bornes definies et comparez"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Validateur de configuration live",
+    "# TODO etudiant : Creer une checklist + validateur automatique",
+    "# Indice : Dict config + bornes + rapport PASS/FAIL",
+    "# Etape 1 : Definir la configuration live",
+    "# Etape 2 : Definir les bornes acceptables",
+    "# Etape 3 : Implementer le validateur",
+    "# Etape 4 : Afficher le rapport",
+    "",
+    "result = None  # TODO etudiant : remplacer par le validateur",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -1170,6 +1255,49 @@
     "\n",
     "print(f\"\\nTotal alerts: {len(monitor.alerts)}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Orchestrateur multi-strategies",
+    "",
+    "Un systeme de production combine plusieurs strategies. L'orchestrateur gere l'allocation inter-strategies.",
+    "",
+    "**Objectif** : Implementer un allocateur dynamique basé sur la performance recente.",
+    "",
+    "**Regles** :",
+    "- 3 strategies simulees avec des rendements differents",
+    "- Alloquer proportionnellement au Sharpe ratio glissant (20 jours)",
+    "- Poids minimum 10% par strategie, maximum 50%",
+    "- Rebalance hebdomadaire",
+    "- Affichez les allocations et la performance combinee",
+    "",
+    "**Indices** :",
+    "- # Indice : `sharpe_glissant = mean(returns_20j) / max(std(returns_20j), 1e-6)`",
+    "- # Indice : Normalisez les Sharpe en poids puis clippez entre 0.10 et 0.50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Allocateur multi-strategies",
+    "# TODO etudiant : Implementer un allocateur dynamique",
+    "# Indice : Sharpe glissant + normalisation + contraintes min/max",
+    "# Etape 1 : Simuler les rendements des 3 strategies",
+    "# Etape 2 : Calculer les Sharpe glissants",
+    "# Etape 3 : Convertir en allocations contraintes",
+    "# Etape 4 : Afficher allocations et performance combinee",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'allocateur",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-28-Market-Regime-Detection.ipynb
@@ -770,6 +770,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Regime performance attribution",
+    "",
+    "Decomposez la performance d'une strategie par regime pour identifier les forces et faiblesses.",
+    "",
+    "**Objectif** : Calculer les metriques de performance par regime de marche.",
+    "",
+    "**Regles** :",
+    "- Identifiez 3 regimes : bull, bear, flat (via les labels du HMM ci-dessus)",
+    "- Pour chaque regime, calculez : nombre de jours, rendement moyen, volatilite, Sharpe, max drawdown",
+    "- Affichez un tableau comparatif par regime",
+    "- Identifiez le regime ou la strategie sous-performe le plus",
+    "",
+    "**Indices** :",
+    "- # Indice : Groupby par label de regime : `df.groupby('regime')['returns'].agg(...)`",
+    "- # Indice : Sharpe par regime = `mean / std` avec annualisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Performance par regime",
+    "# TODO etudiant : Decomposer la performance par regime",
+    "# Indice : Groupby regime + agg(mean, std, sharpe, max_dd)",
+    "# Etape 1 : Attribuer un regime a chaque jour",
+    "# Etape 2 : Calculer les metriques par regime",
+    "# Etape 3 : Construire le tableau comparatif",
+    "# Etape 4 : Identifier le regime sous-performant",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'attribution par regime",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -1104,6 +1146,48 @@
     "print(f\"  Jours avec GLD > 0 : {(signals['GLD'] > 0).sum()} ({(signals['GLD'] > 0).sum() / len(signals) * 100:.1f}%)\")\n",
     "print(f\"  Jours avec IEF > 0 : {(signals['IEF'] > 0).sum()} ({(signals['IEF'] > 0).sum() / len(signals) * 100:.1f}%)\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Strategie de rotation adaptative",
+    "",
+    "Une strategie adaptative change de regime en fonction de la volatilite et de la tendance.",
+    "",
+    "**Objectif** : Implementer un signal de rotation qui adapte le style (trend vs mean-reversion) au regime.",
+    "",
+    "**Regles** :",
+    "- Regime trend (SMA50 > SMA200) : utiliser un signal momentum (retour 20j)",
+    "- Regime mean-reversion (RSI extremes) : utiliser un signal RSI inversé",
+    "- Regime neutre : signal = 0 (flat, ne pas trader)",
+    "- Calculez le PnL cumulé et comparez avec un buy-and-hold",
+    "",
+    "**Indices** :",
+    "- # Indice : `np.where(condition_trend, signal_momentum, np.where(condition_mr, signal_rsi_inv, 0))`",
+    "- # Indice : RSI inverse = `-1 * (RSI - 50) / 50`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Rotation adaptative trend/mean-reversion",
+    "# TODO etudiant : Adapter le signal au regime detecte",
+    "# Indice : np.where pour switcher entre momentum et RSI inverse",
+    "# Etape 1 : Detecter le regime (trend/mean-reversion/neutre)",
+    "# Etape 2 : Calculer le signal momentum",
+    "# Etape 3 : Calculer le signal RSI inverse",
+    "# Etape 4 : Combiner et afficher le PnL vs B&H",
+    "",
+    "result = None  # TODO etudiant : remplacer par la rotation adaptative",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1457,6 +1541,50 @@
     "print(f\"  Jours oversold (< 30) : {(rsi < 30).sum()}\")\n",
     "print(f\"  Jours overbought (> 70) : {(rsi > 70).sum()}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Detecteur de regime multi-indicateurs",
+    "",
+    "Un seul indicateur (SMA, RSI, volatilite) est insuffisant. Un detecteur robuste combine plusieurs signaux.",
+    "",
+    "**Objectif** : Implementer un score de regime combinant tendance, momentum et volatilite.",
+    "",
+    "**Regles** :",
+    "- Score tendance : +1 si SMA50 > SMA200, -1 sinon",
+    "- Score momentum : +1 si retour 20j > 0, -1 sinon",
+    "- Score volatilite : +1 si vol 20j < vol 60j (calme), -1 sinon",
+    "- Score composite = 0.4*tendance + 0.3*momentum + 0.3*volatilite",
+    "- Regime : > 0.5 = bull, < -0.5 = bear, sinon = flat",
+    "- Affichez la distribution des regimes",
+    "",
+    "**Indices** :",
+    "- # Indice : Chaque sous-score est `np.where(condition, +1, -1)`",
+    "- # Indice : Le score composite est une somme ponderee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Detecteur multi-indicateurs",
+    "# TODO etudiant : Combiner tendance + momentum + volatilite",
+    "# Indice : 3 sous-scores binaires, somme ponderee, seuils +/-0.5",
+    "# Etape 1 : Calculer le score tendance",
+    "# Etape 2 : Calculer le score momentum",
+    "# Etape 3 : Calculer le score volatilite",
+    "# Etape 4 : Combiner et classifier les regimes",
+    "",
+    "result = None  # TODO etudiant : remplacer par le detecteur multi-indicateurs",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -865,6 +865,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Feature engineering pour LSTM",
+    "",
+    "Le choix des features d'entree impacte directement la qualite des predictions.",
+    "",
+    "**Objectif** : Comparer 3 ensembles de features pour le meme modele LSTM.",
+    "",
+    "**Regles** :",
+    "- Features A : prix uniquement (close, open, high, low)",
+    "- Features B : prix + indicateurs techniques (RSI, MACD, Bollinger)",
+    "- Features C : prix + volume + indicateurs",
+    "- Meme architecture LSTM, meme split, meme hyperparametres",
+    "- Comparez : MSE, correlation prediction vs realite, temps d'entrainement",
+    "",
+    "**Indices** :",
+    "- # Indice : `ta.momentum.RSIIndicator(close, 14).rsi()` pour le RSI",
+    "- # Indice : Entrainement court (20 epochs) pour la comparaison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Comparaison d'ensembles de features",
+    "# TODO etudiant : Comparer 3 jeux de features pour LSTM",
+    "# Indice : Meme modele, 3 datasets differents, 20 epochs",
+    "# Etape 1 : Construire les 3 ensembles de features",
+    "# Etape 2 : Entrainer le meme LSTM sur chaque ensemble",
+    "# Etape 3 : Evaluer sur le test set",
+    "# Etape 4 : Comparer MSE, correlation et temps",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison de features",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "bb799250",
    "metadata": {
     "papermill": {
@@ -1621,6 +1664,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Analyse des erreurs de prediction",
+    "",
+    "Le MSE global masque les patterns d'erreur. Analyser quand le modele se trompe est crucial.",
+    "",
+    "**Objectif** : Analyser les erreurs par regime de volatilite et par direction.",
+    "",
+    "**Regles** :",
+    "- Calculez les erreurs = `y_true - y_pred`",
+    "- Segmentez par regime de volatilite (low/medium/high via terciles)",
+    "- Pour chaque regime : MSE, MAE, biais (erreur moyenne)",
+    "- Segmentez aussi par direction (hausse vs baisse)",
+    "- Affichez un heatmap erreurs x regime",
+    "",
+    "**Indices** :",
+    "- # Indice : `pd.qcut(volatility, 3, labels=['low','mid','high'])` pour les terciles",
+    "- # Indice : `pd.crosstab(vol_regime, direction, values=abs_error, aggfunc='mean')`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Analyse des erreurs",
+    "# TODO etudiant : Segmenter les erreurs par regime et direction",
+    "# Indice : qcut pour terciles de volatilite, crosstab pour heatmap",
+    "# Etape 1 : Calculer les erreurs",
+    "# Etape 2 : Segmenter par volatilite (terciles)",
+    "# Etape 3 : Segmenter par direction (hausse/baisse)",
+    "# Etape 4 : Afficher le heatmap",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'analyse d'erreurs",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "bb7fb7cf",
    "metadata": {
     "papermill": {
@@ -1932,6 +2018,49 @@
     "    top5 = np.argsort(avg_w)[-5:][::-1]\n",
     "    print(f\"  Head {h+1}: jours {top5.tolist()} (poids: {avg_w[top5].round(3).tolist()})\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Backtest du signal LSTM avec couts de transaction",
+    "",
+    "Un signal de prediction doit etre evalue avec des couts de transaction realistes.",
+    "",
+    "**Objectif** : Implementer un backtest simplifie avec slippage et couts.",
+    "",
+    "**Regles** :",
+    "- Signal : pred LSTM > 0 = long, < 0 = short",
+    "- Cout de transaction : 5 basis points par trade",
+    "- Slippage : 2 bps supplementaires",
+    "- Calculez : PnL net, Sharpe net, turnover, nombre de trades",
+    "- Comparez avec un buy-and-hold sans couts",
+    "",
+    "**Indices** :",
+    "- # Indice : Cout par trade = `abs(position_change) * (5 + 2) * 1e-4 * capital`",
+    "- # Indice : Turnover = `sum(abs(position_changes)) / (2 * len(data))`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Backtest avec couts de transaction",
+    "# TODO etudiant : Evaluer le signal LSTM avec slippage",
+    "# Indice : 7 bps par trade, PnL net, turnover",
+    "# Etape 1 : Generer les signaux a partir des predictions",
+    "# Etape 2 : Calculer les positions et les changements",
+    "# Etape 3 : Deduire les couts de transaction",
+    "# Etape 4 : Comparer PnL net vs B&H",
+    "",
+    "result = None  # TODO etudiant : remplacer par le backtest avec couts",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-31-Transformer-Training.ipynb
@@ -899,6 +899,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Positional encoding from scratch",
+    "",
+    "Le Transformer n'a pas de recurrence, il depend du positional encoding pour capturer l'ordre temporel.",
+    "",
+    "**Objectif** : Implementer le sinusoidal positional encoding original de Vaswani et al.",
+    "",
+    "**Regles** :",
+    "- Formule : `PE(pos, 2i) = sin(pos / 10000^(2i/d_model))`, `PE(pos, 2i+1) = cos(...)`",
+    "- Dimensions : `max_len=500`, `d_model=64`",
+    "- Affichez la heatmap du positional encoding",
+    "- Verifiez que PE est ajoute a l'input sans changer ses dimensions",
+    "",
+    "**Indices** :",
+    "- # Indice : `position = torch.arange(max_len).unsqueeze(1)` et `div_term = torch.exp(...)`",
+    "- # Indice : `pe[:, 0::2] = sin(...)` et `pe[:, 1::2] = cos(...)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Positional encoding sinusoidal",
+    "# TODO etudiant : Implementer PE(pos, 2i) = sin, PE(pos, 2i+1) = cos",
+    "# Indice : torch.arange + div_term + sin/cos alternes",
+    "# Etape 1 : Creer la matrice PE de zeros",
+    "# Etape 2 : Calculer les div_term",
+    "# Etape 3 : Remplir sin et cos aux positions paires/impaires",
+    "# Etape 4 : Afficher la heatmap",
+    "",
+    "result = None  # TODO etudiant : remplacer par le positional encoding",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-11",
    "metadata": {
     "papermill": {
@@ -2078,6 +2120,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Impact de la longueur de sequence",
+    "",
+    "La longueur de sequence (context window) est un hyperparametre critique du Transformer.",
+    "",
+    "**Objectif** : Comparer les performances avec differentes longueurs de sequence.",
+    "",
+    "**Regles** :",
+    "- Longueurs a tester : 10, 30, 60, 120 jours",
+    "- Pour chaque longueur : reentrainer le Transformer (20 epochs, meme architecture)",
+    "- Metriques : MSE test, temps d'entrainement, utilisation memoire",
+    "- Affichez un graphique MSE vs sequence_length",
+    "",
+    "**Indices** :",
+    "- # Indice : Bouclez sur `seq_lengths = [10, 30, 60, 120]`, recrez les dataloaders",
+    "- # Indice : `torch.cuda.memory_allocated()` pour la memoire GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Impact de la longueur de sequence",
+    "# TODO etudiant : Comparer seq_len=10/30/60/120",
+    "# Indice : Boucle, meme architecture, 20 epochs, MSE + temps + memoire",
+    "# Etape 1 : Definir les longueurs a tester",
+    "# Etape 2 : Pour chaque, recreer sequences et dataloaders",
+    "# Etape 3 : Entrainer et evaluer",
+    "# Etape 4 : Afficher MSE vs seq_length",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison de longueurs",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-25",
    "metadata": {
     "papermill": {
@@ -2505,6 +2589,48 @@
     "    print(f\"  Tete {head_idx} - Top 5 positions les plus attentives: {top_positions}\")\n",
     "    print(f\"    Poids correspondants: {avg_col[top_positions].round(3)}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Visualisation des poids d'attention",
+    "",
+    "Les poids d'attention montrent quelles pas de temps le modele considere les plus importants.",
+    "",
+    "**Objectif** : Extraire et visualiser les poids d'attention du Transformer.",
+    "",
+    "**Regles** :",
+    "- Interceptez les poids d'attention lors de l'inference (`attn_weights`)",
+    "- Affichez une heatmap (pas de temps d'entree vs tete d'attention)",
+    "- Identifiez les pas de temps les plus attendus",
+    "- Comparez les patterns d'attention pour une prediction correcte vs incorrecte",
+    "",
+    "**Indices** :",
+    "- # Indice : `torch.softmax(scores, dim=-1).detach().numpy()` pour extraire les poids",
+    "- # Indice : `sns.heatmap(attn_weights[head], cmap='viridis')` pour la visualisation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Visualisation des poids d'attention",
+    "# TODO etudiant : Extraire et visualiser les poids d'attention",
+    "# Indice : Intercepter attn_weights, heatmap, comparer correct/incorrect",
+    "# Etape 1 : Modifier le modele pour retourner les poids d'attention",
+    "# Etape 2 : Extraire les poids pour un batch de test",
+    "# Etape 3 : Afficher la heatmap",
+    "# Etape 4 : Comparer correct vs incorrect",
+    "",
+    "result = None  # TODO etudiant : remplacer par la visualisation d'attention",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -587,6 +587,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Replay buffer prioritaire",
+    "",
+    "Le replay buffer uniforme echantillonne toutes les experiences egalement. Le buffer prioritaire echantillonne plus souvent les experiences surprenantes.",
+    "",
+    "**Objectif** : Implementer un replay buffer avec echantillonnage prioritaire.",
+    "",
+    "**Regles** :",
+    "- Priorite = `|TD_error| + epsilon` (epsilon=1e-6 pour stabilite)",
+    "- Probabilite d'echantillonnage = `priorite^alpha / sum(priorite^alpha)` avec alpha=0.6",
+    "- Importance sampling weights = `(N * P(i))^(-beta)` avec beta=0.4",
+    "- Buffer size = 10000, batch_size = 32",
+    "",
+    "**Indices** :",
+    "- # Indice : Utilisez `numpy.random.choice(probs=priorities)` pour l'echantillonnage",
+    "- # Indice : Les weights corrigent le biais d'echantillonnage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Replay buffer prioritaire",
+    "# TODO etudiant : Implementer un PER avec TD_error comme priorite",
+    "# Indice : Priorite = |TD_error|+eps, sampling proportionnel, IS weights",
+    "# Etape 1 : Stocker les experiences avec priorite",
+    "# Etape 2 : Echantillonner proportionnellement aux priorites",
+    "# Etape 3 : Calculer les importance sampling weights",
+    "# Etape 4 : Mettre a jour les priorites apres apprentissage",
+    "",
+    "result = None  # TODO etudiant : remplacer par le PER",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "903e4402",
    "metadata": {
     "papermill": {
@@ -966,6 +1008,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Exploration vs exploitation (epsilon scheduling)",
+    "",
+    "Le parametre epsilon controle le trade-off exploration/exploitation. Un scheduling adapte accelere l'apprentissage.",
+    "",
+    "**Objectif** : Comparer 3 strategies de decay d'epsilon.",
+    "",
+    "**Regles** :",
+    "- Strategie A : epsilon lineaire de 1.0 a 0.01 sur 10000 steps",
+    "- Strategie B : epsilon exponentiel `epsilon * 0.995` par episode",
+    "- Strategie C : epsilon cosine annealing",
+    "- Comparez : reward cumule, vitesse de convergence, performance finale",
+    "- Affichez les 3 courbes epsilon et les 3 courbes de reward",
+    "",
+    "**Indices** :",
+    "- # Indice : Lineaire = `epsilon - (1.0 - 0.01) / total_steps`",
+    "- # Indice : Cosine = `0.01 + 0.5 * (1.0 - 0.01) * (1 + cos(pi * step / total_steps))`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Epsilon scheduling",
+    "# TODO etudiant : Comparer lineaire, exponentiel, cosine",
+    "# Indice : 3 strategies, meme DQN, comparer reward + convergence",
+    "# Etape 1 : Implementer les 3 fonctions de decay",
+    "# Etape 2 : Entrainer avec chaque scheduling",
+    "# Etape 3 : Collecter les metriques",
+    "# Etape 4 : Afficher les comparaisons",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison epsilon",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "b415464d",
    "metadata": {
     "papermill": {
@@ -1312,6 +1397,48 @@
     "plt.show()\n",
     "print(\"Courbes sauvegardees dans dqn_training_curves.png\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Double DQN et target network",
+    "",
+    "Le DQN classique surestime les Q-values. Le Double DQN separe la selection et l'evaluation des actions.",
+    "",
+    "**Objectif** : Implementer le Double DQN et comparer avec le DQN classique.",
+    "",
+    "**Regles** :",
+    "- DQN classique : `Q_target = max_a Q_target(s', a)`",
+    "- Double DQN : `a* = argmax_a Q_online(s', a)`, `Q_target = Q_target(s', a*)`",
+    "- Comparez : Q-values moyennes, stabilite de l'apprentissage, performance finale",
+    "- Affichez les courbes de Q-value au fil de l'entrainement",
+    "",
+    "**Indices** :",
+    "- # Indice : `best_actions = q_online(next_states).argmax(1)` puis `q_target(next_states).gather(1, best_actions)`",
+    "- # Indice : Le target network est mis a jour periodiquement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Double DQN",
+    "# TODO etudiant : Implementer Double DQN (separer selection/evaluation)",
+    "# Indice : argmax sur Q_online, evaluate avec Q_target",
+    "# Etape 1 : Modifier le calcul de la target",
+    "# Etape 2 : Separer la selection (Q_online) de l'evaluation (Q_target)",
+    "# Etape 3 : Entrainer et comparer",
+    "# Etape 4 : Afficher les Q-values moyennes",
+    "",
+    "result = None  # TODO etudiant : remplacer par le Double DQN",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -173,6 +173,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Comparaison DQN vs PPO sur meme environnement",
+    "",
+    "DQN et PPO representent deux paradigmes RL differents (value-based vs policy-based).",
+    "",
+    "**Objectif** : Comparer les deux approches sur le meme environnement de trading.",
+    "",
+    "**Regles** :",
+    "- Meme environnement (meme seed, meme donnees)",
+    "- DQN : replay_buffer=10000, epsilon_decay lineaire",
+    "- PPO : clip_ratio=0.2, GAE_lambda=0.95",
+    "- 100 episodes chacun",
+    "- Comparez : reward finale, nombre de trades, PnL, temps d'entrainement",
+    "",
+    "**Indices** :",
+    "- # Indice : Fixez `np.random.seed(42)` avant chaque entrainement",
+    "- # Indice : Mesurez le temps avec `time.perf_counter()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : DQN vs PPO",
+    "# TODO etudiant : Comparer value-based vs policy-based sur meme env",
+    "# Indice : Meme seed, 100 episodes, mesurer reward + PnL + temps",
+    "# Etape 1 : Configurer le meme environnement",
+    "# Etape 2 : Entrainer DQN",
+    "# Etape 3 : Entrainer PPO",
+    "# Etape 4 : Comparer les metriques",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison DQN vs PPO",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "f90c2ca5",
    "metadata": {},
    "source": [
@@ -790,6 +833,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Advantage estimation (GAE)",
+    "",
+    "Generalized Advantage Estimation (GAE) equilibre biais et variance dans l'estimation de l'avantage.",
+    "",
+    "**Objectif** : Implementer GAE et comparer avec l'avantage Monte-Carlo.",
+    "",
+    "**Regles** :",
+    "- GAE : `A_t = sum((gamma*lambda)^l * delta_{t+l})` ou delta = r + gamma*V(s') - V(s)",
+    "- Lambda a tester : 0.0 (MC pur), 0.5, 0.95 (GAE standard)",
+    "- Comparez : variance de l'avantage, vitesse d'apprentissage, performance finale",
+    "",
+    "**Indices** :",
+    "- # Indice : Boucle inverse : `for t in reversed(range(T))` pour calculer GAE",
+    "- # Indice : `delta = rewards[t] + gamma * values[t+1] - values[t]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : GAE advantage estimation",
+    "# TODO etudiant : Implementer GAE et comparer lambda=0/0.5/0.95",
+    "# Indice : Boucle inverse, delta_t, accumulateur exponentiel",
+    "# Etape 1 : Calculer les TD residuals delta_t",
+    "# Etape 2 : Implementer la boucle GAE",
+    "# Etape 3 : Tester 3 valeurs de lambda",
+    "# Etape 4 : Comparer variance et performance",
+    "",
+    "result = None  # TODO etudiant : remplacer par GAE",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "d69ddbbb",
    "metadata": {},
    "source": [
@@ -1196,6 +1280,48 @@
     "print(f\"  Actions - Hold: {int(action_counts_ppo[0])}, Buy: {int(action_counts_ppo[1])}, \"\n",
     "      f\"Sell: {int(action_counts_ppo[2])}, Close: {int(action_counts_ppo[3])}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : PPO clip parameter tuning",
+    "",
+    "Le parametre epsilon de clipping de PPO controle la taille des mises a jour de politique.",
+    "",
+    "**Objectif** : Comparer l'impact de epsilon sur la stabilite et la performance.",
+    "",
+    "**Regles** :",
+    "- Testez epsilon = 0.1, 0.2, 0.3",
+    "- Pour chaque valeur : entrainez 100 episodes, enregistrez la reward par episode",
+    "- Comparez : convergence, stabilite (variance de la reward), performance finale",
+    "- Affichez les courbes de reward avec bandes de confiance",
+    "",
+    "**Indices** :",
+    "- # Indice : Le clip ratio est passe en parametre du constructeur PPOAgent",
+    "- # Indice : Bandes de confiance = `mean +/- 1.96 * std / sqrt(n_runs)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : PPO clip parameter",
+    "# TODO etudiant : Comparer epsilon=0.1/0.2/0.3",
+    "# Indice : Meme architecture, 100 episodes, comparer convergence",
+    "# Etape 1 : Modifier le clip_ratio dans PPOAgent",
+    "# Etape 2 : Entrainer pour chaque valeur",
+    "# Etape 3 : Collecter les rewards par episode",
+    "# Etape 4 : Afficher avec bandes de confiance",
+    "",
+    "result = None  # TODO etudiant : remplacer par le tuning PPO",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -451,6 +451,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Environnement avec couts de transaction pour RL",
+    "",
+    "Les environnements RL de trading omettent souvent les couts de transaction, ce qui surestime la performance.",
+    "",
+    "**Objectif** : Ajouter des couts de transaction a l'environnement et observer l'impact sur l'agent.",
+    "",
+    "**Regles** :",
+    "- Cout fixe par trade : 5 bps (0.05%)",
+    "- Reward ajuste : `reward = pnl - cout_transaction`",
+    "- Comparez SAC avec et sans couts (50 episodes chacun)",
+    "- Affichez : reward cumule, nombre de trades, ratio reward/trade",
+    "",
+    "**Indices** :",
+    "- # Indice : `cout = abs(action - prev_action) * prix * 0.0005`",
+    "- # Indice : Comparez les deux courbes de reward sur le meme graphique"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Environnement avec couts de transaction",
+    "# TODO etudiant : Ajouter 5 bps par trade et comparer",
+    "# Indice : Modifier step() pour deduire les couts, comparer avec/sans",
+    "# Etape 1 : Modifier l'environnement",
+    "# Etape 2 : Entrainer SAC sans couts (baseline)",
+    "# Etape 3 : Entrainer SAC avec couts",
+    "# Etape 4 : Comparer reward, trades, ratio",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'environnement avec couts",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -791,6 +833,48 @@
     "n_params_a2c = sum(p.numel() for p in list(a2c_agent.shared.parameters()) + list(a2c_agent.actor_head.parameters()) + list(a2c_agent.critic_head.parameters()))\n",
     "print(f\"A2C: {n_params_a2c:,} parametres, n_steps={a2c_agent.n_steps}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : A2C avec entropy bonus",
+    "",
+    "L'entropy bonus dans A2C encourage l'exploration. Un coefficient trop eleve empeche la convergence.",
+    "",
+    "**Objectif** : Trouver le coefficient d'entropy optimal pour A2C.",
+    "",
+    "**Regles** :",
+    "- Testez `entropy_coef = 0.0, 0.01, 0.05, 0.1`",
+    "- Pour chaque valeur : entrainer 100 episodes",
+    "- Comparez : reward finale, diversite des actions (entropy moyenne), convergence",
+    "- Affichez les courbes de reward et d'entropy",
+    "",
+    "**Indices** :",
+    "- # Indice : La loss A2C = `policy_loss - entropy_coef * entropy`",
+    "- # Indice : `entropy = -(probs * log(probs)).sum(dim=-1).mean()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : A2C entropy bonus",
+    "# TODO etudiant : Tuner le coefficient d'entropy",
+    "# Indice : loss = policy_loss - coef * entropy, comparer 4 valeurs",
+    "# Etape 1 : Ajouter le terme d'entropy dans la loss",
+    "# Etape 2 : Tester 4 coefficients",
+    "# Etape 3 : Enregistrer reward et entropy",
+    "# Etape 4 : Afficher les comparaisons",
+    "",
+    "result = None  # TODO etudiant : remplacer par le tuning entropy",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1146,6 +1230,48 @@
     "plt.show()\n",
     "print(\"Courbes sauvegardees dans sac_a2c_training.png\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Comparaison quadri-algorithmes",
+    "",
+    "DQN, PPO, SAC et A2C ont des forces et faiblesses differentes selon l'environnement.",
+    "",
+    "**Objectif** : Benchmark complet des 4 algorithmes.",
+    "",
+    "**Regles** :",
+    "- Meme environnement, meme seed",
+    "- 50 episodes chacun (rapide pour la comparaison)",
+    "- Metriques : reward finale, variance inter-episode, nombre de trades, temps",
+    "- Affichez un tableau comparatif et un boxplot des rewards",
+    "",
+    "**Indices** :",
+    "- # Indice : Utilisez les agents definis dans les notebooks precedents (DQN, PPO)",
+    "- # Indice : `plt.boxplot([rewards_dqn, rewards_ppo, rewards_sac, rewards_a2c])`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Benchmark DQN/PPO/SAC/A2C",
+    "# TODO etudiant : Comparer les 4 algorithmes",
+    "# Indice : Meme env, 50 episodes, tableau + boxplot",
+    "# Etape 1 : Configurer les 4 agents",
+    "# Etape 2 : Entrainer chacun 50 episodes",
+    "# Etape 3 : Collecter les metriques",
+    "# Etape 4 : Afficher le tableau comparatif et le boxplot",
+    "",
+    "result = None  # TODO etudiant : remplacer par le benchmark",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Batch 6 of QC Python exercise rollout for convention #2161. 8 notebooks, 24 exercises total. 1021 insertions pure.

### Notebooks modified (8)

| Notebook | Exercises | Topics |
|----------|-----------|--------|
| QC-Py-26 LLM Trading | 3 | API cost estimation, Prompt engineering comparison, Multi-LLM voting system |
| QC-Py-27 Production | 3 | Pre-deployment pipeline, Live config validator, Multi-strategy allocator |
| QC-Py-28 Regime Detection | 3 | Multi-indicator regime scorer, Adaptive rotation strategy, Performance attribution by regime |
| QC-Py-30 LSTM Training | 3 | Feature set comparison, Prediction error analysis, Backtest with transaction costs |
| QC-Py-31 Transformer | 3 | Sinusoidal positional encoding, Sequence length impact, Attention weight visualization |
| QC-Py-32 DQN | 3 | Prioritized replay buffer, Epsilon scheduling (linear/exp/cosine), Double DQN |
| QC-Py-33 PPO | 3 | DQN vs PPO benchmark, GAE advantage estimation, Clip parameter tuning |
| QC-Py-34 SAC/A2C | 3 | Environment with transaction costs, A2C entropy bonus tuning, Quadri-algorithm benchmark |

### Validation

- C.1 check: PASS (no `raise NotImplementedError`, `assert False`, literal `1/0`)
- Note: grep for `1/0` finds `0.1/0.2/0.3` in NB-33 Ex3 markdown (decimal notation, not division by zero) — false positive
- All stubs: `result = None  # TODO etudiant` + `print("Exercice a completer")`
- Exercise markdown cells: objective + rules + `# Indice` / `# Etape N` hints
- Exercises spread throughout notebooks (after relevant section content)
- All plain Python executable style (PyTorch/ML focused)
- **1021 insertions, 1 deletion** (deletion = formatting artifact)

### Convention #2161 compliance

Each notebook now has exactly 3 exercise stubs, meeting the >= 3 target.