### PR TITLE
oublie de rendu du TP lean 5 tactics

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -2,17 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "17bf1bc5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004912,
-     "end_time": "2026-05-27T01:57:34.456831+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.451919+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Lean 5 - Mode Tactique\n",
     "\n",
@@ -61,17 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d822f2b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003657,
-     "end_time": "2026-05-27T01:57:34.464846+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.461189+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 1. Introduction au Mode Tactique\n",
     "\n",
@@ -83,109 +63,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "2d996e6e",
+   "cell_type": "raw",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:34.474222Z",
-     "iopub.status.busy": "2026-05-27T01:57:34.473954Z",
-     "iopub.status.idle": "2026-05-27T01:57:34.712297Z",
-     "shell.execute_reply": "2026-05-27T01:57:34.711589Z"
-    },
-    "papermill": {
-     "duration": 0.243929,
-     "end_time": "2026-05-27T01:57:34.712870+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.468941+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Meme theoreme, deux styles</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Style terme</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>impl_refl_term<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">fun</span><span class=\"w\"> </span>hp<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Style tactique</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>impl_refl_tactic<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>hp<span class=\"w\">      </span><span class=\"c1\">-- Introduire l&#39;hypothese hp : p</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  exact<span class=\"w\"> </span>hp<span class=\"w\">      </span><span class=\"c1\">-- Fournir exactement hp comme preuve</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>impl_refl_term<span class=\"w\">   </span><span class=\"c1\">-- impl_refl_term : (p : Prop) -&gt; p -&gt; p</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> impl_refl_term<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>p</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>impl_refl_tactic<span class=\"w\"> </span><span class=\"c1\">-- meme type</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> impl_refl_tactic<span class=\"w\"> </span>(p<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>p</blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Meme theoreme, deux styles\\n\\n-- Style terme\\ntheorem impl_refl_term (p : Prop) : p -> p :=\\n  fun hp => hp\\n\\n-- Style tactique\\ntheorem impl_refl_tactic (p : Prop) : p -> p := by\\n  intro hp      -- Introduire l'hypothese hp : p\\n  exact hp      -- Fournir exactement hp comme preuve\\n\\n#check impl_refl_term   -- impl_refl_term : (p : Prop) -> p -> p\\n#check impl_refl_tactic -- meme type\"}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"messages\":\r\n",
-       " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
-       "   \"data\": \"impl_refl_term (p : Prop) : p → p\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
-       "   \"data\": \"impl_refl_tactic (p : Prop) : p → p\"}],\r\n",
-       " \"env\": 0}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Meme theoreme, deux styles\n",
-       "\n",
-       "-- Style terme\n",
-       "theorem impl_refl_term (p : Prop) : p -> p :=\n",
-       "  fun hp => hp\n",
-       "\n",
-       "-- Style tactique\n",
-       "theorem impl_refl_tactic (p : Prop) : p -> p := by\n",
-       "  intro hp      -- Introduire l'hypothese hp : p\n",
-       "  exact hp      -- Fournir exactement hp comme preuve\n",
-       "\n",
-       "#check impl_refl_term   -- impl_refl_term : (p : Prop) -> p -> p\n",
-       "──────▶  impl_refl_term (p : Prop) : p → p\n",
-       "#check impl_refl_tactic -- meme type\n",
-       "──────▶  impl_refl_tactic (p : Prop) : p → p\n",
-       "--% env 0\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Meme theoreme, deux styles\\n\\n-- Style terme\\ntheorem impl_refl_term (p : Prop) : p -> p :=\\n  fun hp => hp\\n\\n-- Style tactique\\ntheorem impl_refl_tactic (p : Prop) : p -> p := by\\n  intro hp      -- Introduire l'hypothese hp : p\\n  exact hp      -- Fournir exactement hp comme preuve\\n\\n#check impl_refl_term   -- impl_refl_term : (p : Prop) -> p -> p\\n#check impl_refl_tactic -- meme type\"}\n",
-       "Raw output:\n",
-       "{\"messages\":\r\n",
-       " [{\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 12, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 12, \"column\": 6},\r\n",
-       "   \"data\": \"impl_refl_term (p : Prop) : p → p\"},\r\n",
-       "  {\"severity\": \"info\",\r\n",
-       "   \"pos\": {\"line\": 13, \"column\": 0},\r\n",
-       "   \"endPos\": {\"line\": 13, \"column\": 6},\r\n",
-       "   \"data\": \"impl_refl_tactic (p : Prop) : p → p\"}],\r\n",
-       " \"env\": 0}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    "vscode": {
+     "languageId": "raw"
     }
-   ],
+   },
    "source": [
     "-- Meme theoreme, deux styles\n",
     "\n",
@@ -204,17 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32371d33",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003595,
-     "end_time": "2026-05-27T01:57:34.720281+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.716686+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 1.2 L'etat de preuve\n",
     "\n",
@@ -232,23 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "1799fb34",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:34.727872Z",
-     "iopub.status.busy": "2026-05-27T01:57:34.727741Z",
-     "iopub.status.idle": "2026-05-27T01:57:34.833715Z",
-     "shell.execute_reply": "2026-05-27T01:57:34.833077Z"
-    },
-    "papermill": {
-     "duration": 0.110372,
-     "end_time": "2026-05-27T01:57:34.834169+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.723797+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -316,17 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cd3b600",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00377,
-     "end_time": "2026-05-27T01:57:34.841815+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.838045+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 2. Tactiques de Base\n",
     "\n",
@@ -338,23 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "f2e40954",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:34.849143Z",
-     "iopub.status.busy": "2026-05-27T01:57:34.849013Z",
-     "iopub.status.idle": "2026-05-27T01:57:34.956523Z",
-     "shell.execute_reply": "2026-05-27T01:57:34.955846Z"
-    },
-    "papermill": {
-     "duration": 0.111895,
-     "end_time": "2026-05-27T01:57:34.957054+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.845159+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -416,17 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "caf83a6d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003618,
-     "end_time": "2026-05-27T01:57:34.964510+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.960892+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 2.2 `intro` : introduction d'hypotheses\n",
     "\n",
@@ -438,23 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "9f814019",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:34.972436Z",
-     "iopub.status.busy": "2026-05-27T01:57:34.972321Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.083456Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.082674Z"
-    },
-    "papermill": {
-     "duration": 0.115835,
-     "end_time": "2026-05-27T01:57:35.084155+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:34.968320+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -471,12 +276,14 @@
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Introduction d&#39;implication</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>intro_impl<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>hp<span class=\"w\">     </span><span class=\"c1\">-- hp : p ajoute au contexte, but devient q -&gt; p</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>hq<span class=\"w\">     </span><span class=\"c1\">-- hq : q ajoute, but devient p</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\">  intro<span class=\"w\"> </span>hq<span class=\"w\">     </span><span class=\"c1\">-- hq : q ajoute, but devient p</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`hq</span><span class=\"bp\">`</span>\n",
+       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  exact<span class=\"w\"> </span>hp</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- intro multiple</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>intro_multi<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\">  </span><span class=\"c1\">-- Introduit les deux d&#39;un coup</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\">  intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\">  </span><span class=\"c1\">-- Introduit les deux d&#39;un coup</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`hq</span><span class=\"bp\">`</span>\n",
+       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  exact<span class=\"w\"> </span>hp</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Introduction de forall</span></span></span></pre>\n",
@@ -491,7 +298,18 @@
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 3}</code>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 10},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 11},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 13},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       " \"env\": 3}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -500,11 +318,15 @@
        "theorem intro_impl (p q : Prop) : p -> q -> p := by\n",
        "  intro hp     -- hp : p ajoute au contexte, but devient q -> p\n",
        "  intro hq     -- hq : q ajoute, but devient p\n",
