### PR TITLE
enrich(qc): add transaction cost sensitivity analysis for 10 research baselines (See #1407 #1630)

### DIFF
--- a/docs/qc-comparative-backtests.md
+++ b/docs/qc-comparative-backtests.md
@@ -255,9 +255,89 @@ Standardized backtest results from QC Cloud via MCP qc-mcp-lite. Period: 2018-01
 1. ~~**Standardized backtest period**: Re-run all 62 tested + 39 untested strategies on 2018-01-01 → 2024-12-31~~ — Done, 21 baselines verified via QC Cloud API (See #1630)
 2. ~~**Run aligned baselines for AllWeather/SectorMomentum/EMA-Cross-Stocks/MomentumStrategy**~~ — Done, all 4 re-backtested via QC Cloud
 3. ~~**Student strategies (ESGF #1405)**: DualMomentum, RiskParity, ValueFactor, OptionWheel backtestees~~ — Done, 4/6 valides
-4. **Transaction cost adjustment**: 5bps SPY, 10bps crypto, 2bps FX
-5. **Cross-seed validation**: ≥4 seeds (0/1/7/42/99) for ML/DL/RL strategies
-6. **Edge vs σ**: Compute for all strategies vs B&H baseline
+4. ~~**Transaction cost sensitivity analysis**: Estimated turnover and cost impact for all 10 research baselines~~ — Done (See #1407)
+5. **Transaction cost re-backtest**: Add `SetFeeModel` to high-sensitivity strategies + fee sweep (0x/1x/2x)
+6. **Cross-seed validation**: ≥4 seeds (0/1/7/42/99) for ML/DL/RL strategies
+7. **Edge vs σ**: Compute for all strategies vs B&H baseline
+
+---
+
+## Transaction Cost Sensitivity (See #1407)
+
+Source code analysis of all 10 research projects. Zero strategies have explicitly configurable transaction cost parameters (`SetFeeModel` / custom fee). Costs are implicit in the brokerage model or use QC defaults.
+
+### Fee Model Configuration
+
+| Project | QC ID | `SetFeeModel` | `SetBrokerageModel` | Default Fees |
+|---------|-------|---------------|----------------------|--------------|
+| TrendFollowing | 28797562 | NONE | NONE | QC Default (equity) |
+| EMA-Cross-Stocks | 28789946 | NONE | NONE | QC Default (equity) |
+| MomentumStrategy | 28657837 | NONE | NONE | QC Default (equity) |
+| AllWeather | 28657833 | NONE | NONE | QC Default (equity) |
+| VolTarget-Momentum | 30784745 | NONE | NONE | QC Default (equity) |
+| Crypto-MultiCanal | 30750734 | NONE | `BINANCE, CASH` | Binance schedule (0.1%) |
+| Portfolio-IBKR-Binance | 31717642 | NONE | NONE | QC Default (equity) |
+| MomentumRegime | 31243821 | NONE | `IBKR, MARGIN` | IBKR tiered |
+| TrendStocks-Alpha | 28885507 | NONE | `IBKR, MARGIN` | IBKR tiered |
+| EMA-Cross-Alpha | 28885488 | NONE | `IBKR, MARGIN` | IBKR tiered |
+
+### Turnover Estimation
+
+| Project | Rebalance Freq | Universe | Est. Annual Trades | Turnover | Cost Sensitivity |
+|---------|----------------|----------|--------------------|----------|------------------|
+| TrendFollowing | Monthly | 7 ETFs | ~24-48 | MEDIUM | MEDIUM |
+| EMA-Cross-Stocks | Daily (5% drift) | 5 stocks | ~125-250 | HIGH | **HIGH** |
+| MomentumStrategy | Monthly + stop-loss | 11 sectors | ~48-96 | MEDIUM-HIGH | HIGH |
+| AllWeather | Quarterly (3% drift) | 4 ETFs | ~8-16 | LOW | LOW |
+| VolTarget-Momentum | Monthly (leverage 0.3-1.5x) | 7 ETFs | ~24-48 | MEDIUM | MEDIUM |
+| Crypto-MultiCanal | Daily (signal) | 1 (BTC) | ~50-100 | HIGH | **HIGH** (0.1% crypto) |
+| Portfolio-IBKR-Binance | One-shot | 3 assets | ~3 | VERY LOW | NEGLIGIBLE |
+| MomentumRegime | Monthly | 4 assets | ~24-48 | MEDIUM | MEDIUM |
+| TrendStocks-Alpha | Weekly | 15 stocks | ~150-300 | HIGH | **HIGH** |
+| EMA-Cross-Alpha | Daily (1-day insight) | 5 stocks | ~125-250 | HIGH | **HIGH** |
+
+### Cost Sensitivity Ranking
+
+**TIER 1 — Highly Sensitive** (cost change would significantly impact Sharpe):
+
+1. **EMA-Cross-Stocks** — Daily rebalance, 5 stocks, 5% drift threshold. No brokerage model = default QC fees. A 2x fee increase could eat 50-100bps CAGR.
+2. **EMA-Cross-Alpha** — Daily insight emission, IBKR margin. Same high-frequency cross logic.
+3. **TrendStocks-Alpha** — 15-stock universe, weekly rebalance. Largest universe = most trades.
+4. **Crypto-MultiCanal** — Daily BTC signals, Binance CASH (already has real 0.1% crypto fees). Crypto percentage-based fees amplify impact vs per-share equity fees.
+5. **MomentumStrategy** — Monthly rotation of top-4 from 11 sectors + daily stop-loss checks. Stop-losses generate unplanned trades.
+
+**TIER 2 — Moderately Sensitive:**
+
+6. **TrendFollowing** — Monthly rebalance, 6 risky + 1 safe. Moderate turnover on regime changes.
+7. **VolTarget-Momentum** — Monthly with leverage scaling (0.3x to 1.5x). Leverage changes mean larger position sizes.
+8. **MomentumRegime** — Monthly composite on 4 assets, IBKR margin. Moderate.
+
+**TIER 3 — Low Sensitivity:**
+
+9. **AllWeather** — Quarterly + 3% drift threshold, 4 static-weight ETFs. Very few trades.
+10. **Portfolio-IBKR-Binance** — One-shot buy of SPY/BND/AAPL. 3 trades total. Zero sensitivity.
+
+### Recommended Actions
+
+| Priority | Project | Action | Rationale |
+|----------|---------|--------|-----------|
+| HIGH | EMA-Cross-Stocks | Add configurable fee + 0x/1x/2x sweep | Highest turnover, no brokerage = blind to real costs |
+| HIGH | TrendStocks-Alpha | Same | Largest universe, weekly rebalance |
+| HIGH | Crypto-MultiCanal | Test 0x/2x Binance fees | Already has real crypto fees, should verify sensitivity |
+| MEDIUM | MomentumStrategy | Add fee sweep | Stop-losses create unplanned trades |
+| MEDIUM | VolTarget-Momentum | Add fee sweep | Leverage amplifies trade sizes |
+| LOW | AllWeather | Optional | Very few trades, minimal cost impact |
+| SKIP | Portfolio-IBKR-Binance | Not applicable | One-shot, 3 trades total |
+
+### Fix Pattern (for fee sweep)
+
+```python
+# In initialize(), add configurable fee model
+self.transaction_cost_bps = self.get_parameter("transaction_cost_bps", 5)  # default 5bps
+for ticker in self.all_tickers:
+    security = self.add_equity(ticker, Resolution.DAILY)
+    security.set_fee_model(ConstantFeeModel(self.transaction_cost_bps / 10000 * self.portfolio.total_portfolio_value * 0.20))
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Source code analysis of all 10 QC Cloud research strategies for transaction cost sensitivity (See #1407).

### Key findings

- **0/10 strategies** have configurable transaction cost parameters ( / custom fee)
- **7/10** use QC default brokerage (no explicit model) — costs are implicit
- **3/10** have explicit brokerage models: Crypto-MultiCanal (Binance), MomentumRegime/TrendStocks-Alpha/EMA-Cross-Alpha (IBKR)

### Added to `docs/qc-comparative-backtests.md`

1. **Fee Model Configuration** table — which strategies have which brokerage/fee setup
2. **Turnover Estimation** table — rebalance frequency, universe size, estimated annual trades
3. **Cost Sensitivity Ranking** — 3 tiers (HIGH/MEDIUM/LOW) with per-strategy rationale
4. **Recommended Actions** — prioritized list of which strategies need fee sweeps
5. **Fix Pattern** — code snippet for adding configurable fees via QC API

### High-sensitivity strategies (cost changes would significantly impact Sharpe)

| Strategy | Rebalance | Trades/yr | Sensitivity |
|----------|-----------|-----------|-------------|
| EMA-Cross-Stocks | Daily (5% drift) | 125-250 | HIGH |
| EMA-Cross-Alpha | Daily (1-day insight) | 125-250 | HIGH |
| TrendStocks-Alpha | Weekly, 15 stocks | 150-300 | HIGH |
| Crypto-MultiCanal | Daily signal, BTC | 50-100 | HIGH |
| MomentumStrategy | Monthly + stop-loss | 48-96 | HIGH |

### Low-sensitivity (skip)

- AllWeather: quarterly, 4 ETFs, ~12 trades/yr
- Portfolio-IBKR-Binance: one-shot, 3 trades total

## Test plan

- [ ] Verify tables render correctly in markdown
- [ ] Confirm turnover estimates against QC Cloud trade logs
- [ ] Next step: implement fee sweep on HIGH-sensitivity strategies