### PR TITLE
fix(search): resolve hardcoded image path in App-9b EdgeDetection C# notebook

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb
@@ -3399,7 +3399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b49cecc2",
    "metadata": {
     "dotnet_interactive": {
@@ -3423,31 +3423,8 @@
     },
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "Error",
-     "evalue": "System.IO.FileNotFoundException: D:\\dev\\CoursIA-2\\MRI_Prostate_Cancer.jpg\r\n   at System.Drawing.Image.FromFile(String filename, Boolean useEmbeddedColorManagement) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 95\r\n   at System.Drawing.Image.FromFile(String filename) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 86\r\n   at Submission#8.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-     "output_type": "error",
-     "traceback": [
-      "System.IO.FileNotFoundException: D:\\dev\\CoursIA-2\\MRI_Prostate_Cancer.jpg\r\n   at System.Drawing.Image.FromFile(String filename, Boolean useEmbeddedColorManagement) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 95\r\n   at System.Drawing.Image.FromFile(String filename) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 86\r\n   at Submission#8.<<Initialize>>d__0.MoveNext()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)",
-      "   at System.Drawing.Image.FromFile(String filename, Boolean useEmbeddedColorManagement) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 95",
-      "   at System.Drawing.Image.FromFile(String filename) in /_/src/System.Drawing.Common/src/System/Drawing/Image.cs:line 86",
-      "   at Submission#8.<<Initialize>>d__0.MoveNext()",
-      "--- End of stack trace from previous location ---",
-      "   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.RunSubmissionsAsync[TResult](ImmutableArray`1 precedingExecutors, Func`2 currentExecutor, StrongBox`1 exceptionHolderOpt, Func`2 catchExceptionOpt, CancellationToken cancellationToken)"
-     ]
-    }
-   ],
-   "source": [
-    "var imagePath = @\"MRI_Prostate_Cancer.jpg\"; \n",
-    "var originalImage = (Bitmap)Image.FromFile(imagePath);\n",
-    "\n",
-    "var fitness = new EdgeFitness(originalImage);\n",
-    "\n",
-    "// Test d'un chromosome\n",
-    "var chromosome = new EdgeChromosome(20);\n",
-    "Console.WriteLine($\"Score de fitness : {fitness.Evaluate(chromosome)}\");\n"
-   ]
+   "outputs": [],
+   "source": "var imagePath = Path.Combine(Directory.GetCurrentDirectory(), \"MyIA.AI.Notebooks\", \"Search\", \"MRI_Prostate_Cancer.jpg\");\nif (!File.Exists(imagePath))\n{\n    // Fallback: try relative path from notebook directory\n    var altPath = @\"../../MRI_Prostate_Cancer.jpg\";\n    if (File.Exists(altPath)) imagePath = Path.GetFullPath(altPath);\n}\nvar originalImage = (Bitmap)Image.FromFile(imagePath);\n\nvar fitness = new EdgeFitness(originalImage);\n\n// Test d'un chromosome\nvar chromosome = new EdgeChromosome(20);\nConsole.WriteLine($\"Score de fitness : {fitness.Evaluate(chromosome)}\");"
   },
   {
    "cell_type": "markdown",
@@ -3542,39 +3519,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": [
-    "// Charger une image de test\n",
-    "var imagePath = @\"MRI_Prostate_Cancer.jpg\"; \n",
-    "var originalImage = (Bitmap)Bitmap.FromFile(imagePath);\n",
-    "\n",
-    "// await SkiaUtils.ShowImage(imagePath, originalImage.Width, originalImage.Height);\n",
-    "\n",
-    "// Initialiser la fonction de fitness\n",
-    "var fitness = new EdgeFitness(originalImage);\n",
-    "await fitness.DisplayImagesAsync();\n",
-    "\n",
-    "// Initialiser un chromosome\n",
-    "var chromosome = new EdgeChromosome(20); // Taille des chromosomes\n",
-    "\n",
-    "// Initialiser la population\n",
-    "var population = new Population(50, 100, chromosome);\n",
-    "\n",
-    "// Configurer les opérateurs génétiques\n",
-    "var selection = new EliteSelection();\n",
-    "var crossover = new UniformCrossover();\n",
-    "var mutation = new ReverseSequenceMutation();\n",
-    "\n",
-    "// Configurer l'algorithme génétique\n",
-    "var ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)\n",
-    "{\n",
-    "    Termination = new GenerationNumberTermination(100)\n",
-    "\n",
-    "\n",
-    "};\n",
-    "\n",
-    "\n",
-    "Console.WriteLine(\"Algorithme génétique configuré.\");\n"
-   ]
+   "source": "// Charger une image de test\nvar imagePath = Path.Combine(Directory.GetCurrentDirectory(), \"MyIA.AI.Notebooks\", \"Search\", \"MRI_Prostate_Cancer.jpg\");\nif (!File.Exists(imagePath))\n{\n    var altPath = @\"../../MRI_Prostate_Cancer.jpg\";\n    if (File.Exists(altPath)) imagePath = Path.GetFullPath(altPath);\n}\nvar originalImage = (Bitmap)Bitmap.FromFile(imagePath);\n\n// await SkiaUtils.ShowImage(imagePath, originalImage.Width, originalImage.Height);\n\n// Initialiser la fonction de fitness\nvar fitness = new EdgeFitness(originalImage);\nawait fitness.DisplayImagesAsync();\n\n// Initialiser un chromosome\nvar chromosome = new EdgeChromosome(20); // Taille des chromosomes\n\n// Initialiser la population\nvar population = new Population(50, 100, chromosome);\n\n// Configurer les opérateurs génétiques\nvar selection = new EliteSelection();\nvar crossover = new UniformCrossover();\nvar mutation = new ReverseSequenceMutation();\n\n// Configurer l'algorithme génétique\nvar ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)\n{\n    Termination = new GenerationNumberTermination(100)\n\n\n};\n\n\nConsole.WriteLine(\"Algorithme génétique configuré.\");"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Fix `System.IO.FileNotFoundException` in App-9b-EdgeDetection-CSharp.ipynb where `MRI_Prostate_Cancer.jpg` was referenced as a bare filename, but the image lives in `Search/` while the notebook is in `Search/Applications/Hybrid/`.

## Fix
- Use `Path.Combine(Directory.GetCurrentDirectory(), ...)` with the correct relative path to the Search directory
- Add fallback: try `../../MRI_Prostate_Cancer.jpg` relative to notebook directory

## Validation
- Source-only fix (2 cells modified). No re-execution needed (notebook requires Windows + Emgu.CV).
- Pattern consistent with #2328 (Sudoku paths fix) and #2314-#2319 (multi-platform compat epic).

See #2314