+       "        ──▶ 🟨 unused variable `hq`\n",
+       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
        "  exact hp\n",
        "\n",
        "-- intro multiple\n",
        "theorem intro_multi (p q : Prop) : p -> q -> p := by\n",
        "  intro hp hq  -- Introduit les deux d'un coup\n",
+       "           ──▶ 🟨 unused variable `hq`\n",
+       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
        "  exact hp\n",
        "\n",
        "-- Introduction de forall\n",
@@ -516,7 +338,18 @@
        "Raw input:\n",
        "{\"cmd\": \"-- Introduction d'implication\\ntheorem intro_impl (p q : Prop) : p -> q -> p := by\\n  intro hp     -- hp : p ajoute au contexte, but devient q -> p\\n  intro hq     -- hq : q ajoute, but devient p\\n  exact hp\\n\\n-- intro multiple\\ntheorem intro_multi (p q : Prop) : p -> q -> p := by\\n  intro hp hq  -- Introduit les deux d'un coup\\n  exact hp\\n\\n-- Introduction de forall\\ntheorem intro_forall : forall n : Nat, n + 0 = n := by\\n  intro n      -- n : Nat ajoute au contexte\\n  rfl          -- Preuve par reflexivite (calcul)\", \"env\": 2}\n",
        "Raw output:\n",
-       "{\"env\": 3}"
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 10},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 9, \"column\": 11},\r\n",
+       "   \"endPos\": {\"line\": 9, \"column\": 13},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       " \"env\": 3}"
       ]
      },
      "metadata": {},
@@ -543,17 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd153878",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004356,
-     "end_time": "2026-05-27T01:57:35.093140+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.088784+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 2.3 `apply` : appliquer un lemme/hypothese\n",
     "\n",
@@ -563,23 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "45ee591b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.102234Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.102048Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.208899Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.208246Z"
-    },
-    "papermill": {
-     "duration": 0.112039,
-     "end_time": "2026-05-27T01:57:35.209369+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.097330+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -662,17 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1fcbf065",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003743,
-     "end_time": "2026-05-27T01:57:35.217265+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.213522+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 2.4 `assumption` : chercher dans le contexte\n",
     "\n",
@@ -682,23 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "63cdc226",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.225445Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.225305Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.331974Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.331497Z"
-    },
-    "papermill": {
-     "duration": 0.111755,
-     "end_time": "2026-05-27T01:57:35.332685+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.220930+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -713,9 +494,8 @@
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- assumption trouve automatiquement l&#39;hypothese</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>assumption_example<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>(hp<span class=\"w\"> </span>:<span class=\"w\"> </span>p)<span class=\"w\"> </span>(hq<span class=\"w\"> </span>:<span class=\"w\"> </span>q)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`hq</span><span class=\"bp\">`</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>assumption_example<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>(hp<span class=\"w\"> </span>:<span class=\"w\"> </span>p)<span class=\"w\"> </span>(hq<span class=\"w\"> </span>:<span class=\"w\"> </span>q)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`hq</span><span class=\"bp\">`</span>\n",
+       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  assumption<span class=\"w\">   </span><span class=\"c1\">-- Trouve hp : p dans le contexte</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Utile quand on ne veut pas nommer</span></span></span></pre>\n",
@@ -737,7 +517,7 @@
        "   \"pos\": {\"line\": 2, \"column\": 50},\r\n",
        "   \"endPos\": {\"line\": 2, \"column\": 52},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `hq`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
        " \"env\": 5}</code>\n",
        "        </details>\n",
        "    "
@@ -746,8 +526,7 @@
        "-- assumption trouve automatiquement l'hypothese\n",
        "theorem assumption_example (p q : Prop) (hp : p) (hq : q) : p := by\n",
        "                                                  ──▶ 🟨 unused variable `hq`\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedVariables false`\n",
+       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
        "  assumption   -- Trouve hp : p dans le contexte\n",
        "\n",
        "-- Utile quand on ne veut pas nommer\n",
@@ -766,7 +545,7 @@
        "   \"pos\": {\"line\": 2, \"column\": 50},\r\n",
        "   \"endPos\": {\"line\": 2, \"column\": 52},\r\n",
        "   \"data\":\r\n",
-       "   \"unused variable `hq`\\n\\nNote: This linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       "   \"unused variable `hq`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
        " \"env\": 5}"
       ]
      },
@@ -789,17 +568,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "405db572",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004076,
-     "end_time": "2026-05-27T01:57:35.340830+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.336754+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 2.5 `rfl` : reflexivite\n",
     "\n",
