### PR TITLE
docs(IIT): enrich README as pedagogical visitor guide (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/README.md
+++ b/MyIA.AI.Notebooks/IIT/README.md
@@ -7,11 +7,23 @@ breakdown: root=2
 maturity: PRODUCTION=2
 -->
 
-La conscience est-elle mesurable ? La Théorie de l'Information Intégrée (IIT), proposée par Giulio Tononi, répond oui : un système est conscient dans la mesure où il intègre de l'information de manière non réductible. Plus formellement, la quantité de conscience d'un système correspond à la valeur **Phi** (big Phi), qui mesure le degré d'intégration causale irréductible. Cette série vous apprend à calculer cette mesure avec **PyPhi**, la bibliothèque de référence du laboratoire Tononi, et à explorer la géométrie informationnelle des systèmes complexes.
+La conscience est-elle mesurable ? La Theorie de l'Information Integree (IIT), proposee par Giulio Tononi, repond oui : un systeme est conscient dans la mesure ou il integre de l'information de maniere non reductible. Plus formellement, la quantite de conscience d'un systeme correspond a la valeur **Phi** (big Phi), qui mesure le degre d'integration causale irreductible. Cette serie vous apprend a calculer cette mesure avec **PyPhi**, la bibliotheque de reference du laboratoire Tononi, et a explorer la geometrie informationnelle des systemes complexes.
 
-Le premier notebook couvre le spectre fondamental : construction de graphes causaux binaires, calcul des Transition Probability Matrices (TPM), définition des sous-systèmes, extraction des Cause-Effect Structures (CES), et exploration des macro-subsystemes. Le second approfondit les aspects avancés : partitionnement MIP, repertoires cause-effet, MICE, comparaison big Phi vs small phi, reseaux elargis a 4+ noeuds, coarse-graining et apercu IIT 4.0.
+Le premier notebook couvre le spectre fondamental : construction de graphes causaux binaires, calcul des Transition Probability Matrices (TPM), definition des sous-systemes, extraction des Cause-Effect Structures (CES), et exploration des macro-subsystemes. Le second approfondit les aspects avances : partitionnement MIP, repertoires cause-effet, MICE, comparaison big Phi vs small phi, reseaux elargis a 4+ noeuds, coarse-graining et apercu IIT 4.0.
 
-**À qui s'adresse cette série** : étudiants en sciences cognitives, neuroscience computationnelle, et philosophie de l'esprit. Les notebooks (~60-90 min chacun) nécessitent Python 3.9 avec `pyphi` (installé via conda env dédié). Une familiarité avec les graphes et la logique booléenne suffit. Il constitue un complément théorique aux séries [Probas](../Probas/README.md) (modèles probabilistes) et [GameTheory](../GameTheory/README.md) (systèmes multi-agents), avec lesquelles il partage les concepts de causalité et d'interaction.
+**A qui s'adresse cette serie** : etudiants en sciences cognitives, neuroscience computationnelle, et philosophie de l'esprit. Les notebooks (~60-90 min chacun) necessitent Python 3.9 avec `pyphi` (installe via conda env dedie). Une familiarite avec les graphes et la logique booleenne suffit. Il constitue un complement theorique aux series [Probas](../Probas/README.md) (modeles probabilistes) et [GameTheory](../GameTheory/README.md) (systemes multi-agents), avec lesquelles il partage les concepts de causalite et d'interaction.
+
+## Objectifs d'apprentissage
+
+A l'issue de cette serie, vous serez capable de :
+
+1. **Construire et manipuler des reseaux causaux** binaires avec PyPhi (TPM, noeuds, connexions)
+2. **Calculer Phi** pour un sous-systeme et interpreter sa valeur (integration vs separabilite)
+3. **Analyser une Cause-Effect Structure (CES)** : identifier les concepts, mecanismes et purviews
+4. **Appliquer le partitionnement MIP** pour localiser le "maillon faible" d'un systeme
+5. **Differencier big Phi et small phi** et comprendre leur roles respectifs dans la theorie
+6. **Evaluer les limites computationnelles** de l'IIT et les strategies de coarse-graining
+7. **Discuter les implications philosophiques** de l'IIT pour la conscience artificielle
 
 ## Vue d'ensemble
 
@@ -22,12 +34,37 @@ Le premier notebook couvre le spectre fondamental : construction de graphes caus
 | Duree estimee | ~120-180 min |
 | Version | PyPhi 1.2.0+ |
 
-## Notebook
+## Notebooks
 
-| # | Notebook | Contenu | Durée |
+| # | Notebook | Contenu | Duree |
 |---|----------|---------|-------|
-| 1 | [Intro_to_PyPhi](Intro_to_PyPhi.ipynb) | Introduction complète à PyPhi et IIT | 60-90 min |
+| 1 | [Intro_to_PyPhi](Intro_to_PyPhi.ipynb) | Introduction complete a PyPhi et IIT | 60-90 min |
 | 2 | [IIT-2-AdvancedTopics](IIT-2-AdvancedTopics.ipynb) | Partitionnement MIP, repertoires, MICE, reseaux elargis | 60-90 min |
+
+## Parcours recommandes
+
+```
+Notebook 1 (Fondements)
+    |
+    v
+Notebook 2 (Sujets avances)
+```
+
+| Objectif | Parcours |
+|----------|----------|
+| Decouverte rapide | Notebook 1 seul |
+| Maitrise complete | Notebook 1 puis 2 |
+| Focus philosophie | Notebook 1 (sections CES + debats) + Notebook 2 (section IIT 4.0) |
+
+### Parcours d'apprentissage
+
+**Phase 1 : Fondements (~90 min, notebook 1)**
+
+Vous installez PyPhi dans un environnement conda dedie (Python 3.9 obligatoire), puis construisez votre premier reseau causal binaire. Le calcul de Phi sur un reseau XOR a 3 noeuds illustre concretement la notion d'integration irreductible. L'exploration de la CES revele comment un systeme "specifie" sa propre geometrie informationnelle. Les 4 exercices vous font varier les sous-systemes, les topologies de reseau et les parametres pour developper une intuition sur ce qui fait monter ou baisser Phi.
+
+**Phase 2 : Approfondissement (~90 min, notebook 2)**
+
+Le deuxieme notebook deconstruit le calcul de Phi : vous manipulez les bipartitions (MIP), les repertoires cause-effet, et les MICE (Maximally Irreducible Cause or Effect). La comparaison big Phi vs small phi clarifie les deux niveaux d'analyse. L'extension a des reseaux a 4+ noeuds montre l'explosion combinatoire et justifie le coarse-graining. L'apercu IIT 4.0 ouvre sur les evolutions recentes de la theorie. Les 3 exercices testent votre comprehension des repertoires, du Phi multi-etats et des reseaux feed-forward (Phi = 0 attendu).
 
 ## Contenu detaille
 
@@ -63,8 +100,11 @@ Le premier notebook couvre le spectre fondamental : construction de graphes caus
 | **TPM** | Regles d'evolution du systeme | Lois de la physique |
 | **Etat** | Configuration binaire des noeuds (0 ou 1) | Instantane cerebral |
 | **Phi (Big Phi)** | Niveau d'integration du systeme | Force d'un noeud de corde |
+| **Small phi** | Integration d'un mecanisme individuel | Tension d'un fil du noeud |
 | **MIP** | Point faible du systeme (Minimum Information Partition) | Maillon le plus faible |
-| **CES** | Geometrie informationnelle | Forme d'une pensee |
+| **CES** | Geometrie informationnelle (Cause-Effect Structure) | Forme d'une pensee |
+| **MICE** | Mechanisme maximalement irreductible | Brique elementaire de conscience |
+| **Purview** | Ensemble de noeuds sur lesquels un mecanisme specifie de l'information | Champ d'influence |
 
 ## Prerequis
 
@@ -117,12 +157,34 @@ La Theorie de l'Information Integree (IIT) propose une approche mathematique de 
 
 L'IIT n'est pas qu'une speculation philosophique : elle a engendre des outils utilises en clinique et alimente l'un des debats les plus vifs des neurosciences.
 
-- **Mesure clinique de la conscience.** Le *Perturbational Complexity Index* (PCI), inspire des principes de l'IIT, est utilise pour evaluer la conscience chez des patients non communicants (coma, etat vegetatif, anesthesie). Le protocole « zap-and-zip » (stimulation TMS + EEG, compression de la reponse) distingue empiriquement les etats conscients des etats inconscients — une retombee concrete et reproductible d'une theorie de la conscience.
+- **Mesure clinique de la conscience.** Le *Perturbational Complexity Index* (PCI), inspire des principes de l'IIT, est utilise pour evaluer la conscience chez des patients non communicants (coma, etat vegetatif, anesthesie). Le protocole "zap-and-zip" (stimulation TMS + EEG, compression de la reponse) distingue empiriquement les etats conscients des etats inconscients — une retombee concrete et reproductible d'une theorie de la conscience.
 - **Une theorie concurrente.** L'IIT s'oppose frontalement aux theories de type *Global Workspace* (Dehaene, Baars), qui font de la conscience une diffusion globale de l'information plutot qu'une integration causale locale. Des programmes de tests adversariaux (collaboration Templeton) confrontent leurs predictions sur des donnees reelles.
-- **Enjeu pour l'IA.** L'IIT predit qu'un reseau purement *feed-forward* (comme l'inference d'un LLM classique) a un Phi nul : il calcule sans « etre » conscient, faute de boucles causales integrees. Cette these est centrale dans les discussions sur la conscience artificielle.
-- **Controverse.** Le calcul exact de Phi est computationnellement intractable au-dela de petits reseaux (d'ou le coarse-graining du notebook), et la theorie a fait l'objet d'une critique publique retentissante (lettre ouverte de 2023 la qualifiant de « pseudoscience ») — un cas d'ecole pour discuter des criteres de scientificite d'une theorie de l'esprit.
+- **Enjeu pour l'IA.** L'IIT predit qu'un reseau purement *feed-forward* (comme l'inference d'un LLM classique) a un Phi nul : il calcule sans "etre" conscient, faute de boucles causales integrees. Cette these est centrale dans les discussions sur la conscience artificielle.
+- **Controverse.** Le calcul exact de Phi est computationnellement intractable au-dela de petits reseaux (d'ou le coarse-graining du notebook), et la theorie a fait l'objet d'une critique publique retentissante (lettre ouverte de 2023 la qualifiant de "pseudoscience") — un cas d'ecole pour discuter des criteres de scientificite d'une theorie de l'esprit.
 
 Ces tensions font de l'IIT un excellent terrain pour exercer l'esprit critique : on y manipule un formalisme precis (calculable avec PyPhi) tout en gardant a l'esprit les limites de son interpretation.
+
+## FAQ
+
+### Pourquoi Python 3.9 est-il obligatoire ?
+
+PyPhi 1.2.0 utilise `collections.Iterable`, qui a ete supprime dans Python 3.10 (PEP 585). Tenter d'installer PyPhi sur Python 3.10+ provoque une `ImportError` des le `import pyphi`. L'environnement conda dedie isole cette contrainte sans affecter vos autres projets.
+
+### Quelle est la difference entre big Phi et small phi ?
+
+**Big Phi** ($\Phi$) mesure l'integration au niveau du systeme complet : il quantifie a quel point le systeme est "plus que la somme de ses parties". **Small phi** ($\varphi$) mesure l'integration d'un mecanisme individuel (un sous-ensemble de noeuds) : chaque concept dans la CES a son propre small phi. La CES est l'ensemble des concepts dont le small phi > 0, et le big Phi aggrege ces contributions.
+
+### Un reseau feed-forward peut-il etre conscient selon l'IIT ?
+
+Non. L'IIT predit qu'un reseau purement feed-forward (A -> B -> C, sans boucle de retroaction) a un Phi de zero. L'information transite mais n'est pas "integree" — il n'y a pas de causalite bidirectionnelle. C'est un resultat fondamental pour le debat sur la conscience des LLMs, dont l'inference est essentiellement feed-forward.
+
+### Le calcul de Phi est-il tractable en pratique ?
+
+Pas au-dela de ~5-7 noeuds en pratique. Le nombre de bipartitions a evaluer croit super-exponentiellement avec la taille du systeme. Le notebook 2 (section 7) demontre cette explosion et introduit le coarse-graining comme strategie d'approximation. Pour les systemes reels (cerveau humain : ~86 milliards de neurones), seul le PCI (mesure clinique indirecte) est applicable.
+
+### Peut-on utiliser PyPhi pour un projet de recherche ?
+
+Oui, mais avec caveats. PyPhi est la reference pour IIT 3.0, mais IIT 4.0 (2024+) introduit des changements fondamentaux dans le calcul de Phi. Pour un projet de recherche, verifier la version de la theorie que vous suivez et consulter la [documentation PyPhi](https://pyphi.readthedocs.io/en/stable/) pour les limitations actuelles.
 
 ## Ressources
 
@@ -157,6 +219,7 @@ Voir la licence du repository principal.
 
 | Serie | Lien | Connection |
 |-------|------|-------------|
-| [Probas](../Probas/README.md) | Infer.NET / Pyro | Modeles probabilistes partagent les memes fondements que la mesure d'integration (phi) |
-| [GameTheory](../GameTheory/README.md) | OpenSpiel | Jeux cooperatifs et choix social eclairent la complexite de l'interaction multi-agent |
-| [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Preuves formelles | Preuves Arrow/Sen montrent comment formaliser des proprietes structurelles |
+| [Probas](../Probas/README.md) | Infer.NET / PyMC | Modeles probabilistes et inference bayesienne partagent les fondements de la mesure d'integration |
+| [GameTheory](../GameTheory/README.md) | OpenSpiel / Nashpy | Interactions strategiques multi-agents eclairent la complexite des systemes distribues |
+| [SymbolicAI/Lean](../SymbolicAI/Lean/README.md) | Preuves formelles | Formalisation Arrow/Sen montre comment prouver des proprietes structurelles impossibles |
+| [RL](../RL/README.md) | Stable Baselines3 | La distinction feed-forward vs recurrent (Phi = 0 vs > 0) eclaire le choix d'architecture RL |


### PR DESCRIPTION
## Summary

Enrich the IIT series README with pedagogical visitor-guide content:

- **Learning objectives**: 7 concrete outcomes (construct networks, calculate Phi, analyze CES, apply MIP, differentiate big/small Phi, evaluate computational limits, discuss philosophical implications)
- **Parcours**: 2-phase learning path with estimated durations
- **Alternative tracks**: quick discovery, philosophy focus, full mastery
- **FAQ**: 5 questions covering Python 3.9 requirement, big Phi vs small phi, feed-forward consciousness, tractability, and research usage
- **Expanded concepts table**: added MICE, Purview, Small phi entries
- **RL cross-series bridge**: feed-forward vs recurrent distinction relevant to RL architecture choice

## Validation
- Markdown-only change (+76/-13)
- CATALOG-STATUS marker preserved
- No code cells affected

See #2161