### PR TITLE
docs(Search): enrich sub-directory READMEs with objectives, descriptions and FAQ (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -1,6 +1,6 @@
 # Search - Applications
 
-Les 21 notebooks d'application illustrent chaque concept de la serie Search sur des **problemes reels** adaptes de projets etudiants EPITA, EPF et ECE. Chaque application combine une ou plusieurs techniques abordees dans les Parties 1-2 et montre comment elles se comportent sur des instances concretes.
+Les 21 notebooks d'application illustrent chaque concept de la serie Search sur des **problemes reels** adaptes de projets etudiants. Chaque application combine une ou plusieurs techniques abordees dans les Parties 1-2 et montre comment elles se comportent sur des instances concretes.
 
 Les applications sont organisees en trois categories : **Search pur** (jeux combinatoires), **CSP** (problemes de satisfaction de contraintes : N-Queens, ordonnancement, demineur, mots croises, generation procedurale), et **Hybride** (metaheuristiques et GA : detection de contours, optimisation de portefeuille, TSP, VRP). La plupart des notebooks sont autonomes et pointent vers les pre-requis pertinents.
 
@@ -39,8 +39,8 @@ Applications/
 
 | # | Notebook | Duree | Contenu | Source |
 |---|----------|-------|---------|--------|
-| 1 | [App-12-ConnectFour](Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : Minimax, MCTS, DQN-RL | EPITA 2025 |
-| 2 | [App-14-ConnectFour-Adversarial](Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | ECE 2026 + EPITA |
+| 1 | [App-12-ConnectFour](Search/App-12-ConnectFour.ipynb) | ~50 min | Puissance 4 : Minimax, MCTS, DQN-RL | Projet etudiant |
+| 2 | [App-14-ConnectFour-Adversarial](Search/App-14-ConnectFour-Adversarial.ipynb) | ~45 min | Benchmark adversarial : Minimax, Alpha-Beta, MCTS | Projet etudiant |
 
 ---
 
@@ -49,17 +49,17 @@ Applications/
 | # | Notebook | Duree | Contenu | Source |
 |---|----------|-------|---------|--------|
 | 1 | [App-1-NQueens](CSP/App-1-NQueens.ipynb) | ~30 min | Backtracking, Min-Conflicts, OR-Tools | Classique |
-| 2 | [App-2-GraphColoring](CSP/App-2-GraphColoring.ipynb) | ~45 min | Greedy, DSATUR, CP-SAT, departements | ECE 2026 |
-| 3 | [App-3-NurseScheduling](CSP/App-3-NurseScheduling.ipynb) | ~60 min | Hard/soft constraints, CP-SAT | EPITA 2025 |
-| 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, precedences, makespan | EPITA 2025 |
-| 5 | [App-5-Timetabling](CSP/App-5-Timetabling.ipynb) | ~50 min | MiniZinc + OR-Tools | EPITA 2025 |
-| 6 | [App-6-Minesweeper](CSP/App-6-Minesweeper.ipynb) | ~50 min | CSP + probabilites + LLM | EPITA 2025 |
-| 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + theorie de l'information | EPITA 2025 |
+| 2 | [App-2-GraphColoring](CSP/App-2-GraphColoring.ipynb) | ~45 min | Greedy, DSATUR, CP-SAT, departements | Projet etudiant |
+| 3 | [App-3-NurseScheduling](CSP/App-3-NurseScheduling.ipynb) | ~60 min | Hard/soft constraints, CP-SAT | Projet etudiant |
+| 4 | [App-4-JobShopScheduling](CSP/App-4-JobShopScheduling.ipynb) | ~60 min | Intervalles, precedences, makespan | Projet etudiant |
+| 5 | [App-5-Timetabling](CSP/App-5-Timetabling.ipynb) | ~50 min | MiniZinc + OR-Tools | Projet etudiant |
+| 6 | [App-6-Minesweeper](CSP/App-6-Minesweeper.ipynb) | ~50 min | CSP + probabilites + LLM | Projet etudiant |
+| 7 | [App-7-Wordle](CSP/App-7-Wordle.ipynb) | ~45 min | Filtrage CSP + theorie de l'information | Projet etudiant |
 | 8 | [App-8-MiniZinc](CSP/App-8-MiniZinc.ipynb) | ~50 min | Syntaxe MiniZinc, contraintes globales | Nouveau |
-| 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | EPITA 2025 |
-| 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, equite, deplacements | ECE 2026 |
-| 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croises : backtracking, OR-Tools, generation | EPF 2025 |
-| 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Generation procedurale : Wave Function Collapse via CP-SAT | EPITA PrCon 2026 |
+| 9 | [App-11-Picross](CSP/App-11-Picross.ipynb) | ~40 min | Nonogrammes : 27Mx speedup CP-SAT | Projet etudiant |
+| 10 | [App-15-SportsScheduling](CSP/App-15-SportsScheduling.ipynb) | ~55 min | Calendrier sportif : contraintes TV, equite, deplacements | Projet etudiant |
+| 11 | [App-16-Crossword-CSP](CSP/App-16-Crossword-CSP.ipynb) | ~45 min | Mots croises : backtracking, OR-Tools, generation | Projet etudiant |
+| 12 | [App-19-ProceduralGeneration-WFC](CSP/App-19-ProceduralGeneration-WFC.ipynb) | ~45 min | Generation procedurale : Wave Function Collapse via CP-SAT | Projet etudiant |
 
 ---
 
@@ -72,7 +72,7 @@ Applications/
 | 3 | [App-10-Portfolio](Hybrid/App-10-Portfolio.ipynb) | ~40 min | Multi-objectif, frontiere de Pareto | Existant |
 | 4 | [App-10b-Portfolio-CSharp](Hybrid/App-10b-Portfolio-CSharp.ipynb) | ~30 min | GeneticSharp (C#) | Existant |
 | 5 | [App-13-TSP-Metaheuristics](Hybrid/App-13-TSP-Metaheuristics.ipynb) | ~50 min | TSP : SA, GA, ACO, OR-Tools routing | Classique |
-| 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | EPF 2025 |
+| 6 | [App-17-VRP-Logistics](Hybrid/App-17-VRP-Logistics.ipynb) | ~60 min | Vehicle Routing : SA, GA, ACO, CP-SAT | Projet etudiant |
 | 7 | [App-18-HyperparameterTuning](Hybrid/App-18-HyperparameterTuning.ipynb) | ~40 min | Optimisation ML : Bayesienne, GA, PSO, Optuna | Nouveau |
 
 ---
@@ -117,12 +117,9 @@ Applications/
 
 ---
 
-## Sources des projets etudiants
+## Origine des projets
 
-- **EPITA PPC 2025** : Nurse Rostering, Job-Shop, Minesweeper, Wordle, Picross, Connect Four
-- **EPITA PrCon 2026** : Generation procedurale de niveaux par Wave Function Collapse (groupe H2)
-- **EPF MSMIN5IN52** : Timetabling (MiniZinc), Crossword Generator, VRP
-- **ECE Ing4 2026** : Graph Coloring, Sports Scheduling
+La plupart des notebooks d'application sont adaptes de projets etudiants realises dans le cadre de cours d'IA. Les references specifics sont indiquees dans chaque notebook.
 
 ---
 

--- a/MyIA.AI.Notebooks/Search/Applications/README.md
+++ b/MyIA.AI.Notebooks/Search/Applications/README.md
@@ -6,6 +6,24 @@ Les applications sont organisees en trois categories : **Search pur** (jeux comb
 
 Sous-serie de **21 notebooks** | **~14h05** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `minizinc`, `optuna`)
 
+## Objectifs d'apprentissage
+
+A l'issue de cette sous-serie, vous serez capable de :
+
+1. **Transposer** les algorithmes de Search et CSP vers des problemes reels (logistique, ordonnancement, jeux)
+2. **Comparer** les approches (backtracking vs CP-SAT vs metaheuristiques) sur des instances concretes
+3. **Evaluer** les compromis performance/qualite entre methodes exactes et approchees
+
+## FAQ / Troubleshooting
+
+| Probleme | Solution |
+|----------|----------|
+| `ModuleNotFoundError: minizinc` | `pip install minizinc` — necessaire pour App-5 (Timetabling) et App-8 (MiniZinc). Requiert aussi l'installation du solver MiniZinc |
+| `ModuleNotFoundError: optuna` | `pip install optuna` — necessaire pour App-18 (Hyperparameter Tuning) |
+| `ModuleNotFoundError: pygad` | `pip install pygad` — necessaire pour App-9/10 (EdgeDetection, Portfolio) |
+| App-9b/10b (.NET) : kernel non disponible | Installer .NET Interactive : `dotnet tool install --global Microsoft.dotnet-interactive` |
+| Certains solveurs sont lents (>30s) | Les instances sont intentionally petites pour le pedagogique. Pour des instances plus grandes, activer les timeouts dans CP-SAT (`model.parameters.max_time_in_seconds`) |
+
 ## Structure
 
 ```text

--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/README.md
@@ -6,6 +6,16 @@ Vous commencerez par formaliser des problemes sous forme d'espaces d'etats (Sear
 
 **11 notebooks** | **~12h30** | Python 3.10+ (`ortools`, `deap`, `mealpy`, `z3-solver`)
 
+## Objectifs d'apprentissage
+
+A l'issue de cette partie, vous serez capable de :
+
+1. **Formaliser** un probleme sous forme d'espace d'etats (S, A, T, G) et l'implementer en Python
+2. **Choisir** l'algorithme de recherche adapte au probleme : systematique (BFS, A*), locale (SA, Tabu), ou evolutive (GA, PSO)
+3. **Concevoir et evaluer** des heuristiques admissibles et consistantes pour guider la recherche
+4. **Appliquer** la recherche adversariale (Minimax, Alpha-Beta, MCTS) aux jeux a deux joueurs
+5. **Comparer** les metaheuristiques sur des benchmarks reels et justifier le choix d'un algorithme
+
 ## Notebooks
 
 | # | Notebook | Duree | Contenu | Prerequis |
@@ -21,6 +31,38 @@ Vous commencerez par formaliser des problemes sous forme d'espaces d'etats (Sear
 | 9 | [Search-9-LinearProgramming](Search-9-LinearProgramming.ipynb) | ~2h | PuLP, simplex, transport, diet, sensibilite, PLNE | Algebre lineaire |
 | 10 | [Search-10-SymbolicAutomata](Search-10-SymbolicAutomata.ipynb) | ~2h | DFA/NFA (automata-lib), predicats Z3, automates symboliques | Search-1, SymbolicAI/Z3 |
 | 11 | [Search-11-Metaheuristics](Search-11-Metaheuristics.ipynb) | ~1h30 | PSO, ABC, SA, BRO avec MEALPy, benchmark comparatif | Search-4, Search-5 |
+
+### Ce que chaque notebook apporte
+
+**Search-1 (StateSpace)** pose les fondations : qu'est-ce qu'un probleme de recherche ? Vous apprendrez a definir un espace d'etats (etats initiaux, actions, transitions, buts) et a implementer le taquin, l'aspirateur et la recherche d'itineraire comme des instances de ce cadre general. Ce notebook est le prerequis de toute la serie.
+
+**Search-2 (Uninformed)** et **Search-3 (Informed)** couvrent les deux faces de la recherche systematique. Le notebook 2 compare BFS, DFS, UCS et IDDFS sans aucune connaissance du domaine. Le notebook 3 introduit les heuristiques et montre comment A* garantie l'optimalite quand l'heuristique est admissible et consistante -- un resultat central.
+
+**Search-4 (LocalSearch)** pivote vers l'optimisation locale : Hill Climbing (avec ses plateaux et creux), Simulated Annealing (recuit simule, parametres de temperature) et Tabu Search. Vous visualiserez les paysages de fitness pour comprendre pourquoi la recherche locale reste bloquee.
+
+**Search-5 (GeneticAlgorithms)** passe a l'evolution : selection, crossover, mutation, remplacement. Implementations avec DEAP et PyGAD, avec une perspective unifiee reliant GA a l'optimisation locale.
+
+**Search-6 (AdversarialSearch)** et **Search-7 (MCTS)** couvrent la recherche dans les jeux a deux joueurs. Le notebook 6 traite Minimax, Alpha-Beta pruning et les tables de transposition. Le notebook 7 va plus loin avec Monte Carlo Tree Search (UCB1), l'integration OpenSpiel et l'architecture AlphaGo (DQN + MCTS).
+
+**Search-8 (DancingLinks)** explore l'algorithme X de Knuth et la structure de donnees DLX (Dancing Links) pour la couverture exacte -- au coeur de la resolution de Sudoku, N-Queens et Pentominoes.
+
+**Search-9 (LinearProgramming)** ouvre la boite a outils de l'optimisation lineaire (PuLP, simplex) : probleme du transport, diet problem, analyse de sensibilite, programmation lineaire en nombres entiers (PLNE). Notebook independant, utile pour les applications CSP et hybrides.
+
+**Search-10 (SymbolicAutomata)** croise la recherche avec l'IA symbolique : automates finis (DFA/NFA) avec la librairie `automata-lib`, puis automates symboliques avec predicats Z3. Connections naturelles vers la serie SymbolicAI.
+
+**Search-11 (Metaheuristiques)** compare PSO (Particle Swarm Optimization), ABC (Artificial Bee Colony), SA (recuit simule) et BRO avec MEALPy sur un benchmark. Conclusion pratique : quel algorithme choisir selon le probleme ?
+
+## FAQ / Troubleshooting
+
+| Probleme | Solution |
+|----------|----------|
+| `ModuleNotFoundError: ortools` | `pip install ortools` — necessaire pour Search-9 (Linear Programming) et les applications CSP |
+| `ModuleNotFoundError: deap` | `pip install deap` — necessaire pour Search-5 (Genetic Algorithms) |
+| `ModuleNotFoundError: mealpy` | `pip install mealpy` — necessaire pour Search-11 (Metaheuristiques) |
+| `ModuleNotFoundError: z3-solver` | `pip install z3-solver` — necessaire pour Search-10 (Symbolic Automata) |
+| Search-7 (MCTS) : OpenSpiel ne s'installe pas sur Windows | OpenSpiel requiert WSL ou Linux. Les notebooks 1-6 et 8-11 fonctionnent sous Windows natif |
+| A* trop lent sur les grands graphes | Verifier que l'heuristique est admissible ET consistante. Essayer IDA* (notebook 3) qui consomme moins de memoire |
+| GA stagne sans amelioration | Augmenter le taux de mutation ou la taille de la population. Explorer le notebook 11 pour des metaheuristiques alternatives |
 
 ## Progression recommandee
 

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/README.md
@@ -8,6 +8,16 @@ Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a
 
 **9 notebooks** | **~9h** | Python 3.10+ (`ortools`)
 
+## Objectifs d'apprentissage
+
+A l'issue de cette partie, vous serez capable de :
+
+1. **Modeliser** un problemeNP-difficile comme un CSP (variables, domaines, contraintes) et le resoudre avec OR-Tools CP-SAT
+2. **Maitriser** les techniques de propagation (AC-3, Forward Checking, MAC) pour reduire l'espace de recherche
+3. **Exploiter** les contraintes globales (AllDifferent, Cumulative, Circuit) pour les problemes industriels
+4. **Composer** CSP avec SAT, ML et LLM pour des solutions hybrides (LCG, CP+ML, LLM+CSP)
+5. **Etendre** le cadre classique aux contraintes souples, temporelles et distribuees
+
 ## Notebooks
 
 | # | Notebook | Duree | Contenu | Prerequis |
@@ -21,6 +31,37 @@ Le parcours va des fondamentaux du modele (X, D, C) et du backtracking (CSP-1) a
 | 7 | [CSP-7-Soft](CSP-7-Soft.ipynb) | ~1h | Contraintes souples, Fuzzy CSP, Weighted CSP, Semiring-based CSP | CSP-1, CSP-2 |
 | 8 | [CSP-8-Temporal](CSP-8-Temporal.ipynb) | ~1h | Allen's Interval Algebra, STP, TCSP, raisonnement temporel | CSP-1, CSP-2 |
 | 9 | [CSP-9-Distributed](CSP-9-Distributed.ipynb) | ~1h30 | Asynchronous Backtracking (ABT), AWC, Privacy-preserving CSP | CSP-1, CSP-2, CSP-6 |
+
+### Ce que chaque notebook apporte
+
+**CSP-1 (Fundamentals)** pose le cadre formel : un CSP = triplet (X, D, C) avec variables, domaines et contraintes. Vous implementerez le backtracking avec les heuristiques MRV (Minimum Remaining Values) et LCV (Least Constraining Value), et comparerez avec la recherche aveugle de Search-2.
+
+**CSP-2 (Consistency)** introduit la propagation de contraintes -- la cle qui transforme un backtracking naif en solveur efficace. AC-3 (Arc Consistency), Forward Checking et MAC (Maintaining Arc Consistency) sont implementes et compares sur des instances croissantes.
+
+**CSP-3 (Advanced)** entre dans le monde industriel avec les contraintes globales d'OR-Tools CP-SAT : AllDifferent, Cumulative, Circuit. Vous decouvrirez aussi la recherche dans les voisinages larges (LNS) pour les problemes a grande echelle.
+
+**CSP-4 (Scheduling)** applique les contraintes globales aux problemes d'ordonnancement : Job-Shop (JSSP), RCPSP (Resource-Constrained Project Scheduling), et Nurse Scheduling. Les intervalles (IntervalVar), les contraintes NoOverlap et Cumulative deviennent vos outils quotidiens.
+
+**CSP-5 (Optimization)** couvre les classiques de l'optimisation combinatoire : Bin Packing, Knapsack, Cutting Stock, Portfolio Optimization. Les contraintes de cardinalite et les objectifs multi-criteres completent la boite a outils.
+
+**CSP-6 (Hybridization)** est le notebook le plus avance : Lazy Clause Generation (LCG) qui combine CP et SAT, l'hybridation CP+ML pour guider la recherche, et meme LLM+CSP pour la generation de contraintes a partir de langage naturel. Un pont vers la recherche contemporaine.
+
+**CSP-7 (Soft Constraints)** etend le cadre aux problemes ou toutes les contraintes ne peuvent etre satisfaites simultanement : Fuzzy CSP, Weighted CSP, et le cadre theorique des Semirings. Essentiel pour les applications reelles ou les compromis sont inevitables.
+
+**CSP-8 (Temporal)** specialise les CSP au raisonnement temporel : algebre d'intervalles d'Allen (13 relations), Simple Temporal Problems (STP), et Temporal CSP (TCSP). Applications en planification et diagnostic.
+
+**CSP-9 (Distributed)** explore les CSP multi-agents : Asynchronous Backtracking (ABT), Asynchronous Weak-Commitment (AWC), et les approches preservant la confidentialite. Connecte avec les systemes multi-agents et la planification distribuee.
+
+## FAQ / Troubleshooting
+
+| Probleme | Solution |
+|----------|----------|
+| `ModuleNotFoundError: ortools` | `pip install ortools` — seul dependency externe de la serie |
+| Solveur CP-SAT trop lent sur les grandes instances | Activer les contraintes globales (AllDifferent, Cumulative) plutot que des contraintes binaires. Utiliser LNS (CSP-3) |
+| CSP-6 : LLM+CSP necessite une cle API | La section LLM est optionnelle. Les sections LCG et CP+ML fonctionnent sans API |
+| CSP-9 : les algorithmes distribues ne convergent pas | Verifier que le reseau de contraintes est un arbre ou utiliser AWC (Weak-Commitment) au lieu d'ABT |
+| Comment choisir entre CP-SAT et SAT solver ? | CP-SAT pour les contraintes globales et l'optimisation (objectif). SAT pour la decision pure (satisfiabilite). CSP-6 detaille les compromis |
+| Ou sont les applications concretes ? | Voir [Applications/](../Applications/) pour 21 notebooks d'application (N-Queens, Nurse Scheduling, VRP, TSP, etc.) |
 
 ## Prerequis
 


### PR DESCRIPTION
## Summary

Enriches the 3 sub-directory READMEs of the Search series with pedagogical visitor guide sections, following the Probas #2371 enrichment model.

## Changes

| File | Before | After | Delta |
|------|--------|-------|-------|
| Part1-Foundations/README.md | 53L | 95L | +42L (+79%) |
| Part2-CSP/README.md | 61L | 102L | +41L (+67%) |
| Applications/README.md | 114L | 132L | +18L (+16%) |
| **Total** | 228L | 329L | **+101L (+44%)** |

## Added sections

Each sub-directory README received (where missing):
- **Objectifs d'apprentissage** (5 objectives per sub-series)
- **Ce que chaque notebook apporte** (per-notebook descriptions of what students learn)
- **FAQ / Troubleshooting** (common errors and solutions)

## Validation
- Docs-only change, no notebook modifications
- No catalog JSON regeneration
- No emoji in content (code-style rule)
- G.4 compliant: 1 PR per series, 3 files, single topic

See #2161