### PR TITLE
curate(#2288): Lean-15 Kochen-Specker solutions -> exemples guides + nouvel exercice

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-15-Kochen-Specker.ipynb
@@ -1042,7 +1042,8 @@
     "tags": []
    },
    "source": [
-    "### Exercice 1 : Verifier l'orthogonalite d'une base (rappel section 3)\n",
+    "### Exemple guide 1 : Verifier l'orthogonalite d'une base (rappel section 3)\n",
+    "\n_Resolu par le groupe Matteo Atkinson & Paul Witkowski (contribution PR #2288)._\n",
     "\n",
     "**Objectif.** Ecrire une fonction qui verifie qu'un contexte (4 indices de vecteurs) forme bien une\n",
     "base orthogonale de R^4, c'est-a-dire que les 4 vecteurs sont deux a deux orthogonaux.\n",
@@ -1076,22 +1077,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 1 a completer -- base_est_orthogonale(C0) = None (attendu : True)\n"
+      "base_est_orthogonale(C0) = True (attendu : True)\n",
+      "Verification sur les 9 bases : True\n"
      ]
     }
    ],
-   "source": [
-    "def base_est_orthogonale(ctx, vectors):\n",
-    "    # TODO etudiant : retourner True si les 4 vecteurs de ctx sont deux a deux orthogonaux\n",
-    "    # Indice : generer les 6 paires (i, j) avec i < j parmi les 4 indices de ctx\n",
-    "    # Etape 1 : pour chaque paire, calculer dot(vectors[i], vectors[j])\n",
-    "    # Etape 2 : retourner True si tous ces produits scalaires sont nuls, False sinon\n",
-    "    return None  # TODO etudiant\n",
-    "\n",
-    "# Test (une fois complete, attendu : True pour chaque base) :\n",
-    "resultat = base_est_orthogonale(contexts[0], vectors)\n",
-    "print(f\"Exercice 1 a completer -- base_est_orthogonale(C0) = {resultat} (attendu : True)\")\n"
-   ]
+   "source": "def base_est_orthogonale(ctx, vectors):\n    # Indice : generer les 6 paires (i, j) avec i < j parmi les 4 indices de ctx\n    # Etape 1 : pour chaque paire, calculer dot(vectors[i], vectors[j])\n    # Etape 2 : retourner True si tous ces produits scalaires sont nuls, False sinon\n    for idx_i in range(len(ctx)):\n        for idx_j in range(idx_i + 1, len(ctx)):\n            i, j = ctx[idx_i], ctx[idx_j]\n            if dot(vectors[i], vectors[j]) != 0:\n                return False\n    return True\n\n# Test (une fois complete, attendu : True pour chaque base) :\nresultat = base_est_orthogonale(contexts[0], vectors)\nprint(f\"base_est_orthogonale(C0) = {resultat} (attendu : True)\")\nprint(f\"Verification sur les 9 bases : {all(base_est_orthogonale(ctx, vectors) for ctx in contexts)}\")\n"
   },
   {
    "cell_type": "markdown",
@@ -1107,7 +1098,8 @@
     "tags": []
    },
    "source": [
-    "### Exercice 2 : Compter les slots et leur parite (rappel section 4)\n",
+    "### Exemple guide 2 : Compter les slots et leur parite (rappel section 4)\n",
+    "\n_Resolu par le groupe Matteo Atkinson & Paul Witkowski (contribution PR #2288)._\n",
     "\n",
     "**Objectif.** L'argument de parite repose sur le decompte des \"slots\" (paires vecteur-base). Ecrire\n",
     "une fonction qui calcule le nombre total de slots sur les 9 bases et renvoie aussi sa parite.\n",
@@ -1141,22 +1133,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 2 a completer -- (total_slots, parite) = None (attendu : (36, 0), soit PAIR)\n"
+      "(total_slots, parite) = (36, 0) (attendu : (36, 0), soit PAIR)\n",
+      "Interpretation : 9 bases x 4 vecteurs = 36 slots, PAIR\n"
      ]
     }
    ],
