### PR TITLE
fix(socialchoice): repair broken/stale 16b-16g cross-refs after consolidation (#2259)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
@@ -3518,7 +3518,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [← SocialChoice/01-Arrow (notebook non disponible) | [Index](GameTheory-1-Setup.ipynb) | [Fin de la serie]"
+    "**Navigation** : [<< 15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | [Index](README.md) | side track [Social Choice](SocialChoice/README.md)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [<< 15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | [Index](README.md) | [17-MultiAgent-RL >>](GameTheory-17-MultiAgent-RL.ipynb)\n",
     "\n",
-    "**Side tracks** : [16b-Lean-SocialChoice (notebook non disponible) | [16c-SocialChoice-Python (notebook non disponible)\n",
+    "**Side tracks** : sous-serie [Social Choice](SocialChoice/README.md) — [SC-01 Arrow (Python)](SocialChoice/01-Arrow-Impossibility-Theorem.ipynb) | [SC-02 Lean](SocialChoice/02-Lean-SocialChoice-Formal.ipynb) | [SC-03 Methodes de vote](SocialChoice/03-Voting-Methods.ipynb) | [SC-04 SAT/Z3](SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb)\n",
     "\n",
     "## Concevoir des Regles pour des Agents Strategiques\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/01-Arrow-Impossibility-Theorem.ipynb
@@ -1840,7 +1840,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< 16b-Lean-SocialChoice](02-Lean-SocialChoice-Formal.ipynb) | [16c-SocialChoice-Python >>](03-Voting-Methods.ipynb) | [Index](README.md)"
+    "**Navigation** : [<< SC-02 Lean SocialChoice](02-Lean-SocialChoice-Formal.ipynb) | [SC-03 Methodes de vote >>](03-Voting-Methods.ipynb) | [Index](README.md)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods.ipynb
@@ -97,7 +97,7 @@
     "\n",
     "## 0. Classe Profile : Formalisation Python\n",
     "\n",
-    "Pour structurer nos manipulations de preferences, nous definissons une **classe Profile** equivalente a la structure Lean du notebook 16b. Elle encapsule :\n",
+    "Pour structurer nos manipulations de preferences, nous definissons une **classe Profile** equivalente a la structure Lean du notebook SC-02 (Lean). Elle encapsule :\n",
     "- Les **preferences individuelles** (liste d'ordres stricts)\n",
     "- Des methodes de **requete** : `prefers()`, `majority_prefers()`\n",
     "- Des **criteres d'agregation** : `is_pareto_unanimous()`, `social_ranking()`"
@@ -2273,7 +2273,7 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [<< 16b-Lean-SocialChoice](02-Lean-SocialChoice-Formal.ipynb) | [Index](README.md) | [16d-SocialChoice-SAT >>](04-Computational-Aggregation-SAT-Z3.ipynb)"
+    "**Navigation** : [<< SC-02 Lean SocialChoice](02-Lean-SocialChoice-Formal.ipynb) | [Index](README.md) | [SC-04 SAT/Z3 >>](04-Computational-Aggregation-SAT-Z3.ipynb)"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
@@ -40,7 +40,7 @@
     "ne peut satisfaire toutes les conditions.\n",
     "\n",
     "### Prerequis\n",
-    "- Notebook [16c-SocialChoice-Python](03-Voting-Methods.ipynb) (concepts du choix social)\n",
+    "- Notebook [SC-03 Methodes de vote](03-Voting-Methods.ipynb) (concepts du choix social)\n",
     "- Notions de logique propositionnelle (variables booleennes, clauses, CNF)\n",
     "\n",
     "### Duree estimee : 45 minutes"


### PR DESCRIPTION
## Objet

Reparation de **references croisees cassees / perimees** laissees par la consolidation `6fdedca7` (« refactor(gametheory): consolidate 16b-16g into SocialChoice/ sub-series »), dans le cadre du wrapup #2259 / Epic #2162. Cette consolidation a deplace les notebooks autonomes 16b-16g dans la sous-serie `SocialChoice/` (renommes `SC-01`..`SC-04`). La passe de nav-fix `f8706dfd` (#1985) a **manque plusieurs lignes**, laissant dans 5 notebooks : (a) **2 liens markdown casses** affichant litteralement `(notebook non disponible)`, et (b) des labels de navigation **perimes** pointant encore vers les anciens noms `16b/16c/16d`. Confusion active pour les etudiants pendant le cours EPITA-IS live (liens morts + noms de notebooks qui n'existent plus).

## Diagnostic (content-based)

5 notebooks, 6 lignes markdown incoherentes — chacune verifiee par lecture directe :

| Notebook | Cellule | Defaut constate | Type |
|----------|---------|-----------------|------|
| GameTheory-16-MechanismDesign | cell0 (md) | `[16b-Lean-SocialChoice (notebook non disponible)` + `[16c-SocialChoice-Python (notebook non disponible)` | **lien casse** |
| GameTheory-15b-Lean-CooperativeGames | cell44 (md, footer nav) | `[← SocialChoice/01-Arrow (notebook non disponible)` + index pointant vers `GameTheory-1-Setup.ipynb` | **lien casse** |
| SocialChoice/01-Arrow-Impossibility-Theorem | cell30 (md, footer nav) | `[<< 16b-Lean-SocialChoice]` / `[16c-SocialChoice-Python >>]` (labels perimes, cibles OK) | **label perime** |
| SocialChoice/03-Voting-Methods | cell2 (md prose) + cell42 (md, footer nav) | prose « structure Lean du notebook **16b** » ; nav `[<< 16b-...]` / `[16d-SocialChoice-SAT >>]` | **label perime** |
| SocialChoice/04-Computational-Aggregation-SAT-Z3 | cell0 (md, prereqs) | `- Notebook [16c-SocialChoice-Python]` (label perime, cible OK) | **label perime** |

## Mapping ancien -> nouveau (link-verifie, toutes cibles existent sur disque)

D'apres le contenu reel de `SocialChoice/` (verifie ce cycle, les 7 cibles `EXISTS`) :

| Ancien nom | Nouveau notebook |
|-----------|------------------|
| `16b-Lean-SocialChoice` | **SC-02** `02-Lean-SocialChoice-Formal.ipynb` |
| `16c-SocialChoice-Python` | **SC-03** `03-Voting-Methods.ipynb` |
| `16d-SocialChoice-SAT` | **SC-04** `04-Computational-Aggregation-SAT-Z3.ipynb` |

(SC-01 `01-Arrow-Impossibility-Theorem.ipynb` = fusion 16b+16c, conformement aux annotations de provenance du README — **non touchees**.)

## Correction

6 lignes markdown corrigees (1 par defaut, sauf SC-03 = 2) :

1. **GT-16 cell0** : les 2 « side tracks » casses -> pointeur vers la sous-serie `[Social Choice](SocialChoice/README.md)` + les 4 liens `SC-01`..`SC-04` valides.
2. **GT-15b cell44 (footer nav UNIQUEMENT)** : `[← SocialChoice/01-Arrow (notebook non disponible) | [Index](GameTheory-1-Setup.ipynb)` -> `[<< 15-CooperativeGames](GameTheory-15-CooperativeGames.ipynb) | [Index](README.md) | side track [Social Choice](SocialChoice/README.md)`.
3. **SC-01 cell30 (footer nav)** : labels `16b/16c` -> `SC-02 Lean SocialChoice` / `SC-03 Methodes de vote` (cibles inchangees, deja correctes).
4. **SC-03 cell2 (prose)** : « structure Lean du notebook 16b » -> « structure Lean du notebook SC-02 (Lean) ».
5. **SC-03 cell42 (footer nav)** : labels `16b/16d` -> `SC-02 Lean SocialChoice` / `SC-04 SAT/Z3`.
6. **SC-04 cell0 (prereqs)** : label `[16c-SocialChoice-Python]` -> `[SC-03 Methodes de vote]`.

`git diff --stat` = **5 fichiers, 6 insertions / 6 deletions**.

## GT-15b : SEULE la nav footer est touchee (PAS le contenu Lean)

Note explicite vu la sensibilite des variants `*-Lean-*`. La modification de GT-15b se limite a **cell44 ligne footer de navigation** (markdown pur, lien casse). Les cellules de **Correction Lean** et les enonces d'exercice (notamment cell44 prose `16b-16f reorganises en SC-01 a SC-04`, qui est une description **correcte** du reorg) **ne sont PAS touchees**. Aucune preuve formelle, aucun `*.lean`, aucun stub d'exercice modifie.

## Modernisation de labels de navigation != relabel Exercice/Exemple

Les changements `16b-Lean-SocialChoice` -> `SC-02 Lean` portent sur des **noms de notebooks dans la navigation**, pas sur des labels `Exercice`/`Exemple`. Aucun rapport avec [exercise-example-labeling.md](.claude/rules/exercise-example-labeling.md) ni avec un revert #1343 : pure modernisation de cross-reference apres un renommage de fichiers. Aucun stub rempli, aucun exemple stubbe, aucun titre Exercice/Exemple touche.

## Verification (section D — notebook PR discipline)

- **Markdown-only** : `git diff --stat` = 5 fichiers, 6 insertions / 6 deletions — exactement les 6 lignes markdown ; 0 reformatage JSON des cellules non touchees (round-trip `json.dumps(indent=1, ensure_ascii=False)` byte-exact, **trailing-newline par notebook** : SC-01 = +`\n`, les 4 autres sans) ; **cellules avant == apres** (39/45/39/43/67, re-parse JSON OK).
- **C.2 (exception markdown-only)** : « modifs uniquement markdown -> outputs precedents valides ». Aucune cellule code modifiee ; les `execution_count` des cellules code sont **identiques avant/apres** (preuve que rien de code n'a bouge). Aucun re-exec stage (C.3 : seul du source markdown a change).
- **§D exec proof = N/A justifie** : modif markdown-only (exception C.2) ; les kernels declares (`gametheory-wsl` / `lean4-wsl`) ne sont pas disponibles localement, donc une re-execution serait impossible — mais elle n'est **pas necessaire** (aucune cellule code modifiee, outputs committes valides). Pas de contournement regle F : aucun changement de code a re-executer.
- **C.1** : `raise NotImplementedError | assert False | 1/0` sur le **source des cellules code** = **0** sur les 5 notebooks (scan Python sur le source des cellules, pas grep brut sur le JSON qui matcherait le base64 d'un PNG).
- **Anti-regression** : 0 cellule `# Solution` / `# Exemple resolu` supprimee ; aucune preuve formelle, aucune implementation, aucun stub touche. Uniquement des liens/labels de navigation et 1 ligne de prose.
- **Liens valides** : les 7 cibles introduites verifiees `EXISTS` sur disque (`SocialChoice/README.md`, SC-01..04, `GameTheory-15-CooperativeGames.ipynb`, `GameTheory/README.md`) — aucun lien casse remplace par un autre lien casse. Residu `(notebook non disponible)` post-fix sur ces 5 notebooks = **0**.
- **Section B (Lean PR)** : non applicable — aucun fichier `*.lean` touche.

## TIER B — differe (re-mapping editorial, hors-scope de cette passe hygiene)

Honnetete : il reste des references `16b-16g` qui ne sont **pas** de simples liens casses mais demandent un re-mapping **editorial** (many-to-one : `16b+16e -> SC-02`, `16d+16f -> SC-04`) ou touchent du **code** (re-exec sur kernel indisponible). Differe explicitement, a traiter dans une passe dediee :
- **SC-01 cell1** : table comparative `16b(Lean)/16c(Python)/Ce notebook(16g)` (cadre comme notebooks separes alors qu'ils sont desormais fusionnes) + prerequis `16c`, `16b ou 16c`.
- **SC-01 cell30** : liste « Pour aller plus loin » (`16b-16f` -> mapping many-to-one).
- **SC-03 cell4 (commentaire code)**, **SC-04 cell50/58/62 (commentaires/prints code)** : references `16b/16d` dans du source code -> changement de code = re-exec requis sur `gametheory-wsl` indisponible.

## Scope

Un seul sujet : reparation des cross-references cassees/perimees issues de **la meme** consolidation `6fdedca7` (+ passe nav-fix `f8706dfd` incomplete). Les 5 fichiers touches font partie du **meme reseau de navigation** SocialChoice <-> GameTheory — ce n'est pas un composite multi-feature (1 feature, markdown-only, 6 lignes, << seuils G.4). Aucune collision de lane (Lean Conway/Grothendieck = po-2026 ; QC = po-2024 ; ML/RL = po-2025). Annotations de provenance du README (`16b+16c`, etc.) **deliberement preservees** (intentionnelles).

See #2259
See #2162

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
