### PR TITLE
fix(catalog): preserve curated git fields on regen-from-stale-branch

### DIFF
--- a/scripts/notebook_tools/generate_catalog.py
+++ b/scripts/notebook_tools/generate_catalog.py
@@ -604,6 +604,81 @@ def analyze_notebook(nb_path: Path, pedagogical: bool, git_meta: dict | None = N
     }
 
 
+# Fields derived from git history that may be more up-to-date on origin/main
+# than on the current branch. These should be preserved from origin/main
+# for entries that were NOT modified on the current branch.
+CURATED_GIT_FIELDS = ("last_validation", "last_validator", "issue_pr_associee")
+
+
+def _load_main_catalog() -> dict[str, dict]:
+    """Load the catalog from origin/main via git show.
+
+    Returns a dict keyed by notebook path with the full entry dict.
+    Returns empty dict if not in a git repo or file doesn't exist on main.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", "origin/main:COURSE_CATALOG.generated.json"],
+            capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=15,
+        )
+        if result.returncode != 0:
+            return {}
+        import json as _json
+        data = _json.loads(result.stdout)
+        return {e["path"]: e for e in data if "path" in e}
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        return {}
+
+
+def _merge_curated_fields(
+    entries: list[dict],
+    main_catalog: dict[str, dict],
+) -> list[dict]:
+    """Preserve curated git fields from origin/main for unchanged entries.
+
+    When running from a branch that is behind main, git log won't include
+    commits that landed on main after the branch diverged. This causes
+    last_validation/last_validator/issue_pr_associee to be blanked for
+    entries not touched on the current branch.
+
+    This function merges the curated fields from origin/main's catalog
+    into the freshly generated entries, preserving the more complete data.
+    """
+    if not main_catalog:
+        return entries
+
+    merged_count = 0
+    for entry in entries:
+        path = entry.get("path", "")
+        main_entry = main_catalog.get(path)
+        if not main_entry:
+            continue
+
+        # Check if current branch has stale/empty values for these fields
+        needs_merge = False
+        for field in CURATED_GIT_FIELDS:
+            current_val = entry.get(field, "")
+            main_val = main_entry.get(field, "")
+            # Merge if current is empty/missing and main has data
+            if (not current_val or current_val == "") and main_val:
+                needs_merge = True
+                break
+
+        if needs_merge:
+            for field in CURATED_GIT_FIELDS:
+                current_val = entry.get(field, "")
+                main_val = main_entry.get(field, "")
+                # Prefer non-empty value from main when current is empty
+                if (not current_val or current_val == "") and main_val:
+                    entry[field] = main_val
+            merged_count += 1
+
+    if merged_count:
+        print(f"Preserved curated fields from origin/main for {merged_count} entries")
+
+    return entries
+
+
 def _git_tracked_files() -> set[str] | None:
     """Return set of git-tracked relative paths, or None if not in a git repo."""
     try:
@@ -788,6 +863,11 @@ def main():
         pedagogical=pedagogical, series_filter=args.series,
         git_meta=git_meta, git_tracked_only=args.git_tracked_only,
     )
+
+    # Preserve curated git fields from origin/main for entries not
+    # touched on the current branch (prevents stale-branch blanching)
+    main_catalog = _load_main_catalog()
+    entries = _merge_curated_fields(entries, main_catalog)
 
     if args.status:
         entries = [e for e in entries if e["status"] == args.status]

--- a/scripts/notebook_tools/tests/test_generate_catalog.py
+++ b/scripts/notebook_tools/tests/test_generate_catalog.py
@@ -16,9 +16,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from generate_catalog import (
+    CURATED_GIT_FIELDS,
     NOTEBOOKS_DIR,
     _effective_code_cells,
     _is_exercise_stub,
+    _merge_curated_fields,
     check_errors,
     classify_maturity,
     count_todos,
@@ -1065,6 +1067,143 @@ class TestDetectRequirementsEdgeCases:
         result = detect_requirements(nb)
         # Documenting the actual behavior — substring match
         assert result["requires_gpu"] is True  # "gpu" in "pug" → True (heuristic)
+
+
+class TestMergeCuratedFields:
+    """Regression tests for stale-branch field preservation.
+
+    When generate_catalog.py runs on a branch behind main, git log
+    misses recent commits. The _merge_curated_fields function preserves
+    last_validation/last_validator/issue_pr_associee from origin/main
+    for entries not touched on the current branch.
+    """
+
+    def _entry(self, path, last_validation="", last_validator="",
+               issue_pr_associee="", **kwargs):
+        """Build a catalog entry with defaults."""
+        return {
+            "path": path,
+            "title": kwargs.get("title", "Test"),
+            "serie": kwargs.get("serie", "Test"),
+            "kernel": kwargs.get("kernel", "Python 3"),
+            "status": kwargs.get("status", "READY"),
+            "maturity": kwargs.get("maturity", "PRODUCTION"),
+            "last_validation": last_validation,
+            "last_validator": last_validator,
+            "issue_pr_associee": issue_pr_associee,
+        }
+
+    def test_preserves_empty_fields_from_main(self):
+        """Entries with empty git fields get values from main."""
+        fresh = [
+            self._entry("Series/nb1.ipynb", last_validation="",
+                        last_validator="", issue_pr_associee=""),
+        ]
+        main = {
+            "Series/nb1.ipynb": self._entry(
+                "Series/nb1.ipynb", last_validation="2026-06-01",
+                last_validator="dev@example.com",
+                issue_pr_associee="#2161",
+            ),
+        }
+        result = _merge_curated_fields(fresh, main)
+        assert result[0]["last_validation"] == "2026-06-01"
+        assert result[0]["last_validator"] == "dev@example.com"
+        assert result[0]["issue_pr_associee"] == "#2161"
+
+    def test_preserves_current_nonempty_values(self):
+        """Entries with existing values are NOT overwritten by main."""
+        fresh = [
+            self._entry("Series/nb1.ipynb", last_validation="2026-06-04",
+                        last_validator="me@test.com",
+                        issue_pr_associee="#2309"),
+        ]
+        main = {
+            "Series/nb1.ipynb": self._entry(
+                "Series/nb1.ipynb", last_validation="2026-06-01",
+                last_validator="dev@example.com",
+                issue_pr_associee="#2161",
+            ),
+        }
+        result = _merge_curated_fields(fresh, main)
+        # Current values preserved — they are non-empty and more recent
+        assert result[0]["last_validation"] == "2026-06-04"
+        assert result[0]["last_validator"] == "me@test.com"
+        assert result[0]["issue_pr_associee"] == "#2309"
+
+    def test_no_matching_main_entry(self):
+        """Entries not in main catalog are left unchanged."""
+        fresh = [
+            self._entry("Series/new_notebook.ipynb",
+                        last_validation="", last_validator=""),
+        ]
+        main = {}  # no matching entry
+        result = _merge_curated_fields(fresh, main)
+        assert result[0]["last_validation"] == ""
+
+    def test_empty_main_catalog(self):
+        """Empty main catalog = no changes, no crash."""
+        fresh = [
+            self._entry("Series/nb1.ipynb", last_validation=""),
+        ]
+        result = _merge_curated_fields(fresh, {})
+        assert result[0]["last_validation"] == ""
+
+    def test_mixed_entries_some_need_merge(self):
+        """Only entries with empty git fields get merged."""
+        fresh = [
+            self._entry("Series/nb1.ipynb", last_validation="",
+                        last_validator=""),  # needs merge
+            self._entry("Series/nb2.ipynb", last_validation="2026-06-04",
+                        last_validator="me@test.com"),  # has data
+        ]
+        main = {
+            "Series/nb1.ipynb": self._entry(
+                "Series/nb1.ipynb", last_validation="2026-06-01",
+                last_validator="dev@example.com",
+                issue_pr_associee="#2161",
+            ),
+            "Series/nb2.ipynb": self._entry(
+                "Series/nb2.ipynb", last_validation="2026-05-01",
+                last_validator="old@example.com",
+            ),
+        }
+        result = _merge_curated_fields(fresh, main)
+        # nb1 got merged from main
+        assert result[0]["last_validation"] == "2026-06-01"
+        assert result[0]["issue_pr_associee"] == "#2161"
+        # nb2 kept its current values (non-empty)
+        assert result[1]["last_validation"] == "2026-06-04"
+        assert result[1]["last_validator"] == "me@test.com"
+
+    def test_partial_field_merge(self):
+        """Only empty fields are filled, non-empty kept."""
+        fresh = [
+            self._entry("Series/nb1.ipynb", last_validation="",
+                        last_validator="local@test.com",
+                        issue_pr_associee=""),
+        ]
+        main = {
+            "Series/nb1.ipynb": self._entry(
+                "Series/nb1.ipynb", last_validation="2026-06-01",
+                last_validator="remote@test.com",
+                issue_pr_associee="#2161",
+            ),
+        }
+        result = _merge_curated_fields(fresh, main)
+        # last_validation was empty → filled from main
+        assert result[0]["last_validation"] == "2026-06-01"
+        # last_validator was non-empty → kept current
+        assert result[0]["last_validator"] == "local@test.com"
+        # issue_pr_associee was empty → filled from main
+        assert result[0]["issue_pr_associee"] == "#2161"
+
+    def test_curated_fields_constant_contains_expected_fields(self):
+        """CURATED_GIT_FIELDS must contain the 3 git-derived fields."""
+        assert "last_validation" in CURATED_GIT_FIELDS
+        assert "last_validator" in CURATED_GIT_FIELDS
+        assert "issue_pr_associee" in CURATED_GIT_FIELDS
+        assert len(CURATED_GIT_FIELDS) == 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

When `generate_catalog.py` runs on a branch behind `main`, `git log` misses recent commits, causing `last_validation`, `last_validator`, and `issue_pr_associee` to be silently blanked for entries not touched on the current branch. This is the root cause of the `COURSE_CATALOG.generated.json` treadmill.

## Root cause

Full overwrite via `write_text()` with no preservation logic. The catalog is regenerated from scratch each time, but git-derived fields come only from the current branch history.

## Fix

- `_load_main_catalog()`: loads the catalog from `origin/main` via `git show` before writing
- `_merge_curated_fields()`: for each entry, if a curated git field is empty but has a value in the main catalog, it is preserved
- Integration in `main()`: called between `scan_all_notebooks()` and the write step

## Test evidence

```
147 passed in 0.27s
```

7 new regression tests in `TestMergeCuratedFields`:
- empty fields merged from main
- non-empty values preserved as-is
- no matching main entry (graceful fallback)
- empty main catalog (no crash)
- mixed entries (some need merge, some don't)
- partial field merge (only empty fields filled)
- CURATED_GIT_FIELDS constant validation

## Files changed

| File | Change |
|------|--------|
| `scripts/notebook_tools/generate_catalog.py` | +2 functions (`_load_main_catalog`, `_merge_curated_fields`) + integration in `main()` |
| `scripts/notebook_tools/tests/test_generate_catalog.py` | +7 regression tests (`TestMergeCuratedFields`) |

See #2149