### PR TITLE
fix(Infer-19): relabel Exemple guide as Exercice for exercise stub (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Decision-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-19-Decision-Expert-Systems.ipynb
@@ -144,7 +144,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-11892.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-63096.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -194,7 +194,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '11892.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '63096.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -2705,7 +2705,7 @@
       "text/html": [
        "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
        "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_06_04_26_08_31_40_99.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
+       "                Copiez le contenu de <code>Model_06_04_26_17_56_47_45.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
        "            </div>"
       ]
      },
@@ -3249,7 +3249,7 @@
     "tags": []
    },
    "source": [
-    "## 9. Exemple guide : Systeme Expert de Diagnostic\n",
+    "## 9. Exercice : Systeme Expert de Diagnostic\n",
     "\n",
     "### Enonce\n",
     "\n",
@@ -3322,7 +3322,7 @@
     }
    ],
    "source": [
-    "// Exemple guide : Systeme expert informatique complet\n",
+    "// Exercice : Systeme expert informatique complet\n",
     "// Inclut : diagnostic bayesien + decision par minimax regret\n",
     "\n",
     "var causes = new[] { \"virus\", \"disque_plein\", \"RAM_defaillante\", \"surchauffe_CPU\" };\n",


### PR DESCRIPTION
## Summary

Fix labeling in Infer-19 section 9: both markdown header and code comment said `Exemple guide` but content was an exercise stub with TODOs. Per content-based classification rule, relabel to `Exercice`.

### Changes
- Cell 38 markdown: `## 9. Exemple guide : Systeme Expert de Diagnostic` → `## 9. Exercice : Systeme Expert de Diagnostic`
- Cell 40 code comment: `// Exemple guide : Systeme expert informatique complet` → `// Exercice : Systeme expert informatique complet`

### Validation
- **Papermill SUCCESS**: 14/14 code cells (14s)
- **H.3 PASS**: 14/14 exec_count, 14/14 with outputs
- **Exercise count**: 3 (Minimax Cloud, Hurwicz Commercial, Expert System Diagnostic)

See #2161