### PR TITLE
test(notebook_tools): add 56 mutation-killing tests — Round 3 (See #2149)

### DIFF
--- a/scripts/notebook_tools/tests/test_notebook_tools.py
+++ b/scripts/notebook_tools/tests/test_notebook_tools.py
@@ -35,6 +35,13 @@ from notebook_tools import (
     SKIP_PATTERNS,
 )
 
+# Attempt to import NotebookExecutor (may not be available without helpers)
+try:
+    from notebook_tools import NotebookExecutor
+    HAS_EXECUTOR = True
+except ImportError:
+    HAS_EXECUTOR = False
+
 
 # =============================================================================
 # should_skip
@@ -800,3 +807,712 @@ class TestDiscoverNotebooksMutations:
         (nb_dir / "data.csv").write_text("a,b,c", encoding="utf-8")
         result = discover_notebooks(str(nb_dir), repo_root=tmp_path)
         assert len(result) == 1
+
+
+# =============================================================================
+# Round 2 — Mutation-killing tests for uncovered zones
+# =============================================================================
+
+
+class TestNotebookExecutorDetectKernelName:
+    """Kill mutants in NotebookExecutor.detect_kernel_name (L1057-1073).
+
+    Tests the mapping from analyzer.kernel → execution kernel name,
+    including fallback default 'python3'.
+    """
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_smartcontracts_kernel(self, tmp_path):
+        """'smartcontracts' kernel should map to 'smartcontracts'."""
+        nb = _make_notebook([], kernel_name="smartcontracts")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == "smartcontracts"
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_python3_kernel(self, tmp_path):
+        """'python3' kernel should map to 'python3'."""
+        nb = _make_notebook([], kernel_name="python3")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == "python3"
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_dotnet_csharp_kernel(self, tmp_path):
+        """'.NET C#' kernel from detect_kernel should map to '.net-csharp'."""
+        nb = _make_notebook([], kernel_name=".net-csharp", language="C#")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == ".net-csharp"
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_dotnet_fsharp_kernel(self, tmp_path):
+        """'.NET F#' kernel should map to '.net-fsharp'."""
+        nb = _make_notebook([], kernel_name=".net-fsharp", language="F#")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == ".net-fsharp"
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_lean4_kernel(self, tmp_path):
+        """'lean4' kernel should map to 'lean4'."""
+        nb = _make_notebook([], kernel_name="lean4")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == "lean4"
+
+    @pytest.mark.skipif(not HAS_EXECUTOR, reason="NotebookExecutor requires notebook_helpers")
+    def test_unknown_kernel_defaults_python3(self, tmp_path):
+        """Unknown kernel should default to 'python3'."""
+        nb = _make_notebook([], kernel_name="julia-1.9")
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        executor = NotebookExecutor(str(nb_path))
+        assert executor.detect_kernel_name() == "python3"
+
+
+class TestExtractSections:
+    """Kill mutants in NotebookAnalyzer._extract_sections (L530-550).
+
+    Tests markdown heading extraction: depth filter, bold stripping,
+    link text extraction, multiple headings per cell.
+    """
+
+    def test_extracts_h1_h2_h3(self, tmp_path):
+        """Sections at depth 1-3 are extracted."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["# Title\n"], "metadata": {}},
+            {"cell_type": "markdown", "source": ["## Section 1\n"], "metadata": {}},
+            {"cell_type": "markdown", "source": ["### Sub 1.1\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert len(skeleton.sections) == 3
+        assert skeleton.sections[0].level == 1
+        assert skeleton.sections[0].title == "Title"
+        assert skeleton.sections[1].level == 2
+        assert skeleton.sections[2].level == 3
+
+    def test_h4_filtered_by_max_depth(self, tmp_path):
+        """H4+ headings should be filtered out when max_depth=3."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["#### Deep\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert len(skeleton.sections) == 0
+
+    def test_h4_included_with_higher_max_depth(self, tmp_path):
+        """H4 should be included when max_depth=4."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["#### Deep\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton(include_code_preview=False)
+        # get_skeleton uses max_depth=3 by default, so H4 is filtered
+        # We test _extract_sections directly with max_depth=4
+        sections = analyzer._extract_sections(max_depth=4)
+        assert len(sections) == 1
+        assert sections[0].level == 4
+
+    def test_bold_stripped_from_title(self, tmp_path):
+        """**bold** should be stripped from section titles."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["## **Important** Section\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        sections = analyzer._extract_sections()
+        assert sections[0].title == "Important Section"
+
+    def test_link_text_preserved(self, tmp_path):
+        """[text](url) should be replaced with just 'text' in titles."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["## See [docs](http://example.com)\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        sections = analyzer._extract_sections()
+        assert sections[0].title == "See docs"
+
+    def test_multiple_headings_per_cell(self, tmp_path):
+        """Multiple headings in a single markdown cell are all extracted."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["# Title\n## Sub\n### Detail\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        sections = analyzer._extract_sections()
+        assert len(sections) == 3
+
+    def test_code_cells_ignored(self, tmp_path):
+        """Code cells should not produce sections."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": ["# This is a comment, not a heading\n"], "metadata": {},
+             "execution_count": 1, "outputs": []},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        sections = analyzer._extract_sections()
+        assert len(sections) == 0
+
+
+class TestGetCellOutputsAnalysis:
+    """Kill mutants in NotebookAnalyzer.get_cell_outputs_analysis (L552-597).
+
+    Tests output analysis: error detection, not-executed status, empty cells.
+    """
+
+    def test_error_output_detected(self, tmp_path):
+        """Cells with error outputs should be counted."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": ["1/0\n"], "metadata": {},
+             "execution_count": 1, "outputs": [
+                 {"output_type": "error", "ename": "ZeroDivisionError", "evalue": "division by zero"}
+             ]},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert analysis["cells_with_errors"] == 1
+        assert len(analysis["errors"]) == 1
+        assert analysis["errors"][0]["ename"] == "ZeroDivisionError"
+
+    def test_not_executed_status(self, tmp_path):
+        """Code cell without outputs should be 'NOT_EXECUTED'."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": ["x = 1\n"], "metadata": {},
+             "execution_count": None, "outputs": []},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert analysis["cells"][0]["status"] == "NOT_EXECUTED"
+
+    def test_empty_code_cell_status(self, tmp_path):
+        """Empty code cell should be 'EMPTY'."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": [""], "metadata": {},
+             "execution_count": None, "outputs": []},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert analysis["cells"][0]["status"] == "EMPTY"
+
+    def test_ok_status_with_outputs(self, tmp_path):
+        """Code cell with outputs should be 'OK'."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": ["print('hello')\n"], "metadata": {},
+             "execution_count": 1, "outputs": [
+                 {"output_type": "stream", "name": "stdout", "text": ["hello\n"]}
+             ]},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert analysis["cells"][0]["status"] == "OK"
+        assert analysis["cells_with_output"] == 1
+
+    def test_markdown_cells_not_analyzed(self, tmp_path):
+        """Markdown cells should not appear in code analysis."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["# Title\n"], "metadata": {}},
+            {"cell_type": "code", "source": ["x=1\n"], "metadata": {},
+             "execution_count": 1, "outputs": [{"output_type": "stream", "name": "stdout", "text": ["1\n"]}]},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert analysis["code_cells"] == 1
+        assert len(analysis["cells"]) == 1
+
+    def test_first_line_preview(self, tmp_path):
+        """first_line should show first line of source, truncated to 60 chars."""
+        long_line = "x = " + "a" * 100
+        nb = _make_notebook([
+            {"cell_type": "code", "source": [long_line + "\n"], "metadata": {},
+             "execution_count": 1, "outputs": []},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        analysis = analyzer.get_cell_outputs_analysis()
+        assert len(analysis["cells"][0]["first_line"]) == 60
+
+
+class TestNotebookSkeletonToDict:
+    """Kill mutants in NotebookSkeleton.to_dict (L276-290).
+
+    Tests serialization including sections, code_previews, and edge cases.
+    """
+
+    def test_to_dict_with_sections(self, tmp_path):
+        """to_dict should include sections with level, title, cell_index."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["# Title\n## Section 1\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        d = skeleton.to_dict()
+        assert len(d["sections"]) == 2
+        assert d["sections"][0]["level"] == 1
+        assert d["sections"][0]["title"] == "Title"
+        assert d["sections"][1]["level"] == 2
+
+    def test_to_dict_with_code_previews(self, tmp_path):
+        """to_dict should include code_previews with CellInfo fields."""
+        nb = _make_notebook([
+            {"cell_type": "code", "source": ["x = 1\n"], "metadata": {},
+             "execution_count": 1, "outputs": []},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        d = skeleton.to_dict()
+        assert len(d["code_previews"]) == 1
+        assert d["code_previews"][0]["index"] == 0
+        assert d["code_previews"][0]["has_output"] is False
+
+    def test_to_dict_empty_skeleton(self):
+        """Empty skeleton should serialize with defaults."""
+        skeleton = NotebookSkeleton(path="/test", name="test")
+        d = skeleton.to_dict()
+        assert d["path"] == "/test"
+        assert d["name"] == "test"
+        assert d["total_cells"] == 0
+        assert d["sections"] == []
+        assert d["code_previews"] == []
+        assert d["estimated_duration"] is None
+
+
+class TestFormatMarkdownTable:
+    """Kill mutants in _format_markdown_table (L1404-1423).
+
+    Tests table formatting: number extraction, section truncation, duration display.
+    """
+
+    def test_number_extraction_from_name(self):
+        """Notebook name with -N- pattern should extract N."""
+        from notebook_tools import _format_markdown_table
+        skeleton = NotebookSkeleton(
+            path="test", name="Sudoku-3-Test", total_cells=10, estimated_duration=15,
+        )
+        result = _format_markdown_table([skeleton], Path("test"))
+        assert "| 3 |" in result
+
+    def test_fallback_number_when_no_match(self):
+        """Notebook without -N- pattern should use index."""
+        from notebook_tools import _format_markdown_table
+        skeleton = NotebookSkeleton(
+            path="test", name="NoNumberHere", total_cells=5, estimated_duration=10,
+        )
+        result = _format_markdown_table([skeleton], Path("test"))
+        assert "| 1 |" in result
+
+    def test_sections_truncated_at_40_chars(self):
+        """Sections string longer than 40 chars should be truncated."""
+        from notebook_tools import _format_markdown_table
+        skeleton = NotebookSkeleton(
+            path="test", name="Test-1", total_cells=5, estimated_duration=10,
+            sections=[
+                SectionInfo(level=2, title="A" * 50, cell_index=0),
+            ],
+        )
+        result = _format_markdown_table([skeleton], Path("test"))
+        assert "..." in result
+
+    def test_no_duration_shows_dash(self):
+        """Notebook without estimated_duration should show '-'."""
+        from notebook_tools import _format_markdown_table
+        skeleton = NotebookSkeleton(
+            path="test", name="Test-1", total_cells=5, estimated_duration=None,
+        )
+        result = _format_markdown_table([skeleton], Path("test"))
+        assert "| - |" in result
+
+
+class TestFormatSummary:
+    """Kill mutants in _format_summary (L1426-1443).
+
+    Tests summary formatting: totals, duration, per-notebook section counts.
+    """
+
+    def test_summary_totals(self):
+        """Summary should show correct notebook count and cell total."""
+        from notebook_tools import _format_summary
+        skeletons = [
+            NotebookSkeleton(path="a", name="A", total_cells=10, estimated_duration=30),
+            NotebookSkeleton(path="b", name="B", total_cells=20, estimated_duration=60),
+        ]
+        result = _format_summary(skeletons)
+        assert "Notebooks: 2" in result
+        assert "Total cells: 30" in result
+
+    def test_duration_formatting(self):
+        """Duration should be formatted as hours and minutes."""
+        from notebook_tools import _format_summary
+        skeletons = [
+            NotebookSkeleton(path="a", name="A", total_cells=5, estimated_duration=90),
+        ]
+        result = _format_summary(skeletons)
+        assert "1h30" in result
+
+    def test_no_duration_shows_zero(self):
+        """Notebooks without duration should contribute 0 to total."""
+        from notebook_tools import _format_summary
+        skeletons = [
+            NotebookSkeleton(path="a", name="A", total_cells=5, estimated_duration=None),
+        ]
+        result = _format_summary(skeletons)
+        assert "0 min" in result
+        assert "0h00" in result
+
+    def test_sections_count_per_notebook(self):
+        """Each notebook line should show section count."""
+        from notebook_tools import _format_summary
+        skeletons = [
+            NotebookSkeleton(
+                path="a", name="A", total_cells=5, estimated_duration=10,
+                sections=[SectionInfo(level=2, title="S1", cell_index=0),
+                          SectionInfo(level=2, title="S2", cell_index=1)],
+            ),
+        ]
+        result = _format_summary(skeletons)
+        assert "2 sections" in result
+
+
+class TestNotebookValidationStatusEdgeCases:
+    """Kill mutants in NotebookValidation.status property edge cases.
+
+    Tests MISSING, INVALID, WARNING, OK status transitions.
+    """
+
+    def test_missing_status(self):
+        """status should be MISSING when exists=False."""
+        v = NotebookValidation(path="missing.ipynb", name="missing.ipynb")
+        assert v.status == "MISSING"
+
+    def test_invalid_status(self):
+        """status should be INVALID when valid_json=False and exists=True."""
+        v = NotebookValidation(path="bad.ipynb", name="bad.ipynb", exists=True)
+        assert v.status == "INVALID"
+
+    def test_error_status(self):
+        """status should be ERROR when error issues exist."""
+        v = NotebookValidation(
+            path="test.ipynb", name="test.ipynb",
+            exists=True, valid_json=True,
+            issues=[ValidationIssue(issue_type="error", category="test", cell_index=0, message="err")],
+        )
+        assert v.status == "ERROR"
+
+    def test_warning_status(self):
+        """status should be WARNING when only warning issues exist."""
+        v = NotebookValidation(
+            path="test.ipynb", name="test.ipynb",
+            exists=True, valid_json=True,
+            issues=[ValidationIssue(issue_type="warning", category="test", cell_index=0, message="warn")],
+        )
+        assert v.status == "WARNING"
+
+    def test_ok_status(self):
+        """status should be OK when no issues."""
+        v = NotebookValidation(
+            path="test.ipynb", name="test.ipynb",
+            exists=True, valid_json=True, has_cells=True,
+        )
+        assert v.status == "OK"
+
+    def test_error_count_property(self):
+        """error_count should count only error-type issues."""
+        v = NotebookValidation(
+            path="test.ipynb", name="test.ipynb",
+            issues=[
+                ValidationIssue(issue_type="error", category="a", cell_index=0, message="e1"),
+                ValidationIssue(issue_type="warning", category="b", cell_index=1, message="w1"),
+                ValidationIssue(issue_type="error", category="c", cell_index=2, message="e2"),
+            ],
+        )
+        assert v.error_count == 2
+
+    def test_warning_count_property(self):
+        """warning_count should count only warning-type issues."""
+        v = NotebookValidation(
+            path="test.ipynb", name="test.ipynb",
+            issues=[
+                ValidationIssue(issue_type="error", category="a", cell_index=0, message="e1"),
+                ValidationIssue(issue_type="warning", category="b", cell_index=1, message="w1"),
+            ],
+        )
+        assert v.warning_count == 1
+
+
+class TestDiscoverNotebooksEdgeCases:
+    """Kill mutants in discover_notebooks: exclude_subdirs, python_only, dotnet_only, direct file."""
+
+    def test_discover_specific_ipynb_file(self, tmp_path):
+        """Target ending with .ipynb should find that exact file."""
+        nb = _make_notebook([])
+        nb_path = tmp_path / "Test-1.ipynb"
+        _write_notebook(nb, str(nb_path))
+        result = discover_notebooks(str(nb_path), repo_root=tmp_path)
+        assert len(result) == 1
+
+    def test_discover_nonexistent_file_returns_empty(self, tmp_path):
+        """Nonexistent .ipynb target should return empty list."""
+        result = discover_notebooks(str(tmp_path / "nope.ipynb"), repo_root=tmp_path)
+        assert result == []
+
+    def test_discover_path_as_directory(self, tmp_path):
+        """Non-family target that is a directory should find notebooks inside."""
+        nb_dir = tmp_path / "MySeries"
+        nb_dir.mkdir()
+        nb = _make_notebook([])
+        _write_notebook(nb, str(nb_dir / "NB-1.ipynb"))
+        result = discover_notebooks(str(nb_dir), repo_root=tmp_path)
+        assert len(result) == 1
+
+    def test_discover_non_recursive(self, tmp_path):
+        """recursive=False should not search subdirectories."""
+        nb_dir = tmp_path / "Series"
+        sub = nb_dir / "Sub"
+        sub.mkdir(parents=True)
+        nb1 = _make_notebook([])
+        _write_notebook(nb1, str(nb_dir / "Top-1.ipynb"))
+        nb2 = _make_notebook([])
+        _write_notebook(nb2, str(sub / "Deep-1.ipynb"))
+        result = discover_notebooks(str(nb_dir), repo_root=tmp_path, recursive=False)
+        assert len(result) == 1
+        assert "Top-1" in str(result[0])
+
+    def test_discover_deduplicates(self, tmp_path):
+        """discover_notebooks should deduplicate results (sorted set)."""
+        nb_dir = tmp_path / "Series"
+        nb_dir.mkdir()
+        nb = _make_notebook([])
+        _write_notebook(nb, str(nb_dir / "Test-1.ipynb"))
+        # Calling with the same directory target twice shouldn't produce dupes
+        r1 = discover_notebooks(str(nb_dir), repo_root=tmp_path)
+        r2 = discover_notebooks(str(nb_dir), repo_root=tmp_path)
+        assert len(r1) == 1
+        assert len(r2) == 1
+
+
+class TestGetSkeletonEstimatedDuration:
+    """Kill mutants in get_skeleton duration estimation (L514).
+
+    Duration = (md_cells * 0.5 + code_cells * 1.0).__ceil__().
+    Mutation: * 0.5 -> * 0.6, * 1.0 -> * 1.1, __ceil__ -> __floor__.
+    """
+
+    def test_duration_with_code_only(self, tmp_path):
+        """5 code cells, 0 markdown = ceil(5.0) = 5 min."""
+        cells = [
+            {"cell_type": "code", "source": [f"x{i}=1\n"], "metadata": {},
+             "execution_count": i, "outputs": []}
+            for i in range(5)
+        ]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.estimated_duration == 5
+
+    def test_duration_with_mixed_cells(self, tmp_path):
+        """3 markdown + 2 code = ceil(1.5 + 2.0) = ceil(3.5) = 4 min."""
+        cells = [
+            {"cell_type": "markdown", "source": [f"# H{i}\n"], "metadata": {}}
+            for i in range(3)
+        ] + [
+            {"cell_type": "code", "source": [f"x{i}=1\n"], "metadata": {},
+             "execution_count": i, "outputs": []}
+            for i in range(2)
+        ]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.estimated_duration == 4
+
+    def test_duration_zero_cells(self, tmp_path):
+        """0 cells = ceil(0) = 0 min."""
+        nb = _make_notebook([])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.estimated_duration == 0
+
+    def test_duration_ceil_not_floor(self, tmp_path):
+        """1 md + 1 code = ceil(0.5 + 1.0) = ceil(1.5) = 2, NOT 1."""
+        cells = [
+            {"cell_type": "markdown", "source": ["# Title\n"], "metadata": {}},
+            {"cell_type": "code", "source": ["x=1\n"], "metadata": {},
+             "execution_count": 1, "outputs": []},
+        ]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.estimated_duration == 2  # ceil(1.5), not floor(1.5)=1
+
+
+class TestNotebookAnalyzerGetSkeletonTitle:
+    """Kill mutants in get_skeleton title extraction (L469-476).
+
+    Title = first # heading from markdown cells.
+    """
+
+    def test_title_from_first_h1(self, tmp_path):
+        """Title should be the first H1 found."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["# My Great Title\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.title == "My Great Title"
+
+    def test_title_none_when_no_h1(self, tmp_path):
+        """No H1 heading should result in title=None."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["Just some text\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.title is None
+
+    def test_title_from_h2_not_used(self, tmp_path):
+        """H2 should not be detected as title (only H1 with ^# )."""
+        nb = _make_notebook([
+            {"cell_type": "markdown", "source": ["## Section\n"], "metadata": {}},
+        ])
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        # Title is only extracted from ^#\s+ (single # at start of line)
+        assert skeleton.title is None
+
+    def test_error_notebook_skeleton(self, tmp_path):
+        """Invalid notebook should produce error skeleton."""
+        nb_path = tmp_path / "broken.ipynb"
+        nb_path.write_text("NOT JSON", encoding="utf-8")
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert skeleton.title == "[Error: Could not load notebook]"
+
+
+class TestNotebookExecutionResultDataclass:
+    """Kill mutants in NotebookExecutionResult defaults (L1025-1037)."""
+
+    def test_default_values(self):
+        """NotebookExecutionResult should have sensible defaults."""
+        r = NotebookExecutionResult(path="test.ipynb", success=False, kernel="python3")
+        assert r.success is False
+        assert r.total_cells == 0
+        assert r.executed_cells == 0
+        assert r.success_cells == 0
+        assert r.error_cells == 0
+        assert r.execution_time == 0.0
+        assert r.message == ""
+
+    def test_custom_values(self):
+        """NotebookExecutionResult should accept all fields."""
+        r = NotebookExecutionResult(
+            path="test.ipynb", success=True, kernel=".net-csharp",
+            total_cells=10, executed_cells=10, success_cells=9, error_cells=1,
+            execution_time=42.5, message="SUCCESS"
+        )
+        assert r.total_cells == 10
+        assert r.error_cells == 1
+        assert r.execution_time == 42.5
+
+
+class TestCellInfoDataclassDefaults:
+    """Kill mutants in CellInfo defaults — index and cell_type required."""
+
+    def test_cell_info_minimal(self):
+        """CellInfo with only required fields."""
+        c = CellInfo(index=0, cell_type="code")
+        assert c.preview == ""
+        assert c.line_count == 0
+        assert c.has_output is False
+        assert c.output_type is None
+        assert c.cell_id is None
+
+    def test_cell_info_full(self):
+        """CellInfo with all fields set."""
+        c = CellInfo(index=5, cell_type="code", preview="x = 1", line_count=2,
+                     has_output=True, output_type="stream", cell_id="abc123")
+        assert c.index == 5
+        assert c.has_output is True
+        assert c.cell_id == "abc123"
+
+
+class TestCodePreviewLimit:
+    """Kill mutants in get_skeleton code_previews[:20] limit (L526).
+
+    Mutation: [:20] -> [:10] or removed entirely.
+    """
+
+    def test_code_previews_capped_at_20(self, tmp_path):
+        """More than 20 code cells should produce at most 20 code_previews."""
+        cells = [
+            {"cell_type": "code", "source": [f"x{i} = {i}\n"], "metadata": {},
+             "execution_count": i, "outputs": []}
+            for i in range(25)
+        ]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton(include_code_preview=True)
+        assert len(skeleton.code_previews) == 20
+
+    def test_code_preview_skip_empty_cells(self, tmp_path):
+        """Empty code cells should not produce code_previews."""
+        cells = [
+            {"cell_type": "code", "source": ["x=1\n"], "metadata": {},
+             "execution_count": 1, "outputs": []},
+            {"cell_type": "code", "source": [""], "metadata": {},
+             "execution_count": None, "outputs": []},
+            {"cell_type": "code", "source": ["y=2\n"], "metadata": {},
+             "execution_count": 2, "outputs": []},
+        ]
+        nb = _make_notebook(cells)
+        nb_path = tmp_path / "test.ipynb"
+        _write_notebook(nb, str(nb_path))
+        analyzer = NotebookAnalyzer(str(nb_path))
+        skeleton = analyzer.get_skeleton()
+        assert len(skeleton.code_previews) == 2


### PR DESCRIPTION
## Summary

Round 3 of mutation testing for `scripts/notebook_tools/notebook_tools.py`. Targets previously uncovered zones identified by AST analysis of the 1656-line module.

### Zones covered (0% → tested)

| Zone | Tests | Mutation points killed |
|------|-------|----------------------|
| `NotebookExecutor.detect_kernel_name` (L1057-1073) | 6 | smartcontracts/python3/csharp/fsharp/lean4/unknown-default mapping |
| `_extract_sections` (L530-550) | 7 | depth filter, bold stripping, link extraction, multi-heading, code exclusion |
| `get_cell_outputs_analysis` (L552-597) | 6 | error detection, NOT_EXECUTED/EMPTY/OK status, first_line truncation |
| `NotebookSkeleton.to_dict` (L276-290) | 3 | sections serialization, code_previews, empty skeleton |
| `_format_markdown_table` (L1404-1423) | 4 | number extraction, section truncation, duration display |
| `_format_summary` (L1426-1443) | 4 | totals, duration formatting, section count |
| `NotebookValidation.status` property | 7 | MISSING/INVALID/ERROR/WARNING/OK transitions, error/warning_count |
| `discover_notebooks` edge cases | 5 | .ipynb file, nonexistent, directory, non-recursive, dedup |
| Estimated duration (L514) | 4 | code-only, mixed, zero, **ceil-not-floor** (kills `__ceil__`→`__floor__` mutant) |
| Title extraction (L469-476) | 4 | H1 detection, no-H1, H2-not-title, error notebook |
| Dataclass defaults | 4 | ExecutionResult, CellInfo |
| Code preview cap [:20] (L526) | 2 | 25-code-cell cap, empty-cell skip |

### Metrics

- **Tests**: 93 → **149** (+56)
- **Full suite**: 1256 passed (0 failures)
- **Mutation score estimated**: ~65% → ~78%

### Cumulative mutation testing #2149

| Script | PR | Tests | Score |
|--------|-----|-------|-------|
| notebook_tools.py | #2333 (R1) + this PR (R3) | 65→149 (+84) | ~78% |
| generate_catalog.py | #2338 (R2) | 71→140 (+69) | ~65% |
| expand_catalog_markers.py | #2346 (R2) | 26→50 (+24) | ~60% |

### Test plan

- [x] `python -m pytest scripts/notebook_tools/tests/test_notebook_tools.py -v` — 149 passed
- [x] `python -m pytest scripts/notebook_tools/tests/ -q` — 1256 passed
- [x] No code changes — test file only

See #2149