### PR TITLE
enrich(Lean-14b): coherence audit - sorry counts + CPU attribution + theorem mapping

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14b-Conway-Game-of-Life-Lean.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-14b-Conway-Game-of-Life-Lean.ipynb
@@ -239,13 +239,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interpretation : 8 modules Conway en Lean 4\n",
-    "\n",
-    "Les 5 modules Phase 1 (Doomsday, LookAndSay, Fractran, Nim, Angel) + 2 modules de lemmes (DoomsdayLemmas, LookAndSayLemmas) + le nouveau **Life.lean** que nous introduisons dans ce notebook. KochenSpecker.lean est un module distinct (Pilier 1 de l'Epic #1651, Conway Free Will Theorem).\n",
-    "\n",
-    "**Statut sorry** : 0 sur Doomsday/LookAndSay/Fractran/Nim/Angel/Life ; 2 sur KochenSpecker (TODO Pilier 1, cf Lean-15). Une cible globale `lake build Conway` doit donc compiler avec uniquement les 2 warnings KochenSpecker."
-   ]
+   "source": "### Interpretation : 8 modules Conway en Lean 4\n\nLes 5 modules Phase 1 (Doomsday, LookAndSay, Fractran, Nim, Angel) + 2 modules de lemmes (DoomsdayLemmas, LookAndSayLemmas) + le nouveau **Life.lean** que nous introduisons dans ce notebook. KochenSpecker.lean est un module distinct (Pilier 1 de l'Epic #1651, Conway Free Will Theorem) — desormais **0 sorry** (PR #2019, argument de parite). FreeWillTheorem.lean (PR #2026) complete le theoreme de libre arbitre avec 0 sorry.\n\n**Statut sorry** : 0 sur Doomsday/LookAndSay/Fractran/Nim/Angel/Life/KochenSpecker/FreeWillTheorem. Une cible globale `lake build Conway` compile avec SUCCESS (3331 jobs)."
   },
   {
    "cell_type": "markdown",
@@ -1057,25 +1051,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Acte II - CALCUL : machine de Turing (Rendell, 2000) et CPU 8 bits (Carlini, 2020)\n",
-    "\n",
-    "- **Paul Rendell, avril 2000** : la premiere machine de Turing explicite construite dans Life - le witness telechargeable ci-dessous.\n",
-    "- **Nicholas Carlini, 2020** : un CPU 8 bits complet (ROM, RAM, ALU, registres, horloge), de l'ordre de $10^6$ cellules - trop massif pour etre rendu ou decide ici, c'est le sommet de la discipline.\n",
-    "- **Adam P. Goucher, additionneur Spartan** : environ 5 000 cellules, cible pragmatique pour la preuve Lean.\n",
-    "\n",
-    "Le deuxieme prodige, c'est le **calcul** proprement dit. Des 1970, Conway conjecturait que Life etait Turing-complete ; Paul Rendell l'a prouve *par construction* en 2000 en batissant une vraie machine de Turing - ruban, tete de lecture, table de transitions - entierement en cellules B3/S23. Vingt ans plus tard, Carlini est alle au bout de l'idee avec un microprocesseur 8 bits fonctionnel.\n",
-    "\n",
-    "Pour la preuve formelle, on ne vise pas le CPU complet (le binaire `native_decide` n'y tiendrait pas) : on commence par l'**additionneur Spartan** de Goucher, assez petit pour etre decide, et on remonte si la machine suit.\n",
-    "\n",
-    "**Theoreme cible Lean** (additionneur, Phase 8) :\n",
-    "```lean\n",
-    "theorem spartan_adder_correct : forall (a b : Fin 256),\n",
-    "    read_output (step^[adder_cycle] (adder_init a b)) = a + b := by native_decide\n",
-    "```\n",
-    "\n",
-    "Le witness ci-dessous est la machine de Rendell : un objet qu'on peut tenir dans une grille et regarder."
-   ]
+   "source": "### Acte II - CALCUL : machine de Turing (Rendell, 2000) et calculateurs numeriques\n\n- **Paul Rendell, avril 2000** : la premiere machine de Turing explicite construite dans Life - le witness telechargeable ci-dessous.\n- **Nicolay Beluchenko / Andy Stearns, 2016** : un **CPU digital** programmable construit a partir d'OTCA metapixels, executant un cycle en 1 048 576 generations. Ce CPU est le temoin `cpu_witness` declare dans `Conway.Life.Pillars.lean` (Phase 8 cible).\n- **Nicholas Carlini, 2020** : un CPU 8 bits complet (ROM, RAM, ALU, registres, horloge), de l'ordre de $10^6$ cellules - independant du CPU de Beluchenko/Stearns. Trop massif pour etre rendu ou decide ici, c'est le sommet de la discipline.\n- **Adam P. Goucher, additionneur Spartan** : environ 5 000 cellules, cible pragmatique pour la preuve Lean.\n\nLe deuxieme prodige, c'est le **calcul** proprement dit. Des 1970, Conway conjecturait que Life etait Turing-complete ; Paul Rendell l'a prouve *par construction* en 2000 en batissant une vraie machine de Turing - ruban, tete de lecture, table de transitions - entierement en cellules B3/S23. Vingt ans plus tard, Carlini est alle au bout de l'idee avec un microprocesseur 8 bits fonctionnel.\n\nPour la preuve formelle, on ne vise pas le CPU complet (le binaire `native_decide` n'y tiendrait pas) : on commence par l'**additionneur Spartan** de Goucher, assez petit pour etre decide, et on remonte si la machine suit.\n\n**Theoreme cible Lean** (additionneur, Phase 8) :\n```lean\ntheorem spartan_adder_correct : forall (a b : Fin 256),\n    read_output (step^[adder_cycle] (adder_init a b)) = a + b := by native_decide\n```\n\nLe witness ci-dessous est la machine de Rendell : un objet qu'on peut tenir dans une grille et regarder."
   },
   {
    "cell_type": "code",
@@ -1246,21 +1222,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### La cascade : Life calcule Life qui calcule un CPU\n",
-    "\n",
-    "Remettons les trois actes dans l'ordre ou on vient de les voir :\n",
-    "\n",
-    "| Acte | Witness | Prouesse | En une phrase |\n",
-    "|------|---------|----------|---------------|\n",
-    "| I | OTCA Metapixel (Due, 2006) | self-emulation | Life se simule elle-meme |\n",
-    "| II | Turing / Carlini (2000-2020) | calcul universel | Life calcule n'importe quoi |\n",
-    "| III | Gemini (Wade, 2010) | self-replication | Life se recopie elle-meme |\n",
-    "\n",
-    "La beaute de l'histoire tient a leur **emboitement**, et l'ordre est une montee en puissance. L'Acte I prouve que Life peut faire tourner Life. L'Acte II prouve que Life peut faire tourner un ordinateur. En composant les deux, on obtient un ordinateur *a l'interieur d'un metapixel* : **Life calcule Life qui calcule un CPU**. Et l'Acte III, le bouquet final, garantit qu'une telle construction peut se **reproduire** toute seule - on tient la, en cellules vivantes, les trois ingredients de von Neumann d'une machine auto-reproductrice et universelle.\n",
-    "\n",
-    "C'est pourquoi ces trois witnesses sont les *piliers* de l'Epic #1647 : chacun est une preuve par construction, et leur composition est l'argument de Turing-completude le plus tangible qu'on puisse donner du Game of Life. Les theoremes cibles ci-dessus (`otca_self_emulates`, `spartan_adder_correct`, `gemini_replicates`) traduisent cette histoire en Lean, ou chaque prouesse devient un `native_decide` sur le temoin concret correspondant."
-   ]
+   "source": "### La cascade : Life calcule Life qui calcule un CPU\n\nRemettons les trois actes dans l'ordre ou on vient de les voir :\n\n| Acte | Witness | Prouesse | En une phrase |\n|------|---------|----------|---------------|\n| I | OTCA Metapixel (Due, 2006) | self-emulation | Life se simule elle-meme |\n| II | Turing / calculateurs (2000-2020) | calcul universel | Life calcule n'importe quoi |\n| III | Gemini (Wade, 2010) | self-replication | Life se recopie elle-meme |\n\nLa beaute de l'histoire tient a leur **emboitement**, et l'ordre est une montee en puissance. L'Acte I prouve que Life peut faire tourner Life. L'Acte II prouve que Life peut faire tourner un ordinateur. En composant les deux, on obtient un ordinateur *a l'interieur d'un metapixel* : **Life calcule Life qui calcule un CPU**. Et l'Acte III, le bouquet final, garantit qu'une telle construction peut se **reproduire** toute seule - on tient la, en cellules vivantes, les trois ingredients de von Neumann d'une machine auto-reproductrice et universelle.\n\nC'est pourquoi ces trois witnesses sont les *piliers* de l'Epic #1647 : chacun est une preuve par construction, et leur composition est l'argument de Turing-completude le plus tangible qu'on puisse donner du Game of Life.\n\n### Noms de theoremes : narration vs implementation\n\nLes theoremes cibles ci-dessus (`otca_self_emulates`, `spartan_adder_correct`, `gemini_replicates`) sont des **noms prospectifs** qui servent le recit pedagogique. Les noms reels dans le code Lean suivent la convention `<pattern>_witness` :\n\n| Nom prospectif (section 6) | Nom reel dans `Pillars.lean` | Statut |\n|----------------------------|------------------------------|--------|\n| `otca_self_emulates` | `otca_metapixel_witness` | sorry (Phase 7) |\n| `spartan_adder_correct` | `cpu_witness` (Beluchenko/Stearns) | sorry (Phase 8) |\n| `gemini_replicates` | `gemini_witness` | sorry (Phase 6) |\n| — | `unitcell_witness` (Beluchenko 2011) | sorry (Phase 8) |\n\nLe quatrieme temoin (`unitcell_witness`, UnitCell de Beluchenko, 4096 generations) n'apparait pas dans le recit des trois actes : c'est un metapixel plus petit que l'OTCA, plus accessible comme premiere cible `native_decide`. Il est integrallement defini dans `Pillars.lean` et constitue un jalon intermediaire naturel avant l'OTCA complete.\n\nChaque preuve est prevue comme un seul `by native_decide` une fois la memoization Hashlife en place."
   },
   {
    "cell_type": "code",
@@ -2252,7 +2214,7 @@
    "id": "section-11-roadmap",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-04T03:17:07.503459",
      "exception": false,
      "start_time": "2026-06-04T03:17:07.503459",
@@ -2260,51 +2222,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 11. Feuille de route : phases ulterieures de l'Epic #1647\n",
-    "\n",
-    "Ce notebook + `Life.lean` + `Spaceships.lean` + `Oscillators.lean` + `MacroCell.lean` + `Hashlife.lean` + `HashlifeCorrectness.lean` constituent les **Phases 0, 1, 3a, 3b et 5** de l'Epic #1647. Les phases suivantes (dispatch sur cycles futurs) :\n",
-    "\n",
-    "| Phase | Fichier(s) Lean | Theme | Statut |\n",
-    "|-------|------------------|-------|--------|\n",
-    "| **Phase 0** | (notebook) | Hommage + showcase | **FAIT** |\n",
-    "| **Phase 1** | `Life.lean` | Fondations B3/S23, 7 microproofs | **FAIT** |\n",
-    "| **Phase 5** | `Life/Spaceships.lean` + `Life/Oscillators.lean` | 3 vaisseaux + 7 still-lifes/oscillateurs | **FAIT (PR #1975)** |\n",
-    "| **Phase 2** | `Life/RLE.lean` | Parser RLE + chargement de patterns communautaires | **FAIT** |\n",
-    "| **Phase 3a** | `Life/MacroCell.lean` | Encodage quadtree arborescent | **FAIT** |\n",
-    "| **Phase 3b** | `Life/Hashlife.lean` + `Life/HashlifeCorrectness.lean` | Step recursif + correction light-cone | **EN COURS — 5 sorries** (P2-P5, PR #2173 a ferme P1 L242) |\n",
-    "| **Phase 3c** | `Life/HashlifeMemo.lean` + `Life/Pillars.lean` | Memoization + temoins communautaires | **SCAFFOLD POSE — Phase 3c roadmap** |\n",
-    "| Phase 4 | `Life/Omniperiodic.lean` | $\f",
-    "orall n \\le 64, \\exists P, \text{period}(P) = n$ | A venir |\n",
-    "| Phase 6 | (theoreme `gemini_witness` dans Pillars) | Gemini self-replication (33M gen) | Phase 3c dependance |\n",
-    "| Phase 7 | (theoreme `otca_metapixel_witness` dans Pillars) | OTCA self-emulation (35K gen) | Phase 3c dependance |\n",
-    "| Phase 8 | (theoreme `unitcell_witness` + `cpu_witness` dans Pillars) | UnitCell 4096 gen + Digital CPU 1M gen | Phase 3c dependance |\n",
-    "| Phase 9 | `Life/LogicGates.lean` | NAND gate + axiome Turing-completude | A venir |\n",
-    "\n",
-    "### Phase 3c — Scaffolding pose\n",
-    "\n",
-    "Les fichiers `Conway/Life/HashlifeMemo.lean` et `Conway/Life/Pillars.lean` sont desormais presents avec leur API declaree. Ce que le scaffold etablit :\n",
-    "\n",
-    "1. **`MacroCellId` + `MemoCache`** : identifiant content-addresse + `Std.HashMap MacroCellId MacroCell` pour le cache de hash-consing.\n",
-    "2. **`hashlifeResultMemo : MacroCell → StateM MemoCache MacroCell`** : version memoisee de `hashlifeResultAux`. Theoreme bridge `hashlifeResultMemo_correct` declare.\n",
-    "3. **`evolveHashlifeFastMemo`** : entree top-level pour le chemin rapide memoise. Theoreme `evolveHashlifeFastMemo_eq_evolveHashlifeFast` declare.\n",
-    "4. **4 theoremes-temoins** : `otca_metapixel_witness` (35 328 gen), `unitcell_witness` (4 096 gen), `gemini_witness` (33 699 586 gen), `cpu_witness` (1 048 576 gen). Chaque preuve est prevue comme un seul `by native_decide` une fois la memoization en place et les patterns RLE charges.\n",
-    "\n",
-    "Les `sorry`s presents dans `HashlifeMemo.lean` et `Pillars.lean` sont des **marqueurs de roadmap Phase 3c documentes**, scopes a ces deux modules. Ils ne dependent pas et n'affectent pas les 5 sorries restants de `HashlifeCorrectness.lean` (qui concernent la correction directe du light-cone Phase 3b, independante de la memoization).\n",
-    "\n",
-    "**Jalon cle** : Phase 3c (memoization + temoins). Sans memoization, le facteur de compression `9^k` de `hashlifeResultAux` rend Gemini (level ~14) intraitable. Avec memoization, les patterns realistes (peu de sous-arbres distincts) tiennent dans le budget `native_decide`.\n",
-    "\n",
-    "### Strategie \"fichiers precieux mis en avant\"\n",
-    "\n",
-    "Pour chaque pattern (Gemini, OTCA, UnitCell, Digital CPU, Goucher adder, NAND Rendell), import verbatim depuis LifeWiki en tant que constante Lean publique avec docstring complete (auteur + date + URL source). Pas d'alteration des fichiers communautaires - juste un import propre.\n",
-    "\n",
-    "### Lien avec les autres Epics Conway\n",
-    "\n",
-    "- **#1151 (CLOSED)** : 5 modules Lean sur des resultats moins connus de Conway (Doomsday, FRACTRAN, LookAndSay, Nim, Angel) — dans `conway_lean/Conway/`\n",
-    "- **#1647 (CETTE EPIC)** : Life-as-Computation (ce notebook Lean-14 + Life.lean + Spaceships + Oscillators + MacroCell + Hashlife + HashlifeCorrectness + HashlifeMemo + Pillars)\n",
-    "- **#1651** : Theoreme de Libre Arbitre Conway-Kochen (notebook Lean-15 + KochenSpecker.lean) — **FAIT (PR #2026)**\n",
-    "- **#1646** : Tribute Grothendieck (notebook Lean-13, parallele structurel)"
-   ]
+   "source": "## 11. Feuille de route : phases ulterieures de l'Epic #1647\n\nCe notebook + `Life.lean` + `Spaceships.lean` + `Oscillators.lean` + `MacroCell.lean` + `Hashlife.lean` + `HashlifeCorrectness.lean` + `HashlifeMemo.lean` + `Pillars.lean` constituent les **Phases 0, 1, 3a, 3b et 5** de l'Epic #1647. Les phases suivantes (dispatch sur cycles futurs) :\n\n| Phase | Fichier(s) Lean | Theme | Statut |\n|-------|------------------|-------|--------|\n| **Phase 0** | (notebook) | Hommage + showcase | **FAIT** |\n| **Phase 1** | `Life.lean` | Fondations B3/S23, 7 microproofs | **FAIT** |\n| **Phase 5** | `Life/Spaceships.lean` + `Life/Oscillators.lean` | 3 vaisseaux + 7 still-lifes/oscillateurs | **FAIT (PR #1975)** |\n| **Phase 2** | `Life/RLE.lean` | Parser RLE + chargement de patterns communautaires | **FAIT** |\n| **Phase 3a** | `Life/MacroCell.lean` | Encodage quadtree arborescent | **FAIT** |\n| **Phase 3b** | `Life/Hashlife.lean` + `Life/HashlifeCorrectness.lean` | Step recursif + correction light-cone | **EN COURS — 2 sorries** (P4 L748 + P5 L828). P1 ferme par PR #2173, P2 et P3 fermes par PRs #2097/#2107 |\n| **Phase 3c** | `Life/HashlifeMemo.lean` + `Life/Pillars.lean` | Memoization + 4 temoins communautaires | **SCAFFOLD POSE — 6 sorries de roadmap** (2 HashlifeMemo + 4 Pillars) |\n| Phase 4 | `Life/Omniperiodic.lean` | $\\forall n \\le 64, \\exists P, \\text{period}(P) = n$ | A venir |\n| Phase 6 | (theoreme `gemini_witness` dans Pillars) | Gemini self-replication (33M gen) | Phase 3c dependance |\n| Phase 7 | (theoreme `otca_metapixel_witness` dans Pillars) | OTCA self-emulation (35K gen) | Phase 3c dependance |\n| Phase 8 | (theoreme `unitcell_witness` + `cpu_witness` dans Pillars) | UnitCell 4096 gen + Digital CPU 1M gen | Phase 3c dependance |\n| Phase 9 | `Life/LogicGates.lean` | NAND gate + axiome Turing-completude | A venir |\n\n### Phase 3b — 2 sorries restants (intractables)\n\nLe module `HashlifeCorrectness.lean` (867 lignes) contient 5 sous-objectifs de correction, numerotes P1 a P5 dans le docstring :\n\n- **P1** (L242, `hashlifeResultAux_correct_base`) : **FERME** par PR #2173 — cas de base du step 4x4.\n- **P2** (containment niveau 2) : **FERME** par PR #2097 — lemme de confinement spatial.\n- **P3** (containment step central) : **FERME** par PR #2107 — lemme de confinement du step central.\n- **P4** (L748, theoreme central de correction `hashlifeResultAux_correct`) : **INTRACTABLE** — preuve par induction sur le niveau du MacroCell. Tentees : simplification structurelle, strong induction, omega sur les niveaux. Le prover automatique a echoue a plusieurs reprises (iterations F6-F11).\n- **P5** (L828, theoreme principal `hashlife_correct`) : **INTRACTABLE** — composition de P2-P4. Depend de P4.\n\nCes deux cibles sont independantes du scaffold Phase 3c et ne bloquent pas la pose des temoins.\n\n### Phase 3c — Scaffolding pose (6 sorries de roadmap)\n\nLes fichiers `Conway/Life/HashlifeMemo.lean` et `Conway/Life/Pillars.lean` sont desormais presents avec leur API declaree. Ce que le scaffold etablit :\n\n1. **`MacroCellId` + `MemoCache`** : identifiant content-addresse + `Std.HashMap MacroCellId MacroCell` pour le cache de hash-consing.\n2. **`hashlifeResultMemo : MacroCell → StateM MemoCache MacroCell`** : version memoisee de `hashlifeResultAux`. Theoreme bridge `hashlifeResultMemo_correct` declare (sorry L189).\n3. **`evolveHashlifeFastMemo`** : entree top-level pour le chemin rapide memoise. Theoreme `evolveHashlifeFastMemo_eq_evolveHashlifeFast` declare (sorry L209).\n4. **4 theoremes-temoins** dans `Pillars.lean` :\n   - `otca_metapixel_witness` (35 328 gen) — sorry L130\n   - `unitcell_witness` (4 096 gen) — sorry L139\n   - `gemini_witness` (33 699 586 gen) — sorry L149\n   - `cpu_witness` (1 048 576 gen) — sorry L158\n\n   Chaque preuve est prevue comme un seul `by native_decide` une fois la memoization en place et les patterns RLE charges.\n\nLes 6 `sorry`s (2 HashlifeMemo + 4 Pillars) sont des **marqueurs de roadmap Phase 3c documentes**, scopes a ces deux modules. Ils ne dependent pas et n'affectent pas les 2 sorries restants de `HashlifeCorrectness.lean` (P4/P5, correction directe du light-cone Phase 3b, independante de la memoization).\n\n**Total des sorries Lean Life** : 2 (intractables, HashlifeCorrectness) + 6 (scaffolding roadmap, HashlifeMemo + Pillars) = **8 sorry** sur les 9 modules `Conway.Life.*`. Les 3 modules fondamentaux (Life + Spaceships + Oscillators) restent a **0 sorry**.\n\n**Jalon cle** : Phase 3c (memoization + temoins). Sans memoization, le facteur de compression `9^k` de `hashlifeResultAux` rend Gemini (level ~14) intraitable. Avec memoization, les patterns realistes (peu de sous-arbres distincts) tiennent dans le budget `native_decide`.\n\n### Strategie \"fichiers precieux mis en avant\"\n\nPour chaque pattern (Gemini, OTCA, UnitCell, Digital CPU, Goucher adder, NAND Rendell), import verbatim depuis LifeWiki en tant que constante Lean publique avec docstring complete (auteur + date + URL source). Pas d'alteration des fichiers communautaires - juste un import propre.\n\n### Lien avec les autres Epics Conway\n\n- **#1151 (CLOSED)** : 5 modules Lean sur des resultats moins connus de Conway (Doomsday, FRACTRAN, LookAndSay, Nim, Angel) — dans `conway_lean/Conway/`\n- **#1647 (CETTE EPIC)** : Life-as-Computation (ce notebook Lean-14 + Life.lean + Spaceships + Oscillators + MacroCell + Hashlife + HashlifeCorrectness + HashlifeMemo + Pillars)\n- **#1651** : Theoreme de Libre Arbitre Conway-Kochen (notebook Lean-15 + KochenSpecker.lean) — **FAIT (PR #2026)**\n- **#1646** : Tribute Grothendieck (notebook Lean-13, parallele structurel)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Coherence audit of Lean-14b notebook against actual Lean source (`Pillars.lean`, `HashlifeCorrectness.lean`, `HashlifeMemo.lean`). See #2155.

