### PR TITLE
enrich(GenAI/Texte): add exercises to 10_LocalLlama (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -1644,6 +1644,79 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex1-tokenization-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01,
+     "end_time": "2026-06-03T00:00:00.000000",
+     "exception": false,
+     "start_time": "2026-06-03T00:00:00.000000",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Analyse comparative de tokenisation\n",
+    "\n",
+    "**Duree estimee :** 10-15 minutes\n",
+    "\n",
+    "**Objectif** : Comparer la tokenisation d'un meme texte entre differents modeles/endpoints et analyser les differences observees.\n",
+    "\n",
+    "**Contexte**\n",
+    "\n",
+    "La section precedente montre que chaque modele possede son propre tokenizer. Un meme texte peut etre decoupe en un nombre different de tokens selon le modele utilise, ce qui impacte directement le cout et la vitesse de generation. Comprendre ces differences est essentiel pour optimiser les prompts.\n",
+    "\n",
+    "**Instructions**\n",
+    "\n",
+    "1. Definir un texte de test contenant au moins : un mot technique, un nombre decimal, de la ponctuation speciale\n",
+    "2. Utiliser l'endpoint `/tokenize` de vLLM pour tokeniser le texte avec chaque modele disponible\n",
+    "3. Comparer le nombre de tokens et afficher les 5 premiers tokens de chaque modele\n",
+    "4. Identifier quel modele est le plus efficient pour ce texte\n",
+    "\n",
+    "**Indices**\n",
+    "\n",
+    "- # Etape 1 : Le texte de test doit contenir au moins 20 caracteres pour etre significatif\n",
+    "- # Etape 2 : L'endpoint `/tokenize` attend un POST avec `{\"text\": \"...\"}` en JSON\n",
+    "- # Etape 3 : La reponse contient un champ `tokens` (liste) et `count` (entier)\n",
+    "- # Indice : Les fonctions `tokenize_local` et `detokenize_local` definies precedemment montrent le format d'appel\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex1-tokenization-code",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": false,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 : Analyse comparative de tokenisation\n",
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "# Etape 1 : Definir un texte de test varie\n",
+    "test_text = None  # TODO etudiant : ecrire un texte contenant un mot technique, un decimal, de la ponctuation\n",
+    "\n",
+    "# Etape 2 : Fonction pour tokeniser via l'endpoint vLLM\n",
+    "def tokenize_text(endpoint_url, text):\n",
+    "    \"\"\"Tokenise un texte via l'endpoint /tokenize d'un serveur vLLM.\"\"\"\n",
+    "    result = None  # TODO etudiant : envoyer la requete POST et retourner les tokens\n",
+    "    return result\n",
+    "\n",
+    "# Etape 3 : Comparer les tokenisations\n",
+    "print(\"Exercice a completer\")\n",
+    "pass\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6232b9b5",
    "metadata": {
     "papermill": {
@@ -4036,6 +4109,86 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ex2-benchmark-md",
+   "metadata": {
+    "papermill": {
+     "duration": 0.01,
+     "end_time": "2026-06-03T00:00:00.000000",
+     "exception": false,
+     "start_time": "2026-06-03T00:00:00.000000",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Comparaison de performances entre endpoints\n",
+    "\n",
+    "**Duree estimee :** 15-20 minutes\n",
+    "\n",
+    "**Objectif** : Comparer les performances (latence, debit en tokens/seconde) de plusieurs endpoints locaux en variant les parametres de generation.\n",
+    "\n",
+    "**Contexte**\n",
+    "\n",
+    "Le benchmark precedent montre que les modeles locaux ont des profils de performance tres differents selon leur taille, leur quantification et leur architecture. Dans cet exercice, vous allez construire votre propre benchmark en faisant varier un parametre cle.\n",
+    "\n",
+    "**Instructions**\n",
+    "\n",
+    "1. Choisir un parametre a faire varier parmi :\n",
+    "   - `max_completion_tokens` : 50, 100, 250, 500\n",
+    "   - `temperature` : 0.0, 0.5, 1.0, 1.5\n",
+    "   - `top_p` : 0.1, 0.5, 0.9, 1.0\n",
+    "\n",
+    "2. Pour chaque valeur du parametre, envoyer la meme requete a chacun des endpoints disponibles et mesurer :\n",
+    "   - La latence totale (en secondes)\n",
+    "   - Le nombre de tokens generes\n",
+    "   - Le debit en tokens/seconde\n",
+    "\n",
+    "3. Presenter les resultats sous forme de tableau comparatif\n",
+    "\n",
+    "**Indices**\n",
+    "\n",
+    "- # Etape 1 : Utiliser `time.perf_counter()` pour mesurer la latence avec precision\n",
+    "- # Etape 2 : Le nombre de tokens se trouve dans `response[\"usage\"][\"completion_tokens\"]`\n",
+    "- # Etape 3 : Le debit = `completion_tokens / latence_totale`\n",
+    "- # Indice : La fonction `test_openai_chat` definie precedemment peut servir de base, en ajoutant la mesure du temps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ex2-benchmark-code",
+   "metadata": {
+    "papermill": {
+     "duration": null,
+     "end_time": null,
+     "exception": false,
+     "start_time": null,
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 : Comparaison de performances entre endpoints\n",
+    "import time\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "# Etape 1 : Definir le prompt de test (identique pour toutes les mesures)\n",
+    "test_prompt = \"Expliquez en 3 phrases ce qu'est un modele de langage.\"\n",
+    "\n",
+    "# Etape 2 : Definir les valeurs du parametre a tester\n",
+    "param_values = [50, 100, 250, 500]  # max_completion_tokens\n",
+    "# param_values = [0.0, 0.5, 1.0, 1.5]  # temperature (decommenter pour tester)\n",
+    "\n",
+    "# Etape 3 : Boucler sur les endpoints et les valeurs du parametre\n",
+    "results = []  # TODO etudiant : stocker les resultats\n",
+    "\n",
+    "print(\"Exercice a completer\")\n",
+    "pass\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bad3bbd4",
    "metadata": {
     "papermill": {
@@ -4794,7 +4947,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice : Déploiement d'un modèle local avec function calling\n",
+    "### Exercice 3 : Déploiement d'un modèle local avec function calling\n",
     "\n",
     "**Durée estimée :** 20-25 minutes\n",
     "\n",


### PR DESCRIPTION
## Summary

Add 2 exercises to 10_LocalLlama + rename existing exercise for consistent numbering.

| Notebook | Before->After | New exercises |
|----------|--------------|---------------|
| 10_LocalLlama | 1->3 | Tokenization comparison, endpoint performance comparison |

**GenAI/Texte series now COMPLETE**: all 11/11 notebooks >=3 exercises.

## Validation
- C.1: Stubs use `pass` / `print("Exercice a completer")` / `return None # TODO`. 0 raise NotImplementedError.

See #2161