### PR TITLE
enrich(CaseStudies): add technical troubleshooting FAQ (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/README.md
+++ b/MyIA.AI.Notebooks/CaseStudies/README.md
@@ -178,6 +178,97 @@ Le **Diagnostic Medical** resout un probleme de classification : etant donne des
 
 Oui, c'est l'objectif. Les sections "Extensions possibles" de chaque projet proposent des pistes : ajouter de nouvelles pathologies au diagnostic, integrer des donnees genomiques au modele oncologique, deployer une interface web avec SemanticKernel. Ces extensions mobilisent les competences de plusieurs series simultanement.
 
+### Le package z3-solver ne s'installe pas ou echoue a l'import
+
+Le solveur Z3 (utilise dans le Diagnostic Medical) requiert un compilateur C sur certaines plateformes :
+
+```bash
+# Option 1 : installer via pip (version precompilee)
+pip install z3-solver
+
+# Option 2 : si echec, installer via conda
+conda install -c conda-forge z3-solver
+
+# Verification
+python -c "from z3 import Solver; print('Z3 OK')"
+```
+
+Sur Windows, si l'erreur `Microsoft Visual C++ 14.0 is required` apparait, installer les [Build Tools Visual Studio](https://visualstudio.microsoft.com/visual-cpp-build-tools/) avec le workload "Desktop development with C++".
+
+### Pyro renvoie des erreurs de shape ou de type dans le modele oncologique
+
+Le modele probabiliste Pyro (OncoPlan) est sensible aux dimensions des tensors. Verifier :
+
+1. **Shape mismatch** : les variables observees doivent avoir la meme dimension que le prior. Afficher avec `print(tensor.shape)` avant chaque `pyro.sample`.
+2. **Type mismatch** : Pyro requiert des `torch.float32`. Convertir avec `tensor.float()` si les donnees sont en `float64`.
+3. **Contraintes de support** : une distribution `Gamma` n'accepte pas de valeurs negatives. Verifier que les parametres sont strictement positifs : `torch.clamp(param, min=1e-6)`.
+
+### OR-Tools CP-SAT met trop de temps ou ne converge pas
+
+Le solveur CP-SAT (Oncology Planning) peut etre lent sur des instances complexes. Configurer les parametres :
+
+```python
+from ortools.sat.python import cp_model
+
+solver = cp_model.CpSolver()
+solver.parameters.max_time_in_seconds = 30.0  # Timeout 30s
+solver.parameters.num_workers = 4             # Parallelisation
+solver.parameters.log_search_progress = True  # Debug
+
+status = solver.Solve(model)
+if status == cp_model.OPTIMAL:
+    print("Solution optimale")
+elif status == cp_model.FEASIBLE:
+    print("Solution sous-optimale (augmenter max_time)")
+else:
+    print("Aucune solution : relacher des contraintes")
+```
+
+Si le solveur ne trouve rien, relayer les contraintes les plus strictes (par exemple, elargir les fenetres temporelles ou reduire le nombre de medicaments simultanes).
+
+### Les fichiers de donnees patient sont introuvables
+
+Les notebooks referencent des fichiers CSV dans le dossier `data/` de chaque projet :
+
+```text
+CaseStudies/
+├── MedicalDiagnosis/data/    # Symptomes, maladies
+└── OncoPlan/data/            # Parametres patient, protocoles
+```
+
+Verifier le chemin dans le notebook :
+
+```python
+import os
+data_dir = os.path.join(os.path.dirname("__file__"), "data")
+assert os.path.exists(data_dir), f"Dossier introuvable : {data_dir}"
+```
+
+Si les fichiers sont absents, les generer depuis les cellules de generation de donnees synthetiques (fournies dans chaque notebook).
+
+### Comment adapter les modeles a un autre domaine medical ?
+
+Les modeles du Diagnostic Medical et de l'Oncology Planning sont parametrables :
+
+1. **Diagnostic Medical** : modifier la base de connaissances dans `data/symptoms_db.csv` pour changer les maladies et symptomes. L'espace d'etats et les contraintes Z3 s'adaptent automatiquement.
+2. **Oncology Planning** : ajuster les parametres du modele Pyro (distributions prior, nombre de cycles, seuils de toxicite) dans la section de configuration du notebook. L'ontologie medicale (OWL) peut etre etendue avec de nouveaux medicaments et interactions.
+
+Le diagramme de dependencies (aussi bien pour le diagnostic que pour la planification) reste valide quel que soit le domaine tant que la structure du probleme (classification ou optimisation sous contraintes) est preservee.
+
+### Comment passer de Pyro a Infer.NET pour les modeles probabilistes ?
+
+Les modeles Pyro de l'Oncology Planning peuvent etre reimplantements en Infer.NET (C#) pour un deploiement dans l'ecosysteme .NET :
+
+| Concept Pyro | Equivalent Infer.NET |
+| ------------- | --------------------- |
+| `pyro.sample("x", dist.Normal(...))` | `Variable.GaussianFromMeanAndVariance(mean, var)` |
+| `pyro.condition(model, data=...)` | `Variable.Observe(value)` |
+| `AutoDelta` guide | `InferenceEngine` avec point estimates |
+| `SVI(loss=Trace_ELBO())` | `InferenceEngine(InferenceScheme=...)` |
+| `Predictive` | `InferenceEngine.Infer<DistributionType>` |
+
+La serie [Probas/Infer](../Probas/Infer/README.md) couvre Infer.NET en detail avec les memes concepts fondamentaux.
+
 ## Connections cross-series
 
 Les etudes de cas de cette serie sont des projets interdisciplinaires qui combinent les techniques de plusieurs series du cursus.


### PR DESCRIPTION
## Summary

Add 6 technical troubleshooting FAQ entries to CaseStudies README, complementing the pedagogical FAQ added in #2438.

### New FAQ entries

| # | Entry | Content |
|---|-------|---------|
| 1 | z3-solver install | Compiler requirement, conda fallback, Windows build tools |
| 2 | PyRo shape/type errors | Shape mismatch, dtype float32, support constraints |
| 3 | OR-Tools CP-SAT timeout | max_time_in_seconds, num_workers, constraint relaxation |
| 4 | Patient data paths | Directory structure, synthetic data generation |
| 5 | Domain adaptation | Symptoms DB, PyRo params, ontology extension |
| 6 | PyRo to Infer.NET migration | 5-row concept mapping table |

### Changes

- +91 lines in \MyIA.AI.Notebooks/CaseStudies/README.md\
- No changes to existing pedagogical FAQ (lines 159-179 untouched)
- Technical FAQ follows model #2371 (Probas README enrichment)

## Validation

- [x] Diff scope: 1 file, +91 lines (G.4 compliant)
- [x] No content deleted or modified in existing sections
- [x] Markdown lint: fenced code blocks have language, table spacing fixed
- [x] Follows same style as ML/Probas README FAQ entries (#2414, #2431, #2432, #2437)

See #2161