@@ -809,23 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "f5244c6a",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.349126Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.349004Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.458774Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.458111Z"
-    },
-    "papermill": {
-     "duration": 0.11493,
-     "end_time": "2026-05-27T01:57:35.459663+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.344733+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -890,17 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74e9802f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003991,
-     "end_time": "2026-05-27T01:57:35.467800+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.463809+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 3. Gestion du Contexte\n",
     "\n",
@@ -910,23 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c937eb84",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.476550Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.476432Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.588016Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.587246Z"
-    },
-    "papermill": {
-     "duration": 0.116498,
-     "end_time": "2026-05-27T01:57:35.588438+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.471940+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1009,17 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f2ac925",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003922,
-     "end_time": "2026-05-27T01:57:35.596591+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.592669+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 3.2 `let` : definitions locales\n",
     "\n",
@@ -1029,23 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "f6ad0774",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.605786Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.605650Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.736974Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.736226Z"
-    },
-    "papermill": {
-     "duration": 0.13647,
-     "end_time": "2026-05-27T01:57:35.737535+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.601065+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1065,8 +766,10 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"c1\">-- On peut prouver manuellement avec les lemmes de Nat</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">show</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">2</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">have</span><span class=\"w\"> </span>h1<span class=\"w\"> </span>:<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>m<span class=\"w\"> </span>:=<span class=\"w\"> </span>Nat<span class=\"bp\">.</span>mul_comm<span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"mi\">2</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">have</span><span class=\"w\"> </span>h2<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">have</span><span class=\"w\"> </span>h3<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>Nat<span class=\"bp\">.</span>mul_add<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\">  <span class=\"k\">have</span><span class=\"w\"> </span>h2<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`h2</span><span class=\"bp\">`</span>\n",
+       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\">  <span class=\"k\">have</span><span class=\"w\"> </span>h3<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>Nat<span class=\"bp\">.</span>mul_add<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"mi\">1</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>unused<span class=\"w\"> </span><span class=\"kn\">variable</span><span class=\"w\"> </span><span class=\"ss\">`h3</span><span class=\"bp\">`</span>\n",
+       "note:<span class=\"w\"> </span>this<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedVariables<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"k\">calc</span><span class=\"w\"> </span>m<span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>m<span class=\"w\"> </span>:=<span class=\"w\"> </span>h1</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">       <span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">1</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span>rfl</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">       <span class=\"bp\">_</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>Nat<span class=\"bp\">.</span>mul_add<span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"mi\">1</span></span></span></pre>\n",
@@ -1079,7 +782,18 @@
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 8}</code>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 9},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `h2`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 9},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `h3`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       " \"env\": 8}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -1091,7 +805,11 @@
        "  show m * 2 = 2 * n + 2\n",
        "  have h1 : m * 2 = 2 * m := Nat.mul_comm m 2\n",
        "  have h2 : 2 * m = 2 * (n + 1) := rfl\n",
+       "       ──▶ 🟨 unused variable `h2`\n",
+       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
        "  have h3 : 2 * (n + 1) = 2 * n + 2 := Nat.mul_add 2 n 1\n",
+       "       ──▶ 🟨 unused variable `h3`\n",
+       "note: this linter can be disabled with `set_option linter.unusedVariables false`\n",
        "  calc m * 2 = 2 * m := h1\n",
        "       _ = 2 * (n + 1) := rfl\n",
        "       _ = 2 * n + 2 * 1 := Nat.mul_add 2 n 1\n",
@@ -1101,7 +819,18 @@
        "Raw input:\n",
        "{\"cmd\": \"-- let pour des valeurs calculees\\ntheorem let_example (n : Nat) : (n + 1) * 2 = 2 * n + 2 := by\\n  let m := n + 1     -- m = n + 1 visible dans le contexte\\n  -- On peut prouver manuellement avec les lemmes de Nat\\n  show m * 2 = 2 * n + 2\\n  have h1 : m * 2 = 2 * m := Nat.mul_comm m 2\\n  have h2 : 2 * m = 2 * (n + 1) := rfl\\n  have h3 : 2 * (n + 1) = 2 * n + 2 := Nat.mul_add 2 n 1\\n  calc m * 2 = 2 * m := h1\\n       _ = 2 * (n + 1) := rfl\\n       _ = 2 * n + 2 * 1 := Nat.mul_add 2 n 1\\n       _ = 2 * n + 2 := by rfl\", \"env\": 7}\n",
        "Raw output:\n",
-       "{\"env\": 8}"
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 7, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 7, \"column\": 9},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `h2`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"},\r\n",
+       "  {\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 8, \"column\": 7},\r\n",
+       "   \"endPos\": {\"line\": 8, \"column\": 9},\r\n",
+       "   \"data\":\r\n",
+       "   \"unused variable `h3`\\nnote: this linter can be disabled with `set_option linter.unusedVariables false`\"}],\r\n",
+       " \"env\": 8}"
       ]
      },
      "metadata": {},
@@ -1125,17 +854,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51847327",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004231,
-     "end_time": "2026-05-27T01:57:35.746297+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.742066+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 3.3 `show` : annoter le but\n",
     "\n",
@@ -1145,23 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d7673f0c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.755496Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.755135Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.861398Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.860699Z"
-    },
-    "papermill": {
-     "duration": 0.111497,
-     "end_time": "2026-05-27T01:57:35.861887+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.750390+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1226,17 +929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb7bc147",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004262,
-     "end_time": "2026-05-27T01:57:35.870555+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.866293+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 3.4 `revert` : remettre dans le but\n",
     "\n",
@@ -1246,23 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "7b22e015",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:35.879827Z",
-     "iopub.status.busy": "2026-05-27T01:57:35.879707Z",
-     "iopub.status.idle": "2026-05-27T01:57:35.985051Z",
-     "shell.execute_reply": "2026-05-27T01:57:35.984397Z"
-    },
-    "papermill": {
-     "duration": 0.110562,
-     "end_time": "2026-05-27T01:57:35.985619+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.875057+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1327,17 +1004,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74f93458",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004444,
-     "end_time": "2026-05-27T01:57:35.994518+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.990074+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 4. Tactiques pour la Logique\n",
     "\n",
@@ -1347,23 +1014,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "d116e2e1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.003786Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.003647Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.117535Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.116683Z"
-    },
-    "papermill": {
-     "duration": 0.119219,
-     "end_time": "2026-05-27T01:57:36.118059+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:35.998840+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1476,17 +1127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b70a5584",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004503,
-     "end_time": "2026-05-27T01:57:36.127565+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.123062+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 4.2 `cases` : analyse par cas\n",
     "\n",
@@ -1496,23 +1137,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "db139759",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.137394Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.137252Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.251636Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.251105Z"
-    },
-    "papermill": {
-     "duration": 0.120632,
-     "end_time": "2026-05-27T01:57:36.252844+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.132212+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1607,17 +1232,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a4f14a25",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005162,
-     "end_time": "2026-05-27T01:57:36.263034+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.257872+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 4.3 `left` et `right` : introduction de Or\n",
     "\n",
@@ -1627,23 +1242,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "18307adc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.273510Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.273360Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.380439Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.379698Z"
-    },
-    "papermill": {
-     "duration": 0.113123,
-     "end_time": "2026-05-27T01:57:36.381078+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.267955+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1711,17 +1310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58e75458",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005864,
-     "end_time": "2026-05-27T01:57:36.392289+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.386425+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 4.4 `contradiction` : detecter l'absurdite\n",
     "\n",
@@ -1731,23 +1320,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "81c6424d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.435070Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.434806Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.543048Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.542356Z"
-    },
-    "papermill": {
-     "duration": 0.115877,
-     "end_time": "2026-05-27T01:57:36.543532+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.427655+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1812,17 +1385,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68918a35",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004659,
-     "end_time": "2026-05-27T01:57:36.553363+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.548704+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 5. Reecriture avec `rw`\n",
     "\n",
@@ -1834,23 +1397,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "36816a73",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.563655Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.563512Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.678751Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.677861Z"
-    },
-    "papermill": {
-     "duration": 0.121312,
-     "end_time": "2026-05-27T01:57:36.679302+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.557990+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1927,17 +1474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44cb4396",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006427,
-     "end_time": "2026-05-27T01:57:36.691555+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.685128+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 5.2 Reecriture avec lemmes de la bibliotheque\n",
     "\n",
@@ -1947,23 +1484,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "182cdbc9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.704272Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.704115Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.824301Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.823459Z"
-    },
-    "papermill": {
-     "duration": 0.127012,
-     "end_time": "2026-05-27T01:57:36.824835+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.697823+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2043,17 +1564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "875f866e",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005216,
-     "end_time": "2026-05-27T01:57:36.835577+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.830361+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 5.3 Reecriture dans le contexte avec `at`"
    ]
