### PR TITLE
enrich(GenAI/Texte): add exercises to 4 remaining notebooks (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -417,6 +417,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "40274ffc",
+   "source": "### Exercice 1 : Planification GPU pour le deploiement de modeles\n\nVous etes charge de planifier l'infrastructure GPU pour deployer plusieurs LLMs.\nOn dispose de **RTX 4090 (24 GB VRAM chacune)**. Pour chaque modele, determinez\ncombien de GPU sont necessaires en W4A16, en tenant compte de la surcharge de 20%.\n\n**Objectif** : Ecrire une fonction qui recommande le nombre de GPUs et la configuration\nde deploiement optimale.\n\n**Indices** :\n- `# Indice` : Memoire W4A16 = params * 0.5 octets, puis ajouter 20% de surcharge\n- `# Indice` : Un modele tient sur N GPU si `memoire_totale / N <= vram_par_gpu`\n- `# Indice` : Le MoE Mixtral 8x7B a 46.7B parametres totaux (tous les experts sont en memoire)\n- `# Etape 1` : Calculer la memoire requise pour chaque precision (BF16, INT8, W4A16)\n- `# Etape 2` : Diviser par la VRAM d'un GPU et arrondir au superieur\n- `# Etape 3` : Ajouter la surcharge KV cache (20%) au calcul\n- `# Etape 4` : Retourner un rapport formatte avec la recommandation",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "145ba24f",
+   "source": "def plan_gpu_deployment(model_name, num_params_billions, gpu_vram_gb=24, precision=\"w4a16\"):\n    \"\"\"\n    Calcule le nombre de GPUs necessaires pour deployer un modele LLM.\n    \n    Args:\n        model_name: Nom du modele (ex: \"Llama 3.1 70B\")\n        num_params_billions: Nombre de parametres en milliards\n        gpu_vram_gb: VRAM disponible par GPU en GB (defaut: 24 GB pour RTX 4090)\n        precision: Precision cible (\"bf16\", \"int8\", \"w4a16\")\n    \n    Returns:\n        dict: Plan de deploiement avec nombre de GPUs et details memoire\n    \"\"\"\n    # TODO etudiant : calculer la memoire requise avec surcharge 20%\n    memory_required_gb = None  # TODO etudiant : utiliser bytes_per_param * params * 1.2 / 1e9\n    \n    # TODO etudiant : calculer le nombre de GPUs necessaires\n    num_gpus = None  # TODO etudiant : arrondir au superieur (math.ceil)\n    \n    return {\n        \"model\": model_name,\n        \"memory_required_gb\": memory_required_gb,\n        \"num_gpus\": num_gpus,  # TODO etudiant\n        \"precision\": precision,\n    }\n\n\n# Modeles a evaluer\nmodels_to_plan = [\n    (\"Mistral 7B\", 7),\n    (\"Mixtral 8x7B (MoE)\", 46.7),\n    (\"Llama 3.1 405B\", 405),\n]\n\nprint(\"Exercice a completer : implementer plan_gpu_deployment()\")\nfor name, params in models_to_plan:\n    print(f\"  {name} ({params}B params) -> ? RTX 4090 necessaires\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "c9d0e1f2",
    "metadata": {
     "papermill": {
@@ -856,6 +870,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8499bea0",
+   "source": "### Exercice 2 : Configuration d'une recette de quantification GPTQ\n\nAdaptez la configuration GPTQ pour un scenario specifique : vous devez quantifier\nun modele **text-only de 7B parametres** destine a un serveur vLLM en production,\nen maximisant la qualite de generation.\n\n**Objectif** : Configurer le `GPTQModifier` avec les bons hyperparametres.\n\n**Indices** :\n- `# Indice` : Le parametre `scheme` definit la precision (W4A16 = 4-bit poids, 16-bit activations)\n- `# Indice` : Le parametre `block_size` influence la qualite : 128 est le standard, 256 offre un meilleur compromis\n- `# Indice` : Le parametre `dampening_frac` stabilise la matrice de Hessian ; 0.01 est le defaut\n- `# Etape 1` : Definir les parametres de base (targets, scheme, ignore)\n- `# Etape 2` : Ajouter les parametres numeriques (dampening_frac, block_size)\n- `# Etape 3` : Calculer la taille attendue du modele quantifie en GB\n- `# Etape 4` : Verifier que la configuration est compatible avec vLLM (format compressed-tensors)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "01c21b88",
+   "source": "def configure_gptq_recipe(model_params_billions, model_type=\"text\"):\n    \"\"\"\n    Configure une recette de quantification GPTQ pour un modele LLM.\n    \n    Args:\n        model_params_billions: Nombre de parametres en milliards (ex: 7.0)\n        model_type: \"text\" pour texte-only, \"vl\" pour vision-language\n    \n    Returns:\n        dict: Configuration avec parametres GPTQ et taille estimee\n    \"\"\"\n    # TODO etudiant : construire le dictionnaire de configuration\n    config = {}  # TODO etudiant : remplir avec targets, scheme, ignore, dampening_frac, block_size\n    \n    # TODO etudiant : calculer la taille estimee du modele quantifie\n    estimated_size_gb = None  # TODO etudiant : utiliser la formule params * bytes_per_param / 1e9 * 1.2\n    \n    return {\n        \"config\": config,\n        \"estimated_size_gb\": estimated_size_gb,\n        \"compatible_vllm\": None  # TODO etudiant : verifier la compatibilite\n    }\n\n\n# Test\nresult = configure_gptq_recipe(7.0, \"text\")\nprint(\"Exercice a completer : implementer configure_gptq_recipe()\")\nprint(f\"Modele cible : 7B text-only, destine a vLLM\")\nprint(f\"Taille BF16 attendue : ~14.0 GB\")\nprint(f\"Taille W4A16 attendue : ~4.2 GB (a confirmer par votre calcul)\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "d6e7f8a9",
    "metadata": {
     "papermill": {
@@ -1101,6 +1129,20 @@
     "print('    if \\\"visual\\\" in name or \\\"merger\\\" in name:')\n",
     "print('        print(name)  # Ces couches doivent etre exclues')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74c573fd",
+   "source": "### Exercice 3 : Identification des couches a exclure pour un modele VL\n\nVous devez ecrire une fonction qui inspecte les couches d'un modele et genere automatiquement\nla liste des patterns d'exclusion pour la quantification.\n\n**Objectif** : Produire la liste `ignore` adaptee a un modele Vision-Language.\n\n**Indices** :\n- `# Indice` : Utilisez `model.named_modules()` pour iterer sur toutes les couches\n- `# Indice` : Les couches visuelles contiennent generalement les mots \"visual\", \"vision\", \"patch\", \"merger\", \"embed\" dans leur nom\n- `# Indice` : Les couches sensibles a exclure systematiquement sont `lm_head` et les couches de normalization\n- `# Etape 1` : Definir une fonction `identify_exclusions(model)` qui retourne une liste de strings\n- `# Etape 2` : Iterer sur `model.named_modules()` et filtrer selon les patterns\n- `# Etape 3` : Ajouter les exclusions systematiques (`lm_head`)\n- `# Etape 4` : Compter les parametres exclus vs total pour estimer le surcout memoire",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "a20f8fa6",
+   "source": "def identify_exclusions(model):\n    \"\"\"\n    Analyse les couches d'un modele et retourne la liste des patterns d'exclusion\n    pour la quantification GPTQ.\n    \n    Args:\n        model: Un modele HuggingFace (ex: Qwen3VLForConditionalGeneration)\n    \n    Returns:\n        list: Patterns d'exclusion pour GPTQModifier(ignore=[...])\n    \"\"\"\n    # TODO etudiant : iterer sur les modules et identifier les couches a exclure\n    pass  # TODO etudiant : implementer l'identification des exclusions\n\n\n# Test avec les noms de couches simules (sans charger de modele reel)\n# Ces noms sont representatifs d'un modele Qwen3-VL\nsample_layer_names = [\n    \"model.layers.0.self_attn.q_proj\",\n    \"model.layers.0.self_attn.k_proj\",\n    \"visual.encoder.block.0.attn.qkv\",\n    \"visual.patch_embed.proj\",\n    \"model.merger.adapter\",\n    \"lm_head\",\n    \"model.norm\",\n]\n\nprint(\"Exercice a completer : implementer identify_exclusions()\")\nprint(f\"Couches a analyser : {len(sample_layer_names)}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/1_OpenAI_Intro.ipynb
@@ -636,6 +636,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "47cd747b",
+   "source": "### Exercice 1 : Creer un assistant specialise avec le role system\n\nDans cet exercice, vous allez definir un message system pour transformer le modele en assistant specialise, puis tester son comportement.\n\n**Objectif** : Concevoir un message system qui contraint le modele a adopter un role et un format de reponse specifiques.\n\n**Contexte** : L'exemple precedent montre comment un message system \"poetique\" modifie le comportement du modele. Vous allez maintenant definir votre propre specialisation et observer comment le modele adapte ses reponses.\n\n**Etapes** :\n1. Choisissez un domaine de specialisation (par exemple : nutrition, droit, histoire des sciences, etc.)\n2. Redigez un message system precis qui definit le role, le ton et le format attendu\n3. Posez une question technique dans ce domaine et observez si le modele respecte les consignes\n\n**Indices** :\n- # Indice : Un bon message system precise role ET format : \"Tu es un nutritionniste certifie. Tu reponds en listes a puces avec des sources scientifiques quand c'est possible\"\n- # Indice : Pensez a tester avec un message system incomplet puis un message complet pour comparer la difference de qualite",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ecfda2fd",
+   "source": "# Exercice 1 : Creer un assistant specialise avec le role system\n# TODO etudiant : Definissez votre message system et testez le comportement du modele\n\n# Etape 1 : Definissez le message system pour votre assistant specialise\nmessage_system = \"\"  # TODO etudiant : redigez un message system precis (role + format)\n\n# Etape 2 : Formulez une question technique dans le domaine choisi\nquestion_technique = \"\"  # TODO etudiant : posez une question qui teste la specialisation\n\n# Etape 3 : Construisez la liste de messages et appelez l'API\nmessages_ex1 = [\n    {\"role\": \"system\", \"content\": message_system},\n    {\"role\": \"user\", \"content\": question_technique}\n]\n\nresponse_ex1 = None  # TODO etudiant : remplacer par l'appel client.chat.completions.create(...)\n\n# Affichage du resultat\nif response_ex1:\n    print(\"=== Reponse de l'assistant specialise ===\")\n    print(response_ex1.choices[0].message.content)\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "4e6b17ae",
    "metadata": {
     "papermill": {
@@ -844,6 +858,20 @@
     "cout_estimé = prompt_tokens * PRIX_PAR_TOKEN\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09071791",
+   "source": "### Exercice 2 : Estimer le cout d'un appel API\n\nDans cet exercice, vous allez utiliser `tiktoken` pour estimer le nombre de tokens et le cout approximatif d'un appel API.\n\n**Objectif** : Calculer le nombre de tokens d'un prompt complexe et estimer le cout avant de l'envoyer.\n\n**Contexte** : La tokenisation determine le cout de chaque appel API. Savoir estimer ce cout a l'avance est une competence essentielle pour optimiser l'utilisation des LLMs.\n\n**Etapes** :\n1. Encodez le texte fourni avec l'encodeur du modele par defaut\n2. Comptez le nombre de tokens en entree\n3. Estimez le cout en supposant un prix de 0.15 USD par million de tokens en entree\n\n**Indices** :\n- # Indice : Utilisez `get_encoder(DEFAULT_MODEL)` (defini plus haut) puis `encoder.encode(texte)`\n- # Indice : La longueur de la liste de tokens donne directement le nombre de tokens : `len(tokens)`\n- # Indice : Pour le cout, multipliez par le prix unitaire : `cout = nb_tokens * 0.15 / 1_000_000`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8a8900c6",
+   "source": "# Exercice 2 : Estimer le cout d'un appel API\n# TODO etudiant : Completez les etapes ci-dessous\n\ntexte_long = \"\"\"\nL'intelligence artificielle generative transforme de nombreux secteurs economiques.\nEn sante, elle assiste les medecins dans le diagnostic et la recherche de nouveaux medicaments.\nDans l'education, elle permet de personnaliser les parcours d'apprentissage.\nLe secteur juridique l'utilise pour analyser des contrats et predire l'issue de litiges.\nCependant, des questions ethiques persistent concernant les biais, la confidentialite et l'impact environnemental.\n\"\"\"\n\n# Etape 1 : Obtenir l'encodeur pour le modele par defaut\nencoder_ex2 = None  # TODO etudiant : utiliser get_encoder(DEFAULT_MODEL)\n\n# Etape 2 : Encoder le texte et compter les tokens\nnb_tokens = 0  # TODO etudiant : encoder le texte et compter les tokens\n\n# Etape 3 : Estimer le cout (0.15 USD / million tokens input)\ncout_estime = 0.0  # TODO etudiant : calculer le cout\n\n# Affichage des resultats\nif nb_tokens > 0:\n    print(f\"Nombre de tokens : {nb_tokens}\")\n    print(f\"Cout estime (input) : ${cout_estime:.6f} USD\")\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1093,6 +1121,20 @@
     "\n",
     "**Leçon clé** : Les LLMs sont excellents pour générer du texte cohérent, mais ne distinguent pas intrinsèquement le vrai du faux. La vérification humaine reste essentielle."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23b0aa05",
+   "source": "### Exercice 3 : Mitiger les hallucinations\n\nDans cet exercice, vous allez comparer le comportement du modele face a un prompt factuellement faux, avec et sans consigne anti-hallucination.\n\n**Objectif** : Modifier le prompt pour que le modele reconnaisse son ignorance au lieu d'inventer une reponse.\n\n**Contexte** : Le test d'hallucination ci-dessus montre que le modele invente librement une \"guerre de 2076 sur Mars\". Vous allez concevoir une variante du prompt qui inclut une consigne explicite pour forcer le modele a etre honnete.\n\n**Etapes** :\n1. Reprenez le meme sujet fictif (\"la guerre de 2076 sur Mars\")\n2. Ajoutez une instruction system ou user qui demande au modele de signaler s'il n'a pas d'information fiable\n3. Comparez la reponse obtenue avec la version sans protection\n\n**Indices** :\n- # Indice : Un message \"system\" peut contenir une regle du type \"Si tu n'as pas d'information verifiable sur le sujet, reponds que tu ne sais pas\"\n- # Indice : Testez aussi avec `temperature=0.0` pour voir si une temperature basse reduit les inventions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "f3a91b5c",
+   "source": "# Exercice 3 : Mitiger les hallucinations\n# TODO etudiant : Modifiez le prompt ci-dessous pour que le modele reconnaisse son ignorance\n\nprompt_anti_hallucination = \"Decris-moi la celebre guerre de 2076 sur la planete Mars.\"  # TODO etudiant : ajoutez une consigne anti-hallucination\n\nmessages_ex3 = [\n    # Etape 1 : Ajoutez un message \"system\" avec une regle d'honnetete\n    {\"role\": \"user\", \"content\": prompt_anti_hallucination}\n]\n\n# Etape 2 : Appelez l'API avec temperature=0.0 pour limiter la creativite\nresponse_ex3 = None  # TODO etudiant : remplacer par l'appel client.chat.completions.create(...)\n\n# Etape 3 : Affichez et analysez la reponse\nif response_ex3:\n    print(response_ex3.choices[0].message.content)\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/2_PromptEngineering.ipynb
@@ -373,7 +373,7 @@
    "id": "1830e31c",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T17:44:21.851252",
      "exception": false,
      "start_time": "2026-05-29T17:44:21.851252",
@@ -458,7 +458,7 @@
    "id": "94oe4gyr61r",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T17:44:22.153713",
      "exception": false,
      "start_time": "2026-05-29T17:44:22.153713",
@@ -565,7 +565,7 @@
    "id": "f9619dc4",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T17:44:22.184507",
      "exception": false,
      "start_time": "2026-05-29T17:44:22.184507",
@@ -693,6 +693,20 @@
     "\n",
     "Dans cet exemple, le modèle génère 3 recettes végétariennes à base de tomates sans aucun exemple préalable. La qualité dépend fortement de la clarté du prompt et de la capacité du modèle à comprendre le domaine."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2adb5f53",
+   "source": "### Exercice 1 : Comparer zero-shot et few-shot sur une tache de formatage\n\nVous avez vu le zero-shot prompting en action avec les recettes vegetariennes. L'objectif de cet exercice est de **comparer** le zero-shot et le few-shot sur une meme tache pour observer la difference de qualite.\n\n**Objectif** : Formuler deux prompts pour la meme tache de formatage -- l'un sans exemple (zero-shot), l'autre avec 2 exemples (few-shot) -- et comparer les resultats.\n\n**Tache suggeree** : Convertir une phrase informelle en message professionnel formel.\n\n**Contraintes** :\n- Le prompt zero-shot doit contenir uniquement la consigne, sans exemple\n- Le prompt few-shot doit contenir 2 exemples de conversion avant la demande\n- Comparer la coherence du format et du ton entre les deux reponses\n\n**Indices** :\n- `# Indice` : Pour le few-shot, structurez vos exemples avec \"Exemple : Phrases informelle -> Version professionnelle\"\n- `# Indice` : Utilisez le meme `MODEL_NAME` et `max_completion_tokens` pour les deux appels afin de comparer equitablement\n- `# Etape 1` : Ecrire le prompt zero-shot (consigne seule)\n- `# Etape 2` : Ecrire le prompt few-shot (2 exemples + consigne)\n- `# Etape 3` : Appeler l'API pour les deux et afficher les resultats cote a cote",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "d98cf956",
+   "source": "# Exercice 1 : Comparer zero-shot et few-shot sur une tache de formatage\n\n# TODO etudiant : Definissez la phrase informelle a convertir\nphrase_informelle = None  # TODO etudiant : ex. \"faut qu'on se capte demain pour le projet\"\n\n# # Etape 1 : Prompt zero-shot (consigne seule, sans exemple)\n# zero_shot_prompt = None  # TODO etudiant : \"Convertis cette phrase en message professionnel : ...\"\n#\n# # Etape 2 : Prompt few-shot (2 exemples + consigne)\n# few_shot_prompt = None  # TODO etudiant : \"Voici des exemples : ...\" + consigne\n#\n# # Etape 3 : Appels API et comparaison\n# if zero_shot_prompt and few_shot_prompt:\n#     resp_zero = client.chat.completions.create(\n#         model=MODEL_NAME,\n#         messages=[{\"role\": \"user\", \"content\": zero_shot_prompt}],\n#         max_completion_tokens=500,\n#     )\n#     resp_few = client.chat.completions.create(\n#         model=MODEL_NAME,\n#         messages=[{\"role\": \"user\", \"content\": few_shot_prompt}],\n#         max_completion_tokens=500,\n#     )\n#     print(\"=== Zero-shot ===\")\n#     print(resp_zero.choices[0].message.content)\n#     print(\"\\n=== Few-shot ===\")\n#     print(resp_few.choices[0].message.content)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1158,7 +1172,7 @@
    "id": "730a6f88",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-05-29T17:44:47.066849",
      "exception": false,
      "start_time": "2026-05-29T17:44:47.066849",
@@ -1193,6 +1207,20 @@
     "\n",
     "**Note** : Temperature=0.2 garantit un raisonnement cohérent et reproductible."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84646924",
+   "source": "### Exercice 2 : Concevoir un prompt Chain-of-thought pour un probleme logique\n\nL'exemple precedent utilise le CoT sur un calcul arithmetique simple. Vous allez maintenant concevoir un prompt CoT pour un **probleme de logique** plus elabore.\n\n**Objectif** : Formuler un prompt qui force le modele a detailler son raisonnement etape par etape, puis verifier la qualite de la reponse.\n\n**Probleme suggere** : \"Dans une ecole, chaque eleve porte soit un chapeau rouge, soit un chapeau bleu. Paul voit 3 chapeaux rouges et 2 chapeaux bleus. Marie voit 4 chapeaux rouges et 1 chapeau bleu. Combien d'eleves y a-t-il au minimum dans cette ecole ?\"\n\n**Contraintes** :\n- Le prompt doit contenir explicitement l'instruction de raisonner etape par etape\n- Le prompt doit demander une reponse finale claire\n- Vous evaluerez si le raisonnement du modele est correct\n\n**Indices** :\n- `# Indice` : Pensez a qui Paul et Marie voient (et ne voient pas)\n- `# Indice` : Le modele doit identifier les informations manquantes et faire des deductions\n- `# Etape 1` : Ecrire le prompt avec la consigne CoT explicite\n- `# Etape 2` : Appeler l'API et analyser le raisonnement produit\n- `# Etape 3` : Verifier manuellement si la conclusion du modele est correcte",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7b831950",
+   "source": "# Exercice 2 : Concevoir un prompt Chain-of-thought pour un probleme logique\n\n# TODO etudiant : Redigez votre prompt CoT ici\n# Indice : incluez \"Explique ton raisonnement etape par etape\"\ncot_prompt_exercise = None  # TODO etudiant : remplacez par votre prompt\n\n# # Etape 2 : Appel a l'API\n# if cot_prompt_exercise:\n#     response_cot = client.chat.completions.create(\n#         model=MODEL_NAME,\n#         messages=[{\"role\": \"user\", \"content\": cot_prompt_exercise}],\n#         max_completion_tokens=1500,\n#     )\n#     print(\"Raisonnement du modele :\")\n#     print(response_cot.choices[0].message.content)\n# else:\n#     print(\"Definissez votre prompt dans cot_prompt_exercise\")\n\n# # Etape 3 : Verification manuelle\n# # TODO etudiant : Le raisonnement est-il correct ? La conclusion est-elle valide ?\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "code",
@@ -1892,6 +1920,20 @@
     "- **Long terme** : Tronquer les messages anciens ou résumer périodiquement\n",
     "- **Tokens** : Attention au coût - chaque tour envoie TOUT l'historique à l'API"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "040842eb",
+   "source": "### Exercice 3 : Chatbot specialise avec memoire conversationnelle\n\nDans les exemples precedents, nous avons vu comment accumuler les messages pour donner de la memoire au modele. Votre objectif est de creer un **chatbot specialise** qui repond dans un style et un domaine precis.\n\n**Objectif** : Configurer un system prompt specialise, puis simuler un echange de 3 tours en mode batch.\n\n**Contraintes** :\n- Le system prompt doit definir un role clair (ex : professeur de maths, guide touristique, coach sportif...)\n- La conversation doit comporter au moins 3 echanges utilisateur/assistant\n- Le modele doit exploiter le contexte des tours precedents\n\n**Indices** :\n- `# Indice` : Inspirez-vous de la structure `current_messages` de la cellule precedente\n- `# Indice` : Le role `\"system\"` ou `\"developer\"` definit le comportement global du modele\n- `# Etape 1` : Definir le system_prompt et le premier message utilisateur\n- `# Etape 2` : Boucler sur les messages suivants en accumulant l'historique\n- `# Etape 3` : Verifier que le modele utilise les informations des tours precedents",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "89973221",
+   "source": "# Exercice 3 : Chatbot specialise avec memoire conversationnelle\n\n# TODO etudiant : Definissez un system_prompt specialise\nsystem_prompt = None  # TODO etudiant : \"Tu es un...\" \n\n# TODO etudiant : Liste de 3 messages utilisateur pour simuler la conversation\nuser_messages = [\n    # \"Message 1\",\n    # \"Message 2\",\n    # \"Message 3\",\n]\n\n# TODO etudiant : Construisez la conversation avec accumulation de l'historique\n# current_messages = [{\"role\": \"system\", \"content\": system_prompt}]\n# for msg in user_messages:\n#     ...\n#     current_messages.append(...)\n#     current_messages.append(...)\n\nprint(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/6_PDF_Web_Search.ipynb
@@ -530,6 +530,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6985f8c2",
+   "source": "### Exercice 1 : Analyser un document personnalise avec Vision\n\nL'objectif est de creer une image contenant des informations structurees (tableau ou liste chiffree), puis de l'analyser avec l'API Vision pour en extraire des donnees specifiques dans un format exploitable.\n\n**Contexte** : Dans un contexte professionnel, on recoit souvent des documents visuels (captures d'ecran de tableaux de bord, graphiques exportes, rapports scannes). Savoir extraire automatiquement des informations ciblees de ces images est une competence cle.\n\n**Etapes** :\n1. Creer une image avec PIL contenant un tableau de donnees (ventes mensuelles, par exemple)\n2. Encoder l'image en base64 et l'envoyer au modele avec un prompt d'extraction structuree\n3. Parser la reponse du modele pour extraire les valeurs numeriques\n4. Calculer et afficher des statistiques simples (moyenne, min, max)\n\n**Indices** :\n- Utilisez `ImageDraw` pour dessiner les lignes du tableau et le texte\n- Demandez au modele de repondre au format structure (ex: \"Donne les valeurs sous forme de liste JSON\")\n- Pour parser les nombres, vous pouvez utiliser `re.findall(r'[\\d.]+', texte)` ou demander au modele un format CSV\n- La fonction `create_test_image()` ci-dessus montre comment creer une image avec PIL",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "3805d2ce",
+   "source": "def analyser_document_vision():\n    \"\"\"\n    Cree une image avec un tableau de donnees, l'analyse via Vision,\n    et retourne les statistiques extraites.\n\n    Returns:\n        dict: {valeurs: [...], moyenne: float, min: float, max: float}\n    \"\"\"\n    # TODO etudiant : implementer la fonction\n    # Etape 1 : Creer une image avec PIL (Image + ImageDraw)\n    # Indice : dessiner un tableau avec 4-6 lignes de donnees (mois + montant)\n    # Etape 2 : Encoder en base64 et appeler client.chat.completions.create\n    # Indice : demander un format structure comme \"liste les montants separees par des virgules\"\n    # Etape 3 : Parser la reponse pour extraire les valeurs numeriques\n    # Etape 4 : Calculer moyenne, min, max des valeurs\n    return None  # TODO etudiant : retourner le dictionnaire resultat\n\nstats = analyser_document_vision()\nif stats:\n    print(f\"Valeurs extraites: {stats['valeurs']}\")\n    print(f\"Moyenne: {stats['moyenne']:.1f}\")\n    print(f\"Min: {stats['min']}, Max: {stats['max']}\")\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "4595cd74",
    "metadata": {
     "papermill": {
@@ -754,6 +768,20 @@
     "\n",
     "# Note: Les citations sont incluses automatiquement dans la réponse"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9054a37c",
+   "source": "### Exercice 2 : Comparaison multi-sources avec web search\n\nL'objectif est d'effectuer plusieurs recherches web sur un meme sujet, puis de synthetiser les resultats en identifiant les points de convergence et de divergence entre les sources.\n\n**Contexte** : Lors d'une veille technologique, il est courant de croiser plusieurs sources pour obtenir une vue fiable et equilibree d'un sujet. L'API web search permet d'automatiser cette demarche.\n\n**Etapes** :\n1. Choisir un sujet d'actualite technologique (ou utiliser celui propose ci-dessous)\n2. Effectuer 3 requetes web search formulees differemment sur le meme sujet\n3. Collecter les reponses et extraire les citations de chaque requete\n4. Produire une synthese identifiant les informations communes et les contradictions\n\n**Indices** :\n- Formulez les requetes avec des angles differents : \"quels sont les impacts de X\", \"critiques de X\", \"benefices de X\"\n- Chaque appel a `responses.create` retourne une reponse independante\n- Comparez les URLs des annotations pour detecter si les memes sources reviennent\n- Le dictionnaire final peut suivre la structure : `{convergences: [...], divergences: [...], sources_uniques: [...]}`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ad432956",
+   "source": "def compare_sources(topic):\n    \"\"\"\n    Effectue 3 recherches web sous des angles differents et synthetise les resultats.\n\n    Args:\n        topic (str): Sujet a investiguer\n\n    Returns:\n        dict: Synthese avec convergences, divergences et sources\n    \"\"\"\n    # TODO etudiant : implementer la fonction\n    # Etape 1 : Definir 3 angles de requetes sur le meme sujet\n    # Etape 2 : Effectuer les 3 appels web_search_preview\n    # Etape 3 : Extraire texte et URLs de chaque reponse\n    # Indice : utiliser une boucle sur les 3 formulations\n    # Indice : pour extraire les URLs, parcourir item.annotations dans response.output\n    return None  # TODO etudiant : retourner le dictionnaire de synthese\n\n# Test\ntopic = \"regulation de l'intelligence artificielle en Europe en 2026\"\nsynthese = compare_sources(topic)\nif synthese:\n    print(f\"Convergences: {len(synthese.get('convergences', []))}\")\n    print(f\"Divergences: {len(synthese.get('divergences', []))}\")\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -1105,6 +1133,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9db2736",
+   "source": "### Exercice 3 : Fact-checking personnalise\n\nL'objectif est de construire un mini-pipeline de verification qui prend une affirmation en entree, la soumet au web search, puis classe le resultat dans l'une des categories suivantes : `CONFIRMEE`, `INFIRMEE`, `NUANCEE` ou `NON VERIFIABLE`.\n\n**Contexte** : Dans le monde professionnel, on rencontre frequemment des affirmations chiffrees dans des rapports, presentations ou articles. Verifier automatiquement ces claims avec des sources web recentes est un gain de temps considerable.\n\n**Etapes** :\n1. Definir une fonction `fact_check(claim)` qui effectue une recherche web via `responses.create` avec `web_search_preview`\n2. Extraire le texte de la reponse et le nombre de citations (annotations)\n3. Classifier la reponse en se basant sur le nombre de sources et le contenu\n4. Retourner un dictionnaire avec la claim, le verdict, les sources et un resume\n\n**Indices** :\n- `response.output` contient des items dont certains sont du type `ResponseOutputText` avec un attribut `annotations`\n- Le nombre d'annotations reflète le nombre de sources citees par le modele\n- Une claim confirmee par 3+ sources independantes est generalement fiable\n- Pensez a gerer le cas ou le web search ne retourne pas de resultats pertinents",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "703c9ddf",
+   "source": "def fact_check(claim):\n    \"\"\"\n    Verifie une affirmation via web search et la classe en :\n    CONFIRMEE, INFIRMEE, NUANCEE ou NON VERIFIABLE.\n\n    Args:\n        claim (str): L'affirmation a verifier\n\n    Returns:\n        dict: {claim, verdict, sources, resume}\n    \"\"\"\n    # TODO etudiant : implementer la fonction\n    # Etape 1 : Construire la requete de verification\n    # Etape 2 : Appeler client.responses.create avec web_search_preview\n    # Etape 3 : Extraire le texte et les annotations de la reponse\n    # Etape 4 : Classifier le verdict selon le nombre de sources\n    return None  # TODO etudiant : retourner le dictionnaire resultat\n\n# Test avec une affirmation\nresult = fact_check(\"Le marche mondial du cloud depassera 700 milliards de dollars en 2026\")\nif result:\n    print(f\"Verdict: {result['verdict']}\")\n    print(f\"Sources: {len(result['sources'])}\")\n    print(f\"Resume: {result['resume']}\")\nelse:\n    print(\"Exercice a completer\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "1af18f09",
    "metadata": {
     "papermill": {
@@ -1259,62 +1301,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "### Ce que nous avons appris\n",
-    "\n",
-    "1. **Support PDF natif** : Les modèles vision peuvent analyser des PDFs directement\n",
-    "   - Encodage base64 pour envoi direct\n",
-    "   - Limites : 100 pages, 32 MB\n",
-    "   - Coût : 1 page = 1 image\n",
-    "\n",
-    "2. **Web Search** : Accès en temps réel à l'information\n",
-    "   - Via Responses API avec `web_search_preview`\n",
-    "   - Citations automatiques\n",
-    "   - Idéal pour données actuelles\n",
-    "\n",
-    "3. **Combinaison PDF + Web** : Analyses enrichies\n",
-    "   - Extraction de données PDF\n",
-    "   - Contextualisation avec sources web\n",
-    "   - Fact-checking et vérification\n",
-    "\n",
-    "### Cas d'usage professionnels\n",
-    "\n",
-    "| Domaine | Application |\n",
-    "|---------|-------------|\n",
-    "| **Finance** | Analyse de rapports avec données marché en temps réel |\n",
-    "| **Juridique** | Vérification de conformité avec réglementations actuelles |\n",
-    "| **Recherche** | Actualisation de revues de littérature |\n",
-    "| **Consulting** | Benchmarking clients vs. tendances secteur |\n",
-    "| **Journalism** | Fact-checking automatisé de documents |\n",
-    "\n",
-    "### Exercices suggérés\n",
-    "\n",
-    "1. **Niveau débutant** :\n",
-    "   - Analyser votre CV (PDF) et obtenir des conseils basés sur les tendances emploi actuelles\n",
-    "   - Créer un résumé enrichi d'un article de recherche\n",
-    "\n",
-    "2. **Niveau intermédiaire** :\n",
-    "   - Développer un système de veille qui compare des rapports trimestriels successifs avec l'actualité\n",
-    "   - Créer un fact-checker pour articles de presse (PDF) vs. sources web\n",
-    "\n",
-    "3. **Niveau avancé** :\n",
-    "   - Pipeline automatisé d'analyse de documents contractuels avec vérification de conformité légale\n",
-    "   - Système de recommandation qui analyse des rapports internes et suggère des actions basées sur les tendances marché\n",
-    "\n",
-    "### Prochaines étapes\n",
-    "\n",
-    "- **Notebook 7** : Structured Outputs (JSON Schema forcé)\n",
-    "- **Notebook 8** : Function Calling avancé\n",
-    "- **Notebook 9** : Assistants API et Code Interpreter\n",
-    "\n",
-    "### Ressources complémentaires\n",
-    "\n",
-    "- [Documentation OpenAI - Vision](https://platform.openai.com/docs/guides/vision)\n",
-    "- [Responses API Reference](https://platform.openai.com/docs/api-reference/responses)\n",
-    "- [Guide des prix OpenAI](https://openai.com/api/pricing/)"
-   ]
+   "source": "## Conclusion\n\n### Ce que nous avons appris\n\n1. **Support PDF natif** : Les modèles vision peuvent analyser des PDFs directement\n   - Encodage base64 pour envoi direct\n   - Limites : 100 pages, 32 MB\n   - Coût : 1 page = 1 image\n\n2. **Web Search** : Accès en temps réel à l'information\n   - Via Responses API avec `web_search_preview`\n   - Citations automatiques\n   - Idéal pour données actuelles\n\n3. **Combinaison PDF + Web** : Analyses enrichies\n   - Extraction de données PDF\n   - Contextualisation avec sources web\n   - Fact-checking et vérification\n\n### Cas d'usage professionnels\n\n| Domaine | Application |\n|---------|-------------|\n| **Finance** | Analyse de rapports avec données marché en temps réel |\n| **Juridique** | Vérification de conformité avec réglementations actuelles |\n| **Recherche** | Actualisation de revues de littérature |\n| **Consulting** | Benchmarking clients vs. tendances secteur |\n| **Journalisme** | Fact-checking automatisé de documents |\n\n### Exercices du notebook\n\n| # | Titre | Section | Concept cle |\n|---|-------|---------|-------------|\n| 1 | Analyser un document personnalise avec Vision | 1. Documents | PIL + Vision API + extraction de donnees |\n| 2 | Comparaison multi-sources avec web search | 2. Web Search | Requetes multi-angles + synthese convergences/divergences |\n| 3 | Fact-checking personnalise | 4. Verification | Pipeline de verification + classification automatique |\n\n### Prochaines étapes\n\n- **Notebook 7** : Structured Outputs (JSON Schema forcé)\n- **Notebook 8** : Function Calling avancé\n- **Notebook 9** : Assistants API et Code Interpreter\n\n### Ressources complémentaires\n\n- [Documentation OpenAI - Vision](https://platform.openai.com/docs/guides/vision)\n- [Responses API Reference](https://platform.openai.com/docs/api-reference/responses)\n- [Guide des prix OpenAI](https://openai.com/api/pricing/)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Add 3 exercises each to the remaining GenAI/Texte notebooks that failed in the previous batch (API errors).

| Notebook | Before->After | New exercises |
|----------|--------------|---------------|
| 1_OpenAI_Intro | 0->3 | System roles, cost estimation, hallucination mitigation |
| 2_PromptEngineering | 0->3 | Zero-shot vs few-shot, CoT logic, chatbot memory |
| 6_PDF_Web_Search | 0->3 | Vision analysis, multi-source comparison, fact-checking |
| 11_Quantization | 0->3 | GPU planning, GPTQ recipe, layer exclusion |

**Still missing**: 10_LocalLlama (agent error, will retry next cycle)

## Validation

**C.1**: All stubs use `return None # TODO` / `print("Exercice a completer")`. 0 raise NotImplementedError/assert False/1/0.

**GenAI/Texte series status**: 10/11 notebooks now >=3 exercises.

See #2161