### PR TITLE
fix(GameTheory): fix GT-13 duplicate Exercice 3 -> Exercice 5

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR.ipynb
@@ -7208,7 +7208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Kuhn Poker - Implementation CFR\n",
+    "### Exercice 5 : Kuhn Poker - Implementation CFR\n",
     "\n",
     "Implementez le jeu de Kuhn Poker (3 cartes, 2 joueurs, mise 1 jeton) et resolvez-le par CFR.\n",
     "\n",
@@ -7234,7 +7234,7 @@
     }
    ],
    "source": [
-    "# Exercice 3 : Kuhn Poker CFR\n",
+    "# Exercice 5 : Kuhn Poker CFR\n",
     "# TODO etudiant : implementer Kuhn Poker (3 cartes, 2 joueurs)\n",
     "# Etape 1 : definir les infosets et actions\n",
     "# Etape 2 : regret matching\n",


### PR DESCRIPTION
## Summary

Fix duplicate exercise numbering in GameTheory-13-ImperfectInfo-CFR notebook. Cell 36 lists Exercice 3 as "MCCFR variants" but cell 38 also has "Exercice 3 : Kuhn Poker" — two different exercises with the same number.

## Changes

- Cell 38: `Exercice 3` → `Exercice 5` (Kuhn Poker CFR markdown header)
- Cell 39: `Exercice 3` → `Exercice 5` (Kuhn Poker CFR code comment)

## Validation

- Markdown + code comment changes only (no logic changes)
- 2 insertions, 2 deletions
- C.2 exception: markdown-only changes, no re-execution needed
- Notebook structure verified (42 cells, all keys intact)

See #2259