### PR TITLE
chore(catalog): scheduled main regen cron + agent catalog/PR-hygiene rule

### DIFF
--- a/.claude/rules/catalog-pr-hygiene.md
+++ b/.claude/rules/catalog-pr-hygiene.md
@@ -1,0 +1,44 @@
+# Catalogue & hygiène PR — le catalogue appartient à l'automatisation
+
+S'applique à **tous les agents du cluster CoursIA** (workers `po-*` + coordinateur `ai-01`) qui ouvrent des PR. Source : mandat user 2026-06-06 (« régler définitivement le pb du catalogue et faire faire aux agents workers le travail t'économisant le tien »). Codifie la leçon `stale-catalog-silent-revert` (incidents #2376 / #2383 / #2385).
+
+## Règle HARD 1 — NE JAMAIS régénérer le catalogue sur une branche feature
+
+`COURSE_CATALOG.generated.json`, `COURSE_CATALOG.generated.md` et les blocs `<!-- CATALOG-STATUS:START -->…:END -->` dans les README **sont des artefacts générés appartenant à l'automatisation**. Un agent ne les régénère **jamais** à la main sur une branche.
+
+**Pourquoi** : le catalogue embarque des champs git-dérivés (`last_validation`, `issue_pr_associee`, …) + une heuristique de maturité qui **dérivent avec le temps** au fil des commits sur `main`. Régénérer sur une branche dont la base est ancienne produit un diff massif (1000+ lignes) qui mélange des entrées **sans rapport** avec le livrable → conflit catalogue à chaque merge, revert silencieux des champs curés des autres entrées, et explosion de tokens côté coordinateur pour démêler (`git merge origin/main` + de-churn manuel, un par PR).
+
+**Qui régénère, alors** :
+- `.github/workflows/catalog-cron.yml` — **cron quotidien sur `main`** (régén `.json` + `.md` + marqueurs, commit `[skip ci]` par `github-actions[bot]`). C'est le backstop canonique.
+- `.github/workflows/catalog-drift.yml` — **par-PR**, auto-régénère et committe le catalogue sur la branche d'une PR same-repo (préserve les champs curés via `_merge_curated_fields`, #2433).
+
+**Ce que fait l'agent à la place** : laisser le catalogue **byte-identique à `main`**. Si une branche a malgré tout du churn catalogue (régén accidentelle, base stale) :
+
+```bash
+git checkout origin/main -- COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md
+# puis re-checkout origin/main sur les README dont SEULS les marqueurs CATALOG-STATUS ont bougé
+```
+
+Une **nouvelle entrée** notebook (nouveau notebook ajouté) n'est PAS à inscrire à la main : le cron (`<24h`) ou la CI par-PR la crée. Si l'inscription immédiate est nécessaire, la confier à la lane catalog-drift (po-2023), **pas** la régénérer dans une PR de contenu.
+
+## Règle HARD 2 — Rebase frais avant push
+
+Repartir d'un `origin/main` à jour avant de pousser. Le label `base-stale-14d` (workflow `stale-base-warning.yml`) signale une base de plus de 14 jours en retard → re-baser **avant** de demander un merge. Une branche stale = source n°1 du poison catalogue ci-dessus + de conflits inutiles.
+
+## Règle HARD 3 — Un seul livrable par PR (atomique)
+
+Une PR = **un** sujet vérifiable (cf G.4 / one-subject-per-PR). Pas de composite « 4 notebooks + refactor script + docs » : split. Seuils CHANGES_REQUESTED : > 3000 lignes hors notebooks / > 15 fichiers / > 4 features / > 1 domaine ([pr-review-discipline.md](pr-review-discipline.md) §A).
+
+## Règle HARD 4 — `Closes #X` quand la PR résout entièrement l'issue
+
+- **`Closes #X` / `Fixes #X`** dans le body **uniquement** quand UNE PR résout **entièrement** UNE issue → GitHub la ferme automatiquement au merge (le backlog d'issues diminue tout seul).
+- **`See #X` / `refs #X`** pour une **contribution partielle** à une epic (l'epic reste ouverte). Ne PAS utiliser `Closes` sur une sous-tâche d'epic.
+
+Cette discipline est ce qui fait **baisser le compte d'issues** sans intervention manuelle du coordinateur : une PR qui clôt vraiment une issue le déclare, les epics au long cours restent `See`.
+
+## Voir aussi
+
+- [.claude/rules/git-workflow.md](git-workflow.md) — branches `feature/`, no force push, no direct main push
+- [.claude/rules/proactive-coordination.md](proactive-coordination.md) — 1 PR/wakeup, atomique
+- [.claude/rules/pr-review-discipline.md](pr-review-discipline.md) — §A composites trop larges
+- `~/.claude/projects/d--CoursIA/memory/stale-catalog-silent-revert.md` — incident fondateur

--- a/.github/workflows/catalog-cron.yml
+++ b/.github/workflows/catalog-cron.yml
@@ -1,0 +1,103 @@
+name: Catalog Auto-Regen (main, scheduled)
+
+# Purpose
+# -------
+# Keep COURSE_CATALOG.generated.{json,md} + README CATALOG-STATUS markers
+# CANONICAL ON MAIN without any human or agent regenerating them by hand.
+#
+# Why a scheduled job is needed:
+#   The catalog embeds git-derived fields (last_validation, issue_pr_associee...)
+#   and a maturity heuristic that drift purely as commits land on main -- even
+#   when no notebook changes. Nothing refreshes main's catalog on a cadence, so
+#   it goes stale over time. A feature branch that later regenerates against a
+#   stale main produces a large spurious diff (the "stale-catalog poison",
+#   incidents #2376 / #2383 / #2385) that has to be hand-resolved at merge time.
+#   Refreshing main on a schedule removes that drift at the source.
+#
+# Companion automation (do NOT duplicate):
+#   - catalog-drift.yml         : per-PR sync (auto-regen+commit on same-repo PR
+#                                 branches; informational annotation on forks).
+#   - stale-base-warning.yml    : labels PRs whose base is >14d behind main.
+#
+# Governance rule (.claude/rules/catalog-pr-hygiene.md):
+#   Agents MUST NOT regenerate or commit COURSE_CATALOG.generated.* nor the
+#   CATALOG-STATUS markers on a feature branch. The catalog is owned by this
+#   automation. New entries appear at the next run (eventual consistency, <24h).
+#
+# The generator (scripts/notebook_tools/generate_catalog.py) preserves curated
+# git fields from origin/main for entries untouched on the current ref
+# (_load_main_catalog + _merge_curated_fields, the #2433 fix), so running it on
+# main is idempotent: only the time-drifted fields are refreshed.
+
+on:
+  schedule:
+    # 03:37 UTC daily -- off-peak, off-:00 minute to avoid the top-of-hour rush.
+    - cron: '37 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: catalog-cron-main
+  cancel-in-progress: false
+
+jobs:
+  regen:
+    name: Regenerate catalog on main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0          # full history so git-derived fields are exact
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Regenerate catalog (.json + .md) + README markers
+        run: |
+          set -euo pipefail
+          # No --json-only here: refresh BOTH root artifacts (.json AND .md).
+          # --git-tracked-only keeps CI output deterministic (ignores untracked).
+          python scripts/notebook_tools/generate_catalog.py --git-tracked-only
+          python scripts/notebook_tools/expand_catalog_markers.py
+
+      - name: Commit + push to main if the catalog drifted
+        run: |
+          set -euo pipefail
+          git add COURSE_CATALOG.generated.json COURSE_CATALOG.generated.md
+          # Stage only README files actually modified by marker expansion.
+          mapfile -t changed_readmes < <(git ls-files -m -- '*README.md')
+          if [ "${#changed_readmes[@]}" -gt 0 ]; then
+            git add -- "${changed_readmes[@]}"
+          fi
+
+          if git diff --cached --quiet; then
+            echo "::notice title=Catalog::main catalog already canonical -- no change."
+            exit 0
+          fi
+
+          echo "Drift detected. Files to commit:"
+          git diff --cached --name-only
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit \
+            -m "chore(catalog): scheduled auto-regenerate on main [skip ci]" \
+            -m "Refresh COURSE_CATALOG.generated.{json,md} + CATALOG-STATUS markers." \
+            -m "Catalog is owned by automation; agents must not regenerate it on feature branches (see .claude/rules/catalog-pr-hygiene.md, #2433)."
+
+          # Direct push of a generated artifact to main. Requires branch
+          # protection to allow github-actions[bot] (GITHUB_TOKEN) to push to
+          # main, or main to have no PR-required protection for this actor.
+          # A hard failure here is intentional and visible in the Actions tab.
+          if ! git push origin HEAD:main; then
+            echo "::error title=Catalog push rejected::Could not push the regenerated catalog to main. Allow github-actions[bot] to push generated artifacts to main in branch-protection settings, then re-run this workflow."
+            exit 1
+          fi
+          echo "::notice title=Catalog::main catalog refreshed and pushed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Guidance pour Claude Code travaillant avec le repository CoursIA.
 - [.claude/rules/proactive-coordination.md](.claude/rules/proactive-coordination.md) - 1 PR/wakeup + main track + side-track async via sous-agents spécialistes (mandat user 2026-05-23)
 - [.claude/rules/user-blocker-signaling.md](.claude/rules/user-blocker-signaling.md) - Re-poke chaque fin de session quand le user bloque (mandat user 2026-05-28, anti-dilution wakeup)
 - [.claude/rules/harness-hygiene.md](.claude/rules/harness-hygiene.md) - Info 3 tiers : harnais succinct / docs pérenne / dashboard éphémère (mandat user 2026-06-01)
+- [.claude/rules/catalog-pr-hygiene.md](.claude/rules/catalog-pr-hygiene.md) - Catalogue = propriété de l'automatisation (cron main + CI par-PR), JAMAIS régén sur branche + rebase frais + atomique + `Closes #X` (mandat user 2026-06-06)
 - [.claude/rules/three-exercises-per-notebook.md](.claude/rules/three-exercises-per-notebook.md) - Convention >=3 exercices par notebook, rollout progressif (#2161)
 
 ---


### PR DESCRIPTION
## Problème structurel (la vraie cause du token-burn catalogue)

Le catalogue (`COURSE_CATALOG.generated.{json,md}` + marqueurs `CATALOG-STATUS` dans les README) embarque des **champs git-dérivés** (`last_validation`, `issue_pr_associee`, …) + une **heuristique de maturité** qui **dérivent avec le temps**, au fil des commits sur `main`, **même sans changement de notebook**.

Rien ne rafraîchit le catalogue **sur `main`** à une cadence régulière → il se périme. Une branche feature qui régénère ensuite le catalogue contre un `main` périmé produit un diff massif (1000+ lignes) mélangeant des entrées **sans rapport** avec le livrable → le « **stale-catalog poison** » : conflit catalogue à chaque merge, revert silencieux des champs curés des autres entrées, et démêlage manuel coûteux côté coordinateur (un `git merge origin/main` + de-churn par PR). Incidents fondateurs : #2376 / #2383 / #2385.

## Fix : sortir définitivement les agents de la boucle de régén

**1. `.github/workflows/catalog-cron.yml`** — job planifié (`schedule` quotidien 03:37 UTC, off-peak) + `workflow_dispatch` :
- checkout `main`, régénère **les deux** artefacts racine (`.json` **et** `.md`) + les marqueurs README,
- committe le résultat sur `main` en tant que `github-actions[bot]` avec `[skip ci]`,
- **idempotent + curated-field-safe** : le générateur préserve déjà les champs curés depuis `origin/main` (`_load_main_catalog` + `_merge_curated_fields`, le fix #2433) → seuls les champs périmés par le temps sont rafraîchis.

**2. `.claude/rules/catalog-pr-hygiene.md`** — règle HARD auto-loaded :
- les agents **ne régénèrent JAMAIS** le catalogue sur une branche feature (le garder **byte-identique à `main`**),
- rebase frais avant push (le label `base-stale-14d` est le signal),
- **un seul livrable par PR** (atomique),
- **`Closes #X`** uniquement quand une PR résout **entièrement** une issue (auto-fermeture, le backlog d'issues baisse seul) ; `See #X` pour les sous-tâches d'epic.

## Complémentarité (pas de duplication)

| Workflow | Rôle | Statut |
|---|---|---|
| **catalog-cron.yml** (cette PR) | régén+commit **sur `main`**, cadence | NOUVEAU — comble le gap |
| catalog-drift.yml | régén+commit **par-PR** (same-repo) ; annotation info (forks) | existant, conservé |
| stale-base-warning.yml | label `base-stale-14d` à >14j de retard | existant, conservé |

Le cron rafraîchit `main` (dérive temporelle) ; `catalog-drift.yml` synchronise les branches de PR ; ensemble + la règle, **plus aucun agent ne régénère le catalogue à la main**.

## Pré-requis de déploiement (one-time, côté maintainer)

Le job pousse un artefact généré directement sur `main`. La protection de branche doit **autoriser `github-actions[bot]` (GITHUB_TOKEN) à pousser sur `main`** (artefact généré, `[skip ci]`). En cas de rejet, le job **échoue volontairement et visiblement** (Actions tab) avec un message explicite — pas d'échec silencieux. Cadence ajustable (quotidien → hebdo) si le bruit de commits sur `main` est jugé excessif.

## Vérification

- YAML parsé OK (triggers `schedule`+`workflow_dispatch`, `permissions: contents: write`, 4 steps).
- Diff : **+148 / -0** (3 fichiers : 1 workflow, 1 rule, 1 pointer CLAUDE.md). Aucune régression, aucun notebook, aucun catalogue touché par cette PR elle-même.
- `workflow_dispatch` permet un run manuel de validation post-merge avant de se fier au cron.

Mandat user 2026-06-06 : « La transformation de la gestion du catalogue en un cron automatique qui ne vous fait pas consommer des tokens me paraît un quick win impactant. »

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
