### PR TITLE
fix(sudoku): replace hardcoded paths with Path.cwd() in 3 notebooks

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
@@ -148,7 +148,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ATTENTION: Dossier Puzzles non trouvé à \\home\\dorian\\cours\\cours_fork\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
+      "ATTENTION: Dossier Puzzles non trouve\n"
      ]
     }
    ],
@@ -158,7 +158,7 @@
     "from pathlib import Path\n",
     "\n",
     "# Définir le chemin absolu vers le dossier Puzzles\n",
-    "NOTEBOOK_DIR = Path(r\"/home/dorian/cours/cours_fork/MyIA.AI.Notebooks/Sudoku/\")\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
     "PUZZLES_DIR = NOTEBOOK_DIR / \"Puzzles\"\n",
     "\n",
     "# Vérifier que le dossier existe\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -145,7 +145,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ATTENTION: Dossier Puzzles non trouve a C:\\Users\\Risto\\Documents\\Evariste\\Ecole\\Epita\\2025-2026\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
+      "ATTENTION: Dossier Puzzles non trouve\n"
      ]
     }
    ],
@@ -154,7 +154,7 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "NOTEBOOK_DIR = Path(r\"C:\\Users\\Risto\\Documents\\Evariste\\Ecole\\Epita\\2025-2026\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\")\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
     "PUZZLES_DIR = NOTEBOOK_DIR / \"Puzzles\"\n",
     "\n",
     "if PUZZLES_DIR.exists():\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-8-HumanStrategies-Python.ipynb
@@ -142,7 +142,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ATTENTION: Dossier Puzzles non trouve a \\home\\nch\\ING2\\ProgContraintes\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
+      "ATTENTION: Dossier Puzzles non trouve\n"
      ]
     }
    ],
@@ -151,7 +151,7 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "NOTEBOOK_DIR = Path(r\"/home/nch/ING2/ProgContraintes/CoursIA/MyIA.AI.Notebooks/Sudoku\")\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
     "PUZZLES_DIR = NOTEBOOK_DIR / \"Puzzles\"\n",
     "\n",
     "if PUZZLES_DIR.exists():\n",


### PR DESCRIPTION
## Summary

Replace hardcoded Windows/Linux paths with  in 3 Sudoku notebooks, fixing cross-platform portability issue.

### Files changed
- `Sudoku-3-Genetic-Python.ipynb`: `/home/dorian/cours/cours_fork/...` -> `Path.cwd()`
- `Sudoku-6-AIMA-CSP-Python.ipynb`: `C:\Users\Risto\Documents\...` -> `Path.cwd()`
- `Sudoku-8-HumanStrategies-Python.ipynb`: `/home/nch/ING2/ProgContraintes/...` -> `Path.cwd()`

### Validation
- Source: `NOTEBOOK_DIR = Path(r"...")` -> `NOTEBOOK_DIR = Path.cwd()` (cross-platform)
- Output: removed hardcoded path from warning messages
- All other Sudoku notebooks already use `Path.cwd()` (verified)
- Diff: 3 files, 6 insertions, 6 deletions (minimal, targeted)

See #2319