### PR TITLE
docs: remove school names from all READMEs (SymbolicAI, SmartContracts, ML)

### DIFF
--- a/MyIA.AI.Notebooks/ML/README.md
+++ b/MyIA.AI.Notebooks/ML/README.md
@@ -21,7 +21,7 @@ Le parcours Python commence par les fondations (NumPy/Pandas) puis se divise en 
 
 ## Positionnement pedagogique
 
-Cette série sert les cours **ECE / EPITA / EPF** en introduction au Machine Learning appliqué. Elle se situe après les fondamentaux de programmation (Python ou C#) et avant les séries spécialisées ([QuantConnect](../QuantConnect/) pour le trading, [RL](../RL/) pour l'apprentissage par renforcement). Aucune prérequis en statistiques avancées : les concepts sont introduits au fil des notebooks.
+Cette série sert les cours d'introduction au Machine Learning appliqué. Elle se situe après les fondamentaux de programmation (Python ou C#) et avant les séries spécialisées ([QuantConnect](../QuantConnect/) pour le trading, [RL](../RL/) pour l'apprentissage par renforcement). Aucune prérequis en statistiques avancées : les concepts sont introduits au fil des notebooks.
 
 **Slides de cours associes** : [06-apprentissage/](../../slides/06-apprentissage/) | **Livre de reference** : [Hands-On AI Trading](https://www.hands-on-ai-trading.com/) (chapitres ML)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -251,7 +251,7 @@ Documentation complete : [SmartContracts/README.md](SmartContracts/README.md)
 
 Pipeline d'analyse argumentative multi-agents avec **Semantic Kernel** et LLMs. Combine detection de sophismes, formalisation logique, et validation par TweetyProject.
 
-> **Note** : Cette serie est un projet/demo, pas un cours. Aucun exercice etudiant. Non adaptee en l'etat pour EPITA.
+> **Note** : Cette serie est un projet/demo, pas un cours. Aucun exercice etudiant. Non adaptee en l'etat pour un cours structure.
 
 ### Structure detaillee
 
@@ -519,7 +519,7 @@ Le setup est entierement automatise via `Tweety-1-Setup.ipynb` :
 
 ## Ponts cross-series
 
-Ces connexions entre series sont exploitees dans le curriculum EPITA IA Symbolique (demarrage 18/05/2026).
+Ces connexions entre series sont exploitees dans le curriculum IA Symbolique.
 
 ### Lean <-> GameTheory (Choix social)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/README.md
@@ -209,4 +209,4 @@ Les mecanismes de vote et de gouvernance on-chain (SC-9, SC-17) sont des instanc
 
 ---
 
-*Serie creee pour CoursIA (EPITA IA Symbolique) - Issue #129*
+*Serie creee pour CoursIA - Issue #129*

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/mon-premier-projet/README.md
@@ -61,4 +61,4 @@ mon-premier-projet/
 
 ## Auteurs
 
-Nabil Chartouni, Lucas Majerczyk, Wilfrid Wangon Zekou — TP Smart Contracts EPITA-IS 2026.
+Nabil Chartouni, Lucas Majerczyk, Wilfrid Wangon Zekou — TP Smart Contracts 2026.


### PR DESCRIPTION
Remove EPITA/EPF/ECE references from README files.

Changes:
- SymbolicAI/README.md: 2 school-specific references replaced with generic labels
- SymbolicAI/SmartContracts/README.md: attribution line cleaned
- SymbolicAI/SmartContracts/mon-premier-projet/README.md: author line cleaned
- ML/README.md: course references cleaned

Related PRs already cleaning Search and Sudoku:
- PR #2403 (Search top README)
- PR #2404 (Sudoku README)
- PR #2409 (Search sub-dir READMEs)

Total across all PRs: 4 README files cleaned in this PR + 3 in related PRs.