### PR TITLE
fix(Sudoku): H.3 re-exec 3 notebooks + fix f-string SyntaxError in Sudoku-15

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "intro",
    "metadata": {
     "papermill": {
-     "duration": 0.012325,
-     "end_time": "2026-06-02T21:45:27.773332+00:00",
+     "duration": 0.004978,
+     "end_time": "2026-06-05T06:07:55.604914",
      "exception": false,
-     "start_time": "2026-06-02T21:45:27.761007+00:00",
+     "start_time": "2026-06-05T06:07:55.599936",
      "status": "completed"
     },
     "tags": []
@@ -36,10 +36,10 @@
    "id": "intro-choco",
    "metadata": {
     "papermill": {
-     "duration": 0.007015,
-     "end_time": "2026-06-02T21:45:27.785548+00:00",
+     "duration": 0.003999,
+     "end_time": "2026-06-05T06:07:55.613914",
      "exception": false,
-     "start_time": "2026-06-02T21:45:27.778533+00:00",
+     "start_time": "2026-06-05T06:07:55.609915",
      "status": "completed"
     },
     "tags": []
@@ -89,16 +89,16 @@
    "id": "imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:27.801811Z",
-     "iopub.status.busy": "2026-06-02T21:45:27.801586Z",
-     "iopub.status.idle": "2026-06-02T21:45:29.195443Z",
-     "shell.execute_reply": "2026-06-02T21:45:29.194850Z"
+     "iopub.execute_input": "2026-06-05T06:07:55.623956Z",
+     "iopub.status.busy": "2026-06-05T06:07:55.623956Z",
+     "iopub.status.idle": "2026-06-05T06:07:58.183888Z",
+     "shell.execute_reply": "2026-06-05T06:07:58.182988Z"
     },
     "papermill": {
-     "duration": 1.404817,
-     "end_time": "2026-06-02T21:45:29.196241+00:00",
+     "duration": 2.566447,
+     "end_time": "2026-06-05T06:07:58.185401",
      "exception": false,
-     "start_time": "2026-06-02T21:45:27.791424+00:00",
+     "start_time": "2026-06-05T06:07:55.618954",
      "status": "completed"
     },
     "tags": []
@@ -139,10 +139,10 @@
    "id": "749fe2ff",
    "metadata": {
     "papermill": {
-     "duration": 0.004759,
-     "end_time": "2026-06-02T21:45:29.207463+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-05T06:07:58.193505",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.202704+00:00",
+     "start_time": "2026-06-05T06:07:58.189505",
      "status": "completed"
     },
     "tags": []
@@ -173,10 +173,10 @@
    "id": "160a389d",
    "metadata": {
     "papermill": {
-     "duration": 0.004403,
-     "end_time": "2026-06-02T21:45:29.216799+00:00",
+     "duration": 0.004534,
+     "end_time": "2026-06-05T06:07:58.202042",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.212396+00:00",
+     "start_time": "2026-06-05T06:07:58.197508",
      "status": "completed"
     },
     "tags": []
@@ -191,16 +191,16 @@
    "id": "jpype-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:29.228648Z",
-     "iopub.status.busy": "2026-06-02T21:45:29.228202Z",
-     "iopub.status.idle": "2026-06-02T21:45:29.836782Z",
-     "shell.execute_reply": "2026-06-02T21:45:29.834115Z"
+     "iopub.execute_input": "2026-06-05T06:07:58.210021Z",
+     "iopub.status.busy": "2026-06-05T06:07:58.210021Z",
+     "iopub.status.idle": "2026-06-05T06:07:58.556540Z",
+     "shell.execute_reply": "2026-06-05T06:07:58.555645Z"
     },
     "papermill": {
-     "duration": 0.616356,
-     "end_time": "2026-06-02T21:45:29.837739+00:00",
+     "duration": 0.351412,
+     "end_time": "2026-06-05T06:07:58.556540",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.221383+00:00",
+     "start_time": "2026-06-05T06:07:58.205128",
      "status": "completed"
     },
     "tags": []
@@ -210,7 +210,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Choco deja present: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\choco-solver-4.10.17-jar-with-dependencies.jar\n"
+      "Choco deja present: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\choco-solver-4.10.17-jar-with-dependencies.jar\n"
      ]
     },
     {
@@ -287,10 +287,10 @@
    "id": "b9022e73",
    "metadata": {
     "papermill": {
-     "duration": 0.009956,
-     "end_time": "2026-06-02T21:45:29.861046+00:00",
+     "duration": 0.00565,
+     "end_time": "2026-06-05T06:07:58.567284",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.851090+00:00",
+     "start_time": "2026-06-05T06:07:58.561634",
      "status": "completed"
     },
     "tags": []
@@ -322,10 +322,10 @@
    "id": "1e29d390",
    "metadata": {
     "papermill": {
-     "duration": 0.005125,
-     "end_time": "2026-06-02T21:45:29.872733+00:00",
+     "duration": 0.003528,
+     "end_time": "2026-06-05T06:07:58.574506",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.867608+00:00",
+     "start_time": "2026-06-05T06:07:58.570978",
      "status": "completed"
     },
     "tags": []
@@ -340,16 +340,16 @@
    "id": "choco-imports",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:29.885063Z",
-     "iopub.status.busy": "2026-06-02T21:45:29.884590Z",
-     "iopub.status.idle": "2026-06-02T21:45:30.524855Z",
-     "shell.execute_reply": "2026-06-02T21:45:30.523714Z"
+     "iopub.execute_input": "2026-06-05T06:07:58.583572Z",
+     "iopub.status.busy": "2026-06-05T06:07:58.583572Z",
+     "iopub.status.idle": "2026-06-05T06:07:58.868993Z",
+     "shell.execute_reply": "2026-06-05T06:07:58.867995Z"
     },
     "papermill": {
-     "duration": 0.647838,
-     "end_time": "2026-06-02T21:45:30.525939+00:00",
+     "duration": 0.291482,
+     "end_time": "2026-06-05T06:07:58.869995",
      "exception": false,
-     "start_time": "2026-06-02T21:45:29.878101+00:00",
+     "start_time": "2026-06-05T06:07:58.578513",
      "status": "completed"
     },
     "tags": []
@@ -392,10 +392,10 @@
    "id": "03a26cbb",
    "metadata": {
     "papermill": {
-     "duration": 0.005504,
-     "end_time": "2026-06-02T21:45:30.538167+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-05T06:07:58.878499",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.532663+00:00",
+     "start_time": "2026-06-05T06:07:58.874499",
      "status": "completed"
     },
     "tags": []
@@ -425,10 +425,10 @@
    "id": "c0dd24b8",
    "metadata": {
     "papermill": {
-     "duration": 0.005532,
-     "end_time": "2026-06-02T21:45:30.548828+00:00",
+     "duration": 0.005001,
+     "end_time": "2026-06-05T06:07:58.888506",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.543296+00:00",
+     "start_time": "2026-06-05T06:07:58.883505",
      "status": "completed"
     },
     "tags": []
@@ -443,16 +443,16 @@
    "id": "puzzle-config",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:30.561249Z",
-     "iopub.status.busy": "2026-06-02T21:45:30.560976Z",
-     "iopub.status.idle": "2026-06-02T21:45:30.567739Z",
-     "shell.execute_reply": "2026-06-02T21:45:30.566646Z"
+     "iopub.execute_input": "2026-06-05T06:07:58.898016Z",
+     "iopub.status.busy": "2026-06-05T06:07:58.898016Z",
+     "iopub.status.idle": "2026-06-05T06:07:58.915070Z",
+     "shell.execute_reply": "2026-06-05T06:07:58.915070Z"
     },
     "papermill": {
-     "duration": 0.014251,
-     "end_time": "2026-06-02T21:45:30.568660+00:00",
+     "duration": 0.023551,
+     "end_time": "2026-06-05T06:07:58.916056",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.554409+00:00",
+     "start_time": "2026-06-05T06:07:58.892505",
      "status": "completed"
     },
     "tags": []
@@ -462,7 +462,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
+      "Dossier Puzzles: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n",
       "Fichiers disponibles: ['Sudoku_Easy51.txt', 'Sudoku_hardest.txt', 'Sudoku_top95.txt']\n"
      ]
     }
@@ -491,10 +491,10 @@
    "id": "50323b4e",
    "metadata": {
     "papermill": {
-     "duration": 0.006235,
-     "end_time": "2026-06-02T21:45:30.580336+00:00",
+     "duration": 0.005998,
+     "end_time": "2026-06-05T06:07:58.927621",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.574101+00:00",
+     "start_time": "2026-06-05T06:07:58.921623",
      "status": "completed"
     },
     "tags": []
@@ -526,10 +526,10 @@
    "id": "7506627c",
    "metadata": {
     "papermill": {
-     "duration": 0.00606,
-     "end_time": "2026-06-02T21:45:30.591616+00:00",
+     "duration": 0.006548,
+     "end_time": "2026-06-05T06:07:58.940168",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.585556+00:00",
+     "start_time": "2026-06-05T06:07:58.933620",
      "status": "completed"
     },
     "tags": []
@@ -544,16 +544,16 @@
    "id": "puzzle-loader",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:30.608942Z",
-     "iopub.status.busy": "2026-06-02T21:45:30.608497Z",
-     "iopub.status.idle": "2026-06-02T21:45:30.620280Z",
-     "shell.execute_reply": "2026-06-02T21:45:30.618988Z"
+     "iopub.execute_input": "2026-06-05T06:07:58.953624Z",
+     "iopub.status.busy": "2026-06-05T06:07:58.953624Z",
+     "iopub.status.idle": "2026-06-05T06:07:58.994129Z",
+     "shell.execute_reply": "2026-06-05T06:07:58.993127Z"
     },
     "papermill": {
-     "duration": 0.022786,
-     "end_time": "2026-06-02T21:45:30.621391+00:00",
+     "duration": 0.04936,
+     "end_time": "2026-06-05T06:07:58.995456",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.598605+00:00",
+     "start_time": "2026-06-05T06:07:58.946096",
      "status": "completed"
     },
     "tags": []
@@ -640,10 +640,10 @@
    "id": "75b45d38",
    "metadata": {
     "papermill": {
-     "duration": 0.007945,
-     "end_time": "2026-06-02T21:45:30.638437+00:00",
+     "duration": 0.00477,
+     "end_time": "2026-06-05T06:07:59.004903",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.630492+00:00",
+     "start_time": "2026-06-05T06:07:59.000133",
      "status": "completed"
     },
     "tags": []
@@ -681,10 +681,10 @@
    "id": "modelisation",
    "metadata": {
     "papermill": {
-     "duration": 0.005435,
-     "end_time": "2026-06-02T21:45:30.649250+00:00",
+     "duration": 0.004893,
+     "end_time": "2026-06-05T06:07:59.014269",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.643815+00:00",
+     "start_time": "2026-06-05T06:07:59.009376",
      "status": "completed"
     },
     "tags": []
@@ -716,16 +716,16 @@
    "id": "choco-solver-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:30.661529Z",
-     "iopub.status.busy": "2026-06-02T21:45:30.661116Z",
-     "iopub.status.idle": "2026-06-02T21:45:30.836660Z",
-     "shell.execute_reply": "2026-06-02T21:45:30.835033Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.023840Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.023840Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.133497Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.132788Z"
     },
     "papermill": {
-     "duration": 0.183615,
-     "end_time": "2026-06-02T21:45:30.838088+00:00",
+     "duration": 0.116277,
+     "end_time": "2026-06-05T06:07:59.134645",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.654473+00:00",
+     "start_time": "2026-06-05T06:07:59.018368",
      "status": "completed"
     },
     "tags": []
@@ -756,7 +756,7 @@
       "7 1 5 | 2 9 6 | 3 8 4 \n",
       "6 8 3 | 7 4 1 | 9 5 2 \n",
       "\n",
-      "Temps de resolution: 39.58 ms\n"
+      "Temps de resolution: 27.03 ms\n"
      ]
     }
    ],
@@ -856,10 +856,10 @@
    "id": "0434737d",
    "metadata": {
     "papermill": {
-     "duration": 0.007974,
-     "end_time": "2026-06-02T21:45:30.854352+00:00",
+     "duration": 0.005368,
+     "end_time": "2026-06-05T06:07:59.145420",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.846378+00:00",
+     "start_time": "2026-06-05T06:07:59.140052",
      "status": "completed"
     },
     "tags": []
@@ -895,26 +895,115 @@
   {
    "cell_type": "markdown",
    "id": "7acb4b52",
-   "source": "### Exercice : Generation d'une grille de Sudoku valide\n\nTous les exemples precedents partent d'une grille pre-remplie a resoudre. Mais comment les grilles de Sudoku sont-elles creees en premier lieu ? L'objectif de cet exercice est de **generer** une grille de Sudoku complete et valide, puis de la transformer en puzzle en retirant des valeurs.\n\n**Principe** : un Sudoku complet n'est qu'une solution particuliere d'un CSP sans valeurs initiales. Choco peut donc en generer un simplement en resolvant un modele vide (81 variables libres + 27 contraintes allDifferent, sans aucune valeur fixee).\n\n**Etapes demandees** :\n1. Creer un modele Choco avec 81 variables `IntVar(1, 9)` et les 27 contraintes `allDifferent`, **sans fixer de valeurs initiales**\n2. Resoudre pour obtenir une grille complete (une solution parmi ~6.67 x 10^21 possibilites)\n3. Retirer aleatoirement des valeurs pour ne garder que `n_clues` indices\n4. Verifier que le puzzle resultant possede une **solution unique**\n\n**Indices** :\n- L'etape 1 reutilise exactement le meme schema que `ChocoSudokuSolver.solve()`, mais sans la boucle qui fixe les valeurs initiales\n- Pour l'etape 3, utiliser `random.sample(range(81), 81 - n_clues)` pour choisir les positions a vider\n- Pour l'etape 4, resoudre le puzzle puis chercher une seconde solution ; s'il n'y en a qu'une, le puzzle est valide",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004793,
+     "end_time": "2026-06-05T06:07:59.155195",
+     "exception": false,
+     "start_time": "2026-06-05T06:07:59.150402",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Generation d'une grille de Sudoku valide\n",
+    "\n",
+    "Tous les exemples precedents partent d'une grille pre-remplie a resoudre. Mais comment les grilles de Sudoku sont-elles creees en premier lieu ? L'objectif de cet exercice est de **generer** une grille de Sudoku complete et valide, puis de la transformer en puzzle en retirant des valeurs.\n",
+    "\n",
+    "**Principe** : un Sudoku complet n'est qu'une solution particuliere d'un CSP sans valeurs initiales. Choco peut donc en generer un simplement en resolvant un modele vide (81 variables libres + 27 contraintes allDifferent, sans aucune valeur fixee).\n",
+    "\n",
+    "**Etapes demandees** :\n",
+    "1. Creer un modele Choco avec 81 variables `IntVar(1, 9)` et les 27 contraintes `allDifferent`, **sans fixer de valeurs initiales**\n",
+    "2. Resoudre pour obtenir une grille complete (une solution parmi ~6.67 x 10^21 possibilites)\n",
+    "3. Retirer aleatoirement des valeurs pour ne garder que `n_clues` indices\n",
+    "4. Verifier que le puzzle resultant possede une **solution unique**\n",
+    "\n",
+    "**Indices** :\n",
+    "- L'etape 1 reutilise exactement le meme schema que `ChocoSudokuSolver.solve()`, mais sans la boucle qui fixe les valeurs initiales\n",
+    "- Pour l'etape 3, utiliser `random.sample(range(81), 81 - n_clues)` pour choisir les positions a vider\n",
+    "- Pour l'etape 4, resoudre le puzzle puis chercher une seconde solution ; s'il n'y en a qu'une, le puzzle est valide"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "ae43e874",
-   "source": "import random\n\ndef generate_sudoku(n_clues: int = 30, seed: int = 42) -> tuple:\n    \"\"\"\n    Genere une grille de Sudoku valide avec exactement n_clues indices.\n\n    Algorithme :\n    1. Creer un modele CSP sans valeurs initiales (81 variables libres)\n    2. Ajouter les 27 contraintes allDifferent\n    3. Resoudre pour obtenir une grille complete\n    4. Retirer des valeurs aleatoirement jusqu'a n_clues restantes\n    5. Verifier que le puzzle obtenu a une solution unique\n\n    Args:\n        n_clues: Nombre d'indices a conserver dans le puzzle (defaut: 30)\n        seed: Graine aleatoire pour la reproductibilite\n\n    Returns:\n        (puzzle_grid, solution_grid) ou (None, None) si echec\n    \"\"\"\n    # TODO etudiant : implementer la generation de Sudoku\n    # Etape 1 : creer le modele CSP avec 81 variables IntVar(1, 9)\n    # Indice : reutiliser le schema de ChocoSudokuSolver.solve() mais SANS fixer les valeurs initiales\n    # Etape 2 : ajouter les 27 contraintes allDifferent (lignes, colonnes, blocs 3x3)\n    # Etape 3 : resoudre et extraire la grille complete (solution)\n    # Etape 4 : retirer (81 - n_clues) valeurs aleatoirement\n    # Indice : random.seed(seed) puis random.sample(range(81), 81 - n_clues) pour choisir les cases a vider\n    # Etape 5 : verifier l'unicite de la solution du puzzle obtenu\n    # Indice : resoudre le puzzle, puis chercher une seconde solution differente (max_count=2)\n    return (None, None)  # TODO etudiant : remplacer\n\nprint(\"Exercice a completer : generation de Sudoku\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:07:59.166354Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.166354Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.179356Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.178683Z"
+    },
+    "papermill": {
+     "duration": 0.020152,
+     "end_time": "2026-06-05T06:07:59.180393",
+     "exception": false,
+     "start_time": "2026-06-05T06:07:59.160241",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : generation de Sudoku"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import random\n",
+    "\n",
+    "def generate_sudoku(n_clues: int = 30, seed: int = 42) -> tuple:\n",
+    "    \"\"\"\n",
+    "    Genere une grille de Sudoku valide avec exactement n_clues indices.\n",
+    "\n",
+    "    Algorithme :\n",
+    "    1. Creer un modele CSP sans valeurs initiales (81 variables libres)\n",
+    "    2. Ajouter les 27 contraintes allDifferent\n",
+    "    3. Resoudre pour obtenir une grille complete\n",
+    "    4. Retirer des valeurs aleatoirement jusqu'a n_clues restantes\n",
+    "    5. Verifier que le puzzle obtenu a une solution unique\n",
+    "\n",
+    "    Args:\n",
+    "        n_clues: Nombre d'indices a conserver dans le puzzle (defaut: 30)\n",
+    "        seed: Graine aleatoire pour la reproductibilite\n",
+    "\n",
+    "    Returns:\n",
+    "        (puzzle_grid, solution_grid) ou (None, None) si echec\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer la generation de Sudoku\n",
+    "    # Etape 1 : creer le modele CSP avec 81 variables IntVar(1, 9)\n",
+    "    # Indice : reutiliser le schema de ChocoSudokuSolver.solve() mais SANS fixer les valeurs initiales\n",
+    "    # Etape 2 : ajouter les 27 contraintes allDifferent (lignes, colonnes, blocs 3x3)\n",
+    "    # Etape 3 : resoudre et extraire la grille complete (solution)\n",
+    "    # Etape 4 : retirer (81 - n_clues) valeurs aleatoirement\n",
+    "    # Indice : random.seed(seed) puis random.sample(range(81), 81 - n_clues) pour choisir les cases a vider\n",
+    "    # Etape 5 : verifier l'unicite de la solution du puzzle obtenu\n",
+    "    # Indice : resoudre le puzzle, puis chercher une seconde solution differente (max_count=2)\n",
+    "    return (None, None)  # TODO etudiant : remplacer\n",
+    "\n",
+    "print(\"Exercice a completer : generation de Sudoku\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "strategies",
    "metadata": {
     "papermill": {
-     "duration": 0.007859,
-     "end_time": "2026-06-02T21:45:30.869446+00:00",
+     "duration": 0.004797,
+     "end_time": "2026-06-05T06:07:59.190734",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.861587+00:00",
+     "start_time": "2026-06-05T06:07:59.185937",
      "status": "completed"
     },
     "tags": []
@@ -946,20 +1035,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "strategy-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:30.887429Z",
-     "iopub.status.busy": "2026-06-02T21:45:30.887057Z",
-     "iopub.status.idle": "2026-06-02T21:45:31.034236Z",
-     "shell.execute_reply": "2026-06-02T21:45:31.032972Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.201316Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.200316Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.227638Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.227215Z"
     },
     "papermill": {
-     "duration": 0.158755,
-     "end_time": "2026-06-02T21:45:31.035203+00:00",
+     "duration": 0.032872,
+     "end_time": "2026-06-05T06:07:59.228141",
      "exception": false,
-     "start_time": "2026-06-02T21:45:30.876448+00:00",
+     "start_time": "2026-06-05T06:07:59.195269",
      "status": "completed"
     },
     "tags": []
@@ -973,12 +1062,12 @@
       "\n",
       "\n",
       "=== Benchmark Choco Sudoku ===\n",
-      "  Puzzle 1: OK, 7.74 ms\n",
-      "  Puzzle 2: OK, 7.19 ms\n",
-      "  Puzzle 3: OK, 3.23 ms\n",
+      "  Puzzle 1: OK, 2.00 ms\n",
+      "  Puzzle 2: OK, 0.00 ms\n",
+      "  Puzzle 3: OK, 2.01 ms\n",
       "\n",
       "Sudoku resolus: 3/3\n",
-      "Temps moyen: 6.05 ms\n"
+      "Temps moyen: 1.34 ms\n"
      ]
     }
    ],
@@ -1027,10 +1116,10 @@
    "id": "cface51c",
    "metadata": {
     "papermill": {
-     "duration": 0.006421,
-     "end_time": "2026-06-02T21:45:31.047172+00:00",
+     "duration": 0.004999,
+     "end_time": "2026-06-05T06:07:59.238145",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.040751+00:00",
+     "start_time": "2026-06-05T06:07:59.233146",
      "status": "completed"
     },
     "tags": []
@@ -1062,10 +1151,10 @@
    "id": "9c63cd81",
    "metadata": {
     "papermill": {
-     "duration": 0.005913,
-     "end_time": "2026-06-02T21:45:31.058941+00:00",
+     "duration": 0.0042,
+     "end_time": "2026-06-05T06:07:59.246361",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.053028+00:00",
+     "start_time": "2026-06-05T06:07:59.242161",
      "status": "completed"
     },
     "tags": []
@@ -1076,20 +1165,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "hard-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:31.073059Z",
-     "iopub.status.busy": "2026-06-02T21:45:31.072709Z",
-     "iopub.status.idle": "2026-06-02T21:45:31.152162Z",
-     "shell.execute_reply": "2026-06-02T21:45:31.148487Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.255929Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.255929Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.291959Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.290958Z"
     },
     "papermill": {
-     "duration": 0.088039,
-     "end_time": "2026-06-02T21:45:31.153326+00:00",
+     "duration": 0.042169,
+     "end_time": "2026-06-05T06:07:59.293087",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.065287+00:00",
+     "start_time": "2026-06-05T06:07:59.250918",
      "status": "completed"
     },
     "tags": []
@@ -1105,17 +1194,11 @@
       "\n",
       "\n",
       "=== Benchmark Choco Sudoku ===\n",
-      "  Puzzle 1: OK, 7.32 ms\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Puzzle 2: OK, 42.84 ms\n",
+      "  Puzzle 1: OK, 2.00 ms\n",
+      "  Puzzle 2: OK, 14.03 ms\n",
       "\n",
       "Sudoku resolus: 2/2\n",
-      "Temps moyen: 25.08 ms\n"
+      "Temps moyen: 8.01 ms\n"
      ]
     }
    ],
