### PR TITLE
docs(SemanticWeb): enrich README with editorial intro, concepts, alt tracks, FAQ (See #2065)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -7,15 +7,35 @@ breakdown: RDF-Foundations=6, Linked-Data-Ontologies=5, Modern-Standards=3, Know
 maturity: PRODUCTION=6, BETA=12
 -->
 
-Serie de notebooks pour explorer le **Web Semantique**, combinant **.NET C#** (dotNetRDF, fondations) et **Python** (rdflib, standards modernes, IA).
+Le Web Semantique est la promesse d'un Web ou les machines comprennent la signification des donnees, pas seulement leur syntaxe. RDF, SPARQL, OWL, SHACL : ces standards du W3C definissent un langage commun pour decrire, interroger, valider et raisonner sur des graphes de connaissances. Cette serie vous mene des fondations (.NET C# avec dotNetRDF) aux applications modernes (Python avec rdflib, pySHACL, GraphRAG), en passant par les ontologies, les donnees liees et les standards emergents (RDF 1.2, JSON-LD 1.1).
 
----
+**18 notebooks** | **2 langages** | **~10h**
 
-## Presentation
+**A qui s'adresse cette serie** : developpeurs web curieux du sens cache dans leurs donnees, data scientists voulant structurer leurs pipelines, et etudiants en IA souhaitant comprendre comment les graphes de connaissances ancrent les LLMs. Aucun prerequis en logique formelle.
 
-Le Web Semantique etend le Web classique en permettant aux machines de comprendre la signification des donnees. Cette serie couvre l'ensemble du spectre : des fondations RDF aux graphes de connaissances integres aux LLMs (GraphRAG), en passant par SPARQL, OWL, SHACL, JSON-LD et RDF 1.2.
+## Pourquoi cette serie
 
-La vision originale de Tim Berners-Lee etait de creer un "Web de donnees" ou les informations seraient liees de facon signifiante, permettant aux machines d'effectuer des raisonnements automatiques. Cette serie vous accompagnera depuis les concepts fondamentaux jusqu'aux applications modernes integrant l'IA generative.
+Le Web Semantique a traverse des cycles de hype et de desillusion. En 2001, Tim Berners-Lee en faisait la couverture de *Scientific American*. En 2010, les donnees liees semblaient une niche academique. En 2024, GraphRAG (Microsoft) a montre que les graphes de connaissances RDF pouvaient ancrer les LLMs sur des faits verifiables : le Web Semantique devenait un garde-fou pour l'IA generative.
+
+Cette serie couvre le spectre complet parce que les briques s'articulent : RDF definit les donnees, SPARQL les interroge, RDFS/OWL structurent le raisonnement, SHACL valide la qualite, JSON-LD ponte vers le Web, RDF-Star ajoute la provenance, et les KG+LLMs ferment la boucle. Chaque standard est une couche qui s'appuie sur les precedentes.
+
+La serie propose deliberement deux stacks : **.NET C#** (SW-1 a SW-7) pour les fondations avec dotNetRDF (typed, performant, integre a l'ecosysteme CoursIA), et **Python** (SW-8 a SW-13) pour les standards modernes et l'IA. Les sidetracks Python (SW-2b, 4b, 5b, 7b) offrent un miroir des notebooks C# en Python.
+
+## Concepts cles
+
+| Concept | En une phrase | Notebook |
+|---------|---------------|----------|
+| **Triplet RDF** | Un fait elementaire : sujet-predicat-objet (comme une phrase simple) | SW-2 |
+| **Graphe RDF** | Un ensemble de triplets formant un reseau semantique | SW-3 |
+| **SPARQL** | Le SQL du Web Semantique : interroger des graphes avec des patterns | SW-4 |
+| **Linked Data** | Des donnees publiees sur le Web avec des URIs resolvables | SW-5 |
+| **RDFS** | Un vocabulaire pour definir des hierarchies de classes et proprietes | SW-6 |
+| **OWL** | Une logique de description pour le raisonnement automatique | SW-7 |
+| **SHACL** | Des contraintes de validation sur les graphes (comme des schemas JSON) | SW-8 |
+| **JSON-LD** | Du JSON avec un contexte semantique (le pont Web classique ↔ Web Semantique) | SW-9 |
+| **RDF-Star** | Des metadonnees sur les triplets (provenance, confiance, annotations) | SW-10 |
+| **Graphe de connaissances** | Un RDF riche, visualisable, requetable, ancre dans une ontologie | SW-11 |
+| **GraphRAG** | Un KG ancre dans un LLM pour du RAG structure (anti-hallucination) | SW-12 |
 
 ## Vue d'ensemble
 
@@ -278,6 +298,44 @@ A l'issue de cette serie, l'apprenant est capable de :
 - **Serialiser et echanger des donnees RDF en JSON-LD** (`@context`, framing, compaction/expansion) pour interoperer avec les APIs Web modernes (`SW-9-Python-JSONLD.ipynb`).
 - **Annoter des assertions avec RDF-Star / SPARQL-Star** (citations de triplets, provenance, niveau de confiance) pour modeliser metadonnees et reification compacte (`SW-10-Python-RDFStar.ipynb`).
 - **Construire et exploiter un graphe de connaissances integre a un LLM** (extraction de triplets, embeddings, GraphRAG) pour ancrer les reponses generatives sur des donnees structurees (`SW-11-Python-KnowledgeGraphs.ipynb`, `SW-12-Python-GraphRAG.ipynb`).
+
+---
+
+## Parcours alternatifs
+
+### Parcours Python-only (~5h)
+
+Si vous n'avez pas d'environnement .NET, vous pouvez suivre uniquement les notebooks Python :
+
+1. **SW-2b** (RDF Basics Python) → **SW-4b** (SPARQL Python) → **SW-5b** (Linked Data Python) → **SW-7b** (OWL Python) : les 4 sidetracks couvrent les fondamentaux avec rdflib.
+2. Puis **SW-8** (SHACL) → **SW-9** (JSON-LD) → **SW-10** (RDF-Star) → **SW-11** (KG) → **SW-12** (GraphRAG) : les standards modernes et l'IA.
+
+### Parcours data engineer (~3h)
+
+Pour les praticiens qui veulent aller vite :
+
+1. **SW-2b** (RDF en 5 min) → **SW-4b** (SPARQL) → **SW-8** (SHACL : valider vos donnees) → **SW-9** (JSON-LD : exposer en API) → **SW-12** (GraphRAG : connecter aux LLMs).
+
+### Parcours ontologue (~4h)
+
+Pour les personnes creant des ontologies et des vocabulaires :
+
+1. **SW-6** (RDFS) → **SW-7** (OWL) → **SW-7b** (OWL Python) → **SW-8** (SHACL : contraintes sur les donnees) → **SW-13** (comparaison raisonneurs).
+
+## FAQ / Troubleshooting
+
+| Probleme | Solution |
+|----------|----------|
+| `dotNetRDF` NuGet restore echoue | Verifier .NET SDK 9.0+ (`dotnet --version`). Relancer la cellule d'import. |
+| Endpoint DBpedia/Wikidata timeout | Les endpoints publics ont des limites. Ajouter `LIMIT 100` aux requetes. Reessayer hors heures de pointe. |
+| pySHACL validation vide | Verifier que les prefixes du graphe de donnees correspondent aux shapes (meme `ex:` namespace). |
+| OWLReady2 Java bridge error | Installer JDK 11+ (OWlReady2 utilise HermiT en Java). Sur Windows : `winget install EclipseAdoptium.Temurin.11.JDK`. |
+| RDF-Star syntax non reconnue | rdflib 7.x supporte RDF-Star en mode experimental. Verifier `rdflib.__version__ >= 7.0`. |
+| GraphRAG : `OPENAI_API_KEY` manquant | SW-12 requiert une cle LLM (OpenAI ou Anthropic). Configurer `.env` (voir `.env.example`). Les notebooks SW-1 a SW-11 n'ont pas besoin de cle. |
+
+## Lecture transversale
+
+La serie SemanticWeb illustre un mouvement profond du depot CoursIA : **prendre des donnees non-structurees et les re-representer dans un cadre verifiable**. RDF donne un sens formel a du JSON, OWL ajoute le raisonnement, SHACL ajoute la validation, GraphRAG ancre les LLMs sur des faits. Ce geste — trouver la representation ou le probleme se dissout — traverse toutes les series du depot, des CSP (Search) aux preuves Lean (SymbolicAI). La cle de lecture [La mer qui monte](../../../docs/grothendieckian-lens.md) developpe ce fil conducteur.
 
 ---
 


### PR DESCRIPTION
## Summary

Enrichissement du README SemanticWeb suivant le modele Probas #2371 :

1. **Introduction editoriale** (`Pourquoi cette serie`) : Berners-Lee 2001 → desillusion 2010 → GraphRAG 2024. Le Web Semantique comme garde-fou pour l'IA generative.
2. **Concepts cles** : table 11 lignes (Triplet RDF → GraphRAG, chacun en une phrase + notebook)
3. **3 parcours alternatifs** : Python-only (~5h), data engineer (~3h), ontologue (~4h)
4. **FAQ/Troubleshooting** : 6 problemes courants (NuGet restore, endpoint timeout, pySHACL, OWLReady2 Java, RDF-Star, GraphRAG API key)
5. **Lecture transversale** : lien vers `docs/grothendieckian-lens.md` (changement de representation)

Markdown-only (+63/-5), CATALOG-STATUS preserve.

## Verification
- [x] Pas de re-execution requise (markdown uniquement)
- [x] CATALOG-STATUS marker intact
- [x] Tous les numeros de notebooks cites existent

See #2065