@@ -2061,23 +1572,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "6eeec3ad",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.846961Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.846824Z",
-     "iopub.status.idle": "2026-05-27T01:57:36.961908Z",
-     "shell.execute_reply": "2026-05-27T01:57:36.960755Z"
-    },
-    "papermill": {
-     "duration": 0.121532,
-     "end_time": "2026-05-27T01:57:36.962445+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.840913+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2148,17 +1643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "589d7c21",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005685,
-     "end_time": "2026-05-27T01:57:36.974305+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.968620+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 6. Simplification avec `simp`\n",
     "\n",
@@ -2170,23 +1655,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "1c8cf1a6",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:36.987145Z",
-     "iopub.status.busy": "2026-05-27T01:57:36.986988Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.109240Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.108295Z"
-    },
-    "papermill": {
-     "duration": 0.129361,
-     "end_time": "2026-05-27T01:57:37.109918+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:36.980557+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2260,17 +1729,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aea953de",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006639,
-     "end_time": "2026-05-27T01:57:37.123685+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.117046+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 6.2 Options de simp"
    ]
@@ -2278,23 +1737,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "e00b63d2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.137805Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.137638Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.256757Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.255438Z"
-    },
-    "papermill": {
-     "duration": 0.128131,
-     "end_time": "2026-05-27T01:57:37.257930+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.129799+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2371,17 +1814,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64af1a30",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005903,
-     "end_time": "2026-05-27T01:57:37.270337+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.264434+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 6.3 L'attribut `@[simp]`\n",
     "\n",
@@ -2391,23 +1824,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "497820cf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.282616Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.282471Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.392862Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.392154Z"
-    },
-    "papermill": {
-     "duration": 0.117374,
-     "end_time": "2026-05-27T01:57:37.393458+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.276084+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2469,17 +1886,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d2a77dd",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005663,
-     "end_time": "2026-05-27T01:57:37.405243+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.399580+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 7. Structuration des Preuves\n",
     "\n",
@@ -2489,23 +1896,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "eb55cf94",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.417732Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.417578Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.525199Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.523887Z"
-    },
-    "papermill": {
-     "duration": 0.114991,
-     "end_time": "2026-05-27T01:57:37.525868+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.410877+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2570,17 +1961,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81603479",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006819,
-     "end_time": "2026-05-27T01:57:37.539068+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.532249+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 7.2 `case` pour nommer les cas"
    ]
@@ -2588,23 +1969,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "cefe9134",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.552600Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.552441Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.659784Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.659014Z"
-    },
-    "papermill": {
-     "duration": 0.114681,
-     "end_time": "2026-05-27T01:57:37.660315+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.545634+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2675,17 +2040,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b56cefe",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005913,
-     "end_time": "2026-05-27T01:57:37.672329+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.666416+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 7.3 Combinateurs `;` et `<;>`"
    ]
@@ -2693,23 +2048,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "abd55f74",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.685688Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.685534Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.797096Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.796400Z"
-    },
-    "papermill": {
-     "duration": 0.118936,
-     "end_time": "2026-05-27T01:57:37.797627+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.678691+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2786,17 +2125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63c6176f",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007728,
-     "end_time": "2026-05-27T01:57:37.811677+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.803949+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 8. Tactiques Avancees\n",
     "\n",
@@ -2806,23 +2135,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "e4ca8a52",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.826572Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.826415Z",
-     "iopub.status.idle": "2026-05-27T01:57:37.945401Z",
-     "shell.execute_reply": "2026-05-27T01:57:37.944502Z"
-    },
-    "papermill": {
-     "duration": 0.127035,
-     "end_time": "2026-05-27T01:57:37.945959+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.818924+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2850,13 +2163,7 @@
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>my_add_zero<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>n<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  induction<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>zero<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>rfl</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\">  <span class=\"bp\">|</span><span class=\"w\"> </span>succ<span class=\"w\"> </span>k<span class=\"w\"> </span>ih<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>simp<span class=\"w\"> </span>[ih]</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>This<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>is<span class=\"w\"> </span>unused:\n",
-       "<span class=\"w\">  </span>ih\n",
-       "\n",
-       "Hint:<span class=\"w\"> </span>Omit<span class=\"w\"> </span>it<span class=\"w\"> </span><span class=\"k\">from</span><span class=\"w\"> </span>the<span class=\"w\"> </span>simp<span class=\"w\"> </span>argument<span class=\"w\"> </span>list<span class=\"bp\">.</span>\n",
-       "<span class=\"w\">  </span>simp<span class=\"w\"> </span><span class=\"bp\">̵</span>[<span class=\"bp\">̵</span>i<span class=\"bp\">̵</span>h<span class=\"bp\">̵</span>]<span class=\"bp\">̵</span>\n",
-       "\n",
-       "Note:<span class=\"w\"> </span>This<span class=\"w\"> </span>linter<span class=\"w\"> </span>can<span class=\"w\"> </span>be<span class=\"w\"> </span>disabled<span class=\"w\"> </span><span class=\"k\">with</span><span class=\"w\"> </span><span class=\"ss\">`set_option</span><span class=\"w\"> </span>linter<span class=\"bp\">.</span>unusedSimpArgs<span class=\"w\"> </span>false<span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">|</span><span class=\"w\"> </span>succ<span class=\"w\"> </span>k<span class=\"w\"> </span>ih<span class=\"w\"> </span><span class=\"bp\">=&gt;</span><span class=\"w\"> </span>simp<span class=\"w\"> </span>[ih]</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 24</span></span></span></pre>\n",
        "        </div>\n",
        "        <details>\n",
@@ -2865,13 +2172,7 @@
        "        </details>\n",
        "        <details>\n",
        "            <summary>Raw output</summary>\n",
-       "            <code>{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 15, \"column\": 23},\r\n",
-       "   \"endPos\": {\"line\": 15, \"column\": 25},\r\n",
-       "   \"data\":\r\n",
-       "   \"This simp argument is unused:\\n  ih\\n\\nHint: Omit it from the simp argument list.\\n  simp ̵[̵i̵h̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"}],\r\n",
-       " \"env\": 24}</code>\n",
+       "            <code>{\"env\": 24}</code>\n",
        "        </details>\n",
        "    "
       ],