@@ -1135,10 +1218,10 @@
    "id": "83783477",
    "metadata": {
     "papermill": {
-     "duration": 0.012438,
-     "end_time": "2026-06-02T21:45:31.173785+00:00",
+     "duration": 0.005509,
+     "end_time": "2026-06-05T06:07:59.302597",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.161347+00:00",
+     "start_time": "2026-06-05T06:07:59.297088",
      "status": "completed"
     },
     "tags": []
@@ -1169,10 +1252,10 @@
    "id": "132c8105",
    "metadata": {
     "papermill": {
-     "duration": 0.006329,
-     "end_time": "2026-06-02T21:45:31.193434+00:00",
+     "duration": 0.005,
+     "end_time": "2026-06-05T06:07:59.312603",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.187105+00:00",
+     "start_time": "2026-06-05T06:07:59.307603",
      "status": "completed"
     },
     "tags": []
@@ -1185,20 +1268,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "561afdcf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:31.210572Z",
-     "iopub.status.busy": "2026-06-02T21:45:31.210164Z",
-     "iopub.status.idle": "2026-06-02T21:45:31.217197Z",
-     "shell.execute_reply": "2026-06-02T21:45:31.215794Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.324636Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.324636Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.337641Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.336641Z"
     },
     "papermill": {
-     "duration": 0.015575,
-     "end_time": "2026-06-02T21:45:31.218256+00:00",
+     "duration": 0.021038,
+     "end_time": "2026-06-05T06:07:59.338641",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.202681+00:00",
+     "start_time": "2026-06-05T06:07:59.317603",
      "status": "completed"
     },
     "tags": []
@@ -1240,10 +1323,10 @@
    "id": "advanced-features",
    "metadata": {
     "papermill": {
-     "duration": 0.006874,
-     "end_time": "2026-06-02T21:45:31.231451+00:00",
+     "duration": 0.005505,
+     "end_time": "2026-06-05T06:07:59.349146",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.224577+00:00",
+     "start_time": "2026-06-05T06:07:59.343641",
      "status": "completed"
     },
     "tags": []
@@ -1291,10 +1374,10 @@
    "id": "cf366431",
    "metadata": {
     "papermill": {
-     "duration": 0.006692,
-     "end_time": "2026-06-02T21:45:31.244835+00:00",
+     "duration": 0.005982,
+     "end_time": "2026-06-05T06:07:59.361156",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.238143+00:00",
+     "start_time": "2026-06-05T06:07:59.355174",
      "status": "completed"
     },
     "tags": []
@@ -1307,20 +1390,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "37cc50e5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:31.262732Z",
-     "iopub.status.busy": "2026-06-02T21:45:31.262391Z",
-     "iopub.status.idle": "2026-06-02T21:45:31.270338Z",
-     "shell.execute_reply": "2026-06-02T21:45:31.268869Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.372164Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.371661Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.384737Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.383693Z"
     },
     "papermill": {
-     "duration": 0.019742,
-     "end_time": "2026-06-02T21:45:31.271905+00:00",
+     "duration": 0.019584,
+     "end_time": "2026-06-05T06:07:59.385742",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.252163+00:00",
+     "start_time": "2026-06-05T06:07:59.366158",
      "status": "completed"
     },
     "tags": []
@@ -1362,10 +1445,10 @@
    "id": "comparison",
    "metadata": {
     "papermill": {
-     "duration": 0.009286,
-     "end_time": "2026-06-02T21:45:31.289424+00:00",
+     "duration": 0.004999,
+     "end_time": "2026-06-05T06:07:59.395743",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.280138+00:00",
+     "start_time": "2026-06-05T06:07:59.390744",
      "status": "completed"
     },
     "tags": []
@@ -1404,20 +1487,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "visualization",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:31.312977Z",
-     "iopub.status.busy": "2026-06-02T21:45:31.312347Z",
-     "iopub.status.idle": "2026-06-02T21:45:33.583341Z",
-     "shell.execute_reply": "2026-06-02T21:45:33.582029Z"
+     "iopub.execute_input": "2026-06-05T06:07:59.407252Z",
+     "iopub.status.busy": "2026-06-05T06:07:59.407252Z",
+     "iopub.status.idle": "2026-06-05T06:07:59.965034Z",
+     "shell.execute_reply": "2026-06-05T06:07:59.964164Z"
     },
     "papermill": {
-     "duration": 2.28388,
-     "end_time": "2026-06-02T21:45:33.584149+00:00",
+     "duration": 0.563783,
+     "end_time": "2026-06-05T06:07:59.965034",
      "exception": false,
-     "start_time": "2026-06-02T21:45:31.300269+00:00",
+     "start_time": "2026-06-05T06:07:59.401251",
      "status": "completed"
     },
     "tags": []
@@ -1425,7 +1508,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAJOCAYAAACkx02ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcY1JREFUeJzt3QeYFOW6J/D/wMCQUQcQnIEhKEGFZbkEdcgCKpKUi4RnUKIEda8oBlwWhFWBK464oLiIgIDASkaueEiLgwQ5IusFhAMqORy5XDhImMBQ+/y/snFCg6MSmrf+v+fp032qW6ar66uqt77vfb+K8jzPg4iIiIgB+a73FxARERG5UhTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2MgNrWnTpoiKirqqf2PatGnub/BZJFJVrFjRPUSCToGNXFVnzpzBG2+8gTp16qBYsWKIiYlBfHw8GjVqhCFDhuCHH3647ltg7969LnDp0aMHbgSvvvqq+75r1qy53l9FriLe7WbBggV49NFH3T7Dfad48eL4L//lv2DQoEH47rvv9PuLhBEdbqHIlfDzzz+jYcOG+Pd//3fcfvvtSEpKQmxsLP7jP/4DmzZtwujRo1GlShX3iGSPPPII7rnnHpQrV+56fxUJiP/8z/9Ep06dsHr1atx0001o2bIlKleujPT0dGzfvh3vvfce/tf/+l9YtWqV67UUkV8psJGrZty4cS6o6dOnDyZNmpRryGjPnj1IS0uL+C1QsmRJ9xC5Fs6fP++C6ZSUFHcx8O6776JEiRLZPnPkyBH89//+3/GPf/xDG0UkJ97dW+RqeOihh3jneG/Lli2/67/bunWr16lTJ6906dJewYIFvYoVK3r/8i//4v3Hf/xHrs82adLE/Y2shg8f7pb93//7f3N9furUqe49Pmf9/+Eeof8+53+T1Zdffum1bt3au/nmm72YmBivWrVq3rBhw7wzZ87k+iz/DX7fo0ePeo8//rgXGxvrFSpUyGvQoEHY7xpOaH1zPhISEi5+hq/5OHHihPfUU0958fHxXv78+bN9/yVLlnhNmzb1SpQo4b5DrVq1vLfeesvLyMjI9vf4vfjv8zfNac+ePe69J5544uKyKlWqeMWKFQu7/tS2bVv33/ztb3/LtnzRokVe8+bNvZtuusn9jnfddZf35ptveufPnw/77/zez1/uu2/bts1tw5IlS3pFixb1WrZs6X399de5/hsu4+/JvxX63e6++25v1KhRXnp6eq7P52U7hDNlyhT33Ro3buxlZmZe9rOpqam5/t7PP//s/bf/9t+8cuXKuf2nZs2a3ty5c8P+98eOHXP7Fvcxfpb7HPc97oPhpKWlecnJyV7dunXddubvVaNGDW/QoEHef/7nf/7h/VjkSlKPjVw1HHaiXbt2oXbt2nn6b7788ks88MADrsv9n//5n10y5IYNG/DOO+9g6dKl2LhxI0qVKnXFviO/17/8y7+4f5+5Cx06dLj43m8lYs6dOxddu3Z1uQ+dO3dGmTJlsHz5cowcORJ/+ctfXA5MoUKFsv03J0+edMNz7AHq3r07fvrpJ/yf//N/3Dpv3rwZd99992X/ZigP6IsvvsATTzxx8TtyuCIr9oQ1b94cp0+fRrt27RAdHY1bb73VvZecnIznn38et9xyC7p164aiRYtiyZIlbtnatWtdXscfTchmD8OIESOwaNEi929nxSHIzz//HA0aNEDVqlUvLmeuFYcl4+LiXD4Jfxt+jxdeeAFfffWV+52z+r2fv5wff/wRiYmJLgdswIAB2Ldvn/vvGzdu7IaB+F1DPvjgA3z66afuvdatW+Ps2bNuG/P7/PWvf8X8+fNz/fuX2w6X8uGHH7rnoUOHIl++y6dBsu1llZGRgVatWuHEiRPo2LGj+45z5szBY4895n57vhdy7Ngx3HvvvS7PjcNZXbp0cb2o8+bNw7/927+5Nsy2GnLu3Dk3JLZu3Trccccd6Nmzp/v7u3fvxv/+3/8bjz/+OG6++ebrsh+LZHNFwySRLBYvXuyuPIsXL+49//zz3l/+8pfLXq3x6pRX/PxvPv/882zvvfDCC255r169rmiPzaV6Hn7rv/nHP/7hrvDZW/Dtt99mW4fOnTu7z48cOTLbvxPqXRk4cGC2K/HJkye75f369ctT+7nc+hGv2vn+Aw884J09ezbbe99//70XHR3tlSlTxtu/f3+2K/+GDRu6/2769Ol/uMdm9+7dbhl763IaP368e2/ChAkXly1fvvzidz19+vTF5RcuXPD69+/v3ps3b94f/vylhL47Hy+//HK299j2uJw9HVnt27cvV48Q/y7bJD/P3ru8bodLYY9ZgQIF3DY6d+5cnv6bnH+vffv2rmclZOXKlRe/R1Y9e/Z0y4cMGZJt+b/927+55bfffnu2dsp9mMu7d++e63c4efKk6yn6o/uxyJWkwEauKg5vsMs667AJD3rsmt+1a1e2z6akpFzypMiD5i233OK6/7MetK9XYMOTP5cNGDAg1+d5AuSJqXLlytmW8/Psug+dALKezPj5OnXqeFcysMkacIUw2OJ7Y8aMyfXeunXr3Hsc4vmjgQ3de++9bn3+/ve/Z1tev359d9Lm8EdIu3bt3L/B3ywnniyjoqK8jh07/uHPX0rou3MoK+f2oPvvv9+9H25IKqfNmze7z7766qt53g6XwmFK/jdly5bN83+T8+/9+OOPYd/j/hPCfYj7EodDww0bcjiO/xb3yVAb5QUKg/mcQ045/ZH9WORK0lCUXFXPPfcc+vbt67rB169fj6+//toNFzAhkl3uHIZhFz1t2bLFPYer8mCpeN26dd1Qz9/+9jfUrFnzum65y33XChUquAoWDsGxMowluiEcguG6ZBUanuAw1ZXCIbBwv9HlvjeHJfjf/b//9//+1N/mEBuHHWbPnu2G+YjDFayEa9u2bbYhCA5JcChsypQpYf+twoULY+fOnX/487/lv/7X/5prexCnI2DFEX+vf/qnf3LLOKwyYcIEN7TDv8HhJT9e9R0+fDjP2+Fq4ZBkpUqVci1nuTi3SQi/f2pqKpo1a4YiRYrk+jyXr1ixwrUF/hb8PNtyixYtLg43XcqNtB+LTQps5KrjiZ2lq3wQKzleeeUVV7Lau3dvHDp0CAULFsSpU6fc+5fKQQiVW4c+dz3l5bsysOHnsgY2OatbsgY3mZmZV+z7Md8nXJ7M5b43P8/l3B5/BvONnn32WcycOfNiYDNjxoyLQU/OsmZWATEv53JzIf3Rz/+WS22/0PKsVUfMFWGODYPTUE5VgQIFXEDK3JFwFX6X2g6Xy0vjv3n8+HH37+XMofktl6reY/u6cOHCxf//e/e10O/AvKbfciPtx2KTJuiTa44HX175JiQkuITSrVu3Zjvp//3vfw/73x09ejTb5y4llHDJE2BOV6o89kp916vlUifTy31v9j5wedbv/Ed+SyYlM7mWvXO8KicGOdzu7LHJ+X14Mv9lWDzsgwmtf/Tzv+VS2y+0PBQoMDmYQQ0TYjkxHhOJX3/9dTdZIpNuL+X3JmEzAKlfv75LAma599Xye9tvKDk9L0FvpO8bYp8CG7kueMDnkELOYQEKN6Mur8J5ouRQQ7Vq1S77b4e6ysMdhEPd5Fnlz5/fPf+eHpPLfdcDBw64ShMOR2XtrblS/sj3zcv35hAhhyeyVrD93t8yJNQzw4CGVTQMNtjjkbNKjFVH7J3gUFVe/N7P/xauA4eUcmKVVdbfKzRD9sMPP3zx98/52SuFvZjEGbuzDnWF80fngapevbrbFgzYWDmVU6h9hNoC9zkGIvw8K64u50rtxyJ/2BXN2BHJ4v333/c2bdoU9jdZuHChS/Rk8mZoLo6s1RQrVqzI9nlWruS1KmrDhg0Xk2CzVnWsX7/eJbXmTARmQiO/C/+t31sVxSRIzoOStUqma9eul6yKutTfCM1BkhesKrrUvDq/9W+FqqJuvfVW79ChQxeXM5GT86bkrIriciaNMuHz+PHj2ZJcQ9sqXNI1tynn9qlUqZL35JNPus+tWbMm1+eWLVvm3mNFVriKuSNHjnjffffdH/78n6mK4hw1WdsOlz322GPZPsttz/UM9zv8nm2aFRN1GzVqdPHfPHXqVK7P8Pfv06ePm88nL38v3H4SqooaOnRotuWh3zhnVVSooun3VEXldT8WuZIU2MhVw7LT0AGSB2iWlXLisNBBO1++fN6sWbOy/Tdr1671ihQp4qpnunXr5v4bTiQXqqb66aeffvOATYmJiW45K3EGDx7sJgrjJGGPPPJI2KCAn2Nwk5SU5I0YMcL7n//zf3p79+697AR9n3zyiZtwjZVOPFC/9NJL3j/90z9d/Ls5y3WvVGCzfft29105ARvXjd+VpdR5/bdYqcbvwooYVnXx3+DEgqFSYQZnWb3yyisXJwHk9uMJsVSpUq766HLVZCxf5/vclvxvc/67If/jf/yPixVKXbp0cb8jT9rc7vx9OQHen/n85QIbtkUGqM2aNXNtjUEpA7/ChQt7GzduvPh5nsi5TUP/DU/yLOvn5/75n//5igY2xCCSgTn/XQZO/FsMCp577jnvwQcfdAE11zVrsPh7AxvuS6zcC10EZF1/7oPcF7Niew7tu3fccYdrC/wd2A64D2SdiPP37sciV5ICG7lqdu7c6f3rv/6rKx3llTsPxnzwwMaTwKVKaf/93//dnSx48gydFDljadYy4d8KbHg1z9l92dPAk88999zj5tG5VJDCmXA5+yxPlgwa8jrzMEtbWdbK/46BU9WqVd2JN+scK1c6sKFp06a5eVY4j86lZh7+rTmG+F3YG8N/g/9WuJmHQ1fgLGUuX778xXV85513XFnx5QIbzusS6hXJOVdKTryy56zEnKWW25zlziwbZ9CWdb6dP/r5vMw8zNmEeYJu0aJF2LbJkzED2Ntuu821Y/5m77777iV/hz8T2BADQc7J06FDB/c3+dszWGBPEoOKnD1TvzewIe5T/Lf43/F35D7Hfe9SMw+zJ27s2LFe7dq13X7FqRzuvPNON8cNZ1j+o/uxyJUUxf/54wNZIiI3Ht7RnWXRnL152rRp1/vriMgVpORhERERMUOBjYiIiJihwEZERETMUI6NiIiImKEeGxERETFDgY2IiIiYocBGREREgnd37997MzcRERGRKykvU+/lObAJ3ek3dMv5IODN9ngn4aAI2voeOXIEFy5cULsOgCC1bbXr4AhSuw617bz4XYENg5qDBw8iKNq1a4clS5YgKIK2vvHx8e6u1WrX9gWpbatdB0eQ2nWobeeFcmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMSPiApsLFy5gwoQJqFOnDooUKYISJUqgcePGWLJkCaxbuBBo2RKIjQUKFQIqVQK6dgUOHIAphw4dwrhx49CqVStUqFABBQsWRNmyZdGxY0d89dVXsGrmTKBfP6BuXSAmBoiKAqZNg2meByxYADRrBpQrBxQpAlSr5v8OP/4IcypWrIioqKiwj6ZNmyIoxowZc3G9N27cCEu4z3Lfvdzj/vthSmpqKp577jl3Lr7ttttQqFAhd8xOTEzE1KlTkZGRgUgSjQjieR4ee+wxzJ8/H1WqVEHv3r2RlpaGxYsXo3379hg/fjyefvppWDz49+8PTJoEVKkCdOkCFC8OHD4MfPEFsG8fUL48zOB25IGP25jBTenSpbF7924sWrTIPWbNmoXOnTvDmqFD/W1ZqpR/kudr6wYPBpKT/fXt0AEoUQL49lvggw+A2bOB9euBu++GKSVLlsSzzz4bNugJgm3btmH48OEoWrQozpw5A2tq1waGDw//3rx5wPbtwAMPwJTTp09j4sSJqF+/Ph5++GF3zD5x4gSWLVuGXr16Yc6cOe51vnwR0lfi5RE/GhcX511Nc+fOdX8nMTHRO3v27MXlx44d8xISEryYmBhvz5493rXStm3ba/J3xo3j7+t5Awd63vnzud/PyLC1vvPnz/fWrFmTa3lKSopXoEAB7+abb/ZSU1Ov+vdge74W7TpkxQrP27vXfz1qlL/Np071rrlrtZ2PHPG8fPk8LyHB806ezP5ecrK//j172lpnHqf4uJ6udbvOKj093atTp47XoEEDLykpyX2PDRs2XJO/fa228aWkpXlebKznRUd73tGjnql1zszM9NK4gjlkZGR4TZs2ddt56dKlV/175LVNR0h45WPPDL3yyisoXLjwxeWlSpXCoEGDXO8Nu70sOXcOGDECqFwZeOcdIH/+3J+Jjqh+tT/v0UcfRZMmTXItb9SoEZo1a+auBLZu3QprWrQAEhIQGHv3cmgZSExkL0b299q08Z+PHbsuX02uktdffx3bt2/HlClTkD/cwcywRYuA48f9tn3rrTAlX758LmUgp+joaDzyyCPu9ffff49IEVGnzKNHj7rnSkwuySG0bPXq1RjBSMCI5cuBEyeAnj2BzEyAqUS7dgE33eSfCG+/HYFSoECBizuM3NjuuAPgsXDdOuDUKX8YKmTpUv/ZWi4C8QJs2rRpOHz4sMsRrFevHho0aADrvvnmGxfYjBw5EnfeeSeCZvJk/7lPHwTGhQsX8Pnnn7vXd0fQmHJEnT3YM0N79uxBjRo1sr3HZbSLZ31DNm/2n3lxU6uWH9SEcLhy0CBg7FgEwv79+7Fy5UqUK1cONWvWvN5fR/4kJsGPHg08/zxQvTrQvv2vOTarVwMDBwIGU+bcBVpPXqlkweBm9uzZLq/MIgZzjz/+OGrXro0XX3wRQcN8uVWrgPh44MEHYVZ6ejreeOMNlw97/PhxrFq1Cjt37nTt/f4IukqJqMDmoYcecklIo0ePRvPmzV3mNfEHZBUNnTx5Epb89JP/zATLOnWATZsAxnRbtgBPPgm89ZafUDxgAExjVn337t3dAZKJxUHrxraKgXlcnH8V+/77vy5v2BDo1s3eMCsP8BxS5dVrsWLF3IVYcnIyZsyY4Q78HGItzsoAY4YNG+YKADZv3hzIfZcZEhx27dEjfDqBpcBmRJYRE1a9DR48GKNGjUIkiagcm27durkci7Vr17or9meeeQb9+/fHXXfd5bp0KWKyrq8Q7gzELnuO0darBxQrxnwTYO5cv9eGwY317swePXogJSUFffv2dQGO2DByJJCUxLw5f9qCn38G1q5l+SjA6mdrsziwGogXZWXKlHHTVbAHY/r06a5N79u3Dx+wHMyYDRs2YOzYsRg6dGhEDUdcy2M4AxuWeffqBdOKFSvmemsyMzNx4MABvPvuu5g8ebKbyuAUx5sjRERFCcyrYMnYq6++6gKYSZMmYcGCBa7Uex7r6AB3wLAklFTJuU1uuy37ezxGMKn4hx/YUwWzQQ3LBVninZSUhPezXtbLDW3lSr8slsNNL7/sd9MzaGdvzaefMp/KH6YKgn6cuAfMN1oHS86fP48nnngCtWrVwsvcyAFt5/v3A82b+3OPBUG+fPkQHx+PAQMGuPM02zXzqyJFxHUEx8TEuKsePrJas2aNe67LCMAQTlZGTBYOJ7Sc1VOX+syNHNSw655XtF27dnUJl9Z65IJs2TL/mZPz5VS2rJ93wyHX06f9gMeyUP6gtXldOL8Jh6AoXNUM3Xvvve554cKF6MDJjIwJYtJwVpyLLOs5OhJEXGBzKR9//LF77sLZ6wwJHfR37Mj9HidzZAVd0aJA6dIwG9RwMj7mIARxbN6y9PTLl3RzOePYXwrhTAvNqG1tkj5eiHIi1XA4tMygp127dm5CN2vrTizv5iwlt9wC/FL1HDiHOZNslorWSBBxgQ3H6UL5NCEchuK8CKws4BwoljAxmAEvy74Z+WeN+llRwiEo5ihYSrIMDT8xqOnUqRNmzpypoMYgzl8zYYKfGN+xY/a5bDjiePCg/xneXsICVofwFiHMrcm5/KWXXrqYR2gJ5xtjjkU4zJtjYDNkyBDcc889sGjGDD+A5zHaSjsO57vvvnOBac62ffbsWXerBWrdujUiRcSdLjnfQ/ny5V25N6uiNm3a5Lq4KleujLlz55o8Ab73HnDffUDfvn4CcaiLniWxnNDtzTdhCue5+Oijj1wiWtWqVfHaa6/l+gy7rJl4aQmP/19+6b8OzT/IZaEeXOaeWOrO7tQJmDiRV+5A1apAu3b+cOo33/htm3NwMuixghWdrIDi/XQSEhLcLQVYFfXZZ5+5qj+e4Pme2PHhh/6zpf02nE8++cS17YYNG7oAh50PvOcfc2JZtcxKQE6iGykiLrDhsAQThnnjNB4MODEfs+1feOGFXD05lnptvv6aJZMA5zpi7w1zEJ56yl9mLF8aezkl7S/j85dKOOPOYy2wYVDz0UfZlzGXNGs+qaUDJK9B2JbffpsHRmDWLP/qlrOyhiqlckxXdUNjReeOHTuwZcsWV9nJq1nm1vBKduDAgRdzEcQGTs2xbRtQvz5gfdqtNm3auCGn9evXuyo4Hrt5TzQmjTM9hD3wkTSpahTvq5CnD0ZFIS4uDgfZfxwQHBsOwl3Fg7q+zOrnVYfatX1Battq18ERpHYdatt5iUFUgiIiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyI8jzPy9MHo6JQqFAhtGzZEkGxadMm1K9fH0ERtPVdsWIFUlNT1a4DIEhtW+06OILUrkNt+9y5c7iigU1cXBwOHjyIoGjXrh2WLFmCoAja+sbHx+PQoUNq1wEQpLatdh0cQWrXobadlxhEQ1EiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyIuMBm5syZ6NevH+rWrYuYmBhERUVh2rRpsIyrFxV1+cf998O8MWN+Xd+NG2HOhQvAhAlAnTpAkSJAiRJA48bAkiUwb+HChWjZsiViY2NRqFAhVKpUCV27dsWBAwdgRWpqKp577jk0btwYt912m1vPsmXLIjExEVOnTkVGRgYs8jxgwQKgWTOgXDm/bVerBvTrB/z4I8w5dOgQxo0bh1atWqFChQooWLCg284dO3bEV199BasqVqzozsfhHk2bNkUkiUaEGTp0KPbt24dSpUqhXLly7rV1tWsDw4eHf2/ePGD7duCBB2Datm3+b1C0KHDmDEwe/B97DJg/H6hSBejdG0hLAxYvBtq3B8aPB55+GuZ4nof+/ftj0qRJqFKlCrp06YLixYvj8OHD+OKLL9z+Xb58eVhw+vRpTJw4EfXr18fDDz+M0qVL48SJE1i2bBl69eqFOXPmuNf58kXc9eSfMngwkJzsBzUdOvgB+7ffAh98AMyeDaxfD9x9N8wYP348xowZ49ozgxtu5927d2PRokXuMWvWLHTu3BkWlSxZEs8++2zYoCeieHnEj8bFxXlX24oVK7y9e/e616NGjXJ/d+rUqd710LZtW+96SkvzvNhYz4uO9ryjR+2ub3q659Wp43kNGnheUhLbmudt2HD1/y7b87Vq13Pn+uuVmOh5Z8/+uvzYMc9LSPC8mBjP27PHuyau5XYeN26c+40HDhzonT9/Ptf7GRkZZtY5MzPTS+NOG2YdmzZt6n6HpUuXmmrXR454Xr58fhs+eTL7e8nJfpvv2dMz1a7nz5/vrVmzJtfylJQUr0CBAt7NN9/spaammtuXExIS3ON6ymubjrhLhxYtWiAhIeF6f42IsGgRcPw40KYNcOutMOv11/1eqSlTgPz5YRJ7ZuiVV4DChX9dXqoUMGiQ33szdSpMOXfuHEaMGIHKlSvjnXfeQf4wGzc6OuI6jf8w9sRwWCLcOj7yyCPu9ffffw9L9u71h1gTE3k1n/09Hrfo2DGY8uijj6JJkya5ljdq1AjNmjVzvXRbt269Lt9NfHaOKgZNnuw/9+kDs775xg9sRo4E7rwTZh096j9XqpT7vdCy1auBESNgxvLly91BvmfPnsjMzMSSJUuwa9cu3HTTTe4C5vbbb0cQXLhwAZ9//rl7fbelMRkAd9wBMJZbtw44dcofhgpZutR/DkJ+YEiBAgXMBexZpaWluZxXDiWXKFEC9erVQ4MGDRBpbP76BjC1aNUqID4eePBBmMReiscf93OMXnwRprFnhvbsAWrUyP4el9GuXTBl8+bN7pk9NbVq1XJBTdbejUGDBmHs2LGwJj09HW+88YbLLzp+/DhWrVqFnTt3ugDvfmNn+dhYYPRo4PnngerV/XyxUI4NA/WBA23mjoWzf/9+rFy50uWG1qxZExYdPXrUteOsGNzMnj3b5RxFCgU2EYrDEuzi7dHD7vDMsGHA7t08Adpdx5CHHgLmzPFPAs2bA4UK+cs51DhunP/65EmY8tNPP7nn5ORk1KlTB5s2bUKNGjWwZcsWPPnkk3jrrbfcwXDAgAGwFthwCC6EVSODBw/GqFGjYBGHUuPi/J7l99//dXnDhkC3buy9gHmseOvevbvr0WBicbhh1xtdz5493XAbex2LFSvmLlS4b8+YMcMF7Bx+Y2FAJIi4HBvxAxoGNix77tXL5i+yYQPAi/WhQ21VTFwKD/Ash127FuDF3DPPAP37A3fd9Wv3vbFiGTcEQ8w7YbUIr+x4QOTBce7cua7XhsGNNVxH9tZw+I3l7O+++y4mT57sSmJPcbzGGA4jJyX5+WOs3v/5Z7+dp6YCrAK2Pp0B23mPHj2QkpKCvn37ugDHouHDh6N58+YoU6YMihQpgtq1a2P69OlufVnd+AHL4CKEsUOpDStXslvTv7IPl5Nxozt/HnjiCaBWLeDllxEIvGpdtgx49VU/gJk0yZ/7g133LOmnMmVgrjSUOCcV53XJild9TCr+4YcfcNJaV9UvGLjFx8e7HimWu69btw6vM6HM2LGK0zRwuIn7MofOixXze2s+/ZQ5J/4wleWghqX8LPFOSkrC+1m7rAKiHycsAvOs1iFSBKCT8MZjPWn49Gl/CIrCFJE4997rPy9c6M+NYUFMjH8SyDln0Zo1/nPdujClGmdpA1yycDih5ayeutRnrOB8J7QmtLGNYLBO7I3MqWxZP+9myxZ/n2fAYy2o4fAMey042SSTaq3NUZQXnHOOzkTQBGQKbCIMcy5YGnzLLcAvFaLm8ATPCerCSUnxg5527YDSpTnxE8z7+GP/uUsXmMLSV9qxY0fYnASWPhctWtRNcGYdq0iyVs1YkZ5++ZJuLue53thqZwtqOBkf80ws5tXkRWi25UiapC944WWEmzHDP1hwzJoBgEWcx4W9UuEe993nf2bIEP//s2LKinDpFRyG4vw99epxfgyYEpqZlQEMc0yyGj16tBuC4vwuVkpjv/vuO5w9ezbXci7jrRaodevWsITz1xBnHv7HP7K/x1GZgwf93ldLx7LQ8BODmk6dOrnbAFkPanbu3Bm2bXP5Sy+95F53YyJhhIi4IwoPgF9++aV7HZrkiMtCXbgNGzZEH6tjNAA+/NB/NryKgcXpHnj3AJZ7sypq0yZ/GKpyZWDuXJuVYe+99x7uu+8+l1TJBOLq1au7qqjVq1e7iTjffPNNWPHJJ5+4KhEeo3j1ynk+eF8h3kaBZd9MmmaJuyWdOgETJ/o9rVWr+j2tHFXk/FQs9+ZFDIMeS0aOHImPPvrIJYlXrVoVr732Wq7PdOjQwSXXWjFnzhzXtnkfNO637GllVdRnn33mel+HDBni3osUERfYMKhho8mKSUlZE5OsBjY80fGeSfXr+5UzYgtvH8OEYd7gk/dDZGI4q8JeeCH7xGbWem2+/vprDBs2zE1Sx0n7eMPAp556yi1jhYUVbdq0cUNO69evx4YNG9y9o5hAzTl8eI8sXuVb6Z0KYTC+fDnw9tsM7IBZs/weZ86UHqqUyjlv041uL6db/uXeYJdKBmdgaymwadasmRtS5kXJ2rVrXe8Nc2vYAzlw4MCLOWSRIuL2MiZgWb+b96UwoHF35Qowbnqrm58VUXwEDW9yybtbW8fqLz6ChsNMrIgKSoVjEM9RTZo0CXsbiUilHBsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGlOd5Xp4+GBWFQoUKoWXLlgiKTZs2oX79+giKoK3vihUrkJqaqnYdAEFq22rXwRGkdh1q2+fOncMVDWzi4uJw8OBBBEW7du2wZMkSBEXQ1jc+Ph6HDh1Suw6AILVttevgCFK7DrXtvMQgGooSERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGRAY2FStWRFRUVNhH06ZNYUlqKvDcc0DjxsBttwGFCgFlywKJicDUqUBGBkzyPA8LFixAs2bNUK5cORQpUgTVqlVDv3798OOPPyIIxowZc7Fdb9y4EdYcOgSMGwe0agVUqAAULOi37Y4dga++gknTpk275LEr9Lj//vthycyZQL9+QN26QEwMEBXF3wGBsHDhQrRs2RKxsbEoVKgQKlWqhK5du+LAgQOw5MIFYMIEoE4doEgRoEQJ/5y1ZAkiUjQiVMmSJfHss8+GDXosOX0amDgRqF8fePhhoHRp4MQJYNkyoFcvYM4c/3W+iAxB/7jBgwcjOTnZBTUdOnRAiRIl8O233+KDDz7A7NmzsX79etx9992watu2bRg+fDiKFi2KM2fOwKLx4xm8AVWq+MEN2/bu3cCiRf5j1iygc2eYUrt2bbddw5k3bx62b9+OBx54AJYMHQrs2weUKgWUK+e/to4XZv3798ekSZNQpUoVdOnSBcWLF8fhw4fxxRdfYN++fShfvjws8DzgsceA+fP9fbl3byAtDVi8GGjf3t/Pn34akcXLI340Li7OuxYSEhLc43pr27btVf8bmZmel5aWe3lGhuc1bcrf3fOWLvXMrC8dOXLEy5cvn9vGJ0+ezPZecnKya2s9e/a86t+D7flatuuQ9PR0r06dOl6DBg28pKQk9x02bNhwzf7+tdrO8+d73po1uZenpHhegQKed/PNnpeaamudLyUtLc2LjY31oqOjvaNHj5pq1ytWeN7evf7rUaP8Y9bUqd41dy238bhx49xvPHDgQO/8+fO53s/gAdzIOs+d62/TxETPO3v21+XHjvFc7XkxMZ63Z493TeS1TRvrB7jxsCeGXfQ5RUcDjzziv/7+e5iyd+9eXLhwAYmJia5nLqs2bdq452PHjsGq119/3V25T5kyBfnz54dVjz4KNGmSe3mjRkCzZn7P5NatCIRFixbh+PHjrn3feuutsKRFCyAhAYFx7tw5jBgxApUrV8Y777wTdh+O5gHciMWL/edXXgEKF/51OXvoBg3ye2+YNhFJIvbXT0tLc+PV7NrjMEW9evXQoEEDBAXHND//3H9tbUTmjjvuQMGCBbFu3TqcOnXKbd+QpUuXumdreQgh33zzjQtsRo4ciTvvvBNBVaCA/2zo+H9ZkydPds99+vS53l9F/qTly5fjxIkT6NmzJzIzM7FkyRLs2rULN910E1q0aIHbb7/d1G989Kj/XKlS7vdCy1avBkaMQMSI2MPK0aNHXcPJisEN8y84pmlNejrwxhv+eObx48CqVcDOnQB/AmvneCbajR49Gs8//zyqV6+O9u3bX8yxWb16NQYOHIinI27Q9soE648//rjLw3jxxRcRVPv3AytX+vkYNWvCPOZbrFq1CvHx8XjwwQev99eRP2nz5s3umT01tWrVckFNSL58+TBo0CCMHTvWzO9cqpT/vGcPUKNG9ve4jLL8BBEhIgMbBjSNGjVyyaPFihVzDYeJpjNmzHBX8lu3bnWJWtYCm6wRLysLBg8GRo2CSdz54+Li3BXs+++/f3F5w4YN0a1bN1NduSHDhg3D7t273YHR8hDU5bDKr3t3v/uaicVB+BmmTp3qhl579OgR2O1uyU8//eSeeU6qU6cONm3ahBo1amDLli148skn8dZbb7mL7wEDBsCChx7yi1hGjwaaN/crd4kX4Kx6pJMnEVEiMseGVQXNmzdHmTJlXBkwr3CnT5+O7t27u6sfVs5YU6yY31uTmQmwUvDdd9l9DbC6/dQpmMOhmKSkJLzyyiuuNPLnn3/G2rVrkZqa6kr62b1ryYYNG9xV3NChQ01Xe/3W8GqPHkBKCtC3rx/gWMeAhoENy7x7scxRTGxT4nA6c6c4ksALcF6Mz5071/XaMLixols3Pydu7Vq/h/WZZ4D+/YG77vLLvinSqnYj7OtcHuc4IeZmWMUGEh8PMNifNInrymRTmLJy5UoXvHK46eWXX3Zd9DwwsLfm008/RYECBdwwlRXnz5/HE0884bqtub5BxHMBz+ss8U5KArJ00pnGtr5//353ocY5TuTGFyp4qFu3Lm7j5GNZ8KKFScU//PADTkZaN8YfxM5zTjny6qv++YnnpQUL/FLvefP8z5Qpg4hyQ/X3l/plsM/qvB85ce4PWrMGpizjXgJeBTTL9V7ZsmVd3g27dU+fPu0Cnhsd14NDUKGrvHDuvffeixN+cV4fa0ENc8WmTwe6dvUnb4u0K7yrRUnD9nAiUWKycDih5ayeutRnbjQxMRxJ8R9Zhc5NnJwxktxQgc1Xv0xXam2Svks5fDh7BYkV6UwoukxJN5ezO5c9NxbExMSgN2e1CiMlJcUFPe3atUPp0qXNte2sQQ0n45sxIxh5NcTy7sWLF+OWW27BI6G5G+SGF7og27FjR673MjIy8P3337uJN7k/W/fxx/5zly7X+5tEeGCzc+dOVKhQweXW5Fz+0ksvuddMLrXiu+8YqPnTVGd19qx/qwVq3RqmcP6aCRMmuOS7jh07ZpvLhonEBw8edJ9hQGBB4cKFL16558SEUgY2Q4YMwT333AOLw08Majp18qfeD0pQQyx2YBDPXDIrbVk4+24VtGrVypV9c7/OWsLPak8OQXGbWyqAOHXq13yaEA5DTZnCamV/zqpIEnG//Jw5c9wJr3HjxkhISHCRL6uiPvvsMxcN8wTA96z45BNm17MayA9w2Hh4jx2O1jDrnJOZcRIkSzp16oSJEye63oqqVau63gp22XKOF5Z7MxBgG5Ab28iRwEcf+YnxVasCr72W+zMcdatdGyZ9+OGHgZi7hjH7l1/6r0MTLnJZaJiCxzZrP8F7772H++67D3379nUJxKHhcx6/eN568803YUmDBgDvEMFyb1ZFbdrkb9/KlYG5cyPvgiU6Erv52MXHRsIqmbNnz7rcmtatW7v5TRgpW8KJdjnktH49K2f8e0exA6NWLb97j1e8hgJ/hyWvvNp5++238cknn2DWrFnuypYzsoYqpVg+KTe2vXv9Z7bpSyXAM5i3GNiwBJj3A6tfvz5qGp+sh0ENA9isWPSQtcbDWmDDXpuvv/7aTeHw+eefu+MZ8wOfeuopt4wVvZZ07uwnDPNevZyygXnwvEfYCy/k7smJBBF3ymzSpIl7BAWTriIt8epaYNc8K4SCWiUUwtm1+bCIq2V01X4TAxr/Fnv2BXU78yaXLOUPgldf9R83ioDUJoiIiEgQKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImBHleZ6Xpw9GRSFfvnwoV64cguL48eOIjY1FUARtfY8cOYILFy6oXQdAkNq22nVwBKldh9p2ZmYmrmhgIyIiInK95CVkif49/6B6bGwLYvSvHptgCFLbVrsOjiC161DbzovfFdhwGOrgwYMIinbt2mHJkiUIiqCtb3x8PA4dOqR2HQBBattq18ERpHYdatt5oeRhERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImBGRgY3nAQsWAM2aAeXKAUWKANWqAf36AT/+CFMOHTqEcePGoVWrVqhQoQIKFiyIsmXLomPHjvjqq69g3cKFC9GyZUvExsaiUKFCqFSpErp27YoDBw7AktTUVDz33HNo3LgxbrvtNreu3M6JiYmYOnUqMjIyYFHFikBUVPhH06Yw58KFC5gwYQLq1KmDIkWKoESJEm6bL1myBBZNm3bp7Rt63H8/zBsz5tf13bgR5sycORP9+vVD3bp1ERMTg6ioKEzjxo9Q0YhAgwcDycl+UNOhA1CiBPDtt8AHHwCzZwPr1wN33w0Txo8fjzFjxqBKlSouuCldujR2796NRYsWucesWbPQuXNnWON5Hvr3749Jkya5de/SpQuKFy+Ow4cP44svvsC+fftQvnx5WHH69GlMnDgR9evXx8MPP+y284kTJ7Bs2TL06tULc+bMca/z5YvIa40/pWRJ4Nlnwwc91tr0Y489hvnz57s23bt3b6SlpWHx4sVo376929effvppWFK7NjB8ePj35s0Dtm8HHngApm3b5v8GRYsCZ87ApKFDh7pjcqlSpVCuXDn3OqJ5ecSPxsXFeVfbkSOely+f5yUkeN7Jk9nfS07m9/C8nj29a6Jt27ZX/W/Mnz/fW7NmTa7lKSkpXoECBbybb77ZS01N9aysb8i4ceNcmxo4cKB3/vz5XO9nZGRc9e/A9nyt2nVmZqaXlpYWdj2bNm3qvsfSpUs9a9uZ+zEf19u1WOe5c+e67ZiYmOidPXv24vJjx455CQkJXkxMjLdnzx5T7fpS2NRjYz0vOtrzjh71zLXrkPR0z6tTx/MaNPC8pCT//LRhw7X7+9dqnVesWOHt3bvXvR41apRrX1OnTvWutby26Yi7PNy7l925QGKif6WXVZs2/vOxYzDj0UcfRZMmTXItb9SoEZo1a+au6rdu3QpLzp07hxEjRqBy5cp45513kD9//lyfiY6OyM7EP4w9MRxmDLeejzzyiHv9/fffX4dvJlcKe2bolVdeQeHChS8u51XuoEGDXO8Nhx2DYNEi4Phx/5h9660w6/XX/V6pKVOAMIcxM1q0aIGEhATcKCLu7HHHHQCP/+vWAadO+cNQIUuX+s9BGLOlAgUKmDzJL1++3AVsPXv2RGZmpss/2LVrF2666Sa3A91+++0ICuZkfP755+713VbGV3NIS/NzMQ4f9vfnevWABg1gztGjR90z88RyCi1bvXq1C+qtmzzZf+7TB2Z9840f2IwcCdx55/X+NpJVxJ0xY2OB0aOB558HqlcH2rf/Ncdm9Wpg4EDA2DB1WPv378fKlSvdeGbNmjVhyebNm90ze2pq1arlgpqsPRu8uh07diwsSk9PxxtvvOHyMY4fP45Vq1Zh586dLsi732jEzvN9z57ZlzG4Yb5clSowgz0ztGfPHtSoUSPbe1xGWdu6VUy/WLUKiI8HHnwQZoP1xx/3c4xefPF6fxuJ+MCGBg0C4uL8aP/9939d3rAh0K0bezBgGitkunfv7rqumVgcbqjmRvbTTz+55+TkZFc9smnTJnci2LJlC5588km89dZbLvlywIABsBjYZL1iZ3XB4MGDMWrUKFjEgKZRIz/Zv1gxntj9woAZM/yeV46yFi8OEx566CGXBD569Gg0b97cVb4RA1hWPtLJkydhHUfbmE7Qo4fd4Zlhw4Ddu3mRZncdb2QRl2ND7NpLSuJYNcCq359/BtauZcmsXyJqtHLy4tBEjx49kJKSgr59+7oAx+I6EnNOWPlVr149FCtWzOUVzZ071/XaMLixiOvJ3hoOwbGk/d1338XkyZPRtGlTnOLYqzGsFmneHChTxp+2gVe406cDbNa8smeloxXdunVzeXFr1651vazPPPOMq/y76667XNk3Wax6y4q7NgMblj336gWTNmwA2KE8dKid6lxrIm4vW7nSPxhyuOnll/3uTF7psbfm00+Zd+IPU1nEEz5Lf1ninZSUhPezdlcZUvKXrHDOicA5XbJingmTin/44QfTV7c8wcXHx7teKZa8r1u3Dq9zwD4gOCcVMZfOCubCsWT/1VdfdduX23XBggWu1Hsea5/BAK8MLOPxe/9+P5gNk2p0wzt/HnjiCaBWLf/8JJEp4gZ1li3znzk5X05ly/p5N1u2cF4QP+CxFNQwz2L69OlugjpOfmT16q4aZ1sEXLJwOKHlrJ661Gcs4fxFtGbNGgTFL+ko5ub94ORlw4cPd4+sQtuWwbxl1pOGed7hEBSFKXJ07r3Xf1640J+HTa69iAts0tMvX9LN5Tzf/1IwZC6o4WR8M2bMMJdXkxW762nHjh1h84tY9ly0aFE3iV0QcFLCrFVwQRCaVNvaJH2X8vHHH7tnTkRpFcu7WfF+yy3ALzMYmBMTA/TuHf69lBQ/6GnXDuChKyhtOxJFXGDD+WsmTPATDDt2zD6XDUdmDh70P8MGZmn4iUFNp06d3NTVloMaCs2yzLJv5pf0yXJ5x8RLDkFxKM5Smft3332HihUrumn2szp79qy71QK1bt0aluzcCVSo4OfW5Fz+0kv+axYDWMI8qVA+TQiHoaZMmeJyyThvlVVMCOeFKfMjrRyfc+L0RKFeqZyYLM3AZsgQ4J57rvU3k6wi7szRqRMwcaIf/Vat6ke/HI3gnAEs92bDYtBjxciRI/HRRx+5pNKqVavitddey/WZDh06oDazLg157733cN9997kEaSYQV69e3VVFcZ4PTgT15ptvwpJPPvnEVYE1bNjQBTg8+fE+YczJYNUME6dZ5m7JnDn+vtq4McC5vTjlPKuiPvuMPXP+CYDvWdKgQQN3KxBW+bEqihV/HIZi3hgT4y1ftHz4oe1hqCCbPHkyvvzyS/c6NGEsl4WGWHlcy3qBer1FXGDD/X75cuDtt3kyAGbN8q8COHtlqFIqxxQRN7S9nGr5l3sJXSp5lCdCa4ENe22+/vprDBs2zE1Qx94b3hTyqaeecsusJVm2adPGDTmtX78eGzZscNubSdScx4fDE+y1s9RDRRxx5Ggjc+JY1Xj2rJ9bw44pzkf1S2qRKRxKZsLwxo0b3bAqJ+bjfXZeeOGFXD05lmza5N8zqX59wNi0WwK4oIYX4Fmx4IGPkEgKbKJ4X4U8fTAqCnFxcTjIsaCAaNeundm78oYTtPVlVRJ7TdSu7QtS21a7Do4gtetQ285LDGKz7EZEREQCSYGNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGlOd5Xp4+GBWFQoUKoWXLlgiKTZs2oX79+giKoK3vihUrkJqaqnYdAEFq22rXwRGkdh1q2+fOncMVDWzi4uJw8OBBBEW7du2wZMkSBEXQ1jc+Ph6HDh1Suw6AILVttevgCFK7DrXtvMQgGooSERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGxAU2qanAc88BjRsDt90GFCoElC0LJCYCU6cCGRkwp2LFioiKigr7aNq0KayZNm3aJdc39Lj//vthjecBCxYAzZoB5coBRYoA1aoB/foBP/4Ic2bOnIl+/fqhbt26iImJcduV2z5oxowBoqL8x8aNMOXQoUMYN24cWrVqhQoVKqBgwYIoW7YsOnbsiK+++gpWXbhwARMmTECdOnVQpEgRlChRAo0bN8aSJUtg2cKFQMuWQGysf26uVAno2hU4cAARJRoR5vRpYOJEoH594OGHgdKlgRMngGXLgF69gDlz/Nf5Ii4k+3NKliyJZ599NmzQY03t2rUxfPjwsO/NmzcP27dvxwMPPABrBg8GkpP9oKZDB6BECeDbb4EPPgBmzwbWrwfuvhtmDB06FPv27UOpUqVQrlw59zpotm0D2NSLFgXOnIE548ePx5gxY1ClShUX3JQuXRq7d+/GokWL3GPWrFno3LkzLPE8D4899hjmz5/v1rt3795IS0vD4sWL0b59e/ebPP3007B2Uda/PzBpElClCtClC1C8OHD4MPDFFwB37fLlETm8POJH4+LivKstM9Pz0tJyL8/I8LymTfk9PG/pUu+aaNu27TX5OwkJCe5xvV2r9b2UtLQ0LzY21ouOjvaOHj161f8e2/O1atdHjnhevnzc1p538mT295KT/Xbds6dnajuvWLHC27t3r3s9atQo91tPnTrVC0rbTk/3vDp1PK9BA89LSvK38YYNnql2PX/+fG/NmjW5lqekpHgFChTwbr75Zi81NdWztI3nzp3rft/ExETv7NmzF5cfO3bMHcdjYmK8PXv2mFrnceP89jtwoOedPx/+/Hwt5LVNR1y/B3tiChbMvTw6GnjkEf/1999f868l1wCv8I4fP442bdrg1ltvNfWb793L7mt/SLVkyezvtWnjPx87BlNatGiBhIQEBNXrrwPbtwNTpgD588OkRx99FE2aNMm1vFGjRmjWrBlOnDiBrVu3whL2zNArr7yCwoULX1zOnslBgwa53pupzJsw4tw5YMQIoHJl4J13wrdlnp8jSYR9nUvjSeHzz/3XlrrrQ7gzMP/g8OHDbry2Xr16aNCgAYJk8uTJ7rlPnz6w5o47/IB93Trg1Cl/GCpk6VL/2WBaUWB9840f2IwcCdx5JwKpQIEC7jk60s56f9LRo0fdcyUmmOQQWrZ69WqMYDRgwPLlfjpIz55AZibANKJdu4CbbuLFC3D77Yg4Edvi0tOBN97wx/aOHwdWrQJ27vR/XIsnAO4sPblyWTC4mT17thvHtY75F6tWrUJ8fDwefPBBWMNku9GjgeefB6pXB9q3/zXHZvVqYOBAwNiwfGClpQGPP85cMuDFFxFI+/fvx8qVK11uVc2aNWEJe2Zoz549qFGjRrb3uIx28cxvxObN/jN7amrV8oOarCMsgwYBY8ciokTcUFTWwIYBL6943n0X+Nvf/ORLJi9Zw4CGJ/W///3vOHPmDLZs2YLu3bvjr3/9q6sO+vnnn2Edu25ZadCjRw/kN9pvzwMAk9+ZIP/++8C//ivwl78A7Jjr1i3yunPljxk2DNi926/iNNqULysjI8Mdv9gLzcRia/vzQw895J5Hjx6NVJbx/oLD6KwQo5MnT8KKn37yn1n4wGH0TZsAnpJSUoCqVYG33vILfiJJxAY2xYr5vTXs+mIpGYMbjlSw+pld+ZawQqh58+YoU6aMKx1k1dD06dPdwYE9GR+wbMYwBjQMbFgO3Iulb0YxSE9K4ti836Z5cFi71p/igO3aeKVoIGzY4F+9Dh1qc8j8t4QuTlJSUtC3b193DLOmW7duLn9o7dq1rjfqmWeeQf/+/XHXXXe5NALKZ6hs98IF/5lD6YsWcSTBPz83agTMnev32jC4iSQR/+vzR4uPBwYM8HtrmKPAsesg4BwgtI4rbRi7rNl1zeAu3Li1BStX+mW/HG56+WW/TfPg0LAh8OmnzEfwh6nkxnX+PPDEE353PbdxEIMaXpiwxDspKQnvs1vSIOYMLVu2DK+++qoLYCZNmoQFCxa4Um9OV0G8SLWi5C/FDnXr+nPLZcXgnUnFP/zAXipEjBuq87tVK/95zRoEQmgsl8NTlllOGg7h3EvEyfly4gSUzLvZssUfpmLAIzcebjsOQVG4yk66995fJzrjXEaWghoOqbOnuWvXrq4QwlKvRU6ccJI97Tnn41rzy8mJk1JaUa2a/8xk4XBCy1k9danPXGs3VGDDyYDol2R780Izd1qcpC/ruDTLJ2+55RY8EqrnN4g5Y5cr6eZyngeC0rYtiokBevcO/x7zERj0tGvnTzpqaZfOGtRwMr4ZM2aYy6vJq48//tg9d+EMdkY0++VibMeO3O/xTgCcfoUTULJdR4qIC2y++87f6TndfFZnz/q3WqDWrWHGzp073VTkzK3Jufyll166OKZrFQ+C6enpruuaV0FWcf6aCRP8BLyOHbPPZcMe+4MH/c8Y/gnM45Qmv3Q+5tKjhx/YDBkC3HMPzA0/Majp1KmTu41GEIKaU6dOXcynCeEw1JQpU1w1K+f3saJKFX+0hGXfbN9ZO9ZZ6ckhKOYORlLxQwR9Fd8nn/gHf+YeMMBh2zl0yO/KZ9k3E5ZYXWLFnDlzkJyc7O4zwsnMihYt6koFP/vsM1ddMGTIEPeeVR9++KH5YSjq1MmvHAhVEvDKnd22nO+E5d48KbLdWxti/PLLL93r0CRtXBbqrm/YsKH57W7dyJEj8dFHH6FYsWKoWrUqXnvttVyf6dChgyuIsIRzjJUvX96VexcqVAibNm1y7bpy5cqYO3euueDuvfeA++4D+vb1E4hDQ+c8dnEOzjffRESJuMCGs7ByyIn3zWGFAceteXXLhDz27rFoJpIiwz+L2fU7duxwJd7Msj979qzLrWndujUGDhzo7r9iFQ8G27ZtQ/369c3NdZETj3O84nn7bT94nzXLH57iBMuhSqkcU2Lc8BjU8KSXFRPhsybDK7C5se3llNouv+g0Xr9EVQeH0q0FNhxyY8Lwxo0b3QUoix54b7QXXnghV0+OlV6br7/2pzLgRLk8ljE38Kmn/GWRlisdcSECc64M5V39Jk5HHm5K8iBgQOPfhiwYOMzEapmgVMwwgTSId/MOhz+DxZ8iqNuYFVF8BEn58v7cTDcCu2nrIiIiEjgKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERM6I8z/Py9MGoKBQqVAgtW7ZEUGzatAn169dHUARtfVesWIHU1FS16wAIUttWuw6OILXrUNs+d+4crmhgExcXh4MHDyIo2rVrhyVLliAogra+8fHxOHTokNp1AASpbatdB0eQ2nWobeclBtFQlIiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERM26IwGbMGCAqyn9s3AhzLly4gAkTJqBOnTooUqQISpQogcaNG2PJkiWwauZMoF8/oG5dICbG37bTpiEQFi5ciJYtWyI2NhaFChVCpUqV0LVrVxw4cACWTJs2DVFRUZd93H///bDi0CFg3DigVSugQgWgYEGgbFmgY0fgq69gVsWKFS+5fZs2bQprUlNT8dxzz7lj9G233eb24bJlyyIxMRFTp05FRkYGrPE8YMECoFkzoFw5oEgRoFo1/xj+44+IONGIcNu2AcOHA0WLAmfOwBzP8/DYY49h/vz5qFKlCnr37o20tDQsXrwY7du3x/jx4/H000/DmqFDgX37gFKl/B2Fr63jtu7fvz8mTZrktnWXLl1QvHhxHD58GF988QX27duH8uXLw4ratWtjOHfeMObNm4ft27fjgQcegBXjx/sXYVWq+MFN6dLA7t3AokX+Y9YsoHNnmFSyZEk8++yzYYMea06fPo2JEyeifv36ePjhh1G6dGmcOHECy5YtQ69evTBnzhz3Ol++G6LfIE8GDwaSk/1jdYcOQIkSwLffAh98AMyeDaxfD9x9NyKHl0f8aFxcnHctpad7Xp06nteggeclJfE7eN6GDdfu77dt2/aq/425c+e63zYxMdE7e/bsxeXHjh3zEhISvJiYGG/Pnj2elfUNWbHC8/bu9V+PGuVv26lTvWuK7flatutx48a5vzdw4EDv/Pnzud7PyMgwt53DSUtL82JjY73o6Gjv6NGjZtZ5/nzPW7Mm9/KUFM8rUMDzbr7Z81JT7bVrHqf4uN6uVbvOzMx0bTjc/tu0aVP32y9dutTMOh854nn58nE7e97Jk9nfS072j909e3rXRF7bdESHlK+/DmzfDkyZAuTPD5PYM0OvvPIKChcufHF5qVKlMGjQINd7w+5Na1q0ABISEBjnzp3DiBEjULlyZbzzzjvIH6ZBR0dHfAfqFbFo0SIcP34cbdq0wa233gorHn0UaNIk9/JGjfwu/BMngK1br8c3kyuJPTEFOc4YZv995JFH3Ovvv//ezI++dy/TJYDERPbMZX+vTRv/+dgxRJSIPZJ+840f2IwcCdx5J8w6evSoe2aeRU6hZatXr3YnRblxLV++3HVX9+zZE5mZmS5/ateuXbjpppvQokUL3H777QiKyZMnu+c+ffogKAoU8J+txq68AGNOFYdVmSNYr149NGjQAEHCXMnPP//cvb47osZl/pw77vDzxdatA06d8oehQpYu9Z8jLVUuIneztDTg8cc5Rg+8+CJMY88M7dmzBzVq1Mj2HpcRT4ByY9u8ebN7Zk9NrVq1sm1TXgGyd27s2LGwjnlEq1atQnx8PB588EEEwf79wMqVfn5CzZowe4HGoD0rBjezZ892+WQWpaen44033nC5c+yBZLveuXOn+x0sJcXHxgKjRwPPPw9Urw60b/9rjs3q1cDAgUCkpYFG5FDUsGF+0h1HYKwOQYU89NBD7nn06NEu2z6EO8o4llgAOHny5HX7fnJl/PTTT+45OTnZJVpu2rQJP//8M1JSUlC1alW89dZbLiHROg6r8sq2R48eYYfjrGGBTPfu/sUaE4strjJP5Dyp//3vf8eZM2ewZcsWdO/eHX/961/dCZ7t3Gpgw570kSNH4t1338Xf/vY3DB482BUHWDNoEDBnDhOngfffB/71X4G//AVgp1y3bpHXExlxgc2GDQAvXFk1Y6g375K6deuGZs2aYe3atahZsyaeeeYZVzlz1113uS5dspRdH1Q8mRPH5pljwqvZYsWKoVGjRpg7d67bxgxurP8GDGxYBszqEeu4yXv0AFJSgL59/QDHIla+NW/eHGXKlHHTVbAabvr06S64YQ/dByydMYj7L3trOLTMqRoY3HCYlSXupzhmY8jIkUBSEnNBAc5KwVh17VqWvgOs6I+0mUki6ox5/jzwxBNArVrAyy8jEJhwxtLAV1991Z3cGO0vWLDAlXqzJJZ4wJAbG3tpqG7dum7ui6w4Hs+k4h9++MF079zKlSuxf/9+dxIMl1NmLahh7MYSb54QeJUbNP04yQmYm7EOlvG4zaHVAQMGuOM31/d1JogasXKlP+UKh5t4Xo6PZ1AHNGwIfPqpnz/GYapIElEdSOzm4hAUhUk6d+69139euNCvp7cgJibGXfXknPNjzZo1F0+GcmOrxtmsAJcsHE5oOaunLvWZG11QkoYZ1DDdZPp0oGtXf+LJIHa6hvIHOTwVFK04gVGWY7cFy5b5z6zsy4kTUDLvZssW//zNgCcSRFRgwxloe/cO/x67cxn0tGvnT3xlcN6nXD7++GP3zInc5MbG4UbasWNHrvc4UynLQ4sWLeom+7KIOWOc2uCWW265WBJrPajhZHwzZtjMq8mLr36ZbtniJH2XwqowKhAqgzMgPf3yJd1czsA9klY5oq4jOI0LL+rCPe67z//MkCH+/2fFlBXhxmM5DDVlyhSXi/EoJ8iQGxorQ3g1xwAm1HMRwsRxDkHxhG91LpsZM2a4ZMukpCTXQ2l5+IlBTadO/m1DrAc1rAI6e/Zs2OUvvfTSxTxCS7777ruw68xlvNUCtW7dGlYkJvrPnHn4H//I/h6HWA8e9EdSImm3tnkUvcFwvgdOpc9yb953hBUz7Mpk3gUTSy1Wj/Dc/uWX/uvQpGVcFurB5fittRGL9957D/fddx/69u3rEoirV6/uKkg4T1FCQgLefPNNWPXhhx+aH4ZiguVHH/nd8VWrAq+9lvszHD63dFHG2wew0o/3TWIbZq8jpzL47LPPXE/kkCFD3HuWfPLJJ26dGzZs6HqjWORx6NAhlyvJnkkWBHD6Bis6dQJYsMlRE7ZrjppwtJxzzbHcmx0SDHoiiQKbCNC5c2eXMLxx40Z3MGBi5dChQ/HCCy9crIyyhkENTwJZMccwa56htXMge22+/vprDBs2zE3kxUn7ePO8p556yi2zmiTOQH3btm3u3jqs/LOKM7QScw0ulTvKURlLgQ2HWDm8ygCdlZ3stWBuDXssBg4ceDHnxBLOmM0hp/Xr12PDhg3u3lEsDuD8VEwbYMWfpZ7X/Pk5wSjw9tsM6vyEeA5PcdLwUKVUjinYrrsb5tdnAp7Vuz+zIoqPILG8PS+HPXMWb5FxOQxo/NvN2RbENt2kSRP3CBIWcwStoCMmxq+IulGqlSMqx0ZERETkz1BgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETEjyvM8L08fjIpCvnz5UK5cOQTF8ePHERsbi6AI2voeOXIEFy5cULsOgCC1bbXr4AhSuw617czMTFzRwEZERETkeslLyBL9e/5B9djYFsToXz02wRCktq12HRxBatehtp0Xvyuw4TDUwYMHERTt2rXDkiVLEBRBW9/4+HgcOnRI7ToAgtS21a6DI0jtOtS280LJwyIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYEXGBzaFDhzBu3Di0atUKFSpUQMGCBVG2bFl07NgRX331FYJizJgxiIqKco+NGzfCmgsXgAkTgDp1gCJFgBIlgMaNgSVLYFbFihUvbtOcj6ZNm8Ka1NRUPPfcc2jcuDFuu+02FCpUyO3LiYmJmDp1KjIyMmCN5wELFgDNmgHlyvltu1o1oF8/4McfYdrChQvRsmVLxMbGum1dqVIldO3aFQcOHIAlM2f627NuXSAmBoiKAqZNg2nTpvnrebnH/fcjYkQjwowfP96d1KtUqeKCm9KlS2P37t1YtGiRe8yaNQudO3eGZdu2bcPw4cNRtGhRnDlzBhYP/o89BsyfD1SpAvTuDaSlAYsXA+3bsw0ATz8Nk0qWLIlnn302bNBjzenTpzFx4kTUr18fDz/8sNuXT5w4gWXLlqFXr16YM2eOe50vX8RdX/1hgwcDycl+UNOhgx+wf/st8MEHwOzZwPr1wN13wxTP89C/f39MmjTJHbe7dOmC4sWL4/Dhw/jiiy+wb98+lC9fHlYMHQrs2weUKuVvZ762rnZtYPjw8O/Nmwds3w488AAih5dH/GhcXJx3tc2fP99bs2ZNruUpKSlegQIFvJtvvtlLTU31roW2bdt611p6erpXp04dr0GDBl5SUpL73Tds2GBqfefOZXvyvMREzzt79tflx455XkKC58XEeN6ePVf/e7A9X6t2TQkJCe5xvV2r7ZyZmemlpaXlWp6RkeE1bdrU/fZLly41s85Hjnhevnx+Gz55Mvt7ycl+m+/Z0167HjdunPt7AwcO9M6fPx92e1tq1ytWeN7evf7rUaP87Tp1qnddXI9zVFbcvWNjPS862vOOHvWuury26Yi7VHr00UfRpEmTXMsbNWqEZs2auSu+rVu3wqrXX38d27dvx5QpU5A/f35YxJ4ZeuUVoHDhX5fzCmjQIL/3ZurU6/b15AphTwyHknOKjo7GI4884l5///33Zn7vvXv9IdbERPbMZX+vTRv/+dgxmHLu3DmMGDEClStXxjvvvBP2mMXtbUmLFkBCwvX+FpFh0SLg+HG/fd96KyLGDdXiChQoYHJHCfnmm29cYDNy5EjceeedsOroUf+5UqXc74WWrV4NjBgBc9LS0jBt2jTXTV+iRAnUq1cPDRo0QJBcuHABn3/+uXt9t6FxmTvuABjHrVsHnDrlD0OFLF3qP0dSHsKVsHz5cnex2bNnT2RmZmLJkiXYtWsXbrrpJrRo0QK333779f6KchVNnuw/9+mDiHLDRAj79+/HypUrUa5cOdSsWRMWT3iPP/44ateujRdffBGWsWeG9uwBatTI/h6X0a5dMOno0aPuJJAVg5vZs2e7/ASL0tPT8cYbb7hcjOPHj2PVqlXYuXOn+x3uN3Smj40FRo8Gnn8eqF7dzxcL5dgwUB840F7u2ObNm90ze2pq1arlgpqsPXaDBg3C2LFjr+M3lKuFuUWrVgHx8cCDDyKi3BCBDasnunfv7k7+TCy2OEQzbNgwlyTNA4XF9cvqoYeAOXP8k0Dz5kChQv5ydmmOG+e/PnkS5vBEziFV9lIUK1bMnQSSk5MxY8YMd4LnECuTLi0GNhyuCGEV2ODBgzFq1ChYw6HUuDj/Cvb9939d3rAh0K0be5thyk8//eSe2Y7r1KmDTZs2oUaNGtiyZQuefPJJvPXWWy5gHzBgwPX+qnKFMV2AQ689ejCwRUSJuBybcN3WPXr0QEpKCvr27esCHGs2bNjgrmqGDh1qqmv+UniAZzns2rUAO9+eeQbo3x+4665fu+8NFcpcxEq35s2bo0yZMihSpIjrnZs+fbpr06wc+YClMwYxiGNvDYcqWPr77rvvYvLkya7E/RTHbAwZORJISvLzx1jl/PPPfjtPTQVY0W9tOgMen4m5VKxaZe8jtzcD+Llz57peGwY3YsuFC35gwzLvXr0QcfJF+k7DslCWeCclJeH9rJdARpw/fx5PPPGE68Z9+eWXEQS8al22DHj1VT+AmTTJn/uDXfcsHaQyZRAY/TgpBpibsQ6W8SQXHx/vrt5ZGsz1ZU6ZFStX+iWxHG7irswu+mLF/N6aTz9ljqA/TGVt+gKqW7eum6soK16kMan4hx9+wEmLXbABtnIl00P8HvdwuZLXW3QkBzXsuucVLSd5YsKlpfkuss71wSEoCldBQvfee+/FCbA6cHIMAzixFU8COedGWLPGf+bkV0FR6pekI4tzFl0K56iiNaENbgCDdWJvZE5ly/p5N1u2cJ/3Ax4LqnH2QcAlC4cTWs7qqUt9Rm48kyM0aTiiA5usQQ0n42MOgtW8k5iYGPTmDHVhcPiNQU+7du3c5GYWJ3HL6eOP/ecuXRAYoRm1g7B9Q1gVlrXS0YL09MuXdHM5r80MrbKbgoN27NgRNjeS5fycaJTHL7Hh+HF/yo5bbgF+mbUh4kRH6vATg5pOnTph5syZZoMaKly4sMs3CIe5RQxshgwZgnvuuQeW5CyHJQ5DTZnCKiHOZwRTWAXEW4Qwtybn8pdeesm97sbkI0O+++47F6zlXOezZ8+6Wy1Q69atYQXnr+FtQjjzcMeO2eey4Sj6wYP+Z9hbaUVohniWffM41ifLJfzo0aPdEBTTCKxO0RFEM2b4QTxzySK1LUdca+McLh999JFLQKtatSpee+21XJ/hcAwTL+XGxalbOMs6y71ZFbVpkz8MVbkyMHdu5GXZ/1m8fQArR3jfpISEBHcVy6qozz77zF3ZMnjle5Z88sknbp0bNmzoAhzO28N7wfE2Ciz7ZoIpy4Gt6NQJmDiRPa1A1apAu3YciuH8VH65NyejZNBjzXvvvYf77rvPFXcwgbh69equKmr16tWurb/55puwhNehX37pvw7NFctloVFV5lRF6hDNlfDhh/5zJK9jxAU2ezl95y+5J5dKLORBUoHNjY23+2LCMO/vyXshMgGN92B54YXcPTlWuuzZXc8D/tq1a12vBXNr2GMxcODAizknlrRp08YNOa1fv95V/nGfZrIpE+V5PyH2zFq6kmcwvnw58PbbDOqAWbP8K1vOyBqqlMo5b5OVXpuvv/7aTVnBiRfZe8ObnT711FNuGasALWFQ89FH2Zcx7z9r7n8kn/T/DF6AbtsG1K/vV7RGqog7qjBJmA+x/VuwIoqPoOBtQsLdKsQyVsrwESTsmmdFVEAKHC/iTS55x/Yg4CHZ6GH5NzGgcXeOjHD2yoxEREQksBTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmRHme5+Xpg1FRKFSoEFq2bImg2LRpE+rXr4+gCNr6rlixAqmpqWrXARCktq12HRxBatehtn3u3Dlc0cAmLi4OBw8eRFC0a9cOS5YsQVAEbX3j4+Nx6NAhtesACFLbVrsOjiC161DbzksMoqEoERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyIuMBm2rRpiIqKuuzj/vvvhyUzZwL9+gF16wIxMUBUFH8HmFaxYsVLbt+mTZvCmkOHDmHcuHFo1aoVKlSogIIFC6Js2bLo2LEjvvrqK1h04QIwYQJQpw5QpAhQogTQuDGwZAnMW7gQaNkSiI0FChUCKlUCunYFDhyAKampqXjuuefQuHFj3HbbbShUqJBr14mJiZg6dSoyMjJgkecBCxYAzZoB5cr57btaNf84/uOPCIQxY8ZcPGZv3LgRkSQaEaZ27doYPnx42PfmzZuH7du344EHHoAlQ4cC+/YBpUr5OwlfB0HJkiXx7LPPhg16rBk/frw7EFSpUsUFN6VLl8bu3buxaNEi95g1axY6d+4MSwf+xx4D5s8HqlQBevcG0tKAxYuB9u35ewBPPw1zuN79+wOTJvnr3aULULw4cPgw8MUX/r5dvjzMOH36NCZOnIj69evj4Ycfdu36xIkTWLZsGXr16oU5c+a41/nyRdw19J8yeDCQnOwfrzt08IP2b78FPvgAmD0bWL8euPtumLVt2zZ3ni5atCjOnDmDiOPlET8aFxfnXS9paWlebGysFx0d7R09evSa/M22bdtek7+zYoXn7d3rvx41ir+1502d6l1z12p9KSEhwT2uJ7bna9Wu58+f761ZsybX8pSUFK9AgQLezTff7KWmpnpWtvPcuX47Tkz0vLNnf11+7Bi3vefFxHjenj2eubY9bpy/3gMHet7587nfz8iw1a4zMzPdsTmnjIwMr2nTpu57LF261LO0jY8c8bx8+fx2fPJk9veSk/3t37OnvWN2SHp6ulenTh2vQYMGXlJSktvGGzZs8K6FvLbpGyaM5lXt8ePH0aZNG9x6662wpEULICHhen8LuZoeffRRNGnSJNfyRo0aoVmzZu4qd+vWrWY2Antm6JVXgMKFf13OXslBg/zem6lTYcq5c8CIEUDlysA77wD58+f+THTE9ZH/OeyJ4bBqTtHR0XjkkUfc6++//x6W7N3rD7MmJrLXOft7bdr4z8eOwazXX3/djZxMmTIF+cM18ghww+xmkydPds99+vS53l9FrpC0tDSXU3X48GGUKFEC9erVQ4MGDQL3+xYoUODiycCKo0f9Z+aW5BRatnq1HwhYsXw5cOIE0LMnkJnp5xLt2gXcdJN/8XL77QiMCxcu4PPPP3ev7zY2JnPHHQBjuXXrgFOn/GGokKVL/WdjaaAXffPNNy6wGTlyJO68805EqhviSLpv3z6sWrUK8fHxePDBB6/315Er5OjRo+jJs0AWDG5mz57tclGCYP/+/Vi5ciXKlSuHmjVrwgr2zNCePUCNGtnf4zLiSd+SzZv9Z17E1qqVff2YYsKeqrFjYVJ6ejreeOMNpja4nnUer3fu3On2b2vFHkwIHz0aeP55oHp1P2cslGPDYH3gQJv5Y2lpaXj88cddHuyLL76ISHZDBDbMrucVQI8ePSK260t+Hx7wOAzDq7lixYph165dSE5OxowZM9yBkMMyxZl1aRgrRrp37+4OGEwsttS2H3oImDPHPwE0b+5XBtHx48C4cf7rkydhyk8/+c9MKmUl2KZNflC3ZQvw5JPAW2/5CcUDBsBkYDMiS/cbK2UGDx6MUaNGwSIGqXFxHEEA3n//1+UNGwLdutkbcqRhw4a5gofNmzdH/LEq4nNsGNAwsOGOwix7sYEZ9c2bN0eZMmVQpEgRdxUwffp0d6JnD90HLC8wLBSop6SkoG/fvm69LeHBnaWwa9cC7Ih65hm/Wuiuu37tujdWKOPyLojDFIsWsfcRKFaMeVTA3Ln++jK4sYgXJ+ytyczMxIEDB/Duu++69AFO3XCK4zXGjBwJJCX5OWQs4f/5Z7+tp6YCnK3C2pQGGzZswNixYzF06NAbYmgx4g8t7KZndz1PgpXCDdiLKf04EQQ4fr0OloMaBuks8U5KSsL7WS/5jOAV67JlwKuv+id0lj9z3g9228+b53+mTBmYEkok5XxUt92W/T2eC5hU/MMP9nqqciYTM2VgwIABmDRpktuPmZNhycqVvDDzh5tefhmIj/cDWPbWfPopc+b8YSorzp8/jyeeeAK1atXCy1zhG0DEd5gpaThYSv2SnBGRcyNcoaCGw3DsneratatLnrY2x0cIJ5vkCSDntFRr1vwaAFjCCdqIycLhhJazeupSn7GE8zXRmtAGN4IBO7FHMqeyZf28Gw4/nj7tBzwW5iravXu3ex2uAo7uvfde97xw4UJ04MQ+11lEBzZMQlu8eDFuueWWi6WDYltoFl6Lk/RlDWo4GR/ziSJ9rPpq+Phj/5mT11kSOtHt2JH7PU7Ay6rnokWB0qURCKx2zFr1Z0V6+uVLurmc1ypWVjsmJga9OcNmGBxKZ9DTrl07NzljpBy3Izqw4YGfSWnsruePKzawWoK3FWBuTc7lL730knvdjUkaBoefGNR06tQJM2fONB/U5CyFJQ5DTZni5588+ihMYWIwOylY9s3ZKbLOTMEkag5BMS/DUmLpd999505mOffls2fPulstUOvWra/Tt7s6OH8NbxXCJPGOHbPPZcNR5YMH/c9YOWUVLlz44shJTswTZGAzZMgQ3HPPPYgUEb2Lffjhh4GYu4Zt5ssv/dehOdq4LNSDy7FbSz8Bp1lnBRTvL5OQkOCm5WZV1GeffeYqhbiT8D1LOO/DRx995JIsq1atitdeey3XZ9iFyyRqKzglEW8fwMogVkWxSohtmrkmTKa1GNe99x5w331A375+AnFoWIJlwJyE8803Yconn3zi9uWGDRu6AIfzUfG+aLyNAnvcWfk4iCVEhnTqBEycyN4KoGpVoF07f2jxm2/87cwJKRn0yPUTsYHNpk2b3P0oeA8SS/N7hMOg5qOPsi9j7mzW/FlLgQ1n2t2xYwe2bNmCtWvXuqs75tbwym7gwIEXx+Yt2cvpSn8Zr75UMiVPDJYCG976ignDvD8eh2KY+8/7or3wQu6eHEu9Nl9/zdJYgPPTsfeGeRdPPeUvs5YwzZngOeS0fv16VznD9s17wDHRtEuXLq6X0tLEk8SAnNv17bcZ2AGzZvnDU5wQP1QplXPuJrm2IrbFMaDxb1FlH+/kbf1u3lnx1gLhbi9gGZOE+QgSVkTxETTspbJ2u4hLqVu3rnsEDYeZWCB0gxQJBe64ZrMcQ0RERAJJgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYkaU53lenj4YFYVChQqhZcuWCIpNmzahfv36CIqgre+KFSuQmpqqdh0AQWrbatfBEaR2HWrb586dwxUNbOLi4nDw4EEERbt27bBkyRIERdDWNz4+HocOHVK7DoAgtW216+AIUrsOte28xCAaihIREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYkZEBzYLFwItWwKxsUChQkClSkDXrsCBAzDF8zwsWLAAzZo1Q7ly5VCkSBFUq1YN/fr1w48//ghrUlOB554DGjcGbrvN37ZlywKJicDUqUBGBsyZNg2Iirr84/77Yd6YMWMQFRXlHhs3boQ1M2fOdPtt3bp1ERMT49ZzGje+YRcuXMCECRNQp04dd+wqUaIEGjdujCVLlsCqihUrXmzHOR9NmzaFJYcOAePGAa1aARUqAAUL+sfrjh2Br75CRIpGBPI8oH9/YNIkoEoVoEsXoHhx4PBh4IsvgH37gPLlYcbgwYORnJzsgpoOHTq4A8O3336LDz74ALNnz8b69etx9913w4rTp4GJE4H69YGHHwZKlwZOnACWLQN69QLmzPFf54vosPv3qV0bGD48/Hvz5gHbtwMPPADTtm3bhuHDh6No0aI4c+YMLBo6dCj27duHUqVKuf2Zry3jRdljjz2G+fPno0qVKujduzfS0tKwePFitG/fHuPHj8fTTz8Ni0qWLIlnn302bNBjyfjxvCDxz8UMbni83r0bWLTIf8yaBXTujMji5RE/GhcX510L48bx73newIGed/587vczMq7J1/Datm171f/GkSNHvHz58nkJCQneyZMns72XnJzsfveePXt6VtaXMjM9Ly0t/HZt2tTf9kuXXv3vwfZ8Ldt1OPwdYmM9Lzra844e9Uxt56zS09O9OnXqeA0aNPCSkpLc775hw4Zr9vev1TqvWLHC27t3r3s9atQot55Tp071rqVr2a7nzp3r/lZiYqJ39uzZi8uPHTvmjmkxMTHenj17PGvtmuvGx/V2LdZ5/nzPW7Mm9/KUFM8rUMDzbr7Z81JTvWsir2064q6Jz50DRowAKlcG3nkHyJ8/92eiI7Kf6Y/Zu3ev68pNTEx0VwBZtWnTxj0fO3YMlrAnht2Z4bbrI4/4r7//HoHAK57jx7mtgVtvhVmvv/46tm/fjilTpiB/uJ3aiBYtWiAhIQFBwZ4ZeuWVV1C4cOGLy9ljNWjQINd7M5Xjy3LDevRRoEmT3MsbNQKaNfN727duRUSJuBBh+XL/h+rZE8jMBDhMu2sXcNNNPGgAt98OU+644w4ULFgQ69atw6lTp9wwVMjSpUvd8/1BSL5wY/XA55/7rw2NvF3W5Mn+c58+MOubb75xgc3IkSNx5513Xu+vI1fQ0aNH3XMlJkDmEFq2evVqjODVqjEM2pg/dfjwYXfcrlevHho0aIAgKVAgMjsbIuzrAJs3+8+8qKtVyw9qsl7pDxoEjB0LM2JjYzF69Gg8//zzqF69uhuXDuXY8IAwcOBAs2PU6enAG2/4OVXstVi1Cti50w9qgxDLMf2C6xwfDzz4IEziwf/xxx9H7dq18eKLL17vryNXGHtmaM+ePahRo0a297iMdmU9iBsL6nryYJUFgxvmRTLfyLr9+4GVK4Fy5YCaNRFRIi6w+ekn/zk5GahTB9i0CeD+smUL8OSTwFtv+UlMAwbADHbZxsXFoU+fPnj//fcvLm/YsCG6deuG6EgLh69gYJP1Qo6VQYMHA6NGIRDYQ89eqh49wg+5WjBs2DDs3r0bmzdvNj0EFVQPPfQQ5syZ4y7OmjdvjkIscQQvVI5jHEtpAJw8eRLWMKBp1KiRK+ooVqyYC95YADJjxgzXw75161YUZ8WLURkZQPfuvHDxE4sjbdeOuBwbHuiJORjMP6hXDyhWzB/PmzvX77VhcGMJu+iTkpLcOPWBAwfw888/Y+3atUhNTXWlg1bLJrld2VvDIUeW8L/7rj80w2rJU6dgGts5AxsGc6wEs2jDhg0YO3asqxSyVNUnv+KFF6ep4PGqZs2aeOaZZ9C/f3/cddddF4fV81kqb/wFq/sYyJUpU8aVuLNHcvr06ejevburhGNFq1UXfrkYS0kB+vb1A5xIE3EtLpQ/W7euP8dJVjw2Mqn4hx94FQATVq5c6XYSDje9/PLLiI+Pd1cA7K359NNPUaBAATdMZRmPexyOYS8cS/zXrWOyKUxjFy67cps39+dnsub8+fN44oknUKtWLdeuxSb2Ji9btgyvvvqqC2AmTZrk5uTikPo8zmMAuJN/UHAOI2LOpNWgplcvv8Q7KQnIMsAQUSJujKNaNf+ZycLhhJazeupSn7mR8KBAvOrJqWzZsi7vZsuWLTh9+rQLeKzjPAm0Zg1Ms540zPbKIShicnw49957r3teuHChm79JbkyciJAXZ3xkteaXnZiTFQYt58jiPE0XLvj5j9On+xPlct7JSO2Mi7jAJnR+37Ej/Lgey4CLFvUnCbIgnYkmlynp5nJeCbHnJgg4CSNZXl0mSrNK9pZbfi1vt3iy42Rt4aSkpLigp127dihdurS5Cc3E9/HHH7vnLpxhNSC++mUqXmtt+kKWoIaT8c2YEXl5NREd2IRmN2TZN69qs17Rjh7tD0GxC8xKPi3nr+F05Ew869ixY7a5bJhIfPDgQfcZniis+O477vhAkSLZl589699qgVq3hlk8KDCeZTs2tFmz4Zwmk0PdUjn06NHDBTZDhgzBPffcc82/m1xZOaepIA5Dcc4iVgk9yolQDNm5cycqVKjgcmtyLn/ppZcu5h5ZG36aPh3o1Im3DYnsoIYiMjx47z3gvvv8xCQmEFev7ldFrV4NcO6rN9+EGZ06dcLEiRPdVWzVqlXdVexNN93k5v5guTdPEAx6LPnkE7/qrWFDP8DhMZH3I+GoHHszmCjOsn6rPvzQ9jBUkDGY+/LLL91rVsaEloWGZZg7x+pHSzh3S/ny5V25N6uiNm3a5Na3cuXKmDt3rrlqOFaB8ZjM+2FxMkbeIoRVUZ999hkyMjJcwM73rBg5EvjoI7/Yo2pV4LXXcn+GI8m8bUykiMjAhr02X3/NUlF/wjb23vCmW0895S+zlIvGnX758uV4++238cknn2DWrFlueOrWW2+9WCmVc36IGx1n2eWQ0/r1rJzx7x3FjirOW8Rea14dWOmRy4nTF2zb5t8nK9LmfpA/j0HNRzwLZMFE0qzJpNYCm86dO7uEYd7UlCd2TszHSrgXXnghV0+OBcyH3LFjh8t9ZDXY2bNnXW5N69at3bxjrUKJgkbs3es/8zh9qaIOXqBGUmATxfsq5OmDUVFurhUOjQQFe0+sllqHE7T1ZQXaoUOH1K4DIEhtW+06OILUrkNtOy8xSITmNIuIiIj8fgpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImZEeZ7n5emDUVHIly8fypUrh6A4fvw4YmNjERRBW98jR47gwoULatcBEKS2rXYdHEFq16G2nZmZid8SjTzKY/wjIiIict1oKEpERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREYMX/B5242aIbIuCPAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAJOCAYAAACkx02ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAcY1JREFUeJzt3QeYFOW6J/D/wMCQUQcQnIEhKEGFZbkEdcgCKpKUi4RnUKIEda8oBlwWhFWBK464oLiIgIDASkaueEiLgwQ5IusFhAMqORy5XDhImMBQ+/y/snFCg6MSmrf+v+fp032qW6ar66uqt77vfb+K8jzPg4iIiIgB+a73FxARERG5UhTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2MgNrWnTpoiKirqqf2PatGnub/BZJFJVrFjRPUSCToGNXFVnzpzBG2+8gTp16qBYsWKIiYlBfHw8GjVqhCFDhuCHH3647ltg7969LnDp0aMHbgSvvvqq+75r1qy53l9FriLe7WbBggV49NFH3T7Dfad48eL4L//lv2DQoEH47rvv9PuLhBEdbqHIlfDzzz+jYcOG+Pd//3fcfvvtSEpKQmxsLP7jP/4DmzZtwujRo1GlShX3iGSPPPII7rnnHpQrV+56fxUJiP/8z/9Ep06dsHr1atx0001o2bIlKleujPT0dGzfvh3vvfce/tf/+l9YtWqV67UUkV8psJGrZty4cS6o6dOnDyZNmpRryGjPnj1IS0uL+C1QsmRJ9xC5Fs6fP++C6ZSUFHcx8O6776JEiRLZPnPkyBH89//+3/GPf/xDG0UkJ97dW+RqeOihh3jneG/Lli2/67/bunWr16lTJ6906dJewYIFvYoVK3r/8i//4v3Hf/xHrs82adLE/Y2shg8f7pb93//7f3N9furUqe49Pmf9/+Eeof8+53+T1Zdffum1bt3au/nmm72YmBivWrVq3rBhw7wzZ87k+iz/DX7fo0ePeo8//rgXGxvrFSpUyGvQoEHY7xpOaH1zPhISEi5+hq/5OHHihPfUU0958fHxXv78+bN9/yVLlnhNmzb1SpQo4b5DrVq1vLfeesvLyMjI9vf4vfjv8zfNac+ePe69J5544uKyKlWqeMWKFQu7/tS2bVv33/ztb3/LtnzRokVe8+bNvZtuusn9jnfddZf35ptveufPnw/77/zez1/uu2/bts1tw5IlS3pFixb1WrZs6X399de5/hsu4+/JvxX63e6++25v1KhRXnp6eq7P52U7hDNlyhT33Ro3buxlZmZe9rOpqam5/t7PP//s/bf/9t+8cuXKuf2nZs2a3ty5c8P+98eOHXP7Fvcxfpb7HPc97oPhpKWlecnJyV7dunXddubvVaNGDW/QoEHef/7nf/7h/VjkSlKPjVw1HHaiXbt2oXbt2nn6b7788ks88MADrsv9n//5n10y5IYNG/DOO+9g6dKl2LhxI0qVKnXFviO/17/8y7+4f5+5Cx06dLj43m8lYs6dOxddu3Z1uQ+dO3dGmTJlsHz5cowcORJ/+ctfXA5MoUKFsv03J0+edMNz7AHq3r07fvrpJ/yf//N/3Dpv3rwZd99992X/ZigP6IsvvsATTzxx8TtyuCIr9oQ1b94cp0+fRrt27RAdHY1bb73VvZecnIznn38et9xyC7p164aiRYtiyZIlbtnatWtdXscfTchmD8OIESOwaNEi929nxSHIzz//HA0aNEDVqlUvLmeuFYcl4+LiXD4Jfxt+jxdeeAFfffWV+52z+r2fv5wff/wRiYmJLgdswIAB2Ldvn/vvGzdu7IaB+F1DPvjgA3z66afuvdatW+Ps2bNuG/P7/PWvf8X8+fNz/fuX2w6X8uGHH7rnoUOHIl++y6dBsu1llZGRgVatWuHEiRPo2LGj+45z5szBY4895n57vhdy7Ngx3HvvvS7PjcNZXbp0cb2o8+bNw7/927+5Nsy2GnLu3Dk3JLZu3Trccccd6Nmzp/v7u3fvxv/+3/8bjz/+OG6++ebrsh+LZHNFwySRLBYvXuyuPIsXL+49//zz3l/+8pfLXq3x6pRX/PxvPv/882zvvfDCC255r169rmiPzaV6Hn7rv/nHP/7hrvDZW/Dtt99mW4fOnTu7z48cOTLbvxPqXRk4cGC2K/HJkye75f369ctT+7nc+hGv2vn+Aw884J09ezbbe99//70XHR3tlSlTxtu/f3+2K/+GDRu6/2769Ol/uMdm9+7dbhl763IaP368e2/ChAkXly1fvvzidz19+vTF5RcuXPD69+/v3ps3b94f/vylhL47Hy+//HK299j2uJw9HVnt27cvV48Q/y7bJD/P3ru8bodLYY9ZgQIF3DY6d+5cnv6bnH+vffv2rmclZOXKlRe/R1Y9e/Z0y4cMGZJt+b/927+55bfffnu2dsp9mMu7d++e63c4efKk6yn6o/uxyJWkwEauKg5vsMs667AJD3rsmt+1a1e2z6akpFzypMiD5i233OK6/7MetK9XYMOTP5cNGDAg1+d5AuSJqXLlytmW8/Psug+dALKezPj5OnXqeFcysMkacIUw2OJ7Y8aMyfXeunXr3Hsc4vmjgQ3de++9bn3+/ve/Z1tev359d9Lm8EdIu3bt3L/B3ywnniyjoqK8jh07/uHPX0rou3MoK+f2oPvvv9+9H25IKqfNmze7z7766qt53g6XwmFK/jdly5bN83+T8+/9+OOPYd/j/hPCfYj7EodDww0bcjiO/xb3yVAb5QUKg/mcQ045/ZH9WORK0lCUXFXPPfcc+vbt67rB169fj6+//toNFzAhkl3uHIZhFz1t2bLFPYer8mCpeN26dd1Qz9/+9jfUrFnzum65y33XChUquAoWDsGxMowluiEcguG6ZBUanuAw1ZXCIbBwv9HlvjeHJfjf/b//9//+1N/mEBuHHWbPnu2G+YjDFayEa9u2bbYhCA5JcChsypQpYf+twoULY+fOnX/487/lv/7X/5prexCnI2DFEX+vf/qnf3LLOKwyYcIEN7TDv8HhJT9e9R0+fDjP2+Fq4ZBkpUqVci1nuTi3SQi/f2pqKpo1a4YiRYrk+jyXr1ixwrUF/hb8PNtyixYtLg43XcqNtB+LTQps5KrjiZ2lq3wQKzleeeUVV7Lau3dvHDp0CAULFsSpU6fc+5fKQQiVW4c+dz3l5bsysOHnsgY2OatbsgY3mZmZV+z7Md8nXJ7M5b43P8/l3B5/BvONnn32WcycOfNiYDNjxoyLQU/OsmZWATEv53JzIf3Rz/+WS22/0PKsVUfMFWGODYPTUE5VgQIFXEDK3JFwFX6X2g6Xy0vjv3n8+HH37+XMofktl6reY/u6cOHCxf//e/e10O/AvKbfciPtx2KTJuiTa44HX175JiQkuITSrVu3Zjvp//3vfw/73x09ejTb5y4llHDJE2BOV6o89kp916vlUifTy31v9j5wedbv/Ed+SyYlM7mWvXO8KicGOdzu7LHJ+X14Mv9lWDzsgwmtf/Tzv+VS2y+0PBQoMDmYQQ0TYjkxHhOJX3/9dTdZIpNuL+X3JmEzAKlfv75LAma599Xye9tvKDk9L0FvpO8bYp8CG7kueMDnkELOYQEKN6Mur8J5ouRQQ7Vq1S77b4e6ysMdhEPd5Fnlz5/fPf+eHpPLfdcDBw64ShMOR2XtrblS/sj3zcv35hAhhyeyVrD93t8yJNQzw4CGVTQMNtjjkbNKjFVH7J3gUFVe/N7P/xauA4eUcmKVVdbfKzRD9sMPP3zx98/52SuFvZjEGbuzDnWF80fngapevbrbFgzYWDmVU6h9hNoC9zkGIvw8K64u50rtxyJ/2BXN2BHJ4v333/c2bdoU9jdZuHChS/Rk8mZoLo6s1RQrVqzI9nlWruS1KmrDhg0Xk2CzVnWsX7/eJbXmTARmQiO/C/+t31sVxSRIzoOStUqma9eul6yKutTfCM1BkhesKrrUvDq/9W+FqqJuvfVW79ChQxeXM5GT86bkrIriciaNMuHz+PHj2ZJcQ9sqXNI1tynn9qlUqZL35JNPus+tWbMm1+eWLVvm3mNFVriKuSNHjnjffffdH/78n6mK4hw1WdsOlz322GPZPsttz/UM9zv8nm2aFRN1GzVqdPHfPHXqVK7P8Pfv06ePm88nL38v3H4SqooaOnRotuWh3zhnVVSooun3VEXldT8WuZIU2MhVw7LT0AGSB2iWlXLisNBBO1++fN6sWbOy/Tdr1671ihQp4qpnunXr5v4bTiQXqqb66aeffvOATYmJiW45K3EGDx7sJgrjJGGPPPJI2KCAn2Nwk5SU5I0YMcL7n//zf3p79+697AR9n3zyiZtwjZVOPFC/9NJL3j/90z9d/Ls5y3WvVGCzfft29105ARvXjd+VpdR5/bdYqcbvwooYVnXx3+DEgqFSYQZnWb3yyisXJwHk9uMJsVSpUq766HLVZCxf5/vclvxvc/67If/jf/yPixVKXbp0cb8jT9rc7vx9OQHen/n85QIbtkUGqM2aNXNtjUEpA7/ChQt7GzduvPh5nsi5TUP/DU/yLOvn5/75n//5igY2xCCSgTn/XQZO/FsMCp577jnvwQcfdAE11zVrsPh7AxvuS6zcC10EZF1/7oPcF7Niew7tu3fccYdrC/wd2A64D2SdiPP37sciV5ICG7lqdu7c6f3rv/6rKx3llTsPxnzwwMaTwKVKaf/93//dnSx48gydFDljadYy4d8KbHg1z9l92dPAk88999zj5tG5VJDCmXA5+yxPlgwa8jrzMEtbWdbK/46BU9WqVd2JN+scK1c6sKFp06a5eVY4j86lZh7+rTmG+F3YG8N/g/9WuJmHQ1fgLGUuX778xXV85513XFnx5QIbzusS6hXJOVdKTryy56zEnKWW25zlziwbZ9CWdb6dP/r5vMw8zNmEeYJu0aJF2LbJkzED2Ntuu821Y/5m77777iV/hz8T2BADQc7J06FDB/c3+dszWGBPEoOKnD1TvzewIe5T/Lf43/F35D7Hfe9SMw+zJ27s2LFe7dq13X7FqRzuvPNON8cNZ1j+o/uxyJUUxf/54wNZIiI3Ht7RnWXRnL152rRp1/vriMgVpORhERERMUOBjYiIiJihwEZERETMUI6NiIiImKEeGxERETFDgY2IiIiYocBGREREgnd37997MzcRERGRKykvU+/lObAJ3ek3dMv5IODN9ngn4aAI2voeOXIEFy5cULsOgCC1bbXr4AhSuw617bz4XYENg5qDBw8iKNq1a4clS5YgKIK2vvHx8e6u1WrX9gWpbatdB0eQ2nWobeeFcmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMSPiApsLFy5gwoQJqFOnDooUKYISJUqgcePGWLJkCaxbuBBo2RKIjQUKFQIqVQK6dgUOHIAphw4dwrhx49CqVStUqFABBQsWRNmyZdGxY0d89dVXsGrmTKBfP6BuXSAmBoiKAqZNg2meByxYADRrBpQrBxQpAlSr5v8OP/4IcypWrIioqKiwj6ZNmyIoxowZc3G9N27cCEu4z3Lfvdzj/vthSmpqKp577jl3Lr7ttttQqFAhd8xOTEzE1KlTkZGRgUgSjQjieR4ee+wxzJ8/H1WqVEHv3r2RlpaGxYsXo3379hg/fjyefvppWDz49+8PTJoEVKkCdOkCFC8OHD4MfPEFsG8fUL48zOB25IGP25jBTenSpbF7924sWrTIPWbNmoXOnTvDmqFD/W1ZqpR/kudr6wYPBpKT/fXt0AEoUQL49lvggw+A2bOB9euBu++GKSVLlsSzzz4bNugJgm3btmH48OEoWrQozpw5A2tq1waGDw//3rx5wPbtwAMPwJTTp09j4sSJqF+/Ph5++GF3zD5x4gSWLVuGXr16Yc6cOe51vnwR0lfi5RE/GhcX511Nc+fOdX8nMTHRO3v27MXlx44d8xISEryYmBhvz5493rXStm3ba/J3xo3j7+t5Awd63vnzud/PyLC1vvPnz/fWrFmTa3lKSopXoEAB7+abb/ZSU1Ov+vdge74W7TpkxQrP27vXfz1qlL/Np071rrlrtZ2PHPG8fPk8LyHB806ezP5ecrK//j172lpnHqf4uJ6udbvOKj093atTp47XoEEDLykpyX2PDRs2XJO/fa228aWkpXlebKznRUd73tGjnql1zszM9NK4gjlkZGR4TZs2ddt56dKlV/175LVNR0h45WPPDL3yyisoXLjwxeWlSpXCoEGDXO8Nu70sOXcOGDECqFwZeOcdIH/+3J+Jjqh+tT/v0UcfRZMmTXItb9SoEZo1a+auBLZu3QprWrQAEhIQGHv3cmgZSExkL0b299q08Z+PHbsuX02uktdffx3bt2/HlClTkD/cwcywRYuA48f9tn3rrTAlX758LmUgp+joaDzyyCPu9ffff49IEVGnzKNHj7rnSkwuySG0bPXq1RjBSMCI5cuBEyeAnj2BzEyAqUS7dgE33eSfCG+/HYFSoECBizuM3NjuuAPgsXDdOuDUKX8YKmTpUv/ZWi4C8QJs2rRpOHz4sMsRrFevHho0aADrvvnmGxfYjBw5EnfeeSeCZvJk/7lPHwTGhQsX8Pnnn7vXd0fQmHJEnT3YM0N79uxBjRo1sr3HZbSLZ31DNm/2n3lxU6uWH9SEcLhy0CBg7FgEwv79+7Fy5UqUK1cONWvWvN5fR/4kJsGPHg08/zxQvTrQvv2vOTarVwMDBwIGU+bcBVpPXqlkweBm9uzZLq/MIgZzjz/+OGrXro0XX3wRQcN8uVWrgPh44MEHYVZ6ejreeOMNlw97/PhxrFq1Cjt37nTt/f4IukqJqMDmoYcecklIo0ePRvPmzV3mNfEHZBUNnTx5Epb89JP/zATLOnWATZsAxnRbtgBPPgm89ZafUDxgAExjVn337t3dAZKJxUHrxraKgXlcnH8V+/77vy5v2BDo1s3eMCsP8BxS5dVrsWLF3IVYcnIyZsyY4Q78HGItzsoAY4YNG+YKADZv3hzIfZcZEhx27dEjfDqBpcBmRJYRE1a9DR48GKNGjUIkiagcm27durkci7Vr17or9meeeQb9+/fHXXfd5bp0KWKyrq8Q7gzELnuO0darBxQrxnwTYO5cv9eGwY317swePXogJSUFffv2dQGO2DByJJCUxLw5f9qCn38G1q5l+SjA6mdrsziwGogXZWXKlHHTVbAHY/r06a5N79u3Dx+wHMyYDRs2YOzYsRg6dGhEDUdcy2M4AxuWeffqBdOKFSvmemsyMzNx4MABvPvuu5g8ebKbyuAUx5sjRERFCcyrYMnYq6++6gKYSZMmYcGCBa7Uex7r6AB3wLAklFTJuU1uuy37ezxGMKn4hx/YUwWzQQ3LBVninZSUhPezXtbLDW3lSr8slsNNL7/sd9MzaGdvzaefMp/KH6YKgn6cuAfMN1oHS86fP48nnngCtWrVwsvcyAFt5/v3A82b+3OPBUG+fPkQHx+PAQMGuPM02zXzqyJFxHUEx8TEuKsePrJas2aNe67LCMAQTlZGTBYOJ7Sc1VOX+syNHNSw655XtF27dnUJl9Z65IJs2TL/mZPz5VS2rJ93wyHX06f9gMeyUP6gtXldOL8Jh6AoXNUM3Xvvve554cKF6MDJjIwJYtJwVpyLLOs5OhJEXGBzKR9//LF77sLZ6wwJHfR37Mj9HidzZAVd0aJA6dIwG9RwMj7mIARxbN6y9PTLl3RzOePYXwrhTAvNqG1tkj5eiHIi1XA4tMygp127dm5CN2vrTizv5iwlt9wC/FL1HDiHOZNslorWSBBxgQ3H6UL5NCEchuK8CKws4BwoljAxmAEvy74Z+WeN+llRwiEo5ihYSrIMDT8xqOnUqRNmzpypoMYgzl8zYYKfGN+xY/a5bDjiePCg/xneXsICVofwFiHMrcm5/KWXXrqYR2gJ5xtjjkU4zJtjYDNkyBDcc889sGjGDD+A5zHaSjsO57vvvnOBac62ffbsWXerBWrdujUiRcSdLjnfQ/ny5V25N6uiNm3a5Lq4KleujLlz55o8Ab73HnDffUDfvn4CcaiLniWxnNDtzTdhCue5+Oijj1wiWtWqVfHaa6/l+gy7rJl4aQmP/19+6b8OzT/IZaEeXOaeWOrO7tQJmDiRV+5A1apAu3b+cOo33/htm3NwMuixghWdrIDi/XQSEhLcLQVYFfXZZ5+5qj+e4Pme2PHhh/6zpf02nE8++cS17YYNG7oAh50PvOcfc2JZtcxKQE6iGykiLrDhsAQThnnjNB4MODEfs+1feOGFXD05lnptvv6aJZMA5zpi7w1zEJ56yl9mLF8aezkl7S/j85dKOOPOYy2wYVDz0UfZlzGXNGs+qaUDJK9B2JbffpsHRmDWLP/qlrOyhiqlckxXdUNjReeOHTuwZcsWV9nJq1nm1vBKduDAgRdzEcQGTs2xbRtQvz5gfdqtNm3auCGn9evXuyo4Hrt5TzQmjTM9hD3wkTSpahTvq5CnD0ZFIS4uDgfZfxwQHBsOwl3Fg7q+zOrnVYfatX1Battq18ERpHYdatt5iUFUgiIiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyI8jzPy9MHo6JQqFAhtGzZEkGxadMm1K9fH0ERtPVdsWIFUlNT1a4DIEhtW+06OILUrkNt+9y5c7iigU1cXBwOHjyIoGjXrh2WLFmCoAja+sbHx+PQoUNq1wEQpLatdh0cQWrXobadlxhEQ1EiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyIuMBm5syZ6NevH+rWrYuYmBhERUVh2rRpsIyrFxV1+cf998O8MWN+Xd+NG2HOhQvAhAlAnTpAkSJAiRJA48bAkiUwb+HChWjZsiViY2NRqFAhVKpUCV27dsWBAwdgRWpqKp577jk0btwYt912m1vPsmXLIjExEVOnTkVGRgYs8jxgwQKgWTOgXDm/bVerBvTrB/z4I8w5dOgQxo0bh1atWqFChQooWLCg284dO3bEV199BasqVqzozsfhHk2bNkUkiUaEGTp0KPbt24dSpUqhXLly7rV1tWsDw4eHf2/ePGD7duCBB2Datm3+b1C0KHDmDEwe/B97DJg/H6hSBejdG0hLAxYvBtq3B8aPB55+GuZ4nof+/ftj0qRJqFKlCrp06YLixYvj8OHD+OKLL9z+Xb58eVhw+vRpTJw4EfXr18fDDz+M0qVL48SJE1i2bBl69eqFOXPmuNf58kXc9eSfMngwkJzsBzUdOvgB+7ffAh98AMyeDaxfD9x9N8wYP348xowZ49ozgxtu5927d2PRokXuMWvWLHTu3BkWlSxZEs8++2zYoCeieHnEj8bFxXlX24oVK7y9e/e616NGjXJ/d+rUqd710LZtW+96SkvzvNhYz4uO9ryjR+2ub3q659Wp43kNGnheUhLbmudt2HD1/y7b87Vq13Pn+uuVmOh5Z8/+uvzYMc9LSPC8mBjP27PHuyau5XYeN26c+40HDhzonT9/Ptf7GRkZZtY5MzPTS+NOG2YdmzZt6n6HpUuXmmrXR454Xr58fhs+eTL7e8nJfpvv2dMz1a7nz5/vrVmzJtfylJQUr0CBAt7NN9/spaammtuXExIS3ON6ymubjrhLhxYtWiAhIeF6f42IsGgRcPw40KYNcOutMOv11/1eqSlTgPz5YRJ7ZuiVV4DChX9dXqoUMGiQ33szdSpMOXfuHEaMGIHKlSvjnXfeQf4wGzc6OuI6jf8w9sRwWCLcOj7yyCPu9ffffw9L9u71h1gTE3k1n/09Hrfo2DGY8uijj6JJkya5ljdq1AjNmjVzvXRbt269Lt9NfHaOKgZNnuw/9+kDs775xg9sRo4E7rwTZh096j9XqpT7vdCy1auBESNgxvLly91BvmfPnsjMzMSSJUuwa9cu3HTTTe4C5vbbb0cQXLhwAZ9//rl7fbelMRkAd9wBMJZbtw44dcofhgpZutR/DkJ+YEiBAgXMBexZpaWluZxXDiWXKFEC9erVQ4MGDRBpbP76BjC1aNUqID4eePBBmMReiscf93OMXnwRprFnhvbsAWrUyP4el9GuXTBl8+bN7pk9NbVq1XJBTdbejUGDBmHs2LGwJj09HW+88YbLLzp+/DhWrVqFnTt3ugDvfmNn+dhYYPRo4PnngerV/XyxUI4NA/WBA23mjoWzf/9+rFy50uWG1qxZExYdPXrUteOsGNzMnj3b5RxFCgU2EYrDEuzi7dHD7vDMsGHA7t08Adpdx5CHHgLmzPFPAs2bA4UK+cs51DhunP/65EmY8tNPP7nn5ORk1KlTB5s2bUKNGjWwZcsWPPnkk3jrrbfcwXDAgAGwFthwCC6EVSODBw/GqFGjYBGHUuPi/J7l99//dXnDhkC3buy9gHmseOvevbvr0WBicbhh1xtdz5493XAbex2LFSvmLlS4b8+YMcMF7Bx+Y2FAJIi4HBvxAxoGNix77tXL5i+yYQPAi/WhQ21VTFwKD/Ash127FuDF3DPPAP37A3fd9Wv3vbFiGTcEQ8w7YbUIr+x4QOTBce7cua7XhsGNNVxH9tZw+I3l7O+++y4mT57sSmJPcbzGGA4jJyX5+WOs3v/5Z7+dp6YCrAK2Pp0B23mPHj2QkpKCvn37ugDHouHDh6N58+YoU6YMihQpgtq1a2P69OlufVnd+AHL4CKEsUOpDStXslvTv7IPl5Nxozt/HnjiCaBWLeDllxEIvGpdtgx49VU/gJk0yZ/7g133LOmnMmVgrjSUOCcV53XJild9TCr+4YcfcNJaV9UvGLjFx8e7HimWu69btw6vM6HM2LGK0zRwuIn7MofOixXze2s+/ZQ5J/4wleWghqX8LPFOSkrC+1m7rAKiHycsAvOs1iFSBKCT8MZjPWn49Gl/CIrCFJE4997rPy9c6M+NYUFMjH8SyDln0Zo1/nPdujClGmdpA1yycDih5ayeutRnrOB8J7QmtLGNYLBO7I3MqWxZP+9myxZ/n2fAYy2o4fAMey042SSTaq3NUZQXnHOOzkTQBGQKbCIMcy5YGnzLLcAvFaLm8ATPCerCSUnxg5527YDSpTnxE8z7+GP/uUsXmMLSV9qxY0fYnASWPhctWtRNcGYdq0iyVs1YkZ5++ZJuLue53thqZwtqOBkf80ws5tXkRWi25UiapC944WWEmzHDP1hwzJoBgEWcx4W9UuEe993nf2bIEP//s2LKinDpFRyG4vw99epxfgyYEpqZlQEMc0yyGj16tBuC4vwuVkpjv/vuO5w9ezbXci7jrRaodevWsITz1xBnHv7HP7K/x1GZgwf93ldLx7LQ8BODmk6dOrnbAFkPanbu3Bm2bXP5Sy+95F53YyJhhIi4IwoPgF9++aV7HZrkiMtCXbgNGzZEH6tjNAA+/NB/NryKgcXpHnj3AJZ7sypq0yZ/GKpyZWDuXJuVYe+99x7uu+8+l1TJBOLq1au7qqjVq1e7iTjffPNNWPHJJ5+4KhEeo3j1ynk+eF8h3kaBZd9MmmaJuyWdOgETJ/o9rVWr+j2tHFXk/FQs9+ZFDIMeS0aOHImPPvrIJYlXrVoVr732Wq7PdOjQwSXXWjFnzhzXtnkfNO637GllVdRnn33mel+HDBni3osUERfYMKhho8mKSUlZE5OsBjY80fGeSfXr+5UzYgtvH8OEYd7gk/dDZGI4q8JeeCH7xGbWem2+/vprDBs2zE1Sx0n7eMPAp556yi1jhYUVbdq0cUNO69evx4YNG9y9o5hAzTl8eI8sXuVb6Z0KYTC+fDnw9tsM7IBZs/weZ86UHqqUyjlv041uL6db/uXeYJdKBmdgaymwadasmRtS5kXJ2rVrXe8Nc2vYAzlw4MCLOWSRIuL2MiZgWb+b96UwoHF35Qowbnqrm58VUXwEDW9yybtbW8fqLz6ChsNMrIgKSoVjEM9RTZo0CXsbiUilHBsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGlOd5Xp4+GBWFQoUKoWXLlgiKTZs2oX79+giKoK3vihUrkJqaqnYdAEFq22rXwRGkdh1q2+fOncMVDWzi4uJw8OBBBEW7du2wZMkSBEXQ1jc+Ph6HDh1Suw6AILVttevgCFK7DrXtvMQgGooSERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGRAY2FStWRFRUVNhH06ZNYUlqKvDcc0DjxsBttwGFCgFlywKJicDUqUBGBkzyPA8LFixAs2bNUK5cORQpUgTVqlVDv3798OOPPyIIxowZc7Fdb9y4EdYcOgSMGwe0agVUqAAULOi37Y4dga++gknTpk275LEr9Lj//vthycyZQL9+QN26QEwMEBXF3wGBsHDhQrRs2RKxsbEoVKgQKlWqhK5du+LAgQOw5MIFYMIEoE4doEgRoEQJ/5y1ZAkiUjQiVMmSJfHss8+GDXosOX0amDgRqF8fePhhoHRp4MQJYNkyoFcvYM4c/3W+iAxB/7jBgwcjOTnZBTUdOnRAiRIl8O233+KDDz7A7NmzsX79etx9992watu2bRg+fDiKFi2KM2fOwKLx4xm8AVWq+MEN2/bu3cCiRf5j1iygc2eYUrt2bbddw5k3bx62b9+OBx54AJYMHQrs2weUKgWUK+e/to4XZv3798ekSZNQpUoVdOnSBcWLF8fhw4fxxRdfYN++fShfvjws8DzgsceA+fP9fbl3byAtDVi8GGjf3t/Pn34akcXLI340Li7OuxYSEhLc43pr27btVf8bmZmel5aWe3lGhuc1bcrf3fOWLvXMrC8dOXLEy5cvn9vGJ0+ezPZecnKya2s9e/a86t+D7flatuuQ9PR0r06dOl6DBg28pKQk9x02bNhwzf7+tdrO8+d73po1uZenpHhegQKed/PNnpeaamudLyUtLc2LjY31oqOjvaNHj5pq1ytWeN7evf7rUaP8Y9bUqd41dy238bhx49xvPHDgQO/8+fO53s/gAdzIOs+d62/TxETPO3v21+XHjvFc7XkxMZ63Z493TeS1TRvrB7jxsCeGXfQ5RUcDjzziv/7+e5iyd+9eXLhwAYmJia5nLqs2bdq452PHjsGq119/3V25T5kyBfnz54dVjz4KNGmSe3mjRkCzZn7P5NatCIRFixbh+PHjrn3feuutsKRFCyAhAYFx7tw5jBgxApUrV8Y777wTdh+O5gHciMWL/edXXgEKF/51OXvoBg3ye2+YNhFJIvbXT0tLc+PV7NrjMEW9evXQoEEDBAXHND//3H9tbUTmjjvuQMGCBbFu3TqcOnXKbd+QpUuXumdreQgh33zzjQtsRo4ciTvvvBNBVaCA/2zo+H9ZkydPds99+vS53l9F/qTly5fjxIkT6NmzJzIzM7FkyRLs2rULN910E1q0aIHbb7/d1G989Kj/XKlS7vdCy1avBkaMQMSI2MPK0aNHXcPJisEN8y84pmlNejrwxhv+eObx48CqVcDOnQB/AmvneCbajR49Gs8//zyqV6+O9u3bX8yxWb16NQYOHIinI27Q9soE648//rjLw3jxxRcRVPv3AytX+vkYNWvCPOZbrFq1CvHx8XjwwQev99eRP2nz5s3umT01tWrVckFNSL58+TBo0CCMHTvWzO9cqpT/vGcPUKNG9ve4jLL8BBEhIgMbBjSNGjVyyaPFihVzDYeJpjNmzHBX8lu3bnWJWtYCm6wRLysLBg8GRo2CSdz54+Li3BXs+++/f3F5w4YN0a1bN1NduSHDhg3D7t273YHR8hDU5bDKr3t3v/uaicVB+BmmTp3qhl579OgR2O1uyU8//eSeeU6qU6cONm3ahBo1amDLli148skn8dZbb7mL7wEDBsCChx7yi1hGjwaaN/crd4kX4Kx6pJMnEVEiMseGVQXNmzdHmTJlXBkwr3CnT5+O7t27u6sfVs5YU6yY31uTmQmwUvDdd9l9DbC6/dQpmMOhmKSkJLzyyiuuNPLnn3/G2rVrkZqa6kr62b1ryYYNG9xV3NChQ01Xe/3W8GqPHkBKCtC3rx/gWMeAhoENy7x7scxRTGxT4nA6c6c4ksALcF6Mz5071/XaMLixols3Pydu7Vq/h/WZZ4D+/YG77vLLvinSqnYj7OtcHuc4IeZmWMUGEh8PMNifNInrymRTmLJy5UoXvHK46eWXX3Zd9DwwsLfm008/RYECBdwwlRXnz5/HE0884bqtub5BxHMBz+ss8U5KArJ00pnGtr5//353ocY5TuTGFyp4qFu3Lm7j5GNZ8KKFScU//PADTkZaN8YfxM5zTjny6qv++YnnpQUL/FLvefP8z5Qpg4hyQ/X3l/plsM/qvB85ce4PWrMGpizjXgJeBTTL9V7ZsmVd3g27dU+fPu0Cnhsd14NDUKGrvHDuvffeixN+cV4fa0ENc8WmTwe6dvUnb4u0K7yrRUnD9nAiUWKycDih5ayeutRnbjQxMRxJ8R9Zhc5NnJwxktxQgc1Xv0xXam2Svks5fDh7BYkV6UwoukxJN5ezO5c9NxbExMSgN2e1CiMlJcUFPe3atUPp0qXNte2sQQ0n45sxIxh5NcTy7sWLF+OWW27BI6G5G+SGF7og27FjR673MjIy8P3337uJN7k/W/fxx/5zly7X+5tEeGCzc+dOVKhQweXW5Fz+0ksvuddMLrXiu+8YqPnTVGd19qx/qwVq3RqmcP6aCRMmuOS7jh07ZpvLhonEBw8edJ9hQGBB4cKFL16558SEUgY2Q4YMwT333AOLw08Majp18qfeD0pQQyx2YBDPXDIrbVk4+24VtGrVypV9c7/OWsLPak8OQXGbWyqAOHXq13yaEA5DTZnCamV/zqpIEnG//Jw5c9wJr3HjxkhISHCRL6uiPvvsMxcN8wTA96z45BNm17MayA9w2Hh4jx2O1jDrnJOZcRIkSzp16oSJEye63oqqVau63gp22XKOF5Z7MxBgG5Ab28iRwEcf+YnxVasCr72W+zMcdatdGyZ9+OGHgZi7hjH7l1/6r0MTLnJZaJiCxzZrP8F7772H++67D3379nUJxKHhcx6/eN568803YUmDBgDvEMFyb1ZFbdrkb9/KlYG5cyPvgiU6Erv52MXHRsIqmbNnz7rcmtatW7v5TRgpW8KJdjnktH49K2f8e0exA6NWLb97j1e8hgJ/hyWvvNp5++238cknn2DWrFnuypYzsoYqpVg+KTe2vXv9Z7bpSyXAM5i3GNiwBJj3A6tfvz5qGp+sh0ENA9isWPSQtcbDWmDDXpuvv/7aTeHw+eefu+MZ8wOfeuopt4wVvZZ07uwnDPNevZyygXnwvEfYCy/k7smJBBF3ymzSpIl7BAWTriIt8epaYNc8K4SCWiUUwtm1+bCIq2V01X4TAxr/Fnv2BXU78yaXLOUPgldf9R83ioDUJoiIiEgQKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImBHleZ6Xpw9GRSFfvnwoV64cguL48eOIjY1FUARtfY8cOYILFy6oXQdAkNq22nVwBKldh9p2ZmYmrmhgIyIiInK95CVkif49/6B6bGwLYvSvHptgCFLbVrsOjiC161DbzovfFdhwGOrgwYMIinbt2mHJkiUIiqCtb3x8PA4dOqR2HQBBattq18ERpHYdatt5oeRhERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImBGRgY3nAQsWAM2aAeXKAUWKANWqAf36AT/+CFMOHTqEcePGoVWrVqhQoQIKFiyIsmXLomPHjvjqq69g3cKFC9GyZUvExsaiUKFCqFSpErp27YoDBw7AktTUVDz33HNo3LgxbrvtNreu3M6JiYmYOnUqMjIyYFHFikBUVPhH06Yw58KFC5gwYQLq1KmDIkWKoESJEm6bL1myBBZNm3bp7Rt63H8/zBsz5tf13bgR5sycORP9+vVD3bp1ERMTg6ioKEzjxo9Q0YhAgwcDycl+UNOhA1CiBPDtt8AHHwCzZwPr1wN33w0Txo8fjzFjxqBKlSouuCldujR2796NRYsWucesWbPQuXNnWON5Hvr3749Jkya5de/SpQuKFy+Ow4cP44svvsC+fftQvnx5WHH69GlMnDgR9evXx8MPP+y284kTJ7Bs2TL06tULc+bMca/z5YvIa40/pWRJ4Nlnwwc91tr0Y489hvnz57s23bt3b6SlpWHx4sVo376929effvppWFK7NjB8ePj35s0Dtm8HHngApm3b5v8GRYsCZ87ApKFDh7pjcqlSpVCuXDn3OqJ5ecSPxsXFeVfbkSOely+f5yUkeN7Jk9nfS07m9/C8nj29a6Jt27ZX/W/Mnz/fW7NmTa7lKSkpXoECBbybb77ZS01N9aysb8i4ceNcmxo4cKB3/vz5XO9nZGRc9e/A9nyt2nVmZqaXlpYWdj2bNm3qvsfSpUs9a9uZ+zEf19u1WOe5c+e67ZiYmOidPXv24vJjx455CQkJXkxMjLdnzx5T7fpS2NRjYz0vOtrzjh71zLXrkPR0z6tTx/MaNPC8pCT//LRhw7X7+9dqnVesWOHt3bvXvR41apRrX1OnTvWutby26Yi7PNy7l925QGKif6WXVZs2/vOxYzDj0UcfRZMmTXItb9SoEZo1a+au6rdu3QpLzp07hxEjRqBy5cp45513kD9//lyfiY6OyM7EP4w9MRxmDLeejzzyiHv9/fffX4dvJlcKe2bolVdeQeHChS8u51XuoEGDXO8Nhx2DYNEi4Phx/5h9660w6/XX/V6pKVOAMIcxM1q0aIGEhATcKCLu7HHHHQCP/+vWAadO+cNQIUuX+s9BGLOlAgUKmDzJL1++3AVsPXv2RGZmpss/2LVrF2666Sa3A91+++0ICuZkfP755+713VbGV3NIS/NzMQ4f9vfnevWABg1gztGjR90z88RyCi1bvXq1C+qtmzzZf+7TB2Z9840f2IwcCdx55/X+NpJVxJ0xY2OB0aOB558HqlcH2rf/Ncdm9Wpg4EDA2DB1WPv378fKlSvdeGbNmjVhyebNm90ze2pq1arlgpqsPRu8uh07diwsSk9PxxtvvOHyMY4fP45Vq1Zh586dLsi732jEzvN9z57ZlzG4Yb5clSowgz0ztGfPHtSoUSPbe1xGWdu6VUy/WLUKiI8HHnwQZoP1xx/3c4xefPF6fxuJ+MCGBg0C4uL8aP/9939d3rAh0K0bezBgGitkunfv7rqumVgcbqjmRvbTTz+55+TkZFc9smnTJnci2LJlC5588km89dZbLvlywIABsBjYZL1iZ3XB4MGDMWrUKFjEgKZRIz/Zv1gxntj9woAZM/yeV46yFi8OEx566CGXBD569Gg0b97cVb4RA1hWPtLJkydhHUfbmE7Qo4fd4Zlhw4Ddu3mRZncdb2QRl2ND7NpLSuJYNcCq359/BtauZcmsXyJqtHLy4tBEjx49kJKSgr59+7oAx+I6EnNOWPlVr149FCtWzOUVzZ071/XaMLixiOvJ3hoOwbGk/d1338XkyZPRtGlTnOLYqzGsFmneHChTxp+2gVe406cDbNa8smeloxXdunVzeXFr1651vazPPPOMq/y76667XNk3Wax6y4q7NgMblj336gWTNmwA2KE8dKid6lxrIm4vW7nSPxhyuOnll/3uTF7psbfm00+Zd+IPU1nEEz5Lf1ninZSUhPezdlcZUvKXrHDOicA5XbJingmTin/44QfTV7c8wcXHx7teKZa8r1u3Dq9zwD4gOCcVMZfOCubCsWT/1VdfdduX23XBggWu1Hsea5/BAK8MLOPxe/9+P5gNk2p0wzt/HnjiCaBWLf/8JJEp4gZ1li3znzk5X05ly/p5N1u2cF4QP+CxFNQwz2L69OlugjpOfmT16q4aZ1sEXLJwOKHlrJ661Gcs4fxFtGbNGgTFL+ko5ub94ORlw4cPd4+sQtuWwbxl1pOGed7hEBSFKXJ07r3Xf1640J+HTa69iAts0tMvX9LN5Tzf/1IwZC6o4WR8M2bMMJdXkxW762nHjh1h84tY9ly0aFE3iV0QcFLCrFVwQRCaVNvaJH2X8vHHH7tnTkRpFcu7WfF+yy3ALzMYmBMTA/TuHf69lBQ/6GnXDuChKyhtOxJFXGDD+WsmTPATDDt2zD6XDUdmDh70P8MGZmn4iUFNp06d3NTVloMaCs2yzLJv5pf0yXJ5x8RLDkFxKM5Smft3332HihUrumn2szp79qy71QK1bt0aluzcCVSo4OfW5Fz+0kv+axYDWMI8qVA+TQiHoaZMmeJyyThvlVVMCOeFKfMjrRyfc+L0RKFeqZyYLM3AZsgQ4J57rvU3k6wi7szRqRMwcaIf/Vat6ke/HI3gnAEs92bDYtBjxciRI/HRRx+5pNKqVavitddey/WZDh06oDazLg157733cN9997kEaSYQV69e3VVFcZ4PTgT15ptvwpJPPvnEVYE1bNjQBTg8+fE+YczJYNUME6dZ5m7JnDn+vtq4McC5vTjlPKuiPvuMPXP+CYDvWdKgQQN3KxBW+bEqihV/HIZi3hgT4y1ftHz4oe1hqCCbPHkyvvzyS/c6NGEsl4WGWHlcy3qBer1FXGDD/X75cuDtt3kyAGbN8q8COHtlqFIqxxQRN7S9nGr5l3sJXSp5lCdCa4ENe22+/vprDBs2zE1Qx94b3hTyqaeecsusJVm2adPGDTmtX78eGzZscNubSdScx4fDE+y1s9RDRRxx5Ggjc+JY1Xj2rJ9bw44pzkf1S2qRKRxKZsLwxo0b3bAqJ+bjfXZeeOGFXD05lmza5N8zqX59wNi0WwK4oIYX4Fmx4IGPkEgKbKJ4X4U8fTAqCnFxcTjIsaCAaNeundm78oYTtPVlVRJ7TdSu7QtS21a7Do4gtetQ285LDGKz7EZEREQCSYGNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGlOd5Xp4+GBWFQoUKoWXLlgiKTZs2oX79+giKoK3vihUrkJqaqnYdAEFq22rXwRGkdh1q2+fOncMVDWzi4uJw8OBBBEW7du2wZMkSBEXQ1jc+Ph6HDh1Suw6AILVttevgCFK7DrXtvMQgGooSERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImJGxAU2qanAc88BjRsDt90GFCoElC0LJCYCU6cCGRkwp2LFioiKigr7aNq0KayZNm3aJdc39Lj//vthjecBCxYAzZoB5coBRYoA1aoB/foBP/4Ic2bOnIl+/fqhbt26iImJcduV2z5oxowBoqL8x8aNMOXQoUMYN24cWrVqhQoVKqBgwYIoW7YsOnbsiK+++gpWXbhwARMmTECdOnVQpEgRlChRAo0bN8aSJUtg2cKFQMuWQGysf26uVAno2hU4cAARJRoR5vRpYOJEoH594OGHgdKlgRMngGXLgF69gDlz/Nf5Ii4k+3NKliyJZ599NmzQY03t2rUxfPjwsO/NmzcP27dvxwMPPABrBg8GkpP9oKZDB6BECeDbb4EPPgBmzwbWrwfuvhtmDB06FPv27UOpUqVQrlw59zpotm0D2NSLFgXOnIE548ePx5gxY1ClShUX3JQuXRq7d+/GokWL3GPWrFno3LkzLPE8D4899hjmz5/v1rt3795IS0vD4sWL0b59e/ebPP3007B2Uda/PzBpElClCtClC1C8OHD4MPDFFwB37fLlETm8POJH4+LivKstM9Pz0tJyL8/I8LymTfk9PG/pUu+aaNu27TX5OwkJCe5xvV2r9b2UtLQ0LzY21ouOjvaOHj161f8e2/O1atdHjnhevnzc1p538mT295KT/Xbds6dnajuvWLHC27t3r3s9atQo91tPnTrVC0rbTk/3vDp1PK9BA89LSvK38YYNnql2PX/+fG/NmjW5lqekpHgFChTwbr75Zi81NdWztI3nzp3rft/ExETv7NmzF5cfO3bMHcdjYmK8PXv2mFrnceP89jtwoOedPx/+/Hwt5LVNR1y/B3tiChbMvTw6GnjkEf/1999f868l1wCv8I4fP442bdrg1ltvNfWb793L7mt/SLVkyezvtWnjPx87BlNatGiBhIQEBNXrrwPbtwNTpgD588OkRx99FE2aNMm1vFGjRmjWrBlOnDiBrVu3whL2zNArr7yCwoULX1zOnslBgwa53pupzJsw4tw5YMQIoHJl4J13wrdlnp8jSYR9nUvjSeHzz/3XlrrrQ7gzMP/g8OHDbry2Xr16aNCgAYJk8uTJ7rlPnz6w5o47/IB93Trg1Cl/GCpk6VL/2WBaUWB9840f2IwcCdx5JwKpQIEC7jk60s56f9LRo0fdcyUmmOQQWrZ69WqMYDRgwPLlfjpIz55AZibANKJdu4CbbuLFC3D77Yg4Edvi0tOBN97wx/aOHwdWrQJ27vR/XIsnAO4sPblyWTC4mT17thvHtY75F6tWrUJ8fDwefPBBWMNku9GjgeefB6pXB9q3/zXHZvVqYOBAwNiwfGClpQGPP85cMuDFFxFI+/fvx8qVK11uVc2aNWEJe2Zoz549qFGjRrb3uIx28cxvxObN/jN7amrV8oOarCMsgwYBY8ciokTcUFTWwIYBL6943n0X+Nvf/ORLJi9Zw4CGJ/W///3vOHPmDLZs2YLu3bvjr3/9q6sO+vnnn2Edu25ZadCjRw/kN9pvzwMAk9+ZIP/++8C//ivwl78A7Jjr1i3yunPljxk2DNi926/iNNqULysjI8Mdv9gLzcRia/vzQw895J5Hjx6NVJbx/oLD6KwQo5MnT8KKn37yn1n4wGH0TZsAnpJSUoCqVYG33vILfiJJxAY2xYr5vTXs+mIpGYMbjlSw+pld+ZawQqh58+YoU6aMKx1k1dD06dPdwYE9GR+wbMYwBjQMbFgO3Iulb0YxSE9K4ti836Z5cFi71p/igO3aeKVoIGzY4F+9Dh1qc8j8t4QuTlJSUtC3b193DLOmW7duLn9o7dq1rjfqmWeeQf/+/XHXXXe5NALKZ6hs98IF/5lD6YsWcSTBPz83agTMnev32jC4iSQR/+vzR4uPBwYM8HtrmKPAsesg4BwgtI4rbRi7rNl1zeAu3Li1BStX+mW/HG56+WW/TfPg0LAh8OmnzEfwh6nkxnX+PPDEE353PbdxEIMaXpiwxDspKQnvs1vSIOYMLVu2DK+++qoLYCZNmoQFCxa4Um9OV0G8SLWi5C/FDnXr+nPLZcXgnUnFP/zAXipEjBuq87tVK/95zRoEQmgsl8NTlllOGg7h3EvEyfly4gSUzLvZssUfpmLAIzcebjsOQVG4yk66995fJzrjXEaWghoOqbOnuWvXrq4QwlKvRU6ccJI97Tnn41rzy8mJk1JaUa2a/8xk4XBCy1k9danPXGs3VGDDyYDol2R780Izd1qcpC/ruDTLJ2+55RY8EqrnN4g5Y5cr6eZyngeC0rYtiokBevcO/x7zERj0tGvnTzpqaZfOGtRwMr4ZM2aYy6vJq48//tg9d+EMdkY0++VibMeO3O/xTgCcfoUTULJdR4qIC2y++87f6TndfFZnz/q3WqDWrWHGzp073VTkzK3Jufyll166OKZrFQ+C6enpruuaV0FWcf6aCRP8BLyOHbPPZcMe+4MH/c8Y/gnM45Qmv3Q+5tKjhx/YDBkC3HMPzA0/Majp1KmTu41GEIKaU6dOXcynCeEw1JQpU1w1K+f3saJKFX+0hGXfbN9ZO9ZZ6ckhKOYORlLxQwR9Fd8nn/gHf+YeMMBh2zl0yO/KZ9k3E5ZYXWLFnDlzkJyc7O4zwsnMihYt6koFP/vsM1ddMGTIEPeeVR9++KH5YSjq1MmvHAhVEvDKnd22nO+E5d48KbLdWxti/PLLL93r0CRtXBbqrm/YsKH57W7dyJEj8dFHH6FYsWKoWrUqXnvttVyf6dChgyuIsIRzjJUvX96VexcqVAibNm1y7bpy5cqYO3euueDuvfeA++4D+vb1E4hDQ+c8dnEOzjffRESJuMCGs7ByyIn3zWGFAceteXXLhDz27rFoJpIiwz+L2fU7duxwJd7Msj979qzLrWndujUGDhzo7r9iFQ8G27ZtQ/369c3NdZETj3O84nn7bT94nzXLH57iBMuhSqkcU2Lc8BjU8KSXFRPhsybDK7C5se3llNouv+g0Xr9EVQeH0q0FNhxyY8Lwxo0b3QUoix54b7QXXnghV0+OlV6br7/2pzLgRLk8ljE38Kmn/GWRlisdcSECc64M5V39Jk5HHm5K8iBgQOPfhiwYOMzEapmgVMwwgTSId/MOhz+DxZ8iqNuYFVF8BEn58v7cTDcCu2nrIiIiEjgKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERM6I8z/Py9MGoKBQqVAgtW7ZEUGzatAn169dHUARtfVesWIHU1FS16wAIUttWuw6OILXrUNs+d+4crmhgExcXh4MHDyIo2rVrhyVLliAogra+8fHxOHTokNp1AASpbatdB0eQ2nWobeclBtFQlIiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERM26IwGbMGCAqyn9s3AhzLly4gAkTJqBOnTooUqQISpQogcaNG2PJkiWwauZMoF8/oG5dICbG37bTpiEQFi5ciJYtWyI2NhaFChVCpUqV0LVrVxw4cACWTJs2DVFRUZd93H///bDi0CFg3DigVSugQgWgYEGgbFmgY0fgq69gVsWKFS+5fZs2bQprUlNT8dxzz7lj9G233eb24bJlyyIxMRFTp05FRkYGrPE8YMECoFkzoFw5oEgRoFo1/xj+44+IONGIcNu2AcOHA0WLAmfOwBzP8/DYY49h/vz5qFKlCnr37o20tDQsXrwY7du3x/jx4/H000/DmqFDgX37gFKl/B2Fr63jtu7fvz8mTZrktnWXLl1QvHhxHD58GF988QX27duH8uXLw4ratWtjOHfeMObNm4ft27fjgQcegBXjx/sXYVWq+MFN6dLA7t3AokX+Y9YsoHNnmFSyZEk8++yzYYMea06fPo2JEyeifv36ePjhh1G6dGmcOHECy5YtQ69evTBnzhz3Ol++G6LfIE8GDwaSk/1jdYcOQIkSwLffAh98AMyeDaxfD9x9NyKHl0f8aFxcnHctpad7Xp06nteggeclJfE7eN6GDdfu77dt2/aq/425c+e63zYxMdE7e/bsxeXHjh3zEhISvJiYGG/Pnj2elfUNWbHC8/bu9V+PGuVv26lTvWuK7flatutx48a5vzdw4EDv/Pnzud7PyMgwt53DSUtL82JjY73o6Gjv6NGjZtZ5/nzPW7Mm9/KUFM8rUMDzbr7Z81JT7bVrHqf4uN6uVbvOzMx0bTjc/tu0aVP32y9dutTMOh854nn58nE7e97Jk9nfS072j909e3rXRF7bdESHlK+/DmzfDkyZAuTPD5PYM0OvvPIKChcufHF5qVKlMGjQINd7w+5Na1q0ABISEBjnzp3DiBEjULlyZbzzzjvIH6ZBR0dHfAfqFbFo0SIcP34cbdq0wa233gorHn0UaNIk9/JGjfwu/BMngK1br8c3kyuJPTEFOc4YZv995JFH3Ovvv//ezI++dy/TJYDERPbMZX+vTRv/+dgxRJSIPZJ+840f2IwcCdx5J8w6evSoe2aeRU6hZatXr3YnRblxLV++3HVX9+zZE5mZmS5/ateuXbjpppvQokUL3H777QiKyZMnu+c+ffogKAoU8J+txq68AGNOFYdVmSNYr149NGjQAEHCXMnPP//cvb47osZl/pw77vDzxdatA06d8oehQpYu9Z8jLVUuIneztDTg8cc5Rg+8+CJMY88M7dmzBzVq1Mj2HpcRT4ByY9u8ebN7Zk9NrVq1sm1TXgGyd27s2LGwjnlEq1atQnx8PB588EEEwf79wMqVfn5CzZowe4HGoD0rBjezZ892+WQWpaen44033nC5c+yBZLveuXOn+x0sJcXHxgKjRwPPPw9Urw60b/9rjs3q1cDAgUCkpYFG5FDUsGF+0h1HYKwOQYU89NBD7nn06NEu2z6EO8o4llgAOHny5HX7fnJl/PTTT+45OTnZJVpu2rQJP//8M1JSUlC1alW89dZbLiHROg6r8sq2R48eYYfjrGGBTPfu/sUaE4strjJP5Dyp//3vf8eZM2ewZcsWdO/eHX/961/dCZ7t3Gpgw570kSNH4t1338Xf/vY3DB482BUHWDNoEDBnDhOngfffB/71X4G//AVgp1y3bpHXExlxgc2GDQAvXFk1Y6g375K6deuGZs2aYe3atahZsyaeeeYZVzlz1113uS5dspRdH1Q8mRPH5pljwqvZYsWKoVGjRpg7d67bxgxurP8GDGxYBszqEeu4yXv0AFJSgL59/QDHIla+NW/eHGXKlHHTVbAabvr06S64YQ/dByydMYj7L3trOLTMqRoY3HCYlSXupzhmY8jIkUBSEnNBAc5KwVh17VqWvgOs6I+0mUki6ox5/jzwxBNArVrAyy8jEJhwxtLAV1991Z3cGO0vWLDAlXqzJJZ4wJAbG3tpqG7dum7ui6w4Hs+k4h9++MF079zKlSuxf/9+dxIMl1NmLahh7MYSb54QeJUbNP04yQmYm7EOlvG4zaHVAQMGuOM31/d1JogasXKlP+UKh5t4Xo6PZ1AHNGwIfPqpnz/GYapIElEdSOzm4hAUhUk6d+69139euNCvp7cgJibGXfXknPNjzZo1F0+GcmOrxtmsAJcsHE5oOaunLvWZG11QkoYZ1DDdZPp0oGtXf+LJIHa6hvIHOTwVFK04gVGWY7cFy5b5z6zsy4kTUDLvZssW//zNgCcSRFRgwxloe/cO/x67cxn0tGvnT3xlcN6nXD7++GP3zInc5MbG4UbasWNHrvc4UynLQ4sWLeom+7KIOWOc2uCWW265WBJrPajhZHwzZtjMq8mLr36ZbtniJH2XwqowKhAqgzMgPf3yJd1czsA9klY5oq4jOI0LL+rCPe67z//MkCH+/2fFlBXhxmM5DDVlyhSXi/EoJ8iQGxorQ3g1xwAm1HMRwsRxDkHxhG91LpsZM2a4ZMukpCTXQ2l5+IlBTadO/m1DrAc1rAI6e/Zs2OUvvfTSxTxCS7777ruw68xlvNUCtW7dGlYkJvrPnHn4H//I/h6HWA8e9EdSImm3tnkUvcFwvgdOpc9yb953hBUz7Mpk3gUTSy1Wj/Dc/uWX/uvQpGVcFurB5fittRGL9957D/fddx/69u3rEoirV6/uKkg4T1FCQgLefPNNWPXhhx+aH4ZiguVHH/nd8VWrAq+9lvszHD63dFHG2wew0o/3TWIbZq8jpzL47LPPXE/kkCFD3HuWfPLJJ26dGzZs6HqjWORx6NAhlyvJnkkWBHD6Bis6dQJYsMlRE7ZrjppwtJxzzbHcmx0SDHoiiQKbCNC5c2eXMLxx40Z3MGBi5dChQ/HCCy9crIyyhkENTwJZMccwa56htXMge22+/vprDBs2zE3kxUn7ePO8p556yi2zmiTOQH3btm3u3jqs/LOKM7QScw0ulTvKURlLgQ2HWDm8ygCdlZ3stWBuDXssBg4ceDHnxBLOmM0hp/Xr12PDhg3u3lEsDuD8VEwbYMWfpZ7X/Pk5wSjw9tsM6vyEeA5PcdLwUKVUjinYrrsb5tdnAp7Vuz+zIoqPILG8PS+HPXMWb5FxOQxo/NvN2RbENt2kSRP3CBIWcwStoCMmxq+IulGqlSMqx0ZERETkz1BgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETEjyvM8L08fjIpCvnz5UK5cOQTF8ePHERsbi6AI2voeOXIEFy5cULsOgCC1bbXr4AhSuw617czMTFzRwEZERETkeslLyBL9e/5B9djYFsToXz02wRCktq12HRxBatehtp0Xvyuw4TDUwYMHERTt2rXDkiVLEBRBW9/4+HgcOnRI7ToAgtS21a6DI0jtOtS280LJwyIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYEXGBzaFDhzBu3Di0atUKFSpUQMGCBVG2bFl07NgRX331FYJizJgxiIqKco+NGzfCmgsXgAkTgDp1gCJFgBIlgMaNgSVLYFbFihUvbtOcj6ZNm8Ka1NRUPPfcc2jcuDFuu+02FCpUyO3LiYmJmDp1KjIyMmCN5wELFgDNmgHlyvltu1o1oF8/4McfYdrChQvRsmVLxMbGum1dqVIldO3aFQcOHIAlM2f627NuXSAmBoiKAqZNg2nTpvnrebnH/fcjYkQjwowfP96d1KtUqeKCm9KlS2P37t1YtGiRe8yaNQudO3eGZdu2bcPw4cNRtGhRnDlzBhYP/o89BsyfD1SpAvTuDaSlAYsXA+3bsw0ATz8Nk0qWLIlnn302bNBjzenTpzFx4kTUr18fDz/8sNuXT5w4gWXLlqFXr16YM2eOe50vX8RdX/1hgwcDycl+UNOhgx+wf/st8MEHwOzZwPr1wN13wxTP89C/f39MmjTJHbe7dOmC4sWL4/Dhw/jiiy+wb98+lC9fHlYMHQrs2weUKuVvZ762rnZtYPjw8O/Nmwds3w488AAih5dH/GhcXJx3tc2fP99bs2ZNruUpKSlegQIFvJtvvtlLTU31roW2bdt611p6erpXp04dr0GDBl5SUpL73Tds2GBqfefOZXvyvMREzzt79tflx455XkKC58XEeN6ePVf/e7A9X6t2TQkJCe5xvV2r7ZyZmemlpaXlWp6RkeE1bdrU/fZLly41s85Hjnhevnx+Gz55Mvt7ycl+m+/Z0167HjdunPt7AwcO9M6fPx92e1tq1ytWeN7evf7rUaP87Tp1qnddXI9zVFbcvWNjPS862vOOHvWuury26Yi7VHr00UfRpEmTXMsbNWqEZs2auSu+rVu3wqrXX38d27dvx5QpU5A/f35YxJ4ZeuUVoHDhX5fzCmjQIL/3ZurU6/b15AphTwyHknOKjo7GI4884l5///33Zn7vvXv9IdbERPbMZX+vTRv/+dgxmHLu3DmMGDEClStXxjvvvBP2mMXtbUmLFkBCwvX+FpFh0SLg+HG/fd96KyLGDdXiChQoYHJHCfnmm29cYDNy5EjceeedsOroUf+5UqXc74WWrV4NjBgBc9LS0jBt2jTXTV+iRAnUq1cPDRo0QJBcuHABn3/+uXt9t6FxmTvuABjHrVsHnDrlD0OFLF3qP0dSHsKVsHz5cnex2bNnT2RmZmLJkiXYtWsXbrrpJrRo0QK333779f6KchVNnuw/9+mDiHLDRAj79+/HypUrUa5cOdSsWRMWT3iPP/44ateujRdffBGWsWeG9uwBatTI/h6X0a5dMOno0aPuJJAVg5vZs2e7/ASL0tPT8cYbb7hcjOPHj2PVqlXYuXOn+x3uN3Smj40FRo8Gnn8eqF7dzxcL5dgwUB840F7u2ObNm90ze2pq1arlgpqsPXaDBg3C2LFjr+M3lKuFuUWrVgHx8cCDDyKi3BCBDasnunfv7k7+TCy2OEQzbNgwlyTNA4XF9cvqoYeAOXP8k0Dz5kChQv5ydmmOG+e/PnkS5vBEziFV9lIUK1bMnQSSk5MxY8YMd4LnECuTLi0GNhyuCGEV2ODBgzFq1ChYw6HUuDj/Cvb9939d3rAh0K0be5thyk8//eSe2Y7r1KmDTZs2oUaNGtiyZQuefPJJvPXWWy5gHzBgwPX+qnKFMV2AQ689ejCwRUSJuBybcN3WPXr0QEpKCvr27esCHGs2bNjgrmqGDh1qqmv+UniAZzns2rUAO9+eeQbo3x+4665fu+8NFcpcxEq35s2bo0yZMihSpIjrnZs+fbpr06wc+YClMwYxiGNvDYcqWPr77rvvYvLkya7E/RTHbAwZORJISvLzx1jl/PPPfjtPTQVY0W9tOgMen4m5VKxaZe8jtzcD+Llz57peGwY3YsuFC35gwzLvXr0QcfJF+k7DslCWeCclJeH9rJdARpw/fx5PPPGE68Z9+eWXEQS8al22DHj1VT+AmTTJn/uDXfcsHaQyZRAY/TgpBpibsQ6W8SQXHx/vrt5ZGsz1ZU6ZFStX+iWxHG7irswu+mLF/N6aTz9ljqA/TGVt+gKqW7eum6soK16kMan4hx9+wEmLXbABtnIl00P8HvdwuZLXW3QkBzXsuucVLSd5YsKlpfkuss71wSEoCldBQvfee+/FCbA6cHIMAzixFU8COedGWLPGf+bkV0FR6pekI4tzFl0K56iiNaENbgCDdWJvZE5ly/p5N1u2cJ/3Ax4LqnH2QcAlC4cTWs7qqUt9Rm48kyM0aTiiA5usQQ0n42MOgtW8k5iYGPTmDHVhcPiNQU+7du3c5GYWJ3HL6eOP/ecuXRAYoRm1g7B9Q1gVlrXS0YL09MuXdHM5r80MrbKbgoN27NgRNjeS5fycaJTHL7Hh+HF/yo5bbgF+mbUh4kRH6vATg5pOnTph5syZZoMaKly4sMs3CIe5RQxshgwZgnvuuQeW5CyHJQ5DTZnCKiHOZwRTWAXEW4Qwtybn8pdeesm97sbkI0O+++47F6zlXOezZ8+6Wy1Q69atYQXnr+FtQjjzcMeO2eey4Sj6wYP+Z9hbaUVohniWffM41ifLJfzo0aPdEBTTCKxO0RFEM2b4QTxzySK1LUdca+McLh999JFLQKtatSpee+21XJ/hcAwTL+XGxalbOMs6y71ZFbVpkz8MVbkyMHdu5GXZ/1m8fQArR3jfpISEBHcVy6qozz77zF3ZMnjle5Z88sknbp0bNmzoAhzO28N7wfE2Ciz7ZoIpy4Gt6NQJmDiRPa1A1apAu3YciuH8VH65NyejZNBjzXvvvYf77rvPFXcwgbh69equKmr16tWurb/55puwhNehX37pvw7NFctloVFV5lRF6hDNlfDhh/5zJK9jxAU2ezl95y+5J5dKLORBUoHNjY23+2LCMO/vyXshMgGN92B54YXcPTlWuuzZXc8D/tq1a12vBXNr2GMxcODAizknlrRp08YNOa1fv95V/nGfZrIpE+V5PyH2zFq6kmcwvnw58PbbDOqAWbP8K1vOyBqqlMo5b5OVXpuvv/7aTVnBiRfZe8ObnT711FNuGasALWFQ89FH2Zcx7z9r7n8kn/T/DF6AbtsG1K/vV7RGqog7qjBJmA+x/VuwIoqPoOBtQsLdKsQyVsrwESTsmmdFVEAKHC/iTS55x/Yg4CHZ6GH5NzGgcXeOjHD2yoxEREQksBTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmRHme5+Xpg1FRKFSoEFq2bImg2LRpE+rXr4+gCNr6rlixAqmpqWrXARCktq12HRxBatehtn3u3Dlc0cAmLi4OBw8eRFC0a9cOS5YsQVAEbX3j4+Nx6NAhtesACFLbVrsOjiC161DbzksMoqEoERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMyIuMBm2rRpiIqKuuzj/vvvhyUzZwL9+gF16wIxMUBUFH8HmFaxYsVLbt+mTZvCmkOHDmHcuHFo1aoVKlSogIIFC6Js2bLo2LEjvvrqK1h04QIwYQJQpw5QpAhQogTQuDGwZAnMW7gQaNkSiI0FChUCKlUCunYFDhyAKampqXjuuefQuHFj3HbbbShUqJBr14mJiZg6dSoyMjJgkecBCxYAzZoB5cr57btaNf84/uOPCIQxY8ZcPGZv3LgRkSQaEaZ27doYPnx42PfmzZuH7du344EHHoAlQ4cC+/YBpUr5OwlfB0HJkiXx7LPPhg16rBk/frw7EFSpUsUFN6VLl8bu3buxaNEi95g1axY6d+4MSwf+xx4D5s8HqlQBevcG0tKAxYuB9u35ewBPPw1zuN79+wOTJvnr3aULULw4cPgw8MUX/r5dvjzMOH36NCZOnIj69evj4Ycfdu36xIkTWLZsGXr16oU5c+a41/nyRdw19J8yeDCQnOwfrzt08IP2b78FPvgAmD0bWL8euPtumLVt2zZ3ni5atCjOnDmDiOPlET8aFxfnXS9paWlebGysFx0d7R09evSa/M22bdtek7+zYoXn7d3rvx41ir+1502d6l1z12p9KSEhwT2uJ7bna9Wu58+f761ZsybX8pSUFK9AgQLezTff7KWmpnpWtvPcuX47Tkz0vLNnf11+7Bi3vefFxHjenj2eubY9bpy/3gMHet7587nfz8iw1a4zMzPdsTmnjIwMr2nTpu57LF261LO0jY8c8bx8+fx2fPJk9veSk/3t37OnvWN2SHp6ulenTh2vQYMGXlJSktvGGzZs8K6FvLbpGyaM5lXt8ePH0aZNG9x6662wpEULICHhen8LuZoeffRRNGnSJNfyRo0aoVmzZu4qd+vWrWY2Antm6JVXgMKFf13OXslBg/zem6lTYcq5c8CIEUDlysA77wD58+f+THTE9ZH/OeyJ4bBqTtHR0XjkkUfc6++//x6W7N3rD7MmJrLXOft7bdr4z8eOwazXX3/djZxMmTIF+cM18ghww+xmkydPds99+vS53l9FrpC0tDSXU3X48GGUKFEC9erVQ4MGDQL3+xYoUODiycCKo0f9Z+aW5BRatnq1HwhYsXw5cOIE0LMnkJnp5xLt2gXcdJN/8XL77QiMCxcu4PPPP3ev7zY2JnPHHQBjuXXrgFOn/GGokKVL/WdjaaAXffPNNy6wGTlyJO68805EqhviSLpv3z6sWrUK8fHxePDBB6/315Er5OjRo+jJs0AWDG5mz57tclGCYP/+/Vi5ciXKlSuHmjVrwgr2zNCePUCNGtnf4zLiSd+SzZv9Z17E1qqVff2YYsKeqrFjYVJ6ejreeOMNpja4nnUer3fu3On2b2vFHkwIHz0aeP55oHp1P2cslGPDYH3gQJv5Y2lpaXj88cddHuyLL76ISHZDBDbMrucVQI8ePSK260t+Hx7wOAzDq7lixYph165dSE5OxowZM9yBkMMyxZl1aRgrRrp37+4OGEwsttS2H3oImDPHPwE0b+5XBtHx48C4cf7rkydhyk8/+c9MKmUl2KZNflC3ZQvw5JPAW2/5CcUDBsBkYDMiS/cbK2UGDx6MUaNGwSIGqXFxHEEA3n//1+UNGwLdutkbcqRhw4a5gofNmzdH/LEq4nNsGNAwsOGOwix7sYEZ9c2bN0eZMmVQpEgRdxUwffp0d6JnD90HLC8wLBSop6SkoG/fvm69LeHBnaWwa9cC7Ih65hm/Wuiuu37tujdWKOPyLojDFIsWsfcRKFaMeVTA3Ln++jK4sYgXJ+ytyczMxIEDB/Duu++69AFO3XCK4zXGjBwJJCX5OWQs4f/5Z7+tp6YCnK3C2pQGGzZswNixYzF06NAbYmgx4g8t7KZndz1PgpXCDdiLKf04EQQ4fr0OloMaBuks8U5KSsL7WS/5jOAV67JlwKuv+id0lj9z3g9228+b53+mTBmYEkok5XxUt92W/T2eC5hU/MMP9nqqciYTM2VgwIABmDRpktuPmZNhycqVvDDzh5tefhmIj/cDWPbWfPopc+b8YSorzp8/jyeeeAK1atXCy1zhG0DEd5gpaThYSv2SnBGRcyNcoaCGw3DsneratatLnrY2x0cIJ5vkCSDntFRr1vwaAFjCCdqIycLhhJazeupSn7GE8zXRmtAGN4IBO7FHMqeyZf28Gw4/nj7tBzwW5iravXu3ex2uAo7uvfde97xw4UJ04MQ+11lEBzZMQlu8eDFuueWWi6WDYltoFl6Lk/RlDWo4GR/ziSJ9rPpq+Phj/5mT11kSOtHt2JH7PU7Ay6rnokWB0qURCKx2zFr1Z0V6+uVLurmc1ypWVjsmJga9OcNmGBxKZ9DTrl07NzljpBy3Izqw4YGfSWnsruePKzawWoK3FWBuTc7lL730knvdjUkaBoefGNR06tQJM2fONB/U5CyFJQ5DTZni5588+ihMYWIwOylY9s3ZKbLOTMEkag5BMS/DUmLpd999505mOffls2fPulstUOvWra/Tt7s6OH8NbxXCJPGOHbPPZcNR5YMH/c9YOWUVLlz44shJTswTZGAzZMgQ3HPPPYgUEb2Lffjhh4GYu4Zt5ssv/dehOdq4LNSDy7FbSz8Bp1lnBRTvL5OQkOCm5WZV1GeffeYqhbiT8D1LOO/DRx995JIsq1atitdeey3XZ9iFyyRqKzglEW8fwMogVkWxSohtmrkmTKa1GNe99x5w331A375+AnFoWIJlwJyE8803Yconn3zi9uWGDRu6AIfzUfG+aLyNAnvcWfk4iCVEhnTqBEycyN4KoGpVoF07f2jxm2/87cwJKRn0yPUTsYHNpk2b3P0oeA8SS/N7hMOg5qOPsi9j7mzW/FlLgQ1n2t2xYwe2bNmCtWvXuqs75tbwym7gwIEXx+Yt2cvpSn8Zr75UMiVPDJYCG976ignDvD8eh2KY+8/7or3wQu6eHEu9Nl9/zdJYgPPTsfeGeRdPPeUvs5YwzZngOeS0fv16VznD9s17wDHRtEuXLq6X0tLEk8SAnNv17bcZ2AGzZvnDU5wQP1QplXPuJrm2IrbFMaDxb1FlH+/kbf1u3lnx1gLhbi9gGZOE+QgSVkTxETTspbJ2u4hLqVu3rnsEDYeZWCB0gxQJBe64ZrMcQ0RERAJJgY2IiIiYocBGREREzFBgIyIiImYosBEREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYkaU53lenj4YFYVChQqhZcuWCIpNmzahfv36CIqgre+KFSuQmpqqdh0AQWrbatfBEaR2HWrb586dwxUNbOLi4nDw4EEERbt27bBkyRIERdDWNz4+HocOHVK7DoAgtW216+AIUrsOte28xCAaihIREREzFNiIiIiIGQpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYkZEBzYLFwItWwKxsUChQkClSkDXrsCBAzDF8zwsWLAAzZo1Q7ly5VCkSBFUq1YN/fr1w48//ghrUlOB554DGjcGbrvN37ZlywKJicDUqUBGBsyZNg2Iirr84/77Yd6YMWMQFRXlHhs3boQ1M2fOdPtt3bp1ERMT49ZzGje+YRcuXMCECRNQp04dd+wqUaIEGjdujCVLlsCqihUrXmzHOR9NmzaFJYcOAePGAa1aARUqAAUL+sfrjh2Br75CRIpGBPI8oH9/YNIkoEoVoEsXoHhx4PBh4IsvgH37gPLlYcbgwYORnJzsgpoOHTq4A8O3336LDz74ALNnz8b69etx9913w4rTp4GJE4H69YGHHwZKlwZOnACWLQN69QLmzPFf54vosPv3qV0bGD48/Hvz5gHbtwMPPADTtm3bhuHDh6No0aI4c+YMLBo6dCj27duHUqVKuf2Zry3jRdljjz2G+fPno0qVKujduzfS0tKwePFitG/fHuPHj8fTTz8Ni0qWLIlnn302bNBjyfjxvCDxz8UMbni83r0bWLTIf8yaBXTujMji5RE/GhcX510L48bx73newIGed/587vczMq7J1/Datm171f/GkSNHvHz58nkJCQneyZMns72XnJzsfveePXt6VtaXMjM9Ly0t/HZt2tTf9kuXXv3vwfZ8Ldt1OPwdYmM9Lzra844e9Uxt56zS09O9OnXqeA0aNPCSkpLc775hw4Zr9vev1TqvWLHC27t3r3s9atQot55Tp071rqVr2a7nzp3r/lZiYqJ39uzZi8uPHTvmjmkxMTHenj17PGvtmuvGx/V2LdZ5/nzPW7Mm9/KUFM8rUMDzbr7Z81JTvWsir2064q6Jz50DRowAKlcG3nkHyJ8/92eiI7Kf6Y/Zu3ev68pNTEx0VwBZtWnTxj0fO3YMlrAnht2Z4bbrI4/4r7//HoHAK57jx7mtgVtvhVmvv/46tm/fjilTpiB/uJ3aiBYtWiAhIQFBwZ4ZeuWVV1C4cOGLy9ljNWjQINd7M5Xjy3LDevRRoEmT3MsbNQKaNfN727duRUSJuBBh+XL/h+rZE8jMBDhMu2sXcNNNPGgAt98OU+644w4ULFgQ69atw6lTp9wwVMjSpUvd8/1BSL5wY/XA55/7rw2NvF3W5Mn+c58+MOubb75xgc3IkSNx5513Xu+vI1fQ0aNH3XMlJkDmEFq2evVqjODVqjEM2pg/dfjwYXfcrlevHho0aIAgKVAgMjsbIuzrAJs3+8+8qKtVyw9qsl7pDxoEjB0LM2JjYzF69Gg8//zzqF69uhuXDuXY8IAwcOBAs2PU6enAG2/4OVXstVi1Cti50w9qgxDLMf2C6xwfDzz4IEziwf/xxx9H7dq18eKLL17vryNXGHtmaM+ePahRo0a297iMdmU9iBsL6nryYJUFgxvmRTLfyLr9+4GVK4Fy5YCaNRFRIi6w+ekn/zk5GahTB9i0CeD+smUL8OSTwFtv+UlMAwbADHbZxsXFoU+fPnj//fcvLm/YsCG6deuG6EgLh69gYJP1Qo6VQYMHA6NGIRDYQ89eqh49wg+5WjBs2DDs3r0bmzdvNj0EFVQPPfQQ5syZ4y7OmjdvjkIscQQvVI5jHEtpAJw8eRLWMKBp1KiRK+ooVqyYC95YADJjxgzXw75161YUZ8WLURkZQPfuvHDxE4sjbdeOuBwbHuiJORjMP6hXDyhWzB/PmzvX77VhcGMJu+iTkpLcOPWBAwfw888/Y+3atUhNTXWlg1bLJrld2VvDIUeW8L/7rj80w2rJU6dgGts5AxsGc6wEs2jDhg0YO3asqxSyVNUnv+KFF6ep4PGqZs2aeOaZZ9C/f3/cddddF4fV81kqb/wFq/sYyJUpU8aVuLNHcvr06ejevburhGNFq1UXfrkYS0kB+vb1A5xIE3EtLpQ/W7euP8dJVjw2Mqn4hx94FQATVq5c6XYSDje9/PLLiI+Pd1cA7K359NNPUaBAATdMZRmPexyOYS8cS/zXrWOyKUxjFy67cps39+dnsub8+fN44oknUKtWLdeuxSb2Ji9btgyvvvqqC2AmTZrk5uTikPo8zmMAuJN/UHAOI2LOpNWgplcvv8Q7KQnIMsAQUSJujKNaNf+ZycLhhJazeupSn7mR8KBAvOrJqWzZsi7vZsuWLTh9+rQLeKzjPAm0Zg1Ms540zPbKIShicnw49957r3teuHChm79JbkyciJAXZ3xkteaXnZiTFQYt58jiPE0XLvj5j9On+xPlct7JSO2Mi7jAJnR+37Ej/Lgey4CLFvUnCbIgnYkmlynp5nJeCbHnJgg4CSNZXl0mSrNK9pZbfi1vt3iy42Rt4aSkpLigp127dihdurS5Cc3E9/HHH7vnLpxhNSC++mUqXmtt+kKWoIaT8c2YEXl5NREd2IRmN2TZN69qs17Rjh7tD0GxC8xKPi3nr+F05Ew869ixY7a5bJhIfPDgQfcZniis+O477vhAkSLZl589699qgVq3hlk8KDCeZTs2tFmz4Zwmk0PdUjn06NHDBTZDhgzBPffcc82/m1xZOaepIA5Dcc4iVgk9yolQDNm5cycqVKjgcmtyLn/ppZcu5h5ZG36aPh3o1Im3DYnsoIYiMjx47z3gvvv8xCQmEFev7ldFrV4NcO6rN9+EGZ06dcLEiRPdVWzVqlXdVexNN93k5v5guTdPEAx6LPnkE7/qrWFDP8DhMZH3I+GoHHszmCjOsn6rPvzQ9jBUkDGY+/LLL91rVsaEloWGZZg7x+pHSzh3S/ny5V25N6uiNm3a5Na3cuXKmDt3rrlqOFaB8ZjM+2FxMkbeIoRVUZ999hkyMjJcwM73rBg5EvjoI7/Yo2pV4LXXcn+GI8m8bUykiMjAhr02X3/NUlF/wjb23vCmW0895S+zlIvGnX758uV4++238cknn2DWrFlueOrWW2+9WCmVc36IGx1n2eWQ0/r1rJzx7x3FjirOW8Rea14dWOmRy4nTF2zb5t8nK9LmfpA/j0HNRzwLZMFE0qzJpNYCm86dO7uEYd7UlCd2TszHSrgXXnghV0+OBcyH3LFjh8t9ZDXY2bNnXW5N69at3bxjrUKJgkbs3es/8zh9qaIOXqBGUmATxfsq5OmDUVFurhUOjQQFe0+sllqHE7T1ZQXaoUOH1K4DIEhtW+06OILUrkNtOy8xSITmNIuIiIj8fgpsRERExAwFNiIiImKGAhsRERExQ4GNiIiImKHARkRERMxQYCMiIiJmKLARERERMxTYiIiIiBkKbERERMQMBTYiIiJihgIbERERMUOBjYiIiJihwEZERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREzFBgIyIiImZEeZ7n5emDUVHIly8fypUrh6A4fvw4YmNjERRBW98jR47gwoULatcBEKS2rXYdHEFq16G2nZmZid8SjTzKY/wjIiIict1oKEpERETMUGAjIiIiZiiwERERETMU2IiIiIgZCmxERETEDAU2IiIiYoYCGxERETFDgY2IiIiYocBGREREYMX/B5242aIbIuCPAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 600x600 with 1 Axes>"
       ]
@@ -1485,10 +1568,10 @@
    "id": "2a0ed8be",
    "metadata": {
     "papermill": {
-     "duration": 0.00777,
-     "end_time": "2026-06-02T21:45:33.598594+00:00",
+     "duration": 0.005692,
+     "end_time": "2026-06-05T06:07:59.975819",
      "exception": false,
-     "start_time": "2026-06-02T21:45:33.590824+00:00",
+     "start_time": "2026-06-05T06:07:59.970127",
      "status": "completed"
     },
     "tags": []
@@ -1518,10 +1601,10 @@
    "id": "exercises",
    "metadata": {
     "papermill": {
-     "duration": 0.006072,
-     "end_time": "2026-06-02T21:45:33.611628+00:00",
+     "duration": 0.004975,
+     "end_time": "2026-06-05T06:07:59.987082",
      "exception": false,
-     "start_time": "2026-06-02T21:45:33.605556+00:00",
+     "start_time": "2026-06-05T06:07:59.982107",
      "status": "completed"
     },
     "tags": []
@@ -1569,10 +1652,10 @@
    "id": "hr8egzwev4q",
    "metadata": {
     "papermill": {
-     "duration": 0.005694,
-     "end_time": "2026-06-02T21:45:33.623631+00:00",
+     "duration": 0.004751,
+     "end_time": "2026-06-05T06:07:59.996833",
      "exception": false,
-     "start_time": "2026-06-02T21:45:33.617937+00:00",
+     "start_time": "2026-06-05T06:07:59.992082",
      "status": "completed"
     },
     "tags": []
@@ -1602,20 +1685,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "0742z141zkqc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T21:45:33.637907Z",
-     "iopub.status.busy": "2026-06-02T21:45:33.637391Z",
-     "iopub.status.idle": "2026-06-02T21:45:33.644061Z",
-     "shell.execute_reply": "2026-06-02T21:45:33.642757Z"
+     "iopub.execute_input": "2026-06-05T06:08:00.008193Z",
+     "iopub.status.busy": "2026-06-05T06:08:00.008193Z",
+     "iopub.status.idle": "2026-06-05T06:08:00.011696Z",
+     "shell.execute_reply": "2026-06-05T06:08:00.011696Z"
     },
     "papermill": {
-     "duration": 0.015265,
-     "end_time": "2026-06-02T21:45:33.644884+00:00",
+     "duration": 0.010406,
+     "end_time": "2026-06-05T06:08:00.012659",
      "exception": false,
-     "start_time": "2026-06-02T21:45:33.629619+00:00",
+     "start_time": "2026-06-05T06:08:00.002253",
      "status": "completed"
     },
     "tags": []
@@ -1686,10 +1769,10 @@
    "id": "conclusion",
    "metadata": {
     "papermill": {
-     "duration": 0.006631,
-     "end_time": "2026-06-02T21:45:33.658166+00:00",
+     "duration": 0.006006,
+     "end_time": "2026-06-05T06:08:00.023682",
      "exception": false,
-     "start_time": "2026-06-02T21:45:33.651535+00:00",
+     "start_time": "2026-06-05T06:08:00.017676",
      "status": "completed"
     },
     "tags": []
@@ -1756,18 +1839,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 8.169589,
-   "end_time": "2026-06-02T21:45:34.136220+00:00",
+   "duration": 6.328008,
+   "end_time": "2026-06-05T06:08:00.261265",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-11-Choco-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-11-Choco-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-11-Choco-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-11-Choco-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T21:45:25.966631+00:00",
+   "start_time": "2026-06-05T06:07:53.933257",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "ef5ff599",
    "metadata": {
     "papermill": {
-     "duration": 0.002238,
-     "end_time": "2026-02-26T01:22:45.117674",
+     "duration": 0.028269,
+     "end_time": "2026-06-05T06:19:14.321566",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.115436",
+     "start_time": "2026-06-05T06:19:14.293297",
      "status": "completed"
     },
     "tags": []
@@ -50,10 +50,10 @@
    "id": "6572477a",
    "metadata": {
     "papermill": {
-     "duration": 0.001578,
-     "end_time": "2026-02-26T01:22:45.121080",
+     "duration": 0.006633,
+     "end_time": "2026-06-05T06:19:14.337226",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.119502",
+     "start_time": "2026-06-05T06:19:14.330593",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
    "id": "7cf1c89c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.037074Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.036629Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.527297Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.525376Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.351766Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.350769Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.476621Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.475894Z"
     },
     "papermill": {
-     "duration": 0.665994,
-     "end_time": "2026-02-26T01:22:45.788563",
+     "duration": 0.134865,
+     "end_time": "2026-06-05T06:19:14.477635",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.122569",
+     "start_time": "2026-06-05T06:19:14.342770",
      "status": "completed"
     },
     "tags": []
@@ -122,7 +122,16 @@
   {
    "cell_type": "markdown",
    "id": "e0ca3e38",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005083,
+     "end_time": "2026-06-05T06:19:14.487233",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.482150",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Environnement NumPyro/JAX\n",
     "\n",
@@ -148,10 +157,10 @@
    "id": "7e052680",
    "metadata": {
     "papermill": {
-     "duration": 0.001771,
-     "end_time": "2026-02-26T01:22:45.792152",
+     "duration": 0.004509,
+     "end_time": "2026-06-05T06:19:14.495743",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.790381",
+     "start_time": "2026-06-05T06:19:14.491234",
      "status": "completed"
     },
     "tags": []
@@ -166,16 +175,16 @@
    "id": "ef0ada77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.531368Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.530587Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.556600Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.554592Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.504764Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.504764Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.523875Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.522872Z"
     },
     "papermill": {
-     "duration": 0.011083,
-     "end_time": "2026-02-26T01:22:45.804902",
+     "duration": 0.025087,
+     "end_time": "2026-06-05T06:19:14.524851",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.793819",
+     "start_time": "2026-06-05T06:19:14.499764",
      "status": "completed"
     },
     "tags": []
@@ -297,7 +306,16 @@
   {
    "cell_type": "markdown",
    "id": "6a898168",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003993,
+     "end_time": "2026-06-05T06:19:14.532864",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.528871",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Chargement des Puzzles\n",
     "\n",
@@ -325,10 +343,10 @@
    "id": "074bd1c4",
    "metadata": {
     "papermill": {
-     "duration": 0.001618,
-     "end_time": "2026-02-26T01:22:45.808307",
+     "duration": 0.003944,
+     "end_time": "2026-06-05T06:19:14.540671",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.806689",
+     "start_time": "2026-06-05T06:19:14.536727",
      "status": "completed"
     },
     "tags": []
@@ -349,16 +367,16 @@
    "id": "36e448cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.560712Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.560094Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.579104Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.577452Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.550072Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.550072Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.569412Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.569412Z"
     },
     "papermill": {
-     "duration": 0.009608,
-     "end_time": "2026-02-26T01:22:45.819647",
+     "duration": 0.025447,
+     "end_time": "2026-06-05T06:19:14.570733",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.810039",
+     "start_time": "2026-06-05T06:19:14.545286",
      "status": "completed"
     },
     "tags": []
@@ -457,10 +475,10 @@
    "id": "33e976ac",
    "metadata": {
     "papermill": {
-     "duration": 0.001749,
-     "end_time": "2026-02-26T01:22:45.823129",
+     "duration": 0.004794,
+     "end_time": "2026-06-05T06:19:14.579721",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.821380",
+     "start_time": "2026-06-05T06:19:14.574927",
      "status": "completed"
     },
     "tags": []
@@ -480,16 +498,16 @@
    "id": "d612595c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.582944Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.582436Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.596122Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.593960Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.589001Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.589001Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.600911Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.600911Z"
     },
     "papermill": {
-     "duration": 0.007211,
-     "end_time": "2026-02-26T01:22:45.832056",
+     "duration": 0.01809,
+     "end_time": "2026-06-05T06:19:14.602329",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.824845",
+     "start_time": "2026-06-05T06:19:14.584239",
      "status": "completed"
     },
     "tags": []
@@ -561,10 +579,10 @@
    "id": "75beac6f",
    "metadata": {
     "papermill": {
-     "duration": 0.001616,
-     "end_time": "2026-02-26T01:22:45.835410",
+     "duration": 0.00401,
+     "end_time": "2026-06-05T06:19:14.610349",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.833794",
+     "start_time": "2026-06-05T06:19:14.606339",
      "status": "completed"
     },
     "tags": []
@@ -579,16 +597,16 @@
    "id": "a55a60b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.600481Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.599508Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.609324Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.607853Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.619349Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.619349Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.633319Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.632396Z"
     },
     "papermill": {
-     "duration": 7.070987,
-     "end_time": "2026-02-26T01:22:52.908062",
+     "duration": 0.01897,
+     "end_time": "2026-06-05T06:19:14.633319",
      "exception": false,
-     "start_time": "2026-02-26T01:22:45.837075",
+     "start_time": "2026-06-05T06:19:14.614349",
      "status": "completed"
     },
     "tags": []
@@ -631,7 +649,16 @@
   {
    "cell_type": "markdown",
    "id": "a7db79c3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003525,
+     "end_time": "2026-06-05T06:19:14.641393",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.637868",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur Probabiliste Pur (RobustProbabilisticSolver)\n",
     "\n",
@@ -657,21 +684,161 @@
   {
    "cell_type": "markdown",
    "id": "0df3f512",
-   "source": "### Exercice : Analyser la confiance du modele probabiliste par cellule\n\nLe solveur probabiliste produit pour chaque cellule une **distribution de probabilites** sur les 9 valeurs possibles (1-9). Certaines cellules ont une distribution tres pointue (haute confiance) tandis que d'autres sont plus incertaines.\n\n**Objectif** : Implementez deux fonctions pour analyser la confiance du modele :\n1. `entropy(probs)` : calculer l'entropie d'une distribution (mesure d'incertitude)\n2. `analyze_confidence(grid, probs)` : identifier les cellules les plus certaines et les plus incertaines\n\n**Concepts cles** :\n- **Entropie** : quantifie l'incertitude d'une distribution. Valeur faible = modele certain, valeur elevee = modele hesitant\n- **Confiance** : probabilite maximale de la distribution pour une cellule\n- **Distribution uniforme** : 9 valeurs equiprobables, entropie = ln(9) ~ 2.20 nats\n\n**Indices** :\n- Etape 1 : Implementez `entropy(probs)` avec la formule `-sum(p * log(p))` en ignorant les valeurs nulles\n- Etape 2 : Pour chaque cellule vide de la grille, extrayez confiance et entropie depuis la distribution\n- Etape 3 : Triez les resultats et affichez les extremes\n- Indice : `np.log` et un filtre `probs > 0` pour eviter `log(0)`",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.003688,
+     "end_time": "2026-06-05T06:19:14.649572",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.645884",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Analyser la confiance du modele probabiliste par cellule\n",
+    "\n",
+    "Le solveur probabiliste produit pour chaque cellule une **distribution de probabilites** sur les 9 valeurs possibles (1-9). Certaines cellules ont une distribution tres pointue (haute confiance) tandis que d'autres sont plus incertaines.\n",
+    "\n",
+    "**Objectif** : Implementez deux fonctions pour analyser la confiance du modele :\n",
+    "1. `entropy(probs)` : calculer l'entropie d'une distribution (mesure d'incertitude)\n",
+    "2. `analyze_confidence(grid, probs)` : identifier les cellules les plus certaines et les plus incertaines\n",
+    "\n",
+    "**Concepts cles** :\n",
+    "- **Entropie** : quantifie l'incertitude d'une distribution. Valeur faible = modele certain, valeur elevee = modele hesitant\n",
+    "- **Confiance** : probabilite maximale de la distribution pour une cellule\n",
+    "- **Distribution uniforme** : 9 valeurs equiprobables, entropie = ln(9) ~ 2.20 nats\n",
+    "\n",
+    "**Indices** :\n",
+    "- Etape 1 : Implementez `entropy(probs)` avec la formule `-sum(p * log(p))` en ignorant les valeurs nulles\n",
+    "- Etape 2 : Pour chaque cellule vide de la grille, extrayez confiance et entropie depuis la distribution\n",
+    "- Etape 3 : Triez les resultats et affichez les extremes\n",
+    "- Indice : `np.log` et un filtre `probs > 0` pour eviter `log(0)`"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "8449e4d7",
-   "source": "# EXERCICE : Analyser la confiance du modele probabiliste par cellule\n#\n# Indications :\n#   - Pour chaque cellule vide, la distribution Dirichlet donne 9 probabilites\n#   - La confiance = max(probs) indique a quel point le modele est certain\n#   - L'entropie mesure l'incertitude globale de la distribution\n#\n# Etape 1 : Implementez entropy(probs) avec la formule -sum(p * log(p))\n#   Attention : ignorez les probabilites nulles (log(0) indefini)\n# Etape 2 : Implementez analyze_confidence(grid, probs) qui retourne\n#   une liste de (row, col, confidence, entropy, top_value) pour chaque cellule vide\n#   triee par confiance decroissante\n# Etape 3 : Affichez les 10 cellules les plus certaines et les 10 les plus incertaines\n# Indice : pour l'entropie, utilisez np.log et filtrez les valeurs > 0\n#   Entropie maximale pour 9 valeurs = log(9) ~ 2.20 (distribution uniforme)\n#   Entropie minimale = 0 (une seule valeur a 100%)\n\nimport numpy as np\n\n\ndef entropy(probs):\n    \"\"\"Calcule l'entropie d'une distribution de probabilites.\n\n    Args:\n        probs: tableau de probabilites (somme = 1)\n\n    Returns:\n        Entropie en nats (>= 0)\n    \"\"\"\n    # TODO etudiant : implementez le calcul d'entropie\n    return 0.0  # TODO\n\n\ndef analyze_confidence(grid, probs):\n    \"\"\"Analyse la confiance du modele pour chaque cellule vide.\n\n    Args:\n        grid: grille 9x9 (0 = case vide)\n        probs: tableau 81x9 de probabilites (sortie du solveur)\n\n    Returns:\n        Liste de (row, col, confidence, entropy, top_value)\n        triee par confiance decroissante\n    \"\"\"\n    # TODO etudiant : parcourez les cellules vides et collectez les metriques\n    return []  # TODO\n\n\n# Grille de test pour cet exercice\n_ex_grid = [\n    [0,0,0,2,6,0,7,0,1],\n    [6,8,0,0,7,0,0,9,0],\n    [1,9,0,0,0,4,5,0,0],\n    [8,2,0,1,0,0,0,4,0],\n    [0,0,4,6,0,2,9,0,0],\n    [0,5,0,0,0,3,0,2,8],\n    [0,0,9,3,0,0,0,7,4],\n    [0,4,0,0,5,0,0,3,6],\n    [7,0,3,0,1,8,0,0,0]\n]\n\n# Test avec des probabilites simulees (distribution Dirichlet aleatoire)\n# Si JAX est disponible, decommentez pour utiliser les vraies probabilites :\n# solver = RobustProbabilisticSolverPy(n_iterations=300)\n# probs = solver.infer_probabilities(_ex_grid)\n# analysis = analyze_confidence(_ex_grid, probs)\n\nfake_probs = np.random.dirichlet(np.ones(9), size=81)\nanalysis = analyze_confidence(_ex_grid, fake_probs)\n\nif analysis:\n    print(\"Top 5 cellules les plus certaines :\")\n    for row, col, conf, ent, val in analysis[:5]:\n        print(f\"  ({row},{col}) : confiance={conf:.3f}, entropie={ent:.3f}, valeur={val}\")\n    print(\"\\nTop 5 cellules les plus incertaines :\")\n    for row, col, conf, ent, val in analysis[-5:]:\n        print(f\"  ({row},{col}) : confiance={conf:.3f}, entropie={ent:.3f}, valeur={val}\")\nelse:\n    print(\"Analyse a completer : implementez analyze_confidence()\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:19:14.657638Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.656627Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.679379Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.679379Z"
+    },
+    "papermill": {
+     "duration": 0.028573,
+     "end_time": "2026-06-05T06:19:14.681203",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.652630",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyse a completer : implementez analyze_confidence()\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE : Analyser la confiance du modele probabiliste par cellule\n",
+    "#\n",
+    "# Indications :\n",
+    "#   - Pour chaque cellule vide, la distribution Dirichlet donne 9 probabilites\n",
+    "#   - La confiance = max(probs) indique a quel point le modele est certain\n",
+    "#   - L'entropie mesure l'incertitude globale de la distribution\n",
+    "#\n",
+    "# Etape 1 : Implementez entropy(probs) avec la formule -sum(p * log(p))\n",
+    "#   Attention : ignorez les probabilites nulles (log(0) indefini)\n",
+    "# Etape 2 : Implementez analyze_confidence(grid, probs) qui retourne\n",
+    "#   une liste de (row, col, confidence, entropy, top_value) pour chaque cellule vide\n",
+    "#   triee par confiance decroissante\n",
+    "# Etape 3 : Affichez les 10 cellules les plus certaines et les 10 les plus incertaines\n",
+    "# Indice : pour l'entropie, utilisez np.log et filtrez les valeurs > 0\n",
+    "#   Entropie maximale pour 9 valeurs = log(9) ~ 2.20 (distribution uniforme)\n",
+    "#   Entropie minimale = 0 (une seule valeur a 100%)\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def entropy(probs):\n",
+    "    \"\"\"Calcule l'entropie d'une distribution de probabilites.\n",
+    "\n",
+    "    Args:\n",
+    "        probs: tableau de probabilites (somme = 1)\n",
+    "\n",
+    "    Returns:\n",
+    "        Entropie en nats (>= 0)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementez le calcul d'entropie\n",
+    "    return 0.0  # TODO\n",
+    "\n",
+    "\n",
+    "def analyze_confidence(grid, probs):\n",
+    "    \"\"\"Analyse la confiance du modele pour chaque cellule vide.\n",
+    "\n",
+    "    Args:\n",
+    "        grid: grille 9x9 (0 = case vide)\n",
+    "        probs: tableau 81x9 de probabilites (sortie du solveur)\n",
+    "\n",
+    "    Returns:\n",
+    "        Liste de (row, col, confidence, entropy, top_value)\n",
+    "        triee par confiance decroissante\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : parcourez les cellules vides et collectez les metriques\n",
+    "    return []  # TODO\n",
+    "\n",
+    "\n",
+    "# Grille de test pour cet exercice\n",
+    "_ex_grid = [\n",
+    "    [0,0,0,2,6,0,7,0,1],\n",
+    "    [6,8,0,0,7,0,0,9,0],\n",
+    "    [1,9,0,0,0,4,5,0,0],\n",
+    "    [8,2,0,1,0,0,0,4,0],\n",
+    "    [0,0,4,6,0,2,9,0,0],\n",
+    "    [0,5,0,0,0,3,0,2,8],\n",
+    "    [0,0,9,3,0,0,0,7,4],\n",
+    "    [0,4,0,0,5,0,0,3,6],\n",
+    "    [7,0,3,0,1,8,0,0,0]\n",
+    "]\n",
+    "\n",
+    "# Test avec des probabilites simulees (distribution Dirichlet aleatoire)\n",
+    "# Si JAX est disponible, decommentez pour utiliser les vraies probabilites :\n",
+    "# solver = RobustProbabilisticSolverPy(n_iterations=300)\n",
+    "# probs = solver.infer_probabilities(_ex_grid)\n",
+    "# analysis = analyze_confidence(_ex_grid, probs)\n",
+    "\n",
+    "fake_probs = np.random.dirichlet(np.ones(9), size=81)\n",
+    "analysis = analyze_confidence(_ex_grid, fake_probs)\n",
+    "\n",
+    "if analysis:\n",
+    "    print(\"Top 5 cellules les plus certaines :\")\n",
+    "    for row, col, conf, ent, val in analysis[:5]:\n",
+    "        print(f\"  ({row},{col}) : confiance={conf:.3f}, entropie={ent:.3f}, valeur={val}\")\n",
+    "    print(\"\\nTop 5 cellules les plus incertaines :\")\n",
+    "    for row, col, conf, ent, val in analysis[-5:]:\n",
+    "        print(f\"  ({row},{col}) : confiance={conf:.3f}, entropie={ent:.3f}, valeur={val}\")\n",
+    "else:\n",
+    "    print(\"Analyse a completer : implementez analyze_confidence()\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ex-count-candidates",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003354,
+     "end_time": "2026-06-05T06:19:14.688573",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.685219",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Compter les candidats possibles par case\n",
     "\n",
@@ -691,9 +858,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "ex-count-candidates-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:19:14.698425Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.698425Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.709436Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.709436Z"
+    },
+    "papermill": {
+     "duration": 0.017917,
+     "end_time": "2026-06-05T06:19:14.710440",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.692523",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -757,10 +939,10 @@
    "id": "19ab91a8",
    "metadata": {
     "papermill": {
-     "duration": 0.002008,
-     "end_time": "2026-02-26T01:22:52.912125",
+     "duration": 0.003895,
+     "end_time": "2026-06-05T06:19:14.719210",
      "exception": false,
-     "start_time": "2026-02-26T01:22:52.910117",
+     "start_time": "2026-06-05T06:19:14.715315",
      "status": "completed"
     },
     "tags": []
@@ -773,20 +955,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2dab7e0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.613067Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.612506Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.627884Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.626335Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.726262Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.726262Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.739781Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.739781Z"
     },
     "papermill": {
-     "duration": 0.014321,
-     "end_time": "2026-02-26T01:22:52.928354",
+     "duration": 0.018457,
+     "end_time": "2026-06-05T06:19:14.740786",
      "exception": false,
-     "start_time": "2026-02-26T01:22:52.914033",
+     "start_time": "2026-06-05T06:19:14.722329",
      "status": "completed"
     },
     "tags": []
@@ -876,10 +1058,10 @@
    "id": "bc0f034f",
    "metadata": {
     "papermill": {
-     "duration": 0.00499,
-     "end_time": "2026-02-26T01:22:52.935970",
+     "duration": 0.004001,
+     "end_time": "2026-06-05T06:19:14.748791",
      "exception": false,
-     "start_time": "2026-02-26T01:22:52.930980",
+     "start_time": "2026-06-05T06:19:14.744790",
      "status": "completed"
     },
     "tags": []
@@ -890,20 +1072,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d42a58fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.631464Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.630916Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.640811Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.639355Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.757153Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.757153Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.770944Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.770944Z"
     },
     "papermill": {
-     "duration": 413.980784,
-     "end_time": "2026-02-26T01:29:46.919360",
+     "duration": 0.02011,
+     "end_time": "2026-06-05T06:19:14.771901",
      "exception": false,
-     "start_time": "2026-02-26T01:22:52.938576",
+     "start_time": "2026-06-05T06:19:14.751791",
      "status": "completed"
     },
     "tags": []
@@ -947,7 +1129,16 @@
   {
    "cell_type": "markdown",
    "id": "44d951b2",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003996,
+     "end_time": "2026-06-05T06:19:14.780532",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.776536",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Solveur Iteratif Probabiliste\n",
     "\n",
@@ -974,7 +1165,16 @@
   {
    "cell_type": "markdown",
    "id": "ex-verify-deterministic",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00321,
+     "end_time": "2026-06-05T06:19:14.788733",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.785523",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Verifier la reproductibilite d'un solveur\n",
     "\n",
@@ -994,9 +1194,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "ex-verify-deterministic-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:19:14.798344Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.797835Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.817509Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.817509Z"
+    },
+    "papermill": {
+     "duration": 0.026211,
+     "end_time": "2026-06-05T06:19:14.818516",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.792305",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1067,8 +1282,10 @@
     "\n",
     "\n",
     "result = measure_reproducibility(simple_backtrack_solve, test_grid_15, n_runs=3)\n",
-    "print(f\"Taux de succes : {result[\"success_rate\"]:.1%}\")\n",
-    "print(f\"Solutions uniques : {result[\"unique_solutions\"]}\")\n"
+    "success_rate = result[\"success_rate\"]\n",
+    "unique_solutions = result[\"unique_solutions\"]\n",
+    "print(f\"Taux de succes : {success_rate:.1%}\")\n",
+    "print(f\"Solutions uniques : {unique_solutions}\")"
    ]
   },
   {
@@ -1076,10 +1293,10 @@
    "id": "e2d986e1",
    "metadata": {
     "papermill": {
-     "duration": 0.003907,
-     "end_time": "2026-02-26T01:29:46.926916",
+     "duration": 0.005146,
+     "end_time": "2026-06-05T06:19:14.828236",
      "exception": false,
-     "start_time": "2026-02-26T01:29:46.923009",
+     "start_time": "2026-06-05T06:19:14.823090",
      "status": "completed"
     },
     "tags": []
@@ -1100,20 +1317,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "1163cd1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.644417Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.643883Z",
-     "iopub.status.idle": "2026-04-20T23:56:45.657398Z",
-     "shell.execute_reply": "2026-04-20T23:56:45.655864Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.839807Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.839807Z",
+     "iopub.status.idle": "2026-06-05T06:19:14.849380Z",
+     "shell.execute_reply": "2026-06-05T06:19:14.849380Z"
     },
     "papermill": {
-     "duration": 21.139909,
-     "end_time": "2026-02-26T01:30:08.069657",
+     "duration": 0.015618,
+     "end_time": "2026-06-05T06:19:14.850378",
      "exception": false,
-     "start_time": "2026-02-26T01:29:46.929748",
+     "start_time": "2026-06-05T06:19:14.834760",
      "status": "completed"
     },
     "tags": []
@@ -1188,7 +1405,16 @@
   {
    "cell_type": "markdown",
    "id": "6e447ffa",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004446,
+     "end_time": "2026-06-05T06:19:14.859779",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:14.855333",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Comparaison Python vs C#\n",
     "\n",
@@ -1220,10 +1446,10 @@
    "id": "543d230f",
    "metadata": {
     "papermill": {
-     "duration": 0.00254,
-     "end_time": "2026-02-26T01:30:08.074981",
+     "duration": 0.004018,
+     "end_time": "2026-06-05T06:19:14.868911",
      "exception": false,
-     "start_time": "2026-02-26T01:30:08.072441",
+     "start_time": "2026-06-05T06:19:14.864893",
      "status": "completed"
     },
     "tags": []
@@ -1234,20 +1460,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "9518beb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:45.661100Z",
-     "iopub.status.busy": "2026-04-20T23:56:45.660586Z",
-     "iopub.status.idle": "2026-04-20T23:56:46.600156Z",
-     "shell.execute_reply": "2026-04-20T23:56:46.598800Z"
+     "iopub.execute_input": "2026-06-05T06:19:14.879422Z",
+     "iopub.status.busy": "2026-06-05T06:19:14.879422Z",
+     "iopub.status.idle": "2026-06-05T06:19:15.143169Z",
+     "shell.execute_reply": "2026-06-05T06:19:15.143169Z"
     },
     "papermill": {
-     "duration": 0.310188,
-     "end_time": "2026-02-26T01:30:08.387642",
+     "duration": 0.270224,
+     "end_time": "2026-06-05T06:19:15.144216",
      "exception": false,
-     "start_time": "2026-02-26T01:30:08.077454",
+     "start_time": "2026-06-05T06:19:14.873992",
      "status": "completed"
     },
     "tags": []
@@ -1318,10 +1544,10 @@
    "id": "ee942928",
    "metadata": {
     "papermill": {
-     "duration": 0.003232,
-     "end_time": "2026-02-26T01:30:08.394542",
+     "duration": 0.004973,
+     "end_time": "2026-06-05T06:19:15.154230",
      "exception": false,
-     "start_time": "2026-02-26T01:30:08.391310",
+     "start_time": "2026-06-05T06:19:15.149257",
      "status": "completed"
     },
     "tags": []
@@ -1348,7 +1574,16 @@
   {
    "cell_type": "markdown",
    "id": "ql41ouqadip",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004071,
+     "end_time": "2026-06-05T06:19:15.162859",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:15.158788",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Solveur Hybride Probabiliste + Deterministe\n",
     "\n",
@@ -1385,15 +1620,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "icemgf35orf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-20T23:56:46.603440Z",
-     "iopub.status.busy": "2026-04-20T23:56:46.602886Z",
-     "iopub.status.idle": "2026-04-20T23:56:46.611646Z",
-     "shell.execute_reply": "2026-04-20T23:56:46.610213Z"
-    }
+     "iopub.execute_input": "2026-06-05T06:19:15.171899Z",
+     "iopub.status.busy": "2026-06-05T06:19:15.171899Z",
+     "iopub.status.idle": "2026-06-05T06:19:15.190182Z",
+     "shell.execute_reply": "2026-06-05T06:19:15.189146Z"
+    },
+    "papermill": {
+     "duration": 0.024239,
+     "end_time": "2026-06-05T06:19:15.191160",
+     "exception": false,
+     "start_time": "2026-06-05T06:19:15.166921",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1466,10 +1709,10 @@
    "id": "16240cb9",
    "metadata": {
     "papermill": {
-     "duration": 0.003026,
-     "end_time": "2026-02-26T01:30:08.400668",
+     "duration": 0.005998,
+     "end_time": "2026-06-05T06:19:15.203160",
      "exception": false,
-     "start_time": "2026-02-26T01:30:08.397642",
+     "start_time": "2026-06-05T06:19:15.197162",
      "status": "completed"
     },
     "tags": []
@@ -1502,18 +1745,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 447.881112,
-   "end_time": "2026-02-26T01:30:11.354548",
+   "duration": 2.724656,
+   "end_time": "2026-06-05T06:19:15.332459",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-15-Infer-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-15-Infer-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-02-26T01:22:43.473436",
+   "start_time": "2026-06-05T06:19:12.607803",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Python.ipynb
@@ -6,10 +6,10 @@
    "id": "4862d5e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005479,
-     "end_time": "2026-04-25T15:01:20.847177",
+     "duration": 0.005997,
+     "end_time": "2026-06-05T06:09:02.263304",
      "exception": false,
-     "start_time": "2026-04-25T15:01:20.841698",
+     "start_time": "2026-06-05T06:09:02.257307",
      "status": "completed"
     },
     "tags": []
@@ -74,16 +74,16 @@
    "id": "83c9d836",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:20.868818Z",
-     "iopub.status.busy": "2026-04-25T15:01:20.868313Z",
-     "iopub.status.idle": "2026-04-25T15:01:28.823518Z",
-     "shell.execute_reply": "2026-04-25T15:01:28.822712Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.275863Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.275863Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.694460Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.694460Z"
     },
     "papermill": {
-     "duration": 7.962286,
-     "end_time": "2026-04-25T15:01:28.824716",
+     "duration": 0.425856,
+     "end_time": "2026-06-05T06:09:02.695708",
      "exception": false,
-     "start_time": "2026-04-25T15:01:20.862430",
+     "start_time": "2026-06-05T06:09:02.269852",
      "status": "completed"
     },
     "tags": []
@@ -121,10 +121,10 @@
    "id": "9c100eda",
    "metadata": {
     "papermill": {
-     "duration": 0.005013,
-     "end_time": "2026-04-25T15:01:28.836902",
+     "duration": 0.005014,
+     "end_time": "2026-06-05T06:09:02.706815",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.831889",
+     "start_time": "2026-06-05T06:09:02.701801",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +157,10 @@
    "id": "15a2991d",
    "metadata": {
     "papermill": {
-     "duration": 0.004629,
-     "end_time": "2026-04-25T15:01:28.846649",
+     "duration": 0.004945,
+     "end_time": "2026-06-05T06:09:02.716857",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.842020",
+     "start_time": "2026-06-05T06:09:02.711912",
      "status": "completed"
     },
     "tags": []
@@ -175,16 +175,16 @@
    "id": "bc9b88e4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:28.857287Z",
-     "iopub.status.busy": "2026-04-25T15:01:28.856883Z",
-     "iopub.status.idle": "2026-04-25T15:01:28.863397Z",
-     "shell.execute_reply": "2026-04-25T15:01:28.862517Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.727738Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.727738Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.741428Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.741428Z"
     },
     "papermill": {
-     "duration": 0.013229,
-     "end_time": "2026-04-25T15:01:28.864446",
+     "duration": 0.020525,
+     "end_time": "2026-06-05T06:09:02.742439",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.851217",
+     "start_time": "2026-06-05T06:09:02.721914",
      "status": "completed"
     },
     "tags": []
@@ -194,7 +194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dossier Puzzles: C:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
+      "Dossier Puzzles: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
      ]
     }
    ],
@@ -224,10 +224,10 @@
    "id": "ae5bc588",
    "metadata": {
     "papermill": {
-     "duration": 0.004777,
-     "end_time": "2026-04-25T15:01:28.874221",
+     "duration": 0.004765,
+     "end_time": "2026-06-05T06:09:02.752192",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.869444",
+     "start_time": "2026-06-05T06:09:02.747427",
      "status": "completed"
     },
     "tags": []
@@ -258,10 +258,10 @@
    "id": "a3bc36a4",
    "metadata": {
     "papermill": {
-     "duration": 0.004495,
-     "end_time": "2026-04-25T15:01:28.883416",
+     "duration": 0.005023,
+     "end_time": "2026-06-05T06:09:02.762316",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.878921",
+     "start_time": "2026-06-05T06:09:02.757293",
      "status": "completed"
     },
     "tags": []
@@ -279,16 +279,16 @@
    "id": "7414b376",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:28.894725Z",
-     "iopub.status.busy": "2026-04-25T15:01:28.894317Z",
-     "iopub.status.idle": "2026-04-25T15:01:28.905639Z",
-     "shell.execute_reply": "2026-04-25T15:01:28.904946Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.773715Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.773715Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.789088Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.788085Z"
     },
     "papermill": {
-     "duration": 0.019998,
-     "end_time": "2026-04-25T15:01:28.907915",
+     "duration": 0.022643,
+     "end_time": "2026-06-05T06:09:02.789973",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.887917",
+     "start_time": "2026-06-05T06:09:02.767330",
      "status": "completed"
     },
     "tags": []
@@ -407,10 +407,10 @@
    "id": "ae2304d3",
    "metadata": {
     "papermill": {
-     "duration": 0.004471,
-     "end_time": "2026-04-25T15:01:28.917452",
+     "duration": 0.003636,
+     "end_time": "2026-06-05T06:09:02.799154",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.912981",
+     "start_time": "2026-06-05T06:09:02.795518",
      "status": "completed"
     },
     "tags": []
@@ -448,10 +448,10 @@
    "id": "73e432ea",
    "metadata": {
     "papermill": {
-     "duration": 0.005012,
-     "end_time": "2026-04-25T15:01:28.927202",
+     "duration": 0.0047,
+     "end_time": "2026-06-05T06:09:02.810641",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.922190",
+     "start_time": "2026-06-05T06:09:02.805941",
      "status": "completed"
     },
     "tags": []
@@ -475,10 +475,10 @@
    "id": "a3a457fd",
    "metadata": {
     "papermill": {
-     "duration": 0.004907,
-     "end_time": "2026-04-25T15:01:28.937543",
+     "duration": 0.004927,
+     "end_time": "2026-06-05T06:09:02.820857",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.932636",
+     "start_time": "2026-06-05T06:09:02.815930",
      "status": "completed"
     },
     "tags": []
@@ -496,16 +496,16 @@
    "id": "23aa4f00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:28.949064Z",
-     "iopub.status.busy": "2026-04-25T15:01:28.948625Z",
-     "iopub.status.idle": "2026-04-25T15:01:28.959307Z",
-     "shell.execute_reply": "2026-04-25T15:01:28.958701Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.832985Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.832985Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.850687Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.850687Z"
     },
     "papermill": {
-     "duration": 0.01802,
-     "end_time": "2026-04-25T15:01:28.960567",
+     "duration": 0.024444,
+     "end_time": "2026-06-05T06:09:02.851651",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.942547",
+     "start_time": "2026-06-05T06:09:02.827207",
      "status": "completed"
     },
     "tags": []
@@ -611,10 +611,10 @@
    "id": "3445ed0c",
    "metadata": {
     "papermill": {
-     "duration": 0.005144,
-     "end_time": "2026-04-25T15:01:28.970859",
+     "duration": 0.005133,
+     "end_time": "2026-06-05T06:09:02.862271",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.965715",
+     "start_time": "2026-06-05T06:09:02.857138",
      "status": "completed"
     },
     "tags": []
@@ -645,10 +645,10 @@
    "id": "c52783a9",
    "metadata": {
     "papermill": {
-     "duration": 0.004737,
-     "end_time": "2026-04-25T15:01:28.980508",
+     "duration": 0.005155,
+     "end_time": "2026-06-05T06:09:02.872295",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.975771",
+     "start_time": "2026-06-05T06:09:02.867140",
      "status": "completed"
     },
     "tags": []
@@ -663,16 +663,16 @@
    "id": "f99d621c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:28.992773Z",
-     "iopub.status.busy": "2026-04-25T15:01:28.992255Z",
-     "iopub.status.idle": "2026-04-25T15:01:28.998272Z",
-     "shell.execute_reply": "2026-04-25T15:01:28.997641Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.882937Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.882937Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.897610Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.897610Z"
     },
     "papermill": {
-     "duration": 0.013048,
-     "end_time": "2026-04-25T15:01:28.999218",
+     "duration": 0.021901,
+     "end_time": "2026-06-05T06:09:02.898916",
      "exception": false,
-     "start_time": "2026-04-25T15:01:28.986170",
+     "start_time": "2026-06-05T06:09:02.877015",
      "status": "completed"
     },
     "tags": []
@@ -724,10 +724,10 @@
    "id": "cdab968f",
    "metadata": {
     "papermill": {
-     "duration": 0.004513,
-     "end_time": "2026-04-25T15:01:29.008618",
+     "duration": 0.005167,
+     "end_time": "2026-06-05T06:09:02.910012",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.004105",
+     "start_time": "2026-06-05T06:09:02.904845",
      "status": "completed"
     },
     "tags": []
@@ -758,10 +758,10 @@
    "id": "b48a1859",
    "metadata": {
     "papermill": {
-     "duration": 0.004614,
-     "end_time": "2026-04-25T15:01:29.017660",
+     "duration": 0.005957,
+     "end_time": "2026-06-05T06:09:02.920863",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.013046",
+     "start_time": "2026-06-05T06:09:02.914906",
      "status": "completed"
     },
     "tags": []
@@ -776,16 +776,16 @@
    "id": "98058902",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:29.028728Z",
-     "iopub.status.busy": "2026-04-25T15:01:29.028330Z",
-     "iopub.status.idle": "2026-04-25T15:01:29.033534Z",
-     "shell.execute_reply": "2026-04-25T15:01:29.032797Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.931644Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.931644Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.943385Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.943385Z"
     },
     "papermill": {
-     "duration": 0.011809,
-     "end_time": "2026-04-25T15:01:29.034523",
+     "duration": 0.019298,
+     "end_time": "2026-06-05T06:09:02.944938",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.022714",
+     "start_time": "2026-06-05T06:09:02.925640",
      "status": "completed"
     },
     "tags": []
@@ -823,10 +823,10 @@
    "id": "d31c60ad",
    "metadata": {
     "papermill": {
-     "duration": 0.004873,
-     "end_time": "2026-04-25T15:01:29.044379",
+     "duration": 0.005142,
+     "end_time": "2026-06-05T06:09:02.955208",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.039506",
+     "start_time": "2026-06-05T06:09:02.950066",
      "status": "completed"
     },
     "tags": []
@@ -859,10 +859,10 @@
    "id": "b8212fb8",
    "metadata": {
     "papermill": {
-     "duration": 0.004657,
-     "end_time": "2026-04-25T15:01:29.054852",
+     "duration": 0.00511,
+     "end_time": "2026-06-05T06:09:02.965400",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.050195",
+     "start_time": "2026-06-05T06:09:02.960290",
      "status": "completed"
     },
     "tags": []
@@ -878,16 +878,16 @@
    "id": "6b02a3f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:29.065568Z",
-     "iopub.status.busy": "2026-04-25T15:01:29.065257Z",
-     "iopub.status.idle": "2026-04-25T15:01:29.076787Z",
-     "shell.execute_reply": "2026-04-25T15:01:29.075924Z"
+     "iopub.execute_input": "2026-06-05T06:09:02.976061Z",
+     "iopub.status.busy": "2026-06-05T06:09:02.976061Z",
+     "iopub.status.idle": "2026-06-05T06:09:02.991538Z",
+     "shell.execute_reply": "2026-06-05T06:09:02.990530Z"
     },
     "papermill": {
-     "duration": 0.018605,
-     "end_time": "2026-04-25T15:01:29.078072",
+     "duration": 0.021475,
+     "end_time": "2026-06-05T06:09:02.991538",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.059467",
+     "start_time": "2026-06-05T06:09:02.970063",
      "status": "completed"
     },
     "tags": []
@@ -1036,10 +1036,10 @@
    "id": "543b8705",
    "metadata": {
     "papermill": {
-     "duration": 0.004895,
-     "end_time": "2026-04-25T15:01:29.088666",
+     "duration": 0.00455,
+     "end_time": "2026-06-05T06:09:03.002091",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.083771",
+     "start_time": "2026-06-05T06:09:02.997541",
      "status": "completed"
     },
     "tags": []
@@ -1072,10 +1072,10 @@
    "id": "7e7ed443",
    "metadata": {
     "papermill": {
-     "duration": 0.004688,
-     "end_time": "2026-04-25T15:01:29.098149",
+     "duration": 0.005884,
+     "end_time": "2026-06-05T06:09:03.013685",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.093461",
+     "start_time": "2026-06-05T06:09:03.007801",
      "status": "completed"
     },
     "tags": []
@@ -1091,16 +1091,16 @@
    "id": "f1330c9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:29.108984Z",
-     "iopub.status.busy": "2026-04-25T15:01:29.108384Z",
-     "iopub.status.idle": "2026-04-25T15:01:31.101456Z",
-     "shell.execute_reply": "2026-04-25T15:01:31.100612Z"
+     "iopub.execute_input": "2026-06-05T06:09:03.025265Z",
+     "iopub.status.busy": "2026-06-05T06:09:03.025265Z",
+     "iopub.status.idle": "2026-06-05T06:09:04.547756Z",
+     "shell.execute_reply": "2026-06-05T06:09:04.546778Z"
     },
     "papermill": {
-     "duration": 2.000012,
-     "end_time": "2026-04-25T15:01:31.102791",
+     "duration": 1.531086,
+     "end_time": "2026-06-05T06:09:04.549731",
      "exception": false,
-     "start_time": "2026-04-25T15:01:29.102779",
+     "start_time": "2026-06-05T06:09:03.018645",
      "status": "completed"
     },
     "tags": []
@@ -1132,7 +1132,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Solution trouvee en 2.24s:\n",
+      "Solution trouvee en 1.50s:\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
       "1 7 4 | 9 6 3 | 8 2 5 \n",
       "5 3 8 | 4 2 7 | 1 6 9 \n",
@@ -1176,10 +1176,10 @@
    "id": "cef4d40c",
    "metadata": {
     "papermill": {
-     "duration": 0.005999,
-     "end_time": "2026-04-25T15:01:31.114557",
+     "duration": 0.018758,
+     "end_time": "2026-06-05T06:09:04.576493",
      "exception": false,
-     "start_time": "2026-04-25T15:01:31.108558",
+     "start_time": "2026-06-05T06:09:04.557735",
      "status": "completed"
     },
     "tags": []
@@ -1200,7 +1200,16 @@
   {
    "cell_type": "markdown",
    "id": "ex-pso-error-breakdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.015767,
+     "end_time": "2026-06-05T06:09:04.604139",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:04.588372",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Decomposition des erreurs par type\n",
     "\n",
@@ -1223,7 +1232,22 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "ex-pso-error-breakdown-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:09:04.636327Z",
+     "iopub.status.busy": "2026-06-05T06:09:04.636327Z",
+     "iopub.status.idle": "2026-06-05T06:09:04.656337Z",
+     "shell.execute_reply": "2026-06-05T06:09:04.653832Z"
+    },
+    "papermill": {
+     "duration": 0.039629,
+     "end_time": "2026-06-05T06:09:04.660376",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:04.620747",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1259,10 +1283,10 @@
    "id": "9f0f856f",
    "metadata": {
     "papermill": {
-     "duration": 0.007796,
-     "end_time": "2026-04-25T15:01:31.127121",
+     "duration": 0.01359,
+     "end_time": "2026-06-05T06:09:04.685627",
      "exception": false,
-     "start_time": "2026-04-25T15:01:31.119325",
+     "start_time": "2026-06-05T06:09:04.672037",
      "status": "completed"
     },
     "tags": []
@@ -1278,16 +1302,16 @@
    "id": "16434222",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:01:31.138626Z",
-     "iopub.status.busy": "2026-04-25T15:01:31.138182Z",
-     "iopub.status.idle": "2026-04-25T15:02:01.469124Z",
-     "shell.execute_reply": "2026-04-25T15:02:01.468295Z"
+     "iopub.execute_input": "2026-06-05T06:09:04.700726Z",
+     "iopub.status.busy": "2026-06-05T06:09:04.700726Z",
+     "iopub.status.idle": "2026-06-05T06:09:27.755623Z",
+     "shell.execute_reply": "2026-06-05T06:09:27.754617Z"
     },
     "papermill": {
-     "duration": 30.340742,
-     "end_time": "2026-04-25T15:02:01.472649",
+     "duration": 23.064259,
+     "end_time": "2026-06-05T06:09:27.757621",
      "exception": false,
-     "start_time": "2026-04-25T15:01:31.131907",
+     "start_time": "2026-06-05T06:09:04.693362",
      "status": "completed"
     },
     "tags": []
@@ -1307,7 +1331,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK, 36 vides, 1.34s\n",
+      "  Puzzle 1: OK, 36 vides, 1.13s\n",
       "Tentative 1/5\n",
       "  Epoch 0, Best error: 29\n"
      ]
@@ -1323,19 +1347,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 2: OK, 49 vides, 28.88s\n",
+      "  Puzzle 2: OK, 49 vides, 21.91s\n",
       "\n",
       "Resume:\n",
       "  Resolus: 2/2\n",
-      "  Temps total: 30.22s\n",
-      "  Temps moyen: 15.11s\n"
+      "  Temps total: 23.04s\n",
+      "  Temps moyen: 11.52s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'solved': True, 'errors': 0, 'time': 1.3386695384979248},\n",
-       " {'solved': True, 'errors': 0, 'time': 28.876943588256836}]"
+       "[{'solved': True, 'errors': 0, 'time': 1.1262714862823486},\n",
+       " {'solved': True, 'errors': 0, 'time': 21.912666082382202}]"
       ]
      },
      "execution_count": 10,
@@ -1390,10 +1414,10 @@
    "id": "437ee5ea",
    "metadata": {
     "papermill": {
-     "duration": 0.004666,
-     "end_time": "2026-04-25T15:02:01.482099",
+     "duration": 0.006185,
+     "end_time": "2026-06-05T06:09:27.769368",
      "exception": false,
-     "start_time": "2026-04-25T15:02:01.477433",
+     "start_time": "2026-06-05T06:09:27.763183",
      "status": "completed"
     },
     "tags": []
@@ -1425,7 +1449,16 @@
   {
    "cell_type": "markdown",
    "id": "ex-pso-convergence",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006014,
+     "end_time": "2026-06-05T06:09:27.780750",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:27.774736",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice : Detection de convergence\n",
     "\n",
@@ -1448,7 +1481,22 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "ex-pso-convergence-code",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:09:27.793244Z",
+     "iopub.status.busy": "2026-06-05T06:09:27.792244Z",
+     "iopub.status.idle": "2026-06-05T06:09:27.800260Z",
+     "shell.execute_reply": "2026-06-05T06:09:27.800260Z"
+    },
+    "papermill": {
+     "duration": 0.01603,
+     "end_time": "2026-06-05T06:09:27.801768",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:27.785738",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1486,10 +1534,10 @@
    "id": "1afbd0e5",
    "metadata": {
     "papermill": {
-     "duration": 0.004865,
-     "end_time": "2026-04-25T15:02:01.491907",
+     "duration": 0.004998,
+     "end_time": "2026-06-05T06:09:27.813281",
      "exception": false,
-     "start_time": "2026-04-25T15:02:01.487042",
+     "start_time": "2026-06-05T06:09:27.808283",
      "status": "completed"
     },
     "tags": []
@@ -1505,16 +1553,16 @@
    "id": "5487473c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:01.503315Z",
-     "iopub.status.busy": "2026-04-25T15:02:01.502734Z",
-     "iopub.status.idle": "2026-04-25T15:02:07.134857Z",
-     "shell.execute_reply": "2026-04-25T15:02:07.134014Z"
+     "iopub.execute_input": "2026-06-05T06:09:27.828549Z",
+     "iopub.status.busy": "2026-06-05T06:09:27.828549Z",
+     "iopub.status.idle": "2026-06-05T06:09:32.050217Z",
+     "shell.execute_reply": "2026-06-05T06:09:32.050217Z"
     },
     "papermill": {
-     "duration": 5.639345,
-     "end_time": "2026-04-25T15:02:07.135966",
+     "duration": 4.231733,
+     "end_time": "2026-06-05T06:09:32.051167",
      "exception": false,
-     "start_time": "2026-04-25T15:02:01.496621",
+     "start_time": "2026-06-05T06:09:27.819434",
      "status": "completed"
     },
     "tags": []
@@ -1533,7 +1581,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Conservateur: 1.13s - Succes\n",
+      "Conservateur: 0.82s - Succes\n",
       "Tentative 1/10\n",
       "  Epoch 0, Best error: 23\n"
      ]
@@ -1542,7 +1590,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Standard: 1.96s - Succes\n",
+      "Standard: 1.50s - Succes\n",
       "Tentative 1/20\n",
       "  Epoch 0, Best error: 21\n"
      ]
@@ -1551,7 +1599,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Agressif: 2.42s - Succes\n"
+      "Agressif: 1.90s - Succes\n"
      ]
     }
    ],
@@ -1586,10 +1634,10 @@
    "id": "df657b25",
    "metadata": {
     "papermill": {
-     "duration": 0.004703,
-     "end_time": "2026-04-25T15:02:07.145860",
+     "duration": 0.005017,
+     "end_time": "2026-06-05T06:09:32.062182",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.141157",
+     "start_time": "2026-06-05T06:09:32.057165",
      "status": "completed"
     },
     "tags": []
@@ -1616,16 +1664,118 @@
   {
    "cell_type": "markdown",
    "id": "1a7665c0",
-   "source": "## Exercice : Ratio workers/explorers adaptatif\n\n### Contexte\nDans le solveur PSO, le parametre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.\n\nOr, les besoins en exploration vs exploitation changent au cours de la resolution :\n- **Debut** : Il faut beaucoup d'exploration pour couvrir l'espace de recherche\n- **Milieu** : Un equilibre entre exploration et exploitation\n- **Fin** : L'exploitation domine pour affiner la meilleure solution\n\n### Objectif\nImplementez la fonction `adaptive_worker_ratio` qui calcule dynamiquement le ratio workers/explorers en fonction de la progression de l'erreur.\n\n### Resultats attendus\n\n| Situation | current_error | initial_error | worker_ratio attendu |\n|-----------|---------------|---------------|---------------------|\n| Debut (0% progres) | 20 | 20 | 0.700 |\n| Mi-parcours (50%) | 10 | 20 | 0.825 |\n| Pres du but (90%) | 2 | 20 | 0.925 |\n| Erreur nulle (100%) | 0 | 20 | 0.950 |\n\n### Indice\nLa formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le resultat.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.004999,
+     "end_time": "2026-06-05T06:09:32.073191",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:32.068192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Ratio workers/explorers adaptatif\n",
+    "\n",
+    "### Contexte\n",
+    "Dans le solveur PSO, le parametre `worker_ratio` fixe la proportion de workers (exploitation) par rapport aux explorers (exploration). Une valeur statique de 0.90 signifie 90% de workers et 10% d'explorers, independamment de la progression de la recherche.\n",
+    "\n",
+    "Or, les besoins en exploration vs exploitation changent au cours de la resolution :\n",
+    "- **Debut** : Il faut beaucoup d'exploration pour couvrir l'espace de recherche\n",
+    "- **Milieu** : Un equilibre entre exploration et exploitation\n",
+    "- **Fin** : L'exploitation domine pour affiner la meilleure solution\n",
+    "\n",
+    "### Objectif\n",
+    "Implementez la fonction `adaptive_worker_ratio` qui calcule dynamiquement le ratio workers/explorers en fonction de la progression de l'erreur.\n",
+    "\n",
+    "### Resultats attendus\n",
+    "\n",
+    "| Situation | current_error | initial_error | worker_ratio attendu |\n",
+    "|-----------|---------------|---------------|---------------------|\n",
+    "| Debut (0% progres) | 20 | 20 | 0.700 |\n",
+    "| Mi-parcours (50%) | 10 | 20 | 0.825 |\n",
+    "| Pres du but (90%) | 2 | 20 | 0.925 |\n",
+    "| Erreur nulle (100%) | 0 | 20 | 0.950 |\n",
+    "\n",
+    "### Indice\n",
+    "La formule est un interpolation lineaire : plus l'erreur baisse (bonne progression), plus on augmente le ratio de workers. Utilisez `max()` et `min()` pour borner le resultat."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "id": "0b6c97d8",
-   "source": "def adaptive_worker_ratio(current_error: int, initial_error: int, \n                          min_ratio: float = 0.70, max_ratio: float = 0.95) -> float:\n    \"\"\"Calcule un worker_ratio adaptatif en fonction de la progression.\n\n    Quand l'erreur baisse (bonne exploitation), on augmente le ratio de workers.\n    Quand l'erreur stagne ou remonte, on augmente les explorers.\n\n    Args:\n        current_error: Erreur actuelle de la meilleure solution\n        initial_error: Erreur a l'initialisation de l'essaim\n        min_ratio: Ratio minimum d'explorers (exploration renforcee)\n        max_ratio: Ratio maximum de workers (exploitation renforcee)\n\n    Returns:\n        Worker_ratio adapte entre min_ratio et max_ratio\n    \"\"\"\n    # Etape 1 : Calculer le taux de progression (0.0 a 1.0)\n    # Indice : progression = 1.0 - (current_error / initial_error)\n    # Attention au cas ou initial_error == 0\n    \n    # Etape 2 : Calculer le ratio lineairement entre min_ratio et max_ratio\n    # Indice : ratio = min_ratio + progression * (max_ratio - min_ratio)\n    \n    # Etape 3 : Retourner le ratio clamp entre min_ratio et max_ratio\n    return 0.90  # TODO etudiant : remplacer par le calcul adaptatif\n\n\n# Tests pour verifier votre implementation\n# Test 1 : Erreur initiale -> ratio par defaut (peu de progression)\nratio_start = adaptive_worker_ratio(current_error=20, initial_error=20)\nprint(f\"Debut (erreur 20/20) : worker_ratio = {ratio_start:.3f}\")\n\n# Test 2 : Mi-parcours -> ratio intermediaire\nratio_mid = adaptive_worker_ratio(current_error=10, initial_error=20)\nprint(f\"Mi-parcours (erreur 10/20) : worker_ratio = {ratio_mid:.3f}\")\n\n# Test 3 : Pres de la solution -> beaucoup de workers (exploitation)\nratio_end = adaptive_worker_ratio(current_error=2, initial_error=20)\nprint(f\"Pres de la solution (erreur 2/20) : worker_ratio = {ratio_end:.3f}\")\n\nprint(\"Exercice adaptive_worker_ratio a completer\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:09:32.086711Z",
+     "iopub.status.busy": "2026-06-05T06:09:32.086711Z",
+     "iopub.status.idle": "2026-06-05T06:09:32.097710Z",
+     "shell.execute_reply": "2026-06-05T06:09:32.097710Z"
+    },
+    "papermill": {
+     "duration": 0.020516,
+     "end_time": "2026-06-05T06:09:32.099218",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:32.078702",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Debut (erreur 20/20) : worker_ratio = 0.900\n",
+      "Mi-parcours (erreur 10/20) : worker_ratio = 0.900\n",
+      "Pres de la solution (erreur 2/20) : worker_ratio = 0.900\n",
+      "Exercice adaptive_worker_ratio a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def adaptive_worker_ratio(current_error: int, initial_error: int, \n",
+    "                          min_ratio: float = 0.70, max_ratio: float = 0.95) -> float:\n",
+    "    \"\"\"Calcule un worker_ratio adaptatif en fonction de la progression.\n",
+    "\n",
+    "    Quand l'erreur baisse (bonne exploitation), on augmente le ratio de workers.\n",
+    "    Quand l'erreur stagne ou remonte, on augmente les explorers.\n",
+    "\n",
+    "    Args:\n",
+    "        current_error: Erreur actuelle de la meilleure solution\n",
+    "        initial_error: Erreur a l'initialisation de l'essaim\n",
+    "        min_ratio: Ratio minimum d'explorers (exploration renforcee)\n",
+    "        max_ratio: Ratio maximum de workers (exploitation renforcee)\n",
+    "\n",
+    "    Returns:\n",
+    "        Worker_ratio adapte entre min_ratio et max_ratio\n",
+    "    \"\"\"\n",
+    "    # Etape 1 : Calculer le taux de progression (0.0 a 1.0)\n",
+    "    # Indice : progression = 1.0 - (current_error / initial_error)\n",
+    "    # Attention au cas ou initial_error == 0\n",
+    "    \n",
+    "    # Etape 2 : Calculer le ratio lineairement entre min_ratio et max_ratio\n",
+    "    # Indice : ratio = min_ratio + progression * (max_ratio - min_ratio)\n",
+    "    \n",
+    "    # Etape 3 : Retourner le ratio clamp entre min_ratio et max_ratio\n",
+    "    return 0.90  # TODO etudiant : remplacer par le calcul adaptatif\n",
+    "\n",
+    "\n",
+    "# Tests pour verifier votre implementation\n",
+    "# Test 1 : Erreur initiale -> ratio par defaut (peu de progression)\n",
+    "ratio_start = adaptive_worker_ratio(current_error=20, initial_error=20)\n",
+    "print(f\"Debut (erreur 20/20) : worker_ratio = {ratio_start:.3f}\")\n",
+    "\n",
+    "# Test 2 : Mi-parcours -> ratio intermediaire\n",
+    "ratio_mid = adaptive_worker_ratio(current_error=10, initial_error=20)\n",
+    "print(f\"Mi-parcours (erreur 10/20) : worker_ratio = {ratio_mid:.3f}\")\n",
+    "\n",
+    "# Test 3 : Pres de la solution -> beaucoup de workers (exploitation)\n",
+    "ratio_end = adaptive_worker_ratio(current_error=2, initial_error=20)\n",
+    "print(f\"Pres de la solution (erreur 2/20) : worker_ratio = {ratio_end:.3f}\")\n",
+    "\n",
+    "print(\"Exercice adaptive_worker_ratio a completer\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1633,10 +1783,10 @@
    "id": "b5cd6e6c",
    "metadata": {
     "papermill": {
-     "duration": 0.004517,
-     "end_time": "2026-04-25T15:02:07.154956",
+     "duration": 0.006001,
+     "end_time": "2026-06-05T06:09:32.110738",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.150439",
+     "start_time": "2026-06-05T06:09:32.104737",
      "status": "completed"
     },
     "tags": []
@@ -1648,20 +1798,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "b879f289",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:07.165079Z",
-     "iopub.status.busy": "2026-04-25T15:02:07.164764Z",
-     "iopub.status.idle": "2026-04-25T15:02:07.169009Z",
-     "shell.execute_reply": "2026-04-25T15:02:07.168425Z"
+     "iopub.execute_input": "2026-06-05T06:09:32.122247Z",
+     "iopub.status.busy": "2026-06-05T06:09:32.122247Z",
+     "iopub.status.idle": "2026-06-05T06:09:32.129375Z",
+     "shell.execute_reply": "2026-06-05T06:09:32.129375Z"
     },
     "papermill": {
-     "duration": 0.010598,
-     "end_time": "2026-04-25T15:02:07.170059",
+     "duration": 0.014129,
+     "end_time": "2026-06-05T06:09:32.130376",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.159461",
+     "start_time": "2026-06-05T06:09:32.116247",
      "status": "completed"
     },
     "tags": []
@@ -1702,10 +1852,10 @@
    "id": "b243d8f0",
    "metadata": {
     "papermill": {
-     "duration": 0.004894,
-     "end_time": "2026-04-25T15:02:07.182034",
+     "duration": 0.005015,
+     "end_time": "2026-06-05T06:09:32.140898",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.177140",
+     "start_time": "2026-06-05T06:09:32.135883",
      "status": "completed"
     },
     "tags": []
@@ -1737,10 +1887,10 @@
    "id": "bf6de260",
    "metadata": {
     "papermill": {
-     "duration": 0.004537,
-     "end_time": "2026-04-25T15:02:07.191084",
+     "duration": 0.005,
+     "end_time": "2026-06-05T06:09:32.151882",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.186547",
+     "start_time": "2026-06-05T06:09:32.146882",
      "status": "completed"
     },
     "tags": []
@@ -1764,10 +1914,10 @@
    "id": "uci1dzfatl",
    "metadata": {
     "papermill": {
-     "duration": 0.004608,
-     "end_time": "2026-04-25T15:02:07.200438",
+     "duration": 0.005036,
+     "end_time": "2026-06-05T06:09:32.162918",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.195830",
+     "start_time": "2026-06-05T06:09:32.157882",
      "status": "completed"
     },
     "tags": []
@@ -1793,20 +1943,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "wys24hodpo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-25T15:02:07.212497Z",
-     "iopub.status.busy": "2026-04-25T15:02:07.212074Z",
-     "iopub.status.idle": "2026-04-25T15:02:07.218127Z",
-     "shell.execute_reply": "2026-04-25T15:02:07.217489Z"
+     "iopub.execute_input": "2026-06-05T06:09:32.175381Z",
+     "iopub.status.busy": "2026-06-05T06:09:32.175381Z",
+     "iopub.status.idle": "2026-06-05T06:09:32.192019Z",
+     "shell.execute_reply": "2026-06-05T06:09:32.192019Z"
     },
     "papermill": {
-     "duration": 0.013913,
-     "end_time": "2026-04-25T15:02:07.219308",
+     "duration": 0.024645,
+     "end_time": "2026-06-05T06:09:32.193528",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.205395",
+     "start_time": "2026-06-05T06:09:32.168883",
      "status": "completed"
     },
     "tags": []
@@ -1886,8 +2036,25 @@
   {
    "cell_type": "markdown",
    "id": "c6f15b91",
-   "source": "## Resume et perspectives\n\nCe notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double role (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : de 1 seconde pour les puzzles chanceux a plus de 30 secondes pour les cas defavorables, avec un taux de succes de 80% sur les puzzles faciles. La stagnation frequente a erreur=2 illustre la difficulte des metaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.\n\nL'analyse des parametres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration \"Conservatrice\" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration \"Agressive\" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise precisement a resoudre le probleme de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.\n\nLe notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche deterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00562,
+     "end_time": "2026-06-05T06:09:32.204812",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:32.199192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Resume et perspectives\n",
+    "\n",
+    "Ce notebook a implemente le Particle Swarm Optimization (PSO) pour la resolution de Sudoku, avec un encodage par blocs 3x3 qui garantit la validite locale de chaque bloc. L'architecture a double role (Workers pour l'exploitation locale, Explorers pour l'exploration globale) offre un equilibre entre convergence et diversification. Les benchmarks ont montre une grande variabilite : de 1 seconde pour les puzzles chanceux a plus de 30 secondes pour les cas defavorables, avec un taux de succes de 80% sur les puzzles faciles. La stagnation frequente a erreur=2 illustre la difficulte des metaheuristiques a echapper aux optima locaux sur les problemes fortement contraints.\n",
+    "\n",
+    "L'analyse des parametres (taille de l'essaim, nombre d'epochs, redemarrages) a montre que la configuration \"Conservatrice\" suffit souvent pour les puzzles faciles, tandis que les puzzles difficiles necessitent une configuration \"Agressive\" avec un cout temporel significatif. L'exercice propose sur le PSO hybride avec recherche locale vise precisement a resoudre le probleme de stagnation en combinant l'exploration globale de l'essaim avec une descente de gradient locale.\n",
+    "\n",
+    "Le notebook suivant, [Sudoku-6-AIMA-CSP-Python](Sudoku-6-AIMA-CSP-Python.ipynb), aborde une approche deterministe : la programmation par contraintes (CSP) selon le cadre academique AIMA, avec les algorithmes AC-3, Forward Checking et MAC qui garantissent la resolution complete."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1895,10 +2062,10 @@
    "id": "66458d28",
    "metadata": {
     "papermill": {
-     "duration": 0.005571,
-     "end_time": "2026-04-25T15:02:07.230202",
+     "duration": 0.006632,
+     "end_time": "2026-06-05T06:09:32.216654",
      "exception": false,
-     "start_time": "2026-04-25T15:02:07.224631",
+     "start_time": "2026-06-05T06:09:32.210022",
      "status": "completed"
     },
     "tags": []
@@ -1969,18 +2136,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 48.922268,
-   "end_time": "2026-04-25T15:02:07.687107",
+   "duration": 31.858481,
+   "end_time": "2026-06-05T06:09:32.457700",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-5-PSO-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-04-25T15:01:18.764839",
+   "start_time": "2026-06-05T06:09:00.599219",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "71960cdb",
    "metadata": {
     "papermill": {
-     "duration": 0.00426,
-     "end_time": "2026-06-02T16:29:05.826639+00:00",
+     "duration": 0.028643,
+     "end_time": "2026-06-05T06:09:53.584017",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.822379+00:00",
+     "start_time": "2026-06-05T06:09:53.555374",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +68,16 @@
    "id": "537fe538",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:05.836214Z",
-     "iopub.status.busy": "2026-06-02T16:29:05.836039Z",
-     "iopub.status.idle": "2026-06-02T16:29:05.915376Z",
-     "shell.execute_reply": "2026-06-02T16:29:05.914730Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.617553Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.617553Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.692929Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.691913Z"
     },
     "papermill": {
-     "duration": 0.083733,
-     "end_time": "2026-06-02T16:29:05.916232+00:00",
+     "duration": 0.086393,
+     "end_time": "2026-06-05T06:09:53.693940",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.832499+00:00",
+     "start_time": "2026-06-05T06:09:53.607547",
      "status": "completed"
     },
     "tags": []
@@ -108,10 +108,10 @@
    "id": "dbb0a1df",
    "metadata": {
     "papermill": {
-     "duration": 0.005104,
-     "end_time": "2026-06-02T16:29:05.924880+00:00",
+     "duration": 0.004,
+     "end_time": "2026-06-05T06:09:53.702928",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.919776+00:00",
+     "start_time": "2026-06-05T06:09:53.698928",
      "status": "completed"
     },
     "tags": []
@@ -126,16 +126,16 @@
    "id": "0044c653",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:05.933146Z",
-     "iopub.status.busy": "2026-06-02T16:29:05.932845Z",
-     "iopub.status.idle": "2026-06-02T16:29:05.936430Z",
-     "shell.execute_reply": "2026-06-02T16:29:05.935970Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.712929Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.712929Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.722230Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.722230Z"
     },
     "papermill": {
-     "duration": 0.008362,
-     "end_time": "2026-06-02T16:29:05.936891+00:00",
+     "duration": 0.015711,
+     "end_time": "2026-06-05T06:09:53.723638",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.928529+00:00",
+     "start_time": "2026-06-05T06:09:53.707927",
      "status": "completed"
     },
     "tags": []
@@ -145,7 +145,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ATTENTION: Dossier Puzzles non trouve\n"
+      "Dossier Puzzles: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Puzzles\n"
      ]
     }
    ],
@@ -169,10 +169,10 @@
    "id": "fa502dad",
    "metadata": {
     "papermill": {
-     "duration": 0.002667,
-     "end_time": "2026-06-02T16:29:05.942343+00:00",
+     "duration": 0.004252,
+     "end_time": "2026-06-05T06:09:53.731975",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.939676+00:00",
+     "start_time": "2026-06-05T06:09:53.727723",
      "status": "completed"
     },
     "tags": []
@@ -187,16 +187,16 @@
    "id": "3fcb945a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:05.950050Z",
-     "iopub.status.busy": "2026-06-02T16:29:05.949874Z",
-     "iopub.status.idle": "2026-06-02T16:29:05.964063Z",
-     "shell.execute_reply": "2026-06-02T16:29:05.963586Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.744426Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.744426Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.769695Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.768692Z"
     },
     "papermill": {
-     "duration": 0.019803,
-     "end_time": "2026-06-02T16:29:05.964646+00:00",
+     "duration": 0.033409,
+     "end_time": "2026-06-05T06:09:53.771201",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.944843+00:00",
+     "start_time": "2026-06-05T06:09:53.737792",
      "status": "completed"
     },
     "tags": []
@@ -315,10 +315,10 @@
    "id": "708f3cdf",
    "metadata": {
     "papermill": {
-     "duration": 0.002888,
-     "end_time": "2026-06-02T16:29:05.970340+00:00",
+     "duration": 0.005017,
+     "end_time": "2026-06-05T06:09:53.782734",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.967452+00:00",
+     "start_time": "2026-06-05T06:09:53.777717",
      "status": "completed"
     },
     "tags": []
@@ -349,10 +349,10 @@
    "id": "52ee651d",
    "metadata": {
     "papermill": {
-     "duration": 0.002775,
-     "end_time": "2026-06-02T16:29:05.975838+00:00",
+     "duration": 0.005,
+     "end_time": "2026-06-05T06:09:53.792241",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.973063+00:00",
+     "start_time": "2026-06-05T06:09:53.787241",
      "status": "completed"
     },
     "tags": []
@@ -386,16 +386,16 @@
    "id": "0b5a7b4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:05.982046Z",
-     "iopub.status.busy": "2026-06-02T16:29:05.981813Z",
-     "iopub.status.idle": "2026-06-02T16:29:05.985554Z",
-     "shell.execute_reply": "2026-06-02T16:29:05.985125Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.806243Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.805241Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.817231Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.815986Z"
     },
     "papermill": {
-     "duration": 0.007689,
-     "end_time": "2026-06-02T16:29:05.986063+00:00",
+     "duration": 0.019984,
+     "end_time": "2026-06-05T06:09:53.818240",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.978374+00:00",
+     "start_time": "2026-06-05T06:09:53.798256",
      "status": "completed"
     },
     "tags": []
@@ -442,10 +442,10 @@
    "id": "6c9459a6",
    "metadata": {
     "papermill": {
-     "duration": 0.002764,
-     "end_time": "2026-06-02T16:29:05.991477+00:00",
+     "duration": 0.006509,
+     "end_time": "2026-06-05T06:09:53.831848",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.988713+00:00",
+     "start_time": "2026-06-05T06:09:53.825339",
      "status": "completed"
     },
     "tags": []
@@ -462,16 +462,16 @@
    "id": "8a6136dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:05.998948Z",
-     "iopub.status.busy": "2026-06-02T16:29:05.998759Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.004768Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.004121Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.841903Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.840902Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.863504Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.862502Z"
     },
     "papermill": {
-     "duration": 0.010567,
-     "end_time": "2026-06-02T16:29:06.005577+00:00",
+     "duration": 0.027603,
+     "end_time": "2026-06-05T06:09:53.864505",
      "exception": false,
-     "start_time": "2026-06-02T16:29:05.995010+00:00",
+     "start_time": "2026-06-05T06:09:53.836902",
      "status": "completed"
     },
     "tags": []
@@ -536,10 +536,10 @@
    "id": "0184debd",
    "metadata": {
     "papermill": {
-     "duration": 0.002978,
-     "end_time": "2026-06-02T16:29:06.012116+00:00",
+     "duration": 0.004548,
+     "end_time": "2026-06-05T06:09:53.876050",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.009138+00:00",
+     "start_time": "2026-06-05T06:09:53.871502",
      "status": "completed"
     },
     "tags": []
@@ -559,16 +559,16 @@
    "id": "13e41d53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.018721Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.018562Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.024287Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.023749Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.887895Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.887895Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.910923Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.908919Z"
     },
     "papermill": {
-     "duration": 0.009843,
-     "end_time": "2026-06-02T16:29:06.024847+00:00",
+     "duration": 0.032036,
+     "end_time": "2026-06-05T06:09:53.912292",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.015004+00:00",
+     "start_time": "2026-06-05T06:09:53.880256",
      "status": "completed"
     },
     "tags": []
@@ -648,10 +648,10 @@
    "id": "58ad5d46",
    "metadata": {
     "papermill": {
-     "duration": 0.003197,
-     "end_time": "2026-06-02T16:29:06.030846+00:00",
+     "duration": 0.005011,
+     "end_time": "2026-06-05T06:09:53.922322",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.027649+00:00",
+     "start_time": "2026-06-05T06:09:53.917311",
      "status": "completed"
     },
     "tags": []
@@ -666,16 +666,16 @@
    "id": "5c5d6393",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.039426Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.039156Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.043441Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.042804Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.932301Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.932301Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.940257Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.939800Z"
     },
     "papermill": {
-     "duration": 0.010214,
-     "end_time": "2026-06-02T16:29:06.044006+00:00",
+     "duration": 0.012956,
+     "end_time": "2026-06-05T06:09:53.940257",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.033792+00:00",
+     "start_time": "2026-06-05T06:09:53.927301",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +726,10 @@
    "id": "96136f46",
    "metadata": {
     "papermill": {
-     "duration": 0.003156,
-     "end_time": "2026-06-02T16:29:06.050108+00:00",
+     "duration": 0.005039,
+     "end_time": "2026-06-05T06:09:53.951361",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.046952+00:00",
+     "start_time": "2026-06-05T06:09:53.946322",
      "status": "completed"
     },
     "tags": []
@@ -750,16 +750,16 @@
    "id": "d536dc0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.059355Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.059083Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.064277Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.063748Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.961995Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.961995Z",
+     "iopub.status.idle": "2026-06-05T06:09:53.971149Z",
+     "shell.execute_reply": "2026-06-05T06:09:53.971149Z"
     },
     "papermill": {
-     "duration": 0.010693,
-     "end_time": "2026-06-02T16:29:06.064832+00:00",
+     "duration": 0.01679,
+     "end_time": "2026-06-05T06:09:53.972752",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.054139+00:00",
+     "start_time": "2026-06-05T06:09:53.955962",
      "status": "completed"
     },
     "tags": []
@@ -825,10 +825,10 @@
    "id": "a99e1efc",
    "metadata": {
     "papermill": {
-     "duration": 0.003614,
-     "end_time": "2026-06-02T16:29:06.071353+00:00",
+     "duration": 0.004101,
+     "end_time": "2026-06-05T06:09:53.982573",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.067739+00:00",
+     "start_time": "2026-06-05T06:09:53.978472",
      "status": "completed"
     },
     "tags": []
@@ -843,16 +843,16 @@
    "id": "38ec4aac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.078145Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.077974Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.082398Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.081917Z"
+     "iopub.execute_input": "2026-06-05T06:09:53.993183Z",
+     "iopub.status.busy": "2026-06-05T06:09:53.993183Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.001585Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.001585Z"
     },
     "papermill": {
-     "duration": 0.0085,
-     "end_time": "2026-06-02T16:29:06.082896+00:00",
+     "duration": 0.015322,
+     "end_time": "2026-06-05T06:09:54.003603",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.074396+00:00",
+     "start_time": "2026-06-05T06:09:53.988281",
      "status": "completed"
     },
     "tags": []
@@ -912,10 +912,10 @@
    "id": "07fc6430",
    "metadata": {
     "papermill": {
-     "duration": 0.002669,
-     "end_time": "2026-06-02T16:29:06.088449+00:00",
+     "duration": 0.006096,
+     "end_time": "2026-06-05T06:09:54.015694",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.085780+00:00",
+     "start_time": "2026-06-05T06:09:54.009598",
      "status": "completed"
     },
     "tags": []
@@ -932,16 +932,16 @@
    "id": "9f95b034",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.094688Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.094541Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.100666Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.100001Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.028746Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.028746Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.050350Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.049445Z"
     },
     "papermill": {
-     "duration": 0.010024,
-     "end_time": "2026-06-02T16:29:06.101138+00:00",
+     "duration": 0.030589,
+     "end_time": "2026-06-05T06:09:54.052335",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.091114+00:00",
+     "start_time": "2026-06-05T06:09:54.021746",
      "status": "completed"
     },
     "tags": []
@@ -1031,26 +1031,103 @@
   {
    "cell_type": "markdown",
    "id": "728b8070",
-   "source": "## Exercice : Analyse pas-a-pas de la propagation Forward Checking\n\n### Objectif\n\nImplementez la fonction `analyze_fc_propagation` qui simule et affiche les etapes de reduction de domaine lorsqu'on assigne une valeur a une cellule donnee, en suivant le mecanisme du Forward Checking.\n\nCet exercice vous permettra de visualiser concretement comment le Forward Checking elague l'espace de recherche : a chaque assignation, les domaines des voisins sont reduits, et les domaines vides signalent un echec precoce.\n\n### Etapes\n\n1. **Construire** le CSP a partir de la grille et copier les domaines\n2. **Choisir** une cellule et une valeur (par exemple `(0, 1)` avec la valeur `6`)\n3. **Appliquer** `ForwardChecking.propagate()` pour obtenir les valeurs eliminees\n4. **Afficher** pour chaque voisin affecte : les valeurs retirees et la taille du domaine restant\n5. **Detecter** si la propagation a provoque un domaine vide (echec)\n\n### Indices\n\n- `ForwardChecking.propagate(csp, var, val, assignment, current_domains)` retourne `(removals, success)`\n- `removals` est une liste de tuples `(neighbor, value_retiree)`\n- Utilisez `defaultdict(list)` pour regrouper les retraits par voisin\n- Comparez la taille des domaines avant et apres propagation pour mesurer l'impact",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.00501,
+     "end_time": "2026-06-05T06:09:54.064344",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:54.059334",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice : Analyse pas-a-pas de la propagation Forward Checking\n",
+    "\n",
+    "### Objectif\n",
+    "\n",
+    "Implementez la fonction `analyze_fc_propagation` qui simule et affiche les etapes de reduction de domaine lorsqu'on assigne une valeur a une cellule donnee, en suivant le mecanisme du Forward Checking.\n",
+    "\n",
+    "Cet exercice vous permettra de visualiser concretement comment le Forward Checking elague l'espace de recherche : a chaque assignation, les domaines des voisins sont reduits, et les domaines vides signalent un echec precoce.\n",
+    "\n",
+    "### Etapes\n",
+    "\n",
+    "1. **Construire** le CSP a partir de la grille et copier les domaines\n",
+    "2. **Choisir** une cellule et une valeur (par exemple `(0, 1)` avec la valeur `6`)\n",
+    "3. **Appliquer** `ForwardChecking.propagate()` pour obtenir les valeurs eliminees\n",
+    "4. **Afficher** pour chaque voisin affecte : les valeurs retirees et la taille du domaine restant\n",
+    "5. **Detecter** si la propagation a provoque un domaine vide (echec)\n",
+    "\n",
+    "### Indices\n",
+    "\n",
+    "- `ForwardChecking.propagate(csp, var, val, assignment, current_domains)` retourne `(removals, success)`\n",
+    "- `removals` est une liste de tuples `(neighbor, value_retiree)`\n",
+    "- Utilisez `defaultdict(list)` pour regrouper les retraits par voisin\n",
+    "- Comparez la taille des domaines avant et apres propagation pour mesurer l'impact"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "901f7da3",
-   "source": "def analyze_fc_propagation(grid: SudokuGrid, var: Tuple[int, int], val: int) -> None:\n    \"\"\"Analyse et affiche la reduction de domaine par Forward Checking.\n    \n    Args:\n        grid: Grille de Sudoku\n        var: Variable (cellule) a assigner, sous forme (row, col)\n        val: Valeur a assigner\n    \"\"\"\n    # TODO etudiant : implementer l'analyse de propagation FC\n    # Etape 1 : construire le CSP avec SudokuCSPBuilder.build_csp(grid)\n    # Etape 2 : copier les domaines avec csp.copy_domains()\n    # Etape 3 : compter les valeurs de domaine avant propagation\n    # Etape 4 : appeler ForwardChecking.propagate(csp, var, val, {}, current_domains)\n    # Etape 5 : regrouper les retraits par voisin et afficher le detail\n    # Indice : defaultdict(list) pour grouper les (neighbor, val_retiree) par voisin\n    print(\"Exercice a completer\")\n\n\n# Test sur la grille de reference\ntest_grid_fc = SudokuGrid.from_string(easy_puzzles[0])\nanalyze_fc_propagation(test_grid_fc, (0, 1), 6)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-05T06:09:54.074344Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.074344Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.080874Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.080874Z"
+    },
+    "papermill": {
+     "duration": 0.013538,
+     "end_time": "2026-06-05T06:09:54.082883",
+     "exception": false,
+     "start_time": "2026-06-05T06:09:54.069345",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
+   "source": [
+    "def analyze_fc_propagation(grid: SudokuGrid, var: Tuple[int, int], val: int) -> None:\n",
+    "    \"\"\"Analyse et affiche la reduction de domaine par Forward Checking.\n",
+    "    \n",
+    "    Args:\n",
+    "        grid: Grille de Sudoku\n",
+    "        var: Variable (cellule) a assigner, sous forme (row, col)\n",
+    "        val: Valeur a assigner\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant : implementer l'analyse de propagation FC\n",
+    "    # Etape 1 : construire le CSP avec SudokuCSPBuilder.build_csp(grid)\n",
+    "    # Etape 2 : copier les domaines avec csp.copy_domains()\n",
+    "    # Etape 3 : compter les valeurs de domaine avant propagation\n",
+    "    # Etape 4 : appeler ForwardChecking.propagate(csp, var, val, {}, current_domains)\n",
+    "    # Etape 5 : regrouper les retraits par voisin et afficher le detail\n",
+    "    # Indice : defaultdict(list) pour grouper les (neighbor, val_retiree) par voisin\n",
+    "    print(\"Exercice a completer\")\n",
+    "\n",
+    "\n",
+    "# Test sur la grille de reference\n",
+    "test_grid_fc = SudokuGrid.from_string(easy_puzzles[0])\n",
+    "analyze_fc_propagation(test_grid_fc, (0, 1), 6)"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6711928f",
    "metadata": {
     "papermill": {
-     "duration": 0.002613,
-     "end_time": "2026-06-02T16:29:06.106747+00:00",
+     "duration": 0.004985,
+     "end_time": "2026-06-05T06:09:54.092411",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.104134+00:00",
+     "start_time": "2026-06-05T06:09:54.087426",
      "status": "completed"
     },
     "tags": []
@@ -1063,20 +1140,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ade78048",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.113116Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.112975Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.118183Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.117580Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.101952Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.101952Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.112479Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.112479Z"
     },
     "papermill": {
-     "duration": 0.009096,
-     "end_time": "2026-06-02T16:29:06.118631+00:00",
+     "duration": 0.016497,
+     "end_time": "2026-06-05T06:09:54.113464",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.109535+00:00",
+     "start_time": "2026-06-05T06:09:54.096967",
      "status": "completed"
     },
     "tags": []
@@ -1155,10 +1232,10 @@
    "id": "d58e63d9",
    "metadata": {
     "papermill": {
-     "duration": 0.002773,
-     "end_time": "2026-06-02T16:29:06.124243+00:00",
+     "duration": 0.004099,
+     "end_time": "2026-06-05T06:09:54.123274",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.121470+00:00",
+     "start_time": "2026-06-05T06:09:54.119175",
      "status": "completed"
     },
     "tags": []
@@ -1189,20 +1266,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "afd5fa4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.130924Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.130760Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.134250Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.133777Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.133339Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.133339Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.146070Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.143628Z"
     },
     "papermill": {
-     "duration": 0.007521,
-     "end_time": "2026-06-02T16:29:06.134750+00:00",
+     "duration": 0.019253,
+     "end_time": "2026-06-05T06:09:54.147612",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.127229+00:00",
+     "start_time": "2026-06-05T06:09:54.128359",
      "status": "completed"
     },
     "tags": []
@@ -1243,10 +1320,10 @@
    "id": "82aa1e52",
    "metadata": {
     "papermill": {
-     "duration": 0.002981,
-     "end_time": "2026-06-02T16:29:06.140491+00:00",
+     "duration": 0.00774,
+     "end_time": "2026-06-05T06:09:54.168371",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.137510+00:00",
+     "start_time": "2026-06-05T06:09:54.160631",
      "status": "completed"
     },
     "tags": []
@@ -1259,20 +1336,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "bd528b4c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.147903Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.147749Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.152657Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.152200Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.179952Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.179952Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.193245Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.190227Z"
     },
     "papermill": {
-     "duration": 0.00971,
-     "end_time": "2026-06-02T16:29:06.153230+00:00",
+     "duration": 0.023908,
+     "end_time": "2026-06-05T06:09:54.197273",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.143520+00:00",
+     "start_time": "2026-06-05T06:09:54.173365",
      "status": "completed"
     },
     "tags": []
@@ -1340,10 +1417,10 @@
    "id": "9ce278e9",
    "metadata": {
     "papermill": {
-     "duration": 0.002988,
-     "end_time": "2026-06-02T16:29:06.159409+00:00",
+     "duration": 0.006508,
+     "end_time": "2026-06-05T06:09:54.210396",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.156421+00:00",
+     "start_time": "2026-06-05T06:09:54.203888",
      "status": "completed"
     },
     "tags": []
@@ -1354,20 +1431,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "6c19a9e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.166690Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.166552Z",
-     "iopub.status.idle": "2026-06-02T16:29:06.208637Z",
-     "shell.execute_reply": "2026-06-02T16:29:06.207988Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.222397Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.222397Z",
+     "iopub.status.idle": "2026-06-05T06:09:54.284734Z",
+     "shell.execute_reply": "2026-06-05T06:09:54.283920Z"
     },
     "papermill": {
-     "duration": 0.045942,
-     "end_time": "2026-06-02T16:29:06.209170+00:00",
+     "duration": 0.068958,
+     "end_time": "2026-06-05T06:09:54.285377",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.163228+00:00",
+     "start_time": "2026-06-05T06:09:54.216419",
      "status": "completed"
     },
     "tags": []
@@ -1390,7 +1467,7 @@
       "7 . 5 | 2 . . | 3 . 4 \n",
       ". 8 . | . 4 1 | 9 5 . \n",
       "\n",
-      "Solution (MAC): 37.8ms, 81 assignations, 0 backtracks\n",
+      "Solution (MAC): 47.2ms, 81 assignations, 0 backtracks\n",
       "9 6 2 | 1 8 5 | 4 7 3 \n",
       "1 7 4 | 9 6 3 | 8 2 5 \n",
       "5 3 8 | 4 2 7 | 1 6 9 \n",
@@ -1436,10 +1513,10 @@
    "id": "142aefae",
    "metadata": {
     "papermill": {
-     "duration": 0.004269,
-     "end_time": "2026-06-02T16:29:06.216480+00:00",
+     "duration": 0.005848,
+     "end_time": "2026-06-05T06:09:54.296491",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.212211+00:00",
+     "start_time": "2026-06-05T06:09:54.290643",
      "status": "completed"
     },
     "tags": []
@@ -1455,20 +1532,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "ad2f5862",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:06.227200Z",
-     "iopub.status.busy": "2026-06-02T16:29:06.227032Z",
-     "iopub.status.idle": "2026-06-02T16:29:36.582551Z",
-     "shell.execute_reply": "2026-06-02T16:29:36.571835Z"
+     "iopub.execute_input": "2026-06-05T06:09:54.307303Z",
+     "iopub.status.busy": "2026-06-05T06:09:54.307303Z",
+     "iopub.status.idle": "2026-06-05T06:10:05.336915Z",
+     "shell.execute_reply": "2026-06-05T06:10:05.336915Z"
     },
     "papermill": {
-     "duration": 30.371852,
-     "end_time": "2026-06-02T16:29:36.592700+00:00",
+     "duration": 11.036595,
+     "end_time": "2026-06-05T06:10:05.337897",
      "exception": false,
-     "start_time": "2026-06-02T16:29:06.220848+00:00",
+     "start_time": "2026-06-05T06:09:54.301302",
      "status": "completed"
     },
     "tags": []
@@ -1489,28 +1566,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING SIMPLE          2889322       499461        29220 2/2\n"
+      "BACKTRACKING SIMPLE          2889322       499461        10779 2/2\n",
+      "BACKTRACKING MRV LCV             255            0           74 2/2\n",
+      "FORWARD CHECKING                  81            0           51 2/2\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING MRV LCV             255            0          364 2/2\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "FORWARD CHECKING                  81            0          290 2/2\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MAC                               81            0          439 2/2\n",
+      "MAC                               81            0          113 2/2\n",
       "================================================================================\n"
      ]
     }
@@ -1593,10 +1658,10 @@
    "id": "69cef42b",
    "metadata": {
     "papermill": {
-     "duration": 0.044495,
-     "end_time": "2026-06-02T16:29:36.700619+00:00",
+     "duration": 0.005,
+     "end_time": "2026-06-05T06:10:05.348902",
      "exception": false,
-     "start_time": "2026-06-02T16:29:36.656124+00:00",
+     "start_time": "2026-06-05T06:10:05.343902",
      "status": "completed"
     },
     "tags": []
@@ -1622,10 +1687,10 @@
    "id": "e34035b8",
    "metadata": {
     "papermill": {
-     "duration": 0.059786,
-     "end_time": "2026-06-02T16:29:36.809060+00:00",
+     "duration": 0.005011,
+     "end_time": "2026-06-05T06:10:05.358913",
      "exception": false,
-     "start_time": "2026-06-02T16:29:36.749274+00:00",
+     "start_time": "2026-06-05T06:10:05.353902",
      "status": "completed"
     },
     "tags": []
@@ -1655,20 +1720,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "1850070a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:36.912600Z",
-     "iopub.status.busy": "2026-06-02T16:29:36.912030Z",
-     "iopub.status.idle": "2026-06-02T16:29:37.039317Z",
-     "shell.execute_reply": "2026-06-02T16:29:37.033751Z"
+     "iopub.execute_input": "2026-06-05T06:10:05.369918Z",
+     "iopub.status.busy": "2026-06-05T06:10:05.368918Z",
+     "iopub.status.idle": "2026-06-05T06:10:05.417224Z",
+     "shell.execute_reply": "2026-06-05T06:10:05.416408Z"
     },
     "papermill": {
-     "duration": 0.15456,
-     "end_time": "2026-06-02T16:29:37.042155+00:00",
+     "duration": 0.055323,
+     "end_time": "2026-06-05T06:10:05.419241",
      "exception": false,
-     "start_time": "2026-06-02T16:29:36.887595+00:00",
+     "start_time": "2026-06-05T06:10:05.363918",
      "status": "completed"
     },
     "tags": []
@@ -1678,7 +1743,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CBJ (easy): 76ms, 81 assigns, 0 backtracks, valide=True\n",
+      "CBJ (easy): 25ms, 81 assigns, 0 backtracks, valide=True\n",
       "ConflictBackjumping implemente.\n"
      ]
     }
@@ -1801,10 +1866,10 @@
    "id": "e27d2cc2",
    "metadata": {
     "papermill": {
-     "duration": 0.009303,
-     "end_time": "2026-06-02T16:29:37.063693+00:00",
+     "duration": 0.011023,
+     "end_time": "2026-06-05T06:10:05.441487",
      "exception": false,
-     "start_time": "2026-06-02T16:29:37.054390+00:00",
+     "start_time": "2026-06-05T06:10:05.430464",
      "status": "completed"
     },
     "tags": []
@@ -1817,20 +1882,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "85ba2c40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:37.112746Z",
-     "iopub.status.busy": "2026-06-02T16:29:37.111945Z",
-     "iopub.status.idle": "2026-06-02T16:29:38.400481Z",
-     "shell.execute_reply": "2026-06-02T16:29:38.399456Z"
+     "iopub.execute_input": "2026-06-05T06:10:05.458655Z",
+     "iopub.status.busy": "2026-06-05T06:10:05.458655Z",
+     "iopub.status.idle": "2026-06-05T06:10:05.789962Z",
+     "shell.execute_reply": "2026-06-05T06:10:05.788985Z"
     },
     "papermill": {
-     "duration": 1.327296,
-     "end_time": "2026-06-02T16:29:38.401323+00:00",
+     "duration": 0.338414,
+     "end_time": "2026-06-05T06:10:05.789962",
      "exception": false,
-     "start_time": "2026-06-02T16:29:37.074027+00:00",
+     "start_time": "2026-06-05T06:10:05.451548",
      "status": "completed"
     },
     "tags": []
@@ -1850,15 +1915,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BACKTRACKING MRV LCV             366           10          892 3/3\n",
-      "CONFLICT BACK JUMPING             82            1          205 3/3\n"
+      "BACKTRACKING MRV LCV             366           10          133 3/3\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FORWARD CHECKING                  91           10          145 3/3\n",
+      "CONFLICT BACK JUMPING             82            1           89 3/3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FORWARD CHECKING                  91           10           86 3/3\n",
       "================================================================================\n"
      ]
     }
@@ -1930,10 +2001,10 @@
    "id": "69fac6e4",
    "metadata": {
     "papermill": {
-     "duration": 0.009434,
-     "end_time": "2026-06-02T16:29:38.418484+00:00",
+     "duration": 0.004982,
+     "end_time": "2026-06-05T06:10:05.801148",
      "exception": false,
-     "start_time": "2026-06-02T16:29:38.409050+00:00",
+     "start_time": "2026-06-05T06:10:05.796166",
      "status": "completed"
     },
     "tags": []
@@ -1970,20 +2041,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "6452d7ef",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-02T16:29:38.439012Z",
-     "iopub.status.busy": "2026-06-02T16:29:38.438606Z",
-     "iopub.status.idle": "2026-06-02T16:29:38.448336Z",
-     "shell.execute_reply": "2026-06-02T16:29:38.447268Z"
+     "iopub.execute_input": "2026-06-05T06:10:05.812265Z",
+     "iopub.status.busy": "2026-06-05T06:10:05.812265Z",
+     "iopub.status.idle": "2026-06-05T06:10:05.819532Z",
+     "shell.execute_reply": "2026-06-05T06:10:05.819532Z"
     },
     "papermill": {
-     "duration": 0.023848,
-     "end_time": "2026-06-02T16:29:38.449223+00:00",
+     "duration": 0.014575,
+     "end_time": "2026-06-05T06:10:05.820707",
      "exception": false,
-     "start_time": "2026-06-02T16:29:38.425375+00:00",
+     "start_time": "2026-06-05T06:10:05.806132",
      "status": "completed"
     },
     "tags": []
@@ -2078,10 +2149,10 @@
    "id": "888465da",
    "metadata": {
     "papermill": {
-     "duration": 0.01024,
-     "end_time": "2026-06-02T16:29:38.467235+00:00",
+     "duration": 0.00515,
+     "end_time": "2026-06-05T06:10:05.831167",
      "exception": false,
-     "start_time": "2026-06-02T16:29:38.456995+00:00",
+     "start_time": "2026-06-05T06:10:05.826017",
      "status": "completed"
     },
     "tags": []
@@ -2101,10 +2172,10 @@
    "id": "ebb356b0",
    "metadata": {
     "papermill": {
-     "duration": 0.008209,
-     "end_time": "2026-06-02T16:29:38.483725+00:00",
+     "duration": 0.005011,
+     "end_time": "2026-06-05T06:10:05.841167",
      "exception": false,
-     "start_time": "2026-06-02T16:29:38.475516+00:00",
+     "start_time": "2026-06-05T06:10:05.836156",
      "status": "completed"
     },
     "tags": []
@@ -2163,18 +2234,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 34.733942,
-   "end_time": "2026-06-02T16:29:38.868879+00:00",
+   "duration": 14.146727,
+   "end_time": "2026-06-05T06:10:05.977139",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python.ipynb",
-   "output_path": "D:\\dev\\CoursIA-2\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python_output.ipynb",
+   "input_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python.ipynb",
+   "output_path": "D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-6-AIMA-CSP-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-06-02T16:29:04.134937+00:00",
+   "start_time": "2026-06-05T06:09:51.830412",
    "version": "2.6.0"
   }
  },


### PR DESCRIPTION
## Summary

Fix H.3 execution gaps in 4 Sudoku Python notebooks (See #2161).

### Changes

**Sudoku-15-Infer-Python.ipynb** — Fix + re-exec
- **Bug fix**: Python 3.12 f-string SyntaxError in cell `ex-verify-deterministic-code`
  - `print(f"Taux de succes : {result["success_rate"]:.1%}")` → extracted to variable `success_rate = result["success_rate"]`
  - Same fix for `unique_solutions` line
- Papermill SUCCESS (5.1s), all cells execute without error

**Sudoku-5-PSO-Python.ipynb** — Re-exec
- Resolve null-exec cell (`def adaptive_worker_ratio`)
- Papermill SUCCESS (34.3s), 15 code cells, 0 null-exec

**Sudoku-6-AIMA-CSP-Python.ipynb** — Re-exec
- Resolve null-exec cell (`def analyze_fc_propagation`)
- Papermill SUCCESS (16.7s), 19 code cells, 0 null-exec

**Sudoku-11-Choco-Python.ipynb** — Re-exec
- Resolve null-exec cell (imports + function defs)
- Papermill SUCCESS, 13 code cells, 0 null-exec

### Validation

- Papermill SUCCESS on all 4 notebooks
- 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1 compliant)
- Diff: +1320/-756 (enrichment, re-execution outputs)
- Source changes ONLY in Sudoku-15 (f-string fix), others are re-exec output only