-   "source": [
-    "def slots_totaux_et_parite(contexts):\n",
-    "    # TODO etudiant : retourner (total_slots, parite) ou parite = total_slots % 2\n",
-    "    # Indice : un \"slot\" est une occurrence (vecteur, base) ; sommez len(ctx) sur les 9 contextes\n",
-    "    # Etape 1 : total = somme des tailles des 9 contextes\n",
-    "    # Etape 2 : retourner (total, total % 2)  # parite : 0 = pair, 1 = impair\n",
-    "    return None  # TODO etudiant\n",
-    "\n",
-    "# Test (une fois complete, attendu : (36, 0) -> PAIR) :\n",
-    "res = slots_totaux_et_parite(contexts)\n",
-    "print(f\"Exercice 2 a completer -- (total_slots, parite) = {res} (attendu : (36, 0), soit PAIR)\")\n"
-   ]
+   "source": "def slots_totaux_et_parite(contexts):\n    # Indice : un \"slot\" est une occurrence (vecteur, base) ; sommez len(ctx) sur les 9 contextes\n    # Etape 1 : total = somme des tailles des 9 contextes\n    total = sum(len(ctx) for ctx in contexts)\n    # Etape 2 : retourner (total, total % 2)  # parite : 0 = pair, 1 = impair\n    return (total, total % 2)\n\n# Test (une fois complete, attendu : (36, 0) -> PAIR) :\nres = slots_totaux_et_parite(contexts)\nprint(f\"(total_slots, parite) = {res} (attendu : (36, 0), soit PAIR)\")\nprint(f\"Interpretation : 9 bases x 4 vecteurs = {res[0]} slots, {'PAIR' if res[1] == 0 else 'IMPAIR'}\")\n"
   },
   {
    "cell_type": "markdown",
@@ -1172,7 +1154,8 @@
     "tags": []
    },
    "source": [
-    "### Exercice 3 : Reconstituer l'argument de parite (rappel section 5)\n",
+    "### Exemple guide 3 : Reconstituer l'argument de parite (rappel section 5)\n",
+    "\n_Resolu par le groupe Matteo Atkinson & Paul Witkowski (contribution PR #2288)._\n",
     "\n",
     "**Objectif.** Sous l'hypothese (fausse, c'est tout l'enjeu) qu'une coloration `{0, 1}` valide existe\n",
     "-- exactement un vecteur \"vrai\" par base -- exhiber la contradiction de parite : le decompte \"cote\n",
@@ -1209,26 +1192,53 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice 3 a completer -- (cote_bases, cote_vecteurs) = None\n",
-      "Objectif : montrer que 9 (impair, cote bases) contredit une somme paire (cote vecteurs).\n"
+      "(cote_bases, cote_vecteurs) = (9, 'pair')\n",
+      "Contradiction : 9 est impair (cote bases) mais la somme cote vecteurs est toujours pair.\n",
+      "=> Aucune coloration valide ne peut exister (QED).\n"
+     ]
+    }
+   ],
+   "source": "def argument_de_parite(contexts, occurrences):\n    # Indice : somme_cote_bases = nombre de bases (un 1 par base dans une coloration valide)\n    # Etape 1 : somme_cote_bases = len(contexts)            # = 9, impair\n    somme_cote_bases = len(contexts)\n    # Etape 2 : la somme cote vecteurs vaut sum(color[v] * occurrences[v]) ; chaque occurrences[v] = 2\n    #           donc elle est PAIRE quelle que soit la coloration -> parite_cote_vecteurs = \"pair\"\n    parite_cote_vecteurs = \"pair\"\n    # Etape 3 : retourner (somme_cote_bases, parite_cote_vecteurs)\n    return (somme_cote_bases, parite_cote_vecteurs)\n\n# Test (une fois complete, attendu : (9, 'pair') -> 9 impair contredit une somme paire) :\nverdict = argument_de_parite(contexts, occurrences)\nprint(f\"(cote_bases, cote_vecteurs) = {verdict}\")\nprint(f\"Contradiction : {verdict[0]} est {'impair' if verdict[0] % 2 == 1 else 'pair'} \"\n      f\"(cote bases) mais la somme cote vecteurs est toujours {verdict[1]}.\")\nprint(\"=> Aucune coloration valide ne peut exister (QED).\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "### Exercice (a completer) : toutes les paires orthogonales de la configuration\n",
+    "\n",
+    "Les exemples guides ci-dessus verifient l'orthogonalite *a l'interieur* de chaque base. A votre\n",
+    "tour : comptez le nombre total de paires orthogonales parmi les 18 vecteurs (toutes paires\n",
+    "confondues, pas seulement intra-bases), et comparez-le aux `9 x 6 = 54` paires garanties par\n",
+    "les bases.\n",
+    "\n",
+    "- *Indice* : reutilisez `dot(u, v)` et parcourez les paires `(i, j)` avec `i < j` parmi les 18 vecteurs.\n",
+    "- *Etape 1* : enumerer toutes les paires `(i, j)`, `i < j`.\n",
+    "- *Etape 2* : compter celles dont le produit scalaire est nul ; comparer a 54.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
      ]
     }
    ],
    "source": [
-    "def argument_de_parite(contexts, occurrences):\n",
-    "    # TODO etudiant : renvoyer un tuple (somme_cote_bases, parite_cote_vecteurs)\n",
-    "    #                 qui rend visible la contradiction 9 (impair) vs pair\n",
-    "    # Indice : somme_cote_bases = nombre de bases (un 1 par base dans une coloration valide)\n",
-    "    # Etape 1 : somme_cote_bases = len(contexts)            # = 9, impair\n",
-    "    # Etape 2 : la somme cote vecteurs vaut sum(color[v] * occurrences[v]) ; chaque occurrences[v] = 2\n",
-    "    #           donc elle est PAIRE quelle que soit la coloration -> parite_cote_vecteurs = \"pair\"\n",
-    "    # Etape 3 : retourner (somme_cote_bases, parite_cote_vecteurs)\n",
-    "    return None  # TODO etudiant\n",
+    "# Exercice : compter toutes les paires orthogonales parmi les 18 vecteurs\n",
+    "# TODO etudiant :\n",
+    "#   Etape 1 : parcourir toutes les paires (i, j) avec i < j parmi les 18 vecteurs\n",
+    "#   Etape 2 : compter celles dont dot(vectors[i], vectors[j]) == 0\n",
+    "#   Etape 3 : comparer ce total aux 9 x 6 = 54 paires intra-bases\n",
     "\n",
-    "# Test (une fois complete, attendu : (9, 'pair') -> 9 impair contredit une somme paire) :\n",
-    "verdict = argument_de_parite(contexts, occurrences)\n",
-    "print(f\"Exercice 3 a completer -- (cote_bases, cote_vecteurs) = {verdict}\")\n",
-    "print(\"Objectif : montrer que 9 (impair, cote bases) contredit une somme paire (cote vecteurs).\")\n"
+    "print(\"Exercice a completer\")\n"
    ]
   },
   {


### PR DESCRIPTION
Pilotage coordinateur du merge de la PR etudiante #2288 (Matteo Atkinson & Paul Witkowski), protocole same-notebook (#1429/#1416).

## Transformations
- 3 exercices resolus par le groupe -> **exemples guides** credites, avec leurs outputs reels :
  - `base_est_orthogonale` (orthogonalite des 9 bases = True)
  - `slots_totaux_et_parite` ((36, 0) = PAIR)
  - `argument_de_parite` ((9, 'pair') => contradiction, QED)
- **Nouvel exercice** : compter toutes les paires orthogonales parmi les 18 vecteurs.
- Cellules d'infrastructure conservees depuis main (lake build / grep sorry) au lieu des reecritures locales du fork.

## Verification
- H.3 = 0, C.1 = 0, 0 output d'erreur
- diff = notebook seul, aucune pollution catalogue
- exemples guides = code etudiant byte-identique (outputs reels, numpy 2.4.6) ; nouvel exercice = stub deterministe

Bonus etudiant attribue via inscription/rendu (independant du merge).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>