### PR TITLE
fix(sc): add native anvil management for macOS/Linux setup (See #2317)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -129,18 +129,42 @@ SmartContracts/
 
 ## Demarrage Rapide
 
+### macOS / Linux (natif)
+
 ```bash
-# 1. Installer les dependances Python
-pip install -r requirements.txt
+# Setup complet en une commande (Foundry + Python + kernel Jupyter)
+bash scripts/setup.sh
 
-# 2. Installer Foundry
-curl -L https://foundry.paradigm.xyz | bash
-foundryup
+# Ou via l'orchestrateur Python
+python setup_env.py --setup
 
-# 3. Lancer anvil (blockchain locale)
-anvil  # dans un terminal separe
+# Lancer anvil (blockchain locale)
+python setup_env.py --start-anvil
+# ou directement: anvil
 
-# 4. Commencer par SC-0-Cypherpunk-Origins
+# Ouvrir les notebooks et selectionner le kernel "Python (SmartContracts + Foundry)"
+```
+
+### Windows (via WSL)
+
+```bash
+# Depuis PowerShell, lance le setup dans WSL Ubuntu
+wsl -d Ubuntu -- bash /mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
+
+# Ou alternative en 2 etapes (WSL puis PowerShell)
+# Etape 1: dans WSL Ubuntu
+bash scripts/setup_wsl_smartcontracts.sh
+# Etape 2: dans PowerShell
+.\scripts\setup_wsl_kernel.ps1
+
+# Lancer anvil
+python setup_env.py --start-anvil
+```
+
+### Verifier l'installation
+
+```bash
+python setup_env.py --check
 ```
 
 ## Ressources Externes

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/README.md
@@ -16,6 +16,22 @@ Ce repertoire contient les scripts de configuration de l'environnement pour la s
   wsl -d Ubuntu -- bash /mnt/d/CoursIA/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/scripts/setup.sh
   ```
 
+### Setup alternatif (Python)
+
+- `setup_env.py` (niveau parent) — Orchestrateur Python cross-plateforme. Detecte l'OS, installe les dependances, gere le cycle de vie anvil (natif sur Mac/Linux, via WSL sur Windows).
+
+  ```bash
+  # Verification complete de l'environnement
+  python setup_env.py --check
+
+  # Setup complet (Mac/Linux natif, Windows via WSL)
+  python setup_env.py --setup
+
+  # Demarrer/Arreter anvil
+  python setup_env.py --start-anvil
+  python setup_env.py --stop-anvil
+  ```
+
 ### Setup WSL (Windows uniquement)
 
 - [setup_wsl_smartcontracts.sh](setup_wsl_smartcontracts.sh) — Variante WSL-only de `setup.sh` : installe Foundry, le venv Python avec les paquets Linux-only, et le wrapper de kernel `~/.smartcontracts-kernel-wrapper.sh` qui gere la conversion des chemins Windows -> WSL (workaround pour le bug Jupyter qui mange les backslashes).

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/setup_env.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/setup_env.py
@@ -37,6 +37,7 @@ Known limitations:
 import argparse
 import importlib
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -316,6 +317,50 @@ def stop_anvil_wsl() -> bool:
         return False
 
 
+def start_anvil_native(port: int = 8545) -> bool:
+    """Start anvil natively on Mac/Linux as a background process."""
+    if check_anvil_running():
+        print(f"  [OK] anvil already running on port {port}")
+        return True
+
+    anvil_path = shutil.which("anvil")
+    if not anvil_path:
+        print("  [FAIL] anvil not found on PATH. Install Foundry first:")
+        print("    curl -L https://foundry.paradigm.xyz | bash && foundryup")
+        return False
+
+    print(f"  Starting anvil on port {port}...")
+    subprocess.Popen(
+        [anvil_path, "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    import time
+    for _ in range(10):
+        time.sleep(0.5)
+        if check_anvil_running():
+            print(f"  [OK] anvil started on localhost:{port}")
+            return True
+
+    print("  [FAIL] anvil did not start. Check if port is available.")
+    return False
+
+
+def stop_anvil_native() -> bool:
+    """Stop anvil running natively on Mac/Linux."""
+    import signal
+    try:
+        result = subprocess.run(
+            ["pkill", "-f", "anvil"],
+            capture_output=True, timeout=5
+        )
+        print("  anvil stopped")
+        return True
+    except Exception:
+        return False
+
+
 # =============================================================================
 # INSTALL
 # =============================================================================
@@ -554,11 +599,17 @@ Examples:
 
     # ---- ANVIL MANAGEMENT ----
     if args.start_anvil:
-        start_anvil_wsl()
+        if sys.platform == "win32":
+            start_anvil_wsl()
+        else:
+            start_anvil_native()
         return
 
     if args.stop_anvil:
-        stop_anvil_wsl()
+        if sys.platform == "win32":
+            stop_anvil_wsl()
+        else:
+            stop_anvil_native()
         return
 
     # ---- CHECK MODE ----


### PR DESCRIPTION
## Summary

Add cross-platform anvil lifecycle management and improved setup documentation for the SmartContracts series, enabling full native execution on macOS/Linux without WSL.

## Changes

### `setup_env.py` — Native anvil management (+55 lines)
- **`start_anvil_native()`**: Starts anvil via `shutil.which("anvil")` on Mac/Linux, with same readiness check as WSL version
- **`stop_anvil_native()`**: Stops anvil via `pkill -f anvil` on Mac/Linux
- **`--start-anvil` / `--stop-anvil`** now dispatches to native or WSL based on `sys.platform`

### `README.md` — Platform-specific quickstart
- Replaced single-platform quickstart with explicit **macOS/Linux** and **Windows** sections
- Added `python setup_env.py --check` verification step

### `scripts/README.md` — Document `setup_env.py` orchestrator
- Added section documenting the Python orchestrator (`--check`, `--setup`, `--start-anvil`, `--stop-anvil`)

## Verification

- `ast.parse()` — syntax OK
- Logic review: `sys.platform` guards ensure Windows-only WSL code never runs on Mac/Linux

## Acceptance Criteria (#2317)

| Criterion | Status |
|-----------|--------|
| Setup SmartContracts complet sur macOS/Linux sans WSL | **Partiel** — setup.sh + forge_helper.py already handle Mac/Linux natively; anvil management now native too |
| Sous Windows : inchange | **Verified** — all new code gated by `sys.platform` |
| Un notebook SC execute sur cible non-Windows | **Requires macOS/Linux machine to validate** — code paths verified, no WSL dependency in Mac/Linux branch |

## Related

- See #2317 (SmartContracts multiplatform setup)
- Parent Epic #2314 (macOS/Linux compatibility)