### PR TITLE
docs(notebook-tools): document execute --kernel/--cwd/--env/--scrub-keys options (See #2476)

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -29,6 +29,7 @@ paths: MyIA.AI.Notebooks/**/*.ipynb
 - **WSL notebooks** (GameTheory/Lean) : `wsl_papermill.py` (cf [.claude/rules/wsl-kernels.md](wsl-kernels.md))
 - Working directory explicite pour notebooks avec paths relatifs
 - `BATCH_MODE=true` pour notebooks avec widgets interactifs
+- **Notebooks LLM/API** (SC-11, GenAI) : re-exec validation via `--scrub-keys` pour forcer le chemin mock deterministe sans appel API payant : `notebook_tools.py execute <path> --scrub-keys`. Cf [docs/scripts-reference.md](../../docs/scripts-reference.md) pour le cookbook complet (`--kernel`, `--cwd`, `--env`, `--scrub-keys`).
 
 ## Cellules code : output systematique (anti faux-positif maturite)
 

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -23,6 +23,41 @@ Les scripts `scripts/fix_*.py` / `scripts/recycle_*.py` à la racine sont des on
 | `execute_qcpy_docker.py`, `qc_quantbook_execute.py` | Exécution QuantConnect (Quantbooks via Docker/QC Cloud) |
 | `_exec_bdd_csharp.py` | Exécution C# BDD interne |
 
+#### `notebook_tools.py execute` — Options avancées
+
+```bash
+python scripts/notebook_tools/notebook_tools.py execute <target> [options]
+```
+
+| Option | Description | Cas d'usage |
+|--------|-------------|-------------|
+| `--kernel <name>` | Force un kernel specifique (ex. `python3`, `.net-csharp`, `python3 (PyMC)`) | Cibler un env conda precis quand le kernel par defaut manque des deps |
+| `--cwd <path>` | Execute depuis ce repertoire au lieu du dossier parent du notebook | Executer dans un worktree de curation, ou isoler `load_dotenv()` |
+| `--env KEY=VAL` | Injecte une variable d'environnement (repeter pour plusieurs) | `--env BATCH_MODE=true`, overrides ponctuels |
+| `--scrub-keys` | Retire les cles API LLM (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) du sous-processus | Force le chemin mock deterministe pour les notebooks LLM (SC-11, GenAI) sans appel API payant |
+| `--batch-mode` | Active BATCH_MODE=true (env + param Papermill) | Notebooks interactifs en validation non-interactive |
+| `--cell-by-cell` | Execution cellule par cellule (.NET/Lean) | Kernels persistants |
+| `--timeout N` | Timeout par notebook en secondes (defaut: 300) | Notebooks longs |
+
+**Cookbook — cas d'usage courants** :
+
+```bash
+# Re-exec validation standard (chemin mock, pas d'appel API)
+python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/SymbolicAI/SmartContracts/SC-11-LLM-Assisted.ipynb --scrub-keys
+
+# Re-exec dans un worktree de curation
+python scripts/notebook_tools/notebook_tools.py execute /tmp/worktree/SC-11.ipynb --cwd /tmp/worktree
+
+# Forcer un kernel conda specifique
+python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/Probas/PyMC/ --kernel "python3 (PyMC)"
+
+# Re-exec avec variables d'env personnalisees
+python scripts/notebook_tools/notebook_tools.py execute MyIA.AI.Notebooks/GenAI/ --env BATCH_MODE=true --env MOCK_RESPONSES=true
+
+# Re-exec batch d'une famille complete, mode mock
+python scripts/notebook_tools/notebook_tools.py execute SmartContracts --scrub-keys --batch-mode
+```
+
 ### Catalogue (anti-drift)
 | Script | Usage |
 |--------|-------|


### PR DESCRIPTION
## Summary

Document the 4 CLI options already implemented in `notebook_tools.py execute` but missing from user-facing docs.

**Context**: Issue #2476 identified that agents bypass `notebook_tools.py execute` in favor of raw papermill because the options `--kernel`, `--cwd`, `--env`, `--scrub-keys` were implemented in code but invisible in documentation.

## Changes

- **`docs/scripts-reference.md`**: Added "Options avancees" subsection under Execution with option table + cookbook (6 usage examples covering worktree isolation, conda kernel targeting, mock path for LLM notebooks, batch mode)
- **`.claude/rules/notebook-conventions.md`**: Added `--scrub-keys` guidance in Execution section for LLM/API notebook re-execution validation

## What this does NOT change

- No code changes — the 4 options were already fully implemented (CLI parser + `cmd_execute` + `execute_with_papermill`)
- This is **Volet 2** (documentation) of #2476. **Volet 1** (implementation) is already complete.

## Validation

- `python scripts/notebook_tools/notebook_tools.py execute --help` shows all 4 options correctly
- 2 files changed, 36 insertions, docs-only PR

See #2476 (partial — volet 2 only)