### PR TITLE
fix(Probas/PyMC): replace stale _python_port references with PyMC/ (See #2048)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
@@ -705,8 +705,8 @@
    "end_time": "2026-05-11T08:14:18.541980+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-1-Setup.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-1-Setup.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb",
    "parameters": {},
    "start_time": "2026-05-11T08:13:31.437031+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb
@@ -1902,8 +1902,8 @@
    "end_time": "2026-06-03T00:03:34.417350+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-10-Crowdsourcing.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-10-Crowdsourcing_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Crowdsourcing_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:21.157878+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb
@@ -1638,8 +1638,8 @@
    "end_time": "2026-06-03T00:58:17.506083+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-14-Decision-Utility-Foundations.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-14-Decision-Utility-Foundations.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Decision-Utility-Foundations.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:56:50.901874+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb
@@ -2284,8 +2284,8 @@
    "end_time": "2026-06-03T00:58:03.602449+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-15-Decision-Utility-Money.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-15-Decision-Utility-Money.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Decision-Utility-Money.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:56:50.901874+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb
@@ -2175,8 +2175,8 @@
    "end_time": "2026-06-03T00:58:29.996570+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-16-Decision-Multi-Attribute.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-16-Decision-Multi-Attribute.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Decision-Multi-Attribute.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:56:50.901874+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb
@@ -1999,8 +1999,8 @@
    "end_time": "2026-06-03T00:58:24.359205+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-17-Decision-Networks.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-17-Decision-Networks.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Decision-Networks.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:56:50.901874+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-18 : Valeur de l'Information\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/_python_port/PyMC-18-Decision-Value-Information.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -2063,8 +2063,8 @@
    "end_time": "2026-06-03T00:58:00.290487+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-18-Decision-Value-Information.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-18-Decision-Value-Information.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Decision-Value-Information.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:57:05.708994+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-19 : Systemes Experts et Decisions Robustes\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/_python_port/PyMC-19-Decision-Expert-Systems.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -2377,8 +2377,8 @@
    "end_time": "2026-06-03T00:58:19.572016+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-19-Decision-Expert-Systems.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-19-Decision-Expert-Systems.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Decision-Expert-Systems.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:57:05.709994+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "# PyMC-20 : MDPs, Bandits et POMDPs\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/_python_port/PyMC-20-Decision-Sequential.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jsboige/CoursIA/blob/main/MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb)\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -4314,8 +4314,8 @@
    "end_time": "2026-06-03T01:01:21.749301+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-20-Decision-Sequential.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-20-Decision-Sequential.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-20-Decision-Sequential.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:57:05.836926+00:00",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb
@@ -1937,8 +1937,8 @@
    "end_time": "2026-06-03T00:09:13.443623+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-8-Model-Selection.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-8-Model-Selection_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-Model-Selection_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:21.111595+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb
@@ -1442,8 +1442,8 @@
    "end_time": "2026-06-03T00:07:45.096022+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-9-Topic-Models.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Probas/_python_port/PyMC-9-Topic-Models_output.ipynb",
+   "input_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models.ipynb",
+   "output_path": "MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Topic-Models_output.ipynb",
    "parameters": {},
    "start_time": "2026-06-03T00:03:21.120320+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/Probas/requirements.txt
+++ b/MyIA.AI.Notebooks/Probas/requirements.txt
@@ -3,13 +3,13 @@
 #
 # Note: 20 notebooks are C# (.NET Interactive) using Infer.NET.
 # Python notebooks: Pyro_RSA_Hyperbole, PyMC-HMM-Trading-Alpha,
-#   and _python_port/PyMC-* series (20 notebooks).
+#   and PyMC/PyMC-* series (20 notebooks).
 
 # === Pyro (RSA Hyperbole) ===
 pyro-ppl>=1.8                # Probabilistic programming (Pyro)
 torch>=2.0                   # PyTorch (Pyro backend)
 
-# === PyMC (_python_port/ series + HMM Trading Alpha) ===
+# === PyMC (PyMC/ series + HMM Trading Alpha) ===
 pymc>=5.0                    # Probabilistic programming (PyMC)
 arviz>=0.14                  # Bayesian diagnostics & visualization
 


### PR DESCRIPTION
## Summary

Replace 27 stale `_python_port/` path references across 12 files in the Probas/PyMC series.

The directory was renamed from `_python_port` to `PyMC` in a previous PR, but these references in Papermill metadata, Colab badge links, and requirements.txt comments were never updated.

## Changes

- **11 notebooks**: Papermill `input_path`/`output_path` metadata updated from `_python_port/` to `PyMC/`
- **3 notebooks** (PyMC-18, 19, 20): Colab badge links updated to use correct `PyMC/` path
- **requirements.txt**: Comments updated to reference `PyMC/` instead of `_python_port/`

## Files changed

- `PyMC-1-Setup.ipynb` (2 replacements)
- `PyMC-8-Model-Selection.ipynb` (2 replacements)
- `PyMC-9-Topic-Models.ipynb` (2 replacements)
- `PyMC-10-Crowdsourcing.ipynb` (2 replacements)
- `PyMC-14-Decision-Utility-Foundations.ipynb` (2 replacements)
- `PyMC-15-Decision-Utility-Money.ipynb` (2 replacements)
- `PyMC-16-Decision-Multi-Attribute.ipynb` (2 replacements)
- `PyMC-17-Decision-Networks.ipynb` (2 replacements)
- `PyMC-18-Decision-Value-Information.ipynb` (3 replacements)
- `PyMC-19-Decision-Expert-Systems.ipynb` (3 replacements)
- `PyMC-20-Decision-Sequential.ipynb` (3 replacements)
- `requirements.txt` (2 replacements)

## Verification

- `grep -r "_python_port" Probas/` returns 0 results
- All 12 JSON files validated (0 parse errors)
- No code changes — metadata/comments only

See #2048