### PR TITLE
docs(qc): document qc-mcp-lite .mcp.json config (See #1407)

### DIFF
--- a/docs/quantconnect.md
+++ b/docs/quantconnect.md
@@ -66,6 +66,31 @@ Toute modification d'une strategie QC (main.py, parametres, periodes) **DOIT** e
 }
 ```
 
+### Alternative legere : `qc-mcp-lite` (~5k tokens vs ~40k)
+
+Le MCP Docker officiel charge un schema d'outils volumineux (~40k tokens). Pour les workflows de backtest standard, le depot fournit un wrapper Python leger **`scripts/qc-mcp-lite/server.py`** (~10 outils, schema <5k tokens) qui re-expose l'API QC v2 sans conteneur Docker.
+
+Outils exposes : `create_compile`, `read_compile`, `create_backtest`, `read_backtest` (Sharpe/CAGR/MaxDD), `list_backtests`, `list_projects`, `read_project`, `read_file`, `create_file`, `update_file_contents`. Auth = pattern QC v2 (`SHA256(token:timestamp)` + header `Basic userId:hash`). Rate limiting 10 appels/min applique in-process (meme limite fleet-wide).
+
+Config `.mcp.json` (remplace l'entree Docker `qc-mcp` ; secrets dans `.env` gitignore, **JAMAIS inline**) :
+
+```json
+{
+  "mcpServers": {
+    "qc-mcp-lite": {
+      "command": "python",
+      "args": ["scripts/qc-mcp-lite/server.py"],
+      "env": {
+        "QC_API_USER_ID": "<voir dashboard RooSync>",
+        "QC_API_ACCESS_TOKEN": "<voir dashboard RooSync>"
+      }
+    }
+  }
+}
+```
+
+Verification rapide : `python -c "from server import list_projects; print(list_projects())"` depuis `scripts/qc-mcp-lite/`. Procedure complete (setup `.env`, retour au MCP Docker complet) : [`scripts/qc-mcp-lite/README.md`](../scripts/qc-mcp-lite/README.md).
+
 ### Rate limiting strict
 
 MAX 10 appels/minute entre TOUS les agents. Avant de lancer un backtest, poster sur le dashboard. Un seul agent a la fois sur l'API QC.


### PR DESCRIPTION
## Contexte

Audit de cloture de #1407 (QC MCP leger) declenche par #2211 (prevention auto-close premature). Le wrapper `scripts/qc-mcp-lite/server.py` est livre et fonctionnel (10 outils, auth QC v2, rate-limit in-process) et **auto-documente dans son propre `scripts/qc-mcp-lite/README.md`** (sections Setup `.env` + Configure `.mcp.json` + Verify).

Mais le **critere 5** de #1407 demandait explicitement : *« config `.mcp.json` documentee dans `docs/quantconnect.md` »*. Verification mecanique sur `origin/main` : `grep -i "qc-mcp-lite" docs/quantconnect.md` = **0 resultat**. Le critere 5 etait donc **genuinement non rempli** — le wrapper n'etait reference que dans son README local, pas dans la doc QC centrale.

## Changement

Ajoute une sous-section **`### Alternative legere : qc-mcp-lite`** dans `docs/quantconnect.md`, sous la section MCP Docker existante :
- rationale (~5k tokens vs ~40k pour le Docker officiel) + emplacement du wrapper ;
- liste des 10 outils exposes (dont `create_backtest`/`read_backtest` Sharpe/CAGR/MaxDD) + schema auth QC v2 ;
- bloc config `.mcp.json` de la variante lite (secrets en placeholder `<voir dashboard RooSync>`, **aucun litteral**) ;
- commande de verification rapide + lien relatif vers `scripts/qc-mcp-lite/README.md`.

## Verification

- `git diff --stat` : **1 fichier, +25 lignes**, `docs/quantconnect.md` uniquement.
- Aucun notebook, aucun catalogue touche (doc-only → exempt C.2/C.3).
- Aucun secret inline (placeholders seulement ; secrets restent en `.env` gitignore).
- Lien relatif `../scripts/qc-mcp-lite/README.md` valide (cible existe sur main).

## Note de cloture #1407

Ce PR remplit le critere 5. Le **critere 2** (boucle `create_compile -> create_backtest -> read_backtest` verifiee avec Sharpe/CAGR/MaxDD reels) n'a pas de preuve d'execution localisee → #1407 est **rouvert** pour ce seul point residuel (verification live a dispatcher quand l'acces QC/Docker est disponible). Cloture non-complaisante : la doc est livree ici, la verification live reste tracee.

See #1407
See #2211

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
