### PR TITLE
docs(readme): FAQ sections Planners + GenAI-Image + GenAI-Video (See #2161)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -164,6 +164,81 @@ Le fil rouge de cette serie est la creation d'un systeme de visuels pedagogiques
 | [Texte](../Texte/README.md) | Prompts structures | Les prompts DALL-E et GPT-5 Image beneficient des techniques de prompt engineering (Texte/2) et function calling (Texte/4) |
 | [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les pipelines d'orchestration (03-2) partagent les memes patterns que les agents Semantic Kernel |
 
+## FAQ
+
+### DALL-E 3 retourne des images floues ou hors-sujet
+
+DALL-E 3 (notebook [01-1](01-Foundation/01-1-OpenAI-DALL-E-3.ipynb)) interprete les prompts librement et peut simplifier les details complexes. Mitigation :
+
+- Structurer le prompt : `style [photographiste/illustration/3D render], sujet [precis], contexte [arriere-plan], eclairage [type]`.
+- Utiliser `size="1792x1024"` pour les compositions larges, `1024x1024` pour les portraits.
+- GPT-5 Image (notebook [01-2](01-Foundation/01-2-GPT-5-Image-Generation.ipynb)) offre un meilleur suivi des instructions detaillees que DALL-E 3.
+- Pour un controle total, passer en ComfyUI local (niveau 02+).
+
+### ComfyUI retourne une erreur 401 ou 502
+
+Les services ComfyUI (ports 8188, 8001, 1111, 17861) tournent dans des conteneurs Docker avec authentification bearer token. Si erreur 401 ou 502 :
+
+```bash
+# Verifier les conteneurs actifs
+docker ps | grep comfyui
+
+# Redemarrer le service
+cd docker-configurations/services/comfyui-qwen && docker-compose restart
+
+# Verifier le bearer token (drift bcrypt entre container et .env)
+cat MyIA.AI.Notebooks/GenAI/.env | grep COMFYUI_BEARER_TOKEN
+```
+
+Les notebooks ont une graceful degradation : sans token, ils basculent vers les API cloud quand c'est possible.
+
+### Qwen Image Edit ne modifie pas l'image correctement
+
+Le modele Qwen Image Edit (notebooks [01-5](01-Foundation/01-5-Qwen-Image-Edit.ipynb) et [02-1](02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb)) est sensible au format du prompt d'edition. Points critiques :
+
+- L'image source doit etre en PNG ou JPEG, resolution <= 1024x1024 pour des resultats optimaux.
+- Le prompt d'edition doit etre specifique : "remplacer le texte 'X' par 'Y'" plutot que "changer le texte".
+- L'architecture Qwen utilise un VAE 16 canaux (non standard SDXL), un scheduler `beta`, et CFG 1.0 — ces parametres sont pre-configures dans les notebooks, ne pas les modifier sans test.
+
+### GPU Out of Memory pendant un notebook ComfyUI
+
+Les modeles image sont gourmands en VRAM. Allocation typique :
+
+| Modele | VRAM requise | Notebooks |
+|--------|-------------|-----------|
+| Qwen Image Edit | ~29 GB | 01-5, 02-1 |
+| FLUX.1 | ~24 GB | 02-2 |
+| SD XL Turbo | ~10 GB | 01-4 |
+| SD 3.5 | ~12 GB | 02-3 |
+| Z-Image/Lumina | ~10 GB | 02-4 |
+
+Strategies si OOM :
+
+- Utiliser les quantizations Nunchaku INT4 ou FP8 pour reduire la VRAM (notebook [03-3](03-Orchestration/03-3-Performance-Optimization.ipynb)).
+- Fermer les autres notebooks GPU avant une generation lourde.
+- Verifier avec `nvidia-smi` et liberer avec `torch.cuda.empty_cache()`.
+
+### Quelle difference entre DALL-E 3, GPT-5 Image et ComfyUI ?
+
+| Critere | DALL-E 3 | GPT-5 Image | ComfyUI (SD/FLUX/Qwen) |
+|---------|----------|-------------|------------------------|
+| **Cout** | $0.04-0.12/image | Variable (API) | Gratuit (local) |
+| **Controle** | Prompt seul | Prompt + instructions | Noeuds, masques, seeds |
+| **Edition** | Non | Oui (native) | Oui (inpainting, ControlNet) |
+| **Qualite** | Bonne | Excellente | Excellente (avec reglages) |
+| **VRAM** | 0 (API) | 0 (API) | 10-29 GB |
+
+Pour du prototypage rapide, DALL-E 3 ou GPT-5 Image suffisent. Pour un controle fin, une production repetitive, ou des donnees sensibles, ComfyUI est indispensable.
+
+### Comment creer un workflow ComfyUI reproductible ?
+
+Un workflow ComfyUI est un graphe JSON de noeuds connectes. Pour le rendre reproductible :
+
+1. Exporter le workflow depuis l'interface ComfyUI (bouton "Save").
+2. Utiliser la meme seed (`noise_seed` dans le noeud KSampler) pour reproduire exactement la meme image.
+3. Verrouiller les versions de modeles (checkpoint, VAE, CLIP) — un modele mis a jour peut changer les resultats.
+4. Le notebook [03-2](03-Orchestration/03-2-Workflow-Orchestration.ipynb) montre comment charger un workflow JSON et l'executer programmatiquement via l'API ComfyUI.
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/GenAI/Video/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Video/README.md
@@ -140,6 +140,80 @@ winget install FFmpeg
 | [Texte](../Texte/README.md) | Prompts et APIs | La comprehension video (01-2) utilise les memes APIs GPT-5 que Texte ; Sora (04-3) depend de prompts structures |
 | [SemanticKernel](../SemanticKernel/README.md) | Orchestration | Les workflows video ComfyUI (03-3) partagent les patterns d'orchestration avec les agents Semantic Kernel |
 
+## FAQ
+
+### HunyuanVideo OOM ou generation extremement lente
+
+HunyuanVideo (notebook [02-1](02-Advanced/02-1-HunyuanVideo-Generation.ipynb)) est le modele le plus gourmand de la serie (~18-24 GB VRAM). Strategies :
+
+- Utiliser la quantization integree au notebook pour reduire a ~18 GB.
+- Generer des clips courts (2-3 secondes) plutot que des sequences longues.
+- Si votre GPU a 12 GB ou moins, utiliser **LTX-Video** (notebook [02-2](02-Advanced/02-2-LTX-Video-Lightweight.ipynb), ~8 GB) ou **Wan** (notebook [02-3](02-Advanced/02-3-Wan-Video-Generation.ipynb), ~10 GB) comme alternatives legeres.
+- Fermer tous les autres processus GPU avant la generation (`nvidia-smi` pour verifier).
+
+### FFmpeg non trouve ou erreurs de codec
+
+FFmpeg est requis par moviepy (notebook [01-1](01-Foundation/01-1-Video-Operations-Basics.ipynb)) et les notebooks de production (04-4). Si erreur `FileNotFoundError: [WinError 2]` ou codec non supporte :
+
+```bash
+# Windows (via winget)
+winget install FFmpeg
+
+# Ou via conda
+conda install -c conda-forge ffmpeg
+```
+
+Verifier : `ffmpeg -version`. Si installe dans un chemin non-standard, ajouter au PATH ou configurer :
+
+```python
+import imageio_ffmpeg
+ffmpeg_path = imageio_ffmpeg.get_ffmpeg_exe()
+```
+
+### Quelle difference entre Sora 2 et les modeles locaux ?
+
+| Critere | Sora 2 (cloud) | HunyuanVideo | Wan | LTX-Video |
+|---------|----------------|--------------|-----|-----------|
+| **Cout** | $0.10-1.00/video | Gratuit (local) | Gratuit (local) | Gratuit (local) |
+| **Qualite** | Excellente | Haute | Bonne | Correcte |
+| **Duree max** | 20s | 5-10s | 5-10s | 3-5s |
+| **VRAM** | 0 (API) | ~18-24 GB | ~10 GB | ~8 GB |
+| **Latence** | 30s-2min | 1-5min | 30s-2min | 10-30s |
+
+Pour du prototypage ou des resultats rapides, Sora 2 (notebook [04-3](04-Applications/04-3-Sora-API-Cloud-Video.ipynb)) est ideal. Pour un controle fin, une production repetitive, ou des donnees sensibles, les modeaux locaux sont indispensables.
+
+### Les videos generees manquent de coherence temporelle
+
+La coherence entre les frames est le defi principal de la generation video. Le flickering, les objets qui apparaissent/disparaissent, ou les mouvements irrealistes sont frequents, surtout avec les modeaux les plus legers. Mitigation :
+
+- Limiter la duree a 3-5 secondes pour les modeaux legers (LTX, AnimateDiff).
+- Utiliser des prompts simples et descriptifs plutot que narratifs.
+- HunyuanVideo et Wan offrent une meilleure coherence temporelle que LTX-Video.
+- Le pipeline ComfyUI (notebook [03-3](03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb)) permet de controler finement les parametres de generation (CFG, steps, seed).
+- L'upscaling ESRGAN + interpolation RIFE (notebook [01-4](01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb)) ameliore la qualite visuelle a posteriori.
+
+### ComfyUI Video retourne des erreurs de noeuds manquants
+
+Les workflows video ComfyUI (notebook [03-3](03-Orchestration/03-3-ComfyUI-Video-Workflows.ipynb)) necessitent des noeuds specifiques (AnimateDiff, SVD, HunyuanVideo) qui ne sont pas dans l'installation de base de ComfyUI. Si erreur `Node not found` :
+
+```bash
+# Verifier les noeuds installes
+ls ComfyUI/custom_nodes/
+
+# Installer les noeuds video manquants
+cd ComfyUI/custom_nodes/ && git clone <node-repo-url>
+```
+
+Les conteneurs Docker CoursIA incluent deja les noeuds necessaires. Si vous utilisez une installation ComfyUI propre, verifier que les custom nodes video sont installes.
+
+### GPT-5 Video Understanding echoue sur les videos longues
+
+L'API GPT-5 video (notebook [01-2](01-Foundation/01-2-GPT-5-Video-Understanding.ipynb)) a des limites sur la duree et la taille des fichiers envoyes. Si erreur 413 ou timeout :
+
+- Decouper la video en segments de 30-60 secondes avec moviepy (notebook [01-1](01-Foundation/01-1-Video-Operations-Basics.ipynb)).
+- Compresser avant envoi : resolution 720p, bitrate reduit.
+- Utiliser le modele local Qwen2.5-VL (notebook [01-3](01-Foundation/01-3-Qwen-VL-Video-Analysis.ipynb)) pour les videos longues ou sensibles, sans limite de taille.
+
 ## Licence
 
 Voir la licence du repository principal.

--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/README.md
@@ -517,6 +517,115 @@ La planification automatique est une branche de l'IA symbolique :
 | [GameTheory](../../GameTheory/README.md) | Recherche sequentielle | A* en planification et minimax en jeux partagent la meme structure de graphe |
 | [Search](../../Search/README.md) | Fondations algorithmiques | A*, BFS, DFS de Search sont les bases des planificateurs classiques |
 
+## FAQ / Troubleshooting
+
+### 1. Le conteneur Docker Fast Downward ne repond pas sur le port 8200
+
+**Symptome** : `ConnectionRefusedError` ou timeout dans les notebooks 4-6.
+
+**Causes et solutions** :
+
+```bash
+# Verifier que le conteneur tourne
+docker ps | grep coursia-fast-downward
+
+# S'il n'apparait pas, le lancer
+docker run -d --name coursia-fast-downward -p 8200:8200 jsboige/coursia-fast-downward:latest
+
+# Verifier que le port est accessible
+curl -s http://localhost:8200/health
+```
+
+Si le port 8200 est deja pris par un autre service, utiliser un port different :
+```bash
+docker run -d --name coursia-fast-downward -p 8201:8200 jsboige/coursia-fast-downward:latest
+```
+Dans ce cas, adapter l'URL dans les notebooks de `localhost:8200` vers `localhost:8201`.
+
+### 2. unified-planning ne detecte pas Fast Downward
+
+**Symptome** : `up_fast_downward` importe mais `FastDownwardPDDLPlanner()` echoue avec une erreur de chemin.
+
+**Cause** : `unified-planning` attend l'executable `downward` dans le PATH ou dans le repertoire configure. Avec Docker, ce n'est pas necessaire — les notebooks utilisent l'API HTTP a la place.
+
+**Solution** : Les notebooks 4-6 utilisent le serveur Docker (endpoint `/plan`), pas l'executable local. Verifier que les appels HTTP fonctionnent :
+```python
+import requests
+resp = requests.post("http://localhost:8200/plan",
+    json={"domain": domain_pddl, "problem": problem_pddl, "search": "astar(lmcut())"})
+print(resp.status_code, resp.json())
+```
+
+### 3. Erreurs PDDL "undeclared variable" ou "type mismatch"
+
+**Symptome** : Le solveur rejette le domaine ou le probleme PDDL avec une erreur de parsing.
+
+**Causes frequentes** :
+
+| Erreur | Cause | Correction |
+| ------ | ----- | ---------- |
+| `undeclared variable '?x'` | Parametre non declare dans `:parameters` | Ajouter `?x - type` dans la signature de l'action |
+| `type mismatch` | Type de parametre incorrect | Verifier que le type existe dans `:types` |
+| `unsupported requirement` | Requirement non supporte par le solveur | Retirer `:adl`, `:quantified-preconditions` ou utiliser un solveur compatible |
+| `precondition false` | Conjonction vide ou variable non initialisee | Verifier les noms de predicats dans `:predicates` |
+
+**Astuce** : Valider le PDDL avec [planning.wiki](https://planning.wiki/) avant de le soumettre au solveur. Le notebook 2 (PDDL-Basics) couvre la syntaxe complete.
+
+### 4. OR-Tools CP-SAT : "model is infeasible" sur un probleme simple
+
+**Symptome** : Le solveur CP-SAT retourne `INFEASIBLE` alors que le probleme devrait avoir une solution.
+
+**Causes** :
+
+1. **Contradiction entre contraintes** : deux contraintes `model.Add(x == 1)` et `model.Add(x == 2)` sur la meme variable.
+2. **Domaine vide** : `model.NewIntVar(5, 3, "x")` (borne inferieure > superieure).
+3. **Contraintes cumulatives** : la capacite cumulee est inferieure a la demande totale.
+
+**Diagnostic** :
+```python
+# Activer le log du solveur pour comprendre l'infeasibilite
+solver = cp_model.CpSolver()
+solver.parameters.max_time_in_seconds = 30.0
+status = solver.Solve(model)
+if status == cp_model.INFEASIBLE:
+    # Verifier les contraintes une par une en les desactivant
+    for i, ct in enumerate(model.proto.constraint):
+        print(f"Constraint {i}: {ct}")
+```
+
+### 5. Explication combinatoire : le solveur ne termine pas
+
+**Symptome** : Le planificateur tourne indefiniment sur un probleme de taille moyenne.
+
+**Cause** : L'espace d'etats explose ($O(2^n)$ pour $n$ predicats). Les domaines comme Logistics ou Satellite avec beaucoup d'objets sont particulierement sensibles.
+
+**Solutions** :
+
+| Strategie | Configuration | Quand l'utiliser |
+| --------- | ------------- | ---------------- |
+| **Limiter le temps** | `solver.parameters.max_time_in_seconds = 60` | Probleme trop grand |
+| **Heuristique rapide** | Utiliser `eager_greedy([ff()])` au lieu de `astar(lmcut())` | Solution rapide, pas forcement optimale |
+| **Reduire le probleme** | Moins d'objets dans `:objects` | Prototypage, validation du modele |
+| **Sous-optimal** | `astar(ff())` avec weight > 1 | Bon compromis qualite/temps |
+
+### 6. Docker sur Windows : "permission denied" ou "daemon not running"
+
+**Symptome** : Les commandes `docker` echouent sur Windows.
+
+**Solutions** :
+
+1. Verifier que Docker Desktop est lance (icone dans la barre de taches).
+2. Sur Windows, utiliser PowerShell en mode Administrateur si necessaire.
+3. Alternative sans Docker : installer Fast Downward nativement (Linux/WSL uniquement) :
+   ```bash
+   # Dans WSL
+   git clone https://github.com/aibasel/downward.git
+   cd downward && ./build.py
+   # Puis pointer unified-planning vers le binaire
+   ```
+
+Les notebooks theoriques (1-3, 7-12) ne necessitent **pas** Docker et fonctionnent avec uniquement `pip install unified-planning ortools`.
+
 ## Contribution
 
 Pour contribuer a cette serie :


### PR DESCRIPTION
## Summary
Regroupe 3 ajouts FAQ markdown-only (convention #2161) extraits proprement de #2451/#2459/#2461, **sans** la regeneration de catalogue stale qui polluait ces 3 branches.

### Probleme detecte sur les PRs originales
Les 3 branches (#2451/#2459/#2461) avaient ete coupees du merge-base `a95bee85` puis avaient regenere `COURSE_CATALOG.generated.json` -> divergence de **4214 lignes** vs main + touches non-declarees a `README.md`/`RL/README.md`/`Probas/README.md`. Comme main n'a PAS touche ces fichiers depuis le merge-base, merger ces PRs aurait **silencieusement reverte** le catalogue cure (pattern stale-catalog-silent-revert, cf #2376/#2383/#2385). Les bodies declaraient a tort "0 catalog files touched".

### Cette PR
- `Planners/README.md` +109 / `GenAI/Image/README.md` +75 / `GenAI/Video/README.md` +74
- **markdown-only** (C.3 source-unchanged, pas de re-exec), 0 fichier catalogue, 0 nom d'ecole, 0 emoji.

### G.4 / Rule E
Regroupement de 3 petits ajouts docs homogenes (convention #2161) = conforme a la regle E (grouper les petites PRs docs). 258 lignes, 1 sujet (FAQ enrichment).

Supersede #2451 #2459 #2461.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>