### PR TITLE
fix(GameTheory): renumber GT-11 exercises 2-3-4-5 to 1-2-3-4

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-11-BayesianGames.ipynb
@@ -1808,7 +1808,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Enchere All-Pay\n",
+    "### Exercice 1 : Enchere All-Pay\n",
     "\n",
     "Analysez l'enchere all-pay ou :\n",
     "- 2 joueurs, valeurs privees $v_i \\sim U[0,1]$\n",
@@ -1851,7 +1851,7 @@
     }
    ],
    "source": [
-    "# Exercice 2 : Enchere All-Pay Bayesienne\n",
+    "# Exercice 1 : Enchere All-Pay Bayesienne\n",
     "# ======================================\n",
     "# Regles :\n",
     "#   - 2 joueurs, valeurs privees v_i ~ U[0,1]\n",
@@ -1898,7 +1898,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Mecanisme de Revelation - Enchere de Vickrey\n",
+    "### Exercice 2 : Mecanisme de Revelation - Enchere de Vickrey\n",
     "\n",
     "L'enchere de **Vickrey** (second-price sealed bid) est un mecanisme ou :\n",
     "- Chaque encherisseur soumet une offre en pli scelle\n",
@@ -1960,7 +1960,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Mecanisme de Revelation - Enchere de Vickrey\n",
+    "# Exercice 2 : Mecanisme de Revelation - Enchere de Vickrey\n",
     "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -2000,7 +2000,7 @@
     "tags": []
    },
    "source": [
-    "### Exercice 4 : Selection Adverse (Akerlof)\n",
+    "### Exercice 3 : Selection Adverse (Akerlof)\n",
     "\n",
     "Marche de voitures d'occasion (Akerlof):\n",
     "- Qualite $q \\sim U[0,1]$\n",
@@ -2046,7 +2046,7 @@
     }
    ],
    "source": [
-    "# Exercice 4 : Selection Adverse (Akerlof)\n",
+    "# Exercice 3 : Selection Adverse (Akerlof)\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -2083,7 +2083,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Exercice 5 : Calcul d'un BNE (Bayesian Nash Equilibrium)\n",
+    "### Exercice 4 : Calcul d'un BNE (Bayesian Nash Equilibrium)\n",
     "\n",
     "**Objectifs** :\n",
     "1. Modeliser un jeu avec information incomplete\n",
@@ -2128,7 +2128,7 @@
     }
    ],
    "source": [
-    "# Exercice 5 : Enchere Bayesienne\n",
+    "# Exercice 4 : Enchere Bayesienne\n",
     "import numpy as np\n",
     "from scipy import integrate\n",
     "\n",


### PR DESCRIPTION
## Summary

Fix broken exercise numbering in GameTheory-11-BayesianGames notebook. Exercises were numbered 2-3-4-5 instead of 1-2-3-4 (no Exercice 1 existed).

## Changes

- Cell 37/38: `Exercice 2` → `Exercice 1` (All-Pay auction)
- Cell 39/40: `Exercice 3` → `Exercice 2` (Vickrey revelation)
- Cell 41/42: `Exercice 4` → `Exercice 3` (Akerlof adverse selection)
- Cell 43/44: `Exercice 5` → `Exercice 4` (BNE calculation) + fix `##` → `###` header level

## Validation

- Markdown + code comment changes only (no logic changes)
- 8 insertions, 8 deletions (text replace only)
- C.2 exception: markdown-only changes, no re-execution needed
- Notebook structure verified (47 cells, all keys intact)

See #2259