@@ -2891,25 +2192,12 @@
        "  induction n with\n",
        "  | zero => rfl\n",
        "  | succ k ih => simp [ih]\n",
-       "                       ──▶ 🟨 This simp argument is unused:\n",
-       "  ih\n",
-       "\n",
-       "Hint: Omit it from the simp argument list.\n",
-       "  simp ̵[̵i̵h̵]̵\n",
-       "\n",
-       "Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`\n",
        "--% env 24\n",
        "\n",
        "Raw input:\n",
        "{\"cmd\": \"-- Recurrence sur Nat\\n-- Exemple simple : 0 + n = n (deja dans la bibliotheque, on le reprouve)\\ntheorem my_zero_add (n : Nat) : 0 + n = n := by\\n  induction n with\\n  | zero => rfl\\n  | succ k ih =>\\n    -- But : 0 + (k + 1) = k + 1\\n    -- On utilise la definition de + pour Nat\\n    simp only [Nat.add_succ, ih]\\n\\n-- Exemple : n + 0 = n\\ntheorem my_add_zero (n : Nat) : n + 0 = n := by\\n  induction n with\\n  | zero => rfl\\n  | succ k ih => simp [ih]\", \"env\": 23}\n",
        "Raw output:\n",
-       "{\"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 15, \"column\": 23},\r\n",
-       "   \"endPos\": {\"line\": 15, \"column\": 25},\r\n",
-       "   \"data\":\r\n",
-       "   \"This simp argument is unused:\\n  ih\\n\\nHint: Omit it from the simp argument list.\\n  simp ̵[̵i̵h̵]̵\\n\\nNote: This linter can be disabled with `set_option linter.unusedSimpArgs false`\"}],\r\n",
-       " \"env\": 24}"
+       "{\"env\": 24}"
       ]
      },
      "metadata": {},
@@ -2936,17 +2224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "edb2e20d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.0076,
-     "end_time": "2026-05-27T01:57:37.960612+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.953012+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 8.2 `decide` : propositions decidables"
    ]
@@ -2954,23 +2232,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "a53ec84b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:37.975190Z",
-     "iopub.status.busy": "2026-05-27T01:57:37.975037Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.089893Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.089167Z"
-    },
-    "papermill": {
-     "duration": 0.123447,
-     "end_time": "2026-05-27T01:57:38.090697+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:37.967250+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3038,17 +2300,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "636978fd",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006332,
-     "end_time": "2026-05-27T01:57:38.104076+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.097744+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 8.3 `omega` : arithmetique lineaire"
    ]
@@ -3056,23 +2308,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "9f0f0026",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.117624Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.117471Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.256126Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.255427Z"
-    },
-    "papermill": {
-     "duration": 0.146346,
-     "end_time": "2026-05-27T01:57:38.256770+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.110424+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3137,17 +2373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0de421f5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005869,
-     "end_time": "2026-05-27T01:57:38.268882+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.263013+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 8.4 `ring` : algebre"
    ]
@@ -3155,23 +2381,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "f32f45f1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.281913Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.281761Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.396426Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.395632Z"
-    },
-    "papermill": {
-     "duration": 0.12269,
-     "end_time": "2026-05-27T01:57:38.397521+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.274831+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3254,17 +2464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b189bc94",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006518,
-     "end_time": "2026-05-27T01:57:38.410484+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.403966+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 9. Melange Termes et Tactiques\n",
     "\n",
@@ -3274,23 +2474,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "b4ec3331",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.423285Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.423122Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.533316Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.532592Z"
-    },
-    "papermill": {
-     "duration": 0.117319,
-     "end_time": "2026-05-27T01:57:38.533843+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.416524+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3361,17 +2545,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c856651d",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00638,
-     "end_time": "2026-05-27T01:57:38.546838+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.540458+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### 9.2 Termes dans les tactiques"
    ]
@@ -3379,23 +2553,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "37f1d764",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.559577Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.559440Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.667726Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.666938Z"
-    },
-    "papermill": {
-     "duration": 0.115386,
-     "end_time": "2026-05-27T01:57:38.668213+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.552827+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3463,17 +2621,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "754f3737",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006213,
-     "end_time": "2026-05-27T01:57:38.681352+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.675139+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## 10. Exercices\n",
     "\n",
@@ -3482,24 +2630,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "id": "f382bcf1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.694166Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.694020Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.802658Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.801654Z"
-    },
-    "papermill": {
-     "duration": 0.116035,
-     "end_time": "2026-05-27T01:57:38.803293+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.687258+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3515,7 +2647,7 @@
        "        <div class=\"alectryon-root alectryon-centered\">\n",
        "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">variable</span><span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)</span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_assoc_tactic<span class=\"w\"> </span>:<span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_assoc_tactic<span class=\"w\"> </span>:<span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 30</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
