### PR TITLE
fix(Infer-16): resolve Plotly.NET Chart.Combine CS0103 on re-execution

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-16-Decision-Multi-Attribute.ipynb
@@ -477,6 +477,7 @@
    ],
    "source": [
     "// Installation Plotly.NET pour les visualisations\n",
+    "#r \"nuget: Plotly.NET, 5.0.0\"\n",
     "#r \"nuget: Plotly.NET.Interactive, 5.0.0\"\n",
     "using Plotly.NET;\n",
     "using Plotly.NET.LayoutObjects;\n",
@@ -1663,7 +1664,7 @@
     "    )\n",
     ").ToList();\n",
     "\n",
-    "var chartSensibilite = Chart.Combine(sensitivityTraces)\n",
+    "var chartSensibilite = Plotly.NET.Chart.Combine(sensitivityTraces)\n",
     "    .WithTitle(\"Analyse de sensibilite : Impact du poids Salaire sur V\")\n",
     "    .WithXAxisStyle(Title.init(\"Poids du Salaire\"))\n",
     "    .WithYAxisStyle(Title.init(\"Valeur totale V\"))\n",


### PR DESCRIPTION
## Summary

Fix issue #2369 — `chartSensibilite` cell (ec=14) fails with CS0103 on fresh .net-csharp re-execution.

## Root cause

1. **Missing core package pin**: Cell ec=5 only pins `Plotly.NET.Interactive, 5.0.0` — the core `Plotly.NET` package version floats transitively, causing symbol resolution inconsistency on clean exec.
2. **Ambiguous symbol**: `Chart.Combine` not resolved when core package version drifts.

## Changes

| Cell | Before | After |
|------|--------|-------|
| ec=5 (idx 12) | `#r "nuget: Plotly.NET.Interactive, 5.0.0"` | Added `#r "nuget: Plotly.NET, 5.0.0"` before Interactive ref |
| ec=14 (idx 32) | `Chart.Combine(sensitivityTraces)` | `Plotly.NET.Chart.Combine(sensitivityTraces)` (fully qualified) |

## Validation

- Re-executed end-to-end via `notebook_tools.py execute --cell-by-cell` (.net-csharp kernel)
- **20/22 code cells OK, 0 errors**
- 2 cells with `execution_count: null` are exercise stubs (idx 19, 33) — conform C.1
- `chartSensibilite` renders correctly (display_data output present)
- Diff contains only the 2 source changes + re-execution outputs

Closes #2369