### Corrections applied

| # | Section | Before | After |
|---|---------|--------|-------|
| 1 | 11 (roadmap) | "5 sorries (P2-P5)" | "2 sorries (P4 L748 + P5 L828)" — P1 #2173, P2 #2097, P3 #2107 fermes |
| 2 | 6 (Acte II) | "Carlini, 2020" unique | Beluchenko/Stearns 2016 (CPU digital, `cpu_witness`) + Carlini 2020 (8-bit CPU, independant) |
| 3 | 6 (synthese) | No theorem mapping | Table prospectif vs reel (`otca_self_emulates` → `otca_metapixel_witness`, etc.) + 4e temoin UnitCell |
| 4 | 1b | "2 sur KochenSpecker" | "0 sorry (PR #2019) + FreeWillTheorem 0 sorry (PR #2026)" |

### Phase 3b/3c breakdown added

- **Phase 3b**: detailed P1-P5 status with closure PRs
- **Phase 3c**: explicit sorry count 6 (2 HashlifeMemo + 4 Pillars) with line numbers
- **Total Lean Life sorry**: 8 (2 intractable + 6 scaffolding)

### Files changed

- `Lean-14b-Conway-Game-of-Life-Lean.ipynb` — 4 markdown cells edited, 0 code cells touched

### Verification

- All changes are **markdown-only** (convention C.2 exception: previous outputs valid)
- No code cell source modified
- Sorry counts verified against actual `grep -n sorry` on `.lean` files
- `git diff --stat`: 5 insertions, 87 deletions (all markdown)

See #2155