### PR TITLE
enrich(QC): add exercises to QC-Py-35/40/41 for >=3 target (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -375,6 +375,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Fonction de reward avec penalite de drawdown",
+    "",
+    "La reward basee uniquement sur le rendement encourage les allocations trop agressives. Une penalite de drawdown rend l'agent plus prudent.",
+    "",
+    "**Objectif** : Modifier la fonction de reward pour penaliser le drawdown maximum.",
+    "",
+    "**Regles** :",
+    "- Reward = `retour_portefeuille - lambda * max_drawdown_glissant`",
+    "- `lambda` a tester : 0 (pas de penalite), 0.5, 1.0, 2.0",
+    "- Calculez le max drawdown glissant sur une fenetre de 20 pas",
+    "- Comparez les 4 configurations (reward, allocation, max DD final)",
+    "",
+    "**Indices** :",
+    "- # Indice : `running_max = np.maximum.accumulate(portfolio_value)` puis `dd = (running_max - portfolio_value) / running_max`",
+    "- # Indice : Utilisez le meme agent Q-learning pour chaque lambda"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Reward avec penalite drawdown",
+    "# TODO etudiant : Modifier la reward et tester 4 valeurs de lambda",
+    "# Indice : Reward = retour - lambda * maxDD_glissant, tester lambda=0/0.5/1.0/2.0",
+    "# Etape 1 : Implementer le calcul du drawdown glissant",
+    "# Etape 2 : Modifier la fonction de reward",
+    "# Etape 3 : Tester les 4 valeurs de lambda",
+    "# Etape 4 : Comparer les resultats",
+    "",
+    "result = None  # TODO etudiant : remplacer par la reward penalisee",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Trade-off exploration/exploitation en allocation\n",
@@ -617,6 +659,48 @@
     "        print(f\"{regime_names[regime]:>8}/{vol_names[vol]:>9} | \" +\n",
     "              \" | \".join(f\"{v:+.3f}{marker if i == best_a else '':>4}\" for i, v in enumerate(q_vals)))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Agent SARSA pour l'allocation",
+    "",
+    "Q-learning est off-policy (utilise max Q pour la mise a jour). SARSA est on-policy (utilise l'action reellement prise), ce qui le rend plus conservateur.",
+    "",
+    "**Objectif** : Implementer SARSA et comparer avec Q-learning sur le meme environnement.",
+    "",
+    "**Regles** :",
+    "- SARSA update : `Q(s,a) += alpha * (r + gamma * Q(s',a') - Q(s,a))`",
+    "- Utilisez le meme PortfolioEnv que ci-dessus",
+    "- Meme hyperparametres : alpha=0.1, gamma=0.95, epsilon=0.1",
+    "- Comparez : reward cumule, allocation finale, variance inter-episodes",
+    "",
+    "**Indices** :",
+    "- # Indice : La difference avec Q-learning est `Q(s',a')` (action prise) vs `max_a Q(s',a)` (action optimale)",
+    "- # Indice : L'action a' est choisie avec la meme politique epsilon-greedy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : SARSA on-policy",
+    "# TODO etudiant : Implementer SARSA et comparer avec Q-learning",
+    "# Indice : Meme structure que QL mais update avec Q(s',a') au lieu de max Q(s',a)",
+    "# Etape 1 : Copier la structure du TabularQLearning",
+    "# Etape 2 : Modifier update() pour SARSA",
+    "# Etape 3 : Entrainer et collecter les resultats",
+    "# Etape 4 : Comparer avec Q-learning",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'agent SARSA",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -726,6 +726,48 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Alerte de deviation backtest vs paper",
+    "",
+    "En paper trading, les performances reelles devient du backtest. Un systeme d'alerte detecte ces deviations.",
+    "",
+    "**Objectif** : Implementer un detecteur de deviation entre metriques backtest et paper trading.",
+    "",
+    "**Regles** :",
+    "- Metriques a comparer : Sharpe, max drawdown, win rate, trade frequency",
+    "- Seuils d'alerte : deviation > 20% sur n'importe quelle metrique",
+    "- Alerte critique : Sharpe paper < Sharpe backtest * 0.5",
+    "- Affichez un rapport de deviation avec niveau (OK/WARNING/CRITICAL)",
+    "",
+    "**Indices** :",
+    "- # Indice : `deviation = abs(paper - backtest) / abs(backtest)`",
+    "- # Indice : Assignez un niveau par metrique puis prenez le max"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Alerte deviation backtest vs paper",
+    "# TODO etudiant : Implementer un detecteur de deviation",
+    "# Indice : Comparer metriques, seuils 20%/50%, rapport OK/WARNING/CRITICAL",
+    "# Etape 1 : Definir les metriques backtest et paper (simulees)",
+    "# Etape 2 : Calculer les deviations",
+    "# Etape 3 : Appliquer les seuils d'alerte",
+    "# Etape 4 : Generer le rapport de deviation",
+    "",
+    "result = None  # TODO etudiant : remplacer par le detecteur de deviation",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "d5dae0f6",

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
@@ -181,6 +181,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 1 : Comparaison couts de trading Binance vs IBKR",
+    "",
+    "Les frais de transaction differents entre brokers impactent la rentabilite nette.",
+    "",
+    "**Objectif** : Calculer et comparer les couts totaux de trading sur Binance et IBKR.",
+    "",
+    "**Regles** :",
+    "- Binance : 0.1% par trade (maker/taker)",
+    "- IBKR : $0.005/share (minimum $1.00/trade) + regulatory fees",
+    "- Simulez 100 trades de tailles variables (100 a 10000 shares, prix $50 a $500)",
+    "- Pour chaque trade : calculez le cout Binance vs IBKR",
+    "- Affichez le scatter plot cout vs taille de trade et identifiez le seuil de rentabilite",
+    "",
+    "**Indices** :",
+    "- # Indice : `cout_ibkr = max(1.0, n_shares * 0.005) + regulatory_fees`",
+    "- # Indice : Le seuil est le point ou `cout_binance == cout_ibkr`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 1 : Comparaison couts Binance vs IBKR",
+    "# TODO etudiant : Calculer et comparer les couts de trading",
+    "# Indice : 0.1% Binance, $0.005/share IBKR, scatter plot",
+    "# Etape 1 : Definir les structures de frais",
+    "# Etape 2 : Generer 100 trades aleatoires",
+    "# Etape 3 : Calculer les couts pour chaque broker",
+    "# Etape 4 : Afficher et identifier le seuil de rentabilite",
+    "",
+    "result = None  # TODO etudiant : remplacer par la comparaison de couts",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "1c9c83d0",
    "source": "### Interpretation : Configuration IBKR\n\nInteractive Brokers necessite une infrastructure locale (TWS ou Gateway) qui tourne en continu, contrairement aux brokers crypto comme Binance. Cela ajoute de la complexite mais offre un acces multi-asset professionnel.",
    "metadata": {}
@@ -530,6 +573,48 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 2 : Analyse des ecarts slippage backtest vs realite",
+    "",
+    "Le slippage (ecart entre prix execute et prix attendu) est la principale source de deviation.",
+    "",
+    "**Objectif** : Modeliser l'impact du slippage sur la performance.",
+    "",
+    "**Regles** :",
+    "- Slippage modele : normal(0, sigma) avec sigma = 1/5/10/20 bps",
+    "- Pour chaque sigma : recalculez les rendements net de slippage",
+    "- Comparez : Sharpe net, PnL net, nombre de trades perdants supplementaires",
+    "- Affichez les courbes de PnL avec et sans slippage",
+    "",
+    "**Indices** :",
+    "- # Indice : `slippage = np.random.normal(0, sigma_bps * 1e-4, n_trades)`",
+    "- # Indice : Le slippage s'applique a chaque trade, pas a chaque jour"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Impact du slippage",
+    "# TODO etudiant : Modeliser et comparer 4 niveaux de slippage",
+    "# Indice : normal(0, sigma_bps*1e-4) par trade, recalcul PnL",
+    "# Etape 1 : Generer les slippages pour chaque sigma",
+    "# Etape 2 : Recalculer les rendements nets",
+    "# Etape 3 : Calculer les metriques nettes",
+    "# Etape 4 : Afficher les comparaisons",
+    "",
+    "result = None  # TODO etudiant : remplacer par l'analyse slippage",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "027dd943",
    "metadata": {
     "papermill": {
@@ -740,6 +825,48 @@
     "print(\"Ecarts backtest vs paper trading (IBKR):\")\n",
     "print(ecarts_ibkr.to_string(index=False))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "---",
+    "### Exercice 3 : Risk management overlay pour paper trading",
+    "",
+    "Avant de passer au live trading, ajoutez un module de risk management au systeme.",
+    "",
+    "**Objectif** : Implementer un module de risk management avec 3 gardes-fous.",
+    "",
+    "**Regles** :",
+    "- Garde-fou 1 : maximum position size = 10% du portefeuille par actif",
+    "- Garde-fou 2 : stop-loss journalier = -2% du portefeuille",
+    "- Garde-fou 3 : circuit breaker = arreter le trading si 3 pertes consecutives",
+    "- Simulez un jour de trading avec des ordres aleatoires et montrez quelles gardes s'activent",
+    "",
+    "**Indices** :",
+    "- # Indice : Chaque garde-fou est une fonction `check(state) -> (bool, reason)`",
+    "- # Indice : Le circuit breaker maintient un compteur de pertes consecutives"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Risk management overlay",
+    "# TODO etudiant : Implementer 3 gardes-fous de risk management",
+    "# Indice : max position, stop-loss, circuit breaker",
+    "# Etape 1 : Implementer la garde position max",
+    "# Etape 2 : Implementer la garde stop-loss",
+    "# Etape 3 : Implementer la garde circuit breaker",
+    "# Etape 4 : Simuler un jour de trading avec les gardes",
+    "",
+    "result = None  # TODO etudiant : remplacer par le risk management",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Batch 7 — final QC-Py gap fill (excluding QC-Py-04 blocked by #2255). 3 notebooks, 6 new exercises.

### Notebooks modified (3)

| Notebook | Added | Total | Topics |
|----------|-------|-------|--------|
| QC-Py-35 RL Portfolio | +2 | 3 | SARSA on-policy agent, Reward with drawdown penalty |
| QC-Py-40 PaperTrading Binance | +1 | 3 | Backtest vs paper deviation alert system |
| QC-Py-41 PaperTrading IBKR | +3 | 3 | Binance vs IBKR cost comparison, Slippage impact modeling, Risk management overlay |

### Validation

- C.1 check: PASS (no forbidden patterns)
- All stubs: `result = None  # TODO etudiant` + `print("Exercice a completer")`
- 253 insertions, 0 deletions

### QC-Py #2161 Status

After this PR + pending batches 5/6: **33/34 non-Setup QC-Py notebooks at >=3 exercises**. Only remaining: QC-Py-04 (blocked by Chrome/QC Cloud, #2255).