### PR TITLE
wire(Conway): import KochenSpecker now that sorry=0 (See #2157)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
@@ -29,5 +29,6 @@ import Conway.Life.Computation
 import Conway.Life.HashlifeCorrectness
 import Conway.Life.HashlifeMemo
 import Conway.Life.Pillars
+import Conway.KochenSpecker
 import Conway.FreeWillTheorem
 import Conway.MathlibMap


### PR DESCRIPTION
## Summary

Wire `Conway.KochenSpecker` into the Conway.lean umbrella import.

Since PR #2019 (2026-06-01), KochenSpecker.lean has **0 sorry** — the 18-vector Cabello proof is fully proved via parity argument (`fin_cases` + `decide` + `Finset.sum_comm` + `omega`).

Issue #2157 criterion 3 said: **NE PAS importer tant que sorry != 0**. This restriction no longer applies.

## Changes

- `Conway.lean`: Added `import Conway.KochenSpecker` between `Conway.Life.Pillars` and `Conway.FreeWillTheorem`

## Validation

- **Lake build SUCCESS**: 2950 jobs, `Conway.KochenSpecker` compiled clean
- **sorry count**: 0 (verified `grep -c sorry`)
- **Diff**: 1 file, +1 line

## Related

- See #2157 (Conway Lean depth Epic)
- See #2155 (Lean-14b 3-pillars)