### PR TITLE
fix(Infer-18): relabel Exemple guide as Exercice for exercise stub (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-18-Decision-Value-Information.ipynb
@@ -105,7 +105,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-10536.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-60880.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -155,7 +155,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '10536.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '60880.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -4015,7 +4015,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Decision de test medical\n",
+    "// Exercice : Decision de test medical\n",
     "\n",
     "// Parametres\n",
     "double pMaladie_ex = 0.05;\n",


### PR DESCRIPTION
## Summary

Fix labeling in Infer-18 cell 0a52f646: code comment said `Exemple guide` but content is an exercise stub with TODOs. Per content-based classification rule, relabel to `Exercice`.

### Change
- 1 line fix: `// Exemple guide : Decision de test medical` → `// Exercice : Decision de test medical`

### Validation
- **Papermill SUCCESS**: 18/18 code cells (15s)
- **H.3 PASS**: 18/18 exec_count, 18/18 with outputs
- **Exercise count**: Was 2 detected (scan missed cell 46 due to C# TODO pattern), now correctly identified as 3 exercises total

See #2161