### PR TITLE
fix(prover): add delta-0 stagnation guard to autonomous loop (P2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -1110,6 +1110,18 @@ class AutonomousProver:
                         next_phase = PHASE_TRANSITIONS.get(state.phase, ProofPhase.TACTIC_GEN)
                         state.phase = next_phase
 
+                # Delta-0 stagnation guard (P2, #1453 forensic):
+                # The multi-agent path has DELTA0_STAGNATION_HARDCAP=6 in
+                # workflow.py:223-237, but the autonomous loop had no equivalent.
+                # Forensic: custom_Basic_L308 burned 5.9h with 7 identical
+                # compiles. A hardcap at 6 stops pathological burners.
+                DELTA0_HARDCAP = 6
+                if tactic_tools._consecutive_delta0 >= DELTA0_HARDCAP:
+                    print(f"  DELTA0 STAGNATION: {tactic_tools._consecutive_delta0} "
+                          f"compiles without progress (hardcap={DELTA0_HARDCAP}). "
+                          f"Stopping to preserve budget.", flush=True)
+                    break
+
                 # B.9: HITL — ask for human hint when stuck
                 if self.hitl_enabled and state.consecutive_failures >= self.hitl_threshold:
                     print(f"\n  [HITL] {state.consecutive_failures} echecs consecutifs. "


### PR DESCRIPTION
## Summary

Forensic analysis of 55 prover traces (44.8h wall-clock) found the multi-agent path has `DELTA0_STAGNATION_HARDCAP=6` in `workflow.py:223-237` but the **autonomous loop had no equivalent**.

### Bug (P2)
- `AutonomousProver._run_session()` in `provers.py` has no delta-0 stagnation check
- `custom_Basic_L308` burned **5.9h** with 7 identical compiles producing zero sorry delta
- Other targets (Lattice DOCTOR_OPTIMAL, GaleShapley STABLE) also showed pathological delta-0 cycling

### Fix
- Add `consecutive_delta0 >= 6` check after phase transitions (L1113), before HITL
- Uses existing `tactic_tools._consecutive_delta0` counter (tracked in `tools.py:577/901`)
- Breaks loop when 6 consecutive compiles make zero progress
- Parity with multi-agent path (`workflow.py` hardcap)

### Evidence
- Trace: `multi_custom_Basic_L308_zai_result.json` — 5.9h, 7 delta-0 compiles
- `workflow.py:60-73`: DELTA0_STAGNATION_HARDCAP = 6 (multi mode)
- `tools.py:577`: `self._consecutive_delta0: int = 0` (already tracked)

### Files changed
- `agent_tests/prover/provers.py` (+12 lines) — stagnation guard in autonomous loop

See #1453 (prover Epic)