### PR TITLE
feat(grothendieck): wire SheafBasics.lean into umbrella import (See #2159)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -24,3 +24,4 @@ import Grothendieck.ZariskiSite
 import Grothendieck.MathlibMap
 import Grothendieck.Calibration
 import Grothendieck.SieveLattice
+import Grothendieck.SheafBasics

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -31,6 +31,12 @@ The goal is to give learners a curated entry point into:
 |------|---------|-------|
 | `Grothendieck/SieveLattice.lean` | Sieve pullback identities: `pullback_id`, `pullback_pullback` (contravariant composition), `pullback_bot`, `pullback_monotone` | ~90 |
 
+### Phase 3 (Sheaf Basics) — `0 sorry` (Issue #2159, Epic #2162)
+
+| File | Content | Lines |
+|------|---------|-------|
+| `Grothendieck/SheafBasics.lean` | Sheaf/separated basics, subcanonical topologies, sheaf transfer along J₁ ≤ J₂ | ~128 |
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary

Wire the orphan `Grothendieck/SheafBasics.lean` (Phase 3, 128 lines) into the umbrella import `Grothendieck.lean`.

## Changes

- **`Grothendieck.lean`**: Add `import Grothendieck.SheafBasics` after `SieveLattice` (Phase 2)
- **`README.md`**: Add Phase 3 table row documenting SheafBasics.lean content

## Validation

- **Lake build SUCCESS**: 912 jobs (including `Grothendieck.SheafBasics`)
- **Sorry count**: 0 production sorry (only docstring mention). Before/after: 0 → 0
- **6 theorems**: `sheaf_is_separated`, `isSeparated_trivial`, `yoneda_isSheaf_subcanonical`, `isSheaf_of_le`, `subcanonical_of_le`, `trivial_subcanonical`
- **No .lean files modified** (only umbrella import added)
- **No notebook changes**

See #2159. Epic #1646 / #2162.