@@ -3572,47 +2704,41 @@
    "source": [
     "variable (p q r : Prop)\n",
     "\n",
-    "theorem and_assoc_tactic : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-    "  sorry"
+    "theorem and_assoc_practice (p q r : Prop) : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
+    "  constructor\n",
+    "  · intro h\n",
+    "    cases h with\n",
+    "    | intro hpq hr =>\n",
+    "      cases hpq with\n",
+    "      | intro hp hq =>\n",
+    "        constructor\n",
+    "        · exact hp\n",
+    "        · constructor\n",
+    "          · exact hq\n",
+    "          · exact hr\n",
+    "  · intro h\n",
+    "    cases h with\n",
+    "    | intro hp hqr =>\n",
+    "      cases hqr with\n",
+    "      | intro hq hr =>\n",
+    "        constructor\n",
+    "        · constructor\n",
+    "          · exact hp\n",
+    "          · exact hq\n",
+    "        · exact hr"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a28082f5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006694,
-     "end_time": "2026-05-27T01:57:38.816501+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.809807+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Exercice 2 : Utiliser rw pour une preuve arithmetique"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "9009ecb1",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.829700Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.829562Z",
-     "iopub.status.idle": "2026-05-27T01:57:38.939873Z",
-     "shell.execute_reply": "2026-05-27T01:57:38.939053Z"
-    },
-    "papermill": {
-     "duration": 0.117587,
-     "end_time": "2026-05-27T01:57:38.940356+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.822769+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3626,7 +2752,7 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>arith_rw<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>arith_rw<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 31</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
@@ -3679,47 +2805,22 @@
     }
    ],
    "source": [
-    "theorem arith_rw (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-    "  sorry"
+    "theorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
+    "  rw [Nat.two_mul]\n",
+    "  rw [Nat.add_comm b a]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "567872b0",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006578,
-     "end_time": "2026-05-27T01:57:38.953595+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.947017+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Exercice 3 : Analyse par cas avec Or"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "5614eaac",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:38.967307Z",
-     "iopub.status.busy": "2026-05-27T01:57:38.967173Z",
-     "iopub.status.idle": "2026-05-27T01:57:39.075173Z",
-     "shell.execute_reply": "2026-05-27T01:57:39.073929Z"
-    },
-    "papermill": {
-     "duration": 0.11605,
-     "end_time": "2026-05-27T01:57:39.076087+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:38.960037+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -3733,7 +2834,7 @@
        "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
        "    \n",
        "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>or_distrib<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>or_distrib<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>r)<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
        "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 32</span></span></span></pre>\n",
@@ -3788,254 +2889,6 @@
     }
    ],
    "source": [
-    "theorem or_distrib (p q r : Prop) :\n",
-    "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-    "  sorry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ac1958b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007411,
-     "end_time": "2026-05-27T01:57:39.091297+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.083886+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exemples guides : Preuves tactiques\n",
-    "\n",
-    "Voici trois exemples complets illustrant les tactiques `constructor`, `rw` et `cases`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "id": "80ef06cc",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:39.107544Z",
-     "iopub.status.busy": "2026-05-27T01:57:39.107377Z",
-     "iopub.status.idle": "2026-05-27T01:57:39.249523Z",
-     "shell.execute_reply": "2026-05-27T01:57:39.248801Z"
-    },
-    "papermill": {
-     "duration": 0.151227,
-     "end_time": "2026-05-27T01:57:39.250064+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.098837+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exemple guide 1 : Associativite de la conjonction (avec tactics)</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Demonstrateur : constructor, intro, cases, exact</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_assoc_practice<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hpq<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hq<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exemple guide 2 : Manipulation arithmetique avec rw</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>arith_rw_practice<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>(b<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span><span class=\"mi\">2</span><span class=\"w\"> </span><span class=\"bp\">*</span><span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  rw<span class=\"w\"> </span>[Nat<span class=\"bp\">.</span>two_mul]</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  rw<span class=\"w\"> </span>[Nat<span class=\"bp\">.</span>add_comm<span class=\"w\"> </span>b<span class=\"w\"> </span>a]</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exemple guide 3 : Distribution avec tactics</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Demonstrateur : constructor, intro, cases, left/right</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>or_distrib_practice<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>r<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>(q<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>r)<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>(p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>r)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hqr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>inl<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        left</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>inr<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        right</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"bp\">·</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>h</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    cases<span class=\"w\"> </span>h<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>inl<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpq<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hq<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>left</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          exact<span class=\"w\"> </span>hq</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">    <span class=\"bp\">|</span><span class=\"w\"> </span>inr<span class=\"w\"> </span>hpr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      cases<span class=\"w\"> </span>hpr<span class=\"w\"> </span><span class=\"k\">with</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">      <span class=\"bp\">|</span><span class=\"w\"> </span>intro<span class=\"w\"> </span>hp<span class=\"w\"> </span>hr<span class=\"w\"> </span><span class=\"bp\">=&gt;</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        constructor</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>exact<span class=\"w\"> </span>hp</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">        <span class=\"bp\">·</span><span class=\"w\"> </span>right</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">          exact<span class=\"w\"> </span>hr</span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 33</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 32}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"env\": 33}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\n",
-       "-- Demonstrateur : constructor, intro, cases, exact\n",
-       "theorem and_assoc_practice (p q r : Prop) : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-       "  constructor\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hpq hr =>\n",
-       "      cases hpq with\n",
-       "      | intro hp hq =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · constructor\n",
-       "          · exact hq\n",
-       "          · exact hr\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hp hqr =>\n",
-       "      cases hqr with\n",
-       "      | intro hq hr =>\n",
-       "        constructor\n",
-       "        · constructor\n",
-       "          · exact hp\n",
-       "          · exact hq\n",
-       "        · exact hr\n",
-       "\n",
-       "-- Exemple guide 2 : Manipulation arithmetique avec rw\n",
-       "-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\n",
-       "theorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-       "  rw [Nat.two_mul]\n",
-       "  rw [Nat.add_comm b a]\n",
-       "\n",
-       "-- Exemple guide 3 : Distribution avec tactics\n",
-       "-- Demonstrateur : constructor, intro, cases, left/right\n",
-       "theorem or_distrib_practice (p q r : Prop) :\n",
-       "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
-       "  constructor\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | intro hp hqr =>\n",
-       "      cases hqr with\n",
-       "      | inl hq =>\n",
-       "        left\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · exact hq\n",
-       "      | inr hr =>\n",
-       "        right\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · exact hr\n",
-       "  · intro h\n",
-       "    cases h with\n",
-       "    | inl hpq =>\n",
-       "      cases hpq with\n",
-       "      | intro hp hq =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · left\n",
-       "          exact hq\n",
-       "    | inr hpr =>\n",
-       "      cases hpr with\n",
-       "      | intro hp hr =>\n",
-       "        constructor\n",
-       "        · exact hp\n",
-       "        · right\n",
-       "          exact hr\n",
-       "--% env 33\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\\n-- Demonstrateur : constructor, intro, cases, exact\\ntheorem and_assoc_practice (p q r : Prop) : (p /\\\\ q) /\\\\ r <-> p /\\\\ (q /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hpq hr =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 constructor\\n          \\u00b7 exact hq\\n          \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | intro hq hr =>\\n        constructor\\n        \\u00b7 constructor\\n          \\u00b7 exact hp\\n          \\u00b7 exact hq\\n        \\u00b7 exact hr\\n\\n-- Exemple guide 2 : Manipulation arithmetique avec rw\\n-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\\ntheorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\\n  rw [Nat.two_mul]\\n  rw [Nat.add_comm b a]\\n\\n-- Exemple guide 3 : Distribution avec tactics\\n-- Demonstrateur : constructor, intro, cases, left/right\\ntheorem or_distrib_practice (p q r : Prop) :\\n  p /\\\\ (q \\\\/ r) <-> (p /\\\\ q) \\\\/ (p /\\\\ r) := by\\n  constructor\\n  \\u00b7 intro h\\n    cases h with\\n    | intro hp hqr =>\\n      cases hqr with\\n      | inl hq =>\\n        left\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hq\\n      | inr hr =>\\n        right\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 exact hr\\n  \\u00b7 intro h\\n    cases h with\\n    | inl hpq =>\\n      cases hpq with\\n      | intro hp hq =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 left\\n          exact hq\\n    | inr hpr =>\\n      cases hpr with\\n      | intro hp hr =>\\n        constructor\\n        \\u00b7 exact hp\\n        \\u00b7 right\\n          exact hr\", \"env\": 32}\n",
-       "Raw output:\n",
-       "{\"env\": 33}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exemple guide 1 : Associativite de la conjonction (avec tactics)\n",
-    "-- Demonstrateur : constructor, intro, cases, exact\n",
-    "theorem and_assoc_practice (p q r : Prop) : (p /\\ q) /\\ r <-> p /\\ (q /\\ r) := by\n",
-    "  constructor\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | intro hpq hr =>\n",
-    "      cases hpq with\n",
-    "      | intro hp hq =>\n",
-    "        constructor\n",
-    "        · exact hp\n",
-    "        · constructor\n",
-    "          · exact hq\n",
-    "          · exact hr\n",
-    "  · intro h\n",
-    "    cases h with\n",
-    "    | intro hp hqr =>\n",
-    "      cases hqr with\n",
-    "      | intro hq hr =>\n",
-    "        constructor\n",
-    "        · constructor\n",
-    "          · exact hp\n",
-    "          · exact hq\n",
-    "        · exact hr\n",
-    "\n",
-    "-- Exemple guide 2 : Manipulation arithmetique avec rw\n",
-    "-- Demonstrateur : rw avec Nat.two_mul et Nat.add_comm\n",
-    "theorem arith_rw_practice (a b : Nat) : (a + b) + (b + a) = 2 * (a + b) := by\n",
-    "  rw [Nat.two_mul]\n",
-    "  rw [Nat.add_comm b a]\n",
-    "\n",
-    "-- Exemple guide 3 : Distribution avec tactics\n",
-    "-- Demonstrateur : constructor, intro, cases, left/right\n",
     "theorem or_distrib_practice (p q r : Prop) :\n",
     "  p /\\ (q \\/ r) <-> (p /\\ q) \\/ (p /\\ r) := by\n",
     "  constructor\n",
@@ -4073,369 +2926,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d532845b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006638,
-     "end_time": "2026-05-27T01:57:39.263716+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.257078+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Exercices a completer\n",
-    "\n",
-    "Remplacez `sorry` par votre preuve en utilisant les tactiques vues dans les exemples ci-dessus.\n",
-    "\n",
-    "### Exercice 1 : Commutativite de la conjunction\n",
-    "\n",
-    "Prouvez que `p /\\ q <-> q /\\ p` en utilisant `constructor`, `intro`, `cases` et `exact`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "id": "0b2e60f0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:39.277247Z",
-     "iopub.status.busy": "2026-05-27T01:57:39.277106Z",
-     "iopub.status.idle": "2026-05-27T01:57:39.383875Z",
-     "shell.execute_reply": "2026-05-27T01:57:39.383343Z"
-    },
-    "language": "lean4",
-    "papermill": {
-     "duration": 0.114739,
-     "end_time": "2026-05-27T01:57:39.384777+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.270038+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : Commutativite de la conjunction</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez p /\\ q &lt;-&gt; q /\\ p</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>and_comm_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">&lt;-&gt;</span><span class=\"w\"> </span>q<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span>p<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 34</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 3</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 33}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 3,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 62},\r\n",
-       "   \"goal\": \"p q : Prop\\n⊢ p ∧ q ↔ q ∧ p\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 67}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 34}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exercice 1 : Commutativite de la conjunction\n",
-       "-- TODO etudiant : prouvez p /\\ q <-> q /\\ p\n",
-       "theorem and_comm_exercise (p q : Prop) : p /\\ q <-> q /\\ p := sorry\n",
-       "        ─────────────────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "--% env 34\n",
-       "--% prove 3\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 1 : Commutativite de la conjunction\\n-- TODO etudiant : prouvez p /\\\\ q <-> q /\\\\ p\\ntheorem and_comm_exercise (p q : Prop) : p /\\\\ q <-> q /\\\\ p := sorry\\n\", \"env\": 33}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 3,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 62},\r\n",
-       "   \"goal\": \"p q : Prop\\n⊢ p ∧ q ↔ q ∧ p\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 67}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 34}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exercice 1 : Commutativite de la conjunction\n",
-    "-- TODO etudiant : prouvez p /\\ q <-> q /\\ p\n",
-    "theorem and_comm_exercise (p q : Prop) : p /\\ q <-> q /\\ p := sorry\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0cc13061",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007873,
-     "end_time": "2026-05-27T01:57:39.399639+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.391766+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 2 : Addition avec associativite et commutativite\n",
-    "\n",
-    "Prouvez que `(a + b) + c = (c + a) + b` en utilisant `rw` avec les lemmes de `Nat`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "1dcfda73",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:39.414661Z",
-     "iopub.status.busy": "2026-05-27T01:57:39.414514Z",
-     "iopub.status.idle": "2026-05-27T01:57:39.523530Z",
-     "shell.execute_reply": "2026-05-27T01:57:39.522696Z"
-    },
-    "language": "lean4",
-    "papermill": {
-     "duration": 0.117617,
-     "end_time": "2026-05-27T01:57:39.524230+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.406613+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : Rearrangement avec rw</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez (a + b) + c = (c + a) + b</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Indice : Nat.add_assoc, Nat.add_comm</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>rearrange_exercise<span class=\"w\"> </span>(a<span class=\"w\"> </span>b<span class=\"w\"> </span>c<span class=\"w\"> </span>:<span class=\"w\"> </span>Nat)<span class=\"w\"> </span>:<span class=\"w\"> </span>(a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>c<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>(c<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>a)<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>b<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 35</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 4</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 34}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 4,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 72},\r\n",
-       "   \"goal\": \"a b c : Nat\\n⊢ a + b + c = c + a + b\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 77}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 26},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 35}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exercice 2 : Rearrangement avec rw\n",
-       "-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\n",
-       "-- Indice : Nat.add_assoc, Nat.add_comm\n",
-       "theorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\n",
-       "        ──────────────────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "--% env 35\n",
-       "--% prove 4\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 2 : Rearrangement avec rw\\n-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\\n-- Indice : Nat.add_assoc, Nat.add_comm\\ntheorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\\n\", \"env\": 34}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 4,\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 72},\r\n",
-       "   \"goal\": \"a b c : Nat\\n⊢ a + b + c = c + a + b\",\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 77}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 4, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 4, \"column\": 26},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 35}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exercice 2 : Rearrangement avec rw\n",
-    "-- TODO etudiant : prouvez (a + b) + c = (c + a) + b\n",
-    "-- Indice : Nat.add_assoc, Nat.add_comm\n",
-    "theorem rearrange_exercise (a b c : Nat) : (a + b) + c = (c + a) + b := sorry\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5bb9f488",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007319,
-     "end_time": "2026-05-27T01:57:39.538953+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.531634+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exercice 3 : De Morgan avec tactics\n",
-    "\n",
-    "Prouvez que `¬(p ∨ q) <-> ¬p ∧ ¬q` en utilisant `constructor`, `intro`, `cases`, `contradiction`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "5d40d3cf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-27T01:57:39.554094Z",
-     "iopub.status.busy": "2026-05-27T01:57:39.553933Z",
-     "iopub.status.idle": "2026-05-27T01:57:39.660928Z",
-     "shell.execute_reply": "2026-05-27T01:57:39.660142Z"
-    },
-    "language": "lean4",
-    "papermill": {
-     "duration": 0.115214,
-     "end_time": "2026-05-27T01:57:39.661359+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.546145+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        \n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
-       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
-       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
-       "    \n",
-       "        <div class=\"alectryon-root alectryon-centered\">\n",
-       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : De Morgan</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant : prouvez la premiere direction de De Morgan</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>de_morgan_exercise<span class=\"w\"> </span>(p<span class=\"w\"> </span>q<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span>)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">¬</span>(p<span class=\"w\"> </span><span class=\"bp\">\\/</span><span class=\"w\"> </span>q)<span class=\"w\"> </span><span class=\"bp\">-&gt;</span><span class=\"w\"> </span><span class=\"bp\">¬</span>p<span class=\"w\"> </span><span class=\"bp\">/\\</span><span class=\"w\"> </span><span class=\"bp\">¬</span>q<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"gr\">sorry</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"bp\">&#39;</span><span class=\"gr\">sorry</span><span class=\"bp\">&#39;</span></blockquote></div></div></small></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 36</span></span></span></pre>\n",
-       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 5</span></span></span></pre>\n",
-       "        </div>\n",
-       "        <details>\n",
-       "            <summary>Raw input</summary>\n",
-       "            <code>{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 35}</code>\n",
-       "        </details>\n",
-       "        <details>\n",
-       "            <summary>Raw output</summary>\n",
-       "            <code>{\"sorries\":\r\n",
-       " [{\"proofState\": 5,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 67},\r\n",
-       "   \"goal\": \"p q : Prop\\n⊢ ¬(p ∨ q) → ¬p ∧ ¬q\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 72}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 26},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 36}</code>\n",
-       "        </details>\n",
-       "    "
-      ],
-      "text/plain": [
-       "-- Exercice 3 : De Morgan\n",
-       "-- TODO etudiant : prouvez la premiere direction de De Morgan\n",
-       "theorem de_morgan_exercise (p q : Prop) : ¬(p \\/ q) -> ¬p /\\ ¬q := sorry\n",
-       "        ──────────────────▶ 🟨 declaration uses 'sorry'\n",
-       "\n",
-       "--% env 36\n",
-       "--% prove 5\n",
-       "\n",
-       "Raw input:\n",
-       "{\"cmd\": \"-- Exercice 3 : De Morgan\\n-- TODO etudiant : prouvez la premiere direction de De Morgan\\ntheorem de_morgan_exercise (p q : Prop) : \\u00ac(p \\\\/ q) -> \\u00acp /\\\\ \\u00acq := sorry\\n\", \"env\": 35}\n",
-       "Raw output:\n",
-       "{\"sorries\":\r\n",
-       " [{\"proofState\": 5,\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 67},\r\n",
-       "   \"goal\": \"p q : Prop\\n⊢ ¬(p ∨ q) → ¬p ∧ ¬q\",\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 72}}],\r\n",
-       " \"messages\":\r\n",
-       " [{\"severity\": \"warning\",\r\n",
-       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
-       "   \"endPos\": {\"line\": 3, \"column\": 26},\r\n",
-       "   \"data\": \"declaration uses 'sorry'\"}],\r\n",
-       " \"env\": 36}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "-- Exercice 3 : De Morgan\n",
-    "-- TODO etudiant : prouvez la premiere direction de De Morgan\n",
-    "theorem de_morgan_exercise (p q : Prop) : ¬(p \\/ q) -> ¬p /\\ ¬q := sorry\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9bd5a610",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00703,
-     "end_time": "2026-05-27T01:57:39.676054+00:00",
-     "exception": false,
-     "start_time": "2026-05-27T01:57:39.669024+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## Resume des Tactiques\n",
     "\n",
@@ -4473,29 +2964,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Lean 4",
-   "language": "lean4",
-   "name": "lean4"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": "python",
-   "file_extension": ".lean",
-   "mimetype": "text/x-lean4",
-   "name": "lean4"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 6.519972,
-   "end_time": "2026-05-27T01:57:39.897210+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "/mnt/c/dev/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb",
-   "output_path": "/tmp/Lean-5-Tactics_wsl_output.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-27T01:57:33.377238+00:00",
-   "version": "2.7.0"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
<!-- ETUDIANTS (PR de TP) : remplissez seulement la section Summary ci-dessous. Laissez les checklists telles quelles — votre encadrant s'en charge. Une CI rouge ne bloque pas votre TP. -->

> **Etudiants (PR de TP)** : remplissez seulement **Summary**. Les checklists de review sont pour l'encadrant — laissez-les telles quelles. Une CI rouge ne bloque pas le merge de votre TP.

## Summary

<!-- 1-3 bullet points describing what this PR does -->

-

## Changes

<!-- List the main changes: files added/modified, features, fixes -->

-

## Review Checklist

<!-- 5-point review system (CLAUDE.md section B) -->

- [ ] **1. Scope** — PR does exactly what it announces, nothing more, nothing less
- [ ] **2. Post-fix validation** — Automated script ran AFTER the last commit on the deliverable (not just source code)
- [ ] **3. Pedagogical coherence** — Exercises aligned with taught content, no redundancy, TODO stubs consistent, logical cell order
- [ ] **4. Real execution** — Notebooks executed with outputs (Papermill/Jupyter), Slidev `?clicks=99` for slides
- [ ] **5. Regression check** — Grep touched symbols in the rest of the repo; no unintended side effects

## Anti-regression

<!-- For PRs touching production code (Lean/Coq, business logic, tests, libraries) -->

- [ ] No `sorry` introduced in Lean/Coq certified modules (run: `grep -c sorry` on touched `.lean` files)
- [ ] No `@pytest.skip` or `assert True` added to bypass failing tests
- [ ] Deletions on production code justified (ratio insertions/deletions reasonable)

## Notebook-specific

<!-- For PRs modifying .ipynb files — skip if not applicable -->

- [ ] No `raise NotImplementedError` / `assert False` / `1/0` in any cell (use `pass` or `print("Exercice a completer")`)
- [ ] All code cells have `execution_count: <int>` + coherent `outputs`
- [ ] Only notebooks with source changes are committed (rule C.3)

## Test plan

<!-- How to verify this PR works -->

-
