### PR TITLE
enrich(GenAI/ML): add exercises to 10 notebooks for >=3 target (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/3_Structured_Outputs.ipynb
@@ -964,6 +964,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "abbf01ee",
+   "source": "### Exercice 2 : Extracteur de films\n\nL'objectif est de definir un modele Pydantic pour extraire des informations structurees a partir d'une critique de film.\n\n**Objectifs pedagogiques** :\n- Creer un modele Pydantic avec des objets imbriques et des contraintes\n- Utiliser `Field(description=...)` pour guider le modele\n- Valider les contraintes (`conint`, `enum`) sur les donnees extraites\n\n**Etapes** :\n1. Definir un modele `Acteur` avec nom et personnage joue\n2. Definir un modele `CritiqueFilm` avec titre, annee, realisateur, acteurs (liste), note sur 10 et resume\n3. Utiliser `extract_structured()` pour extraire les informations d'un texte de critique\n4. Afficher les resultats valides\n\n**Indices** :\n- Utilisez `conint(ge=0, le=10)` pour contraindre la note entre 0 et 10\n- Utilisez `List[Acteur]` pour les acteurs\n- Le texte de critique est fourni dans la variable `texte_critique`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b809b5a4",
+   "source": "# Exercice 2 : Extracteur de films\n# TODO etudiant : definir les modeles Pydantic et extraire les donnees\n\nfrom pydantic import conint\n\ntexte_critique = \"\"\"\nInception (2010), realise par Christopher Nolan, est un thriller de science-fiction\nqui explore les reves lucides a travers plusieurs niveaux de profondeur.\nLeonardo DiCaprio y joue Dom Cobb, un voleur specialise dans l'extraction de secrets\ndans le subconscient. Il est accompagne de Joseph Gordon-Levitt dans le role d'Arthur,\nson associe, et d'Elliot Page dans le role d'Ariadne, l'architecte des reves.\nUn film brillant, note 9/10 pour son originalite et sa mise en scene vertigineuse.\n\"\"\"\n\n# Etape 1 : Definir le modele Acteur\n# class Acteur(BaseModel):\n#     nom: str = Field(description=\"Nom de l'acteur\")\n#     personnage: str = Field(description=\"Nom du personnage joue\")\n\n# Etape 2 : Definir le modele CritiqueFilm\n# Indice : utilisez conint(ge=0, le=10) pour la note\n# class CritiqueFilm(BaseModel):\n#     titre: str = Field(description=\"Titre du film\")\n#     annee: int = Field(description=\"Annee de sortie\")\n#     realisateur: str = Field(description=\"Nom du realisateur\")\n#     acteurs: List[Acteur] = Field(description=\"Liste des acteurs mentionnes\")\n#     note: conint(ge=0, le=10) = Field(description=\"Note sur 10\")\n#     resume: str = Field(description=\"Resume en une phrase\")\n\n# Etape 3 : Extraire avec extract_structured\n# Indice : extract_structured(f\"Extrais les informations de cette critique:\\n\\n{texte_critique}\", CritiqueFilm)\n\n# Etape 4 : Afficher les resultats\n# Indice : affichez le titre, l'annee, le realisateur, la note et les acteurs\n\nresult = None  # TODO etudiant : remplacer par le resultat de l'extraction\nprint(f\"Critique extraite: {result}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "27da427a",
    "metadata": {
     "papermill": {
@@ -1506,6 +1520,20 @@
     "\n",
     "> **Note production** : En contexte réel, ajouter une validation humaine pour les feedbacks haute priorité avant création automatique de tickets."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af49e722",
+   "source": "### Exercice 3 : Analyseur multi-documents\n\nL'objectif est de creer une fonction qui analyse **plusieurs feedbacks clients en une seule boucle** et synthetise les resultats dans une structure Pydantic.\n\n**Objectifs pedagogiques** :\n- Reutiliser la fonction `extract_structured()` avec un nouveau modele Pydantic\n- Agreger des resultats structures dans un objet synthese\n- Produire des statistiques a partir de donnees extraites\n\n**Etapes** :\n1. Definir un modele `FeedbackSynthese` avec les champs pertinents (distribution des sentiments, nombre de bugs total, actions prioritaires)\n2. Creer une liste de 3-4 feedbacks variés (positif, negatif, mixte)\n3. Analyser chaque feedback individuellement avec `extract_structured`\n4. Agreger les resultats dans une instance de `FeedbackSynthese`\n\n**Indices** :\n- Inspirez-vous du modele `FeedbackAnalyse` defini precedemment\n- Utilisez `collections.Counter` pour compter les sentiments\n- Pensez a gerer le cas ou `extract_structured` retourne `None`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "221a4518",
+   "source": "# Exercice 3 : Analyseur multi-documents\n# TODO etudiant : analyser plusieurs feedbacks et produire une synthese structuree\n\n# Etape 1 : Definir le modele Pydantic pour la synthese\n# class FeedbackSynthese(BaseModel):\n#     total_feedbacks: int = Field(description=\"Nombre total de feedbacks analyses\")\n#     sentiments: dict = Field(description=\"Distribution des sentiments, ex: {'positif': 2, 'negatif': 1}\")\n#     total_bugs: int = Field(description=\"Nombre total de bugs detectes\")\n#     actions_prioritaires: List[str] = Field(description=\"Actions les plus critiques concatenees\")\n\n# Etape 2 : Liste de feedbacks a analyser\nfeedbacks = [\n    \"Super application, mais l'export PDF plante systematiquement sur mon telephone.\",\n    \"J'adore la nouvelle interface, tres fluide et moderne !\",\n    \"Le service client est injoignable depuis 3 jours, c'est inacceptable.\",\n]\n\n# Etape 3 : Analyser chaque feedback avec extract_structured\n# Indice : reutilisez le modele FeedbackAnalyse defini plus haut dans le notebook\n# analyses = []\n# for fb in feedbacks:\n#     resultat = extract_structured(f\"Analyse ce feedback:\\n\\n{fb}\", FeedbackAnalyse)\n#     if resultat:\n#         analyses.append(resultat)\n\n# Etape 4 : Agreger les resultats dans FeedbackSynthese\n# Indice : utilisez Counter pour compter les sentiments\n# synthese = FeedbackSynthese(...)\n\nresult = None  # TODO etudiant : remplacer par la synthese finale\nprint(f\"Synthese: {result}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -1216,6 +1216,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c67e6ad5",
+   "source": "### Exercice 2 : Valider les arguments d'un tool avant execution\n\nLa fonction `run_safe_conversation` verifie que le JSON est valide, mais ne valide pas que les arguments correspondent au schema attendu. Implementez une **fonction de validation** qui verifie les types et les valeurs autorisees avant d'executer une fonction.\n\n**Objectif** : Creer `validate_tool_args(tool_schema, function_args)` qui retourne `(True, args)` ou `(False, error_message)`.\n\n**Indices** :\n- Analysez la structure de `tool_schema[\"function\"][\"parameters\"]` pour obtenir les types attendus\n- Verifiez que les champs `\"required\"` sont presents dans `function_args`\n- Pour les champs `\"enum\"`, verifiez que la valeur est dans la liste autorisee\n- Testez avec des arguments valides ET invalides sur le tool `get_weather`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "21ac6cf4",
+   "source": "# Exercice 2 : Validation des arguments d'un tool\n# TODO etudiant : implementez validate_tool_args(tool_schema, function_args)\n\n# Etape 1 : Definir la signature de la fonction\n# def validate_tool_args(tool_schema: dict, function_args: dict) -> tuple:\n#     \"\"\"\n#     Valide les arguments par rapport au schema JSON du tool.\n#     Retourne (True, function_args) si valide, (False, error_message) sinon.\n#     \"\"\"\n\n# Etape 2 : Verifier les champs requis (required)\n# required_fields = tool_schema[\"function\"][\"parameters\"].get(\"required\", [])\n# ...\n\n# Etape 3 : Verifier les types (string -> str, integer -> int, etc.)\n# properties = tool_schema[\"function\"][\"parameters\"][\"properties\"]\n# ...\n\n# Etape 4 : Verifier les enums si presents\n# if \"enum\" in properties[field]:\n#     ...\n\n# Etape 5 : Tester avec des cas valides et invalides\n# tool_schema = tools[0]  # get_weather\n# print(validate_tool_args(tool_schema, {\"location\": \"Paris\"}))              # True\n# print(validate_tool_args(tool_schema, {\"unit\": \"celsius\"}))                 # False (missing location)\n# print(validate_tool_args(tool_schema, {\"location\": \"Paris\", \"unit\": \"kelvin\"}))  # False (bad enum)\n\n# Indice : python type() retourne <class 'str'>, <class 'int'>, etc.\n# Indice : le mapping JSON Schema -> Python est {\"string\": str, \"integer\": int, \"number\": float, \"boolean\": bool}\n\nresult = None  # TODO etudiant : remplacer par les appels de test\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "1f4dd289",
    "metadata": {
     "papermill": {
@@ -1424,6 +1438,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ca418704",
+   "source": "### Exercice 3 : Ordonnancer et paginer les resultats d'une base de donnees\n\nLa fonction `search_courses` filtre par categorie, duree et prix, mais ne permet ni le tri ni la pagination. Etendez cette fonction pour supporter le **tri** (par prix, duree) et la **pagination** (limiter le nombre de resultats + offset).\n\n**Objectif** : Modifier le tool JSON Schema et la fonction `search_courses` pour ajouter les parametres `sort_by`, `sort_order` et `limit`.\n\n**Indices** :\n- Ajoutez `sort_by` (enum: \"price\", \"duration_hours\", \"title\") et `sort_order` (enum: \"asc\", \"desc\") au schema\n- Utilisez `sorted(results, key=lambda c: c[sort_by])` pour le tri\n- Le parametre `limit` (integer) controle le nombre max de resultats retournes\n- Testez avec : \"Quels sont les 2 cours les moins chers ?\" et \"Trie les cours ML par duree decroissante\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "59adbf07",
+   "source": "# Exercice 3 : Recherche de cours avec tri et pagination\n# TODO etudiant : etendez search_courses avec sort_by, sort_order et limit\n\n# Etape 1 : Copier et modifier la fonction search_courses\n# def search_courses_v2(category=None, min_duration=None, max_price=None,\n#                        level=None, sort_by=None, sort_order=\"asc\", limit=None):\n#     ...\n#     # Appliquer les filtres existants\n#     # Etape 2 : Appliquer le tri si sort_by est fourni\n#     # Etape 3 : Appliquer la limit si fournie\n#     return json.dumps({\"count\": len(results), \"courses\": results}, ensure_ascii=False)\n\n# Etape 4 : Creer le nouveau tool JSON Schema avec les parametres supplementaires\n# search_tool_v2 = [{...}]\n\n# Etape 5 : Tester avec la boucle agentique\n# print(run_safe_conversation(\n#     \"Quels sont les 2 cours les moins chers ?\",\n#     search_tool_v2,\n#     {\"search_courses_v2\": search_courses_v2}\n# ))\n\n# Indice : sorted(results, key=lambda c: c.get(sort_by, 0), reverse=(sort_order == \"desc\"))\n# Indice : results[:limit] pour tronquer la liste\n\nresult = None  # TODO etudiant : remplacer par l'appel de test\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "067f0c4d",
    "metadata": {
     "papermill": {
@@ -1566,6 +1594,20 @@
     "\n",
     "Ce pattern de recherche s'applique à de nombreux cas d'usage réels (e-commerce, CRM, documentation, etc.)."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca6bcaef",
+   "source": "### Exercice 1 : Fonction de conversion de devises\n\nL'assistant `get_weather` ne retourne que des donnees meteo. Ajoutez une **fonction de conversion de devises** pour que le modele puisse repondre a des questions combinees comme \"Quelle est la meteo a New York et convertis 100 EUR en USD ?\".\n\n**Objectif** : Definir un tool JSON Schema et sa fonction d'execution, puis l'integrer dans la boucle agentique.\n\n**Indices** :\n- Reutilisez le pattern de `get_weather` pour le JSON Schema du tool\n- Simulez les taux de change dans un dictionnaire (pas besoin d'API reelle)\n- Ajoutez le nouveau tool a la liste `extended_tools` et la fonction a `all_functions`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6a100928",
+   "source": "# Exercice 1 : Fonction de conversion de devises\n# TODO etudiant : implementez une fonction convert_currency(amount, from_currency, to_currency)\n\n# Etape 1 : Definir le dictionnaire des taux de change simulés\n# EXCHANGE_RATES = {\"EUR\": {\"USD\": 1.08, \"GBP\": 0.86}, ...}\n\n# Etape 2 : Implementer la fonction convert_currency\n# def convert_currency(amount: float, from_currency: str, to_currency: str) -> str:\n#     ...\n\n# Etape 3 : Definir le tool JSON Schema pour convert_currency\n# currency_tool = [{...}]\n\n# Etape 4 : Ajouter a extended_tools et all_functions, puis tester avec :\n# run_safe_conversation(\n#     \"Quelle est la meteo a New York et convertis 100 EUR en USD ?\",\n#     extended_tools + [currency_tool],\n#     {**all_functions, \"convert_currency\": convert_currency}\n# )\n\n# Indice : la fonction doit retourner un JSON string comme get_weather\n# Indice : pensez a gerer le cas ou la devise n'existe pas dans le dictionnaire\n\nresult = None  # TODO etudiant : remplacer par l'appel a run_safe_conversation\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -409,7 +409,7 @@
    "id": "0626b75f",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:53:50.044075",
      "exception": false,
      "start_time": "2026-05-29T22:53:50.044075",
@@ -461,7 +461,7 @@
    "id": "df6b8526",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:53:50.056280",
      "exception": false,
      "start_time": "2026-05-29T22:53:50.056280",
@@ -531,7 +531,7 @@
    "id": "7328629c",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:53:50.071063",
      "exception": false,
      "start_time": "2026-05-29T22:53:50.071063",
@@ -1540,7 +1540,7 @@
    "id": "a22219ca",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:54:13.065525",
      "exception": false,
      "start_time": "2026-05-29T22:54:13.065525",
@@ -1803,6 +1803,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f4bab2e8",
+   "source": "### Exercice 2 : Evaluer la qualite du retrieval avec des metriques\n\nLa recherche k-NN retourne des chunks avec un score de similarite cosinus, mais comment savoir si les chunks retrieves sont **reellement pertinents** ? Implementez une fonction `evaluate_retrieval(questions, vector_store, k)` qui mesure la qualite du retrieval sur un jeu de questions de test.\n\n**Objectif** : Creer une fonction qui pose plusieurs questions, collecte les scores des chunks retrieves, et calcule les metriques de qualite (score moyen, pire score, taux de chunks pertinents).\n\n**Indices** :\n- Definissez une liste de 5 questions avec leurs reponses attendues (ground truth)\n- Pour chaque question, appelez `vector_store.search(query_embedding, k=3)`\n- Calculez le score moyen des meilleurs chunks et le taux de questions avec au moins un chunk pertinent (score > 0.5)\n- Affichez un tableau recapitulatif avec `pd.DataFrame`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "6457504d",
+   "source": "# Exercice 2 : Evaluation du retrieval\n# TODO etudiant : implementez evaluate_retrieval(test_questions, vector_store, k)\n\n# Etape 1 : Definir le jeu de questions de test\n# test_questions = [\n#     {\"question\": \"What did Lincoln say about slavery?\", \"expected_topic\": \"slavery\"},\n#     {\"question\": \"What was Douglas's position on popular sovereignty?\", \"expected_topic\": \"sovereignty\"},\n#     {\"question\": \"Where was the debate held?\", \"expected_topic\": \"location\"},\n#     {\"question\": \"What is quantum physics?\", \"expected_topic\": \"irrelevant\"},  # hors sujet\n#     {\"question\": \"How many people attended the debate?\", \"expected_topic\": \"attendance\"},\n# ]\n\n# Etape 2 : Implementer la fonction d'evaluation\n# def evaluate_retrieval(test_questions: list, vector_store: VectorStore, k: int = 3) -> pd.DataFrame:\n#     results = []\n#     for q in test_questions:\n#         query_embedding = create_embedding(q[\"question\"])\n#         chunks = vector_store.search(query_embedding, k=k)\n#         scores = [c[\"score\"] for c in chunks]\n#         results.append({\n#             \"question\": q[\"question\"][:50],\n#             \"best_score\": max(scores),\n#             \"avg_score\": sum(scores) / len(scores),\n#             \"has_relevant\": max(scores) > 0.5,\n#         })\n#     return pd.DataFrame(results)\n\n# Etape 3 : Executer et analyser les resultats\n# df_eval = evaluate_retrieval(test_questions, vector_store)\n# print(df_eval)\n# print(f\"\\nTaux de pertinence: {df_eval['has_relevant'].mean():.0%}\")\n\n# Indice : une question \"hors sujet\" (quantum physics) devrait avoir des scores faibles (< 0.4)\n# Indice : le taux de pertinence global mesure la robustesse du retrieval\n\nresult = None  # TODO etudiant : remplacer par l'evaluation\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "65c32843",
    "metadata": {
     "papermill": {
@@ -1988,7 +2002,7 @@
    "id": "3c5397c0",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:54:23.970741",
      "exception": false,
      "start_time": "2026-05-29T22:54:23.970741",
@@ -2533,7 +2547,7 @@
    "id": "c44a2e2f",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T22:54:54.222914",
      "exception": false,
      "start_time": "2026-05-29T22:54:54.222914",
@@ -2720,6 +2734,34 @@
     "\n",
     "**Prochaine étape** : La conclusion résume toutes les fonctions créées et les bonnes pratiques pour la production."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2aaec74",
+   "source": "### Exercice 3 : Reformulation automatique de requete pour ameliorer le retrieval\n\nLes questions utilisateur sont souvent imprecises ou mal formulees pour la recherche vectorielle (\"Et l'esclavage dans tout ca ?\"). Implementez une fonction `reformulate_query(question, conversation_history)` qui utilise le LLM pour **reformuler** la question en une requete autonome et precise avant le retrieval.\n\n**Objectif** : Creer une fonction qui prend une question potentiellement ambigu et retourne une version reformulee optimale pour la recherche semantique.\n\n**Indices** :\n- Utilisez `client.chat.completions.create()` avec un prompt systeme qui explique la tache de reformulation\n- Si `conversation_history` est fournie, incluez-la dans le contexte pour resoudre les pronoms (\"il\", \"cela\")\n- La reformulation doit etre **autonome** (comprehensible sans contexte precedent) et **specifique** (contient les mots-cles importants)\n- Testez avec \"Et l'esclavage dans tout ca ?\" (contexte : debat Lincoln-Douglas) et \"Combien ?\" (contexte : \"Combien de personnes ont assiste au debat ?\")",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "229f6ac1",
+   "source": "# Exercice 3 : Reformulation de requete\n# TODO etudiant : implementez reformulate_query(question, conversation_history)\n\n# Etape 1 : Definir le prompt systeme pour la reformulation\n# REFORMULATE_SYSTEM = (\n#     \"Tu es un assistant qui reformule les questions pour la recherche documentaire. \"\n#     \"Transforme la question en une requete autonome, precise et riche en mots-cles. \"\n#     \"Resous les pronoms et references ambigues en utilisant le contexte de conversation.\"\n# )\n\n# Etape 2 : Implementer la fonction\n# def reformulate_query(question: str, conversation_history: list = None) -> str:\n#     messages = [{\"role\": \"system\", \"content\": REFORMULATE_SYSTEM}]\n#     if conversation_history:\n#         messages.extend(conversation_history)\n#     messages.append({\"role\": \"user\", \"content\": f\"Reformule: {question}\"})\n#     response = client.chat.completions.create(model=DEFAULT_MODEL, messages=messages)\n#     return response.choices[0].message.content\n\n# Etape 3 : Tester avec des questions ambigues\n# print(reformulate_query(\"Et l'esclavage dans tout ca ?\"))\n# print(reformulate_query(\"Combien ?\",\n#     [{\"role\": \"user\", \"content\": \"Combien de personnes ont assiste au debat Lincoln-Douglas ?\"}]))\n\n# Etape 4 (bonus) : Integrer dans le pipeline RAG\n# def rag_with_reformulation(question, vector_store, conversation_history=None):\n#     reformulated = reformulate_query(question, conversation_history)\n#     print(f\"Requete reformulee: {reformulated}\")\n#     return rag_query(reformulated, vector_store)\n\n# Indice : la reformulation doit contenir les entites nommees (Lincoln, Douglas, esclavage)\n# Indice : \"Combien ?\" -> \"Combien de personnes ont assiste au premier debat Lincoln-Douglas a Ottawa en 1858 ?\"\n\nresult = None  # TODO etudiant : remplacer par les tests\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ec8458b",
+   "source": "### Exercice 1 : Implementer une strategie de chunking hybride\n\nLes trois strategies de chunking (fixe, semantique, recursif) ont chacune des faiblesses. Implementez une **strategie hybride** qui combine le chunking recursif avec un regroupement semantique : les chunks recursifs trop courts sont fusionnes avec le suivant.\n\n**Objectif** : Creer `chunk_hybrid(text, max_size, min_size)` qui garantit que chaque chunk a entre `min_size` et `max_size` caracteres.\n\n**Indices** :\n- Commencez par appeler `chunk_recursive(text, max_size)` pour obtenir les chunks initiaux\n- Parcourez les chunks et fusionnez ceux dont `len(chunk) < min_size` avec le chunk suivant\n- Verifiez que la fusion ne depasse pas `max_size` ; si oui, gardez le chunk court\n- Testez sur `debate_text` avec `max_size=500` et `min_size=100`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "71f0ff76",
+   "source": "# Exercice 1 : Chunking hybride\n# TODO etudiant : implementez chunk_hybrid(text, max_size, min_size)\n\n# Etape 1 : Appeler chunk_recursive pour obtenir les chunks initiaux\n# recursive_chunks = chunk_recursive(text, max_size)\n\n# Etape 2 : Parcourir les chunks et fusionner les trop courts\n# def chunk_hybrid(text: str, max_size: int = 500, min_size: int = 100) -> List[str]:\n#     ...\n#     # merged = []\n#     # for chunk in recursive_chunks:\n#     #     if merged and len(merged[-1]) + len(chunk) <= max_size and len(merged[-1]) < min_size:\n#     #         merged[-1] += \"\\n\" + chunk\n#     #     else:\n#     #         merged.append(chunk)\n#     ...\n\n# Etape 3 : Tester sur debate_text et comparer avec les autres strategies\n# chunks_hybrid = chunk_hybrid(debate_text, max_size=500, min_size=100)\n# print(f\"Chunking hybride: {len(chunks_hybrid)} chunks\")\n# print(f\"Taille min: {min(len(c) for c in chunks_hybrid)} chars\")\n# print(f\"Taille max: {max(len(c) for c in chunks_hybrid)} chars\")\n\n# Indice : len(chunk) < min_size est la condition pour fusionner\n# Indice : apres fusion, le chunk fusionne ne doit pas depasser max_size\n\nresult = None  # TODO etudiant : remplacer par les resultats du test\nprint(\"Exercice a completer\")\n",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/7_Code_Interpreter.ipynb
@@ -1623,6 +1623,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ccf8d929",
+   "source": "### Exercice 3 : Pipeline de tests d'hypotheses\n\nVous disposez d'un jeu de donnees contenant les ventes de 3 produits (A, B, C) dans 4 regions. L'objectif est de construire un pipeline statistique complet qui teste si les produits ont des performances significativement differentes entre les regions.\n\n**Objectifs** :\n- Verifier la normalite des distributions par sous-groupe\n- Choisir le test adequat (parametrique ou non-parametrique) en fonction des resultats\n- Interpreter les p-values et conclure sur les differences observees\n\n**Indices** :\n- Utilisez `scipy.stats.shapiro` pour la normalite (attention : necessite au moins 3 valeurs)\n- Si toutes les distributions sont normales, utilisez ANOVA ; sinon, Kruskal-Wallis\n- Un seuil de 5% (p < 0.05) est classiquement utilise pour rejeter l'hypothese nulle",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "f9f4f6dd",
+   "source": "# Exercice 3 : Pipeline de tests d'hypotheses\n# TODO etudiant : construire un pipeline qui teste les differences de ventes entre regions\n# Etape 1 : Recharger le dataset de ventes (recreer le CSV si necessaire avec les memes parametres)\n# Etape 2 : Pour chaque combinaison (produit, region), tester la normalite avec scipy.stats.shapiro\n# Etape 3 : En fonction des resultats de normalite, choisir et appliquer le test adapte\n# Etape 4 : Afficher un recapitulatif clair des p-values et conclusions par produit\n# Indice : df.groupby(['produit', 'region']) pour acceder aux sous-groupes\n# Indice : scipy.stats.f_oneway pour ANOVA, scipy.stats.kruskal pour Kruskal-Wallis\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "559a0781",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/8_Reasoning_Models.ipynb
@@ -529,6 +529,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e779e366",
+   "source": "### Exercice 1 : Comparer chat et reasoning sur un probleme multi-etapes\n\nLa difference entre le mode chat et le mode reasoning est subtile sur les problemes simples, mais devient significative sur les taches necessitant plusieurs etapes de raisonnement. Vous allez construire un probleme specifiquement concu pour mettre en evidence cette difference.\n\n**Objectifs :**\n- Concevoir un probleme mathematique a plusieurs etapes\n- Appeler l'API en mode chat ET en mode reasoning\n- Comparer la precision et le temps de reponse\n\n**Indices :**\n- Un bon probleme test combine des contraintes : calcul + logique + verifications intermediaires\n- Utilisez `extra_body={\"reasoning_effort\": \"medium\"}` pour le mode reasoning\n- Affichez les deux reponses cote a cote avec les temps pour faciliter la comparaison",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ab1e9b2b",
+   "source": "# Exercice 1 : Comparer chat vs reasoning sur un probleme multi-etapes\n# TODO etudiant : Creez votre propre probleme et comparez les deux modes\n\ndef compare_chat_vs_reasoning(problem: str) -> dict:\n    \"\"\"\n    Compare le mode chat et le mode reasoning sur un probleme donne.\n    \n    # Etape 1 : Appeler l'API en mode chat (sans reasoning_effort)\n    # Etape 2 : Appeler l'API en mode reasoning (avec extra_body={\"reasoning_effort\": \"medium\"})\n    # Etape 3 : Mesurer le temps de chaque appel\n    # Etape 4 : Retourner un dict avec les resultats et temps\n    \n    # Indice : Reutilisez le pattern de la section 1 avec time.time() avant/apres\n    # Indice : Le dict de retour peut contenir {\"chat_content\", \"reasoning_content\", \"chat_time\", \"reasoning_time\"}\n    \"\"\"\n    result = {\n        \"chat_content\": None,  # TODO etudiant\n        \"reasoning_content\": None,  # TODO etudiant\n        \"chat_time\": 0,  # TODO etudiant\n        \"reasoning_time\": 0,  # TODO etudiant\n    }\n    return result\n\n# Probleme a concevoir : un enigme combinant calcul et logique\nmon_probleme = \"\"  # TODO etudiant : ecrire un probleme multi-etapes\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "d980bed9",
    "metadata": {
     "papermill": {
@@ -1268,6 +1282,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8393d566",
+   "source": "### Exercice 2 : Generer un algorithme de tri avec analysis de complexite\n\nLes modeles de raisonnement sont particulierement utiles pour generer du code algorithmique complexe. Dans cet exercice, vous allez demander au modele d'implementer un algorithme de tri en analysant sa complexite.\n\n**Objectifs :**\n- Construire un prompt demandant l'implementation d'un algorithme de tri (merge sort ou quick sort)\n- Demander une analyse formelle de la complexite (meilleur cas, pire cas, cas moyen)\n- Utiliser le message developer pour activer le formatage markdown\n\n**Indices :**\n- Precisez dans le prompt que vous attendez les complexites en notation Grand O\n- Demandez des tests unitaires inclus dans le code\n- Utilisez `reasoning_effort=\"medium\"` pour un bon equilibre temps/qualite",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "01534371",
+   "source": "# Exercice 2 : Generer un algorithme de tri avec analyse de complexite\n# TODO etudiant : Construisez le prompt et appelez l'API\n\ndef generate_sort_algorithm() -> str:\n    \"\"\"\n    Demande au modele raisonnant d'implementer un algorithme de tri\n    avec une analyse complete de la complexite.\n    \n    # Etape 1 : Definir le prompt demandant un merge sort ou quick sort\n    # Etape 2 : Inclure la demande d'analyse O(n log n), O(n^2), etc.\n    # Etape 3 : Demander des tests unitaires avec assert\n    # Etape 4 : Appeler l'API avec reasoning_effort=\"medium\" et le message developer\n    \n    # Indice : Le prompt doit contenir \"Inclus des tests unitaires avec assert\"\n    # Indice : Specifiez \"Analyse la complexite temporelle ET spatiale\"\n    \"\"\"\n    prompt = \"\"  # TODO etudiant : ecrire le prompt\n    response_content = None  # TODO etudiant : appeler l'API et extraire le contenu\n    return response_content or \"\"\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "1c8cea6f",
    "metadata": {
     "papermill": {
@@ -1882,6 +1910,20 @@
     "print(\"  - Complexité O(2^n) due aux appels récursifs redondants\")\n",
     "print(\"  - Solution: mémoïsation ou approche itérative (O(n))\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbad163c",
+   "source": "### Exercice 3 : Analyser un probleme logique avec reasoning_effort\n\nLe choix du niveau de `reasoning_effort` a un impact direct sur la qualite de la reponse et le temps de traitement. Dans cet exercice, vous allez comparer les trois niveaux sur un probleme de logique qui necessite plusieurs etapes de deduction.\n\n**Objectifs :**\n- Appeler l'API avec les trois niveaux de `reasoning_effort`\n- Mesurer et comparer les temps de reponse\n- Evaluer la qualite des reponses obtenues\n\n**Indices :**\n- Reutilisez le pattern de la section 2 avec la boucle `for effort in [\"low\", \"medium\", \"high\"]`\n- Utilisez `time.time()` pour mesurer la duree de chaque appel\n- Testez avec un probleme du type : \"5 personnes habitent 5 maisons de couleurs differentes...\"",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "716305f0",
+   "source": "# Exercice 3 : Comparer les niveaux de reasoning_effort sur un probleme logique\n# TODO etudiant : Complétez la fonction pour tester un probleme de logique avec 3 niveaux d'effort\n\ndef compare_reasoning_efforts(problem_text: str) -> list:\n    \"\"\"\n    Teste un probleme avec low, medium et high reasoning_effort.\n    \n    # Etape 1 : Definir la liste des niveaux a tester\n    # Etape 2 : Pour chaque niveau, appeler l'API avec extra_body={\"reasoning_effort\": effort}\n    # Etape 3 : Mesurer le temps de chaque appel avec time.time()\n    # Etape 4 : Stocker les resultats (niveau, duree, contenu) dans une liste\n    \n    # Indice : Utilisez un message developer avec \"Formatting re-enabled\"\n    # Indice : Ajoutez try/except pour gerer le cas ou reasoning_effort n'est pas supporte\n    \"\"\"\n    results = []  # TODO etudiant : remplacer par l'implementation\n    return results\n\n# Test avec un probleme de logique type \"Einstein riddle\"\nprobleme_einstein = \"\"\"\nDans une rue, 5 maisons sont alignees. Chaque maison a une couleur differente.\nL'Anglais vit dans la maison rouge.\nLe Suedois a un chien.\nLe Danois boit du the.\nLa maison verte est a gauche de la maison blanche.\nLe proprietaire de la maison verte boit du cafe.\nQui possede le poisson?\nReponds de maniere concise.\n\"\"\"\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/9_Production_Patterns.ipynb
@@ -2149,6 +2149,30 @@
     "\n",
     "**Bonus :** Ajouter des statistiques (nombre de requêtes dans les dernières 24h, temps moyen d'attente)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c516c68b",
+   "source": "# Exercice 1 : Chatbot avec gestion du contexte et logging\n# TODO etudiant : Implementez un chatbot qui maintient le contexte avec historique\n\nclass SessionChatbot:\n    \"\"\"\n    Chatbot avec persistance du contexte entre les echanges.\n    \n    # Etape 1 : Initialiser l'historique des messages et le compteur de tokens\n    # Etape 2 : Implementer chat() pour ajouter un message utilisateur, appeler l'API, stocker la reponse\n    # Etape 3 : Implementer summary() pour demander un resume de la conversation\n    # Etape 4 : Implementer get_token_usage() pour retourner le total de tokens utilises\n    \n    # Indice : L'historique est une liste de dicts {\"role\": ..., \"content\": ...}\n    # Indice : Pour summary(), ajoutez un message demandant le resume au contexte existant\n    # Indice : Utilisez safe_completion() defini plus haut dans le notebook pour le retry automatique\n    \"\"\"\n    def __init__(self, system_prompt: str = \"Tu es un assistant utile.\"):\n        self.messages = [{\"role\": \"system\", \"content\": system_prompt}]\n        self.total_tokens = 0  # TODO etudiant : accumuler les tokens\n    \n    def chat(self, user_message: str) -> str:\n        pass  # TODO etudiant : implementer\n    \n    def summary(self) -> str:\n        result = None  # TODO etudiant : generer un resume\n        return result or \"\"\n    \n    def get_token_usage(self) -> int:\n        return self.total_tokens  # TODO etudiant : retourner le total\n\n# Test\nbot = SessionChatbot(\"Tu es un assistant de support client expert.\")\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "70b4e61b",
+   "source": "# Exercice 2 : Systeme d'analyse de documents avec streaming\n# TODO etudiant : Implementez un systeme qui analyse un document en streaming\n\ndef analyze_document_stream(document: str, question: str) -> str:\n    \"\"\"\n    Analyse un document en reponse streamée.\n    \n    # Etape 1 : Construire le prompt avec le document et la question\n    # Etape 2 : Appeler l'API avec stream=True\n    # Etape 3 : Concatener les chunks au fur et a mesure\n    # Etape 4 : Calculer le cout approximatif (compter les caracteres comme proxy)\n    \n    # Indice : Utilisez le pattern de streaming vu en section 3\n    # Indice : Pour le cout, estimez 1 token ~= 4 caracteres, puis appliquez le tarif gpt-5-mini\n    \"\"\"\n    full_response = \"\"  # TODO etudiant : accumuler les chunks ici\n    estimated_cost = 0.0  # TODO etudiant : calculer le cout\n    \n    # TODO etudiant : implementer l'appel streaming\n    \n    return full_response or \"\"\n\n# Document test\nsample_document = \"\"\"\nL'intelligence artificielle generee (GenAI) transforme de nombreux secteurs economiques.\nEn sante, elle accelere le diagnostic medical et la decouverte de medicaments.\nEn finance, elle automatise l'analyse de risque et la detection de fraude.\nCependant, des defis ethiques et reglementaires persistent, notamment autour\nde la protection des donnees personnelles et des biais algorithmiques.\n\"\"\"\n\nresult = analyze_document_stream(sample_document, \"Quels sont les 3 secteurs mentionnes et leurs applications?\")\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "7cd3484d",
+   "source": "# Exercice 3 : Rate Limiter Multi-Tier\n# TODO etudiant : Ameliorez la classe RateLimiter pour supporter limites par minute ET par jour\n\nclass MultiTierRateLimiter:\n    \"\"\"\n    Rate limiter avec limites par minute ET par jour.\n    \n    # Etape 1 : Ajouter un parametre max_requests_per_day au constructeur\n    # Etape 2 : Maintenir un deuxieme deque pour les requetes quotidiennes\n    # Etape 3 : Verifier les deux limites avant d'autoriser une requete\n    # Etape 4 : Ajouter une methode get_stats() retournant (req_last_minute, req_last_day, avg_wait)\n    \n    # Indice : Utilisez le meme pattern de fenetre glissante mais avec 86400s au lieu de 60s\n    # Indice : get_stats() doit calculer le temps moyen d'attente sur les dernieres requetes\n    \"\"\"\n    def __init__(self, max_requests_per_minute: int = 60, max_requests_per_day: int = 10000):\n        self.max_rpm = max_requests_per_minute\n        self.max_rpd = max_requests_per_day  # TODO etudiant : utiliser cette valeur\n        self.requests_minute = deque()\n        self.requests_day = None  # TODO etudiant : initialiser un deque pour le suivi quotidien\n        self._wait_times = []  # Pour les statistiques\n    \n    def wait_if_needed(self):\n        pass  # TODO etudiant : implementer la logique de limitation\n    \n    def get_stats(self) -> dict:\n        result = None  # TODO etudiant : retourner les statistiques\n        return result or {\"requests_last_minute\": 0, \"requests_last_day\": 0, \"avg_wait_time\": 0}\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-5-TimeSeries.ipynb
@@ -397,6 +397,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "source": "// Exercice 5 : Detection d'anomalies par ecart a la moyenne mobile\n// TODO etudiant : Identifiez les jours anormaux dans la serie temporelle\n// Indice : moyenne mobile sur 7 jours, seuil = 2 ecarts-types\n// Etape 1 : charger les donnees dans un tableau trie par date\n// Etape 2 : pour chaque jour (a partir du 8e), calculer la moyenne et l'ecart-type des 7 jours precedents\n// Etape 3 : verifier si la valeur du jour s'ecarte de plus de 2 sigma de la moyenne mobile\n// Etape 4 : afficher les dates anormales avec leur valeur, la moyenne mobile et l'ecart\n\nvar anomalies = null; // TODO etudiant : remplacer par la liste des anomalies detectees\nConsole.WriteLine(\"Exercice a completer : detection d'anomalies par moyenne mobile\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 5 : Detection d'anomalies par ecart a la moyenne mobile\n\nCalculez une moyenne mobile sur 7 jours des ventes et identifiez les jours ou les ventes reelles s'ecartent de plus de 2 ecarts-types de la moyenne mobile. Affichez les dates et les valeurs de ces anomalies.\n\n**Indice** : Pour chaque jour, calculez la moyenne des 7 jours precedents (fenetre glissante). L'ecart-type de la fenetre mesure la variabilite locale. Un point est une anomalie si `|valeur - moyenne_mobile| > 2 * ecart_type`. Utilisez une boucle ou LINQ avec `Skip`/`Take` pour la fenetre glissante.",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -574,6 +586,18 @@
     "\n",
     "**Exemple** : Si les ventes moyennes sont de 150, un MAE de 15 (10%) est considéré comme bon."
    ]
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice 4 : Calcul du MAPE et analyse d'erreur par jour de la semaine\n// TODO etudiant : Calculez le MAPE global et par jour de la semaine\n// Indice : MAPE = moyenne(|reel - predit| / |reel|) * 100, utilisez GroupBy sur DayOfWeek\n// Etape 1 : extraire les valeurs reelles et predites depuis les predictions de la Partie 4\n// Etape 2 : calculer le MAPE global sur toutes les predictions\n// Etape 3 : joindre les predictions avec le jour de la semaine (DayOfWeek)\n// Etape 4 : grouper par jour et calculer le MAPE par jour, afficher les resultats\n\nvar mapeByDay = null; // TODO etudiant : remplacer par le MAPE par jour de la semaine\nConsole.WriteLine(\"Exercice a completer : calcul du MAPE et analyse d'erreur par jour\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 4 : Calcul du MAPE et analyse d'erreur par jour\n\nCalculez le MAPE (Mean Absolute Percentage Error) sur les predictions de la Partie 4, puis decomposez l'erreur par jour de la semaine pour identifier les jours ou le modele est le moins precis.\n\n**Indice** : Le MAPE = moyenne(|reel - predit| / |reel|) * 100. Utilisez LINQ pour joindre les predictions avec les donnees originales (incluant `DayOfWeek`), puis groupez par `DayOfWeek` et calculez le MAPE par jour. Visualisez avec un graphique en barres.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -770,6 +794,18 @@
     "\n",
     "> **Règle empirique** : Si > 95% des valeurs réelles sont dans l'intervalle, le modèle est bien calibré."
    ]
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice 3 : Impact du niveau de confiance sur les intervalles\n// TODO etudiant : Comparez les intervalles pour differents niveaux de confiance\n// Indice : bouclez sur les niveaux 0.80, 0.90, 0.95, 0.99 et creez un pipeline pour chacun\n// Etape 1 : definir la liste des niveaux de confiance a tester\n// Etape 2 : pour chaque niveau, creer un pipeline ForecastBySsa avec ce confidenceLevel\n// Etape 3 : entrainer le modele et extraire les intervalles (LowerBound, UpperBound)\n// Etape 4 : calculer le pourcentage de valeurs reelles dans l'intervalle et la largeur moyenne\n\nvar confidenceResults = null; // TODO etudiant : remplacer par les resultats de comparaison\nConsole.WriteLine(\"Exercice a completer : impact du niveau de confiance sur les intervalles\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 3 : Impact du niveau de confiance sur les intervalles\n\nReentrainez le modele SSA en modifiant le parametre `confidenceLevel` (0.80, 0.90, 0.95, 0.99) et comparez la largeur des intervalles et le pourcentage de valeurs reelles contenues dans chaque intervalle.\n\n**Indice** : Pour chaque niveau de confiance, creez un nouveau pipeline `ForecastBySsa` avec la valeur correspondante. Parcourez les predictions et comptez combien de valeurs reelles tombent dans l'intervalle [LowerBound, UpperBound]. Un niveau de confiance plus eleve devrait produire des intervalles plus larges mais un meilleur taux de couverture.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
@@ -316,6 +316,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "id": "e5da867d",
+   "source": "// Exercice 5 : Definition des classes d'entree/sortie pour un modele de prix immobilier\n// TODO etudiant : Concevez les classes pour integrer un modele ONNX de prediction immobiliere\n// Indice : utilisez [VectorType(N)] pour les tableaux, definissez les colonnes d'entree/sortie\n// Etape 1 : definir la classe RealEstateInput avec les 6 features (surface, chambres, etage, age, distance, quartier)\n// Etape 2 : definir la classe RealEstateOutput avec le prix predit et les bornes de confiance\n// Etape 3 : creer un exemple de donnees d'entree avec des valeurs realistes\n// Etape 4 : ecrire le pipeline ApplyOnnxModel commente avec les bons noms de colonnes\n\n// public class RealEstateInput { ... }  // TODO etudiant\n// public class RealEstateOutput { ... } // TODO etudiant\n\nConsole.WriteLine(\"Exercice a completer : classes d'entree/sortie ONNX pour prediction immobiliere\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82e67ad3",
+   "source": "### Exercice 5 : Definition des classes d'entree/sortie pour un modele de prix immobilier\n\nConcevez les classes d'entree et de sortie C# necessaires pour integrer un modele ONNX de prediction de prix immobilier. Le modele prend 6 features (surface, nombre de chambres, etage, age du batiment, distance au centre, quartier) et produit un prix estime avec un intervalle de confiance.\n\n**Indice** : Utilisez `[VectorType(N)]` pour les tableaux de features. La classe d'entree doit contenir soit 6 proprietes individuelles soit un tableau `[VectorType(6)]`. La classe de sortie doit contenir le prix predit et les bornes de l'intervalle. Inspirez-vous des classes `OnnxInputData` et `OnnxOutputData` definies ci-dessus.",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "id": "a7f82309",
    "metadata": {
@@ -514,6 +528,20 @@
     "\n",
     "Console.WriteLine(\"Modèle ML.NET entraîné avec succès !\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cb3bfa00",
+   "source": "// Exercice 4 : Variation du pipeline avec FastTree\n// TODO etudiant : Remplacez SdcaLogisticRegression par FastTree et comparez\n// Indice : utilisez mlContext.BinaryClassification.Trainers.FastTree()\n// Etape 1 : creer un nouveau pipeline identique mais avec FastTree au lieu de SdcaLogisticRegression\n// Etape 2 : entrainer le modele FastTree sur les memes donnees (trainingData)\n// Etape 3 : evaluer les metriques (Accuracy, AUC, F1Score) avec mlContext.BinaryClassification.Evaluate()\n// Etape 4 : afficher un tableau comparatif entre SDCA et FastTree\n\nvar trainerComparison = null; // TODO etudiant : remplacer par les metriques comparees\nConsole.WriteLine(\"Exercice a completer : comparaison SDCA vs FastTree pour export ONNX\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e91c94a2",
+   "source": "### Exercice 4 : Variation du pipeline avec FastTree\n\nModifiez le pipeline de l'Exemple 2 en remplacant `SdcaLogisticRegression` par un algorithme `FastTree` (arbres de decision boostes). Comparez les metriques de classification binaire (Accuracy, AUC) entre les deux algorithmes sur les memes donnees.\n\n**Indice** : Utilisez `mlContext.BinaryClassification.Trainers.FastTree(labelColumnName: \"Label\", featureColumnName: \"Features\")`. Chargez les memes donnees d'entrainement et evaluez avec `mlContext.BinaryClassification.Evaluate()`. Les arbres boostes capturent souvent des relations non-lineaires que la regression logistique ne peut pas modeliser.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -821,6 +849,20 @@
     "| ONNX Runtime (CPU) | 5 | 200 |\n",
     "| ONNX Runtime (GPU) | 1 | 1000 |"
    ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0e2fdba6",
+   "source": "// Exercice 3 : Comparaison des formats de modele (natif ML.NET vs ONNX)\n// TODO etudiant : Comparez taille et performance entre les deux formats\n// Indice : utilisez Stopwatch pour les temps, FileInfo pour la taille\n// Etape 1 : sauvegarder le modele au format natif avec mlContext.Model.Save()\n// Etape 2 : mesurer le temps de sauvegarde et la taille du fichier .zip\n// Etape 3 : charger le modele et mesurer le temps de prediction sur 100 echantillons\n// Etape 4 : afficher un tableau comparatif (taille, temps sauvegarde, temps prediction)\n\nvar formatComparison = null; // TODO etudiant : remplacer par les resultats de comparaison\nConsole.WriteLine(\"Exercice a completer : comparaison des formats de modele ML.NET vs ONNX\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e94e5034",
+   "source": "### Exercice 3 : Comparaison des formats de modele\n\nEn utilisant le modele ML.NET entraine dans l'Exemple 2, comparez la taille (en octets) et le temps de serialisation entre le format natif ML.NET (`.zip`) et le format ONNX. Mesurez egalement le temps de chargement et de prediction pour chaque format.\n\n**Indice** : Utilisez `mlContext.Model.Save()` pour le format natif et `System.Diagnostics.Stopwatch` pour mesurer les temps. Pour la taille, utilisez `new FileInfo(path).Length`. Un modele ONNX peut etre plus volumineux mais plus rapide en inference grace a ONNX Runtime.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -405,6 +405,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "source": "// Exercice 5 : Enrichissement du jeu de donnees de notes\n// TODO etudiant : Ajoutez de nouveaux utilisateurs et films avec des profils varies\n// Indice : creez des MovieRating supplementaires avec des patterns de preference distincts\n// Etape 1 : ajouter 2 nouveaux films (MovieId 4 et 5) avec des genres differents (ex: Comedie, Thriller)\n// Etape 2 : ajouter au moins 3 nouveaux utilisateurs (UserId 6, 7, 8) avec des profils varies\n// Etape 3 : creer les notes pour chaque nouvel utilisateur sur tous les films\n// Etape 4 : afficher la nouvelle matrice utilisateur-item enrichie\n\nvar enrichedMovieData = movieData; // TODO etudiant : enrichir avec les nouvelles donnees\nConsole.WriteLine(\"Exercice a completer : enrichissement du jeu de donnees de notes\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 5 : Enrichissement du jeu de donnees de notes\n\nLe jeu de donnees actuel contient seulement 5 utilisateurs et 3 films. Ajoutez au moins 3 nouveaux utilisateurs et 2 nouveaux films avec des profils de preferences varies (par exemple un amateur de comedie, un fan de thrillers). Creez les nouvelles donnees et affichez la matrice utilisateur-item enrichie.\n\n**Indice** : Definissez des profils clairs pour chaque nouvel utilisateur (ex: User 6 aime les thrillers mais pas la romance). Ajoutez les nouveaux `MovieRating` a la liste `movieData`. Reconstruisez la matrice avec le code de la cellule precedente pour verifier que les donnees sont coherentes.",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -556,6 +568,18 @@
     "var prediction3 = predictionEngine.Predict(new MovieRating { UserId = 1, MovieId = 4 });\n",
     "Console.WriteLine($\"Utilisateur 1 - Film 4 (nouveau) : Note prédite = {prediction3.Score:F2}\");\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice 4 : Similarite entre utilisateurs\n// TODO etudiant : Calculez la similarite cosinus entre toutes les paires d'utilisateurs\n// Indice : cos(A,B) = (A.B) / (||A|| * ||B||), representez chaque user par son vecteur de notes\n// Etape 1 : construire un dictionnaire UserId -> vecteur de notes (3 dimensions, 1 par film)\n// Etape 2 : implementer la fonction similarite cosinus (produit scalaire / normes)\n// Etape 3 : calculer la similarite pour chaque paire d'utilisateurs\n// Etape 4 : identifier les utilisateurs les plus similaires et les plus differents\n\nvar userSimilarities = null; // TODO etudiant : remplacer par la matrice de similarite\nConsole.WriteLine(\"Exercice a completer : similarite cosinus entre utilisateurs\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 4 : Similarite entre utilisateurs\n\nCalculez la similarite cosinus entre chaque paire d'utilisateurs a partir de leurs vecteurs de notes dans la matrice utilisateur-item. Identifiez les deux utilisateurs les plus similaires et les deux les plus differents.\n\n**Indice** : La similarite cosinus entre deux vecteurs A et B = (A.B) / (||A|| * ||B||). Representez chaque utilisateur par un vecteur de notes (taille = nombre de films, 0 pour les films non notes). Comparez les paires (1,2), (1,3), (1,4), (1,5), (2,3), (2,4), (2,5), (3,4), (3,5), (4,5).",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -908,6 +932,18 @@
     "Console.WriteLine(\"\\nOption 3 - Recommandations basées sur le contenu :\");\n",
     "Console.WriteLine(\"  'Vous aimez l'Action ? Voici les meilleurs films d'Action.'\");\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "source": "// Exercice 3 : Diversite des recommandations\n// TODO etudiant : Mesurez et ameliorez la diversite des recommandations\n// Indice : calculez l'ecart-type des MovieId dans le Top-5 recommande\n// Etape 1 : generer les Top-5 recommandations pour l'utilisateur 4 (par exemple)\n// Etape 2 : calculer l'ecart-type des MovieId recommandes (mesure de diversite)\n// Etape 3 : implementer une strategie d'amélioration (ex: penaliser les items consecutifs)\n// Etape 4 : comparer la diversite avant et apres amelioration\n\nvar diversityScore = 0.0; // TODO etudiant : remplacer par le score de diversite calcule\nConsole.WriteLine(\"Exercice a completer : diversite des recommandations\");",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Exercice 3 : Diversite des recommandations\n\nLes systemes de recommandation ont tendance a proposer des items trop similaires. Implementez une mesure de diversite en calculant la moyenne des distances entre les items recommandes (par exemple en utilisant l'ecart-type des MovieId dans le Top-5). Proposez une strategie simple pour ameliorer la diversite.\n\n**Indice** : Un ensemble diversifie a des MovieId repartis sur un large spectre. Calculer l'ecart-type des MovieId dans le Top-5 recommande. Pour ameliorer la diversite, vous pouvez forcer la selection d'items de categories differentes, ou penaliser les items trop similaires dans le score final.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Add exercise stubs to 10 notebooks toward >=3 convention (#2161).

### GenAI/Texte (6 notebooks)

| Notebook | Before->After | New exercises |
|----------|--------------|---------------|
| 3_Structured_Outputs | 0->2 | Partial (API error) |
| 4_Function_Calling | 0->3 | Tool schema, validation, pagination |
| 5_RAG_Modern | 0->3 | Chunking, retrieval eval, query reformulation |
| 7_Code_Interpreter | 0->1 | Partial (API error) |
| 8_Reasoning_Models | 0->3 | Chat vs reasoning, algorithm, logic |
| 9_Production_Patterns | 0->3 | Chatbot, streaming, rate limiter |

### ML/ML.Net (4 notebooks)

| Notebook | Before->After | New exercises |
|----------|--------------|---------------|
| ML-5-TimeSeries | 0->5 | +3 new |
| ML-6-ONNX | 0->5 | +3 new |
| ML-7-Recommendation | 0->5 | +3 new |
| TP-prevision-ventes | 0->5 | +3 new |

**Note**: ML-1 to ML-4 already had 3 exercises each (verified).

### Not yet enriched (API errors)
- GenAI/Texte: 1_OpenAI_Intro, 2_PromptEngineering, 6_PDF_Web_Search, 10_LocalLlama, 11_Quantization

## Validation

**C.1**: All stubs use `return None # TODO` / `print("Exercice a completer")` / `Console.WriteLine("Exercice a completer")`. 0 raise NotImplementedError/assert False/1/0.

See #2161