### PR TITLE
enrich(SymbolicAI): add exercises to 3 notebooks for >=3 target (See #2260)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -1767,6 +1767,84 @@
   },
   {
    "cell_type": "markdown",
+   "id": "p10-ex2-md",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : Valider un domaine PDDL genere par LLM\n",
+    "\n",
+    "Ecrivez un validateur qui verifie si un domaine PDDL genere par LLM est correct.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Verifiez que chaque action reference des predicats declares\n",
+    "- Verifiez que les parametres d'action existent dans \n",
+    "- Testez votre validateur sur  (fourni dans la section 5) et sur un domaine contenant une erreur intentionnelle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "p10-ex2-stub",
+   "metadata": {},
+   "source": [
+    "# Exercice 2 : Valider un domaine PDDL genere par LLM\n",
+    "# TODO etudiant : implementez validate_domain(pddl_code: str) -> tuple[bool, list[str]]\n",
+    "# Etape 1 : verifier que chaque predicat dans les actions est declare dans :predicates\n",
+    "# Etape 2 : verifier que les parametres dans preconditions/effets existent dans :parameters\n",
+    "# Etape 3 : retourner (True, []) si valide, (False, [erreurs]) sinon\n",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": 17,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p10-ex3-md",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Plan Repair symbolique\n",
+    "\n",
+    "Un plan partiel a echoue a l'etape 2 (le robot ne peut pas ramasser l'objet car il n'est pas libre).\n",
+    "Ecrivez une fonction  qui identifie la precondition violee et propose une action corrective.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Utilisez les structures ,  et  de l'exemple guide\n",
+    "- Simulez l'execution pas-a-pas et detectez la premiere precondition non satisfaite\n",
+    "- Proposez une action corrective (insertion d'une action  avant le )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "p10-ex3-stub",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Plan Repair symbolique\n",
+    "# TODO etudiant : implementez repair_plan_symbolic(plan, domain, initial_state, goal)\n",
+    "# Etape 1 : simulez l'execution du plan et detectez la premiere erreur\n",
+    "# Etape 2 : identifiez la precondition manquante\n",
+    "# Etape 3 : cherchez une action corrective (dans DOMAIN[\"actions\"]) qui retablit la precondition\n",
+    "# Etape 4 : inserez l'action corrective et re-validez le plan\n",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": 18,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6c2833b7",
    "metadata": {
     "papermill": {

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-11-Unified-Planning.ipynb
@@ -2233,6 +2233,47 @@
     "\n",
     "print(\"Exercice a completer\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "p11-ex3-md",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : Export PDDL et re-import\n",
+    "\n",
+    "Reprenez le probleme de navigation robot defini dans la section 2 et :\n",
+    "1. Exportez-le en PDDL avec PDDLWriter\n",
+    "2. Relisez-le avec PDDLReader\n",
+    "3. Verifiez que le probleme re-importe est equivalent (meme nombre d actions, objets, buts)\n",
+    "4. (Bonus) Modifiez le domaine PDDL exporte a la main (ajoutez une action) et re-importez\n",
+    "\n",
+    "**Indice** : Utilisez le code de la section 5 comme point de depart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "p11-ex3-stub",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Export PDDL et re-import\n",
+    "# TODO etudiant : exportez problem en PDDL, relisez, et verifiez l equivalente\n",
+    "# Etape 1 : utiliser PDDLWriter pour obtenir le domaine et le probleme\n",
+    "# Etape 2 : ecrire dans des fichiers temporaires et relire avec PDDLReader\n",
+    "# Etape 3 : comparer les proprietes (actions, objets, buts)\n",
+    "from unified_planning.io import PDDLWriter, PDDLReader\n",
+    "import tempfile, os\n",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": 18,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
@@ -1794,6 +1794,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "sl1-ex-find-s-md",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : Implementer l algorithme Find-S\n",
+    "\n",
+    "L algorithme **Find-S** est complementaire au Version Space : il trouve l hypothese la plus\n",
+    "specifique consistante avec les exemples positifs.\n",
+    "\n",
+    "**Etapes** :\n",
+    "1. Initialisez h = [0, 0, 0, 0, 0, 0] (hypothese la plus specifique)\n",
+    "2. Pour chaque exemple positif, generalisez h pour couvrir cet exemple\n",
+    "3. Ignorez les exemples negatifs\n",
+    "\n",
+    "**Indice** : Pour chaque attribut, si h[i] != example[i], remplacez h[i] par None (generalisation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "sl1-ex-find-s-code",
+   "metadata": {},
+   "source": [
+    "# Exercice 3 : Implementer l algorithme Find-S\n",
+    "# TODO etudiant : implementez find_s(examples, labels) qui retourne l hypothese la plus specifique\n",
+    "# Etape 1 : initialiser h a [0, 0, 0, 0, 0, 0]\n",
+    "# Etape 2 : pour chaque exemple positif (labels[i] == 1), generaliser h\n",
+    "# Etape 3 : retourner h\n",
+    "def find_s(examples, labels):\n",
+    "    pass  # TODO etudiant\n",
+    "    return None\n",
+    "\n",
+    "print(\"Exercice a completer\")"
+   ],
+   "execution_count": 13,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a464171c",
    "metadata": {
     "papermill": {


### PR DESCRIPTION
## Summary

Adds exercise stubs to 3 SymbolicAI notebooks that were below the >=3 exercise threshold (convention #2161, audit #2260).

### Changes

| Notebook | Before | After | Exercises added |
|----------|--------|-------|-----------------|
| Planners-10-LLM-Planning | 1 ex | 3 ex | +2 (Validate PDDL domain, Plan repair symbolic) |
| Planners-11-Unified-Planning | 2 ex | 3 ex | +1 (PDDL export and re-import) |
| SL-1-LogicalLearning | 2 ex | 3 ex | +1 (Find-S algorithm implementation) |

### Audit report (63 notebooks, non-Lean SymbolicAI)

| Series | CONFORME | EXEMPT | NON-CONFORME (before) |
|--------|----------|--------|----------------------|
| SmartContracts | 25 | 2 (setup) | 0 |
| SemanticWeb | 14 | 1 (setup) | 0 |
| Tweety | 9 | 1 (setup) | 0 |
| Planners | 11 | 1 (setup) | 4 -> 0 |
| SymbolicLearning | 7 | 0 | 1 -> 0 |

### Compliance

- All stubs use `pass`/`return None`/`print("Exercice a completer")` (C.1)
- 0 `raise NotImplementedError` / `assert False` / `1/0` across all notebooks
- All new code cells have `execution_count` + `outputs` (C.2)
- 164 insertions, 0 deletions (pure enrichment)

See #2260